### PR TITLE
[cloud] [orc8r] [agw] Adding cleanup capabilities for Cloudstrapper

### DIFF
--- a/experimental/cloudstrapper/playbooks/cleanup.yaml
+++ b/experimental/cloudstrapper/playbooks/cleanup.yaml
@@ -1,0 +1,14 @@
+---
+
+- hosts: localhost
+  roles:
+    - aws-cleanup 
+  vars_files:
+    - roles/vars/cluster.yaml
+    - roles/vars/defaults.yaml
+    - "{{ dirInventory }}/secrets.yaml"
+  environment:
+    AWS_ACCESS_KEY_ID: "{{ awsAccessKey }}"
+    AWS_SECRET_ACCESS_KEY: "{{ awsSecretKey }}"
+
+

--- a/experimental/cloudstrapper/playbooks/roles/aws-cleanup/tasks/agw-stacks.yaml
+++ b/experimental/cloudstrapper/playbooks/roles/aws-cleanup/tasks/agw-stacks.yaml
@@ -1,0 +1,10 @@
+---
+
+- name: cleaning up all aws region gateway stacks
+  cloudformation:
+    stack_name: "{{ item }}"
+    state: absent
+  with_items:
+    - "{{ deleteStacks }}"
+
+

--- a/experimental/cloudstrapper/playbooks/roles/aws-cleanup/tasks/gw.yaml
+++ b/experimental/cloudstrapper/playbooks/roles/aws-cleanup/tasks/gw.yaml
@@ -1,0 +1,7 @@
+---
+
+- include: agw-stacks.yaml
+  tags: agw
+  environment:
+    AWS_REGION: "{{ awsAgwRegion }}"
+

--- a/experimental/cloudstrapper/playbooks/roles/aws-cleanup/tasks/main.yaml
+++ b/experimental/cloudstrapper/playbooks/roles/aws-cleanup/tasks/main.yaml
@@ -1,0 +1,8 @@
+---
+
+- include: gw.yaml
+  environment:
+    AWS_DEFAULT_REGION: "{{ awsAgwRegion }}"
+- include: orc8r.yaml
+  environment:
+    AWS_DEFAULT_REGION: "{{ awsOrc8rRegion }}"

--- a/experimental/cloudstrapper/playbooks/roles/aws-cleanup/tasks/orc8r-cloudwatch.yaml
+++ b/experimental/cloudstrapper/playbooks/roles/aws-cleanup/tasks/orc8r-cloudwatch.yaml
@@ -1,0 +1,4 @@
+---
+
+- name: delete orchestrator cloudwatch group
+  command: aws logs delete-log-group --log-group-name "{{ orc8rCloudwatchLog }}"

--- a/experimental/cloudstrapper/playbooks/roles/aws-cleanup/tasks/orc8r-ec2-asg.yaml
+++ b/experimental/cloudstrapper/playbooks/roles/aws-cleanup/tasks/orc8r-ec2-asg.yaml
@@ -1,0 +1,22 @@
+---
+
+- name: list autoscaling groups
+  ec2_asg_info:
+    tags:
+      Name: "{{ orc8rAsgClusterTagName }}"
+  register: valAsgCluster
+
+- name: debug
+  debug:
+    msg: "{{ valAsgCluster }}"
+
+- name: set autoscaling group fact
+  set_fact:
+    factAsgCluster: "{{ valAsgCluster.results[0].auto_scaling_group_name }}"
+
+- name: delete autoscaling group
+  command: aws autoscaling delete-auto-scaling-group --auto-scaling-group-name "{{ factAsgCluster }}" --force-delete
+  #  ec2_asg:
+  #  name: "{{ factAsgCluster }}"
+  #  state: absent
+

