### PR TITLE
[MME] Correct mis-sized allocation of grpc_service_data_t

### DIFF
--- a/lte/gateway/c/oai/tasks/grpc_service/grpc_service_task.c
+++ b/lte/gateway/c/oai/tasks/grpc_service/grpc_service_task.c
@@ -70,7 +70,7 @@ static void* grpc_service_thread(__attribute__((unused)) void* args) {
 
 int grpc_service_init(void) {
   OAILOG_DEBUG(LOG_UTIL, "Initializing grpc_service task interface\n");
-  grpc_service_config                 = calloc(1, sizeof(grpc_service_config));
+  grpc_service_config                 = calloc(1, sizeof(grpc_service_data_t));
   grpc_service_config->server_address = bfromcstr(GRPCSERVICES_SERVER_ADDRESS);
 
   if (itti_create_task(TASK_GRPC_SERVICE, &grpc_service_thread, NULL) < 0) {


### PR DESCRIPTION
## Summary

Incorrect use of sizeof() reference here was probably guarded by the fact that grpc_service_data_t is strictly larger than the intended grpc_service_config struct (performance implications, not safety implications).

## Test Plan

Validated that the associated clang-tidy findings were resolved.

Additionally:

```
cd lte/gateway
make build_oai
```

Signed-off-by: Scott Harrison Moeller <smoeller@fb.com>