### PR TITLE
[agw][mme][easy] Remove unused S1AP ITTI log msgs and gcc warning on fn return type

### DIFF
--- a/lte/gateway/c/oai/common/itti_free_defined_msg.c
+++ b/lte/gateway/c/oai/common/itti_free_defined_msg.c
@@ -138,18 +138,6 @@ void itti_free_msg_content(MessageDef* const message_p) {
       message_p->ittiMsg.s11_paging_request.imsi = NULL;
     } break;
 
-    case S1AP_UPLINK_NAS_LOG:
-    case S1AP_UE_CAPABILITY_IND_LOG:
-    case S1AP_INITIAL_CONTEXT_SETUP_LOG:
-    case S1AP_NAS_NON_DELIVERY_IND_LOG:
-    case S1AP_DOWNLINK_NAS_LOG:
-    case S1AP_S1_SETUP_LOG:
-    case S1AP_INITIAL_UE_MESSAGE_LOG:
-    case S1AP_UE_CONTEXT_RELEASE_REQ_LOG:
-    case S1AP_UE_CONTEXT_RELEASE_COMMAND_LOG:
-    case S1AP_UE_CONTEXT_RELEASE_LOG:
-      // DO nothing
-      break;
     case S1AP_ENB_INITIATED_RESET_ACK:
       free_wrapper((void**) &message_p->ittiMsg.s1ap_enb_initiated_reset_ack
                        .ue_to_reset_list);

