### PR TITLE
[orc8r] Update Minikube Documentation

### DIFF
--- a/docs/readmes/orc8r/development/minikube_deployment.md
+++ b/docs/readmes/orc8r/development/minikube_deployment.md
@@ -28,7 +28,7 @@ Setup minikube with the following command to give it enough resources and seed t
 metrics config files:
 
 ```
-$ minikube start --memory=8192 --cpus=8 --kubernetes-version=v1.14.1 --mount --mount-string "${MAGMA_ROOT}/orc8r/cloud/docker/metrics-configs:/configs"
+$ minikube start --memory=8192 --cpus=8 --kubernetes-version=v1.18.0 --mount --mount-string "${MAGMA_ROOT}/orc8r/cloud/docker/metrics-configs:/configs"
 ```
 
 > Note: This has been tested on MacOS. There are a lot of things that can go wrong
@@ -43,7 +43,7 @@ $ helm install \
     --create-namespace \
     --namespace magma \
     --set postgresqlPassword=postgres,postgresqlDatabase=magma,fullnameOverride=postgresql \
-    stable/postgresql
+    bitnami/postgresql
 ```
 
 Mysql is a requirement to run the NMS (you can skip this step if you don't want the NMS)
@@ -55,7 +55,7 @@ $ helm install mysql \
     stable/mysql
 ```
 
-> Note: You may need to run `helm repo add stable https://kubernetes-charts.storage.googleapis.com/` if the chart is not found
+> Note: You may need to run `helm repo add bitnami https://charts.bitnami.com/bitnami` if the chart is not found
 
 ### Generate Secrets
 
@@ -100,7 +100,7 @@ helm template orc8r-secrets charts/secrets \
 
 ### Create Values File
 
-A minimum values file that can be used to deploy orc8r is at `${MAGMA_ROOT}/cloud/helm/orc8r/helm/examples/minikube_values.yml`.
+A minimum values file that can be used to deploy orc8r is at `${MAGMA_ROOT}/orc8r/cloud/helm/orc8r/examples/minikube_values.yml`.
 Use that file and make sure to replace `<DOCKER_REGISTRY>` with your registry and `<TAG>` with your tag.
 
 Save this file wherever you want.
@@ -108,8 +108,8 @@ Save this file wherever you want.
 ### Install with Helm
 
 ```
-$ helm dep update
 $ cd ${MAGMA_ROOT}/orc8r/cloud/helm/orc8r
+$ helm dep update
 $ helm install orc8r --namespace magma . --values=<path-to-values-file>
 ```
 


### PR DESCRIPTION
Signed-off-by: Andy Lee Khuu <andykhuu@stanford.edu>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary
The Minikube onboarding documentation has been outdated for quite a while. This PR updates the docs to reflect a verified set of steps that ensures Minikube is up and running.

<img width="839" alt="Screen Shot 2021-02-18 at 10 05 47 PM" src="https://user-images.githubusercontent.com/46101219/108465774-7a90a680-7237-11eb-8bcc-f32959eb7a54.png">

<img width="892" alt="Screen Shot 2021-02-18 at 10 05 56 PM" src="https://user-images.githubusercontent.com/46101219/108465782-7d8b9700-7237-11eb-87c8-cbe632afd472.png">
<!-- Enumerate changes you made and why you made them -->

## Test Plan
- [x] Manual verification and walkthrough of onboarding steps
- [x] Confirmation that the pods are initialized and up and running through "kubectl -n magma get pods" 
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
