### PR TITLE
[AGW][Package] Update dnsmasq version due to security vulnerability in 2.83

### DIFF
--- a/lte/gateway/release/build-magma.sh
+++ b/lte/gateway/release/build-magma.sh
@@ -97,7 +97,7 @@ MAGMA_DEPS=(
     "python3-protobuf >= 3.14.0"
     "redis-server >= 3.2.0"
     "sudo"
-    "dnsmasq >= 2.72"
+    "dnsmasq > 2.83"
     "net-tools" # for ifconfig
     "python3-pip"
     "python3-apt" # The version in pypi is abandoned and broken on stretch


### PR DESCRIPTION
Signed-off-by: Shruti Sanadhya <ssanadhya@fb.com>

## Summary

There are 7 vulnerabilities in dnsmasq being tracked as DNSpooq that can be split into two categories, dns cache poisoning and remote code execution. This vulnerability affects dnsmasq versions prior to 2.83. 

This change updates the DNSmasq dependency version for Magma to be newer than 2.83.

## Test Plan

`fab dev package:vcs=git`
