### PR TITLE
[go] bypass initflag in case of test with debugger

### DIFF
--- a/orc8r/lib/go/initflag/initflag.go
+++ b/orc8r/lib/go/initflag/initflag.go
@@ -26,7 +26,8 @@ func init() {
 	flag.Var(
 		&syslogDest,
 		syslogFlag,
-		"Redirect stderr to syslog, optional syslog destination in network::address format (system default otherwise)")
+		"Redirect stderr to syslog, optional syslog destination in network::address format (system default otherwise)",
+	)
 
 	if shouldParse() {
 		// Save original settings
@@ -66,6 +67,18 @@ func init() {
 func shouldParse() bool {
 	isTest := strings.HasSuffix(os.Args[0], ".test") ||
 		strings.HasSuffix(os.Args[0], "_test.go") ||
-		strings.HasSuffix(os.Args[0], "_test_go")
+		strings.HasSuffix(os.Args[0], "_test_go") ||
+		isInArgs("-test.v")
 	return !flag.Parsed() && !isTest
+}
+
+// isInArgs returns true if any of the argunents passed to the command maches
+// with the passed match stirng
+func isInArgs(match string) bool {
+	for _, arg := range os.Args {
+		if arg == match {
+			return true
+		}
+	}
+	return false
 }


### PR DESCRIPTION
Signed-off-by: Oriol Batalla <obatalla@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary

This PR enhances the hack to bypass parsing the flags in case of running a test.

Now we can see the output of the test on the debugger

Before
``
PASS
``

After
```
=== RUN   TestS8Proxy
mock PGW Received a CreateSessionRequest
--- PASS: TestS8Proxy (0.04s)
    s8_proxy_test.go:40: Running PGW at 127.0.0.1:63973
PASS
```

## Test Plan

make precommit both feg and orc8r

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
