### PR TITLE
pipelined: classifier test failure #5239

### DIFF
--- a/lte/gateway/python/magma/pipelined/app/classifier.py
+++ b/lte/gateway/python/magma/pipelined/app/classifier.py
@@ -12,6 +12,7 @@ limitations under the License.
 """
 import subprocess
 import ipaddress
+import socket
 from collections import namedtuple
 from ryu.ofproto.ofproto_v1_4 import OFPP_LOCAL
 
@@ -87,7 +88,7 @@ class Classifier(MagmaController):
             self.ovs_gtp_type = "gtp"
 
     def _ip_addr_to_gtp_port_name(self, enodeb_ip_addr:str):
-        ip_no = hex(int(ipaddress.ip_address(enodeb_ip_addr)))
+        ip_no = hex(socket.htonl(int(ipaddress.ip_address(enodeb_ip_addr))))
         buf = "g_{}".format(ip_no[2:])
         return buf
 
@@ -97,7 +98,7 @@ class Classifier(MagmaController):
             return None
 
         try:
-            return ovs.get_ofport(port_name)
+            port_no = ovs.get_ofport(port_name)
 
         except AssertionError as error:
             self.logger.debug('Cannot get port number for %s: %s',
@@ -108,6 +109,8 @@ class Classifier(MagmaController):
             self.logger.debug('Cannot get port number for %s: %s',
                                port_name, e)
             return None
+
+        return port_no
 
     def _add_gtp_port(self, gnb_ip):
         if not self.config.multi_tunnel_flag:


### PR DESCRIPTION
Signed-off-by: prabina pattnaik <prabinak@wavelabs.ai>
## Summary

The issue was reproduced with exception errors and two failed test cases while running the "test_classifier.py" when 
Port "g_*" and Interface "g_*" already attached to gtp_br0 bridge, like as below:

Bridge "gtp_br0"
        Controller "tcp:127.0.0.1:6633"
        Controller "tcp:127.0.0.1:6654"
        fail_mode: secure
        Port "g_913ca8c0"
            Interface "g_913ca8c0"
                type: gtp
                options: {key=flow, remote_ip="192.168.60.145"}

Steps for issue reproduction : 
1. Run the 4G testcase () Like : make integ_test TESTS=s1aptests/test_attach_ul_udp_data.py    
2. Once the testcase is finished stop the magma services.
3. Execute the testcase (test_classifier.py).
4. Observation is that the testcase fails. 

Reason being the integ_test does not cleans up the bridge and attached ports. Hence the port
numbering (for stored snapshot) mismatches.

For fix the exception, need to convert the htonl of Gnb_ip address before convert to port_name "g_*".

For test cases issue fix, The following approaches colud help to avoid the issues:
1) Need to restart the magma before running the test cases
2) Or need to put precondition if "g_*" port name is present then skip the test cases.
3) Or "ovs_multi_tunnel" flag set to false in "test_classifier.py" and "in_port" value will be "32768"
