### PR TITLE
[AGW][S1APTests] Clean UE interfaces from previous unsuccessful runs

### DIFF
--- a/lte/gateway/python/integ_tests/s1aptests/util/traffic_util.py
+++ b/lte/gateway/python/integ_tests/s1aptests/util/traffic_util.py
@@ -387,6 +387,13 @@ class TrafficTest(object):
             sc_in = sc.makefile('rb')
             sc_out = sc.makefile('wb')
 
+            # Flush all the addresses left by previous failed tests
+            for i in range(len(instances)):
+                net_iface_index = TrafficTest._iproute.link_lookup(
+                    ifname=TrafficTest._net_iface)[0]
+                TrafficTest._iproute.flush_addr(index=net_iface_index,
+                                                address=instances[i].ip.exploded)
+
             # Set up network ifaces and get UL port assignments for DL
             aliases = ()
             for instance in instances:


### PR DESCRIPTION
## Summary
Some failed integration tests do not remove UE interfaces. This causes subsequent tests to fail

## Test Plan
Tested on local vagrant boxes
