### PR TITLE
[LTEIntegTest] Add DEBIAN_FRONTEND=noninteractive flag to dist-upgrade command

### DIFF
--- a/lte/gateway/fabfile.py
+++ b/lte/gateway/fabfile.py
@@ -348,7 +348,7 @@ def get_test_logs(gateway_host=None,
 def _dist_upgrade():
     """ Upgrades OS packages on dev box """
     run('sudo apt-get update')
-    run('sudo apt-get -y dist-upgrade')
+    run('sudo DEBIAN_FRONTEND=noninteractive apt-get -y dist-upgrade')
 
 
 def _build_magma():


### PR DESCRIPTION
Signed-off-by: Marie Bremner <marwhal@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary
See attached issue https://github.com/magma/magma/issues/4809
<!-- Enumerate changes you made and why you made them -->

## Test Plan
Getting past the issue: https://app.circleci.com/pipelines/github/magma/magma/14197/workflows/fba56679-6639-4922-96fb-121fe68dcb37/jobs/128071
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
