### PR TITLE
[orc8r][docs] Replace CNTLR_POD with ORC_POD

### DIFF
--- a/docs/readmes/orc8r/deploy_install.md
+++ b/docs/readmes/orc8r/deploy_install.md
@@ -235,15 +235,15 @@ Create the Orchestrator admin user with the `admin_operator` certificate
 created earlier
 
 ```bash
-export CNTLR_POD=$(kubectl get pod -l app.kubernetes.io/component=controller -o jsonpath='{.items[0].metadata.name}')
-kubectl exec ${CNTLR_POD} -- envdir /var/opt/magma/envdir /var/opt/magma/bin/accessc add-existing -admin -cert /var/opt/magma/certs/admin_operator.pem admin_operator
+export ORC_POD=$(kubectl get pod -l app.kubernetes.io/component=orchestrator -o jsonpath='{.items[0].metadata.name}')
+kubectl exec ${ORC_POD} -- envdir /var/opt/magma/envdir /var/opt/magma/bin/accessc add-existing -admin -cert /var/opt/magma/certs/admin_operator.pem admin_operator
 ```
 
 If you want to verify the admin user was successfully created, inspect the
 output from
 
 ```bash
-$ kubectl exec ${CNTLR_POD} -- envdir /var/opt/magma/envdir /var/opt/magma/bin/accessc list-certs
+$ kubectl exec ${ORC_POD} -- envdir /var/opt/magma/envdir /var/opt/magma/bin/accessc list-certs
 
 # NOTE: actual values will differ
 Serial Number: 83550F07322CEDCD; Identity: Id_Operator_admin_operator; Not Before: 2020-06-26 22:39:55 +0000 UTC; Not After: 2030-06-24 22:39:55 +0000 UTC

--- a/orc8r/cloud/deploy/bare-metal/deploy_charts.sh
+++ b/orc8r/cloud/deploy/bare-metal/deploy_charts.sh
@@ -43,7 +43,7 @@ kubectl -n $namespace create secret generic nms-certs \
   --from-file controller.key \
   --from-file controller.crt \
   --dry-run=client -oyaml > ../secrets/nms-certs.yaml
-cd .. 
+cd ..
 kubectl -n $namespace apply -f secrets/
 
 echo "Checking kube-dns service..."
@@ -79,10 +79,10 @@ helm -n $namespace upgrade --install kibana stable/kibana -f charts/kibana.yaml
 
 helm -n $namespace upgrade --install orc8r github-repo/orc8r -f charts/orc8r.yaml --wait
 
-export CNTLR_POD=$(kubectl -n $namespace get pod -l app.kubernetes.io/component=controller -o jsonpath='{.items[0].metadata.name}')
+export ORC_POD=$(kubectl -n $namespace get pod -l app.kubernetes.io/component=orchestrator -o jsonpath='{.items[0].metadata.name}')
 export NMS_POD=$(kubectl -n $namespace get pod -l app.kubernetes.io/component=magmalte -o jsonpath='{.items[0].metadata.name}')
 
-kubectl -n $namespace exec -it ${CNTLR_POD} -- envdir /var/opt/magma/envdir /var/opt/magma/bin/accessc add-existing -admin -cert /var/opt/magma/certs/admin_operator.pem admin_operator || :
+kubectl -n $namespace exec -it ${ORC_POD} -- envdir /var/opt/magma/envdir /var/opt/magma/bin/accessc add-existing -admin -cert /var/opt/magma/certs/admin_operator.pem admin_operator || :
 kubectl -n $namespace exec -it ${NMS_POD} -- yarn setAdminPassword master $admin_email $admin_password
 
 NMS_ADDR="master.nms.$dns_domain"


### PR DESCRIPTION
## Summary

With service mesh changes, the controller pods (`CNTLR_POD`) no longer exist. But everything performed on a controller pod can be performed on an orchestrator pod, so we replace with `ORC_POD`

## Test Plan

- Local manual validation

## Additional Information

- [ ] This change is backwards-breaking