### PR TITLE
[NMS] Add dhcp_server_enabled attribute to default dns config

### DIFF
--- a/nms/app/packages/magmalte/app/views/equipment/GatewayDetailConfigEdit.js
+++ b/nms/app/packages/magmalte/app/views/equipment/GatewayDetailConfigEdit.js
@@ -786,6 +786,7 @@ export function EPCEdit(props: Props) {
 }
 
 const DEFAULT_DNS_CONFIG = {
+  dhcp_server_enabled: false,
   enable_caching: false,
   local_ttl: 0,
   records: [],


### PR DESCRIPTION
Signed-off-by: Karthik Subraveti <ksubraveti@fb.com>


## Summary

Add dhcp_server_enabled to default dns config

## Test Plan

yarn test works

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
