### PR TITLE
AGW: pipelined: qos: fix recovery of APN AMBR config

### DIFF
--- a/lte/gateway/configs/pipelined.yml
+++ b/lte/gateway/configs/pipelined.yml
@@ -116,6 +116,7 @@ qos:
  ovs_meter:
   min_idx: 2
   max_idx: 100000
+ apn_ambr_enabled: true
 
 monitored_ifaces: ['gtp_br0',
                    'gtp0',

--- a/lte/gateway/python/magma/pipelined/qos/common.py
+++ b/lte/gateway/python/magma/pipelined/qos/common.py
@@ -18,7 +18,8 @@ from enum import Enum
 from lte.protos.policydb_pb2 import FlowMatch
 from magma.pipelined.qos.qos_meter_impl import MeterManager
 from magma.pipelined.qos.qos_tc_impl import TCManager, TrafficClass
-from magma.pipelined.qos.types import QosInfo, get_json, get_key, get_subscriber_key
+from magma.pipelined.qos.types import QosInfo, get_key_json, get_key, get_subscriber_key,\
+    get_subscriber_data, get_data_json, get_data
 from magma.pipelined.qos.utils import QosStore
 from magma.configuration.service_configs import load_service_config
 import traceback
@@ -104,17 +105,24 @@ class SubscriberState(object):
                 break
         return session_with_rule
 
-    def update_rule(self, ip_addr: str, rule_num: int, d: FlowMatch.Direction,
-                    qos_handle: int) -> None:
-        k = get_subscriber_key(self.imsi, ip_addr, rule_num, d)
-        self._redis_store[get_json(k)] = qos_handle
+    def _update_rules_map(self, ip_addr: str, rule_num: int, d: FlowMatch.Direction,
+                    qos_data) -> None:
 
         if rule_num not in self.rules:
             self.rules[rule_num] = []
 
         session = self.get_or_create_session(ip_addr)
         session.rules.add(rule_num)
-        self.rules[rule_num].append((d, qos_handle))
+        self.rules[rule_num].append((d, qos_data))
+
+    def update_rule(self, ip_addr: str, rule_num: int, d: FlowMatch.Direction,
+                    qos_handle: int, ambr: int, leaf: int) -> None:
+        k = get_key_json(get_subscriber_key(self.imsi, ip_addr, rule_num, d))
+        qos_data = get_data_json(get_subscriber_data(qos_handle, ambr, leaf))
+        LOG.debug("Update: %s -> %s", k, qos_data)
+        self._redis_store[k] = qos_data
+
+        self._update_rules_map(ip_addr, rule_num, d, qos_data)
 
     def remove_rule(self, rule_num: int) -> None:
         session_with_rule = self.find_session_with_rule(rule_num)
@@ -122,8 +130,8 @@ class SubscriberState(object):
             for (d, _) in self.rules[rule_num]:
                 k = get_subscriber_key(self.imsi, session_with_rule.ip_addr,
                                        rule_num, d)
-                if get_json(k) in self._redis_store:
-                    del self._redis_store[get_json(k)]
+                if get_key_json(k) in self._redis_store:
+                    del self._redis_store[get_key_json(k)]
 
         del self.rules[rule_num]
         session_with_rule.rules.remove(rule_num)
@@ -140,9 +148,10 @@ class SubscriberState(object):
     def get_qos_handle(self, rule_num: int, direction: FlowMatch.Direction) -> int:
         rule = self.rules.get(rule_num)
         if rule:
-            for d, qos_handle in rule:
+            for d, qos_data in rule:
                 if d == direction:
-                    return qos_handle
+                    _, qid, _, _ = get_data(qos_data)
+                    return qid
         return 0
 
 
@@ -178,16 +187,27 @@ class QosManager(object):
         qos_store = QosStore(cls.__name__)
         for k, v in qos_store.items():
             _, imsi, ip_addr, rule_num, d = get_key(k)
+            _, qid, ambr, leaf = get_data(v)
             print('imsi :', imsi)
             print('ip_addr :', ip_addr)
             print('rule_num :', rule_num)
             print('direction :', d)
-            print('qos_handle:', v)
+            print('qos_handle:', qid)
+            print('qos_handle_ambr:', ambr)
+            print('qos_handle_ambr_leaf:', leaf)
             if qos_impl_type == QosImplType.OVS_METER:
                 MeterManager.dump_meter_state(v)
             else:
                 intf = 'nat_iface' if d == FlowMatch.UPLINK else 'enodeb_iface'
-                TrafficClass.dump_class_state(config[intf], v)
+                print("Dev: ", config[intf])
+                TrafficClass.dump_class_state(config[intf], qid)
+                if leaf and leaf != qid:
+                    print("Leaf:")
+                    TrafficClass.dump_class_state(config[intf], leaf)
+                if ambr:
+                    print("AMBR (parent):")
+                    TrafficClass.dump_class_state(config[intf], ambr)
+
 
     def _is_redis_available(self):
         try:
@@ -200,7 +220,8 @@ class QosManager(object):
         self._qos_enabled = config["qos"]["enable"]
         if not self._qos_enabled:
             return
-
+        self._apn_ambr_enabled = config["qos"].get("apn_ambr_enabled", True)
+        LOG.info("QoS: apn_ambr_enabled: %s", self._apn_ambr_enabled)
         self._clean_restart = config["clean_restart"]
         self._subscriber_state = {}
         self._loop = loop
@@ -234,61 +255,76 @@ class QosManager(object):
             LOG.info("Qos Setup: recovering existing state")
             self.impl.setup()
 
-            qos_state, apn_qid_list = self.impl.read_all_state()
-            LOG.debug("qos_state -> %s", json.dumps(qos_state, indent=1))
+            cur_qos_state, apn_qid_list = self.impl.read_all_state()
+            LOG.debug("Initial qos_state -> %s", json.dumps(cur_qos_state, indent=1))
             LOG.debug("apn_qid_list -> %s", apn_qid_list)
+            LOG.debug("Redis state: %s", self._redis_store)
             try:
                 # populate state from db
                 in_store_qid = set()
+                in_store_ambr_qid = set()
                 purge_store_set = set()
-                for rule, qid in self._redis_store.items():
-                    if qid not in qos_state:
+                for rule, sub_data in self._redis_store.items():
+                    _, qid, ambr, leaf = get_data(sub_data)
+                    if qid not in cur_qos_state:
+                        LOG.warning("missing qid: %s in TC", qid)
                         purge_store_set.add(rule)
                         continue
-                    in_store_qid.add(qid)
-                    _, imsi, ip_addr, rule_num, direction = get_key(rule)
-                    subscriber = self.get_or_create_subscriber(imsi)
-                    subscriber.update_rule(ip_addr, rule_num, direction, qid)
+                    if ambr and ambr != 0 and ambr not in cur_qos_state:
+                        purge_store_set.add(rule)
+                        LOG.warning("missing ambr class: %s of qid %d",ambr, qid)
+                        continue
+                    if leaf and leaf != 0 and leaf not in cur_qos_state:
+                        purge_store_set.add(rule)
+                        LOG.warning("missing leaf class: %s of qid %d",leaf, qid)
+                        continue
 
-                    qid_state = qos_state[qid]
-                    if qid_state['ambr_qid'] != 0:
-                        session = subscriber.get_or_create_session(ip_addr)
-                        ambr_qid = qid_state['ambr_qid']
-                        leaf = 0
-                        # its AMBR QoS handle if its config matches with parent
-                        # pylint: disable=too-many-function-args
-                        if self.impl.same_qos_config(direction, ambr_qid, qid):
-                            leaf = qid
-                        session.set_ambr(direction, qid_state['ambr_qid'], leaf)
+                    if ambr:
+                        qid_state = cur_qos_state[qid]
+                        if qid_state['ambr_qid'] != ambr:
+                            purge_store_set.add(rule)
+                            LOG.warning("Inconsistent amber class: %s of qid %d", qid_state['ambr_qid'], ambr)
+                            continue
+
+                    in_store_qid.add(qid)
+                    if ambr:
+                        in_store_qid.add(ambr)
+                        in_store_ambr_qid.add(ambr)
+                    in_store_qid.add(leaf)
+
+                    _, imsi, ip_addr, rule_num, direction = get_key(rule)
+
+                    subscriber = self.get_or_create_subscriber(imsi)
+                    subscriber.update_rule(ip_addr, rule_num, direction, qid, ambr, leaf)
+                    session = subscriber.get_or_create_session(ip_addr)
+                    session.set_ambr(direction, ambr, leaf)
 
                 # purge entries from qos_store
                 for rule in purge_store_set:
-                    LOG.debug("purging qos_store entry %s qos_handle", rule)
+                    LOG.debug("purging qos_store entry %s", rule)
                     del self._redis_store[rule]
 
                 # purge unreferenced qos configs from system
                 # Step 1. Delete child nodes
-                apn_list_for_step_2 = []
-                for qos_handle in qos_state:
+                lost_and_found_apn_list = set()
+                for qos_handle in cur_qos_state:
                     if qos_handle not in in_store_qid:
                         if qos_handle in apn_qid_list:
-                            apn_list_for_step_2.append(qos_handle)
+                            lost_and_found_apn_list.add(qos_handle)
                         else:
                             LOG.debug("removing qos_handle %d", qos_handle)
                             self.impl.remove_qos(qos_handle,
-                                                 qos_state[qos_handle]['direction'],
+                                                 cur_qos_state[qos_handle]['direction'],
                                                  recovery_mode=True)
 
-                # Step 2. delete qos handle without any child
-                qos_state2, apn_qid_list2 = self.impl.read_all_state()
-                LOG.debug("intermediate qos_state -> %s", json.dumps(qos_state2, indent=1))
-                LOG.debug("intermediate apn_qid_list -> %s", apn_qid_list2)
-                for qos_handle in apn_list_for_step_2:
-                    if qos_handle not in apn_qid_list2:
-                        LOG.debug("removing qos_handle %d", qos_handle)
-                        self.impl.remove_qos(qos_handle,
-                                             qos_state[qos_handle]['direction'],
-                                             recovery_mode=True)
+                if len(lost_and_found_apn_list) > 0:
+                    # Step 2. delete qos ambr without any leaf nodes
+                    for qos_handle in lost_and_found_apn_list:
+                        if qos_handle not in in_store_ambr_qid:
+                            LOG.debug("removing apn qos_handle %d", qos_handle)
+                            self.impl.remove_qos(qos_handle,
+                                                 cur_qos_state[qos_handle]['direction'],
+                                                 recovery_mode=True)
                 final_qos_state, _ = self.impl.read_all_state()
                 LOG.info("final_qos_state -> %s", json.dumps(final_qos_state, indent=1))
                 LOG.info("final_redis state -> %s", self._redis_store)
@@ -317,7 +353,7 @@ class QosManager(object):
             qos_info: QosInfo,
     ):
         if not self._qos_enabled or not self._initialized:
