### PR TITLE
AGW: mobilityd: handle error cases for static IP allocation.

### DIFF
--- a/lte/gateway/configs/gateway.mconfig
+++ b/lte/gateway/configs/gateway.mconfig
@@ -7,8 +7,8 @@
       "ipv6Block": "fdee:5:6c::/48",
       "ipv6PrefixAllocationType": "RANDOM",
       "ip_allocator_type": "IP_POOL",
-      "static_ip_enabled": false,
-      "multi_apn_ip_alloc": false
+      "static_ip_enabled": true,
+      "multi_apn_ip_alloc": true
     },
     "mme": {
       "@type": "type.googleapis.com/magma.mconfig.MME",

--- a/lte/gateway/python/magma/mobilityd/subscriberdb_client.py
+++ b/lte/gateway/python/magma/mobilityd/subscriberdb_client.py
@@ -50,7 +50,10 @@ class StaticIPInfo:
                  gw_ip: Optional[str],
                  gw_mac: Optional[str],
                  vlan: int):
-        self.ip = ipaddress.ip_address(ip)
+        if ip:
+            self.ip = ipaddress.ip_address(ip)
+        else:
+            self.ip = None
         self.net_info = NetworkInfo(gw_ip, gw_mac, vlan)
 
     def __str__(self):
@@ -72,18 +75,19 @@ class SubscriberDbClient:
         try:
             apn_config = self._find_ip_and_apn_config(sid)
             logging.debug("ip: Got APN: %s", apn_config)
-            if apn_config:
+            if apn_config and apn_config.assigned_static_ip:
                 return StaticIPInfo(ip=apn_config.assigned_static_ip,
                                     gw_ip=apn_config.resource.gateway_ip,
                                     gw_mac=apn_config.resource.gateway_mac,
                                     vlan=apn_config.resource.vlan_id)
 
-        except ValueError:
-            logging.warning("Invalid or missing data for sid %s: ", sid)
+        except ValueError as ex:
+            logging.warning("static Ip: Invalid or missing data for sid %s: ", sid)
+            logging.debug(ex)
             raise SubscriberDBStaticIPValueError(sid)
 
         except grpc.RpcError as err:
-            msg = "GetSubscriberData while reading vlan-id error[%s] %s" % \
+            msg = "GetSubscriberData: while reading vlan-id error[%s] %s" % \
                   (err.code(), err.details())
             logging.error(msg)
             raise SubscriberDBConnectionError(msg)
@@ -99,13 +103,14 @@ class SubscriberDbClient:
             try:
                 apn_config = self._find_ip_and_apn_config(sid)
                 logging.debug("vlan: Got APN: %s", apn_config)
-                if apn_config:
+                if apn_config and apn_config.resource.vlan_id:
                     return NetworkInfo(gw_ip=apn_config.resource.gateway_ip,
                                        gw_mac=apn_config.resource.gateway_mac,
                                        vlan=apn_config.resource.vlan_id)
 
-            except ValueError:
-                logging.warning("Invalid or missing data for sid %s: ", sid)
+            except ValueError as ex:
+                logging.warning("vlan: Invalid or missing data for sid %s", sid)
+                logging.debug(ex)
                 raise SubscriberDBMultiAPNValueError(sid)
 
             except grpc.RpcError as err:

--- a/lte/gateway/python/magma/mobilityd/tests/test_multi_apn_ip_alloc.py
+++ b/lte/gateway/python/magma/mobilityd/tests/test_multi_apn_ip_alloc.py
@@ -38,8 +38,6 @@ from magma.mobilityd.ipv6_allocator_pool import \
     IPv6AllocatorPool
 from magma.mobilityd.ip_allocator_static import \
     IPAllocatorStaticWrapper
-from magma.mobilityd.subscriberdb_client import SubscriberDBMultiAPNValueError, \
-    SubscriberDBStaticIPValueError
 
 
 class MockedSubscriberDBStub:
@@ -392,5 +390,12 @@ class MultiAPNIPAllocationTests(unittest.TestCase):
         MockedSubscriberDBStub.add_sub_ip(sid=imsi, apn=apn, ip=None,
                                           vlan=vlan)
 
-        with self.assertRaises(SubscriberDBStaticIPValueError):
-            ip0, _ = self._allocator.alloc_ip_address(sid)
+        ip0, _ = self._allocator.alloc_ip_address(sid)
+        ip0_returned = self._allocator.get_ip_for_sid(sid)
+
+        # check if retrieved ip is the same as the one allocated
+        self.assertEqual(ip0, ip0_returned)
+        self.assertNotEqual(ip0, ipaddress.ip_address(wild_assigned_ip))
+        self.check_type(sid, IPType.IP_POOL)
+        self.check_vlan(sid, 0)
+        self.check_gw_info(vlan, None, None)

--- a/lte/gateway/python/magma/mobilityd/tests/test_static_ip_alloc.py
+++ b/lte/gateway/python/magma/mobilityd/tests/test_static_ip_alloc.py
@@ -263,8 +263,13 @@ class StaticIPAllocationTests(unittest.TestCase):
         MockedSubscriberDBStub.add_sub(sid=imsi, apn="*", ip=assigned_ip_wild)
         MockedSubscriberDBStub.add_sub_ip(sid=imsi, apn=apn, ip=None)
 
-        with self.assertRaises(SubscriberDBStaticIPValueError):
-            ip0, _ = self._allocator.alloc_ip_address(sid)
+        ip0, _ = self._allocator.alloc_ip_address(sid)
+        ip0_returned = self._allocator.get_ip_for_sid(sid)
+
+        # check if retrieved ip is the same as the one allocated
+        self.assertEqual(ip0, ip0_returned)
+        self.assertNotEqual(ip0, ipaddress.ip_address(assigned_ip_wild))
+        self.check_type(sid, IPType.IP_POOL)
 
     def test_get_ip_for_subscriber_with_apn_with_gw(self):
         """ test get_ip_for_sid with static IP """


### PR DESCRIPTION
This patch adds validation for static IP allocation to avoid
IP allocation failures. This also enables static and multi APN
IP allocation on integ tests.

Signed-off-by: Pravin B Shelar <pbshelar@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->

## Test Plan
Ran `make test` and subset of `make integ_tests`
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
