### PR TITLE
[tf] Modify fluentd output.conf for correct ES index prefixes for events

### DIFF
--- a/orc8r/cloud/deploy/terraform/orc8r-helm-aws/logging.tf
+++ b/orc8r/cloud/deploy/terraform/orc8r-helm-aws/logging.tf
@@ -55,6 +55,35 @@ resource "helm_release" "fluentd" {
         </transport>
       </source>
     output.conf: |-
+      <match eventd>
+        @id eventd_elasticsearch
+        @type elasticsearch
+        @log_level info
+        include_tag_key true
+        host "#{ENV['OUTPUT_HOST']}"
+        port "#{ENV['OUTPUT_PORT']}"
+        scheme "#{ENV['OUTPUT_SCHEME']}"
+        ssl_version "#{ENV['OUTPUT_SSL_VERSION']}"
+        logstash_format true
+        logstash_prefix "eventd"
+        reconnect_on_error true
+        reload_on_failure true
+        reload_connections false
+        log_es_400_reason true
+        <buffer>
+          @type file
+          path /var/log/fluentd-buffers/eventd.kubernetes.system.buffer
+          flush_mode interval
+          retry_type exponential_backoff
+          flush_thread_count 2
+          flush_interval 5s
+          retry_forever
+          retry_max_interval 30
+          chunk_limit_size "#{ENV['OUTPUT_BUFFER_CHUNK_LIMIT']}"
+          queue_limit_length "#{ENV['OUTPUT_BUFFER_QUEUE_LIMIT']}"
+          overflow_action block
+        </buffer>
+      </match>
       <match **>
         @id elasticsearch
         @type elasticsearch
@@ -69,6 +98,7 @@ resource "helm_release" "fluentd" {
         reconnect_on_error true
         reload_on_failure true
         reload_connections false
+        log_es_400_reason true
         <buffer>
           @type file
           path /var/log/fluentd-buffers/kubernetes.system.buffer


### PR DESCRIPTION
Signed-off-by: Andrei Lee <andreilee@fb.com>

## Summary

Adds a new `match` section to the fluentd config file `output.conf` for matching event entries coming from `eventd` service. These events will be populated in elasticsearch indexes prefixed with `eventd`, allowing the current REST API endpoints which fetch events via this prefix assumption to work correctly.

## Test Plan

N/A

## Additional Information

- [ ] This change is backwards-breaking
