### PR TITLE
[lte][agw][infra][pkgrepo] add pkgrepo VM and related files

### DIFF
--- a/infra/pkgrepo/README.md
+++ b/infra/pkgrepo/README.md
@@ -1,0 +1,45 @@
+<!--
+Copyright 2020 The Magma Authors.
+
+This source code is licensed under the BSD-style license found in the
+LICENSE file in the root directory of this source tree.
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+## start the dev vm
+### Environment variables required (convenient to manage with envdir...)
+* DOCKER_REGISTRY
+* DOCKER_USERNAME
+* DOCKER_PASSWORD
+* MAGMA_ROOT
+
+DOCKER_REGISTRY should point to a location with aptly images
+TODO: give `docker` role the ability to build images at provision time
+
+MAGMA_ROOT should point to the magma git repository currently being used,
+defaults to current working copy
+
+
+```
+vagrant up aptly
+```
+
+## testing locally
+```
+# from magma/lte/gateway
+fab dev package:vcs=git
+```
+
+```
+fab test shipit
+```
+
+```
+fab  promote:test,beta,0.3.73-1560277031-53f7ae53
+```
+

--- a/infra/pkgrepo/Vagrantfile
+++ b/infra/pkgrepo/Vagrantfile
@@ -1,0 +1,63 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+################################################################################
+# Copyright 2020 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+require 'fileutils'
+
+# Vagrantfile API/syntax version. Don't touch unless you know what you're doing!
+VAGRANTFILE_API_VERSION = "2"
+Vagrant.require_version ">=1.9.1"
+
+Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
+
+  config.vm.define :aptly, primary: true do |aptly|
+    # Get our prepackaged box from the atlas cloud, based on
+    # - debian/contrib-jessie64
+    # - linux kernel from debian jessie backports
+    # - updated vbguest-tool
+    aptly.vm.box = "ubuntu/xenial64"
+    aptly.vm.box_version = "= 20191108.0.0"
+    aptly.vm.hostname = "aptly-dev"
+    # Create a private network, which allows host-only access to the machine
+    # using a specific IP.
+    aptly.vm.network "private_network", ip: "192.168.60.194", nic_type: "82540EM"
+
+    cache_dir = File.expand_path('~/.magma/ubuntu_snapshots')
+    FileUtils.mkdir_p(cache_dir) unless Dir.exists?(cache_dir)
+
+    aptly.vm.synced_folder ".", "/vagrant", disabled: true
+    aptly.vm.synced_folder cache_dir, "/cache"
+
+    aptly.vm.provider "virtualbox" do |vb|
+      vb.name = "aptly-dev"
+      vb.linked_clone = true
+      vb.customize ["modifyvm", :id, "--memory", "4096"]
+      vb.customize ["modifyvm", :id, "--cpus", "4"]
+      vb.customize ["modifyvm", :id, "--nicpromisc2", "allow-all"]
+    end
+
+    aptly.vm.provision "shell",
+                       inline: "apt update; apt install -y python python3"
+
+    ENV["ANSIBLE_CONFIG"] = "deploy/ansible.cfg"
+    aptly.vm.provision "ansible" do |ansible|
+      ansible.host_key_checking = false
+      ansible.playbook = "deploy/magma_aptly_vagrant.yml"
+      ansible.inventory_path = "deploy/vagrant-hosts"
+      ansible.raw_arguments = ENV.fetch("ANSIBLE_ARGS", "").split(";") +
+                              ["--timeout=30"]
+      ansible.verbose = 'v'
+    end
+  end
+end

--- a/infra/pkgrepo/deploy/ansible.cfg
+++ b/infra/pkgrepo/deploy/ansible.cfg
@@ -1,0 +1,19 @@
+################################################################################
+# Copyright (c) 2016-present, Facebook, Inc.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree. An additional grant
+# of patent rights can be found in the PATENTS file in the same directory.
+################################################################################
+
+[defaults]
+# In gather_facts when ansible-playbook starts, innore hardware facts,
+# facts from facter and ohai, so gather_facts finish faster
+# See https://raw.githubusercontent.com/ansible/ansible/devel/examples/ansible.cfg
+gather_subset = !hardware,!facter,!ohai
+callback_whitelist = profile_tasks
+roles_path = ../../../orc8r/tools/ansible/roles
+
+[connection]
+pipelining=True

--- a/infra/pkgrepo/deploy/magma_aptly_vagrant.yml
+++ b/infra/pkgrepo/deploy/magma_aptly_vagrant.yml
@@ -52,5 +52,3 @@
     - role: aptly-fix-unix-socket-perms
       vars:
         - socket_path: /home/vagrant/docker/run/aptly/aptly.sock
-
-    - role: aptly-magma-base-dependencies

--- a/infra/pkgrepo/deploy/magma_aptly_vagrant.yml
+++ b/infra/pkgrepo/deploy/magma_aptly_vagrant.yml
@@ -1,0 +1,56 @@
+---
+################################################################################
+# Copyright 2020 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+- name: Set up the Magma Package Server
+  hosts: aptly
+  become: yes
+
+  roles:
+    - role: test-ssl-key
+      vars:
+        - keypath: /etc/ssl/private/aptly.key
+        - crtpath: /etc/ssl/private/aptly.crt
+        - use_rngd: yes
+
+    - role: aptly-files
+      vars:
+        - user: vagrant
+        - aptly_user: aptly-user
+        - aptly_user_id: 12345
+        - group: aptly
+        - gid: 34567
+        - docker_path: /home/vagrant/
+
+    - role: docker
+      vars:
+        - compose_file: ../docker/docker-compose.yml
+        - image_names: ["aptly-nginx", "aptly"]
+        - systemd_extra: |
+            Environment=APTLY_NGINX_HTTP_PORT=80
+            Environment=APTLY_NGINX_HTTPS_PORT=443
+            Environment=APTLY_NGINX_CRT=/etc/ssl/private/aptly.crt
+            Environment=APTLY_NGINX_KEY=/etc/ssl/private/aptly.key
+        - systemd_service: aptly
+        - systemd_stdout: journal
+        - systemd_stop_args: ""
+        - systemd_start_args_pre: -f docker-compose.yml -f docker-compose-prod.yml
+        - working_dir: /home/vagrant/docker/
+
+    - role: aptly-gpg-test-key
+
+    - role: aptly-fix-unix-socket-perms
+      vars:
+        - socket_path: /home/vagrant/docker/run/aptly/aptly.sock
+
+    - role: aptly-magma-base-dependencies

--- a/infra/pkgrepo/deploy/roles/aptly-files/files/template_aptly.conf
+++ b/infra/pkgrepo/deploy/roles/aptly-files/files/template_aptly.conf
@@ -1,0 +1,18 @@
+{
+  "rootDir": "ROOT",
+  "downloadConcurrency": 4,
+  "downloadSpeedLimit": 0,
+  "architectures": ["amd64"],
+  "dependencyFollowSuggests": false,
+  "dependencyFollowRecommends": false,
+  "dependencyFollowAllVariants": false,
+  "dependencyFollowSource": false,
+  "dependencyVerboseResolve": false,
+  "gpgDisableSign": false,
+  "gpgDisableVerify": false,
+  "gpgProvider": "gpg",
+  "downloadSourcePackages": false,
+  "skipLegacyPool": true,
+  "ppaDistributorID": "ubuntu",
+  "ppaCodename": ""
+}

--- a/infra/pkgrepo/deploy/roles/aptly-files/tasks/main.yml
+++ b/infra/pkgrepo/deploy/roles/aptly-files/tasks/main.yml
@@ -1,0 +1,55 @@
+---
+################################################################################
+# Copyright 2020 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+- name: Install dependencies
+  apt:
+    package: ['python3-pip', 'jq', 'python3-requests-unixsocket']
+    state: present
+    update_cache: yes
+
+- name: Install other dependencies with pip3
+  pip:
+    name: ["awscli", "verlib"]
+    executable: /usr/bin/pip3
+
+- name: Copy container definitions, configs, and docker-compose.yml
+  copy:
+    src: "{{ role_path }}/../../../docker"
+    dest: "{{ docker_path }}"
+    owner: "{{ user }}"
+
+- name: Ensure {{ group }} group is present
+  group:
+    name: "{{ group }}"
+    state: present
+    gid: "{{ gid }}"
+
+- name: Create a host account for docker user {{ aptly_user }}
+  user:
+    name: "{{ aptly_user }}"
+    shell: /sbin/nologin
+    create_home: no
+    uid: "{{ aptly_user_id }}"
+    group: "{{ group }}"
+    groups: ''
+    password: '!'
+    
+- name: Add {{ user }} to {{ group }} group
+  command: gpasswd -a {{ user | quote }} {{ group | quote }}
+
+- name: Ensure write permissions for aptly group (uid=34567) to create unix socket
+  command: setfacl -m g:aptly:rwx {{ docker_path | quote }}/docker/run/aptly
+
+- name: Copy alternate aptly config for snapshots
+  copy: src="template_aptly.conf" dest="/home/{{ user }}/template_aptly.conf"

--- a/infra/pkgrepo/deploy/roles/aptly-fix-unix-socket-perms/tasks/main.yml
+++ b/infra/pkgrepo/deploy/roles/aptly-fix-unix-socket-perms/tasks/main.yml
@@ -1,0 +1,20 @@
+---
+################################################################################
+# Copyright 2020 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+# must run after docker role -- real fix may be available in aptly 1.4
+- name: Set permissions on {{ socket_path }} for group write access
+  file:
+    path: "{{ socket_path }}"
+    mode: u+rw,g+rw,o-rwx
+    group: aptly

--- a/infra/pkgrepo/deploy/roles/aptly-gpg-test-key/tasks/main.yml
+++ b/infra/pkgrepo/deploy/roles/aptly-gpg-test-key/tasks/main.yml
@@ -1,0 +1,52 @@
+---
+################################################################################
+# Copyright 2020 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+- name: Wait a few seconds for docker services to start
+  command: sleep 10
+
+- name: Ensure rngd tool for extra entropy generation is present
+  apt: pkg=rng-tools state=present
+
+- name: Start rngd
+  command: rngd -r /dev/urandom
+  become: yes
+
+- name: Check for existing gpg keyring
+  command: docker-compose exec -T aptly gpg1 --list-secret-keys
+  args:
+    chdir: docker
+  register: secret_key_output
+  
+- name: Create gpg test key
+  command: docker-compose exec -T aptly gpg1 --gen-key --yes --batch insecurekeygen.txt
+  args:
+    chdir: docker
+  when: not secret_key_output.stdout is search("\nsec ")
+
+- name: Create /aptly/public
+  command: docker-compose exec -T aptly mkdir -p /aptly/public
+  args:
+    chdir: docker
+  when: not secret_key_output.stdout is search("\nsec ")
+    
+- name: Export new secret key to /aptly/public/key.gpg
+  command: docker-compose exec -T aptly gpg1 --export --armor --output /aptly/public/key.gpg 'insecure test key'
+  args:
+    chdir: docker
+  when: not secret_key_output.stdout is search("\nsec ")
+
+- name: Stop rngd
+  ignore_errors: yes
+  command: killall -q rngd
+  become: yes

--- a/infra/pkgrepo/deploy/roles/aptly-magma-base-dependencies/defaults/main.yml
+++ b/infra/pkgrepo/deploy/roles/aptly-magma-base-dependencies/defaults/main.yml
@@ -1,0 +1,16 @@
+---
+################################################################################
+# Copyright 2020 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+upstream_repo_url: http://packages.magma.etagecom.io
+pubkey_checksum: sha256:67b28492fe47050a12e2d61bfe1c1a690e75b6d70548452d75b3622682abad9d

