### PR TITLE
[lte] Minor CMakeLists.txt cleanups

### DIFF
--- a/lte/gateway/c/connection_tracker/CMakeLists.txt
+++ b/lte/gateway/c/connection_tracker/CMakeLists.txt
@@ -9,11 +9,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-cmake_minimum_required(VERSION 3.0.2)
+cmake_minimum_required(VERSION 3.7.2)
 
 PROJECT(ConnectionTracker)
 
-add_compile_options(-std=c++14)
+set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
 
 include($ENV{MAGMA_ROOT}/orc8r/gateway/c/common/CMakeProtoMacros.txt)
 

--- a/lte/gateway/c/oai/CMakeLists.txt
+++ b/lte/gateway/c/oai/CMakeLists.txt
@@ -1,4 +1,16 @@
-cmake_minimum_required(VERSION 3.0.2)
+# Copyright 2020 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+cmake_minimum_required(VERSION 3.7.2)
+
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 project(MagmaCore)

--- a/lte/gateway/c/oai/common/CMakeLists.txt
+++ b/lte/gateway/c/oai/common/CMakeLists.txt
@@ -1,3 +1,20 @@
+# Copyright 2020 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+cmake_minimum_required(VERSION 3.7.2)
+
+set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
 if (${LINK_GCOV})
   set(GCOV_LIB gcov)
 else ()

--- a/lte/gateway/c/oai/common/glogwrapper/CMakeLists.txt
+++ b/lte/gateway/c/oai/common/glogwrapper/CMakeLists.txt
@@ -1,6 +1,20 @@
-cmake_minimum_required(VERSION 3.7)
+# Copyright 2020 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+cmake_minimum_required(VERSION 3.7.2)
+
 project(glogwrapper)
 
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
 set(CMAKE_CXX_STANDARD 14)
 
 add_library(glogwrapper glog_logging.cpp glog_logging.h)

--- a/lte/gateway/c/oai/common/redis_utils/CMakeLists.txt
+++ b/lte/gateway/c/oai/common/redis_utils/CMakeLists.txt
@@ -1,4 +1,19 @@
-cmake_minimum_required(VERSION 3.7)
+# Copyright 2020 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+cmake_minimum_required(VERSION 3.7.2)
+
+set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
 
 include_directories(${CMAKE_CURRENT_SOURCE_DIR})
 include_directories(${CMAKE_CURRENT_BINARY_DIR})

