### PR TITLE
[Orc8r] Minor changes in Analytics service

### DIFF
--- a/lte/cloud/configs/lte.yml
+++ b/lte/cloud/configs/lte.yml
@@ -18,7 +18,7 @@ analytics:
       enforceMinUserThreshold: true
       labels:
         class: reliability
-      expr: round((sum by(gatewayID) (increase(ue_attach{action="attach_accept_sent"}[{{.Duration}}]))) * 100 / (sum by(gatewayID) (increase(ue_attach{action=~"attach_accept_sent|attach_reject_sent|attach_abort"}[{{.Duration}}]))))
+      expr: round((sum by(networkID, gatewayID) (increase(ue_attach{action="attach_accept_sent"}[{{.Duration}}]))) * 100 / (sum by(networkID, gatewayID) (increase(ue_attach{action=~"attach_accept_sent|attach_reject_sent|attach_abort"}[{{.Duration}}]))))
 
     subscriber_attach_reject_percent:
       register: false
@@ -26,7 +26,7 @@ analytics:
       enforceMinUserThreshold: true
       labels:
         class: reliability
-      expr: round((sum by(gatewayID) (increase(ue_attach{action="attach_reject_sent"}[{{.Duration}}]))) * 100 / (sum by(gatewayID) (increase(ue_attach{action=~"attach_accept_sent|attach_reject_sent|attach_abort"}[{{.Duration}}]))))
+      expr: round((sum by(networkID, gatewayID) (increase(ue_attach{action="attach_reject_sent"}[{{.Duration}}]))) * 100 / (sum by(networkID, gatewayID) (increase(ue_attach{action=~"attach_accept_sent|attach_reject_sent|attach_abort"}[{{.Duration}}]))))
 
     subscriber_duplicate_attach_count:
       register: false
@@ -62,6 +62,7 @@ analytics:
     gateway_throughput_dl:
       register: false
       export: true
+      enforceMinUserThreshold: true
       labels:
         class: network
       expr: sum(increase(gtp_port_user_plane_dl_bytes[{{.Duration}}])) by (networkID, gatewayID)
@@ -77,6 +78,7 @@ analytics:
     gateway_throughput_ul:
       register: false
       export: true
+      enforceMinUserThreshold: true
       labels:
         class: network
       expr: sum(increase(gtp_port_user_plane_ul_bytes[{{.Duration}}])) by (networkID, gatewayID)
@@ -120,19 +122,7 @@ analytics:
       labels:
         class: engagement
 
-    network_type:
-      register: false
-      export: true
-      labels:
-        class: network
-
     enodeb_connected:
-      register: false
-      export: true
-      labels:
-        class: site
-
-    gateway_version:
       register: false
       export: true
       labels:

--- a/lte/cloud/go/services/lte/analytics/analytics.go
+++ b/lte/cloud/go/services/lte/analytics/analytics.go
@@ -26,11 +26,7 @@ func GetAnalyticsCalculations(config *calculations.AnalyticsConfig) []calculatio
 	}
 
 	calcs := make([]calculations.Calculation, 0)
