### PR TITLE
[NMS] Minor cleanup in log component and alerts dashboard

### DIFF
--- a/nms/app/packages/magmalte/app/components/__tests__/DashboardAlertTableTest.js
+++ b/nms/app/packages/magmalte/app/components/__tests__/DashboardAlertTableTest.js
@@ -157,18 +157,18 @@ describe('<DashboardAlertTable />', () => {
     const rowItems = await getAllByRole('row');
 
     // check if the default is critical alert sections
-    expect(rowItems[0]).toHaveTextContent('TestAlert1');
-    fireEvent.click(getByText('1 Critical'));
-    expect(rowItems[0]).toHaveTextContent('TestAlert1');
+    expect(rowItems[1]).toHaveTextContent('TestAlert1');
+    fireEvent.click(getByText('Critical(1)'));
+    expect(rowItems[1]).toHaveTextContent('TestAlert1');
 
-    fireEvent.click(getByText('1 Major'));
-    expect(rowItems[0]).toHaveTextContent('TestAlert2');
+    fireEvent.click(getByText('Major(1)'));
+    expect(rowItems[1]).toHaveTextContent('TestAlert2');
 
-    fireEvent.click(getByText('1 Minor'));
-    expect(rowItems[0]).toHaveTextContent('TestAlert3');
+    fireEvent.click(getByText('Minor(1)'));
+    expect(rowItems[1]).toHaveTextContent('TestAlert3');
 
-    fireEvent.click(getByText('1 Other'));
-    expect(rowItems[0]).toHaveTextContent('TestAlert4');
+    fireEvent.click(getByText('Other(1)'));
+    expect(rowItems[1]).toHaveTextContent('TestAlert4');
 
     expect(getByText('Alerts (4)')).toBeInTheDocument();
   });

--- a/nms/app/packages/magmalte/app/theme/default.js
+++ b/nms/app/packages/magmalte/app/theme/default.js
@@ -49,6 +49,12 @@ export const colors = {
     warningAlt: '#B69900',
     warningFill: '#FFFCED',
   },
