### PR TITLE
[MME] Fix sctpd pointer inequality comparison with zero #clang

### DIFF
--- a/lte/gateway/c/oai/tasks/sctp/sctpd_downlink_client.cpp
+++ b/lte/gateway/c/oai/tasks/sctp/sctpd_downlink_client.cpp
@@ -134,7 +134,7 @@ int sctpd_init(sctp_init_t* init) {
 
   for (i = 0; i < init->nb_ipv4_addr; i++) {
     auto ipv4_addr = init->ipv4_address[i];
-    if (inet_ntop(AF_INET, &ipv4_addr, ipv4_str, INET_ADDRSTRLEN) < 0) {
+    if (inet_ntop(AF_INET, &ipv4_addr, ipv4_str, INET_ADDRSTRLEN) == nullptr) {
       Fatal("failed to convert ipv4 addr\n");
       return -1;
     }
@@ -143,7 +143,8 @@ int sctpd_init(sctp_init_t* init) {
 
   for (i = 0; i < init->nb_ipv6_addr; i++) {
     auto ipv6_addr = init->ipv6_address[i];
-    if (inet_ntop(AF_INET6, &ipv6_addr, ipv6_str, INET6_ADDRSTRLEN) < 0) {
+    if (inet_ntop(AF_INET6, &ipv6_addr, ipv6_str, INET6_ADDRSTRLEN) ==
+        nullptr) {
       Fatal("failed to convert ipv6 addr\n");
       return -1;
     }


### PR DESCRIPTION
In effort to bring up Clang compilation (Issue #4865) - aside from a barrage of new warnings, there are some errors being found.

## Clang Error

```shell
/home/vagrant/magma/lte/gateway/c/oai/tasks/sctp/sctpd_downlink_client.cpp:137:67: error: ordered comparison between pointer and zero ('const char *' and 'int')
    if (inet_ntop(AF_INET, &ipv4_addr, ipv4_str, INET_ADDRSTRLEN) < 0) {
        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ^ ~
/home/vagrant/magma/lte/gateway/c/oai/tasks/sctp/sctpd_downlink_client.cpp:146:69: error: ordered comparison between pointer and zero ('const char *' and 'int')
    if (inet_ntop(AF_INET6, &ipv6_addr, ipv6_str, INET6_ADDRSTRLEN) < 0) {
        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ^
```

## Resolution in this PR

It is unclear to me how this would behave in GCC.  My best guess would be that no error checking (for null pointer) is occuring.

In this PR I've moved this comparison to `!= nullptr` instead of `< 0`.

Signed-off-by: Scott Harrison Moeller <smoeller@fb.com>