### PR TITLE
[orc8r] Make s8 field optional in swagger for FEG gateways too

### DIFF
--- a/feg/cloud/go/services/feg/obsidian/models/gateway_federation_configs_swaggergen.go
+++ b/feg/cloud/go/services/feg/obsidian/models/gateway_federation_configs_swaggergen.go
@@ -55,8 +55,7 @@ type GatewayFederationConfigs struct {
 	S6a *S6a `json:"s6a"`
 
 	// s8
-	// Required: true
-	S8 *S8 `json:"s8"`
+	S8 *S8 `json:"s8,omitempty"`
 
 	// served network ids
 	// Required: true
@@ -316,8 +315,8 @@ func (m *GatewayFederationConfigs) validateS6a(formats strfmt.Registry) error {
 
 func (m *GatewayFederationConfigs) validateS8(formats strfmt.Registry) error {
 
-	if err := validate.Required("s8", "body", m.S8); err != nil {
-		return err
+	if swag.IsZero(m.S8) { // not required
+		return nil
 	}
 
 	if m.S8 != nil {

--- a/feg/cloud/go/services/feg/obsidian/models/swagger.v1.yml
+++ b/feg/cloud/go/services/feg/obsidian/models/swagger.v1.yml
@@ -1485,7 +1485,6 @@ definitions:
     minLength: 1
     required:
       - s6a
-      - s8
       - hss
       - gx
       - gy

--- a/orc8r/cloud/go/obsidian/swagger/v1/swagger.yml
+++ b/orc8r/cloud/go/obsidian/swagger/v1/swagger.yml
@@ -8403,7 +8403,6 @@ definitions:
         $ref: '#/definitions/swx'
     required:
     - s6a
-    - s8
     - hss
     - gx
     - gy


### PR DESCRIPTION
Signed-off-by: Oriol Batalla <obatalla@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary

Make s8 field not required for gateways too 

## Test Plan

./build -g

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
