### PR TITLE
[NMS] Add axios as nms dependency and bump to ^0.21.1

### DIFF
--- a/nms/app/package.json
+++ b/nms/app/package.json
@@ -19,6 +19,7 @@
     "babel-plugin-fbt": "^0.10.4",
     "babel-plugin-fbt-runtime": "^0.9.9",
     "babel-plugin-lodash": "^3.3.4",
+    "axios": "^0.21.1",
     "fbt": "^0.10.6"
   },
   "devDependencies": {

--- a/nms/app/yarn.lock
+++ b/nms/app/yarn.lock
@@ -3272,6 +3272,13 @@ axios@^0.18.0:
     follow-redirects "1.5.10"
     is-buffer "^2.0.2"
 
+axios@^0.21.1:
+  version "0.21.1"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.21.1.tgz#22563481962f4d6bde9a76d516ef0e5d3c09b2b8"
+  integrity sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==
+  dependencies:
+    follow-redirects "^1.10.0"
+
 axobject-query@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/axobject-query/-/axobject-query-2.2.0.tgz#943d47e10c0b704aa42275e20edf3722648989be"
@@ -6674,6 +6681,11 @@ follow-redirects@^1.0.0:
   version "1.12.1"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.12.1.tgz#de54a6205311b93d60398ebc01cf7015682312b6"
   integrity sha512-tmRv0AVuR7ZyouUHLeNSiO6pqulF7dYa3s19c6t+wz9LD69/uSzdMxJ2S91nTI9U3rt/IldxpzMOFejp6f0hjg==
+
+follow-redirects@^1.10.0:
+  version "1.13.1"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.13.1.tgz#5f69b813376cee4fd0474a3aba835df04ab763b7"
+  integrity sha512-SSG5xmZh1mkPGyKzjZP8zLjltIfpW32Y5QpdNJyjcfGxK3qo3NDDkZOZSFiGn1A6SclQxY9GzEwAHQ3dmYRWpg==
 
 for-in@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
Signed-off-by: Timothée Dzik <timdzik@fb.com>

[NMS] Add axios as nms dependency and bump to ^0.21.1

## Summary

There is currently a CVE open about axios (used in fbcnms/alert and another package) 

the CVE: 
```
CVE-2020-28168
high severity
Vulnerable versions: < 0.21.1
Patched version: 0.21.1
Axios NPM package 0.21.0 contains a Server-Side Request Forgery (SSRF) vulnerability where an attacker is able to bypass a proxy by providing a URL that responds with a redirect to a restricted host or IP address.
```

The resolution: 

Add axios as nms dep and bump it to the newest version that doesn't have the CVE. 

## Test Plan
![let it go](https://media.giphy.com/media/3o6fJ0KIn7yy4DlBM4/giphy.gif)


cc @HannaFar  @karthiksubraveti 
