### PR TITLE
Adding experimental cloudstrapper

### DIFF
--- a/experimental/cloudstrapper/README.md
+++ b/experimental/cloudstrapper/README.md
@@ -1,0 +1,178 @@
+
+# Chapter 1
+
+## 0. Prerequisites
+   - Create private repo on github to host helm charts. 
+     This information would be used in the build.yaml and cluster.yaml files when building and deploying Magma respectively. 
+
+   - Identify two security keys in the Build/Gateway regions to be used for the following
+     - Bootkey: Used only by Cloudstrapper instance
+     - Hostkey: Used by all Gateway instances
+       Both values are specified in the defaults.yaml vars file and embedded in hosts.
+     To generate keys through a playbook, see section 1 below.
+
+   - Create inventory directory on localhost to save keys, secrets etc. This directory
+     will be referred to as WORK_DIR and used as dirInventory in commands.
+
+   - Gather following credentials and update secrets.yaml on local machine in WORK_DIR. 
+     Use format from $CODE_DIR/playbooks/roles/vars/secrets.yaml as base.
+     - AWS Access and Secret keys
+     - Github username and PAT
+     - Dockerhub username and password 
+
+   - Understand key directories
+     - CODE_DIR: Directory hosting Magma code, typically in the ~/code/magma/experimental/cloudstrapper folder
+     - VARS_DIR: Directory where all variables reside, typically in the CODE_DIR/playbooks/roles/vars folder
+     - WORK_DIR: Directory where all working copies reside, typically n the ~/magma-experimental
+       folder
+
+## 1. Run aws-essentials to setup all AWS related components as a stack
+
+  The aws-essentials playbook will:
+  - Create boot and host keys if required using the keyCreate tag. Default is to not create keys.
+  - Create security group on the default VPC
+  - Create default bucket for shared storage. Ensure bucket does not exist by checking defaults.yaml
+
+  - Command:
+    ```
+    ansible-playbook aws-prerequisites.yaml -e 'awsTargetRegion=<< AWS Region >>' -e "dirInventory=<directory>" [ --tags keyCreate ]
+    ```
+  - Example:
+    ```
+    ansible-playbook aws-prerequisites.yaml -e 'awsTargetRegion=us-east-1' -e "dirInventory=~/magma-experimental/files" 
+    ``` 
+  - Result: Created stackMantleEssentials with common security group, S3 storage
+
+### 1.1 For users who do not have access to a Cloudstrapper AMI: Optional CI/CD
+  The devops playbooks are used to initialize a default instance, configure it to act as a Cloudstrapper and generate an
+  AMI that can be used as Cloudstrapper AMI and either published in the Marketplace as a public or community AMI or 
+  retained locally.
+
+
+  - devops-provision: Setup instance using default security group, Bootkey and Ubuntu 
+  - Command:
+    ```
+    ansible-playbook devops-provision.yaml -e "dirInventory=<directory>" 
+    ```
+  - Example:
+    ```
+    ansible-playbook devops-provision.yaml -e "dirInventory=~/magma-experimental/files
+    ```
+  - Result: Base instance for Devops provisioned
+
+  - devops-configure: Install ansible, golang, packages, local working directory and latest github sources
+    Command:
+    ```
+    ansible-playbook devops-configure.yaml -i <dynamic inventory file> -e "< hostname,inventory folder> -u ubuntu --skip-tags usingGitSshKey,buildMagma,pubMagma,helm
+    ```
+    Example:
+    ```
+    ansible-playbook devops-configure.yaml -i ~/magma-experimental/files/common_instance_aws_ec2.yaml -e "devops=tag_Name_ec2MagmaDevopsCloudstrapper" -e "dirInventory=~/magma-experimental/files" -u ubuntu --skip-tags usingGitSshKey,buildMagma,pubMagma,helm
+    ```
+  - Result: Base instance configured using packages and latest Mantle source 
+
+  - devops-init: Snapshot instance  
+    Command:
+    ```
+    ansible-playbook devops-init.yaml  -e "dirInventory=<directory>"
+    ```
+    Example:
+    ```
+    ansible-playbook devops-init.yaml  -e "dirInventory=~/magma-experimental/files" 
+    ```
+  - Result: imgMagmaCloudstrap AMI created
+
+## 2. Cloudstrapper Process - Marketplace experience begins for users who have access to Cloudstrapper AMI
+
+  - Launch from instance using Bootkey, Ubuntu 20.04 and default security group
+    - (or) run cloudstrapper-provision
+      ```
+      ansible-playbook cloudstrapper-provision.yaml  -e "dirLocalInventory=~/magma-experimental/files"
+      ```
+  - Result: Cloudstraper node with code package running now, ordered from Marketplace
+
+  - Login to Cloustrapper node via SSH to start Build, Control Plane and Data Plane rollouts
+
+  - Locate ~/code/mantle/magma-on-aws/playbooks/vars/secrets.yaml file and fill out Secrets
+    section and save it in WORK_DIR on Cloudstrapper. Optionally, change other values if required.
+
+## 3. Build
+
+  The build- playbooks provision, configure and initiate the build process before posting 
+  the artifacts on identified repositories on successful build.
+
+  - Create build elements: Provision, Configure and Init. 
+     
+  - Before beginning Build process, check variables to ensure deployment is customized.
+    build.yaml : 
+      - buildMagmaVersion indicates which version of Magma to build (v1.3, v1.4 etc)
+      - buildOrc8rLabel indicates what label the images would have
+      - buildHelmRepo indicates which github repo will hold Helm charts
+
+      - buildAwsRegion indicates which region will host the build instance. 
+      - buildAwsAz indicates an AZ within the region specified above
+
+  - build-provision: Setup build instance using default security group, Bootkey and Ubuntu with
+    t2.xlarge. Optionally, Provision a AGW compliant image (Debian 4909 or Ubuntu 20.04) 
+    ```
+    ansible-playbook build-provision.yaml
+    ```
+
+  - build-configure: Configure build instance by setting up necessary parameters and reading from
+    dynamic inventory. The build node was provisioned with the tag Name:buildOrc8r in this example.
+    ```
+    ansible-playbook build-configure.yaml -i ~/magma-experimental/files/common_instance_aws_ec2.yaml -e "buildnode=tag_Name_buildOrc8r" -e "ansible_python_interpreter=/usr/bin/python3"
+    ```
+
+  - build-ami-configure: Configure AMI for AGW by configuring base AMI image with AGW packages and
+    building OVS.
+    *TODO: Remove existing snapshot and create new snapshot*
+    ```
+    ansible-playbook build-ami-configure.yaml -e '@vars/main.yaml' -i files/build_instance_aws_ec2.yaml -e "buildnode=tag_Name_ec2MagmaBuild" -u admin
+    ```
+
+  - Result: Build instance created, images and helm charts published. AGW AMI created.
+
+## 4. Control Plane/Cloud Services
+
+  The control- roles deploy and configure orc8r in a target region.
+
+  - Create control plane elements: Provision, Configure and Init
+    Observe the variables set in cluster.yaml
+
+    Make any custom changes to main.tf here before initializing. If you would like to persist changes
+    across re-installs, make changes to the main.tf.j2 Jinja2 template file directly so that the custom
+    configuration be used across every terraform init.
+
+  - Requires: secrets.yaml in the dirInventory folder. Use the sample file in roles/vars/secrets.yaml
+  - Orchestrator : Deploy orchestrator 
+  ```
+    ansible-playbook orc8r.yaml [ --skip-tags deploy-orc8r ]
+  ```
+
+  Note: First time installs might want to skip using Terraform from within Ansible to make sure the
+  new build works as expected. When using a stable build, the tag does not have to be skipped.
+
+  - Result: Orchestrator certificates created, Terraform files initialized, Orchestrator deployed
+    via Terraform
+
+## Known Issues, Best Practices & Expected Behavior
+
+### Best Practices
+    
+    1. Although the deployment will work from any Ubuntu host, using the Cloudstrapper AMI might be
+       the quickest way to get the deployment going since it includes all the necessary dependencies
+       in-built. 
+
+    2. The tool is customizable to build every desired type of installation. However, for initial
+       efforts, it might be better to to use the existing default values. 
+
+### Expected Behavior - Install
+
+    1. Prior code base
+       If a prior code base resides in the home folder, install exists reporting code already exists.
+       This is done to ensure the user is aware that a prior code base exists and needs to be moved
+       before pulling the new code and not automatically have it overwritten. This is expected
+       behavior. 
+
+

--- a/experimental/cloudstrapper/playbooks/aws-prerequisites.yaml
+++ b/experimental/cloudstrapper/playbooks/aws-prerequisites.yaml
@@ -1,0 +1,14 @@
+---
+
+- hosts: localhost
+  roles:
+    - aws-essentials
+  environment:
+    AWS_ACCESS_KEY_ID: "{{ awsAccessKey }}"
+    AWS_SECRET_ACCESS_KEY: "{{ awsSecretKey }}"
+    AWS_DEFAULT_REGION: "{{ awsAgwRegion }}"
+  vars_files:
+    - roles/vars/defaults.yaml
+    - "{{ dirLocalInventory }}/secrets.yaml"
+    - roles/vars/cluster.yaml
+    - roles/vars/build.yaml

--- a/experimental/cloudstrapper/playbooks/cloudstrapper-provision.yaml
+++ b/experimental/cloudstrapper/playbooks/cloudstrapper-provision.yaml
@@ -1,0 +1,14 @@
+---
+
+- hosts: localhost
+  roles:
+    - cloudstrapper-infra
+  vars_files:
+    - roles/vars/defaults.yaml
+    - roles/vars/cluster.yaml
+    - roles/vars/build.yaml
+    - "{{ dirLocalInventory }}/secrets.yaml"
+  environment:
+    AWS_ACCESS_KEY_ID: "{{ awsAccessKey }}"
+    AWS_SECRET_ACCESS_KEY: "{{ awsSecretKey }}"
+    AWS_DEFAULT_REGION: "{{ awsAgwRegion }}"

--- a/experimental/cloudstrapper/playbooks/devops-configure.yaml
+++ b/experimental/cloudstrapper/playbooks/devops-configure.yaml
@@ -1,0 +1,16 @@
+---
+
+- hosts: "{{ devops }}"
+  roles:
+    - { role: ansible-server, become: yes }
+    - golang-host
+    - mantle-base
+    - build-platform
+    - { role: key-manager, tags: keyManager }     
+  vars_files:
+    - roles/vars/defaults.yaml
+    - roles/vars/cluster.yaml
+    - roles/vars/build.yaml
+    - "{{ dirLocalInventory }}/secrets.yaml"
+  vars:
+    ansible_ssh_private_key_file: "{{ dirLocalInventory }}/{{ keyHost }}.pem"

--- a/experimental/cloudstrapper/playbooks/devops-init.yaml
+++ b/experimental/cloudstrapper/playbooks/devops-init.yaml
@@ -1,0 +1,14 @@
+---
+
+- hosts: localhost
+  roles:
+    - devops-platform
+  vars_files:
+    - roles/vars/defaults.yaml
+    - roles/vars/cluster.yaml
+    - roles/vars/build.yaml
+    - "{{ dirLocalInventory }}/secrets.yaml"
+  environment:
+    AWS_ACCESS_KEY_ID: "{{ awsAccessKey }}"
+    AWS_SECRET_ACCESS_KEY: "{{ awsSecretKey }}"
+    AWS_DEFAULT_REGION: "{{ awsAgwRegion }}"

--- a/experimental/cloudstrapper/playbooks/devops-provision.yaml
+++ b/experimental/cloudstrapper/playbooks/devops-provision.yaml
@@ -1,0 +1,18 @@
+---
+
+- hosts: localhost
+  roles:
+    - devops-infra
+    - role: aws-inventory
+      vars:
+        dirInventory: "{{ dirLocalInventory }}"
+      tags: inventory
+  vars_files:
+    - roles/vars/defaults.yaml
+    - roles/vars/cluster.yaml
+    - roles/vars/build.yaml
+    - "{{ dirLocalInventory }}/secrets.yaml"
+  environment:
+    AWS_ACCESS_KEY_ID: "{{ awsAccessKey }}"
+    AWS_SECRET_ACCESS_KEY: "{{ awsSecretKey }}"
+    AWS_DEFAULT_REGION: "{{ awsAgwRegion }}"

--- a/experimental/cloudstrapper/playbooks/orc8r.yaml
+++ b/experimental/cloudstrapper/playbooks/orc8r.yaml
@@ -1,0 +1,14 @@
+---
+
+- hosts: localhost
+  roles:
+    - { role: magma-base, tags: base }
+    - { role: control, tags: controller } 
+  vars_files:
+    - roles/vars/cluster.yaml
+    - roles/vars/defaults.yaml
+    - "{{ dirInventory }}/secrets.yaml"
+  environment:
+    AWS_ACCESS_KEY_ID: "{{ awsAccessKey }}"
+    AWS_SECRET_ACCESS_KEY: "{{ awsSecretKey }}"
+    AWS_DEFAULT_REGION: "{{ awsOrc8rRegion }}"

--- a/experimental/cloudstrapper/playbooks/roles/ansible-server/tasks/main.yaml
+++ b/experimental/cloudstrapper/playbooks/roles/ansible-server/tasks/main.yaml
@@ -1,0 +1,16 @@
+#Installing Ansible Server
+#Needs to be run as sudo user (instead of becoming sudo user for each play)
+
+
+- name: installing ansible dependent packages
+  apt: 
+    name: "{{ bootPackages }}" 
+    state: present
+    update_cache: yes
+  with_items:
+    - software-properties-common
+    - python3-boto
+    - python3-boto3
+    - python3-botocore
+    - ansible
+

--- a/experimental/cloudstrapper/playbooks/roles/ansible-server/vars/main.yaml
+++ b/experimental/cloudstrapper/playbooks/roles/ansible-server/vars/main.yaml
@@ -1,0 +1,9 @@
+---
+
+bootPackages:
+  - software-properties-common
+  - python3-boto
+  - python3-boto3
+  - python3-botocore
+  - ansible
+  - awscli

--- a/experimental/cloudstrapper/playbooks/roles/aws-essentials/tasks/main.yaml
+++ b/experimental/cloudstrapper/playbooks/roles/aws-essentials/tasks/main.yaml
@@ -1,0 +1,56 @@
+---
+#aws-essentials setup up aws prerequisite resources
+#common magma s3 bucket to store and retrive objects
+#common magma security group that all instances will use. 
+#common magma ssh keypair that will be embedded in all hosts
+#common magma ssh keypair that will be embedded in bootstrap only
+
+- name: allocate keyBoot
+  ec2_key:
+    name: "{{ keyBoot }}"
+  register: keyboot_val
+  tags: [ never, keyCreate ]
+
+- name: copy .pem file
+  copy: 
+    content: "{{ keyboot_val.key.private_key }}" 
+    dest: "{{ dirLocalInventory }}/{{ keyBoot }}.pem"
+    mode: 0600
+  when: keyboot_val.changed
+  tags: [ never, keyCreate ]
+
+- name: allocate keyHost
+  ec2_key:
+    name: "{{ keyHost }}"
+  register: keyhost_val
+  tags: [ never, keyCreate ]
+
+- name: copy .pem file
+  copy: 
+    content: "{{ keyhost_val.key.private_key }}" 
+    dest: "{{ dirLocalInventory }}/{{ keyHost }}.pem"
+    mode: 0600
+  when: keyhost_val.changed
+  tags: [ never, keyCreate ]
+
+- name: find vpc id of default gateway for bootstrap
+  ec2_vpc_net_info:
+    filters:
+      "isDefault": "true"
+  register: return_val
+
+- name: assign vpc id to variable
+  set_fact: 
+    factVpcId: "{{ return_val.vpcs[0].vpc_id }}"
+
+- name: create other aws resources 
+  cloudformation: 
+    stack_name: "stackMantleEssentials"
+    state: "present"
+    region: "{{ awsAgwRegion }}"
+    disable_rollback: true
+    template: "roles/cfn/cfnMagmaEssentials.json"
+    template_parameters:
+      paramVpcDefault: "{{ factVpcId }}"
+      paramSecgroupMagmaDefault: "{{ secgroupDefault }}"
+      paramBucketMagmaDefault: "{{ bucketDefault }}"

--- a/experimental/cloudstrapper/playbooks/roles/aws-inventory/tasks/main.yaml
+++ b/experimental/cloudstrapper/playbooks/roles/aws-inventory/tasks/main.yaml
@@ -1,0 +1,17 @@
+---
+
+- name: folder for dynamic inventory file
+  file:
+    path: "{{ dirInventory }}"
+#    owner: "{{ userBootstrap }}"
+#    group: "{{ userBootstrap }}"
+    mode: '0755'
+    state: directory 
+
+- name: templatizing dynamic inventory file
+  template:
+    src: roles/aws-inventory/templates/instance_aws_ec2.yaml.j2
+    dest: "{{ dirInventory }}/common_instance_aws_ec2.yaml"
+#    owner: "{{ userBootstrap }}"
+#    group: "{{ userBootstrap }}"
+    mode: '0644' 

--- a/experimental/cloudstrapper/playbooks/roles/aws-inventory/templates/instance_aws_ec2.yaml.j2
+++ b/experimental/cloudstrapper/playbooks/roles/aws-inventory/templates/instance_aws_ec2.yaml.j2
@@ -1,0 +1,12 @@
+---
+
+plugin: aws_ec2
+aws_access_key: "{{ awsAccessKey }}"
+aws_secret_key: "{{ awsSecretKey }}"
+
+regions: 
+  - "{{ awsAgwRegion }}"
+
+keyed_groups:
+  - key: tags
+    prefix: tag

--- a/experimental/cloudstrapper/playbooks/roles/build-platform/files/01-docker.bash
+++ b/experimental/cloudstrapper/playbooks/roles/build-platform/files/01-docker.bash
@@ -1,0 +1,9 @@
+curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
+sudo apt-key fingerprint 0EBFCD88
+sudo add-apt-repository \
+	"deb [arch=amd64] https://download.docker.com/linux/ubuntu \
+	$(lsb_release -cs) stable"
+
+sudo apt-get -y install docker-ce docker-ce-cli containerd.io
+
+

