### PR TITLE
[fix] freediamter script has wrong version number.

### DIFF
--- a/third_party/build/bin/freediameter_build.sh
+++ b/third_party/build/bin/freediameter_build.sh
@@ -16,7 +16,7 @@ SCRIPT_DIR="$(dirname "$(realpath "$0")")"
 source "${SCRIPT_DIR}"/../lib/util.sh
 GIT_URL=https://github.com/lionelgo/opencord.org.freeDiameter.git
 GIT_COMMIT=13b0e7de0d66906d50e074a339f890d6e59813ad
-PKGVERSION=1.2.0
+PKGVERSION=1.2.0 
 ITERATION=1
 VERSION="${PKGVERSION}"-"${ITERATION}"
 PKGNAME=oai-freediameter

--- a/third_party/build/bin/freediameter_build.sh
+++ b/third_party/build/bin/freediameter_build.sh
@@ -16,7 +16,7 @@ SCRIPT_DIR="$(dirname "$(realpath "$0")")"
 source "${SCRIPT_DIR}"/../lib/util.sh
 GIT_URL=https://github.com/lionelgo/opencord.org.freeDiameter.git
 GIT_COMMIT=13b0e7de0d66906d50e074a339f890d6e59813ad
-PKGVERSION=0.0.1
+PKGVERSION=1.2.0
 ITERATION=1
 VERSION="${PKGVERSION}"-"${ITERATION}"
 PKGNAME=oai-freediameter


### PR DESCRIPTION
[lte][agw] Fixing a problem of the packet version for freediamter library 

## Summary

Packet version of the freediamter library is set to 0.0.1 while the AGW build script creates a dependancy to 1.2.0. This problem was discovered during porting to ARM.

## Test Plan

Generated the freediamter package. Package should show version 1.2.0
Install the generated package. Magma package should be able to install.

## Additional Information

- [ ] This change is backwards-breaking
