### PR TITLE
[orc8r] Remove Warning log when there are no errors

### DIFF
--- a/orc8r/cloud/go/swagger/combine.go
+++ b/orc8r/cloud/go/swagger/combine.go
@@ -45,7 +45,7 @@ func Combine(yamlCommon string, yamlSpecs []string) (string, error, error) {
 		return "", nil, err
 	}
 
-	return out, warnings, nil
+	return out, warnings.ErrorOrNil(), nil
 }
 
 func combine(common Spec, specs []Spec) (Spec, error) {


### PR DESCRIPTION
Signed-off-by: Andy Lee Khuu <andykhuu@stanford.edu>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary
Currently we are printing a warning log even when there are 0 merge errors from the combination of Swagger specs. This PR is a simple update so that we only log when there is at least one error. 
<!-- Enumerate changes you made and why you made them -->

Before
> Reading common spec from file:
/src/magma/orc8r/cloud/docker/controller/apidocs/v1/swagger-common.ym
Combining specs together...
Warnings: 0 errors occurred:
Writing combined Swagger spec to file:
/src/magma/orc8r/cloud/docker/controller/apidocs/v1/swagger.yml

After
> Reading common spec from file:
/src/magma/orc8r/cloud/docker/controller/apidocs/v1/swagger-common.yml
Combining specs together...
Writing combined Swagger spec to file:
/src/magma/orc8r/cloud/docker/controller/apidocs/v1/swagger.yml



## Test Plan
- [x] cd $MAGMA_ROOT/orc8r/cloud/docker && ./build.py -t ; noti
- [x] cd $MAGMA_ROOT/orc8r/cloud/docker && ./build.py -g;
- [x] Manual Inspection   
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
