### PR TITLE
[agw] Fix the service_restart_status metric to be a counter instead of a gauge

### DIFF
--- a/orc8r/gateway/python/magma/magmad/metrics.py
+++ b/orc8r/gateway/python/magma/magmad/metrics.py
@@ -58,7 +58,7 @@ UNATTENDED_UPGRADE_STATUS = Gauge('unattended_upgrade_status',
                                   '1 for active, 0 for inactive')
 
 
-SERVICE_RESTART_STATUS = Gauge('service_restart_status',
+SERVICE_RESTART_STATUS = Counter('service_restart_status',
                                'Count of service restarts',
                                ['service_name', 'status'])
 


### PR DESCRIPTION
Resolves #3623

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary

Fix the service_restart_status metric to be a counter instead of a gauge as requested in #3623.


