### PR TITLE
[Terraform] Replace hardcoded unique names with optional configurable variables

### DIFF
--- a/orc8r/cloud/deploy/terraform/orc8r-helm-aws/efs.tf
+++ b/orc8r/cloud/deploy/terraform/orc8r-helm-aws/efs.tf
@@ -13,7 +13,7 @@
 
 # k8s requires provisioner to treat efs as a persistent volume
 resource "helm_release" "efs_provisioner" {
-  name       = "efs-provisioner"
+  name       = var.efs_provisioner_name
   repository = local.stable_helm_repo
   chart      = "efs-provisioner"
   version    = "0.11.0"
@@ -27,7 +27,7 @@ resource "helm_release" "efs_provisioner" {
     path: /pv-volume
     provisionerName: aws-efs
     storageClass:
-      name: efs
+      name: ${var.efs_storage_class_name}
   podAnnotations:
     iam-assumable-role: ${var.efs_provisioner_role_arn}
   VALUES

--- a/orc8r/cloud/deploy/terraform/orc8r-helm-aws/k8s.tf
+++ b/orc8r/cloud/deploy/terraform/orc8r-helm-aws/k8s.tf
@@ -25,7 +25,7 @@ resource "kubernetes_namespace" "monitoring" {
 
 # external dns maps route53 to ingress resources
 resource "helm_release" "external_dns" {
-  name       = "external-dns"
+  name       = var.external_dns_deployment_name
   repository = local.stable_helm_repo
   chart      = "external-dns"
   version    = "2.19.1"

--- a/orc8r/cloud/deploy/terraform/orc8r-helm-aws/logging.tf
+++ b/orc8r/cloud/deploy/terraform/orc8r-helm-aws/logging.tf
@@ -18,7 +18,7 @@ locals {
 resource "helm_release" "fluentd" {
   count = var.elasticsearch_endpoint == null ? 0 : 1
 
-  name       = "fluentd"
+  name       = var.external_dns_deployment_name
   namespace  = kubernetes_namespace.orc8r.metadata[0].name
   repository = local.stable_helm_repo
   chart      = "fluentd"
@@ -130,7 +130,7 @@ resource "helm_release" "fluentd" {
 resource "helm_release" "elasticsearch_curator" {
   count = var.elasticsearch_endpoint == null ? 0 : 1
 
-  name       = "elasticsearch-curator"
+  name       = var.elasticsearch_curator_name
   repository = local.stable_helm_repo
   chart      = "elasticsearch-curator"
   namespace  = kubernetes_namespace.monitoring.metadata[0].name

--- a/orc8r/cloud/deploy/terraform/orc8r-helm-aws/logging.tf
+++ b/orc8r/cloud/deploy/terraform/orc8r-helm-aws/logging.tf
@@ -18,7 +18,7 @@ locals {
 resource "helm_release" "fluentd" {
   count = var.elasticsearch_endpoint == null ? 0 : 1
 
-  name       = var.external_dns_deployment_name
+  name       = var.fluentd_deployment_name
   namespace  = kubernetes_namespace.orc8r.metadata[0].name
   repository = local.stable_helm_repo
   chart      = "fluentd"

--- a/orc8r/cloud/deploy/terraform/orc8r-helm-aws/storage.tf
+++ b/orc8r/cloud/deploy/terraform/orc8r-helm-aws/storage.tf
@@ -55,7 +55,7 @@ resource "kubernetes_persistent_volume_claim" "storage" {
         storage = each.value.storage
       }
     }
-    storage_class_name = "efs"
+    storage_class_name = var.efs_storage_class_name
   }
 
   depends_on = [helm_release.efs_provisioner]

--- a/orc8r/cloud/deploy/terraform/orc8r-helm-aws/variables.tf
+++ b/orc8r/cloud/deploy/terraform/orc8r-helm-aws/variables.tf
@@ -43,6 +43,12 @@ variable "orc8r_route53_zone_id" {
   type        = string
 }
 
+variable "external_dns_deployment_name" {
+  description = "Name of the external dns helm deployment"
+  type        = string
+  default     = "external-dns"
+}
+
 variable "external_dns_role_arn" {
   description = "IAM role ARN for ExternalDNS."
   type        = string
@@ -214,6 +220,18 @@ variable "efs_provisioner_role_arn" {
   type        = string
 }
 
+variable "efs_provisioner_name" {
+  description = "Name of the efs provisioner helm deployment"
+  type        = string
+  default     = "efs-provisioner"
+}
+
+variable "efs_storage_class_name" {
+  description = "Name of the Storage class"
+  type        = string
+  default     = "efs"
+}
+
 ##############################################################################
 # Log aggregation configuration
 ##############################################################################
@@ -246,6 +264,18 @@ variable "elasticsearch_curator_log_level" {
   description = "Defines Elasticsearch curator logging level."
   type        = string
   default     = "INFO"
+}
+
+variable "elasticsearch_curator_name" {
+  description = "Name of the elasticsearch-curator helm deployment"
+  type        = string
+  default     = "elasticsearch-curator"
+}
+
+variable "fluentd_deployment_name" {
+  description = "Name of the fluentd helm deployment"
+  type        = string
+  default     = "fluentd"
 }
 
 ##############################################################################


### PR DESCRIPTION

## Summary

Updating current terraforms modules to make them more configurable. These changes will allow users to do several deployments of Orc8r on top of the same EKS cluster

