### PR TITLE
[helm][tf] provide default grafana volumes

### DIFF
--- a/docs/readmes/orc8r/upgrade_1_4.md
+++ b/docs/readmes/orc8r/upgrade_1_4.md
@@ -56,14 +56,14 @@ module orc8r {
 module orc8r-app {
   source = "github.com/magma/magma//orc8r/cloud/deploy/terraform/orc8r-helm-aws?ref=v1.4"
   # ...
-  orc8r_chart_version   = "1.5.15"
+  orc8r_chart_version   = "1.5.16"
   orc8r_tag             = "MAGMA_TAG"  # from build step, e.g. v1.4.0
   orc8r_deployment_type = "fwa"        # valid options: ["fwa", "federated_fwa", "all"]
 }
 ```
 
 Set `cluster_version` to the Kubernetes version found during the
-`Prerequisites` section. Bump your chart version to `1.5.15` and `orc8r_tag` to
+`Prerequisites` section. Bump your chart version to `1.5.16` and `orc8r_tag` to
 the semver tag you published your new Orchestrator container images as.
 You also need to set the `orc8r_deployment_type` variable to the deployment
 type that you intend to deploy. This type sets which orc8r modules will run.

--- a/orc8r/cloud/deploy/terraform/orc8r-helm-aws/templates/orc8r-values.tpl
+++ b/orc8r/cloud/deploy/terraform/orc8r-helm-aws/templates/orc8r-values.tpl
@@ -115,17 +115,21 @@ metrics:
     create: ${create_usergrafana}
     volumes:
       datasources:
-        persistentVolumeClaim:
-          claimName: ${grafana_pvc_grafanaDatasources}
+        volumeSpec:
+          persistentVolumeClaim:
+            claimName: ${grafana_pvc_grafanaDatasources}
       dashboardproviders:
-        persistentVolumeClaim:
-          claimName: ${grafana_pvc_grafanaProviders}
+        volumeSpec:
+          persistentVolumeClaim:
+            claimName: ${grafana_pvc_grafanaProviders}
       dashboards:
-        persistentVolumeClaim:
-          claimName: ${grafana_pvc_grafanaDashboards}
+        volumeSpec:
+          persistentVolumeClaim:
+            claimName: ${grafana_pvc_grafanaDashboards}
       grafanaData:
-        persistentVolumeClaim:
-          claimName: ${grafana_pvc_grafanaData}
+        volumeSpec:
+          persistentVolumeClaim:
+            claimName: ${grafana_pvc_grafanaData}
 
   thanos:
     enabled: ${thanos_enabled}

--- a/orc8r/cloud/helm/orc8r/Chart.lock
+++ b/orc8r/cloud/helm/orc8r/Chart.lock
@@ -4,7 +4,7 @@ dependencies:
   version: 0.1.10
 - name: metrics
   repository: ""
-  version: 1.4.21
+  version: 1.4.22
 - name: nms
   repository: ""
   version: 0.1.9
@@ -14,5 +14,5 @@ dependencies:
 - name: orc8rlib
   repository: file://../orc8rlib
   version: 0.1.2
-digest: sha256:d157bbd42149d3d52806e1727e02f39555e367a54b5fe6f1be4af61d64186484
-generated: "2021-02-25T09:56:22.461744047+05:30"
+digest: sha256:2cc15507df1e81fdd345dd88d25fae40aac58f9a4d2b9aa813d2f52e80785969
+generated: "2021-03-03T10:38:07.173141-08:00"

--- a/orc8r/cloud/helm/orc8r/Chart.yaml
+++ b/orc8r/cloud/helm/orc8r/Chart.yaml
@@ -13,7 +13,7 @@ apiVersion: v2
 appVersion: "1.0"
 description: A Helm chart for magma orchestrator
 name: orc8r
-version: 1.5.15
+version: 1.5.16
 engine: gotpl
 sources:
   - https://github.com/magma/magma
@@ -27,7 +27,7 @@ dependencies:
     repository: ""
     condition: secrets.create
   - name: metrics
-    version: 1.4.21
+    version: 1.4.22
     repository: ""
     condition: metrics.enabled
   - name: nms

--- a/orc8r/cloud/helm/orc8r/charts/metrics/Chart.yaml
+++ b/orc8r/cloud/helm/orc8r/charts/metrics/Chart.yaml
@@ -13,7 +13,7 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for magma metrics
 name: metrics
-version: 1.4.21
+version: 1.4.22
 engine: gotpl
 sources:
   - https://github.com/magma/magma

--- a/orc8r/cloud/helm/orc8r/charts/metrics/templates/user-grafana.deployment.yaml
+++ b/orc8r/cloud/helm/orc8r/charts/metrics/templates/user-grafana.deployment.yaml
@@ -90,13 +90,29 @@ spec:
           configMap:
             name: grafana-config-file
         - name: "datasources"
-{{ toYaml .Values.userGrafana.volumes.datasources | indent 10 }}
+{{- if .Values.userGrafana.volumes.datasources.volumeSpec }}
+{{ toYaml .Values.userGrafana.volumes.datasources.volumeSpec | indent 10 }}
+{{- else }}
+{{ toYaml .Values.userGrafana.volumes.datasources.defaultVolumeSpec | indent 10 }}
+{{- end }}
         - name: "dashboardproviders"
-{{ toYaml .Values.userGrafana.volumes.dashboardproviders | indent 10 }}
+{{- if .Values.userGrafana.volumes.dashboardproviders.volumeSpec }}
+{{ toYaml .Values.userGrafana.volumes.dashboardproviders.volumeSpec | indent 10 }}
+{{- else }}
+{{ toYaml .Values.userGrafana.volumes.dashboardproviders.defaultVolumeSpec | indent 10 }}
+{{- end }}
         - name: "dashboards"
-{{ toYaml .Values.userGrafana.volumes.dashboards | indent 10 }}
+{{- if .Values.userGrafana.volumes.dashboards.volumeSpec }}
+{{ toYaml .Values.userGrafana.volumes.dashboards.volumeSpec | indent 10 }}
+{{- else }}
+{{ toYaml .Values.userGrafana.volumes.dashboards.defaultVolumeSpec | indent 10 }}
+{{- end }}
         - name: "grafana-data"
-{{ toYaml .Values.userGrafana.volumes.grafanaData | indent 10 }}
+{{- if .Values.userGrafana.volumes.grafanaData.volumeSpec }}
+{{ toYaml .Values.userGrafana.volumes.grafanaData.volumeSpec | indent 10 }}
+{{- else }}
+{{ toYaml .Values.userGrafana.volumes.grafanaData.defaultVolumeSpec | indent 10 }}
+{{- end }}
 
 
 ---

--- a/orc8r/cloud/helm/orc8r/charts/metrics/values.yaml
+++ b/orc8r/cloud/helm/orc8r/charts/metrics/values.yaml
@@ -299,10 +299,30 @@ userGrafana:
 
   volumes:
     # Default volume configurations for grafana data.
-    dashboards: {}
-    datasources: {}
-    dashboardproviders: {}
-    grafanaData: {}
+    dashboards:
+      volumeSpec: {}
+      defaultVolumeSpec:
+        hostPath:
+          path: /usergrafana/dashboards
+          type: DirectoryOrCreate
+    datasources:
+      volumeSpec: {}
+      defaultVolumeSpec:
+        hostPath:
+          path: /usergrafana/datasources
+          type: DirectoryOrCreate
+    dashboardproviders:
+      volumeSpec: {}
+      defaultVolumeSpec:
+        hostPath:
+          path: /usergrafana/dashboardproviders
+          type: DirectoryOrCreate
+    grafanaData:
+      volumeSpec: {}
+      defaultVolumeSpec:
+        hostPath:
+          path: /usergrafana/grafanaData
+          type: DirectoryOrCreate
 
   image:
     repository: grafana/grafana


### PR DESCRIPTION
Signed-off-by: Scott8440 <scott8440@gmail.com>

## Summary
Partner engineer found a helm templating problem when deploying on bare metal due to grafana volume values being empty. The default values for these volumes were passed in as empty objects `{}` because of the way helm merges key/values from values files. If a real default was provided then the "override" would not actually override and instead provide to volume specs for the same volume which would cause templating to fail. To solve this, I use a field `defaultVolumeSpec` in all the grafana volume values and check if a real value is provided. If so, the real value is used otherwise it falls back to the default. 

## Test Plan
Deployed with Terraform:
```
Volumes:
  config:
    Type:      ConfigMap (a volume populated by a ConfigMap)
    Name:      grafana-config-file
    Optional:  false
  datasources:
    Type:       PersistentVolumeClaim (a reference to a PersistentVolumeClaim in the same namespace)
    ClaimName:  grafanadatasources
    ReadOnly:   false
  dashboardproviders:
    Type:       PersistentVolumeClaim (a reference to a PersistentVolumeClaim in the same namespace)
    ClaimName:  grafanaproviders
    ReadOnly:   false
  dashboards:
    Type:       PersistentVolumeClaim (a reference to a PersistentVolumeClaim in the same namespace)
    ClaimName:  grafanadashboards
    ReadOnly:   false
  grafana-data:
    Type:       PersistentVolumeClaim (a reference to a PersistentVolumeClaim in the same namespace)
    ClaimName:  grafanadata
    ReadOnly:   false
```

Deployed on minikube with/without values and saw expected results
