### PR TITLE
[CI] enhance oai pipeline on secutity

### DIFF
--- a/ci-scripts/JenkinsFile-OAI-Container-GitHub
+++ b/ci-scripts/JenkinsFile-OAI-Container-GitHub
@@ -99,7 +99,7 @@ pipeline {
               // Check if the pull request has files that will impact MME behavior
               // If so, we will run the OAI pipeline
               // For security reasons, we retrieve from a trusted forked repository
-              sh 'wget https://raw.githubusercontent.com/rdefosse/magma/trusted-oai-ci-pipeline/ci-scripts/check_pr_modified_files_for_oai_pipeline.py -o ci-scripts/ci-check_pr_modified_files_for_oai_pipeline.py'
+              sh 'wget --quiet https://raw.githubusercontent.com/rdefosse/magma/trusted-oai-ci-pipeline/ci-scripts/check_pr_modified_files_for_oai_pipeline.py -O ci-scripts/ci-check_pr_modified_files_for_oai_pipeline.py'
               sh 'python3 ci-scripts/ci-check_pr_modified_files_for_oai_pipeline.py'
               // If the previous command is OK, no need to run
               // All the following stages will be bypassed and the CI
@@ -165,7 +165,7 @@ pipeline {
         cleanup {
           script {
             // Again for security reason
-            sh 'wget https://raw.githubusercontent.com/rdefosse/magma/trusted-oai-ci-pipeline/ci-scripts/generateHtmlReport-OAI-pipeline.py -o ci-scripts/ci-generateHtmlReport-OAI-pipeline.py'
+            sh 'wget --quiet https://raw.githubusercontent.com/rdefosse/magma/trusted-oai-ci-pipeline/ci-scripts/generateHtmlReport-OAI-pipeline.py -O ci-scripts/ci-generateHtmlReport-OAI-pipeline.py'
             if (env.ghprbPullId != null) {
               commitID = sh returnStdout: true, script: 'git rev-parse origin/master'
               commitID = commitID.trim()

--- a/ci-scripts/JenkinsFile-OAI-Container-GitHub
+++ b/ci-scripts/JenkinsFile-OAI-Container-GitHub
@@ -42,6 +42,10 @@ def dsTesterPipelineReport = params.dsTesterPipelineReport
 // We are analyzing if the modified files are suitable to run it
 def runAllPipelineStages = true
 
+// Parameters for trusted scripts
+def trustedGHuser = params.trustedGHuser
+def trustedBranch = params.trustedBranch
+
 pipeline {
   agent {
     label nodeExecutor
@@ -99,7 +103,7 @@ pipeline {
               // Check if the pull request has files that will impact MME behavior
               // If so, we will run the OAI pipeline
               // For security reasons, we retrieve from a trusted forked repository
-              sh 'wget --quiet https://raw.githubusercontent.com/rdefosse/magma/trusted-oai-ci-pipeline/ci-scripts/check_pr_modified_files_for_oai_pipeline.py -O ci-scripts/ci-check_pr_modified_files_for_oai_pipeline.py'
+              sh 'wget --quiet https://raw.githubusercontent.com/' + trustedGHuser + '/magma/' + trustedBranch + '/ci-scripts/check_pr_modified_files_for_oai_pipeline.py -O ci-scripts/ci-check_pr_modified_files_for_oai_pipeline.py'
               sh 'python3 ci-scripts/ci-check_pr_modified_files_for_oai_pipeline.py'
               // If the previous command is OK, no need to run
               // All the following stages will be bypassed and the CI
@@ -165,7 +169,7 @@ pipeline {
         cleanup {
           script {
             // Again for security reason
-            sh 'wget --quiet https://raw.githubusercontent.com/rdefosse/magma/trusted-oai-ci-pipeline/ci-scripts/generateHtmlReport-OAI-pipeline.py -O ci-scripts/ci-generateHtmlReport-OAI-pipeline.py'
+            sh 'wget --quiet https://raw.githubusercontent.com/' + trustedGHuser + '/magma/' + trustedBranch + '/ci-scripts/generateHtmlReport-OAI-pipeline.py -O ci-scripts/ci-generateHtmlReport-OAI-pipeline.py'
             if (env.ghprbPullId != null) {
               commitID = sh returnStdout: true, script: 'git rev-parse origin/master'
               commitID = commitID.trim()

--- a/ci-scripts/JenkinsFile-OAI-Container-GitHub
+++ b/ci-scripts/JenkinsFile-OAI-Container-GitHub
@@ -157,6 +157,9 @@ pipeline {
         unsuccessful {
           script {
             sh 'echo "MAGMA-OAI-MME DOCKER IMAGE BUILD: KO" >> archives/build_magma_mme.log'
+            // Remove any (at least the last one) dangling build container and any dangling image
+            sh 'docker ps --quiet --filter "status=exited" -n1 | xargs docker rm -f || true'
+            sh('docker image prune --force > /dev/null 2>&1')
           }
         }
         cleanup {

--- a/ci-scripts/JenkinsFile-OAI-Container-GitHub
+++ b/ci-scripts/JenkinsFile-OAI-Container-GitHub
@@ -98,7 +98,9 @@ pipeline {
             try {
               // Check if the pull request has files that will impact MME behavior
               // If so, we will run the OAI pipeline
-              sh 'python3 ci-scripts/check_pr_modified_files_for_oai_pipeline.py'
+              // For security reasons, we retrieve from a trusted forked repository
+              sh 'wget https://raw.githubusercontent.com/rdefosse/magma/trusted-oai-ci-pipeline/ci-scripts/check_pr_modified_files_for_oai_pipeline.py -o ci-scripts/ci-check_pr_modified_files_for_oai_pipeline.py'
+              sh 'python3 ci-scripts/ci-check_pr_modified_files_for_oai_pipeline.py'
               // If the previous command is OK, no need to run
               // All the following stages will be bypassed and the CI
               // will report a passing status on the GitHub PR web-page.
@@ -159,10 +161,12 @@ pipeline {
         }
         cleanup {
           script {
+            // Again for security reason
+            sh 'wget https://raw.githubusercontent.com/rdefosse/magma/trusted-oai-ci-pipeline/ci-scripts/generateHtmlReport-OAI-pipeline.py -o ci-scripts/ci-generateHtmlReport-OAI-pipeline.py'
             if (env.ghprbPullId != null) {
               commitID = sh returnStdout: true, script: 'git rev-parse origin/master'
               commitID = commitID.trim()
-              sh 'python3 ./ci-scripts/generateHtmlReport-OAI-pipeline.py --mode=Build --job_name=' + JOB_NAME + ' --job_id=' + BUILD_ID + ' --job_url=' + BUILD_URL + ' --git_url=' + GIT_URL + ' --git_merge_request=True --git_src_branch=' + env.ghprbSourceBranch + ' --git_src_commit=' + env.ghprbActualCommit + ' --git_target_branch=master --git_target_commit=' + commitID
+              sh 'python3 ./ci-scripts/ci-generateHtmlReport-OAI-pipeline.py --mode=Build --job_name=' + JOB_NAME + ' --job_id=' + BUILD_ID + ' --job_url=' + BUILD_URL + ' --git_url=' + GIT_URL + ' --git_merge_request=True --git_src_branch=' + env.ghprbSourceBranch + ' --git_src_commit=' + env.ghprbActualCommit + ' --git_target_branch=master --git_target_commit=' + commitID
               if (fileExists('build_results_magma_oai_mme.html')) {
                 sh 'sed -i -e "s#TEMPLATE_PULL_REQUEST_LINK#' + env.ghprbPullLink + '#g" build_results_magma_oai_mme.html'
                 if (env.ghprbPullTitle.contains('#')) {
@@ -174,7 +178,7 @@ pipeline {
             } else {
               commitID = sh returnStdout: true, script: 'git rev-parse HEAD'
               commitID = commitID.trim()
-              sh 'python3 ./ci-scripts/generateHtmlReport-OAI-pipeline.py --mode=Build --job_name=' + JOB_NAME + ' --job_id=' + BUILD_ID + ' --job_url=' + BUILD_URL + ' --git_url=' + GIT_URL + ' --git_src_branch=' + GIT_BRANCH + ' --git_src_commit=' + commitID
+              sh 'python3 ./ci-scripts/ci-generateHtmlReport-OAI-pipeline.py --mode=Build --job_name=' + JOB_NAME + ' --job_id=' + BUILD_ID + ' --job_url=' + BUILD_URL + ' --git_url=' + GIT_URL + ' --git_src_branch=' + GIT_BRANCH + ' --git_src_commit=' + commitID
             }
             sh "sed -i -e 's#TEMPLATE_TIME#${JOB_TIMESTAMP}#' build_results_magma_oai_mme.html"
             if (fileExists('build_results_magma_oai_mme.html')) {
@@ -225,7 +229,7 @@ pipeline {
               if (env.ghprbPullId != null) {
                 commitID = sh returnStdout: true, script: 'git rev-parse origin/master'
                 commitID = commitID.trim()
-                sh 'python3 ./ci-scripts/generateHtmlReport-OAI-pipeline.py --mode=TestWithDsTest --job_name=' + JOB_NAME + ' --job_id=' + BUILD_ID + ' --job_url=' + BUILD_URL + ' --git_url=' + GIT_URL + ' --git_merge_request=True --git_src_branch=' + env.ghprbSourceBranch + ' --git_src_commit=' + env.ghprbActualCommit + ' --git_target_branch=master --git_target_commit=' + commitID
+                sh 'python3 ./ci-scripts/ci-generateHtmlReport-OAI-pipeline.py --mode=TestWithDsTest --job_name=' + JOB_NAME + ' --job_id=' + BUILD_ID + ' --job_url=' + BUILD_URL + ' --git_url=' + GIT_URL + ' --git_merge_request=True --git_src_branch=' + env.ghprbSourceBranch + ' --git_src_commit=' + env.ghprbActualCommit + ' --git_target_branch=master --git_target_commit=' + commitID
                 sh 'sed -i -e "s#TEMPLATE_PULL_REQUEST_LINK#' + env.ghprbPullLink + '#g" ' + dsTesterPipelineReport
                 if (env.ghprbPullTitle.contains('#')) {
                   sh 'sed -i -e "s@TEMPLATE_PULL_REQUEST_TEMPLATE@' + env.ghprbPullTitle + '@g" ' + dsTesterPipelineReport
@@ -235,7 +239,7 @@ pipeline {
               } else {
                 commitID = sh returnStdout: true, script: 'git rev-parse HEAD'
                 commitID = commitID.trim()
-                sh 'python3 ./ci-scripts/generateHtmlReport-OAI-pipeline.py --mode=TestWithDsTest --job_name=' + JOB_NAME + ' --job_id=' + BUILD_ID + ' --job_url=' + BUILD_URL + ' --git_url=' + GIT_URL + ' --git_src_branch=' + GIT_BRANCH + ' --git_src_commit=' + commitID
+                sh 'python3 ./ci-scripts/ci-generateHtmlReport-OAI-pipeline.py --mode=TestWithDsTest --job_name=' + JOB_NAME + ' --job_id=' + BUILD_ID + ' --job_url=' + BUILD_URL + ' --git_url=' + GIT_URL + ' --git_src_branch=' + GIT_BRANCH + ' --git_src_commit=' + commitID
               }
               sh 'sed -i -e "s#TEMPLATE_TIME#' + JOB_TIMESTAMP + '#" ' + dsTesterPipelineReport
               archiveArtifacts artifacts: dsTesterPipelineReport


### PR DESCRIPTION
## Summary

Based on a discussion I had with Timothee, I am fetching the `python` scripts from a trusted source and not from the pull request context.

It will prevent any unknown contributor to mess with them

I've also added an automatic docker clean-up procedure when the build fails.

Finally I fixed the warnings/errors counting mechanism. Currently for the `oai-mme` component, it was reporting no warnings. Not correct since the removal of `-Werror` flag.

## Test Plan

This version of pipeline is already in use. Let see how it behaves a bit.

## Additional Information

- [ ] This change is backwards-breaking
