### PR TITLE
[MME] fix fall-through of S1AP_INVALID_MME_UE_S1AP_ID handling

### DIFF
--- a/lte/gateway/c/oai/tasks/s1ap/s1ap_mme_handlers.c
+++ b/lte/gateway/c/oai/tasks/s1ap/s1ap_mme_handlers.c
@@ -1262,6 +1262,7 @@ int s1ap_mme_generate_ue_context_release_command(
     case S1AP_INVALID_MME_UE_S1AP_ID:
       cause_type  = S1ap_Cause_PR_radioNetwork;
       cause_value = S1ap_CauseRadioNetwork_unknown_mme_ue_s1ap_id;
+      break;
     case S1AP_NAS_MME_OFFLOADING:
       cause_type  = S1ap_Cause_PR_radioNetwork;
       cause_value = S1ap_CauseRadioNetwork_load_balancing_tau_required;


### PR DESCRIPTION
This resolves issue #5388.

## Test Plan

Ran [Magma Integ tests](https://github.com/magma/magma/tree/master/lte/gateway/python/integ_tests) (omitted traffic tests).

Signed-off-by: Scott Harrison Moeller <smoeller@fb.com>