### PR TITLE
[lte][agw] Disable smsd AGW service by default

### DIFF
--- a/lte/gateway/python/magma/smsd/main.py
+++ b/lte/gateway/python/magma/smsd/main.py
@@ -12,12 +12,10 @@ limitations under the License.
 """
 
 from magma.common.service import MagmaService
-from lte.protos.mconfig import mconfigs_pb2
 from lte.protos.sms_orc8r_pb2_grpc import SMSOrc8rServiceStub, SMSOrc8rGatewayServiceStub, SmsDStub
 from magma.common.service_registry import ServiceRegistry
 from orc8r.protos.directoryd_pb2_grpc import GatewayDirectoryServiceStub
 from .relay import SmsRelay
-
 
 def main():
     """ main() for smsd """
@@ -41,7 +39,6 @@ def main():
     service.run()
     # Cleanup the service
     service.close()
-
 
 if __name__ == "__main__":
     main()

--- a/lte/gateway/python/magma/smsd/relay.py
+++ b/lte/gateway/python/magma/smsd/relay.py
@@ -18,6 +18,8 @@ import grpc
 from magma.common.job import Job
 
 from magma.common.rpc_utils import grpc_async_wrapper, return_void
+from magma.configuration.mconfig_managers import load_service_mconfig
+from lte.protos.mconfig.mconfigs_pb2 import MME
 import lte.protos.sms_orc8r_pb2_grpc as sms_orc8r_pb2_grpc
 import lte.protos.sms_orc8r_pb2 as sms_orc8r_pb2
 from orc8r.protos.common_pb2 import Void
@@ -46,6 +48,11 @@ class SmsRelay(Job):
         sms_orc8r_pb2_grpc.add_SMSOrc8rServiceServicer_to_server(self, server)
 
     async def _run(self) -> None:
+        if not self._is_enabled():
+            # sleep, and don't poll for messages
+            logging.info("mme non_eps_service_config is not SMS_ORC8R, sleeping.")
+            return 
+
         imsis = await self._get_attached_imsis()
         if len(imsis) == 0:
             logging.debug("No active subs")
@@ -92,6 +99,12 @@ class SmsRelay(Job):
     def SMOUplink(self, request: sms_orc8r_pb2.SMOUplinkUnitdata, context):
         logging.debug("got an uplink: %s: %s",
                       request.imsi, request.nas_message_container.hex())
+
+        if not self._is_enabled():
+            # sleep, and don't poll for messages
+            logging.info("mme non_eps_service_config is not SMS_ORC8R, ignoring uplink message.")
+            return 
+
         try:
             self._smsd.ReportDelivery(
                 sms_orc8r_pb2.ReportDeliveryRequest(
@@ -105,3 +118,15 @@ class SmsRelay(Job):
             context.set_details('SMS delivery report to smsd failed: %s' % err)
             context.set_code(grpc.StatusCode.INTERNAL)
             return
+
+    def _is_enabled(self):
+        """ 
+        Returns True if MME's NON_EPS_SERVICE_CONFIG is set to SMS_ORC8R, False
+        otherwise. smsd should only act as a relay when that config paramater
+        is set to SMS_ORC8R (value 3).
+        """
+        mme_service_config = load_service_mconfig("mme", MME())
+        non_eps_service_control = mme_service_config.non_eps_service_control
+        if non_eps_service_control and non_eps_service_control == 3:
+            return True
+        return False


### PR DESCRIPTION
Signed-off-by: Shaddi Hasan <shasan@fb.com>

## Summary

~Disables smsd AGW service by default, and adds a mechanism to enable/disable services via configuration. When a service is disabled, its event loop is not started, and `run()` does nothing.~

Based on feedback, disables smsd AGW service unless the MME is in `SMS_ORC8R` mode. 

## Test Plan

CI + testing on VM

## Additional Information