--- a/infra/pkgrepo/deploy/roles/aptly-magma-base-dependencies/tasks/main.yml
+++ b/infra/pkgrepo/deploy/roles/aptly-magma-base-dependencies/tasks/main.yml
@@ -1,0 +1,75 @@
+---
+################################################################################
+# Copyright 2020 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+- name: Initialize base dependencies
+  become: yes
+  block:
+    - name: Make sure {{ ansible_user }} is in docker group
+      user:
+        name: "{{ ansible_user }}"
+        groups:
+          - docker
+
+    - name: Download pubkey.gpg from upstream
+      get_url:
+        url: "{{ upstream_repo_url }}/pubkey.gpg"
+        checksum: "{{ pubkey_checksum }}"
+        dest: ~/upstream-pubkey.gpg
+
+    - name: Register aptly container id
+      command: docker-compose ps -q aptly
+      args:
+        chdir: docker
+      register: aptly_instance_id
+
+    - name: Copy upstream-pubkey.gpg into aptly container
+      command: docker cp ~/upstream-pubkey.gpg {{ aptly_instance_id.stdout | quote }}:/home/aptly-user/upstream-pubkey.gpg
+
+    - name: Fix permissions
+      command: docker-compose exec -T -u root aptly chown aptly-user /home/aptly-user/upstream-pubkey.gpg
+      args:
+        chdir: docker
+
+    - name: Import upstream key to gpg1 keyring
+      command: docker-compose exec -T aptly gpg1 --no-default-keyring --keyring trustedkeys.gpg --import upstream-pubkey.gpg
+      args:
+        chdir: docker
+
+    - name: Create mirror of {{ upstream_repo_url }} for base-dependencies
+      ignore_errors: True
+      command: docker-compose exec -T aptly aptly mirror create upstream-base-dependencies http://packages.magma.etagecom.io base-dependencies
+      args:
+        chdir: docker
+
+    - name: Download contents of {{ upstream_repo_url }} for base-dependencies
+      command: docker-compose exec -T aptly aptly mirror update upstream-base-dependencies
+      args:
+        chdir: docker
+
+    - name: Create repo stretch-test
+      ignore_errors: True
+      command: docker-compose exec -T aptly aptly repo create stretch-test
+      args:
+        chdir: docker
+
+    - name: Clean stale packages
+      ignore_errors: True
+      command: docker-compose exec -T aptly aptly db cleanup
+      args:
+        chdir: docker
+
+    - name: Import downloaded packages into stretch-test
+      command: docker-compose exec -T aptly aptly repo import -with-deps -architectures=amd64 upstream-base-dependencies stretch-test 'Name (% *)'
+      args:
+        chdir: docker

--- a/infra/pkgrepo/deploy/roles/test-ssl-key/tasks/main.yml
+++ b/infra/pkgrepo/deploy/roles/test-ssl-key/tasks/main.yml
@@ -1,0 +1,38 @@
+---
+################################################################################
+# Copyright 2020 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+- name: Ensure rngd installed (saves lots of time waiting for random numbers)
+  apt: pkg=rng-tools state=present update_cache=yes
+  when: use_rngd
+
+- name: Start rngd
+  command: rngd -r /dev/urandom
+  become: yes
+  when: use_rngd
+
+- name: Create openssl keys
+  command: >
+    openssl req -newkey rsa:2048 -nodes -x509 -days 3650
+    -keyout {{ keypath | quote }}
+    -out {{ crtpath | quote }}
+    -subj "/C=US/ST=Calfiornia/L=Menlo Park/O=Test Organization/OU=TEST/CN=testssl.localdomain"
+  become: yes
+  args:
+    creates: "{{ keypath }}"
+
+- name: Stop rngd
+  ignore_errors: yes
+  command: killall rngd
+  become: yes
+  when: use_rngd

--- a/infra/pkgrepo/deploy/vagrant-hosts
+++ b/infra/pkgrepo/deploy/vagrant-hosts
@@ -1,0 +1,15 @@
+################################################################################
+# Copyright 2020 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+[aptly]
+aptly_server ansible_host=192.168.60.194 ansible_user=ubuntu ansible_port=22

--- a/infra/pkgrepo/docker/README.md
+++ b/infra/pkgrepo/docker/README.md
@@ -1,0 +1,89 @@
+<!--
+Copyright 2020 The Magma Authors.
+
+This source code is licensed under the BSD-style license found in the
+LICENSE file in the root directory of this source tree.
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+# Requirements:
+* docker
+* docker-compose
+* web browser (nginx container currently serves at http://localhost:8880/ )
+* some .deb files to serve
+
+# Download Images and Run
+From the same directory as this file:
+```
+docker login facebookconnectivity-orc8r-docker.jfrog.io
+
+docker-compose pull
+docker-compose up
+```
+
+# Build and Run
+From the same directory as this file:
+```
+docker-compose up --build
+```
+
+# Access
+available users
+root
+aptly-user
+```
+docker-compose exec aptly bash --login
+docker-compose exec -u root aptly bash --login
+```
+
+# Keys
+in order to publish an aptly repository, aptly-user needs a gpg1 key -- see aptly/insecurekeygen.txt
+or ~aptly-user/insecurekeygen.txt for sample instructions
+
+
+# Usage
+first upload some .deb files
+```
+docker-compose exec aptly mkdir /home/aptly-user/upload
+docker cp ~/fbsource/fbcode/magma/.cache/apt/xenial "$(docker-compose ps -q aptly)":/home/aptly-user/upload
+docker-compose exec -u root aptly chown -R aptly-user:aptly-user /home/aptly-user/upload
+```
+
+create a repository
+```
+docker-compose exec aptly aptly repo create -architectures=amd64 example1
+```
+
+add some packages
+```
+docker-compose exec aptly aptly repo add example1 upload/xenial
+```
+
+create a snapshot
+```
+export SNAPSHOT_DATE=$(date +%Y%m%d%H%M%S)
+docker-compose exec aptly aptly snapshot create snap_${SNAPSHOT_DATE} from repo example1
+```
+
+publish snapshot by name (see aptly publish switch)
+```
+docker-compose exec aptly aptly publish snapshot -distribution=exampledistro snap_${SNAPSHOT_DATE}
+```
+
+publish snapshot with timestamp
+```
+docker-compose exec aptly aptly publish snapshot -distribution=snap_${SNAPSHOT_DATE} snap_${SNAPSHOT_DATE}
+```
+
+
+If everything works right, you should have a valid debian repository at http://localhost:8880/
+
+
+
+Further Reading
+https://www.aptly.info/doc/

--- a/infra/pkgrepo/docker/aptly/Dockerfile
+++ b/infra/pkgrepo/docker/aptly/Dockerfile
@@ -1,0 +1,51 @@
+################################################################################
+# Copyright 2020 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+FROM ubuntu:bionic
+
+RUN apt-get update && \
+    apt-get install -y gnupg && \
+    apt-get clean
+
+RUN echo "deb http://repo.aptly.info/ squeeze main" > /etc/apt/sources.list.d/aptly.list && \
+    apt-key adv --keyserver keys.gnupg.net --recv-keys ED75B5A4483DA07C && \
+    apt-get update && \
+    apt-get install aptly ca-certificates -y && \
+    apt-get clean
+
+ADD aptly.conf /etc/aptly.conf
+
+# required for aptly
+RUN apt-get install -y gnupg1 gpgv1
+
+
+# add additional required software
+RUN apt-get install -y sudo python less 2>&1 | tail
+
+# create a normal user to manage repository
+RUN groupadd -g 12345 aptly-user
+RUN useradd -m -o -u 12345 -g 12345 -s /bin/bash aptly-user
+RUN groupadd -g 34567 aptly
+RUN gpasswd -a aptly-user aptly
+
+
+RUN mkdir /aptly
+RUN chown aptly-user:aptly-user /aptly
+
+ADD insecurekeygen.txt /home/aptly-user/
+
+RUN mkdir -p /var/run/aptly
+RUN chown aptly-user:aptly /var/run/aptly
+
+USER aptly-user
+WORKDIR /home/aptly-user

--- a/infra/pkgrepo/docker/aptly/aptly.conf
+++ b/infra/pkgrepo/docker/aptly/aptly.conf
@@ -1,0 +1,16 @@
+{
+  "rootDir": "/aptly",
+  "downloadConcurrency": 4,
+  "downloadSpeedLimit": 0,
+  "architectures": [],
+  "dependencyFollowSuggests": false,
+  "dependencyFollowRecommends": false,
+  "dependencyFollowAllVariants": false,
+  "dependencyFollowSource": false,
+  "gpgDisableSign": false,
+  "gpgDisableVerify": false,
+  "downloadSourcePackages": false,
+  "ppaDistributorID": "ubuntu",
+  "ppaCodename": "",
+  "S3PublishEndpoints": {}
+}

--- a/infra/pkgrepo/docker/aptly/insecurekeygen.txt
+++ b/infra/pkgrepo/docker/aptly/insecurekeygen.txt
@@ -1,0 +1,34 @@
+################################################################################
+# Copyright 2020 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+# run similar to gpg1 --gen-key --yes --batch insecurekeygen.txt
+%echo ======================================================================
+%echo ======================================================================
+%echo generate a no-passphrase key FOR TESTING ONLY
+%echo please create keys for production in accordance with relevant policies
+%echo ======================================================================
+%echo ======================================================================
+
+
+Key-Type: DSA
+Key-Length: 2048
+
+
+
+Name-Real: insecure test key
+Name-Comment: test package signing key
+Name-Email: noreply@example.com
+
+
+%commit
+%echo done

--- a/infra/pkgrepo/docker/docker-compose-prod.yml
+++ b/infra/pkgrepo/docker/docker-compose-prod.yml
@@ -1,0 +1,25 @@
+################################################################################
+# Copyright 2020 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+version: '3.7'
+
+services:
+  aptly:
+    command: aptly api serve -no-lock -listen=unix:///var/run/aptly/aptly.sock
+    stdin_open: false
+    tty: false
+
+  nginx:
+    volumes:
+      - ${APTLY_NGINX_CRT:-./aptly.crt}:/etc/nginx/ssl/aptly.crt
+      - ${APTLY_NGINX_KEY:-./aptly.key}:/etc/nginx/ssl/aptly.key

--- a/infra/pkgrepo/docker/docker-compose.yml
+++ b/infra/pkgrepo/docker/docker-compose.yml
@@ -1,0 +1,81 @@
+################################################################################
+# Copyright 2020 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+version: '3.7'
+
+services:
+  aptly:
+    user: aptly-user
+    build: aptly
+    image: facebookconnectivity-orc8r-docker.jfrog.io/aptly:${APTLY_TAG:-latest}
+    restart: always
+    stdin_open: true
+    tty: true
+    environment:
+      - TERM=xterm-256color
+    volumes:
+      - type: volume
+        source: aptlystorage
+        target: /aptly
+        volume:
+          # copy permissions from empty volume on init
+          nocopy: false
+      - type: volume
+        source: aptlyhome
+        target: /home
+        volume:
+          # copy new user aptly-user's home directory on init
+          nocopy: false
+      - ./run/aptly:/var/run/aptly
+
+  nginx:
+    build: nginx
+    image: facebookconnectivity-orc8r-docker.jfrog.io/aptly-nginx:${APTLY_TAG:-latest}
+    restart: always
+    expose:
+      # allow local containers to access without https
+      - "${APTLY_NGINX_HTTP_INTERNAL_PORT:-8080}"
+    ports:
+      # port 80 will probably be removed after ssl cert config
+      - "${APTLY_NGINX_HTTP_PORT:-8880}:80"
+      - "${APTLY_NGINX_HTTPS_PORT:-8443}:443"
+    logging:
+      # nginx is configured to log to /var/log/nginx/access.log which is a symlink
+      # to /dev/stdout -- new configuration for logging should probably keep that convention
+      # access.log -> /dev/stdout and error.log -> /dev/stderr
+      # include this just in case something in container does use syslog or similar
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "10"
+    volumes:
+      # the data to serve
+      - type: volume
+        source: aptlystorage
+        # minimize changes from default config for now
+        target: /usr/share/nginx/html
+        read_only: true
+        volume:
+          nocopy: true
+
+      # webserver config
+      - ./nginx/conf.d:/etc/nginx/conf.d
+
+volumes:
+  # cross-mounted between aptly and nginx to serve repositories
+  # deleting this volume will lose all pkgrepo contents and history; use caution when choosing to delete
+  aptlystorage:
+
+  # this volume should usually not be deleted -- it will contain encryption keys
+  aptlyhome:
+

--- a/infra/pkgrepo/docker/nginx/Dockerfile
+++ b/infra/pkgrepo/docker/nginx/Dockerfile
@@ -1,0 +1,30 @@
+################################################################################
+# Copyright 2020 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+FROM nginx
+
+# install openssl to generate default key
+RUN apt update && apt install openssl
+
+# prepare a place for nginx ssl keys
+RUN mkdir -p /etc/nginx/ssl
+RUN chown root:nginx /etc/nginx/ssl
+RUN chmod g+rx /etc/nginx/ssl
+RUN chmod g-w /etc/nginx/ssl
+RUN chmod o-rwx /etc/nginx/ssl
+
+# create a default ssl key for localhost
+RUN openssl req -newkey rsa:2048 -nodes -x509 -days 3650 \
+    -keyout /etc/nginx/ssl/aptly.key \
+    -out /etc/nginx/ssl/aptly.crt \
+    -subj "/C=US/ST=California/L=Menlo Park/O=Test Organization/OU=TEST/CN=localhost"

--- a/infra/pkgrepo/docker/nginx/conf.d/default.conf
+++ b/infra/pkgrepo/docker/nginx/conf.d/default.conf
@@ -1,0 +1,7 @@
+server {
+    # this will not work unless docker maps 443:443
+    # -- connect directly to configured https port otherwise (default 8443)
+    listen       80 default_server;
+    server_name  _;
+    return       301 https://$host$request_uri;
+}

--- a/infra/pkgrepo/docker/nginx/conf.d/internal.conf
+++ b/infra/pkgrepo/docker/nginx/conf.d/internal.conf
@@ -1,0 +1,28 @@
+################################################################################
+# Copyright 2020 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+server {
+    listen       8080;
+    server_name  $hostname;
+
+    location / {
+        root   /usr/share/nginx/html/public;
+        autoindex on;
+    }
+    # redirect server error pages to the static page /50x.html
+    #
+    error_page   500 502 503 504  /50x.html;
+    location = /50x.html {
+        root   /usr/share/nginx/html;
+    }
+}

