### PR TITLE
[orc8r] [refactor] Refactor instances of []Blob to Blobs (blobstorage)

### DIFF
--- a/cwf/gateway/services/uesim/servicers/ue_store_utils.go
+++ b/cwf/gateway/services/uesim/servicers/ue_store_utils.go
@@ -44,7 +44,7 @@ func addUeToStore(srvstore blobstore.BlobStorageFactory, ue *cwfprotos.UEConfig)
 		}
 	}()
 
-	err = store.CreateOrUpdate(networkIDPlaceholder, []blobstore.Blob{blob})
+	err = store.CreateOrUpdate(networkIDPlaceholder, blobstore.Blobs{blob})
 
 }
 

--- a/fbinternal/cloud/go/services/testcontroller/store/testcontroller_store.go
+++ b/fbinternal/cloud/go/services/testcontroller/store/testcontroller_store.go
@@ -185,7 +185,7 @@ func (s *TestControllerStore) put(networkID string, version string, timestamp in
 	if err != nil {
 		return err
 	}
-	err = s.store.CreateOrUpdate(networkID, []blobstore.Blob{blob})
+	err = s.store.CreateOrUpdate(networkID, blobstore.Blobs{blob})
 	if err != nil {
 		return err
 	}

--- a/feg/cloud/go/services/health/servicers/health_test.go
+++ b/feg/cloud/go/services/health/servicers/health_test.go
@@ -112,9 +112,9 @@ func TestHealthServer_UpdateHealth_SingleGateway(t *testing.T) {
 		Key:  test_utils.TestFegNetwork,
 	}
 	factory.On("StartTransaction", mock.Anything).Return(store, nil).Times(2)
-	store.On("CreateOrUpdate", test_utils.TestFegNetwork, []blobstore.Blob{healthBlob}).Return(nil).Once()
+	store.On("CreateOrUpdate", test_utils.TestFegNetwork, blobstore.Blobs{healthBlob}).Return(nil).Once()
 	store.On("GetExistingKeys", []string{test_utils.TestFegNetwork}, mock.AnythingOfType("SearchFilter")).Return([]string{}, nil)
-	store.On("CreateOrUpdate", test_utils.TestFegNetwork, []blobstore.Blob{clusterBlob}).Return(nil).Once()
+	store.On("CreateOrUpdate", test_utils.TestFegNetwork, blobstore.Blobs{clusterBlob}).Return(nil).Once()
 	store.On("Get", test_utils.TestFegNetwork, clusterTK).Return(clusterBlob, nil).Once()
 	store.On("Commit").Return(nil).Times(2)
 
@@ -128,8 +128,8 @@ func TestHealthServer_UpdateHealth_SingleGateway(t *testing.T) {
 	unhealthyBlob, err := fegstorage.HealthToBlob(test_utils.TestFegLogicalId1, unhealthyRequest.GetHealthStats())
 	assert.NoError(t, err)
 	factory.On("StartTransaction", mock.Anything).Return(store, nil).Times(2)
-	store.On("CreateOrUpdate", test_utils.TestFegNetwork, []blobstore.Blob{unhealthyBlob}).Return(nil)
-	store.On("CreateOrUpdate", test_utils.TestFegNetwork, []blobstore.Blob{clusterBlob}).Return(nil)
+	store.On("CreateOrUpdate", test_utils.TestFegNetwork, blobstore.Blobs{unhealthyBlob}).Return(nil)
+	store.On("CreateOrUpdate", test_utils.TestFegNetwork, blobstore.Blobs{clusterBlob}).Return(nil)
 	store.On("GetExistingKeys", []string{test_utils.TestFegNetwork}, mock.Anything).Return([]string{test_utils.TestFegNetwork}, nil)
 	store.On("Get", test_utils.TestFegNetwork, clusterTK).Return(clusterBlob, nil).Once()
 	store.On("Commit").Return(nil).Times(2)
@@ -171,7 +171,7 @@ func TestHealthServer_UpdateHealth_DualFeg_HealthyActive(t *testing.T) {
 		Key:  gwId2,
 	}
 	factory.On("StartTransaction", mock.Anything).Return(store, nil).Times(3)
-	store.On("CreateOrUpdate", testNetworkID, []blobstore.Blob{healthBlob}).Return(nil)
+	store.On("CreateOrUpdate", testNetworkID, blobstore.Blobs{healthBlob}).Return(nil)
 	store.On("GetExistingKeys", []string{testNetworkID}, mock.AnythingOfType("SearchFilter")).Return([]string{testNetworkID}, nil)
 	store.On("Get", testNetworkID, clusterTK).Return(clusterBlob, nil)
 	store.On("Get", testNetworkID, healthTK2).Return(healthBlob2, nil)
@@ -185,7 +185,7 @@ func TestHealthServer_UpdateHealth_DualFeg_HealthyActive(t *testing.T) {
 	// Update test servicer to simulate like this request is coming from standby feg
 	service.Feg1 = false
 	factory.On("StartTransaction", mock.Anything).Return(store, nil).Times(3)
-	store.On("CreateOrUpdate", testNetworkID, []blobstore.Blob{healthBlob2}).Return(nil)
+	store.On("CreateOrUpdate", testNetworkID, blobstore.Blobs{healthBlob2}).Return(nil)
 	store.On("GetExistingKeys", []string{testNetworkID}, mock.AnythingOfType("SearchFilter")).Return([]string{testNetworkID}, nil)
 	store.On("Get", testNetworkID, clusterTK).Return(clusterBlob, nil)
 	store.On("Get", testNetworkID, healthTK).Return(healthBlob, nil)
@@ -231,11 +231,11 @@ func TestNewHealthServer_UpdateHealth_FailoverFromActive(t *testing.T) {
 	assert.NoError(t, err)
 
 	factory.On("StartTransaction", mock.Anything).Return(store, nil).Times(4)
-	store.On("CreateOrUpdate", testNetworkID, []blobstore.Blob{unhealthyBlob}).Return(nil)
+	store.On("CreateOrUpdate", testNetworkID, blobstore.Blobs{unhealthyBlob}).Return(nil)
 	store.On("GetExistingKeys", []string{testNetworkID}, mock.AnythingOfType("SearchFilter")).Return([]string{testNetworkID}, nil)
 	store.On("Get", testNetworkID, clusterTK).Return(clusterBlob, nil)
 	store.On("Get", testNetworkID, healthTK2).Return(healthyBlob, nil)
-	store.On("CreateOrUpdate", testNetworkID, []blobstore.Blob{updatedClusterBlob}).Return(nil)
+	store.On("CreateOrUpdate", testNetworkID, blobstore.Blobs{updatedClusterBlob}).Return(nil)
 	store.On("Commit").Return(nil).Times(4)
 
 	res, err := service.UpdateHealth(context.Background(), unhealthyRequest)
@@ -280,11 +280,11 @@ func TestNewHealthServer_UpdateHealth_FailoverFromStandby(t *testing.T) {
 	assert.NoError(t, err)
 
 	factory.On("StartTransaction", mock.Anything).Return(store, nil).Times(4)
-	store.On("CreateOrUpdate", testNetworkID, []blobstore.Blob{healthyBlob}).Return(nil)
+	store.On("CreateOrUpdate", testNetworkID, blobstore.Blobs{healthyBlob}).Return(nil)
 	store.On("GetExistingKeys", []string{testNetworkID}, mock.AnythingOfType("SearchFilter")).Return([]string{testNetworkID}, nil)
 	store.On("Get", testNetworkID, clusterTK).Return(clusterBlob, nil)
 	store.On("Get", testNetworkID, healthTK).Return(unhealthyBlob, nil)
-	store.On("CreateOrUpdate", testNetworkID, []blobstore.Blob{updatedClusterBlob}).Return(nil)
+	store.On("CreateOrUpdate", testNetworkID, blobstore.Blobs{updatedClusterBlob}).Return(nil)
 	store.On("Commit").Return(nil).Times(4)
 
 	res, err := service.UpdateHealth(context.Background(), healthyRequest)
@@ -323,7 +323,7 @@ func TestNewHealtherServer_UpdateHealth_AllUnhealthy(t *testing.T) {
 		Key:  gwId2,
 	}
 	factory.On("StartTransaction", mock.Anything).Return(store, nil).Times(3)
-	store.On("CreateOrUpdate", testNetworkID, []blobstore.Blob{unhealthyBlob}).Return(nil)
+	store.On("CreateOrUpdate", testNetworkID, blobstore.Blobs{unhealthyBlob}).Return(nil)
 	store.On("GetExistingKeys", []string{testNetworkID}, mock.AnythingOfType("SearchFilter")).Return([]string{testNetworkID}, nil)
 	store.On("Get", testNetworkID, clusterTK).Return(clusterBlob, nil)
 	store.On("Get", testNetworkID, healthTK2).Return(unhealthyBlob, nil)
@@ -338,7 +338,7 @@ func TestNewHealtherServer_UpdateHealth_AllUnhealthy(t *testing.T) {
 	service.Feg1 = false
 
 	factory.On("StartTransaction", mock.Anything).Return(store, nil).Times(3)
-	store.On("CreateOrUpdate", testNetworkID, []blobstore.Blob{unhealthyBlob2}).Return(nil)
+	store.On("CreateOrUpdate", testNetworkID, blobstore.Blobs{unhealthyBlob2}).Return(nil)
 	store.On("GetExistingKeys", []string{testNetworkID}, mock.AnythingOfType("SearchFilter")).Return([]string{testNetworkID}, nil)
 	store.On("Get", testNetworkID, clusterTK).Return(clusterBlob, nil)
 	store.On("Get", testNetworkID, healthTK).Return(unhealthyBlob, nil)

--- a/feg/cloud/go/services/health/storage/health_blobstore.go
+++ b/feg/cloud/go/services/health/storage/health_blobstore.go
@@ -76,7 +76,7 @@ func (h *healthBlobstore) UpdateHealth(networkID string, gatewayID string, healt
 	if err != nil {
 		return err
 	}
-	err = store.CreateOrUpdate(networkID, []blobstore.Blob{healthBlob})
+	err = store.CreateOrUpdate(networkID, blobstore.Blobs{healthBlob})
 	if err != nil {
 		store.Rollback()
 		return err
@@ -95,7 +95,7 @@ func (h *healthBlobstore) UpdateClusterState(networkID string, clusterID string,
 	if err != nil {
 		return err
 	}
-	err = store.CreateOrUpdate(networkID, []blobstore.Blob{clusterBlob})
+	err = store.CreateOrUpdate(networkID, blobstore.Blobs{clusterBlob})
 	if err != nil {
 		store.Rollback()
 		return err
@@ -149,5 +149,5 @@ func (h *healthBlobstore) initializeCluster(store blobstore.TransactionalBlobSto
 	if err != nil {
 		return err
 	}
-	return store.CreateOrUpdate(networkID, []blobstore.Blob{clusterBlob})
+	return store.CreateOrUpdate(networkID, blobstore.Blobs{clusterBlob})
 }

--- a/lte/cloud/go/services/subscriberdb/servicers/lookup.go
+++ b/lte/cloud/go/services/subscriberdb/servicers/lookup.go
@@ -60,7 +60,7 @@ func (l *lookupServicer) GetMSISDNs(ctx context.Context, req *protos.GetMSISDNsR
 	defer store.Rollback()
 
 	tks := storage.MakeTKs(lte.MSISDNBlobstoreType, req.Msisdns)
-	var blobs []blobstore.Blob
+	var blobs blobstore.Blobs
 	if len(tks) == 0 {
 		blobs, err = blobstore.GetAllOfType(store, req.NetworkId, lte.MSISDNBlobstoreType)
 		if err != nil {
@@ -102,7 +102,7 @@ func (l *lookupServicer) SetMSISDN(ctx context.Context, req *protos.SetMSISDNReq
 		return nil, makeErr(err, "get msisdn from blobstore")
 	}
 
-	err = store.CreateOrUpdate(req.NetworkId, []blobstore.Blob{{
+	err = store.CreateOrUpdate(req.NetworkId, blobstore.Blobs{{
 		Type:  lte.MSISDNBlobstoreType,
 		Key:   req.Msisdn,
 		Value: []byte(req.Imsi),

--- a/orc8r/cloud/go/blobstore/ent.go
+++ b/orc8r/cloud/go/blobstore/ent.go
@@ -92,9 +92,9 @@ func (e *entStorage) Get(networkID string, id storage.TypeAndKey) (Blob, error) 
 	return blobs[0], nil
 }
 
-func (e *entStorage) GetMany(networkID string, ids []storage.TypeAndKey) ([]Blob, error) {
+func (e *entStorage) GetMany(networkID string, ids []storage.TypeAndKey) (Blobs, error) {
 	ctx := context.Background()
-	var blobs []Blob
+	var blobs Blobs
 	err := e.Blob.Query().
 		Where(P(networkID, ids)).
 		Select(blob.FieldKey, blob.FieldType, blob.FieldValue, blob.FieldVersion).
@@ -105,7 +105,7 @@ func (e *entStorage) GetMany(networkID string, ids []storage.TypeAndKey) ([]Blob
 	return blobs, nil
 }
 
-func (e *entStorage) Search(filter SearchFilter, criteria LoadCriteria) (map[string][]Blob, error) {
+func (e *entStorage) Search(filter SearchFilter, criteria LoadCriteria) (map[string]Blobs, error) {
 	ctx := context.Background()
 
 	// Get fields from load criteria
@@ -131,7 +131,7 @@ func (e *entStorage) Search(filter SearchFilter, criteria LoadCriteria) (map[str
 		}
 	}
 
-	ret := map[string][]Blob{}
+	ret := map[string]Blobs{}
 	var blobs []blobWithNetworkID
 	err := e.Blob.Query().
 		Where(blob.And(preds...)).
@@ -178,7 +178,7 @@ func (e *entStorage) Delete(networkID string, ids []storage.TypeAndKey) error {
 	return err
 }
 
-func (e *entStorage) CreateOrUpdate(networkID string, blobs []Blob) error {
+func (e *entStorage) CreateOrUpdate(networkID string, blobs Blobs) error {
 	ctx := context.Background()
 	existingBlobs, err := e.GetMany(networkID, getBlobIDs(blobs))
 	if err != nil {

--- a/orc8r/cloud/go/blobstore/ent_test.go
+++ b/orc8r/cloud/go/blobstore/ent_test.go
@@ -32,7 +32,7 @@ func TestMigration(t *testing.T) {
 	require.NoError(t, err)
 	storev1, err := fact.StartTransaction(nil)
 	require.NoError(t, err)
-	blobs := []blobstore.Blob{
+	blobs := blobstore.Blobs{
 		{Type: "type1", Key: "key1", Value: []byte("value")},
 		{Type: "type2", Key: "key2", Value: []byte("value")},
 		{Type: "type1", Key: "key2", Value: []byte("value")},
@@ -103,7 +103,7 @@ func TestMigration(t *testing.T) {
 	blob, err = storev2.Get("id1", storage.TypeAndKey{Type: "type3", Key: "key1"})
 	require.Equal(t, magmaerrors.ErrNotFound, err)
 
-	err = storev2.CreateOrUpdate("id1", []blobstore.Blob{
+	err = storev2.CreateOrUpdate("id1", blobstore.Blobs{
 		{Type: "type1", Key: "key1", Value: []byte("world")},
 		{Type: "type3", Key: "key1", Value: []byte("value")},
 	})

--- a/orc8r/cloud/go/blobstore/integration_test.go
+++ b/orc8r/cloud/go/blobstore/integration_test.go
@@ -60,7 +60,7 @@ func integration(t *testing.T, fact blobstore.BlobStorageFactory) {
 
 	// Create blobs on 2 networks
 	// network1: (t1, t2) X (k1, k2)
-	err = store1.CreateOrUpdate("network1", []blobstore.Blob{
+	err = store1.CreateOrUpdate("network1", blobstore.Blobs{
 		{Type: "t1", Key: "k1", Value: []byte("v1")},
 		{Type: "t1", Key: "k2", Value: []byte("v2")},
 		{Type: "t2", Key: "k1", Value: []byte("v3"), Version: 2},
@@ -72,7 +72,7 @@ func integration(t *testing.T, fact blobstore.BlobStorageFactory) {
 	// network2: (t3) X (k3, k4)
 	store2, err := fact.StartTransaction(nil)
 	assert.NoError(t, err)
-	err = store2.CreateOrUpdate("network2", []blobstore.Blob{
+	err = store2.CreateOrUpdate("network2", blobstore.Blobs{
 		{Type: "t3", Key: "k3", Value: []byte("v5")},
 		{Type: "t3", Key: "k4", Value: []byte("v6")},
 	})
@@ -116,7 +116,7 @@ func integration(t *testing.T, fact blobstore.BlobStorageFactory) {
 	sort.Slice(getManyActual, getBlobsComparator(getManyActual))
 	assert.Equal(
 		t,
-		[]blobstore.Blob{
+		blobstore.Blobs{
 			{Type: "t1", Key: "k1", Value: []byte("v1"), Version: 0},
 			{Type: "t1", Key: "k2", Value: []byte("v2"), Version: 0},
 			{Type: "t2", Key: "k1", Value: []byte("v3"), Version: 2},
@@ -128,7 +128,7 @@ func integration(t *testing.T, fact blobstore.BlobStorageFactory) {
 	getAllActual, err = blobstore.GetAllOfType(store, "network1", "t2")
 	assert.NoError(t, err)
 	sort.Slice(getAllActual, getBlobsComparator(getAllActual))
-	getAllExpected := []blobstore.Blob{
+	getAllExpected := blobstore.Blobs{
 		{Type: "t2", Key: "k1", Value: []byte("v3"), Version: 2},
 		{Type: "t2", Key: "k2", Value: []byte("v4"), Version: 1},
 	}
@@ -142,7 +142,7 @@ func integration(t *testing.T, fact blobstore.BlobStorageFactory) {
 	sort.Slice(getManyActual, getBlobsComparator(getManyActual))
 	assert.Equal(
 		t,
-		[]blobstore.Blob{
+		blobstore.Blobs{
 			{Type: "t3", Key: "k3", Value: []byte("v5"), Version: 0},
 			{Type: "t3", Key: "k4", Value: []byte("v6"), Version: 0},
 		},
@@ -162,7 +162,7 @@ func integration(t *testing.T, fact blobstore.BlobStorageFactory) {
 	store, err = fact.StartTransaction(nil)
 	assert.NoError(t, err)
 
-	err = store.CreateOrUpdate("network1", []blobstore.Blob{
+	err = store.CreateOrUpdate("network1", blobstore.Blobs{
 		{Type: "t1", Key: "k1", Value: []byte("hello"), Version: 20},
 		{Type: "t9", Key: "k9", Value: []byte("world")},
 	})
@@ -176,7 +176,7 @@ func integration(t *testing.T, fact blobstore.BlobStorageFactory) {
 	sort.Slice(getManyActual, getBlobsComparator(getManyActual))
 	assert.Equal(
 		t,
-		[]blobstore.Blob{
+		blobstore.Blobs{
 			{Type: "t1", Key: "k1", Value: []byte("hello"), Version: 20},
 			{Type: "t9", Key: "k9", Value: []byte("world"), Version: 0},
 		},
@@ -218,7 +218,7 @@ func integration(t *testing.T, fact blobstore.BlobStorageFactory) {
 		{Type: "t9", Key: "k9"},
 	})
 	assert.NoError(t, err)
-	assert.Equal(t, []blobstore.Blob{{Type: "t9", Key: "k9", Value: []byte("world"), Version: 0}}, getManyActual)
+	assert.Equal(t, blobstore.Blobs{{Type: "t9", Key: "k9", Value: []byte("world"), Version: 0}}, getManyActual)
 
 	assert.NoError(t, store.Commit())
 
@@ -246,7 +246,7 @@ func integration(t *testing.T, fact blobstore.BlobStorageFactory) {
 		{Type: "t3", Key: "k3"},
 	})
 	assert.NoError(t, err)
-	assert.Equal(t, []blobstore.Blob{{Type: "t3", Key: "k3", Value: []byte("v5"), Version: 0}}, getManyActual)
+	assert.Equal(t, blobstore.Blobs{{Type: "t3", Key: "k3", Value: []byte("v5"), Version: 0}}, getManyActual)
 	assert.NoError(t, store.Commit())
 
 	// Increment version
@@ -261,7 +261,7 @@ func integration(t *testing.T, fact blobstore.BlobStorageFactory) {
 		{Type: "t7", Key: "k1"},
 	})
 	assert.NoError(t, err)
-	assert.Equal(t, []blobstore.Blob{{Type: "t7", Key: "k1", Version: 1}}, getManyActual)
+	assert.Equal(t, blobstore.Blobs{{Type: "t7", Key: "k1", Version: 1}}, getManyActual)
 
 	// Increment existing type/key twice
 	err = store.IncrementVersion("network2", storage.TypeAndKey{Type: "t3", Key: "k3"})
@@ -273,7 +273,7 @@ func integration(t *testing.T, fact blobstore.BlobStorageFactory) {
 		{Type: "t3", Key: "k3"},
 	})
 	assert.NoError(t, err)
-	assert.Equal(t, []blobstore.Blob{{Type: "t3", Key: "k3", Value: []byte("v5"), Version: 2}}, getManyActual)
+	assert.Equal(t, blobstore.Blobs{{Type: "t3", Key: "k3", Value: []byte("v5"), Version: 2}}, getManyActual)
 }
 
 type searchTestCase struct {
@@ -283,7 +283,7 @@ type searchTestCase struct {
 	keyPrefix *string
 	criteria  *blobstore.LoadCriteria
 
-	expected map[string][]blobstore.Blob
+	expected map[string]blobstore.Blobs
 }
 
 func runSearchTestCases(t *testing.T, fact blobstore.BlobStorageFactory) {
@@ -293,7 +293,7 @@ func runSearchTestCases(t *testing.T, fact blobstore.BlobStorageFactory) {
 	allNetworkSearchTestCases := []searchTestCase{
 		{
 			// emtpy search filter
-			expected: map[string][]blobstore.Blob{
+			expected: map[string]blobstore.Blobs{
 				"network1": {
 					{Type: "t1", Key: "k1", Value: []byte("v1"), Version: 0},
 					{Type: "t1", Key: "k2", Value: []byte("v2"), Version: 0},
@@ -308,7 +308,7 @@ func runSearchTestCases(t *testing.T, fact blobstore.BlobStorageFactory) {
 		},
 		{
 			types: []string{"t1", "t3"},
-			expected: map[string][]blobstore.Blob{
+			expected: map[string]blobstore.Blobs{
 				"network1": {
 					{Type: "t1", Key: "k1", Value: []byte("v1"), Version: 0},
 					{Type: "t1", Key: "k2", Value: []byte("v2"), Version: 0},
@@ -323,7 +323,7 @@ func runSearchTestCases(t *testing.T, fact blobstore.BlobStorageFactory) {
 			// with load criteria
 			criteria: &blobstore.LoadCriteria{LoadValue: false},
 			types:    []string{"t1", "t3"},
-			expected: map[string][]blobstore.Blob{
+			expected: map[string]blobstore.Blobs{
 				"network1": {
 					{Type: "t1", Key: "k1", Value: nil, Version: 0},
 					{Type: "t1", Key: "k2", Value: nil, Version: 0},
@@ -336,7 +336,7 @@ func runSearchTestCases(t *testing.T, fact blobstore.BlobStorageFactory) {
 		},
 		{
 			types: []string{"t3"},
-			expected: map[string][]blobstore.Blob{
+			expected: map[string]blobstore.Blobs{
 				"network2": {
 					{Type: "t3", Key: "k3", Value: []byte("v5"), Version: 0},
 					{Type: "t3", Key: "k4", Value: []byte("v6"), Version: 0},
@@ -345,7 +345,7 @@ func runSearchTestCases(t *testing.T, fact blobstore.BlobStorageFactory) {
 		},
 		{
 			keys: []string{"k1", "k3"},
-			expected: map[string][]blobstore.Blob{
+			expected: map[string]blobstore.Blobs{
 				"network1": {
 					{Type: "t1", Key: "k1", Value: []byte("v1"), Version: 0},
 					{Type: "t2", Key: "k1", Value: []byte("v3"), Version: 2},
@@ -357,7 +357,7 @@ func runSearchTestCases(t *testing.T, fact blobstore.BlobStorageFactory) {
 		},
 		{
 			keys: []string{"k3"},
-			expected: map[string][]blobstore.Blob{
+			expected: map[string]blobstore.Blobs{
 				"network2": {
 					{Type: "t3", Key: "k3", Value: []byte("v5"), Version: 0},
 				},
@@ -366,7 +366,7 @@ func runSearchTestCases(t *testing.T, fact blobstore.BlobStorageFactory) {
 		{
 			types: []string{"t1", "t3"},
 			keys:  []string{"k1"},
-			expected: map[string][]blobstore.Blob{
+			expected: map[string]blobstore.Blobs{
 				"network1": {
 					{Type: "t1", Key: "k1", Value: []byte("v1"), Version: 0},
 				},
@@ -375,7 +375,7 @@ func runSearchTestCases(t *testing.T, fact blobstore.BlobStorageFactory) {
 		// with key prefix
 		{
 			keyPrefix: strPtr("k1"),
-			expected: map[string][]blobstore.Blob{
+			expected: map[string]blobstore.Blobs{
 				"network1": {
 					{Type: "t1", Key: "k1", Value: []byte("v1"), Version: 0},
 					{Type: "t2", Key: "k1", Value: []byte("v3"), Version: 2},
@@ -386,7 +386,7 @@ func runSearchTestCases(t *testing.T, fact blobstore.BlobStorageFactory) {
 		{
 			keys:      []string{"k1", "k2"},
 			keyPrefix: strPtr("k"),
-			expected: map[string][]blobstore.Blob{
+			expected: map[string]blobstore.Blobs{
 				"network1": {
 					{Type: "t1", Key: "k1", Value: []byte("v1"), Version: 0},
 					{Type: "t1", Key: "k2", Value: []byte("v2"), Version: 0},
@@ -402,7 +402,7 @@ func runSearchTestCases(t *testing.T, fact blobstore.BlobStorageFactory) {
 		{
 			types:    []string{"t4"},
 			keys:     []string{"k1", "k2", "k3", "k4"},
-			expected: map[string][]blobstore.Blob{},
+			expected: map[string]blobstore.Blobs{},
 		},
 	}
 	for _, tc := range allNetworkSearchTestCases {
@@ -413,7 +413,7 @@ func runSearchTestCases(t *testing.T, fact blobstore.BlobStorageFactory) {
 		{
 			nid:   strPtr("network1"),
 			types: []string{"t1", "t3"},
-			expected: map[string][]blobstore.Blob{
+			expected: map[string]blobstore.Blobs{
 				"network1": {
 					{Type: "t1", Key: "k1", Value: []byte("v1"), Version: 0},
 					{Type: "t1", Key: "k2", Value: []byte("v2"), Version: 0},
@@ -423,7 +423,7 @@ func runSearchTestCases(t *testing.T, fact blobstore.BlobStorageFactory) {
 		{
 			nid:   strPtr("network2"),
 			types: []string{"t3"},
-			expected: map[string][]blobstore.Blob{
+			expected: map[string]blobstore.Blobs{
 				"network2": {
 					{Type: "t3", Key: "k3", Value: []byte("v5"), Version: 0},
 					{Type: "t3", Key: "k4", Value: []byte("v6"), Version: 0},
@@ -433,7 +433,7 @@ func runSearchTestCases(t *testing.T, fact blobstore.BlobStorageFactory) {
 		{
 			nid:  strPtr("network1"),
 			keys: []string{"k1", "k3"},
-			expected: map[string][]blobstore.Blob{
+			expected: map[string]blobstore.Blobs{
 				"network1": {
 					{Type: "t1", Key: "k1", Value: []byte("v1"), Version: 0},
 					{Type: "t2", Key: "k1", Value: []byte("v3"), Version: 2},
@@ -443,7 +443,7 @@ func runSearchTestCases(t *testing.T, fact blobstore.BlobStorageFactory) {
 		{
 			nid:  strPtr("network2"),
 			keys: []string{"k3", "k4"},
-			expected: map[string][]blobstore.Blob{
+			expected: map[string]blobstore.Blobs{
 				"network2": {
 					{Type: "t3", Key: "k3", Value: []byte("v5"), Version: 0},
 					{Type: "t3", Key: "k4", Value: []byte("v6"), Version: 0},
@@ -454,7 +454,7 @@ func runSearchTestCases(t *testing.T, fact blobstore.BlobStorageFactory) {
 			nid:   strPtr("network1"),
 			types: []string{"t1", "t2"},
 			keys:  []string{"k1"},
-			expected: map[string][]blobstore.Blob{
+			expected: map[string]blobstore.Blobs{
 				"network1": {
 					{Type: "t1", Key: "k1", Value: []byte("v1"), Version: 0},
 					{Type: "t2", Key: "k1", Value: []byte("v3"), Version: 2},
@@ -465,7 +465,7 @@ func runSearchTestCases(t *testing.T, fact blobstore.BlobStorageFactory) {
 			nid:   strPtr("network2"),
 			types: []string{"t3"},
 			keys:  []string{"k1", "k2", "k3", "k4"},
-			expected: map[string][]blobstore.Blob{
+			expected: map[string]blobstore.Blobs{
 				"network2": {
 					{Type: "t3", Key: "k3", Value: []byte("v5"), Version: 0},
 					{Type: "t3", Key: "k4", Value: []byte("v6"), Version: 0},
@@ -476,7 +476,7 @@ func runSearchTestCases(t *testing.T, fact blobstore.BlobStorageFactory) {
 			nid:      strPtr("network3"),
 			types:    []string{"t1", "t2", "t3"},
 			keys:     []string{"k1", "k2", "k3", "k4"},
-			expected: map[string][]blobstore.Blob{},
+			expected: map[string]blobstore.Blobs{},
 		},
 	}
 	for _, tc := range specificNetworkSearchTestCases {
@@ -506,13 +506,13 @@ func getTKsComparator(tks []storage.TypeAndKey) func(i, j int) bool {
 	}
 }
 
-func getBlobsComparator(blobs []blobstore.Blob) func(i, j int) bool {
+func getBlobsComparator(blobs blobstore.Blobs) func(i, j int) bool {
 	return func(i, j int) bool {
 		return blobs[i].Type+blobs[i].Key < blobs[j].Type+blobs[j].Key
 	}
 }
 
-func sortSearchOutput(searchActual map[string][]blobstore.Blob) {
+func sortSearchOutput(searchActual map[string]blobstore.Blobs) {
 	for _, blobs := range searchActual {
 		sort.Slice(blobs, getBlobsComparator(blobs))
 	}

--- a/orc8r/cloud/go/blobstore/memory_test.go
+++ b/orc8r/cloud/go/blobstore/memory_test.go
@@ -42,7 +42,7 @@ func TestMemoryBlobStorageStorage_CreateOrUpdate(t *testing.T) {
 	assert.NoError(t, err)
 
 	// create
-	assert.NoError(t, store.CreateOrUpdate(network1, []blobstore.Blob{blob1}))
+	assert.NoError(t, store.CreateOrUpdate(network1, blobstore.Blobs{blob1}))
 
 	blob, err := store.Get(network1, storage.TypeAndKey{Type: type1, Key: key1})
 	assert.Equal(t, err, nil)
@@ -50,7 +50,7 @@ func TestMemoryBlobStorageStorage_CreateOrUpdate(t *testing.T) {
 	version1 := blob.Version
 
 	// update
-	assert.NoError(t, store.CreateOrUpdate(network1, []blobstore.Blob{blob2}))
+	assert.NoError(t, store.CreateOrUpdate(network1, blobstore.Blobs{blob2}))
 	blob, err = store.Get(network1, storage.TypeAndKey{Type: type1, Key: key1})
 	assert.Equal(t, err, nil)
 	assert.True(t, blobEqual(blob2, blob))
@@ -60,7 +60,7 @@ func TestMemoryBlobStorageStorage_CreateOrUpdate(t *testing.T) {
 
 	// update blob version
 	blob1.Version = 10
-	assert.NoError(t, store.CreateOrUpdate(network1, []blobstore.Blob{blob1}))
+	assert.NoError(t, store.CreateOrUpdate(network1, blobstore.Blobs{blob1}))
 	blob, err = store.Get(network1, storage.TypeAndKey{Type: type1, Key: key1})
 	assert.Equal(t, err, nil)
 	assert.True(t, blobEqual(blob1, blob))
@@ -79,7 +79,7 @@ func TestMemoryBlobStorage_Rollback(t *testing.T) {
 	assert.NoError(t, err)
 
 	// create
-	assert.NoError(t, store.CreateOrUpdate(network1, []blobstore.Blob{blob1}))
+	assert.NoError(t, store.CreateOrUpdate(network1, blobstore.Blobs{blob1}))
 
 	_, err = store.Get(network1, storage.TypeAndKey{Type: type1, Key: key1})
 	assert.Equal(t, err, nil)
@@ -104,7 +104,7 @@ func TestMemoryBlobStorage_Commit(t *testing.T) {
 	assert.NoError(t, err)
 
 	// create
-	assert.NoError(t, store.CreateOrUpdate(network1, []blobstore.Blob{blob1}))
+	assert.NoError(t, store.CreateOrUpdate(network1, blobstore.Blobs{blob1}))
 
 	_, err = store.Get(network1, id1)
 	assert.Equal(t, err, nil)
@@ -117,7 +117,7 @@ func TestMemoryBlobStorage_Commit(t *testing.T) {
 	assert.NoError(t, err)
 	assert.True(t, blobEqual(blob, blob1))
 	blob1.Value = []byte("value2")
-	assert.NoError(t, store.CreateOrUpdate(network1, []blobstore.Blob{blob1}))
+	assert.NoError(t, store.CreateOrUpdate(network1, blobstore.Blobs{blob1}))
 	assert.NoError(t, store.Commit())
 
 	store, err = factory.StartTransaction(nil)
@@ -145,8 +145,8 @@ func TestMemoryBlobStorage_GetMany(t *testing.T) {
 	assert.NoError(t, err)
 
 	// create
-	assert.NoError(t, store.CreateOrUpdate(network1, []blobstore.Blob{blob1}))
-	assert.NoError(t, store.CreateOrUpdate(network1, []blobstore.Blob{blob2}))
+	assert.NoError(t, store.CreateOrUpdate(network1, blobstore.Blobs{blob1}))
+	assert.NoError(t, store.CreateOrUpdate(network1, blobstore.Blobs{blob2}))
 
 	// lookup
 	blobs, err := store.GetMany(network1, ids)
@@ -176,9 +176,9 @@ func TestMemoryBlobStorage_Delete(t *testing.T) {
 
 	// create, update, delete within a transaction session should end up with
 	// the blob being deleted
-	assert.NoError(t, store.CreateOrUpdate(network1, []blobstore.Blob{blob1}))
+	assert.NoError(t, store.CreateOrUpdate(network1, blobstore.Blobs{blob1}))
 	blob1.Value = []byte("value1_updated")
-	assert.NoError(t, store.CreateOrUpdate(network1, []blobstore.Blob{blob1}))
+	assert.NoError(t, store.CreateOrUpdate(network1, blobstore.Blobs{blob1}))
 	assert.NoError(t, store.Delete(network1, ids))
 	assert.NoError(t, store.Commit())
 	store, err = factory.StartTransaction(nil)
@@ -188,10 +188,10 @@ func TestMemoryBlobStorage_Delete(t *testing.T) {
 
 	// create, delete, update within a transaction session should end up with
 	// the blob being deleted
-	assert.NoError(t, store.CreateOrUpdate(network1, []blobstore.Blob{blob1}))
+	assert.NoError(t, store.CreateOrUpdate(network1, blobstore.Blobs{blob1}))
 	blob1.Value = []byte("value1_updated")
 	assert.NoError(t, store.Delete(network1, ids))
-	assert.NoError(t, store.CreateOrUpdate(network1, []blobstore.Blob{blob1}))
+	assert.NoError(t, store.CreateOrUpdate(network1, blobstore.Blobs{blob1}))
 	assert.NoError(t, store.Commit())
 	store, err = factory.StartTransaction(nil)
 	assert.NoError(t, err)
@@ -212,7 +212,7 @@ func TestMemoryBlobStorage_ListKeys(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Test local changes
-	assert.NoError(t, store.CreateOrUpdate(network1, []blobstore.Blob{blob1, blob2}))
+	assert.NoError(t, store.CreateOrUpdate(network1, blobstore.Blobs{blob1, blob2}))
 	keys, err := store.ListKeys(network1, type1)
 	assert.Equal(t, []string{key1, key2}, keys)
 

--- a/orc8r/cloud/go/blobstore/mocks/TransactionalBlobStorage.go
+++ b/orc8r/cloud/go/blobstore/mocks/TransactionalBlobStorage.go
@@ -30,11 +30,11 @@ func (_m *TransactionalBlobStorage) Commit() error {
 }
 
 // CreateOrUpdate provides a mock function with given fields: networkID, blobs
-func (_m *TransactionalBlobStorage) CreateOrUpdate(networkID string, blobs []blobstore.Blob) error {
+func (_m *TransactionalBlobStorage) CreateOrUpdate(networkID string, blobs blobstore.Blobs) error {
 	ret := _m.Called(networkID, blobs)
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(string, []blobstore.Blob) error); ok {
+	if rf, ok := ret.Get(0).(func(string, blobstore.Blobs) error); ok {
 		r0 = rf(networkID, blobs)
 	} else {
 		r0 = ret.Error(0)
@@ -102,15 +102,15 @@ func (_m *TransactionalBlobStorage) GetExistingKeys(keys []string, filter blobst
 }
 
 // GetMany provides a mock function with given fields: networkID, ids
-func (_m *TransactionalBlobStorage) GetMany(networkID string, ids []storage.TypeAndKey) ([]blobstore.Blob, error) {
+func (_m *TransactionalBlobStorage) GetMany(networkID string, ids []storage.TypeAndKey) (blobstore.Blobs, error) {
 	ret := _m.Called(networkID, ids)
 
-	var r0 []blobstore.Blob
-	if rf, ok := ret.Get(0).(func(string, []storage.TypeAndKey) []blobstore.Blob); ok {
+	var r0 blobstore.Blobs
+	if rf, ok := ret.Get(0).(func(string, []storage.TypeAndKey) blobstore.Blobs); ok {
 		r0 = rf(networkID, ids)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).([]blobstore.Blob)
+			r0 = ret.Get(0).(blobstore.Blobs)
 		}
 	}
 
@@ -176,15 +176,15 @@ func (_m *TransactionalBlobStorage) Rollback() error {
 }
 
 // Search provides a mock function with given fields: filter, criteria
-func (_m *TransactionalBlobStorage) Search(filter blobstore.SearchFilter, criteria blobstore.LoadCriteria) (map[string][]blobstore.Blob, error) {
+func (_m *TransactionalBlobStorage) Search(filter blobstore.SearchFilter, criteria blobstore.LoadCriteria) (map[string]blobstore.Blobs, error) {
 	ret := _m.Called(filter, criteria)
 
-	var r0 map[string][]blobstore.Blob
-	if rf, ok := ret.Get(0).(func(blobstore.SearchFilter, blobstore.LoadCriteria) map[string][]blobstore.Blob); ok {
+	var r0 map[string]blobstore.Blobs
+	if rf, ok := ret.Get(0).(func(blobstore.SearchFilter, blobstore.LoadCriteria) map[string]blobstore.Blobs); ok {
 		r0 = rf(filter, criteria)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(map[string][]blobstore.Blob)
+			r0 = ret.Get(0).(map[string]blobstore.Blobs)
 		}
 	}
 

--- a/orc8r/cloud/go/blobstore/sql_test.go
+++ b/orc8r/cloud/go/blobstore/sql_test.go
@@ -144,7 +144,7 @@ func TestSqlBlobStorage_GetMany(t *testing.T) {
 		},
 
 		expectedError: nil,
-		expectedResult: []blobstore.Blob{
+		expectedResult: blobstore.Blobs{
 			{Type: "t1", Key: "k1", Value: []byte("value1"), Version: 42},
 			{Type: "t2", Key: "k2", Value: []byte("value2"), Version: 43},
 		},
@@ -189,7 +189,7 @@ func TestSqlBlobStorage_Search(t *testing.T) {
 		},
 
 		expectedError: nil,
-		expectedResult: map[string][]blobstore.Blob{
+		expectedResult: map[string]blobstore.Blobs{
 			"network": {
 				{Type: "t1", Key: "k1", Value: []byte("value1"), Version: 42},
 				{Type: "t2", Key: "k2", Value: []byte("value2"), Version: 43},
@@ -216,7 +216,7 @@ func TestSqlBlobStorage_Search(t *testing.T) {
 		},
 
 		expectedError: nil,
-		expectedResult: map[string][]blobstore.Blob{
+		expectedResult: map[string]blobstore.Blobs{
 			"network": {
 				{Type: "t1", Key: "kprefix1", Value: []byte("value1"), Version: 42},
 				{Type: "t2", Key: "kprefix2", Value: []byte("value2"), Version: 43},
@@ -244,7 +244,7 @@ func TestSqlBlobStorage_Search(t *testing.T) {
 		},
 
 		expectedError: nil,
-		expectedResult: map[string][]blobstore.Blob{
+		expectedResult: map[string]blobstore.Blobs{
 			"network1": {
 				{Type: "t1", Key: "k1", Value: []byte("value1"), Version: 42},
 				{Type: "t2", Key: "k2", Value: []byte("value2"), Version: 43},
@@ -274,7 +274,7 @@ func TestSqlBlobStorage_Search(t *testing.T) {
 		},
 
 		expectedError: nil,
-		expectedResult: map[string][]blobstore.Blob{
+		expectedResult: map[string]blobstore.Blobs{
 			"network1": {
 				{Type: "t1", Key: "k1", Value: []byte("value1"), Version: 42},
 			},
@@ -303,7 +303,7 @@ func TestSqlBlobStorage_Search(t *testing.T) {
 		},
 
 		expectedError: nil,
-		expectedResult: map[string][]blobstore.Blob{
+		expectedResult: map[string]blobstore.Blobs{
 			"network1": {
 				{Type: "t1", Key: "k1", Value: nil, Version: 42},
 			},
@@ -345,7 +345,7 @@ func TestSqlBlobStorage_CreateOrUpdate(t *testing.T) {
 			expectGetMany(
 				mock,
 				[]driver.Value{"network", "t1", "k1", "network", "t2", "k2"},
-				[]blobstore.Blob{
+				blobstore.Blobs{
 					{Type: "t1", Key: "k1", Value: []byte("hello"), Version: 42},
 				},
 			)
@@ -364,7 +364,7 @@ func TestSqlBlobStorage_CreateOrUpdate(t *testing.T) {
 		run: func(store blobstore.TransactionalBlobStorage) (interface{}, error) {
 			err := store.CreateOrUpdate(
 				"network",
-				[]blobstore.Blob{
+				blobstore.Blobs{
 					{Type: "t1", Key: "k1", Value: []byte("goodbye"), Version: 0},
 					{Type: "t2", Key: "k2", Value: []byte("world"), Version: 1000},
 				},
@@ -381,7 +381,7 @@ func TestSqlBlobStorage_CreateOrUpdate(t *testing.T) {
 			expectGetMany(
 				mock,
 				[]driver.Value{"network", "t1", "k1", "network", "t2", "k2"},
-				[]blobstore.Blob{
+				blobstore.Blobs{
 					{Type: "t1", Key: "k1", Value: []byte("hello"), Version: 42},
 					{Type: "t2", Key: "k2", Value: []byte("world"), Version: 43},
 				},
@@ -400,7 +400,7 @@ func TestSqlBlobStorage_CreateOrUpdate(t *testing.T) {
 		run: func(store blobstore.TransactionalBlobStorage) (interface{}, error) {
 			err := store.CreateOrUpdate(
 				"network",
-				[]blobstore.Blob{
+				blobstore.Blobs{
 					{Type: "t1", Key: "k1", Value: []byte("goodbye"), Version: 100},
 					{Type: "t2", Key: "k2", Value: []byte("foo"), Version: 0},
 				},
@@ -431,7 +431,7 @@ func TestSqlBlobStorage_CreateOrUpdate(t *testing.T) {
 		run: func(store blobstore.TransactionalBlobStorage) (interface{}, error) {
 			err := store.CreateOrUpdate(
 				"network",
-				[]blobstore.Blob{
+				blobstore.Blobs{
 					{Type: "t1", Key: "k1", Value: []byte("hello"), Version: 0},
 					{Type: "t2", Key: "k2", Value: []byte("world"), Version: 1000},
 				},
@@ -448,7 +448,7 @@ func TestSqlBlobStorage_CreateOrUpdate(t *testing.T) {
 			expectGetMany(
 				mock,
 				[]driver.Value{"network", "t1", "k1", "network", "t2", "k2"},
-				[]blobstore.Blob{
+				blobstore.Blobs{
 					{Type: "t1", Key: "k1", Value: []byte("hello"), Version: 42},
 				},
 			)
@@ -463,7 +463,7 @@ func TestSqlBlobStorage_CreateOrUpdate(t *testing.T) {
 		run: func(store blobstore.TransactionalBlobStorage) (interface{}, error) {
 			err := store.CreateOrUpdate(
 				"network",
-				[]blobstore.Blob{
+				blobstore.Blobs{
 					{Type: "t1", Key: "k1", Value: []byte("goodbye"), Version: 0},
 					{Type: "t2", Key: "k2", Value: []byte("world"), Version: 1000},
 				},
@@ -480,7 +480,7 @@ func TestSqlBlobStorage_CreateOrUpdate(t *testing.T) {
 			expectGetMany(
 				mock,
 				[]driver.Value{"network", "t1", "k1", "network", "t2", "k2"},
-				[]blobstore.Blob{
+				blobstore.Blobs{
 					{Type: "t1", Key: "k1", Value: []byte("hello"), Version: 42},
 				},
 			)
@@ -499,7 +499,7 @@ func TestSqlBlobStorage_CreateOrUpdate(t *testing.T) {
 		run: func(store blobstore.TransactionalBlobStorage) (interface{}, error) {
 			err := store.CreateOrUpdate(
 				"network",
-				[]blobstore.Blob{
+				blobstore.Blobs{
 					{Type: "t1", Key: "k1", Value: []byte("goodbye"), Version: 0},
 					{Type: "t2", Key: "k2", Value: []byte("world"), Version: 1000},
 				},
@@ -637,7 +637,7 @@ func expectCreateTable(mock sqlmock.Sqlmock) {
 	mock.ExpectCommit()
 }
 
-func expectGetMany(mock sqlmock.Sqlmock, args []driver.Value, blobs []blobstore.Blob) {
+func expectGetMany(mock sqlmock.Sqlmock, args []driver.Value, blobs blobstore.Blobs) {
 	rows := sqlmock.NewRows([]string{"type", "key", "value", "version"})
 	for _, blob := range blobs {
 		rows.AddRow(blob.Type, blob.Key, blob.Value, blob.Version)

--- a/orc8r/cloud/go/blobstore/storage.go
+++ b/orc8r/cloud/go/blobstore/storage.go
@@ -51,7 +51,7 @@ func (bs Blobs) ByTK() map[storage.TypeAndKey]Blob {
 	return ret
 }
 
-func (bs Blobs) GetKeys() []string {
+func (bs Blobs) Keys() []string {
 	var keys []string
 	for _, b := range bs {
 		keys = append(keys, b.Key)

--- a/orc8r/cloud/go/blobstore/storage.go
+++ b/orc8r/cloud/go/blobstore/storage.go
@@ -68,7 +68,6 @@ type BlobStorageFactory interface {
 // TransactionalBlobStorage is the client API for blob storage operations
 // within the context of a transaction.
 // TODO(4/9/2020): refactor Get-like methods into package-level defaults wrapping Search -- see e.g. ListKeysByNetwork
-// TODO(10/19/2020): refactor []Blob to Blobs in interface
 type TransactionalBlobStorage interface {
 	// Commit commits the existing transaction.
 	// If an error is returned from the backing storage while committing,
@@ -92,21 +91,21 @@ type TransactionalBlobStorage interface {
 	// specifiedIDs.
 	// If there is no blob corresponding to a TypeAndKey, the returned list
 	// will not have a corresponding Blob.
-	GetMany(networkID string, ids []storage.TypeAndKey) ([]Blob, error)
+	GetMany(networkID string, ids []storage.TypeAndKey) (Blobs, error)
 
 	// Search returns a filtered collection of blobs keyed by the network ID
 	// to which they belong.
 	// Blobs are filtered according to the search filter. Empty filter returns
 	// all blobs. Blobs contents are loaded according to the load criteria.
 	// Empty criteria loads all fields.
-	Search(filter SearchFilter, criteria LoadCriteria) (map[string][]Blob, error)
+	Search(filter SearchFilter, criteria LoadCriteria) (map[string]Blobs, error)
 
 	// CreateOrUpdate writes blobs to the storage.
 	// Blobs are either updated in-place or created. The Version field of
 	// blobs passed here will be used if it is not set to 0, otherwise version
 	// incrementation will be handled internally inside the storage
 	// implementation.
-	CreateOrUpdate(networkID string, blobs []Blob) error
+	CreateOrUpdate(networkID string, blobs Blobs) error
 
 	// GetExistingKeys takes in a list of keys and returns a list of keys that
 	// exist from the input.
@@ -123,7 +122,7 @@ type TransactionalBlobStorage interface {
 }
 
 // GetAllOfType returns all blobs in the network of the passed type.
-func GetAllOfType(store TransactionalBlobStorage, networkID, typ string) ([]Blob, error) {
+func GetAllOfType(store TransactionalBlobStorage, networkID, typ string) (Blobs, error) {
 	filter := CreateSearchFilter(nil, []string{typ}, nil, nil)
 	criteria := LoadCriteria{LoadValue: true}
 
@@ -147,7 +146,7 @@ func ListKeysByNetwork(store TransactionalBlobStorage) (map[string][]storage.Typ
 
 	tks := map[string][]storage.TypeAndKey{}
 	for network, blobs := range blobsByNetwork {
-		tks[network] = GetTKsFromBlobs(blobs)
+		tks[network] = blobs.TKs()
 	}
 
 	return tks, nil
@@ -217,30 +216,20 @@ type LoadCriteria struct {
 	LoadValue bool
 }
 
-// GetTKsFromBlobs converts blobs to their associated type and key.
-func GetTKsFromBlobs(blobs []Blob) []storage.TypeAndKey {
-	tks := make([]storage.TypeAndKey, 0, len(blobs))
-	for _, blob := range blobs {
+// TKs converts blobs to their associated type and key.
+func (bs Blobs) TKs() []storage.TypeAndKey {
+	tks := make([]storage.TypeAndKey, 0, len(bs))
+	for _, blob := range bs {
 		tks = append(tks, storage.TypeAndKey{Type: blob.Type, Key: blob.Key})
 	}
 	return tks
 }
 
-// GetTKsFromKeys returns the passed keys mapped as TypeAndKey, with the passed
-// type applied to each.
-func GetTKsFromKeys(typ string, keys []string) []storage.TypeAndKey {
-	tks := make([]storage.TypeAndKey, 0, len(keys))
-	for _, k := range keys {
-		tks = append(tks, storage.TypeAndKey{Type: typ, Key: k})
-	}
-	return tks
-}
-
-// GetBlobsByTypeAndKey returns a computed view of a list of blobs as a map of
+// ByTK returns a computed view of a list of blobs as a map of
 // blobs keyed by blob TypeAndKey.
-func GetBlobsByTypeAndKey(blobs []Blob) map[storage.TypeAndKey]Blob {
-	ret := make(map[storage.TypeAndKey]Blob, len(blobs))
-	for _, blob := range blobs {
+func (bs Blobs) ByTK() map[storage.TypeAndKey]Blob {
+	ret := make(map[storage.TypeAndKey]Blob, len(bs))
+	for _, blob := range bs {
 		ret[storage.TypeAndKey{Type: blob.Type, Key: blob.Key}] = blob
 	}
 	return ret

--- a/orc8r/cloud/go/blobstore/storage.go
+++ b/orc8r/cloud/go/blobstore/storage.go
@@ -32,6 +32,25 @@ type Blob struct {
 
 type Blobs []Blob
 
+// TKs converts blobs to their associated type and key.
+func (bs Blobs) TKs() []storage.TypeAndKey {
+	tks := make([]storage.TypeAndKey, 0, len(bs))
+	for _, blob := range bs {
+		tks = append(tks, storage.TypeAndKey{Type: blob.Type, Key: blob.Key})
+	}
+	return tks
+}
+
+// ByTK returns a computed view of a list of blobs as a map of
+// blobs keyed by blob TypeAndKey.
+func (bs Blobs) ByTK() map[storage.TypeAndKey]Blob {
+	ret := make(map[storage.TypeAndKey]Blob, len(bs))
+	for _, blob := range bs {
+		ret[storage.TypeAndKey{Type: blob.Type, Key: blob.Key}] = blob
+	}
+	return ret
+}
+
 func (bs Blobs) GetKeys() []string {
 	var keys []string
 	for _, b := range bs {
@@ -214,25 +233,6 @@ type LoadCriteria struct {
 	// LoadValue specifies whether to load the value of a blob.
 	// Set to false to only load blob metadata.
 	LoadValue bool
-}
-
-// TKs converts blobs to their associated type and key.
-func (bs Blobs) TKs() []storage.TypeAndKey {
-	tks := make([]storage.TypeAndKey, 0, len(bs))
-	for _, blob := range bs {
-		tks = append(tks, storage.TypeAndKey{Type: blob.Type, Key: blob.Key})
-	}
-	return tks
-}
-
-// ByTK returns a computed view of a list of blobs as a map of
-// blobs keyed by blob TypeAndKey.
-func (bs Blobs) ByTK() map[storage.TypeAndKey]Blob {
-	ret := make(map[storage.TypeAndKey]Blob, len(bs))
-	for _, blob := range bs {
-		ret[storage.TypeAndKey{Type: blob.Type, Key: blob.Key}] = blob
-	}
-	return ret
 }
 
 func stringListToSet(v []string) map[string]bool {

--- a/orc8r/cloud/go/services/accessd/storage/storage_blobstore_test.go
+++ b/orc8r/cloud/go/services/accessd/storage/storage_blobstore_test.go
@@ -66,7 +66,7 @@ func TestAccessdBlobstore_ListAllIdentity(t *testing.T) {
 		{Type: astorage.AccessdDefaultType, Key: idHashes[0]},
 		{Type: astorage.AccessdDefaultType, Key: idHashes[1]},
 	}
-	blobs := []blobstore.Blob{
+	blobs := blobstore.Blobs{
 		{Type: astorage.AccessdDefaultType, Key: idHashes[0], Value: marshaledACL0},
 		{Type: astorage.AccessdDefaultType, Key: idHashes[1], Value: marshaledACL1},
 	}
@@ -102,8 +102,6 @@ func TestAccessdBlobstore_ListAllIdentity(t *testing.T) {
 	blobFactMock.On("StartTransaction", mock.Anything).Return(blobStoreMock, nil).Once()
 	blobStoreMock.On("Rollback").Return(nil).Once()
 	blobStoreMock.On("ListKeys", mock.Anything, astorage.AccessdDefaultType).Return([]string{}, nil).Once()
-	blobStoreMock.On("GetMany", mock.Anything, []storage.TypeAndKey{}).
-		Return([]blobstore.Blob{}, nil).Once()
 	blobStoreMock.On("Commit").Return(nil).Once()
 	store = astorage.NewAccessdBlobstore(blobFactMock)
 
@@ -119,7 +117,7 @@ func TestAccessdBlobstore_ListAllIdentity(t *testing.T) {
 	blobFactMock.On("StartTransaction", mock.Anything).Return(blobStoreMock, nil).Once()
 	blobStoreMock.On("Rollback").Return(nil).Once()
 	blobStoreMock.On("ListKeys", mock.Anything, astorage.AccessdDefaultType).Return(idHashes, nil).Once()
-	blobStoreMock.On("GetMany", mock.Anything, tks).Return([]blobstore.Blob{}, someErr).Once()
+	blobStoreMock.On("GetMany", mock.Anything, tks).Return(blobstore.Blobs{}, someErr).Once()
 	store = astorage.NewAccessdBlobstore(blobFactMock)
 
 	_, err = store.ListAllIdentity()
@@ -161,7 +159,7 @@ func TestAccessdBlobstore_GetACL(t *testing.T) {
 	marshaledACL, err := proto.Marshal(acl)
 	assert.NoError(t, err)
 	tks := []storage.TypeAndKey{{Type: astorage.AccessdDefaultType, Key: idHash}}
-	blobs := []blobstore.Blob{{Type: astorage.AccessdDefaultType, Key: idHash, Value: marshaledACL}}
+	blobs := blobstore.Blobs{{Type: astorage.AccessdDefaultType, Key: idHash, Value: marshaledACL}}
 
 	// Fail to start transaction
 	blobFactMock = &mocks.BlobStorageFactory{}
@@ -192,7 +190,7 @@ func TestAccessdBlobstore_GetACL(t *testing.T) {
 	blobStoreMock = &mocks.TransactionalBlobStorage{}
 	blobFactMock.On("StartTransaction", mock.Anything).Return(blobStoreMock, nil).Once()
 	blobStoreMock.On("Rollback").Return(nil).Once()
-	blobStoreMock.On("GetMany", mock.Anything, tks).Return([]blobstore.Blob{}, nil).Once()
+	blobStoreMock.On("GetMany", mock.Anything, tks).Return(blobstore.Blobs{}, nil).Once()
 	blobStoreMock.On("Commit").Return(nil).Once()
 	store = astorage.NewAccessdBlobstore(blobFactMock)
 
@@ -207,7 +205,7 @@ func TestAccessdBlobstore_GetACL(t *testing.T) {
 	blobStoreMock = &mocks.TransactionalBlobStorage{}
 	blobFactMock.On("StartTransaction", mock.Anything).Return(blobStoreMock, nil).Once()
 	blobStoreMock.On("Rollback").Return(nil).Once()
-	blobStoreMock.On("GetMany", mock.Anything, tks).Return([]blobstore.Blob{}, someErr).Once()
+	blobStoreMock.On("GetMany", mock.Anything, tks).Return(blobstore.Blobs{}, someErr).Once()
 	store = astorage.NewAccessdBlobstore(blobFactMock)
 
 	_, err = store.GetACL(id)
@@ -266,7 +264,7 @@ func TestAccessdBlobstore_GetManyACL(t *testing.T) {
 		{Type: astorage.AccessdDefaultType, Key: idHashes[0]},
 		{Type: astorage.AccessdDefaultType, Key: idHashes[1]},
 	}
-	blobs := []blobstore.Blob{
+	blobs := blobstore.Blobs{
 		{Type: astorage.AccessdDefaultType, Key: idHashes[0], Value: marshaledACL0},
 		{Type: astorage.AccessdDefaultType, Key: idHashes[1], Value: marshaledACL1},
 	}
@@ -302,7 +300,7 @@ func TestAccessdBlobstore_GetManyACL(t *testing.T) {
 	blobStoreMock = &mocks.TransactionalBlobStorage{}
 	blobFactMock.On("StartTransaction", mock.Anything).Return(blobStoreMock, nil).Once()
 	blobStoreMock.On("Rollback").Return(nil).Once()
-	blobStoreMock.On("GetMany", mock.Anything, tks).Return([]blobstore.Blob{}, someErr).Once()
+	blobStoreMock.On("GetMany", mock.Anything, tks).Return(blobstore.Blobs{}, someErr).Once()
 	store = astorage.NewAccessdBlobstore(blobFactMock)
 
 	_, err = store.GetManyACL(ids)
@@ -315,7 +313,7 @@ func TestAccessdBlobstore_GetManyACL(t *testing.T) {
 	blobStoreMock = &mocks.TransactionalBlobStorage{}
 	blobFactMock.On("StartTransaction", mock.Anything).Return(blobStoreMock, nil).Once()
 	blobStoreMock.On("Rollback").Return(nil).Once()
-	blobStoreMock.On("GetMany", mock.Anything, tks).Return([]blobstore.Blob{}, nil).Once()
+	blobStoreMock.On("GetMany", mock.Anything, tks).Return(blobstore.Blobs{}, nil).Once()
 	blobStoreMock.On("Commit").Return(nil).Once()
 	store = astorage.NewAccessdBlobstore(blobFactMock)
 
@@ -356,7 +354,7 @@ func TestAccessdBlobstore_PutACL(t *testing.T) {
 
 	marshaledACL, err := proto.Marshal(acl)
 	assert.NoError(t, err)
-	blobs := []blobstore.Blob{{Type: astorage.AccessdDefaultType, Key: idHash, Value: marshaledACL}}
+	blobs := blobstore.Blobs{{Type: astorage.AccessdDefaultType, Key: idHash, Value: marshaledACL}}
 
 	// Call with nil id
 	blobFactMock = &mocks.BlobStorageFactory{}
@@ -437,8 +435,8 @@ func TestAccessdBlobstore_UpdateACLWithEntities(t *testing.T) {
 	marshaledACLFinal, err := proto.Marshal(aclFinal)
 	assert.NoError(t, err)
 	tk := storage.TypeAndKey{Type: astorage.AccessdDefaultType, Key: idHash}
-	blobsInitial := []blobstore.Blob{{Type: astorage.AccessdDefaultType, Key: idHash, Value: marshaledACLInitial}}
-	blobsFinal := []blobstore.Blob{{Type: astorage.AccessdDefaultType, Key: idHash, Value: marshaledACLFinal}}
+	blobsInitial := blobstore.Blobs{{Type: astorage.AccessdDefaultType, Key: idHash, Value: marshaledACLInitial}}
+	blobsFinal := blobstore.Blobs{{Type: astorage.AccessdDefaultType, Key: idHash, Value: marshaledACLFinal}}
 
 	// Fail to start transaction
 	blobFactMock = &mocks.BlobStorageFactory{}

--- a/orc8r/cloud/go/services/certifier/storage/storage_blobstore.go
+++ b/orc8r/cloud/go/services/certifier/storage/storage_blobstore.go
@@ -97,7 +97,7 @@ func (c *certifierBlobstore) GetManyCertInfo(serialNumbers []string) (map[string
 }
 
 func (c *certifierBlobstore) GetAllCertInfo() (map[string]*protos.CertificateInfo, error) {
-	infos := make(map[string]*protos.CertificateInfo)
+	infos := map[string]*protos.CertificateInfo{}
 
 	store, err := c.factory.StartTransaction(&storage.TxOptions{ReadOnly: true})
 	if err != nil {

--- a/orc8r/cloud/go/services/certifier/storage/storage_blobstore.go
+++ b/orc8r/cloud/go/services/certifier/storage/storage_blobstore.go
@@ -77,7 +77,7 @@ func (c *certifierBlobstore) GetManyCertInfo(serialNumbers []string) (map[string
 	}
 	defer store.Rollback()
 
-	tks := blobstore.GetTKsFromKeys(CertInfoType, serialNumbers)
+	tks := storage.MakeTKs(CertInfoType, serialNumbers)
 	blobs, err := store.GetMany(placeholderNetworkID, tks)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to get many certificate info")
@@ -97,6 +97,8 @@ func (c *certifierBlobstore) GetManyCertInfo(serialNumbers []string) (map[string
 }
 
 func (c *certifierBlobstore) GetAllCertInfo() (map[string]*protos.CertificateInfo, error) {
+	infos := make(map[string]*protos.CertificateInfo)
+
 	store, err := c.factory.StartTransaction(&storage.TxOptions{ReadOnly: true})
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to start transaction")
@@ -108,23 +110,26 @@ func (c *certifierBlobstore) GetAllCertInfo() (map[string]*protos.CertificateInf
 		return nil, errors.Wrap(err, "failed to list keys")
 	}
 
-	tks := blobstore.GetTKsFromKeys(CertInfoType, serialNumbers)
+	if len(serialNumbers) == 0 {
+		return infos, store.Commit()
+	}
+	
+	tks := storage.MakeTKs(CertInfoType, serialNumbers)
 	blobs, err := store.GetMany(placeholderNetworkID, tks)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to get many certificate info")
 	}
 
-	ret := make(map[string]*protos.CertificateInfo)
 	for _, blob := range blobs {
 		info := &protos.CertificateInfo{}
 		err = proto.Unmarshal(blob.Value, info)
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to unmarshal cert info")
 		}
-		ret[blob.Key] = info
+		infos[blob.Key] = info
 	}
 
-	return ret, store.Commit()
+	return infos, store.Commit()
 }
 
 func (c *certifierBlobstore) PutCertInfo(serialNumber string, certInfo *protos.CertificateInfo) error {
@@ -140,7 +145,7 @@ func (c *certifierBlobstore) PutCertInfo(serialNumber string, certInfo *protos.C
 	}
 
 	blob := blobstore.Blob{Type: CertInfoType, Key: serialNumber, Value: marshaledCertInfo}
-	err = store.CreateOrUpdate(placeholderNetworkID, []blobstore.Blob{blob})
+	err = store.CreateOrUpdate(placeholderNetworkID, blobstore.Blobs{blob})
 	if err != nil {
 		return errors.Wrap(err, "failed to put certificate info")
 	}

--- a/orc8r/cloud/go/services/certifier/storage/storage_blobstore_test.go
+++ b/orc8r/cloud/go/services/certifier/storage/storage_blobstore_test.go
@@ -45,7 +45,7 @@ func TestCertifierBlobstore_GetCertInfo(t *testing.T) {
 	marshaledInfo, err := proto.Marshal(info)
 	assert.NoError(t, err)
 	tks := []storage.TypeAndKey{{Type: cstorage.CertInfoType, Key: serialNumber}}
-	blobs := []blobstore.Blob{{Type: cstorage.CertInfoType, Key: serialNumber, Value: marshaledInfo}}
+	blobs := blobstore.Blobs{{Type: cstorage.CertInfoType, Key: serialNumber, Value: marshaledInfo}}
 
 	// Fail to start transaction
 	blobFactMock = &mocks.BlobStorageFactory{}
@@ -63,7 +63,7 @@ func TestCertifierBlobstore_GetCertInfo(t *testing.T) {
 	blobStoreMock = &mocks.TransactionalBlobStorage{}
 	blobFactMock.On("StartTransaction", mock.Anything).Return(blobStoreMock, nil).Once()
 	blobStoreMock.On("Rollback").Return(nil).Once()
-	blobStoreMock.On("GetMany", mock.Anything, tks).Return([]blobstore.Blob{}, nil).Once()
+	blobStoreMock.On("GetMany", mock.Anything, tks).Return(blobstore.Blobs{}, nil).Once()
 	blobStoreMock.On("Commit").Return(nil).Once()
 	store = cstorage.NewCertifierBlobstore(blobFactMock)
 
@@ -77,7 +77,7 @@ func TestCertifierBlobstore_GetCertInfo(t *testing.T) {
 	blobStoreMock = &mocks.TransactionalBlobStorage{}
 	blobFactMock.On("StartTransaction", mock.Anything).Return(blobStoreMock, nil).Once()
 	blobStoreMock.On("Rollback").Return(nil).Once()
-	blobStoreMock.On("GetMany", mock.Anything, tks).Return([]blobstore.Blob{}, someErr).Once()
+	blobStoreMock.On("GetMany", mock.Anything, tks).Return(blobstore.Blobs{}, someErr).Once()
 	store = cstorage.NewCertifierBlobstore(blobFactMock)
 
 	_, err = store.GetCertInfo(serialNumber)
@@ -129,7 +129,7 @@ func TestCertifierBlobstore_GetManyCertInfo(t *testing.T) {
 		{Type: cstorage.CertInfoType, Key: serialNumbers[0]},
 		{Type: cstorage.CertInfoType, Key: serialNumbers[1]},
 	}
-	blobs := []blobstore.Blob{
+	blobs := blobstore.Blobs{
 		{Type: cstorage.CertInfoType, Key: serialNumbers[0], Value: marshaledInfo0},
 		{Type: cstorage.CertInfoType, Key: serialNumbers[1], Value: marshaledInfo1},
 	}
@@ -154,7 +154,7 @@ func TestCertifierBlobstore_GetManyCertInfo(t *testing.T) {
 	blobStoreMock = &mocks.TransactionalBlobStorage{}
 	blobFactMock.On("StartTransaction", mock.Anything).Return(blobStoreMock, nil).Once()
 	blobStoreMock.On("Rollback").Return(nil).Once()
-	blobStoreMock.On("GetMany", mock.Anything, tks).Return([]blobstore.Blob{}, someErr).Once()
+	blobStoreMock.On("GetMany", mock.Anything, tks).Return(blobstore.Blobs{}, someErr).Once()
 	store = cstorage.NewCertifierBlobstore(blobFactMock)
 
 	_, err = store.GetManyCertInfo(serialNumbers)
@@ -167,7 +167,7 @@ func TestCertifierBlobstore_GetManyCertInfo(t *testing.T) {
 	blobStoreMock = &mocks.TransactionalBlobStorage{}
 	blobFactMock.On("StartTransaction", mock.Anything).Return(blobStoreMock, nil).Once()
 	blobStoreMock.On("Rollback").Return(nil).Once()
-	blobStoreMock.On("GetMany", mock.Anything, tks).Return([]blobstore.Blob{}, nil).Once()
+	blobStoreMock.On("GetMany", mock.Anything, tks).Return(blobstore.Blobs{}, nil).Once()
 	blobStoreMock.On("Commit").Return(nil).Once()
 	store = cstorage.NewCertifierBlobstore(blobFactMock)
 
@@ -224,7 +224,7 @@ func TestCertifierBlobstore_GetAllCertInfo(t *testing.T) {
 		{Type: cstorage.CertInfoType, Key: serialNumbers[0]},
 		{Type: cstorage.CertInfoType, Key: serialNumbers[1]},
 	}
-	blobs := []blobstore.Blob{
+	blobs := blobstore.Blobs{
 		{Type: cstorage.CertInfoType, Key: serialNumbers[0], Value: marshaledInfo0},
 		{Type: cstorage.CertInfoType, Key: serialNumbers[1], Value: marshaledInfo1},
 	}
@@ -264,7 +264,6 @@ func TestCertifierBlobstore_GetAllCertInfo(t *testing.T) {
 	blobFactMock.On("StartTransaction", mock.Anything).Return(blobStoreMock, nil).Once()
 	blobStoreMock.On("Rollback").Return(nil).Once()
 	blobStoreMock.On("ListKeys", mock.Anything, cstorage.CertInfoType).Return([]string{}, nil).Once()
-	blobStoreMock.On("GetMany", mock.Anything, []storage.TypeAndKey{}).Return([]blobstore.Blob{}, nil).Once()
 	blobStoreMock.On("Commit").Return(nil).Once()
 	store = cstorage.NewCertifierBlobstore(blobFactMock)
 
@@ -280,7 +279,7 @@ func TestCertifierBlobstore_GetAllCertInfo(t *testing.T) {
 	blobFactMock.On("StartTransaction", mock.Anything).Return(blobStoreMock, nil).Once()
 	blobStoreMock.On("Rollback").Return(nil).Once()
 	blobStoreMock.On("ListKeys", mock.Anything, cstorage.CertInfoType).Return(serialNumbers, nil).Once()
-	blobStoreMock.On("GetMany", mock.Anything, tks).Return([]blobstore.Blob{}, someErr).Once()
+	blobStoreMock.On("GetMany", mock.Anything, tks).Return(blobstore.Blobs{}, someErr).Once()
 	store = cstorage.NewCertifierBlobstore(blobFactMock)
 
 	_, err = store.GetAllCertInfo()
@@ -341,7 +340,7 @@ func TestCertifierBlobstore_PutCertInfo(t *testing.T) {
 	blobStoreMock = &mocks.TransactionalBlobStorage{}
 	blobFactMock.On("StartTransaction", mock.Anything).Return(blobStoreMock, nil).Once()
 	blobStoreMock.On("Rollback").Return(nil).Once()
-	blobStoreMock.On("CreateOrUpdate", mock.Anything, []blobstore.Blob{blob}).Return(someErr).Once()
+	blobStoreMock.On("CreateOrUpdate", mock.Anything, blobstore.Blobs{blob}).Return(someErr).Once()
 	store = cstorage.NewCertifierBlobstore(blobFactMock)
 
 	err = store.PutCertInfo(serialNumber, info)
@@ -353,7 +352,7 @@ func TestCertifierBlobstore_PutCertInfo(t *testing.T) {
 	blobStoreMock = &mocks.TransactionalBlobStorage{}
 	blobFactMock.On("StartTransaction", mock.Anything).Return(blobStoreMock, nil).Once()
 	blobStoreMock.On("Rollback").Return(nil).Once()
-	blobStoreMock.On("CreateOrUpdate", mock.Anything, []blobstore.Blob{blob}).
+	blobStoreMock.On("CreateOrUpdate", mock.Anything, blobstore.Blobs{blob}).
 		Return(nil).Once()
 	blobStoreMock.On("Commit").Return(nil).Once()
 	store = cstorage.NewCertifierBlobstore(blobFactMock)

--- a/orc8r/cloud/go/services/ctraced/storage/storage_blobstore.go
+++ b/orc8r/cloud/go/services/ctraced/storage/storage_blobstore.go
@@ -51,7 +51,7 @@ func (c *ctracedBlobStore) StoreCallTrace(networkID string, callTraceID string, 
 
 	err = store.CreateOrUpdate(
 		networkID,
-		[]blobstore.Blob{
+		blobstore.Blobs{
 			blobstore.Blob{Type: CtracedBlobType, Key: callTraceID, Value: data, Version: 0},
 		},
 	)

--- a/orc8r/cloud/go/services/ctraced/storage/storage_blobstore_test.go
+++ b/orc8r/cloud/go/services/ctraced/storage/storage_blobstore_test.go
@@ -144,7 +144,7 @@ func TestCtracedBlobstoreStorage_StoreCallTrace(t *testing.T) {
 	blobStoreMock = &mocks.TransactionalBlobStorage{}
 	blobFactMock.On("StartTransaction", mock.Anything).Return(blobStoreMock, nil).Once()
 	blobStoreMock.On("Rollback").Return(nil).Once()
-	blobStoreMock.On("CreateOrUpdate", placeholderNetworkID, []blobstore.Blob{blob}).
+	blobStoreMock.On("CreateOrUpdate", placeholderNetworkID, blobstore.Blobs{blob}).
 		Return(nil).Once()
 	blobStoreMock.On("Commit").Return(nil).Once()
 	store = cstorage.NewCtracedBlobstore(blobFactMock)

--- a/orc8r/cloud/go/services/device/protos/device_helper.go
+++ b/orc8r/cloud/go/services/device/protos/device_helper.go
@@ -39,7 +39,7 @@ func DeviceIDsToTypeAndKey(deviceIDs []*DeviceID) []storage.TypeAndKey {
 }
 
 // BlobsToEntityByDeviceID maps a list of blobstore.Blob to map[deviceID]PhysicalEntity
-func BlobsToEntityByDeviceID(entities []blobstore.Blob) map[string]*PhysicalEntity {
+func BlobsToEntityByDeviceID(entities blobstore.Blobs) map[string]*PhysicalEntity {
 	ret := map[string]*PhysicalEntity{}
 	for _, blob := range entities {
 		ret[blob.Key] = blobToEntity(blob)

--- a/orc8r/cloud/go/services/device/servicers/device.go
+++ b/orc8r/cloud/go/services/device/servicers/device.go
@@ -45,7 +45,7 @@ func (srv *deviceServicer) RegisterDevices(ctx context.Context, req *protos.Regi
 	defer store.Rollback()
 
 	blobs := protos.EntitiesToBlobs(req.GetEntities())
-	existingKeys, err := store.GetExistingKeys(blobs.GetKeys(), blobstore.SearchFilter{})
+	existingKeys, err := store.GetExistingKeys(blobs.Keys(), blobstore.SearchFilter{})
 	if err != nil {
 		return nil, err
 	}

--- a/orc8r/cloud/go/services/directoryd/storage/storage_blobstore.go
+++ b/orc8r/cloud/go/services/directoryd/storage/storage_blobstore.go
@@ -122,8 +122,8 @@ func (d *directorydBlobstore) MapSessionIDsToIMSIs(networkID string, sessionIDTo
 }
 
 // convertKVToBlobs deterministically converts a string-string map to blobstore blobs.
-func convertKVToBlobs(typ string, kv map[string]string) []blobstore.Blob {
-	var blobs []blobstore.Blob
+func convertKVToBlobs(typ string, kv map[string]string) blobstore.Blobs {
+	var blobs blobstore.Blobs
 	for k, v := range kv {
 		blobs = append(blobs, blobstore.Blob{Type: typ, Key: k, Value: []byte(v)})
 	}

--- a/orc8r/cloud/go/services/directoryd/storage/storage_blobstore_test.go
+++ b/orc8r/cloud/go/services/directoryd/storage/storage_blobstore_test.go
@@ -116,7 +116,7 @@ func TestDirectorydBlobstoreStorage_MapHWIDToHostname(t *testing.T) {
 		{Type: dstorage.DirectorydTypeHWIDToHostname, Key: hwids[1]},
 	}
 
-	blobs := []blobstore.Blob{
+	blobs := blobstore.Blobs{
 		{
 			Type:  tks[0].Type,
 			Key:   tks[0].Key,
@@ -259,7 +259,7 @@ func TestDirectorydBlobstore_MapSessionIDToIMSI(t *testing.T) {
 		{Type: dstorage.DirectorydTypeSessionIDToIMSI, Key: sids[1]},
 	}
 
-	blobs := []blobstore.Blob{
+	blobs := blobstore.Blobs{
 		{
 			Type:  tks[0].Type,
 			Key:   tks[0].Key,

--- a/orc8r/cloud/go/services/state/indexer/reindex/store.go
+++ b/orc8r/cloud/go/services/state/indexer/reindex/store.go
@@ -59,7 +59,7 @@ func (s *storeImpl) GetAllIDs() (state_types.IDsByNetwork, error) {
 	return ids, nil
 }
 
-func blobsToIDs(byNetwork map[string][]blobstore.Blob) state_types.IDsByNetwork {
+func blobsToIDs(byNetwork map[string]blobstore.Blobs) state_types.IDsByNetwork {
 	ids := state_types.IDsByNetwork{}
 	for network, blobs := range byNetwork {
 		for _, b := range blobs {

--- a/orc8r/cloud/go/services/state/indexer/reindex/store_test.go
+++ b/orc8r/cloud/go/services/state/indexer/reindex/store_test.go
@@ -26,7 +26,7 @@ import (
 )
 
 func TestIndexerServicer_GetAllIDs(t *testing.T) {
-	blobs := map[string][]blobstore.Blob{
+	blobs := map[string]blobstore.Blobs{
 		"nid0": {{Type: "typeA", Key: "keyA"}},
 		"nid1": {{Type: "typeB", Key: "keyB"}},
 	}

--- a/orc8r/cloud/go/services/state/servicers/servicer.go
+++ b/orc8r/cloud/go/services/state/servicers/servicer.go
@@ -268,8 +268,8 @@ func wrapStateWithAdditionalInfo(st *protos.State, hwID string, time uint64, cer
 	return ret, nil
 }
 
-func addWrapperAndMakeBlobs(states []*protos.State, hwID string, timeMs uint64, certExpiry int64) ([]blobstore.Blob, error) {
-	var blobs []blobstore.Blob
+func addWrapperAndMakeBlobs(states []*protos.State, hwID string, timeMs uint64, certExpiry int64) (blobstore.Blobs, error) {
+	var blobs blobstore.Blobs
 	for _, st := range states {
 		wrappedValue, err := wrapStateWithAdditionalInfo(st, hwID, timeMs, certExpiry)
 		if err != nil {
@@ -301,7 +301,7 @@ func idAndVersionsToTKs(IDs []*protos.IDAndVersion) []storage.TypeAndKey {
 	return ids
 }
 
-func blobsToStates(blobs []blobstore.Blob) []*protos.State {
+func blobsToStates(blobs blobstore.Blobs) []*protos.State {
 	var states []*protos.State
 	for _, b := range blobs {
 		st := &protos.State{

--- a/orc8r/cloud/go/services/state/servicers/servicer_test.go
+++ b/orc8r/cloud/go/services/state/servicers/servicer_test.go
@@ -41,14 +41,14 @@ func TestStateServicer_GetStates(t *testing.T) {
 		blobstore.CreateSearchFilter(strPtr("network1"), []string{"t1", "t2"}, []string{"k1", "k2"}, nil),
 		blobstore.GetDefaultLoadCriteria(),
 	).
-		Return(map[string][]blobstore.Blob{
+		Return(map[string]blobstore.Blobs{
 			"network1": {
 				{Type: "t1", Key: "k1", Value: []byte("v1"), Version: 42},
 				{Type: "t2", Key: "k2", Value: []byte("v2"), Version: 43},
 			},
 		}, nil)
 	mockStore.On("GetMany", "network1", []storage.TypeAndKey{{Type: "t1", Key: "k1"}, {Type: "t2", Key: "k2"}}).
-		Return([]blobstore.Blob{
+		Return(blobstore.Blobs{
 			{Type: "t1", Key: "k1", Value: []byte("v1"), Version: 42},
 			{Type: "t2", Key: "k2", Value: []byte("v2"), Version: 43},
 		}, nil)

--- a/orc8r/cloud/go/services/tenants/servicers/storage/storage.go
+++ b/orc8r/cloud/go/services/tenants/servicers/storage/storage.go
@@ -38,7 +38,7 @@ func (b *blobstoreStore) CreateTenant(tenantID int64, tenant protos.Tenant) erro
 	defer store.Rollback()
 
 	tenantBlob, err := tenantToBlob(tenantID, tenant)
-	err = store.CreateOrUpdate(networkWildcard, []blobstore.Blob{tenantBlob})
+	err = store.CreateOrUpdate(networkWildcard, blobstore.Blobs{tenantBlob})
 	if err != nil {
 		return err
 	}
@@ -119,7 +119,7 @@ func (b *blobstoreStore) SetTenant(tenantID int64, tenant protos.Tenant) error {
 	if err != nil {
 		return err
 	}
-	err = store.CreateOrUpdate(networkWildcard, []blobstore.Blob{tenantBlob})
+	err = store.CreateOrUpdate(networkWildcard, blobstore.Blobs{tenantBlob})
 	if err != nil {
 		return err
 	}

--- a/orc8r/cloud/go/services/tenants/servicers/storage/storage_test.go
+++ b/orc8r/cloud/go/services/tenants/servicers/storage/storage_test.go
@@ -43,12 +43,12 @@ func setupTestStore() (*mocks.TransactionalBlobStorage, Store) {
 
 func TestBlobstoreStore_CreateTenant(t *testing.T) {
 	txStore, s := setupTestStore()
-	txStore.On("CreateOrUpdate", networkWildcard, []blobstore.Blob{sampleTenant0Blob}).Return(nil)
+	txStore.On("CreateOrUpdate", networkWildcard, blobstore.Blobs{sampleTenant0Blob}).Return(nil)
 	err := s.CreateTenant(0, sampleTenant0)
 	assert.NoError(t, err)
 
 	txStore, s = setupTestStore()
-	txStore.On("CreateOrUpdate", networkWildcard, []blobstore.Blob{sampleTenant0Blob}).Return(errors.New("error"))
+	txStore.On("CreateOrUpdate", networkWildcard, blobstore.Blobs{sampleTenant0Blob}).Return(errors.New("error"))
 	err = s.CreateTenant(0, sampleTenant0)
 	assert.EqualError(t, err, "error")
 }
@@ -78,7 +78,7 @@ func TestBlobstoreStore_GetAllTenants(t *testing.T) {
 			Type: tenants.TenantInfoType,
 			Key:  "1",
 		},
-	}).Return([]blobstore.Blob{sampleTenant0Blob, sampleTenant1Blob}, nil)
+	}).Return(blobstore.Blobs{sampleTenant0Blob, sampleTenant1Blob}, nil)
 
 	retTenants, err := s.GetAllTenants()
 	assert.NoError(t, err)
@@ -101,7 +101,7 @@ func TestBlobstoreStore_GetAllTenants(t *testing.T) {
 			Type: tenants.TenantInfoType,
 			Key:  "0",
 		},
-	}).Return([]blobstore.Blob{}, errors.New("error"))
+	}).Return(blobstore.Blobs{}, errors.New("error"))
 	retTenants, err = s.GetAllTenants()
 	assert.EqualError(t, err, "error")
 
@@ -113,7 +113,7 @@ func TestBlobstoreStore_GetAllTenants(t *testing.T) {
 			Type: tenants.TenantInfoType,
 			Key:  "0",
 		},
-	}).Return([]blobstore.Blob{invalidBlob}, nil)
+	}).Return(blobstore.Blobs{invalidBlob}, nil)
 	retTenants, err = s.GetAllTenants()
 	assert.EqualError(t, err, `non-integer key: strconv.ParseInt: parsing "word": invalid syntax`)
 
@@ -121,12 +121,12 @@ func TestBlobstoreStore_GetAllTenants(t *testing.T) {
 
 func TestBlobstoreStore_SetTenant(t *testing.T) {
 	txStore, s := setupTestStore()
-	txStore.On("CreateOrUpdate", networkWildcard, []blobstore.Blob{sampleTenant0Blob}).Return(nil)
+	txStore.On("CreateOrUpdate", networkWildcard, blobstore.Blobs{sampleTenant0Blob}).Return(nil)
 	err := s.SetTenant(0, sampleTenant0)
 	assert.NoError(t, err)
 
 	txStore, s = setupTestStore()
-	txStore.On("CreateOrUpdate", networkWildcard, []blobstore.Blob{sampleTenant0Blob}).Return(errors.New("error"))
+	txStore.On("CreateOrUpdate", networkWildcard, blobstore.Blobs{sampleTenant0Blob}).Return(errors.New("error"))
 	err = s.SetTenant(0, sampleTenant0)
 	assert.EqualError(t, err, "error")
 }


### PR DESCRIPTION
<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary
This PR is the preferred version of the PR made at #4344 due to complicated git history on the prior.
There has been an outstanding TO:DO to replace the usage of []Blob to Blobs according to the type alias defined in
orc8r/cloud/go/blobstore/storage.go. This PR merely refactors all using instances of []Blob to now follow the type alias Blobs as a means of improving readability.
<!-- Enumerate changes you made and why you made them -->

## Test Plan
cd $MAGMA_ROOT/orc8r/cloud/docker && ./build.py -t
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
