### PR TITLE
Clearing the Redis state for radio link failure testcases

### DIFF
--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_enb_rlf_initial_ue_msg.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_enb_rlf_initial_ue_msg.py
@@ -26,6 +26,19 @@ class TestAttachEnbRlf(unittest.TestCase):
 
     def tearDown(self):
         self._s1ap_wrapper.cleanup()
+        self._s1ap_wrapper.magmad_util.exec_command(
+            "sudo service sctpd restart"
+        )
+        print(
+            "Restart sctpd service to clear Redis state as test case doesn't"
+            " intend to initiate detach procedure"
+        )
+        magtivate_cmd = "source /home/vagrant/build/python/bin/activate"
+        state_cli_cmd = "state_cli.py keys IMSI*"
+        redis_state = self._s1ap_wrapper.magmad_util.exec_command_output(
+            magtivate_cmd + " && " + state_cli_cmd
+        )
+        print("Redis state is [\n", redis_state, "]")
 
     def test_attach_enb_rlf(self):
         """
@@ -100,7 +113,7 @@ class TestAttachEnbRlf(unittest.TestCase):
         sec_ctxt = s1ap_types.TFW_CREATE_NEW_SECURITY_CONTEXT
         id_type = s1ap_types.TFW_MID_TYPE_IMSI
         eps_type = s1ap_types.TFW_EPS_ATTACH_TYPE_EPS_ATTACH
-        attach_req.ue_Id = 2
+        attach_req.ue_Id = 1
         attach_req.mIdType = id_type
         attach_req.epsAttachType = eps_type
         attach_req.useOldSecCtxt = sec_ctxt

--- a/lte/gateway/python/integ_tests/s1aptests/test_sctp_shutdown_after_multi_ue_attach.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_sctp_shutdown_after_multi_ue_attach.py
@@ -22,6 +22,19 @@ class TestSctpShutdownAfterMultiUeAttach(unittest.TestCase):
 
     def tearDown(self):
         self._s1ap_wrapper.cleanup()
+        self._s1ap_wrapper.magmad_util.exec_command(
+            "sudo service sctpd restart"
+        )
+        print(
+            "Restart sctpd service to clear Redis state as test case doesn't"
+            " intend to initiate detach procedure"
+        )
+        magtivate_cmd = "source /home/vagrant/build/python/bin/activate"
+        state_cli_cmd = "state_cli.py keys IMSI*"
+        redis_state = self._s1ap_wrapper.magmad_util.exec_command_output(
+            magtivate_cmd + " && " + state_cli_cmd
+        )
+        print("Redis state is [\n", redis_state, "]")
 
     def test_sctp_shutdown_after_multi_ue_attach(self):
         """ Attah multiple UEs and send sctp shutdown without detach """


### PR DESCRIPTION
[lte][agw]: Clearing the Redis state for radio link failure testcases 

## Summary
The test cases doesn't intend to initiate detach procedure, but Redis state needs to be cleaned-up before proceeding for execution of next test case, so clearing Redis DB is done explicitly by restarting sctpd service
## Test Plan
Executed s1ap sanity test suite
