### PR TITLE
[MME] Fix 'set but unused' build error with RelWithDebInfo in OAI

### DIFF
--- a/lte/gateway/c/oai/tasks/sgw/pgw_pco.c
+++ b/lte/gateway/c/oai/tasks/sgw/pgw_pco.c
@@ -75,6 +75,9 @@ int pgw_process_pco_request_ipcp(
   int8_t ipcp_req_identifier = 0;
   int16_t ipcp_req_length    = 0;
 
+  UNUSED(ipcp_req_code);
+  UNUSED(ipcp_req_length);
+
   uint8_t ipcp_req_option       = 0;
   int8_t ipcp_req_option_length = 0;
 


### PR DESCRIPTION
Signed-off-by: Marie Bremner <marwhal@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary
https://github.com/magma/magma/pull/4691 reverted the `UNUSED` lines which suppresses these build errors below on `RelWithDebInfo`:
```
[magma@10.240.0.13] out: [vagrant@127.0.0.1:2222] out: /home/vagrant/magma/lte/gateway/c/oai/tasks/sgw/pgw_pco.c:76:11: error: variable ‘ipcp_req_length’ set but not used [-Werror=unused-but-set-variable]
[magma@10.240.0.13] out: [vagrant@127.0.0.1:2222] out:    int16_t ipcp_req_length    = 0;
[magma@10.240.0.13] out: [vagrant@127.0.0.1:2222] out:            ^~~~~~~~~~~~~~~
[magma@10.240.0.13] out: [vagrant@127.0.0.1:2222] out: /home/vagrant/magma/lte/gateway/c/oai/tasks/sgw/pgw_pco.c:74:10: error: variable ‘ipcp_req_code’ set but not used [-Werror=unused-but-set-variable]
[magma@10.240.0.13] out: [vagrant@127.0.0.1:2222] out:    int8_t ipcp_req_code       = 0;
[magma@10.240.0.13] out: [vagrant@127.0.0.1:2222] out:           ^~~~~~~~~~~~~
[magma@10.240.0.13] out: [vagrant@127.0.0.1:2222] out: cc1: all warnings being treated as errors
```
<!-- Enumerate changes you made and why you made them -->

## Test Plan
`make build` locally with `RelWithDebInfo` set
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
