### PR TITLE
[SessionD] Reject all new sessions while PipelineD is setting up

### DIFF
--- a/lte/gateway/c/session_manager/LocalSessionManagerHandler.cpp
+++ b/lte/gateway/c/session_manager/LocalSessionManagerHandler.cpp
@@ -37,7 +37,7 @@ LocalSessionManagerHandlerImpl::LocalSessionManagerHandlerImpl(
       current_epoch_(0),
       reported_epoch_(0),
       retry_timeout_ms_(std::chrono::milliseconds{5000}),
-      is_setting_up_pipelined_(false) {}
+      pipelined_state_(PipelineDState::NOT_READY) {}
 
 void LocalSessionManagerHandlerImpl::ReportRuleStats(
     ServerContext* context, const RuleRecordTable* request,
@@ -140,37 +140,37 @@ bool LocalSessionManagerHandlerImpl::is_pipelined_restarted() {
 
 void LocalSessionManagerHandlerImpl::handle_setup_callback(
     const std::uint64_t& epoch, Status status, SetupFlowsResult resp) {
-  using namespace std::placeholders;
-  // Reset the variable since we've received a SetupResponse
-  is_setting_up_pipelined_ = false;
-  if (status.ok() && resp.result() == resp.SUCCESS) {
-    MLOG(MDEBUG) << "Successfully setup PipelineD with epoch: " << epoch;
-    return;
-  }
-
-  if (current_epoch_ != epoch) {
-    // This means that PipelineD has restarted since the initial Setup call was
-    // called
-    MLOG(MDEBUG) << "Received stale PipelineD setup callback for epoch: "
-                 << epoch << ", current epoch: " << current_epoch_;
-    return;
-  }
-  if (status.ok() && resp.result() == resp.OUTDATED_EPOCH) {
-    MLOG(MWARNING) << "PipelineD setup call has outdated epoch, abandoning.";
-    return;
-  }
-
-  // Cases for which we re-try the Setup call
-  if (!status.ok()) {
-    MLOG(MERROR) << "Could not setup PipelineD, rpc failed with: "
-                 << status.error_message() << ", retrying PipelineD setup "
-                 << "for epoch: " << epoch;
-  } else if (resp.result() == resp.FAILURE) {
-    MLOG(MWARNING) << "PipelineD setup failed, retrying PipelineD setup "
-                   << "after delay, for epoch: " << epoch;
-  }
-
+  // Run everything in the event base thread since we asynchronously
+  // read/modify pipelined_state_
   enforcer_->get_event_base().runInEventBaseThread([=] {
+    if (status.ok() && resp.result() == resp.SUCCESS) {
+      MLOG(MDEBUG) << "Successfully setup PipelineD with epoch: " << epoch;
+      pipelined_state_ = PipelineDState::READY;
+      return;
+    }
+    pipelined_state_ = PipelineDState::NOT_READY;
+    if (current_epoch_ != epoch) {
+      // This means that PipelineD has restarted since the initial Setup call
+      // was called
+      MLOG(MDEBUG) << "Received stale PipelineD setup callback for epoch: "
+                   << epoch << ", current epoch: " << current_epoch_;
+      return;
+    }
+    if (status.ok() && resp.result() == resp.OUTDATED_EPOCH) {
+      MLOG(MWARNING) << "PipelineD setup call has outdated epoch, abandoning.";
+      return;
+    }
+
+    // Cases for which we re-try the Setup call
+    if (!status.ok()) {
+      MLOG(MERROR) << "Could not setup PipelineD, rpc failed with: "
+                   << status.error_message() << ", retrying PipelineD setup "
+                   << "for epoch: " << epoch;
+    } else if (resp.result() == resp.FAILURE) {
+      MLOG(MWARNING) << "PipelineD setup failed, retrying PipelineD setup "
+                     << "after delay, for epoch: " << epoch;
+    }
+
     enforcer_->get_event_base().runAfterDelay(
         [=] { call_setup_pipelined(epoch); }, retry_timeout_ms_.count());
   });
@@ -179,15 +179,16 @@ void LocalSessionManagerHandlerImpl::handle_setup_callback(
 void LocalSessionManagerHandlerImpl::call_setup_pipelined(
     const std::uint64_t& epoch) {
   using namespace std::placeholders;
-  if (is_setting_up_pipelined_) {
+  if (pipelined_state_ == PipelineDState::SETTING_UP) {
     // Return if there is already a Setup call in progress
     return;
   }
   if (current_epoch_ != epoch) {
-    // This means that PipelineD has restarted since the this call was scheduled
+    // This means that PipelineD has restarted since the this call was
+    // scheduled
     return;
   }
-  is_setting_up_pipelined_ = true;
+  pipelined_state_ = PipelineDState::SETTING_UP;
 
   MLOG(MINFO) << "Sending a setup call to PipelineD with epoch: " << epoch;
   auto session_map = session_store_.read_all_sessions();
@@ -230,6 +231,15 @@ void LocalSessionManagerHandlerImpl::CreateSession(
         const auto& session_id = id_gen_.gen_session_id(imsi);
         SessionConfig cfg(request_cpy);
         log_create_session(cfg);
+        if (pipelined_state_ != READY) {
+          MLOG(MINFO) << "Rejecting LocalCreateSessionRequest for " << imsi
+                      << " apn=" << cfg.common_context.apn()
+                      << " since PipelineD is still setting up.";
+          send_local_create_session_response(
+              Status(grpc::UNAVAILABLE, "PipelineD is not ready"), session_id,
+              response_callback);
+          return;
+        }
 
         auto session_map     = session_store_.read_sessions({imsi});
         const auto& rat_type = cfg.common_context.rat_type();
@@ -577,8 +587,8 @@ void LocalSessionManagerHandlerImpl::UpdateTunnelIds(
     bool update_success =
         session_store_.raw_write_sessions(std::move(session_map));
     if (!update_success) {
-      MLOG(MERROR)
-          << "Failed in updating SessionStore after processing UpdateTunnelIds";
+      MLOG(MERROR) << "Failed in updating SessionStore after processing "
+                      "UpdateTunnelIds";
       auto err_status = Status(grpc::ABORTED, "Failed to store tunnels Ids");
       response_callback(err_status, UpdateTunnelIdsResponse());
       return;

--- a/lte/gateway/c/session_manager/LocalSessionManagerHandler.h
+++ b/lte/gateway/c/session_manager/LocalSessionManagerHandler.h
@@ -31,6 +31,15 @@ using namespace orc8r;
 
 class LocalSessionManagerHandler {
  public:
+  enum PipelineDState {
+    // PipelineD restarted and has not been setup
+    NOT_READY = 0,
+    // Currently exchanging Setup requests
+    SETTING_UP = 1,
+    // PipelineD is setup and is ready to accept requests
+    READY = 2,
+  };
+
   virtual ~LocalSessionManagerHandler() {}
 
   /**
@@ -152,8 +161,7 @@ class LocalSessionManagerHandlerImpl : public LocalSessionManagerHandler {
   uint64_t current_epoch_;
   uint64_t reported_epoch_;
   std::chrono::milliseconds retry_timeout_ms_;
-  // True if there is an ongoing attempt to setup PipelineD
-  bool is_setting_up_pipelined_;
+  PipelineDState pipelined_state_;
   static const std::string hex_digit_;
 
  private:

--- a/lte/gateway/c/session_manager/test/SessiondMocks.h
+++ b/lte/gateway/c/session_manager/test/SessiondMocks.h
@@ -42,12 +42,15 @@ namespace magma {
 class MockPipelined final : public Pipelined::Service {
  public:
   MockPipelined() : Pipelined::Service() {
-    ON_CALL(*this, AddRule(_, _, _)).WillByDefault(Return(Status::OK));
     ON_CALL(*this, ActivateFlows(_, _, _)).WillByDefault(Return(Status::OK));
     ON_CALL(*this, DeactivateFlows(_, _, _)).WillByDefault(Return(Status::OK));
+    ON_CALL(*this, SetupPolicyFlows(_, _, _)).WillByDefault(Return(Status::OK));
+    ON_CALL(*this, SetupDefaultControllers(_, _, _))
+        .WillByDefault(Return(Status::OK));
+    ON_CALL(*this, SetupUEMacFlows(_, _, _)).WillByDefault(Return(Status::OK));
+    ON_CALL(*this, SetupQuotaFlows(_, _, _)).WillByDefault(Return(Status::OK));
   }
 
-  MOCK_METHOD3(AddRule, Status(grpc::ServerContext*, const PolicyRule*, Void*));
   MOCK_METHOD3(
       ActivateFlows, Status(
                          grpc::ServerContext*, const ActivateFlowsRequest*,
@@ -56,6 +59,22 @@ class MockPipelined final : public Pipelined::Service {
       DeactivateFlows, Status(
                            grpc::ServerContext*, const DeactivateFlowsRequest*,
                            DeactivateFlowsResult*));
+  MOCK_METHOD3(
+      SetupPolicyFlows,
+      Status(
+          grpc::ServerContext*, const SetupPolicyRequest*, SetupFlowsResult*));
+  MOCK_METHOD3(
+      SetupDefaultControllers,
+      Status(
+          grpc::ServerContext*, const SetupDefaultRequest*, SetupFlowsResult*));
+  MOCK_METHOD3(
+      SetupUEMacFlows,
+      Status(
+          grpc::ServerContext*, const SetupUEMacRequest*, SetupFlowsResult*));
+  MOCK_METHOD3(
+      SetupQuotaFlows,
+      Status(
+          grpc::ServerContext*, const SetupQuotaRequest*, SetupFlowsResult*));
 };
 
 class MockPipelinedClient : public PipelinedClient {

--- a/lte/gateway/c/session_manager/test/test_sessiond_integ.cpp
+++ b/lte/gateway/c/session_manager/test/test_sessiond_integ.cpp
@@ -42,6 +42,44 @@ using ::testing::Return;
 using ::testing::Test;
 
 namespace magma {
+ACTION_P2(SetEndPromise, promise_p, status) {
+  promise_p->set_value();
+  return status;
+}
+
+ACTION_P(SetPromise, promise_p) {
+  promise_p->set_value();
+}
+
+// Take the SessionID from the request as it is generated internally
+ACTION_P2(SetCreateSessionResponse, first_quota, second_quota) {
+  auto req  = static_cast<const CreateSessionRequest*>(arg1);
+  auto res  = static_cast<CreateSessionResponse*>(arg2);
+  auto imsi = req->common_context().sid().id();
+  res->mutable_static_rules()->Add()->mutable_rule_id()->assign("rule1");
+  res->mutable_static_rules()->Add()->mutable_rule_id()->assign("rule2");
+  res->mutable_static_rules()->Add()->mutable_rule_id()->assign("rule3");
+  create_credit_update_response(
+      imsi, req->session_id(), 1, first_quota, res->mutable_credits()->Add());
+  create_credit_update_response(
+      imsi, req->session_id(), 2, second_quota, res->mutable_credits()->Add());
+}
+// Take the SessionID from the request as it is generated internally
+ACTION_P(SetUpdateSessionResponse, quota) {
+  auto req        = static_cast<const UpdateSessionRequest*>(arg1)->updates(0);
+  auto res        = static_cast<UpdateSessionResponse*>(arg2);
+  auto imsi       = req.common_context().sid().id();
+  auto session_id = req.session_id();
+  create_credit_update_response(
+      imsi, session_id, 1, quota, res->mutable_responses()->Add());
+}
+
+ACTION(SetSessionTerminateResponse) {
+  auto req = static_cast<const SessionTerminateRequest*>(arg1);
+  auto res = static_cast<SessionTerminateResponse*>(arg2);
+  res->set_sid(req->common_context().sid().id());
+  res->set_session_id(req->session_id());
+}
 
 class SessiondTest : public ::testing::Test {
  protected:
@@ -191,6 +229,21 @@ class SessiondTest : public ::testing::Test {
     stub->ReportRuleStats(&context, empty_table, &void_resp);
   }
 
+  void wait_for_setup_calls() {
+    std::promise<void> setup_promise1, setup_promise2;
+    EXPECT_CALL(
+        *pipelined_mock,
+        SetupDefaultControllers(testing::_, testing::_, testing::_))
+        .WillOnce(testing::DoAll(
+            SetPromise(&setup_promise2), testing::Return(grpc::Status::OK)));
+    EXPECT_CALL(
+        *pipelined_mock, SetupPolicyFlows(testing::_, testing::_, testing::_))
+        .WillOnce(testing::DoAll(
+            SetPromise(&setup_promise1), testing::Return(grpc::Status::OK)));
+    setup_promise1.get_future().get();
+    setup_promise2.get_future().get();
+  }
+
   void send_update_pipelined_table(
       std::unique_ptr<LocalSessionManager::Stub>& stub, RuleRecordTable table) {
     grpc::ClientContext context;
@@ -218,45 +271,6 @@ class SessiondTest : public ::testing::Test {
   std::shared_ptr<SessionStore> session_store;
   SessionMap session_map;
 };
-
-ACTION_P2(SetEndPromise, promise_p, status) {
-  promise_p->set_value();
-  return status;
-}
-
-ACTION_P(SetPromise, promise_p) {
-  promise_p->set_value();
-}
-
-// Take the SessionID from the request as it is generated internally
-ACTION_P2(SetCreateSessionResponse, first_quota, second_quota) {
-  auto req  = static_cast<const CreateSessionRequest*>(arg1);
-  auto res  = static_cast<CreateSessionResponse*>(arg2);
-  auto imsi = req->common_context().sid().id();
-  res->mutable_static_rules()->Add()->mutable_rule_id()->assign("rule1");
-  res->mutable_static_rules()->Add()->mutable_rule_id()->assign("rule2");
-  res->mutable_static_rules()->Add()->mutable_rule_id()->assign("rule3");
-  create_credit_update_response(
-      imsi, req->session_id(), 1, first_quota, res->mutable_credits()->Add());
-  create_credit_update_response(
-      imsi, req->session_id(), 2, second_quota, res->mutable_credits()->Add());
-}
-// Take the SessionID from the request as it is generated internally
-ACTION_P(SetUpdateSessionResponse, quota) {
-  auto req        = static_cast<const UpdateSessionRequest*>(arg1)->updates(0);
-  auto res        = static_cast<UpdateSessionResponse*>(arg2);
-  auto imsi       = req.common_context().sid().id();
-  auto session_id = req.session_id();
-  create_credit_update_response(
-      imsi, session_id, 1, quota, res->mutable_responses()->Add());
-}
-
-ACTION(SetSessionTerminateResponse) {
-  auto req = static_cast<const SessionTerminateRequest*>(arg1);
-  auto res = static_cast<SessionTerminateResponse*>(arg2);
-  res->set_sid(req->common_context().sid().id());
-  res->set_session_id(req->session_id());
-}
 
 /**
  * End to end test.
@@ -293,6 +307,7 @@ TEST_F(SessiondTest, end_to_end_success) {
   // Setup the SessionD/PipelineD epoch value by sending an empty record. This
   // will prevent SessionD thinking that PipelineD has restarted mid-test.
   send_empty_pipelined_table(stub);
+  wait_for_setup_calls();
 
   {
     // 1- CreateSession Expectations
@@ -308,8 +323,6 @@ TEST_F(SessiondTest, end_to_end_success) {
             SetCreateSessionResponse(1536, 1024), SetPromise(&create_promise),
             testing::Return(grpc::Status::OK)));
   }
-
-  // send_empty_pipelined_table(stub);
 
   // 1- CreateSession Trigger
   grpc::ClientContext create_context;
@@ -337,7 +350,6 @@ TEST_F(SessiondTest, end_to_end_success) {
   // and the call to PipelineD, ActivateFlows(), is assumed in this test
   // to happened before the ReportRuleStats().
   create_promise.get_future().get();
-
   {
     // 2- UpdateTunnelIds Expectations
     // Expect rules to be installed and pipelined to be configured
@@ -373,7 +385,6 @@ TEST_F(SessiondTest, end_to_end_success) {
 
   // Wait until the ActivateFlows call from UpdateTunnelIds has completed
   tunnel_promise.get_future().get();
-
   {
     InSequence s;
     // 3 - PipelineD update + UpdateSession Expectations
@@ -467,6 +478,7 @@ TEST_F(SessiondTest, end_to_end_cloud_down) {
   // Setup the SessionD/PipelineD epoch value by sending an empty record. This
   // will prevent SessionD thinking that PipelineD has restarted mid-test.
   send_empty_pipelined_table(stub);
+  wait_for_setup_calls();
 
   {
     // Expect create session with IMSI1


### PR DESCRIPTION
Signed-off-by: Marie Bremner <marwhal@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary
Add a new state to track PipelineD readiness in LocalSessionManagerHandler. This value is set by the result of the setup exchanges between SessionD and PipelineD. 
* On SessionD restart: state=NOT_READY
* Send a setup exchange SessionD->PipelineD: state=NOT_READY->SETTING_UP
* Receive a successful setup response: state=SETTING_UP->READY
* Receive an unsuccessful setup response: state=SETTING_UP->NOT_READY
* Notice a PipelineD restart: state=READY->NOT_READY
```
  enum PipelineDState {
    // PipelineD restarted and has not been setup
    NOT_READY = 0,
    // Currently exchanging Setup requests
    SETTING_UP = 1,
    // PipelineD is setup and is ready to accept requests
    READY = 2,
  };
```
The new logic is to reject all CreateSession requests while the pipelined is not READY.
Additional unit test to cover the case where we receive a LocalSessionManagerHandler::CreateSession while the state is not READY.
<!-- Enumerate changes you made and why you made them -->

## Test Plan
make precommit_sm
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
