### PR TITLE
[NMS] Run db migration on nms startup

### DIFF
--- a/nms/app/packages/magmalte/docker-compose.yml
+++ b/nms/app/packages/magmalte/docker-compose.yml
@@ -53,6 +53,13 @@ services:
       MYSQL_PASS: password
       MAPBOX_ACCESS_TOKEN: ${MAPBOX_ACCESS_TOKEN:-}
       MYSQL_DIALECT: postgres
+      # Specify these to migrate data from the source db to the current one.
+      #MYSQL_SRC_HOST: mariadb
+      #MYSQL_SRC_PORT: 3306
+      #MYSQL_SRC_DB: nms
+      #MYSQL_SRC_USER: nms
+      #MYSQL_SRC_PASS: password
+      #MYSQL_SRC_DIALECT: mariadb
       # Tell Puppeteer to skip installing Chrome. We'll be using the installed package.
       PUPPETEER_SKIP_DOWNLOAD: "true"
     healthcheck:

--- a/nms/app/packages/magmalte/package.json
+++ b/nms/app/packages/magmalte/package.json
@@ -33,7 +33,7 @@
     "@fbcnms/magma-api": "^0.1.0",
     "@fbcnms/platform-server": "^0.1.23",
     "@fbcnms/projects": "^0.1.0",
-    "@fbcnms/sequelize-models": "^0.1.1",
+    "@fbcnms/sequelize-models": "^0.1.2",
     "@fbcnms/strings": "^0.1.0",
     "@fbcnms/types": "^0.1.11",
     "@fbcnms/ui": "^0.1.8",

--- a/nms/app/packages/magmalte/scripts/runDataMigration.js
+++ b/nms/app/packages/magmalte/scripts/runDataMigration.js
@@ -1,0 +1,51 @@
+/**
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @flow
+ * @format
+ */
+
+const logger = require('@fbcnms/logging').getLogger(module);
+
+const {importFromDatabase} = require('@fbcnms/sequelize-models');
+import {User} from '@fbcnms/sequelize-models';
+import type {Options} from 'sequelize';
+
+export async function runDataMigration() {
+  const sourceDbHost = process.env.MYSQL_SRC_HOST;
+  if (typeof sourceDbHost === 'undefined') {
+    return;
+  }
+  const allUsers = await User.findAll();
+  if (allUsers.length > 0) {
+    logger.info('Users found in NMS DB. Skipping migration from source DB');
+    return;
+  }
+
+  const dbOptions: Options = {
+    username: process.env.MYSQL_SRC_USER || 'root',
+    password: process.env.MYSQL_SRC_PASS || '',
+    database: process.env.MYSQL_SRC_DB || 'nms',
+    host: process.env.MYSQL_SRC_HOST,
+    port: parseInt(process.env.MYSQL_SRC_PORT || '3306'),
+    dialect: process.env.MYSQL_SRC_DIALECT || 'mysql',
+    logging: (msg: string) => logger.debug(msg),
+  };
+  try {
+    await importFromDatabase(dbOptions);
+    logger.info('Completed data migration to current NMS DB');
+  } catch (error) {
+    logger.error(
+      `Unable to connect to source database with specified options for migration: ${error}`,
+    );
+  }
+}

