### PR TITLE
[lte][agw] Adding write-through cache to RedisFlatDict, removing few locking on read mobilityd functions

### DIFF
--- a/lte/gateway/python/magma/mobilityd/ip_address_man.py
+++ b/lte/gateway/python/magma/mobilityd/ip_address_man.py
@@ -51,13 +51,11 @@ from typing import List, Optional, Tuple
 
 from lte.protos.mobilityd_pb2 import GWInfo, IPAddress
 
-from magma.mobilityd.ip_descriptor import IPState, IPType
+from magma.mobilityd.ip_descriptor import IPState
 from magma.mobilityd.metrics import (IP_ALLOCATED_TOTAL, IP_RELEASED_TOTAL)
-
 from .ip_allocator_base import DuplicateIPAssignmentError, IPAllocator, \
     IPNotInUseError, \
     MappingNotFoundError
-
 from .mobility_store import MobilityStore
 
 DEFAULT_IP_RECYCLE_INTERVAL = 15
@@ -333,21 +331,19 @@ class IPAddressManager:
 
     def get_ip_for_sid(self, sid: str) -> Optional[ip_address]:
         """ if ip is mapped to sid, return it, else return None """
-        with self._lock:
-            if sid in self._store.sid_ips_map:
-                if not self._store.sid_ips_map[sid]:
-                    raise AssertionError("Unexpected internal state")
-                else:
-                    return self._store.sid_ips_map[sid].ip
-            return None
+        if sid in self._store.sid_ips_map:
+            if not self._store.sid_ips_map[sid]:
+                raise AssertionError("Unexpected internal state")
+            else:
+                return self._store.sid_ips_map[sid].ip
+        return None
 
     def get_sid_for_ip(self, requested_ip: ip_address) -> Optional[str]:
         """ If ip is associated with an sid, return the sid, else None """
-        with self._lock:
-            for sid, ip_desc in self._store.sid_ips_map.items():
-                if requested_ip == ip_desc.ip:
-                    return sid
-            return None
+        for sid, ip_desc in self._store.sid_ips_map.items():
+            if requested_ip == ip_desc.ip:
+                return sid
+        return None
 
     def is_ip_in_state(self, ip_addr: ip_address, state: IPState):
         """

--- a/lte/gateway/python/magma/mobilityd/ip_address_man.py
+++ b/lte/gateway/python/magma/mobilityd/ip_address_man.py
@@ -331,12 +331,10 @@ class IPAddressManager:
 
     def get_ip_for_sid(self, sid: str) -> Optional[ip_address]:
         """ if ip is mapped to sid, return it, else return None """
-        if sid in self._store.sid_ips_map:
-            if not self._store.sid_ips_map[sid]:
-                raise AssertionError("Unexpected internal state")
-            else:
-                return self._store.sid_ips_map[sid].ip
-        return None
+        if not self._store.sid_ips_map.get(sid, None):
+            return None
+        else:
+            return self._store.sid_ips_map[sid].ip
 
     def get_sid_for_ip(self, requested_ip: ip_address) -> Optional[str]:
         """ If ip is associated with an sid, return the sid, else None """

--- a/lte/gateway/python/magma/mobilityd/ip_descriptor_map.py
+++ b/lte/gateway/python/magma/mobilityd/ip_descriptor_map.py
@@ -36,7 +36,7 @@ from __future__ import absolute_import, division, print_function, \
     unicode_literals
 
 from ipaddress import ip_address, ip_network
-from typing import Dict, List, Optional, Set
+from typing import Dict, List, MutableMapping, Optional, Set
 
 from magma.mobilityd.ip_descriptor import IPDesc, IPState
 
@@ -45,7 +45,7 @@ DEFAULT_IP_RECYCLE_INTERVAL = 15
 
 class IpDescriptorMap:
 
-    def __init__(self, ip_states: Dict[str, IPDesc]):
+    def __init__(self, ip_states: MutableMapping[IPState, Dict[str, IPDesc]]):
         """
 
         Args:

