### PR TITLE
[NMS] Add remediation for few predefined alerts

### DIFF
--- a/nms/app/packages/magmalte/alerts/lteAlerts.js
+++ b/nms/app/packages/magmalte/alerts/lteAlerts.js
@@ -56,6 +56,23 @@ export default function getLteAlerts(
         description: 'Alerts when we have unexpected service restarts',
       },
     },
+    'Service Crashlooping Alert': {
+      alert: 'Service Crashlooping Alert',
+      expr: `increase(unexpected_service_restarts{networkID=~"${networkID}"}[5m]) > 3`,
+      labels: {severity: 'critical'},
+      annotations: {
+        description: 'Alerts when we have services crashlooping',
+      },
+    },
+    'Sctpd Crashlooping Alert': {
+      alert: 'Sctpd Crashlooping Alert',
+      expr: `increase(unexpected_service_restarts{networkID=~"${networkID}", service_name="sctpd"}[5m]) > 3`,
+      labels: {severity: 'critical'},
+      annotations: {
+        description: 'Alerts when we have sctpd service crashlooping',
+        remediation: 'Reboot the gateway',
+      },
+    },
     'Bootstrap Exception Alert': {
       alert: 'Bootstrap Exception Alert',
       expr: `increase(bootstrap_exception{networkID=~"${networkID}"}[5m]) > 0`,
@@ -74,7 +91,10 @@ export default function getLteAlerts(
       alert: 'S1 Setup Failure',
       expr: `increase(s1_setup{result="failure", networkID=~"${networkID}"}[5m]) > 0`,
       labels: {severity: 'major'},
-      annotations: {description: 'Alerts when we have S1 setup failures'},
+      annotations: {
+        description: 'Alerts when we have S1 setup failures',
+        remediation: 'Restart sctpd service',
+      },
     },
     'UE attach Failure': {
       alert: 'UE attach Failure',
@@ -86,7 +106,11 @@ export default function getLteAlerts(
       alert: 'Gateway Checkin Failure',
       expr: `checkin_status{networkID=~"${networkID}"} < 1`,
       labels: {severity: 'critical'},
-      annotations: {description: 'Alerts when we have gateway checkin failure'},
+      annotations: {
+        description: 'Alerts when we have gateway checkin failure',
+        troubleshooting:
+          'Run checkin_cli.py script on the gateway and follow resolution steps suggested',
+      },
     },
     'Dip in Connected UEs': {
       alert: 'Dip in Connected UEs',

--- a/nms/app/packages/magmalte/app/components/DashboardAlertTable.js
+++ b/nms/app/packages/magmalte/app/components/DashboardAlertTable.js
@@ -261,7 +261,7 @@ function TabPanel(props: TabPanelProps) {
     <ActionTable
       data={props.alerts}
       columns={[
-        {title: 'Date', field: 'date', type: 'datetime'},
+        {title: 'Date', field: 'date', type: 'datetime', defaultSort: 'desc'},
         {title: 'Status', field: 'status', width: 200},
         {title: 'Alert Name', field: 'alertName', width: 200},
         {title: 'Service', field: 'service', width: 200},


### PR DESCRIPTION
Signed-off-by: Karthik Subraveti <ksubraveti@fb.com>


## Summary
- Add remediation for S1 setup failure, gateway checkin alert
- Add critical alerts for large number of unexpected service restarts within 5 minutes

## Test Plan
For e.g. it will look as follows
<img width="1680" alt="Screen Shot 2021-02-10 at 3 48 06 PM" src="https://user-images.githubusercontent.com/8224854/107588116-ea5bbd00-6bb7-11eb-932d-77bb6fea42e8.png">

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
