### PR TITLE
[orc8r][indexer] Log warning on auto reindexing mismatch

### DIFF
--- a/orc8r/cloud/docker/docker-compose.yml
+++ b/orc8r/cloud/docker/docker-compose.yml
@@ -12,6 +12,7 @@ services:
       SERVICE_HOSTNAME: localhost  # All services are reachable through localhost
       SQL_DRIVER: postgres
       DATABASE_SOURCE: "dbname=magma_dev user=magma_dev password=magma_dev host=postgres sslmode=disable"
+#      DATABASE_SOURCE: "magma_dev:magma_dev@(maria)/magma_dev"
       SQL_DIALECT: psql
       SERVICE_REGISTRY_MODE: yaml
     links:

--- a/orc8r/cloud/go/services/state/state/main.go
+++ b/orc8r/cloud/go/services/state/state/main.go
@@ -38,6 +38,22 @@ import (
 // how often to report gateway status
 const gatewayStatusReportInterval = time.Second * 60
 
+const nonPostgresDriverMessage = `Configuration warning:
+
+This deployment has automatic state reindexing enabled, but is targeting a
+database driver other than Postgres. This will cause the state service
+to log a (harmless) DB syntax error, due to its use of Postgres-specific
+syntax for automatic reindexing.
+
+(Option 1) Continue using non-Postgres driver. To clear this warning, update
+the state.yml cloud config to set enable_automatic_reindexing to false.
+Keep in mind that, for this option, you will have to perform manual state
+reindexing on every Orc8r upgrade. We provide a CLI to manage this, and will
+provide directions in the upgrade notes.
+
+(Option 2) Switch to a Postgres driver.
+`
+
 func main() {
 	srv, err := service.NewOrchestratorService(orc8r.ModuleName, state.ServiceName)
 	if err != nil {
@@ -88,6 +104,10 @@ func newIndexerManagerServicer(cfg *config.ConfigMap, db *sql.DB, store blobstor
 	autoReindex := cfg.MustGetBool(state_config.EnableAutomaticReindexing)
 	reindexer := reindex.NewReindexer(queue, reindex.NewStore(store))
 	servicer := servicers.NewIndexerManagerServicer(reindexer, autoReindex)
+
+	if autoReindex && storage.SQLDriver != sqorc.PostgresDriver {
+		glog.Warning(nonPostgresDriverMessage)
+	}
 
 	if autoReindex {
 		glog.Info("Automatic reindexing enabled for state service")

--- a/orc8r/cloud/go/sqorc/open.go
+++ b/orc8r/cloud/go/sqorc/open.go
@@ -23,6 +23,8 @@ import (
 )
 
 const (
+	// MariaDriver etc. are allowed database/sql drivers.
+	// Full list: https://github.com/golang/go/wiki/SQLDrivers
 	MariaDriver    = "mysql"
 	PostgresDriver = "postgres"
 	SQLiteDriver   = "sqlite3"


### PR DESCRIPTION
## Summary

Without this warning, the only indication of issue is Maria spitting out a syntax error. This confuses operators as they're afraid things are broken. This warning should resolve the issue.

## Test Plan

- [x] Manual verification

```
root@ffb9a9d2c9a0:/var/opt/magma/bin# DATABASE_SOURCE='magma_dev:magma_dev@(maria)/magma_dev' SQL_DIALECT=maria SQL_DRIVER=mysql /usr/bin/envdir /var/opt/magma/envdir /var/opt/magma/bin/state -logtostderr=true -v=0
I0311 06:13:35.708568     613 service_config.go:169] Successfully loaded 'cwf::service_registry' service configs from '/etc/magma/configs/cwf/service_registry.yml'
I0311 06:13:35.708716     613 service_config.go:169] Successfully loaded 'fbinternal::service_registry' service configs from '/etc/magma/configs/fbinternal/service_registry.yml'
I0311 06:13:35.708909     613 service_config.go:169] Successfully loaded 'feg::service_registry' service configs from '/etc/magma/configs/feg/service_registry.yml'
I0311 06:13:35.709269     613 service_config.go:169] Successfully loaded 'lte::service_registry' service configs from '/etc/magma/configs/lte/service_registry.yml'
I0311 06:13:35.709788     613 service_config.go:169] Successfully loaded 'orc8r::service_registry' service configs from '/etc/magma/configs/orc8r/service_registry.yml'
I0311 06:13:35.709930     613 service_config.go:169] Successfully loaded 'wifi::service_registry' service configs from '/etc/magma/configs/wifi/service_registry.yml'
I0311 06:13:35.710354     613 service_config.go:169] Successfully loaded 'orc8r::state' service configs from '/etc/magma/configs/orc8r/state.yml'
I0311 06:13:35.748157     613 queue_sql.go:163] Succeeded in updating reindex job queue and overwriting new indexer versions
W0311 06:13:35.748199     613 main.go:104] Configuration warning:
This deployment has automatic state reindexing enabled, but is targeting a
database driver other than Postgres.

(Option 1) Continue using non-Postgres driver. To clear this warning, update
the state.yml cloud config to set enable_automatic_reindexing to false.
Keep in mind that, for this option, you will have to perform manual state
reindexing on every Orc8r upgrade. We provide a CLI to manage this.

(Option 2) Switch to a Postgres driver.
```

## Additional Information

- [ ] This change is backwards-breaking