### PR TITLE
Verify Monitoring/Connectiond rules are supported #4560

### DIFF
--- a/lte/gateway/configs/pipelined.yml
+++ b/lte/gateway/configs/pipelined.yml
@@ -164,6 +164,12 @@ he_proxy_eth_mac: 'e6:8f:a2:80:80:80'
 # Make as a True when gnb ip will support for uplink 
 ovs_multi_tunnel: False
 
+# Internal port for processing internal conntrack
+ovs_internal_conntrack_port_number: 15579
+
+# Table to forward packets from the internal conntrack
+ovs_internal_conntrack_fwd_tbl_number: 202
+
 # For 5G Functionality Support flag
 5G_feature_set:
  enable: False

--- a/lte/gateway/configs/pipelined.yml_prod
+++ b/lte/gateway/configs/pipelined.yml_prod
@@ -154,3 +154,9 @@ uplink_gw_mac: 'ff:ff:ff:ff:ff:ff'
 he_proxy_eth_mac: 'e6:8f:a2:80:80:80'
 
 ovs_gtp_stats_polling_interval: 180
+
+# Internal port for processing internal conntrack
+ovs_internal_conntrack_port_number: 15579
+
+# Table to forward packets from the internal conntrack
+ovs_internal_conntrack_fwd_tbl_number: 202

--- a/lte/gateway/python/magma/pipelined/app/classifier.py
+++ b/lte/gateway/python/magma/pipelined/app/classifier.py
@@ -174,12 +174,9 @@ class Classifier(MagmaController):
     def _install_internal_conntrack_flow(self):
         match = MagmaMatch(in_port=self.config.internal_conntrack_port)
         flows.add_resubmit_next_service_flow(self._datapath,self.tbl_num, match, [],
-                                             priority=flows.MINIMUM_PRIORITY, 
+                                             priority=flows.MINIMUM_PRIORITY,
+                                             reset_default_register=1,
                                              resubmit_table=self.config.internal_conntrack_fwd_tbl)
-
-        #flows.add_flow(self._datapath,self.tbl_num, match,
-        #               priority=flows.MINIMUM_PRIORITY,
-        #               goto_table=self.config.internal_conntrack_fwd_tbl)
 
     def add_tunnel_flows(self, precedence:int, i_teid:int,
                          o_teid:int, ue_ip_adr:IPAddress,

--- a/lte/gateway/python/magma/pipelined/app/classifier.py
+++ b/lte/gateway/python/magma/pipelined/app/classifier.py
@@ -42,7 +42,9 @@ class Classifier(MagmaController):
     APP_TYPE = ControllerType.SPECIAL
     ClassifierConfig = namedtuple(
             'ClassifierConfig',
-            ['gtp_port', 'mtr_ip', 'mtr_port', 'internal_sampling_port', 'internal_sampling_fwd_tbl', 'multi_tunnel_flag'],
+            ['gtp_port', 'mtr_ip', 'mtr_port', 'internal_sampling_port',
+             'internal_sampling_fwd_tbl', 'multi_tunnel_flag',
+             'internal_conntrack_port', 'internal_conntrack_fwd_tbl'],
     )
 
     def __init__(self, *args, **kwargs):
@@ -77,8 +79,12 @@ class Classifier(MagmaController):
             internal_sampling_port=
                                config_dict['ovs_internal_sampling_port_number'],
             internal_sampling_fwd_tbl=
-                              config_dict['ovs_internal_sampling_fwd_tbl_number'],
+                               config_dict['ovs_internal_sampling_fwd_tbl_number'],
             multi_tunnel_flag=multi_tunnel_flag,
+            internal_conntrack_port=
+                               config_dict['ovs_internal_conntrack_port_number'],
+            internal_conntrack_fwd_tbl=
+                               config_dict['ovs_internal_conntrack_fwd_tbl_number'],
 
         )
 
@@ -142,6 +148,7 @@ class Classifier(MagmaController):
 
         self._install_default_tunnel_flows()
         self._install_internal_pkt_fwd_flow()
+        self._install_internal_conntrack_flow()
 
     def _delete_all_flows(self):
         flows.delete_all_flows_from_table(self._datapath, self.tbl_num)
