### PR TITLE
[lte][agw] add agw_focal_install.sh to install magma on bare metal Ubuntu 20.04 machine

### DIFF
--- a/lte/gateway/deploy/agw_focal_install.sh
+++ b/lte/gateway/deploy/agw_focal_install.sh
@@ -35,6 +35,7 @@ fi
 
 echo "Making sure $MAGMA_USER user is sudoers"
 if ! grep -q "$MAGMA_USER ALL=(ALL) NOPASSWD:ALL" /etc/sudoers; then
+  apt update
   apt install -y sudo
   adduser $MAGMA_USER sudo
   echo "$MAGMA_USER ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers

--- a/lte/gateway/deploy/agw_focal_install.sh
+++ b/lte/gateway/deploy/agw_focal_install.sh
@@ -141,7 +141,7 @@ if [ "$PING_RESULT" != "$SUCCESS_MESSAGE" ]; then
   exit 1
 fi
 echo "Checking if magma has been installed"
-MAGMA_INSTALLED=$(apt-cache show magma >  /dev/null 2>&1 echo "$SUCCESS_MESSAGE")
+MAGMA_INSTALLED=$(apt-cache show magma >  /dev/null 2>&1 && echo "$SUCCESS_MESSAGE")
 if [ "$MAGMA_INSTALLED" != "$SUCCESS_MESSAGE" ]; then
   echo "Magma not installed, processing installation"
   apt-get update

--- a/lte/gateway/deploy/agw_focal_install.sh
+++ b/lte/gateway/deploy/agw_focal_install.sh
@@ -73,7 +73,7 @@ fi
 
 # configure environment variable defaults needed for ansible
 ANSIBLE_VARS="preburn=yes PACKAGE_LOCATION=/tmp"
-if [ -n "${REPO_HOST}" ]; then
+if [ -n "${REPO}" ]; then
     if [ -z "${REPO_PROTO}" ]; then
         REPO_PROTO=http
     fi
@@ -84,7 +84,7 @@ if [ -n "${REPO_HOST}" ]; then
         REPO_COMPONENT=main
     fi
     # configure pkgrepo location
-    ANSIBLE_VARS="ovs_pkgrepo_proto=${REPO_PROTO} ovs_pkgrepo_host=${REPO_HOST} ovs_pkgrepo_path=${REPO_PATH} ${ANSIBLE_VARS}"
+    ANSIBLE_VARS="ovs_pkgrepo_proto=${REPO_PROTO} ovs_pkgrepo=${REPO} ${ANSIBLE_VARS}"
 
     # configure pkgrepo distribution
     ANSIBLE_VARS="ovs_pkgrepo_dist=${REPO_DIST} ovs_pkgrepo_component=${REPO_COMPONENT} ${ANSIBLE_VARS}"
@@ -115,7 +115,7 @@ Wants=network-online.target
 Environment=MAGMA_VERSION=${MAGMA_VERSION}
 Environment=GIT_URL=${GIT_URL}
 Environment=REPO_PROTO=${REPO_PROTO}
-Environment=REPO_HOST=${REPO_HOST}
+Environment=REPO=${REPO}
 Environment=REPO_DIST=${REPO_DIST}
 Environment=REPO_COMPONENT=${REPO_COMPONENT}
 Environment=REPO_KEY=${REPO_KEY}

--- a/lte/gateway/deploy/agw_focal_install.sh
+++ b/lte/gateway/deploy/agw_focal_install.sh
@@ -2,7 +2,7 @@
 # Setting up env variable, user and project path
 MAGMA_USER="magma"
 AGW_INSTALL_SERVICE="/etc/systemd/system/multi-user.target.wants/agw_installation.service"
-AGW_INSTALL_CONFIG="/tmp/agw_installation.service"
+AGW_INSTALL_CONFIG="/lib/systemd/system/agw_installation.service"
 AGW_SCRIPT_PATH="/root/$(basename $0)"
 MAGMA_ROOT=/home/$MAGMA_USER/magma
 DEPLOY_PATH="${MAGMA_ROOT}/lte/gateway/deploy"
@@ -168,7 +168,7 @@ if [ "$MAGMA_INSTALLED" != "$SUCCESS_MESSAGE" ]; then
 
   echo "Deleting boot script if it exists"
   if [ -f "$AGW_INSTALL_CONFIG" ]; then
-    rm -rf $AGW_INSTALL_CONFIG
+    rm -rf $AGW_INSTALL_CONFIG "${AGW_INSTALL_SERVICE}"
   fi
   rm -rf /home/$MAGMA_USER/build
   echo "AGW installation is done, make sure all services above are running correctly.. rebooting"

