### PR TITLE
[lte][agw] Fix null pointer access in delete session response

### DIFF
--- a/lte/gateway/c/oai/tasks/mme_app/mme_app_bearer.c
+++ b/lte/gateway/c/oai/tasks/mme_app/mme_app_bearer.c
@@ -952,7 +952,8 @@ void mme_app_handle_delete_session_rsp(
       pdn_cid_t pid =
           ue_context_p->bearer_contexts[EBI_TO_INDEX(delete_sess_resp_pP->lbi)]
               ->pdn_cx_id;
-      if (ue_context_p->pdn_contexts[pid]->ue_rej_act_def_ber_req) {
+      if ((ue_context_p->pdn_contexts[pid]) &&
+          (ue_context_p->pdn_contexts[pid]->ue_rej_act_def_ber_req)) {
         // Reset flag
         ue_context_p->pdn_contexts[pid]->ue_rej_act_def_ber_req = false;
         // Free the contents of PDN session

--- a/lte/gateway/c/oai/tasks/mme_app/mme_app_bearer.c
+++ b/lte/gateway/c/oai/tasks/mme_app/mme_app_bearer.c
@@ -959,9 +959,7 @@ void mme_app_handle_delete_session_rsp(
         // Free the contents of PDN session
         _pdn_connectivity_delete(&ue_context_p->emm_context, pid);
         // Free PDN context
-        if (ue_context_p->pdn_contexts[pid]) {
-          free_wrapper((void**) &ue_context_p->pdn_contexts[pid]);
-        }
+        free_wrapper((void**) &ue_context_p->pdn_contexts[pid]);
         // Free bearer context entry
         for (uint8_t bid = 0; bid < BEARERS_PER_UE; bid++) {
           if ((ue_context_p->bearer_contexts[bid]) &&


### PR DESCRIPTION
## Summary

During delete session response processing, a null pointer access occurs. The PR adds the additional check for non-null pointer.

## Test Plan

lte integ tests.

## Additional Information

- [ ] This change is backwards-breaking

