### PR TITLE
[lte][agw] Adding mtr_ip to service config only if mtr_interface is present

### DIFF
--- a/lte/gateway/python/magma/pipelined/main.py
+++ b/lte/gateway/python/magma/pipelined/main.py
@@ -96,11 +96,10 @@ def main():
     service.config['he_enabled'] = he_enabled
 
     # monitoring related configuration
-    mtr_ip = None
     mtr_interface = service.config.get('mtr_interface', None)
     if mtr_interface:
         mtr_ip = get_ip_from_if(mtr_interface)
-    service.config['mtr_ip'] = mtr_ip
+        service.config['mtr_ip'] = mtr_ip
 
     # Load the ryu apps
     service_manager = ServiceManager(service)


### PR DESCRIPTION
Signed-off-by: Alex Rodriguez <ardzoht@gmail.com>

## Summary

- With #4368 changes, CWF setups fail because there's no `ovs_mtr_port_number` config present on the service YML configs, this was triggered because we were injecting `mtr_ip` to the apps always even if `mtr_interface` parameter was not present, this PR fixes it.

## Test Plan

- make integ_test for LTE sanity validation
- fab integ_test for cwf validation

## Additional Information

- [ ] This change is backwards-breaking


