### PR TITLE
[Backport][V1.3] [MME] fix incorrect formatting of time/timezone in EMM-information pa…

### DIFF
--- a/lte/gateway/c/oai/include/state_converter.h
+++ b/lte/gateway/c/oai/include/state_converter.h
@@ -95,7 +95,7 @@ class StateConverter {
         (*proto_map)[ht_keys->keys[i]] = proto;
       } else {
         OAILOG_ERROR(
-            log_task_level, "Key %u not found on %s hashtable",
+            log_task_level, "Key %lu not found on %s hashtable",
             ht_keys->keys[i], state_ht->name->data);
       }
     }

--- a/lte/gateway/c/oai/tasks/mme_app/mme_app_state_converter.cpp
+++ b/lte/gateway/c/oai/tasks/mme_app/mme_app_state_converter.cpp
@@ -59,7 +59,7 @@ void MmeNasStateConverter::hashtable_ts_to_proto(
       (*proto_map)[(uint32_t) keys->keys[i]] = ue_ctxt_proto;
     } else {
       OAILOG_ERROR(
-          LOG_MME_APP, "Key %u not in mme_ue_s1ap_id_ue_context_htbl",
+          LOG_MME_APP, "Key %lu not in mme_ue_s1ap_id_ue_context_htbl",
           keys->keys[i]);
     }
   }
@@ -134,10 +134,12 @@ void MmeNasStateConverter::guti_table_to_proto(
     if (ht_rc == HASH_TABLE_OK) {
       (*proto_map)[guti_str] = mme_ue_id;
     } else {
-      OAILOG_ERROR(LOG_MME_APP, "Key %s not in guti_ue_context_htbl", guti_str);
+      OAILOG_ERROR(
+          LOG_MME_APP, "Key %s not in guti_ue_context_htbl", guti_str.c_str());
     }
     OAILOG_DEBUG(
-        LOG_MME_APP, "guti_str:%s mme_ue_id:%d\n", guti_str.c_str(), mme_ue_id);
+        LOG_MME_APP, "guti_str:%s mme_ue_id:%lu\n", guti_str.c_str(),
+        mme_ue_id);
   }
   FREE_OBJ_HASHTABLE_KEY_ARRAY(key_array_p);
 }

