### PR TITLE
[ctraced][nms] Add page and tab for controlling call tracing

### DIFF
--- a/nms/app/packages/fbcnms-magma-api/__generated__/MagmaAPIBindings.js
+++ b/nms/app/packages/fbcnms-magma-api/__generated__/MagmaAPIBindings.js
@@ -129,6 +129,20 @@ export type base_name_record = {
 };
 export type base_names = Array < base_name >
 ;
+export type call_trace = {
+    config: call_trace_config,
+    state ? : call_trace_state,
+};
+export type call_trace_config = {
+    gateway_id ? : string,
+    timeout ? : number,
+    trace_id: string,
+    trace_type: "GATEWAY",
+};
+export type call_trace_state = {
+    call_trace_available ? : boolean,
+    call_trace_ending ? : boolean,
+};
 export type carrier_wifi_gateway_health_status = {
     description: string,
     status: "HEALTHY" | "UNHEALTHY",
@@ -360,6 +374,7 @@ export type enodeb_state = {
     rf_tx_desired: boolean,
     rf_tx_on: boolean,
     time_reported ? : number,
+    ues_connected ? : number,
 };
 export type enodebd_e2e_test = {
     config: enodebd_test_config,
@@ -507,9 +522,10 @@ export type gateway_he_config = {
     enable_encryption: boolean,
     enable_header_enrichment: boolean,
     encryption_key ? : string,
-    he_encoding_type: "BASE64",
-    he_encryption_algorithm: "RC4",
-    he_hash_function: "MD5",
+    he_encoding_type: "BASE64" | "HEX2BIN",
+    he_encryption_algorithm: "RC4" | "AES256_CBC_HMAC_MD5" | "AES256_ECB_HMAC_MD5" | "GZIPPED_AES256_ECB_SHA1",
+    he_hash_function: "MD5" | "HEX" | "SHA256",
+    hmac_key ? : string,
 };
 export type gateway_health_configs = {
     cpu_util_threshold_pct ? : number,
@@ -780,6 +796,9 @@ export type msisdn = string;
 export type msisdn_assignment = {
     id: subscriber_id,
     msisdn: msisdn,
+};
+export type mutable_call_trace = {
+    requested_end: boolean,
 };
 export type mutable_cellular_gateway_pool = {
     config: cellular_gateway_pool_configs,
@@ -1366,6 +1385,7 @@ export type untyped_subscriber_state = {};
 export type virtual_apn_rule = {
     apn_filter ? : string,
     apn_overwrite ? : string,
+    charging_characteristics_filter ? : string,
 };
 export type webhook_receiver = {
     http_config ? : http_config,
@@ -9136,6 +9156,153 @@ export default class MagmaAPIBindings {
 
         return await this.request(path, 'PUT', query, body);
     }
+    static async getNetworksByNetworkIdTracing(
+            parameters: {
+                'networkId': string,
+            }
+        ): Promise < Array < {} >
+        >
+        {
+            let path = '/networks/{network_id}/tracing';
+            let body;
+            let query = {};
+            if (parameters['networkId'] === undefined) {
+                throw new Error('Missing required  parameter: networkId');
+            }
+
+            path = path.replace('{network_id}', `${parameters['networkId']}`);
+
+            return await this.request(path, 'GET', query, body);
+        }
+    static async postNetworksByNetworkIdTracing(
+            parameters: {
+                'networkId': string,
+                'callTraceConfiguration': call_trace_config,
+            }
+        ): Promise < string >
+        {
+            let path = '/networks/{network_id}/tracing';
+            let body;
+            let query = {};
+            if (parameters['networkId'] === undefined) {
+                throw new Error('Missing required  parameter: networkId');
+            }
+
+            path = path.replace('{network_id}', `${parameters['networkId']}`);
+
+            if (parameters['callTraceConfiguration'] === undefined) {
+                throw new Error('Missing required  parameter: callTraceConfiguration');
+            }
+
+            if (parameters['callTraceConfiguration'] !== undefined) {
+                body = parameters['callTraceConfiguration'];
+            }
+
+            return await this.request(path, 'POST', query, body);
+        }
+    static async deleteNetworksByNetworkIdTracingByTraceId(
+        parameters: {
+            'networkId': string,
+            'traceId': string,
+        }
+    ): Promise < "Success" > {
+        let path = '/networks/{network_id}/tracing/{trace_id}';
+        let body;
+        let query = {};
+        if (parameters['networkId'] === undefined) {
+            throw new Error('Missing required  parameter: networkId');
+        }
+
+        path = path.replace('{network_id}', `${parameters['networkId']}`);
+
+        if (parameters['traceId'] === undefined) {
+            throw new Error('Missing required  parameter: traceId');
+        }
+
+        path = path.replace('{trace_id}', `${parameters['traceId']}`);
+
+        return await this.request(path, 'DELETE', query, body);
+    }
+    static async getNetworksByNetworkIdTracingByTraceId(
+            parameters: {
+                'networkId': string,
+                'traceId': string,
+            }
+        ): Promise < call_trace >
+        {
+            let path = '/networks/{network_id}/tracing/{trace_id}';
+            let body;
+            let query = {};
+            if (parameters['networkId'] === undefined) {
+                throw new Error('Missing required  parameter: networkId');
+            }
+
+            path = path.replace('{network_id}', `${parameters['networkId']}`);
+
+            if (parameters['traceId'] === undefined) {
+                throw new Error('Missing required  parameter: traceId');
+            }
+
+            path = path.replace('{trace_id}', `${parameters['traceId']}`);
+
+            return await this.request(path, 'GET', query, body);
+        }
+    static async putNetworksByNetworkIdTracingByTraceId(
+        parameters: {
+            'networkId': string,
+            'traceId': string,
+            'callTraceConfiguration': mutable_call_trace,
+        }
+    ): Promise < "Success" > {
+        let path = '/networks/{network_id}/tracing/{trace_id}';
+        let body;
+        let query = {};
+        if (parameters['networkId'] === undefined) {
+            throw new Error('Missing required  parameter: networkId');
+        }
+
+        path = path.replace('{network_id}', `${parameters['networkId']}`);
+
+        if (parameters['traceId'] === undefined) {
+            throw new Error('Missing required  parameter: traceId');
+        }
+
+        path = path.replace('{trace_id}', `${parameters['traceId']}`);
+
+        if (parameters['callTraceConfiguration'] === undefined) {
+            throw new Error('Missing required  parameter: callTraceConfiguration');
+        }
+
+        if (parameters['callTraceConfiguration'] !== undefined) {
+            body = parameters['callTraceConfiguration'];
+        }
+
+        return await this.request(path, 'PUT', query, body);
+    }
+    static async getNetworksByNetworkIdTracingByTraceIdDownload(
+            parameters: {
+                'networkId': string,
+                'traceId': string,
+            }
+        ): Promise < {} >
+        {
+            let path = '/networks/{network_id}/tracing/{trace_id}/download';
+            let body;
+            let query = {};
+            if (parameters['networkId'] === undefined) {
+                throw new Error('Missing required  parameter: networkId');
+            }
+
+            path = path.replace('{network_id}', `${parameters['networkId']}`);
+
+            if (parameters['traceId'] === undefined) {
+                throw new Error('Missing required  parameter: traceId');
+            }
+
+            path = path.replace('{trace_id}', `${parameters['traceId']}`);
+
+            return await this.request(path, 'GET', query, body);
+        }
     static async getNetworksByNetworkIdType(
             parameters: {
                 'networkId': string,

--- a/nms/app/packages/magmalte/app/components/ActionTable.js
+++ b/nms/app/packages/magmalte/app/components/ActionTable.js
@@ -80,7 +80,7 @@ const tableIcons = {
 
 type ActionMenuItems = {
   name: string,
-  handleFunc?: () => void,
+  handleFunc?: () => void | (() => Promise<void>),
 };
 
 type ColumnType =

--- a/nms/app/packages/magmalte/app/components/context/TraceContext.js
+++ b/nms/app/packages/magmalte/app/components/context/TraceContext.js
@@ -1,0 +1,25 @@
+/**
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @flow strict-local
+ * @format
+ */
+import type {call_trace, mutable_call_trace} from '@fbcnms/magma-api';
+
+import React from 'react';
+
+export type TraceContextType = {
+  state: {[string]: call_trace},
+  setState?: (key: string, val?: mutable_call_trace) => Promise<void>,
+};
+
+export default React.createContext<TraceContextType>({});

--- a/nms/app/packages/magmalte/app/components/lte/LteSections.js
+++ b/nms/app/packages/magmalte/app/components/lte/LteSections.js
@@ -24,6 +24,7 @@ import Enodebs from './Enodebs';
 import EquipmentDashboard from '../../views/equipment/EquipmentDashboard';
 import Gateways from '../Gateways';
 import Insights from '@fbcnms/ui/insights/Insights';
+import LineStyleIcon from '@material-ui/icons/LineStyle';
 import ListIcon from '@material-ui/icons/List';
 import Logs from '@fbcnms/ui/insights/Logs/Logs';
 import LteConfigure from '../LteConfigure';
@@ -39,6 +40,7 @@ import SettingsInputAntennaIcon from '@material-ui/icons/SettingsInputAntenna';
 import ShowChartIcon from '@material-ui/icons/ShowChart';
 import SubscriberDashboard from '../../views/subscriber/SubscriberOverview';
 import Subscribers from '../Subscribers';
+import TracingDashboard from '../../views/tracing/TracingDashboard';
 import TrafficDashboard from '../../views/traffic/TrafficOverview';
 import WifiTetheringIcon from '@material-ui/icons/WifiTethering';
 
@@ -137,6 +139,12 @@ export function getLteSectionsV2(alertsEnabled: boolean): SectionsConfigs {
         label: 'Traffic',
         icon: <WifiTetheringIcon />,
         component: TrafficDashboard,
+      },
+      {
+        path: 'tracing',
+        label: 'Call Tracing',
+        icon: <LineStyleIcon />,
+        component: TracingDashboard,
       },
       {
         path: 'metrics',

--- a/nms/app/packages/magmalte/app/state/TraceState.js
+++ b/nms/app/packages/magmalte/app/state/TraceState.js
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @flow strict-local
+ * @format
+ */
+
+import MagmaV1API from '@fbcnms/magma-api/client/WebClient';
+
+import type {
+  call_trace,
+  call_trace_config,
+  mutable_call_trace,
+  network_id,
+} from '@fbcnms/magma-api';
+
+type InitTraceStateProps = {
+  networkId: network_id,
+  setTraceMap: ({[string]: call_trace}) => void,
+  enqueueSnackbar?: (msg: string, cfg: {}) => ?(string | number),
+};
+
+export async function InitTraceState(props: InitTraceStateProps) {
+  const {networkId, setTraceMap, enqueueSnackbar} = props;
+  try {
+    const traces = await MagmaV1API.getNetworksByNetworkIdTracing({
+      networkId,
+    });
+    if (traces) {
+      setTraceMap(traces);
+    }
+  } catch (e) {
+    enqueueSnackbar?.('failed fetching call trace information', {
+      variant: 'error',
+    });
+    return;
+  }
+}
+
+type CallTraceProps = {
+  networkId: network_id,
+  callTraces: {[string]: call_trace},
+  setCallTraces: ({[string]: call_trace}) => void,
+  key: string,
+  value?: $Shape<call_trace_config & mutable_call_trace>,
+};
+
+/* SetCallTraceState
+SetCallTraceState
+if key and value are passed in,
+if key is not present, a new trace is created (POST)
+if key is present, existing trace is updated (PUT)
+if value is not present, the trace is deleted (DELETE)
+*/
+export async function SetCallTraceState(props: CallTraceProps) {
+  const {networkId, callTraces, setCallTraces, key, value} = props;
+  if (value != null) {
+    if (!(key in callTraces)) {
+      await MagmaV1API.postNetworksByNetworkIdTracing({
+        networkId: networkId,
+        callTraceConfiguration: value, // call_trace_config
+      });
+    } else {
+      await MagmaV1API.putNetworksByNetworkIdTracingByTraceId({
+        networkId: networkId,
+        traceId: key,
+        callTraceConfiguration: value, // mutable_call_trace
+      });
+    }
+    const callTrace = await MagmaV1API.getNetworksByNetworkIdTracingByTraceId({
+      networkId: networkId,
+      traceId: key,
+    });
+
+    if (callTrace) {
+      const newTraces = {...callTraces, [key]: callTrace};
+      setCallTraces(newTraces);
+    }
+  } else {
+    await MagmaV1API.deleteNetworksByNetworkIdTracingByTraceId({
+      networkId: networkId,
+      traceId: key,
+    });
+    const newCallTraces = {...callTraces};
+    delete newCallTraces[key];
+    setCallTraces(newCallTraces);
+  }
+}

--- a/nms/app/packages/magmalte/app/views/tracing/TraceStartDialog.js
+++ b/nms/app/packages/magmalte/app/views/tracing/TraceStartDialog.js
@@ -1,0 +1,209 @@
+/*
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @flow strict-local
+ * @format
+ */
+import type {call_trace_config} from '@fbcnms/magma-api';
+
+import Button from '@material-ui/core/Button';
+import Dialog from '@material-ui/core/Dialog';
+import DialogActions from '@material-ui/core/DialogActions';
+import DialogContent from '@material-ui/core/DialogContent';
+import DialogTitle from '../../theme/design-system/DialogTitle';
+import FormLabel from '@material-ui/core/FormLabel';
+import Grid from '@material-ui/core/Grid';
+import List from '@material-ui/core/List';
+import OutlinedInput from '@material-ui/core/OutlinedInput';
+import React from 'react';
+import TraceContext from '../../components/context/TraceContext';
+import TypedSelect from '@fbcnms/ui/components/TypedSelect';
+
+import {AltFormField} from '../../components/FormField';
+import {colors, typography} from '../../theme/default';
+import {makeStyles} from '@material-ui/styles';
+import {useContext} from 'react';
+import {useEnqueueSnackbar} from '@fbcnms/ui/hooks/useSnackbar';
+import {useState} from 'react';
+
+const DEFAULT_TRACE_CONFIG: call_trace_config = {
+  gateway_id: '',
+  timeout: 300,
+  trace_id: '',
+  trace_type: 'GATEWAY',
+};
+
+const useStyles = makeStyles(_ => ({
+  topBar: {
+    backgroundColor: colors.primary.mirage,
+    padding: '20px 40px 20px 40px',
+    color: colors.primary.white,
+  },
+  appBarBtn: {
+    color: colors.primary.white,
+    background: colors.primary.comet,
+    fontFamily: typography.button.fontFamily,
+    fontWeight: typography.button.fontWeight,
+    fontSize: typography.button.fontSize,
+    lineHeight: typography.button.lineHeight,
+    letterSpacing: typography.button.letterSpacing,
+
+    '&:hover': {
+      background: colors.primary.mirage,
+    },
+  },
+}));
+
+export default function CreateTraceButton() {
+  const classes = useStyles();
+  const [open, setOpen] = useState(false);
+
+  return (
+    <>
+      <CreateTraceDialog open={open} onClose={() => setOpen(false)} />
+      <Button onClick={() => setOpen(true)} className={classes.appBarBtn}>
+        {'Start New Trace'}
+      </Button>
+    </>
+  );
+}
+
+type DialogProps = {
+  open: boolean,
+  onClose: () => void,
+};
+
+function CreateTraceDialog(props: DialogProps) {
+  const classes = useStyles();
+  return (
+    <Dialog
+      data-testid="addSubscriberDialog"
+      open={props.open}
+      fullWidth={true}
+      maxWidth="sm">
+      <DialogTitle
+        className={classes.topBar}
+        onClose={props.onClose}
+        label={'Start Call Trace'}
+      />
+
+      <CreateTraceDetails onClose={props.onClose} />
+    </Dialog>
+  );
+}
+
+type Props = {
+  traceCfg?: call_trace_config,
+  onClose: () => void,
+};
+
+function CreateTraceDetails(props: Props) {
+  //   const classes = useStyles();
+  const ctx = useContext(TraceContext);
+  const [error, setError] = useState('');
+  const [traceCfg, setTraceCfg] = useState<call_trace_config>({
+    ...(props.traceCfg || DEFAULT_TRACE_CONFIG),
+  });
+  const enqueueSnackbar = useEnqueueSnackbar();
+
+  const startTrace = async (cfg: call_trace_config) => {
+    try {
+      // $FlowFixMe[prop-missing]: Suppress type error, cannot refine type
+      await ctx.setState?.(cfg.trace_id, cfg);
+      props.onClose();
+      enqueueSnackbar('Call trace started successfully', {
+        variant: 'success',
+      });
+    } catch (e) {
+      const errMsg = e.response?.data?.message ?? e.message ?? e;
+      setError('error starting call trace: ' + errMsg);
+    }
+  };
+
+  return (
+    <>
+      <DialogContent>
+        <List>
+          {error !== '' && (
+            <AltFormField label={''}>
+              <FormLabel data-testid="configEditError" error>
+                {error}
+              </FormLabel>
+            </AltFormField>
+          )}
+          <Grid container>
+            <Grid item xs={12} sm={6}>
+              <AltFormField label={'Trace ID'}>
+                <OutlinedInput
+                  data-testid="trace-id"
+                  placeholder="Enter Trace ID"
+                  fullWidth={true}
+                  value={traceCfg.trace_id}
+                  onChange={({target}) => {
+                    setTraceCfg({...traceCfg, trace_id: target.value});
+                  }}
+                />
+              </AltFormField>
+            </Grid>
+            <Grid item xs={12} sm={6}>
+              <AltFormField label={'Timeout'}>
+                <OutlinedInput
+                  data-testid="timeout"
+                  placeholder="Enter Trace Timeout (s)"
+                  fullWidth={true}
+                  value={traceCfg.timeout}
+                  onChange={({target}) => {
+                    setTraceCfg({...traceCfg, timeout: target.value});
+                  }}
+                />
+              </AltFormField>
+            </Grid>
+          </Grid>
+          <AltFormField label={'Trace Type'}>
+            <TypedSelect
+              input={<OutlinedInput />}
+              value={traceCfg.trace_type}
+              fullWidth={true}
+              items={{
+                GATEWAY: 'Gateway',
+              }}
+              onChange={target => {
+                setTraceCfg({...traceCfg, trace_type: target});
+              }}
+            />
+          </AltFormField>
+          <AltFormField label={'Gateway ID'}>
+            <OutlinedInput
+              data-testid="gateway-id"
+              placeholder="Enter Gateway ID"
+              fullWidth={true}
+              value={traceCfg.gateway_id}
+              onChange={({target}) => {
+                setTraceCfg({...traceCfg, gateway_id: target.value});
+              }}
+            />
+          </AltFormField>
+        </List>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={props.onClose}> Cancel </Button>
+        <Button
+          data-testid="startTrace"
+          onClick={async () => {
+            await startTrace(traceCfg);
+          }}>
+          {'Start'}
+        </Button>
+      </DialogActions>
+    </>
+  );
+}

--- a/nms/app/packages/magmalte/app/views/tracing/TracingDashboard.js
+++ b/nms/app/packages/magmalte/app/views/tracing/TracingDashboard.js
@@ -1,0 +1,179 @@
+/*
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @flow
+ * @format
+ */
+
+import type {WithAlert} from '@fbcnms/ui/components/Alert/withAlert';
+import type {call_trace} from '@fbcnms/magma-api';
+
+import ActionTable from '../../components/ActionTable';
+import CardTitleRow from '../../components/layout/CardTitleRow';
+import CreateTraceButton from './TraceStartDialog';
+import HistoryIcon from '@material-ui/icons/History';
+import LineStyleIcon from '@material-ui/icons/LineStyle';
+import NetworkContext from '../../components/context/NetworkContext';
+import React from 'react';
+import TopBar from '../../components/TopBar';
+import TraceContext from '../../components/context/TraceContext';
+import withAlert from '@fbcnms/ui/components/Alert/withAlert';
+import {makeStyles} from '@material-ui/styles';
+import {useContext, useState} from 'react';
+import {useEnqueueSnackbar} from '@fbcnms/ui/hooks/useSnackbar';
+
+const useStyles = makeStyles(theme => ({
+  dashboardRoot: {
+    margin: theme.spacing(5),
+  },
+}));
+
+function TracingDashboard() {
+  return (
+    <>
+      <TopBar
+        header="Call Tracing"
+        tabs={[
+          {
+            label: 'Call Traces',
+            to: '/overview',
+            icon: LineStyleIcon,
+            filters: <div />,
+          },
+        ]}
+      />
+      <TracingTable />
+    </>
+  );
+}
+
+type TracingRowType = {
+  traceID: string,
+  state: 'COMPLETED' | 'ACTIVE',
+  gatewayID: string,
+  traceType: string,
+};
+
+function TracingTableRaw(_: WithAlert) {
+  const [currRow, setCurrRow] = useState<TracingRowType>({});
+  const classes = useStyles();
+  const ctx = useContext(TraceContext);
+  const {networkId} = useContext(NetworkContext);
+  const enqueueSnackbar = useEnqueueSnackbar();
+  const traceMap = ctx.state;
+  const tableData = tracesToRows(traceMap);
+  const tableColumns = [
+    {title: 'Trace ID', field: 'traceID'},
+    {title: 'State', field: 'state'},
+    {title: 'Gateway ID', field: 'gatewayID'},
+    {title: 'Trace Type', field: 'traceType'},
+  ];
+
+  const TraceFilter = () => {
+    return <CreateTraceButton />;
+  };
+
+  const handleStop = async () => {
+    if (currRow.state === 'COMPLETED') {
+      enqueueSnackbar('Call trace ' + currRow.traceID + ' already stopped.', {
+        variant: 'error',
+      });
+      return;
+    }
+
+    try {
+      // $FlowFixMe[prop-missing]: Suppress type error, cannot refine type
+      await ctx.setState?.(currRow.traceID, {
+        requested_end: true,
+      });
+      enqueueSnackbar('Call trace ended successfully', {
+        variant: 'success',
+      });
+    } catch (e) {
+      const errMsg = e.response?.data?.message ?? e.message ?? e;
+      enqueueSnackbar('Failed stopping call trace: ' + errMsg, {
+        variant: 'error',
+      });
+    }
+  };
+
+  const handleDownload = async () => {
+    if (currRow.state != 'COMPLETED') {
+      enqueueSnackbar('Call trace ' + currRow.traceID + ' is still active', {
+        variant: 'error',
+      });
+      return;
+    }
+
+    if (networkId) {
+      // TODO(andreilee): Build download link based on generated API bindings
+      window.location.href =
+        '/nms/apicontroller/magma/v1/networks/' +
+        networkId +
+        '/tracing/' +
+        currRow.traceID +
+        '/download';
+    }
+  };
+
+  return (
+    <div className={classes.dashboardRoot}>
+      <CardTitleRow
+        icon={HistoryIcon}
+        label={'Call Traces'}
+        filter={TraceFilter}
+      />
+      <ActionTable
+        data={tableData}
+        columns={tableColumns}
+        handleCurrRow={(row: TracingRowType) => setCurrRow(row)}
+        menuItems={[
+          {
+            name: 'Download',
+            // $FlowFixMe[incompatible-type]
+            handleFunc: handleDownload,
+          },
+          {
+            name: 'Stop',
+            // $FlowFixMe[incompatible-type]
+            handleFunc: handleStop,
+          },
+        ]}
+        options={{
+          actionsColumnIndex: -1,
+          pageSize: 10,
+          pageSizeOptions: [10, 20],
+        }}
+      />
+    </div>
+  );
+}
+
+function tracesToRows(traceMap: {[string]: call_trace}): Array<TracingRowType> {
+  const rows = [];
+  Object.keys(traceMap).map((traceID: string, _) => {
+    const isTraceEnding: boolean = !!traceMap[traceID]?.state
+      ?.call_trace_ending;
+
+    rows.push({
+      traceID: traceID,
+      state: isTraceEnding ? 'COMPLETED' : 'ACTIVE',
+      gatewayID: traceMap[traceID].config?.gateway_id || '',
+      traceType: 'GATEWAY',
+    });
+  });
+  return rows;
+}
+
+const TracingTable = withAlert(TracingTableRaw);
+
+export default TracingDashboard;

--- a/nms/app/packages/magmalte/scripts/mockServer.js
+++ b/nms/app/packages/magmalte/scripts/mockServer.js
@@ -278,6 +278,11 @@ networks.forEach(network => {
       res.status(200).jsonp(db['lte']['enodebs']);
     }
   });
+  server.get(`/magma/v1/networks/${network}/tracing`, (req, res) => {
+    if (req.method === 'GET') {
+      res.status(200).jsonp([]);
+    }
+  });
   server.get(
     `/magma/v1/lte/{network}/enodebs/12020000051696P0013/state`,
     (req, res) => {


### PR DESCRIPTION
## Summary

Added a new tab and page for controlling call tracing on NMS

<img width="909" alt="Screen Shot 2021-01-07 at 9 44 25 PM" src="https://user-images.githubusercontent.com/804385/103980236-5a4bd300-5134-11eb-953a-1bf9593720ab.png">

Capabilities are available for starting and stopping call traces. Basic filtering is also available.

## Test Plan

- js flow verified
- manually tested, see attached video:

https://user-images.githubusercontent.com/804385/103823237-89741e80-5026-11eb-9abc-3809f6115975.mov

## Additional Information

- [ ] This change is backwards-breaking
