### PR TITLE
[MME][Memory] Enable UBSAN for debug builds and resolve unaligned memory access issues

### DIFF
--- a/lte/gateway/c/oai/CMakeLists.txt
+++ b/lte/gateway/c/oai/CMakeLists.txt
@@ -41,9 +41,9 @@ add_definitions(-DCMAKER)
 # Generate *.gcno rather than *.c.gcno files for gcov
 set(CMAKE_C_OUTPUT_EXTENSION_REPLACE 1)
 
-set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS} -fstack-protector-all -g -DMALLOC_CHECK_=3 -DDEBUG_IS_ON=1 -DTRACE_IS_ON=1 -O0 -fsanitize=address -fno-omit-frame-pointer")
+set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS} -fstack-protector-all -g -DMALLOC_CHECK_=3 -DDEBUG_IS_ON=1 -DTRACE_IS_ON=1 -O0 -fsanitize=address -fsanitize=undefined -fno-omit-frame-pointer")
 set(CMAKE_C_FLAGS_RELWITHDEBINFO "${CMAKE_C_FLAGS} -g -DMALLOC_CHECK_=3  -DDEBUG_IS_ON -O1")
-set(CMAKE_EXE_LINKER_FLAGS_DEBUG  "${CMAKE_EXE_LINKER_FLAGS_DEBUG} -fsanitize=address")
+set(CMAKE_EXE_LINKER_FLAGS_DEBUG  "${CMAKE_EXE_LINKER_FLAGS_DEBUG} -fsanitize=address -fsanitize=undefined")
 
 set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -DDEBUG_IS_ON=1")
 set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "${CMAKE_CXX_FLAGS_DEBUG} -DDEBUG_IS_ON=1")

