### PR TITLE
[lte][agw] Using set instead of incrementing for gtp stats UL/DL bytes metrics

### DIFF
--- a/lte/gateway/python/magma/pipelined/gtp_stats_collector.py
+++ b/lte/gateway/python/magma/pipelined/gtp_stats_collector.py
@@ -80,9 +80,9 @@ class GTPStatsCollector(Job):
         for r in list(dump_stats_results)[0].out:
             if GTP_IP_INTERFACE_PREFIX in r.Interface or \
                     r.Interface == GTP_INTERFACE_PREFIX:
-                GTP_PORT_USER_PLANE_DL_BYTES.labels(r.remote_ip).inc(
+                GTP_PORT_USER_PLANE_DL_BYTES.labels(r.remote_ip).set(
                     float(r.rx_bytes))
-                GTP_PORT_USER_PLANE_UL_BYTES.labels(r.remote_ip).inc(
+                GTP_PORT_USER_PLANE_UL_BYTES.labels(r.remote_ip).set(
                     float(r.tx_bytes))
 
 

--- a/lte/gateway/python/magma/pipelined/metrics.py
+++ b/lte/gateway/python/magma/pipelined/metrics.py
@@ -49,12 +49,12 @@ NETWORK_IFACE_STATUS = Gauge(
     ['iface_name'],
 )
 
-GTP_PORT_USER_PLANE_UL_BYTES = Counter('gtp_port_user_plane_ul_bytes',
+GTP_PORT_USER_PLANE_UL_BYTES = Gauge('gtp_port_user_plane_ul_bytes',
                                        'GTP port user plane uplink bytes',
                                        ['ip_addr'],
                                        )
 
-GTP_PORT_USER_PLANE_DL_BYTES = Counter('gtp_port_user_plane_dl_bytes',
+GTP_PORT_USER_PLANE_DL_BYTES = Gauge('gtp_port_user_plane_dl_bytes',
                                        'GTP port user plane downlink bytes',
                                        ['ip_addr'],
                                        )


### PR DESCRIPTION
Signed-off-by: Alex Rodriguez <ardzoht@gmail.com>

## Summary

- GTP stats (used for UL / DL data usage for eNB) are incorrectly being incremented each scraping time period (1 min), from aggregated value on Interface table from OVS DB.
- This updates the metric for both upload and download usage to be set instead of incrementing metric.

## Test Plan

- Tested using eNB and UE locally, 

```
"g_f002000a" {key=flow, remote_ip=flow} {rx_bytes=6131, rx_packets=979, tx_bytes=26402, tx_packets=278}

name: "gtp_port_user_plane_dl_bytes"
type: GAUGE
metric {
  label {
    name: "ip_addr"
    value: "0.0.0.0"
  }
  gauge {
    value: 0.0
  }
  timestamp_ms: 1611102128580
}
metric {
  label {
    name: "ip_addr"
    value: "10.0.2.10"
  }
  gauge {
    value: 6131.0
  }
  timestamp_ms: 1611102128580
}
```

## Additional Information

- [ ] This change is backwards-breaking
