### PR TITLE
[feg/lte/xwf] upgrade dockers to focal with py3.8

### DIFF
--- a/cwf/gateway/configs/gateway.mconfig
+++ b/cwf/gateway/configs/gateway.mconfig
@@ -67,6 +67,6 @@
       "@type": "type.googleapis.com/magma.mconfig.MonitorD",
       "logLevel": "DEBUG",
       "pollingInterval": 60
-    },
+    }
   }
 }

--- a/cwf/gateway/deploy/roles/ovs/files/0004-ovsdb-idlc.in-dict-changes.patch
+++ b/cwf/gateway/deploy/roles/ovs/files/0004-ovsdb-idlc.in-dict-changes.patch
@@ -1,0 +1,18 @@
+---
+ ovsdb/ovsdb-idlc.in | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/ovsdb/ovsdb-idlc.in b/ovsdb/ovsdb-idlc.in
+index 40fef39ed..22d0a4e22 100755
+--- a/ovsdb/ovsdb-idlc.in
++++ b/ovsdb/ovsdb-idlc.in
+@@ -176,7 +176,7 @@ def replace_cplusplus_keyword(schema):
+                 'wchar_t', 'while', 'xor', 'xor_eq'}
+
+     for tableName, table in schema.tables.items():
+-        for columnName in table.columns:
++        for columnName in list(table.columns):
+             if columnName in keywords:
+                 table.columns[columnName + '_'] = table.columns.pop(columnName)
+
+--

--- a/cwf/gateway/docker/docker-compose.yml
+++ b/cwf/gateway/docker/docker-compose.yml
@@ -67,7 +67,7 @@ services:
       test: ["CMD", "nc", "-zv", "localhost","50067"]
       timeout: "4s"
       retries: 3
-    command: python3.5 -m magma.directoryd.main
+    command: python3.8 -m magma.directoryd.main
 
   eap_sim:
     <<: *feggoservice
@@ -94,7 +94,7 @@ services:
   eventd:
     <<: *pyservice
     container_name: eventd
-    command: python3.5 -m magma.eventd.main
+    command: python3.8 -m magma.eventd.main
 
   health:
     <<: *feggoservice
@@ -130,7 +130,7 @@ services:
       DOCKER_REGISTRY: ${DOCKER_REGISTRY}
       DOCKER_USERNAME: ${DOCKER_USERNAME}
       DOCKER_PASSWORD: ${DOCKER_PASSWORD}
-    command: python3.5 -m magma.magmad.main
+    command: python3.8 -m magma.magmad.main
 
   pipelined:
     <<: *ltepyservice
@@ -154,12 +154,12 @@ services:
         /usr/bin/ovs-vsctl set-fail-mode cwag_br0 secure &&
         /usr/bin/ovs-vsctl set bridge cwag_br0 other-config:disable-in-band=true &&
         /var/opt/magma/scripts/add_uplink_bridge_flows.sh ${UPLINK_PORTS:-eth2 eth3} &&
-        python3.5 -m magma.pipelined.main"
+        python3.8 -m magma.pipelined.main"
 
   monitord:
     <<: *ltepyservice
     container_name: monitord
-    command: python3.5 -m magma.monitord.main
+    command: python3.8 -m magma.monitord.main
 
   policydb:
     <<: *ltepyservice
@@ -170,12 +170,12 @@ services:
       retries: 3
     depends_on:
       - redis
-    command: python3.5 -m magma.policydb.main
+    command: python3.8 -m magma.policydb.main
 
   redirectd:
     <<: *ltepyservice
     container_name: redirectd
-    command: python3.5 -m magma.redirectd.main
+    command: python3.8 -m magma.redirectd.main
 
   radius:
     image: ${DOCKER_REGISTRY}gateway_go:${IMAGE_VERSION}
@@ -232,7 +232,7 @@ services:
     container_name: state
     depends_on:
       - redis
-    command: python3.5 -m magma.state.main
+    command: python3.8 -m magma.state.main
 
   td-agent-bit:
     <<: *pyservice
@@ -242,4 +242,3 @@ services:
     command: >
         /bin/bash -c "/usr/local/bin/generate_fluent_bit_config.py &&
         /opt/td-agent-bit/bin/td-agent-bit -c /var/opt/magma/tmp/td-agent-bit.conf"
-

