### PR TITLE
AGW: envoy: delay envoy to let the controller boot up

### DIFF
--- a/lte/gateway/deploy/roles/magma/files/systemd/magma_dp_envoy.service
+++ b/lte/gateway/deploy/roles/magma/files/systemd/magma_dp_envoy.service
@@ -16,6 +16,8 @@ After=magma@envoy_controller.service
 [Service]
 Type=simple
 EnvironmentFile=/etc/environment
+# Add delay to let envoy-controller init
+ExecStartPre=/bin/sleep 40
 ExecStart=/sbin/ip netns exec envoy_ns1 /usr/bin/envoy --bootstrap-version 2 -c /var/opt/magma/envoy.yaml --log-path /var/log/envoy.log -l debug
 MemoryAccounting=yes
 StandardOutput=syslog


### PR DESCRIPTION
In case envoy controller is not ready, envoy gets into
crash loop. So it is safer to delay envoy init.

Signed-off-by: Pravin B Shelar <pbshelar@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
