### PR TITLE
[lte][agw] Improve writes to redis for ue hash tables and s1ap states

### DIFF
--- a/lte/gateway/c/oai/lib/hashtable/hashtable.h
+++ b/lte/gateway/c/oai/lib/hashtable/hashtable.h
@@ -92,6 +92,7 @@ typedef struct hash_table_s {
   bstring name;
   bool is_allocated_by_malloc;
   bool log_enabled;
+  uint64_t generation;  // increment with every ht modification
 } hash_table_t;
 
 typedef struct hash_table_ts_s {
@@ -106,7 +107,9 @@ typedef struct hash_table_ts_s {
   bstring name;
   bool is_allocated_by_malloc;
   bool log_enabled;
+  uint64_t generation;  // increment with every ht modification
 } hash_table_ts_t;
+
 typedef struct hash_table_uint64_s {
   hash_size_t size;
   hash_size_t num_elements;
@@ -115,6 +118,7 @@ typedef struct hash_table_uint64_s {
   bstring name;
   bool is_allocated_by_malloc;
   bool log_enabled;
+  uint64_t generation;  // increment with every ht modification
 } hash_table_uint64_t;
 
 typedef struct hash_table_uint64_ts_s {
@@ -127,6 +131,7 @@ typedef struct hash_table_uint64_ts_s {
   bstring name;
   bool is_allocated_by_malloc;
   bool log_enabled;
+  uint64_t generation;  // increment with every ht modification
 } hash_table_uint64_ts_t;
 
 typedef struct hashtable_key_array_s {
@@ -174,6 +179,7 @@ hashtable_rc_t hashtable_get(
     __attribute__((hot));
 hashtable_rc_t hashtable_resize(
     hash_table_t* const hashtbl, const hash_size_t size);
+uint64_t hashtable_get_generation(hash_table_t* const hashtblP);
 
 // Thread-safe functions
 hash_table_ts_t* hashtable_ts_init(
@@ -209,6 +215,7 @@ hashtable_rc_t hashtable_ts_get(
     __attribute__((hot));
 hashtable_rc_t hashtable_ts_resize(
     hash_table_ts_t* const hashtbl, const hash_size_t size);
+uint64_t hashtable_ts_get_generation(hash_table_ts_t* const hashtblP);
 hash_table_uint64_ts_t* hashtable_uint64_ts_init(
     hash_table_uint64_ts_t* const hashtbl, const hash_size_t size,
     hash_size_t (*hashfunc)(const hash_key_t), bstring display_name_p);
@@ -243,5 +250,6 @@ hashtable_rc_t hashtable_uint64_ts_get(
     uint64_t* const dataP) __attribute__((hot));
 hashtable_rc_t hashtable_uint64_ts_resize(
     hash_table_uint64_ts_t* const hashtbl, const hash_size_t size);
-
+uint64_t hashtable_uint64_ts_get_generation(
+    hash_table_uint64_ts_t* const hashtblP);
 #endif

--- a/lte/gateway/c/oai/lib/hashtable/obj_hashtable.h
+++ b/lte/gateway/c/oai/lib/hashtable/obj_hashtable.h
@@ -76,7 +76,9 @@ typedef struct obj_hash_table_s {
   void (*freedatafunc)(void**);
   bstring name;
   bool log_enabled;
+  uint64_t generation;  // increment with every ht modification
 } obj_hash_table_t;
+
 typedef struct obj_hash_table_uint64_s {
   pthread_mutex_t mutex;
   hash_size_t size;
@@ -87,6 +89,7 @@ typedef struct obj_hash_table_uint64_s {
   void (*freekeyfunc)(void**);
   bstring name;
   bool log_enabled;
+  uint64_t generation;  // increment with every ht modification
 } obj_hash_table_uint64_t;
 
 void obj_hashtable_no_free_key_callback(void* param);
@@ -179,6 +182,7 @@ hashtable_rc_t obj_hashtable_uint64_get_keys(
     unsigned int* sizeP);
 hashtable_rc_t obj_hashtable_uint64_resize(
     obj_hash_table_uint64_t* const hashtblP, const hash_size_t sizeP);
+uint64_t obj_hashtable_get_generation(obj_hash_table_t* const hashtblP);
 
 // Thread-safe functions
 obj_hash_table_uint64_t* obj_hashtable_uint64_ts_init(
@@ -210,5 +214,6 @@ hashtable_rc_t obj_hashtable_uint64_ts_get_keys(
     unsigned int* sizeP);
 hashtable_rc_t obj_hashtable_uint64_ts_resize(
     obj_hash_table_uint64_t* const hashtblP, const hash_size_t sizeP);
-
+uint64_t obj_hashtable_uint64_ts_get_generation(
+    obj_hash_table_uint64_t* const hashtblP);
 #endif

--- a/lte/gateway/c/oai/tasks/mme_app/mme_app_state_manager.cpp
+++ b/lte/gateway/c/oai/tasks/mme_app/mme_app_state_manager.cpp
@@ -27,7 +27,7 @@ extern "C" {
 
 namespace {
 constexpr char MME_NAS_STATE_KEY[] = "mme_nas_state";
-const int NUM_MAX_UE_HTBL_LISTS    = 6;
+const int NUM_MAX_UE_HTBL_LISTS    = 512;
 constexpr char UE_ID_UE_CTXT_TABLE_NAME[] =
     "mme_app_mme_ue_s1ap_id_ue_context_htbl";
 constexpr char IMSI_UE_ID_TABLE_NAME[] = "mme_app_imsi_ue_context_htbl";

--- a/lte/gateway/c/oai/tasks/s1ap/s1ap_state.cpp
+++ b/lte/gateway/c/oai/tasks/s1ap/s1ap_state.cpp
@@ -50,7 +50,17 @@ void s1ap_state_exit() {
 }
 
 void put_s1ap_state() {
-  S1apStateManager::getInstance().write_state_to_db();
+  uint64_t enbs_ht_new_gen, mmeid2associd_ht_new_gen;
+  if (S1apStateManager::getInstance().should_sync_state_cache(
+          enbs_ht_new_gen, mmeid2associd_ht_new_gen)) {
+    S1apStateManager::getInstance().write_state_to_db();
+    if (S1apStateManager::getInstance().is_state_dirty() == false) {
+      OAILOG_DEBUG(
+          LOG_S1AP, "S1apStateManager::put_s1ap_state: Wrote state to db");
+      S1apStateManager::getInstance().sync_state_cache(
+          enbs_ht_new_gen, mmeid2associd_ht_new_gen);
+    }
+  }
 }
 
 enb_description_t* s1ap_state_get_enb(
@@ -149,6 +159,9 @@ void put_s1ap_ue_state(imsi64_t imsi64) {
     if (ue_ctxt) {
       auto imsi_str = S1apStateManager::getInstance().get_imsi_str(imsi64);
       S1apStateManager::getInstance().write_ue_state_to_db(ue_ctxt, imsi_str);
+      OAILOG_DEBUG(
+          LOG_S1AP,
+          "S1apStateManager::put_s1ap_ue_state: Wrote ue state to db");
     }
   }
 }

--- a/lte/gateway/c/oai/tasks/s1ap/s1ap_state_manager.h
+++ b/lte/gateway/c/oai/tasks/s1ap/s1ap_state_manager.h
@@ -87,6 +87,19 @@ class S1apStateManager
    */
   s1ap_imsi_map_t* get_s1ap_imsi_map();
 
+  /**
+   * Returns true if state needs to be updated
+   */
+  bool should_sync_state_cache(
+      uint64_t& enbs_ht_new_gen, uint64_t& mmeid2associd_ht_new_gen);
+
+  /**
+   * Sets the generation values of state hash tables
+   * to the latest
+   */
+  void sync_state_cache(
+      uint64_t enbs_ht_new_gen, uint64_t mmeid2associd_ht_new_gen);
+
  private:
   S1apStateManager();
   ~S1apStateManager();
@@ -102,6 +115,10 @@ class S1apStateManager
   uint32_t max_ues_;
   uint32_t max_enbs_;
   s1ap_imsi_map_t* s1ap_imsi_map_;
+  // last synced generation values
+  uint64_t enbs_ht_generation_;
+  uint64_t mmeid2associd_ht_generation_;
+  uint64_t mme_ue_id_imsi_ht_generation_;
 };
 }  // namespace lte
 }  // namespace magma

--- a/lte/gateway/configs/mme.yml
+++ b/lte/gateway/configs/mme.yml
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-log_level: INFO
+log_level: DEBUG
 s11_iface_name: "eth1"  # 'mme_s11_ip' will be filled automatically
 remote_sgw_ip: "192.168.60.153" # IP Address of the remote IP for S11
 s1ap_iface_name: "eth1"  # 's1_ip' will be filled automatically

--- a/lte/gateway/configs/mme.yml
+++ b/lte/gateway/configs/mme.yml
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-log_level: DEBUG
+log_level: INFO
 s11_iface_name: "eth1"  # 'mme_s11_ip' will be filled automatically
 remote_sgw_ip: "192.168.60.153" # IP Address of the remote IP for S11
 s1ap_iface_name: "eth1"  # 's1_ip' will be filled automatically

--- a/lte/gateway/configs/templates/mme.conf.template
+++ b/lte/gateway/configs/templates/mme.conf.template
@@ -18,7 +18,7 @@ MME :
     # Define the limits of the system in terms of served eNB and served UE.
     # When the limits will be reached, overload procedure will take place.
     MAXENB                                    = 8;                              # power of 2
-    MAXUE                                     = 16;                             # power of 2
+    MAXUE                                     = 512;                             # power of 2
     RELATIVE_CAPACITY                         = {{ mmeRelativeCapacity }};
 
     EMERGENCY_ATTACH_SUPPORTED                     = "no";


### PR DESCRIPTION
## Summary
This PR adds couple of speed improvements to MME particularly for stateless.
- In stateless mode, every message leads to writes regardless of whether there were any state changes or not. PR adds generation numbers to hash tables. For state_ue_ht (used across S1AP, MME and SPGW) and s1ap state hashtables, it only writes if there were changes to these hash tables by keeping track of generation numbers for the hash tables. Upon first start up and restarts, all generation numbers start from zero.
- Increased the small hash table sizes to improve the look up speeds as the defaults were too low for handling 100s of UEs.

## Test Plan

Spirent tests and s1ap integ tests.

## Additional Information

- [ ] This change is backwards-breaking

