### PR TITLE
[orc8r][tf] fixing init error cause of validation

### DIFF
--- a/orc8r/cloud/deploy/terraform/orc8r-helm-aws/variables.tf
+++ b/orc8r/cloud/deploy/terraform/orc8r-helm-aws/variables.tf
@@ -164,7 +164,7 @@ variable "orc8r_deployment_type" {
       var.orc8r_deployment_type == "federated_fwa" ||
       var.orc8r_deployment_type == "all"
     )
-    error_message = "The orc8r_deployment_type value must be one of ['fwa', 'federated_fwa', 'all']"
+    error_message = "The orc8r_deployment_type value must be one of ['fwa', 'federated_fwa', 'all']."
   }
 }
 


### PR DESCRIPTION
Signed-off-by: Ayelet Regev Dabah <ayelet.regev@gmail.com>

[orc8r][tf] fixing init error cause of validation

## Summary

currently tf init fails on validation cause sentence doesnt end with "."


Before:
```
$ terraform init
Initializing modules...
There are some problems with the configuration, described below.

The Terraform configuration must be valid before initialization so that
Terraform can determine which modules and providers need to be installed.

Error: Invalid validation error message

  on ../../magma/orc8r/cloud/deploy/terraform/orc8r-helm-aws/variables.tf line 167, in variable "orc8r_deployment_type":
 167:     error_message = "The orc8r_deployment_type value must be one of ['fwa', 'federated_fwa', 'all']"

Validation error message must be at least one full English sentence starting
with an uppercase letter and ending with a period or question mark.
```

After:
```
$ terraform init
Initializing modules...
- orc8r in ../../../magma/orc8r/cloud/deploy/terraform/orc8r-aws
Downloading terraform-aws-modules/eks/aws 8.2.0 for orc8r.eks...
- orc8r.eks in .terraform/modules/orc8r.eks
- orc8r.eks.node_groups in .terraform/modules/orc8r.eks/modules/node_groups
Downloading terraform-aws-modules/vpc/aws 2.17.0 for orc8r.vpc...
- orc8r.vpc in .terraform/modules/orc8r.vpc
- orc8r-app in ../../../magma/orc8r/cloud/deploy/terraform/orc8r-helm-aws

Initializing the backend...

Successfully configured the backend "s3"! Terraform will automatically
use this backend unless the backend configuration changes.

Initializing provider plugins...
[...]
```

## Test Plan

tested locally on small tf code with validation.

## Additional Information

- [ ] This change is backwards-breaking

