### PR TITLE
AGW: pipelined: qos: skip filter for APN ambr queue

### DIFF
--- a/lte/gateway/deploy/roles/magma/files/systemd/magma_pipelined.service
+++ b/lte/gateway/deploy/roles/magma/files/systemd/magma_pipelined.service
@@ -21,6 +21,9 @@ Wants=openvswitch-switch.service
 [Service]
 Type=simple
 PermissionsStartOnly=true
+LimitNOFILE=65536
+LimitNPROC=65536
+LimitSIGPENDING=65536
 EnvironmentFile=/etc/environment
 ExecStartPre=/usr/bin/ovs-vsctl set bridge gtp_br0 protocols=OpenFlow10,OpenFlow13,OpenFlow14 other-config:disable-in-band=true
 ExecStartPre=/usr/bin/ovs-vsctl set-controller gtp_br0 tcp:127.0.0.1:6633 tcp:127.0.0.1:6654

--- a/lte/gateway/python/magma/pipelined/qos/common.py
+++ b/lte/gateway/python/magma/pipelined/qos/common.py
@@ -324,7 +324,8 @@ class QosManager(object):
                             LOG.debug("removing apn qos_handle %d", qos_handle)
                             self.impl.remove_qos(qos_handle,
                                                  cur_qos_state[qos_handle]['direction'],
-                                                 recovery_mode=True)
+                                                 recovery_mode=True,
+                                                 skip_filter=True)
                 final_qos_state, _ = self.impl.read_all_state()
                 LOG.info("final_qos_state -> %s", json.dumps(final_qos_state, indent=1))
                 LOG.info("final_redis state -> %s", self._redis_store)
@@ -384,7 +385,7 @@ class QosManager(object):
             LOG.debug("existing root rec: ambr_qos_handle_root %d", ambr_qos_handle_root)
 
             if not ambr_qos_handle_root:
-                ambr_qos_handle_root = self.impl.add_qos(direction, QosInfo(gbr=None, mbr=apn_ambr))
+                ambr_qos_handle_root = self.impl.add_qos(direction, QosInfo(gbr=None, mbr=apn_ambr), skip_filter=True)
                 if not ambr_qos_handle_root:
                     LOG.error('Failed adding root ambr qos mbr %u direction %d',
                               apn_ambr, direction)
@@ -407,7 +408,7 @@ class QosManager(object):
                 else:
                     LOG.error('Failed adding leaf ambr qos mbr %u direction %d',
                               apn_ambr, direction)
-                    self.impl.remove_qos(ambr_qos_handle_root, direction)
+                    self.impl.remove_qos(ambr_qos_handle_root, direction, skip_filter=True)
                     return None, None
             qos_handle = ambr_qos_handle_leaf
 
@@ -479,7 +480,7 @@ class QosManager(object):
                 ambr_qos_handle = session.get_ambr(d)
                 if ambr_qos_handle:
                     LOG.debug("removing root ambr qos handle %d direction %d", ambr_qos_handle, d)
-                    self.impl.remove_qos(ambr_qos_handle, d)
+                    self.impl.remove_qos(ambr_qos_handle, d, skip_filter=True)
             LOG.debug("purging session %s %s ", imsi, session.ip_addr)
             subscriber_state.remove_session(session.ip_addr)
 

--- a/lte/gateway/python/magma/pipelined/qos/qos_meter_impl.py
+++ b/lte/gateway/python/magma/pipelined/qos/qos_meter_impl.py
@@ -57,7 +57,7 @@ class MeterManager(object):
         ofproto = self._datapath.ofproto
         return None, parser.OFPInstructionMeter(meter_id, ofproto.OFPIT_METER)
 
-    def add_qos(self, _, qos_info: QosInfo, parent=None) -> int:
+    def add_qos(self, _, qos_info: QosInfo, parent=None, __=False) -> int:
         if self._qos_impl_broken:
             raise RuntimeError(BROKEN_KERN_ERROR_MSG)
 
@@ -72,7 +72,7 @@ class MeterManager(object):
         LOG.debug("Adding meter_id %d", meter_id)
         return meter_id
 
-    def remove_qos(self, meter_id: int, d, recovery_mode=False):
+    def remove_qos(self, meter_id: int, d, recovery_mode=False, _=False):
         LOG.debug("Removing meter %d d %d recovery_mode %s", meter_id,
                   d, recovery_mode)
         if meter_id < self._start_idx or meter_id > (self._max_idx - 1):


### PR DESCRIPTION
QoS does not use apn root qos filter, avoid creating it.
This patch also increases FD limits on pipelineD service
this helps in scale test.

Signed-off-by: Pravin B Shelar <pbshelar@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
