### PR TITLE
[sessiond][Valgrind] add missing initialization on SessionState 

### DIFF
--- a/lte/gateway/c/session_manager/SessionState.cpp
+++ b/lte/gateway/c/session_manager/SessionState.cpp
@@ -187,7 +187,12 @@ SessionState::SessionState(
       tgpp_context_(tgpp_context),
       create_session_response_(csr),
       static_rules_(rule_store),
-      credit_map_(4, &ccHash, &ccEqual) {}
+      credit_map_(4, &ccHash, &ccEqual) {
+  // other default initializations
+  current_version_        = 0;
+  session_level_key_      = "";
+  subscriber_quota_state_ = SubscriberQuotaUpdate_Type_VALID_QUOTA;
+}
 
 /*For 5G which doesn't have response context*/
 SessionState::SessionState(


### PR DESCRIPTION
Signed-off-by: Oriol Batalla <obatalla@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary

Valgrind was complaining of reading of some uninitialized variables. That may have caused issues in the future if those vars were read for some reason.  Also that issue was filling Valgrind with lot of noise that may prevent further analysis.

```
=29589== Conditional jump or move depends on uninitialised value(s)
==29589==    at 0x4C326BC: memmove (vg_replace_strmem.c:1252)
==29589==    by 0xBCC588: cpp_redis::network::redis_connection::commit() (in /home/vagrant/build/c/session_manager/sessiond)
==29589==    by 0xBBE8F1: cpp_redis::client::try_commit() (in /home/vagrant/build/c/session_manager/sessiond)
==29589==    by 0xBBEA4F: cpp_redis::client::sync_commit() (in /home/vagrant/build/c/session_manager/sessiond)
==29589==    by 0x8DEFF1: magma::lte::RedisStoreClient::write_sessions(std::unordered_map<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::vector<std::unique_ptr<magma::SessionState, std::default_delete<magma::SessionState> >, std::allocator<std::unique_ptr<magma::SessionState, std::default_delete<magma::SessionState> > > >, std::hash<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::equal_to<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, std::vector<std::unique_ptr<magma::SessionState, std::default_delete<magma::SessionState> >, std::allocator<std::unique_ptr<magma::SessionState, std::default_delete<magma::SessionState> > > > > > >) (RedisStoreClient.cpp:161)
...
```

## Test Plan

make precommit_sm
## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
