### PR TITLE
AGW: mobilityD: Do not allocate IP in case of static IP allocation error

### DIFF
--- a/lte/gateway/python/magma/mobilityd/rpc_servicer.py
+++ b/lte/gateway/python/magma/mobilityd/rpc_servicer.py
@@ -29,6 +29,9 @@ from .ip_allocator_base import DuplicateIPAssignmentError, \
     DuplicatedIPAllocationError, IPBlockNotFoundError, NoAvailableIPError, \
     OverlappedIPBlocksError
 
+from .subscriberdb_client import SubscriberDBConnectionError,\
+    SubscriberDBStaticIPValueError, SubscriberDBMultiAPNValueError
+
 from .ipv6_allocator_pool import MaxCalculationError
 
 
@@ -288,6 +291,18 @@ class MobilityServiceRpcServicer(MobilityServiceServicer):
             context.set_details(
                 'Reached maximum IPv6 calculation tries')
             context.set_code(grpc.StatusCode.RESOURCE_EXHAUSTED)
+        except SubscriberDBConnectionError:
+            context.set_details(
+                'Could not connect to SubscriberDB')
+            context.set_code(grpc.StatusCode.FAILED_PRECONDITION)
+        except SubscriberDBStaticIPValueError:
+            context.set_details(
+                'Could not parse static IP response from SubscriberDB')
+            context.set_code(grpc.StatusCode.FAILED_PRECONDITION)
+        except SubscriberDBMultiAPNValueError:
+            context.set_details(
+                'Could not parse MultiAPN IP response from SubscriberDB')
+            context.set_code(grpc.StatusCode.FAILED_PRECONDITION)
         return AllocateIPAddressResponse()
 
     def _ipblock_msg_to_ipblock(self, ipblock_msg, context):

--- a/lte/gateway/python/magma/mobilityd/subscriberdb_client.py
+++ b/lte/gateway/python/magma/mobilityd/subscriberdb_client.py
@@ -80,12 +80,13 @@ class SubscriberDbClient:
 
         except ValueError:
             logging.warning("Invalid data for sid %s: ", sid)
+            raise SubscriberDBStaticIPValueError(sid)
 
         except grpc.RpcError as err:
-            logging.error(
-                "GetSubscriberData while reading static ip, error[%s] %s",
-                err.code(),
-                err.details())
+            msg = "GetSubscriberData while reading vlan-id error[%s] %s" % \
+                  (err.code(), err.details())
+            logging.error(msg)
+            raise SubscriberDBConnectionError(msg)
         return None
 
     def get_subscriber_apn_network_info(self, sid: str) -> NetworkInfo:
@@ -105,12 +106,14 @@ class SubscriberDbClient:
 
             except ValueError:
                 logging.warning("Invalid data for sid %s: ", sid)
+                raise SubscriberDBMultiAPNValueError(sid)
 
             except grpc.RpcError as err:
-                logging.error(
-                    "GetSubscriberData while reading vlan-id error[%s] %s",
-                    err.code(),
-                    err.details())
+                msg = "GetSubscriberData while reading vlan-id error[%s] %s" % \
+                    (err.code(), err.details())
+                logging.error(msg)
+                raise SubscriberDBConnectionError(msg)
+
         return NetworkInfo()
 
     # use same API to retrieve IP address and related config.
@@ -142,3 +145,22 @@ class SubscriberDbClient:
             return selected_apn_conf
 
         return None
+
+
+class SubscriberDBConnectionError(Exception):
+    """ Exception thrown subscriber DB is not available
+    """
+    pass
+
+
+class SubscriberDBStaticIPValueError(Exception):
+    """ Exception thrown when subscriber DB has invalid IP value for the subscriber.
+    """
+    pass
+
+
+class SubscriberDBMultiAPNValueError(Exception):
+    """ Exception thrown when subscriber DB has invalid MultiAPN vlan value
+    for the subscriber.
+    """
+    pass

