### PR TITLE
Add Pipelined Cli Benchmark

### DIFF
--- a/lte/gateway/python/magma/pipelined/app/enforcement_stats.py
+++ b/lte/gateway/python/magma/pipelined/app/enforcement_stats.py
@@ -618,8 +618,8 @@ class EnforcementStatsController(PolicyMixin, RestartMixin, MagmaController):
         for flow in stat_flows[self.tbl_num]:
             self.last_usage_for_delta = self._update_usage_from_flow_stat(
                 self.last_usage_for_delta, flow)
-        self.logger.info("Recovered stats:")
-        self.logger.info(self.last_usage_for_delta)
+        self.logger.info("Recovered enforcement stats")
+        self.logger.debug(self.last_usage_for_delta)
 
 
 def _generate_rule_match(imsi, ip_addr, rule_num, version, direction):

--- a/lte/gateway/python/scripts/pipelined_cli.py
+++ b/lte/gateway/python/scripts/pipelined_cli.py
@@ -152,6 +152,7 @@ def get_policy_usage(client, _):
 
 @grpc_wrapper
 def stress_test_grpc(client, args):
+    print("WARNING: DO NOT USE ON PRODUCTION SETUPS")
     UEInfo = namedtuple('UEInfo', ['imsi_str', 'ipv4_src', 'ipv4_dst',
                                    'rule_id'])
     delta_time = 1/args.attaches_per_sec
@@ -218,8 +219,7 @@ def stress_test_grpc(client, args):
         duration = (datetime.now() - timestamp).total_seconds()
         print("Finished {0} attaches in {1} seconds".format(len(ue_dict),
                                                             duration))
-        print("Actual attach rate = {0} UEs per sec",
-              round(len(ue_dict)/duration))
+        print("Actual attach rate = {0} UEs per sec".format(round(len(ue_dict)/duration)))
 
         time.sleep(args.time_between_detach)
 

--- a/lte/gateway/python/scripts/pipelined_cli.py
+++ b/lte/gateway/python/scripts/pipelined_cli.py
@@ -157,13 +157,15 @@ def stress_test_grpc(client, args):
     delta_time = 1/args.attaches_per_sec
     print("Attach every ~{0} seconds".format(delta_time))
 
-    if args.enable_qos:
+    if args.disable_qos:
+        print("QOS Disabled")
+        apn_ambr = None
+    else:
+        print("QOS Enabled")
         apn_ambr = AggregatedMaximumBitrate(
             max_bandwidth_ul=1000000000,
             max_bandwidth_dl=1000000000,
         )
-    else:
-        apn_ambr = None
 
     def _gen_ue_set(num_of_ues):
         imsi = 123000000
@@ -316,8 +318,8 @@ def create_enforcement_parser(apps):
                         type=int, default=10)
     subcmd.add_argument('--test_iterations', help='Test duration in seconds',
                         type=int, default=5)
-    subcmd.add_argument('--enable_qos', help='If rule should include qos',
-                        type=bool, default=True)
+    subcmd.add_argument('--disable_qos', help='If we want to disable QOS',
+                        action="store_true")
     subcmd.set_defaults(func=stress_test_grpc)
 
 # -------------

--- a/lte/gateway/python/scripts/pipelined_cli.py
+++ b/lte/gateway/python/scripts/pipelined_cli.py
@@ -15,10 +15,14 @@ limitations under the License.
 
 import argparse
 import errno
-from pprint import pprint
+import time
+import random
 import subprocess
+from datetime import datetime
+from collections import namedtuple
+from pprint import pprint
 
