### PR TITLE
[AGW][MME] Reset num_ues_checked while cleaning up UE state for each eNB

### DIFF
--- a/lte/gateway/c/oai/tasks/s1ap/s1ap_mme_handlers.c
+++ b/lte/gateway/c/oai/tasks/s1ap/s1ap_mme_handlers.c
@@ -325,8 +325,7 @@ void clean_stale_enb_state(
   enb_description_t* stale_enb_association = NULL;
 
   hashtable_ts_apply_callback_on_elements(
-      (hash_table_ts_t* const) & state->enbs,
-      get_stale_enb_connection_with_enb_id, new_enb_association,
+      &state->enbs, get_stale_enb_connection_with_enb_id, new_enb_association,
       (void**) &stale_enb_association);
   if (stale_enb_association == NULL) {
     // No stale eNB connection found;

--- a/lte/gateway/c/oai/tasks/s1ap/s1ap_state.cpp
+++ b/lte/gateway/c/oai/tasks/s1ap/s1ap_state.cpp
@@ -188,7 +188,7 @@ void remove_ues_without_imsi_from_ue_id_coll() {
 
   hashtable_rc_t ht_rc;
   hash_key_t* mme_ue_id_no_imsi_list;
-  uint32_t num_ues_checked = 0;
+  uint32_t num_ues_checked;
 
   // get each eNB in s1ap_state
   for (uint32_t i = 0; i < ht_keys->num_keys; i++) {
@@ -206,6 +206,7 @@ void remove_ues_without_imsi_from_ue_id_coll() {
 
     // for each ue comp_s1ap_id in eNB->ue_id_coll, check if it has an S1ap
     // ue_context, if not delete it
+    num_ues_checked        = 0;
     mme_ue_id_no_imsi_list = (hash_key_t*) calloc(
         enb_association_p->ue_id_coll.num_elements, sizeof(hash_key_t));
     hashtable_uint64_ts_apply_callback_on_elements(


### PR DESCRIPTION
Signed-off-by: Shruti Sanadhya <ssanadhya@fb.com>

## Summary

The scaled test on Spirent with v1.4 were repeatedly crashing after https://github.com/magma/magma/pull/5091, where MME was hitting the DevAssert https://github.com/magma/magma/blob/master/lte/gateway/c/oai/tasks/s1ap/s1ap_mme.c#L515. This change fixes the `num_ues_checked` counter for multiple eNB scenarios so that `nb_ue_associated` is not decremented incorrectly. 

Also made a minor formatting clean-up.

## Test Plan

- make integ_test
- Spirent scaled test with 200UEs connecting over 6 eNBs, ran for 5 iterations without reporting a crash.