--- a/infra/pkgrepo/docker/nginx/conf.d/ssl.conf
+++ b/infra/pkgrepo/docker/nginx/conf.d/ssl.conf
@@ -1,0 +1,19 @@
+server {
+    listen       443 ssl;
+    server_name  $hostname;
+
+    ssl_certificate      /etc/nginx/ssl/aptly.crt;
+    ssl_certificate_key  /etc/nginx/ssl/aptly.key;
+    
+
+    location / {
+        root   /usr/share/nginx/html/public;
+        autoindex on;
+    }
+    # redirect server error pages to the static page /50x.html
+    #
+    error_page   500 502 503 504  /50x.html;
+    location = /50x.html {
+        root   /usr/share/nginx/html;
+    }
+}

--- a/infra/pkgrepo/docker/run/aptly/README.md
+++ b/infra/pkgrepo/docker/run/aptly/README.md
@@ -1,0 +1,14 @@
+<!--
+Copyright 2020 The Magma Authors.
+
+This source code is licensed under the BSD-style license found in the
+LICENSE file in the root directory of this source tree.
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+this directory will be bind-mounted in aptly:/var/run/aptly

--- a/infra/pkgrepo/fabfile.py
+++ b/infra/pkgrepo/fabfile.py
@@ -1,0 +1,481 @@
+"""
+Copyright 2020 The Magma Authors.
+
+This source code is licensed under the BSD-style license found in the
+LICENSE file in the root directory of this source tree.
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import fnmatch
+import getpass
+import json
+import os
+import re
+import sys
+import time
+from contextlib import contextmanager
+from distutils.version import LooseVersion
+from enum import Enum
+
+import requests
+from fabric.api import cd, env, execute, hide, hosts, lcd, local, run, settings
+from fabric.operations import get, prompt, put
+from github import GithubException
+
+if not env.get('magma_root'):
+    env.magma_root = os.environ.get('MAGMA_ROOT', '../..')
+env.magma_root = os.path.abspath(os.path.expanduser(env.magma_root))
+
+sys.path.append(env.magma_root + '/orc8r')
+from tools.fab.vagrant import setup_env_vagrant
+
+env.pkgfmt = "deb"
+
+# Look for keys as specified in our ~/.ssh/config
+env.use_ssh_config = True
+
+
+class DeployTarget(Enum):
+    STABLE = 1
+    BETA = 2
+    DEV = 3
+    TEST = 4
+
+
+def _setup_env(target, channel):
+    # If a host list isn't specified, default to the magma vagrant vm
+    if not env.hosts:
+        with lcd(env.magma_root + '/lte/gateway'):
+            setup_env_vagrant()
+
+    env.deploy_target = target
+    env._release_channel = channel
+
+
+def dev():
+    """ [deploy] dev deploy settings """
+    _setup_env(DeployTarget.DEV, "stretch-dev")
+
+
+def beta():
+    """ [deploy] beta deploy settings """
+    _setup_env(DeployTarget.BETA, "stretch-beta")
+
+
+def test():
+    """ [deploy] Test deploy settings """
+    _setup_env(DeployTarget.TEST, "stretch-test")
+
+
+def stable():
+    _setup_env(DeployTarget.STABLE, "stretch-stable")
+
+
+def shipit():
+    """Takes packages on a local dev VM and pushes them to repo."""
+
+    if env.pkgfmt != "deb":
+        # Since we don't support pushing packages to non-deb repos, just fail
+        # early. This can be removed when _push_packages_to_repo has CentOS
+        # support.
+        print("Only shipping deb packages is supported, not shipping.")
+        return
+
+    with hide('running', 'warnings', 'output'), settings(warn_only=True):
+        execute(_get_packages)
+
+        pkgs = local("ls -lrth /tmp/magma-packages-deploy/*.deb", capture=True)
+        magma_pkgs = local("ls /tmp/magma-packages-deploy | grep '^magma-[0-9].*.deb'",
+                           capture=True).split()
+        if len(pkgs.strip()) == 0:
+            print("No packages to release!")
+            execute(cleanup_package_deploy)
+            exit(0)
+
+    with hide('running', 'warnings', 'output'), settings(warn_only=True):
+        release = env._release_channel
+        if release not in ['stretch-test', 'stretch-dev', 'stretch-beta',
+                           'stretch-stable']:
+            release = prompt('Specify release branch',
+                             validate='^(stretch-test|stretch-dev|stretch-beta'
+                             + '|stretch-stable)$')
+        print("Releasing to '%s'." % release)
+
+        env.release_success = False
+
+    with apply_custom_env_options() as opts:
+        execute(push_packages_to_repo, release, **opts)
+    execute(cleanup_package_deploy)
+
+
+def _get_packages():
+    """Get all the packages from a remote machine and put them in a local temp
+    deploy directory.
+
+    We check if the package we're getting has a version less than or equal to
+    what's already in the remote VM's apt cache; if so, we print a warning and
+    we don't pull the package in.
+    """
+    local('mkdir -p /tmp/magma-packages-deploy')
+    result = run('ls ~/magma-packages/*.%s' % env.pkgfmt)
+    if result.return_code != 0:
+        local('ls /tmp/magma-packages-deploy')
+        return
+
+    pkgs = result.stdout.split()
+
+    for p in pkgs:
+        with hide('running', 'warnings', 'output'), settings(warn_only=True):
+            put(local_path='scripts/pkgavail',
+                remote_path='/tmp/')
+            run('chmod a+x /tmp/pkgavail')
+            is_avail = run("/tmp/pkgavail --release %s %s" %
+                           (env._release_channel, p)).strip()
+            if is_avail == "False":
+                get(remote_path='%s' % p,
+                    local_path='/tmp/magma-packages-deploy/')
+            else:
+                print(("WARNING: %s is not a newer version than what is "
+                       "available already in release branch '%s', ignoring." %
+                       (p, env._release_channel)))
+    local('ls /tmp/magma-packages-deploy')
+
+
+@contextmanager
+def apply_custom_env_options(**kwargs):
+    extra_args = {}
+    extra_settings = {}
+    extra_settings.update(kwargs)
+    pkgrepo_env = setup_env_vagrant(machine=env.get('local_pkgrepo')
+                                    or extra_settings.get('local_pkgrepo', 'aptly'),
+                                    apply_to_env=False)
+    extra_args["hosts"] = pkgrepo_env["hosts"]
+    extra_settings["hosts"] = pkgrepo_env["hosts"]
+    extra_settings["key_filename"] = pkgrepo_env["key_filename"]
+    extra_settings["host_string"] = pkgrepo_env["host_string"]
+    
+    with settings(**extra_settings):
+        yield extra_args
+
+
+def promote(src, dest, version):
+    """
+    Copy a magma package and its dependencies from one channel to another
+
+    src: The channel to promote from
+    dest: The channel to promote to
+    version: The version of magma to promote. It should look something like
+             0.3.31-1508456917-bdbaa7c2
+    """
+
+    REPO_PREFIX = 'stretch'
+    if (src == 'test' and dest != 'beta') \
+       or (src == 'beta' and dest != 'stable') \
+       or (src != 'test' and src != 'beta'):
+        print("Supported promotions are:\n\n"
+              "\tfab promote:test,beta,VERSION\n"
+              "\tfab promote:beta,stable,VERSION\n")
+        return
+
+    # FIXME: don't use aws here                                       
+
+    # Grab the list of dependencies from the aws bucket
+    os.environ['AWS_PROFILE'] = 'fbinfra'
+    local('aws s3 cp s3://magma-images/gateway/%s.deplist'
+          ' /tmp/deplist' % version)
+    pkgs = local('cat /tmp/deplist | awk \'{print $3}\'', capture=True)
+    pkgs = pkgs.split()
+
+    print("Promoting magma version `%s` from '%s' to '%s'"
+          % (version, src, dest))
+
+    env.release_success = False
+    try:
+        repo_src = "%s-%s" % (REPO_PREFIX, src)
+        repo_dest = "%s-%s" % (REPO_PREFIX, dest)
+        with apply_custom_env_options():
+            promote_pkgs(repo_src, repo_dest, pkgs)
+        env.release_success = True
+    finally:
+        pass
+    return
+
+
+def fab_cmd(prefix):
+    return lambda cmd, **kwargs: run(prefix + ' ' + cmd, **kwargs)
+
+
+run_aptly = fab_cmd('docker-compose exec aptly aptly ')
+rsudo = fab_cmd('sudo')
+
+
+def push_packages_to_repo(release_channel):
+    """Push local deploy directory of packages to actual repo, and refresh the
+    repo.
+    """
+
+    if env.pkgfmt != "deb":
+        # We only support freight, which is only for deb packages. We'd need to
+        # add something that understands RPM repos as well if we want to add
+        # support for CentOS here.
+        print("Only pushing deb packages is supported, not pushing.")
+        return
+
+    magma_filename = local("ls /tmp/magma-packages-deploy/magma_*.deb",
+                           capture=True).split("/")[-1]
+
+    # quick check that version is in the right format
+    # -- [version]-[timestamp]-[hashprefix]
+    version, ts, hashprefix = magma_filename[6:-4].split("-")
+
+    build_id = "-".join([version, ts, hashprefix])
+
+    run("rm -rf /tmp/magma-packages-deploy")
+    run('mkdir -p /tmp/magma-packages-deploy')
+    put(local_path='/tmp/magma-packages-deploy/*.deb',
+        remote_path='/tmp/magma-packages-deploy/')
+
+    with cd("~/docker"):
+        run_aptly("repo create " + release_channel, quiet=True)
+        run("docker-compose exec aptly mkdir -p upload/" + build_id,
+            quiet=True)
+
+        aptly_image_ps = run("docker-compose ps -q aptly")
+
+        destdir = "/home/aptly-user/upload/" + build_id
+        run("docker cp /tmp/magma-packages-deploy/ "
+            + aptly_image_ps + ":" + destdir)
+
+        run("docker-compose exec -u root aptly chown -R aptly-user:aptly-user "
+            + destdir)
+
+        run_aptly("repo add -remove-files " + release_channel + " "
+                  + destdir + "/magma-packages-deploy/" + magma_filename)
+        run_aptly("repo add -remove-files " + release_channel + " "
+                  + destdir + "/magma-packages-deploy/", warn_only=True)
+
+        run("docker-compose exec aptly rm -r -- '" + destdir + "'")
+        run_aptly("publish -architectures=amd64 -distribution "
+                  + release_channel + " repo " + release_channel,
+                  warn_only=True)
+        run_aptly("publish update " + release_channel)
+
+    env.release_success = True
+
+
+def cleanup_package_deploy():
+    """Delete local temp deploy directory."""
+    local('rm -r /tmp/magma-packages-deploy')
+
+
+def promote_pkgs(src, dest, packages):
+    """
+    Copy a list of packages from one channel to another
+    """
+    packages = [package[:-4] if package.endswith(".deb") else package
+                for package in packages]
+    # magma package filename not consistent with .deb version format
+    # convert package name to package query for current version
+    # in similar form to 'magma (= 0.3.74-1560475061-fb43abf4)'
+    # to conform to the expected filename format,
+    # magma-0.3.74-1560475061-fb43abf4.deb
+    # should be
+    # magma_0.3.74-1560475061-fb43abf4_amd64.deb
+    packages = [re.sub("^magma-([0-9]+.*)", r"'magma (= \1)'", package)
+                for package in packages]
+
+    with cd("docker"):
+        pkg_list = " ".join(packages)
+        run_aptly("repo create {dest}".format(dest=dest), warn_only=True)
+        run_aptly("repo copy -with-deps -architectures=amd64 "
+                  "{src} {dest} {pkg_list}".format(src=src, dest=dest,
+                                                   pkg_list=pkg_list))
+        run_aptly("publish repo -architectures=amd64 "
+                  "-distribution={dest} {dest}".format(dest=dest),
+                  warn_only=True)
+        run_aptly("publish update " + dest)
+    return
+
+
+def _get_latest_version(version_list):
+    loose_versions = [LooseVersion(x) for x in version_list]
+    return str(max(loose_versions))
+
+
+def as_bool(v):
+    return str(v).lower() in ['true', 't', '1', 'y', 'yes']
+
+
+def get_repo_list(release):
+    upstream_repos = {
+        'bionic': [
+            'deb http://security.ubuntu.com/ubuntu bionic-security main restricted',
+            'deb http://security.ubuntu.com/ubuntu bionic-security multiverse',
+            'deb http://security.ubuntu.com/ubuntu bionic-security universe',
+            ('deb http://us.archive.ubuntu.com/ubuntu bionic-backports main '
+             'restricted universe multiverse'),
+            'deb http://us.archive.ubuntu.com/ubuntu bionic main restricted',
+            'deb http://us.archive.ubuntu.com/ubuntu bionic multiverse',
+            'deb http://us.archive.ubuntu.com/ubuntu bionic universe',
+            'deb http://us.archive.ubuntu.com/ubuntu bionic-updates main restricted/',
+            'deb http://us.archive.ubuntu.com/ubuntu bionic-updates multiverse',
+            'deb http://us.archive.ubuntu.com/ubuntu bionic-updates universe',
+        ],
+        'xenial': [
+            'deb http://security.ubuntu.com/ubuntu xenial-security main restricted',
+            'deb http://security.ubuntu.com/ubuntu xenial-security multiverse',
+            'deb http://security.ubuntu.com/ubuntu xenial-security universe',
+            ('deb http://us.archive.ubuntu.com/ubuntu/ xenial-backports main '
+             'restricted universe multiverse'),
+            'deb http://us.archive.ubuntu.com/ubuntu/ xenial main restricted',
+            'deb http://us.archive.ubuntu.com/ubuntu/ xenial multiverse',
+            'deb http://us.archive.ubuntu.com/ubuntu/ xenial universe',
+            'deb http://us.archive.ubuntu.com/ubuntu/ xenial-updates main restricted',
+            'deb http://us.archive.ubuntu.com/ubuntu/ xenial-updates multiverse',
+            'deb http://us.archive.ubuntu.com/ubuntu/ xenial-updates universe',
+        ]
+    }
+    return upstream_repos.get(release)
+
+
+def get_required_packages(release):
+    per_release = {}
+    required_packages = [
+        'autoconf',
+        'automake',
+        'build-essential',
+        'bzip2',
+        'bzr',
+        'curl',
+        'daemontools',
+        'debhelper',
+        'fakeroot',
+        'git',
+        'graphviz',
+        'libseccomp2',
+        'libssl-dev',
+        'libtool',
+        'netcat',
+        'openssl',
+        'python-all',
+        'python-cffi-backend',
+        'python-six',
+        'python-twisted-conch',
+        'python-zope.interface',
+        'python3-pip',
+        'supervisor',
+        'unzip',
+        'vim',
+        'wget',
+    ]
+
+    return required_packages + per_release.get(release, [])
+
+
+def make_ubuntu_snapshot(release, force_provision=False, clean=False,
+                         extra_packages=''):
+    extra_packages = extra_packages.split(',') if extra_packages else []
+    clean = as_bool(clean)
+    force_provision = as_bool(force_provision)
+
+    setup_env_vagrant(machine='aptly', force_provision=force_provision)
+    workdir = '/work/{}'.format(release)
+    cachedir = '/cache/{}/deb'.format(release)
+    localdir = os.path.expanduser('~/.magma/ubuntu_snapshots/{}'.format(release))
+    snap_time = time.time()
+    snap_name = time.strftime('{}_%Y%m%d%H%M%S'.format(release),
+                              time.gmtime(snap_time))
+
+    rsudo('mkdir -p {}'.format(workdir))
+    rsudo('apt update')
+    rsudo('apt install -y debootstrap')
+
+    if clean:
+        rsudo('find {} -name "*.deb" -delete'.format(cachedir))
+
+    rsudo('rm -rf {}'.format(workdir))
+    rsudo('mkdir -p {}'.format(workdir))
+
+    _prepare_ubuntu_snapshot(release, cachedir, workdir, extra_packages)
+    _create_ubuntu_archive(release, snap_name, workdir, localdir)
+
+
+def _prepare_ubuntu_snapshot(release, cachedir, workdir, extra_packages):
+    required_packages = get_required_packages(release)
+    with cd(workdir):
+        # sync from cache
+        rsudo('mkdir -p {}'.format(cachedir))
+        rsudo('mkdir -p {}/var/cache/apt/archives'.format(workdir))
+        rsudo('rsync -r {}/ {}/var/cache/apt/archives/'.format(cachedir, workdir))
+
+        rsudo(('debootstrap --arch amd64 --components=main,universe --download-only '
+               '--include=software-properties-common {} '
+               '{} http://archive.ubuntu.com/ubuntu/'
+               '').format(release, workdir))
+
+        # sync to cache
+        rsudo('rsync -r {}/var/cache/apt/archives/ {}/'.format(workdir, cachedir))
+
+        # install base system
+        rsudo(('debootstrap --arch amd64 --components=main,universe '
+               '--include=software-properties-common {} '
+               '{} http://archive.ubuntu.com/ubuntu/'
+               '').format(release, workdir))
+        for repo in get_repo_list(release):
+            rsudo('''chroot {} /bin/bash -c "add-apt-repository '{}'"'''.format(workdir,
+                                                                                repo))
+
+        rsudo('chroot /work/{} /bin/bash -c "apt update"'.format(release))
+
+        rsudo(('chroot /work/{} /bin/bash -c "apt install -y --download-only {}"'
+               '').format(release, ' '.join(extra_packages + required_packages)))
+
+        # sync to cache
+        rsudo('rsync -r {}/var/cache/apt/archives/ {}/'.format(workdir, cachedir))
+
+
+def _create_ubuntu_archive(release, snap_name, workdir, localdir):
+    with cd('~/docker'):
+        archivedir = '/tmp/' + snap_name
+        archivefile = snap_name + '.tar.gz'
+        uploaddir = archivedir + '/upload'
+        conf = archivedir + '/aptly.conf'
+        run_compose = fab_cmd('docker-compose exec aptly')
+        # not actually sudo, but has equivalent effect
+        rsudo_compose = fab_cmd('docker-compose exec -u root aptly')
+
+        try:
+            aptly_image_ps = run('docker-compose ps -q aptly')
+
+            run_compose('mkdir -p ' + archivedir, quiet=True)
+            run_compose('mkdir -p ' + uploaddir)
+
+            run('docker cp ~/template_aptly.conf '
+                + aptly_image_ps + ':' + conf)
+            rsudo_compose('chown aptly-user:aptly-user ' + conf)
+            run_compose('sed -i "s|ROOT|{}|g" {}'.format(archivedir, conf))
+            run('docker cp {}/var/cache/apt/archives/. {}:{}'.format(workdir,
+                                                                     aptly_image_ps,
+                                                                     uploaddir))
+
+            rsudo_compose('chown -R aptly-user:aptly-user ' + uploaddir)
+
+            run_aptly = fab_cmd('docker-compose exec aptly aptly -config=' + conf)
+            run_aptly('repo create ' + snap_name)
+            run_aptly('repo add {} {}'.format(snap_name, uploaddir))
+            run_aptly('publish -distribution {} repo {}'.format(release, snap_name))
+
+            run_compose('cp /aptly/public/key.gpg {}/public/'.format(archivedir))
+            run_compose('mv {}/public {}/{}'.format(archivedir, archivedir, snap_name))
+            run_compose('tar czf /tmp/{} -C {} {}'.format(archivefile, archivedir,
+                                                          snap_name))
+            run('docker cp {}:/tmp/{} /tmp/'.format(aptly_image_ps, archivefile))
+            get('/tmp/{}'.format(archivefile), '{}/%(path)s'.format(localdir))
+        finally:
+            rsudo_compose('rm -rf -- ' + archivedir)
+            rsudo('rm -f /tmp/{}'.format(archivefile))

--- a/infra/pkgrepo/scripts/pkgavail
+++ b/infra/pkgrepo/scripts/pkgavail
@@ -1,0 +1,63 @@
+#!/usr/bin/python3
+"""
+Copyright 2020 The Magma Authors.
+
+This source code is licensed under the BSD-style license found in the
+LICENSE file in the root directory of this source tree.
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+"""
+-- imported from old repo
+Pass in a path to a dpkg file. If there is a package version already available
+that's >= the dpkg file specified, print True, otherwise print False.
+"""
+
+import sys
+
+import apt
+import apt_pkg
+import argparse
+
+from debian import debfile
+
+# Default repo and release branch
+pkgrepo = "packages.magma.etagecom.io"
+release = "prod"
+
+# Cmdline options that overwrite the defaults above
+parser = argparse.ArgumentParser(description='Specify package repo'
+                                 'and release branch.')
+parser.add_argument('--repo', help='package repo URL')
+parser.add_argument('--release', help='release branch')
+parser.add_argument('package', help='package path')
+args = parser.parse_args()
+repo = args.repo
+release = args.release
+path = args.package
+
+deb = debfile.DebFile(path)
+name = deb.debcontrol()['Package']
+ver = deb.debcontrol()['Version']
+
+c = apt.Cache()
+if name in c:
+    # the package exists, check versions avail from repo
+    repo_versions = []
+    for v in c[name].versions:
+        for o in v.origins:
+            if o.site == pkgrepo and o.archive == release:
+                repo_versions.append(v)
+
+    if len(repo_versions) > 0:
+        max_ver = max(repo_versions).version
+        print(apt_pkg.version_compare(ver, max_ver) <= 0)
+        exit(0)
+
+# the package doesn't exist, return False
+print(False)

