### PR TITLE
[AGW] Add a version file to the coredump pkg

### DIFF
--- a/lte/gateway/deploy/roles/magma/files/coredump
+++ b/lte/gateway/deploy/roles/magma/files/coredump
@@ -15,9 +15,11 @@ rm -rf /tmp/"$NAME"_bundle
 mkdir /tmp/"$NAME"_bundle
 mv /var/$NAME.gz /tmp/"$NAME"_bundle
 
+dpkg -s magma | grep Version | sed 's/Version: //' > /tmp/"$NAME"_bundle/version
+
 for FILE in `cat /etc/magma/logfiles.txt`
 do
-  cp $FILE /tmp/"$NAME"_bundle 2>/dev/null || echo "Couldnt copy $FILE to bundle"
+  cp $FILE /tmp/"$NAME"_bundle 2>/dev/null || echo "Couldn't copy $FILE to bundle"
 done
 
 tar czf /var/core/"$NAME".tgz -C /tmp/"$NAME"_bundle .


### PR DESCRIPTION
Signed-off-by: Marie Bremner <marwhal@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary
The coredump pkg currently is missing any information about the magma version. This makes it difficult to find the corresponding exec to analyze the dumps.
<!-- Enumerate changes you made and why you made them -->

## Test Plan
Replaced the coredump file with the updated version + waited for a core
```
magma@agw1:/var/core$ sudo tar -zxvf  core-1614196371-mme-15571.tgz
./
./syslog
./mme.log
./version
./core-1614196371-mme-15571.gz

...

magma@agw1:/var/core$ cat version
1.4.0-1614171043-7cd5877d
```
## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
