### PR TITLE
[CI][OAI] when failing on the DsTester pipeline, logs are retrieved

### DIFF
--- a/ci-scripts/JenkinsFile-OAI-Container-GitHub
+++ b/ci-scripts/JenkinsFile-OAI-Container-GitHub
@@ -182,6 +182,19 @@ pipeline {
         }
       }
       post {
+        unsuccessful {
+          script {
+            // In case of failure during DsTester pipeline
+            // Retrieve the logs so developer does not need to look for them
+            copyArtifacts(projectName: dsTesterPipelineName,
+                          filter: 'fed_docker_logs.zip',
+                          elector: lastCompleted())
+            if (fileExists('fed_docker_logs.zip')) {
+              sh "mv fed_docker_logs.zip ds_tester_fed_docker_logs.zip"
+              archiveArtifacts artifacts: 'ds_tester_fed_docker_logs.zip'
+            }
+          }
+        }
         always {
           script {
             copyArtifacts(projectName: dsTesterPipelineName,


### PR DESCRIPTION
And stored as an artifact of the main pipeline

Signed-off-by: Raphael Defosseux <raphael.defosseux@openairinterface.org>

## Summary

Based on a discussion w/ Scott Moeller, easier for developer to see the logs when it failed.

## Test Plan

None required. Already in production

## Additional Information

- [ ] This change is backwards-breaking
