### PR TITLE
[feg] Fix s8_cli user plane ip

### DIFF
--- a/feg/gateway/tools/s8_cli/main.go
+++ b/feg/gateway/tools/s8_cli/main.go
@@ -172,7 +172,7 @@ func createSession(cmd *commands.Command, args []string) int {
 		BearerContext: &protos.BearerContext{
 			Id: bearerId,
 			UserPlaneFteid: &protos.Fteid{
-				Ipv4Address: generateRandomIPv4(),
+				Ipv4Address: "11.11.11.11",
 				Ipv6Address: "",
 				Teid:        uint32(AGWTeidU),
 			},


### PR DESCRIPTION
Signed-off-by: Oriol Batalla <obatalla@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary

Used fixed ip for User plane to avoid creation of multiple tunnels at PGW

This IP is a fake IP, so it does not have any impact in the client

## Test Plan

teravm test

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
