### PR TITLE
refactor(ci): Add molecule test into ovs_prepare ansible role

### DIFF
--- a/.github/workflows/molecule_tests.yml
+++ b/.github/workflows/molecule_tests.yml
@@ -1,0 +1,37 @@
+---
+# SPDX-license-identifier: Apache-2.0
+##############################################################################
+# Copyright (c) 2021
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Apache License, Version 2.0
+# which accompanies this distribution, and is available at
+# http://www.apache.org/licenses/LICENSE-2.0
+##############################################################################
+
+name: Check Molecule Tests
+# yamllint disable-line rule:truthy
+on: [push, pull_request]
+
+jobs:
+  check-molecule:
+    runs-on: macos-10.15
+    strategy:
+      fail-fast: false
+      matrix:
+        tox_env: [ovs_prepare]
+    steps:
+      - uses: actions/checkout@v2
+      - name: Cache Vagrant boxes
+        uses: actions/cache@v2
+        with:
+          path: ~/.vagrant.d/boxes
+          key: ${{ runner.os }}-vagrant-${{ hashFiles('Vagrantfile') }}
+          restore-keys: |
+            ${{ runner.os }}-vagrant-
+      - name: Install Tox tool
+        run: brew install tox
+      - name: Run molecule tests
+        env:
+          VAGRANT_DISABLE_VBOXSYMLINKCREATE: 1
+          TOXENV: ${{ matrix.tox_env }}
+        run: tox

--- a/lte/gateway/deploy/roles/ovs_prepare/defaults/main.yml
+++ b/lte/gateway/deploy/roles/ovs_prepare/defaults/main.yml
@@ -11,6 +11,21 @@
 # limitations under the License.
 #
 
+packages:
+  - graphviz
+  - debhelper
+  - dh-autoreconf
+  - python-all
+  - python-twisted-conch
+  - module-assistant
+  - openssl
+  - pkg-config
+  - libssl-dev
+  - build-essential
+  - libcap-ng-dev
+  - git
+  - ruby-dev
+
 # ovs version on github default v2.8.1
 ovs_version: "v2.8.10"
 # ovs version short in order to retreive patches if any

--- a/lte/gateway/deploy/roles/ovs_prepare/defaults/main.yml
+++ b/lte/gateway/deploy/roles/ovs_prepare/defaults/main.yml
@@ -1,4 +1,16 @@
 ---
+# Copyright 2021 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 # ovs version on github default v2.8.1
 ovs_version: "v2.8.10"
 # ovs version short in order to retreive patches if any

--- a/lte/gateway/deploy/roles/ovs_prepare/defaults/main.yml
+++ b/lte/gateway/deploy/roles/ovs_prepare/defaults/main.yml
@@ -33,7 +33,7 @@ ovs_version_short: "2.8.10"
 # patches relative location
 gtp_patch_path: "third_party/gtp_ovs/kernel-4.9/"
 # Working directory where ovs will be clone and patch applied
-WORK_DIR: "~/build-ovs"
+build_folder: "/tmp/build-ovs"
 # Patches you want to apply
 patches:
   - "0001-datapath-add-vport-gtp-for-GPRS-Tunneling-Protocol.patch"

--- a/lte/gateway/deploy/roles/ovs_prepare/defaults/main.yml
+++ b/lte/gateway/deploy/roles/ovs_prepare/defaults/main.yml
@@ -16,7 +16,6 @@ packages:
   - debhelper
   - dh-autoreconf
   - python-all
-  - python-twisted-conch
   - module-assistant
   - openssl
   - pkg-config

--- a/lte/gateway/deploy/roles/ovs_prepare/handlers/main.yml
+++ b/lte/gateway/deploy/roles/ovs_prepare/handlers/main.yml
@@ -1,0 +1,18 @@
+---
+# Copyright 2021 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+- name: Restart service ssh
+  become: true
+  service:
+    name: ssh
+    state: restarted

--- a/lte/gateway/deploy/roles/ovs_prepare/molecule/default/converge.yml
+++ b/lte/gateway/deploy/roles/ovs_prepare/molecule/default/converge.yml
@@ -1,0 +1,20 @@
+---
+# Copyright 2021 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+- name: Converge
+  hosts: all
+  vars:
+    MAGMA_ROOT: ../../../../../../magma
+  tasks:
+    - name: Include ovs_prepare
+      include_role:
+        name: ovs_prepare

