### PR TITLE
[CI] Turn up Dockerfile Linting in GH PR

### DIFF
--- a/.github/workflows/hadolint.yml
+++ b/.github/workflows/hadolint.yml
@@ -1,0 +1,17 @@
+name: Dockerfile Linting
+on: [pull_request]
+jobs:
+  hadolint:
+    name: Dockerfile Lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v1
+      - name: hadolint
+        uses: reviewdog/action-hadolint@v1
+        with:
+          github_token: ${{ secrets.github_token }}
+          reporter: github-pr-review # Default is github-pr-check
+          # Ignore DL3005-"Do not use apt-get upgrade or dist-upgrade"
+          hadolint_ignore: DL3005
+          filter_mode: file


### PR DESCRIPTION
[Hadolint](https://github.com/hadolint/hadolint) is an industry leading Dockerfile linting tool written in Haskell.  This GH action uses [reviewdog](https://github.com/reviewdog/reviewdog) for Github Actions to annotate our Dockerfiles with linting warnings from Hadolint - in Pull Requests containing Dockerfiles.

Hadolint also lints shell commands thanks to the fantastic [Shellcheck](https://github.com/koalaman/shellcheck) linting tool for the shell.

The sample findings on my existing Dockerfile are very helpful, this seems worth having available to us on PRs.  @rdefosse if you find it annoying, or disagree with its advice, we can certainly whitelist some directories so they aren't linted - if you like. Let me know.

Presently I have it linting any file that is touched. We can alternatively lint only modified lines (one line change). Up to us.

Signed-off-by: Scott Harrison Moeller <smoeller@fb.com>