### PR TITLE
[Clang-Tidy Fix] Fix bugprone-reserved-identifier findings

### DIFF
--- a/lte/gateway/c/oai/common/log.c
+++ b/lte/gateway/c/oai/common/log.c
@@ -162,14 +162,14 @@ typedef struct oai_log_s {
       shared_log_handler; /*!< \brief Logging handler function pointers */
 } oai_log_t;
 
-#define _LOG_START_USE g_oai_log.log_handler.log_start_use
-#define _LOG g_oai_log.log_handler.log
-#define _LOG_GET_ITEM g_oai_log.log_handler.get_log_queue_item
-#define _LOG_FREE_ITEM g_oai_log.log_handler.free_log_queue_item
+#define LOG_START_USE g_oai_log.log_handler.log_start_use
+#define LOG g_oai_log.log_handler.log
+#define LOG_GET_ITEM g_oai_log.log_handler.get_log_queue_item
+#define LOG_FREE_ITEM g_oai_log.log_handler.free_log_queue_item
 
-#define _LOG_ASYNC g_oai_log.shared_log_handler.log
-#define _LOG_GET_ITEM_ASYNC g_oai_log.shared_log_handler.get_log_queue_item
-#define _LOG_FREE_ITEM_ASYNC g_oai_log.shared_log_handler.free_log_queue_item
+#define LOG_ASYNC g_oai_log.shared_log_handler.log
+#define LOG_GET_ITEM_ASYNC g_oai_log.shared_log_handler.get_log_queue_item
+#define LOG_FREE_ITEM_ASYNC g_oai_log.shared_log_handler.free_log_queue_item
 static oai_log_t g_oai_log = {
     0}; /*!< \brief  logging utility internal variables global var definition*/
 
