### PR TITLE
AGW: mobilityd: static IP alloc: Fix typo

### DIFF
--- a/lte/gateway/python/magma/mobilityd/ip_allocator_static.py
+++ b/lte/gateway/python/magma/mobilityd/ip_allocator_static.py
@@ -88,7 +88,7 @@ class IPAllocatorStaticWrapper(IPAllocator):
             self._store.ip_state_map.remove_ip_from_state(ip_desc.ip,
                                                           IPState.FREE)
             ip_block_network = ip_network(ip_desc.ip_block)
-            if ip_block_network in self._assigned_ip_blocks:
+            if ip_block_network in self._store.assigned_ip_blocks:
                 self._store.assigned_ip_blocks.remove(ip_block_network)
         else:
             self._ip_allocator.release_ip(ip_desc)


### PR DESCRIPTION
Fix typo in accessing _assigned_ip_blocks.

Signed-off-by: Pravin B Shelar <pbshelar@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
