### PR TITLE
[AGW][Health] Update agw_health_cli script to handle errors better 

### DIFF
--- a/lte/gateway/python/magma/health/health_service.py
+++ b/lte/gateway/python/magma/health/health_service.py
@@ -88,8 +88,8 @@ class AGWHealth:
 
         mme_log_path = '/var/log/mme.log'
         health_summary = AGWHealthSummary(
-            hss_relay_enabled=config['hssRelayEnabled'],
-            nb_enbs_connected=status.meta['n_enodeb_connected'],
+            hss_relay_enabled=config.get('hssRelayEnabled', False),
+            nb_enbs_connected=status.meta.get('n_enodeb_connected', 0),
             allocated_ips=self.get_allocated_ips(),
             subscriber_table=self.get_subscriber_table(),
             core_dumps=self.get_core_dumps(),


### PR DESCRIPTION
<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary
When `hssRelayEnabled` is missing from the mconfig, the health script fails with the following error: 
```
magma@agw2:~$ agw_health_cli.py
Access Gateway health summary
Error: 'hssRelayEnabled'
magma@agw2:~$
```
Fixing by adding a default value=False.
<!-- Enumerate changes you made and why you made them -->

## Test Plan
run the script on an AGW with the missing field
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
