### PR TITLE
[Git] Update gitignore for build directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,7 +25,7 @@ __pycache__/
 # Distribution / packaging
 .Python
 env/
-build/
+/build/
 develop-eggs/
 dist/
 eggs/


### PR DESCRIPTION
This change would limit gitignore to only `/magma/build`.

See #5271 for the broader issue of fixing up gitignore.

I am unsure whether build directories are ever generated anywhere but `/magma/build` (if so this PR is not good).

I do this because the present gitignore causes shadowing of e.g. `third_party/build/...` subdirectory - which clearly should not be gitignored.

If the are build directories generated elsewhere, then we need to enumerate them or rename `third_party/build`. I think enumeration is a better path - we have too many gitignore wildcards right now (this is not the first time I have modified a file and found `git status` shows no impact).

Signed-off-by: Scott Harrison Moeller <smoeller@fb.com>