### PR TITLE
[agw][lte][bug fix] Fixed malformed ue radio capability msg embedded in ICS req

### DIFF
--- a/lte/gateway/c/oai/tasks/s1ap/s1ap_mme_nas_procedures.c
+++ b/lte/gateway/c/oai/tasks/s1ap/s1ap_mme_nas_procedures.c
@@ -1046,8 +1046,8 @@ void s1ap_handle_conn_est_cnf(
         S1ap_InitialContextSetupRequestIEs__value_PR_UERadioCapability;
     OCTET_STRING_fromBuf(
         &ie->value.choice.UERadioCapability,
-        (const char*) conn_est_cnf_pP->ue_radio_capability,
-        conn_est_cnf_pP->ue_radio_cap_length);
+        (const char*) conn_est_cnf_pP->ue_radio_capability->data,
+        conn_est_cnf_pP->ue_radio_capability->slen);
     ASN_SEQUENCE_ADD(&out->protocolIEs.list, ie);
   }
 


### PR DESCRIPTION
Signed-off-by: Pruthvi Hebbani <pruthvi.hebbani@radisys.com>
[agw][lte][bug fix] Fixed malformed ue radio capability msg embedded in ICS req

## Summary

When UE moves from idle to connected mode MME optionally includes UE radio capability info message  in initial context req message. The way UE radio capability info was copied into ICS request was changed recently in PR https://github.com/magma/magma/pull/2707/. Due to this change UE radio capability info message was malformed. Reverted this change.

## Test Plan

- Verified that UE radio capability info message is sent properly in ICS Req message
- Verified s1 sim sanity

