### PR TITLE
[MME] Fix null pointer dereference in TLVDecoder.c

### DIFF
--- a/lte/gateway/c/oai/common/TLVDecoder.c
+++ b/lte/gateway/c/oai/common/TLVDecoder.c
@@ -41,7 +41,6 @@ int decode_bstring(
     *bstr = blk2bstr(buffer, pdulen);
     return pdulen;
   } else {
-    *bstr = NULL;
     return TLV_BUFFER_TOO_SHORT;
   }
 }


### PR DESCRIPTION
## Summary

In this code branch, `bstr == NULL`.  Removing the assignment of `*bstr = NULL.`

## Test Plan

```
cd lte/gateway
make build_oai
```

And CI Pipelines.

Signed-off-by: Scott Harrison Moeller <smoeller@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