--- a/experimental/cloudstrapper/playbooks/roles/build-platform/files/02-docker-compose.bash
+++ b/experimental/cloudstrapper/playbooks/roles/build-platform/files/02-docker-compose.bash
@@ -1,0 +1,9 @@
+sudo curl -L "https://github.com/docker/compose/releases/download/1.27.4/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
+
+sudo chmod +x /usr/local/bin/docker-compose
+
+sudo ln -s /usr/local/bin/docker-compose /usr/bin/docker-compose
+
+sudo usermod -aG docker ${USER}
+
+

--- a/experimental/cloudstrapper/playbooks/roles/build-platform/files/03-pyenv.bash
+++ b/experimental/cloudstrapper/playbooks/roles/build-platform/files/03-pyenv.bash
@@ -1,0 +1,9 @@
+curl https://pyenv.run | bash
+
+echo "export PATH=$HOME/.pyenv/bin:"'$PATH' >> ~/.bash_profile
+echo -e 'if command -v pyenv 1>/dev/null 2>&1; then\n  eval "$(pyenv init -)"\nfi' >> ~/.bash_profile
+
+sudo ln -s ~/.pyenv/bin/pyenv /usr/local/bin
+
+pyenv install 3.7.3
+pyenv global 3.7.3

--- a/experimental/cloudstrapper/playbooks/roles/build-platform/files/05-aws-tools.bash
+++ b/experimental/cloudstrapper/playbooks/roles/build-platform/files/05-aws-tools.bash
@@ -1,0 +1,5 @@
+curl -o aws-iam-authenticator https://amazon-eks.s3.us-west-2.amazonaws.com/1.18.9/2020-11-02/bin/linux/amd64/aws-iam-authenticator
+chmod +x ./aws-iam-authenticator
+mkdir -p $HOME/bin && cp ./aws-iam-authenticator $HOME/bin/aws-iam-authenticator && export PATH=$PATH:$HOME/bin
+echo 'export PATH=$PATH:$HOME/bin' >> ~/.bashrc
+sudo cp ./aws-iam-authenticator /usr/local/bin/

--- a/experimental/cloudstrapper/playbooks/roles/build-platform/files/11-magma-env.bash
+++ b/experimental/cloudstrapper/playbooks/roles/build-platform/files/11-magma-env.bash
@@ -1,0 +1,5 @@
+export MAGMA_ROOT=~/source/magma
+export MAGMA_DOCKER_USER=arunuke
+export PUBLISH=$MAGMA_ROOT/orc8r/tools/docker/publish.sh 
+export REGISTRY=registry.hub.docker.com/$MAGMA_DOCKER_USER
+export MAGMA_TAG=1.3.0-master

--- a/experimental/cloudstrapper/playbooks/roles/build-platform/files/build-configure.bash
+++ b/experimental/cloudstrapper/playbooks/roles/build-platform/files/build-configure.bash
@@ -1,0 +1,5 @@
+export MAGMA_ROOT=~/magma-source/magma/
+export PUBLISH=$MAGMA_ROOT/orc8r/tools/docker/publish.sh
+export REGISTRY=registry.hub.docker.com/REGISTRY
+export MAGMA_TAG=1.3.0-master
+export PWD=`pwd`

--- a/experimental/cloudstrapper/playbooks/roles/build-platform/files/composeBootstrapper.bash
+++ b/experimental/cloudstrapper/playbooks/roles/build-platform/files/composeBootstrapper.bash
@@ -1,0 +1,3 @@
+source ./05-aws-tools.bash
+source ./08-terraform.bash
+source ./09-ansible.bash

--- a/experimental/cloudstrapper/playbooks/roles/build-platform/files/helm-publish.bash
+++ b/experimental/cloudstrapper/playbooks/roles/build-platform/files/helm-publish.bash
@@ -1,0 +1,16 @@
+#arg1: gitusername arg2: gitpassword arg3: git publish branch 
+gitBranchCheckout=a7580153
+gitPublishBranch=$3
+gitUserName=$1
+gitPat=$2
+dirMagmaRoot=$4
+dirHelmChart=~/magma-charts
+
+cd $dirMagmaRoot
+git checkout $gitBranchCheckout
+cd $dirHelmChart
+git init
+helm package $dirMagmaRoot/orc8r/cloud/helm/orc8r/ && helm repo index .
+git add . && git commit -m "Initial Commit"
+git remote add origin https://$gitUserName:$gitPat@github.com/$gitUserName/$gitPublishBranch && git push -u origin master
+

--- a/experimental/cloudstrapper/playbooks/roles/build-platform/files/helm-verify.bash
+++ b/experimental/cloudstrapper/playbooks/roles/build-platform/files/helm-verify.bash
@@ -1,0 +1,11 @@
+
+gitPublishBranch=$3
+gitUserName=$1
+gitPat=$2
+#helm repo add *requires* PAT and will not work with password
+
+
+helm repo add $gitPublishBranch --username $gitUserName --password $gitPat https://raw.githubusercontent.com/$gitUserName/$gitPublishBranch/master/
+helm repo update && helm repo list
+helm search repo $gitPublishBranch
+

--- a/experimental/cloudstrapper/playbooks/roles/build-platform/files/magma-env.bash
+++ b/experimental/cloudstrapper/playbooks/roles/build-platform/files/magma-env.bash
@@ -1,0 +1,5 @@
+export MAGMA_ROOT=~/source/magma
+export MAGMA_DOCKER_USER=arunuke
+export PUBLISH=$MAGMA_ROOT/orc8r/tools/docker/publish.sh 
+export REGISTRY=registry.hub.docker.com/$MAGMA_DOCKER_USER
+export MAGMA_TAG=1.3.0-master

