### PR TITLE
[agw] Attach Optional Sentry Error Handling

### DIFF
--- a/lte/gateway/configs/control_proxy.yml
+++ b/lte/gateway/configs/control_proxy.yml
@@ -39,3 +39,8 @@ proxy_cloud_connections: True
 
 # Allows http_proxy usage if the environment variable is present
 allow_http_proxy: False
+
+# Dummy URL to Sentry logging -> Modify to local sentry instance in order
+# to pipe error handling to sentry
+sentry_url: ""
+sentry_sample_rate: 1.0

--- a/lte/gateway/python/magma/enodebd/main.py
+++ b/lte/gateway/python/magma/enodebd/main.py
@@ -11,14 +11,13 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-import sentry_sdk
 from threading import Thread
 from typing import List
 from unittest import mock
 
 from magma.enodebd.enodeb_status import get_service_status_old, \
     get_operational_states
-from magma.configuration.service_configs import get_service_config_value
+from magma.common.sentry import sentry_init
 from magma.enodebd.state_machines.enb_acs_manager import StateMachineManager
 from magma.enodebd.logger import EnodebdLogger as logger
 from .rpc_servicer import EnodebdRpcServicer
@@ -46,10 +45,7 @@ def main():
     logger.init()
 
     # Optionally pipe errors to Sentry
-    sentry_url = get_service_config_value('control_proxy', 'sentry_url', default="")
-    if sentry_url:
-        sentry_sample_rate = get_service_config_value('control_proxy', 'sentry_sample_rate',default=1.0)
-        sentry_sdk.init(dsn=sentry_url, traces_sample_rate=sentry_sample_rate)
+    sentry_init()
 
     # State machine manager for tracking multiple connected eNB devices.
     state_machine_manager = StateMachineManager(service)

--- a/lte/gateway/python/magma/health/main.py
+++ b/lte/gateway/python/magma/health/main.py
@@ -11,11 +11,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-import sentry_sdk
-
 from magma.common.health.service_state_wrapper import ServiceStateWrapper
+from magma.common.sentry import sentry_init
 from magma.common.service import MagmaService
-from magma.configuration.service_configs import load_service_config, get_service_config_value
+from magma.configuration.service_configs import load_service_config
 
 from magma.health.state_recovery import StateRecoveryJob
 
@@ -27,10 +26,7 @@ def main():
     service = MagmaService('health', None)
 
     # Optionally pipe errors to Sentry
-    sentry_url = get_service_config_value('control_proxy', 'sentry_url', default="")
-    if sentry_url:
-        sentry_sample_rate = get_service_config_value('control_proxy', 'sentry_sample_rate',default=1.0)
-        sentry_sdk.init(dsn=sentry_url, traces_sample_rate=sentry_sample_rate)
+    sentry_init()
 
     # Service state wrapper obj
     service_state = ServiceStateWrapper()

--- a/lte/gateway/python/magma/health/main.py
+++ b/lte/gateway/python/magma/health/main.py
@@ -10,9 +10,12 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
+
+import sentry_sdk
+
 from magma.common.health.service_state_wrapper import ServiceStateWrapper
 from magma.common.service import MagmaService
-from magma.configuration.service_configs import load_service_config
+from magma.configuration.service_configs import load_service_config, get_service_config_value
 
 from magma.health.state_recovery import StateRecoveryJob
 
@@ -22,6 +25,12 @@ def main():
     Top-level function for health service
     """
     service = MagmaService('health', None)
+
+    # Optionally pipe errors to Sentry
+    sentry_url = get_service_config_value('control_proxy', 'sentry_url', default="")
+    if sentry_url:
+        sentry_sample_rate = get_service_config_value('control_proxy', 'sentry_sample_rate',default=1.0)
+        sentry_sdk.init(dsn=sentry_url, traces_sample_rate=sentry_sample_rate)
 
     # Service state wrapper obj
     service_state = ServiceStateWrapper()

--- a/lte/gateway/python/magma/mobilityd/main.py
+++ b/lte/gateway/python/magma/mobilityd/main.py
@@ -12,13 +12,12 @@ limitations under the License.
 """
 import ipaddress
 import logging
-import sentry_sdk
 from typing import Optional
 
 from magma.common.redis.client import get_default_client