--- a/lte/gateway/deploy/agw_focal_install.sh
+++ b/lte/gateway/deploy/agw_focal_install.sh
@@ -35,6 +35,7 @@ fi
 
 echo "Making sure $MAGMA_USER user is sudoers"
 if ! grep -q "$MAGMA_USER ALL=(ALL) NOPASSWD:ALL" /etc/sudoers; then
+  apt update
   apt install -y sudo
   adduser $MAGMA_USER sudo
   echo "$MAGMA_USER ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers

--- a/lte/gateway/deploy/agw_focal_install.sh
+++ b/lte/gateway/deploy/agw_focal_install.sh
@@ -141,7 +141,7 @@ if [ "$PING_RESULT" != "$SUCCESS_MESSAGE" ]; then
   exit 1
 fi
 echo "Checking if magma has been installed"
-MAGMA_INSTALLED=$(apt-cache show magma >  /dev/null 2>&1 echo "$SUCCESS_MESSAGE")
+MAGMA_INSTALLED=$(apt-cache show magma >  /dev/null 2>&1 && echo "$SUCCESS_MESSAGE")
 if [ "$MAGMA_INSTALLED" != "$SUCCESS_MESSAGE" ]; then
   echo "Magma not installed, processing installation"
   apt-get update

--- a/lte/gateway/deploy/agw_focal_install.sh
+++ b/lte/gateway/deploy/agw_focal_install.sh
@@ -73,7 +73,7 @@ fi
 
 # configure environment variable defaults needed for ansible
 ANSIBLE_VARS="preburn=yes PACKAGE_LOCATION=/tmp"
-if [ -n "${REPO_HOST}" ]; then
+if [ -n "${REPO}" ]; then
     if [ -z "${REPO_PROTO}" ]; then
         REPO_PROTO=http
     fi
@@ -84,7 +84,7 @@ if [ -n "${REPO_HOST}" ]; then
         REPO_COMPONENT=main
     fi
     # configure pkgrepo location
