### PR TITLE
AGW: pipelined: Fix QoS init for stateless

### DIFF
--- a/lte/gateway/python/magma/pipelined/qos/common.py
+++ b/lte/gateway/python/magma/pipelined/qos/common.py
@@ -214,6 +214,7 @@ class QosManager(object):
         else:
             # read existing state from qos_impl
             LOG.info("Qos Setup: recovering existing state")
+            self.impl.setup()
 
             def callback(fut):
                 LOG.debug("read_all_state complete => \n%s", fut.result())

--- a/lte/gateway/python/magma/pipelined/qos/qos_tc_impl.py
+++ b/lte/gateway/python/magma/pipelined/qos/qos_tc_impl.py
@@ -118,7 +118,7 @@ class TrafficClass:
 
         qdisc_cmd = "tc qdisc add dev {intf} root handle 1: htb".format(intf=intf)
         parent_q_cmd = "tc class add dev {intf} parent 1: classid 1:{root_qid} htb "
-        parent_q_cmd +="rate {speed}Mbit ceil {speed}Mbit"
+        parent_q_cmd += "rate {speed}Mbit ceil {speed}Mbit"
         parent_q_cmd = parent_q_cmd.format(intf=intf, root_qid=qid_hex, speed=speed)
         tc_cmd = "tc class add dev {intf} parent 1:{root_qid} classid 1:1 htb "
         tc_cmd += "rate {rate} ceil {speed}Mbit"


### PR DESCRIPTION
In stateless mode initialize root QoS to boot strap TC
config.

Signed-off-by: Pravin B Shelar <pbshelar@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
