### PR TITLE
[SessionD] Reduce GRPC calls from SessionD to PipelineD

### DIFF
--- a/lte/gateway/c/session_manager/test/test_sessiond_integ.cpp
+++ b/lte/gateway/c/session_manager/test/test_sessiond_integ.cpp
@@ -355,15 +355,6 @@ TEST_F(SessiondTest, end_to_end_success) {
             CheckActivateFlowsForTunnIds(
                 IMSI1, ipv4_addrs, ipv6_addrs, enb_teid, agw_teid, 3),
             testing::_))
-        .Times(1);
-    // Here is the call for dynamic rules, which in this case should be empty.
-    EXPECT_CALL(
-        *pipelined_mock,
-        ActivateFlows(
-            testing::_,
-            CheckActivateFlowsForTunnIds(
-                IMSI1, ipv4_addrs, ipv6_addrs, enb_teid, agw_teid, 0),
-            testing::_))
         .WillOnce(testing::DoAll(
             SetPromise(&tunnel_promise), testing::Return(grpc::Status::OK)));
   }


### PR DESCRIPTION
<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary
We might still have the pipelined issue where dynamic+static rules cannot be installed together, but we can reduce the number of RPCs by checking.
<!-- Enumerate changes you made and why you made them -->

## Test Plan
make precommit_sm
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
