### PR TITLE
[lte][agw] Change eNB ID initialization from 0 to 0xFFFFFFFF

### DIFF
--- a/lte/gateway/c/oai/tasks/s1ap/s1ap_mme_handlers.c
+++ b/lte/gateway/c/oai/tasks/s1ap/s1ap_mme_handlers.c
@@ -2357,7 +2357,8 @@ int s1ap_handle_new_association(
       OAILOG_FUNC_RETURN(LOG_S1AP, RETURNok);
     }
     enb_association->sctp_assoc_id = sctp_new_peer_p->assoc_id;
-    hashtable_rc_t hash_rc         = hashtable_ts_insert(
+    enb_association->enb_id = 0xFFFFFFFF;  // home or macro eNB is 28 or 20bits.
+    hashtable_rc_t hash_rc  = hashtable_ts_insert(
         &state->enbs, (const hash_key_t) enb_association->sctp_assoc_id,
         (void*) enb_association);
     if (HASH_TABLE_OK != hash_rc) {


### PR DESCRIPTION
## Summary

If one of the eNB id is assigned as zero and multiple concurrent sctp association setup and s1 setup procedures occur, MME makes the false assessment that there is an existing association for the eNB with zero id as the eNBs that finished sctp association but not yet completed s1 setup are also initialized with zero id. Since eNB id is either 20 or 28 bits, assigning all 32 bits to 1 is the safe way of initialization.

## Test Plan

- integ tests.
- spirent scaling tests.

## Additional Information

- [ ] This change is backwards-breaking

