### PR TITLE
Modified code to properly convert GUTI in UE context

### DIFF
--- a/lte/gateway/c/oai/tasks/nas/nas_state_converter.cpp
+++ b/lte/gateway/c/oai/tasks/nas/nas_state_converter.cpp
@@ -34,7 +34,19 @@ NasStateConverter::~NasStateConverter() = default;
 
 void NasStateConverter::proto_to_guti(
     const oai::Guti& guti_proto, guti_t* state_guti) {
-  memcpy(&state_guti->gummei.plmn, (guti_proto.plmn()).c_str(), sizeof(plmn_t));
+  state_guti->gummei.plmn.mcc_digit1 =
+      ((int) guti_proto.plmn()[0]) - ASCII_ZERO;
+  state_guti->gummei.plmn.mcc_digit2 =
+      ((int) guti_proto.plmn()[1]) - ASCII_ZERO;
+  state_guti->gummei.plmn.mcc_digit3 =
+      ((int) guti_proto.plmn()[2]) - ASCII_ZERO;
+  state_guti->gummei.plmn.mnc_digit1 =
+      ((int) guti_proto.plmn()[3]) - ASCII_ZERO;
+  state_guti->gummei.plmn.mnc_digit2 =
+      ((int) guti_proto.plmn()[4]) - ASCII_ZERO;
+  state_guti->gummei.plmn.mnc_digit3 =
+      ((int) guti_proto.plmn()[5]) - ASCII_ZERO;
+
   state_guti->gummei.mme_gid  = guti_proto.mme_gid();
   state_guti->gummei.mme_code = guti_proto.mme_code();
   state_guti->m_tmsi          = (tmsi_t) guti_proto.m_tmsi();


### PR DESCRIPTION
[lte][agw]: Modified code to properly convert GUTI in UE context

## Summary
Issue description: For test case, test_attach_detach_with_mme-restart.py guti hash table entries were not completely cleared. This is because, when mme restart, mme reads data from Redis DB, during conversion guti was copied as string, due to which during deletion guti value was not matching and not removed from hash table.
Fix: Modified the conversion of guti with consideration of ascii values. With this change, during deletion guti value matches and is removed from hash table
## Test Plan
Executed s1ap sanity test suite