### PR TITLE
[lte][agw] Handle null eNB context

### DIFF
--- a/lte/gateway/c/oai/tasks/s1ap/s1ap_mme_nas_procedures.c
+++ b/lte/gateway/c/oai/tasks/s1ap/s1ap_mme_nas_procedures.c
@@ -283,6 +283,12 @@ int s1ap_mme_handle_uplink_nas_transport(
   mme_ue_s1ap_id = (mme_ue_s1ap_id_t) ie->value.choice.MME_UE_S1AP_ID;
 
   enb_ref = s1ap_state_get_enb(state, assoc_id);
+  if (enb_ref == NULL) {
+    OAILOG_ERROR(
+        LOG_S1AP, "No eNB reference exists for association id %d\n", assoc_id);
+    return RETURNerror;
+  }
+
   if (mme_ue_s1ap_id == INVALID_MME_UE_S1AP_ID) {
     OAILOG_WARNING(
         LOG_S1AP,


### PR DESCRIPTION
## Summary

Added null pointer check for eNB reference that is fetched using the association ID provided for the NAS UL message. Normally, NAS messages from UEs should not come to the MME without an eNB association. However, we see the following crash dump that indicates that we are in such a situation and leading to segfault:

```
(lldb) bt
* thread #1, name = 'mme', stop reason = signal SIGSEGV
  * frame #0: 0x00005565327c7fdd mme`s1ap_mme_handle_uplink_nas_transport(state=0x000060f00000b4f0, assoc_id=3380, stream=<unavailable>, pdu=0x00007fb5d92bcd10) at s1ap_mme_nas_procedures.c:325
    frame #1: 0x00005565327c59f6 mme`s1ap_mme_handle_message(state=<unavailable>, assoc_id=3380, stream=<unavailable>, pdu=0x00007fb5d92bcd10) at s1ap_mme_handlers.c:205
    frame #2: 0x0000556532776420 mme`handle_message(loop=<unavailable>, reader=<unavailable>, arg=<unavailable>) at s1ap_mme.c:141
    frame #3: 0x00007fb5ec46e7be libczmq.so.4
```

where line 325 in `s1ap_mme_nas_procedures.c` is with enb_ref is set as NULL:
```
s1ap_mme_remove_stale_ue_context(enb_ue_s1ap_id, enb_ref->enb_id);
```

## Test Plan

Integ tests.

## Additional Information

- [ ] This change is backwards-breaking

