### PR TITLE
Add Scott Moeller as a Magma maintainer

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -24,7 +24,7 @@ lte/gateway/c/oai @ssanadhya @ulaskozat @lionelgo @ardzoht
 lte/gateway/c/sctpd @ssanadhya @ulaskozat
 lte/gateway/c/connection_tracker @koolzz
 lte/gateway/docker @rdefosse @tmdzk
-lte/gateway/release @kkahrs @tmdzk
+lte/gateway/release @tmdzk
 lte/gateway/python/magma/pipelined @koolzz @pshelar
 lte/gateway/python/integ_tests @ssanadhya @ulaskozat
 lte/gateway/Vagrantfile @mattymo @119Vik @tmdzk
@@ -38,4 +38,4 @@ feg/radius @AyliD @aharonnovo @r-i-g @themarwhal @mpgermano @uri200 @emakeev
 
 nms/ @karthiksubraveti @andreilee @Scott8440
 
-CODEOWNERS @amarpad
+CODEOWNERS @amarpad @electronjoe


### PR DESCRIPTION
Scott is working on improving the overall developer efficiency of Magma
and has demostrated consistent commitment to the same by integrating
static analysis, clang and build improvements towards the same.
Add him as a maintainer for Magma responsible for the overall developer
effeciency.

Signed-off-by: Amar Padmanabhan <amarpadmanabhan@fb.com>