--- a/experimental/cloudstrapper/playbooks/roles/build-platform/files/pre-build.bash
+++ b/experimental/cloudstrapper/playbooks/roles/build-platform/files/pre-build.bash
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+#Objective: Run common tasks to setup or destroy pre-build elements
+#Pre-requisite: AWS profile is configured with access key, secret key, region and
+#json
+#Philosophy: Use CloudFormation (cfn) when applicable
+
+source ./global.env
+
+function prebuild-create {
+#Create EC2 private key pair.
+#For everything else, use CloudFormation
+
+aws ec2 create-key-pair --key-name $AWS_ANSIBLE_KEY --query 'KeyMaterial' --output text > $AWS_ANSIBLE_KEY.pem
+chmod 600 $AWS_ANSIBLE_KEY.pem 
+
+aws cloudformation create-stack --stack-name $AWS_CFN_PREBUILD_STACK --template-body file://$PROTO_CONFIG/cfnMagmaPreBuildProto.json
+}
+
+
+function prebuild-cleanup {
+
+aws ec2 delete-key-pair --key-name $AWS_ANSIBLE_KEY
+rm -f $AWS_ANSIBLE_KEY.pem
+
+aws cloudformation delete-stack --stack-name $AWS_CFN_PREBUILD_STACK
+
+}
+
+#Check if AWS creds are configured
+if [ $# -ne 1 ]
+then
+	echo "Need one argument. Create or Cleanup"
+	exit 1
+fi
+
+if [ $1 = "Create" ]
+then
+	echo "Create" 
+	prebuild-create
+elif [ $1 = "Cleanup" ]
+then
+	echo "Cleanup"
+	prebuild-cleanup
+else
+	echo "Error. Argument must be Create or Cleanup"
+fi
+
+

--- a/experimental/cloudstrapper/playbooks/roles/build-platform/files/python-configure.bash
+++ b/experimental/cloudstrapper/playbooks/roles/build-platform/files/python-configure.bash
@@ -1,0 +1,1 @@
+sudo apt-get install python3.7

--- a/experimental/cloudstrapper/playbooks/roles/build-platform/tasks/build-magma.yaml
+++ b/experimental/cloudstrapper/playbooks/roles/build-platform/tasks/build-magma.yaml
@@ -1,0 +1,20 @@
+---
+
+- name: install PyYAML via pip3. 
+  command: "{{ dirShim }}/pip3 install PyYAML"
+
+- name: install boto3  pip3.
+  command: "{{ dirShim }}/pip3 install boto3"
+
+- name: preparing build
+  pause:
+    minutes: 5
+  tags: buildPrep
+
+- name: primary build to generate orc8r artifacts
+  command: "chdir={{ magmaBuildDir }} {{ dirShim }}/python3.7 build.py --all"
+
+- name: primary build to generate lte artifacts
+  command: "chdir={{ magmaNmsDir }} docker-compose build magmalte"
+
+

--- a/experimental/cloudstrapper/playbooks/roles/build-platform/tasks/build-tools-packages.yml
+++ b/experimental/cloudstrapper/playbooks/roles/build-platform/tasks/build-tools-packages.yml
@@ -1,0 +1,71 @@
+---
+
+- name: install all dependencies
+  apt:
+    name: "{{ allDeps }}"
+    state: present
+    update_cache: yes
+  become: yes
+
+- name: prepare docker
+  script: 01-docker.bash
+
+- name: install docker 
+  apt:
+    name: "{{ dockerPackages }}"
+    state: present
+    update_cache: yes
+  become: yes
+
+- name: install docker compose
+  script: 02-docker-compose.bash
+
+- name: install aws components 
+  script: 05-aws-tools.bash
+
+- name: add k8s key
+  apt_key:
+    url: https://packages.cloud.google.com/apt/doc/apt-key.gpg
+    state: present
+  become: yes
+
+- name: add k8s repo
+  apt_repository:
+    repo: deb https://apt.kubernetes.io/ kubernetes-xenial main
+    state: present
+    filename: kubernetes.list
+  become: yes
+
+- name: add helm key
+  apt_key:
+    url: https://baltocdn.com/helm/signing.asc
+    state: present
+  become: yes
+
+- name: add helm repo
+  apt_repository:
+    repo: deb https://baltocdn.com/helm/stable/debian/ all main
+    state: present
+    filename: helm.list
+  become: yes
+
+- name: add terraform key
+  apt_key:
+    url: https://apt.releases.hashicorp.com/gpg
+    state: present
+  become: yes
+
+- name: add terraform repo
+  apt_repository:
+    repo: deb [arch=amd64] https://apt.releases.hashicorp.com bionic main
+    state: present
+    filename: terraform.list
+  become: yes
+
+- name: install terraform, kubectl and helm
+  apt:
+    name: "{{ k8sPackages }}"
+    state: present
+    update_cache: yes
+  become: yes
+

--- a/experimental/cloudstrapper/playbooks/roles/build-platform/tasks/magma-repo.yaml
+++ b/experimental/cloudstrapper/playbooks/roles/build-platform/tasks/magma-repo.yaml
@@ -1,0 +1,13 @@
+---
+
+- name: create magma directory
+  file:
+    path: "{{ dirSourceLocal }}"
+    state: directory
+
+- name: download github repo
+  git:
+    repo: "{{ buildMagmaRepo }}"
+    dest: "{{ dirSourceLocal }}"
+    version: "{{ buildMagmaVersion }}"
+

--- a/experimental/cloudstrapper/playbooks/roles/build-platform/tasks/main.yaml
+++ b/experimental/cloudstrapper/playbooks/roles/build-platform/tasks/main.yaml
@@ -1,0 +1,19 @@
+---
+
+- include: py-packages.yml
+  tags: py
+- include: build-tools-packages.yml
+  tags: tools
+- include: magma-repo.yaml
+  tags: setupMagma
+#TODO: Do we need to sleep here? Random failures which go away on a re-run
+- include: build-magma.yaml
+  tags: buildMagma
+- include: publish-magma.yaml
+  tags: pubMagma
+- include: publish-helm-v13.yaml
+  tags: helm
+  when: buildMagmaVersion == "v1.3"
+- include: publish-helm-v14.yaml
+  tags: helm
+  when: buildMagmaVersion == "v1.4"

--- a/experimental/cloudstrapper/playbooks/roles/build-platform/tasks/publish-helm-v13.yaml
+++ b/experimental/cloudstrapper/playbooks/roles/build-platform/tasks/publish-helm-v13.yaml
@@ -1,0 +1,22 @@
+---
+
+#TODO: presumes magma-helm directory is available on github
+#
+
+- name: clear existing directories
+  file: 
+    path: "{{ magmaHelmDir }}"
+    state: absent
+
+- name: create new chart directory
+  file: 
+    path: "{{ magmaHelmDir }}"
+    state: directory
+    mode: '0755'
+
+- name: publish helm charts
+  script: "roles/build-platform/files/helm-publish.bash {{ gitUser }} {{ gitPat }} {{ buildHelmRepo }} {{ dirSourceLocal }}"
+
+- name: verify helm charts
+  script: "roles/build-platform/files/helm-verify.bash {{ gitUser }} {{ gitPat }} {{ buildHelmRepo }}" 
+

--- a/experimental/cloudstrapper/playbooks/roles/build-platform/tasks/publish-helm-v14.yaml
+++ b/experimental/cloudstrapper/playbooks/roles/build-platform/tasks/publish-helm-v14.yaml
@@ -1,0 +1,13 @@
+---
+
+#TODO: presumes helm14 directory is available on github. use gh to check and create
+#
+
+- name: publish helm charts
+  command: "/usr/bin/bash package.sh -d {{ buildDeploymentType }} "
+  args:
+    chdir: "{{ buildPackageDir }}"
+
+- name: verify helm charts
+  script: "roles/build-platform/files/helm-verify.bash {{ gitUser }} {{ gitPat }} {{ buildHelmRepo }}" 
+

--- a/experimental/cloudstrapper/playbooks/roles/build-platform/tasks/publish-helm.yaml
+++ b/experimental/cloudstrapper/playbooks/roles/build-platform/tasks/publish-helm.yaml
@@ -1,0 +1,13 @@
+---
+
+#TODO: presumes magma-helm directory is available on github
+#
+
+- name: publish helm charts
+  command: "/usr/bin/bash package.sh -d {{ magmaDeploymentType }} "
+  args:
+    chdir: "{{ magmaPackageDir }}"
+
+- name: verify helm charts
+  script: "roles/build-service/files/helm-verify.bash {{ gitUser }} {{ gitPat }} {{ gitHelmRepo }}" 
+

--- a/experimental/cloudstrapper/playbooks/roles/build-platform/tasks/publish-magma.yaml
+++ b/experimental/cloudstrapper/playbooks/roles/build-platform/tasks/publish-magma.yaml
@@ -1,0 +1,41 @@
+---
+
+- name: install docker-py
+  command: "{{ dirShim }}/pip3 install pip install docker-py"
+  tags: tryMagma
+
+- name: login to docker
+  docker_login:
+    username: "{{ dockerUser }}"
+    password: "{{ dockerPassword }}"
+  tags: pushMagma
+
+- name: add tag to local image
+  docker_image:
+    name: "orc8r_{{ item }}:{{ buildDockerLabel }}"
+    repository: "{{ dockerUser }}/{{ item }}:{{ buildOrc8rLabel }}" 
+    force_tag: yes
+    source: local
+  tags: tryMagma
+  with_items:
+    - controller
+    - nginx
+
+- name: add tag to local image
+  docker_image:
+    name: "{{ item }}_{{ item }}:{{ buildDockerLabel }}"
+    repository: "{{ dockerUser }}/{{ item }}:{{ buildOrc8rLabel }}"
+    force_tag: yes
+    source: local
+  tags: tryMagma 
+  with_items:
+    - magmalte
+
+- name: push all images
+  command: docker push "{{ dockerUser }}/{{ item }}:{{ buildOrc8rLabel }}"
+  with_items:
+    - controller
+    - nginx
+    - magmalte
+  tags: pushMagma
+

--- a/experimental/cloudstrapper/playbooks/roles/build-platform/tasks/py-packages.yml
+++ b/experimental/cloudstrapper/playbooks/roles/build-platform/tasks/py-packages.yml
@@ -1,0 +1,45 @@
+---
+
+- name: install pyenv dependencies
+  apt:
+    name: "{{ pyenvDeps }}"
+    state: present
+    update_cache: yes
+  become: yes
+
+- name: download pyenv
+  get_url:
+    url: https://pyenv.run
+    dest: "{{ binPyenv }}"
+
+- name: remove pyenv
+  file:
+    path: "{{ usrHome }}/.pyenv"
+    state: absent
+
+- name: install pyenv
+  command: /usr/bin/bash "{{ binPyenv }}"
+
+- name: update bash profile
+  lineinfile:
+    path: "{{ usrProfile }}"
+    regexp: '^if command -v pyenv 1'
+    line: "{{ item }}"
+  with_items:
+    - "export PATH={{ usrHome }}/.pyenv/bin:$PATH"
+    - 'if command -v pyenv 1>/dev/null 2>&1; then  eval "$(pyenv init -)"; fi'
+
+- name: Source bash profile.
+  shell: . "{{ usrProfile }}"
+
+- name: install and apply pyenv
+  command: "{{ item }}"
+  with_items:
+    - "{{ usrHome }}/.pyenv/bin/pyenv install {{ pyenvVersion }}"
+    - "{{ usrHome }}/.pyenv/bin/pyenv global {{ pyenvVersion }}"
+  
+- name: install pip packages
+  pip:
+    name: "{{ item }}"
+  loop: "{{ pipPackages }}"
+

--- a/experimental/cloudstrapper/playbooks/roles/build-platform/vars/main.yaml
+++ b/experimental/cloudstrapper/playbooks/roles/build-platform/vars/main.yaml
@@ -1,0 +1,59 @@
+---
+
+allDeps: 
+  - apt-transport-https 
+  - ca-certificates
+  - curl 
+  - gnupg-agent 
+  - software-properties-common
+  - gnupg2 
+dockerPackages:
+  - docker-ce
+  - docker-ce-cli
+  - containerd.io
+  - python3-docker
+pyenvDeps:
+  - build-essential 
+  - libssl-dev
+  - zlib1g-dev
+  - libbz2-dev
+  - libreadline-dev
+  - libsqlite3-dev
+  - wget
+  - curl
+  - llvm
+  - libncurses5-dev
+  - libncursesw5-dev
+  - xz-utils 
+  - tk-dev
+  - libffi-dev
+  - liblzma-dev
+  - python-openssl
+  - git
+  - python3-pip
+  - awscli
+pipPackages:
+  - ansible
+  - fabric3
+  - jsonpickle
+  - requests
+  - PyYAML
+  - boto3
+k8sPackages:
+  - kubectl
+  - helm
+  - terraform
+
+usrName: ubuntu
+usrHome: "{{ dirHome }}"
+usrProfile: "{{ dirHome }}/.bashrc"
+binPyenv: "{{ dirHome }}/pyenv.run"
+pyenvVersion: 3.7.3
+magmaRootDir: "{{ dirExpHome }}/magma"
+magmaBuildDir: "{{ magmaRootDir }}/orc8r/cloud/docker"
+magmaNmsDir: "{{ magmaRootDir }}/nms/app/packages/magmalte"
+magmaPublishTag: latest
+dirShim: "{{ usrHome }}/.pyenv/shims/"
+usrProfile: "{{ dirHome }}/.profile"
+buildDockerLabel: latest
+magmaHelmDir: ~/magma-charts

--- a/experimental/cloudstrapper/playbooks/roles/cfn/cfnMagmaAgwAmiBuild.json
+++ b/experimental/cloudstrapper/playbooks/roles/cfn/cfnMagmaAgwAmiBuild.json
@@ -1,0 +1,49 @@
+{
+    "AWSTemplateFormatVersion": "2010-09-09",
+    "Parameters": {
+      "paramImageId": {
+        "Type": "AWS::EC2::Image::Id",
+	"Default": "ami-0a91cd140a1fc148a",
+	"Description": "Base image for Build instance"
+      },
+      "paramSecGroup": {
+        "Type": "AWS::EC2::SecurityGroup::Id",
+	"Default": "sg-09eb50f05d956bee9",
+	"Description": "Primary Security Group"
+      },
+      "paramAvlZone": {
+        "Type": "AWS::EC2::AvailabilityZone::Name",
+	"Default": "us-east-2a",
+	"Description": "Primary Region"
+      },
+      "paramKeyHost": {
+        "Type": "AWS::EC2::KeyPair::KeyName",
+	"Default": "keyMagmaHostProto",
+	"Description": "Host key for instance"
+      },
+      "paramInstanceType": {
+        "Type":"String",
+        "Default": "t2.xlarge",
+	"Description": "Instance type required to do a full Magma Build"
+      },
+      "paramTagName": {
+        "Type": "String",
+	"Default": "ec2MagmaBuild",
+	"Description": "Searchable Tag For Build instance"
+      }
+    },
+    "Resources": {
+        "Builder": {
+            "Type": "AWS::EC2::Instance",
+            "Properties": {
+                "ImageId": { "Ref": "paramImageId" },
+		"AvailabilityZone": { "Ref": "paramAvlZone" },
+                "InstanceType": { "Ref" : "paramInstanceType" },
+                "KeyName": { "Ref" : "paramKeyHost" },
+                "SecurityGroupIds": [ {"Ref" : "paramSecGroup"} ],
+                "Tags": [ {"Key": "Name", "Value": {"Ref": "paramTagName"} }, 
+			  {"Key": "Purpose","Value":"To run Magma in a Box"} ]
+            }
+        }
+    }
+}

--- a/experimental/cloudstrapper/playbooks/roles/cfn/cfnMagmaAgwNicAttach.json
+++ b/experimental/cloudstrapper/playbooks/roles/cfn/cfnMagmaAgwNicAttach.json
@@ -1,0 +1,41 @@
+{
+    "AWSTemplateFormatVersion": "2010-09-09",
+    "Parameters": {
+      "paramGatewayInstance": {
+        "Type": "String",
+	"Description": "Public IP-only AGW instance"
+      },
+      "paramSubnetEnb": {
+        "Type": "String",
+	"Description": "Subnet for new NIC"
+      },
+      "paramNicTagName": {
+        "Type": "String",
+	"Description": "Tagname for NIC"
+      },
+      "paramSgSgi": {
+        "Type": "String",
+	"Description": "Security Group for NIC"
+      }
+    },
+    "Resources": {
+      "nicEnb": {
+        "Type" : "AWS::EC2::NetworkInterface",
+        "Properties" : {
+          "Tags": [{"Key":"Name","Value": { "Ref" : "paramNicTagName" }}],
+          "Description": "S1 NIC for AGW - Connects to eNB",
+          "SourceDestCheck": "false",
+          "GroupSet": [{ "Ref": "paramSgSgi"}],
+          "SubnetId": { "Ref" : "paramSubnetEnb" }
+       }
+     },
+	"Nic2": {
+	  "Type" : "AWS::EC2::NetworkInterfaceAttachment",
+          "Properties" : {
+             "InstanceId" : {"Ref" : "paramGatewayInstance"},
+             "NetworkInterfaceId" : {"Ref" : "nicEnb"},
+             "DeviceIndex" : "1"
+          }
+	}
+    }
+}

--- a/experimental/cloudstrapper/playbooks/roles/cfn/cfnMagmaAgwPrivate.json
+++ b/experimental/cloudstrapper/playbooks/roles/cfn/cfnMagmaAgwPrivate.json
@@ -1,0 +1,59 @@
+{
+    "AWSTemplateFormatVersion": "2010-09-09",
+    "Parameters": {
+      "paramImageBase": {
+        "Type": "AWS::EC2::Image::Id",
+	"Description": "Base Image Id",
+	"Default": "ami-0a91cd140a1fc148a"
+      },
+      "paramSubnetSgi": {
+        "Type": "String",
+	"Description": "SGi Subnet",
+	"Default": "subnet-0203ca4c94d36bbf1"
+      },
+      "paramAzHome": {
+        "Type": "AWS::EC2::AvailabilityZone::Name",
+	"Description": "Base Availability Zone",
+	"Default": "us-east-2c"
+      },
+      "paramSecGroup": {
+        "Type": "String",
+	"Description": "Security Group Name",
+	"Default":"sg-070fa87221a1bc6fb"
+      },
+      "paramSshKey": {
+        "Type": "AWS::EC2::KeyPair::KeyName",
+	"Description": "Keypair",
+	"Default": "keyMagmaAnsibleProto"
+      },
+      "paramAgwTagName": {
+        "Type": "String",
+	"Description": "Tag Name",
+	"Default":"MenloPark AGW 1"
+      }
+    },
+    "Resources": {
+        "GatewayA": {
+            "Type": "AWS::EC2::Instance",
+            "Properties": {
+                "ImageId": { "Ref": "paramImageBase" },
+                "InstanceType": "t2.medium",
+                "KeyName": { "Ref": "paramSshKey" },
+		"AvailabilityZone":{ "Ref": "paramAzHome" },
+		"NetworkInterfaces": [
+		  {
+		    "DeleteOnTermination": "true",
+		    "Description": "SGi interface",
+		    "DeviceIndex": "0",
+		    "GroupSet": [ { "Ref": "paramSecGroup" } ],
+		    "SubnetId":{ "Ref": "paramSubnetSgi" }
+		   }
+                ],	
+		"Tags": [ 
+			{ "Key": "Name", "Value": { "Ref": "paramAgwTagName"} },
+			{ "Key": "Purpose","Value":"EC2 instance of AGW" }
+			]
+            }
+        }
+    }
+}

--- a/experimental/cloudstrapper/playbooks/roles/cfn/cfnMagmaAgwPublic.json
+++ b/experimental/cloudstrapper/playbooks/roles/cfn/cfnMagmaAgwPublic.json
@@ -1,0 +1,60 @@
+{
+    "AWSTemplateFormatVersion": "2010-09-09",
+    "Parameters": {
+      "paramImageBase": {
+        "Type": "AWS::EC2::Image::Id",
+	"Description": "Base Image Id",
+	"Default": "ami-0a91cd140a1fc148a"
+      },
+      "paramSubnetSgi": {
+        "Type": "String",
+	"Description": "SGi Subnet",
+	"Default": "subnet-0203ca4c94d36bbf1"
+      },
+      "paramAzHome": {
+        "Type": "AWS::EC2::AvailabilityZone::Name",
+	"Description": "Base Availability Zone",
+	"Default": "us-east-2c"
+      },
+      "paramSecGroup": {
+        "Type": "String",
+	"Description": "Security Group Name",
+	"Default":"sg-070fa87221a1bc6fb"
+      },
+      "paramSshKey": {
+        "Type": "AWS::EC2::KeyPair::KeyName",
+	"Description": "Keypair",
+	"Default": "keyMagmaAnsibleProto"
+      },
+      "paramAgwTagName": {
+        "Type": "String",
+	"Description": "Tag Name",
+	"Default":"MenloPark AGW 1"
+      }
+    },
+    "Resources": {
+        "GatewayA": {
+            "Type": "AWS::EC2::Instance",
+            "Properties": {
+                "ImageId": { "Ref": "paramImageBase" },
+                "InstanceType": "t2.medium",
+                "KeyName": { "Ref": "paramSshKey" },
+		"AvailabilityZone":{ "Ref": "paramAzHome" },
+		"NetworkInterfaces": [
+		  {
+                    "AssociatePublicIpAddress" : "true",  
+		    "DeleteOnTermination": "true",
+		    "Description": "SGi interface",
+		    "DeviceIndex": "0",
+		    "GroupSet": [ { "Ref": "paramSecGroup" } ],
+		    "SubnetId":{ "Ref": "paramSubnetSgi" }
+		   }
+                ],	
+		"Tags": [ 
+			{ "Key": "Name", "Value": { "Ref": "paramAgwTagName"} },
+			{ "Key": "Purpose","Value":"EC2 instance of AGW" }
+			]
+            }
+        }
+    }
+}

--- a/experimental/cloudstrapper/playbooks/roles/cfn/cfnMagmaBootstrap.json
+++ b/experimental/cloudstrapper/playbooks/roles/cfn/cfnMagmaBootstrap.json
@@ -1,0 +1,46 @@
+{
+    "AWSTemplateFormatVersion": "2010-09-09",
+    "Parameters": {
+      "paramImageId" : {
+        "Type": "AWS::EC2::Image::Id",
+	"Default": "ami-0a91cd140a1fc148a",
+	"Description": "Base image for Bootstrap: Ubuntu Focal"
+      },
+      "paramKeyName" : {
+        "Type": "String",
+	"Default": "keyMagmaBootProto",
+	"Description": "Bootstrap key"
+      },
+      "paramSecGroup" : {
+        "Type": "AWS::EC2::SecurityGroup::Id",
+	"Default": "sg-0c290ac2a7d8189b7",
+	"Description": "Bootstrap Security Group"
+      },
+      "paramTagName" : {
+        "Type": "String",
+	"Default": "ec2MagmaDevOpsBootstrap",
+	"Description": "Bootstrap Devops Node"
+      },
+      "paramTagId": {
+        "Type": "String",
+	"Default": "SanRamon",
+	"Description": "Cluster Identifier"
+      }
+    },
+    "Resources": {
+        "Bootstrapper": {
+            "Type": "AWS::EC2::Instance",
+            "Properties": {
+                "ImageId": { "Ref": "paramImageId" },
+                "InstanceType": "t2.micro",
+                "SecurityGroupIds": [ { "Ref": "paramSecGroup" }],
+                "KeyName": { "Ref": "paramKeyName" },
+                "Tags": [ 
+			{"Key": "Name", "Value": { "Ref": "paramTagName" } }, 
+			{"Key": "Purpose","Value":"DevOps Bootstrapper node to create a MagmaBootstrap image"},
+			{"Key": "ClusterId","Value": { "Ref": "paramTagId" }}
+	       	]
+            }
+        }
+    }
+}

--- a/experimental/cloudstrapper/playbooks/roles/cfn/cfnMagmaBuild.json
+++ b/experimental/cloudstrapper/playbooks/roles/cfn/cfnMagmaBuild.json
@@ -1,0 +1,60 @@
+{
+    "AWSTemplateFormatVersion": "2010-09-09",
+    "Parameters": {
+      "paramImageId": {
+        "Type": "AWS::EC2::Image::Id",
+	"Default": "ami-0a91cd140a1fc148a",
+	"Description": "Base image for Build instance"
+      },
+      "paramSecGroup": {
+        "Type": "AWS::EC2::SecurityGroup::Id",
+	"Default": "sg-09eb50f05d956bee9",
+	"Description": "Primary Security Group"
+      },
+      "paramAvlZone": {
+        "Type": "AWS::EC2::AvailabilityZone::Name",
+	"Default": "us-east-2a",
+	"Description": "Primary Region"
+      },
+      "paramKeyHost": {
+        "Type": "AWS::EC2::KeyPair::KeyName",
+	"Default": "keyMagmaHostProto",
+	"Description": "Host key for instance"
+      },
+      "paramInstanceType": {
+        "Type":"String",
+        "Default": "t2.xlarge",
+	"Description": "Instance type required to do a full Magma Build"
+      },
+      "paramTagName": {
+        "Type": "String",
+	"Default": "ec2MagmaBuild",
+	"Description": "Searchable Tag For Build instance"
+      }
+    },
+    "Resources": {
+        "Builder": {
+            "Type": "AWS::EC2::Instance",
+            "Properties": {
+                "ImageId": { "Ref": "paramImageId" },
+		"AvailabilityZone": { "Ref": "paramAvlZone" },
+                "InstanceType": { "Ref" : "paramInstanceType" },
+                "KeyName": { "Ref" : "paramKeyHost" },
+                "SecurityGroupIds": [ {"Ref" : "paramSecGroup"} ],
+		"BlockDeviceMappings": [
+          				{
+            				"DeviceName": "/dev/sda1", 
+					"Ebs": {
+              					"VolumeType": "gp2",
+              					"VolumeSize": "64",
+              					"DeleteOnTermination":"false",
+              					"Encrypted": "true" 
+						} 
+					}
+        	], 
+                "Tags": [ {"Key": "Name", "Value": {"Ref": "paramTagName"} }, 
+			  {"Key": "Purpose","Value":"To run Magma in a Box"} ]
+            }
+        }
+    }
+}

--- a/experimental/cloudstrapper/playbooks/roles/cfn/cfnMagmaEdgeNetPublic.json
+++ b/experimental/cloudstrapper/playbooks/roles/cfn/cfnMagmaEdgeNetPublic.json
@@ -1,0 +1,139 @@
+{
+  "Parameters": {
+    "paramCidr" : {
+      "Type": "String",
+      "Default": "10.0.0.0/16",
+      "Description": "CIDR for Edge network to host SGi and S1 networks"
+    },
+    "paramSgiCidr" : {
+      "Type": "String",
+      "Default": "10.0.4.0/24",
+      "Description": "CIDR for SGi subnet"
+    },
+    "paramEnbCidr" : {
+      "Type": "String",
+      "Default": "10.0.2.0/24",
+      "Description": "CIDR for S1 subnet"
+    },
+    "paramAvlZone" : {
+      "Type": "AWS::EC2::AvailabilityZone::Name",
+      "Default": "us-east-2c",
+      "Description": "Availability Zone"
+    },
+    "paramVpcTagName" : {
+      "Type": "String",
+      "Default": "SGi VPC",
+      "Description": "Tag Name for VPC"
+    },
+    "paramSgiSubnetTagName" : {
+      "Type": "String",
+      "Default": "SGi Subnet",
+      "Description": "Tag Name for SGi Subnet"
+    },
+    "paramEnodebSubnetTagName" : {
+      "Type": "String",
+      "Default": "S1 Subnet",
+      "Description": "Tag Name for eNodeB Subnet"
+    },
+    "paramRouteTableTagName" : {
+      "Type": "String",
+      "Default": "Route Table for SGi Subnet",
+      "Description": "Tag Name for SGi Route Table"
+    },
+    "paramSecGroupName" : {
+      "Type": "String",
+      "Default": "secGroupMagma",
+      "Description": "Security Group Name"
+    },
+    "paramGwTagName" : {
+      "Type": "String",
+      "Default": "SGi Internet Gateway",
+      "Description": "Tag Name for Internet Gateway"
+    }
+  },
+  "Resources": {
+    "vpcSgi": {
+      "Type" : "AWS::EC2::VPC",
+        "Properties" : {
+          "CidrBlock" : { "Ref": "paramCidr" },
+      	  "EnableDnsHostnames" : "true",
+      	  "EnableDnsSupport" : "true",
+      	  "InstanceTenancy" : "default",
+      	  "Tags" : [ {"Key": "Name", "Value": { "Ref" : "paramVpcTagName"}}, {"Key": "Purpose", "Value": "SGi Gateway Proto"} ]
+    	}
+    },
+    "netGwSgi" : {
+      "Type" : "AWS::EC2::InternetGateway",
+        "Properties" : {
+          "Tags" : [ {"Key" : "Name", "Value" : { "Ref" : "paramGwTagName"}} ]
+        }
+     },
+     "gWAttach" : {
+       "Type" : "AWS::EC2::VPCGatewayAttachment",
+         "Properties" : {
+           "VpcId" : { "Ref" : "vpcSgi" },
+           "InternetGatewayId" : { "Ref" : "netGwSgi" }
+         }
+    },
+    "subEnb" : {
+     "Type" : "AWS::EC2::Subnet",
+     "Properties" : {
+       "VpcId" : {  "Ref": "vpcSgi" },
+       "CidrBlock" : { "Ref": "paramEnbCidr" },
+       "AvailabilityZone" : { "Ref": "paramAvlZone" },
+       "Tags" : [ { "Key" : "Name", "Value" : { "Ref": "paramEnodebSubnetTagName" }} ]
+     }
+    },
+    "subSgi" : {
+     "Type" : "AWS::EC2::Subnet",
+     "Properties" : {
+       "VpcId" : { "Ref" : "vpcSgi" },
+       "CidrBlock" : { "Ref": "paramSgiCidr" },
+       "AvailabilityZone" : { "Ref": "paramAvlZone" },
+       "Tags" : [ { "Key" : "Name", "Value" : { "Ref": "paramSgiSubnetTagName" }} ]
+      }
+    },
+    "rttGwSgi" : {
+      "Type" : "AWS::EC2::RouteTable",
+      "Properties" : {
+        "VpcId" : { "Ref" : "vpcSgi" },
+        "Tags" : [ { "Key" : "Name", "Value" : "Route Table for Internet Traffic" } ]
+       }
+    },
+    "rtGwSgi" : {
+      "Type" : "AWS::EC2::Route",
+      "Properties" : {
+        "RouteTableId" : { "Ref" : "rttGwSgi" },
+        "DestinationCidrBlock" : "0.0.0.0/0",
+        "GatewayId" : { "Ref" : "netGwSgi" }
+       }
+    },
+    "rtAssocSubnet" : {
+      "Type" : "AWS::EC2::SubnetRouteTableAssociation",
+      "Properties" : {
+        "SubnetId" : { "Ref" : "subSgi" },
+        "RouteTableId" : { "Ref" : "rttGwSgi" }
+       }
+    },
+    "sgSgi": {
+      "Type" : "AWS::EC2::SecurityGroup",
+      "Properties" : {
+        "GroupDescription" : "Allow all TCP to client host",
+	"GroupName": { "Ref": "paramSecGroupName" },
+        "VpcId" : {"Ref" : "vpcSgi"},
+        "SecurityGroupIngress" : [{
+          "IpProtocol" : "-1",
+          "FromPort" : 0,
+          "ToPort" : 65535,
+          "CidrIp" : "0.0.0.0/0"
+        }],
+        "SecurityGroupEgress" : [{
+          "IpProtocol" : "-1",
+          "FromPort" : 0,
+          "ToPort" : 65535,
+          "CidrIp" : "0.0.0.0/0"
+        }]
+      }
+    }
+  }
+}

--- a/experimental/cloudstrapper/playbooks/roles/cfn/cfnMagmaEnodebPublic.json
+++ b/experimental/cloudstrapper/playbooks/roles/cfn/cfnMagmaEnodebPublic.json
@@ -1,0 +1,60 @@
+{
+    "AWSTemplateFormatVersion": "2010-09-09",
+    "Parameters": {
+      "paramImageBase": {
+        "Type": "AWS::EC2::Image::Id",
+	"Description": "Base Image Id",
+	"Default": "ami-0a91cd140a1fc148a"
+      },
+      "paramSubnetSgi": {
+        "Type": "String",
+	"Description": "SGi Subnet",
+	"Default": "subnet-0203ca4c94d36bbf1"
+      },
+      "paramAzHome": {
+        "Type": "AWS::EC2::AvailabilityZone::Name",
+	"Description": "Base Availability Zone",
+	"Default": "us-east-2c"
+      },
+      "paramSecGroup": {
+        "Type": "String",
+	"Description": "Security Group Name",
+	"Default":"sg-070fa87221a1bc6fb"
+      },
+      "paramSshKey": {
+        "Type": "AWS::EC2::KeyPair::KeyName",
+	"Description": "Keypair",
+	"Default": "keyMagmaAnsibleProto"
+      },
+      "paramAgwTagName": {
+        "Type": "String",
+	"Description": "Tag Name",
+	"Default":"MenloPark AGW 1"
+      }
+    },
+    "Resources": {
+        "GatewayA": {
+            "Type": "AWS::EC2::Instance",
+            "Properties": {
+                "ImageId": { "Ref": "paramImageBase" },
+                "InstanceType": "t2.micro",
+                "KeyName": { "Ref": "paramSshKey" },
+		"AvailabilityZone":{ "Ref": "paramAzHome" },
+		"NetworkInterfaces": [
+		  {
+                    "AssociatePublicIpAddress" : "true",  
+		    "DeleteOnTermination": "true",
+		    "Description": "SGi interface",
+		    "DeviceIndex": "0",
+		    "GroupSet": [ { "Ref": "paramSecGroup" } ],
+		    "SubnetId":{ "Ref": "paramSubnetSgi" }
+		   }
+                ],	
+		"Tags": [ 
+			{ "Key": "Name", "Value": { "Ref": "paramAgwTagName"} },
+			{ "Key": "Purpose","Value":"EC2 instance of AGW" }
+			]
+            }
+        }
+    }
+}

--- a/experimental/cloudstrapper/playbooks/roles/cfn/cfnMagmaEssentials.json
+++ b/experimental/cloudstrapper/playbooks/roles/cfn/cfnMagmaEssentials.json
@@ -1,0 +1,47 @@
+{
+  "Parameters": {
+    "paramVpcDefault": {
+      "Type": "AWS::EC2::VPC::Id",
+      "Default": "vpc-ecc63687",
+      "Description": "The VPC ID of the Default Subnet that hosts Bootstrapper"
+    },    
+    "paramSecgroupMagmaDefault": {
+      "Type": "String",
+      "Default": "secgroupMagmaProto",
+      "Description": "The base security group - SSH access only "
+    },    
+    "paramBucketMagmaDefault": {
+      "Type": "String",
+      "Default": "bucket-magma-proto",
+      "Description": "The default bucket used to host shareable artifacts"
+    }    
+  },
+  "Resources": {
+    "magmaS3Bucket": {
+      "Type": "AWS::S3::Bucket",
+      "Properties": {
+        "BucketName": { "Ref" : "paramBucketMagmaDefault" }
+      }
+    },
+    "magmaSecGroup": {
+      "Type" : "AWS::EC2::SecurityGroup",
+      "Properties" : {
+        "GroupDescription" : "Allow ssh to client host",
+        "GroupName" : { "Ref" : "paramSecgroupMagmaDefault" },
+        "VpcId" : { "Ref" : "paramVpcDefault" },
+        "SecurityGroupIngress" : [{
+         "IpProtocol" : "tcp",
+         "FromPort" :22 ,
+         "ToPort" : 22,
+         "CidrIp" : "0.0.0.0/0"
+        }],
+        "SecurityGroupEgress" : [{
+         "IpProtocol" : "tcp",
+         "FromPort" : 0,
+         "ToPort" : 65535,
+         "CidrIp" : "0.0.0.0/0"
+         }]
+        }
+     }
+   }
+}

--- a/experimental/cloudstrapper/playbooks/roles/cfn/paramCfnMagmaAgwNicAttachMenloPark.json
+++ b/experimental/cloudstrapper/playbooks/roles/cfn/paramCfnMagmaAgwNicAttachMenloPark.json
@@ -1,0 +1,18 @@
+[
+  {
+    "ParameterKey":"paramGatewayInstance",
+    "ParameterValue": "i-03761bc149fea1d0d"
+  }, 
+  {
+    "ParameterKey":"paramNicTagName",
+    "ParameterValue": "MenloParkAgwDebNic2  "
+  }, 
+  {
+    "ParameterKey":"paramSgSgi",
+    "ParameterValue": "sg-006e465a1fe96dcbe"
+  }, 
+  {
+    "ParameterKey":"paramSubnetEnb",
+    "ParameterValue": "subnet-04148600b79378ad9"
+  }
+]

--- a/experimental/cloudstrapper/playbooks/roles/cfn/paramCfnMagmaAgwNicAttachSanRamon.json
+++ b/experimental/cloudstrapper/playbooks/roles/cfn/paramCfnMagmaAgwNicAttachSanRamon.json
@@ -1,0 +1,10 @@
+[
+  {
+    "ParameterKey":"paramGatewayInstance",
+    "ParameterValue": "i-03cfa4016b239d197"
+  }, 
+  {
+    "ParameterKey":"paramNicEnb",
+    "ParameterValue": "eni-0855b8d7d4ecb9ba4"
+  }
+]

--- a/experimental/cloudstrapper/playbooks/roles/cfn/paramCfnMagmaAgwPublicMenloPark.json
+++ b/experimental/cloudstrapper/playbooks/roles/cfn/paramCfnMagmaAgwPublicMenloPark.json
@@ -1,0 +1,26 @@
+[
+  {
+    "ParameterKey":"paramImageBase",
+    "ParameterValue": "ami-0c305b7817e9fd559"
+  }, 
+  {
+    "ParameterKey":"paramSecGroup",
+    "ParameterValue": "sg-006e465a1fe96dcbe"
+  }, 
+  {
+    "ParameterKey":"paramAgwTagName",
+    "ParameterValue": "MenloParkAgwU"
+  }, 
+  {
+    "ParameterKey":"paramSshKey",
+    "ParameterValue": "keyMagmaHostProto"
+  }, 
+  {
+    "ParameterKey":"paramSubnetSgi",
+    "ParameterValue": "subnet-01016b8d42a14e83e"
+  }, 
+  {
+    "ParameterKey":"paramAzHome",
+    "ParameterValue": "us-east-2c"
+  } 
+]

--- a/experimental/cloudstrapper/playbooks/roles/cfn/paramCfnMagmaAgwPublicSanRamon.json
+++ b/experimental/cloudstrapper/playbooks/roles/cfn/paramCfnMagmaAgwPublicSanRamon.json
@@ -1,0 +1,26 @@
+[
+  {
+    "ParameterKey":"paramImageBase",
+    "ParameterValue": "ami-0c305b7817e9fd559"
+  }, 
+  {
+    "ParameterKey":"paramSecGroup",
+    "ParameterValue": "sg-0f63cf61d234bca69"
+  }, 
+  {
+    "ParameterKey":"paramAgwTagName",
+    "ParameterValue": "MenloParkAgwA"
+  }, 
+  {
+    "ParameterKey":"paramSshKey",
+    "ParameterValue": "keyMagmaHostProto"
+  }, 
+  {
+    "ParameterKey":"paramSubnetSgi",
+    "ParameterValue": "subnet-0f4d357ab0b4a4119"
+  }, 
+  {
+    "ParameterKey":"paramAzHome",
+    "ParameterValue": "us-east-2c"
+  } 
+]

--- a/experimental/cloudstrapper/playbooks/roles/cfn/paramCfnMagmaBootstrap.json
+++ b/experimental/cloudstrapper/playbooks/roles/cfn/paramCfnMagmaBootstrap.json
@@ -1,0 +1,18 @@
+[
+  {
+    "ParameterKey": "paramImageId",
+    "ParameterValue": "ami-0a91cd140a1fc148a"
+  },
+  {
+    "ParameterKey": "paramSecGroup",
+    "ParameterValue": "sg-0c290ac2a7d8189b7"
+  },
+  {
+    "ParameterKey": "paramKeyName",
+    "ParameterValue": "keyMagmaBootProto"
+  },
+  {
+    "ParameterKey": "paramTagId",
+    "ParameterValue": "SanRamon"
+  }
+]

--- a/experimental/cloudstrapper/playbooks/roles/cfn/paramCfnMagmaEdgeNetPublicMenloPark.json
+++ b/experimental/cloudstrapper/playbooks/roles/cfn/paramCfnMagmaEdgeNetPublicMenloPark.json
@@ -1,0 +1,42 @@
+[
+  {
+    "ParameterKey": "paramCidr",
+    "ParameterValue": "10.1.0.0/16"
+  },
+  {
+    "ParameterKey": "paramSgiCidr",
+    "ParameterValue": "10.1.4.0/24"
+  },
+  {
+    "ParameterKey": "paramEnbCidr",
+    "ParameterValue": "10.1.2.0/24"
+  },
+  {
+    "ParameterKey": "paramAvlZone",
+    "ParameterValue": "us-east-2c"
+  },
+  {
+    "ParameterKey": "paramSgiSubnetTagName",
+    "ParameterValue": "Menlo Park SGi Subnet "
+  },
+  {
+    "ParameterKey": "paramEnodebSubnetTagName",
+    "ParameterValue": "Menlo Park eNodeB Subnet "
+  },
+  {
+    "ParameterKey": "paramRouteTableTagName",
+    "ParameterValue": "Menlo Park Route Table "
+  },
+  {
+    "ParameterKey": "paramSecGroupName",
+    "ParameterValue": "Menlo Park Security Group "
+  },
+  {
+    "ParameterKey": "paramGwTagName",
+    "ParameterValue": "Menlo Park Internet Gateway "
+  },
+  {
+    "ParameterKey": "paramVpcTagName",
+    "ParameterValue": "Menlo Park VPC"
+  }
+]

--- a/experimental/cloudstrapper/playbooks/roles/cfn/paramCfnMagmaEdgeNetPublicSanRamon.json
+++ b/experimental/cloudstrapper/playbooks/roles/cfn/paramCfnMagmaEdgeNetPublicSanRamon.json
@@ -1,0 +1,42 @@
+[
+  {
+    "ParameterKey": "paramCidr",
+    "ParameterValue": "10.2.0.0/16"
+  },
+  {
+    "ParameterKey": "paramSgiCidr",
+    "ParameterValue": "10.2.4.0/24"
+  },
+  {
+    "ParameterKey": "paramEnbCidr",
+    "ParameterValue": "10.2.2.0/24"
+  },
+  {
+    "ParameterKey": "paramAvlZone",
+    "ParameterValue": "us-east-2c"
+  },
+  {
+    "ParameterKey": "paramSgiSubnetTagName",
+    "ParameterValue": "San Ramon SGi Subnet "
+  },
+  {
+    "ParameterKey": "paramEnodebSubnetTagName",
+    "ParameterValue": "San Ramon eNodeB Subnet "
+  },
+  {
+    "ParameterKey": "paramRouteTableTagName",
+    "ParameterValue": "San Ramon Route Table "
+  },
+  {
+    "ParameterKey": "paramSecGroupName",
+    "ParameterValue": "San Ramon Security Group "
+  },
+  {
+    "ParameterKey": "paramGwTagName",
+    "ParameterValue": "San Ramon Internet Gateway "
+  },
+  {
+    "ParameterKey": "paramVpcTagName",
+    "ParameterValue": "San Ramon VPC"
+  }
+]

--- a/experimental/cloudstrapper/playbooks/roles/cfn/paramCfnMagmaEssentials.json
+++ b/experimental/cloudstrapper/playbooks/roles/cfn/paramCfnMagmaEssentials.json
@@ -1,0 +1,14 @@
+[
+  {
+    "ParameterKey": "paramVpcDefault",
+    "ParameterValue": "vpc-ecc63687"
+  },
+  {
+    "ParameterKey": "paramSecgroupMagmaDefault",
+    "ParameterValue": "secgroupMagmaProto"
+  },
+  {
+    "ParameterKey": "paramBucketMagmaDefault",
+    "ParameterValue": "bucketMagmaProto"
+  }
+]

--- a/experimental/cloudstrapper/playbooks/roles/cloudstrapper-infra/tasks/main.yaml
+++ b/experimental/cloudstrapper/playbooks/roles/cloudstrapper-infra/tasks/main.yaml
@@ -1,0 +1,38 @@
+---
+#Find image info
+#Locate image id
+#Use as parameter to cloudformation template
+
+- name: find image info
+  ec2_ami_info:
+    filters:
+      "tag:Name": "{{ devOpsAmi }}"
+  register: valAmi
+
+- name: locate image id
+  set_fact:
+    factAmi: "{{ valAmi.images[0].image_id }}"
+
+- name: query all security groups
+  ec2_group_info:
+    filters:
+      group-name: "{{ secgroupDefault }}"
+  register: reg_secgroup
+
+- name: assign security group id to variable
+  set_fact:
+    factSecgroup: "{{ reg_secgroup.security_groups[0].group_id }}"
+
+- name: instantiate ec2 instance using cloudformation
+  cloudformation:
+    stack_name: "stackMantlePrimeBootstrap"
+    state: present
+    region: "{{ awsAgwRegion }}"
+    disable_rollback: true
+    template: "roles/cfn/cfnMagmaBootstrap.json"
+    template_parameters:
+      paramKeyName: "{{ keyBoot }}"
+      paramSecGroup: "{{ factSecgroup }}"
+      paramTagId: "MantlePrimeBoot"
+      paramTagName: "{{ primaryCloudstrapper }}"
+      paramImageId: "{{ factAmi }}"

--- a/experimental/cloudstrapper/playbooks/roles/control/files/self_sign_certs.sh
+++ b/experimental/cloudstrapper/playbooks/roles/control/files/self_sign_certs.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+
+# Copyright 2020 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# self_sign_certs.sh generates a set of keys and self-signed certificates.
+#
+# Generated secrets
+#   - rootCA.key, rootCA.pem -- certs for trusted root CA (rootCA.key is
+#     subsequently deleted)
+#   - controller.key, controller.crt -- certs for orc8r deployment's public
+#     domain name, signed by rootCA.key
+#
+# NOTE: extension naming for certs and keys is non-normalized here due to
+# expected naming conventions from other parts of the code. For reference,
+# all outputs are PEM-encoded, *.key is a private key, and *.crt and missing
+# indicator are both certificates.
+
+usage() {
+  echo "Usage: $0 DOMAIN_NAME"
+  exit 2
+}
+
+domain="$1"
+if [[ ${domain} == "" ]]; then
+    usage
+fi
+
+echo ""
+echo "################"
+echo "Creating root CA"
+echo "################"
+openssl genrsa -out rootCA.key 2048
+openssl req -x509 -new -nodes -key rootCA.key -sha256 -days 3650 -out rootCA.pem -subj "/C=US/CN=rootca.$domain"
+
+echo ""
+echo "########################"
+echo "Creating controller cert"
+echo "########################"
+openssl genrsa -out controller.key 2048
+openssl req -new -key controller.key -out controller.csr -subj "/C=US/CN=*.$domain"
+openssl x509 -req -in controller.csr -CA rootCA.pem -CAkey rootCA.key -CAcreateserial -out controller.crt -days 3650 -sha256
+
+echo ""
+echo "###########################"
+echo "Deleting intermediate files"
+echo "###########################"
+rm -f controller.csr rootCA.srl
+
+echo ""
+echo "####################"
+echo "Deleting root CA key"
+echo "####################"
+#rm -f rootCA.key

--- a/experimental/cloudstrapper/playbooks/roles/control/files/v1.3/orc8r-aws/eks.tf
+++ b/experimental/cloudstrapper/playbooks/roles/control/files/v1.3/orc8r-aws/eks.tf
@@ -1,0 +1,74 @@
+################################################################################
+# Copyright 2020 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+resource "tls_private_key" "eks_workers" {
+  count = var.eks_worker_group_key == null ? 1 : 0
+
+  algorithm = "RSA"
+}
+
+resource "aws_key_pair" "eks_workers" {
+  count = var.eks_worker_group_key == null ? 1 : 0
+
+  key_name_prefix = var.cluster_name
+  public_key      = tls_private_key.eks_workers[0].public_key_openssh
+}
+
+module "eks" {
+  source  = "terraform-aws-modules/eks/aws"
+  version = "~> 8.0"
+
+  cluster_name = var.cluster_name
+  cluster_version = "1.17"
+  vpc_id       = module.vpc.vpc_id
+  subnets      = length(module.vpc.private_subnets) > 0 ? module.vpc.private_subnets : module.vpc.public_subnets
+
+  cluster_enabled_log_types = [
+    "api",
+    "audit",
+    "authenticator",
+    "controllerManager",
+    "scheduler",
+  ]
+
+  workers_group_defaults = {
+    key_name = var.eks_worker_group_key == null ? aws_key_pair.eks_workers[0].key_name : var.eks_worker_group_key
+  }
+  worker_additional_security_group_ids = concat([aws_security_group.default.id], var.eks_worker_additional_sg_ids)
+  workers_additional_policies          = var.eks_worker_additional_policy_arns
+  worker_groups                        = var.eks_worker_groups
+
+  map_roles = var.eks_map_roles
+  map_users = var.eks_map_users
+
+  tags = var.global_tags
+}
+
+# role assume policy for eks workers
+data "aws_iam_policy_document" "eks_worker_assumable" {
+  statement {
+    principals {
+      identifiers = ["ec2.amazonaws.com"]
+      type        = "Service"
+    }
+    actions = ["sts:AssumeRole"]
+  }
+
+  statement {
+    principals {
+      identifiers = [module.eks.worker_iam_role_arn]
+      type        = "AWS"
+    }
+    actions = ["sts:AssumeRole"]
+  }
+}

