### PR TITLE
[feg][radius] Fix potential out-of-bounds access in EAP packet

### DIFF
--- a/feg/radius/src/modules/eap/packet/packet.go
+++ b/feg/radius/src/modules/eap/packet/packet.go
@@ -23,9 +23,10 @@ import (
 
 // EAP constants
 const (
-	EapMinLegalPacketLength  int = 4
-	EapPacketHeaderLength    int = 4
-	EapPacketTypeFieldLength int = 1
+	EapMinLegalPacketLength                int = 4
+	EapRequestResponseMinLegalPacketLength int = 5
+	EapPacketHeaderLength                  int = 4
+	EapPacketTypeFieldLength               int = 1
 )
 
 // EAP packet header offsets
@@ -105,6 +106,13 @@ func NewPacketFromRaw(b []byte) (*Packet, error) {
 	eapCode := Code(b[EapCodeOffset])
 	if !eapCode.IsValid() {
 		return nil, fmt.Errorf("invalid eap packet code '%d'", b[EapCodeOffset])
+	}
+	if eapCode.IsRequestOrResponse() && (len(b) < EapRequestResponseMinLegalPacketLength) {
+		return nil, fmt.Errorf(
+			"request or response packet length must be at least %d bytes, got %d bytes",
+			EapRequestResponseMinLegalPacketLength,
+			len(b),
+		)
 	}
 
 	var eapType = EAPTypeNONE


### PR DESCRIPTION
## Summary

This PR addresses one instance covered in Issue #4654. Previously, malformed EAP packets could cause an out-of-bounds access. This PR addresses this issue by returning an error under such circumstances.

## Test Plan

### New Tests

Augmented existing unit tests to include off-nominal binary packet representations with incorrect size for their EAP packet type.

### Existing Presubmit Process

Confirmed success of:

> cd feg/radius/src/
> ./run.sh make
> ./run.sh test

Signed-off-by: Scott Harrison Moeller <smoeller@fb.com>