### PR TITLE
[subscriberdb] implement purgeUE

### DIFF
--- a/lte/gateway/python/magma/subscriberdb/protocols/s6a_proxy_servicer.py
+++ b/lte/gateway/python/magma/subscriberdb/protocols/s6a_proxy_servicer.py
@@ -19,6 +19,8 @@ from magma.subscriberdb.store.base import SubscriberNotFoundError
 
 from feg.protos import s6a_proxy_pb2, s6a_proxy_pb2_grpc
 
+from google.protobuf.json_format import MessageToJson
+
 
 class S6aProxyRpcServicer(s6a_proxy_pb2_grpc.S6aProxyServicer):
     """
@@ -42,7 +44,7 @@ class S6aProxyRpcServicer(s6a_proxy_pb2_grpc.S6aProxyServicer):
             plmn = request.visited_plmn
 
             re_sync_info = request.resync_info
-            #resync_info =
+            # resync_info =
             #  rand + auts, rand is of 16 bytes + auts is of 14 bytes
             sizeof_resync_info = 30
             if re_sync_info and (re_sync_info != b'\x00' * sizeof_resync_info):
@@ -127,6 +129,14 @@ class S6aProxyRpcServicer(s6a_proxy_pb2_grpc.S6aProxyServicer):
 
         return ula
 
+    def PurgeUE(self, request, context):
+        self._print_grpc(request)
+        logging.getLevelName()
+        logging.warning("Purge request not implemented: %s %s",
+                        request.DESCRIPTOR.full_name, MessageToJson(request))
+
+        return s6a_proxy_pb2.PurgeUEAnswer()
+
     @staticmethod
     def encode_msisdn(msisdn: str) -> bytes:
         # Mimic how the MSISDN is encoded in ULA : 3GPP TS 29.329-f10
@@ -135,9 +145,9 @@ class S6aProxyRpcServicer(s6a_proxy_pb2_grpc.S6aProxyServicer):
             msisdn = msisdn + "F"
         result = []
         # Treat each 2 characters as a byte and flip the order
-        for i in range(len(msisdn)//2):
-            first = int(msisdn[2*i])
-            second = int(msisdn[2*i+1], 16)
+        for i in range(len(msisdn) // 2):
+            first = int(msisdn[2 * i])
+            second = int(msisdn[2 * i + 1], 16)
             flipped = first + (second << 4)
             result.append(flipped)
         return bytes(result)


### PR DESCRIPTION
Signed-off-by: Oriol Batalla <obatalla@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary

PurgeUE is not being implemented by subscriber db because it is not used on non federated case. But when testing federated case purgeUE was being called

Purge UE call is a 3gpp specific call to inform HSS that MME has dropped the information about this subscriber. In case of subscriberdb there is no action to be done, so we just return no error to this call

## Test Plan

make test_python

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
