### PR TITLE
[NMS] Gateway create was failing because the dhcp_server_enabled wasn't present in the request

### DIFF
--- a/nms/app/packages/magmalte/app/components/GatewayUtils.js
+++ b/nms/app/packages/magmalte/app/components/GatewayUtils.js
@@ -235,6 +235,7 @@ export const DEFAULT_GATEWAY_CONFIG = {
   tier: 'default',
 };
 export const DEFAULT_DNS_CONFIG = {
+  dhcp_server_enabled: false,
   enable_caching: false,
   local_ttl: 0,
   records: [],


### PR DESCRIPTION
Signed-off-by: Karthik Subraveti <ksubraveti@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary

Gateway create was failing because the dhcp_server_enabled wasn't present in the request.
This fix adds the attribute as in the default dns config

## Test Plan
yarn test succeeds
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
