### PR TITLE
AGW: mobilityD: disable static IP for dev tests

### DIFF
--- a/lte/gateway/configs/gateway.mconfig
+++ b/lte/gateway/configs/gateway.mconfig
@@ -7,8 +7,8 @@
       "ipv6Block": "fdee:5:6c::/48",
       "ipv6PrefixAllocationType": "RANDOM",
       "ip_allocator_type": "IP_POOL",
-      "static_ip_enabled": true,
-      "multi_apn_ip_alloc": true
+      "static_ip_enabled": false,
+      "multi_apn_ip_alloc": false
     },
     "mme": {
       "@type": "type.googleapis.com/magma.mconfig.MME",

--- a/lte/gateway/python/magma/mobilityd/subscriberdb_client.py
+++ b/lte/gateway/python/magma/mobilityd/subscriberdb_client.py
@@ -79,7 +79,7 @@ class SubscriberDbClient:
                                     vlan=apn_config.resource.vlan_id)
 
         except ValueError:
-            logging.warning("Invalid data for sid %s: ", sid)
+            logging.warning("Invalid or missing data for sid %s: ", sid)
             raise SubscriberDBStaticIPValueError(sid)
 
         except grpc.RpcError as err:
@@ -105,7 +105,7 @@ class SubscriberDbClient:
                                        vlan=apn_config.resource.vlan_id)
 
             except ValueError:
-                logging.warning("Invalid data for sid %s: ", sid)
+                logging.warning("Invalid or missing data for sid %s: ", sid)
                 raise SubscriberDBMultiAPNValueError(sid)
 
             except grpc.RpcError as err:


### PR DESCRIPTION
Integ tests are failing due to missing static IP config. To
unblock tests I have disabled these features.

Signed-off-by: Pravin B Shelar <pbshelar@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
