### PR TITLE
Fix potential null pointer dereference in log.c

### DIFF
--- a/lte/gateway/c/oai/common/log.c
+++ b/lte/gateway/c/oai/common/log.c
@@ -1403,6 +1403,10 @@ void log_message_int(
 error_event:
   if (!(g_oai_log.is_async)) {
     LOG_FREE_ITEM(sync_context_p);
+  } else if (async_context_p == NULL) {
+    // To guard against mutation of is_async during post-init
+    // runtime, though this should not be mutated.
+    return;
   } else {
     LOG_FREE_ITEM_ASYNC(*async_context_p);
   }
@@ -1477,7 +1481,9 @@ void log_message_int_prefix_id(
 error_event:
   if (!(g_oai_log.is_async)) {
     LOG_FREE_ITEM(sync_context_p);
-  } else {
+  } else if (async_context_p == NULL) {
+      return;
+  } else {  
     LOG_FREE_ITEM_ASYNC(*async_context_p);
   }
 }


### PR DESCRIPTION
## Summary

It's unclear to me whether is_async can change over the course of
execution in e.g. log_message_int_prefix_id or log_message_int.

But if this is possible (and static analysis wouldn't know if it
wasn't), then we can pass through the top check of g_oai_log.is_async
and assume it is false -> not initialize async behavior. Then hit an
error in e.g. the bvcformata call and goto error_event -> where it is
conceivable that is_async has toggled to true -> and we now de-reference
it's NULL-initialized value.

Here we add a guard against this sequence of events, however unlikely
given the use pattern of logging (I would note that the g_oai_log
structure is statically initialized, I'm not certain there are
guarantees on the ordering of its initialization and first function
calls?).

## Test Plan

```
cd lte/gateway
make build_oai
make test_oai
```

In addition to CI pipelines.

Signed-off-by: Scott Harrison Moeller <smoeller@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
