### PR TITLE
Revert "[lte][agw] changes need for `make build_oai` and `make build_…

### DIFF
--- a/lte/gateway/Makefile
+++ b/lte/gateway/Makefile
@@ -58,8 +58,6 @@ OAI_FLAGS = $(S6A_FLAGS) -DEMBEDDED_SGW=True -DENABLE_OPENFLOW=True -DSPGW_ENABL
 
 endif
 
-COMMON_FLAGS = -DCMAKE_C_FLAGS="-Wno-error=duplicate-decl-specifier -Wno-error=maybe-uninitialized -Wno-error=address-of-packed-member"
-
 $(info OAI_FLAGS $(OAI_FLAGS))
 
 FUZZ_FLAGS = $(OAI_FLAGS) -DFUZZ=True
@@ -133,10 +131,10 @@ build_python: stop ## Build Python environment
 	make -C $(MAGMA_ROOT)/lte/gateway/python buildenv
 
 build_common: ## Build shared libraries
-	$(call run_cmake, $(C_BUILD)/magma_common, $(MAGMA_ROOT)/orc8r/gateway/c/common, $(COMMON_FLAGS))
+	$(call run_cmake, $(C_BUILD)/magma_common, $(MAGMA_ROOT)/orc8r/gateway/c/common, )
 
 build_oai: format_oai build_common ## Build OAI
-	$(call run_cmake, $(C_BUILD)/oai, $(GATEWAY_C_DIR)/oai, $(OAI_FLAGS) $(COMMON_FLAGS))
+	$(call run_cmake, $(C_BUILD)/oai, $(GATEWAY_C_DIR)/oai, $(OAI_FLAGS))
 
 build_sctpd: build_common ## Build SCTPD
 	$(call run_cmake, $(C_BUILD)/sctpd, $(GATEWAY_C_DIR)/sctpd, )
@@ -153,7 +151,7 @@ build_envoy_controller: ## Build envoy controller
 # Catch all for c services that don't have custom flags
 # This works with build_dpi
 build_%:
-	$(call run_cmake, $(C_BUILD)/$*, $(MAGMA_ROOT)/c/$*, $(COMMON_FLAGS))
+	$(call run_cmake, $(C_BUILD)/$*, $(MAGMA_ROOT)/c/$*, )
 
 scan_oai: ## Scan OAI
 	$(call run_scanbuild, $(C_BUILD)/scan/oai, $(GATEWAY_C_DIR)/oai, $(OAI_FLAGS))

--- a/lte/gateway/c/oai/include/state_converter.h
+++ b/lte/gateway/c/oai/include/state_converter.h
@@ -32,7 +32,6 @@ extern "C" {
 #ifdef __cplusplus
 }
 #endif
-#include <functional>
 
 #include <google/protobuf/map.h>
 


### PR DESCRIPTION
…common` to succeed on ubuntu 20.04 (#4247)"

This reverts commit 78dfdbb4e27864884c4d70d9b7a7a01f2b482e53.

Signed-off-by: Pravin B Shelar <pbshelar@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary
Original PR is causing issue in make build. Reverting to fix master branch..

<!-- Enumerate changes you made and why you made them -->

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
