### PR TITLE
[CI] Pre-creat go-build cache folder with correct permissions

### DIFF
--- a/lte/gateway/deploy/roles/dev_common/tasks/main.yml
+++ b/lte/gateway/deploy/roles/dev_common/tasks/main.yml
@@ -62,6 +62,14 @@
     group: "{{ ansible_user }}"
   when: full_provision
 
+- name: Create the Go cache directory
+  file:
+    path: "{{magma_root}}/.cache/go-build"
+    state: directory
+    owner: "{{ ansible_user }}"
+    group: "{{ ansible_user }}"
+  when: full_provision
+
 #################################
 # Add common convenience aliases
 #################################


### PR DESCRIPTION
Signed-off-by: Vitalii Kostenko <vitalii@freedomfi.com>

At the moment CI builds are failing cause gateway make run command is failing cause it have no permissions to write to go-build folder. This patch is fixing permissions for the folder
