### PR TITLE
[agw][mme] Replace ctime_r with strftime

### DIFF
--- a/lte/gateway/c/oai/common/log.c
+++ b/lte/gateway/c/oai/common/log.c
@@ -88,6 +88,7 @@
   "%06" PRIu64 " %s %08lX %-*.*s %-*.*s %-*.*s:%04u   [%lu]%*s"
 
 #define LOG_MAGMA_REPO_ROOT "/oai/"
+#define MAX_TIME_STR_LEN 32
 //-------------------------------
 
 typedef unsigned long log_message_number_t;
@@ -559,16 +560,15 @@ static void log_get_elapsed_time_since_start(struct timeval * const elapsed_time
 }
 #endif
 //------------------------------------------------------------------------------
-static char* log_get_readable_cur_time(time_t* cur_time) {
+static void log_get_readable_cur_time(time_t* cur_time, char* time_str) {
   // get the current local time
   time(cur_time);
   struct tm* cur_local_time;
   cur_local_time = localtime(cur_time);
-  char* time_str = calloc(32, sizeof(char));
   // get the current local time in readable string format
   strftime(
-      time_str, 32, "%a %b %d %H:%M:%S %Y", (const struct tm*) cur_local_time);
-  return time_str;
+      time_str, MAX_TIME_STR_LEN, "%a %b %d %H:%M:%S %Y",
+      (const struct tm*) cur_local_time);
 }
 
 //------------------------------------------------------------------------------
