### PR TITLE
[EASY] Add SessionD CMake debug files to GitIgnore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,9 +70,8 @@ orc8r/cloud/helm/**/.secrets/
 # Certs for accessing the cloud
 .certs
 
-# Clion config
-devmand/gateway/.idea/
-devmand/gateway/cmake-build-debug/
+# CMake debug files
+lte/gateway/c/session_manager/cmake-build-debug/
 
 # Log files
 *.log


### PR DESCRIPTION
<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary
* Add SessionD cmake build files to gitignore
* Remove DevmanD related gitignore entries since it is deprecated
<!-- Enumerate changes you made and why you made them -->

## Test Plan
Git now ignores these files
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
