### PR TITLE
[lte][agw] Add missing parts for picking plmn restriction from gateway.mconfig

### DIFF
--- a/lte/gateway/configs/templates/mme.conf.template
+++ b/lte/gateway/configs/templates/mme.conf.template
@@ -96,8 +96,13 @@ MME :
     # By default this list is empty
     # Max number of restricted plmn is 10
     RESTRICTED_PLMN_LIST = (
-         # Sample plmn
-         #{ MCC="001" ; MNC="010";}
+        # PlmnConfig values can be found at magma/lte/protos/mconfig/mconfigs.proto
+        {% for plmn_config in restrictedPlmns -%}
+        {
+          MCC        = "{{ plmn_config.mcc }}"
+          MNC        = "{{ plmn_config.mnc }}"
+        }{% if not loop.last %},{% endif %}
+        {% endfor %}
     );
 
     CSFB :

--- a/lte/gateway/deploy/roles/magma/files/update_mme_config_for_sanity.sh
+++ b/lte/gateway/deploy/roles/magma/files/update_mme_config_for_sanity.sh
@@ -69,7 +69,7 @@ function reduce_mobile_reachability_timer_value {
 
 function configure_restricted_plmn {
   # Remove default restricted PLMN from MME configuration file
-  sed -i -e '/RESTRICTED_PLMN_LIST/{n;d}' \
+  sed -i -e '/RESTRICTED_PLMN_LIST/{n;N;N;N;N;N;N;d}' \
     "$mme_config_file"
 
   # Configure restricted PLMN/s in MME configuration file

--- a/lte/gateway/python/scripts/generate_oai_config.py
+++ b/lte/gateway/python/scripts/generate_oai_config.py
@@ -184,6 +184,10 @@ def _get_federated_mode_map(service_mconfig):
         return service_mconfig.federated_mode_map.mapping
     return {}
 
+def _get_restricted_plmns(mme_service_config):
+    if service_mconfig.restricted_plmns:
+        return service_mconfig.restricted_plmns
+    return {}
 
 def _get_context():
     """
@@ -215,7 +219,8 @@ def _get_context():
                                                   "use_stateless", ""),
         "attached_enodeb_tacs": _get_attached_enodeb_tacs(mme_service_config),
         "enable_nat": _get_enable_nat(mme_service_config),
-        "federated_mode_map" : _get_federated_mode_map(mme_service_config)
+        "federated_mode_map" : _get_federated_mode_map(mme_service_config),
+        "restricted_plmns" : _get_restricted_plmns(mme_service_config)
     }
 
     context["s1u_ip"] = mme_service_config.ipv4_sgw_s1u_addr or \


### PR DESCRIPTION
## Summary

The PR bridges the gap for generating the list of restricted PLMNs in mme.conf from the gateway.mconfig.

## Test Plan

Added the following to gateway.mconfig (under the service key "mme"):

```
      "restrictedPlmns":[
        {"mcc":"123","mnc":"450"},
        {"mcc":"765","mnc":"281"},
        {"mcc":"112","mnc":"76"}]
```

Restarted the mme service via `sudo service magma@mme restart`. Observed the following field is added to mme.conf:
```
    RESTRICTED_PLMN_LIST = (
        # PlmnConfig values can be found at magma/lte/protos/mconfig/mconfigs.proto
        {
          MCC        = "123"
          MNC        = "450"
        },
        {
          MCC        = "765"
          MNC        = "281"
        },
        {
          MCC        = "112"
          MNC        = "76"
        }
    );
```

Run `test_attach_restricted_plmn.py` and confirm the attach reject.

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
