### PR TITLE
[AGW] Remove -Werror compiler flag everywhere, add -Wextra

### DIFF
--- a/lte/gateway/c/connection_tracker/CMakeLists.txt
+++ b/lte/gateway/c/connection_tracker/CMakeLists.txt
@@ -38,7 +38,7 @@ add_definitions(-DLOG_WITH_GLOG)
 
 message("Build type is ${CMAKE_BUILD_TYPE}")
 if (CMAKE_BUILD_TYPE STREQUAL "Debug")
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Werror -Wno-unused-function")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra")
 endif ()
 
 include_directories("${OUTPUT_DIR}")

--- a/lte/gateway/c/oai/CMakeLists.txt
+++ b/lte/gateway/c/oai/CMakeLists.txt
@@ -26,7 +26,7 @@ endif ()
 
 # TODO (amar) check all the flags used. Copied as is from OAI.
 set(CMAKE_C_FLAGS
-  "${CMAKE_C_FLAGS} ${C_FLAGS_PROCESSOR} -std=gnu99 -Wall -Werror -Wstrict-prototypes -fno-strict-aliasing -rdynamic -funroll-loops -Wno-packed-bitfield-compat -fPIC"
+  "${CMAKE_C_FLAGS} ${C_FLAGS_PROCESSOR} -std=gnu99 -Wall -Wextra -Wstrict-prototypes -fno-strict-aliasing -rdynamic -funroll-loops -fPIC"
 )
 
 # add autoTOOLS definitions that were maybe used

--- a/lte/gateway/c/session_manager/CMakeLists.txt
+++ b/lte/gateway/c/session_manager/CMakeLists.txt
@@ -42,7 +42,7 @@ add_definitions(-DLOG_WITH_GLOG)
 
 message("Build type is ${CMAKE_BUILD_TYPE}")
 if (CMAKE_BUILD_TYPE STREQUAL "Debug")
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Werror -Wno-unused-function")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra")
 endif ()
 
 include_directories("${OUTPUT_DIR}")


### PR DESCRIPTION
# Summary

Per  [This](https://github.com/magma/magma/discussions/5273) GH Discussion, here we drop the Werror compiler flag.  In its place, we offer #5404 which is capable of Github Pull Request GCC Warning annotations for code reviewers.

With `-Werror` gone, we also turn up the warnings by adding `-Wextra` and remove some suppressed warnings.

There are some places where `-Wextra` is noisy - e.g. functions that have unused parameters because they are callback driven and have to contain a specified shape.  We should be able to mitigate these warnings by appropriate modification of the unused parameter declaration. E.g. in C++ as advocated by [Herb Sutter](https://herbsutter.com/2009/10/18/mailbag-shutting-up-compiler-warnings/) and in C by omitting the name or void casting.

```
void foo(int /*bar_unused*/) {
    ...
}
```

or

```
void foo(int bar_unused) {
    // bar_unused is not needed for this function, but must exist to meet interface expectations
    (void)bar_unused;
    ...
}
```

Signed-off-by: Scott Harrison Moeller <smoeller@fb.com>