### PR TITLE
[CI][OAI] prepare pipeline for automatic triggering by web-hook

### DIFF
--- a/ci-scripts/JenkinsFile-OAI-Container-GitHub
+++ b/ci-scripts/JenkinsFile-OAI-Container-GitHub
@@ -38,6 +38,10 @@ def dsTesterPipelineName = params.dsTesterPipelineName
 // Name of the DsTester child pipeline HTML report file
 def dsTesterPipelineReport = params.dsTesterPipelineReport
 
+// This pipeline is triggered automatically
+// We are analyzing if the modified files are suitable to run it
+def runAllPipelineStages = true
+
 pipeline {
   agent {
     label nodeExecutor
@@ -90,12 +94,28 @@ pipeline {
                   submoduleCfg: [],
                   userRemoteConfigs: [[refspec: '+refs/pull/*:refs/remotes/origin/pr/*', url: "https://" + GIT_URL + ".git"]]]
           )
+          if (!params.REGRESSION_TEST) {
+            try {
+              // Check if the pull request has files that will impact MME behavior
+              // If so, we will run the OAI pipeline
+              sh 'python3 ci-scripts/check_pr_modified_files_for_oai_pipeline.py'
+              // If the previous command is OK, no need to run
+              // All the following stages will be bypassed and the CI
+              // will report a passing status on the GitHub PR web-page.
+              echo '\u2705 \u001B[32mOAI Pipeline is not required to be run on this Pull Request\u001B[0m'
+              runAllPipelineStages = false
+            } catch (Exception e) {
+              echo '\u2705 \u001B[32mOAI Pipeline is mandatory to be run on this Pull Request\u001B[0m'
+              runAllPipelineStages = true
+            }
+          }
           sh "git clean -x -d -f > /dev/null 2>&1"
           sh "mkdir -p archives"
         }
       }
     }
     stage ("Create Test Image") {
+      when { expression {runAllPipelineStages} }
       steps {
         script {
           echo '\u2705 \u001B[32mBuild Target Image to Test\u001B[0m'
@@ -165,6 +185,7 @@ pipeline {
       }
     }
     stage ("Test Image in Unified DsTester Framework") {
+      when { expression {runAllPipelineStages} }
       steps {
         script {
           localStatus = build job: dsTesterPipelineName,
@@ -214,19 +235,21 @@ pipeline {
   post {
     always {
       script {
-        // Remove CI Base image tag
-        sh('docker rmi magma-dev-mme:ci-base-image')
-        // Clean any residual images
-        sh('docker image prune --force > /dev/null 2>&1')
-        try {
-          sh('docker image rm magma-mme:ci-tmp > /dev/null 2>&1')
-        } catch (Exception e) {
-          echo 'OK if not present'
-        }
-        // Zipping all archived log files
-        sh "zip -r -qq magma_logs.zip archives"
-        if (fileExists('magma_logs.zip')) {
-          archiveArtifacts artifacts: 'magma_logs.zip'
+        if (runAllPipelineStages) {
+          // Remove CI Base image tag
+          sh('docker rmi magma-dev-mme:ci-base-image')
+          // Clean any residual images
+          sh('docker image prune --force > /dev/null 2>&1')
+          try {
+            sh('docker image rm magma-mme:ci-tmp > /dev/null 2>&1')
+          } catch (Exception e) {
+            echo 'OK if not present'
+          }
+          // Zipping all archived log files
+          sh "zip -r -qq magma_logs.zip archives"
+          if (fileExists('magma_logs.zip')) {
+            archiveArtifacts artifacts: 'magma_logs.zip'
+          }
         }
       }
     }

--- a/ci-scripts/check_pr_modified_files_for_oai_pipeline.py
+++ b/ci-scripts/check_pr_modified_files_for_oai_pipeline.py
@@ -1,0 +1,46 @@
+"""
+Copyright 2020 The Magma Authors.
+
+This source code is licensed under the BSD-style license found in the
+LICENSE file in the root directory of this source tree.
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import os
+import re
+import subprocess
+import sys
+
+cmd = 'git diff --name-only `git merge-base origin/master HEAD`'
+listModifiedFiles = subprocess.check_output(cmd, shell=True, universal_newlines=True)
+mmeIsImpacted = False
+
+for line in listModifiedFiles.split('\n'):
+    res = re.search('lte/gateway/Makefile', line)
+    if res is not None:
+        mmeIsImpacted = True
+    res = re.search('lte/gateway/c/oai', line)
+    if res is not None:
+        mmeIsImpacted = True
+    res = re.search('lte/gateway/c/sctpd', line)
+    if res is not None:
+        mmeIsImpacted = True
+    res = re.search('lte/gateway/docker/mme', line)
+    if res is not None:
+        mmeIsImpacted = True
+    res = re.search('ci-scripts/JenkinsFile-OAI-Container-GitHub|ci-scripts/generateHtmlReport-OAI-pipeline.py|ci-scripts/check_pr_modified_files_for_oai_pipeline.py', line)
+    if res is not None:
+        mmeIsImpacted = True
+    res = re.search('ci-scripts/docker/Dockerfile.mme.ci.ubuntu18', line)
+    if res is not None:
+        mmeIsImpacted = True
+
+if mmeIsImpacted:
+    sys.exit(-1)
+else:
+    sys.exit(0)


### PR DESCRIPTION
Signed-off-by: Raphael Defosseux <raphael.defosseux@openairinterface.org>


## Summary

Currently the OAI Jenkins pipeline is triggered manually by some admin people when they add a comment with the pattern `MAGMA-OAI-TESTS`.

This will be replaced by an automatic web-hook and we will analyze the content of the Pull Request.

We will list the name of files that are modified and we check if they fit in the `MME` realm.

## Test Plan

Jenkins linter OK.

Then when it is merged into `master`, we need to setup the trigger.

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
