### PR TITLE
[MME] Repair Clang tautological related warnings

### DIFF
--- a/lte/gateway/c/oai/tasks/mme_app/mme_app_bearer.c
+++ b/lte/gateway/c/oai/tasks/mme_app/mme_app_bearer.c
@@ -978,12 +978,10 @@ void mme_app_handle_delete_session_rsp(
        Do not send UE Context Release Command to eNB before receiving SGs IMSI
        Detach Ack from MSC/VLR */
     if (ue_context_p->sgs_context != NULL) {
-      if (((ue_context_p->sgs_detach_type !=
-            SGS_EXPLICIT_UE_INITIATED_IMSI_DETACH_FROM_NONEPS) ||
-           (ue_context_p->sgs_detach_type !=
-            SGS_COMBINED_UE_INITIATED_IMSI_DETACH_FROM_EPS_N_NONEPS)) &&
-          (ue_context_p->sgs_context->ts9_timer.id ==
-           MME_APP_TIMER_INACTIVE_ID)) {
+      if ((ue_context_p->sgs_detach_type == SGS_EXPLICIT_UE_INITIATED_IMSI_DETACH_FROM_NONEPS) ||
+           (ue_context_p->sgs_detach_type == SGS_COMBINED_UE_INITIATED_IMSI_DETACH_FROM_EPS_N_NONEPS)) {
+          OAILOG_FUNC_OUT(LOG_MME_APP);
+      } else if (ue_context_p->sgs_context->ts9_timer.id == MME_APP_TIMER_INACTIVE_ID) {
         /* Notify S1AP to send UE Context Release Command to eNB or free
          * s1 context locally.
          */

--- a/lte/gateway/c/oai/tasks/nas/emm/Attach.c
+++ b/lte/gateway/c/oai/tasks/nas/emm/Attach.c
@@ -2489,12 +2489,10 @@ void proc_new_attach_req(struct ue_mm_context_s* ue_context_p) {
        Do not send UE Context Release Command to eNB before receiving SGs IMSI
        Detach Ack from MSC/VLR */
     if (ue_context_p->sgs_context != NULL) {
-      if (((ue_context_p->sgs_detach_type !=
-            SGS_EXPLICIT_UE_INITIATED_IMSI_DETACH_FROM_NONEPS) ||
-           (ue_context_p->sgs_detach_type !=
-            SGS_COMBINED_UE_INITIATED_IMSI_DETACH_FROM_EPS_N_NONEPS)) &&
-          (ue_context_p->sgs_context->ts9_timer.id ==
-           MME_APP_TIMER_INACTIVE_ID)) {
+      if ((ue_context_p->sgs_detach_type == SGS_EXPLICIT_UE_INITIATED_IMSI_DETACH_FROM_NONEPS) ||
+           (ue_context_p->sgs_detach_type == SGS_COMBINED_UE_INITIATED_IMSI_DETACH_FROM_EPS_N_NONEPS)) {
+          OAILOG_FUNC_OUT(LOG_NAS_EMM);
+      } else if (ue_context_p->sgs_context->ts9_timer.id == MME_APP_TIMER_INACTIVE_ID) {
         /* Notify S1AP to send UE Context Release Command to eNB or free
          * s1 context locally.
          */

--- a/lte/gateway/c/oai/tasks/nas/emm/msg/emm_cause.h
+++ b/lte/gateway/c/oai/tasks/nas/emm/msg/emm_cause.h
@@ -44,6 +44,6 @@ Description Defines error cause code returned upon receiving unknown,
  * Cause code used to notify that the EPS mobility management procedure
  * has been successfully processed
  */
-#define EMM_CAUSE_SUCCESS (-1)
+#define EMM_CAUSE_SUCCESS (255)
 
 #endif /* FILE_EMM_CAUSE_H_SEEN*/

--- a/lte/gateway/c/oai/tasks/nas/emm/sap/emm_send.c
+++ b/lte/gateway/c/oai/tasks/nas/emm/sap/emm_send.c
@@ -1594,7 +1594,9 @@ int emm_send_emm_information(
   /*
    * optional - Local Time Zone
    */
-  if ((emm_msg->localtimezone = get_time_zone()) != RETURNerror) {
+  int result = get_time_zone();
+  if (result != RETURNerror) {
+    emm_msg->localtimezone = result;
     size += TIME_ZONE_IE_MAX_LENGTH;
     emm_msg->presencemask |= EMM_INFORMATION_LOCAL_TIME_ZONE_PRESENT;
   }
@@ -1647,7 +1649,7 @@ int emm_send_emm_information(
   formatted = (string[1] - '0') << 4;
   formatted |= (string[0] - '0');
   emm_msg->universaltimeandlocaltimezone.second = formatted;
-  if (emm_msg->localtimezone != RETURNerror) {
+  if ((emm_msg->presencemask && EMM_INFORMATION_LOCAL_TIME_ZONE_PRESENT) != 0) {
     emm_msg->universaltimeandlocaltimezone.timezone = emm_msg->localtimezone;
   }
   /*

--- a/lte/gateway/c/oai/tasks/sgw/sgw_handlers.c
+++ b/lte/gateway/c/oai/tasks/sgw/sgw_handlers.c
@@ -219,17 +219,6 @@ int sgw_handle_s11_create_session_request(
              .pdn_connection,
         0, sizeof(sgw_pdn_connection_t));
 
-    if (s_plus_p_gw_eps_bearer_ctxt_info_p->sgw_eps_bearer_context_information
-            .pdn_connection.sgw_eps_bearers_array == NULL) {
-      OAILOG_ERROR_UE(
-          LOG_SPGW_APP, imsi64,
-          "Failed to create eps bearers collection object\n");
-      increment_counter(
-          "spgw_create_session", 1, 2, "result", "failure", "cause",
-          "internal_software_error");
-      OAILOG_FUNC_RETURN(LOG_SPGW_APP, RETURNerror);
-    }
-
     if (session_req_pP->apn) {
       s_plus_p_gw_eps_bearer_ctxt_info_p->sgw_eps_bearer_context_information
           .pdn_connection.apn_in_use = strdup(session_req_pP->apn);


### PR DESCRIPTION
# Summary

The following changes and rationale were applied.

- mme_app_bearer.c
  - Logic error corrected in sgs_detach_type condition
  - Existing condtion was tautolotically true
  - Corrected logic courtesy of shruti@
- Attach.c
  - Logic error corrected in sgs_detach_type condition
  - Existing condtion was tautolotically true
  - Corrected logic courtesy of shruti@
- emm_cause.h
  - EMM_CAUSE_SUCCESS is frequently compared with emm_cause_t types
  - But emm_cause_t is unsigned char
  - Clang claims the EMM_CAUSE_SUCCESS(-1) can never equal emm_cause_t as a result
  - As a corrective action, this PR moves EMM_CAUSE_SUCCESS to 255
  - It's unclear how GCC is handling this (perhaps differently?)
- emm_send.c
  - Assignment of get_time_zone() -> signed int to localtimezone (unsigned char)
  - Clang points out that as a result, RETURNerror (-1) can never equal localtimezone
  - Correct by making intermediate variable that is signed and checking error there
  - Use emm_msg->presencemask in later function to determine presence
- sgw_handlers.c
  - Clang points out that the array pointer cannot be NULL
  - The error condition being checked appears invalid - and is removed

The following Clang 11 warnings are addressed.

```
/magma/lte/gateway/c/oai/tasks/sgw/sgw_handlers.c:226:29: warning: comparison of array 's_plus_p_gw_eps_bearer_ctxt_info_p->sgw_eps_bearer_context_information.pdn_connection.sgw_eps_bearers_array' equal to a null pointer is always false [-Wtautological-pointer-compare]
/magma/lte/gateway/c/oai/tasks/nas/emm/Attach.c:2464:64: warning: overlapping comparisons always evaluate to true [-Wtautological-overlap-compare]
/magma/lte/gateway/c/oai/tasks/nas/emm/sap/emm_recv.c:1008:21: warning: result of comparison of constant -1 with expression of type 'emm_cause_t' (aka 'unsigned char') is always false [-Wtautological-constant-out-of-range-compare]
/magma/lte/gateway/c/oai/tasks/nas/emm/sap/emm_recv.c:1131:21: warning: result of comparison of constant -1 with expression of type 'emm_cause_t' (aka 'unsigned char') is always false [-Wtautological-constant-out-of-range-compare]
/magma/lte/gateway/c/oai/tasks/nas/emm/sap/emm_send.c:1595:50: warning: result of comparison of constant 'RETURNerror' (-1) with expression of type 'time_zone_t' (aka 'unsigned char') is always true [-Wtautological-constant-out-of-range-compare]
/magma/lte/gateway/c/oai/tasks/nas/emm/sap/emm_send.c:1648:30: warning: result of comparison of constant 'RETURNerror' (-1) with expression of type 'time_zone_t' (aka 'unsigned char') is always true [-Wtautological-constant-out-of-range-compare]
/magma/lte/gateway/c/oai/tasks/mme_app/mme_app_bearer.c:990:64: warning: overlapping comparisons always evaluate to true [-Wtautological-overlap-compare]
```

# Test Plan

- Confirmed that OAI MME builds
- Ran Unit test suite
- run integ_tests
  - minus traffic source tests

Signed-off-by: Scott Harrison Moeller <smoeller@fb.com>