### PR TITLE
AGW: MME: GTP-APP: Add support to add S8 tunnels

### DIFF
--- a/lte/gateway/c/oai/lib/openflow/controller/ControllerEvents.cpp
+++ b/lte/gateway/c/oai/lib/openflow/controller/ControllerEvents.cpp
@@ -185,7 +185,7 @@ AddGTPTunnelEvent::AddGTPTunnelEvent(
       dl_flow_valid_(false),
       dl_flow_(),
       dl_flow_precedence_(DEFAULT_PRECEDENCE),
-      ExternalEvent(EVENT_ADD_GTP_TUNNEL),
+      ExternalEvent(EVENT_ADD_GTP_S8_TUNNEL),
       enb_gtp_port_(enb_gtp_port),
       pgw_gtp_port_(pgw_gtp_port) {}
 
@@ -203,7 +203,7 @@ AddGTPTunnelEvent::AddGTPTunnelEvent(
       dl_flow_valid_(false),
       dl_flow_(),
       dl_flow_precedence_(DEFAULT_PRECEDENCE),
-      ExternalEvent(EVENT_ADD_GTP_TUNNEL),
+      ExternalEvent(EVENT_ADD_GTP_S8_TUNNEL),
       enb_gtp_port_(enb_gtp_port),
       pgw_gtp_port_(pgw_gtp_port) {}
 
@@ -285,7 +285,7 @@ DeleteGTPTunnelEvent::DeleteGTPTunnelEvent(
       in_tei_(in_tei),
       dl_flow_valid_(true),
       dl_flow_(*dl_flow),
-      ExternalEvent(EVENT_DELETE_GTP_TUNNEL),
+      ExternalEvent(EVENT_DELETE_GTP_S8_TUNNEL),
       enb_gtp_port_(enb_gtp_port),
       pgw_gtp_port_(pgw_gtp_port) {}
 
@@ -296,7 +296,7 @@ DeleteGTPTunnelEvent::DeleteGTPTunnelEvent(
       in_tei_(in_tei),
       dl_flow_valid_(false),
       dl_flow_(),
-      ExternalEvent(EVENT_DELETE_GTP_TUNNEL),
+      ExternalEvent(EVENT_DELETE_GTP_S8_TUNNEL),
       enb_gtp_port_(enb_gtp_port),
       pgw_gtp_port_(pgw_gtp_port) {}
 

--- a/lte/gateway/c/oai/lib/openflow/controller/ControllerMain.cpp
+++ b/lte/gateway/c/oai/lib/openflow/controller/ControllerMain.cpp
@@ -64,6 +64,8 @@ int start_of_controller(bool persist_state) {
   ctrl.register_for_event(&gtp_app, openflow::EVENT_SWITCH_UP);
   ctrl.register_for_event(&gtp_app, openflow::EVENT_ADD_GTP_TUNNEL);
   ctrl.register_for_event(&gtp_app, openflow::EVENT_DELETE_GTP_TUNNEL);
+  ctrl.register_for_event(&gtp_app, openflow::EVENT_ADD_GTP_S8_TUNNEL);
+  ctrl.register_for_event(&gtp_app, openflow::EVENT_DELETE_GTP_S8_TUNNEL);
   ctrl.register_for_event(&gtp_app, openflow::EVENT_DISCARD_DATA_ON_GTP_TUNNEL);
   ctrl.register_for_event(&gtp_app, openflow::EVENT_FORWARD_DATA_ON_GTP_TUNNEL);
   ctrl.start();
@@ -117,6 +119,40 @@ int openflow_controller_del_gtp_tunnel(
   } else {
     auto del_tunnel = std::make_shared<openflow::DeleteGTPTunnelEvent>(
         ue, ue_ipv6, i_tei, gtp_portno);
+    ctrl.inject_external_event(del_tunnel, external_event_callback);
+  }
+  OAILOG_FUNC_RETURN(LOG_GTPV1U, RETURNok);
+}
+
+int openflow_controller_add_gtp_s8_tunnel(
+    struct in_addr ue, struct in6_addr* ue_ipv6, int vlan, struct in_addr enb,
+    struct in_addr pgw, uint32_t i_tei, uint32_t o_tei, const char* imsi,
+    struct ip_flow_dl* flow_dl, uint32_t flow_precedence_dl,
+    uint32_t enb_gtp_port, uint32_t pgw_gtp_port) {
+  if (flow_dl) {
+    auto add_tunnel = std::make_shared<openflow::AddGTPTunnelEvent>(
+        ue, ue_ipv6, vlan, enb, pgw, i_tei, o_tei, imsi, flow_dl,
+        flow_precedence_dl, enb_gtp_port, pgw_gtp_port);
+    ctrl.inject_external_event(add_tunnel, external_event_callback);
+  } else {
+    auto add_tunnel = std::make_shared<openflow::AddGTPTunnelEvent>(
+        ue, ue_ipv6, vlan, enb, pgw, i_tei, o_tei, imsi, enb_gtp_port,
+        pgw_gtp_port);
+    ctrl.inject_external_event(add_tunnel, external_event_callback);
+  }
+  OAILOG_FUNC_RETURN(LOG_GTPV1U, RETURNok);
+}
+
+int openflow_controller_del_gtp_s8_tunnel(
+    struct in_addr ue, struct in6_addr* ue_ipv6, uint32_t i_tei,
+    struct ip_flow_dl* flow_dl, uint32_t enb_gtp_port, uint32_t pgw_gtp_port) {
+  if (flow_dl) {
+    auto del_tunnel = std::make_shared<openflow::DeleteGTPTunnelEvent>(
+        ue, ue_ipv6, i_tei, flow_dl, enb_gtp_port, pgw_gtp_port);
+    ctrl.inject_external_event(del_tunnel, external_event_callback);
+  } else {
+    auto del_tunnel = std::make_shared<openflow::DeleteGTPTunnelEvent>(
+        ue, ue_ipv6, i_tei, enb_gtp_port, pgw_gtp_port);
     ctrl.inject_external_event(del_tunnel, external_event_callback);
   }
   OAILOG_FUNC_RETURN(LOG_GTPV1U, RETURNok);

--- a/lte/gateway/c/oai/lib/openflow/controller/ControllerMain.h
+++ b/lte/gateway/c/oai/lib/openflow/controller/ControllerMain.h
@@ -54,6 +54,16 @@ int openflow_controller_add_paging_rule(struct in_addr ue_ip);
 
 int openflow_controller_delete_paging_rule(struct in_addr ue_ip);
 
+int openflow_controller_add_gtp_s8_tunnel(
+    struct in_addr ue, struct in6_addr* ue_ipv6, int vlan, struct in_addr enb,
+    struct in_addr pgw, uint32_t i_tei, uint32_t o_tei, const char* imsi,
+    struct ip_flow_dl* flow_dl, uint32_t flow_precedence_dl,
+    uint32_t enb_gtp_port, uint32_t pgw_gtp_port);
+
+int openflow_controller_del_gtp_s8_tunnel(
+    struct in_addr ue, struct in6_addr* ue_ipv6, uint32_t i_tei,
+    struct ip_flow_dl* flow_dl, uint32_t enb_gtp_port, uint32_t pgw_gtp_port);
+
 #ifdef __cplusplus
 }
 #endif

--- a/lte/gateway/c/oai/lib/openflow/controller/GTPApplication.cpp
+++ b/lte/gateway/c/oai/lib/openflow/controller/GTPApplication.cpp
@@ -49,10 +49,12 @@ GTPApplication::GTPApplication(
 void GTPApplication::event_callback(
     const ControllerEvent& ev, const OpenflowMessenger& messenger) {
   if (ev.get_type() == EVENT_ADD_GTP_TUNNEL) {
+    printf("pbs: reg add tun");
     auto add_tunnel_event = static_cast<const AddGTPTunnelEvent&>(ev);
     add_uplink_tunnel_flow(add_tunnel_event, messenger);
-    add_downlink_tunnel_flow(add_tunnel_event, messenger, uplink_port_num_);
-    add_downlink_tunnel_flow(add_tunnel_event, messenger, mtr_port_num_);
+    add_downlink_tunnel_flow(
+        add_tunnel_event, messenger, uplink_port_num_, false);
+    add_downlink_tunnel_flow(add_tunnel_event, messenger, mtr_port_num_, false);
     add_downlink_arp_flow(add_tunnel_event, messenger, uplink_port_num_);
     add_downlink_arp_flow(add_tunnel_event, messenger, mtr_port_num_);
   } else if (ev.get_type() == EVENT_DELETE_GTP_TUNNEL) {
@@ -61,6 +63,30 @@ void GTPApplication::event_callback(
     delete_downlink_tunnel_flow(del_tunnel_event, messenger, uplink_port_num_);
     delete_downlink_tunnel_flow(del_tunnel_event, messenger, mtr_port_num_);
     delete_downlink_arp_flow(del_tunnel_event, messenger, uplink_port_num_);
+    delete_downlink_arp_flow(del_tunnel_event, messenger, mtr_port_num_);
+  } else if (ev.get_type() == EVENT_ADD_GTP_S8_TUNNEL) {
+    printf("pbs: S8 add tun");
+
+    auto add_tunnel_event = static_cast<const AddGTPTunnelEvent&>(ev);
+    add_uplink_s8_tunnel_flow(add_tunnel_event, messenger);
+    int pgw_port = add_tunnel_event.get_pgw_gtp_portno();
+    if (pgw_port == 0) {
+      pgw_port = GTPApplication::gtp0_port_num_;
+    }
+    add_downlink_tunnel_flow(add_tunnel_event, messenger, pgw_port, true);
+    add_downlink_tunnel_flow(add_tunnel_event, messenger, mtr_port_num_, true);
+    add_downlink_arp_flow(add_tunnel_event, messenger, mtr_port_num_);
+  } else if (ev.get_type() == EVENT_DELETE_GTP_S8_TUNNEL) {
+    auto del_tunnel_event = static_cast<const DeleteGTPTunnelEvent&>(ev);
+    // Same delete can be used, since uplink flow match is same for S8 tunnel.
+    delete_uplink_tunnel_flow(del_tunnel_event, messenger);
+    int pgw_port = del_tunnel_event.get_pgw_gtp_portno();
+    if (pgw_port == 0) {
+      pgw_port = GTPApplication::gtp0_port_num_;
+    }
+    delete_downlink_tunnel_flow(del_tunnel_event, messenger, pgw_port);
+
+    delete_downlink_tunnel_flow(del_tunnel_event, messenger, mtr_port_num_);
     delete_downlink_arp_flow(del_tunnel_event, messenger, mtr_port_num_);
   } else if (ev.get_type() == EVENT_DISCARD_DATA_ON_GTP_TUNNEL) {
     auto discard_tunnel_flow =
@@ -103,7 +129,7 @@ void GTPApplication::install_internal_pkt_fwd_flow(
 /*
  * Helper method to add matching for adding/deleting the uplink flow
  */
-void GTPApplication::add_uplink_match(
+void GTPApplication::add_tunnel_match(
     of13::FlowMod& uplink_fm, uint32_t gtp_port, uint32_t i_tei) {
   if (gtp_port == 0) {
     gtp_port = GTPApplication::gtp0_port_num_;
@@ -131,7 +157,7 @@ void GTPApplication::add_uplink_tunnel_flow(
       convert_precedence_to_priority(ev.get_dl_flow_precedence());
   of13::FlowMod uplink_fm =
       messenger.create_default_flow_mod(0, of13::OFPFC_ADD, flow_priority);
-  add_uplink_match(uplink_fm, ev.get_enb_gtp_portno(), ev.get_in_tei());
+  add_tunnel_match(uplink_fm, ev.get_enb_gtp_portno(), ev.get_in_tei());
 
   // Set eth src and dst
   of13::ApplyActions apply_ul_inst;
@@ -168,6 +194,19 @@ void GTPApplication::add_uplink_tunnel_flow(
   OAILOG_DEBUG_UE(LOG_GTPV1U, imsi, "Uplink flow added\n");
 }
 
+void GTPApplication::add_uplink_s8_tunnel_flow(
+    const AddGTPTunnelEvent& ev, const OpenflowMessenger& messenger) {
+  uint32_t flow_priority =
+      convert_precedence_to_priority(ev.get_dl_flow_precedence());
+  of13::FlowMod uplink_fm =
+      messenger.create_default_flow_mod(0, of13::OFPFC_ADD, flow_priority);
+  add_tunnel_match(uplink_fm, ev.get_enb_gtp_portno(), ev.get_in_tei());
+
+  add_tunnel_flow_action(
+      ev.get_out_tei(), ev.get_imsi(), ev.get_pgw_ip(), ev.get_pgw_gtp_portno(),
+      ev.get_connection(), messenger, uplink_fm, "S8 Uplink", true);
+}
+
 void GTPApplication::delete_uplink_tunnel_flow(
     const DeleteGTPTunnelEvent& ev, const OpenflowMessenger& messenger) {
   of13::FlowMod uplink_fm =
@@ -176,7 +215,7 @@ void GTPApplication::delete_uplink_tunnel_flow(
   uplink_fm.out_port(of13::OFPP_ANY);
   uplink_fm.out_group(of13::OFPG_ANY);
 
-  add_uplink_match(uplink_fm, ev.get_enb_gtp_portno(), ev.get_in_tei());
+  add_tunnel_match(uplink_fm, ev.get_enb_gtp_portno(), ev.get_in_tei());
 
   messenger.send_of_msg(uplink_fm, ev.get_connection());
 }
@@ -316,27 +355,34 @@ static void add_ded_brr_dl_match(
 /**
  * Helper function to add downlink flow action.
  */
-void GTPApplication::add_downlink_tunnel_flow_action(
-    const AddGTPTunnelEvent& ev, const OpenflowMessenger& messenger,
-    of13::FlowMod downlink_fm) {
-  auto imsi = IMSIEncoder::compact_imsi(ev.get_imsi());
+void GTPApplication::add_tunnel_flow_action(
+    uint32_t tei, std::string ue_imsi, struct in_addr remote_ip,
+    uint32_t egress_gtp_port, fluid_base::OFConnection* connection,
+    const OpenflowMessenger& messenger, of13::FlowMod downlink_fm,
+    const std::string& flow_type, bool passthrough) {
   of13::ApplyActions apply_dl_inst;
+  auto imsi = IMSIEncoder::compact_imsi(ue_imsi);
 
   // Set outgoing tunnel id and tunnel destination ip
-  of13::SetFieldAction set_out_tunnel(new of13::TUNNELId(ev.get_out_tei()));
+  of13::SetFieldAction set_out_tunnel(new of13::TUNNELId(tei));
   apply_dl_inst.add_action(set_out_tunnel);
   of13::SetFieldAction set_tunnel_dst(
-      new of13::TunnelIPv4Dst(ev.get_enb_ip().s_addr));
+      new of13::TunnelIPv4Dst(remote_ip.s_addr));
   apply_dl_inst.add_action(set_tunnel_dst);
 
-  int gtp_port = ev.get_enb_gtp_portno();
+  int gtp_port = egress_gtp_port;
   if (gtp_port == 0) {
     gtp_port = GTPApplication::gtp0_port_num_;
   }
-
   of13::SetFieldAction set_tunnel_port(new of13::NXMReg8(gtp_port));
   apply_dl_inst.add_action(set_tunnel_port);
 
+  if (passthrough) {
+    // Set register6, this is pipelineD internal details.
+    // Once GTP app is moved to pipelineD we can remove this hack.
+    of13::SetFieldAction set_passthrough(new of13::NXMRegX(6, 1));
+    apply_dl_inst.add_action(set_passthrough);
+  }
   // add imsi to packet metadata to pass to other tables
   add_imsi_metadata(apply_dl_inst, imsi);
 
@@ -347,61 +393,69 @@ void GTPApplication::add_downlink_tunnel_flow_action(
   downlink_fm.add_instruction(goto_inst);
 
   // Finally, send flow mod
-  messenger.send_of_msg(downlink_fm, ev.get_connection());
-  OAILOG_DEBUG_UE(LOG_GTPV1U, imsi, "Downlink flow added\n");
+  messenger.send_of_msg(downlink_fm, connection);
+  OAILOG_DEBUG_UE(LOG_GTPV1U, imsi, "%s flow added\n", flow_type);
+}
+
+void GTPApplication::add_downlink_tunnel_flow_action(
+    const AddGTPTunnelEvent& ev, const OpenflowMessenger& messenger,
+    of13::FlowMod downlink_fm, bool passthrough) {
+  add_tunnel_flow_action(
+      ev.get_out_tei(), ev.get_imsi(), ev.get_enb_ip(), ev.get_enb_gtp_portno(),
+      ev.get_connection(), messenger, downlink_fm, "S1 Downlink", passthrough);
 }
 
 void GTPApplication::add_downlink_tunnel_flow_ipv4(
     const AddGTPTunnelEvent& ev, const OpenflowMessenger& messenger,
-    uint32_t port_number) {
+    uint32_t ingress_port, bool passthrough) {
   uint32_t flow_priority =
       convert_precedence_to_priority(ev.get_dl_flow_precedence());
   of13::FlowMod downlink_fm =
       messenger.create_default_flow_mod(0, of13::OFPFC_ADD, flow_priority);
 
-  add_downlink_match(downlink_fm, ev.get_ue_ip(), port_number);
-  add_downlink_tunnel_flow_action(ev, messenger, downlink_fm);
+  add_downlink_match(downlink_fm, ev.get_ue_ip(), ingress_port);
+  add_downlink_tunnel_flow_action(ev, messenger, downlink_fm, passthrough);
 }
 
 void GTPApplication::add_downlink_tunnel_flow_ipv6(
     const AddGTPTunnelEvent& ev, const OpenflowMessenger& messenger,
-    uint32_t port_number) {
+    uint32_t ingress_port, bool passthrough) {
   uint32_t flow_priority =
       convert_precedence_to_priority(ev.get_dl_flow_precedence());
   of13::FlowMod downlink_fm =
       messenger.create_default_flow_mod(0, of13::OFPFC_ADD, flow_priority);
 
   add_downlink_match_ipv6(
-      downlink_fm, ev.get_ue_info().get_ipv6(), port_number);
-  add_downlink_tunnel_flow_action(ev, messenger, downlink_fm);
+      downlink_fm, ev.get_ue_info().get_ipv6(), ingress_port);
+  add_downlink_tunnel_flow_action(ev, messenger, downlink_fm, passthrough);
 }
 
 void GTPApplication::add_downlink_tunnel_flow_ded_brr(
     const AddGTPTunnelEvent& ev, const OpenflowMessenger& messenger,
-    uint32_t port_number) {
+    uint32_t ingress_port, bool passthrough) {
   uint32_t flow_priority =
       convert_precedence_to_priority(ev.get_dl_flow_precedence());
   of13::FlowMod downlink_fm =
       messenger.create_default_flow_mod(0, of13::OFPFC_ADD, flow_priority);
 
-  add_ded_brr_dl_match(downlink_fm, ev.get_dl_flow(), port_number);
-  add_downlink_tunnel_flow_action(ev, messenger, downlink_fm);
+  add_ded_brr_dl_match(downlink_fm, ev.get_dl_flow(), ingress_port);
+  add_downlink_tunnel_flow_action(ev, messenger, downlink_fm, passthrough);
 }
 
 void GTPApplication::add_downlink_tunnel_flow(
     const AddGTPTunnelEvent& ev, const OpenflowMessenger& messenger,
-    uint32_t port_number) {
+    uint32_t ingress_port, bool passthrough) {
   if (ev.is_dl_flow_valid()) {
-    add_downlink_tunnel_flow_ded_brr(ev, messenger, port_number);
+    add_downlink_tunnel_flow_ded_brr(ev, messenger, ingress_port, passthrough);
     return;
   }
   UeNetworkInfo ue_info = ev.get_ue_info();
 
   if (ue_info.is_ue_ipv4_addr_valid()) {
-    add_downlink_tunnel_flow_ipv4(ev, messenger, port_number);
+    add_downlink_tunnel_flow_ipv4(ev, messenger, ingress_port, passthrough);
   }
   if (ue_info.is_ue_ipv6_addr_valid()) {
-    add_downlink_tunnel_flow_ipv6(ev, messenger, port_number);
+    add_downlink_tunnel_flow_ipv6(ev, messenger, ingress_port, passthrough);
   }
 }
 
@@ -430,46 +484,46 @@ void GTPApplication::add_downlink_arp_flow_action(
 
 void GTPApplication::add_downlink_arp_flow(
     const AddGTPTunnelEvent& ev, const OpenflowMessenger& messenger,
-    uint32_t port_number) {
+    uint32_t ingress_port) {
   uint32_t flow_priority =
       convert_precedence_to_priority(ev.get_dl_flow_precedence());
   of13::FlowMod downlink_fm =
       messenger.create_default_flow_mod(0, of13::OFPFC_ADD, flow_priority);
 
-  add_downlink_arp_match(downlink_fm, ev.get_ue_ip(), port_number);
+  add_downlink_arp_match(downlink_fm, ev.get_ue_ip(), ingress_port);
 
   add_downlink_arp_flow_action(ev, messenger, downlink_fm);
 }
 
 void GTPApplication::delete_downlink_tunnel_flow_ipv4(
     const DeleteGTPTunnelEvent& ev, const OpenflowMessenger& messenger,
-    uint32_t port_number) {
+    uint32_t ingress_port) {
   of13::FlowMod downlink_fm =
       messenger.create_default_flow_mod(0, of13::OFPFC_DELETE, 0);
   // match all ports and groups
   downlink_fm.out_port(of13::OFPP_ANY);
   downlink_fm.out_group(of13::OFPG_ANY);
 
-  add_downlink_match(downlink_fm, ev.get_ue_ip(), port_number);
+  add_downlink_match(downlink_fm, ev.get_ue_ip(), ingress_port);
   messenger.send_of_msg(downlink_fm, ev.get_connection());
 }
 
 void GTPApplication::delete_downlink_tunnel_flow_ded_brr(
     const DeleteGTPTunnelEvent& ev, const OpenflowMessenger& messenger,
-    uint32_t port_number) {
+    uint32_t ingress_port) {
   of13::FlowMod downlink_fm =
       messenger.create_default_flow_mod(0, of13::OFPFC_DELETE, 0);
   // match all ports and groups
   downlink_fm.out_port(of13::OFPP_ANY);
   downlink_fm.out_group(of13::OFPG_ANY);
 
-  add_ded_brr_dl_match(downlink_fm, ev.get_dl_flow(), port_number);
+  add_ded_brr_dl_match(downlink_fm, ev.get_dl_flow(), ingress_port);
   messenger.send_of_msg(downlink_fm, ev.get_connection());
 }
 
 void GTPApplication::delete_downlink_tunnel_flow_ipv6(
     const DeleteGTPTunnelEvent& ev, const OpenflowMessenger& messenger,
-    uint32_t port_number) {
+    uint32_t ingress_port) {
   of13::FlowMod downlink_fm =
       messenger.create_default_flow_mod(0, of13::OFPFC_DELETE, 0);
   // match all ports and groups
@@ -477,37 +531,37 @@ void GTPApplication::delete_downlink_tunnel_flow_ipv6(
   downlink_fm.out_group(of13::OFPG_ANY);
 
   add_downlink_match_ipv6(
-      downlink_fm, ev.get_ue_info().get_ipv6(), port_number);
+      downlink_fm, ev.get_ue_info().get_ipv6(), ingress_port);
   messenger.send_of_msg(downlink_fm, ev.get_connection());
 }
 
 void GTPApplication::delete_downlink_tunnel_flow(
     const DeleteGTPTunnelEvent& ev, const OpenflowMessenger& messenger,
-    uint32_t port_number) {
+    uint32_t ingress_port) {
   if (ev.is_dl_flow_valid()) {
-    delete_downlink_tunnel_flow_ded_brr(ev, messenger, port_number);
+    delete_downlink_tunnel_flow_ded_brr(ev, messenger, ingress_port);
     return;
   }
   UeNetworkInfo ue_info = ev.get_ue_info();
 
   if (ue_info.is_ue_ipv4_addr_valid()) {
-    delete_downlink_tunnel_flow_ipv4(ev, messenger, port_number);
+    delete_downlink_tunnel_flow_ipv4(ev, messenger, ingress_port);
   }
   if (ue_info.is_ue_ipv6_addr_valid()) {
-    delete_downlink_tunnel_flow_ipv6(ev, messenger, port_number);
+    delete_downlink_tunnel_flow_ipv6(ev, messenger, ingress_port);
   }
 }
 
 void GTPApplication::delete_downlink_arp_flow(
     const DeleteGTPTunnelEvent& ev, const OpenflowMessenger& messenger,
-    uint32_t port_number) {
+    uint32_t ingress_port) {
   of13::FlowMod downlink_fm =
       messenger.create_default_flow_mod(0, of13::OFPFC_DELETE, 0);
   // match all ports and groups
   downlink_fm.out_port(of13::OFPP_ANY);
   downlink_fm.out_group(of13::OFPG_ANY);
 
-  add_downlink_arp_match(downlink_fm, ev.get_ue_ip(), port_number);
+  add_downlink_arp_match(downlink_fm, ev.get_ue_ip(), ingress_port);
 
   messenger.send_of_msg(downlink_fm, ev.get_connection());
 }
@@ -522,14 +576,14 @@ void GTPApplication::discard_uplink_tunnel_flow(
   uplink_fm.cookie(cookie);
   uplink_fm.cookie_mask(cookie);
 
-  add_uplink_match(uplink_fm, gtp0_port_num_, ev.get_in_tei());
+  add_tunnel_match(uplink_fm, gtp0_port_num_, ev.get_in_tei());
 
   messenger.send_of_msg(uplink_fm, ev.get_connection());
 }
 
 void GTPApplication::discard_downlink_tunnel_flow(
     const HandleDataOnGTPTunnelEvent& ev, const OpenflowMessenger& messenger,
-    uint32_t port_number) {
+    uint32_t ingress_port) {
   of13::FlowMod downlink_fm = messenger.create_default_flow_mod(
       0, of13::OFPFC_ADD, DEFAULT_PRIORITY + 1);
   // match all ports and groups
@@ -539,9 +593,9 @@ void GTPApplication::discard_downlink_tunnel_flow(
   downlink_fm.cookie_mask(cookie + 1);
 
   if (ev.is_dl_flow_valid()) {
-    add_ded_brr_dl_match(downlink_fm, ev.get_dl_flow(), port_number);
+    add_ded_brr_dl_match(downlink_fm, ev.get_dl_flow(), ingress_port);
   } else {
-    add_downlink_match(downlink_fm, ev.get_ue_ip(), port_number);
+    add_downlink_match(downlink_fm, ev.get_ue_ip(), ingress_port);
   }
 
   messenger.send_of_msg(downlink_fm, ev.get_connection());
@@ -559,14 +613,14 @@ void GTPApplication::forward_uplink_tunnel_flow(
   uplink_fm.cookie(cookie);
   uplink_fm.cookie_mask(cookie);
 
-  add_uplink_match(uplink_fm, gtp0_port_num_, ev.get_in_tei());
+  add_tunnel_match(uplink_fm, gtp0_port_num_, ev.get_in_tei());
 
   messenger.send_of_msg(uplink_fm, ev.get_connection());
 }
 
 void GTPApplication::forward_downlink_tunnel_flow(
     const HandleDataOnGTPTunnelEvent& ev, const OpenflowMessenger& messenger,
-    uint32_t port_number) {
+    uint32_t ingress_port) {
   uint32_t flow_priority =
       convert_precedence_to_priority(ev.get_dl_flow_precedence());
   of13::FlowMod downlink_fm = messenger.create_default_flow_mod(
@@ -578,9 +632,9 @@ void GTPApplication::forward_downlink_tunnel_flow(
   downlink_fm.cookie_mask(cookie + 1);
 
   if (ev.is_dl_flow_valid()) {
-    add_ded_brr_dl_match(downlink_fm, ev.get_dl_flow(), port_number);
+    add_ded_brr_dl_match(downlink_fm, ev.get_dl_flow(), ingress_port);
   } else {
-    add_downlink_match(downlink_fm, ev.get_ue_ip(), port_number);
+    add_downlink_match(downlink_fm, ev.get_ue_ip(), ingress_port);
   }
 
   messenger.send_of_msg(downlink_fm, ev.get_connection());

--- a/lte/gateway/c/oai/lib/openflow/controller/GTPApplication.h
+++ b/lte/gateway/c/oai/lib/openflow/controller/GTPApplication.h
@@ -63,7 +63,13 @@ class GTPApplication : public Application {
    */
   void add_downlink_tunnel_flow(
       const AddGTPTunnelEvent& ev, const OpenflowMessenger& messenger,
-      uint32_t port_number);
+      uint32_t port_number, bool passthrough);
+
+  /*
+   * Add downlink tunnel flow for S8
+   */
+  void add_uplink_s8_tunnel_flow(
+      const AddGTPTunnelEvent& ev, const OpenflowMessenger& messenger);
 
   /*
    * Remove uplink tunnel flow on disconnect
@@ -137,7 +143,7 @@ class GTPApplication : public Application {
    * @param gtp_port GTP port from event
    * @param i_tei tunnel id.
    */
-  void add_uplink_match(
+  void add_tunnel_match(
       of13::FlowMod& uplink_fm, uint32_t gtp_port, uint32_t i_tei);
 
  private:
@@ -164,19 +170,25 @@ class GTPApplication : public Application {
       const AddGTPTunnelEvent& ev, const OpenflowMessenger& messenger,
       of13::FlowMod downlink_fm);
 
+  void add_tunnel_flow_action(
+      uint32_t tei, std::string ue_imsi, struct in_addr remote_ip,
+      uint32_t egress_gtp_port, fluid_base::OFConnection* connection,
+      const OpenflowMessenger& messenger, of13::FlowMod downlink_fm,
+      const std::string& flow_type, bool passthrough);
+
   void add_downlink_tunnel_flow_action(
       const AddGTPTunnelEvent& ev, const OpenflowMessenger& messenger,
-      of13::FlowMod downlink_fm);
+      of13::FlowMod downlink_fm, bool passthrough);
 
   void add_downlink_tunnel_flow_ipv4(
       const AddGTPTunnelEvent& ev, const OpenflowMessenger& messenger,
-      uint32_t port_number);
+      uint32_t port_number, bool passthrough);
   void add_downlink_tunnel_flow_ipv6(
       const AddGTPTunnelEvent& ev, const OpenflowMessenger& messenger,
-      uint32_t port_number);
+      uint32_t port_number, bool passthrough);
   void add_downlink_tunnel_flow_ded_brr(
       const AddGTPTunnelEvent& ev, const OpenflowMessenger& messenger,
-      uint32_t port_number);
+      uint32_t port_number, bool passthrough);
 
   void delete_downlink_tunnel_flow_ipv4(
       const DeleteGTPTunnelEvent& ev, const OpenflowMessenger& messenger,

--- a/lte/gateway/c/oai/tasks/gtpv1-u/gtp_tunnel_openflow.c
+++ b/lte/gateway/c/oai/tasks/gtpv1-u/gtp_tunnel_openflow.c
@@ -267,6 +267,30 @@ int openflow_del_tunnel(
       ue, ue_ipv6, i_tei, flow_dl, gtp_portno);
 }
 
+/* S8 tunnel related APIs */
+int openflow_add_s8_tunnel(
+    struct in_addr ue, struct in6_addr* ue_ipv6, int vlan, struct in_addr enb,
+    struct in_addr pgw, uint32_t i_tei, uint32_t o_tei, Imsi_t imsi,
+    struct ip_flow_dl* flow_dl, uint32_t flow_precedence_dl) {
+  uint32_t enb_portno = find_gtp_port_no(enb);
+  uint32_t pgw_portno = find_gtp_port_no(pgw);
+
+  return openflow_controller_add_gtp_s8_tunnel(
+      ue, ue_ipv6, vlan, enb, pgw, i_tei, o_tei, (const char*) imsi.digit,
+      flow_dl, flow_precedence_dl, enb_portno, pgw_portno);
+}
+
+int openflow_del_s8_tunnel(
+    struct in_addr enb, struct in_addr pgw, struct in_addr ue,
+    struct in6_addr* ue_ipv6, uint32_t i_tei, uint32_t o_tei,
+    struct ip_flow_dl* flow_dl) {
+  uint32_t enb_portno = find_gtp_port_no(enb);
+  uint32_t pgw_portno = find_gtp_port_no(pgw);
+
+  return openflow_controller_del_gtp_s8_tunnel(
+      ue, ue_ipv6, i_tei, flow_dl, enb_portno, pgw_portno);
+}
+
 int openflow_discard_data_on_tunnel(
     struct in_addr ue, struct in6_addr* ue_ipv6, uint32_t i_tei,
     struct ip_flow_dl* flow_dl) {
@@ -346,6 +370,8 @@ static const struct gtp_tunnel_ops openflow_ops = {
     .reset                  = openflow_reset,
     .add_tunnel             = openflow_add_tunnel,
     .del_tunnel             = openflow_del_tunnel,
+    .add_s8_tunnel          = openflow_add_s8_tunnel,
+    .del_s8_tunnel          = openflow_del_s8_tunnel,
     .discard_data_on_tunnel = openflow_discard_data_on_tunnel,
     .forward_data_on_tunnel = openflow_forward_data_on_tunnel,
     .add_paging_rule        = openflow_add_paging_rule,

--- a/lte/gateway/c/oai/tasks/gtpv1-u/gtpv1u.h
+++ b/lte/gateway/c/oai/tasks/gtpv1-u/gtpv1u.h
@@ -143,6 +143,14 @@ struct gtp_tunnel_ops {
   int (*del_tunnel)(
       struct in_addr enb, struct in_addr ue, struct in6_addr* ue_ipv6,
       uint32_t i_tei, uint32_t o_tei, struct ip_flow_dl* flow_dl);
+  int (*add_s8_tunnel)(
+      struct in_addr ue, struct in6_addr* ue_ipv6, int vlan, struct in_addr enb,
+      struct in_addr pgw, uint32_t i_tei, uint32_t o_tei, Imsi_t imsi,
+      struct ip_flow_dl* flow_dl, uint32_t flow_precedence_dl);
+  int (*del_s8_tunnel)(
+      struct in_addr enb, struct in_addr pgw, struct in_addr ue,
+      struct in6_addr* ue_ipv6, uint32_t i_tei, uint32_t o_tei,
+      struct ip_flow_dl* flow_dl);
   int (*discard_data_on_tunnel)(
       struct in_addr ue, struct in6_addr* ue_ipv6, uint32_t i_tei,
       struct ip_flow_dl* flow_dl);

--- a/lte/gateway/c/oai/tasks/gtpv1-u/gtpv1u_task.c
+++ b/lte/gateway/c/oai/tasks/gtpv1-u/gtpv1u_task.c
@@ -200,6 +200,33 @@ int gtpv1u_add_tunnel(
       ue, ue_ipv6, vlan, enb, i_tei, o_tei, imsi, flow_dl, flow_precedence_dl);
 }
 
+int gtpv1u_add_s8_tunnel(
+    struct in_addr ue, struct in6_addr* ue_ipv6, int vlan, struct in_addr enb,
+    struct in_addr pgw, uint32_t i_tei, uint32_t o_tei, Imsi_t imsi,
+    struct ip_flow_dl* flow_dl, uint32_t flow_precedence_dl) {
+  OAILOG_DEBUG(LOG_GTPV1U, "Add S8 tunnel ue %s", inet_ntoa(ue));
+  if (gtp_tunnel_ops->add_s8_tunnel) {
+    return gtp_tunnel_ops->add_s8_tunnel(
+        ue, ue_ipv6, vlan, enb, pgw, i_tei, o_tei, imsi, flow_dl,
+        flow_precedence_dl);
+  } else {
+    return -EINVAL;
+  }
+}
+
+int gtpv1u_del_s8_tunnel(
+    struct in_addr enb, struct in_addr pgw, struct in_addr ue,
+    struct in6_addr* ue_ipv6, uint32_t i_tei, uint32_t o_tei,
+    struct ip_flow_dl* flow_dl) {
+  OAILOG_DEBUG(LOG_GTPV1U, "Del S8 tunnel ue %s", inet_ntoa(ue));
+  if (gtp_tunnel_ops->del_s8_tunnel) {
+    return gtp_tunnel_ops->del_s8_tunnel(
+        enb, pgw, ue, ue_ipv6, i_tei, o_tei, flow_dl);
+  } else {
+    return -EINVAL;
+  }
+}
+
 //------------------------------------------------------------------------------
 void gtpv1u_exit(void) {
   gtp_tunnel_ops->uninit();

--- a/lte/gateway/c/oai/test/openflow/test_gtp_app.cpp
+++ b/lte/gateway/c/oai/test/openflow/test_gtp_app.cpp
@@ -66,6 +66,9 @@ class GTPApplicationTest : public ::testing::Test {
         new OpenflowController("127.0.0.1", 6666, 2, false, messenger));
     controller->register_for_event(gtp_app, openflow::EVENT_ADD_GTP_TUNNEL);
     controller->register_for_event(gtp_app, openflow::EVENT_DELETE_GTP_TUNNEL);
+    controller->register_for_event(gtp_app, openflow::EVENT_ADD_GTP_S8_TUNNEL);
+    controller->register_for_event(
+        gtp_app, openflow::EVENT_DELETE_GTP_S8_TUNNEL);
   }
 
   virtual void TearDown() {
@@ -883,6 +886,117 @@ TEST_F(GTPApplicationTest, TestDeleteTunnelDlFlowIpv6) {
                           CheckEthType(0x0806), CheckArpTpa(ue_ip),
                           CheckCommandType(of13::OFPFC_DELETE)),
                       _))
+      .Times(1);
+
+  EXPECT_CALL(
+      *messenger,
+      send_of_msg(
+          AllOf(
+              CheckTableId(0), CheckInPort(TEST_MTR_PORT), CheckEthType(0x0806),
+              CheckArpTpa(ue_ip), CheckCommandType(of13::OFPFC_DELETE)),
+          _))
+      .Times(1);
+
+  controller->dispatch_event(del_tunnel);
+}
+
+/*
+ * Test that tunnel flows are added when an add S8 tunnel event is sent.
+ * This only tests the flow matchers for now, because it is not easy to verify
+ * the actions with the libfluid framework
+ */
+TEST_F(GTPApplicationTest, TestAddTunnelS8) {
+  struct in_addr ue_ip;
+  ue_ip.s_addr = inet_addr("0.0.0.1");
+  struct in_addr enb_ip;
+  enb_ip.s_addr = inet_addr("0.0.0.2");
+  struct in_addr pgw_ip;
+  enb_ip.s_addr    = inet_addr("0.0.0.22");
+  uint32_t in_tei  = 1;
+  uint32_t out_tei = 2;
+  char imsi[]      = "001010000000013";
+  int vlan         = 0;
+  int enb_port     = 100;
+  int pgw_port     = 200;
+
+  AddGTPTunnelEvent add_tunnel(
+      ue_ip, NULL, vlan, enb_ip, pgw_ip, in_tei, out_tei, imsi, enb_port,
+      pgw_port);
+  // Uplink
+  EXPECT_CALL(
+      *messenger,
+      send_of_msg(
+          AllOf(
+              CheckTableId(0), CheckInPort(enb_port), CheckTunnelId(in_tei),
+              CheckCommandType(of13::OFPFC_ADD)),
+          _))
+      .Times(1);
+  // downlink
+  EXPECT_CALL(
+      *messenger,
+      send_of_msg(
+          AllOf(
+              CheckTableId(0), CheckInPort(pgw_port), CheckEthType(0x0800),
+              CheckIPv4Dst(ue_ip), CheckCommandType(of13::OFPFC_ADD)),
+          _))
+      .Times(1);
+  EXPECT_CALL(
+      *messenger,
+      send_of_msg(
+          AllOf(
+              CheckTableId(0), CheckInPort(TEST_MTR_PORT), CheckEthType(0x0800),
+              CheckIPv4Dst(ue_ip), CheckCommandType(of13::OFPFC_ADD)),
+          _))
+      .Times(1);
+
+  EXPECT_CALL(
+      *messenger,
+      send_of_msg(
+          AllOf(
+              CheckTableId(0), CheckInPort(TEST_MTR_PORT), CheckEthType(0x0806),
+              CheckArpTpa(ue_ip), CheckCommandType(of13::OFPFC_ADD)),
+          _))
+      .Times(1);
+
+  controller->dispatch_event(add_tunnel);
+}
+
+/*
+ * Test that tunnel flows are deleted when a delete S8 tunnel event is sent
+ */
+TEST_F(GTPApplicationTest, TestDeleteTunnelS8) {
+  struct in_addr ue_ip;
+  ue_ip.s_addr    = inet_addr("0.0.0.1");
+  uint32_t in_tei = 1;
+  int enb_port    = 100;
+  int pgw_port    = 200;
+
+  DeleteGTPTunnelEvent del_tunnel(ue_ip, NULL, in_tei, enb_port, pgw_port);
+  // Uplink
+  EXPECT_CALL(
+      *messenger,
+      send_of_msg(
+          AllOf(
+              CheckTableId(0), CheckInPort(enb_port), CheckTunnelId(in_tei),
+              CheckCommandType(of13::OFPFC_DELETE)),
+          _))
+      .Times(1);
+  // downlink
+  EXPECT_CALL(
+      *messenger,
+      send_of_msg(
+          AllOf(
+              CheckTableId(0), CheckInPort(pgw_port), CheckEthType(0x0800),
+              CheckIPv4Dst(ue_ip), CheckCommandType(of13::OFPFC_DELETE)),
+          _))
+      .Times(1);
+  EXPECT_CALL(
+      *messenger,
+      send_of_msg(
+          AllOf(
+              CheckTableId(0), CheckInPort(TEST_MTR_PORT), CheckEthType(0x0800),
+              CheckIPv4Dst(ue_ip), CheckCommandType(of13::OFPFC_DELETE)),
+          _))
       .Times(1);
 
   EXPECT_CALL(


### PR DESCRIPTION
Add support to match on ingress and egress inbound packets.
New API is added to added to gtp task to add these flows:
openflow_add_s8_tunnel()
openflow_del_s8_tunnel()

Signed-off-by: Pravin B Shelar <pbshelar@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->

## Test Plan
Ran OAI_tests

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

This patch depends on binary from #5419. 