### PR TITLE
[orc8r][bare-metal] Pin ansible-haproxy galaxy commit due to docker issue

### DIFF
--- a/orc8r/cloud/deploy/bare-metal/deploy.sh
+++ b/orc8r/cloud/deploy/bare-metal/deploy.sh
@@ -17,7 +17,7 @@ pip install -r requirements.txt
 # Prepare KeepaliveD role
 ansible-galaxy install evrardjp.keepalived
 # Prepare HAProxy role
-ansible-galaxy install uoi-io.haproxy
+ansible-galaxy install git+https://github.com/uoi-io/ansible-haproxy,fe397a380ad733be7d17b567b626301e1ee90089
 
 # Copy ``inventory/sample`` as ``inventory/$CLUSTER_NAME``
 cp -rfp inventory/sample inventory/$CLUSTER_NAME

--- a/orc8r/cloud/deploy/bare-metal/setup_ha_proxy.yml
+++ b/orc8r/cloud/deploy/bare-metal/setup_ha_proxy.yml
@@ -4,7 +4,7 @@
   become_user: root
   roles:
     - evrardjp.keepalived
-    - uoi-io.haproxy
+    - ansible-haproxy
   vars:
     virtual_ip: "{{ loadbalancer_apiserver.address }}/24"
     keepalived_sync_groups:


### PR DESCRIPTION
The deploy script depends on an ansible-galaxy package that is being updated with new features, which are requiring new python dependencies. We don't need this functionality and we can safely pin back to an older commit from Dec 2020.