### PR TITLE
Add namespace in kubectl commands

### DIFF
--- a/docs/readmes/faq/faq_magma.md
+++ b/docs/readmes/faq/faq_magma.md
@@ -84,9 +84,9 @@ This section lists some of the commonly asked questions related to Magma operati
 
 ## Orchestrator
 ### How can I check production pods in Orchestrator running on Kubernetes?
-  - **For all pods:** `kubectl -n magma get pods`.
-  - **Logs of a particular pod:** `kubectl -n magma logs -f <CONTROLLER PODNAME>`.
-  - **NOTE:** In above commands, please use the actual namespace after `-n` you have chosen to install orc8r in.
+  - **For all pods:** `kubectl --namespace orc8r get pods`.
+  - **Logs of a particular pod:** `kubectl --namespace orc8r logs -f <CONTROLLER PODNAME>`.
+  - **NOTE:** In above commands, please use the actual namespace after `--namespace` you have chosen to install orc8r in.
 
 ### How can I test Orchestrator connection with Gateway?
   - Login to Gateway, then run `sudo checkin_cli.py`.
@@ -102,13 +102,13 @@ This section lists some of the commonly asked questions related to Magma operati
   - Put in the required inputs and click **Execute**.
 
 ### How can I check the services running in Orchestrator?
-  - List the running pods with `kubectl -norc8r get pods`
+  - List the running pods with `kubectl --namespace orc8r get pods`
   - Grab the name of orc8r-controller pods, they are in the format `orc8r-controller-xxxxxxxxxx-yyyyy`
-  - Collect the state of services on each pod: `kubectl -norc8r exec orc8r-controller-xxxxxxxxxx-yyyyy  bash -- supervisorctl status`
+  - Collect the state of services on each pod: `kubectl --namespace orc8r exec orc8r-controller-xxxxxxxxxx-yyyyy  bash -- supervisorctl status`
 
 ### How to verify which services are running in Orc8r-controller?
-  - **Get the controller pods:** `kubectl -n magma get pods`.
-  - **Execute the command in the pod:** `kubectl exec -n magma <CONTROLLER PODNAME> supervisorctl status`.
+  - **Get the controller pods:** `kubectl --namespace orc8r get pods`.
+  - **Execute the command in the pod:** `kubectl --namespace orc8r exec <CONTROLLER PODNAME> supervisorctl status`.
 
 ## NMS
 ### What is an NMS (Network Management System)?

--- a/docs/readmes/howtos/thanos.md
+++ b/docs/readmes/howtos/thanos.md
@@ -13,8 +13,8 @@ with Thanos in order to have a more robust metrics pipeline.
 
 ## Deploying Orc8r with Thanos
 
-The terraform module makes deploying Thanos very easy. In your `main.tf` you 
-just need to set the following values: 
+The terraform module makes deploying Thanos very easy. In your `main.tf` you
+just need to set the following values:
 
 ```
 module orc8r {
@@ -27,14 +27,14 @@ module orc8r-app {
 }
 ```
 
-Choose a value for `thanos_object_store_bucket_name` that will be globally 
+Choose a value for `thanos_object_store_bucket_name` that will be globally
 (across all of AWS) unique, but other than that the value doesn't matter.
 
-That's all you need to do to deploy with Thanos! All interacting components 
+That's all you need to do to deploy with Thanos! All interacting components
 will be adjusted accordingly, so the NMS/Grafana will work the same as before.
 If you don't care about the internals you can stop reading here.
 
-If you run `kubectl -n orc8r get pods` it should now look like this:
+If you run `kubectl --namespace orc8r get pods` it should now look like this:
 ```
 NAME                                             READY   STATUS    RESTARTS   AGE
 fluentd-6fb9f57dff-ljmfw                         1/1     Running   0          24h
@@ -64,9 +64,9 @@ that run independently: compact, query, and store.
 ## Advanced configuration options
 
 The default infrastructure setup deploys an additional node for Thanos, since
-there is one component that requires significant on-node ephemeral storage. 
+there is one component that requires significant on-node ephemeral storage.
 However, you may want to deploy more nodes if you want to make sure thanos
-components run on different nodes than the rest of orc8r. To do that you can 
+components run on different nodes than the rest of orc8r. To do that you can
 override the default value for `thanos_worker_groups` in the `orc8r` module.
 The default value is:
 ```
