### PR TITLE
[lte][agw] Updating IP allocator pool to not do full look-up of IPs in free state

### DIFF
--- a/lte/gateway/python/magma/mobilityd/ip_address_man.py
+++ b/lte/gateway/python/magma/mobilityd/ip_address_man.py
@@ -429,7 +429,7 @@ class IPAddressManager:
 
             # Set timer for the next round of recycling
             self._recycle_timer = None
-            if self._store.ip_state_map.get_ip_count(IPState.RELEASED):
+            if not self._store.ip_state_map.is_ip_state_map_empty(IPState.RELEASED):
                 self._try_set_recycle_timer()
 
     def _try_set_recycle_timer(self):

--- a/lte/gateway/python/magma/mobilityd/ip_allocator_pool.py
+++ b/lte/gateway/python/magma/mobilityd/ip_allocator_pool.py
@@ -195,8 +195,8 @@ class IpAllocatorPool(IPAllocator):
         TODO: Add support of per APN IP-POOL
         """
         # if an IP is not yet allocated for the UE, allocate a new IP
-        if self._store.ip_state_map.get_ip_count(IPState.FREE):
-            ip_desc = self._store.ip_state_map.pop_ip_from_state(IPState.FREE)
+        ip_desc = self._store.ip_state_map.pop_ip_from_state(IPState.FREE)
+        if ip_desc:
             ip_desc.sid = sid
             ip_desc.state = IPState.ALLOCATED
             return ip_desc

--- a/lte/gateway/python/magma/mobilityd/ip_descriptor_map.py
+++ b/lte/gateway/python/magma/mobilityd/ip_descriptor_map.py
@@ -37,7 +37,6 @@ from __future__ import absolute_import, division, print_function, \
 
 from ipaddress import ip_address, ip_network
 from typing import Dict, List, Optional, Set
-from random import choice
 
 from magma.mobilityd.ip_descriptor import IPDesc, IPState
 
@@ -82,10 +81,15 @@ class IpDescriptorMap:
             return None
 
     def is_ip_state_map_empty(self, state: IPState) -> bool:
-        """ Return if IPs map is empty for a given state """
+        """
+        Args:
+            state: IP State to check for
+
+        Returns: True if IPs map is empty for a given state, else otherwise
+        """
         assert state in IPState, "unknown state %s" % state
 
-        return self.ip_states[state] == False
+        return bool(self.ip_states[state]) == False
 
     def test_ip_state(self, ip: ip_address, state: IPState) -> bool:
         """ check if IP is in state X """
@@ -119,7 +123,7 @@ class IpDescriptorMap:
         assert ip == ip_desc.ip, "Unmatching ip_desc for %s" % ip
 
         if ip_desc.state == IPState.FREE:
-            assert ip_desc.sid is None,\
+            assert ip_desc.sid is None, \
                 "Unexpected sid in a freed IPDesc {}".format(ip_desc)
         else:
             assert ip_desc.sid is not None, \

--- a/lte/gateway/python/magma/mobilityd/ip_descriptor_map.py
+++ b/lte/gateway/python/magma/mobilityd/ip_descriptor_map.py
@@ -36,7 +36,7 @@ from __future__ import absolute_import, division, print_function, \
     unicode_literals
 
 from ipaddress import ip_address, ip_network
-from typing import Dict, List, Set
+from typing import Dict, List, Optional, Set
 from random import choice
 
 from magma.mobilityd.ip_descriptor import IPDesc, IPState
@@ -71,19 +71,21 @@ class IpDescriptorMap:
         ip_desc = self.ip_states[state].pop(ip.exploded, None)
         return ip_desc
 
-    def pop_ip_from_state(self, state: IPState) -> IPDesc:
+    def pop_ip_from_state(self, state: IPState) -> Optional[IPDesc]:
         """ Pop an IP from a internal dict """
         assert state in IPState, "unknown state %s" % state
 
-        ip_state_key = choice(list(self.ip_states[state].keys()))
-        ip_desc = self.ip_states[state].pop(ip_state_key)
-        return ip_desc
+        try:
+            _, ip_desc = self.ip_states[state].popitem()
+            return ip_desc
+        except KeyError:
+            return None
 
-    def get_ip_count(self, state: IPState) -> int:
-        """ Return number of IPs in a state """
+    def is_ip_state_map_empty(self, state: IPState) -> bool:
+        """ Return if IPs map is empty for a given state """
         assert state in IPState, "unknown state %s" % state
 
-        return len(self.ip_states[state])
+        return self.ip_states[state] == False
 
     def test_ip_state(self, ip: ip_address, state: IPState) -> bool:
         """ check if IP is in state X """


### PR DESCRIPTION
Signed-off-by: Alex Rodriguez <ardzoht@gmail.com>

## Summary

- On stateless mode, we've seen that when setting an IP block with high number of IPs available, the performance on mobilityd allocation results on attaching UE operations very slow.
- This PR fixes the lookup in the IP state map dictionary to not lookup the count of IPs to check if there are IPs available to allocate.

## Test Plan

- make integ_test for sanity testing
- Tested with s1ap tester, setting and updating the IP block to /19 to setup a high number of IPs available

## Additional Information

- [ ] This change is backwards-breaking