+from magma.common.sentry import sentry_init
 from magma.common.service import MagmaService
 from magma.common.service_registry import ServiceRegistry
-from magma.configuration.service_configs import get_service_config_value
 from magma.mobilityd.ip_address_man import IPAddressManager
 from magma.mobilityd.ip_allocator_base import OverlappedIPBlocksError
 from magma.mobilityd.ip_allocator_dhcp import IPAllocatorDHCP
@@ -94,10 +93,7 @@ def main():
     service = MagmaService('mobilityd', mconfigs_pb2.MobilityD())
 
     # Optionally pipe errors to Sentry
-    sentry_url = get_service_config_value('control_proxy', 'sentry_url', default="")
-    if sentry_url:
-        sentry_sample_rate = get_service_config_value('control_proxy', 'sentry_sample_rate',default=1.0)
-        sentry_sdk.init(dsn=sentry_url, traces_sample_rate=sentry_sample_rate)
+    sentry_init()
 
     # Load service configs and mconfig
     config = service.config

--- a/lte/gateway/python/magma/monitord/main.py
+++ b/lte/gateway/python/magma/monitord/main.py
@@ -10,13 +10,15 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
+import logging
+import sentry_sdk
+
 from lte.protos.mconfig import mconfigs_pb2
 from magma.common.service import MagmaService
-from magma.configuration import load_service_config
+from magma.configuration import load_service_config, get_service_config_value
 from magma.monitord.icmp_monitoring import ICMPMonitoring
 from magma.monitord.icmp_state import serialize_subscriber_states
 from magma.monitord.cpe_monitoring import CpeMonitoringModule
-import logging
 from lte.protos.mobilityd_pb2 import IPAddress
 
 
@@ -28,6 +30,12 @@ def main():
     """ main() for monitord service"""
     manual_ping_targets = {}
     service = MagmaService('monitord', mconfigs_pb2.MonitorD())
+
+    # Optionally pipe errors to Sentry
+    sentry_url = get_service_config_value('control_proxy', 'sentry_url', default="")
+    if sentry_url:
+        sentry_sample_rate = get_service_config_value('control_proxy', 'sentry_sample_rate',default=1.0)
+        sentry_sdk.init(dsn=sentry_url, traces_sample_rate=sentry_sample_rate)
 
     # Monitoring thread loop
     mtr_interface = load_service_config("monitord")["mtr_interface"]

--- a/lte/gateway/python/magma/monitord/main.py
+++ b/lte/gateway/python/magma/monitord/main.py
@@ -10,12 +10,13 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
+
 import logging
-import sentry_sdk
 
 from lte.protos.mconfig import mconfigs_pb2
 from magma.common.service import MagmaService
-from magma.configuration import load_service_config, get_service_config_value
+from magma.common.sentry import sentry_init
+from magma.configuration import load_service_config
 from magma.monitord.icmp_monitoring import ICMPMonitoring
 from magma.monitord.icmp_state import serialize_subscriber_states
 from magma.monitord.cpe_monitoring import CpeMonitoringModule
@@ -32,10 +33,7 @@ def main():
     service = MagmaService('monitord', mconfigs_pb2.MonitorD())
 
     # Optionally pipe errors to Sentry
-    sentry_url = get_service_config_value('control_proxy', 'sentry_url', default="")
-    if sentry_url:
-        sentry_sample_rate = get_service_config_value('control_proxy', 'sentry_sample_rate',default=1.0)
-        sentry_sdk.init(dsn=sentry_url, traces_sample_rate=sentry_sample_rate)
+    sentry_init()
 
     # Monitoring thread loop
     mtr_interface = load_service_config("monitord")["mtr_interface"]

--- a/lte/gateway/python/magma/pipelined/main.py
+++ b/lte/gateway/python/magma/pipelined/main.py
@@ -17,7 +17,6 @@ limitations under the License.
 
 import asyncio
 import logging
-import sentry_sdk
 import threading
 
 import aioeventlet
@@ -27,9 +26,9 @@ from scapy.arch import get_if_hwaddr
 from ryu.ofproto.ofproto_v1_4 import OFPP_LOCAL
 
 from magma.common.misc_utils import call_process, get_ip_from_if
+from magma.common.sentry import sentry_init
 from magma.common.service import MagmaService
 from magma.configuration import environment
