### PR TITLE
[orc8r][indexer] Add tests to fix nondeterminate codecov

### DIFF
--- a/orc8r/cloud/docker/run.py
+++ b/orc8r/cloud/docker/run.py
@@ -15,11 +15,13 @@ limitations under the License.
 
 import argparse
 import fileinput
+import pathlib
 import subprocess
 import sys
 
 from typing import List
 
+HOST_BUILD_CTX = '/tmp/magma_orc8r_build'
 DO_NOT_COMMIT = '# DO NOT COMMIT THIS CHANGE'
 
 
@@ -48,6 +50,9 @@ def main() -> None:
 
     if args.print:
         return
+
+    # Ensure build context exists, otherwise docker-compose throws an error
+    pathlib.Path(HOST_BUILD_CTX).mkdir(parents=True, exist_ok=True)
 
     cmd = ['docker-compose', 'up', '-d']
     print("Running '%s'..." % ' '.join(cmd))

--- a/orc8r/cloud/go/services/state/indexer/empty_indexer.go
+++ b/orc8r/cloud/go/services/state/indexer/empty_indexer.go
@@ -1,0 +1,52 @@
+/*
+Copyright 2020 The Magma Authors.
+
+This source code is licensed under the BSD-style license found in the
+LICENSE file in the root directory of this source tree.
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package indexer
+
+import (
+	"magma/orc8r/cloud/go/services/state/types"
+)
+
+type emptyIndexer struct {
+	id string
+}
+
+// NewEmptyIndexer returns a do-nothing indexer that returns the passed ID
+// to GetID() calls.
+func NewEmptyIndexer(id string) Indexer {
+	return &emptyIndexer{id: id}
+}
+
+func (r *emptyIndexer) GetID() string {
+	return r.id
+}
+
+func (r *emptyIndexer) GetVersion() Version {
+	return 0
+}
+
+func (r *emptyIndexer) GetTypes() []string {
+	return nil
+}
+
+func (r *emptyIndexer) PrepareReindex(from, to Version, isFirstReindex bool) error {
+	return nil
+}
+
+func (r *emptyIndexer) CompleteReindex(from, to Version) error {
+	return nil
+}
+
+func (r *emptyIndexer) Index(networkID string, states types.SerializedStatesByID) (types.StateErrors, error) {
+	return nil, nil
+}

--- a/orc8r/cloud/go/services/state/indexer/registry.go
+++ b/orc8r/cloud/go/services/state/indexer/registry.go
@@ -28,11 +28,11 @@ import (
 )
 
 // GetIndexer returns the remote indexer for a desired service.
-// Returns nil if not found.
+// Returns an empty indexer if not found.
 func GetIndexer(serviceName string) (Indexer, error) {
 	x, err := getIndexer(serviceName)
 	if err != nil {
-		return nil, errors.Wrapf(err, "get indexer for service %s", serviceName)
+		return NewEmptyIndexer(serviceName), errors.Wrapf(err, "indexer not found for service %s", serviceName)
 	}
 	return x, nil
 }


### PR DESCRIPTION
## Summary

The nondeterminism of the reindexing tests is causing codecov to be annoyingly noisy. This PR adds tests to deterministically ensure that the noisy areas are covered.

Side benefit: more thorough testing of state indexers.

## Test Plan

- [x] CI, with added tests

## Additional Information

- [ ] This change is backwards-breaking