### PR TITLE
[CMake] Ensure compile_commands.json generation

### DIFF
--- a/lte/gateway/Makefile
+++ b/lte/gateway/Makefile
@@ -112,6 +112,8 @@ help: ## Show documented commands
 define run_cmake
 mkdir -p $(1)
 cd $(1) && $(4) cmake $(2) -DCMAKE_BUILD_TYPE=$(BUILD_TYPE) $(3) -GNinja
+# Turn on generation of compile_commands.json (See GH Issue #5488)
+cd $(1) && awk '{if (/^CMAKE_EXPORT_COMPILE_COMMANDS/) gsub(/OFF/, "ON"); print}' CMakeCache.txt > tmp && mv tmp CMakeCache.txt
 ninja -C $(1)
 endef
 

--- a/lte/gateway/c/oai/CMakeLists.txt
+++ b/lte/gateway/c/oai/CMakeLists.txt
@@ -1,5 +1,4 @@
 cmake_minimum_required(VERSION 3.0.2)
-set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 project(MagmaCore)
 

--- a/lte/gateway/c/sctpd/CMakeLists.txt
+++ b/lte/gateway/c/sctpd/CMakeLists.txt
@@ -1,5 +1,4 @@
 cmake_minimum_required(VERSION 3.7)
-set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 set(CMAKE_CXX_STANDARD 14)
 
 project(MagmaSctpd)


### PR DESCRIPTION
## Summary

Because the CMake commands were not being applied within CMakeLists, here we move the configuration of compile_commands.json output to the post-Cmake CMakeCache.txt cofiguration phase.

This PR fixes #5488.

## Test Plan

Executed test build in Docker, observed compile_commands.json in `/build/c/*` for all sub-builds.

Signed-off-by: Scott Harrison Moeller <smoeller@fb.com>