### PR TITLE
AGW: pipelined: Set direction for inbound traffic,

### DIFF
--- a/lte/gateway/python/magma/pipelined/tests/snapshots/test_inout.InOutTest.testFlowSnapshotMatch.snapshot
+++ b/lte/gateway/python/magma/pipelined/tests/snapshots/test_inout.InOutTest.testFlowSnapshotMatch.snapshot
@@ -1,5 +1,6 @@
  cookie=0x0, table=ingress(main_table), n_packets=0, n_bytes=0, priority=10,in_port=LOCAL actions=set_field:0x10->reg1,resubmit(,middle(main_table)),set_field:0->reg0,set_field:0->reg3
- cookie=0x0, table=ingress(main_table), n_packets=0, n_bytes=0, priority=0 actions=set_field:0x1->reg1,resubmit(,middle(main_table)),set_field:0->reg0,set_field:0->reg3
+ cookie=0x0, table=ingress(main_table), n_packets=0, n_bytes=0, priority=0,reg6=0 actions=set_field:0x1->reg1,resubmit(,middle(main_table)),set_field:0->reg0,set_field:0->reg3
+ cookie=0x0, table=ingress(main_table), n_packets=0, n_bytes=0, priority=0,reg6=0x1 actions=set_field:0x10->reg1,resubmit(,middle(main_table)),set_field:0->reg0,set_field:0->reg3
  cookie=0x0, table=middle(main_table), n_packets=0, n_bytes=0, priority=15,reg6=0x1 actions=resubmit(,egress(main_table)),set_field:0->reg0,set_field:0->reg3
  cookie=0x0, table=middle(main_table), n_packets=0, n_bytes=0, priority=10 actions=resubmit(,egress(main_table)),set_field:0->reg0,set_field:0->reg3
  cookie=0x0, table=egress(main_table), n_packets=0, n_bytes=0, priority=0,reg1=0x10 actions=output:32768

--- a/lte/gateway/python/magma/pipelined/tests/snapshots/test_inout.InOutTestLTE.testFlowSnapshotMatch.snapshot
+++ b/lte/gateway/python/magma/pipelined/tests/snapshots/test_inout.InOutTestLTE.testFlowSnapshotMatch.snapshot
@@ -1,6 +1,7 @@
  cookie=0x0, table=ingress(main_table), n_packets=0, n_bytes=0, priority=10,in_port=LOCAL actions=set_field:0x10->reg1,resubmit(,middle(main_table)),set_field:0->reg0,set_field:0->reg3
  cookie=0x0, table=ingress(main_table), n_packets=0, n_bytes=0, priority=10,in_port=211 actions=set_field:0x10->reg1,resubmit(,middle(main_table)),set_field:0->reg0,set_field:0->reg3
- cookie=0x0, table=ingress(main_table), n_packets=0, n_bytes=0, priority=0 actions=set_field:0x1->reg1,resubmit(,middle(main_table)),set_field:0->reg0,set_field:0->reg3
+ cookie=0x0, table=ingress(main_table), n_packets=0, n_bytes=0, priority=0,reg6=0 actions=set_field:0x1->reg1,resubmit(,middle(main_table)),set_field:0->reg0,set_field:0->reg3
+ cookie=0x0, table=ingress(main_table), n_packets=0, n_bytes=0, priority=0,reg6=0x1 actions=set_field:0x10->reg1,resubmit(,middle(main_table)),set_field:0->reg0,set_field:0->reg3
  cookie=0x0, table=middle(main_table), n_packets=0, n_bytes=0, priority=15,reg6=0x1 actions=resubmit(,egress(main_table)),set_field:0->reg0,set_field:0->reg3
  cookie=0x0, table=middle(main_table), n_packets=0, n_bytes=0, priority=12,ip,reg1=0x1,vlan_tci=0x0000/0x1000,nw_dst=1.2.3.4 actions=output:211
  cookie=0x0, table=middle(main_table), n_packets=0, n_bytes=0, priority=12,ip,reg1=0x1,vlan_tci=0x1000/0x1000,nw_dst=1.2.3.4 actions=strip_vlan,output:211

--- a/lte/gateway/python/magma/pipelined/tests/snapshots/test_inout.InOutTestXWF.testFlowSnapshotMatch.snapshot
+++ b/lte/gateway/python/magma/pipelined/tests/snapshots/test_inout.InOutTestXWF.testFlowSnapshotMatch.snapshot
@@ -1,5 +1,6 @@
  cookie=0x0, table=ingress(main_table), n_packets=0, n_bytes=0, priority=10,in_port=LOCAL actions=set_field:0x10->reg1,resubmit(,middle(main_table)),set_field:0->reg0,set_field:0->reg3