@@ -84,7 +84,7 @@ The default value is:
 ```
 
 To add more workers, either adjust the `asg_...` values in that object, or add
-another entry to that array of worker groups. To specify thanos components to 
+another entry to that array of worker groups. To specify thanos components to
 run on specific nodes, just set the following variables in the `orc8r-app` module:
 ```
 thanos_query_node_selector = "thanos"

--- a/docs/readmes/nms/alert.md
+++ b/docs/readmes/nms/alert.md
@@ -214,11 +214,9 @@ Duration:
 In case we are having issues with alerts. Logs from the following services will give more information on debugging this further.
 
 ```
-kubectl logs -n orc8r -l [app.kubernetes.io/component=alertmanager](http://app.kubernetes.io/component=alertmanager)
-kubectl logs -n orc8r -l [app.kubernetes.io/component=alertmanager-configurer](http://app.kubernetes.io/component=alertmanager-configurer)
-kubectl logs -n orc8r -l app.kubernetes.io/component=prometheus-configurer -c prometheus-configurer
-kubectl logs -n orc8r -l app.kubernetes.io/component=prometheus -c prometheus
-kubectl logs -n orc8r -l app.kubernetes.io/component=metricsd
+kubectl --namespace orc8r logs -l [app.kubernetes.io/component=alertmanager](http://app.kubernetes.io/component=alertmanager)
+kubectl --namespace orc8r logs -l [app.kubernetes.io/component=alertmanager-configurer](http://app.kubernetes.io/component=alertmanager-configurer)
+kubectl --namespace orc8r logs -l app.kubernetes.io/component=prometheus-configurer -c prometheus-configurer
+kubectl --namespace orc8r logs -l app.kubernetes.io/component=prometheus -c prometheus
+kubectl --namespace orc8r logs -l app.kubernetes.io/component=metricsd
 ```
-
-

--- a/docs/readmes/nms/metrics.md
+++ b/docs/readmes/nms/metrics.md
@@ -187,8 +187,8 @@ ERROR:root:Metrics upload error! [StatusCode.UNKNOWN] rpc error: code = Unavaila
 
 On the orc8r, we can debug the issues by dumping the logs on prometheus, prometheus-configmanager, prometheus-cache and metricsd
 ```
-kubectl logs -n orc8r -l app.kubernetes.io/component=prometheus-configurer -c prometheus-configurer
-kubectl logs -n orc8r -l app.kubernetes.io/component=prometheus -c prometheus
-kubectl logs -n orc8r -l app.kubernetes.io/component=metricsd
+kubectl --namespace orc8r logs -l app.kubernetes.io/component=prometheus-configurer -c prometheus-configurer
+kubectl --namespace orc8r logs -l app.kubernetes.io/component=prometheus -c prometheus
+kubectl --namespace orc8r logs -l app.kubernetes.io/component=metricsd
 helm --debug -n orc8r get values orc8r
 ```

--- a/docs/readmes/orc8r/deploy_faq.md
+++ b/docs/readmes/orc8r/deploy_faq.md
@@ -22,8 +22,8 @@ Error: rpc error: code = Unknown desc = release orc8r failed: timed out waiting 
 - Run following kubectl commands to get more details on the error encountered
 
 ```
-kubectl -n orc8r get pods
-kubectl -n orc8r describe pods
+kubectl --namespace orc8r get pods
+kubectl --namespace orc8r describe pods
 # pod status ImagePullBackOff, indicates that Image wasn't found
 # pod can also be crash looping, pod status will provide this information,
 # in this case, looking at the logs of individual container will help debug this further

--- a/docs/readmes/orc8r/deploy_install.md
+++ b/docs/readmes/orc8r/deploy_install.md
@@ -239,15 +239,15 @@ Create the Orchestrator admin user with the `admin_operator` certificate
 created earlier
 
 ```bash
