### PR TITLE
[CI][NOTIFICATIONS]Split slack notifications

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -367,7 +367,7 @@ commands:
 
             slack_data=$(cat \<<EOF
             {
-              "channel": "#ci",
+              "channel": "${SLACK_CHANNEL_CI}",
               "text": "*CircleCI Job Failure*",
               "attachments": [
                 {
@@ -435,7 +435,7 @@ commands:
 
             slack_data=$(cat \<<EOF
             {
-              "channel": "#ci",
+              "channel": "${SLACK_CHANNEL_ARTIFACTS}",
               "text": "*<< parameters.artifact_name >> Artifact Has Been Published*",
               "attachments": [
                 {


### PR DESCRIPTION
Signed-off-by: Timothée Dzik <timdzik@fb.com>

[CI][NOTIFICATIONS]Split slack notifications

## Summary

[CI][NOTIFICATIONS]Split slack notifications into 2 chans 
one for artifacts publishing 
one for ci failures

## Test Plan

/shrug

## Additional Information

- [ ] This change is backwards-breaking