### PR TITLE
[teravm] add a check for state of ng40

### DIFF
--- a/ci-scripts/teravm/fabfile.py
+++ b/ci-scripts/teravm/fabfile.py
@@ -282,10 +282,13 @@ def run_3gpp_tests(
         test_files = [test_files]
     test_output = []
 
-    for test_file in test_files:
-        fastprint("Run test for file %s\n" % (test_file))
-        _setup_env("ng40", VM_IP_MAP[setup]["ng40"], key_filename)
-        with cd("/home/ng40/magma/automation"):
+    _setup_env("ng40", VM_IP_MAP[setup]["ng40"], key_filename)
+
+    with cd("/home/ng40/magma/automation"):
+        for test_file in test_files:
+            fastprint("Check ng40 status (if any test is currently running\n")
+            run("ng40test state.ntl")
+            fastprint("Run test for file %s\n" % (test_file))
             with hide("warnings", "running", "stdout"), settings(warn_only=True):
                 output = run("ng40test %s" % test_file)
                 test_output.append(output)


### PR DESCRIPTION
Signed-off-by: Oriol Batalla <obatalla@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary

Add a check to make sure no tests are running before executing the tests

## Test Plan

teravm test

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
