### PR TITLE
AGW: sessionD: ubuntu: handle newer gmock lib location.

### DIFF
--- a/lte/gateway/c/session_manager/test/CMakeLists.txt
+++ b/lte/gateway/c/session_manager/test/CMakeLists.txt
@@ -3,6 +3,7 @@ add_compile_options(-std=c++14)
 set(OUTPUT_DIR "${CMAKE_CURRENT_BINARY_DIR}")
 
 include_directories("${PROJECT_SOURCE_DIR}")
+include_directories("/usr/src/googletest/googlemock/include/")
 
 add_library(SESSIOND_TEST_LIB
     Consts.h
@@ -13,7 +14,8 @@ add_library(SESSIOND_TEST_LIB
     SessionStateTester.h
     )
 
-target_link_libraries(SESSIOND_TEST_LIB SESSION_MANAGER gmock_main pthread rt)
+link_directories(/usr/src/googletest/googlemock/lib/)
+target_link_libraries(SESSIOND_TEST_LIB SESSION_MANAGER gmock_main gtest gtest_main gmock pthread rt)
 
 foreach (session_test session_credit local_enforcer cloud_reporter
     session_manager_handler sessiond_integ session_state


### PR DESCRIPTION
gmock lib location is changed on ubuntu, This PR adds it to makefile.

Signed-off-by: Pravin B Shelar <pbshelar@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
