### PR TITLE
[AGW] Fix coredump generation in local setup

### DIFF
--- a/lte/gateway/deploy/roles/magma/files/coredump
+++ b/lte/gateway/deploy/roles/magma/files/coredump
@@ -15,7 +15,7 @@ rm -rf /tmp/"$NAME"_bundle
 mkdir /tmp/"$NAME"_bundle
 mv /var/$NAME.gz /tmp/"$NAME"_bundle
 
-dpkg -s magma | grep Version | sed 's/Version: //' > /tmp/"$NAME"_bundle/version
+apt-cache policy magma | grep Installed > /tmp/"$NAME"_bundle/version
 
 for FILE in `cat /etc/magma/logfiles.txt`
 do

--- a/lte/gateway/deploy/roles/magma/tasks/main.yml
+++ b/lte/gateway/deploy/roles/magma/tasks/main.yml
@@ -71,6 +71,18 @@
   copy: src=99-magma.conf dest=/etc/sysctl.d/99-magma.conf
   when: full_provision
 
+- name: Add the sysctl config from the step before
+  become: yes
+  command: 'sysctl -p /etc/sysctl.d/99-magma.conf'
+  when: full_provision
+
+- name: Set core ulimit to unlimited
+  pam_limits:
+    domain: '*'
+    limit_item: core
+    limit_type: '-'
+    value: unlimited
+
 - name: Create the /var/core directory
   file: path=/var/core state=directory
   when: full_provision


### PR DESCRIPTION
Signed-off-by: Marie Bremner <marwhal@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary
1. fix coredump generation for local dev VM setup. We were not setting the ulimit and core_pattern properly, so doing that in ansible
2. For local devVM the dpkg command fails since there is not a magma package installed. I've changed it to a less nice option of just outputting a filtered `apt-cache policy magmag`. :'( 
<!-- Enumerate changes you made and why you made them -->

## Test Plan
```
vagrant destroy magma
vagrant up magma
...
force MME to crash
...
vagrant@magma-dev:~/magma/lte/gateway$ ls -la /var/core
total 8844
drwxr-xr-x  2 root root    4096 Feb 24 22:21 .
drwxr-xr-x 13 root root    4096 Feb 24 22:21 ..
-rw-rw-rw-  1 root root 1295716 Feb 24 22:02 core-1614204134-sessiond-27822.tgz
-rw-rw-rw-  1 root root 2661162 Feb 24 22:04 core-1614204289-mme-29304.tgz
-rw-rw-rw-  1 root root 2499931 Feb 24 22:06 core-1614204409-mme-32224.tgz
-rw-rw-rw-  1 root root 2581291 Feb 24 22:21 core-1614205273-mme-10665.tgz
```
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
