### PR TITLE
[NMS] Refresh equipment and subscriber detail

### DIFF
--- a/nms/app/packages/magmalte/app/components/context/RefreshContext.js
+++ b/nms/app/packages/magmalte/app/components/context/RefreshContext.js
@@ -19,7 +19,7 @@ import {
   FetchSubscriberState,
   FetchSubscribers,
 } from '../../state/lte/SubscriberState';
-import {useContext, useEffect, useState} from 'react';
+import {useContext, useEffect, useRef, useState} from 'react';
 
 export const REFRESH_INTERVAL = 30000;
 
@@ -95,6 +95,12 @@ export function useRefreshingContext(props: Props) {
     return ctx.setState(null, null, newState);
   }
 
+  // Avoid using state as a dependency of useEffect
+  const stateRef = useRef(null);
+  useEffect(() => {
+    stateRef.current = state;
+  }, [state]);
+
   useEffect(() => {
     const intervalId = setInterval(
       () => setAutoRefreshTime(new Date().toLocaleString()),
@@ -104,11 +110,11 @@ export function useRefreshingContext(props: Props) {
       return clearInterval(intervalId);
     }
     return () => {
-      updateContext(props.id, state);
+      updateContext(props.id, stateRef.current);
       clearInterval(intervalId);
     };
     // eslint-disable-next-line
-  }, [props.interval, props.refresh, state]);
+  }, [props.interval, props.refresh]);
 
   useEffect(() => {
     if (props.lastRefreshTime != autoRefreshTime) {

--- a/nms/app/packages/magmalte/app/views/equipment/EnodebDetailMain.js
+++ b/nms/app/packages/magmalte/app/views/equipment/EnodebDetailMain.js
@@ -15,6 +15,7 @@
  */
 import type {WithAlert} from '@fbcnms/ui/components/Alert/withAlert';
 
+import AutorefreshCheckbox from '../../components/AutorefreshCheckbox';
 import Button from '@material-ui/core/Button';
 import CardTitleRow from '../../components/layout/CardTitleRow';
 import DashboardIcon from '@material-ui/icons/Dashboard';
@@ -23,6 +24,7 @@ import DateTimeMetricChart from '../../components/DateTimeMetricChart';
 import EnodebConfig from './EnodebDetailConfig';
 import EnodebContext from '../../components/context/EnodebContext';
 import GatewayLogs from './GatewayLogs';
+import GraphicEqIcon from '@material-ui/icons/GraphicEq';
 import Grid from '@material-ui/core/Grid';
 import React from 'react';
 import SettingsIcon from '@material-ui/icons/Settings';
@@ -166,6 +168,7 @@ function Overview() {
   const classes = useStyles();
   const [startDate, setStartDate] = useState(moment().subtract(3, 'hours'));
   const [endDate, setEndDate] = useState(moment());
+  const [refresh, setRefresh] = useState(true);
 
   function MetricChartFilter() {
     return (
@@ -204,6 +207,15 @@ function Overview() {
       </Grid>
     );
   }
+
+  function refreshFilter() {
+    return (
+      <AutorefreshCheckbox
+        autorefreshEnabled={refresh}
+        onToggle={() => setRefresh(current => !current)}
+      />
+    );
+  }
   return (
     <div className={classes.dashboardRoot}>
       <Grid container spacing={4}>
@@ -214,7 +226,12 @@ function Overview() {
             </Grid>
 
             <Grid item xs={12} md={6} alignItems="center">
-              <EnodebStatus />
+              <CardTitleRow
+                icon={GraphicEqIcon}
+                label="Status"
+                filter={() => refreshFilter()}
+              />
+              <EnodebStatus refresh={refresh} />
             </Grid>
           </Grid>
         </Grid>

--- a/nms/app/packages/magmalte/app/views/equipment/EnodebDetailSummaryStatus.js
+++ b/nms/app/packages/magmalte/app/views/equipment/EnodebDetailSummaryStatus.js
@@ -18,7 +18,6 @@ import type {DataRows} from '../../components/DataGrid';
 import CardTitleRow from '../../components/layout/CardTitleRow';
 import DataGrid from '../../components/DataGrid';
 import EnodebContext from '../../components/context/EnodebContext';
-import GraphicEqIcon from '@material-ui/icons/GraphicEq';
 import React from 'react';
 import SettingsInputAntennaIcon from '@material-ui/icons/SettingsInputAntenna';
 import nullthrows from '@fbcnms/util/nullthrows';
@@ -53,7 +52,7 @@ export function EnodebSummary() {
   );
 }
 
-export function EnodebStatus() {
+export function EnodebStatus({refresh}: {refresh: boolean}) {
   const {match} = useRouter();
   const enodebSerial: string = nullthrows(match.params.enodebSerial);
   const networkId: string = nullthrows(match.params.networkId);
@@ -67,7 +66,7 @@ export function EnodebStatus() {
     interval: REFRESH_INTERVAL,
     id: enodebSerial,
     enqueueSnackbar,
-    refresh: true,
+    refresh: refresh,
   });
 
   // $FlowIgnore
@@ -126,7 +125,6 @@ export function EnodebStatus() {
   ];
   return (
     <>
-      <CardTitleRow icon={GraphicEqIcon} label="Status" />
       <DataGrid data={kpiData} />
     </>
   );

--- a/nms/app/packages/magmalte/app/views/equipment/GatewayDetailMain.js
+++ b/nms/app/packages/magmalte/app/views/equipment/GatewayDetailMain.js
@@ -14,9 +14,11 @@
  * @format
  */
 import type {WithAlert} from '@fbcnms/ui/components/Alert/withAlert';
+import type {lte_gateway} from '@fbcnms/magma-api';
 
 import AccessAlarmIcon from '@material-ui/icons/AccessAlarm';
 import ArrowDropDownIcon from '@material-ui/icons/ArrowDropDown';
+import AutorefreshCheckbox from '../../components/AutorefreshCheckbox';
 import Button from '@material-ui/core/Button';
 import CardTitleRow from '../../components/layout/CardTitleRow';
 import CellWifiIcon from '@material-ui/icons/CellWifi';
@@ -259,6 +261,10 @@ function GatewayMenuInternal(props: WithAlert) {
 }
 const GatewayMenu = withAlert(GatewayMenuInternal);
 
+export type GatewayDetailType = {
+  gwInfo: lte_gateway,
+  refresh: boolean,
+};
 export function GatewayDetail() {
   const {relativePath, relativeUrl, match} = useRouter();
   const gatewayId: string = nullthrows(match.params.gatewayId);
@@ -339,6 +345,18 @@ function GatewayOverview() {
   const gatewayId: string = nullthrows(match.params.gatewayId);
   const gwCtx = useContext(GatewayContext);
   const gwInfo = gwCtx.state[gatewayId];
+  const [refresh, setRefresh] = useState(true);
+  const [refreshEnodebs, setRefreshEnodebs] = useState(false);
+  const [refreshSubscribers, setRefreshSubscribers] = useState(false);
+
+  const filter = (refresh: boolean, setRefresh) => {
+    return (
+      <AutorefreshCheckbox
+        autorefreshEnabled={refresh}
+        onToggle={() => setRefresh(current => !current)}
+      />
+    );
+  };
 
   return (
     <div className={classes.dashboardRoot}>
@@ -362,19 +380,31 @@ function GatewayOverview() {
         <Grid item xs={12} md={6}>
           <Grid container spacing={4} direction="column">
             <Grid item>
-              <CardTitleRow icon={GraphicEqIcon} label="Status" />
-              <GatewayDetailStatus />
+              <CardTitleRow
+                icon={GraphicEqIcon}
+                label="Status"
+                filter={() => filter(refresh, setRefresh)}
+              />
+              <GatewayDetailStatus refresh={refresh} />
             </Grid>
             <Grid item>
               <CardTitleRow
                 icon={SettingsInputAntennaIcon}
                 label="Connected eNodeBs"
+                filter={() => filter(refreshEnodebs, setRefreshEnodebs)}
               />
-              <GatewayDetailEnodebs gwInfo={gwInfo} />
+              <GatewayDetailEnodebs gwInfo={gwInfo} refresh={refreshEnodebs} />
             </Grid>
             <Grid item>
-              <CardTitleRow icon={PeopleIcon} label="Subscribers" />
-              <GatewayDetailSubscribers gwInfo={gwInfo} />
+              <CardTitleRow
+                icon={PeopleIcon}
+                label="Subscribers"
+                filter={() => filter(refreshSubscribers, setRefreshSubscribers)}
+              />
+              <GatewayDetailSubscribers
+                gwInfo={gwInfo}
+                refresh={refreshSubscribers}
+              />
             </Grid>
           </Grid>
         </Grid>

--- a/nms/app/packages/magmalte/app/views/equipment/GatewayDetailStatus.js
+++ b/nms/app/packages/magmalte/app/views/equipment/GatewayDetailStatus.js
@@ -30,7 +30,7 @@ import {
 } from '../../components/context/RefreshContext';
 import {useRouter} from '@fbcnms/ui/hooks';
 
-export default function GatewayDetailStatus() {
+export default function GatewayDetailStatus({refresh}: {refresh: boolean}) {
   const {match} = useRouter();
   const networkId: string = nullthrows(match.params.networkId);
   const gatewayId: string = nullthrows(match.params.gatewayId);
@@ -41,7 +41,7 @@ export default function GatewayDetailStatus() {
     type: 'gateway',
     interval: REFRESH_INTERVAL,
     id: gatewayId,
-    refresh: true,
+    refresh: refresh,
   });
   const gwInfo = state[gatewayId];
   let checkInTime = new Date(0);

--- a/nms/app/packages/magmalte/app/views/subscriber/SubscriberAddDialog.js
+++ b/nms/app/packages/magmalte/app/views/subscriber/SubscriberAddDialog.js
@@ -391,7 +391,7 @@ export function SubscriberEditDialog(props: DialogProps) {
         variant: 'success',
       });
     } catch (e) {
-      const errMsg = e.response.data?.message ?? e.message;
+      const errMsg = e.response?.data?.message ?? e.message;
       setError('error saving ' + subscriberState.id + ' : ' + errMsg);
       return;
     }

--- a/nms/app/packages/magmalte/app/views/subscriber/SubscriberDetail.js
+++ b/nms/app/packages/magmalte/app/views/subscriber/SubscriberDetail.js
@@ -16,6 +16,7 @@
 import type {DataRows} from '../../components/DataGrid';
 import type {subscriber} from '@fbcnms/magma-api';
 
+import AutorefreshCheckbox from '../../components/AutorefreshCheckbox';
 import CardTitleRow from '../../components/layout/CardTitleRow';
 import DashboardIcon from '@material-ui/icons/Dashboard';
 import DataGrid from '../../components/DataGrid';
@@ -40,7 +41,7 @@ import {Redirect, Route, Switch} from 'react-router-dom';
 import {SubscriberJsonConfig} from './SubscriberDetailConfig';
 import {colors, typography} from '../../theme/default';
 import {makeStyles} from '@material-ui/styles';
-import {useContext} from 'react';
+import {useContext, useState} from 'react';
 import {useRouter} from '@fbcnms/ui/hooks';
 
 const useStyles = makeStyles(theme => ({
@@ -106,7 +107,7 @@ export default function SubscriberDetail() {
   return (
     <>
       <TopBar
-        header={`Equipment/${subscriberInfo.name ?? subscriberId}`}
+        header={`Subscriber/${subscriberInfo.name ?? subscriberId}`}
         tabs={
           !Object.keys(subscriberInfo).length
             ? [
@@ -166,18 +167,26 @@ function StatusInfo() {
   const {match} = useRouter();
   const subscriberId: string = nullthrows(match.params.subscriberId);
   const networkId: string = nullthrows(match.params.networkId);
+  const [refresh, setRefresh] = useState(false);
 
   const ctx = useRefreshingContext({
     context: SubscriberContext,
     networkId: networkId,
     type: 'subscriber',
     interval: REFRESH_INTERVAL,
-    refresh: true,
+    refresh: refresh,
     id: subscriberId,
   });
   // $FlowIgnore
   const subscriberInfo: subscriber = ctx.state?.[subscriberId];
-
+  function refreshFilter() {
+    return (
+      <AutorefreshCheckbox
+        autorefreshEnabled={refresh}
+        onToggle={() => setRefresh(current => !current)}
+      />
+    );
+  }
   return (
     <Grid container spacing={4}>
       <Grid item xs={12} md={6}>
@@ -185,7 +194,11 @@ function StatusInfo() {
         <Info subscriberInfo={subscriberInfo} />
       </Grid>
       <Grid item xs={12} md={6}>
-        <CardTitleRow icon={GraphicEqIcon} label="Status" />
+        <CardTitleRow
+          icon={GraphicEqIcon}
+          label="Status"
+          filter={() => refreshFilter()}
+        />
         <Status subscriberInfo={subscriberInfo} />
       </Grid>
     </Grid>

--- a/nms/app/packages/magmalte/app/views/subscriber/__tests__/SubscriberAddEditTest.js
+++ b/nms/app/packages/magmalte/app/views/subscriber/__tests__/SubscriberAddEditTest.js
@@ -24,6 +24,7 @@ import MuiStylesThemeProvider from '@material-ui/styles/ThemeProvider';
 import PolicyContext from '../../../components/context/PolicyContext';
 import React from 'react';
 import SubscriberContext from '../../../components/context/SubscriberContext';
+import SubscriberDetailConfig from '../SubscriberDetailConfig';
 import defaultTheme from '../../../theme/default.js';
 
 import {MemoryRouter, Route} from 'react-router-dom';
@@ -284,72 +285,74 @@ describe('<AddSubscriberButton />', () => {
     );
   };
 
-  // const DetailWrapper = () => {
-  //   const [subscribers, setSubscribers] = useState(subscribersMock);
-  //   const policyCtx = {
-  //     state: policies,
-  //     qosProfiles: {},
-  //     ratingGroups: {},
-  //     setRatingGroups: async () => {},
-  //     setQosProfiles: async () => {},
-  //     setState: async () => {},
-  //   };
+  const DetailWrapper = () => {
+    const [subscribers, setSubscribers] = useState(subscribersMock);
+    const [sessionState, setSessionState] = useState({});
+    const policyCtx = {
+      state: policies,
+      qosProfiles: {},
+      ratingGroups: {},
+      setRatingGroups: async () => {},
+      setQosProfiles: async () => {},
+      setState: async () => {},
+    };
 
-  //   const apnCtx = {
-  //     state: apns,
-  //     setState: async () => {},
-  //   };
+    const apnCtx = {
+      state: apns,
+      setState: async () => {},
+    };
 
-  //   const networkCtx = {
-  //     state: {
-  //       ...testNetwork,
-  //       cellular: {
-  //         epc: epc,
-  //         ran: ran,
-  //       },
-  //     },
-  //     updateNetworks: async () => {},
-  //   };
-  //   return (
-  //     <MemoryRouter
-  //       initialEntries={[
-  //         '/nms/test/subscribers/overview/IMSI00000000001002/config',
-  //       ]}
-  //       initialIndex={0}>
-  //       <MuiThemeProvider theme={defaultTheme}>
-  //         <MuiStylesThemeProvider theme={defaultTheme}>
-  //           <LteNetworkContext.Provider value={networkCtx}>
-  //             <PolicyContext.Provider value={policyCtx}>
-  //               <ApnContext.Provider value={apnCtx}>
-  //                 <SubscriberContext.Provider
-  //                   value={{
-  //                     state: {
-  //                       IMSI00000000001002: subscribers['IMSI00000000001002'],
-  //                     },
-  //                     gwSubscriberMap: {},
-  //                     sessionState: {},
-  //                     setState: (key, value?) =>
-  //                       setSubscriberState({
-  //                         networkId: 'test',
-  //                         subscriberMap: subscribers,
-  //                         setSubscriberMap: setSubscribers,
-  //                         key: key,
-  //                         value: value,
-  //                       }),
-  //                   }}>
-  //                   <Route
-  //                     path="/nms/:networkId/subscribers/overview/:subscriberId/config"
-  //                     render={props => <SubscriberDetailConfig {...props} />}
-  //                   />
-  //                 </SubscriberContext.Provider>
-  //               </ApnContext.Provider>
-  //             </PolicyContext.Provider>
-  //           </LteNetworkContext.Provider>
-  //         </MuiStylesThemeProvider>
-  //       </MuiThemeProvider>
-  //     </MemoryRouter>
-  //   );
-  // };
+    const networkCtx = {
+      state: {
+        ...testNetwork,
+        cellular: {
+          epc: epc,
+          ran: ran,
+        },
+      },
+      updateNetworks: async () => {},
+    };
+    return (
+      <MemoryRouter
+        initialEntries={[
+          '/nms/test/subscribers/overview/IMSI00000000001002/config',
+        ]}
+        initialIndex={0}>
+        <MuiThemeProvider theme={defaultTheme}>
+          <MuiStylesThemeProvider theme={defaultTheme}>
+            <LteNetworkContext.Provider value={networkCtx}>
+              <PolicyContext.Provider value={policyCtx}>
+                <ApnContext.Provider value={apnCtx}>
+                  <SubscriberContext.Provider
+                    value={{
+                      state: {
+                        IMSI00000000001002: subscribers['IMSI00000000001002'],
+                      },
+                      gwSubscriberMap: {},
+                      sessionState: sessionState,
+                      setState: (key, value?) =>
+                        setSubscriberState({
+                          networkId: 'test',
+                          subscriberMap: subscribers,
+                          setSubscriberMap: setSubscribers,
+                          setSessionState,
+                          key: key,
+                          value: value,
+                        }),
+                    }}>
+                    <Route
+                      path="/nms/:networkId/subscribers/overview/:subscriberId/config"
+                      render={props => <SubscriberDetailConfig {...props} />}
+                    />
+                  </SubscriberContext.Provider>
+                </ApnContext.Provider>
+              </PolicyContext.Provider>
+            </LteNetworkContext.Provider>
+          </MuiStylesThemeProvider>
+        </MuiThemeProvider>
+      </MemoryRouter>
+    );
+  };
 
   it('Verify Subscribers Add', async () => {
     const {
@@ -443,47 +446,47 @@ describe('<AddSubscriberButton />', () => {
     );
   });
 
-  // it('Verify Subscriber edit', async () => {
-  //   const {getByTestId, queryByTestId} = render(<DetailWrapper />);
-  //   await wait();
-  //   expect(queryByTestId('editDialog')).toBeNull();
+  it('Verify Subscriber edit', async () => {
+    const {getByTestId, queryByTestId} = render(<DetailWrapper />);
+    await wait();
+    expect(queryByTestId('editDialog')).toBeNull();
 
-  //   // Edit tab 1 : subscriber info
-  //   fireEvent.click(getByTestId('subscriber'));
-  //   await wait();
-  //   expect(queryByTestId('editDialog')).not.toBeNull();
+    // Edit tab 1 : subscriber info
+    fireEvent.click(getByTestId('subscriber'));
+    await wait();
+    expect(queryByTestId('editDialog')).not.toBeNull();
 
-  //   const name = getByTestId('name').firstChild;
+    const name = getByTestId('name').firstChild;
 
-  //   if (name instanceof HTMLInputElement) {
-  //     fireEvent.change(name, {target: {value: 'test_subscriber'}});
-  //   } else {
-  //     throw 'invalid type';
-  //   }
+    if (name instanceof HTMLInputElement) {
+      fireEvent.change(name, {target: {value: 'test_subscriber'}});
+    } else {
+      throw 'invalid type';
+    }
 
-  //   fireEvent.click(getByTestId('subscriber-saveButton'));
-  //   await wait();
+    fireEvent.click(getByTestId('subscriber-saveButton'));
+    await wait();
 
-  //   expect(
-  //     MagmaAPIBindings.putLteByNetworkIdSubscribersBySubscriberId,
-  //   ).toHaveBeenCalledWith({
-  //     networkId: 'test',
-  //     subscriberId: 'IMSI00000000001002',
-  //     subscriber: {
-  //       active_apns: ['apn_0'],
-  //       active_base_names: undefined,
-  //       id: 'IMSI00000000001002',
-  //       lte: {
-  //         auth_algo: 'MILENAGE',
-  //         auth_key: 'i69HPy+P0JSHzMvXCXxoYg==',
-  //         auth_opc: 'jie2rw5pLnUPMmZ6OxRgXQ==',
-  //         state: 'ACTIVE',
-  //         sub_profile: 'default',
-  //       },
-  //       name: 'test_subscriber',
-  //       static_ips: {apn_0: '1.1.1.1'},
-  //     },
-  //   });
-  //   // TODO: Test other tabs
-  // });
+    expect(
+      MagmaAPIBindings.putLteByNetworkIdSubscribersBySubscriberId,
+    ).toHaveBeenCalledWith({
+      networkId: 'test',
+      subscriberId: 'IMSI00000000001002',
+      subscriber: {
+        active_apns: ['apn_0'],
+        active_base_names: undefined,
+        id: 'IMSI00000000001002',
+        lte: {
+          auth_algo: 'MILENAGE',
+          auth_key: 'i69HPy+P0JSHzMvXCXxoYg==',
+          auth_opc: 'jie2rw5pLnUPMmZ6OxRgXQ==',
+          state: 'ACTIVE',
+          sub_profile: 'default',
+        },
+        name: 'test_subscriber',
+        static_ips: {apn_0: '1.1.1.1'},
+      },
+    });
+    // TODO: Test other tabs
+  });
 });


### PR DESCRIPTION
Signed-off-by: HannaFar <hannafarag159@gmail.com>


## Summary

Refresh gateway detail enodeb and subscriber table.
Add autoRefresh checkbox to enodeb, gateway and subscriber detail.
Fix subscriber add/edit unit test.
Close #4405 

<img width="1792" alt="Capture d’écran 2021-01-20 à 15 39 49" src="https://user-images.githubusercontent.com/26038920/105189966-d3d0c180-5b35-11eb-8340-96337470aa1f.png">

<img width="1791" alt="Capture d’écran 2021-01-20 à 15 39 22" src="https://user-images.githubusercontent.com/26038920/105189994-d92e0c00-5b35-11eb-82c6-38797013ab2f.png">

<img width="1792" alt="Capture d’écran 2021-01-20 à 15 30 16" src="https://user-images.githubusercontent.com/26038920/105190014-ddf2c000-5b35-11eb-9bc1-9664e1a563f0.png">



## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
