### PR TITLE
AGW: fix OVS dependencies for ubuntu package

### DIFF
--- a/lte/gateway/fabfile.py
+++ b/lte/gateway/fabfile.py
@@ -71,7 +71,7 @@ def test():
 def package(vcs='hg', all_deps="False",
             cert_file=DEFAULT_CERT, proxy_config=DEFAULT_PROXY,
             destroy_vm='False',
-            vm='magma'):
+            vm='magma', os="debian"):
     """ Builds the magma package """
     all_deps = False if all_deps == "False" else True
     destroy_vm = bool(strtobool(destroy_vm))
@@ -99,8 +99,9 @@ def package(vcs='hg', all_deps="False",
         print("Building magma package, picking up commit %s..." % hash)
         run('make clean')
         build_type = "Debug" if env.debug_mode else "RelWithDebInfo"
-        run('./release/build-magma.sh -h "%s" -t %s --cert %s --proxy %s' %
-            (hash, build_type, cert_file, proxy_config))
+
+        run('./release/build-magma.sh -h "%s" -t %s --cert %s --proxy %s --os %s' %
+            (hash, build_type, cert_file, proxy_config, os))
 
 
         run('rm -rf ~/magma-packages')

--- a/lte/gateway/release/magma.lockfile
+++ b/lte/gateway/release/magma.lockfile
@@ -826,6 +826,12 @@
           "sysdep": "python3-ryu",
           "version": "4.30"
         },
+        "sentry-sdk": {
+          "root": true,
+          "source": "pypi",
+          "sysdep": "python3-sentry-sdk",
+          "version": "1.0.0"
+        },
         "simplejson": {
           "root": false,
           "source": "pypi",
@@ -980,6 +986,9 @@
         },
         "rfc3987": {
           "version": "1.3.8"
+        },
+        "sentry-sdk": {
+          "version": "1.0.0"
         },
         "setuptools": {
           "version": "49.6.0"


### PR DESCRIPTION
On ubuntu distribution magma AGW is going to use
updated OVS 2.14 binaries.
Following patch updates OVS 2.8 dependency to 2.14.

Signed-off-by: Pravin B Shelar <pbshelar@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
