### PR TITLE
[lte][agw] Fixing null ptr access for PDN context sgw teid on handling create session response

### DIFF
--- a/lte/gateway/c/oai/tasks/mme_app/mme_app_bearer.c
+++ b/lte/gateway/c/oai/tasks/mme_app/mme_app_bearer.c
@@ -1123,8 +1123,10 @@ int mme_app_handle_create_sess_resp(
             "Bad pdn id (%d) for bearer\n", pdn_cx_id);
         continue;
       }
-      ue_context_p->pdn_contexts[pdn_cx_id]->s_gw_teid_s11_s4 =
-          create_sess_resp_pP->s11_sgw_fteid.teid;
+      if (ue_context_p->pdn_contexts[pdn_cx_id]) {
+        ue_context_p->pdn_contexts[pdn_cx_id]->s_gw_teid_s11_s4 =
+            create_sess_resp_pP->s11_sgw_fteid.teid;
+      }
       transaction_identifier = current_bearer_p->transaction_identifier;
     }
 


### PR DESCRIPTION
Signed-off-by: Alex Rodriguez <alexrod@fb.com>

## Summary

- There's a potential null ptr access during create session response on SGW teid property, this PR adds a check for PDN context existence.

## Test Plan

- make integ_test

## Additional Information

- [ ] This change is backwards-breaking

