### PR TITLE
[ci][xwfm] reordering deployments

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1091,25 +1091,18 @@ workflows:
             - cwf-integ-test
       - xwfm-deploy:
           <<: *only_master
+          name: xwfm-deploy-latest
           requires:
-            - xwfm-test
             - cwag-deploy
+            - xwfm-test
+          tag-latest: true
       - cwag-deploy:
           <<: *only_master
           name: cwag-deploy-latest
           requires:
-            - xwfm-test
-            - cwag-precommit
-            - cwf-integ-test
+            - cwag-deploy
+            - xwfm-deploy-latest
           images: 'gateway_python|gateway_pipelined|gateway_go'
-          tag-latest: true
-      - xwfm-deploy:
-          <<: *only_master
-          name: xwfm-deploy-latest
-          requires:
-            - xwfm-test
-            - cwag-precommit
-            - cwf-integ-test
           tag-latest: true
 
 


### PR DESCRIPTION
Signed-off-by: Ayelet Regev Dabah <ayelet.regev@gmail.com>

<!--
    [ci][xwfm] reordering deployments
-->

## Summary

No need to have 2 xwf-m jobs, we canhave 1 to tag latest and regular hash.
Will deploy latest only after regular cwag and not in parallel cause that sometimes ruin the latest hash.

## Test Plan

circleci

$ circleci config validate .circleci/config.yml
Config file at .circleci/config.yml is valid.


## Additional Information

- [ ] This change is backwards-breaking

