### PR TITLE
Update Debian Mirror Links [lte][agw][documentation]

### DIFF
--- a/docs/docusaurus/versioned_docs/version-1.0.0/lte/setup_deb.md
+++ b/docs/docusaurus/versioned_docs/version-1.0.0/lte/setup_deb.md
@@ -31,7 +31,7 @@ satisfies the following requirements:
 ## Deployment
 ### 1. Create boot USB stick and install Debian on your AGW host
 
-- Download .iso image from [Debian mirror](http://cdimage.debian.org/mirror/cdimage/archive/9.9.0/amd64/iso-cd/debian-9.9.0-amd64-netinst.iso)
+- Download .iso image from [Debian mirror](https://cdimage.debian.org/cdimage/archive/9.13.0/amd64/iso-cd/debian-9.13.0-amd64-netinst.iso)
 - Create bootable usb using etcher [tutorial here](https://tutorials.ubuntu.com/tutorial/tutorial-create-a-usb-stick-on-macos#0)
 - Boot your AGW host from USB
   (Press F11 to select boot sequence, :warning: This might be different for

--- a/docs/docusaurus/versioned_docs/version-1.1.0/lte/setup_deb.md
+++ b/docs/docusaurus/versioned_docs/version-1.1.0/lte/setup_deb.md
@@ -22,7 +22,7 @@ satisfies the following requirements:
 ## Deployment
 ### 1. Create boot USB stick and install Debian on your AGW host
 
-- Download .iso image from [Debian mirror](http://cdimage.debian.org/mirror/cdimage/archive/9.9.0/amd64/iso-cd/debian-9.9.0-amd64-netinst.iso)
+- Download .iso image from [Debian mirror](https://cdimage.debian.org/cdimage/archive/9.13.0/amd64/iso-cd/debian-9.13.0-amd64-netinst.iso)
 - Create bootable usb using etcher [tutorial here](https://tutorials.ubuntu.com/tutorial/tutorial-create-a-usb-stick-on-macos#0)
 - Boot your AGW host from USB
   (Press F11 to select boot sequence, :warning: This might be different for

--- a/docs/docusaurus/versioned_docs/version-1.2.0/lte/setup_deb.md
+++ b/docs/docusaurus/versioned_docs/version-1.2.0/lte/setup_deb.md
@@ -22,7 +22,7 @@ satisfies the following requirements:
 ## Deployment
 ### 1. Create boot USB stick and install Debian on your AGW host
 
-- Download .iso image from [Debian mirror](http://cdimage.debian.org/mirror/cdimage/archive/9.9.0/amd64/iso-cd/debian-9.9.0-amd64-netinst.iso)
+- Download .iso image from [Debian mirror](https://cdimage.debian.org/cdimage/archive/9.13.0/amd64/iso-cd/debian-9.13.0-amd64-netinst.iso)
 - Create bootable usb using etcher [tutorial here](https://tutorials.ubuntu.com/tutorial/tutorial-create-a-usb-stick-on-macos#0)
 - Boot your AGW host from USB
   (Press F11 to select boot sequence, :warning: This might be different for

--- a/docs/docusaurus/versioned_docs/version-1.3.0/lte/setup_deb.md
+++ b/docs/docusaurus/versioned_docs/version-1.3.0/lte/setup_deb.md
@@ -22,7 +22,7 @@ satisfies the following requirements:
 ## Deployment
 ### 1. Create boot USB stick and install Debian on your AGW host
 
-- Download .iso image from [Debian mirror](http://cdimage.debian.org/mirror/cdimage/archive/9.9.0/amd64/iso-cd/debian-9.9.0-amd64-netinst.iso)
+- Download .iso image from [Debian mirror](https://cdimage.debian.org/cdimage/archive/9.13.0/amd64/iso-cd/debian-9.13.0-amd64-netinst.iso)
 - Create bootable usb using etcher [tutorial here](https://tutorials.ubuntu.com/tutorial/tutorial-create-a-usb-stick-on-macos#0)
 - Boot your AGW host from USB
   (Press F11 to select boot sequence, :warning: This might be different for


### PR DESCRIPTION
Updated broken links for Debian iso mirror and updated version to match current tested version.

Signed-off-by: Jared Mullane <jmullane@fb.com>


## Summary

Updated the links for the debian installation mirrors. The current mirror we display (http://cdimage.debian.org/mirror/cdimage/archive/9.9.0/amd64/iso-cd/debian-9.9.0-amd64-netinst.iso) is no longer a valid link and is an outdated version. 

## Test Plan

Tested new link. 

