### PR TITLE
[Orc8r] workaround for handling increased number of subscribers

### DIFF
--- a/lte/cloud/go/services/lte/lte/main.go
+++ b/lte/cloud/go/services/lte/lte/main.go
@@ -36,10 +36,15 @@ import (
 	"magma/orc8r/lib/go/service/config"
 
 	"github.com/golang/glog"
+	"google.golang.org/grpc"
 )
 
 func main() {
-	srv, err := service.NewOrchestratorService(lte.ModuleName, lte_service.ServiceName)
+	srv, err := service.NewOrchestratorService(
+		lte.ModuleName,
+		lte_service.ServiceName,
+		grpc.MaxSendMsgSize(service.DefaultMaxGRPCMsgSize),
+		grpc.MaxRecvMsgSize(service.DefaultMaxGRPCMsgSize))
 	if err != nil {
 		glog.Fatalf("Error creating lte service: %s", err)
 	}

--- a/lte/cloud/go/services/subscriberdb/subscriberdb/main.go
+++ b/lte/cloud/go/services/subscriberdb/subscriberdb/main.go
@@ -30,11 +30,15 @@ import (
 	"magma/orc8r/cloud/go/storage"
 
 	"github.com/golang/glog"
+	"google.golang.org/grpc"
 )
 
 func main() {
 	// Create service
-	srv, err := service.NewOrchestratorService(lte.ModuleName, subscriberdb.ServiceName)
+	srv, err := service.NewOrchestratorService(
+		lte.ModuleName,
+		subscriberdb.ServiceName,
+		grpc.MaxRecvMsgSize(service.DefaultMaxGRPCMsgSize))
 	if err != nil {
 		glog.Fatalf("Error creating service: %v", err)
 	}

--- a/orc8r/cloud/go/service/service.go
+++ b/orc8r/cloud/go/service/service.go
@@ -33,7 +33,8 @@ import (
 )
 
 const (
-	RunEchoServerFlag = "run_echo_server"
+	RunEchoServerFlag     = "run_echo_server"
+	DefaultMaxGRPCMsgSize = 50 * 1024 * 1024
 )
 
 var (

--- a/orc8r/cloud/go/services/configurator/configurator/main.go
+++ b/orc8r/cloud/go/services/configurator/configurator/main.go
@@ -29,11 +29,16 @@ import (
 	storage2 "magma/orc8r/cloud/go/storage"
 
 	"github.com/golang/glog"
+	"google.golang.org/grpc"
 )
 
 func main() {
 	// Create the service
-	srv, err := service.NewOrchestratorService(orc8r.ModuleName, configurator.ServiceName)
+	srv, err := service.NewOrchestratorService(
+		orc8r.ModuleName,
+		configurator.ServiceName,
+		grpc.MaxRecvMsgSize(service.DefaultMaxGRPCMsgSize),
+		grpc.MaxSendMsgSize(service.DefaultMaxGRPCMsgSize))
 	if err != nil {
 		glog.Fatalf("Error creating service: %s", err)
 	}

--- a/orc8r/cloud/go/services/state/state/main.go
+++ b/orc8r/cloud/go/services/state/state/main.go
@@ -33,13 +33,18 @@ import (
 	"magma/orc8r/lib/go/service/config"
 
 	"github.com/golang/glog"
+	"google.golang.org/grpc"
 )
 
 // how often to report gateway status
 const gatewayStatusReportInterval = time.Second * 60
 
 func main() {
-	srv, err := service.NewOrchestratorService(orc8r.ModuleName, state.ServiceName)
+	srv, err := service.NewOrchestratorService(
+		orc8r.ModuleName,
+		state.ServiceName,
+		grpc.MaxSendMsgSize(service.DefaultMaxGRPCMsgSize))
+
 	if err != nil {
 		glog.Fatalf("Error creating state service %v", err)
 	}

--- a/orc8r/cloud/go/services/streamer/providers/remote_provider.go
+++ b/orc8r/cloud/go/services/streamer/providers/remote_provider.go
@@ -24,6 +24,11 @@ import (
 
 	"github.com/golang/glog"
 	"github.com/golang/protobuf/ptypes/any"
+	"google.golang.org/grpc"
+)
+
+const (
+	defaultMaxGRPCMsgSize = 50 * 1024 * 1024
 )
 
 type remoteProvider struct {
@@ -61,7 +66,8 @@ func (r *remoteProvider) GetUpdates(gatewayId string, extraArgs *any.Any) ([]*pr
 }
 
 func (r *remoteProvider) getProviderClient() (streamer_protos.StreamProviderClient, error) {
-	conn, err := registry.GetConnection(r.service)
+	conn, err := registry.GetConnectionWithAddOptions(r.service,
+		grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(defaultMaxGRPCMsgSize)))
 	if err != nil {
 		initErr := merrors.NewInitError(err, r.service)
 		glog.Error(initErr)

--- a/orc8r/cloud/go/services/streamer/streamer/main.go
+++ b/orc8r/cloud/go/services/streamer/streamer/main.go
@@ -24,7 +24,10 @@ import (
 )
 
 func main() {
-	srv, err := service.NewOrchestratorService(orc8r.ModuleName, streamer.ServiceName)
+	srv, err := service.NewOrchestratorService(
+		orc8r.ModuleName,
+		streamer.ServiceName)
+
 	if err != nil {
 		glog.Fatalf("Error creating streamer service: %s", err)
 	}

--- a/orc8r/lib/go/registry/global_registry.go
+++ b/orc8r/lib/go/registry/global_registry.go
@@ -135,6 +135,11 @@ func GetConnection(service string) (*grpc.ClientConn, error) {
 	return globalRegistry.GetConnection(service)
 }
 
+// GetConnectionWithAddOptions provides a gRPC connection to a service in the registry.
+func GetConnectionWithAddOptions(service string, opts ...grpc.DialOption) (*grpc.ClientConn, error) {
+	return globalRegistry.GetConnectionWithAddOptions(service)
+}
+
 func GetConnectionImpl(ctx context.Context, service string, opts ...grpc.DialOption) (*grpc.ClientConn, error) {
 	return globalRegistry.GetConnectionImpl(ctx, service, opts...)
 }

--- a/orc8r/lib/go/registry/registry.go
+++ b/orc8r/lib/go/registry/registry.go
@@ -365,6 +365,16 @@ func (r *ServiceRegistry) GetConnection(service string) (*grpc.ClientConn, error
 	return r.GetConnectionImpl(ctx, service, r.getGRPCDialOptions()...)
 }
 
+// GetConnectionWithAddOptions is same as GetConnection, but allows caller to
+// provide their own gRPC dial options appended to current default dial options.
+func (r *ServiceRegistry) GetConnectionWithAddOptions(service string, options ...grpc.DialOption) (*grpc.ClientConn, error) {
+	service = strings.ToLower(service)
+	ctx, cancel := context.WithTimeout(context.Background(), GrpcMaxTimeoutSec*time.Second)
+	defer cancel()
+	opts := append(r.getGRPCDialOptions(), options...)
+	return r.GetConnectionImpl(ctx, service, opts...)
+}
+
 // GetConnectionWithOptions is same as GetConnection, but allows caller to
 // provide their own gRPC dial options.
 func (r *ServiceRegistry) GetConnectionWithOptions(service string, options ...grpc.DialOption) (*grpc.ClientConn, error) {


### PR DESCRIPTION
Signed-off-by: Karthik Subraveti <ksubraveti@fb.com>

## Summary
Rough big picture for the subscriber flow
![Screen Shot 2021-01-29 at 7 39 18 AM](https://user-images.githubusercontent.com/8224854/106295306-1add4780-6205-11eb-8da9-0d9c90feb7be.png)


Subscriberdb 
Why changes are necessary
- Handles large subscriber API configs
- Set and Get configs in configurator
- Gets state from state service

Changes made 
- Increase recv msg size in subscriberdb

Configurator
Why changes are necessary ?
- Handles requests from subscriberdb
- Handles requests from lte service

Changes made 
- Increase send and recv msg size in configurator
- Increase the configurator client’s send and recv msg size
- Increase the grpc deadline in configurator client’s request


State Service
Why changes are necessary ?
- Handles get requests from subscriberdb (supporting list API)
- Handles state report requests from dispatcher

Changes made
- Increase send and recv msg size in state service
- Increase the recv msg size in state client service
- Increase the grpc deadline in state clients requests

Streamer Service
Why changes are necessary ?
- Handles get updates streams from various provider services. 
- Don’t increase send msg size(might cause issues with dispatcher and gateway sync rpc service, if they have different grpc recv msg size configured)

Changes made
- Increase Recv msg size on the streamer clients 
- Batch the received updates

Lte Service
Why changes are necessary ?
- Handles request from streamer to get subscriber updates

Changes made 
- Increase Send and recv msg size for lte service




## Test Plan
- With 5000 subscribers and setting a very low deadline,I was able to verify that we timed out similar to what was observed in staging
-```
E0128 22:41:32.072107     269 storage.go:101] error while rolling back tx: sql: transaction has already been committed or rolled back
E0128 22:41:32.072130     269 handler.go:116] [ERROR /magma.orc8r.configurator.NorthboundConfigurator/LoadEntities]: sql: transaction has already been committed or rolled back
error querying for entities
magma/orc8r/cloud/go/services/configurator/storage.(*sqlConfiguratorStorage).loadFromEntitiesTable
	/src/magma/orc8r/cloud/go/services/configurator/storage/sql_entity_load_helpers.go:37
magma/orc8r/cloud/go/services/configurator/storage.(*sqlConfiguratorStorage).LoadEntities
	/src/magma/orc8r/cloud/go/services/configurator/storage/sql.go:446
magma/orc8r/cloud/go/services/configurator/servicers.(*nbConfiguratorServicer).LoadEntities
	/src/magma/orc8r/cloud/go/services/configurator/servicers/northbound.go:142
magma/orc8r/cloud/go/services/configurator/protos._NorthboundConfigurator_LoadEntities_Handler.func1
	/src/magma/orc8r/cloud/go/services/configurator/protos/northbound.pb.go:1168
magma/orc8r/cloud/go/service/middleware/unary.callHandler
	/src/magma/orc8r/cloud/go/service/middleware/unary/handler.go:114
magma/orc8r/cloud/go/service/middleware/unary.MiddlewareHandler
	/src/magma/orc8r/cloud/go/service/middleware/unary/handler.go:101
magma/orc8r/cloud/go/services/configurator/protos._NorthboundConfigurator_LoadEntities_Handler
	/src/magma/orc8r/cloud/go/services/configurator/protos/northbound.pb.go:1170
google.golang.org/grpc.(*Server).processUnaryRPC
	/go/pkg/mod/google.golang.org/grpc@v1.31.0/server.go:1180
google.golang.org/grpc.(*Server).handleStream
	/go/pkg/mod/google.golang.org/grpc@v1.31.0/server.go:1503
google.golang.org/grpc.(*Server).serveStreams.func1.2
	/go/pkg/mod/google.golang.org/grpc@v1.31.0/server.go:843
runtime.goexit```
- 
-  and setting a higher deadline fixed the above problem

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
