### PR TITLE
[docs] Update minikube docs

### DIFF
--- a/docs/readmes/orc8r/development/minikube_deployment.md
+++ b/docs/readmes/orc8r/development/minikube_deployment.md
@@ -80,7 +80,7 @@ $ cp -r ../../../../.cache/test_certs/* charts/secrets/.secrets/certs/.
 Create the kubernetes secrets
 
 ```
-helm template orc8r-secrets charts/secrets \
+helm template orc8r charts/secrets \
     --namespace magma \
     --set-string secret.certs.enabled=true \
     --set-file secret.certs.files."rootCA\.pem"=charts/secrets/.secrets/certs/rootCA.pem \

--- a/orc8r/cloud/helm/orc8r/examples/minikube_values.yml
+++ b/orc8r/cloud/helm/orc8r/examples/minikube_values.yml
@@ -2,13 +2,13 @@
 # Make sure to replace <DOCKER_REGISTRY> and <TAG> with your specific values.
 
 imagePullSecrets:
-  - name: orc8r-secrets-secrets-registry
+  - name: orc8r-secrets-registry
 
 secret:
   configs:
-    orc8r: orc8r-secrets-secrets-configs-orc8r
-  envdir: orc8r-secrets-secrets-envdir
-  certs: orc8r-secrets-secrets-certs
+    orc8r: orc8r-secrets-configs-orc8r
+  envdir: orc8r-secrets-envdir
+  certs: orc8r-secrets-certs
 
 controller:
   tolerations: []
@@ -36,9 +36,9 @@ controller:
 ## NMS
 nms:
   secret:
-    certs: orc8r-secrets-secrets-certs
+    certs: orc8r-secrets-certs
   imagePullSecrets:
-    - name: orc8r-secrets-secrets-registry
+    - name: orc8r-secrets-registry
   pod:
     replicas:
       nginx:
@@ -84,7 +84,7 @@ nms:
 metrics:
   enabled: true
   imagePullSecrets:
-    - name: orc8r-secrets-secrets-registry
+    - name: orc8r-secrets-registry
 
   metrics:
     volumes:
@@ -125,7 +125,7 @@ logging:
   enabled: false
 nginx:
   secret:
-    certs: orc8r-secrets-secrets-certs
+    certs: orc8r-secrets-certs
   create: true
   replicas: 1
   podDisruptionBudget:


### PR DESCRIPTION
Signed-off-by: Scott8440 <scott8440@gmail.com>

## Summary

While following minikube instructions, some users ran into an issue where the release name of the secrets was different from the release name of orc8r, causing some services to be unable to talk to each other. This diff updates the documentation and example values file to fix this issue. `orc8r-secrets` -> `orc8r`

## Test Plan

Follow minikube docs and install with new values file. Chart comes up as expected.

