### PR TITLE
[ci][xwfm_tests] removing un-needed aws env vars related to xwf

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -980,8 +980,6 @@ jobs:
           name: Setup Environment Variables
           command: |
             echo export MAGMA_ROOT=$(pwd) >> $BASH_ENV
-            echo export AWS_ACCESS_KEY_ID="$(printenv XWF_AWS_ACCESS_KEY_ID)" >> $BASH_ENV
-            echo export AWS_SECRET_ACCESS_KEY="$(printenv XWF_AWS_SECRET_ACCESS_KEY)" >> $BASH_ENV
             echo export RUN_UID=$RANDOM >> $BASH_ENV
       - run:
           command: |


### PR DESCRIPTION
Signed-off-by: Ayelet Regev Dabah <ayelet.regev@gmail.com>

[ci][xwfm_tests] removing un-needed aws env vars related to xwf

## Summary

We dont need those anymore on tests

## Test Plan

circleci in fbc

## Additional Information

- [ ] This change is backwards-breaking

