### PR TITLE
[AGW][Stateless MME ]Sctp reset enb state

### DIFF
--- a/lte/gateway/c/oai/tasks/mme_app/mme_app_context.c
+++ b/lte/gateway/c/oai/tasks/mme_app/mme_app_context.c
@@ -2107,6 +2107,7 @@ static void _mme_app_handle_s1ap_ue_context_release(
           "IDLE. mme_ue_s1ap_id = %d, enb_ue_s1ap_id = %d Action -- Handle the "
           "message\n ",
           ue_mm_context->mme_ue_s1ap_id, ue_mm_context->enb_ue_s1ap_id);
+      OAILOG_FUNC_OUT(LOG_MME_APP);
     }
     OAILOG_ERROR_UE(
         LOG_MME_APP, ue_mm_context->emm_context._imsi64,

--- a/lte/gateway/c/oai/tasks/mme_app/mme_app_context.c
+++ b/lte/gateway/c/oai/tasks/mme_app/mme_app_context.c
@@ -1556,12 +1556,27 @@ void mme_ue_context_update_ue_sig_connection_state(
     OAILOG_INFO_UE(
         LOG_MME_APP, ue_context_p->emm_context._imsi64,
         "UE STATE - CONNECTED.\n");
+  } else if (ue_context_p->ecm_state == ECM_IDLE && new_ecm_state == ECM_IDLE) {
+    OAILOG_INFO_UE(
+        LOG_MME_APP, ue_context_p->emm_context._imsi64,
+        "Old UE ECM State (IDLE) is same as the new UE ECM state (IDLE)\n");
+    hash_rc = hashtable_uint64_ts_remove(
+        mme_ue_context_p->enb_ue_s1ap_id_ue_context_htbl,
+        (const hash_key_t) ue_context_p->enb_s1ap_id_key);
+    if (HASH_TABLE_OK != hash_rc) {
+      OAILOG_WARNING_UE(
+          LOG_MME_APP, ue_context_p->emm_context._imsi64,
+          "UE context enb_ue_s1ap_ue_id_key %ld "
+          "mme_ue_s1ap_id " MME_UE_S1AP_ID_FMT
+          ", ENB_UE_S1AP_ID_KEY could not be found",
+          ue_context_p->enb_s1ap_id_key, ue_context_p->mme_ue_s1ap_id);
+    }
+    ue_context_p->enb_s1ap_id_key = INVALID_ENB_UE_S1AP_ID_KEY;
   } else {
     OAILOG_INFO_UE(
         LOG_MME_APP, ue_context_p->emm_context._imsi64,
-        "Old UE ECM State (%s) is same as the new UE ECM state (%s)\n",
-        (ue_context_p->ecm_state == ECM_CONNECTED ? "CONNECTED" : "IDLE"),
-        (new_ecm_state == ECM_CONNECTED ? "CONNECTED" : "IDLE"));
+        "Old UE ECM State (CONNECTED) is same as the new UE ECM state "
+        "(CONNECTED)\n");
   }
   OAILOG_FUNC_OUT(LOG_MME_APP);
 }

--- a/lte/gateway/c/oai/tasks/mme_app/mme_app_state_converter.cpp
+++ b/lte/gateway/c/oai/tasks/mme_app/mme_app_state_converter.cpp
@@ -137,9 +137,6 @@ void MmeNasStateConverter::guti_table_to_proto(
       OAILOG_ERROR(
           LOG_MME_APP, "Key %s not in guti_ue_context_htbl", guti_str.c_str());
     }
-    /*OAILOG_DEBUG(
-        LOG_MME_APP, "guti_str:%s mme_ue_id:%lu\n", guti_str.c_str(),
-        mme_ue_id);*/
   }
   FREE_OBJ_HASHTABLE_KEY_ARRAY(key_array_p);
 }

