### PR TITLE
[orc8r] [fix] Add a service name constant for the eventd service in the cloud package.

### DIFF
--- a/orc8r/cloud/go/services/eventd/doc.go
+++ b/orc8r/cloud/go/services/eventd/doc.go
@@ -1,0 +1,16 @@
+/*
+Copyright 2020 The Magma Authors.
+
+This source code is licensed under the BSD-style license found in the
+LICENSE file in the root directory of this source tree.
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package eventd
+
+const ServiceName = "EVENTD"

--- a/orc8r/cloud/go/services/eventd/eventd/main.go
+++ b/orc8r/cloud/go/services/eventd/eventd/main.go
@@ -14,11 +14,11 @@ limitations under the License.
 package main
 
 import (
-	"magma/gateway/eventd"
 	"magma/orc8r/cloud/go/obsidian/swagger"
 	swagger_protos "magma/orc8r/cloud/go/obsidian/swagger/protos"
 	"magma/orc8r/cloud/go/orc8r"
 	"magma/orc8r/cloud/go/service"
+	"magma/orc8r/cloud/go/services/eventd"
 
 	"github.com/golang/glog"
 )


### PR DESCRIPTION
Signed-off-by: Andy Lee Khuu <andykhuu@stanford.edu>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary
The eventd service was utilizing a constant from the orc8r/gateway instead of orcr8/cloud which was causing random init functions to generate warnings. This PR adds a service name for eventd within the cloud package to circumvent this problem.
<!-- Enumerate changes you made and why you made them -->

## Test Plan
- [x] cd $MAGMA_ROOT/orc8r/cloud/docker && ./build.py -t ; noti
- [x] Manually inspecting run-time logs so that errors with eventd don't appear
- 
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