@@ -1481,8 +1481,9 @@ int append_log_ctx_info(
     const log_thread_ctxt_t* thread_ctxt, time_t* cur_time,
     const char* short_source_fileP) {
   int rv;
-  char* time_str = log_get_readable_cur_time(cur_time);
-  rv             = bformata(
+  char time_str[MAX_TIME_STR_LEN];
+  log_get_readable_cur_time(cur_time, time_str);
+  rv = bformata(
       bstr, LOG_CTXT_INFO_FMT,
       __sync_fetch_and_add(&g_oai_log.log_message_number, 1), time_str,
       thread_ctxt->tid, LOG_DISPLAYED_LOG_LEVEL_NAME_MAX_LENGTH,
@@ -1492,7 +1493,6 @@ int append_log_ctx_info(
       &g_oai_log.log_proto2str[(*protoP)][0], LOG_DISPLAYED_FILENAME_MAX_LENGTH,
       LOG_DISPLAYED_FILENAME_MAX_LENGTH, &short_source_fileP[filename_length],
       line_numP, thread_ctxt->indent, " ");
-  free_wrapper((void**) &time_str);
   return rv;
 }
 
@@ -1502,8 +1502,9 @@ int append_log_ctx_info_prefix_id(
     size_t filename_length, const log_thread_ctxt_t* thread_ctxt,
     time_t* cur_time, const char* short_source_fileP) {
   int rv;
-  char* time_str = log_get_readable_cur_time(cur_time);
-  rv             = bformata(
+  char time_str[MAX_TIME_STR_LEN];
+  log_get_readable_cur_time(cur_time, time_str);
+  rv = bformata(
       bstr, LOG_CTXT_INFO_ID_FMT,
       __sync_fetch_and_add(&g_oai_log.log_message_number, 1), time_str,
       thread_ctxt->tid, LOG_DISPLAYED_LOG_LEVEL_NAME_MAX_LENGTH,
@@ -1513,7 +1514,6 @@ int append_log_ctx_info_prefix_id(
       &g_oai_log.log_proto2str[(*protoP)][0], LOG_DISPLAYED_FILENAME_MAX_LENGTH,
       LOG_DISPLAYED_FILENAME_MAX_LENGTH, &short_source_fileP[filename_length],
       line_numP, prefix_id, thread_ctxt->indent, " ");
-  free_wrapper((void**) &time_str);
   return rv;
 }
 

--- a/lte/gateway/c/oai/common/log.c
+++ b/lte/gateway/c/oai/common/log.c
@@ -561,10 +561,14 @@ static void log_get_elapsed_time_since_start(struct timeval * const elapsed_time
 //------------------------------------------------------------------------------
 static char* log_get_readable_cur_time(time_t* cur_time) {
   // get the current local time
-  *cur_time = time(NULL);
+  time(cur_time);
+  struct tm* cur_local_time;
+  cur_local_time = localtime(cur_time);
+  char* time_str = calloc(32, sizeof(char));
   // get the current local time in readable string format
-  char buf[26];
-  return (strtok(ctime_r((const time_t*) cur_time, buf), "\n"));
+  strftime(
+      time_str, 32, "%a %b %d %H:%M:%S %Y", (const struct tm*) cur_local_time);
+  return time_str;
 }
 
 //------------------------------------------------------------------------------
@@ -1477,17 +1481,18 @@ int append_log_ctx_info(
     const log_thread_ctxt_t* thread_ctxt, time_t* cur_time,
     const char* short_source_fileP) {
   int rv;
-  rv = bformata(
+  char* time_str = log_get_readable_cur_time(cur_time);
+  rv             = bformata(
       bstr, LOG_CTXT_INFO_FMT,
-      __sync_fetch_and_add(&g_oai_log.log_message_number, 1),
-      log_get_readable_cur_time(cur_time), thread_ctxt->tid,
-      LOG_DISPLAYED_LOG_LEVEL_NAME_MAX_LENGTH,
+      __sync_fetch_and_add(&g_oai_log.log_message_number, 1), time_str,
+      thread_ctxt->tid, LOG_DISPLAYED_LOG_LEVEL_NAME_MAX_LENGTH,
       LOG_DISPLAYED_LOG_LEVEL_NAME_MAX_LENGTH,
       &g_oai_log.log_level2str[(*log_levelP)][0],
       LOG_DISPLAYED_PROTO_NAME_MAX_LENGTH, LOG_DISPLAYED_PROTO_NAME_MAX_LENGTH,
       &g_oai_log.log_proto2str[(*protoP)][0], LOG_DISPLAYED_FILENAME_MAX_LENGTH,
       LOG_DISPLAYED_FILENAME_MAX_LENGTH, &short_source_fileP[filename_length],
       line_numP, thread_ctxt->indent, " ");
+  free_wrapper((void**) &time_str);
   return rv;
 }
 
@@ -1497,17 +1502,18 @@ int append_log_ctx_info_prefix_id(
     size_t filename_length, const log_thread_ctxt_t* thread_ctxt,
     time_t* cur_time, const char* short_source_fileP) {
   int rv;
-  rv = bformata(
+  char* time_str = log_get_readable_cur_time(cur_time);
+  rv             = bformata(
       bstr, LOG_CTXT_INFO_ID_FMT,
-      __sync_fetch_and_add(&g_oai_log.log_message_number, 1),
-      log_get_readable_cur_time(cur_time), thread_ctxt->tid,
-      LOG_DISPLAYED_LOG_LEVEL_NAME_MAX_LENGTH,
+      __sync_fetch_and_add(&g_oai_log.log_message_number, 1), time_str,
+      thread_ctxt->tid, LOG_DISPLAYED_LOG_LEVEL_NAME_MAX_LENGTH,
       LOG_DISPLAYED_LOG_LEVEL_NAME_MAX_LENGTH,
       &g_oai_log.log_level2str[(*log_levelP)][0],
       LOG_DISPLAYED_PROTO_NAME_MAX_LENGTH, LOG_DISPLAYED_PROTO_NAME_MAX_LENGTH,
       &g_oai_log.log_proto2str[(*protoP)][0], LOG_DISPLAYED_FILENAME_MAX_LENGTH,
       LOG_DISPLAYED_FILENAME_MAX_LENGTH, &short_source_fileP[filename_length],
       line_numP, prefix_id, thread_ctxt->indent, " ");
+  free_wrapper((void**) &time_str);
   return rv;
 }
 


### PR DESCRIPTION
Signed-off-by: Shruti Sanadhya <ssanadhya@fb.com>

## Summary

Replace ctime_r with recommended strftime

## Test Plan

`make integ_test` for functional testing

`tail /var/log/mme.log` to make sure the time is printed correctly
```
vagrant@magma-dev:~/magma/lte/gateway$ tail /var/log/mme.log
000275 Mon Jan 04 23:37:17 2021 7FBF36BEDC80 INFO  SPGW-A tasks/sgw/pgw_config.c          :0588        SGi MTU (read)........: 1500
000276 Mon Jan 04 23:37:17 2021 7FBF36BEDC80 INFO  SPGW-A tasks/sgw/pgw_config.c          :0591        NAT ..................: true
000277 Mon Jan 04 23:37:17 2021 7FBF36BEDC80 INFO  SPGW-A tasks/sgw/pgw_config.c          :0594        User TCP MSS clamping : true
000278 Mon Jan 04 23:37:17 2021 7FBF36BEDC80 INFO  SPGW-A tasks/sgw/pgw_config.c          :0597        User IP masquerading  : false
000279 Mon Jan 04 23:37:17 2021 7FBF36BEDC80 INFO  SPGW-A tasks/sgw/pgw_config.c          :0600    - PCEF support ...........: false (in development)
000280 Mon Jan 04 23:37:17 2021 7FBF36BEDC80 INFO  SPGW-A tasks/sgw/pgw_config.c          :0646    - DNS Configuration:
000281 Mon Jan 04 23:37:17 2021 7FBF36BEDC80 INFO  SPGW-A tasks/sgw/pgw_config.c          :0649        IPv4 Primary Address ..........: 8.8.8.8
000282 Mon Jan 04 23:37:17 2021 7FBF36BEDC80 INFO  SPGW-A tasks/sgw/pgw_config.c          :0652        IPv4 Secondary Address ..........: 8.8.4.4
000283 Mon Jan 04 23:37:17 2021 7FBF36BEDC80 INFO  SPGW-A tasks/sgw/pgw_config.c          :0653    - Helpers:
000284 Mon Jan 04 23:37:17 2021 7FBF36BEDC80 INFO  SPGW-A tasks/sgw/pgw_config.c          :0656        Push PCO (DNS+MTU) ........: false
```