### PR TITLE
[NMS] Fix edit tabs

### DIFF
--- a/nms/app/packages/magmalte/app/views/equipment/EnodebDetailConfigEdit.js
+++ b/nms/app/packages/magmalte/app/views/equipment/EnodebDetailConfigEdit.js
@@ -161,7 +161,6 @@ function EnodeEditDialog(props: DialogProps) {
   const onClose = () => {
     // clear existing state
     setEnb({});
-    setTabPos(0);
     props.onClose();
   };
 

--- a/nms/app/packages/magmalte/app/views/equipment/GatewayDetailConfigEdit.js
+++ b/nms/app/packages/magmalte/app/views/equipment/GatewayDetailConfigEdit.js
@@ -230,7 +230,6 @@ function GatewayEditDialog(props: DialogProps) {
   const ctx = useContext(GatewayContext);
   const onClose = () => {
     setGateway({});
-    setTabPos(0);
     props.onClose();
   };
 

--- a/nms/app/packages/magmalte/app/views/network/NetworkEdit.js
+++ b/nms/app/packages/magmalte/app/views/network/NetworkEdit.js
@@ -133,7 +133,6 @@ export function NetworkEditDialog(props: DialogProps) {
   }, [open, editProps, ctx.state]);
 
   const onClose = () => {
-    setTabPos(0);
     props.onClose();
   };
 

--- a/nms/app/packages/magmalte/app/views/subscriber/SubscriberAddDialog.js
+++ b/nms/app/packages/magmalte/app/views/subscriber/SubscriberAddDialog.js
@@ -338,7 +338,6 @@ export function SubscriberEditDialog(props: DialogProps) {
   }, [props.editProps]);
 
   const onClose = () => {
-    setTabPos(0);
     props.onClose();
   };
 

--- a/nms/app/packages/magmalte/app/views/traffic/PolicyEdit.js
+++ b/nms/app/packages/magmalte/app/views/traffic/PolicyEdit.js
@@ -144,7 +144,6 @@ export default function PolicyRuleEditDialog(props: Props) {
   };
 
   const onClose = () => {
-    setTabPos(0);
     props.onClose();
   };
 


### PR DESCRIPTION
Signed-off-by: HannaFar <hannafarag159@gmail.com>


## Summary

Fix edit tabs. We were always setting edit tab to 0 (first tab) when we closed edit modal.

## Test Plan


## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
