### PR TITLE
[agw] [stateless] Add explicit override for stateful config

### DIFF
--- a/lte/gateway/python/scripts/config_stateless_agw.py
+++ b/lte/gateway/python/scripts/config_stateless_agw.py
@@ -146,10 +146,7 @@ def disable_stateless_agw():
         sys.exit(return_codes.STATEFUL.value)
     for service, config, value in STATELESS_SERVICE_CONFIGS:
         cfg = load_override_config(service) or {}
-
-        # remove the stateless override
-        cfg.pop(config, None)
-
+        cfg[config] = not value
         save_override_config(service, cfg)
 
     # restart Sctpd so that eNB connections are reset and local state cleared

--- a/orc8r/gateway/python/magma/common/stateless_agw.py
+++ b/orc8r/gateway/python/magma/common/stateless_agw.py
@@ -67,7 +67,7 @@ def enable_stateless_agw():
 def disable_stateless_agw():
     if check_stateless_agw() == magmad_pb2.CheckStatelessResponse.STATEFUL:
         logging.info("Nothing to disable, AGW is stateful")
-    for service, config, _ in STATELESS_SERVICE_CONFIGS:
+    for service, config, value in STATELESS_SERVICE_CONFIGS:
         cfg = load_override_config(service) or {}
         cfg[config] = not value
         save_override_config(service, cfg)

--- a/orc8r/gateway/python/magma/common/stateless_agw.py
+++ b/orc8r/gateway/python/magma/common/stateless_agw.py
@@ -69,10 +69,7 @@ def disable_stateless_agw():
         logging.info("Nothing to disable, AGW is stateful")
     for service, config, _ in STATELESS_SERVICE_CONFIGS:
         cfg = load_override_config(service) or {}
-
-        # remove the stateless override
-        cfg.pop(config, None)
-
+        cfg[config] = not value
         save_override_config(service, cfg)
 
     # restart Sctpd so that eNB connections are reset and local state cleared


### PR DESCRIPTION
Signed-off-by: Shruti Sanadhya <ssanadhya@fb.com>

## Summary

The scripts to enable/disable stateless mode assume that the default config is stateful, which will change in release 1.4. This change adds an explicit override config while disabling stateless mode.

## Test Plan

- Sanity check with `make integ_test`
- On gateway VM, check override file after running  `magmad_cli.py config_stateless disable` 
```
vagrant@magma-dev:~$ cat /var/opt/magma/configs/mme.yml
use_stateless: false
```

## Additional Information

- [x] This change is backwards-breaking

Need to re-provision gateway VM to make sure the correct `config_stateless_agw.py` is available.
