### PR TITLE
AGW: pipelined: use pyroute2 to manage TC queue and filters

### DIFF
--- a/lte/gateway/configs/pipelined.yml
+++ b/lte/gateway/configs/pipelined.yml
@@ -109,6 +109,7 @@ ipv6_router_addr: 'd88d:aba4:472f:fc95:7e7d:8457:5301:ebce'
 qos:
  enable: true
  impl: linux_tc
+ enable_pyroute2: true
  max_rate: 1000000000
  linux_tc:
   min_idx: 2

--- a/lte/gateway/configs/pipelined.yml_prod
+++ b/lte/gateway/configs/pipelined.yml_prod
@@ -107,6 +107,7 @@ ipv6_router_addr: 'd88d:aba4:472f:fc95:7e7d:8457:5301:ebce'
 qos:
  enable: true
  impl: linux_tc
+ enable_pyroute2: True
  max_rate: 1000000000
  linux_tc:
   min_idx: 2

--- a/lte/gateway/python/magma/pipelined/bridge_util.py
+++ b/lte/gateway/python/magma/pipelined/bridge_util.py
@@ -86,6 +86,8 @@ class BridgeTools:
         if ip is not None:
             subprocess.Popen(["ifconfig", iface_name, ip]).wait()
 
+        subprocess.Popen(["ifconfig", iface_name, "up"]).wait()
+
     @staticmethod
     def add_ovs_port(bridge_name: str, iface_name: str, ofp_port: str):
         """

--- a/lte/gateway/python/magma/pipelined/qos/tc_ops_cmd.py
+++ b/lte/gateway/python/magma/pipelined/qos/tc_ops_cmd.py
@@ -75,6 +75,6 @@ class TcOpsCmd(TcOpsBase):
 
     def del_filter(self, iface: str, mark: str, qid: str, proto: int = 3) -> int:
         filter_cmd = "tc filter del dev {intf} protocol ip parent 1: prio 1 "
-        filter_cmd += "handle {qid} fw flowid 1:{qid}"
-        filter_cmd = filter_cmd.format(intf=iface, qid=qid)
+        filter_cmd += "handle {mark} fw flowid 1:{qid}"
+        filter_cmd = filter_cmd.format(intf=iface, mark=mark, qid=qid)
         return run_cmd([filter_cmd], True)

--- a/lte/gateway/python/magma/pipelined/qos/tc_ops_pyroute2.py
+++ b/lte/gateway/python/magma/pipelined/qos/tc_ops_pyroute2.py
@@ -1,0 +1,145 @@
+"""
+Copyright 2021 The Magma Authors.
+
+This source code is licensed under the BSD-style license found in the
+LICENSE file in the root directory of this source tree.
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+
+from .tc_ops import TcOpsBase
+import logging
+from pyroute2 import IPRoute, NetlinkError
+import pprint
+
+LOG = logging.getLogger('pipelined.qos.tc_pyroute2')
+
+QUEUE_PREFIX = '1:'
+PROTOCOL = 0x0800
+PARENT_ID = 0x10000
+
+
+class TcOpsPyRoute2(TcOpsBase):
+    """
+    Create TC scheduler and corresponding filter
+    """
+    def __init__(self):
+        self._ipr = IPRoute()
+        self._iface_if_index = {}
+        LOG.info("initialized")
+
+    def create_htb(self, iface: str, qid: str, max_bw: int, rate: str,
+                   parent_qid: str = None) -> int:
+        LOG.debug("Create HTB iface %s qid %s", iface, qid)
+
+        try:
+            if_index = self._get_if_index(iface)
+            htb_queue = QUEUE_PREFIX + qid
+            ret = self._ipr.tc("add-class", "htb", if_index,
+                               htb_queue, parent=parent_qid,
+                               rate=str(rate).lower(), ceil=max_bw, prio=1)
+            LOG.debug("Return: %s", ret)
+        except (ValueError, NetlinkError) as ex:
+            LOG.error("create-htb error : %s", ex.code)
+            LOG.debug(ex, exc_info=True)
+            return ex.code
+        return 0
+
+    def del_htb(self, iface: str, qid: str) -> int:
+        LOG.debug("Delete HTB iface %s qid %s", iface, qid)
+
+        try:
+            if_index = self._get_if_index(iface)
+            htb_queue = QUEUE_PREFIX + qid
+
+            ret = self._ipr.tc("del-class", "htb", if_index, htb_queue)
+            LOG.debug("Return: %s", ret)
+        except (ValueError, NetlinkError) as ex:
+            LOG.error("del-htb  error error : %s", ex.code)
+            LOG.debug(ex, exc_info=True)
+            return ex.code
+        return 0
+
+    def create_filter(self, iface: str, mark: str, qid: str, proto: int = PROTOCOL) -> int:
+        LOG.debug("Create Filter iface %s qid %s", iface, qid)
+
+        try:
+            if_index = self._get_if_index(iface)
+
+            class_id = int(PARENT_ID) | int(qid, 16)
+            ret = self._ipr.tc("add-filter", "fw", if_index, int(mark, 16),
+                               parent=PARENT_ID,
+                               prio=1,
+                               protocol=proto,
+                               classid=class_id)
+            LOG.debug("Return: %s", ret)
+
+        except (ValueError, NetlinkError) as ex:
+            LOG.error("create-filter error : %s", ex.code)
+            LOG.debug(ex, exc_info=True)
+            return ex.code
+        return 0
+
+    def del_filter(self, iface: str, mark: str, qid: str, proto: int = PROTOCOL) -> int:
+        LOG.debug("Del Filter iface %s qid %s", iface, qid)
+
+        try:
+            if_index = self._get_if_index(iface)
+
+            class_id = int(PARENT_ID) | int(qid, 16)
+
+            ret = self._ipr.tc("del-filter", "fw", if_index, int(mark, 16),
+                               parent=PARENT_ID,
+                               prio=1,
+                               protocol=proto,
+                               classid=class_id)
+            LOG.debug("Return: %s", ret)
+        except (ValueError, NetlinkError) as ex:
+            LOG.error("del-filter error : %s", ex.code)
+            LOG.debug(ex, exc_info=True)
+            return ex.code
+        return 0
+
+    def create(self, iface: str, qid: str, max_bw: int, rate=None,
+               parent_qid: str = None, proto=PROTOCOL) -> int:
+        err = self.create_htb(iface, qid, max_bw, rate, parent_qid)
+        if err:
+            return err
+        err = self.create_filter(iface, qid, qid, proto)
+        if err:
+            return err
+        return 0
+
+    def delete(self, iface: str, qid: str, proto=PROTOCOL) -> int:
+        err = self.del_filter(iface, qid, qid, proto)
+        if err:
+            return err
+
+        err = self.del_htb(iface, qid)
+        if err:
+            return err
+
+        return 0
+
+    def _get_if_index(self, iface: str):
+        if_index = self._iface_if_index.get(iface, -1)
+        if if_index == -1:
+            if_index = self._ipr.link_lookup(ifname=iface)
+            self._iface_if_index[iface] = if_index
+
+        return if_index
+
+    def _print_classes(self, iface):
+        if_index = self._get_if_index(iface)
+
+        pprint.pprint(self._ipr.get_classes(if_index))
+
+    def _print_filters(self, iface):
+        if_index = self._get_if_index(iface)
+
+        pprint.pprint(self._ipr.get_filters(if_index))

