### PR TITLE
[feg] Bump go-gtp to 0.7.17 and remove WaitUntilClientIsReady

### DIFF
--- a/cwf/gateway/go.sum
+++ b/cwf/gateway/go.sum
@@ -262,6 +262,7 @@ github.com/google/go-cmp v0.4.0 h1:xsAVV57WRhGj6kEIi8ReJzQlHHqcBYCElAvkovg3B/4=
 github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.4/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/gofuzz v0.0.0-20161122191042-44d81051d367/go.mod h1:HP5RmnzzSNb993RKQDq4+1A4ia9nllfqcQFTQJedwGI=
 github.com/google/gofuzz v0.0.0-20170612174753-24818f796faf/go.mod h1:HP5RmnzzSNb993RKQDq4+1A4ia9nllfqcQFTQJedwGI=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
@@ -574,6 +575,7 @@ github.com/vishvananda/netns v0.0.0-20191106174202-0a2b9b5464df/go.mod h1:JP3t17
 github.com/wadey/gocovmerge v0.0.0-20160331181800-b5bfa59ec0ad/go.mod h1:Hy8o65+MXnS6EwGElrSRjUzQDLXreJlzYLlWiHtt8hM=
 github.com/warthog618/sms v0.3.0/go.mod h1:+bYZGeBxu003sxD5xhzsrIPBAjPBzTABsRTwSpd7ld4=
 github.com/wmnsk/go-gtp v0.7.15/go.mod h1:v1psjZ7skpPSDegH23Amg9rNufs0BoXNM+GBtW5t58I=
+github.com/wmnsk/go-gtp v0.7.17/go.mod h1:IQ5tTgk1EDaKLLAum2vzYheKX9JeRngM1fm9ohdXAac=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
 github.com/xlab/treeprint v0.0.0-20180616005107-d6fb6747feb6/go.mod h1:ce1O1j6UtZfjr22oyGxGLbauSBp2YVXpARAosm7dHBg=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=

--- a/feg/gateway/go.mod
+++ b/feg/gateway/go.mod
@@ -40,7 +40,7 @@ require (
 	github.com/stretchr/objx v0.3.0 // indirect
 	github.com/stretchr/testify v1.6.1
 	github.com/thoas/go-funk v0.7.0
-	github.com/wmnsk/go-gtp v0.7.15
+	github.com/wmnsk/go-gtp v0.7.17
 	golang.org/x/crypto v0.0.0-20201016220609-9e8e0b390897 // indirect
 	golang.org/x/net v0.0.0-20201110031124-69a78807bb2b
 	golang.org/x/sys v0.0.0-20201018230417-eeed37f84f13 // indirect

--- a/feg/gateway/go.sum
+++ b/feg/gateway/go.sum
@@ -275,6 +275,7 @@ github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.4 h1:L8R9j+yAqZuZjsqh/z+F1NCffTKKLShY6zXTItVIZ8M=
 github.com/google/go-cmp v0.5.4/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/gofuzz v0.0.0-20161122191042-44d81051d367/go.mod h1:HP5RmnzzSNb993RKQDq4+1A4ia9nllfqcQFTQJedwGI=
 github.com/google/gofuzz v0.0.0-20170612174753-24818f796faf/go.mod h1:HP5RmnzzSNb993RKQDq4+1A4ia9nllfqcQFTQJedwGI=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
@@ -627,6 +628,8 @@ github.com/wadey/gocovmerge v0.0.0-20160331181800-b5bfa59ec0ad/go.mod h1:Hy8o65+
 github.com/warthog618/sms v0.3.0/go.mod h1:+bYZGeBxu003sxD5xhzsrIPBAjPBzTABsRTwSpd7ld4=
 github.com/wmnsk/go-gtp v0.7.15 h1:D0L2ISdfsVwzHvN/l7uyTvdqewUl+p0BDFElN0p7Uy0=
 github.com/wmnsk/go-gtp v0.7.15/go.mod h1:v1psjZ7skpPSDegH23Amg9rNufs0BoXNM+GBtW5t58I=
+github.com/wmnsk/go-gtp v0.7.17 h1:Q/zZopp/6mJPgqz5kb/yseOYTQ7v/E4Hp99Y4DzwnyY=
+github.com/wmnsk/go-gtp v0.7.17/go.mod h1:IQ5tTgk1EDaKLLAum2vzYheKX9JeRngM1fm9ohdXAac=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
 github.com/xlab/treeprint v0.0.0-20180616005107-d6fb6747feb6/go.mod h1:ce1O1j6UtZfjr22oyGxGLbauSBp2YVXpARAosm7dHBg=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=

--- a/feg/gateway/gtp/gtp_client.go
+++ b/feg/gateway/gtp/gtp_client.go
@@ -71,12 +71,14 @@ func NewRunningClient(ctx context.Context, localIpAndPort string, connType uint8
 
 	localAddr := &net.UDPAddr{IP: ipAddr, Port: port, Zone: ""}
 	c := newClient(localAddr, connType, gtpTimeout)
-	c.enable(localAddr)
-	err = c.run(ctx)
+	err = c.run(ctx, localAddr)
 	if err != nil {
 		return nil, err
 	}
-	c.WaitUntilClientIsReady(0)
+
+	// We need to disable GTP validation in order to support stateless operation
+	// Otherwise if we receive a message which doesnt have an actie session, the message
+	// will be discarded.
 	c.DisableValidation()
 	return c, nil
 }
@@ -122,22 +124,18 @@ func newClient(localAddr *net.UDPAddr, connType uint8, gtpTimeout time.Duration)
 	return cli
 }
 
