### PR TITLE
[AGW][MME] Remove IMSI SPGW state only when tunnel list is empty

### DIFF
--- a/lte/gateway/c/oai/tasks/mme_app/mme_app_context.c
+++ b/lte/gateway/c/oai/tasks/mme_app/mme_app_context.c
@@ -175,7 +175,7 @@ void mme_app_ue_sgs_context_free_content(
   }
   // Stop SGS EPS Detach indication timer if running
   if (sgs_context_p->ts8_timer.id != MME_APP_TIMER_INACTIVE_ID) {
-   if (timer_remove(sgs_context_p->ts8_timer.id, (void**) &timer_argP)) {
+    if (timer_remove(sgs_context_p->ts8_timer.id, (void**) &timer_argP)) {
       OAILOG_ERROR_UE(
           LOG_MME_APP, imsi,
           "Failed to stop SGS EPS Detach Indication"

--- a/lte/gateway/c/oai/tasks/sgw/sgw_context_manager.c
+++ b/lte/gateway/c/oai/tasks/sgw/sgw_context_manager.c
@@ -225,7 +225,6 @@ int sgw_cm_remove_bearer_context_information(
   if (temp != HASH_TABLE_OK) {
     OAILOG_ERROR_UE(
         LOG_SPGW_APP, imsi64, "Failed to free teid from state_imsi_ht \n");
-    delete_spgw_ue_state(imsi64);
     return temp;
   }
   spgw_ue_context_t* ue_context_p = NULL;
@@ -249,10 +248,11 @@ int sgw_cm_remove_bearer_context_information(
         OAILOG_ERROR_UE(
             LOG_SPGW_APP, imsi64,
             "Failed to free imsi64 from imsi_ue_context_htbl \n");
+        return temp;
       }
+      delete_spgw_ue_state(imsi64);
     }
   }
-  delete_spgw_ue_state(imsi64);
   return temp;
 }
 

--- a/lte/gateway/python/integ_tests/s1aptests/test_secondary_pdn_with_dedicated_bearer_multiple_services_restart.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_secondary_pdn_with_dedicated_bearer_multiple_services_restart.py
@@ -199,7 +199,7 @@ class TestSecondaryPdnWithDedicatedBearerMultipleServicesRestart(
             "********************** Sending RAR for IMSI",
             "".join([str(i) for i in req.imsi]),
         )
-        self._sessionManager_util.create_ReAuthRequest(
+        self._sessionManager_util.send_ReAuthRequest(
             "IMSI" + "".join([str(i) for i in req.imsi]),
             policy_id1,
             flow_list1,
@@ -245,7 +245,7 @@ class TestSecondaryPdnWithDedicatedBearerMultipleServicesRestart(
             "********************** Sending RAR for IMSI",
             "".join([str(i) for i in req.imsi]),
         )
-        self._sessionManager_util.create_ReAuthRequest(
+        self._sessionManager_util.send_ReAuthRequest(
             "IMSI" + "".join([str(i) for i in req.imsi]),
             policy_id2,
             flow_list2,


### PR DESCRIPTION
Signed-off-by: Shruti Sanadhya <ssanadhya@fb.com>

## Summary

The `sgw_cm_remove_bearer_context_information` is called when a UE session is deleted or default bearer is deleted. In case of multiple PDNs per UE, this logic would lead to Redis state being deleted for the IMSI when default bearer for any PDN is deleted. This change fixes the logic to only delete state from Redis when the last bearer is removed for a given UE.

Also updated the `test_secondary_pdn_with_dedicated_bearer_multiple_services_restart.py` to use the latest API for sending ReAuthRequest.

## Test Plan

Regression testing: `make integ_test`
Functional testing
- `test_secondary_pdn_with_dedicated_bearer_multiple_services_restart.py`

TBD: Add new test case with delete bearer checks
