### PR TITLE
[helm][tf] backport alertmanager fixes to 1.3

### DIFF
--- a/orc8r/cloud/deploy/terraform/orc8r-helm-aws/main.tf
+++ b/orc8r/cloud/deploy/terraform/orc8r-helm-aws/main.tf
@@ -80,6 +80,9 @@ resource "helm_release" "orc8r" {
     alertmanager_hostname     = format("%s-alertmanager", var.helm_deployment_name)
     alertmanager_url          = format("%s-alertmanager:9093", var.helm_deployment_name)
     prometheus_url            = format("%s-prometheus:9090", var.helm_deployment_name)
+
+    prometheus_configurer_version = var.prometheus_configurer_version
+    alertmanager_configurer_version = var.alertmanager_configurer_version
   })]
 
   set_sensitive {

--- a/orc8r/cloud/deploy/terraform/orc8r-helm-aws/secrets.tf
+++ b/orc8r/cloud/deploy/terraform/orc8r-helm-aws/secrets.tf
@@ -96,8 +96,8 @@ resource "kubernetes_secret" "orc8r_configs" {
       "prometheusQueryAddress" : format("http://%s-prometheus:9090", var.helm_deployment_name),
 
       "alertmanagerApiURL" : format("http://%s-alertmanager:9093/api/v2", var.helm_deployment_name),
-      "prometheusConfigServiceURL" : format("http://%s-prometheus-configurer:9100", var.helm_deployment_name),
-      "alertmanagerConfigServiceURL" : format("http://%s-alertmanager-configurer:9101", var.helm_deployment_name),
+      "prometheusConfigServiceURL" : format("http://%s-prometheus-configurer:9100/v1", var.helm_deployment_name),
+      "alertmanagerConfigServiceURL" : format("http://%s-alertmanager-configurer:9101/v1", var.helm_deployment_name),
     })
 
     "orchestrator.yml" = yamlencode({

--- a/orc8r/cloud/deploy/terraform/orc8r-helm-aws/templates/orc8r-values.tpl
+++ b/orc8r/cloud/deploy/terraform/orc8r-helm-aws/templates/orc8r-values.tpl
@@ -89,14 +89,14 @@ metrics:
     create: true
     image:
       repository: docker.io/facebookincubator/prometheus-configurer
-      tag: 1.0.0
+      tag: ${prometheus_configurer_version}
     prometheusURL: ${prometheus_url}
 
   alertmanagerConfigurer:
     create: true
     image:
       repository: docker.io/facebookincubator/alertmanager-configurer
-      tag: 1.0.0
+      tag: ${alertmanager_configurer_version}
     alertmanagerURL: ${alertmanager_url}
 
   prometheusCache:

--- a/orc8r/cloud/deploy/terraform/orc8r-helm-aws/variables.tf
+++ b/orc8r/cloud/deploy/terraform/orc8r-helm-aws/variables.tf
@@ -265,3 +265,20 @@ variable "deploy_openvpn" {
   type        = bool
   default     = false
 }
+
+##############################################################################
+# Other dependency variables
+##############################################################################
+
+variable "prometheus_configurer_version" {
+  description = "Image version for prometheus configurer."
+  type        = string
+  default     = "1.0.4"
+}
+
+variable "alertmanager_configurer_version" {
+  description = "Image version for alertmanager configurer."
+  type        = string
+  default     = "1.0.4"
+}
+


### PR DESCRIPTION
Signed-off-by: Scott8440 <scott8440@gmail.com>

## Summary
Updates v1.3 terraform modules to deploy latest versions of prometheus-configmanagers and corrects orchestrator.yml config generation.

## Test Plan
Deploy following 1.3 terraform instructions.

