### PR TITLE
[SessionD] Remove boolean return values from PipelinedClient

### DIFF
--- a/lte/gateway/c/session_manager/LocalEnforcer.h
+++ b/lte/gateway/c/session_manager/LocalEnforcer.h
@@ -110,7 +110,7 @@ class LocalEnforcer {
    * Setup rules for all sessions in pipelined, used whenever pipelined
    * restarts and needs to recover state
    */
-  bool setup(
+  void setup(
       SessionMap& session_map, const std::uint64_t& epoch,
       std::function<void(Status status, SetupFlowsResult)> callback);
 

--- a/lte/gateway/c/session_manager/PipelinedClient.cpp
+++ b/lte/gateway/c/session_manager/PipelinedClient.cpp
@@ -209,7 +209,7 @@ AsyncPipelinedClient::AsyncPipelinedClient()
     : AsyncPipelinedClient(ServiceRegistrySingleton::Instance()->GetGrpcChannel(
           "pipelined", ServiceRegistrySingleton::LOCAL)) {}
 
-bool AsyncPipelinedClient::setup_cwf(
+void AsyncPipelinedClient::setup_cwf(
     const std::vector<SessionState::SessionInfo>& infos,
     const std::vector<SubscriberQuotaUpdate>& quota_updates,
     const std::vector<std::string> ue_mac_addrs,
@@ -230,10 +230,9 @@ bool AsyncPipelinedClient::setup_cwf(
   setup_ue_mac_rpc(setup_ue_mac_req, callback);
 
   update_subscriber_quota_state(quota_updates);
-  return true;
 }
 
-bool AsyncPipelinedClient::setup_lte(
+void AsyncPipelinedClient::setup_lte(
     const std::vector<SessionState::SessionInfo>& infos,
     const std::uint64_t& epoch,
     std::function<void(Status status, SetupFlowsResult)> callback) {
@@ -241,19 +240,17 @@ bool AsyncPipelinedClient::setup_lte(
   setup_default_controllers_rpc(setup_default_req, callback);
   SetupPolicyRequest setup_policy_req = create_setup_policy_req(infos, epoch);
   setup_policy_rpc(setup_policy_req, callback);
-  return true;
 }
 
 // Method to Setup UPF Session
-bool AsyncPipelinedClient::set_upf_session(
+void AsyncPipelinedClient::set_upf_session(
     const SessionState::SessionInfo info,
     std::function<void(Status status, UPFSessionContextState)> callback) {
   SessionSet setup_session_req = create_session_set_req(info);
   set_upf_session_rpc(setup_session_req, callback);
-  return true;
 }
 
-bool AsyncPipelinedClient::deactivate_all_flows(const std::string& imsi) {
+void AsyncPipelinedClient::deactivate_all_flows(const std::string& imsi) {
   DeactivateFlowsRequest req;
   req.mutable_sid()->set_id(imsi);
   MLOG(MDEBUG) << "Deactivating all flows for subscriber " << imsi;
@@ -263,10 +260,9 @@ bool AsyncPipelinedClient::deactivate_all_flows(const std::string& imsi) {
                    << ": " << status.error_message();
     }
   });
-  return true;
 }
 
-bool AsyncPipelinedClient::deactivate_flows_for_rules_for_termination(
+void AsyncPipelinedClient::deactivate_flows_for_rules_for_termination(
     const std::string& imsi, const std::string& ip_addr,
     const std::string& ipv6_addr, const Teids teids,
     const std::vector<std::string>& rule_ids,
@@ -281,10 +277,10 @@ bool AsyncPipelinedClient::deactivate_flows_for_rules_for_termination(
   auto req = create_deactivate_req(
       imsi, ip_addr, ipv6_addr, teids, rule_ids, dynamic_rules, origin_type,
       true);
-  return deactivate_flows(req);
+  deactivate_flows(req);
 }
 
-bool AsyncPipelinedClient::deactivate_flows_for_rules(
+void AsyncPipelinedClient::deactivate_flows_for_rules(
     const std::string& imsi, const std::string& ip_addr,
     const std::string& ipv6_addr, const Teids teids,
     const std::vector<std::string>& rule_ids,
@@ -297,10 +293,10 @@ bool AsyncPipelinedClient::deactivate_flows_for_rules(
   auto req = create_deactivate_req(
       imsi, ip_addr, ipv6_addr, teids, rule_ids, dynamic_rules, origin_type,
       false);
-  return deactivate_flows(req);
+  deactivate_flows(req);
 }
 
-bool AsyncPipelinedClient::deactivate_flows(DeactivateFlowsRequest& request) {
+void AsyncPipelinedClient::deactivate_flows(DeactivateFlowsRequest& request) {
   auto imsi = request.sid().id();
   deactivate_flows_rpc(
       request, [imsi](Status status, DeactivateFlowsResult resp) {
@@ -309,10 +305,9 @@ bool AsyncPipelinedClient::deactivate_flows(DeactivateFlowsRequest& request) {
                        << ": " << status.error_message();
         }
       });
-  return true;
 }
 
-bool AsyncPipelinedClient::activate_flows_for_rules(
+void AsyncPipelinedClient::activate_flows_for_rules(
     const std::string& imsi, const std::string& ip_addr,
     const std::string& ipv6_addr, const Teids teids, const std::string& msisdn,
     const optional<AggregatedMaximumBitrate>& ambr,
@@ -345,10 +340,9 @@ bool AsyncPipelinedClient::activate_flows_for_rules(
         dynamic_rules, RequestOriginType::GX);
     activate_flows_rpc(req, callback);
   }
-  return true;
 }
 
-bool AsyncPipelinedClient::add_ue_mac_flow(
+void AsyncPipelinedClient::add_ue_mac_flow(
     const SubscriberID& sid, const std::string& ue_mac_addr,
     const std::string& msisdn, const std::string& ap_mac_addr,
     const std::string& ap_name,
@@ -356,10 +350,9 @@ bool AsyncPipelinedClient::add_ue_mac_flow(
   auto req = create_add_ue_mac_flow_req(
       sid, ue_mac_addr, msisdn, ap_mac_addr, ap_name, 0);
   add_ue_mac_flow_rpc(req, callback);
-  return true;
 }
 
-bool AsyncPipelinedClient::update_ipfix_flow(
+void AsyncPipelinedClient::update_ipfix_flow(
     const SubscriberID& sid, const std::string& ue_mac_addr,
     const std::string& msisdn, const std::string& ap_mac_addr,
     const std::string& ap_name, const uint64_t& pdp_start_time) {
@@ -371,10 +364,9 @@ bool AsyncPipelinedClient::update_ipfix_flow(
                    << ue_mac_addr << ": " << status.error_message();
     }
   });
-  return true;
 }
 
-bool AsyncPipelinedClient::delete_ue_mac_flow(
+void AsyncPipelinedClient::delete_ue_mac_flow(
     const SubscriberID& sid, const std::string& ue_mac_addr) {
   auto req = create_delete_ue_mac_flow_req(sid, ue_mac_addr);
   delete_ue_mac_flow_rpc(req, [ue_mac_addr](Status status, FlowResponse resp) {
@@ -383,10 +375,9 @@ bool AsyncPipelinedClient::delete_ue_mac_flow(
                    << ue_mac_addr << ": " << status.error_message();
     }
   });
-  return true;
 }
 
-bool AsyncPipelinedClient::update_subscriber_quota_state(
+void AsyncPipelinedClient::update_subscriber_quota_state(
     const std::vector<SubscriberQuotaUpdate>& updates) {
   auto req = create_subscriber_quota_state_req(updates);
   update_subscriber_quota_state_rpc(req, [](Status status, FlowResponse resp) {
@@ -394,10 +385,9 @@ bool AsyncPipelinedClient::update_subscriber_quota_state(
       MLOG(MERROR) << "Could send quota update " << status.error_message();
     }
   });
-  return true;
 }
 
-bool AsyncPipelinedClient::add_gy_final_action_flow(
+void AsyncPipelinedClient::add_gy_final_action_flow(
     const std::string& imsi, const std::string& ip_addr,
     const std::string& ipv6_addr, const Teids teids, const std::string& msisdn,
     const std::vector<std::string>& static_rules,
@@ -423,7 +413,6 @@ bool AsyncPipelinedClient::add_gy_final_action_flow(
                        << imsi << ": " << status.error_message();
         }
       });
-  return true;
 }
 
 // RPC definition to Send Set Session request to UPF

--- a/lte/gateway/c/session_manager/PipelinedClient.h
+++ b/lte/gateway/c/session_manager/PipelinedClient.h
@@ -42,9 +42,8 @@ class PipelinedClient {
   /**
    * Activates all rules for provided SessionInfos
    * @param infos - list of SessionInfos to setup flows for
-   * @return true if the operation was successful
    */
-  virtual bool setup_cwf(
+  virtual void setup_cwf(
       const std::vector<SessionState::SessionInfo>& infos,
       const std::vector<SubscriberQuotaUpdate>& quota_updates,
       const std::vector<std::string> ue_mac_addrs,
@@ -58,9 +57,8 @@ class PipelinedClient {
   /**
    * Activates all rules for provided SessionInfos
    * @param infos - list of SessionInfos to setup flows for
-   * @return true if the operation was successful
    */
-  virtual bool setup_lte(
+  virtual void setup_lte(
       const std::vector<SessionState::SessionInfo>& infos,
       const std::uint64_t& epoch,
       std::function<void(Status status, SetupFlowsResult)> callback) = 0;
@@ -68,18 +66,16 @@ class PipelinedClient {
   /**
    * Deactivate all flows for a subscriber's session
    * @param imsi - UE to delete all policy flows for
-   * @return true if the operation was successful
    */
-  virtual bool deactivate_all_flows(const std::string& imsi) = 0;
+  virtual void deactivate_all_flows(const std::string& imsi) = 0;
 
   /**
    * Deactivate all flows for the specified rules plus any drop default rule
    * added by pipelined
    * @param imsi - UE to delete flows for
    * @param rule_ids - rules to deactivate
-   * @return true if the operation was successful
    */
-  virtual bool deactivate_flows_for_rules_for_termination(
+  virtual void deactivate_flows_for_rules_for_termination(
       const std::string& imsi, const std::string& ip_addr,
       const std::string& ipv6_addr, const Teids teids,
       const std::vector<std::string>& rule_ids,
@@ -90,9 +86,8 @@ class PipelinedClient {
    * Deactivate all flows for the specified rules
    * @param imsi - UE to delete flows for
    * @param rule_ids - rules to deactivate
-   * @return true if the operation was successful
    */
-  virtual bool deactivate_flows_for_rules(
+  virtual void deactivate_flows_for_rules(
       const std::string& imsi, const std::string& ip_addr,
       const std::string& ipv6_addr, const Teids teids,
       const std::vector<std::string>& rule_ids,
@@ -102,7 +97,7 @@ class PipelinedClient {
   /**
    * Activate all rules for the specified rules, using a normal vector
    */
-  virtual bool activate_flows_for_rules(
+  virtual void activate_flows_for_rules(
       const std::string& imsi, const std::string& ip_addr,
       const std::string& ipv6_addr, const Teids teids,
       const std::string& msisdn, const optional<AggregatedMaximumBitrate>& ambr,
@@ -114,7 +109,7 @@ class PipelinedClient {
    * Send the MAC address of UE and the subscriberID
    * for pipelined to add a flow for the subscriber by matching the MAC
    */
-  virtual bool add_ue_mac_flow(
+  virtual void add_ue_mac_flow(
       const SubscriberID& sid, const std::string& ue_mac_addr,
       const std::string& msisdn, const std::string& ap_mac_addr,
       const std::string& ap_name,
@@ -123,7 +118,7 @@ class PipelinedClient {
   /**
    * Update the IPFIX export rule in pipeliend
    */
-  virtual bool update_ipfix_flow(
+  virtual void update_ipfix_flow(
       const SubscriberID& sid, const std::string& ue_mac_addr,
       const std::string& msisdn, const std::string& ap_mac_addr,
       const std::string& ap_name, const uint64_t& pdp_start_time) = 0;
@@ -132,19 +127,19 @@ class PipelinedClient {
    * Send the MAC address of UE and the subscriberID
    * for pipelined to delete a flow for the subscriber by matching the MAC
    */
-  virtual bool delete_ue_mac_flow(
+  virtual void delete_ue_mac_flow(
       const SubscriberID& sid, const std::string& ue_mac_addr) = 0;
 
   /**
    * Propagate whether a subscriber has quota / no quota / or terminated
    */
-  virtual bool update_subscriber_quota_state(
+  virtual void update_subscriber_quota_state(
       const std::vector<SubscriberQuotaUpdate>& updates) = 0;
 
   /**
    * Activate the GY final action policy
    */
-  virtual bool add_gy_final_action_flow(
+  virtual void add_gy_final_action_flow(
       const std::string& imsi, const std::string& ip_addr,
       const std::string& ipv6_addr, const Teids teids,
       const std::string& msisdn, const std::vector<std::string>& static_rules,
@@ -153,7 +148,7 @@ class PipelinedClient {
   /**
    * Set up a Session of type SetMessage to be sent to UPF
    */
-  virtual bool set_upf_session(
+  virtual void set_upf_session(
       const SessionState::SessionInfo info,
       std::function<void(Status status, UPFSessionContextState)> callback) = 0;
 
@@ -176,7 +171,7 @@ class AsyncPipelinedClient : public GRPCReceiver, public PipelinedClient {
    * @param infos - list of SessionInfos to setup flows for
    * @return true if the operation was successful
    */
-  bool setup_cwf(
+  void setup_cwf(
       const std::vector<SessionState::SessionInfo>& infos,
       const std::vector<SubscriberQuotaUpdate>& quota_updates,
       const std::vector<std::string> ue_mac_addrs,
@@ -190,9 +185,8 @@ class AsyncPipelinedClient : public GRPCReceiver, public PipelinedClient {
   /**
    * Activates all rules for provided SessionInfos
    * @param infos - list of SessionInfos to setup flows for
-   * @return true if the operation was successful
    */
-  bool setup_lte(
+  void setup_lte(
       const std::vector<SessionState::SessionInfo>& infos,
       const std::uint64_t& epoch,
       std::function<void(Status status, SetupFlowsResult)> callback);
@@ -200,18 +194,16 @@ class AsyncPipelinedClient : public GRPCReceiver, public PipelinedClient {
   /**
    * Deactivate all flows for a subscriber's session
    * @param imsi - UE to delete all policy flows for
-   * @return true if the operation was successful
    */
-  bool deactivate_all_flows(const std::string& imsi);
+  void deactivate_all_flows(const std::string& imsi);
 
   /**
    * Deactivate all flows related to a specific charging key plus any default
    * rule installed by pipelined. Used for session termination.
    * @param imsi - UE to delete flows for
    * @param charging_key - key to deactivate
-   * @return true if the operation was successful
    */
-  bool deactivate_flows_for_rules_for_termination(
+  void deactivate_flows_for_rules_for_termination(
       const std::string& imsi, const std::string& ip_addr,
       const std::string& ipv6_addr, const Teids teids,
       const std::vector<std::string>& rule_ids,
@@ -222,9 +214,8 @@ class AsyncPipelinedClient : public GRPCReceiver, public PipelinedClient {
    * Deactivate all flows related to a specific charging key
    * @param imsi - UE to delete flows for
    * @param charging_key - key to deactivate
-   * @return true if the operation was successful
    */
-  bool deactivate_flows_for_rules(
+  void deactivate_flows_for_rules(
       const std::string& imsi, const std::string& ip_addr,
       const std::string& ipv6_addr, const Teids teids,
       const std::vector<std::string>& rule_ids,
@@ -234,14 +225,13 @@ class AsyncPipelinedClient : public GRPCReceiver, public PipelinedClient {
   /**
    * Deactivate all flows included on the request
    * @param request
-   * @return true if the operation was successful
    */
-  bool deactivate_flows(DeactivateFlowsRequest& request);
+  void deactivate_flows(DeactivateFlowsRequest& request);
 
   /**
    * Activate all rules for the specified rules, using a normal vector
    */
-  bool activate_flows_for_rules(
+  void activate_flows_for_rules(
       const std::string& imsi, const std::string& ip_addr,
       const std::string& ipv6_addr, const Teids teids,
       const std::string& msisdn, const optional<AggregatedMaximumBitrate>& ambr,
@@ -253,7 +243,7 @@ class AsyncPipelinedClient : public GRPCReceiver, public PipelinedClient {
    * Send the MAC address of UE and the subscriberID
    * for pipelined to add a flow for the subscriber by matching the MAC
    */
-  bool add_ue_mac_flow(
+  void add_ue_mac_flow(
       const SubscriberID& sid, const std::string& ue_mac_addr,
       const std::string& msisdn, const std::string& ap_mac_addr,
       const std::string& ap_name,
@@ -262,7 +252,7 @@ class AsyncPipelinedClient : public GRPCReceiver, public PipelinedClient {
   /**
    * Update the IPFIX export rule in pipeliend
    */
-  bool update_ipfix_flow(
+  void update_ipfix_flow(
       const SubscriberID& sid, const std::string& ue_mac_addr,
       const std::string& msisdn, const std::string& ap_mac_addr,
       const std::string& ap_name, const uint64_t& pdp_start_time);
@@ -270,19 +260,19 @@ class AsyncPipelinedClient : public GRPCReceiver, public PipelinedClient {
   /**
    * Propagate whether a subscriber has quota / no quota / or terminated
    */
-  bool update_subscriber_quota_state(
+  void update_subscriber_quota_state(
       const std::vector<SubscriberQuotaUpdate>& updates);
 
-  bool delete_ue_mac_flow(
+  void delete_ue_mac_flow(
       const SubscriberID& sid, const std::string& ue_mac_addr);
 
-  bool add_gy_final_action_flow(
+  void add_gy_final_action_flow(
       const std::string& imsi, const std::string& ip_addr,
       const std::string& ipv6_addr, const Teids teids,
       const std::string& msisdn, const std::vector<std::string>& static_rules,
       const std::vector<PolicyRule>& dynamic_rules);
 
-  bool set_upf_session(
+  void set_upf_session(
       const SessionState::SessionInfo info,
       std::function<void(Status status, UPFSessionContextState)> callback);
 

--- a/lte/gateway/c/session_manager/test/SessiondMocks.h
+++ b/lte/gateway/c/session_manager/test/SessiondMocks.h
@@ -80,34 +80,13 @@ class MockPipelined final : public Pipelined::Service {
 class MockPipelinedClient : public PipelinedClient {
  public:
   MockPipelinedClient() {
-    ON_CALL(*this, setup_cwf(_, _, _, _, _, _, _, _, _))
-        .WillByDefault(Return(true));
-    ON_CALL(*this, setup_lte(_, _, _)).WillByDefault(Return(true));
-    ON_CALL(*this, deactivate_all_flows(_)).WillByDefault(Return(true));
-    ON_CALL(*this, deactivate_flows_for_rules(_, _, _, _, _, _, _))
-        .WillByDefault(Return(true));
-    ON_CALL(
-        *this, deactivate_flows_for_rules_for_termination(_, _, _, _, _, _, _))
-        .WillByDefault(Return(true));
-    ON_CALL(*this, activate_flows_for_rules(_, _, _, _, _, _, _, _, _))
-        .WillByDefault(Return(true));
-    ON_CALL(*this, add_ue_mac_flow(_, _, _, _, _, _))
-        .WillByDefault(Return(true));
-    ON_CALL(*this, delete_ue_mac_flow(_, _)).WillByDefault(Return(true));
-    ON_CALL(*this, update_ipfix_flow(_, _, _, _, _, _))
-        .WillByDefault(Return(true));
-    ON_CALL(*this, add_gy_final_action_flow(_, _, _, _, _, _, _))
-        .WillByDefault(Return(true));
-    ON_CALL(*this, set_upf_session(_, _)).WillByDefault(Return(true));
-    ON_CALL(*this, update_subscriber_quota_state(_))
-        .WillByDefault(Return(true));
     ON_CALL(*this, get_next_teid()).WillByDefault(Return(0));
     ON_CALL(*this, get_current_teid()).WillByDefault(Return(0));
   }
 
   MOCK_METHOD9(
       setup_cwf,
-      bool(
+      void(
           const std::vector<SessionState::SessionInfo>& infos,
           const std::vector<SubscriberQuotaUpdate>& quota_updates,
           const std::vector<std::string> ue_mac_addrs,
@@ -119,14 +98,14 @@ class MockPipelinedClient : public PipelinedClient {
           std::function<void(Status status, SetupFlowsResult)> callback));
   MOCK_METHOD3(
       setup_lte,
-      bool(
+      void(
           const std::vector<SessionState::SessionInfo>& infos,
           const std::uint64_t& epoch,
           std::function<void(Status status, SetupFlowsResult)> callback));
-  MOCK_METHOD1(deactivate_all_flows, bool(const std::string& imsi));
+  MOCK_METHOD1(deactivate_all_flows, void(const std::string& imsi));
   MOCK_METHOD7(
       deactivate_flows_for_rules,
-      bool(
+      void(
           const std::string& imsi, const std::string& ip_addr,
           const std::string& ipv6_addr, const Teids teids,
           const std::vector<std::string>& rule_ids,
@@ -134,7 +113,7 @@ class MockPipelinedClient : public PipelinedClient {
           const RequestOriginType_OriginType origin_type));
   MOCK_METHOD7(
       deactivate_flows_for_rules_for_termination,
-      bool(
+      void(
           const std::string& imsi, const std::string& ip_addr,
           const std::string& ipv6_addr, const Teids teids,
           const std::vector<std::string>& rule_ids,
@@ -142,7 +121,7 @@ class MockPipelinedClient : public PipelinedClient {
           const RequestOriginType_OriginType origin_type));
   MOCK_METHOD9(
       activate_flows_for_rules,
-      bool(
+      void(
           const std::string& imsi, const std::string& ip_addr,
           const std::string& ipv6_addr, const Teids teids,
           const std::string& msisdn,
@@ -152,26 +131,26 @@ class MockPipelinedClient : public PipelinedClient {
           std::function<void(Status status, ActivateFlowsResult)> callback));
   MOCK_METHOD6(
       add_ue_mac_flow,
-      bool(
+      void(
           const SubscriberID& sid, const std::string& ue_mac_addr,
           const std::string& msisdn, const std::string& ap_mac_addr,
           const std::string& ap_name,
           std::function<void(Status status, FlowResponse)> callback));
   MOCK_METHOD6(
       update_ipfix_flow,
-      bool(
+      void(
           const SubscriberID& sid, const std::string& ue_mac_addr,
           const std::string& msisdn, const std::string& ap_mac_addr,
           const std::string& ap_name, const uint64_t& pdp_start_time));
   MOCK_METHOD1(
       update_subscriber_quota_state,
-      bool(const std::vector<SubscriberQuotaUpdate>& updates));
+      void(const std::vector<SubscriberQuotaUpdate>& updates));
   MOCK_METHOD2(
       delete_ue_mac_flow,
-      bool(const SubscriberID& sid, const std::string& ue_mac_addr));
+      void(const SubscriberID& sid, const std::string& ue_mac_addr));
   MOCK_METHOD7(
       add_gy_final_action_flow,
-      bool(
+      void(
           const std::string& imsi, const std::string& ip_addr,
           const std::string& ipv6_addr, const Teids teids,
           const std::string& msisdn,
@@ -179,7 +158,7 @@ class MockPipelinedClient : public PipelinedClient {
           const std::vector<PolicyRule>& dynamic_rules));
   MOCK_METHOD2(
       set_upf_session,
-      bool(
+      void(
           const SessionState::SessionInfo info,
           std::function<void(Status status, UPFSessionContextState)> callback));
   MOCK_METHOD0(get_next_teid, uint32_t());

--- a/lte/gateway/c/session_manager/test/test_local_enforcer.cpp
+++ b/lte/gateway/c/session_manager/test/test_local_enforcer.cpp
@@ -190,15 +190,13 @@ TEST_F(LocalEnforcerTest, test_init_cwf_session_credit) {
                              IMSI1, testing::_, testing::_, testing::_,
                              test_cwf_cfg.common_context.msisdn(), testing::_,
                              CheckCount(0), CheckCount(0), testing::_))
-      .Times(1)
-      .WillOnce(testing::Return(true));
+      .Times(1);
 
   EXPECT_CALL(
       *pipelined_client, update_ipfix_flow(
                              testing::_, testing::_, testing::_, testing::_,
                              testing::_, testing::_))
-      .Times(1)
-      .WillOnce(testing::Return(true));
+      .Times(1);
 
   local_enforcer->init_session(
       session_map, IMSI1, SESSION_ID_1, test_cwf_cfg, response);
@@ -230,8 +228,7 @@ TEST_F(LocalEnforcerTest, test_init_infinite_metered_credit) {
                              IMSI1, IP1, IPv6_1, CheckTeids(teids1),
                              test_cfg_.common_context.msisdn(), testing::_,
                              CheckCount(1), CheckCount(0), testing::_))
-      .Times(1)
-      .WillOnce(testing::Return(true));
+      .Times(1);
   local_enforcer->init_session(
       session_map, IMSI1, SESSION_ID_1, test_cfg_, response);
 
@@ -263,8 +260,7 @@ TEST_F(LocalEnforcerTest, test_init_no_credit) {
           test_cfg_.common_context.ue_ipv6(), CheckTeids(teids1),
           test_cfg_.common_context.msisdn(), testing::_, CheckCount(1),
           CheckCount(0), testing::_))
-      .Times(1)
-      .WillOnce(testing::Return(true));
+      .Times(1);
   local_enforcer->init_session(
       session_map, IMSI1, SESSION_ID_1, test_cfg_, response);
 
@@ -289,8 +285,7 @@ TEST_F(LocalEnforcerTest, test_init_session_credit) {
           testing::_, testing::_, testing::_, CheckTeids(teids1),
           test_cfg_.common_context.msisdn(), testing::_, testing::_, testing::_,
           testing::_))
-      .Times(1)
-      .WillOnce(testing::Return(true));
+      .Times(1);
   ;
   local_enforcer->init_session(
       session_map, IMSI1, SESSION_ID_1, test_cfg_, response);
@@ -582,8 +577,7 @@ TEST_F(LocalEnforcerTest, test_update_session_credits_and_rules_with_failure) {
       deactivate_flows_for_rules_for_termination(
           IMSI1, testing::_, testing::_, testing::_,
           std::vector<std::string>{"rule1"}, CheckCount(0), testing::_))
-      .Times(1)
-      .WillOnce(testing::Return(true));
+      .Times(1);
   local_enforcer->update_session_credits_and_rules(
       session_map, update_response, update);
 
@@ -875,8 +869,7 @@ TEST_F(LocalEnforcerTest, test_final_unit_handling) {
       *pipelined_client, deactivate_flows_for_rules_for_termination(
                              testing::_, testing::_, testing::_, testing::_,
                              testing::_, testing::_, testing::_))
-      .Times(1)
-      .WillOnce(testing::Return(true));
+      .Times(1);
   // Since this is a termination triggered by SessionD/Core (quota exhaustion
   // + FUA-Terminate), we expect MME to be notified to delete the bearer
   // created on session creation
@@ -931,8 +924,7 @@ TEST_F(LocalEnforcerTest, test_cwf_final_unit_handling) {
       *pipelined_client, deactivate_flows_for_rules_for_termination(
                              testing::_, testing::_, testing::_, testing::_,
                              testing::_, testing::_, testing::_))
-      .Times(1)
-      .WillOnce(testing::Return(true));
+      .Times(1);
 
   EXPECT_CALL(*aaa_client, terminate_session(testing::_, testing::_))
       .Times(1)
@@ -1094,8 +1086,7 @@ TEST_F(LocalEnforcerTest, test_credit_init_with_transient_error_redirect) {
       *pipelined_client, deactivate_flows_for_rules(
                              testing::_, testing::_, testing::_, testing::_,
                              CheckCount(1), CheckCount(0), testing::_))
-      .Times(1)
-      .WillOnce(testing::Return(true));
+      .Times(1);
   local_enforcer->init_session(
       session_map, IMSI1, SESSION_ID_1, test_cfg_, response);
   local_enforcer->update_tunnel_ids(
@@ -1149,8 +1140,7 @@ TEST_F(LocalEnforcerTest, test_credit_init_with_transient_error_redirect) {
           IMSI1, test_cfg_.common_context.ue_ipv4(),
           test_cfg_.common_context.ue_ipv6(), CheckTeids(teids1),
           test_cfg_.common_context.msisdn(), CheckCount(0), CheckCount(1)))
-      .Times(1)
-      .WillOnce(testing::Return(true));
+      .Times(1);
   local_enforcer->execute_actions(session_map, actions, update);
   EXPECT_EQ(session_update.updates_size(), 0);
   EXPECT_EQ(
@@ -1194,8 +1184,7 @@ TEST_F(LocalEnforcerTest, test_update_with_transient_error) {
       *pipelined_client, deactivate_flows_for_rules(
                              testing::_, testing::_, testing::_, testing::_,
                              CheckCount(2), CheckCount(0), testing::_))
-      .Times(1)
-      .WillOnce(testing::Return(true));
+      .Times(1);
 
   local_enforcer->update_session_credits_and_rules(
       session_map, update_response, session_uc);
@@ -1277,8 +1266,7 @@ TEST_F(LocalEnforcerTest, test_reauth_with_redirected_suspended_credit) {
                              test_cfg_.common_context.msisdn(), testing::_,
                              CheckStaticRulesNames(static_rules_to_activate),
                              CheckCount(0), testing::_))
-      .Times(1)
-      .WillOnce(testing::Return(true));
+      .Times(1);
   local_enforcer->update_session_credits_and_rules(
       session_map, update_response, update);
   EXPECT_FALSE(update[IMSI1][SESSION_ID_1].charging_credit_map[1].suspended);
@@ -1325,8 +1313,7 @@ TEST_F(LocalEnforcerTest, test_re_auth) {
                              testing::_, testing::_, testing::_, testing::_,
                              test_cfg_.common_context.msisdn(), testing::_,
                              testing::_, testing::_, testing::_))
-      .Times(1)
-      .WillOnce(testing::Return(true));
+      .Times(1);
   actions.clear();
   local_enforcer->collect_updates(session_map, actions, update);
   local_enforcer->execute_actions(session_map, actions, update);
@@ -1396,8 +1383,7 @@ TEST_F(LocalEnforcerTest, test_dynamic_rule_actions) {
                              testing::_, testing::_, testing::_, testing::_,
                              test_cfg_.common_context.msisdn(), testing::_,
                              CheckCount(2), CheckCount(1), testing::_))
-      .Times(1)
-      .WillOnce(testing::Return(true));
+      .Times(1);
 
   local_enforcer->init_session(
       session_map, IMSI1, SESSION_ID_1, test_cfg_, response);
@@ -1420,8 +1406,7 @@ TEST_F(LocalEnforcerTest, test_dynamic_rule_actions) {
       *pipelined_client, deactivate_flows_for_rules_for_termination(
                              testing::_, testing::_, testing::_, testing::_,
                              CheckCount(2), CheckCount(1), testing::_))
-      .Times(1)
-      .WillOnce(testing::Return(true));
+      .Times(1);
   std::vector<std::unique_ptr<ServiceAction>> actions;
   auto usage_updates =
       local_enforcer->collect_updates(session_map, actions, update);
@@ -1486,8 +1471,7 @@ TEST_F(LocalEnforcerTest, test_installing_rules_with_activation_time) {
                              IMSI1, ip_addr, ipv6_addr, CheckTeids(teids),
                              test_cfg_.common_context.msisdn(), testing::_,
                              CheckCount(2), CheckCount(2), testing::_))
-      .Times(1)
-      .WillOnce(testing::Return(true));
+      .Times(1);
 
   // We do not expect rule5 and rule2 to be activated since they are scheduled a
   // day away
@@ -1628,8 +1612,7 @@ TEST_F(LocalEnforcerTest, test_usage_monitors) {
                              IMSI1, testing::_, testing::_, testing::_,
                              std::vector<std::string>{"pcrf_only"},
                              CheckCount(0), RequestOriginType::GX))
-      .Times(1)
-      .WillOnce(testing::Return(true));
+      .Times(1);
   local_enforcer->update_session_credits_and_rules(
       session_map, update_response, update);
 
@@ -1653,8 +1636,7 @@ TEST_F(LocalEnforcerTest, test_usage_monitors) {
           IMSI1, testing::_, testing::_, testing::_,
           test_cfg_.common_context.msisdn(), testing::_,
           std::vector<std::string>{"pcrf_only"}, CheckCount(0), testing::_))
-      .Times(1)
-      .WillOnce(testing::Return(true));
+      .Times(1);
   local_enforcer->update_session_credits_and_rules(
       session_map, update_response, update);
 }
@@ -2157,8 +2139,7 @@ TEST_F(LocalEnforcerTest, test_set_session_rules) {
           IMSI1, ip1, testing::_, CheckTeids(config1.common_context.teids()),
           config1.common_context.msisdn(), testing::_,
           std::vector<std::string>{"static3"}, CheckCount(1), testing::_))
-      .Times(1)
-      .WillOnce(testing::Return(true));
+      .Times(1);
   // PipelineD expectations for Session2
   EXPECT_CALL(
       *pipelined_client,
@@ -2166,16 +2147,14 @@ TEST_F(LocalEnforcerTest, test_set_session_rules) {
           IMSI1, ip2, testing::_, CheckTeids(config2.common_context.teids()),
           config2.common_context.msisdn(), testing::_, CheckCount(0),
           CheckCount(1), testing::_))
-      .Times(1)
-      .WillOnce(testing::Return(true));
+      .Times(1);
   // For both Session1 + Session2
   EXPECT_CALL(
       *pipelined_client,
       deactivate_flows_for_rules(
           IMSI1, testing::_, testing::_, testing::_,
           std::vector<std::string>{"static2"}, CheckCount(1), testing::_))
-      .Times(2)
-      .WillOnce(testing::Return(true));
+      .Times(2);
 
   // Since static3 is also a QoS rule with a new QCI (not equal to default), we
   // should also expect a create bearer request here
@@ -2496,8 +2475,7 @@ TEST_F(LocalEnforcerTest, test_pipelined_cwf_setup) {
               static_rule_list, dynamic_rule_list),
           testing::_, ue_mac_addrs, msisdns, apn_mac_addrs, apn_names,
           testing::_, testing::_, testing::_))
-      .Times(1)
-      .WillOnce(testing::Return(true));
+      .Times(1);
 
   local_enforcer->setup(
       session_map, epoch, [](Status status, SetupFlowsResult resp) {});
@@ -2565,8 +2543,7 @@ TEST_F(LocalEnforcerTest, test_pipelined_lte_setup) {
               imsi_list, ip_address_list, ipv6_address_list, test_cfg_,
               static_rule_list, dynamic_rule_list),
           testing::_, testing::_))
-      .Times(1)
-      .WillOnce(testing::Return(true));
+      .Times(1);
 
   local_enforcer->setup(
       session_map, epoch, [](Status status, SetupFlowsResult resp) {});
@@ -2605,8 +2582,7 @@ TEST_F(LocalEnforcerTest, test_valid_apn_parsing) {
       setup_cwf(
           testing::_, testing::_, ue_mac_addrs, msisdns, apn_mac_addrs,
           apn_names, testing::_, epoch, testing::_))
-      .Times(1)
-      .WillOnce(testing::Return(true));
+      .Times(1);
 
   local_enforcer->setup(
       session_map, epoch, [](Status status, SetupFlowsResult resp) {});
@@ -2647,8 +2623,7 @@ TEST_F(LocalEnforcerTest, test_invalid_apn_parsing) {
       setup_cwf(
           testing::_, testing::_, ue_mac_addrs, msisdns, apn_mac_addrs,
           apn_names, testing::_, epoch, testing::_))
-      .Times(1)
-      .WillOnce(testing::Return(true));
+      .Times(1);
 
   local_enforcer->setup(
       session_map, epoch, [](Status status, SetupFlowsResult resp) {});
@@ -2673,8 +2648,7 @@ TEST_F(LocalEnforcerTest, test_final_unit_redirect_activation_and_termination) {
                              IMSI1, ip_addr, ipv6_addr, CheckTeids(teids),
                              test_cfg_.common_context.msisdn(), testing::_,
                              CheckCount(1), CheckCount(0), testing::_))
-      .Times(1)
-      .WillOnce(testing::Return(true));
+      .Times(1);
   local_enforcer->init_session(
       session_map, IMSI1, SESSION_ID_1, test_cfg_, response);
   local_enforcer->update_tunnel_ids(
@@ -2703,8 +2677,7 @@ TEST_F(LocalEnforcerTest, test_final_unit_redirect_activation_and_termination) {
       add_gy_final_action_flow(
           IMSI1, ip_addr, ipv6_addr, CheckTeids(teids),
           test_cfg_.common_context.msisdn(), CheckCount(0), CheckCount(1)))
-      .Times(1)
-      .WillOnce(testing::Return(true));
+      .Times(1);
   // Execute actions and asset final action state
   local_enforcer->execute_actions(session_map, actions, update);
   const CreditKey& credit_key(1);
@@ -2715,15 +2688,13 @@ TEST_F(LocalEnforcerTest, test_final_unit_redirect_activation_and_termination) {
       *pipelined_client, deactivate_flows_for_rules_for_termination(
                              IMSI1, ip_addr, ipv6_addr, CheckTeids(teids),
                              std::vector<std::string>{"static_1"},
-                             CheckCount(0), RequestOriginType::GX))
-      .WillOnce(testing::Return(true));
+                             CheckCount(0), RequestOriginType::GX));
   EXPECT_CALL(
       *pipelined_client,
       deactivate_flows_for_rules_for_termination(
           IMSI1, ip_addr, ipv6_addr, CheckTeids(teids), CheckCount(0),
           CheckCount(1), RequestOriginType::GY))
-      .Times(1)
-      .WillOnce(testing::Return(true));
+      .Times(1);
   local_enforcer->handle_termination_from_access(
       session_map, IMSI1, APN1, update);
 }
@@ -2757,8 +2728,7 @@ TEST_F(LocalEnforcerTest, test_final_unit_activation_and_canceling) {
       activate_flows_for_rules(
           IMSI1, ip_addr, ipv6_addr, CheckTeids(teids), msisdn, testing::_,
           CheckCount(2), CheckCount(1), testing::_))
-      .Times(1)
-      .WillOnce(testing::Return(true));
+      .Times(1);
 
   local_enforcer->init_session(
       session_map, IMSI1, SESSION_ID_1, cfg1, response);
@@ -2787,8 +2757,7 @@ TEST_F(LocalEnforcerTest, test_final_unit_activation_and_canceling) {
       *pipelined_client, add_gy_final_action_flow(
                              IMSI1, ip_addr, ipv6_addr, CheckTeids(teids),
                              msisdn, CheckCount(1), testing::_))
-      .Times(1)
-      .WillOnce(testing::Return(true));
+      .Times(1);
   // Execute actions and asset final action state
   local_enforcer->execute_actions(session_map, actions, update);
 
@@ -2829,8 +2798,7 @@ TEST_F(LocalEnforcerTest, test_final_unit_activation_and_canceling) {
       activate_flows_for_rules(
           IMSI1, ip_addr, ipv6_addr, CheckTeids(teids), msisdn, testing::_,
           testing::_, testing::_, testing::_))
-      .Times(1)
-      .WillOnce(testing::Return(true));
+      .Times(1);
   actions.clear();
   local_enforcer->collect_updates(session_map, actions, update);
   local_enforcer->execute_actions(session_map, actions, update);
@@ -2863,8 +2831,7 @@ TEST_F(LocalEnforcerTest, test_final_unit_action_no_update) {
       activate_flows_for_rules(
           IMSI1, ip_addr, ipv6_addr, CheckTeids(teids), msisdn, testing::_,
           CheckCount(1), CheckCount(0), testing::_))
-      .Times(1)
-      .WillOnce(testing::Return(true));
+      .Times(1);
 
   local_enforcer->init_session(
       session_map, IMSI1, SESSION_ID_1, test_cfg_, response);
@@ -2906,8 +2873,7 @@ TEST_F(LocalEnforcerTest, test_final_unit_action_no_update) {
       add_gy_final_action_flow(
           IMSI1, ip_addr, ipv6_addr, CheckTeids(teids),
           test_cfg_.common_context.msisdn(), CheckCount(1), testing::_))
-      .Times(1)
-      .WillOnce(testing::Return(true));
+      .Times(1);
   // Execute actions and asset final action state
   local_enforcer->execute_actions(session_map, actions, update);
 
@@ -2936,8 +2902,7 @@ TEST_F(LocalEnforcerTest, test_rar_dynamic_rule_modification) {
                              IMSI1, testing::_, testing::_, testing::_,
                              test_cfg_.common_context.msisdn(), testing::_,
                              CheckCount(0), CheckCount(1), testing::_))
-      .Times(1)
-      .WillOnce(testing::Return(true));
+      .Times(1);
 
   local_enforcer->init_session(
       session_map, IMSI1, SESSION_ID_1, test_cfg_, response);
@@ -2968,15 +2933,13 @@ TEST_F(LocalEnforcerTest, test_rar_dynamic_rule_modification) {
         *pipelined_client, deactivate_flows_for_rules(
                                IMSI1, testing::_, testing::_, testing::_,
                                CheckCount(0), CheckCount(1), testing::_))
-        .Times(1)
-        .WillOnce(testing::Return(true));
+        .Times(1);
     EXPECT_CALL(
         *pipelined_client, activate_flows_for_rules(
                                IMSI1, testing::_, testing::_, testing::_,
                                test_cfg_.common_context.msisdn(), testing::_,
                                CheckCount(0), CheckCount(1), testing::_))
-        .Times(1)
-        .WillOnce(testing::Return(true));
+        .Times(1);
   }
   local_enforcer->init_policy_reauth(session_map, rar, raa, session_ucs);
   auto& dynamic_rules = session_map[IMSI1][0]->get_dynamic_rules();

--- a/lte/gateway/c/session_manager/test/test_local_enforcer_wallet_exhaust.cpp
+++ b/lte/gateway/c/session_manager/test/test_local_enforcer_wallet_exhaust.cpp
@@ -190,8 +190,7 @@ TEST_F(LocalEnforcerTest, test_cwf_quota_exhaustion_on_init_has_quota) {
       *pipelined_client,
       update_subscriber_quota_state(
           CheckSubscriberQuotaUpdate(SubscriberQuotaUpdate_Type_VALID_QUOTA)))
-      .Times(1)
-      .WillOnce(testing::Return(true));
+      .Times(1);
   local_enforcer->init_session(
       session_map, IMSI1, SESSION_ID_1, cwf_session_config, response);
   local_enforcer->update_tunnel_ids(
@@ -213,8 +212,7 @@ TEST_F(LocalEnforcerTest, test_cwf_quota_exhaustion_on_init_no_quota) {
       *pipelined_client,
       update_subscriber_quota_state(
           CheckSubscriberQuotaUpdate(SubscriberQuotaUpdate_Type_NO_QUOTA)))
-      .Times(1)
-      .WillOnce(testing::Return(true));
+      .Times(1);
   local_enforcer->init_session(
       session_map, IMSI1, SESSION_ID_1, cwf_session_config, response);
   local_enforcer->update_tunnel_ids(
@@ -248,8 +246,7 @@ TEST_F(LocalEnforcerTest, test_cwf_quota_exhaustion_on_rar) {
       *pipelined_client,
       update_subscriber_quota_state(
           CheckSubscriberQuotaUpdate(SubscriberQuotaUpdate_Type_TERMINATE)))
-      .Times(1)
-      .WillOnce(testing::Return(true));
+      .Times(1);
 
   PolicyReAuthAnswer answer;
   auto update = SessionStore::get_default_session_update(session_map);
@@ -297,8 +294,7 @@ TEST_F(LocalEnforcerTest, test_cwf_quota_exhaustion_on_update) {
       *pipelined_client,
       update_subscriber_quota_state(
           CheckSubscriberQuotaUpdate(SubscriberQuotaUpdate_Type_TERMINATE)))
-      .Times(1)
-      .WillOnce(testing::Return(true));
+      .Times(1);
 
   local_enforcer->update_session_credits_and_rules(
       session_map, update_response, update);

--- a/lte/gateway/c/session_manager/test/test_proxy_responder_handler.cpp
+++ b/lte/gateway/c/session_manager/test/test_proxy_responder_handler.cpp
@@ -259,8 +259,7 @@ TEST_F(SessionProxyResponderHandlerTest, test_abort_session) {
       *pipelined_client,
       deactivate_flows_for_rules_for_termination(
           IMSI1, _, _, _, CheckCount(1), CheckCount(0), RequestOriginType::GX))
-      .Times(1)
-      .WillOnce(testing::Return(true));
+      .Times(1);
   proxy_responder->AbortSession(
       &create_context, &request,
       [this](grpc::Status status, AbortSessionResult response_out) {});

--- a/lte/gateway/c/session_manager/test/test_session_manager_handler.cpp
+++ b/lte/gateway/c/session_manager/test/test_session_manager_handler.cpp
@@ -118,9 +118,7 @@ class SessionManagerHandlerTest : public ::testing::Test {
     EXPECT_CALL(
         *pipelined_client, setup_lte(testing::_, testing::_, testing::_))
         .Times(1)
-        .WillOnce(testing::DoAll(
-            CallSetupCallback(SetupFlowsResult_Result_SUCCESS),
-            testing::Return(true)));
+        .WillOnce(CallSetupCallback(SetupFlowsResult_Result_SUCCESS));
     evb->loopOnce();
     evb->loopOnce();
   }
@@ -366,9 +364,7 @@ TEST_F(SessionManagerHandlerTest, test_create_session_pipelined_unavailable) {
   send_empty_table();
   // On failure cases, LocalEnforcer will endlessly retry the setup call
   EXPECT_CALL(*pipelined_client, setup_lte(testing::_, testing::_, testing::_))
-      .WillRepeatedly(testing::DoAll(
-          CallSetupCallback(SetupFlowsResult_Result_FAILURE),
-          testing::Return(true)));
+      .WillRepeatedly(CallSetupCallback(SetupFlowsResult_Result_FAILURE));
   evb->loopOnce();
   evb->loopOnce();
   // 1) Create the session


### PR DESCRIPTION
Signed-off-by: Marie Bremner <marwhal@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary
* Since PipelineD client relies on callback functions to do error handling, these functions never return false. This is a clean up PR that changes all the return types to void, so the typing makes that clear.
<!-- Enumerate changes you made and why you made them -->

## Test Plan
make precommit_sm, s1ap
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