-export ORC_POD=$(kubectl get pod -n orc8r -l app.kubernetes.io/component=orchestrator -o jsonpath='{.items[0].metadata.name}')
-kubectl -n orc8r exec ${ORC_POD} -- envdir /var/opt/magma/envdir /var/opt/magma/bin/accessc add-existing -admin -cert /var/opt/magma/certs/admin_operator.pem admin_operator
+export ORC_POD=$(kubectl --namespace orc8r get pod -l app.kubernetes.io/component=orchestrator -o jsonpath='{.items[0].metadata.name}')
+kubectl --namespace orc8r exec ${ORC_POD} -- envdir /var/opt/magma/envdir /var/opt/magma/bin/accessc add-existing -admin -cert /var/opt/magma/certs/admin_operator.pem admin_operator
 ```
 
 If you want to verify the admin user was successfully created, inspect the
 output from
 
 ```bash
-$ kubectl -n orc8r exec ${ORC_POD} -- envdir /var/opt/magma/envdir /var/opt/magma/bin/accessc list-certs
+$ kubectl --namespace orc8r exec ${ORC_POD} -- envdir /var/opt/magma/envdir /var/opt/magma/bin/accessc list-certs
 
 # NOTE: actual values will differ
 Serial Number: 83550F07322CEDCD; Identity: Id_Operator_admin_operator; Not Before: 2020-06-26 22:39:55 +0000 UTC; Not After: 2030-06-24 22:39:55 +0000 UTC
@@ -264,8 +264,8 @@ also need to add a new admin user with the updated `admin_operator` cert.
 Create an admin user for the `master` organization on the NMS
 
 ```bash
-export NMS_POD=$(kubectl -n orc8r get pod -l  app.kubernetes.io/component=magmalte -o jsonpath='{.items[0].metadata.name}')
-kubectl -n orc8r exec -it ${NMS_POD} -- yarn setAdminPassword master ADMIN_USER_EMAIL ADMIN_USER_PASSWORD
+export NMS_POD=$(kubectl --namespace orc8r get pod -l  app.kubernetes.io/component=magmalte -o jsonpath='{.items[0].metadata.name}')
+kubectl --namespace orc8r exec -it ${NMS_POD} -- yarn setAdminPassword master ADMIN_USER_EMAIL ADMIN_USER_PASSWORD
 ```
 
 ## DNS Resolution
@@ -334,7 +334,7 @@ API. Remember to include `https://`, as well as the port number for
 non-standard TLS ports.
 
 ```bash
-$ kubectl get services
+$ kubectl --namespace orc8r get services
 
 # NOTE: values will differ, e.g. the EXTERNAL-IP column
 NAME                            TYPE           CLUSTER-IP       EXTERNAL-IP                       PORT(S)                                                     AGE

--- a/docs/readmes/orc8r/upgrade_1_1.md
+++ b/docs/readmes/orc8r/upgrade_1_1.md
@@ -157,8 +157,8 @@ and will not affect the v1.0 deployment.
 
 ```bash
 # Replace orc8r with your v1.1 k8s namespace if you changed the name
-$ export CNTLR_POD=$(kubectl -n orc8r get pod -l app.kubernetes.io/component=controller -o jsonpath='{.items[0].metadata.name}')
-$ kubectl exec -it ${CNTLR_POD} bash
+$ export CNTLR_POD=$(kubectl --namespace orc8r get pod -l app.kubernetes.io/component=controller -o jsonpath='{.items[0].metadata.name}')
+$ kubectl --namespace orc8r exec -it ${CNTLR_POD} bash
 
 (pod)$ cd /var/opt/magma/bin
 (pod)$ ./m005_certifier_to_blobstore -verify
