### PR TITLE
[agw][lte] Adding checks for health service enable and disable on S1AP wrapper

### DIFF
--- a/lte/gateway/python/integ_tests/s1aptests/s1ap_wrapper.py
+++ b/lte/gateway/python/integ_tests/s1aptests/s1ap_wrapper.py
@@ -58,6 +58,7 @@ class TestWrapper(object):
         self,
         stateless_mode=MagmadUtil.stateless_cmds.ENABLE,
         apn_correction=MagmadUtil.apn_correction_cmds.DISABLE,
+        health_service=MagmadUtil.health_service_cmds.DISABLE,
     ):
         """
         Initialize the various classes required by the tests and setup.
@@ -85,6 +86,7 @@ class TestWrapper(object):
         self._magmad_util = MagmadUtil(magmad_client)
         self._magmad_util.config_stateless(stateless_mode)
         self._magmad_util.config_apn_correction(apn_correction)
+        self._magmad_util.config_health_service(health_service)
         # gateway tests don't require restart, just wait for healthy now
         self._gateway_services = GatewayServicesUtil()
         if not self.wait_gateway_healthy:

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_with_corrupt_stateless_mme.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_with_corrupt_stateless_mme.py
@@ -23,7 +23,8 @@ class TestAttachDetachWithCorruptStatelessMME(unittest.TestCase):
 
     def setUp(self):
         self._s1ap_wrapper = s1ap_wrapper.TestWrapper(
-            stateless_mode=MagmadUtil.stateless_cmds.ENABLE)
+            stateless_mode=MagmadUtil.stateless_cmds.ENABLE,
+            health_service=MagmadUtil.stateless_cmds.ENABLE)
 
     def tearDown(self):
         self._s1ap_wrapper.cleanup()

--- a/lte/gateway/python/integ_tests/s1aptests/test_modify_mme_config_for_sanity.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_modify_mme_config_for_sanity.py
@@ -37,8 +37,5 @@ class TestModifyMMEConfigForSanity(unittest.TestCase):
         print("Restarting services to apply configuration change")
         self._magmad_util.restart_all_services()
 
-        print("Stopping and disabling magma@health service")
-        self._magmad_util.disable_service("health")
-
 if __name__ == "__main__":
     unittest.main()

--- a/lte/gateway/python/integ_tests/s1aptests/test_restore_mme_config_after_sanity.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_restore_mme_config_after_sanity.py
@@ -38,8 +38,5 @@ class TestRestoreMMEConfigAfterSanity(unittest.TestCase):
             MagmadUtil.config_update_cmds.RESTORE
         )
 
-        print("Enabling magma@health service")
-        self._magmad_util.enable_service("health")
-
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Signed-off-by: Alex Rodriguez <alexrod@fb.com>

## Summary

- Adding health service ENABLE / DISABLE cmds on s1ap_wrapper, default is DISABLE for s1ap tests.
- Enabling health service for s1ap test `test_attach_detach_with_corrupt_stateteless_mme` (state recovery test)

## Test Plan

- make integ_test, to ensure health service is disabled on most tests
- running individual state recovery test to ensure health service is activated

## Additional Information

- [ ] This change is backwards-breaking

