### PR TITLE
[Clang_Formatting] [sctpd] Fixed clang formatting for sctpd files

### DIFF
--- a/lte/gateway/c/sctpd/sctp_assoc.cpp
+++ b/lte/gateway/c/sctpd/sctp_assoc.cpp
@@ -20,22 +20,19 @@
 namespace magma {
 namespace sctpd {
 
-SctpAssoc::SctpAssoc():
-  sd(0),
-  ppid(0),
-  instreams(0),
-  outstreams(0),
-  assoc_id(0),
-  messages_recv(0),
-  messages_sent(0)
-{
-}
+SctpAssoc::SctpAssoc()
+    : sd(0),
+      ppid(0),
+      instreams(0),
+      outstreams(0),
+      assoc_id(0),
+      messages_recv(0),
+      messages_sent(0) {}
 
-void SctpAssoc::dump() const
-{
+void SctpAssoc::dump() const {
   MLOG(MDEBUG) << "SctpAssoc<id: " << std::to_string(this->assoc_id) << ">"
                << std::endl;
 }
 
-} // namespace sctpd
-} // namespace magma
+}  // namespace sctpd
+}  // namespace magma

--- a/lte/gateway/c/sctpd/sctp_assoc.h
+++ b/lte/gateway/c/sctpd/sctp_assoc.h
@@ -21,13 +21,13 @@ namespace sctpd {
 // Models the state of an SCTP association
 class SctpAssoc {
  public:
-  int sd;                 ///< Socket descriptor
-  uint32_t ppid;          ///< Payload protocol Identifier
-  uint16_t instreams;     ///< Number of input streams negotiated
-  uint16_t outstreams;    ///< Number of output strams negotiated
-  uint32_t assoc_id;      ///< SCTP association id
-  uint32_t messages_recv; ///< Number of messages received
-  uint32_t messages_sent; ///< Number of messages sent
+  int sd;                  ///< Socket descriptor
+  uint32_t ppid;           ///< Payload protocol Identifier
+  uint16_t instreams;      ///< Number of input streams negotiated
+  uint16_t outstreams;     ///< Number of output strams negotiated
+  uint32_t assoc_id;       ///< SCTP association id
+  uint32_t messages_recv;  ///< Number of messages received
+  uint32_t messages_sent;  ///< Number of messages sent
 
   SctpAssoc();
 
@@ -35,5 +35,5 @@ class SctpAssoc {
   void dump() const;
 };
 
-} // namespace sctpd
-} // namespace magma
+}  // namespace sctpd
+}  // namespace magma

--- a/lte/gateway/c/sctpd/sctp_connection.h
+++ b/lte/gateway/c/sctpd/sctp_connection.h
@@ -29,9 +29,9 @@ namespace sctpd {
 
 // Describes status of Sctp event (up or down stream)
 enum class SctpStatus {
-  OK,         // Sctp event was ok
-  FAILURE,    // General failure - nonfatal
-  DISCONNECT, // Sctp assoc disconnected
+  OK,          // Sctp event was ok
+  FAILURE,     // General failure - nonfatal
+  DISCONNECT,  // Sctp assoc disconnected
 };
 
 // Interface for upstream Sctp event handling
@@ -39,25 +39,24 @@ class SctpEventHandler {
  public:
   // Specification for NewAssoc handler function
   virtual void HandleNewAssoc(
-     uint32_t ppid, uint32_t assoc_id, uint32_t instreams, uint32_t outstreams,
+      uint32_t ppid, uint32_t assoc_id, uint32_t instreams, uint32_t outstreams,
       std::string& ran_cp_ipaddr) = 0;
 
   // Specification for CloseAssoc handler function
-  virtual void HandleCloseAssoc(uint32_t ppid, uint32_t assoc_id, bool reset) = 0;
+  virtual void HandleCloseAssoc(
+      uint32_t ppid, uint32_t assoc_id, bool reset) = 0;
 
   // Specification for Recv handler function
   virtual void HandleRecv(
-    uint32_t ppid,
-    uint32_t assoc_id,
-    uint32_t stream,
-    const std::string &payload) = 0;
+      uint32_t ppid, uint32_t assoc_id, uint32_t stream,
+      const std::string& payload) = 0;
 };
 
 // Manages Sctp connection including setup/teardown and send/recv
 class SctpConnection {
  public:
   // Construct as per the InitReq and sending upstream events to handler
-  SctpConnection(const InitReq &req, SctpEventHandler &handler);
+  SctpConnection(const InitReq& req, SctpEventHandler& handler);
 
   // Start SCTP connection and begin listening/relaying events to handler
   void Start();
@@ -65,7 +64,7 @@ class SctpConnection {
   void Close();
 
   // Send a message on the Sctp connection to (assoc_id, stream)
-  void Send(uint32_t assoc_id, uint32_t stream, const std::string &msg);
+  void Send(uint32_t assoc_id, uint32_t stream, const std::string& msg);
 
  private:
   // Listener loop run in separate thread by Start
@@ -73,9 +72,9 @@ class SctpConnection {
   // Handle an event on a client socket
   SctpStatus HandleClientSock(int sd);
   // Handle an association change event for an association sd/change
-  SctpStatus HandleAssocChange(int sd, struct sctp_assoc_change *change);
+  SctpStatus HandleAssocChange(int sd, struct sctp_assoc_change* change);
   // Handle a comup event on an association sd/change
-  SctpStatus HandleComUp(int sd, struct sctp_assoc_change *change);
+  SctpStatus HandleComUp(int sd, struct sctp_assoc_change* change);
   // Handle a comdown event on an association keyed by assoc_id
   SctpStatus HandleComDown(uint32_t assoc_id);
   // Handle a reset event on an association keyed by assoc_id
@@ -84,7 +83,7 @@ class SctpConnection {
   // Flag is set to true when the connection is closing
   std::atomic<bool> _done;
   // Concrete handler instance to handle upstream events
-  SctpEventHandler &_handler;
+  SctpEventHandler& _handler;
   // PPID to use with Sctp connections
   int _ppid;
   // Keeps track of sctp and assocation info
@@ -93,5 +92,5 @@ class SctpConnection {
   std::unique_ptr<std::thread> _thread;
 };
 
-} // namespace sctpd
-}; // namespace magma
+}  // namespace sctpd
+};  // namespace magma