--- a/lte/gateway/deploy/agw_focal_install.sh
+++ b/lte/gateway/deploy/agw_focal_install.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 # Setting up env variable, user and project path
 MAGMA_USER="magma"
-AGW_INSTALL_CONFIG="/etc/systemd/system/multi-user.target.wants/agw_installation.service"
+AGW_INSTALL_SERVICE="/etc/systemd/system/multi-user.target.wants/agw_installation.service"
+AGW_INSTALL_CONFIG="/tmp/agw_installation.service"
 AGW_SCRIPT_PATH="/root/$(basename $0)"
 MAGMA_ROOT=/home/$MAGMA_USER/magma
 DEPLOY_PATH="${MAGMA_ROOT}/lte/gateway/deploy"
@@ -128,6 +129,7 @@ Group=root
 WantedBy=multi-user.target
 EOF
   chmod 644 $AGW_INSTALL_CONFIG
+  ln -sf "${AGW_INSTALL_CONFIG}" "${AGW_INSTALL_SERVICE}"
   reboot
 fi
 

--- a/lte/gateway/deploy/agw_focal_install.sh
+++ b/lte/gateway/deploy/agw_focal_install.sh
@@ -3,7 +3,8 @@
 MAGMA_USER="magma"
 AGW_INSTALL_CONFIG="/etc/systemd/system/multi-user.target.wants/agw_installation.service"
 AGW_SCRIPT_PATH="/root/$(basename $0)"
-DEPLOY_PATH="/home/$MAGMA_USER/magma/lte/gateway/deploy"
+MAGMA_ROOT=/home/$MAGMA_USER/magma
+DEPLOY_PATH="${MAGMA_ROOT}/lte/gateway/deploy"
 SUCCESS_MESSAGE="ok"
 NEED_REBOOT=0
 WHOAMI=$(whoami)
@@ -69,7 +70,7 @@ else
 fi
 
 # configure environment variable defaults needed for ansible
-ANSIBLE_VARS="PACKAGE_LOCATION=/tmp"
+ANSIBLE_VARS="preburn=yes PACKAGE_LOCATION=/tmp"
 if [ -n "${REPO_HOST}" ]; then
     if [ -z "${REPO_PROTO}" ]; then
         REPO_PROTO=http

--- a/lte/gateway/deploy/agw_focal_install.sh
+++ b/lte/gateway/deploy/agw_focal_install.sh
@@ -12,6 +12,7 @@ WHOAMI=$(whoami)
 KVERS=$(uname -r)
 MAGMA_VERSION="${MAGMA_VERSION:-v1.3}"
 GIT_URL="${GIT_URL:-https://github.com/magma/magma.git}"
+INSTALL_TIMEOUT="${INSTALL_TIMEOUT:-3800}"
 
 REQUIRED_OS_DIST=Ubuntu
 REQUIRED_OS_RELEASE=20.04
@@ -122,8 +123,8 @@ Environment=REPO_KEY=${REPO_KEY}
 Environment=REPO_KEY_FINGERPRINT=${REPO_KEY_FINGERPRINT}
 Type=oneshot
 ExecStart=/bin/bash ${AGW_SCRIPT_PATH}
-TimeoutStartSec=3800
-TimeoutSec=3600
+TimeoutStartSec=${INSTALL_TIMEOUT}
+TimeoutSec=${INSTALL_TIMEOUT}
 User=root
 Group=root
 [Install]

