### PR TITLE
[MME] fix hashtable.c potentially undersized key structure

### DIFF
--- a/lte/gateway/c/oai/lib/hashtable/hashtable.c
+++ b/lte/gateway/c/oai/lib/hashtable/hashtable.c
@@ -457,7 +457,7 @@ hashtable_key_array_t* hashtable_ts_get_keys(hash_table_ts_t* const hashtblP) {
     return NULL;
   }
 
-  ka->keys = calloc(hashtblP->num_elements, sizeof(hash_key_t*));
+  ka->keys = calloc(hashtblP->num_elements, sizeof(hash_key_t));
   if (ka->keys == NULL) {
     free(ka);
     return NULL;
@@ -490,7 +490,7 @@ hashtable_element_array_t* hashtable_ts_get_elements(
     return NULL;
   }
   ea           = calloc(1, sizeof(hashtable_element_array_t));
-  ea->elements = calloc(hashtblP->num_elements, sizeof(hash_key_t*));
+  ea->elements = calloc(hashtblP->num_elements, sizeof(void*));
 
   while ((ea->num_elements < hashtblP->num_elements) && (i < hashtblP->size)) {
     pthread_mutex_lock(&hashtblP->lock_nodes[i]);


### PR DESCRIPTION
## Summary

This is two of ~ten Clang-Tidy findings for check type clang-analyzer-unix.MallocSizeof (see #5326).

- hashtable.c:460
  - Results in under-allocation of hashtable keys if sizeof(hash_key_t*) != sizeof(uint64_t)
    - E.g. 32 bit builds
- hashtable.c:492
  - Results in under-allocation of hashtable keys if sizeof(hash_key_t*) != sizeof(void*)
    - Not guaranteed by [C++11 draft standard](http://www.open-std.org/jtc1/sc22/wg14/www/docs/n1570.pdf) Section 6.2.5 Types para 28

## Test Plan

```
cd lte/gateway
make build_oai
```

Signed-off-by: Scott Harrison Moeller <smoeller@fb.com>