--- a/cwf/gateway/docker/python/Dockerfile
+++ b/cwf/gateway/docker/python/Dockerfile
@@ -1,7 +1,7 @@
 # -----------------------------------------------------------------------------
 # Builder image for Magma proto files
 # -----------------------------------------------------------------------------
-FROM ubuntu:bionic AS builder
+FROM ubuntu:focal AS builder
 
 # Install the runtime deps from apt.
 RUN apt-get -y update && apt-get -y install curl make virtualenv zip \
@@ -16,9 +16,9 @@ RUN curl -Lfs https://github.com/google/protobuf/releases/download/v3.1.0/protoc
   chmod -R a+Xr /usr/include/google && \
   rm -rf protoc3.zip protoc3
 
-# Install python3.5 since it's not native on bionic
+# Install python3.8 since it's not native on focal
 RUN apt-add-repository "ppa:deadsnakes/ppa"
-RUN apt-get -y update && apt-get -y install python3.5
+RUN apt-get -y update && apt-get -y install python3.8
 
 ENV MAGMA_ROOT /magma
 ENV PYTHON_BUILD /build/python
@@ -39,7 +39,10 @@ RUN make -C $MAGMA_ROOT/orc8r/gateway/python protos
 # -----------------------------------------------------------------------------
 # Dev/Production image
 # -----------------------------------------------------------------------------
-FROM ubuntu:bionic AS lte_gateway_python
+FROM ubuntu:focal AS lte_gateway_python
+
+# workaround to avoid interactive tzdata configuration
+ARG DEBIAN_FRONTEND=noninteractive
 
 # Add the magma apt repo
 RUN apt-get update && \
@@ -50,9 +53,9 @@ RUN apt-key add /tmp/jfrog.pub && \
     apt-add-repository "deb https://facebookconnectivity.jfrog.io/artifactory/list/dev/ bionic main" && \
     apt-add-repository "deb http://archive.ubuntu.com/ubuntu/ bionic-proposed restricted main multiverse universe"
 
- # Install python3.5 since it's not native on bionic
+ # Install python3.8 since it's not native on focal
 RUN apt-add-repository "ppa:deadsnakes/ppa"
-RUN apt-get -y update && apt-get -y install python3.5
+RUN apt-get -y update && apt-get -y install python3.8
 
 RUN apt-get -y update && apt-get -y install \
     curl \
@@ -60,7 +63,7 @@ RUN apt-get -y update && apt-get -y install \
     libev4 \
     libffi-dev \
     libjansson4 \
-    libjemalloc1 \
+    libjemalloc2 \
     libssl-dev \
     libsystemd-dev \
     magma-nghttpx=1.31.1-1 \
@@ -81,7 +84,7 @@ RUN apt-get -y update && apt-get -y install \
     netcat \
     iputils-ping
 
-RUN python3.5 -m pip install --no-cache-dir \
+RUN python3.8 -m pip install --no-cache-dir \
     Cython \
     fire \
     envoy \
@@ -137,11 +140,11 @@ RUN make install
 
 # Install orc8r python (magma.common required for lte python)
 COPY orc8r/gateway/python /tmp/orc8r
-RUN python3.5 -m pip install --no-cache-dir /tmp/orc8r
+RUN python3.8 -m pip install --no-cache-dir /tmp/orc8r
 
 # Install lte python
 COPY lte/gateway/python /tmp/lte
-RUN python3.5 -m pip install --no-cache-dir /tmp/lte
+RUN python3.8 -m pip install --no-cache-dir /tmp/lte
 
 # Copy the configs.
 COPY lte/gateway/configs /etc/magma

--- a/cwf/gateway/docker/python/Dockerfile
+++ b/cwf/gateway/docker/python/Dockerfile
@@ -3,6 +3,9 @@
 # -----------------------------------------------------------------------------
 FROM ubuntu:focal AS builder
 
+# workaround to avoid interactive tzdata configurtaion
+ARG DEBIAN_FRONTEND=noninteractive
+
 # Install the runtime deps from apt.
 RUN apt-get -y update && apt-get -y install curl make virtualenv zip \
   apt-utils software-properties-common apt-transport-https
@@ -41,17 +44,14 @@ RUN make -C $MAGMA_ROOT/orc8r/gateway/python protos
 # -----------------------------------------------------------------------------
 FROM ubuntu:focal AS lte_gateway_python
 