--- a/experimental/cloudstrapper/playbooks/roles/control/files/v1.3/orc8r-aws/variables.tf
+++ b/experimental/cloudstrapper/playbooks/roles/control/files/v1.3/orc8r-aws/variables.tf
@@ -1,0 +1,345 @@
+################################################################################
+# Copyright 2020 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+variable "region" {
+  description = "AWS region to deploy Orchestrator components into. The chosen region must provide EKS."
+  type        = string
+}
+
+data "aws_availability_zones" "available" {}
+
+##############################################################################
+# Module flags
+##############################################################################
+
+variable "deploy_elasticsearch" {
+  description = "Flag to deploy AWS Elasticsearch service as the datasink for aggregated logs."
+  type        = bool
+  default     = false
+}
+
+variable "deploy_elasticsearch_service_linked_role" {
+  description = "Flag to deploy AWS Elasticsearch service linked role with cluster. If you've already created an ES service linked role for another cluster, you should set this to false."
+  type        = bool
+  default     = false
+}
+
+variable "global_tags" {
+  default = {}
+}
+##############################################################################
+# K8s configuration
+##############################################################################
+
+variable "orc8r_domain_name" {
+  description = "Base domain name for AWS Route 53 hosted zone."
+  type        = string
+}
+
+##############################################################################
+# K8s configuration
+##############################################################################
+
+variable "cluster_name" {
+  description = "Name for the Orchestrator EKS cluster."
+  type        = string
+  default     = "orc8r"
+}
+
+variable "eks_worker_group_key" {
+  description = "If specified, the worker nodes for EKS will use this EC2 keypair."
+  type        = string
+  default     = null
+}
+
+variable "eks_worker_additional_sg_ids" {
+  description = "Additional security group IDs to attach to EKS worker nodes."
+  type        = list(string)
+  default     = []
+}
+
+variable "eks_worker_additional_policy_arns" {
+  description = "Additional IAM policy ARNs to attach to EKS worker nodes."
+  type        = list(string)
+  default     = []
+}
+
+variable "eks_worker_groups" {
+  # Check the docs at https://github.com/terraform-aws-modules/terraform-aws-eks
+  # for the complete set of valid properties for these objects.
+  description = "Worker group configuration for EKS. Default value is 1 worker group consisting of 3 t3.large instances."
+  type        = any
+  default = [
+    {
+      name                 = "wg-1"
+      instance_type        = "t3.large"
+      asg_desired_capacity = 3
+      asg_min_size         = 1
+      asg_max_size         = 3
+      autoscaling_enabled  = false
+    },
+  ]
+}
+
+variable "eks_map_roles" {
+  description = "EKS IAM role mapping. Note that by default, the creator of the cluster will be in the system:master group."
+  type = list(
+    object({
+      rolearn  = string,
+      username = string,
+      groups   = list(string),
+    })
+  )
+  default = []
+}
+
+variable "eks_map_users" {
+  description = "Additional IAM users to add to the aws-auth ConfigMap."
+  type = list(object({
+    userarn  = string
+    username = string
+    groups   = list(string)
+  }))
+  default = []
+}
+
+##############################################################################
+# EFS configuration
+##############################################################################
+
+variable "efs_project_name" {
+  description = "Project name for EFS file system"
+  type        = string
+  default     = "orc8r"
+}
+
+##############################################################################
+# VPC configuration
+##############################################################################
+
+# TODO: support an existing VPC
+
+variable "vpc_name" {
+  description = "Name for the VPC that will contain all the Orchestrator components."
+  type        = string
+  default     = "orc8r_vpc"
+}
+
+variable "vpc_cidr" {
+  description = "CIDR block for the VPC."
+  type        = string
+  default     = "10.10.0.0/16"
+}
+
+variable "vpc_public_subnets" {
+  description = "CIDR blocks for the VPC's public subnets."
+  type        = list(string)
+  default     = ["10.10.0.0/24", "10.10.1.0/24", "10.10.2.0/24"]
+}
+
+variable "vpc_private_subnets" {
+  description = "CIDR blocks for the VPC's private subnets."
+  type        = list(string)
+  default     = ["10.10.100.0/24", "10.10.101.0/24", "10.10.102.0/24"]
+}
+
+variable "vpc_database_subnets" {
+  description = "CIDR blocks for the VPC's database subnets."
+  type        = list(string)
+  default     = ["10.10.200.0/24", "10.10.201.0/24", "10.10.202.0/24"]
+}
+
+variable "vpc_extra_tags" {
+  description = "Tags to add to the VPC."
+  default     = {}
+}
+
+##############################################################################
+# Orchestrator DB Specs
+##############################################################################
+
+variable "orc8r_db_identifier" {
+  description = "Identifier for the RDS instance for Orchestrator."
+  type        = string
+  default     = "orc8rdb"
+}
+
+variable "orc8r_db_storage_gb" {
+  description = "Capacity in GB to allocate for Orchestrator RDS instance."
+  type        = number
+  default     = 64
+}
+
+variable "orc8r_db_instance_class" {
+  description = "RDS instance type for Orchestrator DB."
+  type        = string
+  default     = "db.m4.large"
+}
+
+variable "orc8r_db_name" {
+  description = "DB name for Orchestrator RDS instance."
+  type        = string
+  default     = "orc8r"
+}
+
+variable "orc8r_db_username" {
+  description = "Username for default DB user for Orchestrator DB."
+  type        = string
+  default     = "orc8r"
+}
+
+variable "orc8r_db_password" {
+  description = "Password for the Orchestrator DB. Must be at least 8 characters."
+  type        = string
+}
+
+variable "orc8r_db_engine_version" {
+  description = "Postgres engine version for Orchestrator DB."
+  type        = string
+  default     = "9.6.15"
+}
+
+##############################################################################
+# NMS DB Specs
+##############################################################################
+
+variable "nms_db_identifier" {
+  description = "Identifier for the RDS instance for NMS."
+  type        = string
+  default     = "nmsdb"
+}
+
+variable "nms_db_storage_gb" {
+  description = "Capacity in GB to allocate for NMS RDS instance."
+  type        = number
+  default     = 16
+}
+
+variable "nms_db_instance_class" {
+  description = "RDS instance type for NMS DB."
+  type        = string
+  default     = "db.m4.large"
+}
+
+variable "nms_db_name" {
+  description = "DB name for NMS RDS instance."
+  type        = string
+  default     = "magma"
+}
+
+variable "nms_db_username" {
+  description = "Username for default DB user for NMS DB."
+  type        = string
+  default     = "magma"
+}
+
+variable "nms_db_password" {
+  description = "Password for the NMS DB. Must be at least 8 characters."
+  type        = string
+}
+
+variable "nms_db_engine_version" {
+  description = "MySQL engine version for NMS DB."
+  type        = string
+  default     = "5.7"
+}
+
+##############################################################################
+# Secretmanager configuration
+##############################################################################
+
+variable "secretsmanager_orc8r_secret" {
+  description = "AWS Secret Manager secret to store Orchestrator secrets."
+  type        = string
+}
+
+##############################################################################
+# Elasticsearch configuration
+##############################################################################
+
+variable "elasticsearch_domain_name" {
+  description = "Name for the ES domain."
+  type        = string
+  default     = null
+}
+
+variable "elasticsearch_version" {
+  description = "ES version for ES domain."
+  default     = "7.1"
+}
+
+variable "elasticsearch_instance_type" {
+  description = "AWS instance type for ES domain."
+  type        = string
+  default     = null
+}
+
+variable "elasticsearch_instance_count" {
+  description = "Number of instances to allocate for ES domain."
+  type        = number
+  default     = null
+}
+
+variable "elasticsearch_dedicated_master_enabled" {
+  description = "Enable/disable dedicated master nodes for ES."
+  type        = bool
+  default     = false
+}
+
+variable "elasticsearch_dedicated_master_type" {
+  description = "Instance type for ES dedicated master nodes."
+  type        = string
+  default     = null
+}
+
+variable "elasticsearch_dedicated_master_count" {
+  description = "Number of dedicated ES master nodes."
+  type        = number
+  default     = null
+}
+
+variable "elasticsearch_az_count" {
+  description = "AZ count for ES."
+  type        = number
+  default     = 2
+}
+
+variable "elasticsearch_ebs_enabled" {
+  description = "Use EBS for ES storage. See https://aws.amazon.com/elasticsearch-service/pricing/ to check if your chosen instance types can use non-EBS storage."
+  type        = bool
+  default     = false
+}
+
+variable "elasticsearch_ebs_volume_size" {
+  description = "Size in GB to allocate for ES EBS data volumes."
+  type        = number
+  default     = null
+}
+
+variable "elasticsearch_ebs_volume_type" {
+  description = "EBS volume type for ES data volumes."
+  type        = string
+  default     = null
+}
+
+variable "elasticsearch_ebs_iops" {
+  description = "IOPS for ES EBS volumes."
+  type        = number
+  default     = null
+}
+
+variable "elasticsearch_domain_tags" {
+  description = "Extra tags for the ES domain."
+  default     = {}
+}
+