-from magma.common.rpc_utils import grpc_wrapper
+from magma.common.rpc_utils import grpc_wrapper, grpc_async_wrapper
 from lte.protos.pipelined_pb2 import (
     SubscriberQuotaUpdate,
     UpdateSubscriberQuotaStateRequest,
@@ -39,6 +43,7 @@ from lte.protos.pipelined_pb2 import (
     RuleModResult,
     UEMacFlowRequest,
     RequestOriginType,
+    DeactivateFlowsResult,
 )
 from lte.protos.pipelined_pb2_grpc import PipelinedStub
 from lte.protos.policydb_pb2 import FlowMatch, FlowDescription, PolicyRule
@@ -142,6 +147,92 @@ def get_policy_usage(client, _):
     pprint(rule_table)
 
 
+@grpc_wrapper
+def stress_test_grpc(client, args):
+    UEInfo = namedtuple('UEInfo', ['imsi_str', 'ipv4_src', 'ipv4_dst',
+                                   'rule_id'])
+    delta_time = 1/args.attaches_per_sec
+    print("Attach every ~{0} seconds".format(delta_time))
+
+    def _gen_ue_set(num_of_ues):
+        imsi = 123000000
+        ue_set = set()
+        for _ in range(0, num_of_ues):
+            imsi_str = "IMSI" + str(imsi)
+            ipv4_src = ".".join(str(random.randint(0, 255)) for _ in range(4))
+            ipv4_dst = ".".join(str(random.randint(0, 255)) for _ in range(4))
+            rule_id = "allow." + imsi_str
+            ue_set.add(UEInfo(imsi_str, ipv4_src, ipv4_dst, rule_id))
+            imsi = imsi + 1
+        return ue_set
+
+    for i in range (0, args.test_iterations):
+        print("Starting iteration {0} of attach/detach requests".format(i))
+        ue_dict = _gen_ue_set(args.num_of_ues)
+        print("Starting attaches")
+
+        timestamp = datetime.now()
+        for ue in ue_dict:
+            grpc_start_timestamp = datetime.now()
+            request = ActivateFlowsRequest(
+                sid=SIDUtils.to_pb(ue.imsi_str),
+                ip_addr=ue.ipv4_src,
+                dynamic_rules=[PolicyRule(
+                    id=ue.rule_id,
+                    priority=10,
+                    flow_list=[
+                        FlowDescription(match=FlowMatch(
+                            ip_dst=convert_ipv4_str_to_ip_proto(ue.ipv4_src),
+                            direction=FlowMatch.UPLINK)),
+                        FlowDescription(match=FlowMatch(
+                            ip_src=convert_ipv4_str_to_ip_proto(ue.ipv4_dst),
+                            direction=FlowMatch.DOWNLINK)),
+                    ],
+                )],
+                request_origin=RequestOriginType(type=RequestOriginType.GX))
+            response = client.ActivateFlows(request)
+            if any(r.result != RuleModResult.SUCCESS for
+                   r in response.dynamic_rule_results):
+                _print_rule_mod_results(response.dynamic_rule_results)
+
+            grpc_end_timestamp = datetime.now()
+            call_duration = (grpc_end_timestamp - grpc_start_timestamp).total_seconds()
+            if call_duration < delta_time:
+                time.sleep(delta_time - call_duration)
+
+        duration = (datetime.now() - timestamp).total_seconds()
+        print("Finished {0} attaches in {1} seconds".format(len(ue_dict),
+                                                            duration))
+        print("Actual attach rate = {0} UEs per sec",
+              round(len(ue_dict)/duration))
+
+        time.sleep(args.time_between_detach)
+
+        print("Starting detaches")
+        timestamp = datetime.now()
+        for ue in ue_dict:
+            grpc_start_timestamp = datetime.now()
+            request = DeactivateFlowsRequest(
+                sid=SIDUtils.to_pb(ue.imsi_str),
+                ip_addr=ue.ipv4_src,
+                rule_ids=[ue.rule_id],
+                request_origin=RequestOriginType(type=RequestOriginType.GX))
+            response = client.DeactivateFlows(request)
+            if response.result != DeactivateFlowsResult.SUCCESS:
+                _print_rule_mod_results(response.dynamic_rule_results)
+
+            grpc_end_timestamp = datetime.now()
+            call_duration = (grpc_end_timestamp - grpc_start_timestamp).total_seconds()
+            if call_duration < delta_time:
+                time.sleep(delta_time - call_duration)
+
+        duration = (datetime.now() - timestamp).total_seconds()
+        print("Finished {0} detaches in {1} seconds".format(len(ue_dict),
+                                                            duration))
+        print("Actual detach rate = {0} UEs per sec",
+              round(len(ue_dict)/duration))
+
+
 def create_enforcement_parser(apps):
     """
     Creates the argparse subparser for the enforcement app
@@ -200,6 +291,19 @@ def create_enforcement_parser(apps):
                                    help='Get policy usage stats')
     subcmd.set_defaults(func=get_policy_usage)
 
+    subcmd = subparsers.add_parser('stress_test_grpc',
+        help='Sends a set of Activate grpc requests, followed by Deactivates')
+    subcmd.add_argument('--attaches_per_sec',
+                        help='Number of grpc Attach requests per second',
+                        type=int, default=10)
+    subcmd.add_argument('--num_of_ues', help='Number of total UEs to atach',
+                        type=int, default=600)
+    subcmd.add_argument('--time_between_detach',
+                        help='Time between attaches and detaches in seconds',
+                        type=int, default=10)
+    subcmd.add_argument('--test_iterations', help='Test duration in seconds',
+                        type=int, default=5)
+    subcmd.set_defaults(func=stress_test_grpc)
 
 # -------------
 # UE MAC APP

--- a/lte/gateway/python/scripts/pipelined_cli.py
+++ b/lte/gateway/python/scripts/pipelined_cli.py
@@ -231,7 +231,8 @@ def stress_test_grpc(client, args):
                 sid=SIDUtils.to_pb(ue.imsi_str),
                 ip_addr=ue.ipv4_src,
                 rule_ids=[ue.rule_id],
-                request_origin=RequestOriginType(type=RequestOriginType.GX))
+                request_origin=RequestOriginType(type=RequestOriginType.GX),
+                remove_default_drop_flows=True)
             response = client.DeactivateFlows(request)
             if response.result != DeactivateFlowsResult.SUCCESS:
                 _print_rule_mod_results(response.dynamic_rule_results)


### PR DESCRIPTION
Signed-off-by: Nick Yurchenko <koolzz@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary
F.E local test run:

```
(python) vagrant@magma-dev:~/magma/lte/gateway/python/scripts$ pipelined_cli.py enforcement stress_test_grpc --attaches_per_sec=30 --test_iterations=1
/home/vagrant/build/python/lib/python3.5/site-packages/scapy/config.py:411: CryptographyDeprecationWarning: Python 3.5 support will be dropped in the next release of cryptography. Please upgrade your Python.
  import cryptography
Attach every ~0.03333333333333333 seconds
Starting iteration 0 of attach/detach requests
Starting attaches
Finished 600 attaches in 25.23167 seconds
Actual attach rate = {0} UEs per sec 24
Starting detaches
Finished 600 detaches in 20.353623 seconds
Actual detach rate = {0} UEs per sec 29

(python) vagrant@magma-dev:~/magma/lte/gateway/python/scripts$ pipelined_cli.py enforcement stress_test_grpc --attaches_per_sec=30 --test_iterations=1 --enable_qos=True
/home/vagrant/build/python/lib/python3.5/site-packages/scapy/config.py:411: CryptographyDeprecationWarning: Python 3.5 support will be dropped in the next release of cryptography. Please upgrade your Python.
  import cryptography
Attach every ~0.03333333333333333 seconds
Starting iteration 0 of attach/detach requests
Starting attaches
^[[BFinished 600 attaches in 52.237711 seconds
Actual attach rate = {0} UEs per sec 11
Starting detaches
Finished 600 detaches in 20.313224 seconds
Actual detach rate = {0} UEs per sec 30
```

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->

[profile.txt](https://github.com/magma/magma/files/6037046/profile.txt)
