### PR TITLE
[lte][agw]Mitigate GRPC timeouts in S6a requests

### DIFF
--- a/lte/gateway/c/oai/lib/s6a_proxy/S6aClient.h
+++ b/lte/gateway/c/oai/lib/s6a_proxy/S6aClient.h
@@ -83,7 +83,7 @@ class S6aClient : public GRPCReceiver {
   S6aClient();
   static S6aClient& get_instance();
   std::unique_ptr<feg::S6aProxy::Stub> stub_;
-  static const uint32_t RESPONSE_TIMEOUT = 3;  // seconds
+  static const uint32_t RESPONSE_TIMEOUT = 10;  // seconds
 };
 
 // There are 3 services which can handle authentication:

--- a/lte/gateway/configs/subscriberdb.yml
+++ b/lte/gateway/configs/subscriberdb.yml
@@ -20,7 +20,7 @@ host_address: 0.0.0.0 # Bind to all interfaces
 enable_streaming: True
 
 # Keep subscriberdb in a file.
-# Comment out db_path to default to :memory: to store subscribers in memory.
+# If this is omitted default path of /var/opt/magma/ will be assumed.
 db_path: /var/opt/magma/
 
 # Bucketize subscribers based on last sid_last_n digits

--- a/lte/gateway/configs/subscriberdb.yml
+++ b/lte/gateway/configs/subscriberdb.yml
@@ -43,3 +43,6 @@ relay_retry_count: 0
 # shall set to false if intend to use Free-Diameter for s6a interface
 # TODO replace boolean with list of protocols: "s6a_over_grpc", "s6a_over_fd"
 s6a_over_grpc: True
+
+# Number of grpc workers
+grpc_workers: 1

--- a/lte/gateway/configs/subscriberdb.yml
+++ b/lte/gateway/configs/subscriberdb.yml
@@ -20,8 +20,11 @@ host_address: 0.0.0.0 # Bind to all interfaces
 enable_streaming: True
 
 # Keep subscriberdb in a file.
-# Change filename to :memory: to store subscribers in memory.
-db_path: file:/var/opt/magma/subscriber.db?cache=shared
+# Comment out db_path to default to :memory: to store subscribers in memory.
+db_path: /var/opt/magma/
+
+# Bucketize subscribers based on last sid_last_n digits
+sid_last_n: 2
 
 # S6A Peer Configurations
 mme_host_name: hss.magma.com

--- a/lte/gateway/configs/subscriberdb.yml
+++ b/lte/gateway/configs/subscriberdb.yml
@@ -45,4 +45,4 @@ relay_retry_count: 0
 s6a_over_grpc: True
 
 # Number of grpc workers
-grpc_workers: 1
+grpc_workers: 10

--- a/lte/gateway/configs/subscriberdb.yml
+++ b/lte/gateway/configs/subscriberdb.yml
@@ -47,5 +47,5 @@ relay_retry_count: 0
 # TODO replace boolean with list of protocols: "s6a_over_grpc", "s6a_over_fd"
 s6a_over_grpc: True
 
-# Number of grpc workers
+# Number of thread workers for the gRPC server
 grpc_workers: 10

--- a/lte/gateway/python/magma/subscriberdb/main.py
+++ b/lte/gateway/python/magma/subscriberdb/main.py
@@ -29,8 +29,7 @@ from lte.protos.mconfig import mconfigs_pb2
 def main():
     """ main() for subscriberdb """
     service = MagmaService('subscriberdb',
-                           mconfigs_pb2.SubscriberDB(),
-                           workers=1)
+                           mconfigs_pb2.SubscriberDB())
 
     # Initialize a store to keep all subscriber data.
     store = SqliteStore(service.config['db_path'], loop=service.loop)

--- a/lte/gateway/python/magma/subscriberdb/main.py
+++ b/lte/gateway/python/magma/subscriberdb/main.py
@@ -28,8 +28,7 @@ from lte.protos.mconfig import mconfigs_pb2
 
 def main():
     """ main() for subscriberdb """
-    service = MagmaService('subscriberdb',
-                           mconfigs_pb2.SubscriberDB())
+    service = MagmaService('subscriberdb', mconfigs_pb2.SubscriberDB())
 
     # Initialize a store to keep all subscriber data.
     store = SqliteStore(service.config['db_path'], loop=service.loop)

--- a/lte/gateway/python/magma/subscriberdb/main.py
+++ b/lte/gateway/python/magma/subscriberdb/main.py
@@ -31,7 +31,8 @@ def main():
     service = MagmaService('subscriberdb', mconfigs_pb2.SubscriberDB())
 
     # Initialize a store to keep all subscriber data.
