### PR TITLE
Update node version for docusaurus

### DIFF
--- a/docs/docusaurus/Dockerfile
+++ b/docs/docusaurus/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:8.11.4
+FROM node:14
 
 WORKDIR /app/website
 


### PR DESCRIPTION
Signed-off-by: Bruce Davie <3101026+drbruced12@users.noreply.github.com>

<!--
   [docs]
-->

## Summary

Docusaurus requires node version >= 10.9.0. This commit updates the Dockerfile to use Node 14 (previously 8.11.4)

## Test Plan

<!--
    Built docs locally, and successfully viewed them. 
Terminal output:
  docusaurus git:(node-version) ✗ ./create_docusaurus_website.sh
[+] Building 4.2s (12/12) FINISHED
 => [internal] load build definition from Dockerfile                                                                  0.1s
 => => transferring dockerfile: 260B                                                                                  0.0s
 => [internal] load .dockerignore                                                                                     0.0s
 => => transferring context: 2B                                                                                       0.0s
 => [internal] load metadata for docker.io/library/node:14                                                            3.7s
 => [1/7] FROM docker.io/library/node:14@sha256:fe842f5b828c121514d62cbe0ace0927aec4f3130297180c3343e54e7ae97362      0.0s
 => [internal] load build context                                                                                     0.1s
 => => transferring context: 33.72kB                                                                                  0.1s
 => CACHED [2/7] WORKDIR /app/website                                                                                 0.0s
 => CACHED [3/7] COPY docusaurus/package.json /app/website/package.json                                               0.0s
 => CACHED [4/7] RUN yarn install                                                                                     0.0s
 => CACHED [5/7] COPY docusaurus /app/website                                                                         0.0s
 => CACHED [6/7] COPY readmes /app/docs                                                                               0.0s
 => CACHED [7/7] RUN yarn build                                                                                       0.0s
 => exporting to image                                                                                                0.0s
 => => exporting layers                                                                                               0.0s
 => => writing image sha256:66d498131a97d237800d23a09acc7192eab166a193831c9160bc9381b946442f                          0.0s
 => => naming to docker.io/library/docusaurus-doc                                                                     0.0s
docs_container
62488ad22f0d7b569662c31f69499c87c57db968fc49989cf10e91e8aa888cfb

Navigate to http://localhost:3000/ to see the docs.
-->

## Additional Information


