### PR TITLE
[CI] Enable GCC Warning Annotations on GH Pull Requests

### DIFF
--- a/.github/workflows/gcc-problems.yml
+++ b/.github/workflows/gcc-problems.yml
@@ -1,0 +1,182 @@
+#######
+# This pipeline runs various static analysis (e.g. GCC warnings) against the c / c++ pull requests.
+#
+# TODO: Move Docker container caching / storage to a repository
+#
+# TODO: Reduce workflow description duplication across jobs
+#   - Option: by use of Workflow Templates per gcc-build-target (need to move docker build to another workflow and requires container repo)
+#   - Option: by improving our build system and enabling faster build-all-targets
+#######
+name: "GCC Warnings & Errors"
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+    paths:
+      - lte/gateway/c/**
+      - orc8r/gateway/c/**
+
+# See [Example Sharing Container Between Jobs](https://github.com/docker/build-push-action/issues/225)
+jobs:
+  gen_build_container:
+    runs-on: ubuntu-latest
+    steps:
+      - 
+        name: Check Out Repo 
+        uses: actions/checkout@v2
+      - 
+        name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v1
+      - 
+        name: Cache Docker layers
+        uses: actions/cache@v2
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-
+      - 
+        name: Docker Build
+        id: docker_build
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: ./lte/gateway/docker/mme/Dockerfile.ubuntu20.04
+          push: false
+          tags: magma/mme_builder:latest
+          outputs: type=docker,dest=/tmp/mme_builder.tar
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache-new
+      - 
+        # Temp fix
+        # https://github.com/docker/build-push-action/issues/252
+        # https://github.com/moby/buildkit/issues/1896
+        name: Move cache - Fixup for buildx cache issue
+        run: |
+          rm -rf /tmp/.buildx-cache
+          mv /tmp/.buildx-cache-new /tmp/.buildx-cache
+      -
+        name: Upload docker image for other jobs
+        uses: actions/upload-artifact@v2
+        with:
+          name: build_container
+          path: /tmp/mme_builder.tar
+
+  build_oai:
+    runs-on: ubuntu-latest
+    needs: gen_build_container
+    steps:
+      - 
+        # This is necessary for overlays into the Docker container below.
+        name: Check Out Repo 
+        uses: actions/checkout@v2
+      -
+        # I am using mmagician fork of get-changed-files (forked from jitterbit/get-changed-files)
+        #   Rationale: our workflow (merge branch into upstream master) is incompatible
+        #   See long list of GH Issues on https://github.com/jitterbit/get-changed-files w.r.t. head ahead of base
+        name: Fetch list of changed files
+        id: changed_files
+        uses: mmagician/get-changed-files@v2
+        with:
+          format: 'space-delimited'
+      -
+        name: Download docker image from generate_container_for_build
+        uses: actions/download-artifact@v2
+        with:
+          name: build_container
+          path: /tmp
+      -
+        name: Load Docker image
+        run: |
+          docker load --input /tmp/mme_builder.tar
+          docker image ls -a
+      -
+        # If needed https://github.com/microsoft/vscode-cpptools/issues/2266 for path fixups
+        #
+        # Additional GH Issues regarding paths for monorepos without root build.
+        # - https://github.com/actions/runner/issues/659
+        # - https://github.com/actions/runner/issues/765
+        #
+        # Paths emitted on warnings must be relative to the repository (e.g. lte/gateway/...),
+        # Therefore below I use `xo` to fixup our path emissions on gcc warnings.
+        uses: electronjoe/gcc-problem-matcher@v1
+      -
+        name: Build and Apply GCC Problem Matcher
+        uses: addnab/docker-run-action@v2
+        with:
+          image: magma/mme_builder:latest
+          # TODO: Remove work-around mount of Github workspace to /magma (https://github.com/addnab/docker-run-action/issues/11)
+          options: -v ${{ github.workspace }}:/magma -e ABC=123
+          run: |
+            cd /magma/lte/gateway/
+            make build_oai 2>&1 > /magma/compile.log
+            for file in ${{ steps.changed_files.outputs.all }};
+            do grep $file /magma/compile.log | xo '/\/magma\/((.*):(\d+):(\d+):\s+(?:fatal\s)?(warning|error):\s+(.*))/$1/' || true;
+            done;
+      -
+        name: Store build_logs_oai Artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: build_logs_oai
+          path: ${{ github.workspace }}/compile.log      
+
+  build_session_manager:
+    runs-on: ubuntu-latest
+    needs: gen_build_container
+    steps:
+      - 
+        # This is necessary for overlays into the Docker container below.
+        name: Check Out Repo 
+        uses: actions/checkout@v2
+      -
+        # I am using mmagician fork of get-changed-files (forked from jitterbit/get-changed-files)
+        #   Rationale: our workflow (merge branch into upstream master) is incompatible
+        #   See long list of GH Issues on https://github.com/jitterbit/get-changed-files w.r.t. head ahead of base
+        name: Fetch list of changed files
+        id: changed_files
+        uses: mmagician/get-changed-files@v2
+        with:
+          format: 'space-delimited'
+      -
+        name: Download docker image from generate_container_for_build
+        uses: actions/download-artifact@v2
+        with:
+          name: build_container
+          path: /tmp
+      -
+        name: Load Docker image
+        run: |
+          docker load --input /tmp/mme_builder.tar
+          docker image ls -a
+      -
+        # If needed https://github.com/microsoft/vscode-cpptools/issues/2266 for path fixups
+        #
+        # Additional GH Issues regarding paths for monorepos without root build.
+        # - https://github.com/actions/runner/issues/659
+        # - https://github.com/actions/runner/issues/765
+        #
+        # Paths emitted on warnings must be relative to the repository (e.g. lte/gateway/...),
+        # Therefore below I use `xo` to fixup our path emissions on gcc warnings.
+        uses: electronjoe/gcc-problem-matcher@v1
+      -
+        name: Build and Apply GCC Problem Matcher
+        uses: addnab/docker-run-action@v2
+        with:
+          image: magma/mme_builder:latest
+          # TODO: Remove work-around mount of Github workspace to /magma (https://github.com/addnab/docker-run-action/issues/11)
+          options: -v ${{ github.workspace }}:/magma -e ABC=123
+          run: |
+            cd /magma/lte/gateway/
+            make build_session_manager 2>&1 > /magma/compile.log
+            for file in ${{ steps.changed_files.outputs.all }};
+            do grep $file /magma/compile.log | xo '/\/magma\/((.*):(\d+):(\d+):\s+(?:fatal\s)?(warning|error):\s+(.*))/$1/' || true;
+            done;
+      -
+        name: Store build_logs_session_manager Artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: build_logs_session_manager
+          path: ${{ github.workspace }}/compile.log      

--- a/lte/gateway/c/oai/tasks/nas/emm/Attach.c
+++ b/lte/gateway/c/oai/tasks/nas/emm/Attach.c
@@ -201,6 +201,7 @@ static void _create_new_attach_info(
 int emm_proc_attach_request(
     mme_ue_s1ap_id_t ue_id, const bool is_mm_ctx_new,
     emm_attach_request_ies_t* const ies) {
+  int totally_useless = 1;
   OAILOG_FUNC_IN(LOG_NAS_EMM);
   int rc = RETURNerror;
   ue_mm_context_t ue_ctx;

--- a/lte/gateway/c/session_manager/AAAClient.cpp
+++ b/lte/gateway/c/session_manager/AAAClient.cpp
@@ -22,6 +22,7 @@ namespace {  // anonymous
 
 aaa::terminate_session_request create_deactivate_req(
     const std::string& radius_session_id, const std::string& imsi) {
+  int yet_another_unused_variable = 2;
   aaa::terminate_session_request req;
   req.set_radius_session_id(radius_session_id);
   req.set_imsi(imsi);

--- a/lte/gateway/docker/mme/Dockerfile.ubuntu20.04
+++ b/lte/gateway/docker/mme/Dockerfile.ubuntu20.04
@@ -1,0 +1,260 @@
+################################################################
+# Builder Image (can also be used as developer's image)
+################################################################
+FROM ubuntu:focal as mme_builder 
+
+ARG GIT_PROXY
+ARG FEATURES=mme_oai
+ENV MAGMA_ROOT=/magma
+ENV BUILD_TYPE=Debug
+ENV C_BUILD=/build/c
+ENV TZ=Europe/Paris
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN mkdir -p $C_BUILD
+
+RUN echo "Install general purpouse packages" && \
+    apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get upgrade -y && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y \
+        apt-transport-https \
+        apt-utils \
+        autoconf \
+        autoconf automake \
+        automake \
+        build-essential \
+        ca-certificates \
+        clang-11 \
+        clang-format-11 \
+        clang-tidy-11 \
+        curl \
+        g++ \
+        g++-9 \
+        gcc-9 \
+        lcov \
+        git \
+        gnupg \
+        golang \
+        libgmp3-dev \
+        libpcap-dev \
+        libssl-dev \
+        libtool \
+        make \
+        ninja-build \
+        perl \
+        pkg-config \
+        python2.7 \
+        redis-server \
+        ruby \
+        rubygems \
+        ruby-dev \
+        software-properties-common \
+        tzdata \
+        unzip \
+        vim \
+        wget && \
+        gem install fpm && \
+        update-alternatives --install /usr/bin/clang-tidy clang-tidy /usr/lib/llvm-11/bin/clang-tidy 10 && \
+        update-alternatives --install /usr/bin/clang-format clang-format /usr/lib/llvm-11/bin/clang-format 10 && \
+        update-alternatives --install /usr/bin/clang clang /usr/lib/llvm-11/bin/clang 10 && \
+        update-alternatives --install /usr/bin/clang++ clang++ /usr/lib/llvm-11/bin/clang++ 10
+
+RUN echo "Install 3rd party dependencies" && \
+    apt-get update && \
+    echo "Install CMake" && \
+    apt-get -y install cmake && \
+    echo "Install FMT lib requirements" && \
+    apt-get -y install libunwind8-dev libelf-dev libdwarf-dev bzip2 && \
+    echo "Install Folly requirements" && \
+    apt-get -y install libboost-all-dev libevent-dev libdouble-conversion-dev \
+    libgoogle-glog-dev libgflags-dev libiberty-dev liblz4-dev liblzma-dev \
+    libsnappy-dev binutils-dev libjemalloc-dev libssl-dev pkg-config libunwind-dev && \
+    echo "Install check for test support" && \
+    apt-get -y install check && \
+    echo "Install gtest for test support" && \
+    apt-get -y install libgtest-dev && \
+    echo "Install FreeDiameter requirements" && \
+    apt-get -y install libsctp1 libsctp-dev libgcrypt-dev \
+    bison flex libidn11-dev && \
+    echo "Install libgtpnl requirements" && \
+    apt-get -y install libmnl-dev && \
+    echo "Install Nettle requirements" && \
+    apt-get install -y libgoogle-glog-dev libconfig-dev libxml2-dev \
+    libyaml-cpp-dev nlohmann-json3-dev && \
+    echo "Install ZeroMQ" && \
+    apt-get install -y libczmq-dev && \
+    ln -s /usr/bin/python2.7 /usr/local/bin/python && \
+    # TODO(fixup this include in source code @ MConfigLoader.cpp)
+    ln -s /usr/include/nlohmann/json.hpp /usr/include/json.hpp
+
+RUN ["/bin/bash", "-c", "if [[ -v GIT_PROXY ]]; then git config --global http.proxy $GIT_PROXY; fi"]
+
+##### NETTLE and GNUTLS
+# TODO Upgrade these - requires us to update our use of libnettle due to API migration.
+#  see https://gist.github.com/electronjoe/a899e4bfbc2904cb353444386296c38e
+# Note the CFLAGS define below due to glibc deprecation of critical flag,
+#  see https://github.com/rdslw/openwrt/blob/e5d47f32131849a69a9267de51a30d6be1f0d0ac/tools/bison/patches/110-glibc-change-work-around.patch
+RUN wget https://ftp.gnu.org/gnu/nettle/nettle-2.5.tar.gz && \
+    tar -xf nettle-2.5.tar.gz && \
+    cd nettle-2.5 && \
+    mkdir build && \
+    cd build/ && \
+    ../configure --disable-openssl --enable-shared --libdir=/usr/local/lib && \
+    make -j`nproc` && \
+    make install && \
+    ldconfig -v && \
+    cd / && \
+    wget http://mirrors.dotsrc.org/gcrypt/gnutls/v3.1/gnutls-3.1.23.tar.xz && \
+    tar xf gnutls-3.1.23.tar.xz && \
+    cd gnutls-3.1.23 && \
+    mkdir build && cd build && \
+    CFLAGS=-D_IO_ftrylockfile ../configure --with-libnettle-prefix=/usr/local && \
+    make -j`nproc` && \
+    make install && \
+    ldconfig -v && \
+    cd / && \
+    rm -rf nettle* && \
+    rm -rf gnutls*
+
+##### Useful for logfile modification e.g. pruning all /magma/... prefix from GCC warning logs
+RUN GOBIN="/usr/bin/" go get github.com/ezekg/xo
+
+##### GRPC and it's dependencies
+RUN git clone --recurse-submodules -b v1.35.0 https://github.com/grpc/grpc && \
+    cd grpc && \
+    mkdir -p cmake/build && \
+    cd cmake/build && \
+    cmake -DgRPC_INSTALL=ON -DgRPC_BUILD_TESTS=OFF -DBUILD_SHARED_LIBS=ON ../.. && \
+    make -j`nproc` && \
+    make install && \
+    cd / && \
+    rm -rf grpc
+
+##### Prometheus CPP
+RUN git clone https://github.com/jupp0r/prometheus-cpp.git && \
+    cd prometheus-cpp && \
+    git checkout d8326b2bba945a435f299e7526c403d7a1f68c1f && \
+    git submodule init && git submodule update && \
+    mkdir _build && \
+    cd _build/ && \
+    cmake .. && \
+    make -j`nproc` && \
+    make install && \
+    rm -rf /prometheus-cpp
+
+##### Redis CPP
+RUN git clone https://github.com/cpp-redis/cpp_redis.git && \
+    cd cpp_redis && \
+    git checkout bbe38a7f83de943ffcc90271092d689ae02b3489 && \
+    git submodule init && git submodule update && \
+    mkdir build && cd build && \
+    cmake .. -DCMAKE_BUILD_TYPE=Release && \
+    make -j`nproc` && \
+    make install && \
+    rm -rf /cpp_redis
+
+##### liblfds
+# https://www.liblfds.org/mediawiki/index.php?title=r7.1.0:Building_Guide_(liblfds)
+RUN wget https://liblfds.org/downloads/liblfds%20release%207.1.0%20source.tar.bz2  && \
+    tar -xf liblfds\ release\ 7.1.0\ source.tar.bz2  && \
+    cd liblfds/liblfds7.1.0/liblfds710/build/gcc_gnumake/ && \
+    make -j`nproc` && \
+    make ar_install && \
+    cd / && \
+    rm -rf liblfds
+
+##### libgtpnl
+# review https://github.com/OPENAIRINTERFACE/openair-cn/blob/master/build/tools/build_helper.gtpnl
+RUN git clone https://git.osmocom.org/libgtpnl && \
+    cd libgtpnl && \
+    git reset --hard 345d687 && \
+    autoreconf -fi && \
+    ./configure && \
+    make -j`nproc` && \
+    make install && \
+    ldconfig && \
+    cd / && \
+    rm -rf libgtpnl
+
+#####  asn1c
+RUN git clone https://gitlab.eurecom.fr/oai/asn1c.git && \
+    cd asn1c && \
+    git checkout f12568d617dbf48497588f8e227d70388fa217c9 && \
+    autoreconf -iv && \
+    ./configure && \
+    make -j`nproc` && \
+    make install && \
+    ldconfig
+
+
+## Install Fmt (Folly Dep)
+RUN git clone https://github.com/fmtlib/fmt.git && cd fmt && \
+    mkdir _build && cd _build && \
+    cmake -DBUILD_SHARED_LIBS=ON .. && \
+    make -j$(nproc) && \
+    make install && \
+    cd / && \
+    rm -rf fmt
+
+##### Facebook Folly C++ lib
+# Note: "Because folly does not provide any ABI compatibility guarantees from
+#        commit to commit, we generally recommend building folly as a static library."
+# Here we checkout the hash for v2021.02.22.00 (arbitrary recent version)
+RUN git clone https://github.com/facebook/folly && cd folly && \
+    git checkout tags/v2021.02.15.00 && \
+    mkdir _build && cd _build && \
+    cmake -DBUILD_SHARED_LIBS=ON .. && \
+    make -j$(nproc) && \
+    make install && \
+    cd / && \
+    rm -rf folly
+    
+##### Build and install libgtest and gmock
+RUN cd /usr/src/googletest && \
+    mkdir build && \
+    cd build && \
+    cmake -DBUILD_SHARED_LIBS=ON .. && \
+    echo "Build gtest and gmock" && \
+    make && \
+    echo "Install gtest and gmock" && \
+    make install && \
+    ldconfig -v
+
+#### libtins is required to build the connection_tracker
+RUN git clone --branch v4.3 https://github.com/mfontanini/libtins.git && \
+    cd libtins && \
+    mkdir build && \
+    cd build && \
+    cmake ../ -DLIBTINS_ENABLE_CXX11=1 && \
+    make -j`nproc` && \
+    make install && \
+    cd / && \
+    rm -rf libtins
+
+# Add Converged MME sources to the container
+# Must be done prior to FreeDiameter build as we need the patches from Magma repo
+COPY ./ $MAGMA_ROOT
+
+##### libfluid is requird to build MME with OVS support
+RUN cd /magma/third_party/build/bin && \
+    ./libfluid_build.sh && \
+    find . -name magma-libfluid_0.1* -exec dpkg -i {} \; && \
+    rm -rf /tmp/*
+
+##### FreeDiameter
+RUN git clone https://github.com/OPENAIRINTERFACE/opencord.org.freeDiameter.git freediameter && \
+    cd freediameter && \
+    patch -p1 < $MAGMA_ROOT/lte/gateway/c/oai/patches/0001-opencoord.org.freeDiameter.patch && \
+    mkdir build && \
+    cd build && \
+    cmake ../ && \
+    awk '{if (/^DISABLE_SCTP/) gsub(/OFF/, "ON"); print}' CMakeCache.txt > tmp && mv tmp CMakeCache.txt && \
+    make -j`nproc` && \
+    make install && \
+    cd / && \
+    rm -rf freediameter
+
+##### Clean up MAGMA_ROOT so others don't accidentally use it.
+# E.g. in CI environments access to repo should occur through docker volume from the parent OS.
+# Further, some environments assume specific mount points for the source code (e.g. GitHub Actions).
+RUN rm -rf $MAGMA_ROOT


### PR DESCRIPTION
# Summary

Here is an example GCC Warning Annotation directly on a Pull Request.

<img width="713" alt="Screen Shot 2021-03-14 at 7 24 26 AM" src="https://user-images.githubusercontent.com/3752618/111066627-60449400-8496-11eb-8ac0-be21ec105a72.png">

Among several motivations for this change - I feel that by enabling GCC warning annotations we can now move forward with removal of `-Werror` compiler flags (#5358).

The approach of this PR can now be applied to also annotate Clang 11 warnings, Clang-Tidy findings, and Clang-Format findings (with some extra work required for each - but they will be much easier to add now).

This PR achieves the annotations through the following.

- Dockerfile capable of build and analysis of Magma c/c++ targets
  - Using Ubuntu 20.04
  - GCC 9.3 (default 20.04)
- A Github Workflow that emits Pull Request GCC Warning Annotations
  - That show up directly in-line during code review
  - Using [electronjoe/gcc-problem-matcher](https://github.com/electronjoe/gcc-problem-matcher)

# Some Details

## Annotation Count Limits

There are annotation limits in GitHub Actions:

- 10 warning annotations and 10 error annotations per step
- 50 annotations per job (sum of annotations from all the steps)
- 50 annotations per run (separate from the job annotations, these annotations aren’t created by users)

Given that our codebase now has 600 GCC 9.3 warnings (with `-Wextra` enabled), this PR had to filter them.  Annotations are filtered and emitted only for modified files.

** The implication is that only the first 10 Annotations will be emitted, for the modified files. **

This could at times miss things, until we burn down some of the GCC warnings being emitted.

## Determining changed files

In order to determine the set of files modified by the PR - we use the `get-changed-files@v2` github action.  The original implementation (jiterrbit/get-changed-files) has some weaknesses that result in action-terminating warnings under the Magma workflow (any time the forked-branch is not based upon origin-master).  Pragmatically, the warning emitted by jiterrbit's github action does not often impact the output results, so we use here a fork of get-changed-files by mmagician which disables the error / halt under this warning.

** The implication however is that the set of files filtered as having changes in a Pull Request could, in certain situations, not reflect reality due to the complexity of the merge situation. **

Signed-off-by: Scott Harrison Moeller <smoeller@fb.com>