### PR TITLE
[feg] enable S8_proxy on docker-compose

### DIFF
--- a/feg/gateway/docker/docker-compose.yml
+++ b/feg/gateway/docker/docker-compose.yml
@@ -102,6 +102,11 @@ services:
     container_name: s6a_proxy
     command: envdir /var/opt/magma/envdir /var/opt/magma/bin/s6a_proxy -logtostderr=true -v=0
 
+  s8_proxy:
+    <<: *goservice
+    container_name: s8_proxy
+    command: envdir /var/opt/magma/envdir /var/opt/magma/bin/s8_proxy -logtostderr=true -v=0
+
   radiusd:
     <<: *goservice
     container_name: radiusd

--- a/feg/gateway/services/s8_proxy/servicers/mock_pgw/cs.go
+++ b/feg/gateway/services/s8_proxy/servicers/mock_pgw/cs.go
@@ -167,7 +167,9 @@ func (mPgw *MockPgw) getHandleCreateSessionRequest() gtpv2.HandlerFunc {
 			// use passed options value
 			pgwUteid = mPgw.CreateSessionOptions.PgwFTEIDu
 		} else {
+			mPgw.randGenMux.Lock()
 			pgwUteid = (rand.Uint32() / 1000) * 1000 // for easy identification, this teid will always end in 000
+			mPgw.randGenMux.Unlock()
 		}
 		pgwFTEIDu := ie.NewFullyQualifiedTEID(gtpv2.IFTypeS5S8PGWGTPU, pgwUteid, uIP, "").WithInstance(2)
 

--- a/feg/gateway/services/s8_proxy/servicers/mock_pgw/mock_pgw.go
+++ b/feg/gateway/services/s8_proxy/servicers/mock_pgw/mock_pgw.go
@@ -17,6 +17,7 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"sync"
 	"time"
 
 	"github.com/wmnsk/go-gtp/gtpv1"
@@ -31,7 +32,7 @@ import (
 
 const (
 	dummyUserPlanePgwIP = "10.0.0.1"
-	gtpTimeout          = 500 * time.Millisecond
+	gtpTimeout          = 5 * time.Second
 )
 
 // MockPgw is just a wrapper around gtp.Client
@@ -39,6 +40,7 @@ type MockPgw struct {
 	*gtp.Client
 	LastValues
 	CreateSessionOptions CreateSessionOptions
+	randGenMux           sync.Mutex
 }
 
 type LastValues struct {

--- a/feg/gateway/tools/s8_cli/main_test.go
+++ b/feg/gateway/tools/s8_cli/main_test.go
@@ -1,0 +1,14 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"testing"
+)
+
+func TestS8Cli(t *testing.T) {
+	// replace the arguments
+	os.Args = []string{"s8_cli", "cs", "-test", "-delete", "0"}
+	fmt.Printf("\ncommand to run: %+v\n", os.Args)
+	main()
+}


### PR DESCRIPTION
Signed-off-by: Oriol Batalla <obatalla@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary

This PR adds s8_proxy to docker-compose for feg. 

It also adds some new test case for s8_cli

## Test Plan

docker-compose up -d

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