-# workaround to avoid interactive tzdata configuration
-ARG DEBIAN_FRONTEND=noninteractive
-
 # Add the magma apt repo
 RUN apt-get update && \
     apt-get install -y apt-utils software-properties-common apt-transport-https
 COPY orc8r/tools/ansible/roles/pkgrepo/files/jfrog.pub /tmp/jfrog.pub
 COPY cwf/gateway/deploy/roles/ovs/files/magma-preferences /etc/apt/preferences.d/
 RUN apt-key add /tmp/jfrog.pub && \
-    apt-add-repository "deb https://facebookconnectivity.jfrog.io/artifactory/list/dev/ bionic main" && \
-    apt-add-repository "deb http://archive.ubuntu.com/ubuntu/ bionic-proposed restricted main multiverse universe"
+    apt-add-repository "deb https://facebookconnectivity.jfrog.io/artifactory/list/dev/ focal main" && \
+    apt-add-repository "deb http://archive.ubuntu.com/ubuntu/ focal-proposed restricted main multiverse universe"
 
  # Install python3.8 since it's not native on focal
 RUN apt-add-repository "ppa:deadsnakes/ppa"
@@ -72,7 +72,7 @@ RUN apt-get -y update && apt-get -y install \
     pkg-config \
     python-cffi \
     python3-pip \
-    python3.5-dev \
+    python3.8-dev \
     redis-server \
     iptables \
     git \
@@ -116,7 +116,7 @@ RUN python3.8 -m pip install --no-cache-dir \
     python-dateutil \
     jsonpickle
 
-COPY cwf/gateway/deploy/roles/ovs/files/nx_actions.py /usr/local/lib/python3.5/dist-packages/ryu/ofproto/
+COPY cwf/gateway/deploy/roles/ovs/files/nx_actions.py /usr/local/lib/python3.8/dist-packages/ryu/ofproto/
 
 # Temporary workaround to restore uplink bridge flows
 RUN mkdir -p /var/opt/magma/scripts
@@ -128,11 +128,12 @@ RUN git clone --depth 1 --single-branch --branch v2.12.0 https://github.com/open
 COPY cwf/gateway/deploy/roles/ovs/files/0001-Add-custom-IPDR-fields-for-IPFIX-export.patch /tmp
 COPY cwf/gateway/deploy/roles/ovs/files/0002-ovs-Handle-spaces-in-ovs-arguments.patch /tmp
 COPY cwf/gateway/deploy/roles/ovs/files/0003-Add-pdp_start_epoch-custom-field-to-IPFIX-export.patch /tmp
-
+COPY cwf/gateway/deploy/roles/ovs/files//0004-ovsdb-idlc.in-dict-changes.patch /tmp
 WORKDIR ovs
 RUN git apply /tmp/0001-Add-custom-IPDR-fields-for-IPFIX-export.patch
 RUN git apply /tmp/0002-ovs-Handle-spaces-in-ovs-arguments.patch
 RUN git apply /tmp/0003-Add-pdp_start_epoch-custom-field-to-IPFIX-export.patch
+RUN git apply /tmp/0004-ovsdb-idlc.in-dict-changes.patch
 RUN ./boot.sh
 RUN ./configure --prefix=/usr --localstatedir=/var --sysconfdir=/etc
 RUN make
@@ -154,4 +155,12 @@ RUN mkdir -p /var/opt/magma/configs
 WORKDIR /
 
 # Copy the build artifacts.
-COPY --from=builder /build/python/gen /usr/local/lib/python3.5/dist-packages/
+COPY --from=builder /build/python/gen /usr/local/lib/python3.8/dist-packages/
+
+# update aioh2 since there is no pushed package, but master is fixed
+RUN python3.8 -m pip install --force-reinstall git+https://github.com/URenko/aioh2.git
+
+# patching aioeventlet
+RUN mkdir /patches
+COPY lte/gateway/python/patches/aioeventlet.py38.patch /patches
+RUN patch -N -s -f /usr/local/lib/python3.8/dist-packages/aioeventlet.py < patches/aioeventlet.py38.patch

--- a/feg/gateway/docker/.env
+++ b/feg/gateway/docker/.env
@@ -25,4 +25,4 @@ CONFIGS_TEMPLATES_PATH=../../../orc8r/gateway/configs/templates
 CERTS_VOLUME=gwcerts
 CONFIGS_VOLUME=gwconfigs
 
