### PR TITLE
[s1ap] Remove loop on ReAuthRequest

### DIFF
--- a/lte/gateway/python/integ_tests/s1aptests/s1ap_utils.py
+++ b/lte/gateway/python/integ_tests/s1aptests/s1ap_utils.py
@@ -1284,35 +1284,20 @@ class SessionManagerUtil(object):
         qos = QoSInformation(qci=qos["qci"])
 
         # Get sessionid
-        #TODO: remove retries
-        i = 0
-        MAX = 3
         res = None
-        while i < MAX:
-            req = GetDirectoryFieldRequest(id=imsi, field_key="session_id")
-            try:
-                res = self._directorydstub.GetDirectoryField(
-                    req, DEFAULT_GRPC_TIMEOUT
-                )
-            except grpc.RpcError as err:
-                print(
-                    "error: GetDirectoryFieldRequest error for id: %s! [%s] %s",
-                    imsi,
-                    err.code(),
-                    err.details(),
-                )
-            if req != None:
-                i = MAX
-            else:
-                i+=1
-                print("warning: directoryd failed to return sessionId for %s. Retrying", imsi)
-                time.sleep(3)
+        req = GetDirectoryFieldRequest(id=imsi, field_key="session_id")
+        try:
+            res = self._directorydstub.GetDirectoryField(
+                req, DEFAULT_GRPC_TIMEOUT
+            )
+        except grpc.RpcError as err:
+            print("error: GetDirectoryFieldRequest error for id: "
+                  "%s! [%s] %s" % (imsi, err.code(),err.details())
+            )
 
         if res == None:
-            print("error: Couldnt find sessionid. Directoryd content:")
-            allRecordsResponse = self._directorydstub.GetAllDirectoryRecords(Void(), DEFAULT_GRPC_TIMEOUT)
-            for record in allRecordsResponse.recordsResponse:
-                print("%s", str(record))
+            print("error: Couldn't find sessionid. Directoryd content:")
+            self._print_directoryd_content()
 
         self._session_stub.PolicyReAuth(
             PolicyReAuthRequest(
@@ -1338,17 +1323,28 @@ class SessionManagerUtil(object):
                 req, DEFAULT_GRPC_TIMEOUT
             )
         except grpc.RpcError as err:
-            print("Error: GetDirectoryFieldRequest error for id: %s! [%s] %s",
-                imsi,
-                err.code(),
-                err.details(),
-            )
+            print("Error: GetDirectoryFieldRequest error for id: %s! [%s] %s" %
+                  (imsi, err.code(), err.details()))
+            self._print_directoryd_content()
+
         return self._abort_session_stub.AbortSession(
             AbortSessionRequest(
                 session_id=res.value,
                 user_name=imsi,
             )
         )
+
+    def _print_directoryd_content(self):
+        try:
+            allRecordsResponse = self._directorydstub.GetAllDirectoryRecords(Void(), DEFAULT_GRPC_TIMEOUT)
+        except grpc.RpcError as e:
+            print("error: couldnt print directoryd content. gRPC failed with %s: %s" % (e.code(), e.details()))
+            return
+        if allRecordsResponse is None:
+            print("No records were found at directoryd")
+        else:
+            for record in allRecordsResponse.records:
+                print("%s" % str(record))
 
 
 class GTPBridgeUtils:


### PR DESCRIPTION
Signed-off-by: Oriol Batalla <obatalla@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary

This PR removes a retries loop on `ReAuthRequest` but adds a new print message showing the content of directoryd in case directory doesn't find the session id

## Test Plan

make integ_test

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
