### PR TITLE
[orc8r][subcribers] Add configurable max gRPC msg size

### DIFF
--- a/orc8r/cloud/configs/shared.yml
+++ b/orc8r/cloud/configs/shared.yml
@@ -1,0 +1,13 @@
+---
+# Copyright 2020 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+maxGRPCMessageSizeMB: 50

--- a/orc8r/cloud/go/orc8r/const.go
+++ b/orc8r/cloud/go/orc8r/const.go
@@ -68,3 +68,10 @@ const (
 	// In prod, this will be the relevant pod's IP.
 	ServiceHostnameEnvVar = "SERVICE_HOSTNAME"
 )
+
+// Configs
+const (
+	// SharedService is the name of the pseudo-service that stores shared
+	// configs across all Orc8r services.
+	SharedService = "shared"
+)

--- a/orc8r/cloud/go/service/service.go
+++ b/orc8r/cloud/go/service/service.go
@@ -22,13 +22,16 @@ import (
 	"fmt"
 	"net"
 
+	"magma/orc8r/cloud/go/orc8r"
 	"magma/orc8r/cloud/go/service/middleware/unary"
 	"magma/orc8r/lib/go/protos"
 	"magma/orc8r/lib/go/registry"
 	platform_service "magma/orc8r/lib/go/service"
+	"magma/orc8r/lib/go/service/config"
 
 	"github.com/golang/glog"
 	"github.com/labstack/echo"
+	"github.com/pkg/errors"
 	"google.golang.org/grpc"
 )
 
@@ -67,6 +70,18 @@ func NewOrchestratorService(moduleName string, serviceName string, serverOptions
 	if err != nil {
 		return nil, err
 	}
+
+	sharedConfig, err := getSharedConfig()
+	if err != nil {
+		return nil, err
+	}
+	maxGRPCMsgSize := sharedConfig.MaxGRPCMessageSizeMB * 1024 * 1024
+
+	// Set max gRPC message size to receive when acting as the client
+	opts := grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(maxGRPCMsgSize))
+	registry.SetDialOpts(opts)
+	// Set max gRPC message size to receive when acting as the server
+	serverOptions = append(serverOptions, grpc.MaxRecvMsgSize(maxGRPCMsgSize))
 
 	serverOptions = append(serverOptions, grpc.UnaryInterceptor(unary.MiddlewareHandler))
 	platformService, err := platform_service.NewServiceWithOptionsImpl(moduleName, serviceName, serverOptions...)
@@ -146,4 +161,34 @@ func getEchoServerForOrchestratorService(serviceName string) (*echo.Echo, error)
 	e.Server.Addr = portStr
 	e.HideBanner = true
 	return e, nil
+}
+
+type Config struct {
+	// MaxGRPCMessageSizeMB is the maximum message size, in megabytes, allowed
+	// by this service's gRPC servicer.
+	//
+	// Defaults:
+	// - Server receive max:	4mb
+	// - Server send max:		1gb
+	// - Client receive max:	4mb
+	// - Client send max:		1gb
+	//
+	// For simplicity, this config sets the receive max for both server and
+	// client, leaving the send max unchanged.
+	MaxGRPCMessageSizeMB int `yaml:"maxGRPCMessageSizeMB"`
+}
+
+func getSharedConfig() (*Config, error) {
+	c := &Config{}
+
+	_, _, err := config.GetStructuredServiceConfig(orc8r.ModuleName, orc8r.SharedService, c)
+	if err != nil {
+		return nil, err
+	}
+
+	if c.MaxGRPCMessageSizeMB == 0 {
+		return nil, errors.New("parsed shared.yml and didn't find a max gRPC message size")
+	}
+
+	return c, nil
 }

--- a/orc8r/lib/go/registry/global_registry.go
+++ b/orc8r/lib/go/registry/global_registry.go
@@ -34,6 +34,10 @@ func Get() *ServiceRegistry {
 	return globalRegistry
 }
 
+func SetDialOpts(opts ...grpc.DialOption) {
+	globalRegistry.additionalOpts = opts
+}
+
 // PopulateServices populates the service registry based on the per-module
 // config files at /etc/magma/configs/MODULE_NAME/service_registry.yml.
 func PopulateServices() error {

--- a/orc8r/lib/go/registry/registry.go
+++ b/orc8r/lib/go/registry/registry.go
@@ -52,6 +52,8 @@ type ServiceRegistry struct {
 	cloudConnections map[string]cloudConnection
 
 	serviceRegistryMode string
+
+	additionalOpts []grpc.DialOption
 }
 
 type cloudConnection struct {
@@ -74,6 +76,12 @@ func New() *ServiceRegistry {
 		cloudConnections:    map[string]cloudConnection{},
 		serviceRegistryMode: registryMode,
 	}
+}
+
+func NewWithDialOpts(opts ...grpc.DialOption) *ServiceRegistry {
+	r := New()
+	r.additionalOpts = opts
+	return r
 }
 
 func NewWithMode(mode string) *ServiceRegistry {
@@ -434,6 +442,7 @@ func (r *ServiceRegistry) getGRPCDialOptions() []grpc.DialOption {
 		timeoutInterceptor = CloudClientTimeoutInterceptor
 	}
 	opts = append(opts, grpc.WithUnaryInterceptor(timeoutInterceptor))
+	opts = append(opts, r.additionalOpts...)
 	return opts
 }
 


### PR DESCRIPTION
## Summary

Provide Orc8r-wide default max gRPC message size, as a service config. This empowers operators to circumvent drop-dead scale issues, as a stopgap solution when critically necessary.

## Test Plan

Manual inspection

```sh
/tmp/magma_protos                                                                                                                       
$ head -c $(( 5 )) </dev/urandom | base64 > rand_out ; echo -n '{"states": [{"type": "test", "value": "' > req.json ; cat rand_out | tr -d '\n' >> req.json ; echo '"}]}' >> req.json


/tmp/magma_protos                                                                                                                       
$ grpcurl \
    -insecure \                             
    -key /tmp/magma_protos/gateway.key \
    -cert /tmp/magma_protos/gateway.crt \
    -authority state-controller.magma.test \
    -protoset /tmp/magma_protos/out.protoset \
    -d @ \                      
    localhost:7443 \
    magma.orc8r.StateService/ReportStates <req.json
{
  
}

/tmp/magma_protos                                                                                                                       
$ head -c $(( 50*1024*1024 )) </dev/urandom | base64 > rand_out ; echo -n '{"states": [{"type": "test", "value": "' > req.json ; cat rand_out | tr -d '\n' >> req.json ; echo '"}]}' >> req.json


/tmp/magma_protos                                                                                                                    12s
$ grpcurl \
    -insecure \                                        
    -key /tmp/magma_protos/gateway.key \
    -cert /tmp/magma_protos/gateway.crt \
    -authority state-controller.magma.test \
    -protoset /tmp/magma_protos/out.protoset \
    -d @ \                      
    localhost:7443 \
    magma.orc8r.StateService/ReportStates <req.json
ERROR:
  Code: ResourceExhausted
  Message: grpc: received message larger than max (52428816 vs. 52428800)
```

## Additional Information

- [ ] This change is backwards-breaking