### PR TITLE
AGW: ubuntu: Fix resolv.conf link

### DIFF
--- a/lte/gateway/deploy/roles/magma/tasks/main.yml
+++ b/lte/gateway/deploy/roles/magma/tasks/main.yml
@@ -10,6 +10,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+- name: Fix resove conf
+  when: ansible_distribution == "Ubuntu"
+  shell: ln -sf /var/run/systemd/resolve/resolv.conf /etc/resolv.conf
+
 - name: Include vars of all.yaml
   include_vars:
     file: all.yaml


### PR DESCRIPTION
On ubuntu there is known issue of resolv.conf symb link. Fix it
during privisioning.

Signed-off-by: Pravin B Shelar <pbshelar@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