--- a/lte/gateway/c/sctpd/sctp_desc.cpp
+++ b/lte/gateway/c/sctpd/sctp_desc.cpp
@@ -18,49 +18,41 @@
 namespace magma {
 namespace sctpd {
 
-SctpDesc::SctpDesc(int sd): _sd(sd)
-{
+SctpDesc::SctpDesc(int sd) : _sd(sd) {
   assert(sd >= 0);
 }
 
-void SctpDesc::addAssoc(const SctpAssoc &assoc)
-{
+void SctpDesc::addAssoc(const SctpAssoc& assoc) {
   _assocs[assoc.assoc_id] = assoc;
 }
 
-SctpAssoc &SctpDesc::getAssoc(uint32_t assoc_id)
-{
-  return _assocs.at(assoc_id); // throws std::out_of_range
+SctpAssoc& SctpDesc::getAssoc(uint32_t assoc_id) {
+  return _assocs.at(assoc_id);  // throws std::out_of_range
 }
 
-int SctpDesc::delAssoc(uint32_t assoc_id)
-{
+int SctpDesc::delAssoc(uint32_t assoc_id) {
   auto num_removed = _assocs.erase(assoc_id);
   return num_removed == 1 ? 0 : -1;
 }
 
-AssocMap::const_iterator SctpDesc::begin() const
-{
+AssocMap::const_iterator SctpDesc::begin() const {
   return _assocs.cbegin();
 }
 
-AssocMap::const_iterator SctpDesc::end() const
-{
+AssocMap::const_iterator SctpDesc::end() const {
   return _assocs.cend();
 }
 
-int SctpDesc::sd() const
-{
+int SctpDesc::sd() const {
   return _sd;
 }
 
-void SctpDesc::dump() const
-{
-  for (auto const &kv : _assocs) {
+void SctpDesc::dump() const {
+  for (auto const& kv : _assocs) {
     auto assoc = kv.second;
     assoc.dump();
   }
 }
 
-} // namespace sctpd
-} // namespace magma
+}  // namespace sctpd
+}  // namespace magma

--- a/lte/gateway/c/sctpd/sctp_desc.h
+++ b/lte/gateway/c/sctpd/sctp_desc.h
@@ -31,9 +31,9 @@ class SctpDesc {
   SctpDesc(int sd);
 
   // Add assocation, assoc, to the list of assocations - keyed by assoc_id
-  void addAssoc(const SctpAssoc &assoc);
+  void addAssoc(const SctpAssoc& assoc);
   // Get association keyed by assoc_id, throw std::out_of_range otherwise
-  SctpAssoc &getAssoc(uint32_t assoc_id);
+  SctpAssoc& getAssoc(uint32_t assoc_id);
   // Remove assoc keyed by assoc_id from assoc list, returns 0/-1 on ok/fail
   int delAssoc(uint32_t assoc_id);
 
@@ -55,5 +55,5 @@ class SctpDesc {
   int _sd;
 };
 
-} // namespace sctpd
-} // namespace magma
+}  // namespace sctpd
+}  // namespace magma

--- a/lte/gateway/c/sctpd/sctpd.cpp
+++ b/lte/gateway/c/sctpd/sctpd.cpp
@@ -28,9 +28,7 @@ using magma::sctpd::SctpdDownlinkImpl;
 using magma::sctpd::SctpdEventHandler;
 using magma::sctpd::SctpdUplinkClient;
 
-
-int signalMask(void)
-{
+int signalMask(void) {
   sigset_t set;
   sigemptyset(&set);
   sigaddset(&set, SIGSEGV);
@@ -44,10 +42,7 @@ int signalMask(void)
 }
 
 int signalHandler(
-  int *end,
-  std::unique_ptr<Server> &server,
-  SctpdDownlinkImpl &downLink)
-{
+    int* end, std::unique_ptr<Server>& server, SctpdDownlinkImpl& downLink) {
   int ret;
   siginfo_t info;
   sigset_t set;
@@ -79,15 +74,14 @@ int signalHandler(
   return 0;
 }
 
-int main()
-{
+int main() {
   signalMask();
 
   magma::init_logging("sctpd");
   magma::set_verbosity(MDEBUG);
 
   auto channel =
-    grpc::CreateChannel(UPSTREAM_SOCK, grpc::InsecureChannelCredentials());
+      grpc::CreateChannel(UPSTREAM_SOCK, grpc::InsecureChannelCredentials());
 
   SctpdUplinkClient client(channel);
   SctpdEventHandler handler(client);

--- a/lte/gateway/c/sctpd/sctpd_downlink_impl.cpp
+++ b/lte/gateway/c/sctpd/sctpd_downlink_impl.cpp
@@ -23,73 +23,63 @@
 namespace magma {
 namespace sctpd {
 
-SctpdDownlinkImpl::SctpdDownlinkImpl(SctpEventHandler &uplink_handler):
-  _uplink_handler(uplink_handler),
-  _sctp_4G_connection(nullptr),
-  _sctp_5G_connection(nullptr)
-{
-}
+SctpdDownlinkImpl::SctpdDownlinkImpl(SctpEventHandler& uplink_handler)
+    : _uplink_handler(uplink_handler),
+      _sctp_4G_connection(nullptr),
+      _sctp_5G_connection(nullptr) {}
 
 Status SctpdDownlinkImpl::create_sctp_connection(
-  std::unique_ptr<SctpConnection>& sctp_connection,
-  const InitReq *req,
-InitRes *res)
-{
+    std::unique_ptr<SctpConnection>& sctp_connection, const InitReq* req,
+    InitRes* res) {
   if (sctp_connection != nullptr && !req->force_restart()) {
-	MLOG(MERROR) << "SctpdDownlinkImpl::Init reusing existing connection";
-	res->set_result(InitRes::INIT_OK);
-	return Status::OK;
+    MLOG(MERROR) << "SctpdDownlinkImpl::Init reusing existing connection";
+    res->set_result(InitRes::INIT_OK);
+    return Status::OK;
   }
   if (sctp_connection != nullptr) {
-	MLOG(MINFO)<< "SctpdDownlinkImpl::Init cleaning up sctp_desc and listener";
-	auto conn = std::move(sctp_connection);
-	conn->Close();
+    MLOG(MINFO) << "SctpdDownlinkImpl::Init cleaning up sctp_desc and listener";
+    auto conn = std::move(sctp_connection);
+    conn->Close();
   }
   MLOG(MINFO) << "SctpdDownlinkImpl::Init creating new socket and listener";
   try {
-	sctp_connection = std::make_unique<SctpConnection>(*req, _uplink_handler);
+    sctp_connection = std::make_unique<SctpConnection>(*req, _uplink_handler);
   } catch (...) {
-	res->set_result(InitRes::INIT_FAIL);
-	return Status::OK;
+    res->set_result(InitRes::INIT_FAIL);
+    return Status::OK;
   }
   sctp_connection->Start();
   return Status::OK;
 }
 
 Status SctpdDownlinkImpl::Init(
-  ServerContext *context,
-  const InitReq *req,
-  InitRes *res)
-{
-  MLOG(MINFO) << "SctpdDownlinkImpl::req->ppid()=" << std::to_string(req->ppid());
-  MLOG(MINFO) << "SctpdDownlinkImpl::req->port()=" << std::to_string(req->port());
+    ServerContext* context, const InitReq* req, InitRes* res) {
+  MLOG(MINFO) << "SctpdDownlinkImpl::req->ppid()="
+              << std::to_string(req->ppid());
+  MLOG(MINFO) << "SctpdDownlinkImpl::req->port()="
+              << std::to_string(req->port());
 
- Status rc;
+  Status rc;
 
   if (req->ppid() == S1AP) {
-	rc = create_sctp_connection(_sctp_4G_connection, req, res);
+    rc = create_sctp_connection(_sctp_4G_connection, req, res);
 
-}
-  else if (req->ppid() == NGAP) {
-	rc = create_sctp_connection(_sctp_5G_connection, req, res);
-
-}
-	res->set_result(InitRes::INIT_OK);
-	return Status::OK;
+  } else if (req->ppid() == NGAP) {
+    rc = create_sctp_connection(_sctp_5G_connection, req, res);
+  }
+  res->set_result(InitRes::INIT_OK);
+  return Status::OK;
 }
 
 Status SctpdDownlinkImpl::SendDl(
-  ServerContext *context,
-  const SendDlReq *req,
-  SendDlRes *res)
-{
+    ServerContext* context, const SendDlReq* req, SendDlRes* res) {
   MLOG(MDEBUG) << "SctpdDownlinkImpl::SendDl starting";
 
   try {
-	  if (req->ppid() == S1AP )
-		  _sctp_4G_connection->Send(req->assoc_id(), req->stream(), req->payload());
-	  else
-		  _sctp_5G_connection->Send(req->assoc_id(), req->stream(), req->payload());
+    if (req->ppid() == S1AP)
+      _sctp_4G_connection->Send(req->assoc_id(), req->stream(), req->payload());
+    else
+      _sctp_5G_connection->Send(req->assoc_id(), req->stream(), req->payload());
 
   } catch (...) {
     res->set_result(SendDlRes::SEND_DL_FAIL);
@@ -100,15 +90,14 @@ Status SctpdDownlinkImpl::SendDl(
   return Status::OK;
 }
 
-void SctpdDownlinkImpl::stop()
-{
-	if (_sctp_4G_connection != nullptr) {
-		 _sctp_4G_connection->Close();
-	}
-	if (_sctp_5G_connection != nullptr) {
-		 _sctp_5G_connection->Close();
-	}
+void SctpdDownlinkImpl::stop() {
+  if (_sctp_4G_connection != nullptr) {
+    _sctp_4G_connection->Close();
+  }
+  if (_sctp_5G_connection != nullptr) {
+    _sctp_5G_connection->Close();
+  }
 }
 
-} // namespace sctpd
-} // namespace magma
+}  // namespace sctpd
+}  // namespace magma

--- a/lte/gateway/c/sctpd/sctpd_downlink_impl.h
+++ b/lte/gateway/c/sctpd/sctpd_downlink_impl.h
@@ -36,29 +36,32 @@ using grpc::Status;
 class SctpdDownlinkImpl final : public SctpdDownlink::Service {
  public:
   // Construct a new SctpdDownlinkImpl service
-  SctpdDownlinkImpl(SctpEventHandler &uplink_handler);
+  SctpdDownlinkImpl(SctpEventHandler& uplink_handler);
 
   // Implementation of SctpdDownlink.Init method (see sctpd.proto for more info)
-  Status Init(ServerContext *context, const InitReq *request, InitRes *response)
-    override;
+  Status Init(ServerContext* context, const InitReq* request, InitRes* response)
+      override;
 
-  // Implementation of SctpdDownlink.SendDl method (see sctpd.proto for more info)
-  Status SendDl( ServerContext *context, const SendDlReq *request, SendDlRes *response)
-    override;
+  // Implementation of SctpdDownlink.SendDl method (see sctpd.proto for more
+  // info)
+  Status SendDl(
+      ServerContext* context, const SendDlReq* request,
+      SendDlRes* response) override;
 
   // Implementation of SctpdDownlink.create_sctp_connection method
   //(creates 4G/5G sctp connection)
-  Status create_sctp_connection(std::unique_ptr<SctpConnection>& sctp_connection,
-    const InitReq *request, InitRes *response);
+  Status create_sctp_connection(
+      std::unique_ptr<SctpConnection>& sctp_connection, const InitReq* request,
+      InitRes* response);
 
   // Close SCTP connection for this SctpdDownlink.
   void stop();
 
  private:
-  SctpEventHandler &_uplink_handler;
+  SctpEventHandler& _uplink_handler;
   std::unique_ptr<SctpConnection> _sctp_4G_connection;
   std::unique_ptr<SctpConnection> _sctp_5G_connection;
 };
 
-} // namespace sctpd
-} // namespace magma
+}  // namespace sctpd
+}  // namespace magma

--- a/lte/gateway/c/sctpd/sctpd_event_handler.cpp
+++ b/lte/gateway/c/sctpd/sctpd_event_handler.cpp
@@ -18,9 +18,8 @@
 namespace magma {
 namespace sctpd {
 
-SctpdEventHandler::SctpdEventHandler(SctpdUplinkClient &client): _client(client)
-{
-}
+SctpdEventHandler::SctpdEventHandler(SctpdUplinkClient& client)
+    : _client(client) {}
 
 void SctpdEventHandler::HandleNewAssoc(
     uint32_t ppid, uint32_t assoc_id, uint32_t instreams, uint32_t outstreams,
@@ -37,8 +36,8 @@ void SctpdEventHandler::HandleNewAssoc(
   _client.newAssoc(req, &res);
 }
 
-void SctpdEventHandler::HandleCloseAssoc(uint32_t ppid, uint32_t assoc_id, bool reset)
-{
+void SctpdEventHandler::HandleCloseAssoc(
+    uint32_t ppid, uint32_t assoc_id, bool reset) {
   CloseAssocReq req;
   CloseAssocRes res;
 
@@ -50,11 +49,8 @@ void SctpdEventHandler::HandleCloseAssoc(uint32_t ppid, uint32_t assoc_id, bool 
 }
 
 void SctpdEventHandler::HandleRecv(
-  uint32_t ppid,
-  uint32_t assoc_id,
-  uint32_t stream,
-  const std::string &payload)
-{
+    uint32_t ppid, uint32_t assoc_id, uint32_t stream,
+    const std::string& payload) {
   SendUlReq req;
   SendUlRes res;
 
@@ -66,5 +62,5 @@ void SctpdEventHandler::HandleRecv(
   _client.sendUl(req, &res);
 }
 
-} // namespace sctpd
-} // namespace magma
+}  // namespace sctpd
+}  // namespace magma

--- a/lte/gateway/c/sctpd/sctpd_event_handler.h
+++ b/lte/gateway/c/sctpd/sctpd_event_handler.h
@@ -28,7 +28,7 @@ class SctpdEventHandler : public SctpEventHandler {
 
   // Relay new assocation to MME/AMF over GRPC
   void HandleNewAssoc(
-       uint32_t ppid, uint32_t assoc_id, uint32_t instreams, uint32_t outstreams,
+      uint32_t ppid, uint32_t assoc_id, uint32_t instreams, uint32_t outstreams,
       std::string& ran_cp_ipaddr) override;
 
   // Relay close assocation to MME/AMF over GRPC
@@ -36,7 +36,9 @@ class SctpdEventHandler : public SctpEventHandler {
 
   // Relay new message to MME over GRPC
   void HandleRecv(
-     uint32_t ppid, uint32_t assoc_id, uint32_t stream, const std::string& payload) override;
+      uint32_t ppid, uint32_t assoc_id, uint32_t stream,
+      const std::string& payload) override;
+
  private:
   SctpdUplinkClient& _client;
 };

--- a/lte/gateway/c/sctpd/sctpd_uplink_client.cpp
+++ b/lte/gateway/c/sctpd/sctpd_uplink_client.cpp
@@ -20,13 +20,11 @@ namespace sctpd {
 
 using grpc::ClientContext;
 
-SctpdUplinkClient::SctpdUplinkClient(std::shared_ptr<Channel> channel)
-{
+SctpdUplinkClient::SctpdUplinkClient(std::shared_ptr<Channel> channel) {
   _stub = SctpdUplink::NewStub(channel);
 }
 
-int SctpdUplinkClient::sendUl(const SendUlReq &req, SendUlRes *res)
-{
+int SctpdUplinkClient::sendUl(const SendUlReq& req, SendUlRes* res) {
   assert(res != nullptr);
 
   ClientContext context;
@@ -41,8 +39,7 @@ int SctpdUplinkClient::sendUl(const SendUlReq &req, SendUlRes *res)
   return status.ok() ? 0 : -1;
 }
 
-int SctpdUplinkClient::newAssoc(const NewAssocReq &req, NewAssocRes *res)
-{
+int SctpdUplinkClient::newAssoc(const NewAssocReq& req, NewAssocRes* res) {
   assert(res != nullptr);
 
   ClientContext context;
@@ -57,8 +54,8 @@ int SctpdUplinkClient::newAssoc(const NewAssocReq &req, NewAssocRes *res)
   return status.ok() ? 0 : -1;
 }
 
-int SctpdUplinkClient::closeAssoc(const CloseAssocReq &req, CloseAssocRes *res)
-{
+int SctpdUplinkClient::closeAssoc(
+    const CloseAssocReq& req, CloseAssocRes* res) {
   assert(res != nullptr);
 
   ClientContext context;
@@ -73,5 +70,5 @@ int SctpdUplinkClient::closeAssoc(const CloseAssocReq &req, CloseAssocRes *res)
   return status.ok() ? 0 : -1;
 }
 
-} // namespace sctpd
-} // namespace magma
+}  // namespace sctpd
+}  // namespace magma

--- a/lte/gateway/c/sctpd/sctpd_uplink_client.h
+++ b/lte/gateway/c/sctpd/sctpd_uplink_client.h
@@ -31,16 +31,16 @@ class SctpdUplinkClient {
   explicit SctpdUplinkClient(std::shared_ptr<Channel> channel);
 
   // Send an uplink packet to MME (see sctpd.proto for more info)
-  virtual int sendUl(const SendUlReq &req, SendUlRes *res);
+  virtual int sendUl(const SendUlReq& req, SendUlRes* res);
   // Notify MME of new association (see sctpd.proto for more info)
-  virtual int newAssoc(const NewAssocReq &req, NewAssocRes *res);
+  virtual int newAssoc(const NewAssocReq& req, NewAssocRes* res);
   // Notify MME of closing/reseting association (see sctpd.proto for more info)
-  virtual int closeAssoc(const CloseAssocReq &req, CloseAssocRes *res);
+  virtual int closeAssoc(const CloseAssocReq& req, CloseAssocRes* res);
 
  private:
   // Stub used for client to communicate with server
   std::unique_ptr<SctpdUplink::Stub> _stub;
 };
 
-} // namespace sctpd
-} // namespace magma
+}  // namespace sctpd
+}  // namespace magma

--- a/lte/gateway/c/sctpd/test/test_event_handler.cpp
+++ b/lte/gateway/c/sctpd/test/test_event_handler.cpp
@@ -36,23 +36,21 @@ namespace sctpd {
 
 class MockSctpdUplinkClient final : public SctpdUplinkClient {
  public:
-  MockSctpdUplinkClient(std::shared_ptr<Channel> channel):
-    SctpdUplinkClient(channel)
-  {
+  MockSctpdUplinkClient(std::shared_ptr<Channel> channel)
+      : SctpdUplinkClient(channel) {
     ON_CALL(*this, sendUl(_, _)).WillByDefault(Return(0));
     ON_CALL(*this, newAssoc(_, _)).WillByDefault(Return(0));
     ON_CALL(*this, closeAssoc(_, _)).WillByDefault(Return(0));
   }
 
-  MOCK_METHOD2(sendUl, int(const SendUlReq &, SendUlRes *));
-  MOCK_METHOD2(newAssoc, int(const NewAssocReq &, NewAssocRes *));
-  MOCK_METHOD2(closeAssoc, int(const CloseAssocReq &, CloseAssocRes *));
+  MOCK_METHOD2(sendUl, int(const SendUlReq&, SendUlRes*));
+  MOCK_METHOD2(newAssoc, int(const NewAssocReq&, NewAssocRes*));
+  MOCK_METHOD2(closeAssoc, int(const CloseAssocReq&, CloseAssocRes*));
 };
 
 class EventHandlerTest : public ::testing::Test {
  protected:
-  virtual void SetUp()
-  {
+  virtual void SetUp() {
     send_ul_req.set_assoc_id(123);
     send_ul_req.set_stream(321);
     send_ul_req.set_payload("testtest");
@@ -67,7 +65,7 @@ class EventHandlerTest : public ::testing::Test {
     auto channel = grpc::CreateChannel("", grpc::InsecureChannelCredentials());
 
     _uplink_client = std::make_unique<MockSctpdUplinkClient>(channel);
-    _handler = std::make_unique<SctpdEventHandler>(*_uplink_client);
+    _handler       = std::make_unique<SctpdEventHandler>(*_uplink_client);
   }
 
   SendUlReq send_ul_req;
@@ -78,64 +76,59 @@ class EventHandlerTest : public ::testing::Test {
   std::unique_ptr<SctpdEventHandler> _handler;
 };
 
-TEST_F(EventHandlerTest, test_event_handler_new_assoc)
-{
+TEST_F(EventHandlerTest, test_event_handler_new_assoc) {
   auto correct_assoc_id =
-    Property(&NewAssocReq::assoc_id, Eq(new_assoc_req.assoc_id()));
+      Property(&NewAssocReq::assoc_id, Eq(new_assoc_req.assoc_id()));
   auto correct_instreams =
-    Property(&NewAssocReq::instreams, Eq(new_assoc_req.instreams()));
+      Property(&NewAssocReq::instreams, Eq(new_assoc_req.instreams()));
   auto correct_outstreams =
-    Property(&NewAssocReq::outstreams, Eq(new_assoc_req.outstreams()));
+      Property(&NewAssocReq::outstreams, Eq(new_assoc_req.outstreams()));
   auto correct_new_assoc_req =
-    AllOf(correct_assoc_id, correct_instreams, correct_outstreams);
+      AllOf(correct_assoc_id, correct_instreams, correct_outstreams);
 
   EXPECT_CALL(*_uplink_client, newAssoc(correct_new_assoc_req, NotNull()))
-    .Times(1);
+      .Times(1);
 
   _handler->HandleNewAssoc(
-    new_assoc_req.assoc_id(),
-    new_assoc_req.instreams(),
-    new_assoc_req.outstreams());
+      new_assoc_req.assoc_id(), new_assoc_req.instreams(),
+      new_assoc_req.outstreams());
 }
 
-TEST_F(EventHandlerTest, test_event_handler_close_assoc)
-{
+TEST_F(EventHandlerTest, test_event_handler_close_assoc) {
   auto correct_assoc_id =
-    Property(&CloseAssocReq::assoc_id, Eq(close_assoc_req.assoc_id()));
+      Property(&CloseAssocReq::assoc_id, Eq(close_assoc_req.assoc_id()));
   auto correct_reset =
-    Property(&CloseAssocReq::is_reset, Eq(close_assoc_req.is_reset()));
+      Property(&CloseAssocReq::is_reset, Eq(close_assoc_req.is_reset()));
   auto correct_close_assoc_req = AllOf(correct_assoc_id, correct_reset);
 
   EXPECT_CALL(*_uplink_client, closeAssoc(correct_close_assoc_req, NotNull()))
-    .Times(1);
+      .Times(1);
 
   _handler->HandleCloseAssoc(
-    close_assoc_req.assoc_id(), close_assoc_req.is_reset());
+      close_assoc_req.assoc_id(), close_assoc_req.is_reset());
 }
 
-TEST_F(EventHandlerTest, test_event_handler_send_ul)
-{
+TEST_F(EventHandlerTest, test_event_handler_send_ul) {
   auto correct_assoc_id =
-    Property(&SendUlReq::assoc_id, Eq(send_ul_req.assoc_id()));
+      Property(&SendUlReq::assoc_id, Eq(send_ul_req.assoc_id()));
   auto correct_stream = Property(&SendUlReq::stream, Eq(send_ul_req.stream()));
   auto correct_payload =
-    Property(&SendUlReq::payload, Eq(send_ul_req.payload()));
+      Property(&SendUlReq::payload, Eq(send_ul_req.payload()));
   auto correct_send_ul_req =
-    AllOf(correct_assoc_id, correct_stream, correct_payload);
+      AllOf(correct_assoc_id, correct_stream, correct_payload);
 
   EXPECT_CALL(*_uplink_client, sendUl(correct_send_ul_req, NotNull())).Times(1);
 
   _handler->HandleRecv(
-    send_ul_req.assoc_id(), send_ul_req.stream(), send_ul_req.payload());
+      send_ul_req.assoc_id(), send_ul_req.stream(), send_ul_req.payload());
 }
 
-} // namespace sctpd
-} // namespace magma
+}  // namespace sctpd
+}  // namespace magma
 
-int main(int argc, char **argv)
-{
+int main(int argc, char** argv) {
   ::testing::InitGoogleTest(&argc, argv);
   FLAGS_logtostderr = 1;
-  FLAGS_v = 10;
+  FLAGS_v           = 10;
   return RUN_ALL_TESTS();
 }

--- a/lte/gateway/c/sctpd/test/test_sctp_desc.cpp
+++ b/lte/gateway/c/sctpd/test/test_sctp_desc.cpp
@@ -25,22 +25,20 @@ namespace sctpd {
 const int DESC_SD = 3;
 
 const int ASSOC_1_ASSOC_ID = 1;
-const int ASSOC_1_SD = 4;
+const int ASSOC_1_SD       = 4;
 const int ASSOC_2_ASSOC_ID = 2;
-const int ASSOC_2_SD = 5;
+const int ASSOC_2_SD       = 5;
 
 class SctpdDescTest : public ::testing::Test {
  protected:
-  virtual void SetUp()
-  {
+  virtual void SetUp() {
     assoc_1.assoc_id = ASSOC_1_ASSOC_ID;
-    assoc_1.sd = ASSOC_1_SD;
+    assoc_1.sd       = ASSOC_1_SD;
     assoc_2.assoc_id = ASSOC_2_ASSOC_ID;
-    assoc_2.sd = ASSOC_2_SD;
+    assoc_2.sd       = ASSOC_2_SD;
   }
 
-  void check_assoc(int assoc_id, int sd, const SctpAssoc &assoc)
-  {
+  void check_assoc(int assoc_id, int sd, const SctpAssoc& assoc) {
     EXPECT_EQ(assoc_id, assoc.assoc_id);
     EXPECT_EQ(sd, assoc.sd);
   }
@@ -49,8 +47,7 @@ class SctpdDescTest : public ::testing::Test {
   SctpAssoc assoc_2;
 };
 
-TEST_F(SctpdDescTest, test_sctpd_desc)
-{
+TEST_F(SctpdDescTest, test_sctpd_desc) {
   SctpDesc desc(DESC_SD);
 
   EXPECT_EQ(DESC_SD, desc.sd());
@@ -74,7 +71,7 @@ TEST_F(SctpdDescTest, test_sctpd_desc)
   bool found_2 = false;
   for (auto kv : desc) {
     auto assoc_id = kv.first;
-    auto assoc = kv.second;
+    auto assoc    = kv.second;
 
     EXPECT_EQ(assoc_id, assoc.assoc_id);
     if (assoc_id == ASSOC_1_ASSOC_ID) {
@@ -102,13 +99,12 @@ TEST_F(SctpdDescTest, test_sctpd_desc)
   EXPECT_THROW(desc.getAssoc(ASSOC_2_ASSOC_ID), std::out_of_range);
 }
 
-} // namespace sctpd
-} // namespace magma
+}  // namespace sctpd
+}  // namespace magma
 
-int main(int argc, char **argv)
-{
+int main(int argc, char** argv) {
   ::testing::InitGoogleTest(&argc, argv);
   FLAGS_logtostderr = 1;
-  FLAGS_v = 10;
+  FLAGS_v           = 10;
   return RUN_ALL_TESTS();
 }

--- a/lte/gateway/c/sctpd/util.cpp
+++ b/lte/gateway/c/sctpd/util.cpp
@@ -23,19 +23,15 @@ namespace sctpd {
 
 // Set up basic sctp options of socket "sd"
 int set_sctp_opts(
-  const int sd,
-  const uint16_t instreams,
-  const uint16_t outstreams,
-  const uint16_t max_attempts,
-  const uint16_t init_timeout);
+    const int sd, const uint16_t instreams, const uint16_t outstreams,
+    const uint16_t max_attempts, const uint16_t init_timeout);
 
 // Convert address specified in InitReq into struct sockaddr for sctp setup
-int convert_addrs(const InitReq *req, struct sockaddr **addrs, int *num_addrs);
+int convert_addrs(const InitReq* req, struct sockaddr** addrs, int* num_addrs);
 
-int create_sctp_sock(const InitReq &req)
-{
+int create_sctp_sock(const InitReq& req) {
   int num_addrs;
-  struct sockaddr *addrs;
+  struct sockaddr* addrs;
   int sd;
 
   if (!req.use_ipv4() && !req.use_ipv6()) return -1;
@@ -78,16 +74,12 @@ fail:
 }
 
 int set_sctp_opts(
-  const int sd,
-  const uint16_t instreams,
-  const uint16_t outstreams,
-  const uint16_t max_attempts,
-  const uint16_t init_timeout)
-{
+    const int sd, const uint16_t instreams, const uint16_t outstreams,
+    const uint16_t max_attempts, const uint16_t init_timeout) {
   struct sctp_initmsg init;
-  init.sinit_num_ostreams = outstreams;
-  init.sinit_max_instreams = instreams;
-  init.sinit_max_attempts = max_attempts;
+  init.sinit_num_ostreams   = outstreams;
+  init.sinit_max_instreams  = instreams;
+  init.sinit_max_attempts   = max_attempts;
   init.sinit_max_init_timeo = init_timeout;
 
   if (setsockopt(sd, IPPROTO_SCTP, SCTP_INITMSG, &init, sizeof(init)) < 0) {
@@ -98,19 +90,18 @@ int set_sctp_opts(
   int on = 1;
 
   struct linger sctp_linger;
-  sctp_linger.l_onoff = on;
+  sctp_linger.l_onoff  = on;
   sctp_linger.l_linger = 0;  // send an ABORT
-  if (
-    setsockopt(sd, SOL_SOCKET, SO_LINGER, &sctp_linger, sizeof(sctp_linger)) < 0
-    ) {
+  if (setsockopt(sd, SOL_SOCKET, SO_LINGER, &sctp_linger, sizeof(sctp_linger)) <
+      0) {
     MLOG_perror("setsockopt linger");
     return -1;
   }
 
   struct sctp_event_subscribe event;
   event.sctp_association_event = on;
-  event.sctp_shutdown_event = on;
-  event.sctp_data_io_event = on;
+  event.sctp_shutdown_event    = on;
+  event.sctp_data_io_event     = on;
 
   if (setsockopt(sd, IPPROTO_SCTP, SCTP_EVENTS, &event, sizeof(event)) < 0) {
     MLOG_perror("setsockopt");
@@ -120,37 +111,35 @@ int set_sctp_opts(
   return 0;
 }
 
-int convert_addrs(const InitReq *req, struct sockaddr **addrs, int *num_addrs)
-{
+int convert_addrs(const InitReq* req, struct sockaddr** addrs, int* num_addrs) {
   int i;
-  struct sockaddr_in *ipv4_addr;
-  struct sockaddr_in6 *ipv6_addr;
+  struct sockaddr_in* ipv4_addr;
+  struct sockaddr_in6* ipv6_addr;
 
   auto num_ipv4_addrs = req->ipv4_addrs_size();
   auto num_ipv6_addrs = req->ipv6_addrs_size();
-  *num_addrs = num_ipv4_addrs + num_ipv6_addrs;
+  *num_addrs          = num_ipv4_addrs + num_ipv6_addrs;
 
-  *addrs = (struct sockaddr *) calloc(*num_addrs, sizeof(struct sockaddr *));
+  *addrs = (struct sockaddr*) calloc(*num_addrs, sizeof(struct sockaddr*));
   if (*addrs == NULL) return -1;
 
   for (i = 0; i < num_ipv4_addrs; i++) {
-    ipv4_addr = (struct sockaddr_in *) &(*addrs)[i];
+    ipv4_addr = (struct sockaddr_in*) &(*addrs)[i];
 
     ipv4_addr->sin_family = AF_INET;
-    ipv4_addr->sin_port = htons(req->port());
+    ipv4_addr->sin_port   = htons(req->port());
     if (inet_aton(req->ipv4_addrs(i).c_str(), &ipv4_addr->sin_addr) < 0) {
       return -1;
     }
   }
 
   for (i = 0; i < num_ipv6_addrs; i++) {
-    ipv6_addr = (struct sockaddr_in6 *) &(*addrs)[i + num_ipv4_addrs];
+    ipv6_addr = (struct sockaddr_in6*) &(*addrs)[i + num_ipv4_addrs];
 
     ipv6_addr->sin6_family = AF_INET6;
-    ipv6_addr->sin6_port = htons(req->port());
-    if (
-      inet_pton(AF_INET6, req->ipv6_addrs(i).c_str(), &ipv6_addr->sin6_addr) <
-      0) {
+    ipv6_addr->sin6_port   = htons(req->port());
+    if (inet_pton(AF_INET6, req->ipv6_addrs(i).c_str(), &ipv6_addr->sin6_addr) <
+        0) {
       return -1;
     }
   }
@@ -158,15 +147,16 @@ int convert_addrs(const InitReq *req, struct sockaddr **addrs, int *num_addrs)
   return 0;
 }
 
-int pull_peer_ipaddr(const int sd, const uint32_t assoc_id, std::string& ran_cp_ipaddr) {
+int pull_peer_ipaddr(
+    const int sd, const uint32_t assoc_id, std::string& ran_cp_ipaddr) {
   int n_remote_addr             = -1;
   struct sockaddr* remote_addrs = NULL;
-  n_remote_addr = sctp_getpaddrs(sd, assoc_id, &remote_addrs);
+  n_remote_addr                 = sctp_getpaddrs(sd, assoc_id, &remote_addrs);
 
   // Since socket is opened as AF_INET6, remote address comes as IPv6 formatted
   // for both IPv4 and IPv6 end points
-  const uint8_t *remote_addr_ipv6_bytes =
-          ((const struct sockaddr_in6*) &remote_addrs[0])->sin6_addr.s6_addr;
+  const uint8_t* remote_addr_ipv6_bytes =
+      ((const struct sockaddr_in6*) &remote_addrs[0])->sin6_addr.s6_addr;
   const char* fromaddr = NULL;
   if (n_remote_addr >= 1) {
     // Picking the first address only.
@@ -174,18 +164,17 @@ int pull_peer_ipaddr(const int sd, const uint32_t assoc_id, std::string& ran_cp_
     if (IN6_IS_ADDR_V4MAPPED(
             &((struct sockaddr_in6*) &remote_addrs[0])->sin6_addr)) {
       // First 12 bytes are ::FFFF for IPv4-mapped-IPv6
-      fromaddr = (const char *) remote_addr_ipv6_bytes + 12;
+      fromaddr      = (const char*) remote_addr_ipv6_bytes + 12;
       ran_cp_ipaddr = std::string(fromaddr, 4);
     } else {
-      fromaddr = (const char *) remote_addr_ipv6_bytes;
+      fromaddr      = (const char*) remote_addr_ipv6_bytes;
       ran_cp_ipaddr = std::string(fromaddr, 16);
     }
   }
-
 
   sctp_freepaddrs(remote_addrs);
   return 0;
 }
 
-} // namespace sctpd
-} // namespace magma
+}  // namespace sctpd
+}  // namespace magma


### PR DESCRIPTION
## Title
[Clang_Formatting] [sctpd] Fixed clang formatting for sctpd files

## Summary
While compiling code using make run on latest master, the following files were showing need of clang-formatting:
c/sctpd/sctp_assoc.cpp
c/sctpd/sctp_assoc.h
c/sctpd/sctp_connection.cpp
c/sctpd/sctp_connection.h
c/sctpd/sctp_desc.cpp
c/sctpd/sctp_desc.h
c/sctpd/sctpd.cpp
c/sctpd/sctpd_downlink_impl.cpp
c/sctpd/sctpd_downlink_impl.h
c/sctpd/sctpd_event_handler.cpp
c/sctpd/sctpd_event_handler.h
c/sctpd/sctpd_uplink_client.cpp
c/sctpd/sctpd_uplink_client.h
c/sctpd/test/test_event_handler.cpp
c/sctpd/test/test_sctp_desc.cpp
c/sctpd/util.cpp
This PR applies clang formatting on these files

## Test Plan
Compiled the code successfully and ran sanity

Signed-off-by: VinashakAnkitAman <ankit.aman@radisys.com>