### PR TITLE
AGW: ubuntu: fix test-oai compilation.

### DIFF
--- a/lte/gateway/c/oai/test/CMakeLists.txt
+++ b/lte/gateway/c/oai/test/CMakeLists.txt
@@ -1,6 +1,7 @@
 find_package(Check REQUIRED)
 find_package(Threads REQUIRED)
 
+include_directories("/usr/src/googletest/googlemock/include/")
 set(MME_APP_UE_CONTEXT_IMSI_SRC
     test_mme_app_ue_context.c
 )

--- a/lte/gateway/c/oai/test/openflow/CMakeLists.txt
+++ b/lte/gateway/c/oai/test/openflow/CMakeLists.txt
@@ -3,6 +3,7 @@ add_compile_options(-std=c++11)
 set(OUTPUT_DIR "${CMAKE_CURRENT_BINARY_DIR}")
 
 include_directories("${PROJECT_SOURCE_DIR}/openflow/controller")
+link_directories(/usr/src/googletest/googlemock/lib/)
 add_executable(openflow_controller_test test_openflow_controller.cpp)
 add_executable(imsi_encoder_test test_imsi_encoder.cpp)
 add_executable(gtp_app_test test_gtp_app.cpp)
@@ -12,7 +13,7 @@ target_link_libraries(OPENFLOW_TEST
     COMMON
     lfds710
     LIB_OPENFLOW_CONTROLLER  LIB_BSTR LIB_HASHTABLE LIB_ITTI LIB_S1AP TASK_S1AP
-    gmock_main pthread rt)
+    gmock_main gtest gtest_main gmock pthread rt)
 
 set_target_properties(OPENFLOW_TEST PROPERTIES LINKER_LANGUAGE CXX)
 


### PR DESCRIPTION
This commit adds required gmock lib path.

Signed-off-by: Pravin B Shelar <pbshelar@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
