### PR TITLE
AGW: mobilityD: set default GW for DHCP ip allocation.

### DIFF
--- a/lte/gateway/python/magma/mobilityd/main.py
+++ b/lte/gateway/python/magma/mobilityd/main.py
@@ -36,8 +36,10 @@ def _get_ipv4_allocator(store: MobilityStore, allocator_type: int,
                         static_ip_enabled: bool, multi_apn: bool,
                         dhcp_iface: str, dhcp_retry_limit: int,
                         subscriberdb_rpc_stub: SubscriberDBStub = None):
+    # Read default GW, this is required for static IP allocation.
+    store.dhcp_gw_info.read_default_gw()
+
     if allocator_type == mconfigs_pb2.MobilityD.IP_POOL:
-        store.dhcp_gw_info.read_default_gw()
         ip_allocator = IpAllocatorPool(store)
     elif allocator_type == mconfigs_pb2.MobilityD.DHCP:
         ip_allocator = IPAllocatorDHCP(store=store,


### PR DESCRIPTION
Set default GW mac address for all IP allocation mode.
This helps when operator has static only ip-allocation scheme.

Signed-off-by: Pravin B Shelar <pbshelar@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
