### PR TITLE
[SessionD] Address some clang-tidy warnings

### DIFF
--- a/lte/gateway/c/session_manager/LocalEnforcer.cpp
+++ b/lte/gateway/c/session_manager/LocalEnforcer.cpp
@@ -35,7 +35,6 @@ uint32_t LocalEnforcer::REDIRECT_FLOW_PRIORITY                = 2000;
 bool LocalEnforcer::SEND_ACCESS_TIMEZONE                      = false;
 
 using google::protobuf::RepeatedPtrField;
-using google::protobuf::util::TimeUtil;
 
 using namespace std::placeholders;
 

--- a/lte/gateway/c/session_manager/RedisStoreClient.cpp
+++ b/lte/gateway/c/session_manager/RedisStoreClient.cpp
@@ -67,13 +67,12 @@ SessionMap RedisStoreClient::read_sessions(
   SessionMap session_map;
   for (const std::string& key : subscriber_ids) {
     auto reply = futures[key].get();
-    if (reply.is_null()) {
-      // value just doesn't exist
-      session_map[key] = SessionVector{};
-    } else if (reply.is_error()) {
+    if (reply.is_error()) {
       MLOG(MERROR) << "RedisStoreClient: Unable to get value for key " << key;
       throw RedisReadFailed();
-    } else if (!reply.is_string()) {
+    }
+    if (reply.is_null() || !reply.is_string()) {
+      // value just doesn't exist
       session_map[key] = SessionVector{};
     } else {
       session_map[key] = std::move(deserialize_session_vec(reply.as_string()));

--- a/lte/gateway/c/session_manager/RuleStore.cpp
+++ b/lte/gateway/c/session_manager/RuleStore.cpp
@@ -15,8 +15,6 @@
 #include "RuleStore.h"
 #include "ServiceRegistrySingleton.h"
 
-using grpc::Status;
-
 namespace magma {
 
 template<typename KeyType, typename hash, typename equal>

--- a/lte/gateway/c/session_manager/SessionID.cpp
+++ b/lte/gateway/c/session_manager/SessionID.cpp
@@ -17,13 +17,14 @@
 #include "SessionID.h"
 
 SessionIDGenerator::SessionIDGenerator() {
-  // init random seed
-  srand(time(NULL));
+  std::random_device rseed;
+  rgen_  = std::mt19937(rseed());  // mersenne_twister
+  idist_ = std::uniform_int_distribution<int>(0, 999999);
 }
 
 std::string SessionIDGenerator::gen_session_id(const std::string& imsi) {
   // imsi- + random 6 digit number
-  return imsi + "-" + std::to_string(rand() % 1000000);
+  return imsi + "-" + std::to_string(idist_(rgen_));
 }
 
 bool SessionIDGenerator::get_imsi_from_session_id(

--- a/lte/gateway/c/session_manager/SessionID.h
+++ b/lte/gateway/c/session_manager/SessionID.h
@@ -13,6 +13,8 @@
 
 #pragma once
 
+#include <random>
+
 class SessionIDGenerator {
  public:
   SessionIDGenerator();
@@ -28,4 +30,8 @@ class SessionIDGenerator {
    */
   bool get_imsi_from_session_id(
       const std::string& session_id, std::string& imsi_out);
+
+ private:
+  std::mt19937 rgen_;
+  std::uniform_int_distribution<int> idist_;
 };

--- a/lte/gateway/c/session_manager/SessionManagerServer.cpp
+++ b/lte/gateway/c/session_manager/SessionManagerServer.cpp
@@ -14,7 +14,6 @@
 #include "magma_logging.h"
 #include <chrono>
 #include <ctime>
-using grpc::ServerContext;
 using grpc::Status;
 
 namespace magma {

--- a/lte/gateway/c/session_manager/sessiond_main.cpp
+++ b/lte/gateway/c/session_manager/sessiond_main.cpp
@@ -179,9 +179,9 @@ int main(int argc, char* argv[]) {
       magma::ServiceConfigLoader{}.load_service_config(SESSIOND_SERVICE);
   magma::set_verbosity(get_log_verbosity(config, mconfig));
   bool converged_access = false;
-  // Check converged sesiond is enebaled or not
-  if ((config["converged_access"].IsDefined()) &&
-      (config["converged_access"].as<bool>())) {
+  // Check converged SessionD is enabled or not
+  if (config["converged_access"].IsDefined() &&
+      config["converged_access"].as<bool>()) {
     converged_access = true;
   }
   MLOG(MINFO) << "Starting Session Manager";
@@ -421,7 +421,7 @@ int main(int argc, char* argv[]) {
     free(conv_set_message_service);
     access_common_message_thread.join();
   }
-  free(session_store);
+  delete session_store;
 
   return 0;
 }


### PR DESCRIPTION
Signed-off-by: Marie Bremner <marwhal@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary
This PR addresses several clang-tidy warning. I'll list them out at the bottom.

## Test Plan
Run unit tests + s1ap tests

## Clang-tidy warnings
These two below are very straightforward, with unused namespaces.
```
/magma/lte/gateway/c/session_manager/SessionManagerServer.cpp:17:13: warning: using decl 'ServerContext' is unused [misc-unused-using-decls]
using grpc::ServerContext;
```
```
/magma/lte/gateway/c/session_manager/RuleStore.cpp:18:13: warning: using decl 'Status' is unused [misc-unused-using-decls]
using grpc::Status;
            ^
/magma/lte/gateway/c/session_manager/RuleStore.cpp:18:13: note: remove the using
using grpc::Status;
~~~~~~~~~~~~^~~~~~~
```
C++ oopsies
```
/magma/lte/gateway/c/session_manager/sessiond_main.cpp:418:3: warning: Memory allocated by 'new' should be deallocated by 'delete', not free() [clang-analyzer-unix.MismatchedDeallocator]
  free(session_store);
```
Apparently using `rand()` is a big NO NO. Fun talk about it here: https://channel9.msdn.com/Events/GoingNative/2013/rand-Considered-Harmful
```
/magma/lte/gateway/c/session_manager/SessionID.cpp:21:3: warning: random number generator seeded with a disallowed source of seed value will generate a predictable sequence of values [cert-msc32-c,cert-msc51-cpp]
  srand(time(NULL));
  ^
/magma/lte/gateway/c/session_manager/SessionID.cpp:26:38: warning: rand() has limited randomness; use C++11 random library instead [cert-msc30-c,cert-msc50-cpp]
  return imsi + "-" + std::to_string(rand() % 1000000);
                                     ^
```