- cookie=0x0, table=ingress(main_table), n_packets=0, n_bytes=0, priority=0 actions=set_field:0x1->reg1,resubmit(,middle(main_table)),set_field:0->reg0,set_field:0->reg3
+ cookie=0x0, table=ingress(main_table), n_packets=0, n_bytes=0, priority=0,reg6=0 actions=set_field:0x1->reg1,resubmit(,middle(main_table)),set_field:0->reg0,set_field:0->reg3
+ cookie=0x0, table=ingress(main_table), n_packets=0, n_bytes=0, priority=0,reg6=0x1 actions=set_field:0x10->reg1,resubmit(,middle(main_table)),set_field:0->reg0,set_field:0->reg3
  cookie=0x0, table=middle(main_table), n_packets=0, n_bytes=0, priority=15,reg6=0x1 actions=resubmit(,egress(main_table)),set_field:0->reg0,set_field:0->reg3
  cookie=0x0, table=middle(main_table), n_packets=0, n_bytes=0, priority=10 actions=resubmit(,egress(main_table)),set_field:0->reg0,set_field:0->reg3
  cookie=0x0, table=egress(main_table), n_packets=0, n_bytes=0, priority=0,reg1=0x10 actions=output:32768

--- a/lte/gateway/python/magma/pipelined/tests/snapshots/test_inout_non_nat.InOutTestNonNATBasicFlows.testFlowSnapshotMatch.snapshot
+++ b/lte/gateway/python/magma/pipelined/tests/snapshots/test_inout_non_nat.InOutTestNonNATBasicFlows.testFlowSnapshotMatch.snapshot
@@ -1,5 +1,6 @@
  cookie=0x0, table=ingress(main_table), n_packets=0, n_bytes=0, priority=10,in_port=LOCAL actions=set_field:0x10->reg1,resubmit(,middle(main_table)),set_field:0->reg0,set_field:0->reg3
- cookie=0x0, table=ingress(main_table), n_packets=0, n_bytes=0, priority=0 actions=set_field:0x1->reg1,resubmit(,middle(main_table)),set_field:0->reg0,set_field:0->reg3
+ cookie=0x0, table=ingress(main_table), n_packets=0, n_bytes=0, priority=0,reg6=0 actions=set_field:0x1->reg1,resubmit(,middle(main_table)),set_field:0->reg0,set_field:0->reg3
+ cookie=0x0, table=ingress(main_table), n_packets=0, n_bytes=0, priority=0,reg6=0x1 actions=set_field:0x10->reg1,resubmit(,middle(main_table)),set_field:0->reg0,set_field:0->reg3
  cookie=0x0, table=middle(main_table), n_packets=0, n_bytes=0, priority=15,reg6=0x1 actions=resubmit(,egress(main_table)),set_field:0->reg0,set_field:0->reg3
  cookie=0x0, table=middle(main_table), n_packets=0, n_bytes=0, priority=10 actions=resubmit(,egress(main_table)),set_field:0->reg0,set_field:0->reg3
  cookie=0x0, table=egress(main_table), n_packets=0, n_bytes=0, priority=0,reg1=0x10 actions=output:32768

--- a/lte/gateway/python/magma/pipelined/tests/snapshots/test_li_mirror.LIMirrorTest.testFlowSnapshotMatch.snapshot
+++ b/lte/gateway/python/magma/pipelined/tests/snapshots/test_li_mirror.LIMirrorTest.testFlowSnapshotMatch.snapshot
@@ -1,6 +1,7 @@
  cookie=0x0, table=ingress(main_table), n_packets=0, n_bytes=0, priority=10,in_port=LOCAL actions=set_field:0x10->reg1,resubmit(,middle(main_table)),set_field:0->reg0,set_field:0->reg3
  cookie=0x0, table=ingress(main_table), n_packets=0, n_bytes=0, priority=10,in_port=1 actions=set_field:0x10->reg1,resubmit(,li_mirror(main_table)),set_field:0->reg0,set_field:0->reg3
- cookie=0x0, table=ingress(main_table), n_packets=0, n_bytes=0, priority=0 actions=set_field:0x1->reg1,resubmit(,middle(main_table)),set_field:0->reg0,set_field:0->reg3
+ cookie=0x0, table=ingress(main_table), n_packets=0, n_bytes=0, priority=0,reg6=0 actions=set_field:0x1->reg1,resubmit(,middle(main_table)),set_field:0->reg0,set_field:0->reg3
+ cookie=0x0, table=ingress(main_table), n_packets=0, n_bytes=0, priority=0,reg6=0x1 actions=set_field:0x10->reg1,resubmit(,middle(main_table)),set_field:0->reg0,set_field:0->reg3
  cookie=0x0, table=middle(main_table), n_packets=0, n_bytes=0, priority=15,reg6=0x1 actions=resubmit(,egress(main_table)),set_field:0->reg0,set_field:0->reg3
  cookie=0x0, table=middle(main_table), n_packets=0, n_bytes=0, priority=10 actions=resubmit(,li_mirror(main_table)),set_field:0->reg0,set_field:0->reg3
  cookie=0x0, table=li_mirror(main_table), n_packets=0, n_bytes=0, priority=0,ip,reg1=0x10 actions=output:2,resubmit(,egress(main_table)),set_field:0->reg0,set_field:0->reg3

