### PR TITLE
[lte][ha] Add gateway pool API update route

### DIFF
--- a/lte/cloud/go/services/lte/obsidian/handlers/handlers.go
+++ b/lte/cloud/go/services/lte/obsidian/handlers/handlers.go
@@ -114,6 +114,7 @@ func GetHandlers() []obsidian.Handler {
 		{Path: ListGatewayPoolsPath, Methods: obsidian.GET, HandlerFunc: listGatewayPoolsHandler},
 		{Path: ListGatewayPoolsPath, Methods: obsidian.POST, HandlerFunc: createGatewayPoolHandler},
 		{Path: ManageGatewayPoolsPath, Methods: obsidian.GET, HandlerFunc: getGatewayPoolHandler},
+		{Path: ManageGatewayPoolsPath, Methods: obsidian.PUT, HandlerFunc: updateGatewayPoolHandler},
 		{Path: ManageGatewayPoolsPath, Methods: obsidian.DELETE, HandlerFunc: deleteGatewayPoolHandler},
 
 		{Path: ManageNetworkApnPath, Methods: obsidian.GET, HandlerFunc: listApns},
@@ -810,6 +811,37 @@ func getGatewayPoolHandler(c echo.Context) error {
 		return obsidian.HttpError(err, http.StatusInternalServerError)
 	}
 	return c.JSON(http.StatusOK, gatewayPool)
+}
+
+func updateGatewayPoolHandler(c echo.Context) error {
+	networkID, gatewayPoolID, nerr := getNetworkIDAndGatewayPoolID(c)
+	if nerr != nil {
+		return nerr
+	}
+	gatewayPool := &lte_models.MutableCellularGatewayPool{}
+	if err := c.Bind(gatewayPool); err != nil {
+		return obsidian.HttpError(err, http.StatusBadRequest)
+	}
+	if err := gatewayPool.ValidateModel(); err != nil {
+		return obsidian.HttpError(err, http.StatusBadRequest)
+	}
+	if string(gatewayPool.GatewayPoolID) != gatewayPoolID {
+		err := fmt.Errorf("gateway pool ID from parameters (%s) and payload (%s) must match", gatewayPoolID, gatewayPool.GatewayPoolID)
+		return obsidian.HttpError(err, http.StatusBadRequest)
+	}
+	// 404 if pool doesn't exist
+	exists, err := configurator.DoesEntityExist(networkID, lte.CellularGatewayPoolEntityType, gatewayPoolID)
+	if err != nil {
+		return obsidian.HttpError(errors.Wrap(err, "Error while checking if gateway pool exists"), http.StatusInternalServerError)
+	}
+	if !exists {
+		return echo.ErrNotFound
+	}
+	_, err = configurator.UpdateEntity(networkID, gatewayPool.ToEntityUpdateCriteria(), serdes.Entity)
+	if err != nil {
+		return obsidian.HttpError(err, http.StatusInternalServerError)
+	}
+	return c.JSON(http.StatusCreated, gatewayPool.GatewayPoolID)
 }
 
 func deleteGatewayPoolHandler(c echo.Context) error {

--- a/lte/cloud/go/services/lte/obsidian/handlers/handlers_test.go
+++ b/lte/cloud/go/services/lte/obsidian/handlers/handlers_test.go
@@ -3774,6 +3774,7 @@ func TestHAGatewayPools(t *testing.T) {
 	listHaPools := tests.GetHandlerByPathAndMethod(t, obsidianHandlers, "/magma/v1/lte/:network_id/gateway_pools", obsidian.GET).HandlerFunc
 	createHaPool := tests.GetHandlerByPathAndMethod(t, obsidianHandlers, "/magma/v1/lte/:network_id/gateway_pools", obsidian.POST).HandlerFunc
 	getHaPool := tests.GetHandlerByPathAndMethod(t, obsidianHandlers, "/magma/v1/lte/:network_id/gateway_pools/:gateway_pool_id", obsidian.GET).HandlerFunc
+	updateHaPool := tests.GetHandlerByPathAndMethod(t, obsidianHandlers, "/magma/v1/lte/:network_id/gateway_pools/:gateway_pool_id", obsidian.PUT).HandlerFunc
 	deleteHaPool := tests.GetHandlerByPathAndMethod(t, obsidianHandlers, "/magma/v1/lte/:network_id/gateway_pools/:gateway_pool_id", obsidian.DELETE).HandlerFunc
 
 	getPoolRecord := tests.GetHandlerByPathAndMethod(t, obsidianHandlers, "/magma/v1/lte/:network_id/gateways/:gateway_id/cellular/pooling", obsidian.GET).HandlerFunc
@@ -3888,6 +3889,34 @@ func TestHAGatewayPools(t *testing.T) {
 	}
 	tests.RunUnitTest(t, e, tc)
 
+	// Update HA Pool
+	expectedPool.GatewayPoolName = "pool 1 updated"
+	expectedPool.Config = &lteModels.CellularGatewayPoolConfigs{MmeGroupID: 4}
+
+	tc = tests.Test{
+		Method:         "PUT",
+		URL:            fmt.Sprintf("%s/:gateway_pool_id", gatewayPoolsURLRoot),
+		Payload:        tests.JSONMarshaler(expectedPool),
+		ParamNames:     []string{"network_id", "gateway_pool_id"},
+		ParamValues:    []string{"n1", "pool1"},
+		Handler:        updateHaPool,
+		ExpectedStatus: 201,
+		ExpectedResult: tests.JSONMarshaler("pool1"),
+	}
+	tests.RunUnitTest(t, e, tc)
+
+	// Ensure update succeeded
+	tc = tests.Test{
+		Method:         "GET",
+		URL:            fmt.Sprintf("%s/:gateway_pool_id", gatewayPoolsURLRoot),
+		ParamNames:     []string{"network_id", "gateway_pool_id"},
+		ParamValues:    []string{"n1", "pool1"},
+		Handler:        getHaPool,
+		ExpectedStatus: 200,
+		ExpectedResult: tests.JSONMarshaler(expectedPool),
+	}
+	tests.RunUnitTest(t, e, tc)
+
 	// Create pool2
 	pool2 := &lteModels.MutableCellularGatewayPool{
 		GatewayPoolID:   lteModels.GatewayPoolID("pool2"),
@@ -3937,6 +3966,7 @@ func TestHAGatewayPools(t *testing.T) {
 	expectedPool.GatewayIds = []models2.GatewayID{"g1"}
 	expectedPool.GatewayPoolID = "pool2"
 	expectedPool.GatewayPoolName = "pool2"
+	expectedPool.Config.MmeGroupID = 1
 	tc = tests.Test{
 		Method:         "GET",
 		URL:            fmt.Sprintf("%s/:gateway_pool_id", gatewayPoolsURLRoot),

--- a/lte/cloud/go/services/lte/obsidian/models/conversion.go
+++ b/lte/cloud/go/services/lte/obsidian/models/conversion.go
@@ -683,6 +683,16 @@ func (m *MutableCellularGatewayPool) ToEntity() configurator.NetworkEntity {
 	return ent
 }
 
+func (m *MutableCellularGatewayPool) ToEntityUpdateCriteria() configurator.EntityUpdateCriteria {
+	update := configurator.EntityUpdateCriteria{
+		Type:      lte.CellularGatewayPoolEntityType,
+		Key:       string(m.GatewayPoolID),
+		NewName:   &m.GatewayPoolName,
+		NewConfig: m.Config,
+	}
+	return update
+}
+
 func (m *CellularGatewayPoolRecords) FromBackendModels(networkID string, gatewayID string) error {
 	cellularConfig := &GatewayCellularConfigs{}
 	err := cellularConfig.FromBackendModels(networkID, gatewayID)

--- a/lte/cloud/go/services/lte/obsidian/models/swagger.v1.yml
+++ b/lte/cloud/go/services/lte/obsidian/models/swagger.v1.yml
@@ -405,6 +405,24 @@ paths:
             $ref: '#/definitions/cellular_gateway_pool'
         default:
           $ref: './orc8r-swagger-common.yml#/responses/UnexpectedError'
+    put:
+      summary: Update gateway pool in LTE network
+      tags:
+        - LTE Networks
+      parameters:
+        - $ref: './orc8r-swagger-common.yml#/parameters/network_id'
+        - $ref: '#/parameters/gateway_pool_id'
+        - in: body
+          name: HA Gateway Pool
+          description: LTE HA gateway pool
+          required: true
+          schema:
+            $ref: '#/definitions/mutable_cellular_gateway_pool'
+      responses:
+        '201':
+          description: Success
+        default:
+          $ref: './orc8r-swagger-common.yml#/responses/UnexpectedError'
     delete:
       summary: Delete gateway pool from LTE network
       tags:

--- a/orc8r/cloud/go/obsidian/swagger/v1/swagger.yml
+++ b/orc8r/cloud/go/obsidian/swagger/v1/swagger.yml
@@ -2497,6 +2497,24 @@ paths:
       summary: Retrieve gateway pool from LTE network
       tags:
       - LTE Networks
+    put:
+      parameters:
+      - $ref: '#/parameters/network_id'
+      - $ref: '#/parameters/gateway_pool_id'
+      - description: LTE HA gateway pool
+        in: body
+        name: HA Gateway Pool
+        required: true
+        schema:
+          $ref: '#/definitions/mutable_cellular_gateway_pool'
+      responses:
+        "201":
+          description: Success
+        default:
+          $ref: '#/responses/UnexpectedError'
+      summary: Update gateway pool in LTE network
+      tags:
+      - LTE Networks
   /lte/{network_id}/gateways:
     get:
       parameters:


### PR DESCRIPTION
Signed-off-by: Michael Germano <mgermano@fb.com>

## Summary

This PR adds support for updating a cellular gateway pool entity. This route 
will allow a more natural UI in the NMS.

## Test Plan

Added unit tests
Test route locally.