### PR TITLE
[xwf][xwfm][fluentbit] revert "we will log also locally on mount bind…

### DIFF
--- a/xwf/gateway/deploy/roles/containers/files/clean_fluentbit_logs
+++ b/xwf/gateway/deploy/roles/containers/files/clean_fluentbit_logs
@@ -1,4 +1,0 @@
-SHELL=/bin/bash
-PATH=/sbin:/bin:/usr/sbin:/usr/bin
-
-10 10 * * * root find /var/log/fluentbit-logs/ -type f -mtime +7 -exec rm {} \;

--- a/xwf/gateway/deploy/roles/containers/tasks/main.yml
+++ b/xwf/gateway/deploy/roles/containers/tasks/main.yml
@@ -30,19 +30,6 @@
     dest: /var/opt/magma/docker/.env
     mode: 0400
 
-- name: create fluentbit logs directory
-  file:
-    path: "/var/log/fluentbit-logs/"
-    state: directory
-    mode: '0700'
-
-- name: place clean_fluentbit_logs cron file
-  copy:
-   src: clean_fluentbit_logs
-   dest: /etc/cron.d/clean_fluentbit_logs
-   mode: '0644'
-
-
 - name: Clone the git repo
   git:
    repo: "https://github.com/magma/magma.git"

--- a/xwf/gateway/docker/docker-compose.yml
+++ b/xwf/gateway/docker/docker-compose.yml
@@ -128,8 +128,6 @@ services:
       - SCRIBE_ACCESS_TOKEN=${SCUBA_ACCESS_TOKEN}
       - SCUBA_TABLE=perfpipe_xwf_xwfm_logs
       - PARTNER_SHORTNAME=${PARTNER_SHORTNAME}
-    volumes:
-      - /var/log/fluentbit-logs:/var/log/fluentbit-logs
 
   cadvisor:
     image: gcr.io/google-containers/cadvisor:latest


### PR DESCRIPTION
… pointing to directory on the host which we will clean with cron #3653"

Signed-off-by: Leonid Brandes <leonidb@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary

Following [dual-logging enablement](https://github.com/magma/magma/pull/4799) we no longer need to route logs to local host through flientbit.

## Test Plan

### Before this PR
There is a cron job which clears logs in directory **/var/log/fluentbit-logs/** which is bound to container "logrouter":
```
[root@xwfm centos]# ls /etc/cron.d/clean_fluentbit_logs
/etc/cron.d/clean_fluentbit_logs
[root@xwfm centos]# ls /var/log/fluentbit-logs/
radius.02-07-2021  radius.02-08-2021  radius.02-09-2021
[root@xwfm centos]# docker inspect logrouter | grep -A2 -e "Volumes\":"
            "Volumes": {
                "/var/log/fluentbit-logs": {}
            },

```

### After this PR
On a fresh box, fetch the PR instead of master Magma:
```
[root@ip-10-0-10-95 centos]# git clone https://github.com/interfan7/magma.git -b revert_local_fluentbit_logs_and_cleanup
... 
[root@ip-10-0-10-95 centos]# cd magma/xwf/gateway/deploy/

```
Before executing Ansible, need to modify an Ansible task which clones from Magma github master repo.
The Ansible task shall clone from the PR instead.
Open roles/containers/tasks/main.yml and replace this Ansible task:
```
[root@ip-10-0-10-226 deploy]# vi roles/containers/tasks/main.yml
...
- name: Clone the git repo
  git:
   repo: "https://github.com/magma/magma.git"
   clone: yes
   force: yes
   dest: "/opt/magma"
   version: "{{ image_version }}"
...

```
with this (note we replace repo and version):
```
- name: Clone the git repo
  git:
   repo: "https://github.com/interfan7/magma.git"
   clone: yes
   force: yes
   dest: "/opt/magma"
   version: "revert_local_fluentbit_logs_and_cleanup"

```
Execute the Ansible:
```
[root@ip-10-0-10-226 deploy]# ansible-playbook xwf.yml
...

```

Confirm no cron job, no fluentb logs directory and no docker volume bound to this directory:
```
[root@ip-10-0-10-226 deploy]# ls /etc/cron.d/clean_fluentbit_logs
ls: cannot access /etc/cron.d/clean_fluentbit_logs: No such file or directory
[root@ip-10-0-10-226 deploy]# ls /var/log/fluentbit-logs/
ls: cannot access /var/log/fluentbit-logs/: No such file or directory
[root@ip-10-0-10-226 deploy]# docker inspect logrouter | grep -A8 -e "Volumes\":"
            "Volumes": {
                "/etc/magma": {},
                "/etc/magma/control_proxy.yml": {},
                "/etc/magma/templates": {},
                "/etc/snowflake": {},
                "/var/opt/magma/certs": {},
                "/var/opt/magma/certs/rootCA.pem": {},
                "/var/opt/magma/configs": {}
            },

```

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
