### PR TITLE
[pipelined]Move rule info storage to Flat Redis Dicts

### DIFF
--- a/lte/gateway/python/magma/pipelined/rpc_servicer.py
+++ b/lte/gateway/python/magma/pipelined/rpc_servicer.py
@@ -14,6 +14,7 @@ import os
 import logging
 import concurrent.futures
 import queue
+from functools import partial
 from concurrent.futures import Future
 from itertools import chain
 from typing import List, Tuple
@@ -26,6 +27,7 @@ from lte.protos.pipelined_pb2 import (
     RequestOriginType,
     ActivateFlowsResult,
     DeactivateFlowsResult,
+    DeactivateFlowsRequest,
     FlowResponse,
     RuleModResult,
     SetupUEMacRequest,
@@ -220,6 +222,24 @@ class PipelinedRpcServicer(pipelined_pb2_grpc.PipelinedServicer):
             self._service_manager.session_rule_version_mapper.update_version(
                 request.sid.id, ipv4, rule.id)
 
+    def _remove_version(self, request: DeactivateFlowsRequest, ip_address: str):
+        def cleanup_redis(imsi, ip_address, rule_id, version):
+            self._service_manager.session_rule_version_mapper \
+                .remove(imsi, ip_address, rule_id, version)
+
+        for rule_id in request.rule_ids:
+            self._service_manager.session_rule_version_mapper \
+                .update_version(request.sid.id, ip_address,
+                                rule_id)
+            version = self._service_manager.session_rule_version_mapper \
+                .get_version(request.sid.id, ip_address, rule_id)
+
+            # Give it sometime to cleanup enf stats
+            self._loop.call_later(
+                self._service_config['enforcement']['poll_interval'] * 2,
+                partial(cleanup_redis, request.sid.id, ip_address, rule_id,
+                        version))
+
     def _activate_flows(self, request: ActivateFlowsRequest,
                         fut: 'Future[ActivateFlowsResult]'
                         ) -> None:
@@ -410,12 +430,11 @@ class PipelinedRpcServicer(pipelined_pb2_grpc.PipelinedServicer):
 
     def _deactivate_flows_gx(self, request, ip_address: IPAddress):
         logging.debug('Deactivating GX flows for %s', request.sid.id)
+
         if request.rule_ids:
-            for rule_id in request.rule_ids:
-                self._service_manager.session_rule_version_mapper \
-                    .update_version(request.sid.id, ip_address,
-                                    rule_id)
+            self._remove_version(request, ip_address)
         else:
+            # TODO cleanup redis?
             # If no rule ids are given, all flows are deactivated
             self._service_manager.session_rule_version_mapper.update_version(
                 request.sid.id, ip_address)
@@ -429,9 +448,7 @@ class PipelinedRpcServicer(pipelined_pb2_grpc.PipelinedServicer):
         logging.debug('Deactivating GY flows for %s', request.sid.id)
         # Only deactivate requested rules here to not affect GX
         if request.rule_ids:
-            for rule_id in request.rule_ids:
-                self._service_manager.session_rule_version_mapper \
-                    .update_version(request.sid.id, ip_address, rule_id)
+            self._remove_version(request, ip_address)
         self._gy_app.deactivate_rules(request.sid.id, ip_address,
                                       request.rule_ids)
 

--- a/lte/gateway/python/magma/pipelined/rule_mappers.py
+++ b/lte/gateway/python/magma/pipelined/rule_mappers.py
@@ -18,9 +18,10 @@ from typing import Optional
 from lte.protos.mobilityd_pb2 import IPAddress
 from magma.pipelined.imsi import encode_imsi
 from magma.common.redis.client import get_default_client
-from magma.common.redis.containers import RedisHashDict
+from magma.common.redis.containers import RedisFlatDict, RedisHashDict
 from magma.common.redis.serializers import get_json_deserializer, \
     get_json_serializer
+from magma.common.redis.serializers import RedisSerde
 
 
 SubscriberRuleKey = namedtuple('SubscriberRuleKey', 'key_type imsi ip_addr rule_id')
@@ -50,6 +51,7 @@ class RuleIDToNumMapper:
         self._rule_nums_by_rule[rule_id] = rule_num
         self._rules_by_rule_num[rule_num] = rule_id
         self._curr_rule_num += 1
+
         return rule_num
 
     def get_rule_num(self, rule_id):
@@ -59,6 +61,7 @@ class RuleIDToNumMapper:
     def get_or_create_rule_num(self, rule_id):
         with self._lock:
             rule_num = self._rule_nums_by_rule.get(rule_id)
+
             if rule_num is None:
                 return self._register_rule(rule_id)
             return rule_num
@@ -102,7 +105,7 @@ class SessionRuleToVersionMapper:
         if ip_addr is None or ip_addr.address is None:
             ip_addr_str = ""
         else:
-            ip_addr_str = ip_addr.address.decode('utf-8')
+            ip_addr_str = ip_addr.address.decode('utf-8').strip()
         with self._lock:
             if rule_id is None:
                 for k, v in self._version_by_imsi_and_rule.items():
@@ -119,7 +122,7 @@ class SessionRuleToVersionMapper:
         if ip_addr is None or ip_addr.address is None:
             ip_addr_str = ""
         else:
-            ip_addr_str = ip_addr.address.decode('utf-8')
+            ip_addr_str = ip_addr.address.decode('utf-8').strip()
         key = self._get_json_key(encode_imsi(imsi), ip_addr_str, rule_id)
         with self._lock:
             version = self._version_by_imsi_and_rule.get(key)
@@ -127,12 +130,29 @@ class SessionRuleToVersionMapper:
                 version = 0
         return version
 
+    def remove(self, imsi: str, ip_addr: IPAddress, rule_id: str, version: int):
+        """
+        Removed the element from redis if the passed version matches the
+        current one
+        """
+        if ip_addr is None or ip_addr.address is None:
+            ip_addr_str = ""
+        else:
+            ip_addr_str = ip_addr.address.decode('utf-8').strip()
+        key = self._get_json_key(encode_imsi(imsi), ip_addr_str, rule_id)
+        with self._lock:
+            cur_version = self._version_by_imsi_and_rule.get(key)
+            if version is None:
+                return
+            if cur_version == version:
+                del self._version_by_imsi_and_rule[key]
+
     def _get_json_key(self, imsi: str, ip_addr: str, rule_id: str):
         return json.dumps(SubscriberRuleKey('imsi_rule', imsi, ip_addr,
                                             rule_id))
 
 
-class RuleIDDict(RedisHashDict):
+class RuleIDDict(RedisFlatDict):
     """
     RuleIDDict uses the RedisHashDict collection to store a mapping of
     rule name to rule id.
@@ -142,10 +162,9 @@ class RuleIDDict(RedisHashDict):
 
     def __init__(self):
         client = get_default_client()
-        super().__init__(
-            client,
-            self._DICT_HASH,
-            get_json_serializer(), get_json_deserializer())
+        serde = RedisSerde(self._DICT_HASH, get_json_serializer(),
+                           get_json_deserializer())
+        super().__init__(client, serde, writethrough=True)
 
     def __missing__(self, key):
         """Instead of throwing a key error, return None when key not found"""
@@ -172,7 +191,7 @@ class RuleNameDict(RedisHashDict):
         return None
 
 
-class RuleVersionDict(RedisHashDict):
+class RuleVersionDict(RedisFlatDict):
     """
     RuleVersionDict uses the RedisHashDict collection to store a mapping of
     subscriber+rule_id to rule version.
@@ -182,30 +201,9 @@ class RuleVersionDict(RedisHashDict):
 
     def __init__(self):
         client = get_default_client()
-        super().__init__(
-            client,
-            self._DICT_HASH,
-            get_json_serializer(), get_json_deserializer())
-
-    def __missing__(self, key):
-        """Instead of throwing a key error, return None when key not found"""
-        return None
-
-
-class UsageDeltaDict(RedisHashDict):
-    """
-    UsageDeltaDict uses the RedisHashDict collection to store a mapping of
-    subscriber+rule_id+ip to rule usage.
-    Setting and deleting items in the dictionary syncs with Redis automatically
-    """
-    _DICT_HASH = "pipelined:last_usage_delta"
-
-    def __init__(self):
-        client = get_default_client()
-        super().__init__(
-            client,
-            self._DICT_HASH,
-            get_json_serializer(), get_json_deserializer())
+        serde = RedisSerde(self._DICT_HASH, get_json_serializer(),
+                           get_json_deserializer())
+        super().__init__(client, serde, writethrough=True)
 
     def __missing__(self, key):
         """Instead of throwing a key error, return None when key not found"""


### PR DESCRIPTION
 - On lab tests pipelined would only work properly for 1 iteration
 - Changing the RedisHashDict->RedisFlatDict helps stabilize this
 - RuleNameDict is kept as RedisHashDict because RedisFlatDict is
   not currently compatible with int keys (TODO for the future)
 - Added some redis cleanup for rule removal(some left as TODO)

Signed-off-by: Nick Yurchenko <koolzz@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
