### PR TITLE
[Orc8r] Fix the subscriber policy setting bug 

### DIFF
--- a/lte/cloud/go/services/policydb/obsidian/models/conversion.go
+++ b/lte/cloud/go/services/policydb/obsidian/models/conversion.go
@@ -463,3 +463,19 @@ func (m *PolicyQosProfile) ToProto() *protos.FlowQos {
 	}
 	return proto
 }
+
+func (m PolicyIds) ToTKs() []storage.TypeAndKey {
+	var tks []storage.TypeAndKey
+	for _, policyID := range m {
+		tks = append(tks, storage.TypeAndKey{Type: lte.PolicyRuleEntityType, Key: string(policyID)})
+	}
+	return tks
+}
+
+func (m BaseNames) ToTKs() []storage.TypeAndKey {
+	var tks []storage.TypeAndKey
+	for _, baseName := range m {
+		tks = append(tks, storage.TypeAndKey{Type: lte.BaseNameEntityType, Key: string(baseName)})
+	}
+	return tks
+}

--- a/lte/cloud/go/services/subscriberdb/obsidian/handlers/handlers_test.go
+++ b/lte/cloud/go/services/subscriberdb/obsidian/handlers/handlers_test.go
@@ -1656,6 +1656,227 @@ func TestUpdateSubscriberProfile(t *testing.T) {
 	assert.Equal(t, expected, actual)
 }
 
