### PR TITLE
[SubscriberDB] Fix subscriberdb crash + some format leftovers on master

### DIFF
--- a/lte/gateway/c/oai/lib/openflow/controller/ControllerEvents.cpp
+++ b/lte/gateway/c/oai/lib/openflow/controller/ControllerEvents.cpp
@@ -170,13 +170,12 @@ AddGTPTunnelEvent::AddGTPTunnelEvent(
       enb_gtp_port_(enb_gtp_port),
       pgw_gtp_port_(0) {}
 
-  AddGTPTunnelEvent::AddGTPTunnelEvent(
-      const struct in_addr ue_ip, struct in6_addr* ue_ipv6, int vlan,
-      const struct in_addr enb_ip, const struct in_addr pgw_ip,
-      const uint32_t in_tei, const uint32_t out_tei,
-      const char* imsi,
-      const struct ip_flow_dl* dl_flow, const uint32_t dl_flow_precedence,
-      uint32_t enb_gtp_port, uint32_t pgw_gtp_port)
+AddGTPTunnelEvent::AddGTPTunnelEvent(
+    const struct in_addr ue_ip, struct in6_addr* ue_ipv6, int vlan,
+    const struct in_addr enb_ip, const struct in_addr pgw_ip,
+    const uint32_t in_tei, const uint32_t out_tei, const char* imsi,
+    const struct ip_flow_dl* dl_flow, const uint32_t dl_flow_precedence,
+    uint32_t enb_gtp_port, uint32_t pgw_gtp_port)
     : ue_info_(ue_ip, ue_ipv6, vlan),
       enb_ip_(enb_ip),
       pgw_ip_(pgw_ip),
@@ -190,13 +189,12 @@ AddGTPTunnelEvent::AddGTPTunnelEvent(
       enb_gtp_port_(enb_gtp_port),
       pgw_gtp_port_(pgw_gtp_port) {}
 
-  AddGTPTunnelEvent::AddGTPTunnelEvent(
-      const struct in_addr ue_ip, struct in6_addr* ue_ipv6, int vlan,
-      const struct in_addr enb_ip, const struct in_addr pgw_ip,
-      const uint32_t in_tei, const uint32_t out_tei,
-      const char* imsi,
-      uint32_t enb_gtp_port, uint32_t pgw_gtp_port)
-      : ue_info_(ue_ip, vlan),
+AddGTPTunnelEvent::AddGTPTunnelEvent(
+    const struct in_addr ue_ip, struct in6_addr* ue_ipv6, int vlan,
+    const struct in_addr enb_ip, const struct in_addr pgw_ip,
+    const uint32_t in_tei, const uint32_t out_tei, const char* imsi,
+    uint32_t enb_gtp_port, uint32_t pgw_gtp_port)
+    : ue_info_(ue_ip, vlan),
       enb_ip_(enb_ip),
       pgw_ip_(pgw_ip),
       in_tei_(in_tei),
@@ -208,7 +206,6 @@ AddGTPTunnelEvent::AddGTPTunnelEvent(
       ExternalEvent(EVENT_ADD_GTP_TUNNEL),
       enb_gtp_port_(enb_gtp_port),
       pgw_gtp_port_(pgw_gtp_port) {}
-
 
 const struct in_addr& AddGTPTunnelEvent::get_ue_ip() const {
   return ue_info_.get_ip();
@@ -281,9 +278,9 @@ DeleteGTPTunnelEvent::DeleteGTPTunnelEvent(
       pgw_gtp_port_(0) {}
 
 DeleteGTPTunnelEvent::DeleteGTPTunnelEvent(
-      const struct in_addr ue_ip, struct in6_addr* ue_ipv6,
-      const uint32_t in_tei, const struct ip_flow_dl* dl_flow,
-      uint32_t enb_gtp_port, uint32_t pgw_gtp_port)
+    const struct in_addr ue_ip, struct in6_addr* ue_ipv6, const uint32_t in_tei,
+    const struct ip_flow_dl* dl_flow, uint32_t enb_gtp_port,
+    uint32_t pgw_gtp_port)
     : ue_info_(ue_ip, ue_ipv6),
       in_tei_(in_tei),
       dl_flow_valid_(true),
@@ -293,9 +290,8 @@ DeleteGTPTunnelEvent::DeleteGTPTunnelEvent(
       pgw_gtp_port_(pgw_gtp_port) {}
 
 DeleteGTPTunnelEvent::DeleteGTPTunnelEvent(
-      const struct in_addr ue_ip, struct in6_addr* ue_ipv6,
-      const uint32_t in_tei,
-      uint32_t enb_gtp_port, uint32_t pgw_gtp_port)
+    const struct in_addr ue_ip, struct in6_addr* ue_ipv6, const uint32_t in_tei,
+    uint32_t enb_gtp_port, uint32_t pgw_gtp_port)
     : ue_info_(ue_ip, ue_ipv6),
       in_tei_(in_tei),
       dl_flow_valid_(false),

--- a/lte/gateway/c/oai/lib/openflow/controller/ControllerEvents.h
+++ b/lte/gateway/c/oai/lib/openflow/controller/ControllerEvents.h
@@ -26,9 +26,7 @@ using namespace fluid_msg;
 
 namespace openflow {
 
-static struct in_addr INADDR_ZERO {
-  .s_addr = 0
-};
+static struct in_addr INADDR_ZERO { .s_addr = 0 };
 
 enum ControllerEventType {
   EVENT_PACKET_IN,
@@ -174,34 +172,29 @@ class UeNetworkInfo {
  */
 class AddGTPTunnelEvent : public ExternalEvent {
  public:
-   AddGTPTunnelEvent(
+  AddGTPTunnelEvent(
       const struct in_addr ue_ip, struct in6_addr* ue_ipv6, int vlan,
-      const struct in_addr enb_ip,
-      const uint32_t in_tei, const uint32_t out_tei,
-      const char* imsi,
+      const struct in_addr enb_ip, const uint32_t in_tei,
+      const uint32_t out_tei, const char* imsi,
       const struct ip_flow_dl* dl_flow, const uint32_t dl_flow_precedence,
       uint32_t enb_gtp_port);
 
   AddGTPTunnelEvent(
       const struct in_addr ue_ip, struct in6_addr* ue_ipv6, int vlan,
-      const struct in_addr enb_ip,
-      const uint32_t in_tei, const uint32_t out_tei,
-      const char* imsi,
-      uint32_t enb_gtp_port);
+      const struct in_addr enb_ip, const uint32_t in_tei,
+      const uint32_t out_tei, const char* imsi, uint32_t enb_gtp_port);
 
   AddGTPTunnelEvent(
       const struct in_addr ue_ip, struct in6_addr* ue_ipv6, int vlan,
       const struct in_addr enb_ip, const struct in_addr pgw_ip,
-      const uint32_t in_tei, const uint32_t out_tei,
-      const char* imsi,
+      const uint32_t in_tei, const uint32_t out_tei, const char* imsi,
       const struct ip_flow_dl* dl_flow, const uint32_t dl_flow_precedence,
       uint32_t enb_gtp_port, uint32_t pgw_gtp_port);
 
   AddGTPTunnelEvent(
       const struct in_addr ue_ip, struct in6_addr* ue_ipv6, int vlan,
       const struct in_addr enb_ip, const struct in_addr pgw_ip,
-      const uint32_t in_tei, const uint32_t out_tei,
-      const char* imsi,
+      const uint32_t in_tei, const uint32_t out_tei, const char* imsi,
       uint32_t enb_gtp_port, uint32_t pgw_gtp_port);
 
   const struct UeNetworkInfo& get_ue_info() const;
@@ -239,14 +232,13 @@ class AddGTPTunnelEvent : public ExternalEvent {
  */
 class DeleteGTPTunnelEvent : public ExternalEvent {
  public:
-   DeleteGTPTunnelEvent(
+  DeleteGTPTunnelEvent(
       const struct in_addr ue_ip, struct in6_addr* ue_ipv6,
       const uint32_t in_tei, const struct ip_flow_dl* dl_flow,
       uint32_t enb_gtp_port);
   DeleteGTPTunnelEvent(
       const struct in_addr ue_ip, struct in6_addr* ue_ipv6,
-      const uint32_t in_tei,
-      uint32_t enb_gtp_port);
+      const uint32_t in_tei, uint32_t enb_gtp_port);
 
   DeleteGTPTunnelEvent(
       const struct in_addr ue_ip, struct in6_addr* ue_ipv6,
@@ -254,8 +246,7 @@ class DeleteGTPTunnelEvent : public ExternalEvent {
       uint32_t enb_gtp_port, uint32_t pgw_gtp_port);
   DeleteGTPTunnelEvent(
       const struct in_addr ue_ip, struct in6_addr* ue_ipv6,
-      const uint32_t in_tei,
-      uint32_t enb_gtp_port, uint32_t pgw_gtp_port);
+      const uint32_t in_tei, uint32_t enb_gtp_port, uint32_t pgw_gtp_port);
 
   const struct UeNetworkInfo& get_ue_info() const;
   const struct in_addr& get_ue_ip() const;
@@ -272,7 +263,7 @@ class DeleteGTPTunnelEvent : public ExternalEvent {
   const bool dl_flow_valid_;
   const uint32_t enb_gtp_port_;
   const uint32_t pgw_gtp_port_;
-  };
+};
 
 /*
  * Event triggered by SPGW to either Discard/Forward DL data on GTP tunnel

--- a/lte/gateway/configs/subscriberdb.yml
+++ b/lte/gateway/configs/subscriberdb.yml
@@ -14,7 +14,7 @@
 # log_level is set in mconfig. it can be overridden here
 
 # Append GRPC content to the log
-print_grpc_payload: true
+print_grpc_payload: false
 
 # Host address of the Diameter/S6A MME server
 host_address: 0.0.0.0 # Bind to all interfaces

--- a/lte/gateway/python/magma/subscriberdb/main.py
+++ b/lte/gateway/python/magma/subscriberdb/main.py
@@ -44,7 +44,7 @@ def main():
     # Add all servicers to the server
     subscriberdb_servicer = SubscriberDBRpcServicer(
         store,
-        service.mconfig.get('print_grpc_payload', False))
+        service.config.get('print_grpc_payload', False))
     subscriberdb_servicer.add_to_server(service.rpc_server)
 
 

--- a/lte/gateway/python/magma/subscriberdb/rpc_servicer.py
+++ b/lte/gateway/python/magma/subscriberdb/rpc_servicer.py
@@ -46,7 +46,10 @@ class SubscriberDBRpcServicer(subscriberdb_pb2_grpc.SubscriberDBServicer):
         """
         Adds a subscriber to the store
         """
-        self._print_grpc(request)
+        try:
+            self._print_grpc(request)
+        except Exception as e:  # pylint: disable=broad-except
+            logging.debug("Exception while trying to log GRPC: %s", e)
         sid = SIDUtils.to_str(request.sid)
         logging.debug("Add subscriber rpc for sid: %s", sid)
         try:
@@ -60,7 +63,10 @@ class SubscriberDBRpcServicer(subscriberdb_pb2_grpc.SubscriberDBServicer):
         """
         Deletes a subscriber from the store
         """
-        self._print_grpc(request)
+        try:
+            self._print_grpc(request)
+        except Exception as e:  # pylint: disable=broad-except
+            logging.debug("Exception while trying to log GRPC: %s", e)
         sid = SIDUtils.to_str(request)
         logging.debug("Delete subscriber rpc for sid: %s", sid)
         self._store.delete_subscriber(sid)
@@ -70,7 +76,10 @@ class SubscriberDBRpcServicer(subscriberdb_pb2_grpc.SubscriberDBServicer):
         """
         Updates the subscription data
         """
-        self._print_grpc(request)
+        try:
+            self._print_grpc(request)
+        except Exception as e:  # pylint: disable=broad-except
+            logging.debug("Exception while trying to log GRPC: %s", e)
         sid = SIDUtils.to_str(request.data.sid)
         try:
             with self._store.edit_subscriber(sid) as subs:
@@ -85,7 +94,10 @@ class SubscriberDBRpcServicer(subscriberdb_pb2_grpc.SubscriberDBServicer):
         """
         Returns the subscription data for the subscriber
         """
-        self._print_grpc(request)
+        try:
+            self._print_grpc(request)
+        except Exception as e:  # pylint: disable=broad-except
+            logging.debug("Exception while trying to log GRPC: %s", e)
         sid = SIDUtils.to_str(request)
         try:
             return self._store.get_subscriber_data(sid)
@@ -98,7 +110,10 @@ class SubscriberDBRpcServicer(subscriberdb_pb2_grpc.SubscriberDBServicer):
         """
         Returns a list of subscribers from the store
         """
-        self._print_grpc(request)
+        try:
+            self._print_grpc(request)
+        except Exception as e:  # pylint: disable=broad-except
+            logging.debug("Exception while trying to log GRPC: %s", e)
         sids = self._store.list_subscribers()
         sid_msgs = [SIDUtils.to_pb(sid) for sid in sids]
         return subscriberdb_pb2.SubscriberIDSet(sids=sid_msgs)


### PR DESCRIPTION
Signed-off-by: Marie Bremner <marwhal@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary
Seeing this on master + s1ap tests are failing with subscriberdb error
```
Mar 05 20:40:18 magma-dev subscriberdb[15390]: Traceback (most recent call last):
Mar 05 20:40:18 magma-dev subscriberdb[15390]:   File "/usr/lib/python3.5/runpy.py", line 193, in _run_module_as_main
Mar 05 20:40:18 magma-dev subscriberdb[15390]:     "__main__", mod_spec)
Mar 05 20:40:18 magma-dev subscriberdb[15390]:   File "/usr/lib/python3.5/runpy.py", line 85, in _run_code
Mar 05 20:40:18 magma-dev subscriberdb[15390]:     exec(code, run_globals)
Mar 05 20:40:18 magma-dev subscriberdb[15390]:   File "/home/vagrant/magma/lte/gateway/python/magma/subscriberdb/main.py", line 109, in <module>
Mar 05 20:40:18 magma-dev subscriberdb[15390]:     main()
Mar 05 20:40:18 magma-dev subscriberdb[15390]:   File "/home/vagrant/magma/lte/gateway/python/magma/subscriberdb/main.py", line 47, in main
Mar 05 20:40:18 magma-dev subscriberdb[15390]:     service.mconfig.get('print_grpc_payload', False))
Mar 05 20:40:18 magma-dev subscriberdb[15390]: AttributeError: get
```
The grpc config is supposed to come from the service config, not mconfig.
<!-- Enumerate changes you made and why you made them -->

## Test Plan
run gw, no crash
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
