### PR TITLE
[v1.4][eventd] Fix failing build due to missing code for eventd service

### DIFF
--- a/orc8r/cloud/go/services/eventd/eventd/main.go
+++ b/orc8r/cloud/go/services/eventd/eventd/main.go
@@ -15,8 +15,6 @@ package main
 
 import (
 	"magma/gateway/eventd"
-	"magma/orc8r/cloud/go/obsidian/swagger"
-	swagger_protos "magma/orc8r/cloud/go/obsidian/swagger/protos"
 	"magma/orc8r/cloud/go/orc8r"
 	"magma/orc8r/cloud/go/service"
 
@@ -28,8 +26,6 @@ func main() {
 	if err != nil {
 		glog.Fatalf("Error creating service: %+v", err)
 	}
-
-	swagger_protos.RegisterSwaggerSpecServer(srv.GrpcServer, swagger.NewSpecServicerFromFile(eventd.ServiceName))
 
 	err = srv.Run()
 	if err != nil {


### PR DESCRIPTION
Signed-off-by: Michael Germano <mgermano@fb.com>

## Summary

Recently merged changes require other code that doesn't exist in the v1.4 branch. Given that this functionality isn't being
used in v1.4, we can safely remove the failing calls.

## Test Plan

Ensure precommit passes