### PR TITLE
[lte][agw] Reset hash table size to 0 upon destroy

### DIFF
--- a/lte/gateway/c/oai/lib/hashtable/hashtable_uint64.c
+++ b/lte/gateway/c/oai/lib/hashtable/hashtable_uint64.c
@@ -278,6 +278,7 @@ hashtable_rc_t hashtable_uint64_destroy(hash_table_uint64_t* hashtblP) {
 
   free_wrapper((void**) &hashtblP->nodes);
   bdestroy_wrapper(&hashtblP->name);
+  hashtblP->size = 0;
   if (hashtblP->is_allocated_by_malloc) {
     free_wrapper((void**) &hashtblP);
   }
@@ -316,6 +317,7 @@ hashtable_rc_t hashtable_uint64_ts_destroy(hash_table_uint64_ts_t* hashtblP) {
   free_wrapper((void**) &hashtblP->nodes);
   bdestroy_wrapper(&hashtblP->name);
   free_wrapper((void**) &hashtblP->lock_nodes);
+  hashtblP->size = 0;
   if (hashtblP->is_allocated_by_malloc) {
     free_wrapper((void**) &hashtblP);
   }


### PR DESCRIPTION
## Summary

Upon destruction of the hash tables, the size was not reset to zero. This would result in segmentation fault when the same table is attempted to be destroyed more than once as the size is not reset to zero.

## Test Plan

integration testing.
scaling tests with spirent where the coredumps were observed.

## Additional Information

- [ ] This change is backwards-breaking