--- a/lte/gateway/c/oai/tasks/mme_app/mme_app_state_converter.cpp
+++ b/lte/gateway/c/oai/tasks/mme_app/mme_app_state_converter.cpp
@@ -137,9 +137,9 @@ void MmeNasStateConverter::guti_table_to_proto(
       OAILOG_ERROR(
           LOG_MME_APP, "Key %s not in guti_ue_context_htbl", guti_str.c_str());
     }
-    OAILOG_DEBUG(
+    /*OAILOG_DEBUG(
         LOG_MME_APP, "guti_str:%s mme_ue_id:%lu\n", guti_str.c_str(),
-        mme_ue_id);
+        mme_ue_id);*/
   }
   FREE_OBJ_HASHTABLE_KEY_ARRAY(key_array_p);
 }

--- a/lte/gateway/c/oai/tasks/nas/emm/Attach.c
+++ b/lte/gateway/c/oai/tasks/nas/emm/Attach.c
@@ -284,6 +284,26 @@ int emm_proc_attach_request(
    */
   mme_app_desc_t* mme_app_desc_p = get_mme_nas_state(false);
   ue_mm_context                  = mme_ue_context_exists_mme_ue_s1ap_id(ue_id);
+  if (!ue_mm_context) {
+    OAILOG_ERROR_UE(
+        LOG_NAS_EMM, ue_ctx.emm_context._imsi64,
+        "EMM-PROC - Sending Attach Reject for ue_id = " MME_UE_S1AP_ID_FMT "\n",
+        ue_id);
+    struct nas_emm_attach_proc_s no_attach_proc = {0};
+    no_attach_proc.ue_id                        = ue_id;
+    no_attach_proc.emm_cause                    = ue_ctx.emm_context.emm_cause;
+    no_attach_proc.esm_msg_out                  = NULL;
+    ue_ctx.emm_context.emm_cause = EMM_CAUSE_UE_IDENTITY_CANT_BE_DERIVED_BY_NW;
+    rc                           = _emm_attach_reject(
+        &ue_ctx.emm_context, (struct nas_base_proc_s*) &no_attach_proc);
+    increment_counter(
+        "ue_attach", 1, 2, "result", "failure", "cause",
+        "ue_context_not_found");
+    if (ies) {
+      free_emm_attach_request_ies((emm_attach_request_ies_t * * const) & ies);
+    }
+    OAILOG_FUNC_RETURN(LOG_NAS_EMM, rc);
+  }
   // if is_mm_ctx_new==TRUE then ue_mm_context should always be not NULL
 
   // Actually uplink_nas_transport is sent from S1AP task to NAS task without

--- a/lte/gateway/c/oai/tasks/s1ap/s1ap_mme.c
+++ b/lte/gateway/c/oai/tasks/s1ap/s1ap_mme.c
@@ -501,6 +501,7 @@ ue_description_t* s1ap_new_ue(
   }
   // Increment number of UE
   enb_ref->nb_ue_associated++;
+  OAILOG_DEBUG(LOG_S1AP, "Num ue associated: %d on assoc id:%d", enb_ref->nb_ue_associated, sctp_assoc_id);
   return ue_ref;
 }
 
@@ -547,10 +548,12 @@ void s1ap_remove_ue(s1ap_state_t* state, ue_description_t* ue_ref) {
       &imsi64);
   delete_s1ap_ue_state(imsi64);
 
