### PR TITLE
[sessiond] temporal fix for searches with bearerid

### DIFF
--- a/lte/gateway/c/session_manager/SessionStore.cpp
+++ b/lte/gateway/c/session_manager/SessionStore.cpp
@@ -229,10 +229,10 @@ optional<SessionVector::iterator> SessionStore::find_session(
         switch (context.rat_type()) {
           case RATType::TGPP_LTE:
             // lte case
-            if ((*it)
-                    ->get_config()
-                    .rat_specific_context.lte_context()
-                    .bearer_id() == criteria.secondary_key_unit32) {
+            if ((*it)->get_config()
+                        .rat_specific_context.lte_context()
+                        .bearer_id() == criteria.secondary_key_unit32 &&
+                (*it)->is_active()) {
               return it;
             }
             break;


### PR DESCRIPTION
Signed-off-by: Oriol Batalla <obatalla@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary

This is a temporal fix that prevents returning sessions that are not active when we search using IMSI + BEARER ID

Note that returning sessions that are in not active state is totally fine. But with this fix we just skip those that are not active. 

We will remove that fix once UpdateTunnelIDRequest From mme sends sessionid

## Test Plan
make precommit
integ_lte_test

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
