### PR TITLE
These changes enable the session_id to be a document id in elk stack

### DIFF
--- a/orc8r/cloud/docker/fluentd/conf/fluent.conf
+++ b/orc8r/cloud/docker/fluentd/conf/fluent.conf
@@ -64,6 +64,7 @@
     logstash_prefix eventd
     include_tag_key true
     tag_key tag
+    id_key session_id
     flush_interval 1s
   </store>
   <store>

--- a/orc8r/gateway/python/magma/eventd/rpc_servicer.py
+++ b/orc8r/gateway/python/magma/eventd/rpc_servicer.py
@@ -62,9 +62,10 @@ class EventDRpcServicer(eventd_pb2_grpc.EventServiceServicer):
             'stream_name': request.stream_name,
             'event_type': request.event_type,
             'event_tag': request.tag,
-            'value': request.value,
             'retry_on_failure': self._needs_retries(request.event_type),
         }
+        values_dict = json.loads(request.value)
+        value.update(values_dict)
         try:
             with closing(socket.create_connection(
                     ('localhost', self._fluent_bit_port),


### PR DESCRIPTION
Signed-off-by: Sourabh Shekhar Nanoti <sourabhn@fb.com>

#5245 

## Summary

Changes 
1. Instead of logging the event information as a json dump, now each field is logged separately. This will help in a) Better visual representation of  the event information. b) The user can query for specific fields during information retrieval. 
2. Changed the fluentd config such that it will now use the session_id as a document id while creating the ELK record. 

## Test Plan

Tested by running local integration tests. Please see the output below: 

<img width="1660" alt="Screen Shot 2021-03-02 at 1 51 37 PM" src="https://user-images.githubusercontent.com/48265190/109605120-aaa54700-7b5f-11eb-81a2-813818c29a31.png">


[elk record output.pdf](https://github.com/magma/magma/files/6066438/elk.record.output.pdf)



## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
