### PR TITLE
[AGW] [S1ap tests] Enhance S1aptest redis state and Redis key cleaning

### DIFF
--- a/lte/gateway/python/integ_tests/s1aptests/s1ap_utils.py
+++ b/lte/gateway/python/integ_tests/s1aptests/s1ap_utils.py
@@ -823,6 +823,8 @@ class MagmadUtil(object):
         )
         keys_to_be_cleaned = []
         for key in redis_imsi_keys.split('\n'):
+            # Ignore directoryd per-IMSI keys in this analysis as they will
+            # persist after each test
             if "directory" not in key:
                 keys_to_be_cleaned.append(key)
         print(

--- a/lte/gateway/python/integ_tests/s1aptests/s1ap_utils.py
+++ b/lte/gateway/python/integ_tests/s1aptests/s1ap_utils.py
@@ -819,22 +819,28 @@ class MagmadUtil(object):
         magtivate_cmd = "source /home/vagrant/build/python/bin/activate"
         imsi_state_cmd = "state_cli.py keys IMSI*"
         redis_imsi_keys = self.exec_command_output(
-                magtivate_cmd + " && " + imsi_state_cmd)
-        keys_to_be_cleaned = ""
+            magtivate_cmd + " && " + imsi_state_cmd
+        )
+        keys_to_be_cleaned = []
         for key in redis_imsi_keys.split('\n'):
             if "directory" not in key:
-                keys_to_be_cleaned = keys_to_be_cleaned + key + "\n"
-        print("Keys left in Redis [\n", keys_to_be_cleaned, "]")
+                keys_to_be_cleaned.append(key)
+        print(
+            "Keys left in Redis (list should be empty)[\n",
+            "\n".join(keys_to_be_cleaned),
+            "\n]"
+        )
         mme_nas_state_cmd = "state_cli.py parse mme_nas_state"
         mme_nas_state = self.exec_command_output(
-                magtivate_cmd + " && " + mme_nas_state_cmd)
+            magtivate_cmd + " && " + mme_nas_state_cmd
+        )
         num_htbl_entries = 0
         for state in mme_nas_state.split("\n"):
             if "nb_enb_connected" in state or "nb_ue_attached" in state:
-                print(state,"\n")
+                print(state,"(should be zero)\n")
             elif "htbl" in state:
                 num_htbl_entries += 1
-        print("Entries left in hashtables:", num_htbl_entries)
+        print("Entries left in hashtables (should be zero):", num_htbl_entries)
 
 
 class MobilityUtil(object):

--- a/lte/gateway/python/integ_tests/s1aptests/s1ap_wrapper.py
+++ b/lte/gateway/python/integ_tests/s1aptests/s1ap_wrapper.py
@@ -62,6 +62,9 @@ class TestWrapper(object):
         """
         Initialize the various classes required by the tests and setup.
         """
+        t = time.localtime()
+        current_time = time.strftime("%H:%M:%S", t)
+        print("Start time", current_time)
         self._s1_util = S1ApUtil()
         self._enBConfig()
 

--- a/lte/gateway/python/scripts/config_stateless_agw.py
+++ b/lte/gateway/python/scripts/config_stateless_agw.py
@@ -87,7 +87,10 @@ def clear_redis_state():
     redis_client = get_default_client()
     for key_regex in [
         "*_state",
-        "IMSI*",
+        "IMSI*MME",
+        "IMSI*S1AP",
+        "IMSI*SPGW",
+        "IMSI*mobilityd*",
         "mobilityd:assigned_ip_blocks",
         "mobilityd:ip_states:*",
         "NO_VLAN:mobilityd_gw_info",


### PR DESCRIPTION
## Summary

- The per-IMSI Redis entries for directoryd service should not be cleaned at Sctpd restart, as they are cleaned by the State service. This change modifies the `config_stateless_agw.py` script to only clean per-IMSI state created by MME service (i.e. S1ap task, MME_APP task or SPGW task) and Mobilityd service.

- At the end of each S1ap test, we need to check if the `mme_nas_state` key show any connected eNB or UE. These two metrics should always be zero. Further, it also checks whether there are any entries left in the MME hashtables and need to be cleaned.

- Also added a "Start time" log in the S1ap wrapper init function so that test runs can be matched with gateway logs.

## Test Plan

- Regression `make integ_test` 
- Run `test_attach_detach.py` and stop the test before the detach request. Check that the Redis has entries for `IMSI.*mobility*`. These are cleared after `sudo service sctpd restart`, but the `IMSI.*directory_record` keys are left as-is.
- Run `test_attach_detach.py` and console log shows `Start time` and `Entries left in hashtables`

```
echo "Running test: s1aptests/test_attach_detach.py"
Running test: s1aptests/test_attach_detach.py
sudo -E PATH=/usr/lib/ccache:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/go/bin PYTHONPATH=:/home/vagrant/s1ap-tester/bin /home/vagrant/build/python/bin/nosetests -x -s s1aptests/test_attach_detach.py || exit 1
Start time 19:18:55
tag: AUTH_TYPE tagVal: MILENAGE
************************* Enb tester config

**********************TPT open server******** 0

 Server Socket FD =[13]
************* Testing *Time elapsed(in usec): for timer expiry               :8763 usec
AGW is stateless
APN Correction configured
Using subscriber IMSI IMSI001010000000001
Using subscriber IMSI IMSI001010000000002
************************* UE device config for ue_id  1
************************* UE device config for ue_id  2
************************* Configuring IP block
************************* Waiting for IP changes to propagate
************************* S1 setup
************************* UE App config
************************* Running End to End attach for  UE id  1
ue id 1 found

*************NbUiNbuHdlUeRadioCapMsg: Send UE cap msg SUCCESS*********
PDN_TYPE: 1
IPv4 PDN_ADDRESS:192 168 128 12
************************* Running UE detach for UE id  1
Deleting Ue Context from Traffic Handler
************************* Running End to End attach for  UE id  2
ue id 2 found

*************NbUiNbuHdlUeRadioCapMsg: Send UE cap msg SUCCESS*********
PDN_TYPE: 1
IPv4 PDN_ADDRESS:192 168 128 13
************************* Running UE detach for UE id  2
Deleting Ue Context from Traffic Handler
************************* send SCTP SHUTDOWN
Keys left in Redis (this list should be empty)[
  ]
Entries left in hashtables (should be zero): 6
.
```

