### PR TITLE
AGW: pipelined: fix vsctl warning: target type "testing_br" is possibly erroneous

### DIFF
--- a/lte/gateway/python/magma/pipelined/bridge_util.py
+++ b/lte/gateway/python/magma/pipelined/bridge_util.py
@@ -140,8 +140,7 @@ class BridgeTools:
                           "other-config:disable-in-band=true"]).wait()
         subprocess.Popen(["ovs-vsctl", "set-controller", bridge_name,
                           "tcp:127.0.0.1:6633", "tcp:127.0.0.1:6654"]).wait()
-        subprocess.Popen(["ovs-vsctl", "set-manager", bridge_name,
-                          "ptcp:6640"]).wait()
+        subprocess.Popen(["ovs-vsctl", "set-manager", "ptcp:6640"]).wait()
         subprocess.Popen(["ifconfig", iface_name, "192.168.1.1/24"]).wait()
 
     @staticmethod


### PR DESCRIPTION
`ovs-vsctl set-namager ...` does not need bridge name.

Signed-off-by: Pravin B Shelar <pbshelar@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