-LOG_DRIVER=journald
+LOG_DRIVER=json-file

--- a/feg/gateway/docker/.env
+++ b/feg/gateway/docker/.env
@@ -25,4 +25,4 @@ CONFIGS_TEMPLATES_PATH=../../../orc8r/gateway/configs/templates
 CERTS_VOLUME=gwcerts
 CONFIGS_VOLUME=gwconfigs
 
-LOG_DRIVER=json-file
+LOG_DRIVER=journald

--- a/feg/gateway/docker/docker-compose.override.yml
+++ b/feg/gateway/docker/docker-compose.override.yml
@@ -60,7 +60,7 @@ services:
     extra_hosts:
       - controller.magma.test:127.0.0.1
       - bootstrapper-controller.magma.test:127.0.0.1
-    command: python3.5 -m magma.magmad.main
+    command: python3.8 -m magma.magmad.main
 
 volumes:
   gwcerts:

--- a/feg/gateway/docker/docker-compose.yml
+++ b/feg/gateway/docker/docker-compose.yml
@@ -63,7 +63,7 @@ services:
   eventd:
     <<: *pyservice
     container_name: eventd
-    command: python3.5 -m magma.eventd.main
+    command: python3.8 -m magma.eventd.main
 
   aaa_server:
     <<: *goservice
@@ -132,7 +132,7 @@ services:
       DOCKER_REGISTRY: ${DOCKER_REGISTRY}
       DOCKER_USERNAME: ${DOCKER_USERNAME}
       DOCKER_PASSWORD: ${DOCKER_PASSWORD}
-    command: python3.5 -m magma.magmad.main
+    command: python3.8 -m magma.magmad.main
 
   redis:
     <<: *pyservice

--- a/feg/gateway/docker/python/Dockerfile
+++ b/feg/gateway/docker/python/Dockerfile
@@ -19,7 +19,7 @@ RUN curl -Lfs https://github.com/google/protobuf/releases/download/v3.1.0/protoc
   chmod -R a+Xr /usr/include/google && \
   rm -rf protoc3.zip protoc3
 
-# Install python3.5 since it's not native on bionic
+# Install python3.8 since it's not native on focal
 RUN apt-add-repository "ppa:deadsnakes/ppa"
 RUN apt-get -y update && apt-get -y install python3.8
 
@@ -63,22 +63,24 @@ RUN make -C $MAGMA_ROOT/orc8r/gateway/python swagger
 # -----------------------------------------------------------------------------
 # Production image
 # -----------------------------------------------------------------------------
-FROM ubuntu:bionic AS gateway_python
+FROM ubuntu:focal AS gateway_python
 
 # Add the magma apt repo
 RUN apt-get update && \
     apt-get install -y apt-utils software-properties-common apt-transport-https curl
 COPY orc8r/tools/ansible/roles/pkgrepo/files/jfrog.pub /tmp/jfrog.pub
+# TODO: change repo to focal once there will be such
 RUN apt-key add /tmp/jfrog.pub && \
-    apt-add-repository "deb https://facebookconnectivity.jfrog.io/artifactory/list/dev/ xenial main"
+    apt-add-repository "deb https://facebookconnectivity.jfrog.io/artifactory/list/dev/ bionic main"
 RUN curl -L http://packages.fluentbit.io/fluentbit.key > /tmp/fluentbit.key
 RUN apt-key add /tmp/fluentbit.key && \
-    apt-add-repository "deb https://packages.fluentbit.io/ubuntu/bionic bionic main"
+    apt-add-repository "deb https://packages.fluentbit.io/ubuntu/focal focal main"
 
-# Install python3.5 since it's not native on focal
+# Install python3.8 since it's not native on focal
 RUN apt-add-repository "ppa:deadsnakes/ppa"
 RUN apt-get -y update && apt-get -y install python3.8
 
+# TODO: magma-nghttpx=1.31.1-1 requires upgrade to ff.
 # Install the runtime deps from apt.
 RUN apt-get -y update && apt-get -y install \
   iproute2 \
@@ -86,7 +88,7 @@ RUN apt-get -y update && apt-get -y install \
   libev4 \
   libffi-dev \
   libjansson4 \
-  libjemalloc1 \
+  libjemalloc2 \
   libssl-dev \
   libsystemd-dev \
   magma-nghttpx=1.31.1-1 \
