### PR TITLE
[SessionD] Add a DirectoryDClient base class

### DIFF
--- a/lte/gateway/c/session_manager/DirectorydClient.cpp
+++ b/lte/gateway/c/session_manager/DirectorydClient.cpp
@@ -12,23 +12,10 @@
  */
 
 #include "DirectorydClient.h"
-
 #include "ServiceRegistrySingleton.h"
 #include "magma_logging.h"
 
 using grpc::Status;
-
-namespace {  // anonymous
-
-magma::GetDirectoryFieldRequest create_directory_field_req(
-    const std::string& imsi) {
-  magma::GetDirectoryFieldRequest req;
-  req.set_id(imsi);
-  req.set_field_key("ipv4_addr");
-  return req;
-}
-
-}  // namespace
 
 namespace magma {
 
@@ -41,14 +28,6 @@ AsyncDirectorydClient::AsyncDirectorydClient()
           ServiceRegistrySingleton::Instance()->GetGrpcChannel(
               "directoryd", ServiceRegistrySingleton::LOCAL)) {}
 
-bool AsyncDirectorydClient::get_directoryd_ip_field(
-    const std::string& imsi,
-    std::function<void(Status status, DirectoryField)> callback) {
-  auto req = create_directory_field_req(imsi);
-  get_directoryd_ip_field_rpc(req, callback);
-  return true;
-}
-
 void AsyncDirectorydClient::update_directoryd_record(
     const UpdateRecordRequest& request,
     std::function<void(Status status, Void)> callback) {
@@ -58,23 +37,13 @@ void AsyncDirectorydClient::update_directoryd_record(
       local_response->get_context(), request, &queue_)));
 }
 
