### PR TITLE
[ctraced] Add missing port definition for ctraced orc8r service

### DIFF
--- a/orc8r/cloud/helm/orc8r/Chart.yaml
+++ b/orc8r/cloud/helm/orc8r/Chart.yaml
@@ -13,7 +13,7 @@ apiVersion: v2
 appVersion: "1.0"
 description: A Helm chart for magma orchestrator
 name: orc8r
-version: 1.5.9
+version: 1.5.10
 engine: gotpl
 sources:
   - https://github.com/facebookincubator/magma

--- a/orc8r/cloud/helm/orc8r/templates/ctraced.service.yaml
+++ b/orc8r/cloud/helm/orc8r/templates/ctraced.service.yaml
@@ -30,4 +30,7 @@ spec:
     - name: grpc
       port: 9180
       targetPort: 9118
+    - name: http
+      port: 8080
+      targetPort: 10118
 {{- end -}}


### PR DESCRIPTION
Signed-off-by: Andrei Lee <andreilee@fb.com>

## Summary

Add missing http port definition for `ctraced` service.

Bumped helm chart version.

## Test Plan

N/A

## Additional Information

- [ ] This change is backwards-breaking