-            LOG.error("add_subscriber_qos: not enabled or initialized")
+            LOG.debug("add_subscriber_qos: not enabled or initialized")
             return None, None
 
         LOG.debug("adding qos for imsi %s rule_num %d direction %d apn_ambr %d, qos_info %s",
@@ -334,14 +370,15 @@ class QosManager(object):
         subscriber_state = self.get_or_create_subscriber(imsi)
 
         qos_handle = subscriber_state.get_qos_handle(rule_num, direction)
-        LOG.debug("existing rec: qos_handle %d", qos_handle)
         if qos_handle:
             LOG.debug("qos exists for imsi %s rule_num %d direction %d",
                       imsi, rule_num, direction)
+
             return self.impl.get_action_instruction(qos_handle)
 
-        ambr_qos_handle_root = None
-        if apn_ambr > 0:
+        ambr_qos_handle_root = 0
+        ambr_qos_handle_leaf = 0
+        if self._apn_ambr_enabled and apn_ambr > 0:
             session = subscriber_state.get_or_create_session(ip_addr)
             ambr_qos_handle_root = session.get_ambr(direction)
             LOG.debug("existing root rec: ambr_qos_handle_root %d", ambr_qos_handle_root)
@@ -384,13 +421,15 @@ class QosManager(object):
                 LOG.error('Failed adding qos %s direction %d', qos_info, direction)
                 return None, None
 
-        LOG.debug("qos_handle %d", qos_handle)
-        subscriber_state.update_rule(ip_addr, rule_num, direction, qos_handle)
-        return self.impl.get_action_instruction(qos_handle)
+        if qos_handle:
+            subscriber_state.update_rule(ip_addr, rule_num, direction,
+                                         qos_handle, ambr_qos_handle_root, ambr_qos_handle_leaf)
+            return self.impl.get_action_instruction(qos_handle)
+        return None, None
 
     def remove_subscriber_qos(self, imsi: str = "", rule_num: int = -1):
         if not self._qos_enabled or not self._initialized:
-            LOG.error("remove_subscriber_qos: not enabled or initialized")
+            LOG.debug("remove_subscriber_qos: not enabled or initialized")
             return
 
         LOG.debug("removing Qos for imsi %s rule_num %d", imsi, rule_num)
@@ -404,29 +443,32 @@ class QosManager(object):
             LOG.debug('imsi %s not found, nothing to remove ', imsi)
             return
 
-        to_be_deleted_rules = []
+        to_be_deleted_rules = set()
         if rule_num == -1:
             # deleting all rules for the subscriber
             rules = subscriber_state.get_all_rules()
             for (rule_num, rule) in rules.items():
-                LOG.debug("removing rule %s %s ", imsi, rule_num)
                 session_with_rule = subscriber_state.find_session_with_rule(rule_num)
-                for (d, qos_handle) in rule:
-                    if session_with_rule.get_ambr(d) != qos_handle:
-                        self.impl.remove_qos(qos_handle, d)
-                to_be_deleted_rules.append(rule_num)
+                for (d, qos_data) in rule:
+                    _, qid, _, leaf = get_data(qos_data)
+                    if session_with_rule.get_ambr(d) != qid:
+                        self.impl.remove_qos(qid, d)
+                to_be_deleted_rules.add(rule_num)
         else:
             rule = subscriber_state.find_rule(rule_num)
-            if rule is None:
-                LOG.error("unable to find rule_num %d for imsi %s", rule_num, imsi)
-                return
+            if rule:
+                session_with_rule = subscriber_state.find_session_with_rule(rule_num)
+                for (d, qos_data) in rule:
+                    _, qid, _, leaf = get_data(qos_data)
+                    if session_with_rule.get_ambr(d) != qid:
+                        self.impl.remove_qos(qid, d)
+                        if leaf and leaf != qid:
+                            self.impl.remove_qos(leaf, d)
 
-            session_with_rule = subscriber_state.find_session_with_rule(rule_num)
-            for (d, qos_handle) in rule:
-                if session_with_rule.get_ambr(d) != qos_handle:
-                    self.impl.remove_qos(qos_handle, d)
-            LOG.debug("removing rule %s %s ", imsi, rule_num)
-            to_be_deleted_rules.append(rule_num)
+                LOG.debug("removing rule %s %s ", imsi, rule_num)
+                to_be_deleted_rules.add(rule_num)
+            else:
+                LOG.debug("unable to find rule_num %d for imsi %s", rule_num, imsi)
 
         for rule_num in to_be_deleted_rules:
             subscriber_state.remove_rule(rule_num)

--- a/lte/gateway/python/magma/pipelined/qos/types.py
+++ b/lte/gateway/python/magma/pipelined/qos/types.py
@@ -17,17 +17,34 @@ QosInfo = namedtuple('QosInfo', 'gbr mbr')
 
 # key_type - identifies the type of QosKey. This ideally should be in base type
 # Will modify this when dataclasses are available
-SubscriberKey = namedtuple('SubscriberKey', 'key_type imsi ip_addr rule_num direction')
+SubscriberRuleKey = namedtuple('SubscriberRuleKey', 'key_type imsi ip_addr rule_num direction')
 
 
 def get_subscriber_key(*args):
     keyType = "Subscriber"
-    return SubscriberKey(keyType, *args)
+    return SubscriberRuleKey(keyType, *args)
 
 
-def get_json(key):
+def get_key_json(key):
     return json.dumps(key)
 
 
 def get_key(json_val):
-    return SubscriberKey(*json.loads(json_val))
+    return SubscriberRuleKey(*json.loads(json_val))
+
+
+SubscriberRuleData = namedtuple('SubscriberRuleData', 'data_type qid ambr leaf')
+
+
+def get_subscriber_data(*args):
+    keyType = "qos_data"
+    return SubscriberRuleData(keyType, *args)
+
+
+def get_data_json(key):
+    return json.dumps(key)
+
+
+def get_data(json_val):
+    return SubscriberRuleData(*json.loads(json_val))
+

--- a/lte/gateway/python/magma/pipelined/qos/utils.py
+++ b/lte/gateway/python/magma/pipelined/qos/utils.py
@@ -32,6 +32,7 @@ class IdManager(object):
         self._counter = start_idx
         self._free_idx_list = deque()
         self._lock = threading.RLock()  # re-entrant locks
+        self._restore_done = False
 
     def allocate_idx(self,) -> int:
         with self._lock:
@@ -55,6 +56,8 @@ class IdManager(object):
 
     def restore_state(self, id_set):
         with self._lock:
+            if self._restore_done:
+                return
             if not id_set:
                 return
 
@@ -62,6 +65,7 @@ class IdManager(object):
             for idx in range(self._start_idx, self._counter):
                 if idx not in id_set:
                     self._free_idx_list.append(idx)
+            self._restore_done = True
 
     def _get_free_idx(self) -> int:
         if self._free_idx_list:

--- a/lte/gateway/python/magma/pipelined/tests/test_qos.py
+++ b/lte/gateway/python/magma/pipelined/tests/test_qos.py
@@ -19,10 +19,11 @@ from unittest.mock import MagicMock, call, patch
 from magma.pipelined.qos.common import QosImplType, QosManager, SubscriberState
 from magma.pipelined.qos.qos_meter_impl import MeterManager
 from magma.pipelined.qos.qos_tc_impl import TrafficClass, argSplit, run_cmd
-from magma.pipelined.qos.types import QosInfo, get_json, get_key, get_subscriber_key
+from magma.pipelined.qos.types import QosInfo, get_key_json, get_key, get_subscriber_key, \
+        get_subscriber_data, get_data, get_data_json
 from magma.pipelined.qos.utils import IdManager
 from lte.protos.policydb_pb2 import FlowMatch
-
+import logging
 
 class TestQosCommon(unittest.TestCase):
     def testIdManager(self):
@@ -80,7 +81,7 @@ class TestQosCommon(unittest.TestCase):
 
     def testQosKeyUtils(self):
         k = get_subscriber_key("1234", '1.1.1.1', 10, 0)
-        j = get_json(k)
+        j = get_key_json(k)
         self.assertTrue(get_key(j) == k)
 
 
@@ -103,7 +104,7 @@ class TestQosManager(unittest.TestCase):
         }
 
     def verifyTcAddQos(self, mock_get_action_inst, mock_traffic_cls, d, qid, qos_info,
-                       parent_qid=None):
+                       parent_qid=0):
         intf = self.ul_intf if d == FlowMatch.UPLINK else self.dl_intf
         mock_get_action_inst.assert_any_call(qid)
         mock_traffic_cls.init_qdisc.assert_any_call(self.ul_intf)
