### PR TITLE
AGW: ubuntu: dev-vm: fix multipath conf

### DIFF
--- a/lte/gateway/deploy/roles/dev_common/files/patches/multipath-conf.patch
+++ b/lte/gateway/deploy/roles/dev_common/files/patches/multipath-conf.patch
@@ -1,0 +1,12 @@
+--- /etc/multipath.conf.orig	2021-03-18 09:06:46.425528574 +0000
++++ /etc/multipath.conf	2021-03-17 12:52:18.472644591 +0000
+@@ -1,3 +1,9 @@
+ defaults {
+     user_friendly_names yes
+ }
++blacklist {
++  device {
++    vendor "VBOX"
++    product "HARDDISK"
++  }
++}

--- a/lte/gateway/deploy/roles/dev_common/tasks/main.yml
+++ b/lte/gateway/deploy/roles/dev_common/tasks/main.yml
@@ -320,3 +320,9 @@
     path: /var/tmp/test_results
     state: directory
     mode: 0777
+
+- name: Patch multipath conf
+  when: preburn and ansible_distribution == "Ubuntu"
+  patch:
+    src: patches/multipath-conf.patch
+    dest: /etc/multipath.conf


### PR DESCRIPTION
Change config to skip virtualbox disk from multipath probe.
this avoids error msg in syslogs

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
