### PR TITLE
[NMS] Hide autoRefresh checkbox for gateways upgrade table

### DIFF
--- a/nms/app/packages/magmalte/app/views/equipment/EquipmentGateway.js
+++ b/nms/app/packages/magmalte/app/views/equipment/EquipmentGateway.js
@@ -91,6 +91,8 @@ const useStyles = makeStyles(theme => ({
   },
 }));
 
+const UPGRADE_VIEW = 'UPGRADE';
+
 export default function Gateway() {
   const classes = useStyles();
 
@@ -151,12 +153,14 @@ function GatewayTable() {
         label={`Gateways (${Object.keys(ctx.state).length})`}
         filter={() => (
           <Grid container justify="flex-end" alignItems="center" spacing={1}>
-            <Grid item>
-              <AutorefreshCheckbox
-                autorefreshEnabled={refresh}
-                onToggle={() => setRefresh(current => !current)}
-              />
-            </Grid>
+            {currentView !== UPGRADE_VIEW && (
+              <Grid item>
+                <AutorefreshCheckbox
+                  autorefreshEnabled={refresh}
+                  onToggle={() => setRefresh(current => !current)}
+                />
+              </Grid>
+            )}
             <Grid item>
               <Text variant="body3" className={classes.viewLabelText}>
                 View


### PR DESCRIPTION
Signed-off-by: HannaFar <hannafarag159@gmail.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary

Hide autoRefresh checkbox for gateways upgrade table

<img width="1251" alt="Capture d’écran 2021-02-16 à 15 59 39" src="https://user-images.githubusercontent.com/26038920/108121226-72d2d580-7070-11eb-9fea-238100250b24.png">
<img width="1251" alt="Capture d’écran 2021-02-16 à 15 59 50" src="https://user-images.githubusercontent.com/26038920/108121232-75352f80-7070-11eb-9782-18c50c617272.png">

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