--- a/lte/gateway/deploy/roles/ovs_prepare/molecule/default/molecule.yml
+++ b/lte/gateway/deploy/roles/ovs_prepare/molecule/default/molecule.yml
@@ -1,0 +1,26 @@
+---
+# Copyright 2021 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+driver:
+  name: vagrant
+lint: |
+  set -e
+  PATH=${PATH}
+  yamllint .
+  ansible-lint .
+platforms:
+  - name: instance
+    box: magmacore/magma_dev
+    memory: 3072
+    cpus: 1
+provisioner:
+  name: ansible

--- a/lte/gateway/deploy/roles/ovs_prepare/molecule/default/verify.yml
+++ b/lte/gateway/deploy/roles/ovs_prepare/molecule/default/verify.yml
@@ -1,0 +1,26 @@
+---
+# Copyright 2021 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+- name: Verify
+  hosts: all
+  tasks:
+    - name: Include default vars
+      include_vars: ../../defaults/main.yml
+    - name: Check that ovs depcomp file exists
+      stat:
+        path: "{{ build_folder | realpath }}/ovs/build-aux/depcomp"
+      register: ovs_depcomp
+    - name: testinfra execution
+      assert:
+        that:
+          - ovs_depcomp.stat.exists

--- a/lte/gateway/deploy/roles/ovs_prepare/tasks/main.yml
+++ b/lte/gateway/deploy/roles/ovs_prepare/tasks/main.yml
@@ -16,11 +16,6 @@
     msg: MAGMA_ROOT is required
   when: MAGMA_ROOT is not defined
 
-- name: Validate kernel version supported
-  fail:
-    msg: Kernel {{ ansible_kernel  }} not supported please use 4.9.0-9-amd64
-  when: ansible_kernel != '4.9.0-9-amd64'
-
 - name: Creating "{{ build_folder }}"
   file:
     path: "{{ build_folder | realpath }}"

--- a/lte/gateway/deploy/roles/ovs_prepare/tasks/main.yml
+++ b/lte/gateway/deploy/roles/ovs_prepare/tasks/main.yml
@@ -76,9 +76,10 @@
 
 - name: Install FPM
   become: true
-  gem: name=fpm
-       user_install=no
-       state=present
+  gem:
+    name: fpm
+    user_install: false
+    state: present
 
 - name: Check that ovs source code folder exists
   stat:

--- a/lte/gateway/deploy/roles/ovs_prepare/tasks/main.yml
+++ b/lte/gateway/deploy/roles/ovs_prepare/tasks/main.yml
@@ -17,6 +17,7 @@
   when: MAGMA_ROOT is not defined
 
 - name: Creating "{{ build_folder }}"
+  become: true
   file:
     path: "{{ build_folder | realpath }}"
     state: directory
@@ -67,6 +68,7 @@
   register: ovs_dest_stat
 
 - name: Prepare the ovs source code
+  become: true
   block:
     - name: Cloning the ovs "{{ ovs_version }}".
       git:
@@ -106,6 +108,7 @@
   register: ovs_depcomp
 
 - name: Execute the boot.sh script.
+  become: true
   command: sh boot.sh  # noqa 301
   args:
     chdir: "{{ GIT_HOME.path }}/ovs"

--- a/lte/gateway/deploy/roles/ovs_prepare/tasks/main.yml
+++ b/lte/gateway/deploy/roles/ovs_prepare/tasks/main.yml
@@ -21,13 +21,8 @@
     msg: Kernel {{ ansible_kernel  }} not supported please use 4.9.0-9-amd64
   when: ansible_kernel != '4.9.0-9-amd64'
 
-- name: Include vars of all.yaml
-  include_vars:
-    file: all.yaml
-    name: all_vars
-
 - name: Converting WORK_DIR to absolute path
-  shell: realpath {{ all_vars.WORK_DIR }}
+  shell: realpath {{ WORK_DIR }}
   register: WORK_DIR_ABSOLUTE
 
 - name: Converting OUTPUT_DIR to absolute path
@@ -41,9 +36,9 @@
     state: absent
     force: true
 
-- name: Creating "{{ all_vars.WORK_DIR }}"
+- name: Creating "{{ WORK_DIR }}"
   file:
-    path: "{{ all_vars.WORK_DIR }}"
+    path: "{{ WORK_DIR }}"
     state: directory
     mode: 0755
   register: GIT_HOME
@@ -97,36 +92,36 @@
        user_install=no
        state=present
 
