### PR TITLE
[AGW][Stateless] Restart Open vSwitch service on Sctpd restart

### DIFF
--- a/lte/gateway/python/scripts/config_stateless_agw.py
+++ b/lte/gateway/python/scripts/config_stateless_agw.py
@@ -163,7 +163,11 @@ def sctpd_pre_start():
         # switching from stateless to stateful
         print("AGW is stateful, nothing to be done")
     else:
+        # Clean up all mobilityd, MME, pipelined and sessiond Redis keys
         clear_redis_state()
+        # Clean up OVS flows
+        subprocess.call("service openvswitch-switch restart".split())
+
     sys.exit(0)
 
 


### PR DESCRIPTION
Signed-off-by: Shruti Sanadhya <ssanadhya@fb.com>

## Summary

The table 0 entries in OVS were not explicitly cleaned when Sctpd service restarts. This change fixes that by restarting Open vSwitch whenever Sctpd restarts.

## Test Plan

Run any test case, such as `test_attach_detach.py` to populate all the OVS flow tables and kill the test before completion. Next run `watch "sudo ovs-ofctl dump-flows gtp_br0 "` to monitor OVS flows and in a separate terminal run `sudo service sctpd restart`. The flows disappear while Sctpd is restarting and finally show only default flow rules for each table.

## Additional Information

- [x] This change is backwards-breaking

Please re-provision your Magma VM so that the latest `config_stateless_agw.py` is copied over into the VM.
