### PR TITLE
Fixup missing includes detected by new docker build env

### DIFF
--- a/lte/gateway/c/session_manager/ChargingGrant.cpp
+++ b/lte/gateway/c/session_manager/ChargingGrant.cpp
@@ -13,6 +13,7 @@
 
 #include <ctime>
 #include <limits>
+#include <sstream>
 
 #include "ChargingGrant.h"
 #include "EnumToString.h"

--- a/lte/gateway/c/session_manager/EnumToString.cpp
+++ b/lte/gateway/c/session_manager/EnumToString.cpp
@@ -11,6 +11,7 @@
  * limitations under the License.
  */
 
+#include <sstream>
 #include "EnumToString.h"
 
 namespace magma {

--- a/lte/gateway/c/session_manager/EnumToString.h
+++ b/lte/gateway/c/session_manager/EnumToString.h
@@ -16,6 +16,7 @@
 #include "ServiceAction.h"
 #include "ChargingGrant.h"
 #include <lte/protos/abort_session.pb.h>
+#include <lte/protos/session_manager.pb.h>
 
 namespace magma {
 std::string reauth_state_to_str(ReAuthState state);


### PR DESCRIPTION
# Summary

These build targets failed in my (likely newer) docker environment with GCC 9.3 / CMake latest of Ubuntu 20.04.  We should IncludeWhatYouUse this whole directory. Here I just spot fix to get compiling myself.

Working goes toward #5529.

Signed-off-by: Scott Harrison Moeller <smoeller@fb.com>