### PR TITLE
fix artifacts archive command placement in LTE pipeline

### DIFF
--- a/ci-scripts/JenkinsFile-LTE-integ-test
+++ b/ci-scripts/JenkinsFile-LTE-integ-test
@@ -201,7 +201,9 @@ pipeline {
                 """
               }
             }
-            archiveArtifacts("${test_folder}/*")
+            timeout(time: 10, unit: 'MINUTES') {
+              archiveArtifacts("${test_folder}/*")
+            }
           }
         }
       }


### PR DESCRIPTION
Signed-off-by: Vitalii Kostenko <vitalii@freedomfi.com>

As long as artefacts are exported on failure only they should be archived on failure only as well.
