### PR TITLE
[ctraced][orc8r] Add content-dispositions headers to trace download API

### DIFF
--- a/orc8r/cloud/docker/controller/apidocs/v1/swagger.yml
+++ b/orc8r/cloud/docker/controller/apidocs/v1/swagger.yml
@@ -5387,6 +5387,9 @@ paths:
       responses:
         "200":
           description: Show tracing status
+          headers:
+            Content-Disposition:
+              type: string
           schema:
             format: binary
             type: file

--- a/orc8r/cloud/go/services/ctraced/obsidian/handlers/handlers.go
+++ b/orc8r/cloud/go/services/ctraced/obsidian/handlers/handlers.go
@@ -212,7 +212,13 @@ func getDownloadCallTraceHandlerFunc(storage storage.CtracedStorage) echo.Handle
 			return obsidian.HttpError(errors.Wrap(err, "failed to retrieve call trace data"), http.StatusInternalServerError)
 		}
 
-		return c.Blob(http.StatusOK, "application/pcapng", callTrace)
+		res := c.Response()
+		header := res.Header()
+		header.Set(echo.HeaderContentType, "application/pcapng")
+		header.Set(echo.HeaderContentDisposition, "attachment; filename="+fmt.Sprintf("%s.pcapng", callTraceID))
+		res.WriteHeader(http.StatusOK)
+		_, err = res.Write(callTrace)
+		return err
 	}
 }
 

--- a/orc8r/cloud/go/services/ctraced/obsidian/models/swagger.v1.yml
+++ b/orc8r/cloud/go/services/ctraced/obsidian/models/swagger.v1.yml
@@ -125,6 +125,9 @@ paths:
           schema:
             type: file
             format: binary
+          headers:
+            Content-Disposition:
+              type: string
         default:
           $ref: './orc8r-swagger-common.yml#/responses/UnexpectedError'
 

--- a/orc8r/cloud/helm/orc8r/Chart.yaml
+++ b/orc8r/cloud/helm/orc8r/Chart.yaml
@@ -13,7 +13,7 @@ apiVersion: v2
 appVersion: "1.0"
 description: A Helm chart for magma orchestrator
 name: orc8r
-version: 1.5.7
+version: 1.5.8
 engine: gotpl
 sources:
   - https://github.com/facebookincubator/magma

--- a/orc8r/cloud/helm/orc8r/templates/ctraced.deployment.yaml
+++ b/orc8r/cloud/helm/orc8r/templates/ctraced.deployment.yaml
@@ -1,0 +1,51 @@
+{{/*
+# Copyright 2020 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+*/}}
+{{- include "orc8rlib.deployment" (list . "ctraced.deployment") -}}
+{{- define "ctraced.deployment" -}}
+metadata:
+  name: orc8r-ctraced
+  labels:
+    app.kubernetes.io/component: ctraced
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: ctraced
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/component: ctraced
+    spec:
+      containers:
+      -
+{{ include "orc8rlib.container" (list . "ctraced.container")}}
+{{- end -}}
+{{- define "ctraced.container" -}}
+name: ctraced
+command: ["/usr/bin/envdir"]
+args: ["/var/opt/magma/envdir", "/var/opt/magma/bin/ctraced","-run_echo_server=true", "-logtostderr=true", "-v=0"]
+ports:
+  - name: grpc
+    containerPort: 9118
+  - name: http
+    containerPort: 10118
+livenessProbe:
+  tcpSocket:
+    port: 9118
+  initialDelaySeconds: 10
+  periodSeconds: 30
+readinessProbe:
+  tcpSocket:
+    port: 9118
+  initialDelaySeconds: 5
+  periodSeconds: 10
+{{- end -}}

--- a/orc8r/cloud/helm/orc8r/templates/ctraced.pdb.yaml
+++ b/orc8r/cloud/helm/orc8r/templates/ctraced.pdb.yaml
@@ -1,0 +1,25 @@
+{{/*
+Copyright 2020 The Magma Authors.
+
+This source code is licensed under the BSD-style license found in the
+LICENSE file in the root directory of this source tree.
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/}}
+{{- include "orc8rlib.pdb" (list . "ctraced.pdb") -}}
+{{- define "ctraced.pdb" -}}
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: orc8r-ctraced
+  labels:
+    app.kubernetes.io/component: ctraced
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: ctraced
+{{- end }}

--- a/orc8r/cloud/helm/orc8r/templates/ctraced.service.yaml
+++ b/orc8r/cloud/helm/orc8r/templates/ctraced.service.yaml
@@ -24,6 +24,8 @@ metadata:
 {{ toYaml . | indent 4}}
   {{- end }}
 spec:
+  selector:
+    app.kubernetes.io/component: ctraced
   ports:
     - name: grpc
       port: 9180


### PR DESCRIPTION
Signed-off-by: Andrei Lee <andreilee@fb.com>

## Summary

Added `Content-Disposition` to call tracing API endpoint for downloading traces.

## Test Plan

Tested manually through the swagger API with Chrome developer tools to examine network response from orc8r API.

<img width="540" alt="Screen Shot 2021-01-07 at 9 59 05 PM" src="https://user-images.githubusercontent.com/804385/104064995-d33e3f80-51b3-11eb-8431-d5a6e923dd95.png">


## Additional Information

- [ ] This change is backwards-breaking
