### PR TITLE
[orc8r] Updated orchestrator pod label

### DIFF
--- a/orc8r/cloud/deploy/bare-metal/deploy_charts.sh
+++ b/orc8r/cloud/deploy/bare-metal/deploy_charts.sh
@@ -79,7 +79,7 @@ helm -n $namespace upgrade --install kibana stable/kibana -f charts/kibana.yaml
 
 helm -n $namespace upgrade --install orc8r github-repo/orc8r -f charts/orc8r.yaml --wait
 
-export ORC_POD=$(kubectl -n $namespace get pod -l app.kubernetes.io/component=orchestrator -o jsonpath='{.items[0].metadata.name}')
+export ORC_POD=$(kubectl -n $namespace get pod -l app.kubernetes.io/component=controller -o jsonpath='{.items[0].metadata.name}')
 export NMS_POD=$(kubectl -n $namespace get pod -l app.kubernetes.io/component=magmalte -o jsonpath='{.items[0].metadata.name}')
 
 kubectl -n $namespace exec -it ${ORC_POD} -- envdir /var/opt/magma/envdir /var/opt/magma/bin/accessc add-existing -admin -cert /var/opt/magma/certs/admin_operator.pem admin_operator || :


### PR DESCRIPTION
<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->

When deploying bare metal Orchestrator via helm chart it label's the **orc8r-controller** deployment with `app.kubernetes.io/component=controller` which is required by **deploy_charts.sh** script for finishing the setup.

## Test Plan

Test the labels on **orc8r-controller** deployment:
```bash
kubectl get deploy orc8r-controller --show-labels
```
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
