### PR TITLE
[feg]Changes to push FEG docker images (gateway_go|gateway_python) to new JFROG repo

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -227,7 +227,7 @@ commands:
       - run: |
           if [ "${CIRCLE_BRANCH}" != "master" ]; then
             echo "Push only happens for master branch"
-            #exit 0
+            exit 0
           fi
 
           DOCKER_REGISTRY="<< parameters.registry >>"
@@ -641,8 +641,7 @@ jobs:
       - tag-push-docker:
           project: feg
           images: "gateway_go|gateway_python"
-          tag: test
-          registry: $FEGTEST_JFROG_DOCKER_REGISTRY
+          registry: $JFROG_DOCKER_FEG_REGISTRY
           username: $JFROG_USERNAME
           password: $JFROG_PASSWORD
       - persist-githash-version:
@@ -1068,6 +1067,31 @@ jobs:
 workflows:
   version: 2
 
+  cloud:
+    jobs:
+      - insync-checkin
+      - cloud_lint
+      - cloud-test
+      - orc8r-build:
+          requires:
+            - insync-checkin
+            - cloud_lint
+            - cloud-test
+
+  lib_gateway:
+    jobs:
+      - orc8r-gateway-test
+
+  agw:
+    jobs:
+      - lte-test
+      - lte-integ-test:
+          <<: *master_and_develop
+      - lte-agw-deploy:
+          <<: *only_master
+          requires:
+            - lte-integ-test
+
   feg:
     jobs:
       - feg-precommit
@@ -1075,3 +1099,76 @@ workflows:
           requires:
             - feg-precommit
 
+  cwag:
+    jobs:
+      - cwag-precommit
+      - cwf-integ-test:
+          <<: *master_and_develop
+      - xwfm-test:
+          <<: *master_and_develop
+      - cwag-deploy:
+          <<: *only_master
+          requires:
+            - cwag-precommit
+            - cwf-integ-test
+      - xwfm-deploy:
+          <<: *only_master
+          name: xwfm-deploy-latest
+          requires:
+            - cwag-deploy
+            - xwfm-test
+          tag-latest: true
+      - cwag-deploy:
+          <<: *only_master
+          name: cwag-deploy-latest
+          requires:
+            - cwag-deploy
+            - xwfm-deploy-latest
+          images: 'gateway_python|gateway_pipelined|gateway_go'
+          tag-latest: true
+
+
+  cwf_operator:
+    jobs:
+      - cwf-operator-precommit
+      - cwf-operator-build:
+          requires:
+            - cwf-operator-precommit
+
+  hourly_xwfm:
+    triggers:
+      - schedule:
+          cron: "0 * * * *"
+          <<: *only_master
+    jobs:
+      - xwfm-test:
+          notify_magma_ci: false
+
+  nms:
+    jobs:
+      - nms-flow-test
+      - eslint
+      - nms-yarn-test:
+          requires:
+            - nms-flow-test
+      - nms-e2e-test:
+          requires:
+            - nms-flow-test
+            - eslint
+            - nms-yarn-test
+      - nms-build:
+          requires:
+            - nms-flow-test
+            - eslint
+            - nms-yarn-test
+            - nms-e2e-test
+
+  docusaurus:
+   jobs:
+    - docusaurus_build_and_deploy:
+        <<: *only_master
+
+  fossa:
+    jobs:
+      - fossa-analyze:
+          <<: *only_master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -643,7 +643,7 @@ jobs:
           images: "gateway_go|gateway_python"
           tag: test
           registry: $FEGTEST_JFROG_DOCKER_REGISTRY
-          username: $JFROM_USERNAME
+          username: $JFROG_USERNAME
           password: $JFROG_PASSWORD
       - persist-githash-version:
           file_prefix: feg

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -227,7 +227,7 @@ commands:
       - run: |
           if [ "${CIRCLE_BRANCH}" != "master" ]; then
             echo "Push only happens for master branch"
-            exit 0
+            #exit 0
           fi
 
           DOCKER_REGISTRY="<< parameters.registry >>"
@@ -641,6 +641,7 @@ jobs:
       - tag-push-docker:
           project: feg
           images: "gateway_go|gateway_python"
