### PR TITLE
[AGW][S1ap tests] Split mandatory S1ap tests into precommit and extended

### DIFF
--- a/lte/gateway/python/integ_tests/Makefile
+++ b/lte/gateway/python/integ_tests/Makefile
@@ -28,13 +28,22 @@ define execute_test
 	sleep 1
 endef
 
+.PHONY: precommit
+precommit: $(PYTHON_BUILD)/setupinteg_env $(BIN)/nosetests
+	. $(PYTHON_BUILD)/bin/activate
+ifdef TESTS
+	$(call execute_test,$(TESTS))
+else
+	$(foreach test,$(PRECOMMIT_TESTS),$(call execute_test,$(test));)
+endif
+
 .PHONY: integ_test
 integ_test: $(PYTHON_BUILD)/setupinteg_env $(BIN)/nosetests
 	. $(PYTHON_BUILD)/bin/activate
 ifdef TESTS
 	$(call execute_test,$(TESTS))
 else
-	$(foreach test,$(MANDATORY_TESTS),$(call execute_test,$(test));)
+	$(foreach test,$(EXTENDED_TESTS) $(PRECOMMIT_TESTS),$(call execute_test,$(test));)
 endif
 
 local_integ_test:

--- a/lte/gateway/python/integ_tests/defs.mk
+++ b/lte/gateway/python/integ_tests/defs.mk
@@ -13,8 +13,7 @@
 PROTO_LIST:=orc8r_protos lte_protos feg_protos
 
 # Add the s1aptester integration tests
-MANDATORY_TESTS = s1aptests/test_modify_mme_config_for_sanity.py \
-s1aptests/test_attach_detach.py \
+PRECOMMIT_TESTS = s1aptests/test_attach_detach.py \
 s1aptests/test_gateway_metrics_attach_detach.py \
 s1aptests/test_attach_detach_looped.py  \
 s1aptests/test_attach_emergency.py \
@@ -73,7 +72,6 @@ s1aptests/test_attach_detach_dedicated.py \
 s1aptests/test_attach_detach_dedicated_qci_0.py \
 s1aptests/test_attach_detach_dedicated_multi_ue.py \
 s1aptests/test_attach_detach_dedicated_looped.py \
-s1aptests/test_attach_detach_dedicated_deactivation_timer_expiry.py \
 s1aptests/test_attach_detach_dedicated_bearer_deactivation_invalid_lbi.py \
 s1aptests/test_attach_detach_dedicated_bearer_deactivation_invalid_imsi.py \
 s1aptests/test_attach_detach_dedicated_bearer_deactivation_invalid_ebi.py \
@@ -82,7 +80,6 @@ s1aptests/test_attach_detach_dedicated_bearer_activation_invalid_imsi.py \
 s1aptests/test_attach_detach_dedicated_activation_timer_expiry.py \
 s1aptests/test_attach_detach_dedicated_activation_reject.py \
 s1aptests/test_attach_detach_multiple_dedicated.py \
-s1aptests/test_attach_detach_secondary_pdn.py \
 s1aptests/test_attach_detach_secondary_pdn_multi_ue.py \
 s1aptests/test_attach_detach_secondary_pdn_looped.py \
 s1aptests/test_attach_detach_secondary_pdn_invalid_apn.py \
@@ -107,7 +104,6 @@ s1aptests/test_attach_standalone_act_dflt_ber_ctxt_rej.py \
 s1aptests/test_attach_standalone_act_dflt_ber_ctxt_rej_ded_bearer_activation.py \
 s1aptests/test_ics_timer_expiry_ue_registered.py \
 s1aptests/test_ics_timer_expiry_ue_unregistered.py \
-s1aptests/test_attach_service_with_multi_pdns_and_bearers.py \
 s1aptests/test_attach_service_with_multi_pdns_and_bearers_looped.py \
 s1aptests/test_attach_service_with_multi_pdns_and_bearers_multi_ue.py \
 s1aptests/test_attach_service_with_multi_pdns_and_bearers_failure.py \
@@ -116,34 +112,39 @@ s1aptests/test_dedicated_bearer_activation_idle_mode_multi_ue.py \
 s1aptests/test_dedicated_bearer_activation_idle_mode_paging_timer_expiry.py \
 s1aptests/test_multi_enb_multi_ue.py \
 s1aptests/test_multi_enb_multi_ue_diff_enbtype.py \
