### PR TITLE
[AGW][MME] Send ITTI message from PCEF create session callback

### DIFF
--- a/lte/gateway/c/oai/include/gx_messages_def.h
+++ b/lte/gateway/c/oai/include/gx_messages_def.h
@@ -29,6 +29,10 @@
  */
 
 MESSAGE_DEF(
+    PCEF_CREATE_SESSION_RESPONSE, itti_pcef_create_session_response_t,
+    pcef_create_session_response)
+
+MESSAGE_DEF(
     GX_NW_INITIATED_ACTIVATE_BEARER_REQ, itti_gx_nw_init_actv_bearer_request_t,
     gx_nw_init_actv_bearer_request)
 

--- a/lte/gateway/c/oai/include/gx_messages_types.h
+++ b/lte/gateway/c/oai/include/gx_messages_types.h
@@ -37,11 +37,11 @@
  * \version 0.1
  */
 
-#ifndef FILE_GX_MESSAGES_TYPES_SEEN
-#define FILE_GX_MESSAGES_TYPES_SEEN
+#pragma once
 
 #include "3gpp_24.007.h"
 #include "3gpp_29.274.h"
+#include "ip_forward_messages_types.h"
 
 #define GX_NW_INITIATED_ACTIVATE_BEARER_REQ(mSGpTR)                            \
   (mSGpTR)->ittiMsg.gx_nw_init_actv_bearer_request
@@ -50,6 +50,22 @@
 
 #define POLICY_RULE_NAME_MAXLEN                                                \
   100  // The policy name will be truncated to this
