### PR TITLE
[SessionD][v1.4] Deactivate flows for dead sessions on usage reporting

### DIFF
--- a/lte/gateway/c/session_manager/LocalEnforcer.h
+++ b/lte/gateway/c/session_manager/LocalEnforcer.h
@@ -651,6 +651,8 @@ class LocalEnforcer {
   void add_rules_for_unsuspended_credit(
       const std::unique_ptr<SessionState>& session, const CreditKey& ckey,
       SessionStateUpdateCriteria& session_uc);
+
+  void cleanup_dead_sessions(std::vector<RuleRecord>& dead_sessions_to_cleanup);
 };
 
 }  // namespace magma

--- a/lte/gateway/c/session_manager/test/test_local_enforcer.cpp
+++ b/lte/gateway/c/session_manager/test/test_local_enforcer.cpp
@@ -2829,6 +2829,32 @@ TEST_F(LocalEnforcerTest, test_rar_dynamic_rule_modification) {
   EXPECT_TRUE(session_store->update_sessions(session_ucs));
 }
 
+// Test the case where PipelineD sends a data usage report for a session that
+// does not exist anymore. We expect SessionD to send a deactivate flows request
+// to PipelineD.
+TEST_F(LocalEnforcerTest, test_dead_session_in_usage_report) {
+  // no sessions exist at this point
+  // We expect to empty calls for both Gx + Gy
+  EXPECT_CALL(
+      *pipelined_client, deactivate_flows_for_rules_for_termination(
+                             IMSI1, IP1, testing::_, testing::_, CheckCount(0),
+                             CheckCount(0), RequestOriginType::GX))
+      .Times(1)
+      .WillOnce(testing::Return(true));
+  EXPECT_CALL(
+      *pipelined_client, deactivate_flows_for_rules_for_termination(
+                             IMSI1, IP1, testing::_, testing::_, CheckCount(0),
+                             CheckCount(0), RequestOriginType::GY))
+      .Times(1)
+      .WillOnce(testing::Return(true));
+
+  RuleRecordTable table;
+  auto record_list = table.mutable_records();
+  create_rule_record(IMSI1, IP1, "rule1", 16, 32, record_list->Add());
+  auto update = SessionStore::get_default_session_update(session_map);
+  local_enforcer->aggregate_records(session_map, table, update);
+}
+
 int main(int argc, char** argv) {
   ::testing::InitGoogleTest(&argc, argv);
   FLAGS_logtostderr = 1;


### PR DESCRIPTION
<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary
On some failure cases, we can have flows leftover in PIpelineD that are not cleaned up.
Whenever we receive flows for a session that does not exist anymore, we should re-send deactivate flows to pipelined to help cleanup.

### This change is for 1.4 only
<!-- Enumerate changes you made and why you made them -->

## Test Plan
unit tests
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
