### PR TITLE
[AGW] Typo in build-magma.sh for libmnl-dev

### DIFF
--- a/lte/gateway/release/build-magma.sh
+++ b/lte/gateway/release/build-magma.sh
@@ -116,7 +116,7 @@ MAGMA_DEPS=(
     "python3-scapy >= 2.4.3-4"
     "tshark" # required for call tracing
     "libtins-dev" # required for Connection tracker
-    "libml-dev" # required for Connection tracker
+    "libmnl-dev" # required for Connection tracker
     "getenvoy-envoy" # for envoy dep
     )
 


### PR DESCRIPTION
Signed-off-by: Timothée Dzik <timdzik@fb.com>

[AGW] Typo in build-magma.sh for libmnl-dev

## Summary

[AGW] Typo in build-magma.sh for libmnl-dev
A Surfer ate a letter in `libmnl-dev`

## Test Plan

![Surfer](https://media.giphy.com/media/l0HlxgojaVTyM7dNC/giphy.gif)

