### PR TITLE
MME: GTP-APP: introduce pgw port and ip in tunnel events.

### DIFF
--- a/lte/gateway/c/oai/lib/openflow/controller/ControllerEvents.cpp
+++ b/lte/gateway/c/oai/lib/openflow/controller/ControllerEvents.cpp
@@ -138,9 +138,10 @@ const int UeNetworkInfo::get_vlan() const {
 AddGTPTunnelEvent::AddGTPTunnelEvent(
     const struct in_addr ue_ip, struct in6_addr* ue_ipv6, int vlan,
     const struct in_addr enb_ip, const uint32_t in_tei, const uint32_t out_tei,
-    const char* imsi, uint32_t gtp_port_no)
+    const char* imsi, uint32_t enb_gtp_port)
     : ue_info_(ue_ip, ue_ipv6, vlan),
       enb_ip_(enb_ip),
+      pgw_ip_(INADDR_ZERO),
       in_tei_(in_tei),
       out_tei_(out_tei),
       imsi_(imsi),
@@ -148,15 +149,17 @@ AddGTPTunnelEvent::AddGTPTunnelEvent(
       dl_flow_(),
       dl_flow_precedence_(DEFAULT_PRECEDENCE),
       ExternalEvent(EVENT_ADD_GTP_TUNNEL),
-      gtp_portno_(gtp_port_no) {}
+      enb_gtp_port_(enb_gtp_port),
+      pgw_gtp_port_(0) {}
 
 AddGTPTunnelEvent::AddGTPTunnelEvent(
     const struct in_addr ue_ip, struct in6_addr* ue_ipv6, int vlan,
     const struct in_addr enb_ip, const uint32_t in_tei, const uint32_t out_tei,
     const char* imsi, const struct ip_flow_dl* dl_flow,
-    const uint32_t dl_flow_precedence, uint32_t gtp_port_no)
+    const uint32_t dl_flow_precedence, uint32_t enb_gtp_port)
     : ue_info_(ue_ip, vlan),
       enb_ip_(enb_ip),
+      pgw_ip_(INADDR_ZERO),
       in_tei_(in_tei),
       out_tei_(out_tei),
       imsi_(imsi),
