### PR TITLE
Adding sgw_s8 task during initialization of main task

### DIFF
--- a/lte/gateway/c/oai/oai_mme/oai_mme.c
+++ b/lte/gateway/c/oai/oai_mme/oai_mme.c
@@ -74,9 +74,9 @@ static int main_init(void) {
   init_task_context(
       TASK_MAIN,
       (task_id_t[]){TASK_MME_APP, TASK_SERVICE303, TASK_SERVICE303_SERVER,
-                    TASK_S6A, TASK_S1AP, TASK_SCTP, TASK_SPGW_APP,
+                    TASK_S6A, TASK_S1AP, TASK_SCTP, TASK_SPGW_APP, TASK_SGW_S8,
                     TASK_GRPC_SERVICE, TASK_LOG, TASK_SHARED_TS_LOG},
-      10, NULL, &main_zmq_ctx);
+      11, NULL, &main_zmq_ctx);
 
   return RETURNok;
 }


### PR DESCRIPTION
[lte][agw]: Adding sgw_s8 task during initialization of main task

## Summary
Looing at the back trace from issue id, https://app.zenhub.com/workspaces/magma-5fac75d3e2cd890011f1677a/issues/magma/magma/5284 and https://app.zenhub.com/workspaces/magma-5fac75d3e2cd890011f1677a/issues/magma/magma/5286.
The crash is observed during start and exit of sgw_s8 task; which would be initiated from main task.

So added sgw_s8 task to initialization of main task. 
I executed sanity with and without the fixes, but I was not able to re-create the scenario and validate the fixes.

## Test Plan
Executed s1ap sanity test suite.