### PR TITLE
[cwf][orc8r]Changes to push cwf and orc8r docker images to the new JFROG repo

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -558,6 +558,13 @@ jobs:
           project: orc8r
           images: "nginx|controller"
           tag-latest: true
+      - tag-push-docker:
+          project: orc8r
+          images: "nginx|controller"
+          tag-latest: true
+          registry: $JFROG_DOCKER_ORC8R_REGISTRY
+          username: $JFROG_USERNAME
+          password: $JFROG_PASSWORD
       - persist-githash-version:
           file_prefix: orc8r
       - notify-magma:
@@ -712,6 +719,14 @@ jobs:
           tag: <<parameters.tag>>
           registry: $DOCKER_MAGMA_REGISTRY
           tag-latest: <<parameters.tag-latest>>
+      - tag-push-docker:
+          project: cwf
+          images: <<parameters.images>>
+          tag: <<parameters.tag>>
+          tag-latest: <<parameters.tag-latest>>
+          registry: $JFROG_DOCKER_CWF_REGISTRY
+          username: $JFROG_USERNAME
+          password: $JFROG_PASSWORD
       - persist-githash-version:
           file_prefix: cwag
       - notify-magma:
@@ -822,6 +837,12 @@ jobs:
           project: cwf
           images: "operator"
           registry: $DOCKER_MAGMA_REGISTRY
+      - tag-push-docker:
+          project: cwf
+          images: "operator"
+          registry: $JFROG_DOCKER_CWF_REGISTRY
+          username: $JFROG_USERNAME
+          password: $JFROG_PASSWORD
       - persist-githash-version:
           file_prefix: cwf_operator
       - notify-magma:


### PR DESCRIPTION
Signed-off-by: Ranjini Iyer <ranj8work@gmail.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary
[cwf][orc8r]Changes to push cwf and orc8r docker images to new JFROG repo. Created new environment variables in CircleCi for the new jfrog repo - JFROG_DOCKER_CWF_REGISTRY and JFROG_DOCKER_ORC8R_REGISTRY

## Change Details
Updated the circle config file to push the CWF and ORC8R images to the new jfrog repos:
cwf-test.artifactory.magmacore.org:443
orc8r-test.artifactory.magmacore.org:443

<!-- Enumerate changes you made and why you made them -->

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Test Plan

**CircleCI job execution:**
https://app.circleci.com/pipelines/github/magma/magma?branch=docker_jfrog_migration


## Additional Information

- [NO] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