@@ -187,22 +188,25 @@ get_action_instruction"
         qos_mgr.add_subscriber_qos(imsi, ip_addr, 0, rule_num, FlowMatch.UPLINK, qos_info)
         qos_mgr.add_subscriber_qos(imsi, ip_addr, 0, rule_num, FlowMatch.DOWNLINK, qos_info)
 
-        k1 = get_json(get_subscriber_key(imsi, ip_addr, rule_num, FlowMatch.UPLINK))
-        k2 = get_json(get_subscriber_key(imsi, ip_addr, rule_num, FlowMatch.DOWNLINK))
+        k1 = get_key_json(get_subscriber_key(imsi, ip_addr, rule_num, FlowMatch.UPLINK))
+        k2 = get_key_json(get_subscriber_key(imsi, ip_addr, rule_num, FlowMatch.DOWNLINK))
         ul_exp_id = qos_mgr.impl._start_idx
         dl_exp_id = qos_mgr.impl._start_idx + 1
-        self.assertTrue(qos_mgr._redis_store[k1] == ul_exp_id)
-        self.assertTrue(qos_mgr._redis_store[k2] == dl_exp_id)
-        self.assertTrue(qos_mgr._subscriber_state[imsi].rules[rule_num][0] == (0, ul_exp_id))
-        self.assertTrue(qos_mgr._subscriber_state[imsi].rules[rule_num][1] == (1, dl_exp_id))
+        ul_qid_info = get_data_json(get_subscriber_data(ul_exp_id, 0, 0))
+        dl_qid_info = get_data_json(get_subscriber_data(dl_exp_id, 0, 0))
+
+        self.assertTrue(qos_mgr._redis_store[k1] == ul_qid_info)
+        self.assertTrue(qos_mgr._redis_store[k2] == dl_qid_info)
+        self.assertTrue(qos_mgr._subscriber_state[imsi].rules[rule_num][0] == (0, ul_qid_info))
+        self.assertTrue(qos_mgr._subscriber_state[imsi].rules[rule_num][1] == (1, dl_qid_info))
 
         # add the same subscriber and ensure that we didn't create another
         # qos config for the subscriber
         qos_mgr.add_subscriber_qos(imsi, ip_addr, 0, rule_num, FlowMatch.UPLINK, qos_info)
         qos_mgr.add_subscriber_qos(imsi, ip_addr, 0, rule_num, FlowMatch.DOWNLINK, qos_info)
 
