### PR TITLE
[lte][agw] fix package management issues for magma .deb

### DIFF
--- a/lte/gateway/deploy/roles/ovs_deploy/tasks/main.yml
+++ b/lte/gateway/deploy/roles/ovs_deploy/tasks/main.yml
@@ -127,6 +127,7 @@
   become: yes
   apt:
     name: "{{ packages }}"
+    dpkg_options: 'force-confold,force-confdef,force-overwrite'
   vars:
     packages:
       - magma

--- a/lte/gateway/release/build-magma.sh
+++ b/lte/gateway/release/build-magma.sh
@@ -165,7 +165,11 @@ POSTINST=${RELEASE_DIR}/magma-postinst
 
 # python environment
 # python3.5 on stretch, python3.8 on focal
-PY_VERSION=python3
+if grep -q stretch /etc/os-release; then
+    PY_VERSION=python3.5
+else
+    PY_VERSION=python3.8
+fi
 PY_PKG_LOC=dist-packages
 PY_DEST=/usr/local/lib/${PY_VERSION}/${PY_PKG_LOC}
 PY_PROTOS=${PYTHON_BUILD}/gen/


### PR DESCRIPTION
## Summary
python3 sys.path on debian system by default includes
`/usr/local/lib/python3.<MINOR>/dist-packages/`
but not
`/usr/local/lib/python3/dist-packages/`

apply `force-overwrite` dpkg option to ovs_deploy ansible role
to allow magma package to control rsyslog logrotate

## Test Plan
* verify magma package installs on magma_prod vm
* verify magma services start on magma_prod vm
## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
