### PR TITLE
[lte][agw] Updating health.yml to 3 mins for checking num of restarts

### DIFF
--- a/lte/gateway/configs/health.yml
+++ b/lte/gateway/configs/health.yml
@@ -22,6 +22,6 @@ state_recovery:
 
   # Number of restarts of services_check that triggers recovery process
   restart_threshold: 2
-  interval_check_mins: 1
+  interval_check_mins: 3
   # Destination path to save redis RDB temp snapshots
   snapshots_dir: /tmp/redis_snapshots


### PR DESCRIPTION
Signed-off-by: Alex Rodriguez <alexrod@fb.com>

## Summary

- This PR changes service restarts threshold checkin time to 3 mins, as previous time (1 min) was not enough interval to detect service restarts 

## Test Plan

- Tested on spirent AGW with sctpd bind issue:
```
Feb 05 13:51:41 agw2 health[28106]: DEBUG:root:Unexpected restarts for service pipelined: 0
Feb 05 13:53:41 agw2 health[28106]: INFO:root:Service mme has failed 3 times over last 180 seconds, restarting sctpd to clean state...
Feb 05 13:53:41 agw2 sudo[1754]:     root : TTY=unknown ; PWD=/ ; USER=root ; COMMAND=/usr/sbin/service sctpd restart
Feb 05 13:53:41 agw2 sudo[1754]: pam_unix(sudo:session): session opened for user root by (uid=0)
Feb 05 13:53:44 agw2 health[28106]: DEBUG:root:Unexpected restarts for service mme: 3
Feb 05 13:53:44 agw2 health[28106]: DEBUG:root:Unexpected restarts for service mobilityd: 0
Feb 05 13:53:44 agw2 health[28106]: DEBUG:root:Unexpected restarts for service sessiond: 0
Feb 05 13:53:44 agw2 health[28106]: DEBUG:root:Unexpected restarts for service pipelined: 0
```

## Additional Information

- [ ] This change is backwards-breaking

