### PR TITLE
[DOC] OAI EPC is also under BSD-3-Clause license

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,4 +40,5 @@ See the [CONTRIBUTING](CONTRIBUTING.md) file for how to help out.
 ## License
 
 Magma is BSD License licensed, as found in the LICENSE file.
-The EPC is OAI is offered under the OAI Apache 2.0 license, as found in the LICENSE file in the OAI directory.
+
+The EPC originates from OAI (OpenAirInterface Software Alliance) and is offered under the same BSD-3-Clause License.


### PR DESCRIPTION
I just saw that while waiting for a meeting.

We made  during the Converge-MME phase changes to the license/banners on all OAI-owned files

And we removed the LICENCE file in `lte/gateway/c/oai` folder