### PR TITLE
[lte][agw] Adding logrotate conf for syslog for hourly rotation with max size

### DIFF
--- a/lte/gateway/deploy/roles/magma/files/logrotate_rsyslog.conf
+++ b/lte/gateway/deploy/roles/magma/files/logrotate_rsyslog.conf
@@ -1,0 +1,38 @@
+/var/log/syslog
+{
+        rotate 7
+        hourly
+        missingok
+        notifempty
+        delaycompress
+        compress
+        maxsize 50M
+        postrotate
+                invoke-rc.d rsyslog rotate > /dev/null
+        endscript
+}
+
+/var/log/mail.info
+/var/log/mail.warn
+/var/log/mail.err
+/var/log/mail.log
+/var/log/daemon.log
+/var/log/kern.log
+/var/log/auth.log
+/var/log/user.log
+/var/log/lpr.log
+/var/log/cron.log
+/var/log/debug
+/var/log/messages
+{
+        rotate 4
+        weekly
+        missingok
+        notifempty
+        compress
+        delaycompress
+        sharedscripts
+        postrotate
+                invoke-rc.d rsyslog rotate > /dev/null
+        endscript
+}

--- a/lte/gateway/deploy/roles/magma/tasks/main.yml
+++ b/lte/gateway/deploy/roles/magma/tasks/main.yml
@@ -51,7 +51,13 @@
     dest: /etc/systemd/system/magma_dp@envoy.service
   when: full_provision
 
-- name: Copy logrotate config file
+- name: Copy syslog logrotate config file
+  copy:
+    src: logrotate_rsyslog.conf
+    dest: /etc/logrotate.d/rsyslog
+  when: full_provision
+
+- name: Copy OAI logrotate config file
   copy:
     src: logrotate_oai.conf
     dest: /etc/logrotate.d/oai

--- a/lte/gateway/release/build-magma.sh
+++ b/lte/gateway/release/build-magma.sh
@@ -356,6 +356,7 @@ ${CONTROL_PROXY_FILE}=/etc/magma/ \
 $(glob_files "${ANSIBLE_FILES}/magma_modules_load" /etc/modules-load.d/magma.conf) \
 $(glob_files "${ANSIBLE_FILES}/configure_envoy_namespace.sh" /usr/local/bin/ ) \
 $(glob_files "${ANSIBLE_FILES}/logrotate_oai.conf" /etc/logrotate.d/oai) \
+$(glob_files "${ANSIBLE_FILES}/logrotate_rsyslog.conf" /etc/logrotate.d/rsyslog) \
 $(glob_files "${ANSIBLE_FILES}/local-cdn/*" /var/www/local-cdn/) \
 ${ANSIBLE_FILES}/99-magma.conf=/etc/sysctl.d/ \
 ${ANSIBLE_FILES}/magma_ifaces_gtp=/etc/network/interfaces.d/gtp \


### PR DESCRIPTION
Signed-off-by: Alex Rodriguez <alexrod@fb.com>

## Summary

- This adds rsyslog conf to the magma ansible role to add it to `/etc/logrotate.d/rsyslog`, it also copies the config to the `build-magma.sh` script 
- rotation is set to be done hourly, rather than daily
- this also adds a max size check, for rotation triggered by the size of the file

## Test Plan

- `logrotate -d /etc/logrotate.d/rsyslog`
```
rotating pattern: /var/log/syslog
 hourly (7 rotations)
empty log files are not rotated, log files >= 52428800 are rotated earlier, old logs are removed
considering log /var/log/syslog
  Now: 2021-02-04 03:07
  Last rotated at 2021-02-04 03:07
  log does not need rotating (log has been already rotated)
  ```

## Additional Information

- [ ] This change is backwards-breaking

