### PR TITLE
[CircleCI] Extend CircleCI LTE integration test timeout to b 2hrs instead of 1.5

### DIFF
--- a/circleci/fabfile.py
+++ b/circleci/fabfile.py
@@ -208,7 +208,7 @@ def _checkout_code(repo: str, branch: str, sha1: str, tag: str, pr_num: str,
 def _run_remote_lte_integ_test(repo: str, magma_root: str):
     repo_name = _get_repo_name(repo)
     with cd(f'{repo_name}/{magma_root}/lte/gateway'):
-        test_result = run('fab integ_test', timeout=90*60, warn_only=True)
+        test_result = run('fab integ_test', timeout=120*60, warn_only=True)
         # On failure, transfer logs from all 3 VMs and copy to the log
         # directory. This will get stored as an artifact in the CircleCI
         # config.


### PR DESCRIPTION
Signed-off-by: Marie Bremner <marwhal@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary
- We've recently a few more tests that made the overall integration test run longer
- I'm seeing a few integration test runs terminated due to the timeout instead of a failure: https://app.circleci.com/pipelines/github/magma/magma/14539/workflows/20ccfdc4-abae-422f-ac57-7a7a4e1c713c/jobs/132282
- We still have a separate configuration for a 20minute inactivity timer, so that is still in place.
<!-- Enumerate changes you made and why you made them -->

## Test Plan
Test in prod?
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
