### PR TITLE
[orc8r] make s8 proxy optional in swagger api

### DIFF
--- a/feg/cloud/go/services/feg/obsidian/models/network_federation_configs_swaggergen.go
+++ b/feg/cloud/go/services/feg/obsidian/models/network_federation_configs_swaggergen.go
@@ -55,8 +55,7 @@ type NetworkFederationConfigs struct {
 	S6a *S6a `json:"s6a"`
 
 	// s8
-	// Required: true
-	S8 *S8 `json:"s8"`
+	S8 *S8 `json:"s8,omitempty"`
 
 	// served network ids
 	// Required: true
@@ -316,8 +315,8 @@ func (m *NetworkFederationConfigs) validateS6a(formats strfmt.Registry) error {
 
 func (m *NetworkFederationConfigs) validateS8(formats strfmt.Registry) error {
 
-	if err := validate.Required("s8", "body", m.S8); err != nil {
-		return err
+	if swag.IsZero(m.S8) { // not required
+		return nil
 	}
 
 	if m.S8 != nil {

--- a/feg/cloud/go/services/feg/obsidian/models/swagger.v1.yml
+++ b/feg/cloud/go/services/feg/obsidian/models/swagger.v1.yml
@@ -1166,7 +1166,6 @@ definitions:
     minLength: 1
     required:
       - s6a
-      - s8
       - hss
       - gx
       - gy

--- a/orc8r/cloud/docker/controller/apidocs/v1/swagger.yml
+++ b/orc8r/cloud/docker/controller/apidocs/v1/swagger.yml
@@ -9728,7 +9728,6 @@ definitions:
         $ref: '#/definitions/swx'
     required:
     - s6a
-    - s8
     - hss
     - gx
     - gy


### PR DESCRIPTION
Signed-off-by: Oriol Batalla <obatalla@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary

Make s8 optional in swagger. 
That will fix NMS not being able to create a FEG network due to missing s8

## Test Plan
Created a network without s8
```
curl -X POST "https://127.0.0.1:9443/magma/v1/feg" -H "accept: application/json" -H "content-type: application/json" -d "{ \"description\": \"Foobar network\", \"dns\": { \"dhcp_server_enabled\": true, \"enable_caching\": false, \"local_ttl\": 0, \"records\": [ { \"a_record\": [ \"192.88.99.142\" ], \"aaaa_record\": [ \"2001:0db8:85a3:0000:0000:8a2e:0370:7334\" ], \"cname_record\": [ \"cname.example.com\" ], \"domain\": \"example.com\" } ] }, \"features\": { \"features\": { \"featureName1\": \"featureProp1\", \"featureName2\": \"featureProp2\" } }, \"federation\": { \"aaa_server\": { \"accounting_enabled\": true, \"create_session_on_auth\": true, \"event_logging_enabled\": false, \"idle_session_timeout_ms\": 21600000, \"radius_config\": { \"DAE_addr\": \"127.0.0.1:3799\", \"acct_addr\": \"127.0.0.1:1813\", \"auth_addr\": \"127.0.0.1:1812\", \"network\": \"udp\", \"secret\": \"MTIzNDU2\" } }, \"csfb\": { \"client\": { \"local_address\": \":56789\", \"server_address\": \"foo.bar.com:5555\" } }, \"eap_aka\": { \"mnc_len\": 3, \"plmn_ids\": [ \"123456\" ], \"timeout\": { \"challenge_ms\": 20000, \"error_notification_ms\": 10000, \"session_authenticated_ms\": 5000, \"session_ms\": 43200000 }, \"use_s6a\": false }, \"eap_sim\": { \"mnc_len\": 3, \"plmn_ids\": [ \"123456\" ], \"timeout\": { \"challenge_ms\": 20000, \"error_notification_ms\": 10000, \"session_authenticated_ms\": 5000, \"session_ms\": 43200000 }, \"use_s6a\": false }, \"gx\": { \"disableGx\": false, \"overwrite_apn\": \"\", \"server\": { \"address\": \"foo.bar.com:5555\", \"dest_host\": \"magma-fedgw.magma.com\", \"dest_realm\": \"magma.com\", \"disable_dest_host\": false, \"host\": \"string\", \"local_address\": \":56789\", \"overwrite_dest_host\": false, \"product_name\": \"string\", \"protocol\": \"tcp\", \"realm\": \"string\", \"retransmits\": 0, \"retry_count\": 0, \"watchdog_interval\": 0 }, \"servers\": [ { \"address\": \"foo.bar.com:5555\", \"dest_host\": \"magma-fedgw.magma.com\", \"dest_realm\": \"magma.com\", \"disable_dest_host\": false, \"host\": \"string\", \"local_address\": \":56789\", \"overwrite_dest_host\": false, \"product_name\": \"string\", \"protocol\": \"tcp\", \"realm\": \"string\", \"retransmits\": 0, \"retry_count\": 0, \"watchdog_interval\": 0 } ], \"virtual_apn_rules\": [ { \"apn_filter\": \".*\\\\.magma.*\", \"apn_overwrite\": \"new.magma.apn\", \"charging_characteristics_filter\": \"12\" } ] }, \"gy\": { \"disableGy\": false, \"init_method\": 2, \"overwrite_apn\": \"\", \"server\": { \"address\": \"foo.bar.com:5555\", \"dest_host\": \"magma-fedgw.magma.com\", \"dest_realm\": \"magma.com\", \"disable_dest_host\": false, \"host\": \"string\", \"local_address\": \":56789\", \"overwrite_dest_host\": false, \"product_name\": \"string\", \"protocol\": \"tcp\", \"realm\": \"string\", \"retransmits\": 0, \"retry_count\": 0, \"watchdog_interval\": 0 }, \"servers\": [ { \"address\": \"foo.bar.com:5555\", \"dest_host\": \"magma-fedgw.magma.com\", \"dest_realm\": \"magma.com\", \"disable_dest_host\": false, \"host\": \"string\", \"local_address\": \":56789\", \"overwrite_dest_host\": false, \"product_name\": \"string\", \"protocol\": \"tcp\", \"realm\": \"string\", \"retransmits\": 0, \"retry_count\": 0, \"watchdog_interval\": 0 } ], \"virtual_apn_rules\": [ { \"apn_filter\": \".*\\\\.magma.*\", \"apn_overwrite\": \"new.magma.apn\", \"charging_characteristics_filter\": \"12\" } ] }, \"health\": { \"cloud_disable_period_secs\": 10, \"cpu_utilization_threshold\": 0.9, \"health_services\": [ \"SESSION_PROXY\", \"SWX_PROXY\" ], \"local_disable_period_secs\": 1, \"memory_available_threshold\": 0.75, \"minimum_request_threshold\": 1, \"request_failure_threshold\": 0.5, \"update_failure_threshold\": 3, \"update_interval_secs\": 10 }, \"hss\": { \"default_sub_profile\": { \"max_dl_bit_rate\": 200000000, \"max_ul_bit_rate\": 100000000 }, \"lte_auth_amf\": \"gAA=\", \"lte_auth_op\": \"EREREREREREREREREREREQ==\", \"server\": { \"address\": \"foo.bar.com:5555\", \"dest_host\": \"magma-fedgw.magma.com\", \"dest_realm\": \"magma.com\", \"local_address\": \":56789\", \"protocol\": \"tcp\" }, \"stream_subscribers\": false, \"sub_profiles\": { \"additionalProp1\": { \"max_dl_bit_rate\": 200000000, \"max_ul_bit_rate\": 100000000 }, \"additionalProp2\": { \"max_dl_bit_rate\": 200000000, \"max_ul_bit_rate\": 100000000 }, \"additionalProp3\": { \"max_dl_bit_rate\": 200000000, \"max_ul_bit_rate\": 100000000 } } }, \"nh_routes\": { }, \"s6a\": { \"plmn_ids\": [ \"123456\" ], \"server\": { \"address\": \"foo.bar.com:5555\", \"dest_host\": \"magma-fedgw.magma.com\", \"dest_realm\": \"magma.com\", \"disable_dest_host\": false, \"host\": \"string\", \"local_address\": \":56789\", \"overwrite_dest_host\": false, \"product_name\": \"string\", \"protocol\": \"tcp\", \"realm\": \"string\", \"retransmits\": 0, \"retry_count\": 0, \"watchdog_interval\": 0 } }, \"served_network_ids\": [ \"string\" ], \"served_nh_ids\": [ \"string\" ], \"swx\": { \"cache_TTL_seconds\": 10800, \"derive_unregister_realm\": false, \"hlr_plmn_ids\": [ \"00101\" ], \"register_on_auth\": false, \"server\": { \"address\": \"foo.bar.com:5555\", \"dest_host\": \"magma-fedgw.magma.com\", \"dest_realm\": \"magma.com\", \"disable_dest_host\": false, \"host\": \"string\", \"local_address\": \":56789\", \"overwrite_dest_host\": false, \"product_name\": \"string\", \"protocol\": \"tcp\", \"realm\": \"string\", \"retransmits\": 0, \"retry_count\": 0, \"watchdog_interval\": 0 }, \"servers\": [ { \"address\": \"foo.bar.com:5555\", \"dest_host\": \"magma-fedgw.magma.com\", \"dest_realm\": \"magma.com\", \"disable_dest_host\": false, \"host\": \"string\", \"local_address\": \":56789\", \"overwrite_dest_host\": false, \"product_name\": \"string\", \"protocol\": \"tcp\", \"realm\": \"string\", \"retransmits\": 0, \"retry_count\": 0, \"watchdog_interval\": 0 } ], \"verify_authorization\": false } }, \"id\": \"network_5\", \"name\": \"Sample Network\", \"network_subscriber_config\": { \"network_wide_base_names\": [ ], \"network_wide_rule_names\": [ ] }}"
```

![image](https://user-images.githubusercontent.com/16157139/108286314-b5aeaf00-713d-11eb-8c6d-63e1be659a9b.png)


## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
