### PR TITLE
[AGW][Stateless MME] Assert whenever eNB state is corrupted and Sctp reset is received

### DIFF
--- a/lte/gateway/c/oai/tasks/s1ap/s1ap_mme_handlers.c
+++ b/lte/gateway/c/oai/tasks/s1ap/s1ap_mme_handlers.c
@@ -2262,6 +2262,18 @@ int s1ap_handle_sctp_disconnection(
     OAILOG_FUNC_RETURN(LOG_S1AP, RETURNok);
   }
 
+  if (reset) {
+    // Check if the UE counters for eNB are equal.
+    // If note, the eNB will never switch to INIT state, particularly in
+    // stateless mode.
+    // Exit the process so that health checker can clean-up all Redis
+    // state and restart all stateless services.
+    AssertFatal(
+        enb_association->nb_ue_associated ==
+            enb_association->ue_id_coll.num_elements,
+        "Num UEs associated with eNB is more than the UEs with valid "
+        "mme_ue_s1ap_id, the eNB will never recover from this. Asserting.");
+  }
   /*
    * Send S1ap deregister indication to MME app in batches of UEs where
    * UE count in each batch <= S1AP_ITTI_UE_PER_DEREGISTER_MESSAGE

--- a/lte/gateway/c/oai/tasks/s1ap/s1ap_mme_handlers.c
+++ b/lte/gateway/c/oai/tasks/s1ap/s1ap_mme_handlers.c
@@ -447,6 +447,21 @@ int s1ap_mme_handle_s1_setup_request(
         S1ap_TimeToWait_v20s);
     increment_counter(
         "s1_setup", 1, 2, "result", "failure", "cause", "invalid_state");
+    // Check if the UE counters for eNB are equal.
+    // If not, the eNB will never switch to INIT state, particularly in
+    // stateless mode.
+    // Exit the process so that health checker can clean-up all Redis
+    // state and restart all stateless services.
+    AssertFatal(
+        enb_association->nb_ue_associated ==
+            enb_association->ue_id_coll.num_elements,
+        "Num UEs associated with eNB (%u) is more than the UEs with valid "
+        "mme_ue_s1ap_id (%zu). This is a deadlock state potentially caused by "
+        "misbehaving eNB; restarting MME. In stateless mode, health management "
+        "service will eventually detect multiple MME restarts due to this "
+        "deadlock state and force sctpd and hence all services to restart.",
+        enb_association->nb_ue_associated,
+        enb_association->ue_id_coll.num_elements);
     OAILOG_FUNC_RETURN(LOG_S1AP, rc);
   }
   log_queue_item_t* context = NULL;
@@ -2180,6 +2195,7 @@ bool s1ap_send_enb_deregistered_ind(
     *resultP = arg->message_p;
   } else {
     OAILOG_TRACE(LOG_S1AP, "No valid UE provided in callback: %p\n", ue_ref_p);
+    AssertFatal(0, "No valid UE while creating S1AP_ENB_DEREGISTERED_IND");
   }
   return false;
 }
@@ -2264,15 +2280,20 @@ int s1ap_handle_sctp_disconnection(
 
   if (reset) {
     // Check if the UE counters for eNB are equal.
-    // If note, the eNB will never switch to INIT state, particularly in
+    // If not, the eNB will never switch to INIT state, particularly in
     // stateless mode.
     // Exit the process so that health checker can clean-up all Redis
     // state and restart all stateless services.
     AssertFatal(
         enb_association->nb_ue_associated ==
             enb_association->ue_id_coll.num_elements,
-        "Num UEs associated with eNB is more than the UEs with valid "
-        "mme_ue_s1ap_id, the eNB will never recover from this. Asserting.");
+        "Num UEs associated with eNB (%u) is more than the UEs with valid "
+        "mme_ue_s1ap_id (%zu). This is a deadlock state potentially caused by "
+        "misbehaving eNB; restarting MME. In stateless mode, health management "
+        "service will eventually detect multiple MME restarts due to this "
+        "deadlock state and force sctpd and hence all services to restart.",
+        enb_association->nb_ue_associated,
+        enb_association->ue_id_coll.num_elements);
   }
   /*
    * Send S1ap deregister indication to MME app in batches of UEs where


### PR DESCRIPTION
## Summary

The eNB state in S1AP task gets into S1AP_RESETTING mode on getting an SCTP reset event. As described in https://github.com/magma/magma/pull/4861 , if the UE counters are out of sync when such event happens, the eNB never moves back to S1AP_INIT mode and all S1 Setup Requests are rejected. This change provides a catch all solution to this issue by forcing the MME to assert and letting the health service restart Sctpd to clean Redis and break the deadlock.

It also asserts if the UE object is null while creating the deregister indication.

## Test Plan

- Sanity check with `make integ_test`
- Run `test_continuous_random_attach.py` multiple times and verify that MME asserts while handling Sctp reset and Redis state is eventually cleared. 
On magma VM:

```
vagrant@magma-dev:~$ sudo journalctl -u sctpd -u magma@mme -u magma@health | grep "reset\|Assert\|Started\|restarting sctpd"
Feb 10 22:28:31 magma-dev sctpd[29856]: I0210 22:28:31.138128 30133 sctp_connection.cpp:296] Handling sctp reset
Feb 10 22:28:31 magma-dev mme[2052]: Assertion (enb_association->nb_ue_associated == enb_association->ue_id_coll.num_elements) failed!
Feb 10 22:28:31 magma-dev mme[2052]: Num UEs associated with eNB (50) is more than the UEs with valid mme_ue_s1ap_id (12), the eNB will never recover from this. Asserting.
Feb 10 22:28:48 magma-dev systemd[1]: Started Magma OAI MME service.
Feb 10 22:29:50 magma-dev sctpd[29856]: I0210 22:29:50.272719 30133 sctp_connection.cpp:296] Handling sctp reset
Feb 10 22:29:50 magma-dev mme[3840]: Assertion (enb_association->nb_ue_associated == enb_association->ue_id_coll.num_elements) failed!
Feb 10 22:29:50 magma-dev mme[3840]: Num UEs associated with eNB (50) is more than the UEs with valid mme_ue_s1ap_id (12), the eNB will never recover from this. Asserting.
Feb 10 22:30:04 magma-dev systemd[1]: Started Magma OAI MME service.
Feb 10 22:31:25 magma-dev sctpd[29856]: I0210 22:31:25.629892 30133 sctp_connection.cpp:296] Handling sctp reset
Feb 10 22:31:25 magma-dev mme[5311]: Assertion (enb_association->nb_ue_associated == enb_association->ue_id_coll.num_elements) failed!
Feb 10 22:31:25 magma-dev mme[5311]: Num UEs associated with eNB (50) is more than the UEs with valid mme_ue_s1ap_id (12), the eNB will never recover from this. Asserting.
Feb 10 22:31:42 magma-dev systemd[1]: Started Magma OAI MME service.
Feb 10 22:32:17 magma-dev systemd[1]: Started Magma OAI MME service.
Feb 10 22:33:41 magma-dev mme[7965]: Assertion (0) failed!
Feb 10 22:33:55 magma-dev systemd[1]: Started Magma OAI MME service.
Feb 10 22:34:16 magma-dev systemd[1]: Started Magma OAI MME service.
Feb 10 22:35:13 magma-dev sctpd[29856]: I0210 22:35:13.397742 30133 sctp_connection.cpp:296] Handling sctp reset
Feb 10 22:35:13 magma-dev mme[10278]: Assertion (enb_association->nb_ue_associated == enb_association->ue_id_coll.num_elements) failed!
Feb 10 22:35:13 magma-dev mme[10278]: Num UEs associated with eNB (22) is more than the UEs with valid mme_ue_s1ap_id (0), the eNB will never recover from this. Asserting.
Feb 10 22:35:33 magma-dev systemd[1]: Started Magma OAI MME service.
Feb 10 22:36:03 magma-dev health[8700]: INFO:root:Service mme has failed 3 times over last 180 seconds, restarting sctpd to clean state...
Feb 10 22:36:06 magma-dev systemd[1]: Started Magma sctpd service.
Feb 10 22:36:11 magma-dev systemd[1]: Started Magma OAI MME service.
```
