### PR TITLE
Modified s1ap sanity test suite

### DIFF
--- a/lte/gateway/python/integ_tests/defs.mk
+++ b/lte/gateway/python/integ_tests/defs.mk
@@ -16,7 +16,6 @@ PROTO_LIST:=orc8r_protos lte_protos feg_protos
 MANDATORY_TESTS = s1aptests/test_modify_mme_config_for_sanity.py \
 s1aptests/test_attach_detach.py \
 s1aptests/test_gateway_metrics_attach_detach.py \
-s1aptests/test_attach_detach_multi_ue.py \
 s1aptests/test_attach_detach_looped.py  \
 s1aptests/test_attach_emergency.py \
 s1aptests/test_attach_combined_eps_imsi.py \
@@ -69,6 +68,7 @@ s1aptests/test_sctp_shutdown_after_auth_req.py \
 s1aptests/test_sctp_shutdown_after_identity_req.py \
 s1aptests/test_sctp_shutdown_after_smc.py \
 s1aptests/test_sctp_shutdown_after_multi_ue_attach.py \
+s1aptests/test_attach_detach_multi_ue.py \
 s1aptests/test_attach_detach_dedicated.py \
 s1aptests/test_attach_detach_dedicated_qci_0.py \
 s1aptests/test_attach_detach_dedicated_multi_ue.py \


### PR DESCRIPTION
[lte][agw] :Modified s1ap sanity test suite
## Summary
Moved the test case, test_attach_detach_multi_ue.py after the execution of test case, test_sctp_shutdown_after_multi_ue_attach.py to have cleaner Redis state.
After execution of test_sctp_shutdown_after_multi_ue_attach.py, detach is not done; so UE contexts still exists in Redis DB
So on next attach, older contexts gets deleted and proceeds with new attach request. If test_attach_detach_multi_ue.py is executed after test_sctp_shutdown_after_multi_ue_attach.py, all old contexts gets deleted and removed from DB.
Otherwise if single UE is attached after test case, test_sctp_shutdown_after_multi_ue_attach.py; then only one UE's context will be removed and other UE's contexts will be retained in DB and same Redis state would roll over for further test cases.

## Test Plan
Executed s1ap sanity test suite