### PR TITLE
[SessionD] Sync ue_traffic metrics counter value with persisted usage value on service restart

### DIFF
--- a/lte/gateway/c/session_manager/MeteringReporter.cpp
+++ b/lte/gateway/c/session_manager/MeteringReporter.cpp
@@ -53,6 +53,13 @@ void MeteringReporter::report_usage(
   report_download(imsi, session_id, total_rx);
 }
 
+void MeteringReporter::initialize_usage(
+    const std::string& imsi, const std::string& session_id,
+    SessionCredit::TotalCreditUsage usage) {
+  report_upload(imsi, session_id, usage.monitoring_tx + usage.charging_tx);
+  report_download(imsi, session_id, usage.monitoring_rx + usage.charging_rx);
+}
+
 void MeteringReporter::report_upload(
     const std::string& imsi, const std::string& session_id,
     double unreported_usage_bytes) {

--- a/lte/gateway/c/session_manager/MeteringReporter.h
+++ b/lte/gateway/c/session_manager/MeteringReporter.h
@@ -13,6 +13,7 @@
 #pragma once
 
 #include "StoredState.h"
+#include "SessionCredit.h"
 
 namespace magma {
 namespace lte {
@@ -28,6 +29,16 @@ class MeteringReporter {
   void report_usage(
       const std::string& imsi, const std::string& session_id,
       SessionStateUpdateCriteria& update_criteria);
+
+  /**
+   * Reports the usage as described in TotalCreditUsage
+   * This function is intended to be used on service restart to offset the
+   * counter value. TotalCreditUsage contains the cumulative usage since the
+   * start, not a delta value.
+   */
+  void initialize_usage(
+      const std::string& imsi, const std::string& session_id,
+      SessionCredit::TotalCreditUsage usage);
 
  private:
   /**

--- a/lte/gateway/c/session_manager/SessionCredit.h
+++ b/lte/gateway/c/session_manager/SessionCredit.h
@@ -35,6 +35,14 @@ class SessionCredit {
     uint64_t time_of_last_usage;
   };
 
+  // TODO refactor to use the Usage struct above
+  struct TotalCreditUsage {
+    uint64_t monitoring_tx;
+    uint64_t monitoring_rx;
+    uint64_t charging_tx;
+    uint64_t charging_rx;
+  };
+
   SessionCredit();
 
   SessionCredit(ServiceState start_state);

--- a/lte/gateway/c/session_manager/SessionEvents.cpp
+++ b/lte/gateway/c/session_manager/SessionEvents.cpp
@@ -213,14 +213,15 @@ void EventsReporterImpl::session_terminated(
   event.set_event_type(SESSION_TERMINATED_EV);
   event.set_tag(imsi);
 
-  folly::dynamic event_value           = folly::dynamic::object;
-  event_value[IMSI]                    = imsi;
-  event_value[IP_ADDR]                 = session_cfg.common_context.ue_ipv4();
-  event_value[IPV6_ADDR]               = session_cfg.common_context.ue_ipv6();
-  event_value[MSISDN]                  = session_cfg.common_context.msisdn();
-  event_value[APN]                     = session_cfg.common_context.apn();
-  event_value[SESSION_ID]              = session->get_session_id();
-  SessionState::TotalCreditUsage usage = session->get_total_credit_usage();
+  folly::dynamic event_value = folly::dynamic::object;
+  event_value[IMSI]          = imsi;
+  event_value[IP_ADDR]       = session_cfg.common_context.ue_ipv4();
+  event_value[IPV6_ADDR]     = session_cfg.common_context.ue_ipv6();
+  event_value[MSISDN]        = session_cfg.common_context.msisdn();
+  event_value[APN]           = session_cfg.common_context.apn();
+  event_value[SESSION_ID]    = session->get_session_id();
+
+  SessionCredit::TotalCreditUsage usage = session->get_total_credit_usage();
   event_value[TOTAL_TX]       = usage.charging_tx + usage.monitoring_tx;
   event_value[TOTAL_RX]       = usage.charging_rx + usage.monitoring_rx;
   event_value[CHARGING_TX]    = usage.charging_tx;

--- a/lte/gateway/c/session_manager/SessionState.cpp
+++ b/lte/gateway/c/session_manager/SessionState.cpp
@@ -764,7 +764,7 @@ ChargingCreditSummaries SessionState::get_charging_credit_summaries() {
   return charging_credit_summaries;
 }
 
-SessionState::TotalCreditUsage SessionState::get_total_credit_usage() {
+SessionCredit::TotalCreditUsage SessionState::get_total_credit_usage() {
   // Collate unique charging/monitoring keys used by rules
   std::unordered_set<CreditKey, decltype(&ccHash), decltype(&ccEqual)>
       used_charging_keys(4, ccHash, ccEqual);
@@ -787,14 +787,17 @@ SessionState::TotalCreditUsage SessionState::get_total_credit_usage() {
       bool should_track_monitoring_key =
           rules.get_monitoring_key_for_rule_id(rule_id, &monitoring_key);
 
-      if (should_track_charging_key) used_charging_keys.insert(charging_key);
-      if (should_track_monitoring_key)
+      if (should_track_charging_key) {
+        used_charging_keys.insert(charging_key);
+      }
+      if (should_track_monitoring_key) {
         used_monitoring_keys.insert(monitoring_key);
+      }
     }
   }
 
   // Sum up usage
-  TotalCreditUsage usage{
+  SessionCredit::TotalCreditUsage usage{
       .monitoring_tx = 0,
       .monitoring_rx = 0,
       .charging_tx   = 0,

--- a/lte/gateway/c/session_manager/SessionState.h
+++ b/lte/gateway/c/session_manager/SessionState.h
@@ -129,13 +129,6 @@ class SessionState {
 
   magma::lte::Fsm_state_FsmState get_proto_fsm_state();
 
-  struct TotalCreditUsage {
-    uint64_t monitoring_tx;
-    uint64_t monitoring_rx;
-    uint64_t charging_tx;
-    uint64_t charging_rx;
-  };
-
  public:
   SessionState(
       const std::string& imsi, const std::string& session_id,
@@ -255,7 +248,7 @@ class SessionState {
    * rules (static and dynamic)
    * Should be called after complete_termination.
    */
-  TotalCreditUsage get_total_credit_usage();
+  SessionCredit::TotalCreditUsage get_total_credit_usage();
 
   ChargingCreditSummaries get_charging_credit_summaries();
 

--- a/lte/gateway/c/session_manager/SessionStore.cpp
+++ b/lte/gateway/c/session_manager/SessionStore.cpp
@@ -19,17 +19,20 @@
 namespace magma {
 namespace lte {
 
-SessionStore::SessionStore(std::shared_ptr<StaticRuleStore> rule_store)
+SessionStore::SessionStore(
+    std::shared_ptr<StaticRuleStore> rule_store,
+    std::shared_ptr<magma::MeteringReporter> metering_reporter)
     : rule_store_(rule_store),
       store_client_(std::make_shared<MemoryStoreClient>(rule_store)),
-      metering_reporter_(std::make_shared<MeteringReporter>()) {}
+      metering_reporter_(metering_reporter) {}
 
 SessionStore::SessionStore(
     std::shared_ptr<StaticRuleStore> rule_store,
+    std::shared_ptr<magma::MeteringReporter> metering_reporter,
     std::shared_ptr<RedisStoreClient> store_client)
     : rule_store_(rule_store),
       store_client_(store_client),
-      metering_reporter_(std::make_shared<MeteringReporter>()) {}
+      metering_reporter_(metering_reporter) {}
 
 bool SessionStore::raw_write_sessions(SessionMap session_map) {
   // return true;
@@ -170,6 +173,8 @@ bool SessionStore::update_sessions(const SessionUpdate& update_criteria) {
         if (!(*it2)->apply_update_criteria(update)) {
           return false;
         }
+        // TODO pull the metering logic out of SessionStore. SessionStore should
+        // only handle logic relating to storage/search.
         metering_reporter_->report_usage(imsi, session_id, update);
 
         if (update.is_session_ended) {
@@ -183,6 +188,24 @@ bool SessionStore::update_sessions(const SessionUpdate& update_criteria) {
     }
   }
   return store_client_->write_sessions(std::move(session_map));
+}
+
+void SessionStore::initialize_metering_counter() {
+  auto session_map = store_client_->read_all_sessions();
+  for (auto& sessions_by_imsi : session_map) {
+    const std::string imsi = sessions_by_imsi.first;
+    for (auto& session : sessions_by_imsi.second) {
+      const std::string session_id = session->get_session_id();
+      auto total_usage             = session->get_total_credit_usage();
+      MLOG(MDEBUG) << "Initializing metering metrics on startup for "
+                   << session_id
+                   << ", monitoring: {tx=" << total_usage.monitoring_tx
+                   << ", rx=" << total_usage.monitoring_rx
+                   << "}, charging: {tx=" << total_usage.charging_tx
+                   << ", rx=" << total_usage.charging_rx << "}";
+      metering_reporter_->initialize_usage(imsi, session_id, total_usage);
+    }
+  }
 }
 
 optional<SessionVector::iterator> SessionStore::find_session(

--- a/lte/gateway/c/session_manager/SessionStore.h
+++ b/lte/gateway/c/session_manager/SessionStore.h
@@ -80,10 +80,13 @@ class SessionStore {
  public:
   static SessionUpdate get_default_session_update(SessionMap& session_map);
 
-  SessionStore(std::shared_ptr<StaticRuleStore> rule_store);
+  SessionStore(
+      std::shared_ptr<StaticRuleStore> rule_store,
+      std::shared_ptr<magma::MeteringReporter> metering_reporter);
 
   SessionStore(
       std::shared_ptr<StaticRuleStore> rule_store,
+      std::shared_ptr<magma::MeteringReporter> metering_reporter,
       std::shared_ptr<RedisStoreClient> store_client);
 
   /**
@@ -186,6 +189,13 @@ class SessionStore {
    */
   optional<SessionVector::iterator> find_session(
       SessionMap& session_map, SessionSearchCriteria criteria);
+
+  // TODO move this logic outside of this class into MeteringReporter
+  /**
+   * This function loops through all sessions and propagates the total usage to
+   * metering_reporter
+   */
+  void initialize_metering_counter();
 
  private:
   std::shared_ptr<StaticRuleStore> rule_store_;

--- a/lte/gateway/c/session_manager/sessiond_main.cpp
+++ b/lte/gateway/c/session_manager/sessiond_main.cpp
@@ -133,7 +133,8 @@ void set_consts(const YAML::Node& config) {
 
 magma::SessionStore* create_session_store(
     const YAML::Node& config,
-    std::shared_ptr<magma::StaticRuleStore> rule_store) {
+    std::shared_ptr<magma::StaticRuleStore> rule_store,
+    std::shared_ptr<magma::MeteringReporter> metering_reporter) {
   bool is_stateless = config["support_stateless"].IsDefined() &&
                       config["support_stateless"].as<bool>();
   if (is_stateless) {
@@ -147,10 +148,10 @@ magma::SessionStore* create_session_store(
       std::this_thread::sleep_for(std::chrono::milliseconds(100));
     } while (!connected);
     MLOG(MINFO) << "Successfully connected to Redis";
-    return new magma::SessionStore(rule_store, store_client);
+    return new magma::SessionStore(rule_store, metering_reporter, store_client);
   } else {
     MLOG(MINFO) << "Session store in memory";
-    return new magma::SessionStore(rule_store);
+    return new magma::SessionStore(rule_store, metering_reporter);
   }
 }
 
@@ -262,7 +263,12 @@ int main(int argc, char* argv[]) {
   });
 
   // Case on stateless config, setup the appropriate store client
-  magma::SessionStore* session_store = create_session_store(config, rule_store);
+  auto metering_reporter = std::make_shared<magma::MeteringReporter>();
+  magma::SessionStore* session_store =
+      create_session_store(config, rule_store, metering_reporter);
+  // service restart clears the UE metering metrics, so we need to offset
+  // metering_reporter with existing usage
+  session_store->initialize_metering_counter();
 
   // Some setup work for the SessionCredit class
   set_consts(config);

--- a/lte/gateway/c/session_manager/test/test_local_enforcer.cpp
+++ b/lte/gateway/c/session_manager/test/test_local_enforcer.cpp
@@ -47,9 +47,10 @@ Teids teids2;
 class LocalEnforcerTest : public ::testing::Test {
  protected:
   virtual void SetUp() {
-    reporter             = std::make_shared<MockSessionReporter>();
-    rule_store           = std::make_shared<StaticRuleStore>();
-    session_store        = std::make_shared<SessionStore>(rule_store);
+    reporter      = std::make_shared<MockSessionReporter>();
+    rule_store    = std::make_shared<StaticRuleStore>();
+    session_store = std::make_shared<SessionStore>(
+        rule_store, std::make_shared<MeteringReporter>());
     pipelined_client     = std::make_shared<MockPipelinedClient>();
     directoryd_client    = std::make_shared<MockDirectorydClient>();
     spgw_client          = std::make_shared<MockSpgwServiceClient>();

--- a/lte/gateway/c/session_manager/test/test_local_enforcer_wallet_exhaust.cpp
+++ b/lte/gateway/c/session_manager/test/test_local_enforcer_wallet_exhaust.cpp
@@ -43,9 +43,10 @@ Teids teids0;
 class LocalEnforcerTest : public ::testing::Test {
  protected:
   void SetUpWithMConfig(magma::mconfig::SessionD mconfig) {
-    reporter          = std::make_shared<MockSessionReporter>();
-    rule_store        = std::make_shared<StaticRuleStore>();
-    session_store     = std::make_shared<SessionStore>(rule_store);
+    reporter      = std::make_shared<MockSessionReporter>();
+    rule_store    = std::make_shared<StaticRuleStore>();
+    session_store = std::make_shared<SessionStore>(
+        rule_store, std::make_shared<MeteringReporter>());
     pipelined_client  = std::make_shared<MockPipelinedClient>();
     directoryd_client = std::make_shared<MockDirectorydClient>();
     spgw_client       = std::make_shared<MockSpgwServiceClient>();

--- a/lte/gateway/c/session_manager/test/test_proxy_responder_handler.cpp
+++ b/lte/gateway/c/session_manager/test/test_proxy_responder_handler.cpp
@@ -49,9 +49,10 @@ class SessionProxyResponderHandlerTest : public ::testing::Test {
     monitoring_key = "mk1";
     rule_id        = "test_rule_1";
 
-    reporter               = std::make_shared<MockSessionReporter>();
-    auto rule_store        = std::make_shared<StaticRuleStore>();
-    session_store          = std::make_shared<SessionStore>(rule_store);
+    reporter        = std::make_shared<MockSessionReporter>();
+    auto rule_store = std::make_shared<StaticRuleStore>();
+    session_store   = std::make_shared<SessionStore>(
+        rule_store, std::make_shared<MeteringReporter>());
     pipelined_client       = std::make_shared<MockPipelinedClient>();
     auto directoryd_client = std::make_shared<MockDirectorydClient>();
     auto spgw_client       = std::make_shared<MockSpgwServiceClient>();

--- a/lte/gateway/c/session_manager/test/test_session_manager_handler.cpp
+++ b/lte/gateway/c/session_manager/test/test_session_manager_handler.cpp
@@ -26,6 +26,7 @@
 #include "ServiceRegistrySingleton.h"
 #include "SessionState.h"
 #include "SessionStore.h"
+#include "MeteringReporter.h"
 #include "SessiondMocks.h"
 #include "StoredState.h"
 #include "magma_logging.h"
@@ -42,9 +43,10 @@ class SessionManagerHandlerTest : public ::testing::Test {
   virtual void SetUp() {
     monitoring_key = "mk1";
 
-    reporter               = std::make_shared<MockSessionReporter>();
-    rule_store             = std::make_shared<StaticRuleStore>();
-    session_store          = std::make_shared<SessionStore>(rule_store);
+    reporter      = std::make_shared<MockSessionReporter>();
+    rule_store    = std::make_shared<StaticRuleStore>();
+    session_store = std::make_shared<SessionStore>(
+        rule_store, std::make_shared<MeteringReporter>());
     pipelined_client       = std::make_shared<MockPipelinedClient>();
     auto directoryd_client = std::make_shared<MockDirectorydClient>();
     auto spgw_client       = std::make_shared<MockSpgwServiceClient>();

--- a/lte/gateway/c/session_manager/test/test_session_state.cpp
+++ b/lte/gateway/c/session_manager/test/test_session_state.cpp
@@ -591,7 +591,7 @@ TEST_F(SessionStateTest, test_tgpp_context_is_set_on_update) {
 TEST_F(SessionStateTest, test_get_total_credit_usage_single_rule_no_key) {
   insert_rule(0, "", "rule1", STATIC, 0, 0);
   session_state->add_rule_usage("rule1", 2000, 1000, 0, 0, update_criteria);
-  SessionState::TotalCreditUsage actual =
+  SessionCredit::TotalCreditUsage actual =
       session_state->get_total_credit_usage();
   EXPECT_EQ(actual.monitoring_tx, 0);
   EXPECT_EQ(actual.monitoring_rx, 0);
@@ -603,7 +603,7 @@ TEST_F(SessionStateTest, test_get_total_credit_usage_single_rule_single_key) {
   insert_rule(1, "", "rule1", STATIC, 0, 0);
   receive_credit_from_ocs(1, 3000);
   session_state->add_rule_usage("rule1", 2000, 1000, 0, 0, update_criteria);
-  SessionState::TotalCreditUsage actual =
+  SessionCredit::TotalCreditUsage actual =
       session_state->get_total_credit_usage();
   EXPECT_EQ(actual.monitoring_tx, 0);
   EXPECT_EQ(actual.monitoring_rx, 0);
@@ -616,7 +616,7 @@ TEST_F(SessionStateTest, test_get_total_credit_usage_single_rule_multiple_key) {
   receive_credit_from_ocs(1, 3000);
   receive_credit_from_pcrf("m1", 3000, MonitoringLevel::PCC_RULE_LEVEL);
   session_state->add_rule_usage("rule1", 2000, 1000, 0, 0, update_criteria);
-  SessionState::TotalCreditUsage actual =
+  SessionCredit::TotalCreditUsage actual =
       session_state->get_total_credit_usage();
   EXPECT_EQ(actual.monitoring_tx, 2000);
   EXPECT_EQ(actual.monitoring_rx, 1000);
@@ -633,7 +633,7 @@ TEST_F(SessionStateTest, test_get_total_credit_usage_multiple_rule_shared_key) {
   receive_credit_from_pcrf("m1", 3000, MonitoringLevel::PCC_RULE_LEVEL);
   session_state->add_rule_usage("rule1", 1000, 10, 0, 0, update_criteria);
   session_state->add_rule_usage("rule2", 500, 5, 0, 0, update_criteria);
-  SessionState::TotalCreditUsage actual =
+  SessionCredit::TotalCreditUsage actual =
       session_state->get_total_credit_usage();
   EXPECT_EQ(actual.monitoring_tx, 1500);
   EXPECT_EQ(actual.monitoring_rx, 15);

--- a/lte/gateway/c/session_manager/test/test_sessiond_integ.cpp
+++ b/lte/gateway/c/session_manager/test/test_sessiond_integ.cpp
@@ -58,7 +58,8 @@ class SessiondTest : public ::testing::Test {
     spgw_client       = std::make_shared<AsyncSpgwServiceClient>(test_channel);
     events_reporter   = std::make_shared<MockEventsReporter>();
     auto rule_store   = std::make_shared<StaticRuleStore>();
-    session_store     = std::make_shared<SessionStore>(rule_store);
+    session_store     = std::make_shared<SessionStore>(
+        rule_store, std::make_shared<MeteringReporter>());
     insert_static_rule(rule_store, 1, "rule1");
     insert_static_rule(rule_store, 1, "rule2");
     insert_static_rule(rule_store, 2, "rule3");

--- a/lte/gateway/c/session_manager/test/test_set_session_manager_handler.cpp
+++ b/lte/gateway/c/session_manager/test/test_set_session_manager_handler.cpp
@@ -40,8 +40,9 @@ namespace magma {
 class SessionManagerHandlerTest : public ::testing::Test {
  public:
   virtual void SetUp() {
-    rule_store            = std::make_shared<StaticRuleStore>();
-    session_store         = std::make_shared<SessionStore>(rule_store);
+    rule_store    = std::make_shared<StaticRuleStore>();
+    session_store = std::make_shared<SessionStore>(
+        rule_store, std::make_shared<MeteringReporter>());
     auto pipelined_client = std::make_shared<magma::AsyncPipelinedClient>();
     amf_srv_client        = std::make_shared<magma::AsyncAmfServiceClient>();
 


### PR DESCRIPTION
Signed-off-by: Marie Bremner <marwhal@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary
A few things:
1. Changing the SessionStore interface to take in the MeteringReporter object, not initialize it inside. First of all, it's easier for testing + everything when things are initialized at the top level. And also, I don't think MeteringReporter has any business inside SessionStore. So when I have some bandwidth I'll separate out the two objects completely. 
2. Light refactor on session store unit tests due to 1.
3. New function in SessionStore `initialize_metering_counter`. This loops through all the existing sessions and updates the ue_traffic metric based on the existing values. Since the counter resets on SessionD restart, we need to do this to make sure the values do not get reset.

## Test Plan
Add a session with one rule+RG and run some traffic with a modified s1ap test
Check metrics:
```
name: "ue_traffic"
help: ""
type: COUNTER
metric {
  label {
    name: "IMSI"
    value: "IMSI001010000000001"
  }
  label {
    name: "direction"
    value: "down"
  }
  label {
    name: "session_id"
    value: "IMSI001010000000001-173122"
  }
  counter {
    value: 2597.0
  }
}
metric {
  label {
    name: "IMSI"
    value: "IMSI001010000000001"
  }
  label {
    name: "direction"
    value: "up"
  }
  label {
    name: "session_id"
    value: "IMSI001010000000001-173122"
  }
  counter {
    value: 20851.0
  }
}
```
Restart and observe logs: `sudo service magma@sessiond restart && sudo journalctl -fu magma@sessiond`
```
Mar 04 00:59:42 magma-dev sessiond[15226]: I0304 00:59:42.429770 15226 SessionStore.cpp:200] Initializing metering metrics with on startup for IMSI001010000000001-173122: monitoring: {tx=0, rx=0}, charging: {tx=20851, rx=2597}
Mar 04 00:59:42 magma-dev sessiond[15226]: I0304 00:59:42.429796 15226 MeteringReporter.cpp:79] dir up val 20851
Mar 04 00:59:42 magma-dev sessiond[15226]: I0304 00:59:42.430260 15226 MeteringReporter.cpp:79] dir down val 2597
```
and check metric
```
name: "ue_traffic"
help: ""
type: COUNTER
metric {
  label {
    name: "IMSI"
    value: "IMSI001010000000001"
  }
  label {
    name: "direction"
    value: "down"
  }
  label {
    name: "session_id"
    value: "IMSI001010000000001-173122"
  }
  counter {
    value: 2597.0
  }
}
metric {
  label {
    name: "IMSI"
    value: "IMSI001010000000001"
  }
  label {
    name: "direction"
    value: "up"
  }
  label {
    name: "session_id"
    value: "IMSI001010000000001-173122"
  }
  counter {
    value: 20851.0
  }
}
```
The previous behavior being that after a restart all values are 0.
<!-- Enumerate changes you made and why you made them -->


<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
