### PR TITLE
Reduce pipelined interval to 2 s

### DIFF
--- a/lte/gateway/configs/pipelined.yml
+++ b/lte/gateway/configs/pipelined.yml
@@ -42,7 +42,7 @@ static_services: [
 
 of_server_port: 3333
 
-default_priority: 10
+default_priority: 2
 default_rule_tag: 0x1
 
 # Pipeline application level configs

--- a/lte/gateway/configs/pipelined.yml_prod
+++ b/lte/gateway/configs/pipelined.yml_prod
@@ -40,7 +40,7 @@ static_services: [
 
 of_server_port: 3333
 
-default_priority: 10
+default_priority: 2
 default_rule_tag: 0x1
 
 # Pipeline application level configs


### PR DESCRIPTION
Signed-off-by: Oriol Batalla <obatalla@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary

Test for lte-testing branch to see if reducing back the pipelined polling interval to 2 helps to fix CI issues

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
