### PR TITLE
[lte][agw] Revert ICS message criticality to reject

### DIFF
--- a/lte/gateway/c/oai/tasks/s1ap/s1ap_mme_nas_procedures.c
+++ b/lte/gateway/c/oai/tasks/s1ap/s1ap_mme_nas_procedures.c
@@ -886,7 +886,7 @@ void s1ap_handle_conn_est_cnf(
       S1ap_ProcedureCode_id_InitialContextSetup;
   pdu.choice.initiatingMessage.value.present =
       S1ap_InitiatingMessage__value_PR_InitialContextSetupRequest;
-  pdu.choice.initiatingMessage.criticality = S1ap_Criticality_ignore;
+  pdu.choice.initiatingMessage.criticality = S1ap_Criticality_reject;
   out = &pdu.choice.initiatingMessage.value.choice.InitialContextSetupRequest;
 
   /* mandatory */


### PR DESCRIPTION
## Summary

Rel 15 changes in v1.4 potentially changed the ICS criticality as outlined at issue #5576. PR changes the IE criticality back to reject as the spec dictates. 

## Test Plan

Run test_attach_detach.py in s1ap tester and check the encoded message in PCAP.

![Screen Shot 2021-03-19 at 10 23 20 AM](https://user-images.githubusercontent.com/16007119/111819298-67581180-889d-11eb-9f9a-07d2bd54ad3d.png)


## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
