### PR TITLE
[NMS] Fix misc NMS issues

### DIFF
--- a/nms/app/packages/magmalte/alerts/lteAlerts.js
+++ b/nms/app/packages/magmalte/alerts/lteAlerts.js
@@ -22,15 +22,31 @@ export default function getLteAlerts(
   return {
     'Service Restart Alert': {
       alert: 'Service Restart Alert',
-      expr: `avg_over_time(service_restart_status{networkID=~"${networkID}"}[5m]) > 0`,
+      expr: `increase(service_restart_status{networkID=~"${networkID}"}[5m]) > 0`,
       labels: {severity: 'minor'},
       annotations: {description: 'Alerts upon service restarts'},
     },
     'Cpu Percent Alert': {
       alert: 'Cpu Percent Alert',
-      expr: `avg_over_time(cpu_percent{networkID=~"${networkID}"}[5m]) > 75`,
+      expr: `avg_over_time(cpu_percent{networkID=~"${networkID}"}[5m]) > 70`,
       labels: {severity: 'minor'},
-      annotations: {description: 'Alerts when cpu percent is greater than 75%'},
+      annotations: {description: 'Alerts when cpu percent is greater than 70%'},
+    },
+    'High Disk Usage Alert': {
+      alert: 'High Disk Usage Alert',
+      expr: `avg_over_time(disk_percent{networkID="${networkID}"}[5m]) > 70`,
+      labels: {severity: 'major'},
+      annotations: {
+        description: 'Alerts when disk percent is greater than 70%',
+      },
+    },
+    'High Memory Usage Alert': {
+      alert: 'High Memory Usage Alert',
+      expr: `((1 - mem_available{networkID="${networkID}"} / mem_total{networkID=~"${networkID}"}) * 100) > 70`,
+      labels: {severity: 'major'},
+      annotations: {
+        description: 'Alerts when memory used is greater than 70%',
+      },
     },
     'Unexpected Service Restart Alert': {
       alert: 'Unexpected Service Restart Alert',
@@ -65,6 +81,21 @@ export default function getLteAlerts(
       expr: `increase(ue_attach{result="failure", networkID=~"${networkID}"}[5m]) > 0`,
       labels: {severity: 'minor'},
       annotations: {description: 'Alerts when we have UE attach failures'},
+    },
+    'Gateway Checkin Failure': {
+      alert: 'Gateway Checkin Failure',
+      expr: `checkin_status{networkID=~"${networkID}" < 1`,
+      labels: {severity: 'critical'},
+      annotations: {description: 'Alerts when we have gateway checkin failure'},
+    },
+    'Dip in Connected UEs': {
+      alert: 'Dip in Connected UEs',
+      expr: `(ue_connected{networkID=~"${networkID}"} - ue_connected{networkID=~"${networkID}"} offset 5m) / (ue_connected{networkID=~"${networkID}"}) < -0.5`,
+      labels: {severity: 'critical'},
+      annotations: {
+        description:
+          'Alerts when there is a 50% dip in connected UEs in last 5 minutes',
+      },
     },
   };
 }

--- a/nms/app/packages/magmalte/app/components/DashboardAlertTable.js
+++ b/nms/app/packages/magmalte/app/components/DashboardAlertTable.js
@@ -306,7 +306,7 @@ function AlertsTabbedTable(props: Props) {
                 style={{color: colors.alerts.severe}}
                 className={classes.tabIconLabel}
               />
-              {`Critical(${props.alerts['Major'].length})`}
+              {`Critical(${props.alerts['Critical'].length})`}
             </div>
           }
           className={classes.tab}

--- a/nms/app/packages/magmalte/app/components/DataGrid.js
+++ b/nms/app/packages/magmalte/app/components/DataGrid.js
@@ -191,7 +191,7 @@ function DataCollapse(data: Data) {
               : dataEntryValue
           }
           titleTypographyProps={{
-            variant: 'body3',
+            variant: 'caption',
             className: classes.dataLabel,
             title: data.category,
           }}

--- a/nms/app/packages/magmalte/app/components/FormField.js
+++ b/nms/app/packages/magmalte/app/components/FormField.js
@@ -14,15 +14,17 @@
  * @format
  */
 
+import Box from '@material-ui/core/Box';
 import Divider from '@material-ui/core/Divider';
 import Grid from '@material-ui/core/Grid';
 import HelpIcon from '@material-ui/icons/Help';
 import IconButton from '@material-ui/core/IconButton';
 import InputAdornment from '@material-ui/core/InputAdornment';
+import LinearProgress from '@material-ui/core/LinearProgress';
 import ListItem from '@material-ui/core/ListItem';
 import OutlinedInput from '@material-ui/core/OutlinedInput';
 import React from 'react';
-import Text from '@fbcnms/ui/components/design-system/Text';
+import Text from '../theme/design-system/Text';
 import Tooltip from '@material-ui/core/Tooltip';
 import Typography from '@material-ui/core/Typography';
 import Visibility from '@material-ui/icons/Visibility';
@@ -188,5 +190,23 @@ export function PasswordInput(props: PasswordProps) {
         </InputAdornment>
       }
     />
+  );
+}
+
+type ProgressProps = {
+  value: number,
+  text?: string,
+};
+
+export function LinearProgressWithLabel(props: ProgressProps) {
+  return (
+    <Box display="flex" alignItems="center">
+      <Box width="100%" mr={1}>
+        <LinearProgress variant="determinate" value={props.value} />
+      </Box>
+      <Box minWidth={35}>
+        <Text>{props.text ?? `${Math.round(props.value)}%`}</Text>
+      </Box>
+    </Box>
   );
 }

