### PR TITLE
Added code to remove SPGW's UE context from Redis DB

### DIFF
--- a/lte/gateway/c/oai/tasks/sgw/sgw_context_manager.c
+++ b/lte/gateway/c/oai/tasks/sgw/sgw_context_manager.c
@@ -216,11 +216,42 @@ sgw_cm_create_bearer_context_information_in_collection(
 }
 
 //-----------------------------------------------------------------------------
-int sgw_cm_remove_bearer_context_information(teid_t teid, imsi64_t imsi64) {
+int sgw_cm_remove_bearer_context_information(
+    spgw_state_t* spgw_state, teid_t teid, imsi64_t imsi64) {
   int temp = 0;
 
   hash_table_ts_t* state_imsi_ht = get_spgw_ue_state();
   temp                           = hashtable_ts_free(state_imsi_ht, teid);
+  if (temp != HASH_TABLE_OK) {
+    OAILOG_ERROR_UE(
+        LOG_SPGW_APP, imsi64, "Failed to free teid from state_imsi_ht \n");
+    delete_spgw_ue_state(imsi64);
+    return temp;
+  }
+  spgw_ue_context_t* ue_context_p = NULL;
+  hashtable_ts_get(
+      spgw_state->imsi_ue_context_htbl, (const hash_key_t) imsi64,
+      (void**) &ue_context_p);
+  if (ue_context_p) {
+    sgw_s11_teid_t* p1 = LIST_FIRST(&(ue_context_p->sgw_s11_teid_list));
+    while (p1) {
+      if (p1->sgw_s11_teid == teid) {
+        LIST_REMOVE(p1, entries);
+        free_wrapper((void**) &p1);
+        break;
+      }
+      p1 = LIST_NEXT(p1, entries);
+    }
+    if (LIST_EMPTY(&ue_context_p->sgw_s11_teid_list)) {
+      temp = hashtable_ts_free(
+          spgw_state->imsi_ue_context_htbl, (const hash_key_t) imsi64);
+      if (temp != HASH_TABLE_OK) {
+        OAILOG_ERROR_UE(
+            LOG_SPGW_APP, imsi64,
+            "Failed to free imsi64 from imsi_ue_context_htbl \n");
+      }
+    }
+  }
   delete_spgw_ue_state(imsi64);
   return temp;
 }

--- a/lte/gateway/c/oai/tasks/sgw/sgw_context_manager.h
+++ b/lte/gateway/c/oai/tasks/sgw/sgw_context_manager.h
@@ -46,7 +46,8 @@ mme_sgw_tunnel_t* sgw_cm_create_s11_tunnel(
 s_plus_p_gw_eps_bearer_context_information_t*
 sgw_cm_create_bearer_context_information_in_collection(
     spgw_state_t* spgw_state, teid_t teid, imsi64_t imsi64);
-int sgw_cm_remove_bearer_context_information(teid_t teid, imsi64_t imsi64);
+int sgw_cm_remove_bearer_context_information(
+    spgw_state_t* state, teid_t teid, imsi64_t imsi64);
 sgw_eps_bearer_ctxt_t* sgw_cm_create_eps_bearer_ctxt_in_collection(
     sgw_pdn_connection_t* const sgw_pdn_connection, const ebi_t eps_bearer_idP);
 sgw_eps_bearer_ctxt_t* sgw_cm_insert_eps_bearer_ctxt_in_collection(

--- a/lte/gateway/c/oai/tasks/sgw/sgw_handlers.c
+++ b/lte/gateway/c/oai/tasks/sgw/sgw_handlers.c
@@ -1044,6 +1044,7 @@ int sgw_handle_modify_bearer_request(
 
 //------------------------------------------------------------------------------
 int sgw_handle_delete_session_request(
+    spgw_state_t* spgw_state,
     const itti_s11_delete_session_request_t* const delete_session_req_pP,
     imsi64_t imsi64) {
   OAILOG_FUNC_IN(LOG_SPGW_APP);
@@ -1169,7 +1170,7 @@ int sgw_handle_delete_session_request(
           delete_session_req_pP->lbi);
 
       sgw_cm_remove_bearer_context_information(
-          delete_session_req_pP->teid, imsi64);
+          spgw_state, delete_session_req_pP->teid, imsi64);
       increment_counter("spgw_delete_session", 1, 1, "result", "success");
     }
 
@@ -1464,7 +1465,7 @@ void handle_s5_create_session_response(
            .pdn_connection,
       sgi_create_endpoint_resp.eps_bearer_id);
   sgw_cm_remove_bearer_context_information(
-      session_resp.context_teid,
+      state, session_resp.context_teid,
       new_bearer_ctxt_info_p->sgw_eps_bearer_context_information.imsi64);
 
   OAILOG_FUNC_OUT(LOG_SPGW_APP);
@@ -1710,6 +1711,7 @@ int sgw_handle_nw_initiated_actv_bearer_rsp(
  */
 
 int sgw_handle_nw_initiated_deactv_bearer_rsp(
+    spgw_state_t* spgw_state,
     const itti_s11_nw_init_deactv_bearer_rsp_t* const
         s11_pcrf_ded_bearer_deactv_rsp,
     imsi64_t imsi64) {
@@ -1807,7 +1809,7 @@ int sgw_handle_nw_initiated_deactv_bearer_rsp(
         &spgw_ctxt->sgw_eps_bearer_context_information.pdn_connection, ebi);
 
     sgw_cm_remove_bearer_context_information(
-        s11_pcrf_ded_bearer_deactv_rsp->s_gw_teid_s11_s4, imsi64);
+        spgw_state, s11_pcrf_ded_bearer_deactv_rsp->s_gw_teid_s11_s4, imsi64);
   } else {
     // Remove the dedicated bearer/s context
     for (i = 0; i < no_of_bearers; i++) {

--- a/lte/gateway/c/oai/tasks/sgw/sgw_handlers.h
+++ b/lte/gateway/c/oai/tasks/sgw/sgw_handlers.h
@@ -47,6 +47,7 @@ int sgw_handle_modify_bearer_request(
     const itti_s11_modify_bearer_request_t* const modify_bearer_p,
     imsi64_t imsi64);
 int sgw_handle_delete_session_request(
+    spgw_state_t* spgw_state,
     const itti_s11_delete_session_request_t* const delete_session_p,
     imsi64_t imsi64);
 int sgw_handle_release_access_bearers_request(
@@ -60,6 +61,7 @@ int sgw_handle_nw_initiated_actv_bearer_rsp(
     const itti_s11_nw_init_actv_bearer_rsp_t* const s11_actv_bearer_rsp,
     imsi64_t imsi64);
 int sgw_handle_nw_initiated_deactv_bearer_rsp(
+    spgw_state_t* spgw_state,
     const itti_s11_nw_init_deactv_bearer_rsp_t* const
         s11_pcrf_ded_bearer_deactv_rsp,
     imsi64_t imsi64);

--- a/lte/gateway/c/oai/tasks/sgw/sgw_task.c
+++ b/lte/gateway/c/oai/tasks/sgw/sgw_task.c
@@ -81,7 +81,8 @@ static int handle_message(zloop_t* loop, zsock_t* reader, void* arg) {
 
     case S11_DELETE_SESSION_REQUEST: {
       sgw_handle_delete_session_request(
-          &received_message_p->ittiMsg.s11_delete_session_request, imsi64);
+          spgw_state, &received_message_p->ittiMsg.s11_delete_session_request,
+          imsi64);
     } break;
 
     case S11_MODIFY_BEARER_REQUEST: {
@@ -121,6 +122,7 @@ static int handle_message(zloop_t* loop, zsock_t* reader, void* arg) {
     case S11_NW_INITIATED_DEACTIVATE_BEARER_RESP: {
       // Handle Dedicated bearer deactivation Rsp from MME
       sgw_handle_nw_initiated_deactv_bearer_rsp(
+          spgw_state,
           &received_message_p->ittiMsg.s11_nw_init_deactv_bearer_rsp, imsi64);
     } break;
 


### PR DESCRIPTION
[lte][agw] Added code to remove SPGW's UE context from Redis DB
## Summary
After UE detaches from network, it is expected to remove UE details from Redis DB. Even though contents of UE were getting released, but SPGW's UE context was still existing. 
Because UE context was getting freed but not removed from imsi_ue_context_htbl hash list.
So now added code to remove UE contexts from hash list.
## Test Plan
Executed s1ap sanity test suite
