### PR TITLE
[orc8r][obsidian] Clean up noisy obsidian error logs

### DIFF
--- a/orc8r/cloud/go/obsidian/access/definitions.go
+++ b/orc8r/cloud/go/obsidian/access/definitions.go
@@ -13,7 +13,7 @@ limitations under the License.
 
 package access
 
-// RequestOperator relies on x-magma-client-cert-serial HTTP request header,
+// getOperator relies on x-magma-client-cert-serial HTTP request header,
 // the header string is redefined here to avoid sharing it with magma GRPC
 // Identity middleware & to comply with specific to Go's net/http header
 // capitalization: https://golang.org/pkg/net/http/#Request

--- a/orc8r/cloud/go/obsidian/access/finder_registry.go
+++ b/orc8r/cloud/go/obsidian/access/finder_registry.go
@@ -16,11 +16,10 @@ package access
 import (
 	"strings"
 
-	"magma/orc8r/cloud/go/obsidian"
-
 	"github.com/labstack/echo"
 
 	"magma/orc8r/cloud/go/identity"
+	"magma/orc8r/cloud/go/obsidian"
 	"magma/orc8r/lib/go/protos"
 )
 

--- a/orc8r/cloud/go/obsidian/access/log_decorator.go
+++ b/orc8r/cloud/go/obsidian/access/log_decorator.go
@@ -16,33 +16,23 @@ package access
 import (
 	"fmt"
 	"net/http"
-
-	"github.com/labstack/echo"
 )
 
