### PR TITLE
[xwf][xwfm][docker] Update Docker CE to support dual-logging

### DIFF
--- a/xwf/gateway/deploy/roles/docker/tasks/main.yml
+++ b/xwf/gateway/deploy/roles/docker/tasks/main.yml
@@ -30,10 +30,9 @@
 - name: Add the stable repository for Docker
   shell: yum-config-manager --add-repo https://download.docker.com/linux/centos/docker-ce.repo
 
-- name: Install the latest version of Docker CE
-  yum:
-    name: docker-ce
-    state: present
+- name: Install Docker CE
+  include_role:
+    name: docker_ce_update
 
 - name: Install Docker compose
   become: true
@@ -50,5 +49,3 @@
 
 - name: start docker service
   systemd: name=docker state=started enabled=yes
-
-

--- a/xwf/gateway/deploy/roles/docker_ce_update/tasks/main.yml
+++ b/xwf/gateway/deploy/roles/docker_ce_update/tasks/main.yml
@@ -11,20 +11,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License
 
-- name: Upgrade Express Wi-FI Magma  Gateway for production
-  hosts: localhost
-  become: yes
-  roles:
-    - role: xwfmvars
-      tags:
-         - run_pipelined
-         - fbstatsd
-    - role: dhcpd
-      when: uplink_if is none
-    - role: docker_ce_update
-    - role: containers
-    - role: exporter
-    - role: fbstatsd
-      tags:
-         - fbstatsd
-    - role: system_updates
+- name: install docker-ce
+  yum:
+    name:
+      - docker-ce-20.10.3-3.el7
+      - docker-ce-cli-20.10.3-3.el7
+    state: present
+    allow_downgrade: yes # pin to a version even if the installed docker-ce is newer


### PR DESCRIPTION
Signed-off-by: Leonid Brandes <leonidb@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary

The Ansible installs docker to a pinned version "20.10.3-3.el7".
The upgrade Ansible play also pins the docker to this version, even if the current version is newer (something which normally shall not happen, unless a manual user intervention). 

## Test Plan

### On a fresh XWFQA box:

```
[root@ip-10-0-10-156 centos]# docker --version
bash: docker: command not found
[root@ip-10-0-10-156 centos]# git clone https://github.com/interfan7/magma.git -b upgrade_docker_ce_to_support_dual_loggin
...
[root@ip-10-0-10-156 centos]# cd magma/xwf/gateway/deploy/
[root@ip-10-0-10-156 deploy]# ansible-playbook xwf.yml
...
[root@ip-10-0-10-156 deploy]# docker --version
Docker version 20.10.3, build 48d30b5
[root@xwfm deploy]# docker logs radius
{messages are shown}
```

### On a running box with older docker-ce
Old docker doesn't get logs from container:
```
[root@xwfm deploy]# docker --version
Docker version 18.09.9, build 039a7df9ba
[root@xwfm deploy]# docker logs radius
Error response from daemon: configured logging driver does not support reading

```

Get the new Ansible upgrade and apply it.
Then try to read logs again.
```
[root@xwfm centos]# git clone https://github.com/interfan7/magma.git -b upgrade_docker_ce_to_support_dual_loggin
...
[root@ip-10-0-10-156 centos]# cd magma/xwf/gateway/deploy/
[root@xwfm deploy]# ansible-playbook upgrade.yml
...
[root@xwfm deploy]# docker --version
Docker version 20.10.3, build 48d30b5
[root@xwfm deploy]# docker logs radius
{messages are shown}
```


## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
