### PR TITLE
[lte][agw]Push debian packages to new jfrog repository as part of the artifactory migration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -803,8 +803,8 @@ jobs:
     machine:
       image: ubuntu-1604:201903-01
     steps:
-      - build/determinator:
-          <<: *lte_build_verify
+      #- build/determinator:
+      #    <<: *lte_build_verify
       - magma_integ_test:
           stack: lte
           test: 'False'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -316,7 +316,7 @@ commands:
           command: |
             sleep 10
             cd ${MAGMA_ROOT}/circleci
-            fab <<parameters.stack>> integ_test:repo=${CIRCLE_REPOSITORY_URL},branch=${CIRCLE_BRANCH},sha1=${CIRCLE_SHA1},run_integ_test=<<parameters.test>>,build_package=<<parameters.build>>,deploy_artifacts=<<parameters.deploy>>
+            # fab <<parameters.stack>> integ_test:repo=${CIRCLE_REPOSITORY_URL},branch=${CIRCLE_BRANCH},sha1=${CIRCLE_SHA1},run_integ_test=<<parameters.test>>,build_package=<<parameters.build>>,deploy_artifacts=<<parameters.deploy>>
 
             mkdir -p versions
             cp *_version versions || true
@@ -333,7 +333,7 @@ commands:
                for i in `ls -a1 *.deb`
                do
                   echo "Pushing package $i to JFROG artifiactory: ${JFROG_DEBIANLOCAL_REGISTRY}"
-                  curl -uci-bot:${JFROG_CIBOT_APIKEYS} -XPUT "${JFROG_DEBIANLOCAL_REGISTRY}/$i;deb.distribution=stretch-ci;deb.component=main;deb.architecture=amd64" -T $i
+                 # curl -uci-bot:${JFROG_CIBOT_APIKEYS} -XPUT "${JFROG_DEBIANLOCAL_REGISTRY}/$i;deb.distribution=stretch-ci;deb.component=main;deb.architecture=amd64" -T $i
                done
             else
                echo "${PACKAGE_FILE} does NOT exist"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -316,7 +316,7 @@ commands:
           command: |
             sleep 10
             cd ${MAGMA_ROOT}/circleci
-            # fab <<parameters.stack>> integ_test:repo=${CIRCLE_REPOSITORY_URL},branch=${CIRCLE_BRANCH},sha1=${CIRCLE_SHA1},run_integ_test=<<parameters.test>>,build_package=<<parameters.build>>,deploy_artifacts=<<parameters.deploy>>
+            fab <<parameters.stack>> integ_test:repo=${CIRCLE_REPOSITORY_URL},branch=${CIRCLE_BRANCH},sha1=${CIRCLE_SHA1},run_integ_test=<<parameters.test>>,build_package=<<parameters.build>>,deploy_artifacts=<<parameters.deploy>>
 
             mkdir -p versions
             cp *_version versions || true

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1114,13 +1114,13 @@ workflows:
 
   agw:
     jobs:
-      - lte-test
-      - lte-integ-test:
-          <<: *master_and_develop
+      #- lte-test
+      #- lte-integ-test:
+      #    <<: *master_and_develop
       - lte-agw-deploy:
-          <<: *only_master
-          requires:
-            - lte-integ-test
+      #    <<: *only_master
+      #    requires:
+      #      - lte-integ-test
 
   feg:
     jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -316,7 +316,7 @@ commands:
           command: |
             sleep 10
             cd ${MAGMA_ROOT}/circleci
-            fab <<parameters.stack>> integ_test:repo=${CIRCLE_REPOSITORY_URL},branch=${CIRCLE_BRANCH},sha1=${CIRCLE_SHA1},run_integ_test=<<parameters.test>>,build_package=<<parameters.build>>,deploy_artifacts=<<parameters.deploy>>
+            #fab <<parameters.stack>> integ_test:repo=${CIRCLE_REPOSITORY_URL},branch=${CIRCLE_BRANCH},sha1=${CIRCLE_SHA1},run_integ_test=<<parameters.test>>,build_package=<<parameters.build>>,deploy_artifacts=<<parameters.deploy>>
 
             mkdir -p versions
             cp *_version versions || true

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1114,10 +1114,11 @@ workflows:
 
   agw:
     jobs:
+      - lte-agw-deploy
       #- lte-test
       #- lte-integ-test:
       #    <<: *master_and_develop
-      - lte-agw-deploy:
+      #- lte-agw-deploy:
       #    <<: *only_master
       #    requires:
       #      - lte-integ-test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -316,7 +316,7 @@ commands:
           command: |
             sleep 10
             cd ${MAGMA_ROOT}/circleci
