### PR TITLE
[NMS] Fix multiple NMS bugs

### DIFF
--- a/nms/app/packages/magmalte/alerts/lteAlerts.js
+++ b/nms/app/packages/magmalte/alerts/lteAlerts.js
@@ -84,7 +84,7 @@ export default function getLteAlerts(
     },
     'Gateway Checkin Failure': {
       alert: 'Gateway Checkin Failure',
-      expr: `checkin_status{networkID=~"${networkID}" < 1`,
+      expr: `checkin_status{networkID=~"${networkID}"} < 1`,
       labels: {severity: 'critical'},
       annotations: {description: 'Alerts when we have gateway checkin failure'},
     },

--- a/nms/app/packages/magmalte/app/views/equipment/GatewayDetailConfigEdit.js
+++ b/nms/app/packages/magmalte/app/views/equipment/GatewayDetailConfigEdit.js
@@ -594,6 +594,7 @@ export function DynamicServicesEdit(props: Props) {
           )}
           <AltFormField label={'Event Aggregation'}>
             <Switch
+              data-testid="eventdService"
               onChange={({target}) =>
                 handleChange(target.checked, DynamicServices.EVENTD)
               }
@@ -604,6 +605,7 @@ export function DynamicServicesEdit(props: Props) {
           </AltFormField>
           <AltFormField label={'Log Aggregation'}>
             <Switch
+              data-testid="tdAgentService"
               onChange={({target}) =>
                 handleChange(target.checked, DynamicServices.TD_AGENT_BIT)
               }
@@ -614,6 +616,7 @@ export function DynamicServicesEdit(props: Props) {
           </AltFormField>
           <AltFormField label={'CPE Monitoring'}>
             <Switch
+              data-testid="monitordService"
               onChange={({target}) =>
                 handleChange(target.checked, DynamicServices.MONITORD)
               }
@@ -686,6 +689,7 @@ export function EPCEdit(props: Props) {
           )}
           <AltFormField label={'Nat Enabled'}>
             <Switch
+              data-testid="natEnabled"
               onChange={() =>
                 handleEPCChange('nat_enabled', !EPCConfig.nat_enabled)
               }
@@ -815,8 +819,9 @@ export function RanEdit(props: Props) {
       const gateway = {
         ...(props.gateway || DEFAULT_GATEWAY_CONFIG),
         cellular: {
-          ...DEFAULT_GATEWAY_CONFIG.cellular,
+          ...(props.gateway?.cellular || DEFAULT_GATEWAY_CONFIG.cellular),
           ran: ranConfig,
+          dns: {...DEFAULT_DNS_CONFIG, ...dnsConfig},
         },
         connected_enodeb_serials: connectedEnodebs,
       };
@@ -869,7 +874,7 @@ export function RanEdit(props: Props) {
               onChange={({target}) => {
                 setConnectedEnodebs(Array.from(target.value));
               }}
-              data-testid="networkType"
+              data-testid="registeredEnodeb"
               MenuProps={{classes: {paper: classes.selectMenu}}}
               renderValue={selected => {
                 if (!selected.length) {
@@ -923,7 +928,7 @@ export function RanEdit(props: Props) {
           Cancel
         </Button>
         <Button onClick={onSave} variant="contained" color="primary">
-          {props.isAdd ? 'Save And Close' : 'Save'}
+          {props.isAdd ? 'Save And Continue' : 'Save'}
         </Button>
       </DialogActions>
     </>
@@ -942,7 +947,6 @@ export function ApnResourcesEdit(props: Props) {
   const [apnResourcesRows, setApnResourcesRows] = useState(
     Object.keys(apnResources).map(apn => apnResources[apn]),
   );
-
   const handleApnResourcesChange = (key: string, val, index: number) => {
     const rows = apnResourcesRows;
     rows[index][key] = val;
@@ -971,6 +975,7 @@ export function ApnResourcesEdit(props: Props) {
         apn_resources: gatewayApnResources,
       };
       await ctx.setState(gateway.id, gateway);
+
       enqueueSnackbar('Gateway saved successfully', {
         variant: 'success',
       });
@@ -982,7 +987,7 @@ export function ApnResourcesEdit(props: Props) {
 
   return (
     <>
-      <DialogContent data-testid="ranEdit">
+      <DialogContent data-testid="apnResourcesEdit">
         <List>
           {error !== '' && (
             <AltFormField label={''}>
@@ -990,6 +995,7 @@ export function ApnResourcesEdit(props: Props) {
             </AltFormField>
           )}
           <Button
+            data-testid="apnResourcesAdd"
             onClick={addApnResource}
             disabled={
               !lteCtx.state.cellular.epc.mobility
@@ -999,7 +1005,7 @@ export function ApnResourcesEdit(props: Props) {
             <AddIcon />
           </Button>
           {apnResourcesRows.map((apn, index) => (
-            <Accordion>
+            <Accordion key={index}>
               <AccordionSummary expandIcon={<ExpandMoreIcon />}>
                 <List className={classes.accordionList}>
                   <ListItem>
@@ -1033,6 +1039,7 @@ export function ApnResourcesEdit(props: Props) {
                 <AltFormField label={'APN name'}>
                   <FormControl className={classes.input}>
                     <Select
+                      data-testid="apnName"
                       value={apn.apn_name}
                       onChange={({target}) => {
                         const apns = apnResourcesRows;
@@ -1041,7 +1048,7 @@ export function ApnResourcesEdit(props: Props) {
                       }}
                       input={<OutlinedInput />}>
                       {(Object.keys(apnCtx.state) || []).map(apn => (
-                        <MenuItem value={apn}>
+                        <MenuItem key={apn} value={apn}>
                           <ListItemText primary={apn} />
                         </MenuItem>
                       ))}
@@ -1050,6 +1057,7 @@ export function ApnResourcesEdit(props: Props) {
                 </AltFormField>
                 <AltFormField label={'APN Resource ID'}>
                   <OutlinedInput
+                    data-testid="apnID"
                     className={classes.input}
                     placeholder="Enter ID"
                     fullWidth={true}
@@ -1063,6 +1071,7 @@ export function ApnResourcesEdit(props: Props) {
                 </AltFormField>
                 <AltFormField label={'VLAN ID'}>
                   <OutlinedInput
+                    data-testid="vlanID"
                     className={classes.input}
                     type="number"
                     placeholder="Enter number"

--- a/nms/app/packages/magmalte/app/views/equipment/__tests__/GatewayConfigTest.js
+++ b/nms/app/packages/magmalte/app/views/equipment/__tests__/GatewayConfigTest.js
@@ -13,13 +13,15 @@
  * @flow strict-local
  * @format
  */
-import type {lte_gateway} from '@fbcnms/magma-api';
+import type {apn, lte_gateway, lte_network} from '@fbcnms/magma-api';
 
 import 'jest-dom/extend-expect';
 
 import AddEditGatewayButton from '../GatewayDetailConfigEdit';
+import ApnContext from '../../../components/context/ApnContext';
 import GatewayConfig from '../GatewayDetailConfig';
 import GatewayContext from '../../../components/context/GatewayContext';
+import LteNetworkContext from '../../../components/context/LteNetworkContext';
 import MagmaAPIBindings from '@fbcnms/magma-api';
 import MuiStylesThemeProvider from '@material-ui/styles/ThemeProvider';
 import React from 'react';
@@ -86,8 +88,108 @@ const mockGw0: lte_gateway = {
   },
 };
 
+const mockGw1: lte_gateway = {
+  apn_resources: {},
+  id: ' testGatewayId1',
+  name: ' testGateway1',
+  description: ' testGateway1',
+  tier: 'default',
+  device: {
+    key: {key: '', key_type: 'SOFTWARE_ECDSA_SHA256'},
+    hardware_id: '',
+  },
+  magmad: {
+    autoupgrade_enabled: true,
+    autoupgrade_poll_interval: 300,
+    checkin_interval: 60,
+    checkin_timeout: 100,
+    tier: 'tier2',
+  },
+  connected_enodeb_serials: [],
+  cellular: {
+    epc: {
+      ip_block: '192.168.0.1/24',
+      nat_enabled: false,
+      sgi_management_iface_static_ip: '1.1.1.1/24',
+      sgi_management_iface_vlan: '100',
+    },
+    ran: {
+      pci: 620,
+      transmit_enabled: true,
+    },
+  },
+  status: {
+    checkin_time: 0,
+    meta: {
+      gps_latitude: '0',
+      gps_longitude: '0',
+      gps_connected: '0',
+      enodeb_connected: '0',
+      mme_connected: '0',
+    },
+  },
+};
+
+const mockNw: lte_network = {
+  cellular: {
+    epc: {
+      default_rule_id: 'default_rule_1',
+      gx_gy_relay_enabled: false,
+      hss_relay_enabled: false,
+      lte_auth_amf: 'gAA=',
+      lte_auth_op: '=',
+      mcc: '001',
+      mnc: '01',
+      mobility: {
+        ip_allocation_mode: 'DHCP_BROADCAST',
+        enable_multi_apn_ip_allocation: true,
+      },
+      network_services: ['policy_enforcement'],
+      tac: 1,
+    },
+    ran: {
+      bandwidth_mhz: 20,
+      tdd_config: {
+        earfcndl: 44590,
+        special_subframe_pattern: 7,
+        subframe_assignment: 2,
+      },
+    },
+  },
+  description: 'magma appliance',
+  dns: {
+    enable_caching: false,
+    local_ttl: 0,
+  },
+  features: {
+    features: {
+      placeholder: 'true',
+    },
+  },
+  id: '1dev_agw',
+  name: '1dev_agw',
+};
+
+const mockApns: {[string]: apn} = {
+  'oai.ipv4': {
+    apn_configuration: {
+      ambr: {max_bandwidth_dl: 1000000, max_bandwidth_ul: 1000000},
+      qos_profile: {
+        class_id: 9,
+        preemption_capability: false,
+        preemption_vulnerability: false,
+        priority_level: 15,
+      },
+    },
+    apn_name: 'oai.ipv4',
+  },
+};
+
 describe('<AddEditGatewayButton />', () => {
   afterEach(() => {
+    MagmaAPIBindings.getLteByNetworkIdGateways.mockResolvedValue({
+      testGatewayId0: mockGw0,
+    });
     MagmaAPIBindings.postLteByNetworkIdGateways.mockClear();
     MagmaAPIBindings.putLteByNetworkIdGatewaysByGatewayIdCellularDns.mockClear();
   });
@@ -98,30 +200,46 @@ describe('<AddEditGatewayButton />', () => {
       <MemoryRouter initialEntries={['/nms/test/gateway']} initialIndex={0}>
         <MuiThemeProvider theme={defaultTheme}>
           <MuiStylesThemeProvider theme={defaultTheme}>
-            <GatewayContext.Provider
+            <ApnContext.Provider
               value={{
-                state: lteGateways,
-                setState: async (key, value?) =>
-                  SetGatewayState({
-                    lteGateways: lteGateways,
-                    setLteGateways: setLteGateways,
-                    networkId: 'test',
-                    key: key,
-                    value: value,
-                  }),
-                updateGateway: async () => {},
+                state: mockApns,
+                setState: async () => {},
               }}>
-              <Route
-                path="/nms/:networkId/gateway"
-                render={props => (
-                  <AddEditGatewayButton
-                    {...props}
-                    title="Add Gateway"
-                    isLink={false}
+              <LteNetworkContext.Provider
+                value={{
+                  state: mockNw,
+                  updateNetworks: async () => {},
+                }}>
+                <GatewayContext.Provider
+                  value={{
+                    state: lteGateways,
+                    setState: async (key, value?) =>
+                      SetGatewayState({
+                        lteGateways: lteGateways,
+                        setLteGateways: setLteGateways,
+                        networkId: 'test',
+                        key: key,
+                        value: value,
+                      }),
+                    updateGateway: props =>
+                      UpdateGateway({
+                        networkId: 'test',
+                        setLteGateways,
+                        ...props,
+                      }),
+                  }}>
+                  <Route
+                    path="/nms/:networkId/gateway"
+                    render={_ => (
+                      <AddEditGatewayButton
+                        title="Add Gateway"
+                        isLink={false}
+                      />
+                    )}
                   />
-                )}
-              />
-            </GatewayContext.Provider>
+                </GatewayContext.Provider>
+              </LteNetworkContext.Provider>
+            </ApnContext.Provider>
           </MuiStylesThemeProvider>
         </MuiThemeProvider>
       </MemoryRouter>
@@ -171,6 +289,7 @@ describe('<AddEditGatewayButton />', () => {
     expect(queryByTestId('dynamicServicesEdit')).toBeNull();
     expect(queryByTestId('ranEdit')).toBeNull();
     expect(queryByTestId('epcEdit')).toBeNull();
+    expect(queryByTestId('apnResourcesEdit')).toBeNull();
 
     const gatewayID = getByTestId('id').firstChild;
     const gatewayName = getByTestId('name').firstChild;
@@ -266,6 +385,244 @@ describe('<AddEditGatewayButton />', () => {
         },
         tier: 'default',
       },
+      networkId: 'test',
+    });
+
+    // mock adding test gatewayID1 to ensure we invoke the put method
+    MagmaAPIBindings.getLteByNetworkIdGateways.mockResolvedValue({
+      testGatewayID1: mockGw1,
+    });
+
+    expect(queryByTestId('configEdit')).toBeNull();
+    expect(queryByTestId('dynamicServicesEdit')).not.toBeNull();
+    expect(queryByTestId('ranEdit')).toBeNull();
+    expect(queryByTestId('epcEdit')).toBeNull();
+    expect(queryByTestId('apnResourcesEdit')).toBeNull();
+
+    // Verify Dynamic Services Edit
+    const monitordService = getByTestId('monitordService').firstChild;
+    if (
+      monitordService instanceof HTMLElement &&
+      monitordService.firstChild instanceof HTMLElement
+    ) {
+      fireEvent.click(monitordService.firstChild);
+    } else {
+      throw 'invalid type';
+    }
+    fireEvent.click(getByText('Save And Continue'));
+    await wait();
+
+    expect(
+      MagmaAPIBindings.putLteByNetworkIdGatewaysByGatewayIdMagmad,
+    ).toHaveBeenCalledWith({
+      gatewayId: 'testGatewayID1',
+      networkId: 'test',
+      magmad: {
+        autoupgrade_enabled: true,
+        autoupgrade_poll_interval: 60,
+        checkin_interval: 60,
+        checkin_timeout: 30,
+        dynamic_services: [
+          DynamicServices.EVENTD,
+          DynamicServices.TD_AGENT_BIT,
+          DynamicServices.MONITORD,
+        ],
+        logging: {
+          aggregation: {
+            target_files_by_tag: {
+              mme: 'var/log/mme.log',
+            },
+          },
+          log_level: 'DEBUG',
+        },
+      },
+    });
+
+    expect(queryByTestId('configEdit')).toBeNull();
+    expect(queryByTestId('dynamicServicesEdit')).toBeNull();
+    expect(queryByTestId('epcEdit')).not.toBeNull();
+    expect(queryByTestId('ranEdit')).toBeNull();
+    expect(queryByTestId('apnResourcesEdit')).toBeNull();
+
+    // Verify EPC Edit
+    const natEnabled = getByTestId('natEnabled').firstChild;
+    if (
+      natEnabled instanceof HTMLElement &&
+      natEnabled.firstChild instanceof HTMLElement
+    ) {
+      fireEvent.click(natEnabled.firstChild);
+    } else {
+      throw 'invalid type';
+    }
+    fireEvent.click(getByText('Save And Continue'));
+    await wait();
+
+    expect(
+      MagmaAPIBindings.putLteByNetworkIdGatewaysByGatewayIdCellularEpc,
+    ).toHaveBeenCalledWith({
+      gatewayId: 'testGatewayID1',
+      networkId: 'test',
+      config: {
+        ip_block: '192.168.128.0/24',
+        nat_enabled: false,
+        dns_primary: '',
+        dns_secondary: '',
+        sgi_management_iface_gw: '',
+        sgi_management_iface_static_ip: '',
+        sgi_management_iface_vlan: '',
+      },
+    });
+
+    expect(queryByTestId('configEdit')).toBeNull();
+    expect(queryByTestId('dynamicServicesEdit')).toBeNull();
+    expect(queryByTestId('epcEdit')).toBeNull();
+    expect(queryByTestId('ranEdit')).not.toBeNull();
+    expect(queryByTestId('apnResourcesEdit')).toBeNull();
+
+    // Verify RAN Edit
+    let pci = getByTestId('pci').firstChild;
+    if (pci instanceof HTMLInputElement) {
+      expect(pci.disabled).toBe(false);
+    } else {
+      throw 'invalid type';
+    }
+
+    const enbDhcpService = getByTestId('enbDhcpService').firstChild;
+    if (
+      enbDhcpService instanceof HTMLElement &&
+      enbDhcpService.firstChild instanceof HTMLElement
+    ) {
+      fireEvent.click(enbDhcpService.firstChild);
+    } else {
+      throw 'invalid type';
+    }
+    await wait();
+
+    pci = getByTestId('pci').firstChild;
+    if (pci instanceof HTMLInputElement) {
+      expect(pci.disabled).toBe(true);
+    } else {
+      throw 'invalid type';
+    }
+    fireEvent.click(getByText('Save And Continue'));
+    await wait();
+    expect(
+      MagmaAPIBindings.putLteByNetworkIdGatewaysByGatewayIdCellularDns,
+    ).toHaveBeenCalledWith({
+      config: {
+        dhcp_server_enabled: false,
+        enable_caching: false,
+        local_ttl: 0,
+        records: [],
+      },
+      gatewayId: 'testGatewayID1',
+      networkId: 'test',
+    });
+    expect(
+      MagmaAPIBindings.putLteByNetworkIdGatewaysByGatewayIdCellularRan,
+    ).toHaveBeenCalledWith({
+      config: {
+        pci: 260,
+        transmit_enabled: true,
+      },
+      gatewayId: 'testGatewayID1',
+      networkId: 'test',
+    });
+
+    expect(queryByTestId('configEdit')).toBeNull();
+    expect(queryByTestId('dynamicServicesEdit')).toBeNull();
+    expect(queryByTestId('epcEdit')).toBeNull();
+    expect(queryByTestId('ranEdit')).toBeNull();
+    expect(queryByTestId('apnResourcesEdit')).not.toBeNull();
+
+    // Verify Apn Resources Edit
+    expect(queryByTestId('apnResourcesAdd')).not.toBeNull();
+    const apnResourcesAdd = queryByTestId('apnResourcesAdd');
+    if (!apnResourcesAdd) {
+      throw new Error('apn resources add button unexpected null');
+    }
+    fireEvent.click(apnResourcesAdd);
+    const apnID = getByTestId('apnID').firstChild;
+    const vlanID = getByTestId('vlanID').firstChild;
+
+    if (apnID instanceof HTMLInputElement) {
+      fireEvent.change(apnID, {target: {value: '1'}});
+    } else {
+      throw 'invalid type';
+    }
+
+    if (vlanID instanceof HTMLInputElement) {
+      fireEvent.change(vlanID, {target: {value: '1'}});
+    } else {
+      throw 'invalid type';
+    }
+
+    fireEvent.click(getByText('Save And Close'));
+    await wait();
+
+    expect(
+      MagmaAPIBindings.putLteByNetworkIdGatewaysByGatewayId,
+    ).toHaveBeenCalledWith({
+      gateway: {
+        apn_resources: {'': {apn_name: '', id: '1', vlan_id: 1}},
+        cellular: {
+          dns: {
+            dhcp_server_enabled: false,
+            enable_caching: false,
+            local_ttl: 0,
+            records: [],
+          },
+          epc: {
+            ip_block: '192.168.128.0/24',
+            nat_enabled: false,
+            dns_primary: '',
+            dns_secondary: '',
+            sgi_management_iface_gw: '',
+            sgi_management_iface_static_ip: '',
+            sgi_management_iface_vlan: '',
+          },
+          ran: {pci: 260, transmit_enabled: true},
+        },
+        connected_enodeb_serials: [],
+        description: 'Test Gateway Description',
+        device: {
+          hardware_id: 'testHwId',
+          key: {key: 'testChallenge', key_type: 'SOFTWARE_ECDSA_SHA256'},
+        },
+        id: 'testGatewayID1',
+        magmad: {
+          autoupgrade_enabled: true,
+          autoupgrade_poll_interval: 60,
+          checkin_interval: 60,
+          checkin_timeout: 30,
+          dynamic_services: [
+            DynamicServices.EVENTD,
+            DynamicServices.TD_AGENT_BIT,
+            DynamicServices.MONITORD,
+          ],
+          logging: {
+            aggregation: {
+              target_files_by_tag: {
+                mme: 'var/log/mme.log',
+              },
+            },
+            log_level: 'DEBUG',
+          },
+        },
+        name: 'testGatewayName',
+
+        status: {
+          platform_info: {
+            packages: [
+              {
+                version: '1.0',
+              },
+            ],
+          },
+        },
+        tier: 'default',
+      },
+      gatewayId: 'testGatewayID1',
       networkId: 'test',
     });
   });

--- a/nms/app/packages/magmalte/app/views/events/EventsTable.js
+++ b/nms/app/packages/magmalte/app/views/events/EventsTable.js
@@ -253,7 +253,7 @@ export default function EventsTable(props: EventTableProps) {
   let actionTableOptions = {
     actionsColumnIndex: -1,
     pageSize: 5,
-    pageSizeOptions: [10, 20],
+    pageSizeOptions: [5, 10, 20],
     toolbar: false,
   };
 

--- a/nms/app/packages/magmalte/app/views/subscriber/SubscriberAddDialog.js
+++ b/nms/app/packages/magmalte/app/views/subscriber/SubscriberAddDialog.js
@@ -125,8 +125,42 @@ type SubscriberInfo = {
   state: 'INACTIVE' | 'ACTIVE',
   dataPlan: string,
   apns: Array<string>,
-  policies: Array<string>,
+  policies?: Array<string>,
 };
+
+const SUB_NAME_OFFSET = 0;
+const SUB_IMSI_OFFSET = 1;
+const SUB_AUTH_KEY_OFFSET = 2;
+const SUB_AUTH_OPC_OFFSET = 3;
+const SUB_STATE_OFFSET = 4;
+const SUB_DATAPLAN_OFFSET = 5;
+const SUB_APN_OFFSET = 6;
+const SUB_POLICY_OFFSET = 7;
+const SUB_MAX_FIELDS = 8;
+
+function parseSubscriber(line: string) {
+  const items = line.split(',').map(item => item.trim());
+  if (items.length > SUB_MAX_FIELDS) {
+    throw new Error(
+      `Too many fields to parse, expected ${SUB_MAX_FIELDS} fields, received ${items.length} fields`,
+    );
+  }
+
+  return {
+    name: items[SUB_NAME_OFFSET],
+    imsi: items[SUB_IMSI_OFFSET],
+    authKey: items[SUB_AUTH_KEY_OFFSET],
+    authOpc: items[SUB_AUTH_OPC_OFFSET],
+    state: items[SUB_STATE_OFFSET] === 'ACTIVE' ? 'ACTIVE' : 'INACTIVE',
+    dataPlan: items[SUB_DATAPLAN_OFFSET],
+    apns: items[SUB_APN_OFFSET].split('|')
+      .map(item => item.trim())
+      .filter(Boolean),
+    policies: items?.[SUB_POLICY_OFFSET]?.split('|')
+      .map(item => item.trim())
+      .filter(Boolean),
+  };
+}
 
 function parseSubscriberFile(fileObj: File) {
   const reader = new FileReader();
@@ -156,23 +190,7 @@ function parseSubscriberFile(fileObj: File) {
           .split('\n')
           .map(item => item.trim())
           .filter(Boolean)) {
-          const items = line.split(',').map(item => item.trim());
-          if (items.length != 7) {
-            reject('failed parsing ' + line);
-            return;
-          }
-          subscribers.push({
-            name: items[0],
-            imsi: items[1],
-            authKey: items[2],
-            authOpc: items[3],
-            state: items[4] === 'ACTIVE' ? 'ACTIVE' : 'INACTIVE',
-            dataPlan: items[5],
-            apns: items[6]
-              .split('|')
-              .map(item => item.trim())
-              .filter(Boolean),
-          });
+          subscribers.push(parseSubscriber(line));
         }
       } catch (e) {
         reject('Failed parsing the file ' + fileObj.name + '. ' + e?.message);
@@ -184,13 +202,19 @@ function parseSubscriberFile(fileObj: File) {
   });
 }
 
-export default function AddSubscriberButton() {
+export default function AddSubscriberButton(props: {onClose: () => void}) {
   const classes = useStyles();
   const [open, setOpen] = useState(false);
 
   return (
     <>
-      <AddSubscriberDialog open={open} onClose={() => setOpen(false)} />
+      <AddSubscriberDialog
+        open={open}
+        onClose={() => {
+          setOpen(false);
+          props.onClose();
+        }}
+      />
       <Button onClick={() => setOpen(true)} className={classes.appBarBtn}>
         {'Add Subscriber'}
       </Button>

--- a/nms/app/packages/magmalte/app/views/subscriber/SubscriberOverview.js
+++ b/nms/app/packages/magmalte/app/views/subscriber/SubscriberOverview.js
@@ -23,13 +23,12 @@ import type {
 import ActionTable from '../../components/ActionTable';
 import AddSubscriberButton from './SubscriberAddDialog';
 import AutorefreshCheckbox from '../../components/AutorefreshCheckbox';
-import Button from '@material-ui/core/Button';
+import CardTitleRow from '../../components/layout/CardTitleRow';
 import Dialog from '@material-ui/core/Dialog';
 import DialogContent from '@material-ui/core/DialogContent';
 import DialogTitle from '@material-ui/core/DialogTitle';
 import ExpandLess from '@material-ui/icons/ExpandLess';
 import ExpandMore from '@material-ui/icons/ExpandMore';
-import Grid from '@material-ui/core/Grid';
 import Link from '@material-ui/core/Link';
 import List from '@material-ui/core/List';
 import ListItem from '@material-ui/core/ListItem';
@@ -43,7 +42,6 @@ import Text from '../../theme/design-system/Text';
 import TopBar from '../../components/TopBar';
 import nullthrows from '@fbcnms/util/nullthrows';
 import withAlert from '@fbcnms/ui/components/Alert/withAlert';
-import {useEffect} from 'react';
 
 import {FEG_LTE} from '@fbcnms/types/network';
 import {
@@ -98,10 +96,7 @@ export default function SubscriberDashboard() {
         component={SubscriberDetail}
       />
 
-      <Route
-        path={relativePath('/overview')}
-        component={SubscriberDashboardInternal}
-      />
+      <Route path={relativePath('/overview')} component={SubscriberOverview} />
       <Redirect to={relativeUrl('/overview')} />
     </Switch>
   );
@@ -127,44 +122,6 @@ type SubscriberSessionRowType = {
   activeDuration: string,
   activePolicies: Array<string>,
 };
-
-function SubscriberDashboardInternal() {
-  const classes = useStyles();
-  return (
-    <>
-      <TopBar
-        header={TITLE}
-        tabs={[
-          {
-            label: 'Subscribers',
-            to: '/subscribersv2',
-            icon: PeopleIcon,
-            filters: (
-              <Grid
-                container
-                justify="flex-end"
-                alignItems="center"
-                spacing={2}>
-                <Grid item>
-                  {/* TODO: these button styles need to be localized */}
-                  <Button variant="text" className={classes.appBarBtnSecondary}>
-                    Secondary Action
-                  </Button>
-                </Grid>
-                <Grid item>
-                  <Button variant="contained" className={classes.appBarBtn}>
-                    Primary Action
-                  </Button>
-                </Grid>
-              </Grid>
-            ),
-          },
-        ]}
-      />
-      <Subscribers />
-    </>
-  );
-}
 
 type Props = {
   open: boolean,
@@ -194,57 +151,14 @@ function JsonDialog(props: Props) {
   );
 }
 
-function Subscribers() {
-  const [refresh, setRefresh] = useState(true);
-  const classes = useStyles();
-
-  return (
-    <div className={classes.dashboardRoot}>
-      <Grid container spacing={4}>
-        <Grid item xs={12}>
-          <Grid item xs={12} container>
-            <Grid
-              container
-              alignItems="center"
-              className={classes.cardTitleRow}>
-              <Grid item xs>
-                <Grid container alignItems="center">
-                  <PeopleIcon className={classes.cardTitleIcon} />
-                  <Text variant="body1">{TITLE}</Text>
-                </Grid>
-              </Grid>
-              <Grid item>
-                <Grid
-                  container
-                  justify="flex-end"
-                  alignItems="center"
-                  spacing={2}>
-                  <Grid item>
-                    <AutorefreshCheckbox
-                      autorefreshEnabled={refresh}
-                      onToggle={() => setRefresh(current => !current)}
-                    />
-                  </Grid>
-                  <Grid item>
-                    <AddSubscriberButton />
-                  </Grid>
-                </Grid>
-              </Grid>
-            </Grid>
-          </Grid>
-          <SubscriberTable refresh={refresh} />
-        </Grid>
-      </Grid>
-    </div>
-  );
-}
-
-function Table(props: WithAlert & {refresh: boolean}) {
+function SubscriberInternal(props: WithAlert) {
   const {history, match, relativeUrl} = useRouter();
   const [currRow, setCurrRow] = useState<SubscriberRowType>({});
   const networkId: string = nullthrows(match.params.networkId);
   const enqueueSnackbar = useEnqueueSnackbar();
   const ctx = useContext(SubscriberContext);
+  const [refresh, setRefresh] = useState(true);
+  const classes = useStyles();
   const [lastRefreshTime, setLastRefreshTime] = useState(
     new Date().toLocaleString(),
   );
@@ -252,18 +166,14 @@ function Table(props: WithAlert & {refresh: boolean}) {
   // Auto refresh subscribers every 30 seconds
   const state = useRefreshingContext({
     context: SubscriberContext,
-    networkId: networkId,
+    networkId,
     type: 'subscriber',
     interval: REFRESH_INTERVAL,
     enqueueSnackbar,
-    refresh: props.refresh,
-    lastRefreshTime: lastRefreshTime,
+    refresh,
+    lastRefreshTime,
   });
-  const ctxValues = [...Object.values(ctx.state)];
-  const sessionValues = [...Object.values(ctx.sessionState)];
-  useEffect(() => {
-    setLastRefreshTime(new Date().toLocaleString());
-  }, [ctxValues.length, sessionValues.length]);
+
   const networkCtx = useContext(NetworkContext);
   // $FlowIgnore
   const subscriberMap: {[string]: subscriber} = state.state;
@@ -337,197 +247,230 @@ function Table(props: WithAlert & {refresh: boolean}) {
   const onClose = () => setJsonDialog(false);
   return (
     <>
-      {subscriberMap || sessionState ? (
-        <div>
-          <JsonDialog open={jsonDialog} onClose={onClose} imsi={currRow.imsi} />
-          <ActionTable
-            data={
-              !Object.keys(sessionState).length
-                ? tableData
-                : tableData.map(row => {
-                    const subscriber =
-                      sessionState[row.imsi]?.subscriber_state || {};
-                    const ipAddresses = [];
-                    const activeApns = [];
-                    let activeSessions = 0;
-                    Object.keys(subscriber || {}).forEach(apn => {
-                      subscriber[apn].forEach(session => {
-                        if (session.lifecycle_state === 'SESSION_ACTIVE') {
-                          ipAddresses.push(session?.ipv4);
-                          activeSessions++;
-                        }
+      <TopBar
+        header={TITLE}
+        tabs={[
+          {
+            label: 'Subscribers',
+            to: '/subscribersv2',
+            icon: PeopleIcon,
+            filters: (
+              <AddSubscriberButton
+                onClose={() => setLastRefreshTime(new Date().toLocaleString())}
+              />
+            ),
+          },
+        ]}
+      />
+      <div className={classes.dashboardRoot}>
+        <CardTitleRow
+          key="title"
+          icon={PeopleIcon}
+          label={TITLE}
+          filter={() => (
+            <AutorefreshCheckbox
+              autorefreshEnabled={refresh}
+              onToggle={() => setRefresh(current => !current)}
+            />
+          )}
+        />
+        {subscriberMap || sessionState ? (
+          <div>
+            <JsonDialog
+              open={jsonDialog}
+              onClose={onClose}
+              imsi={currRow.imsi}
+            />
+            <ActionTable
+              data={
+                !Object.keys(sessionState).length
+                  ? tableData
+                  : tableData.map(row => {
+                      const subscriber =
+                        sessionState[row.imsi]?.subscriber_state || {};
+                      const ipAddresses = [];
+                      const activeApns = [];
+                      let activeSessions = 0;
+                      Object.keys(subscriber || {}).forEach(apn => {
+                        subscriber[apn].forEach(session => {
+                          if (session.lifecycle_state === 'SESSION_ACTIVE') {
+                            ipAddresses.push(session?.ipv4);
+                            activeSessions++;
+                          }
+                        });
+                        activeApns.push(apn);
                       });
-                      activeApns.push(apn);
-                    });
-                    return {
-                      ...row,
-                      activeApns:
-                        activeApns.length > 0 ? activeApns.join() : '-',
-                      activeSessions: activeSessions,
-                      ipAddress:
-                        ipAddresses.length > 0 ? ipAddresses.join() : '-',
-                    };
-                  })
-            }
-            columns={
-              !Object.keys(sessionState).length
-                ? tableColumns
-                : [
-                    ...tableColumns,
-                    {
-                      title: 'Active Sessions',
-                      field: 'activeSessions',
-                      width: 175,
-                    },
-                    {title: 'Active APNs', field: 'activeApns'},
-                    {title: 'IP Address', field: 'ipAddress'},
-                  ]
-            }
-            handleCurrRow={(row: SubscriberRowType) => setCurrRow(row)}
-            menuItems={
-              networkCtx.networkType === FEG_LTE
-                ? [
-                    {
-                      name: 'View JSON',
-                      handleFunc: () => {
-                        setJsonDialog(true);
+                      return {
+                        ...row,
+                        activeApns:
+                          activeApns.length > 0 ? activeApns.join() : '-',
+                        activeSessions: activeSessions,
+                        ipAddress:
+                          ipAddresses.length > 0 ? ipAddresses.join() : '-',
+                      };
+                    })
+              }
+              columns={
+                !Object.keys(sessionState).length
+                  ? tableColumns
+                  : [
+                      ...tableColumns,
+                      {
+                        title: 'Active Sessions',
+                        field: 'activeSessions',
+                        width: 175,
                       },
-                    },
-                  ]
-                : [
-                    {
-                      name: 'View JSON',
-                      handleFunc: () => {
-                        setJsonDialog(true);
+                      {title: 'Active APNs', field: 'activeApns'},
+                      {title: 'IP Address', field: 'ipAddress'},
+                    ]
+              }
+              handleCurrRow={(row: SubscriberRowType) => setCurrRow(row)}
+              menuItems={
+                networkCtx.networkType === FEG_LTE
+                  ? [
+                      {
+                        name: 'View JSON',
+                        handleFunc: () => {
+                          setJsonDialog(true);
+                        },
                       },
-                    },
-                    {
-                      name: 'View',
-                      handleFunc: () => {
-                        history.push(relativeUrl('/' + currRow.imsi));
+                    ]
+                  : [
+                      {
+                        name: 'View JSON',
+                        handleFunc: () => {
+                          setJsonDialog(true);
+                        },
                       },
-                    },
-                    {
-                      name: 'Edit',
-                      handleFunc: () => {
-                        history.push(
-                          relativeUrl('/' + currRow.imsi + '/config'),
-                        );
+                      {
+                        name: 'View',
+                        handleFunc: () => {
+                          history.push(relativeUrl('/' + currRow.imsi));
+                        },
                       },
-                    },
-                    {
-                      name: 'Remove',
-                      handleFunc: () => {
-                        props
-                          .confirm(
-                            `Are you sure you want to delete ${currRow.imsi}?`,
-                          )
-                          .then(async confirmed => {
-                            if (!confirmed) {
-                              return;
-                            }
+                      {
+                        name: 'Edit',
+                        handleFunc: () => {
+                          history.push(
+                            relativeUrl('/' + currRow.imsi + '/config'),
+                          );
+                        },
+                      },
+                      {
+                        name: 'Remove',
+                        handleFunc: () => {
+                          props
+                            .confirm(
+                              `Are you sure you want to delete ${currRow.imsi}?`,
+                            )
+                            .then(async confirmed => {
+                              if (!confirmed) {
+                                return;
+                              }
 
-                            try {
-                              await ctx.setState?.(currRow.imsi);
-                            } catch (e) {
-                              enqueueSnackbar(
-                                'failed deleting subscriber ' + currRow.imsi,
-                                {
-                                  variant: 'error',
-                                },
-                              );
-                            }
-                          });
+                              try {
+                                await ctx.setState?.(currRow.imsi);
+                                setLastRefreshTime(new Date().toLocaleString());
+                              } catch (e) {
+                                enqueueSnackbar(
+                                  'failed deleting subscriber ' + currRow.imsi,
+                                  {
+                                    variant: 'error',
+                                  },
+                                );
+                              }
+                            });
+                        },
                       },
-                    },
-                  ]
-            }
-            options={{
-              actionsColumnIndex: -1,
-              pageSize: 10,
-              pageSizeOptions: [10, 20],
-            }}
-            detailPanel={
-              !Object.keys(sessionState).length
-                ? []
-                : [
-                    {
-                      icon: () => {
-                        return <ExpandMore data-testid="details" />;
-                      },
-                      openIcon: ExpandLess,
-                      render: rowData => {
-                        const subscriber =
-                          sessionState[rowData.imsi]?.subscriber_state || {};
-                        const subscriberSessionRows: Array<SubscriberSessionRowType> = [];
-                        Object.keys(subscriber).map((apn: string) => {
-                          subscriber[apn].map(infos => {
-                            subscriberSessionRows.push({
-                              apnName: apn,
-                              sessionId: infos.session_id,
-                              ipAddr: infos.ipv4 ?? '-',
-                              state: infos.lifecycle_state,
-                              activeDuration: `${infos.active_duration_sec} sec`,
-                              activePolicies: infos.active_policy_rules,
+                    ]
+              }
+              options={{
+                actionsColumnIndex: -1,
+                pageSize: 10,
+                pageSizeOptions: [10, 20],
+              }}
+              detailPanel={
+                !Object.keys(sessionState).length
+                  ? []
+                  : [
+                      {
+                        icon: () => {
+                          return <ExpandMore data-testid="details" />;
+                        },
+                        openIcon: ExpandLess,
+                        render: rowData => {
+                          const subscriber =
+                            sessionState[rowData.imsi]?.subscriber_state || {};
+                          const subscriberSessionRows: Array<SubscriberSessionRowType> = [];
+                          Object.keys(subscriber).map((apn: string) => {
+                            subscriber[apn].map(infos => {
+                              subscriberSessionRows.push({
+                                apnName: apn,
+                                sessionId: infos.session_id,
+                                ipAddr: infos.ipv4 ?? '-',
+                                state: infos.lifecycle_state,
+                                activeDuration: `${infos.active_duration_sec} sec`,
+                                activePolicies: infos.active_policy_rules,
+                              });
                             });
                           });
-                        });
 
-                        return (
-                          <ActionTable
-                            data-testid="detailPanel"
-                            title=""
-                            data={subscriberSessionRows}
-                            columns={[
-                              {title: 'APN Name', field: 'apnName'},
-                              {title: 'Session ID', field: 'sessionId'},
-                              {title: 'State', field: 'state'},
-                              {title: 'IP Address', field: 'ipAddr'},
-                              {
-                                title: 'Active Duration',
-                                field: 'activeDuration',
-                              },
-                              {
-                                title: 'Active Policy IDs',
-                                field: 'activePolicies',
-                                render: currRow =>
-                                  currRow.activePolicies.length ? (
-                                    <List>
-                                      {currRow.activePolicies.map(policy => (
-                                        <ListItem key={policy.id}>
-                                          <Link>{policy.id} </Link>
-                                        </ListItem>
-                                      ))}
-                                    </List>
-                                  ) : (
-                                    <Text>{'-'}</Text>
-                                  ),
-                              },
-                            ]}
-                            options={{
-                              actionsColumnIndex: -1,
-                              pageSizeOptions: [5],
-                              toolbar: false,
-                              paging: false,
-                              rowStyle: {background: '#f7f7f7'},
-                              headerStyle: {
-                                background: '#f7f7f7',
-                                color: colors.primary.comet,
-                              },
-                            }}
-                          />
-                        );
+                          return (
+                            <ActionTable
+                              data-testid="detailPanel"
+                              title=""
+                              data={subscriberSessionRows}
+                              columns={[
+                                {title: 'APN Name', field: 'apnName'},
+                                {title: 'Session ID', field: 'sessionId'},
+                                {title: 'State', field: 'state'},
+                                {title: 'IP Address', field: 'ipAddr'},
+                                {
+                                  title: 'Active Duration',
+                                  field: 'activeDuration',
+                                },
+                                {
+                                  title: 'Active Policy IDs',
+                                  field: 'activePolicies',
+                                  render: currRow =>
+                                    currRow.activePolicies.length ? (
+                                      <List>
+                                        {currRow.activePolicies.map(policy => (
+                                          <ListItem key={policy.id}>
+                                            <Link>{policy.id} </Link>
+                                          </ListItem>
+                                        ))}
+                                      </List>
+                                    ) : (
+                                      <Text>{'-'}</Text>
+                                    ),
+                                },
+                              ]}
+                              options={{
+                                actionsColumnIndex: -1,
+                                pageSizeOptions: [5],
+                                toolbar: false,
+                                paging: false,
+                                rowStyle: {background: '#f7f7f7'},
+                                headerStyle: {
+                                  background: '#f7f7f7',
+                                  color: colors.primary.comet,
+                                },
+                              }}
+                            />
+                          );
+                        },
                       },
-                    },
-                  ]
-            }
-          />
-        </div>
-      ) : (
-        '<Text>No Subscribers Found</Text>'
-      )}
+                    ]
+              }
+            />
+          </div>
+        ) : (
+          '<Text>No Subscribers Found</Text>'
+        )}
+      </div>
     </>
   );
 }
 
-const SubscriberTable = withAlert(Table);
+const SubscriberOverview = withAlert(SubscriberInternal);

--- a/nms/app/packages/magmalte/app/views/subscriber/__tests__/SubscriberAddEditTest.js
+++ b/nms/app/packages/magmalte/app/views/subscriber/__tests__/SubscriberAddEditTest.js
@@ -273,7 +273,7 @@ describe('<AddSubscriberButton />', () => {
                   <SubscriberContext.Provider value={subscriberCtx}>
                     <Route
                       path="/nms/:networkId/subscribers"
-                      render={() => <AddSubscriberButton />}
+                      render={() => <AddSubscriberButton onClose={() => {}} />}
                     />
                   </SubscriberContext.Provider>
                 </ApnContext.Provider>

--- a/nms/app/packages/magmalte/app/views/traffic/PolicyTracking.js
+++ b/nms/app/packages/magmalte/app/views/traffic/PolicyTracking.js
@@ -100,7 +100,7 @@ export default function PolicyTrackingEdit(props: Props) {
         <TypedSelect
           className={props.inputClass}
           input={<OutlinedInput />}
-          value={props.policyRule?.tracking_type ?? 'Only OCS'}
+          value={props.policyRule?.tracking_type ?? 'ONLY_OCS'}
           items={{
             ONLY_OCS: 'Only OCS',
             ONLY_PCRF: 'Only PCRF',

--- a/nms/app/packages/magmalte/app/views/traffic/ProfileEdit.js
+++ b/nms/app/packages/magmalte/app/views/traffic/ProfileEdit.js
@@ -138,7 +138,7 @@ export default function ProfileEditDialog(props: Props) {
               className={classes.input}
               fullWidth={true}
               data-testid="profileID"
-              placeholder="Eg. profile_id"
+              placeholder="test_profile"
               value={profile.id}
               onChange={({target}) => handleProfileChange('id', target.value)}
             />
@@ -156,14 +156,14 @@ export default function ProfileEditDialog(props: Props) {
               }
             />
           </AltFormField>
-          <AltFormField label={'Max Bandwidth Downlink'} disableGutters>
+          <AltFormField label={'Max Bandwidth Downlink(bps)'} disableGutters>
             <OutlinedInput
               className={classes.input}
               type="number"
               fullWidth={true}
               min={0}
               data-testid="maxReqBwDl"
-              placeholder="9"
+              placeholder="1000"
               value={profile.max_req_bw_dl}
               onChange={({target}) =>
                 handleProfileChange(
@@ -173,13 +173,13 @@ export default function ProfileEditDialog(props: Props) {
               }
             />
           </AltFormField>
-          <AltFormField label={'Max Bandwidth Uplink'} disableGutters>
+          <AltFormField label={'Max Bandwidth Uplink(bps)'} disableGutters>
             <OutlinedInput
               className={classes.input}
               type="number"
               fullWidth={true}
               data-testid="maxReqBwUl"
-              placeholder="9"
+              placeholder="1000"
               value={profile.max_req_bw_ul}
               onChange={({target}) =>
                 handleProfileChange(


### PR DESCRIPTION
Signed-off-by: Karthik Subraveti <ksubraveti@fb.com>

## Summary

1. EPC configs was being overriden by RAN config component, this patch fixes the issue. This patch also contains gateway config tests which edit configurations across all the config tabs and saves the gateway config. We verify if the edits across all individual config tab is reflected in the final gateway config.
2. This patch also fixes a minor issue with pre defined alerts where gateway checkin alert was missing a "}".
3. Fixes a minor issue where the bulk upload csv file didn't support policies field
4. Also fixes a minor issue with subscribers add dialog, here we update the subscriber state in every loop, setState however is async and when we 
```
 ...
    setSubscriberMap({...subscriberMap, [key]: value}); <==== it doesn't get set immediately. 
````
So we keep overwriting the subscriber map present in the context, when we exit the dialog, since we only have the last one in subscriber map, we don't refresh the subscriber overview immediately. Fixed this by 
- cleaning up subscriber overview, removed grids and used TopBars and CardTitleRow instead
- Triggered setLastRefreshTime from the delete and add dialog handler rather than in useEffect which relied on the number of subscribers in subscriber context to change for triggering refresh.

## Test Plan

- Add an additional unit test to verify gateway config add
- Verified predefined alerts by manually syncing the alerts
-
![Screen Shot 2021-02-08 at 5 08 40 AM](https://user-images.githubusercontent.com/8224854/107224054-cb003c80-69cb-11eb-91ec-bf828c64e5ba.png)

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
