### PR TITLE
AGW: pipelined: add missing match fields in diff generator.

### DIFF
--- a/lte/gateway/python/magma/pipelined/policy_converters.py
+++ b/lte/gateway/python/magma/pipelined/policy_converters.py
@@ -22,7 +22,10 @@ from ryu.lib.packet import ether_types
 
 MATCH_ATTRIBUTES = ['metadata', 'reg0', 'reg1', 'reg2', 'reg3', 'reg4', 'reg5',
                     'reg6', 'reg8', 'reg9', 'reg10',
-                    'eth_type', 'ipv4_dst', 'ipv4_src', 'ipv6_src', 'ipv6_dst',
+                    'in_port', 'dl_vlan', 'vlan_tci',
+                    'eth_type', 'dl_dst', 'dl_src',
+                    'arp_tpa', 'arp_spa', 'arp_op',
+                    'ipv4_dst', 'ipv4_src', 'ipv6_src', 'ipv6_dst',
                     'ip_proto', 'tcp_src', 'tcp_dst', 'udp_src', 'udp_dst']
 
 


### PR DESCRIPTION
Current code is missing some match fields while comparing
new vs existing flows. This can cause diff generator to
drop new required flows from startup flow list.

Signed-off-by: Pravin B Shelar <pbshelar@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
