### PR TITLE
[MME][ZMQ] Restrict ZMQ buffer depth to 2 sec to prevent delay build up

### DIFF
--- a/lte/gateway/c/oai/common/async_system.c
+++ b/lte/gateway/c/oai/common/async_system.c
@@ -58,6 +58,9 @@ task_zmq_ctx_t async_system_task_zmq_ctx;
 static int handle_message(zloop_t* loop, zsock_t* reader, void* arg) {
   int rc                         = 0;
   MessageDef* received_message_p = receive_msg(reader);
+  if (!received_message_p) {
+    return 0;
+  }
 
   switch (ITTI_MSG_ID(received_message_p)) {
     case ASYNC_SYSTEM_COMMAND: {

--- a/lte/gateway/c/oai/common/log.c
+++ b/lte/gateway/c/oai/common/log.c
@@ -63,6 +63,7 @@
 #include "hashtable.h"
 #include "intertask_interface_types.h"
 #include "itti_types.h"
+#include "itti_free_defined_msg.h"
 
 #if HAVE_CONFIG_H
 #include "config.h"
@@ -298,15 +299,20 @@ static void get_thread_context(log_thread_ctxt_t** thread_ctxt) {
 
 static int handle_message(zloop_t* loop, zsock_t* reader, void* arg) {
   MessageDef* received_message_p = receive_msg(reader);
+  if (!received_message_p) {
+    return 0;
+  }
 
   switch (ITTI_MSG_ID(received_message_p)) {
     case TERMINATE_MESSAGE: {
+      itti_free_msg_content(received_message_p);
       free(received_message_p);
       log_exit();
     } break;
 
     default: { } break; }
 
+  itti_free_msg_content(received_message_p);
   free(received_message_p);
   return 0;
 }

--- a/lte/gateway/c/oai/common/shared_ts_log.c
+++ b/lte/gateway/c/oai/common/shared_ts_log.c
@@ -49,6 +49,7 @@
 #include "dynamic_memory_check.h"
 #include "intertask_interface_types.h"
 #include "itti_types.h"
+#include "itti_free_defined_msg.h"
 
 //-------------------------------
 #define LOG_MAX_QUEUE_ELEMENTS 2048
@@ -164,15 +165,20 @@ static int handle_timer(zloop_t* loop, int id, void* arg) {
 
 static int handle_message(zloop_t* loop, zsock_t* reader, void* arg) {
   MessageDef* received_message_p = receive_msg(reader);
+  if (!received_message_p) {
+    return 0;
+  }
 
   switch (ITTI_MSG_ID(received_message_p)) {
     case TERMINATE_MESSAGE: {
+      itti_free_msg_content(received_message_p);
       free(received_message_p);
       shared_log_exit();
     } break;
 
     default: { } break; }
 
+  itti_free_msg_content(received_message_p);
   free(received_message_p);
   return 0;
 }

--- a/lte/gateway/c/oai/lib/itti/intertask_interface.h
+++ b/lte/gateway/c/oai/lib/itti/intertask_interface.h
@@ -51,7 +51,6 @@
 #define ITTI_MSG_ORIGIN_ID(mSGpTR) ((mSGpTR)->ittiMsgHeader.originTaskId)
 #define ITTI_MSG_DESTINATION_ID(mSGpTR)                                        \
   ((mSGpTR)->ittiMsgHeader.destinationTaskId)
-#define ITTI_MSG_INSTANCE(mSGpTR) ((mSGpTR)->ittiMsgHeader.instance)
 #define ITTI_MSG_NAME(mSGpTR) itti_get_message_name(ITTI_MSG_ID(mSGpTR))
 #define ITTI_MSG_ORIGIN_NAME(mSGpTR)                                           \
   itti_get_task_name(ITTI_MSG_ORIGIN_ID(mSGpTR))

--- a/lte/gateway/c/oai/lib/itti/intertask_interface_types.h
+++ b/lte/gateway/c/oai/lib/itti/intertask_interface_types.h
@@ -64,8 +64,6 @@
 
 /* Defines to extract task ID fields */
 #define TASK_GET_THREAD_ID(tASKiD) (itti_desc.tasks_info[tASKiD].thread)
-/* Extract the instance from a message */
-#define ITTI_MESSAGE_GET_INSTANCE(mESSAGE) ((mESSAGE)->ittiMsgHeader.instance)
 
 #include <messages_types.h>
 
@@ -128,7 +126,7 @@ typedef struct MessageHeader_s {
 
       task_id_t originTaskId;      /**< ID of the sender task */
       task_id_t destinationTaskId; /**< ID of the destination task */
-      instance_t instance;         /**< Task instance for virtualization */
+      struct timespec timestamp;   /** Time msg got created */
       imsi64_t imsi;               /** IMSI associated to sender task */
 
       MessageHeaderSize

--- a/lte/gateway/c/oai/tasks/grpc_service/grpc_service_task.c
+++ b/lte/gateway/c/oai/tasks/grpc_service/grpc_service_task.c
@@ -29,6 +29,7 @@
 #include "log.h"
 #include "mme_default_values.h"
 #include "grpc_service.h"
+#include "itti_free_defined_msg.h"
 
 static void grpc_service_exit(void);
 
@@ -37,9 +38,13 @@ task_zmq_ctx_t grpc_service_task_zmq_ctx;
 
 static int handle_message(zloop_t* loop, zsock_t* reader, void* arg) {
   MessageDef* received_message_p = receive_msg(reader);
+  if (!received_message_p) {
+    return 0;
+  }
 
   switch (ITTI_MSG_ID(received_message_p)) {
     case TERMINATE_MESSAGE:
+      itti_free_msg_content(received_message_p);
       free(received_message_p);
       grpc_service_exit();
       break;
@@ -50,6 +55,7 @@ static int handle_message(zloop_t* loop, zsock_t* reader, void* arg) {
       break;
   }
 
+  itti_free_msg_content(received_message_p);
   free(received_message_p);
   return 0;
 }

--- a/lte/gateway/c/oai/tasks/ha/ha_task.c
+++ b/lte/gateway/c/oai/tasks/ha/ha_task.c
@@ -40,6 +40,9 @@ static int handle_timer(zloop_t* loop, int id, void* arg) {
 
 static int handle_message(zloop_t* loop, zsock_t* reader, void* arg) {
   MessageDef* received_message_p = receive_msg(reader);
+  if (!received_message_p) {
+    return 0;
+  }
 
   switch (ITTI_MSG_ID(received_message_p)) {
     case AGW_OFFLOAD_REQ: {

--- a/lte/gateway/c/oai/tasks/mme_app/mme_app_main.c
+++ b/lte/gateway/c/oai/tasks/mme_app/mme_app_main.c
@@ -69,6 +69,9 @@ task_zmq_ctx_t mme_app_task_zmq_ctx;
 
 static int handle_message(zloop_t* loop, zsock_t* reader, void* arg) {
   MessageDef* received_message_p = receive_msg(reader);
+  if (!received_message_p) {
+    return 0;
+  }
   imsi64_t imsi64                = itti_get_associated_imsi(received_message_p);
   mme_app_desc_t* mme_app_desc_p = get_mme_nas_state(false);
 

--- a/lte/gateway/c/oai/tasks/s11/s11_tasks.c
+++ b/lte/gateway/c/oai/tasks/s11/s11_tasks.c
@@ -196,6 +196,9 @@ static nw_rc_t s11_mme_stop_timer_wrapper(
 
 static int handle_message(zloop_t* loop, zsock_t* reader, void* arg) {
   MessageDef* received_message_p = receive_msg(reader);
+  if (!received_message_p) {
+    return 0;
+  }
 
   switch (ITTI_MSG_ID(received_message_p)) {
     case MESSAGE_TEST: {

--- a/lte/gateway/c/oai/tasks/s1ap/s1ap_mme.c
+++ b/lte/gateway/c/oai/tasks/s1ap/s1ap_mme.c
@@ -108,8 +108,11 @@ static int s1ap_send_init_sctp(void) {
 static int handle_message(zloop_t* loop, zsock_t* reader, void* arg) {
   s1ap_state_t* state;
   MessageDef* received_message_p = receive_msg(reader);
-  imsi64_t imsi64                = itti_get_associated_imsi(received_message_p);
-  state                          = get_s1ap_state(false);
+  if (!received_message_p) {
+    return 0;
+  }
+  imsi64_t imsi64 = itti_get_associated_imsi(received_message_p);
+  state           = get_s1ap_state(false);
   AssertFatal(state != NULL, "failed to retrieve s1ap state (was null)");
 
   switch (ITTI_MSG_ID(received_message_p)) {

--- a/lte/gateway/c/oai/tasks/s6a/s6a_task.c
+++ b/lte/gateway/c/oai/tasks/s6a/s6a_task.c
@@ -57,7 +57,10 @@ task_zmq_ctx_t s6a_task_zmq_ctx;
 
 static int handle_message(zloop_t* loop, zsock_t* reader, void* arg) {
   MessageDef* received_message_p = receive_msg(reader);
-  int rc                         = RETURNerror;
+  if (!received_message_p) {
+    return 0;
+  }
+  int rc = RETURNerror;
 
   switch (ITTI_MSG_ID(received_message_p)) {
     case MESSAGE_TEST: {

--- a/lte/gateway/c/oai/tasks/sctp/sctp_primitives_server.c
+++ b/lte/gateway/c/oai/tasks/sctp/sctp_primitives_server.c
@@ -56,8 +56,11 @@ sctp_config_t sctp_conf;
 task_zmq_ctx_t sctp_task_zmq_ctx;
 
 static int handle_message(zloop_t* loop, zsock_t* reader, void* arg) {
-  MessageDef* received_message_p    = receive_msg(reader);
   static bool UPLINK_SERVER_STARTED = false;
+  MessageDef* received_message_p = receive_msg(reader);
+  if (!received_message_p) {
+    return 0;
+  }
 
   switch (ITTI_MSG_ID(received_message_p)) {
     case SCTP_INIT_MSG: {

--- a/lte/gateway/c/oai/tasks/service303/service303_task.c
+++ b/lte/gateway/c/oai/tasks/service303/service303_task.c
@@ -40,6 +40,9 @@ task_zmq_ctx_t service303_message_task_zmq_ctx;
 static int handle_service303_server_message(
     zloop_t* loop, zsock_t* reader, void* arg) {
   MessageDef* received_message_p = receive_msg(reader);
+  if (!received_message_p) {
+    return 0;
+  }
 
   switch (ITTI_MSG_ID(received_message_p)) {
     case TERMINATE_MESSAGE:
@@ -76,6 +79,9 @@ static void* service303_server_thread(__attribute__((unused)) void* args) {
 
 static int handle_service_message(zloop_t* loop, zsock_t* reader, void* arg) {
   MessageDef* received_message_p = receive_msg(reader);
+  if (!received_message_p) {
+    return 0;
+  }
 
   switch (ITTI_MSG_ID(received_message_p)) {
     case TIMER_HAS_EXPIRED: {
@@ -101,6 +107,7 @@ static int handle_service_message(zloop_t* loop, zsock_t* reader, void* arg) {
       service303_set_application_health(APP_UNHEALTHY);
     } break;
     case TERMINATE_MESSAGE:
+      itti_free_msg_content(received_message_p);
       free(received_message_p);
       service303_message_exit();
       break;
@@ -111,6 +118,7 @@ static int handle_service_message(zloop_t* loop, zsock_t* reader, void* arg) {
     } break;
   }
 
+  itti_free_msg_content(received_message_p);
   free(received_message_p);
   return 0;
 }

--- a/lte/gateway/c/oai/tasks/sgs/sgs_task.c
+++ b/lte/gateway/c/oai/tasks/sgs/sgs_task.c
@@ -33,6 +33,7 @@
 #include "csfb_client_api.h"
 #include "common_defs.h"
 #include "intertask_interface_types.h"
+#include "itti_free_defined_msg.h"
 
 static void sgs_exit(void);
 
@@ -40,6 +41,9 @@ task_zmq_ctx_t sgs_task_zmq_ctx;
 
 static int handle_message(zloop_t* loop, zsock_t* reader, void* arg) {
   MessageDef* received_message_p = receive_msg(reader);
+  if (!received_message_p) {
+    return 0;
+  }
 
   switch (ITTI_MSG_ID(received_message_p)) {
     case SGSAP_LOCATION_UPDATE_REQ: {
@@ -156,6 +160,7 @@ static int handle_message(zloop_t* loop, zsock_t* reader, void* arg) {
       send_ue_unreachable(&SGSAP_UE_UNREACHABLE(received_message_p));
     } break;
     case TERMINATE_MESSAGE: {
+      itti_free_msg_content(received_message_p);
       free(received_message_p);
       sgs_exit();
     } break;
@@ -167,6 +172,7 @@ static int handle_message(zloop_t* loop, zsock_t* reader, void* arg) {
     } break;
   }
 
+  itti_free_msg_content(received_message_p);
   free(received_message_p);
   return 0;
 }

--- a/lte/gateway/c/oai/tasks/sgw/sgw_task.c
+++ b/lte/gateway/c/oai/tasks/sgw/sgw_task.c
@@ -55,6 +55,9 @@ extern __pid_t g_pid;
 
 static int handle_message(zloop_t* loop, zsock_t* reader, void* arg) {
   MessageDef* received_message_p = receive_msg(reader);
+  if (!received_message_p) {
+    return 0;
+  }
 
   imsi64_t imsi64          = itti_get_associated_imsi(received_message_p);
   spgw_state_t* spgw_state = get_spgw_state(false);

--- a/lte/gateway/c/oai/tasks/sms_orc8r/sms_orc8r_task.c
+++ b/lte/gateway/c/oai/tasks/sms_orc8r/sms_orc8r_task.c
@@ -33,6 +33,7 @@
 #include "sms_orc8r_client_api.h"
 #include "common_defs.h"
 #include "intertask_interface_types.h"
+#include "itti_free_defined_msg.h"
 
 static void sms_orc8r_exit(void);
 
@@ -40,6 +41,9 @@ task_zmq_ctx_t sms_orc8r_task_zmq_ctx;
 
 static int handle_message(zloop_t* loop, zsock_t* reader, void* arg) {
   MessageDef* received_message_p = receive_msg(reader);
+  if (!received_message_p) {
+    return 0;
+  }
 
   switch (ITTI_MSG_ID(received_message_p)) {
     case SGSAP_UPLINK_UNITDATA: {
@@ -55,6 +59,7 @@ static int handle_message(zloop_t* loop, zsock_t* reader, void* arg) {
     } break;
 
     case TERMINATE_MESSAGE: {
+      itti_free_msg_content(received_message_p);
       free(received_message_p);
       sms_orc8r_exit();
     } break;
@@ -66,6 +71,7 @@ static int handle_message(zloop_t* loop, zsock_t* reader, void* arg) {
     } break;
   }
 
+  itti_free_msg_content(received_message_p);
   free(received_message_p);
   return 0;
 }

--- a/lte/gateway/c/oai/tasks/udp/udp_primitives_server.c
+++ b/lte/gateway/c/oai/tasks/udp/udp_primitives_server.c
@@ -362,6 +362,9 @@ static int udp_server_create_socket_v6(
 
 static int handle_message(zloop_t* loop, zsock_t* reader, void* arg) {
   MessageDef* received_message_p = receive_msg(reader);
+  if (!received_message_p) {
+    return 0;
+  }
 
   switch (ITTI_MSG_ID(received_message_p)) {
     case MESSAGE_TEST: {


### PR DESCRIPTION

Signed-off-by: Tariq Al-Khasib <talkhasib@fb.com>

## Summary

ZMQ buffer size has a limit of 1000 messages by default. We can change that limit. But prefer adding a time based limit instead.

This PR adds a 2 sec delay limit on all ZMQ buffers. Consumer will ignore top of queue message if it exceeded the deadline.

## Test Plan

Continuous attach Integ test
