### PR TITLE
[magmad][metrics] Update metrics reporting to sync once per gw service

### DIFF
--- a/cwf/gateway/configs/magmad.yml
+++ b/cwf/gateway/configs/magmad.yml
@@ -79,7 +79,6 @@ metricsd:
   collect_interval: 60 # How frequently to collect metrics samples in seconds
   sync_interval: 60 # How frequently to sync to cloud in seconds
   grpc_timeout: 30 # Timeout in seconds
-  queue_length: 1000 # Number of failed samples to enqueue for resend
   max_grpc_msg_size_mb: 40 # Max message size for gRPC channel in MBs
 
   # An optional function  to mutate metrics before they are sent to the cloud

--- a/example/gateway/configs/magmad.yml
+++ b/example/gateway/configs/magmad.yml
@@ -31,7 +31,6 @@ metricsd:
   collect_interval: 60 # How frequently to collect metrics samples in seconds
   sync_interval: 60 # How frequently to sync to cloud in seconds
   grpc_timeout: 10 # Timeout in seconds
-  queue_length: 1000 # Number of failed samples to enqueue for resend
   # List of services for metricsd to poll
   services:
     - magmad

--- a/feg/gateway/configs/magmad.yml
+++ b/feg/gateway/configs/magmad.yml
@@ -66,7 +66,6 @@ metricsd:
   collect_interval: 60 # How frequently to collect metrics samples in seconds
   sync_interval: 60 # How frequently to sync to cloud in seconds
   grpc_timeout: 10 # Timeout in seconds
-  queue_length: 1000 # Number of failed samples to enqueue for resend
   max_grpc_msg_size_mb: 4 # Max message size for gRPC channel in MBs
   # List of services for metricsd to poll
   services:

--- a/feg/gateway/configs/magmad_legacy.yml
+++ b/feg/gateway/configs/magmad_legacy.yml
@@ -62,7 +62,6 @@ metricsd:
   collect_interval: 60 # How frequently to collect metrics samples in seconds
   sync_interval: 60 # How frequently to sync to cloud in seconds
   grpc_timeout: 10 # Timeout in seconds
-  queue_length: 1000 # Number of failed samples to enqueue for resend
   # List of services for metricsd to poll
   services:
     - magmad

--- a/lte/gateway/configs/magmad.yml
+++ b/lte/gateway/configs/magmad.yml
@@ -106,7 +106,6 @@ metricsd:
   collect_interval: 60 # How frequently to collect metrics samples in seconds
   sync_interval: 60 # How frequently to sync to cloud in seconds
   grpc_timeout: 30 # Timeout in seconds
-  queue_length: 1000 # Number of failed samples to enqueue for resend
   max_grpc_msg_size_mb: 4 # Max message size for gRPC channel in MBs
 
   # An optional function  to mutate metrics before they are sent to the cloud

--- a/openwrt/gateway/configs/etc/magma/configs/magmad.yml
+++ b/openwrt/gateway/configs/etc/magma/configs/magmad.yml
@@ -48,7 +48,6 @@ metricsd:
   collect_interval: 120 # How frequently to collect metrics samples in seconds
   sync_interval: 120 # How frequently to sync to cloud in seconds
   grpc_timeout: 10 # Timeout in seconds
-  queue_length: 300 # Number of failed samples to enqueue for resend
   # List of services for metricsd to poll
   services:
     - magmad

--- a/orc8r/gateway/configs/magmad.yml
+++ b/orc8r/gateway/configs/magmad.yml
@@ -57,7 +57,6 @@ metricsd:
   collect_interval: 60 # How frequently to collect metrics samples in seconds
   sync_interval: 60 # How frequently to sync to cloud in seconds
   grpc_timeout: 30 # Timeout in seconds
-  queue_length: 1000 # Number of failed samples to enqueue for resend
   max_grpc_msg_size_mb: 4 # Max message size for gRPC channel in MBs
 
   # An optional function  to mutate metrics before they are sent to the cloud

--- a/orc8r/gateway/python/magma/magmad/main.py
+++ b/orc8r/gateway/python/magma/magmad/main.py
@@ -73,7 +73,6 @@ def main():
     sync_interval = metrics_config['sync_interval']
     grpc_timeout = metrics_config['grpc_timeout']
     grpc_msg_size = metrics_config.get('max_grpc_msg_size_mb', 4)