@@ -193,8 +193,8 @@ create a new admin user in the `master` organization to set up access for
 other tenants:
 
 ```bash
-kubectl exec -it -n magma \
-    $(kubectl -n magma get pod -l app.kubernetes.io/component=magmalte -o jsonpath='{.items[0].metadata.name}') -- \
+kubectl --namespace orc8r exec -it \
+    $(kubectl --namespace orc8r get pod -l app.kubernetes.io/component=magmalte -o jsonpath='{.items[0].metadata.name}') -- \
     yarn setAdminPassword master ADMIN_USER_EMAIL ADMIN_USER_PASSWORD
 ```
 

--- a/docs/readmes/orc8r/upgrade_1_2.md
+++ b/docs/readmes/orc8r/upgrade_1_2.md
@@ -163,8 +163,8 @@ after the non-reversible schema change you will need to upgrade to v1.2 or fall
 back to a DB checkpoint.
 
 ```bash
-$ export CNTLR_POD=$(kubectl get pod -l app.kubernetes.io/component=controller -o jsonpath='{.items[0].metadata.name}')
-$ kubectl exec -it ${CNTLR_POD} -- bash
+$ export CNTLR_POD=$(kubectl --namespace orc8r get pod -l app.kubernetes.io/component=controller -o jsonpath='{.items[0].metadata.name}')
+$ kubectl --namespace orc8r exec -it ${CNTLR_POD} -- bash
 
 (pod)$ cd /var/opt/magma/bin
 

--- a/docs/readmes/orc8r/upgrade_1_3.md
+++ b/docs/readmes/orc8r/upgrade_1_3.md
@@ -68,7 +68,7 @@ Before upgrading the deployment, manually scale the Prometheus pods to 0
 replicas, otherwise the Prometheus version upgrade in this release will fail:
 
 ```bash
-kubectl scale deployment orc8r-prometheus --replicas=0
+kubectl --namespace orc8r scale deployment orc8r-prometheus --replicas=0
 
 terraform apply     # Check this output VERY carefully!
 ```
@@ -81,8 +81,8 @@ upgraded and Prometheus should be back up on v2.20.1.
 > **_NOTE:_** If you're upgrading to release tag v1.3.0 specifically, `m014_enodeb_config` is not required.
 
 ```
-$ export CNTLR_POD=$(kubectl get pod -l app.kubernetes.io/component=controller -o jsonpath='{.items[0].metadata.name}')
-$ kubectl exec -it ${CNTLR_POD} -- bash
+$ export CNTLR_POD=$(kubectl --namespace orc8r get pod -l app.kubernetes.io/component=controller -o jsonpath='{.items[0].metadata.name}')
+$ kubectl --namespace orc8r exec -it ${CNTLR_POD} -- bash
 
 (pod)$ cd /var/opt/magma/bin
 

--- a/docs/readmes/orc8r/upgrade_1_4.md
+++ b/docs/readmes/orc8r/upgrade_1_4.md
@@ -92,7 +92,7 @@ a separate terminal tab and manually scale the Prometheus deployment. You can
 re-run the Terraform command if it times out.
 
 ```bash
-kubectl -n orc8r scale deployment orc8r-prometheus --replicas=0 && kubectl -n orc8r scale deployment orc8r-prometheus --replicas=1
+kubectl --namespace orc8r scale deployment orc8r-prometheus --replicas=0 && kubectl --namespace orc8r scale deployment orc8r-prometheus --replicas=1
 ```
 
 After the Terraform command completes, all application components should be


### PR DESCRIPTION
Signed-off-by: Wally Rodriguez B <wallyrb@fb.com>


## Summary

1. Adding namespace "orc8r" in kubectl commands for master documentation
2. In FAQ, fixing misspelling in the kubectl commands

## Test Plan

tested locally with create_docusaurus_website.sh  