-// LogRequestDecorator closure, appends remote address, URI & certificate CN
-// (if available from the passed http.Request) to every log string
-func LogRequestDecorator(req *http.Request) func(f string, a ...interface{}) string {
-	return func(f string, a ...interface{}) string {
+type logDecorator func(string, ...interface{}) string
+
+// getDecorator returns a logDecorator that appends remote address, URI, and
+// certificate CN as available from the passed context.
+func getDecorator(req *http.Request) logDecorator {
+	return func(fmtStr string, args ...interface{}) string {
 		if req != nil {
-			f += "; Remote: %s, URI: %s"
-			a = append(a, req.RemoteAddr, req.RequestURI)
+			fmtStr += "; remote: %s, URI: %s"
+			args = append(args, req.RemoteAddr, req.RequestURI)
 			ccn := req.Header.Get(CLIENT_CERT_CN_KEY)
 			if len(ccn) > 0 {
-				f += ", Cert CN: %s"
-				a = append(a, ccn)
+				fmtStr += ", cert CN: %s"
+				args = append(args, ccn)
 			}
 		}
-		return fmt.Sprintf(f, a...)
+		return fmt.Sprintf(fmtStr, args...)
 	}
-}
-
-// LogDecorator closure, appends remote address, URI & certificate CN
-// (if available from the passed echo.Context) to every log string
-func LogDecorator(c echo.Context) func(f string, a ...interface{}) string {
-	var req *http.Request
-	if c != nil {
-		req = c.Request()
-	}
-	return LogRequestDecorator(req)
 }

--- a/orc8r/cloud/go/obsidian/access/operator.go
+++ b/orc8r/cloud/go/obsidian/access/operator.go
@@ -15,6 +15,7 @@ package access
 
 import (
 	"fmt"
+	"net/http"
 
 	"magma/orc8r/cloud/go/identity"
 	"magma/orc8r/cloud/go/services/certifier"
@@ -22,62 +23,49 @@ import (
 	"magma/orc8r/lib/go/protos"
 
 	"github.com/golang/glog"
-	"github.com/labstack/echo"
 )
 
-// RequestOperator returns Identity of request's Operator (client)
+// getOperator returns Identity of request's Operator (client).
 // If either the request is missing TLS certificate headers or the certificate's
 // SN is not found by Certifier or one of certificate & its identity checks fail
 // - nil will be returned & the corresponding error logged
-func RequestOperator(c echo.Context) (*protos.Identity, error) {
-	if c == nil {
-		glog.Error("Nil Echo Context")
-		return nil, fmt.Errorf("Internal Server Error (Context)") // nil CTX, no useful info to log here
-	}
-	req := c.Request()
-	if req == nil {
-		glog.Error("Nil HTTP Request")
-		return nil, fmt.Errorf("Internal Server Error (Request)")
-	}
-
+func getOperator(req *http.Request, decorate logDecorator) (*protos.Identity, error) {
 	// Get Certificate SN header value
 	// TBD: to optimize - use map directly
 	csn := req.Header.Get(CLIENT_CERT_SN_KEY)
 	if len(csn) == 0 {
-		glog.Warning(LogDecorator(c)("Missing REST Client Certificate"))
-		return nil, fmt.Errorf("Missing Client Certificate")
+		glog.V(1).Info(decorate("Missing REST client certificate"))
+		return nil, fmt.Errorf("missing client certificate")
 	}
 	certInfo, err := certifier.GetCertificateIdentity(csn)
 	if err != nil {
-		glog.Error(LogDecorator(c)(
-			"Certificate SN '%s' lookup error '%s'", csn, err))
 		if _, ok := err.(errors.ClientInitError); ok {
+			glog.Error(decorate("Certificate SN '%s' lookup error '%s'", csn, err))
 			return nil, err
 		}
-		return nil, fmt.Errorf("Unknown Client Certificate SN: %s, err: %v", csn, err)
+		glog.V(1).Info(decorate("Certificate SN '%s' lookup error '%s'", csn, err))
+		return nil, fmt.Errorf("unknown client certificate SN: %s, err: %v", csn, err)
 	}
 	if certInfo == nil {
-		glog.Error(LogDecorator(c)("No Certificate Info for SN: %s", csn))
-		return nil, fmt.Errorf("Unregistered Client Certificate, SN: %s", csn)
+		glog.V(1).Info(decorate("No certificate info for SN: %s", csn))
+		return nil, fmt.Errorf("unregistered client certificate, SN: %s", csn)
 	}
 	// Check if certificate time is not expired/not active yet
 	err = certifier.VerifyDateRange(certInfo)
 	if err != nil {
-		glog.Error(LogDecorator(c)(
-			"Certificate Validation Error '%s' for SN: %s", err, csn))
-		return nil, fmt.Errorf("Certificate Validation Error: %s", err)
+		glog.V(1).Info(decorate("Certificate validation error '%s' for SN: %s", err, csn))
+		return nil, fmt.Errorf("certificate validation error: %s", err)
 	}
 	opId := certInfo.Id
 	if opId == nil {
-		glog.Error(LogDecorator(c)("Nil Identity for Certificate SN: %s", csn))
-		return nil, fmt.Errorf("Internal Server Error (Identity)")
+		glog.Error(decorate("Nil identity for certificate SN: %s", csn))
+		return nil, fmt.Errorf("Internal server error (identity)")
 	}
 	// Check if it's operator identity
 	if !identity.IsOperator(opId) {
-		glog.Error(LogDecorator(c)(
-			"Identity (%s) of CSN %s is not Operator", opId.HashString(), csn))
-		return nil, fmt.Errorf("Internal Server Error (Operator)")
+		glog.V(1).Info(decorate("Identity '%s' of CSN '%s' is not an operator", opId.HashString(), csn))
+		return nil, fmt.Errorf("identity must be for an operator")
 	}
-	// all checks are OK, return it
+
 	return certInfo.Id, nil
 }


### PR DESCRIPTION
## Summary

Obsidian error logging is causing excessive oncall alerts. This PR reduces the noise.

Note: this PR does not mutate any business logic. It only affects when/whether certain errors are logged.

Before

```
orc8r-obsidian-bc9974f69-b755r obsidian 2021/01/22 07:44:06 REST HTTP Error: Missing Network ID, Status: 400
orc8r-obsidian-bc9974f69-b755r obsidian 2021/01/22 07:44:06 REST HTTP Error: Missing Network ID, Status: 400
orc8r-obsidian-bc9974f69-b755r obsidian 2021/01/22 07:44:07 REST HTTP Error: Missing Network ID, Status: 400
orc8r-obsidian-bc9974f69-b755r obsidian 2021/01/22 07:44:07 REST HTTP Error: Missing Network ID, Status: 400
orc8r-obsidian-bc9974f69-b755r obsidian 2021/01/22 07:44:07 REST HTTP Error: Missing Network ID, Status: 400
orc8r-obsidian-bc9974f69-b755r obsidian 2021/01/22 07:44:07 REST HTTP Error: Missing Network ID, Status: 400
orc8r-obsidian-bc9974f69-b755r obsidian 2021/01/22 07:44:07 REST HTTP Error: Missing Network ID, Status: 400
orc8r-obsidian-bc9974f69-b755r obsidian 2021/01/22 07:44:07 REST HTTP Error: Missing Network ID, Status: 400
orc8r-obsidian-bc9974f69-b755r obsidian 2021/01/22 07:44:07 REST HTTP Error: Missing Network ID, Status: 400
orc8r-obsidian-bc9974f69-b755r obsidian 2021/01/22 07:44:07 REST HTTP Error: Missing Network ID, Status: 400
orc8r-obsidian-bc9974f69-b755r obsidian 2021/01/22 07:44:07 REST HTTP Error: Missing Network ID, Status: 400
orc8r-obsidian-bc9974f69-b755r obsidian 2021/01/22 07:44:08 REST HTTP Error: Missing Network ID, Status: 400
orc8r-obsidian-bc9974f69-b755r obsidian 2021/01/22 07:44:08 REST HTTP Error: Missing Network ID, Status: 400
orc8r-obsidian-bc9974f69-b755r obsidian 2021/01/22 07:44:08 REST HTTP Error: Missing Network ID, Status: 400
orc8r-obsidian-bc9974f69-b755r obsidian E0122 07:44:08.299007       1 operator.go:77] Identity (Id_Gateway_faceb00c-face-b00c-face-54833a8bd18a) of CSN 9D82811B75DBDCAE1E2CEFE567608971 is not Operator; Remote: 10.0.101.251:44630, URI: /s3/soma-update-nbg6817-0f98f1efaf1147ea98dee85e7b4254f4-dev.bin, Cert CN: faceb00c-face-b00c-face-54833a8bd18a
orc8r-obsidian-bc9974f69-b755r obsidian E0122 07:44:08.299030       1 rest_middleware.go:114] Client Credentials Error: Internal Server Error (Operator); Remote: 10.0.101.251:44630, URI: /s3/soma-update-nbg6817-0f98f1efaf1147ea98dee85e7b4254f4-dev.bin, Cert CN: faceb00c-face-b00c-face-54833a8bd18a
orc8r-obsidian-bc9974f69-b755r obsidian 2021/01/22 07:44:08 REST HTTP Error: Missing Network ID, Status: 400
orc8r-obsidian-bc9974f69-b755r obsidian 2021/01/22 07:44:08 REST HTTP Error: Missing Network ID, Status: 400
orc8r-obsidian-bc9974f69-b755r obsidian 2021/01/22 07:44:08 REST HTTP Error: Missing Network ID, Status: 400
orc8r-obsidian-bc9974f69-b755r obsidian 2021/01/22 07:44:08 REST HTTP Error: Missing Network ID, Status: 400
orc8r-obsidian-bc9974f69-b755r obsidian E0122 07:44:13.888626       1 operator.go:77] Identity (Id_Gateway_faceb00c-face-b00c-face-5ce28cf2adfa) of CSN 8F9283DEE5EC4EB5A7F2183E613703E7 is not Operator; Remote: 10.0.101.251:44786, URI: /s3/soma-update-nbg6817-soma.image-dev:7c7a50ee958f48fa94fee14b57044ba2-dev.bin, Cert CN: faceb00c-face-b00c-face-5ce28cf2adfa
orc8r-obsidian-bc9974f69-b755r obsidian E0122 07:44:13.888658       1 rest_middleware.go:114] Client Credentials Error: Internal Server Error (Operator); Remote: 10.0.101.251:44786, URI: /s3/soma-update-nbg6817-soma.image-dev:7c7a50ee958f48fa94fee14b57044ba2-dev.bin, Cert CN: faceb00c-face-b00c-face-5ce28cf2adfa
orc8r-obsidian-bc9974f69-b755r obsidian E0122 07:44:19.435341       1 operator.go:77] Identity (Id_Gateway_faceb00c-face-b00c-face-5ce28cf2fbf2) of CSN 2B9955E760D40696FD143B8F25345895 is not Operator; Remote: 10.0.101.251:44952, URI: /s3/soma-update-nbg6817-soma.image-dev:7c7a50ee958f48fa94fee14b57044ba2-dev.bin, Cert CN: faceb00c-face-b00c-face-5ce28cf2fbf2
orc8r-obsidian-bc9974f69-b755r obsidian E0122 07:44:19.438783       1 rest_middleware.go:114] Client Credentials Error: Internal Server Error (Operator); Remote: 10.0.101.251:44952, URI: /s3/soma-update-nbg6817-soma.image-dev:7c7a50ee958f48fa94fee14b57044ba2-dev.bin, Cert CN: faceb00c-face-b00c-face-5ce28cf2fbf2
orc8r-obsidian-bc9974f69-b755r obsidian E0122 07:44:22.548246       1 operator.go:77] Identity (Id_Gateway_faceb00c-face-b00c-face-8c5973fca8c2) of CSN AC39F1D122972E7146FAAF23D21E565D is not Operator; Remote: 10.0.101.251:45032, URI: /s3/soma-update-nbg6817-soma.image-dev:7c7a50ee958f48fa94fee14b57044ba2-dev.bin, Cert CN: faceb00c-face-b00c-face-8c5973fca8c2
orc8r-obsidian-bc9974f69-b755r obsidian E0122 07:44:22.548275       1 rest_middleware.go:114] Client Credentials Error: Internal Server Error (Operator); Remote: 10.0.101.251:45032, URI: /s3/soma-update-nbg6817-soma.image-dev:7c7a50ee958f48fa94fee14b57044ba2-dev.bin, Cert CN: faceb00c-face-b00c-face-8c5973fca8c2
orc8r-obsidian-bc9974f69-b755r obsidian E0122 07:44:23.483263       1 operator.go:77] Identity (Id_Gateway_faceb00c-face-b00c-face-8c5973fca776) of CSN 2ABF33F67C9182ECF1D3BDF1529BF34E is not Operator; Remote: 10.0.101.251:45066, URI: /s3/soma-update-nbg6817-soma.image-dev:7c7a50ee958f48fa94fee14b57044ba2-dev.bin, Cert CN: faceb00c-face-b00c-face-8c5973fca776
orc8r-obsidian-bc9974f69-b755r obsidian E0122 07:44:23.483287       1 rest_middleware.go:114] Client Credentials Error: Internal Server Error (Operator); Remote: 10.0.101.251:45066, URI: /s3/soma-update-nbg6817-soma.image-dev:7c7a50ee958f48fa94fee14b57044ba2-dev.bin, Cert CN: faceb00c-face-b00c-face-8c5973fca776
orc8r-obsidian-bc9974f69-b755r obsidian E0122 07:44:27.817517       1 operator.go:77] Identity (Id_Gateway_faceb00c-face-b00c-face-5ce28cf2ae7a) of CSN 7ABC76ECB3FF715D0F5EE2B9B089EDA2 is not Operator; Remote: 10.0.101.251:45196, URI: /s3/soma-update-nbg6817-soma.image-dev:7c7a50ee958f48fa94fee14b57044ba2-dev.bin, Cert CN: faceb00c-face-b00c-face-5ce28cf2ae7a
orc8r-obsidian-bc9974f69-b755r obsidian E0122 07:44:27.817546       1 rest_middleware.go:114] Client Credentials Error: Internal Server Error (Operator); Remote: 10.0.101.251:45196, URI: /s3/soma-update-nbg6817-soma.image-dev:7c7a50ee958f48fa94fee14b57044ba2-dev.bin, Cert CN: faceb00c-face-b00c-face-5ce28cf2ae7a
```

After: by default, only log errors if they indicate orc8r itself is malfunctioning (e.g. 5xx HTTP response code). Otherwise, for e.g. invalid HTTP requests, we can log that as info behind v1 verbosity.

## Test Plan

- Lack of logic changes: existing tests
- Log changes: doing_it_live.png

## Additional Information

- [ ] This change is backwards-breaking