--- a/lte/gateway/deploy/agw_focal_install.sh
+++ b/lte/gateway/deploy/agw_focal_install.sh
@@ -1,0 +1,174 @@
+#!/bin/bash
+# Setting up env variable, user and project path
+MAGMA_USER="magma"
+AGW_INSTALL_CONFIG="/etc/systemd/system/multi-user.target.wants/agw_installation.service"
+AGW_SCRIPT_PATH="/root/$(basename $0)"
+DEPLOY_PATH="/home/$MAGMA_USER/magma/lte/gateway/deploy"
+SUCCESS_MESSAGE="ok"
+NEED_REBOOT=0
+WHOAMI=$(whoami)
+KVERS=$(uname -r)
+MAGMA_VERSION="${MAGMA_VERSION:-v1.3}"
+GIT_URL="${GIT_URL:-https://github.com/magma/magma.git}"
+
+REQUIRED_OS_DIST=Ubuntu
+REQUIRED_OS_RELEASE=20.04
+
+echo "Checking if the script has been executed by root user"
+if [ "$WHOAMI" != "root" ]; then
+  echo "You're executing the script as $WHOAMI instead of root.. exiting"
+  exit 1
+fi
+
+echo "Checking if ${REQUIRED_OS_DIST} ${REQUIRED_OS_RELEASE} is installed"
+if ! grep -iq "${REQUIRED_OS_DIST}" /etc/os-release; then
+  echo "${REQUIRED_OS_DIST} is not installed"
+  exit 1
+fi
+if ! grep -iq "${REQUIRED_OS_RELEASE}" /etc/os-release; then
+  echo "${REQUIRED_OS_RELEASE} is not installed"
+  exit 1
+fi
+
+
+echo "Making sure $MAGMA_USER user is sudoers"
+if ! grep -q "$MAGMA_USER ALL=(ALL) NOPASSWD:ALL" /etc/sudoers; then
+  apt install -y sudo
+  adduser $MAGMA_USER sudo
+  echo "$MAGMA_USER ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers
+fi
+
+echo "Need to check if both interfaces are named eth0 and eth1"
+INTERFACES=$(ip -br a)
+if [[ ! $INTERFACES == *'eth0'*  ]] || [[ ! $INTERFACES == *'eth1'* ]] || ! grep -q 'GRUB_CMDLINE_LINUX="net.ifnames=0 biosdevname=0"' /etc/default/grub; then
+  # changing intefaces name
+  sed -i 's/GRUB_CMDLINE_LINUX=""/GRUB_CMDLINE_LINUX="net.ifnames=0 biosdevname=0"/g' /etc/default/grub
+  # changing interface name
+  grub-mkconfig -o /boot/grub/grub.cfg
+  rm -f /etc/netplan/00-installer-config.yaml
+  cat <<EOF > /etc/netplan/00-magma-focal-config.yaml
+---
+network:
+  version: 2
+  ethernets:
+    eth0:
+      dhcp4: yes
+    eth1:
+      dhcp4: no
+      addresses: [10.0.2.1/24]
+EOF
+  netplan apply
+  # Setting REBOOT flag to 1 because we need to reload new interface and network services.
+  NEED_REBOOT=1
+else
+  echo "Interfaces name are correct, let's check if network and DNS are up"
+  while ! ping -c 1 -W 1 -I eth0 google.com; do
+    echo "Network not ready yet"
+    sleep 1
+  done
+fi
+
+# configure environment variable defaults needed for ansible
+ANSIBLE_VARS="PACKAGE_LOCATION=/tmp"
+if [ -n "${REPO_HOST}" ]; then
+    if [ -z "${REPO_PROTO}" ]; then
+        REPO_PROTO=http
+    fi
+    if [ -z "${REPO_DIST}" ]; then
+        REPO_DIST=focal-test
+    fi
+    if [ -z "${REPO_COMPONENT}" ]; then
+        REPO_COMPONENT=main
+    fi
+    # configure pkgrepo location
+    ANSIBLE_VARS="ovs_pkgrepo_proto=${REPO_PROTO} ovs_pkgrepo_host=${REPO_HOST} ovs_pkgrepo_path=${REPO_PATH} ${ANSIBLE_VARS}"
+
+    # configure pkgrepo distribution
+    ANSIBLE_VARS="ovs_pkgrepo_dist=${REPO_DIST} ovs_pkgrepo_component=${REPO_COMPONENT} ${ANSIBLE_VARS}"
+
+    # configure pkgrepo gpg key
+    ANSIBLE_VARS="ovs_pkgrepo_key=${REPO_KEY} ${ANSIBLE_VARS}"
+    if [ -z "${REPO_KEY_FINGERPRINT}" ]; then
+        ANSIBLE_VARS="ovs_pkgrepo_key_fingerprint=${REPO_KEY_FINGERPRINT} ${ANSIBLE_VARS}"
+    fi
+fi
+
+if [ "${REPO_PROTO}" == 'https' ]; then
+    echo "Ensure HTTPS apt transport method is installed"
+    apt install -y apt-transport-https
+fi
+
+if [ $NEED_REBOOT = 1 ]; then
+  echo "Will reboot in a few seconds, loading a boot script in order to install magma"
+  if [ ! -f "$AGW_SCRIPT_PATH" ]; then
+      cp "$(realpath $0)" "${AGW_SCRIPT_PATH}"
+  fi
+  cat <<EOF > $AGW_INSTALL_CONFIG
+[Unit]
+Description=AGW Installation
+After=network-online.target
+Wants=network-online.target
+[Service]
+Environment=MAGMA_VERSION=${MAGMA_VERSION}
+Environment=GIT_URL=${GIT_URL}
+Environment=REPO_PROTO=${REPO_PROTO}
+Environment=REPO_HOST=${REPO_HOST}
+Environment=REPO_DIST=${REPO_DIST}
+Environment=REPO_COMPONENT=${REPO_COMPONENT}
+Environment=REPO_KEY=${REPO_KEY}
+Environment=REPO_KEY_FINGERPRINT=${REPO_KEY_FINGERPRINT}
+Type=oneshot
+ExecStart=/bin/bash ${AGW_SCRIPT_PATH}
+TimeoutStartSec=3800
+TimeoutSec=3600
+User=root
+Group=root
+[Install]
+WantedBy=multi-user.target
+EOF
+  chmod 644 $AGW_INSTALL_CONFIG
+  reboot
+fi
+
+echo "Making sure eth0 is connected to internet"
+PING_RESULT=$(ping -c 1 -I eth0 8.8.8.8 > /dev/null 2>&1 && echo "$SUCCESS_MESSAGE")
+if [ "$PING_RESULT" != "$SUCCESS_MESSAGE" ]; then
+  echo "eth0 (enp1s0) is not connected to internet, please double check your plugged wires."
+  exit 1
+fi
+echo "Checking if magma has been installed"
+MAGMA_INSTALLED=$(apt-cache show magma >  /dev/null 2>&1 echo "$SUCCESS_MESSAGE")
+if [ "$MAGMA_INSTALLED" != "$SUCCESS_MESSAGE" ]; then
+  echo "Magma not installed, processing installation"
+  apt-get update
+  apt-get -y install curl make virtualenv zip rsync git software-properties-common python3-pip python-dev
+  alias python=python3
+  pip3 install ansible
+
+  git clone "${GIT_URL}" /home/$MAGMA_USER/magma
+  cd /home/$MAGMA_USER/magma
+  git checkout "$MAGMA_VERSION"
+
+  echo "Generating localhost hostfile for Ansible"
+  echo "[ovs_build]
+  127.0.0.1 ansible_connection=local
+  [ovs_deploy]
+  127.0.0.1 ansible_connection=local" > $DEPLOY_PATH/agw_hosts
+  if [ -n "${FORCE_OVS_BUILD}" ]; then
+      echo "Triggering ovs_build playbook"
+      su - $MAGMA_USER -c "ansible-playbook -e \"MAGMA_ROOT='/home/$MAGMA_USER/magma' OUTPUT_DIR='/tmp'\" -i $DEPLOY_PATH/agw_hosts $DEPLOY_PATH/ovs_build.yml"
+      ANSIBLE_VARS="${ANSIBLE_VARS} ovs_use_pkgrepo=no"
+  fi
+  echo "Triggering ovs_deploy playbook"
+  su - $MAGMA_USER -c "ansible-playbook -e '${ANSIBLE_VARS}' -i $DEPLOY_PATH/agw_hosts $DEPLOY_PATH/ovs_deploy.yml --skip-tags \"skipfirstinstall\""
+
+  echo "Deleting boot script if it exists"
+  if [ -f "$AGW_INSTALL_CONFIG" ]; then
+    rm -rf $AGW_INSTALL_CONFIG
+  fi
+  rm -rf /home/$MAGMA_USER/build
+  echo "AGW installation is done, make sure all services above are running correctly.. rebooting"
+  reboot
+else
+  echo "Magma already installed, skipping.."
+fi

