### PR TITLE
[subscriberdb] Add GRPC printing to log

### DIFF
--- a/docs/readmes/lte/dev_notes.md
+++ b/docs/readmes/lte/dev_notes.md
@@ -112,8 +112,9 @@ the section previous (`/var/log/syslog`). By default, it is disabled.
 Note GRPC printing is independent of the `log_level`. So you can enabled GRPC
 printing even that your level is set as `INFO`.
 
-To enable GRPC logging for `pipelined`, `directoryd` or `subcriberdb` you can
-modify this line on the `/etc/magma/<service_name>.yml` config file:
+To enable GRPC logging for `pipelined`, `mobilityd`, `directoryd` or
+`subcriberdb` you can modify this line on the `/etc/magma/<service_name>.yml`
+config file:
 ```yaml
 print_grpc_payload: true
 ```

--- a/lte/gateway/configs/subscriberdb.yml
+++ b/lte/gateway/configs/subscriberdb.yml
@@ -13,6 +13,9 @@
 
 # log_level is set in mconfig. it can be overridden here
 
+# Append GRPC content to the log
+print_grpc_payload: true
+
 # Host address of the Diameter/S6A MME server
 host_address: 0.0.0.0 # Bind to all interfaces
 

--- a/lte/gateway/python/magma/subscriberdb/main.py
+++ b/lte/gateway/python/magma/subscriberdb/main.py
@@ -42,7 +42,9 @@ def main():
                           service.mconfig.lte_auth_amf)
 
     # Add all servicers to the server
-    subscriberdb_servicer = SubscriberDBRpcServicer(store)
+    subscriberdb_servicer = SubscriberDBRpcServicer(
+        store,
+        service.mconfig.get('print_grpc_payload', False))
     subscriberdb_servicer.add_to_server(service.rpc_server)
 
 
@@ -62,9 +64,11 @@ def main():
             await store.on_ready()
 
         if service.config['s6a_over_grpc']:
+            logging.info('Running s6a over grpc')
             s6a_proxy_servicer = S6aProxyRpcServicer(processor)
             s6a_proxy_servicer.add_to_server(service.rpc_server)
         else:
+            logging.info('Running s6a over DIAMETER')
             base_manager = base.BaseApplication(
                 service.config['mme_realm'],
                 service.config['mme_host_name'],


### PR DESCRIPTION
Signed-off-by: Oriol Batalla <obatalla@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary

This adds grpc printing to log on directoryd. To enable this modify the following variable on `directoryd.yml`

```
print_grpc_payload: true
```


## Test Plan

make run at agw

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