@@ -117,10 +119,7 @@ COPY orc8r/gateway/python /tmp/orc8r
 RUN python3.8 -m pip install --no-cache-dir /tmp/orc8r
 
 # update aioh2 since there is no pushed package
-RUN curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
-RUN python3.8 get-pip.py
 RUN pip3 install --force-reinstall git+https://github.com/URenko/aioh2.git
-
 
 # Copy the build artifacts.
 COPY --from=builder /build/python/gen /usr/local/lib/python3.8/dist-packages/

--- a/feg/gateway/docker/python/Dockerfile
+++ b/feg/gateway/docker/python/Dockerfile
@@ -1,7 +1,10 @@
 # -----------------------------------------------------------------------------
 # Builder image to generate proto files
 # -----------------------------------------------------------------------------
-FROM ubuntu:bionic AS builder
+FROM ubuntu:focal AS builder
+
+# workaround to avoid interactive tzdata configuration
+ARG DEBIAN_FRONTEND=noninteractive
 
 # Install the runtime deps from apt.
 RUN apt-get -y update && apt-get -y install curl make virtualenv zip \
@@ -18,7 +21,7 @@ RUN curl -Lfs https://github.com/google/protobuf/releases/download/v3.1.0/protoc
 
 # Install python3.5 since it's not native on bionic
 RUN apt-add-repository "ppa:deadsnakes/ppa"
-RUN apt-get -y update && apt-get -y install python3.5
+RUN apt-get -y update && apt-get -y install python3.8
 
 ENV MAGMA_ROOT /magma
 ENV PYTHON_BUILD /build/python
@@ -72,9 +75,9 @@ RUN curl -L http://packages.fluentbit.io/fluentbit.key > /tmp/fluentbit.key
 RUN apt-key add /tmp/fluentbit.key && \
     apt-add-repository "deb https://packages.fluentbit.io/ubuntu/bionic bionic main"
 
-# Install python3.5 since it's not native on bionic
+# Install python3.5 since it's not native on focal
 RUN apt-add-repository "ppa:deadsnakes/ppa"
-RUN apt-get -y update && apt-get -y install python3.5
+RUN apt-get -y update && apt-get -y install python3.8
 
 # Install the runtime deps from apt.
 RUN apt-get -y update && apt-get -y install \
@@ -93,7 +96,7 @@ RUN apt-get -y update && apt-get -y install \
   pkg-config \
   python-cffi \
   python3-pip \
-  python3.5-dev \
+  python3.8-dev \
   redis-server \
   git \
   netcat \
@@ -111,10 +114,16 @@ RUN chmod 755 /usr/bin/docker-compose
 
 # Install python code.
 COPY orc8r/gateway/python /tmp/orc8r
-RUN python3.5 -m pip install --no-cache-dir /tmp/orc8r
+RUN python3.8 -m pip install --no-cache-dir /tmp/orc8r
+
+# update aioh2 since there is no pushed package
+RUN curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
+RUN python3.8 get-pip.py
+RUN pip3 install --force-reinstall git+https://github.com/URenko/aioh2.git
+
 
 # Copy the build artifacts.
-COPY --from=builder /build/python/gen /usr/local/lib/python3.5/dist-packages/
+COPY --from=builder /build/python/gen /usr/local/lib/python3.8/dist-packages/
 
 # Copy the configs.
 COPY feg/gateway/configs /etc/magma

--- a/orc8r/gateway/docker/Dockerfile
+++ b/orc8r/gateway/docker/Dockerfile
@@ -1,6 +1,6 @@
 # Builder image to generate proto files
 # -----------------------------------------------------------------------------
-FROM ubuntu:bionic AS builder
+FROM ubuntu:focal AS builder
 
 # Install the runtime deps from apt.
 RUN apt-get -y update && apt-get -y install curl make virtualenv zip \
@@ -15,9 +15,9 @@ RUN curl -Lfs https://github.com/google/protobuf/releases/download/v3.1.0/protoc
   chmod -R a+Xr /usr/include/google && \
   rm -rf protoc3.zip protoc3
 
-# Install python3.5 since it's not native on bionic
+# Install python3.8 since it's not native on bionic
 RUN apt-add-repository "ppa:deadsnakes/ppa"
