### PR TITLE
add default image tags for prometheus components

### DIFF
--- a/orc8r/cloud/helm/orc8r/charts/metrics/values.yaml
+++ b/orc8r/cloud/helm/orc8r/charts/metrics/values.yaml
@@ -111,8 +111,8 @@ prometheusConfigurer:
   prometheusURL: "orc8r-prometheus:9090"
 
   image:
-    repository:
-    tag:
+    repository: docker.io/facebookincubator/prometheus-configurer
+    tag: 1.0.3
     pullPolicy: IfNotPresent
 
   resources: {}
@@ -150,8 +150,8 @@ alertmanagerConfigurer:
   alertmanagerURL: "orc8r-alertmanager:9093"
 
   image:
-    repository:
-    tag:
+    repository: docker.io/facebookincubator/alertmanager-configurer
+    tag: 1.0.3
     pullPolicy: IfNotPresent
 
   resources: {}
@@ -183,8 +183,8 @@ prometheusCache:
         targetPort: 9091
 
   image:
-    repository:
-    tag:
+    repository: docker.io/facebookincubator/prometheus-edge-hub
+    tag: 1.0.0
     pullPolicy: IfNotPresent
 
   # Maximum number of datapoints in the cache at one time. Unlimited if <= 0.


### PR DESCRIPTION
Signed-off-by: Scott8440 <scott8440@gmail.com>

## Summary
In the old versions of the chart, these default values weren't there. Add them back to the old version to make deploying 1.3 easier.

## Test Plan

it's the same as current versions