-    ANSIBLE_VARS="ovs_pkgrepo_proto=${REPO_PROTO} ovs_pkgrepo_host=${REPO_HOST} ovs_pkgrepo_path=${REPO_PATH} ${ANSIBLE_VARS}"
+    ANSIBLE_VARS="ovs_pkgrepo_proto=${REPO_PROTO} ovs_pkgrepo=${REPO} ${ANSIBLE_VARS}"
 
     # configure pkgrepo distribution
     ANSIBLE_VARS="ovs_pkgrepo_dist=${REPO_DIST} ovs_pkgrepo_component=${REPO_COMPONENT} ${ANSIBLE_VARS}"
@@ -115,7 +115,7 @@ Wants=network-online.target
 Environment=MAGMA_VERSION=${MAGMA_VERSION}
 Environment=GIT_URL=${GIT_URL}
 Environment=REPO_PROTO=${REPO_PROTO}
-Environment=REPO_HOST=${REPO_HOST}
+Environment=REPO=${REPO}
 Environment=REPO_DIST=${REPO_DIST}
 Environment=REPO_COMPONENT=${REPO_COMPONENT}
 Environment=REPO_KEY=${REPO_KEY}

--- a/lte/gateway/deploy/agw_focal_install.sh
+++ b/lte/gateway/deploy/agw_focal_install.sh
@@ -2,7 +2,7 @@
 # Setting up env variable, user and project path
 MAGMA_USER="magma"
 AGW_INSTALL_SERVICE="/etc/systemd/system/multi-user.target.wants/agw_installation.service"
-AGW_INSTALL_CONFIG="/tmp/agw_installation.service"
+AGW_INSTALL_CONFIG="/lib/systemd/system/agw_installation.service"
 AGW_SCRIPT_PATH="/root/$(basename $0)"
 MAGMA_ROOT=/home/$MAGMA_USER/magma
 DEPLOY_PATH="${MAGMA_ROOT}/lte/gateway/deploy"
@@ -168,7 +168,7 @@ if [ "$MAGMA_INSTALLED" != "$SUCCESS_MESSAGE" ]; then
 
   echo "Deleting boot script if it exists"
   if [ -f "$AGW_INSTALL_CONFIG" ]; then
-    rm -rf $AGW_INSTALL_CONFIG
+    rm -rf $AGW_INSTALL_CONFIG "${AGW_INSTALL_SERVICE}"
   fi
   rm -rf /home/$MAGMA_USER/build
   echo "AGW installation is done, make sure all services above are running correctly.. rebooting"

--- a/lte/gateway/deploy/agw_focal_install.sh
+++ b/lte/gateway/deploy/agw_focal_install.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 # Setting up env variable, user and project path
 MAGMA_USER="magma"
-AGW_INSTALL_CONFIG="/etc/systemd/system/multi-user.target.wants/agw_installation.service"
+AGW_INSTALL_SERVICE="/etc/systemd/system/multi-user.target.wants/agw_installation.service"
+AGW_INSTALL_CONFIG="/tmp/agw_installation.service"
 AGW_SCRIPT_PATH="/root/$(basename $0)"
 MAGMA_ROOT=/home/$MAGMA_USER/magma
 DEPLOY_PATH="${MAGMA_ROOT}/lte/gateway/deploy"
@@ -128,6 +129,7 @@ Group=root
 WantedBy=multi-user.target
 EOF
   chmod 644 $AGW_INSTALL_CONFIG
+  ln -sf "${AGW_INSTALL_CONFIG}" "${AGW_INSTALL_SERVICE}"
   reboot
 fi
 

--- a/lte/gateway/deploy/agw_focal_install.sh
+++ b/lte/gateway/deploy/agw_focal_install.sh
@@ -3,7 +3,8 @@
 MAGMA_USER="magma"
 AGW_INSTALL_CONFIG="/etc/systemd/system/multi-user.target.wants/agw_installation.service"
 AGW_SCRIPT_PATH="/root/$(basename $0)"
-DEPLOY_PATH="/home/$MAGMA_USER/magma/lte/gateway/deploy"
+MAGMA_ROOT=/home/$MAGMA_USER/magma
+DEPLOY_PATH="${MAGMA_ROOT}/lte/gateway/deploy"
 SUCCESS_MESSAGE="ok"
 NEED_REBOOT=0
 WHOAMI=$(whoami)
@@ -69,7 +70,7 @@ else
 fi
 
 # configure environment variable defaults needed for ansible
-ANSIBLE_VARS="PACKAGE_LOCATION=/tmp"
+ANSIBLE_VARS="preburn=yes PACKAGE_LOCATION=/tmp"
 if [ -n "${REPO_HOST}" ]; then
     if [ -z "${REPO_PROTO}" ]; then
         REPO_PROTO=http

--- a/lte/gateway/deploy/agw_focal_install.sh
+++ b/lte/gateway/deploy/agw_focal_install.sh
@@ -12,6 +12,7 @@ WHOAMI=$(whoami)
 KVERS=$(uname -r)
 MAGMA_VERSION="${MAGMA_VERSION:-v1.3}"
 GIT_URL="${GIT_URL:-https://github.com/magma/magma.git}"
+INSTALL_TIMEOUT="${INSTALL_TIMEOUT:-3800}"
 
 REQUIRED_OS_DIST=Ubuntu
 REQUIRED_OS_RELEASE=20.04
@@ -122,8 +123,8 @@ Environment=REPO_KEY=${REPO_KEY}
 Environment=REPO_KEY_FINGERPRINT=${REPO_KEY_FINGERPRINT}
 Type=oneshot
 ExecStart=/bin/bash ${AGW_SCRIPT_PATH}
-TimeoutStartSec=3800
-TimeoutSec=3600
+TimeoutStartSec=${INSTALL_TIMEOUT}
+TimeoutSec=${INSTALL_TIMEOUT}
 User=root
 Group=root
 [Install]

--- a/lte/gateway/deploy/agw_focal_install.sh
+++ b/lte/gateway/deploy/agw_focal_install.sh
@@ -1,0 +1,174 @@
+#!/bin/bash
+# Setting up env variable, user and project path
+MAGMA_USER="magma"
+AGW_INSTALL_CONFIG="/etc/systemd/system/multi-user.target.wants/agw_installation.service"
+AGW_SCRIPT_PATH="/root/$(basename $0)"
+DEPLOY_PATH="/home/$MAGMA_USER/magma/lte/gateway/deploy"
+SUCCESS_MESSAGE="ok"
+NEED_REBOOT=0
+WHOAMI=$(whoami)
+KVERS=$(uname -r)
+MAGMA_VERSION="${MAGMA_VERSION:-v1.3}"
+GIT_URL="${GIT_URL:-https://github.com/magma/magma.git}"
+
+REQUIRED_OS_DIST=Ubuntu
+REQUIRED_OS_RELEASE=20.04
+
+echo "Checking if the script has been executed by root user"
+if [ "$WHOAMI" != "root" ]; then
+  echo "You're executing the script as $WHOAMI instead of root.. exiting"
+  exit 1
+fi
+
+echo "Checking if ${REQUIRED_OS_DIST} ${REQUIRED_OS_RELEASE} is installed"
+if ! grep -iq "${REQUIRED_OS_DIST}" /etc/os-release; then
+  echo "${REQUIRED_OS_DIST} is not installed"
+  exit 1
+fi
+if ! grep -iq "${REQUIRED_OS_RELEASE}" /etc/os-release; then
+  echo "${REQUIRED_OS_RELEASE} is not installed"
+  exit 1
+fi
+
+
+echo "Making sure $MAGMA_USER user is sudoers"
+if ! grep -q "$MAGMA_USER ALL=(ALL) NOPASSWD:ALL" /etc/sudoers; then
+  apt install -y sudo
+  adduser $MAGMA_USER sudo
+  echo "$MAGMA_USER ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers
+fi
+
+echo "Need to check if both interfaces are named eth0 and eth1"
+INTERFACES=$(ip -br a)
+if [[ ! $INTERFACES == *'eth0'*  ]] || [[ ! $INTERFACES == *'eth1'* ]] || ! grep -q 'GRUB_CMDLINE_LINUX="net.ifnames=0 biosdevname=0"' /etc/default/grub; then
+  # changing intefaces name
+  sed -i 's/GRUB_CMDLINE_LINUX=""/GRUB_CMDLINE_LINUX="net.ifnames=0 biosdevname=0"/g' /etc/default/grub
+  # changing interface name
+  grub-mkconfig -o /boot/grub/grub.cfg
+  rm -f /etc/netplan/00-installer-config.yaml
+  cat <<EOF > /etc/netplan/00-magma-focal-config.yaml
+---
+network:
+  version: 2
+  ethernets:
+    eth0:
+      dhcp4: yes
+    eth1:
+      dhcp4: no
+      addresses: [10.0.2.1/24]
+EOF
+  netplan apply
+  # Setting REBOOT flag to 1 because we need to reload new interface and network services.
+  NEED_REBOOT=1
+else
+  echo "Interfaces name are correct, let's check if network and DNS are up"
+  while ! ping -c 1 -W 1 -I eth0 google.com; do
+    echo "Network not ready yet"
+    sleep 1
+  done
+fi
+
+# configure environment variable defaults needed for ansible
+ANSIBLE_VARS="PACKAGE_LOCATION=/tmp"
+if [ -n "${REPO_HOST}" ]; then
+    if [ -z "${REPO_PROTO}" ]; then
+        REPO_PROTO=http
+    fi
+    if [ -z "${REPO_DIST}" ]; then
+        REPO_DIST=focal-test
+    fi
+    if [ -z "${REPO_COMPONENT}" ]; then
+        REPO_COMPONENT=main
+    fi
+    # configure pkgrepo location
+    ANSIBLE_VARS="ovs_pkgrepo_proto=${REPO_PROTO} ovs_pkgrepo_host=${REPO_HOST} ovs_pkgrepo_path=${REPO_PATH} ${ANSIBLE_VARS}"
+
+    # configure pkgrepo distribution
+    ANSIBLE_VARS="ovs_pkgrepo_dist=${REPO_DIST} ovs_pkgrepo_component=${REPO_COMPONENT} ${ANSIBLE_VARS}"
+
+    # configure pkgrepo gpg key
+    ANSIBLE_VARS="ovs_pkgrepo_key=${REPO_KEY} ${ANSIBLE_VARS}"
+    if [ -z "${REPO_KEY_FINGERPRINT}" ]; then
+        ANSIBLE_VARS="ovs_pkgrepo_key_fingerprint=${REPO_KEY_FINGERPRINT} ${ANSIBLE_VARS}"
+    fi
+fi
+
+if [ "${REPO_PROTO}" == 'https' ]; then
+    echo "Ensure HTTPS apt transport method is installed"
+    apt install -y apt-transport-https
+fi
+
+if [ $NEED_REBOOT = 1 ]; then
+  echo "Will reboot in a few seconds, loading a boot script in order to install magma"
+  if [ ! -f "$AGW_SCRIPT_PATH" ]; then
+      cp "$(realpath $0)" "${AGW_SCRIPT_PATH}"
+  fi
+  cat <<EOF > $AGW_INSTALL_CONFIG
+[Unit]
+Description=AGW Installation
+After=network-online.target
+Wants=network-online.target
+[Service]
+Environment=MAGMA_VERSION=${MAGMA_VERSION}
+Environment=GIT_URL=${GIT_URL}
+Environment=REPO_PROTO=${REPO_PROTO}
+Environment=REPO_HOST=${REPO_HOST}
+Environment=REPO_DIST=${REPO_DIST}
+Environment=REPO_COMPONENT=${REPO_COMPONENT}
+Environment=REPO_KEY=${REPO_KEY}
+Environment=REPO_KEY_FINGERPRINT=${REPO_KEY_FINGERPRINT}
+Type=oneshot
+ExecStart=/bin/bash ${AGW_SCRIPT_PATH}
+TimeoutStartSec=3800
+TimeoutSec=3600
+User=root
+Group=root
+[Install]
+WantedBy=multi-user.target
+EOF
+  chmod 644 $AGW_INSTALL_CONFIG
+  reboot
+fi
+
+echo "Making sure eth0 is connected to internet"
+PING_RESULT=$(ping -c 1 -I eth0 8.8.8.8 > /dev/null 2>&1 && echo "$SUCCESS_MESSAGE")
+if [ "$PING_RESULT" != "$SUCCESS_MESSAGE" ]; then
+  echo "eth0 (enp1s0) is not connected to internet, please double check your plugged wires."
+  exit 1
+fi
+echo "Checking if magma has been installed"
+MAGMA_INSTALLED=$(apt-cache show magma >  /dev/null 2>&1 echo "$SUCCESS_MESSAGE")
+if [ "$MAGMA_INSTALLED" != "$SUCCESS_MESSAGE" ]; then
+  echo "Magma not installed, processing installation"
+  apt-get update
+  apt-get -y install curl make virtualenv zip rsync git software-properties-common python3-pip python-dev
+  alias python=python3
+  pip3 install ansible
+
+  git clone "${GIT_URL}" /home/$MAGMA_USER/magma
+  cd /home/$MAGMA_USER/magma
+  git checkout "$MAGMA_VERSION"
+
+  echo "Generating localhost hostfile for Ansible"
+  echo "[ovs_build]
+  127.0.0.1 ansible_connection=local
+  [ovs_deploy]
+  127.0.0.1 ansible_connection=local" > $DEPLOY_PATH/agw_hosts
+  if [ -n "${FORCE_OVS_BUILD}" ]; then
+      echo "Triggering ovs_build playbook"
+      su - $MAGMA_USER -c "ansible-playbook -e \"MAGMA_ROOT='/home/$MAGMA_USER/magma' OUTPUT_DIR='/tmp'\" -i $DEPLOY_PATH/agw_hosts $DEPLOY_PATH/ovs_build.yml"
+      ANSIBLE_VARS="${ANSIBLE_VARS} ovs_use_pkgrepo=no"
+  fi
+  echo "Triggering ovs_deploy playbook"
+  su - $MAGMA_USER -c "ansible-playbook -e '${ANSIBLE_VARS}' -i $DEPLOY_PATH/agw_hosts $DEPLOY_PATH/ovs_deploy.yml --skip-tags \"skipfirstinstall\""
+
+  echo "Deleting boot script if it exists"
+  if [ -f "$AGW_INSTALL_CONFIG" ]; then
+    rm -rf $AGW_INSTALL_CONFIG
+  fi
+  rm -rf /home/$MAGMA_USER/build
+  echo "AGW installation is done, make sure all services above are running correctly.. rebooting"
+  reboot
+else
+  echo "Magma already installed, skipping.."
+fi