--- a/experimental/cloudstrapper/playbooks/roles/aws-cleanup/tasks/orc8r-efs.yaml
+++ b/experimental/cloudstrapper/playbooks/roles/aws-cleanup/tasks/orc8r-efs.yaml
@@ -1,0 +1,27 @@
+---
+
+- name: find all filesystems
+  efs_info:
+  register: valEfs
+
+- name: debug filesystem
+  debug:
+    msg: "{{ valEfs }}" 
+
+- name: delete mount targets, because the efs module doesn't do it on it's own
+  command: aws efs delete-mount-target --mount-target-id "{{ item.mount_target_id }}"
+  with_items:
+    - "{{ valEfs.efs[0].mount_targets }}"
+  when: valEfs.efs[0].mount_targets is defined 
+
+- name: sleep for a while before deleting filesystem
+  pause:
+    minutes: 2
+
+- name: delete orc8r efs volume
+  command: aws efs delete-file-system --file-system-id "{{ item.file_system_id }}"
+  with_items:
+    - "{{ valEfs.efs }}"
+  environment:
+    AWS_REGION: "{{ awsOrc8rRegion }}"
+

--- a/experimental/cloudstrapper/playbooks/roles/aws-cleanup/tasks/orc8r-eks.yaml
+++ b/experimental/cloudstrapper/playbooks/roles/aws-cleanup/tasks/orc8r-eks.yaml
@@ -1,0 +1,9 @@
+---
+
+- name: cleaning up orchestator eks cluster
+  aws_eks_cluster:
+    name: "{{ orc8rEksCluster }}"
+    wait: yes
+    state: absent
+
+

--- a/experimental/cloudstrapper/playbooks/roles/aws-cleanup/tasks/orc8r-elb.yaml
+++ b/experimental/cloudstrapper/playbooks/roles/aws-cleanup/tasks/orc8r-elb.yaml
@@ -1,0 +1,12 @@
+---
+
+- name: collect all elb info
+  ec2_elb_info:
+  register: valElb
+
+- name: delete all elbs, because this is a clean deployment
+  ec2_elb_lb:
+    state: absent
+    name: "{{ item.name }}"
+  with_items:
+    - "{{ valElb.elbs }}"

--- a/experimental/cloudstrapper/playbooks/roles/aws-cleanup/tasks/orc8r-eni-subnet-route.yaml
+++ b/experimental/cloudstrapper/playbooks/roles/aws-cleanup/tasks/orc8r-eni-subnet-route.yaml
@@ -1,0 +1,57 @@
+---
+
+- name: locate VPC
+  ec2_vpc_net_info:
+    filters:
+      "tag:Name": "{{ orc8rVpc }}"
+  register: valVpc
+
+
+- name: set vpc cidr fact
+  set_fact: 
+    factVpcCidr: "{{ valVpc.vpcs[0].cidr_block }}"
+
+- name: set vpc id fact
+  set_fact: 
+    factVpcId: "{{ valVpc.vpcs[0].vpc_id }}"
+
+- name: collect all interfaces for this VPC
+  ec2_eni_info:
+    filters: 
+      vpc-id: "{{ factVpcId }}"
+  register: valEni
+
+- name: find subnets of this VPC
+  ec2_vpc_subnet_info:
+    filters:
+      vpc-id: "{{ factVpcId }}"
+  register: valSubnets
+
+
+- name: loop and delete subnets
+  ec2_vpc_subnet:
+    state: absent
+    vpc_id: "{{ item.vpc_id }}"
+    cidr: "{{ item.cidr_block }}"
+  when: item.default_for_az == false
+  with_items:
+    - "{{ valSubnets.subnets }}"
+
+- name: gather all route tables for this subnet
+  ec2_vpc_route_table_info:
+    filters:
+      vpc_id: "{{ factVpcId }}"
+  register: valRtb
+
+- name: print all routing table info
+  debug:
+    msg: "{{ valRtb }}"
+
+
+- name: delete all route tables for this VPC
+  command: aws ec2 delete-route-table --route-table-id "{{ item.id }}"
+  when: item.associations[0] is not defined 
+  with_items:
+    - "{{ valRtb.route_tables }}"
+
+

--- a/experimental/cloudstrapper/playbooks/roles/aws-cleanup/tasks/orc8r-es.yaml
+++ b/experimental/cloudstrapper/playbooks/roles/aws-cleanup/tasks/orc8r-es.yaml
@@ -1,0 +1,4 @@
+---
+
+- name: delete elasticsearch
+  command: aws es delete-elasticsearch-domain --domain-name "{{ orc8rElasticsearch }}"

