### PR TITLE
[s1 sim][new testcases] Verified the stability of idle mode multi pdn testcases and added them to sanity suite

### DIFF
--- a/lte/gateway/python/integ_tests/defs.mk
+++ b/lte/gateway/python/integ_tests/defs.mk
@@ -107,6 +107,13 @@ s1aptests/test_attach_standalone_act_dflt_ber_ctxt_rej.py \
 s1aptests/test_attach_standalone_act_dflt_ber_ctxt_rej_ded_bearer_activation.py \
 s1aptests/test_ics_timer_expiry_ue_registered.py \
 s1aptests/test_ics_timer_expiry_ue_unregistered.py \
+s1aptests/test_attach_service_with_multi_pdns_and_bearers.py \
+s1aptests/test_attach_service_with_multi_pdns_and_bearers_looped.py \
+s1aptests/test_attach_service_with_multi_pdns_and_bearers_multi_ue.py \
+s1aptests/test_attach_service_with_multi_pdns_and_bearers_failure.py \
+s1aptests/test_dedicated_bearer_activation_idle_mode.py \
+s1aptests/test_dedicated_bearer_activation_idle_mode_multi_ue.py \
+s1aptests/test_dedicated_bearer_activation_idle_mode_paging_timer_expiry.py \
 s1aptests/test_multi_enb_multi_ue.py \
 s1aptests/test_multi_enb_multi_ue_diff_enbtype.py \
 s1aptests/test_multi_enb_multi_ue_diff_plmn.py \
@@ -123,6 +130,7 @@ s1aptests/test_attach_ul_tcp_data.py \
 s1aptests/test_attach_detach_attach_ul_tcp_data.py \
 s1aptests/test_attach_detach_rar_tcp_data.py \
 s1aptests/test_attach_detach_multiple_rar_tcp_data.py \
+s1aptests/test_attach_service_with_multi_pdns_and_bearers_mt_data.py \
 s1aptests/test_attach_asr.py \
 s1aptests/test_attach_detach_with_sctpd_restart.py \
 s1aptests/test_attach_detach_with_mme_restart.py \


### PR DESCRIPTION
Signed-off-by: Pruthvi Hebbani <pruthvi.hebbani@radisys.com>

[s1 sim][new testcases] Verified the stability of idle mode multi pdn testcases and added them to sanity suite

## Summary

Added multi pdn idle mode TCs in PRs #2521 and #2758 to sanity suite. These TCs were flaky earlier. On the latest master they are stable. Hence added them to sanity suite.

## Test Plan

- Verified TCs in PRs #2521 and #2758 are stable on multiple runs
- Executed sanity suite multiple times


