### PR TITLE
[lte][agw] Adding null check for ht keys on UEs context on stale eNB state

### DIFF
--- a/lte/gateway/c/oai/tasks/s1ap/s1ap_mme.c
+++ b/lte/gateway/c/oai/tasks/s1ap/s1ap_mme.c
@@ -563,7 +563,6 @@ void s1ap_remove_ue(s1ap_state_t* state, ue_description_t* ue_ref) {
       OAILOG_INFO(LOG_S1AP, "Deleting eNB \n");
       set_gauge("s1_connection", 0, 1, "enb_name", enb_ref->enb_name);
       s1ap_remove_enb(state, enb_ref);
-      update_mme_app_stats_connected_enb_sub();
     }
   }
 }
@@ -577,4 +576,5 @@ void s1ap_remove_enb(s1ap_state_t* state, enb_description_t* enb_ref) {
   hashtable_uint64_ts_destroy(&enb_ref->ue_id_coll);
   hashtable_ts_free(&state->enbs, enb_ref->sctp_assoc_id);
   state->num_enbs--;
+  update_mme_app_stats_connected_enb_sub();
 }

--- a/lte/gateway/c/oai/tasks/s1ap/s1ap_mme_handlers.c
+++ b/lte/gateway/c/oai/tasks/s1ap/s1ap_mme_handlers.c
@@ -339,15 +339,17 @@ void clean_stale_enb_state(
   // Remove the S1 context for UEs associated with old eNB association
   hashtable_key_array_t* keys =
       hashtable_uint64_ts_get_keys(&stale_enb_association->ue_id_coll);
-  ue_description_t* ue_ref = NULL;
-  for (int i = 0; i < keys->num_keys; i++) {
-    ue_ref = s1ap_state_get_ue_mmeid((mme_ue_s1ap_id_t) keys->keys[i]);
-    s1ap_remove_ue(state, ue_ref);
+  if (keys != NULL) {
+    ue_description_t* ue_ref = NULL;
+    for (int i = 0; i < keys->num_keys; i++) {
+      ue_ref = s1ap_state_get_ue_mmeid((mme_ue_s1ap_id_t) keys->keys[i]);
+      s1ap_remove_ue(state, ue_ref);
+    }
+    FREE_HASHTABLE_KEY_ARRAY(keys);
   }
-  FREE_HASHTABLE_KEY_ARRAY(keys);
+
   // Remove the old eNB association
   s1ap_remove_enb(state, stale_enb_association);
-  update_mme_app_stats_connected_enb_sub();
   OAILOG_DEBUG(LOG_S1AP, "Removed stale eNB and all associated UEs.");
 }
 
@@ -2257,7 +2259,6 @@ int s1ap_handle_sctp_disconnection(
 
       OAILOG_INFO(LOG_S1AP, "Removing eNB with association id %u \n", assoc_id);
       s1ap_remove_enb(state, enb_association);
-      update_mme_app_stats_connected_enb_sub();
     }
     OAILOG_FUNC_RETURN(LOG_S1AP, RETURNok);
   }


### PR DESCRIPTION
Signed-off-by: Alex Rodriguez <ardzoht@gmail.com>

## Summary

- Adding null check for keys on UEs coll hashtable for s1ap eNB association ref, as it can return NULL if the UE coll is not initialized / is empty

## Test Plan

- make integ_test

## Additional Information

- [ ] This change is backwards-breaking
