### PR TITLE
[redis] Skip invalid keys in redis dict __iter__

### DIFF
--- a/orc8r/gateway/python/magma/common/redis/containers.py
+++ b/orc8r/gateway/python/magma/common/redis/containers.py
@@ -222,7 +222,12 @@ class RedisFlatDict(MutableMapping[str, T]):
                 split_key = deserialized_key.split(":", 1)
             except AttributeError:
                 split_key = k.split(":", 1)
-            if self.is_garbage(split_key[0]):
+            # There could be a delete key in between KEYS and GET, so ignore
+            # invalid values for now
+            try:
+                if self.is_garbage(split_key[0]):
+                    continue
+            except KeyError:
                 continue
             yield split_key[0]
 
@@ -351,7 +356,12 @@ class RedisFlatDict(MutableMapping[str, T]):
                 split_key = deserialized_key.split(":", 1)
             except AttributeError:
                 split_key = k.split(":", 1)
-            if not self.is_garbage(split_key[0]):
+            # There could be a delete key in between KEYS and GET, so ignore
+            # invalid values for now
+            try:
+                if not self.is_garbage(split_key[0]):
+                    continue
+            except KeyError:
                 continue
             garbage_keys.append(split_key[0])
         return garbage_keys


### PR DESCRIPTION
Signed-off-by: Marie Bremner <marwhal@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary
Since __iter__ and garbage_keys are called without locking the entire DB, there could be a transaction that could take place in between getting all the keys and iterating through them. Currently, when this happen we throw an exception that we don't catch. This PR adds the change to catch and ignore.

Seeing lots of errrors like this on 1.4.
```
Feb 24 14:59:26 agw1 state[1533]: ERROR:root:Exception from _run: 'IMSI001011234560087:MME'
Feb 24 14:59:26 agw1 state[1533]: Traceback (most recent call last):
Feb 24 14:59:26 agw1 state[1533]:   File "/usr/local/lib/python3.5/dist-packages/magma/common/job.py", line 121, in _periodic
Feb 24 14:59:26 agw1 state[1533]:     await self._run()
Feb 24 14:59:26 agw1 state[1533]:   File "/usr/local/lib/python3.5/dist-packages/magma/state/state_replicator.py", line 81, in _run
Feb 24 14:59:26 agw1 state[1533]:     request = await self._collect_states_to_replicate()
Feb 24 14:59:26 agw1 state[1533]:   File "/usr/local/lib/python3.5/dist-packages/magma/state/state_replicator.py", line 131, in _collect_states_to_replicate
Feb 24 14:59:26 agw1 state[1533]:     for key in redis_dict:
Feb 24 14:59:26 agw1 state[1533]:   File "/usr/local/lib/python3.5/dist-packages/magma/common/redis/containers.py", line 225, in __iter__
Feb 24 14:59:26 agw1 state[1533]:     if self.is_garbage(split_key[0]):
Feb 24 14:59:26 agw1 state[1533]:   File "/usr/local/lib/python3.5/dist-packages/magma/common/redis/containers.py", line 336, in is_garbage
Feb 24 14:59:26 agw1 state[1533]:     raise KeyError(composite_key)
Feb 24 14:59:26 agw1 state[1533]: KeyError: 'IMSI001011234560087:MME'
```
## Test Plan
tested in lab setup
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
