### PR TITLE
[agw][stateless AGW] Make Pipelined GTP app stateless #3554

### DIFF
--- a/lte/gateway/python/magma/pipelined/app/classifier.py
+++ b/lte/gateway/python/magma/pipelined/app/classifier.py
@@ -45,6 +45,7 @@ class Classifier(MagmaController):
         self.next_table = self._service_manager.get_table_num(INGRESS)
         self._uplink_port = OFPP_LOCAL
         self._datapath = None
+        self._clean_restart = kwargs['config']['clean_restart']
 
     def _get_config(self, config_dict):
         mtr_ip = None
@@ -68,7 +69,9 @@ class Classifier(MagmaController):
 
     def initialize_on_connect(self, datapath):
         self._datapath = datapath
-        self._delete_all_flows()
+        if self._clean_restart:
+            self._delete_all_flows()
+
         self._install_default_tunnel_flows()
         self._install_internal_pkt_fwd_flow()
 
@@ -76,7 +79,8 @@ class Classifier(MagmaController):
         flows.delete_all_flows_from_table(self._datapath, self.tbl_num)
 
     def cleanup_on_disconnect(self, datapath):
-        self._delete_all_flows()
+        if self._clean_restart:
+            self._delete_all_flows()
 
     def _install_default_tunnel_flows(self):
         match = MagmaMatch()


### PR DESCRIPTION
Signed-off-by: prabina pattnaik <prabinak@wavelabs.ai>

## Summary
GTP app in Pipelined clears the flows in OVS table 0 during restart the pipelined process when the clean_restart flag is set to false.

## Test Plan

Scenario-1:
1) clean_restart: false
2) 5G_feature_set:
     enable: True
Executed the below s1ap test cases:
s1aptests/test_attach_detach_with_mobilityd_restart.py
s1aptests/test_attach_ul_udp_data_with_mobilityd_restart.py
s1aptests/test_attach_ul_udp_data_with_pipelined_restart.py

Scenario-2:
1) clean_restart: True
2) 5G_feature_set:
     enable: False
Executed the below s1ap test cases:
s1aptests/test_attach_detach_with_mobilityd_restart.py
s1aptests/test_attach_ul_udp_data_with_mobilityd_restart.py
s1aptests/test_attach_ul_udp_data_with_pipelined_restart.py

UT logs attached as reference.
## Additional Information


[pr_3554_UT_logs.log](https://github.com/magma/magma/files/5783630/pr_3554_UT_logs.log)