@@ -164,7 +167,48 @@ AddGTPTunnelEvent::AddGTPTunnelEvent(
       dl_flow_(*dl_flow),
       dl_flow_precedence_(dl_flow_precedence),
       ExternalEvent(EVENT_ADD_GTP_TUNNEL),
-      gtp_portno_(gtp_port_no) {}
+      enb_gtp_port_(enb_gtp_port),
+      pgw_gtp_port_(0) {}
+
+  AddGTPTunnelEvent::AddGTPTunnelEvent(
+      const struct in_addr ue_ip, struct in6_addr* ue_ipv6, int vlan,
+      const struct in_addr enb_ip, const struct in_addr pgw_ip,
+      const uint32_t in_tei, const uint32_t out_tei,
+      const char* imsi,
+      const struct ip_flow_dl* dl_flow, const uint32_t dl_flow_precedence,
+      uint32_t enb_gtp_port, uint32_t pgw_gtp_port)
+    : ue_info_(ue_ip, ue_ipv6, vlan),
+      enb_ip_(enb_ip),
+      pgw_ip_(pgw_ip),
+      in_tei_(in_tei),
+      out_tei_(out_tei),
+      imsi_(imsi),
+      dl_flow_valid_(false),
+      dl_flow_(),
+      dl_flow_precedence_(DEFAULT_PRECEDENCE),
+      ExternalEvent(EVENT_ADD_GTP_TUNNEL),
+      enb_gtp_port_(enb_gtp_port),
+      pgw_gtp_port_(pgw_gtp_port) {}
+
+  AddGTPTunnelEvent::AddGTPTunnelEvent(
+      const struct in_addr ue_ip, struct in6_addr* ue_ipv6, int vlan,
+      const struct in_addr enb_ip, const struct in_addr pgw_ip,
+      const uint32_t in_tei, const uint32_t out_tei,
+      const char* imsi,
+      uint32_t enb_gtp_port, uint32_t pgw_gtp_port)
+      : ue_info_(ue_ip, vlan),
+      enb_ip_(enb_ip),
+      pgw_ip_(pgw_ip),
+      in_tei_(in_tei),
+      out_tei_(out_tei),
+      imsi_(imsi),
+      dl_flow_valid_(false),
+      dl_flow_(),
+      dl_flow_precedence_(DEFAULT_PRECEDENCE),
+      ExternalEvent(EVENT_ADD_GTP_TUNNEL),
+      enb_gtp_port_(enb_gtp_port),
+      pgw_gtp_port_(pgw_gtp_port) {}
+
 
 const struct in_addr& AddGTPTunnelEvent::get_ue_ip() const {
   return ue_info_.get_ip();
@@ -176,6 +220,10 @@ const struct UeNetworkInfo& AddGTPTunnelEvent::get_ue_info() const {
 
 const struct in_addr& AddGTPTunnelEvent::get_enb_ip() const {
   return enb_ip_;
+}
+
+const struct in_addr& AddGTPTunnelEvent::get_pgw_ip() const {
+  return pgw_ip_;
 }
 
 const uint32_t AddGTPTunnelEvent::get_in_tei() const {
@@ -202,29 +250,59 @@ const uint32_t AddGTPTunnelEvent::get_dl_flow_precedence() const {
   return dl_flow_precedence_;
 }
 
-const uint32_t AddGTPTunnelEvent::get_gtp_portno() const {
-  return gtp_portno_;
+const uint32_t AddGTPTunnelEvent::get_enb_gtp_portno() const {
+  return enb_gtp_port_;
+}
+
+const uint32_t AddGTPTunnelEvent::get_pgw_gtp_portno() const {
+  return pgw_gtp_port_;
 }
 
 DeleteGTPTunnelEvent::DeleteGTPTunnelEvent(
     const struct in_addr ue_ip, struct in6_addr* ue_ipv6, const uint32_t in_tei,
-    const struct ip_flow_dl* dl_flow, uint32_t gtp_port_no)
+    const struct ip_flow_dl* dl_flow, uint32_t enb_gtp_port)
     : ue_info_(ue_ip, ue_ipv6),
       in_tei_(in_tei),
       dl_flow_valid_(true),
       dl_flow_(*dl_flow),
       ExternalEvent(EVENT_DELETE_GTP_TUNNEL),
-      gtp_portno_(gtp_port_no) {}
+      enb_gtp_port_(enb_gtp_port),
+      pgw_gtp_port_(0) {}
 
 DeleteGTPTunnelEvent::DeleteGTPTunnelEvent(
     const struct in_addr ue_ip, struct in6_addr* ue_ipv6, const uint32_t in_tei,
-    uint32_t gtp_port_no)
+    uint32_t enb_gtp_port)
     : ue_info_(ue_ip, ue_ipv6),
       in_tei_(in_tei),
       dl_flow_valid_(false),
       dl_flow_(),
       ExternalEvent(EVENT_DELETE_GTP_TUNNEL),
-      gtp_portno_(gtp_port_no) {}
+      enb_gtp_port_(enb_gtp_port),
+      pgw_gtp_port_(0) {}
+
+DeleteGTPTunnelEvent::DeleteGTPTunnelEvent(
+      const struct in_addr ue_ip, struct in6_addr* ue_ipv6,
+      const uint32_t in_tei, const struct ip_flow_dl* dl_flow,
+      uint32_t enb_gtp_port, uint32_t pgw_gtp_port)
+    : ue_info_(ue_ip, ue_ipv6),
+      in_tei_(in_tei),
+      dl_flow_valid_(true),
+      dl_flow_(*dl_flow),
+      ExternalEvent(EVENT_DELETE_GTP_TUNNEL),
+      enb_gtp_port_(enb_gtp_port),
+      pgw_gtp_port_(pgw_gtp_port) {}
+
+DeleteGTPTunnelEvent::DeleteGTPTunnelEvent(
+      const struct in_addr ue_ip, struct in6_addr* ue_ipv6,
+      const uint32_t in_tei,
+      uint32_t enb_gtp_port, uint32_t pgw_gtp_port)
+    : ue_info_(ue_ip, ue_ipv6),
+      in_tei_(in_tei),
+      dl_flow_valid_(false),
+      dl_flow_(),
+      ExternalEvent(EVENT_DELETE_GTP_TUNNEL),
+      enb_gtp_port_(enb_gtp_port),
+      pgw_gtp_port_(pgw_gtp_port) {}
 
 const struct UeNetworkInfo& DeleteGTPTunnelEvent::get_ue_info() const {
   return ue_info_;
@@ -246,8 +324,12 @@ const struct ip_flow_dl& DeleteGTPTunnelEvent::get_dl_flow() const {
   return dl_flow_;
 }
 
-const uint32_t DeleteGTPTunnelEvent::get_gtp_portno() const {
-  return gtp_portno_;
+const uint32_t DeleteGTPTunnelEvent::get_enb_gtp_portno() const {
+  return enb_gtp_port_;
+}
+
+const uint32_t DeleteGTPTunnelEvent::get_pgw_gtp_portno() const {
+  return pgw_gtp_port_;
 }
 
 HandleDataOnGTPTunnelEvent::HandleDataOnGTPTunnelEvent(

--- a/lte/gateway/c/oai/lib/openflow/controller/ControllerEvents.h
+++ b/lte/gateway/c/oai/lib/openflow/controller/ControllerEvents.h
@@ -26,6 +26,10 @@ using namespace fluid_msg;
 
 namespace openflow {
 
+static struct in_addr INADDR_ZERO {
+  .s_addr = 0
+};
+
 enum ControllerEventType {
   EVENT_PACKET_IN,
   EVENT_SWITCH_DOWN,
@@ -37,6 +41,8 @@ enum ControllerEventType {
   EVENT_FORWARD_DATA_ON_GTP_TUNNEL,
   EVENT_ADD_PAGING_RULE,
   EVENT_DELETE_PAGING_RULE,
+  EVENT_ADD_GTP_S8_TUNNEL,
+  EVENT_DELETE_GTP_S8_TUNNEL,
 };
 
 /**
@@ -168,41 +174,64 @@ class UeNetworkInfo {
  */
 class AddGTPTunnelEvent : public ExternalEvent {
  public:
-  AddGTPTunnelEvent(
+   AddGTPTunnelEvent(
       const struct in_addr ue_ip, struct in6_addr* ue_ipv6, int vlan,
-      const struct in_addr enb_ip, const uint32_t in_tei,
-      const uint32_t out_tei, const char* imsi,
+      const struct in_addr enb_ip,
+      const uint32_t in_tei, const uint32_t out_tei,
+      const char* imsi,
       const struct ip_flow_dl* dl_flow, const uint32_t dl_flow_precedence,
-      uint32_t gtp_port_no);
+      uint32_t enb_gtp_port);
 
   AddGTPTunnelEvent(
       const struct in_addr ue_ip, struct in6_addr* ue_ipv6, int vlan,
-      const struct in_addr enb_ip, const uint32_t in_tei,
-      const uint32_t out_tei, const char* imsi, uint32_t gtp_port_no);
+      const struct in_addr enb_ip,
+      const uint32_t in_tei, const uint32_t out_tei,
+      const char* imsi,
+      uint32_t enb_gtp_port);
+
+  AddGTPTunnelEvent(
+      const struct in_addr ue_ip, struct in6_addr* ue_ipv6, int vlan,
+      const struct in_addr enb_ip, const struct in_addr pgw_ip,
+      const uint32_t in_tei, const uint32_t out_tei,
+      const char* imsi,
+      const struct ip_flow_dl* dl_flow, const uint32_t dl_flow_precedence,
+      uint32_t enb_gtp_port, uint32_t pgw_gtp_port);
+
+  AddGTPTunnelEvent(
+      const struct in_addr ue_ip, struct in6_addr* ue_ipv6, int vlan,
+      const struct in_addr enb_ip, const struct in_addr pgw_ip,
+      const uint32_t in_tei, const uint32_t out_tei,
+      const char* imsi,
+      uint32_t enb_gtp_port, uint32_t pgw_gtp_port);
 
   const struct UeNetworkInfo& get_ue_info() const;
   const struct in_addr& get_ue_ip() const;
   const struct in_addr& get_ue_ipv6() const;
 
   const struct in_addr& get_enb_ip() const;
+  const struct in_addr& get_pgw_ip() const;
+
   const uint32_t get_in_tei() const;
   const uint32_t get_out_tei() const;
   const std::string& get_imsi() const;
   const bool is_dl_flow_valid() const;
   const struct ip_flow_dl& get_dl_flow() const;
   const uint32_t get_dl_flow_precedence() const;
-  const uint32_t get_gtp_portno() const;
+  const uint32_t get_enb_gtp_portno() const;
+  const uint32_t get_pgw_gtp_portno() const;
 
  private:
   const UeNetworkInfo ue_info_;
   const struct in_addr enb_ip_;
+  const struct in_addr pgw_ip_;
   const uint32_t in_tei_;
   const uint32_t out_tei_;
   const std::string imsi_;
   const struct ip_flow_dl dl_flow_;
   const bool dl_flow_valid_;
   const uint32_t dl_flow_precedence_;
-  const uint32_t gtp_portno_;
+  const uint32_t enb_gtp_port_;
+  const uint32_t pgw_gtp_port_;
 };
 
 /*
@@ -210,28 +239,40 @@ class AddGTPTunnelEvent : public ExternalEvent {
  */
 class DeleteGTPTunnelEvent : public ExternalEvent {
  public:
+   DeleteGTPTunnelEvent(
+      const struct in_addr ue_ip, struct in6_addr* ue_ipv6,
+      const uint32_t in_tei, const struct ip_flow_dl* dl_flow,
+      uint32_t enb_gtp_port);
+  DeleteGTPTunnelEvent(
+      const struct in_addr ue_ip, struct in6_addr* ue_ipv6,
+      const uint32_t in_tei,
+      uint32_t enb_gtp_port);
+
   DeleteGTPTunnelEvent(
       const struct in_addr ue_ip, struct in6_addr* ue_ipv6,
       const uint32_t in_tei, const struct ip_flow_dl* dl_flow,
-      uint32_t gtp_port_no);
+      uint32_t enb_gtp_port, uint32_t pgw_gtp_port);
   DeleteGTPTunnelEvent(
       const struct in_addr ue_ip, struct in6_addr* ue_ipv6,
-      const uint32_t in_tei, uint32_t gtp_port_no);
+      const uint32_t in_tei,
+      uint32_t enb_gtp_port, uint32_t pgw_gtp_port);
 
   const struct UeNetworkInfo& get_ue_info() const;
   const struct in_addr& get_ue_ip() const;
   const uint32_t get_in_tei() const;
   const bool is_dl_flow_valid() const;
   const struct ip_flow_dl& get_dl_flow() const;
-  const uint32_t get_gtp_portno() const;
+  const uint32_t get_enb_gtp_portno() const;
+  const uint32_t get_pgw_gtp_portno() const;
 
  private:
   const UeNetworkInfo ue_info_;
   const uint32_t in_tei_;
   const struct ip_flow_dl dl_flow_;
   const bool dl_flow_valid_;
-  const uint32_t gtp_portno_;
-};
+  const uint32_t enb_gtp_port_;
+  const uint32_t pgw_gtp_port_;
+  };
 
 /*
  * Event triggered by SPGW to either Discard/Forward DL data on GTP tunnel

--- a/lte/gateway/c/oai/lib/openflow/controller/GTPApplication.cpp
+++ b/lte/gateway/c/oai/lib/openflow/controller/GTPApplication.cpp
@@ -131,7 +131,7 @@ void GTPApplication::add_uplink_tunnel_flow(
       convert_precedence_to_priority(ev.get_dl_flow_precedence());
   of13::FlowMod uplink_fm =
       messenger.create_default_flow_mod(0, of13::OFPFC_ADD, flow_priority);
-  add_uplink_match(uplink_fm, ev.get_gtp_portno(), ev.get_in_tei());
+  add_uplink_match(uplink_fm, ev.get_enb_gtp_portno(), ev.get_in_tei());
 
   // Set eth src and dst
   of13::ApplyActions apply_ul_inst;
@@ -176,7 +176,7 @@ void GTPApplication::delete_uplink_tunnel_flow(
   uplink_fm.out_port(of13::OFPP_ANY);
   uplink_fm.out_group(of13::OFPG_ANY);
 
-  add_uplink_match(uplink_fm, ev.get_gtp_portno(), ev.get_in_tei());
+  add_uplink_match(uplink_fm, ev.get_enb_gtp_portno(), ev.get_in_tei());
 
   messenger.send_of_msg(uplink_fm, ev.get_connection());
 }
@@ -329,7 +329,7 @@ void GTPApplication::add_downlink_tunnel_flow_action(
       new of13::TunnelIPv4Dst(ev.get_enb_ip().s_addr));
   apply_dl_inst.add_action(set_tunnel_dst);
 
-  int gtp_port = ev.get_gtp_portno();
+  int gtp_port = ev.get_enb_gtp_portno();
   if (gtp_port == 0) {
     gtp_port = GTPApplication::gtp0_port_num_;
   }


### PR DESCRIPTION
Add PGW ip and port number to Add and Del Tunnel event.
This would be used by inbound roaming event.
This PR does not change any functionality.

Signed-off-by: Pravin B Shelar <pbshelar@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