+func TestSubscriberBasename(t *testing.T) {
+	assert.NoError(t, plugin.RegisterPluginForTests(t, &pluginimpl.BaseOrchestratorPlugin{}))
+	assert.NoError(t, plugin.RegisterPluginForTests(t, &ltePlugin.LteOrchestratorPlugin{}))
+
+	configuratorTestInit.StartTestService(t)
+	stateTestInit.StartTestService(t)
+	err := configurator.CreateNetwork(configurator.Network{ID: "n0"}, serdes.Network)
+	assert.NoError(t, err)
+	_, err = configurator.CreateEntities(
+		"n0",
+		[]configurator.NetworkEntity{
+			{Type: lte.APNEntityType, Key: "apn0"},
+			{Type: lte.APNEntityType, Key: "apn1"},
+			{Type: lte.BaseNameEntityType, Key: "basename0"},
+			{Type: lte.BaseNameEntityType, Key: "basename2"},
+		},
+		serdes.Entity,
+	)
+	assert.NoError(t, err)
+
+	e := echo.New()
+	urlBase := "/magma/v1/lte/:network_id/subscribers"
+	urlManage := urlBase + "/:subscriber_id"
+	subscriberdbHandlers := handlers.GetHandlers()
+	getAllSubscribers := tests.GetHandlerByPathAndMethod(t, subscriberdbHandlers, urlBase, obsidian.GET).HandlerFunc
+	postSubscriber := tests.GetHandlerByPathAndMethod(t, subscriberdbHandlers, urlBase, obsidian.POST).HandlerFunc
+	putSubscriber := tests.GetHandlerByPathAndMethod(t, subscriberdbHandlers, urlManage, obsidian.PUT).HandlerFunc
+
+	imsi := "IMSI1234567890"
+	mutableSub := newMutableSubscriber(imsi)
+
+	// Post a policy association with a non existent policy
+	mutableSub.ActiveBaseNames = policydbModels.BaseNames{"baseXXX"}
+	tc := tests.Test{
+		Method:                 "POST",
+		URL:                    "/magma/v1/lte/n0/subscribers",
+		Payload:                mutableSub,
+		Handler:                postSubscriber,
+		ParamNames:             []string{"network_id"},
+		ParamValues:            []string{"n0"},
+		ExpectedStatus:         500, // would make more sense as 400
+		ExpectedErrorSubstring: `could not find entities matching [type:"base_name" key:"baseXXX" ]`,
+	}
+	tests.RunUnitTest(t, e, tc)
+
+	// Successful post request
+	mutableSub.ActiveBaseNames = policydbModels.BaseNames{"basename0"}
+	tc = tests.Test{
+		Method:         "POST",
+		URL:            "/magma/v1/lte/n0/subscribers",
+		Payload:        mutableSub,
+		Handler:        postSubscriber,
+		ParamNames:     []string{"network_id"},
+		ParamValues:    []string{"n0"},
+		ExpectedStatus: 201,
+	}
+	tests.RunUnitTest(t, e, tc)
+
+	// Get all, posted subscriber found
+	tc = tests.Test{
+		Method:         "GET",
+		URL:            "/magma/v1/lte/n0/subscribers",
+		Handler:        getAllSubscribers,
+		ParamNames:     []string{"network_id"},
+		ParamValues:    []string{"n0"},
+		ExpectedStatus: 200,
+		ExpectedResult: tests.JSONMarshaler(map[string]*subscriberModels.Subscriber{imsi: mutableSub.ToSubscriber()}),
+	}
+	tests.RunUnitTest(t, e, tc)
+
+	// Put request with non existent basename
+	mutableSub.ActiveBaseNames = policydbModels.BaseNames{"baseXXX"}
+	tc = tests.Test{
+		Method:                 "PUT",
+		URL:                    "/magma/v1/lte/n0/subscribers/" + imsi,
+		Payload:                mutableSub,
+		ParamNames:             []string{"network_id", "subscriber_id"},
+		ParamValues:            []string{"n0", imsi},
+		Handler:                putSubscriber,
+		ExpectedStatus:         500, // would make more sense as 400
+		ExpectedErrorSubstring: `could not find entities matching [type:"base_name" key:"baseXXX" ]`,
+	}
+	tests.RunUnitTest(t, e, tc)
+
+	// Successful put request
+	mutableSub.ActiveBaseNames = policydbModels.BaseNames{"basename2"}
+	tc = tests.Test{
+		Method:         "PUT",
+		URL:            "/magma/v1/lte/n0/subscribers/" + imsi,
+		Payload:        mutableSub,
+		ParamNames:     []string{"network_id", "subscriber_id"},
+		ParamValues:    []string{"n0", imsi},
+		Handler:        putSubscriber,
+		ExpectedStatus: 204,
+	}
+	tests.RunUnitTest(t, e, tc)
+
+	// Get all, updated subscriber matches the expected value
+	tc = tests.Test{
+		Method:         "GET",
+		URL:            "/magma/v1/lte/n0/subscribers",
+		Handler:        getAllSubscribers,
+		ParamNames:     []string{"network_id"},
+		ParamValues:    []string{"n0"},
+		ExpectedStatus: 200,
+		ExpectedResult: tests.JSONMarshaler(map[string]*subscriberModels.Subscriber{imsi: mutableSub.ToSubscriber()}),
+	}
+	tests.RunUnitTest(t, e, tc)
+}
+
+func TestSubscriberPolicy(t *testing.T) {
+	assert.NoError(t, plugin.RegisterPluginForTests(t, &pluginimpl.BaseOrchestratorPlugin{}))
+	assert.NoError(t, plugin.RegisterPluginForTests(t, &ltePlugin.LteOrchestratorPlugin{}))
+
+	configuratorTestInit.StartTestService(t)
+	stateTestInit.StartTestService(t)
+	err := configurator.CreateNetwork(configurator.Network{ID: "n0"}, serdes.Network)
+	assert.NoError(t, err)
+	_, err = configurator.CreateEntities(
+		"n0",
+		[]configurator.NetworkEntity{
+			{Type: lte.APNEntityType, Key: "apn0"},
+			{Type: lte.APNEntityType, Key: "apn1"},
+			{Type: lte.PolicyRuleEntityType, Key: "rule0"},
+			{Type: lte.PolicyRuleEntityType, Key: "rule1"},
+			{Type: lte.PolicyRuleEntityType, Key: "rule2"},
+		},
+		serdes.Entity,
+	)
+	assert.NoError(t, err)
+
+	e := echo.New()
+	urlBase := "/magma/v1/lte/:network_id/subscribers"
+	urlManage := urlBase + "/:subscriber_id"
+	subscriberdbHandlers := handlers.GetHandlers()
+	getAllSubscribers := tests.GetHandlerByPathAndMethod(t, subscriberdbHandlers, urlBase, obsidian.GET).HandlerFunc
+	postSubscriber := tests.GetHandlerByPathAndMethod(t, subscriberdbHandlers, urlBase, obsidian.POST).HandlerFunc
+	putSubscriber := tests.GetHandlerByPathAndMethod(t, subscriberdbHandlers, urlManage, obsidian.PUT).HandlerFunc
+
+	imsi := "IMSI1234567890"
+	mutableSub := newMutableSubscriber(imsi)
+
+	// Post a policy association with a non existent policy
+	mutableSub.ActivePolicies = policydbModels.PolicyIds{"ruleXXX"}
+	tc := tests.Test{
+		Method:                 "POST",
+		URL:                    "/magma/v1/lte/n0/subscribers",
+		Payload:                mutableSub,
+		Handler:                postSubscriber,
+		ParamNames:             []string{"network_id"},
+		ParamValues:            []string{"n0"},
+		ExpectedStatus:         500, // would make more sense as 400
+		ExpectedErrorSubstring: `could not find entities matching [type:"policy" key:"ruleXXX" ]`,
+	}
+	tests.RunUnitTest(t, e, tc)
+
+	// Successful post request
+	mutableSub.ActivePolicies = policydbModels.PolicyIds{"rule0"}
+	tc = tests.Test{
+		Method:         "POST",
+		URL:            "/magma/v1/lte/n0/subscribers",
+		Payload:        mutableSub,
+		Handler:        postSubscriber,
+		ParamNames:     []string{"network_id"},
+		ParamValues:    []string{"n0"},
+		ExpectedStatus: 201,
+	}
+	tests.RunUnitTest(t, e, tc)
+
+	// Get all, posted subscriber found
+	tc = tests.Test{
+		Method:         "GET",
+		URL:            "/magma/v1/lte/n0/subscribers",
+		Handler:        getAllSubscribers,
+		ParamNames:     []string{"network_id"},
+		ParamValues:    []string{"n0"},
+		ExpectedStatus: 200,
+		ExpectedResult: tests.JSONMarshaler(map[string]*subscriberModels.Subscriber{imsi: mutableSub.ToSubscriber()}),
+	}
+	tests.RunUnitTest(t, e, tc)
+
+	// Put request with non existent policy
+	mutableSub.ActivePolicies = policydbModels.PolicyIds{"ruleXXX"}
+	tc = tests.Test{
+		Method:                 "PUT",
+		URL:                    "/magma/v1/lte/n0/subscribers/" + imsi,
+		Payload:                mutableSub,
+		ParamNames:             []string{"network_id", "subscriber_id"},
+		ParamValues:            []string{"n0", imsi},
+		Handler:                putSubscriber,
+		ExpectedStatus:         500, // would make more sense as 400
+		ExpectedErrorSubstring: `could not find entities matching [type:"policy" key:"ruleXXX" ]`,
+	}
+	tests.RunUnitTest(t, e, tc)
+
+	// Successful put request
+	mutableSub.ActivePolicies = policydbModels.PolicyIds{"rule2"}
+	tc = tests.Test{
+		Method:         "PUT",
+		URL:            "/magma/v1/lte/n0/subscribers/" + imsi,
+		Payload:        mutableSub,
+		ParamNames:     []string{"network_id", "subscriber_id"},
+		ParamValues:    []string{"n0", imsi},
+		Handler:        putSubscriber,
+		ExpectedStatus: 204,
+	}
+	tests.RunUnitTest(t, e, tc)
+
+	// Get all, updated subscriber matches the expected value
+	tc = tests.Test{
+		Method:         "GET",
+		URL:            "/magma/v1/lte/n0/subscribers",
+		Handler:        getAllSubscribers,
+		ParamNames:     []string{"network_id"},
+		ParamValues:    []string{"n0"},
+		ExpectedStatus: 200,
+		ExpectedResult: tests.JSONMarshaler(map[string]*subscriberModels.Subscriber{imsi: mutableSub.ToSubscriber()}),
+	}
+	tests.RunUnitTest(t, e, tc)
+}
+
 func TestAPNPolicyProfile(t *testing.T) {
 	assert.NoError(t, plugin.RegisterPluginForTests(t, &pluginimpl.BaseOrchestratorPlugin{}))
 	assert.NoError(t, plugin.RegisterPluginForTests(t, &ltePlugin.LteOrchestratorPlugin{}))

--- a/lte/cloud/go/services/subscriberdb/obsidian/models/conversion.go
+++ b/lte/cloud/go/services/subscriberdb/obsidian/models/conversion.go
@@ -150,6 +150,14 @@ func (m *MutableSubscriber) FromEnt(ent configurator.NetworkEntity, policyProfil
 		model.ActiveApns = append(model.ActiveApns, tk.Key)
 	}
 
+	for _, tk := range ent.Associations.Filter(lte.PolicyRuleEntityType) {
+		model.ActivePolicies = append(model.ActivePolicies, policymodels.PolicyID(tk.Key))
+	}
+
+	for _, tk := range ent.Associations.Filter(lte.BaseNameEntityType) {
+		model.ActiveBaseNames = append(model.ActiveBaseNames, policymodels.BaseName(tk.Key))
+	}
+
 	// Each policy profile has 1 apn and n policy_rule
 	// Convert these assocs to a map of apn->policy_rules
 	for _, p := range policyProfileEnts {
@@ -170,6 +178,8 @@ func (m *MutableSubscriber) GetAssocs() []storage.TypeAndKey {
 	var assocs []storage.TypeAndKey
 	assocs = append(assocs, m.ActivePoliciesByApn.ToTKs(string(m.ID))...)
 	assocs = append(assocs, m.ActiveApns.ToTKs()...)
+	assocs = append(assocs, m.ActivePolicies.ToTKs()...)
+	assocs = append(assocs, m.ActiveBaseNames.ToTKs()...)
 	return assocs
 }
 

--- a/lte/cloud/go/services/subscriberdb/obsidian/models/mutable_subscriber_swaggergen.go
+++ b/lte/cloud/go/services/subscriberdb/obsidian/models/mutable_subscriber_swaggergen.go
@@ -6,10 +6,8 @@ package models
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
-	models1 "magma/lte/cloud/go/services/policydb/obsidian/models"
-	"strconv"
-
 	strfmt "github.com/go-openapi/strfmt"
+	models1 "magma/lte/cloud/go/services/policydb/obsidian/models"
 
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/swag"
@@ -23,8 +21,8 @@ type MutableSubscriber struct {
 	// active apns
 	ActiveApns ApnList `json:"active_apns,omitempty"`
 
-	// Base names which are active for this subscriber
-	ActiveBaseNames []models1.BaseName `json:"active_base_names,omitempty"`
+	// active base names
+	ActiveBaseNames models1.BaseNames `json:"active_base_names,omitempty"`
 
 	// active policies
 	ActivePolicies models1.PolicyIds `json:"active_policies,omitempty"`
@@ -107,15 +105,11 @@ func (m *MutableSubscriber) validateActiveBaseNames(formats strfmt.Registry) err
 		return nil
 	}
 
-	for i := 0; i < len(m.ActiveBaseNames); i++ {
-
-		if err := m.ActiveBaseNames[i].Validate(formats); err != nil {
-			if ve, ok := err.(*errors.Validation); ok {
-				return ve.ValidateName("active_base_names" + "." + strconv.Itoa(i))
-			}
-			return err
+	if err := m.ActiveBaseNames.Validate(formats); err != nil {
+		if ve, ok := err.(*errors.Validation); ok {
+			return ve.ValidateName("active_base_names")
 		}
-
+		return err
 	}
 
 	return nil

--- a/lte/cloud/go/services/subscriberdb/obsidian/models/subscriber_swaggergen.go
+++ b/lte/cloud/go/services/subscriberdb/obsidian/models/subscriber_swaggergen.go
@@ -6,10 +6,8 @@ package models
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
-	models1 "magma/lte/cloud/go/services/policydb/obsidian/models"
-	"strconv"
-
 	strfmt "github.com/go-openapi/strfmt"
+	models1 "magma/lte/cloud/go/services/policydb/obsidian/models"
 
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/swag"
@@ -23,8 +21,8 @@ type Subscriber struct {
 	// active apns
 	ActiveApns ApnList `json:"active_apns,omitempty"`
 
-	// Base names which are active for this subscriber
-	ActiveBaseNames []models1.BaseName `json:"active_base_names,omitempty"`
+	// active base names
+	ActiveBaseNames models1.BaseNames `json:"active_base_names,omitempty"`
 
 	// active policies
 	ActivePolicies models1.PolicyIds `json:"active_policies,omitempty"`
@@ -129,15 +127,11 @@ func (m *Subscriber) validateActiveBaseNames(formats strfmt.Registry) error {
 		return nil
 	}
 
-	for i := 0; i < len(m.ActiveBaseNames); i++ {
-
-		if err := m.ActiveBaseNames[i].Validate(formats); err != nil {
-			if ve, ok := err.(*errors.Validation); ok {
-				return ve.ValidateName("active_base_names" + "." + strconv.Itoa(i))
-			}
-			return err
+	if err := m.ActiveBaseNames.Validate(formats); err != nil {
+		if ve, ok := err.(*errors.Validation); ok {
+			return ve.ValidateName("active_base_names")
 		}
-
+		return err
 	}
 
 	return nil

--- a/lte/cloud/go/services/subscriberdb/obsidian/models/swagger.v1.yml
+++ b/lte/cloud/go/services/subscriberdb/obsidian/models/swagger.v1.yml
@@ -299,14 +299,7 @@ definitions:
       config:
         $ref: '#/definitions/subscriber_config'
       active_base_names:
-        type: array
-        items:
-          $ref: './lte-policydb-swagger.yml#/definitions/base_name'
-        x-omitempty: true
-        description: 'Base names which are active for this subscriber'
-        example:
-          - 'base_name_1'
-          - 'base_name_2'
+        $ref: './lte-policydb-swagger.yml#/definitions/base_names'
       active_policies:
         $ref: './lte-policydb-swagger.yml#/definitions/policy_ids'
       active_policies_by_apn:
@@ -336,14 +329,7 @@ definitions:
       lte:
         $ref: '#/definitions/lte_subscription'
       active_base_names:
-        type: array
-        items:
-          $ref: './lte-policydb-swagger.yml#/definitions/base_name'
-        x-omitempty: true
-        description: 'Base names which are active for this subscriber'
-        example:
-          - 'base_name_1'
-          - 'base_name_2'
+        $ref: './lte-policydb-swagger.yml#/definitions/base_names'
       static_ips:
         $ref: '#/definitions/subscriber_static_ips'
       active_policies:

--- a/orc8r/cloud/docker/controller/apidocs/v1/swagger.yml
+++ b/orc8r/cloud/docker/controller/apidocs/v1/swagger.yml
@@ -9415,14 +9415,7 @@ definitions:
       active_apns:
         $ref: '#/definitions/apn_list'
       active_base_names:
-        description: Base names which are active for this subscriber
-        example:
-        - base_name_1
-        - base_name_2
-        items:
-          $ref: '#/definitions/base_name'
-        type: array
-        x-omitempty: true
+        $ref: '#/definitions/base_names'
       active_policies:
         $ref: '#/definitions/policy_ids'
       active_policies_by_apn:
@@ -10823,14 +10816,7 @@ definitions:
       active_apns:
         $ref: '#/definitions/apn_list'
       active_base_names:
-        description: Base names which are active for this subscriber
-        example:
-        - base_name_1
-        - base_name_2
-        items:
-          $ref: '#/definitions/base_name'
-        type: array
-        x-omitempty: true
+        $ref: '#/definitions/base_names'
       active_policies:
         $ref: '#/definitions/policy_ids'
       active_policies_by_apn:


### PR DESCRIPTION
Signed-off-by: Karthik Subraveti <ksubraveti@fb.com>

## Summary

Subscriber specific attributes active_policies and active_basenames aren't handled at all in the current orc8r code.
This patch fixes this bug and adds a regression test for verifying the change. 

## Test Plan
Enhanced the handler_test for verifying this fix.
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