--- a/nms/app/packages/magmalte/app/components/__tests__/GatewayCommandTest.js
+++ b/nms/app/packages/magmalte/app/components/__tests__/GatewayCommandTest.js
@@ -63,7 +63,7 @@ describe('<verify successful aggregation validation/>', () => {
   });
 
   it('', async () => {
-    const {getByTestId} = render(<Wrapper />);
+    const {getByTestId, getAllByTestId} = render(<Wrapper />);
     await wait();
     const controProxyValidationContent = getByTestId(
       'Control Proxy Config Validation',
@@ -71,7 +71,7 @@ describe('<verify successful aggregation validation/>', () => {
     const apiValidationContent = getByTestId('API validation');
 
     expect(controProxyValidationContent).toHaveTextContent('Good');
-    expect(getByTestId('fileContent')).toHaveTextContent(
+    expect(getAllByTestId('fileContent')[0]).toHaveTextContent(
       'fluentd_address: fluentd.magma.io fluentd_port: 24224',
     );
     expect(apiValidationContent).toHaveTextContent('Good');
@@ -99,7 +99,7 @@ describe('<verify control proxy validation failure/>', () => {
   });
 
   it('', async () => {
-    const {getByTestId} = render(<Wrapper />);
+    const {getByTestId, getAllByTestId} = render(<Wrapper />);
     await wait();
     const controProxyValidationContent = getByTestId(
       'Control Proxy Config Validation',
@@ -107,7 +107,7 @@ describe('<verify control proxy validation failure/>', () => {
     const apiValidationContent = getByTestId('API validation');
 
     expect(controProxyValidationContent).toHaveTextContent('Bad');
-    expect(getByTestId('fileError')).toHaveTextContent('file not found');
+    expect(getAllByTestId('fileError')[0]).toHaveTextContent('file not found');
     expect(apiValidationContent).toHaveTextContent('Good');
   });
 });

--- a/nms/app/packages/magmalte/app/components/lte/LteContext.js
+++ b/nms/app/packages/magmalte/app/components/lte/LteContext.js
@@ -344,6 +344,10 @@ export function PolicyProvider(props: Props) {
   const [isLoading, setIsLoading] = useState(true);
   const networkType = networkCtx.networkType;
   const enqueueSnackbar = useEnqueueSnackbar();
+  let fegNetworkId = '';
+  if (networkType === FEG_LTE) {
+    fegNetworkId = lteNetworkCtx.state?.federation.feg_network_id;
+  }
 
   useEffect(() => {
     const fetchState = async () => {
@@ -360,18 +364,15 @@ export function PolicyProvider(props: Props) {
         setQosProfiles(
           await MagmaV1API.getLteByNetworkIdPolicyQosProfiles({networkId}),
         );
-        if (networkType === FEG_LTE) {
-          const fegNetworkId = lteNetworkCtx.state?.federation.feg_network_id;
-          if (fegNetworkId != null && fegNetworkId !== '') {
-            setFegNetwork(
-              await MagmaV1API.getFegByNetworkId({networkId: fegNetworkId}),
-            );
-            setFegPolicies(
-              await MagmaV1API.getNetworksByNetworkIdPoliciesRulesViewFull({
-                networkId: fegNetworkId,
-              }),
-            );
-          }
+        if (fegNetworkId != null && fegNetworkId !== '') {
+          setFegNetwork(
+            await MagmaV1API.getFegByNetworkId({networkId: fegNetworkId}),
+          );
+          setFegPolicies(
+            await MagmaV1API.getNetworksByNetworkIdPoliciesRulesViewFull({
+              networkId: fegNetworkId,
+            }),
+          );
         }
       } catch (e) {
         enqueueSnackbar?.('failed fetching policy information', {
@@ -381,7 +382,7 @@ export function PolicyProvider(props: Props) {
       setIsLoading(false);
     };
     fetchState();
-  }, [networkId, networkType, lteNetworkCtx, enqueueSnackbar]);
+  }, [networkId, fegNetworkId, networkType, enqueueSnackbar]);
 
   if (isLoading) {
     return <LoadingFiller />;

--- a/nms/app/packages/magmalte/app/views/equipment/GatewayDetailStatus.js
+++ b/nms/app/packages/magmalte/app/views/equipment/GatewayDetailStatus.js
@@ -44,7 +44,7 @@ export default function GatewayDetailStatus({refresh}: {refresh: boolean}) {
     refresh: refresh,
   });
   const gwInfo = state[gatewayId];
-  let checkInTime = new Date(0);
+  let checkInTime;
   if (
     gwInfo.status &&
     gwInfo.status.checkin_time !== undefined &&
@@ -93,7 +93,7 @@ export default function GatewayDetailStatus({refresh}: {refresh: boolean}) {
       },
       {
         category: 'Last Check in',
-        value: checkInTime.toLocaleString(),
+        value: checkInTime?.toLocaleString() ?? '-',
         statusCircle: false,
       },
       {

--- a/nms/app/packages/magmalte/app/views/equipment/__tests__/EquipmentGatewayTest.js
+++ b/nms/app/packages/magmalte/app/views/equipment/__tests__/EquipmentGatewayTest.js
@@ -189,13 +189,13 @@ describe('<Gateway />', () => {
     expect(rowItems[1]).toHaveTextContent('test_gateway0');
     expect(rowItems[1]).toHaveTextContent('0');
     expect(rowItems[1]).toHaveTextContent('Bad');
-    expect(rowItems[1]).toHaveTextContent(new Date(0).toLocaleDateString());
+    expect(rowItems[1]).toHaveTextContent('-');
 
     expect(rowItems[2]).toHaveTextContent('test_gw1');
     expect(rowItems[2]).toHaveTextContent('test_gateway1');
     expect(rowItems[2]).toHaveTextContent('2');
     expect(rowItems[2]).toHaveTextContent('Bad');
-    expect(rowItems[2]).toHaveTextContent(new Date(0).toLocaleDateString());
+    expect(rowItems[2]).toHaveTextContent('-');
 
     expect(rowItems[3]).toHaveTextContent('test_gw2');
     expect(rowItems[3]).toHaveTextContent('test_gateway2');

--- a/nms/app/packages/magmalte/app/views/subscriber/SubscriberAddDialog.js
+++ b/nms/app/packages/magmalte/app/views/subscriber/SubscriberAddDialog.js
@@ -42,7 +42,11 @@ import Tabs from '@material-ui/core/Tabs';
 import TypedSelect from '@fbcnms/ui/components/TypedSelect';
 import nullthrows from '@fbcnms/util/nullthrows';
 
-import {AltFormField, PasswordInput} from '../../components/FormField';
+import {
+  AltFormField,
+  LinearProgressWithLabel,
+  PasswordInput,
+} from '../../components/FormField';
 import {SelectEditComponent} from '../../components/ActionTable';
 import {base64ToHex, hexToBase64, isValidHex} from '@fbcnms/util/strings';
 import {colors, typography} from '../../theme/default';
@@ -476,6 +480,8 @@ function AddSubscriberDetails(props: DialogProps) {
   const policyCtx = useContext(PolicyContext);
   const [error, setError] = useState('');
   const [subscribers, setSubscribers] = useState<Array<SubscriberInfo>>([]);
+  const successCountRef = useRef(0);
+
   const fileInput = useRef(null);
   const enqueueSnackbar = useEnqueueSnackbar();
 
@@ -490,6 +496,7 @@ function AddSubscriberDetails(props: DialogProps) {
     new Set(Object.keys(policyCtx.state || {})).add('default'),
   );
   const saveSubscribers = async () => {
+    successCountRef.current = 0;
     for (const subscriber of subscribers) {
       try {
         const err = validateSubscriberInfo(subscriber, ctx.state);
@@ -518,21 +525,35 @@ function AddSubscriberDetails(props: DialogProps) {
             sub_profile: subscriber.dataPlan,
           },
         });
-        enqueueSnackbar('Subscriber(s) saved successfully', {
-          variant: 'success',
-        });
+        successCountRef.current = successCountRef.current + 1;
       } catch (e) {
         const errMsg = e.response?.data?.message ?? e.message ?? e;
         setError('error saving ' + subscriber.imsi + ' : ' + errMsg);
         return;
       }
     }
+    enqueueSnackbar(
+      ` Subscriber${
+        successCountRef.current > 0 ? 's ' : ''
+      } saved successfully`,
+      {
+        variant: 'success',
+      },
+    );
     props.onClose();
   };
 
   return (
     <>
       <DialogContent>
+        {successCountRef.current > 0 && subscribers.length > 0 && (
+          <LinearProgressWithLabel
+            value={Math.round(
+              (successCountRef.current * 100) / subscribers.length,
+            )}
+            text={`${successCountRef.current}/${subscribers.length}`}
+          />
+        )}
         {error !== '' && <FormLabel error>{error}</FormLabel>}
         <input
           type="file"

--- a/nms/app/packages/magmalte/app/views/subscriber/__tests__/SubscriberTest.js
+++ b/nms/app/packages/magmalte/app/views/subscriber/__tests__/SubscriberTest.js
@@ -182,7 +182,7 @@ describe('<SubscriberDashboard />', () => {
             msisdn: '',
             apn: 'apn_1',
             session_start_time: 1605281209,
-            ipv4: '192.168.128.217',
+            ipv4: '192.168.128.218',
           },
         ],
       },
@@ -236,7 +236,7 @@ describe('<SubscriberDashboard />', () => {
             msisdn: '',
             apn: 'apn_4',
             session_start_time: 1605281600,
-            ipv4: '192.168.128.217',
+            ipv4: '192.168.128.219',
           },
         ],
         apn_5: [
@@ -328,17 +328,22 @@ describe('<SubscriberDashboard />', () => {
     expect(rowItems[1]).toHaveTextContent('ACTIVE');
     expect(rowItems[1]).toHaveTextContent('0');
     expect(rowItems[1]).toHaveTextContent('2');
+    expect(rowItems[1]).toHaveTextContent('apn_0,apn_1');
+    expect(rowItems[1]).toHaveTextContent('-');
 
     expect(rowItems[2]).toHaveTextContent('subscriber1');
     expect(rowItems[2]).toHaveTextContent('IMSI0000000001');
     expect(rowItems[2]).toHaveTextContent('INACTIVE');
     expect(rowItems[2]).toHaveTextContent('0');
     expect(rowItems[2]).toHaveTextContent('1');
+    expect(rowItems[2]).toHaveTextContent('apn_3');
+    expect(rowItems[2]).toHaveTextContent('-');
 
     expect(rowItems[3]).toHaveTextContent('IMSI0000000002');
     expect(rowItems[3]).toHaveTextContent('0');
-    expect(rowItems[3]).toHaveTextContent('3');
     expect(rowItems[3]).toHaveTextContent('1');
+    expect(rowItems[3]).toHaveTextContent('apn_4,apn_5,apn_6');
+    expect(rowItems[3]).toHaveTextContent('192.168.128.219');
 
     // click the actions button for subscriber0
     const actionList = getAllByTitle('Actions');


### PR DESCRIPTION
Signed-off-by: Karthik Subraveti <ksubraveti@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary

- Fix issue where the number of critical alerts shown was incorrect
- Fix issue where saving a policy caused the component to fail to rerender. The main issue was due to the new order in which hooks were rendered. When collapse prop is used for datagrid, we should set it to a default value instead of hiding it. useState hook is invoked when collapse component gets rendered. So this causes the order of hooks for the last hook to go from undefined-> useState causing the failure
- Fix the subscriber table to show ip address and APN information in the table. This is a useful feature asked by partners
- Fix the subscriber table to show "-" when last reported time is 0 instead of showing it as some random 1969 date. 
- Fix the equipment overview table and equipment detail table to show "-" when last reported time is 0 instead of showing it as some random 1969 date. 
- Fix the case where useEffect for PolicyProvider gets invoked multiple times due to lteContext object changing constantly. Fixed the dependency to be set to fegNetworkID instead. 
- Add predefined alerts for gateway_checkin, dip in connected UEs, disk usage 
## Test Plan

https://user-images.githubusercontent.com/8224854/105933497-5ad4dc80-6003-11eb-9066-6dcc5a0d4835.mov

![Screen Shot 2021-01-27 at 12 17 08 PM](https://user-images.githubusercontent.com/8224854/106048333-9b7f3500-6099-11eb-9965-35007e12753e.png)

yarn test succeeds. 

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