+
+typedef enum {
+  PCEF_STATUS_OK     = 0,
+  PCEF_STATUS_FAILED = 1,
+} PcefRpcStatus_t;
+
+/**
+ * PCEF Create Session response from PCEFClient, sent from GRPC task to SPGW
+ * during processing of Create Session Request by SPGW task
+ */
+typedef struct itti_pcef_create_session_response_s {
+  PcefRpcStatus_t rpc_status;
+  teid_t teid;
+  ebi_t eps_bearer_id;
+  SGIStatus_t sgi_status;
+} itti_pcef_create_session_response_t;
 
 typedef struct itti_gx_nw_init_actv_bearer_request_s {
   char imsi[IMSI_BCD_DIGITS_MAX + 1];
@@ -69,5 +85,3 @@ typedef struct itti_gx_nw_init_deactv_bearer_request_s {
   ebi_t lbi;
   ebi_t ebi[BEARERS_PER_UE];
 } itti_gx_nw_init_deactv_bearer_request_t;
-
-#endif /* FILE_GX_MESSAGES_TYPES_SEEN */

--- a/lte/gateway/c/oai/lib/mobility_client/MobilityClientAPI.cpp
+++ b/lte/gateway/c/oai/lib/mobility_client/MobilityClientAPI.cpp
@@ -225,8 +225,7 @@ int pgw_handle_allocate_ipv6_address(
                    .saved_message,
               &session_data);
           pcef_create_session(
-              spgw_state, subscriber_id, nullptr, ip6_str, &session_data,
-              session_req, new_bearer_ctxt_info_p);
+              subscriber_id, nullptr, ip6_str, &session_data, session_req);
         } else {
           // If we are here then the IP address allocation has failed
           s5_response.eps_bearer_id = sgi_create_endpoint_resp.eps_bearer_id;
@@ -340,8 +339,7 @@ int pgw_handle_allocate_ipv4v6_address(
                    .saved_message,
               &session_data);
           pcef_create_session(
-              spgw_state, subscriber_id, ip4_str, ip6_str, &session_data,
-              session_req, new_bearer_ctxt_info_p);
+              subscriber_id, ip4_str, ip6_str, &session_data, session_req);
           s5_response.eps_bearer_id = sgi_create_endpoint_resp.eps_bearer_id;
           s5_response.context_teid  = sgi_create_endpoint_resp.context_teid;
         } else {

--- a/lte/gateway/c/oai/lib/pcef/PCEFClient.cpp
+++ b/lte/gateway/c/oai/lib/pcef/PCEFClient.cpp
@@ -56,6 +56,7 @@ PCEFClient::PCEFClient() {
   // Create stub for LocalSessionManager gRPC service
   stub_ = LocalSessionManager::NewStub(channel);
   std::thread resp_loop_thread([&]() { rpc_response_loop(); });
+  std::cout << "PCEF Client thread id " << resp_loop_thread.native_handle();
   resp_loop_thread.detach();
 }
 

--- a/lte/gateway/c/oai/lib/pcef/pcef_handlers.h
+++ b/lte/gateway/c/oai/lib/pcef/pcef_handlers.h
@@ -58,10 +58,9 @@ struct pcef_create_session_data {
  * This is a long process, so it needs to by asynchronous
  */
 void pcef_create_session(
-    spgw_state_t* state, const char* imsi, const char* ip4, const char* ip6,
+    const char* imsi, const char* ip4, const char* ip6,
     const struct pcef_create_session_data* session_data,
-    s5_create_session_request_t bearer_request,
-    s_plus_p_gw_eps_bearer_context_information_t* ctx_p);
+    s5_create_session_request_t bearer_request);
 
 /**
  * pcef_end_session is a *synchronous* call that ends the UE session in the

--- a/lte/gateway/c/oai/tasks/sgw/pgw_handlers.h
+++ b/lte/gateway/c/oai/tasks/sgw/pgw_handlers.h
@@ -32,6 +32,11 @@ void handle_s5_create_session_request(
     s_plus_p_gw_eps_bearer_context_information_t* new_bearer_ctxt_info_p,
     teid_t context_teid, ebi_t eps_bearer_id);
 
+void spgw_handle_pcef_create_session_response(
+    spgw_state_t* spgw_state,
+    const itti_pcef_create_session_response_t* const pcef_csr_resp_p,
+    imsi64_t imsi64);
+
 uint32_t spgw_handle_nw_init_deactivate_bearer_rsp(
     gtpv2c_cause_t cause, ebi_t lbi);
 

--- a/lte/gateway/c/oai/tasks/sgw/sgw_handlers.c
+++ b/lte/gateway/c/oai/tasks/sgw/sgw_handlers.c
@@ -1945,9 +1945,7 @@ int sgw_handle_ip_allocation_rsp(
     inet_ntop(
         AF_INET, &(ip_allocation_rsp->paa.ipv4_address.s_addr), ip_str,
         INET_ADDRSTRLEN);
-    pcef_create_session(
-        spgw_state, imsi, ip_str, NULL, &session_data, session_req,
-        bearer_ctxt_info_p);
+    pcef_create_session(imsi, ip_str, NULL, &session_data, session_req);
   } else {
     if (ip_allocation_rsp->status == SGI_STATUS_ERROR_SYSTEM_FAILURE) {
       /*

--- a/lte/gateway/c/oai/tasks/sgw/sgw_task.c
+++ b/lte/gateway/c/oai/tasks/sgw/sgw_task.c
@@ -124,6 +124,12 @@ static int handle_message(zloop_t* loop, zsock_t* reader, void* arg) {
           &received_message_p->ittiMsg.s11_nw_init_deactv_bearer_rsp, imsi64);
     } break;
 
+    case PCEF_CREATE_SESSION_RESPONSE: {
+      spgw_handle_pcef_create_session_response(
+          spgw_state, &received_message_p->ittiMsg.pcef_create_session_response,
+          imsi64);
+    } break;
+
     case GX_NW_INITIATED_ACTIVATE_BEARER_REQ: {
       /* TODO need to discuss as part sending response to PCEF,
        * should these errors need to be mapped to gx errors
@@ -237,14 +243,6 @@ int spgw_app_init(spgw_config_t* spgw_config_pP, bool persist_state) {
     OAILOG_ALERT(LOG_SPGW_APP, "Initializing SPGW-APP task interface: ERROR\n");
     return RETURNerror;
   }
-
-  FILE* fp         = NULL;
-  bstring filename = bformat("/tmp/spgw_%d.status", g_pid);
-  fp               = fopen(bdata(filename), "w+");
-  bdestroy_wrapper(&filename);
-  fprintf(fp, "STARTED\n");
-  fflush(fp);
-  fclose(fp);
 
   OAILOG_DEBUG(LOG_SPGW_APP, "Initializing SPGW-APP task interface: DONE\n");
   return RETURNok;

--- a/lte/gateway/c/oai/tasks/sgw/spgw_state.cpp
+++ b/lte/gateway/c/oai/tasks/sgw/spgw_state.cpp
@@ -42,6 +42,8 @@ spgw_state_t* get_spgw_state(bool read_from_db) {
 }
 
 hash_table_ts_t* get_spgw_ue_state() {
+  OAILOG_DEBUG(
+      LOG_SPGW_APP, "get_spgw_ue_state called by thread id %u", pthread_self());
   return SpgwStateManager::getInstance().get_ue_state_ht();
 }
 


### PR DESCRIPTION
Signed-off-by: Shruti Sanadhya <ssanadhya@fb.com>

## Summary

This change makes the PCEF Client create session callback send an ITTI message to SPGW task, instead of altering SPGW state in the context of the the PCEF GRPC handler thread.

Also cleaned up unused code to dump SPGW status into a file in `/tmp/`

## Test Plan

- `make integ_test`
- To be done: testing on Spirent AGW testbed