-// Enable just creates the object connection enabling messages to be sent
-func (c *Client) enable(localAddr *net.UDPAddr) {
+// run starts the listener and launches the actual GTP-C routine
+func (c *Client) run(ctx context.Context, localAddr *net.UDPAddr) error {
 	c.Conn = gtpv2.NewConn(localAddr, c.connType, 0)
-}
-
-// Run launches the actual GTP-C cluent which will be able to send and receive GTP-C messages
-func (c *Client) run(ctx context.Context) error {
-	if c.Conn == nil {
-		return fmt.Errorf("nil conn object. You may need to Enable the client first")
+	if err := c.Conn.Listen(ctx); err != nil {
+		return fmt.Errorf("error enabling GTP client: %s", err)
 	}
 	go func() {
 		if ctx == nil {
 			ctx = context.Background()
 		}
-		if err := c.ListenAndServe(ctx); err != nil {
-			glog.Errorf("error running gtp server: %s", err)
+		if err := c.Serve(ctx); err != nil {
+			glog.Errorf("error running GTP client: %s", err)
 			return
 		}
 	}()
@@ -163,35 +161,4 @@ func configOrDefaultTimeout(configTimeout time.Duration) time.Duration {
 		return DefaultGtpTimeout
 	}
 	return configTimeout
-}
-
-//TODO: remove this once we find a way to safely wait for initialization of the service
-// WaitUntilClientIsReady is a hack to know when the client is ready and avoid null pointer issues using
-// the GTP-C client too early. Since go-gtp doesn't offer any visibuility on the readines of the connection
-// we use LocalAddrs as indicator
-func (c *Client) WaitUntilClientIsReady(count int) {
-
-	// TODO: only use those 3 waits for debugging
-	time.Sleep(time.Millisecond * 20)
-	time.Sleep(time.Millisecond * 20)
-	time.Sleep(time.Millisecond * 20)
-
-	defer func() {
-
-		if count > 50 {
-			time.Sleep(time.Millisecond * 20)
-		}
-		if count > 100 {
-			glog.Errorf("Couldnt start GTP-Client")
-			return
-		}
-		if r := recover(); r != nil {
-			fmt.Print(".")
-			c.WaitUntilClientIsReady(count + 1)
-		}
-	}()
-	// this call will panic while client is starting
-	addr := c.LocalAddr().String()
-	fmt.Println()
-	glog.V(2).Infof("Started GTP-C client in %s", addr)
 }


### PR DESCRIPTION
Signed-off-by: Oriol Batalla <obatalla@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary

We patched `go-gtp` to make sure the Listener was ready to be used (https://github.com/wmnsk/go-gtp/pull/146), Now we don't need to check if the listener is ready, so we can remove `WaitUntilClientIsReady` 

Note the update required a downgrade of a module in go gtp due to some conflicts with envoy
https://github.com/wmnsk/go-gtp/issues/155

We will have to monitor this dependency (google.golang.org/grpc) and notify [go-gtp](https://github.com/wmnsk/go-gtp) once we can support it

## Test Plan

make precommit at feg

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
