### PR TITLE
[orc8r] reverse condition to check network type on lte mconfig builder

### DIFF
--- a/feg/cloud/go/services/feg/obsidian/models/feg_network_id_swaggergen.go
+++ b/feg/cloud/go/services/feg/obsidian/models/feg_network_id_swaggergen.go
@@ -9,7 +9,7 @@ import (
 	strfmt "github.com/go-openapi/strfmt"
 )
 
-// FegNetworkID feg network Id
+// FegNetworkID Name of the federated network serving this LTE network. Blank for non federated
 // swagger:model fegNetworkId
 type FegNetworkID string
 

--- a/lte/cloud/go/services/lte/obsidian/models/feg_network_id_swaggergen.go
+++ b/lte/cloud/go/services/lte/obsidian/models/feg_network_id_swaggergen.go
@@ -9,7 +9,7 @@ import (
 	strfmt "github.com/go-openapi/strfmt"
 )
 
-// FegNetworkID feg network id
+// FegNetworkID Name of the federated network serving this LTE network. Blank for non federated
 // swagger:model feg_network_id
 type FegNetworkID string
 

--- a/lte/cloud/go/services/lte/obsidian/models/swagger.v1.yml
+++ b/lte/cloud/go/services/lte/obsidian/models/swagger.v1.yml
@@ -1603,8 +1603,9 @@ definitions:
        $ref: '#/definitions/feg_network_id'
 
   feg_network_id:
+    description: Name of the federated network serving this LTE network. Blank for non federated
     type: string
-    example: 'example_feg_network'
+    example: 'feg_id_only_for_federated_network'
 
   network_ran_configs:
     description: RAN (radio access network) cellular configuration for a network

--- a/orc8r/cloud/go/obsidian/swagger/v1/swagger.yml
+++ b/orc8r/cloud/go/obsidian/swagger/v1/swagger.yml
@@ -8141,7 +8141,8 @@ definitions:
     - dns
     type: object
   feg_network_id:
-    example: example_feg_network
+    description: Name of the federated network serving this LTE network. Blank for non federated
+    example: feg_id_only_for_federated_network
     type: string
   flow_description:
     properties:


### PR DESCRIPTION
Signed-off-by: Oriol Batalla <obatalla@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary

It looks like some LTE networks at staging include `feg_netowrk_id` as part of its configuration. That is unexpected since those LTE network are not federated and shouldn't include that field. 

That field is causing the builder to think those are federated.

In order to avoid that, this PR reverse the way we are checking this is for sure a federated network. First it checks for the type and then it checks for the existence of the field


## Test Plan
```
./build -g
./build --test --up
```
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