-from magma.configuration.service_configs import get_service_config_value
 from magma.pipelined.app import of_rest_server
 from magma.pipelined.check_quota_server import run_flask
 from magma.pipelined.service_manager import ServiceManager
@@ -56,10 +55,7 @@ def main():
     service = MagmaService('pipelined', mconfigs_pb2.PipelineD())
 
     # Optionally pipe errors to Sentry
-    sentry_url = get_service_config_value('control_proxy', 'sentry_url', default="")
-    if sentry_url:
-        sentry_sample_rate = get_service_config_value('control_proxy', 'sentry_sample_rate',default=1.0)
-        sentry_sdk.init(dsn=sentry_url, traces_sample_rate=sentry_sample_rate)
+    sentry_init()
 
     service_config = service.config
 

--- a/lte/gateway/python/magma/policydb/main.py
+++ b/lte/gateway/python/magma/policydb/main.py
@@ -12,6 +12,8 @@ limitations under the License.
 """
 
 import logging
+import sentry_sdk
+
 from lte.protos.mconfig import mconfigs_pb2
 from lte.protos.policydb_pb2_grpc import PolicyAssignmentControllerStub
 from lte.protos.session_manager_pb2_grpc import LocalSessionManagerStub,\
@@ -19,6 +21,7 @@ from lte.protos.session_manager_pb2_grpc import LocalSessionManagerStub,\
 from magma.common.service import MagmaService
 from magma.common.service_registry import ServiceRegistry
 from magma.common.streamer import StreamerClient
+from magma.configuration.service_configs import get_service_config_value
 from magma.policydb.apn_rule_map_store import ApnRuleAssignmentsDict
 from magma.policydb.basename_store import BaseNameDict
 from magma.policydb.rating_group_store import RatingGroupsDict
@@ -32,6 +35,12 @@ from .streamer_callback import ApnRuleMappingsStreamerCallback,\
 
 def main():
     service = MagmaService('policydb', mconfigs_pb2.PolicyDB())
+
+    # Optionally pipe errors to Sentry
+    sentry_url = get_service_config_value('control_proxy', 'sentry_url', default="")
+    if sentry_url:
+        sentry_sample_rate = get_service_config_value('control_proxy', 'sentry_sample_rate',default=1.0)
+        sentry_sdk.init(dsn=sentry_url, traces_sample_rate=sentry_sample_rate)
 
     apn_rules_dict = ApnRuleAssignmentsDict()
     assignments_dict = RuleAssignmentsDict()

--- a/lte/gateway/python/magma/policydb/main.py
+++ b/lte/gateway/python/magma/policydb/main.py
@@ -12,16 +12,15 @@ limitations under the License.
 """
 
 import logging
-import sentry_sdk
 
 from lte.protos.mconfig import mconfigs_pb2
 from lte.protos.policydb_pb2_grpc import PolicyAssignmentControllerStub
 from lte.protos.session_manager_pb2_grpc import LocalSessionManagerStub,\
     SessionProxyResponderStub
+from magma.common.sentry import sentry_init
 from magma.common.service import MagmaService
 from magma.common.service_registry import ServiceRegistry
 from magma.common.streamer import StreamerClient
-from magma.configuration.service_configs import get_service_config_value
 from magma.policydb.apn_rule_map_store import ApnRuleAssignmentsDict
 from magma.policydb.basename_store import BaseNameDict
 from magma.policydb.rating_group_store import RatingGroupsDict
@@ -37,10 +36,7 @@ def main():
     service = MagmaService('policydb', mconfigs_pb2.PolicyDB())
 
     # Optionally pipe errors to Sentry
-    sentry_url = get_service_config_value('control_proxy', 'sentry_url', default="")
-    if sentry_url:
-        sentry_sample_rate = get_service_config_value('control_proxy', 'sentry_sample_rate',default=1.0)
-        sentry_sdk.init(dsn=sentry_url, traces_sample_rate=sentry_sample_rate)
+    sentry_init()
 
     apn_rules_dict = ApnRuleAssignmentsDict()
     assignments_dict = RuleAssignmentsDict()