-        self.assertTrue(qos_mgr._subscriber_state[imsi].rules[rule_num][0] == (0, ul_exp_id))
-        self.assertTrue(qos_mgr._subscriber_state[imsi].rules[rule_num][1] == (1, dl_exp_id))
+        self.assertTrue(qos_mgr._subscriber_state[imsi].rules[rule_num][0] == (0, ul_qid_info))
+        self.assertTrue(qos_mgr._subscriber_state[imsi].rules[rule_num][1] == (1, dl_qid_info))
 
         # verify if traffic class was invoked properly
         if self.config["qos"]["impl"] == QosImplType.OVS_METER:
@@ -284,7 +288,12 @@ get_action_instruction"
         qos_mgr = QosManager(MagicMock, asyncio.new_event_loop(), self.config)
         qos_mgr._redis_store = {}
         qos_mgr._setupInternal()
-        rule_list1 = [("1", 0, 0), ("1", 1, 0), ("1", 2, 1), ("2", 0, 0)]
+        rule_list1 = [
+            ("1", 0, 0),
+            ("1", 1, 0),
+            ("1", 2, 1),
+            ("2", 0, 0)
+        ]
 
         rule_list2 = [
             ("2", 1, 0),
@@ -305,11 +314,11 @@ get_action_instruction"
             qos_mgr.add_subscriber_qos(imsi, '', 0, rule_num, d, qos_info)
 
             exp_id = id_list[i]
-            k = get_json(get_subscriber_key(imsi, '', rule_num, d))
+            k = get_key_json(get_subscriber_key(imsi, '', rule_num, d))
             exp_id_dict[k] = exp_id
             # self.assertTrue(qos_mgr._redis_store[k] == exp_id)
-
-            self.assertTrue(qos_mgr._subscriber_state[imsi].rules[rule_num][0] == (d, exp_id))
+            qid_info = get_data_json(get_subscriber_data(exp_id, 0, 0))
+            self.assertEqual(qos_mgr._subscriber_state[imsi].rules[rule_num][0], (d, qid_info))
 
             if self.config["qos"]["impl"] == QosImplType.OVS_METER:
                 self.verifyMeterAddQos(
@@ -323,7 +332,7 @@ get_action_instruction"
         # deactivate one rule
         # verify for imsi1 if rule num 0 gets cleaned up
         imsi, rule_num, d = rule_list1[0]
-        k = get_json(get_subscriber_key(imsi, '', rule_num, d))
+        k = get_key_json(get_subscriber_key(imsi, '', rule_num, d))
         exp_id = exp_id_dict[k]
 
         qos_mgr.remove_subscriber_qos(imsi, rule_num)
@@ -336,11 +345,11 @@ get_action_instruction"
             self.verifyTcRemoveQos(mock_traffic_cls, d, exp_id)
 
         # deactivate same rule and check if we log properly
-        with self.assertLogs("pipelined.qos.common", level="ERROR") as cm:
+        with self.assertLogs("pipelined.qos.common", level="DEBUG") as cm:
             qos_mgr.remove_subscriber_qos(imsi, rule_num)
 
         error_msg = "unable to find rule_num 0 for imsi 1"
-        self.assertTrue(cm.output[0].endswith(error_msg))
+        self.assertTrue(cm.output[1].endswith(error_msg))
 
         # deactivate imsi
         # verify for imsi1 if rule num 1 and 2 gets cleaned up
@@ -350,7 +359,7 @@ get_action_instruction"
             if imsi != "1":
                 continue
 
-            k = get_json(get_subscriber_key(imsi, '', rule_num, d))
+            k = get_key_json(get_subscriber_key(imsi, '', rule_num, d))
             exp_id = exp_id_dict[k]
             self.assertTrue(k not in qos_mgr._redis_store)
             remove_qos_args.append((d, exp_id))
@@ -363,8 +372,12 @@ get_action_instruction"
         self.assertTrue("1" not in qos_mgr._subscriber_state)
 
         # deactivate same imsi again and ensure nothing bad happens
+
+        logging.debug("removing qos")
         with self.assertLogs("pipelined.qos.common", level="DEBUG") as cm:
             qos_mgr.remove_subscriber_qos("1")
+        logging.debug("removing qos: done")
+
         error_msg = "imsi 1 not found"
         self.assertTrue(error_msg in cm.output[-1])
 
@@ -373,6 +386,7 @@ get_action_instruction"
         assert(len(qos_mgr._subscriber_state['2'].rules) == 1)
         assert(len(qos_mgr._subscriber_state['2'].rules[0]) == 1)
         existing_qid = qos_mgr._subscriber_state['2'].rules[0][0][1]
+        _, existing_qid, _, _ = get_data(existing_qid)
 
         # add second rule list and delete and verify if things work
         qos_info = QosInfo(100000, 200000)
@@ -385,9 +399,11 @@ get_action_instruction"
         for i, (imsi, rule_num, d) in enumerate(rule_list2):
             qos_mgr.add_subscriber_qos(imsi, '', 0, rule_num, d, qos_info)
             exp_id = id_list[i]
-            k = get_json(get_subscriber_key(imsi, '', rule_num, d))
-            self.assertTrue(qos_mgr._redis_store[k] == exp_id)
-            self.assertTrue(qos_mgr._subscriber_state[imsi].rules[rule_num][0] == (d, exp_id))
+            qid_info = get_data_json(get_subscriber_data(exp_id, 0, 0))
+
+            k = get_key_json(get_subscriber_key(imsi, '', rule_num, d))
+            self.assertEqual(qos_mgr._redis_store[k], qid_info)
+            self.assertEqual(qos_mgr._subscriber_state[imsi].rules[rule_num][0], (d, qid_info))
             if self.config["qos"]["impl"] == QosImplType.OVS_METER:
                 self.verifyMeterAddQos(
                     mock_meter_get_action_inst, mock_meter_cls, d, exp_id, qos_info
@@ -414,7 +430,7 @@ get_action_instruction"
 
         # imsi2 from rule_list1 alone wasn't removed
         imsi, rule_num, d = rule_list1[3]
-        k = get_json(get_subscriber_key(imsi, '', rule_num, d))
+        k = get_key_json(get_subscriber_key(imsi, '', rule_num, d))
         self.assertTrue(not qos_mgr._redis_store)
         self.assertTrue(not qos_mgr._subscriber_state)
         if self.config["qos"]["impl"] == QosImplType.OVS_METER:
@@ -439,8 +455,9 @@ get_action_instruction"
         def populate_db(qid_list, rule_list):
             qos_mgr._redis_store.clear()
             for i, t in enumerate(rule_list):
-                k = get_json(get_subscriber_key(*t))
-                qos_mgr._redis_store[k] = qid_list[i]
+                k = get_key_json(get_subscriber_key(*t))
+                v = get_data_json(get_subscriber_data(qid_list[i], 0, 0))
+                qos_mgr._redis_store[k] = v
 
         MockSt = namedtuple("MockSt", "meter_id")
         dummy_meter_ev_body = [MockSt(11), MockSt(13), MockSt(2), MockSt(15)]
@@ -467,7 +484,13 @@ get_action_instruction"
         qos_mgr._setupInternal()
 
         # verify that qos_handle 20 not found in system is purged from map
-        self.assertFalse([v for _, v in qos_mgr._redis_store.items() if v == 20])
+        qid_list = []
+        for _, v in qos_mgr._redis_store.items():
+            _, qid, _, _ = get_data(v)
+            qid_list.append(qid)
+
+        logging.debug("qid_list %s", qid_list)
+        self.assertNotIn(20, qid_list)
 
         # verify that unreferenced qos configs are purged from the system
         if self.config["qos"]["impl"] == QosImplType.OVS_METER:
@@ -479,11 +502,13 @@ get_action_instruction"
         imsi, rule_num, d, qos_info = "3", 0, 0, QosInfo(100000, 100000)
         qos_mgr.impl.get_action_instruction = MagicMock
         qos_mgr.add_subscriber_qos(imsi, '', 0, rule_num, d, qos_info)
-        k = get_json(get_subscriber_key(imsi, '', rule_num, d))
+        k = get_key_json(get_subscriber_key(imsi, '', rule_num, d))
 
         exp_id = 3  # since start_idx 2 is already used
-        self.assertTrue(qos_mgr._redis_store[k] == exp_id)
-        self.assertTrue(qos_mgr._subscriber_state[imsi].rules[rule_num][0] == (d, exp_id))
+        d3 = get_data_json(get_subscriber_data(exp_id, 0, 0))
+
+        self.assertEqual(qos_mgr._redis_store[k], d3)
+        self.assertEqual(qos_mgr._subscriber_state[imsi].rules[rule_num][0], (d, d3))
 
         # delete the restored rule - ensure that it gets cleaned properly
         purge_imsi = "1"
@@ -548,6 +573,153 @@ get_action_instruction"
             mock_traffic_cls.delete_class.assert_any_call(self.dl_intf, 13)
             mock_traffic_cls.delete_class.assert_any_call(self.dl_intf, 11)
 
+    @patch("magma.pipelined.qos.qos_tc_impl.TrafficClass")
+    @patch("magma.pipelined.qos.qos_meter_impl.MeterClass")
+    def _testUncleanRestartWithApnAMBR(self, mock_meter_cls, mock_traffic_cls):
+        """This test verifies all tests cases from _testUncleanRestart for APN
+        AMBR configs.
+        """
+        loop = asyncio.new_event_loop()
+        qos_mgr = QosManager(MagicMock, loop, self.config)
+        qos_mgr._redis_store = {}
+
+        def populate_db(qid_list, old_ambr_list, old_leaf_list, rule_list):
+            qos_mgr._redis_store.clear()
+            for i, t in enumerate(rule_list):
+                k = get_key_json(get_subscriber_key(*t))
+                v = get_data_json(get_subscriber_data(qid_list[i],
+                                                      old_ambr_list[i],
+                                                      old_leaf_list[i]))
+                qos_mgr._redis_store[k] = v
+
+        MockSt = namedtuple("MockSt", "meter_id")
+        dummy_meter_ev_body = [MockSt(11), MockSt(13), MockSt(2), MockSt(15)]
+
+        def tc_read(intf):
+            if intf == self.ul_intf:
+                return [(30, 3000), (15, 1500),
+                        (300, 3000), (150, 1500),
+                        (3000, 65534), (1500, 65534)]
+            else:
+                return [(13, 1300), (11, 1100),
+                        (130, 1300), (110, 1100),
+                        (1300, 65534), (1100, 65534)]
+
+        # prepopulate qos_store
+        old_qid_list = [2, 11, 13, 30]
+        old_leaf_list = [20, 110, 130, 300]
+        old_ambr_list = [200, 1100, 1300, 3000]
+
+        old_rule_list = [("1",'1.1.1.1', 0, 0), ("1", '1.1.1.2', 1, 0),
+                        ("1", '1.1.1.3', 2, 1), ("2", '1.1.1.4', 0, 0)]
+        populate_db(old_qid_list, old_ambr_list, old_leaf_list, old_rule_list)
+
+        # mock future state
+        if self.config["qos"]["impl"] == QosImplType.OVS_METER:
+            qos_mgr.impl.handle_meter_config_stats(dummy_meter_ev_body)
+        else:
+            mock_traffic_cls.read_all_classes.side_effect = tc_read
+
+        qos_mgr._initialized = False
+        qos_mgr._setupInternal()
+
+        # verify that qos_handle 20 not found in system is purged from map
+        qid_list = []
+        for _, v in qos_mgr._redis_store.items():
+            _, qid, _, _ = get_data(v)
+            qid_list.append(qid)
+
+        logging.debug("qid_list %s", qid_list)
+        self.assertNotIn(20, qid_list)
+
+        # verify that unreferenced qos configs are purged from the system
+        if self.config["qos"]["impl"] == QosImplType.OVS_METER:
+            mock_meter_cls.del_meter.assert_called_with(MagicMock, 15)
+        else:
+            mock_traffic_cls.delete_class.assert_any_call(self.ul_intf, 15)
+            mock_traffic_cls.delete_class.assert_any_call(self.ul_intf, 150)
+            mock_traffic_cls.delete_class.assert_any_call(self.ul_intf, 1500)
+
+        # add a new rule to the qos_mgr and check if it is assigned right id
+        imsi, rule_num, d, qos_info = "3", 0, 0, QosInfo(100000, 100000)
+        qos_mgr.impl.get_action_instruction = MagicMock
+        qos_mgr.add_subscriber_qos(imsi, '', 10, rule_num, d, qos_info)
+        k = get_key_json(get_subscriber_key(imsi, '', rule_num, d))
+
+        exp_id = 3  # since start_idx 2 is already used
+        d3 = get_data_json(get_subscriber_data(exp_id+1, exp_id-1, exp_id))
+
+        self.assertEqual(qos_mgr._redis_store[k], d3)
+        self.assertEqual(qos_mgr._subscriber_state[imsi].rules[rule_num][0], (d, d3))
+
+        # delete the restored rule - ensure that it gets cleaned properly
+        purge_imsi = "1"
+        purge_rule_num = 1
+        purge_qos_handle = 2
+        qos_mgr.remove_subscriber_qos(purge_imsi, purge_rule_num)
+        self.assertTrue(purge_rule_num not in qos_mgr._subscriber_state[purge_imsi].rules)
+        if self.config["qos"]["impl"] == QosImplType.OVS_METER:
+            mock_meter_cls.del_meter.assert_called_with(MagicMock, purge_qos_handle)
+        else:
+            mock_traffic_cls.delete_class.assert_any_call(self.ul_intf, 11)
+            mock_traffic_cls.delete_class.assert_any_call(self.ul_intf, 110)
+            mock_traffic_cls.delete_class.assert_any_call(self.ul_intf, 1100)
+
+        # case 2 - check with empty qos configs, qos_map gets purged
+        mock_meter_cls.reset_mock()
+        mock_traffic_cls.reset_mock()
+        populate_db(old_qid_list, old_ambr_list, old_leaf_list, old_rule_list)
+
+        # mock future state
+        if self.config["qos"]["impl"] == QosImplType.OVS_METER:
+            MockSt = namedtuple("MockSt", "meter_id")
+            qos_mgr.impl._fut = loop.create_future()
+            qos_mgr.impl.handle_meter_config_stats([])
+        else:
+            mock_traffic_cls.read_all_classes.side_effect = lambda _: []
+
+        qos_mgr._initialized = False
+        qos_mgr._setupInternal()
+
+        self.assertTrue(not qos_mgr._redis_store)
+        if self.config["qos"]["impl"] == QosImplType.OVS_METER:
+            mock_meter_cls.del_meter.assert_not_called()
+        else:
+            mock_traffic_cls.delete_class.assert_not_called()
+
+        # case 3 - check with empty qos_map, all qos configs get purged
+        mock_meter_cls.reset_mock()
+        mock_traffic_cls.reset_mock()
+        qos_mgr._redis_store.clear()
+
+        # mock future state
+        if self.config["qos"]["impl"] == QosImplType.OVS_METER:
+            qos_mgr.impl._fut = loop.create_future()
+            qos_mgr.impl.handle_meter_config_stats(dummy_meter_ev_body)
+        else:
+            mock_traffic_cls.read_all_classes.side_effect = tc_read
+
+        logging.debug("case three")
+        qos_mgr._initialized = False
+        qos_mgr._setupInternal()
+
+        self.assertTrue(not qos_mgr._redis_store)
+        # verify that unreferenced qos configs are purged from the system
+        if self.config["qos"]["impl"] == QosImplType.OVS_METER:
+            mock_meter_cls.del_meter.assert_any_call(MagicMock, 2)
+            mock_meter_cls.del_meter.assert_any_call(MagicMock, 15)
+            mock_meter_cls.del_meter.assert_any_call(MagicMock, 13)
+            mock_meter_cls.del_meter.assert_any_call(MagicMock, 11)
+        else:
+            mock_traffic_cls.delete_class.assert_any_call(self.ul_intf, 15)
+            mock_traffic_cls.delete_class.assert_any_call(self.ul_intf, 150)
+
+            mock_traffic_cls.delete_class.assert_any_call(self.dl_intf, 13)
+            mock_traffic_cls.delete_class.assert_any_call(self.dl_intf, 130)
+
+            mock_traffic_cls.delete_class.assert_any_call(self.dl_intf, 11)
+            mock_traffic_cls.delete_class.assert_any_call(self.dl_intf, 110)
+
     def testSanity(self):
         for impl_type in (QosImplType.LINUX_TC, QosImplType.OVS_METER):
             self.config["qos"]["impl"] = impl_type
@@ -563,6 +735,12 @@ get_action_instruction"
             for impl_type in [QosImplType.LINUX_TC]:
                 self.config["qos"]["impl"] = impl_type
                 self._testUncleanRestart()
+
+    def testUncleanRestartAPN(self):
+        with patch.dict(self.config, {"clean_restart": False}):
+            for impl_type in [QosImplType.LINUX_TC]:
+                self.config["qos"]["impl"] = impl_type
+                self._testUncleanRestartWithApnAMBR()
 
     @patch("magma.pipelined.qos.qos_tc_impl.TrafficClass")
     @patch("magma.pipelined.qos.qos_tc_impl.TCManager.get_action_instruction")
@@ -589,18 +767,20 @@ get_action_instruction"
         qos_mgr.add_subscriber_qos(imsi, ip_addr, ambr_ul, rule_num, FlowMatch.UPLINK, qos_info)
         qos_mgr.add_subscriber_qos(imsi, ip_addr, ambr_dl, rule_num, FlowMatch.DOWNLINK, qos_info)
 
-        k1 = get_json(get_subscriber_key(imsi, ip_addr, rule_num, FlowMatch.UPLINK))
-        k2 = get_json(get_subscriber_key(imsi, ip_addr, rule_num, FlowMatch.DOWNLINK))
+        k1 = get_key_json(get_subscriber_key(imsi, ip_addr, rule_num, FlowMatch.UPLINK))
+        k2 = get_key_json(get_subscriber_key(imsi, ip_addr, rule_num, FlowMatch.DOWNLINK))
 
         ambr_ul_exp_id = qos_mgr.impl._start_idx
         ul_exp_id = qos_mgr.impl._start_idx + 2
         ambr_dl_exp_id = qos_mgr.impl._start_idx + 3
         dl_exp_id = qos_mgr.impl._start_idx + 5
 
-        self.assertEqual(qos_mgr._redis_store[k1], ul_exp_id)
-        self.assertEqual(qos_mgr._redis_store[k2], dl_exp_id)
-        self.assertTrue(qos_mgr._subscriber_state[imsi].rules[rule_num][0] == (0, ul_exp_id))
-        self.assertTrue(qos_mgr._subscriber_state[imsi].rules[rule_num][1] == (1, dl_exp_id))
+        qid_info_ul = get_subscriber_data(ul_exp_id, ul_exp_id - 2, ul_exp_id - 1)
+        qid_info_dl = get_subscriber_data(dl_exp_id, dl_exp_id - 2, dl_exp_id - 1)
+        self.assertEqual(get_data(qos_mgr._redis_store[k1]), qid_info_ul)
+        self.assertEqual(get_data(qos_mgr._redis_store[k2]), qid_info_dl)
+        self.assertTrue(qos_mgr._subscriber_state[imsi].rules[rule_num][0] == (0, get_data_json(qid_info_ul)))
+        self.assertTrue(qos_mgr._subscriber_state[imsi].rules[rule_num][1] == (1, get_data_json(qid_info_dl)))
 
         self.assertEqual(len(qos_mgr._subscriber_state[imsi].sessions), 1)
         self.assertEqual(qos_mgr._subscriber_state[imsi].sessions[ip_addr].ambr_dl, ambr_dl_exp_id)
@@ -613,8 +793,8 @@ get_action_instruction"
         qos_mgr.add_subscriber_qos(imsi, ip_addr, 0, rule_num, FlowMatch.UPLINK, qos_info)
         qos_mgr.add_subscriber_qos(imsi, ip_addr, 0, rule_num, FlowMatch.DOWNLINK, qos_info)
 
-        self.assertTrue(qos_mgr._subscriber_state[imsi].rules[rule_num][0] == (0, ul_exp_id))
-        self.assertTrue(qos_mgr._subscriber_state[imsi].rules[rule_num][1] == (1, dl_exp_id))
+        self.assertTrue(qos_mgr._subscriber_state[imsi].rules[rule_num][0] == (0, get_data_json(qid_info_ul)))
+        self.assertTrue(qos_mgr._subscriber_state[imsi].rules[rule_num][1] == (1, get_data_json(qid_info_dl)))
 
         # verify if traffic class was invoked properly
         self.verifyTcAddQos(mock_tc_get_action_inst, mock_traffic_cls, FlowMatch.UPLINK,
@@ -760,7 +940,7 @@ class TestSubscriberState(unittest.TestCase):
         subscriber_state = SubscriberState('IMSI101', {})
         assert(subscriber_state.check_empty())
         assert(not subscriber_state.get_qos_handle(rule_num, d))
-        subscriber_state.update_rule(ip_addr, rule_num, d, qos_handle)
+        subscriber_state.update_rule(ip_addr, rule_num, d, qos_handle, 0, 0)
 
         assert(subscriber_state.find_rule(rule_num))
         session_with_rule = subscriber_state.find_session_with_rule(rule_num)
@@ -786,7 +966,7 @@ class TestSubscriberState(unittest.TestCase):
 
         session = subscriber_state.get_or_create_session(ip_addr)
         session.set_ambr(d, ambr_qos_handle, 0)
-        subscriber_state.update_rule(ip_addr, rule_num, d, qos_handle)
+        subscriber_state.update_rule(ip_addr, rule_num, d, qos_handle, 0, 0)
 
         assert(subscriber_state.find_rule(rule_num))
         session_with_rule = subscriber_state.find_session_with_rule(rule_num)
@@ -816,16 +996,16 @@ class TestSubscriberState(unittest.TestCase):
         assert(not subscriber_state.get_qos_handle(rule_num1, d1))
 
         subscriber_state.get_or_create_session(ip_addr)
-        subscriber_state.update_rule(ip_addr, rule_num1, d1, qos_handle1)
+        subscriber_state.update_rule(ip_addr, rule_num1, d1, qos_handle1, 0, 0)
 
         # add rule_num2
-        subscriber_state.update_rule(ip_addr, rule_num2, d2, qos_handle2)
+        subscriber_state.update_rule(ip_addr, rule_num2, d2, qos_handle2, 0, 0)
 
         # add rule_num3 with apn_ambr in downlink direction
         session = subscriber_state.get_or_create_session(ip_addr)
         assert(session)
         session.set_ambr(d3, ambr_qos_handle, 0)
-        subscriber_state.update_rule(ip_addr, rule_num3, d3, qos_handle3)
+        subscriber_state.update_rule(ip_addr, rule_num3, d3, qos_handle3, 0, 0)
 
         assert(len(subscriber_state.rules) == 2)
         assert(rule_num1 in subscriber_state.rules)
@@ -863,23 +1043,23 @@ class TestSubscriberState(unittest.TestCase):
         assert(not subscriber_state.get_qos_handle(rule_num1, d1))
 
         subscriber_state.get_or_create_session(ip_addr)
-        subscriber_state.update_rule(ip_addr, rule_num1, d1, qos_handle1)
+        subscriber_state.update_rule(ip_addr, rule_num1, d1, qos_handle1, 0, 0)
 
         # add rule_num2
-        subscriber_state.update_rule(ip_addr, rule_num2, d2, qos_handle2)
+        subscriber_state.update_rule(ip_addr, rule_num2, d2, qos_handle2, 0, 0)
 
         # add rule_num3 with apn_ambr in downlink direction
         session = subscriber_state.get_or_create_session(ip_addr)
         assert(session)
         session.set_ambr(d3, ambr_qos_handle, 0)
-        subscriber_state.update_rule(ip_addr, rule_num3, d3, qos_handle3)
+        subscriber_state.update_rule(ip_addr, rule_num3, d3, qos_handle3, 0, 0)
 
         # add rule_num4 with apn_ambr in uplink direction
         session = subscriber_state.get_or_create_session(new_session_ip_addr)
         assert(session)
         session.set_ambr(new_d1, new_ambr_qos_handle, 0)
         subscriber_state.update_rule(new_session_ip_addr, new_rule_num4, new_d1,
-            new_qos_handle1)
+            new_qos_handle1, 0, 0)
 
         assert(len(subscriber_state.rules) == 3)
         assert(rule_num1 in subscriber_state.rules)


### PR DESCRIPTION
Rather than using TC as only source of APN AMBR, use Redis
to store the qid->APN_qid and APN_leaf->APN_qid info.
This avoid complicated recovery in stateless mode.
This PR also adds apn_ambr_enabled config to enable APN AMBR feature.

Signed-off-by: Pravin B Shelar <pbshelar@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
