### PR TITLE
[PipelineD] Fix pipelined unit test failures from Redis changes

### DIFF
--- a/lte/gateway/python/magma/mobilityd/tests/ip_alloc_dhcp_test.py
+++ b/lte/gateway/python/magma/mobilityd/tests/ip_alloc_dhcp_test.py
@@ -16,7 +16,6 @@ import os
 import subprocess
 import sys
 import threading
-import unittest
 import unittest.mock
 
 from ipaddress import ip_network
@@ -29,7 +28,6 @@ from magma.pipelined.bridge_util import BridgeTools
 from magma.mobilityd.ip_descriptor import IPDesc, IPType, IPState
 
 from magma.mobilityd.mac import create_mac_from_sid
-from magma.mobilityd.dhcp_desc import DHCPState
 
 from magma.mobilityd.ipv6_allocator_pool import \
     IPv6AllocatorPool

--- a/lte/gateway/python/magma/pipelined/tests/pipelined_test_util.py
+++ b/lte/gateway/python/magma/pipelined/tests/pipelined_test_util.py
@@ -16,12 +16,15 @@ import os
 import re
 import subprocess
 import netifaces
+import fakeredis
 
 from collections import namedtuple
 from concurrent.futures import Future
 from difflib import unified_diff
 from typing import Dict, List, Optional
+
 from unittest import TestCase
+from unittest import mock
 from unittest.mock import MagicMock
 from ryu.lib import hub
 
@@ -377,7 +380,12 @@ def create_service_manager(services: List[int],
         'static_services': static_services,
         '5G_feature_set': {'enable': False}
     }
-    service_manager = ServiceManager(magma_service)
+    # mock the get_default_client function used to return a fakeredis object
+    func_mock = MagicMock(return_value=fakeredis.FakeStrictRedis())
+    with mock.patch(
+            'magma.pipelined.rule_mappers.get_default_client',
+            func_mock):
+        service_manager = ServiceManager(magma_service)
 
     # Workaround as we don't use redis in unit tests
     service_manager.rule_id_mapper._rule_nums_by_rule = {}


### PR DESCRIPTION
Signed-off-by: Marie Bremner <marwhal@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary
Fixing some redis related failures seen from https://github.com/magma/magma/pull/5379. (failures=https://app.circleci.com/pipelines/github/magma/magma/16226/workflows/63d86198-8486-4b2e-9896-cd88d874dc46/jobs/150403)
The change just mocks the return value of `get_default_client` so that we always use the fakeredis object, not a real redis client.
<!-- Enumerate changes you made and why you made them -->

## Test Plan
run all python unit tests
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
