### PR TITLE
[PipelineD][UnitTests] Fix pipelined redis tests round by mocking redis

### DIFF
--- a/lte/gateway/python/magma/pipelined/tests/test_rule_mappers.py
+++ b/lte/gateway/python/magma/pipelined/tests/test_rule_mappers.py
@@ -12,6 +12,9 @@ limitations under the License.
 """
 
 import unittest
+import fakeredis
+from unittest.mock import MagicMock
+from unittest import mock
 
 from magma.pipelined.rule_mappers import SessionRuleToVersionMapper
 from magma.pipelined.policy_converters import convert_ipv4_str_to_ip_proto
@@ -19,7 +22,12 @@ from magma.pipelined.policy_converters import convert_ipv4_str_to_ip_proto
 
 class RuleMappersTest(unittest.TestCase):
     def setUp(self):
-        self._session_rule_version_mapper = SessionRuleToVersionMapper()
+        # mock the get_default_client function used to return a fakeredis object
+        func_mock = MagicMock(return_value=fakeredis.FakeStrictRedis())
+        with mock.patch(
+                'magma.pipelined.rule_mappers.get_default_client',
+                func_mock):
+            self._session_rule_version_mapper = SessionRuleToVersionMapper()
         self._session_rule_version_mapper._version_by_imsi_and_rule = {}
 
     def test_session_rule_version_mapper(self):

--- a/lte/gateway/python/magma/pipelined/tests/test_service_manager.py
+++ b/lte/gateway/python/magma/pipelined/tests/test_service_manager.py
@@ -13,7 +13,9 @@ limitations under the License.
 
 import unittest
 from collections import OrderedDict
+import fakeredis
 from unittest.mock import MagicMock
+from unittest import mock
 
 from magma.pipelined.app.base import ControllerType
 from magma.pipelined.app.access_control import AccessControlController
@@ -43,7 +45,12 @@ class ServiceManagerTest(unittest.TestCase):
             'static_services': ['arpd', 'access_control', 'ipfix', 'proxy'],
             '5G_feature_set': {'enable': False}
         }
-        self.service_manager = ServiceManager(magma_service_mock)
+        # mock the get_default_client function used to return a fakeredis object
+        func_mock = MagicMock(return_value=fakeredis.FakeStrictRedis())
+        with mock.patch(
+            'magma.pipelined.rule_mappers.get_default_client',
+            func_mock):
+            self.service_manager = ServiceManager(magma_service_mock)
 
     def test_get_table_num(self):
         self.assertEqual(self.service_manager.get_table_num(INGRESS), 1)


### PR DESCRIPTION
Signed-off-by: Marie Bremner <marwhal@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary
Apparently I missed a few in https://github.com/magma/magma/pull/5386 :/ 
Not sure why all the tests passed locally last run. 

Fixing some redis related failures seen from #5379. (failures=https://app.circleci.com/pipelines/github/magma/magma/16226/workflows/63d86198-8486-4b2e-9896-cd88d874dc46/jobs/150403)
The change just mocks the return value of get_default_client so that we always use the fakeredis object, not a real redis client.
<!-- Enumerate changes you made and why you made them -->

## Test Plan
locally running tests
Looks like it is working here: https://app.circleci.com/pipelines/github/magma/magma/16269/workflows/f51ea78e-f61b-4d0d-874a-96484fd74c21/jobs/150986 
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
