### PR TITLE
[lte][agw] Removed unsafe mme_nas state sync to db

### DIFF
--- a/lte/gateway/c/oai/tasks/mme_app/mme_app_main.c
+++ b/lte/gateway/c/oai/tasks/mme_app/mme_app_main.c
@@ -501,7 +501,6 @@ static bool _is_mme_app_healthy(void) {
 //------------------------------------------------------------------------------
 static void mme_app_exit(void) {
   destroy_task_context(&mme_app_task_zmq_ctx);
-  put_mme_nas_state();
   mme_app_edns_exit();
   clear_mme_nas_state();
   // Clean-up NAS module

--- a/lte/gateway/c/oai/tasks/mme_app/mme_app_statistics.c
+++ b/lte/gateway/c/oai/tasks/mme_app/mme_app_statistics.c
@@ -96,17 +96,19 @@ int mme_app_statistics_display(void) {
 // Number of Connected eNBs
 void update_mme_app_stats_connected_enb_add(void) {
   mme_app_desc_t* mme_app_desc_p = get_mme_nas_state(false);
+  // These stats will be persisted by mme_app task clocked
+  // by its incoming messages
   (mme_app_desc_p->nb_enb_connected)++;
   (mme_app_desc_p->nb_enb_connected_since_last_stat)++;
-  put_mme_nas_state();
   return;
 }
 void update_mme_app_stats_connected_enb_sub(void) {
   mme_app_desc_t* mme_app_desc_p = get_mme_nas_state(false);
+  // These stats will be persisted by mme_app task clocked
+  // by its incoming messages
   if (mme_app_desc_p->nb_enb_connected != 0)
     (mme_app_desc_p->nb_enb_connected)--;
   (mme_app_desc_p->nb_enb_released_since_last_stat)++;
-  put_mme_nas_state();
   return;
 }
 

--- a/lte/gateway/c/oai/tasks/service303/service303_mme_stats.c
+++ b/lte/gateway/c/oai/tasks/service303/service303_mme_stats.c
@@ -27,7 +27,6 @@ static void service303_mme_statistics_read(void) {
   set_gauge("enb_connected", mme_app_desc_p->nb_enb_connected, label);
   set_gauge("ue_registered", mme_app_desc_p->nb_ue_attached, label);
   set_gauge("ue_connected", mme_app_desc_p->nb_ue_connected, label);
-  put_mme_nas_state();
   return;
 }
 


### PR DESCRIPTION
## Summary

Removed unsafe put for mme_nas state.

## Test Plan

Integ tests.

## Additional Information

- [ ] This change is backwards-breaking

