### PR TITLE
[AGW][S1ap tests][Bug Fix] Add sleep after sctpd restart to make sure services are healthy

### DIFF
--- a/lte/gateway/python/integ_tests/s1aptests/s1ap_utils.py
+++ b/lte/gateway/python/integ_tests/s1aptests/s1ap_utils.py
@@ -799,6 +799,29 @@ class MagmadUtil(object):
         print("Waiting for mme to restart. 20 sec")
         time.sleep(20)
 
+    def restart_sctpd(self):
+        """
+        The Sctpd service is not managed by magmad, hence needs to be
+        restarted explicitly
+        """
+        self.exec_command(
+            "sudo service sctpd restart"
+        )
+        for j in range(30):
+            print("Waiting for", 30-j, "seconds for restart to complete")
+            time.sleep(1)
+
+    def print_redis_state(self):
+        """
+        Print the per-IMSI state in Redis data store on AGW
+        """
+        magtivate_cmd = "source /home/vagrant/build/python/bin/activate"
+        state_cli_cmd = "state_cli.py keys IMSI*"
+        redis_state = self.exec_command_output(
+                magtivate_cmd + " && " + state_cli_cmd)
+        print("Redis state is [\n", redis_state, "]")
+
+
 
 class MobilityUtil(object):
     """ Utility wrapper for interacting with mobilityd """

--- a/lte/gateway/python/integ_tests/s1aptests/s1ap_wrapper.py
+++ b/lte/gateway/python/integ_tests/s1aptests/s1ap_wrapper.py
@@ -418,12 +418,7 @@ class TestWrapper(object):
         self._sub_util.cleanup()
         self._trf_util.cleanup()
         self._mobility_util.cleanup()
-
-        magtivate_cmd = "source /home/vagrant/build/python/bin/activate"
-        state_cli_cmd = "state_cli.py keys IMSI*"
-        redis_state = self._magmad_util.exec_command_output(
-                magtivate_cmd + " && " + state_cli_cmd)
-        print("Redis state is [\n", redis_state, "]")
+        self._magmad_util.print_redis_state()
 
         # Cloud cleanup needs to happen after cleanup for
         # subscriber util and mobility util

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_enb_rlf_initial_ue_msg.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_enb_rlf_initial_ue_msg.py
@@ -26,19 +26,12 @@ class TestAttachEnbRlf(unittest.TestCase):
 
     def tearDown(self):
         self._s1ap_wrapper.cleanup()
-        self._s1ap_wrapper.magmad_util.exec_command(
-            "sudo service sctpd restart"
-        )
         print(
             "Restart sctpd service to clear Redis state as test case doesn't"
             " intend to initiate detach procedure"
         )
-        magtivate_cmd = "source /home/vagrant/build/python/bin/activate"
-        state_cli_cmd = "state_cli.py keys IMSI*"
-        redis_state = self._s1ap_wrapper.magmad_util.exec_command_output(
-            magtivate_cmd + " && " + state_cli_cmd
-        )
-        print("Redis state is [\n", redis_state, "]")
+        self._s1ap_wrapper.magmad_util.restart_sctpd()
+        self._s1ap_wrapper.magmad_util.print_redis_state()
 
     def test_attach_enb_rlf(self):
         """

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_with_sctpd_restart.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_with_sctpd_restart.py
@@ -64,15 +64,7 @@ class TestAttachDetachWithSctpdRestart(unittest.TestCase):
                 "gateway",
             )
 
-            # The Sctpd service is not managed by magmad, hence needs to be
-            # restarted explicitly
-            self._s1ap_wrapper.magmad_util.exec_command(
-                "sudo service sctpd restart"
-            )
-
-            for j in range(30):
-                print("Waiting for", j, "seconds")
-                time.sleep(1)
+            self._s1ap_wrapper.magmad_util.restart_sctpd()
 
             # Re-establish S1 connection between eNB and MME
             self._s1ap_wrapper._s1setup()

--- a/lte/gateway/python/integ_tests/s1aptests/test_sctp_shutdown_after_multi_ue_attach.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_sctp_shutdown_after_multi_ue_attach.py
@@ -11,7 +11,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-import time
 import unittest
 import s1ap_types
 import s1ap_wrapper

--- a/lte/gateway/python/integ_tests/s1aptests/test_sctp_shutdown_after_multi_ue_attach.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_sctp_shutdown_after_multi_ue_attach.py
@@ -11,6 +11,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
+import time
 import unittest
 import s1ap_types
 import s1ap_wrapper
@@ -22,19 +23,12 @@ class TestSctpShutdownAfterMultiUeAttach(unittest.TestCase):
 
     def tearDown(self):
         self._s1ap_wrapper.cleanup()
-        self._s1ap_wrapper.magmad_util.exec_command(
-            "sudo service sctpd restart"
-        )
         print(
             "Restart sctpd service to clear Redis state as test case doesn't"
             " intend to initiate detach procedure"
         )
-        magtivate_cmd = "source /home/vagrant/build/python/bin/activate"
-        state_cli_cmd = "state_cli.py keys IMSI*"
-        redis_state = self._s1ap_wrapper.magmad_util.exec_command_output(
-            magtivate_cmd + " && " + state_cli_cmd
-        )
-        print("Redis state is [\n", redis_state, "]")
+        self._s1ap_wrapper.magmad_util.restart_sctpd()
+        self._s1ap_wrapper.magmad_util.print_redis_state()
 
     def test_sctp_shutdown_after_multi_ue_attach(self):
         """ Attah multiple UEs and send sctp shutdown without detach """


### PR DESCRIPTION
Signed-off-by: Shruti Sanadhya <ssanadhya@fb.com>

## Summary

Tests cases for eNB Radio Link Failure and Sctp shutdown need to restart Sctpd to clear Redis state before running the next test.  These tests were failing in CI as they next test started before the services were up and healthy. This change adds a 30 second sleep after sctpd restart so that all AGW services are up before next test runs.

As a clean-up, it also adds functions to restart Sctpd and print Redis state, to keep the logic in one place and make the test case more readable.

## Test Plan

make integ_test