-void AsyncDirectorydClient::get_directoryd_ip_field_rpc(
-    const GetDirectoryFieldRequest& request,
-    std::function<void(Status, DirectoryField)> callback) {
-  auto local_resp = new AsyncLocalResponse<DirectoryField>(
-      std::move(callback), RESPONSE_TIMEOUT);
-  local_resp->set_response_reader(std::move(stub_->AsyncGetDirectoryField(
-      local_resp->get_context(), request, &queue_)));
-}
-
-bool AsyncDirectorydClient::delete_directoryd_record(
+void AsyncDirectorydClient::delete_directoryd_record(
     const DeleteRecordRequest& request,
     std::function<void(Status status, Void)> callback) {
   auto local_response =
       new AsyncLocalResponse<Void>(std::move(callback), RESPONSE_TIMEOUT);
   local_response->set_response_reader(std::move(stub_->AsyncDeleteRecord(
       local_response->get_context(), request, &queue_)));
-  return true;
 }
 
 void AsyncDirectorydClient::get_all_directoryd_records(

--- a/lte/gateway/c/session_manager/DirectorydClient.h
+++ b/lte/gateway/c/session_manager/DirectorydClient.h
@@ -26,43 +26,60 @@ namespace magma {
 using namespace orc8r;
 
 /**
- * AsyncDirectorydClient sends asynchronous calls to directoryd to retrieve
+ * DirectorydClient is the base class for managing interactions with DirectoryD.
+ */
+class DirectorydClient {
+ public:
+  virtual ~DirectorydClient() = default;
+  /**
+   * Update the DirectoryD record
+   * @param update_request - request used to update the record
+   */
+  virtual void update_directoryd_record(
+      const UpdateRecordRequest& request,
+      std::function<void(Status status, Void)> callback) = 0;
+  /**
+   * Delete the DirectoryD record for the specified ID
+   * @param delelete_request - request used to delete the record
+   */
+  virtual void delete_directoryd_record(
+      const DeleteRecordRequest& request,
+      std::function<void(Status status, Void)> callback) = 0;
+
+  /**
+   * Get all DirectoryD records
+   */
+  virtual void get_all_directoryd_records(
+      std::function<void(Status status, AllDirectoryRecords)> callback) = 0;
+};
+
+/**
+ * AsyncDirectorydClient sends asynchronous calls to DirectoryD to retrieve
  * UE information.
  */
-class AsyncDirectorydClient : public GRPCReceiver {
+class AsyncDirectorydClient : public GRPCReceiver, public DirectorydClient {
  public:
   AsyncDirectorydClient();
 
   AsyncDirectorydClient(std::shared_ptr<grpc::Channel> directoryd_channel);
 
   /**
-   * Gets the directoryd imsi's 'ip' field
-   * @param imsi - UE to query
-   * @return true if the operation was successful
-   */
-  bool get_directoryd_ip_field(
-      const std::string& imsi,
-      std::function<void(Status status, DirectoryField)> callback);
-  /**
-   * Update the directoryd record
+   * Update the DirectoryD record
    * @param update_request - request used to update the record
-   * @return status of update
    */
   void update_directoryd_record(
       const UpdateRecordRequest& request,
       std::function<void(Status status, Void)> callback);
   /**
-   * Delete the directoryd record for the specified ID
+   * Delete the DirectoryD record for the specified ID
    * @param delelete_request - request used to delete the record
-   * @return status of delete
    */
-  bool delete_directoryd_record(
+  void delete_directoryd_record(
       const DeleteRecordRequest& request,
       std::function<void(Status status, Void)> callback);
 
   /**
-   * Get all directory records
-   * @return true if the operation was successful
+   * Get all DirectoryD records
    */
   void get_all_directoryd_records(
       std::function<void(Status status, AllDirectoryRecords)> callback);
@@ -70,11 +87,6 @@ class AsyncDirectorydClient : public GRPCReceiver {
  private:
   static const uint32_t RESPONSE_TIMEOUT = 6;  // seconds
   std::unique_ptr<GatewayDirectoryService::Stub> stub_;
-
- private:
-  void get_directoryd_ip_field_rpc(
-      const GetDirectoryFieldRequest& request,
-      std::function<void(Status, DirectoryField)> callback);
 };
 
 }  // namespace magma

--- a/lte/gateway/c/session_manager/LocalEnforcer.cpp
+++ b/lte/gateway/c/session_manager/LocalEnforcer.cpp
@@ -56,7 +56,7 @@ LocalEnforcer::LocalEnforcer(
     std::shared_ptr<SessionReporter> reporter,
     std::shared_ptr<StaticRuleStore> rule_store, SessionStore& session_store,
     std::shared_ptr<PipelinedClient> pipelined_client,
-    std::shared_ptr<AsyncDirectorydClient> directoryd_client,
+    std::shared_ptr<DirectorydClient> directoryd_client,
     std::shared_ptr<EventsReporter> events_reporter,
     std::shared_ptr<SpgwServiceClient> spgw_client,
     std::shared_ptr<aaa::AAAClient> aaa_client,

--- a/lte/gateway/c/session_manager/LocalEnforcer.h
+++ b/lte/gateway/c/session_manager/LocalEnforcer.h
@@ -91,7 +91,7 @@ class LocalEnforcer {
       std::shared_ptr<SessionReporter> reporter,
       std::shared_ptr<StaticRuleStore> rule_store, SessionStore& session_store,
       std::shared_ptr<PipelinedClient> pipelined_client,
-      std::shared_ptr<AsyncDirectorydClient> directoryd_client,
+      std::shared_ptr<DirectorydClient> directoryd_client,
       std::shared_ptr<EventsReporter> events_reporter,
       std::shared_ptr<SpgwServiceClient> spgw_client,
       std::shared_ptr<aaa::AAAClient> aaa_client,
@@ -298,7 +298,7 @@ class LocalEnforcer {
   std::shared_ptr<SessionReporter> reporter_;
   std::shared_ptr<StaticRuleStore> rule_store_;
   std::shared_ptr<PipelinedClient> pipelined_client_;
-  std::shared_ptr<AsyncDirectorydClient> directoryd_client_;
+  std::shared_ptr<DirectorydClient> directoryd_client_;
   std::shared_ptr<EventsReporter> events_reporter_;
   std::shared_ptr<SpgwServiceClient> spgw_client_;
   std::shared_ptr<aaa::AAAClient> aaa_client_;

--- a/lte/gateway/c/session_manager/LocalSessionManagerHandler.cpp
+++ b/lte/gateway/c/session_manager/LocalSessionManagerHandler.cpp
@@ -26,7 +26,7 @@ namespace magma {
 
 LocalSessionManagerHandlerImpl::LocalSessionManagerHandlerImpl(
     std::shared_ptr<LocalEnforcer> enforcer, SessionReporter* reporter,
-    std::shared_ptr<AsyncDirectorydClient> directoryd_client,
+    std::shared_ptr<DirectorydClient> directoryd_client,
     std::shared_ptr<EventsReporter> events_reporter,
     SessionStore& session_store)
     : session_store_(session_store),

--- a/lte/gateway/c/session_manager/LocalSessionManagerHandler.h
+++ b/lte/gateway/c/session_manager/LocalSessionManagerHandler.h
@@ -99,7 +99,7 @@ class LocalSessionManagerHandlerImpl : public LocalSessionManagerHandler {
  public:
   LocalSessionManagerHandlerImpl(
       std::shared_ptr<LocalEnforcer> monitor, SessionReporter* reporter,
-      std::shared_ptr<AsyncDirectorydClient> directoryd_client,
+      std::shared_ptr<DirectorydClient> directoryd_client,
       std::shared_ptr<EventsReporter> events_reporter,
       SessionStore& session_store);
   ~LocalSessionManagerHandlerImpl() {}
@@ -155,7 +155,7 @@ class LocalSessionManagerHandlerImpl : public LocalSessionManagerHandler {
   SessionStore& session_store_;
   std::shared_ptr<LocalEnforcer> enforcer_;
   SessionReporter* reporter_;
-  std::shared_ptr<AsyncDirectorydClient> directoryd_client_;
+  std::shared_ptr<DirectorydClient> directoryd_client_;
   std::shared_ptr<EventsReporter> events_reporter_;
   SessionIDGenerator id_gen_;
   uint64_t current_epoch_;

--- a/lte/gateway/c/session_manager/RestartHandler.cpp
+++ b/lte/gateway/c/session_manager/RestartHandler.cpp
@@ -23,7 +23,7 @@ const uint RestartHandler::max_cleanup_retries_  = 3;
 const uint RestartHandler::rpc_retry_interval_s_ = 5;
 
 RestartHandler::RestartHandler(
-    std::shared_ptr<AsyncDirectorydClient> directoryd_client,
+    std::shared_ptr<DirectorydClient> directoryd_client,
     std::shared_ptr<aaa::AsyncAAAClient> aaa_client,
     std::shared_ptr<LocalEnforcer> enforcer, SessionReporter* reporter,
     SessionStore& session_store)

--- a/lte/gateway/c/session_manager/RestartHandler.h
+++ b/lte/gateway/c/session_manager/RestartHandler.h
@@ -28,7 +28,7 @@ namespace sessiond {
 class RestartHandler {
  public:
   RestartHandler(
-      std::shared_ptr<AsyncDirectorydClient> directoryd_client,
+      std::shared_ptr<DirectorydClient> directoryd_client,
       std::shared_ptr<aaa::AsyncAAAClient> aaa_client,
       std::shared_ptr<LocalEnforcer> enforcer, SessionReporter* reporter,
       SessionStore& session_store);
@@ -50,7 +50,7 @@ class RestartHandler {
   bool launch_threads_to_terminate_with_retries();
 
  private:
-  std::shared_ptr<AsyncDirectorydClient> directoryd_client_;
+  std::shared_ptr<DirectorydClient> directoryd_client_;
   std::shared_ptr<aaa::AsyncAAAClient> aaa_client_;
   std::shared_ptr<LocalEnforcer> enforcer_;
   SessionReporter* reporter_;

--- a/lte/gateway/c/session_manager/test/SessiondMocks.h
+++ b/lte/gateway/c/session_manager/test/SessiondMocks.h
@@ -186,17 +186,21 @@ class MockPipelinedClient : public PipelinedClient {
   MOCK_METHOD0(get_current_teid, uint32_t());
 };
 
-class MockDirectorydClient : public AsyncDirectorydClient {
+class MockDirectorydClient : public DirectorydClient {
  public:
-  MockDirectorydClient() {
-    ON_CALL(*this, get_directoryd_ip_field(_, _)).WillByDefault(Return(true));
-  }
-
   MOCK_METHOD2(
-      get_directoryd_ip_field,
-      bool(
-          const std::string& imsi,
-          std::function<void(Status status, DirectoryField)> callback));
+      update_directoryd_record,
+      void(
+          const UpdateRecordRequest& request,
+          std::function<void(Status status, Void)> callback));
+  MOCK_METHOD2(
+      delete_directoryd_record,
+      void(
+          const DeleteRecordRequest& request,
+          std::function<void(Status status, Void)> callback));
+  MOCK_METHOD1(
+      get_all_directoryd_records,
+      void(std::function<void(Status status, AllDirectoryRecords)> callback));
 };
 
 class MockEventdClient : public AsyncEventdClient {


### PR DESCRIPTION
Signed-off-by: Marie Bremner <marwhal@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary
* Add a `DirectoryClient` base class that `AsyncDirectoryClient` inherits from so that the methods we mock are virtual
* Get rid of `get_directoryd_ip_field` since we don't use it anymore
* Change return types to be void not bool, since they are async calls.
<!-- Enumerate changes you made and why you made them -->

## Test Plan
make precommit_sm
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