--- a/lte/gateway/deploy/agw_install.sh
+++ b/lte/gateway/deploy/agw_install.sh
@@ -3,7 +3,8 @@
 MAGMA_USER="magma"
 AGW_INSTALL_CONFIG="/etc/systemd/system/multi-user.target.wants/agw_installation.service"
 AGW_SCRIPT_PATH="/root/agw_install.sh"
-DEPLOY_PATH="/home/$MAGMA_USER/magma/lte/gateway/deploy"
+MAGMA_ROOT=/home/$MAGMA_USER/magma
+DEPLOY_PATH="${MAGMA_ROOT}/lte/gateway/deploy"
 SUCCESS_MESSAGE="ok"
 NEED_REBOOT=0
 WHOAMI=$(whoami)
@@ -72,7 +73,7 @@ if [ "$KVERS" != "4.9.0-9-amd64" ]; then
 fi
 
 # configure environment variable defaults needed for ansible
-ANSIBLE_VARS="PACKAGE_LOCATION=/tmp"
+ANSIBLE_VARS="preburn=yes PACKAGE_LOCATION=/tmp"
 if [ -n "${REPO_HOST}" ]; then
     if [ -z "${REPO_PROTO}" ]; then
         REPO_PROTO=http
@@ -159,7 +160,7 @@ if [ "$MAGMA_INSTALLED" != "$SUCCESS_MESSAGE" ]; then
   127.0.0.1 ansible_connection=local" > $DEPLOY_PATH/agw_hosts
   if [ -n "${FORCE_OVS_BUILD}" ]; then
       echo "Triggering ovs_build playbook"
-      su - $MAGMA_USER -c "ansible-playbook -e \"MAGMA_ROOT='/home/$MAGMA_USER/magma' OUTPUT_DIR='/tmp'\" -i $DEPLOY_PATH/agw_hosts $DEPLOY_PATH/ovs_build.yml"
+      su - $MAGMA_USER -c "ansible-playbook -e \"MAGMA_ROOT='${MAGMA_ROOT}' OUTPUT_DIR='/tmp'\" -i $DEPLOY_PATH/agw_hosts $DEPLOY_PATH/ovs_build.yml"
       ANSIBLE_VARS="${ANSIBLE_VARS} ovs_use_pkgrepo=no"
   fi
   echo "Triggering ovs_deploy playbook"

--- a/lte/gateway/deploy/agw_install.sh
+++ b/lte/gateway/deploy/agw_install.sh
@@ -11,6 +11,7 @@ WHOAMI=$(whoami)
 KVERS=$(uname -r)
 MAGMA_VERSION="${MAGMA_VERSION:-v1.3}"
 GIT_URL="${GIT_URL:-https://github.com/magma/magma.git}"
+INSTALL_TIMEOUT="${INSTALL_TIMEOUT:-3800}"
 
 echo "Checking if the script has been executed by root user"
 if [ "$WHOAMI" != "root" ]; then
@@ -123,8 +124,8 @@ Environment=REPO_KEY=${REPO_KEY}
 Environment=REPO_KEY_FINGERPRINT=${REPO_KEY_FINGERPRINT}
 Type=oneshot
 ExecStart=/bin/bash ${AGW_SCRIPT_PATH}
-TimeoutStartSec=3800
-TimeoutSec=3600
+TimeoutStartSec=${INSTALL_TIMEOUT}
+TimeoutSec=${INSTALL_TIMEOUT}
 User=root
 Group=root
 [Install]

--- a/lte/gateway/deploy/magma_prod.yml
+++ b/lte/gateway/deploy/magma_prod.yml
@@ -17,9 +17,10 @@
   become: yes
 
   vars:
-    preburn: false
+    preburn: true
     full_provision: true
 
   roles:
     - role: stretch_snapshot
     - role: uselocalpkgrepo
+    - role: envoy

--- a/lte/gateway/deploy/ovs_deploy.yml
+++ b/lte/gateway/deploy/ovs_deploy.yml
@@ -11,6 +11,8 @@
 # limitations under the License.
 
 - name: Deploy ovs and magma
+  become: yes
   hosts: ovs_deploy
   roles:
+    - role: envoy
     - role: ovs_deploy

--- a/lte/gateway/deploy/roles/envoy/tasks/main.yml
+++ b/lte/gateway/deploy/roles/envoy/tasks/main.yml
@@ -30,7 +30,7 @@
 
 - name: Add Getenvoy.io repo
   apt_repository:
-    repo: "deb [arch=amd64] https://dl.bintray.com/tetrate/getenvoy-deb stretch stable"
+    repo: "deb [arch=amd64] https://dl.bintray.com/tetrate/getenvoy-deb {{ ansible_distribution_release }} stable"
     state: present
   register: envoy_getenvoy_debian_repo
   when: preburn

--- a/lte/gateway/deploy/roles/ovs_deploy/tasks/main.yml
+++ b/lte/gateway/deploy/roles/ovs_deploy/tasks/main.yml
@@ -62,11 +62,16 @@
     packages:
       - graphviz
       - python-all
-      - python-twisted-conch
       - module-assistant
       - openssl
       - dkms
       - uuid-runtime
+
+- name: Install python-twisted-conch (not available for ubuntu focal)
+  when: ansible_distribution_release != 'focal'
+  apt:
+    pkg:
+      - python-twisted-conch
 
 - name: Build openvswitch packages
   when: not ovs_use_pkgrepo
@@ -111,12 +116,17 @@
   become: yes
   apt:
     name:
-      - oai-gtp
       - libopenvswitch
       - openvswitch-datapath-dkms
       - openvswitch-datapath-source
       - openvswitch-common
       - openvswitch-switch
+
+- name: Install oai-gtp (not needed for ubuntu focal)
+  when: ansible_distribution_release != 'focal'
+  apt:
+    pkg:
+      - oai-gtp
 
 - name: Preconfigure wireshark (tshark) SUID property
   become: yes

--- a/lte/gateway/deploy/roles/ovs_deploy/tasks/main.yml
+++ b/lte/gateway/deploy/roles/ovs_deploy/tasks/main.yml
@@ -18,8 +18,7 @@
 - name: Configuring private package manager.
   copy:
     content: >
-      deb {{ ovs_pkgrepo_proto }}://{{ ovs_pkgrepo_host }}{{ ovs_pkgrepo_path}}
-      {{ ovs_pkgrepo_dist }} {{ ovs_pkgrepo_component }}
+      deb {{ ovs_pkgrepo_proto }}://{{ ovs_pkgrepo }} {{ ovs_pkgrepo_dist }} {{ ovs_pkgrepo_component }}
     dest: /etc/apt/sources.list.d/{{ ovs_pkgrepo_name }}.list
   become: yes
 

--- a/lte/gateway/deploy/roles/ovs_deploy/tasks/main.yml
+++ b/lte/gateway/deploy/roles/ovs_deploy/tasks/main.yml
@@ -127,6 +127,7 @@
   become: yes
   apt:
     name: "{{ packages }}"
+    dpkg_options: 'force-confold,force-confdef,force-overwrite'
   vars:
     packages:
       - magma

--- a/lte/gateway/deploy/roles/ovs_deploy/vars/all.yaml
+++ b/lte/gateway/deploy/roles/ovs_deploy/vars/all.yaml
@@ -24,8 +24,7 @@ ovs_build_config:
     - "openvswitch-switch_2.8.9-1_amd64.deb"
 
 ovs_pkgrepo_proto: http
-ovs_pkgrepo_host: packages.magma.etagecom.io
-ovs_pkgrepo_path: ""
+ovs_pkgrepo: packages.magma.etagecom.io
 ovs_pkgrepo_dist: stretch-stable
 ovs_pkgrepo_component: main
 ovs_pkgrepo_name: "ovs_package_repo"

