### PR TITLE
[AGW]Bump lxml to 4.6.2

### DIFF
--- a/lte/gateway/python/setup.py
+++ b/lte/gateway/python/setup.py
@@ -90,7 +90,7 @@ setup(
         'envoy>=0.0.3',
         'glob2>=0.7',
         # lxml required by spyne.
-        'lxml==4.2.1',
+        'lxml==4.6.2',
         'ryu>=4.30',
         'spyne>=2.12.16',
         'scapy==2.4.4',


### PR DESCRIPTION
Signed-off-by: Timothée Dzik <timdzik@fb.com>

[AGW]Bump lxml to 4.6.2

## Summary

CVE-2020-27783
moderate severity
Vulnerable versions: < 4.6.2
Patched version: 4.6.2
A XSS vulnerability was discovered in python-lxml's clean module. The module's parser didn't properly imitate browsers, which caused different behaviors between the sanitizer and the user's page. A remote attacker could exploit this flaw to run arbitrary HTML/JS code.

## Test Plan

let lte-agw-test run