-	calcs = append(calcs, &lte_calculations.NetworkMetricsCalculation{
-		BaseCalculation: calculations.BaseCalculation{
-			CalculationParams: calculations.CalculationParams{AnalyticsConfig: config},
-		},
-	})
+
 	calcs = append(calcs, &lte_calculations.UserMetricsCalculation{
 		BaseCalculation: calculations.BaseCalculation{
 			CalculationParams: calculations.CalculationParams{AnalyticsConfig: config},

--- a/lte/cloud/go/services/lte/analytics/calculations/state.go
+++ b/lte/cloud/go/services/lte/analytics/calculations/state.go
@@ -21,10 +21,8 @@ import (
 	"magma/orc8r/cloud/go/services/analytics/protos"
 	"magma/orc8r/cloud/go/services/analytics/query_api"
 	"magma/orc8r/cloud/go/services/configurator"
-	"magma/orc8r/cloud/go/services/orchestrator/obsidian/models"
 	"magma/orc8r/cloud/go/services/state"
 	"magma/orc8r/cloud/go/services/state/wrappers"
-	merrors "magma/orc8r/lib/go/errors"
 	"magma/orc8r/lib/go/metrics"
 
 	"github.com/golang/glog"
@@ -39,50 +37,6 @@ const (
 	// sessionActive string literal identifying active subscriber session
 	sessionActive = "SESSION_ACTIVE"
 )
-
-type NetworkMetricsCalculation struct {
-	calculations.BaseCalculation
-}
-
-func (x *NetworkMetricsCalculation) Calculate(prometheusClient query_api.PrometheusAPI) ([]*protos.CalculationResult, error) {
-	glog.V(1).Info("Calculate Network Metrics")
-
-	var results []*protos.CalculationResult
-	networks, err := configurator.ListNetworkIDs()
-	if err != nil || networks == nil {
-		return results, err
-	}
-
-	metricConfig, ok := x.AnalyticsConfig.Metrics[metrics.NetworkTypeMetric]
-	if !ok {
-		glog.Errorf("%s metric not found in metric config", metrics.NetworkTypeMetric)
-		return results, err
-	}
-
-	for _, networkID := range networks {
-		network, err := configurator.LoadNetwork(networkID, true, true, serdes.Network)
-		if err == merrors.ErrNotFound {
-			glog.Errorf("Network %s not found", networkID)
-			continue
-		}
-		if err != nil {
-			glog.Errorf("Failed %v loading network %s", err, networkID)
-			continue
-		}
-		ret := (&models.Network{}).FromConfiguratorNetwork(network)
-		labels := prometheus.Labels{
-			metrics.NetworkLabelName: networkID,
-			metrics.NetworkTypeLabel: string(ret.Type),
-		}
-		results = append(results,
-			calculations.NewResult(1,
-				metrics.NetworkTypeMetric,
-				calculations.CombineLabels(labels, metricConfig.Labels)))
-	}
-
-	glog.V(1).Info("Network Metrics Results ", results)
-	return results, nil
-}
 
 type UserMetricsCalculation struct {
 	calculations.BaseCalculation

--- a/lte/cloud/go/services/lte/analytics/calculations/state_test.go
+++ b/lte/cloud/go/services/lte/analytics/calculations/state_test.go
@@ -10,10 +10,10 @@ import (
 	"magma/orc8r/cloud/go/orc8r"
 	"magma/orc8r/cloud/go/services/analytics/calculations"
 	"magma/orc8r/cloud/go/services/configurator"
-	configuratorTestInit "magma/orc8r/cloud/go/services/configurator/test_init"
+	configurator_test_init "magma/orc8r/cloud/go/services/configurator/test_init"
 	"magma/orc8r/cloud/go/services/orchestrator/obsidian/models"
 	"magma/orc8r/cloud/go/services/state"
-	stateTestInit "magma/orc8r/cloud/go/services/state/test_init"
+	state_test_init "magma/orc8r/cloud/go/services/state/test_init"
 	"magma/orc8r/cloud/go/services/state/test_utils"
 	"magma/orc8r/lib/go/metrics"
 
@@ -21,8 +21,8 @@ import (
 )
 
 func TestUserCalculations(t *testing.T) {
-	configuratorTestInit.StartTestService(t)
-	stateTestInit.StartTestService(t)
+	configurator_test_init.StartTestService(t)
+	state_test_init.StartTestService(t)
 	err := configurator.CreateNetwork(configurator.Network{ID: "n0"}, serdes.Network)
 	assert.NoError(t, err)
 	_, err = configurator.CreateEntity(
@@ -87,44 +87,9 @@ func TestUserCalculations(t *testing.T) {
 	assert.Equal(t, resultMetricMap[metrics.ActualSubscribersMetric], float64(2))
 }
 
-func TestNetworkCalculations(t *testing.T) {
-	configuratorTestInit.StartTestService(t)
-	stateTestInit.StartTestService(t)
-	configurator.CreateNetwork(configurator.Network{ID: "n0_1", Type: "LTE"}, serdes.Network)
-	configurator.CreateNetwork(configurator.Network{ID: "n1", Type: "FEG_LTE"}, serdes.Network)
-	configurator.CreateNetwork(configurator.Network{ID: "n2_0", Type: "FEG"}, serdes.Network)
-	configurator.CreateNetwork(configurator.Network{ID: "n2_2", Type: "FEG"}, serdes.Network)
-	analyticsConfig := &calculations.AnalyticsConfig{
-		Metrics: map[string]calculations.MetricConfig{
-			metrics.NetworkTypeMetric: {
-				Export:   true,
-				Register: true,
-			},
-		},
-	}
-	generalCalculation := lte_calculations.NetworkMetricsCalculation{
-		BaseCalculation: calculations.BaseCalculation{
-			CalculationParams: calculations.CalculationParams{
-				AnalyticsConfig: analyticsConfig,
-			},
-		},
-	}
-	results, err := generalCalculation.Calculate(nil)
-	resultMetricMap := make(map[string]string)
-	for _, result := range results {
-		resultMetricMap[result.GetLabels()[metrics.NetworkLabelName]] = result.GetLabels()[metrics.NetworkTypeLabel]
-	}
-	assert.NoError(t, err)
-	t.Log(results)
-	assert.Equal(t, resultMetricMap["n0_1"], "LTE")
-	assert.Equal(t, resultMetricMap["n1"], "FEG_LTE")
-	assert.Equal(t, resultMetricMap["n2_0"], "FEG")
-	assert.Equal(t, resultMetricMap["n2_2"], "FEG")
-}
-
 func TestSiteCalculations(t *testing.T) {
-	configuratorTestInit.StartTestService(t)
-	stateTestInit.StartTestService(t)
+	configurator_test_init.StartTestService(t)
+	state_test_init.StartTestService(t)
 	err := configurator.CreateNetwork(configurator.Network{ID: "n0"}, serdes.Network)
 	assert.NoError(t, err)
 

--- a/orc8r/cloud/configs/orchestrator.yml
+++ b/orc8r/cloud/configs/orchestrator.yml
@@ -103,18 +103,10 @@ analytics:
       labels:
         class: reliability
 
-    orc8r_error_count:
-      logConfig:
-        query: error
-      export: true
-      register: false
-      labels:
-        class: reliability
-
     orc8r_alertmanager_error_count:
       logConfig:
         tags:
-          kubernetes.container_name: orc8r-alertmanager
+          kubernetes.container_name: alertmanager
         query: error
       export: true
       register: false
@@ -124,7 +116,7 @@ analytics:
     orc8r_bootstrapper_error_count:
       logConfig:
         tags:
-          kubernetes.container_name: orc8r-bootstrapper
+          kubernetes.container_name: bootstrapper
         query: error
       export: true
       register: false
@@ -134,7 +126,7 @@ analytics:
     orc8r_certifier_error_count:
       logConfig:
         tags:
-          kubernetes.container_name: orc8r-certifier
+          kubernetes.container_name: certifier
         query: error
       export: true
       register: false
@@ -144,7 +136,7 @@ analytics:
     orc8r_configurator_error_count:
       logConfig:
         tags:
-          kubernetes.container_name: orc8r-configurator
+          kubernetes.container_name: configurator
         query: error
       export: true
       register: false
@@ -154,7 +146,7 @@ analytics:
     orc8r_cwf_error_count:
       logConfig:
         tags:
-          kubernetes.container_name: orc8r-cwf
+          kubernetes.container_name: cwf
         query: error
       export: true
       register: false
@@ -164,7 +156,7 @@ analytics:
     orc8r_device_error_count:
       logConfig:
         tags:
-          kubernetes.container_name: orc8r-device
+          kubernetes.container_name: device
         query: error
       export: true
       register: false
@@ -174,7 +166,7 @@ analytics:
     orc8r_directoryd_error_count:
       logConfig:
         tags:
-          kubernetes.container_name: orc8r-directoryd
+          kubernetes.container_name: directoryd
         query: error
       export: true
       register: false
@@ -184,7 +176,7 @@ analytics:
     orc8r_lte_error_count:
       logConfig:
         tags:
-          kubernetes.container_name: orc8r-lte
+          kubernetes.container_name: lte
         query: error
       export: true
       register: false
@@ -194,7 +186,7 @@ analytics:
     orc8r_ha_error_count:
       logConfig:
         tags:
-          kubernetes.container_name: orc8r-ha
+          kubernetes.container_name: ha
         query: error
       export: true
       register: false
@@ -204,7 +196,7 @@ analytics:
     orc8r_nginx_error_count:
       logConfig:
         tags:
-          kubernetes.container_name: orc8r-nginx
+          kubernetes.container_name: nginx
         query: error
       export: true
       register: false
@@ -214,7 +206,7 @@ analytics:
     orc8r_obsidian_error_count:
       logConfig:
         tags:
-          kubernetes.container_name: orc8r-obsidian
+          kubernetes.container_name: obsidian
         query: error
       export: true
       register: false
@@ -224,7 +216,7 @@ analytics:
     orc8r_orchestrator_error_count:
       logConfig:
         tags:
-          kubernetes.container_name: orc8r-orchestrator
+          kubernetes.container_name: orchestrator
         query: error
       export: true
       register: false
@@ -234,7 +226,7 @@ analytics:
     orc8r_policydb_error_count:
       logConfig:
         tags:
-          kubernetes.container_name: orc8r-policydb
+          kubernetes.container_name: policydb
         query: error
       export: true
       register: false
@@ -244,7 +236,7 @@ analytics:
     orc8r_smsd_error_count:
       logConfig:
         tags:
-          kubernetes.container_name: orc8r-smsd
+          kubernetes.container_name: smsd
         query: error
       export: true
       register: false
@@ -254,7 +246,7 @@ analytics:
     orc8r_subscriber_error_count:
       logConfig:
         tags:
-          kubernetes.container_name: orc8r-subscriberdb
+          kubernetes.container_name: subscriberdb
         query: error
       export: true
       register: false
@@ -264,21 +256,52 @@ analytics:
     orc8r_state_error_count:
       logConfig:
         tags:
-          kubernetes.container_name: orc8r-state
+          kubernetes.container_name: state
         query: error
       export: true
       register: false
       labels:
         class: reliability
-
-
 
     orc8r_service_error_count:
       logConfig:
         tags:
-          kubernetes.container_name: orc8r-service
+          kubernetes.container_name: service
         query: error
       export: true
       register: false
       labels:
         class: reliability
+
+    orc8r_metricsd_error_count:
+      logConfig:
+        tags:
+          kubernetes.container_name: metricsd
+        query: error
+      export: true
+      register: false
+      labels:
+        class: reliability
+
+    orc8r_prometheus_error_count:
+      logConfig:
+        tags:
+          kubernetes.container_name: prometheus
+        query: error
+      export: true
+      register: false
+      labels:
+        class: reliability
+
+    # state metrics
+    network_type:
+      register: false
+      export: true
+      labels:
+        class: network
+
+    gateway_version:
+      register: false
+      export: true
+      labels:
+        class: site

--- a/orc8r/cloud/go/services/analytics/collector_servicer.go
+++ b/orc8r/cloud/go/services/analytics/collector_servicer.go
@@ -106,31 +106,36 @@ func (c *collectorServicer) filterResult(result *protos.CalculationResult) bool 
 	gatewayID, gatewayLabelPresent := result.Labels[metrics.GatewayLabelName]
 
 	numUsers := 0
+	minUserVerificationScope := "Deployment Wide"
 	if networkLabelPresent && gatewayLabelPresent {
 		numUsers = c.userStateManager.GetTotalUsersInGateway(networkID, gatewayID)
+		minUserVerificationScope = "Site Wide"
 	} else if networkLabelPresent {
 		numUsers = c.userStateManager.GetTotalUsersInNetwork(networkID)
+		minUserVerificationScope = "Network Wide"
 	} else {
 		numUsers = c.userStateManager.GetTotalUsers()
 	}
 
 	if numUsers > analyticsConfig.MinUserThreshold {
 		glog.V(2).Infof("Metric(%s) network label(%s) gateway label(%s) can "+
-			"be exported numUsers(%d) greater than minUserThreshold(%d)\n",
+			"be exported numUsers(%d) in the %s greater than minUserThreshold(%d)",
 			result.GetMetricName(),
 			networkID,
 			gatewayID,
 			numUsers,
+			minUserVerificationScope,
 			analyticsConfig.MinUserThreshold)
 		return true
 	}
 	glog.V(1).Infof(
 		"Metric(%s) network label(%s) gateway label(%s) dropped, active "+
-			"users(%d) below user threshold (%d)\n",
+			"users(%d) in the %s below user threshold (%d)\n",
 		result.GetMetricName(),
 		networkID,
 		gatewayID,
 		numUsers,
+		minUserVerificationScope,
 		analyticsConfig.MinUserThreshold)
 	return false
 }

--- a/orc8r/cloud/go/services/orchestrator/analytics/analytics.go
+++ b/orc8r/cloud/go/services/orchestrator/analytics/analytics.go
@@ -16,6 +16,7 @@ package analytics
 import (
 	"magma/orc8r/cloud/go/services/analytics"
 	"magma/orc8r/cloud/go/services/analytics/calculations"
+	orchestrator_calcs "magma/orc8r/cloud/go/services/orchestrator/analytics/calculations"
 )
 
 // GetAnalyticsCalculations returns all calculations computed by the component
@@ -24,7 +25,18 @@ func GetAnalyticsCalculations(config *calculations.AnalyticsConfig) []calculatio
 		return nil
 	}
 
-	calcs := analytics.GetLogMetricsCalculations(config)
+	calcs := make([]calculations.Calculation, 0)
+	calcs = append(calcs, analytics.GetLogMetricsCalculations(config)...)
 	calcs = append(calcs, analytics.GetRawMetricsCalculations(config)...)
+	calcs = append(calcs, &orchestrator_calcs.NetworkMetricsCalculation{
+		BaseCalculation: calculations.BaseCalculation{
+			CalculationParams: calculations.CalculationParams{AnalyticsConfig: config},
+		},
+	})
+	calcs = append(calcs, &orchestrator_calcs.SiteMetricsCalculation{
+		BaseCalculation: calculations.BaseCalculation{
+			CalculationParams: calculations.CalculationParams{AnalyticsConfig: config},
+		},
+	})
 	return calcs
 }

--- a/orc8r/cloud/go/services/orchestrator/analytics/calculations/state.go
+++ b/orc8r/cloud/go/services/orchestrator/analytics/calculations/state.go
@@ -1,0 +1,142 @@
+/*
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package calculations
+
+import (
+	"magma/orc8r/cloud/go/orc8r"
+	"magma/orc8r/cloud/go/serdes"
+	"magma/orc8r/cloud/go/services/analytics/calculations"
+	"magma/orc8r/cloud/go/services/analytics/protos"
+	"magma/orc8r/cloud/go/services/analytics/query_api"
+	"magma/orc8r/cloud/go/services/configurator"
+	"magma/orc8r/cloud/go/services/orchestrator/obsidian/models"
+	"magma/orc8r/cloud/go/services/state/wrappers"
+	merrors "magma/orc8r/lib/go/errors"
+	"magma/orc8r/lib/go/metrics"
+
+	"github.com/go-openapi/swag"
+	"github.com/golang/glog"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+type NetworkMetricsCalculation struct {
+	calculations.BaseCalculation
+}
+
+func (x *NetworkMetricsCalculation) Calculate(prometheusClient query_api.PrometheusAPI) ([]*protos.CalculationResult, error) {
+	glog.V(1).Info("Calculate Network Metrics")
+
+	var results []*protos.CalculationResult
+	networks, err := configurator.ListNetworkIDs()
+	if err != nil || networks == nil {
+		return results, err
+	}
+
+	metricConfig, ok := x.AnalyticsConfig.Metrics[metrics.NetworkTypeMetric]
+	if !ok {
+		glog.Errorf("%s metric not found in metric config", metrics.NetworkTypeMetric)
+		return results, err
+	}
+
+	for _, networkID := range networks {
+		network, err := configurator.LoadNetwork(networkID, true, true, serdes.Network)
+		if err == merrors.ErrNotFound {
+			glog.Errorf("Network %s not found", networkID)
+			continue
+		}
+		if err != nil {
+			glog.Errorf("Failed %v loading network %s", err, networkID)
+			continue
+		}
+		ret := (&models.Network{}).FromConfiguratorNetwork(network)
+		labels := prometheus.Labels{
+			metrics.NetworkLabelName: networkID,
+			metrics.NetworkTypeLabel: string(ret.Type),
+		}
+		labels = calculations.CombineLabels(labels, metricConfig.Labels)
+		result := calculations.NewResult(1, metrics.NetworkTypeMetric, labels)
+		results = append(results, result)
+		glog.V(1).Info(result)
+	}
+
+	return results, nil
+}
+
+type SiteMetricsCalculation struct {
+	calculations.BaseCalculation
+}
+
+// Calculate computes site specific calculations based on gateway state present in the orc8r
+func (x *SiteMetricsCalculation) Calculate(prometheusClient query_api.PrometheusAPI) ([]*protos.CalculationResult, error) {
+	glog.V(1).Info("Calculate Site Metrics")
+	var results []*protos.CalculationResult
+
+	gatewayVersionCfg, gatewayVersionCfgOk := x.AnalyticsConfig.Metrics[metrics.GatewayMagmaVersionMetric]
+	networks, err := configurator.ListNetworkIDs()
+	if err != nil || networks == nil || !gatewayVersionCfgOk {
+		return results, err
+	}
+
+	for _, networkID := range networks {
+		gatewayEnts, _, err := configurator.LoadEntities(
+			networkID,
+			swag.String(orc8r.MagmadGatewayType),
+			nil,
+			nil,
+			nil,
+			configurator.EntityLoadCriteria{},
+			serdes.Entity,
+		)
+		if err != nil {
+			continue
+		}
+		for _, ent := range gatewayEnts {
+			status, err := wrappers.GetGatewayStatus(networkID, ent.PhysicalID)
+			if err != nil ||
+				status == nil ||
+				status.PlatformInfo == nil ||
+				len(status.PlatformInfo.Packages) == 0 {
+				glog.V(2).Infof("gateway %s, err %v or version not available",
+					ent.PhysicalID, err)
+				continue
+			}
+
+			gatewayVersion := ""
+			for _, pkg := range status.PlatformInfo.Packages {
+				if pkg.Name != "magma" {
+					continue
+				}
+				gatewayVersion = pkg.Version
+				break
+			}
+
+			if gatewayVersion == "" {
+				glog.V(2).Infof("gateway %s, version not found", ent.PhysicalID)
+				continue
+			}
+
+			labels := prometheus.Labels{
+				metrics.NetworkLabelName:         networkID,
+				metrics.GatewayLabelName:         ent.PhysicalID,
+				metrics.GatewayMagmaVersionLabel: gatewayVersion,
+			}
+			labels = calculations.CombineLabels(labels, gatewayVersionCfg.Labels)
+			result := calculations.NewResult(1, metrics.GatewayMagmaVersionMetric, labels)
+			results = append(results, result)
+			glog.V(1).Info(result)
+		}
+	}
+
+	return results, nil
+}

--- a/orc8r/cloud/go/services/orchestrator/analytics/calculations/state_test.go
+++ b/orc8r/cloud/go/services/orchestrator/analytics/calculations/state_test.go
@@ -1,0 +1,96 @@
+package calculations_test
+
+import (
+	"testing"
+
+	"magma/orc8r/cloud/go/orc8r"
+	"magma/orc8r/cloud/go/serdes"
+	"magma/orc8r/cloud/go/services/analytics/calculations"
+	"magma/orc8r/cloud/go/services/configurator"
+	configurator_test_init "magma/orc8r/cloud/go/services/configurator/test_init"
+	orchestrator_calcs "magma/orc8r/cloud/go/services/orchestrator/analytics/calculations"
+	"magma/orc8r/cloud/go/services/orchestrator/obsidian/models"
+	state_test_init "magma/orc8r/cloud/go/services/state/test_init"
+	"magma/orc8r/cloud/go/services/state/test_utils"
+	"magma/orc8r/lib/go/metrics"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSiteCalculations(t *testing.T) {
+	configurator_test_init.StartTestService(t)
+	state_test_init.StartTestService(t)
+	err := configurator.CreateNetwork(configurator.Network{ID: "n0"}, serdes.Network)
+	assert.NoError(t, err)
+
+	_, err = configurator.CreateEntity(
+		"n0",
+		configurator.NetworkEntity{
+			Type:       orc8r.MagmadGatewayType,
+			Key:        "g0",
+			Config:     &models.MagmadGatewayConfigs{},
+			PhysicalID: "hw0"},
+		serdes.Entity,
+	)
+
+	ctx := test_utils.GetContextWithCertificate(t, "hw0")
+	test_utils.ReportGatewayStatus(t, ctx, models.NewDefaultGatewayStatus("hw0"))
+	analyticsConfig := &calculations.AnalyticsConfig{
+		Metrics: map[string]calculations.MetricConfig{
+			metrics.GatewayMagmaVersionMetric: {
+				Export:   true,
+				Register: true,
+			},
+		},
+	}
+	siteMetricsCalculation := orchestrator_calcs.SiteMetricsCalculation{
+		BaseCalculation: calculations.BaseCalculation{
+			CalculationParams: calculations.CalculationParams{
+				AnalyticsConfig: analyticsConfig,
+			},
+		},
+	}
+	results, err := siteMetricsCalculation.Calculate(nil)
+	assert.NoError(t, err)
+	t.Log(results)
+	resultMetricMap := make(map[string]string)
+	for _, result := range results {
+		resultMetricMap[result.GetLabels()[metrics.GatewayLabelName]] = result.GetLabels()[metrics.GatewayMagmaVersionLabel]
+	}
+	assert.Equal(t, resultMetricMap["hw0"], "0.0.0.0")
+}
+
+func TestNetworkCalculations(t *testing.T) {
+	configurator_test_init.StartTestService(t)
+	state_test_init.StartTestService(t)
+	configurator.CreateNetwork(configurator.Network{ID: "n0_1", Type: "LTE"}, serdes.Network)
+	configurator.CreateNetwork(configurator.Network{ID: "n1", Type: "FEG_LTE"}, serdes.Network)
+	configurator.CreateNetwork(configurator.Network{ID: "n2_0", Type: "FEG"}, serdes.Network)
+	configurator.CreateNetwork(configurator.Network{ID: "n2_2", Type: "FEG"}, serdes.Network)
+	analyticsConfig := &calculations.AnalyticsConfig{
+		Metrics: map[string]calculations.MetricConfig{
+			metrics.NetworkTypeMetric: {
+				Export:   true,
+				Register: true,
+			},
+		},
+	}
+	generalCalculation := orchestrator_calcs.NetworkMetricsCalculation{
+		BaseCalculation: calculations.BaseCalculation{
+			CalculationParams: calculations.CalculationParams{
+				AnalyticsConfig: analyticsConfig,
+			},
+		},
+	}
+	results, err := generalCalculation.Calculate(nil)
+	resultMetricMap := make(map[string]string)
+	for _, result := range results {
+		resultMetricMap[result.GetLabels()[metrics.NetworkLabelName]] = result.GetLabels()[metrics.NetworkTypeLabel]
+	}
+	assert.NoError(t, err)
+	t.Log(results)
+	assert.Equal(t, resultMetricMap["n0_1"], "LTE")
+	assert.Equal(t, resultMetricMap["n1"], "FEG_LTE")
+	assert.Equal(t, resultMetricMap["n2_0"], "FEG")
+	assert.Equal(t, resultMetricMap["n2_2"], "FEG")
+}


### PR DESCRIPTION
Signed-off-by: Karthik Subraveti <ksubraveti@fb.com>

## Summary

PR contains following changes

config file changes
- Added networkID in subscriber_attach_success_percent, subscriber_attach_reject_percent metrics computation, 
- Added enforceMinUserThreshold attribute to gateway_throughput_dl, gateway_throughput_ul 
- Changed the log error metric config to use term query(kubernetes.container_name=="\<service\>" rather than kubernetes.container_name=="orc8r-\<service\>" and verified the term query by running it on elastic search instance 

go code changes
- Changed gateway version computation to be done on Magmad gateway instead of lte gateway and moved the corresponding go file into orchestrator/analytics/calculation directory

## Test Plan

`./build.py -t` passes 

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
