### PR TITLE
AGW: package: fix rsyslog config conflict.

### DIFF
--- a/lte/gateway/release/build-magma.sh
+++ b/lte/gateway/release/build-magma.sh
@@ -364,7 +364,7 @@ $(glob_files "${ANSIBLE_FILES}/magma_modules_load" /etc/modules-load.d/magma.con
 $(glob_files "${ANSIBLE_FILES}/configure_envoy_namespace.sh" /usr/local/bin/ ) \
 $(glob_files "${ANSIBLE_FILES}/envoy.yaml" /var/opt/magma/ ) \
 $(glob_files "${ANSIBLE_FILES}/logrotate_oai.conf" /etc/logrotate.d/oai) \
-$(glob_files "${ANSIBLE_FILES}/logrotate_rsyslog.conf" /etc/logrotate.d/rsyslog) \
+$(glob_files "${ANSIBLE_FILES}/logrotate_rsyslog.conf" /etc/logrotate.d/rsyslog.magma) \
 $(glob_files "${ANSIBLE_FILES}/local-cdn/*" /var/www/local-cdn/) \
 ${ANSIBLE_FILES}/99-magma.conf=/etc/sysctl.d/ \
 ${ANSIBLE_FILES}/magma_ifaces_gtp=/etc/network/interfaces.d/gtp \

--- a/lte/gateway/release/magma-postinst
+++ b/lte/gateway/release/magma-postinst
@@ -37,6 +37,8 @@ systemctl stop lighttpd
 systemctl disable lighttpd
 
 # Restart rsyslog to pick up fluent-bit config, create fluent-bit DB directory
+cp /etc/logrotate.d/rsyslog /etc/logrotate.d/rsyslog.orig
+cp /etc/logrotate.d/rsyslog.magma /etc/logrotate.d/rsyslog
 systemctl restart rsyslog
 mkdir -p /var/opt/magma/fluent-bit
 


### PR DESCRIPTION
config '/etc/logrotate.d/rsyslog' is owned by rsyslog package.
avoid packging the config to fix following package installation issue
---8<---
vagrant@ubuntu-focal:/vagrant/test1$ sudo dpkg -i magma_1.5.0-1616259638-d9dbdbb4_amd64.deb
(Reading database ... 75065 files and directories currently installed.)
Preparing to unpack magma_1.5.0-1616259638-d9dbdbb4_amd64.deb ...
Unpacking magma (1.5.0-1616259638-d9dbdbb4) ...
dpkg: error processing archive magma_1.5.0-1616259638-d9dbdbb4_amd64.deb (--install):
 trying to overwrite '/etc/logrotate.d/rsyslog', which is also in package rsyslog 8.2001.0-1ubuntu1.1
Processing triggers for rsyslog (8.2001.0-1ubuntu1.1) ...
Errors were encountered while processing:
 magma_1.5.0-1616259638-d9dbdbb4_amd64.deb

Signed-off-by: Pravin B Shelar <pbshelar@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