+          tag: test
           registry: $FEGTEST_JFROG_DOCKER_REGISTRY
           username: $JFROM_USERNAME
           password: $JFROG_PASSWORD
@@ -1067,31 +1068,6 @@ jobs:
 workflows:
   version: 2
 
-  cloud:
-    jobs:
-      - insync-checkin
-      - cloud_lint
-      - cloud-test
-      - orc8r-build:
-          requires:
-            - insync-checkin
-            - cloud_lint
-            - cloud-test
-
-  lib_gateway:
-    jobs:
-      - orc8r-gateway-test
-
-  agw:
-    jobs:
-      - lte-test
-      - lte-integ-test:
-          <<: *master_and_develop
-      - lte-agw-deploy:
-          <<: *only_master
-          requires:
-            - lte-integ-test
-
   feg:
     jobs:
       - feg-precommit
@@ -1099,76 +1075,3 @@ workflows:
           requires:
             - feg-precommit
 
-  cwag:
-    jobs:
-      - cwag-precommit
-      - cwf-integ-test:
-          <<: *master_and_develop
-      - xwfm-test:
-          <<: *master_and_develop
-      - cwag-deploy:
-          <<: *only_master
-          requires:
-            - cwag-precommit
-            - cwf-integ-test
-      - xwfm-deploy:
-          <<: *only_master
-          name: xwfm-deploy-latest
-          requires:
-            - cwag-deploy
-            - xwfm-test
-          tag-latest: true
-      - cwag-deploy:
-          <<: *only_master
-          name: cwag-deploy-latest
-          requires:
-            - cwag-deploy
-            - xwfm-deploy-latest
-          images: 'gateway_python|gateway_pipelined|gateway_go'
-          tag-latest: true
-
-
-  cwf_operator:
-    jobs:
-      - cwf-operator-precommit
-      - cwf-operator-build:
-          requires:
-            - cwf-operator-precommit
-
-  hourly_xwfm:
-    triggers:
-      - schedule:
-          cron: "0 * * * *"
-          <<: *only_master
-    jobs:
-      - xwfm-test:
-          notify_magma_ci: false
-
-  nms:
-    jobs:
-      - nms-flow-test
-      - eslint
-      - nms-yarn-test:
-          requires:
-            - nms-flow-test
-      - nms-e2e-test:
-          requires:
-            - nms-flow-test
-            - eslint
-            - nms-yarn-test
-      - nms-build:
-          requires:
-            - nms-flow-test
-            - eslint
-            - nms-yarn-test
-            - nms-e2e-test
-
-  docusaurus:
-   jobs:
-    - docusaurus_build_and_deploy:
-        <<: *only_master
-
-  fossa:
-    jobs:
-      - fossa-analyze:
-          <<: *only_master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -638,6 +638,12 @@ jobs:
           project: feg
           images: "gateway_go|gateway_python"
           registry: $DOCKER_FEG_REGISTRY
+      - tag-push-docker:
+          project: feg
+          images: "gateway_go|gateway_python"
+          registry: $FEGTEST_JFROG_DOCKER_REGISTRY
+          username: $JFROM_USERNAME
+          password: $JFROG_PASSWORD
       - persist-githash-version:
           file_prefix: feg
       - notify-magma:


### PR DESCRIPTION
<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary
[feg]Changes to push FEG docker images (gateway_go|gateway_python) to new JFROG repo
Created new environment variables in CircleCi for the new jfrog repo - JFROG_DOCKER_FEG_REGISTRY, JFROG_USERNAME, JFROG_PASSWORD
Updated the circle config file to push the feg images to new jfrog repo

<!-- Enumerate changes you made and why you made them -->

## Test Plan
Tested by mocking changes in circleci config to push images of feg to new jfrog repo. The below links have details and can be reviewed for test case evidence:

**CircleCI job execution:**
https://app.circleci.com/pipelines/github/magma/magma/16535/workflows/42ca1197-a230-4199-b489-c7366a304bf9/jobs/154820

**FEG images pushed to the jfrog repo:**
https://feg-test.artifactory.magmacore.org/ui/repos/tree/General/feg-test%2Fgateway_go%2Ftest

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [NO ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
