### PR TITLE
[lte][agw] break COMMON_FLAGS definition into Makefile conditional

### DIFF
--- a/lte/gateway/Makefile
+++ b/lte/gateway/Makefile
@@ -59,7 +59,14 @@ OAI_FLAGS = $(S6A_FLAGS) -DEMBEDDED_SGW=True -DENABLE_OPENFLOW=True -DSPGW_ENABL
 endif
 
 # debian stretch build uses older cc not recognizing options needed on ubuntu focal
-COMMON_FLAGS := $(shell grep -q stretch /etc/os-release || echo -DCMAKE_C_FLAGS='"-Wno-error=duplicate-decl-specifier -Wno-error=maybe-uninitialized -Wno-error=address-of-packed-member"')
+
+OS_VERSION_NAME := $(shell (grep VERSION_CODENAME /etc/os-release || true) | sed 's/.*=//g')
+
+ifeq ($(OS_VERSION_NAME), focal)
+COMMON_FLAGS = -DCMAKE_C_FLAGS="-Wno-error=duplicate-decl-specifier -Wno-error=maybe-uninitialized -Wno-error=address-of-packed-member"
+else
+COMMON_FLAGS =
+endif
 
 $(info OAI_FLAGS $(OAI_FLAGS))
 


### PR DESCRIPTION
Signed-off-by: Ken Kahrs <kkahrs@gmail.com>

## Summary

not all non-`focal` systems understand compiler flags required for focal, make conditional inclusion explicit

## Test Plan
* verify `make` succeeds on `magma` vm
* verify `make` succeeds on `magma_focal` vm
* `docker build --target magma-mme --tag magma-mme:latest --file lte/gateway/docker/mme/Dockerfile.ubuntu18.04 .` fails for unrelated reasons
## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
