### PR TITLE
[Orc8r][AWS/Terraform/Helm] Fix elastic search curator config

### DIFF
--- a/orc8r/cloud/deploy/terraform/orc8r-helm-aws/logging.tf
+++ b/orc8r/cloud/deploy/terraform/orc8r-helm-aws/logging.tf
@@ -114,6 +114,10 @@ resource "helm_release" "elasticsearch_curator" {
       client:
         hosts:
           - "${var.elasticsearch_endpoint}"
+        port: "${var.elasticsearch_port}"
+        use_ssl: "${var.elasticsearch_use_ssl}"
+      logging:
+        loglevel: "${var.elasticsearch_curator_log_level}"
 
     action_file_yml: |-
       ---

--- a/orc8r/cloud/deploy/terraform/orc8r-helm-aws/variables.tf
+++ b/orc8r/cloud/deploy/terraform/orc8r-helm-aws/variables.tf
@@ -240,6 +240,24 @@ variable "elasticsearch_retention_days" {
   default     = 7
 }
 
+variable "elasticsearch_port" {
+  description = "Port Elastic search is listening."
+  type        = number
+  default     = 443
+}
+
+variable "elasticsearch_use_ssl" {
+  description = "Defines if elasicsearch curator should speak to ELK HTTP or HTTPS."
+  type        = string
+  default     = "True"
+}
+
+variable "elasticsearch_curator_log_level" {
+  description = "Defines Elasticsearch curator logging level."
+  type        = string
+  default     = "INFO"
+}
+
 ##############################################################################
 # Secret configuration and values
 ##############################################################################


### PR DESCRIPTION
Signed-off-by: Vitalii Kostenko <vitalii@freedomfi.com>

At the moment as a result of terraform deployment we are getting misconfigured elastic search curator job - which is silently failing. As a result indexes in ELK live forever and ELK dies with out of dick space. This patch fixes elastic search curator config.
## Summary
By default Elastic Search curator is configured to connect to port 9200 of the host specified in the config, but AWS ElasticSearch is listening port 443.  

## Test Plan
- Preconfigure Elastic Search Curator with 1 day retention
- Perform vanilla deployment using magma master version
- Wait for 2-3 days - see that log retention is not happening
- Update deployment with patched version
- Run following, and check that indexes were delete
```
kubectl -n monitoring create job --from=cronjob.batch/elasticsearch-curator cron-test
kubectl -n monitoring logs cron-test-....
```
- Check Indexes in Kibana



