### PR TITLE
[CI] Remove -Wextra from default flags, enable env use

### DIFF
--- a/.github/workflows/gcc-problems.yml
+++ b/.github/workflows/gcc-problems.yml
@@ -112,7 +112,7 @@ jobs:
           options: -v ${{ github.workspace }}:/magma -e ABC=123
           run: |
             cd /magma/lte/gateway/
-            make build_oai 2>&1 > /magma/compile.log
+            CPPFLAGS="-Wextra" make build_oai 2>&1 > /magma/compile.log
             for file in ${{ steps.changed_files.outputs.all }};
             do grep $file /magma/compile.log | xo '/\/magma\/((.*):(\d+):(\d+):\s+(?:fatal\s)?(warning|error):\s+(.*))/$1/' || true;
             done;
@@ -170,7 +170,7 @@ jobs:
           options: -v ${{ github.workspace }}:/magma -e ABC=123
           run: |
             cd /magma/lte/gateway/
-            make build_session_manager 2>&1 > /magma/compile.log
+            CPPFLAGS="-Wextra" make build_session_manager 2>&1 > /magma/compile.log
             for file in ${{ steps.changed_files.outputs.all }};
             do grep $file /magma/compile.log | xo '/\/magma\/((.*):(\d+):(\d+):\s+(?:fatal\s)?(warning|error):\s+(.*))/$1/' || true;
             done;

--- a/lte/gateway/Makefile
+++ b/lte/gateway/Makefile
@@ -61,7 +61,7 @@ endif
 # debian stretch build uses older cc not recognizing options needed on ubuntu focal
 
 OS_VERSION_NAME := $(shell (grep VERSION_CODENAME /etc/os-release || true) | sed 's/.*=//g')
-COMMON_FLAGS = -DCMAKE_C_FLAGS="-Wall"
+COMMON_FLAGS = -DCMAKE_C_FLAGS="-Wall $(CPPFLAGS)" -DCMAKE_CXX_FLAGS="-Wall $(CPPFLAGS)"
 
 $(info OAI_FLAGS $(OAI_FLAGS))
 

--- a/lte/gateway/c/connection_tracker/CMakeLists.txt
+++ b/lte/gateway/c/connection_tracker/CMakeLists.txt
@@ -38,7 +38,7 @@ add_definitions(-DLOG_WITH_GLOG)
 
 message("Build type is ${CMAKE_BUILD_TYPE}")
 if (CMAKE_BUILD_TYPE STREQUAL "Debug")
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall")
 endif ()
 
 include_directories("${OUTPUT_DIR}")

--- a/lte/gateway/c/oai/CMakeLists.txt
+++ b/lte/gateway/c/oai/CMakeLists.txt
@@ -25,7 +25,7 @@ endif ()
 
 # TODO (amar) check all the flags used. Copied as is from OAI.
 set(CMAKE_C_FLAGS
-  "${CMAKE_C_FLAGS} ${C_FLAGS_PROCESSOR} -std=gnu99 -Wall -Wextra -Wstrict-prototypes -fno-strict-aliasing -rdynamic -funroll-loops -fPIC"
+  "${CMAKE_C_FLAGS} ${C_FLAGS_PROCESSOR} -std=gnu99 -Wall -Wstrict-prototypes -fno-strict-aliasing -rdynamic -funroll-loops -fPIC"
 )
 
 # add autoTOOLS definitions that were maybe used

--- a/lte/gateway/c/session_manager/CMakeLists.txt
+++ b/lte/gateway/c/session_manager/CMakeLists.txt
@@ -42,7 +42,7 @@ add_definitions(-DLOG_WITH_GLOG)
 
 message("Build type is ${CMAKE_BUILD_TYPE}")
 if (CMAKE_BUILD_TYPE STREQUAL "Debug")
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall")
 endif ()
 
 include_directories("${OUTPUT_DIR}")


### PR DESCRIPTION
This PR removes -Wextra from default flags, in order to mitigate the high warning count currently being emitted in our builds.

It is added to Github Action Annotations, however, by use of env parameters to the Makefile. This enables Github pull requests to still benefit from -Wextra.

Signed-off-by: Scott Harrison Moeller <smoeller@fb.com>