### PR TITLE
[AGW][Debug] Install libczmq-dbg package to resolve coredump symbols

### DIFF
--- a/lte/gateway/deploy/roles/magma/tasks/main.yml
+++ b/lte/gateway/deploy/roles/magma/tasks/main.yml
@@ -168,6 +168,7 @@
       - oai-freediameter
       - prometheus-cpp-dev
       - libczmq-dev
+      - libczmq-dbg
   retries: 5
   when: preburn
 

--- a/lte/gateway/docker/mme/Dockerfile.ubuntu18.04
+++ b/lte/gateway/docker/mme/Dockerfile.ubuntu18.04
@@ -56,6 +56,7 @@ RUN echo "Install 3rd party dependencies" && \
     apt-get -y install telegraf && \
     echo "Install ZeroMQ" && \
     apt-get install -y libczmq-dev=4.1.0-2 && \
+    apt-get install -y libczmq-dbg=4.1.0-2 && \
     ln -s /usr/bin/python2.7 /usr/local/bin/python
 
 RUN ["/bin/bash", "-c", "if [[ -v GIT_PROXY ]]; then git config --global http.proxy $GIT_PROXY; fi"]
@@ -172,7 +173,7 @@ RUN git clone https://git.osmocom.org/libgtpnl && \
 RUN git clone https://gitlab.eurecom.fr/oai/asn1c.git && \
     cd asn1c && \
     git checkout f12568d617dbf48497588f8e227d70388fa217c9 && \
-    autoreconf -iv && \    
+    autoreconf -iv && \
     ./configure && \
     make -j4 && \
     make install && \
@@ -201,7 +202,7 @@ RUN echo "Install fmtlib required by Folly" && \
 COPY ./ $MAGMA_ROOT
 
 ##### FreeDiameter
-RUN git clone https://github.com/OPENAIRINTERFACE/opencord.org.freeDiameter.git freediameter && \ 
+RUN git clone https://github.com/OPENAIRINTERFACE/opencord.org.freeDiameter.git freediameter && \
     cd freediameter && \
     patch -p1 < $MAGMA_ROOT/lte/gateway/c/oai/patches/0001-opencoord.org.freeDiameter.patch && \
     mkdir build && \
@@ -210,9 +211,9 @@ RUN git clone https://github.com/OPENAIRINTERFACE/opencord.org.freeDiameter.git 
     awk '{if (/^DISABLE_SCTP/) gsub(/OFF/, "ON"); print}' CMakeCache.txt > tmp && mv tmp CMakeCache.txt && \
     make -j4 && \
     make install
-    
+
 ### Following  is required to build MME with OVS support
-# WARNING!!! for the moment it'snot working well cause libfluid linked with Ubuntu incorrectly 
+# WARNING!!! for the moment it'snot working well cause libfluid linked with Ubuntu incorrectly
 # ENV FEATURES=agw_of
 # RUN git clone https://github.com/facebookincubator/magma.git /fb_magma
 # Clone repos and checkout latest commit
@@ -232,7 +233,7 @@ RUN git clone https://github.com/OPENAIRINTERFACE/opencord.org.freeDiameter.git 
 # Build MME executables
 RUN ldconfig && \
     cd $MAGMA_ROOT/lte/gateway && \
-    echo $FEATURES && \ 
+    echo $FEATURES && \
     make build_oai && \
     make build_sctpd
 

--- a/lte/gateway/release/build-magma.sh
+++ b/lte/gateway/release/build-magma.sh
@@ -130,6 +130,7 @@ OAI_DEPS=(
     "liblfds710"
     "magma-sctpd >= ${SCTPD_MIN_VERSION}"
     "libczmq-dev >= 4.0.2-7"
+    "libczmq-dbg >= 4.0.2-7"
     "oai-gtp >= 4.9-5"
     )
 


### PR DESCRIPTION
## Summary

Backtrace symbols are not resolved for libzmq. This made it harder to debug issues from the field.
Add libczmq-dbg package to resolve symbols

## Test Plan

Only adds the package. Once this lands, we need to generate vagrant box images and update the hash.