### PR TITLE
[ctraced][orc8r] Add Content-Disposition header to trace download API

### DIFF
--- a/orc8r/cloud/docker/controller/apidocs/v1/swagger.yml
+++ b/orc8r/cloud/docker/controller/apidocs/v1/swagger.yml
@@ -5387,6 +5387,9 @@ paths:
       responses:
         "200":
           description: Show tracing status
+          headers:
+            Content-Disposition:
+              type: string
           schema:
             format: binary
             type: file

--- a/orc8r/cloud/go/services/ctraced/obsidian/handlers/handlers.go
+++ b/orc8r/cloud/go/services/ctraced/obsidian/handlers/handlers.go
@@ -212,7 +212,13 @@ func getDownloadCallTraceHandlerFunc(storage storage.CtracedStorage) echo.Handle
 			return obsidian.HttpError(errors.Wrap(err, "failed to retrieve call trace data"), http.StatusInternalServerError)
 		}
 
-		return c.Blob(http.StatusOK, "application/pcapng", callTrace)
+		res := c.Response()
+		header := res.Header()
+		header.Set(echo.HeaderContentType, "application/pcapng")
+		header.Set(echo.HeaderContentDisposition, "attachment; filename="+fmt.Sprintf("%s.pcapng", callTraceID))
+		res.WriteHeader(http.StatusOK)
+		_, err = res.Write(callTrace)
+		return err
 	}
 }
 

--- a/orc8r/cloud/go/services/ctraced/obsidian/models/swagger.v1.yml
+++ b/orc8r/cloud/go/services/ctraced/obsidian/models/swagger.v1.yml
@@ -125,6 +125,9 @@ paths:
           schema:
             type: file
             format: binary
+          headers:
+            Content-Disposition:
+              type: string
         default:
           $ref: './orc8r-swagger-common.yml#/responses/UnexpectedError'
 


### PR DESCRIPTION
Signed-off-by: Andrei Lee <andreilee@fb.com>

## Summary

Added `Content-Disposition` to call tracing API endpoint for downloading traces.

## Test Plan

Tested manually through the swagger API with Chrome developer tools to examine network response from orc8r API.

<img width="540" alt="Screen Shot 2021-01-07 at 9 59 05 PM" src="https://user-images.githubusercontent.com/804385/104064995-d33e3f80-51b3-11eb-8431-d5a6e923dd95.png">


## Additional Information

- [ ] This change is backwards-breaking