-- name: Cloning the ovs "{{ all_vars.ovs_version }}".
+- name: Cloning the ovs "{{ ovs_version }}".
   git:
     repo: https://github.com/openvswitch/ovs.git
     dest: "{{ GIT_HOME.path }}/ovs"
-    version: "{{ all_vars.ovs_version }}"
+    version: "{{ ovs_version }}"
 
 - name: Uploading gtp backport patch to remote.
   synchronize:
-    src: "{{ MAGMA_ROOT }}/{{ all_vars.gtp_patch_path }}/gtp-v4.9-backport/"
+    src: "{{ MAGMA_ROOT }}/{{ gtp_patch_path }}/gtp-v4.9-backport/"
     dest: "{{ GIT_HOME.path }}/ovs/flow-based-gtp-linux-v4.9"
 
 - name: Uploading gtp patches to remote.
   synchronize:
     # yamllint disable-line rule:line-length
-    src: "{{ MAGMA_ROOT }}/{{ all_vars.gtp_patch_path }}/{{ all_vars.ovs_version_short }}/"
+    src: "{{ MAGMA_ROOT }}/{{ gtp_patch_path }}/{{ ovs_version_short }}/"
     dest: "{{ GIT_HOME.path }}/ovs/"
   with_items:
-    - "{{ all_vars.patches }}"
+    - "{{ patches }}"
 
 - name: Patch ovs
   command: git apply "{{ item }}"
   args:
     chdir: "{{ GIT_HOME.path }}/ovs"
   with_items:
-    - "{{ all_vars.patches }}"
+    - "{{ patches }}"
 
 - name: Cherry pick vlan patch
   shell: |
     set -o pipefail
-    git show "{{ all_vars.vlan_fix_hash }}" | git apply -3 -
+    git show "{{ vlan_fix_hash }}" | git apply -3 -
   args:
     executable: /bin/bash
     chdir: "{{ GIT_HOME.path }}/ovs"

--- a/lte/gateway/deploy/roles/ovs_prepare/tasks/main.yml
+++ b/lte/gateway/deploy/roles/ovs_prepare/tasks/main.yml
@@ -21,24 +21,13 @@
     msg: Kernel {{ ansible_kernel  }} not supported please use 4.9.0-9-amd64
   when: ansible_kernel != '4.9.0-9-amd64'
 
-- name: Converting WORK_DIR to absolute path
-  shell: realpath {{ WORK_DIR }}
-  register: WORK_DIR_ABSOLUTE
-
 - name: Converting OUTPUT_DIR to absolute path
   shell: realpath {{ OUTPUT_DIR }}
   register: OUTPUT_DIR_ABSOLUTE
 
-- name: Removing "{{ WORK_DIR_ABSOLUTE.stdout }}".
-  become: true
+- name: Creating "{{ build_folder }}"
   file:
-    path: "{{ WORK_DIR_ABSOLUTE.stdout }}"
-    state: absent
-    force: true
-
-- name: Creating "{{ WORK_DIR }}"
-  file:
-    path: "{{ WORK_DIR }}"
+    path: "{{ build_folder | realpath }}"
     state: directory
     mode: 0755
   register: GIT_HOME

--- a/lte/gateway/deploy/roles/ovs_prepare/tasks/main.yml
+++ b/lte/gateway/deploy/roles/ovs_prepare/tasks/main.yml
@@ -119,7 +119,13 @@
         chdir: "{{ GIT_HOME.path }}/ovs"
   when: not ovs_dest_stat.stat.exists
 
+- name: Check that ovs depcomp file exists
+  stat:
+    path: "{{ GIT_HOME.path }}/ovs/build-aux/depcomp"
+  register: ovs_depcomp
+
 - name: Execute the boot.sh script.
   command: sh boot.sh  # noqa 301
   args:
     chdir: "{{ GIT_HOME.path }}/ovs"
+  when: not ovs_depcomp.stat.exists

--- a/lte/gateway/deploy/roles/ovs_prepare/tasks/main.yml
+++ b/lte/gateway/deploy/roles/ovs_prepare/tasks/main.yml
@@ -80,39 +80,44 @@
        user_install=no
        state=present
 
-- name: Cloning the ovs "{{ ovs_version }}".
-  git:
-    repo: https://github.com/openvswitch/ovs.git
-    dest: "{{ GIT_HOME.path }}/ovs"
-    version: "{{ ovs_version }}"
+- name: Check that ovs source code folder exists
+  stat:
+    path: "{{ GIT_HOME.path }}/ovs"
+  register: ovs_dest_stat
 
