### PR TITLE
[SessionD] Add a EventDClient base class with virtual methods

### DIFF
--- a/lte/gateway/c/session_manager/AAAClient.h
+++ b/lte/gateway/c/session_manager/AAAClient.h
@@ -27,6 +27,8 @@ using namespace protos;
  */
 class AAAClient {
  public:
+  virtual ~AAAClient() = default;
+
   virtual bool terminate_session(
       const std::string& radius_session_id, const std::string& imsi) = 0;
 

--- a/lte/gateway/c/session_manager/PipelinedClient.h
+++ b/lte/gateway/c/session_manager/PipelinedClient.h
@@ -37,6 +37,8 @@ using std::experimental::optional;
  */
 class PipelinedClient {
  public:
+  virtual ~PipelinedClient() = default;
+
   /**
    * Activates all rules for provided SessionInfos
    * @param infos - list of SessionInfos to setup flows for

--- a/lte/gateway/c/session_manager/SessionEvents.cpp
+++ b/lte/gateway/c/session_manager/SessionEvents.cpp
@@ -75,7 +75,7 @@ enum ServiceConditionChange {  // TS 132 298
 namespace magma {
 namespace lte {
 
-EventsReporterImpl::EventsReporterImpl(AsyncEventdClient& eventd_client)
+EventsReporterImpl::EventsReporterImpl(EventdClient& eventd_client)
     : eventd_client_(eventd_client) {}
 
 void EventsReporterImpl::session_created(

--- a/lte/gateway/c/session_manager/SessionEvents.h
+++ b/lte/gateway/c/session_manager/SessionEvents.h
@@ -29,26 +29,29 @@ namespace lte {
 
 class EventsReporter {
  public:
+  virtual ~EventsReporter() = default;
+
   virtual void session_created(
       const std::string& imsi, const std::string& session_id,
       const SessionConfig& session_context,
-      const std::unique_ptr<SessionState>& session){};
+      const std::unique_ptr<SessionState>& session) = 0;
 
   virtual void session_create_failure(
       const SessionConfig& session_context,
-      const std::string& failure_reason){};
+      const std::string& failure_reason) = 0;
 
   virtual void session_updated(
       const std::string& session_id, const SessionConfig& session_context,
-      const UpdateRequests& update_request){};
+      const UpdateRequests& update_request) = 0;
 
   virtual void session_update_failure(
       const std::string& session_id, const SessionConfig& session_context,
       const UpdateRequests& failed_request,
-      const std::string& failure_reason){};
+      const std::string& failure_reason) = 0;
 
   virtual void session_terminated(
-      const std::string& imsi, const std::unique_ptr<SessionState>& session){};
+      const std::string& imsi,
+      const std::unique_ptr<SessionState>& session) = 0;
 };
 
 /**
@@ -56,7 +59,7 @@ class EventsReporter {
  */
 class EventsReporterImpl : public EventsReporter {
  public:
-  EventsReporterImpl(AsyncEventdClient& eventd_client);
+  EventsReporterImpl(EventdClient& eventd_client);
 
   void session_created(
       const std::string& imsi, const std::string& session_id,
@@ -86,7 +89,7 @@ class EventsReporterImpl : public EventsReporter {
   folly::dynamic get_update_summary(const UpdateRequests& updates);
 
  private:
-  AsyncEventdClient& eventd_client_;
+  EventdClient& eventd_client_;
 };
 
 }  // namespace lte

--- a/lte/gateway/c/session_manager/SessionReporter.h
+++ b/lte/gateway/c/session_manager/SessionReporter.h
@@ -51,6 +51,8 @@ class AsyncEvbResponse : public AsyncGRPCResponse<ResponseType> {
 
 class SessionReporter : public GRPCReceiver {
  public:
+  virtual ~SessionReporter() = default;
+
   /**
    * Either proxy an UpdateSessionRequest gRPC call to the cloud
    * or send the request to the local PCRF/OCS on the gateway

--- a/lte/gateway/c/session_manager/SpgwServiceClient.h
+++ b/lte/gateway/c/session_manager/SpgwServiceClient.h
@@ -30,6 +30,8 @@ using namespace lte;
  */
 class SpgwServiceClient {
  public:
+  virtual ~SpgwServiceClient() = default;
+
   /**
    * Delete a default bearer (all session bearers)
    * @param imsi - msi to identify a UE

--- a/lte/gateway/c/session_manager/test/SessiondMocks.h
+++ b/lte/gateway/c/session_manager/test/SessiondMocks.h
@@ -203,7 +203,7 @@ class MockDirectorydClient : public DirectorydClient {
       void(std::function<void(Status status, AllDirectoryRecords)> callback));
 };
 
-class MockEventdClient : public AsyncEventdClient {
+class MockEventdClient : public EventdClient {
  public:
   MOCK_METHOD2(
       log_event, void(

--- a/orc8r/gateway/c/common/eventd/EventdClient.cpp
+++ b/orc8r/gateway/c/common/eventd/EventdClient.cpp
@@ -37,7 +37,7 @@ AsyncEventdClient::AsyncEventdClient() {
 void AsyncEventdClient::log_event(
     const Event& request, std::function<void(Status status, Void)> callback) {
   auto local_response =
-      new AsyncLocalResponse<Void>(std::move(callback), RESPONSE_TIMEOUT);
+      new AsyncLocalResponse<Void>(std::move(callback), RESPONSE_TIMEOUT_SEC);
   local_response->set_response_reader(std::move(
       stub_->AsyncLogEvent(local_response->get_context(), request, &queue_)));
 }

--- a/orc8r/gateway/c/common/eventd/EventdClient.h
+++ b/orc8r/gateway/c/common/eventd/EventdClient.h
@@ -25,24 +25,34 @@ using grpc::Status;
 namespace magma {
 
 /**
- * AsyncEventdClient sends asynchronous calls to eventd
+ * Base class for interfacing with EventD
+ */
+class EventdClient {
+ public:
+  virtual ~EventdClient() = default;
+  virtual void log_event(
+      const orc8r::Event& request,
+      std::function<void(Status status, orc8r::Void)> callback) = 0;
+};
+
+/**
+ * AsyncEventdClient sends asynchronous calls to EventD
  * to log events
  */
-class AsyncEventdClient : public GRPCReceiver {
+class AsyncEventdClient : public GRPCReceiver, public EventdClient {
  public:
   AsyncEventdClient(AsyncEventdClient const&) = delete;
   void operator=(AsyncEventdClient const&) = delete;
 
   static AsyncEventdClient& getInstance();
 
-  // Logs an event
   void log_event(
       const orc8r::Event& request,
       std::function<void(Status status, orc8r::Void)> callback);
 
  private:
   AsyncEventdClient();
-  static const uint32_t RESPONSE_TIMEOUT = 6;  // seconds
+  static const uint32_t RESPONSE_TIMEOUT_SEC = 6;
   std::unique_ptr<orc8r::EventService::Stub> stub_{};
 };
 


### PR DESCRIPTION
<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary
* Add a EventClient base class that AsyncEventClient inherits from. This way, the class we mock in tests have virtual methods. (The way we're currently using gmock for EventdClient is undocumented :o ) https://github.com/google/googletest/blob/master/docs/gmock_for_dummies.md#writing-the-mock-class
* `RESPONSE_TIMEOUT` -> `RESPONSE_TIMEOUT_SEC` to be more descriptive
* For any class with virtual methods, setup a default virtual destructor. (More info: https://stackoverflow.com/questions/461203/when-to-use-virtual-destructors)

<!-- Enumerate changes you made and why you made them -->

## Test Plan
make test in AGW + S1AP tests to make sure event logging still works
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
