### PR TITLE
[sessiond] split CreateSession

### DIFF
--- a/cwf/gateway/services/uesim/servicers/uesim_hssless.go
+++ b/cwf/gateway/services/uesim/servicers/uesim_hssless.go
@@ -93,9 +93,10 @@ func (srv *UESimServerHssLess) Authenticate(ctx context.Context, id *cwfprotos.A
 		return &cwfprotos.AuthenticateResponse{}, err
 	}
 
+	sid := makeSubscriberId(ue.GetImsi())
 	req := &lte_protos.LocalCreateSessionRequest{
 		CommonContext: &lte_protos.CommonSessionContext{
-			Sid:     makeSubscriberId(ue.GetImsi()),
+			Sid:     sid,
 			UeIpv4:  DEFAULT_UE_IP,
 			Apn:     ue.GetHsslessCfg().GetApn(),
 			Msisdn:  ([]byte)(ue.GetHsslessCfg().GetMsisdn()),
@@ -112,10 +113,23 @@ func (srv *UESimServerHssLess) Authenticate(ctx context.Context, id *cwfprotos.A
 		},
 	}
 	resp, err := session_manager.CreateSession(req)
-	if err == nil {
-		return &cwfprotos.AuthenticateResponse{SessionId: resp.GetSessionId()}, nil
+	if err != nil {
+		return &cwfprotos.AuthenticateResponse{SessionId: ""}, err
 	}
-	return &cwfprotos.AuthenticateResponse{SessionId: ""}, err
+	activateReq := &lte_protos.UpdateTunnelIdsRequest{
+		Sid:                  sid,
+		BearerId:             0,
+		EnbTeid:              0,
+		AgwTeid:              0,
+	}
+
+	// activate is needed to install all hte flows
+	_, err = session_manager.UpdateTunnelIds(activateReq)
+	if err != nil {
+		return &cwfprotos.AuthenticateResponse{SessionId: ""}, err
+	}
+
+	return &cwfprotos.AuthenticateResponse{SessionId: resp.GetSessionId()}, nil
 }
 func (srv *UESimServerHssLess) GenTraffic(ctx context.Context, req *cwfprotos.GenTrafficRequest) (*cwfprotos.GenTrafficResponse, error) {
 	glog.V(2).Infof("Reached GenTraffic...")

--- a/feg/gateway/services/aaa/servicers/accounting.go
+++ b/feg/gateway/services/aaa/servicers/accounting.go
@@ -172,10 +172,16 @@ func (srv *accountingService) CreateSession(
 	}
 
 	csResp, err := createSessionOnSessionManager(mac, subscriberId, aaaCtx)
+	if err != nil {
+		glog.Errorf("Not activating flows because CreateSession failed: %s", err)
+		pipelined.DeleteUeMacFlow(subscriberId, aaaCtx)
+		return nil, err
+	}
+
+	_, err = activateSessionOnSessionManager(subscriberId)
 	if err == nil {
 		metrics.CreateSessionLatency.Observe(time.Since(startime).Seconds())
 	} else {
-		// TODO: do we really need to remove the flow?
 		pipelined.DeleteUeMacFlow(subscriberId, aaaCtx)
 	}
 
@@ -319,6 +325,18 @@ func createSessionOnSessionManager(mac net.HardwareAddr, subscriberId *lte_proto
 		},
 	}
 	return session_manager.CreateSession(req)
+}
+
+func activateSessionOnSessionManager(subscriberId *lte_protos.SubscriberID) (*lte_protos.UpdateTunnelIdsResponse, error) {
+	// BearerID, EnbTeid and AgwTeid are defaulted to 0 because they are not
+	// needed by sessiond for CWF
+	req := &lte_protos.UpdateTunnelIdsRequest{
+		Sid:      subscriberId,
+		BearerId: 0,
+		EnbTeid:  0,
+		AgwTeid:  0,
+	}
+	return session_manager.UpdateTunnelIds(req)
 }
 
 func (srv *accountingService) timeoutSessionNotifier(s aaa.Session) error {

--- a/feg/gateway/services/aaa/session_manager/client_api.go
+++ b/feg/gateway/services/aaa/session_manager/client_api.go
@@ -17,7 +17,6 @@ package session_manager
 import (
 	"errors"
 	"fmt"
-
 	"github.com/golang/glog"
 	"golang.org/x/net/context"
 
@@ -73,4 +72,15 @@ func EndSession(in *protos.LocalEndSessionRequest) (*protos.LocalEndSessionRespo
 		return nil, err
 	}
 	return cli.EndSession(context.Background(), in)
+}
+
+func UpdateTunnelIds(in *protos.UpdateTunnelIdsRequest) (*protos.UpdateTunnelIdsResponse, error) {
+	if in == nil {
+		return nil, errors.New("Nil LocalEndSessionRequest")
+	}
+	cli, err := getSessionManagerClient()
+	if err != nil {
+		return nil, err
+	}
+	return cli.UpdateTunnelIds(context.Background(), in)
 }

--- a/lte/gateway/c/session_manager/LocalEnforcer.h
+++ b/lte/gateway/c/session_manager/LocalEnforcer.h
@@ -161,7 +161,7 @@ class LocalEnforcer {
    * Perform any rule installs/removals that need to be executed given a
    * CreateSessionResponse.
    */
-  void handle_session_init_rule_updates(
+  void handle_session_activate_rule_updates(
       const std::string& imsi, SessionState& session_state,
       const CreateSessionResponse& response,
       std::unordered_set<uint32_t>& charging_credits_received);
@@ -171,11 +171,11 @@ class LocalEnforcer {
       BearerUpdate& bearer_updates);
 
   /**
-   * Initialize credit received from the cloud in the system. This adds all the
-   * charging keys to the credit manager for tracking
+   * Initialize session on session map. Adds some information comming from
+   * the core (cloud). Rules will be installed by init_session_credit
    * @param credit_response - message from cloud containing initial credits
    */
-  void init_session_credit(
+  void init_session(
       SessionMap& session_map, const std::string& imsi,
       const std::string& session_id, const SessionConfig& cfg,
       const CreateSessionResponse& response);
@@ -281,12 +281,10 @@ class LocalEnforcer {
    * UE on pipelined. UE will be identified by pipelined using its IP
    * @param session_map
    * @param request
-   * @param session_update
    * @return true if successfully processed the request
    */
   bool update_tunnel_ids(
-      SessionMap& session_map, const UpdateTunnelIdsRequest& request,
-      SessionUpdate& session_update);
+      SessionMap& session_map, const UpdateTunnelIdsRequest& request);
 
   std::unique_ptr<Timezone>& get_access_timezone() { return access_timezone_; };
 
@@ -621,7 +619,7 @@ class LocalEnforcer {
    * Otherwise, mark the subscriber as out of quota to pipelined, and schedule
    * the session to be terminated in a configured amount of time.
    */
-  void handle_session_init_subscriber_quota_state(
+  void handle_session_activate_subscriber_quota_state(
       const std::string& imsi, SessionState& session_state);
 
   bool is_wallet_exhausted(SessionState& session_state);

--- a/lte/gateway/c/session_manager/LocalSessionManagerHandler.cpp
+++ b/lte/gateway/c/session_manager/LocalSessionManagerHandler.cpp
@@ -269,7 +269,7 @@ void LocalSessionManagerHandlerImpl::send_create_session(
         if (status.ok()) {
           MLOG(MINFO) << "Processing a CreateSessionResponse for "
                       << session_id;
-          enforcer_->init_session_credit(
+          enforcer_->init_session(
               *session_map_ptr, imsi, session_id, cfg, response);
           bool write_success = session_store_.create_sessions(
               imsi, std::move((*session_map_ptr)[imsi]));
@@ -559,10 +559,7 @@ void LocalSessionManagerHandlerImpl::UpdateTunnelIds(
   enforcer_->get_event_base().runInEventBaseThread([this, request_cpy, imsi,
                                                     response_callback]() {
     auto session_map = session_store_.read_sessions({imsi});
-    SessionUpdate update =
-        SessionStore::get_default_session_update(session_map);
-    auto success =
-        enforcer_->update_tunnel_ids(session_map, request_cpy, update);
+    auto success     = enforcer_->update_tunnel_ids(session_map, request_cpy);
     if (!success) {
       MLOG(MDEBUG) << "Failed to UpdateTunnelIds for imsi " << imsi
                    << " and bearer " << request_cpy.bearer_id();

--- a/lte/gateway/c/session_manager/PipelinedClient.h
+++ b/lte/gateway/c/session_manager/PipelinedClient.h
@@ -109,14 +109,6 @@ class PipelinedClient {
       std::function<void(Status status, ActivateFlowsResult)> callback) = 0;
 
   /**
-   * update_tunnel_ids adds eNB tunnel ID and AGW Tunnel ID to an specific flow
-   * specified by its ip_addrs
-   * */
-  virtual bool update_tunnel_ids(
-      const std::string& imsi, const std::string& ip_addr,
-      const std::string& ipv6_addr, const Teids teids) = 0;
-
-  /**
    * Send the MAC address of UE and the subscriberID
    * for pipelined to add a flow for the subscriber by matching the MAC
    */
@@ -254,14 +246,6 @@ class AsyncPipelinedClient : public GRPCReceiver, public PipelinedClient {
       const std::vector<std::string>& static_rules,
       const std::vector<PolicyRule>& dynamic_rules,
       std::function<void(Status status, ActivateFlowsResult)> callback);
-
-  /**
-   * update_tunnel_ids adds eNB tunnel ID and AGW Tunnel ID to an specific flow
-   * specified by its ip_addrs
-   */
-  bool update_tunnel_ids(
-      const std::string& imsi, const std::string& ip_addr,
-      const std::string& ipv6_addr, const Teids teids);
 
   /**
    * Send the MAC address of UE and the subscriberID

--- a/lte/gateway/c/session_manager/SessionState.h
+++ b/lte/gateway/c/session_manager/SessionState.h
@@ -140,7 +140,8 @@ class SessionState {
   SessionState(
       const std::string& imsi, const std::string& session_id,
       const SessionConfig& cfg, StaticRuleStore& rule_store,
-      const magma::lte::TgppContext& tgpp_context, uint64_t pdp_start_time);
+      const magma::lte::TgppContext& tgpp_context, uint64_t pdp_start_time,
+      const CreateSessionResponse& csr);
 
   SessionState(
       const StoredSessionState& marshaled, StaticRuleStore& rule_store);
@@ -297,6 +298,10 @@ class SessionState {
   SessionTerminateRequest make_termination_request(
       SessionStateUpdateCriteria& uc);
 
+  CreateSessionResponse get_create_session_response();
+
+  void clear_create_session_response();
+
   // Methods related to the session's static and dynamic rules
   /**
    * Infer the policy's type (STATIC or DYNAMIC)
@@ -428,10 +433,14 @@ class SessionState {
 
   SessionFsmState get_state();
 
+  void get_unsuspended_rules(RulesToProcess& rulesToProcess);
+
   void get_rules_per_credit_key(
       CreditKey charging_key, RulesToProcess& rulesToProcess);
 
-  void set_teids(Teids teids, SessionStateUpdateCriteria session_uc);
+  void set_teids(uint32_t enb_teid, uint32_t agw_teid);
+
+  void set_teids(Teids teids);
 
   // Event Triggers
   void add_new_event_trigger(
@@ -559,6 +568,9 @@ class SessionState {
   // (only used for CWF at the moment)
   magma::lte::SubscriberQuotaUpdate_Type subscriber_quota_state_;
   magma::lte::TgppContext tgpp_context_;
+
+  // Used between create session and activate session. Empty afterwards
+  CreateSessionResponse create_session_response_;
 
   // All static rules synced from policy DB
   StaticRuleStore& static_rules_;

--- a/lte/gateway/c/session_manager/SessionStore.cpp
+++ b/lte/gateway/c/session_manager/SessionStore.cpp
@@ -193,62 +193,83 @@ optional<SessionVector::iterator> SessionStore::find_session(
   }
   auto& sessions = sm_it->second;
   for (auto it = sessions.begin(); it != sessions.end(); ++it) {
+    const auto& context = (*it)->get_config().common_context;
     switch (criteria.search_type) {
       case IMSI_AND_SESSION_ID:
         if ((*it)->get_session_id() == criteria.secondary_key) {
           return it;
         }
         break;
-      case IMSI_AND_TEID:
-        if ((*it)->get_local_teid() == criteria.secondary_key_unit32) {
-          return it;
-        }
-        break;
+
       case IMSI_AND_APN:
-        if ((*it)->get_config().common_context.apn() ==
-            criteria.secondary_key) {
+        if (context.apn() == criteria.secondary_key) {
           return it;
         }
         break;
+
       case IMSI_AND_UE_IPV4:
-        if ((*it)->get_config().common_context.ue_ipv4() ==
-            criteria.secondary_key) {
+        if (context.ue_ipv4() == criteria.secondary_key) {
           return it;
         }
         break;
+
       case IMSI_AND_UE_IPV4_OR_IPV6:
         // cwag case (cwag doesn't store ip)
-        if ((*it)->get_config().common_context.rat_type() ==
-            RATType::TGPP_WLAN) {
+        if (context.rat_type() == RATType::TGPP_WLAN) {
           return it;
         }
         // other case(lte,5g)
-        // lte case
-        if ((*it)->get_config().common_context.ue_ipv4() ==
-                criteria.secondary_key ||
-            (*it)->get_config().common_context.ue_ipv6() ==
-                criteria.secondary_key) {
+        if (context.ue_ipv4() == criteria.secondary_key ||
+            context.ue_ipv6() == criteria.secondary_key) {
           return it;
         }
         break;
+
       case IMSI_AND_BEARER:
-        if ((*it)->get_config().common_context.rat_type() ==
-            RATType::TGPP_LTE) {
-          // lte case
-          if ((*it)
-                  ->get_config()
-                  .rat_specific_context.lte_context()
-                  .bearer_id() == criteria.secondary_key_unit32) {
+        switch (context.rat_type()) {
+          case RATType::TGPP_LTE:
+            // lte case
+            if ((*it)
+                    ->get_config()
+                    .rat_specific_context.lte_context()
+                    .bearer_id() == criteria.secondary_key_unit32) {
+              return it;
+            }
+            break;
+          case RATType::TGPP_WLAN:
             return it;
-          }
-        } else {
-          // 5g and cwag
-          MLOG(MERROR) << "find_session by bearer is not implemented "
-                          "for cwg or 5g. Couldnt find session for "
-                       << criteria.imsi;
-          return it;
+          default:
+          case RATType::TGPP_NR:
+            MLOG(MERROR) << "Search criteria for IMSI_AND_BEARER "
+                            "not implemented for this RAT "
+                         << context.rat_type();
+            break;
         }
-        break;
+        break;  // break IMSI_AND_BEARER
+
+      case IMSI_AND_TEID:
+        switch (context.rat_type()) {
+          case RATType::TGPP_WLAN:
+            return it;
+            break;
+          case RATType::TGPP_LTE:
+            if (context.teids().enb_teid() == criteria.secondary_key_unit32 ||
+                context.teids().agw_teid() == criteria.secondary_key_unit32) {
+              return it;
+            }
+            break;
+          case RATType::TGPP_NR:
+            if ((*it)->get_local_teid() == criteria.secondary_key_unit32) {
+              return it;
+            }
+            break;
+          default:
+            MLOG(MERROR) << "Search criteria for IMSI_AND_TEID not implemented"
+                            "for this RAT "
+                         << context.rat_type();
+            break;
+        }
+        break;  // break IMSI_AND_TEID
     }
     continue;
   }

--- a/lte/gateway/c/session_manager/StoredState.cpp
+++ b/lte/gateway/c/session_manager/StoredState.cpp
@@ -400,10 +400,10 @@ std::string serialize_stored_session(StoredSessionState& stored) {
   marshaled["local_teid"]        = std::to_string(stored.local_teid);
   marshaled["subscriber_quota_state"] =
       static_cast<int>(stored.subscriber_quota_state);
+  marshaled["create_session_response"] =
+      stored.create_session_response.SerializeAsString();
 
-  std::string tgpp_context;
-  stored.tgpp_context.SerializeToString(&tgpp_context);
-  marshaled["tgpp_context"]   = tgpp_context;
+  marshaled["tgpp_context"]   = stored.tgpp_context.SerializeAsString();
   marshaled["pdp_start_time"] = std::to_string(stored.pdp_start_time);
   marshaled["pdp_end_time"]   = std::to_string(stored.pdp_end_time);
 
@@ -473,6 +473,10 @@ StoredSessionState deserialize_stored_session(std::string& serialized) {
 
   stored.bearer_id_by_policy = deserialize_bearer_id_by_policy(
       marshaled["bearer_id_by_policy"].getString());
+
+  CreateSessionResponse csr;
+  csr.ParseFromString(marshaled["create_session_response"].getString());
+  stored.create_session_response = csr;
 
   magma::lte::TgppContext tgpp_context;
   tgpp_context.ParseFromString(marshaled["tgpp_context"].getString());

--- a/lte/gateway/c/session_manager/StoredState.h
+++ b/lte/gateway/c/session_manager/StoredState.h
@@ -218,6 +218,8 @@ struct StoredSessionState {
   uint32_t local_teid;
   uint64_t pdp_start_time;
   uint64_t pdp_end_time;
+  // will store the response from the core between Create and Activate Session
+  CreateSessionResponse create_session_response;
   // 5G session version handling
   uint32_t current_version;
   magma::lte::SubscriberQuotaUpdate_Type subscriber_quota_state;

--- a/lte/gateway/c/session_manager/test/Consts.h
+++ b/lte/gateway/c/session_manager/test/Consts.h
@@ -40,3 +40,6 @@
 #define TEID_3_DL 32
 #define TEID_4_UL 41
 #define TEID_4_DL 42
+#define BEARER_ID_1 0
+#define BEARER_ID_2 2
+#define BEARER_ID_3 3

--- a/lte/gateway/c/session_manager/test/Matchers.h
+++ b/lte/gateway/c/session_manager/test/Matchers.h
@@ -51,11 +51,11 @@ MATCHER_P(CheckStaticRulesNames, list_static_rules, "") {
   return true;
 }
 
-MATCHER_P(CheckTeids, comming_teids, "") {
-  Teids configured_teids = static_cast<Teids>(arg);
+MATCHER_P(CheckTeids, configured_teids, "") {
+  Teids pipelined_req_teids = static_cast<const Teids>(arg);
 
-  if ((configured_teids.agw_teid() == comming_teids.agw_teid()) &&
-      (configured_teids.enb_teid() == comming_teids.enb_teid())) {
+  if ((pipelined_req_teids.agw_teid() == configured_teids.agw_teid()) &&
+      (pipelined_req_teids.enb_teid() == configured_teids.enb_teid())) {
     return true;
   }
 
@@ -182,7 +182,8 @@ MATCHER_P(CheckSubscriberQuotaUpdate, quota, "") {
 MATCHER_P2(CheckCreateSession, imsi, promise_p, "") {
   auto req = static_cast<const CreateSessionRequest*>(arg);
   promise_p->set_value(req->session_id());
-  return req->common_context().sid().id() == imsi;
+  auto res = req->common_context().sid().id() == imsi;
+  return res;
 }
 
 MATCHER_P(CheckSingleUpdate, expected_update, "") {
@@ -207,7 +208,7 @@ MATCHER_P(CheckTerminate, imsi, "") {
   return request->common_context().sid().id() == imsi;
 }
 
-MATCHER_P4(CheckActivateFlows, imsi, rule_count, ipv4, ipv6, "") {
+MATCHER_P4(CheckActivateFlows, imsi, ipv4, ipv6, rule_count, "") {
   auto request = static_cast<const ActivateFlowsRequest*>(arg);
   auto res     = request->sid().id() == imsi &&
              request->rule_ids_size() == rule_count &&
@@ -215,13 +216,15 @@ MATCHER_P4(CheckActivateFlows, imsi, rule_count, ipv4, ipv6, "") {
   return res;
 }
 
-MATCHER_P5(
-    CheckActivateFlowsForTunnIds, imsi, ipv4, ipv6, enb_teid, agw_teid, "") {
+MATCHER_P6(
+    CheckActivateFlowsForTunnIds, imsi, ipv4, ipv6, enb_teid, agw_teid,
+    rule_count, "") {
   auto request = static_cast<const ActivateFlowsRequest*>(arg);
   auto res     = request->sid().id() == imsi && request->ip_addr() == ipv4 &&
              request->ipv6_addr() == ipv6 &&
              request->uplink_tunnel() == agw_teid &&
-             request->downlink_tunnel() == enb_teid;
+             request->downlink_tunnel() == enb_teid &&
+             request->rule_ids_size() == rule_count;
   return res;
 }
 

--- a/lte/gateway/c/session_manager/test/ProtobufCreators.cpp
+++ b/lte/gateway/c/session_manager/test/ProtobufCreators.cpp
@@ -439,4 +439,22 @@ PolicyBearerBindingRequest create_policy_bearer_bind_req(
   bearer_bind_req.set_bearer_id(bearer_id);
   return bearer_bind_req;
 }
+
+UpdateTunnelIdsRequest create_update_tunnel_ids_request(
+    const std::string& imsi, const uint32_t bearer_id, const Teids teids) {
+  return create_update_tunnel_ids_request(
+      imsi, bearer_id, teids.agw_teid(), teids.enb_teid());
+}
+
+UpdateTunnelIdsRequest create_update_tunnel_ids_request(
+    const std::string& imsi, const uint32_t bearer_id, const uint32_t agw_teid,
+    const uint32_t enb_teid) {
+  UpdateTunnelIdsRequest req;
+  req.mutable_sid()->set_id(imsi);
+  req.set_bearer_id(bearer_id);
+  req.set_agw_teid(agw_teid);
+  req.set_enb_teid(enb_teid);
+  return req;
+}
+
 }  // namespace magma

--- a/lte/gateway/c/session_manager/test/ProtobufCreators.h
+++ b/lte/gateway/c/session_manager/test/ProtobufCreators.h
@@ -183,4 +183,11 @@ magma::mconfig::SessionD get_default_mconfig();
 PolicyBearerBindingRequest create_policy_bearer_bind_req(
     const std::string& imsi, const uint32_t linked_bearer_id,
     const std::string& rule_id, const uint32_t bearer_id);
+
+UpdateTunnelIdsRequest create_update_tunnel_ids_request(
+    const std::string& imsi, const uint32_t bearer_id, const Teids teids);
+
+UpdateTunnelIdsRequest create_update_tunnel_ids_request(
+    const std::string& imsi, const uint32_t bearer_id, const uint32_t agw_teid,
+    const uint32_t enb_teid);
 }  // namespace magma

--- a/lte/gateway/c/session_manager/test/SessionStateTester.h
+++ b/lte/gateway/c/session_manager/test/SessionStateTester.h
@@ -35,7 +35,7 @@ class SessionStateTest : public ::testing::Test {
     rule_store    = std::make_shared<StaticRuleStore>();
     session_state = std::make_shared<SessionState>(
         "imsi", "session", test_sstate_cfg, *rule_store, tgpp_ctx,
-        pdp_start_time);
+        pdp_start_time, CreateSessionResponse{});
     update_criteria = get_default_update_criteria();
   }
   enum RuleType {

--- a/lte/gateway/c/session_manager/test/SessiondMocks.h
+++ b/lte/gateway/c/session_manager/test/SessiondMocks.h
@@ -72,7 +72,6 @@ class MockPipelinedClient : public PipelinedClient {
         .WillByDefault(Return(true));
     ON_CALL(*this, activate_flows_for_rules(_, _, _, _, _, _, _, _, _))
         .WillByDefault(Return(true));
-    ON_CALL(*this, update_tunnel_ids(_, _, _, _)).WillByDefault(Return(true));
     ON_CALL(*this, add_ue_mac_flow(_, _, _, _, _, _))
         .WillByDefault(Return(true));
     ON_CALL(*this, delete_ue_mac_flow(_, _)).WillByDefault(Return(true));
@@ -132,11 +131,6 @@ class MockPipelinedClient : public PipelinedClient {
           const std::vector<std::string>& static_rules,
           const std::vector<PolicyRule>& dynamic_rules,
           std::function<void(Status status, ActivateFlowsResult)> callback));
-  MOCK_METHOD4(
-      update_tunnel_ids,
-      bool(
-          const std::string& imsi, const std::string& ip_addr,
-          const std::string& ipv6_addr, const Teids teids));
   MOCK_METHOD6(
       add_ue_mac_flow,
       bool(

--- a/lte/gateway/c/session_manager/test/test_local_enforcer_wallet_exhaust.cpp
+++ b/lte/gateway/c/session_manager/test/test_local_enforcer_wallet_exhaust.cpp
@@ -126,8 +126,10 @@ TEST_F(LocalEnforcerTest, test_termination_scheduling_on_sync_sessions) {
       *pipelined_client,
       update_subscriber_quota_state(
           CheckSubscriberQuotaUpdate(SubscriberQuotaUpdate_Type_VALID_QUOTA)));
-  local_enforcer->init_session_credit(
+  local_enforcer->init_session(
       session_map, IMSI1, SESSION_ID_1, cwf_session_config, response);
+  local_enforcer->update_tunnel_ids(
+      session_map, create_update_tunnel_ids_request(IMSI1, 0, teids0));
 
   EXPECT_EQ(session_map[IMSI1].size(), 1);
   bool success =
@@ -192,8 +194,10 @@ TEST_F(LocalEnforcerTest, test_cwf_quota_exhaustion_on_init_has_quota) {
           CheckSubscriberQuotaUpdate(SubscriberQuotaUpdate_Type_VALID_QUOTA)))
       .Times(1)
       .WillOnce(testing::Return(true));
-  local_enforcer->init_session_credit(
+  local_enforcer->init_session(
       session_map, IMSI1, SESSION_ID_1, cwf_session_config, response);
+  local_enforcer->update_tunnel_ids(
+      session_map, create_update_tunnel_ids_request(IMSI1, 0, teids0));
 }
 
 TEST_F(LocalEnforcerTest, test_cwf_quota_exhaustion_on_init_no_quota) {
@@ -213,8 +217,10 @@ TEST_F(LocalEnforcerTest, test_cwf_quota_exhaustion_on_init_no_quota) {
           CheckSubscriberQuotaUpdate(SubscriberQuotaUpdate_Type_NO_QUOTA)))
       .Times(1)
       .WillOnce(testing::Return(true));
-  local_enforcer->init_session_credit(
+  local_enforcer->init_session(
       session_map, IMSI1, SESSION_ID_1, cwf_session_config, response);
+  local_enforcer->update_tunnel_ids(
+      session_map, create_update_tunnel_ids_request(IMSI1, 0, teids0));
 }
 
 TEST_F(LocalEnforcerTest, test_cwf_quota_exhaustion_on_rar) {
@@ -226,8 +232,10 @@ TEST_F(LocalEnforcerTest, test_cwf_quota_exhaustion_on_rar) {
   CreateSessionResponse response;
   create_session_create_response(
       IMSI1, SESSION_ID_1, "m1", static_rules, &response);
-  local_enforcer->init_session_credit(
+  local_enforcer->init_session(
       session_map, IMSI1, SESSION_ID_1, cwf_session_config, response);
+  local_enforcer->update_tunnel_ids(
+      session_map, create_update_tunnel_ids_request(IMSI1, 0, teids0));
 
   // send a policy reauth request with rule removals for "static_1" to indicate
   // total monitoring quota exhaustion
@@ -260,8 +268,10 @@ TEST_F(LocalEnforcerTest, test_cwf_quota_exhaustion_on_update) {
   CreateSessionResponse response;
   create_session_create_response(
       IMSI1, SESSION_ID_1, "m1", static_rules, &response);
-  local_enforcer->init_session_credit(
+  local_enforcer->init_session(
       session_map, IMSI1, SESSION_ID_1, cwf_session_config, response);
+  local_enforcer->update_tunnel_ids(
+      session_map, create_update_tunnel_ids_request(IMSI1, 0, teids0));
 
   // remove only static_2, should not change anything in terms of quota since
   // static_1 is still active

--- a/lte/gateway/c/session_manager/test/test_proxy_responder_handler.cpp
+++ b/lte/gateway/c/session_manager/test/test_proxy_responder_handler.cpp
@@ -83,7 +83,8 @@ class SessionProxyResponderHandlerTest : public ::testing::Test {
     auto tgpp_context   = TgppContext{};
     auto pdp_start_time = 12345;
     return std::make_unique<SessionState>(
-        IMSI1, SESSION_ID_1, cfg, *rule_store, tgpp_context, pdp_start_time);
+        IMSI1, SESSION_ID_1, cfg, *rule_store, tgpp_context, pdp_start_time,
+        CreateSessionResponse{});
   }
 
   UsageMonitoringUpdateResponse* get_monitoring_update() {

--- a/lte/gateway/c/session_manager/test/test_session_manager_handler.cpp
+++ b/lte/gateway/c/session_manager/test/test_session_manager_handler.cpp
@@ -34,6 +34,9 @@ using ::testing::Test;
 
 namespace magma {
 
+Teids teids0;
+Teids teids1;
+
 class SessionManagerHandlerTest : public ::testing::Test {
  protected:
   virtual void SetUp() {
@@ -65,6 +68,11 @@ class SessionManagerHandlerTest : public ::testing::Test {
     session_manager = std::make_shared<LocalSessionManagerHandlerImpl>(
         local_enforcer, reporter.get(), directoryd_client, events_reporter,
         *session_store);
+
+    teids0.set_agw_teid(0);
+    teids0.set_enb_teid(0);
+    teids1.set_agw_teid(TEID_1_UL);
+    teids1.set_enb_teid(TEID_1_DL);
   }
 
   void insert_static_rule(
@@ -100,13 +108,11 @@ TEST_F(SessionManagerHandlerTest, test_create_session_cfg) {
 
   LocalCreateSessionRequest request;
   CreateSessionResponse response;
-  Teids teids;
-  teids.set_enb_teid(TEID_1_UL);
-  teids.set_agw_teid(TEID_1_DL);
+
   const std::string& hardware_addr_bytes = {0x0f, 0x10, 0x2e, 0x12, 0x3a, 0x55};
   SessionConfig cfg;
   cfg.common_context =
-      build_common_context(IMSI1, "", "", teids, "apn1", MSISDN, TGPP_WLAN);
+      build_common_context(IMSI1, "", "", teids0, "apn1", MSISDN, TGPP_WLAN);
   const auto& wlan = build_wlan_context(MAC_ADDR, RADIUS_SESSION_ID);
   cfg.rat_specific_context.mutable_wlan_context()->CopyFrom(wlan);
 
@@ -121,8 +127,11 @@ TEST_F(SessionManagerHandlerTest, test_create_session_cfg) {
       IMSI1, SESSION_ID_1, 1, 1536, response.mutable_credits()->Add());
 
   auto session_map = session_store->read_sessions({IMSI1});
-  local_enforcer->init_session_credit(
-      session_map, IMSI1, SESSION_ID_1, cfg, response);
+  local_enforcer->init_session(session_map, IMSI1, SESSION_ID_1, cfg, response);
+  local_enforcer->update_tunnel_ids(
+      session_map,
+      create_update_tunnel_ids_request(IMSI1, BEARER_ID_1, teids0));
+
   bool write_success =
       session_store->create_sessions(IMSI1, std::move(session_map[IMSI1]));
   EXPECT_TRUE(write_success);
@@ -134,11 +143,9 @@ TEST_F(SessionManagerHandlerTest, test_create_session_cfg) {
   EXPECT_EQ(session->get_config().common_context.apn(), "apn1");
 
   grpc::ServerContext create_context;
-  Teids teids2;
-  teids2.set_enb_teid(TEID_2_UL);
-  teids2.set_agw_teid(TEID_2_DL);
+
   auto common =
-      build_common_context(IMSI1, "", "", teids2, "apn2", MSISDN, TGPP_WLAN);
+      build_common_context(IMSI1, "", "", teids0, "apn2", MSISDN, TGPP_WLAN);
   request.mutable_common_context()->CopyFrom(common);
   request.mutable_rat_specific_context()->mutable_wlan_context()->CopyFrom(
       wlan);  // use same WLAN config as previous
@@ -148,6 +155,9 @@ TEST_F(SessionManagerHandlerTest, test_create_session_cfg) {
   session_manager->CreateSession(
       &create_context, &request,
       [this](grpc::Status status, LocalCreateSessionResponse response_out) {});
+  local_enforcer->update_tunnel_ids(
+      session_map,
+      create_update_tunnel_ids_request(IMSI1, BEARER_ID_1, teids0));
 
   // Run session creation in the EventBase loop
   // It needs to loop once here.
@@ -169,14 +179,13 @@ TEST_F(SessionManagerHandlerTest, test_session_recycling_lte) {
 
   CreateSessionResponse response;
   auto sid = id_gen_.gen_session_id(IMSI1);
-  Teids teids;
-  teids.set_enb_teid(TEID_1_UL);
-  teids.set_agw_teid(TEID_1_DL);
+
   SessionConfig cfg;
   cfg.common_context =
-      build_common_context(IMSI1, IP1, IPv6_1, teids, APN1, MSISDN, TGPP_LTE);
+      build_common_context(IMSI1, IP1, IPv6_1, teids1, APN1, MSISDN, TGPP_LTE);
   auto lte_context = build_lte_context(
-      "spgw_ip", "imei", "plmn_id", "imsi_plmn_id", "user_loc", 1, nullptr);
+      "spgw_ip", "imei", "plmn_id", "imsi_plmn_id", "user_loc", BEARER_ID_1,
+      nullptr);
   cfg.rat_specific_context.mutable_lte_context()->CopyFrom(lte_context);
 
   response.set_session_id(sid);
@@ -187,7 +196,12 @@ TEST_F(SessionManagerHandlerTest, test_session_recycling_lte) {
       IMSI1, sid, 1, 1536, response.mutable_credits()->Add());
 
   auto session_map = session_store->read_sessions({IMSI1});
-  local_enforcer->init_session_credit(session_map, IMSI1, sid, cfg, response);
+
+  local_enforcer->init_session(session_map, IMSI1, sid, cfg, response);
+  local_enforcer->update_tunnel_ids(
+      session_map,
+      create_update_tunnel_ids_request(IMSI1, BEARER_ID_1, teids1));
+
   bool write_success =
       session_store->create_sessions(IMSI1, std::move(session_map[IMSI1]));
   EXPECT_TRUE(write_success);
@@ -204,25 +218,16 @@ TEST_F(SessionManagerHandlerTest, test_session_recycling_lte) {
   LocalCreateSessionRequest request;
   grpc::ServerContext create_context;
   auto common =
-      build_common_context(IMSI1, IP1, IPv6_1, teids, APN1, MSISDN, TGPP_LTE);
+      build_common_context(IMSI1, IP1, IPv6_1, teids1, APN1, MSISDN, TGPP_LTE);
   request.mutable_common_context()->CopyFrom(common);
   lte_context = build_lte_context(
-      "spgw_ip", "imei", "plmn_id", "imsi_plmn_id", "user_loc", 1, nullptr);
+      "spgw_ip", "imei", "plmn_id", "imsi_plmn_id", "user_loc", BEARER_ID_1,
+      nullptr);
   request.mutable_rat_specific_context()->mutable_lte_context()->CopyFrom(
       lte_context);
 
   // Ensure session is not reported as its a duplicate
   EXPECT_CALL(*reporter, report_create_session(_, _)).Times(0);
-  // Termination process for the previous session is started
-  EXPECT_CALL(
-      *pipelined_client, deactivate_flows_for_rules_for_termination(
-                             IMSI1, IP1, IPv6_1, CheckTeids(teids), testing::_,
-                             testing::_, testing::_))
-      .Times(1)
-      .WillOnce(testing::Return(true));
-  session_manager->CreateSession(
-      &create_context, &request,
-      [this](grpc::Status status, LocalCreateSessionResponse response_out) {});
 
   // Run session creation in the EventBase loop
   // It needs to loop once here.
@@ -238,16 +243,17 @@ TEST_F(SessionManagerHandlerTest, test_session_recycling_lte) {
 
   // Now make the config not identical but with the same APN=apn1, this should
   // trigger a terminate for the existing and a creation for the new session
-  Teids teids3;
-  teids3.set_enb_teid(TEID_3_UL);
-  teids3.set_agw_teid(TEID_3_DL);
+  Teids teids2;
+  teids2.set_enb_teid(TEID_2_UL);
+  teids2.set_agw_teid(TEID_2_DL);
   LocalCreateSessionRequest request2;
   grpc::ServerContext create_context2;
   common = build_common_context(
-      IMSI1, "", "", teids3, APN1, "different msisdn", TGPP_LTE);
+      IMSI1, "", "", teids2, APN1, "different msisdn", TGPP_LTE);
   request2.mutable_common_context()->CopyFrom(common);
   lte_context = build_lte_context(
-      "spgw_ip", "imei", "plmn_id", "imsi_plmn_id", "user_loc", 1, nullptr);
+      "spgw_ip", "imei", "plmn_id", "imsi_plmn_id", "user_loc", BEARER_ID_1,
+      nullptr);
   request2.mutable_rat_specific_context()->mutable_lte_context()->CopyFrom(
       lte_context);
 
@@ -262,6 +268,9 @@ TEST_F(SessionManagerHandlerTest, test_session_recycling_lte) {
   // Run session creation in the EventBase loop
   // It needs to loop once here.
   evb->loopOnce();
+  local_enforcer->update_tunnel_ids(
+      session_map,
+      create_update_tunnel_ids_request(IMSI1, BEARER_ID_1, teids2));
 }
 
 TEST_F(SessionManagerHandlerTest, test_create_session) {
@@ -327,15 +336,20 @@ TEST_F(SessionManagerHandlerTest, test_report_rule_stats) {
   cfg.common_context =
       build_common_context(IMSI1, IP1, IPv6_1, teids, "APN", MSISDN, TGPP_LTE);
   const auto& lte_context = build_lte_context(
-      "127.0.0.1", "imei", "plmn_id", "imsi_plmn_id", "user_loc", 1, nullptr);
+      "127.0.0.1", "imei", "plmn_id", "imsi_plmn_id", "user_loc", BEARER_ID_1,
+      nullptr);
   cfg.rat_specific_context.mutable_lte_context()->CopyFrom(lte_context);
   auto session_map = session_store->read_sessions({IMSI1});
   EXPECT_CALL(
       *events_reporter,
       session_created(IMSI1, SESSION_ID_1, testing::_, testing::_))
       .Times(1);
-  local_enforcer->init_session_credit(
-      session_map, IMSI1, SESSION_ID_1, cfg, response);
+
+  local_enforcer->init_session(session_map, IMSI1, SESSION_ID_1, cfg, response);
+  local_enforcer->update_tunnel_ids(
+      session_map,
+      create_update_tunnel_ids_request(IMSI1, BEARER_ID_1, teids0));
+
   bool write_success =
       session_store->create_sessions(IMSI1, std::move(session_map[IMSI1]));
   EXPECT_TRUE(write_success);
@@ -381,8 +395,11 @@ TEST_F(SessionManagerHandlerTest, test_end_session) {
   cfg.rat_specific_context.mutable_wlan_context()->CopyFrom(wlan);
 
   auto session_map = session_store->read_sessions({IMSI1});
-  local_enforcer->init_session_credit(
-      session_map, IMSI1, SESSION_ID_1, cfg, response);
+
+  local_enforcer->init_session(session_map, IMSI1, SESSION_ID_1, cfg, response);
+  local_enforcer->update_tunnel_ids(
+      session_map, create_update_tunnel_ids_request(IMSI1, 0, teids0));
+
   bool write_success =
       session_store->create_sessions(IMSI1, std::move(session_map[IMSI1]));
   EXPECT_TRUE(write_success);

--- a/lte/gateway/c/session_manager/test/test_sessiond_integ.cpp
+++ b/lte/gateway/c/session_manager/test/test_sessiond_integ.cpp
@@ -296,6 +296,7 @@ TEST_F(SessiondTest, end_to_end_success) {
   {
     // 1- CreateSession Expectations
     // Expect create session with IMSI1
+
     EXPECT_CALL(
         *controller_mock,
         CreateSession(
@@ -303,31 +304,8 @@ TEST_F(SessiondTest, end_to_end_success) {
             testing::_))
         .Times(1)
         .WillOnce(testing::DoAll(
-            SetCreateSessionResponse(1536, 1024),
+            SetCreateSessionResponse(1536, 1024), SetPromise(&create_promise),
             testing::Return(grpc::Status::OK)));
-
-    EXPECT_CALL(
-        *events_reporter,
-        session_created(IMSI1, testing::_, testing::_, testing::_))
-        .Times(1);
-
-    // Temporary fix for PipelineD client in SessionD introduces separate
-    // calls for static and dynamic rules. So here is the call for static
-    // rules.
-    EXPECT_CALL(
-        *pipelined_mock,
-        ActivateFlows(
-            testing::_, CheckActivateFlows(IMSI1, 3, ipv4_addrs, ipv6_addrs),
-            testing::_))
-        .Times(1);
-    // Here is the call for dynamic rules, which in this case should be empty.
-    EXPECT_CALL(
-        *pipelined_mock,
-        ActivateFlows(
-            testing::_, CheckActivateFlows(IMSI1, 0, ipv4_addrs, ipv6_addrs),
-            testing::_))
-        .WillOnce(testing::DoAll(
-            SetPromise(&create_promise), testing::Return(grpc::Status::OK)));
   }
 
   // send_empty_pipelined_table(stub);
@@ -339,7 +317,7 @@ TEST_F(SessiondTest, end_to_end_success) {
   request.mutable_common_context()->mutable_sid()->set_id(IMSI1);
   request.mutable_common_context()->set_rat_type(RATType::TGPP_LTE);
   request.mutable_rat_specific_context()->mutable_lte_context()->set_bearer_id(
-      5);
+      default_bearer);
   request.mutable_common_context()->set_ue_ipv4(ipv4_addrs);
   request.mutable_common_context()->set_ue_ipv6(ipv6_addrs);
   // Todo, remove emptyTeids once we split CreateSession
@@ -347,6 +325,7 @@ TEST_F(SessiondTest, end_to_end_success) {
   emptyTeids.set_enb_teid(0);
   emptyTeids.set_agw_teid(0);
   request.mutable_common_context()->mutable_teids()->CopyFrom(emptyTeids);
+
   stub->CreateSession(&create_context, request, &create_resp);
 
   // Block and wait until we process CreateSessionResponse, after which the
@@ -360,14 +339,31 @@ TEST_F(SessiondTest, end_to_end_success) {
 
   {
     // 2- UpdateTunnelIds Expectations
+    // Expect rules to be installed and pipelined to be configured
+    EXPECT_CALL(
+        *events_reporter,
+        session_created(IMSI1, testing::_, testing::_, testing::_))
+        .Times(1);
+
+    // Temporary fix for PipelineD client in SessionD introduces separate
+    // calls for static and dynamic rules. So here is the call for static
+    // rules.
     EXPECT_CALL(
         *pipelined_mock,
         ActivateFlows(
             testing::_,
             CheckActivateFlowsForTunnIds(
-                IMSI1, ipv4_addrs, ipv6_addrs, enb_teid, agw_teid),
+                IMSI1, ipv4_addrs, ipv6_addrs, enb_teid, agw_teid, 3),
             testing::_))
-        .Times(1)
+        .Times(1);
+    // Here is the call for dynamic rules, which in this case should be empty.
+    EXPECT_CALL(
+        *pipelined_mock,
+        ActivateFlows(
+            testing::_,
+            CheckActivateFlowsForTunnIds(
+                IMSI1, ipv4_addrs, ipv6_addrs, enb_teid, agw_teid, 0),
+            testing::_))
         .WillOnce(testing::DoAll(
             SetPromise(&tunnel_promise), testing::Return(grpc::Status::OK)));
   }
@@ -470,6 +466,9 @@ TEST_F(SessiondTest, end_to_end_success) {
 TEST_F(SessiondTest, end_to_end_cloud_down) {
   std::promise<void> end_promise, failed_update_promise;
   std::promise<std::string> session_id_promise;
+  uint32_t default_bearer = 5;
+  uint32_t enb_teid       = TEID_1_DL;
+  uint32_t agw_teid       = TEID_1_UL;
   auto channel = ServiceRegistrySingleton::Instance()->GetGrpcChannel(
       "sessiond", ServiceRegistrySingleton::LOCAL);
   auto stub = LocalSessionManager::NewStub(channel);
@@ -489,12 +488,26 @@ TEST_F(SessiondTest, end_to_end_cloud_down) {
             SetCreateSessionResponse(1025, 1024),
             testing::Return(grpc::Status::OK)));
   }
+  // 1- Create session
   grpc::ClientContext create_context;
   LocalCreateSessionResponse create_resp;
   LocalCreateSessionRequest request;
   request.mutable_common_context()->mutable_sid()->set_id(IMSI1);
   request.mutable_common_context()->set_rat_type(RATType::TGPP_LTE);
+  request.mutable_rat_specific_context()->mutable_lte_context()->set_bearer_id(
+      default_bearer);
   stub->CreateSession(&create_context, request, &create_resp);
+
+  // 2- UpdateTunnelIds Trigger
+  grpc::ClientContext tun_update_context;
+  UpdateTunnelIdsResponse tun_update_response;
+  UpdateTunnelIdsRequest tun_update_request;
+  tun_update_request.mutable_sid()->set_id(IMSI1);
+  tun_update_request.set_bearer_id(default_bearer);
+  tun_update_request.set_enb_teid(enb_teid);
+  tun_update_request.set_agw_teid(agw_teid);
+  stub->UpdateTunnelIds(
+      &tun_update_context, tun_update_request, &tun_update_response);
 
   {
     CreditUsageUpdate expected_update_fail;

--- a/lte/gateway/c/session_manager/test/test_store_client.cpp
+++ b/lte/gateway/c/session_manager/test/test_store_client.cpp
@@ -22,6 +22,7 @@
 #include "SessionID.h"
 #include "SessionState.h"
 #include "magma_logging.h"
+#include "Consts.h"
 
 using ::testing::Test;
 
@@ -54,8 +55,8 @@ TEST_F(StoreClientTest, test_read_and_write) {
   auto sid2 = id_gen_.gen_session_id(imsi2);
   auto sid3 = id_gen_.gen_session_id(imsi3);
   Teids teids;
-  teids.set_agw_teid(0);
-  teids.set_enb_teid(0);
+  teids.set_agw_teid(1);
+  teids.set_enb_teid(2);
   SessionConfig cfg;
   cfg.common_context = build_common_context(
       "", "128.0.0.1", "2001:0db8:0a0b:12f0:0000:0000:0000:0001", teids, "APN",
@@ -72,13 +73,26 @@ TEST_F(StoreClientTest, test_read_and_write) {
   std::set<std::string> requested_ids{imsi, imsi2};
   auto session_map = store_client->read_sessions(requested_ids);
 
-  auto uc      = get_default_update_criteria();
+  auto uc = get_default_update_criteria();
+
+  CreateSessionResponse response1;
+  auto credits = response1.mutable_credits();
+  create_credit_update_response(imsi, sid, 1, 1000, credits->Add());
   auto session = std::make_unique<SessionState>(
-      imsi, sid, cfg, *rule_store, tgpp_context, pdp_start_time);
+      imsi, sid, cfg, *rule_store, tgpp_context, pdp_start_time, response1);
+
+  CreateSessionResponse response2;
+  credits = response2.mutable_credits();
+  create_credit_update_response(imsi2, sid2, 2, 2000, credits->Add());
   auto session2 = std::make_unique<SessionState>(
-      imsi2, sid2, cfg, *rule_store, tgpp_context, pdp_start_time);
+      imsi2, sid2, cfg, *rule_store, tgpp_context, pdp_start_time, response2);
+
+  CreateSessionResponse response3;
+  credits = response3.mutable_credits();
+  create_credit_update_response(imsi3, sid3, 3, 3000, credits->Add());
   auto session3 = std::make_unique<SessionState>(
-      imsi3, sid3, cfg, *rule_store, tgpp_context, pdp_start_time);
+      imsi3, sid3, cfg, *rule_store, tgpp_context, pdp_start_time, response3);
+
   EXPECT_EQ(session->get_session_id(), sid);
   EXPECT_EQ(session2->get_session_id(), sid2);
 
@@ -108,6 +122,10 @@ TEST_F(StoreClientTest, test_read_and_write) {
   EXPECT_EQ(session_map_2[imsi].front()->get_session_id(), sid);
   EXPECT_EQ(
       session_map_2[imsi].front()->is_static_rule_installed("rule1"), true);
+  EXPECT_EQ(session_map_2[imsi].front()->get_config(), cfg);
+  EXPECT_EQ(
+      session_map_2[imsi].front()->get_create_session_response().DebugString(),
+      response1.DebugString());
 
   // Now create a third session
   std::set<std::string> requested_imsi3{imsi3};
@@ -124,6 +142,9 @@ TEST_F(StoreClientTest, test_read_and_write) {
   EXPECT_EQ(all_sessions[imsi].front()->get_session_id(), sid);
   EXPECT_EQ(all_sessions[imsi3].size(), 1);
   EXPECT_EQ(all_sessions[imsi3].front()->get_session_id(), sid3);
+  EXPECT_EQ(
+      all_sessions[imsi3].front()->get_create_session_response().DebugString(),
+      response3.DebugString());
 }
 
 TEST_F(StoreClientTest, test_lambdas) {


### PR DESCRIPTION
Signed-off-by: Oriol Batalla <obatalla@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary

This PR splits create session into two: Create Session and Activate session (note activate session is still called Update Tunnel Ids in this PR. This will be changed in the future)

The idea is Create Session will create a new session entry on SessionStore and will send the create session to the Core. It will receive the `CreateSessionResponse` and store that answer (not process it)

Activate session (now Update Tunnel ID) will receive the bearer id and tunnel ids from MME. Then Sessiond using the `CreateSessionResponse` received from the core(stored during CreateSession) and initialize any credits and install rules on Pipelined


In order to make the process the same between LTE and CWF, we have changed the way AAA_server creates a session (just adding UpdateTunnelID which it just activate rules and install rules right after receiving `LocalCreateSessionResponsethe` from sessiond. It will use a default value for bearer and tunnelid (`=0`)  on pipelined, but ignores bearer id or tunnel id sent in the request)

This PR does not include how to handle sessions that were created but never activated. That will come in a different PR

## Test Plan

make precommit_sm
teravm tests

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
