### PR TITLE
[ctraced] Add obsidian labels for ctraced REST endpoints

### DIFF
--- a/orc8r/cloud/helm/orc8r/Chart.yaml
+++ b/orc8r/cloud/helm/orc8r/Chart.yaml
@@ -13,7 +13,7 @@ apiVersion: v2
 appVersion: "1.0"
 description: A Helm chart for magma orchestrator
 name: orc8r
-version: 1.5.8
+version: 1.5.9
 engine: gotpl
 sources:
   - https://github.com/facebookincubator/magma

--- a/orc8r/cloud/helm/orc8r/values.yaml
+++ b/orc8r/cloud/helm/orc8r/values.yaml
@@ -213,8 +213,11 @@ configurator:
 
 ctraced:
   service:
-    labels: {}
-    annotations: {}
+    labels:
+      orc8r.io/obsidian_handlers: "true"
+    annotations:
+      orc8r.io/obsidian_handlers_path_prefixes: >
+        /magma/v1/networks/:network_id/tracing,
 
 device:
   service:


### PR DESCRIPTION
Signed-off-by: Andrei Lee <andreilee@fb.com>

## Summary

Added obsidian labels for ctraced REST endpoints, prefix:
`magma/v1/networks/:network_id/tracing`, so that when running orc8r with service mesh enabled, the tracing API calls are routed to the `ctraced` service

## Test Plan

N/A

## Additional Information

- [ ] This change is backwards-breaking