@@ -286,7 +286,7 @@ static void get_thread_context(log_thread_ctxt_t** thread_ctxt) {
         g_oai_log.thread_context_htbl, (hash_key_t) p, (void**) thread_ctxt);
     if (HASH_TABLE_KEY_NOT_EXISTS == hash_rc) {
       // Initialize thread context
-      _LOG_START_USE();
+      LOG_START_USE();
       hash_rc = hashtable_ts_get(
           g_oai_log.thread_context_htbl, (hash_key_t) p, (void**) thread_ctxt);
       AssertFatal(
@@ -338,7 +338,7 @@ static void* log_thread(__attribute__((unused)) void* args_p) {
       &log_task_zmq_ctx, LOG_FLUSH_PERIOD_MSEC, TIMER_REPEAT_ONCE, handle_timer,
       NULL);
 
-  _LOG_START_USE();
+  LOG_START_USE();
 
   zloop_start(log_task_zmq_ctx.event_loop);
   log_exit();
@@ -878,7 +878,7 @@ static void log_stream_hex_async(
       g_oai_log.thread_context_htbl, (hash_key_t) p, (void**) &thread_ctxt);
   if (HASH_TABLE_KEY_NOT_EXISTS == hash_rc) {
     // make the thread safe LFDS collections usable by this thread
-    _LOG_START_USE();
+    LOG_START_USE();
   }
   hash_rc = hashtable_ts_get(
       g_oai_log.thread_context_htbl, (hash_key_t) p, (void**) &thread_ctxt);
@@ -1030,11 +1030,11 @@ static void log_message_finish_sync(log_queue_item_t* messageP) {
     OAI_FPRINTF_ERR("Error while logging message\n");
     goto error_event;
   }
-  _LOG(messageP);
+  LOG(messageP);
   return;
 
 error_event:
-  _LOG_FREE_ITEM(&messageP);
+  LOG_FREE_ITEM(&messageP);
 }
 //------------------------------------------------------------------------------
 void log_message_finish_async(struct shared_log_queue_item_s* messageP) {
@@ -1115,7 +1115,7 @@ void log_message_start_async(
         g_oai_log.thread_context_htbl, (hash_key_t) p, (void**) &thread_ctxt);
     if (HASH_TABLE_KEY_NOT_EXISTS == hash_rc) {
       // make the thread safe LFDS collections usable by this thread
-      _LOG_START_USE();
+      LOG_START_USE();
       hash_rc = hashtable_ts_get(
           g_oai_log.thread_context_htbl, (hash_key_t) p, (void**) &thread_ctxt);
       AssertFatal(
@@ -1214,7 +1214,7 @@ void log_func(
       g_oai_log.thread_context_htbl, (hash_key_t) p, (void**) &thread_ctxt);
   if (HASH_TABLE_KEY_NOT_EXISTS == hash_rc) {
     // make the thread safe LFDS collections usable by this thread
-    _LOG_START_USE();
+    LOG_START_USE();
   }
   hash_rc = hashtable_ts_get(
       g_oai_log.thread_context_htbl, (hash_key_t) p, (void**) &thread_ctxt);
@@ -1251,7 +1251,7 @@ void log_func_return(
       g_oai_log.thread_context_htbl, (hash_key_t) p, (void**) &thread_ctxt);
   if (HASH_TABLE_KEY_NOT_EXISTS == hash_rc) {
     // make the thread safe LFDS collections usable by this thread
-    _LOG_START_USE();
+    LOG_START_USE();
   }
   hash_rc = hashtable_ts_get(
       g_oai_log.thread_context_htbl, (hash_key_t) p, (void**) &thread_ctxt);
@@ -1286,13 +1286,13 @@ void log_message(
     if (g_oai_log.is_ansi_codes) {
       bformata(new_item_p_async->bstr, "%s", ANSI_COLOR_RESET);
     }
-    _LOG_ASYNC(new_item_p_async);
+    LOG_ASYNC(new_item_p_async);
   } else {
     new_item_p_sync = (log_queue_item_t*) new_item_p;
     if (g_oai_log.is_ansi_codes) {
       bformata(new_item_p_sync->bstr, "%s", ANSI_COLOR_RESET);
     }
-    _LOG(new_item_p_sync);
+    LOG(new_item_p_sync);
   }
 }
 
@@ -1319,13 +1319,13 @@ void log_message_prefix_id(
     if (g_oai_log.is_ansi_codes) {
       bformata(new_item_p_async->bstr, "%s", ANSI_COLOR_RESET);
     }
-    _LOG_ASYNC(new_item_p_async);
+    LOG_ASYNC(new_item_p_async);
   } else {
     new_item_p_sync = (log_queue_item_t*) new_item_p;
     if (g_oai_log.is_ansi_codes) {
       bformata(new_item_p_sync->bstr, "%s", ANSI_COLOR_RESET);
     }
-    _LOG(new_item_p_sync);
+    LOG(new_item_p_sync);
   }
 }
 
@@ -1346,7 +1346,7 @@ void log_message_int(
   get_thread_context(&thread_ctxt);
 
   assert(thread_ctxt != NULL);
-  *contextP = _LOG_GET_ITEM();
+  *contextP = LOG_GET_ITEM();
 #if 0
   struct timeval elapsed_time;
   log_get_elapsed_time_since_start(&elapsed_time);
@@ -1402,9 +1402,9 @@ void log_message_int(
 
 error_event:
   if (!(g_oai_log.is_async)) {
-    _LOG_FREE_ITEM(sync_context_p);
+    LOG_FREE_ITEM(sync_context_p);
   } else {
-    _LOG_FREE_ITEM_ASYNC(*async_context_p);
+    LOG_FREE_ITEM_ASYNC(*async_context_p);
   }
 }
 
@@ -1424,7 +1424,7 @@ void log_message_int_prefix_id(
   get_thread_context(&thread_ctxt);
 
   assert(thread_ctxt != NULL);
-  *contextP = _LOG_GET_ITEM();
+  *contextP = LOG_GET_ITEM();
   time_t cur_time;
 
   // get the short file name to use for printing in log
@@ -1476,9 +1476,9 @@ void log_message_int_prefix_id(
 
 error_event:
   if (!(g_oai_log.is_async)) {
-    _LOG_FREE_ITEM(sync_context_p);
+    LOG_FREE_ITEM(sync_context_p);
   } else {
-    _LOG_FREE_ITEM_ASYNC(*async_context_p);
+    LOG_FREE_ITEM_ASYNC(*async_context_p);
   }
 }
 

--- a/lte/gateway/c/oai/lib/3gpp/3gpp_24.008_gprs_common_ies.c
+++ b/lte/gateway/c/oai/lib/3gpp/3gpp_24.008_gprs_common_ies.c
@@ -49,7 +49,7 @@
 // 10.5.7.3 GPRS Timer
 //------------------------------------------------------------------------------
 
-static const long _gprs_timer_unit[] = {2, 60, 360, 60, 60, 60, 60, 0};
+static const long gprs_timer_unit[] = {2, 60, 360, 60, 60, 60, 60, 0};
 
 //------------------------------------------------------------------------------
 int decode_gprs_timer_ie(
@@ -95,5 +95,5 @@ int encode_gprs_timer_ie(
 //------------------------------------------------------------------------------
 
 long gprs_timer_value(gprs_timer_t* gprstimer) {
-  return (gprstimer->timervalue * _gprs_timer_unit[gprstimer->unit]);
+  return (gprstimer->timervalue * gprs_timer_unit[gprstimer->unit]);
 }

--- a/lte/gateway/c/oai/lib/itti/intertask_interface.c
+++ b/lte/gateway/c/oai/lib/itti/intertask_interface.c
@@ -28,7 +28,7 @@
  * policies, either expressed or implied, of the FreeBSD Project.
  */
 
-#define _GNU_SOURCE
+#define GNU_SOURCE
 #include <pthread.h>
 #include <stdio.h>
 #include <stdlib.h>

--- a/lte/gateway/c/oai/lib/itti/signals.c
+++ b/lte/gateway/c/oai/lib/itti/signals.c
@@ -67,7 +67,7 @@
 static sigset_t set;
 
 #if LINK_GCOV
-void __gcov_flush(void);
+void gcov_flush(void);
 #endif
 
 // We have had cases where threads have been created before the main thread

--- a/lte/gateway/c/oai/lib/itti/timer.c
+++ b/lte/gateway/c/oai/lib/itti/timer.c
@@ -67,8 +67,8 @@ typedef struct timer_desc_s {
 
 static timer_desc_t timer_desc;
 
-static int _timer_delete_helper(struct timer_elm_s* timer_p);
-static struct timer_elm_s* _find_timer(long timer_id);
+static int timer_delete_helper(struct timer_elm_s* timer_p);
+static struct timer_elm_s* find_timer(long timer_id);
 
 #define TIMER_SEARCH(vAR, tIMERfIELD, tIMERvALUE, tIMERqUEUE)                  \
   do {                                                                         \
@@ -215,7 +215,7 @@ int timer_setup(
 }
 
 // Helper function to delete a timer from queue and cleanup associated resources
-static int _timer_delete_helper(struct timer_elm_s* timer_p) {
+static int timer_delete_helper(struct timer_elm_s* timer_p) {
   int rc = TIMER_OK;
   pthread_mutex_lock(&timer_desc.timer_list_mutex);
   STAILQ_REMOVE(&timer_desc.timer_queue, timer_p, timer_elm_s, entries);
@@ -234,7 +234,7 @@ static int _timer_delete_helper(struct timer_elm_s* timer_p) {
 }
 
 // Helper function to find a timer in the queue
-static struct timer_elm_s* _find_timer(long timer_id) {
+static struct timer_elm_s* find_timer(long timer_id) {
   struct timer_elm_s* timer_p = NULL;
   pthread_mutex_lock(&timer_desc.timer_list_mutex);
   TIMER_SEARCH(timer_p, timer, ((timer_t) timer_id), &timer_desc.timer_queue);
@@ -253,7 +253,7 @@ static struct timer_elm_s* _find_timer(long timer_id) {
  */
 int timer_handle_expired(long timer_id) {
   OAILOG_INFO(LOG_ITTI, "timer 0x%lx expired \n", timer_id);
-  struct timer_elm_s* timer_p = _find_timer(timer_id);
+  struct timer_elm_s* timer_p = find_timer(timer_id);
   if (timer_p == NULL) {
     return TIMER_NOT_FOUND;
   }
@@ -261,7 +261,7 @@ int timer_handle_expired(long timer_id) {
   if (timer_p->type == TIMER_ONE_SHOT) {
     OAILOG_INFO(
         LOG_ITTI, "Timer 0x%lx expiry signal received, deleting\n", timer_id);
-    return _timer_delete_helper(timer_p);
+    return timer_delete_helper(timer_p);
   }
 
   OAILOG_INFO(
@@ -271,7 +271,7 @@ int timer_handle_expired(long timer_id) {
 }
 
 bool timer_exists(long timer_id) {
-  return _find_timer(timer_id) != NULL;
+  return find_timer(timer_id) != NULL;
 }
 
 int timer_remove(long timer_id, void** arg) {

--- a/lte/gateway/c/oai/lib/s6a_proxy/s6a_client_api.cpp
+++ b/lte/gateway/c/oai/lib/s6a_proxy/s6a_client_api.cpp
@@ -63,7 +63,7 @@ bool s6a_purge_ue(const char* imsi) {
   return true;
 }
 
-static void _s6a_handle_authentication_info_ans(
+static void s6a_handle_authentication_info_ans(
     const std::string& imsi, uint8_t imsi_length, const grpc::Status& status,
     feg::AuthenticationInformationAnswer response) {
   MessageDef* message_p         = NULL;
@@ -115,13 +115,13 @@ bool s6a_authentication_info_req(const s6a_auth_info_req_t* const air_p) {
       air_p,
       [imsiStr = std::string(air_p->imsi), imsi_len](
           grpc::Status status, feg::AuthenticationInformationAnswer response) {
-        _s6a_handle_authentication_info_ans(
+        s6a_handle_authentication_info_ans(
             imsiStr, imsi_len, status, response);
       });
   return true;
 }
 
-static void _s6a_handle_update_location_ans(
+static void s6a_handle_update_location_ans(
     const std::string& imsi, uint8_t imsi_length, const grpc::Status& status,
     feg::UpdateLocationAnswer response) {
   MessageDef* message_p               = NULL;
@@ -173,7 +173,7 @@ bool s6a_update_location_req(const s6a_update_location_req_t* const ulr_p) {
   magma::S6aClient::update_location_request(
       ulr_p, [imsiStr = std::string(ulr_p->imsi), imsi_len](
                  grpc::Status status, feg::UpdateLocationAnswer response) {
-        _s6a_handle_update_location_ans(imsiStr, imsi_len, status, response);
+        s6a_handle_update_location_ans(imsiStr, imsi_len, status, response);
       });
   return true;
 }

--- a/lte/gateway/c/oai/lib/secu/snow3g.c
+++ b/lte/gateway/c/oai/lib/secu/snow3g.c
@@ -20,17 +20,17 @@
 #include "rijndael.h"
 #include "snow3g.h"
 
-static uint8_t _MULx(uint8_t V, uint8_t c);
-static uint8_t _MULxPOW(uint8_t V, uint8_t i, uint8_t c);
-static uint32_t _MULalpha(uint8_t c);
-static uint32_t _DIValpha(uint8_t c);
-static uint32_t _S1(uint32_t w);
-static uint32_t _S2(uint32_t w);
-static void _snow3g_clock_LFSR_initialization_mode(
+static uint8_t MULx(uint8_t V, uint8_t c);
+static uint8_t MULxPOW(uint8_t V, uint8_t i, uint8_t c);
+static uint32_t MULalpha(uint8_t c);
+static uint32_t DIValpha(uint8_t c);
+static uint32_t S1(uint32_t w);
+static uint32_t S2(uint32_t w);
+static void snow3g_clock_LFSR_initialization_mode(
     uint32_t F, snow_3g_context_t* s3g_ctx_pP);
-static void _snow3g_clock_LFSR_key_stream_mode(
+static void snow3g_clock_LFSR_key_stream_mode(
     snow_3g_context_t* snow_3g_context_pP);
-static uint32_t _snow3g_clock_fsm(snow_3g_context_t* snow_3g_context_pP);
+static uint32_t snow3g_clock_fsm(snow_3g_context_t* snow_3g_context_pP);
 void snow3g_initialize(
     uint32_t k[4], uint32_t IV[4], snow_3g_context_t* snow_3g_context_pP);
 void snow3g_generate_key_stream(
@@ -43,7 +43,7 @@ void snow3g_generate_key_stream(
   MULx maps 16 bits to 8 bits
 */
 
-static uint8_t _MULx(uint8_t V, uint8_t c) {
+static uint8_t MULx(uint8_t V, uint8_t c) {
   // If the leftmost (i.e. the most significant) bit of V equals 1
   if (V & 0x80)
     return ((V << 1) ^ c);
@@ -59,11 +59,11 @@ static uint8_t _MULx(uint8_t V, uint8_t c) {
   MULxPOW maps 16 bits and a positive integer i to 8 bit.
 */
 
-static uint8_t _MULxPOW(uint8_t V, uint8_t i, uint8_t c) {
+static uint8_t MULxPOW(uint8_t V, uint8_t i, uint8_t c) {
   if (i == 0)
     return V;
   else
-    return _MULx(_MULxPOW(V, i - 1, c), c);
+    return MULx(MULxPOW(V, i - 1, c), c);
 }
 
 /* The function _MULalpha.
@@ -72,12 +72,12 @@ static uint8_t _MULxPOW(uint8_t V, uint8_t i, uint8_t c) {
   maps 8 bits to 32 bits.
 */
 
-static uint32_t _MULalpha(uint8_t c) {
+static uint32_t MULalpha(uint8_t c) {
   return (
-      (((uint32_t) _MULxPOW(c, 23, 0xa9)) << 24) |
-      (((uint32_t) _MULxPOW(c, 245, 0xa9)) << 16) |
-      (((uint32_t) _MULxPOW(c, 48, 0xa9)) << 8) |
-      (((uint32_t) _MULxPOW(c, 239, 0xa9))));
+      (((uint32_t) MULxPOW(c, 23, 0xa9)) << 24) |
+      (((uint32_t) MULxPOW(c, 245, 0xa9)) << 16) |
+      (((uint32_t) MULxPOW(c, 48, 0xa9)) << 8) |
+      (((uint32_t) MULxPOW(c, 239, 0xa9))));
 }
 
 /* The function DIV alpha.
@@ -86,12 +86,12 @@ static uint32_t _MULalpha(uint8_t c) {
   maps 8 bits to 32 bit.
 */
 
-static uint32_t _DIValpha(uint8_t c) {
+static uint32_t DIValpha(uint8_t c) {
   return (
-      (((uint32_t) _MULxPOW(c, 16, 0xa9)) << 24) |
-      (((uint32_t) _MULxPOW(c, 39, 0xa9)) << 16) |
-      (((uint32_t) _MULxPOW(c, 6, 0xa9)) << 8) |
-      (((uint32_t) _MULxPOW(c, 64, 0xa9))));
+      (((uint32_t) MULxPOW(c, 16, 0xa9)) << 24) |
+      (((uint32_t) MULxPOW(c, 39, 0xa9)) << 16) |
+      (((uint32_t) MULxPOW(c, 6, 0xa9)) << 8) |
+      (((uint32_t) MULxPOW(c, 64, 0xa9))));
 }
 
 /* The 32x32-bit S-Box S1
@@ -103,17 +103,17 @@ static uint32_t _DIValpha(uint8_t c) {
   least significant byte.
 */
 
-static uint32_t _S1(uint32_t w) {
+static uint32_t S1(uint32_t w) {
   uint8_t r0 = 0, r1 = 0, r2 = 0, r3 = 0;
   uint8_t srw0 = SR[(uint8_t)((w >> 24) & 0xff)];
   uint8_t srw1 = SR[(uint8_t)((w >> 16) & 0xff)];
   uint8_t srw2 = SR[(uint8_t)((w >> 8) & 0xff)];
   uint8_t srw3 = SR[(uint8_t)((w) &0xff)];
 
-  r0 = ((_MULx(srw0, 0x1b)) ^ (srw1) ^ (srw2) ^ ((_MULx(srw3, 0x1b)) ^ srw3));
-  r1 = (((_MULx(srw0, 0x1b)) ^ srw0) ^ (_MULx(srw1, 0x1b)) ^ (srw2) ^ (srw3));
-  r2 = ((srw0) ^ ((_MULx(srw1, 0x1b)) ^ srw1) ^ (_MULx(srw2, 0x1b)) ^ (srw3));
-  r3 = ((srw0) ^ (srw1) ^ ((_MULx(srw2, 0x1b)) ^ srw2) ^ (_MULx(srw3, 0x1b)));
+  r0 = ((MULx(srw0, 0x1b)) ^ (srw1) ^ (srw2) ^ ((MULx(srw3, 0x1b)) ^ srw3));
+  r1 = (((MULx(srw0, 0x1b)) ^ srw0) ^ (MULx(srw1, 0x1b)) ^ (srw2) ^ (srw3));
+  r2 = ((srw0) ^ ((MULx(srw1, 0x1b)) ^ srw1) ^ (MULx(srw2, 0x1b)) ^ (srw3));
+  r3 = ((srw0) ^ (srw1) ^ ((MULx(srw2, 0x1b)) ^ srw2) ^ (MULx(srw3, 0x1b)));
   return (
       (((uint32_t) r0) << 24) | (((uint32_t) r1) << 16) |
       (((uint32_t) r2) << 8) | (((uint32_t) r3)));
@@ -128,17 +128,17 @@ static uint32_t _S1(uint32_t w) {
   r3 the least significant byte.
 */
 
-static uint32_t _S2(uint32_t w) {
+static uint32_t S2(uint32_t w) {
   uint8_t r0 = 0, r1 = 0, r2 = 0, r3 = 0;
   uint8_t sqw0 = SQ[(uint8_t)((w >> 24) & 0xff)];
   uint8_t sqw1 = SQ[(uint8_t)((w >> 16) & 0xff)];
   uint8_t sqw2 = SQ[(uint8_t)((w >> 8) & 0xff)];
   uint8_t sqw3 = SQ[(uint8_t)((w) &0xff)];
 
-  r0 = ((_MULx(sqw0, 0x69)) ^ (sqw1) ^ (sqw2) ^ ((_MULx(sqw3, 0x69)) ^ sqw3));
-  r1 = (((_MULx(sqw0, 0x69)) ^ sqw0) ^ (_MULx(sqw1, 0x69)) ^ (sqw2) ^ (sqw3));
-  r2 = ((sqw0) ^ ((_MULx(sqw1, 0x69)) ^ sqw1) ^ (_MULx(sqw2, 0x69)) ^ (sqw3));
-  r3 = ((sqw0) ^ (sqw1) ^ ((_MULx(sqw2, 0x69)) ^ sqw2) ^ (_MULx(sqw3, 0x69)));
+  r0 = ((MULx(sqw0, 0x69)) ^ (sqw1) ^ (sqw2) ^ ((MULx(sqw3, 0x69)) ^ sqw3));
+  r1 = (((MULx(sqw0, 0x69)) ^ sqw0) ^ (MULx(sqw1, 0x69)) ^ (sqw2) ^ (sqw3));
+  r2 = ((sqw0) ^ ((MULx(sqw1, 0x69)) ^ sqw1) ^ (MULx(sqw2, 0x69)) ^ (sqw3));
+  r3 = ((sqw0) ^ (sqw1) ^ ((MULx(sqw2, 0x69)) ^ sqw2) ^ (MULx(sqw3, 0x69)));
   return (
       (((uint32_t) r0) << 24) | (((uint32_t) r1) << 16) |
       (((uint32_t) r2) << 8) | (((uint32_t) r3)));
@@ -150,13 +150,13 @@ static uint32_t _S2(uint32_t w) {
   See section 3.4.4.
 */
 
-static void _snow3g_clock_LFSR_initialization_mode(
+static void snow3g_clock_LFSR_initialization_mode(
     uint32_t F, snow_3g_context_t* s3g_ctx_pP) {
   uint32_t v =
       (((s3g_ctx_pP->LFSR_S0 << 8) & 0xffffff00) ^
-       (_MULalpha((uint8_t)((s3g_ctx_pP->LFSR_S0 >> 24) & 0xff))) ^
+       (MULalpha((uint8_t)((s3g_ctx_pP->LFSR_S0 >> 24) & 0xff))) ^
        (s3g_ctx_pP->LFSR_S2) ^ ((s3g_ctx_pP->LFSR_S11 >> 8) & 0x00ffffff) ^
-       (_DIValpha((uint8_t)((s3g_ctx_pP->LFSR_S11) & 0xff))) ^ (F));
+       (DIValpha((uint8_t)((s3g_ctx_pP->LFSR_S11) & 0xff))) ^ (F));
 
   s3g_ctx_pP->LFSR_S0  = s3g_ctx_pP->LFSR_S1;
   s3g_ctx_pP->LFSR_S1  = s3g_ctx_pP->LFSR_S2;
@@ -180,14 +180,14 @@ static void _snow3g_clock_LFSR_initialization_mode(
   LFSR Registers S0 to S15 are updated as the LFSR receives a single clock.
   See section 3.4.5.
 */
-static void _snow3g_clock_LFSR_key_stream_mode(
+static void snow3g_clock_LFSR_key_stream_mode(
     snow_3g_context_t* snow_3g_context_pP) {
   uint32_t v =
       (((snow_3g_context_pP->LFSR_S0 << 8) & 0xffffff00) ^
-       (_MULalpha((uint8_t)((snow_3g_context_pP->LFSR_S0 >> 24) & 0xff))) ^
+       (MULalpha((uint8_t)((snow_3g_context_pP->LFSR_S0 >> 24) & 0xff))) ^
        (snow_3g_context_pP->LFSR_S2) ^
        ((snow_3g_context_pP->LFSR_S11 >> 8) & 0x00ffffff) ^
-       (_DIValpha((uint8_t)((snow_3g_context_pP->LFSR_S11) & 0xff))));
+       (DIValpha((uint8_t)((snow_3g_context_pP->LFSR_S11) & 0xff))));
 
   snow_3g_context_pP->LFSR_S0  = snow_3g_context_pP->LFSR_S1;
   snow_3g_context_pP->LFSR_S1  = snow_3g_context_pP->LFSR_S2;
@@ -213,7 +213,7 @@ static void _snow3g_clock_LFSR_key_stream_mode(
   See Section 3.4.6.
 */
 
-static uint32_t _snow3g_clock_fsm(snow_3g_context_t* snow_3g_context_pP) {
+static uint32_t snow3g_clock_fsm(snow_3g_context_t* snow_3g_context_pP) {
   uint32_t F = ((snow_3g_context_pP->LFSR_S15 + snow_3g_context_pP->FSM_R1) &
                 0xffffffff) ^
                snow_3g_context_pP->FSM_R2;
@@ -221,8 +221,8 @@ static uint32_t _snow3g_clock_fsm(snow_3g_context_t* snow_3g_context_pP) {
                 (snow_3g_context_pP->FSM_R3 ^ snow_3g_context_pP->LFSR_S5)) &
                0xffffffff;
 
-  snow_3g_context_pP->FSM_R3 = _S2(snow_3g_context_pP->FSM_R2);
-  snow_3g_context_pP->FSM_R2 = _S1(snow_3g_context_pP->FSM_R1);
+  snow_3g_context_pP->FSM_R3 = S2(snow_3g_context_pP->FSM_R2);
+  snow_3g_context_pP->FSM_R2 = S1(snow_3g_context_pP->FSM_R1);
   snow_3g_context_pP->FSM_R1 = r;
   return F;
 }
@@ -260,8 +260,8 @@ void snow3g_initialize(
   snow_3g_context_pP->FSM_R3   = 0x0;
 
   for (i = 0; i < 32; i++) {
-    F = _snow3g_clock_fsm(snow_3g_context_pP);
-    _snow3g_clock_LFSR_initialization_mode(F, snow_3g_context_pP);
+    F = snow3g_clock_fsm(snow_3g_context_pP);
+    snow3g_clock_LFSR_initialization_mode(F, snow_3g_context_pP);
   }
 }
 
@@ -278,17 +278,17 @@ void snow3g_generate_key_stream(
   uint32_t t = 0;
   uint32_t F = 0x0;
 
-  _snow3g_clock_fsm(
+  snow3g_clock_fsm(
       snow_3g_context_pP); /* Clock FSM once. Discard the output. */
-  _snow3g_clock_LFSR_key_stream_mode(
+  snow3g_clock_LFSR_key_stream_mode(
       snow_3g_context_pP); /* Clock LFSR in keystream mode once. */
 
   for (t = 0; t < n; t++) {
-    F     = _snow3g_clock_fsm(snow_3g_context_pP); /* STEP 1 */
+    F     = snow3g_clock_fsm(snow_3g_context_pP); /* STEP 1 */
     ks[t] = F ^ snow_3g_context_pP->LFSR_S0;       /* STEP 2 */
     /*
      * Note that ks[t] corresponds to z_{t+1} in section 4.2
      */
-    _snow3g_clock_LFSR_key_stream_mode(snow_3g_context_pP); /* STEP 3 */
+    snow3g_clock_LFSR_key_stream_mode(snow_3g_context_pP); /* STEP 3 */
   }
 }

--- a/lte/gateway/c/oai/tasks/mme_app/mme_app_bearer.c
+++ b/lte/gateway/c/oai/tasks/mme_app/mme_app_bearer.c
@@ -82,7 +82,7 @@
 #endif
 
 extern task_zmq_ctx_t mme_app_task_zmq_ctx;
-extern int _pdn_connectivity_delete(emm_context_t* emm_context, pdn_cid_t pid);
+extern int pdn_connectivity_delete(emm_context_t* emm_context, pdn_cid_t pid);
 
 int send_modify_bearer_req(mme_ue_s1ap_id_t ue_id, ebi_t ebi) {
   OAILOG_FUNC_IN(LOG_MME_APP);
@@ -210,7 +210,7 @@ void print_bearer_ids_helper(const ebi_t* ebi, uint32_t no_of_bearers) {
 }
 
 //------------------------------------------------------------------------------
-int _send_pcrf_bearer_actv_rsp(
+int send_pcrf_bearer_actv_rsp(
     struct ue_mm_context_s* ue_context_p, ebi_t ebi,
     gtpv2c_cause_value_t cause) {
   OAILOG_FUNC_IN(LOG_MME_APP);
@@ -951,7 +951,7 @@ void mme_app_handle_delete_session_rsp(
         // Reset flag
         ue_context_p->pdn_contexts[pid]->ue_rej_act_def_ber_req = false;
         // Free the contents of PDN session
-        _pdn_connectivity_delete(&ue_context_p->emm_context, pid);
+        pdn_connectivity_delete(&ue_context_p->emm_context, pid);
         // Free PDN context
         free_wrapper((void**) &ue_context_p->pdn_contexts[pid]);
         // Free bearer context entry
@@ -2210,7 +2210,7 @@ int mme_app_handle_initial_paging_request(
 //------------------------------------------------------------------------------
 /* Send actv_dedicated_bearer_rej to spgw app for the pending dedicated bearers
  * without creating a context as the UE did not respond to paging*/
-void _mme_app_send_actv_dedicated_bearer_rej_for_pending_bearers(
+void mme_app_send_actv_dedicated_bearer_rej_for_pending_bearers(
     ue_mm_context_t* ue_context_p,
     emm_cn_activate_dedicated_bearer_req_t* pending_ded_ber_req) {
   OAILOG_FUNC_IN(LOG_MME_APP);
@@ -2306,7 +2306,7 @@ int mme_app_handle_paging_timer_expiry(
      * to Paging and free the memory*/
     for (uint8_t idx = 0; idx < BEARERS_PER_UE; idx++) {
       if (ue_context_p->pending_ded_ber_req[idx]) {
-        _mme_app_send_actv_dedicated_bearer_rej_for_pending_bearers(
+        mme_app_send_actv_dedicated_bearer_rej_for_pending_bearers(
             ue_context_p, ue_context_p->pending_ded_ber_req[idx]);
         if (ue_context_p->pending_ded_ber_req[idx]->tft) {
           free_traffic_flow_template(
@@ -2793,7 +2793,7 @@ void mme_app_handle_create_dedicated_bearer_rsp(
       "Sending Activate Dedicated Bearer Response to SPGW for "
       "ue-id: " MME_UE_S1AP_ID_FMT "\n",
       ue_context_p->mme_ue_s1ap_id);
-  _send_pcrf_bearer_actv_rsp(ue_context_p, ebi, REQUEST_ACCEPTED);
+  send_pcrf_bearer_actv_rsp(ue_context_p, ebi, REQUEST_ACCEPTED);
   OAILOG_FUNC_OUT(LOG_MME_APP);
 #endif
   // TODO:
@@ -2845,7 +2845,7 @@ void mme_app_handle_create_dedicated_bearer_rej(
       "Sending Activate Dedicated bearer Reject to SPGW: " MME_UE_S1AP_ID_FMT
       "\n",
       ue_context_p->mme_ue_s1ap_id);
-  _send_pcrf_bearer_actv_rsp(ue_context_p, ebi, REQUEST_REJECTED);
+  send_pcrf_bearer_actv_rsp(ue_context_p, ebi, REQUEST_REJECTED);
   OAILOG_FUNC_OUT(LOG_MME_APP);
 #endif
 

--- a/lte/gateway/c/oai/tasks/mme_app/mme_app_context.c
+++ b/lte/gateway/c/oai/tasks/mme_app/mme_app_context.c
@@ -107,14 +107,14 @@ static void mme_app_resume_timers(
     struct mme_app_timer_t* timer,
     mme_app_timer_callback_t timer_expiry_handler, char* timer_name);
 
-static void _directoryd_report_location(uint64_t imsi, uint8_t imsi_len) {
+static void directoryd_report_location_a(uint64_t imsi, uint8_t imsi_len) {
   char imsi_str[IMSI_BCD_DIGITS_MAX + 1];
   IMSI64_TO_STRING(imsi, imsi_str, imsi_len);
   directoryd_report_location(imsi_str);
   OAILOG_INFO_UE(LOG_MME_APP, imsi, "Reported UE location to directoryd\n");
 }
 
-static void _directoryd_remove_location(uint64_t imsi, uint8_t imsi_len) {
+static void directoryd_remove_location_a(uint64_t imsi, uint8_t imsi_len) {
   char imsi_str[IMSI_BCD_DIGITS_MAX + 1];
   IMSI64_TO_STRING(imsi, imsi_str, imsi_len);
   directoryd_remove_location(imsi_str);
@@ -751,7 +751,7 @@ void mme_remove_ue_context(
   }
 
   // First, notify directoryd of removal
-  _directoryd_remove_location(
+  directoryd_remove_location_a(
       ue_context_p->emm_context._imsi64,
       ue_context_p->emm_context._imsi.length);
 
@@ -1875,7 +1875,7 @@ void mme_ue_context_update_ue_emm_state(
     ue_context_p->mm_state = new_mm_state;
 
     // Report directoryd UE record
-    _directoryd_report_location(
+    directoryd_report_location_a(
         ue_context_p->emm_context._imsi64,
         ue_context_p->emm_context._imsi.length);
 

--- a/lte/gateway/c/oai/tasks/mme_app/mme_app_context.c
+++ b/lte/gateway/c/oai/tasks/mme_app/mme_app_context.c
@@ -94,7 +94,7 @@ void print_trace(void) {
 }
 
 typedef void (*mme_app_timer_callback_t)(void* args, imsi64_t* imsi64);
-static void _mme_app_handle_s1ap_ue_context_release(
+static void mme_app_handle_s1ap_ue_context_release(
     const mme_ue_s1ap_id_t mme_ue_s1ap_id,
     const enb_ue_s1ap_id_t enb_ue_s1ap_id, uint32_t enb_id, enum s1cause cause);
 
@@ -1639,7 +1639,7 @@ void mme_app_handle_s1ap_ue_context_release_req(
     const itti_s1ap_ue_context_release_req_t* const s1ap_ue_context_release_req)
 
 {
-  _mme_app_handle_s1ap_ue_context_release(
+  mme_app_handle_s1ap_ue_context_release(
       s1ap_ue_context_release_req->mme_ue_s1ap_id,
       s1ap_ue_context_release_req->enb_ue_s1ap_id,
       s1ap_ue_context_release_req->enb_id,
@@ -1721,7 +1721,7 @@ void mme_app_handle_s1ap_ue_context_modification_resp(
 void mme_app_handle_enb_deregister_ind(
     const itti_s1ap_eNB_deregistered_ind_t* const eNB_deregistered_ind) {
   for (int i = 0; i < eNB_deregistered_ind->nb_ue_to_deregister; i++) {
-    _mme_app_handle_s1ap_ue_context_release(
+    mme_app_handle_s1ap_ue_context_release(
         eNB_deregistered_ind->mme_ue_s1ap_id[i],
         eNB_deregistered_ind->enb_ue_s1ap_id[i], eNB_deregistered_ind->enb_id,
         S1AP_SCTP_SHUTDOWN_OR_RESET);
@@ -1745,7 +1745,7 @@ void mme_app_handle_enb_reset_req(
   }
 
   for (int i = 0; i < enb_reset_req->num_ue; i++) {
-    _mme_app_handle_s1ap_ue_context_release(
+    mme_app_handle_s1ap_ue_context_release(
         enb_reset_req->ue_to_reset_list[i].mme_ue_s1ap_id,
         enb_reset_req->ue_to_reset_list[i].enb_ue_s1ap_id,
         enb_reset_req->enb_id, S1AP_SCTP_SHUTDOWN_OR_RESET);
@@ -1899,7 +1899,7 @@ void mme_ue_context_update_ue_emm_state(
 }
 
 //------------------------------------------------------------------------------
-static void _mme_app_handle_s1ap_ue_context_release(
+static void mme_app_handle_s1ap_ue_context_release(
     const mme_ue_s1ap_id_t mme_ue_s1ap_id,
     const enb_ue_s1ap_id_t enb_ue_s1ap_id, uint32_t enb_id, enum s1cause cause)
 //------------------------------------------------------------------------------

--- a/lte/gateway/c/oai/tasks/mme_app/mme_app_location.c
+++ b/lte/gateway/c/oai/tasks/mme_app/mme_app_location.c
@@ -165,7 +165,7 @@ int mme_app_send_s6a_update_location_req(
   OAILOG_FUNC_RETURN(LOG_MME_APP, rc);
 }
 
-int _handle_ula_failure(struct ue_mm_context_s* ue_context_p) {
+int handle_ula_failure(struct ue_mm_context_s* ue_context_p) {
   int rc = RETURNok;
 
   OAILOG_FUNC_IN(LOG_MME_APP);
@@ -225,7 +225,7 @@ int mme_app_handle_s6a_update_location_ans(
           "ULR/ULA procedure returned non success "
           "(ULA.result.choice.base=%d)\n",
           ula_pP->result.choice.base);
-      if (_handle_ula_failure(ue_mm_context) != RETURNok) {
+      if (handle_ula_failure(ue_mm_context) != RETURNok) {
         OAILOG_ERROR(
             LOG_MME_APP,
             "Failed to handle Un-successful ULA message for ue_id (%u)\n",
@@ -244,7 +244,7 @@ int mme_app_handle_s6a_update_location_ans(
         LOG_MME_APP,
         "ULR/ULA procedure returned non success (ULA.result.present=%d)\n",
         ula_pP->result.present);
-    if (_handle_ula_failure(ue_mm_context) == RETURNok) {
+    if (handle_ula_failure(ue_mm_context) == RETURNok) {
       OAILOG_DEBUG(
           LOG_MME_APP, "Sent PDN Connectivity failure to NAS for ue_id (%u)\n",
           ue_mm_context->mme_ue_s1ap_id);

--- a/lte/gateway/c/oai/tasks/mme_app/mme_app_main.c
+++ b/lte/gateway/c/oai/tasks/mme_app/mme_app_main.c
@@ -59,8 +59,8 @@
 #include "sctp_messages_types.h"
 #include "timer_messages_types.h"
 
-static void _check_mme_healthy_and_notify_service(void);
-static bool _is_mme_app_healthy(void);
+static void check_mme_healthy_and_notify_service(void);
+static bool is_mme_app_healthy(void);
 static void mme_app_exit(void);
 
 bool mme_hss_associated = false;
@@ -292,13 +292,13 @@ static int handle_message(zloop_t* loop, zsock_t* reader, void* arg) {
 
     case ACTIVATE_MESSAGE: {
       mme_hss_associated = true;
-      _check_mme_healthy_and_notify_service();
+      check_mme_healthy_and_notify_service();
     } break;
 
     case SCTP_MME_SERVER_INITIALIZED: {
       mme_sctp_bounded =
           &received_message_p->ittiMsg.sctp_mme_server_initialized.successful;
-      _check_mme_healthy_and_notify_service();
+      check_mme_healthy_and_notify_service();
     } break;
 
     case S6A_PURGE_UE_ANS: {
@@ -498,13 +498,13 @@ int mme_app_init(const mme_config_t* mme_config_p) {
   OAILOG_FUNC_RETURN(LOG_MME_APP, RETURNok);
 }
 
-static void _check_mme_healthy_and_notify_service(void) {
-  if (_is_mme_app_healthy()) {
+static void check_mme_healthy_and_notify_service(void) {
+  if (is_mme_app_healthy()) {
     send_app_health_to_service303(&mme_app_task_zmq_ctx, TASK_MME_APP, true);
   }
 }
 
-static bool _is_mme_app_healthy(void) {
+static bool is_mme_app_healthy(void) {
   return mme_hss_associated && mme_sctp_bounded;
 }
 

--- a/lte/gateway/c/oai/tasks/mme_app/mme_app_sgs_alert.c
+++ b/lte/gateway/c/oai/tasks/mme_app/mme_app_sgs_alert.c
@@ -55,11 +55,11 @@
 #include "mme_app_ue_context.h"
 #include "sgs_messages_types.h"
 
-static int _mme_app_send_sgsap_alert_reject(
+static int mme_app_send_sgsap_alert_reject(
     itti_sgsap_alert_request_t* const sgsap_alert_req_pP, SgsCause_t sgs_cause,
     uint64_t imsi64);
 
-static int _mme_app_send_sgsap_alert_ack(
+static int mme_app_send_sgsap_alert_ack(
     itti_sgsap_alert_request_t* const sgsap_alert_req_pP, uint64_t imsi64);
 
 /****************************************************************************
@@ -100,7 +100,7 @@ int mme_app_handle_sgsap_alert_request(
         "SGS-ALERT REQUEST: Failed to find UE context for IMSI " IMSI_64_FMT
         "\n",
         imsi64);
-    _mme_app_send_sgsap_alert_reject(
+    mme_app_send_sgsap_alert_reject(
         sgsap_alert_req_pP, SGS_CAUSE_IMSI_UNKNOWN, imsi64);
     increment_counter("sgsap_alert_reject", 1, 1, "cause", "imsi_unknown");
     OAILOG_FUNC_RETURN(LOG_MME_APP, RETURNerror);
@@ -111,7 +111,7 @@ int mme_app_handle_sgsap_alert_request(
         "SGS-ALERT REQUEST: UE is currently not attached to EPS service and "
         "send Alert Reject to MSC/VLR for UE:" IMSI_64_FMT " \n",
         imsi64);
-    _mme_app_send_sgsap_alert_reject(
+    mme_app_send_sgsap_alert_reject(
         sgsap_alert_req_pP, SGS_CAUSE_IMSI_DETACHED_FOR_EPS_SERVICE, imsi64);
     increment_counter(
         "sgsap_alert_reject", 1, 1, "cause", "ue_is_not_registered_to_eps");
@@ -128,7 +128,7 @@ int mme_app_handle_sgsap_alert_request(
   }
   ue_context_p->sgs_context->neaf = SET_NEAF;
   /* send Alert Ack */
-  _mme_app_send_sgsap_alert_ack(sgsap_alert_req_pP, imsi64);
+  mme_app_send_sgsap_alert_ack(sgsap_alert_req_pP, imsi64);
   OAILOG_FUNC_RETURN(LOG_MME_APP, RETURNok);
 }
 
@@ -144,7 +144,7 @@ int mme_app_handle_sgsap_alert_request(
  **          Return:    RETURNok, RETURNerror **
  **
  ***********************************************************************************/
-static int _mme_app_send_sgsap_alert_reject(
+static int mme_app_send_sgsap_alert_reject(
     itti_sgsap_alert_request_t* const sgsap_alert_req_pP, SgsCause_t sgs_cause,
     uint64_t imsi64) {
   OAILOG_FUNC_IN(LOG_MME_APP);
@@ -189,7 +189,7 @@ static int _mme_app_send_sgsap_alert_reject(
  **          Return:    RETURNok, RETURNerror **
  **
  ***********************************************************************************/
-static int _mme_app_send_sgsap_alert_ack(
+static int mme_app_send_sgsap_alert_ack(
     itti_sgsap_alert_request_t* const sgsap_alert_req_pP, uint64_t imsi64) {
   int rc                                     = RETURNerror;
   MessageDef* message_p                      = NULL;

--- a/lte/gateway/c/oai/tasks/mme_app/mme_app_sgs_fsm.c
+++ b/lte/gateway/c/oai/tasks/mme_app/mme_app_sgs_fsm.c
@@ -51,7 +51,7 @@
 */
 
 /* String representation of SGS events */
-static const char* _sgs_fsm_event_str[] = {
+static const char* sgs_fsm_event_str[] = {
     "_SGS_LOCATION_UPDATE_ACCEPT", "_SGS_LOCATION_UPDATE_REJECT",
     "_SGS_PAGING_REQUEST",         "_SGS_SERVICE_ABORT_REQUEST",
     "_SGS_EPS_DETACH_IND",         "_SGS_IMSI_DETACH_IND",
@@ -59,7 +59,7 @@ static const char* _sgs_fsm_event_str[] = {
 };
 
 /* String representation of SGS state */
-static const char* _sgs_fsm_state_str[SGS_STATE_MAX] = {
+static const char* sgs_fsm_state_str[SGS_STATE_MAX] = {
     "_SGS_INVALID",
     "_SGS_NULL",
     "_SGS_LA-UPDATE-REQUESTED",
@@ -80,7 +80,7 @@ int sgs_la_update_requested_handler(const sgs_fsm_t*);
 int sgs_associated_handler(const sgs_fsm_t*);
 
 /* SGS state machine handlers */
-static const sgs_fsm_handler_t _sgs_fsm_handlers[SGS_STATE_MAX] = {
+static const sgs_fsm_handler_t sgs_fsm_handlers[SGS_STATE_MAX] = {
     NULL,
     sgs_null_handler,
     sgs_la_update_requested_handler,
@@ -135,17 +135,17 @@ int sgs_fsm_process(const sgs_fsm_t* sgs_evt) {
     state = sgs_fsm_get_status(sgs_evt->ue_id, sgs_ctx);
     OAILOG_INFO(
         LOG_MME_APP, "SGS-FSM   - Received sgs-event %s (%d) in state %s\n",
-        _sgs_fsm_event_str[primitive], primitive, _sgs_fsm_state_str[state]);
+        sgs_fsm_event_str[primitive], primitive, sgs_fsm_state_str[state]);
     /*
      * Execute the SGS state machine
      */
-    rc = (_sgs_fsm_handlers[state])(sgs_evt);
+    rc = (sgs_fsm_handlers[state])(sgs_evt);
   } else {
     OAILOG_WARNING(
         LOG_MME_APP,
         "SGS-FSM   - Received event %s (%d) but no SGS context context found "
         "\n",
-        _sgs_fsm_event_str[primitive], primitive);
+        sgs_fsm_event_str[primitive], primitive);
   }
   OAILOG_FUNC_RETURN(LOG_MME_APP, rc);
 }
@@ -183,8 +183,8 @@ int sgs_fsm_set_status(
       OAILOG_INFO(
           LOG_MME_APP,
           "UE " MME_UE_S1AP_ID_FMT " SGS-FSM   - State changed: %s ===> %s\n",
-          ue_id, _sgs_fsm_state_str[sgs_ctx->sgs_state],
-          _sgs_fsm_state_str[state]);
+          ue_id, sgs_fsm_state_str[sgs_ctx->sgs_state],
+          sgs_fsm_state_str[state]);
       sgs_ctx->sgs_state = state;
     }
 

--- a/lte/gateway/c/oai/tasks/mme_app/mme_app_sgs_paging.c
+++ b/lte/gateway/c/oai/tasks/mme_app/mme_app_sgs_paging.c
@@ -49,30 +49,30 @@
 #include "s1ap_messages_types.h"
 #include "sgs_messages_types.h"
 
-static int _mme_app_send_sgsap_ue_unreachable(
+static int mme_app_send_sgsap_ue_unreachable(
     struct ue_mm_context_s* ue_context_p, SgsCause_t sgs_cause);
 
-static int _sgsap_handle_paging_request_without_lai(
+static int sgsap_handle_paging_request_without_lai(
     ue_mm_context_t* ue_context_p,
     itti_sgsap_paging_request_t* const sgsap_paging_req_pP);
 
-static int _sgs_handle_paging_request_for_mt_call(const sgs_fsm_t* evt);
+static int sgs_handle_paging_request_for_mt_call(const sgs_fsm_t* evt);
 
-static int _sgs_handle_paging_request_for_mt_call_in_connected(
+static int sgs_handle_paging_request_for_mt_call_in_connected(
     ue_mm_context_t* ue_context_p,
     itti_sgsap_paging_request_t* const sgsap_paging_req_pP);
 
-static int _sgs_handle_paging_request_for_mt_call_in_idle(
+static int sgs_handle_paging_request_for_mt_call_in_idle(
     ue_mm_context_t* ue_context_p,
     itti_sgsap_paging_request_t* const sgsap_paging_req_pP);
 
-static int _sgs_handle_paging_request_for_mt_sms(const sgs_fsm_t* evt);
+static int sgs_handle_paging_request_for_mt_sms(const sgs_fsm_t* evt);
 
-static int _sgs_handle_paging_request_for_mt_sms_in_connected(
+static int sgs_handle_paging_request_for_mt_sms_in_connected(
     ue_mm_context_t* ue_context_p,
     itti_sgsap_paging_request_t* const sgsap_paging_req_pP);
 
-static int _sgs_handle_paging_request_for_mt_sms_in_idle(
+static int sgs_handle_paging_request_for_mt_sms_in_idle(
     ue_mm_context_t* ue_context_p,
     itti_sgsap_paging_request_t* const sgsap_paging_req_pP);
 /*****************************************************************************
@@ -104,9 +104,9 @@ int sgs_handle_associated_paging_request(const sgs_fsm_t* evt) {
 
 #define SGSAP_SMS_INDICATOR 0x02
   if (sgsap_paging_req_pP->service_indicator == SGSAP_SMS_INDICATOR) {
-    rc = _sgs_handle_paging_request_for_mt_sms(evt);
+    rc = sgs_handle_paging_request_for_mt_sms(evt);
   } else {
-    rc = _sgs_handle_paging_request_for_mt_call(evt);
+    rc = sgs_handle_paging_request_for_mt_call(evt);
   }
   OAILOG_FUNC_RETURN(LOG_MME_APP, rc);
 }
@@ -121,7 +121,7 @@ int sgs_handle_associated_paging_request(const sgs_fsm_t* evt) {
  **          Return:    RETURNok, RETURNerror                               **
  **                                                                         **
  ******************************************************************************/
-static int _sgs_handle_paging_request_for_mt_sms(const sgs_fsm_t* evt) {
+static int sgs_handle_paging_request_for_mt_sms(const sgs_fsm_t* evt) {
   int rc                                           = RETURNerror;
   ue_mm_context_t* ue_context_p                    = NULL;
   sgs_context_t* sgs_context                       = NULL;
@@ -163,15 +163,15 @@ static int _sgs_handle_paging_request_for_mt_sms(const sgs_fsm_t* evt) {
        PAGING_REQUEST_LAI_PARAMETER_PRESENT));
   if (!(sgsap_paging_req_pP->presencemask &
         PAGING_REQUEST_LAI_PARAMETER_PRESENT)) {
-    rc = _sgsap_handle_paging_request_without_lai(
+    rc = sgsap_handle_paging_request_without_lai(
         ue_context_p, sgsap_paging_req_pP);
     OAILOG_FUNC_RETURN(LOG_MME_APP, rc);
   }
   if (ue_context_p->ecm_state == ECM_CONNECTED) {
-    rc = _sgs_handle_paging_request_for_mt_sms_in_connected(
+    rc = sgs_handle_paging_request_for_mt_sms_in_connected(
         ue_context_p, sgsap_paging_req_pP);
   } else if (ue_context_p->ecm_state == ECM_IDLE) {
-    rc = _sgs_handle_paging_request_for_mt_sms_in_idle(
+    rc = sgs_handle_paging_request_for_mt_sms_in_idle(
         ue_context_p, sgsap_paging_req_pP);
   }
   OAILOG_FUNC_RETURN(LOG_MME_APP, rc);
@@ -187,7 +187,7 @@ static int _sgs_handle_paging_request_for_mt_sms(const sgs_fsm_t* evt) {
  **          Return:    RETURNok, RETURNerror                                **
  **                                                                          **
  *******************************************************************************/
-static int _sgs_handle_paging_request_for_mt_call(const sgs_fsm_t* evt) {
+static int sgs_handle_paging_request_for_mt_call(const sgs_fsm_t* evt) {
   int rc                                           = RETURNerror;
   ue_mm_context_t* ue_context_p                    = NULL;
   sgs_context_t* sgs_context                       = NULL;
@@ -231,7 +231,7 @@ static int _sgs_handle_paging_request_for_mt_call(const sgs_fsm_t* evt) {
   /* Fetch LAI if present */
   if (!(sgsap_paging_req_pP->presencemask &
         PAGING_REQUEST_LAI_PARAMETER_PRESENT)) {
-    rc = _sgsap_handle_paging_request_without_lai(
+    rc = sgsap_handle_paging_request_without_lai(
         ue_context_p, sgsap_paging_req_pP);
     OAILOG_FUNC_RETURN(LOG_MME_APP, rc);
   }
@@ -246,16 +246,16 @@ static int _sgs_handle_paging_request_for_mt_call(const sgs_fsm_t* evt) {
     /* Handling for paging received without LAI and vlr-reliable flag set to
      * false is same
      */
-    rc = _sgsap_handle_paging_request_without_lai(
+    rc = sgsap_handle_paging_request_without_lai(
         ue_context_p, sgsap_paging_req_pP);
     OAILOG_FUNC_RETURN(LOG_MME_APP, rc);
   }
 
   if (ue_context_p->ecm_state == ECM_CONNECTED) {
-    rc = _sgs_handle_paging_request_for_mt_call_in_connected(
+    rc = sgs_handle_paging_request_for_mt_call_in_connected(
         ue_context_p, sgsap_paging_req_pP);
   } else if (ue_context_p->ecm_state == ECM_IDLE) {
-    rc = _sgs_handle_paging_request_for_mt_call_in_idle(
+    rc = sgs_handle_paging_request_for_mt_call_in_idle(
         ue_context_p, sgsap_paging_req_pP);
   }
   OAILOG_FUNC_RETURN(LOG_MME_APP, rc);
@@ -273,7 +273,7 @@ static int _sgs_handle_paging_request_for_mt_call(const sgs_fsm_t* evt) {
  **                                                                         **
  ******************************************************************************/
 
-static int _sgs_handle_paging_request_for_mt_call_in_connected(
+static int sgs_handle_paging_request_for_mt_call_in_connected(
     ue_mm_context_t* ue_context_p,
     itti_sgsap_paging_request_t* const sgsap_paging_req_pP) {
   int rc            = RETURNerror;
@@ -340,7 +340,7 @@ static int _sgs_handle_paging_request_for_mt_call_in_connected(
  **          Return:    RETURNok, RETURNerror                               **
  **                                                                         **
  ******************************************************************************/
-static int _sgs_handle_paging_request_for_mt_sms_in_connected(
+static int sgs_handle_paging_request_for_mt_sms_in_connected(
     ue_mm_context_t* ue_context_p,
     itti_sgsap_paging_request_t* const sgsap_paging_req_pP) {
   int rc = RETURNerror;
@@ -391,7 +391,7 @@ static int _sgs_handle_paging_request_for_mt_sms_in_connected(
  ** **
  ***********************************************************************************/
 
-static int _sgs_handle_paging_request_for_mt_call_in_idle(
+static int sgs_handle_paging_request_for_mt_call_in_idle(
     ue_mm_context_t* ue_context_p,
     itti_sgsap_paging_request_t* const sgsap_paging_req_pP)
 
@@ -454,7 +454,7 @@ static int _sgs_handle_paging_request_for_mt_call_in_idle(
     }
   } else {
     // Send UE Unreachable to MSC/VLR
-    _mme_app_send_sgsap_ue_unreachable(ue_context_p, SGS_CAUSE_UE_UNREACHABLE);
+    mme_app_send_sgsap_ue_unreachable(ue_context_p, SGS_CAUSE_UE_UNREACHABLE);
     if (rc != RETURNok) {
       OAILOG_ERROR(
           LOG_MME_APP, "Failed to send SGSAP-UE-UNREACHABLE for ue-id :%u \n",
@@ -476,7 +476,7 @@ static int _sgs_handle_paging_request_for_mt_call_in_idle(
  ** **
  ***********************************************************************************/
 
-static int _sgs_handle_paging_request_for_mt_sms_in_idle(
+static int sgs_handle_paging_request_for_mt_sms_in_idle(
     ue_mm_context_t* ue_context_p,
     itti_sgsap_paging_request_t* const sgsap_paging_req_pP)
 
@@ -539,7 +539,7 @@ static int _sgs_handle_paging_request_for_mt_sms_in_idle(
     }
   } else {
     // Send UE Unreachable to MSC/VLR
-    rc = _mme_app_send_sgsap_ue_unreachable(
+    rc = mme_app_send_sgsap_ue_unreachable(
         ue_context_p, SGS_CAUSE_UE_UNREACHABLE);
     if (rc != RETURNok) {
       OAILOG_ERROR(
@@ -735,7 +735,7 @@ int sgs_handle_null_paging_request(const sgs_fsm_t* evt) {
  **
  ***********************************************************************************/
 
-static int _mme_app_send_sgsap_ue_unreachable(
+static int mme_app_send_sgsap_ue_unreachable(
     struct ue_mm_context_s* ue_context_p, SgsCause_t sgs_cause) {
   int rc                                               = RETURNerror;
   MessageDef* message_p                                = NULL;
@@ -787,7 +787,7 @@ static int _mme_app_send_sgsap_ue_unreachable(
  **          Return:    RETURNok, RETURNerror **
  **
  ***********************************************************************************/
-static int _sgsap_handle_paging_request_without_lai(
+static int sgsap_handle_paging_request_without_lai(
     ue_mm_context_t* ue_context_p,
     itti_sgsap_paging_request_t* const sgsap_paging_req_pP) {
   int rc                     = RETURNok;
@@ -839,7 +839,7 @@ static int _sgsap_handle_paging_request_without_lai(
       }
     } else {
       // Send UE Unreachable to MSC/VLR
-      rc = _mme_app_send_sgsap_ue_unreachable(
+      rc = mme_app_send_sgsap_ue_unreachable(
           ue_context_p, SGS_CAUSE_UE_UNREACHABLE);
       if (rc != RETURNok) {
         OAILOG_ERROR(

--- a/lte/gateway/c/oai/tasks/mme_app/mme_app_sgs_status.c
+++ b/lte/gateway/c/oai/tasks/mme_app/mme_app_sgs_status.c
@@ -38,13 +38,13 @@
 #include "nas_proc.h"
 #include "mme_app_timer.h"
 
-static void _mme_app_handle_sgs_status_for_imsi_detach_ind(
+static void mme_app_handle_sgs_status_for_imsi_detach_ind(
     ue_mm_context_t* ue_context_p);
 
-static void _mme_app_handle_sgs_status_for_eps_detach_ind(
+static void mme_app_handle_sgs_status_for_eps_detach_ind(
     ue_mm_context_t* ue_context_p);
 
-static void _mme_app_handle_sgs_status_for_loc_upd_req(
+static void mme_app_handle_sgs_status_for_loc_upd_req(
     ue_mm_context_t* ue_context_p);
 
 /****************************************************************************
@@ -105,7 +105,7 @@ int mme_app_handle_sgs_status_message(
           LOG_MME_APP,
           "Received SGS Error Status message for"
           "LOCATION_UPDATE_REQUEST \n");
-      _mme_app_handle_sgs_status_for_loc_upd_req(ue_context_p);
+      mme_app_handle_sgs_status_for_loc_upd_req(ue_context_p);
       break;
     }
     case SGS_TMSI_REALLOCATION_COMPLETE: {
@@ -120,7 +120,7 @@ int mme_app_handle_sgs_status_message(
           LOG_MME_APP,
           "Received SGS Error Status message for"
           "EPS_DETACH_INDICATION \n");
-      _mme_app_handle_sgs_status_for_eps_detach_ind(ue_context_p);
+      mme_app_handle_sgs_status_for_eps_detach_ind(ue_context_p);
       break;
     }
     case SGS_IMSI_DETACH_INDICATION: {
@@ -128,7 +128,7 @@ int mme_app_handle_sgs_status_message(
           LOG_MME_APP,
           "Received SGS Error Status message for"
           "IMSI_DETACH_INDICATION \n");
-      _mme_app_handle_sgs_status_for_imsi_detach_ind(ue_context_p);
+      mme_app_handle_sgs_status_for_imsi_detach_ind(ue_context_p);
       break;
     }
     case SGS_RESET_ACK: {
@@ -226,7 +226,7 @@ int mme_app_handle_sgs_status_message(
  **                                                                        **
  ***************************************************************************/
 
-static void _mme_app_handle_sgs_status_for_imsi_detach_ind(
+static void mme_app_handle_sgs_status_for_imsi_detach_ind(
     ue_mm_context_t* ue_context_p) {
   OAILOG_FUNC_IN(LOG_MME_APP);
 
@@ -277,7 +277,7 @@ static void _mme_app_handle_sgs_status_for_imsi_detach_ind(
  **                                                                        **
  ***************************************************************************/
 
-static void _mme_app_handle_sgs_status_for_eps_detach_ind(
+static void mme_app_handle_sgs_status_for_eps_detach_ind(
     ue_mm_context_t* ue_context_p) {
   OAILOG_FUNC_IN(LOG_MME_APP);
 
@@ -307,7 +307,7 @@ static void _mme_app_handle_sgs_status_for_eps_detach_ind(
  **                                                                        **
  ***************************************************************************/
 
-static void _mme_app_handle_sgs_status_for_loc_upd_req(
+static void mme_app_handle_sgs_status_for_loc_upd_req(
     ue_mm_context_t* ue_context_p) {
   OAILOG_FUNC_IN(LOG_MME_APP);
   lai_t* lai = NULL;

--- a/lte/gateway/c/oai/tasks/mme_app/mme_app_sgsap_location_update.c
+++ b/lte/gateway/c/oai/tasks/mme_app/mme_app_sgsap_location_update.c
@@ -63,7 +63,7 @@
  ** Inputs:              Pointer to UE context                                **
  **                                                                           **
  ********************************************************************************/
-void _mme_app_update_granted_service_for_ue(ue_mm_context_t* ue_context) {
+void mme_app_update_granted_service_for_ue(ue_mm_context_t* ue_context) {
   OAILOG_FUNC_IN(LOG_MME_APP);
   additional_updt_t additional_update_type =
       (additional_updt_t) ue_context->emm_context.additional_update_type;
@@ -108,7 +108,7 @@ void _mme_app_update_granted_service_for_ue(ue_mm_context_t* ue_context) {
  ** Returns:             Mapped EPS attach type                               **
  **                                                                           **
  ********************************************************************************/
-uint8_t _get_eps_attach_type(uint8_t emm_attach_type) {
+uint8_t get_eps_attach_type(uint8_t emm_attach_type) {
   OAILOG_FUNC_IN(LOG_MME_APP);
   uint8_t eps_attach_type = 0;
 
@@ -183,7 +183,7 @@ void mme_app_send_itti_sgsap_ue_activity_ind(
  ** Inputs:              Mobile Id **
  ** **
  ***********************************************************************************/
-static int _copy_mobile_identity_helper(
+static int copy_mobile_identity_helper(
     MobileIdentity_t* mobileid_dest, MobileIdentity_t* mobileid_src) {
   OAILOG_FUNC_IN(LOG_MME_APP);
 
@@ -208,7 +208,7 @@ static int _copy_mobile_identity_helper(
  ** **
  ***********************************************************************************/
 
-static int _build_sgs_status(
+static int build_sgs_status(
     char* imsi, uint8_t imsi_length, lai_t laicsfb, MobileIdentity_t* mobileid,
     uint8_t msg_id) {
   int rc = RETURNok;
@@ -255,7 +255,7 @@ static int _build_sgs_status(
 
   // Encode Mobile Identity
   if (mobileid) {
-    _copy_mobile_identity_helper(
+    copy_mobile_identity_helper(
         &sgsap_status->error_msg.u.sgsap_location_update_acc.mobileid,
         mobileid);
     sgsap_status->error_msg.u.sgsap_location_update_acc.presencemask |=
@@ -278,7 +278,7 @@ static int _build_sgs_status(
  ** Outputs:                                                                   *
  **      Return:    RETURNok, RETURNerror                                      *
  *******************************************************************************/
-static int _handle_cs_domain_loc_updt_acc(
+static int handle_cs_domain_loc_updt_acc(
     itti_sgsap_location_update_acc_t* const itti_sgsap_location_update_acc,
     struct ue_mm_context_s* ue_context_p) {
   OAILOG_FUNC_IN(LOG_MME_APP);
@@ -389,10 +389,10 @@ int mme_app_handle_nas_cs_domain_location_update_req(
   // Store granted service type based on attach type & addition updt type
   if (msg_type == ATTACH_REQUEST) {
     ue_context_p->attach_type =
-        _get_eps_attach_type(ue_context_p->emm_context.attach_type);
+        get_eps_attach_type(ue_context_p->emm_context.attach_type);
     ue_context_p->sgs_context->ongoing_procedure = COMBINED_ATTACH;
     if (ue_context_p->attach_type == EPS_ATTACH_TYPE_COMBINED_EPS_IMSI) {
-      _mme_app_update_granted_service_for_ue(ue_context_p);
+      mme_app_update_granted_service_for_ue(ue_context_p);
     }
   }
   if ((ue_context_p->network_access_mode == NAM_PACKET_AND_CIRCUIT) &&
@@ -400,7 +400,7 @@ int mme_app_handle_nas_cs_domain_location_update_req(
        MME_APP_TIMER_INACTIVE_ID)) {
     if (msg_type == TAU_REQUEST) {
       ue_context_p->sgs_context->ongoing_procedure = COMBINED_TAU;
-      _mme_app_update_granted_service_for_ue(ue_context_p);
+      mme_app_update_granted_service_for_ue(ue_context_p);
     }
     OAILOG_INFO(
         LOG_MME_APP,
@@ -710,7 +710,7 @@ int sgs_fsm_null_loc_updt_acc(const sgs_fsm_t* fsm_evt) {
           SGSAP_MOBILE_IDENTITY) {
         mobileid = &itti_sgsap_location_update_acc_p->mobileid;
       }
-      if (_build_sgs_status(
+      if (build_sgs_status(
               itti_sgsap_location_update_acc_p->imsi,
               itti_sgsap_location_update_acc_p->imsi_length,
               itti_sgsap_location_update_acc_p->laicsfb, mobileid,
@@ -798,7 +798,7 @@ int sgs_fsm_la_updt_req_loc_updt_acc(const sgs_fsm_t* fsm_evt) {
     mme_app_stop_timer(ue_context_p->sgs_context->ts6_1_timer.id);
 
     sgs_context->ts6_1_timer.id = MME_APP_TIMER_INACTIVE_ID;
-    if ((_handle_cs_domain_loc_updt_acc(
+    if ((handle_cs_domain_loc_updt_acc(
             itti_sgsap_location_update_acc_p, ue_context_p)) == RETURNerror) {
       OAILOG_DEBUG(
           LOG_MME_APP,
@@ -834,7 +834,7 @@ int sgs_fsm_la_updt_req_loc_updt_acc(const sgs_fsm_t* fsm_evt) {
         mobileid = &itti_sgsap_location_update_acc_p->mobileid;
       }
       // Send SGS-STATUS message to SGS task
-      if (_build_sgs_status(
+      if (build_sgs_status(
               itti_sgsap_location_update_acc_p->imsi,
               itti_sgsap_location_update_acc_p->imsi_length,
               itti_sgsap_location_update_acc_p->laicsfb, mobileid,

--- a/lte/gateway/c/oai/tasks/nas/api/mme/mme_api.c
+++ b/lte/gateway/c/oai/tasks/nas/api/mme/mme_api.c
@@ -69,7 +69,7 @@
 #define MME_API_BIT_RATE_1024K 0x87
 
 /* Total number of PDN connections (should not exceed MME_API_PDN_MAX) */
-static int _mme_api_pdn_id = 0;
+static int mme_api_pdn_id = 0;
 
 static tmsi_t generate_random_TMSI(void);
 
@@ -637,7 +637,7 @@ int mme_api_unsubscribe(bstring apn) {
   /*
    * Decrement the total number of PDN connections
    */
-  _mme_api_pdn_id -= 1;
+  mme_api_pdn_id -= 1;
   OAILOG_FUNC_RETURN(LOG_NAS, rc);
 }
 

--- a/lte/gateway/c/oai/tasks/nas/api/network/nas_message.c
+++ b/lte/gateway/c/oai/tasks/nas/api/network/nas_message.c
@@ -46,26 +46,26 @@
 
 /* Functions used to decode layer 3 NAS messages */
 
-static int _nas_message_plain_decode(
+static int nas_message_plain_decode(
     const unsigned char* buffer, const nas_message_security_header_t* header,
     nas_message_plain_t* msg, size_t length);
 
-static int _nas_message_protected_decode(
+static int nas_message_protected_decode(
     unsigned char* const buffer, nas_message_security_header_t* header,
     nas_message_plain_t* msg, size_t length,
     emm_security_context_t* const emm_security_context,
     nas_message_decode_status_t* status);
 
 /* Functions used to encode layer 3 NAS messages */
-static int _nas_message_header_encode(
+static int nas_message_header_encode(
     unsigned char* buffer, const nas_message_security_header_t* header,
     size_t length);
 
-static int _nas_message_plain_encode(
+static int nas_message_plain_encode(
     unsigned char* buffer, const nas_message_security_header_t* header,
     const nas_message_plain_t* msg, size_t length);
 
-static int _nas_message_protected_encode(
+static int nas_message_protected_encode(
     unsigned char* buffer, const nas_message_security_protected_t* msg,
     size_t length, void* security);
 
@@ -82,7 +82,7 @@ static int nas_message_encrypt_a(
     emm_security_context_t* const emm_security_context);
 
 /* Functions used for integrity protection of layer 3 NAS messages */
-static uint32_t _nas_message_get_mac(
+static uint32_t nas_message_get_mac(
     const unsigned char* const buffer, size_t const length, int const direction,
     emm_security_context_t* const emm_security_context);
 
@@ -121,7 +121,7 @@ int nas_message_encrypt(
   /*
    * Encode the header
    */
-  int size = _nas_message_header_encode(outbuf, header, length);
+  int size = nas_message_header_encode(outbuf, header, length);
 
   if (size < 0) {
     OAILOG_FUNC_RETURN(LOG_NAS, TLV_BUFFER_TOO_SHORT);
@@ -147,7 +147,7 @@ int nas_message_encrypt(
       /*
        * Compute the NAS message authentication code
        */
-      uint32_t mac = _nas_message_get_mac(
+      uint32_t mac = nas_message_get_mac(
           outbuf + offset, bytes + size - offset,
           emm_security_context->direction_encode, emm_security_context);
 
@@ -269,7 +269,7 @@ int nas_message_decrypt(
     /*
      * Compute the NAS message authentication code
      */
-    uint32_t mac = _nas_message_get_mac(
+    uint32_t mac = nas_message_get_mac(
         inbuf + offset, length - offset, SECU_DIRECTION_UPLINK,
         emm_security_context);
 
@@ -421,7 +421,7 @@ int nas_message_decode(
      * Compute the NAS message authentication code, return 0 if no security
      * context
      */
-    mac = _nas_message_get_mac(
+    mac = nas_message_get_mac(
         buffer, SR_MAC_SIZE_BYTES, SECU_DIRECTION_UPLINK, emm_security_context);
 
     /*
@@ -471,7 +471,7 @@ int nas_message_decode(
        * Compute the NAS message authentication code, return 0 if no security
        * context
        */
-      mac = _nas_message_get_mac(
+      mac = nas_message_get_mac(
           buffer + offset, length - offset,
           emm_security_context->direction_decode, emm_security_context);
       /*
@@ -492,7 +492,7 @@ int nas_message_decode(
      * Decode security protected NAS message
      */
     // LG WARNING  msg->plain versus msg->security.plain.
-    bytes = _nas_message_protected_decode(
+    bytes = nas_message_protected_decode(
         (unsigned char* const)(buffer + size), &msg->header, &msg->plain,
         length - size, emm_security_context, status);
   } else {
@@ -500,7 +500,7 @@ int nas_message_decode(
      * Decode plain NAS message
      */
     bytes =
-        _nas_message_plain_decode(buffer, &msg->header, &msg->plain, length);
+        nas_message_plain_decode(buffer, &msg->header, &msg->plain, length);
   }
 
   if (bytes < 0) {
@@ -541,7 +541,7 @@ int nas_message_encode(
   /*
    * Encode the header
    */
-  int size = _nas_message_header_encode(buffer, &msg->header, length);
+  int size = nas_message_header_encode(buffer, &msg->header, length);
 
   if (size < 0) {
     OAILOG_FUNC_RETURN(LOG_NAS, TLV_BUFFER_TOO_SHORT);
@@ -549,7 +549,7 @@ int nas_message_encode(
     /*
      * Encode security protected NAS message
      */
-    bytes = _nas_message_protected_encode(
+    bytes = nas_message_protected_encode(
         buffer + size, &msg->security_protected, length - size,
         emm_security_context);
 
@@ -569,7 +569,7 @@ int nas_message_encode(
           LOG_NAS,
           "offset %d = %d - %lu, hdr encode = %d, length = %lu bytes = %d\n",
           offset, size, sizeof(uint8_t), size, length, bytes);
-      uint32_t mac = _nas_message_get_mac(
+      uint32_t mac = nas_message_get_mac(
           buffer + offset, bytes + size - offset,
           emm_security_context->direction_encode, emm_security_context);
 
@@ -632,7 +632,7 @@ int nas_message_encode(
      * Encode plain NAS message
      */
     bytes =
-        _nas_message_plain_encode(buffer, &msg->header, &msg->plain, length);
+        nas_message_plain_encode(buffer, &msg->header, &msg->plain, length);
   }
 
   if (bytes < 0) {
@@ -760,7 +760,7 @@ int nas_message_header_decode(
  **    Others:  None                                       **
  **                                                                        **
  ***************************************************************************/
-static int _nas_message_plain_decode(
+static int nas_message_plain_decode(
     const unsigned char* buffer, const nas_message_security_header_t* header,
     nas_message_plain_t* msg, size_t length) {
   OAILOG_FUNC_IN(LOG_NAS);
@@ -810,7 +810,7 @@ static int _nas_message_plain_decode(
  **    Others:  None                                       **
  **                                                                        **
  ***************************************************************************/
-static int _nas_message_protected_decode(
+static int nas_message_protected_decode(
     unsigned char* const buffer, nas_message_security_header_t* header,
     nas_message_plain_t* msg, size_t length,
     emm_security_context_t* const emm_security_context,
@@ -830,7 +830,7 @@ static int _nas_message_protected_decode(
     /*
      * Decode the decrypted message as plain NAS message
      */
-    bytes = _nas_message_plain_decode(plain_msg, header, msg, length);
+    bytes = nas_message_plain_decode(plain_msg, header, msg, length);
     free_wrapper((void**) &plain_msg);
   }
 
@@ -862,7 +862,7 @@ static int _nas_message_protected_decode(
  **    Others:  None                                       **
  **                                                                        **
  ***************************************************************************/
-static int _nas_message_header_encode(
+static int nas_message_header_encode(
     unsigned char* buffer, const nas_message_security_header_t* header,
     size_t length) {
   OAILOG_FUNC_IN(LOG_NAS);
@@ -924,7 +924,7 @@ static int _nas_message_header_encode(
  **    Others:  None                                       **
  **                                                                        **
  ***************************************************************************/
-static int _nas_message_plain_encode(
+static int nas_message_plain_encode(
     unsigned char* buffer, const nas_message_security_header_t* header,
     const nas_message_plain_t* msg, size_t length) {
   OAILOG_FUNC_IN(LOG_NAS);
@@ -975,7 +975,7 @@ static int _nas_message_plain_encode(
  ** Others:   None                                                         **
  **                                                                        **
  ***************************************************************************/
-static int _nas_message_protected_encode(
+static int nas_message_protected_encode(
     unsigned char* buffer, const nas_message_security_protected_t* msg,
     size_t length, void* security) {
   OAILOG_FUNC_IN(LOG_NAS);
@@ -989,7 +989,7 @@ static int _nas_message_protected_encode(
      * Encode the security protected NAS message as plain NAS message
      */
     int size =
-        _nas_message_plain_encode(plain_msg, &msg->header, &msg->plain, length);
+        nas_message_plain_encode(plain_msg, &msg->header, &msg->plain, length);
 
     if (size > 0) {
       // static uint8_t seq = 0;
@@ -1393,7 +1393,7 @@ static int nas_message_encrypt_a(
  **    Others:  None                                                   **
  **                                                                        **
  ***************************************************************************/
-static uint32_t _nas_message_get_mac(
+static uint32_t nas_message_get_mac(
     const unsigned char* const buffer, size_t const length, int const direction,
     emm_security_context_t* const emm_security_context) {
   OAILOG_FUNC_IN(LOG_NAS);

--- a/lte/gateway/c/oai/tasks/nas/api/network/nas_message.c
+++ b/lte/gateway/c/oai/tasks/nas/api/network/nas_message.c
@@ -70,13 +70,13 @@ static int _nas_message_protected_encode(
     size_t length, void* security);
 
 /* Functions used to decrypt and encrypt layer 3 NAS messages */
-static int _nas_message_decrypt(
+static int nas_message_decrypt_a(
     unsigned char* const dest, unsigned char* const src, uint8_t type,
     uint32_t code, uint8_t seq, size_t length,
     emm_security_context_t* const emm_security_context,
     nas_message_decode_status_t* status);
 
-static int _nas_message_encrypt(
+static int nas_message_encrypt_a(
     unsigned char* dest, const unsigned char* src, uint8_t type, uint32_t code,
     uint8_t seq, size_t length,
     emm_security_context_t* const emm_security_context);
@@ -130,7 +130,7 @@ int nas_message_encrypt(
      * Encrypt the plain NAS message.
      * bytes is zero if emm_security_context is null.
      */
-    bytes = _nas_message_encrypt(
+    bytes = nas_message_encrypt_a(
         outbuf + size, inbuf, header->security_header_type,
         header->message_authentication_code, header->sequence_number,
         length - size, emm_security_context);
@@ -295,7 +295,7 @@ int nas_message_decrypt(
      * Decrypt the security protected NAS message
      */
     // OAI_GCC_DIAG_OFF(discarded-qualifiers);
-    header->protocol_discriminator = _nas_message_decrypt(
+    header->protocol_discriminator = nas_message_decrypt_a(
         outbuf, (unsigned char* const)(inbuf + size),
         header->security_header_type, header->message_authentication_code,
         header->sequence_number, length - size, emm_security_context, status);
@@ -823,7 +823,7 @@ static int _nas_message_protected_decode(
     /*
      * Decrypt the security protected NAS message
      */
-    header->protocol_discriminator = _nas_message_decrypt(
+    header->protocol_discriminator = nas_message_decrypt_a(
         plain_msg, buffer, header->security_header_type,
         header->message_authentication_code, header->sequence_number, length,
         emm_security_context, status);
@@ -996,7 +996,7 @@ static int _nas_message_protected_encode(
       /*
        * Encrypt the encoded plain NAS message
        */
-      bytes = _nas_message_encrypt(
+      bytes = nas_message_encrypt_a(
           buffer, plain_msg, msg->header.security_header_type,
           msg->header.message_authentication_code, msg->header.sequence_number,
           size, emm_security_context);
@@ -1018,7 +1018,7 @@ static int _nas_message_protected_encode(
 
 /****************************************************************************
  **                                                                        **
- ** Name:  _nas_message_decrypt()                                    **
+ ** Name:  nas_message_decrypt_a()                                    **
  **                                                                        **
  ** Description: Decrypt security protected NAS message                    **
  **                                                                        **
@@ -1035,7 +1035,7 @@ static int _nas_message_protected_encode(
  **    Others:  None                                       **
  **                                                                        **
  ***************************************************************************/
-static int _nas_message_decrypt(
+static int nas_message_decrypt_a(
     unsigned char* const dest, unsigned char* const src,
     uint8_t security_header_type, uint32_t code, uint8_t seq, size_t length,
     emm_security_context_t* const emm_security_context,
@@ -1215,7 +1215,7 @@ static int _nas_message_decrypt(
 
 /****************************************************************************
  **                                                                        **
- ** Name:  _nas_message_encrypt()                                    **
+ ** Name:  nas_message_encrypt_a()                                    **
  **                                                                        **
  ** Description: Encrypt plain NAS message                                 **
  **                                                                        **
@@ -1234,7 +1234,7 @@ static int _nas_message_decrypt(
  **    Others:  None                                       **
  **                                                                        **
  ***************************************************************************/
-static int _nas_message_encrypt(
+static int nas_message_encrypt_a(
     unsigned char* dest, const unsigned char* src, uint8_t security_header_type,
     uint32_t code, uint8_t seq, size_t length,
     emm_security_context_t* const emm_security_context) {

--- a/lte/gateway/c/oai/tasks/nas/emm/Attach.c
+++ b/lte/gateway/c/oai/tasks/nas/emm/Attach.c
@@ -129,7 +129,7 @@ static int _emm_start_attach_proc_authentication(
 static int _emm_start_attach_proc_security(
     emm_context_t* emm_context, nas_emm_attach_proc_t* attach_proc);
 
-static int _emm_attach_security(emm_context_t* emm_context);
+static int emm_attach_security_a(emm_context_t* emm_context);
 static int _emm_attach(emm_context_t* emm_context);
 
 static int _emm_attach_success_identification_cb(emm_context_t* emm_context);
@@ -1373,7 +1373,7 @@ static int _emm_attach_failure_security_cb(emm_context_t* emm_context) {
 //}
 /*
  *
- * Name:        _emm_attach_security()
+ * Name:        emm_attach_security_a()
  *
  * Description: Initiates security mode control EMM common procedure.
  *
@@ -1387,11 +1387,11 @@ static int _emm_attach_failure_security_cb(emm_context_t* emm_context) {
  */
 //------------------------------------------------------------------------------
 int emm_attach_security(struct emm_context_s* emm_context) {
-  return _emm_attach_security(emm_context);
+  return emm_attach_security_a(emm_context);
 }
 
 //------------------------------------------------------------------------------
-static int _emm_attach_security(emm_context_t* emm_context) {
+static int emm_attach_security_a(emm_context_t* emm_context) {
   OAILOG_FUNC_IN(LOG_NAS_EMM);
   int rc = RETURNerror;
 

--- a/lte/gateway/c/oai/tasks/nas/emm/Attach.c
+++ b/lte/gateway/c/oai/tasks/nas/emm/Attach.c
@@ -108,7 +108,7 @@
 /****************************************************************************/
 
 /* String representation of the EPS attach type */
-static const char* _emm_attach_type_str[] = {"EPS", "IMSI", "EMERGENCY",
+static const char* emm_attach_type_str[] = {"EPS", "IMSI", "EMERGENCY",
                                              "RESERVED"};
 
 /*
@@ -119,48 +119,48 @@ static const char* _emm_attach_type_str[] = {"EPS", "IMSI", "EMERGENCY",
 /*
    Timer handlers
 */
-static void _emm_attach_t3450_handler(void*, imsi64_t* imsi64);
+static void emm_attach_t3450_handler(void*, imsi64_t* imsi64);
 
 /*
    Functions that may initiate EMM common procedures
 */
-static int _emm_start_attach_proc_authentication(
+static int emm_start_attach_proc_authentication(
     emm_context_t* emm_context, nas_emm_attach_proc_t* attach_proc);
-static int _emm_start_attach_proc_security(
+static int emm_start_attach_proc_security(
     emm_context_t* emm_context, nas_emm_attach_proc_t* attach_proc);
 
 static int emm_attach_security_a(emm_context_t* emm_context);
-static int _emm_attach(emm_context_t* emm_context);
+static int emm_attach(emm_context_t* emm_context);
 
-static int _emm_attach_success_identification_cb(emm_context_t* emm_context);
-static int _emm_attach_failure_identification_cb(emm_context_t* emm_context);
-static int _emm_attach_success_authentication_cb(emm_context_t* emm_context);
-static int _emm_attach_failure_authentication_cb(emm_context_t* emm_context);
-static int _emm_attach_success_security_cb(emm_context_t* emm_context);
-static int _emm_attach_failure_security_cb(emm_context_t* emm_context);
+static int emm_attach_success_identification_cb(emm_context_t* emm_context);
+static int emm_attach_failure_identification_cb(emm_context_t* emm_context);
+static int emm_attach_success_authentication_cb(emm_context_t* emm_context);
+static int emm_attach_failure_authentication_cb(emm_context_t* emm_context);
+static int emm_attach_success_security_cb(emm_context_t* emm_context);
+static int emm_attach_failure_security_cb(emm_context_t* emm_context);
 
 /*
    Abnormal case attach procedures
 */
-static int _emm_attach_release(emm_context_t* emm_context);
-static int _emm_attach_abort(
+static int emm_attach_release(emm_context_t* emm_context);
+static int emm_attach_abort(
     struct emm_context_s* emm_context, struct nas_base_proc_s* base_proc);
-static int _emm_attach_run_procedure(emm_context_t* emm_context);
-static int _emm_send_attach_accept(emm_context_t* emm_context);
+static int emm_attach_run_procedure(emm_context_t* emm_context);
+static int emm_send_attach_accept(emm_context_t* emm_context);
 
-static bool _emm_attach_ies_have_changed(
+static bool emm_attach_ies_have_changed(
     mme_ue_s1ap_id_t ue_id, emm_attach_request_ies_t* const ies1,
     emm_attach_request_ies_t* const ies2);
 
-static void _emm_proc_create_procedure_attach_request(
+static void emm_proc_create_procedure_attach_request(
     ue_mm_context_t* const ue_mm_context, emm_attach_request_ies_t* const ies);
 
-static int _emm_attach_update(
+static int emm_attach_update(
     emm_context_t* const emm_context, emm_attach_request_ies_t* const ies);
 
-static int _emm_attach_accept_retx(emm_context_t* emm_context);
+static int emm_attach_accept_retx(emm_context_t* emm_context);
 
-static void _create_new_attach_info(
+static void create_new_attach_info(
     emm_context_t* emm_context_p, mme_ue_s1ap_id_t mme_ue_s1ap_id,
     struct emm_attach_request_ies_s* ies, bool is_mm_ctx_new);
 
@@ -236,7 +236,7 @@ int emm_proc_attach_request(
 
   OAILOG_INFO(
       LOG_NAS_EMM, "EMM-PROC:  ATTACH - EPS attach type = %s (%d)\n",
-      _emm_attach_type_str[ies->type], ies->type);
+      emm_attach_type_str[ies->type], ies->type);
   OAILOG_DEBUG(
       LOG_NAS_EMM,
       "is_initial request = %u\n (ue_id=" MME_UE_S1AP_ID_FMT
@@ -322,7 +322,7 @@ int emm_proc_attach_request(
     // Allocate new context and process the new request as fresh attach
     // request
     if (guti_ue_mm_ctx) {
-      _create_new_attach_info(
+      create_new_attach_info(
           &guti_ue_mm_ctx->emm_context, ue_mm_context->mme_ue_s1ap_id, ies,
           is_mm_ctx_new);
       /*
@@ -392,7 +392,7 @@ int emm_proc_attach_request(
               LOG_NAS_EMM,
               "EMM-PROC  - the new ATTACH REQUEST is progressed\n");
           // process the new request as fresh attach request
-          _create_new_attach_info(
+          create_new_attach_info(
               &imsi_ue_mm_ctx->emm_context, ue_mm_context->mme_ue_s1ap_id, ies,
               is_mm_ctx_new);
           // Trigger clean up
@@ -410,7 +410,7 @@ int emm_proc_attach_request(
                                 // implicit
 
         imsi_ue_mm_ctx->emm_context.num_attach_request++;
-        if (_emm_attach_ies_have_changed(
+        if (emm_attach_ies_have_changed(
                 imsi_ue_mm_ctx->mme_ue_s1ap_id, attach_proc->ies, ies)) {
           OAILOG_WARNING(
               LOG_NAS_EMM, "EMM-PROC  - Attach parameters have changed\n");
@@ -424,7 +424,7 @@ int emm_proc_attach_request(
            */
           // After releasing of contexts of old UE, process the new request as
           // fresh attach request
-          _create_new_attach_info(
+          create_new_attach_info(
               &imsi_ue_mm_ctx->emm_context, ue_mm_context->mme_ue_s1ap_id, ies,
               is_mm_ctx_new);
 
@@ -439,7 +439,7 @@ int emm_proc_attach_request(
            * an ATTACH COMPLETE message is expected. In that case, the
            * retransmission counter related to T3450 is not incremented.
            */
-          _emm_attach_accept_retx(&imsi_ue_mm_ctx->emm_context);
+          emm_attach_accept_retx(&imsi_ue_mm_ctx->emm_context);
           increment_counter(
               "duplicate_attach_request", 1, 1, "action",
               "ignored_duplicate_req_retx_attach_accept");
@@ -465,7 +465,7 @@ int emm_proc_attach_request(
           (0 < imsi_ue_mm_ctx->emm_context.num_attach_request) &&
           ((attach_proc) && ((!is_nas_attach_accept_sent(attach_proc)) &&
                              (!is_nas_attach_reject_sent(attach_proc))))) {
-        if (_emm_attach_ies_have_changed(
+        if (emm_attach_ies_have_changed(
                 imsi_ue_mm_ctx->mme_ue_s1ap_id, attach_proc->ies, ies)) {
           OAILOG_WARNING(
               LOG_NAS_EMM, "EMM-PROC  - Attach parameters have changed\n");
@@ -481,7 +481,7 @@ int emm_proc_attach_request(
           increment_counter(
               "duplicate_attach_request", 1, 1, "action",
               "processed_old_ctxt_cleanup");
-          _create_new_attach_info(
+          create_new_attach_info(
               &imsi_ue_mm_ctx->emm_context, ue_mm_context->mme_ue_s1ap_id, ies,
               is_mm_ctx_new);
 
@@ -602,9 +602,9 @@ int emm_proc_attach_request(
     }
   }
   if (!is_nas_specific_procedure_attach_running(&ue_mm_context->emm_context)) {
-    _emm_proc_create_procedure_attach_request(ue_mm_context, ies);
+    emm_proc_create_procedure_attach_request(ue_mm_context, ies);
   }
-  rc = _emm_attach_run_procedure(&ue_mm_context->emm_context);
+  rc = emm_attach_run_procedure(&ue_mm_context->emm_context);
   OAILOG_FUNC_RETURN(LOG_NAS_EMM, rc);
 }
 /*
@@ -854,31 +854,31 @@ int emm_proc_attach_complete(
  */
 
 void set_callbacks_for_attach_proc(nas_emm_attach_proc_t* attach_proc) {
-  ((nas_base_proc_t*) attach_proc)->abort    = _emm_attach_abort;
+  ((nas_base_proc_t*) attach_proc)->abort    = emm_attach_abort;
   ((nas_base_proc_t*) attach_proc)->fail_in  = NULL;
-  ((nas_base_proc_t*) attach_proc)->time_out = _emm_attach_t3450_handler;
+  ((nas_base_proc_t*) attach_proc)->time_out = emm_attach_t3450_handler;
   ((nas_base_proc_t*) attach_proc)->fail_out = _emm_attach_reject;
 }
 
 void set_notif_callbacks_for_auth_proc(nas_emm_auth_proc_t* auth_proc) {
   auth_proc->emm_com_proc.emm_proc.base_proc.success_notif =
-      _emm_attach_success_authentication_cb;
+      emm_attach_success_authentication_cb;
   auth_proc->emm_com_proc.emm_proc.base_proc.failure_notif =
-      _emm_attach_failure_authentication_cb;
+      emm_attach_failure_authentication_cb;
 }
 
 void set_notif_callbacks_for_smc_proc(nas_emm_smc_proc_t* smc_proc) {
   smc_proc->emm_com_proc.emm_proc.base_proc.success_notif =
-      _emm_attach_success_security_cb;
+      emm_attach_success_security_cb;
   smc_proc->emm_com_proc.emm_proc.base_proc.failure_notif =
-      _emm_attach_failure_security_cb;
+      emm_attach_failure_security_cb;
 }
 
 /****************************************************************************/
 /*********************  L O C A L    F U N C T I O N S  *********************/
 /****************************************************************************/
 
-static void _emm_proc_create_procedure_attach_request(
+static void emm_proc_create_procedure_attach_request(
     ue_mm_context_t* const ue_mm_context, emm_attach_request_ies_t* const ies) {
   nas_emm_attach_proc_t* attach_proc =
       nas_new_attach_procedure(&ue_mm_context->emm_context);
@@ -886,9 +886,9 @@ static void _emm_proc_create_procedure_attach_request(
   if ((attach_proc)) {
     attach_proc->ies                           = ies;
     attach_proc->ue_id                         = ue_mm_context->mme_ue_s1ap_id;
-    ((nas_base_proc_t*) attach_proc)->abort    = _emm_attach_abort;
+    ((nas_base_proc_t*) attach_proc)->abort    = emm_attach_abort;
     ((nas_base_proc_t*) attach_proc)->fail_in  = NULL;  // No parent procedure
-    ((nas_base_proc_t*) attach_proc)->time_out = _emm_attach_t3450_handler;
+    ((nas_base_proc_t*) attach_proc)->time_out = emm_attach_t3450_handler;
     ((nas_base_proc_t*) attach_proc)->fail_out = _emm_attach_reject;
   }
 }
@@ -920,7 +920,7 @@ static void _emm_proc_create_procedure_attach_request(
  *      Others:    None
  *
  */
-static void _emm_attach_t3450_handler(void* args, imsi64_t* imsi64) {
+static void emm_attach_t3450_handler(void* args, imsi64_t* imsi64) {
   OAILOG_FUNC_IN(LOG_NAS_EMM);
   emm_context_t* emm_context = (emm_context_t*) (args);
 
@@ -944,7 +944,7 @@ static void _emm_attach_t3450_handler(void* args, imsi64_t* imsi64) {
        * On the first expiry of the timer, the network shall retransmit the
        * ATTACH ACCEPT message and shall reset and restart timer T3450.
        */
-      _emm_attach_accept_retx(emm_context);
+      emm_attach_accept_retx(emm_context);
       attach_proc->attach_accept_sent++;
     } else {
       REQUIREMENT_3GPP_24_301(R10_5_5_1_2_7_c__2);
@@ -970,7 +970,7 @@ static void _emm_attach_t3450_handler(void* args, imsi64_t* imsi64) {
 }
 
 //------------------------------------------------------------------------------
-static int _emm_attach_release(emm_context_t* emm_context) {
+static int emm_attach_release(emm_context_t* emm_context) {
   OAILOG_FUNC_IN(LOG_NAS_EMM);
   int rc = RETURNerror;
 
@@ -1071,7 +1071,7 @@ int _emm_attach_reject(
  *
  */
 //------------------------------------------------------------------------------
-static int _emm_attach_abort(
+static int emm_attach_abort(
     struct emm_context_s* emm_context, struct nas_base_proc_s* base_proc) {
   OAILOG_FUNC_IN(LOG_NAS_EMM);
   int rc = RETURNerror;
@@ -1103,7 +1103,7 @@ static int _emm_attach_abort(
  */
 
 //------------------------------------------------------------------------------
-static int _emm_attach_run_procedure(emm_context_t* emm_context) {
+static int emm_attach_run_procedure(emm_context_t* emm_context) {
   OAILOG_FUNC_IN(LOG_NAS_EMM);
   int rc = RETURNerror;
   nas_emm_attach_proc_t* attach_proc =
@@ -1137,7 +1137,7 @@ static int _emm_attach_run_procedure(emm_context_t* emm_context) {
         imsi64_t imsi64 = imsi_to_imsi64(attach_proc->ies->imsi);
         emm_ctx_set_valid_imsi(emm_context, attach_proc->ies->imsi, imsi64);
         emm_context_upsert_imsi(&_emm_data, emm_context);
-        rc = _emm_start_attach_proc_authentication(emm_context, attach_proc);
+        rc = emm_start_attach_proc_authentication(emm_context, attach_proc);
         if (rc != RETURNok) {
           OAILOG_ERROR(
               LOG_NAS_EMM,
@@ -1147,14 +1147,14 @@ static int _emm_attach_run_procedure(emm_context_t* emm_context) {
         // force identification, even if not necessary
         rc = emm_proc_identification(
             emm_context, (nas_emm_proc_t*) attach_proc, IDENTITY_TYPE_2_IMSI,
-            _emm_attach_success_identification_cb,
-            _emm_attach_failure_identification_cb);
+            emm_attach_success_identification_cb,
+            emm_attach_failure_identification_cb);
       }
     } else if (attach_proc->ies->guti) {
       rc = emm_proc_identification(
           emm_context, (nas_emm_proc_t*) attach_proc, IDENTITY_TYPE_2_IMSI,
-          _emm_attach_success_identification_cb,
-          _emm_attach_failure_identification_cb);
+          emm_attach_success_identification_cb,
+          emm_attach_failure_identification_cb);
     } else if (attach_proc->ies->imei) {
       // emergency allowed if go here, but have to be implemented...
       AssertFatal(0, "TODO emergency");
@@ -1164,7 +1164,7 @@ static int _emm_attach_run_procedure(emm_context_t* emm_context) {
 }
 
 //------------------------------------------------------------------------------
-static int _emm_attach_success_identification_cb(emm_context_t* emm_context) {
+static int emm_attach_success_identification_cb(emm_context_t* emm_context) {
   OAILOG_FUNC_IN(LOG_NAS_EMM);
   int rc = RETURNerror;
 
@@ -1174,7 +1174,7 @@ static int _emm_attach_success_identification_cb(emm_context_t* emm_context) {
 
   if (attach_proc) {
     REQUIREMENT_3GPP_24_301(R10_5_5_1_2_3__1);
-    rc = _emm_start_attach_proc_authentication(
+    rc = emm_start_attach_proc_authentication(
         emm_context,
         attach_proc);  //, IDENTITY_TYPE_2_IMSI, _emm_attach_authentified,
                        //_emm_attach_release);
@@ -1183,7 +1183,7 @@ static int _emm_attach_success_identification_cb(emm_context_t* emm_context) {
 }
 
 //------------------------------------------------------------------------------
-static int _emm_attach_failure_identification_cb(emm_context_t* emm_context) {
+static int emm_attach_failure_identification_cb(emm_context_t* emm_context) {
   OAILOG_FUNC_IN(LOG_NAS_EMM);
   int rc = RETURNerror;
 
@@ -1194,7 +1194,7 @@ static int _emm_attach_failure_identification_cb(emm_context_t* emm_context) {
 }
 
 //------------------------------------------------------------------------------
-static int _emm_start_attach_proc_authentication(
+static int emm_start_attach_proc_authentication(
     emm_context_t* emm_context, nas_emm_attach_proc_t* attach_proc) {
   OAILOG_FUNC_IN(LOG_NAS_EMM);
   int rc = RETURNerror;
@@ -1202,14 +1202,14 @@ static int _emm_start_attach_proc_authentication(
   if ((emm_context) && (attach_proc)) {
     rc = emm_proc_authentication(
         emm_context, &attach_proc->emm_spec_proc,
-        _emm_attach_success_authentication_cb,
-        _emm_attach_failure_authentication_cb);
+        emm_attach_success_authentication_cb,
+        emm_attach_failure_authentication_cb);
   }
   OAILOG_FUNC_RETURN(LOG_NAS_EMM, rc);
 }
 
 //------------------------------------------------------------------------------
-static int _emm_attach_success_authentication_cb(emm_context_t* emm_context) {
+static int emm_attach_success_authentication_cb(emm_context_t* emm_context) {
   OAILOG_FUNC_IN(LOG_NAS_EMM);
   int rc = RETURNerror;
 
@@ -1219,13 +1219,13 @@ static int _emm_attach_success_authentication_cb(emm_context_t* emm_context) {
 
   if (attach_proc) {
     REQUIREMENT_3GPP_24_301(R10_5_5_1_2_3__1);
-    rc = _emm_start_attach_proc_security(emm_context, attach_proc);
+    rc = emm_start_attach_proc_security(emm_context, attach_proc);
   }
   OAILOG_FUNC_RETURN(LOG_NAS_EMM, rc);
 }
 
 //------------------------------------------------------------------------------
-static int _emm_attach_failure_authentication_cb(emm_context_t* emm_context) {
+static int emm_attach_failure_authentication_cb(emm_context_t* emm_context) {
   OAILOG_FUNC_IN(LOG_NAS_EMM);
   int rc = RETURNerror;
   OAILOG_ERROR(LOG_NAS_EMM, "ATTACH - Authentication procedure failed!\n");
@@ -1249,7 +1249,7 @@ static int _emm_attach_failure_authentication_cb(emm_context_t* emm_context) {
 }
 
 //------------------------------------------------------------------------------
-static int _emm_start_attach_proc_security(
+static int emm_start_attach_proc_security(
     emm_context_t* emm_context, nas_emm_attach_proc_t* attach_proc) {
   OAILOG_FUNC_IN(LOG_NAS_EMM);
   int rc = RETURNerror;
@@ -1265,7 +1265,7 @@ static int _emm_start_attach_proc_security(
     emm_ctx_clear_security(emm_context);
     rc = emm_proc_security_mode_control(
         emm_context, &attach_proc->emm_spec_proc, attach_proc->ksi,
-        _emm_attach_success_security_cb, _emm_attach_failure_security_cb);
+        emm_attach_success_security_cb, emm_attach_failure_security_cb);
     if (rc != RETURNok) {
       /*
        * Failed to initiate the security mode control procedure
@@ -1294,7 +1294,7 @@ static int _emm_start_attach_proc_security(
 }
 
 //------------------------------------------------------------------------------
-static int _emm_attach_success_security_cb(emm_context_t* emm_context) {
+static int emm_attach_success_security_cb(emm_context_t* emm_context) {
   OAILOG_FUNC_IN(LOG_NAS_EMM);
   int rc = RETURNerror;
 
@@ -1303,13 +1303,13 @@ static int _emm_attach_success_security_cb(emm_context_t* emm_context) {
       get_nas_specific_procedure_attach(emm_context);
 
   if (attach_proc) {
-    rc = _emm_attach(emm_context);
+    rc = emm_attach(emm_context);
   }
   OAILOG_FUNC_RETURN(LOG_NAS_EMM, rc);
 }
 
 //------------------------------------------------------------------------------
-static int _emm_attach_failure_security_cb(emm_context_t* emm_context) {
+static int emm_attach_failure_security_cb(emm_context_t* emm_context) {
   OAILOG_FUNC_IN(LOG_NAS_EMM);
   int rc = RETURNerror;
   OAILOG_ERROR(LOG_NAS_EMM, "ATTACH - Security procedure failed!\n");
@@ -1317,7 +1317,7 @@ static int _emm_attach_failure_security_cb(emm_context_t* emm_context) {
       get_nas_specific_procedure_attach(emm_context);
 
   if (attach_proc) {
-    _emm_attach_release(emm_context);
+    emm_attach_release(emm_context);
   }
   OAILOG_FUNC_RETURN(LOG_NAS_EMM, rc);
 }
@@ -1415,8 +1415,8 @@ static int emm_attach_security_a(emm_context_t* emm_context) {
      * Initialize the security mode control procedure
      */
     rc = emm_proc_security_mode_control(
-        emm_context, &attach_proc->emm_spec_proc, attach_proc->ksi, _emm_attach,
-        _emm_attach_release);
+        emm_context, &attach_proc->emm_spec_proc, attach_proc->ksi, emm_attach,
+        emm_attach_release);
 
     if (rc != RETURNok) {
       /*
@@ -1473,7 +1473,7 @@ static int emm_attach_security_a(emm_context_t* emm_context) {
  *
  */
 //------------------------------------------------------------------------------
-static int _emm_attach(emm_context_t* emm_context) {
+static int emm_attach(emm_context_t* emm_context) {
   OAILOG_FUNC_IN(LOG_NAS_EMM);
   int rc = RETURNerror;
   mme_ue_s1ap_id_t ue_id =
@@ -1529,7 +1529,7 @@ static int _emm_attach(emm_context_t* emm_context) {
         rc = RETURNok;
       }
     } else {
-      rc = _emm_send_attach_accept(emm_context);
+      rc = emm_send_attach_accept(emm_context);
     }
   }
 
@@ -1572,7 +1572,7 @@ static int _emm_attach(emm_context_t* emm_context) {
  **                                                                        **
  ***************************************************************************/
 
-static void _encode_csfb_parameters_attach_accept(
+static void encode_csfb_parameters_attach_accept(
     emm_context_t* emm_ctx, emm_as_establish_t* establish_p) {
   OAILOG_FUNC_IN(LOG_NAS_EMM);
 
@@ -1630,7 +1630,7 @@ static void _encode_csfb_parameters_attach_accept(
 
 //------------------------------------------------------------------------------
 int emm_cn_wrapper_attach_accept(emm_context_t* emm_context) {
-  return _emm_send_attach_accept(emm_context);
+  return emm_send_attach_accept(emm_context);
 }
 
 /****************************************************************************
@@ -1647,7 +1647,7 @@ int emm_cn_wrapper_attach_accept(emm_context_t* emm_context) {
  **      Others:    T3450                                      **
  **                                                                        **
  ***************************************************************************/
-static int _emm_send_attach_accept(emm_context_t* emm_context) {
+static int emm_send_attach_accept(emm_context_t* emm_context) {
   OAILOG_FUNC_IN(LOG_NAS_EMM);
   int rc = RETURNerror;
 
@@ -1661,7 +1661,7 @@ static int _emm_send_attach_accept(emm_context_t* emm_context) {
     mme_ue_s1ap_id_t ue_id = ue_mm_context_p->mme_ue_s1ap_id;
 
     if (attach_proc) {
-      _emm_attach_update(emm_context, attach_proc->ies);
+      emm_attach_update(emm_context, attach_proc->ies);
       /*
        * Notify EMM-AS SAP that Attach Accept message together with an Activate
        * Default EPS Bearer Context Request message has to be sent to the UE
@@ -1812,7 +1812,7 @@ static int _emm_send_attach_accept(emm_context_t* emm_context) {
     emm_sap.u.emm_as.u.establish.t3402 = &mme_config.nas_config.t3402_min;
 
     // Encode CSFB parameters
-    _encode_csfb_parameters_attach_accept(
+    encode_csfb_parameters_attach_accept(
         emm_context, &emm_sap.u.emm_as.u.establish);
 
     REQUIREMENT_3GPP_24_301(R10_5_5_1_2_4__2);
@@ -1850,7 +1850,7 @@ static int _emm_send_attach_accept(emm_context_t* emm_context) {
  **                                                                        **
  ***************************************************************************/
 
-static void _encode_csfb_parameters_attach_accept_retx(
+static void encode_csfb_parameters_attach_accept_retx(
     emm_context_t* emm_ctx, emm_as_data_t* data_p) {
   OAILOG_FUNC_IN(LOG_NAS_EMM);
   ue_mm_context_t* ue_mm_context_p =
@@ -1893,7 +1893,7 @@ static void _encode_csfb_parameters_attach_accept_retx(
  **      Others:    T3450                                                  **
  **                                                                        **
  ***************************************************************************/
-static int _emm_attach_accept_retx(emm_context_t* emm_context) {
+static int emm_attach_accept_retx(emm_context_t* emm_context) {
   OAILOG_FUNC_IN(LOG_NAS_EMM);
   emm_sap_t emm_sap = {0};
   int rc            = RETURNerror;
@@ -1967,7 +1967,7 @@ static int _emm_attach_accept_retx(emm_context_t* emm_context) {
         blength(emm_sap.u.emm_as.u.data.nas_msg));
 
     // Encode CSFB parameters
-    _encode_csfb_parameters_attach_accept_retx(
+    encode_csfb_parameters_attach_accept_retx(
         emm_context, &emm_sap.u.emm_as.u.data);
 
     rc = emm_sap_send(&emm_sap);
@@ -2019,7 +2019,7 @@ static int _emm_attach_accept_retx(emm_context_t* emm_context) {
  *
  */
 //-----------------------------------------------------------------------------
-static bool _emm_attach_ies_have_changed(
+static bool emm_attach_ies_have_changed(
     mme_ue_s1ap_id_t ue_id, emm_attach_request_ies_t* const ies1,
     emm_attach_request_ies_t* const ies2) {
   OAILOG_FUNC_IN(LOG_NAS_EMM);
@@ -2375,7 +2375,7 @@ void free_emm_attach_request_ies(emm_attach_request_ies_t** const ies) {
 
  */
 //------------------------------------------------------------------------------
-static int _emm_attach_update(
+static int emm_attach_update(
     emm_context_t* const emm_context, emm_attach_request_ies_t* const ies) {
   OAILOG_FUNC_IN(LOG_NAS_EMM);
   /*
@@ -2507,14 +2507,14 @@ void proc_new_attach_req(struct ue_mm_context_s* ue_context_p) {
         VOICE_DOMAIN_PREF_UE_USAGE_SETTING;
   }
   if (!is_nas_specific_procedure_attach_running(&ue_mm_context->emm_context)) {
-    _emm_proc_create_procedure_attach_request(ue_mm_context, attach_info->ies);
+    emm_proc_create_procedure_attach_request(ue_mm_context, attach_info->ies);
   }
-  _emm_attach_run_procedure(&ue_mm_context->emm_context);
+  emm_attach_run_procedure(&ue_mm_context->emm_context);
   free_wrapper((void**) &ue_context_p->emm_context.new_attach_info);
   OAILOG_FUNC_OUT(LOG_NAS_EMM);
 }
 
-static void _create_new_attach_info(
+static void create_new_attach_info(
     emm_context_t* emm_context_p, mme_ue_s1ap_id_t mme_ue_s1ap_id,
     struct emm_attach_request_ies_s* ies, bool is_mm_ctx_new) {
   OAILOG_FUNC_IN(LOG_NAS_EMM);

--- a/lte/gateway/c/oai/tasks/nas/emm/Authentication.c
+++ b/lte/gateway/c/oai/tasks/nas/emm/Authentication.c
@@ -75,35 +75,35 @@
    --------------------------------------------------------------------------
 */
 // callbacks for authentication procedure
-static void _authentication_t3460_handler(void* args, imsi64_t* imsi64);
-static int _authentication_ll_failure(
+static void authentication_t3460_handler(void* args, imsi64_t* imsi64);
+static int authentication_ll_failure(
     struct emm_context_s* emm_context, struct nas_emm_proc_s* emm_proc);
-static int _authentication_non_delivered_ho(
+static int authentication_non_delivered_ho(
     struct emm_context_s* emm_context, struct nas_emm_proc_s* emm_proc);
-static int _authentication_abort(
+static int authentication_abort(
     struct emm_context_s* emm_context, struct nas_base_proc_s* base_proc);
 
-static int _start_authentication_information_procedure(
+static int start_authentication_information_procedure(
     struct emm_context_s* emm_context, nas_emm_auth_proc_t* const auth_proc,
     const_bstring auts);
-static int _auth_info_proc_success_cb(struct emm_context_s* emm_ctx);
-static int _auth_info_proc_failure_cb(struct emm_context_s* emm_ctx);
+static int auth_info_proc_success_cb(struct emm_context_s* emm_ctx);
+static int auth_info_proc_failure_cb(struct emm_context_s* emm_ctx);
 
-static int _authentication_check_imsi_5_4_2_5__1(
+static int authentication_check_imsi_5_4_2_5__1(
     struct emm_context_s* emm_context);
-static int _authentication_check_imsi_5_4_2_5__1_fail(
+static int authentication_check_imsi_5_4_2_5__1_fail(
     struct emm_context_s* emm_context);
-static int _authentication_request(
+static int authentication_request(
     struct emm_context_s* emm_ctx, nas_emm_auth_proc_t* auth_proc);
-static int _authentication_reject(
+static int authentication_reject(
     struct emm_context_s* emm_context, struct nas_base_proc_s* base_proc);
 
-static void _nas_itti_auth_info_req(
+static void nas_itti_auth_info_req(
     const mme_ue_s1ap_id_t ue_idP, const imsi_t* const imsiP,
     const bool is_initial_reqP, plmn_t* const visited_plmnP,
     const uint8_t num_vectorsP, const_bstring const auts_pP);
 
-static void _s6a_auth_info_rsp_timer_expiry_handler(
+static void s6a_auth_info_rsp_timer_expiry_handler(
     void* args, imsi64_t* imsi64);
 
 /****************************************************************************/
@@ -207,24 +207,24 @@ int emm_proc_authentication_ksi(
       auth_proc->emm_com_proc.emm_proc.previous_emm_fsm_state =
           emm_fsm_get_state(emm_context);
       auth_proc->emm_com_proc.emm_proc.not_delivered =
-          _authentication_ll_failure;
+          authentication_ll_failure;
       auth_proc->emm_com_proc.emm_proc.not_delivered_ho =
-          _authentication_non_delivered_ho;
+          authentication_non_delivered_ho;
       auth_proc->emm_com_proc.emm_proc.base_proc.success_notif = success;
       auth_proc->emm_com_proc.emm_proc.base_proc.failure_notif = failure;
-      auth_proc->emm_com_proc.emm_proc.base_proc.abort = _authentication_abort;
+      auth_proc->emm_com_proc.emm_proc.base_proc.abort = authentication_abort;
       auth_proc->emm_com_proc.emm_proc.base_proc.fail_in =
           NULL;  // only response
       auth_proc->emm_com_proc.emm_proc.base_proc.fail_out =
-          _authentication_reject;
+          authentication_reject;
       auth_proc->emm_com_proc.emm_proc.base_proc.time_out =
-          _authentication_t3460_handler;
+          authentication_t3460_handler;
     }
 
     /*
      * Send authentication request message to the UE
      */
-    rc = _authentication_request(emm_context, auth_proc);
+    rc = authentication_request(emm_context, auth_proc);
 
     if (rc != RETURNerror) {
       /*
@@ -278,10 +278,10 @@ int emm_proc_authentication(
     auth_proc->emm_com_proc.emm_proc.not_delivered_ho        = NULL;
     auth_proc->emm_com_proc.emm_proc.base_proc.success_notif = success;
     auth_proc->emm_com_proc.emm_proc.base_proc.failure_notif = failure;
-    auth_proc->emm_com_proc.emm_proc.base_proc.abort   = _authentication_abort;
+    auth_proc->emm_com_proc.emm_proc.base_proc.abort   = authentication_abort;
     auth_proc->emm_com_proc.emm_proc.base_proc.fail_in = NULL;  // only response
     auth_proc->emm_com_proc.emm_proc.base_proc.fail_out =
-        _authentication_reject;
+        authentication_reject;
     auth_proc->emm_com_proc.emm_proc.base_proc.time_out = NULL;
 
     bool run_auth_info_proc = false;
@@ -322,7 +322,7 @@ int emm_proc_authentication(
       }
     }
     if (run_auth_info_proc) {
-      rc = _start_authentication_information_procedure(
+      rc = start_authentication_information_procedure(
           emm_context, auth_proc, NULL);
     }
   }
@@ -331,7 +331,7 @@ int emm_proc_authentication(
 }
 
 //------------------------------------------------------------------------------
-static int _start_authentication_information_procedure(
+static int start_authentication_information_procedure(
     struct emm_context_s* emm_context, nas_emm_auth_proc_t* const auth_proc,
     const_bstring auts) {
   OAILOG_FUNC_IN(LOG_NAS_EMM);
@@ -350,10 +350,10 @@ static int _start_authentication_information_procedure(
       &auth_proc->emm_com_proc.emm_proc.base_proc;
   auth_proc->emm_com_proc.emm_proc.base_proc.child =
       &auth_info_proc->cn_proc.base_proc;
-  auth_info_proc->success_notif = _auth_info_proc_success_cb;
-  auth_info_proc->failure_notif = _auth_info_proc_failure_cb;
+  auth_info_proc->success_notif = auth_info_proc_success_cb;
+  auth_info_proc->failure_notif = auth_info_proc_failure_cb;
   auth_info_proc->cn_proc.base_proc.time_out =
-      _s6a_auth_info_rsp_timer_expiry_handler;
+      s6a_auth_info_rsp_timer_expiry_handler;
   auth_info_proc->ue_id  = ue_id;
   auth_info_proc->resync = auth_info_proc->request_sent;
 
@@ -366,7 +366,7 @@ static int _start_authentication_information_procedure(
       auth_info_proc->ue_id, &auth_info_proc->timer_s6a,
       auth_info_proc->cn_proc.base_proc.time_out, emm_context);
 
-  _nas_itti_auth_info_req(
+  nas_itti_auth_info_req(
       ue_id, &emm_context->_imsi, is_initial_req, &visited_plmn,
       MAX_EPS_AUTH_VECTORS, auts);
 
@@ -374,7 +374,7 @@ static int _start_authentication_information_procedure(
 }
 
 //------------------------------------------------------------------------------
-static int _start_authentication_information_procedure_synch(
+static int start_authentication_information_procedure_synch(
     struct emm_context_s* emm_context, nas_emm_auth_proc_t* const auth_proc,
     const_bstring auts) {
   OAILOG_FUNC_IN(LOG_NAS_EMM);
@@ -388,14 +388,14 @@ static int _start_authentication_information_procedure_synch(
   if (!auth_info_proc) {
     auth_info_proc               = nas_new_cn_auth_info_procedure(emm_context);
     auth_info_proc->request_sent = true;
-    _start_authentication_information_procedure(emm_context, auth_proc, auts);
+    start_authentication_information_procedure(emm_context, auth_proc, auts);
     OAILOG_FUNC_RETURN(LOG_NAS_EMM, RETURNok);
   }
   OAILOG_FUNC_RETURN(LOG_NAS_EMM, RETURNerror);
 }
 
 //------------------------------------------------------------------------------
-static int _auth_info_proc_success_cb(struct emm_context_s* emm_ctx) {
+static int auth_info_proc_success_cb(struct emm_context_s* emm_ctx) {
   OAILOG_FUNC_IN(LOG_NAS_EMM);
   nas_auth_info_proc_t* auth_info_proc =
       get_nas_cn_procedure_auth_info(emm_ctx);
@@ -543,7 +543,7 @@ static int _auth_info_proc_success_cb(struct emm_context_s* emm_ctx) {
 }
 
 //------------------------------------------------------------------------------
-static int _auth_info_proc_failure_cb(struct emm_context_s* emm_ctx) {
+static int auth_info_proc_failure_cb(struct emm_context_s* emm_ctx) {
   OAILOG_FUNC_IN(LOG_NAS_EMM);
   nas_auth_info_proc_t* auth_info_proc =
       get_nas_cn_procedure_auth_info(emm_ctx);
@@ -660,7 +660,7 @@ int emm_proc_authentication_failure(
               AUTS_LENGTH);
           // TODO: Double check this case as there is no identity request being
           // sent.
-          _start_authentication_information_procedure_synch(
+          start_authentication_information_procedure_synch(
               emm_ctx, auth_proc, &resync_param);
           free_wrapper((void**) &resync_param.data);
           emm_ctx_clear_auth_vectors(emm_ctx);
@@ -703,8 +703,8 @@ int emm_proc_authentication_failure(
             }
             rc = emm_proc_identification(
                 emm_ctx, &auth_proc->emm_com_proc.emm_proc,
-                IDENTITY_TYPE_2_IMSI, _authentication_check_imsi_5_4_2_5__1,
-                _authentication_check_imsi_5_4_2_5__1_fail);
+                IDENTITY_TYPE_2_IMSI, authentication_check_imsi_5_4_2_5__1,
+                authentication_check_imsi_5_4_2_5__1_fail);
           } else {
             rc = RETURNerror;
           }
@@ -793,8 +793,8 @@ int emm_proc_authentication_failure(
               sizeof(*auth_proc->unchecked_imsi));
           rc = emm_proc_identification(
               emm_ctx, &auth_proc->emm_com_proc.emm_proc, IDENTITY_TYPE_2_IMSI,
-              _authentication_check_imsi_5_4_2_5__1,
-              _authentication_check_imsi_5_4_2_5__1_fail);
+              authentication_check_imsi_5_4_2_5__1,
+              authentication_check_imsi_5_4_2_5__1_fail);
         }
         if (rc != RETURNok) {
           REQUIREMENT_3GPP_24_301(
@@ -913,8 +913,8 @@ int emm_proc_authentication_complete(
         REQUIREMENT_3GPP_24_301(R10_5_4_2_7_c__2);
         rc = emm_proc_identification(
             emm_ctx, &auth_proc->emm_com_proc.emm_proc, IDENTITY_TYPE_2_IMSI,
-            _authentication_check_imsi_5_4_2_5__1,
-            _authentication_check_imsi_5_4_2_5__1_fail);
+            authentication_check_imsi_5_4_2_5__1,
+            authentication_check_imsi_5_4_2_5__1_fail);
 
         if (rc != RETURNok) {
           REQUIREMENT_3GPP_24_301(
@@ -922,7 +922,7 @@ int emm_proc_authentication_complete(
           // Failed to initiate the identification procedure
           emm_ctx->emm_cause = EMM_CAUSE_ILLEGAL_UE;
           // Do not accept the UE to attach to the network
-          rc = _authentication_reject(emm_ctx, (nas_base_proc_t*) auth_proc);
+          rc = authentication_reject(emm_ctx, (nas_base_proc_t*) auth_proc);
         }
       } else {
         REQUIREMENT_3GPP_24_301(R10_5_4_2_5__2);
@@ -938,7 +938,7 @@ int emm_proc_authentication_complete(
             "ue_attach", 1, 2, "result", "failure", "cause",
             "authentication_xres_validation_failed");
         // Do not accept the UE to attach to the network
-        rc = _authentication_reject(emm_ctx, (nas_base_proc_t*) auth_proc);
+        rc = authentication_reject(emm_ctx, (nas_base_proc_t*) auth_proc);
       }
       OAILOG_FUNC_RETURN(LOG_NAS_EMM, rc);
     }
@@ -981,21 +981,21 @@ int emm_proc_authentication_complete(
  */
 
 void set_callbacks_for_auth_info_proc(nas_auth_info_proc_t* auth_info_proc) {
-  auth_info_proc->success_notif = _auth_info_proc_success_cb;
-  auth_info_proc->failure_notif = _auth_info_proc_failure_cb;
+  auth_info_proc->success_notif = auth_info_proc_success_cb;
+  auth_info_proc->failure_notif = auth_info_proc_failure_cb;
   auth_info_proc->cn_proc.base_proc.time_out =
-      _s6a_auth_info_rsp_timer_expiry_handler;
+      s6a_auth_info_rsp_timer_expiry_handler;
 }
 
 void set_callbacks_for_auth_proc(nas_emm_auth_proc_t* auth_proc) {
-  auth_proc->emm_com_proc.emm_proc.not_delivered = _authentication_ll_failure;
+  auth_proc->emm_com_proc.emm_proc.not_delivered = authentication_ll_failure;
   auth_proc->emm_com_proc.emm_proc.not_delivered_ho =
-      _authentication_non_delivered_ho;
-  auth_proc->emm_com_proc.emm_proc.base_proc.abort    = _authentication_abort;
+      authentication_non_delivered_ho;
+  auth_proc->emm_com_proc.emm_proc.base_proc.abort    = authentication_abort;
   auth_proc->emm_com_proc.emm_proc.base_proc.fail_in  = NULL;
-  auth_proc->emm_com_proc.emm_proc.base_proc.fail_out = _authentication_reject;
+  auth_proc->emm_com_proc.emm_proc.base_proc.fail_out = authentication_reject;
   auth_proc->emm_com_proc.emm_proc.base_proc.time_out =
-      _authentication_t3460_handler;
+      authentication_t3460_handler;
 }
 
 /****************************************************************************/
@@ -1029,7 +1029,7 @@ void set_callbacks_for_auth_proc(nas_emm_auth_proc_t* auth_proc) {
  **      Others:    None                                       **
  **                                                                        **
  ***************************************************************************/
-static void _authentication_t3460_handler(void* args, imsi64_t* imsi64) {
+static void authentication_t3460_handler(void* args, imsi64_t* imsi64) {
   OAILOG_FUNC_IN(LOG_NAS_EMM);
   emm_context_t* emm_ctx = (emm_context_t*) (args);
 
@@ -1062,7 +1062,7 @@ static void _authentication_t3460_handler(void* args, imsi64_t* imsi64) {
       /*
        * Send authentication request message to the UE
        */
-      _authentication_request(emm_ctx, auth_proc);
+      authentication_request(emm_ctx, auth_proc);
     } else {
       emm_context_t* emm_ctx = emm_context_get(&_emm_data, auth_proc->ue_id);
       /*
@@ -1104,7 +1104,7 @@ static void _authentication_t3460_handler(void* args, imsi64_t* imsi64) {
    --------------------------------------------------------------------------
 */
 
-static int _authentication_check_imsi_5_4_2_5__1(
+static int authentication_check_imsi_5_4_2_5__1(
     struct emm_context_s* emm_context) {
   int rc = RETURNerror;
 
@@ -1165,7 +1165,7 @@ static int _authentication_check_imsi_5_4_2_5__1(
 }
 
 //------------------------------------------------------------------------------
-static int _authentication_check_imsi_5_4_2_5__1_fail(
+static int authentication_check_imsi_5_4_2_5__1_fail(
     struct emm_context_s* emm_context) {
   int rc = RETURNerror;
   if (!(emm_context)) {
@@ -1204,7 +1204,7 @@ static int _authentication_check_imsi_5_4_2_5__1_fail(
  **      Return:    RETURNok, RETURNerror                      **
  **                                                                        **
  ***************************************************************************/
-static int _authentication_request(
+static int authentication_request(
     struct emm_context_s* emm_ctx, nas_emm_auth_proc_t* auth_proc) {
   OAILOG_FUNC_IN(LOG_NAS_EMM);
   int rc = RETURNerror;
@@ -1268,7 +1268,7 @@ static int _authentication_request(
  **      Others:    None                                       **
  **                                                                        **
  ***************************************************************************/
-static int _authentication_reject(
+static int authentication_reject(
     emm_context_t* emm_context, struct nas_base_proc_s* base_proc) {
   OAILOG_FUNC_IN(LOG_NAS_EMM);
   emm_sap_t emm_sap = {0};
@@ -1310,7 +1310,7 @@ static int _authentication_reject(
  **      Others:    T3460                                      **
  **                                                                        **
  ***************************************************************************/
-static int _authentication_ll_failure(
+static int authentication_ll_failure(
     struct emm_context_s* emm_context, struct nas_emm_proc_s* emm_proc) {
   OAILOG_FUNC_IN(LOG_NAS_EMM);
   int rc = RETURNerror;
@@ -1344,7 +1344,7 @@ static int _authentication_ll_failure(
  **      Return:    RETURNok, RETURNerror                                  **
  **                                                                        **
  ***************************************************************************/
-static int _authentication_non_delivered_ho(
+static int authentication_non_delivered_ho(
     struct emm_context_s* emm_ctx, struct nas_emm_proc_s* emm_proc) {
   OAILOG_FUNC_IN(LOG_NAS_EMM);
   int rc = RETURNerror;
@@ -1404,7 +1404,7 @@ static int _authentication_non_delivered_ho(
  **     Others: None
  **                                                                        **
  ***************************************************************************/
-static int _authentication_abort(
+static int authentication_abort(
     emm_context_t* emm_ctx, struct nas_base_proc_s* base_proc) {
   OAILOG_FUNC_IN(LOG_NAS_EMM);
   int rc = RETURNerror;
@@ -1449,7 +1449,7 @@ static int _authentication_abort(
  **     Return: None                                                       **
  **                                                                        **
  ***************************************************************************/
-static void _nas_itti_auth_info_req(
+static void nas_itti_auth_info_req(
     const mme_ue_s1ap_id_t ue_id, const imsi_t* const imsiP,
     const bool is_initial_reqP, plmn_t* const visited_plmnP,
     const uint8_t num_vectorsP, const_bstring const auts_pP) {
@@ -1516,7 +1516,7 @@ static void _nas_itti_auth_info_req(
  ** Inputs:  args:      handler parameters                             **
  **                                                                    **
  ************************************************************************/
-static void _s6a_auth_info_rsp_timer_expiry_handler(
+static void s6a_auth_info_rsp_timer_expiry_handler(
     void* args, imsi64_t* imsi64) {
   OAILOG_FUNC_IN(LOG_NAS_EMM);
   emm_context_t* emm_ctx = (emm_context_t*) (args);

--- a/lte/gateway/c/oai/tasks/nas/emm/Detach.c
+++ b/lte/gateway/c/oai/tasks/nas/emm/Detach.c
@@ -53,7 +53,7 @@
 /****************************************************************************/
 
 /* String representation of the detach type */
-static const char* _emm_detach_type_str[] = {"EPS",
+static const char* emm_detach_type_str[] = {"EPS",
                                              "IMSI",
                                              "EPS/IMSI",
                                              "RE-ATTACH REQUIRED",
@@ -61,7 +61,7 @@ static const char* _emm_detach_type_str[] = {"EPS",
                                              "RESERVED"};
 
 /* String representation of the sgs detach type */
-static const char* _emm_sgs_detach_type_str[] = {"EPS",
+static const char* emm_sgs_detach_type_str[] = {"EPS",
                                                  "UE-INITIATED-EXPLICIT-NONEPS",
                                                  "COMBINED",
                                                  "NW-INITIATED-EPS",
@@ -236,7 +236,7 @@ int emm_proc_detach(mme_ue_s1ap_id_t ue_id, emm_proc_detach_type_t type) {
 
   OAILOG_INFO(
       LOG_NAS_EMM, "EMM-PROC  - Initiate detach type = %s (%d)",
-      _emm_detach_type_str[type], type);
+      emm_detach_type_str[type], type);
   /*
    * TODO
    */
@@ -266,7 +266,7 @@ int emm_proc_sgs_detach_request(
       LOG_NAS_EMM,
       "EMM-PROC  - SGS Detach type = %s (%d) requested "
       "(ue_id=" MME_UE_S1AP_ID_FMT ") \n",
-      _emm_sgs_detach_type_str[sgs_detach_type], sgs_detach_type, ue_id);
+      emm_sgs_detach_type_str[sgs_detach_type], sgs_detach_type, ue_id);
   /*
    * Get the UE emm context
    */
@@ -333,7 +333,7 @@ int emm_proc_detach_request(
       LOG_NAS_EMM,
       "EMM-PROC  - Detach type = %s (%d) requested"
       " (ue_id=" MME_UE_S1AP_ID_FMT ")\n",
-      _emm_detach_type_str[params->type], params->type, ue_id);
+      emm_detach_type_str[params->type], params->type, ue_id);
   /*
    * Get the UE emm context
    */

--- a/lte/gateway/c/oai/tasks/nas/emm/EmmInformation.c
+++ b/lte/gateway/c/oai/tasks/nas/emm/EmmInformation.c
@@ -66,7 +66,7 @@
 /*********************  L O C A L    F U N C T I O N S  *********************/
 /****************************************************************************/
 
-static void _emm_information_pack_gsm_7Bit(bstring str, unsigned char* result);
+static void emm_information_pack_gsm_7Bit(bstring str, unsigned char* result);
 
 int emm_proc_emm_informtion(ue_mm_context_t* ue_emm_ctx) {
   int rc                    = RETURNerror;
@@ -93,13 +93,13 @@ int emm_proc_emm_informtion(ue_mm_context_t* ue_emm_ctx) {
    * The encoding is done referring to 3gpp 24.008
    * (section: 10.5.3.5a)and 23.038
    */
-  _emm_information_pack_gsm_7Bit(_emm_data.conf.full_network_name, result);
+  emm_information_pack_gsm_7Bit(_emm_data.conf.full_network_name, result);
   emm_as->full_network_name = bfromcstr((const char*) result);
   /*
    * Encode short_network_name with gsm 7 bit encoding
    */
   memset(result, 0, sizeof(result));
-  _emm_information_pack_gsm_7Bit(_emm_data.conf.short_network_name, result);
+  emm_information_pack_gsm_7Bit(_emm_data.conf.short_network_name, result);
   emm_as->short_network_name = bfromcstr((const char*) result);
 
   /*
@@ -116,7 +116,7 @@ int emm_proc_emm_informtion(ue_mm_context_t* ue_emm_ctx) {
   OAILOG_FUNC_RETURN(LOG_NAS_EMM, rc);
 }
 
-static void _emm_information_pack_gsm_7Bit(bstring str, unsigned char* result) {
+static void emm_information_pack_gsm_7Bit(bstring str, unsigned char* result) {
   OAILOG_FUNC_IN(LOG_NAS_EMM);
   int encIdx = 0;
   int len, i = 0, j = 0;

--- a/lte/gateway/c/oai/tasks/nas/emm/Identification.c
+++ b/lte/gateway/c/oai/tasks/nas/emm/Identification.c
@@ -52,19 +52,19 @@ extern int check_plmn_restriction(imsi_t imsi);
 /****************************************************************************/
 
 /* String representation of the requested identity type */
-static const char* _emm_identity_type_str[] = {"NOT AVAILABLE", "IMSI", "IMEI",
+static const char* emm_identity_type_str[] = {"NOT AVAILABLE", "IMSI", "IMEI",
                                                "IMEISV", "TMSI"};
 
 // callbacks for identification procedure
-static void _identification_t3470_handler(void* args, imsi64_t* imsi64);
-static int _identification_ll_failure(
+static void identification_t3470_handler(void* args, imsi64_t* imsi64);
+static int identification_ll_failure(
     struct emm_context_s* emm_context, struct nas_emm_proc_s* emm_proc);
-static int _identification_non_delivered_ho(
+static int identification_non_delivered_ho(
     struct emm_context_s* emm_context, struct nas_emm_proc_s* emm_proc);
-static int _identification_abort(
+static int identification_abort(
     struct emm_context_s* emm_context, struct nas_base_proc_s* base_proc);
 
-static int _identification_request(nas_emm_ident_proc_t* const proc);
+static int identification_request(nas_emm_ident_proc_t* const proc);
 
 /****************************************************************************/
 /******************  E X P O R T E D    F U N C T I O N S  ******************/
@@ -120,7 +120,7 @@ int emm_proc_identification(
     OAILOG_INFO(
         LOG_NAS_EMM,
         "EMM-PROC  - Initiate identification type = %s (%d), ctx = %p\n",
-        _emm_identity_type_str[type], type, emm_context);
+        emm_identity_type_str[type], type, emm_context);
 
     nas_emm_ident_proc_t* ident_proc =
         nas_new_identification_procedure(emm_context);
@@ -140,19 +140,19 @@ int emm_proc_identification(
       ident_proc->emm_com_proc.emm_proc.previous_emm_fsm_state =
           emm_fsm_get_state(emm_context);
       ident_proc->emm_com_proc.emm_proc.not_delivered =
-          _identification_ll_failure;
+          identification_ll_failure;
       ident_proc->emm_com_proc.emm_proc.not_delivered_ho =
-          _identification_non_delivered_ho;
+          identification_non_delivered_ho;
       ident_proc->emm_com_proc.emm_proc.base_proc.success_notif = success;
       ident_proc->emm_com_proc.emm_proc.base_proc.failure_notif = failure;
-      ident_proc->emm_com_proc.emm_proc.base_proc.abort = _identification_abort;
+      ident_proc->emm_com_proc.emm_proc.base_proc.abort = identification_abort;
       ident_proc->emm_com_proc.emm_proc.base_proc.fail_in =
           NULL;  // only response
       ident_proc->emm_com_proc.emm_proc.base_proc.time_out =
-          _identification_t3470_handler;
+          identification_t3470_handler;
     }
 
-    rc = _identification_request(ident_proc);
+    rc = identification_request(ident_proc);
 
     if (rc != RETURNerror) {
       /*
@@ -307,7 +307,7 @@ int emm_proc_identification_complete(
  **      Others:    None                                       **
  **                                                                        **
  ***************************************************************************/
-static void _identification_t3470_handler(void* args, imsi64_t* imsi64) {
+static void identification_t3470_handler(void* args, imsi64_t* imsi64) {
   OAILOG_FUNC_IN(LOG_NAS_EMM);
   emm_context_t* emm_ctx = (emm_context_t*) (args);
 
@@ -341,7 +341,7 @@ static void _identification_t3470_handler(void* args, imsi64_t* imsi64) {
       /*
        * Send identity request message to the UE
        */
-      _identification_request(ident_proc);
+      identification_request(ident_proc);
     } else {
       /*
        * Abort the identification procedure
@@ -393,7 +393,7 @@ static void _identification_t3470_handler(void* args, imsi64_t* imsi64) {
  *      Return:    None
  *      Others:    T3470
  */
-static int _identification_request(nas_emm_ident_proc_t* const proc) {
+static int identification_request(nas_emm_ident_proc_t* const proc) {
   OAILOG_FUNC_IN(LOG_NAS_EMM);
   emm_sap_t emm_sap             = {0};
   int rc                        = RETURNok;
@@ -439,7 +439,7 @@ static int _identification_request(nas_emm_ident_proc_t* const proc) {
 }
 
 //------------------------------------------------------------------------------
-static int _identification_ll_failure(
+static int identification_ll_failure(
     struct emm_context_s* emm_ctx, struct nas_emm_proc_s* emm_proc) {
   OAILOG_FUNC_IN(LOG_NAS_EMM);
   int rc = RETURNerror;
@@ -458,7 +458,7 @@ static int _identification_ll_failure(
 }
 
 //------------------------------------------------------------------------------
-static int _identification_non_delivered_ho(
+static int identification_non_delivered_ho(
     struct emm_context_s* emm_ctx, struct nas_emm_proc_s* emm_proc) {
   OAILOG_FUNC_IN(LOG_NAS_EMM);
   int rc = RETURNerror;
@@ -513,7 +513,7 @@ static int _identification_non_delivered_ho(
  *      Return:    None
  *      Others:    T3470
  */
-static int _identification_abort(
+static int identification_abort(
     struct emm_context_s* emm_context, struct nas_base_proc_s* base_proc) {
   OAILOG_FUNC_IN(LOG_NAS_EMM);
   int rc = RETURNerror;

--- a/lte/gateway/c/oai/tasks/nas/emm/SecurityModeControl.c
+++ b/lte/gateway/c/oai/tasks/nas/emm/SecurityModeControl.c
@@ -98,10 +98,10 @@
 /*
    Timer handlers
 */
-static void _security_t3460_handler(void*, imsi64_t* imsi64);
-static int _security_ll_failure(
+static void security_t3460_handler(void*, imsi64_t* imsi64);
+static int security_ll_failure(
     emm_context_t* emm_context, struct nas_emm_proc_s* nas_emm_proc);
-static int _security_non_delivered_ho(
+static int security_non_delivered_ho(
     emm_context_t* emm_context, struct nas_emm_proc_s* nas_emm_proc);
 
 /*
@@ -109,13 +109,13 @@ static int _security_non_delivered_ho(
    the security mode control procedure is aborted or the maximum value of the
    retransmission timer counter is exceed
 */
-static int _security_abort(
+static int security_abort(
     emm_context_t* emm_context, struct nas_base_proc_s* base_proc);
-static int _security_select_algorithms(
+static int security_select_algorithms(
     const int ue_eiaP, const int ue_eeaP, int* const mme_eiaP,
     int* const mme_eeaP);
 
-static int _security_request(nas_emm_smc_proc_t* const smc_proc);
+static int security_request(nas_emm_smc_proc_t* const smc_proc);
 
 /****************************************************************************/
 /******************  E X P O R T E D    F U N C T I O N S  ******************/
@@ -228,7 +228,7 @@ int emm_proc_security_mode_control(
        *  Compute NAS cyphering and integrity keys
        */
 
-      rc = _security_select_algorithms(
+      rc = security_select_algorithms(
           emm_ctx->_ue_network_capability.eia,
           emm_ctx->_ue_network_capability.eea, &mme_eia, &mme_eea);
       emm_ctx->_security.selected_algorithms.encryption = mme_eea;
@@ -273,16 +273,16 @@ int emm_proc_security_mode_control(
     smc_proc->emm_com_proc.emm_proc.delivered = NULL;
     smc_proc->emm_com_proc.emm_proc.previous_emm_fsm_state =
         emm_fsm_get_state(emm_ctx);
-    smc_proc->emm_com_proc.emm_proc.not_delivered = _security_ll_failure;
+    smc_proc->emm_com_proc.emm_proc.not_delivered = security_ll_failure;
     smc_proc->emm_com_proc.emm_proc.not_delivered_ho =
-        _security_non_delivered_ho;
+        security_non_delivered_ho;
     smc_proc->emm_com_proc.emm_proc.base_proc.success_notif = success;
     smc_proc->emm_com_proc.emm_proc.base_proc.failure_notif = failure;
-    smc_proc->emm_com_proc.emm_proc.base_proc.abort         = _security_abort;
+    smc_proc->emm_com_proc.emm_proc.base_proc.abort         = security_abort;
     smc_proc->emm_com_proc.emm_proc.base_proc.fail_in  = NULL;  // only response
     smc_proc->emm_com_proc.emm_proc.base_proc.fail_out = NULL;
     smc_proc->emm_com_proc.emm_proc.base_proc.time_out =
-        _security_t3460_handler;
+        security_t3460_handler;
 
     /*
      * Set the UE identifier
@@ -355,7 +355,7 @@ int emm_proc_security_mode_control(
     /*
      * Send security mode command message to the UE
      */
-    rc = _security_request(smc_proc);
+    rc = security_request(smc_proc);
 
     if (rc != RETURNerror) {
       /*
@@ -584,12 +584,12 @@ int emm_proc_security_mode_reject(mme_ue_s1ap_id_t ue_id) {
  */
 
 void set_callbacks_for_smc_proc(nas_emm_smc_proc_t* smc_proc) {
-  smc_proc->emm_com_proc.emm_proc.not_delivered    = _security_ll_failure;
-  smc_proc->emm_com_proc.emm_proc.not_delivered_ho = _security_non_delivered_ho;
-  smc_proc->emm_com_proc.emm_proc.base_proc.abort  = _security_abort;
+  smc_proc->emm_com_proc.emm_proc.not_delivered    = security_ll_failure;
+  smc_proc->emm_com_proc.emm_proc.not_delivered_ho = security_non_delivered_ho;
+  smc_proc->emm_com_proc.emm_proc.base_proc.abort  = security_abort;
   smc_proc->emm_com_proc.emm_proc.base_proc.fail_in  = NULL;
   smc_proc->emm_com_proc.emm_proc.base_proc.fail_out = NULL;
-  smc_proc->emm_com_proc.emm_proc.base_proc.time_out = _security_t3460_handler;
+  smc_proc->emm_com_proc.emm_proc.base_proc.time_out = security_t3460_handler;
 }
 
 /****************************************************************************/
@@ -622,7 +622,7 @@ void set_callbacks_for_smc_proc(nas_emm_smc_proc_t* smc_proc) {
  **      Others:    None                                       **
  **                                                                        **
  ***************************************************************************/
-static void _security_t3460_handler(void* args, imsi64_t* imsi64) {
+static void security_t3460_handler(void* args, imsi64_t* imsi64) {
   OAILOG_FUNC_IN(LOG_NAS_EMM);
   emm_context_t* emm_ctx = (emm_context_t*) (args);
 
@@ -648,7 +648,7 @@ static void _security_t3460_handler(void* args, imsi64_t* imsi64) {
       /*
        * Send security mode command message to the UE
        */
-      _security_request(smc_proc);
+      security_request(smc_proc);
     } else {
       REQUIREMENT_3GPP_24_301(R10_5_4_3_7_b__2);
       /*
@@ -659,7 +659,7 @@ static void _security_t3460_handler(void* args, imsi64_t* imsi64) {
       increment_counter(
           "ue_attach", 1, 2, "result", "failure", "cause",
           "no_response_for_security_mode_command");
-      _security_abort(emm_ctx, (struct nas_base_proc_s*) smc_proc);
+      security_abort(emm_ctx, (struct nas_base_proc_s*) smc_proc);
       emm_common_cleanup_by_ueid(smc_proc->ue_id);
       emm_sap_t emm_sap = {0};
       emm_sap.primitive = EMMCN_IMPLICIT_DETACH_UE;
@@ -693,7 +693,7 @@ static void _security_t3460_handler(void* args, imsi64_t* imsi64) {
  **      Others:    T3460                                      **
  **                                                                        **
  ***************************************************************************/
-static int _security_request(nas_emm_smc_proc_t* const smc_proc) {
+static int security_request(nas_emm_smc_proc_t* const smc_proc) {
   OAILOG_FUNC_IN(LOG_NAS_EMM);
   ue_mm_context_t* ue_mm_context = NULL;
   struct emm_context_s* emm_ctx  = NULL;
@@ -764,7 +764,7 @@ static int _security_request(nas_emm_smc_proc_t* const smc_proc) {
 }
 
 //------------------------------------------------------------------------------
-static int _security_ll_failure(
+static int security_ll_failure(
     emm_context_t* emm_context, struct nas_emm_proc_s* nas_emm_proc) {
   OAILOG_FUNC_IN(LOG_NAS_EMM);
   int rc = RETURNerror;
@@ -790,7 +790,7 @@ static int _security_ll_failure(
 }
 
 //------------------------------------------------------------------------------
-static int _security_non_delivered_ho(
+static int security_non_delivered_ho(
     emm_context_t* emm_ctx, struct nas_emm_proc_s* nas_emm_proc) {
   OAILOG_FUNC_IN(LOG_NAS_EMM);
   int rc = RETURNerror;
@@ -810,7 +810,7 @@ static int _security_non_delivered_ho(
      */
     nas_emm_smc_proc_t* smc_proc = (nas_emm_smc_proc_t*) nas_emm_proc;
     smc_proc->is_new             = false;
-    _security_abort(emm_ctx, (struct nas_base_proc_s*) smc_proc);
+    security_abort(emm_ctx, (struct nas_base_proc_s*) smc_proc);
     emm_common_cleanup_by_ueid(smc_proc->ue_id);
     // Clean up MME APP UE context
     emm_sap_t emm_sap                               = {0};
@@ -836,7 +836,7 @@ static int _security_non_delivered_ho(
  **      Return:    RETURNok, RETURNerror                                  **
  **                                                                        **
  ***************************************************************************/
-static int _security_abort(
+static int security_abort(
     emm_context_t* emm_ctx, struct nas_base_proc_s* base_proc) {
   OAILOG_FUNC_IN(LOG_NAS_EMM);
   int rc = RETURNerror;
@@ -886,7 +886,7 @@ static int _security_abort(
  **      Others:    None                                                   **
  **                                                                        **
  ***************************************************************************/
-static int _security_select_algorithms(
+static int security_select_algorithms(
     const int ue_eiaP, const int ue_eeaP, int* const mme_eiaP,
     int* const mme_eeaP) {
   OAILOG_FUNC_IN(LOG_NAS_EMM);

--- a/lte/gateway/c/oai/tasks/nas/emm/ServiceRequestHdl.c
+++ b/lte/gateway/c/oai/tasks/nas/emm/ServiceRequestHdl.c
@@ -52,9 +52,9 @@
 /****************************************************************************/
 /*******************  L O C A L    D E F I N I T I O N S  *******************/
 /****************************************************************************/
-static int _emm_service_reject(mme_ue_s1ap_id_t ue_id, uint8_t emm_cause);
+static int emm_service_reject(mme_ue_s1ap_id_t ue_id, uint8_t emm_cause);
 
-static int _check_paging_received_without_lai(mme_ue_s1ap_id_t ue_id);
+static int check_paging_received_without_lai(mme_ue_s1ap_id_t ue_id);
 /*
    --------------------------------------------------------------------------
     Internal data handled by the service request procedure in the UE
@@ -74,7 +74,7 @@ int emm_proc_service_reject(
     const mme_ue_s1ap_id_t ue_id, const uint8_t emm_cause) {
   int rc = RETURNok;
   OAILOG_FUNC_IN(LOG_NAS_EMM);
-  rc = _emm_service_reject(ue_id, emm_cause);
+  rc = emm_service_reject(ue_id, emm_cause);
   OAILOG_FUNC_RETURN(LOG_NAS_EMM, rc);
 }
 /****************************************************************************/
@@ -85,7 +85,7 @@ int emm_proc_service_reject(
      @param [in]args UE EMM context data
      @returns status of operation
 */
-static int _emm_service_reject(mme_ue_s1ap_id_t ue_id, uint8_t emm_cause)
+static int emm_service_reject(mme_ue_s1ap_id_t ue_id, uint8_t emm_cause)
 
 {
   int rc = RETURNerror;
@@ -282,7 +282,7 @@ int emm_recv_initial_ext_service_request(
   /* Check cs paging procedure initiated without LAI
    * If cs paging initiated without LAI, On reception of Extended service
    * request procedure send Detach Request ( IMSI Detach) to UE */
-  if (_check_paging_received_without_lai(ue_id)) {
+  if (check_paging_received_without_lai(ue_id)) {
     emm_sap.primitive = EMMCN_NW_INITIATED_DETACH_UE;
     emm_sap.u.emm_cn.u.emm_cn_nw_initiated_detach.ue_id = ue_id;
     emm_sap.u.emm_cn.u.emm_cn_nw_initiated_detach.detach_type =
@@ -311,7 +311,7 @@ int emm_recv_initial_ext_service_request(
   OAILOG_FUNC_RETURN(LOG_NAS_EMM, rc);
 }
 
-static int _check_paging_received_without_lai(mme_ue_s1ap_id_t ue_id) {
+static int check_paging_received_without_lai(mme_ue_s1ap_id_t ue_id) {
   ue_mm_context_t* ue_context = NULL;
   OAILOG_FUNC_IN(LOG_NAS_EMM);
   ue_context = mme_ue_context_exists_mme_ue_s1ap_id(ue_id);

--- a/lte/gateway/c/oai/tasks/nas/emm/TrackingAreaUpdate.c
+++ b/lte/gateway/c/oai/tasks/nas/emm/TrackingAreaUpdate.c
@@ -72,18 +72,18 @@
  * Other aspects of TAU are TODOs for future.
  */
 
-static int _emm_tracking_area_update_reject(
+static int emm_tracking_area_update_reject(
     const mme_ue_s1ap_id_t ue_id, const int emm_cause);
-static int _emm_tracking_area_update_accept(nas_emm_tau_proc_t* const tau_proc);
-static int _emm_tracking_area_update_abort(
+static int emm_tracking_area_update_accept(nas_emm_tau_proc_t* const tau_proc);
+static int emm_tracking_area_update_abort(
     struct emm_context_s* emm_context, struct nas_base_proc_s* base_proc);
-static void _emm_tracking_area_update_t3450_handler(
+static void emm_tracking_area_update_t3450_handler(
     void* args, imsi64_t* imsi64);
 
-static nas_emm_tau_proc_t* _emm_proc_create_procedure_tau(
+static nas_emm_tau_proc_t* emm_proc_create_procedure_tau(
     ue_mm_context_t* const ue_mm_context, emm_tau_request_ies_t* const ies);
 
-static int _send_tau_accept_and_check_for_neaf_flag(
+static int send_tau_accept_and_check_for_neaf_flag(
     nas_emm_tau_proc_t* tau_proc, ue_mm_context_t* ue_mm_context);
 /****************************************************************************/
 /******************  E X P O R T E D    F U N C T I O N S  ******************/
@@ -92,7 +92,7 @@ static int _send_tau_accept_and_check_for_neaf_flag(
 int emm_proc_tracking_area_update_accept(nas_emm_tau_proc_t* const tau_proc) {
   int rc = RETURNerror;
   OAILOG_FUNC_IN(LOG_NAS_EMM);
-  rc = _emm_tracking_area_update_accept(tau_proc);
+  rc = emm_tracking_area_update_accept(tau_proc);
   OAILOG_FUNC_RETURN(LOG_NAS_EMM, rc);
 }
 
@@ -108,7 +108,7 @@ int emm_proc_tracking_area_update_accept(nas_emm_tau_proc_t* const tau_proc) {
  ** Outputs: Return:    RETURNok, RETURNerror                              **
  **                                                                        **
  ***************************************************************************/
-int _csfb_handle_tracking_area_req(
+int csfb_handle_tracking_area_req(
     emm_context_t* emm_context_p, emm_tau_request_ies_t* ies) {
   OAILOG_FUNC_IN(LOG_NAS_EMM);
   ue_mm_context_t* ue_mm_context = NULL;
@@ -146,7 +146,7 @@ int _csfb_handle_tracking_area_req(
     nas_emm_tau_proc_t* tau_proc =
         get_nas_specific_procedure_tau(emm_context_p);
     if (!tau_proc) {
-      tau_proc = _emm_proc_create_procedure_tau(ue_mm_context, ies);
+      tau_proc = emm_proc_create_procedure_tau(ue_mm_context, ies);
       if (ue_mm_context->sgs_context &&
           ((emm_context_p->tau_updt_type ==
             EPS_UPDATE_TYPE_COMBINED_TA_LA_UPDATING) ||
@@ -160,7 +160,7 @@ int _csfb_handle_tracking_area_req(
            * associated state and vlr_reliable flag is true
            * Send TAU accept to UE
            */
-          _send_tau_accept_and_check_for_neaf_flag(tau_proc, ue_mm_context);
+          send_tau_accept_and_check_for_neaf_flag(tau_proc, ue_mm_context);
           OAILOG_FUNC_RETURN(LOG_NAS_EMM, RETURNok);
         } else {
           if ((mme_app_handle_nas_cs_domain_location_update_req(
@@ -213,7 +213,7 @@ int emm_proc_tracking_area_update_request(
         OAILOG_DEBUG(LOG_NAS_EMM, "EMM-PROC-  GUTI Context found\n");
       } else {
         // NO S10
-        rc = _emm_tracking_area_update_reject(
+        rc = emm_tracking_area_update_reject(
             ue_id, EMM_CAUSE_IMPLICITLY_DETACHED);
         increment_counter(
             "tracking_area_update_req", 1, 2, "result", "failure", "cause",
@@ -244,7 +244,7 @@ int emm_proc_tracking_area_update_request(
    */
   if ((_esm_data.conf.features & MME_API_CSFB_SMS_SUPPORTED) ||
       (_esm_data.conf.features & MME_API_SMS_SUPPORTED)) {
-    if ((_csfb_handle_tracking_area_req(emm_context, ies)) == RETURNok) {
+    if ((csfb_handle_tracking_area_req(emm_context, ies)) == RETURNok) {
       OAILOG_FUNC_RETURN(LOG_NAS_EMM, RETURNok);
     }
   }
@@ -264,7 +264,7 @@ int emm_proc_tracking_area_update_request(
         "EMM-PROC- Sending Tracking Area Update Reject. "
         "ue_id=" MME_UE_S1AP_ID_FMT ", cause=%d)\n",
         ue_id, EMM_CAUSE_IE_NOT_IMPLEMENTED);
-    rc = _emm_tracking_area_update_reject(ue_id, EMM_CAUSE_IE_NOT_IMPLEMENTED);
+    rc = emm_tracking_area_update_reject(ue_id, EMM_CAUSE_IE_NOT_IMPLEMENTED);
     increment_counter(
         "tracking_area_update_req", 1, 2, "result", "failure", "cause",
         "normal_tau_not_supported");
@@ -339,7 +339,7 @@ int emm_proc_tracking_area_update_request(
     // Handle periodic TAU
     nas_emm_tau_proc_t* tau_proc = get_nas_specific_procedure_tau(emm_context);
     if (!tau_proc) {
-      tau_proc = _emm_proc_create_procedure_tau(ue_mm_context, ies);
+      tau_proc = emm_proc_create_procedure_tau(ue_mm_context, ies);
       if (tau_proc) {
         // Store the received voice domain pref & UE usage setting IE
         if (ies->voicedomainpreferenceandueusagesetting) {
@@ -349,7 +349,7 @@ int emm_proc_tracking_area_update_request(
               ies->voicedomainpreferenceandueusagesetting,
               sizeof(voice_domain_preference_and_ue_usage_setting_t));
         }
-        rc = _emm_tracking_area_update_accept(tau_proc);
+        rc = emm_tracking_area_update_accept(tau_proc);
         if (rc != RETURNok) {
           OAILOG_ERROR(
               LOG_NAS_EMM,
@@ -393,7 +393,7 @@ int emm_proc_tracking_area_update_reject(
     const mme_ue_s1ap_id_t ue_id, const int emm_cause) {
   int rc = RETURNerror;
   OAILOG_FUNC_IN(LOG_NAS_EMM);
-  rc = _emm_tracking_area_update_reject(ue_id, emm_cause);
+  rc = emm_tracking_area_update_reject(ue_id, emm_cause);
   OAILOG_FUNC_RETURN(LOG_NAS_EMM, rc);
 }
 
@@ -426,7 +426,7 @@ described for case a above.
 @param [in]args TAU accept data
 */
 //------------------------------------------------------------------------------
-static void _emm_tracking_area_update_t3450_handler(
+static void emm_tracking_area_update_t3450_handler(
     void* args, imsi64_t* imsi64) {
   OAILOG_FUNC_IN(LOG_NAS_EMM);
   emm_context_t* emm_context = (emm_context_t*) (args);
@@ -457,7 +457,7 @@ static void _emm_tracking_area_update_t3450_handler(
       /*
        * Send attach accept message to the UE
        */
-      _emm_tracking_area_update_accept(tau_proc);
+      emm_tracking_area_update_accept(tau_proc);
     } else {
       /*
        * Abort the attach procedure
@@ -500,7 +500,7 @@ static int _emm_tracking_area_update_security (emm_context_t * emm_context)
      @returns status of operation
 */
 //------------------------------------------------------------------------------
-static int _emm_tracking_area_update_reject(
+static int emm_tracking_area_update_reject(
     const mme_ue_s1ap_id_t ue_id, const int emm_cause)
 
 {
@@ -557,7 +557,7 @@ static int _emm_tracking_area_update_reject(
 
 //------------------------------------------------------------------------------
 
-static int _build_csfb_parameters_combined_tau(
+static int build_csfb_parameters_combined_tau(
     emm_context_t* emm_ctx, emm_as_establish_t* establish) {
   OAILOG_FUNC_IN(LOG_NAS_EMM);
 
@@ -599,7 +599,7 @@ static int _build_csfb_parameters_combined_tau(
      @returns status of operation (RETURNok, RETURNerror)
 */
 //------------------------------------------------------------------------------
-static int _emm_tracking_area_update_accept(
+static int emm_tracking_area_update_accept(
     nas_emm_tau_proc_t* const tau_proc) {
   OAILOG_FUNC_IN(LOG_NAS_EMM);
   int rc                         = RETURNerror;
@@ -668,7 +668,7 @@ static int _emm_tracking_area_update_accept(
           (_esm_data.conf.features & MME_API_SMS_SUPPORTED)) {
         OAILOG_INFO(
             LOG_NAS_EMM, "Encoding _build_csfb_parameters_combined_tau\n");
-        if (_build_csfb_parameters_combined_tau(
+        if (build_csfb_parameters_combined_tau(
                 emm_context, &emm_sap.u.emm_as.u.establish) == RETURNerror) {
           OAILOG_ERROR(
               LOG_NAS_EMM,
@@ -827,7 +827,7 @@ static int _emm_tracking_area_update_accept(
 }
 
 //------------------------------------------------------------------------------
-static int _emm_tracking_area_update_abort(
+static int emm_tracking_area_update_abort(
     struct emm_context_s* emm_context, struct nas_base_proc_s* base_proc) {
   OAILOG_FUNC_IN(LOG_NAS_EMM);
   int rc = RETURNerror;
@@ -981,7 +981,7 @@ int emm_proc_tau_complete(mme_ue_s1ap_id_t ue_id) {
   OAILOG_FUNC_RETURN(LOG_NAS_EMM, RETURNok);
 }
 
-static nas_emm_tau_proc_t* _emm_proc_create_procedure_tau(
+static nas_emm_tau_proc_t* emm_proc_create_procedure_tau(
     ue_mm_context_t* const ue_mm_context, emm_tau_request_ies_t* const ies) {
   OAILOG_FUNC_IN(LOG_NAS_EMM);
 
@@ -992,11 +992,11 @@ static nas_emm_tau_proc_t* _emm_proc_create_procedure_tau(
     tau_proc->ies   = ies;
     tau_proc->ue_id = ue_mm_context->mme_ue_s1ap_id;
     tau_proc->emm_spec_proc.emm_proc.base_proc.abort =
-        _emm_tracking_area_update_abort;
+        emm_tracking_area_update_abort;
     tau_proc->emm_spec_proc.emm_proc.base_proc.fail_in =
         NULL;  // No parent procedure
     tau_proc->emm_spec_proc.emm_proc.base_proc.time_out =
-        _emm_tracking_area_update_t3450_handler;
+        emm_tracking_area_update_t3450_handler;
     tau_proc->emm_spec_proc.emm_proc.base_proc.fail_out = NULL;
     OAILOG_FUNC_RETURN(LOG_NAS_EMM, tau_proc);
   }
@@ -1015,7 +1015,7 @@ static nas_emm_tau_proc_t* _emm_proc_create_procedure_tau(
  ** Outputs: Return:    RETURNok, RETURNerror                              **
  **                                                                        **
  ***************************************************************************/
-static int _send_tau_accept_and_check_for_neaf_flag(
+static int send_tau_accept_and_check_for_neaf_flag(
     nas_emm_tau_proc_t* tau_proc, ue_mm_context_t* ue_context) {
   OAILOG_FUNC_IN(LOG_NAS_EMM);
   if ((emm_proc_tracking_area_update_accept(tau_proc)) == RETURNerror) {

--- a/lte/gateway/c/oai/tasks/nas/emm/sap/emm_as.c
+++ b/lte/gateway/c/oai/tasks/nas/emm/sap/emm_as.c
@@ -105,7 +105,7 @@ static int _emm_as_encrypt(
     const unsigned char* buffer, size_t length,
     emm_security_context_t* emm_security_context);
 
-static int _emm_as_send(const emm_as_t* msg);
+static int emm_as_send_a(const emm_as_t* msg);
 static int _emm_as_security_req(
     const emm_as_security_t*, dl_info_transfer_req_t*);
 static int _emm_as_security_rej(
@@ -195,7 +195,7 @@ int emm_as_send(emm_as_t* msg) {
       /*
        * Other primitives are forwarded to lower layers (S1AP)
        */
-      rc = _emm_as_send(msg);
+      rc = emm_as_send_a(msg);
 
       if (rc != RETURNok) {
         OAILOG_ERROR(
@@ -1159,7 +1159,7 @@ static int _emm_as_encrypt(
 
 /****************************************************************************
  **                                                                        **
- ** Name:    _emm_as_send()                                            **
+ ** Name:    emm_as_send_a()                                            **
  **                                                                        **
  ** Description: Builds NAS message according to the given EMMAS Service   **
  **      Access Point primitive and sends it to the Access Stratum **
@@ -1173,7 +1173,7 @@ static int _emm_as_encrypt(
  **      Others:    None                                       **
  **                                                                        **
  ***************************************************************************/
-static int _emm_as_send(const emm_as_t* msg) {
+static int emm_as_send_a(const emm_as_t* msg) {
   OAILOG_FUNC_IN(LOG_NAS_EMM);
   as_message_t as_msg = {0};
 

--- a/lte/gateway/c/oai/tasks/nas/emm/sap/emm_as.c
+++ b/lte/gateway/c/oai/tasks/nas/emm/sap/emm_as.c
@@ -66,7 +66,7 @@
 /*
    String representation of EMMAS-SAP primitives
 */
-static const char* _emm_as_primitive_str[] = {
+static const char* emm_as_primitive_str[] = {
     "EMMAS_SECURITY_REQ",   "EMMAS_SECURITY_IND",   "EMMAS_SECURITY_RES",
     "EMMAS_SECURITY_REJ",   "EMMAS_ESTABLISH_REQ",  "EMMAS_ESTABLISH_CNF",
     "EMMAS_ESTABLISH_REJ",  "EMMAS_RELEASE_REQ",    "EMMAS_RELEASE_IND",
@@ -79,48 +79,48 @@ static const char* _emm_as_primitive_str[] = {
    Functions executed to process EMM procedures upon receiving
    data from the network
 */
-static int _emm_as_recv(
+static int emm_as_recv(
     mme_ue_s1ap_id_t ue_id, tai_t const* originating_tai,
     ecgi_t const* originating_ecgi, bstring msg, size_t len, int* emm_cause,
     nas_message_decode_status_t* decode_status);
 
-static int _emm_as_establish_req(emm_as_establish_t* msg, int* emm_cause);
-static int _emm_as_data_ind(emm_as_data_t* msg, int* emm_cause);
-static int _emm_as_release_ind(
+static int emm_as_establish_req(emm_as_establish_t* msg, int* emm_cause);
+static int emm_as_data_ind(emm_as_data_t* msg, int* emm_cause);
+static int emm_as_release_ind(
     const emm_as_release_t* const release, int* emm_cause);
 
 /*
    Functions executed to send data to the network when requested
    within EMM procedure processing
 */
-static EMM_msg* _emm_as_set_header(
+static EMM_msg* emm_as_set_header(
     nas_message_t* msg, const emm_as_security_data_t* security);
 
-static int _emm_as_encode(
+static int emm_as_encode(
     bstring* info, nas_message_t* msg, size_t length,
     emm_security_context_t* emm_security_context);
 
-static int _emm_as_encrypt(
+static int emm_as_encrypt(
     bstring* info, const nas_message_security_header_t* header,
     const unsigned char* buffer, size_t length,
     emm_security_context_t* emm_security_context);
 
 static int emm_as_send_a(const emm_as_t* msg);
-static int _emm_as_security_req(
+static int emm_as_security_req(
     const emm_as_security_t*, dl_info_transfer_req_t*);
-static int _emm_as_security_rej(
+static int emm_as_security_rej(
     const emm_as_security_t*, dl_info_transfer_req_t*);
-static int _emm_as_establish_cnf(
+static int emm_as_establish_cnf(
     const emm_as_establish_t*, nas_establish_rsp_t*);
-static int _emm_as_establish_rej(
+static int emm_as_establish_rej(
     const emm_as_establish_t*, nas_establish_rsp_t*);
-static int _emm_as_data_req(const emm_as_data_t*, dl_info_transfer_req_t*);
-static int _emm_as_status_ind(const emm_as_status_t*, dl_info_transfer_req_t*);
-static int _emm_as_release_req(const emm_as_release_t*, nas_release_req_t*);
-static int _emm_as_erab_setup_req(
+static int emm_as_data_req(const emm_as_data_t*, dl_info_transfer_req_t*);
+static int emm_as_status_ind(const emm_as_status_t*, dl_info_transfer_req_t*);
+static int emm_as_release_req(const emm_as_release_t*, nas_release_req_t*);
+static int emm_as_erab_setup_req(
     const emm_as_activate_bearer_context_req_t*,
     activate_bearer_context_req_t*);
-static int _emm_as_erab_rel_cmd(
+static int emm_as_erab_rel_cmd(
     const emm_as_deactivate_bearer_context_req_t* msg,
     deactivate_bearer_context_req_t* as_msg);
 
@@ -173,21 +173,21 @@ int emm_as_send(emm_as_t* msg) {
 
   OAILOG_INFO(
       LOG_NAS_EMM, "EMMAS-SAP - Received primitive %s (%d)\n",
-      _emm_as_primitive_str[primitive - _EMMAS_START - 1], primitive);
+      emm_as_primitive_str[primitive - _EMMAS_START - 1], primitive);
 
   switch (primitive) {
     case _EMMAS_DATA_IND:
-      rc    = _emm_as_data_ind(&msg->u.data, &emm_cause);
+      rc    = emm_as_data_ind(&msg->u.data, &emm_cause);
       ue_id = msg->u.data.ue_id;
       break;
 
     case _EMMAS_ESTABLISH_REQ:
-      rc    = _emm_as_establish_req(&msg->u.establish, &emm_cause);
+      rc    = emm_as_establish_req(&msg->u.establish, &emm_cause);
       ue_id = msg->u.establish.ue_id;
       break;
 
     case _EMMAS_RELEASE_IND:
-      rc    = _emm_as_release_ind(&msg->u.release, &emm_cause);
+      rc    = emm_as_release_ind(&msg->u.release, &emm_cause);
       ue_id = msg->u.release.ue_id;
       break;
 
@@ -202,7 +202,7 @@ int emm_as_send(emm_as_t* msg) {
             LOG_NAS_EMM,
             "EMMAS-SAP - "
             "Failed to process primitive %s (%d)\n",
-            _emm_as_primitive_str[primitive - _EMMAS_START - 1], primitive);
+            emm_as_primitive_str[primitive - _EMMAS_START - 1], primitive);
         OAILOG_FUNC_RETURN(LOG_NAS_EMM, RETURNerror);
       }
 
@@ -248,7 +248,7 @@ int emm_as_send(emm_as_t* msg) {
   if (rc != RETURNok) {
     OAILOG_ERROR(
         LOG_NAS_EMM, "EMMAS-SAP - Failed to process primitive %s (%d)\n",
-        _emm_as_primitive_str[primitive - _EMMAS_START - 1], primitive);
+        emm_as_primitive_str[primitive - _EMMAS_START - 1], primitive);
   }
 
   OAILOG_FUNC_RETURN(LOG_NAS_EMM, rc);
@@ -282,7 +282,7 @@ int emm_as_send(emm_as_t* msg) {
  **      Others:    None                                       **
  **                                                                        **
  ***************************************************************************/
-static int _emm_as_recv(
+static int emm_as_recv(
     mme_ue_s1ap_id_t ue_id, tai_t const* originating_tai,
     ecgi_t const* originating_ecgi, bstring msg, size_t len, int* emm_cause,
     nas_message_decode_status_t* decode_status) {
@@ -610,7 +610,7 @@ static int _emm_as_recv(
  **      Others:    None                                       **
  **                                                                        **
  ***************************************************************************/
-static int _emm_as_data_ind(emm_as_data_t* msg, int* emm_cause) {
+static int emm_as_data_ind(emm_as_data_t* msg, int* emm_cause) {
   OAILOG_FUNC_IN(LOG_NAS_EMM);
   int rc = RETURNerror;
 
@@ -675,7 +675,7 @@ static int _emm_as_data_ind(emm_as_data_t* msg, int* emm_cause) {
           tai_t originating_tai = {0};  // originating TAI
           memcpy(&originating_tai, msg->tai, sizeof(originating_tai));
 
-          rc = _emm_as_recv(
+          rc = emm_as_recv(
               msg->ue_id, &originating_tai, &msg->ecgi, plain_msg, bytes,
               emm_cause, &decode_status);
         } else if (
@@ -728,7 +728,7 @@ static int _emm_as_data_ind(emm_as_data_t* msg, int* emm_cause) {
  **      Others:    None                                       **
  **                                                                        **
  ***************************************************************************/
-static int _emm_as_establish_req(emm_as_establish_t* msg, int* emm_cause) {
+static int emm_as_establish_req(emm_as_establish_t* msg, int* emm_cause) {
   OAILOG_FUNC_IN(LOG_NAS_EMM);
   struct emm_context_s* emm_ctx                = NULL;
   emm_security_context_t* emm_security_context = NULL;
@@ -944,7 +944,7 @@ static int _emm_as_establish_req(emm_as_establish_t* msg, int* emm_cause) {
 }
 
 //------------------------------------------------------------------------------
-static int _emm_as_release_ind(
+static int emm_as_release_ind(
     const emm_as_release_t* const release, int* emm_cause) {
   OAILOG_FUNC_IN(LOG_NAS_EMM);
   int rc = lowerlayer_release(release->ue_id, release->cause);
@@ -975,7 +975,7 @@ static int _emm_as_release_ind(
  **      Others:    None                                       **
  **                                                                        **
  ***************************************************************************/
-static EMM_msg* _emm_as_set_header(
+static EMM_msg* emm_as_set_header(
     nas_message_t* msg, const emm_as_security_data_t* security) {
   OAILOG_FUNC_IN(LOG_NAS_EMM);
   msg->header.protocol_discriminator = EPS_MOBILITY_MANAGEMENT_MESSAGE;
@@ -1059,7 +1059,7 @@ static EMM_msg* _emm_as_set_header(
  **      Others:    None                                       **
  **                                                                        **
  ***************************************************************************/
-static int _emm_as_encode(
+static int emm_as_encode(
     bstring* info, nas_message_t* msg, size_t length,
     emm_security_context_t* emm_security_context) {
   OAILOG_FUNC_IN(LOG_NAS_EMM);
@@ -1121,7 +1121,7 @@ static int _emm_as_encode(
  **      Others:    None                                       **
  **                                                                        **
  ***************************************************************************/
-static int _emm_as_encrypt(
+static int emm_as_encrypt(
     bstring* info, const nas_message_security_header_t* header,
     const unsigned char* msg, size_t length,
     emm_security_context_t* emm_security_context) {
@@ -1180,48 +1180,48 @@ static int emm_as_send_a(const emm_as_t* msg) {
   switch (msg->primitive) {
     case _EMMAS_DATA_REQ:
       as_msg.msg_id =
-          _emm_as_data_req(&msg->u.data, &as_msg.msg.dl_info_transfer_req);
+          emm_as_data_req(&msg->u.data, &as_msg.msg.dl_info_transfer_req);
       break;
 
     case _EMMAS_ERAB_SETUP_REQ:
-      as_msg.msg_id = _emm_as_erab_setup_req(
+      as_msg.msg_id = emm_as_erab_setup_req(
           &msg->u.activate_bearer_context_req,
           &as_msg.msg.activate_bearer_context_req);
       break;
 
     case _EMMAS_ERAB_REL_CMD:
-      as_msg.msg_id = _emm_as_erab_rel_cmd(
+      as_msg.msg_id = emm_as_erab_rel_cmd(
           &msg->u.deactivate_bearer_context_req,
           &as_msg.msg.deactivate_bearer_context_req);
       break;
 
     case _EMMAS_STATUS_IND:
       as_msg.msg_id =
-          _emm_as_status_ind(&msg->u.status, &as_msg.msg.dl_info_transfer_req);
+          emm_as_status_ind(&msg->u.status, &as_msg.msg.dl_info_transfer_req);
       break;
 
     case _EMMAS_RELEASE_REQ:
       as_msg.msg_id =
-          _emm_as_release_req(&msg->u.release, &as_msg.msg.nas_release_req);
+          emm_as_release_req(&msg->u.release, &as_msg.msg.nas_release_req);
       break;
 
     case _EMMAS_SECURITY_REQ:
-      as_msg.msg_id = _emm_as_security_req(
+      as_msg.msg_id = emm_as_security_req(
           &msg->u.security, &as_msg.msg.dl_info_transfer_req);
       break;
 
     case _EMMAS_SECURITY_REJ:
-      as_msg.msg_id = _emm_as_security_rej(
+      as_msg.msg_id = emm_as_security_rej(
           &msg->u.security, &as_msg.msg.dl_info_transfer_req);
       break;
 
     case _EMMAS_ESTABLISH_CNF:
-      as_msg.msg_id = _emm_as_establish_cnf(
+      as_msg.msg_id = emm_as_establish_cnf(
           &msg->u.establish, &as_msg.msg.nas_establish_rsp);
       break;
 
     case _EMMAS_ESTABLISH_REJ:
-      as_msg.msg_id = _emm_as_establish_rej(
+      as_msg.msg_id = emm_as_establish_rej(
           &msg->u.establish, &as_msg.msg.nas_establish_rsp);
       break;
 
@@ -1239,7 +1239,7 @@ static int emm_as_send_a(const emm_as_t* msg) {
         "EMMAS-SAP - "
         "Sending msg with id 0x%x, primitive %s (%d) to S1AP layer for "
         "transmission\n",
-        as_msg.msg_id, _emm_as_primitive_str[msg->primitive - _EMMAS_START - 1],
+        as_msg.msg_id, emm_as_primitive_str[msg->primitive - _EMMAS_START - 1],
         msg->primitive);
 
     switch (as_msg.msg_id) {
@@ -1330,7 +1330,7 @@ static int emm_as_send_a(const emm_as_t* msg) {
  **      Others:    None                                       **
  **                                                                        **
  ***************************************************************************/
-static int _emm_as_data_req(
+static int emm_as_data_req(
     const emm_as_data_t* msg, dl_info_transfer_req_t* as_msg) {
   OAILOG_FUNC_IN(LOG_NAS_EMM);
   int size       = 0;
@@ -1354,7 +1354,7 @@ static int _emm_as_data_req(
   /*
    * Setup the NAS security header
    */
-  EMM_msg* emm_msg = _emm_as_set_header(&nas_msg, &msg->sctx);
+  EMM_msg* emm_msg = emm_as_set_header(&nas_msg, &msg->sctx);
 
   /*
    * Setup the NAS information message
@@ -1438,13 +1438,13 @@ static int _emm_as_data_req(
       /*
        * Encode the NAS information message
        */
-      bytes = _emm_as_encode(
+      bytes = emm_as_encode(
           &as_msg->nas_msg, &nas_msg, size, emm_security_context);
     } else {
       /*
        * Encrypt the NAS information message
        */
-      bytes = _emm_as_encrypt(
+      bytes = emm_as_encrypt(
           &as_msg->nas_msg, &nas_msg.header, msg->nas_msg->data, size,
           emm_security_context);
     }
@@ -1503,7 +1503,7 @@ static int _emm_as_data_req(
  **      Others:    None                                       **
  **                                                                        **
  ***************************************************************************/
-static int _emm_as_status_ind(
+static int emm_as_status_ind(
     const emm_as_status_t* msg, dl_info_transfer_req_t* as_msg) {
   OAILOG_FUNC_IN(LOG_NAS_EMM);
   int size = 0;
@@ -1528,7 +1528,7 @@ static int _emm_as_status_ind(
   /*
    * Setup the NAS security header
    */
-  EMM_msg* emm_msg = _emm_as_set_header(&nas_msg, &msg->sctx);
+  EMM_msg* emm_msg = emm_as_set_header(&nas_msg, &msg->sctx);
 
   /*
    * Setup the NAS information message
@@ -1563,7 +1563,7 @@ static int _emm_as_status_ind(
      * Encode the NAS information message
      */
     int bytes =
-        _emm_as_encode(&as_msg->nas_msg, &nas_msg, size, emm_security_context);
+        emm_as_encode(&as_msg->nas_msg, &nas_msg, size, emm_security_context);
 
     if (bytes > 0) {
       as_msg->err_code = AS_SUCCESS;
@@ -1591,7 +1591,7 @@ static int _emm_as_status_ind(
  **      Others:    None                                       **
  **                                                                        **
  ***************************************************************************/
-static int _emm_as_release_req(
+static int emm_as_release_req(
     const emm_as_release_t* msg, nas_release_req_t* as_msg) {
   OAILOG_FUNC_IN(LOG_NAS_EMM);
   OAILOG_INFO(LOG_NAS_EMM, "EMMAS-SAP - Send AS release request\n");
@@ -1631,7 +1631,7 @@ static int _emm_as_release_req(
  **      Others:    None                                       **
  **                                                                        **
  ***************************************************************************/
-static int _emm_as_security_req(
+static int emm_as_security_req(
     const emm_as_security_t* msg, dl_info_transfer_req_t* as_msg) {
   OAILOG_FUNC_IN(LOG_NAS_EMM);
   int size = 0;
@@ -1653,7 +1653,7 @@ static int _emm_as_security_req(
   /*
    * Setup the NAS security header
    */
-  EMM_msg* emm_msg = _emm_as_set_header(&nas_msg, &msg->sctx);
+  EMM_msg* emm_msg = emm_as_set_header(&nas_msg, &msg->sctx);
 
   /*
    * Setup the NAS security message
@@ -1708,7 +1708,7 @@ static int _emm_as_security_req(
      * Encode the NAS security message
      */
     int bytes =
-        _emm_as_encode(&as_msg->nas_msg, &nas_msg, size, emm_security_context);
+        emm_as_encode(&as_msg->nas_msg, &nas_msg, size, emm_security_context);
     // Free any allocated data
     switch (msg->msg_type) {
       // authentication_request is the only message with allocated mem
@@ -1744,7 +1744,7 @@ static int _emm_as_security_req(
  **      Others:    None                                       **
  **                                                                        **
  ***************************************************************************/
-static int _emm_as_security_rej(
+static int emm_as_security_rej(
     const emm_as_security_t* msg, dl_info_transfer_req_t* as_msg) {
   OAILOG_FUNC_IN(LOG_NAS_EMM);
   int size = 0;
@@ -1767,7 +1767,7 @@ static int _emm_as_security_rej(
   /*
    * Setup the NAS security header
    */
-  EMM_msg* emm_msg = _emm_as_set_header(&nas_msg, &msg->sctx);
+  EMM_msg* emm_msg = emm_as_set_header(&nas_msg, &msg->sctx);
 
   /*
    * Setup the NAS security message
@@ -1815,7 +1815,7 @@ static int _emm_as_security_rej(
      * Encode the NAS security message
      */
     int bytes =
-        _emm_as_encode(&as_msg->nas_msg, &nas_msg, size, emm_security_context);
+        emm_as_encode(&as_msg->nas_msg, &nas_msg, size, emm_security_context);
 
     if (bytes > 0) {
       /*
@@ -1831,7 +1831,7 @@ static int _emm_as_security_rej(
 }
 
 //------------------------------------------------------------------------------
-static int _emm_as_erab_setup_req(
+static int emm_as_erab_setup_req(
     const emm_as_activate_bearer_context_req_t* msg,
     activate_bearer_context_req_t* as_msg) {
   OAILOG_FUNC_IN(LOG_NAS_EMM);
@@ -1856,7 +1856,7 @@ static int _emm_as_erab_setup_req(
   /*
    * Setup the NAS security header
    */
-  EMM_msg* emm_msg = _emm_as_set_header(&nas_msg, &msg->sctx);
+  EMM_msg* emm_msg = emm_as_set_header(&nas_msg, &msg->sctx);
 
   /*
    * Setup the NAS information message
@@ -1893,13 +1893,13 @@ static int _emm_as_erab_setup_req(
       /*
        * Encode the NAS information message
        */
-      bytes = _emm_as_encode(
+      bytes = emm_as_encode(
           &as_msg->nas_msg, &nas_msg, size, emm_security_context);
     } else {
       /*
        * Encrypt the NAS information message
        */
-      bytes = _emm_as_encrypt(
+      bytes = emm_as_encrypt(
           &as_msg->nas_msg, &nas_msg.header, msg->nas_msg->data, size,
           emm_security_context);
     }
@@ -1913,7 +1913,7 @@ static int _emm_as_erab_setup_req(
 }
 
 //------------------------------------------------------------------------------
-static int _emm_as_erab_rel_cmd(
+static int emm_as_erab_rel_cmd(
     const emm_as_deactivate_bearer_context_req_t* msg,
     deactivate_bearer_context_req_t* as_msg) {
   OAILOG_FUNC_IN(LOG_NAS_EMM);
@@ -1934,7 +1934,7 @@ static int _emm_as_erab_rel_cmd(
   /*
    * Setup the NAS security header
    */
-  EMM_msg* emm_msg = _emm_as_set_header(&nas_msg, &msg->sctx);
+  EMM_msg* emm_msg = emm_as_set_header(&nas_msg, &msg->sctx);
 
   /*
    * Setup the NAS information message
@@ -1971,13 +1971,13 @@ static int _emm_as_erab_rel_cmd(
       /*
        * Encode the NAS information message
        */
-      bytes = _emm_as_encode(
+      bytes = emm_as_encode(
           &as_msg->nas_msg, &nas_msg, size, emm_security_context);
     } else {
       /*
        * Encrypt the NAS information message
        */
-      bytes = _emm_as_encrypt(
+      bytes = emm_as_encrypt(
           &as_msg->nas_msg, &nas_msg.header, msg->nas_msg->data, size,
           emm_security_context);
     }
@@ -2007,7 +2007,7 @@ static int _emm_as_erab_rel_cmd(
  **      Others:    None                                       **
  **                                                                        **
  ***************************************************************************/
-static int _emm_as_establish_cnf(
+static int emm_as_establish_cnf(
     const emm_as_establish_t* msg, nas_establish_rsp_t* as_msg) {
   EMM_msg* emm_msg = NULL;
   int size         = 0;
@@ -2074,7 +2074,7 @@ static int _emm_as_establish_cnf(
       /*
        * Setup the NAS security header
        */
-      emm_msg = _emm_as_set_header(&nas_msg, &msg->sctx);
+      emm_msg = emm_as_set_header(&nas_msg, &msg->sctx);
       if (emm_msg) {
         OAILOG_TRACE(
             LOG_NAS_EMM, "EMMAS-SAP - emm_as_establish.nasMSG.length=%d\n",
@@ -2087,7 +2087,7 @@ static int _emm_as_establish_cnf(
       /*
        * Setup the NAS security header
        */
-      emm_msg = _emm_as_set_header(&nas_msg, &msg->sctx);
+      emm_msg = emm_as_set_header(&nas_msg, &msg->sctx);
       if (emm_msg) {
         size = emm_send_tracking_area_update_accept(
             msg, &emm_msg->tracking_area_update_accept);
@@ -2118,7 +2118,7 @@ static int _emm_as_establish_cnf(
    * Encode the initial NAS information message
    */
   int bytes =
-      _emm_as_encode(&as_msg->nas_msg, &nas_msg, size, emm_security_context);
+      emm_as_encode(&as_msg->nas_msg, &nas_msg, size, emm_security_context);
 
   // Free any allocated data
   if (msg->nas_info == EMM_AS_NAS_INFO_ATTACH) {
@@ -2149,7 +2149,7 @@ static int _emm_as_establish_cnf(
  **      Others:    None                                       **
  **                                                                        **
  ***************************************************************************/
-static int _emm_as_establish_rej(
+static int emm_as_establish_rej(
     const emm_as_establish_t* msg, nas_establish_rsp_t* as_msg) {
   EMM_msg* emm_msg      = NULL;
   int size              = 0;
@@ -2173,7 +2173,7 @@ static int _emm_as_establish_rej(
   /*
    * Setup the NAS security header
    */
-  emm_msg = _emm_as_set_header(&nas_msg, &msg->sctx);
+  emm_msg = emm_as_set_header(&nas_msg, &msg->sctx);
 
   /*
    * Setup the NAS information messag
@@ -2227,7 +2227,7 @@ static int _emm_as_establish_rej(
      * Encode the initial NAS information message
      */
     int bytes =
-        _emm_as_encode(&as_msg->nas_msg, &nas_msg, size, emm_security_context);
+        emm_as_encode(&as_msg->nas_msg, &nas_msg, size, emm_security_context);
     if (bytes > 0) {
       // This is to indicate MME-APP to release the S1AP UE context after
       // sending the message.

--- a/lte/gateway/c/oai/tasks/nas/emm/sap/emm_cn.c
+++ b/lte/gateway/c/oai/tasks/nas/emm/sap/emm_cn.c
@@ -96,15 +96,15 @@ typedef struct {
 
 extern int emm_cn_wrapper_attach_accept(emm_context_t* emm_context);
 
-static int _emm_cn_authentication_res(emm_cn_auth_res_t* const msg);
-static int _emm_cn_authentication_fail(const emm_cn_auth_fail_t* msg);
-static int _emm_cn_ula_success(emm_cn_ula_success_t* msg_pP);
-static int _emm_cn_cs_response_success(emm_cn_cs_response_success_t* msg_pP);
+static int emm_cn_authentication_res(emm_cn_auth_res_t* const msg);
+static int emm_cn_authentication_fail(const emm_cn_auth_fail_t* msg);
+static int emm_cn_ula_success(emm_cn_ula_success_t* msg_pP);
+static int emm_cn_cs_response_success(emm_cn_cs_response_success_t* msg_pP);
 
 /*
    String representation of EMMCN-SAP primitives
 */
-static const char* _emm_cn_primitive_str[] = {
+static const char* emm_cn_primitive_str[] = {
     "EMM_CN_AUTHENTICATION_PARAM_RES",
     "EMM_CN_AUTHENTICATION_PARAM_FAIL",
     "EMM_CN_ULA_SUCCESS",
@@ -122,7 +122,7 @@ static const char* _emm_cn_primitive_str[] = {
 };
 
 //------------------------------------------------------------------------------
-static int _emm_cn_authentication_res(emm_cn_auth_res_t* const msg) {
+static int emm_cn_authentication_res(emm_cn_auth_res_t* const msg) {
   OAILOG_FUNC_IN(LOG_NAS_EMM);
   emm_context_t* emm_ctx = NULL;
   int rc                 = RETURNerror;
@@ -158,7 +158,7 @@ static int _emm_cn_authentication_res(emm_cn_auth_res_t* const msg) {
 }
 
 //------------------------------------------------------------------------------
-static int _emm_cn_authentication_fail(const emm_cn_auth_fail_t* msg) {
+static int emm_cn_authentication_fail(const emm_cn_auth_fail_t* msg) {
   OAILOG_FUNC_IN(LOG_NAS_EMM);
   emm_context_t* emm_ctx = NULL;
   int rc                 = RETURNerror;
@@ -190,7 +190,7 @@ static int _emm_cn_authentication_fail(const emm_cn_auth_fail_t* msg) {
 }
 
 //------------------------------------------------------------------------------
-static int _emm_cn_smc_fail(const emm_cn_smc_fail_t* msg) {
+static int emm_cn_smc_fail(const emm_cn_smc_fail_t* msg) {
   int rc = RETURNerror;
 
   OAILOG_FUNC_IN(LOG_NAS_EMM);
@@ -199,7 +199,7 @@ static int _emm_cn_smc_fail(const emm_cn_smc_fail_t* msg) {
 }
 
 //------------------------------------------------------------------------------
-void _handle_apn_mismatch(ue_mm_context_t* const ue_context, int esm_cause) {
+void handle_apn_mismatch(ue_mm_context_t* const ue_context, int esm_cause) {
   ESM_msg esm_msg               = {.header = {0}};
   struct emm_context_s* emm_ctx = NULL;
   uint8_t emm_cn_sap_buffer[EMM_CN_SAP_BUFFER_SIZE];
@@ -235,7 +235,7 @@ void _handle_apn_mismatch(ue_mm_context_t* const ue_context, int esm_cause) {
 }
 
 //------------------------------------------------------------------------------
-static int _emm_cn_ula_success(emm_cn_ula_success_t* msg_pP) {
+static int emm_cn_ula_success(emm_cn_ula_success_t* msg_pP) {
   OAILOG_FUNC_IN(LOG_NAS_EMM);
   int rc                            = RETURNerror;
   struct emm_context_s* emm_ctx     = NULL;
@@ -283,7 +283,7 @@ static int _emm_cn_ula_success(emm_cn_ula_success_t* msg_pP) {
      * provided by HSS or if we fail to select the APN provided
      * by HSS,send Attach Reject to UE
      */
-    _handle_apn_mismatch(ue_mm_context, esm_cause);
+    handle_apn_mismatch(ue_mm_context, esm_cause);
     return RETURNerror;
   }
 
@@ -388,7 +388,7 @@ static int _emm_cn_ula_success(emm_cn_ula_success_t* msg_pP) {
 }
 
 //------------------------------------------------------------------------------
-static int _emm_cn_implicit_detach_ue(const uint32_t ue_id) {
+static int emm_cn_implicit_detach_ue(const uint32_t ue_id) {
   int rc                          = RETURNok;
   struct emm_context_s* emm_ctx_p = NULL;
 
@@ -423,7 +423,7 @@ static int _emm_cn_implicit_detach_ue(const uint32_t ue_id) {
 }
 
 //------------------------------------------------------------------------------
-static int _emm_cn_nw_initiated_detach_ue(
+static int emm_cn_nw_initiated_detach_ue(
     const uint32_t ue_id, uint8_t detach_type) {
   int rc = RETURNok;
 
@@ -436,7 +436,7 @@ static int _emm_cn_nw_initiated_detach_ue(
 }
 
 //------------------------------------------------------------------------------
-static int _emm_proc_combined_attach_req(
+static int emm_proc_combined_attach_req(
     struct emm_context_s* emm_ctx_p, bstring esm_data) {
   int rc = RETURNerror;
   OAILOG_FUNC_IN(LOG_NAS_EMM);
@@ -486,7 +486,7 @@ static int _emm_proc_combined_attach_req(
   OAILOG_FUNC_RETURN(LOG_NAS_EMM, rc);
 }
 //------------------------------------------------------------------------------
-static int _emm_cn_cs_response_success(emm_cn_cs_response_success_t* msg_pP) {
+static int emm_cn_cs_response_success(emm_cn_cs_response_success_t* msg_pP) {
   OAILOG_FUNC_IN(LOG_NAS_EMM);
   int rc                           = RETURNerror;
   struct emm_context_s* emm_ctx    = NULL;
@@ -611,7 +611,7 @@ static int _emm_cn_cs_response_success(emm_cn_cs_response_success_t* msg_pP) {
   /* Notify SGS Location update request to MME App
    * if attach_type == EMM_ATTACH_TYPE_COMBINED_EPS_IMSI
    */
-  if (_emm_proc_combined_attach_req(emm_ctx, rsp) == RETURNok) {
+  if (emm_proc_combined_attach_req(emm_ctx, rsp) == RETURNok) {
     bdestroy_wrapper(&rsp);
     OAILOG_FUNC_RETURN(LOG_NAS_EMM, RETURNok);
   }
@@ -650,7 +650,7 @@ static int _emm_cn_cs_response_success(emm_cn_cs_response_success_t* msg_pP) {
 }
 
 //------------------------------------------------------------------------------
-static int _emm_cn_ula_or_csrsp_fail(const emm_cn_ula_or_csrsp_fail_t* msg) {
+static int emm_cn_ula_or_csrsp_fail(const emm_cn_ula_or_csrsp_fail_t* msg) {
   OAILOG_FUNC_IN(LOG_NAS_EMM);
   int rc                          = RETURNok;
   struct emm_context_s* emm_ctx_p = NULL;
@@ -726,7 +726,7 @@ static int _emm_cn_ula_or_csrsp_fail(const emm_cn_ula_or_csrsp_fail_t* msg) {
 }
 
 //------------------------------------------------------------------------------
-static int _emm_cn_activate_dedicated_bearer_req(
+static int emm_cn_activate_dedicated_bearer_req(
     emm_cn_activate_dedicated_bearer_req_t* msg) {
   OAILOG_FUNC_IN(LOG_NAS_EMM);
   int rc = RETURNok;
@@ -764,7 +764,7 @@ static int _emm_cn_activate_dedicated_bearer_req(
 }
 
 //------------------------------------------------------------------------------
-static int _emm_cn_deactivate_dedicated_bearer_req(
+static int emm_cn_deactivate_dedicated_bearer_req(
     emm_cn_deactivate_dedicated_bearer_req_t* msg) {
   OAILOG_FUNC_IN(LOG_NAS_EMM);
   int rc = RETURNok;
@@ -790,7 +790,7 @@ static int _emm_cn_deactivate_dedicated_bearer_req(
 }
 
 //------------------------------------------------------------------------------
-static int _send_attach_accept(struct emm_context_s* emm_ctx_p) {
+static int send_attach_accept(struct emm_context_s* emm_ctx_p) {
   OAILOG_FUNC_IN(LOG_NAS_EMM);
   int rc = RETURNok;
 
@@ -867,7 +867,7 @@ int emm_send_cs_domain_attach_or_tau_accept(
       }
     }
   } else {
-    if (_send_attach_accept(&ue_context_p->emm_context) == RETURNerror) {
+    if (send_attach_accept(&ue_context_p->emm_context) == RETURNerror) {
       OAILOG_ERROR(
           LOG_NAS_EMM,
           "EMMCN-SAP  - "
@@ -880,7 +880,7 @@ int emm_send_cs_domain_attach_or_tau_accept(
   OAILOG_FUNC_RETURN(LOG_NAS_EMM, rc);
 }
 //------------------------------------------------------------------------------
-static int _emm_cn_cs_domain_loc_updt_fail(
+static int emm_cn_cs_domain_loc_updt_fail(
     emm_cn_cs_domain_location_updt_fail_t emm_cn_sgs_location_updt_fail) {
   int rc = RETURNok;
 
@@ -976,7 +976,7 @@ static int _emm_cn_cs_domain_loc_updt_fail(
 }
 
 // handle CS-Domain MM-Information Request from SGS task
-static int _emm_cn_cs_domain_mm_information_req(
+static int emm_cn_cs_domain_mm_information_req(
     emm_cn_cs_domain_mm_information_req_t* mm_information_req_pP) {
   int rc                        = RETURNerror;
   imsi64_t imsi64               = INVALID_IMSI64;
@@ -1038,7 +1038,7 @@ static int _emm_cn_cs_domain_mm_information_req(
   OAILOG_FUNC_RETURN(LOG_NAS_EMM, rc);
 }
 
-static int _emm_cn_pdn_disconnect_rsp(emm_cn_pdn_disconnect_rsp_t* msg) {
+static int emm_cn_pdn_disconnect_rsp(emm_cn_pdn_disconnect_rsp_t* msg) {
   OAILOG_FUNC_IN(LOG_NAS_EMM);
   int rc = RETURNok;
   proc_tid_t pti;
@@ -1135,64 +1135,64 @@ int emm_cn_send(const emm_cn_t* msg) {
   OAILOG_FUNC_IN(LOG_NAS_EMM);
   OAILOG_INFO(
       LOG_NAS_EMM, "EMMCN-SAP - Received primitive %s (%d)\n",
-      _emm_cn_primitive_str[primitive - _EMMCN_START - 1], primitive);
+      emm_cn_primitive_str[primitive - _EMMCN_START - 1], primitive);
 
   switch (primitive) {
     case _EMMCN_AUTHENTICATION_PARAM_RES:
-      rc = _emm_cn_authentication_res(msg->u.auth_res);
+      rc = emm_cn_authentication_res(msg->u.auth_res);
       break;
 
     case _EMMCN_AUTHENTICATION_PARAM_FAIL:
-      rc = _emm_cn_authentication_fail(msg->u.auth_fail);
+      rc = emm_cn_authentication_fail(msg->u.auth_fail);
       break;
 
     case EMMCN_ULA_SUCCESS:
-      rc = _emm_cn_ula_success(msg->u.emm_cn_ula_success);
+      rc = emm_cn_ula_success(msg->u.emm_cn_ula_success);
       break;
 
     case EMMCN_CS_RESPONSE_SUCCESS:
-      rc = _emm_cn_cs_response_success(msg->u.emm_cn_cs_response_success);
+      rc = emm_cn_cs_response_success(msg->u.emm_cn_cs_response_success);
       break;
 
     case EMMCN_ULA_OR_CSRSP_FAIL:
-      rc = _emm_cn_ula_or_csrsp_fail(msg->u.emm_cn_ula_or_csrsp_fail);
+      rc = emm_cn_ula_or_csrsp_fail(msg->u.emm_cn_ula_or_csrsp_fail);
       break;
 
     case EMMCN_ACTIVATE_DEDICATED_BEARER_REQ:
-      rc = _emm_cn_activate_dedicated_bearer_req(
+      rc = emm_cn_activate_dedicated_bearer_req(
           msg->u.activate_dedicated_bearer_req);
       break;
 
     case EMMCN_IMPLICIT_DETACH_UE:
-      rc = _emm_cn_implicit_detach_ue(msg->u.emm_cn_implicit_detach.ue_id);
+      rc = emm_cn_implicit_detach_ue(msg->u.emm_cn_implicit_detach.ue_id);
       break;
 
     case EMMCN_SMC_PROC_FAIL:
-      rc = _emm_cn_smc_fail(msg->u.smc_fail);
+      rc = emm_cn_smc_fail(msg->u.smc_fail);
       break;
     case EMMCN_NW_INITIATED_DETACH_UE:
-      rc = _emm_cn_nw_initiated_detach_ue(
+      rc = emm_cn_nw_initiated_detach_ue(
           msg->u.emm_cn_nw_initiated_detach.ue_id,
           msg->u.emm_cn_nw_initiated_detach.detach_type);
       break;
 
     case EMMCN_CS_DOMAIN_LOCATION_UPDT_FAIL:
-      rc = _emm_cn_cs_domain_loc_updt_fail(
+      rc = emm_cn_cs_domain_loc_updt_fail(
           msg->u.emm_cn_cs_domain_location_updt_fail);
       break;
 
     case EMMCN_CS_DOMAIN_MM_INFORMATION_REQ:
-      rc = _emm_cn_cs_domain_mm_information_req(
+      rc = emm_cn_cs_domain_mm_information_req(
           msg->u.emm_cn_cs_domain_mm_information_req);
       break;
 
     case EMMCN_DEACTIVATE_BEARER_REQ:
-      rc = _emm_cn_deactivate_dedicated_bearer_req(
+      rc = emm_cn_deactivate_dedicated_bearer_req(
           msg->u.deactivate_dedicated_bearer_req);
       break;
 
     case EMMCN_PDN_DISCONNECT_RES:
-      rc = _emm_cn_pdn_disconnect_rsp(msg->u.emm_cn_pdn_disconnect_rsp);
+      rc = emm_cn_pdn_disconnect_rsp(msg->u.emm_cn_pdn_disconnect_rsp);
       break;
 
     default:
@@ -1206,7 +1206,7 @@ int emm_cn_send(const emm_cn_t* msg) {
   if (rc != RETURNok) {
     OAILOG_ERROR(
         LOG_NAS_EMM, "EMMCN-SAP - Failed to process primitive %s (%d)\n",
-        _emm_cn_primitive_str[primitive - _EMMCN_START - 1], primitive);
+        emm_cn_primitive_str[primitive - _EMMCN_START - 1], primitive);
   }
 
   OAILOG_FUNC_RETURN(LOG_NAS_EMM, rc);

--- a/lte/gateway/c/oai/tasks/nas/emm/sap/emm_esm.c
+++ b/lte/gateway/c/oai/tasks/nas/emm/sap/emm_esm.c
@@ -31,7 +31,7 @@
 /*
    String representation of EMMESM-SAP primitives
 */
-static const char* _emm_esm_primitive_str[] = {
+static const char* emm_esm_primitive_str[] = {
     "EMMESM_RELEASE_IND",           "EMMESM_UNITDATA_REQ",
     "EMMESM_ACTIVATE_BEARER_REQ",   "EMMESM_UNITDATA_IND",
     "EMMESM_DEACTIVATE_BEARER_REQ",
@@ -84,7 +84,7 @@ int emm_esm_send(const emm_esm_t* msg) {
 
   OAILOG_INFO(
       LOG_NAS_EMM, "EMMESM-SAP - Received primitive %s (%d)\n",
-      _emm_esm_primitive_str[primitive - _EMMESM_START - 1], primitive);
+      emm_esm_primitive_str[primitive - _EMMESM_START - 1], primitive);
 
   switch (primitive) {
     case _EMMESM_UNITDATA_REQ:
@@ -114,7 +114,7 @@ int emm_esm_send(const emm_esm_t* msg) {
   if (rc != RETURNok) {
     OAILOG_WARNING(
         LOG_NAS_EMM, "EMMESM-SAP - Failed to process primitive %s (%d)\n",
-        _emm_esm_primitive_str[primitive - _EMMESM_START - 1], primitive);
+        emm_esm_primitive_str[primitive - _EMMESM_START - 1], primitive);
   }
 
   OAILOG_FUNC_RETURN(LOG_NAS_EMM, rc);

--- a/lte/gateway/c/oai/tasks/nas/emm/sap/emm_fsm.c
+++ b/lte/gateway/c/oai/tasks/nas/emm/sap/emm_fsm.c
@@ -41,7 +41,7 @@
 */
 
 /* String representation of EMM events */
-static const char* _emm_fsm_event_str[] = {
+static const char* emm_fsm_event_str[] = {
     "COMMON_PROC_REQ",
     "COMMON_PROC_CNF",
     "COMMON_PROC_REJ",
@@ -66,7 +66,7 @@ static const char* _emm_fsm_event_str[] = {
 };
 
 /* String representation of EMM state */
-static const char* const _emm_fsm_status_str[EMM_STATE_MAX] = {
+static const char* const emm_fsm_status_str[EMM_STATE_MAX] = {
     "INVALID",
     "EMM-DEREGISTERED",
     "EMM-REGISTERED",
@@ -89,7 +89,7 @@ int EmmDeregisteredInitiated(emm_reg_t* const);
 int EmmCommonProcedureInitiated(emm_reg_t* const);
 
 /* EMM state machine handlers */
-static const emm_fsm_handler_t _emm_fsm_handlers[EMM_STATE_MAX] = {
+static const emm_fsm_handler_t emm_fsm_handlers[EMM_STATE_MAX] = {
     NULL,
     EmmDeregistered,
     EmmRegistered,
@@ -152,8 +152,8 @@ int emm_fsm_set_state(
       OAILOG_INFO(
           LOG_NAS_EMM,
           "UE " MME_UE_S1AP_ID_FMT " EMM-FSM   - Status changed: %s ===> %s\n",
-          ue_id, _emm_fsm_status_str[emm_context->_emm_fsm_state],
-          _emm_fsm_status_str[state]);
+          ue_id, emm_fsm_status_str[emm_context->_emm_fsm_state],
+          emm_fsm_status_str[state]);
       emm_context->_emm_fsm_state   = state;
       emm_fsm_state_t new_emm_state = UE_UNREGISTERED;
       if (state == EMM_REGISTERED) {
@@ -205,9 +205,9 @@ const char* emm_fsm_get_state_str(
     const struct emm_context_s* const emm_context) {
   if (emm_context) {
     emm_fsm_state_t state = emm_fsm_get_state(emm_context);
-    return _emm_fsm_status_str[state];
+    return emm_fsm_status_str[state];
   }
-  return _emm_fsm_status_str[EMM_INVALID];
+  return emm_fsm_status_str[EMM_INVALID];
 }
 
 /****************************************************************************
@@ -237,19 +237,19 @@ int emm_fsm_process(struct emm_reg_s* const evt) {
     state = emm_fsm_get_state(emm_ctx);
     OAILOG_INFO(
         LOG_NAS_EMM, "EMM-FSM   - Received event %s (%d) in state %s\n",
-        _emm_fsm_event_str[primitive - _EMMREG_START - 1], primitive,
-        _emm_fsm_status_str[state]);
+        emm_fsm_event_str[primitive - _EMMREG_START - 1], primitive,
+        emm_fsm_status_str[state]);
     /*
      * Execute the EMM state machine
      */
     if (emm_ctx->is_imsi_only_detach == false) {
-      rc = (_emm_fsm_handlers[state])(evt);
+      rc = (emm_fsm_handlers[state])(evt);
     }
   } else {
     OAILOG_WARNING(
         LOG_NAS_EMM,
         "EMM-FSM   - Received event %s (%d) but no EMM data context provided\n",
-        _emm_fsm_event_str[primitive - _EMMREG_START - 1], primitive);
+        emm_fsm_event_str[primitive - _EMMREG_START - 1], primitive);
   }
   OAILOG_FUNC_RETURN(LOG_NAS_EMM, rc);
 }

--- a/lte/gateway/c/oai/tasks/nas/emm/sap/emm_recv.c
+++ b/lte/gateway/c/oai/tasks/nas/emm/sap/emm_recv.c
@@ -66,7 +66,7 @@
 /****************************************************************************/
 /*********************  L O C A L    F U N C T I O N S  *********************/
 /****************************************************************************/
-static int _emm_initiate_default_bearer_re_establishment(
+static int emm_initiate_default_bearer_re_establishment(
     emm_context_t* emm_ctx);
 /*
    --------------------------------------------------------------------------
@@ -753,7 +753,7 @@ int emm_recv_service_request(
    * 2. Move UE ECM state to Connected
    * 3. Stop Mobile reachability time and Implicit Deatch timer (if running)
    */
-  rc = _emm_initiate_default_bearer_re_establishment(emm_ctx);
+  rc = emm_initiate_default_bearer_re_establishment(emm_ctx);
   if (rc == RETURNok) {
     *emm_cause = EMM_CAUSE_SUCCESS;
     increment_counter("service_request", 1, 1, "result", "success");
@@ -1191,7 +1191,7 @@ int emm_recv_detach_accept(mme_ue_s1ap_id_t ue_id, int* emm_cause) {
 }
 
 //-------------------------------------------------------------------------------------
-static int _emm_initiate_default_bearer_re_establishment(
+static int emm_initiate_default_bearer_re_establishment(
     emm_context_t* emm_ctx) {
   /*
    * This function is used to trigger initial context setup request towards eNB

--- a/lte/gateway/c/oai/tasks/nas/esm/DedicatedEpsBearerContextActivation.c
+++ b/lte/gateway/c/oai/tasks/nas/esm/DedicatedEpsBearerContextActivation.c
@@ -60,10 +60,10 @@
    retransmission counter */
 #define DEDICATED_EPS_BEARER_ACTIVATE_COUNTER_MAX 5
 
-static int _dedicated_eps_bearer_activate(
+static int dedicated_eps_bearer_activate(
     emm_context_t* emm_context, ebi_t ebi, STOLEN_REF bstring* msg);
 
-static void _erab_setup_rsp_tmr_exp_ded_bearer_handler(
+static void erab_setup_rsp_tmr_exp_ded_bearer_handler(
     void* args, imsi64_t* imsi64);
 
 /****************************************************************************/
@@ -194,7 +194,7 @@ int esm_proc_dedicated_eps_bearer_context_request(
    * Send activate dedicated EPS bearer context request message and
    * * * * start timer T3485
    */
-  rc = _dedicated_eps_bearer_activate(emm_context, ebi, msg);
+  rc = dedicated_eps_bearer_activate(emm_context, ebi, msg);
 
   if (rc != RETURNerror) {
     /*
@@ -283,7 +283,7 @@ int esm_proc_dedicated_eps_bearer_context_accept(
     } else {
       rc = esm_ebr_start_timer(
           emm_context, ebi, NULL, ERAB_SETUP_RSP_TMR,
-          _erab_setup_rsp_tmr_exp_ded_bearer_handler);
+          erab_setup_rsp_tmr_exp_ded_bearer_handler);
       if (rc != RETURNerror) {
         OAILOG_DEBUG(
             LOG_NAS_ESM,
@@ -427,7 +427,7 @@ void dedicated_eps_bearer_activate_t3485_handler(void* args, imsi64_t* imsi64) {
        * * * * to the UE
        */
       bstring b = bstrcpy(esm_ebr_timer_data->msg);
-      rc        = _dedicated_eps_bearer_activate(
+      rc        = dedicated_eps_bearer_activate(
           esm_ebr_timer_data->ctx, esm_ebr_timer_data->ebi, &b);
       bdestroy_wrapper(&b);
     } else {
@@ -487,7 +487,7 @@ void dedicated_eps_bearer_activate_t3485_handler(void* args, imsi64_t* imsi64) {
  **      Others:    T3485                                                  **
  **                                                                        **
  ***************************************************************************/
-static int _dedicated_eps_bearer_activate(
+static int dedicated_eps_bearer_activate(
     emm_context_t* emm_context, ebi_t ebi, STOLEN_REF bstring* msg) {
   OAILOG_FUNC_IN(LOG_NAS_ESM);
   emm_sap_t emm_sap = {0};
@@ -548,7 +548,7 @@ static int _dedicated_eps_bearer_activate(
  **                                                                        **
  ***************************************************************************/
 
-static void _erab_setup_rsp_tmr_exp_ded_bearer_handler(
+static void erab_setup_rsp_tmr_exp_ded_bearer_handler(
     void* args, imsi64_t* imsi64) {
   OAILOG_FUNC_IN(LOG_NAS_ESM);
   int rc;
@@ -586,7 +586,7 @@ static void _erab_setup_rsp_tmr_exp_ded_bearer_handler(
         // Restart the timer
         rc = esm_ebr_start_timer(
             esm_ebr_timer_data->ctx, esm_ebr_timer_data->ebi, NULL,
-            ERAB_SETUP_RSP_TMR, _erab_setup_rsp_tmr_exp_ded_bearer_handler);
+            ERAB_SETUP_RSP_TMR, erab_setup_rsp_tmr_exp_ded_bearer_handler);
         if (rc != RETURNerror) {
           OAILOG_INFO(
               LOG_NAS_ESM,

--- a/lte/gateway/c/oai/tasks/nas/esm/DefaultEpsBearerContextActivation.c
+++ b/lte/gateway/c/oai/tasks/nas/esm/DefaultEpsBearerContextActivation.c
@@ -60,10 +60,10 @@
    retransmission counter */
 #define DEFAULT_EPS_BEARER_ACTIVATE_COUNTER_MAX 5
 
-static int _default_eps_bearer_activate(
+static int default_eps_bearer_activate(
     emm_context_t* emm_context, ebi_t ebi, STOLEN_REF bstring* msg);
 
-static int _default_eps_bearer_activate_in_bearer_setup_req(
+static int default_eps_bearer_activate_in_bearer_setup_req(
     emm_context_t* emm_context, ebi_t ebi, STOLEN_REF bstring* msg);
 
 /****************************************************************************/
@@ -200,7 +200,7 @@ int esm_proc_default_eps_bearer_context_request(
      * in ERAB SETUP REQ mesage
      */
     rc =
-        _default_eps_bearer_activate_in_bearer_setup_req(emm_context, ebi, msg);
+        default_eps_bearer_activate_in_bearer_setup_req(emm_context, ebi, msg);
   } else {
     OAILOG_INFO(
         LOG_NAS_ESM,
@@ -499,10 +499,10 @@ void default_eps_bearer_activate_t3485_handler(void* args, imsi64_t* imsi64) {
        * activate default eps bearer req message in ICS req
        */
       if (((emm_context_t*) esm_ebr_timer_data->ctx)->esm_ctx.is_standalone) {
-        _default_eps_bearer_activate_in_bearer_setup_req(
+        default_eps_bearer_activate_in_bearer_setup_req(
             esm_ebr_timer_data->ctx, esm_ebr_timer_data->ebi, &b);
       } else {
-        _default_eps_bearer_activate(
+        default_eps_bearer_activate(
             esm_ebr_timer_data->ctx, esm_ebr_timer_data->ebi, &b);
       }
       bdestroy_wrapper(&b);
@@ -549,7 +549,7 @@ void default_eps_bearer_activate_t3485_handler(void* args, imsi64_t* imsi64) {
  **      Others:    T3485                                      **
  **                                                                        **
  ***************************************************************************/
-static int _default_eps_bearer_activate(
+static int default_eps_bearer_activate(
     emm_context_t* emm_context, ebi_t ebi, STOLEN_REF bstring* msg) {
   OAILOG_FUNC_IN(LOG_NAS_ESM);
   emm_sap_t emm_sap = {0};
@@ -606,7 +606,7 @@ static int _default_eps_bearer_activate(
  **      Others:    T3485                                                  **
  **                                                                        **
  ***************************************************************************/
-static int _default_eps_bearer_activate_in_bearer_setup_req(
+static int default_eps_bearer_activate_in_bearer_setup_req(
     emm_context_t* emm_context, ebi_t ebi, STOLEN_REF bstring* msg) {
   OAILOG_FUNC_IN(LOG_NAS_ESM);
   emm_sap_t emm_sap = {0};

--- a/lte/gateway/c/oai/tasks/nas/esm/EpsBearerContextDeactivation.c
+++ b/lte/gateway/c/oai/tasks/nas/esm/EpsBearerContextDeactivation.c
@@ -63,13 +63,13 @@
    retransmission counter */
 #define EPS_BEARER_DEACTIVATE_COUNTER_MAX 5
 
-static int _eps_bearer_deactivate(
+static int eps_bearer_deactivate(
     emm_context_t* emm_context_p, ebi_t ebi, STOLEN_REF bstring* msg);
 
 /****************************************************************************/
 /******************  E X P O R T E D    F U N C T I O N S  ******************/
 /****************************************************************************/
-extern int _pdn_connectivity_delete(emm_context_t* emm_context, pdn_cid_t pid);
+extern int pdn_connectivity_delete(emm_context_t* emm_context, pdn_cid_t pid);
 
 /*
    --------------------------------------------------------------------------
@@ -225,7 +225,7 @@ int esm_proc_eps_bearer_context_deactivate_request(
    * * * * start timer T3495
    */
   /*Currently we only support single bearear deactivation at NAS*/
-  rc  = _eps_bearer_deactivate(emm_context_p, ebi, msg);
+  rc  = eps_bearer_deactivate(emm_context_p, ebi, msg);
   msg = NULL;
 
   if (rc != RETURNerror) {
@@ -321,7 +321,7 @@ pdn_cid_t esm_proc_eps_bearer_context_deactivate_accept(
       /*
        * Delete the PDN connection entry
        */
-      _pdn_connectivity_delete(emm_context_p, pid);
+      pdn_connectivity_delete(emm_context_p, pid);
       // Free PDN context
       if (ue_context_p->pdn_contexts[pid]) {
         free_wrapper((void**) &ue_context_p->pdn_contexts[pid]);
@@ -420,7 +420,7 @@ void eps_bearer_deactivate_t3495_handler(void* args, imsi64_t* imsi64) {
        * Re-send deactivate EPS bearer context request message to the UE
        */
       bstring b = bstrcpy(esm_ebr_timer_data->msg);
-      rc        = _eps_bearer_deactivate(
+      rc        = eps_bearer_deactivate(
           esm_ebr_timer_data->ctx, esm_ebr_timer_data->ebi, &b);
       bdestroy_wrapper(&b);
     } else {
@@ -463,7 +463,7 @@ void eps_bearer_deactivate_t3495_handler(void* args, imsi64_t* imsi64) {
         /*
          * Delete the PDN connection entry
          */
-        _pdn_connectivity_delete(esm_ebr_timer_data->ctx, pdn_id);
+        pdn_connectivity_delete(esm_ebr_timer_data->ctx, pdn_id);
       }
       /* In case of PDN disconnect, no need to inform MME/SPGW as the session
        * would have been already released
@@ -520,7 +520,7 @@ void eps_bearer_deactivate_t3495_handler(void* args, imsi64_t* imsi64) {
  **      Others:    T3495                                      **
  **                                                                        **
  ***************************************************************************/
-static int _eps_bearer_deactivate(
+static int eps_bearer_deactivate(
     emm_context_t* emm_context_p, ebi_t ebi, STOLEN_REF bstring* msg) {
   OAILOG_FUNC_IN(LOG_NAS_ESM);
   emm_sap_t emm_sap = {0};

--- a/lte/gateway/c/oai/tasks/nas/esm/PdnConnectivity.c
+++ b/lte/gateway/c/oai/tasks/nas/esm/PdnConnectivity.c
@@ -60,14 +60,14 @@
 /*
    PDN connection handlers
 */
-static pdn_cid_t _pdn_connectivity_create(
+static pdn_cid_t pdn_connectivity_create(
     emm_context_t* emm_context, const proc_tid_t pti, const pdn_cid_t pdn_cid,
     const context_identifier_t context_identifier, const_bstring const apn,
     pdn_type_t pdn_type, const_bstring const pdn_addr,
     protocol_configuration_options_t* const pco, const bool is_emergency,
     esm_cause_t* esm_cause);
 
-proc_tid_t _pdn_connectivity_delete(
+proc_tid_t pdn_connectivity_delete(
     emm_context_t* emm_context, pdn_cid_t pdn_cid);
 
 /****************************************************************************/
@@ -161,7 +161,7 @@ int esm_proc_pdn_connectivity_request(
   /*
    * Create new PDN connection
    */
-  rc = _pdn_connectivity_create(
+  rc = pdn_connectivity_create(
       emm_context, pti, pdn_cid, context_identifier, apn, pdn_type, pdn_addr,
       pco, is_emergency, esm_cause);
 
@@ -276,7 +276,7 @@ int esm_proc_pdn_connectivity_failure(
   /*
    * Delete the PDN connection entry
    */
-  pti = _pdn_connectivity_delete(emm_context, pdn_cid);
+  pti = pdn_connectivity_delete(emm_context, pdn_cid);
 
   if (pti != ESM_PT_UNASSIGNED) {
     OAILOG_FUNC_RETURN(LOG_NAS_ESM, RETURNok);
@@ -316,7 +316,7 @@ int esm_proc_pdn_connectivity_failure(
  **                  Others:    _esm_data                                  **
  **                                                                        **
  ***************************************************************************/
-static int _pdn_connectivity_create(
+static int pdn_connectivity_create(
     emm_context_t* emm_context, const proc_tid_t pti, const pdn_cid_t pdn_cid,
     const context_identifier_t context_identifier, const_bstring const apn,
     pdn_type_t pdn_type, const_bstring const pdn_addr,
@@ -498,7 +498,7 @@ static int _pdn_connectivity_create(
  **                  Others:    _esm_data                                  **
  **                                                                        **
  ***************************************************************************/
-proc_tid_t _pdn_connectivity_delete(
+proc_tid_t pdn_connectivity_delete(
     emm_context_t* emm_context, pdn_cid_t pdn_cid) {
   proc_tid_t pti = ESM_PT_UNASSIGNED;
 

--- a/lte/gateway/c/oai/tasks/nas/esm/PdnDisconnect.c
+++ b/lte/gateway/c/oai/tasks/nas/esm/PdnDisconnect.c
@@ -39,7 +39,7 @@
 /****************  E X T E R N A L    D E F I N I T I O N S  ****************/
 /****************************************************************************/
 
-extern int _pdn_connectivity_delete(emm_context_t* emm_context, pdn_cid_t pid);
+extern int pdn_connectivity_delete(emm_context_t* emm_context, pdn_cid_t pid);
 
 /****************************************************************************/
 /*******************  L O C A L    D E F I N I T I O N S  *******************/
@@ -53,7 +53,7 @@ extern int _pdn_connectivity_delete(emm_context_t* emm_context, pdn_cid_t pid);
 /*
    PDN disconnection handlers
 */
-static int _pdn_disconnect_get_pid(emm_context_t* emm_context, proc_tid_t pti);
+static int pdn_disconnect_get_pid(emm_context_t* emm_context, proc_tid_t pti);
 
 /****************************************************************************/
 /******************  E X P O R T E D    F U N C T I O N S  ******************/
@@ -110,7 +110,7 @@ int esm_proc_pdn_disconnect_request(
      * Get the identifier of the PDN connection entry assigned to the
      * * * * procedure transaction identity
      */
-    pid = _pdn_disconnect_get_pid(emm_context, pti);
+    pid = pdn_disconnect_get_pid(emm_context, pti);
 
     if (pid >= MAX_APN_PER_UE) {
       OAILOG_ERROR(
@@ -171,7 +171,7 @@ int esm_proc_pdn_disconnect_accept(
     /*
      * Delete the PDN connection entry
      */
-    proc_tid_t pti = _pdn_connectivity_delete(emm_context, pid);
+    proc_tid_t pti = pdn_connectivity_delete(emm_context, pid);
 
     if (pti != ESM_PT_UNASSIGNED) {
       OAILOG_FUNC_RETURN(LOG_NAS_ESM, RETURNok);
@@ -267,7 +267,7 @@ int esm_proc_pdn_disconnect_reject(
  **      Others:    None                                       **
  **                                                                        **
  ***************************************************************************/
-static pdn_cid_t _pdn_disconnect_get_pid(
+static pdn_cid_t pdn_disconnect_get_pid(
     emm_context_t* emm_context, proc_tid_t pti) {
   pdn_cid_t i = MAX_APN_PER_UE;
 

--- a/lte/gateway/c/oai/tasks/nas/esm/esm_ebr.c
+++ b/lte/gateway/c/oai/tasks/nas/esm/esm_ebr.c
@@ -41,7 +41,7 @@
 /****************************************************************************/
 
 /* String representation of EPS bearer context status */
-static const char* _esm_ebr_state_str[ESM_EBR_STATE_MAX] = {
+static const char* esm_ebr_state_str[ESM_EBR_STATE_MAX] = {
     "BEARER CONTEXT INACTIVE", "BEARER CONTEXT ACTIVE",
     "BEARER CONTEXT INACTIVE PENDING", "BEARER CONTEXT MODIFY PENDING",
     "BEARER CONTEXT ACTIVE PENDING"};
@@ -54,7 +54,7 @@ static const char* _esm_ebr_state_str[ESM_EBR_STATE_MAX] = {
 
 /* Returns the index of the next available entry in the list of EPS bearer
    context data */
-static int _esm_ebr_get_available_entry(emm_context_t* emm_context);
+static int esm_ebr_get_available_entry(emm_context_t* emm_context);
 
 /****************************************************************************/
 /******************  E X P O R T E D    F U N C T I O N S  ******************/
@@ -116,7 +116,7 @@ int esm_ebr_assign(emm_context_t* emm_context) {
   ue_mm_context_t* ue_context_p =
       PARENT_STRUCT(emm_context, struct ue_mm_context_s, emm_context);
 
-  int i = _esm_ebr_get_available_entry(emm_context);
+  int i = esm_ebr_get_available_entry(emm_context);
   if (i < 0) {
     OAILOG_FUNC_RETURN(LOG_NAS_ESM, ESM_EBI_UNASSIGNED);
   }
@@ -516,7 +516,7 @@ int esm_ebr_set_status(
           LOG_NAS_ESM,
           "ESM-FSM   - Status of EPS bearer context %d changed:"
           " %s ===> %s\n",
-          ebi, _esm_ebr_state_str[old_status], _esm_ebr_state_str[status]);
+          ebi, esm_ebr_state_str[old_status], esm_ebr_state_str[status]);
       ebr_ctx->status = status;
       OAILOG_FUNC_RETURN(LOG_NAS_ESM, RETURNok);
     } else {
@@ -524,7 +524,7 @@ int esm_ebr_set_status(
           LOG_NAS_ESM,
           "ESM-FSM   - Status of EPS bearer context %d unchanged:"
           " %s \n",
-          ebi, _esm_ebr_state_str[status]);
+          ebi, esm_ebr_state_str[status]);
     }
   }
 
@@ -640,7 +640,7 @@ bool esm_ebr_is_not_in_use(emm_context_t* emm_context, ebi_t ebi) {
  **      Others:    None                                       **
  **                                                                        **
  ***************************************************************************/
-static int _esm_ebr_get_available_entry(emm_context_t* emm_context) {
+static int esm_ebr_get_available_entry(emm_context_t* emm_context) {
   ue_mm_context_t* ue_mm_context =
       PARENT_STRUCT(emm_context, struct ue_mm_context_s, emm_context);
   int i;

--- a/lte/gateway/c/oai/tasks/nas/esm/esm_information.c
+++ b/lte/gateway/c/oai/tasks/nas/esm/esm_information.c
@@ -48,13 +48,13 @@
 /*
    Timer handlers
 */
-static void _esm_information_t3489_handler(void*, imsi64_t* imsi64);
+static void esm_information_t3489_handler(void*, imsi64_t* imsi64);
 
 /* Maximum value of the deactivate EPS bearer context request
    retransmission counter */
 #define ESM_INFORMATION_COUNTER_MAX 3
 
-static int _esm_information(
+static int esm_information(
     emm_context_t* emm_context_p, ebi_t ebi, esm_ebr_timer_data_t* const data);
 
 /****************************************************************************/
@@ -99,7 +99,7 @@ int esm_proc_esm_information_request(
       data->ebi   = EPS_BEARER_IDENTITY_UNASSIGNED;
       data->msg   = msg_req;
       data->ue_id = ue_id;
-      rc          = _esm_information(emm_context_p, pti, data);
+      rc          = esm_information(emm_context_p, pti, data);
     }
   }
   OAILOG_FUNC_RETURN(LOG_NAS_ESM, rc);
@@ -171,7 +171,7 @@ int esm_proc_esm_information_response(
  **      Others:    None                                       **
  **                                                                        **
  ***************************************************************************/
-static void _esm_information_t3489_handler(void* args, imsi64_t* imsi64) {
+static void esm_information_t3489_handler(void* args, imsi64_t* imsi64) {
   OAILOG_FUNC_IN(LOG_NAS_ESM);
 
   /*
@@ -199,7 +199,7 @@ static void _esm_information_t3489_handler(void* args, imsi64_t* imsi64) {
       /*
        * Re-send deactivate EPS bearer context request message to the UE
        */
-      _esm_information(
+      esm_information(
           esm_ebr_timer_data->ctx, esm_ebr_timer_data->ebi, esm_ebr_timer_data);
     } else {
       /*
@@ -248,7 +248,7 @@ static void _esm_information_t3489_handler(void* args, imsi64_t* imsi64) {
  **      Others:    T3489                                                  **
  **                                                                        **
  ***************************************************************************/
-static int _esm_information(
+static int esm_information(
     emm_context_t* emm_context_p, ebi_t ebi, esm_ebr_timer_data_t* const data) {
   OAILOG_FUNC_IN(LOG_NAS_ESM);
   emm_sap_t emm_sap = {0};
@@ -277,7 +277,7 @@ static int _esm_information(
      */
     emm_context_p->esm_ctx.T3489.id = nas_timer_start(
         emm_context_p->esm_ctx.T3489.sec, 0 /*usec*/,
-        _esm_information_t3489_handler, data);
+        esm_information_t3489_handler, data);
 
     OAILOG_INFO(
         LOG_NAS_EMM,

--- a/lte/gateway/c/oai/tasks/nas/esm/msg/esm_msg.c
+++ b/lte/gateway/c/oai/tasks/nas/esm/msg/esm_msg.c
@@ -69,7 +69,7 @@
 /*******************  L O C A L    D E F I N I T I O N S  *******************/
 /****************************************************************************/
 
-static int _esm_msg_encode_header(
+static int esm_msg_encode_header(
     const esm_msg_header_t* header, uint8_t* buffer, uint32_t len);
 
 /****************************************************************************/
@@ -269,7 +269,7 @@ int esm_msg_encode(ESM_msg* msg, uint8_t* buffer, uint32_t len) {
   /*
    * First encode the ESM message header
    */
-  header_result = _esm_msg_encode_header(&msg->header, buffer, len);
+  header_result = esm_msg_encode_header(&msg->header, buffer, len);
 
   if (header_result < 0) {
     OAILOG_ERROR(
@@ -496,7 +496,7 @@ int esm_msg_decode_header(
  **    Others:  None                                       **
  **                                                                        **
  ***************************************************************************/
-static int _esm_msg_encode_header(
+static int esm_msg_encode_header(
     const esm_msg_header_t* header, uint8_t* buffer, uint32_t len) {
   int size = 0;
 

--- a/lte/gateway/c/oai/tasks/nas/esm/sap/esm_recv.c
+++ b/lte/gateway/c/oai/tasks/nas/esm/sap/esm_recv.c
@@ -605,7 +605,7 @@ esm_cause_t esm_recv_information_response(
  **                                                                        **
  ***************************************************************************/
 
-static void _erab_setup_rsp_tmr_exp_handler(void* args, imsi64_t* imsi64) {
+static void erab_setup_rsp_tmr_exp_handler(void* args, imsi64_t* imsi64) {
   OAILOG_FUNC_IN(LOG_NAS_ESM);
   int rc;
 
@@ -642,7 +642,7 @@ static void _erab_setup_rsp_tmr_exp_handler(void* args, imsi64_t* imsi64) {
         // Restart the timer
         rc = esm_ebr_start_timer(
             esm_ebr_timer_data->ctx, esm_ebr_timer_data->ebi, NULL,
-            ERAB_SETUP_RSP_TMR, _erab_setup_rsp_tmr_exp_handler);
+            ERAB_SETUP_RSP_TMR, erab_setup_rsp_tmr_exp_handler);
         if (rc != RETURNerror) {
           OAILOG_INFO(
               LOG_NAS_ESM,
@@ -801,7 +801,7 @@ esm_cause_t esm_recv_activate_default_eps_bearer_context_accept(
       // Wait for ERAB SETUP RSP.Start a timer for 5 secs
       rc = esm_ebr_start_timer(
           emm_context, ebi, NULL, ERAB_SETUP_RSP_TMR,
-          _erab_setup_rsp_tmr_exp_handler);
+          erab_setup_rsp_tmr_exp_handler);
       if (rc != RETURNerror) {
         OAILOG_DEBUG(
             LOG_NAS_ESM,

--- a/lte/gateway/c/oai/tasks/nas/esm/sap/esm_sap.c
+++ b/lte/gateway/c/oai/tasks/nas/esm/sap/esm_sap.c
@@ -55,7 +55,7 @@ static int _esm_sap_recv(
     emm_context_t* emm_context, const_bstring req, bstring rsp,
     esm_sap_error_t* err);
 
-static int _esm_sap_send(
+static int esm_sap_send_a(
     int msg_type, bool is_standalone, emm_context_t* emm_context,
     proc_tid_t pti, ebi_t ebi, const esm_sap_data_t* data, bstring rsp);
 
@@ -229,7 +229,7 @@ int esm_sap_send(esm_sap_t* msg) {
         }
         /* Send PDN connectivity request */
 
-        rc = _esm_sap_send(
+        rc = esm_sap_send_a(
             ACTIVATE_DEDICATED_EPS_BEARER_CONTEXT_REQUEST, msg->is_standalone,
             msg->ctx, (proc_tid_t) 0, bearer_activate->ebi, &msg->data,
             msg->send);
@@ -254,7 +254,7 @@ int esm_sap_send(esm_sap_t* msg) {
     case ESM_EPS_BEARER_CONTEXT_DEACTIVATE_REQ: {
       if (msg->data.eps_bearer_context_deactivate.is_pcrf_initiated) {
         /*Currently we support single bearear deactivation*/
-        rc = _esm_sap_send(
+        rc = esm_sap_send_a(
             DEACTIVATE_EPS_BEARER_CONTEXT_REQUEST, msg->is_standalone, msg->ctx,
             (proc_tid_t) 0, msg->data.eps_bearer_context_deactivate.ebi[0],
             &msg->data, msg->send);
@@ -808,7 +808,7 @@ static int _esm_sap_recv(
 
 /****************************************************************************
  **                                                                        **
- ** Name:    _esm_sap_send()                                           **
+ ** Name:    esm_sap_send_a()                                           **
  **                                                                        **
  ** Description: Processes ESM messages to send onto the network: Encoded  **
  **      the message and execute the relevant ESM procedure.       **
@@ -828,7 +828,7 @@ static int _esm_sap_recv(
  **      Return:    RETURNok, RETURNerror                      **
  **                                                                        **
  ***************************************************************************/
-static int _esm_sap_send(
+static int esm_sap_send_a(
     int msg_type, bool is_standalone, emm_context_t* emm_context,
     proc_tid_t pti, ebi_t ebi, const esm_sap_data_t* data, bstring rsp) {
   OAILOG_FUNC_IN(LOG_NAS_ESM);

--- a/lte/gateway/c/oai/tasks/nas/esm/sap/esm_sap.c
+++ b/lte/gateway/c/oai/tasks/nas/esm/sap/esm_sap.c
@@ -45,12 +45,12 @@
 /****************************************************************************/
 /****************  E X T E R N A L    D E F I N I T I O N S  ****************/
 /****************************************************************************/
-extern int _pdn_connectivity_delete(emm_context_t* ctx, int pid);
+extern int pdn_connectivity_delete(emm_context_t* ctx, int pid);
 /****************************************************************************/
 /*******************  L O C A L    D E F I N I T I O N S  *******************/
 /****************************************************************************/
 
-static int _esm_sap_recv(
+static int esm_sap_recv(
     int msg_type, unsigned int ue_id, bool is_standalone,
     emm_context_t* emm_context, const_bstring req, bstring rsp,
     esm_sap_error_t* err);
@@ -62,7 +62,7 @@ static int esm_sap_send_a(
 /*
    String representation of ESM-SAP primitives
 */
-static const char* _esm_sap_primitive_str[] = {
+static const char* esm_sap_primitive_str[] = {
     "ESM_DEFAULT_EPS_BEARER_CONTEXT_ACTIVATE_REQ",
     "ESM_DEFAULT_EPS_BEARER_CONTEXT_ACTIVATE_CNF",
     "ESM_DEFAULT_EPS_BEARER_CONTEXT_ACTIVATE_REJ",
@@ -139,7 +139,7 @@ int esm_sap_send(esm_sap_t* msg) {
   assert((primitive > ESM_START) && (primitive < ESM_END));
   OAILOG_INFO(
       LOG_NAS_ESM, "ESM-SAP   - Received primitive %s (%d)\n",
-      _esm_sap_primitive_str[primitive - ESM_START - 1], primitive);
+      esm_sap_primitive_str[primitive - ESM_START - 1], primitive);
 
   switch (primitive) {
     case ESM_PDN_CONNECTIVITY_REQ:
@@ -147,7 +147,7 @@ int esm_sap_send(esm_sap_t* msg) {
        * The MME received a PDN connectivity request message
        */
       increment_counter("ue_pdn_connection", 1, NO_LABELS);
-      rc = _esm_sap_recv(
+      rc = esm_sap_recv(
           PDN_CONNECTIVITY_REQUEST, msg->ue_id, msg->is_standalone, msg->ctx,
           msg->recv, msg->send, &msg->err);
       break;
@@ -189,7 +189,7 @@ int esm_sap_send(esm_sap_t* msg) {
       /*
        * The MME received activate default ESP bearer context accept
        */
-      rc = _esm_sap_recv(
+      rc = esm_sap_recv(
           ACTIVATE_DEFAULT_EPS_BEARER_CONTEXT_ACCEPT, msg->ue_id,
           msg->is_standalone, msg->ctx, msg->recv, msg->send, &msg->err);
       /*
@@ -206,7 +206,7 @@ int esm_sap_send(esm_sap_t* msg) {
       /*
        * The MME received activate default ESP bearer context reject
        */
-      rc = _esm_sap_recv(
+      rc = esm_sap_recv(
           ACTIVATE_DEFAULT_EPS_BEARER_CONTEXT_REJECT, msg->ue_id,
           msg->is_standalone, msg->ctx, msg->recv, msg->send, &msg->err);
       bdestroy_wrapper((bstring*) &msg->recv);
@@ -272,7 +272,7 @@ int esm_sap_send(esm_sap_t* msg) {
       // TODO Assertion bellow is not true now:
       // If only default bearer is supported then release PDN connection as well
       // - Implicit Detach
-      _pdn_connectivity_delete(msg->ctx, pid);
+      pdn_connectivity_delete(msg->ctx, pid);
 
     } break;
 
@@ -280,7 +280,7 @@ int esm_sap_send(esm_sap_t* msg) {
       break;
 
     case ESM_UNITDATA_IND:
-      rc = _esm_sap_recv(
+      rc = esm_sap_recv(
           -1, msg->ue_id, msg->is_standalone, msg->ctx, msg->recv, msg->send,
           &msg->err);
       break;
@@ -292,7 +292,7 @@ int esm_sap_send(esm_sap_t* msg) {
   if (rc != RETURNok) {
     OAILOG_ERROR(
         LOG_NAS_ESM, "ESM-SAP   - Failed to process primitive %s (%d)\n",
-        _esm_sap_primitive_str[primitive - ESM_START - 1], primitive);
+        esm_sap_primitive_str[primitive - ESM_START - 1], primitive);
   }
 
   OAILOG_FUNC_RETURN(LOG_NAS_ESM, rc);
@@ -332,7 +332,7 @@ int esm_sap_send(esm_sap_t* msg) {
  **      Return:    RETURNok, RETURNerror                      **
  **                                                                        **
  ***************************************************************************/
-static int _esm_sap_recv(
+static int esm_sap_recv(
     int msg_type, unsigned int ue_id, bool is_standalone,
     emm_context_t* emm_context, const_bstring req, bstring rsp,
     esm_sap_error_t* err) {

--- a/lte/gateway/c/oai/tasks/nas/nas_procedures.c
+++ b/lte/gateway/c/oai/tasks/nas/nas_procedures.c
@@ -562,7 +562,7 @@ void nas_delete_all_emm_procedures(struct emm_context_s* const emm_context) {
 }
 
 //-----------------------------------------------------------------------------
-static emm_procedures_t* _nas_new_emm_procedures(
+static emm_procedures_t* nas_new_emm_procedures(
     struct emm_context_s* const emm_context) {
   emm_procedures_t* emm_procedures =
       calloc(1, sizeof(*emm_context->emm_procedures));
@@ -574,7 +574,7 @@ static emm_procedures_t* _nas_new_emm_procedures(
 nas_emm_attach_proc_t* nas_new_attach_procedure(
     struct emm_context_s* const emm_context) {
   if (!(emm_context->emm_procedures)) {
-    emm_context->emm_procedures = _nas_new_emm_procedures(emm_context);
+    emm_context->emm_procedures = nas_new_emm_procedures(emm_context);
   } else if (emm_context->emm_procedures->emm_specific_proc) {
     OAILOG_ERROR(
         LOG_NAS_EMM,
@@ -610,7 +610,7 @@ nas_emm_attach_proc_t* nas_new_attach_procedure(
 nas_emm_tau_proc_t* nas_new_tau_procedure(
     struct emm_context_s* const emm_context) {
   if (!(emm_context->emm_procedures)) {
-    emm_context->emm_procedures = _nas_new_emm_procedures(emm_context);
+    emm_context->emm_procedures = nas_new_emm_procedures(emm_context);
   } else if (emm_context->emm_procedures->emm_specific_proc) {
     OAILOG_ERROR(
         LOG_NAS_EMM,
@@ -644,7 +644,7 @@ nas_emm_tau_proc_t* nas_new_tau_procedure(
 nas_sr_proc_t* nas_new_service_request_procedure(
     struct emm_context_s* const emm_context) {
   if (!(emm_context->emm_procedures)) {
-    emm_context->emm_procedures = _nas_new_emm_procedures(emm_context);
+    emm_context->emm_procedures = nas_new_emm_procedures(emm_context);
   } else if (emm_context->emm_procedures->emm_con_mngt_proc) {
     OAILOG_ERROR(
         LOG_NAS_EMM,
@@ -676,7 +676,7 @@ nas_sr_proc_t* nas_new_service_request_procedure(
 nas_emm_ident_proc_t* nas_new_identification_procedure(
     struct emm_context_s* const emm_context) {
   if (!(emm_context->emm_procedures)) {
-    emm_context->emm_procedures = _nas_new_emm_procedures(emm_context);
+    emm_context->emm_procedures = nas_new_emm_procedures(emm_context);
   }
 
   nas_emm_ident_proc_t* ident_proc = calloc(1, sizeof(nas_emm_ident_proc_t));
@@ -707,7 +707,7 @@ nas_emm_ident_proc_t* nas_new_identification_procedure(
 nas_emm_auth_proc_t* nas_new_authentication_procedure(
     struct emm_context_s* const emm_context) {
   if (!(emm_context->emm_procedures)) {
-    emm_context->emm_procedures = _nas_new_emm_procedures(emm_context);
+    emm_context->emm_procedures = nas_new_emm_procedures(emm_context);
   }
 
   nas_emm_auth_proc_t* auth_proc = calloc(1, sizeof(nas_emm_auth_proc_t));
@@ -738,7 +738,7 @@ nas_emm_auth_proc_t* nas_new_authentication_procedure(
 nas_emm_smc_proc_t* nas_new_smc_procedure(
     struct emm_context_s* const emm_context) {
   if (!(emm_context->emm_procedures)) {
-    emm_context->emm_procedures = _nas_new_emm_procedures(emm_context);
+    emm_context->emm_procedures = nas_new_emm_procedures(emm_context);
   }
 
   nas_emm_smc_proc_t* smc_proc = calloc(1, sizeof(nas_emm_smc_proc_t));
@@ -769,7 +769,7 @@ nas_emm_smc_proc_t* nas_new_smc_procedure(
 nas_auth_info_proc_t* nas_new_cn_auth_info_procedure(
     struct emm_context_s* const emm_context) {
   if (!(emm_context->emm_procedures)) {
-    emm_context->emm_procedures = _nas_new_emm_procedures(emm_context);
+    emm_context->emm_procedures = nas_new_emm_procedures(emm_context);
   }
 
   nas_auth_info_proc_t* auth_info_proc =

--- a/lte/gateway/c/oai/tasks/sctp/sctpd_uplink_server.cpp
+++ b/lte/gateway/c/oai/tasks/sctp/sctpd_uplink_server.cpp
@@ -133,26 +133,26 @@ using grpc::ServerBuilder;
 
 using magma::mme::SctpdUplinkImpl;
 
-std::shared_ptr<SctpdUplinkImpl> _service = nullptr;
-std::unique_ptr<Server> _server           = nullptr;
+std::shared_ptr<SctpdUplinkImpl> service = nullptr;
+std::unique_ptr<Server> server           = nullptr;
 
 int start_sctpd_uplink_server(void) {
-  _service = std::make_shared<SctpdUplinkImpl>();
+  service = std::make_shared<SctpdUplinkImpl>();
 
   ServerBuilder builder;
   builder.AddListeningPort(UPSTREAM_SOCK, grpc::InsecureServerCredentials());
-  builder.RegisterService(_service.get());
+  builder.RegisterService(service.get());
 
-  _server = builder.BuildAndStart();
+  server = builder.BuildAndStart();
 
   return 0;
 }
 
 void stop_sctpd_uplink_server(void) {
-  if (_server != nullptr) {
-    _server->Shutdown();
-    _server->Wait();
-    _server = nullptr;
+  if (server != nullptr) {
+    server->Shutdown();
+    server->Wait();
+    server = nullptr;
   }
-  _service = nullptr;
+  service = nullptr;
 }

--- a/lte/gateway/c/oai/tasks/sgs/sgs_service_handler.c
+++ b/lte/gateway/c/oai/tasks/sgs/sgs_service_handler.c
@@ -26,7 +26,7 @@
 #include "sgs_messages.h"
 #include "sgs_messages_types.h"
 
-static void _sgs_send_sgsap_vlr_reset_ack(void);
+static void sgs_send_sgsap_vlr_reset_ack(void);
 
 int handle_sgs_location_update_accept(
     const itti_sgsap_location_update_acc_t* itti_sgsap_location_update_acc_p) {
@@ -304,7 +304,7 @@ int handle_sgs_vlr_reset_indication(
         sgs_vlr_reset_ind_p->vlr_name);
   }
   /* Send SGSAP Reset Ack to VLR */
-  _sgs_send_sgsap_vlr_reset_ack();
+  sgs_send_sgsap_vlr_reset_ack();
   OAILOG_FUNC_RETURN(LOG_NAS_EMM, rc);
 }
 
@@ -347,7 +347,7 @@ int handle_sgs_status_message(const itti_sgsap_status_t* sgs_status_pP) {
  * Send VLR Reset Ack In response to Reset Indication from VLR
  */
 
-static void _sgs_send_sgsap_vlr_reset_ack(void) {
+static void sgs_send_sgsap_vlr_reset_ack(void) {
   MessageDef* message_p                          = NULL;
   itti_sgsap_vlr_reset_ack_t* sgsap_reset_ack_pP = NULL;
 

--- a/lte/gateway/c/oai/tasks/sgw/pgw_handlers.c
+++ b/lte/gateway/c/oai/tasks/sgw/pgw_handlers.c
@@ -64,26 +64,26 @@
 extern spgw_config_t spgw_config;
 extern void print_bearer_ids_helper(const ebi_t*, uint32_t);
 
-static int _spgw_build_and_send_s11_create_bearer_request(
+static int spgw_build_and_send_s11_create_bearer_request(
     s_plus_p_gw_eps_bearer_context_information_t* spgw_ctxt_p,
     const itti_gx_nw_init_actv_bearer_request_t* const bearer_req_p,
     spgw_state_t* spgw_state, teid_t s1_u_sgw_fteid);
 
-static int _create_temporary_dedicated_bearer_context(
+static int create_temporary_dedicated_bearer_context(
     s_plus_p_gw_eps_bearer_context_information_t* spgw_ctxt_p,
     const itti_gx_nw_init_actv_bearer_request_t* const bearer_req_p,
     spgw_state_t* spgw_state, teid_t s1_u_sgw_fteid);
 
-static void _delete_temporary_dedicated_bearer_context(
+static void delete_temporary_dedicated_bearer_context(
     teid_t s1_u_sgw_fteid, ebi_t lbi,
     s_plus_p_gw_eps_bearer_context_information_t* spgw_context_p);
 
-static int32_t _spgw_build_and_send_s11_deactivate_bearer_req(
+static int32_t spgw_build_and_send_s11_deactivate_bearer_req(
     imsi64_t imsi64, uint8_t no_of_bearers_to_be_deact,
     ebi_t* ebi_to_be_deactivated, bool delete_default_bearer,
     teid_t mme_teid_S11);
 
-static void _spgw_handle_s5_response_with_error(
+static void spgw_handle_s5_response_with_error(
     spgw_state_t* spgw_state,
     s_plus_p_gw_eps_bearer_context_information_t* new_bearer_ctxt_info_p,
     teid_t context_teid, ebi_t eps_bearer_id,
@@ -110,7 +110,7 @@ void handle_s5_create_session_request(
         "teid" TEID_FMT "\n",
         context_teid);
     s5_response.status = SGI_STATUS_ERROR_CONTEXT_NOT_FOUND;
-    _spgw_handle_s5_response_with_error(
+    spgw_handle_s5_response_with_error(
         spgw_state, new_bearer_ctxt_info_p, context_teid, eps_bearer_id,
         &s5_response);
   }
@@ -164,7 +164,7 @@ void handle_s5_create_session_request(
   }
 }
 
-void _spgw_handle_s5_response_with_error(
+void spgw_handle_s5_response_with_error(
     spgw_state_t* spgw_state,
     s_plus_p_gw_eps_bearer_context_information_t* new_bearer_ctxt_info_p,
     teid_t context_teid, ebi_t eps_bearer_id,
@@ -305,7 +305,7 @@ int spgw_handle_nw_initiated_bearer_actv_req(
 
   teid_t s1_u_sgw_fteid = spgw_get_new_s1u_teid(spgw_state);
   // Create temporary dedicated bearer context
-  rc = _create_temporary_dedicated_bearer_context(
+  rc = create_temporary_dedicated_bearer_context(
       spgw_ctxt_p, bearer_req_p, spgw_state, s1_u_sgw_fteid);
   if (rc != RETURNok) {
     OAILOG_ERROR_UE(
@@ -316,7 +316,7 @@ int spgw_handle_nw_initiated_bearer_actv_req(
     OAILOG_FUNC_RETURN(LOG_SPGW_APP, RETURNerror);
   }
   // Build and send ITTI message, s11_create_bearer_request to MME APP
-  rc = _spgw_build_and_send_s11_create_bearer_request(
+  rc = spgw_build_and_send_s11_create_bearer_request(
       spgw_ctxt_p, bearer_req_p, spgw_state, s1_u_sgw_fteid);
   if (rc != RETURNok) {
     OAILOG_ERROR_UE(
@@ -325,7 +325,7 @@ int spgw_handle_nw_initiated_bearer_actv_req(
         bearer_req_p->lbi);
 
     *failed_cause = REQUEST_REJECTED;
-    _delete_temporary_dedicated_bearer_context(
+    delete_temporary_dedicated_bearer_context(
         s1_u_sgw_fteid, bearer_req_p->lbi, spgw_ctxt_p);
     OAILOG_FUNC_RETURN(LOG_SPGW_APP, RETURNerror);
   }
@@ -436,7 +436,7 @@ int32_t spgw_handle_nw_initiated_bearer_deactv_req(
   if (no_of_bearers_to_be_deact > 0) {
     bool delete_default_bearer =
         (bearer_req_p->lbi == bearer_req_p->ebi[0]) ? true : false;
-    rc = _spgw_build_and_send_s11_deactivate_bearer_req(
+    rc = spgw_build_and_send_s11_deactivate_bearer_req(
         imsi64, no_of_bearers_to_be_deact, ebi_to_be_deactivated,
         delete_default_bearer,
         spgw_ctxt_p->sgw_eps_bearer_context_information.mme_teid_S11);
@@ -445,7 +445,7 @@ int32_t spgw_handle_nw_initiated_bearer_deactv_req(
 }
 
 // Send ITTI message,S11_NW_INITIATED_DEACTIVATE_BEARER_REQUEST to mme_app
-static int32_t _spgw_build_and_send_s11_deactivate_bearer_req(
+static int32_t spgw_build_and_send_s11_deactivate_bearer_req(
     imsi64_t imsi64, uint8_t no_of_bearers_to_be_deact,
     ebi_t* ebi_to_be_deactivated, bool delete_default_bearer,
     teid_t mme_teid_S11) {
@@ -535,7 +535,7 @@ uint32_t spgw_handle_nw_init_deactivate_bearer_rsp(
 }
 
 // Build and send ITTI message, s11_create_bearer_request to MME APP
-static int _spgw_build_and_send_s11_create_bearer_request(
+static int spgw_build_and_send_s11_create_bearer_request(
     s_plus_p_gw_eps_bearer_context_information_t* spgw_ctxt_p,
     const itti_gx_nw_init_actv_bearer_request_t* const bearer_req_p,
     spgw_state_t* spgw_state, teid_t s1_u_sgw_fteid) {
@@ -592,7 +592,7 @@ static int _spgw_build_and_send_s11_create_bearer_request(
 }
 
 // Create temporary dedicated bearer context
-static int _create_temporary_dedicated_bearer_context(
+static int create_temporary_dedicated_bearer_context(
     s_plus_p_gw_eps_bearer_context_information_t* spgw_ctxt_p,
     const itti_gx_nw_init_actv_bearer_request_t* const bearer_req_p,
     spgw_state_t* spgw_state, teid_t s1_u_sgw_fteid) {
@@ -674,7 +674,7 @@ static int _create_temporary_dedicated_bearer_context(
 }
 
 // Deletes temporary dedicated bearer context
-static void _delete_temporary_dedicated_bearer_context(
+static void delete_temporary_dedicated_bearer_context(
     teid_t s1_u_sgw_fteid, ebi_t lbi,
     s_plus_p_gw_eps_bearer_context_information_t* spgw_context_p) {
   OAILOG_FUNC_IN(LOG_SPGW_APP);

--- a/lte/gateway/c/oai/tasks/sgw/sgw_handlers.c
+++ b/lte/gateway/c/oai/tasks/sgw/sgw_handlers.c
@@ -70,18 +70,18 @@
 extern spgw_config_t spgw_config;
 extern struct gtp_tunnel_ops* gtp_tunnel_ops;
 extern void print_bearer_ids_helper(const ebi_t*, uint32_t);
-static void _handle_failed_create_bearer_response(
+static void handle_failed_create_bearer_response(
     s_plus_p_gw_eps_bearer_context_information_t* spgw_context,
     gtpv2c_cause_value_t cause, imsi64_t imsi64, uint8_t eps_bearer_id,
     teid_t teid);
-static void _generate_dl_flow(
+static void generate_dl_flow(
     packet_filter_contents_t* packet_filter, in_addr_t ipv4_s_addr,
     struct in6_addr* ue_ipv6, struct ip_flow_dl* dlflow);
 
 static bool does_bearer_context_hold_valid_enb_ip(
     ip_address_t enb_ip_address_S1u);
 
-static void _add_tunnel_helper(
+static void add_tunnel_helper(
     s_plus_p_gw_eps_bearer_context_information_t* spgw_context,
     sgw_eps_bearer_ctxt_t* eps_bearer_ctxt_entry_p, imsi64_t imsi64);
 
@@ -578,7 +578,7 @@ static void sgw_add_gtp_tunnel(
            ++itrn) {
         // Prepare DL flow rule
         struct ip_flow_dl dlflow = {0};
-        _generate_dl_flow(
+        generate_dl_flow(
             &(eps_bearer_ctxt_p->tft.packetfilterlist.createnewtft[itrn]
                   .packetfiltercontents),
             ue_ipv4.s_addr, ue_ipv6, &dlflow);
@@ -1630,7 +1630,7 @@ int sgw_handle_nw_initiated_actv_bearer_rsp(
         "Error in retrieving s_plus_p_gw context from sgw_s11_teid " TEID_FMT
         "\n",
         s11_actv_bearer_rsp->sgw_s11_teid);
-    _handle_failed_create_bearer_response(
+    handle_failed_create_bearer_response(
         spgw_context, s11_actv_bearer_rsp->cause.cause_value, imsi64,
         bearer_context.eps_bearer_id, bearer_context.s1u_sgw_fteid.teid);
     OAILOG_FUNC_RETURN(LOG_SPGW_APP, rc);
@@ -1652,7 +1652,7 @@ int sgw_handle_nw_initiated_actv_bearer_rsp(
         "so "
         "did not create new EPS bearer entry for EBI %u\n",
         bearer_context.eps_bearer_id);
-    _handle_failed_create_bearer_response(
+    handle_failed_create_bearer_response(
         spgw_context, s11_actv_bearer_rsp->cause.cause_value, imsi64,
         bearer_context.eps_bearer_id, bearer_context.s1u_sgw_fteid.teid);
     OAILOG_FUNC_RETURN(LOG_SPGW_APP, rc);
@@ -1664,7 +1664,7 @@ int sgw_handle_nw_initiated_actv_bearer_rsp(
         "Did not create new EPS bearer entry as "
         "UE rejected the request for EBI %u\n",
         bearer_context.eps_bearer_id);
-    _handle_failed_create_bearer_response(
+    handle_failed_create_bearer_response(
         spgw_context, s11_actv_bearer_rsp->cause.cause_value, imsi64,
         bearer_context.eps_bearer_id, bearer_context.s1u_sgw_fteid.teid);
     OAILOG_FUNC_RETURN(LOG_SPGW_APP, rc);
@@ -1703,7 +1703,7 @@ int sgw_handle_nw_initiated_actv_bearer_rsp(
           strcpy(policy_rule_name, eps_bearer_ctxt_entry_p->policy_rule_name);
           // setup GTPv1-U tunnel for each packet filter
           // enb, UE and imsi are common across rules
-          _add_tunnel_helper(spgw_context, eps_bearer_ctxt_entry_p, imsi64);
+          add_tunnel_helper(spgw_context, eps_bearer_ctxt_entry_p, imsi64);
         }
       }
       // Remove the temporary spgw entry
@@ -1861,7 +1861,7 @@ int sgw_handle_nw_initiated_deactv_bearer_rsp(
               (eps_bearer_ctxt_p->paa.pdn_type == IPv4_AND_v6)) {
             ue_ipv6 = &eps_bearer_ctxt_p->paa.ipv6_address;
           }
-          _generate_dl_flow(
+          generate_dl_flow(
               &(eps_bearer_ctxt_p->tft.packetfilterlist.createnewtft[itrn]
                     .packetfiltercontents),
               eps_bearer_ctxt_p->paa.ipv4_address.s_addr, ue_ipv6, &dlflow);
@@ -1993,7 +1993,7 @@ bool is_enb_ip_address_same(const fteid_t* fte_p, ip_address_t* ip_p) {
   OAILOG_FUNC_RETURN(LOG_SPGW_APP, rc);
 }
 
-static void _handle_failed_create_bearer_response(
+static void handle_failed_create_bearer_response(
     s_plus_p_gw_eps_bearer_context_information_t* spgw_context,
     gtpv2c_cause_value_t cause, imsi64_t imsi64, uint8_t eps_bearer_id,
     teid_t teid) {
@@ -2051,7 +2051,7 @@ static void _handle_failed_create_bearer_response(
 }
 
 // Fills up downlink (DL) flow match rule from packet filters of eps bearer
-static void _generate_dl_flow(
+static void generate_dl_flow(
     packet_filter_contents_t* packet_filter, in_addr_t ipv4_s_addr,
     struct in6_addr* ue_ipv6, struct ip_flow_dl* dlflow) {
   // Prepare DL flow rule
@@ -2154,7 +2154,7 @@ static void _generate_dl_flow(
 
 // Helper function to generate dl flows and add tunnel for ipv4/ipv6/ipv4v6
 // bearers
-static void _add_tunnel_helper(
+static void add_tunnel_helper(
     s_plus_p_gw_eps_bearer_context_information_t* spgw_context,
     sgw_eps_bearer_ctxt_t* eps_bearer_ctxt_entry_p, imsi64_t imsi64) {
   uint32_t rc        = RETURNerror;
@@ -2175,7 +2175,7 @@ static void _add_tunnel_helper(
       eps_bearer_ctxt_entry_p->tft.numberofpacketfilters);
   for (int i = 0; i < eps_bearer_ctxt_entry_p->tft.numberofpacketfilters; ++i) {
     struct ip_flow_dl dlflow = {0};
-    _generate_dl_flow(
+    generate_dl_flow(
         &(eps_bearer_ctxt_entry_p->tft.packetfilterlist.createnewtft[i]
               .packetfiltercontents),
         ue_ipv4.s_addr, ue_ipv6, &dlflow);


### PR DESCRIPTION
This PR uses Clang-Tidy fix to automate the correction of ~700 instances of [bugprone-reserved-identifier](https://clang.llvm.org/extra/clang-tidy/checks/bugprone-reserved-identifier.html).  These are identifiers that contain a `_` or `__` prefix in certain scopes - which results in undefined behavior (these identifiers are reserved for use by the implementation).  For more context see [DCL51-CPP](https://wiki.sei.cmu.edu/confluence/display/cplusplus/DCL51-CPP.+Do+not+declare+or+define+a+reserved+identifier).

The automated fixup was achieved as follows from within our `lte/gateway/docker/mme/Dockerfile.ubuntu20.04` container.

```
cd lte/gateway/docker/mme/
docker build -t magma-mme-build -f Dockerfile.ubuntu20.04 ../../../../
cd  ../../../../ # local magma repo root
docker run -v $PWD:/magma -v $PWD/lte/gateway/configs:/etc/magma -i -t magma-mme-build:latest /bin/bash
update-alternatives --install /usr/bin/clang-apply-replacements clang-apply-replacements /usr/lib/llvm-11/bin/clang-apply-replacements 10
cd /magma/lte/gateway
make build_oai  # To generate the compile_commands.json file within /build/c/oai/
wget https://raw.githubusercontent.com/llvm-mirror/clang-tools-extra/master/clang-tidy/tool/run-clang-tidy.py
python run-clang-tidy.py -p /build/c/oai/ -j 8 -checks='-*,bugprone-reserved-identifier' -fix
```

Beware that `make build_oai` will result in a clang-format of many files in your repo, as clang 11 format under our clang format rules deviates from the repo formatting.

Test Plan

Ran the integ tests on local VMs using [S1AP Integration Tests](https://github.com/magma/magma/blob/master/docs/readmes/lte/s1ap_tests.md).

Signed-off-by: Scott Harrison Moeller <smoeller@fb.com>