--- a/experimental/cloudstrapper/playbooks/roles/control/files/v1.3/orc8r-helm-aws/artifactory.tf
+++ b/experimental/cloudstrapper/playbooks/roles/control/files/v1.3/orc8r-helm-aws/artifactory.tf
@@ -1,0 +1,34 @@
+################################################################################
+# Copyright 2020 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+locals {
+  dockercfg = {
+    (var.docker_registry) = {
+      username = var.docker_user
+      password = var.docker_pass
+    }
+  }
+
+  stable_helm_repo    = "https://charts.helm.sh/stable"
+  incubator_helm_repo = "https://charts.helm.sh/incubator"
+}
+
+resource "kubernetes_secret" "artifactory" {
+  metadata {
+    name      = "artifactory"
+    namespace = kubernetes_namespace.orc8r.metadata[0].name
+  }
+
+  data = { ".dockercfg" = jsonencode(local.dockercfg) }
+  type = "kubernetes.io/dockercfg"
+}

--- a/experimental/cloudstrapper/playbooks/roles/control/files/v1.4/orc8r-aws/eks.tf
+++ b/experimental/cloudstrapper/playbooks/roles/control/files/v1.4/orc8r-aws/eks.tf
@@ -1,0 +1,74 @@
+################################################################################
+# Copyright 2020 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+resource "tls_private_key" "eks_workers" {
+  count = var.eks_worker_group_key == null ? 1 : 0
+
+  algorithm = "RSA"
+}
+
+resource "aws_key_pair" "eks_workers" {
+  count = var.eks_worker_group_key == null ? 1 : 0
+
+  key_name_prefix = var.cluster_name
+  public_key      = tls_private_key.eks_workers[0].public_key_openssh
+}
+
+module "eks" {
+  source  = "terraform-aws-modules/eks/aws"
+  version = "~> 8.0"
+
+  cluster_name = var.cluster_name
+  cluster_version = "1.17"
+  vpc_id       = module.vpc.vpc_id
+  subnets      = length(module.vpc.private_subnets) > 0 ? module.vpc.private_subnets : module.vpc.public_subnets
+
+  cluster_enabled_log_types = [
+    "api",
+    "audit",
+    "authenticator",
+    "controllerManager",
+    "scheduler",
+  ]
+
+  workers_group_defaults = {
+    key_name = var.eks_worker_group_key == null ? aws_key_pair.eks_workers[0].key_name : var.eks_worker_group_key
+  }
+  worker_additional_security_group_ids = concat([aws_security_group.default.id], var.eks_worker_additional_sg_ids)
+  workers_additional_policies          = var.eks_worker_additional_policy_arns
+  worker_groups                        = var.eks_worker_groups
+
+  map_roles = var.eks_map_roles
+  map_users = var.eks_map_users
+
+  tags = var.global_tags
+}
+
+# role assume policy for eks workers
+data "aws_iam_policy_document" "eks_worker_assumable" {
+  statement {
+    principals {
+      identifiers = ["ec2.amazonaws.com"]
+      type        = "Service"
+    }
+    actions = ["sts:AssumeRole"]
+  }
+
+  statement {
+    principals {
+      identifiers = [module.eks.worker_iam_role_arn]
+      type        = "AWS"
+    }
+    actions = ["sts:AssumeRole"]
+  }
+}

--- a/experimental/cloudstrapper/playbooks/roles/control/files/v1.4/orc8r-aws/variables.tf
+++ b/experimental/cloudstrapper/playbooks/roles/control/files/v1.4/orc8r-aws/variables.tf
@@ -1,0 +1,345 @@
+################################################################################
+# Copyright 2020 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+variable "region" {
+  description = "AWS region to deploy Orchestrator components into. The chosen region must provide EKS."
+  type        = string
+}
+
+data "aws_availability_zones" "available" {}
+
+##############################################################################
+# Module flags
+##############################################################################
+
+variable "deploy_elasticsearch" {
+  description = "Flag to deploy AWS Elasticsearch service as the datasink for aggregated logs."
+  type        = bool
+  default     = false
+}
+
+variable "deploy_elasticsearch_service_linked_role" {
+  description = "Flag to deploy AWS Elasticsearch service linked role with cluster. If you've already created an ES service linked role for another cluster, you should set this to false."
+  type        = bool
+  default     = false
+}
+
+variable "global_tags" {
+  default = {}
+}
+##############################################################################
+# K8s configuration
+##############################################################################
+
+variable "orc8r_domain_name" {
+  description = "Base domain name for AWS Route 53 hosted zone."
+  type        = string
+}
+
+##############################################################################
+# K8s configuration
+##############################################################################
+
+variable "cluster_name" {
+  description = "Name for the Orchestrator EKS cluster."
+  type        = string
+  default     = "orc8r"
+}
+
+variable "eks_worker_group_key" {
+  description = "If specified, the worker nodes for EKS will use this EC2 keypair."
+  type        = string
+  default     = null
+}
+
+variable "eks_worker_additional_sg_ids" {
+  description = "Additional security group IDs to attach to EKS worker nodes."
+  type        = list(string)
+  default     = []
+}
+
+variable "eks_worker_additional_policy_arns" {
+  description = "Additional IAM policy ARNs to attach to EKS worker nodes."
+  type        = list(string)
+  default     = []
+}
+
+variable "eks_worker_groups" {
+  # Check the docs at https://github.com/terraform-aws-modules/terraform-aws-eks
+  # for the complete set of valid properties for these objects.
+  description = "Worker group configuration for EKS. Default value is 1 worker group consisting of 3 t3.large instances."
+  type        = any
+  default = [
+    {
+      name                 = "wg-1"
+      instance_type        = "t3.large"
+      asg_desired_capacity = 3
+      asg_min_size         = 1
+      asg_max_size         = 3
+      autoscaling_enabled  = false
+    },
+  ]
+}
+
+variable "eks_map_roles" {
+  description = "EKS IAM role mapping. Note that by default, the creator of the cluster will be in the system:master group."
+  type = list(
+    object({
+      rolearn  = string,
+      username = string,
+      groups   = list(string),
+    })
+  )
+  default = []
+}
+
+variable "eks_map_users" {
+  description = "Additional IAM users to add to the aws-auth ConfigMap."
+  type = list(object({
+    userarn  = string
+    username = string
+    groups   = list(string)
+  }))
+  default = []
+}
+
+##############################################################################
+# EFS configuration
+##############################################################################
+
+variable "efs_project_name" {
+  description = "Project name for EFS file system"
+  type        = string
+  default     = "orc8r"
+}
+
+##############################################################################
+# VPC configuration
+##############################################################################
+
+# TODO: support an existing VPC
+
+variable "vpc_name" {
+  description = "Name for the VPC that will contain all the Orchestrator components."
+  type        = string
+  default     = "orc8r_vpc"
+}
+
+variable "vpc_cidr" {
+  description = "CIDR block for the VPC."
+  type        = string
+  default     = "10.10.0.0/16"
+}
+
+variable "vpc_public_subnets" {
+  description = "CIDR blocks for the VPC's public subnets."
+  type        = list(string)
+  default     = ["10.10.0.0/24", "10.10.1.0/24", "10.10.2.0/24"]
+}
+
+variable "vpc_private_subnets" {
+  description = "CIDR blocks for the VPC's private subnets."
+  type        = list(string)
+  default     = ["10.10.100.0/24", "10.10.101.0/24", "10.10.102.0/24"]
+}
+
+variable "vpc_database_subnets" {
+  description = "CIDR blocks for the VPC's database subnets."
+  type        = list(string)
+  default     = ["10.10.200.0/24", "10.10.201.0/24", "10.10.202.0/24"]
+}
+
+variable "vpc_extra_tags" {
+  description = "Tags to add to the VPC."
+  default     = {}
+}
+
+##############################################################################
+# Orchestrator DB Specs
+##############################################################################
+
+variable "orc8r_db_identifier" {
+  description = "Identifier for the RDS instance for Orchestrator."
+  type        = string
+  default     = "orc8rdb"
+}
+
+variable "orc8r_db_storage_gb" {
+  description = "Capacity in GB to allocate for Orchestrator RDS instance."
+  type        = number
+  default     = 64
+}
+
+variable "orc8r_db_instance_class" {
+  description = "RDS instance type for Orchestrator DB."
+  type        = string
+  default     = "db.m4.large"
+}
+
+variable "orc8r_db_name" {
+  description = "DB name for Orchestrator RDS instance."
+  type        = string
+  default     = "orc8r"
+}
+
+variable "orc8r_db_username" {
+  description = "Username for default DB user for Orchestrator DB."
+  type        = string
+  default     = "orc8r"
+}
+
+variable "orc8r_db_password" {
+  description = "Password for the Orchestrator DB. Must be at least 8 characters."
+  type        = string
+}
+
+variable "orc8r_db_engine_version" {
+  description = "Postgres engine version for Orchestrator DB."
+  type        = string
+  default     = "9.6.15"
+}
+
+##############################################################################
+# NMS DB Specs
+##############################################################################
+
+variable "nms_db_identifier" {
+  description = "Identifier for the RDS instance for NMS."
+  type        = string
+  default     = "nmsdb"
+}
+
+variable "nms_db_storage_gb" {
+  description = "Capacity in GB to allocate for NMS RDS instance."
+  type        = number
+  default     = 16
+}
+
+variable "nms_db_instance_class" {
+  description = "RDS instance type for NMS DB."
+  type        = string
+  default     = "db.m4.large"
+}
+
+variable "nms_db_name" {
+  description = "DB name for NMS RDS instance."
+  type        = string
+  default     = "magma"
+}
+
+variable "nms_db_username" {
+  description = "Username for default DB user for NMS DB."
+  type        = string
+  default     = "magma"
+}
+
+variable "nms_db_password" {
+  description = "Password for the NMS DB. Must be at least 8 characters."
+  type        = string
+}
+
+variable "nms_db_engine_version" {
+  description = "MySQL engine version for NMS DB."
+  type        = string
+  default     = "5.7"
+}
+
+##############################################################################
+# Secretmanager configuration
+##############################################################################
+
+variable "secretsmanager_orc8r_secret" {
+  description = "AWS Secret Manager secret to store Orchestrator secrets."
+  type        = string
+}
+
+##############################################################################
+# Elasticsearch configuration
+##############################################################################
+
+variable "elasticsearch_domain_name" {
+  description = "Name for the ES domain."
+  type        = string
+  default     = null
+}
+
+variable "elasticsearch_version" {
+  description = "ES version for ES domain."
+  default     = "7.1"
+}
+
+variable "elasticsearch_instance_type" {
+  description = "AWS instance type for ES domain."
+  type        = string
+  default     = null
+}
+
+variable "elasticsearch_instance_count" {
+  description = "Number of instances to allocate for ES domain."
+  type        = number
+  default     = null
+}
+
+variable "elasticsearch_dedicated_master_enabled" {
+  description = "Enable/disable dedicated master nodes for ES."
+  type        = bool
+  default     = false
+}
+
+variable "elasticsearch_dedicated_master_type" {
+  description = "Instance type for ES dedicated master nodes."
+  type        = string
+  default     = null
+}
+
+variable "elasticsearch_dedicated_master_count" {
+  description = "Number of dedicated ES master nodes."
+  type        = number
+  default     = null
+}
+
+variable "elasticsearch_az_count" {
+  description = "AZ count for ES."
+  type        = number
+  default     = 2
+}
+
+variable "elasticsearch_ebs_enabled" {
+  description = "Use EBS for ES storage. See https://aws.amazon.com/elasticsearch-service/pricing/ to check if your chosen instance types can use non-EBS storage."
+  type        = bool
+  default     = false
+}
+
+variable "elasticsearch_ebs_volume_size" {
+  description = "Size in GB to allocate for ES EBS data volumes."
+  type        = number
+  default     = null
+}
+
+variable "elasticsearch_ebs_volume_type" {
+  description = "EBS volume type for ES data volumes."
+  type        = string
+  default     = null
+}
+
+variable "elasticsearch_ebs_iops" {
+  description = "IOPS for ES EBS volumes."
+  type        = number
+  default     = null
+}
+
+variable "elasticsearch_domain_tags" {
+  description = "Extra tags for the ES domain."
+  default     = {}
+}
+

