### PR TITLE
[directoryd][mobilityd] Add GRPC messages to service log

### DIFF
--- a/lte/gateway/configs/directoryd.yml
+++ b/lte/gateway/configs/directoryd.yml
@@ -12,3 +12,4 @@
 # limitations under the License.
 
 # log_level is set in mconfig. It can be overridden here
+print_grpc_payload: false

--- a/lte/gateway/configs/mobilityd.yml
+++ b/lte/gateway/configs/mobilityd.yml
@@ -14,3 +14,4 @@
 # log_level is set in mconfig. it can be overridden here
 persist_to_redis: true
 redis_port: 6380
+print_grpc_payload: false

--- a/lte/gateway/python/magma/mobilityd/main.py
+++ b/lte/gateway/python/magma/mobilityd/main.py
@@ -125,7 +125,8 @@ def main():
     ip_address_man = IPAddressManager(ipv4_allocator, ipv6_allocator, store)
 
     # Add all servicers to the server
-    mobility_service_servicer = MobilityServiceRpcServicer(ip_address_man)
+    mobility_service_servicer = MobilityServiceRpcServicer(
+        ip_address_man, config.get('print_grpc_payload', False))
     mobility_service_servicer.add_to_server(service.rpc_server)
 
     # Load IPv4 and IPv6 blocks from the configurable mconfig file

--- a/lte/gateway/python/magma/mobilityd/tests/rpc_servicer_tests.py
+++ b/lte/gateway/python/magma/mobilityd/tests/rpc_servicer_tests.py
@@ -58,7 +58,7 @@ class RpcTests(unittest.TestCase):
                                            store)
 
         # Add the servicer
-        self._servicer = MobilityServiceRpcServicer(self._allocator)
+        self._servicer = MobilityServiceRpcServicer(self._allocator, False)
         self._servicer.add_to_server(self._rpc_server)
         self._rpc_server.start()
 

--- a/orc8r/gateway/python/magma/directoryd/main.py
+++ b/orc8r/gateway/python/magma/directoryd/main.py
@@ -19,9 +19,11 @@ from orc8r.protos.mconfig import mconfigs_pb2
 def main():
     """ main() for Directoryd """
     service = MagmaService('directoryd', mconfigs_pb2.DirectoryD())
+    service_config = service.config
 
     # Add servicer to the server
-    gateway_directory_servicer = GatewayDirectoryServiceRpcServicer()
+    gateway_directory_servicer = GatewayDirectoryServiceRpcServicer(
+        service_config.get('print_grpc_payload', False))
     gateway_directory_servicer.add_to_server(service.rpc_server)
 
     # Run the service loop

--- a/orc8r/gateway/python/magma/directoryd/tests/rpc_servicer_tests.py
+++ b/orc8r/gateway/python/magma/directoryd/tests/rpc_servicer_tests.py
@@ -44,7 +44,7 @@ class DirectorydRpcServiceTests(TestCase):
                 'magma.directoryd.rpc_servicer.get_default_client',
                 func_mock):
             # Add the servicer
-            self._servicer = GatewayDirectoryServiceRpcServicer()
+            self._servicer = GatewayDirectoryServiceRpcServicer(False)
             self._servicer.add_to_server(self._rpc_server)
             self._rpc_server.start()
 


### PR DESCRIPTION
Signed-off-by: Oriol Batalla <obatalla@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary

This PR adds some debug messages and the capability to display GRPC messages in mobiliyd and directoryd log.

To enable grpc message, turn it on using the field `magma_print_grpc_payload: true` on the `directoryd.yml` or `mobilityd.yml`

Note this setting is independent of the log level. So you can have `log_level: info` and `magma_print_grpc_payload: true` to display only GRPC messages

Very useful when troubleshooting to know the content of the messages being received and sent.
```
GRPC message:
  magma.orc8r.UpdateRecordRequest {
    "fields": {
      "mac_addr": "aa:aa:bb:bb:cc:cc",
      "ipv4_addr": "192.168.172.12"
    },
    "id": "IMSI555"
  }

```


## Test Plan

make python_test

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