--- a/experimental/cloudstrapper/playbooks/roles/aws-cleanup/tasks/orc8r-igw.yaml
+++ b/experimental/cloudstrapper/playbooks/roles/aws-cleanup/tasks/orc8r-igw.yaml
@@ -1,0 +1,30 @@
+---
+
+- name: locate VPC
+  ec2_vpc_net_info:
+    filters:
+      "tag:Name": "{{ orc8rVpc }}"
+  register: valVpc
+
+
+- name: set vpc cidr fact
+  set_fact: 
+    factVpcCidr: "{{ valVpc.vpcs[0].cidr_block }}"
+
+- name: set vpc id fact
+  set_fact: 
+    factVpcId: "{{ valVpc.vpcs[0].vpc_id }}"
+
+- name: gather all internet gateways attached to this VPC
+  ec2_vpc_igw_info:
+    filters: 
+      "tag:Name": "{{ orc8rIgw }}"
+      "attachment.state": "available"
+  register: valInetGw
+
+- name: detach internet gateway from VPC
+  command: aws ec2 detach-internet-gateway --internet-gateway-id "{{ valInetGw.internet_gateways[0].internet_gateway_id }}" --vpc-id "{{ factVpcId }}"
+
+- name: delete all inet  gateways for this VPC
+  command: aws ec2 delete-internet-gateway --internet-gateway-id "{{ valInetGw.internet_gateways[0].internet_gateway_id }}"
+

--- a/experimental/cloudstrapper/playbooks/roles/aws-cleanup/tasks/orc8r-natgw.yaml
+++ b/experimental/cloudstrapper/playbooks/roles/aws-cleanup/tasks/orc8r-natgw.yaml
@@ -1,0 +1,32 @@
+---
+
+- name: locate VPC
+  ec2_vpc_net_info:
+    filters:
+      "tag:Name": "{{ orc8rVpc }}"
+  register: valVpc
+
+
+- name: set vpc cidr fact
+  set_fact: 
+    factVpcCidr: "{{ valVpc.vpcs[0].cidr_block }}"
+
+- name: set vpc id fact
+  set_fact: 
+    factVpcId: "{{ valVpc.vpcs[0].vpc_id }}"
+
+- name: gather all NAT gateways for this VPC
+  ec2_vpc_nat_gateway_info:
+    filters: 
+      vpc-id: "{{ factVpcId }}"
+  register: valNatGw
+
+- name: delete all NAT gateways for this VPC
+  ec2_vpc_nat_gateway:
+    state: absent
+    nat_gateway_id: "{{ item.nat_gateway_id }}"
+    release_eip: true
+    wait: yes
+  with_items:
+    - "{{ valNatGw.result }}"
+

--- a/experimental/cloudstrapper/playbooks/roles/aws-cleanup/tasks/orc8r-rds-snapshots.yaml
+++ b/experimental/cloudstrapper/playbooks/roles/aws-cleanup/tasks/orc8r-rds-snapshots.yaml
@@ -1,0 +1,7 @@
+---
+
+- name: delete rds snapshots
+  command: aws rds delete-db-snapshot --db-snapshot-identifier "{{ item }}"
+  with_items: 
+    - "{{ orc8rDbSnapshots }}"
+

--- a/experimental/cloudstrapper/playbooks/roles/aws-cleanup/tasks/orc8r-rds.yaml
+++ b/experimental/cloudstrapper/playbooks/roles/aws-cleanup/tasks/orc8r-rds.yaml
@@ -1,0 +1,27 @@
+---
+
+- name: list all rds instances
+  rds_instance_info:
+  register: dbgRds  
+
+- name: print all rds instances
+  debug:
+    msg: "{{ dbgRds }}"
+  
+- name: delete rds instances
+  command: aws rds delete-db-instance --db-instance-identifier "{{ item }}" --skip-final-snapshot
+  environment: 
+    AWS_ACCESS_KEY: "{{ awsAccessKey }}"
+    AWS_SECRET_KEY: "{{ awsSecretKey }}"
+    AWS_DEFAULT_REGION: "{{ awsOrc8rRegion }}"
+  with_items: 
+    - "{{ orc8rDbs }}"
+
+- name: wait for database deletion before deleting subnet group
+  command: aws rds wait db-instance-deleted --db-instance-identifier "{{ item }}"
+  with_items:
+    - "{{ orc8rDbs }}"
+
+- name: delete rds subnet group
+  command: aws rds delete-db-subnet-group --db-subnet-group-name "{{ orc8rRdsSubnetGroup }}"
+

