### PR TITLE
[AGW][S1ap tests] Handle SMC retransmissions for MME restarts

### DIFF
--- a/lte/gateway/python/integ_tests/s1aptests/test_no_smc_with_mme_restart_reattach.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_no_smc_with_mme_restart_reattach.py
@@ -81,6 +81,10 @@ class TestNoSmcWithMmeRestartReattach(unittest.TestCase):
 
         # Wait for UE context release command
         response = self._s1ap_wrapper.s1_util.get_response()
+        while response.msg_type == s1ap_types.tfwCmd.UE_SEC_MOD_CMD_IND.value:
+            print("Received SMC retx from previous run... Ignoring")
+            response = self._s1ap_wrapper.s1_util.get_response()
+
         self.assertEqual(
             response.msg_type, s1ap_types.tfwCmd.UE_CTX_REL_IND.value
         )


### PR DESCRIPTION
Signed-off-by: Shruti Sanadhya <ssanadhya@fb.com>

## Summary

The `test_no_smc_with_mme_restart_reattach.py` restarts the MME while it is running timer T3460 for the SMC it sent. In such cases, depending on when the MME restarted, it might retransmit the SMC, leading to flakiness in the test. This change adds a loop to absorb all the retransmissions before asserting on UE Context Release

## Test Plan

Ran test `test_no_smc_with_mme_restart_reattach.py` multiple times without any failure
