### PR TITLE
[LTE][CI] set per-test 900s timeout for LTE integration tests

### DIFF
--- a/lte/gateway/python/integ_tests/Makefile
+++ b/lte/gateway/python/integ_tests/Makefile
@@ -23,8 +23,8 @@ $(PYTHON_BUILD)/setupinteg_env:
 # TODO T21489739 - Don't sleep and don't stop after a failure
 RESULTS_DIR := /var/tmp/test_results
 define execute_test
- 	echo "Running test: $(1)"
-	sudo -E PATH=$(PATH) PYTHONPATH=$(PYTHONPATH):$(S1AP_TESTER_PYTHON_PATH) $(PYTHON_BUILD)/bin/nosetests --with-xunit --xunit-file=$(RESULTS_DIR)/$(basename $(notdir $(1))).xml -x -s $(1) || exit 1
+	echo "Running test: $(1)"
+	sudo -E PATH=$(PATH) PYTHONPATH=$(PYTHONPATH):$(S1AP_TESTER_PYTHON_PATH) $(PYTHON_BUILD)/bin/nosetests --with-xunit --xunit-file=$(RESULTS_DIR)/$(basename $(notdir $(1))).xml --processes 2 --process-timeout 900 -x -s $(1) || exit 1
 	sleep 1
 endef
 


### PR DESCRIPTION
The slowest test is currently 750s, so 900s is appropriate
This is only done effectively as a CLI parameter. The timer decorator
from nosetests would still wait for the process to finish and then
report the timeout.