### PR TITLE
Bump the magma build on master to 1.5.0

### DIFF
--- a/lte/gateway/release/build-magma.sh
+++ b/lte/gateway/release/build-magma.sh
@@ -20,8 +20,8 @@ SCRIPT_DIR="$(dirname "$(realpath "$0")")"
 
 # Please update the version number accordingly for beta/stable builds
 # Test builds are versioned automatically by fabfile.py
-VERSION=1.4.0 # magma version number
-SCTPD_MIN_VERSION=1.4.0 # earliest version of sctpd with which this version is compatible
+VERSION=1.5.0 # magma version number
+SCTPD_MIN_VERSION=1.5.0 # earliest version of sctpd with which this version is compatible
 
 # RelWithDebInfo or Debug
 BUILD_TYPE=Debug


### PR DESCRIPTION
Signed-off-by: Michael Callahan <michaelcallahan@fb.com>

## Summary

Switch the magma build versions on master to be 1.5.0

## Test Plan

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
