### PR TITLE
[AGW][SubscriberDb] Limit subscriberdb grpc server to 1 worker

### DIFF
--- a/lte/gateway/python/magma/subscriberdb/main.py
+++ b/lte/gateway/python/magma/subscriberdb/main.py
@@ -28,7 +28,9 @@ from lte.protos.mconfig import mconfigs_pb2
 
 def main():
     """ main() for subscriberdb """
-    service = MagmaService('subscriberdb', mconfigs_pb2.SubscriberDB())
+    service = MagmaService('subscriberdb',
+                           mconfigs_pb2.SubscriberDB(),
+                           workers=1)
 
     # Initialize a store to keep all subscriber data.
     store = SqliteStore(service.config['db_path'], loop=service.loop)

--- a/orc8r/gateway/python/magma/common/service.py
+++ b/orc8r/gateway/python/magma/common/service.py
@@ -59,7 +59,7 @@ class MagmaService(Service303Servicer):
     entities to interact with the service.
     """
 
-    def __init__(self, name, empty_mconfig, loop=None):
+    def __init__(self, name, empty_mconfig, loop=None, workers=None):
         self._name = name
         self._port = 0
         self._get_status_callback = None
@@ -89,6 +89,9 @@ class MagmaService(Service303Servicer):
         self._loop = loop
         self._start_time = int(time.time())
         self._register_signal_handlers()
+
+        if workers is None:
+            workers = 10
 
         # Load the service config if present
         self._config = None
@@ -122,7 +125,7 @@ class MagmaService(Service303Servicer):
         except pkg_resources.ResolutionError as e:
             logging.info(e)
 
-        self._server = grpc.server(futures.ThreadPoolExecutor(max_workers=10))
+        self._server = grpc.server(futures.ThreadPoolExecutor(max_workers=workers))
         add_Service303Servicer_to_server(self, self._server)
 
     @property


### PR DESCRIPTION
Signed-off-by: Tariq Al-Khasib <talkhasib@fb.com>
## Summary
We are getting 
sqlite3.OperationalError: database table is locked
with high UE attach rate 

This PR limits the number of grpc server workers to 1 for the subscriberdb service
This should remove any concurrent access to sqlite

## Test Plan
Integtest with high attach rate
