### PR TITLE
[s1ap] Add logging messages to show content of directoryd

### DIFF
--- a/lte/gateway/python/integ_tests/s1aptests/s1ap_utils.py
+++ b/lte/gateway/python/integ_tests/s1aptests/s1ap_utils.py
@@ -60,6 +60,8 @@ from lte.protos.ha_service_pb2 import (
     StartAgwOffloadRequest,
     EnbOffloadType,
 )
+from orc8r.protos.common_pb2 import Void
+
 DEFAULT_GRPC_TIMEOUT = 10
 
 
@@ -159,7 +161,7 @@ class S1ApUtil(object):
         with self._cond:
             rc = self._test_api(cmd_type.value, c_req)
             if rc:
-                logging.error("Error executing command %s" % repr(cmd_type))
+                print("Error executing command %s" % repr(cmd_type))
                 return rc
         return 0
 
@@ -1260,18 +1262,35 @@ class SessionManagerUtil(object):
         qos = QoSInformation(qci=qos["qci"])
 
         # Get sessionid
-        req = GetDirectoryFieldRequest(id=imsi, field_key="session_id")
-        try:
-            res = self._directorydstub.GetDirectoryField(
-                req, DEFAULT_GRPC_TIMEOUT
-            )
-        except grpc.RpcError as err:
-            logging.error(
-                "GetDirectoryFieldRequest error for id: %s! [%s] %s",
-                imsi,
-                err.code(),
-                err.details(),
-            )
+        #TODO: remove retries
+        i = 0
+        MAX = 3
+        res = None
+        while i < MAX:
+            req = GetDirectoryFieldRequest(id=imsi, field_key="session_id")
+            try:
+                res = self._directorydstub.GetDirectoryField(
+                    req, DEFAULT_GRPC_TIMEOUT
+                )
+            except grpc.RpcError as err:
+                print(
+                    "error: GetDirectoryFieldRequest error for id: %s! [%s] %s",
+                    imsi,
+                    err.code(),
+                    err.details(),
+                )
+            if req != None:
+                i = MAX
+            else:
+                i+=1
+                print("warning: directoryd failed to return sessionId for %s. Retrying", imsi)
+                time.sleep(3)
+
+        if res == None:
+            print("error: Couldnt find sessionid. Directoryd content:")
+            allRecordsResponse = self._directorydstub.GetAllDirectoryRecords(Void(), DEFAULT_GRPC_TIMEOUT)
+            for record in allRecordsResponse.recordsResponse:
+                print("%s", str(record))
 
         self._session_stub.PolicyReAuth(
             PolicyReAuthRequest(
@@ -1297,8 +1316,7 @@ class SessionManagerUtil(object):
                 req, DEFAULT_GRPC_TIMEOUT
             )
         except grpc.RpcError as err:
-            logging.error(
-                "GetDirectoryFieldRequest error for id: %s! [%s] %s",
+            print("Error: GetDirectoryFieldRequest error for id: %s! [%s] %s",
                 imsi,
                 err.code(),
                 err.details(),


### PR DESCRIPTION
Signed-off-by: Oriol Batalla <obatalla@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary

**NOTE this is a temporal change to get some logs on CI runtime**

This PR adds some code to try to find out the error on CI you can see in the link below.

We some messages and a retry mechanism in case of failure 

The idea is not to use the retry mechanism in the future, but trying to figure out why sessionid is not found.


https://app.circleci.com/pipelines/github/magma/magma/13765/workflows/2e8cedc3-0366-42e3-bc4f-9d5bb1b41240/jobs/123496

## Test Plan

```
/magma/lte/gateway/python/integ_tests$ make integ_test TESTS=s1aptests/test_attach_detach_rar_tcp_data.py
...
Ran 1 test in 29.702s

OK
sleep 1

```

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
