### PR TITLE
Downgrade dnsmasq from 2.83 to 2.7 (unavailable on stretch)

### DIFF
--- a/lte/gateway/release/build-magma.sh
+++ b/lte/gateway/release/build-magma.sh
@@ -97,7 +97,7 @@ MAGMA_DEPS=(
     "python3-protobuf >= 3.14.0"
     "redis-server >= 3.2.0"
     "sudo"
-    "dnsmasq > 2.83"
+    "dnsmasq >= 2.7"
     "net-tools" # for ifconfig
     "python3-pip"
     "python3-apt" # The version in pypi is abandoned and broken on stretch


### PR DESCRIPTION
Signed-off-by: Timothée Dzik <timdzik@fb.com>

Downgrade dnsmasq from 2.83 to 2.7 (unavailable on stretch)

## Summary

Downgrade dnsmasq from 2.83 to 2.7 (unavailable on stretch)

## Test Plan

let CI build
