### PR TITLE
[mme] Add federated map to mme.config and template

### DIFF
--- a/lte/gateway/configs/templates/mme.conf.template
+++ b/lte/gateway/configs/templates/mme.conf.template
@@ -263,8 +263,21 @@ MME :
     };
 
     S-GW :
-   {
-    # S-GW binded interface for S11 communication (GTPV2-C), if none selected the ITTI message interface is used
-       SGW_IPV4_ADDRESS_FOR_S11              = "{{ remote_sgw_ip }}";
-   };
+    {
+        # S-GW binded interface for S11 communication (GTPV2-C), if none selected the ITTI message interface is used
+        SGW_IPV4_ADDRESS_FOR_S11              = "{{ remote_sgw_ip }}";
+    };
+
+
+    FEDERATED_MODE_MAP = (
+        # ModeMapItem values can be found at magma/lte/protos/mconfig/mconfigs.proto
+        {% for fed_map in federated_mode_map -%}
+        {
+          MODE        = "{{ fed_map.mode }}"
+          PLMN        = "{{ fed_map.plmn }}"
+          IMSI_RANGE  = "{{ fed_map.imsi_range }}"
+          APN         = "{{ fed_map.apn }}"
+        }{% if not loop.last %},{% endif %}
+        {% endfor %}
+   );
 };

--- a/lte/gateway/python/scripts/generate_oai_config.py
+++ b/lte/gateway/python/scripts/generate_oai_config.py
@@ -177,6 +177,11 @@ def _get_apn_correction_map_list(service_mconfig):
         return service_mconfig.apn_correction_map_list
     return get_service_config_value("mme", "apn_correction_map_list", None)
 
+def _get_federated_mode_map(service_mconfig):
+    if service_mconfig.federated_mode_map and \
+            service_mconfig.federated_mode_map.enabled and \
+            len(service_mconfig.federated_mode_map.mapping) != 0:
+        return service_mconfig.federated_mode_map.mapping
 
 def _get_context():
     """
@@ -207,7 +212,8 @@ def _get_context():
         "use_stateless": get_service_config_value("mme",
                                                   "use_stateless", ""),
         "attached_enodeb_tacs": _get_attached_enodeb_tacs(mme_service_config),
-        "enable_nat": _get_enable_nat(mme_service_config)
+        "enable_nat": _get_enable_nat(mme_service_config),
+        "federated_mode_map" : _get_federated_mode_map(mme_service_config)
     }
 
     context["s1u_ip"] = mme_service_config.ipv4_sgw_s1u_addr or \
@@ -224,11 +230,11 @@ def _get_context():
             "ovs_uplink_mac",
     ):
         context[key] = get_service_config_value("spgw", key, "")
-    context["enable_apn_correction"] = get_service_config_value("mme",
-                                                                "enable_apn_correction",
-                                                                "")
-    context["apn_correction_map_list"] = _get_apn_correction_map_list(
-        mme_service_config)
+    context["enable_apn_correction"] = \
+        get_service_config_value("mme", "enable_apn_correction", "")
+    context["apn_correction_map_list"] = \
+        _get_apn_correction_map_list(mme_service_config)
+
     return context
 
 


### PR DESCRIPTION
Signed-off-by: Oriol Batalla <obatalla@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary

This PR adds `federated_mode_map` to `mme.conf`

This map is needed for the mme services to be able to route the subscriber to the proper service.

Bellow there is an example of how `federated_mode_map` will look like at `mme.conf`:

```
    TESTING :
    {
        # file should be copied here from source tree by following command: run_mme --install-mme-files ...
        SCENARIO_FILE = "/usr/local/share/oai/test/MME/no_regression.xml";
    };

    S-GW :
   {
    # S-GW binded interface for S11 communication (GTPV2-C), if none selected the ITTI message interface is used
       SGW_IPV4_ADDRESS_FOR_S11              = "192.168.60.153";
   };

   FEDERATED_MODE_MAP = (
          {
            MODE = "1"
            PLMN = "123456"
            IMSI_RANGE = "000000000000000:000019999999999"
            APN = "internet.com"
          }

        );

};

```

Note that `MODES` will be integers.  You can match the mode with the enum on `mconfigs.pb.h`

```
enum ModeMapItem_FederatedMode {
  ModeMapItem_FederatedMode_SPGW_SUBSCRIBER  = 0,
  ModeMapItem_FederatedMode_LOCAL_SUBSCRIBER = 1,
  ModeMapItem_FederatedMode_S8_SUBSCRIBER    = 2,
  ModeMapItem_FederatedMode_ModeMapItem_FederatedMode_INT_MIN_SENTINEL_DO_NOT_USE_ =
      ::google::protobuf::kint32min,
  ModeMapItem_FederatedMode_ModeMapItem_FederatedMode_INT_MAX_SENTINEL_DO_NOT_USE_ =
      ::google::protobuf::kint32max
};

```



## Test Plan

TerraVM test


## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