-RUN apt-get -y update && apt-get -y install python3.5
+RUN apt-get -y update && apt-get -y install python3.8
 
 ENV MAGMA_ROOT /magma
 ENV PYTHON_BUILD /build/python
@@ -35,7 +35,7 @@ RUN make -C $MAGMA_ROOT/lte/gateway/python protos
 # -----------------------------------------------------------------------------
 # Production image
 # -----------------------------------------------------------------------------
-FROM ubuntu:bionic AS gateway_python
+FROM ubuntu:focal AS gateway_python
 
 # Add the magma apt repo
 RUN apt-get update && \
@@ -45,11 +45,12 @@ COPY cwf/gateway/deploy/roles/ovs/files/magma-preferences /etc/apt/preferences.d
 RUN apt-key add /tmp/jfrog.pub && \
     apt-add-repository "deb https://facebookconnectivity.jfrog.io/artifactory/list/dev/ xenial main"
 
-# Install python3.5 since it's not native on bionic
-RUN apt-add-repository "ppa:deadsnakes/ppa"
-RUN apt-get -y update && apt-get -y install python3.5
+# Install python3.8 since it's not native on bionic
+#RUN apt-add-repository "ppa:deadsnakes/ppa"
+#RUN apt-get -y update && apt-get -y install python3.8
 
 # Install the runtime deps from apt.
+# TODO: magma-nghttpx=1.31.1-1 requires upgrade to ff.
 RUN apt-get -y update && apt-get -y install \
   curl \
   fabric \
@@ -57,7 +58,7 @@ RUN apt-get -y update && apt-get -y install \
   libev4 \
   libffi-dev \
   libjansson4 \
-  libjemalloc1 \
+  libjemalloc2 \
   libssl-dev \
   libsystemd-dev \
   magma-nghttpx=1.31.1-1 \
@@ -67,7 +68,7 @@ RUN apt-get -y update && apt-get -y install \
   pkg-config \
   python-cffi \
   python3-pip \
-  python3.5-dev \
+  python3.8-dev \
   redis-server \
   network-manager
 
@@ -77,10 +78,10 @@ RUN curl -sSL https://get.docker.com/ > /tmp/get_docker.sh && \
 
 # Install python code.
 COPY orc8r/gateway/python /tmp/orc8r
-RUN python3.5 -m pip install --no-cache-dir /tmp/orc8r
+RUN python3.8 -m pip install --no-cache-dir /tmp/orc8r
 
 # Copy the build artifacts.
-COPY --from=builder /build/python/gen /usr/local/lib/python3.5/dist-packages/
+COPY --from=builder /build/python/gen /usr/local/lib/python3.8/dist-packages/
 
 # Copy the configs.
 COPY orc8r/gateway/configs /etc/magma

--- a/orc8r/gateway/docker/docker-compose.yml
+++ b/orc8r/gateway/docker/docker-compose.yml
@@ -34,7 +34,7 @@ services:
       - ${CONFIGS_VOLUME}:/var/opt/magma/configs
       - ${SNOWFLAKE_PATH}:/etc/snowflake
       - /var/run/docker.sock:/var/run/docker.sock
-    command: python3.5 -m magma.magmad.main
+    command: python3.8 -m magma.magmad.main
 
   control_proxy:
     <<: *pyservice

