### PR TITLE
AGW: pipelined: qos: initialize single instance of QoS manager

### DIFF
--- a/lte/gateway/python/magma/pipelined/app/enforcement.py
+++ b/lte/gateway/python/magma/pipelined/app/enforcement.py
@@ -87,7 +87,7 @@ class EnforcementController(PolicyMixin, RestartMixin, MagmaController):
             datapath: ryu datapath struct
         """
         self._datapath = datapath
-        self._qos_mgr = QosManager(datapath, self.loop, self._config)
+        self._qos_mgr = QosManager.get_qos_manager(datapath, self.loop, self._config)
         self._qos_mgr.setup()
 
     def cleanup_on_disconnect(self, datapath):

--- a/lte/gateway/python/magma/pipelined/app/gy.py
+++ b/lte/gateway/python/magma/pipelined/app/gy.py
@@ -90,7 +90,7 @@ class GYController(PolicyMixin, RestartMixin, MagmaController):
             datapath: ryu datapath struct
         """
         self._datapath = datapath
-        self._qos_mgr = QosManager(datapath, self.loop, self._config)
+        self._qos_mgr = QosManager.get_qos_manager(datapath, self.loop, self._config)
         self._qos_mgr.setup()
 
     def deactivate_rules(self, imsi, ip_addr, rule_ids):

--- a/lte/gateway/python/magma/pipelined/qos/qos_meter_impl.py
+++ b/lte/gateway/python/magma/pipelined/qos/qos_meter_impl.py
@@ -88,7 +88,7 @@ class MeterManager(object):
     def read_all_state(self, ):
         LOG.debug("read_all_state")
         MeterClass.dump_all_meters(self._datapath)
-        return self._fut
+        return {}, []
 
     def handle_meter_config_stats(self, ev_body):
         LOG.debug("handle_meter_config_stats %s", ev_body)

--- a/lte/gateway/python/magma/pipelined/tests/test_qos.py
+++ b/lte/gateway/python/magma/pipelined/tests/test_qos.py
@@ -463,6 +463,7 @@ get_action_instruction"
         else:
             mock_traffic_cls.read_all_classes.side_effect = tc_read
 
+        qos_mgr._initialized = False
         qos_mgr._setupInternal()
 
         # verify that qos_handle 20 not found in system is purged from map
@@ -510,6 +511,7 @@ get_action_instruction"
         else:
             mock_traffic_cls.read_all_classes.side_effect = lambda _: []
 
+        qos_mgr._initialized = False
         qos_mgr._setupInternal()
 
         self.assertTrue(not qos_mgr._redis_store)
@@ -530,6 +532,7 @@ get_action_instruction"
         else:
             mock_traffic_cls.read_all_classes.side_effect = tc_read
 
+        qos_mgr._initialized = False
         qos_mgr._setupInternal()
 
         self.assertTrue(not qos_mgr._redis_store)


### PR DESCRIPTION
Gy and Enforcement APP both need QoS manager, create API
to maintain a single instance of the QoS manager object.
This patch also fixes QoS parsing errors in initialization.

Signed-off-by: Pravin B Shelar <pbshelar@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->

## Test Plan
`make test`
Ran integ tests manually on dev.
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
