### PR TITLE
[5G: MVC][component: agw][type: enhancement] [AMF]Implementation of SmfPduSessionSmContext gRPC call and its processing

### DIFF
--- a/lte/gateway/c/oai/include/amf_service_handler.h
+++ b/lte/gateway/c/oai/include/amf_service_handler.h
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "messages_types.h"
+
+/*
+ * Sends N11_CREATE_PDU_SESSION_RESPONSE message to AMF.
+ */
+int send_n11_create_pdu_session_resp_itti(
+    itti_n11_create_pdu_session_response_t* itti_msg);

--- a/lte/gateway/c/oai/include/messages_def.h
+++ b/lte/gateway/c/oai/include/messages_def.h
@@ -46,3 +46,4 @@
 #include "async_system_messages_def.h"
 #include "udp_messages_def.h"
 #include "ha_messages_def.h"
+#include "n11_messages_def.h"

--- a/lte/gateway/c/oai/include/messages_types.h
+++ b/lte/gateway/c/oai/include/messages_types.h
@@ -48,5 +48,6 @@
 #include "async_system_messages_types.h"
 #include "udp_messages_types.h"
 #include "ha_messages_types.h"
+#include "n11_messages_types.h"
 
 #endif /* FILE_MESSAGES_TYPES_SEEN */

--- a/lte/gateway/c/oai/include/n11_messages_def.h
+++ b/lte/gateway/c/oai/include/n11_messages_def.h
@@ -1,0 +1,16 @@
+/**
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+MESSAGE_DEF(
+    N11_CREATE_PDU_SESSION_RESPONSE, itti_n11_create_pdu_session_response_t,
+    n11_create_pdu_session_response)

--- a/lte/gateway/c/oai/include/n11_messages_types.h
+++ b/lte/gateway/c/oai/include/n11_messages_types.h
@@ -90,16 +90,6 @@ typedef struct redirect_server_s {
   uint8_t redirect_server_address[16];
 } redirect_server_t;
 
-typedef struct qos_rules_s {
-  uint32_t qos_rule_identifier;
-  bool dqr;
-  uint32_t number_of_packet_filters;
-  uint32_t packet_filter_identifier[16];
-  uint32_t qos_rule_precedence;
-  bool segregation;
-  uint32_t qos_flow_identifier;
-} qos_rules_t;
-
 typedef struct itti_n11_create_pdu_session_response_s {
   // common context
   char imsi[IMSI_BCD_DIGITS_MAX + 1];

--- a/lte/gateway/c/oai/include/n11_messages_types.h
+++ b/lte/gateway/c/oai/include/n11_messages_types.h
@@ -11,12 +11,12 @@
  * limitations under the License.
  */
 
