### PR TITLE
[orc8r] Remove MemoryBlobStorage

### DIFF
--- a/cwf/gateway/integ_tests/hssless_test.go
+++ b/cwf/gateway/integ_tests/hssless_test.go
@@ -105,7 +105,7 @@ func setupHssLessTestEnv(t *testing.T) (*servicers.UESimServerHssLess, error) {
 
 	registry.AddService("SESSIOND", "127.0.0.1", 50065)
 
-	store := test_utils.NewSQLBlobstore(t, "blobstore_hss_table")
+	store := test_utils.NewSQLBlobstore(t, "hssless_test_blobstore")
 	server, err := servicers.NewUESimServerHssLess(store)
 	return server, err
 }

--- a/cwf/gateway/integ_tests/hssless_test.go
+++ b/cwf/gateway/integ_tests/hssless_test.go
@@ -23,7 +23,7 @@ import (
 	"magma/cwf/gateway/registry"
 	fegprotos "magma/feg/cloud/go/protos"
 	"magma/lte/cloud/go/services/policydb/obsidian/models"
-	"magma/orc8r/cloud/go/blobstore"
+	"magma/orc8r/cloud/go/test_utils"
 
 	"magma/cwf/gateway/services/uesim/servicers"
 
@@ -40,7 +40,7 @@ const (
 func TestHsslessAuthenticateUe(t *testing.T) {
 	fmt.Println("\nRunning TestAuthenticateUe HSSLess...")
 
-	ueSimServer, err := setupHssLessTestEnv()
+	ueSimServer, err := setupHssLessTestEnv(t)
 	assert.NoError(t, err)
 
 	tr := NewTestRunner(t)
@@ -101,11 +101,11 @@ func TestHsslessAuthenticateUe(t *testing.T) {
 
 }
 
-func setupHssLessTestEnv() (*servicers.UESimServerHssLess, error) {
+func setupHssLessTestEnv(t *testing.T) (*servicers.UESimServerHssLess, error) {
 
 	registry.AddService("SESSIOND", "127.0.0.1", 50065)
 
-	store := blobstore.NewMemoryBlobStorageFactory()
+	store := test_utils.NewSQLBlobstore(t, "blobstore_hss_table")
 	server, err := servicers.NewUESimServerHssLess(store)
 	return server, err
 }

--- a/cwf/gateway/services/uesim/servicers/eap_aka_test.go
+++ b/cwf/gateway/services/uesim/servicers/eap_aka_test.go
@@ -41,7 +41,7 @@ const (
 )
 
 func TestEapAkaIdentityRequest(t *testing.T) {
-	server, ue, err := setupTest()
+	server, ue, err := setupTest(t)
 	assert.NoError(t, err)
 
 	res, err := server.HandleEap(ue, eap.Packet(EapAkaIdentityRequestPacket))
@@ -56,7 +56,7 @@ func TestEapAkaIdentityRequest(t *testing.T) {
 }
 
 func TestEapAkaChallengeRequest(t *testing.T) {
-	server, ue, err := setupTest()
+		server, ue, err := setupTest(t)
 	assert.NoError(t, err)
 
 	res, err := server.HandleEap(ue, eap.Packet(EapAkaChallengeRequestPacket))

--- a/cwf/gateway/services/uesim/servicers/eap_aka_test.go
+++ b/cwf/gateway/services/uesim/servicers/eap_aka_test.go
@@ -56,7 +56,7 @@ func TestEapAkaIdentityRequest(t *testing.T) {
 }
 
 func TestEapAkaChallengeRequest(t *testing.T) {
-		server, ue, err := setupTest(t)
+	server, ue, err := setupTest(t)
 	assert.NoError(t, err)
 
 	res, err := server.HandleEap(ue, eap.Packet(EapAkaChallengeRequestPacket))

--- a/cwf/gateway/services/uesim/servicers/eap_test.go
+++ b/cwf/gateway/services/uesim/servicers/eap_test.go
@@ -15,6 +15,7 @@ package servicers_test
 
 import (
 	"context"
+	"magma/orc8r/cloud/go/test_utils"
 	"reflect"
 	"testing"
 
@@ -22,7 +23,6 @@ import (
 	"magma/cwf/gateway/services/uesim/servicers"
 	fegprotos "magma/feg/gateway/services/aaa/protos"
 	"magma/feg/gateway/services/eap"
-	"magma/orc8r/cloud/go/blobstore"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -40,8 +40,8 @@ const (
 	Seq  = 31
 )
 
-func setupTest() (*servicers.UESimServer, *cwfprotos.UEConfig, error) {
-	store := blobstore.NewMemoryBlobStorageFactory()
+func setupTest(t *testing.T) (*servicers.UESimServer, *cwfprotos.UEConfig, error) {
+	store := test_utils.NewSQLBlobstore(t, "blobstore_uesim_table")
 
 	server, err := servicers.NewUESimServer(store)
 	if err != nil {
@@ -54,7 +54,7 @@ func setupTest() (*servicers.UESimServer, *cwfprotos.UEConfig, error) {
 }
 
 func TestEapIdentityRequest(t *testing.T) {
-	server, ue, err := setupTest()
+	server, ue, err := setupTest(t)
 	assert.NoError(t, err)
 
 	res, err := server.HandleEap(ue, eap.Packet(EapIdentityRequestPacket))
@@ -69,7 +69,7 @@ func TestEapIdentityRequest(t *testing.T) {
 }
 
 func TestInvalidEapPacket(t *testing.T) {
-	server, ue, err := setupTest()
+	server, ue, err := setupTest(t)
 	assert.NoError(t, err)
 
 	// Make packet and set its length to zero.
@@ -82,7 +82,7 @@ func TestInvalidEapPacket(t *testing.T) {
 }
 
 func TestUnsupportedEapType(t *testing.T) {
-	server, ue, err := setupTest()
+	server, ue, err := setupTest(t)
 	assert.NoError(t, err)
 
 	// Make packet and set its type to an unsupported type.

--- a/cwf/gateway/services/uesim/servicers/eap_test.go
+++ b/cwf/gateway/services/uesim/servicers/eap_test.go
@@ -15,7 +15,6 @@ package servicers_test
 
 import (
 	"context"
-	"magma/orc8r/cloud/go/test_utils"
 	"reflect"
 	"testing"
 
@@ -23,6 +22,7 @@ import (
 	"magma/cwf/gateway/services/uesim/servicers"
 	fegprotos "magma/feg/gateway/services/aaa/protos"
 	"magma/feg/gateway/services/eap"
+	"magma/orc8r/cloud/go/test_utils"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -41,7 +41,7 @@ const (
 )
 
 func setupTest(t *testing.T) (*servicers.UESimServer, *cwfprotos.UEConfig, error) {
-	store := test_utils.NewSQLBlobstore(t, "blobstore_uesim_table")
+	store := test_utils.NewSQLBlobstore(t, "useim_eap_test_blobstore")
 
 	server, err := servicers.NewUESimServer(store)
 	if err != nil {

--- a/cwf/gateway/services/uesim/servicers/radius_test.go
+++ b/cwf/gateway/services/uesim/servicers/radius_test.go
@@ -53,7 +53,7 @@ const (
 )
 
 func TestRadius(t *testing.T) {
-	server, _, err := setupTest()
+	server, _, err := setupTest(t)
 	assert.NoError(t, err)
 
 	p, err := radius.Parse([]byte(RadiusAccessChallengeEapAkaIdentityRequestPacket), []byte(Secret))
@@ -73,7 +73,7 @@ func TestRadius(t *testing.T) {
 }
 
 func TestUserNotFound(t *testing.T) {
-	server, _, err := setupTest()
+	server, _, err := setupTest(t)
 	assert.NoError(t, err)
 
 	p, err := radius.Parse([]byte(RadiusAccessChallengeEapAkaIdentityRequestPacket), []byte(Secret))
@@ -84,7 +84,7 @@ func TestUserNotFound(t *testing.T) {
 }
 
 func TestMissingEapPacket(t *testing.T) {
-	server, _, err := setupTest()
+	server, _, err := setupTest(t)
 	assert.NoError(t, err)
 
 	p := radius.New(radius.CodeAccessChallenge, []byte(Secret))
@@ -94,7 +94,7 @@ func TestMissingEapPacket(t *testing.T) {
 }
 
 func TestEapToRadius(t *testing.T) {
-	server, _, err := setupTest()
+	server, _, err := setupTest(t)
 	assert.NoError(t, err)
 	eapMessage := []byte(EapIdentityResponsePacket)
 	expectedIdentifier := uint8(1)

--- a/cwf/gateway/services/uesim/servicers/start_auth_test.go
+++ b/cwf/gateway/services/uesim/servicers/start_auth_test.go
@@ -31,7 +31,7 @@ const (
 )
 
 func TestCreateEAPIdentityRequest(t *testing.T) {
-	server, _, err := setupTest()
+	server, _, err := setupTest(t)
 	assert.NoError(t, err)
 
 	radiusP, err := server.CreateEAPIdentityRequest(Imsi, CalledStationID2)

--- a/cwf/gateway/services/uesim/servicers/uesim_test.go
+++ b/cwf/gateway/services/uesim/servicers/uesim_test.go
@@ -25,7 +25,7 @@ import (
 )
 
 func TestUESimulator_AddUE(t *testing.T) {
-	store := test_utils.NewSQLBlobstore(t, "blobstore_uesim_test_table")
+	store := test_utils.NewSQLBlobstore(t, "uesim_uesim_test_blobstore")
 
 	server, err := servicers.NewUESimServer(store)
 	assert.NoError(t, err)

--- a/cwf/gateway/services/uesim/servicers/uesim_test.go
+++ b/cwf/gateway/services/uesim/servicers/uesim_test.go
@@ -19,13 +19,13 @@ import (
 
 	"magma/cwf/cloud/go/protos"
 	"magma/cwf/gateway/services/uesim/servicers"
-	"magma/orc8r/cloud/go/blobstore"
+	"magma/orc8r/cloud/go/test_utils"
 
 	"github.com/stretchr/testify/assert"
 )
 
 func TestUESimulator_AddUE(t *testing.T) {
-	store := blobstore.NewMemoryBlobStorageFactory()
+	store := test_utils.NewSQLBlobstore(t, "blobstore_uesim_test_table")
 
 	server, err := servicers.NewUESimServer(store)
 	assert.NoError(t, err)

--- a/cwf/gateway/services/uesim/test_init/test_service_init.go
+++ b/cwf/gateway/services/uesim/test_init/test_service_init.go
@@ -25,7 +25,7 @@ import (
 )
 
 func StartTestService(t *testing.T) {
-	factory := test_utils.NewSQLBlobstore(t, "blobstore_cwf_table")
+	factory := test_utils.NewSQLBlobstore(t, "uesim_test_service_blobstore")
 	srv, lis := test_utils.NewTestService(t, registry.ModuleName, registry.UeSim)
 	server, err := servicers.NewUESimServer(factory)
 	assert.NoError(t, err)

--- a/cwf/gateway/services/uesim/test_init/test_service_init.go
+++ b/cwf/gateway/services/uesim/test_init/test_service_init.go
@@ -19,14 +19,13 @@ import (
 	"magma/cwf/cloud/go/protos"
 	"magma/cwf/gateway/registry"
 	"magma/cwf/gateway/services/uesim/servicers"
-	"magma/orc8r/cloud/go/blobstore"
 	"magma/orc8r/cloud/go/test_utils"
 
 	"github.com/stretchr/testify/assert"
 )
 
 func StartTestService(t *testing.T) {
-	factory := blobstore.NewMemoryBlobStorageFactory()
+	factory := test_utils.NewSQLBlobstore(t, "blobstore_cwf_table")
 	srv, lis := test_utils.NewTestService(t, registry.ModuleName, registry.UeSim)
 	server, err := servicers.NewUESimServer(factory)
 	assert.NoError(t, err)

--- a/cwf/gateway/services/uesim/uesim/main.go
+++ b/cwf/gateway/services/uesim/uesim/main.go
@@ -16,6 +16,7 @@ package main
 
 import (
 	"flag"
+	"magma/orc8r/cloud/go/test_utils"
 
 	"magma/cwf/cloud/go/protos"
 	"magma/cwf/gateway/registry"
@@ -52,7 +53,10 @@ func main() {
 		glog.Fatalf("Error creating UeSim service: %s", err)
 	}
 
-	store := blobstore.NewMemoryBlobStorageFactory()
+	store, err := test_utils.NewSQLBlobstoreForServices("uesim_table_main")
+	if err != nil {
+		glog.Fatalf("Error creating in-memory blobstore: %s", err)
+	}
 	servicer, err := createUeSimServer(store)
 
 	protos.RegisterUESimServer(srv.GrpcServer, servicer)

--- a/cwf/gateway/services/uesim/uesim/main.go
+++ b/cwf/gateway/services/uesim/uesim/main.go
@@ -16,12 +16,12 @@ package main
 
 import (
 	"flag"
-	"magma/orc8r/cloud/go/test_utils"
 
 	"magma/cwf/cloud/go/protos"
 	"magma/cwf/gateway/registry"
 	"magma/cwf/gateway/services/uesim/servicers"
 	"magma/orc8r/cloud/go/blobstore"
+	"magma/orc8r/cloud/go/test_utils"
 	"magma/orc8r/lib/go/service"
 
 	"github.com/golang/glog"
@@ -53,9 +53,9 @@ func main() {
 		glog.Fatalf("Error creating UeSim service: %s", err)
 	}
 
-	store, err := test_utils.NewSQLBlobstoreForServices("uesim_table_main")
+	store, err := test_utils.NewSQLBlobstoreForServices("uesim_main_blobstore")
 	if err != nil {
-		glog.Fatalf("Error creating in-memory blobstore: %s", err)
+		glog.Fatalf("Error creating in-memory blobstore: %+v", err)
 	}
 	servicer, err := createUeSimServer(store)
 

--- a/feg/cloud/go/services/health/client_api_test.go
+++ b/feg/cloud/go/services/health/client_api_test.go
@@ -54,8 +54,9 @@ func TestHealthAPI_SingleFeg(t *testing.T) {
 		test_utils.TestFegHwId1,
 		test_utils.TestFegLogicalId1,
 	)
-	_, err = health.GetActiveGateway(test_utils.TestFegNetwork)
-	assert.Error(t, err)
+	active, err := health.GetActiveGateway(test_utils.TestFegNetwork)
+	assert.NoError(t, err)
+	assert.Equal(t, test_utils.TestFegNetwork, active)
 
 	// Simulate request coming from feg1
 	testServicer.Feg1 = true

--- a/feg/cloud/go/services/health/test_init/test_service_init.go
+++ b/feg/cloud/go/services/health/test_init/test_service_init.go
@@ -20,7 +20,6 @@ import (
 	"magma/feg/cloud/go/protos"
 	"magma/feg/cloud/go/services/health"
 	"magma/feg/cloud/go/services/health/servicers"
-	"magma/orc8r/cloud/go/blobstore"
 	"magma/orc8r/cloud/go/test_utils"
 
 	"github.com/stretchr/testify/assert"
@@ -28,7 +27,7 @@ import (
 
 func StartTestService(t *testing.T) (*servicers.TestHealthServer, error) {
 	srv, lis := test_utils.NewTestService(t, feg.ModuleName, health.ServiceName)
-	factory := blobstore.NewMemoryBlobStorageFactory()
+	factory := test_utils.NewSQLBlobstore(t, health.DBTableName)
 	servicer, err := servicers.NewTestHealthServer(factory)
 	assert.NoError(t, err)
 	protos.RegisterHealthServer(srv.GrpcServer, servicer)

--- a/orc8r/cloud/go/service/middleware/unary/test_utils/util.go
+++ b/orc8r/cloud/go/service/middleware/unary/test_utils/util.go
@@ -15,6 +15,7 @@ package test_utils
 
 import (
 	"crypto/x509"
+	"sync"
 	"testing"
 	"time"
 
@@ -27,12 +28,18 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+var (
+	once sync.Once
+)
+
 // StartMockGwAccessControl starts certifier & adds a Gw Identities for
 // Gateways with hwGwIds.
 // Returns a list of corresponding Certificate Serial Numbers.
 func StartMockGwAccessControl(t *testing.T, hwGwIds []string) []string {
-	// Start services
-	test_init.StartTestService(t)
+	// TODO(hcgatewood): the first-best solution here is having callers start
+	// the certifier test service on their own. But this sync.Once solution is a
+	// serviceable stopgap for now.
+	once.Do(func() { test_init.StartTestService(t) })
 
 	result := make([]string, len(hwGwIds))
 	for idx, hwId := range hwGwIds {

--- a/orc8r/cloud/go/services/ctraced/obsidian/handlers/handlers_test.go
+++ b/orc8r/cloud/go/services/ctraced/obsidian/handlers/handlers_test.go
@@ -14,7 +14,6 @@
 package handlers_test
 
 import (
-	"magma/orc8r/cloud/go/blobstore"
 	"magma/orc8r/cloud/go/obsidian"
 	"magma/orc8r/cloud/go/obsidian/tests"
 	"magma/orc8r/cloud/go/plugin"
@@ -22,6 +21,7 @@ import (
 	"magma/orc8r/cloud/go/serdes"
 	"magma/orc8r/cloud/go/services/configurator"
 	"magma/orc8r/cloud/go/services/ctraced/obsidian/handlers"
+	"magma/orc8r/cloud/go/test_utils"
 	traceModels "magma/orc8r/cloud/go/services/ctraced/obsidian/models"
 	"magma/orc8r/cloud/go/services/ctraced/storage"
 	"magma/orc8r/lib/go/protos"
@@ -57,7 +57,7 @@ func TestCtracedHandlersBasic(t *testing.T) {
 	e := echo.New()
 
 	mockGWClient := MockGWCtracedClient{}
-	fact := blobstore.NewMemoryBlobStorageFactory()
+	fact := test_utils.NewSQLBlobstore(t, "blobstore_ctrace_table")
 	blobstore := storage.NewCtracedBlobstore(fact)
 	obsidianHandlers := handlers.GetObsidianHandlers(mockGWClient, blobstore)
 	err := configurator.CreateNetwork(configurator.Network{ID: "n1"}, serdes.Network)

--- a/orc8r/cloud/go/services/ctraced/obsidian/handlers/handlers_test.go
+++ b/orc8r/cloud/go/services/ctraced/obsidian/handlers/handlers_test.go
@@ -57,7 +57,7 @@ func TestCtracedHandlersBasic(t *testing.T) {
 	e := echo.New()
 
 	mockGWClient := MockGWCtracedClient{}
-	fact := test_utils.NewSQLBlobstore(t, "blobstore_ctrace_table")
+	fact := test_utils.NewSQLBlobstore(t, "ctraced_handlers_test_blobstore")
 	blobstore := storage.NewCtracedBlobstore(fact)
 	obsidianHandlers := handlers.GetObsidianHandlers(mockGWClient, blobstore)
 	err := configurator.CreateNetwork(configurator.Network{ID: "n1"}, serdes.Network)

--- a/orc8r/cloud/go/services/device/test_init/test_service_init.go
+++ b/orc8r/cloud/go/services/device/test_init/test_service_init.go
@@ -16,7 +16,6 @@ package test_init
 import (
 	"testing"
 
-	"magma/orc8r/cloud/go/blobstore"
 	"magma/orc8r/cloud/go/orc8r"
 	"magma/orc8r/cloud/go/services/device"
 	"magma/orc8r/cloud/go/services/device/protos"
@@ -28,7 +27,7 @@ import (
 
 // StartTestService instantiates a service backed by an in-memory storage
 func StartTestService(t *testing.T) {
-	factory := blobstore.NewMemoryBlobStorageFactory()
+	factory := test_utils.NewSQLBlobstore(t, "blobstore_orc8r_table")
 	srv, lis := test_utils.NewTestService(t, orc8r.ModuleName, device.ServiceName)
 	server, err := servicers.NewDeviceServicer(factory)
 	assert.NoError(t, err)

--- a/orc8r/cloud/go/services/device/test_init/test_service_init.go
+++ b/orc8r/cloud/go/services/device/test_init/test_service_init.go
@@ -27,7 +27,7 @@ import (
 
 // StartTestService instantiates a service backed by an in-memory storage
 func StartTestService(t *testing.T) {
-	factory := test_utils.NewSQLBlobstore(t, "blobstore_orc8r_table")
+	factory := test_utils.NewSQLBlobstore(t, "device_test_service_blobstore")
 	srv, lis := test_utils.NewTestService(t, orc8r.ModuleName, device.ServiceName)
 	server, err := servicers.NewDeviceServicer(factory)
 	assert.NoError(t, err)

--- a/orc8r/cloud/go/services/tenants/servicers/servicer_test.go
+++ b/orc8r/cloud/go/services/tenants/servicers/servicer_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"testing"
 
-	"magma/orc8r/cloud/go/blobstore"
 	"magma/orc8r/cloud/go/orc8r"
 	"magma/orc8r/cloud/go/services/tenants"
 	"magma/orc8r/cloud/go/services/tenants/servicers"
@@ -99,7 +98,7 @@ func TestTenantsServicer(t *testing.T) {
 
 func newTestService(t *testing.T) (protos.TenantsServiceServer, error) {
 	srv, lis := test_utils.NewTestService(t, orc8r.ModuleName, tenants.ServiceName)
-	factory := blobstore.NewMemoryBlobStorageFactory()
+	factory := test_utils.NewSQLBlobstore(t, "blobstore_tenant_servicer_table")
 	store := storage.NewBlobstoreStore(factory)
 	servicer, err := servicers.NewTenantsServicer(store)
 	assert.NoError(t, err)

--- a/orc8r/cloud/go/services/tenants/servicers/servicer_test.go
+++ b/orc8r/cloud/go/services/tenants/servicers/servicer_test.go
@@ -98,7 +98,7 @@ func TestTenantsServicer(t *testing.T) {
 
 func newTestService(t *testing.T) (protos.TenantsServiceServer, error) {
 	srv, lis := test_utils.NewTestService(t, orc8r.ModuleName, tenants.ServiceName)
-	factory := test_utils.NewSQLBlobstore(t, "blobstore_tenant_servicer_table")
+	factory := test_utils.NewSQLBlobstore(t, "tenants_servicer_test_blobstore")
 	store := storage.NewBlobstoreStore(factory)
 	servicer, err := servicers.NewTenantsServicer(store)
 	assert.NoError(t, err)

--- a/orc8r/cloud/go/test_utils/test_db.go
+++ b/orc8r/cloud/go/test_utils/test_db.go
@@ -49,7 +49,6 @@ func DropTableFromSharedTestDB(t *testing.T, table string) {
 
 // NewSQLBlobstore returns a new blobstore storage factory utilizing the
 // singleton in-memory database.
-// Table name is an optional parameter. Defaults to "blobstore_table_name".
 func NewSQLBlobstore(t *testing.T, tableName string) blobstore.BlobStorageFactory {
 	if t == nil {
 		panic("for tests only")

--- a/orc8r/cloud/go/test_utils/test_db.go
+++ b/orc8r/cloud/go/test_utils/test_db.go
@@ -19,6 +19,7 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/pkg/errors"
 	"magma/orc8r/cloud/go/blobstore"
 	"magma/orc8r/cloud/go/sqorc"
 	storage2 "magma/orc8r/cloud/go/storage"
@@ -33,13 +34,10 @@ var (
 )
 
 // GetSharedMemoryDB returns a singleton in-memory database connection.
-func GetSharedMemoryDB(t *testing.T) *sql.DB {
-	once.Do(func() {
-		db, err := sqorc.Open(storage2.SQLDriver, ":memory:")
-		assert.NoError(t, err)
-		instance = db
-	})
-	return instance
+func GetSharedMemoryDB() (*sql.DB, error) {
+	var err error
+	once.Do(func() {instance, err = sqorc.Open(storage2.SQLDriver, ":memory:")})
+	return instance, err
 }
 
 // DropTableFromSharedTestDB drops the table from the singleton in-memory database.
@@ -49,13 +47,39 @@ func DropTableFromSharedTestDB(t *testing.T, table string) {
 	assert.NoError(t, err)
 }
 
-// NewSQLBlobstore returns a new blobstore storage factory utilizing the singleton in-memory database.
+// NewSQLBlobstore returns a new blobstore storage factory utilizing the
+// singleton in-memory database.
+// Table name is an optional parameter. Defaults to "blobstore_table_name".
 func NewSQLBlobstore(t *testing.T, tableName string) blobstore.BlobStorageFactory {
-	db := GetSharedMemoryDB(t)
-	store := blobstore.NewSQLBlobStorageFactory(tableName, db, sqorc.GetSqlBuilder())
-
-	err := store.InitializeFactory()
+	if t == nil {
+		panic("for tests only")
+	}
+	fact, err := NewSQLBlobstoreForServices(tableName)
 	assert.NoError(t, err)
+	return fact
+}
 
-	return store
+// NewSQLBlobstoreForServices is same as NewSQLBlobstore, but for use in
+// validation-oriented services.
+// Prefer NewSQLBlobstore wherever possible.
+func NewSQLBlobstoreForServices(tableName string) (blobstore.BlobStorageFactory, error) {
+	db, err := GetSharedMemoryDB()
+	if err != nil {
+		return nil, err
+	}
+
+	// Since the backing storage is process-shared, drop the table if it exists
+	// to provide a clean slate across test cases
+	_, err = db.Exec(fmt.Sprintf("DROP TABLE IF EXISTS %s", tableName))
+	if err != nil {
+		return nil, errors.Wrapf(err, "drop test SQL blobstore table: %s", tableName)
+	}
+
+	store := blobstore.NewSQLBlobStorageFactory(tableName, db, sqorc.GetSqlBuilder())
+	err = store.InitializeFactory()
+	if err != nil {
+		return nil, err
+	}
+
+	return store, nil
 }


### PR DESCRIPTION

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->
MemoryBlobStorage and its usage has long been obsolete in favor of SqlMemoryBlobStorage which grants us the same benefits of having a local in-memory blobstorage to test from. MemoryBlobStorage itself is filled with bugs and for the sake of clarity and simpler repo, we have decided to remove it.

## Test Plan
- [x] cd $MAGMA_ROOT/orc8r/cloud/docker && ./build.py -t ; noti
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
