### PR TITLE
[LTE][CI] use timeout instead of unreliable nose timeout

### DIFF
--- a/lte/gateway/python/integ_tests/Makefile
+++ b/lte/gateway/python/integ_tests/Makefile
@@ -24,7 +24,7 @@ $(PYTHON_BUILD)/setupinteg_env:
 RESULTS_DIR := /var/tmp/test_results
 define execute_test
 	echo "Running test: $(1)"
-	sudo -E PATH=$(PATH) PYTHONPATH=$(PYTHONPATH):$(S1AP_TESTER_PYTHON_PATH) $(PYTHON_BUILD)/bin/nosetests --with-xunit --xunit-file=$(RESULTS_DIR)/$(basename $(notdir $(1))).xml --processes 2 --process-timeout 900 -x -s $(1) || exit 1
+	timeout -k 930s 900s sudo -E PATH=$(PATH) PYTHONPATH=$(PYTHONPATH):$(S1AP_TESTER_PYTHON_PATH) $(PYTHON_BUILD)/bin/nosetests --with-xunit --xunit-file=$(RESULTS_DIR)/$(basename $(notdir $(1))).xml -x -s $(1) || exit 1
 	sleep 1
 endef
 


### PR DESCRIPTION
## Summary

nosetests built-in timeout doesn't actually kill the test. It still waits for the current test to finish. gnu timeout will kill the process correctly.

## Test Plan

I modified the command to timeout in 30s as a test. You will see the following:
```
timeout -k 30s 20s sudo -E PATH=/usr/lib/ccache:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/go/bin PYTHONPATH=:/home/vagrant/s1ap-tester/bin /home/vagrant/build/python/bin/nosetests --with-xunit --xunit-file=/var/tmp/test_results/test_modify_mme_config_for_sanity.xml -x -s s1aptests/test_modify_mme_config_for_sanity.py || exit 1
Killed
