### PR TITLE
correct links to images in feg setup guide

### DIFF
--- a/docs/readmes/feg/federated_FWA_setup_guide.md
+++ b/docs/readmes/feg/federated_FWA_setup_guide.md
@@ -23,13 +23,13 @@ When configuring an integration with LTE nodes, it is necessary to link these tw
 
 In the **Federated LTE** **Network**’s NMS page, the Federation config should be the **Federation** **Network**’s network ID.
 
-![NMS-FederatedLTE-Config.png](../assets/feg/NMS-FederatedLTE-Config.png)
+![NMS-FederatedLTE-Config.png](assets/feg/NMS-FederatedLTE-Config.png)
 
 ### Associating Federation network to a FederatedLTE network
 
 In order to complete the association, we also need to modify the **Federation Network**‘s federation configuration.
 
-![API-Federation-Network-Config.png](../assets/feg/API-Federation-Network-Config.png)
+![API-Federation-Network-Config.png](assets/feg/API-Federation-Network-Config.png)
 
 Ensure that the following field “served_network_ids” has the **Federated LTE** **Network** networkID.
 
@@ -43,7 +43,7 @@ Ensure that the following field “served_network_ids” has the **Federated LTE
 
 In **Federated LTE** **Network**’s EPC configuration, ensure both of the relay flags are set to `true`.
 
-![API-LTE-Network-EPC-Config.png](../assets/feg/API-LTE-Network-EPC-Config.png)
+![API-LTE-Network-EPC-Config.png](assets/feg/API-LTE-Network-EPC-Config.png)
 ```
   "gx_gy_relay_enabled": true,
   "hss_relay_enabled": true,
@@ -53,14 +53,14 @@ In **Federated LTE** **Network**’s EPC configuration, ensure both of the relay
 
 The NMS page for  **Federated LTE Network** has the following policy configuration page.
 
-![NMS-Policy-Config.png](../assets/feg/NMS-Policy-Config.png)
+![NMS-Policy-Config.png](assets/feg/NMS-Policy-Config.png)
 
 ### Configuring Omnipresent/Network-Wide Policies
 
 Omnipresent rules or Network-Wide polices are policies that do not require a PCRF to install. On Session creation, all network wide policies will be installed for the session along with any other policies configured by the PCRF.
 In the policy configuration’s edit dialogue, use the **Network Wide** check box to toggle the configuration.
 
-![NMS-Network-Wide-Rules-Config.png](../assets/feg/NMS-Network-Wide-Rules-Config.png)
+![NMS-Network-Wide-Rules-Config.png](assets/feg/NMS-Network-Wide-Rules-Config.png)
 
 
 ## Advanced Configuration Steps
@@ -69,7 +69,7 @@ In the policy configuration’s edit dialogue, use the **Network Wide** check bo
 
 In order to enable FUA-redirection support, enable the `redirectd` service in the magmad configuration.
 
-![API-LTE-Magmad-Config.png](../assets/feg/API-LTE-Magmad-Config.png)
+![API-LTE-Magmad-Config.png](assets/feg/API-LTE-Magmad-Config.png)
 ```
 "dynamic_services": ["eventd","td-agent-bit","redirectd"]
 ```
@@ -80,7 +80,7 @@ In order to enable FUA-redirection support, enable the `redirectd` service in th
 
 **DisableGx**: For PCRF-less deployments. In this setting, omnipresent policies must be added to the networks’ subscriber_config. If the rules contain a rating group, credit usage will be reported through the Gy interface.
 
-![API-Federation-Network-Config.png](../assets/feg/API-Federation-Network-Config.png)
+![API-Federation-Network-Config.png](assets/feg/API-Federation-Network-Config.png)
 
 The relevant configurations for disabling Gx/Gy are:
 
@@ -105,7 +105,7 @@ To enable this feature add a list `plmn_ids` to `s6a` and add a list of PLMN
 ids. The list can contain 5 digit or 6 digit PLMN ids. If the list is empty or
 null, s6a will send any IMSI request to HSS.
 
-![API-Federation-Network-Config.png](../assets/feg/API-Federation-Network-Config.png)
+![API-Federation-Network-Config.png](assets/feg/API-Federation-Network-Config.png)
 
 ```
 "s6a": {


### PR DESCRIPTION
Signed-off-by: Bruce Davie <3101026+drbruced12@users.noreply.github.com>

<!--
    [docs]
-->

## Summary

<!-- Links to images from readmes/feg/federated_FWA_setup_guide.md were broken; this commit
        fixes them
 -->

## Test Plan

<!--
    Built the docs locally and verified that linked images were correctly displayed. Before:
<img width="731" alt="Screen Shot 2021-03-16 at 1 38 03 pm" src="https://user-images.githubusercontent.com/3101026/111249192-6b96eb80-865f-11eb-8965-0463a775dc61.png">
After:
<img width="776" alt="Screen Shot 2021-03-16 at 1 43 37 pm" src="https://user-images.githubusercontent.com/3101026/111249444-d6e0bd80-865f-11eb-9fce-f5836487d3a5.png">

-->

## Additional Information


