### PR TITLE
[MME][Ubuntu18] fixes for build oai-mme in RelWithDebInfo

### DIFF
--- a/ci-scripts/docker/Dockerfile.mme.ci.ubuntu18
+++ b/ci-scripts/docker/Dockerfile.mme.ci.ubuntu18
@@ -5,7 +5,7 @@ FROM magma-dev-mme:ci-base-image as magma-mme-builder
 
 ARG FEATURES=mme_oai
 ENV MAGMA_ROOT=/magma
-ENV BUILD_TYPE=Debug
+ENV BUILD_TYPE=RelWithDebInfo
 ENV C_BUILD=/build/c
 ENV TZ=Europe/Paris
 ENV DEBIAN_FRONTEND=noninteractive

--- a/lte/gateway/c/oai/common/pid_file.c
+++ b/lte/gateway/c/oai/common/pid_file.c
@@ -111,13 +111,13 @@ bool pid_file_lock(char const* pid_file_name) {
     return false;
   }
   // fruncate file content
-  if (0 != ftruncate(g_fd_pid_file, 0)) {
+  if (ftruncate(g_fd_pid_file, 0) != 0) {
     printf("filename %s failed to truncate\n", pid_file_name);
   }
   // write PID in file
   g_pid = getpid();
   snprintf(pid_dec, sizeof(pid_dec), "%ld", (long) g_pid);
-  if (0 != write(g_fd_pid_file, pid_dec, strlen(pid_dec))) {
+  if (write(g_fd_pid_file, pid_dec, strlen(pid_dec)) != 0) {
     printf("filename %s failed to be written\n", pid_file_name);
   }
   return true;

--- a/lte/gateway/c/oai/common/pid_file.c
+++ b/lte/gateway/c/oai/common/pid_file.c
@@ -111,11 +111,15 @@ bool pid_file_lock(char const* pid_file_name) {
     return false;
   }
   // fruncate file content
-  ftruncate(g_fd_pid_file, 0);
+  if (0 != ftruncate(g_fd_pid_file, 0)) {
+    printf("filename %s failed to truncate\n", pid_file_name);
+  }
   // write PID in file
   g_pid = getpid();
   snprintf(pid_dec, sizeof(pid_dec), "%ld", (long) g_pid);
-  write(g_fd_pid_file, pid_dec, strlen(pid_dec));
+  if (0 != write(g_fd_pid_file, pid_dec, strlen(pid_dec))) {
+    printf("filename %s failed to be written\n", pid_file_name);
+  }
   return true;
 }
 

--- a/lte/gateway/c/oai/tasks/udp/udp_primitives_server.c
+++ b/lte/gateway/c/oai/tasks/udp/udp_primitives_server.c
@@ -129,10 +129,10 @@ static void udp_server_receive_and_process(
 
     if (ipv6) {
       from_len = (socklen_t) sizeof(struct sockaddr_in6);
-      memset(&addr, 0, sizeof(struct sockaddr_in6));
+      memset(&addr6, 0, sizeof(struct sockaddr_in6));
     } else {
       from_len = (socklen_t) sizeof(struct sockaddr_in);
-      memset(&addr6, 0, sizeof(struct sockaddr_in));
+      memset(&addr, 0, sizeof(struct sockaddr_in));
     }
 
     if ((bytes_received = recvfrom(

--- a/lte/gateway/docker/mme/Dockerfile.ubuntu18.04
+++ b/lte/gateway/docker/mme/Dockerfile.ubuntu18.04
@@ -6,7 +6,7 @@ FROM ubuntu:bionic as magma-mme-builder
 ARG GIT_PROXY
 ARG FEATURES=mme_oai
 ENV MAGMA_ROOT=/magma
-ENV BUILD_TYPE=Debug
+ENV BUILD_TYPE=RelWithDebInfo
 ENV C_BUILD=/build/c
 ENV TZ=Europe/Paris
 ENV DEBIAN_FRONTEND=noninteractive


### PR DESCRIPTION
Signed-off-by: Raphael Defosseux <raphael.defosseux@openairinterface.org>

## Summary

Following PR #4731, I tried again to compile in our Docker Base image in `RelWithDebInfo`.

With our gcc version (`6.5.0`), we still have 2 files in errors with compilation warnings:

```bash
In file included from /usr/include/string.h:494:0,
                 from /magma/lte/gateway/c/oai/tasks/udp/udp_primitives_server.c:33:
In function 'memset',
    inlined from 'udp_server_receive_and_process' at /magma/lte/gateway/c/oai/tasks/udp/udp_primitives_server.c:132:7,
    inlined from 'udp_socket_handler' at /magma/lte/gateway/c/oai/tasks/udp/udp_primitives_server.c:186:5:
/usr/include/x86_64-linux-gnu/bits/string_fortified.h:71:10: error: call to __builtin___memset_chk will always overflow destination buffer [-Werror]
   return __builtin___memset_chk (__dest, __ch, __len, __bos0 (__dest));
          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

This one is a typo I guess.

```bash
/magma/lte/gateway/c/oai/common/pid_file.c: In function 'pid_file_lock':
/magma/lte/gateway/c/oai/common/pid_file.c:114:3: error: ignoring return value of 'ftruncate', declared with attribute warn_unused_result [-Werror=unused-result]
   ftruncate(g_fd_pid_file, 0);
   ^~~~~~~~~~~~~~~~~~~~~~~~~~~
/magma/lte/gateway/c/oai/common/pid_file.c:118:3: error: ignoring return value of 'write', declared with attribute warn_unused_result [-Werror=unused-result]
   write(g_fd_pid_file, pid_dec, strlen(pid_dec));
   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

2 function calls are not tested with their results.
## Test Plan

CI should be enough

## Additional Information
