### PR TITLE
Make default drop flow stats reporting optional

### DIFF
--- a/lte/gateway/configs/pipelined.yml
+++ b/lte/gateway/configs/pipelined.yml
@@ -68,6 +68,7 @@ meter:
 
 enforcement:
   poll_interval: 2
+  enable_default_drop_flow_stats: false
   default_drop_flow_name: 'internal_default_drop_flow_rule'
 
 # Enable polling mobilityd to identify which subscriber sessions need to be

--- a/lte/gateway/configs/pipelined.yml_prod
+++ b/lte/gateway/configs/pipelined.yml_prod
@@ -66,6 +66,7 @@ meter:
 
 enforcement:
   poll_interval: 2
+  enable_default_drop_flow_stats: false
   default_drop_flow_name: 'internal_default_drop_flow_rule'
 
 dpi:


### PR DESCRIPTION
Signed-off-by: Nick Yurchenko <koolzz@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary
Some deployments don't care about this metric and it reduces the number of flows we install and the report size we send to sessiond

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
