### PR TITLE
[MME] Except some nas_state_converter Clang-Tidy linting

### DIFF
--- a/lte/gateway/c/oai/tasks/nas/nas_state_converter.cpp
+++ b/lte/gateway/c/oai/tasks/nas/nas_state_converter.cpp
@@ -1075,7 +1075,7 @@ void NasStateConverter::proto_to_emm_specific_proc(
     case oai::NasEmmProcWithType::kAttachProc: {
       OAILOG_DEBUG(LOG_MME_APP, "Reading attach proc from proto");
       state_emm_procedures->emm_specific_proc =
-          (nas_emm_specific_proc_t*) calloc(1, sizeof(nas_emm_attach_proc_t));
+          (nas_emm_specific_proc_t*) calloc(1, sizeof(nas_emm_attach_proc_t)); // NOLINT(clang-analyzer-unix.MallocSizeof)
       nas_emm_attach_proc_t* attach_proc =
           (nas_emm_attach_proc_t*) state_emm_procedures->emm_specific_proc;
 
@@ -1089,7 +1089,7 @@ void NasStateConverter::proto_to_emm_specific_proc(
     }
     case oai::NasEmmProcWithType::kDetachProc: {
       state_emm_procedures->emm_specific_proc =
-          (nas_emm_specific_proc_t*) calloc(1, sizeof(nas_emm_detach_proc_t));
+          (nas_emm_specific_proc_t*) calloc(1, sizeof(nas_emm_detach_proc_t)); // NOLINT(clang-analyzer-unix.MallocSizeof)
       nas_emm_detach_proc_t* detach_proc =
           (nas_emm_detach_proc_t*) state_emm_procedures->emm_specific_proc;
       // read the emm proc content


### PR DESCRIPTION
Summary

Due to the specific use of c-style inheritance and cross-struct-type
casting within the NAS - Clang-Tidy throws
clang-analyzer-unix.MallocSizeof warnings.  As these are intended we
annotate them for linter removal here.

Testing Plan

Confirmed Clang-Tidy findings were removed.

Signed-off-by: Scott Harrison Moeller <smoeller@fb.com>