### PR TITLE
[feg] s8 wait for gtp service to be ready (fixes CI)

### DIFF
--- a/feg/gateway/services/s8_proxy/servicers/gtp_handlers.go
+++ b/feg/gateway/services/s8_proxy/servicers/gtp_handlers.go
@@ -42,16 +42,14 @@ func addS8GtpHandlers(s8p *S8Proxy) {
 
 func getHandle_CreateSessionResponse() gtpv2.HandlerFunc {
 	return func(c *gtpv2.Conn, senderAddr net.Addr, msg message.Message) error {
-
-		session, err := c.GetSessionByTEID(msg.TEID(), senderAddr)
-
-		if err != nil {
-			return fmt.Errorf("couldn't find session with TEID %d: %s", msg.TEID(), err)
-		}
-
 		csResGtp := msg.(*message.CreateSessionResponse)
 		csRes := &protos.CreateSessionResponsePgw{}
 		glog.V(2).Infof("Received Create Session Response (gtp):\n%s", csResGtp.String())
+
+		session, err := c.GetSessionByTEID(msg.TEID(), senderAddr)
+		if err != nil {
+			return fmt.Errorf("couldn't find session with TEID %d: %s", msg.TEID(), err)
+		}
 
 		// check Cause value first.
 		if causeIE := csResGtp.Cause; causeIE != nil {
@@ -173,15 +171,14 @@ func getHandle_ModifyBearerRequest() gtpv2.HandlerFunc {
 
 func getHandle_DeleteSessionResponse() gtpv2.HandlerFunc {
 	return func(c *gtpv2.Conn, senderAddr net.Addr, msg message.Message) error {
-		session, err := c.GetSessionByTEID(msg.TEID(), senderAddr)
-
-		if err != nil {
-			return fmt.Errorf("couldn't find session with TEID %d: %s", msg.TEID(), err)
-		}
-
 		cdResGtp := msg.(*message.DeleteSessionResponse)
 		cdRes := &protos.DeleteSessionResponsePgw{}
 		glog.V(2).Infof("Received Delete Session Response (gtp):\n%s", cdResGtp.String())
+
+		session, err := c.GetSessionByTEID(msg.TEID(), senderAddr)
+		if err != nil {
+			return fmt.Errorf("couldn't find session with TEID %d: %s", msg.TEID(), err)
+		}
 
 		// check Cause value first.
 		if causeIE := cdResGtp.Cause; causeIE != nil {

--- a/feg/gateway/services/s8_proxy/servicers/mock_pgw/mock_pgw.go
+++ b/feg/gateway/services/s8_proxy/servicers/mock_pgw/mock_pgw.go
@@ -17,7 +17,6 @@ import (
 	"context"
 	"fmt"
 	"net"
-	"time"
 
 	"github.com/wmnsk/go-gtp/gtpv1"
 
@@ -74,9 +73,9 @@ func (mPgw *MockPgw) Start(ctx context.Context, sgwAddrStr, pgwAddrsStr string) 
 	if err != nil {
 		return fmt.Errorf("Failed to get SGW IP: %s", err)
 	}
-	// Better handle wait for start of service to be ready
-	time.Sleep(time.Millisecond * 20)
-	time.Sleep(time.Millisecond * 20)
+
+	//TODO: remove this once we find a way to safely wait for initialization of the service
+	mPgw.Client.WaitUntilClientIsReady(0)
 
 	// register handlers for ALL the message you expect remote endpoint to send.
 	mPgw.AddHandlers(map[uint8]gtpv2.HandlerFunc{

--- a/feg/gateway/services/s8_proxy/servicers/s8_proxy_test.go
+++ b/feg/gateway/services/s8_proxy/servicers/s8_proxy_test.go
@@ -13,13 +13,14 @@ package servicers
 
 import (
 	"context"
-	"github.com/wmnsk/go-gtp/gtpv2"
+	"log"
 	"testing"
 
 	"magma/feg/cloud/go/protos"
 	"magma/feg/gateway/services/s8_proxy/servicers/mock_pgw"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/wmnsk/go-gtp/gtpv2"
 )
 
 const (
@@ -37,7 +38,7 @@ func TestS8Proxy(t *testing.T) {
 		return
 	}
 	defer mockPgw.Close()
-	//t.Logf("Running PGW at %s\n", mockPgw.LocalAddr().String())
+	log.Printf("Running PGW at %s\n", mockPgw.LocalAddr().String())
 
 	// Run S8_proxy
 	config := getDefaultConfig(mockPgw.LocalAddr().String())

--- a/feg/gateway/services/s8_proxy/servicers/senders.go
+++ b/feg/gateway/services/s8_proxy/servicers/senders.go
@@ -40,9 +40,7 @@ func (s *S8Proxy) sendAndReceiveCreateSession(csReqIEs []*ie.IE, sessionTeids Se
 	glog.V(2).Infof("Send Create Session Request (gtp):\n%s",
 		message.NewCreateSessionRequest(0, 0, csReqIEs...).String())
 
-	glog.V(2).Infof("Server addres to create session -> %s", s.gtpClient.GetServerAddress().String())
 	session, seq, err := s.gtpClient.CreateSession(s.gtpClient.GetServerAddress(), csReqIEs...)
-
 	if err != nil {
 		return nil, fmt.Errorf("failed to send message: %s", err)
 	}

--- a/feg/gateway/tools/s8_cli/main.go
+++ b/feg/gateway/tools/s8_cli/main.go
@@ -122,6 +122,10 @@ func createSession(cmd *commands.Command, args []string) int {
 			fmt.Printf("BuiltIn S8 Proxy initialization error: %v\n", err)
 			return 5
 		}
+
+		//TODO: remove this once we find a way to safely wait for initialization of the service
+		localProxy.WaitUntilClientIsReady()
+
 		cli = s8BuiltIn{localProxy}
 	} else {
 		// TODO: use local proxy running on the gateway


### PR DESCRIPTION
Signed-off-by: Oriol Batalla <obatalla@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary

When GTP-C client is run in a go routine. If we use the client too quick (like test do), the client may not be fully initialized and will panic.  Go-GTP does not offer any way to check if the client is done initializing, so we use a workaround shown in `waitUntilClientIsReady`

## Test Plan

make test precommit 


## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