+  alerts: {
+    severe: 'E52240',
+    major: '#E36730',
+    minor: '#F5DD5A',
+    other: '#88B3F9',
+  },
   data: {
     coral: '#FF824B',
     flamePea: '#E36730',

--- a/nms/app/packages/magmalte/app/views/equipment/GatewayLogs.js
+++ b/nms/app/packages/magmalte/app/views/equipment/GatewayLogs.js
@@ -44,10 +44,17 @@ import {useRouter} from '@fbcnms/ui/hooks';
 const MAX_PAGE_ROW_COUNT = 10000;
 const EXPORT_DELIMITER = ',';
 const LOG_COLUMNS = [
-  {title: 'Date', field: 'date', type: 'datetime', width: 200},
+  {
+    title: 'Date',
+    field: 'date',
+    type: 'datetime',
+    width: 200,
+    filtering: false,
+  },
   {title: 'Service', field: 'service', width: 200},
-  {title: 'Type', field: 'logType', width: 200},
-  {title: 'Output', field: 'output'},
+  {title: 'Tag', field: 'tag', width: 200},
+  {title: 'Type', field: 'logType', width: 200, filtering: false},
+  {title: 'Output', field: 'output', filtering: false},
 ];
 
 const useStyles = makeStyles(theme => ({
@@ -77,15 +84,41 @@ const getLogType = (msg: string): string => {
   return 'debug';
 };
 
+function buildQueryFilters(q: ActionQuery, gatewayId: string) {
+  const logQuery = {
+    simpleQuery: q.search ?? '',
+    fields: undefined,
+    filters: undefined,
+  };
+  const filters = [`gateway_id:${gatewayId}`];
+  if (q.search === '' && q.filters.length === 1) {
+    // for this case we can do a regex search
+    logQuery.simpleQuery = q.filters[0].value;
+    logQuery.fields = q.filters[0].column.field === 'service' ? 'ident' : 'tag';
+  } else if (q.filters.length > 0) {
+    q.filters.forEach((filter, _) => {
+      switch (filter.column.field) {
+        case 'service':
+          filters.push(`ident:${filter.value}`);
+          break;
+        case 'tag':
+          filters.push(`tag:${filter.value}`);
+          break;
+      }
+    });
+  }
+  logQuery.filters = filters.join(',');
+  return logQuery;
+}
+
 async function searchLogs(networkId, gatewayId, from, size, start, end, q) {
   const logs = await MagmaV1API.getNetworksByNetworkIdLogsSearch({
     networkId: networkId,
-    filters: `gateway_id:${gatewayId}`,
     from: from.toString(),
     size: size.toString(),
-    simpleQuery: q.search ?? '',
     start: start.toISOString(),
     end: end.toISOString(),
+    ...buildQueryFilters(q, gatewayId),
   });
 
   return logs.filter(Boolean).map(elastic_hit => {
@@ -94,7 +127,8 @@ async function searchLogs(networkId, gatewayId, from, size, start, end, q) {
     const msg = src['message'];
     return {
       date: date,
-      service: src['ident'] ?? src['tag'] ?? '-',
+      service: src['ident'] ?? '-',
+      tag: src['tag'] ?? '-',
       logType: getLogType(msg ?? ''),
       output: msg,
     };
@@ -142,8 +176,7 @@ function handleLogQuery(networkId, gatewayId, from, size, start, end, q) {
         networkId: networkId,
         start: start.toISOString(),
         end: end.toISOString(),
-        filters: `gateway_id:${gatewayId}`,
-        simpleQuery: q.search,
+        ...buildQueryFilters(q, gatewayId),
       });
 
       const searchReq = searchLogs(
@@ -308,6 +341,7 @@ export default function GatewayLogs() {
             }}
             columns={LOG_COLUMNS}
             options={{
+              filtering: true,
               actionsColumnIndex: -1,
               pageSize: 10,
               pageSizeOptions: [10, 20],

--- a/nms/app/packages/magmalte/app/views/equipment/__tests__/GatewayLogsTest.js
+++ b/nms/app/packages/magmalte/app/views/equipment/__tests__/GatewayLogsTest.js
@@ -161,20 +161,20 @@ describe('<GatewayLogs />', () => {
     expect(rowItems[0]).toHaveTextContent('Type');
     expect(rowItems[0]).toHaveTextContent('Output');
 
-    expect(rowItems[1]).toHaveTextContent(
-      new Date('2020-06-12T17:42:08.000000000+00:00').toLocaleString(),
-    );
-    expect(rowItems[1]).toHaveTextContent('control_proxy');
-    expect(rowItems[1]).toHaveTextContent('debug');
-    expect(rowItems[1]).toHaveTextContent('Message1');
-
-    expect(rowItems[1]).toHaveTextContent(
-      new Date('2020-06-12T17:42:08.000000000+00:00').toLocaleString(),
-    );
-    expect(rowItems[2]).toHaveTextContent('magmad');
-    expect(rowItems[2]).toHaveTextContent('info');
-    expect(rowItems[2]).toHaveTextContent('Info:Message2');
     expect(rowItems[2]).toHaveTextContent(
+      new Date('2020-06-12T17:42:08.000000000+00:00').toLocaleString(),
+    );
+    expect(rowItems[2]).toHaveTextContent('control_proxy');
+    expect(rowItems[2]).toHaveTextContent('debug');
+    expect(rowItems[2]).toHaveTextContent('Message1');
+
+    expect(rowItems[2]).toHaveTextContent(
+      new Date('2020-06-12T17:42:08.000000000+00:00').toLocaleString(),
+    );
+    expect(rowItems[3]).toHaveTextContent('magmad');
+    expect(rowItems[3]).toHaveTextContent('info');
+    expect(rowItems[3]).toHaveTextContent('Info:Message2');
+    expect(rowItems[3]).toHaveTextContent(
       new Date('2020-06-12T17:42:08.000000000+00:00').toLocaleString(),
     );
   });


### PR DESCRIPTION
Signed-off-by: Karthik Subraveti <ksubraveti@fb.com>

## Summary

- Add the ability to filter based on service name and tags in gateway logs
- Cleanup Alerts dashboard table and filter the alerts based on severity and display the labels

## Test Plan
<img width="1680" alt="Screen Shot 2021-01-08 at 4 36 18 PM" src="https://user-images.githubusercontent.com/8224854/104077693-a435c700-51cf-11eb-934b-489cf0eae6c7.png">

<img width="1680" src="https://user-images.githubusercontent.com/8224854/104103458-0f76ac00-5257-11eb-97de-75943bc2c5ae.png">


<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
