### PR TITLE
[fix] Update where we store Swagger spec

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,7 +49,7 @@ orc8r/cloud/test_certs/*.srl
 orc8r/cloud/test_certs/*.pfx
 
 # Ignore generated Swagger files
-orc8r/swagger/specs
+orc8r/cloud/swagger/specs
 
 # Ignore apt/build cache
 .cache/*

--- a/.gitignore
+++ b/.gitignore
@@ -49,7 +49,7 @@ orc8r/cloud/test_certs/*.srl
 orc8r/cloud/test_certs/*.pfx
 
 # Ignore generated Swagger files
-orc8r/cloud/configs/swagger_specs
+orc8r/swagger/specs
 
 # Ignore apt/build cache
 .cache/*

--- a/orc8r/cloud/Makefile
+++ b/orc8r/cloud/Makefile
@@ -26,7 +26,7 @@ SWAGGER_COMMON := swagger-common.yml
 SWAGGER_V1_ROOT := $(SWAGGER_ROOT)/v1
 SWAGGER_V1_YML := $(SWAGGER_ROOT)/v1/swagger.yml
 SWAGGER_V1_CONFIG := $(MAGMA_ROOT)/orc8r/cloud/docker/controller/goswagger-config.yml
-SWAGGER_V1_SPECS_DIR := $(MAGMA_ROOT)/orc8r/swagger/specs
+SWAGGER_V1_SPECS_DIR := $(MAGMA_ROOT)/orc8r/cloud/swagger/specs
 SWAGGER_V1_COMMON_DIR := common
 
 export SWAGGER_ROOT

--- a/orc8r/cloud/Makefile
+++ b/orc8r/cloud/Makefile
@@ -26,7 +26,7 @@ SWAGGER_COMMON := swagger-common.yml
 SWAGGER_V1_ROOT := $(SWAGGER_ROOT)/v1
 SWAGGER_V1_YML := $(SWAGGER_ROOT)/v1/swagger.yml
 SWAGGER_V1_CONFIG := $(MAGMA_ROOT)/orc8r/cloud/docker/controller/goswagger-config.yml
-SWAGGER_V1_SPECS_DIR := $(MAGMA_ROOT)/orc8r/cloud/configs/swagger_specs
+SWAGGER_V1_SPECS_DIR := $(MAGMA_ROOT)/orc8r/swagger/specs
 SWAGGER_V1_COMMON_DIR := common
 
 export SWAGGER_ROOT

--- a/orc8r/cloud/docker/controller/Dockerfile
+++ b/orc8r/cloud/docker/controller/Dockerfile
@@ -106,10 +106,8 @@ RUN mkdir -p /var/opt/magma/envdir
 ARG SWAGGER_FILES=src/magma/orc8r/cloud/go/obsidian/swagger
 COPY --from=builder /${SWAGGER_FILES}/v1/index.html /var/opt/magma/static/swagger/v1/ui/index.html
 COPY --from=builder /${SWAGGER_FILES}/v1/swagger.yml /var/opt/magma/static/swagger/v1/spec/swagger.yml
+COPY --from=builder src/magma/orc8r/cloud/swagger /etc/magma/swagger
 COPY --from=builder /build/bin /var/opt/magma/bin
-
-## Swagger specs
-COPY --from=builder src/magma/orc8r/swagger /etc/magma/swagger
 
 # Supervisor configs
 ARG CNTLR_FILES=src/magma/orc8r/cloud/docker/controller

--- a/orc8r/cloud/docker/controller/Dockerfile
+++ b/orc8r/cloud/docker/controller/Dockerfile
@@ -108,6 +108,9 @@ COPY --from=builder /${SWAGGER_FILES}/v1/index.html /var/opt/magma/static/swagge
 COPY --from=builder /${SWAGGER_FILES}/v1/swagger.yml /var/opt/magma/static/swagger/v1/spec/swagger.yml
 COPY --from=builder /build/bin /var/opt/magma/bin
 
+## Swagger specs
+COPY --from=builder src/magma/orc8r/swagger /etc/magma/swagger
+
 # Supervisor configs
 ARG CNTLR_FILES=src/magma/orc8r/cloud/docker/controller
 COPY ${CNTLR_FILES}/supervisord.conf /etc/supervisor/conf.d/supervisord.conf

--- a/orc8r/cloud/go/obsidian/swagger/combine.go
+++ b/orc8r/cloud/go/obsidian/swagger/combine.go
@@ -23,7 +23,7 @@ import (
 )
 
 var (
-	commonSpecPath = "/etc/magma/configs/orc8r/swagger_specs/common/swagger-common.yml"
+	commonSpecPath = "/etc/magma/swagger/specs/common/swagger-common.yml"
 )
 
 // GetCombinedSpec polls every servicer registered with

--- a/orc8r/cloud/go/obsidian/swagger/combine_test.go
+++ b/orc8r/cloud/go/obsidian/swagger/combine_test.go
@@ -29,9 +29,9 @@ import (
 )
 
 func Test_GetCommonSpec(t *testing.T) {
-	specPath := "/etc/magma/configs/orc8r/swagger_specs"
-	commonSpecDir := "/etc/magma/configs/orc8r/swagger_specs/common"
-	commonSpecFilePath := "/etc/magma/configs/orc8r/swagger_specs/common/swagger-common.yml"
+	specPath := "/etc/magma/swagger/specs"
+	commonSpecDir := "/etc/magma/swagger/specs/common"
+	commonSpecFilePath := "/etc/magma/swagger/specs/common/swagger-common.yml"
 
 	os.RemoveAll(specPath)
 	defer os.RemoveAll(specPath)

--- a/orc8r/cloud/go/obsidian/swagger/spec_servicer.go
+++ b/orc8r/cloud/go/obsidian/swagger/spec_servicer.go
@@ -15,11 +15,12 @@ package swagger
 
 import (
 	"context"
+	"fmt"
 	"io/ioutil"
+	"path/filepath"
 	"strings"
 
 	"magma/orc8r/cloud/go/obsidian/swagger/protos"
-	"magma/orc8r/lib/go/service/config"
 
 	"github.com/golang/glog"
 )
@@ -32,7 +33,7 @@ type specServicer struct {
 // given a service name.
 func NewSpecServicerFromFile(service string) protos.SwaggerSpecServer {
 	service = strings.ToLower(service)
-	path := config.GetSpecPath(service)
+	path := getSpecPath(service)
 	data, err := ioutil.ReadFile(path)
 	if err != nil {
 		// Swallowing ReadFile error because the service should
@@ -50,4 +51,12 @@ func NewSpecServicer(spec string) protos.SwaggerSpecServer {
 
 func (s *specServicer) GetSpec(ctx context.Context, request *protos.GetSpecRequest) (*protos.GetSpecResponse, error) {
 	return &protos.GetSpecResponse{SwaggerSpec: s.spec}, nil
+}
+
+// getSpecPath returns the filepath on the production image
+// that contains the service's Swagger spec
+func getSpecPath(service string) string {
+	specDir := "/etc/magma/swagger/specs"
+	specPath := filepath.Join(specDir, fmt.Sprintf("%s.swagger.v1.yml", service))
+	return specPath
 }

--- a/orc8r/cloud/go/obsidian/swagger/spec_servicer_test.go
+++ b/orc8r/cloud/go/obsidian/swagger/spec_servicer_test.go
@@ -29,7 +29,7 @@ import (
 func TestSpecServicer_NewSpecServicerFromFile(t *testing.T) {
 	testFile := "test_spec_servicer.swagger.v1.yml"
 	testFileContents := "test yaml spec"
-	tmpDir := "/etc/magma/configs/orc8r/swagger_specs"
+	tmpDir := "/etc/magma/swagger/specs"
 
 	os.RemoveAll(tmpDir)
 	defer os.RemoveAll(tmpDir)

--- a/orc8r/lib/go/service/config/service_config.go
+++ b/orc8r/lib/go/service/config/service_config.go
@@ -33,7 +33,7 @@ var (
 	configDir         = "/etc/magma/configs"
 	oldConfigDir      = "/etc/magma"
 	configOverrideDir = "/var/opt/magma/configs"
-	specDir           = "/etc/magma/configs/orc8r/swagger_specs"
+	specDir           = "/etc/magma/swagger/specs"
 	cfgDirMu          sync.RWMutex
 )
 

--- a/orc8r/lib/go/service/config/service_config.go
+++ b/orc8r/lib/go/service/config/service_config.go
@@ -33,7 +33,6 @@ var (
 	configDir         = "/etc/magma/configs"
 	oldConfigDir      = "/etc/magma"
 	configOverrideDir = "/var/opt/magma/configs"
-	specDir           = "/etc/magma/swagger/specs"
 	cfgDirMu          sync.RWMutex
 )
 
@@ -156,13 +155,6 @@ func SetConfigDirectories(main, legacy, overwrite string) {
 	cfgDirMu.Lock()
 	configDir, oldConfigDir, configOverrideDir = main, legacy, overwrite
 	cfgDirMu.Unlock()
-}
-
-// GetSpecPath returns the filepath on the production image
-// that contains the service's Swagger spec
-func GetSpecPath(service string) string {
-	specPath := filepath.Join(specDir, fmt.Sprintf("%s.swagger.v1.yml", service))
-	return specPath
 }
 
 func getServiceConfigImpl(moduleName, serviceName, configDir, oldConfigDir, configOverrideDir string) (*ConfigMap, error) {


### PR DESCRIPTION
Signed-off-by: Andy Lee Khuu <andykhuu@stanford.edu>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary
Currently the Swagger UI is broken due to an issue with Swagger specs not properly copying over to the production image when not existing on the host image. This PR fixes this issue by moving the Swagger specs into a separate directory and copying it over from the build image to the production image.

<!-- Enumerate changes you made and why you made them -->

## Test Plan
- [x] cd $MAGMA_ROOT/orc8r/cloud/docker && ./build.py -t ; noti
- [x] Manually checked that Swagger UI is now working properly on builds even without specs in host 
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
