### PR TITLE
[show-tech] Minor fixes to show tech tool

### DIFF
--- a/show-tech/constants.yml
+++ b/show-tech/constants.yml
@@ -35,6 +35,7 @@ paths_to_collect:
   - "/etc/systemd/system/*"
   - "/usr/local/bin/mme"
   - "/var/log/syslog"
+  - "/var/core/*"
   - "/var/log/MME.*"
   - "/var/log/enode.*"
 

--- a/show-tech/show-tech.yml
+++ b/show-tech/show-tech.yml
@@ -21,7 +21,6 @@
   gather_facts: yes
   roles:
     - role: load_vars
-    - role: install_ansible_modules
     - role: destdir
     - role: files
     - role: commands


### PR DESCRIPTION
Signed-off-by: Karthik Subraveti <ksubraveti@fb.com>

## Summary

- Show tech was failing due to non existent role. Removed that.
- Added /var/core/* to be added to list of paths to be collected.
- 
## Test Plan
Show tech executes without any errors
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