--- a/lte/gateway/c/oai/common/async_system.c
+++ b/lte/gateway/c/oai/common/async_system.c
@@ -56,10 +56,8 @@ static void async_system_exit(void);
 task_zmq_ctx_t async_system_task_zmq_ctx;
 
 static int handle_message(zloop_t* loop, zsock_t* reader, void* arg) {
-  int rc              = 0;
-  zframe_t* msg_frame = zframe_recv(reader);
-  assert(msg_frame);
-  MessageDef* received_message_p = (MessageDef*) zframe_data(msg_frame);
+  int rc                         = 0;
+  MessageDef* received_message_p = receive_msg(reader);
 
   switch (ITTI_MSG_ID(received_message_p)) {
     case ASYNC_SYSTEM_COMMAND: {
@@ -86,7 +84,7 @@ static int handle_message(zloop_t* loop, zsock_t* reader, void* arg) {
 
     case TERMINATE_MESSAGE: {
       itti_free_msg_content(received_message_p);
-      zframe_destroy(&msg_frame);
+      free(received_message_p);
       async_system_exit();
     } break;
 
@@ -98,7 +96,7 @@ static int handle_message(zloop_t* loop, zsock_t* reader, void* arg) {
   }
 
   itti_free_msg_content(received_message_p);
-  zframe_destroy(&msg_frame);
+  free(received_message_p);
   return 0;
 }
 

--- a/lte/gateway/c/oai/common/common_defs.h
+++ b/lte/gateway/c/oai/common/common_defs.h
@@ -38,6 +38,7 @@
 #ifndef FILE_COMMON_DEFS_SEEN
 #define FILE_COMMON_DEFS_SEEN
 
+#include <string.h>  // memcpy
 #include <arpa/inet.h>
 //------------------------------------------------------------------------------
 #define STOLEN_REF
@@ -105,15 +106,18 @@ typedef enum {
   sIZE += sizeof(uint8_t)
 
 #define DECODE_U16(bUFFER, vALUE, sIZE)                                        \
-  vALUE = ntohs(*(uint16_t*) (bUFFER));                                        \
+  memcpy((unsigned char*) &vALUE, bUFFER, sizeof(uint16_t));                   \
+  vALUE = ntohs(vALUE);                                                        \
   sIZE += sizeof(uint16_t)
 
 #define DECODE_U24(bUFFER, vALUE, sIZE)                                        \
-  vALUE = ntohl(*(uint32_t*) (bUFFER)) >> 8;                                   \
+  memcpy((unsigned char*) &vALUE, bUFFER, sizeof(uint32_t));                   \
+  vALUE = ntohl(vALUE) >> 8;                                                   \
   sIZE += sizeof(uint8_t) + sizeof(uint16_t)
 
 #define DECODE_U32(bUFFER, vALUE, sIZE)                                        \
-  vALUE = ntohl(*(uint32_t*) (bUFFER));                                        \
+  memcpy((unsigned char*) &vALUE, bUFFER, sizeof(uint32_t));                   \
+  vALUE = ntohl(vALUE);                                                        \
   sIZE += sizeof(uint32_t)
 
 #if (BYTE_ORDER == LITTLE_ENDIAN)
@@ -131,16 +135,25 @@ typedef enum {
   size += sizeof(uint8_t)
 
 #define ENCODE_U16(buffer, value, size)                                        \
-  *(uint16_t*) (buffer) = htons(value);                                        \
-  size += sizeof(uint16_t)
+  do {                                                                         \
+    uint16_t n_value = htons(value);                                           \
+    memcpy(buffer, (unsigned char*) &n_value, sizeof(uint16_t));               \
+    size += sizeof(uint16_t);                                                  \
+  } while (0)
 
 #define ENCODE_U24(buffer, value, size)                                        \
-  *(uint32_t*) (buffer) = htonl(value);                                        \
-  size += sizeof(uint8_t) + sizeof(uint16_t)
+  do {                                                                         \
+    uint32_t n_value = htonl(value);                                           \
+    memcpy(buffer, (unsigned char*) &n_value, sizeof(uint32_t));               \
+    size += sizeof(uint8_t) + sizeof(uint16_t);                                \
+  } while (0)
 
 #define ENCODE_U32(buffer, value, size)                                        \
-  *(uint32_t*) (buffer) = htonl(value);                                        \
-  size += sizeof(uint32_t)
+  do {                                                                         \
+    uint32_t n_value = htonl(value);                                           \
+    memcpy(buffer, (unsigned char*) &n_value, sizeof(uint32_t));               \
+    size += sizeof(uint32_t);                                                  \
+  } while (0)
 
 #define IPV4_STR_ADDR_TO_INADDR(AdDr_StR, InAdDr, MeSsAgE)                     \
   do {                                                                         \

--- a/lte/gateway/c/oai/common/conversions.h
+++ b/lte/gateway/c/oai/common/conversions.h
@@ -134,7 +134,9 @@
 /* Convert an array of char containing vALUE to x */
 #define BUFFER_TO_INT32(buf, x)                                                \
   do {                                                                         \
-    x = ((buf)[0] << 24) | ((buf)[1] << 16) | ((buf)[2] << 8) | ((buf)[3]);    \
+    x = (int32_t)(                                                             \
+        ((uint32_t)((buf)[0]) << 24) | ((uint32_t)((buf)[1]) << 16) |          \
+        ((uint32_t)((buf)[2]) << 8) | ((uint32_t)((buf)[3])));                 \
   } while (0)
 
 /* Convert an integer on 32 bits to an octet string from aSN1c tool */

--- a/lte/gateway/c/oai/common/log.c
+++ b/lte/gateway/c/oai/common/log.c
@@ -297,19 +297,17 @@ static void get_thread_context(log_thread_ctxt_t** thread_ctxt) {
 }
 
 static int handle_message(zloop_t* loop, zsock_t* reader, void* arg) {
-  zframe_t* msg_frame = zframe_recv(reader);
-  assert(msg_frame);
-  MessageDef* received_message_p = (MessageDef*) zframe_data(msg_frame);
+  MessageDef* received_message_p = receive_msg(reader);
 
   switch (ITTI_MSG_ID(received_message_p)) {
     case TERMINATE_MESSAGE: {
-      zframe_destroy(&msg_frame);
+      free(received_message_p);
       log_exit();
     } break;
 
     default: { } break; }
 
-  zframe_destroy(&msg_frame);
+  free(received_message_p);
   return 0;
 }
 

--- a/lte/gateway/c/oai/common/shared_ts_log.c
+++ b/lte/gateway/c/oai/common/shared_ts_log.c
@@ -163,19 +163,17 @@ static int handle_timer(zloop_t* loop, int id, void* arg) {
 }
 
 static int handle_message(zloop_t* loop, zsock_t* reader, void* arg) {
-  zframe_t* msg_frame = zframe_recv(reader);
-  assert(msg_frame);
-  MessageDef* received_message_p = (MessageDef*) zframe_data(msg_frame);
+  MessageDef* received_message_p = receive_msg(reader);
 
   switch (ITTI_MSG_ID(received_message_p)) {
     case TERMINATE_MESSAGE: {
-      zframe_destroy(&msg_frame);
+      free(received_message_p);
       shared_log_exit();
     } break;
 
     default: { } break; }
 
-  zframe_destroy(&msg_frame);
+  free(received_message_p);
   return 0;
 }
 

--- a/lte/gateway/c/oai/lib/itti/intertask_interface.c
+++ b/lte/gateway/c/oai/lib/itti/intertask_interface.c
@@ -137,6 +137,19 @@ int send_msg_to_task(
   return 0;
 }
 
+MessageDef* receive_msg(zsock_t* reader) {
+  zframe_t* msg_frame = zframe_recv(reader);
+  assert(msg_frame);
+
+  // Copy message to avoid memory alignment problems
+  MessageDef* msg = (MessageDef*) malloc(zframe_size(msg_frame));
+  AssertFatal(msg != NULL, "Message memory allocation failed!\n");
+  memcpy(msg, zframe_data(msg_frame), zframe_size(msg_frame));
+
+  zframe_destroy(&msg_frame);
+  return msg;
+}
+
 void send_broadcast_msg(task_zmq_ctx_t* task_zmq_ctx_p, MessageDef* message) {
   zframe_t* frame = zframe_new(
       message, sizeof(MessageHeader) + message->ittiMsgHeader.ittiMsgSize);

--- a/lte/gateway/c/oai/lib/itti/intertask_interface.h
+++ b/lte/gateway/c/oai/lib/itti/intertask_interface.h
@@ -100,6 +100,12 @@ int send_msg_to_task(
     task_zmq_ctx_t* task_zmq_ctx_p, task_id_t destination_task_id,
     MessageDef* message);
 
+/** \brief Receive a message from zsock
+ \param reader Pointer to ZMQ socket
+ @returns Pointer to the message read (caller to free)
+ **/
+MessageDef* receive_msg(zsock_t* reader);
+
 /** \brief Start timer on the ZMQ loop
  \param task_zmq_ctx_p Pointer to task ZMQ context
  \param msec Timer duration in millisecond

--- a/lte/gateway/c/oai/lib/itti/itti_types.h
+++ b/lte/gateway/c/oai/lib/itti/itti_types.h
@@ -39,7 +39,8 @@
 #include <stdint.h>
 
 #define CHARS_TO_UINT32(c1, c2, c3, c4)                                        \
-  (((c4) << 24) | ((c3) << 16) | ((c2) << 8) | (c1))
+  ((((uint32_t) c4) << 24) | (((uint32_t) c3) << 16) |                         \
+   (((uint32_t) c2) << 8) | ((uint32_t) c1))
 
 #define MESSAGE_NUMBER_CHAR_FORMAT "%11u"
 

--- a/lte/gateway/c/oai/lib/itti/memory_pools.c
+++ b/lte/gateway/c/oai/lib/itti/memory_pools.c
@@ -46,7 +46,8 @@ const static int mp_debug = 0;
 
 /*------------------------------------------------------------------------------*/
 #define CHARS_TO_UINT32(c1, c2, c3, c4)                                        \
-  (((c1) << 24) | ((c2) << 16) | ((c3) << 8) | (c4))
+  ((((uint32_t) c1) << 24) | (((uint32_t) c2) << 16) |                         \
+   (((uint32_t) c3) << 8) | ((uint32_t) c4))
 
 #define MEMORY_POOL_ITEM_INFO_NUMBER 2
 

--- a/lte/gateway/c/oai/lib/message_utils/bytes_to_ie.c
+++ b/lte/gateway/c/oai/lib/message_utils/bytes_to_ie.c
@@ -60,7 +60,8 @@ void bytes_to_tmsi(const char* bytes, tmsi_t* tmsi) {
   unsigned char tmsi_3 = bytes[2];
   unsigned char tmsi_4 = bytes[3];
 
-  *tmsi = tmsi_1 << 24 | tmsi_2 << 16 | tmsi_3 << 8 | tmsi_4;
+  *tmsi = (((uint32_t) tmsi_1) << 24) | (((uint32_t) tmsi_2) << 16) |
+          (((uint32_t) tmsi_3) << 8) | ((uint32_t) tmsi_4);
 
   return;
 }

--- a/lte/gateway/c/oai/lib/secu/nas_stream_eia1.c
+++ b/lte/gateway/c/oai/lib/secu/nas_stream_eia1.c
@@ -17,7 +17,8 @@
 
 #include <stdint.h>
 #include <string.h>
-#include <math.h>  // double ceil(double x);
+#include <math.h>    // double ceil(double x);
+#include <stdlib.h>  // malloc, free
 
 #include "secu_defs.h"
 #include "conversions.h"
@@ -117,12 +118,13 @@ int nas_stream_encrypt_eia1(
   uint64_t c;
   uint64_t M_D_2;
   int rem_bits;
-  uint32_t mask = 0;
-  uint32_t* message;
+  uint32_t mask     = 0;
+  uint32_t* message = (uint32_t*) malloc(
+      sizeof(uint32_t) * ((stream_cipher->blength >> 5) + 1));
 
-  message =
-      (uint32_t*)
-          stream_cipher->message; /* To operate 32 bit message internally. */
+  /* copy message to avoid memory alignment issues */
+  memcpy(message, stream_cipher->message, ceil(stream_cipher->blength / 8.0));
+
   /*
    * Load the Integrity Key for SNOW3G initialization as in section 4.4.
    */
@@ -228,5 +230,6 @@ int nas_stream_encrypt_eia1(
   // printf ("MAC_I:%16X\n",MAC_I);
   MAC_I = hton_int32(MAC_I);
   memcpy((void*) out, &MAC_I, 4);
+  free(message);
   return 0;
 }

--- a/lte/gateway/c/oai/tasks/grpc_service/grpc_service_task.c
+++ b/lte/gateway/c/oai/tasks/grpc_service/grpc_service_task.c
@@ -36,13 +36,11 @@ static grpc_service_data_t* grpc_service_config;
 task_zmq_ctx_t grpc_service_task_zmq_ctx;
 
 static int handle_message(zloop_t* loop, zsock_t* reader, void* arg) {
-  zframe_t* msg_frame = zframe_recv(reader);
-  assert(msg_frame);
-  MessageDef* received_message_p = (MessageDef*) zframe_data(msg_frame);
+  MessageDef* received_message_p = receive_msg(reader);
 
   switch (ITTI_MSG_ID(received_message_p)) {
     case TERMINATE_MESSAGE:
-      zframe_destroy(&msg_frame);
+      free(received_message_p);
       grpc_service_exit();
       break;
     default:
@@ -52,7 +50,7 @@ static int handle_message(zloop_t* loop, zsock_t* reader, void* arg) {
       break;
   }
 
-  zframe_destroy(&msg_frame);
+  free(received_message_p);
   return 0;
 }
 

--- a/lte/gateway/c/oai/tasks/ha/ha_task.c
+++ b/lte/gateway/c/oai/tasks/ha/ha_task.c
@@ -39,9 +39,7 @@ static int handle_timer(zloop_t* loop, int id, void* arg) {
 }
 
 static int handle_message(zloop_t* loop, zsock_t* reader, void* arg) {
-  zframe_t* msg_frame = zframe_recv(reader);
-  assert(msg_frame);
-  MessageDef* received_message_p = (MessageDef*) zframe_data(msg_frame);
+  MessageDef* received_message_p = receive_msg(reader);
 
   switch (ITTI_MSG_ID(received_message_p)) {
     case AGW_OFFLOAD_REQ: {
@@ -54,7 +52,7 @@ static int handle_message(zloop_t* loop, zsock_t* reader, void* arg) {
 
     case TERMINATE_MESSAGE: {
       itti_free_msg_content(received_message_p);
-      zframe_destroy(&msg_frame);
+      free(received_message_p);
       ha_exit();
     } break;
 
@@ -65,7 +63,7 @@ static int handle_message(zloop_t* loop, zsock_t* reader, void* arg) {
     } break;
   }
   itti_free_msg_content(received_message_p);
-  zframe_destroy(&msg_frame);
+  free(received_message_p);
   return 0;
 }
 

--- a/lte/gateway/c/oai/tasks/mme_app/mme_app_main.c
+++ b/lte/gateway/c/oai/tasks/mme_app/mme_app_main.c
@@ -68,10 +68,7 @@ bool mme_sctp_bounded   = false;
 task_zmq_ctx_t mme_app_task_zmq_ctx;
 
 static int handle_message(zloop_t* loop, zsock_t* reader, void* arg) {
-  zframe_t* msg_frame = zframe_recv(reader);
-  assert(msg_frame);
-  MessageDef* received_message_p = (MessageDef*) zframe_data(msg_frame);
-
+  MessageDef* received_message_p = receive_msg(reader);
   imsi64_t imsi64                = itti_get_associated_imsi(received_message_p);
   mme_app_desc_t* mme_app_desc_p = get_mme_nas_state(false);
 
@@ -426,7 +423,7 @@ static int handle_message(zloop_t* loop, zsock_t* reader, void* arg) {
 
     case TERMINATE_MESSAGE: {
       itti_free_msg_content(received_message_p);
-      zframe_destroy(&msg_frame);
+      free(received_message_p);
       mme_app_exit();
     } break;
 
@@ -446,7 +443,7 @@ static int handle_message(zloop_t* loop, zsock_t* reader, void* arg) {
   put_mme_ue_state(mme_app_desc_p, imsi64);
 
   itti_free_msg_content(received_message_p);
-  zframe_destroy(&msg_frame);
+  free(received_message_p);
   return 0;
 }
 

--- a/lte/gateway/c/oai/tasks/nas/api/network/nas_message.c
+++ b/lte/gateway/c/oai/tasks/nas/api/network/nas_message.c
@@ -154,7 +154,10 @@ int nas_message_encrypt(
       /*
        * Set the message authentication code of the NAS message
        */
-      *(uint32_t*) (outbuf + sizeof(uint8_t)) = htonl(mac);
+      uint32_t network_mac = htonl(mac);
+      memcpy(
+          outbuf + sizeof(uint8_t), (unsigned char*) &network_mac,
+          sizeof(uint32_t));
     }
   } else {
     /*
@@ -573,7 +576,10 @@ int nas_message_encode(
       /*
        * Set the message authentication code of the NAS message
        */
-      *(uint32_t*) (buffer + sizeof(uint8_t)) = htonl(mac);
+      uint32_t network_mac = htonl(mac);
+      memcpy(
+          buffer + sizeof(uint8_t), (unsigned char*) &network_mac,
+          sizeof(uint32_t));
 
       if (emm_security_context) {
         /*

--- a/lte/gateway/c/oai/tasks/s11/s11_ie_formatter.c
+++ b/lte/gateway/c/oai/tasks/s11/s11_ie_formatter.c
@@ -1906,8 +1906,9 @@ nw_rc_t gtpv2c_fqcsid_ie_get(
       if (ieLength != 7) {
         return NW_GTPV2C_IE_INCORRECT;
       }
-      int addr = (ieValue[1] << 24) | (ieValue[2] << 16) | (ieValue[3] << 8) |
-                 (ieValue[4]);
+      int addr = (((uint32_t) ieValue[1]) << 24) |
+                 (((uint32_t) ieValue[2]) << 16) |
+                 (((uint32_t) ieValue[3]) << 8) | ((uint32_t) ieValue[4]);
       fq_csid->node_id.unicast_ipv4.s_addr = addr;
       fq_csid->csid                        = (ieValue[5] << 8) | ieValue[6];
       inet_ntop(

--- a/lte/gateway/c/oai/tasks/s11/s11_tasks.c
+++ b/lte/gateway/c/oai/tasks/s11/s11_tasks.c
@@ -195,9 +195,7 @@ static nw_rc_t s11_mme_stop_timer_wrapper(
 }
 
 static int handle_message(zloop_t* loop, zsock_t* reader, void* arg) {
-  zframe_t* msg_frame = zframe_recv(reader);
-  assert(msg_frame);
-  MessageDef* received_message_p = (MessageDef*) zframe_data(msg_frame);
+  MessageDef* received_message_p = receive_msg(reader);
 
   switch (ITTI_MSG_ID(received_message_p)) {
     case MESSAGE_TEST: {
@@ -249,7 +247,7 @@ static int handle_message(zloop_t* loop, zsock_t* reader, void* arg) {
 
     case TERMINATE_MESSAGE: {
       itti_free_msg_content(received_message_p);
-      zframe_destroy(&msg_frame);
+      free(received_message_p);
       s11_mme_exit();
     } break;
 
@@ -286,7 +284,7 @@ static int handle_message(zloop_t* loop, zsock_t* reader, void* arg) {
   }
 
   itti_free_msg_content(received_message_p);
-  zframe_destroy(&msg_frame);
+  free(received_message_p);
   return 0;
 }
 

--- a/lte/gateway/c/oai/tasks/s1ap/s1ap_mme.c
+++ b/lte/gateway/c/oai/tasks/s1ap/s1ap_mme.c
@@ -107,13 +107,9 @@ static int s1ap_send_init_sctp(void) {
 
 static int handle_message(zloop_t* loop, zsock_t* reader, void* arg) {
   s1ap_state_t* state;
-
-  zframe_t* msg_frame = zframe_recv(reader);
-  assert(msg_frame);
-  MessageDef* received_message_p = (MessageDef*) zframe_data(msg_frame);
-
-  imsi64_t imsi64 = itti_get_associated_imsi(received_message_p);
-  state           = get_s1ap_state(false);
+  MessageDef* received_message_p = receive_msg(reader);
+  imsi64_t imsi64                = itti_get_associated_imsi(received_message_p);
+  state                          = get_s1ap_state(false);
   AssertFatal(state != NULL, "failed to retrieve s1ap state (was null)");
 
   switch (ITTI_MSG_ID(received_message_p)) {
@@ -286,7 +282,7 @@ static int handle_message(zloop_t* loop, zsock_t* reader, void* arg) {
 
     case TERMINATE_MESSAGE: {
       itti_free_msg_content(received_message_p);
-      zframe_destroy(&msg_frame);
+      free(received_message_p);
       s1ap_mme_exit();
     } break;
 
@@ -301,7 +297,7 @@ static int handle_message(zloop_t* loop, zsock_t* reader, void* arg) {
   put_s1ap_imsi_map();
   put_s1ap_ue_state(imsi64);
   itti_free_msg_content(received_message_p);
-  zframe_destroy(&msg_frame);
+  free(received_message_p);
   return 0;
 }
 

--- a/lte/gateway/c/oai/tasks/s6a/s6a_task.c
+++ b/lte/gateway/c/oai/tasks/s6a/s6a_task.c
@@ -56,9 +56,7 @@ struct session_handler* ts_sess_hdl;
 task_zmq_ctx_t s6a_task_zmq_ctx;
 
 static int handle_message(zloop_t* loop, zsock_t* reader, void* arg) {
-  zframe_t* msg_frame = zframe_recv(reader);
-  assert(msg_frame);
-  MessageDef* received_message_p = (MessageDef*) zframe_data(msg_frame);
+  MessageDef* received_message_p = receive_msg(reader);
   int rc                         = RETURNerror;
 
   switch (ITTI_MSG_ID(received_message_p)) {
@@ -121,7 +119,7 @@ static int handle_message(zloop_t* loop, zsock_t* reader, void* arg) {
     } break;
     case TERMINATE_MESSAGE: {
       itti_free_msg_content(received_message_p);
-      zframe_destroy(&msg_frame);
+      free(received_message_p);
       s6a_exit();
     } break;
     default: {
@@ -132,7 +130,7 @@ static int handle_message(zloop_t* loop, zsock_t* reader, void* arg) {
   }
 
   itti_free_msg_content(received_message_p);
-  zframe_destroy(&msg_frame);
+  free(received_message_p);
   return 0;
 }
 

--- a/lte/gateway/c/oai/tasks/sctp/sctp_primitives_server.c
+++ b/lte/gateway/c/oai/tasks/sctp/sctp_primitives_server.c
@@ -56,9 +56,7 @@ sctp_config_t sctp_conf;
 task_zmq_ctx_t sctp_task_zmq_ctx;
 
 static int handle_message(zloop_t* loop, zsock_t* reader, void* arg) {
-  zframe_t* msg_frame = zframe_recv(reader);
-  assert(msg_frame);
-  MessageDef* received_message_p    = (MessageDef*) zframe_data(msg_frame);
+  MessageDef* received_message_p    = receive_msg(reader);
   static bool UPLINK_SERVER_STARTED = false;
 
   switch (ITTI_MSG_ID(received_message_p)) {
@@ -113,7 +111,7 @@ static int handle_message(zloop_t* loop, zsock_t* reader, void* arg) {
     } break;
     case TERMINATE_MESSAGE: {
       itti_free_msg_content(received_message_p);
-      zframe_destroy(&msg_frame);
+      free(received_message_p);
       sctp_exit();
     } break;
 
@@ -125,7 +123,7 @@ static int handle_message(zloop_t* loop, zsock_t* reader, void* arg) {
   }
 
   itti_free_msg_content(received_message_p);
-  zframe_destroy(&msg_frame);
+  free(received_message_p);
   return 0;
 }
 

--- a/lte/gateway/c/oai/tasks/service303/service303_task.c
+++ b/lte/gateway/c/oai/tasks/service303/service303_task.c
@@ -39,14 +39,12 @@ task_zmq_ctx_t service303_message_task_zmq_ctx;
 
 static int handle_service303_server_message(
     zloop_t* loop, zsock_t* reader, void* arg) {
-  zframe_t* msg_frame = zframe_recv(reader);
-  assert(msg_frame);
-  MessageDef* received_message_p = (MessageDef*) zframe_data(msg_frame);
+  MessageDef* received_message_p = receive_msg(reader);
 
   switch (ITTI_MSG_ID(received_message_p)) {
     case TERMINATE_MESSAGE:
       itti_free_msg_content(received_message_p);
-      zframe_destroy(&msg_frame);
+      free(received_message_p);
       service303_server_exit();
       break;
     default: {
@@ -57,7 +55,7 @@ static int handle_service303_server_message(
   }
 
   itti_free_msg_content(received_message_p);
-  zframe_destroy(&msg_frame);
+  free(received_message_p);
   return 0;
 }
 
@@ -77,9 +75,7 @@ static void* service303_server_thread(__attribute__((unused)) void* args) {
 }
 
 static int handle_service_message(zloop_t* loop, zsock_t* reader, void* arg) {
-  zframe_t* msg_frame = zframe_recv(reader);
-  assert(msg_frame);
-  MessageDef* received_message_p = (MessageDef*) zframe_data(msg_frame);
+  MessageDef* received_message_p = receive_msg(reader);
 
   switch (ITTI_MSG_ID(received_message_p)) {
     case TIMER_HAS_EXPIRED: {
@@ -105,7 +101,7 @@ static int handle_service_message(zloop_t* loop, zsock_t* reader, void* arg) {
       service303_set_application_health(APP_UNHEALTHY);
     } break;
     case TERMINATE_MESSAGE:
-      zframe_destroy(&msg_frame);
+      free(received_message_p);
       service303_message_exit();
       break;
     default: {
@@ -115,7 +111,7 @@ static int handle_service_message(zloop_t* loop, zsock_t* reader, void* arg) {
     } break;
   }
 
-  zframe_destroy(&msg_frame);
+  free(received_message_p);
   return 0;
 }
 

--- a/lte/gateway/c/oai/tasks/sgs/sgs_task.c
+++ b/lte/gateway/c/oai/tasks/sgs/sgs_task.c
@@ -39,9 +39,7 @@ static void sgs_exit(void);
 task_zmq_ctx_t sgs_task_zmq_ctx;
 
 static int handle_message(zloop_t* loop, zsock_t* reader, void* arg) {
-  zframe_t* msg_frame = zframe_recv(reader);
-  assert(msg_frame);
-  MessageDef* received_message_p = (MessageDef*) zframe_data(msg_frame);
+  MessageDef* received_message_p = receive_msg(reader);
 
   switch (ITTI_MSG_ID(received_message_p)) {
     case SGSAP_LOCATION_UPDATE_REQ: {
@@ -158,7 +156,7 @@ static int handle_message(zloop_t* loop, zsock_t* reader, void* arg) {
       send_ue_unreachable(&SGSAP_UE_UNREACHABLE(received_message_p));
     } break;
     case TERMINATE_MESSAGE: {
-      zframe_destroy(&msg_frame);
+      free(received_message_p);
       sgs_exit();
     } break;
 
@@ -169,7 +167,7 @@ static int handle_message(zloop_t* loop, zsock_t* reader, void* arg) {
     } break;
   }
 
-  zframe_destroy(&msg_frame);
+  free(received_message_p);
   return 0;
 }
 

--- a/lte/gateway/c/oai/tasks/sgw/sgw_handlers.c
+++ b/lte/gateway/c/oai/tasks/sgw/sgw_handlers.c
@@ -1964,10 +1964,11 @@ static void _generate_dl_flow(
     if ((TRAFFIC_FLOW_TEMPLATE_IPV4_REMOTE_ADDR_FLAG & packet_filter->flags) ==
         TRAFFIC_FLOW_TEMPLATE_IPV4_REMOTE_ADDR_FLAG) {
       struct in_addr remoteaddr = {.s_addr = 0};
-      remoteaddr.s_addr = (packet_filter->ipv4remoteaddr[0].addr << 24) +
-                          (packet_filter->ipv4remoteaddr[1].addr << 16) +
-                          (packet_filter->ipv4remoteaddr[2].addr << 8) +
-                          packet_filter->ipv4remoteaddr[3].addr;
+      remoteaddr.s_addr =
+          (((uint32_t) packet_filter->ipv4remoteaddr[0].addr) << 24) +
+          (((uint32_t) packet_filter->ipv4remoteaddr[1].addr) << 16) +
+          (((uint32_t) packet_filter->ipv4remoteaddr[2].addr) << 8) +
+          (((uint32_t) packet_filter->ipv4remoteaddr[3].addr));
       dlflow->src_ip.s_addr = ntohl(remoteaddr.s_addr);
       dlflow->set_params |= SRC_IPV4;
       dlflow->dst_ip.s_addr = ipv4_s_addr;
@@ -1990,10 +1991,11 @@ static void _generate_dl_flow(
     if ((TRAFFIC_FLOW_TEMPLATE_IPV4_REMOTE_ADDR_FLAG & packet_filter->flags) ==
         TRAFFIC_FLOW_TEMPLATE_IPV4_REMOTE_ADDR_FLAG) {
       struct in_addr remoteaddr = {.s_addr = 0};
-      remoteaddr.s_addr = (packet_filter->ipv4remoteaddr[0].addr << 24) +
-                          (packet_filter->ipv4remoteaddr[1].addr << 16) +
-                          (packet_filter->ipv4remoteaddr[2].addr << 8) +
-                          packet_filter->ipv4remoteaddr[3].addr;
+      remoteaddr.s_addr =
+          (((uint32_t) packet_filter->ipv4remoteaddr[0].addr) << 24) +
+          (((uint32_t) packet_filter->ipv4remoteaddr[1].addr) << 16) +
+          (((uint32_t) packet_filter->ipv4remoteaddr[2].addr) << 8) +
+          (((uint32_t) packet_filter->ipv4remoteaddr[3].addr));
       dlflow->src_ip.s_addr = ntohl(remoteaddr.s_addr);
       dlflow->set_params |= SRC_IPV4;
     }

--- a/lte/gateway/c/oai/tasks/sgw/sgw_task.c
+++ b/lte/gateway/c/oai/tasks/sgw/sgw_task.c
@@ -54,9 +54,7 @@ task_zmq_ctx_t spgw_app_task_zmq_ctx;
 extern __pid_t g_pid;
 
 static int handle_message(zloop_t* loop, zsock_t* reader, void* arg) {
-  zframe_t* msg_frame = zframe_recv(reader);
-  assert(msg_frame);
-  MessageDef* received_message_p = (MessageDef*) zframe_data(msg_frame);
+  MessageDef* received_message_p = receive_msg(reader);
 
   imsi64_t imsi64          = itti_get_associated_imsi(received_message_p);
   spgw_state_t* spgw_state = get_spgw_state(false);
@@ -167,7 +165,7 @@ static int handle_message(zloop_t* loop, zsock_t* reader, void* arg) {
     } break;
     case TERMINATE_MESSAGE: {
       itti_free_msg_content(received_message_p);
-      zframe_destroy(&msg_frame);
+      free(received_message_p);
       spgw_app_exit();
     } break;
 
@@ -182,7 +180,7 @@ static int handle_message(zloop_t* loop, zsock_t* reader, void* arg) {
   put_spgw_ue_state(spgw_state, imsi64);
 
   itti_free_msg_content(received_message_p);
-  zframe_destroy(&msg_frame);
+  free(received_message_p);
   return 0;
 }
 

--- a/lte/gateway/c/oai/tasks/sms_orc8r/sms_orc8r_task.c
+++ b/lte/gateway/c/oai/tasks/sms_orc8r/sms_orc8r_task.c
@@ -39,9 +39,7 @@ static void sms_orc8r_exit(void);
 task_zmq_ctx_t sms_orc8r_task_zmq_ctx;
 
 static int handle_message(zloop_t* loop, zsock_t* reader, void* arg) {
-  zframe_t* msg_frame = zframe_recv(reader);
-  assert(msg_frame);
-  MessageDef* received_message_p = (MessageDef*) zframe_data(msg_frame);
+  MessageDef* received_message_p = receive_msg(reader);
 
   switch (ITTI_MSG_ID(received_message_p)) {
     case SGSAP_UPLINK_UNITDATA: {
@@ -57,7 +55,7 @@ static int handle_message(zloop_t* loop, zsock_t* reader, void* arg) {
     } break;
 
     case TERMINATE_MESSAGE: {
-      zframe_destroy(&msg_frame);
+      free(received_message_p);
       sms_orc8r_exit();
     } break;
 
@@ -68,7 +66,7 @@ static int handle_message(zloop_t* loop, zsock_t* reader, void* arg) {
     } break;
   }
 
-  zframe_destroy(&msg_frame);
+  free(received_message_p);
   return 0;
 }
 

--- a/lte/gateway/c/oai/tasks/udp/udp_primitives_server.c
+++ b/lte/gateway/c/oai/tasks/udp/udp_primitives_server.c
@@ -361,9 +361,7 @@ static int udp_server_create_socket_v6(
 }
 
 static int handle_message(zloop_t* loop, zsock_t* reader, void* arg) {
-  zframe_t* msg_frame = zframe_recv(reader);
-  assert(msg_frame);
-  MessageDef* received_message_p = (MessageDef*) zframe_data(msg_frame);
+  MessageDef* received_message_p = receive_msg(reader);
 
   switch (ITTI_MSG_ID(received_message_p)) {
     case MESSAGE_TEST: {
@@ -372,7 +370,7 @@ static int handle_message(zloop_t* loop, zsock_t* reader, void* arg) {
 
     case TERMINATE_MESSAGE: {
       itti_free_msg_content(received_message_p);
-      zframe_destroy(&msg_frame);
+      free(received_message_p);
       udp_exit();
     } break;
 
@@ -499,7 +497,7 @@ static int handle_message(zloop_t* loop, zsock_t* reader, void* arg) {
   }
 
   itti_free_msg_content(received_message_p);
-  zframe_destroy(&msg_frame);
+  free(received_message_p);
   return 0;
 }
 


### PR DESCRIPTION
Signed-off-by: Tariq Al-Khasib <talkhasib@fb.com>

## Summary

Enable UBSAN for debug builds (sanitize=undefined)
Once enabled, it uncovered many unaligned memory access problems.
- ZMQ received message needs to be copied to avoid unaligned memory access.
- Use memcpy() instead of casting memory addresses in few places
- Potential overflow when performing left shifts on bytes

sample logs
```
intertask_interface.c:407:48: runtime error: member access within misaligned address 0x629000163206 for type 'struct MessageDef', which requires 8 byte alignment
mme_app_main.c:78:11: runtime error: member access within misaligned address 0x629000163206 for type 'struct MessageDef', which requires 8 byte alignment
nas_message.c:729:9: runtime error: load of misaligned address 0x60200003c991 for type 'uint32_t', which requires 4 byte alignment
nas_stream_eia1.c:194:31: runtime error: load of misaligned address 0x603000ec0ef5 for type 'uint32_t', which requires 4 byte alignment
```


## Test Plan
fab integ_test