--- a/lte/gateway/python/magma/redirectd/main.py
+++ b/lte/gateway/python/magma/redirectd/main.py
@@ -12,6 +12,7 @@ limitations under the License.
 """
 
 import logging
+import sentry_sdk
 import threading
 
 from magma.common.service import MagmaService
@@ -25,6 +26,12 @@ def main():
     main() for redirectd. Starts the server threads.
     """
     service = MagmaService('redirectd', mconfigs_pb2.RedirectD())
+
+    # Optionally pipe errors to Sentry
+    sentry_url = get_service_config_value('control_proxy', 'sentry_url', default="")
+    if sentry_url:
+        sentry_sample_rate = get_service_config_value('control_proxy', 'sentry_sample_rate',default=1.0)
+        sentry_sdk.init(dsn=sentry_url, traces_sample_rate=sentry_sample_rate)
 
     redirect_ip = get_service_config_value(
         'pipelined',

--- a/lte/gateway/python/magma/redirectd/main.py
+++ b/lte/gateway/python/magma/redirectd/main.py
@@ -12,10 +12,10 @@ limitations under the License.
 """
 
 import logging
-import sentry_sdk
 import threading
 
 from magma.common.service import MagmaService
+from magma.common.sentry import sentry_init
 from magma.configuration.service_configs import get_service_config_value
 from magma.redirectd.redirect_server import run_flask
 from lte.protos.mconfig import mconfigs_pb2
@@ -28,10 +28,7 @@ def main():
     service = MagmaService('redirectd', mconfigs_pb2.RedirectD())
 
     # Optionally pipe errors to Sentry
-    sentry_url = get_service_config_value('control_proxy', 'sentry_url', default="")
-    if sentry_url:
-        sentry_sample_rate = get_service_config_value('control_proxy', 'sentry_sample_rate',default=1.0)
-        sentry_sdk.init(dsn=sentry_url, traces_sample_rate=sentry_sample_rate)
+    sentry_init()
 
     redirect_ip = get_service_config_value(
         'pipelined',

--- a/lte/gateway/python/magma/smsd/main.py
+++ b/lte/gateway/python/magma/smsd/main.py
@@ -11,11 +11,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-import sentry_sdk
-
+from magma.common.sentry import sentry_init
 from magma.common.service import MagmaService
 from magma.common.service_registry import ServiceRegistry
-from magma.configuration.service_configs import get_service_config_value
 from lte.protos.sms_orc8r_pb2_grpc import SMSOrc8rServiceStub, SMSOrc8rGatewayServiceStub, SmsDStub
 from orc8r.protos.directoryd_pb2_grpc import GatewayDirectoryServiceStub
 from .relay import SmsRelay
@@ -25,10 +23,7 @@ def main():
     service = MagmaService('smsd', None)
 
     # Optionally pipe errors to Sentry
-    sentry_url = get_service_config_value('control_proxy', 'sentry_url', default="")
-    if sentry_url:
-        sentry_sample_rate = get_service_config_value('control_proxy', 'sentry_sample_rate',default=1.0)
-        sentry_sdk.init(dsn=sentry_url, traces_sample_rate=sentry_sample_rate)
+    sentry_init()
 
     directoryd_chan = ServiceRegistry.get_rpc_channel('directoryd',
                                                       ServiceRegistry.LOCAL)

--- a/lte/gateway/python/magma/smsd/main.py
+++ b/lte/gateway/python/magma/smsd/main.py
@@ -11,15 +11,24 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
+import sentry_sdk
+
 from magma.common.service import MagmaService
-from lte.protos.sms_orc8r_pb2_grpc import SMSOrc8rServiceStub, SMSOrc8rGatewayServiceStub, SmsDStub
 from magma.common.service_registry import ServiceRegistry
+from magma.configuration.service_configs import get_service_config_value
+from lte.protos.sms_orc8r_pb2_grpc import SMSOrc8rServiceStub, SMSOrc8rGatewayServiceStub, SmsDStub
 from orc8r.protos.directoryd_pb2_grpc import GatewayDirectoryServiceStub
 from .relay import SmsRelay
 
 def main():
     """ main() for smsd """
     service = MagmaService('smsd', None)
+
+    # Optionally pipe errors to Sentry
+    sentry_url = get_service_config_value('control_proxy', 'sentry_url', default="")
+    if sentry_url:
+        sentry_sample_rate = get_service_config_value('control_proxy', 'sentry_sample_rate',default=1.0)
+        sentry_sdk.init(dsn=sentry_url, traces_sample_rate=sentry_sample_rate)
 
     directoryd_chan = ServiceRegistry.get_rpc_channel('directoryd',
                                                       ServiceRegistry.LOCAL)

--- a/lte/gateway/python/magma/subscriberdb/main.py
+++ b/lte/gateway/python/magma/subscriberdb/main.py
@@ -12,11 +12,10 @@ limitations under the License.
 """
 import asyncio
 import logging
-import sentry_sdk
 
+from magma.common.sentry import sentry_init
 from magma.common.service import MagmaService
 from magma.common.streamer import StreamerClient
-from magma.configuration.service_configs import get_service_config_value
 
 from .processor import Processor
 from .protocols.diameter.application import base, s6a
@@ -34,10 +33,7 @@ def main():
     service = MagmaService('subscriberdb', mconfigs_pb2.SubscriberDB())
 
     # Optionally pipe errors to Sentry
-    sentry_url = get_service_config_value('control_proxy', 'sentry_url', default="")
-    if sentry_url:
-        sentry_sample_rate = get_service_config_value('control_proxy', 'sentry_sample_rate',default=1.0)
-        sentry_sdk.init(dsn=sentry_url, traces_sample_rate=sentry_sample_rate)
+    sentry_init()
 
     # Initialize a store to keep all subscriber data.
     store = SqliteStore(service.config['db_path'], loop=service.loop,

--- a/lte/gateway/python/setup.py
+++ b/lte/gateway/python/setup.py
@@ -95,6 +95,7 @@ setup(
         'spyne>=2.12.16',
         'scapy==2.4.4',
         'flask>=1.0.2',
+        'sentry_sdk>=1.0.0',
         'aioeventlet>=0.4',
         'aiodns>=1.1.1',
         'pymemoize>=1.0.2',

--- a/orc8r/gateway/configs/control_proxy.yml
+++ b/orc8r/gateway/configs/control_proxy.yml
@@ -36,3 +36,8 @@ proxy_cloud_connections: True
 
 # Allows http_proxy usage if the environment variable is present
 allow_http_proxy: True
+
+# Dummy URL to Sentry logging -> Modify to local sentry instance in order
+# to pipe error handling to sentry
+sentry_url: ""
+sentry_sample_rate: 1.0

--- a/orc8r/gateway/python/magma/common/sentry.py
+++ b/orc8r/gateway/python/magma/common/sentry.py
@@ -21,5 +21,5 @@ def sentry_init():
     """
     sentry_url = get_service_config_value('control_proxy', 'sentry_url', default="")
     if sentry_url:
-        sentry_sample_rate = get_service_config_value('control_proxy', 'sentry_sample_rate',default=1.0)
+        sentry_sample_rate = get_service_config_value('control_proxy', 'sentry_sample_rate', default=1.0)
         sentry_sdk.init(dsn=sentry_url, traces_sample_rate=sentry_sample_rate)

--- a/orc8r/gateway/python/magma/common/sentry.py
+++ b/orc8r/gateway/python/magma/common/sentry.py
@@ -1,0 +1,25 @@
+"""
+Copyright 2020 The Magma Authors.
+
+This source code is licensed under the BSD-style license found in the
+LICENSE file in the root directory of this source tree.
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import sentry_sdk
+
+from magma.configuration.service_configs import get_service_config_value
+
+def sentry_init():
+    """
+    Initialize connection and start piping errors to sentry.io
+    """
+    sentry_url = get_service_config_value('control_proxy', 'sentry_url', default="")
+    if sentry_url:
+        sentry_sample_rate = get_service_config_value('control_proxy', 'sentry_sample_rate',default=1.0)
+        sentry_sdk.init(dsn=sentry_url, traces_sample_rate=sentry_sample_rate)

--- a/orc8r/gateway/python/magma/ctraced/main.py
+++ b/orc8r/gateway/python/magma/ctraced/main.py
@@ -11,14 +11,24 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
+import sentry_sdk
+
 from magma.common.service import MagmaService
+from magma.configuration.service_configs import get_service_config_value
+from orc8r.protos.mconfig.mconfigs_pb2 import CtraceD
 from .rpc_servicer import CtraceDRpcServicer
 from .trace_manager import TraceManager
-from orc8r.protos.mconfig.mconfigs_pb2 import CtraceD
+
 
 def main():
     """ main() for ctraced """
     service = MagmaService('ctraced', CtraceD())
+
+    # Optionally pipe errors to Sentry
+    sentry_url = get_service_config_value('control_proxy', 'sentry_url', default="")
+    if sentry_url:
+        sentry_sample_rate = get_service_config_value('control_proxy', 'sentry_sample_rate',default=1.0)
+        sentry_sdk.init(dsn=sentry_url, traces_sample_rate=sentry_sample_rate)
 
     trace_manager = TraceManager(service.config)
 

--- a/orc8r/gateway/python/magma/ctraced/main.py
+++ b/orc8r/gateway/python/magma/ctraced/main.py
@@ -11,10 +11,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-import sentry_sdk
-
 from magma.common.service import MagmaService
-from magma.configuration.service_configs import get_service_config_value
+from magma.common.sentry import sentry_init
 from orc8r.protos.mconfig.mconfigs_pb2 import CtraceD
 from .rpc_servicer import CtraceDRpcServicer
 from .trace_manager import TraceManager
@@ -25,10 +23,7 @@ def main():
     service = MagmaService('ctraced', CtraceD())
 
     # Optionally pipe errors to Sentry
-    sentry_url = get_service_config_value('control_proxy', 'sentry_url', default="")
-    if sentry_url:
-        sentry_sample_rate = get_service_config_value('control_proxy', 'sentry_sample_rate',default=1.0)
-        sentry_sdk.init(dsn=sentry_url, traces_sample_rate=sentry_sample_rate)
+    sentry_init()
 
     trace_manager = TraceManager(service.config)
 

--- a/orc8r/gateway/python/magma/directoryd/main.py
+++ b/orc8r/gateway/python/magma/directoryd/main.py
@@ -11,10 +11,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-import sentry_sdk
-
+from magma.common.sentry import sentry_init
 from magma.common.service import MagmaService
-from magma.configuration.service_configs import get_service_config_value
 from magma.directoryd.rpc_servicer import GatewayDirectoryServiceRpcServicer
 from orc8r.protos.mconfig import mconfigs_pb2
 
@@ -24,10 +22,7 @@ def main():
     service = MagmaService('directoryd', mconfigs_pb2.DirectoryD())
 
     # Optionally pipe errors to Sentry
-    sentry_url = get_service_config_value('control_proxy', 'sentry_url', default="")
-    if sentry_url:
-        sentry_sample_rate = get_service_config_value('control_proxy', 'sentry_sample_rate',default=1.0)
-        sentry_sdk.init(dsn=sentry_url, traces_sample_rate=sentry_sample_rate)
+    sentry_init()
 
     service_config = service.config
 

--- a/orc8r/gateway/python/magma/directoryd/main.py
+++ b/orc8r/gateway/python/magma/directoryd/main.py
@@ -11,7 +11,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
+import sentry_sdk
+
 from magma.common.service import MagmaService
+from magma.configuration.service_configs import get_service_config_value
 from magma.directoryd.rpc_servicer import GatewayDirectoryServiceRpcServicer
 from orc8r.protos.mconfig import mconfigs_pb2
 
@@ -19,6 +22,13 @@ from orc8r.protos.mconfig import mconfigs_pb2
 def main():
     """ main() for Directoryd """
     service = MagmaService('directoryd', mconfigs_pb2.DirectoryD())
+
+    # Optionally pipe errors to Sentry
+    sentry_url = get_service_config_value('control_proxy', 'sentry_url', default="")
+    if sentry_url:
+        sentry_sample_rate = get_service_config_value('control_proxy', 'sentry_sample_rate',default=1.0)
+        sentry_sdk.init(dsn=sentry_url, traces_sample_rate=sentry_sample_rate)
+
     service_config = service.config
 
     # Add servicer to the server

--- a/orc8r/gateway/python/magma/eventd/main.py
+++ b/orc8r/gateway/python/magma/eventd/main.py
@@ -11,10 +11,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-import sentry_sdk
-
+from magma.common.sentry import sentry_init
 from magma.common.service import MagmaService
-from magma.configuration.service_configs import get_service_config_value
 from .rpc_servicer import EventDRpcServicer
 from .event_validator import EventValidator
 from orc8r.protos.mconfig.mconfigs_pb2 import EventD
@@ -25,10 +23,7 @@ def main():
     service = MagmaService('eventd', EventD())
 
     # Optionally pipe errors to Sentry
-    sentry_url = get_service_config_value('control_proxy', 'sentry_url', default="")
-    if sentry_url:
-        sentry_sample_rate = get_service_config_value('control_proxy', 'sentry_sample_rate',default=1.0)
-        sentry_sdk.init(dsn=sentry_url, traces_sample_rate=sentry_sample_rate)
+    sentry_init()
 
     event_validator = EventValidator(service.config)
     eventd_servicer = EventDRpcServicer(service.config, event_validator)

--- a/orc8r/gateway/python/magma/eventd/main.py
+++ b/orc8r/gateway/python/magma/eventd/main.py
@@ -11,7 +11,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
+import sentry_sdk
+
 from magma.common.service import MagmaService
+from magma.configuration.service_configs import get_service_config_value
 from .rpc_servicer import EventDRpcServicer
 from .event_validator import EventValidator
 from orc8r.protos.mconfig.mconfigs_pb2 import EventD
@@ -20,6 +23,12 @@ from orc8r.protos.mconfig.mconfigs_pb2 import EventD
 def main():
     """ main() for eventd """
     service = MagmaService('eventd', EventD())
+
+    # Optionally pipe errors to Sentry
+    sentry_url = get_service_config_value('control_proxy', 'sentry_url', default="")
+    if sentry_url:
+        sentry_sample_rate = get_service_config_value('control_proxy', 'sentry_sample_rate',default=1.0)
+        sentry_sdk.init(dsn=sentry_url, traces_sample_rate=sentry_sample_rate)
 
     event_validator = EventValidator(service.config)
     eventd_servicer = EventDRpcServicer(service.config, event_validator)

--- a/orc8r/gateway/python/magma/magmad/main.py
+++ b/orc8r/gateway/python/magma/magmad/main.py
@@ -12,17 +12,16 @@ limitations under the License.
 """
 import importlib
 import logging
-import sentry_sdk
 import snowflake
 import typing
 
 from magma.common.grpc_client_manager import GRPCClientManager
 from magma.common.sdwatchdog import SDWatchdog
+from magma.common.sentry import sentry_init
 from magma.common.service import MagmaService
 from magma.common.streamer import StreamerClient
 from magma.configuration.mconfig_managers import MconfigManagerImpl, \
     get_mconfig_manager
-from magma.configuration.service_configs import get_service_config_value
 from magma.magmad.generic_command.command_executor import \
     get_command_executor_impl
 from magma.magmad.upgrade.upgrader import UpgraderFactory, start_upgrade_loop
@@ -49,10 +48,7 @@ def main():
     service = MagmaService('magmad', mconfigs_pb2.MagmaD())
 
     # Optionally pipe errors to Sentry
-    sentry_url = get_service_config_value('control_proxy', 'sentry_url', default="")
-    if sentry_url:
-        sentry_sample_rate = get_service_config_value('control_proxy', 'sentry_sample_rate',default=1.0)
-        sentry_sdk.init(dsn=sentry_url, traces_sample_rate=sentry_sample_rate)
+    sentry_init()
 
     logging.info('Starting magmad for UUID: %s', snowflake.make_snowflake())
 

--- a/orc8r/gateway/python/magma/magmad/main.py
+++ b/orc8r/gateway/python/magma/magmad/main.py
@@ -12,15 +12,17 @@ limitations under the License.
 """
 import importlib
 import logging
+import sentry_sdk
+import snowflake
 import typing
 
-import snowflake
 from magma.common.grpc_client_manager import GRPCClientManager
 from magma.common.sdwatchdog import SDWatchdog
 from magma.common.service import MagmaService
 from magma.common.streamer import StreamerClient
 from magma.configuration.mconfig_managers import MconfigManagerImpl, \
     get_mconfig_manager
+from magma.configuration.service_configs import get_service_config_value
 from magma.magmad.generic_command.command_executor import \
     get_command_executor_impl
 from magma.magmad.upgrade.upgrader import UpgraderFactory, start_upgrade_loop
@@ -45,6 +47,12 @@ def main():
     Main magmad function
     """
     service = MagmaService('magmad', mconfigs_pb2.MagmaD())
+
+    # Optionally pipe errors to Sentry
+    sentry_url = get_service_config_value('control_proxy', 'sentry_url', default="")
+    if sentry_url:
+        sentry_sample_rate = get_service_config_value('control_proxy', 'sentry_sample_rate',default=1.0)
+        sentry_sdk.init(dsn=sentry_url, traces_sample_rate=sentry_sample_rate)
 
     logging.info('Starting magmad for UUID: %s', snowflake.make_snowflake())
 

--- a/orc8r/gateway/python/magma/state/main.py
+++ b/orc8r/gateway/python/magma/state/main.py
@@ -11,10 +11,13 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
+import sentry_sdk
+
 from orc8r.protos.mconfig import mconfigs_pb2
 from orc8r.protos.state_pb2_grpc import StateServiceStub
 from magma.common.grpc_client_manager import GRPCClientManager
 from magma.common.service import MagmaService
+from magma.configuration.service_configs import get_service_config_value
 from .garbage_collector import GarbageCollector
 from .state_replicator import StateReplicator
 
@@ -24,6 +27,12 @@ def main():
     main() for gateway state replication service
     """
     service = MagmaService('state', mconfigs_pb2.State())
+
+    # Optionally pipe errors to Sentry
+    sentry_url = get_service_config_value('control_proxy', 'sentry_url', default="")
+    if sentry_url:
+        sentry_sample_rate = get_service_config_value('control_proxy', 'sentry_sample_rate',default=1.0)
+        sentry_sdk.init(dsn=sentry_url, traces_sample_rate=sentry_sample_rate)
 
     # _grpc_client_manager to manage grpc client recycling
     grpc_client_manager = GRPCClientManager(

--- a/orc8r/gateway/python/magma/state/main.py
+++ b/orc8r/gateway/python/magma/state/main.py
@@ -11,13 +11,11 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-import sentry_sdk
-
 from orc8r.protos.mconfig import mconfigs_pb2
 from orc8r.protos.state_pb2_grpc import StateServiceStub
 from magma.common.grpc_client_manager import GRPCClientManager
+from magma.common.sentry import sentry_init
 from magma.common.service import MagmaService
-from magma.configuration.service_configs import get_service_config_value
 from .garbage_collector import GarbageCollector
 from .state_replicator import StateReplicator
 
@@ -29,10 +27,7 @@ def main():
     service = MagmaService('state', mconfigs_pb2.State())
 
     # Optionally pipe errors to Sentry
-    sentry_url = get_service_config_value('control_proxy', 'sentry_url', default="")
-    if sentry_url:
-        sentry_sample_rate = get_service_config_value('control_proxy', 'sentry_sample_rate',default=1.0)
-        sentry_sdk.init(dsn=sentry_url, traces_sample_rate=sentry_sample_rate)
+    sentry_init()
 
     # _grpc_client_manager to manage grpc client recycling
     grpc_client_manager = GRPCClientManager(

--- a/orc8r/gateway/python/setup.py
+++ b/orc8r/gateway/python/setup.py
@@ -77,6 +77,7 @@ setup(
         'PyYAML>=3.12',
         'pytz>=2014.4',
         'prometheus_client==0.3.1',
+        'sentry_sdk>=1.0.0',
         'snowflake>=0.0.3',
         'psutil==5.6.6',
         'cryptography>=1.9',


### PR DESCRIPTION
Signed-off-by: Andy Lee Khuu <andykhuu@stanford.edu>

<!--

    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary
This PR adds configs for python services in AGW to pipe errors to Sentry. 

By default, sentry initialization is turned off since we don't want errors which occur during development to be piped to sentry. 

In order to enable sentry.io to manage errors, operators and developers can modify the
 **sentry_url** and **sentry_sample_rate** config which lives  in control_proxy.yml within lte/gateway/configs

**View of how Sentry can manage errors.**
<img width="1776" alt="Screen Shot 2021-03-17 at 10 59 33 AM" src="https://user-images.githubusercontent.com/46101219/111515332-e4ee1700-870f-11eb-9570-12caa0b5510f.png">

<!-- Enumerate changes you made and why you made them -->

## Test Plan
<!--
- [x] make test
- [x] make test_python 
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
