### PR TITLE
Temporarily disable CWF qos

### DIFF
--- a/cwf/gateway/configs/pipelined.yml
+++ b/cwf/gateway/configs/pipelined.yml
@@ -127,7 +127,7 @@ ipv6_router_addr: 'd88d:aba4:472f:fc95:7e7d:8457:5301:ebce'
 
 # QoS parameters
 qos:
- enable: true
+ enable: false
  impl: ovs_meter
  max_rate: 1000000000
  linux_tc:

--- a/cwf/gateway/integ_tests/gx_qos_enforcement_test.go
+++ b/cwf/gateway/integ_tests/gx_qos_enforcement_test.go
@@ -65,6 +65,7 @@ func verifyEgressRate(t *testing.T, tr *TestRunner, req *cwfprotos.GenTrafficReq
 // - Generate traffic and verify if the traffic observed bitrate matches the configured
 // bitrate
 func TestGxUplinkTrafficQosEnforcement(t *testing.T) {
+	t.Skip("Temporarily skipping test due to CWF QOS issues")
 	fmt.Println("\nRunning TestGxUplinkTrafficQosEnforcement")
 	if testing.Short() {
 		t.Skip("skipping test in short mode.")
@@ -147,6 +148,7 @@ func checkIfRuleInstalled(tr *TestRunner, ruleName string) bool {
 // - Generate traffic from server to client and verify if the traffic observed bitrate
 //   matches the configured bitrate
 func TestGxDownlinkTrafficQosEnforcement(t *testing.T) {
+	t.Skip("Temporarily skipping test due to CWF QOS issues")
 	fmt.Println("\nRunning TestGxDownlinkTrafficQosEnforcement")
 	tr := NewTestRunner(t)
 	ruleManager, err := NewRuleManager()
@@ -218,6 +220,7 @@ func TestGxDownlinkTrafficQosEnforcement(t *testing.T) {
 // - Send another CCA-update which upgrades the QOS through a dynamic rule and verify
 // that the observed bitrate maches the newly configured bitrate
 func TestGxQosDowngradeWithCCAUpdate(t *testing.T) {
+	t.Skip("Temporarily skipping test due to CWF QOS issues")
 	fmt.Println("\nRunning TestGxQosDowngradeWithCCAUpdate")
 	if testing.Short() {
 		t.Skip("skipping test in short mode.")
@@ -337,6 +340,7 @@ func TestGxQosDowngradeWithCCAUpdate(t *testing.T) {
 // - Generate traffic and verify if the traffic observed bitrate matches the newly
 // downgraded bitrate
 func TestGxQosDowngradeWithReAuth(t *testing.T) {
+	t.Skip("Temporarily skipping test due to CWF QOS issues")
 	fmt.Println("\nRunning TestGxQosDowngradeWithReAuth")
 	if testing.Short() {
 		t.Skip("skipping test in short mode.")

--- a/cwf/gateway/integ_tests/gx_qos_restart_test.go
+++ b/cwf/gateway/integ_tests/gx_qos_restart_test.go
@@ -70,6 +70,7 @@ const (
 // - Generate traffic and verify if the traffic observed bitrate matches the configured
 // bitrate, restart pipelined and verify if Qos remains enforced
 func testQosEnforcementRestart(t *testing.T, cfgCh chan string, restartCfg string) {
+	t.Skip("Temporarily skipping test due to CWF QOS issues")
 	tr := NewTestRunner(t)
 
 	// do not use restartPipeline functon. Otherwise we are not testing the case where attach

--- a/cwf/gateway/integ_tests/pipelined.yml
+++ b/cwf/gateway/integ_tests/pipelined.yml
@@ -110,7 +110,7 @@ internal_ip_subnet: '192.168.0.0/16'
 
 # QoS parameters
 qos:
- enable: true
+ enable: false
  impl: ovs_meter
  max_rate: 1000000000
  linux_tc:


### PR DESCRIPTION
Signed-off-by: Nick Yurchenko <koolzz@fb.com>


Currently QOS in CWF is breaking pipelined, disabling until fix is found
<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
