### PR TITLE
[SessionD] Activate all rules with PolicyRule definitions

### DIFF
--- a/lte/cloud/go/protos/pipelined.pb.go
+++ b/lte/cloud/go/protos/pipelined.pb.go
@@ -762,8 +762,9 @@ func (m *RequestOriginType) GetType() RequestOriginType_OriginType {
 }
 
 type ActivateFlowsRequest struct {
-	Sid                  *SubscriberID             `protobuf:"bytes,1,opt,name=sid,proto3" json:"sid,omitempty"`
-	IpAddr               string                    `protobuf:"bytes,2,opt,name=ip_addr,json=ipAddr,proto3" json:"ip_addr,omitempty"`
+	Sid    *SubscriberID `protobuf:"bytes,1,opt,name=sid,proto3" json:"sid,omitempty"`
+	IpAddr string        `protobuf:"bytes,2,opt,name=ip_addr,json=ipAddr,proto3" json:"ip_addr,omitempty"`
+	// Deprecated
 	RuleIds              []string                  `protobuf:"bytes,3,rep,name=rule_ids,json=ruleIds,proto3" json:"rule_ids,omitempty"`
 	DynamicRules         []*PolicyRule             `protobuf:"bytes,4,rep,name=dynamic_rules,json=dynamicRules,proto3" json:"dynamic_rules,omitempty"`
 	RequestOrigin        *RequestOriginType        `protobuf:"bytes,5,opt,name=request_origin,json=requestOrigin,proto3" json:"request_origin,omitempty"`

--- a/lte/gateway/c/session_manager/AAAClient.cpp
+++ b/lte/gateway/c/session_manager/AAAClient.cpp
@@ -44,9 +44,7 @@ aaa::add_sessions_request create_add_sessions_req(
         continue;
       }
       const auto& wlan_context = config.rat_specific_context.wlan_context();
-      magma::SessionState::SessionInfo session_info;
-      session->get_session_info(session_info);
-      ctx.set_imsi(session_info.imsi);
+      ctx.set_imsi(config.common_context.sid().id());
       ctx.set_session_id(wlan_context.radius_session_id());
       ctx.set_acct_session_id(session->get_session_id());
       ctx.set_mac_addr(wlan_context.mac_addr());

--- a/lte/gateway/c/session_manager/CMakeLists.txt
+++ b/lte/gateway/c/session_manager/CMakeLists.txt
@@ -48,7 +48,7 @@ add_definitions(-DLOG_WITH_GLOG)
 
 message("Build type is ${CMAKE_BUILD_TYPE}")
 if (CMAKE_BUILD_TYPE STREQUAL "Debug")
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wno-unused-function")
 endif ()
 
 include_directories("${OUTPUT_DIR}")

--- a/lte/gateway/c/session_manager/LocalEnforcer.cpp
+++ b/lte/gateway/c/session_manager/LocalEnforcer.cpp
@@ -563,12 +563,11 @@ void LocalEnforcer::install_final_unit_action_flows(
 
 void LocalEnforcer::cancel_final_unit_action(
     const std::unique_ptr<SessionState>& session,
-    const std::vector<std::string>& restrict_rules,
+    std::vector<PolicyRule> gy_rules_to_deactivate,
     SessionStateUpdateCriteria& uc) {
   SessionState::SessionInfo info;
   session->get_session_info(info);
 
-  std::vector<PolicyRule> gy_rules_to_deactivate;
   for (const auto& rule : info.gy_dynamic_rules) {
     PolicyRule dy_rule;
     bool is_dynamic = session->remove_gy_dynamic_rule(rule.id(), &dy_rule, uc);
@@ -577,9 +576,9 @@ void LocalEnforcer::cancel_final_unit_action(
     }
   }
 
-  if (!gy_rules_to_deactivate.empty() || !restrict_rules.empty()) {
+  if (!gy_rules_to_deactivate.empty()) {
     pipelined_client_->deactivate_flows_for_rules(
-        info.imsi, info.ip_addr, info.ipv6_addr, info.teids, restrict_rules,
+        info.imsi, info.ip_addr, info.ipv6_addr, info.teids,
         gy_rules_to_deactivate, RequestOriginType::GY);
   }
 }
@@ -792,17 +791,22 @@ void LocalEnforcer::schedule_static_rule_deactivation(
         if (session->should_rule_be_active(rule_id, time(nullptr))) {
           return;
         }
+        PolicyRule rule;
+        if (!rule_store_->get_rule(rule_id, &rule)) {
+          MLOG(MERROR) << "static rule " << rule_id
+                       << " is not found, skipping deactivation...";
+          return;
+        }
         auto ip_addr      = session->get_config().common_context.ue_ipv4();
         auto ipv6_addr    = session->get_config().common_context.ue_ipv6();
         const Teids teids = session->get_config().common_context.teids();
 
         pipelined_client_->deactivate_flows_for_rules(
-            imsi, ip_addr, ipv6_addr, teids, {rule_id}, {},
-            RequestOriginType::GX);
+            imsi, ip_addr, ipv6_addr, teids, {rule}, RequestOriginType::GX);
 
         auto& session_uc = session_update[imsi][session_id];
         if (!session->deactivate_static_rule(rule_id, session_uc)) {
-          MLOG(MWARNING) << "Could not find rule " << rule_id << "for "
+          MLOG(MWARNING) << "Could not find rule " << rule_id << " for "
                          << session_id << " during static rule removal";
         }
         session_store_.update_sessions(session_update);
@@ -840,8 +844,7 @@ void LocalEnforcer::schedule_dynamic_rule_deactivation(
         PolicyRule policy;
         session->get_scheduled_dynamic_rules().get_rule(rule_id, &policy);
         pipelined_client_->deactivate_flows_for_rules(
-            imsi, ip_addr, ipv6_addr, teids, {}, {policy},
-            RequestOriginType::GX);
+            imsi, ip_addr, ipv6_addr, teids, {policy}, RequestOriginType::GX);
         auto& uc = session_update[imsi][session_id];
         session->remove_dynamic_rule(policy.id(), nullptr, uc);
         session_store_.update_sessions(session_update);
@@ -1200,12 +1203,6 @@ void LocalEnforcer::complete_termination(
   }
 }
 
-bool LocalEnforcer::rules_to_process_is_not_empty(
-    const RulesToProcess& rules_to_process) {
-  return rules_to_process.static_rules.size() > 0 ||
-         rules_to_process.dynamic_rules.size() > 0;
-}
-
 void LocalEnforcer::terminate_multiple_sessions(
     SessionMap& session_map,
     const std::unordered_set<ImsiAndSessionID>& sessions,
@@ -1338,8 +1335,8 @@ void LocalEnforcer::update_charging_credits(
     const auto& credit_key(credit_update_resp);
     // We need to retrieve restrict_rules and is_final_action_state
     // prior to receiving charging credit as they will be updated.
-    std::vector<std::string> restrict_rules;
-    session->get_final_action_restrict_rules(credit_key, restrict_rules);
+    std::vector<PolicyRule> restrict_rules =
+        session->get_final_action_restrict_rules(credit_key);
     bool is_final_action_state =
         session->is_credit_in_final_unit_state(credit_key);
     bool valid_credit =
@@ -1680,7 +1677,7 @@ void LocalEnforcer::init_policy_reauth_for_session(
     return;
   }
   if (session->get_config().common_context.rat_type() == TGPP_LTE) {
-    create_bearer(session, request, rules_to_activate.dynamic_rules);
+    create_bearer(session, request, rules_to_activate.rules);
   }
 }
 
@@ -1694,30 +1691,20 @@ void LocalEnforcer::propagate_rule_updates_to_pipelined(
   // deactivate_flows_for_rules() should not be called when there is no rule
   // to deactivate, because pipelined deactivates all rules
   // when no rule is provided as the parameter
-  if (rules_to_process_is_not_empty(rules_to_deactivate)) {
+  if (!rules_to_deactivate.empty()) {
     pipelined_client_->deactivate_flows_for_rules(
-        imsi, ip_addr, ipv6_addr, teids, rules_to_deactivate.static_rules,
-        rules_to_deactivate.dynamic_rules, RequestOriginType::GX);
+        imsi, ip_addr, ipv6_addr, teids, rules_to_deactivate.rules,
+        RequestOriginType::GX);
   }
-  if (always_send_activate ||
-      rules_to_process_is_not_empty(rules_to_activate)) {
-    const auto ambr                  = config.get_apn_ambr();
-    const auto msisdn                = config.common_context.msisdn();
-    std::vector<PolicyRule> policies = rules_to_activate.dynamic_rules;
-    for (const std::string& rule_id : rules_to_activate.static_rules) {
-      PolicyRule policy;
-      if (rule_store_->get_rule(rule_id, &policy)) {
-        policies.push_back(policy);
-      } else {
-        MLOG(MWARNING) << "Static rule " << rule_id
-                       << " doesn't exist in RuleStore, skipping...";
-      }
-    }
+  if (always_send_activate || !rules_to_activate.empty()) {
+    const auto ambr   = config.get_apn_ambr();
+    const auto msisdn = config.common_context.msisdn();
     pipelined_client_->activate_flows_for_rules(
-        imsi, ip_addr, ipv6_addr, teids, msisdn, ambr, policies,
+        imsi, ip_addr, ipv6_addr, teids, msisdn, ambr, rules_to_activate.rules,
         std::bind(
             &LocalEnforcer::handle_activate_ue_flows_callback, this, imsi,
-            ip_addr, ipv6_addr, teids, msisdn, ambr, policies, _1, _2));
+            ip_addr, ipv6_addr, teids, msisdn, ambr, rules_to_activate.rules,
+            _1, _2));
   }
 }
 
@@ -1745,15 +1732,17 @@ void LocalEnforcer::process_rules_to_remove(
     RulesToProcess& rules_to_deactivate, SessionStateUpdateCriteria& uc) {
   for (const auto& rule_id : rules_to_remove) {
     // Try to remove as dynamic rule first
-    PolicyRule dy_rule;
+    PolicyRule dy_rule, st_rule;
     bool is_dynamic = session->remove_dynamic_rule(rule_id, &dy_rule, uc);
-    if (is_dynamic) {
-      rules_to_deactivate.dynamic_rules.push_back(dy_rule);
+    if (is_dynamic) {  // dynamic rule
+      rules_to_deactivate.rules.push_back(dy_rule);
+    } else if (  // static rule
+        rule_store_->get_rule(rule_id, &st_rule) &&
+        session->deactivate_static_rule(rule_id, uc)) {
+      rules_to_deactivate.rules.push_back(st_rule);
     } else {
-      if (!session->deactivate_static_rule(rule_id, uc))
-        MLOG(MWARNING) << "Could not find rule " << rule_id << "for IMSI "
-                       << imsi << " during static rule removal";
-      rules_to_deactivate.static_rules.push_back(rule_id);
+      MLOG(MWARNING) << "Could not find rule " << rule_id << " for " << imsi
+                     << " during static rule removal";
     }
   }
 }
@@ -1795,6 +1784,12 @@ void LocalEnforcer::process_rules_to_install(
       // Ignore them here.
       continue;
     }
+    PolicyRule static_rule;
+    if (!rule_store_->get_rule(id, &static_rule)) {
+      MLOG(MERROR) << "static rule " << id
+                   << " is not found, skipping install...";
+    }
+
     RuleLifetime lifetime(rule_install);
     if (lifetime.activation_time > current_time) {
       session.schedule_static_rule(id, lifetime, uc);
@@ -1802,7 +1797,8 @@ void LocalEnforcer::process_rules_to_install(
           imsi, session_id, id, lifetime.activation_time);
     } else {
       session.activate_static_rule(id, lifetime, uc);
-      rules_to_activate.static_rules.push_back(id);
+      // Set up rules_to_activate
+      rules_to_activate.rules.push_back(static_rule);
     }
 
     if (lifetime.deactivation_time > current_time) {
@@ -1814,27 +1810,29 @@ void LocalEnforcer::process_rules_to_install(
         MLOG(MWARNING) << "Could not find rule " << id << "for " << session_id
                        << " during static rule removal";
       }
-      rules_to_deactivate.static_rules.push_back(id);
+
+      rules_to_deactivate.rules.push_back(static_rule);
     }
   }
 
   for (auto& rule_install : dynamic_rule_installs) {
-    auto rule_id = rule_install.policy_rule().id();
+    PolicyRule dynamic_rule = rule_install.policy_rule();
+    auto rule_id            = dynamic_rule.id();
     RuleLifetime lifetime(rule_install);
     if (lifetime.activation_time > current_time) {
-      session.schedule_dynamic_rule(rule_install.policy_rule(), lifetime, uc);
+      session.schedule_dynamic_rule(dynamic_rule, lifetime, uc);
       schedule_dynamic_rule_activation(
           imsi, session_id, rule_id, lifetime.activation_time);
     } else {
-      session.insert_dynamic_rule(rule_install.policy_rule(), lifetime, uc);
-      rules_to_activate.dynamic_rules.push_back(rule_install.policy_rule());
+      session.insert_dynamic_rule(dynamic_rule, lifetime, uc);
+      rules_to_activate.rules.push_back(dynamic_rule);
     }
     if (lifetime.deactivation_time > current_time) {
       schedule_dynamic_rule_deactivation(
           imsi, session_id, rule_id, lifetime.deactivation_time);
     } else if (lifetime.deactivation_time > 0) {
-      session.remove_dynamic_rule(rule_id, NULL, uc);
-      rules_to_deactivate.dynamic_rules.push_back(rule_install.policy_rule());
+      session.remove_dynamic_rule(rule_id, nullptr, uc);
+      rules_to_deactivate.rules.push_back(dynamic_rule);
     }
   }
 }
@@ -1976,7 +1974,10 @@ void LocalEnforcer::create_bearer(
 
     auto req_policy_rules = req.mutable_policy_rules();
     for (const auto& rule : dynamic_rules) {
-      req_policy_rules->Add()->CopyFrom(rule);
+      optional<PolicyType> p_type = session->get_policy_type(rule.id());
+      if (p_type && *p_type == DYNAMIC) {
+        req_policy_rules->Add()->CopyFrom(rule);
+      }
     }
     spgw_client_->create_dedicated_bearer(req);
   }
@@ -2081,25 +2082,26 @@ void LocalEnforcer::remove_rule_due_to_bearer_creation_failure(
                  << " since it is not found";
     return;
   }
-  std::vector<std::string> static_rule_to_remove;
-  std::vector<PolicyRule> dynamic_rule_to_remove;
+
+  PolicyRule rule;
+  bool found = false;
 
   switch (*policy_type) {
     case STATIC:
       session.deactivate_static_rule(rule_id, uc);
-      static_rule_to_remove.push_back(rule_id);
+      found = rule_store_->get_rule(rule_id, &rule);
       break;
     case DYNAMIC: {
-      PolicyRule rule;
-      session.remove_dynamic_rule(rule_id, &rule, uc);
-      dynamic_rule_to_remove.push_back(rule);
+      found = session.remove_dynamic_rule(rule_id, &rule, uc);
+      break;
     }
   }
-  pipelined_client_->deactivate_flows_for_rules(
-      imsi, session.get_config().common_context.ue_ipv4(),
-      session.get_config().common_context.ue_ipv6(),
-      session.get_config().common_context.teids(), static_rule_to_remove,
-      dynamic_rule_to_remove, RequestOriginType::GX);
+  auto config = session.get_config().common_context;
+  if (found) {
+    pipelined_client_->deactivate_flows_for_rules(
+        imsi, config.ue_ipv4(), config.ue_ipv6(), config.teids(), {rule},
+        RequestOriginType::GX);
+  }
 }
 
 std::unique_ptr<Timezone> LocalEnforcer::compute_access_timezone() {

--- a/lte/gateway/c/session_manager/LocalEnforcer.cpp
+++ b/lte/gateway/c/session_manager/LocalEnforcer.cpp
@@ -414,7 +414,7 @@ void LocalEnforcer::remove_all_rules_for_termination(
   for (const std::string& static_rule : info.static_rules) {
     uc.static_rules_to_uninstall.insert(static_rule);
   }
-  for (const PolicyRule& gx_dynamic_rule : info.dynamic_rules) {
+  for (const PolicyRule& gx_dynamic_rule : info.gx_dynamic_rules) {
     uc.dynamic_rules_to_uninstall.insert(gx_dynamic_rule.id());
   }
   for (const PolicyRule& gy_dynamic_rule : info.gy_dynamic_rules) {
@@ -425,7 +425,7 @@ void LocalEnforcer::remove_all_rules_for_termination(
   const auto ipv6_addr = session->get_config().common_context.ue_ipv6();
   const Teids teids    = session->get_config().common_context.teids();
   pipelined_client_->deactivate_flows_for_rules_for_termination(
-      imsi, ip_addr, ipv6_addr, teids, info.static_rules, info.dynamic_rules,
+      imsi, ip_addr, ipv6_addr, teids, info.static_rules, info.gx_dynamic_rules,
       RequestOriginType::GX);
 
   auto gy_rules = session->get_all_final_unit_rules();
@@ -2110,7 +2110,7 @@ void LocalEnforcer::remove_rule_due_to_bearer_creation_failure(
       dynamic_rule_to_remove.push_back(rule);
     }
   }
-  pipelined_client_->deactivate_flows_for_rules_for_termination(
+  pipelined_client_->deactivate_flows_for_rules(
       imsi, session.get_config().common_context.ue_ipv4(),
       session.get_config().common_context.ue_ipv6(),
       session.get_config().common_context.teids(), static_rule_to_remove,

--- a/lte/gateway/c/session_manager/LocalEnforcer.h
+++ b/lte/gateway/c/session_manager/LocalEnforcer.h
@@ -591,15 +591,13 @@ class LocalEnforcer {
    */
   void cancel_final_unit_action(
       const std::unique_ptr<SessionState>& session,
-      const std::vector<std::string>& restrict_rules,
+      std::vector<PolicyRule> gy_rules_to_deactivate,
       SessionStateUpdateCriteria& uc);
 
   /**
    * Create redirection rule
    */
   PolicyRule create_redirect_rule(const std::unique_ptr<ServiceAction>& action);
-
-  bool rules_to_process_is_not_empty(const RulesToProcess& rules_to_process);
 
   void report_subscriber_state_to_pipelined(
       const std::string& imsi, const std::string& ue_mac_addr,

--- a/lte/gateway/c/session_manager/LocalEnforcer.h
+++ b/lte/gateway/c/session_manager/LocalEnforcer.h
@@ -516,7 +516,7 @@ class LocalEnforcer {
 
   /**
    * remove_all_rules_for_termination talks to PipelineD and removes all rules
-   * attached to the session
+   * (Gx/Gy/static/dynamic/everything) attached to the session
    * @param imsi
    * @param session
    * @param uc

--- a/lte/gateway/c/session_manager/LocalEnforcer.h
+++ b/lte/gateway/c/session_manager/LocalEnforcer.h
@@ -483,7 +483,6 @@ class LocalEnforcer {
       const std::string& imsi, const std::string& ip_addr,
       const std::string& ipv6_addr, const Teids teids,
       const std::string& msisdn, optional<AggregatedMaximumBitrate> ambr,
-      const std::vector<std::string>& static_rules,
       const std::vector<PolicyRule>& dynamic_rules, Status status,
       ActivateFlowsResult resp);
 

--- a/lte/gateway/c/session_manager/PipelinedClient.cpp
+++ b/lte/gateway/c/session_manager/PipelinedClient.cpp
@@ -269,18 +269,14 @@ void AsyncPipelinedClient::deactivate_all_flows(const std::string& imsi) {
 void AsyncPipelinedClient::deactivate_flows_for_rules_for_termination(
     const std::string& imsi, const std::string& ip_addr,
     const std::string& ipv6_addr, const Teids teids,
-    const std::vector<std::string>& rule_ids,
-    const std::vector<PolicyRule>& dynamic_rules,
     const RequestOriginType_OriginType origin_type) {
-  MLOG(MDEBUG) << "Deactivating " << rule_ids.size() << " static rules and "
-               << dynamic_rules.size()
-               << " dynamic rules and default drop flows "
-                  "for subscriber "
-               << imsi << " IP " << ip_addr << " " << ipv6_addr;
+  MLOG(MDEBUG)
+      << "Deactivating all static/dynamic rules and default drop flows "
+         "for subscriber "
+      << imsi << " IP " << ip_addr << " " << ipv6_addr;
 
   auto req = create_deactivate_req(
-      imsi, ip_addr, ipv6_addr, teids, rule_ids, dynamic_rules, origin_type,
-      true);
+      imsi, ip_addr, ipv6_addr, teids, {}, {}, origin_type, true);
   deactivate_flows(req);
 }
 

--- a/lte/gateway/c/session_manager/PipelinedClient.cpp
+++ b/lte/gateway/c/session_manager/PipelinedClient.cpp
@@ -51,8 +51,7 @@ magma::SessionSet create_session_set_req(
 magma::DeactivateFlowsRequest create_deactivate_req(
     const std::string& imsi, const std::string& ip_addr,
     const std::string& ipv6_addr, const magma::Teids teids,
-    const std::vector<std::string>& rule_ids,
-    const std::vector<magma::PolicyRule>& dynamic_rules,
+    const std::vector<magma::PolicyRule>& rules,
     const magma::RequestOriginType_OriginType origin_type,
     const bool remove_default_drop_rules) {
   magma::DeactivateFlowsRequest req;
@@ -64,10 +63,7 @@ magma::DeactivateFlowsRequest create_deactivate_req(
   req.set_remove_default_drop_flows(remove_default_drop_rules);
   req.mutable_request_origin()->set_type(origin_type);
   auto ids = req.mutable_rule_ids();
-  for (const auto& id : rule_ids) {
-    ids->Add()->assign(id);
-  }
-  for (const auto& rule : dynamic_rules) {
+  for (const auto& rule : rules) {
     ids->Add()->assign(rule.id());
   }
   return req;
@@ -276,23 +272,21 @@ void AsyncPipelinedClient::deactivate_flows_for_rules_for_termination(
       << imsi << " IP " << ip_addr << " " << ipv6_addr;
 
   auto req = create_deactivate_req(
-      imsi, ip_addr, ipv6_addr, teids, {}, {}, origin_type, true);
+      imsi, ip_addr, ipv6_addr, teids, {}, origin_type, true);
   deactivate_flows(req);
 }
 
 void AsyncPipelinedClient::deactivate_flows_for_rules(
     const std::string& imsi, const std::string& ip_addr,
     const std::string& ipv6_addr, const Teids teids,
-    const std::vector<std::string>& rule_ids,
-    const std::vector<PolicyRule>& dynamic_rules,
+    const std::vector<PolicyRule>& rules,
     const RequestOriginType_OriginType origin_type) {
-  MLOG(MDEBUG) << "Deactivating " << rule_ids.size() << " static rules and "
-               << dynamic_rules.size() << " dynamic rules for subscriber "
-               << imsi << " IP " << ip_addr << " " << ipv6_addr;
+  MLOG(MDEBUG) << "Deactivating " << rules.size()
+               << " rules and for subscriber " << imsi << " IP " << ip_addr
+               << " " << ipv6_addr;
 
   auto req = create_deactivate_req(
-      imsi, ip_addr, ipv6_addr, teids, rule_ids, dynamic_rules, origin_type,
-      false);
+      imsi, ip_addr, ipv6_addr, teids, rules, origin_type, false);
   deactivate_flows(req);
 }
 

--- a/lte/gateway/c/session_manager/PipelinedClient.h
+++ b/lte/gateway/c/session_manager/PipelinedClient.h
@@ -101,8 +101,7 @@ class PipelinedClient {
       const std::string& imsi, const std::string& ip_addr,
       const std::string& ipv6_addr, const Teids teids,
       const std::string& msisdn, const optional<AggregatedMaximumBitrate>& ambr,
-      const std::vector<std::string>& static_rules,
-      const std::vector<PolicyRule>& dynamic_rules,
+      const std::vector<PolicyRule>& rules,
       std::function<void(Status status, ActivateFlowsResult)> callback) = 0;
 
   /**
@@ -142,8 +141,7 @@ class PipelinedClient {
   virtual void add_gy_final_action_flow(
       const std::string& imsi, const std::string& ip_addr,
       const std::string& ipv6_addr, const Teids teids,
-      const std::string& msisdn, const std::vector<std::string>& static_rules,
-      const std::vector<PolicyRule>& dynamic_rules) = 0;
+      const std::string& msisdn, const std::vector<PolicyRule>& rules) = 0;
 
   /**
    * Set up a Session of type SetMessage to be sent to UPF
@@ -235,8 +233,7 @@ class AsyncPipelinedClient : public GRPCReceiver, public PipelinedClient {
       const std::string& imsi, const std::string& ip_addr,
       const std::string& ipv6_addr, const Teids teids,
       const std::string& msisdn, const optional<AggregatedMaximumBitrate>& ambr,
-      const std::vector<std::string>& static_rules,
-      const std::vector<PolicyRule>& dynamic_rules,
+      const std::vector<PolicyRule>& rules,
       std::function<void(Status status, ActivateFlowsResult)> callback);
 
   /**
@@ -269,8 +266,7 @@ class AsyncPipelinedClient : public GRPCReceiver, public PipelinedClient {
   void add_gy_final_action_flow(
       const std::string& imsi, const std::string& ip_addr,
       const std::string& ipv6_addr, const Teids teids,
-      const std::string& msisdn, const std::vector<std::string>& static_rules,
-      const std::vector<PolicyRule>& dynamic_rules);
+      const std::string& msisdn, const std::vector<PolicyRule>& rules);
 
   void set_upf_session(
       const SessionState::SessionInfo info,

--- a/lte/gateway/c/session_manager/PipelinedClient.h
+++ b/lte/gateway/c/session_manager/PipelinedClient.h
@@ -88,7 +88,6 @@ class PipelinedClient {
   virtual void deactivate_flows_for_rules(
       const std::string& imsi, const std::string& ip_addr,
       const std::string& ipv6_addr, const Teids teids,
-      const std::vector<std::string>& rule_ids,
       const std::vector<PolicyRule>& dynamic_rules,
       const RequestOriginType_OriginType origin_type) = 0;
 
@@ -212,7 +211,6 @@ class AsyncPipelinedClient : public GRPCReceiver, public PipelinedClient {
   void deactivate_flows_for_rules(
       const std::string& imsi, const std::string& ip_addr,
       const std::string& ipv6_addr, const Teids teids,
-      const std::vector<std::string>& rule_ids,
       const std::vector<PolicyRule>& dynamic_rules,
       const RequestOriginType_OriginType origin_type);
 

--- a/lte/gateway/c/session_manager/PipelinedClient.h
+++ b/lte/gateway/c/session_manager/PipelinedClient.h
@@ -78,8 +78,6 @@ class PipelinedClient {
   virtual void deactivate_flows_for_rules_for_termination(
       const std::string& imsi, const std::string& ip_addr,
       const std::string& ipv6_addr, const Teids teids,
-      const std::vector<std::string>& rule_ids,
-      const std::vector<PolicyRule>& dynamic_rules,
       const RequestOriginType_OriginType origin_type) = 0;
 
   /**
@@ -204,8 +202,6 @@ class AsyncPipelinedClient : public GRPCReceiver, public PipelinedClient {
   void deactivate_flows_for_rules_for_termination(
       const std::string& imsi, const std::string& ip_addr,
       const std::string& ipv6_addr, const Teids teids,
-      const std::vector<std::string>& rule_ids,
-      const std::vector<PolicyRule>& dynamic_rules,
       const RequestOriginType_OriginType origin_type);
 
   /**

--- a/lte/gateway/c/session_manager/RuleStore.cpp
+++ b/lte/gateway/c/session_manager/RuleStore.cpp
@@ -137,7 +137,7 @@ bool PolicyRuleBiMap::get_rule(
   return true;
 }
 
-bool PolicyRuleBiMap::get_rules(
+bool PolicyRuleBiMap::get_rules_by_ids(
     const std::vector<std::string>& rule_ids,
     std::vector<PolicyRule>& rules_out) {
   std::lock_guard<std::mutex> lock(map_mutex_);

--- a/lte/gateway/c/session_manager/RuleStore.cpp
+++ b/lte/gateway/c/session_manager/RuleStore.cpp
@@ -137,6 +137,20 @@ bool PolicyRuleBiMap::get_rule(
   return true;
 }
 
+bool PolicyRuleBiMap::get_rules(
+    const std::vector<std::string>& rule_ids,
+    std::vector<PolicyRule>& rules_out) {
+  std::lock_guard<std::mutex> lock(map_mutex_);
+  for (const std::string rule_id : rule_ids) {
+    auto it = rules_by_rule_id_.find(rule_id);
+    if (it == rules_by_rule_id_.end()) {
+      return false;
+    }
+    rules_out.push_back(*it->second);
+  }
+  return true;
+}
+
 bool PolicyRuleBiMap::remove_rule(
     const std::string& rule_id, PolicyRule* rule_out) {
   std::lock_guard<std::mutex> lock(map_mutex_);

--- a/lte/gateway/c/session_manager/RuleStore.h
+++ b/lte/gateway/c/session_manager/RuleStore.h
@@ -74,6 +74,10 @@ class PolicyRuleBiMap {
   // If the output rule param is NULL, the rule object is not copied.
   virtual bool get_rule(const std::string& rule_id, PolicyRule* rule_out);
 
+  virtual bool get_rules(
+      const std::vector<std::string>& rule_ids,
+      std::vector<PolicyRule>& rules_out);
+
   // Remove a rule from the store by ID. Returns true if the rule ID was found.
   // The removed rule will be copied into rule_out.
   // If the output rule param is NULL, the rule object is not copied.

--- a/lte/gateway/c/session_manager/RuleStore.h
+++ b/lte/gateway/c/session_manager/RuleStore.h
@@ -74,7 +74,7 @@ class PolicyRuleBiMap {
   // If the output rule param is NULL, the rule object is not copied.
   virtual bool get_rule(const std::string& rule_id, PolicyRule* rule_out);
 
-  virtual bool get_rules(
+  virtual bool get_rules_by_ids(
       const std::vector<std::string>& rule_ids,
       std::vector<PolicyRule>& rules_out);
 

--- a/lte/gateway/c/session_manager/ServiceAction.h
+++ b/lte/gateway/c/session_manager/ServiceAction.h
@@ -111,8 +111,6 @@ class ServiceAction {
 
   const CreditKey& get_credit_key() const { return credit_key_; }
 
-  const std::vector<std::string>& get_rule_ids() const { return rule_ids_; }
-
   const std::vector<PolicyRule>& get_rule_definitions() const {
     return rule_definitions_;
   }
@@ -121,11 +119,9 @@ class ServiceAction {
    * get_restrict_rules returns the associated restrict rules
    * for the RESTRICT action
    */
-  const std::vector<std::string>& get_restrict_rules() const {
+  const std::vector<PolicyRule>& get_restrict_rules() const {
     return restrict_rules_;
   }
-
-  std::vector<std::string>* get_mutable_rule_ids() { return &rule_ids_; }
 
   std::vector<PolicyRule>* get_mutable_rule_definitions() {
     return &rule_definitions_;
@@ -143,7 +139,7 @@ class ServiceAction {
    * get_mutable_restrict_rules returns a mutable list of the associated
    * restrict rules
    */
-  std::vector<std::string>* get_mutable_restrict_rules() {
+  std::vector<PolicyRule>* get_mutable_restrict_rules() {
     return &restrict_rules_;
   }
 
@@ -166,7 +162,7 @@ class ServiceAction {
   std::vector<PolicyRule> rule_definitions_;
   std::unique_ptr<RedirectServer> redirect_server_;
   optional<AggregatedMaximumBitrate> ambr_;
-  std::vector<std::string> restrict_rules_;
+  std::vector<PolicyRule> restrict_rules_;
 };
 
 }  // namespace magma

--- a/lte/gateway/c/session_manager/SessionState.cpp
+++ b/lte/gateway/c/session_manager/SessionState.cpp
@@ -1692,7 +1692,7 @@ void SessionState::fill_service_action(
   action->set_teids(config_.common_context.teids());
   action->set_msisdn(config_.common_context.msisdn());
   action->set_session_id(session_id_);
-  static_rules_.get_rules(
+  static_rules_.get_rules_by_ids(
       active_static_rules_, *action->get_mutable_rule_definitions());
   dynamic_rules_.get_rule_definitions_for_charging_key(
       key, *action->get_mutable_rule_definitions());

--- a/lte/gateway/c/session_manager/SessionState.cpp
+++ b/lte/gateway/c/session_manager/SessionState.cpp
@@ -855,10 +855,18 @@ void SessionState::get_session_info(SessionState::SessionInfo& info) {
   info.ipv6_addr = config_.common_context.ue_ipv6();
   info.teids     = config_.common_context.teids();
   info.msisdn    = config_.common_context.msisdn();
-  get_dynamic_rules().get_rules(info.dynamic_rules);
-  get_gy_dynamic_rules().get_rules(info.gy_dynamic_rules);
+  info.ambr      = config_.get_apn_ambr();
+
+  dynamic_rules_.get_rules(info.gx_dynamic_rules);
+  gy_dynamic_rules_.get_rules(info.gy_dynamic_rules);
   info.static_rules = active_static_rules_;
-  info.ambr         = config_.get_apn_ambr();
+
+  for (const std::string& rule_id : active_static_rules_) {
+    PolicyRule rule;
+    if (static_rules_.get_rule(rule_id, &rule)) {
+      info.gx_static_rules.push_back(rule);
+    }
+  }
 }
 
 std::vector<PolicyRule> SessionState::get_all_active_policies() {

--- a/lte/gateway/c/session_manager/SessionState.h
+++ b/lte/gateway/c/session_manager/SessionState.h
@@ -652,11 +652,9 @@ class SessionState {
    * UpdateSessionRequest.
    *
    * @param update_request_out Modified with added UsdageMonitoringUpdateRequest
-   * @param actions_out Modified with additional actions to take on session.
    */
   void get_monitor_updates(
       UpdateSessionRequest& update_request_out,
-      std::vector<std::unique_ptr<ServiceAction>>* actions_out,
       SessionStateUpdateCriteria& update_criteria);
 
   /**
@@ -697,7 +695,6 @@ class SessionState {
 
   void get_event_trigger_updates(
       UpdateSessionRequest& update_request_out,
-      std::vector<std::unique_ptr<ServiceAction>>* actions_out,
       SessionStateUpdateCriteria& update_criteria);
 
   bool is_static_rule_scheduled(const std::string& rule_id);

--- a/lte/gateway/c/session_manager/SessionState.h
+++ b/lte/gateway/c/session_manager/SessionState.h
@@ -108,8 +108,10 @@ class SessionState {
 
     uint32_t local_f_teid;
     std::string msisdn;
+    // TODO deprecate std::vector<std::string> static_rules
     std::vector<std::string> static_rules;
-    std::vector<PolicyRule> dynamic_rules;
+    std::vector<PolicyRule> gx_static_rules;
+    std::vector<PolicyRule> gx_dynamic_rules;
     std::vector<PolicyRule> gy_dynamic_rules;
     optional<AggregatedMaximumBitrate> ambr;
     // 5G specific extensions

--- a/lte/gateway/c/session_manager/SessionState.h
+++ b/lte/gateway/c/session_manager/SessionState.h
@@ -242,7 +242,7 @@ class SessionState {
       const CreditKey& key, ChargingGrant charging_grant,
       SessionStateUpdateCriteria& uc);
 
-  RulesToProcess get_all_final_unit_rules();
+  std::vector<PolicyRule> get_all_final_unit_rules();
 
   /**
    * get_total_credit_usage returns the tx and rx of the session,
@@ -432,6 +432,13 @@ class SessionState {
 
   void get_rules_per_credit_key(
       CreditKey charging_key, RulesToProcess& rulesToProcess);
+
+  /**
+   * Remove all active/scheduled static/dynamic rules and reflect the change in
+   * session_uc
+   * @param session_uc
+   */
+  void remove_all_rules_for_termination(SessionStateUpdateCriteria& session_uc);
 
   void set_teids(uint32_t enb_teid, uint32_t agw_teid);
 

--- a/lte/gateway/c/session_manager/SessionState.h
+++ b/lte/gateway/c/session_manager/SessionState.h
@@ -40,8 +40,10 @@ typedef std::unordered_map<std::string, std::unique_ptr<Monitor>> MonitorMap;
 static SessionStateUpdateCriteria UNUSED_UPDATE_CRITERIA;
 
 struct RulesToProcess {
-  std::vector<std::string> static_rules;
-  std::vector<PolicyRule> dynamic_rules;
+  // If this vector is set, then it has PolicyRule definitions for both static
+  // and dynamic rules
+  std::vector<PolicyRule> rules;
+  bool empty() const;
 };
 
 // Used to transform the proto message RuleSet into a more useful structure
@@ -473,8 +475,8 @@ class SessionState {
 
   bool is_credit_in_final_unit_state(const CreditKey& charging_key) const;
 
-  void get_final_action_restrict_rules(
-      const CreditKey& charging_key, std::vector<std::string>& restrict_rules);
+  std::vector<PolicyRule> get_final_action_restrict_rules(
+      const CreditKey& charging_key) const;
 
   // Monitors
   bool receive_monitor(

--- a/lte/gateway/c/session_manager/test/Matchers.h
+++ b/lte/gateway/c/session_manager/test/Matchers.h
@@ -31,15 +31,15 @@ MATCHER_P(CheckCount, count, "") {
   return arg_count == count;
 }
 
-MATCHER_P(CheckStaticRulesNames, list_static_rules, "") {
-  std::vector<std::string> static_rules = arg;
-  if (static_rules.size() != list_static_rules.size()) {
+MATCHER_P(CheckRuleNames, list_static_rules, "") {
+  std::vector<PolicyRule> rules = arg;
+  if (rules.size() != list_static_rules.size()) {
     return false;
   }
-  for (auto rule : list_static_rules) {
+  for (PolicyRule rule : rules) {
     bool found = false;
-    for (auto rule_to_check : list_static_rules) {
-      if (rule == rule_to_check) {
+    for (const std::string rule_to_check : list_static_rules) {
+      if (rule.id() == rule_to_check) {
         found = true;
         break;
       }
@@ -220,11 +220,13 @@ MATCHER_P6(
     CheckActivateFlowsForTunnIds, imsi, ipv4, ipv6, enb_teid, agw_teid,
     rule_count, "") {
   auto request = static_cast<const ActivateFlowsRequest*>(arg);
-  auto res     = request->sid().id() == imsi && request->ip_addr() == ipv4 &&
+  std::cerr << "Got dynamic size : " << request->dynamic_rules_size()
+            << std::endl;
+  auto res = request->sid().id() == imsi && request->ip_addr() == ipv4 &&
              request->ipv6_addr() == ipv6 &&
              request->uplink_tunnel() == agw_teid &&
              request->downlink_tunnel() == enb_teid &&
-             request->rule_ids_size() == rule_count;
+             request->dynamic_rules_size() == rule_count;
   return res;
 }
 

--- a/lte/gateway/c/session_manager/test/Matchers.h
+++ b/lte/gateway/c/session_manager/test/Matchers.h
@@ -96,11 +96,6 @@ MATCHER_P3(CheckTerminateRequestCount, imsi, monitorCount, chargingCount, "") {
          req.monitor_usages().size() == monitorCount;
 }
 
-MATCHER_P2(CheckActivateFlows, imsi, rule_count, "") {
-  auto request = static_cast<const ActivateFlowsRequest*>(arg);
-  return request->sid().id() == imsi && request->rule_ids_size() == rule_count;
-}
-
 MATCHER_P6(
     CheckSessionInfos, imsi_list, ip_address_list, ipv6_address_list, cfg,
     static_rule_lists, dynamic_rule_ids_lists, "") {
@@ -114,14 +109,14 @@ MATCHER_P6(
     if (infos[i].ipv6_addr != ipv6_address_list[i]) return false;
     if (infos[i].static_rules.size() != static_rule_lists[i].size())
       return false;
-    if (infos[i].dynamic_rules.size() != dynamic_rule_ids_lists[i].size())
+    if (infos[i].gx_dynamic_rules.size() != dynamic_rule_ids_lists[i].size())
       return false;
     for (size_t r_index = 0; i < infos[i].static_rules.size(); i++) {
       if (infos[i].static_rules[r_index] != static_rule_lists[i][r_index])
         return false;
     }
-    for (size_t r_index = 0; i < infos[i].dynamic_rules.size(); i++) {
-      if (infos[i].dynamic_rules[r_index].id() !=
+    for (size_t r_index = 0; i < infos[i].gx_dynamic_rules.size(); i++) {
+      if (infos[i].gx_dynamic_rules[r_index].id() !=
           dynamic_rule_ids_lists[i][r_index])
         return false;
     }
@@ -206,14 +201,6 @@ MATCHER_P(CheckSingleUpdate, expected_update, "") {
 MATCHER_P(CheckTerminate, imsi, "") {
   auto request = static_cast<const SessionTerminateRequest*>(arg);
   return request->common_context().sid().id() == imsi;
-}
-
-MATCHER_P4(CheckActivateFlows, imsi, ipv4, ipv6, rule_count, "") {
-  auto request = static_cast<const ActivateFlowsRequest*>(arg);
-  auto res     = request->sid().id() == imsi &&
-             request->rule_ids_size() == rule_count &&
-             request->ip_addr() == ipv4 && request->ipv6_addr() == ipv6;
-  return res;
 }
 
 MATCHER_P6(

--- a/lte/gateway/c/session_manager/test/Matchers.h
+++ b/lte/gateway/c/session_manager/test/Matchers.h
@@ -156,9 +156,32 @@ MATCHER_P3(CheckDeleteOneBearerReq, imsi, link_bearer_id, eps_bearer_id, "") {
 }
 
 MATCHER_P(CheckSubset, ids, "") {
-  auto request = static_cast<const std::vector<std::string>>(arg);
+  auto request = static_cast<const std::vector<PolicyRule>>(arg);
   for (size_t i = 0; i < request.size(); i++) {
-    if (ids.find(request[i]) != ids.end()) {
+    if (ids.find(request[i].id()) != ids.end()) {
+      return true;
+    }
+  }
+  return false;
+}
+
+MATCHER_P(CheckPolicyID, id, "") {
+  auto request = static_cast<const std::vector<PolicyRule>>(arg);
+  for (size_t i = 0; i < request.size(); i++) {
+    if (request[i].id() == id) {
+      return true;
+    }
+  }
+  return false;
+}
+
+MATCHER_P2(CheckPolicyIDs, count, ids, "") {
+  auto request = static_cast<const std::vector<PolicyRule>>(arg);
+  if (request.size() != (unsigned int) count) {
+    return false;
+  }
+  for (size_t i = 0; i < request.size(); i++) {
+    if (ids.find(request[i].id()) != ids.end()) {
       return true;
     }
   }

--- a/lte/gateway/c/session_manager/test/SessiondMocks.h
+++ b/lte/gateway/c/session_manager/test/SessiondMocks.h
@@ -103,12 +103,11 @@ class MockPipelinedClient : public PipelinedClient {
           const std::uint64_t& epoch,
           std::function<void(Status status, SetupFlowsResult)> callback));
   MOCK_METHOD1(deactivate_all_flows, void(const std::string& imsi));
-  MOCK_METHOD7(
+  MOCK_METHOD6(
       deactivate_flows_for_rules,
       void(
           const std::string& imsi, const std::string& ip_addr,
           const std::string& ipv6_addr, const Teids teids,
-          const std::vector<std::string>& rule_ids,
           const std::vector<PolicyRule>& dynamic_rules,
           const RequestOriginType_OriginType origin_type));
   MOCK_METHOD5(

--- a/lte/gateway/c/session_manager/test/SessiondMocks.h
+++ b/lte/gateway/c/session_manager/test/SessiondMocks.h
@@ -111,13 +111,11 @@ class MockPipelinedClient : public PipelinedClient {
           const std::vector<std::string>& rule_ids,
           const std::vector<PolicyRule>& dynamic_rules,
           const RequestOriginType_OriginType origin_type));
-  MOCK_METHOD7(
+  MOCK_METHOD5(
       deactivate_flows_for_rules_for_termination,
       void(
           const std::string& imsi, const std::string& ip_addr,
           const std::string& ipv6_addr, const Teids teids,
-          const std::vector<std::string>& rule_ids,
-          const std::vector<PolicyRule>& dynamic_rules,
           const RequestOriginType_OriginType origin_type));
   MOCK_METHOD8(
       activate_flows_for_rules,

--- a/lte/gateway/c/session_manager/test/SessiondMocks.h
+++ b/lte/gateway/c/session_manager/test/SessiondMocks.h
@@ -119,14 +119,13 @@ class MockPipelinedClient : public PipelinedClient {
           const std::vector<std::string>& rule_ids,
           const std::vector<PolicyRule>& dynamic_rules,
           const RequestOriginType_OriginType origin_type));
-  MOCK_METHOD9(
+  MOCK_METHOD8(
       activate_flows_for_rules,
       void(
           const std::string& imsi, const std::string& ip_addr,
           const std::string& ipv6_addr, const Teids teids,
           const std::string& msisdn,
           const std::experimental::optional<AggregatedMaximumBitrate>& ambr,
-          const std::vector<std::string>& static_rules,
           const std::vector<PolicyRule>& dynamic_rules,
           std::function<void(Status status, ActivateFlowsResult)> callback));
   MOCK_METHOD6(
@@ -148,14 +147,12 @@ class MockPipelinedClient : public PipelinedClient {
   MOCK_METHOD2(
       delete_ue_mac_flow,
       void(const SubscriberID& sid, const std::string& ue_mac_addr));
-  MOCK_METHOD7(
+  MOCK_METHOD6(
       add_gy_final_action_flow,
       void(
           const std::string& imsi, const std::string& ip_addr,
           const std::string& ipv6_addr, const Teids teids,
-          const std::string& msisdn,
-          const std::vector<std::string>& static_rules,
-          const std::vector<PolicyRule>& dynamic_rules));
+          const std::string& msisdn, const std::vector<PolicyRule>& rules));
   MOCK_METHOD2(
       set_upf_session,
       void(

--- a/lte/gateway/c/session_manager/test/test_local_enforcer.cpp
+++ b/lte/gateway/c/session_manager/test/test_local_enforcer.cpp
@@ -571,12 +571,11 @@ TEST_F(LocalEnforcerTest, test_update_session_credits_and_rules_with_failure) {
   monitor_response->set_result_code(
       DIAMETER_USER_UNKNOWN);  // USER_UNKNOWN permanent failure
 
-  // expect all rules attached to this session should be removed
+  // the request should has no rules so PipelineD deletes all rules
   EXPECT_CALL(
       *pipelined_client,
       deactivate_flows_for_rules_for_termination(
-          IMSI1, testing::_, testing::_, testing::_,
-          std::vector<std::string>{"rule1"}, CheckCount(0), testing::_))
+          IMSI1, testing::_, testing::_, testing::_, testing::_))
       .Times(1);
   local_enforcer->update_session_credits_and_rules(
       session_map, update_response, update);
@@ -865,10 +864,11 @@ TEST_F(LocalEnforcerTest, test_final_unit_handling) {
   auto update = SessionStore::get_default_session_update(session_map);
   local_enforcer->aggregate_records(session_map, table, update);
 
+  // the request should has no rules so PipelineD deletes all rules
   EXPECT_CALL(
-      *pipelined_client, deactivate_flows_for_rules_for_termination(
-                             testing::_, testing::_, testing::_, testing::_,
-                             testing::_, testing::_, testing::_))
+      *pipelined_client,
+      deactivate_flows_for_rules_for_termination(
+          testing::_, testing::_, testing::_, testing::_, testing::_))
       .Times(1);
   // Since this is a termination triggered by SessionD/Core (quota exhaustion
   // + FUA-Terminate), we expect MME to be notified to delete the bearer
@@ -920,10 +920,11 @@ TEST_F(LocalEnforcerTest, test_cwf_final_unit_handling) {
   auto update = SessionStore::get_default_session_update(session_map);
   local_enforcer->aggregate_records(session_map, table, update);
 
+  // the request should has no rules so PipelineD deletes all rules
   EXPECT_CALL(
-      *pipelined_client, deactivate_flows_for_rules_for_termination(
-                             testing::_, testing::_, testing::_, testing::_,
-                             testing::_, testing::_, testing::_))
+      *pipelined_client,
+      deactivate_flows_for_rules_for_termination(
+          testing::_, testing::_, testing::_, testing::_, testing::_))
       .Times(1);
 
   EXPECT_CALL(*aaa_client, terminate_session(testing::_, testing::_))
@@ -1401,10 +1402,11 @@ TEST_F(LocalEnforcerTest, test_dynamic_rule_actions) {
   auto update = SessionStore::get_default_session_update(session_map);
   local_enforcer->aggregate_records(session_map, table, update);
 
+  // the request should has no rules so PipelineD deletes all rules
   EXPECT_CALL(
-      *pipelined_client, deactivate_flows_for_rules_for_termination(
-                             testing::_, testing::_, testing::_, testing::_,
-                             CheckCount(2), CheckCount(1), testing::_))
+      *pipelined_client,
+      deactivate_flows_for_rules_for_termination(
+          testing::_, testing::_, testing::_, testing::_, testing::_))
       .Times(1);
   std::vector<std::unique_ptr<ServiceAction>> actions;
   auto usage_updates =
@@ -2679,16 +2681,16 @@ TEST_F(LocalEnforcerTest, test_final_unit_redirect_activation_and_termination) {
   assert_session_is_in_final_state(
       session_map, IMSI1, SESSION_ID_1, credit_key, true);
 
-  EXPECT_CALL(
-      *pipelined_client, deactivate_flows_for_rules_for_termination(
-                             IMSI1, ip_addr, ipv6_addr, CheckTeids(teids),
-                             std::vector<std::string>{"static_1"},
-                             CheckCount(0), RequestOriginType::GX));
+  // the request should has no rules so PipelineD deletes all rules
   EXPECT_CALL(
       *pipelined_client,
       deactivate_flows_for_rules_for_termination(
-          IMSI1, ip_addr, ipv6_addr, CheckTeids(teids), CheckCount(0),
-          CheckCount(1), RequestOriginType::GY))
+          IMSI1, ip_addr, ipv6_addr, CheckTeids(teids), RequestOriginType::GX));
+  // the request should has no rules so PipelineD deletes all rules
+  EXPECT_CALL(
+      *pipelined_client,
+      deactivate_flows_for_rules_for_termination(
+          IMSI1, ip_addr, ipv6_addr, CheckTeids(teids), RequestOriginType::GY))
       .Times(1);
   local_enforcer->handle_termination_from_access(
       session_map, IMSI1, APN1, update);

--- a/lte/gateway/c/session_manager/test/test_local_enforcer.cpp
+++ b/lte/gateway/c/session_manager/test/test_local_enforcer.cpp
@@ -1977,7 +1977,7 @@ TEST_F(LocalEnforcerTest, test_dedicated_bearer_lifecycle) {
   std::unordered_set<std::string> rule_ids({"rule1", "rule2"});
   // Expect NO call to PipelineD for rule1
   EXPECT_CALL(
-      *pipelined_client, deactivate_flows_for_rules_for_termination(
+      *pipelined_client, deactivate_flows_for_rules(
                              IMSI1, testing::_, testing::_, testing::_,
                              CheckSubset(rule_ids), CheckCount(0), testing::_))
       .Times(0);
@@ -1991,7 +1991,7 @@ TEST_F(LocalEnforcerTest, test_dedicated_bearer_lifecycle) {
       create_policy_bearer_bind_req(IMSI1, default_bearer_id, "rule3", 0);
   EXPECT_CALL(
       *pipelined_client,
-      deactivate_flows_for_rules_for_termination(
+      deactivate_flows_for_rules(
           IMSI1, testing::_, testing::_, testing::_,
           std::vector<std::string>{"rule3"}, CheckCount(0), testing::_))
       .Times(1);

--- a/lte/gateway/c/session_manager/test/test_proxy_responder_handler.cpp
+++ b/lte/gateway/c/session_manager/test/test_proxy_responder_handler.cpp
@@ -265,10 +265,10 @@ TEST_F(SessionProxyResponderHandlerTest, test_abort_session) {
   request.set_user_name(IMSI1);
   request.set_session_id(SESSION_ID_1);
   grpc::ServerContext create_context;
+  // the request should has no rules so PipelineD deletes all rules
   EXPECT_CALL(
-      *pipelined_client,
-      deactivate_flows_for_rules_for_termination(
-          IMSI1, _, _, _, CheckCount(1), CheckCount(0), RequestOriginType::GX))
+      *pipelined_client, deactivate_flows_for_rules_for_termination(
+                             IMSI1, _, _, _, RequestOriginType::GX))
       .Times(1);
   proxy_responder->AbortSession(
       &create_context, &request,

--- a/lte/gateway/c/session_manager/test/test_proxy_responder_handler.cpp
+++ b/lte/gateway/c/session_manager/test/test_proxy_responder_handler.cpp
@@ -47,11 +47,12 @@ class SessionProxyResponderHandlerTest : public ::testing::Test {
         .detach();
 
     monitoring_key = "mk1";
-    rule_id        = "test_rule_1";
+    rule_id_1      = "test_rule_1";
+    rule_id_2      = "test_rule_2";
 
-    reporter        = std::make_shared<MockSessionReporter>();
-    auto rule_store = std::make_shared<StaticRuleStore>();
-    session_store   = std::make_shared<SessionStore>(
+    reporter      = std::make_shared<MockSessionReporter>();
+    rule_store    = std::make_shared<StaticRuleStore>();
+    session_store = std::make_shared<SessionStore>(
         rule_store, std::make_shared<MeteringReporter>());
     pipelined_client     = std::make_shared<MockPipelinedClient>();
     auto spgw_client     = std::make_shared<MockSpgwServiceClient>();
@@ -123,20 +124,27 @@ class SessionProxyResponderHandlerTest : public ::testing::Test {
     request.set_imsi(IMSI1);
 
     StaticRuleInstall static_rule_1;
-    static_rule_1.set_rule_id("static_1");
+    static_rule_1.set_rule_id(rule_id_2);
 
     // This should be a duplicate rule
     StaticRuleInstall static_rule_2;
-    static_rule_2.set_rule_id(rule_id);
+    static_rule_2.set_rule_id(rule_id_1);
 
     request.mutable_rules_to_install()->Add()->CopyFrom(static_rule_1);
     request.mutable_rules_to_install()->Add()->CopyFrom(static_rule_2);
     return request;
   }
 
+  void insert_static_rule(const std::string& rule_id) {
+    PolicyRule rule;
+    create_policy_rule(rule_id, "", 0, &rule);
+    rule_store->insert_rule(rule);
+  }
+
  protected:
   std::string monitoring_key;
-  std::string rule_id;
+  std::string rule_id_1;
+  std::string rule_id_2;
 
   std::shared_ptr<MockPipelinedClient> pipelined_client;
   std::shared_ptr<SessionProxyResponderHandlerImpl> proxy_responder;
@@ -150,17 +158,18 @@ class SessionProxyResponderHandlerTest : public ::testing::Test {
 };
 
 TEST_F(SessionProxyResponderHandlerTest, test_policy_reauth) {
-  // 1) Create SessionStore
-  auto rule_store = std::make_shared<StaticRuleStore>();
+  // 1) Initialize static rules
+  insert_static_rule(rule_id_1);
+  insert_static_rule(rule_id_2);
 
   // 2) Create bare-bones session for IMSI1
   auto uc      = get_default_update_criteria();
   auto session = get_session(rule_store);
   RuleLifetime lifetime;
-  session->activate_static_rule(rule_id, lifetime, uc);
+  session->activate_static_rule(rule_id_1, lifetime, uc);
   EXPECT_EQ(session->get_session_id(), SESSION_ID_1);
   EXPECT_EQ(session->get_request_number(), 1);
-  EXPECT_EQ(session->is_static_rule_installed(rule_id), true);
+  EXPECT_EQ(session->is_static_rule_installed(rule_id_1), true);
 
   auto monitor_update = get_monitoring_update();
   session->receive_monitor(monitor_update, uc);
@@ -185,10 +194,10 @@ TEST_F(SessionProxyResponderHandlerTest, test_policy_reauth) {
   EXPECT_EQ(session_map[IMSI1].size(), 1);
   EXPECT_EQ(session_map[IMSI1].front()->get_request_number(), 1);
   EXPECT_EQ(
-      session_map[IMSI1].front()->is_static_rule_installed("static_1"), false);
+      session_map[IMSI1].front()->is_static_rule_installed(rule_id_2), false);
 
   // 4) Now call PolicyReAuth
-  //    This is done with a duplicate install of rule_id. This checks that
+  //    This is done with a duplicate install of rule_id_1. This checks that
   //    duplicate rule installs are ignored, as they are occasionally
   //    requested by the session proxy. If the duplicate rule install causes
   //    a failure, then the entire PolicyReAuth will not save to the
@@ -197,7 +206,7 @@ TEST_F(SessionProxyResponderHandlerTest, test_policy_reauth) {
   grpc::ServerContext create_context;
   EXPECT_CALL(
       *pipelined_client,
-      activate_flows_for_rules(IMSI1, _, _, _, _, _, CheckCount(1), _, _))
+      activate_flows_for_rules(IMSI1, _, _, _, _, _, CheckCount(1), _))
       .Times(1);
   proxy_responder->PolicyReAuth(
       &create_context, &request,
@@ -216,21 +225,22 @@ TEST_F(SessionProxyResponderHandlerTest, test_policy_reauth) {
   EXPECT_EQ(session_map[IMSI1].size(), 1);
   EXPECT_EQ(session_map[IMSI1].front()->get_request_number(), 1);
   EXPECT_EQ(
-      session_map[IMSI1].front()->is_static_rule_installed("static_1"), true);
+      session_map[IMSI1].front()->is_static_rule_installed(rule_id_2), true);
 }
 
 TEST_F(SessionProxyResponderHandlerTest, test_abort_session) {
-  // 1) Create SessionStore
-  auto rule_store = std::make_shared<StaticRuleStore>();
+  // 1) Initialize static rules
+  insert_static_rule(rule_id_1);
+  insert_static_rule(rule_id_2);
 
   // 2) Create bare-bones session for IMSI1
   auto uc      = get_default_update_criteria();
   auto session = get_session(rule_store);
   RuleLifetime lifetime;
-  session->activate_static_rule(rule_id, lifetime, uc);
+  session->activate_static_rule(rule_id_1, lifetime, uc);
   EXPECT_EQ(session->get_session_id(), SESSION_ID_1);
   EXPECT_EQ(session->get_request_number(), 1);
-  EXPECT_EQ(session->is_static_rule_installed(rule_id), true);
+  EXPECT_EQ(session->is_static_rule_installed(rule_id_1), true);
 
   // 3) Commit session for IMSI1 into SessionStore
   auto sessions = SessionVector{};
@@ -247,7 +257,7 @@ TEST_F(SessionProxyResponderHandlerTest, test_abort_session) {
   EXPECT_EQ(session_map[IMSI1].size(), 1);
   EXPECT_EQ(session_map[IMSI1].front()->get_request_number(), 1);
   EXPECT_EQ(
-      session_map[IMSI1].front()->is_static_rule_installed("static_1"), false);
+      session_map[IMSI1].front()->is_static_rule_installed(rule_id_2), false);
 
   // 4) Now call AbortSession
   //    We should see a session deletion which would trigger deactivate_flows

--- a/lte/gateway/c/session_manager/test/test_session_state.cpp
+++ b/lte/gateway/c/session_manager/test/test_session_state.cpp
@@ -946,15 +946,21 @@ TEST_F(SessionStateTest, test_apply_session_rule_set) {
   EXPECT_TRUE(session_state->is_dynamic_rule_installed("rule-dynamic-3"));
 
   // Check the RulesToProcess is properly filled out
-  EXPECT_EQ(to_activate.static_rules.size(), 1);
-  EXPECT_EQ(to_activate.static_rules[0], "rule-static-3");
-  EXPECT_EQ(to_deactivate.static_rules.size(), 1);
-  EXPECT_EQ(to_deactivate.static_rules[0], "rule-static-1");
-
-  EXPECT_EQ(to_activate.dynamic_rules.size(), 1);
-  EXPECT_EQ(to_activate.dynamic_rules[0].id(), "rule-dynamic-3");
-  EXPECT_EQ(to_deactivate.dynamic_rules.size(), 1);
-  EXPECT_EQ(to_deactivate.dynamic_rules[0].id(), "rule-dynamic-1");
+  EXPECT_EQ(to_activate.rules.size(), 2);
+  const std::string activate_rule1   = to_activate.rules[0].id();
+  const std::string activate_rule2   = to_activate.rules[1].id();
+  const std::string deactivate_rule1 = to_deactivate.rules[0].id();
+  const std::string deactivate_rule2 = to_deactivate.rules[1].id();
+  EXPECT_TRUE(
+      activate_rule1 == "rule-static-3" || activate_rule1 == "rule-dynamic-3");
+  EXPECT_TRUE(
+      activate_rule2 == "rule-static-3" || activate_rule2 == "rule-dynamic-3");
+  EXPECT_TRUE(
+      deactivate_rule1 == "rule-static-1" ||
+      deactivate_rule1 == "rule-dynamic-1");
+  EXPECT_TRUE(
+      deactivate_rule2 == "rule-static-1" ||
+      deactivate_rule2 == "rule-dynamic-1");
 
   // Finally assert the changes get applied to the update criteria
   EXPECT_EQ(uc.static_rules_to_install.size(), 1);

--- a/lte/gateway/c/session_manager/test/test_sessiond_integ.cpp
+++ b/lte/gateway/c/session_manager/test/test_sessiond_integ.cpp
@@ -95,12 +95,12 @@ class SessiondTest : public ::testing::Test {
     spgw_client       = std::make_shared<MockSpgwServiceClient>();
     directoryd_client = std::make_shared<MockDirectorydClient>();
     events_reporter   = std::make_shared<MockEventsReporter>();
-    auto rule_store   = std::make_shared<StaticRuleStore>();
+    rule_store        = std::make_shared<StaticRuleStore>();
     session_store     = std::make_shared<SessionStore>(
         rule_store, std::make_shared<MeteringReporter>());
-    insert_static_rule(rule_store, 1, "rule1");
-    insert_static_rule(rule_store, 1, "rule2");
-    insert_static_rule(rule_store, 2, "rule3");
+    insert_static_rule(1, "rule1");
+    insert_static_rule(1, "rule2");
+    insert_static_rule(2, "rule3");
 
     session_reporter = std::make_shared<SessionReporterImpl>(evb, test_channel);
     auto default_mconfig = get_default_mconfig();
@@ -206,9 +206,7 @@ class SessiondTest : public ::testing::Test {
     delete evb;
   }
 
-  void insert_static_rule(
-      std::shared_ptr<StaticRuleStore> rule_store, uint32_t charging_key,
-      const std::string& rule_id) {
+  void insert_static_rule(uint32_t charging_key, const std::string& rule_id) {
     auto mkey = "";
     PolicyRule rule;
     create_policy_rule(rule_id, mkey, charging_key, &rule);
@@ -291,6 +289,7 @@ class SessiondTest : public ::testing::Test {
   std::shared_ptr<MockSpgwServiceClient> spgw_client;
   std::shared_ptr<MockEventsReporter> events_reporter;
   std::shared_ptr<SessionStore> session_store;
+  std::shared_ptr<StaticRuleStore> rule_store;
   SessionMap session_map;
 };
 

--- a/lte/protos/pipelined.proto
+++ b/lte/protos/pipelined.proto
@@ -77,6 +77,7 @@ message RequestOriginType {
 message ActivateFlowsRequest {
   SubscriberID sid = 1;
   string ip_addr = 2; // Subscriber session ipv4 address
+  // Deprecated
   repeated string rule_ids = 3; // List of static rules obtained from PCRF
   repeated PolicyRule dynamic_rules = 4;  // List of dynamic rules obtained from PCRF
   RequestOriginType request_origin = 5; // Activate flow source (GX/GY)


### PR DESCRIPTION
<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary
The big change is to migrate all Setup / Activate flows calls to send policies by definition, not by name. This will reduce the need to look up ID->Policy definition in Redis on the PipelineD side.

In order to make this happen, I cleaned up `PipelinedClient`'s interface to only accept a vector of PolicyRules. (A combination of both static and dynamic rules). 

<!-- Enumerate changes you made and why you made them -->

## Test Plan
CWF integ test: https://app.circleci.com/pipelines/github/magma/magma/17025/workflows/bcbd2d95-34dc-4b18-a7b3-ff944984ae8b/jobs/160111
LTE integ test: https://app.circleci.com/pipelines/github/magma/magma/17025/workflows/37d51a34-18f0-4a37-b725-4f1793fcbcc1/jobs/160110
make precommit_sm 
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
Signed-off-by: Marie Bremner <marwhal@fb.com>