--- a/lte/gateway/python/magma/mobilityd/mobility_store.py
+++ b/lte/gateway/python/magma/mobilityd/mobility_store.py
@@ -79,7 +79,7 @@ class IPDescDict(RedisFlatDict):
                            serialize_utils.serialize_ip_desc,
                            serialize_utils.deserialize_ip_desc,
                            )
-        super().__init__(client, serde, writeback=True)
+        super().__init__(client, serde, writethrough=True)
 
 
 def ip_states(client, key):

--- a/lte/gateway/python/magma/mobilityd/mobility_store.py
+++ b/lte/gateway/python/magma/mobilityd/mobility_store.py
@@ -13,13 +13,13 @@ limitations under the License.
 from collections import defaultdict
 
 import redis
-from magma.common.redis.containers import RedisFlatDict, RedisSet
-from magma.common.redis.serializers import RedisSerde
-from magma.common.redis.containers import RedisHashDict
-from magma.common.redis.serializers import get_json_serializer, \
-    get_json_deserializer
-from magma.common.redis.client import get_default_client
+from lte.protos.mobilityd_pb2 import GWInfo
 
+from magma.common.redis.client import get_default_client
+from magma.common.redis.containers import RedisFlatDict, RedisHashDict, \
+    RedisSet
+from magma.common.redis.serializers import RedisSerde, get_json_deserializer, \
+    get_json_serializer
 from magma.mobilityd import serialize_utils
 from magma.mobilityd.ip_descriptor import IPDesc
 from magma.mobilityd.ip_descriptor_map import IpDescriptorMap
@@ -45,7 +45,7 @@ class MobilityStore(object):
             self.ip_state_map = IpDescriptorMap(defaultdict(dict))
             self.assigned_ip_blocks = set()  # {ip_block}
             self.sid_ips_map = defaultdict(IPDesc)  # {SID=>IPDesc}
-            self.dhcp_gw_info = UplinkGatewayInfo(defaultdict(str))
+            self.dhcp_gw_info = UplinkGatewayInfo(defaultdict(GWInfo))
             self.dhcp_store = {}  # mac => DHCP_State
             self.allocated_iid = {}  # {ipv6 interface identifiers}
             self.sid_session_prefix_allocated = {}  # SID => session prefix
@@ -79,7 +79,7 @@ class IPDescDict(RedisFlatDict):
                            serialize_utils.serialize_ip_desc,
                            serialize_utils.deserialize_ip_desc,
                            )
-        super().__init__(client, serde)
+        super().__init__(client, serde, writeback=True)
 
 
 def ip_states(client, key):

--- a/lte/gateway/python/magma/mobilityd/uplink_gw.py
+++ b/lte/gateway/python/magma/mobilityd/uplink_gw.py
@@ -12,9 +12,9 @@ limitations under the License.
 """
 import ipaddress
 import logging
-import netifaces
+from typing import List, MutableMapping, Optional
 
-from typing import MutableMapping, Optional, List
+import netifaces
 from lte.protos.mobilityd_pb2 import GWInfo, IPAddress
 
 NO_VLAN = "NO_VLAN"


### PR DESCRIPTION
Signed-off-by: Alex Rodriguez <alexrod@fb.com>

## Summary

- This adds a writeback option to RedisFlatDict on py containers, which will maintain a local cache to read and write data, which will result in saving multiple redis read operations.
- Removing some locking on `get_sid_from_ip` and `get_ip_from_sid` since these are read operations which will not modify data
- Reformatting a few files on mobilityd

## Test Plan

- make integ_test
- make test
- testing allocate IP and release IP requests with `ghz` load testing tool 
![image](https://user-images.githubusercontent.com/6800940/109621653-1bad1600-7af0-11eb-9303-2e33e5e3bded.png)


## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
