### PR TITLE
[AGW][Health] Update agw_health_cli + health service to handle error better

### DIFF
--- a/lte/gateway/python/magma/health/entities.py
+++ b/lte/gateway/python/magma/health/entities.py
@@ -90,11 +90,11 @@ class AGWHealthSummary:
         #eNBs connected:    {} \t (run `enodebd_cli.py get_all_status` for more details)
         #IPs allocated:     {} \t (run `mobility_cli.py list_allocated_ips` for more details)
         #UEs connected:     {} \t (run `mobility_cli.py get_subscriber_table` for more details)
-        #Core dumps:        {} \t (run `ls /tmp/` to see core dumps)
+        #Core dumps:        {} \t (run `ls /var/core` to see core dumps)
         Earliest core-dump: {}, Latest core-dump: {}
         Registration success rate: {}
         """).format(
-            'Using Feg' if self.hss_relay_enabled else 'Using subscriberdb',
+            'Using Feg' if self.hss_relay_enabled else 'Using SubscriberDB',
             self.nb_enbs_connected,
             len(self.allocated_ips),
             len(self.subscriber_table),

--- a/lte/gateway/python/magma/health/health_service.py
+++ b/lte/gateway/python/magma/health/health_service.py
@@ -67,11 +67,11 @@ class AGWHealth:
             attach_accepts=log.count('Attach Accept'))
 
     def get_core_dumps(self,
-                       directory='/tmp/',
+                       directory='/var/core',
                        start_timestamp=0,
                        end_timestamp=math.inf):
         res = []
-        for filename in glob.glob(path.join(directory, 'core-*_bundle')):
+        for filename in glob.glob(path.join(directory, 'core-*')):
             # core-1565125801-python3-8042_bundle
             ts = int(filename.split('-')[1])
             if start_timestamp <= ts <= end_timestamp:
@@ -88,8 +88,8 @@ class AGWHealth:
 
         mme_log_path = '/var/log/mme.log'
         health_summary = AGWHealthSummary(
-            hss_relay_enabled=config['hssRelayEnabled'],
-            nb_enbs_connected=status.meta['n_enodeb_connected'],
+            hss_relay_enabled=config.get('hssRelayEnabled', False),
+            nb_enbs_connected=status.meta.get('n_enodeb_connected', 0),
             allocated_ips=self.get_allocated_ips(),
             subscriber_table=self.get_subscriber_table(),
             core_dumps=self.get_core_dumps(),

--- a/lte/gateway/python/scripts/agw_health_cli.py
+++ b/lte/gateway/python/scripts/agw_health_cli.py
@@ -45,7 +45,7 @@ class AGWHealthCLI:
         print(str(self._health_checker.get_subscriber_table()))
 
     def core_dumps(self,
-                   directory='/tmp/',
+                   directory='/var/core',
                    start_timestamp=0,
                    end_timestamp=math.inf):
         """


### PR DESCRIPTION
<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary
When `hssRelayEnabled` is missing from the mconfig, the health script fails with the following error: 
```
magma@agw2:~$ agw_health_cli.py
Access Gateway health summary
Error: 'hssRelayEnabled'
magma@agw2:~$
```
This PR fixes this problem by adding a default value=False.

Additionally, this PR fixes the incorrect coredump path as they are now generated into `/var/core/` not `/tmp/`.
<!-- Enumerate changes you made and why you made them -->

## Test Plan
Run the agw_health_script
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