--- a/experimental/cloudstrapper/playbooks/roles/aws-cleanup/tasks/orc8r-secgroup.yaml
+++ b/experimental/cloudstrapper/playbooks/roles/aws-cleanup/tasks/orc8r-secgroup.yaml
@@ -1,0 +1,52 @@
+---
+
+- name: locate VPC
+  ec2_vpc_net_info:
+    filters:
+      "tag:Name": "{{ orc8rVpc }}"
+  register: valVpc
+
+
+- name: set vpc cidr fact
+  set_fact: 
+    factVpcCidr: "{{ valVpc.vpcs[0].cidr_block }}"
+
+- name: set vpc id fact
+  set_fact: 
+    factVpcId: "{{ valVpc.vpcs[0].vpc_id }}"
+
+- name: gather all security groups for this vpc
+  ec2_group_info:
+    filters:
+      vpc_id: "{{ factVpcId }}"
+      "tag:Name": "{{ item }}"
+  register: valSecGroup
+  with_items:
+    - "{{ orc8rSgs }}"
+
+- name: delete limitedsecurity groups in this VPC
+  ec2_group:
+    group_id: "{{ item.security_groups[0].group_id }}"
+    state: absent
+  with_items:
+    - "{{ valSecGroup.results }}"
+
+- name: gather all security groups for this vpc
+  ec2_group_info:
+    filters:
+      vpc_id: "{{ factVpcId }}"
+  register: valSecGroup
+
+- name: debug remaining security groups
+  debug:
+    msg: "{{ valSecGroup }}"
+
+- name: delete all security groups in this VPC
+  ec2_group:
+    group_id: "{{ item.group_id }}"
+    state: absent
+  when: item.group_name != "default"
+  with_items:
+    - "{{ valSecGroup.security_groups }}"
+  ignore_errors: true
+

--- a/experimental/cloudstrapper/playbooks/roles/aws-cleanup/tasks/orc8r-secrets.yaml
+++ b/experimental/cloudstrapper/playbooks/roles/aws-cleanup/tasks/orc8r-secrets.yaml
@@ -1,0 +1,6 @@
+---
+
+- name: delete orc8r secretsmanager forcefully
+  command: aws secretsmanager delete-secret --secret-id "{{ orc8rSecrets }}" --force-delete-without-recovery 
+  tags:
+    - tagCleanupSecrets

--- a/experimental/cloudstrapper/playbooks/roles/aws-cleanup/tasks/orc8r-vpc.yaml
+++ b/experimental/cloudstrapper/playbooks/roles/aws-cleanup/tasks/orc8r-vpc.yaml
@@ -1,0 +1,23 @@
+---
+
+- name: locate VPC
+  ec2_vpc_net_info:
+    filters:
+      "tag:Name": "{{ orc8rVpc }}"
+  register: valVpc
+
+
+- name: set vpc cidr fact
+  set_fact: 
+    factVpcCidr: "{{ valVpc.vpcs[0].cidr_block }}"
+
+- name: set vpc id fact
+  set_fact: 
+    factVpcId: "{{ valVpc.vpcs[0].vpc_id }}"
+
+- name: delete vpc
+  ec2_vpc_net:
+    state: absent
+    name: "{{ orc8rVpc }}"
+    cidr_block: "{{ factVpcCidr }}"
+  tags: tagDeleteVpc

