### PR TITLE
[orc8r] [fix] Remove Temp Directories made in Spec Servicer Test

### DIFF
--- a/orc8r/cloud/go/obsidian/swagger/spec_servicer_test.go
+++ b/orc8r/cloud/go/obsidian/swagger/spec_servicer_test.go
@@ -37,8 +37,6 @@ func TestSpecServicer_NewSpecServicerFromFile(t *testing.T) {
 	os.RemoveAll(tmpDir)
 	defer os.RemoveAll(tmpDir)
 
-	req := &swagger_protos.GetSpecRequest{}
-
 	err := os.Mkdir(tmpDir, os.ModePerm)
 	assert.NoError(t, err)
 
@@ -50,6 +48,7 @@ func TestSpecServicer_NewSpecServicerFromFile(t *testing.T) {
 	servicer := swagger.NewSpecServicerFromFile("test")
 	assert.NoError(t, err)
 
+	req := &swagger_protos.GetSpecRequest{}
 	res, err := servicer.GetSpec(context.Background(), req)
 	assert.NoError(t, err)
 
@@ -57,10 +56,10 @@ func TestSpecServicer_NewSpecServicerFromFile(t *testing.T) {
 }
 
 func TestSpecServicer_GetSpec(t *testing.T) {
-	req := &swagger_protos.GetSpecRequest{}
-
 	// Success
 	servicer := swagger.NewSpecServicer(testFileContents)
+
+	req := &swagger_protos.GetSpecRequest{}
 	res, err := servicer.GetSpec(context.Background(), req)
 	assert.NoError(t, err)
 

--- a/orc8r/cloud/go/obsidian/swagger/spec_servicer_test.go
+++ b/orc8r/cloud/go/obsidian/swagger/spec_servicer_test.go
@@ -34,12 +34,13 @@ var (
 )
 
 func TestSpecServicer_NewSpecServicerFromFile(t *testing.T) {
+	os.RemoveAll(tmpDir)
+	defer os.RemoveAll(tmpDir)
+
 	req := &swagger_protos.GetSpecRequest{}
 
 	err := os.Mkdir(tmpDir, os.ModePerm)
 	assert.NoError(t, err)
-
-	defer os.RemoveAll(tmpDir)
 
 	tmpSpecPath := filepath.Join(tmpDir, testFile)
 	err = ioutil.WriteFile(tmpSpecPath, []byte(testFileContents), 0644)


### PR DESCRIPTION
Signed-off-by: Andy Lee Khuu <andykhuu@stanford.edu>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary
This PR is a quick update to https://github.com/magma/magma/pull/4665 so that we are remembering to delete the temporary directory constructed in our test suite at the beginning and end of the test. 
<!-- Enumerate changes you made and why you made them -->

## Test Plan
- [x] cd $MAGMA_ROOT/orc8r/cloud/docker && ./build.py -t ; noti
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