--- a/lte/gateway/python/magma/pipelined/tests/snapshots/test_ue_passthrough.UEMacAddressTest.test_passthrough_rules.snapshot
+++ b/lte/gateway/python/magma/pipelined/tests/snapshots/test_ue_passthrough.UEMacAddressTest.test_passthrough_rules.snapshot
@@ -2,7 +2,8 @@
  cookie=0x0, table=ue_mac(main_table), n_packets=4, n_bytes=384, priority=12,dl_dst=5e:cc:cc:b1:49:4b actions=set_field:0x48c2739fd9c3->metadata,resubmit(,ue_mac(scratch_table_0)),set_field:0->reg0,set_field:0->reg3
  cookie=0x0, table=ue_mac(main_table), n_packets=0, n_bytes=0, priority=10,arp actions=resubmit(,ingress(main_table)),set_field:0->reg0,set_field:0->reg3
  cookie=0x0, table=ingress(main_table), n_packets=4, n_bytes=384, priority=10,in_port=LOCAL actions=set_field:0x10->reg1,resubmit(,arpd(main_table)),set_field:0->reg0,set_field:0->reg3
- cookie=0x0, table=ingress(main_table), n_packets=0, n_bytes=0, priority=0 actions=set_field:0x1->reg1,resubmit(,arpd(main_table)),set_field:0->reg0,set_field:0->reg3
+ cookie=0x0, table=ingress(main_table), n_packets=0, n_bytes=0, priority=0,reg6=0 actions=set_field:0x1->reg1,resubmit(,arpd(main_table)),set_field:0->reg0,set_field:0->reg3
+ cookie=0x0, table=ingress(main_table), n_packets=0, n_bytes=0, priority=0,reg6=0x1 actions=set_field:0x10->reg1,resubmit(,arpd(main_table)),set_field:0->reg0,set_field:0->reg3
  cookie=0x0, table=arpd(main_table), n_packets=0, n_bytes=0, priority=12,arp,reg1=0x10,arp_tpa=1.2.3.4,arp_op=2 actions=set_field:0x1->reg6,resubmit(,middle(main_table)),set_field:0->reg0,set_field:0->reg3
  cookie=0x0, table=arpd(main_table), n_packets=0, n_bytes=0, priority=12,arp,reg1=0x10,arp_tpa=1.2.3.4,arp_op=1 actions=move:NXM_OF_ETH_SRC[]->NXM_OF_ETH_DST[],mod_dl_src:00:aa:bb:cc:dd:ee,load:0x2->NXM_OF_ARP_OP[],move:NXM_NX_ARP_SHA[]->NXM_NX_ARP_THA[],load:0xaabbccddee->NXM_NX_ARP_SHA[],move:NXM_OF_ARP_TPA[]->NXM_NX_REG0[],move:NXM_OF_ARP_SPA[]->NXM_OF_ARP_TPA[],move:NXM_NX_REG0[]->NXM_OF_ARP_SPA[],IN_PORT
  cookie=0x0, table=arpd(main_table), n_packets=0, n_bytes=0, priority=12,arp,reg1=0x10,arp_tpa=1.1.1.1,arp_op=2 actions=set_field:0x1->reg6,resubmit(,middle(main_table)),set_field:0->reg0,set_field:0->reg3

--- a/lte/gateway/python/magma/pipelined/tests/test_ue_passthrough.py
+++ b/lte/gateway/python/magma/pipelined/tests/test_ue_passthrough.py
@@ -188,11 +188,12 @@ class UEMacAddressTest(unittest.TestCase):
                 FlowTest(FlowQuery(self._tbl_num,
                                    self.testing_controller), 4, 3),
                 FlowTest(FlowQuery(self._ingress_tbl_num,
-                                   self.testing_controller), 4, 2),
+                                   self.testing_controller), 4, 3),
                 FlowTest(FlowQuery(self._egress_tbl_num,
                                    self.testing_controller), 3, 2),
                 FlowTest(flow_queries[0], 4, 1),
             ], lambda: wait_after_send(self.testing_controller))
+
 
         snapshot_verifier = SnapshotVerifier(self, self.BRIDGE,
                                              self.service_manager)


### PR DESCRIPTION
in case of inbound roaming, the packet ingress on PGW GTP tunnel
port. This packets are marked as pass through packets. use that to 
to set direction bit for these packets.

Signed-off-by: Pravin B Shelar <pbshelar@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
