### PR TITLE
[MME] fix hashtable_uint64.c potentially undersized key structure

### DIFF
--- a/lte/gateway/c/oai/lib/hashtable/hashtable_uint64.c
+++ b/lte/gateway/c/oai/lib/hashtable/hashtable_uint64.c
@@ -433,7 +433,7 @@ hashtable_key_array_t* hashtable_uint64_ts_get_keys(
     return NULL;
   }
   ka       = calloc(1, sizeof(hashtable_key_array_t));
-  ka->keys = calloc(hashtblP->num_elements, sizeof(hash_key_t*));
+  ka->keys = calloc(hashtblP->num_elements, sizeof(hash_key_t));
 
   while ((ka->num_keys < hashtblP->num_elements) && (i < hashtblP->size)) {
     pthread_mutex_lock(&hashtblP->lock_nodes[i]);
@@ -463,7 +463,7 @@ hashtable_uint64_element_array_t* hashtable_uint64_ts_get_elements(
   }
 
   ea           = calloc(1, sizeof(hashtable_uint64_element_array_t));
-  ea->elements = calloc(hashtblP->num_elements, sizeof(uint64_t*));
+  ea->elements = calloc(hashtblP->num_elements, sizeof(uint64_t));
 
   while ((ea->num_elements < hashtblP->num_elements) && (i < hashtblP->size)) {
     pthread_mutex_lock(&hashtblP->lock_nodes[i]);


### PR DESCRIPTION
## Summary

This is two of ~ten Clang-Tidy findings for check type clang-analyzer-unix.MallocSizeof (see #5326).

- hashtable_uint64.c:460
  - Results in under-allocation of hashtable keys if sizeof(hash_key_t*) != sizeof(hash_key_t)
    - E.g. 32 bit builds
- hashtable.c_uint64:492
  - Results in under-allocation of hashtable keys if sizeof(uint64_t*) != sizeof(uint64_t)
    - E.g. 32 bit builds

## Test Plan

Validated that the associated clang-tidy findings were resolved.

Additionally:

```
cd lte/gateway
make build_oai
```

Signed-off-by: Scott Harrison Moeller <smoeller@fb.com>