-    queue_length = metrics_config['queue_length']
     metrics_post_processor_fn = metrics_config.get('post_processing_fn')
 
     metric_scrape_targets = map(lambda x: ScrapeTarget(x['url'], x['name'],
@@ -87,7 +86,6 @@ def main():
         sync_interval=sync_interval,
         grpc_timeout=grpc_timeout,
         grpc_max_msg_size_mb=grpc_msg_size,
-        queue_length=queue_length,
         loop=service.loop,
         post_processing_fn=
         get_metrics_postprocessor_fn(metrics_post_processor_fn),

--- a/orc8r/gateway/python/magma/magmad/metrics_collector.py
+++ b/orc8r/gateway/python/magma/magmad/metrics_collector.py
@@ -13,9 +13,11 @@ limitations under the License.
 import asyncio
 import calendar
 import logging
+import math
 import prometheus_client
 from prometheus_client.parser import text_string_to_metric_families
 import requests
+import sys
 import time
 from typing import Callable, List, Optional, Dict, NamedTuple
 
@@ -46,18 +48,18 @@ class MetricsCollector(object):
                  sync_interval: int,
                  grpc_timeout: int,
                  grpc_max_msg_size_mb: int,
-                 queue_length: int,
                  loop: Optional[asyncio.AbstractEventLoop] = None,
                  post_processing_fn: Optional[Callable] = None,
                  scrape_targets: [ScrapeTarget] = None):
         self.sync_interval = sync_interval
         self.collect_interval = collect_interval
         self.grpc_timeout = grpc_timeout
-        self.queue_length = queue_length
+        self.grpc_max_msg_size_bytes = grpc_max_msg_size_mb * 1024 * 1024
         self._services = services
         self._loop = loop if loop else asyncio.get_event_loop()
-        self._retry_queue = []
-        self._samples = []
+        self._samples_for_service = {}
+        for s in self._services:
+            self._samples_for_service[s] = []
         self._grpc_options = _get_metrics_chan_grpc_options(
             grpc_max_msg_size_mb)
         self.scrape_targets = scrape_targets if scrape_targets else []
@@ -70,8 +72,8 @@ class MetricsCollector(object):
         non-magma service prometheus scrape loop.
         """
         logging.info("Starting collector...")
-        self._loop.call_later(self.sync_interval, self.sync)
         for s in self._services:
+            self._loop.call_later(self.sync_interval, self.sync, s)
             self._loop.call_soon(self.collect, s)
 
         for target in self.scrape_targets:
@@ -79,11 +81,13 @@ class MetricsCollector(object):
                                   self.scrape_prometheus_target,
                                   target)
 
-    def sync(self):
+    def sync(self, service_name):
         """
-        Synchronizes sample queue to cloud and reschedules sync loop
+        Synchronizes sample queue for specific service to cloud and reschedules
+        sync loop
         """
-        if self._samples:
+        if service_name in self._samples_for_service and \
+           self._samples_for_service[service_name]:
             chan = ServiceRegistry.get_rpc_channel('metricsd',
                                                    ServiceRegistry.CLOUD,
                                                    grpc_options=self._grpc_options)
@@ -93,37 +97,40 @@ class MetricsCollector(object):
                 # If we throw an exception here, we'll have no idea whether
                 # something was postprocessed or not, so I guess try and make it
                 # idempotent?  #m sevchicken
-                self.post_processing_fn(self._samples)
-            samples = self._retry_queue + self._samples
-            metrics_container = MetricsContainer(
-                gatewayId=snowflake.snowflake(),
-                family=samples
-            )
-            future = client.Collect.future(metrics_container,
-                                           self.grpc_timeout)
-            future.add_done_callback(lambda future:
-                                     self._loop.call_soon_threadsafe(
-                                         self.sync_done, samples, future))
-            self._retry_queue.clear()
-            self._samples.clear()
-        self._loop.call_later(self.sync_interval, self.sync)
+                self.post_processing_fn(self._samples_for_service[service_name])
 
-    def sync_done(self, samples, collect_future):
+            samples = self._samples_for_service[service_name]
+            sample_chunks = self._chunk_samples(samples)
+            for idx, chunk in enumerate(sample_chunks):
+                metrics_container = MetricsContainer(
+                    gatewayId=snowflake.snowflake(),
+                    family=chunk
+                )
+                future = client.Collect.future(metrics_container,
+                                               self.grpc_timeout)
+                future.add_done_callback(self._make_sync_done_func(
+                                            service_name, idx)
+                                        )
+            self._samples_for_service[service_name].clear()
+        self._loop.call_later(self.sync_interval, self.sync, service_name)
+
+    def sync_done(self, service_name, chunk, collect_future):
         """
         Sync callback to handle exceptions
         """
         err = collect_future.exception()
         if err:
-            self._retry_queue = samples[-self.queue_length:]
-            logging.error("Metrics upload error! [%s] %s",
-                          err.code(), err.details())
+            logging.error("Metrics upload error for service %s (chunk %d)! "
+                          "[%s] %s", service_name, chunk, err.code(),
+                          err.details())
         else:
-            logging.debug("Metrics upload success")
+            logging.debug("Metrics upload success for service %s (chunk %d)",
+              service_name, chunk)
 
     def collect(self, service_name):
         """
         Calls into Service303 to get service metrics samples and
-        rescheudle collection.
+        reschedule collection.
         """
         chan = ServiceRegistry.get_rpc_channel(service_name,
                                                ServiceRegistry.LOCAL)
@@ -143,7 +150,7 @@ class MetricsCollector(object):
         if err:
             logging.warning("Collect %s Error! [%s] %s",
                             service_name, err.code(), err.details())
-            self._samples.append(
+            self._samples_for_service[service_name].append(
                 _get_collect_success_metric(service_name, False))
         else:
             container = get_metrics_future.result()
@@ -152,10 +159,10 @@ class MetricsCollector(object):
             for family in container.family:
                 for sample in family.metric:
                     sample.label.add(name="service", value=service_name)
-                self._samples.append(family)
+                self._samples_for_service[service_name].append(family)
                 if _is_start_time_metric(family):
                     self._add_uptime_metric(service_name, family)
-            self._samples.append(
+            self._samples_for_service[service_name].append(
                 _get_collect_success_metric(service_name, True))
 
     def _add_uptime_metric(self, service_name, family):
@@ -167,7 +174,23 @@ class MetricsCollector(object):
         start_time = family.metric[0].gauge.value
         uptime = _get_uptime_metric(service_name, start_time)
         if uptime is not None:
-            self._samples.append(uptime)
+            self._samples_for_service[service_name].append(uptime)
+
+    def _make_sync_done_func(self, service_name, chunk):
+        return lambda future: self._loop.call_soon_threadsafe(
+                               self.sync_done, service_name, chunk,
+                               future)
+
+    def _chunk_samples(self, samples):
+        # Add 1kiB fpr gRPC overhead
+        sample_size_bytes = sys.getsizeof(samples) + 1000
+        buckets = math.ceil(
+          sample_size_bytes / self.grpc_max_msg_size_bytes)
+        sample_length = len(samples)
+        chunk_size = sample_length // buckets
+
+        for i in range(0, sample_length, chunk_size):
+            yield samples[i:i + chunk_size]
 
     def scrape_prometheus_target(self, target: ScrapeTarget) -> None:
         """

--- a/xwf/gateway/configs/magmad.yml
+++ b/xwf/gateway/configs/magmad.yml
@@ -62,7 +62,6 @@ metricsd:
   collect_interval: 60 # How frequently to collect metrics samples in seconds
   sync_interval: 60 # How frequently to sync to cloud in seconds
   grpc_timeout: 30 # Timeout in seconds
-  queue_length: 1000 # Number of failed samples to enqueue for resend
   max_grpc_msg_size_mb: 4 # Max message size for gRPC channel in MBs
 
   # An optional function  to mutate metrics before they are sent to the cloud


### PR DESCRIPTION
Signed-off-by: Michael Germano <mgermano@fb.com>

## Summary

This PR corrects an issue we have seen in live deployments. Currently, 
metrics upload can start failing due to gRPC message size being larger
than the max that the channel has been configured with. While we
have a manual configuration for the max message size, this will not
scale well for large deployments.

This PR updates the metrics upload by sending a metrics upload once
per gateway service. Hence, each gateway has it's own metrics queue
and sync cycle. This should allow metrics to scale much better in the future
without hitting the max gRPC message size. 

## Test Plan

Ensure metrics upload works locally with gw and orc8r.
Simulate connection failure between gw and orc8r and
ensure that retry queue logic works appropriately.
