### PR TITLE
[Coverage] Add BUILD_TESTS flags for code coverage output

### DIFF
--- a/lte/gateway/c/connection_tracker/CMakeLists.txt
+++ b/lte/gateway/c/connection_tracker/CMakeLists.txt
@@ -29,6 +29,12 @@ if (NOT BUILD_TESTS)
      "${CMAKE_C_FLAGS_RELWITHDEBINFO} -fsanitize=leak -fno-omit-frame-pointer")
   set(CMAKE_EXE_LINKER_FLAGS_RELWITHDEBINFO
      "${CMAKE_EXE_LINKER_FLAGS_RELWITHDEBINFO} -fsanitize=leak")
+else() # BUILD_TESTS
+  message("Adding code coverage build and linker flags for BUILD_TESTS")
+  set (CMAKE_CXX_FLAGS_DEBUG
+      "${CMAKE_CXX_FLAGS_DEBUG} -g -O0 -fprofile-arcs -ftest-coverage")
+  set(CMAKE_LINKER_FLAGS_DEBUG
+      "${CMAKE_LINKER_FLAGS_DEBUG} -fprofile-arcs -ftest-coverage")
 endif ()
 
 set(OUTPUT_DIR "${CMAKE_CURRENT_BINARY_DIR}")

--- a/lte/gateway/c/session_manager/CMakeLists.txt
+++ b/lte/gateway/c/session_manager/CMakeLists.txt
@@ -33,6 +33,12 @@ if (NOT BUILD_TESTS)
   #   "${CMAKE_C_FLAGS_RELWITHDEBINFO} -fsanitize=leak -fno-omit-frame-pointer")
   #set(CMAKE_EXE_LINKER_FLAGS_RELWITHDEBINFO
   #   "${CMAKE_EXE_LINKER_FLAGS_RELWITHDEBINFO} -fsanitize=leak")
+else() # BUILD_TESTS
+  message("Adding code coverage build and linker flags for BUILD_TESTS")
+  set (CMAKE_CXX_FLAGS_DEBUG
+      "${CMAKE_CXX_FLAGS_DEBUG} -g -O0 -fprofile-arcs -ftest-coverage")
+  set(CMAKE_LINKER_FLAGS_DEBUG
+      "${CMAKE_LINKER_FLAGS_DEBUG} -fprofile-arcs -ftest-coverage")
 endif ()
 
 set(OUTPUT_DIR "${CMAKE_CURRENT_BINARY_DIR}")


### PR DESCRIPTION
# Summary

For BUILD_TESTS configuration only - turn up -fprofile-arcs and -ftest-coverage compiler / linker flags for the following test targets.

- connection_tracker
- session_manager

Working goes toward #5529.