### PR TITLE
Ubuntu20VM fabfile.py edited to set implicit vcs default = git.

### DIFF
--- a/lte/gateway/fabfile.py
+++ b/lte/gateway/fabfile.py
@@ -68,7 +68,7 @@ def test():
     env.debug_mode = False
 
 
-def package(vcs='hg', all_deps="False",
+def package(vcs='git', all_deps="False",
             cert_file=DEFAULT_CERT, proxy_config=DEFAULT_PROXY,
             destroy_vm='False',
             vm='magma'):


### PR DESCRIPTION
[agw]

## Summary

1. fabfile.py call defaults to current vcs=git

## Test Plan

Run locally on OSX against DebianVM.
Run locally on OSX against Ubuntu20VM.

## Additional Information

- [x] This change is backwards-breaking, but we can update the documented call:  $ dev package

