### PR TITLE
[orc8r][lib] Security options for internal only orc8r services

### DIFF
--- a/orc8r/cloud/go/service/middleware/unary/handler.go
+++ b/orc8r/cloud/go/service/middleware/unary/handler.go
@@ -102,6 +102,15 @@ func MiddlewareHandler(ctx context.Context, req interface{}, info *grpc.UnarySer
 	return
 }
 
+// IntraServiceHandler is an interceptor for internal only orc8r services
+// (services which are supposed to serve only internal orc8r clients)
+func IntraServiceHandler(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (resp interface{}, err error) {
+	if err = EnforceIntraCloudRPC(ctx, info); err != nil {
+		return resp, err
+	}
+	return callHandler(ctx, req, info, handler)
+}
+
 // callHandler wraps the handler with error recovery, logging, and metrics.
 func callHandler(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (resp interface{}, err error) {
 	defer func() {

--- a/orc8r/cloud/go/service/middleware/unary/identity_decorator.go
+++ b/orc8r/cloud/go/service/middleware/unary/identity_decorator.go
@@ -11,7 +11,7 @@
  * limitations under the License.
  */
 
-// package interceptors implements all cloud service framework unary interceptors
+// package unary implements all cloud service framework unary interceptors
 package unary
 
 import (

--- a/orc8r/cloud/go/service/middleware/unary/intra_service_enforcer.go
+++ b/orc8r/cloud/go/service/middleware/unary/intra_service_enforcer.go
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2021 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// package unary implements all cloud service framework unary interceptors
+package unary
+
+import (
+	"context"
+
+	"github.com/golang/glog"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
+
+	unarylib "magma/orc8r/lib/go/service/middleware/unary"
+)
+
+// EnforceIntraCloudRPC verifies that the RPC originated from a service on the cloud (and not a remote Gateway),
+// it'll will also bypass the checks for allowed RPCs (methods in identityDecoratorBypassList)
+func EnforceIntraCloudRPC(ctx context.Context, info *grpc.UnaryServerInfo) error {
+	if err := ensureLocalPeer(ctx); err == nil {
+		// a call from local peer - allow
+		return nil
+	}
+	if info != nil {
+		// Check if the call is for a globally allowed/bypassed method (bootstrapper, etc.)
+		if _, ok := identityDecoratorBypassList[info.FullMethod]; ok {
+			// Bypass method (Bootstrapper & Co.) - allow
+			return nil
+		}
+	}
+	ctxMetadata, ok := metadata.FromIncomingContext(ctx)
+	if !ok || ctxMetadata == nil {
+		// no metadata - fail
+		glog.Error(ERROR_MSG_NO_METADATA)
+		return status.Error(codes.Unauthenticated, ERROR_MSG_NO_METADATA)
+	}
+	// First, try to find the caller's identity
+	snlist, ok := ctxMetadata[CLIENT_CERT_SN_KEY]
+	if !ok || len(snlist) != 1 {
+		// there can be only one CSN, error out if not
+		glog.Errorf("Single CSN is expected in metadata: %+v", ctxMetadata)
+		return status.Error(codes.InvalidArgument, "Single CSN is expected")
+	}
+	if snlist[0] != unarylib.ORC8R_CLIENT_CERT_VALUE {
+		// Not an inter-service CSN - fail
+		glog.Errorf("Non inter-service CSN in request to internal service: %s", snlist[0])
+		return status.Error(codes.PermissionDenied, "Invalid CSN in internal RPC")
+	}
+	return nil
+}

--- a/orc8r/cloud/go/service/middleware/unary/registered_gw_enforcer.go
+++ b/orc8r/cloud/go/service/middleware/unary/registered_gw_enforcer.go
@@ -11,7 +11,7 @@
  * limitations under the License.
  */
 
-// package interceptors implements all cloud service framework unary interceptors
+// package unary implements all cloud service framework unary interceptors
 package unary
 
 import (

--- a/orc8r/cloud/go/services/accessd/accessd/main.go
+++ b/orc8r/cloud/go/services/accessd/accessd/main.go
@@ -30,8 +30,8 @@ import (
 )
 
 func main() {
-	// Create the service
-	srv, err := service.NewOrchestratorService(orc8r.ModuleName, accessd.ServiceName)
+	// Create the service (note: the service is not available to external gateway clients)
+	srv, err := service.NewIntraOrchestratorService(orc8r.ModuleName, accessd.ServiceName)
 	if err != nil {
 		glog.Fatalf("Error creating service: %s", err)
 	}

--- a/orc8r/cloud/go/services/certifier/certifier/main.go
+++ b/orc8r/cloud/go/services/certifier/certifier/main.go
@@ -46,7 +46,7 @@ var (
 
 func main() {
 	// Create the service, flag will be parsed inside this function
-	srv, err := service.NewOrchestratorService(orc8r.ModuleName, certifier.ServiceName)
+	srv, err := service.NewIntraOrchestratorService(orc8r.ModuleName, certifier.ServiceName)
 	if err != nil {
 		glog.Fatalf("Error creating service: %s", err)
 	}

--- a/orc8r/cloud/go/services/configurator/servicers/southbound.go
+++ b/orc8r/cloud/go/services/configurator/servicers/southbound.go
@@ -53,6 +53,9 @@ func (srv *sbConfiguratorServicer) GetMconfig(ctx context.Context, void *protos.
 }
 
 func (srv *sbConfiguratorServicer) GetMconfigInternal(ctx context.Context, req *cfg_protos.GetMconfigRequest) (*cfg_protos.GetMconfigResponse, error) {
+	if protos.IsRemoteClient(ctx) {
+		return nil, status.Error(codes.PermissionDenied, "Remote GetMconfigInternal request")
+	}
 	store, err := srv.factory.StartTransaction(context.Background(), &orc8r_storage.TxOptions{ReadOnly: true})
 	if err != nil {
 		storage.RollbackLogOnError(store)

--- a/orc8r/cloud/go/services/directoryd/servicers/update_servicer.go
+++ b/orc8r/cloud/go/services/directoryd/servicers/update_servicer.go
@@ -24,6 +24,7 @@ import (
 	"magma/orc8r/cloud/go/services/state"
 	state_types "magma/orc8r/cloud/go/services/state/types"
 	"magma/orc8r/lib/go/protos"
+	"magma/orc8r/lib/go/service/middleware/unary"
 
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
@@ -106,7 +107,7 @@ func (d *directoryUpdateServicer) GetDirectoryField(
 		return ret, err
 	}
 	res, err := client.GetStates(
-		makeOutgoingCtx(c),
+		unary.CreateOutgoingCloudClientCtx(),
 		&protos.GetStatesRequest{
 			NetworkID: networkId,
 			Ids:       []*protos.StateID{{Type: orc8r.DirectoryRecordType, DeviceID: r.GetId()}},
@@ -155,7 +156,7 @@ func (d *directoryUpdateServicer) GetAllDirectoryRecords(
 		return ret, err
 	}
 	res, err := client.GetStates(
-		makeOutgoingCtx(c),
+		unary.CreateOutgoingCloudClientCtx(),
 		&protos.GetStatesRequest{
 			NetworkID:  networkId,
 			TypeFilter: []string{orc8r.DirectoryRecordType},

--- a/orc8r/cloud/go/services/service_registry/service_registry/main.go
+++ b/orc8r/cloud/go/services/service_registry/service_registry/main.go
@@ -36,7 +36,7 @@ const (
 )
 
 func main() {
-	srv, err := service.NewOrchestratorService(orc8r.ModuleName, registry.ServiceRegistryServiceName)
+	srv, err := service.NewIntraOrchestratorService(orc8r.ModuleName, registry.ServiceRegistryServiceName)
 	if err != nil {
 		glog.Fatalf("Error creating service registry service %s", err)
 	}

--- a/orc8r/cloud/go/services/state/servicers/servicer.go
+++ b/orc8r/cloud/go/services/state/servicers/servicer.go
@@ -49,6 +49,9 @@ func NewStateServicer(factory blobstore.BlobStorageFactory) (protos.StateService
 }
 
 func (srv *stateServicer) GetStates(ctx context.Context, req *protos.GetStatesRequest) (*protos.GetStatesResponse, error) {
+	if protos.IsRemoteClient(ctx) {
+		return nil, status.Error(codes.PermissionDenied, "Remote GetStates request")
+	}
 	if err := validateGetStatesRequest(req); err != nil {
 		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}

--- a/orc8r/lib/go/protos/identity_helper.go
+++ b/orc8r/lib/go/protos/identity_helper.go
@@ -235,6 +235,11 @@ func GetClientGateway(ctx context.Context) *Identity_Gateway {
 	return GetClientIdentity(ctx).GetGateway()
 }
 
+// IsRemoteClient returns true if the RPC caller
+func IsRemoteClient(ctx context.Context) bool {
+	return GetClientGateway(ctx) != nil
+}
+
 // NewContextWithIdentity returns a new Context that carries the given Identity
 // Since nil Identity is equivalent to no Identity, no new CTX will be created
 // if the passed id is nil and the passed ctx will be returned unmodified

--- a/orc8r/lib/go/service/middleware/unary/client_identity.go
+++ b/orc8r/lib/go/service/middleware/unary/client_identity.go
@@ -56,3 +56,9 @@ func OutgoingCloudClientCtx(ctx context.Context) context.Context {
 	}
 	return metadata.NewOutgoingContext(ctx, md)
 }
+
+// CreateOutgoingCloudClientCtx creates new outgoing cloud client context with magic client CSN metadata
+func CreateOutgoingCloudClientCtx() context.Context {
+	return metadata.NewOutgoingContext(
+		context.Background(), metadata.Pairs(CLIENT_CERT_SN_KEY, ORC8R_CLIENT_CERT_VALUE))
+}


### PR DESCRIPTION
Signed-off-by: Evgeniy Makeev <evgeniym@fb.com>

## Summary

APIs to secure internal only orc8r services. 
Internal only services are orc9r services which can only be called by other orc8r services or obsidian, they should not
allow RPCs from Magma Gateways.

Currently, every orc8r intra-service RPC context contains a special Synthetic Orchestrator Certificate metadata, existing security middleware will block any RPC which doesn't have either Synthetic Orchestrator Certificate metadata or real Gateway Certificate Metadata.
When RPC reaches an orc8r service method, its context will either have Gateway Certificate Metadata or (in case of Synthetic Orchestrator Certificate) no certificate metadata at all. It should allow us to distinguish between Gateway originated RPC and orc8r service originated RPC without requiring additional configuration & deployment  overhead proposed in https://github.com/magma/magma/issues/5412

Developers can secure an internal only orc8r  service by using the provided NewIntraOrchestratorService() function instead of NewOrchestratorService() which allows remote GW RPCs.

If the service has mixed use (GW RPCs for some methods & internal only RPC for others), internal only service methods can be secured using provided  IsRemoteClient() function using the following pattern:

`	if protos.IsRemoteClient(ctx) {
		return nil, status.Error(codes.PermissionDenied, "Remote GetStates request")
	}
`
see state service changes as an example.

Several existing orc8r services (accessd, directoryd, certifier, configurator, state & service_registry) were modified to use the new approach. Additional existing services may need to follow.

Developer introducing new orc8r services should determine if Gateway service accessibility is required and use the introduced patterns accordingly.

## Test Plan
unit tests, additional staging testing to follow

## Additional Information

- [ ] This change is backwards-breaking
