### PR TITLE
[orc8r] Fix hard coded namespace 

### DIFF
--- a/orc8r/cloud/helm/orc8r/charts/logging/templates/fluentd-daemon.configmap.yaml
+++ b/orc8r/cloud/helm/orc8r/charts/logging/templates/fluentd-daemon.configmap.yaml
@@ -2,7 +2,7 @@ kind: ConfigMap
 apiVersion: v1
 metadata:
   name: {{ .Release.Name }}-fluentd-es-configs
-  namespace: kube-system
+  namespace: {{ .Release.Namespace }}
   labels:
     addonmanager.kubernetes.io/mode: Reconcile
 data:


### PR DESCRIPTION
## Summary

When deploying 1.4, you get the following error for the fluentd-daemon.configmap.yaml template and the resource fails to create. 

```
error: the namespace from the provided object "kube-system" does not match the namespace "magma". You must pass '--namespace=kube-system' to perform this operation.
```

## Test Plan

I replaced the hard coded  `kube-system` with the correct namespace variable and re-ran the helm templating and the error went away and the resource wass created 

```
root@ctl01:~/helmchart# kubectl -n magma get cm orc8r-fluentd-es-configs
NAME                       DATA   AGE
orc8r-fluentd-es-configs   4      14m
```
