### PR TITLE
[lte][agw] support `make build_oai` on ubuntu 20.04

### DIFF
--- a/lte/gateway/Makefile
+++ b/lte/gateway/Makefile
@@ -58,6 +58,8 @@ OAI_FLAGS = $(S6A_FLAGS) -DEMBEDDED_SGW=True -DENABLE_OPENFLOW=True -DSPGW_ENABL
 
 endif
 
+COMMON_FLAGS = -DCMAKE_C_FLAGS="-Wno-error=duplicate-decl-specifier -Wno-error=maybe-uninitialized -Wno-error=address-of-packed-member"
+
 $(info OAI_FLAGS $(OAI_FLAGS))
 
 FUZZ_FLAGS = $(OAI_FLAGS) -DFUZZ=True
@@ -128,10 +130,10 @@ build_python: stop ## Build Python environment
 	make -C $(MAGMA_ROOT)/lte/gateway/python buildenv
 
 build_common: ## Build shared libraries
-	$(call run_cmake, $(C_BUILD)/magma_common, $(MAGMA_ROOT)/orc8r/gateway/c/common, )
+	$(call run_cmake, $(C_BUILD)/magma_common, $(MAGMA_ROOT)/orc8r/gateway/c/common, $(COMMON_FLAGS))
 
 build_oai: format_oai build_common ## Build OAI
-	$(call run_cmake, $(C_BUILD)/oai, $(GATEWAY_C_DIR)/oai, $(OAI_FLAGS))
+	$(call run_cmake, $(C_BUILD)/oai, $(GATEWAY_C_DIR)/oai, $(OAI_FLAGS) $(COMMON_FLAGS))
 
 build_sctpd: build_common ## Build SCTPD
 	$(call run_cmake, $(C_BUILD)/sctpd, $(GATEWAY_C_DIR)/sctpd, )
@@ -145,7 +147,7 @@ build_connection_tracker: build_common ## Build connection tracker
 # Catch all for c services that don't have custom flags
 # This works with build_dpi
 build_%:
-	$(call run_cmake, $(C_BUILD)/$*, $(MAGMA_ROOT)/c/$*, )
+	$(call run_cmake, $(C_BUILD)/$*, $(MAGMA_ROOT)/c/$*, $(COMMON_FLAGS))
 
 scan_oai: ## Scan OAI
 	$(call run_scanbuild, $(C_BUILD)/scan/oai, $(GATEWAY_C_DIR)/oai, $(OAI_FLAGS))

--- a/lte/gateway/c/oai/include/state_converter.h
+++ b/lte/gateway/c/oai/include/state_converter.h
@@ -32,6 +32,7 @@ extern "C" {
 #ifdef __cplusplus
 }
 #endif
+#include <functional>
 
 #include <google/protobuf/map.h>
 


### PR DESCRIPTION
## Summary

* change compiler flags for compatibility with newer gcc defaults
* `<functional>` explicitly included in `state_converter.h`

## Test Plan

* `make build_oai` succeeds on ubuntu 20.04
* `make build_oai` succeeds on debian 9

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
