### PR TITLE
Fix stale chart lock in 1.4

### DIFF
--- a/orc8r/cloud/helm/orc8r/Chart.lock
+++ b/orc8r/cloud/helm/orc8r/Chart.lock
@@ -4,15 +4,15 @@ dependencies:
   version: 0.1.10
 - name: metrics
   repository: ""
-  version: 1.4.20
+  version: 1.4.21
 - name: nms
   repository: ""
-  version: 0.1.7
+  version: 0.1.8
 - name: logging
   repository: ""
   version: 0.1.10
 - name: orc8rlib
   repository: file://../orc8rlib
   version: 0.1.2
-digest: sha256:b663c63405553fab8c747f7c8c679975c0ce2cd11c540ebb0c5c83e2ad27b681
-generated: "2021-01-12T14:11:00.994082-08:00"
+digest: sha256:4e380d5be1ac80019bbf358526c8d8dd29b724b2b93a0443e0bc197f486299f2
+generated: "2021-02-19T04:13:25.639571-08:00"


### PR DESCRIPTION
Signed-off-by: Karthik Subraveti <ksubraveti@fb.com>



## Summary

Ran `helm dependency update` and pushed the new chart lock
## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
