### PR TITLE
[orc8r][lib] Option to disable initflag flags parsing logic to accommodate some IDE testing/debugging environments

### DIFF
--- a/orc8r/lib/go/initflag/initflag.go
+++ b/orc8r/lib/go/initflag/initflag.go
@@ -19,7 +19,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
-	"strings"
 )
 
 func init() {
@@ -60,25 +59,4 @@ func init() {
 	if *stdoutToStderr {
 		stdout, os.Stdout = os.Stdout, os.Stderr
 	}
-}
-
-// shouldParse returns true if initflag should parse flags.
-// This hack works around the fact that initflags breaks test tool outputs.
-func shouldParse() bool {
-	isTest := strings.HasSuffix(os.Args[0], ".test") ||
-		strings.HasSuffix(os.Args[0], "_test.go") ||
-		strings.HasSuffix(os.Args[0], "_test_go") ||
-		isInArgs("-test.v")
-	return !flag.Parsed() && !isTest
-}
-
-// isInArgs returns true if any of the argunents passed to the command maches
-// with the passed match stirng
-func isInArgs(match string) bool {
-	for _, arg := range os.Args {
-		if arg == match {
-			return true
-		}
-	}
-	return false
 }

--- a/orc8r/lib/go/initflag/parse_flag_debug.go
+++ b/orc8r/lib/go/initflag/parse_flag_debug.go
@@ -1,0 +1,21 @@
+// +build debug_build
+
+/*
+Copyright 2020 The Magma Authors.
+
+This source code is licensed under the BSD-style license found in the
+LICENSE file in the root directory of this source tree.
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package initflag
+
+// shouldParse returns true if initflag should parse flags.
+func shouldParse() bool {
+	return false
+}

--- a/orc8r/lib/go/initflag/parse_flag_release.go
+++ b/orc8r/lib/go/initflag/parse_flag_release.go
@@ -1,0 +1,44 @@
+// +build !debug_build
+
+/*
+Copyright 2020 The Magma Authors.
+
+This source code is licensed under the BSD-style license found in the
+LICENSE file in the root directory of this source tree.
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package initflag
+
+import (
+	"flag"
+	"os"
+	"strings"
+)
+
+// shouldParse returns true if initflag should parse flags.
+// this hack works around the fact that initflags breaks test tool outputs
+// to completely disable this logic & preliminary flag parsing, use 'debug_build' Go build tag
+func shouldParse() bool {
+	isTest := strings.HasSuffix(os.Args[0], ".test") ||
+		strings.HasSuffix(os.Args[0], "_test.go") ||
+		strings.HasSuffix(os.Args[0], "_test_go") ||
+		isInArgs("-test.v")
+	return !flag.Parsed() && !isTest
+}
+
+// isInArgs returns true if any of the argunents passed to the command maches
+// with the passed match stirng
+func isInArgs(match string) bool {
+	for _, arg := range os.Args {
+		if arg == match {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION

Signed-off-by: Evgeniy Makeev <evgeniym@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary

Option to disable initflag flags parsing logic to accommodate some IDE testing/debugging environments.

This change introduces a Go build tag "debug_build" to use with IDE based debuggers & test executions.

For example, to use this tag with GoLand IDE:

- Add debug_build tag to your IDE Preferences->Go->Build Tags & Vendoring->Custom tags

![Screen Shot 2021-01-28 at 3 14 49 PM](https://user-images.githubusercontent.com/2341877/106214498-bded7d00-6183-11eb-8a06-86402d5902ee.png)

- In all required Run->Edit Configurations select "Use all custom tags" checkbox

![Screen Shot 2021-01-28 at 3 17 54 PM](https://user-images.githubusercontent.com/2341877/106214739-4835e100-6184-11eb-8b1d-d9fd3d741bc9.png)
![Screen Shot 2021-01-28 at 3 13 48 PM](https://user-images.githubusercontent.com/2341877/106214767-57b52a00-6184-11eb-90cd-8ade057a7c00.png)

- Use you IDE to run unit tests or debug as needed


## Test Plan

unit tests; test with GoLand IDE, see screenshots above

## Additional Information

- [ ] This change is backwards-breaking

