### PR TITLE
[lte][agw] Updating ipv6 and ipv4v6 handlers on MobilityClient through ITTI msgs 

### DIFF
--- a/lte/gateway/c/oai/lib/mobility_client/MobilityClientAPI.cpp
+++ b/lte/gateway/c/oai/lib/mobility_client/MobilityClientAPI.cpp
@@ -67,9 +67,9 @@ int get_assigned_ipv4_block(
 int pgw_handle_allocate_ipv4_address(
     const char* subscriber_id, const char* apn, const char* pdn_type,
     teid_t context_teid, ebi_t eps_bearer_id) {
-  std::string subscriber_id_str = std::string(subscriber_id);
-  std::string apn_str           = std::string(apn);
-  std::string pdn_type_str      = std::string(pdn_type);
+  auto subscriber_id_str = std::string(subscriber_id);
+  auto apn_str           = std::string(apn);
+  auto pdn_type_str      = std::string(pdn_type);
   MobilityServiceClient::getInstance().AllocateIPv4AddressAsync(
       subscriber_id_str, apn_str,
       [subscriber_id_str, apn_str, pdn_type_str, context_teid, eps_bearer_id](
@@ -85,7 +85,7 @@ int pgw_handle_allocate_ipv4_address(
             status, addr, vlan, subscriber_id_str.c_str(), apn_str.c_str(),
             pdn_type_str.c_str(), context_teid, eps_bearer_id);
       });
-  return 0;
+  return RETURNok;
 }
 
 static void handle_allocate_ipv4_address_status(
@@ -174,10 +174,13 @@ int get_subscriber_id_from_ipv4(
 int pgw_handle_allocate_ipv6_address(
     const char* subscriber_id, const char* apn, const char* pdn_type,
     teid_t context_teid, ebi_t eps_bearer_id) {
+  auto subscriber_id_str = std::string(subscriber_id);
+  auto apn_str           = std::string(apn);
+  auto pdn_type_str      = std::string(pdn_type);
   // Make an RPC call to Mobilityd
   MobilityServiceClient::getInstance().AllocateIPv6AddressAsync(
-      subscriber_id, apn,
-      [subscriber_id, apn, pdn_type, context_teid, eps_bearer_id](
+      subscriber_id_str, apn_str,
+      [subscriber_id_str, apn_str, pdn_type_str, context_teid, eps_bearer_id](
           const Status& status, const AllocateIPAddressResponse& ip_msg) {
         struct in6_addr ip6_addr;
         std::string ipv6_addr_str;
@@ -187,7 +190,7 @@ int pgw_handle_allocate_ipv6_address(
           OAILOG_ERROR(
               LOG_UTIL,
               " Error in allocating ipv6 address for IMSI <%s> apn <%s>\n",
-              subscriber_id, apn);
+              subscriber_id_str.c_str(), apn_str.c_str());
           OAILOG_FUNC_RETURN(LOG_SPGW_APP, RETURNerror);
         }
 
@@ -195,10 +198,10 @@ int pgw_handle_allocate_ipv6_address(
         int vlan = atoi(ip_msg.vlan().c_str());
 
         handle_allocate_ipv6_address_status(
-            status, ip6_addr, vlan, subscriber_id, apn, pdn_type, context_teid,
-            eps_bearer_id);
+            status, ip6_addr, vlan, subscriber_id_str.c_str(), apn_str.c_str(),
+            pdn_type_str.c_str(), context_teid, eps_bearer_id);
       });
-  return 0;
+  return RETURNok;
 }
 
 static void handle_allocate_ipv6_address_status(
@@ -243,7 +246,7 @@ static void handle_allocate_ipv6_address_status(
           "ue_pdn_connection", 1, 2, "pdn_type", pdn_type, "result", "failure");
       OAILOG_ERROR(
           LOG_UTIL,
-          "Failed to allocate IPv6 PAA for PDN type IPv4 for "
+          "Failed to allocate IPv6 PAA for PDN type IPv6 for "
           "imsi <%s> and apn <%s>\n",
           imsi, apn);
       ip_allocation_response_p->status =
@@ -262,10 +265,13 @@ static void handle_allocate_ipv6_address_status(
 int pgw_handle_allocate_ipv4v6_address(
     const char* subscriber_id, const char* apn, const char* pdn_type,
     teid_t context_teid, ebi_t eps_bearer_id) {
+  auto subscriber_id_str = std::string(subscriber_id);
+  auto apn_str           = std::string(apn);
+  auto pdn_type_str      = std::string(pdn_type);
   // Get IPv4v6 address
   MobilityServiceClient::getInstance().AllocateIPv4v6AddressAsync(
-      subscriber_id, apn,
-      [subscriber_id, apn, pdn_type, context_teid, eps_bearer_id](
+      subscriber_id_str, apn_str,
+      [subscriber_id_str, apn_str, pdn_type_str, context_teid, eps_bearer_id](
           const Status& status, const AllocateIPAddressResponse& ip_msg) {
         struct in_addr ip4_addr;
         struct in6_addr ip6_addr;
@@ -278,24 +284,24 @@ int pgw_handle_allocate_ipv4v6_address(
               LOG_UTIL,
               "Allocated IPv4 Address <%s>, IPv6 Address <%s>, PDN Type <%s>,"
               " for IMSI <%s> and APN <%s>\n",
-              ipv4_addr_str.c_str(), ipv6_addr_str.c_str(), pdn_type,
-              subscriber_id, apn);
+              ipv4_addr_str.c_str(), ipv6_addr_str.c_str(),
+              pdn_type_str.c_str(), subscriber_id_str.c_str(), apn_str.c_str());
         } else {
           OAILOG_ERROR(
               LOG_UTIL,
               " Error in allocating IPv4 and IPv6 addresses for IMSI <%s> apn "
               "<%s>\n",
-              subscriber_id, apn);
+              subscriber_id_str.c_str(), apn_str.c_str());
           OAILOG_FUNC_RETURN(LOG_SPGW_APP, RETURNerror);
         }
         memcpy(&ip4_addr, ipv4_addr_str.c_str(), sizeof(in_addr));
         memcpy(&ip6_addr, ipv6_addr_str.c_str(), sizeof(in6_addr));
         int vlan = atoi(ip_msg.vlan().c_str());
         handle_allocate_ipv4v6_address_status(
-            status, ip4_addr, ip6_addr, vlan, subscriber_id, apn, pdn_type,
-            context_teid, eps_bearer_id);
+            status, ip4_addr, ip6_addr, vlan, subscriber_id_str.c_str(),
+            apn_str.c_str(), pdn_type_str.c_str(), context_teid, eps_bearer_id);
       });
-  return 0;
+  return RETURNok;
 }
 
 static void handle_allocate_ipv4v6_address_status(

--- a/lte/gateway/c/oai/lib/mobility_client/MobilityClientAPI.cpp
+++ b/lte/gateway/c/oai/lib/mobility_client/MobilityClientAPI.cpp
@@ -24,7 +24,6 @@
 
 #include "conversions.h"
 #include "common_defs.h"
-#include "pcef_handlers.h"
 #include "service303.h"
 #include "spgw_types.h"
 #include "intertask_interface.h"
@@ -41,7 +40,6 @@ using magma::lte::AllocateIPAddressResponse;
 using magma::lte::IPAddress;
 using magma::lte::MobilityServiceClient;
 
-extern task_zmq_ctx_t spgw_app_task_zmq_ctx;
 extern task_zmq_ctx_t grpc_service_task_zmq_ctx;
 
 static void handle_allocate_ipv4_address_status(
@@ -49,17 +47,15 @@ static void handle_allocate_ipv4_address_status(
     const char* imsi, const char* apn, const char* pdn_type,
     teid_t context_teid, ebi_t eps_bearer_id);
 
-static itti_sgi_create_end_point_response_t handle_allocate_ipv6_address_status(
+static void handle_allocate_ipv6_address_status(
     const grpc::Status& status, struct in6_addr addr, int vlan,
     const char* imsi, const char* apn, const char* pdn_type,
-    itti_sgi_create_end_point_response_t sgi_create_endpoint_resp);
+    teid_t context_teid, ebi_t eps_bearer_id);
 
-static itti_sgi_create_end_point_response_t
-handle_allocate_ipv4v6_address_status(
+static void handle_allocate_ipv4v6_address_status(
     const grpc::Status& status, struct in_addr ip4_addr,
     struct in6_addr ip6_addr, int vlan, const char* imsi, const char* apn,
-    const char* pdn_type,
-    itti_sgi_create_end_point_response_t sgi_create_endpoint_resp);
+    const char* pdn_type, teid_t context_teid, ebi_t eps_bearer_id);
 
 int get_assigned_ipv4_block(
     int index, struct in_addr* netaddr, uint32_t* netmask) {
@@ -176,16 +172,14 @@ int get_subscriber_id_from_ipv4(
 }
 
 int pgw_handle_allocate_ipv6_address(
-    const char* subscriber_id, const char* apn, struct in6_addr* ip6_addr,
-    itti_sgi_create_end_point_response_t sgi_create_endpoint_resp,
-    const char* pdn_type, spgw_state_t* spgw_state,
-    s_plus_p_gw_eps_bearer_context_information_t* new_bearer_ctxt_info_p,
-    s5_create_session_response_t s5_response) {
+    const char* subscriber_id, const char* apn, const char* pdn_type,
+    teid_t context_teid, ebi_t eps_bearer_id) {
   // Make an RPC call to Mobilityd
   MobilityServiceClient::getInstance().AllocateIPv6AddressAsync(
       subscriber_id, apn,
-      [=, &s5_response](
+      [subscriber_id, apn, pdn_type, context_teid, eps_bearer_id](
           const Status& status, const AllocateIPAddressResponse& ip_msg) {
+        struct in6_addr ip6_addr;
         std::string ipv6_addr_str;
         if (ip_msg.ip_list_size() > 0) {
           ipv6_addr_str = ip_msg.ip_list(0).address();
@@ -197,101 +191,84 @@ int pgw_handle_allocate_ipv6_address(
           OAILOG_FUNC_RETURN(LOG_SPGW_APP, RETURNerror);
         }
 
-        memcpy(ip6_addr->s6_addr, ipv6_addr_str.c_str(), sizeof(in6_addr));
+        memcpy(&ip6_addr.s6_addr, ipv6_addr_str.c_str(), sizeof(in6_addr));
         int vlan = atoi(ip_msg.vlan().c_str());
 
-        auto sgi_resp = handle_allocate_ipv6_address_status(
-            status, *ip6_addr, vlan, subscriber_id, apn, pdn_type,
-            sgi_create_endpoint_resp);
-
-        // create session in PCEF and return
-        if (sgi_resp.status == SGI_STATUS_OK) {
-          char ip6_str[INET6_ADDRSTRLEN];
-          inet_ntop(AF_INET6, ip6_addr, ip6_str, INET6_ADDRSTRLEN);
-
-          OAILOG_INFO(
-              LOG_UTIL,
-              "Allocated IPv6 Address <%s>, PDN Type <%s>,"
-              " for IMSI <%s> and APN <%s>\n",
-              ip6_str, pdn_type, subscriber_id, apn);
-
-          s5_create_session_request_t session_req = {0};
-          session_req.context_teid  = sgi_create_endpoint_resp.context_teid;
-          session_req.eps_bearer_id = sgi_create_endpoint_resp.eps_bearer_id;
-          struct pcef_create_session_data session_data;
-          get_session_req_data(
-              spgw_state,
-              &new_bearer_ctxt_info_p->sgw_eps_bearer_context_information
-                   .saved_message,
-              &session_data);
-          pcef_create_session(
-              subscriber_id, nullptr, ip6_str, &session_data, session_req);
-        } else {
-          // If we are here then the IP address allocation has failed
-          s5_response.eps_bearer_id = sgi_create_endpoint_resp.eps_bearer_id;
-          s5_response.context_teid  = sgi_create_endpoint_resp.context_teid;
-          s5_response.failure_cause = IP_ALLOCATION_FAILURE;
-          handle_s5_create_session_response(
-              spgw_state, new_bearer_ctxt_info_p, s5_response);
-        }
-        OAILOG_FUNC_RETURN(LOG_SPGW_APP, RETURNok);
+        handle_allocate_ipv6_address_status(
+            status, ip6_addr, vlan, subscriber_id, apn, pdn_type, context_teid,
+            eps_bearer_id);
       });
   return 0;
 }
 
-static itti_sgi_create_end_point_response_t handle_allocate_ipv6_address_status(
+static void handle_allocate_ipv6_address_status(
     const Status& status, struct in6_addr addr, int vlan, const char* imsi,
-    const char* apn, const char* pdn_type,
-    itti_sgi_create_end_point_response_t sgi_create_endpoint_resp) {
+    const char* apn, const char* pdn_type, teid_t context_teid,
+    ebi_t eps_bearer_id) {
+  MessageDef* message_p;
+  message_p = itti_alloc_new_message(TASK_GRPC_SERVICE, IP_ALLOCATION_RESPONSE);
+  if (!message_p) {
+    OAILOG_ERROR(
+        LOG_UTIL, "Message IP Allocation Response allocation failed\n");
+    return;
+  }
+
+  itti_ip_allocation_response_t* ip_allocation_response_p;
+  ip_allocation_response_p = &message_p->ittiMsg.ip_allocation_response;
+  memset(ip_allocation_response_p, 0, sizeof(itti_ip_allocation_response_t));
+
+  ip_allocation_response_p->context_teid  = context_teid;
+  ip_allocation_response_p->eps_bearer_id = eps_bearer_id;
+
   if (status.ok()) {
     increment_counter(
         "ue_pdn_connection", 1, 2, "pdn_type", pdn_type, "result", "success");
-    sgi_create_endpoint_resp.paa.ipv6_address       = addr;
-    sgi_create_endpoint_resp.paa.ipv6_prefix_length = IPV6_PREFIX_LEN;
-    sgi_create_endpoint_resp.paa.pdn_type           = IPv6;
-    sgi_create_endpoint_resp.paa.vlan               = vlan;
-    sgi_create_endpoint_resp.status                 = SGI_STATUS_OK;
+    ip_allocation_response_p->paa.ipv6_address       = addr;
+    ip_allocation_response_p->paa.ipv6_prefix_length = IPV6_PREFIX_LEN;
+    ip_allocation_response_p->paa.pdn_type           = IPv6;
+    ip_allocation_response_p->paa.vlan               = vlan;
+    ip_allocation_response_p->status                 = SGI_STATUS_OK;
+
     OAILOG_DEBUG(
         LOG_UTIL, "Allocated IPv6 address for imsi <%s>, apn <%s> vlan %d\n",
         imsi, apn, vlan);
   } else {
     if (status.error_code() == RPC_STATUS_ALREADY_EXISTS) {
       increment_counter(
-          "ue_pdn_connection", 1, 2, "pdn_type", "ipv6", "result",
+          "ue_pdn_connection", 1, 2, "pdn_type", pdn_type, "result",
           "ip_address_already_allocated");
-      /*
-       * This implies that UE session was not released properly.
-       * Release the IP address so that subsequent attempt is successfull
-       */
-      release_ipv6_address(imsi, apn, &addr);
-      sgi_create_endpoint_resp.status = SGI_STATUS_ERROR_SYSTEM_FAILURE;
+      ip_allocation_response_p->status = SGI_STATUS_ERROR_SYSTEM_FAILURE;
     } else {
       increment_counter(
           "ue_pdn_connection", 1, 2, "pdn_type", pdn_type, "result", "failure");
       OAILOG_ERROR(
           LOG_UTIL,
-          "Failed to allocate IPv6 PAA for PDN type IPv6 for "
+          "Failed to allocate IPv6 PAA for PDN type IPv4 for "
           "imsi <%s> and apn <%s>\n",
           imsi, apn);
-      sgi_create_endpoint_resp.status =
+      ip_allocation_response_p->status =
           SGI_STATUS_ERROR_ALL_DYNAMIC_ADDRESSES_OCCUPIED;
     }
   }
-  return sgi_create_endpoint_resp;
+
+  IMSI_STRING_TO_IMSI64(imsi, &message_p->ittiMsgHeader.imsi);
+  OAILOG_DEBUG_UE(
+      LOG_UTIL, message_p->ittiMsgHeader.imsi,
+      "Sending IP allocation response message with cause: %u\n",
+      ip_allocation_response_p->status);
+  send_msg_to_task(&grpc_service_task_zmq_ctx, TASK_SPGW_APP, message_p);
 }
 
 int pgw_handle_allocate_ipv4v6_address(
-    const char* subscriber_id, const char* apn, struct in_addr* ip4_addr,
-    struct in6_addr* ip6_addr,
-    itti_sgi_create_end_point_response_t sgi_create_endpoint_resp,
-    const char* pdn_type, spgw_state_t* spgw_state,
-    s_plus_p_gw_eps_bearer_context_information_t* new_bearer_ctxt_info_p,
-    s5_create_session_response_t s5_response) {
+    const char* subscriber_id, const char* apn, const char* pdn_type,
+    teid_t context_teid, ebi_t eps_bearer_id) {
   // Get IPv4v6 address
   MobilityServiceClient::getInstance().AllocateIPv4v6AddressAsync(
       subscriber_id, apn,
-      [=, &s5_response](
+      [subscriber_id, apn, pdn_type, context_teid, eps_bearer_id](
           const Status& status, const AllocateIPAddressResponse& ip_msg) {
+        struct in_addr ip4_addr;
+        struct in6_addr ip6_addr;
         std::string ipv4_addr_str;
         std::string ipv6_addr_str;
         if (ip_msg.ip_list_size() == 2) {
@@ -306,83 +283,59 @@ int pgw_handle_allocate_ipv4v6_address(
         } else {
           OAILOG_ERROR(
               LOG_UTIL,
-              " Error in allocating ipv4v6 address for IMSI <%s> apn <%s>\n",
+              " Error in allocating IPv4 and IPv6 addresses for IMSI <%s> apn "
+              "<%s>\n",
               subscriber_id, apn);
           OAILOG_FUNC_RETURN(LOG_SPGW_APP, RETURNerror);
         }
-        memcpy(ip4_addr, ipv4_addr_str.c_str(), sizeof(in_addr));
-        memcpy(ip6_addr, ipv6_addr_str.c_str(), sizeof(in6_addr));
-        int vlan      = atoi(ip_msg.vlan().c_str());
-        auto sgi_resp = handle_allocate_ipv4v6_address_status(
-            status, *ip4_addr, *ip6_addr, vlan, subscriber_id, apn, pdn_type,
-            sgi_create_endpoint_resp);
-
-        // create session in PCEF and return
-        if (sgi_resp.status == SGI_STATUS_OK) {
-          s5_create_session_request_t session_req = {0};
-          session_req.context_teid  = sgi_create_endpoint_resp.context_teid;
-          session_req.eps_bearer_id = sgi_create_endpoint_resp.eps_bearer_id;
-          char ip4_str[INET_ADDRSTRLEN];
-          inet_ntop(AF_INET, &(ip4_addr->s_addr), ip4_str, INET_ADDRSTRLEN);
-          char ip6_str[INET6_ADDRSTRLEN];
-          inet_ntop(AF_INET6, ip6_addr, ip6_str, INET6_ADDRSTRLEN);
-          OAILOG_INFO(
-              LOG_UTIL,
-              "Allocated IPv4 Address <%s>, IPv6 Address <%s>, PDN Type <%s>,"
-              " for IMSI <%s> and APN <%s>\n",
-              ip4_str, ip6_str, pdn_type, subscriber_id, apn);
-
-          struct pcef_create_session_data session_data;
-          get_session_req_data(
-              spgw_state,
-              &new_bearer_ctxt_info_p->sgw_eps_bearer_context_information
-                   .saved_message,
-              &session_data);
-          pcef_create_session(
-              subscriber_id, ip4_str, ip6_str, &session_data, session_req);
-          s5_response.eps_bearer_id = sgi_create_endpoint_resp.eps_bearer_id;
-          s5_response.context_teid  = sgi_create_endpoint_resp.context_teid;
-        } else {
-          // If we are here then the IP address allocation has failed
-          s5_response.eps_bearer_id = sgi_create_endpoint_resp.eps_bearer_id;
-          s5_response.context_teid  = sgi_create_endpoint_resp.context_teid;
-          s5_response.failure_cause = IP_ALLOCATION_FAILURE;
-          handle_s5_create_session_response(
-              spgw_state, new_bearer_ctxt_info_p, s5_response);
-        }
-        OAILOG_FUNC_RETURN(LOG_SPGW_APP, RETURNok);
+        memcpy(&ip4_addr, ipv4_addr_str.c_str(), sizeof(in_addr));
+        memcpy(&ip6_addr, ipv6_addr_str.c_str(), sizeof(in6_addr));
+        int vlan = atoi(ip_msg.vlan().c_str());
+        handle_allocate_ipv4v6_address_status(
+            status, ip4_addr, ip6_addr, vlan, subscriber_id, apn, pdn_type,
+            context_teid, eps_bearer_id);
       });
-  OAILOG_FUNC_RETURN(LOG_SPGW_APP, RETURNok);
+  return 0;
 }
 
-static itti_sgi_create_end_point_response_t
-handle_allocate_ipv4v6_address_status(
+static void handle_allocate_ipv4v6_address_status(
     const Status& status, struct in_addr ip4_addr, struct in6_addr ip6_addr,
     int vlan, const char* imsi, const char* apn, const char* pdn_type,
-    itti_sgi_create_end_point_response_t sgi_create_endpoint_resp) {
+    teid_t context_teid, ebi_t eps_bearer_id) {
+  MessageDef* message_p;
+  message_p = itti_alloc_new_message(TASK_GRPC_SERVICE, IP_ALLOCATION_RESPONSE);
+  if (!message_p) {
+    OAILOG_ERROR(
+        LOG_UTIL, "Message IP Allocation Response allocation failed\n");
+    return;
+  }
+
+  itti_ip_allocation_response_t* ip_allocation_response_p;
+  ip_allocation_response_p = &message_p->ittiMsg.ip_allocation_response;
+  memset(ip_allocation_response_p, 0, sizeof(itti_ip_allocation_response_t));
+
+  ip_allocation_response_p->context_teid  = context_teid;
+  ip_allocation_response_p->eps_bearer_id = eps_bearer_id;
+
   if (status.ok()) {
     increment_counter(
         "ue_pdn_connection", 1, 2, "pdn_type", pdn_type, "result", "success");
-    sgi_create_endpoint_resp.paa.ipv4_address       = ip4_addr;
-    sgi_create_endpoint_resp.paa.ipv6_address       = ip6_addr;
-    sgi_create_endpoint_resp.paa.ipv6_prefix_length = IPV6_PREFIX_LEN;
-    sgi_create_endpoint_resp.paa.pdn_type           = IPv4_AND_v6;
-    sgi_create_endpoint_resp.paa.vlan               = vlan;
-    sgi_create_endpoint_resp.status                 = SGI_STATUS_OK;
+    ip_allocation_response_p->paa.ipv4_address       = ip4_addr;
+    ip_allocation_response_p->paa.ipv6_address       = ip6_addr;
+    ip_allocation_response_p->paa.ipv6_prefix_length = IPV6_PREFIX_LEN;
+    ip_allocation_response_p->paa.pdn_type           = IPv4_AND_v6;
+    ip_allocation_response_p->paa.vlan               = vlan;
+    ip_allocation_response_p->status                 = SGI_STATUS_OK;
+
     OAILOG_DEBUG(
-        LOG_UTIL, "Allocated IPv6 address for imsi <%s>, apn <%s> vlan %d\n",
+        LOG_UTIL, "Allocated IPv4v6 address for imsi <%s>, apn <%s> vlan %d\n",
         imsi, apn, vlan);
   } else {
     if (status.error_code() == RPC_STATUS_ALREADY_EXISTS) {
       increment_counter(
-          "ue_pdn_connection", 1, 2, "pdn_type", "ipv4v6", "result",
+          "ue_pdn_connection", 1, 2, "pdn_type", pdn_type, "result",
           "ip_address_already_allocated");
-      /*
-       * This implies that UE session was not released properly.
-       * Release the IP address so that subsequent attempt is successfull
-       */
-      release_ipv4v6_address(imsi, apn, &ip4_addr, &ip6_addr);
-      sgi_create_endpoint_resp.status = SGI_STATUS_ERROR_SYSTEM_FAILURE;
+      ip_allocation_response_p->status = SGI_STATUS_ERROR_SYSTEM_FAILURE;
     } else {
       increment_counter(
           "ue_pdn_connection", 1, 2, "pdn_type", pdn_type, "result", "failure");
@@ -391,11 +344,17 @@ handle_allocate_ipv4v6_address_status(
           "Failed to allocate IPv4v6 PAA for PDN type IPv4v6 for "
           "imsi <%s> and apn <%s>\n",
           imsi, apn);
-      sgi_create_endpoint_resp.status =
+      ip_allocation_response_p->status =
           SGI_STATUS_ERROR_ALL_DYNAMIC_ADDRESSES_OCCUPIED;
     }
   }
-  return sgi_create_endpoint_resp;
+
+  IMSI_STRING_TO_IMSI64(imsi, &message_p->ittiMsgHeader.imsi);
+  OAILOG_DEBUG_UE(
+      LOG_UTIL, message_p->ittiMsgHeader.imsi,
+      "Sending IP allocation response message with cause: %u\n",
+      ip_allocation_response_p->status);
+  send_msg_to_task(&grpc_service_task_zmq_ctx, TASK_SPGW_APP, message_p);
 }
 
 int release_ipv6_address(

--- a/lte/gateway/c/oai/lib/mobility_client/MobilityClientAPI.h
+++ b/lte/gateway/c/oai/lib/mobility_client/MobilityClientAPI.h
@@ -86,11 +86,8 @@ int pgw_handle_allocate_ipv4_address(
  */
 
 int pgw_handle_allocate_ipv6_address(
-    const char* subscriber_id, const char* apn, struct in6_addr* ip6_addr,
-    itti_sgi_create_end_point_response_t sgi_create_endpoint_resp,
-    const char* pdn_type, spgw_state_t* spgw_state,
-    s_plus_p_gw_eps_bearer_context_information_t* new_bearer_ctxt_info_p,
-    s5_create_session_response_t s5_response);
+    const char* subscriber_id, const char* apn, const char* pdn_type,
+    teid_t context_teid, ebi_t eps_bearer_id);
 
 /*
  * Release an allocated IP address.
@@ -170,19 +167,12 @@ int get_subscriber_id_from_ipv4(
  * @param ipv6_addr: contains the IP address allocated upon returning
  * @param sgi_create_endpoint_resp itti message for sgi_create_endpoint_resp
  * @param pdn_type str for PDN type (ipv4v6)
- * @param spgw_state spgw_state_t struct
- * @param new_bearer_ctxt_info_p SPGW ue context struct
- * @param s5_response itti message for s5_create_session response
  * @return status of gRPC call
  */
 
 int pgw_handle_allocate_ipv4v6_address(
-    const char* subscriber_id, const char* apn, struct in_addr* ip4_addr,
-    struct in6_addr* ip6_addr,
-    itti_sgi_create_end_point_response_t sgi_create_endpoint_resp,
-    const char* pdn_type, spgw_state_t* spgw_state,
-    s_plus_p_gw_eps_bearer_context_information_t* new_bearer_ctxt_info_p,
-    s5_create_session_response_t s5_response);
+    const char* subscriber_id, const char* apn, const char* pdn_type,
+    teid_t context_teid, ebi_t eps_bearer_id);
 
 #ifdef __cplusplus
 }

--- a/lte/gateway/c/oai/tasks/sgw/pgw_handlers.c
+++ b/lte/gateway/c/oai/tasks/sgw/pgw_handlers.c
@@ -96,10 +96,8 @@ void handle_s5_create_session_request(
     s_plus_p_gw_eps_bearer_context_information_t* new_bearer_ctxt_info_p,
     teid_t context_teid, ebi_t eps_bearer_id) {
   OAILOG_FUNC_IN(LOG_SPGW_APP);
-  itti_sgi_create_end_point_response_t sgi_create_endpoint_resp = {0};
-  s5_create_session_response_t s5_response                      = {0};
-  struct in_addr inaddr;
-  struct in6_addr in6addr;
+  s5_create_session_response_t s5_response = {0};
+
   char* imsi = NULL;
   char* apn  = NULL;
 
@@ -122,13 +120,6 @@ void handle_s5_create_session_request(
       "EPS bearer id %u\n",
       context_teid, eps_bearer_id);
 
-  // IP forward will forward packets to this teid
-  sgi_create_endpoint_resp.context_teid  = context_teid;
-  sgi_create_endpoint_resp.eps_bearer_id = eps_bearer_id;
-  sgi_create_endpoint_resp.paa.pdn_type =
-      new_bearer_ctxt_info_p->sgw_eps_bearer_context_information.saved_message
-          .pdn_type;
-
   imsi =
       (char*)
           new_bearer_ctxt_info_p->sgw_eps_bearer_context_information.imsi.digit;
@@ -145,14 +136,12 @@ void handle_s5_create_session_request(
 
     case IPv6:
       pgw_handle_allocate_ipv6_address(
-          imsi, apn, &in6addr, sgi_create_endpoint_resp, "ipv6", spgw_state,
-          new_bearer_ctxt_info_p, s5_response);
+          imsi, apn, "ipv6", context_teid, eps_bearer_id);
       break;
 
     case IPv4_AND_v6:
       pgw_handle_allocate_ipv4v6_address(
-          imsi, apn, &inaddr, &in6addr, sgi_create_endpoint_resp, "ipv4v6",
-          spgw_state, new_bearer_ctxt_info_p, s5_response);
+          imsi, apn, "ipv4v6", context_teid, eps_bearer_id);
       break;
 
     default:

--- a/lte/gateway/c/oai/tasks/sgw/pgw_handlers.c
+++ b/lte/gateway/c/oai/tasks/sgw/pgw_handlers.c
@@ -323,7 +323,6 @@ int spgw_handle_nw_initiated_bearer_actv_req(
 
 //------------------------------------------------------------------------------
 int32_t spgw_handle_nw_initiated_bearer_deactv_req(
-    spgw_state_t* spgw_state,
     const itti_gx_nw_init_deactv_bearer_request_t* const bearer_req_p,
     imsi64_t imsi64) {
   OAILOG_FUNC_IN(LOG_SPGW_APP);

--- a/lte/gateway/c/oai/tasks/sgw/pgw_handlers.h
+++ b/lte/gateway/c/oai/tasks/sgw/pgw_handlers.h
@@ -46,7 +46,6 @@ int spgw_handle_nw_initiated_bearer_actv_req(
     imsi64_t imsi64, gtpv2c_cause_value_t* failed_cause);
 
 int32_t spgw_handle_nw_initiated_bearer_deactv_req(
-    spgw_state_t* spgw_state,
     const itti_gx_nw_init_deactv_bearer_request_t* const bearer_req_p,
     imsi64_t imsi64);
 

--- a/lte/gateway/c/oai/tasks/sgw/sgw_handlers.c
+++ b/lte/gateway/c/oai/tasks/sgw/sgw_handlers.c
@@ -932,7 +932,6 @@ static int send_mbr_failure(
 
 //------------------------------------------------------------------------------
 int sgw_handle_modify_bearer_request(
-    spgw_state_t* state,
     const itti_s11_modify_bearer_request_t* const modify_bearer_pP,
     imsi64_t imsi64) {
   OAILOG_FUNC_IN(LOG_SPGW_APP);
@@ -1794,7 +1793,7 @@ int sgw_handle_nw_initiated_deactv_bearer_rsp(
               enb, eps_bearer_ctxt_p->paa.ipv4_address, ue_ipv6,
               eps_bearer_ctxt_p->s_gw_teid_S1u_S12_S4_up,
               eps_bearer_ctxt_p->enb_teid_S1u, NULL);
-          if (rc < 0) {
+          if (rc != RETURNok) {
             OAILOG_ERROR_UE(
                 LOG_SPGW_APP, imsi64,
                 "ERROR in deleting TUNNEL " TEID_FMT
@@ -1873,7 +1872,7 @@ int sgw_handle_nw_initiated_deactv_bearer_rsp(
               enb, eps_bearer_ctxt_p->paa.ipv4_address, ue_ipv6,
               eps_bearer_ctxt_p->s_gw_teid_S1u_S12_S4_up,
               eps_bearer_ctxt_p->enb_teid_S1u, &dlflow);
-          if (rc < 0) {
+          if (rc != RETURNok) {
             OAILOG_ERROR_UE(
                 LOG_SPGW_APP, imsi64,
                 "ERROR in deleting TUNNEL " TEID_FMT
@@ -1947,13 +1946,13 @@ int sgw_handle_ip_allocation_rsp(
       inet_ntop(
           AF_INET, &(ip_allocation_rsp->paa.ipv4_address.s_addr), ip_str,
           INET_ADDRSTRLEN);
-        pcef_create_session(imsi, ip_str, NULL, &session_data, session_req);
+      pcef_create_session(imsi, ip_str, NULL, &session_data, session_req);
     } else if (ip_allocation_rsp->paa.pdn_type == IPv6) {
       char ip6_str[INET6_ADDRSTRLEN];
       inet_ntop(
           AF_INET6, &(ip_allocation_rsp->paa.ipv6_address), ip6_str,
           INET6_ADDRSTRLEN);
-        pcef_create_session(imsi, NULL, ip6_str, &session_data, session_req);
+      pcef_create_session(imsi, NULL, ip6_str, &session_data, session_req);
     } else if (ip_allocation_rsp->paa.pdn_type == IPv4_AND_v6) {
       char ip4_str[INET_ADDRSTRLEN];
       inet_ntop(
@@ -1963,7 +1962,7 @@ int sgw_handle_ip_allocation_rsp(
       inet_ntop(
           AF_INET6, &(ip_allocation_rsp->paa.ipv6_address), ip6_str,
           INET6_ADDRSTRLEN);
-        pcef_create_session(imsi, ip4_str, ip6_str, &session_data, session_req);
+      pcef_create_session(imsi, ip4_str, ip6_str, &session_data, session_req);
     }
   } else {
     if (ip_allocation_rsp->status == SGI_STATUS_ERROR_SYSTEM_FAILURE) {
@@ -2214,7 +2213,7 @@ static void _add_tunnel_helper(
         eps_bearer_ctxt_entry_p->tft.packetfilterlist.createnewtft[i]
             .eval_precedence);
 
-    if (rc < 0) {
+    if (rc != RETURNok) {
       OAILOG_ERROR_UE(
           LOG_SPGW_APP, imsi64, "ERROR in setting up TUNNEL err=%d\n", rc);
     } else {

--- a/lte/gateway/c/oai/tasks/sgw/sgw_handlers.c
+++ b/lte/gateway/c/oai/tasks/sgw/sgw_handlers.c
@@ -1941,11 +1941,30 @@ int sgw_handle_ip_allocation_rsp(
         &bearer_ctxt_info_p->sgw_eps_bearer_context_information.saved_message,
         &session_data);
 
-    char ip_str[INET_ADDRSTRLEN];
-    inet_ntop(
-        AF_INET, &(ip_allocation_rsp->paa.ipv4_address.s_addr), ip_str,
-        INET_ADDRSTRLEN);
-    pcef_create_session(imsi, ip_str, NULL, &session_data, session_req);
+    // Create session based IPv4, IPv6 or IPv4v6 PDN type
+    if (ip_allocation_rsp->paa.pdn_type == IPv4) {
+      char ip_str[INET_ADDRSTRLEN];
+      inet_ntop(
+          AF_INET, &(ip_allocation_rsp->paa.ipv4_address.s_addr), ip_str,
+          INET_ADDRSTRLEN);
+        pcef_create_session(imsi, ip_str, NULL, &session_data, session_req);
+    } else if (ip_allocation_rsp->paa.pdn_type == IPv6) {
+      char ip6_str[INET6_ADDRSTRLEN];
+      inet_ntop(
+          AF_INET6, &(ip_allocation_rsp->paa.ipv6_address), ip6_str,
+          INET6_ADDRSTRLEN);
+        pcef_create_session(imsi, NULL, ip6_str, &session_data, session_req);
+    } else if (ip_allocation_rsp->paa.pdn_type == IPv4_AND_v6) {
+      char ip4_str[INET_ADDRSTRLEN];
+      inet_ntop(
+          AF_INET, &(ip_allocation_rsp->paa.ipv4_address.s_addr), ip4_str,
+          INET_ADDRSTRLEN);
+      char ip6_str[INET6_ADDRSTRLEN];
+      inet_ntop(
+          AF_INET6, &(ip_allocation_rsp->paa.ipv6_address), ip6_str,
+          INET6_ADDRSTRLEN);
+        pcef_create_session(imsi, ip4_str, ip6_str, &session_data, session_req);
+    }
   } else {
     if (ip_allocation_rsp->status == SGI_STATUS_ERROR_SYSTEM_FAILURE) {
       /*
@@ -1955,7 +1974,15 @@ int sgw_handle_ip_allocation_rsp(
       // TODO - Release the GTP-tunnel corresponding to this IP address
       char* apn = (char*) bearer_ctxt_info_p->sgw_eps_bearer_context_information
                       .pdn_connection.apn_in_use;
-      release_ipv4_address(imsi, apn, &ip_allocation_rsp->paa.ipv4_address);
+      if (ip_allocation_rsp->paa.pdn_type == IPv4) {
+        release_ipv4_address(imsi, apn, &ip_allocation_rsp->paa.ipv4_address);
+      } else if (ip_allocation_rsp->paa.pdn_type == IPv6) {
+        release_ipv6_address(imsi, apn, &ip_allocation_rsp->paa.ipv6_address);
+      } else if (ip_allocation_rsp->paa.pdn_type == IPv4_AND_v6) {
+        release_ipv4v6_address(
+            imsi, apn, &ip_allocation_rsp->paa.ipv4_address,
+            &ip_allocation_rsp->paa.ipv6_address);
+      }
     }
 
     // If we are here then the IP address allocation has failed

--- a/lte/gateway/c/oai/tasks/sgw/sgw_handlers.h
+++ b/lte/gateway/c/oai/tasks/sgw/sgw_handlers.h
@@ -43,7 +43,6 @@ void sgw_handle_sgi_endpoint_updated(
 int sgw_handle_sgi_endpoint_deleted(
     const itti_sgi_delete_end_point_request_t* const resp_pP, imsi64_t imsi64);
 int sgw_handle_modify_bearer_request(
-    spgw_state_t* state,
     const itti_s11_modify_bearer_request_t* const modify_bearer_p,
     imsi64_t imsi64);
 int sgw_handle_delete_session_request(

--- a/lte/gateway/c/oai/tasks/sgw/sgw_task.c
+++ b/lte/gateway/c/oai/tasks/sgw/sgw_task.c
@@ -85,8 +85,7 @@ static int handle_message(zloop_t* loop, zsock_t* reader, void* arg) {
 
     case S11_MODIFY_BEARER_REQUEST: {
       sgw_handle_modify_bearer_request(
-          spgw_state, &received_message_p->ittiMsg.s11_modify_bearer_request,
-          imsi64);
+          &received_message_p->ittiMsg.s11_modify_bearer_request, imsi64);
     } break;
 
     case S11_RELEASE_ACCESS_BEARERS_REQUEST: {
@@ -155,7 +154,6 @@ static int handle_message(zloop_t* loop, zsock_t* reader, void* arg) {
 
     case GX_NW_INITIATED_DEACTIVATE_BEARER_REQ: {
       int32_t rc = spgw_handle_nw_initiated_bearer_deactv_req(
-          spgw_state,
           &received_message_p->ittiMsg.gx_nw_init_deactv_bearer_request,
           imsi64);
       if (rc != RETURNok) {


### PR DESCRIPTION
Signed-off-by: Alex Rodriguez <ardzoht@gmail.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary

- This PR completes the movement of processing of SPGW-mobilityd IP allocation through ITTI messaging, similarly as was done on https://github.com/magma/magma/pull/5416/ 

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->
- Tested sanity with make integ_test
- Running `test_ipv6_secondary_pdn_rs_retransmit.py` and `test_ipv4v6_secondary_pdn.py` as well as other ipv6 related s1ap integ tests, however tests are failing due to an unrelated issue 

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