--- a/lte/gateway/deploy/agw_install.sh
+++ b/lte/gateway/deploy/agw_install.sh
@@ -3,7 +3,8 @@
 MAGMA_USER="magma"
 AGW_INSTALL_CONFIG="/etc/systemd/system/multi-user.target.wants/agw_installation.service"
 AGW_SCRIPT_PATH="/root/agw_install.sh"
-DEPLOY_PATH="/home/$MAGMA_USER/magma/lte/gateway/deploy"
+MAGMA_ROOT=/home/$MAGMA_USER/magma
+DEPLOY_PATH="${MAGMA_ROOT}/lte/gateway/deploy"
 SUCCESS_MESSAGE="ok"
 NEED_REBOOT=0
 WHOAMI=$(whoami)
@@ -72,7 +73,7 @@ if [ "$KVERS" != "4.9.0-9-amd64" ]; then
 fi
 
 # configure environment variable defaults needed for ansible
-ANSIBLE_VARS="PACKAGE_LOCATION=/tmp"
+ANSIBLE_VARS="preburn=yes PACKAGE_LOCATION=/tmp"
 if [ -n "${REPO_HOST}" ]; then
     if [ -z "${REPO_PROTO}" ]; then
         REPO_PROTO=http
@@ -159,7 +160,7 @@ if [ "$MAGMA_INSTALLED" != "$SUCCESS_MESSAGE" ]; then
   127.0.0.1 ansible_connection=local" > $DEPLOY_PATH/agw_hosts
   if [ -n "${FORCE_OVS_BUILD}" ]; then
       echo "Triggering ovs_build playbook"
