### PR TITLE
[FeG][Orc8r] Add directoryd configs

### DIFF
--- a/cwf/gateway/configs/directoryd.yml
+++ b/cwf/gateway/configs/directoryd.yml
@@ -1,0 +1,15 @@
+---
+#
+# Copyright 2020 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# log_level is set in mconfig. It can be overridden here
+print_grpc_payload: false

--- a/feg/gateway/configs/directoryd.yml
+++ b/feg/gateway/configs/directoryd.yml
@@ -1,0 +1,15 @@
+---
+#
+# Copyright 2020 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# log_level is set in mconfig. It can be overridden here
+print_grpc_payload: false

--- a/orc8r/gateway/configs/directoryd.yml
+++ b/orc8r/gateway/configs/directoryd.yml
@@ -1,0 +1,15 @@
+---
+#
+# Copyright 2020 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# log_level is set in mconfig. It can be overridden here
+print_grpc_payload: false


### PR DESCRIPTION
<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary
the python dockerfile in `feg/gateway/docker/python` uses feg/gateway/configs to build a python image
the python dockerfile in `orc8r/gateway/docker` uses orc8r/gateway/configs to build a python images

They're both currently lacking the directoryd config, which leads the service to crashloop.
This should fix the cwf integration test failures.

<!-- Enumerate changes you made and why you made them -->

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