--- a/lte/gateway/c/oai/lib/3gpp/CMakeLists.txt
+++ b/lte/gateway/c/oai/lib/3gpp/CMakeLists.txt
@@ -1,3 +1,16 @@
+# Copyright 2020 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+cmake_minimum_required(VERSION 3.7.2)
+
 add_library(LIB_3GPP
     3gpp_24.008_cc_ies.c
     3gpp_24.008_common_ies.c

--- a/lte/gateway/c/oai/lib/CMakeLists.txt
+++ b/lte/gateway/c/oai/lib/CMakeLists.txt
@@ -1,3 +1,16 @@
+# Copyright 2020 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+cmake_minimum_required(VERSION 3.7.2)
+
 set(LIB_DIR ${CMAKE_CURRENT_SOURCE_DIR})
 
 add_subdirectory(3gpp) # LIB_3GPP

--- a/lte/gateway/c/oai/lib/bstr/CMakeLists.txt
+++ b/lte/gateway/c/oai/lib/bstr/CMakeLists.txt
@@ -1,3 +1,16 @@
+# Copyright 2020 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+cmake_minimum_required(VERSION 3.7.2)
+
 add_library(LIB_BSTR
     bstraux.c
     bstrlib.c

--- a/lte/gateway/c/oai/lib/directoryd/CMakeLists.txt
+++ b/lte/gateway/c/oai/lib/directoryd/CMakeLists.txt
@@ -1,4 +1,19 @@
-add_compile_options(-std=c++11)
+# Copyright 2020 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+cmake_minimum_required(VERSION 3.7.2)
+
+set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
 
 # compile the needed protos
 set(DRD_ORC8R_CPP_PROTOS common directoryd)

--- a/lte/gateway/c/oai/lib/event_client/CMakeLists.txt
+++ b/lte/gateway/c/oai/lib/event_client/CMakeLists.txt
@@ -1,4 +1,19 @@
-add_compile_options(-std=c++14)
+# Copyright 2020 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+cmake_minimum_required(VERSION 3.7.2)
+
+set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
 
 include($ENV{MAGMA_ROOT}/orc8r/gateway/c/common/CMakeProtoMacros.txt)
 

--- a/lte/gateway/c/oai/lib/gtpv2-c/CMakeLists.txt
+++ b/lte/gateway/c/oai/lib/gtpv2-c/CMakeLists.txt
@@ -1,3 +1,16 @@
+# Copyright 2020 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+cmake_minimum_required(VERSION 3.7.2)
+
 set(NWGTPV2C_DIR  ${PROJECT_SOURCE_DIR}/lib/gtpv2-c/nwgtpv2c-0.11/src)
 set(NWGTPV2C_IE_FORMATTER_DIR ${PROJECT_SOURCE_DIR}/lib/gtpv2-c/gtpv2c_ie_formatter/src)
 

--- a/lte/gateway/c/oai/lib/hashtable/CMakeLists.txt
+++ b/lte/gateway/c/oai/lib/hashtable/CMakeLists.txt
@@ -1,3 +1,16 @@
+# Copyright 2020 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+cmake_minimum_required(VERSION 3.7.2)
+
 add_library(LIB_HASHTABLE
     hashtable.c
     obj_hashtable.c

--- a/lte/gateway/c/oai/lib/itti/CMakeLists.txt
+++ b/lte/gateway/c/oai/lib/itti/CMakeLists.txt
@@ -1,3 +1,16 @@
+# Copyright 2020 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+cmake_minimum_required(VERSION 3.7.2)
+
 # TODO: ITTI_Messages shouldn't depend on S1_Types
 set(ASN1RELDIR r15)
 set(asn1_generated_dir ${PROJECT_BINARY_DIR}/s1ap)

--- a/lte/gateway/c/oai/lib/message_utils/CMakeLists.txt
+++ b/lte/gateway/c/oai/lib/message_utils/CMakeLists.txt
@@ -1,3 +1,16 @@
+# Copyright 2020 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+cmake_minimum_required(VERSION 3.7.2)
+
 add_library(LIB_MESSAGE_UTILS
     bytes_to_ie.c
     ie_to_bytes.c

--- a/lte/gateway/c/oai/lib/mobility_client/CMakeLists.txt
+++ b/lte/gateway/c/oai/lib/mobility_client/CMakeLists.txt
@@ -1,4 +1,19 @@
-add_compile_options(-std=c++14)
+# Copyright 2020 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+cmake_minimum_required(VERSION 3.7.2)
+
+set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
 
 include($ENV{MAGMA_ROOT}/orc8r/gateway/c/common/CMakeProtoMacros.txt)
 

--- a/lte/gateway/c/oai/lib/openflow/CMakeLists.txt
+++ b/lte/gateway/c/oai/lib/openflow/CMakeLists.txt
@@ -1,3 +1,16 @@
+# Copyright 2020 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+cmake_minimum_required(VERSION 3.7.2)
+
 set(OUTPUT_DIR "${CMAKE_CURRENT_BINARY_DIR}")
 
 include_directories("${OUTPUT_DIR}")

--- a/lte/gateway/c/oai/lib/openflow/controller/CMakeLists.txt
+++ b/lte/gateway/c/oai/lib/openflow/controller/CMakeLists.txt
@@ -1,4 +1,19 @@
-add_compile_options(-std=c++11)
+# Copyright 2020 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+cmake_minimum_required(VERSION 3.7.2)
+
+set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
 
 set(OUTPUT_DIR "${CMAKE_CURRENT_BINARY_DIR}")
 

--- a/lte/gateway/c/oai/lib/pcef/CMakeLists.txt
+++ b/lte/gateway/c/oai/lib/pcef/CMakeLists.txt
@@ -1,4 +1,19 @@
-add_compile_options(-std=c++14)
+# Copyright 2020 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+cmake_minimum_required(VERSION 3.7.2)
+
+set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
 
 set (CMAKE_CXX_FLAGS "-Wno-write-strings -Wno-literal-suffix")
 add_definitions(-DDEBUG_IS_ON=1)

--- a/lte/gateway/c/oai/lib/s6a_proxy/CMakeLists.txt
+++ b/lte/gateway/c/oai/lib/s6a_proxy/CMakeLists.txt
@@ -1,4 +1,19 @@
-add_compile_options(-std=c++14)
+# Copyright 2020 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+cmake_minimum_required(VERSION 3.7.2)
+
+set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
 
 set (CMAKE_CXX_FLAGS "-Wno-write-strings -Wno-literal-suffix")
 add_definitions(-DDEBUG_IS_ON=1)

--- a/lte/gateway/c/oai/lib/secu/CMakeLists.txt
+++ b/lte/gateway/c/oai/lib/secu/CMakeLists.txt
@@ -1,3 +1,16 @@
+# Copyright 2020 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+cmake_minimum_required(VERSION 3.7.2)
+
 ###############################################################################
 # Security library
 ###############################################################################

--- a/lte/gateway/c/oai/lib/sgs_client/CMakeLists.txt
+++ b/lte/gateway/c/oai/lib/sgs_client/CMakeLists.txt
@@ -1,4 +1,19 @@
-add_compile_options(-std=c++14)
+# Copyright 2020 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+cmake_minimum_required(VERSION 3.7.2)
+
+set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
 
 # compile the needed protos
 set(SGSC_FEG_CPP_PROTOS csfb)

--- a/lte/gateway/c/oai/lib/sms_orc8r_client/CMakeLists.txt
+++ b/lte/gateway/c/oai/lib/sms_orc8r_client/CMakeLists.txt
@@ -1,4 +1,19 @@
-add_compile_options(-std=c++14)
+# Copyright 2020 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+cmake_minimum_required(VERSION 3.7.2)
+
+set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
 
 # compile the needed protos
 set(SMOC_LTE_CPP_PROTOS sms_orc8r)

--- a/lte/gateway/c/oai/oai_mme/CMakeLists.txt
+++ b/lte/gateway/c/oai/oai_mme/CMakeLists.txt
@@ -1,3 +1,16 @@
+# Copyright 2020 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+cmake_minimum_required(VERSION 3.7.2)
+
 # Override options for MME
 set (  BYTE_ORDER=LITTLE_ENDIAN )
 set (  S1AP_DEBUG_LIST                 False )

--- a/lte/gateway/c/oai/tasks/CMakeLists.txt
+++ b/lte/gateway/c/oai/tasks/CMakeLists.txt
@@ -1,3 +1,20 @@
+# Copyright 2020 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+cmake_minimum_required(VERSION 3.7.2)
+
+set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
 add_subdirectory(mme_app) # TASK_MME_APP
 add_subdirectory(nas) # TASK_NAS
 add_subdirectory(s1ap) # TASK_S1AP, LIB_S1AP

--- a/lte/gateway/c/oai/tasks/grpc_service/CMakeLists.txt
+++ b/lte/gateway/c/oai/tasks/grpc_service/CMakeLists.txt
@@ -1,5 +1,23 @@
-find_package(Protobuf REQUIRED)
+# Copyright 2020 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+cmake_minimum_required(VERSION 3.7.2)
+
+set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
 set (CMAKE_CXX_FLAGS "-Wno-write-strings -Wno-literal-suffix")
+
+find_package(Protobuf REQUIRED)
 
 # compile the needed protos
 list(APPEND PROTO_SRCS "")

--- a/lte/gateway/c/oai/tasks/gtpv1-u/CMakeLists.txt
+++ b/lte/gateway/c/oai/tasks/gtpv1-u/CMakeLists.txt
@@ -1,3 +1,15 @@
+# Copyright 2020 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+cmake_minimum_required(VERSION 3.7.2)
 
 set (GTPV1U_SRC
     gtpv1u_task.c

--- a/lte/gateway/c/oai/tasks/ha/CMakeLists.txt
+++ b/lte/gateway/c/oai/tasks/ha/CMakeLists.txt
@@ -1,3 +1,20 @@
+# Copyright 2020 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+cmake_minimum_required(VERSION 3.7.2)
+
+set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
 find_package(Protobuf REQUIRED)
 # compile the needed protos
 list(APPEND PROTO_SRCS "")

--- a/lte/gateway/c/oai/tasks/mme_app/CMakeLists.txt
+++ b/lte/gateway/c/oai/tasks/mme_app/CMakeLists.txt
@@ -1,3 +1,20 @@
+# Copyright 2020 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+cmake_minimum_required(VERSION 3.7.2)
+
+set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
 set(S1AP_C_DIR ${PROJECT_BINARY_DIR}/s1ap/r15)
 
 # compile the needed protos

--- a/lte/gateway/c/oai/tasks/nas/CMakeLists.txt
+++ b/lte/gateway/c/oai/tasks/nas/CMakeLists.txt
@@ -1,3 +1,20 @@
+# Copyright 2020 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+cmake_minimum_required(VERSION 3.7.2)
+
+set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
 set(S1AP_C_DIR ${PROJECT_BINARY_DIR}/s1ap/r10.5)
 
 # compile the needed protos

--- a/lte/gateway/c/oai/tasks/s11/CMakeLists.txt
+++ b/lte/gateway/c/oai/tasks/s11/CMakeLists.txt
@@ -1,3 +1,15 @@
+# Copyright 2020 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+cmake_minimum_required(VERSION 3.7.2)
 
 include_directories(${S1AP_C_DIR})
 include_directories(${PROJECT_SOURCE_DIR}/lib/gtpv2-c/gtpv2c_ie_formatter/shared)

--- a/lte/gateway/c/oai/tasks/s1ap/CMakeLists.txt
+++ b/lte/gateway/c/oai/tasks/s1ap/CMakeLists.txt
@@ -1,3 +1,20 @@
+# Copyright 2020 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+cmake_minimum_required(VERSION 3.7.2)
+
+set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
 add_list1_option(S1AP_VERSION R15 "S1AP Asn.1 grammar version" R15)
 add_definitions(-DASN1_MINIMUM_VERSION=923)
 set(ASN1RELDIR r15)

--- a/lte/gateway/c/oai/tasks/s6a/CMakeLists.txt
+++ b/lte/gateway/c/oai/tasks/s6a/CMakeLists.txt
@@ -1,3 +1,20 @@
+# Copyright 2020 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+cmake_minimum_required(VERSION 3.7.2)
+
+set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
 set(S1AP_C_DIR ${PROJECT_BINARY_DIR}/s1ap/r15)
 include_directories(${S1AP_C_DIR})
 

--- a/lte/gateway/c/oai/tasks/sctp/CMakeLists.txt
+++ b/lte/gateway/c/oai/tasks/sctp/CMakeLists.txt
@@ -1,3 +1,19 @@
+# Copyright 2020 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+cmake_minimum_required(VERSION 3.7.2)
+
+set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
 
 set(S1AP_C_DIR ${PROJECT_BINARY_DIR}/s1ap/r15)
 include_directories(${S1AP_C_DIR})

--- a/lte/gateway/c/oai/tasks/service303/CMakeLists.txt
+++ b/lte/gateway/c/oai/tasks/service303/CMakeLists.txt
@@ -1,5 +1,21 @@
+# Copyright 2020 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+cmake_minimum_required(VERSION 3.7.2)
+
 find_package(Protobuf REQUIRED)
-add_compile_options(-std=c++11)
+
+set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
 
 set(OUTPUT_DIR "${CMAKE_CURRENT_BINARY_DIR}")
 

--- a/lte/gateway/c/oai/tasks/sgs/CMakeLists.txt
+++ b/lte/gateway/c/oai/tasks/sgs/CMakeLists.txt
@@ -1,4 +1,21 @@
+# Copyright 2020 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+cmake_minimum_required(VERSION 3.7.2)
+
 find_package(Protobuf REQUIRED)
+
+set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
 
 add_library(TASK_SGS
     sgs_task.c

--- a/lte/gateway/c/oai/tasks/sgw/CMakeLists.txt
+++ b/lte/gateway/c/oai/tasks/sgw/CMakeLists.txt
@@ -1,3 +1,20 @@
+# Copyright 2020 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+cmake_minimum_required(VERSION 3.7.2)
+
+set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
 # compile required protos
 set(SPGW_LTE_CPP_PROTOS spgw_state common_types std_3gpp_types)
 list(APPEND PROTO_SRCS "")

--- a/lte/gateway/c/oai/tasks/sms_orc8r/CMakeLists.txt
+++ b/lte/gateway/c/oai/tasks/sms_orc8r/CMakeLists.txt
@@ -1,3 +1,16 @@
+# Copyright 2020 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+cmake_minimum_required(VERSION 3.7.2)
+
 find_package(Protobuf REQUIRED)
 
 add_library(TASK_SMS_ORC8R

--- a/lte/gateway/c/oai/tasks/udp/CMakeLists.txt
+++ b/lte/gateway/c/oai/tasks/udp/CMakeLists.txt
@@ -1,3 +1,16 @@
+# Copyright 2020 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+cmake_minimum_required(VERSION 3.7.2)
+
 include_directories(${PROJECT_SOURCE_DIR}/common)
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/../../lib/3gpp)
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/../../lib/itti)

--- a/lte/gateway/c/oai/test/CMakeLists.txt
+++ b/lte/gateway/c/oai/test/CMakeLists.txt
@@ -1,3 +1,16 @@
+# Copyright 2020 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+cmake_minimum_required(VERSION 3.7.2)
+
 find_package(Check REQUIRED)
 find_package(Threads REQUIRED)
 

--- a/lte/gateway/c/oai/test/mobility_client/CMakeLists.txt
+++ b/lte/gateway/c/oai/test/mobility_client/CMakeLists.txt
@@ -1,3 +1,20 @@
+# Copyright 2020 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+cmake_minimum_required(VERSION 3.7.2)
+
+set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
 include_directories("${PROJECT_BINARY_DIR}")
 include_directories("${PROJECT_SOURCE_DIR}/mobility_client")
 

--- a/lte/gateway/c/oai/test/openflow/CMakeLists.txt
+++ b/lte/gateway/c/oai/test/openflow/CMakeLists.txt
@@ -1,4 +1,19 @@
-add_compile_options(-std=c++11)
+# Copyright 2020 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+cmake_minimum_required(VERSION 3.7.2)
+
+set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
 
 set(OUTPUT_DIR "${CMAKE_CURRENT_BINARY_DIR}")
 

--- a/lte/gateway/c/oai/test/service303/CMakeLists.txt
+++ b/lte/gateway/c/oai/test/service303/CMakeLists.txt
@@ -1,8 +1,24 @@
-include_directories("${PROJECT_BINARY_DIR}")
-include_directories("${PROJECT_SOURCE_DIR}/service303")
+# Copyright 2020 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+cmake_minimum_required(VERSION 3.7.2)
+
+set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
 
 find_package(Protobuf REQUIRED)
-add_compile_options(-std=c++11)
+
+include_directories("${PROJECT_BINARY_DIR}")
+include_directories("${PROJECT_SOURCE_DIR}/service303")
 
 # compile the needed protos
 set(S303_ORC8R_CPP_PROTOS service303 common metricsd)

--- a/lte/gateway/c/oai/test/service_registry/CMakeLists.txt
+++ b/lte/gateway/c/oai/test/service_registry/CMakeLists.txt
@@ -1,4 +1,19 @@
-add_compile_options(-std=c++11)
+# Copyright 2020 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+cmake_minimum_required(VERSION 3.7.2)
+
+set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
 
 add_executable(service_registry_test test_service_registry.cpp)
 

--- a/lte/gateway/c/sctpd/CMakeLists.txt
+++ b/lte/gateway/c/sctpd/CMakeLists.txt
@@ -1,6 +1,19 @@
-cmake_minimum_required(VERSION 3.7)
-set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+# Copyright 2020 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+cmake_minimum_required(VERSION 3.7.2)
+
 set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
 
 project(MagmaSctpd)
 

--- a/lte/gateway/c/sctpd/test/CMakeLists.txt
+++ b/lte/gateway/c/sctpd/test/CMakeLists.txt
@@ -1,6 +1,21 @@
-add_library(SCTPD_TEST_LIB
+# Copyright 2020 The Magma Authors.
 
-)
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+cmake_minimum_required(VERSION 3.7.2)
+
+set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
+add_library(SCTPD_TEST_LIB)
 
 target_link_libraries(SCTPD_TEST_LIB SCTPD_LIB gmock_main pthread rt)
 

--- a/lte/gateway/c/session_manager/CMakeLists.txt
+++ b/lte/gateway/c/session_manager/CMakeLists.txt
@@ -9,11 +9,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-cmake_minimum_required(VERSION 3.0.2)
+cmake_minimum_required(VERSION 3.7.2)
 
 PROJECT(SessionManager)
 
-add_compile_options(-std=c++14)
+set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
 
 set(CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/modules")
 include(FindClangFormat)

--- a/lte/gateway/c/session_manager/test/CMakeLists.txt
+++ b/lte/gateway/c/session_manager/test/CMakeLists.txt
@@ -1,4 +1,19 @@
-add_compile_options(-std=c++14)
+# Copyright 2020 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+cmake_minimum_required(VERSION 3.7.2)
+
+set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
 
 set(OUTPUT_DIR "${CMAKE_CURRENT_BINARY_DIR}")
 


### PR DESCRIPTION
Make sure all of the CMakeLists.txt files in lte contain
the magma copyright, contain a reasonable minimum cmake version
(arbitrarily picked at 3.7.2 for the C++ extensions),
and set C++14 as the language to use.

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary

Make sure all of the CMakeLists.txt files in lte contain
the magma copyright, contain a reasonable minimum cmake version
(arbitrarily picked at 3.7.2 for the C++ extensions),
and set C++14 as the language to use.

## Test Plan

grep, jenkins

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
