### PR TITLE
[AGW] Add a sigup handler that dumps tracebacks for all python services

### DIFF
--- a/orc8r/gateway/python/magma/common/service.py
+++ b/orc8r/gateway/python/magma/common/service.py
@@ -15,6 +15,7 @@ import asyncio
 import logging
 import signal
 import time
+import faulthandler
 from concurrent import futures
 from typing import List, Optional
 import functools
@@ -332,6 +333,12 @@ class MagmaService(Service303Servicer):
             self._loop.add_signal_handler(
                 getattr(signal, signame),
                 functools.partial(self._stop, signame))
+
+        def _signal_handler():
+            logging.info('Handling SIGHUP...')
+            faulthandler.dump_traceback()
+        self._loop.add_signal_handler(
+            signal.SIGHUP, functools.partial(_signal_handler))
 
     def GetServiceInfo(self, request, context):
         """


### PR DESCRIPTION
Signed-off-by: Marie Bremner <marwhal@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary
Adding a way to inspect running threads for a running python service.
<!-- Enumerate changes you made and why you made them -->

## Test Plan
run services and send a signal `sudo systemctl kill -s SIGHUP magma@pipelined.service`

```
Mar 01 16:08:25 magma-dev pipelined[24465]: INFO:root:Handling SIGHUP...
Mar 01 16:08:25 magma-dev pipelined[24465]: Thread 0x00007fe7fe62b700 (most recent call first):
Mar 01 16:08:25 magma-dev pipelined[24465]:   File "/home/vagrant/build/python/lib/python3.5/site-packages/grpc/_server.py", line 871 in _serve
Mar 01 16:08:25 magma-dev pipelined[24465]:   File "/usr/lib/python3.5/threading.py", line 862 in run
Mar 01 16:08:25 magma-dev pipelined[24465]:   File "/usr/lib/python3.5/threading.py", line 914 in _bootstrap_inner
Mar 01 16:08:25 magma-dev pipelined[24465]:   File "/usr/lib/python3.5/threading.py", line 882 in _bootstrap
Mar 01 16:08:25 magma-dev pipelined[24465]: Current thread 0x00007fe80d679700 (most recent call first):
Mar 01 16:08:25 magma-dev pipelined[24465]:   File "/home/vagrant/magma/orc8r/gateway/python/magma/common/service.py", line 339 in _signal_handler
Mar 01 16:08:25 magma-dev pipelined[24465]:   File "/usr/lib/python3.5/asyncio/events.py", line 126 in _run
Mar 01 16:08:25 magma-dev pipelined[24465]:   File "/usr/lib/python3.5/asyncio/base_events.py", line 1424 in _run_once
Mar 01 16:08:25 magma-dev pipelined[24465]:   File "/usr/lib/python3.5/asyncio/base_events.py", line 421 in run_forever
Mar 01 16:08:25 magma-dev pipelined[24465]:   File "/usr/lib/python3/dist-packages/aioeventlet.py", line 253 in run_forever
Mar 01 16:08:25 magma-dev pipelined[24465]:   File "/home/vagrant/magma/orc8r/gateway/python/magma/common/service.py", line 241 in run
Mar 01 16:08:25 magma-dev pipelined[24465]:   File "/home/vagrant/magma/lte/gateway/python/magma/pipelined/main.py", line 170 in main
Mar 01 16:08:25 magma-dev pipelined[24465]:   File "/home/vagrant/magma/lte/gateway/python/magma/pipelined/main.py", line 186 in <module>
Mar 01 16:08:25 magma-dev pipelined[24465]:   File "/usr/lib/python3.5/runpy.py", line 85 in _run_code
Mar 01 16:08:25 magma-dev pipelined[24465]:   File "/usr/lib/python3.5/runpy.py", line 193 in _run_module_as_main
```
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
