### PR TITLE
[orc8r] Fix targeted build deployment

### DIFF
--- a/docs/readmes/orc8r/development/testing_tips.md
+++ b/docs/readmes/orc8r/development/testing_tips.md
@@ -18,6 +18,10 @@ The set of subprojects is determined by the `MAGMA_MODULES` environment
 variable, which is defined during the container image build process. The
 default subprojects include `orc8r`, `lte`, `feg`, etc.
 
+By default, all subprojects are included in the build. If desired, you can
+use e.g. `build.py --deployment orc8r` to build a deployment-specific set of
+subprojects. This can reduce build time by up to 50%.
+
 ## Run tests on the host
 
 The normal way to run Orchestrator unit tests is `build.py --tests`. This

--- a/orc8r/cloud/docker/build.py
+++ b/orc8r/cloud/docker/build.py
@@ -42,16 +42,16 @@ MODULES = [
 
 DEPLOYMENT_TO_MODULES = {
     'all': MODULES,
-    'orc8r': [],
-    'orc8r-f': ['fbinternal'],
-    'fwa': ['lte'],
-    'fwa-f': ['lte', 'fbinternal'],
-    'ffwa': ['lte', 'feg'],
-    'ffwa-f': ['lte', 'feg', 'fbinternal'],
-    'cwf': ['lte', 'feg', 'cwf'],
-    'cwf-f': ['lte', 'feg', 'cwf', 'fbinternal'],
-    'wifi': ['wifi'],
-    'wifi-f': ['wifi', 'fbinternal'],
+    'orc8r': ['orc8r'],
+    'orc8r-f': ['orc8r', 'fbinternal'],
+    'fwa': ['orc8r', 'lte'],
+    'fwa-f': ['orc8r', 'lte', 'fbinternal'],
+    'ffwa': ['orc8r', 'lte', 'feg'],
+    'ffwa-f': ['orc8r', 'lte', 'feg', 'fbinternal'],
+    'cwf': ['orc8r', 'lte', 'feg', 'cwf'],
+    'cwf-f': ['orc8r', 'lte', 'feg', 'cwf', 'fbinternal'],
+    'wifi': ['orc8r', 'wifi'],
+    'wifi-f': ['orc8r', 'wifi', 'fbinternal'],
 }
 
 DEPLOYMENTS = DEPLOYMENT_TO_MODULES.keys()


### PR DESCRIPTION
Signed-off-by: Andy Lee Khuu <andykhuu@stanford.edu>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary
This PR amends the build process to work when a specific module is targeted. Previously for some reason, none of the modules included their dependency on orc8r which made it impossible to have targeted module builds. If you’re on a crunch for time, adding a “-d {module}” flag to your ./build.py will significantly increase your build time. For those interested rough perf improvements are
<img width="608" alt="Screen Shot 2021-02-12 at 5 07 23 PM" src="https://user-images.githubusercontent.com/46101219/107837267-f29d2f00-6d54-11eb-8bce-e423d13b2efa.png">

TLDR: ~50% build time improvement when you only want to build orc8r.

This PR also contains updated documentation to inform developers of the ability to have targeted builds.
<img width="1775" alt="Screen Shot 2021-02-17 at 11 18 18 PM" src="https://user-images.githubusercontent.com/46101219/108319651-93855300-7176-11eb-96fc-e202a584ec80.png">


<!-- Enumerate changes you made and why you made them -->

## Test Plan
- [x] cd $MAGMA_ROOT/orc8r/cloud/docker && ./build.py -t ; noti
- [x] cd $MAGMA_ROOT/orc8r/cloud/docker && ./build.py
- [x] Manual inspection that nothing broke  
- [x] Manual inspection of locally hosted docusaurus page 
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
