### PR TITLE
[MME] Correct out-of-order ctor initializer lists

### DIFF
--- a/lte/gateway/c/oai/include/state_manager.h
+++ b/lte/gateway/c/oai/include/state_manager.h
@@ -195,13 +195,13 @@ class StateManager {
 
  protected:
   StateManager()
-      : is_initialized(false),
+      : state_cache_p(nullptr),
+        state_ue_ht(nullptr),
+        redis_client(std::make_unique<RedisClient>()) {}
+        is_initialized(false),
         state_dirty(false),
         persist_state_enabled(false),
-        state_cache_p(nullptr),
-        state_ue_ht(nullptr),
         log_task(LOG_UTIL),
-        redis_client(std::make_unique<RedisClient>()) {}
   virtual ~StateManager() = default;
 
   /**

--- a/lte/gateway/c/oai/tasks/s1ap/s1ap_state_manager.cpp
+++ b/lte/gateway/c/oai/tasks/s1ap/s1ap_state_manager.cpp
@@ -28,7 +28,7 @@ using magma::lte::oai::UeDescription;
 namespace magma {
 namespace lte {
 
-S1apStateManager::S1apStateManager() : max_enbs_(0), max_ues_(0) {}
+S1apStateManager::S1apStateManager() : max_ues_(0), max_enbs_(0) {}
 
 S1apStateManager::~S1apStateManager() {
   free_state();


### PR DESCRIPTION
As flagged by Clang build's -Wreorder-ctor, these constructor initializer lists were mis-orderd relative to the member variable declaration. This was harmless in the present situation.

Signed-off-by: Scott Harrison Moeller <smoeller@fb.com>