### PR TITLE
[lte][agw] Added IP address failure to create session response handling

### DIFF
--- a/lte/gateway/c/oai/include/spgw_types.h
+++ b/lte/gateway/c/oai/include/spgw_types.h
@@ -40,7 +40,7 @@ typedef struct s5_create_session_request_s {
   ebi_t eps_bearer_id;
 } s5_create_session_request_t;
 
-enum s5_failure_cause { S5_OK = 0, PCEF_FAILURE };
+enum s5_failure_cause { S5_OK = 0, PCEF_FAILURE, IP_ALLOCATION_FAILURE };
 
 typedef struct s5_create_session_response_s {
   teid_t context_teid;  ///< local SGW S11 Tunnel Endpoint Identifier

--- a/lte/gateway/c/oai/lib/mobility_client/MobilityClientAPI.cpp
+++ b/lte/gateway/c/oai/lib/mobility_client/MobilityClientAPI.cpp
@@ -103,13 +103,14 @@ int pgw_handle_allocate_ipv4_address(
           pcef_create_session(
               spgw_state, subscriber_id, ip_str, NULL, &session_data, sgi_resp,
               session_req, new_bearer_ctxt_info_p);
-          OAILOG_FUNC_OUT(LOG_PGW_APP);
+        } else {
+          // If we are here then the IP address allocation has failed
+          s5_response.eps_bearer_id = sgi_create_endpoint_resp.eps_bearer_id;
+          s5_response.context_teid  = sgi_create_endpoint_resp.context_teid;
+          s5_response.failure_cause = IP_ALLOCATION_FAILURE;
+          handle_s5_create_session_response(
+              spgw_state, new_bearer_ctxt_info_p, s5_response);
         }
-
-        s5_response.eps_bearer_id = sgi_create_endpoint_resp.eps_bearer_id;
-        s5_response.context_teid  = sgi_create_endpoint_resp.context_teid;
-        handle_s5_create_session_response(
-            spgw_state, new_bearer_ctxt_info_p, s5_response);
         OAILOG_FUNC_OUT(LOG_PGW_APP);
       });
   return 0;
@@ -233,12 +234,14 @@ int pgw_handle_allocate_ipv6_address(
           pcef_create_session(
               spgw_state, subscriber_id, NULL, ip6_str, &session_data, sgi_resp,
               session_req, new_bearer_ctxt_info_p);
-          OAILOG_FUNC_RETURN(LOG_SPGW_APP, RETURNok);
+        } else {
+          // If we are here then the IP address allocation has failed
+          s5_response.eps_bearer_id = sgi_create_endpoint_resp.eps_bearer_id;
+          s5_response.context_teid  = sgi_create_endpoint_resp.context_teid;
+          s5_response.failure_cause = IP_ALLOCATION_FAILURE;
+          handle_s5_create_session_response(
+              spgw_state, new_bearer_ctxt_info_p, s5_response);
         }
-        s5_response.eps_bearer_id = sgi_create_endpoint_resp.eps_bearer_id;
-        s5_response.context_teid  = sgi_create_endpoint_resp.context_teid;
-        handle_s5_create_session_response(
-            spgw_state, new_bearer_ctxt_info_p, s5_response);
         OAILOG_FUNC_RETURN(LOG_SPGW_APP, RETURNok);
       });
   return 0;
@@ -348,13 +351,14 @@ int pgw_handle_allocate_ipv4v6_address(
               sgi_resp, session_req, new_bearer_ctxt_info_p);
           s5_response.eps_bearer_id = sgi_create_endpoint_resp.eps_bearer_id;
           s5_response.context_teid  = sgi_create_endpoint_resp.context_teid;
-          OAILOG_FUNC_RETURN(LOG_SPGW_APP, RETURNok);
+        } else {
+          // If we are here then the IP address allocation has failed
+          s5_response.eps_bearer_id = sgi_create_endpoint_resp.eps_bearer_id;
+          s5_response.context_teid  = sgi_create_endpoint_resp.context_teid;
+          s5_response.failure_cause = IP_ALLOCATION_FAILURE;
+          handle_s5_create_session_response(
+              spgw_state, new_bearer_ctxt_info_p, s5_response);
         }
-        // If status != SGI_STATUS_OK
-        s5_response.eps_bearer_id = sgi_create_endpoint_resp.eps_bearer_id;
-        s5_response.context_teid  = sgi_create_endpoint_resp.context_teid;
-        handle_s5_create_session_response(
-            spgw_state, new_bearer_ctxt_info_p, s5_response);
         OAILOG_FUNC_RETURN(LOG_SPGW_APP, RETURNok);
       });
   OAILOG_FUNC_RETURN(LOG_SPGW_APP, RETURNok);

--- a/lte/gateway/c/oai/tasks/mme_app/mme_app_bearer.c
+++ b/lte/gateway/c/oai/tasks/mme_app/mme_app_bearer.c
@@ -1252,8 +1252,9 @@ int mme_app_handle_create_sess_resp(
 
 error_handling_csr_failure:
   increment_counter("mme_spgw_create_session_rsp", 1, 1, "result", "failure");
-  bearer_id = create_sess_resp_pP->bearer_contexts_created.bearer_contexts[0]
-                  .eps_bearer_id /* - 5 */;
+  bearer_id =
+      create_sess_resp_pP->bearer_contexts_marked_for_removal.bearer_contexts[0]
+          .eps_bearer_id;
   current_bearer_p = mme_app_get_bearer_context(ue_context_p, bearer_id);
   if (current_bearer_p) {
     transaction_identifier = current_bearer_p->transaction_identifier;

--- a/lte/gateway/c/oai/tasks/sgw/sgw_handlers.c
+++ b/lte/gateway/c/oai/tasks/sgw/sgw_handlers.c
@@ -1437,9 +1437,14 @@ void handle_s5_create_session_response(
   memset(
       create_session_response_p, 0, sizeof(itti_s11_create_session_response_t));
   create_session_response_p->cause.cause_value = cause;
-  create_session_response_p->bearer_contexts_created.bearer_contexts[0]
+  create_session_response_p->bearer_contexts_marked_for_removal
+      .bearer_contexts[0]
       .cause.cause_value = cause;
-  create_session_response_p->bearer_contexts_created.num_bearer_context += 1;
+  create_session_response_p->bearer_contexts_marked_for_removal
+      .num_bearer_context += 1;
+  create_session_response_p->bearer_contexts_marked_for_removal
+      .bearer_contexts[0]
+      .eps_bearer_id = session_resp.eps_bearer_id;
   create_session_response_p->teid =
       new_bearer_ctxt_info_p->sgw_eps_bearer_context_information.mme_teid_S11;
   create_session_response_p->trxn =

--- a/lte/gateway/c/oai/tasks/sgw/sgw_handlers.c
+++ b/lte/gateway/c/oai/tasks/sgw/sgw_handlers.c
@@ -1420,6 +1420,8 @@ void handle_s5_create_session_response(
     }
   } else if (session_resp.failure_cause == PCEF_FAILURE) {
     cause = SERVICE_DENIED;
+  } else if (session_resp.failure_cause == IP_ALLOCATION_FAILURE) {
+    cause = SYSTEM_FAILURE;
   }
   // Send Create Session Response with Nack
   message_p =


### PR DESCRIPTION
## Summary

When address assignment fails at mobilityd, cause value for session create response message was not passed as failure.

## Test Plan

Integ tests.

## Additional Information

- [ ] This change is backwards-breaking