--- a/experimental/cloudstrapper/playbooks/roles/control/files/v1.4/orc8r-helm-aws/artifactory.tf
+++ b/experimental/cloudstrapper/playbooks/roles/control/files/v1.4/orc8r-helm-aws/artifactory.tf
@@ -1,0 +1,34 @@
+################################################################################
+# Copyright 2020 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+locals {
+  dockercfg = {
+    (var.docker_registry) = {
+      username = var.docker_user
+      password = var.docker_pass
+    }
+  }
+
+  stable_helm_repo    = "https://charts.helm.sh/stable"
+  incubator_helm_repo = "https://charts.helm.sh/incubator"
+}
+
+resource "kubernetes_secret" "artifactory" {
+  metadata {
+    name      = "artifactory"
+    namespace = kubernetes_namespace.orc8r.metadata[0].name
+  }
+
+  data = { ".dockercfg" = jsonencode(local.dockercfg) }
+  type = "kubernetes.io/dockercfg"
+}

--- a/experimental/cloudstrapper/playbooks/roles/control/files/v1.4/orc8r-helm-aws/variables.tf
+++ b/experimental/cloudstrapper/playbooks/roles/control/files/v1.4/orc8r-helm-aws/variables.tf
@@ -1,0 +1,380 @@
+################################################################################
+# Copyright 2020 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+variable "region" {
+  description = "AWS region to deploy Orchestrator components into. The chosen region must provide EKS."
+  type        = string
+}
+
+variable "state_backend" {
+  description = "State backend for terraform (e.g. s3, local)."
+  type        = string
+  default     = "local"
+}
+
+variable "state_config" {
+  description = "Optional config for state backend. The object type will depend on your backend."
+  default     = null
+}
+
+data "aws_availability_zones" "available" {}
+
+##############################################################################
+# DNS configuration
+##############################################################################
+
+variable "orc8r_domain_name" {
+  description = "Base domain name for Orchestrator."
+  type        = string
+}
+
+variable "orc8r_route53_zone_id" {
+  description = "Route53 zone ID of Orchestrator domain name for ExternalDNS."
+  type        = string
+}
+
+variable "external_dns_role_arn" {
+  description = "IAM role ARN for ExternalDNS."
+  type        = string
+}
+
+##############################################################################
+# Kubernetes configuration
+##############################################################################
+
+variable "eks_cluster_id" {
+  description = "EKS cluster ID for the K8s cluster."
+  type        = string
+}
+
+variable "orc8r_kubernetes_namespace" {
+  description = "K8s namespace to install main Orchestrator components into."
+  type        = string
+  default     = "orc8r"
+}
+
+variable "monitoring_kubernetes_namespace" {
+  description = "K8s namespace to install Orchestrator monitoring components into."
+  type        = string
+  default     = "monitoring"
+}
+
+##############################################################################
+# General Orchestrator configuration
+##############################################################################
+
+variable "deploy_nms" {
+  description = "Flag to deploy NMS."
+  type        = bool
+  default     = true
+}
+
+variable "orc8r_controller_replicas" {
+  description = "Replica count for Orchestrator controller pods."
+  type        = number
+  default     = 2
+}
+
+variable "orc8r_proxy_replicas" {
+  description = "Replica count for Orchestrator proxy pods."
+  type        = number
+  default     = 2
+}
+
+variable "orc8r_db_name" {
+  description = "DB name for Orchestrator database connection."
+  type        = string
+}
+
+variable "orc8r_db_host" {
+  description = "DB hostname for Orchestrator database connection."
+  type        = string
+}
+
+variable "orc8r_db_port" {
+  description = "DB port for Orchestrator database connection."
+  type        = number
+  default     = 5432
+}
+
+variable "orc8r_db_user" {
+  description = "DB username for Orchestrator database connection."
+  type        = string
+}
+
+variable "nms_db_name" {
+  description = "DB name for NMS database connection."
+  type        = string
+}
+
+variable "nms_db_host" {
+  description = "DB hostname for NMS database connection."
+  type        = string
+}
+
+variable "nms_db_user" {
+  description = "DB username for NMS database connection."
+  type        = string
+}
+
+##############################################################################
+# Helm configuration
+##############################################################################
+
+variable "existing_tiller_service_account_name" {
+  description = "Name of existing Tiller service account to use for Helm."
+  type        = string
+  default     = null
+}
+
+variable "tiller_namespace" {
+  description = "Namespace where Tiller is installed or should be installed into."
+  type        = string
+  default     = "kube-system"
+}
+
+variable "install_tiller" {
+  description = "Install Tiller in the cluster or not."
+  type        = bool
+  default     = true
+}
+
+variable "helm_deployment_name" {
+  description = "Name for the Helm release."
+  type        = string
+  default     = "orc8r"
+}
+
+variable "orc8r_deployment_type" {
+  description = "Type of orc8r deployment (fixed wireless access, federated fixed wireless access, or all modules)"
+  type        = string
+  validation {
+    condition = (
+      var.orc8r_deployment_type == "fwa" ||
+      var.orc8r_deployment_type == "federated_fwa" ||
+      var.orc8r_deployment_type == "all"
+    )
+    error_message = "The orc8r_deployment_type value must be one of ['fwa', 'federated_fwa', 'all']."
+  }
+}
+
+variable "orc8r_chart_version" {
+  description = "Version of the core orchestrator Helm chart to install."
+  type        = string
+  default     = "1.5.8"
+}
+
+variable "cwf_orc8r_chart_version" {
+  description = "Version of the orchestrator cwf module Helm chart to install."
+  type        = string
+  default     = "0.2.0"
+}
+
+variable "fbinternal_orc8r_chart_version" {
+  description = "Version of the orchestrator fbinternal module Helm chart to install."
+  type        = string
+  default     = "0.2.0"
+}
+
+variable "feg_orc8r_chart_version" {
+  description = "Version of the orchestrator feg module Helm chart to install."
+  type        = string
+  default     = "0.2.1"
+}
+
+variable "lte_orc8r_chart_version" {
+  description = "Version of the orchestrator lte module Helm chart to install."
+  type        = string
+  default     = "0.2.1"
+}
+
+variable "wifi_orc8r_chart_version" {
+  description = "Version of the orchestrator wifi module Helm chart to install."
+  type        = string
+  default     = "0.2.0"
+}
+
+variable "orc8r_tag" {
+  description = "Image tag for Orchestrator components."
+  type        = string
+  default     = ""
+}
+
+##############################################################################
+# EFS configuration
+##############################################################################
+
+variable "efs_file_system_id" {
+  description = "ID of the EFS file system to use for K8s persistent volumes."
+  type        = string
+}
+
+variable "efs_provisioner_role_arn" {
+  description = "ARN of the IAM role for the EFS provisioner."
+  type        = string
+}
+
+##############################################################################
+# Log aggregation configuration
+##############################################################################
+
+variable "elasticsearch_endpoint" {
+  description = "Endpoint of the Elasticsearch datasink for aggregated logs and events."
+  type        = string
+  default     = null
+}
+
+variable "elasticsearch_retention_days" {
+  description = "Retention period in days of Elasticsearch indices."
+  type        = number
+  default     = 7
+}
+
+##############################################################################
+# Secret configuration and values
+##############################################################################
+
+variable "secretsmanager_orc8r_name" {
+  description = "Name of the AWS Secrets Manager secret where Orchestrator deployment secrets will be stored."
+  type        = string
+}
+
+variable "orc8r_db_pass" {
+  description = "Orchestrator DB password."
+  type        = string
+}
+
+variable "nms_db_pass" {
+  description = "NMS DB password."
+  type        = string
+}
+
+variable "docker_registry" {
+  description = "Docker registry to pull Orchestrator containers from."
+  type        = string
+}
+
+variable "docker_user" {
+  description = "Docker username to login to registry with."
+  type        = string
+}
+
+variable "docker_pass" {
+  description = "Docker registry password."
+  type        = string
+}
+
+variable "seed_certs_dir" {
+  description = "Directory on LOCAL disk where Orchestrator certificates are stored to seed Secrets Manager values. Home directory and env vars will be expanded."
+  type        = string
+}
+
+variable "helm_repo" {
+  description = "Helm repository URL for Orchestrator charts."
+  type        = string
+}
+
+variable "helm_user" {
+  description = "Helm username to login to repository with."
+  type        = string
+}
+
+variable "helm_pass" {
+  description = "Helm repository password."
+  type        = string
+}
+
+##############################################################################
+# Other deployment flags
+##############################################################################
+
+variable "deploy_openvpn" {
+  description = "Flag to deploy OpenVPN server into cluster. This is useful if you want to remotely access AGWs."
+  type        = bool
+  default     = false
+}
+
+##############################################################################
+# Thanos Object Storage
+##############################################################################
+
+variable "thanos_enabled" {
+  description = "Deploy thanos components and object storage"
+  type        = bool
+  default     = false
+}
+
+variable "thanos_object_store_bucket_name" {
+  description = "Bucket name for s3 object storage. Must be globally unique"
+  type        = string
+  default     = ""
+}
+
+variable "thanos_query_node_selector" {
+  description = "NodeSelector value to specify which node to run thanos query pod on. Default is 'thanos' to be deployed on the default thanos worker group."
+  type        = string
+  default     = "thanos"
+}
+
+
+variable "thanos_compact_node_selector" {
+  description = "NodeSelector value to specify which node to run thanos compact pod on. Label is 'compute-type:<value>'"
+  type        = string
+  default     = ""
+}
+
+variable "thanos_store_node_selector" {
+  description = "NodeSelector value to specify which node to run thanos store pod on. Label is 'compute-type:<value>'"
+  type        = string
+  default     = ""
+}
+
+##############################################################################
+# Analytics Service
+##############################################################################
+variable "analytics_export_enabled" {
+  description = "Deploy thanos components and object storage"
+  type        = bool
+  default     = false
+}
+
+variable "analytics_metrics_prefix" {
+  description = "Bucket name for s3 object storage. Must be globally unique"
+  type        = string
+  default     = ""
+}
+
+variable "analytics_app_secret" {
+  description = "App secret for which the metrics is to be exported to"
+  type = string
+  default = ""
+}
+
+
+variable "analytics_app_id" {
+  description = "App ID for which the metrics is to be exported to"
+  type = string
+  default = ""
+}
+
+variable "analytics_metric_export_url" {
+  description = "Metric Export URL"
+  type = string
+  default = ""
+}
+
+variable "analytics_category_name" {
+  description = "Category under which the exported metrics will be placed under"
+  type = string
+  default = "magma"
+}

--- a/experimental/cloudstrapper/playbooks/roles/control/tasks/configure-certs.yaml
+++ b/experimental/cloudstrapper/playbooks/roles/control/tasks/configure-certs.yaml
@@ -1,0 +1,27 @@
+---
+
+- name: create certs directory
+  file:
+    name: "{{ dirSecretsLocal }}"
+    state: directory
+    mode: '0775'
+
+- name: generate self-signed certs
+  command: "{{ dirSourceLocal }}/orc8r/cloud/deploy/scripts/self_sign_certs.sh {{ orc8rDomainName }}"
+  args:
+    chdir: "{{ dirSecretsLocal }}"
+
+- name: generate domain certs
+  command: "{{ dirSourceLocal }}/orc8r/cloud/deploy/scripts/create_application_certs.sh {{ orc8rDomainName }}"
+  args:
+    chdir: "{{ dirSecretsLocal }}"
+
+- name: generate pfx file
+  openssl_pkcs12:
+    action: export
+    path: "{{ dirSecretsLocal }}/admin_operator.pfx"
+    friendly_name: orc8rpfx
+    privatekey_path: "{{ dirSecretsLocal }}/admin_operator.key.pem"
+    certificate_path: "{{ dirSecretsLocal }}/admin_operator.pem"
+    state: present
+

--- a/experimental/cloudstrapper/playbooks/roles/control/tasks/configure-terraform.yaml
+++ b/experimental/cloudstrapper/playbooks/roles/control/tasks/configure-terraform.yaml
@@ -1,0 +1,21 @@
+---
+
+- name: create terraform artifacts directory
+  file:
+    path: "{{ dirTerraform }}"
+    state: directory
+    mode: '0755'
+
+- name: apply j2 template for terraform file
+  template:
+    src: "roles/control/templates/main.tf.j2.{{ orc8rVersion }}"
+    dest: "{{ dirTerraform }}/main.tf"
+    owner: "{{ userBootstrap }}"
+    group: "{{ userBootstrap }}"
+    mode: '0644' 
+
+- name: inside terraform home run terraform init
+  command: terraform init
+  args:
+    chdir: "{{ dirTerraform }}"
+

--- a/experimental/cloudstrapper/playbooks/roles/control/tasks/deploy-orc8r.yaml
+++ b/experimental/cloudstrapper/playbooks/roles/control/tasks/deploy-orc8r.yaml
@@ -1,0 +1,28 @@
+---
+
+
+
+- name: inside terraform home run terraform apply for orc8r
+  command: terraform apply -target=module.orc8r -auto-approve
+  args:
+    chdir: "{{ dirTerraform }}"
+  tags: tfFlow
+
+- name: inside terraform home run terraform apply for secrets
+  command: terraform apply -target=module.orc8r-app.null_resource.orc8r_seed_secrets -auto-approve
+  args:
+    chdir: "{{ dirTerraform }}"
+  tags: firstSecret, tfFlow
+
+  #- name: inside terraform home run terraform apply for secrets with taint
+  #command: terraform taint module.orc8r-app.null_resource.orc8r_seed_secrets
+  #args:
+  # chdir: "/home/{{ userBootstrap }}/terraform"
+  #tags: secondSecret, tfFlow
+
+- name: inside terraform home run final terraform apply
+  command: terraform apply -auto-approve
+  args:
+    chdir: "{{ dirTerraform }}"
+  tags: tfFlow
+