-  if (!enb_ref->nb_ue_associated) {
+  OAILOG_DEBUG(LOG_S1AP, "Num UEs associated %u num ue_id_coll %zu", enb_ref->nb_ue_associated, enb_ref->ue_id_coll.num_elements);
+  if ((!enb_ref->nb_ue_associated) || (enb_ref->ue_id_coll.num_elements == 0)) {
     if (enb_ref->s1_state == S1AP_RESETING) {
       OAILOG_INFO(LOG_S1AP, "Moving eNB state to S1AP_INIT \n");
       enb_ref->s1_state = S1AP_INIT;
+      enb_ref->nb_ue_associated = 0;
       set_gauge("s1_connection", 0, 1, "enb_name", enb_ref->enb_name);
       update_mme_app_stats_connected_enb_sub();
     } else if (enb_ref->s1_state == S1AP_SHUTDOWN) {

--- a/lte/gateway/c/oai/tasks/s1ap/s1ap_mme.c
+++ b/lte/gateway/c/oai/tasks/s1ap/s1ap_mme.c
@@ -501,7 +501,9 @@ ue_description_t* s1ap_new_ue(
   }
   // Increment number of UE
   enb_ref->nb_ue_associated++;
-  OAILOG_DEBUG(LOG_S1AP, "Num ue associated: %d on assoc id:%d", enb_ref->nb_ue_associated, sctp_assoc_id);
+  OAILOG_DEBUG(
+      LOG_S1AP, "Num ue associated: %d on assoc id:%d",
+      enb_ref->nb_ue_associated, sctp_assoc_id);
   return ue_ref;
 }
 
@@ -548,12 +550,13 @@ void s1ap_remove_ue(s1ap_state_t* state, ue_description_t* ue_ref) {
       &imsi64);
   delete_s1ap_ue_state(imsi64);
 
-  OAILOG_DEBUG(LOG_S1AP, "Num UEs associated %u num ue_id_coll %zu", enb_ref->nb_ue_associated, enb_ref->ue_id_coll.num_elements);
-  if ((!enb_ref->nb_ue_associated) || (enb_ref->ue_id_coll.num_elements == 0)) {
+  OAILOG_DEBUG(
+      LOG_S1AP, "Num UEs associated %u num ue_id_coll %zu",
+      enb_ref->nb_ue_associated, enb_ref->ue_id_coll.num_elements);
+  if (!enb_ref->nb_ue_associated) {
     if (enb_ref->s1_state == S1AP_RESETING) {
       OAILOG_INFO(LOG_S1AP, "Moving eNB state to S1AP_INIT \n");
       enb_ref->s1_state = S1AP_INIT;
-      enb_ref->nb_ue_associated = 0;
       set_gauge("s1_connection", 0, 1, "enb_name", enb_ref->enb_name);
       update_mme_app_stats_connected_enb_sub();
     } else if (enb_ref->s1_state == S1AP_SHUTDOWN) {

--- a/lte/gateway/c/oai/tasks/s1ap/s1ap_mme_handlers.c
+++ b/lte/gateway/c/oai/tasks/s1ap/s1ap_mme_handlers.c
@@ -437,9 +437,10 @@ int s1ap_mme_handle_s1_setup_request(
     OAILOG_WARNING(
         LOG_S1AP, "Ignoring s1setup from eNB in state %s on assoc id %u",
         s1_enb_state2str(enb_association->s1_state), assoc_id);
-   OAILOG_DEBUG(
-       LOG_S1AP, "Num UEs associated %u num ue_id_coll %zu",
-       enb_association->nb_ue_associated, enb_association->ue_id_coll.num_elements);
+    OAILOG_DEBUG(
+        LOG_S1AP, "Num UEs associated %u num ue_id_coll %zu",
+        enb_association->nb_ue_associated,
+        enb_association->ue_id_coll.num_elements);
     rc = s1ap_mme_generate_s1_setup_failure(
         assoc_id, S1ap_Cause_PR_transport,
         S1ap_CauseTransport_transport_resource_unavailable,

--- a/lte/gateway/c/oai/tasks/s1ap/s1ap_mme_handlers.c
+++ b/lte/gateway/c/oai/tasks/s1ap/s1ap_mme_handlers.c
@@ -2227,8 +2227,9 @@ int s1ap_handle_sctp_disconnection(
   OAILOG_INFO(
       LOG_S1AP,
       "SCTP disconnection request for association id %u, Reset Flag = "
-      "%u. Connected UEs = %u \n",
-      assoc_id, reset, enb_association->nb_ue_associated);
+      "%u. Connected UEs = %u Num elements = %zu\n",
+      assoc_id, reset, enb_association->nb_ue_associated,
+      enb_association->ue_id_coll.num_elements);
 
   // First check if we can just reset the eNB state if there are no UEs
   if (!enb_association->nb_ue_associated) {

--- a/lte/gateway/c/oai/tasks/s1ap/s1ap_mme_handlers.c
+++ b/lte/gateway/c/oai/tasks/s1ap/s1ap_mme_handlers.c
@@ -437,6 +437,9 @@ int s1ap_mme_handle_s1_setup_request(
     OAILOG_WARNING(
         LOG_S1AP, "Ignoring s1setup from eNB in state %s on assoc id %u",
         s1_enb_state2str(enb_association->s1_state), assoc_id);
+   OAILOG_DEBUG(
+       LOG_S1AP, "Num UEs associated %u num ue_id_coll %zu",
+       enb_association->nb_ue_associated, enb_association->ue_id_coll.num_elements);
     rc = s1ap_mme_generate_s1_setup_failure(
         assoc_id, S1ap_Cause_PR_transport,
         S1ap_CauseTransport_transport_resource_unavailable,

--- a/lte/gateway/c/oai/tasks/s1ap/s1ap_mme_nas_procedures.c
+++ b/lte/gateway/c/oai/tasks/s1ap/s1ap_mme_nas_procedures.c
@@ -1103,6 +1103,10 @@ void s1ap_handle_mme_ue_id_notification(
           ue_ref->comp_s1ap_id);
 
       OAILOG_DEBUG(
+          LOG_S1AP, "Num elements in ue_id_coll %zu and num ue associated %u",
+          enb_ref->ue_id_coll.num_elements, enb_ref->nb_ue_associated);
+
+      OAILOG_DEBUG(
           LOG_S1AP,
           "Associated sctp_assoc_id %d, enb_ue_s1ap_id " ENB_UE_S1AP_ID_FMT
           ", mme_ue_s1ap_id " MME_UE_S1AP_ID_FMT ":%s \n",

--- a/lte/gateway/python/integ_tests/s1aptests/s1ap_wrapper.py
+++ b/lte/gateway/python/integ_tests/s1aptests/s1ap_wrapper.py
@@ -52,7 +52,7 @@ class TestWrapper(object):
     # Decreasing the mask value will provide more UE IP addresses in the free
     # IP address pool
     TEST_IP_BLOCK = "192.168.128.0/24"
-    MSX_S1_RETRY = 2
+    MSX_S1_RETRY = 5
 
     def __init__(
         self,
@@ -132,6 +132,9 @@ class TestWrapper(object):
     def _issue_s1setup_req(self):
         """ Issue the actual setup request and get the response"""
         req = None
+        print(
+                "Sending S1-Setup-Request"
+            )
         assert (
             self._s1_util.issue_cmd(s1ap_types.tfwCmd.ENB_S1_SETUP_REQ, req)
             == 0

--- a/lte/gateway/python/integ_tests/s1aptests/s1ap_wrapper.py
+++ b/lte/gateway/python/integ_tests/s1aptests/s1ap_wrapper.py
@@ -52,7 +52,7 @@ class TestWrapper(object):
     # Decreasing the mask value will provide more UE IP addresses in the free
     # IP address pool
     TEST_IP_BLOCK = "192.168.128.0/24"
-    MSX_S1_RETRY = 5
+    MSX_S1_RETRY = 2
 
     def __init__(
         self,
@@ -132,9 +132,6 @@ class TestWrapper(object):
     def _issue_s1setup_req(self):
         """ Issue the actual setup request and get the response"""
         req = None
-        print(
-                "Sending S1-Setup-Request"
-            )
         assert (
             self._s1_util.issue_cmd(s1ap_types.tfwCmd.ENB_S1_SETUP_REQ, req)
             == 0

--- a/lte/protos/oai/s1ap_state.proto
+++ b/lte/protos/oai/s1ap_state.proto
@@ -33,7 +33,7 @@ message EnbDescription {
   uint32 instreams = 8;        // sctp_stream_id_t
   uint32 outstreams = 9;      // sctp_stream_id_t
 
-  map<uint64, uint64> ue_ids = 10; // enb_ue_s1ap_id -> comp_s1ap_id
+  map<uint64, uint64> ue_ids = 10; // mme_ue_s1ap_id -> comp_s1ap_id
   SupportedTaList supported_ta_list = 11; // TAs supported by eNB
   bytes ran_cp_ipaddr = 12; // eNB sctp end point IP addr
   uint32 ran_cp_ipaddr_sz = 13; // eNB sctp end point IP addr size


### PR DESCRIPTION
## Summary

While running `test_continuous_random_attach.py` multiple times, we see Sctp reset event in Sctpd logs, which sets the eNB state to S1AP_RESETTING and gets stuck there (https://github.com/magma/magma/issues/4636) . This occurs because the S1AP task tracks two metrics for eNB:
1. nb_ue_associated = incremented on each Initial UE message, 
2. ue_id_coll.num_elements = incremented once MME allocates an MME_UE_S1AP_ID for the UE. 
If these two counts are out of sync when the Reset is received, then it never recovers

This change partially fixes the issue by:
- Adding clean up of old enb_ue_s1ap_id entries in MME hashtables when mme_ue_context_update_ue_sig_connection_state is called with both and new ECM state as IDLE 
[mme_sctp_reset3.log.zip](https://github.com/magma/magma/files/5960655/mme_sctp_reset3.log.zip)

- Fix seg fault when Attach request comes in NAS UL transport while ue_context is null (as defined in https://github.com/magma/magma/issues/4645)

Some scenarios of Sctp reset are still failing: 
[mme_sctp_reset5.log.zip](https://github.com/magma/magma/files/5960662/mme_sctp_reset5.log.zip)

```
 Entering s1ap_handle_sctp_disconnection()
14951 014238 Wed Feb 10 09:12:08 2021 7F4B71F91700 INFO  S1AP   tasks/s1ap/s1ap_mme_handlers.c  :2182      SCTP disconnection request for association id 56, Reset Flag = 1. Connected UEs = 8 Num elements = 5
14952 014239 Wed Feb 10 09:12:08 2021 7F4B71F91700 TRACE S1AP   tasks/s1ap/s1ap_mme_handlers.c  :2128      No valid UE provided in callback: (nil)
14953 014240 Wed Feb 10 09:12:08 2021 7F4B71F91700 TRACE S1AP   tasks/s1ap/s1ap_mme_handlers.c  :2128      No valid UE provided in callback: (nil)
14954 014241 Wed Feb 10 09:12:08 2021 7F4B71F91700 TRACE S1AP   tasks/s1ap/s1ap_mme_handlers.c  :2128      No valid UE provided in callback: (nil)
14955 014242 Wed Feb 10 09:12:08 2021 7F4B71F91700 TRACE S1AP   tasks/s1ap/s1ap_mme_handlers.c  :2128      No valid UE provided in callback: (nil)
14956 014243 Wed Feb 10 09:12:08 2021 7F4B71F91700 TRACE S1AP   tasks/s1ap/s1ap_mme_handlers.c  :2128      No valid UE provided in callback: (nil)
14957 014244 Wed Feb 10 09:12:08 2021 7F4B71F91700 INFO  S1AP   tasks/s1ap/s1ap_mme_handlers.c  :2229      Marked enb s1 status to Reset, attached to assoc_id: 56
```

## Test Plan

Ran `test_continuous_random_attach.py` over 10 times, seeing 5 Sctp reset events. The next run of the test recovered in 3 out of 5 instances. Two cases are still failing with the "No valid UE" error mentioned above

Sanity check with `make integ_test`