### PR TITLE
[lte][agw] Scptd modifications to avoid burst after mme recovery

### DIFF
--- a/lte/gateway/c/sctpd/sctp_connection.cpp
+++ b/lte/gateway/c/sctpd/sctp_connection.cpp
@@ -145,11 +145,16 @@ void SctpConnection::Listen() {
 
         auto status = HandleClientSock(client_sd);
 
-        if (status == SctpStatus::DISCONNECT) {
+        if ((status == SctpStatus::DISCONNECT) ||
+            (status == SctpStatus::NEW_ASSOC_NOTIF_FAILED)) {
           if (epoll_ctl(epoll_fd, EPOLL_CTL_DEL, client_sd, nullptr) < 0) {
             MLOG_perror("epoll_ctl");
             std::terminate();
           }
+        }
+
+        if (status == SctpStatus::NEW_ASSOC_NOTIF_FAILED) {
+          shutdown(client_sd, 0);
         }
       }
     }
@@ -261,9 +266,12 @@ SctpStatus SctpConnection::HandleComUp(
   std::string ran_cp_ipaddr;
   pull_peer_ipaddr(sd, change->sac_assoc_id, ran_cp_ipaddr);
 
-  _handler.HandleNewAssoc(
-      assoc.ppid, change->sac_assoc_id, change->sac_inbound_streams,
-      change->sac_outbound_streams, ran_cp_ipaddr);
+  if (_handler.HandleNewAssoc(
+          change->sac_assoc_id, change->sac_inbound_streams,
+          change->sac_outbound_streams, ran_cp_ipaddr) < 0) {
+    _sctp_desc.delAssoc(assoc.assoc_id);
+    return SctpStatus::NEW_ASSOC_NOTIF_FAILED;
+  }
 
   return SctpStatus::OK;
 }

