### PR TITLE
[agw][stateless] Move Sctpd restart logic from MME service to config_stateless_agw.py

### DIFF
--- a/lte/gateway/c/oai/tasks/sctp/sctp_primitives_server.c
+++ b/lte/gateway/c/oai/tasks/sctp/sctp_primitives_server.c
@@ -148,7 +148,6 @@ int sctp_init(const mme_config_t* mme_config_p) {
 static void sctp_exit(void) {
   destroy_task_context(&sctp_task_zmq_ctx);
   stop_sctpd_uplink_server();
-  sctpd_exit();
   OAI_FPRINTF_INFO("TASK_SCTP terminated\n");
   pthread_exit(NULL);
 }

--- a/lte/gateway/c/oai/tasks/sctp/sctpd_downlink_client.cpp
+++ b/lte/gateway/c/oai/tasks/sctp/sctpd_downlink_client.cpp
@@ -19,7 +19,6 @@ extern "C" {
 #include "sctpd_downlink_client.h"
 
 #include <arpa/inet.h>
-#include <signal.h>
 
 #include "assertions.h"
 #include "log.h"
@@ -179,25 +178,6 @@ int sctpd_init(sctp_init_t* init) {
     }
   }
   return sctpd_init_res;
-}
-
-// close
-void sctpd_exit() {
-  // send terminate message to sctpd if force_restart is true
-  if (!_client->should_force_restart) {
-    // do nothing
-    return;
-  }
-
-  // send a SIGTERM to sctpd
-  char line[PID_LEN];
-  FILE* cmd = popen("pidof sctpd", "r");
-  fgets(line, PID_LEN, cmd);
-  pid_t pid = strtoul(line, NULL, 10);
-  pclose(cmd);
-  OAILOG_DEBUG(LOG_SCTP, "Sending SIGTERM to pid %d", pid);
-  kill(pid, SIGTERM);
-  return;
 }
 
 // sendDl

--- a/lte/gateway/c/oai/tasks/sctp/sctpd_downlink_client.h
+++ b/lte/gateway/c/oai/tasks/sctp/sctpd_downlink_client.h
@@ -23,15 +23,10 @@
 
 #include "sctp_messages_types.h"
 
-#define PID_LEN 32
-
 int init_sctpd_downlink_client(bool force_restart);
 
 // init
 int sctpd_init(sctp_init_t* init);
-
-// force sctpd to restart if not stateless
-void sctpd_exit(void);
 
 // sendDl
 int sctpd_send_dl(uint32_t assoc_id, uint16_t stream, bstring payload);

--- a/lte/gateway/deploy/roles/magma/files/systemd/magma_mme.service
+++ b/lte/gateway/deploy/roles/magma/files/systemd/magma_mme.service
@@ -27,6 +27,7 @@ ExecStart=/usr/local/bin/mme -c /var/opt/magma/tmp/mme.conf -s /var/opt/magma/tm
 MemoryAccounting=yes
 MemoryLimit=512M
 ExecStartPre=/usr/bin/env python3 /usr/local/bin/generate_oai_config.py
+ExecStartPre=/usr/bin/env python3 /usr/local/bin/config_stateless_agw.py reset_sctpd_for_stateful
 ExecStopPost=/usr/bin/env python3 /usr/local/bin/service_util.py mme
 StandardOutput=syslog
 StandardError=syslog

--- a/lte/gateway/python/scripts/config_stateless_agw.py
+++ b/lte/gateway/python/scripts/config_stateless_agw.py
@@ -187,6 +187,12 @@ def flushall_redis_and_restart():
     sys.exit(0)
 
 
+def reset_sctpd_for_stateful():
+    if check_stateless_services() == return_codes.STATELESS:
+        print("AGW is stateless, no need to restart Sctpd")
+        sys.exit(0)
+    restart_sctpd()
+
 STATELESS_FUNC_DICT = {
     "check": check_stateless_agw,
     "enable": enable_stateless_agw,
@@ -195,6 +201,7 @@ STATELESS_FUNC_DICT = {
     "sctpd_post": sctpd_post_start,
     "clear_redis": clear_redis_and_restart,
     "flushall_redis": flushall_redis_and_restart,
+    "reset_sctpd_for_stateful": reset_sctpd_for_stateful
 }
 
 


### PR DESCRIPTION
Signed-off-by: Shruti Sanadhya <ssanadhya@fb.com>

## Summary

As per the discussion in https://github.com/magma/magma/issues/4190, the restart relationship between MME and Sctpd needs to sit outside the MME service implementation. This change moves the logic to conditionally restart Sctpd whenever MME service restarts into `config_stateless_agw.py`.

## Test Plan

Test that Sctpd restarts every time MME terminates:
- On gateway VM, monitor `sudo journalctl -fu magma@mme -u sctpd` in one terminal
- In a separate terminal, do:
-- `make run` to bring up all services
-- `sudo service magma@mme restart` to gracefully exit MME service and restart Sctpd with MME
-- `sudo pkill -9 mme` to terminate MME with Sigkill and verify that Sctpd restarts as well
-- Run `test_attach_detach.py` and redo `sudo pkill -9 mme` in stateful AGW
-- Run `test_attach_detach_with_mme_restart.py`  and run `sudo pkill -9 mme` while the test case is waiting for 30 seconds to test logic in stateless AGW

Sanity check with `make integ_test`

## Additional Information

- [x] This change is backwards-breaking

Need to re-provision Magma gateway VM for the changes in `config_stateless_agw.py` and `magma_mme.service` to take effect

