### PR TITLE
[MME][Bug] On MME shutdown, stop GRPC service before releasing ZMQ ctx

### DIFF
--- a/lte/gateway/c/oai/tasks/grpc_service/grpc_service_task.c
+++ b/lte/gateway/c/oai/tasks/grpc_service/grpc_service_task.c
@@ -81,8 +81,8 @@ int grpc_service_init(void) {
 static void grpc_service_exit(void) {
   bdestroy_wrapper(&grpc_service_config->server_address);
   free_wrapper((void**) &grpc_service_config);
-  destroy_task_context(&grpc_service_task_zmq_ctx);
   stop_grpc_service();
+  destroy_task_context(&grpc_service_task_zmq_ctx);
   OAI_FPRINTF_INFO("TASK_GRPC_SERVICE terminated\n");
   pthread_exit(NULL);
 }

--- a/lte/gateway/c/oai/tasks/mme_app/mme_app_main.c
+++ b/lte/gateway/c/oai/tasks/mme_app/mme_app_main.c
@@ -500,13 +500,12 @@ static bool _is_mme_app_healthy(void) {
 
 //------------------------------------------------------------------------------
 static void mme_app_exit(void) {
-  destroy_task_context(&mme_app_task_zmq_ctx);
   mme_app_edns_exit();
   clear_mme_nas_state();
   // Clean-up NAS module
   nas_network_cleanup();
   mme_config_exit();
-
+  destroy_task_context(&mme_app_task_zmq_ctx);
   OAI_FPRINTF_INFO("TASK_MME_APP terminated\n");
   pthread_exit(NULL);
 }

--- a/lte/gateway/c/oai/tasks/s1ap/s1ap_mme.c
+++ b/lte/gateway/c/oai/tasks/s1ap/s1ap_mme.c
@@ -350,12 +350,12 @@ int s1ap_mme_init(const mme_config_t* mme_config_p) {
 void s1ap_mme_exit(void) {
   OAILOG_DEBUG(LOG_S1AP, "Cleaning S1AP\n");
 
-  destroy_task_context(&s1ap_task_zmq_ctx);
-
   put_s1ap_state();
   put_s1ap_imsi_map();
 
   s1ap_state_exit();
+
+  destroy_task_context(&s1ap_task_zmq_ctx);
 
   OAILOG_DEBUG(LOG_S1AP, "Cleaning S1AP: DONE\n");
   OAI_FPRINTF_INFO("TASK_S1AP terminated\n");

--- a/lte/gateway/c/oai/tasks/s6a/s6a_task.c
+++ b/lte/gateway/c/oai/tasks/s6a/s6a_task.c
@@ -167,10 +167,8 @@ int s6a_init(const mme_config_t* mme_config_p) {
 
 //------------------------------------------------------------------------------
 static void s6a_exit(void) {
-  destroy_task_context(&s6a_task_zmq_ctx);
-
   s6a_viface_close();
-
+  destroy_task_context(&s6a_task_zmq_ctx);
   OAI_FPRINTF_INFO("TASK_S6A terminated\n");
   pthread_exit(NULL);
 }

--- a/lte/gateway/c/oai/tasks/sctp/sctp_primitives_server.c
+++ b/lte/gateway/c/oai/tasks/sctp/sctp_primitives_server.c
@@ -158,8 +158,8 @@ int sctp_init(const mme_config_t* mme_config_p) {
 }
 
 static void sctp_exit(void) {
-  destroy_task_context(&sctp_task_zmq_ctx);
   stop_sctpd_uplink_server();
+  destroy_task_context(&sctp_task_zmq_ctx);
   OAI_FPRINTF_INFO("TASK_SCTP terminated\n");
   pthread_exit(NULL);
 }

--- a/lte/gateway/c/oai/tasks/service303/service303_task.c
+++ b/lte/gateway/c/oai/tasks/service303/service303_task.c
@@ -186,8 +186,8 @@ static void service303_server_exit(void) {
 }
 
 static void service303_message_exit(void) {
-  destroy_task_context(&service303_message_task_zmq_ctx);
   timer_remove(service303_epc_stats_timer_id, NULL);
+  destroy_task_context(&service303_message_task_zmq_ctx);
   OAI_FPRINTF_INFO("TASK_SERVICE303 terminated\n");
   pthread_exit(NULL);
 }

--- a/lte/gateway/c/oai/tasks/sgw/sgw_task.c
+++ b/lte/gateway/c/oai/tasks/sgw/sgw_task.c
@@ -251,12 +251,10 @@ int spgw_app_init(spgw_config_t* spgw_config_pP, bool persist_state) {
 //------------------------------------------------------------------------------
 static void spgw_app_exit(void) {
   OAILOG_DEBUG(LOG_SPGW_APP, "Cleaning SGW\n");
-
-  destroy_task_context(&spgw_app_task_zmq_ctx);
   put_spgw_state();
   gtpv1u_exit();
   spgw_state_exit();
-
+  destroy_task_context(&spgw_app_task_zmq_ctx);
   OAILOG_DEBUG(LOG_SPGW_APP, "Finished cleaning up SGW\n");
   OAI_FPRINTF_INFO("TASK_SPGW_APP terminated\n");
   pthread_exit(NULL);


### PR DESCRIPTION
Signed-off-by: Tariq Al-Khasib <talkhasib@fb.com>

## Summary

When MME shutsdown, we destroy the grpc service ZMQ context before we stop the GRPC server.
This occasionally leads to processing a GRPC message while the ZMQ context is destroyed. Thus sending a ZMQ msg to NULL socket. There is an assert that catches the issue.

## Test Plan

Ran few integ tests