-#ifndef N11_MESSAGES_TYPES_SEEN
-#define N11_MESSAGES_TYPES_SEEN
+#pragma once
 
 //-----------------------------------------------------------------------------
 /** @struct itti_n11_create_pdu_session_response_t
- *  @brief Create PDU Session Response */
+ *  @brief carries the PDU Session Establishment Response from SMF to AMF task
+ */
 
 typedef enum sm_session_fsm_state_e {
   CREATING_0,
@@ -109,7 +109,6 @@ typedef struct itti_n11_create_pdu_session_response_s {
   uint8_t pdu_session_id;
   pdu_session_type_t pdu_session_type;
   ssc_mode_t selected_ssc_mode;
-  qos_rules_t authorized_qos_rules[4];
   m5g_sm_cause_t m5gsm_cause;
   bool always_on_pdu_session_indication;
   ssc_mode_t allowed_ssc_mode;
@@ -119,5 +118,3 @@ typedef struct itti_n11_create_pdu_session_response_s {
 
 #define N11_CREATE_PDU_SESSION_RESPONSE(mSGpTR)                                \
   (mSGpTR)->ittiMsg.n11_create_pdu_session_response
-
-#endif

--- a/lte/gateway/c/oai/include/n11_messages_types.h
+++ b/lte/gateway/c/oai/include/n11_messages_types.h
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef N11_MESSAGES_TYPES_SEEN
+#define N11_MESSAGES_TYPES_SEEN
+
+//-----------------------------------------------------------------------------
+/** @struct itti_n11_create_pdu_session_response_t
+ *  @brief Create PDU Session Response */
+
+typedef enum sm_session_fsm_state_e {
+  CREATING_0,
+  CREATE_1,
+  ACTIVE_2,
+  INACTIVE_3,
+  RELEASED_4
+} sm_session_fsm_state_t;
+
+typedef enum pdu_session_type_e {
+  IPV4,
+  IPV6,
+  IPV4IPV6,
+  UNSTRUCTURED
+} pdu_session_type_t;
+
+typedef enum ssc_mode_e { SSC_MODE_1, SSC_MODE_2, SSC_MODE_3 } ssc_mode_t;
+
+typedef enum m5g_sm_cause_e {
+  M5GSM_OPERATOR_DETERMINED_BARRING                       = 0,
+  M5GSM_INSUFFICIENT_RESOURCES                            = 1,
+  M5GSM_MISSING_OR_UNKNOWN_DNN                            = 2,
+  M5GSM_UNKNOWN_PDU_SESSION_TYPE                          = 3,
+  M5GSM_USER_AUTHENTICATION_OR_AUTHORIZATION_FAILED       = 4,
+  M5GSM_REQUEST_REJECTED_UNSPECIFIED                      = 5,
+  M5GSM_SERVICE_OPTION_NOT_SUPPORTED                      = 6,
+  M5GSM_REQUESTED_SERVICE_OPTION_NOT_SUBSCRIBED           = 7,
+  M5GSM_SERVICE_OPTION_TEMPORARILY_OUT_OF_ORDER           = 8,
+  M5GSM_REGULAR_DEACTIVATION                              = 10,
+  M5GSM_NETWORK_FAILURE                                   = 11,
+  M5GSM_REACTIVATION_REQUESTED                            = 12,
+  M5GSM_INVALID_PDU_SESSION_IDENTITY                      = 13,
+  M5GSM_SEMANTIC_ERRORS_IN_PACKET_FILTER                  = 14,
+  M5GSM_SYNTACTICAL_ERROR_IN_PACKET_FILTER                = 15,
+  M5GSM_OUT_OF_LADN_SERVICE_AREA                          = 16,
+  M5GSM_PTI_MISMATCH                                      = 17,
+  M5GSM_PDU_SESSION_TYPE_IPV4_ONLY_ALLOWED                = 18,
+  M5GSM_PDU_SESSION_TYPE_IPV6_ONLY_ALLOWED                = 19,
+  M5GSM_PDU_SESSION_DOES_NOT_EXIST                        = 20,
+  M5GSM_INSUFFICIENT_RESOURCES_FOR_SPECIFIC_SLICE_AND_DNN = 21,
+  M5GSM_NOT_SUPPORTED_SSC_MODE                            = 22,
+  M5GSM_INSUFFICIENT_RESOURCES_FOR_SPECIFIC_SLICE         = 23,
+  M5GSM_MISSING_OR_UNKNOWN_DNN_IN_A_SLICE                 = 24,
+  M5GSM_INVALID_PTI_VALUE                                 = 25,
+  M5GSM_MAXIMUM_DATA_RATE_PER_UE_FOR_USER_PLANE_INTEGRITY_PROTECTION_IS_TOO_LOW =
+      26,
+  M5GSM_SEMANTIC_ERROR_IN_THE_QOS_OPERATION                 = 27,
+  M5GSM_SYNTACTICAL_ERROR_IN_THE_QOS_OPERATION              = 28,
+  M5GSM_INVALID_MAPPED_EPS_BEARER_IDENTITY                  = 29,
+  M5GSM_SEMANTICALLY_INCORRECT_MESSAGE                      = 30,
+  M5GSM_INVALID_MANDATORY_INFORMATION                       = 31,
+  M5GSM_MESSAGE_TYPE_NON_EXISTENT_OR_NOT_IMPLEMENTED        = 32,
+  M5GSM_MESSAGE_TYPE_NOT_COMPATIBLE_WITH_THE_PROTOCOL_STATE = 33,
+  M5GSM_INFORMATION_ELEMENT_NON_EXISTENT_OR_NOT_IMPLEMENTED = 34,
+  M5GSM_CONDITIONAL_IE_ERROR                                = 35,
+  M5GSM_MESSAGE_NOT_COMPATIBLE_WITH_THE_PROTOCOL_STATE      = 36,
+  M5GSM_PROTOCOL_ERROR_UNSPECIFIED                          = 37,
+  M5GSM_PTI_ALREADY_IN_USE                                  = 38,
+  M5GSM_OPERATION_SUCCESS                                   = 40
+} m5g_sm_cause_t;
+
+typedef enum redirect_address_type_e {
+  IPV4_1,
+  IPV6_1,
+  URL,
+  SIP_URI
+} redirect_address_type_t;
+
+typedef struct redirect_server_s {
+  redirect_address_type_t redirect_address_type;
+  uint8_t redirect_server_address[16];
+} redirect_server_t;
+
+typedef struct qos_rules_s {
+  uint32_t qos_rule_identifier;
+  bool dqr;
+  uint32_t number_of_packet_filters;
+  uint32_t packet_filter_identifier[16];
+  uint32_t qos_rule_precedence;
+  bool segregation;
+  uint32_t qos_flow_identifier;
+} qos_rules_t;
+
+typedef struct itti_n11_create_pdu_session_response_s {
+  // common context
+  char imsi[IMSI_BCD_DIGITS_MAX + 1];
+  sm_session_fsm_state_t sm_session_fsm_state;
+  uint32_t sm_session_version;
+  // M5GSMSessionContextAccess
+  uint8_t pdu_session_id;
+  pdu_session_type_t pdu_session_type;
+  ssc_mode_t selected_ssc_mode;
+  qos_rules_t authorized_qos_rules[4];
+  m5g_sm_cause_t m5gsm_cause;
+  bool always_on_pdu_session_indication;
+  ssc_mode_t allowed_ssc_mode;
+  bool m5gsm_congetion_re_attempt_indicator;
+  redirect_server_t pdu_address;
+} itti_n11_create_pdu_session_response_t;
+
+#define N11_CREATE_PDU_SESSION_RESPONSE(mSGpTR)                                \
+  (mSGpTR)->ittiMsg.n11_create_pdu_session_response
+
+#endif

--- a/lte/gateway/c/oai/include/n11_messages_types.h
+++ b/lte/gateway/c/oai/include/n11_messages_types.h
@@ -19,11 +19,11 @@
  */
 
 typedef enum sm_session_fsm_state_e {
-  CREATING_0,
-  CREATE_1,
-  ACTIVE_2,
-  INACTIVE_3,
-  RELEASED_4
+  CREATING,
+  CREATE,
+  ACTIVE,
+  INACTIVE,
+  RELEASED
 } sm_session_fsm_state_t;
 
 typedef enum pdu_session_type_e {
@@ -70,7 +70,7 @@ typedef enum m5g_sm_cause_e {
   M5GSM_INVALID_MANDATORY_INFORMATION                       = 31,
   M5GSM_MESSAGE_TYPE_NON_EXISTENT_OR_NOT_IMPLEMENTED        = 32,
   M5GSM_MESSAGE_TYPE_NOT_COMPATIBLE_WITH_THE_PROTOCOL_STATE = 33,
-  M5GSM_INFORMATION_ELEMENT_NON_EXISTENT_OR_NOT_IMPLEMENTED = 34,
+  M5GSM_IE_NON_EXISTENT_OR_NOT_IMPLEMENTED                  = 34,
   M5GSM_CONDITIONAL_IE_ERROR                                = 35,
   M5GSM_MESSAGE_NOT_COMPATIBLE_WITH_THE_PROTOCOL_STATE      = 36,
   M5GSM_PROTOCOL_ERROR_UNSPECIFIED                          = 37,

--- a/lte/gateway/c/oai/tasks/grpc_service/AmfServiceImpl.cpp
+++ b/lte/gateway/c/oai/tasks/grpc_service/AmfServiceImpl.cpp
@@ -18,6 +18,7 @@ extern "C" {
 #endif
 #include "amf_service_handler.h"
 #include "log.h"
+#include "conversions.h"
 #ifdef __cplusplus
 }
 #endif
@@ -76,7 +77,6 @@ Status AmfServiceImpl::SetSmfSessionContext(
   itti_msg.pdu_session_type  = (pdu_session_type_t) req_m5g.pdu_session_type();
   itti_msg.selected_ssc_mode = (ssc_mode_t) req_m5g.selected_ssc_mode();
   itti_msg.m5gsm_cause       = (m5g_sm_cause_t) req_m5g.m5gsm_cause();
-
   itti_msg.always_on_pdu_session_indication =
       req_m5g.always_on_pdu_session_indication();
   itti_msg.allowed_ssc_mode = (ssc_mode_t) req_m5g.allowed_ssc_mode();
@@ -90,13 +90,6 @@ Status AmfServiceImpl::SetSmfSessionContext(
   inet_pton(AF_INET, ip_str, &(ip_addr.s_addr));
   ip_int = ntohl(ip_addr.s_addr);
   INT32_TO_BUFFER(ip_int, itti_msg.pdu_address.redirect_server_address);
-  // get the 4 byte UPF TEID and UPF IP message
-  memcpy(
-      itti_msg.upf_endpoint.teid, req_m5g.upf_endpoint().teid().c_str(),
-      TEID_SIZE);
-  memcpy(
-      itti_msg.upf_endpoint.end_ipv4_addr,
-      req_m5g.upf_endpoint().end_ipv4_addr().c_str(), UPF_IPV4_ADDR_SIZE);
   send_n11_create_pdu_session_resp_itti(&itti_msg);
   return Status::OK;
 }

--- a/lte/gateway/c/oai/tasks/grpc_service/AmfServiceImpl.cpp
+++ b/lte/gateway/c/oai/tasks/grpc_service/AmfServiceImpl.cpp
@@ -1,18 +1,31 @@
 /*
-Copyright 2020 The Magma Authors.
-This source code is licensed under the BSD-style license found in the
-LICENSE file in the root directory of this source tree.
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 #include <string>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+#include "amf_service_handler.h"
+#include "log.h"
+#ifdef __cplusplus
+}
+#endif
+
 #include "AmfServiceImpl.h"
 #include "lte/protos/session_manager.pb.h"
+#include "lte/protos/subscriberdb.pb.h"
+
 
 namespace grpc {
 
@@ -44,7 +57,55 @@ Status AmfServiceImpl::SetSmfSessionContext(
     ServerContext* context, const SetSMSessionContextAccess* request,
     SmContextVoid* response) {
   OAILOG_INFO(LOG_UTIL, "Received  GRPC SetSMSessionContextAccess request\n");
-  // ToDo processing ITTI,ZMQ
+
+  itti_n11_create_pdu_session_response_t itti_msg;
+  auto& req_common = request->common_context();
+  auto& req_m5g    = request->rat_specific_context().m5g_session_context_rsp();
+
+  // CommonSessionContext
+  strcpy(itti_msg.imsi, req_common.sid().id().c_str());
+  itti_msg.sm_session_fsm_state =
+      (sm_session_fsm_state_t) req_common.sm_session_state();
+  itti_msg.sm_session_version = req_common.sm_session_version();
+
+  // RatSpecificContextAccess
+  strncpy(
+      (char*) (&itti_msg.pdu_session_id), req_m5g.pdu_session_id().c_str(), 1);
+  itti_msg.pdu_session_type  = (pdu_session_type_t) req_m5g.pdu_session_type();
+  itti_msg.selected_ssc_mode = (ssc_mode_t) req_m5g.selected_ssc_mode();
+  itti_msg.m5gsm_cause       = (m5g_sm_cause_t) req_m5g.m5gsm_cause();
+  for (int i = 0, m = req_m5g.authorized_qos_rules_size(); i < m; i++) {
+    itti_msg.authorized_qos_rules[i].qos_rule_identifier =
+        (uint32_t) req_m5g.authorized_qos_rules(i).qos_rule_identifier();
+    itti_msg.authorized_qos_rules[i].dqr =
+        req_m5g.authorized_qos_rules(i).dqr();
+    itti_msg.authorized_qos_rules[i].number_of_packet_filters =
+        (uint32_t) req_m5g.authorized_qos_rules(i).number_of_packet_filters();
+    for (int j = 0, n = req_m5g.authorized_qos_rules(i)
+                            .packet_filter_identifier_size();
+         j < n; j++) {
+      itti_msg.authorized_qos_rules[i].packet_filter_identifier[j] =
+          (uint32_t) req_m5g.authorized_qos_rules(i).packet_filter_identifier(
+              j);
+    }
+    itti_msg.authorized_qos_rules[i].qos_rule_precedence =
+        (uint32_t) req_m5g.authorized_qos_rules(i).qos_rule_precedence();
+    itti_msg.authorized_qos_rules[i].segregation =
+        req_m5g.authorized_qos_rules(i).segregation();
+    itti_msg.authorized_qos_rules[i].qos_flow_identifier =
+        (uint32_t) req_m5g.authorized_qos_rules(i).qos_flow_identifier();
+  }
+  itti_msg.always_on_pdu_session_indication =
+      req_m5g.always_on_pdu_session_indication();
+  itti_msg.allowed_ssc_mode = (ssc_mode_t) req_m5g.allowed_ssc_mode();
+  itti_msg.m5gsm_congetion_re_attempt_indicator =
+      req_m5g.m5gsm_congetion_re_attempt_indicator();
+  itti_msg.pdu_address.redirect_address_type =
+      (redirect_address_type_t) req_m5g.pdu_address().redirect_address_type();
+  strcpy(
+      (char*) itti_msg.pdu_address.redirect_server_address,
+      req_m5g.pdu_address().redirect_server_address().c_str());
+  send_n11_create_pdu_session_resp_itti(&itti_msg);
   return Status::OK;
 }
 

--- a/lte/gateway/c/oai/tasks/grpc_service/AmfServiceImpl.cpp
+++ b/lte/gateway/c/oai/tasks/grpc_service/AmfServiceImpl.cpp
@@ -26,7 +26,6 @@ extern "C" {
 #include "lte/protos/session_manager.pb.h"
 #include "lte/protos/subscriberdb.pb.h"
 
-
 namespace grpc {
 
 class ServerContext;
@@ -56,10 +55,11 @@ Status AmfServiceImpl::SetAmfNotification(
 Status AmfServiceImpl::SetSmfSessionContext(
     ServerContext* context, const SetSMSessionContextAccess* request,
     SmContextVoid* response) {
-  struct in_addr ip_addr = {0};
+  struct in_addr ip_addr       = {0};
   char ip_str[INET_ADDRSTRLEN] = {0};
-  uint32_t ip_int = 0;
-  OAILOG_INFO(LOG_UTIL, "Received GRPC SetSmfSessionContext request from SMF\n");
+  uint32_t ip_int              = 0;
+  OAILOG_INFO(
+      LOG_UTIL, "Received GRPC SetSmfSessionContext request from SMF\n");
 
   itti_n11_create_pdu_session_response_t itti_msg;
   auto& req_common = request->common_context();
@@ -72,8 +72,7 @@ Status AmfServiceImpl::SetSmfSessionContext(
   itti_msg.sm_session_version = req_common.sm_session_version();
 
   // RatSpecificContextAccess
-  memcpy(
-       (&itti_msg.pdu_session_id), req_m5g.pdu_session_id().c_str(), 1);
+  memcpy((&itti_msg.pdu_session_id), req_m5g.pdu_session_id().c_str(), 1);
   itti_msg.pdu_session_type  = (pdu_session_type_t) req_m5g.pdu_session_type();
   itti_msg.selected_ssc_mode = (ssc_mode_t) req_m5g.selected_ssc_mode();
   itti_msg.m5gsm_cause       = (m5g_sm_cause_t) req_m5g.m5gsm_cause();
@@ -85,17 +84,19 @@ Status AmfServiceImpl::SetSmfSessionContext(
       req_m5g.m5gsm_congetion_re_attempt_indicator();
   itti_msg.pdu_address.redirect_address_type =
       (redirect_address_type_t) req_m5g.pdu_address().redirect_address_type();
-  /*PDU IP address coming from SMF in human-readable format has to be packed into 4 bytes in hex for NAS5G layer*/ 
-  strcpy(
-      ip_str,
-      req_m5g.pdu_address().redirect_server_address().c_str());
+  // PDU IP address coming from SMF in human-readable format has to be packed
+  // into 4 raw bytes in hex for NAS5G layer
+  strcpy(ip_str, req_m5g.pdu_address().redirect_server_address().c_str());
   inet_pton(AF_INET, ip_str, &(ip_addr.s_addr));
   ip_int = ntohl(ip_addr.s_addr);
   INT32_TO_BUFFER(ip_int, itti_msg.pdu_address.redirect_server_address);
-  
-  //get the 4 byte UPF TEID and UPF IP message 
-  memcpy(itti_msg.upf_endpoint.teid, req_m5g.upf_endpoint().teid().c_str(), TEID_SIZE);
-  memcpy(itti_msg.upf_endpoint.end_ipv4_addr, req_m5g.upf_endpoint().end_ipv4_addr().c_str(), UPF_IPV4_ADDR_SIZE);
+  // get the 4 byte UPF TEID and UPF IP message
+  memcpy(
+      itti_msg.upf_endpoint.teid, req_m5g.upf_endpoint().teid().c_str(),
+      TEID_SIZE);
+  memcpy(
+      itti_msg.upf_endpoint.end_ipv4_addr,
+      req_m5g.upf_endpoint().end_ipv4_addr().c_str(), UPF_IPV4_ADDR_SIZE);
   send_n11_create_pdu_session_resp_itti(&itti_msg);
   return Status::OK;
 }

--- a/lte/gateway/c/oai/tasks/grpc_service/AmfServiceImpl.cpp
+++ b/lte/gateway/c/oai/tasks/grpc_service/AmfServiceImpl.cpp
@@ -56,7 +56,10 @@ Status AmfServiceImpl::SetAmfNotification(
 Status AmfServiceImpl::SetSmfSessionContext(
     ServerContext* context, const SetSMSessionContextAccess* request,
     SmContextVoid* response) {
-  OAILOG_INFO(LOG_UTIL, "Received  GRPC SetSMSessionContextAccess request\n");
+  struct in_addr ip_addr = {0};
+  char ip_str[INET_ADDRSTRLEN] = {0};
+  uint32_t ip_int = 0;
+  OAILOG_INFO(LOG_UTIL, "Received GRPC SetSmfSessionContext request from SMF\n");
 
   itti_n11_create_pdu_session_response_t itti_msg;
   auto& req_common = request->common_context();
@@ -69,32 +72,12 @@ Status AmfServiceImpl::SetSmfSessionContext(
   itti_msg.sm_session_version = req_common.sm_session_version();
 
   // RatSpecificContextAccess
-  strncpy(
-      (char*) (&itti_msg.pdu_session_id), req_m5g.pdu_session_id().c_str(), 1);
+  memcpy(
+       (&itti_msg.pdu_session_id), req_m5g.pdu_session_id().c_str(), 1);
   itti_msg.pdu_session_type  = (pdu_session_type_t) req_m5g.pdu_session_type();
   itti_msg.selected_ssc_mode = (ssc_mode_t) req_m5g.selected_ssc_mode();
   itti_msg.m5gsm_cause       = (m5g_sm_cause_t) req_m5g.m5gsm_cause();
-  for (int i = 0, m = req_m5g.authorized_qos_rules_size(); i < m; i++) {
-    itti_msg.authorized_qos_rules[i].qos_rule_identifier =
-        (uint32_t) req_m5g.authorized_qos_rules(i).qos_rule_identifier();
-    itti_msg.authorized_qos_rules[i].dqr =
-        req_m5g.authorized_qos_rules(i).dqr();
-    itti_msg.authorized_qos_rules[i].number_of_packet_filters =
-        (uint32_t) req_m5g.authorized_qos_rules(i).number_of_packet_filters();
-    for (int j = 0, n = req_m5g.authorized_qos_rules(i)
-                            .packet_filter_identifier_size();
-         j < n; j++) {
-      itti_msg.authorized_qos_rules[i].packet_filter_identifier[j] =
-          (uint32_t) req_m5g.authorized_qos_rules(i).packet_filter_identifier(
-              j);
-    }
-    itti_msg.authorized_qos_rules[i].qos_rule_precedence =
-        (uint32_t) req_m5g.authorized_qos_rules(i).qos_rule_precedence();
-    itti_msg.authorized_qos_rules[i].segregation =
-        req_m5g.authorized_qos_rules(i).segregation();
-    itti_msg.authorized_qos_rules[i].qos_flow_identifier =
-        (uint32_t) req_m5g.authorized_qos_rules(i).qos_flow_identifier();
-  }
+
   itti_msg.always_on_pdu_session_indication =
       req_m5g.always_on_pdu_session_indication();
   itti_msg.allowed_ssc_mode = (ssc_mode_t) req_m5g.allowed_ssc_mode();
@@ -102,9 +85,17 @@ Status AmfServiceImpl::SetSmfSessionContext(
       req_m5g.m5gsm_congetion_re_attempt_indicator();
   itti_msg.pdu_address.redirect_address_type =
       (redirect_address_type_t) req_m5g.pdu_address().redirect_address_type();
+  /*PDU IP address coming from SMF in human-readable format has to be packed into 4 bytes in hex for NAS5G layer*/ 
   strcpy(
-      (char*) itti_msg.pdu_address.redirect_server_address,
+      ip_str,
       req_m5g.pdu_address().redirect_server_address().c_str());
+  inet_pton(AF_INET, ip_str, &(ip_addr.s_addr));
+  ip_int = ntohl(ip_addr.s_addr);
+  INT32_TO_BUFFER(ip_int, itti_msg.pdu_address.redirect_server_address);
+  
+  //get the 4 byte UPF TEID and UPF IP message 
+  memcpy(itti_msg.upf_endpoint.teid, req_m5g.upf_endpoint().teid().c_str(), TEID_SIZE);
+  memcpy(itti_msg.upf_endpoint.end_ipv4_addr, req_m5g.upf_endpoint().end_ipv4_addr().c_str(), UPF_IPV4_ADDR_SIZE);
   send_n11_create_pdu_session_resp_itti(&itti_msg);
   return Status::OK;
 }

--- a/lte/gateway/c/oai/tasks/grpc_service/AmfServiceImpl.h
+++ b/lte/gateway/c/oai/tasks/grpc_service/AmfServiceImpl.h
@@ -1,13 +1,15 @@
 /*
-Copyright 2020 The Magma Authors.
-This source code is licensed under the BSD-style license found in the
-LICENSE file in the root directory of this source tree.
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 #pragma once
 
@@ -16,11 +18,6 @@ limitations under the License.
 
 #include "lte/protos/session_manager.grpc.pb.h"
 #include "lte/protos/policydb.pb.h"
-
-extern "C" {
-//#include "spgw_service_handler.h"
-#include "log.h"
-}
 
 namespace grpc {
 class ServerContext;

--- a/lte/gateway/c/oai/tasks/grpc_service/AmfServiceImpl.h
+++ b/lte/gateway/c/oai/tasks/grpc_service/AmfServiceImpl.h
@@ -39,9 +39,6 @@ using magma::lte::SmfPduSessionSmContext;
 namespace magma {
 using namespace lte;
 
-#define TEID_SIZE 4
-#define UPF_IPV4_ADDR_SIZE 4
-
 // SessionD to AMF server
 class AmfServiceImpl final : public SmfPduSessionSmContext::Service {
  public:

--- a/lte/gateway/c/oai/tasks/grpc_service/AmfServiceImpl.h
+++ b/lte/gateway/c/oai/tasks/grpc_service/AmfServiceImpl.h
@@ -39,6 +39,9 @@ using magma::lte::SmfPduSessionSmContext;
 namespace magma {
 using namespace lte;
 
+#define TEID_SIZE 4
+#define UPF_IPV4_ADDR_SIZE 4
+
 // SessionD to AMF server
 class AmfServiceImpl final : public SmfPduSessionSmContext::Service {
  public:

--- a/lte/gateway/c/oai/tasks/grpc_service/CMakeLists.txt
+++ b/lte/gateway/c/oai/tasks/grpc_service/CMakeLists.txt
@@ -68,6 +68,14 @@ generate_cpp_protos("${HASRV_LTE_CPP_PROTOS}" "${PROTO_SRCS}"
 generate_grpc_protos("${HASRV_LTE_GRPC_PROTOS}" "${PROTO_SRCS}"
   "${PROTO_HDRS}" ${LTE_PROTO_DIR} ${LTE_OUT_DIR})
 
+# AMF
+set(AMFSRV_M5G_CPP_PROTOS subscriberdb session_manager)
+set(AMFSRV_M5G_GRPC_PROTOS session_manager)
+generate_cpp_protos("${AMFSRV_M5G_CPP_PROTOS}" "${PROTO_SRCS}"
+  "${PROTO_HDRS}" ${LTE_PROTO_DIR} ${LTE_OUT_DIR})
+generate_grpc_protos("${AMFSRV_M5G_GRPC_PROTOS}" "${PROTO_SRCS}"
+  "${PROTO_HDRS}" ${LTE_PROTO_DIR} ${LTE_OUT_DIR})
+
 include_directories(${CMAKE_CURRENT_BINARY_DIR})
 
 add_library(TASK_GRPC_SERVICE
@@ -79,7 +87,9 @@ add_library(TASK_GRPC_SERVICE
     SMSOrc8rGatewayServiceImpl.cpp
     S1apServiceImpl.cpp
     HaServiceImpl.cpp
+    AmfServiceImpl.cpp 
     spgw_service_handler.c
+    amf_service_handler.c
     proto_msg_to_itti_msg.cpp
     grpc_service.cpp
     ${PROTO_SRCS}

--- a/lte/gateway/c/oai/tasks/grpc_service/amf_service_handler.c
+++ b/lte/gateway/c/oai/tasks/grpc_service/amf_service_handler.c
@@ -12,6 +12,7 @@
  */
 
 #include "common_types.h"
+#include "common_defs.h"
 #include "intertask_interface.h"
 #include "intertask_interface_types.h"
 #include "itti_types.h"
@@ -26,6 +27,12 @@ int send_n11_create_pdu_session_resp_itti(
       LOG_UTIL, "Sending itti_n11_create_pdu_session_response to AMF \n");
   MessageDef* message_p = itti_alloc_new_message(
       TASK_GRPC_SERVICE, N11_CREATE_PDU_SESSION_RESPONSE);
+  if (message_p == NULL) {
+    OAILOG_ERROR(
+        LOG_UTIL,
+        "Failed to allocate memory for N11_CREATE_PDU_SESSION_RESPONSE\n");
+    return RETURNerror;
+  }
   message_p->ittiMsg.n11_create_pdu_session_response = *itti_msg;
   return send_msg_to_task(&grpc_service_task_zmq_ctx, TASK_AMF_APP, message_p);
 }

--- a/lte/gateway/c/oai/tasks/grpc_service/amf_service_handler.c
+++ b/lte/gateway/c/oai/tasks/grpc_service/amf_service_handler.c
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "common_types.h"
+#include "intertask_interface.h"
+#include "intertask_interface_types.h"
+#include "itti_types.h"
+#include "log.h"
+#include "n11_messages_types.h"
+
+extern task_zmq_ctx_t grpc_service_task_zmq_ctx;
+
+int send_n11_create_pdu_session_resp_itti(
+    itti_n11_create_pdu_session_response_t* itti_msg) {
+  OAILOG_DEBUG(
+      LOG_UTIL, "Sending itti_n11_create_pdu_session_response to AMF \n");
+  MessageDef* message_p = itti_alloc_new_message(
+      TASK_GRPC_SERVICE, N11_CREATE_PDU_SESSION_RESPONSE);
+  message_p->ittiMsg.n11_create_pdu_session_response = *itti_msg;
+  return send_msg_to_task(&grpc_service_task_zmq_ctx, TASK_AMF_APP, message_p);
+}

--- a/lte/gateway/c/oai/tasks/grpc_service/grpc_service_task.c
+++ b/lte/gateway/c/oai/tasks/grpc_service/grpc_service_task.c
@@ -59,7 +59,7 @@ static int handle_message(zloop_t* loop, zsock_t* reader, void* arg) {
 static void* grpc_service_thread(__attribute__((unused)) void* args) {
   itti_mark_task_ready(TASK_GRPC_SERVICE);
   init_task_context(
-      TASK_GRPC_SERVICE, (task_id_t[]){TASK_SPGW_APP, TASK_HA}, 2,
+      TASK_GRPC_SERVICE, (task_id_t[]){TASK_SPGW_APP, TASK_HA, TASK_AMF_APP}, 3,
       handle_message, &grpc_service_task_zmq_ctx);
 
   start_grpc_service(grpc_service_config->server_address);


### PR DESCRIPTION
Implementation of SmfPduSessionSmContext gRPC call, processing and forwarding the message towards AMF

Signed-off-by: ashish-acl <ashish.t@altencalsoftlabs.com>

## Summary

Created the RPC implementation for SmfPduSessionSmContext with the grpc_service in MME. When invoked by SMF, the message as defined in session_manager.proto is parsed and forwarded to AMF via ZMQ for processing.

## Test Plan
[SetSmfSessionContext_Processing_and_sending_to_AMF_UT.log](https://github.com/magma/magma/files/5943299/SetSmfSessionContext_Processing_and_sending_to_AMF_UT.log)


## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
