### PR TITLE
[AGW] [MME] Initialize esm_msg to NULL in emm_init_context

### DIFF
--- a/lte/gateway/c/oai/tasks/nas/emm/emm_data_ctx.c
+++ b/lte/gateway/c/oai/tasks/nas/emm/emm_data_ctx.c
@@ -924,6 +924,7 @@ void emm_init_context(
     esm_init_context(&emm_ctx->esm_ctx);
   }
   emm_ctx->emm_procedures = NULL;
+  emm_ctx->esm_msg        = NULL;
 }
 
 //------------------------------------------------------------------------------


### PR DESCRIPTION
Signed-off-by: Shruti Sanadhya <ssanadhya@fb.com>

## Summary
Potential fix for https://github.com/magma/magma/issues/4645 as esm_msg is not initialized whenever a new EMM context is created, either
- at first attach
- reading state from Redis store and use it for second attach, leading to the coredump in #4645 

```
#0 emm_proc_attach_request (ue_id=ue_id@entry=1700, is_mm_ctx_new=is_mm_ctx_new@entry=false, ies=, ies@entry=0x608000037900)
at /home/vagrant/magma/lte/gateway/c/oai/tasks/nas/emm/Attach.c:565
565 bdestroy(new_emm_ctx->esm_msg);
```

## Test Plan

make integ_test

Still testing with random UE attach/detach scenario
