### PR TITLE
[fix] fixing the OVS makefile to support multi architecture

### DIFF
--- a/third_party/gtp_ovs/kernel-4.9/2.8.9/0003-Build-symbols-for-gtp-vport-linux-4.9-module-require.patch
+++ b/third_party/gtp_ovs/kernel-4.9/2.8.9/0003-Build-symbols-for-gtp-vport-linux-4.9-module-require.patch
@@ -20,7 +20,7 @@ index c847d2853..90ecce19b 100755
  
 +
 +	# make GTP flow based kernel patch
-+	cd flow-based-gtp-linux-v4.9 && $(MAKE) build
++	cd flow-based-gtp-linux-v4.9 && $(MAKE) build ARCH=$(ARCH) KVERS=$(KVERS) LDFLAGS=""
 +	cp flow-based-gtp-linux-v4.9/Module.symvers debian/$(PACKAGE_DKMS)/usr/src/$(PACKAGE)-$(DEB_VERSION_UPSTREAM)/datapath/linux
 +
  	# Prepare dkms.conf from the dkms.conf.in template
@@ -34,7 +34,7 @@ index b0c6cdcee..c0b29af86 100755
  	dh_testroot
  	dh_clean -k
  	tar xzf openvswitch.tar.gz
-+	cd flow-based-gtp-linux-v4.9 && $(MAKE) package
++	cd flow-based-gtp-linux-v4.9 && $(MAKE) package ARCH=$(ARCH) KVERS=$(KVERS)
 +	mv flow-based-gtp-linux-v4.9/*.deb $(DEB_DESTDIR)
 +	cp flow-based-gtp-linux-v4.9/Module.symvers openvswitch/datapath/linux
  	cd openvswitch && ./configure --with-linux=$(KSRC) $(DATAPATH_CONFIGURE_OPTS)

--- a/third_party/gtp_ovs/kernel-4.9/gtp-v4.9-backport/Makefile
+++ b/third_party/gtp_ovs/kernel-4.9/gtp-v4.9-backport/Makefile
@@ -2,7 +2,6 @@ PKGNAME=oai-gtp
 VERSION=4.9
 ITERATION=9
 
-ARCH=amd64
 PKGFMT=deb
 WORK_DIR=/tmp/build-${PKGNAME}
 PKGFILE=${PKGNAME}_${VERSION}-${ITERATION}_${ARCH}.${PKGFMT}
@@ -15,10 +14,10 @@ OUTPUT_PATH=${OUTPUT_DIR}/${PKGFILE}
 obj-m += gtp.o
 
 build:
-	make -C /lib/modules/`uname -r`/build M=$(PWD) modules
+	make -C /lib/modules/$(KVERS)/build M=$(PWD) modules
 
 modules_install: build
-	make -C /lib/modules/`uname -r`/build M=$(PWD) modules_install
+	make -C /lib/modules/$(KVERS)/build M=$(PWD) modules_install
 	mkdir -p ${DEPMOD_CONFIG_DIR}
 	echo "override gtp.ko * extra" >> ${DEPMOD_CONFIG_FILE}
 	echo "override gtp.ko * weak-updates" >> ${DEPMOD_CONFIG_FILE}
@@ -27,7 +26,7 @@ modules_install: build
 package: build 
 	rm -rf ${WORK_DIR}
 	mkdir ${WORK_DIR}
-	make INSTALL_MOD_PATH=${WORK_DIR} -C /lib/modules/`uname -r`/build M=$(PWD) modules_install
+	make INSTALL_MOD_PATH=${WORK_DIR} -C /lib/modules/$(KVERS)/build M=$(PWD) modules_install
 	fpm \
 	    -f \
 	    -s dir \
@@ -45,4 +44,4 @@ package: build
 	    -C ${WORK_DIR}
 
 clean:
-	make -C /lib/modules/`uname -r`/build M=$(PWD) clean
+	make -C /lib/modules/$(KVERS)/build M=$(PWD) clean


### PR DESCRIPTION
[lte][ovs] Modifying OVS makefile to support the multi architecture parameters
## Summary

After the fix the make fill use the variables defined from the build
script instead of the hardcoded values for the kernel version and
architecture.

## Test Plan

Build for `arm64` should generate the packages for `arm64` architecture

## Additional Information

- [ ] This change is backwards-breaking
- [x] Mandatory for multi-platform build
- [x] Depends on  #5352 for the testing and build to work