### PR TITLE
[orc8r] Fix the default search field for searching orc8r logs

### DIFF
--- a/orc8r/cloud/go/services/analytics/calculations/log_calculations.go
+++ b/orc8r/cloud/go/services/analytics/calculations/log_calculations.go
@@ -13,7 +13,7 @@ import (
 
 const (
 	sortTag         = "@timestamp"
-	defaultLogField = "message"
+	defaultLogField = "log"
 )
 
 // LogsMetricCalculation defines new metric calculation based on querying


### PR DESCRIPTION
Signed-off-by: Karthik Subraveti <ksubraveti@fb.com>

## Summary

The default field was incorrect. Fixing that from "message" -> "log"

## Test Plan
```
root@orc8r-orchestrator-6b5864f86f-h9fhl:/# curl -XGET "vpc-tf-symphony-staging.eu-west-1.es.amazonaws.com/_count?pretty" -H 'Content-Type: application/json' -d'{  "query": {    "bool": {    "filter" : [        {"simple_query_string" : {"query": "error", "fields" : ["message"]}},        {"term": {"kubernetes.container_name": "subscriberdb"}}    ]    }  }}'
{
  "count" : 0,
  "_shards" : {
    "total" : 373,
    "successful" : 373,
    "skipped" : 0,
    "failed" : 0
  }
}
root@orc8r-orchestrator-6b5864f86f-h9fhl:/# curl -XGET "vpc-tf-symphony-staging.eu-west-1.es.amazonaws.com/_count?pretty" -H 'Content-Type: application/json' -d'{  "query": {    "bool": {    "filter" : [        {"simple_query_string" : {"query": "error", "fields" : ["log"]}},        {"term": {"kubernetes.container_name": "subscriberdb"}}    ]    }  }}'
{
  "count" : 2,
  "_shards" : {
    "total" : 373,
    "successful" : 373,
    "skipped" : 0,
    "failed" : 0
  }
}
```
## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