--- a/experimental/cloudstrapper/playbooks/roles/control/tasks/local-dirs.yaml
+++ b/experimental/cloudstrapper/playbooks/roles/control/tasks/local-dirs.yaml
@@ -1,0 +1,15 @@
+---
+#backing up certs in bootstrap to pass on to AGW
+
+- name: create certs folder on bootstrapper
+  file: 
+    path: "{{ dirSecretsLocal }}"
+    state: directory
+    mode: '0755'  
+
+    #TODO: Is this really needed?
+- name: install boto3 in local directory
+  command: pip install boto3
+  args:
+    chdir: "{{ dirSecretsLocal }}"
+

--- a/experimental/cloudstrapper/playbooks/roles/control/tasks/main.yaml
+++ b/experimental/cloudstrapper/playbooks/roles/control/tasks/main.yaml
@@ -1,0 +1,14 @@
+---
+- include: configure-certs.yaml
+  tags: config-certs
+- include: configure-terraform.yaml
+  tags: config-tf
+  ignore_errors: true
+- include: patch-terraform-v1.3.yaml
+  tags:  patch-tf 
+  when: orc8rVersion == "v1.3"
+- include: patch-terraform-v1.4.yaml
+  tags: patch-tf
+  when: orc8rVersion == "v1.4"
+- include: deploy-orc8r.yaml
+  tags: deploy-orc8r

--- a/experimental/cloudstrapper/playbooks/roles/control/tasks/patch-terraform-v1.3.yaml
+++ b/experimental/cloudstrapper/playbooks/roles/control/tasks/patch-terraform-v1.3.yaml
@@ -1,0 +1,22 @@
+---
+
+- name: copy aws eks.tf
+  copy:
+    src: "roles/control/files/{{ orc8rVersion }}/orc8r-aws/eks.tf"
+    dest: "{{ localTerraformDir }}/orc8r-aws/eks.tf"
+
+- name: copy aws variables.tf
+  copy:
+    src: "roles/control/files/{{ orc8rVersion }}/orc8r-aws/variables.tf"
+    dest: "{{ localTerraformDir }}/orc8r-aws/variables.tf"
+
+- name: copy artifactory.tf
+  copy:
+    src: "roles/control/files/{{ orc8rVersion }}/orc8r-helm-aws/artifactory.tf"
+    dest: "{{ localTerraformDir }}/orc8r-helm-aws/artifactory.tf"
+
+- name: copy artifactory.tf
+  copy:
+    src: "roles/control/files/{{ orc8rVersion }}/orc8r-helm-aws/artifactory.tf"
+    dest: "{{ localTerraformAppDir }}/orc8r-helm-aws/artifactory.tf"
+

--- a/experimental/cloudstrapper/playbooks/roles/control/tasks/patch-terraform-v1.4.yaml
+++ b/experimental/cloudstrapper/playbooks/roles/control/tasks/patch-terraform-v1.4.yaml
@@ -1,0 +1,17 @@
+---
+
+- name: copy aws eks.tf
+  copy:
+    src: roles/control/files/orc8r-aws/eks.tf
+    dest: "{{ localTerraformDir }}/orc8r-aws/eks.tf"
+
+- name: copy aws variables.tf
+  copy:
+    src: roles/control/files/orc8r-aws/variables.tf
+    dest: "{{ localTerraformDir }}/orc8r-aws/variables.tf"
+
+- name: copy helm-aws variables.tf
+  copy:
+    src: roles/control/files/orc8r-helm-aws/variables.tf
+    dest: "{{ localTerraformDir }}/orc8r-helm-aws/variables.tf"
+

--- a/experimental/cloudstrapper/playbooks/roles/control/templates/main.tf
+++ b/experimental/cloudstrapper/playbooks/roles/control/templates/main.tf
@@ -1,0 +1,89 @@
+################################################################################
+# Copyright 2020 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+module "orc8r" {
+  # Change this to pull from github with a specified ref
+  source = "../../../orc8r-aws"
+
+  region = "us-west-2"
+
+  nms_db_password             = "mypassword" # must be at least 8 characters
+  orc8r_db_password           = "mypassword" # must be at least 8 characters
+  secretsmanager_orc8r_secret = "orc8r-secrets"
+  orc8r_domain_name           = "orc8r.example.com"
+
+  vpc_name     = "orc8r"
+  cluster_name = "orc8r"
+
+  deploy_elasticsearch          = true
+  elasticsearch_domain_name     = "orc8r-es"
+  elasticsearch_version         = "7.7"
+  elasticsearch_instance_type   = "t2.medium.elasticsearch"
+  elasticsearch_instance_count  = 2
+  elasticsearch_az_count        = 2
+  elasticsearch_ebs_enabled     = true
+  elasticsearch_ebs_volume_size = 32
+  elasticsearch_ebs_volume_type = "gp2"
+}
+
+module "orc8r-app" {
+  # Change this to pull from github with a specified ref
+  source = "../.."
+
+  region = "us-west-2"
+
+  orc8r_domain_name     = module.orc8r.orc8r_domain_name
+  orc8r_route53_zone_id = module.orc8r.route53_zone_id
+  external_dns_role_arn = module.orc8r.external_dns_role_arn
+
+  secretsmanager_orc8r_name = module.orc8r.secretsmanager_secret_name
+  seed_certs_dir            = "~/secrets/certs"
+
+  orc8r_db_host = module.orc8r.orc8r_db_host
+  orc8r_db_name = module.orc8r.orc8r_db_name
+  orc8r_db_user = module.orc8r.orc8r_db_user
+  orc8r_db_pass = module.orc8r.orc8r_db_pass
+
+  nms_db_host = module.orc8r.nms_db_host
+  nms_db_name = module.orc8r.nms_db_name
+  nms_db_user = module.orc8r.nms_db_user
+  nms_db_pass = module.orc8r.nms_db_pass
+
+  # Note that this can be any container registry provider -- the example below
+  # provides the URL format for Docker Hub, where the user and pass are your
+  # Docker Hub username and access token, respectively
+  docker_registry = "registry.hub.docker.com/myusername"
+  docker_user     = "myusername"
+  docker_pass     = "mypassword"
+
+  # Note that this can be any Helm chart repo provider -- the example below
+  # provides the URL format for using a raw GitHub repo, where the user and
+  # pass are your GitHub username and access token, respectively
+  helm_repo = "https://raw.githubusercontent.com/myusername/myreponame/master/"
+  helm_user = "myusername"
+  helm_pass = "mypassword"
+
+  eks_cluster_id = module.orc8r.eks_cluster_id
+
+  efs_file_system_id       = module.orc8r.efs_file_system_id
+  efs_provisioner_role_arn = module.orc8r.efs_provisioner_role_arn
+
+  elasticsearch_endpoint = module.orc8r.es_endpoint
+
+  orc8r_deployment_type = "fwa"
+  orc8r_tag             = "1.4.0"
+}
+
+output "nameservers" {
+  value = module.orc8r.route53_nameservers
+}

--- a/experimental/cloudstrapper/playbooks/roles/control/templates/main.tf.1.3.org
+++ b/experimental/cloudstrapper/playbooks/roles/control/templates/main.tf.1.3.org
@@ -1,0 +1,87 @@
+################################################################################
+# Copyright 2020 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+module orc8r {
+  source = "../../../orc8r-aws"
+
+  region = "us-west-2"
+
+  nms_db_password             = "mypassword" # must be at least 8 characters
+  orc8r_db_password           = "mypassword" # must be at least 8 characters
+  secretsmanager_orc8r_secret = "orc8r-secrets"
+  orc8r_domain_name           = "orc8r.example.com"
+
+  vpc_name     = "orc8r"
+  cluster_name = "orc8r"
+
+  deploy_elasticsearch          = true
+  elasticsearch_domain_name     = "orc8r-es"
+  elasticsearch_version         = "7.1"
+  elasticsearch_instance_type   = "t2.medium.elasticsearch"
+  elasticsearch_instance_count  = 2
+  elasticsearch_az_count        = 2
+  elasticsearch_ebs_enabled     = true
+  elasticsearch_ebs_volume_size = 32
+  elasticsearch_ebs_volume_type = "gp2"
+}
+
+module orc8r-app {
+  source = "../.."
+
+  region = "us-west-2"
+
+  orc8r_domain_name     = module.orc8r.orc8r_domain_name
+  orc8r_route53_zone_id = module.orc8r.route53_zone_id
+  external_dns_role_arn = module.orc8r.external_dns_role_arn
+
+  secretsmanager_orc8r_name = module.orc8r.secretsmanager_secret_name
+  seed_certs_dir            = "~/secrets/certs"
+
+  orc8r_db_host = module.orc8r.orc8r_db_host
+  orc8r_db_name = module.orc8r.orc8r_db_name
+  orc8r_db_user = module.orc8r.orc8r_db_user
+  orc8r_db_pass = module.orc8r.orc8r_db_pass
+
+  nms_db_host = module.orc8r.nms_db_host
+  nms_db_name = module.orc8r.nms_db_name
+  nms_db_user = module.orc8r.nms_db_user
+  nms_db_pass = module.orc8r.nms_db_pass
+
+  # Note that this can be any container registry provider -- the example below
+  # provides the URL format for Docker Hub, where the user and pass are your
+  # Docker Hub username and access token, respectively
+  docker_registry = "registry.hub.docker.com/myusername"
+  docker_user     = "myusername"
+  docker_pass     = "mypassword"
+
+  # Note that this can be any Helm chart repo provider -- the example below
+  # provides the URL format for using a raw GitHub repo, where the user and
+  # pass are your GitHub username and access token, respectively
+  helm_repo = "https://raw.githubusercontent.com/myusername/myreponame/master/"
+  helm_user = "myusername"
+  helm_pass = "mypassword"
+
+  eks_cluster_id = module.orc8r.eks_cluster_id
+
+  efs_file_system_id       = module.orc8r.efs_file_system_id
+  efs_provisioner_role_arn = module.orc8r.efs_provisioner_role_arn
+
+  elasticsearch_endpoint = module.orc8r.es_endpoint
+
+  orc8r_chart_version = "1.4.7"
+  orc8r_tag           = "1.0.1"
+}
+
+output "nameservers" {
+  value = module.orc8r.route53_nameservers
+}

--- a/experimental/cloudstrapper/playbooks/roles/control/templates/main.tf.1.4.org
+++ b/experimental/cloudstrapper/playbooks/roles/control/templates/main.tf.1.4.org
@@ -1,0 +1,89 @@
+################################################################################
+# Copyright 2020 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+module "orc8r" {
+  # Change this to pull from github with a specified ref
+  source = "../../../orc8r-aws"
+
+  region = "us-west-2"
+
+  nms_db_password             = "mypassword" # must be at least 8 characters
+  orc8r_db_password           = "mypassword" # must be at least 8 characters
+  secretsmanager_orc8r_secret = "orc8r-secrets"
+  orc8r_domain_name           = "orc8r.example.com"
+
+  vpc_name     = "orc8r"
+  cluster_name = "orc8r"
+
+  deploy_elasticsearch          = true
+  elasticsearch_domain_name     = "orc8r-es"
+  elasticsearch_version         = "7.7"
+  elasticsearch_instance_type   = "t2.medium.elasticsearch"
+  elasticsearch_instance_count  = 2
+  elasticsearch_az_count        = 2
+  elasticsearch_ebs_enabled     = true
+  elasticsearch_ebs_volume_size = 32
+  elasticsearch_ebs_volume_type = "gp2"
+}
+
+module "orc8r-app" {
+  # Change this to pull from github with a specified ref
+  source = "../.."
+
+  region = "us-west-2"
+
+  orc8r_domain_name     = module.orc8r.orc8r_domain_name
+  orc8r_route53_zone_id = module.orc8r.route53_zone_id
+  external_dns_role_arn = module.orc8r.external_dns_role_arn
+
+  secretsmanager_orc8r_name = module.orc8r.secretsmanager_secret_name
+  seed_certs_dir            = "~/secrets/certs"
+
+  orc8r_db_host = module.orc8r.orc8r_db_host
+  orc8r_db_name = module.orc8r.orc8r_db_name
+  orc8r_db_user = module.orc8r.orc8r_db_user
+  orc8r_db_pass = module.orc8r.orc8r_db_pass
+
+  nms_db_host = module.orc8r.nms_db_host
+  nms_db_name = module.orc8r.nms_db_name
+  nms_db_user = module.orc8r.nms_db_user
+  nms_db_pass = module.orc8r.nms_db_pass
+
+  # Note that this can be any container registry provider -- the example below
+  # provides the URL format for Docker Hub, where the user and pass are your
+  # Docker Hub username and access token, respectively
+  docker_registry = "registry.hub.docker.com/myusername"
+  docker_user     = "myusername"
+  docker_pass     = "mypassword"
+
+  # Note that this can be any Helm chart repo provider -- the example below
+  # provides the URL format for using a raw GitHub repo, where the user and
+  # pass are your GitHub username and access token, respectively
+  helm_repo = "https://raw.githubusercontent.com/myusername/myreponame/master/"
+  helm_user = "myusername"
+  helm_pass = "mypassword"
+
+  eks_cluster_id = module.orc8r.eks_cluster_id
+
+  efs_file_system_id       = module.orc8r.efs_file_system_id
+  efs_provisioner_role_arn = module.orc8r.efs_provisioner_role_arn
+
+  elasticsearch_endpoint = module.orc8r.es_endpoint
+
+  orc8r_deployment_type = "fwa"
+  orc8r_tag             = "1.4.0"
+}
+
+output "nameservers" {
+  value = module.orc8r.route53_nameservers
+}

--- a/experimental/cloudstrapper/playbooks/roles/control/templates/main.tf.j2.v1.3
+++ b/experimental/cloudstrapper/playbooks/roles/control/templates/main.tf.j2.v1.3
@@ -1,0 +1,88 @@
+################################################################################
+# Copyright 2020 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+module orc8r {
+  source = "{{ orc8rSource }}"
+
+  region = "{{ awsOrc8rRegion }}"
+
+  nms_db_password             = "{{ nmsDbPassword }}" # must be at least 8 characters
+  orc8r_db_password           = "{{ orc8rDbPassword }}" # must be at least 8 characters
+  secretsmanager_orc8r_secret = "{{ orc8rTfSecrets }}"
+  orc8r_domain_name           = "{{ orc8rDomainName }}"
+
+  vpc_name     = "{{ orc8rTfVpc }}"
+  cluster_name = "{{ orc8rTfCluster }}"
+
+  deploy_elasticsearch          = true
+  elasticsearch_domain_name     = "{{ orc8rTfEs }}"
+  elasticsearch_version         = "7.1"
+  elasticsearch_instance_type   = "t2.medium.elasticsearch"
+  elasticsearch_instance_count  = 2
+  elasticsearch_az_count        = 2
+  elasticsearch_ebs_enabled     = true
+  elasticsearch_ebs_volume_size = 32
+  elasticsearch_ebs_volume_type = "gp2"
+}
+
+module orc8r-app {
+  source = "{{ orc8rAppSource }}"
+
+  region = "{{ awsOrc8rRegion }}"
+
+  orc8r_domain_name     = module.orc8r.orc8r_domain_name
+  orc8r_route53_zone_id = module.orc8r.route53_zone_id
+  external_dns_role_arn = module.orc8r.external_dns_role_arn
+
+  secretsmanager_orc8r_name = module.orc8r.secretsmanager_secret_name
+  seed_certs_dir            = "{{ dirSecretsLocal }}"
+
+  orc8r_db_host = module.orc8r.orc8r_db_host
+  orc8r_db_name = module.orc8r.orc8r_db_name
+  orc8r_db_user = module.orc8r.orc8r_db_user
+  orc8r_db_pass = module.orc8r.orc8r_db_pass
+
+  nms_db_host = module.orc8r.nms_db_host
+  nms_db_name = module.orc8r.nms_db_name
+  nms_db_user = module.orc8r.nms_db_user
+  nms_db_pass = module.orc8r.nms_db_pass
+
+  # Note that this can be any container registry provider -- the example below
+  # provides the URL format for Docker Hub, where the user and pass are your
+  # Docker Hub username and access token, respectively
+  docker_registry = "registry.hub.docker.com/{{ dockerUser }}"
+  docker_user     = "{{ dockerUser }}"
+  docker_pass     = "{{ dockerPassword }}"
+
+  # Note that this can be any Helm chart repo provider -- the example below
+  # provides the URL format for using a raw GitHub repo, where the user and
+  # pass are your GitHub username and access token, respectively
+  helm_repo = "https://raw.githubusercontent.com/{{ gitUser }}/{{ gitHelmRepo }}/master/"
+  helm_user = "{{ gitUser }}"
+  helm_pass = "{{ gitPat }}"
+
+  eks_cluster_id = module.orc8r.eks_cluster_id
+
+  efs_file_system_id       = module.orc8r.efs_file_system_id
+  efs_provisioner_role_arn = module.orc8r.efs_provisioner_role_arn
+
+  elasticsearch_endpoint = module.orc8r.es_endpoint
+
+  orc8r_chart_version = "{{ orc8rChartVersion }}"
+  orc8r_tag           = "{{ orc8rLabel }}"
+}
+
+output "nameservers" {
+  value = module.orc8r.route53_nameservers
+}
+

