### PR TITLE
[NMS] Add monitord to the list of dynamic services supported by the gateway

### DIFF
--- a/nms/app/packages/magmalte/app/components/GatewayUtils.js
+++ b/nms/app/packages/magmalte/app/components/GatewayUtils.js
@@ -181,3 +181,9 @@ export default function isGatewayHealthy({status}: lte_gateway) {
   }
   return false;
 }
+
+export const DynamicServices = Object.freeze({
+  MONITORD: 'monitord',
+  EVENTD: 'eventd',
+  TD_AGENT_BIT: 'td-agent-bit',
+});

--- a/nms/app/packages/magmalte/app/views/equipment/GatewayDetailConfig.js
+++ b/nms/app/packages/magmalte/app/views/equipment/GatewayDetailConfig.js
@@ -30,6 +30,7 @@ import React from 'react';
 import SettingsIcon from '@material-ui/icons/Settings';
 import nullthrows from '@fbcnms/util/nullthrows';
 
+import {DynamicServices} from '../../components/GatewayUtils';
 import {colors, typography} from '../../theme/default';
 import {makeStyles} from '@material-ui/styles';
 import {useContext, useState} from 'react';
@@ -118,7 +119,7 @@ export default function GatewayConfig() {
     );
   }
 
-  function editAggregations() {
+  function editDynamicServices() {
     return (
       <AddEditGatewayButton
         title={'Edit'}
@@ -174,10 +175,10 @@ export default function GatewayConfig() {
                 </Grid>
                 <Grid item xs={12}>
                   <CardTitleRow
-                    label="Aggregations"
-                    filter={editAggregations}
+                    label="Dynamic Services"
+                    filter={editDynamicServices}
                   />
-                  <GatewayAggregation gwInfo={gwInfo} />
+                  <GatewayDynamicServices gwInfo={gwInfo} />
                 </Grid>
               </Grid>
             </Grid>
@@ -271,29 +272,40 @@ function GatewayEPC({gwInfo}: {gwInfo: lte_gateway}) {
   return <DataGrid data={data} />;
 }
 
-function GatewayAggregation({gwInfo}: {gwInfo: lte_gateway}) {
+function GatewayDynamicServices({gwInfo}: {gwInfo: lte_gateway}) {
   const logAggregation = !!gwInfo.magmad.dynamic_services?.includes(
-    'td-agent-bit',
+    DynamicServices.TD_AGENT_BIT,
   );
   const eventAggregation = !!gwInfo.magmad?.dynamic_services?.includes(
-    'eventd',
+    DynamicServices.EVENTD,
   );
-  const aggregations: DataRows[] = [
+  const cpeMonitoring = !!gwInfo.magmad?.dynamic_services?.includes(
+    DynamicServices.MONITORD,
+  );
+  const dynamicServices: DataRows[] = [
     [
       {
-        category: 'Aggregation',
+        category: 'Log Aggregation',
         value: logAggregation ? 'Enabled' : 'Disabled',
-        statusCircle: false,
+        statusCircle: true,
+        status: logAggregation,
       },
       {
-        category: 'Aggregation',
+        category: 'Event Aggregation',
         value: eventAggregation ? 'Enabled' : 'Disabled',
-        statusCircle: false,
+        statusCircle: true,
+        status: eventAggregation,
+      },
+      {
+        category: 'CPE Monitoring',
+        value: cpeMonitoring ? 'Enabled' : 'Disabled',
+        statusCircle: true,
+        status: cpeMonitoring,
       },
     ],
   ];
 
-  return <DataGrid data={aggregations} />;
+  return <DataGrid data={dynamicServices} />;
 }
 
 function EnodebsTable({enbInfo}: {enbInfo: {[string]: EnodebInfo}}) {

--- a/nms/app/packages/magmalte/app/views/equipment/GatewayDetailConfigEdit.js
+++ b/nms/app/packages/magmalte/app/views/equipment/GatewayDetailConfigEdit.js
@@ -61,6 +61,7 @@ import Text from '@fbcnms/ui/components/design-system/Text';
 import nullthrows from '@fbcnms/util/nullthrows';
 
 import {AltFormField} from '../../components/FormField';
+import {DynamicServices} from '../../components/GatewayUtils';
 import {colors, typography} from '../../theme/default';
 import {makeStyles} from '@material-ui/styles';
 import {useContext, useEffect, useState} from 'react';
@@ -104,7 +105,7 @@ const DEFAULT_GATEWAY_CONFIG = {
     autoupgrade_poll_interval: 60,
     checkin_interval: 60,
     checkin_timeout: 30,
-    dynamic_services: ['eventd', 'td-agent-bit'],
+    dynamic_services: [DynamicServices.EVENTD, DynamicServices.TD_AGENT_BIT],
   },
   name: '',
   status: {
@@ -289,7 +290,7 @@ function GatewayEditDialog(props: DialogProps) {
         />
       )}
       {tabPos === 1 && (
-        <AggregationEdit
+        <DynamicServicesEdit
           isAdd={!editProps}
           gateway={
             Object.keys(gateway).length != 0 ? gateway : ctx.state[gatewayId]
@@ -518,7 +519,7 @@ export function ConfigEdit(props: Props) {
   );
 }
 
-export function AggregationEdit(props: Props) {
+export function DynamicServicesEdit(props: Props) {
   const [error, setError] = useState('');
   const enqueueSnackbar = useEnqueueSnackbar();
   const ctx = useContext(GatewayContext);
@@ -526,27 +527,24 @@ export function AggregationEdit(props: Props) {
 
   const gatewayId: string =
     props.gateway?.id || nullthrows(match.params.gatewayId);
-  const [
-    aggregationConfig,
-    setAggregationConfig,
-  ] = useState<magmad_gateway_configs>(
+  const [config, setConfig] = useState<magmad_gateway_configs>(
     props.gateway?.magmad || DEFAULT_GATEWAY_CONFIG.magmad,
   );
 
-  const handleAggregationChange = (val: boolean, key: string) => {
-    const dynamicServices = [...(aggregationConfig.dynamic_services || [])];
+  const handleChange = (val: boolean, key: string) => {
+    const dynamicServices = [...(config.dynamic_services || [])];
     if (val) {
       dynamicServices.push(key);
-      setAggregationConfig({
-        ...aggregationConfig,
+      setConfig({
+        ...config,
         ['dynamic_services']: dynamicServices,
       });
     } else {
       const index = dynamicServices.indexOf(key);
       if (index !== -1) {
         dynamicServices.splice(index, 1);
-        setAggregationConfig({
-          ...aggregationConfig,
+        setConfig({
+          ...config,
           ['dynamic_services']: dynamicServices,
         });
       }
@@ -555,7 +553,7 @@ export function AggregationEdit(props: Props) {
 
   const onSave = async () => {
     try {
-      if (aggregationConfig.dynamic_services?.includes('td-agent-bit')) {
+      if (config.dynamic_services?.includes(DynamicServices.TD_AGENT_BIT)) {
         const logging: gateway_logging_configs = {
           aggregation: {
             target_files_by_tag: {
@@ -564,18 +562,18 @@ export function AggregationEdit(props: Props) {
           },
           log_level: 'DEBUG',
         };
-        aggregationConfig.logging = logging;
+        config.logging = logging;
       } else {
-        if (aggregationConfig.logging) {
-          delete aggregationConfig.logging;
+        if (config.logging) {
+          delete config.logging;
         }
       }
 
       const gateway = {
         ...(props.gateway || DEFAULT_GATEWAY_CONFIG),
-        magmad: aggregationConfig,
+        magmad: config,
       };
-      await ctx.updateGateway({gatewayId, magmadConfigs: aggregationConfig});
+      await ctx.updateGateway({gatewayId, magmadConfigs: config});
       enqueueSnackbar('Gateway saved successfully', {
         variant: 'success',
       });
@@ -587,7 +585,7 @@ export function AggregationEdit(props: Props) {
 
   return (
     <>
-      <DialogContent data-testid="aggregationEdit">
+      <DialogContent data-testid="dynamicServicesEdit">
         <List>
           {error !== '' && (
             <AltFormField label={''}>
@@ -597,18 +595,30 @@ export function AggregationEdit(props: Props) {
           <AltFormField label={'Event Aggregation'}>
             <Switch
               onChange={({target}) =>
-                handleAggregationChange(target.checked, 'eventd')
+                handleChange(target.checked, DynamicServices.EVENTD)
               }
-              checked={aggregationConfig.dynamic_services?.includes('eventd')}
+              checked={config.dynamic_services?.includes(
+                DynamicServices.EVENTD,
+              )}
             />
           </AltFormField>
           <AltFormField label={'Log Aggregation'}>
             <Switch
               onChange={({target}) =>
-                handleAggregationChange(target.checked, 'td-agent-bit')
+                handleChange(target.checked, DynamicServices.TD_AGENT_BIT)
               }
-              checked={aggregationConfig.dynamic_services?.includes(
-                'td-agent-bit',
+              checked={config.dynamic_services?.includes(
+                DynamicServices.TD_AGENT_BIT,
+              )}
+            />
+          </AltFormField>
+          <AltFormField label={'CPE Monitoring'}>
+            <Switch
+              onChange={({target}) =>
+                handleChange(target.checked, DynamicServices.MONITORD)
+              }
+              checked={config.dynamic_services?.includes(
+                DynamicServices.MONITORD,
               )}
             />
           </AltFormField>

--- a/nms/app/packages/magmalte/app/views/equipment/GatewayDetailStatus.js
+++ b/nms/app/packages/magmalte/app/views/equipment/GatewayDetailStatus.js
@@ -20,10 +20,10 @@ import DataGrid from '../../components/DataGrid';
 import LoadingFiller from '@fbcnms/ui/components/LoadingFiller';
 import MagmaV1API from '@fbcnms/magma-api/client/WebClient';
 import React from 'react';
+import isGatewayHealthy, {DynamicServices} from '../../components/GatewayUtils';
 import nullthrows from '@fbcnms/util/nullthrows';
 import useMagmaAPI from '@fbcnms/ui/magma/useMagmaAPI';
 
-import isGatewayHealthy from '../../components/GatewayUtils';
 import {useRouter} from '@fbcnms/ui/hooks';
 
 export default function GatewayDetailStatus({gwInfo}: {gwInfo: lte_gateway}) {
@@ -54,11 +54,15 @@ export default function GatewayDetailStatus({gwInfo}: {gwInfo: lte_gateway}) {
 
   const logAggregation =
     !!gwInfo.magmad.dynamic_services &&
-    gwInfo.magmad.dynamic_services.includes('td-agent-bit');
+    gwInfo.magmad.dynamic_services.includes(DynamicServices.TD_AGENT_BIT);
 
   const eventAggregation =
     !!gwInfo.magmad.dynamic_services &&
-    gwInfo.magmad.dynamic_services.includes('eventd');
+    gwInfo.magmad.dynamic_services.includes(DynamicServices.EVENTD);
+
+  const cpeMonitoring =
+    !!gwInfo.magmad.dynamic_services &&
+    gwInfo.magmad.dynamic_services.includes(DynamicServices.MONITORD);
 
   const isHealthy = isGatewayHealthy(gwInfo);
   const data: DataRows[] = [
@@ -77,6 +81,14 @@ export default function GatewayDetailStatus({gwInfo}: {gwInfo: lte_gateway}) {
         value: checkInTime.toLocaleString(),
         statusCircle: false,
       },
+      {
+        category: 'CPU Usage',
+        value: cpuPercent?.data?.result?.[0]?.values?.[0]?.[1] ?? 'Unknown',
+        unit:
+          cpuPercent?.data?.result?.[0]?.values?.[0]?.[1] ?? false ? '%' : '',
+        statusCircle: false,
+        tooltip: 'Current Gateway CPU %',
+      },
     ],
     [
       {
@@ -92,12 +104,10 @@ export default function GatewayDetailStatus({gwInfo}: {gwInfo: lte_gateway}) {
         status: logAggregation,
       },
       {
-        category: 'CPU Usage',
-        value: cpuPercent?.data?.result?.[0]?.values?.[0]?.[1] ?? 'Unknown',
-        unit:
-          cpuPercent?.data?.result?.[0]?.values?.[0]?.[1] ?? false ? '%' : '',
-        statusCircle: false,
-        tooltip: 'Current Gateway CPU %',
+        category: 'CPE Monitoring',
+        value: cpeMonitoring ? 'Enabled' : 'Disabled',
+        statusCircle: true,
+        status: cpeMonitoring,
       },
     ],
   ];

--- a/nms/app/packages/magmalte/app/views/equipment/__tests__/GatewayConfigTest.js
+++ b/nms/app/packages/magmalte/app/views/equipment/__tests__/GatewayConfigTest.js
@@ -25,6 +25,7 @@ import MuiStylesThemeProvider from '@material-ui/styles/ThemeProvider';
 import React from 'react';
 import defaultTheme from '../../../theme/default.js';
 
+import {DynamicServices} from '../../../components/GatewayUtils';
 import {MemoryRouter, Route} from 'react-router-dom';
 import {MuiThemeProvider} from '@material-ui/core/styles';
 import {
@@ -167,7 +168,7 @@ describe('<AddEditGatewayButton />', () => {
 
     // check if only first tab (config) is active
     expect(queryByTestId('configEdit')).not.toBeNull();
-    expect(queryByTestId('aggregationEdit')).toBeNull();
+    expect(queryByTestId('dynamicServicesEdit')).toBeNull();
     expect(queryByTestId('ranEdit')).toBeNull();
     expect(queryByTestId('epcEdit')).toBeNull();
 
@@ -249,7 +250,10 @@ describe('<AddEditGatewayButton />', () => {
           autoupgrade_poll_interval: 60,
           checkin_interval: 60,
           checkin_timeout: 30,
-          dynamic_services: ['eventd', 'td-agent-bit'],
+          dynamic_services: [
+            DynamicServices.EVENTD,
+            DynamicServices.TD_AGENT_BIT,
+          ],
         },
         status: {
           platform_info: {
@@ -276,7 +280,7 @@ describe('<AddEditGatewayButton />', () => {
 
     expect(queryByTestId('infoEdit')).toBeNull();
     expect(queryByTestId('epcEdit')).toBeNull();
-    expect(queryByTestId('aggregationEdit')).toBeNull();
+    expect(queryByTestId('dynamicServicesEdit')).toBeNull();
     expect(queryByTestId('ranEdit')).not.toBeNull();
 
     let pci = getByTestId('pci').firstChild;


### PR DESCRIPTION
Signed-off-by: Karthik Subraveti <ksubraveti@fb.com>

## Summary
Monitord was missing in the list of dynamic services we could enable through NMS. 

## Test Plan
![Screen Shot 2021-01-06 at 5 42 18 AM](https://user-images.githubusercontent.com/8224854/103774892-252f6b80-4fe2-11eb-9575-94281a7e7a0a.png)
![Screen Shot 2021-01-06 at 5 42 40 AM](https://user-images.githubusercontent.com/8224854/103774897-26f92f00-4fe2-11eb-944b-046dd8bee745.png)
![Screen Shot 2021-01-06 at 5 42 44 AM](https://user-images.githubusercontent.com/8224854/103774902-2791c580-4fe2-11eb-9151-60cb00aa8aa7.png)

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
