### PR TITLE
[ctraced][nms] Add NMS support for call trace command passthrough

### DIFF
--- a/nms/app/packages/fbcnms-magma-api/__generated__/MagmaAPIBindings.js
+++ b/nms/app/packages/fbcnms-magma-api/__generated__/MagmaAPIBindings.js
@@ -134,6 +134,8 @@ export type call_trace = {
     state ? : call_trace_state,
 };
 export type call_trace_config = {
+    capture_filters ? : string,
+    display_filters ? : string,
     gateway_id ? : string,
     timeout ? : number,
     trace_id: string,

--- a/nms/app/packages/magmalte/app/components/admin/AddNetworkDialog.js
+++ b/nms/app/packages/magmalte/app/components/admin/AddNetworkDialog.js
@@ -94,7 +94,7 @@ export default function NetworkDialog(props: Props) {
       <DialogContent>
         {error && <FormLabel error>{error}</FormLabel>}
         <TextField
-          name="name"
+          name="networkId"
           label="Network ID"
           className={classes.input}
           value={networkID}

--- a/nms/app/packages/magmalte/app/e2e/NetworkUtils.js
+++ b/nms/app/packages/magmalte/app/e2e/NetworkUtils.js
@@ -35,6 +35,11 @@ export async function addFegNetwork(
   buttonSelector[0].click();
 
   await page.waitForXPath(ADD_NETWORK_DIALOG);
+
+  await page.waitForSelector('input[name=networkId]');
+  await page.click('input[name=networkId]');
+  await page.type('input[name=networkId]', params.name);
+
   await page.waitForSelector('input[name=name]');
   await page.click('input[name=name]');
   await page.type('input[name=name]', params.name);
@@ -67,6 +72,10 @@ export async function addFegLteNetwork(
   buttonSelector[0].click();
 
   await page.waitForXPath(ADD_NETWORK_DIALOG);
+
+  await page.waitForSelector('input[name=networkId]');
+  await page.click('input[name=networkId]');
+  await page.type('input[name=networkId]', params.name);
 
   await page.waitForSelector('input[name=name]');
   await page.click('input[name=name]');

--- a/nms/app/packages/magmalte/app/e2e/__tests__/FegLte-test.js
+++ b/nms/app/packages/magmalte/app/e2e/__tests__/FegLte-test.js
@@ -41,6 +41,7 @@ afterEach(() => {
 describe('Admin component', () => {
   test('verifying addition of feg_lte networks', async () => {
     const page = await browser.newPage();
+    await page.setViewport({width: 1280, height: 1024});
     try {
       await page.goto('https://magma-test.localhost/');
       await page.waitForXPath(`//span[text()='Dashboard']`, {

--- a/nms/app/packages/magmalte/app/theme/default.js
+++ b/nms/app/packages/magmalte/app/theme/default.js
@@ -297,6 +297,7 @@ export default createMuiTheme({
     MuiDialogContent: {
       root: {
         padding: '32px',
+        minHeight: '480px',
       },
     },
     MuiDialogTitle: {

--- a/nms/app/packages/magmalte/app/views/tracing/TraceStartDialog.js
+++ b/nms/app/packages/magmalte/app/views/tracing/TraceStartDialog.js
@@ -27,6 +27,7 @@ import OutlinedInput from '@material-ui/core/OutlinedInput';
 import React from 'react';
 import TraceContext from '../../components/context/TraceContext';
 import TypedSelect from '@fbcnms/ui/components/TypedSelect';
+import Typography from '@material-ui/core/Typography';
 
 import {AltFormField} from '../../components/FormField';
 import {colors, typography} from '../../theme/default';
@@ -40,6 +41,8 @@ const DEFAULT_TRACE_CONFIG: call_trace_config = {
   timeout: 300,
   trace_id: '',
   trace_type: 'GATEWAY',
+  capture_filters: '',
+  display_filters: '',
 };
 
 const useStyles = makeStyles(_ => ({
@@ -61,6 +64,7 @@ const useStyles = makeStyles(_ => ({
       background: colors.primary.mirage,
     },
   },
+  addSubscriberDialog: {},
 }));
 
 export default function CreateTraceButton() {
@@ -107,7 +111,7 @@ type Props = {
 };
 
 function CreateTraceDetails(props: Props) {
-  //   const classes = useStyles();
+  const classes = useStyles();
   const ctx = useContext(TraceContext);
   const [error, setError] = useState('');
   const [traceCfg, setTraceCfg] = useState<call_trace_config>({
@@ -132,7 +136,7 @@ function CreateTraceDetails(props: Props) {
   return (
     <>
       <DialogContent>
-        <List>
+        <List className={classes.addSubscriberDialog}>
           {error !== '' && (
             <AltFormField label={''}>
               <FormLabel data-testid="configEditError" error>
@@ -170,6 +174,7 @@ function CreateTraceDetails(props: Props) {
           </Grid>
           <AltFormField label={'Trace Type'}>
             <TypedSelect
+              disabled={true}
               input={<OutlinedInput />}
               value={traceCfg.trace_type}
               fullWidth={true}
@@ -191,6 +196,83 @@ function CreateTraceDetails(props: Props) {
                 setTraceCfg({...traceCfg, gateway_id: target.value});
               }}
             />
+          </AltFormField>
+          <AltFormField label={'TShark Custom Capture Filters'}>
+            <OutlinedInput
+              data-testid="capture-filters"
+              placeholder="tcp and (port 80 or port 8080)"
+              fullWidth={true}
+              value={traceCfg.capture_filters}
+              onChange={({target}) => {
+                setTraceCfg({
+                  ...traceCfg,
+                  capture_filters: target.value,
+                });
+              }}
+            />
+          </AltFormField>
+          <AltFormField label={'TShark Custom Display Filters'}>
+            <OutlinedInput
+              data-testid="display-filters"
+              placeholder="http"
+              fullWidth={true}
+              value={traceCfg.display_filters}
+              onChange={({target}) => {
+                setTraceCfg({
+                  ...traceCfg,
+                  display_filters: target.value,
+                });
+              }}
+            />
+          </AltFormField>
+          <AltFormField label={'Example Preset Filters'}>
+            <Grid container>
+              <Grid item xs={12} sm={4}>
+                <Button
+                  onClick={() => {
+                    setTraceCfg({
+                      ...traceCfg,
+                      capture_filters: 'tcp and port 80',
+                      display_filters: 'http',
+                    });
+                  }}
+                  className={classes.appBarBtn}>
+                  {'HTTP Messages'}
+                </Button>
+              </Grid>
+              <Grid item xs={12} sm={4}>
+                <Button
+                  onClick={() => {
+                    setTraceCfg({
+                      ...traceCfg,
+                      capture_filters: '',
+                      display_filters: 'dns',
+                    });
+                  }}
+                  className={classes.appBarBtn}>
+                  {'DNS Messages'}
+                </Button>
+              </Grid>
+              <Grid item xs={12} sm={4}>
+                <Button
+                  onClick={() => {
+                    setTraceCfg({
+                      ...traceCfg,
+                      capture_filters: '',
+                      display_filters: 'ip.src==192.168.0.0/16',
+                    });
+                  }}
+                  className={classes.appBarBtn}>
+                  {'Limit IP Src'}
+                </Button>
+              </Grid>
+            </Grid>
+          </AltFormField>
+          <AltFormField label={'TShark Command'}>
+            <Typography component="div" variant="caption">
+              {'tshark -ni any -a filesize:4000 ' +
+                (traceCfg.capture_filters || '')}
+            </Typography>
           </AltFormField>
         </List>
       </DialogContent>


### PR DESCRIPTION
## Summary

Adds NMS support for starting call traces with custom option specifiers using TShark as the underlying tool.

<img width="615" alt="NMS Start Trace 2" src="https://user-images.githubusercontent.com/804385/109089201-b27b6c00-76c5-11eb-8d7d-0361718767c2.png">

## Test Plan

- Manually started a call trace with tshark and custom options, stopped it, and downloaded the call trace data.

## Additional Information

- [ ] This change is backwards-breaking
