### PR TITLE
Enable Clang Warning CircleCI analysis for MME

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -799,6 +799,22 @@ jobs:
             ci_env=`bash <(curl -s https://codecov.io/env)`
             docker run $ci_env -e CI=true -v /home/circleci/project:/magma -v /home/circleci/project/lte/gateway/configs:/etc/magma -i -t magma/c_cpp_build:latest /bin/bash -c "cd /magma/lte/gateway;make coverage;ls -al /tmp/;bash <(curl -s https://codecov.io/bash) -f /build/c/coverage.info"
 
+  mme-clang-warnings:
+    machine:
+      image: ubuntu-2004:202010-01
+      docker_layer_caching: true
+    environment:
+      MAGMA_ROOT: /home/circleci/project
+      BRANCH: << pipeline.git.branch >>
+      REVISION: << pipeline.git.revision >>
+    steps:
+      - checkout
+      - run:
+          command: |
+            cd $MAGMA_ROOT/lte/gateway/docker/mme
+            docker build -t magma-mme-build -f Dockerfile.ubuntu20.04 ../../../../
+            docker run --env BRANCH=$BRANCH --env REVISION=$REVISION -v /home/circleci/project:/magma -v /home/circleci/project/lte/gateway/configs:/etc/magma -i -t magma-mme-build:latest /bin/bash -c "cd /magma/lte/gateway;make clang_warning_oai_upload"
+
   lte-test:
     machine:
       image: ubuntu-1604:201903-01
@@ -1165,6 +1181,8 @@ workflows:
     jobs:
       - lte-test
       - mme-clang-tidy:
+          <<: *only_master
+      - mme-clang-warnings:
           <<: *only_master
       - lte-integ-test:
           <<: *master_and_develop

--- a/lte/gateway/Makefile
+++ b/lte/gateway/Makefile
@@ -151,6 +151,33 @@ build_common: format_common ## Build shared libraries
 build_oai: format_oai build_common ## Build OAI
 	$(call run_cmake, $(C_BUILD)/oai, $(GATEWAY_C_DIR)/oai, $(OAI_FLAGS) $(COMMON_FLAGS))
 
+build_oai_clang: build_common ## Build OAI with Clang, store compiler outputs to log
+	$(call run_cmake, $(C_BUILD)/oai, $(GATEWAY_C_DIR)/oai, $(OAI_FLAGS) $(COMMON_FLAGS), CC="clang" CXX="clang++") 2>&1 | tee /tmp/clang-build.oai.log
+
+# Upload Clang-Warning counts by type to Google Sheet via Google Survey
+#  Graph available at https://docs.google.com/spreadsheets/d/1ndiIKJNI2IJZBwavnu1x_KwwvlQppnoYEOtYdihqiIQ/edit#gid=734064581
+# TODO: Move to a third party service (I could not find) or make a binary that parses + uploads this without missing new warning types.
+clang_warning_oai_upload: build_oai_clang ## Generate and then upload warning statistics to Google Survey for telemetry
+	curl -L -v -G -Ss \
+		--data-urlencode "entry.608561103=$(BRANCH)" \
+		--data-urlencode "entry.1257088109=$(REVISION)" \
+		--data-urlencode "entry.708918097=OAI" \
+		--data-urlencode "entry.1995144005=$(shell grep '\[-Wconstant-conversion\]' /tmp/clang-build.oai.log | wc -l)" \
+		--data-urlencode "entry.889426184=$(shell grep '\[-Wdeprecated-declarations\]' /tmp/clang-build.oai.log | wc -l)" \
+		--data-urlencode "entry.6143542=$(shell grep '\[-Wenum-conversion\]' /tmp/clang-build.oai.log | wc -l)" \
+		--data-urlencode "entry.1953446373=$(shell grep '\[-Wextern-c-compat\]' /tmp/clang-build.oai.log | wc -l)" \
+		--data-urlencode "entry.1508747323=$(shell grep '\[-Winconsistent-missing-override\]' /tmp/clang-build.oai.log | wc -l)" \
+		--data-urlencode "entry.1682903653=$(shell grep '\[-Winitializer-overrides\]' /tmp/clang-build.oai.log | wc -l)" \
+		--data-urlencode "entry.1030484709=$(shell grep '\[-Wnon-c-typedef-for-linkage\]' /tmp/clang-build.oai.log | wc -l)" \
+		--data-urlencode "entry.1885910120=$(shell grep '\[-Wnull-dereference\]' /tmp/clang-build.oai.log | wc -l)" \
+		--data-urlencode "entry.411691731=$(shell grep '\[-Wparentheses-equality\]' /tmp/clang-build.oai.log | wc -l)" \
+		--data-urlencode "entry.872392934=$(shell grep '\[-Wpointer-bool-conversion\]' /tmp/clang-build.oai.log | wc -l)" \
+		--data-urlencode "entry.1058267165=$(shell grep '\[-Wtautological-constant-out-of-range-compare\]' /tmp/clang-build.oai.log | wc -l)" \
+		--data-urlencode "entry.1145616398=$(shell grep '\[-Wtautological-overlap-compare\]' /tmp/clang-build.oai.log | wc -l)" \
+		--data-urlencode "entry.1265654844=$(shell grep '\[-Wtautological-pointer-compare\]' /tmp/clang-build.oai.log | wc -l)" \
+		--data-urlencode "entry.599425517=$(shell grep '\[-Wtypedef-redefinition\]' /tmp/clang-build.oai.log | wc -l)" \
+		https://docs.google.com/forms/d/e/1FAIpQLScKB3nLPASxzr4AXW5_yeHCjkEURY0K9OAFPIyNFzkA5CY_kw/formResponse?usp=pp_url
+
 build_sctpd: format_sctpd build_common ## Build SCTPD
 	$(call run_cmake, $(C_BUILD)/sctpd, $(GATEWAY_C_DIR)/sctpd, )
 


### PR DESCRIPTION
Summary

This PR enables a CI-built docker run of Clang build for the MME, then scrapes the warnings and posts to a Google Survey for telemetry monitoring over time (e.g. to measure burn-down of warnings).  Warnings are available in the CI logs and are summarized by count at the end of the build.

Test Results

Observe the [Public Google Sheet with automatic update & Graph of Warnings-by-count](https://docs.google.com/spreadsheets/d/e/2PACX-1vSB44kY5bt5Bgvdy9VPOgxrwQHgaa2lnTM_HbbGvw8OpDxs3iJg5fRWt7dOxGIWttTVGQD5Ggeltyqz/pubhtml#).

Signed-off-by: Scott Harrison Moeller <smoeller@fb.com>