### PR TITLE
[FluentBit][EventD] Add a retry option for select events

### DIFF
--- a/orc8r/gateway/configs/templates/td-agent-bit.conf.template
+++ b/orc8r/gateway/configs/templates/td-agent-bit.conf.template
@@ -3,6 +3,8 @@
     # =====
     # Set an interval of seconds before to flush records to a destination
     Flush        5
+    # Path for filesystem based buffering
+    storage.path /tmp/flb-storage
 
     # Daemon
     # ======
@@ -49,12 +51,19 @@
     Listen   0.0.0.0
     port     24224
 
+# Input from the EventD service
 [INPUT]
-    Name        tcp
-    Listen      0.0.0.0
-    Port        5170
-    Format      json
-    Tag eventd
+    Name          tcp
+    Alias         eventlogs
+    Listen        0.0.0.0
+    Port          5170
+    Format        json
+    Tag           eventd
+    # Set the maximum in-memory buffer to 5MB. We will use the filesystem once
+    # we exceed the limit. Since we retry forwarding for some events, we need
+    # to place a limit to avoid OOM.
+    mem_buf_limit 5MB
+    storage.type  filesystem
 
 {% for t,f in files %}
 [INPUT]
@@ -65,6 +74,12 @@
     Refresh_Interval 5
     Key message
 {% endfor %}
+
+# Modify eventd logs with retry-on-failure set
+[FILTER]
+    Name          rewrite_tag
+    Match         eventd
+    Rule          $retry_on_failure True $TAG.retry_on_failure false
 
 [FILTER]
     Name grep
@@ -86,9 +101,33 @@
     Window   {{ throttle_window }}
     Interval {{ throttle_interval}}
 
+# For any logs with retry_on_failure tag, set the retry limit to false
+# At the moment, this only applies to event logs with retry_on_failure flag set
 [OUTPUT]
     Name          forward
-    Match         *
+    Alias         eventlogs_with_retries
+    Match_Regex   ^(eventd).*(retry_on_failure).*$
+    Host          {{ host }}
+    Port          {{ port }}
+    # Re-tag as eventd so we don't affect FluentD
+    Tag           eventd
+    Retry_Limit   False
+
+    {% if is_tls_enabled %}
+    tls on
+    {% else %}
+    tls off
+    {% endif %}
+    tls.verify off
+    tls.debug 3
+    tls.ca_file {{ cacert }}
+    tls.crt_file {{ certfile }}
+    tls.key_file {{ keyfile }}
+
+# Everything else is forwarded without retry
+[OUTPUT]
+    Name          forward
+    Match_Regex   ^((?!retry_on_failure).)*$
     Host          {{ host }}
     Port          {{ port }}
 
@@ -104,6 +143,5 @@
     tls.key_file {{ keyfile }}
 
 [OUTPUT]
-    Name        stdout
-    Match       eventd
-
+    Name              stdout
+    Match_Regex       eventd*


### PR DESCRIPTION
Signed-off-by: Marie Bremner <marwhal@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary
TL;DR: Adding a new functionality for FluentBit to retry a certain set of logs on failure.

### Background on the existing event logging pipeline
There are essentially 3 steps that take place for an event to be reported from the AGW to Orc8r (FluentD).
* GW Service → EventD (Within GW)
    * via GRPC
    * Failure is propagated back to service
    * Possible failure causes
        * GRPC connection error (rare)
        * Event validation error (Probably due to misconfiguration)
* EventD → FluentBit (Within GW)
    * TCP
    * Failure is propagated back to the original GW service
    * Possible failure causes
        * FluentBit is not enabled (Config issue)
* FluentBit → FluentD (GW -> Orc8r)
    * TLS
    * Failure is ignored 
    * Possible failure causes
        * FluentD / Orc8r unreachable (**<== Trying to address this issue**)

### Background on how we implement CDRs (CDR=billing record per session)
CDRs in magma are implemented as an event, specifically `session_terminated` event owned by SessionD.

### So what's the problem? What's the solution? 
We want to do a bit better on making sure this CDR event makes it to the Orc8r even when the connection between FluentBit and FluentD fails unexpectedly. 
There's not an obvious way to report back connection failures to the original service, (SessionD in this case), so the solution in this PR utilizes the unlimited retry option. 
Since FluentBit uses a tag per message to route between filters and outputs, my solution involves adding an additional tag in events that need retries. This tag will be configured via EventD's service config in the event registry section. Based on this tag, FluentBit will re-route the message to an ouput that has unlimited retries configured. (See diagram below)
Additionally, there's some additional backlogging configs (5MB memory, the rest in filesystem) to make sure the messages that are being retried don't fill up memory. (Trying to avoid the OOM killer!) 
Helpful doc on backlogging: https://docs.fluentbit.io/manual/administration/buffering-and-storage

**I'm leaving the default configuration for all events as requiring NO RETRIES**

![Magma FluentBit Flow|250x190](https://user-images.githubusercontent.com/37634144/107833513-2417f980-6d59-11eb-967f-5c720167dbb0.png)


TODO
1. Add documentation for event logging + event persistence

## Test Plan
Running S1AP tests with orc8r disabled to produce event logs, then enabling to confirm the event logs made it to the Orc8r.
Run unit tests

(Note to self)
https://app.elasticvue.com/search + 
```
  elasticsearch:
    image: docker.elastic.co/elasticsearch/elasticsearch:7.3.1
    container_name: elasticsearch
    environment:
      - discovery.type=single-node
      - http.cors.enabled=true
      - http.cors.allow-origin=https://app.elasticvue.com
```
is a pretty easy way to test with elasticsearch

