### PR TITLE
[xwf-m] fix trailing \t error in docker compose

### DIFF
--- a/xwf/gateway/docker/docker-compose.yml
+++ b/xwf/gateway/docker/docker-compose.yml
@@ -96,7 +96,7 @@ services:
     environment:
       - ODS_ACCESS_TOKEN=${ODS_ACCESS_TOKEN}
       - SCUBA_ACCESS_TOKEN=${SCUBA_ACCESS_TOKEN}
-      - AAA_ENDPOINT=${AAA_ENDPOINT:-https://graph.expresswifi.com/radius/authorization}	
+      - AAA_ENDPOINT=${AAA_ENDPOINT:-https://graph.expresswifi.com/radius/authorization}
       - AAA_ENDPOINT=https://graph.expresswifi.com/radius/authorization
       - AAA_ACCESS_TOKEN=${AAA_ACCESS_TOKEN}
       - RADIUS_SECRET=${RADIUS_SECRET:-123456}


### PR DESCRIPTION
Signed-off-by: YOUSSEF EL MASMOUDI <ymasmoudi@fb.com>

## Summary

A trailing \t was preventing containers from coming up.

[root@xwfm docker]# docker-compose up -d
ERROR: yaml.scanner.ScannerError: while scanning for the next token
found character '\t' that cannot start any token
  in "./docker-compose.yml", line 99, column 89

## Test Plan

Tested on QA machine
