### PR TITLE
[MME] Except some nas_precedures.c Clang-Tidy linting

### DIFF
--- a/lte/gateway/c/oai/tasks/nas/nas_procedures.c
+++ b/lte/gateway/c/oai/tasks/nas/nas_procedures.c
@@ -586,7 +586,7 @@ nas_emm_attach_proc_t* nas_new_attach_procedure(
     return NULL;
   }
   emm_context->emm_procedures->emm_specific_proc =
-      calloc(1, sizeof(nas_emm_attach_proc_t));
+      calloc(1, sizeof(nas_emm_attach_proc_t)); // NOLINT(clang-analyzer-unix.MallocSizeof)
   emm_context->emm_procedures->emm_specific_proc->emm_proc.base_proc.nas_puid =
       __sync_fetch_and_add(&nas_puid, 1);
   emm_context->emm_procedures->emm_specific_proc->emm_proc.base_proc.type =
@@ -622,7 +622,7 @@ nas_emm_tau_proc_t* nas_new_tau_procedure(
     return NULL;
   }
   emm_context->emm_procedures->emm_specific_proc =
-      calloc(1, sizeof(nas_emm_tau_proc_t));
+      calloc(1, sizeof(nas_emm_tau_proc_t)); // NOLINT(clang-analyzer-unix.MallocSizeof)
   emm_context->emm_procedures->emm_specific_proc->emm_proc.base_proc.nas_puid =
       __sync_fetch_and_add(&nas_puid, 1);
   emm_context->emm_procedures->emm_specific_proc->emm_proc.base_proc.type =
@@ -656,7 +656,7 @@ nas_sr_proc_t* nas_new_service_request_procedure(
     return NULL;
   }
   emm_context->emm_procedures->emm_con_mngt_proc =
-      calloc(1, sizeof(nas_sr_proc_t));
+      calloc(1, sizeof(nas_sr_proc_t)); // NOLINT(clang-analyzer-unix.MallocSizeof)
   emm_context->emm_procedures->emm_con_mngt_proc->emm_proc.base_proc.nas_puid =
       __sync_fetch_and_add(&nas_puid, 1);
   emm_context->emm_procedures->emm_con_mngt_proc->emm_proc.base_proc.type =


### PR DESCRIPTION
## Summary

These Clang-Tidy linting findings are false positives. The MME uses casting to provide struct inheritance over blocks of allocated memory.  Here we annotate these findings to except them from Linting.

Signed-off-by: Scott Harrison Moeller <smoeller@fb.com>