### PR TITLE
[AGW][Common][sctpd] Update CMakeLists.txt to work for upgraded cmake/ubuntu

### DIFF
--- a/lte/gateway/c/oai/include/mme_app_ue_context.h
+++ b/lte/gateway/c/oai/include/mme_app_ue_context.h
@@ -86,9 +86,6 @@ uint64_t mme_app_imsi_to_u64(mme_app_imsi_t imsi_src);
 void mme_app_ue_context_uint_to_imsi(
     uint64_t imsi_src, mme_app_imsi_t* imsi_dst);
 
-void mme_app_convert_imsi_to_imsi_mme(
-    mme_app_imsi_t* imsi_dst, const imsi_t* imsi_src);
-
 mme_ue_s1ap_id_t mme_app_ctx_get_new_ue_id(
     mme_ue_s1ap_id_t* mme_app_ue_s1ap_id_generator_p);
 

--- a/lte/gateway/c/oai/tasks/mme_app/mme_app_ue_context.c
+++ b/lte/gateway/c/oai/tasks/mme_app/mme_app_ue_context.c
@@ -34,21 +34,6 @@
 #include "3gpp_36.401.h"
 
 /**
- * @brief mme_app_convert_imsi_to_imsi_mme: converts the imsi_t struct to the
- * imsi mme struct
- * @param imsi_dst
- * @param imsi_src
- */
-// TODO: (amar) This and below functions are only used in testing possibly move
-// these to the testing module
-void mme_app_convert_imsi_to_imsi_mme(
-    mme_app_imsi_t* imsi_dst, const imsi_t* imsi_src) {
-  memset(imsi_dst->data, (uint8_t) '\0', sizeof(imsi_dst->data));
-  IMSI_TO_STRING(imsi_src, imsi_dst->data, IMSI_BCD_DIGITS_MAX + 1);
-  imsi_dst->length = strlen(imsi_dst->data);
-}
-
-/**
  * @brief mme_app_copy_imsi: copies an mme imsi to another mme imsi
  * @param imsi_dst
  * @param imsi_src

--- a/lte/gateway/c/oai/test/CMakeLists.txt
+++ b/lte/gateway/c/oai/test/CMakeLists.txt
@@ -13,26 +13,7 @@ set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
-find_package(Check REQUIRED)
-find_package(Threads REQUIRED)
-
-include_directories("/usr/src/googletest/googlemock/include/")
-set(MME_APP_UE_CONTEXT_IMSI_SRC
-    test_mme_app_ue_context.c
-)
-
-add_executable(test_mme_app_ue_context_imsi ${MME_APP_UE_CONTEXT_IMSI_SRC})
-target_link_libraries(test_mme_app_ue_context_imsi
-    TASK_MME_APP ${CHECK_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT}
-    LIB_BSTR LIB_HASHTABLE
-)
-target_include_directories(test_mme_app_ue_context_imsi PUBLIC
-    ${CMAKE_CURRENT_SOURCE_DIR}
-    ${CHECK_INCLUDE_DIRS}
-)
-
-add_test(NAME test_mme_app_ue_context COMMAND test_mme_app_ue_context_imsi)
-
+add_subdirectory(mme_app_task)
 add_subdirectory(mobility_client)
 add_subdirectory(openflow)
 add_subdirectory(spgw_task)

--- a/lte/gateway/c/oai/test/mme_app_task/CMakeLists.txt
+++ b/lte/gateway/c/oai/test/mme_app_task/CMakeLists.txt
@@ -13,29 +13,22 @@ set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
-set(SPGW_LIB_DIR $ENV{C_BUILD}/oai/tasks/sgw)
-include_directories(${SPGW_LIB_DIR})
+find_package(Check REQUIRED)
+find_package(Threads REQUIRED)
 
-include_directories("${PROJECT_SOURCE_DIR}")
 include_directories("/usr/src/googletest/googlemock/include/")
-
-add_library(SPGW_TASK_TEST_LIB
-    state_creators.h
-    state_creators.cpp
+set(MME_APP_UE_CONTEXT_IMSI_SRC
+    test_mme_app_ue_context.c
     )
 
-link_directories(/usr/src/googletest/googlemock/lib/)
-
-target_link_libraries(SPGW_TASK_TEST_LIB
-    TASK_SGW
-    gmock_main gtest gtest_main gmock
-    pthread rt yaml-cpp
+add_executable(test_mme_app_ue_context_imsi ${MME_APP_UE_CONTEXT_IMSI_SRC})
+target_link_libraries(test_mme_app_ue_context_imsi
+    TASK_MME_APP ${CHECK_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT}
+    LIB_BSTR LIB_HASHTABLE
+    )
+target_include_directories(test_mme_app_ue_context_imsi PUBLIC
+    ${CMAKE_CURRENT_SOURCE_DIR}
+    ${CHECK_INCLUDE_DIRS}
     )
 
-set_target_properties(SPGW_TASK_TEST_LIB PROPERTIES LINKER_LANGUAGE CXX)
-
-foreach (sgw_test spgw_state_converter)
-  add_executable(${sgw_test}_test test_${sgw_test}.cpp)
-  target_link_libraries(${sgw_test}_test SPGW_TASK_TEST_LIB)
-  add_test(test_${sgw_test} ${sgw_test}_test)
-endforeach (sgw_test)
+add_test(NAME test_mme_app_ue_context COMMAND test_mme_app_ue_context_imsi)

--- a/lte/gateway/c/oai/test/mme_app_task/test_mme_app_ue_context.c
+++ b/lte/gateway/c/oai/test/mme_app_task/test_mme_app_ue_context.c
@@ -18,10 +18,26 @@
 #include <stdlib.h>
 #include <stdint.h>
 
+#include "conversions.h"
 #include "mme_app_ue_context.h"
 #include "3gpp_23.003.h"
 
 #define TEST_CASE_COMMON_CONVERT_MAX 10
+
+/**
+ * @brief mme_app_convert_imsi_to_imsi_mme: converts the imsi_t struct to the
+ * imsi mme struct
+ * @param imsi_dst
+ * @param imsi_src
+ */
+// TODO: (amar) This and below functions are only used in testing possibly move
+// these to the testing module
+void mme_app_convert_imsi_to_imsi_mme(
+    mme_app_imsi_t* imsi_dst, const imsi_t* imsi_src) {
+  memset(imsi_dst->data, (uint8_t) '\0', sizeof(imsi_dst->data));
+  IMSI_TO_STRING(imsi_src, imsi_dst->data, IMSI_BCD_DIGITS_MAX + 1);
+  imsi_dst->length = strlen(imsi_dst->data);
+}
 
 START_TEST(imsi_empty_test) {
   mme_app_imsi_t imsi_mme = {.length = 0};

--- a/lte/gateway/c/oai/test/mobility_client/CMakeLists.txt
+++ b/lte/gateway/c/oai/test/mobility_client/CMakeLists.txt
@@ -1,5 +1,15 @@
+# Copyright 2020 The Magma Authors.
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 include_directories("${PROJECT_BINARY_DIR}")
 include_directories("${PROJECT_SOURCE_DIR}/mobility_client")
+include_directories("/usr/src/googletest/googlemock/include/")
 
 add_executable(mobility_client_test test_mobility_client.cpp)
 

--- a/lte/gateway/c/oai/test/openflow/CMakeLists.txt
+++ b/lte/gateway/c/oai/test/openflow/CMakeLists.txt
@@ -1,8 +1,18 @@
+# Copyright 2020 The Magma Authors.
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 add_compile_options(-std=c++11)
 
 set(OUTPUT_DIR "${CMAKE_CURRENT_BINARY_DIR}")
 
 include_directories("${PROJECT_SOURCE_DIR}/openflow/controller")
+include_directories("/usr/src/googletest/googlemock/include/")
 link_directories(/usr/src/googletest/googlemock/lib/)
 add_executable(openflow_controller_test test_openflow_controller.cpp)
 add_executable(imsi_encoder_test test_imsi_encoder.cpp)

--- a/lte/gateway/c/sctpd/test/CMakeLists.txt
+++ b/lte/gateway/c/sctpd/test/CMakeLists.txt
@@ -13,14 +13,15 @@ set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
-add_library(SCTPD_TEST_LIB
-
-)
-
-target_link_libraries(SCTPD_TEST_LIB SCTPD_LIB gmock_main pthread rt)
+include_directories("${PROJECT_SOURCE_DIR}")
+include_directories("/usr/src/googletest/googlemock/include/")
+link_directories("/usr/src/googletest/googlemock/lib/")
 
 foreach(sctpd_test sctp_desc event_handler)
   add_executable(${sctpd_test}_test test_${sctpd_test}.cpp)
-  target_link_libraries(${sctpd_test}_test SCTPD_TEST_LIB)
+  target_link_libraries(${sctpd_test}_test
+      SCTPD_LIB
+      gmock_main gtest gtest_main gmock
+      pthread rt)
   add_test(test_${sctpd_test} ${sctpd_test}_test)
 endforeach(sctpd_test)

--- a/orc8r/gateway/c/common/test/CMakeLists.txt
+++ b/orc8r/gateway/c/common/test/CMakeLists.txt
@@ -9,29 +9,26 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+cmake_minimum_required(VERSION 3.7.2)
 
-add_compile_options(-std=c++14)
-set(OUTPUT_DIR "${CMAKE_CURRENT_BINARY_DIR}")
+set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
 
+include_directories("${PROJECT_SOURCE_DIR}")
+include_directories("/usr/src/googletest/googlemock/include/")
 include_directories("${PROJECT_SOURCE_DIR}/../common/config")
 include_directories("${PROJECT_SOURCE_DIR}/../common/service303")
-
 include_directories("${PROJECT_SOURCE_DIR}/../common/protobuf")
-
-add_library(COMMON_TEST_LIB)
-
-target_link_libraries(COMMON_TEST_LIB
-  CONFIG
-  gmock_main
-  yaml-cpp
-  pthread
-  rt
-  ${GCOV_LIB}
-  SERVICE303_LIB
-)
+link_directories("/usr/src/googletest/googlemock/lib/")
 
 foreach(common_test yaml_utils magma_service service_registry service303 metrics)
   add_executable(${common_test}_test test_${common_test}.cpp)
-  target_link_libraries(${common_test}_test COMMON_TEST_LIB)
+  target_link_libraries(${common_test}_test 
+	  CONFIG 
+	  gmock_main gtest gtest_main gmock
+	  yaml-cpp pthread rt
+	  ${GCOV_LIB}
+	  SERVICE303_LIB)
   add_test(test_${common_test} ${common_test}_test)
 endforeach(common_test)


### PR DESCRIPTION
Signed-off-by: Marie Bremner <marwhal@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary
For unit tests, we used to create an empty cmake library with no sourcefile to add dependencies to unit tests (gmock, gtest, etc.) 
This was technically illegal but was allowed by an older version of Cmake that our regular magma VM uses. (I think)
The ubuntu VM uses an updated cmake which does not allow for this. So the PR cleans up the orc8r/gateway/c/common/test + lte/gateway/c/sctpd Cmake.

Additionally, I moved the `test_mme_app_ue_context` test into a `mme_app_task` subdirectory to clean up the tests directory / Cmakelists structure. 
<!-- Enumerate changes you made and why you made them -->

## Test Plan
run unit tests (`make test`) in both old vm (`vagrant up magma`) and new (`vagrant up magma_focal`)
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
