### PR TITLE
[s1ap] Add longer delay on test_attach_detach_rar_tcp_data

### DIFF
--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_rar_tcp_data.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_rar_tcp_data.py
@@ -158,8 +158,8 @@ class TestAttachDetachRarTcpData(unittest.TestCase):
 
             policy_id = "ims-voice"
 
-            print("Sleeping for 5 seconds")
-            time.sleep(5)
+            print("Sleeping for 10 seconds")
+            time.sleep(10)
             print(
                 "********************** Sending RAR for IMSI",
                 "".join([str(i) for i in req.imsi]),


### PR DESCRIPTION
Signed-off-by: Oriol Batalla <obatalla@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary

Adding a delay on `test_attach_detach_rar_tcp_data` to see if that helps

Also modify print functions on `s1ap_utils` to try to catch the content of  directory (dredis) if the call fails

Those functions may be permanent since they will provide some info in case of failure 


## Test Plan
```
make integ_test TESTS=s1aptests/test_attach_detach_rar_tcp_data.py
...
Ran 1 test in 34.943s

OK
sleep 1
```
## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
