### PR TITLE
[sms] Fix potential out-of-bounds access in CP packet decode

### DIFF
--- a/lte/cloud/go/sms_ll/sms_cp.go
+++ b/lte/cloud/go/sms_ll/sms_cp.go
@@ -22,6 +22,13 @@ func smsCpError(field string) error {
 
 // Handles creation of SMS-CM messages (3GPP TS 24.011 7.2)
 
+// SMS CP packet constants
+const (
+	CpCommonHeaderMinLegalPacketLength int = 2
+	CpDataMinLegalPacketLength         int = 3
+	CpErrorMinLegalPacketLength        int = 3
+)
+
 // CP Message represents
 type cpMessage struct {
 	// Contains Transaction ID and Protocol Disc
@@ -84,13 +91,29 @@ func (cpm cpMessage) marshalBinary() []byte {
 }
 
 func (cpm *cpMessage) unmarshalBinary(input []byte) error {
-	// must be at least two octets long
-	if len(input) < 2 {
-		return smsCpError("Message too short")
+	if len(input) < CpCommonHeaderMinLegalPacketLength {
+		return smsCpError(fmt.Sprintf("Message too short (have: %d, need: %d)",
+			len(input), CpCommonHeaderMinLegalPacketLength))
 	}
 
 	cpm.firstOctet = input[0]
 	cpm.messageType = input[1]
+
+	// Validate per-messageType minimum packet sizes
+	switch cpm.messageType {
+	case CpData:
+		if len(input) < CpDataMinLegalPacketLength {
+			return smsCpError(fmt.Sprintf("Data message too short (have: %d, need: %d)",
+				len(input), CpDataMinLegalPacketLength))
+		}
+	case CpError:
+		if len(input) < CpErrorMinLegalPacketLength {
+			return smsCpError(fmt.Sprintf("Error message too short (have: %d, need: %d)",
+				len(input), CpErrorMinLegalPacketLength))
+		}
+	default:
+		// Do nothing -- remaining types handled below
+	}
 
 	switch cpm.messageType {
 	case CpData:

--- a/lte/cloud/go/sms_ll/sms_ll_test.go
+++ b/lte/cloud/go/sms_ll/sms_ll_test.go
@@ -116,6 +116,31 @@ func TestPiecewiseDecodeDeliveryFailure(t *testing.T) {
 	}
 }
 
+func TestInvalidCpMessages(t *testing.T) {
+	tests := []struct {
+		Description string
+		Input       string
+	}{
+		{Description: "too short for common header",
+			Input: "d9"},
+		{Description: "CP-DATA SMS message too short",
+			Input: "d901"},
+		{Description: "CP-ERROR SMS message too short",
+			Input: "d910"},
+	}
+
+	for _, test := range tests {
+		cp_hex, _ := hex.DecodeString(test.Input)
+		cpm := new(cpMessage)
+		err := cpm.unmarshalBinary(cp_hex)
+
+		if err == nil {
+			t.Errorf("test %s got cpm.unmarshalBinary(input=%s) == nil, wanted error",
+				test.Description, test.Input)
+		}
+	}
+}
+
 func TestPiecewiseDecodeDeliveryReport(t *testing.T) {
 	input := "d90106020141020000"
 	cp_hex, _ := hex.DecodeString(input)


### PR DESCRIPTION
## Summary

This PR addresses one instance covered in Issue #4654.  Previously, malformed SMS-CP packets could cause an out-of-bounds access.  This PR addresses this issue by returning an error under such circumstances.

## Test Plan

### Authored New Tests

Augmented existing unit tests to include off-nominal binary packet representations with incorrect size for their CP packet type.

### Applied Existing Process

> cd orc8r/cloud
> make
> make test
> make precommit

Signed-off-by: Scott Harrison Moeller <smoeller@fb.com>