### PR TITLE
[circleci] Add tag of latest to orc8r dockers

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -544,6 +544,10 @@ jobs:
       - tag-push-docker:
           project: orc8r
           images: "nginx|controller"
+      - tag-push-docker:
+          project: orc8r
+          images: "nginx|controller"
+          tag-latest: true
       - persist-githash-version:
           file_prefix: orc8r
       - notify-magma:


### PR DESCRIPTION
Signed-off-by: Ayelet Regev Dabah <ayelet.regev@gmail.com>

[circleci] Add tag of latest to orc8r dockers

## Summary

for xwf team to be able to retrieve latest docker hash without slack dependency

## Test Plan

circleci

## Additional Information

- [ ] This change is backwards-breaking

