### PR TITLE
[pipelined]Add rpc failure for uninitialized controllers

### DIFF
--- a/lte/gateway/python/magma/pipelined/app/base.py
+++ b/lte/gateway/python/magma/pipelined/app/base.py
@@ -137,6 +137,12 @@ class MagmaController(app_manager.RyuApp):
 
         return None
 
+    def is_controller_ready(self):
+        """
+        Check if the controller is setup & ready to process requests
+        """
+        return self._datapath and self.init_finished
+
     def initialize_on_connect(self, datapath):
         """
         Initialize the app on the datapath connect event.

--- a/lte/gateway/python/magma/pipelined/rpc_servicer.py
+++ b/lte/gateway/python/magma/pipelined/rpc_servicer.py
@@ -182,6 +182,13 @@ class PipelinedRpcServicer(pipelined_pb2_grpc.PipelinedServicer):
             context.set_details('Service not enabled!')
             return None
 
+        for controller in [self._gy_app, self._enforcer_app,
+                           self._enforcement_stats]:
+            if not controller.is_controller_ready():
+                context.set_code(grpc.StatusCode.UNAVAILABLE)
+                context.set_details('Enforcement service not initialized!')
+                return ActivateFlowsResult()
+
         fut = Future()  # type: Future[ActivateFlowsResult]
         self._loop.call_soon_threadsafe(self._activate_flows, request, fut)
         try:
@@ -370,6 +377,13 @@ class PipelinedRpcServicer(pipelined_pb2_grpc.PipelinedServicer):
             context.set_code(grpc.StatusCode.UNAVAILABLE)
             context.set_details('Service not enabled!')
             return None
+
+        for controller in [self._gy_app, self._enforcer_app,
+                           self._enforcement_stats]:
+            if not controller.is_controller_ready():
+                context.set_code(grpc.StatusCode.UNAVAILABLE)
+                context.set_details('Enforcement service not initialized!')
+                return ActivateFlowsResult()
 
         self._loop.call_soon_threadsafe(self._deactivate_flows, request)
         return DeactivateFlowsResult()
@@ -561,6 +575,11 @@ class PipelinedRpcServicer(pipelined_pb2_grpc.PipelinedServicer):
             context.set_details('Service not enabled!')
             return None
 
+        if not self._ue_mac_app.is_controller_ready():
+            context.set_code(grpc.StatusCode.UNAVAILABLE)
+            context.set_details('UE MAC service not initialized!')
+            return FlowResponse()
+
         # 12 hex characters + 5 colons
         if len(request.mac_addr) != 17:
             context.set_code(grpc.StatusCode.INVALID_ARGUMENT)
@@ -591,6 +610,11 @@ class PipelinedRpcServicer(pipelined_pb2_grpc.PipelinedServicer):
             context.set_code(grpc.StatusCode.UNAVAILABLE)
             context.set_details('Service not enabled!')
             return None
+
+        if not self._ue_mac_app.is_controller_ready():
+            context.set_code(grpc.StatusCode.UNAVAILABLE)
+            context.set_details('UE MAC service not initialized!')
+            return FlowResponse()
 
         # 12 hex characters + 5 colons
         if len(request.mac_addr) != 17:
@@ -666,6 +690,11 @@ class PipelinedRpcServicer(pipelined_pb2_grpc.PipelinedServicer):
             context.set_code(grpc.StatusCode.UNAVAILABLE)
             context.set_details('Service not enabled!')
             return None
+
+        if not self._check_quota_app.is_controller_ready():
+            context.set_code(grpc.StatusCode.UNAVAILABLE)
+            context.set_details('Check Quota service not initialized!')
+            return FlowResponse()
 
         resp = FlowResponse()
         self._loop.call_soon_threadsafe(


### PR DESCRIPTION
Signed-off-by: Nick Yurchenko <koolzz@fb.com>

Respond with rpc failure when a controller is not yet initialized
<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
