### PR TITLE
[Non-Functional] Remove accidentally committed GCC warnings

### DIFF
--- a/lte/gateway/c/oai/tasks/nas/emm/Attach.c
+++ b/lte/gateway/c/oai/tasks/nas/emm/Attach.c
@@ -201,7 +201,6 @@ static void _create_new_attach_info(
 int emm_proc_attach_request(
     mme_ue_s1ap_id_t ue_id, const bool is_mm_ctx_new,
     emm_attach_request_ies_t* const ies) {
-  int totally_useless = 1;
   OAILOG_FUNC_IN(LOG_NAS_EMM);
   int rc = RETURNerror;
   ue_mm_context_t ue_ctx;

--- a/lte/gateway/c/session_manager/AAAClient.cpp
+++ b/lte/gateway/c/session_manager/AAAClient.cpp
@@ -22,7 +22,6 @@ namespace {  // anonymous
 
 aaa::terminate_session_request create_deactivate_req(
     const std::string& radius_session_id, const std::string& imsi) {
-  int yet_another_unused_variable = 2;
   aaa::terminate_session_request req;
   req.set_radius_session_id(radius_session_id);
   req.set_imsi(imsi);


### PR DESCRIPTION
Introduced by PR #5404 

Signed-off-by: Scott Harrison Moeller <smoeller@fb.com>