### PR TITLE
[lte][agw] Adding mtr_interface config value to pipelined.yml_prod

### DIFF
--- a/lte/gateway/configs/pipelined.yml
+++ b/lte/gateway/configs/pipelined.yml
@@ -130,8 +130,7 @@ redis_enabled: true
 # Logs grpc payload content
 magma_print_grpc_payload: false
 
-# MTR iface IP
-mtr_ip: 10.1.0.1
+# MTR iface
 mtr_interface: mtr0
 
 ###############

--- a/lte/gateway/configs/pipelined.yml_prod
+++ b/lte/gateway/configs/pipelined.yml_prod
@@ -128,6 +128,10 @@ redis_enabled: true
 # Logs grpc payload content
 magma_print_grpc_payload: false
 
+# MTR iface IP
+mtr_ip: 10.1.0.1
+mtr_interface: mtr0
+
 ###############
 ## IMPORTANT ##
 ###############

--- a/lte/gateway/configs/pipelined.yml_prod
+++ b/lte/gateway/configs/pipelined.yml_prod
@@ -128,8 +128,7 @@ redis_enabled: true
 # Logs grpc payload content
 magma_print_grpc_payload: false
 
-# MTR iface IP
-mtr_ip: 10.1.0.1
+# MTR iface
 mtr_interface: mtr0
 
 ###############

--- a/lte/gateway/python/magma/pipelined/main.py
+++ b/lte/gateway/python/magma/pipelined/main.py
@@ -25,7 +25,7 @@ from ryu.base.app_manager import AppManager
 from scapy.arch import get_if_hwaddr
 from ryu.ofproto.ofproto_v1_4 import OFPP_LOCAL
 
-from magma.common.misc_utils import call_process
+from magma.common.misc_utils import call_process, get_ip_from_if
 from magma.common.service import MagmaService
 from magma.configuration import environment
 from magma.pipelined.app import of_rest_server
@@ -94,6 +94,13 @@ def main():
         he_enabled_flag = service.mconfig.he_config.enable_header_enrichment
     he_enabled = service.config.get('he_enabled', he_enabled_flag)
     service.config['he_enabled'] = he_enabled
+
+    # monitoring related configuration
+    mtr_ip = None
+    mtr_interface = service.config.get('mtr_interface', None)
+    if mtr_interface:
+        mtr_ip = get_ip_from_if(mtr_interface)
+    service.config['mtr_ip'] = mtr_ip
 
     # Load the ryu apps
     service_manager = ServiceManager(service)


### PR DESCRIPTION
Signed-off-by: Alex Rodriguez <ardzoht@gmail.com>

## Summary

- pipelined.yml_prod is missing config values for mtr interface and ip, this PR adds these values to match with pipelined.yml file

## Test Plan

- sanity bringing up magma VM and make integ_test

## Additional Information

- [ ] This change is backwards-breaking