-      su - $MAGMA_USER -c "ansible-playbook -e \"MAGMA_ROOT='/home/$MAGMA_USER/magma' OUTPUT_DIR='/tmp'\" -i $DEPLOY_PATH/agw_hosts $DEPLOY_PATH/ovs_build.yml"
+      su - $MAGMA_USER -c "ansible-playbook -e \"MAGMA_ROOT='${MAGMA_ROOT}' OUTPUT_DIR='/tmp'\" -i $DEPLOY_PATH/agw_hosts $DEPLOY_PATH/ovs_build.yml"
       ANSIBLE_VARS="${ANSIBLE_VARS} ovs_use_pkgrepo=no"
   fi
   echo "Triggering ovs_deploy playbook"

--- a/lte/gateway/deploy/agw_install.sh
+++ b/lte/gateway/deploy/agw_install.sh
@@ -11,6 +11,7 @@ WHOAMI=$(whoami)
 KVERS=$(uname -r)
 MAGMA_VERSION="${MAGMA_VERSION:-v1.3}"
 GIT_URL="${GIT_URL:-https://github.com/magma/magma.git}"
+INSTALL_TIMEOUT="${INSTALL_TIMEOUT:-3800}"
 
 echo "Checking if the script has been executed by root user"
 if [ "$WHOAMI" != "root" ]; then
@@ -123,8 +124,8 @@ Environment=REPO_KEY=${REPO_KEY}
 Environment=REPO_KEY_FINGERPRINT=${REPO_KEY_FINGERPRINT}
 Type=oneshot
 ExecStart=/bin/bash ${AGW_SCRIPT_PATH}
-TimeoutStartSec=3800
-TimeoutSec=3600
+TimeoutStartSec=${INSTALL_TIMEOUT}
+TimeoutSec=${INSTALL_TIMEOUT}
 User=root
 Group=root
 [Install]

--- a/lte/gateway/deploy/ovs_deploy.yml
+++ b/lte/gateway/deploy/ovs_deploy.yml
@@ -11,6 +11,8 @@
 # limitations under the License.
 
 - name: Deploy ovs and magma
+  become: yes
   hosts: ovs_deploy
   roles:
+    - role: envoy
     - role: ovs_deploy

--- a/lte/gateway/deploy/roles/envoy/tasks/main.yml
+++ b/lte/gateway/deploy/roles/envoy/tasks/main.yml
@@ -30,7 +30,7 @@
 
 - name: Add Getenvoy.io repo
   apt_repository:
-    repo: "deb [arch=amd64] https://dl.bintray.com/tetrate/getenvoy-deb stretch stable"
+    repo: "deb [arch=amd64] https://dl.bintray.com/tetrate/getenvoy-deb {{ ansible_distribution_release }} stable"
     state: present
   register: envoy_getenvoy_debian_repo
   when: preburn

--- a/lte/gateway/deploy/roles/ovs_deploy/tasks/main.yml
+++ b/lte/gateway/deploy/roles/ovs_deploy/tasks/main.yml
@@ -62,11 +62,16 @@
     packages:
       - graphviz
       - python-all
-      - python-twisted-conch
       - module-assistant
       - openssl
       - dkms
       - uuid-runtime
+
+- name: Install python-twisted-conch (not available for ubuntu focal)
+  when: ansible_distribution_release != 'focal'
+  apt:
+    pkg:
+      - python-twisted-conch
 
 - name: Build openvswitch packages
   when: not ovs_use_pkgrepo
@@ -111,12 +116,17 @@
   become: yes
   apt:
     name:
-      - oai-gtp
       - libopenvswitch
       - openvswitch-datapath-dkms
       - openvswitch-datapath-source
       - openvswitch-common
       - openvswitch-switch
+
+- name: Install oai-gtp (not needed for ubuntu focal)
+  when: ansible_distribution_release != 'focal'
+  apt:
+    pkg:
+      - oai-gtp
 
 - name: Preconfigure wireshark (tshark) SUID property
   become: yes

--- a/lte/gateway/deploy/roles/ovs_deploy/tasks/main.yml
+++ b/lte/gateway/deploy/roles/ovs_deploy/tasks/main.yml
@@ -18,8 +18,7 @@
 - name: Configuring private package manager.
   copy:
     content: >
-      deb {{ ovs_pkgrepo_proto }}://{{ ovs_pkgrepo_host }}{{ ovs_pkgrepo_path}}
-      {{ ovs_pkgrepo_dist }} {{ ovs_pkgrepo_component }}
+      deb {{ ovs_pkgrepo_proto }}://{{ ovs_pkgrepo }} {{ ovs_pkgrepo_dist }} {{ ovs_pkgrepo_component }}
     dest: /etc/apt/sources.list.d/{{ ovs_pkgrepo_name }}.list
   become: yes
 

