### PR TITLE
[dev] Add shared copyright for IntelliJ users

### DIFF
--- a/.idea.shared/copyright/magma.xml
+++ b/.idea.shared/copyright/magma.xml
@@ -1,0 +1,6 @@
+<component name="CopyrightManager">
+  <copyright>
+    <option name="notice" value="Copyright 2020 The Magma Authors.&#10;&#10;This source code is licensed under the BSD-style license found in the&#10;LICENSE file in the root directory of this source tree.&#10;&#10;Unless required by applicable law or agreed to in writing, software&#10;distributed under the License is distributed on an &quot;AS IS&quot; BASIS,&#10;WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#10;See the License for the specific language governing permissions and&#10;limitations under the License." />
+    <option name="myName" value="magma" />
+  </copyright>
+</component>

--- a/.idea.shared/copyright/profiles_settings.xml
+++ b/.idea.shared/copyright/profiles_settings.xml
@@ -1,0 +1,10 @@
+<component name="CopyrightManager">
+  <settings>
+    <module2copyright>
+      <element module="All" copyright="magma" />
+    </module2copyright>
+    <LanguageOptions name="__TEMPLATE__">
+      <option name="prefixLines" value="false" />
+    </LanguageOptions>
+  </settings>
+</component>


### PR DESCRIPTION
## Summary

IntelliJ users can copy from .idea.shared to .idea to have automatic copyright handling

## Test Plan

n/a

## Additional Information

- [ ] This change is backwards-breaking