### PR TITLE
[orc8r] Convert eventd to be a true service

### DIFF
--- a/orc8r/cloud/configs/eventd.yml
+++ b/orc8r/cloud/configs/eventd.yml
@@ -1,0 +1,11 @@
+---
+# Copyright 2020 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/orc8r/cloud/configs/service_registry.yml
+++ b/orc8r/cloud/configs/service_registry.yml
@@ -87,6 +87,14 @@ services:
     port: 9091
     proxy_type: "clientcert"
 
+  eventd:
+    host: "localhost"
+    port: 9121
+    echo_port: 10121
+    proxy_type: "clientcert"
+    labels:
+      orc8r.io/swagger_spec: "true"
+
   obsidian:
     host: "localhost"
     port: 9093

--- a/orc8r/cloud/go/services/eventd/eventd/main.go
+++ b/orc8r/cloud/go/services/eventd/eventd/main.go
@@ -1,0 +1,40 @@
+/*
+Copyright 2020 The Magma Authors.
+
+This source code is licensed under the BSD-style license found in the
+LICENSE file in the root directory of this source tree.
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"magma/gateway/eventd"
+	"magma/orc8r/cloud/go/obsidian/swagger"
+	swagger_protos "magma/orc8r/cloud/go/obsidian/swagger/protos"
+	"magma/orc8r/cloud/go/orc8r"
+	"magma/orc8r/cloud/go/service"
+
+	"github.com/golang/glog"
+)
+
+func main() {
+	// Create the service
+	srv, err := service.NewOrchestratorService(orc8r.ModuleName, eventd.ServiceName)
+	if err != nil {
+		glog.Fatalf("Error creating service: %s", err)
+	}
+
+	swagger_protos.RegisterSwaggerSpecServer(srv.GrpcServer, swagger.NewSpecServicerFromFile(eventd.ServiceName))
+
+	// Run service
+	err = srv.Run()
+	if err != nil {
+		glog.Fatalf("Error running eventd service: %s", err)
+	}
+}

--- a/orc8r/cloud/go/services/eventd/eventd/main.go
+++ b/orc8r/cloud/go/services/eventd/eventd/main.go
@@ -24,17 +24,15 @@ import (
 )
 
 func main() {
-	// Create the service
 	srv, err := service.NewOrchestratorService(orc8r.ModuleName, eventd.ServiceName)
 	if err != nil {
-		glog.Fatalf("Error creating service: %s", err)
+		glog.Fatalf("Error creating service: %+v", err)
 	}
 
 	swagger_protos.RegisterSwaggerSpecServer(srv.GrpcServer, swagger.NewSpecServicerFromFile(eventd.ServiceName))
 
-	// Run service
 	err = srv.Run()
 	if err != nil {
-		glog.Fatalf("Error running eventd service: %s", err)
+		glog.Fatalf("Error running eventd service: %+v", err)
 	}
 }

--- a/orc8r/cloud/helm/orc8r/Chart.lock
+++ b/orc8r/cloud/helm/orc8r/Chart.lock
@@ -4,7 +4,7 @@ dependencies:
   version: 0.1.10
 - name: metrics
   repository: ""
-  version: 1.4.20
+  version: 1.4.21
 - name: nms
   repository: ""
   version: 0.1.7
@@ -14,5 +14,5 @@ dependencies:
 - name: orc8rlib
   repository: file://../orc8rlib
   version: 0.1.2
-digest: sha256:b663c63405553fab8c747f7c8c679975c0ce2cd11c540ebb0c5c83e2ad27b681
-generated: "2021-01-12T14:11:00.994082-08:00"
+digest: sha256:a29c44810cb86f67f4e2d264ce733d823bf2aca0a41cce6899ac3c9340cff63a
+generated: "2021-02-12T22:53:25.775236-08:00"

--- a/orc8r/cloud/helm/orc8r/Chart.yaml
+++ b/orc8r/cloud/helm/orc8r/Chart.yaml
@@ -13,7 +13,7 @@ apiVersion: v2
 appVersion: "1.0"
 description: A Helm chart for magma orchestrator
 name: orc8r
-version: 1.5.12
+version: 1.5.13
 engine: gotpl
 sources:
   - https://github.com/magma/magma

--- a/orc8r/cloud/helm/orc8r/templates/eventd.deployment.yaml
+++ b/orc8r/cloud/helm/orc8r/templates/eventd.deployment.yaml
@@ -1,0 +1,51 @@
+{{/*
+# Copyright 2020 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+*/}}
+{{- include "orc8rlib.deployment" (list . "eventd.deployment") -}}
+{{- define "eventd.deployment" -}}
+metadata:
+  name: orc8r-eventd
+  labels:
+    app.kubernetes.io/component: eventd
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: eventd
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/component: eventd
+    spec:
+      containers:
+      -
+{{ include "orc8rlib.container" (list . "eventd.container")}}
+{{- end -}}
+{{- define "eventd.container" -}}
+name: eventd
+command: ["/usr/bin/envdir"]
+args: ["/var/opt/magma/envdir", "/var/opt/magma/bin/eventd", "-run_echo_server=true", "-logtostderr=true", "-v=0"]
+ports:
+  - name: grpc
+    containerPort: 9121
+  - name: http
+    containerPort: 10121
+livenessProbe:
+  tcpSocket:
+    port: 9121
+  initialDelaySeconds: 10
+  periodSeconds: 30
+readinessProbe:
+  tcpSocket:
+    port: 9121
+  initialDelaySeconds: 5
+  periodSeconds: 10
+{{- end -}}

