### PR TITLE
[docs] Add a step telling the user to install Go on setup

### DIFF
--- a/docs/readmes/basics/prerequisites.md
+++ b/docs/readmes/basics/prerequisites.md
@@ -17,16 +17,14 @@ Install the following tools:
 3. [VirtualBox](https://www.virtualbox.org/)
 4. [Vagrant](https://vagrantup.com)
 
-Replace `brew` with your OS-appropriate package manager as necessary, or see
-the [pyenv installation instructions](https://github.com/pyenv/pyenv#installation).
+Replace `brew` with your OS-appropriate package manager as necessary.
 
 ```bash
-brew install go@1.13
-brew install pyenv
+brew install go@1.13 pyenv
 
 # Replace .zshrc with your appropriate shell RC file
 # IMPORTANT: Use .bash_profile, not .bashrc for bash
-echo export PATH="/usr/local/opt/go@1.13/bin:$PATH" >> ~/.zshrc
+echo 'export PATH="/usr/local/opt/go@1.13/bin:$PATH"' >> ~/.zshrc
 echo -e 'if command -v pyenv 1>/dev/null 2>&1; then eval "$(pyenv init -)"; fi' >> ~/.zshrc
 exec $SHELL
 pyenv install 3.7.3
@@ -38,8 +36,8 @@ vagrant plugin install vagrant-vbguest
 
 If you are on MacOS, you should start Docker for Mac and increase the memory
 allocation for the Docker engine to at least 4GB (Preferences -> Advanced). 
-If you are running into build/test failures with Go that report "signal killed", it's
-likely that you need to increase Docker's allocated resources.
+If you are running into build/test failures with Go that report "signal killed", you
+likely need to increase Docker's allocated resources.
 
 ![Increasing docker engine resources](assets/docker-config.png)
 

--- a/docs/readmes/basics/prerequisites.md
+++ b/docs/readmes/basics/prerequisites.md
@@ -15,27 +15,32 @@ Install the following tools:
 1. [Docker](https://www.docker.com) and Docker Compose
 2. [Homebrew](https://brew.sh/) *only* for MacOS users
 3. [VirtualBox](https://www.virtualbox.org/)
-3. [Vagrant](https://vagrantup.com)
+4. [Vagrant](https://vagrantup.com)
 
 Replace `brew` with your OS-appropriate package manager as necessary, or see
 the [pyenv installation instructions](https://github.com/pyenv/pyenv#installation).
 
 ```bash
+brew install go@1.13
 brew install pyenv
 
-# Replace .zshrc with your appropriate shell RC file
+# Replace .zshrc with your appropriate shell RC files
 # IMPORTANT: Use .bash_profile, not .bashrc for bash
+export PATH="/usr/local/opt/go@1.13/bin:$PATH" >> ~/.zshrc
 echo -e 'if command -v pyenv 1>/dev/null 2>&1; then\n  eval "$(pyenv init -)"\nfi' >> ~/.zshrc
 exec $SHELL
 pyenv install 3.7.3
 pyenv global 3.7.3
+
 
 pip3 install ansible fabric3 jsonpickle requests PyYAML
 vagrant plugin install vagrant-vbguest
 ```
 
 If you are on MacOS, you should start Docker for Mac and increase the memory
-allocation for the Docker engine to at least 4GB (Preferences -> Advanced).
+allocation for the Docker engine to at least 4GB (Preferences -> Advanced). 
+If you are running into build/test failures with Go that report "signal killed", it's
+likely that you need to increase Docker's allocated resources.
 
 ![Increasing docker engine resources](assets/docker-config.png)
 

--- a/docs/readmes/basics/prerequisites.md
+++ b/docs/readmes/basics/prerequisites.md
@@ -25,7 +25,7 @@ brew install go@1.13 pyenv
 # Replace .zshrc with your appropriate shell RC file
 # IMPORTANT: Use .bash_profile, not .bashrc for bash
 echo 'export PATH="/usr/local/opt/go@1.13/bin:$PATH"' >> ~/.zshrc
-echo -e 'if command -v pyenv 1>/dev/null 2>&1; then eval "$(pyenv init -)"; fi' >> ~/.zshrc
+echo 'if command -v pyenv 1>/dev/null 2>&1; then eval "$(pyenv init -)"; fi' >> ~/.zshrc
 exec $SHELL
 pyenv install 3.7.3
 pyenv global 3.7.3

--- a/docs/readmes/basics/prerequisites.md
+++ b/docs/readmes/basics/prerequisites.md
@@ -24,14 +24,13 @@ the [pyenv installation instructions](https://github.com/pyenv/pyenv#installatio
 brew install go@1.13
 brew install pyenv
 
-# Replace .zshrc with your appropriate shell RC files
+# Replace .zshrc with your appropriate shell RC file
 # IMPORTANT: Use .bash_profile, not .bashrc for bash
-export PATH="/usr/local/opt/go@1.13/bin:$PATH" >> ~/.zshrc
-echo -e 'if command -v pyenv 1>/dev/null 2>&1; then\n  eval "$(pyenv init -)"\nfi' >> ~/.zshrc
+echo export PATH="/usr/local/opt/go@1.13/bin:$PATH" >> ~/.zshrc
+echo -e 'if command -v pyenv 1>/dev/null 2>&1; then eval "$(pyenv init -)"; fi' >> ~/.zshrc
 exec $SHELL
 pyenv install 3.7.3
 pyenv global 3.7.3
-
 
 pip3 install ansible fabric3 jsonpickle requests PyYAML
 vagrant plugin install vagrant-vbguest


### PR DESCRIPTION
<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->
The Prerequisities Development Tools Guide was missing a step informing the user to install Go. This PR addresses that as well as adding a quick note about a potential cause for build/test failures related to Go being a result of a shortage in allocated resources for Docker. A small change was also made to condense an existing command(pyenv) to one line.

## Test Plan
- [x] Ran "create_docusaurus_website.sh" script to create and verify local copy
<img width="895" alt="Screen Shot 2021-01-07 at 1 05 01 PM" src="https://user-images.githubusercontent.com/46101219/103944798-0f589e00-50e9-11eb-9049-802ee54f646a.png">

- [x] Manually tested the condensed one liner and PATH addition of Go by following these steps 

- Removed relevant commands from local rc file
- Ran both echo commands
- Double checked that pyenv and Go is working as expected.

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
