### PR TITLE
[orc8r][configurator] Add test to fix nondeterminate codecov

### DIFF
--- a/orc8r/cloud/go/services/configurator/storage/union.go
+++ b/orc8r/cloud/go/services/configurator/storage/union.go
@@ -32,7 +32,8 @@ func newUnionFind(pks []string) *unionFind {
 
 // unionFind is an implementation of a union-find data structure for efficient
 // computation of connected components in a graph. The DS implements path
-// compression on find and rank-rated union
+// compression on find and rank-rated union.
+// Tutorial: https://www.youtube.com/watch?v=0jNmHPfA_yE
 type unionFind struct {
 	parents map[string]string
 	ranks   map[string]int

--- a/orc8r/cloud/go/services/configurator/storage/union_test.go
+++ b/orc8r/cloud/go/services/configurator/storage/union_test.go
@@ -90,4 +90,19 @@ func TestUnionFind(t *testing.T) {
 		},
 		actual,
 	)
+
+	// Trigger xRank < yRank
+	uf = newUnionFind([]string{"1", "2", "3"})
+	uf.union("1", "2")
+	// 1 -> 2 | 3
+	uf.union("3", "1")
+	// 1 -> (2, 3)
+	actual = uf.getComponents()
+	assert.Equal(
+		t,
+		[][]string{
+			{"1", "2", "3"},
+		},
+		actual,
+	)
 }


### PR DESCRIPTION
## Summary

The `xRank < yRank` condition wasn't being checked by the unit test, so the codecov was noisy because the integ tests have some nondeterminism. This PR covers the relevant branch with a unit test, which should resolve the noisy codecov reports.

## Test Plan

n/a

## Additional Information

- [ ] This change is backwards-breaking