-            #fab <<parameters.stack>> integ_test:repo=${CIRCLE_REPOSITORY_URL},branch=${CIRCLE_BRANCH},sha1=${CIRCLE_SHA1},run_integ_test=<<parameters.test>>,build_package=<<parameters.build>>,deploy_artifacts=<<parameters.deploy>>
+            fab <<parameters.stack>> integ_test:repo=${CIRCLE_REPOSITORY_URL},branch=${CIRCLE_BRANCH},sha1=${CIRCLE_SHA1},run_integ_test=<<parameters.test>>,build_package=<<parameters.build>>,deploy_artifacts=<<parameters.deploy>>
 
             mkdir -p versions
             cp *_version versions || true
@@ -332,12 +332,12 @@ commands:
                tar xvf ${PACKAGE_FILE} 
                for i in `ls -a1 *.deb`
                do
-                  echo "Pushing package $i to JFROG artifiactory"
-                  # curl -uci-bot:XXX -XPUT "https://artifactory.magmacore.org/artifactory/debian-local/pool/chef-integration-test.deb;deb.distribution=stretch-ci;deb.component=main;deb.architecture=amd64" -T $i
+                  echo "Pushing package $i to JFROG artifiactory: ${JFROG_DEBIANLOCAL_REGISTRY}"
+                  curl -uci-bot:${JFROG_CIBOT_APIKEYS} -XPUT "${JFROG_DEBIANLOCAL_REGISTRY}/$i;deb.distribution=stretch-ci;deb.component=main;deb.architecture=amd64" -T $i
                done
             else
                echo "${PACKAGE_FILE} does NOT exist"
-               echo "No debian packes to push to JFROG"
+               echo "No debian packages to push to JFROG"
             fi
       - store_artifacts:
           path: /tmp/logs
@@ -803,8 +803,8 @@ jobs:
     machine:
       image: ubuntu-1604:201903-01
     steps:
-      #- build/determinator:
-      #    <<: *lte_build_verify
+      - build/determinator:
+          <<: *lte_build_verify
       - magma_integ_test:
           stack: lte
           test: 'False'
@@ -1114,14 +1114,13 @@ workflows:
 
   agw:
     jobs:
-      - lte-agw-deploy
-      #- lte-test
-      #- lte-integ-test:
-      #    <<: *master_and_develop
-      #- lte-agw-deploy:
-      #    <<: *only_master
-      #    requires:
-      #      - lte-integ-test
+      - lte-test
+      - lte-integ-test:
+          <<: *master_and_develop
+      - lte-agw-deploy:
+          <<: *only_master
+          requires:
+            - lte-integ-test
 
   feg:
     jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -321,6 +321,24 @@ commands:
             mkdir -p versions
             cp *_version versions || true
           no_output_timeout: 20m
+      - run:
+          name: Copy debian packages to new JFROG repo
+          command: |
+            cd ${MAGMA_ROOT}/circleci
+            PACKAGE_FILE=packages.tar.gz
+            if [ -f "${PACKAGE_FILE}" ]; then
+               echo "${PACKAGE_FILE} exists"
+               rm -rf *.deb
+               tar xvf ${PACKAGE_FILE} 
+               for i in `ls -a1 *.deb`
+               do
+                  echo "Pushing package $i to JFROG artifiactory"
+                  # curl -uci-bot:XXX -XPUT "https://artifactory.magmacore.org/artifactory/debian-local/pool/chef-integration-test.deb;deb.distribution=stretch-ci;deb.component=main;deb.architecture=amd64" -T $i
+               done
+            else
+               echo "${PACKAGE_FILE} does NOT exist"
+               echo "No debian packes to push to JFROG"
+            fi
       - store_artifacts:
           path: /tmp/logs
       - store_test_results:


### PR DESCRIPTION
<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary
Push LTE, AGW debian packages to new jfrog repository as part of the artifactory migration.

<!-- Enumerate changes you made and why you made them -->
The changes are made in the .circleci/config.yml file. New environment variables are created in CircleCI - JFROG_CIBOT_APIKEYS, JFROG_DEBIANLOCAL_REGISTRY

## Test Plan
**Unit Testing CircleCI successful build:**
https://app.circleci.com/pipelines/github/magma/magma/16997/workflows/1095a72e-eaa9-4f97-8e3e-ff84a7f4fde8/jobs/159739

**CircleCI successful build with actual changes:**
https://app.circleci.com/pipelines/github/magma/magma?branch=lteagw_debpkgs_jfrog_migration


<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
