### PR TITLE
[orc8r] Add simple collapse button

### DIFF
--- a/orc8r/cloud/go/obsidian/swagger/v1/index.html
+++ b/orc8r/cloud/go/obsidian/swagger/v1/index.html
@@ -30,20 +30,21 @@
       background: #fafafa;
     }
   </style>
+  <script src="https://kit.fontawesome.com/85d0a9f517.js" crossorigin="anonymous"></script>
 </head>
 
 <body>
 
 <!-- Sidebar navigation -->
 <div class="sidenav">
-  <!-- Collapse Button -->
-  <button onclick="window.location=window.location + '?docExpansion=none' "> Collapse Tags </button>
-
   <a id = "home" {{if eq .SelectedService "" }}class="selected"{{end}} href="./"> Home </a>
 
   {{ range $idx, $val := .Services}}
   <a href="{{$val}}" {{if eq $.SelectedService $val}}class="selected"{{end}}> {{ $val }} </a>
   {{ end }}
+
+  <!-- Collapse Button -->
+  <button class="fas fa-compress-alt" style="cursor: pointer; font-size: x-large; margin-left: 10px;" onclick="window.location=window.location + '?docExpansion=none' "></button>
 </div>
 
 <svg xmlns="http://www.w3.org/2000/svg"

--- a/orc8r/cloud/go/obsidian/swagger/v1/index.html
+++ b/orc8r/cloud/go/obsidian/swagger/v1/index.html
@@ -36,6 +36,9 @@
 
 <!-- Sidebar navigation -->
 <div class="sidenav">
+  <!-- Collapse Button -->
+  <button onclick="window.location=window.location + '?docExpansion=none' "> Collapse Tags </button>
+
   <a id = "home" {{if eq .SelectedService "" }}class="selected"{{end}} href="./"> Home </a>
 
   {{ range $idx, $val := .Services}}


### PR DESCRIPTION
Signed-off-by: Andy Lee Khuu <andykhuu@stanford.edu>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary
This PR adds a simple collapse button so that users of the Swagger UI can collapse service tags.
![Screen Shot 2021-03-17 at 2 02 10 PM](https://user-images.githubusercontent.com/46101219/111538052-7453f400-8729-11eb-891a-4c00334123f5.png)
![Screen Shot 2021-03-17 at 2 03 02 PM](https://user-images.githubusercontent.com/46101219/111538113-846bd380-8729-11eb-9f24-e62849a084ab.png)


<!-- Enumerate changes you made and why you made them -->

## Test Plan
- [x] ./build.py -t
- [x] Manual Testing of UI -> see images above
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
