### PR TITLE
[NMS] Enable alerts on dashboard table to auto refresh.

### DIFF
--- a/nms/app/packages/magmalte/app/components/DashboardAlertTable.js
+++ b/nms/app/packages/magmalte/app/components/DashboardAlertTable.js
@@ -35,11 +35,12 @@ import nullthrows from '@fbcnms/util/nullthrows';
 import useMagmaAPI from '@fbcnms/ui/magma/useMagmaAPI';
 
 import {Alarm} from '@material-ui/icons';
+import {REFRESH_INTERVAL} from './context/RefreshContext';
 import {colors, typography} from '../theme/default';
 import {intersection} from 'lodash';
 import {makeStyles} from '@material-ui/styles';
+import {useEffect, useState} from 'react';
 import {useRouter} from '@fbcnms/ui/hooks';
-import {useState} from 'react';
 import {withStyles} from '@material-ui/core/styles';
 
 const useStyles = makeStyles(theme => ({
@@ -159,12 +160,29 @@ export default function DashboardAlertTable(props: DashboardAlertTableProps) {
   const classes = useStyles();
   const {match} = useRouter();
   const networkId: string = nullthrows(match.params.networkId);
+  const [lastRefreshTime, setLastRefreshTime] = useState<string>(
+    new Date().toLocaleString(),
+  );
+
   const {isLoading, response} = useMagmaAPI(
     MagmaV1API.getNetworksByNetworkIdAlerts,
     {
       networkId,
     },
+    undefined,
+    lastRefreshTime,
   );
+  useEffect(() => {
+    const intervalId = setInterval(
+      () => setLastRefreshTime(new Date().toLocaleString()),
+      REFRESH_INTERVAL,
+    );
+
+    return () => {
+      clearInterval(intervalId);
+    };
+  }, []);
+
   if (isLoading) {
     return <LoadingFiller />;
   }


### PR DESCRIPTION
Signed-off-by: Karthik Subraveti <ksubraveti@fb.com>

## Summary

Enabling the alerts to autorefresh on the dashboard every 30s

## Test Plan
![Screen Shot 2021-02-03 at 11 53 33 AM](https://user-images.githubusercontent.com/8224854/106801353-8153d280-6616-11eb-8143-cc5856ad1486.png)
![Screen Shot 2021-02-03 at 11 53 36 AM](https://user-images.githubusercontent.com/8224854/106801365-84e75980-6616-11eb-866c-229aeacecf8b.png)

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