-- name: Uploading gtp backport patch to remote.
-  synchronize:
-    src: "{{ MAGMA_ROOT }}/{{ gtp_patch_path }}/gtp-v4.9-backport/"
-    dest: "{{ GIT_HOME.path }}/ovs/flow-based-gtp-linux-v4.9"
+- name: Prepare the ovs source code
+  block:
+    - name: Cloning the ovs "{{ ovs_version }}".
+      git:
+        repo: https://github.com/openvswitch/ovs.git
+        dest: "{{ GIT_HOME.path }}/ovs"
+        version: "{{ ovs_version }}"
 
-- name: Uploading gtp patches to remote.
-  synchronize:
-    # yamllint disable-line rule:line-length
-    src: "{{ MAGMA_ROOT }}/{{ gtp_patch_path }}/{{ ovs_version_short }}/"
-    dest: "{{ GIT_HOME.path }}/ovs/"
-  with_items:
-    - "{{ patches }}"
+    - name: Uploading gtp backport patch to remote.
+      synchronize:
+        src: "{{ MAGMA_ROOT }}/{{ gtp_patch_path }}/gtp-v4.9-backport/"
+        dest: "{{ GIT_HOME.path }}/ovs/flow-based-gtp-linux-v4.9"
 
-- name: Patch ovs
-  command: git apply "{{ item }}"
-  args:
-    chdir: "{{ GIT_HOME.path }}/ovs"
-  with_items:
-    - "{{ patches }}"
+    - name: Uploading gtp patches to remote.
+      synchronize:
+        src: "{{ MAGMA_ROOT }}/{{ gtp_patch_path }}/{{ ovs_version_short }}/"
+        dest: "{{ GIT_HOME.path }}/ovs/"
+      with_items: "{{ patches }}"
 
-- name: Cherry pick vlan patch
-  shell: |
-    set -o pipefail
-    git show "{{ vlan_fix_hash }}" | git apply -3 -
-  args:
-    executable: /bin/bash
-    chdir: "{{ GIT_HOME.path }}/ovs"
+    - name: Patch ovs
+      command: git apply "{{ item }}"  # noqa 303
+      args:
+        chdir: "{{ GIT_HOME.path }}/ovs"
+      with_items: "{{ patches }}"
+
+    - name: Cherry pick vlan patch
+      shell: |
+        set -o pipefail
+        git show "{{ vlan_fix_hash }}" | git apply -3 -
+      args:
+        executable: /bin/bash
+        chdir: "{{ GIT_HOME.path }}/ovs"
+  when: not ovs_dest_stat.stat.exists
 
 - name: Execute the boot.sh script.
   command: sh boot.sh  # noqa 301

--- a/lte/gateway/deploy/roles/ovs_prepare/tasks/main.yml
+++ b/lte/gateway/deploy/roles/ovs_prepare/tasks/main.yml
@@ -11,19 +11,15 @@
 # limitations under the License.
 #
 
-- name: Validate MAGMA_ROOT env variable
-  fail: msg="MAGMA_ROOT and OUTPUT_DIR are required"
-  when:
-    - MAGMA_ROOT is not defined or OUTPUT_DIR is not defined
+- name: validate MAGMA_ROOT env variable.
+  fail:
+    msg: MAGMA_ROOT is required
+  when: MAGMA_ROOT is not defined
 
 - name: Validate kernel version supported
   fail:
     msg: Kernel {{ ansible_kernel  }} not supported please use 4.9.0-9-amd64
   when: ansible_kernel != '4.9.0-9-amd64'
-
-- name: Converting OUTPUT_DIR to absolute path
-  shell: realpath {{ OUTPUT_DIR }}
-  register: OUTPUT_DIR_ABSOLUTE
 
 - name: Creating "{{ build_folder }}"
   file:

--- a/lte/gateway/deploy/roles/ovs_prepare/tasks/main.yml
+++ b/lte/gateway/deploy/roles/ovs_prepare/tasks/main.yml
@@ -66,12 +66,8 @@
     src: sshd_config
     dest: /etc/ssh/sshd_config
   become: true
-
-- name: Restart service ssh
-  become: true
-  service:
-    name: ssh
-    state: restarted
+  notify:
+    - Restart service ssh
 
 - name: Install FPM
   become: true

