### PR TITLE
[session_manager] Add missing headers and linking for GPR_ASSERT

### DIFF
--- a/lte/gateway/c/session_manager/CMakeLists.txt
+++ b/lte/gateway/c/session_manager/CMakeLists.txt
@@ -173,7 +173,7 @@ add_library(SESSION_MANAGER
 target_link_libraries(SESSION_MANAGER
   SERVICE303_LIB SERVICE_REGISTRY ASYNC_GRPC CONFIG POLICYDB EVENTD
   DATASTORE
-  glog gflags folly pthread ${GCOV_LIB} grpc++ grpc yaml-cpp protobuf cpp_redis
+  glog gflags folly pthread ${GCOV_LIB} gpr grpc++ grpc yaml-cpp protobuf cpp_redis
   prometheus-cpp tacopie
   )
 

--- a/lte/gateway/c/session_manager/SessionManagerServer.cpp
+++ b/lte/gateway/c/session_manager/SessionManagerServer.cpp
@@ -12,6 +12,9 @@
  */
 #include "SessionManagerServer.h"
 #include "magma_logging.h"
+#include <grpc/impl/codegen/port_platform.h>
+#include <stdarg.h>
+#include <stdlib.h>
 #include <chrono>
 #include <ctime>
 using grpc::Status;


### PR DESCRIPTION
# Summary

GPR_ASSERT technically requires some header includes that were missing. Further, in my new docker developer environment, we failed linking for this target due to lack of link with -lgpr.

Working goes toward #5529.

Signed-off-by: Scott Harrison Moeller <smoeller@fb.com>