### PR TITLE
[helm] update default service_regsitry.mode to k8s

### DIFF
--- a/cwf/cloud/helm/cwf-orc8r/Chart.yaml
+++ b/cwf/cloud/helm/cwf-orc8r/Chart.yaml
@@ -13,7 +13,7 @@ apiVersion: v2
 appVersion: "1.0"
 description: A Helm chart for magma orchestrator's cwf module
 name: cwf-orc8r
-version: 0.2.0
+version: 0.2.1
 engine: gotpl
 sources:
   - https://github.com/magma/magma

--- a/cwf/cloud/helm/cwf-orc8r/values.yaml
+++ b/cwf/cloud/helm/cwf-orc8r/values.yaml
@@ -41,7 +41,7 @@ controller:
       user: postgres
       pass: postgres
     service_registry:
-      mode: "yaml"
+      mode: "k8s"
 
   podAnnotations: {}
 

--- a/docs/readmes/orc8r/upgrade_1_4.md
+++ b/docs/readmes/orc8r/upgrade_1_4.md
@@ -56,14 +56,14 @@ module orc8r {
 module orc8r-app {
   source = "github.com/magma/magma//orc8r/cloud/deploy/terraform/orc8r-helm-aws?ref=v1.4"
   # ...
-  orc8r_chart_version   = "1.5.12"
+  orc8r_chart_version   = "1.5.14"
   orc8r_tag             = "MAGMA_TAG"  # from build step, e.g. v1.4.0
   orc8r_deployment_type = "fwa"        # valid options: ["fwa", "federated_fwa", "all"]
 }
 ```
 
 Set `cluster_version` to the Kubernetes version found during the
-`Prerequisites` section. Bump your chart version to `1.5.12` and `orc8r_tag` to
+`Prerequisites` section. Bump your chart version to `1.5.14` and `orc8r_tag` to
 the semver tag you published your new Orchestrator container images as.
 You also need to set the `orc8r_deployment_type` variable to the deployment
 type that you intend to deploy. This type sets which orc8r modules will run.

--- a/fbinternal/cloud/helm/fbinternal-orc8r/Chart.yaml
+++ b/fbinternal/cloud/helm/fbinternal-orc8r/Chart.yaml
@@ -13,7 +13,7 @@ apiVersion: v2
 appVersion: "1.0"
 description: A Helm chart for magma orchestrator's fbinternal module
 name: fbinternal-orc8r
-version: 0.2.0
+version: 0.2.1
 engine: gotpl
 sources:
   - https://github.com/magma/magma

--- a/fbinternal/cloud/helm/fbinternal-orc8r/values.yaml
+++ b/fbinternal/cloud/helm/fbinternal-orc8r/values.yaml
@@ -41,7 +41,7 @@ controller:
       user: postgres
       pass: postgres
     service_registry:
-      mode: "yaml"
+      mode: "k8s"
 
   podAnnotations: {}
 

--- a/feg/cloud/helm/feg-orc8r/Chart.yaml
+++ b/feg/cloud/helm/feg-orc8r/Chart.yaml
@@ -13,7 +13,7 @@ apiVersion: v2
 appVersion: "1.0"
 description: A Helm chart for magma orchestrator's feg module
 name: feg-orc8r
-version: 0.2.2
+version: 0.2.3
 engine: gotpl
 sources:
   - https://github.com/magma/magma

--- a/feg/cloud/helm/feg-orc8r/values.yaml
+++ b/feg/cloud/helm/feg-orc8r/values.yaml
@@ -41,7 +41,7 @@ controller:
       user: postgres
       pass: postgres
     service_registry:
-      mode: "yaml"
+      mode: "k8s"
 
   podAnnotations: {}
 

--- a/lte/cloud/helm/lte-orc8r/Chart.yaml
+++ b/lte/cloud/helm/lte-orc8r/Chart.yaml
@@ -13,7 +13,7 @@ apiVersion: v2
 appVersion: "1.0"
 description: A Helm chart for magma orchestrator's lte module
 name: lte-orc8r
-version: 0.2.1
+version: 0.2.2
 engine: gotpl
 sources:
   - https://github.com/magma/magma

--- a/lte/cloud/helm/lte-orc8r/values.yaml
+++ b/lte/cloud/helm/lte-orc8r/values.yaml
@@ -41,7 +41,7 @@ controller:
       user: postgres
       pass: postgres
     service_registry:
-      mode: "yaml"
+      mode: "k8s"
 
   podAnnotations: {}
 

--- a/orc8r/cloud/deploy/terraform/orc8r-helm-aws/variables.tf
+++ b/orc8r/cloud/deploy/terraform/orc8r-helm-aws/variables.tf
@@ -171,37 +171,37 @@ variable "orc8r_deployment_type" {
 variable "orc8r_chart_version" {
   description = "Version of the core orchestrator Helm chart to install."
   type        = string
-  default     = "1.5.12"
+  default     = "1.5.14"
 }
 
 variable "cwf_orc8r_chart_version" {
   description = "Version of the orchestrator cwf module Helm chart to install."
   type        = string
-  default     = "0.2.0"
+  default     = "0.2.1"
 }
 
 variable "fbinternal_orc8r_chart_version" {
   description = "Version of the orchestrator fbinternal module Helm chart to install."
   type        = string
-  default     = "0.2.0"
+  default     = "0.2.1"
 }
 
 variable "feg_orc8r_chart_version" {
   description = "Version of the orchestrator feg module Helm chart to install."
   type        = string
-  default     = "0.2.1"
+  default     = "0.2.2"
 }
 
 variable "lte_orc8r_chart_version" {
   description = "Version of the orchestrator lte module Helm chart to install."
   type        = string
-  default     = "0.2.1"
+  default     = "0.2.2"
 }
 
 variable "wifi_orc8r_chart_version" {
   description = "Version of the orchestrator wifi module Helm chart to install."
   type        = string
-  default     = "0.2.0"
+  default     = "0.2.1"
 }
 
 variable "orc8r_tag" {

--- a/orc8r/cloud/helm/orc8r/Chart.yaml
+++ b/orc8r/cloud/helm/orc8r/Chart.yaml
@@ -13,7 +13,7 @@ apiVersion: v2
 appVersion: "1.0"
 description: A Helm chart for magma orchestrator
 name: orc8r
-version: 1.5.13
+version: 1.5.14
 engine: gotpl
 sources:
   - https://github.com/magma/magma

--- a/orc8r/cloud/helm/orc8r/values.yaml
+++ b/orc8r/cloud/helm/orc8r/values.yaml
@@ -158,7 +158,7 @@ controller:
       user: postgres
       pass: postgres
     service_registry:
-      mode: "yaml"
+      mode: "k8s"
 
   podAnnotations: {}
 

--- a/wifi/cloud/helm/wifi-orc8r/Chart.yaml
+++ b/wifi/cloud/helm/wifi-orc8r/Chart.yaml
@@ -13,7 +13,7 @@ apiVersion: v2
 appVersion: "1.0"
 description: A Helm chart for magma orchestrator's wifi module
 name: wifi-orc8r
-version: 0.2.0
+version: 0.2.1
 engine: gotpl
 sources:
   - https://github.com/magma/magma

--- a/wifi/cloud/helm/wifi-orc8r/values.yaml
+++ b/wifi/cloud/helm/wifi-orc8r/values.yaml
@@ -41,7 +41,7 @@ controller:
       user: postgres
       pass: postgres
     service_registry:
-      mode: "yaml"
+      mode: "k8s"
 
   podAnnotations: {}
 


### PR DESCRIPTION
Signed-off-by: Scott8440 <scott8440@gmail.com>

## Summary

When deploying on minikube (or bare metal) orc8r-nginx would crashloop due to a misconfiguration caused by the value `controller.service_registry.mode=yaml`, when for 1.4 it should be `k8s`.

## Test Plan

Deploy following minikube instructions (but using 1.4 and most recent helm charts), orc8r-nginx does not crash anymore, and deployment is the same as if deployed on terraform which has been validated to work.
