### PR TITLE
[AGW] [MME] Clean up eNB state at restart to remove UEs without S1ap state

### DIFF
--- a/lte/gateway/c/oai/include/s1ap_state.h
+++ b/lte/gateway/c/oai/include/s1ap_state.h
@@ -78,6 +78,12 @@ bool s1ap_ue_compare_by_imsi(
     __attribute__((unused)) hash_key_t keyP, void* elementP, void* parameterP,
     void** resultP);
 
+bool get_mme_ue_ids_no_imsi(
+    const hash_key_t keyP, uint64_t const dataP,
+    __attribute__((unused)) void* argP, void** resultP);
+
+void remove_ues_without_imsi_from_ue_id_coll(void);
+
 #ifdef __cplusplus
 }
 #endif

--- a/lte/gateway/c/oai/tasks/s1ap/s1ap_mme_handlers.c
+++ b/lte/gateway/c/oai/tasks/s1ap/s1ap_mme_handlers.c
@@ -2197,7 +2197,6 @@ bool s1ap_send_enb_deregistered_ind(
     *resultP = arg->message_p;
   } else {
     OAILOG_TRACE(LOG_S1AP, "No valid UE provided in callback: %p\n", ue_ref_p);
-    AssertFatal(0, "No valid UE while creating S1AP_ENB_DEREGISTERED_IND");
   }
   return false;
 }

--- a/lte/gateway/c/oai/tasks/s1ap/s1ap_state.cpp
+++ b/lte/gateway/c/oai/tasks/s1ap/s1ap_state.cpp
@@ -36,6 +36,8 @@ using magma::lte::S1apStateManager;
 
 int s1ap_state_init(uint32_t max_ues, uint32_t max_enbs, bool use_stateless) {
   S1apStateManager::getInstance().init(max_ues, max_enbs, use_stateless);
+  // remove UEs with unknown IMSI from eNB state
+  remove_ues_without_imsi_from_ue_id_coll();
   return RETURNok;
 }
 
@@ -154,4 +156,75 @@ void put_s1ap_ue_state(imsi64_t imsi64) {
 void delete_s1ap_ue_state(imsi64_t imsi64) {
   auto imsi_str = S1apStateManager::getInstance().get_imsi_str(imsi64);
   S1apStateManager::getInstance().clear_ue_state_db(imsi_str);
+}
+
+bool get_mme_ue_ids_no_imsi(
+    const hash_key_t keyP, uint64_t const dataP, void* argP, void** resultP) {
+  hash_key_t** mme_id_list   = (hash_key_t**) resultP;
+  uint32_t* num_ues_checked  = (uint32_t*) argP;
+  ue_description_t* ue_ref_p = NULL;
+
+  // Check if a UE reference exists for this comp_s1ap_id
+  hash_table_ts_t* s1ap_ue_state = get_s1ap_ue_state();
+  hashtable_ts_get(s1ap_ue_state, (const hash_key_t) dataP, (void**) &ue_ref_p);
+  if (!ue_ref_p) {
+    *mme_id_list[(*num_ues_checked)++] = keyP;
+    OAILOG_DEBUG(
+        LOG_S1AP,
+        "Adding mme_ue_s1ap_id %lu to eNB clean up list with num_ues_checked "
+        "%u",
+        keyP, *num_ues_checked);
+  }
+}
+
+void remove_ues_without_imsi_from_ue_id_coll() {
+  s1ap_state_t* s1ap_state_p     = get_s1ap_state(false);
+  hashtable_key_array_t* ht_keys = hashtable_ts_get_keys(&s1ap_state_p->enbs);
+  if (ht_keys == nullptr) {
+    return;
+  }
+
+  hashtable_rc_t ht_rc;
+  hash_key_t* mme_ue_id_no_imsi_list;
+  uint32_t num_ues_checked = 0;
+
+  // get each eNB in s1ap_state
+  for (uint32_t i = 0; i < ht_keys->num_keys; i++) {
+    enb_description_t* enb_association_p = nullptr;
+    ht_rc                                = hashtable_ts_get(
+        &s1ap_state_p->enbs, (hash_key_t) ht_keys->keys[i],
+        (void**) &enb_association_p);
+    if (ht_rc != HASH_TABLE_OK) {
+      continue;
+    }
+
+    if (enb_association_p->ue_id_coll.num_elements == 0) {
+      continue;
+    }
+
+    // for each ue comp_s1ap_id in eNB->ue_id_coll, check if it has an S1ap
+    // ue_context, if not delete it
+    mme_ue_id_no_imsi_list = (hash_key_t*) calloc(
+        enb_association_p->ue_id_coll.num_elements, sizeof(hash_key_t));
+    hashtable_uint64_ts_apply_callback_on_elements(
+        &enb_association_p->ue_id_coll, get_mme_ue_ids_no_imsi,
+        &num_ues_checked, (void**) &mme_ue_id_no_imsi_list);
+
+    // remove all the mme_ue_s1ap_ids
+    for (uint32_t i = 0; i < num_ues_checked; i++) {
+      hashtable_uint64_ts_free(
+          &enb_association_p->ue_id_coll, mme_ue_id_no_imsi_list[i]);
+      enb_association_p->nb_ue_associated--;
+
+      OAILOG_DEBUG(
+          LOG_S1AP, "Num UEs associated %u num ue_id_coll %zu",
+          enb_association_p->nb_ue_associated,
+          enb_association_p->ue_id_coll.num_elements);
+    }
+
+    // free the list
+    free(mme_ue_id_no_imsi_list);
+  }
+
+  FREE_HASHTABLE_KEY_ARRAY(ht_keys);
 }

--- a/lte/gateway/c/oai/tasks/s1ap/s1ap_state.cpp
+++ b/lte/gateway/c/oai/tasks/s1ap/s1ap_state.cpp
@@ -175,6 +175,7 @@ bool get_mme_ue_ids_no_imsi(
         "%u",
         keyP, *num_ues_checked);
   }
+  return false;  // always return false to make sure it runs on all elements
 }
 
 void remove_ues_without_imsi_from_ue_id_coll() {


### PR DESCRIPTION
Signed-off-by: Shruti Sanadhya <ssanadhya@fb.com>

## Summary

If the MME service restarts before UE has shared its IMSI with MME, the s1ap state does not have any context stored in Redis for this UE. However, the number of UEs associated with eNB reflect this UE with no IMSI. This leads to inconsistent state, leading to the "No valid UE context " error in `s1ap_send_enb_deregistered_ind`. The PR https://github.com/magma/magma/pull/4899 added an assertion to handles this scenario with an Assert and forcing service restart with clean Redis. This is not entirely needed.

This change adds logic to remove any  MME_UE_S1AP_ID from eNB `ue_id_coll` if it does not have a corresponding entry in the S1ap UE state map.

## Test Plan

- Functional testing
Before the change: `test_no_identity_rsp_with_mme_restart.py` was creating a seg fault on MME when SCTP disconnection was sent at the end of the test.
After the change, no seg fault on MME and the test succeeds.

- Regression testing
`make integ_test`