--- a/lte/gateway/c/sctpd/sctp_connection.cpp
+++ b/lte/gateway/c/sctpd/sctp_connection.cpp
@@ -267,7 +267,7 @@ SctpStatus SctpConnection::HandleComUp(
   pull_peer_ipaddr(sd, change->sac_assoc_id, ran_cp_ipaddr);
 
   if (_handler.HandleNewAssoc(
-          change->sac_assoc_id, change->sac_inbound_streams,
+          assoc.ppid, change->sac_assoc_id, change->sac_inbound_streams,
           change->sac_outbound_streams, ran_cp_ipaddr) < 0) {
     _sctp_desc.delAssoc(assoc.assoc_id);
     return SctpStatus::NEW_ASSOC_NOTIF_FAILED;

--- a/lte/gateway/c/sctpd/sctp_connection.h
+++ b/lte/gateway/c/sctpd/sctp_connection.h
@@ -29,16 +29,17 @@ namespace sctpd {
 
 // Describes status of Sctp event (up or down stream)
 enum class SctpStatus {
-  OK,          // Sctp event was ok
-  FAILURE,     // General failure - nonfatal
-  DISCONNECT,  // Sctp assoc disconnected
+  OK,                      // Sctp event was ok
+  FAILURE,                 // General failure - nonfatal
+  DISCONNECT,              // Sctp assoc disconnected
+  NEW_ASSOC_NOTIF_FAILED,  // GRPC call for new assoc notification failed
 };
 
 // Interface for upstream Sctp event handling
 class SctpEventHandler {
  public:
   // Specification for NewAssoc handler function
-  virtual void HandleNewAssoc(
+  virtual int HandleNewAssoc(
       uint32_t ppid, uint32_t assoc_id, uint32_t instreams, uint32_t outstreams,
       std::string& ran_cp_ipaddr) = 0;
 

--- a/lte/gateway/c/sctpd/sctpd_event_handler.cpp
+++ b/lte/gateway/c/sctpd/sctpd_event_handler.cpp
@@ -21,7 +21,7 @@ namespace sctpd {
 SctpdEventHandler::SctpdEventHandler(SctpdUplinkClient& client)
     : _client(client) {}
 
-void SctpdEventHandler::HandleNewAssoc(
+int SctpdEventHandler::HandleNewAssoc(
     uint32_t ppid, uint32_t assoc_id, uint32_t instreams, uint32_t outstreams,
     std::string& ran_cp_ipaddr) {
   NewAssocReq req;
@@ -33,7 +33,7 @@ void SctpdEventHandler::HandleNewAssoc(
   req.set_outstreams(outstreams);
   req.set_ran_cp_ipaddr(ran_cp_ipaddr);
 
-  _client.newAssoc(req, &res);
+  return _client.newAssoc(req, &res);
 }
 
 void SctpdEventHandler::HandleCloseAssoc(

--- a/lte/gateway/c/sctpd/sctpd_event_handler.h
+++ b/lte/gateway/c/sctpd/sctpd_event_handler.h
@@ -27,7 +27,7 @@ class SctpdEventHandler : public SctpEventHandler {
   explicit SctpdEventHandler(SctpdUplinkClient& client);
 
   // Relay new assocation to MME/AMF over GRPC
-  void HandleNewAssoc(
+  int HandleNewAssoc(
       uint32_t ppid, uint32_t assoc_id, uint32_t instreams, uint32_t outstreams,
       std::string& ran_cp_ipaddr) override;
 

--- a/lte/gateway/c/sctpd/sctpd_uplink_client.cpp
+++ b/lte/gateway/c/sctpd/sctpd_uplink_client.cpp
@@ -46,6 +46,9 @@ int SctpdUplinkClient::newAssoc(const NewAssocReq& req, NewAssocRes* res) {
   assert(res != nullptr);
 
   ClientContext context;
+  auto deadline = std::chrono::system_clock::now() +
+                  std::chrono::milliseconds(1000 * RESPONSE_TIMEOUT);
+  context.set_deadline(deadline);
 
   auto status = _stub->NewAssoc(&context, req, res);
 
@@ -62,7 +65,7 @@ int SctpdUplinkClient::closeAssoc(
   assert(res != nullptr);
 
   ClientContext context;
-
+  // Not putting a timeout event for closeAssoc events
   auto status = _stub->CloseAssoc(&context, req, res);
 
   if (!status.ok()) {

--- a/lte/gateway/c/sctpd/sctpd_uplink_client.cpp
+++ b/lte/gateway/c/sctpd/sctpd_uplink_client.cpp
@@ -10,9 +10,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#include <chrono>
 
 #include "sctpd_uplink_client.h"
-
 #include "util.h"
 
 namespace magma {
@@ -28,6 +28,9 @@ int SctpdUplinkClient::sendUl(const SendUlReq& req, SendUlRes* res) {
   assert(res != nullptr);
 
   ClientContext context;
+  auto deadline = std::chrono::system_clock::now() +
+                  std::chrono::milliseconds(1000 * RESPONSE_TIMEOUT);
+  context.set_deadline(deadline);
 
   auto status = _stub->SendUl(&context, req, res);
 

--- a/lte/gateway/c/sctpd/sctpd_uplink_client.h
+++ b/lte/gateway/c/sctpd/sctpd_uplink_client.h
@@ -40,6 +40,8 @@ class SctpdUplinkClient {
  private:
   // Stub used for client to communicate with server
   std::unique_ptr<SctpdUplink::Stub> _stub;
+  // GRPC call timeout
+  static const uint32_t RESPONSE_TIMEOUT = 2;  // seconds
 };
 
 }  // namespace sctpd


### PR DESCRIPTION
## Summary

In stateless mode, when mme crashes, sctpd was queuing up duplicate events from the same UE towards MME due to UE timers. This PR makes the following improvements:
- Place an explicit short time out for uplink rpc calls for s1ap requests to prevent bursts of S1AP requests towards UE that were queued up during the MME recovery.
- When a new association event comes in and it cannot be delivered to MME, close the association.

## Test Plan

Spirent tests and S1 AP tests with forced MME restarts.

## Additional Information

- [ ] This change is backwards-breaking
