### PR TITLE
[lte][agw] Remove redundant mme_app_handle_modify_bearer_rsp

### DIFF
--- a/lte/gateway/c/oai/tasks/mme_app/mme_app_bearer.c
+++ b/lte/gateway/c/oai/tasks/mme_app/mme_app_bearer.c
@@ -3795,9 +3795,6 @@ void mme_app_handle_modify_bearer_rsp(
               ue_context_p->mme_ue_s1ap_id);
           mme_app_handle_create_dedicated_bearer_rej(
               ue_context_p, ue_context_p->pending_ded_ber_req[idx]->linked_ebi);
-        } else{
-          // Added dedicated bearer successfully, update s1u bearer stats
-          update_mme_app_stats_s1u_bearer_add();
         }
       } else {
         mme_app_handle_create_dedicated_bearer_rej(

--- a/lte/gateway/c/oai/tasks/mme_app/mme_app_bearer.c
+++ b/lte/gateway/c/oai/tasks/mme_app/mme_app_bearer.c
@@ -3795,6 +3795,9 @@ void mme_app_handle_modify_bearer_rsp(
               ue_context_p->mme_ue_s1ap_id);
           mme_app_handle_create_dedicated_bearer_rej(
               ue_context_p, ue_context_p->pending_ded_ber_req[idx]->linked_ebi);
+        } else{
+          // Added dedicated bearer successfully, update s1u bearer stats
+          update_mme_app_stats_s1u_bearer_add();
         }
       } else {
         mme_app_handle_create_dedicated_bearer_rej(

--- a/lte/gateway/c/oai/tasks/mme_app/mme_app_main.c
+++ b/lte/gateway/c/oai/tasks/mme_app/mme_app_main.c
@@ -141,10 +141,6 @@ static int handle_message(zloop_t* loop, zsock_t* reader, void* arg) {
           mme_app_handle_modify_bearer_rsp(
               &received_message_p->ittiMsg.s11_modify_bearer_response,
               ue_context_p);
-          update_mme_app_stats_s1u_bearer_add();
-          mme_app_handle_modify_bearer_rsp(
-              &received_message_p->ittiMsg.s11_modify_bearer_response,
-              ue_context_p);
         } else {
           mme_app_handle_path_switch_req_ack(
               &received_message_p->ittiMsg.s11_modify_bearer_response,

--- a/lte/gateway/c/oai/tasks/mme_app/mme_app_main.c
+++ b/lte/gateway/c/oai/tasks/mme_app/mme_app_main.c
@@ -141,6 +141,7 @@ static int handle_message(zloop_t* loop, zsock_t* reader, void* arg) {
           mme_app_handle_modify_bearer_rsp(
               &received_message_p->ittiMsg.s11_modify_bearer_response,
               ue_context_p);
+          update_mme_app_stats_s1u_bearer_add();
         } else {
           mme_app_handle_path_switch_req_ack(
               &received_message_p->ittiMsg.s11_modify_bearer_response,


### PR DESCRIPTION
## Summary

- Remove redundant call to handler for modified bearer response (same function was called twice)

## Test Plan

integ tests

## Additional Information

- [ ] This change is backwards-breaking

