### PR TITLE
[lte][agw] Disabling magma@health while running s1ap tests

### DIFF
--- a/lte/gateway/python/integ_tests/s1aptests/s1ap_utils.py
+++ b/lte/gateway/python/integ_tests/s1aptests/s1ap_utils.py
@@ -736,6 +736,24 @@ class MagmadUtil(object):
         """
         self._magmad_client.restart_services(services)
 
+    def enable_service(self, service):
+        """
+        Enables a magma service on magma_dev VM and starts it
+        Args:
+            service: (str) service to stop
+        """
+        self.exec_command("sudo systemctl unmask magma@{}".format(service))
+        self.exec_command("sudo systemctl start magma@{}".format(service))
+
+    def disable_service(self, service):
+        """
+        Disables a magma service on magma_dev VM, preventing from starting again
+        Args:
+            service: (str) service to stop
+        """
+        self.exec_command("sudo systemctl mask magma@{}".format(service))
+        self.exec_command("sudo systemctl stop magma@{}".format(service))
+
     def update_mme_config_for_sanity(self, cmd):
         mme_config_update_script = (
             "/home/vagrant/magma/lte/gateway/deploy/roles/magma/files/"

--- a/lte/gateway/python/integ_tests/s1aptests/test_modify_mme_config_for_sanity.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_modify_mme_config_for_sanity.py
@@ -37,6 +37,9 @@ class TestModifyMMEConfigForSanity(unittest.TestCase):
         print("Restarting services to apply configuration change")
         self._magmad_util.restart_all_services()
 
+        print("Stopping and disabling magma@health service")
+        self._magmad_util.disable_service("health")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/lte/gateway/python/integ_tests/s1aptests/test_restore_mme_config_after_sanity.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_restore_mme_config_after_sanity.py
@@ -38,6 +38,10 @@ class TestRestoreMMEConfigAfterSanity(unittest.TestCase):
             MagmadUtil.config_update_cmds.RESTORE
         )
 
+        print("Enabling magma@health service")
+        self._magmad_util.enable_service("health")
+
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Signed-off-by: Alex Rodriguez <ardzoht@gmail.com>

## Summary

- magma@health can intervene while running the s1ap tests related with service restarts due to indirect failures with services, this PR disables such service while running the tests

## Test Plan

- tested locally by running `make integ_test`

## Additional Information

- [ ] This change is backwards-breaking

