### PR TITLE
[orc8r] [fix] Register a Swagger spec servicer for testcontroller

### DIFF
--- a/fbinternal/cloud/go/services/testcontroller/testcontroller/main.go
+++ b/fbinternal/cloud/go/services/testcontroller/testcontroller/main.go
@@ -26,6 +26,8 @@ import (
 	"magma/fbinternal/cloud/go/services/testcontroller/statemachines"
 	"magma/fbinternal/cloud/go/services/testcontroller/storage"
 	"magma/orc8r/cloud/go/obsidian"
+	"magma/orc8r/cloud/go/obsidian/swagger"
+	swagger_protos "magma/orc8r/cloud/go/obsidian/swagger/protos"
 	"magma/orc8r/cloud/go/service"
 	"magma/orc8r/cloud/go/sqorc"
 	storage2 "magma/orc8r/cloud/go/storage"
@@ -62,6 +64,8 @@ func main() {
 	}
 	e2eServicer := servicers.NewTestControllerServicer(e2eStore)
 	protos.RegisterTestControllerServer(srv.GrpcServer, e2eServicer)
+
+	swagger_protos.RegisterSwaggerSpecServer(srv.GrpcServer, swagger.NewSpecServicerFromFile(testcontroller.ServiceName))
 
 	// Instantiate state machines, start test execution loop
 	go func() {


### PR DESCRIPTION
Signed-off-by: Andy Lee Khuu <andykhuu@stanford.edu>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary
The testcontroller service did not have a spec servicer attached to it so therefore its endpoints wern't showing up properly on the Swagger UI. This PR adds a one line change to register a servicer for the service.
![Screen Shot 2021-03-17 at 4 21 20 PM](https://user-images.githubusercontent.com/46101219/111551235-00234b80-873d-11eb-90ab-cb5bcbf52552.png)
![Screen Shot 2021-03-17 at 4 21 26 PM](https://user-images.githubusercontent.com/46101219/111551238-01547880-873d-11eb-94f5-2bd76f27c47e.png)

<!-- Enumerate changes you made and why you made them -->

## Test Plan
- [x] cd magma/orc8r/cloud/docker ./build.py -t
- [x] Manually checking swagger ui
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
