### PR TITLE
[orc8r][docker]: Quick-start script: run.py error with '--metrics' parameter

### DIFF
--- a/orc8r/cloud/docker/run.py
+++ b/orc8r/cloud/docker/run.py
@@ -40,7 +40,7 @@ def main() -> None:
         if args.thanos:
             f.append('thanos')
         file_args = _make_file_args(f)
-        compose_line = 'COMPOSE_FILE={}  {}\n'.format(
+        compose_line = 'COMPOSE_FILE={}  \n{}\n'.format(
             ':'.join(file_args),
             DO_NOT_COMMIT,
         )


### PR DESCRIPTION
<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary
Ticket issue: https://github.com/magma/magma/issues/5600 

<!-- Enumerate changes you made and why you made them -->

Looks like the run.py script is creating a comment "# DO NOT COMMIT THIS CHANGE" at same line of parameter "COMPOSE_FILE="
* file: magma/python/magma/orc8r/cloud/docker/.env
```
COMPOSE_FILE=docker-compose.yml:docker-compose.metrics.yml:docker-compose.override.yml  # DO NOT COMMIT THIS CHANGE

```

changing the run.py to add a "\n" in "'COMPOSE_FILE={}  {}\n'.format in this comment, the script run with success with --metrics
*file: magma/python/magma/orc8r/cloud/docker/run.py
```
        compose_line = 'COMPOSE_FILE={}  \n{}\n'.format(
            ':'.join(file_args),
            DO_NOT_COMMIT,
        )

```
and after that the .env file keep as it:
* file: magma/python/magma/orc8r/cloud/docker/.env
```
COMPOSE_FILE=docker-compose.yml:docker-compose.metrics.yml:docker-compose.override.yml 
# DO NOT COMMIT THIS CHANGE

```
After this change, the "run.py --metrics"  run with success

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