--- a/nms/app/packages/magmalte/scripts/server.js
+++ b/nms/app/packages/magmalte/scripts/server.js
@@ -23,12 +23,14 @@ if (!process.env.NODE_ENV) {
 
 import app from '../server/app';
 import logging from '@fbcnms/logging';
+import {runDataMigration} from './runDataMigration';
 import {runMigrations} from './runMigrations';
 
 const logger = logging.getLogger(module);
 const port = parseInt(process.env.PORT || 80);
 
 (async function main() {
+  await runDataMigration();
   await runMigrations();
   app.listen(port, '', err => {
     if (err) {

--- a/nms/app/yarn.lock
+++ b/nms/app/yarn.lock
@@ -1562,6 +1562,13 @@
   dependencies:
     sequelize "^5.8.5"
 
+"@fbcnms/sequelize-models@^0.1.2":
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/@fbcnms/sequelize-models/-/sequelize-models-0.1.2.tgz#edfa3ab06f84789ea40eb299a67f2a60abff4747"
+  integrity sha512-iCB868/+8sB5qbdOdMKwKXtd1+LYvQCy2bAe6jLgShD8CWn56x+m2nmUzRrlwFCelmRfuuOZOhNL145VcbjODg==
+  dependencies:
+    sequelize "^5.8.5"
+
 "@fbcnms/strings@^0.1.0":
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/@fbcnms/strings/-/strings-0.1.0.tgz#50dae22b4cb7cb7d1a30c013d0b40c96b741a1f1"


### PR DESCRIPTION
## Summary

This change allows NMS startup to run a data migration from a `source` DB and the current DB. To support this, additional environment variables are being read on startup, and if they are defined, the NMS will interpret these to specify connection config for the `source` DB. NMS will then read all data from the `source`, and write it to the current NMS DB. This process only occurs if the current NMS DB has no data in it.

This change is part of a larger plan to allow NMS and orc8r to run on the same Postgres AWS RDS instance, whereas they currently run on MariaDB and Postgres, respectively.

## Test Plan

This was manually tested using a docker setup with both MariaDB and Postgres containers running. The extra env variables specified for the `source` DB were set in the `docker-compose.yml` file, triggering the data migration from the `source` db (MariaDB) to the current, `target` db (Postgres)

**Example logs indicating success (magmalte container):**
```
➜  magmalte git:(1-2-nms-migration-startup) ✗ docker-compose logs -f magmalte
Attaching to magmalte_magmalte_1
magmalte_1     | wait-for-it.sh: waiting 30 seconds for postgres:5432
magmalte_1     | wait-for-it.sh: postgres:5432 is available after 0 seconds
magmalte_1     | yarn run v1.22.4
magmalte_1     | $ nodemon scripts/server
magmalte_1     | [nodemon] 2.0.6
magmalte_1     | [nodemon] reading config ./nodemon.json
magmalte_1     | [nodemon] to restart at any time, enter `rs`
magmalte_1     | [nodemon] or send SIGHUP to 47 to restart
magmalte_1     | [nodemon] watching path(s): ../fbcnms-magma-api/**/* config/**/* scripts/**/* server/**/* grafana/**/* alerts/**/*
magmalte_1     | [nodemon] watching extensions: js,mjs,json
magmalte_1     | [nodemon] starting `node -r '@fbcnms/babel-register' scripts/server.js`
magmalte_1     | [nodemon] spawning
magmalte_1     | [nodemon] child pid: 59
magmalte_1     | [nodemon] watching 43 files
magmalte_1     | dbOptions:  { username: 'nms',
magmalte_1     |   password: 'password',
magmalte_1     |   database: 'nms',
magmalte_1     |   host: 'mariadb',
magmalte_1     |   port: 3306,
magmalte_1     |   dialect: 'mariadb',
magmalte_1     |   logging: [Function: logging] }
magmalte_1     | 2021-03-10T01:01:25.089Z [scripts/runDataMigration.js] info: Completed data migration to current NMS DB
magmalte_1     | 2021-03-10T01:01:26.994Z [scripts/server.js] info: Development server started on port 8081
```

**Manual Postgresql queries ran on Postgres before the data migration:**
```
psql (9.5.25)
Type "help" for help.

nms=# SELECT * FROM "Users";
 id | email | password | role | createdAt | updatedAt | networkIDs | verificationType | organization | readOnly | tabs
----+-------+----------+------+-----------+-----------+------------+------------------+--------------+----------+------
(0 rows)
```

**Manual Postgresql run on postgres container after the data migration:**
```
psql (9.5.25)
Type "help" for help.

nms=# SELECT * FROM "Users";
 id |      email       |                           password                           | role |       createdAt        |       updatedAt        | networkIDs | verificationType | organization | readOnly | tabs
----+------------------+--------------------------------------------------------------+------+------------------------+------------------------+------------+------------------+--------------+----------+------
  1 | admin@magma.test | $2a$10$ONQrCBSYRxB.dqlhfLECYuybj5VjHcuPQs8PD4c3JGIsFLxywOVjG |    3 | 2020-07-15 20:03:44+00 | 2021-03-04 01:07:32+00 | []         |                0 | magma-test   | f        |
  2 | admin@magma.test | $2a$10$SX3tBiOBzJ6DJ.knP2zEjea1fc1juflAvsELarEMJ1dMe2QZ5QMp6 |    3 | 2020-07-15 20:03:47+00 | 2020-12-29 21:51:37+00 | []         |                0 | master       | f        |
(2 rows)

nms=# SELECT * FROM "Organizations";
 id | customDomains |    name    |                                                                                          networkIDs                                                                                          |                  tabs
  |       createdAt        |       updatedAt        | ssoCert | ssoEntrypoint | ssoIssuer | csvCharset | ssoSelectedType | ssoOidcClientID | ssoOidcClientSecret | ssoOidcConfigurationURL
----+---------------+------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+---------------------------------------
--+------------------------+------------------------+---------+---------------+-----------+------------+-----------------+-----------------+---------------------+-------------------------
  1 | []            | master     | ["nms_network_2"]                                                                                                                                                                            | ["admin"]
  | 2019-02-11 20:05:05+00 | 2021-02-26 01:26:26+00 |         |               |           |            | none            |                 |                     |
  2 | []            | fb-test    | []                                                                                                                                                                                           | ["inventory","workorders","automation"
] | 2019-02-11 20:05:05+00 | 2019-02-11 20:05:05+00 |         |               |           |            | none            |                 |                     |
  3 | []            | magma-test | ["mpk_test","nms_network","asdfasdf","test","test_feg_lte_network","test_feg_network2","test_network","test_feg_lte_network2","","test_feg_network2","test_feg_lte_network2","test_network"] | ["nms"]
  | 2019-02-11 20:05:05+00 | 2021-03-04 01:08:10+00 |         |               |           |            | none            |                 |                     |
(3 rows)
```

## Additional Information

- [ ] This change is backwards-breaking

**For further discussion on the migration process from MariaDB to combined Postgres for orc8r + NMS, see here:**
https://github.com/magma/magma/discussions/5312