--- a/lte/gateway/c/oai/common/log.c
+++ b/lte/gateway/c/oai/common/log.c
@@ -1531,7 +1531,7 @@ int append_log_ctx_info_prefix_id(
 //    input: /home/vagrant/magma/lte/gateway/c/oai/tasks/nas/emm/sap/emm_cn.c
 //           Assume root is /oai/
 //    output: tasks/nas/emm/sap/emm_cn.c
-const char* const get_short_file_name(const char* const source_file_nameP) {
+const char* get_short_file_name(const char* const source_file_nameP) {
   if (!source_file_nameP) return source_file_nameP;
 
   char* root_startP = strstr(source_file_nameP, LOG_MAGMA_REPO_ROOT);

--- a/lte/gateway/c/oai/common/log.h
+++ b/lte/gateway/c/oai/common/log.h
@@ -364,7 +364,7 @@ int append_log_ctx_info_prefix_id(
     size_t filename_length, const log_thread_ctxt_t* thread_ctxt,
     time_t* cur_time, const char* short_source_fileP);
 
-const char* const get_short_file_name(const char* const source_file_nameP);
+const char* get_short_file_name(const char* const source_file_nameP);
 
 // Return the hex representation of a char array
 char* bytes_to_hex(char* byte_array, int length, char* hex_array);

--- a/lte/gateway/c/oai/include/s1ap_messages_def.h
+++ b/lte/gateway/c/oai/include/s1ap_messages_def.h
@@ -37,29 +37,6 @@
   \email: lionel.gauthier@eurecom.fr
 */
 
-/* Messages for S1AP logging */
-MESSAGE_DEF(S1AP_UPLINK_NAS_LOG, IttiMsgText, s1ap_uplink_nas_log)
-MESSAGE_DEF(S1AP_UE_CAPABILITY_IND_LOG, IttiMsgText, s1ap_ue_capability_ind_log)
-MESSAGE_DEF(
-    S1AP_INITIAL_CONTEXT_SETUP_LOG, IttiMsgText, s1ap_initial_context_setup_log)
-MESSAGE_DEF(
-    S1AP_NAS_NON_DELIVERY_IND_LOG, IttiMsgText, s1ap_nas_non_delivery_ind_log)
-MESSAGE_DEF(S1AP_DOWNLINK_NAS_LOG, IttiMsgText, s1ap_downlink_nas_log)
-MESSAGE_DEF(S1AP_S1_SETUP_LOG, IttiMsgText, s1ap_s1_setup_log)
-MESSAGE_DEF(
-    S1AP_INITIAL_UE_MESSAGE_LOG, IttiMsgText, s1ap_initial_ue_message_log)
-MESSAGE_DEF(
-    S1AP_UE_CONTEXT_RELEASE_REQ_LOG, IttiMsgText,
-    s1ap_ue_context_release_req_log)
-MESSAGE_DEF(
-    S1AP_UE_CONTEXT_RELEASE_COMMAND_LOG, IttiMsgText,
-    s1ap_ue_context_release_command_log)
-MESSAGE_DEF(
-    S1AP_UE_CONTEXT_RELEASE_LOG, IttiMsgText, s1ap_ue_context_release_log)
-MESSAGE_DEF(S1AP_ENB_RESET_LOG, IttiMsgText, s1ap_enb_reset_log)
-MESSAGE_DEF(
-    S1AP_UE_CONTEXT_MODIFICATION_LOG, IttiMsgText,
-    s1ap_ue_context_modification_log)
 MESSAGE_DEF(S1AP_UE_CAPABILITIES_IND, itti_s1ap_ue_cap_ind_t, s1ap_ue_cap_ind)
 MESSAGE_DEF(
     S1AP_ENB_DEREGISTERED_IND, itti_s1ap_eNB_deregistered_ind_t,
@@ -101,11 +78,6 @@ MESSAGE_DEF(
     s1ap_ue_context_mod_failure)
 MESSAGE_DEF(S1AP_E_RAB_REL_CMD, itti_s1ap_e_rab_rel_cmd_t, s1ap_e_rab_rel_cmd)
 MESSAGE_DEF(S1AP_E_RAB_REL_RSP, itti_s1ap_e_rab_rel_rsp_t, s1ap_e_rab_rel_rsp)
-MESSAGE_DEF(
-    S1AP_ENB_CONFIGURATION_TRANSFER_LOG, IttiMsgText,
-    s1ap_enb_configuration_transfer_log)
-MESSAGE_DEF(
-    S1AP_PATH_SWITCH_REQUEST_LOG, IttiMsgText, s1ap_path_switch_request_log)
 MESSAGE_DEF(
     S1AP_PATH_SWITCH_REQUEST, itti_s1ap_path_switch_request_t,
     s1ap_path_switch_request)

--- a/lte/gateway/c/oai/tasks/s1ap/CMakeLists.txt
+++ b/lte/gateway/c/oai/tasks/s1ap/CMakeLists.txt
@@ -43,13 +43,13 @@ target_include_directories(LIB_S1AP PUBLIC
     ${CMAKE_CURRENT_SOURCE_DIR}/r15
 )
 
-set(PCEF_LTE_CPP_PROTOS s1ap_state common_types)
+set(S1AP_STATE_CPP_PROTOS s1ap_state common_types)
 
 list(APPEND PROTO_SRCS "")
 list(APPEND PROTO_HDRS "")
 
 set(STATE_OUT_DIR "${CMAKE_CURRENT_BINARY_DIR}/lte/protos/oai")
-generate_cpp_protos("${PCEF_LTE_CPP_PROTOS}" "${PROTO_SRCS}" "${PROTO_HDRS}"
+generate_cpp_protos("${S1AP_STATE_CPP_PROTOS}" "${PROTO_SRCS}" "${PROTO_HDRS}"
         "${STATE_PROTO_DIR}" "${STATE_OUT_DIR}")
 
 add_library(TASK_S1AP


### PR DESCRIPTION
Signed-off-by: Shruti Sanadhya <ssanadhya@fb.com>

## Summary

- Remove unused ITTI messages for S1AP.*LOG
- Removed `PCEF` name in S1ap CmakeLists.txt
- Fixed the `warning: type qualifiers ignored on function return type [-Wignored-qualifiers]` on `get_short_file_name`

## Test Plan

- `make build_oai` on dev VM
- `make integ_test TESTS=s1aptests/test_attach_detach.py` for basic sanity testing
