### PR TITLE
[docs]Changes to avoid builds when only docs folders are committed

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -92,7 +92,7 @@ orbs:
                   fi
                 done
                 echo "No changes in [$paths]"
-                circleci step halt
+                circleci-agent step halt
 
 commands:
   install-go:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -83,16 +83,27 @@ orbs:
                   exit 0
                 fi
 
-                paths=".circleci circleci <<parameters.paths>>"
+                paths="circleci docs <<parameters.paths>>"
                 echo "Checking paths [$paths]"
+                docsOnlyChanged=1
                 for path in $paths; do
                   if [[ $(git diff master^ --name-only $path) ]]; then
                     echo "Found changes in $path"
-                    exit 0
+                    if [ "$path" != "docs" ]; then
+                      docsOnlyChanged=0
+                      exit 0
+                    fi
                   fi
                 done
+                if [ "$docsOnlyChanged" -eq "1" ]; then
+                   echo "No changes in this commit. So cancelling the CI build."
+                   curl --request POST \
+                               --url https://circleci.com/api/v2/workflow/$CIRCLE_WORKFLOW_ID/cancel \
+                               --header "Circle-Token: 41304b5c2d9ed542f0b061acb0f816e0627a9e4b"
+                   exit 0
+                fi
                 echo "No changes in [$paths]"
-                circleci-agent step halt
+                circleci step halt
 
 commands:
   install-go:

--- a/docs/testfile.txt
+++ b/docs/testfile.txt
@@ -1,0 +1,2 @@
+This is for test only. please ignore.
+Thank you !


### PR DESCRIPTION
<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary
Changes to avoid build if only changes are made in docs/ folder
<!-- Enumerate changes you made and why you made them -->

## Test Plan

**CircleCI build on making changes only to the docs folder:**
https://app.circleci.com/pipelines/github/magma/magma?branch=docs_build_test

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [NO ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