--- a/lte/gateway/python/magma/pipelined/tests/test_qos_pyroute2.py
+++ b/lte/gateway/python/magma/pipelined/tests/test_qos_pyroute2.py
@@ -1,0 +1,173 @@
+from pyroute2 import IPRoute
+from pyroute2 import NetlinkError
+from pyroute2 import protocols
+
+import unittest
+import socket
+import logging
+import traceback
+import time
+import pprint
+import subprocess
+from magma.pipelined.bridge_util import BridgeTools
+from magma.pipelined.qos.qos_tc_impl import TrafficClass
+from magma.pipelined.qos.tc_ops_pyroute2 import TcOpsPyRoute2
+from magma.pipelined.qos.tc_ops_cmd import TcOpsCmd
+
+LOG = logging.getLogger('pipelined.qos.tc_rtnl')
+
+QUEUE_PREFIX = '1:'
+PROTOCOL = 3
+
+
+class TcSetypTest(unittest.TestCase):
+    BRIDGE = 'testing_qos'
+    IFACE = 'dev_qos'
+
+    @classmethod
+    def setUpClass(cls):
+        BridgeTools.create_bridge(cls.BRIDGE, cls.BRIDGE)
+        BridgeTools.create_internal_iface(cls.BRIDGE, cls.IFACE, None)
+        TrafficClass.init_qdisc(cls.IFACE, True)
+
+    @classmethod
+    def tearDownClass(cls):
+        BridgeTools.destroy_bridge(cls.BRIDGE)
+        pass
+
+    def check_qid_in_tc(self, qid):
+        cmd = "tc filter show dev dev_qos"
+        exe_cmd = cmd.split(" ")
+        output = subprocess.check_output(exe_cmd)
+        found = False
+        for ln in output.decode('utf-8').split("\n"):
+            ln = ln.strip()
+            if not ln:
+                continue
+            #print(ln)
+            tokens = ln.split(" ")
+
+            if len(tokens) > 10 and tokens[9] == qid:
+                found = True
+
+        return found
+
+    def test_basic(self):
+        cls = self.__class__
+        t1 = TcOpsPyRoute2()
+        iface = cls.IFACE
+        qid = "0xae"
+        max_bw = 10000
+        rate = 1000
+        parent_qid = '1:fffe'
+
+        err1 = t1.create(iface, qid, max_bw, rate, parent_qid)
+        self.assertTrue(self.check_qid_in_tc(qid))
+        err = t1.delete(iface, qid)
+        self.assertFalse(self.check_qid_in_tc(qid))
+        self.assertEqual(err, 0)
+        self.assertEqual(err1, 0)
+
+    def test_basic6(self):
+        cls = self.__class__
+        t1 = TcOpsPyRoute2()
+        iface = cls.IFACE
+        qid = "0xae"
+        max_bw = 10000
+        rate = 1000
+        parent_qid = '1:fffe'
+
+        err1 = t1.create(iface, qid, max_bw, rate, parent_qid, proto=0x86DD)
+        self.assertTrue(self.check_qid_in_tc(qid))
+        err = t1.delete(iface, qid, proto=0x86DD)
+        self.assertFalse(self.check_qid_in_tc(qid))
+        self.assertEqual(err, 0)
+        self.assertEqual(err1, 0)
+
+    def test_hierarchy(self):
+        cls = self.__class__
+        t1 = TcOpsPyRoute2()
+        # First queue
+
+        iface1 = cls.IFACE
+        qid1 = "0xae"
+        max_bw = 10000
+        rate = 1000
+        parent_qid1 = '1:fffe'
+
+        err1 = t1.create(iface1, qid1, max_bw, rate, parent_qid1)
+        self.assertTrue(self.check_qid_in_tc(qid1))
+
+        # Second queue
+
+        qid2 = "0x1ae"
+        max_bw = 10000
+        rate = 1000
+        parent_qid2 = '1:' + qid1
+
+        err1 = t1.create(iface1, qid2, max_bw, rate, parent_qid2)
+        self.assertTrue(self.check_qid_in_tc(qid2))
+        # t1._print_classes(iface1)
+        # t1._print_filters(iface1)
+
+        err = t1.delete(iface1, qid2)
+        self.assertEqual(err, 0)
+        self.assertFalse(self.check_qid_in_tc(qid2))
+
+        err = t1.delete(iface1, qid1)
+        self.assertFalse(self.check_qid_in_tc(qid1))
+
+        self.assertEqual(err, 0)
+        self.assertEqual(err1, 0)
+
+    def test_mix1(self):
+        cls = self.__class__
+        t1 = TcOpsPyRoute2()
+        t2 = TcOpsCmd()
+        iface = cls.IFACE
+        qid = "0xae"
+        max_bw = 10000
+        rate = 1000
+        parent_qid = '1:fffe'
+
+        err1 = t1.create(iface, qid, max_bw, rate, parent_qid)
+        self.assertTrue(self.check_qid_in_tc(qid))
+
+        err = t2.del_filter(iface, qid, qid)
+        self.assertEqual(err, 0)
+        err = t2.del_htb(iface, qid)
+        self.assertEqual(err, 0)
+
+        self.assertFalse(self.check_qid_in_tc(qid))
+        self.assertEqual(err, 0)
+        self.assertEqual(err1, 0)
+
+    def test_mix2(self):
+        cls = self.__class__
+        t1 = TcOpsPyRoute2()
+        t2 = TcOpsCmd()
+        iface = cls.IFACE
+        qid = "0xae"
+        max_bw = 10000
+        rate = 1000
+        parent_qid = '1:fffe'
+
+        err1 = t2.create_htb(iface, qid, max_bw, rate, parent_qid)
+        self.assertEqual(err1, 0)
+        err1 = t2.create_filter(iface, qid, qid)
+        self.assertEqual(err1, 0)
+
+        self.assertTrue(self.check_qid_in_tc(qid))
+
+        err = t1.del_filter(iface, qid, qid)
+        self.assertEqual(err, 0)
+        err = t1.del_htb(iface, qid)
+        self.assertEqual(err, 0)
+
+        self.assertFalse(self.check_qid_in_tc(qid))
+        self.assertEqual(err, 0)
+        self.assertEqual(err1, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/lte/gateway/python/setup.py
+++ b/lte/gateway/python/setup.py
@@ -113,7 +113,8 @@ setup(
         'h2>=3.2.0',
         'hpack>=3.0',
         'freezegun>=0.3.15',
-        'pycryptodome>=3.9.9'
+        'pycryptodome>=3.9.9',
+        'pyroute2'
     ],
     extras_require={
         'dev': [


### PR DESCRIPTION
Following commit adds second implementation for executing
TC commands. This is using netlink socket rather than executing
`tc` commands. I have seen good improvement over current master.
following numbers are using `pipelined_cli.py enforcement
stress_test_grpc`

With pyroute2
------------
Starting attaches
Finished 600 attaches in 9.850383 seconds
Actual attach rate = 61 UEs per sec
Starting detaches
Finished 600 detaches in 6.381709 seconds

with current master
-------------------
Starting attaches
Finished 600 attaches in 22.11333 seconds
Actual attach rate = 27 UEs per sec
Starting detaches
Finished 600 detaches in 6.360227 seconds

Signed-off-by: Pravin B Shelar <pbshelar@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->

## Test Plan
`make test`

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