--- a/experimental/cloudstrapper/playbooks/roles/control/templates/main.tf.j2.v1.4
+++ b/experimental/cloudstrapper/playbooks/roles/control/templates/main.tf.j2.v1.4
@@ -1,0 +1,88 @@
+################################################################################
+# Copyright 2020 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+module "orc8r" {
+  # Change this to pull from github with a specified ref
+  source = "{{ orc8rSource }}"
+
+  region = "{{ awsOrc8rRegion }}"
+
+  nms_db_password             = "{{ nmsDbPassword }}" # must be at least 8 characters
+  orc8r_db_password           = "{{ orc8rDbPassword }}" # must be at least 8 characters
+  secretsmanager_orc8r_secret = "{{ orc8rTfSecrets }}"
+  orc8r_domain_name           = "{{ orc8rDomainName }}"
+
+  vpc_name     = "{{ orc8rTfVpc }}"
+  cluster_name = "{{ orc8rTfCluster }}"
+
+  deploy_elasticsearch          = true
+  elasticsearch_domain_name     = "{{ orc8rTfEs }}"
+  elasticsearch_version         = "7.7"
+  elasticsearch_instance_type   = "t2.medium.elasticsearch"
+  elasticsearch_instance_count  = 2
+  elasticsearch_az_count        = 2
+  elasticsearch_ebs_enabled     = true
+  elasticsearch_ebs_volume_size = 32
+  elasticsearch_ebs_volume_type = "gp2"
+}
+
+module "orc8r-app" {
+  source = "{{ orc8rAppSource }}"
+
+  region = "{{ awsOrc8rRegion }}"
+
+  orc8r_domain_name     = module.orc8r.orc8r_domain_name
+  orc8r_route53_zone_id = module.orc8r.route53_zone_id
+  external_dns_role_arn = module.orc8r.external_dns_role_arn
+
+  secretsmanager_orc8r_name = module.orc8r.secretsmanager_secret_name
+  seed_certs_dir            = "{{ dirSecretsLocal }}"
+
+  orc8r_db_host = module.orc8r.orc8r_db_host
+  orc8r_db_name = module.orc8r.orc8r_db_name
+  orc8r_db_user = module.orc8r.orc8r_db_user
+  orc8r_db_pass = module.orc8r.orc8r_db_pass
+
+  nms_db_host = module.orc8r.nms_db_host
+  nms_db_name = module.orc8r.nms_db_name
+  nms_db_user = module.orc8r.nms_db_user
+  nms_db_pass = module.orc8r.nms_db_pass
+
+  # Note that this can be any container registry provider -- the example below
+  # provides the URL format for Docker Hub, where the user and pass are your
+  # Docker Hub username and access token, respectively
+  docker_registry = "registry.hub.docker.com/{{ dockerUser }}"
+  docker_user     = "{{ dockerUser }}"
+  docker_pass     = "{{ dockerPassword }}"
+
+  # Note that this can be any Helm chart repo provider -- the example below
+  # provides the URL format for using a raw GitHub repo, where the user and
+  # pass are your GitHub username and access token, respectively
+  helm_repo = "https://raw.githubusercontent.com/{{ gitUser }}/{{ gitHelmRepo }}/master/"
+  helm_user = "{{ gitUser }}"
+  helm_pass = "{{ gitPat }}"
+
+  eks_cluster_id = module.orc8r.eks_cluster_id
+
+  efs_file_system_id       = module.orc8r.efs_file_system_id
+  efs_provisioner_role_arn = module.orc8r.efs_provisioner_role_arn
+
+  elasticsearch_endpoint = module.orc8r.es_endpoint
+
+  orc8r_deployment_type = "fwa"
+  orc8r_tag           = "{{ orc8rLabel }}"
+}
+
+output "nameservers" {
+  value = module.orc8r.route53_nameservers
+}

--- a/experimental/cloudstrapper/playbooks/roles/control/vars/main.yaml
+++ b/experimental/cloudstrapper/playbooks/roles/control/vars/main.yaml
@@ -1,0 +1,17 @@
+---
+
+dirTerraform: "{{ dirExpHome }}/{{ orc8rClusterName }}/terraform"
+localTerraformDir: "{{ dirTerraform }}/.terraform/modules/orc8r/orc8r/cloud/deploy/terraform/"
+localTerraformAppDir: "{{ dirTerraform }}/.terraform/modules/orc8r-app/orc8r/cloud/deploy/terraform/"
+
+orc8rSource: "github.com/magma/magma//orc8r/cloud/deploy/terraform/orc8r-aws?ref={{ orc8rVersion }}"
+orc8rAppSource: "github.com/magma/magma//orc8r/cloud/deploy/terraform/orc8r-helm-aws?ref={{ orc8rVersion }}"
+
+#Terraform variables
+#
+
+nmsDbPassword: testpassword
+orc8rDbPassword: testpassword
+helmRepo: "{{ gitHelmRepo }}"
+orc8rTag: "{{ orc8rLabel }}"
+orc8rChartVersion: 1.4.36

--- a/experimental/cloudstrapper/playbooks/roles/devops-infra/tasks/main.yaml
+++ b/experimental/cloudstrapper/playbooks/roles/devops-infra/tasks/main.yaml
@@ -1,0 +1,26 @@
+---
+- name: query all security groups
+  ec2_group_info:
+    filters:
+      group-name: "{{ secgroupDefault }}" 
+  register: reg_secgroup
+
+- name: assign security group id to variable
+  set_fact:
+    factSecgroup: "{{ reg_secgroup.security_groups[0].group_id }}" 
+
+- name: instantiate ec2 instance using cloudformation
+  cloudformation:
+    stack_name: "stackMantleDevOpsCloudstrapper"
+    state: present
+    region: "{{ awsAgwRegion }}"
+    disable_rollback: true
+    template: "roles/cfn/cfnMagmaBootstrap.json"
+    template_parameters:
+      paramKeyName: "{{ keyHost }}"
+      paramSecGroup: "{{ factSecgroup }}"
+      paramTagId: "Mantle"
+      paramTagName: "{{ devOpsCloudstrapper }}"
+      paramImageId: "{{ buildUbuntuAmi }}"
+        
+

--- a/experimental/cloudstrapper/playbooks/roles/devops-infra/vars/main.yaml
+++ b/experimental/cloudstrapper/playbooks/roles/devops-infra/vars/main.yaml
@@ -1,0 +1,4 @@
+---
+
+gitUrl: https://github.com/arunuke/h33.git
+gitBranch: nov25-magma-on-aws

--- a/experimental/cloudstrapper/playbooks/roles/devops-platform/tasks/main.yaml
+++ b/experimental/cloudstrapper/playbooks/roles/devops-platform/tasks/main.yaml
@@ -1,0 +1,22 @@
+---
+- name: locate instance info
+  ec2_instance_info:
+    filters:
+      "tag:Name": "{{ devOpsCloudstrapper }}"
+      instance-state-name: "running"
+  register: inst_val
+
+- name: retrieve instance id from instance info
+  set_fact:
+    factIid: "{{ inst_val.instances[0].instance_id }}" 
+
+- name: create snapshot of instance
+  ec2_ami:
+    instance_id: "{{ factIid }}"
+    wait: yes
+    name: "{{ devOpsAmi }}"
+    tags:
+      Name: "{{ devOpsAmi }}"
+      Service: DevOpsAMI
+
+

--- a/experimental/cloudstrapper/playbooks/roles/golang-host/tasks/main.yaml
+++ b/experimental/cloudstrapper/playbooks/roles/golang-host/tasks/main.yaml
@@ -1,0 +1,27 @@
+---
+#installing golang so that go modules can be run on this host
+#particularly useful when working with cloud provider platforms
+#need to be run as sudo
+
+- name: download golang version 
+  get_url: 
+    url: "https://golang.org/dl/go{{ goVersion }}.{{ goDistro }}-{{ goArch }}.tar.gz"
+    dest: /tmp/goBin.tar.gz
+
+- name: install on host
+  unarchive:
+    src: /tmp/goBin.tar.gz
+    dest: /usr/local
+    remote_src: yes
+  become: yes
+
+- name: add go to path
+  lineinfile:
+    path: "{{ usrProfile }}"
+    regexp: '^export PATH=$PATH:/usr/local/go/bin'
+    line: "{{ item }}"
+  with_items:
+    - "export export PATH=$PATH:/usr/local/go/bin"
+    - 'export PS1="cloudstrapper:\w #"'
+    - 'alias play="cd {{ dirHome }}/code/mantle/experimental/cloudstrapper/playbooks"'
+

--- a/experimental/cloudstrapper/playbooks/roles/golang-host/vars/main.yaml
+++ b/experimental/cloudstrapper/playbooks/roles/golang-host/vars/main.yaml
@@ -1,0 +1,8 @@
+---
+
+goVersion: 1.15.6
+goDistro: linux
+goArch: amd64
+
+usrName: ubuntu
+usrProfile: "/home/{{ usrName }}/.profile"

--- a/experimental/cloudstrapper/playbooks/roles/key-manager/tasks/main.yaml
+++ b/experimental/cloudstrapper/playbooks/roles/key-manager/tasks/main.yaml
@@ -1,0 +1,7 @@
+---
+
+- name: copy host key into bootstrapper
+  copy:
+    src: "{{ dirLocalInventory }}/{{ keyHost }}.pem"
+    dest: "{{ dirInventory }}/{{ keyHost }}.pem"
+    mode: '0600'

--- a/experimental/cloudstrapper/playbooks/roles/key-manager/vars/main.yaml
+++ b/experimental/cloudstrapper/playbooks/roles/key-manager/vars/main.yaml
@@ -1,0 +1,3 @@
+---
+
+dirLocalKey: ~/work/keys

--- a/experimental/cloudstrapper/playbooks/roles/magma-base/files/ansible-env.yaml
+++ b/experimental/cloudstrapper/playbooks/roles/magma-base/files/ansible-env.yaml
@@ -1,0 +1,3 @@
+MAGMA_ROOT: /home/admin/magma
+OUTPUT_DIR: /tmp
+PACKAGE_LOCATION: /tmp

--- a/experimental/cloudstrapper/playbooks/roles/magma-base/files/inventory
+++ b/experimental/cloudstrapper/playbooks/roles/magma-base/files/inventory
@@ -1,0 +1,4 @@
+[ovs_build]
+127.0.0.1 ansible_connection=local
+[ovs_deploy]
+127.0.0.1 ansible_connection=local

--- a/experimental/cloudstrapper/playbooks/roles/magma-base/tasks/main.yaml
+++ b/experimental/cloudstrapper/playbooks/roles/magma-base/tasks/main.yaml
@@ -1,0 +1,19 @@
+---
+- name: install packages
+  apt:
+    name: "{{ pkgGateway }}"
+    state: present
+  become: yes
+
+- name: create magma directory
+  file:
+    path: "{{ dirSourceLocal }}"
+    state: directory
+    mode: '0775'
+
+- name: download github repo
+  git:
+    repo: "{{ magmaRepo }}"
+    dest: "{{ dirSourceLocal }}"
+    version: "{{ magmaVersion }}"
+

--- a/experimental/cloudstrapper/playbooks/roles/magma-base/vars/main.yml
+++ b/experimental/cloudstrapper/playbooks/roles/magma-base/vars/main.yml
@@ -1,0 +1,16 @@
+---
+magmaVersion: "{{ orc8rVersion }}"
+magmaRepo: https://github.com/magma/magma.git
+pkgGateway:
+  - sudo
+  - curl
+  - make
+  - virtualenv
+  - zip
+  - rsync
+  - git
+  - software-properties-common
+  - python3-pip
+  - python-dev
+  - ansible
+

--- a/experimental/cloudstrapper/playbooks/roles/mantle-base/tasks/main.yaml
+++ b/experimental/cloudstrapper/playbooks/roles/mantle-base/tasks/main.yaml
@@ -1,0 +1,27 @@
+---
+
+- name: create experimental home and inventory folders
+  file:
+    name: "{{ dirInventory }}"
+    state: directory
+    mode: '0775'
+
+- name: create local directory
+  file:
+    name: "{{ mantleHomeDir }}"
+    state: directory
+    mode: '0775'
+
+#doesn't work for now since repo is private and key needs to be on target
+- name: download mantle github repo 
+  git:
+    repo: "{{ mantleGitRpo }}"
+    dest: "{{ mantleHomeDir }}"
+    version: "{{ mantleBranchName }}"
+    key_file: "{{ gitKey }}"
+  tags: [ never, usingGitSshKey ]
+
+- name: download mantle github repo using CLI
+  command: "git clone https://{{ gitUser }}:{{ gitPat }}@github.com/{{ gitProject }}/{{ gitRepo }}.git --branch {{ mantleBranchName }}"
+  args:
+    chdir: "{{ mantleHomeDir }}"

--- a/experimental/cloudstrapper/playbooks/roles/mantle-base/vars/main.yaml
+++ b/experimental/cloudstrapper/playbooks/roles/mantle-base/vars/main.yaml
@@ -1,0 +1,7 @@
+---
+
+mantleHomeDir: "{{ dirHome }}/code"
+mantleGitRepo: git@github.com:fbcinternal/mantle.git
+mantleBranchName: main
+gitProject: fbcinternal
+gitRepo: mantle

--- a/experimental/cloudstrapper/playbooks/roles/vars/build.yaml
+++ b/experimental/cloudstrapper/playbooks/roles/vars/build.yaml
@@ -1,0 +1,35 @@
+#Variables used in Magma build
+
+#Tune for custom builds and verify before build
+buildMagmaVersion: v1.3
+buildOrc8rLabel: mantletest
+buildHelmRepo: mantletest
+
+#Build defaults
+buildAwsRegion: us-east-1
+#AZ in same region as above
+buildAwsAz: us-east-1a
+buildInstanceType: t2.xlarge
+buildGwInstanceType: t2.medium
+
+#AMI IDs are different across regions
+# Ubuntu 20.04 in us-east-2: ami-0a91cd140a1fc148a
+# Ubuntu 20.04 in us-east-1: ami-0885b1f6bd170450c
+# Ubuntu 20.04 in ap-northeast-1: ami-0f2dd5fc989207c82
+# Ubuntu 20.04 in ca-central-1: ami-02e44367276fe7adc
+buildUbuntuAmi: ami-02e44367276fe7adc
+buildDebianAmi: ami-0c305b7817e9fd559
+
+buildControlRegistry: controller
+buildNginxRegistry: nginx
+buildNmsRegistry: magmalte
+buildDockerTag: latest
+
+buildTagName: buildOrc8r
+buildGwTagName: buildAgw
+
+buildHelmRepoUrl: "https://{{ gitUser }}:{{ gitPat }}@github.com/{{ gitUser }}/{{ buildHelmRepo }}" 
+
+buildPackageDir: "{{ dirSourceLocal }}/orc8r/tools/helm/"
+buildDeploymentType: all
+buildMagmaRepo: https://github.com/magma/magma.git

--- a/experimental/cloudstrapper/playbooks/roles/vars/cluster.yaml
+++ b/experimental/cloudstrapper/playbooks/roles/vars/cluster.yaml
@@ -1,0 +1,35 @@
+
+#------------------
+#Cluster-specific Variables
+#Use them to customize each deployment
+#------------------
+#Orc8r deployment variables
+orc8rClusterName: Seoul
+orc8rDomainName: arun.fbmagma.ninja
+orc8rLabel: 1.3.0
+orc8rVersion: v1.3
+gitHelmRepo: helm13
+
+#AWS variables
+awsBootKey: "{{ keyBoot }}"
+awsHostKey: "{{ keyHost }}"
+awsAgwRegion: ca-central-1
+awsOrc8rRegion: ap-southeast-1
+awsAgwAz: ap-northeast-1a
+awsAgwAmi: ami-082cfa03978837a23
+
+#------------------
+#Cluster-specific Presets
+#------------------
+
+#AWS Resource Names
+orc8rTfSecrets: orc8r-secrets
+orc8rTfVpc: orc8r
+orc8rTfCluster: orc8r
+orc8rTfEs: orc8r-es
+
+#------------------
+#Cluster-specific Variables ends
+#------------------
+
+

--- a/experimental/cloudstrapper/playbooks/roles/vars/defaults.yaml
+++ b/experimental/cloudstrapper/playbooks/roles/vars/defaults.yaml
@@ -1,0 +1,29 @@
+
+#------------------
+#Default variables
+#Do not need to be changed
+#Caution before you change
+#------------------
+
+secgroupDefault: secgroupMagmaProto
+bucketDefault: bucket-mantle-canada
+keyBoot: keyMagmaBoot
+keyHost: keyMagmaHost
+
+devOpsCloudstrapper: ec2MagmaDevopsCloudstrapper
+primaryCloudstrapper: ec2MagmaCloudstrapper
+devOpsAmi: imgCloudstrapperBase
+
+userBootstrap: ubuntu
+userMagma: "{{ userBootstrap }}"
+userAgw: admin
+
+#Directories
+dirHome: "/home/{{ userBootstrap }}"
+dirExpHome: "{{ dirHome }}/magma-experimental"
+dirPyenv: "{{ dirHome }}/.pyenv/shims"
+
+dirSourceLocal: "{{ dirExpHome }}/magma"
+dirSecretsLocal: "{{ dirExpHome }}/{{ orc8rClusterName }}/secrets/certs"
+dirInventory: "{{ dirExpHome }}/files"
+

--- a/experimental/cloudstrapper/playbooks/roles/vars/mantle.yaml
+++ b/experimental/cloudstrapper/playbooks/roles/vars/mantle.yaml
@@ -1,0 +1,12 @@
+
+#------------------
+#Source-specific Variables - Used for Devops
+#------------------
+
+mantle_git_repo: git@github.com:fbcinternal/mantle.git
+mantle_version_branch: jan12_aws
+
+#------------------
+#Source-specific Variables Ends
+#------------------
+

--- a/experimental/cloudstrapper/playbooks/roles/vars/secrets.yaml
+++ b/experimental/cloudstrapper/playbooks/roles/vars/secrets.yaml
@@ -1,0 +1,22 @@
+
+#------------------
+#Secret Vars  
+#------------------
+#TODO: Store in Vault
+
+#AWS Pre-requisites
+awsAccessKey: 
+awsSecretKey: 
+
+#Github Pre-requisites - Can be moved to AWS Code Pipeline
+gitUser: 
+gitPat: 
+
+#Dockerhub Pre-requisites - Can be moved to AWS ECR
+dockerUser: 
+dockerPassword: 
+
+#------------------
+#Secret Vars ends
+#------------------
+


### PR DESCRIPTION
[orc8r][Marketplace]

## Summary
Magma Experimental Feature

Adding Cloudstrapper, a set of playbooks that simplify deployment of Magma in a Marketplace. The devops playbooks in Cloudstrapper help in building a custom AMI that acts as the Cloudstrapper instance. This instance performs a simple deployment of Orchestrator in a given AWS region.

## Test Plan

Code deployed and videos of deployment available from https://drive.google.com/file/d/1TdvkhxvfBwZWXWgoiWRQ4G3zbieM1kyB/view?usp=sharing

Manual testing done by following steps from cloudstrapper/README.md

## Additional Information

This is an experimental feature that will reside in the experimental folder before it graduates and move to its own folder or within any of the existing folders.

The deployer current deploys v1.3. 