--- a/orc8r/cloud/helm/orc8r/templates/eventd.pdb.yaml
+++ b/orc8r/cloud/helm/orc8r/templates/eventd.pdb.yaml
@@ -1,0 +1,25 @@
+{{/*
+Copyright 2020 The Magma Authors.
+
+This source code is licensed under the BSD-style license found in the
+LICENSE file in the root directory of this source tree.
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/}}
+{{- include "orc8rlib.pdb" (list . "eventd.pdb") -}}
+{{- define "eventd.pdb" -}}
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: orc8r-eventd
+  labels:
+    app.kubernetes.io/component: eventd
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: eventd
+{{- end }}

--- a/orc8r/cloud/helm/orc8r/templates/eventd.service.yaml
+++ b/orc8r/cloud/helm/orc8r/templates/eventd.service.yaml
@@ -1,0 +1,36 @@
+{{/*
+# Copyright 2020 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+*/}}
+
+{{- include "orc8rlib.service" (list . "eventd.service") -}}
+{{- define "eventd.service" -}}
+metadata:
+  name: orc8r-eventd
+  labels:
+    {{- with .Values.eventd.service.labels }}
+{{ toYaml . | indent 4}}
+    {{- end}}
+  {{- with .Values.eventd.service.annotations }}
+  annotations:
+{{ toYaml . | indent 4}}
+  {{- end }}
+spec:
+  selector:
+    app.kubernetes.io/component: eventd
+  ports:
+    - name: grpc
+      port: 9180
+      targetPort: 9121
+    - name: http
+      port: 8080
+      targetPort: 10121
+{{- end -}}

--- a/orc8r/cloud/helm/orc8r/values.yaml
+++ b/orc8r/cloud/helm/orc8r/values.yaml
@@ -235,6 +235,12 @@ dispatcher:
     labels: {}
     annotations: {}
 
+eventd:
+  service:
+    labels:
+      orc8r.io/swagger_spec: "true"
+    annotations: {}
+
 metricsd:
   service:
     labels:


### PR DESCRIPTION
Signed-off-by: Andy Lee Khuu <andykhuu@stanford.edu>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary
Currently the eventd service has been left out of the Service Mesh conversion and does not have its own charts that register it to be a true service. This PR adds helm charts which enable such to happen. There will be a follow up PR which reattaches the obsidian handlers of the eventd service to no longer rely on the orchestrator service.

<!-- Enumerate changes you made and why you made them -->

## Test Plan
- [x] kubectl -n magma get pods 

<img width="653" alt="Screen Shot 2021-02-17 at 3 53 25 PM" src="https://user-images.githubusercontent.com/46101219/108289699-c2ce9c80-7143-11eb-9216-4be85a14dca6.png">

- [x] Manually testing the API that things are still working.
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