-    store = SqliteStore(service.config['db_path'], loop=service.loop)
+    store = SqliteStore(service.config['db_path'], loop=service.loop,
+                        sid_digits=service.config['sid_last_n'])
 
     # Initialize the processor
     processor = Processor(store,

--- a/lte/gateway/python/magma/subscriberdb/store/sqlite.py
+++ b/lte/gateway/python/magma/subscriberdb/store/sqlite.py
@@ -13,8 +13,6 @@ limitations under the License.
 
 import logging
 import sqlite3
-import threading
-import time
 from contextlib import contextmanager
 
 from lte.protos.subscriberdb_pb2 import SubscriberData

--- a/lte/gateway/python/magma/subscriberdb/store/sqlite.py
+++ b/lte/gateway/python/magma/subscriberdb/store/sqlite.py
@@ -45,7 +45,7 @@ class SqliteStore(BaseStore):
     def _create_db_locations(self, db_location, n_shards):
         # in memory if db_location is not specified
         if not db_location:
-            return [":memory:"]
+            db_location = "/var/opt/magma/"
 
         # construct db_location items as: file:<path>subscriber<shard>.db?cache=shared
         db_location_list = []

--- a/lte/gateway/python/magma/subscriberdb/store/sqlite.py
+++ b/lte/gateway/python/magma/subscriberdb/store/sqlite.py
@@ -12,7 +12,6 @@ limitations under the License.
 """
 
 import logging
-import random
 import sqlite3
 import threading
 import time
@@ -28,9 +27,8 @@ from .base import (
 )
 from .onready import OnDataReady
 
-EXECUTE_TIMEOUT = 5 # wait period in sec if db is locked
-RAND_UPPERBOUND = 250 # maximum delta wait in 2nd attempt (unnormalized)
-RAND_LOWERBOUND = 10 # minimum delta wait after failed first attempt (unnormalized)
+SID_DIGITS = 2 # number of least significant digits from IMSI to use as table buckets
+N_SHARDS = 10 ** SID_DIGITS # number of shards to distribute UEs
 
 class SqliteStore(BaseStore):
     """
@@ -41,27 +39,40 @@ class SqliteStore(BaseStore):
     """
 
     def __init__(self, db_location, loop=None):
-        self._db_location = db_location
-        self._tlocal = threading.local()
+        self._db_location = self._create_db_locations(db_location)
         self._create_store()
         self._on_ready = OnDataReady(loop=loop)
 
-    @property
-    def conn(self):
-        """
-        Returns a thread local connection to the sqlite db.
-        """
-        if not getattr(self._tlocal, 'conn', None):
-            self._tlocal.conn = sqlite3.connect(self._db_location, timeout=EXECUTE_TIMEOUT, uri=True)
-        return self._tlocal.conn
+
+    def _create_db_locations(self, db_location):
+        # db_location in subscriberdb.yml: file:/var/opt/magma/subscriber.db?cache=shared
+        i = db_location.find(".db")
+        db_location_list = []
+        # no sharding if it is not a file
+        if i == -1:
+            return [db_location]
+
+        # file name is passed, use it as a base
+        for n_shard in range(N_SHARDS):
+            if n_shard < 10: # prefix i with '0'
+                db_location_list.append(db_location[:i] + '0' + str(n_shard) + db_location[i:])
+            else:
+                db_location_list.append(db_location[:i] + str(n_shard) + db_location[i:])
+            logging.info("db location: %s", db_location_list[n_shard])
+        return db_location_list
 
     def _create_store(self):
         """
         Create the sqlite table if it doesn't exist already.
         """
-        with self.conn:
-            self.conn.execute("CREATE TABLE IF NOT EXISTS subscriberdb"
-                              "(subscriber_id text PRIMARY KEY, data text)")
+        for db_location in self._db_location:
+            conn = sqlite3.connect(db_location, uri=True)
+            try:
+                with conn:
+                    conn.execute("CREATE TABLE IF NOT EXISTS subscriberdb"
+                                      "(subscriber_id text PRIMARY KEY, data text)")
+            finally:
+                conn.close()
 
     def add_subscriber(self, subscriber_data):
         """
@@ -69,14 +80,19 @@ class SqliteStore(BaseStore):
         """
         sid = SIDUtils.to_str(subscriber_data.sid)
         data_str = subscriber_data.SerializeToString()
-        with self.conn:
-            res = self.conn.execute("SELECT data FROM subscriberdb WHERE "
-                                    "subscriber_id = ?", (sid, ))
-            if res.fetchone():
-                raise DuplicateSubscriberError(sid)
+        db_location = self._db_location[int(sid[SID_DIGITS:])]
+        conn = sqlite3.connect(db_location, uri=True)
+        try:
+            with conn:
+                res = conn.execute("SELECT data FROM subscriberdb WHERE "
+                                        "subscriber_id = ?", (sid, ))
+                if res.fetchone():
+                    raise DuplicateSubscriberError(sid)
 
-            self.conn.execute("INSERT INTO subscriberdb(subscriber_id, data) "
-                              "VALUES (?, ?)", (sid, data_str))
+                conn.execute("INSERT INTO subscriberdb(subscriber_id, data) "
+                                "VALUES (?, ?)", (sid, data_str))
+        finally:
+            conn.close()
         self._on_ready.add_subscriber(subscriber_data)
 
     @contextmanager
@@ -84,59 +100,70 @@ class SqliteStore(BaseStore):
         """
         Context manager to modify the subscriber data.
         """
-        with self.conn:
-            res = self.conn.execute(
-                "SELECT data FROM subscriberdb WHERE " "subscriber_id = ?",
-                (subscriber_id,),
-            )
-            row = res.fetchone()
-            if not row:
-                raise SubscriberNotFoundError(subscriber_id)
-            subscriber_data = SubscriberData()
-            subscriber_data.ParseFromString(row[0])
-            yield subscriber_data
-            data_str = subscriber_data.SerializeToString()
-            try:
-                self.conn.execute(
+        db_location = self._db_location[int(subscriber_id[SID_DIGITS:])]
+        conn = sqlite3.connect(db_location, uri=True)
+        try:
+            with conn:
+                res = conn.execute(
+                    "SELECT data FROM subscriberdb WHERE " "subscriber_id = ?",
+                    (subscriber_id,),
+                )
+                row = res.fetchone()
+                if not row:
+                    raise SubscriberNotFoundError(subscriber_id)
+                subscriber_data = SubscriberData()
+                subscriber_data.ParseFromString(row[0])
+                yield subscriber_data
+                data_str = subscriber_data.SerializeToString()
+                conn.execute(
                     "UPDATE subscriberdb SET data = ? " "WHERE subscriber_id = ?",
                     (data_str, subscriber_id),
                 )
-            except sqlite3.OperationalError:
-                logging.error("sqlite db error for subscriber: %s", subscriber_id)
-                time.sleep(random.randint(RAND_LOWERBOUND, RAND_UPPERBOUND)/100)
-                # Try one more time after random wait
-                self.conn.execute(
-                    "UPDATE subscriberdb SET data = ? " "WHERE subscriber_id = ?",
-                    (data_str, subscriber_id),
-                )
+        finally:
+            conn.close()
 
     def delete_subscriber(self, subscriber_id):
         """
         Method that deletes a subscriber, if present.
         """
-        with self.conn:
-            self.conn.execute(
-                "DELETE FROM subscriberdb WHERE " "subscriber_id = ?",
-                (subscriber_id,),
-            )
+        db_location = self._db_location[int(subscriber_id[SID_DIGITS:])]
+        conn = sqlite3.connect(db_location, uri=True)
+        try:
+            with conn:
+                conn.execute(
+                    "DELETE FROM subscriberdb WHERE " "subscriber_id = ?",
+                    (subscriber_id,),
+                )
+        finally:
+            conn.close()
 
     def delete_all_subscribers(self):
         """
         Method that removes all the subscribers from the store
         """
-        with self.conn:
-            self.conn.execute("DELETE FROM subscriberdb")
+        for db_location in self._db_location:
+            conn = sqlite3.connect(db_location, uri=True)
+            try:
+                with conn:
+                    conn.execute("DELETE FROM subscriberdb")
+            finally:
+                conn.close()
 
     def get_subscriber_data(self, subscriber_id):
         """
         Method that returns the auth key for the subscriber.
         """
-        with self.conn:
-            res = self.conn.execute("SELECT data FROM subscriberdb WHERE "
-                                    "subscriber_id = ?", (subscriber_id, ))
-            row = res.fetchone()
-            if not row:
-                raise SubscriberNotFoundError(subscriber_id)
+        db_location = self._db_location[int(subscriber_id[SID_DIGITS:])]
+        conn = sqlite3.connect(db_location, uri=True)
+        try:
+            with conn:
+                res = conn.execute("SELECT data FROM subscriberdb WHERE "
+                                        "subscriber_id = ?", (subscriber_id, ))
+                row = res.fetchone()
+                if not row:
+                    raise SubscriberNotFoundError(subscriber_id)
+        finally:
+            conn.close()
         subscriber_data = SubscriberData()
         subscriber_data.ParseFromString(row[0])
         return subscriber_data
@@ -145,9 +172,16 @@ class SqliteStore(BaseStore):
         """
         Method that returns the list of subscribers stored
         """
-        with self.conn:
-            res = self.conn.execute("SELECT subscriber_id FROM subscriberdb")
-            return [row[0] for row in res]
+        sub_list = []
+        for db_location in self._db_location:
+            conn = sqlite3.connect(db_location, uri=True)
+            try:
+                with conn:
+                    res = conn.execute("SELECT subscriber_id FROM subscriberdb")
+                    sub_list.extend([row[0] for row in res])
+            finally:
+                conn.close()
+        return sub_list
 
     def update_subscriber(self, subscriber_data):
         """
@@ -164,11 +198,16 @@ class SqliteStore(BaseStore):
         """
         sid = SIDUtils.to_str(subscriber_data.sid)
         data_str = subscriber_data.SerializeToString()
-        with self.conn:
-            res = self.conn.execute("UPDATE subscriberdb SET data = ? "
-                                    "WHERE subscriber_id = ?", (data_str, sid))
-            if not res.rowcount:
-                raise SubscriberNotFoundError(sid)
+        db_location = self._db_location[int(sid[SID_DIGITS:])]
+        conn = sqlite3.connect(db_location, uri=True)
+        try:
+            with conn:
+                res = conn.execute("UPDATE subscriberdb SET data = ? "
+                                        "WHERE subscriber_id = ?", (data_str, sid))
+                if not res.rowcount:
+                    raise SubscriberNotFoundError(sid)
+        finally:
+            conn.close()
 
     def resync(self, subscribers):
         """
@@ -179,26 +218,38 @@ class SqliteStore(BaseStore):
         Args:
             subscribers - list of subscribers to be in the store.
         """
-        with self.conn:
-            # Capture the current state of the subscribers
-            res = self.conn.execute("SELECT subscriber_id, data FROM subscriberdb")
+        for db_location in self._db_location:
+            conn = sqlite3.connect(db_location, uri=True)
             current_state = {}
-            for row in res:
-                sub = SubscriberData()
-                sub.ParseFromString(row[1])
-                current_state[row[0]] = sub.state
+            try:
+                with conn:
+                    # Capture the current state of the subscribers
+                    res = conn.execute("SELECT subscriber_id, data FROM subscriberdb")
 
-            # Clear all subscribers
-            self.conn.execute("DELETE FROM subscriberdb")
+                    for row in res:
+                        sub = SubscriberData()
+                        sub.ParseFromString(row[1])
+                        current_state[row[0]] = sub.state
 
-            # Add the subscribers with the current state
-            for sub in subscribers:
-                sid = SIDUtils.to_str(sub.sid)
-                if sid in current_state:
-                    sub.state.CopyFrom(current_state[sid])
-                data_str = sub.SerializeToString()
-                self.conn.execute("INSERT INTO subscriberdb(subscriber_id, data) "
-                                  "VALUES (?, ?)", (sid, data_str))
+                    # Clear all subscribers
+                    conn.execute("DELETE FROM subscriberdb")
+            finally:
+                conn.close()
+
+        # Add the subscribers with the current state
+        for sub in subscribers:
+            sid = SIDUtils.to_str(sub.sid)
+            db_location = self._db_location[int(sid[SID_DIGITS:])]
+            conn = sqlite3.connect(db_location, uri=True)
+            if sid in current_state:
+                sub.state.CopyFrom(current_state[sid])
+            data_str = sub.SerializeToString()
+            try:
+                with conn:
+                    conn.execute("INSERT INTO subscriberdb(subscriber_id, data) "
+                                        "VALUES (?, ?)", (sid, data_str))
+            finally:
+                conn.close()
         self._on_ready.resync(subscribers)
 
     async def on_ready(self):

--- a/lte/gateway/python/magma/subscriberdb/store/sqlite.py
+++ b/lte/gateway/python/magma/subscriberdb/store/sqlite.py
@@ -48,7 +48,6 @@ class SqliteStore(BaseStore):
             return [":memory:"]
 
         # construct db_location items as: file:<path>subscriber<shard>.db?cache=shared
-        i = db_location.find(".db")
         db_location_list = []
 
         # file name is passed, use it as a base

--- a/lte/gateway/python/magma/subscriberdb/store/sqlite.py
+++ b/lte/gateway/python/magma/subscriberdb/store/sqlite.py
@@ -273,7 +273,7 @@ class SqliteStore(BaseStore):
         """
         try:
             bucket = int(subscriber_id[-self._sid_digits:])
-        except:
+        except (TypeError, ValueError):
             logging.info("Last %d digits of subscriber id %s cannot mapped to a bucket: default to bucket 0"
                          % (self._sid_digits, subscriber_id))
             bucket = 0

--- a/lte/gateway/python/magma/subscriberdb/store/sqlite.py
+++ b/lte/gateway/python/magma/subscriberdb/store/sqlite.py
@@ -80,7 +80,7 @@ class SqliteStore(BaseStore):
         """
         sid = SIDUtils.to_str(subscriber_data.sid)
         data_str = subscriber_data.SerializeToString()
-        db_location = self._db_location[int(sid[SID_DIGITS:])]
+        db_location = self._db_location[int(sid[-SID_DIGITS:])]
         conn = sqlite3.connect(db_location, uri=True)
         try:
             with conn:
@@ -100,7 +100,7 @@ class SqliteStore(BaseStore):
         """
         Context manager to modify the subscriber data.
         """
-        db_location = self._db_location[int(subscriber_id[SID_DIGITS:])]
+        db_location = self._db_location[int(subscriber_id[-SID_DIGITS:])]
         conn = sqlite3.connect(db_location, uri=True)
         try:
             with conn:
@@ -126,7 +126,7 @@ class SqliteStore(BaseStore):
         """
         Method that deletes a subscriber, if present.
         """
-        db_location = self._db_location[int(subscriber_id[SID_DIGITS:])]
+        db_location = self._db_location[int(subscriber_id[-SID_DIGITS:])]
         conn = sqlite3.connect(db_location, uri=True)
         try:
             with conn:
@@ -153,7 +153,7 @@ class SqliteStore(BaseStore):
         """
         Method that returns the auth key for the subscriber.
         """
-        db_location = self._db_location[int(subscriber_id[SID_DIGITS:])]
+        db_location = self._db_location[int(subscriber_id[-SID_DIGITS:])]
         conn = sqlite3.connect(db_location, uri=True)
         try:
             with conn:
@@ -198,7 +198,7 @@ class SqliteStore(BaseStore):
         """
         sid = SIDUtils.to_str(subscriber_data.sid)
         data_str = subscriber_data.SerializeToString()
-        db_location = self._db_location[int(sid[SID_DIGITS:])]
+        db_location = self._db_location[int(sid[-SID_DIGITS:])]
         conn = sqlite3.connect(db_location, uri=True)
         try:
             with conn:
@@ -239,7 +239,7 @@ class SqliteStore(BaseStore):
         # Add the subscribers with the current state
         for sub in subscribers:
             sid = SIDUtils.to_str(sub.sid)
-            db_location = self._db_location[int(sid[SID_DIGITS:])]
+            db_location = self._db_location[int(sid[-SID_DIGITS:])]
             conn = sqlite3.connect(db_location, uri=True)
             if sid in current_state:
                 sub.state.CopyFrom(current_state[sid])

--- a/lte/gateway/python/magma/subscriberdb/store/sqlite.py
+++ b/lte/gateway/python/magma/subscriberdb/store/sqlite.py
@@ -13,6 +13,7 @@ limitations under the License.
 
 import logging
 import sqlite3
+from collections import defaultdict
 from contextlib import contextmanager
 
 from lte.protos.subscriberdb_pb2 import SubscriberData
@@ -216,7 +217,7 @@ class SqliteStore(BaseStore):
         Args:
             subscribers - list of subscribers to be in the store.
         """
-        bucket_subs = {}
+        bucket_subs = defaultdict(list)
         for sub in subscribers:
             sid = SIDUtils.to_str(sub.sid)
             bucket_subs[int(sid[-SID_DIGITS:])].append(sid)

--- a/lte/gateway/python/magma/subscriberdb/store/sqlite.py
+++ b/lte/gateway/python/magma/subscriberdb/store/sqlite.py
@@ -274,7 +274,7 @@ class SqliteStore(BaseStore):
         try:
             bucket = int(subscriber_id[-self._sid_digits:])
         except (TypeError, ValueError):
-            logging.info("Last %d digits of subscriber id %s cannot mapped to a bucket: default to bucket 0"
-                         % (self._sid_digits, subscriber_id))
+            logging.info("Last %d digits of subscriber id %s cannot mapped to a bucket:"
+                         " default to bucket 0", self._sid_digits, subscriber_id)
             bucket = 0
         return bucket

--- a/lte/gateway/python/magma/subscriberdb/store/sqlite.py
+++ b/lte/gateway/python/magma/subscriberdb/store/sqlite.py
@@ -219,7 +219,7 @@ class SqliteStore(BaseStore):
             sid = SIDUtils.to_str(sub.sid)
             bucket_subs[self._sid2bucket(sid)].append(sub)
 
-        for i, db_location in enumerate(self._db_location):
+        for i, db_location in enumerate(self._db_locations):
             conn = sqlite3.connect(db_location, uri=True)
             try:
                 with conn:

--- a/lte/gateway/python/magma/subscriberdb/tests/processor_tests.py
+++ b/lte/gateway/python/magma/subscriberdb/tests/processor_tests.py
@@ -11,8 +11,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-import os
-import shutil
+import tempfile
 import unittest
 
 from lte.protos.mconfig.mconfigs_pb2 import SubscriberDB
@@ -25,8 +24,6 @@ from magma.subscriberdb.store.base import SubscriberNotFoundError
 from magma.subscriberdb.store.sqlite import SqliteStore
 
 from magma.subscriberdb.sid import SIDUtils
-
-dbdirectory = "/home/vagrant/test/"
 
 def _dummy_auth_tuple():
     rand = b'ni\x89\xbel\xeeqTT7p\xae\x80\xb1\xef\r'
@@ -83,13 +80,9 @@ class ProcessorTests(unittest.TestCase):
         processor.Milenage = Milenage
 
     def setUp(self):
-        try:
-            os.mkdir(dbdirectory)
-        except OSError:
-            print ("Creation of the test directory %s failed" % dbdirectory)
-        else:
-            print ("Successfully created the test directory %s " % dbdirectory)
-        store = SqliteStore(dbdirectory)
+        # Create sqlite3 database for testing
+        self._tmpfile = tempfile.TemporaryDirectory()
+        store = SqliteStore(self._tmpfile.name +'/')
         op = 16*b'\x11'
         amf = b'\x80\x00'
         self._sub_profiles = {
@@ -133,12 +126,7 @@ class ProcessorTests(unittest.TestCase):
         store.add_subscriber(sub5)
 
     def tearDown(self):
-        try:
-            shutil.rmtree(dbdirectory)
-        except OSError:
-            print ("Deletion of the test directory %s failed" % dbdirectory)
-        else:
-            print ("Successfully deleted the test directory %s " % dbdirectory)
+        self._tmpfile.cleanup()
 
     def test_gsm_auth_success(self):
         """

--- a/lte/gateway/python/magma/subscriberdb/tests/processor_tests.py
+++ b/lte/gateway/python/magma/subscriberdb/tests/processor_tests.py
@@ -11,6 +11,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
+import os
+import shutil
 import unittest
 
 from lte.protos.mconfig.mconfigs_pb2 import SubscriberDB
@@ -24,6 +26,7 @@ from magma.subscriberdb.store.sqlite import SqliteStore
 
 from magma.subscriberdb.sid import SIDUtils
 
+dbdirectory = "/home/vagrant/test/"
 
 def _dummy_auth_tuple():
     rand = b'ni\x89\xbel\xeeqTT7p\xae\x80\xb1\xef\r'
@@ -80,7 +83,13 @@ class ProcessorTests(unittest.TestCase):
         processor.Milenage = Milenage
 
     def setUp(self):
-        store = SqliteStore('file::memory:')
+        try:
+            os.mkdir(dbdirectory)
+        except OSError:
+            print ("Creation of the test directory %s failed" % dbdirectory)
+        else:
+            print ("Successfully created the test directory %s " % dbdirectory)
+        store = SqliteStore(dbdirectory)
         op = 16*b'\x11'
         amf = b'\x80\x00'
         self._sub_profiles = {
@@ -122,6 +131,14 @@ class ProcessorTests(unittest.TestCase):
         store.add_subscriber(sub3)
         store.add_subscriber(sub4)
         store.add_subscriber(sub5)
+
+    def tearDown(self):
+        try:
+            shutil.rmtree(dbdirectory)
+        except OSError:
+            print ("Deletion of the test directory %s failed" % dbdirectory)
+        else:
+            print ("Successfully deleted the test directory %s " % dbdirectory)
 
     def test_gsm_auth_success(self):
         """

--- a/lte/gateway/python/magma/subscriberdb/tests/rpc_tests.py
+++ b/lte/gateway/python/magma/subscriberdb/tests/rpc_tests.py
@@ -11,6 +11,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
+import os
+import shutil
 import unittest
 from concurrent import futures
 
@@ -22,6 +24,7 @@ from magma.subscriberdb.sid import SIDUtils
 from magma.subscriberdb.store.sqlite import SqliteStore
 from orc8r.protos.common_pb2 import Void
 
+dbdirectory = "/home/vagrant/test/"
 
 class RpcTests(unittest.TestCase):
     """
@@ -29,8 +32,15 @@ class RpcTests(unittest.TestCase):
     """
 
     def setUp(self):
+        try:
+            os.mkdir(dbdirectory)
+        except OSError:
+            print ("Creation of the test directory %s failed" % dbdirectory)
+        else:
+            print ("Successfully created the test directory %s " % dbdirectory)
+
         # Create an in-memory store
-        store = SqliteStore('file::memory:?cache=shared')
+        store = SqliteStore(dbdirectory)
 
         # Bind the rpc server to a free port
         self._rpc_server = grpc.server(
@@ -48,6 +58,12 @@ class RpcTests(unittest.TestCase):
         self._stub = SubscriberDBStub(channel)
 
     def tearDown(self):
+        try:
+            shutil.rmtree(dbdirectory)
+        except OSError:
+            print ("Deletion of the test directory %s failed" % dbdirectory)
+        else:
+            print ("Successfully deleted the test directory %s " % dbdirectory)
         self._rpc_server.stop(0)
 
     def test_get_invalid_subscriber(self):

--- a/lte/gateway/python/magma/subscriberdb/tests/store/cached_store_tests.py
+++ b/lte/gateway/python/magma/subscriberdb/tests/store/cached_store_tests.py
@@ -12,8 +12,7 @@ limitations under the License.
 """
 
 # pylint: disable=protected-access
-import os
-import shutil
+import tempfile
 import unittest
 
 from lte.protos.subscriberdb_pb2 import SubscriberData
@@ -24,8 +23,6 @@ from magma.subscriberdb.store.sqlite import SqliteStore
 
 from magma.subscriberdb.sid import SIDUtils
 
-dbdirectory = "/home/vagrant/test/"
-
 class StoreTests(unittest.TestCase):
     """
     Test class for the CachedStore subscriber storage
@@ -33,22 +30,12 @@ class StoreTests(unittest.TestCase):
 
     def setUp(self):
         cache_size = 3
-        try:
-            os.mkdir(dbdirectory)
-        except OSError:
-            print ("Creation of the test directory %s failed" % dbdirectory)
-        else:
-            print ("Successfully created the test directory %s " % dbdirectory)
-        sqlite = SqliteStore(dbdirectory)
+        self._tmpfile = tempfile.TemporaryDirectory()
+        sqlite = SqliteStore(self._tmpfile.name +'/')
         self._store = CachedStore(sqlite, cache_size)
 
     def tearDown(self):
-        try:
-            shutil.rmtree(dbdirectory)
-        except OSError:
-            print ("Deletion of the test directory %s failed" % dbdirectory)
-        else:
-            print ("Successfully deleted the test directory %s " % dbdirectory)
+        self._tmpfile.cleanup()
 
     def _add_subscriber(self, sid):
         sub = SubscriberData(sid=SIDUtils.to_pb(sid))

--- a/lte/gateway/python/magma/subscriberdb/tests/store/cached_store_tests.py
+++ b/lte/gateway/python/magma/subscriberdb/tests/store/cached_store_tests.py
@@ -12,7 +12,8 @@ limitations under the License.
 """
 
 # pylint: disable=protected-access
-
+import os
+import shutil
 import unittest
 
 from lte.protos.subscriberdb_pb2 import SubscriberData
@@ -23,6 +24,7 @@ from magma.subscriberdb.store.sqlite import SqliteStore
 
 from magma.subscriberdb.sid import SIDUtils
 
+dbdirectory = "/home/vagrant/test/"
 
 class StoreTests(unittest.TestCase):
     """
@@ -31,8 +33,22 @@ class StoreTests(unittest.TestCase):
 
     def setUp(self):
         cache_size = 3
-        sqlite = SqliteStore("file::memory:")
+        try:
+            os.mkdir(dbdirectory)
+        except OSError:
+            print ("Creation of the test directory %s failed" % dbdirectory)
+        else:
+            print ("Successfully created the test directory %s " % dbdirectory)
+        sqlite = SqliteStore(dbdirectory)
         self._store = CachedStore(sqlite, cache_size)
+
+    def tearDown(self):
+        try:
+            shutil.rmtree(dbdirectory)
+        except OSError:
+            print ("Deletion of the test directory %s failed" % dbdirectory)
+        else:
+            print ("Successfully deleted the test directory %s " % dbdirectory)
 
     def _add_subscriber(self, sid):
         sub = SubscriberData(sid=SIDUtils.to_pb(sid))

--- a/lte/gateway/python/magma/subscriberdb/tests/store/onready_test.py
+++ b/lte/gateway/python/magma/subscriberdb/tests/store/onready_test.py
@@ -14,6 +14,8 @@ limitations under the License.
 # pylint: disable=protected-access
 
 import asyncio
+import os
+import shutil
 import unittest
 
 from lte.protos.subscriberdb_pb2 import SubscriberData
@@ -22,6 +24,7 @@ from magma.subscriberdb.store.sqlite import SqliteStore
 
 from magma.subscriberdb.sid import SIDUtils
 
+dbdirectory = "/home/vagrant/test/"
 
 class OnReadyMixinTests(unittest.TestCase):
     """
@@ -31,8 +34,22 @@ class OnReadyMixinTests(unittest.TestCase):
     def setUp(self):
         cache_size = 3
         self.loop = asyncio.new_event_loop()
-        sqlite = SqliteStore("file::memory:", loop=self.loop)
+        try:
+            os.mkdir(dbdirectory)
+        except OSError:
+            print ("Creation of the test directory %s failed" % dbdirectory)
+        else:
+            print ("Successfully created the test directory %s " % dbdirectory)
+        sqlite = SqliteStore(dbdirectory, loop=self.loop)
         self._store = CachedStore(sqlite, cache_size, self.loop)
+
+    def tearDown(self):
+        try:
+            shutil.rmtree(dbdirectory)
+        except OSError:
+            print ("Deletion of the test directory %s failed" % dbdirectory)
+        else:
+            print ("Successfully deleted the test directory %s " % dbdirectory)
 
     def _add_subscriber(self, sid):
         sub = SubscriberData(sid=SIDUtils.to_pb(sid))

--- a/lte/gateway/python/magma/subscriberdb/tests/store/store_tests.py
+++ b/lte/gateway/python/magma/subscriberdb/tests/store/store_tests.py
@@ -11,7 +11,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-import asyncio
 import os
 import shutil
 import unittest

--- a/lte/gateway/python/magma/subscriberdb/tests/store/store_tests.py
+++ b/lte/gateway/python/magma/subscriberdb/tests/store/store_tests.py
@@ -11,6 +11,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
+import asyncio
+import os
+import shutil
 import unittest
 
 from lte.protos.subscriberdb_pb2 import SubscriberData
@@ -20,6 +23,7 @@ from magma.subscriberdb.store.sqlite import SqliteStore
 
 from magma.subscriberdb.sid import SIDUtils
 
+dbdirectory = "/home/vagrant/test/"
 
 class StoreTests(unittest.TestCase):
     """
@@ -27,8 +31,22 @@ class StoreTests(unittest.TestCase):
     """
 
     def setUp(self):
-        # Create an in-memory sqlite3 database for testing
-        self._store = SqliteStore("file::memory:")
+        # Create sqlite3 database for testing
+        try:
+            os.mkdir(dbdirectory)
+        except OSError:
+            print ("Creation of the test directory %s failed" % dbdirectory)
+        else:
+            print ("Successfully created the test directory %s " % dbdirectory)
+        self._store = SqliteStore(dbdirectory)
+
+    def tearDown(self):
+        try:
+            shutil.rmtree(dbdirectory)
+        except OSError:
+            print ("Deletion of the test directory %s failed" % dbdirectory)
+        else:
+            print ("Successfully deleted the test directory %s " % dbdirectory)
 
     def _add_subscriber(self, sid):
         sub = SubscriberData(sid=SIDUtils.to_pb(sid))

--- a/lte/gateway/python/magma/subscriberdb/tests/store/store_tests.py
+++ b/lte/gateway/python/magma/subscriberdb/tests/store/store_tests.py
@@ -11,8 +11,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-import os
-import shutil
+import tempfile
 import unittest
 
 from lte.protos.subscriberdb_pb2 import SubscriberData
@@ -22,8 +21,6 @@ from magma.subscriberdb.store.sqlite import SqliteStore
 
 from magma.subscriberdb.sid import SIDUtils
 
-dbdirectory = "/home/vagrant/test/"
-
 class StoreTests(unittest.TestCase):
     """
     Test class for subscriber storage
@@ -31,21 +28,11 @@ class StoreTests(unittest.TestCase):
 
     def setUp(self):
         # Create sqlite3 database for testing
-        try:
-            os.mkdir(dbdirectory)
-        except OSError:
-            print ("Creation of the test directory %s failed" % dbdirectory)
-        else:
-            print ("Successfully created the test directory %s " % dbdirectory)
-        self._store = SqliteStore(dbdirectory)
+        self._tmpfile = tempfile.TemporaryDirectory()
+        self._store = SqliteStore(self._tmpfile.name +'/')
 
     def tearDown(self):
-        try:
-            shutil.rmtree(dbdirectory)
-        except OSError:
-            print ("Deletion of the test directory %s failed" % dbdirectory)
-        else:
-            print ("Successfully deleted the test directory %s " % dbdirectory)
+        self._tmpfile.cleanup()
 
     def _add_subscriber(self, sid):
         sub = SubscriberData(sid=SIDUtils.to_pb(sid))

--- a/orc8r/gateway/python/magma/common/service.py
+++ b/orc8r/gateway/python/magma/common/service.py
@@ -43,6 +43,7 @@ from .log_count_handler import MsgCounterHandler
 from .metrics_export import get_metrics
 from .service_registry import ServiceRegistry
 
+MAX_DEFAULT_WORKER = 10
 
 async def loop_exit():
     """
@@ -59,7 +60,7 @@ class MagmaService(Service303Servicer):
     entities to interact with the service.
     """
 
-    def __init__(self, name, empty_mconfig, loop=None, workers=None):
+    def __init__(self, name, empty_mconfig, loop=None):
         self._name = name
         self._port = 0
         self._get_status_callback = None
@@ -90,12 +91,10 @@ class MagmaService(Service303Servicer):
         self._start_time = int(time.time())
         self._register_signal_handlers()
 
-        if workers is None:
-            workers = 10
-
         # Load the service config if present
         self._config = None
         self.reload_config()
+
         # Count errors
         self.log_counter = ServiceLogErrorReporter(
             loop=self._loop,
@@ -125,7 +124,11 @@ class MagmaService(Service303Servicer):
         except pkg_resources.ResolutionError as e:
             logging.info(e)
 
-        self._server = grpc.server(futures.ThreadPoolExecutor(max_workers=workers))
+        if self._config and 'grpc_workers' in self._config:
+            self._server = grpc.server(
+                futures.ThreadPoolExecutor(max_workers=self._config['grpc_workers']))
+        else:
+            self._server = grpc.server(futures.ThreadPoolExecutor(max_workers=MAX_DEFAULT_WORKER))
         add_Service303Servicer_to_server(self, self._server)
 
     @property


### PR DESCRIPTION
## Summary

To mitigate GRPC timeouts during authentication step:
-- increased the RPC timeout from 3 seconds to 10 seconds. This is the hard time out.
-- implemented file level sharding of subscribers into 100 buckets based on their last 2 digits in IMSI
-- open/close connections per api call.

To allow number of workers configurable via service yml files, I removed the hardwired value for number of workers passed during service initialization.

## Test Plan

- integ tests
- spirent scaling test

## Additional Information

- [ ] This change is backwards-breaking