--- a/lte/gateway/deploy/roles/ovs_deploy/tasks/main.yml
+++ b/lte/gateway/deploy/roles/ovs_deploy/tasks/main.yml
@@ -127,6 +127,7 @@
   become: yes
   apt:
     name: "{{ packages }}"
+    dpkg_options: 'force-confold,force-confdef,force-overwrite'
   vars:
     packages:
       - magma

--- a/lte/gateway/deploy/roles/ovs_deploy/tasks/main.yml
+++ b/lte/gateway/deploy/roles/ovs_deploy/tasks/main.yml
@@ -35,7 +35,7 @@
       copy:
         dest: /etc/apt/apt.conf.d/99insecurehttpsrepo
         content: |
-          Acquire::https::{{ ovs_pkgrepo_host }} {
+          Acquire::https::{{ ovs_pkgrepo }} {
           Verify-Peer "false";
           Verify-Host "false";
           };
@@ -107,7 +107,7 @@
     dest: /etc/apt/preferences.d/magma-preferences
     content: |
       Package: *
-      Pin: origin {{ ovs_pkgrepo_host }}
+      Pin: origin {{ ovs_pkgrepo }}
       Pin-Priority: 900
 
 - name: Install prebuilt openvswitch packages

--- a/lte/gateway/deploy/roles/ovs_deploy/vars/all.yaml
+++ b/lte/gateway/deploy/roles/ovs_deploy/vars/all.yaml
@@ -24,8 +24,7 @@ ovs_build_config:
     - "openvswitch-switch_2.8.9-1_amd64.deb"
 
 ovs_pkgrepo_proto: http
-ovs_pkgrepo_host: packages.magma.etagecom.io
-ovs_pkgrepo_path: ""
+ovs_pkgrepo: packages.magma.etagecom.io
 ovs_pkgrepo_dist: stretch-stable
 ovs_pkgrepo_component: main
 ovs_pkgrepo_name: "ovs_package_repo"

--- a/lte/gateway/release/build-magma.sh
+++ b/lte/gateway/release/build-magma.sh
@@ -88,9 +88,8 @@ SCTPD_PKGNAME=magma-sctpd
 
 # Magma system dependencies: anything that we depend on at the top level, add
 # here.
-MAGMA_DEPS=(
+MAGMA_DEPS_BASE=(
     "grpc-dev >= 1.15.0"
-    "libprotobuf10 >= 3.0.0"
     "lighttpd >= 1.4.45"
     "libxslt1.1"
     "nghttp2-proxy >= 1.18.1"
@@ -105,7 +104,6 @@ MAGMA_DEPS=(
     "libsystemd-dev"
     "libyaml-cpp-dev" # install yaml parser
     "libgoogle-glog-dev"
-    "nlohmann-json-dev" # c++ json parser
     "python-redis"
     "magma-cpp-redis"
     "libfolly-dev" # required for C++ services
@@ -120,32 +118,81 @@ MAGMA_DEPS=(
     "getenvoy-envoy" # for envoy dep
     )
 
+
+MAGMA_DEPS_STRETCH=(
+    "nlohmann-json-dev" # c++ json parser
+    "libprotobuf10 >= 3.0.0"
+)
+
+MAGMA_DEPS_FOCAL=(
+    "nlohmann-json3-dev" # c++ json parser
+    "libprotobuf17 >= 3.0.0"
+)
+
+if grep -q focal /etc/os-release; then
+    MAGMA_DEPS=("${MAGMA_DEPS_BASE[@]}" "${MAGMA_DEPS_FOCAL[@]}")
+else
+    MAGMA_DEPS=("${MAGMA_DEPS_BASE[@]}" "${MAGMA_DEPS_STRETCH[@]}")
+fi
+
 # OAI runtime dependencies
-OAI_DEPS=(
-    "libasan3"
+OAI_DEPS_BASE=(
     "libconfig9"
     "oai-asn1c"
-    "oai-freediameter >= 1.2.0-1"
     "oai-gnutls >= 3.1.23"
     "oai-nettle >= 1.0.1"
     "prometheus-cpp-dev >= 1.0.2"
     "liblfds710"
     "magma-sctpd >= ${SCTPD_MIN_VERSION}"
     "libczmq-dev >= 4.0.2-7"
+)
+OAI_DEPS_STRETCH=(
     "oai-gtp >= 4.9-5"
-    )
+    "libasan3"
+    "oai-freediameter >= 1.2.0-1"
+)
+OAI_DEPS_FOCAL=(
+    "libasan4"
+    "oai-freediameter >= 0.0.1"
+)
+if grep -q focal /etc/os-release; then
+    OAI_DEPS=("${OAI_DEPS_BASE[@]}" "${OAI_DEPS_FOCAL[@]}")
+else
+    OAI_DEPS=("${OAI_DEPS_BASE[@]}" "${OAI_DEPS_STRETCH[@]}")
+fi
 
 # OVS runtime dependencies
-OVS_DEPS=(
+OVS_DEPS_BASE=(
     "magma-libfluid >= 0.1.0.5"
+    )
+OVS_DEPS_STRETCH=(
     "libopenvswitch >= 2.8.9"
     "openvswitch-switch >= 2.8.9"
     "openvswitch-common >= 2.8.9"
-    "python-openvswitch >= 2.8.9"
     "openvswitch-datapath-module-4.9.0-9-amd64 >= 2.8.9"
-    )
+    "python-openvswitch >= 2.8.9"
+)
+OVS_DEPS_FOCAL=(
+    "libopenvswitch >= 2.14.0"
+    "openvswitch-switch >= 2.14.0"
+    "openvswitch-common >= 2.14.0"
+    "python3-openvswitch >= 2.14.0"
+)
+if grep -q focal /etc/os-release; then
+    OVS_DEPS=("${OVS_DEPS_BASE[@]}" "${OVS_DEPS_FOCAL[@]}")
+else
+    OVS_DEPS=("${OVS_DEPS_BASE[@]}" "${OVS_DEPS_STRETCH[@]}")
+fi
 
 # generate string for FPM
+# compact experimental version
+ALL_DEPS=("${MAGMA_DEPS[@]}" "${OAI_DEPS[@]}" "${OVS_DEPS[@]}")
+SYSTEM_DEPS=""
+for dep in "${ALL_DEPS[@]}"; do
+    SYSTEM_DEPS=${SYSTEM_DEPS}" -d '"${dep}"'"
+done
+
+# original version
 SYSTEM_DEPS=""
 for dep in "${MAGMA_DEPS[@]}"
 do

--- a/lte/gateway/release/build-magma.sh
+++ b/lte/gateway/release/build-magma.sh
@@ -165,7 +165,11 @@ POSTINST=${RELEASE_DIR}/magma-postinst
 
 # python environment
 # python3.5 on stretch, python3.8 on focal
-PY_VERSION=python3
+if grep -q stretch /etc/os-release; then
+    PY_VERSION=python3.5
+else
+    PY_VERSION=python3.8
+fi
 PY_PKG_LOC=dist-packages
 PY_DEST=/usr/local/lib/${PY_VERSION}/${PY_PKG_LOC}
 PY_PROTOS=${PYTHON_BUILD}/gen/

--- a/lte/gateway/release/magma.lockfile
+++ b/lte/gateway/release/magma.lockfile
@@ -348,8 +348,8 @@
         },
         "attrs": {
           "root": false,
-          "source": "pypi",
-          "sysdep": "python3-attrs",
+          "source": "apt",
+          "sysdep": "python3-attr",
           "version": "19.3.0"
         },
         "bravado-core": {
@@ -463,7 +463,7 @@
         "jsonpointer": {
           "root": true,
           "source": "pypi",
-          "sysdep": "python3-jsonpointer",
+          "sysdep": "python3-json-pointer",
           "version": "2.0"
         },
         "jsonref": {
@@ -483,6 +483,12 @@
           "source": "pypi",
           "sysdep": "python3-lazy-object-proxy",
           "version": "1.4.3"
+        },
+        "lxml": {
+          "root": true,
+          "source": "pypi",
+          "sysdep": "python3-lxml",
+          "version": "4.6.2"
         },
         "mccabe": {
           "root": false,
@@ -613,7 +619,7 @@
         "systemd-python": {
           "root": true,
           "source": "pypi",
-          "sysdep": "python3-systemd-python",
+          "sysdep": "python3-systemd",
           "version": "234"
         },
         "toml": {
@@ -698,6 +704,9 @@
         },
         "jsonschema": {
           "version": "3.1.0"
+        },
+        "lxml": {
+          "version": "4.6.2"
         },
         "netifaces": {
           "version": "0.10.4"

--- a/lte/gateway/release/pydep
+++ b/lte/gateway/release/pydep
@@ -64,17 +64,6 @@ log = logging.getLogger(__name__)
 PYPI_API_BASE = "https://pypi.python.org/pypi/%s/json"
 PIP_BLACKLIST = {'pip', 'wheel', 'setuptools', 'virtualenv'}
 
-# In general, system package repos use the same name as PyPI package names,
-# with a prefix (for example, python3-requests is the system package for
-# requests). Some packages break this convention, however, and we maintain a
-# list here. We use the all lower-case version of the package name here.
-PYPI_TO_DEB = {
-    'pyyaml': 'yaml',
-    'msgpack-python': 'msgpack',
-    'scapy-python3': 'scapy',
-    'python-apt': 'apt',
-}
-
 # Some packages exist in the standard Debian repos with an epoch number
 # prepended (this is to handle changes in upstream versioning scheme). This
 # allows us to handle that.
@@ -83,7 +72,7 @@ DEB_EPOCH = {
 }
 
 
-def os_release():
+def os_release() -> Dict[str, str]:
     # copied from third_party/build/build.py
     # FIXME: should be a magma python library for this kind of thing
     release_info = {}
@@ -95,6 +84,33 @@ def os_release():
             except Exception:
                 pass
     return release_info
+
+
+# In general, system package repos use the same name as PyPI package names,
+# with a prefix (for example, python3-requests is the system package for
+# requests). Some packages break this convention, however, and we maintain a
+# list here. We use the all lower-case version of the package name here.
+def pypi_name_remap(pkgname: str, release_name: str='stretch') -> str:
+    base_map = {
+        'pyyaml': 'yaml',
+        'msgpack-python': 'msgpack',
+        'scapy-python3': 'scapy',
+        'python-apt': 'apt',
+    }
+
+    override_maps = {
+        'focal': {
+            'attrs': 'attr',
+            'jsonpointer': 'json-pointer'
+            }
+    }
+
+    if release_name in override_maps and pkgname in override_maps[release_name]:
+        pkgname = override_maps[release_name][pkgname]
+    else:
+        if pkgname in base_map:
+            pkgname = base_map[pkgname]
+    return pkgname
 
 
 def json_equal(a, b):
@@ -150,7 +166,7 @@ def gen_sys_package_name(py_pkgname: str, use_py2: bool=False) -> str:
     Generate the system package name for a Python package. In general, this
     will be `python3-pkgname` for py3 and `python-pkgname` for py2, but some
     packages break convention. We use the PyPI package name as our canonical
-    name source, and PYPI_TO_DEB to handle edge cases.
+    name source, and pypi_name_remap to handle edge cases.
 
     Args:
         py_pkgname: PyPI package name
@@ -164,10 +180,10 @@ def gen_sys_package_name(py_pkgname: str, use_py2: bool=False) -> str:
     else:
         prefix = "python3"
 
-    if py_pkgname.lower() in PYPI_TO_DEB:
-        suffix = PYPI_TO_DEB[py_pkgname.lower()]
-    else:
-        suffix = py_pkgname
+    release_info = os_release()
+
+    suffix = pypi_name_remap(py_pkgname.lower(),
+                             release_name=release_info.get('VERSION_CODENAME'))
 
     sysdep_name = "%s-%s" % (prefix, suffix)
     return sysdep_name.lower()  # deb likes lowercase

--- a/lte/gateway/release/pydep
+++ b/lte/gateway/release/pydep
@@ -63,6 +63,7 @@ log = logging.getLogger(__name__)
 
 PYPI_API_BASE = "https://pypi.python.org/pypi/%s/json"
 PIP_BLACKLIST = {'pip', 'wheel', 'setuptools', 'virtualenv'}
+PIP_WHITELIST = {'protobuf'}
 
 # Some packages exist in the standard Debian repos with an epoch number
 # prepended (this is to handle changes in upstream versioning scheme). This
@@ -101,7 +102,8 @@ def pypi_name_remap(pkgname: str, release_name: str='stretch') -> str:
     override_maps = {
         'focal': {
             'attrs': 'attr',
-            'jsonpointer': 'json-pointer'
+            'jsonpointer': 'json-pointer',
+            'systemd-python': 'systemd'
             }
     }
 
@@ -615,8 +617,9 @@ def py_to_deb(pkgname: str,
         log.error(msg)
         raise Exception(msg)
 
-    if "/.virtualenvs/" not in dist.location:
+    if "/.virtualenvs/" not in dist.location and pkgname not in PIP_WHITELIST:
         # valid package but found in system packages -- source is apt
+        log.debug('apt source for ' + pkgname)
         return 0
 
     syspkg_name = gen_sys_package_name(pkgname, py2)
@@ -817,7 +820,7 @@ def gen_pip_distributions(
     list.
     """
     if not venv:
-        raise ValueError('must supply valid virtualenv command (see tmpvirtualenv)')
+        raise ValueError('must supply valid virtualenv function (see tmpvirtualenv)')
     if not existing_versions:
         existing_versions = {}
     selected_versions = copy.copy(existing_versions)


### PR DESCRIPTION
## Summary

adapt existing `agw_install.sh` to configure netplan etc. for Ubuntu Focal
update supporting files and ansible roles to support Ubuntu Focal

## Test Plan
* verify `agw_focal_install.sh` installs and configures magma on a fresh Ubuntu Focal machine
* verify `agw_install.sh` still installs and configures magma on a fresh Debian Stretch machine
