### PR TITLE
Modified test case such that TC would wait for Attach Reject and receive UE context release request

### DIFF
--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_act_dflt_ber_ctxt_rej.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_act_dflt_ber_ctxt_rej.py
@@ -104,20 +104,17 @@ class TestAttachCompleteWithActvDfltBearCtxtRej(unittest.TestCase):
         self._s1ap_wrapper._s1_util.issue_cmd(
             s1ap_types.tfwCmd.UE_ACTV_DEFAULT_EPS_BEARER_CNTXT_REJECT, act_rej
         )
-        # Added delay to ensure S1APTester receives the emm information before
-        # sending the detach request message
-        time.sleep(0.5)
-        print("************************* Running UE detach")
-        # Now detach the UE
-        detach_req = s1ap_types.uedetachReq_t()
-        detach_req.ue_Id = req.ue_id
-        detach_req.ueDetType = (
-            s1ap_types.ueDetachType_t.UE_SWITCHOFF_DETACH.value
+        # Attach Reject
+        response = self._s1ap_wrapper.s1_util.get_response()
+        self.assertEqual(
+            response.msg_type, s1ap_types.tfwCmd.UE_ATTACH_REJECT_IND.value
         )
-        self._s1ap_wrapper._s1_util.issue_cmd(
-            s1ap_types.tfwCmd.UE_DETACH_REQUEST, detach_req
+
+        response = self._s1ap_wrapper.s1_util.get_response()
+        self.assertEqual(
+            response.msg_type, s1ap_types.tfwCmd.UE_CTX_REL_IND.value
         )
-        time.sleep(0.5)
+        print("******** released UE contexts ********")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
[lte][agw]: Modified test case such that TC would wait for Attach Reject and receive UE context release request

## Summary
The TC simulates to send Activate Default Bearer Reject, later TC was sending Detach Request. But on reception of Activate Default Bearer Reject message, mme sends Attach Reject and release UE s1ap signaling connection. So modified the TC to receive Attach Reject
## Test Plan
Executed s1ap sanity test suite
