### PR TITLE
[AGW][MME] Remove stale eNB state with stateless MME

### DIFF
--- a/lte/gateway/c/oai/tasks/s1ap/s1ap_mme.c
+++ b/lte/gateway/c/oai/tasks/s1ap/s1ap_mme.c
@@ -403,7 +403,7 @@ void s1ap_dump_enb(const enb_description_t* const enb_ref) {
   eNB_LIST_OUT("SCTP assoc id:     %d", enb_ref->sctp_assoc_id);
   eNB_LIST_OUT("SCTP instreams:    %d", enb_ref->instreams);
   eNB_LIST_OUT("SCTP outstreams:   %d", enb_ref->outstreams);
-  eNB_LIST_OUT("UE attache to eNB: %d", enb_ref->nb_ue_associated);
+  eNB_LIST_OUT("UEs attached to eNB: %d", enb_ref->nb_ue_associated);
   indent++;
   sctp_assoc_id_t sctp_assoc_id = enb_ref->sctp_assoc_id;
 

--- a/lte/gateway/c/oai/tasks/s1ap/s1ap_mme_handlers.c
+++ b/lte/gateway/c/oai/tasks/s1ap/s1ap_mme_handlers.c
@@ -348,6 +348,7 @@ void clean_stale_enb_state(
   // Remove the old eNB association
   s1ap_remove_enb(state, stale_enb_association);
   update_mme_app_stats_connected_enb_sub();
+  OAILOG_DEBUG(LOG_S1AP, "Removed stale eNB and all associated UEs.");
 }
 
 int s1ap_mme_handle_s1_setup_request(
@@ -568,11 +569,8 @@ int s1ap_mme_handle_s1_setup_request(
     enb_association->enb_name[ie_enb_name->value.choice.ENBname.size] = '\0';
   }
 
-  // Clean any stale connection for this enb_id and transfer the attached UEs
+  // Clean any stale eNB association (from Redis) for this enb_id
   clean_stale_enb_state(state, enb_association);
-  OAILOG_DEBUG(
-      LOG_S1AP, "Removed stale eNB and new eNB has %d UEs.",
-      enb_association->nb_ue_associated);
 
   s1ap_dump_enb(enb_association);
   rc = s1ap_generate_s1_setup_response(state, enb_association);

--- a/lte/gateway/c/oai/tasks/s1ap/s1ap_mme_handlers.c
+++ b/lte/gateway/c/oai/tasks/s1ap/s1ap_mme_handlers.c
@@ -303,12 +303,11 @@ int s1ap_mme_generate_s1_setup_failure(
 bool get_stale_enb_connection_with_enb_id(
     __attribute__((unused)) const hash_key_t keyP, void* const elementP,
     void* parameterP, void** resultP) {
-
   enb_description_t* new_enb_association = (enb_description_t*) parameterP;
-  enb_description_t* ht_enb_association = (enb_description_t*) elementP;
+  enb_description_t* ht_enb_association  = (enb_description_t*) elementP;
 
   // No need to clean the newly created eNB association
-  if (ht_enb_association == new_enb_association){
+  if (ht_enb_association == new_enb_association) {
     return false;
   }
 
@@ -321,20 +320,34 @@ bool get_stale_enb_connection_with_enb_id(
   return false;
 }
 
-void clean_stale_enb_state(enb_description_t* new_enb_association){
+void clean_stale_enb_state(
+    s1ap_state_t* state, enb_description_t* new_enb_association) {
   enb_description_t* stale_enb_association = NULL;
 
-  hashtable_ts_apply_callback_on_elements((hash_table_ts_t* const) &state->enbs, get_stale_enb_connection_with_enb_id, enb_association, (void**) &stale_enb_association);
+  hashtable_ts_apply_callback_on_elements(
+      (hash_table_ts_t* const) & state->enbs,
+      get_stale_enb_connection_with_enb_id, new_enb_association,
+      (void**) &stale_enb_association);
   if (stale_enb_association == NULL) {
     // No stale eNB connection found;
     return;
   }
 
-  // Transfer the UEs from old eNB association to the new one
-  new_enb_association->nb_ue_associated = stale_enb_association->nb_ue_associated;
-  new_enb_association->ue_id_coll = stale_enb_association->ue_id_coll;
+  OAILOG_INFO(
+      LOG_S1AP, "Found stale eNB at association id %d",
+      stale_enb_association->sctp_assoc_id);
+  // Remove the S1 context for UEs associated with old eNB association
+  hashtable_key_array_t* keys =
+      hashtable_uint64_ts_get_keys(&stale_enb_association->ue_id_coll);
+  ue_description_t* ue_ref = NULL;
+  for (int i = 0; i < keys->num_keys; i++) {
+    ue_ref = s1ap_state_get_ue_mmeid((mme_ue_s1ap_id_t) keys->keys[i]);
+    s1ap_remove_ue(state, ue_ref);
+  }
+  FREE_HASHTABLE_KEY_ARRAY(keys);
   // Remove the old eNB association
   s1ap_remove_enb(state, stale_enb_association);
+  update_mme_app_stats_connected_enb_sub();
 }
 
 int s1ap_mme_handle_s1_setup_request(
@@ -556,8 +569,10 @@ int s1ap_mme_handle_s1_setup_request(
   }
 
   // Clean any stale connection for this enb_id and transfer the attached UEs
-  clean_stale_enb_state(enb_association);
-  OAILOG_DEBUG(LOG_S1AP, "Removed stale eNB and new eNB has %d UEs.", enb_association->nb_ue_associated);
+  clean_stale_enb_state(state, enb_association);
+  OAILOG_DEBUG(
+      LOG_S1AP, "Removed stale eNB and new eNB has %d UEs.",
+      enb_association->nb_ue_associated);
 
   s1ap_dump_enb(enb_association);
   rc = s1ap_generate_s1_setup_response(state, enb_association);

--- a/lte/gateway/c/oai/tasks/s1ap/s1ap_mme_nas_procedures.c
+++ b/lte/gateway/c/oai/tasks/s1ap/s1ap_mme_nas_procedures.c
@@ -98,7 +98,7 @@ int s1ap_mme_handle_initial_ue_message(
   OAILOG_INFO(
       LOG_S1AP,
       "Received S1AP INITIAL_UE_MESSAGE ENB_UE_S1AP_ID " ENB_UE_S1AP_ID_FMT
-      "assoc-id:%d \n",
+      " assoc-id:%d \n",
       (enb_ue_s1ap_id_t) ie->value.choice.ENB_UE_S1AP_ID, assoc_id);
 
   if ((eNB_ref = s1ap_state_get_enb(state, assoc_id)) == NULL) {
@@ -111,7 +111,7 @@ int s1ap_mme_handle_initial_ue_message(
   OAILOG_INFO(
       LOG_S1AP,
       "New Initial UE message received with eNB UE S1AP ID: " ENB_UE_S1AP_ID_FMT
-      "assoc-id :%d \n",
+      " assoc-id :%d \n",
       enb_ue_s1ap_id, eNB_ref->sctp_assoc_id);
   ue_ref = s1ap_state_get_ue_enbid(eNB_ref->sctp_assoc_id, enb_ue_s1ap_id);
 
@@ -138,6 +138,8 @@ int s1ap_mme_handle_initial_ue_message(
           enb_ue_s1ap_id);
       OAILOG_FUNC_RETURN(LOG_S1AP, RETURNerror);
     }
+
+    OAILOG_DEBUG(LOG_S1AP, "Creating new UE Ref on S1ap");
 
     ue_ref->s1_ue_state = S1AP_UE_WAITING_CSR;
 

--- a/lte/gateway/python/integ_tests/s1aptests/s1ap_utils.py
+++ b/lte/gateway/python/integ_tests/s1aptests/s1ap_utils.py
@@ -829,11 +829,7 @@ class MagmadUtil(object):
             # persist after each test
             if "directory" not in key:
                 keys_to_be_cleaned.append(key)
-        print(
-            "Keys left in Redis (list should be empty)[\n",
-            "\n".join(keys_to_be_cleaned),
-            "\n]"
-        )
+
         mme_nas_state_cmd = "state_cli.py parse mme_nas_state"
         mme_nas_state = self.exec_command_output(
             magtivate_cmd + " && " + mme_nas_state_cmd
@@ -841,9 +837,14 @@ class MagmadUtil(object):
         num_htbl_entries = 0
         for state in mme_nas_state.split("\n"):
             if "nb_enb_connected" in state or "nb_ue_attached" in state:
-                print(state,"(should be zero)\n")
+                keys_to_be_cleaned.append(state)
             elif "htbl" in state:
                 num_htbl_entries += 1
+        print(
+            "Keys left in Redis (list should be empty)[\n",
+            "\n".join(keys_to_be_cleaned),
+            "\n]"
+        )
         print("Entries left in hashtables (should be zero):", num_htbl_entries)
 
 

--- a/lte/gateway/python/integ_tests/s1aptests/test_sctp_shutdown_while_mme_is_stopped.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_sctp_shutdown_while_mme_is_stopped.py
@@ -87,6 +87,11 @@ class TestSctpShutdowniWhileStatelessMmeIsStopped(unittest.TestCase):
         self._s1ap_wrapper._s1setup()
 
         # Now detach the UE
+        print(
+            "************************* Calling detach for UE id ",
+            req.ue_id,
+        )
+
         self._s1ap_wrapper.s1_util.detach(
             req.ue_id, s1ap_types.ueDetachType_t.UE_NORMAL_DETACH.value, True
         )

--- a/lte/gateway/python/integ_tests/s1aptests/test_sctp_shutdown_while_mme_is_stopped.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_sctp_shutdown_while_mme_is_stopped.py
@@ -1,0 +1,96 @@
+"""
+Copyright 2020 The Magma Authors.
+
+This source code is licensed under the BSD-style license found in the
+LICENSE file in the root directory of this source tree.
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import time
+import unittest
+
+import s1ap_types
+
+from integ_tests.s1aptests import s1ap_wrapper
+
+
+class TestSctpShutdowniWhileStatelessMmeIsStopped(unittest.TestCase):
+    def setUp(self):
+        self._s1ap_wrapper = s1ap_wrapper.TestWrapper()
+
+    def tearDown(self):
+        self._s1ap_wrapper.cleanup()
+
+    def test_sctp_shutdown_while_stateless_mme_is_stopped(self):
+        """
+        testing SCTP Shutdown while MME is stopped but Sctpd is running, i.e.:
+        1. Attach 1 UE
+        2. Stop MME service on AGW
+        3. Send SCTP shutdown
+        4. Print Redis state
+        5. Start MME
+        6. Test S1 setup
+
+        """
+
+        self._s1ap_wrapper.configUEDevice(1)
+
+        req = self._s1ap_wrapper.ue_req
+        print(
+            "************************* Calling attach for UE id ",
+            req.ue_id,
+        )
+
+        self._s1ap_wrapper.s1_util.attach(
+            req.ue_id,
+            s1ap_types.tfwCmd.UE_END_TO_END_ATTACH_REQUEST,
+            s1ap_types.tfwCmd.UE_ATTACH_ACCEPT_IND,
+            s1ap_types.ueAttachAccept_t,
+        )
+        # Wait for EMM Information from MME
+        self._s1ap_wrapper._s1_util.receive_emm_info()
+
+        print("Stopping MME service")
+        self._s1ap_wrapper.magmad_util.exec_command(
+            "sudo service magma@mme stop"
+        )
+
+        print("send SCTP SHUTDOWN")
+        self._s1ap_wrapper._s1_util.issue_cmd(
+            s1ap_types.tfwCmd.SCTP_SHUTDOWN_REQ, None
+        )
+
+        print("Redis state after SCTP shutdown")
+        self._s1ap_wrapper.magmad_util.print_redis_state()
+
+        print("Starting MME service and waiting for 20 seconds")
+        self._s1ap_wrapper.magmad_util.exec_command(
+            "sudo service magma@mobilityd start"
+        )
+        self._s1ap_wrapper.magmad_util.exec_command(
+            "sudo service magma@pipelined start"
+        )
+        self._s1ap_wrapper.magmad_util.exec_command(
+            "sudo service magma@sessiond start"
+        )
+        self._s1ap_wrapper.magmad_util.exec_command(
+            "sudo service magma@mme start"
+        )
+        time.sleep(30)
+
+        print("Re-establish S1 connection between eNB and MME")
+        self._s1ap_wrapper._s1setup()
+
+        # Now detach the UE
+        self._s1ap_wrapper.s1_util.detach(
+            req.ue_id, s1ap_types.ueDetachType_t.UE_NORMAL_DETACH.value, True
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

In stateless mode, MME could be down while Sctpd gets an SCTP shutdown from eNB. In such case, the eNB state is never cleaned at MME. This change cleans up the stale eNB state, when a new S1Setup from the same eNB ID comes.  

## Test Plan

- Regression testing: `make integ_test`
- Functional testing: Added new test case and verified that num_enb_connected is zero at the end of the test.