--- a/lte/gateway/deploy/roles/ovs_prepare/tasks/main.yml
+++ b/lte/gateway/deploy/roles/ovs_prepare/tasks/main.yml
@@ -11,11 +11,13 @@
 # limitations under the License.
 #
 
-- fail: msg="MAGMA_ROOT and OUTPUT_DIR are required"
+- name: Validate MAGMA_ROOT env variable
+  fail: msg="MAGMA_ROOT and OUTPUT_DIR are required"
   when:
     - MAGMA_ROOT is not defined or OUTPUT_DIR is not defined
 
-- fail:
+- name: Validate kernel version supported
+  fail:
     msg: Kernel {{ ansible_kernel  }} not supported please use 4.9.0-9-amd64
   when: ansible_kernel != '4.9.0-9-amd64'
 
@@ -77,10 +79,11 @@
   become: true
 
 - name: Copy ssh keepAlive configs
-  copy: src={{ item.src }} dest={{ item.dest }}
+  copy:
+    mode: preserve
+    src: sshd_config
+    dest: /etc/ssh/sshd_config
   become: true
-  with_items:
-    - {src: 'sshd_config', dest: '/etc/ssh/sshd_config'}
 
 - name: Restart service ssh
   become: true
@@ -121,11 +124,14 @@
     - "{{ all_vars.patches }}"
 
 - name: Cherry pick vlan patch
-  command: bash -c 'git show "{{ all_vars.vlan_fix_hash }}" | git apply -3 -'
+  shell: |
+    set -o pipefail
+    git show "{{ all_vars.vlan_fix_hash }}" | git apply -3 -
   args:
+    executable: /bin/bash
     chdir: "{{ GIT_HOME.path }}/ovs"
 
 - name: Execute the boot.sh script.
-  command: sh boot.sh
+  command: sh boot.sh  # noqa 301
   args:
     chdir: "{{ GIT_HOME.path }}/ovs"

--- a/lte/gateway/deploy/roles/ovs_prepare/tasks/main.yml
+++ b/lte/gateway/deploy/roles/ovs_prepare/tasks/main.yml
@@ -47,7 +47,9 @@
   become: true
   apt:
     update_cache: true
-    upgrade: "yes"
+    cache_valid_time: 3600
+  changed_when: false
+  when: ansible_os_family == 'Debian'
 
 - name: Install build dependencies.
   become: true
@@ -57,8 +59,11 @@
   with_items: "{{ packages }}"
 
 - name: Ensure correct kernel headers are installed.
-  shell: "apt -y install linux-headers-$(uname -r)"
   become: true
+  package:
+    name: "linux-headers-{{ ansible_kernel }}"
+    state: present
+  when: ansible_os_family == 'Debian'
 
 - name: Copy ssh keepAlive configs
   copy:

--- a/lte/gateway/deploy/roles/ovs_prepare/tasks/main.yml
+++ b/lte/gateway/deploy/roles/ovs_prepare/tasks/main.yml
@@ -15,13 +15,9 @@
   when:
     - MAGMA_ROOT is not defined or OUTPUT_DIR is not defined
 
-- name: Get Kernel version
-  shell: uname -r
-  register: KVERS
-
-- fail: msg="Kernel Version {{ KVERS.stdout  }} not supported please use 4.9.0-9-amd64"
-  when:
-    - KVERS.stdout != '4.9.0-9-amd64'
+- fail:
+    msg: Kernel {{ ansible_kernel  }} not supported please use 4.9.0-9-amd64
+  when: ansible_kernel != '4.9.0-9-amd64'
 
 - name: Include vars of all.yaml
   include_vars:
@@ -37,11 +33,11 @@
   register: OUTPUT_DIR_ABSOLUTE
 
 - name: Removing "{{ WORK_DIR_ABSOLUTE.stdout }}".
-  become: yes
+  become: true
   file:
     path: "{{ WORK_DIR_ABSOLUTE.stdout }}"
     state: absent
-    force: yes
+    force: true
 
 - name: Creating "{{ all_vars.WORK_DIR }}"
   file:
@@ -51,13 +47,13 @@
   register: GIT_HOME
 
 - name: Update and upgrade apt packages
-  become: yes
+  become: true
   apt:
-    update_cache: yes
+    update_cache: true
     upgrade: "yes"
 
 - name: Install build dependencies.
-  become: yes
+  become: true
   apt:
     name: "{{ packages }}"
   vars:
@@ -78,22 +74,22 @@
 
 - name: Ensure correct kernel headers are installed.
   shell: "apt -y install linux-headers-$(uname -r)"