--- a/experimental/cloudstrapper/playbooks/roles/aws-cleanup/tasks/orc8r.yaml
+++ b/experimental/cloudstrapper/playbooks/roles/aws-cleanup/tasks/orc8r.yaml
@@ -1,0 +1,46 @@
+---
+
+- include: orc8r-es.yaml
+  tags: es
+
+- include: orc8r-eks.yaml
+  tags: eks
+
+- include: orc8r-ec2-asg.yaml
+  tags: asg
+
+- include: orc8r-elb.yaml
+  tags: elb
+
+- include: orc8r-rds.yaml
+  tags: rds
+
+    #There may be no snapshots
+- include: orc8r-rds-snapshots.yaml
+  tags: [ never, ndssnap ]
+  ignore_errors: true
+
+- include: orc8r-efs.yaml
+  tags: efs
+
+- include: orc8r-secrets.yaml
+  tags: secrets
+
+- include: orc8r-cloudwatch.yaml
+  tags: cloudwatch
+
+- include: orc8r-natgw.yaml
+  tags: natgw
+
+- include: orc8r-igw.yaml
+  tags: igw
+
+- include: orc8r-eni-subnet-route.yaml
+  tags: subnet
+
+- include: orc8r-secgroup.yaml
+  tags: secgroup
+   
+- include: orc8r-vpc.yaml
+  tags: vpc
+

--- a/experimental/cloudstrapper/playbooks/roles/aws-cleanup/vars/main.yaml
+++ b/experimental/cloudstrapper/playbooks/roles/aws-cleanup/vars/main.yaml
@@ -1,0 +1,57 @@
+---
+deleteStacks:
+  - stackSanRamonAgwANic2
+  - stackSanRamonAgwA
+  - stackSanRamonNetwork
+  - stackTokyogwANic2
+  - stackTokyoAgwA
+  - stackTokyoNetwork
+fullStacks:
+  - stackTokyogwANic2
+  - stackTokyoAgwA
+  - stackTokyoNetwork
+  - stackAlphaDeltaBuild
+  - stackMenloParkAgwBNic2
+  - stackMenloParkAgwB
+  - stackMenloParkNetwork
+  - stackMenloParkAgwANic2
+  - stackMenloParkAgwA
+  - stackMenloParkNetwork
+  - stackCupertinoAgwANic2
+  - stackCupertinoAgwA
+  - stackCupertinoNetwork
+  - stackSanRamonAgwANic2
+  - stackSanRamonAgwA
+  - stackSanRamonNetwork
+orc8rDbs:
+  - nmsdb
+  - orc8rdb
+orc8rDbSnapshots:
+  - nmsdb-final-snapshot
+  - orc8rdb-final-snapshot
+orc8rDbParameterGroups:
+  - default.mysql5.7
+  - default.postgres9.6
+
+orc8rSecrets: "{{ orc8rTfSecrets }}"
+orc8rElasticsearch: "{{ orc8rTfEs }}"
+orc8rCloudwatchLog: "/aws/eks/{{ orc8rTfVpc }}/cluster"
+
+orc8rAsgClusterTagName: "{{ orc8rTfVpc }}-wg-1-eks_asg"
+orc8rEfs: "{{ orc8rTfVpc }}.k8s.pv.local"
+
+orc8rVpc: "{{ orc8rTfVpc }}"
+orc8rIgw: "{{ orc8rTfVpc }}"
+orc8rRdsSubnetGroup: "{{ orc8rTfVpc }}"
+orc8rEksCluster: "{{ orc8rTfVpc }}"
+
+orc8rSgs:
+  - "{{ orc8rTfVpc }}-eks_cluster_sg"
+  - "{{ orc8rTfVpc }}-eks_worker_sg"
+
+orc8rDomainRecords:
+  - api
+  - bootstrapper-controller
+  - controller
+  - fluentd
+  - nms


### PR DESCRIPTION
Signed-off-by: Arun Thulasi <arunt@fb.com>

## Summary

Orchestrator cleanup done via 'terraform destroy' might leave out some resources. This impedes future orchestrator re-deployments until these resources are manually cleaned up. The cleanup capability added to Cloudstrapper provides an automatic, customized way to cleanup an orchestrator deployment with or without an associated 'terraform destroy'.

## Test Plan

A running orchestrator deployment was cleaned up by following the instructions available from the README file.

## Additional Information

The cleanup capability can be used with a Cloudstrapper deployed Orchestrator and with traditionally deployed Orchestrators.