--- a/lte/gateway/python/magma/mobilityd/tests/test_multi_apn_ip_alloc.py
+++ b/lte/gateway/python/magma/mobilityd/tests/test_multi_apn_ip_alloc.py
@@ -38,6 +38,8 @@ from magma.mobilityd.ipv6_allocator_pool import \
     IPv6AllocatorPool
 from magma.mobilityd.ip_allocator_static import \
     IPAllocatorStaticWrapper
+from magma.mobilityd.subscriberdb_client import SubscriberDBMultiAPNValueError, \
+    SubscriberDBStaticIPValueError
 
 
 class MockedSubscriberDBStub:
@@ -390,12 +392,5 @@ class MultiAPNIPAllocationTests(unittest.TestCase):
         MockedSubscriberDBStub.add_sub_ip(sid=imsi, apn=apn, ip=None,
                                           vlan=vlan)
 
-        ip0, _ = self._allocator.alloc_ip_address(sid)
-        ip0_returned = self._allocator.get_ip_for_sid(sid)
-
-        # check if retrieved ip is the same as the one allocated
-        self.assertEqual(ip0, ip0_returned)
-        self.assertNotEqual(ip0, ipaddress.ip_address(wild_assigned_ip))
-        self.check_type(sid, IPType.IP_POOL)
-        self.check_vlan(sid, 0)
-        self.check_gw_info(vlan, None, None)
+        with self.assertRaises(SubscriberDBStaticIPValueError):
+            ip0, _ = self._allocator.alloc_ip_address(sid)

--- a/lte/gateway/python/magma/mobilityd/tests/test_static_ip_alloc.py
+++ b/lte/gateway/python/magma/mobilityd/tests/test_static_ip_alloc.py
@@ -31,6 +31,7 @@ from magma.mobilityd.ip_allocator_pool import \
 from magma.mobilityd.ipv6_allocator_pool import \
     IPv6AllocatorPool
 from magma.mobilityd.mobility_store import MobilityStore
+from magma.mobilityd.subscriberdb_client import SubscriberDBStaticIPValueError
 
 from unittest import mock
 
@@ -86,13 +87,8 @@ class StaticIPAllocationTests(unittest.TestCase):
     def test_get_ip_for_subscriber(self):
         """ test get_ip_for_sid without any assignment """
         sid = 'IMSI11'
-        ip0, _ = self._allocator.alloc_ip_address(sid)
-
-        ip0_returned = self._allocator.get_ip_for_sid(sid)
-
-        # check if retrieved ip is the same as the one allocated
-        self.assertEqual(ip0, ip0_returned)
-        self.check_type(sid, IPType.IP_POOL)
+        with self.assertRaises(SubscriberDBStaticIPValueError):
+            ip0, _ = self._allocator.alloc_ip_address(sid)
 
     def test_get_ip_for_subscriber_with_apn(self):
         """ test get_ip_for_sid with static IP """
@@ -267,13 +263,8 @@ class StaticIPAllocationTests(unittest.TestCase):
         MockedSubscriberDBStub.add_sub(sid=imsi, apn="*", ip=assigned_ip_wild)
         MockedSubscriberDBStub.add_sub_ip(sid=imsi, apn=apn, ip=None)
 
-        ip0, _ = self._allocator.alloc_ip_address(sid)
-        ip0_returned = self._allocator.get_ip_for_sid(sid)
-
-        # check if retrieved ip is the same as the one allocated
-        self.assertEqual(ip0, ip0_returned)
-        self.assertNotEqual(ip0, ipaddress.ip_address(assigned_ip_wild))
-        self.check_type(sid, IPType.IP_POOL)
+        with self.assertRaises(SubscriberDBStaticIPValueError):
+            ip0, _ = self._allocator.alloc_ip_address(sid)
 
     def test_get_ip_for_subscriber_with_apn_with_gw(self):
         """ test get_ip_for_sid with static IP """


### PR DESCRIPTION
MobilityD tries to allocate static IP, it communicates with
subscriberDB. If there is any error in getting the info from
subscriberDB, it continue with ip-pool based allocation.
This does not work when operator wants to only use static IPs
this patch changes this behaviour to failed allocation in
such cases.

Signed-off-by: Pravin B Shelar <pbshelar@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
