### PR TITLE
[orc8r][insync] Fix failing orc8r insync checkin by updating orc8r test image

### DIFF
--- a/orc8r/cloud/docker/docker-compose.override.yml
+++ b/orc8r/cloud/docker/docker-compose.override.yml
@@ -17,7 +17,7 @@ services:
     build:
       context: /tmp/magma_orc8r_build
       dockerfile: $PWD/controller/Dockerfile
-      target: base
+      target: src
     depends_on:
       - postgres_test
     entrypoint: /bin/bash -lc


### PR DESCRIPTION
Signed-off-by: Michael Germano <mgermano@fb.com>

## Summary

Insync checkin is failing due the docker test image using the wrong
target image. This was caused by the controller image getting updated in #4295.
This PR fixes the issue by updating the target for the orc8r test image.

## Test Plan
`./build.py`
`./build.py -g`