--- a/lte/gateway/c/oai/tasks/nas/emm/sap/emm_send.c
+++ b/lte/gateway/c/oai/tasks/nas/emm/sap/emm_send.c
@@ -1531,12 +1531,14 @@ int emm_send_security_mode_command(
 int emm_send_emm_information(
     const emm_as_data_t* msg, emm_information_msg* emm_msg) {
   OAILOG_FUNC_IN(LOG_NAS_EMM);
-  int size     = EMM_HEADER_MAXIMUM_LENGTH;
-  int addci    = 0;
-  int noOfBits = 0;
+  char string[MAX_MINUTE_DIGITS] = {0};
+  int size                       = EMM_HEADER_MAXIMUM_LENGTH;
+  int addci                      = 0;
+  int noOfBits                   = 0;
   time_t t;
   struct tm* tmp;
   struct tm updateTime;
+  uint8_t formatted;
 
   /*
    * Mandatory - Message type
@@ -1602,12 +1604,41 @@ int emm_send_emm_information(
   emm_msg->presencemask |=
       EMM_INFORMATION_UNIVERSAL_TIME_AND_LOCAL_TIME_ZONE_PRESENT;
 
-  emm_msg->universaltimeandlocaltimezone.year   = updateTime.tm_year;
-  emm_msg->universaltimeandlocaltimezone.month  = updateTime.tm_mon;
-  emm_msg->universaltimeandlocaltimezone.day    = updateTime.tm_mday;
-  emm_msg->universaltimeandlocaltimezone.hour   = updateTime.tm_hour;
-  emm_msg->universaltimeandlocaltimezone.minute = updateTime.tm_min;
-  emm_msg->universaltimeandlocaltimezone.second = updateTime.tm_sec;
+  /*
+   * Time SHALL be encoded as specified in 3GPP 23.040 in SM-TL TPDU format.
+   */
+  /*
+   * updateTime.year is "years since 1900"
+   * GSM format is the last 2 digits of the year.
+   */
+  snprintf(string, sizeof(string), "%02d", updateTime.tm_year + 1900 - 2000);
+  formatted = (string[1] - '0') << 4;
+  formatted |= (string[0] - '0');
+  emm_msg->universaltimeandlocaltimezone.year = formatted;
+  /*
+   * updateTime.tm_mon is "months since January" in [0-11] range.
+   * GSM format is months in [1-12] range.
+   */
+  snprintf(string, sizeof(string), "%02d", updateTime.tm_mon + 1);
+  formatted = (string[1] - '0') << 4;
+  formatted |= (string[0] - '0');
+  emm_msg->universaltimeandlocaltimezone.month = formatted;
+  snprintf(string, sizeof(string), "%02d", updateTime.tm_mday);
+  formatted = (string[1] - '0') << 4;
+  formatted |= (string[0] - '0');
+  emm_msg->universaltimeandlocaltimezone.day = formatted;
+  snprintf(string, sizeof(string), "%02d", updateTime.tm_hour);
+  formatted = (string[1] - '0') << 4;
+  formatted |= (string[0] - '0');
+  emm_msg->universaltimeandlocaltimezone.hour = formatted;
+  snprintf(string, sizeof(string), "%02d", updateTime.tm_min);
+  formatted = (string[1] - '0') << 4;
+  formatted |= (string[0] - '0');
+  emm_msg->universaltimeandlocaltimezone.minute = formatted;
+  snprintf(string, sizeof(string), "%02d", updateTime.tm_sec);
+  formatted = (string[1] - '0') << 4;
+  formatted |= (string[0] - '0');
+  emm_msg->universaltimeandlocaltimezone.second = formatted;
   if (emm_msg->localtimezone != RETURNerror) {
     emm_msg->universaltimeandlocaltimezone.timezone = emm_msg->localtimezone;
   }
@@ -1713,6 +1744,7 @@ int get_time_zone(void) {
     OAILOG_ERROR(LOG_NAS_EMM, "EMMAS-SAP - strftime() Failed to get timezone");
     OAILOG_FUNC_RETURN(LOG_NAS_EMM, RETURNerror);
   }
+
   /* the string shall be in the form of +hhmm (+0530) */
   if (timestr[0] == '-') {
     timezone = 0x08;
@@ -1721,9 +1753,9 @@ int get_time_zone(void) {
   minute = ((10 * (timestr[3] - '0')) | (timestr[4] - '0')) + (hour * 60);
   minute /= 15;
 
-  snprintf(string, sizeof(string), "%d", minute);
-  timezone |= (string[0] - '0') << 4;
-  timezone |= (string[1] - '0');
+  snprintf(string, sizeof(string), "%02d", minute);
+  timezone |= (string[1] - '0') << 4;
+  timezone |= (string[0] - '0');
 
   OAILOG_FUNC_RETURN(LOG_NAS_EMM, timezone);
 }

--- a/lte/gateway/docker/mme/Dockerfile
+++ b/lte/gateway/docker/mme/Dockerfile
@@ -7,16 +7,18 @@ ARG GIT_PROXY
 ARG FEATURES=mme_oai
 ENV MAGMA_ROOT=/magma
 ENV C_BUILD=/build/c
+ENV TZ=Europe/Paris
+ENV DEBIAN_FRONTEND=noninteractive
 
 RUN mkdir -p $C_BUILD
 
 RUN ["/bin/bash", "-c", "echo \"Install general purpouse packages\" && \
     apt-get update && \
-    apt-get upgrade -y && \
-    apt-get install -y gnupg wget software-properties-common autoconf automake \
+    DEBIAN_FRONTEND=noninteractive apt-get upgrade -y && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y gnupg wget software-properties-common autoconf automake \
     libtool curl make g++ unzip git build-essential autoconf libtool pkg-config \
-    gcc-6 g++-6 apt-transport-https ca-certificates apt-utils vim redis-server \
-    libssl-dev ninja-build golang python2.7 automake perl libgmp3-dev && \
+    gcc-6 g++-6 apt-transport-https ca-certificates apt-utils vim redis-server tzdata \
+    libssl-dev ninja-build golang python2.7 automake perl libgmp3-dev clang-format-7 && \
     echo \"Configure C/C++ compiler v6.5 as primary\" && \
     update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-7 10 && \
     update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-7 10 && \
@@ -134,7 +136,7 @@ RUN wget https://ftp.gnu.org/gnu/nettle/nettle-2.5.tar.gz && \
     cd build/ && \
     ../configure  && \
     make -j4 && \
-    make install 
+    make install
 
 ##### liblfds
 # https://www.liblfds.org/mediawiki/index.php?title=r7.1.0:Building_Guide_(liblfds)
@@ -185,7 +187,7 @@ RUN echo "Install fmtlib required by Folly" && \
 COPY ./ $MAGMA_ROOT
 
 ##### FreeDiameter
-RUN git clone https://github.com/OPENAIRINTERFACE/opencord.org.freeDiameter.git freediameter && \ 
+RUN git clone https://github.com/OPENAIRINTERFACE/opencord.org.freeDiameter.git freediameter && \
     cd freediameter && \
     patch -p1 < $MAGMA_ROOT/lte/gateway/c/oai/patches/0001-opencoord.org.freeDiameter.patch && \
     mkdir build && \
@@ -194,9 +196,9 @@ RUN git clone https://github.com/OPENAIRINTERFACE/opencord.org.freeDiameter.git 
     awk '{if (/^DISABLE_SCTP/) gsub(/OFF/, "ON"); print}' CMakeCache.txt > tmp && mv tmp CMakeCache.txt && \
     make -j4 && \
     make install
-    
+
 ### Following  is required to build MME with OVS support
-# WARNING!!! for the moment it'snot working well cause libfluid linked with Ubuntu incorrectly 
+# WARNING!!! for the moment it'snot working well cause libfluid linked with Ubuntu incorrectly
 # ENV FEATURES=agw_of
 # RUN git clone https://github.com/facebookincubator/magma.git /fb_magma
 # Clone repos and checkout latest commit
@@ -216,7 +218,7 @@ RUN git clone https://github.com/OPENAIRINTERFACE/opencord.org.freeDiameter.git 
 # Build MME executables
 RUN ldconfig && \
     cd $MAGMA_ROOT/lte/gateway && \
-    echo $FEATURES && \ 
+    echo $FEATURES && \
     make build_oai && \
     make build_sctpd
 
@@ -283,16 +285,16 @@ ENV C_BUILD=/build/c
 
 # Install a few tools (may not be necessary later on)
 ENV DEBIAN_FRONTEND=noninteractive
+ENV TZ=Europe/Paris
 
-# redis-server installation is temporary
-# once we resolve the issue when running it on a separate container, we will remove it
-
-RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get upgrade --yes && DEBIAN_FRONTEND=noninteractive apt-get install --yes \
-    psmisc \
-    openssl \
-    net-tools \
-    tshark \
-    redis-server \
+RUN apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get upgrade --yes && \
+    DEBIAN_FRONTEND=noninteractive apt-get install --yes \
+      psmisc \
+      openssl \
+      net-tools \
+      tshark \
+      tzdata \
   && rm -rf /var/lib/apt/lists/*
 
 # Copy pre-built shared object files


### PR DESCRIPTION
Back-porting #3998 to branch v1.3 after resolving merge conflicts

2 Major issues:

* timezone has to be computed using 2 characters
* time has to follow 3GPP syntax

Fix a few compilation warnings.

Signed-off-by: Raphael Defosseux <raphael.defosseux@openairinterface.org>
Signed-off-by: Shruti Sanadhya <ssanadhya@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
