### PR TITLE
[lte][agw] Backport PR4302 to mme_testing branch

### DIFF
--- a/lte/gateway/c/oai/tasks/mme_app/mme_app_context.c
+++ b/lte/gateway/c/oai/tasks/mme_app/mme_app_context.c
@@ -302,7 +302,7 @@ void mme_app_ue_context_free_content(ue_mm_context_t* const ue_context_p) {
 
   // Stop ULR Response timer if running
   if (ue_context_p->ulr_response_timer.id != MME_APP_TIMER_INACTIVE_ID) {
-    nas_itti_timer_arg_t* timer_argP = NULL;
+    timer_argP = NULL;
     if (timer_remove(
             ue_context_p->ulr_response_timer.id, (void**) &timer_argP)) {
       OAILOG_ERROR_UE(
@@ -314,6 +314,22 @@ void mme_app_ue_context_free_content(ue_mm_context_t* const ue_context_p) {
       free_wrapper((void**) &timer_argP);
     }
     ue_context_p->ulr_response_timer.id = MME_APP_TIMER_INACTIVE_ID;
+  }
+
+  // Stop paging response timer if running
+  if (ue_context_p->paging_response_timer.id != MME_APP_TIMER_INACTIVE_ID) {
+    timer_argP = NULL;
+    if (timer_remove(
+            ue_context_p->paging_response_timer.id, (void**) &timer_argP)) {
+      OAILOG_ERROR_UE(
+          LOG_MME_APP, ue_context_p->emm_context._imsi64,
+          "Failed to stop Paging Response timer for UE id %d \n",
+          ue_context_p->mme_ue_s1ap_id);
+    }
+    if (timer_argP) {
+      free_wrapper((void**) &timer_argP);
+    }
+    ue_context_p->paging_response_timer.id = MME_APP_TIMER_INACTIVE_ID;
   }
 
   if (ue_context_p->sgs_context != NULL) {


### PR DESCRIPTION
## Summary

Backporting the fix for cleaning up paging timer when ue context is removed. 

## Test Plan

s1ap integ tests.

## Additional Information

- [ ] This change is backwards-breaking

