### PR TITLE
[MME] Address Clang -Wextern-c-compat warnings on zero-size structs

### DIFF
--- a/lte/gateway/c/oai/include/s6a_messages_types.h
+++ b/lte/gateway/c/oai/include/s6a_messages_types.h
@@ -156,6 +156,7 @@ typedef struct s6a_purge_ue_ans_s {
 
 typedef struct s6a_reset_req_s {
   /* RESET ALL. Partial Reset TBD*/
+  uint8_t unused;
 } s6a_reset_req_t;
 
 #endif /* FILE_S6A_MESSAGES_TYPES_SEEN */

--- a/lte/gateway/c/oai/include/service303_messages_types.h
+++ b/lte/gateway/c/oai/include/service303_messages_types.h
@@ -17,12 +17,20 @@
 #ifndef FILE_SERVICE303_MESSAGES_TYPES_SEEN
 #define FILE_SERVICE303_MESSAGES_TYPES_SEEN
 
-// Nothing needed in message for now
+#include <stdint.h>
+
+// Nothing needed in message for now, but an empty struct is a c-c++ compatibility
+// risk (sizeof zero bytes in c, sizeof one byte in c++). Therefore we allocate an
+// unused uint8_t to ensure sizes are always 1 byte.
 typedef struct application_healthy_msg {
+  uint8_t unused;
 } application_healthy_msg_t;
 
-// Nothing needed in message for now
+// Nothing needed in message for now, but an empty struct is a c-c++ compatibility
+// risk (sizeof zero bytes in c, sizeof one byte in c++). Therefore we allocate an
+// unused int32_t to ensure sizes are always 1 byte.
 typedef struct application_unhealthy_msg {
+  uint8_t unused;
 } application_unhealthy_msg_t;
 
 #endif /* FILE_SERVICE303_MESSAGES_TYPES_SEEN */

--- a/lte/gateway/c/oai/lib/3gpp/3gpp_24.008.h
+++ b/lte/gateway/c/oai/lib/3gpp/3gpp_24.008.h
@@ -38,6 +38,7 @@
 #define FILE_3GPP_24_008_SEEN
 
 #include <stdbool.h>
+#include <stdint.h>
 
 #include "bstrlib.h"
 
@@ -1102,8 +1103,14 @@ typedef struct packet_filter_contents_s {
  * Packet filter list when the TFP operation is "delete existing TFT"
  * and "no TFT operation" shall be empty.
  * ---------------------------------------------------------------
+ * The empty struct generates -Wextern-c-compat warnings, as the sizeof
+ * an empty struct is zero in c and one byte in c++.
+ * As the struct use of this empty struct is not intended to be byte-
+ * compatible with 3GPP standard, we can add a placeholder uint8_t here
+ * to ensure safe behavior in c/c++ mixed codebase.
  */
 typedef struct {
+  uint8_t unused;
 } no_packet_filter_t;
 
 typedef no_packet_filter_t delete_existing_tft_t;

--- a/lte/gateway/c/oai/lib/itti/intertask_messages_types.h
+++ b/lte/gateway/c/oai/lib/itti/intertask_messages_types.h
@@ -38,7 +38,13 @@
 #ifndef INTERTASK_MESSAGES_TYPES_H_
 #define INTERTASK_MESSAGES_TYPES_H_
 
+#include <stdint.h>
+
+// Nothing needed in message for now, but an empty struct is a c-c++ compatibility
+// risk (sizeof zero bytes in c, sizeof one byte in c++). Therefore we allocate an
+// unused uint8_t to ensure sizes are always 1 byte.
 typedef struct IttiMsgEmpty_s {
+  uint8_t unused;
 } IttiMsgEmpty;
 
 typedef struct IttiMsgText_s {

--- a/lte/gateway/c/oai/tasks/nas/api/mme/mme_api.h
+++ b/lte/gateway/c/oai/tasks/nas/api/mme/mme_api.h
@@ -128,10 +128,6 @@ typedef struct mme_api_qos_s {
   int qci;                    /* QoS Class Identifier         */
 } mme_api_qos_t;
 
-/* Traffic Flow Template */
-typedef struct mme_api_tft_s {
-} mme_api_tft_t;
-
 /****************************************************************************/
 /********************  G L O B A L    V A R I A B L E S  ********************/
 /****************************************************************************/


### PR DESCRIPTION
Zero-size structs are sizeof zero bytes in C, one byte in C++.  This generates a clear usage hazard for code bases that mix c/c++ (as Magma does).

For all Clang compiler warnings of this type, the following fixup approaches were applied in this PR:

- s6a_message_types.h:156
  - It was determined that the s6a_reset_req_t type is never used
  - So its definition has been removed
- service303_messages_types.h:20 and 24
  - application_healthy_msg_t and application_unhealthy_msg_t structs
  - These are ITTI message bus types
  - So we add an unused uint8_t to each struct
- 3gpp_24.008.h
    - no_packet_filter_t struct and it's variants
    - It appears this struct and it's users do not rely on byte-compatible alignment
    - So this PR adds an unused uint8_t
- intertask_message_types.h
  - IttiMsgEmpty struct
  - Again, ITTI message bus use so we can mutate without concern
  - Added an unused uint8_t
- mme_api.h
  - mme_api_tft_t appears unused / unreferenced
  - So this PR removes it's definition

Signed-off-by: Scott Harrison Moeller <smoeller@fb.com>