### PR TITLE
[MME] Fix MME compile errors from compiling with GCC/G++8

### DIFF
--- a/lte/gateway/c/oai/include/mme_events.h
+++ b/lte/gateway/c/oai/include/mme_events.h
@@ -26,7 +26,7 @@ extern "C" {
 /**
  * Helper function to initiate AsyncEventdClient in its own thread
  */
-int event_client_init(void);
+void event_client_init(void);
 
 /**
  * Logs Attach successful event

--- a/lte/gateway/c/oai/include/state_converter.h
+++ b/lte/gateway/c/oai/include/state_converter.h
@@ -36,6 +36,7 @@ extern "C" {
 #include <functional>
 
 #include <google/protobuf/map.h>
+#include <functional>
 
 #include "lte/protos/oai/common_types.pb.h"
 

--- a/lte/gateway/c/oai/lib/event_client/EventClientAPI.cpp
+++ b/lte/gateway/c/oai/lib/event_client/EventClientAPI.cpp
@@ -45,14 +45,15 @@ int log_event(const Event& event) {
     if (status.ok()) {
       std::cout << "[DEBUG] Success logging event: " << event.event_type()
                 << std::endl;
-    } else if (
-        status.error_code() == DEADLINE_EXCEEDED ||
-        status.error_code() == UNAVAILABLE) {
-      return 0;  // Suppress error logs if eventd is unavailable
-    } else {
-      std::cout << "[ERROR] Failed to log event: " << event.event_type()
-                << "; Status: " << status.error_message() << std::endl;
+      return 0;
     }
+    if (status.error_code() == DEADLINE_EXCEEDED ||
+        status.error_code() == UNAVAILABLE) {
+      return 0;  // Suppress error logs if EventD is unavailable
+    }
+    std::cout << "[ERROR] Failed to log event: " << event.event_type()
+              << "; Status: " << status.error_message() << std::endl;
+    return int(status.error_code());
   });
   return 0;
 }

--- a/lte/gateway/c/oai/lib/event_client/EventClientAPI.h
+++ b/lte/gateway/c/oai/lib/event_client/EventClientAPI.h
@@ -23,6 +23,8 @@ namespace lte {
 
 void init_eventd_client();
 
+// This call is async so the return code does not matter here.
+// TODO return void?
 int log_event(const magma::orc8r::Event& event);
 
 }  // namespace lte

--- a/lte/gateway/c/oai/lib/s6a_proxy/s6a_client_api.cpp
+++ b/lte/gateway/c/oai/lib/s6a_proxy/s6a_client_api.cpp
@@ -60,6 +60,7 @@ bool s6a_purge_ue(const char* imsi) {
                   << "; ErrorCode: " << response.error_code() << std::endl;
         return;
       });
+  return true;
 }
 
 static void _s6a_handle_authentication_info_ans(

--- a/lte/gateway/c/oai/tasks/mme_app/mme_events.cpp
+++ b/lte/gateway/c/oai/tasks/mme_app/mme_events.cpp
@@ -45,7 +45,7 @@ constexpr char DETACH_SUCCESS[]   = "detach_success";
 constexpr char S1_SETUP_SUCCESS[] = "s1_setup_success";
 }  // namespace
 
-int event_client_init(void) {
+void event_client_init(void) {
   init_eventd_client();
 }
 
@@ -67,8 +67,7 @@ static int report_event(
   std::string event_value_string = folly::toJson(event_value);
   event_request.set_value(event_value_string);
   event_request.set_tag(event_tag);
-  int rc = log_event(event_request);
-  return rc;
+  return log_event(event_request);
 }
 
 int attach_success_event(imsi64_t imsi64) {

--- a/lte/gateway/c/oai/test/mobility_client/test_mobility_client.cpp
+++ b/lte/gateway/c/oai/test/mobility_client/test_mobility_client.cpp
@@ -68,6 +68,7 @@ int main(int argc, char** argv) {
                 "0001");
             return -1;
           }
+          return 0;
         });
 
     MobilityServiceClient::getInstance().AllocateIPv4AddressAsync(
@@ -97,6 +98,7 @@ int main(int argc, char** argv) {
                 "0002");
             return -1;
           }
+          return 0;
         });
 
     status = MobilityServiceClient::getInstance().GetIPv4AddressForSubscriber(


### PR DESCRIPTION
<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary
I was experimenting with gcc/g++ 8 (we currently compile with gcc6), and noticed a bunch of compilation errors. Fixing that here as it's probably relevant for gcc6 too.

MME still compiles with these changes with gcc6.

Errors:
```
/home/vagrant/magma/lte/gateway/c/oai/include/state_converter.h:80:12: error: ‘std::function’ has not been declared
/home/vagrant/magma/lte/gateway/c/oai/lib/event_client/EventClientAPI.cpp:56:3: warning: control reaches end of non-void function [-Wreturn-type]
/home/vagrant/magma/lte/gateway/c/oai/lib/s6a_proxy/s6a_client_api.cpp:63:1: warning: control reaches end of non-void function [-Wreturn-type]
/home/vagrant/magma/lte/gateway/c/oai/tasks/mme_app/mme_events.cpp:50:1: warning: no return statement in function returning non-void [-Wreturn-type]
/home/vagrant/magma/lte/gateway/c/oai/test/mobility_client/test_mobility_client.cpp:71:9: warning: control reaches end of non-void function [-Wreturn-type]
/home/vagrant/magma/lte/gateway/c/oai/test/mobility_client/test_mobility_client.cpp:100:9: warning: control reaches end of non-void function [-Wreturn-type]
```
<!-- Enumerate changes you made and why you made them -->

## Test Plan
unit tests
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
