### PR TITLE
[feg][nh] Enable Neutral Host Routing for FeG Hello Service

### DIFF
--- a/feg/cloud/configs/service_registry.yml
+++ b/feg/cloud/configs/service_registry.yml
@@ -38,7 +38,7 @@ services:
       csfb:
         port: 9079
       feg_hello:
-        port: 9079
+        port: 9103
       ocs:
         port: 9079
       pcrf:

--- a/feg/cloud/go/services/feg_relay/gw_to_feg_relay/servicers/hello_relay.go
+++ b/feg/cloud/go/services/feg_relay/gw_to_feg_relay/servicers/hello_relay.go
@@ -41,6 +41,7 @@ func (s *RelayRouter) SayHello(ctx context.Context, req *protos.HelloRequest) (*
 	}
 	conn, ctx, cancel, err := s.GetFegServiceConnection(ctx, imsi, FegHello)
 	if err != nil {
+		glog.Errorf("SayHello error for NH IMSI '%s', greeting '%s': %v", imsi, req.GetGreeting(), err)
 		return nil, err
 	}
 	defer cancel()


### PR DESCRIPTION
Signed-off-by: Evgeniy Makeev <evgeniym@fb.com>

## Summary

 Enable Neutral Host Routing for FeG Hello Service

## Test Plan

add NH Hello unit test; go test ./...

## Additional Information

- [ ] This change is backwards-breaking

