### PR TITLE
[orc8r] Add a sidebar to the Swagger UI 

### DIFF
--- a/orc8r/cloud/docker/controller/Dockerfile
+++ b/orc8r/cloud/docker/controller/Dockerfile
@@ -105,6 +105,7 @@ RUN mkdir -p /var/opt/magma/envdir
 # Build artifacts
 ARG SWAGGER_FILES=src/magma/orc8r/cloud/go/obsidian/swagger
 COPY --from=builder /${SWAGGER_FILES}/v1/index.html /var/opt/magma/static/swagger/v1/ui/index.html
+COPY --from=builder /${SWAGGER_FILES}/v1/css/sidebar.css /var/opt/magma/static/swagger/v1/static/sidebar.css
 COPY --from=builder /${SWAGGER_FILES}/v1/swagger.yml /var/opt/magma/static/swagger/v1/spec/swagger.yml
 COPY --from=builder src/magma/orc8r/cloud/swagger /etc/magma/swagger
 COPY --from=builder /build/bin /var/opt/magma/bin

--- a/orc8r/cloud/go/obsidian/server/server.go
+++ b/orc8r/cloud/go/obsidian/server/server.go
@@ -54,6 +54,7 @@ func Start() {
 
 	// Serve static assets for the Swagger UI
 	e.Static(obsidian.StaticURLPrefix+"/static/swagger-ui/dist", obsidian.StaticFolder+"/swagger-ui/dist")
+	e.Static(obsidian.StaticURLPrefix+"/v1/static", obsidian.StaticFolder+"/swagger/v1/static")
 
 	portStr := fmt.Sprintf(":%d", obsidian.Port)
 	log.Printf("Starting %s on %s", obsidian.Product, portStr)

--- a/orc8r/cloud/go/obsidian/swagger/handlers/handlers.go
+++ b/orc8r/cloud/go/obsidian/swagger/handlers/handlers.go
@@ -35,6 +35,7 @@ import (
 type UIInfo struct {
 	// URL of the underlying Swagger spec
 	URL      string
+	// Services list
 	Services []string
 }
 

--- a/orc8r/cloud/go/obsidian/swagger/handlers/handlers.go
+++ b/orc8r/cloud/go/obsidian/swagger/handlers/handlers.go
@@ -34,9 +34,11 @@ import (
 // UI template.
 type UIInfo struct {
 	// URL of the underlying Swagger spec
-	URL      string
+	URL string
 	// Services list
 	Services []string
+	// SelectedService in the sidebar
+	SelectedService string
 }
 
 // RegisterSwaggerHandlers registers routes for Swagger specs and
@@ -116,8 +118,9 @@ func GetUIHandler(tmpl *template.Template) echo.HandlerFunc {
 		sort.Strings(services)
 
 		uiInfo := UIInfo{
-			URL:      obsidian.StaticURLPrefix + "/v1/spec/" + service,
-			Services: services,
+			URL:             obsidian.StaticURLPrefix + "/v1/spec/" + service,
+			Services:        services,
+			SelectedService: service,
 		}
 
 		var buf bytes.Buffer

--- a/orc8r/cloud/go/obsidian/swagger/v1/css/sidebar.css
+++ b/orc8r/cloud/go/obsidian/swagger/v1/css/sidebar.css
@@ -1,7 +1,7 @@
 /* The sidebar menu */
 .sidenav {
   height: 100%; /* Full-height: remove this if you want "auto" height */
-  width: 160px; /* Set the width of the sidebar */
+  width: 200px; /* Set the width of the sidebar */
   position: fixed; /* Fixed Sidebar (stay in place on scroll) */
   z-index: 1; /* Stay on top */
   top: 0; /* Stay at the top */
@@ -13,16 +13,21 @@
 
 /* Sidebar menu items */
 .sidenav a {
-  padding: 6px 8px 6px 16px;
+  padding: 6px 8px 16px 16px;
   text-decoration: none;
+  font-family: Open Sans, sans-serif;
   font-size: 20px;
-  color: #818181;
+  color: #e5e5e5;
   display: block;
 }
 
 /* Change sidebar item color when hovered */
 .sidenav a:hover {
-  color: #f1f1f1;
+  color: #ffa500;
+}
+
+.sidenav .selected {
+  background: #808080;
 }
 
 /* Sidebar home item */
@@ -30,4 +35,9 @@
   padding: 6px 8px 10px 16px;
   font-size: 40px;
   display: block;
+}
+
+/* Prevent overlap with fixed sidebar*/
+.swagger-ui {
+  margin-left: 5%;
 }

--- a/orc8r/cloud/go/obsidian/swagger/v1/css/sidebar.css
+++ b/orc8r/cloud/go/obsidian/swagger/v1/css/sidebar.css
@@ -1,0 +1,33 @@
+/* The sidebar menu */
+.sidenav {
+  height: 100%; /* Full-height: remove this if you want "auto" height */
+  width: 160px; /* Set the width of the sidebar */
+  position: fixed; /* Fixed Sidebar (stay in place on scroll) */
+  z-index: 1; /* Stay on top */
+  top: 0; /* Stay at the top */
+  left: 0;
+  background-color: #111; /* Black */
+  overflow-x: hidden; /* Disable horizontal scroll */
+  padding-top: 20px;
+}
+
+/* Sidebar menu items */
+.sidenav a {
+  padding: 6px 8px 6px 16px;
+  text-decoration: none;
+  font-size: 20px;
+  color: #818181;
+  display: block;
+}
+
+/* Change sidebar item color when hovered */
+.sidenav a:hover {
+  color: #f1f1f1;
+}
+
+/* Sidebar home item */
+#home {
+  padding: 6px 8px 10px 16px;
+  font-size: 40px;
+  display: block;
+}

--- a/orc8r/cloud/go/obsidian/swagger/v1/index.html
+++ b/orc8r/cloud/go/obsidian/swagger/v1/index.html
@@ -36,7 +36,7 @@
 
 <!-- Side navigation -->
 <div class="sidenav">
-  <a id = "home" href="./"> Home </a>
+  <a id = "home" class="selected" href="./"> Home </a>
 
   {{ range $idx, $val := .Services}}
   <a href="{{$val}}"> {{ $val }} </a>
@@ -103,6 +103,19 @@ window.onload = function() {
   window.ui = ui
 }
 </script>
+
+<script>
+  let sideBarItems = document.getElementById("home").parentNode.childNodes
+  sideBarItems.forEach((e) => {
+    if(e.href === window.location.href) {
+      e.classList.add("selected")
+    }
+    else if (e.nodeName === "A") {
+      e.classList.remove("selected")
+    }
+  })
+</script>
+
 </body>
 
 </html>

--- a/orc8r/cloud/go/obsidian/swagger/v1/index.html
+++ b/orc8r/cloud/go/obsidian/swagger/v1/index.html
@@ -8,6 +8,7 @@
   <title>Magma API Docs</title>
   <link href="https://fonts.googleapis.com/css?family=Open+Sans:400,700|Source+Code+Pro:300,600|Titillium+Web:400,600,700" rel="stylesheet">
   <link rel="stylesheet" type="text/css" href="../../static/swagger-ui/dist/swagger-ui.css" >
+  <link rel="stylesheet" type="text/css" href="../../v1/static/sidebar.css" >
   <link rel="icon" type="image/png" href="../../static/swagger-ui/dist/favicon-32x32.png" sizes="32x32" />
   <link rel="icon" type="image/png" href="../../static/swagger-ui/dist/favicon-16x16.png" sizes="16x16" />
   <style>
@@ -32,6 +33,15 @@
 </head>
 
 <body>
+
+<!-- Side navigation -->
+<div class="sidenav">
+  <a id = "home" href="./"> Home </a>
+
+  {{ range $idx, $val := .Services}}
+  <a href="{{$val}}"> {{ $val }} </a>
+  {{ end }}
+</div>
 
 <svg xmlns="http://www.w3.org/2000/svg"
      style="position:absolute;width:0;height:0">

--- a/orc8r/cloud/go/obsidian/swagger/v1/index.html
+++ b/orc8r/cloud/go/obsidian/swagger/v1/index.html
@@ -34,12 +34,12 @@
 
 <body>
 
-<!-- Side navigation -->
+<!-- Sidebar navigation -->
 <div class="sidenav">
-  <a id = "home" class="selected" href="./"> Home </a>
+  <a id = "home" {{if eq .SelectedService "" }}class="selected"{{end}} href="./"> Home </a>
 
   {{ range $idx, $val := .Services}}
-  <a href="{{$val}}"> {{ $val }} </a>
+  <a href="{{$val}}" {{if eq $.SelectedService $val}}class="selected"{{end}}> {{ $val }} </a>
   {{ end }}
 </div>
 
@@ -103,19 +103,6 @@ window.onload = function() {
   window.ui = ui
 }
 </script>
-
-<script>
-  let sideBarItems = document.getElementById("home").parentNode.childNodes
-  sideBarItems.forEach((e) => {
-    if(e.href === window.location.href) {
-      e.classList.add("selected")
-    }
-    else if (e.nodeName === "A") {
-      e.classList.remove("selected")
-    }
-  })
-</script>
-
 </body>
 
 </html>


### PR DESCRIPTION
Signed-off-by: Andy Lee Khuu <andykhuu@stanford.edu>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary
The Swagger UI as it is right now is extremely cluttered with all the endpoints being displayed on a singular page. Recently there has been addition of a per service UI feature which enables the user to scope to the endpoints of a particular service. This PR builds upon this feature by adding a sidebar to the Swagger UI, enabling it to be more ergonomic and approachable to the user.
<!-- Enumerate changes you made and why you made them -->

## Test Plan
- [x] cd $MAGMA_ROOT/orc8r/cloud/docker && ./build.py -t ; noti
- [x] Manual Inspection of new Swagger UI
![Screen Shot 2021-03-09 at 2 46 46 PM](https://user-images.githubusercontent.com/46101219/110549426-e489c680-80e6-11eb-933c-2fcfeb46307a.png)
![Screen Shot 2021-03-09 at 2 46 54 PM](https://user-images.githubusercontent.com/46101219/110549431-e6538a00-80e6-11eb-8e15-6fd117b776d1.png)

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