-s1aptests/test_multi_enb_multi_ue_diff_plmn.py \
-s1aptests/test_multi_enb_multi_ue_diff_tac.py \
 s1aptests/test_multi_enb_partial_reset.py \
 s1aptests/test_multi_enb_complete_reset.py \
 s1aptests/test_multi_enb_sctp_shutdown.py \
-s1aptests/test_x2_handover.py \
-s1aptests/test_x2_handover_ping_pong.py \
-s1aptests/test_attach_mobile_reachability_timer_expiry.py \
-s1aptests/test_attach_implicit_detach_timer_expiry.py \
 s1aptests/test_attach_ul_udp_data.py \
 s1aptests/test_attach_ul_tcp_data.py \
 s1aptests/test_attach_detach_attach_ul_tcp_data.py \
-s1aptests/test_attach_detach_rar_tcp_data.py \
 s1aptests/test_attach_detach_multiple_rar_tcp_data.py \
 s1aptests/test_attach_service_with_multi_pdns_and_bearers_mt_data.py \
 s1aptests/test_attach_asr.py \
 s1aptests/test_attach_detach_with_sctpd_restart.py \
-s1aptests/test_attach_detach_with_mme_restart.py \
 s1aptests/test_attach_nw_initiated_detach_with_mme_restart.py \
-s1aptests/test_attach_detach_with_mobilityd_restart.py \
 s1aptests/test_attach_detach_multiple_ip_blocks_mobilityd_restart.py \
-s1aptests/test_idle_mode_with_mme_restart.py \
 s1aptests/test_attach_ul_udp_data_with_mme_restart.py \
 s1aptests/test_attach_ul_udp_data_with_mobilityd_restart.py \
 s1aptests/test_attach_ul_udp_data_with_multiple_service_restart.py \
 s1aptests/test_attach_ul_udp_data_with_pipelined_restart.py \
 s1aptests/test_attach_ul_udp_data_with_sessiond_restart.py \
-s1aptests/test_service_req_ul_udp_data_with_mme_restart.py \
+s1aptests/test_service_req_ul_udp_data_with_mme_restart.py
+
+EXTENDED_TESTS = s1aptests/test_modify_mme_config_for_sanity.py \
+s1aptests/test_attach_detach_dedicated_deactivation_timer_expiry.py \
+s1aptests/test_attach_detach_secondary_pdn.py \
+s1aptests/test_attach_service_with_multi_pdns_and_bearers.py \
+s1aptests/test_multi_enb_multi_ue_diff_plmn.py \
+s1aptests/test_multi_enb_multi_ue_diff_tac.py \
+s1aptests/test_x2_handover.py \
+s1aptests/test_x2_handover_ping_pong.py \
+s1aptests/test_attach_mobile_reachability_timer_expiry.py \
+s1aptests/test_attach_implicit_detach_timer_expiry.py \
+s1aptests/test_attach_detach_rar_tcp_data.py \
+s1aptests/test_attach_detach_with_mme_restart.py \
+s1aptests/test_attach_detach_with_mobilityd_restart.py \
+s1aptests/test_idle_mode_with_mme_restart.py \
 s1aptests/test_restore_mme_config_after_sanity.py
 
 # Enable these tests once the CI job time-out has increased

--- a/lte/gateway/python/integ_tests/s1aptests/test_enb_partial_reset.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_enb_partial_reset.py
@@ -72,6 +72,9 @@ class TestEnbPartialReset(unittest.TestCase):
         self._s1ap_wrapper.s1_util.issue_cmd(s1ap_types.tfwCmd.RESET_REQ, reset_req)
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(response.msg_type, s1ap_types.tfwCmd.RESET_ACK.value)
+        # Sleep for 3 seconds to ensure that MME has cleaned up all S1 state
+        # before proceeding
+        time.sleep(3)
         # Trigger detach request
         for ue in ue_ids:
             print("************************* Calling detach for UE id ", ue)


### PR DESCRIPTION
Signed-off-by: Shruti Sanadhya <ssanadhya@fb.com>

## Summary

The `make integ_test` target takes around 55 minutes to run. This change splits the test list into:
- PRECOMMIT_TESTS, which should be run on each Pull Request
- EXTENDED_TESTS, which should only run on each commit on master branch, in addition to PRECOMMIT_TESTS

The test `test_enb_partial_reset.py` fails sporadically due to a race condition described in https://github.com/magma/magma/issues/5053. This PR adds a temporary workaround (adding a wait before Detach request) to unblock CI.

## Test Plan

On test VM:
- `make precommit`
- `make integ_test`