--- a/lte/gateway/fabfile.py
+++ b/lte/gateway/fabfile.py
@@ -126,13 +126,39 @@ def package(vcs='hg', all_deps="False",
             run('cp /var/cache/apt/archives/*.deb ~/magma-packages')
 
 
-def openvswitch(destroy_vm='False', destdir='~/magma-packages/'):
+def openvswitch(destroy_vm='False', destdir='~/magma-deps/'):
     destroy_vm = bool(strtobool(destroy_vm))
     # If a host list isn't specified, default to the magma vagrant vm
     if not env.hosts:
         vagrant_setup('magma', destroy_vm=destroy_vm)
     with cd('~/magma/lte/gateway'):
         run('./release/build-ovs.sh ' + destdir)
+
+
+def base_dependencies(destroy_vm='False', destdir='~/magma-deps'):
+    """
+    NOTICE: this will also attempt to install generated packages on build vm
+    """
+    destroy_vm = bool(strtobool(destroy_vm))
+    if not env.hosts:
+        vagrant_setup('magma', destroy_vm=destroy_vm)
+    run('mkdir -p ' + destdir)
+    with cd(destdir):
+        packages = [
+            'asn1c',
+            'freediameter',
+            'folly',
+            'gnutls',
+            'grpc',
+            'libfluid',
+            'liblfds',
+            'magma-cpp-redis',
+            'magma-libtacopie',
+            'nettle',
+            'prometheus-cpp',
+        ]
+
+        run('~/magma/third_party/build/build.py ' + ' '.join(packages))
 
 
 def depclean():

--- a/lte/gateway/release/build-magma.sh
+++ b/lte/gateway/release/build-magma.sh
@@ -88,9 +88,8 @@ SCTPD_PKGNAME=magma-sctpd
 
 # Magma system dependencies: anything that we depend on at the top level, add
 # here.
-MAGMA_DEPS=(
+MAGMA_DEPS_BASE=(
     "grpc-dev >= 1.15.0"
-    "libprotobuf10 >= 3.0.0"
     "lighttpd >= 1.4.45"
     "libxslt1.1"
     "nghttp2-proxy >= 1.18.1"
@@ -105,7 +104,6 @@ MAGMA_DEPS=(
     "libsystemd-dev"
     "libyaml-cpp-dev" # install yaml parser
     "libgoogle-glog-dev"
-    "nlohmann-json-dev" # c++ json parser
     "python-redis"
     "magma-cpp-redis"
     "libfolly-dev" # required for C++ services
@@ -120,32 +118,81 @@ MAGMA_DEPS=(
     "getenvoy-envoy" # for envoy dep
     )
 
+
+MAGMA_DEPS_STRETCH=(
+    "nlohmann-json-dev" # c++ json parser
+    "libprotobuf10 >= 3.0.0"
+)
+
+MAGMA_DEPS_FOCAL=(
+    "nlohmann-json3-dev" # c++ json parser
+    "libprotobuf17 >= 3.0.0"
+)
+
+if grep -q focal /etc/os-release; then
+    MAGMA_DEPS=("${MAGMA_DEPS_BASE[@]}" "${MAGMA_DEPS_FOCAL[@]}")
+else
+    MAGMA_DEPS=("${MAGMA_DEPS_BASE[@]}" "${MAGMA_DEPS_STRETCH[@]}")
+fi
+
 # OAI runtime dependencies
-OAI_DEPS=(
-    "libasan3"
+OAI_DEPS_BASE=(
     "libconfig9"
     "oai-asn1c"
-    "oai-freediameter >= 1.2.0-1"
     "oai-gnutls >= 3.1.23"
     "oai-nettle >= 1.0.1"
     "prometheus-cpp-dev >= 1.0.2"
     "liblfds710"
     "magma-sctpd >= ${SCTPD_MIN_VERSION}"
     "libczmq-dev >= 4.0.2-7"
+)
+OAI_DEPS_STRETCH=(
     "oai-gtp >= 4.9-5"
-    )
+    "libasan3"
+    "oai-freediameter >= 1.2.0-1"
+)
+OAI_DEPS_FOCAL=(
+    "libasan4"
+    "oai-freediameter >= 0.0.1"
+)
+if grep -q focal /etc/os-release; then
+    OAI_DEPS=("${OAI_DEPS_BASE[@]}" "${OAI_DEPS_FOCAL[@]}")
+else
+    OAI_DEPS=("${OAI_DEPS_BASE[@]}" "${OAI_DEPS_STRETCH[@]}")
+fi
 
 # OVS runtime dependencies
-OVS_DEPS=(
+OVS_DEPS_BASE=(
     "magma-libfluid >= 0.1.0.5"
+    )
+OVS_DEPS_STRETCH=(
     "libopenvswitch >= 2.8.9"
     "openvswitch-switch >= 2.8.9"
     "openvswitch-common >= 2.8.9"
-    "python-openvswitch >= 2.8.9"
     "openvswitch-datapath-module-4.9.0-9-amd64 >= 2.8.9"
-    )
+    "python-openvswitch >= 2.8.9"
+)
+OVS_DEPS_FOCAL=(
+    "libopenvswitch >= 2.14.0"
+    "openvswitch-switch >= 2.14.0"
+    "openvswitch-common >= 2.14.0"
+    "python3-openvswitch >= 2.14.0"
+)
+if grep -q focal /etc/os-release; then
+    OVS_DEPS=("${OVS_DEPS_BASE[@]}" "${OVS_DEPS_FOCAL[@]}")
+else
+    OVS_DEPS=("${OVS_DEPS_BASE[@]}" "${OVS_DEPS_STRETCH[@]}")
+fi
 
 # generate string for FPM
+# compact experimental version
+ALL_DEPS=("${MAGMA_DEPS[@]}" "${OAI_DEPS[@]}" "${OVS_DEPS[@]}")
+SYSTEM_DEPS=""
+for dep in "${ALL_DEPS[@]}"; do
+    SYSTEM_DEPS=${SYSTEM_DEPS}" -d '"${dep}"'"
+done
+
+# original version
 SYSTEM_DEPS=""
 for dep in "${MAGMA_DEPS[@]}"
 do

--- a/lte/gateway/release/build-magma.sh
+++ b/lte/gateway/release/build-magma.sh
@@ -165,7 +165,11 @@ POSTINST=${RELEASE_DIR}/magma-postinst
 
 # python environment
 # python3.5 on stretch, python3.8 on focal
-PY_VERSION=python3
+if grep -q stretch /etc/os-release; then
+    PY_VERSION=python3.5
+else
+    PY_VERSION=python3.8
+fi
 PY_PKG_LOC=dist-packages
 PY_DEST=/usr/local/lib/${PY_VERSION}/${PY_PKG_LOC}
 PY_PROTOS=${PYTHON_BUILD}/gen/

--- a/lte/gateway/release/magma.lockfile
+++ b/lte/gateway/release/magma.lockfile
@@ -348,8 +348,8 @@
         },
         "attrs": {
           "root": false,
-          "source": "pypi",
-          "sysdep": "python3-attrs",
+          "source": "apt",
+          "sysdep": "python3-attr",
           "version": "19.3.0"
         },
         "bravado-core": {
@@ -463,7 +463,7 @@
         "jsonpointer": {
           "root": true,
           "source": "pypi",
-          "sysdep": "python3-jsonpointer",
+          "sysdep": "python3-json-pointer",
           "version": "2.0"
         },
         "jsonref": {
@@ -483,6 +483,12 @@
           "source": "pypi",
           "sysdep": "python3-lazy-object-proxy",
           "version": "1.4.3"
+        },
+        "lxml": {
+          "root": true,
+          "source": "pypi",
+          "sysdep": "python3-lxml",
+          "version": "4.6.2"
         },
         "mccabe": {
           "root": false,
@@ -613,7 +619,7 @@
         "systemd-python": {
           "root": true,
           "source": "pypi",
-          "sysdep": "python3-systemd-python",
+          "sysdep": "python3-systemd",
           "version": "234"
         },
         "toml": {
@@ -698,6 +704,9 @@
         },
         "jsonschema": {
           "version": "3.1.0"
+        },
+        "lxml": {
+          "version": "4.6.2"
         },
         "netifaces": {
           "version": "0.10.4"

--- a/lte/gateway/release/magma.lockfile
+++ b/lte/gateway/release/magma.lockfile
@@ -12,17 +12,53 @@
       "sysdep": "python3-aioeventlet",
       "version": "0.5.1"
     },
+    "aioh2": {
+      "root": true,
+      "source": "pypi",
+      "sysdep": "python3-aioh2",
+      "version": "0.2.2"
+    },
+    "aiohttp": {
+      "root": true,
+      "source": "apt",
+      "sysdep": "python3-aiohttp",
+      "version": "1.2.0"
+    },
     "argparse": {
       "root": false,
       "source": "pypi",
       "sysdep": "python3-argparse",
       "version": "1.4.0"
     },
+    "astroid": {
+      "root": false,
+      "source": "pypi",
+      "sysdep": "python3-astroid",
+      "version": "2.4.2"
+    },
+    "attrs": {
+      "root": false,
+      "source": "pypi",
+      "sysdep": "python3-attrs",
+      "version": "20.3.0"
+    },
+    "bravado-core": {
+      "root": true,
+      "source": "pypi",
+      "sysdep": "python3-bravado-core",
+      "version": "5.16.1"
+    },
     "certifi": {
       "root": true,
       "source": "pypi",
       "sysdep": "python3-certifi",
       "version": "2019.6.16"
+    },
+    "cffi": {
+      "root": false,
+      "source": "pypi",
+      "sysdep": "python3-cffi",
+      "version": "1.14.4"
     },
     "chardet": {
       "root": true,
@@ -31,10 +67,16 @@
       "version": "3.0.4"
     },
     "click": {
-      "root": false,
+      "root": true,
       "source": "pypi",
       "sysdep": "python3-click",
       "version": "7.1.2"
+    },
+    "cryptography": {
+      "root": true,
+      "source": "pypi",
+      "sysdep": "python3-cryptography",
+      "version": "3.2.1"
     },
     "cython": {
       "root": true,
@@ -96,6 +138,12 @@
       "sysdep": "python3-greenlet",
       "version": "0.4.16"
     },
+    "grpcio": {
+      "root": true,
+      "source": "pypi",
+      "sysdep": "python3-grpcio",
+      "version": "1.35.0"
+    },
     "h2": {
       "root": true,
       "source": "pypi",
@@ -120,35 +168,89 @@
       "sysdep": "python3-idna",
       "version": "2.8"
     },
+    "importlib-metadata": {
+      "root": false,
+      "source": "pypi",
+      "sysdep": "python3-importlib-metadata",
+      "version": "2.1.1"
+    },
     "importlib-resources": {
       "root": false,
       "source": "pypi",
       "sysdep": "python3-importlib-resources",
       "version": "3.0.0"
     },
-    "itsdangerous": {
+    "isort": {
       "root": false,
+      "source": "pypi",
+      "sysdep": "python3-isort",
+      "version": "4.3.21"
+    },
+    "itsdangerous": {
+      "root": true,
       "source": "pypi",
       "sysdep": "python3-itsdangerous",
       "version": "1.1.0"
     },
     "jinja2": {
-      "root": false,
+      "root": true,
       "source": "pypi",
       "sysdep": "python3-jinja2",
       "version": "2.10"
+    },
+    "js-regex": {
+      "root": false,
+      "source": "pypi",
+      "sysdep": "python3-js-regex",
+      "version": "1.0.1"
+    },
+    "jsonpickle": {
+      "root": true,
+      "source": "apt",
+      "sysdep": "python3-jsonpickle",
+      "version": "0.9.3"
+    },
+    "jsonpointer": {
+      "root": true,
+      "source": "pypi",
+      "sysdep": "python3-jsonpointer",
+      "version": "2.0"
+    },
+    "jsonref": {
+      "root": false,
+      "source": "pypi",
+      "sysdep": "python3-jsonref",
+      "version": "0.2"
+    },
+    "jsonschema": {
+      "root": true,
+      "source": "pypi",
+      "sysdep": "python3-jsonschema",
+      "version": "3.1.0"
+    },
+    "lazy-object-proxy": {
+      "root": false,
+      "source": "pypi",
+      "sysdep": "python3-lazy-object-proxy",
+      "version": "1.4.3"
     },
     "lxml": {
       "root": true,
       "source": "pypi",
       "sysdep": "python3-lxml",
-      "version": "4.2.1"
+      "version": "4.6.2"
     },
     "markupsafe": {
       "root": false,
       "source": "pypi",
       "sysdep": "python3-markupsafe",
       "version": "1.1.1"
+    },
+    "mccabe": {
+      "root": false,
+      "source": "pypi",
+      "sysdep": "python3-mccabe",
+      "version": "0.6.1"
     },
     "monotonic": {
       "root": false,
@@ -168,6 +270,12 @@
       "sysdep": "python3-netaddr",
       "version": "0.8.0"
     },
+    "netifaces": {
+      "root": true,
+      "source": "pypi",
+      "sysdep": "python3-netifaces",
+      "version": "0.10.9"
+    },
     "oslo.config": {
       "root": false,
       "source": "pypi",
@@ -186,17 +294,65 @@
       "sysdep": "python3-pbr",
       "version": "5.4.5"
     },
+    "priority": {
+      "root": false,
+      "source": "pypi",
+      "sysdep": "python3-priority",
+      "version": "1.3.0"
+    },
+    "prometheus-client": {
+      "root": true,
+      "source": "pypi",
+      "sysdep": "python3-prometheus-client",
+      "version": "0.3.1"
+    },
+    "protobuf": {
+      "root": true,
+      "source": "pypi",
+      "sysdep": "python3-protobuf",
+      "version": "3.14.0"
+    },
+    "psutil": {
+      "root": true,
+      "source": "pypi",
+      "sysdep": "python3-psutil",
+      "version": "5.6.6"
+    },
+    "pycares": {
+      "root": true,
+      "source": "pypi",
+      "sysdep": "python3-pycares",
+      "version": "3.1.1"
+    },
+    "pycparser": {
+      "root": false,
+      "source": "pypi",
+      "sysdep": "python3-pycparser",
+      "version": "2.20"
+    },
     "pycryptodome": {
       "root": true,
       "source": "pypi",
       "sysdep": "python3-pycryptodome",
       "version": "3.9.9"
     },
+    "pylint": {
+      "root": true,
+      "source": "pypi",
+      "sysdep": "python3-pylint",
+      "version": "2.6.0"
+    },
     "pymemoize": {
       "root": true,
       "source": "pypi",
       "sysdep": "python3-pymemoize",
       "version": "1.0.2"
+    },
+    "pyrsistent": {
+      "root": false,
+      "source": "pypi",
+      "sysdep": "python3-pyrsistent",
+      "version": "0.17.3"
     },
     "pystemd": {
       "root": true,
@@ -211,10 +367,28 @@
       "version": "2.8.1"
     },
     "pytz": {
-      "root": false,
+      "root": true,
       "source": "pypi",
       "sysdep": "python3-pytz",
       "version": "2020.1"
+    },
+    "pyyaml": {
+      "root": true,
+      "source": "apt",
+      "sysdep": "python3-yaml",
+      "version": "3.12"
+    },
+    "redis": {
+      "root": true,
+      "source": "pypi",
+      "sysdep": "python3-redis",
+      "version": "3.5.3"
+    },
+    "redis-collections": {
+      "root": true,
+      "source": "pypi",
+      "sysdep": "python3-redis-collections",
+      "version": "0.9.0"
     },
     "repoze.lru": {
       "root": false,
@@ -227,6 +401,12 @@
       "source": "pypi",
       "sysdep": "python3-requests",
       "version": "2.22.0"
+    },
+    "rfc3987": {
+      "root": true,
+      "source": "pypi",
+      "sysdep": "python3-rfc3987",
+      "version": "1.3.8"
     },
     "routes": {
       "root": false,
@@ -246,11 +426,23 @@
       "sysdep": "python3-scapy",
       "version": "2.4.4"
     },
+    "simplejson": {
+      "root": false,
+      "source": "apt",
+      "sysdep": "python3-simplejson",
+      "version": "3.10.0"
+    },
     "six": {
       "root": true,
       "source": "pypi",
       "sysdep": "python3-six",
       "version": "1.12.0"
+    },
+    "snowflake": {
+      "root": true,
+      "source": "pypi",
+      "sysdep": "python3-snowflake",
+      "version": "0.0.3"
     },
     "spyne": {
       "root": true,
@@ -264,6 +456,24 @@
       "sysdep": "python3-stevedore",
       "version": "1.32.0"
     },
+    "strict-rfc3339": {
+      "root": true,
+      "source": "pypi",
+      "sysdep": "python3-strict-rfc3339",
+      "version": "0.7"
+    },
+    "swagger-spec-validator": {
+      "root": false,
+      "source": "pypi",
+      "sysdep": "python3-swagger-spec-validator",
+      "version": "2.7.3"
+    },
+    "systemd-python": {
+      "root": true,
+      "source": "pypi",
+      "sysdep": "python3-systemd-python",
+      "version": "234"
+    },
     "termcolor": {
       "root": false,
       "source": "apt",
@@ -276,11 +486,29 @@
       "sysdep": "python3-tinyrpc",
       "version": "1.0.4"
     },
+    "toml": {
+      "root": false,
+      "source": "pypi",
+      "sysdep": "python3-toml",
+      "version": "0.10.2"
+    },
+    "typed-ast": {
+      "root": false,
+      "source": "pypi",
+      "sysdep": "python3-typed-ast",
+      "version": "1.4.2"
+    },
     "urllib3": {
       "root": true,
       "source": "pypi",
       "sysdep": "python3-urllib3",
       "version": "1.25.3"
+    },
+    "webcolors": {
+      "root": true,
+      "source": "pypi",
+      "sysdep": "python3-webcolors",
+      "version": "1.11.1"
     },
     "webob": {
       "root": false,
@@ -299,6 +527,12 @@
       "source": "pypi",
       "sysdep": "python3-werkzeug",
       "version": "0.14"
+    },
+    "wrapt": {
+      "root": false,
+      "source": "pypi",
+      "sysdep": "python3-wrapt",
+      "version": "1.12.1"
     },
     "wsgiserver": {
       "root": true,
@@ -772,11 +1006,26 @@
     "aioeventlet": {
       "version": "0.5.1"
     },
+    "aioh2": {
+      "version": "0.2.2"
+    },
+    "aiohttp": {
+      "version": "1.2.0"
+    },
+    "bravado-core": {
+      "version": "5.16.1"
+    },
     "certifi": {
       "version": "2019.6.16"
     },
     "chardet": {
       "version": "3.0.4"
+    },
+    "click": {
+      "version": "7.1.2"
+    },
+    "cryptography": {
+      "version": "3.2.1"
     },
     "cython": {
       "version": "0.29.1"
@@ -802,6 +1051,9 @@
     "glob2": {
       "version": "0.7"
     },
+    "grpcio": {
+      "version": "1.35.0"
+    },
     "h2": {
       "version": "3.2.0"
     },
@@ -811,23 +1063,71 @@
     "idna": {
       "version": "2.8"
     },
+    "itsdangerous": {
+      "version": "1.1.0"
+    },
+    "jinja2": {
+      "version": "2.10"
+    },
+    "jsonpickle": {
+      "version": "0.9.3"
+    },
+    "jsonpointer": {
+      "version": "2.0"
+    },
+    "jsonschema": {
+      "version": "3.1.0"
+    },
     "lxml": {
-      "version": "4.2.1"
+      "version": "4.6.2"
+    },
+    "netifaces": {
+      "version": "0.10.9"
+    },
+    "prometheus-client": {
+      "version": "0.3.1"
+    },
+    "protobuf": {
+      "version": "3.14.0"
+    },
+    "psutil": {
+      "version": "5.6.6"
+    },
+    "pycares": {
+      "version": "3.1.1"
     },
     "pycryptodome": {
       "version": "3.9.9"
+    },
+    "pylint": {
+      "version": "2.6.0"
     },
     "pymemoize": {
       "version": "1.0.2"
     },
     "pystemd": {
-      "version": "0.5.0"
+      "version": "0.8.0"
     },
     "python-dateutil": {
       "version": "2.8.1"
     },
+    "pytz": {
+      "version": "2020.1"
+    },
+    "pyyaml": {
+      "version": "3.12"
+    },
+    "redis": {
+      "version": "3.5.3"
+    },
+    "redis-collections": {
+      "version": "0.9.0"
+    },
     "requests": {
       "version": "2.22.0"
+    },
+    "rfc3987": {
+      "version": "1.3.8"
     },
     "ryu": {
       "version": "4.30"
@@ -835,14 +1135,29 @@
     "scapy": {
       "version": "2.4.4"
     },
+    "setuptools": {
+      "version": "49.6.0"
+    },
     "six": {
       "version": "1.12.0"
+    },
+    "snowflake": {
+      "version": "0.0.3"
     },
     "spyne": {
       "version": "2.12.16"
     },
+    "strict-rfc3339": {
+      "version": "0.7"
+    },
+    "systemd-python": {
+      "version": "234"
+    },
     "urllib3": {
       "version": "1.25.3"
+    },
+    "webcolors": {
+      "version": "1.11.1"
     },
     "websocket-client": {
       "version": "0.56.0"

--- a/lte/gateway/release/pydep
+++ b/lte/gateway/release/pydep
@@ -64,17 +64,6 @@ log = logging.getLogger(__name__)
 PYPI_API_BASE = "https://pypi.python.org/pypi/%s/json"
 PIP_BLACKLIST = {'pip', 'wheel', 'setuptools', 'virtualenv'}
 
-# In general, system package repos use the same name as PyPI package names,
-# with a prefix (for example, python3-requests is the system package for
-# requests). Some packages break this convention, however, and we maintain a
-# list here. We use the all lower-case version of the package name here.
-PYPI_TO_DEB = {
-    'pyyaml': 'yaml',
-    'msgpack-python': 'msgpack',
-    'scapy-python3': 'scapy',
-    'python-apt': 'apt',
-}
-
 # Some packages exist in the standard Debian repos with an epoch number
 # prepended (this is to handle changes in upstream versioning scheme). This
 # allows us to handle that.
@@ -83,7 +72,7 @@ DEB_EPOCH = {
 }
 
 
-def os_release():
+def os_release() -> Dict[str, str]:
     # copied from third_party/build/build.py
     # FIXME: should be a magma python library for this kind of thing
     release_info = {}
@@ -95,6 +84,33 @@ def os_release():
             except Exception:
                 pass
     return release_info
+
+
+# In general, system package repos use the same name as PyPI package names,
+# with a prefix (for example, python3-requests is the system package for
+# requests). Some packages break this convention, however, and we maintain a
+# list here. We use the all lower-case version of the package name here.
+def pypi_name_remap(pkgname: str, release_name: str='stretch') -> str:
+    base_map = {
+        'pyyaml': 'yaml',
+        'msgpack-python': 'msgpack',
+        'scapy-python3': 'scapy',
+        'python-apt': 'apt',
+    }
+
+    override_maps = {
+        'focal': {
+            'attrs': 'attr',
+            'jsonpointer': 'json-pointer'
+            }
+    }
+
+    if release_name in override_maps and pkgname in override_maps[release_name]:
+        pkgname = override_maps[release_name][pkgname]
+    else:
+        if pkgname in base_map:
+            pkgname = base_map[pkgname]
+    return pkgname
 
 
 def json_equal(a, b):
@@ -150,7 +166,7 @@ def gen_sys_package_name(py_pkgname: str, use_py2: bool=False) -> str:
     Generate the system package name for a Python package. In general, this
     will be `python3-pkgname` for py3 and `python-pkgname` for py2, but some
     packages break convention. We use the PyPI package name as our canonical
-    name source, and PYPI_TO_DEB to handle edge cases.
+    name source, and pypi_name_remap to handle edge cases.
 
     Args:
         py_pkgname: PyPI package name
@@ -164,10 +180,10 @@ def gen_sys_package_name(py_pkgname: str, use_py2: bool=False) -> str:
     else:
         prefix = "python3"
 
-    if py_pkgname.lower() in PYPI_TO_DEB:
-        suffix = PYPI_TO_DEB[py_pkgname.lower()]
-    else:
-        suffix = py_pkgname
+    release_info = os_release()
+
+    suffix = pypi_name_remap(py_pkgname.lower(),
+                             release_name=release_info.get('VERSION_CODENAME'))
 
     sysdep_name = "%s-%s" % (prefix, suffix)
     return sysdep_name.lower()  # deb likes lowercase

--- a/lte/gateway/release/pydep
+++ b/lte/gateway/release/pydep
@@ -63,6 +63,7 @@ log = logging.getLogger(__name__)
 
 PYPI_API_BASE = "https://pypi.python.org/pypi/%s/json"
 PIP_BLACKLIST = {'pip', 'wheel', 'setuptools', 'virtualenv'}
+PIP_WHITELIST = {'protobuf'}
 
 # Some packages exist in the standard Debian repos with an epoch number
 # prepended (this is to handle changes in upstream versioning scheme). This
@@ -101,7 +102,8 @@ def pypi_name_remap(pkgname: str, release_name: str='stretch') -> str:
     override_maps = {
         'focal': {
             'attrs': 'attr',
-            'jsonpointer': 'json-pointer'
+            'jsonpointer': 'json-pointer',
+            'systemd-python': 'systemd'
             }
     }
 
@@ -615,8 +617,9 @@ def py_to_deb(pkgname: str,
         log.error(msg)
         raise Exception(msg)
 
-    if "/.virtualenvs/" not in dist.location:
+    if "/.virtualenvs/" not in dist.location and pkgname not in PIP_WHITELIST:
         # valid package but found in system packages -- source is apt
+        log.debug('apt source for ' + pkgname)
         return 0
 
     syspkg_name = gen_sys_package_name(pkgname, py2)
@@ -817,7 +820,7 @@ def gen_pip_distributions(
     list.
     """
     if not venv:
-        raise ValueError('must supply valid virtualenv command (see tmpvirtualenv)')
+        raise ValueError('must supply valid virtualenv function (see tmpvirtualenv)')
     if not existing_versions:
         existing_versions = {}
     selected_versions = copy.copy(existing_versions)

--- a/third_party/build/bin/freediameter_build.sh
+++ b/third_party/build/bin/freediameter_build.sh
@@ -16,7 +16,7 @@ SCRIPT_DIR="$(dirname "$(realpath "$0")")"
 source "${SCRIPT_DIR}"/../lib/util.sh
 GIT_URL=https://github.com/lionelgo/opencord.org.freeDiameter.git
 GIT_COMMIT=13b0e7de0d66906d50e074a339f890d6e59813ad
-PKGVERSION=0.0.1
+PKGVERSION=1.2.0
 ITERATION=1
 VERSION="${PKGVERSION}"-"${ITERATION}"
 PKGNAME=oai-freediameter


### PR DESCRIPTION
## Summary
Provides a VM to host a local apt repository for magma and its dependencies,
as well as a new fab command `base_dependencies` for `lte/gateway/fabfile.py`
that will build the third party dependencies of magma and leave them available
for copy to VM repository.


## Test Plan
verify
* (from `infra/pkgrepo` with appropriate docker login env vars) `vagrant up aptly` works
* (from `lte/gateway`) `fab dev base_dependencies openvswitch package:vcs=git`
* (from `infra/pkgrepo`) `fab test shipit`
* (as root inside magma_prod VM) apt update
* (as root inside magma_prod VM) apt install magma

The last step should offer to install magma with no missing or broken dependencies.
All of the dependencies are available from official sources or built in the above process.

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
