### PR TITLE
[nms][tf] Add TF options to run Postgres with 2 logical DBs for orc8r/nms

### DIFF
--- a/docs/docusaurus/versioned_docs/version-1.0.0/orc8r/deploy_terraform.md
+++ b/docs/docusaurus/versioned_docs/version-1.0.0/orc8r/deploy_terraform.md
@@ -44,6 +44,8 @@ keypair that you imported or created in the above step:
 $ cat vars.tfvars
 db_password = "foobar"
 nms_db_password = "foobar"
+nms_using_mariadb = true
+nms_using_postgres = false
 key_name = "my_key"
 ```
 

--- a/docs/readmes/orc8r/deploy_install.md
+++ b/docs/readmes/orc8r/deploy_install.md
@@ -126,6 +126,8 @@ new `main.tf` file. Follow the example Terraform root module at
 override the following parameters
 
 - `nms_db_password` must be at least 8 characters
+- `nms_using_mariadb` true/false, for migration off mariadb
+- `nms_using_postgres` true/false, for migration to postgres with orc8r
 - `orc8r_db_password` must be at least 8 characters
 - `orc8r_domain_name` your registered domain name
 - `docker_registry` registry containing desired Orchestrator containers

--- a/orc8r/cloud/deploy/terraform/orc8r-aws/db.tf
+++ b/orc8r/cloud/deploy/terraform/orc8r-aws/db.tf
@@ -32,6 +32,33 @@ resource "aws_db_instance" "default" {
   final_snapshot_identifier = "foo"
 }
 
+# Configure the MySQL provider based on the outcome of
+# creating the aws_db_instance.
+provider "postgresql" {
+  endpoint = "${aws_db_instance.default.endpoint}"
+
+  username = "${aws_db_instance.default.username}"
+  password = "${aws_db_instance.default.password}"
+
+  vpc_security_group_ids = "${aws_db_instance.default.vpc_security_group_ids}"
+
+  db_subnet_group_name = "${aws_db_instance.default.db_subnet_group_name}"
+
+  skip_final_snapshot = "${aws_db_instance.default.skip_final_snapshot}"
+}
+
+resource "postgresql_database" "nms" {
+  allocated_storage = var.nms_db_storage_gb
+
+  name     = var.nms_db_name
+
+  # we only need this as a placeholder value for `terraform destroy` to work,
+  # this won't actually create a final snapshot on destroy
+  final_snapshot_identifier = "nms-bar"
+
+  count = "${var.nms_using_postgres == true ? 1 : 0}"
+}
+
 resource "aws_db_instance" "nms" {
   identifier        = var.nms_db_identifier
   allocated_storage = var.nms_db_storage_gb
@@ -51,4 +78,6 @@ resource "aws_db_instance" "nms" {
   # we only need this as a placeholder value for `terraform destroy` to work,
   # this won't actually create a final snapshot on destroy
   final_snapshot_identifier = "nms-foo"
+
+  count = "${var.nms_using_mariadb == true ? 1 : 0}"
 }

--- a/orc8r/cloud/deploy/terraform/orc8r-aws/examples/basic/main.tf
+++ b/orc8r/cloud/deploy/terraform/orc8r-aws/examples/basic/main.tf
@@ -17,6 +17,8 @@ module orc8r {
   region = "us-west-2"
 
   nms_db_password             = "Faceb00k12345"
+  nms_using_mariadb           = true
+  nms_using_postgres          = false
   orc8r_db_password           = "Faceb00k12345"
   secretsmanager_orc8r_secret = "magma-orc8r-test"
   deployment_secrets_bucket   = "magma.orc8r.test"

--- a/orc8r/cloud/deploy/terraform/orc8r-aws/main.tf
+++ b/orc8r/cloud/deploy/terraform/orc8r-aws/main.tf
@@ -13,4 +13,11 @@
 
 terraform {
   required_version = ">= 0.14"
+
+  required_providers {
+    postgresql = {
+      source = "cyrilgdn/postgresql"
+      version = "1.11.2"
+    }
+  }
 }

--- a/orc8r/cloud/deploy/terraform/orc8r-aws/variables.tf
+++ b/orc8r/cloud/deploy/terraform/orc8r-aws/variables.tf
@@ -284,6 +284,18 @@ variable "nms_db_engine_version" {
   default     = "5.7"
 }
 
+variable "nms_using_mariadb" {
+  description = "Whether NMS is using MariaDB."
+  type        = bool
+  default     = true
+}
+
+variable "nms_using_postgres" {
+  description = "Whether NMS is using Postgres."
+  type        = bool
+  default     = false
+}
+
 ##############################################################################
 # Secretmanager configuration
 ##############################################################################

--- a/orc8r/cloud/deploy/terraform/orc8r-helm-aws/examples/online-upgrade/main.tf
+++ b/orc8r/cloud/deploy/terraform/orc8r-helm-aws/examples/online-upgrade/main.tf
@@ -123,7 +123,7 @@ module orc8r-app {
   orc8r_db_user = module.orc8r.orc8r_db_user
   orc8r_db_pass = module.orc8r.orc8r_db_pass
 
-  nms_db_host = module.orc8r.nms_db_host
+  nms_db_host = var.nms_using_postgres == true ? module.orc8r.orc8r_db_host : module.orc8r.nms_db_host
   nms_db_name = module.orc8r.nms_db_name
   nms_db_user = module.orc8r.nms_db_user
   nms_db_pass = module.orc8r.nms_db_pass

--- a/orc8r/cloud/deploy/terraform/orc8r-helm-aws/examples/online-upgrade/variables.tf
+++ b/orc8r/cloud/deploy/terraform/orc8r-helm-aws/examples/online-upgrade/variables.tf
@@ -230,6 +230,19 @@ variable "deploy_nms" {
   default     = true
 }
 
+variable "nms_using_mariadb" {
+  description = "Whether NMS is using MariaDB."
+  type        = bool
+  default     = true
+}
+
+variable "nms_using_postgres" {
+  description = "Whether NMS is using Postgres."
+  type        = bool
+  default     = false
+}
+
+
 variable "worker_node_policy_suffix" {
   description = "The name suffix of the custom IAM node policy from the v1.0 Terraform root module. This policy name will begin with magma_eks_worker_node_policy."
   type        = string

--- a/orc8r/cloud/deploy/terraform/orc8r-helm-aws/examples/remote/main.tf
+++ b/orc8r/cloud/deploy/terraform/orc8r-helm-aws/examples/remote/main.tf
@@ -26,6 +26,13 @@ terraform {
     dynamodb_table = "my-dynamodb-table"
     region         = "us-west-2"
   }
+
+  required_providers {
+    postgresql = {
+      source = "cyrilgdn/postgresql"
+      version = "1.11.2"
+    }
+  }
 }
 
 provider "aws" {

--- a/orc8r/cloud/deploy/terraform/orc8r-helm-aws/main.tf
+++ b/orc8r/cloud/deploy/terraform/orc8r-helm-aws/main.tf
@@ -212,6 +212,8 @@ data "template_file" "orc8r_values" {
     nms_db_name = var.nms_db_name
     nms_db_host = var.nms_db_host
     nms_db_user = var.nms_db_user
+    nms_using_mariadb = var.nms_using_mariadb
+    nms_using_postgres = var.nms_using_postgres
 
     metrics_pvc_promcfg  = kubernetes_persistent_volume_claim.storage["promcfg"].metadata.0.name
     metrics_pvc_promdata = kubernetes_persistent_volume_claim.storage["promdata"].metadata.0.name

--- a/orc8r/cloud/deploy/terraform/orc8r-helm-aws/variables.tf
+++ b/orc8r/cloud/deploy/terraform/orc8r-helm-aws/variables.tf
@@ -127,6 +127,18 @@ variable "nms_db_user" {
   type        = string
 }
 
+variable "nms_using_mariadb" {
+  description = "Whether NMS is using MariaDB."
+  type        = bool
+  default     = true
+}
+
+variable "nms_using_postgres" {
+  description = "Whether NMS is using Postgres."
+  type        = bool
+  default     = false
+}
+
 ##############################################################################
 # Helm configuration
 ##############################################################################


### PR DESCRIPTION
## Summary

This pull request adds terraform options to choose whether the NMS DB is set up as MariaDB, Postgres, or both, to allow for data migration from MariaDB->Postgres.

To enable NMS to be migrated to use Postgres and share the same AWS RDS instance with orc8r, terraform changes are required. Two new terraform variables are added:
-`nms_using_mariadb`
-`nms_using_postgres`

Before migration, NMS will be using MariaDB, during migration, NMS will use both MariaDB/Postgres, and after migration, NMS will use Postgres only. NMS will share the same AWS RDS instance for Postgres as orc8r, but a separate logical DB will be setup for NMS, to prevent namespace issues.

To migrate, terraform should be configured to use both MariaDB and Postgres, and NMS should detect this automatically, and migrate data from MariaDB to Postgres (coming in a later PR). Terraform should be configured to use Postgres only, and `terraform apply` should be run again.

## Test Plan

To be tested in a test 1.4 deployment after landing.

## Additional Information

- [ ] This change is backwards-breaking
