### PR TITLE
[xwfm] disable pgp check on centos rpms repo in jfrog

### DIFF
--- a/xwf/gateway/deploy/roles/pkgrepo/tasks/redhat.yml
+++ b/xwf/gateway/deploy/roles/pkgrepo/tasks/redhat.yml
@@ -27,6 +27,7 @@
         path: /tmp/jfrog.pub
         state: absent
 
+# TODO: change repo_gpgcheck to 1 once we get the pgp working
 - name: Add JFrog repo
   copy:
     dest: /etc/yum.repos.d/magma-jfrog.repo
@@ -37,4 +38,4 @@
       gpgcheck=0
       enabled=1
       gpgkey=https://facebookconnectivity.jfrog.io/artifactory/{{ repo }}/{{ distribution }}/$releasever/repodata/repomd.xml.key
-      repo_gpgcheck=1
+      repo_gpgcheck=0


### PR DESCRIPTION
Signed-off-by: Ayelet Regev Dabah <ayelet.regev@gmail.com>

[xwfm] disable pgp check on centos rpms repo in jfrog

## Summary

Current installation fails on:

```
2021-02-14 10:25:22 [stdout]TASK [dhcpd : Install dhcp-server] *******************************************
2021-02-14 10:25:38 [stdout]fatal: [localhost]: FAILED! => {"changed": false, "msg": "Failure talking to yum: failure: repodata/repomd.xml from magma-jfrog: [Errno 256] No more mirrors to try.\nhttps://facebookconnectivity.jfrog.io/artifactory/cwf-prod-redhat/centos/7/repodata/repomd.xml: [Errno -1] repomd.xml sign
ature could not be verified for magma-jfrog"}
2021-02-14 10:25:38 [stdout]
2021-02-14 10:25:38 [stdout]PLAY RECAP *******************************************************************
2021-02-14 10:25:38 [stdout]localhost                  : ok=2    changed=0    unreachable=0    failed=1    skipped=0    rescued=0    ignored=0
2021-02-14 10:25:38 [stdout]
```


## Test Plan

on new centos 7 host before running ansible rules, updated the file manually and rerun

## Additional Information

- [ ] This change is backwards-breaking


