### PR TITLE
[AGW][SessionD] Remove per-session counters on session termination

### DIFF
--- a/lte/gateway/c/session_manager/LocalEnforcer.cpp
+++ b/lte/gateway/c/session_manager/LocalEnforcer.cpp
@@ -1215,6 +1215,9 @@ void LocalEnforcer::complete_termination(
   reporter_->report_terminate_session(termination_req, logging_cb);
   events_reporter_->session_terminated(imsi, session);
 
+  // clear all metrics associated with this session
+  session->clear_session_metrics();
+
   // Delete the session from SessionMap
   session_uc.is_session_ended = true;
   session_map[imsi].erase(*session_it);

--- a/lte/gateway/c/session_manager/MeteringReporter.cpp
+++ b/lte/gateway/c/session_manager/MeteringReporter.cpp
@@ -49,27 +49,17 @@ void MeteringReporter::report_usage(
     total_rx += (double) credit_update.bucket_deltas[USED_RX];
   }
 
-  report_upload(imsi, session_id, total_tx);
-  report_download(imsi, session_id, total_rx);
+  report_traffic(imsi, session_id, DIRECTION_UP, total_tx);
+  report_traffic(imsi, session_id, DIRECTION_DOWN, total_rx);
 }
 
 void MeteringReporter::initialize_usage(
     const std::string& imsi, const std::string& session_id,
     SessionCredit::TotalCreditUsage usage) {
-  report_upload(imsi, session_id, usage.monitoring_tx + usage.charging_tx);
-  report_download(imsi, session_id, usage.monitoring_rx + usage.charging_rx);
-}
-
-void MeteringReporter::report_upload(
-    const std::string& imsi, const std::string& session_id,
-    double unreported_usage_bytes) {
-  report_traffic(imsi, session_id, DIRECTION_UP, unreported_usage_bytes);
-}
-
-void MeteringReporter::report_download(
-    const std::string& imsi, const std::string& session_id,
-    double unreported_usage_bytes) {
-  report_traffic(imsi, session_id, DIRECTION_DOWN, unreported_usage_bytes);
+  auto tx = usage.monitoring_tx + usage.charging_tx;
+  auto rx = usage.monitoring_rx + usage.charging_rx;
+  report_traffic(imsi, session_id, DIRECTION_UP, tx);
+  report_traffic(imsi, session_id, DIRECTION_DOWN, rx);
 }
 
 void MeteringReporter::report_traffic(

--- a/lte/gateway/c/session_manager/MeteringReporter.h
+++ b/lte/gateway/c/session_manager/MeteringReporter.h
@@ -42,20 +42,6 @@ class MeteringReporter {
 
  private:
   /**
-   * Report upload traffic usage for a session
-   */
-  void report_upload(
-      const std::string& imsi, const std::string& session_id,
-      double unreported_usage_bytes);
-
-  /**
-   * Report download traffic usage for a session
-   */
-  void report_download(
-      const std::string& imsi, const std::string& session_id,
-      double unreported_usage_bytes);
-
-  /**
    * Report traffic usage for a session
    */
   void report_traffic(

--- a/lte/gateway/c/session_manager/SessionState.cpp
+++ b/lte/gateway/c/session_manager/SessionState.cpp
@@ -30,15 +30,20 @@
 #include "DiameterCodes.h"
 
 namespace {
-const char* LABEL_IMSI      = "IMSI";
-const char* LABEL_APN       = "apn";
-const char* LABEL_MSISDN    = "msisdn";
-const char* LABEL_DIRECTION = "direction";
-const char* DIRECTION_UP    = "up";
-const char* DIRECTION_DOWN  = "down";
+const char* UE_TRAFFIC_COUNTER_NAME = "ue_traffic";
+const char* UE_DROPPED_COUNTER_NAME = "ue_dropped_usage";
+const char* UE_USED_COUNTER_NAME    = "ue_reported_usage";
+const char* LABEL_IMSI              = "IMSI";
+const char* LABEL_APN               = "apn";
+const char* LABEL_MSISDN            = "msisdn";
+const char* LABEL_DIRECTION         = "direction";
+const char* DIRECTION_UP            = "up";
+const char* DIRECTION_DOWN          = "down";
+const char* LABEL_SESSION_ID        = "session_id";
 }  // namespace
 
 using magma::service303::increment_counter;
+using magma::service303::remove_counter;
 
 namespace magma {
 
@@ -525,9 +530,9 @@ void SessionState::add_rule_usage(
     add_to_monitor(session_level_key_, used_tx, used_rx, update_criteria);
   }
   if (is_dynamic_rule_installed(rule_id) || is_static_rule_installed(rule_id)) {
-    update_used_data_metrics(used_tx, used_rx);
+    update_data_metrics(UE_USED_COUNTER_NAME, used_tx, used_rx);
   }
-  update_dropped_data_metrics(dropped_tx, dropped_rx);
+  update_data_metrics(UE_DROPPED_COUNTER_NAME, dropped_tx, dropped_rx);
 }
 
 void SessionState::apply_session_rule_set(
@@ -2117,34 +2122,46 @@ optional<RuleSetToApply> RuleSetBySubscriber::get_combined_rule_set_for_apn(
   return {};
 }
 
-void SessionState::update_used_data_metrics(
-    uint64_t bytes_tx, uint64_t bytes_rx) {
+void SessionState::update_data_metrics(
+    const char* counter_name, uint64_t bytes_tx, uint64_t bytes_rx) {
   const auto sid    = get_config().common_context.sid().id();
   const auto msisdn = get_config().common_context.msisdn();
   const auto apn    = get_config().common_context.apn();
   increment_counter(
-      "ue_reported_usage", bytes_tx, size_t(4), LABEL_IMSI, sid.c_str(),
-      LABEL_APN, apn.c_str(), LABEL_MSISDN, msisdn.c_str(), LABEL_DIRECTION,
-      DIRECTION_UP);
+      counter_name, bytes_tx, size_t(4), LABEL_IMSI, sid.c_str(), LABEL_APN,
+      apn.c_str(), LABEL_MSISDN, msisdn.c_str(), LABEL_DIRECTION, DIRECTION_UP);
   increment_counter(
-      "ue_reported_usage", bytes_rx, size_t(4), LABEL_IMSI, sid.c_str(),
-      LABEL_APN, apn.c_str(), LABEL_MSISDN, msisdn.c_str(), LABEL_DIRECTION,
+      counter_name, bytes_rx, size_t(4), LABEL_IMSI, sid.c_str(), LABEL_APN,
+      apn.c_str(), LABEL_MSISDN, msisdn.c_str(), LABEL_DIRECTION,
       DIRECTION_DOWN);
 }
 
-void SessionState::update_dropped_data_metrics(
-    uint64_t dropped_tx, uint64_t dropped_rx) {
-  const auto sid    = get_config().common_context.sid().id();
+void SessionState::clear_session_metrics() {
+  const auto imsi   = get_config().common_context.sid().id();
   const auto msisdn = get_config().common_context.msisdn();
   const auto apn    = get_config().common_context.apn();
-  increment_counter(
-      "ue_dropped_usage", dropped_tx, size_t(4), LABEL_IMSI, sid.c_str(),
-      LABEL_APN, apn.c_str(), LABEL_MSISDN, msisdn.c_str(), LABEL_DIRECTION,
-      DIRECTION_UP);
-  increment_counter(
-      "ue_dropped_usage", dropped_rx, size_t(4), LABEL_IMSI, sid.c_str(),
-      LABEL_APN, apn.c_str(), LABEL_MSISDN, msisdn.c_str(), LABEL_DIRECTION,
+  remove_counter(
+      UE_USED_COUNTER_NAME, size_t(4), LABEL_IMSI, imsi.c_str(), LABEL_APN,
+      apn.c_str(), LABEL_MSISDN, msisdn.c_str(), LABEL_DIRECTION, DIRECTION_UP);
+  remove_counter(
+      UE_USED_COUNTER_NAME, size_t(4), LABEL_IMSI, imsi.c_str(), LABEL_APN,
+      apn.c_str(), LABEL_MSISDN, msisdn.c_str(), LABEL_DIRECTION,
       DIRECTION_DOWN);
+
+  remove_counter(
+      UE_DROPPED_COUNTER_NAME, size_t(4), LABEL_IMSI, imsi.c_str(), LABEL_APN,
+      apn.c_str(), LABEL_MSISDN, msisdn.c_str(), LABEL_DIRECTION, DIRECTION_UP);
+  remove_counter(
+      UE_DROPPED_COUNTER_NAME, size_t(4), LABEL_IMSI, imsi.c_str(), LABEL_APN,
+      apn.c_str(), LABEL_MSISDN, msisdn.c_str(), LABEL_DIRECTION,
+      DIRECTION_DOWN);
+
+  remove_counter(
+      UE_TRAFFIC_COUNTER_NAME, size_t(3), LABEL_IMSI, imsi.c_str(),
+      LABEL_SESSION_ID, session_id_.c_str(), LABEL_DIRECTION, DIRECTION_UP);
+  remove_counter(
+      UE_TRAFFIC_COUNTER_NAME, size_t(3), LABEL_IMSI, imsi.c_str(),
+      LABEL_SESSION_ID, session_id_.c_str(), LABEL_DIRECTION, DIRECTION_DOWN);
 }
 
 CreateSessionResponse SessionState::get_create_session_response() {

--- a/lte/gateway/c/session_manager/SessionState.h
+++ b/lte/gateway/c/session_manager/SessionState.h
@@ -543,6 +543,11 @@ class SessionState {
   bool should_rule_be_active(const std::string& rule_id, std::time_t time);
   bool is_dynamic_rule_scheduled(const std::string& rule_id);
 
+  /**
+   * Clear all per-session metrics
+   */
+  void clear_session_metrics();
+
  private:
   std::string imsi_;
   std::string session_id_;
@@ -750,17 +755,12 @@ class SessionState {
 
   /**
    * Increments data usage values for session
+   * @param usage_label either UE_DROPPED_LABEL / UE_USED_LABEL
    * @param bytes_tx
    * @param bytes_rx
    */
-  void update_used_data_metrics(uint64_t bytes_tx, uint64_t bytes_rx);
-
-  /**
-   * Increments data usage values for session
-   * @param dropped_tx
-   * @param dropped_rx
-   */
-  void update_dropped_data_metrics(uint64_t dropped_tx, uint64_t dropped_rx);
+  void update_data_metrics(
+      const char* counter_name, uint64_t bytes_tx, uint64_t bytes_rx);
 };
 
 }  // namespace magma

--- a/orc8r/gateway/c/common/service303/MetricsHelpers.cpp
+++ b/orc8r/gateway/c/common/service303/MetricsHelpers.cpp
@@ -18,6 +18,13 @@
 namespace magma {
 namespace service303 {
 
+void remove_counter(const char* name, size_t n_labels, ...) {
+  va_list ap;
+  va_start(ap, n_labels);
+  MetricsSingleton::Instance().RemoveCounter(name, n_labels, ap);
+  va_end(ap);
+}
+
 void increment_counter(
     const char* name, double increment, size_t n_labels, ...) {
   va_list ap;

--- a/orc8r/gateway/c/common/service303/MetricsHelpers.h
+++ b/orc8r/gateway/c/common/service303/MetricsHelpers.h
@@ -20,6 +20,14 @@ namespace magma {
 namespace service303 {
 
 /**
+ * Remove the counter metric that matches name+labels given
+ * @param name
+ * @param n_labels number of labels
+ * @param ... label args (name, value)
+ */
+void remove_counter(const char* name, size_t n_labels, ...);
+
+/**
  * Increments value for Counter metric
  * @param name
  * @param increment value to increment

--- a/orc8r/gateway/c/common/service303/MetricsRegistry.h
+++ b/orc8r/gateway/c/common/service303/MetricsRegistry.h
@@ -55,6 +55,15 @@ class MetricsRegistry {
       const std::string& name, const std::map<std::string, std::string>& labels,
       Args&&... args);
 
+  /**
+   * Remove a metric instance specified by name/labels
+   * @param name
+   * @param labels
+   */
+  void Remove(
+      const std::string& name,
+      const std::map<std::string, std::string>& labels);
+
   const std::size_t SizeFamilies() { return families_.size(); }
 
   const std::size_t SizeMetrics() { return metrics_.size(); }
@@ -113,6 +122,28 @@ T& MetricsRegistry<T, MetricFamilyFactory>::Get(
     metrics_.insert({{metric_hash, metric}});
   }
   return *metric;
+}
+
+template<typename T, typename MetricFamilyFactory>
+void MetricsRegistry<T, MetricFamilyFactory>::Remove(
+    const std::string& name, const std::map<std::string, std::string>& labels) {
+  Family<T>* family;
+  size_t name_hash = std::hash<std::string>{}(name);
+  auto family_it   = families_.find(name_hash);
+  if (family_it == families_.end()) {
+    return;
+  }
+  family = family_it->second;
+
+  T* metric;
+  size_t metric_hash = hash_name_and_labels(name, labels);
+  auto metric_it     = metrics_.find(metric_hash);
+  if (metric_it == metrics_.end()) {
+    return;
+  }
+  metric = metric_it->second;
+  family->Remove(metric);
+  metrics_.erase(metric_hash);
 }
 
 template<typename T, typename MetricFamilyFactory>

--- a/orc8r/gateway/c/common/service303/MetricsSingleton.cpp
+++ b/orc8r/gateway/c/common/service303/MetricsSingleton.cpp
@@ -47,6 +47,13 @@ void MetricsSingleton::args_to_map(
   }
 }
 
+void MetricsSingleton::RemoveCounter(
+    const char* name, size_t label_count, va_list& args) {
+  std::map<std::string, std::string> labels;
+  args_to_map(labels, label_count, args);
+  counters_.Remove(name, labels);
+}
+
 void MetricsSingleton::IncrementCounter(
     const char* name, double increment, size_t label_count, va_list& args) {
   std::map<std::string, std::string> labels;

--- a/orc8r/gateway/c/common/service303/MetricsSingleton.h
+++ b/orc8r/gateway/c/common/service303/MetricsSingleton.h
@@ -46,6 +46,7 @@ class MetricsSingleton {
  public:
   static MetricsSingleton& Instance();
   static void flush();  // destroy instance
+  void RemoveCounter(const char* name, size_t label_count, va_list& args);
   void IncrementCounter(
       const char* name, double increment, size_t label_count, va_list& args);
   void IncrementGauge(


### PR DESCRIPTION
Signed-off-by: Marie Bremner <marwhal@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary
2 things:
1. Add a `RemoveCounter` method to the metric stack in orc8r/gateway/c/common.
2. On session termination, remove all counters that handle per-session information
   i. `ue_traffic`
  ii. `ue_dropped_usage`
  iii. `ue_reported_usage`

Removing the per-session metrics ensures, we don't gradually build up metrics of old sessions on the gateway. But for short-lived sessions (~few seconds), we might remove the metric too quickly for the metrics collector to report the usage.

I'm not sure if we should be using prometheus for data that we need to persist/rely on. So it would be good to migrate to a state based / event based approach.

<!-- Enumerate changes you made and why you made them -->

## Test Plan
Run a s1ap test to attach and generate traffic.
During test:
```
(python) vagrant@magma-dev:~$ service303_cli.py metrics sessiond
name: "0"
help: ""
type: GAUGE
metric {
  gauge {
    value: 1614874631.0
  }
}

name: "3"
help: ""
type: GAUGE
metric {
  gauge {
    value: 44.085746504
  }
}

name: "1"
help: ""
type: GAUGE
metric {
  gauge {
    value: 21990594646016.0
  }
}

name: "2"
help: ""
type: GAUGE
metric {
  gauge {
    value: 59527168.0
  }
}

name: "ue_dropped_usage"
help: ""
type: COUNTER
metric {
  label {
    name: "IMSI"
    value: "IMSI001010036235177"
  }
  label {
    name: "apn"
    value: "magma.ipv4"
  }
  label {
    name: "direction"
    value: "down"
  }
  label {
    name: "msisdn"
    value: ""
  }
  counter {
    value: 0.0
  }
}
metric {
  label {
    name: "IMSI"
    value: "IMSI001010036235177"
  }
  label {
    name: "apn"
    value: "magma.ipv4"
  }
  label {
    name: "direction"
    value: "up"
  }
  label {
    name: "msisdn"
    value: ""
  }
  counter {
    value: 0.0
  }
}

name: "ue_reported_usage"
help: ""
type: COUNTER
metric {
  label {
    name: "IMSI"
    value: "IMSI001010036235177"
  }
  label {
    name: "apn"
    value: "magma.ipv4"
  }
  label {
    name: "direction"
    value: "down"
  }
  label {
    name: "msisdn"
    value: ""
  }
  counter {
    value: 2597.0
  }
}
metric {
  label {
    name: "IMSI"
    value: "IMSI001010036235177"
  }
  label {
    name: "apn"
    value: "magma.ipv4"
  }
  label {
    name: "direction"
    value: "up"
  }
  label {
    name: "msisdn"
    value: ""
  }
  counter {
    value: 20858.0
  }
}

name: "ue_traffic"
help: ""
type: COUNTER
metric {
  label {
    name: "IMSI"
    value: "IMSI001010036235177"
  }
  label {
    name: "direction"
    value: "down"
  }
  label {
    name: "session_id"
    value: "IMSI001010036235177-148766"
  }
  counter {
    value: 0.0
  }
}
metric {
  label {
    name: "IMSI"
    value: "IMSI001010036235177"
  }
  label {
    name: "direction"
    value: "up"
  }
  label {
    name: "session_id"
    value: "IMSI001010036235177-148766"
  }
  counter {
    value: 0.0
  }
}
```
After the test completes and terminates the session:
```
(python) vagrant@magma-dev:~$ service303_cli.py metrics sessiond
name: "0"
help: ""
type: GAUGE
metric {
  gauge {
    value: 1614874631.0
  }
}

name: "3"
help: ""
type: GAUGE
metric {
  gauge {
    value: 70.691450959
  }
}

name: "1"
help: ""
type: GAUGE
metric {
  gauge {
    value: 21990594711552.0
  }
}

name: "2"
help: ""
type: GAUGE
metric {
  gauge {
    value: 61468672.0
  }
}

name: "ue_dropped_usage"
help: ""
type: COUNTER

name: "ue_reported_usage"
help: ""
type: COUNTER

name: "ue_traffic"
help: ""
type: COUNTER
```
## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
