### PR TITLE
[NMS] Fix the nginx proxy config to ensure that https protocol information is included in the header

### DIFF
--- a/orc8r/cloud/helm/orc8r/Chart.yaml
+++ b/orc8r/cloud/helm/orc8r/Chart.yaml
@@ -13,7 +13,7 @@ apiVersion: v2
 appVersion: "1.0"
 description: A Helm chart for magma orchestrator
 name: orc8r
-version: 1.5.11
+version: 1.5.12
 engine: gotpl
 sources:
   - https://github.com/magma/magma
@@ -31,7 +31,7 @@ dependencies:
     repository: ""
     condition: metrics.enabled
   - name: nms
-    version: 0.1.7
+    version: 0.1.8
     repository: ""
     condition: nms.enabled
   - name: logging

--- a/orc8r/cloud/helm/orc8r/charts/nms/Chart.yaml
+++ b/orc8r/cloud/helm/orc8r/charts/nms/Chart.yaml
@@ -12,7 +12,7 @@
 apiVersion: v1
 description: Magma NMS
 name: nms
-version: 0.1.7
+version: 0.1.8
 home: https://github.com/magma/magma
 sources:
   - https://github.com/magma/magma

--- a/orc8r/cloud/helm/orc8r/charts/nms/templates/etc/_nginx_proxy_ssl.conf.tpl
+++ b/orc8r/cloud/helm/orc8r/charts/nms/templates/etc/_nginx_proxy_ssl.conf.tpl
@@ -6,5 +6,6 @@ server {
   location / {
      proxy_pass http://magmalte:8081;
      proxy_set_header Host $http_host;
+     proxy_set_header X-Forwarded-Proto $scheme;
   }
 }


### PR DESCRIPTION
Prod NMS deployment uses secure option for express sessions. The connection between
nginx proxy and magmalte however could be http and this could lead to requests being
rejected. This fix ensures that the protocol is included in the header and will
ensure ensure that server won't reject the request
https://stackoverflow.com/questions/30802322/node-js-express-session-what-does-the-proxy-option-do
https://github.com/expressjs/session#proxy

Signed-off-by: Karthik Subraveti <ksubraveti@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
