### PR TITLE
[NMS] Fix the sctpd alert

### DIFF
--- a/nms/app/packages/magmalte/alerts/lteAlerts.js
+++ b/nms/app/packages/magmalte/alerts/lteAlerts.js
@@ -66,7 +66,7 @@ export default function getLteAlerts(
     },
     'Sctpd Crashlooping Alert': {
       alert: 'Sctpd Crashlooping Alert',
-      expr: `increase(unexpected_service_restarts{networkID=~"${networkID}", service_name="sctpd"}[5m]) > 3`,
+      expr: `increase(service_restart_status{networkID=~"${networkID}", service_name="sctpd"}[5m]) > 3`,
       labels: {severity: 'critical'},
       annotations: {
         description: 'Alerts when we have sctpd service crashlooping',


### PR DESCRIPTION
## Summary

Unexpected service restart metric doesn't get triggered if a service restarts too quickly. Changing the alert around service restart status as a workaround. 

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
