### PR TITLE
[circleci][deploy-latest] adding docker image used by xwf-m to be tag…

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1067,7 +1067,7 @@ workflows:
             - xwfm-test
             - cwag-precommit
             - cwf-integ-test
-          images: 'gateway_python|gateway_pipelined'
+          images: 'gateway_python|gateway_pipelined|gateway_go'
           tag: 'latest'
       - xwfm-deploy:
           <<: *only_master


### PR DESCRIPTION
…ged with latest too

Signed-off-by: Ayelet Regev Dabah <ayelet.regev@gmail.com>

[circleci][deploy-latest] adding docker image used by xwf-m to be tag

## Summary

We plan to query latest tag published for all components use use in xwf-m for our push system.

## Test Plan

will be tested only after landing cause on deployment phase.

## Additional Information

- [ ] This change is backwards-breaking

