### PR TITLE
[SessionD] Modify SessionD unit tests for better stability

### DIFF
--- a/lte/gateway/c/session_manager/test/test_session_manager_handler.cpp
+++ b/lte/gateway/c/session_manager/test/test_session_manager_handler.cpp
@@ -101,9 +101,7 @@ class SessionManagerHandlerTest : public ::testing::Test {
     rule_store->insert_rule(rule);
   }
 
-  // This function should always be called at the beginning of the test to
-  // prevent unexpected SessionD <-> PipelineD syncing logic mid-test.
-  void send_empty_table_and_wait_for_setup(SetupFlowsResult_Result res) {
+  void send_empty_table() {
     RuleRecordTable empty_table;
     // epoch indicates the last PipelineD service start time
     empty_table.set_epoch(DEFAULT_PIPELINED_EPOCH);
@@ -111,12 +109,18 @@ class SessionManagerHandlerTest : public ::testing::Test {
     session_manager->ReportRuleStats(
         &context, &empty_table,
         [this](grpc::Status status, Void response_out) {});
+  }
 
+  // This function should always be called at the beginning of the test to
+  // prevent unexpected SessionD <-> PipelineD syncing logic mid-test.
+  void send_empty_table_and_wait_for_successful_setup() {
+    send_empty_table();
     EXPECT_CALL(
         *pipelined_client, setup_lte(testing::_, testing::_, testing::_))
         .Times(1)
-        .WillOnce(
-            testing::DoAll(CallSetupCallback(res), testing::Return(true)));
+        .WillOnce(testing::DoAll(
+            CallSetupCallback(SetupFlowsResult_Result_SUCCESS),
+            testing::Return(true)));
     evb->loopOnce();
     evb->loopOnce();
   }
@@ -137,7 +141,7 @@ class SessionManagerHandlerTest : public ::testing::Test {
 };
 
 TEST_F(SessionManagerHandlerTest, test_create_session_cfg) {
-  send_empty_table_and_wait_for_setup(SetupFlowsResult_Result_SUCCESS);
+  send_empty_table_and_wait_for_successful_setup();
   // 1) Insert the entry for a rule
   insert_static_rule(rule_store, monitoring_key, 1, "rule1");
   std::vector<std::string> static_rules{"rule1"};
@@ -209,7 +213,7 @@ TEST_F(SessionManagerHandlerTest, test_create_session_cfg) {
 }
 
 TEST_F(SessionManagerHandlerTest, test_session_recycling_lte) {
-  send_empty_table_and_wait_for_setup(SetupFlowsResult_Result_SUCCESS);
+  send_empty_table_and_wait_for_successful_setup();
   // 1) Insert the entry for a rule
   insert_static_rule(rule_store, monitoring_key, 1, "rule1");
   std::vector<std::string> static_rules{"rule1"};
@@ -311,7 +315,7 @@ TEST_F(SessionManagerHandlerTest, test_session_recycling_lte) {
 }
 
 TEST_F(SessionManagerHandlerTest, test_create_session) {
-  send_empty_table_and_wait_for_setup(SetupFlowsResult_Result_SUCCESS);
+  send_empty_table_and_wait_for_successful_setup();
   // 1) Create the session
   LocalCreateSessionRequest request;
 
@@ -359,7 +363,14 @@ TEST_F(SessionManagerHandlerTest, test_create_session) {
 }
 
 TEST_F(SessionManagerHandlerTest, test_create_session_pipelined_unavailable) {
-  send_empty_table_and_wait_for_setup(SetupFlowsResult_Result_FAILURE);
+  send_empty_table();
+  // On failure cases, LocalEnforcer will endlessly retry the setup call
+  EXPECT_CALL(*pipelined_client, setup_lte(testing::_, testing::_, testing::_))
+      .WillRepeatedly(testing::DoAll(
+          CallSetupCallback(SetupFlowsResult_Result_FAILURE),
+          testing::Return(true)));
+  evb->loopOnce();
+  evb->loopOnce();
   // 1) Create the session
   LocalCreateSessionRequest request;
 


### PR DESCRIPTION
Signed-off-by: Marie Bremner <marwhal@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary
The wait_for_setup... function relies on progressing the event loop a few times to make sure the initial setup calls are processed. On failure cases (especially in @electronjoe 's dockerized version), we've seen that this produces an unexpected expectation over-saturation failure as LocalEnforcer calls setup again. 

This is a minor change to expect at least one setup call for failure cases, since we can't guarantee how many.

#thanks @electronjoe for finding this!

## Test Plan
make precommit_sm
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