-  become: yes
+  become: true
 
 - name: Copy ssh keepAlive configs
   copy: src={{ item.src }} dest={{ item.dest }}
-  become: yes
+  become: true
   with_items:
     - {src: 'sshd_config', dest: '/etc/ssh/sshd_config'}
 
 - name: Restart service ssh
-  become: yes
+  become: true
   service:
     name: ssh
     state: restarted
 
 - name: Install FPM
-  become: yes
+  become: true
   gem: name=fpm
        user_install=no
        state=present
@@ -111,6 +107,7 @@
 
 - name: Uploading gtp patches to remote.
   synchronize:
+    # yamllint disable-line rule:line-length
     src: "{{ MAGMA_ROOT }}/{{ all_vars.gtp_patch_path }}/{{ all_vars.ovs_version_short }}/"
     dest: "{{ GIT_HOME.path }}/ovs/"
   with_items:
@@ -121,7 +118,7 @@
   args:
     chdir: "{{ GIT_HOME.path }}/ovs"
   with_items:
-      - "{{ all_vars.patches }}"
+    - "{{ all_vars.patches }}"
 
 - name: Cherry pick vlan patch
   command: bash -c 'git show "{{ all_vars.vlan_fix_hash }}" | git apply -3 -'

--- a/lte/gateway/deploy/roles/ovs_prepare/tasks/main.yml
+++ b/lte/gateway/deploy/roles/ovs_prepare/tasks/main.yml
@@ -51,23 +51,10 @@
 
 - name: Install build dependencies.
   become: true
-  apt:
-    name: "{{ packages }}"
-  vars:
-    packages:
-      - graphviz
-      - debhelper
-      - dh-autoreconf
-      - python-all
-      - python-twisted-conch
-      - module-assistant
-      - openssl
-      - pkg-config
-      - libssl-dev
-      - build-essential
-      - libcap-ng-dev
-      - git
-      - ruby-dev
+  package:
+    name: "{{ item }}"
+    state: present
+  with_items: "{{ packages }}"
 
 - name: Ensure correct kernel headers are installed.
   shell: "apt -y install linux-headers-$(uname -r)"

--- a/lte/gateway/deploy/roles/ovs_prepare/tasks/main.yml
+++ b/lte/gateway/deploy/roles/ovs_prepare/tasks/main.yml
@@ -24,6 +24,13 @@
     mode: 0755
   register: GIT_HOME
 
+- name: Delete /var/cache/apt/archives if exists
+  become: true
+  file:
+    path: /var/cache/apt/archives
+    state: absent
+  changed_when: false
+
 - name: Update and upgrade apt packages
   become: true
   apt:

--- a/lte/gateway/deploy/roles/ovs_prepare/vars/all.yaml
+++ b/lte/gateway/deploy/roles/ovs_prepare/vars/all.yaml
@@ -1,3 +1,4 @@
+---
 # ovs version on github default v2.8.1
 ovs_version: "v2.8.10"
 # ovs version short in order to retreive patches if any

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,0 +1,3 @@
+molecule==3.0.8 # MIT
+molecule_vagrant==0.3 # MIT
+molecule[lint]

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,14 @@
+[tox]
+minversion = 3.15
+skipsdist = True
+
+[testenv]
+passenv = http_proxy HTTP_PROXY https_proxy HTTPS_PROXY no_proxy NO_PROXY
+commands =
+  find . -type f -name "*.pyc" -delete
+
+[testenv:{ovs_prepare}]
+deps = -r{toxinidir}/test-requirements.txt
+envdir = {toxinidir}/.tox/molecule
+changedir = {toxinidir}/lte/gateway/deploy/roles/{envname}
+commands = molecule --debug test


### PR DESCRIPTION
## Summary

[Ansible Molecule](https://molecule.readthedocs.io/en/latest/) project provides a testing framework for Ansible playbooks helping to improve the quality and coverage of the code. This change improves the reproducibility and testing for `ovs_prepare` role.

## Test Plan

This change requires the [tox tool](https://pypi.org/project/tox/) which it's going to facilitate the installation of additional python dependencies on a virtual environment

There are some additional binary dependencies which can manually installed :
- [Vagrant](https://www.vagrantup.com/downloads)
- Libvirt or VirtualBox provisioners

Once those dependencies are installed, the `tox -e ovs_prepare` command will validate the role's execution.

## Additional Information

This change includes a GitHub action which executes this test on the CI.