@@ -164,6 +171,11 @@ class Classifier(MagmaController):
                                              reset_default_register=False,
                                              resubmit_table=self.config.internal_sampling_fwd_tbl)
 
+    def _install_internal_conntrack_flow(self):
+        match = MagmaMatch(in_port=self.config.internal_conntrack_port)
+        flows.add_flow(self._datapath,self.tbl_num, match,
+                       priority=flows.MINIMUM_PRIORITY,
+                       goto_table=self.config.internal_conntrack_fwd_tbl)
 
     def add_tunnel_flows(self, precedence:int, i_teid:int,
                          o_teid:int, ue_ip_adr:IPAddress,

--- a/lte/gateway/python/magma/pipelined/app/classifier.py
+++ b/lte/gateway/python/magma/pipelined/app/classifier.py
@@ -175,7 +175,7 @@ class Classifier(MagmaController):
         match = MagmaMatch(in_port=self.config.internal_conntrack_port)
         flows.add_resubmit_next_service_flow(self._datapath,self.tbl_num, match, [],
                                              priority=flows.MINIMUM_PRIORITY,
-                                             reset_default_register=1,
+                                             reset_default_register=False,
                                              resubmit_table=self.config.internal_conntrack_fwd_tbl)
 
     def add_tunnel_flows(self, precedence:int, i_teid:int,

--- a/lte/gateway/python/magma/pipelined/app/classifier.py
+++ b/lte/gateway/python/magma/pipelined/app/classifier.py
@@ -173,9 +173,13 @@ class Classifier(MagmaController):
 
     def _install_internal_conntrack_flow(self):
         match = MagmaMatch(in_port=self.config.internal_conntrack_port)
-        flows.add_flow(self._datapath,self.tbl_num, match,
-                       priority=flows.MINIMUM_PRIORITY,
-                       goto_table=self.config.internal_conntrack_fwd_tbl)
+        flows.add_resubmit_next_service_flow(self._datapath,self.tbl_num, match, [],
+                                             priority=flows.MINIMUM_PRIORITY, 
+                                             resubmit_table=self.config.internal_conntrack_fwd_tbl)
+
+        #flows.add_flow(self._datapath,self.tbl_num, match,
+        #               priority=flows.MINIMUM_PRIORITY,
+        #               goto_table=self.config.internal_conntrack_fwd_tbl)
 
     def add_tunnel_flows(self, precedence:int, i_teid:int,
                          o_teid:int, ue_ip_adr:IPAddress,

--- a/lte/gateway/python/magma/pipelined/openflow/flows.py
+++ b/lte/gateway/python/magma/pipelined/openflow/flows.py
@@ -138,7 +138,6 @@ def add_flow(datapath, table, match, actions=None, instructions=None,
 
     if actions is None:
         actions = []
-
     reset_scratch_reg_actions = [
              parser.NXActionRegLoad2(dst=reg, value=REG_ZERO_VAL)
              for reg in SCRATCH_REGS]

--- a/lte/gateway/python/magma/pipelined/openflow/flows.py
+++ b/lte/gateway/python/magma/pipelined/openflow/flows.py
@@ -138,6 +138,7 @@ def add_flow(datapath, table, match, actions=None, instructions=None,
 
     if actions is None:
         actions = []
+
     reset_scratch_reg_actions = [
              parser.NXActionRegLoad2(dst=reg, value=REG_ZERO_VAL)
              for reg in SCRATCH_REGS]

--- a/lte/gateway/python/magma/pipelined/tests/snapshots/test_classifier.ClassifierTest.test_install_internal_conntrack_flow.snapshot
+++ b/lte/gateway/python/magma/pipelined/tests/snapshots/test_classifier.ClassifierTest.test_install_internal_conntrack_flow.snapshot
@@ -1,0 +1,1 @@
+ cookie=0x0, table=classifier(main_table), n_packets=0, n_bytes=0, priority=0,in_port=15579 actions=resubmit(,202)

--- a/lte/gateway/python/magma/pipelined/tests/snapshots/test_classifier.ClassifierTest.test_install_internal_conntrack_flow.snapshot
+++ b/lte/gateway/python/magma/pipelined/tests/snapshots/test_classifier.ClassifierTest.test_install_internal_conntrack_flow.snapshot
@@ -1,1 +1,1 @@
- cookie=0x0, table=classifier(main_table), n_packets=0, n_bytes=0, priority=0,in_port=15579 actions=resubmit(,202),set_field:0->reg0,set_field:0->reg3
+ cookie=0x0, table=classifier(main_table), n_packets=0, n_bytes=0, priority=0,in_port=15579 actions=resubmit(,202)

--- a/lte/gateway/python/magma/pipelined/tests/snapshots/test_classifier.ClassifierTest.test_install_internal_conntrack_flow.snapshot
+++ b/lte/gateway/python/magma/pipelined/tests/snapshots/test_classifier.ClassifierTest.test_install_internal_conntrack_flow.snapshot
@@ -1,1 +1,1 @@
- cookie=0x0, table=classifier(main_table), n_packets=0, n_bytes=0, priority=0,in_port=15579 actions=resubmit(,202)
+ cookie=0x0, table=classifier(main_table), n_packets=0, n_bytes=0, priority=0,in_port=15579 actions=resubmit(,202),set_field:0->reg0,set_field:0->reg3

--- a/lte/gateway/python/magma/pipelined/tests/test_classifier.py
+++ b/lte/gateway/python/magma/pipelined/tests/test_classifier.py
@@ -76,6 +76,8 @@ class ClassifierTest(unittest.TestCase):
                 'mtr_ip': cls.MTR_IP,
                 'ovs_internal_sampling_port_number': 15578,
                 'ovs_internal_sampling_fwd_tbl_number': 201,
+                'ovs_internal_conntrack_port_number': 15579,
+                'ovs_internal_conntrack_fwd_tbl_number': 202,
                 'clean_restart': True,
                 'ovs_multi_tunnel': True,
             },
@@ -99,6 +101,16 @@ class ClassifierTest(unittest.TestCase):
         # install the specific flows test case.
         self.test_detach_default_tunnel_flows()
         self.classifier_controller._install_internal_pkt_fwd_flow()
+        snapshot_verifier = SnapshotVerifier(self, self.BRIDGE,
+                                             self.service_manager)
+        with snapshot_verifier:
+            pass
+
+    def test_install_internal_conntrack_flow(self):
+        # Need to delete all default flows in table 0 before
+        # install the specific flows test case.
+        self.test_detach_default_tunnel_flows()
+        self.classifier_controller._install_internal_conntrack_flow()
         snapshot_verifier = SnapshotVerifier(self, self.BRIDGE,
                                              self.service_manager)
         with snapshot_verifier:

--- a/lte/gateway/python/magma/pipelined/tests/test_classifier_traffic.py
+++ b/lte/gateway/python/magma/pipelined/tests/test_classifier_traffic.py
@@ -91,6 +91,8 @@ class GTPTrafficTest(unittest.TestCase):
                 'mtr_ip': cls.MTR_IP,
                 'ovs_internal_sampling_port_number': 15578,
                 'ovs_internal_sampling_fwd_tbl_number': 201,
+                'ovs_internal_conntrack_port_number': 15579,
+                'ovs_internal_conntrack_fwd_tbl_number': 202,
                 'clean_restart': True,
                 'ovs_multi_tunnel': False,
             },


### PR DESCRIPTION
Signed-off-by: prabina pattnaik <prabinak@wavelabs.ai>

## Summary

Here, one default flow added in table 0 for conntrackd rule.
## Test Plan
Added UT test case in "test_classifier.py"
test_install_internal_conntrack_flow()

## Additional Information

Below default rules are present in table 0:
vagrant@magma-dev:~/magma/lte/gateway$ sudo ovs-ofctl -O OpenFlow13 dump-flows gtp_br0 table=0
 cookie=0x0, duration=79.411s, table=0, n_packets=18, n_bytes=1260, priority=0 actions=goto_table:1
 cookie=0x0, duration=79.410s, table=0, n_packets=0, n_bytes=0, priority=0,in_port=ipfix0 actions=goto_table:201
 cookie=0x0, duration=79.409s, table=0, n_packets=0, n_bytes=0, priority=0,in_port=15579 actions=goto_table:202