--- a/orc8r/gateway/python/setup.py
+++ b/orc8r/gateway/python/setup.py
@@ -64,7 +64,7 @@ setup(
         'docker>=4.0.2',
         'fire>=0.2.0',
         'glob2>=0.7',
-        'aioh2==0.2.2',
+        'aioh2>=0.2.2',
         'redis>=2.10.5',  # redis-py (Python bindings to redis)
         'redis-collections>=0.4.2',
         'aiohttp>=0.17.2',


### PR DESCRIPTION
[feg/lte] upgrade dockers to focal with py3.8

## Summary

Changed docker files for feg to use py 3.8 since py3.5 is deprecated


NOTE:
Do not merge this till we get supported version for focal of package magma-nghttp, otherwise docker control_proxy wont start



## Test Plan

```
$ cd magma/feg/gateway/docker
$ docker-compose build
$ docker-compose up -d

$ docker ps
CONTAINER ID        IMAGE                       COMMAND                  CREATED             STATUS              PORTS               NAMES
9696160acd0e        feg_gateway_python:latest   "python3.8 -m magma.…"   9 seconds ago       Up 8 seconds                            magmad
bfe342db5f0a        feg_gateway_python:latest   "/bin/bash -c '/usr/…"   9 seconds ago       Up 8 seconds                            control_proxy
ce17b47a13eb        feg_gateway_python:latest   "/bin/bash -c '/usr/…"   10 seconds ago      Up 9 seconds                            redis
35dd0ea7dc2d        feg_gateway_go_base         "/bin/bash -c 'mkdir…"   10 seconds ago      Up 9 seconds                            test
6fe0c8b1e2f7        feg_gateway_go:latest       "envdir /var/opt/mag…"   19 seconds ago      Up 17 seconds                           radiusd
2a3c08fcee67        feg_gateway_go:latest       "envdir /var/opt/mag…"   19 seconds ago      Up 17 seconds                           eap_aka
0a758bf6f40f        feg_gateway_go:latest       "envdir /var/opt/mag…"   19 seconds ago      Up 17 seconds                           csfb
d71bfd0f9ab8        feg_gateway_go:latest       "envdir /var/opt/mag…"   19 seconds ago      Up 17 seconds                           swx_proxy
04b7f849bb1c        feg_gateway_go:latest       "envdir /var/opt/mag…"   19 seconds ago      Up 17 seconds                           s6a_proxy
2d3a0a7dd66c        feg_gateway_go:latest       "envdir /var/opt/mag…"   19 seconds ago      Up 18 seconds                           feg_hello
2729e89fe120        feg_gateway_go              "envdir /var/opt/mag…"   19 seconds ago      Up 18 seconds                           hss
07db950315a6        feg_gateway_go:latest       "envdir /var/opt/mag…"   19 seconds ago      Up 18 seconds                           aaa_server
9fa5ad5e3fad        feg_gateway_go:latest       "envdir /var/opt/mag…"   19 seconds ago      Up 18 seconds                           session_proxy
d8bf7ec7536c        feg_gateway_go:latest       "envdir /var/opt/mag…"   19 seconds ago      Up 18 seconds                           health
44d07356ee0c        feg_gateway_go:latest       "envdir /var/opt/mag…"   19 seconds ago      Up 18 seconds                           eap_sim
b7c70da83730        feg_gateway_python:latest   "python3.8 -m magma.…"   20 seconds ago      Up 19 seconds                           eventd
62c6344846dd        feg_gateway_python:latest   "/bin/bash -c '/usr/…"   20 seconds ago      Up 18 seconds                           td-agent-bit

```


Tested also xwf-m box with cwf's pipelined and magmad and made sure all looks ok and running py3.8.

```
# docker ps
CONTAINER ID   IMAGE                                                                    COMMAND                  CREATED         STATUS                   PORTS                    NAMES
36bacfa1cc69   facebookconnectivity-xwf-m-staging-docker.jfrog.io/goradius:aff7160f     "/bin/sh -c ./docker…"   3 minutes ago   Up 3 minutes                                      radius
519c5017099d   facebookconnectivity-openflow-docker.jfrog.io/gateway_pipelined:latest   "sh -c 'set bridge c…"   3 minutes ago   Up 3 minutes                                      pipelined
7ccc808fe098   facebookconnectivity-openflow-docker.jfrog.io/gateway_python:latest      "python3.8 -m magma.…"   3 minutes ago   Up 3 minutes                                      magmad
8fa7d6eec5b1   facebookconnectivity-openflow-docker.jfrog.io/gateway_python:latest      "sh -c '/usr/local/b…"   3 minutes ago   Up 3 minutes                                      control_proxy
92bd4591c73a   facebookconnectivity-xwf-m-staging-docker.jfrog.io/gateway_go:aff7160f   "envdir /var/opt/mag…"   3 minutes ago   Up 3 minutes                                      radiusd
2f579a7c1bb1   facebookconnectivity-xwf-m-staging-docker.jfrog.io/logrouter             "/bin/sh -c /entrypo…"   3 minutes ago   Up 3 minutes (healthy)                            logrouter
2f63909df67a   gcr.io/google-containers/cadvisor:latest                                 "/usr/bin/cadvisor -…"   3 minutes ago   Up 3 minutes (healthy)   0.0.0.0:8080->8080/tcp   cadvisor

```
## Additional Information

- [ ] This change is backwards-breaking


