### PR TITLE
[feg] Add ability to use orc8r with S6a_cli

### DIFF
--- a/feg/gateway/services/s8_proxy/client_api.go
+++ b/feg/gateway/services/s8_proxy/client_api.go
@@ -17,11 +17,14 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 
 	"magma/feg/cloud/go/protos"
 	"magma/feg/gateway/registry"
+	"magma/orc8r/lib/go/util"
 
 	"github.com/golang/glog"
+	"google.golang.org/grpc"
 )
 
 type s8ProxyClient struct {
@@ -62,7 +65,15 @@ func SendEcho(req *protos.EchoRequest) (*protos.EchoResponse, error) {
 }
 
 func getS8ProxyClient() (*s8ProxyClient, error) {
-	conn, err := registry.GetConnection(registry.S8_PROXY)
+	var (
+		conn *grpc.ClientConn
+		err  error
+	)
+	if util.GetEnvBool("USE_REMOTE_S8_PROXY") {
+		conn, err = registry.Get().GetSharedCloudConnection(strings.ToLower(registry.S8_PROXY))
+	} else {
+		conn, err = registry.GetConnection(registry.S8_PROXY)
+	}
 	if err != nil {
 		errMsg := fmt.Sprintf("S8 Proxy client initialization error: %s", err)
 		glog.Error(errMsg)

--- a/feg/gateway/services/s8_proxy/servicers/s8_proxy.go
+++ b/feg/gateway/services/s8_proxy/servicers/s8_proxy.go
@@ -108,6 +108,12 @@ func (s *S8Proxy) CreateSession(ctx context.Context, req *protos.CreateSessionRe
 }
 
 func (s *S8Proxy) DeleteSession(ctx context.Context, req *protos.DeleteSessionRequestPgw) (*protos.DeleteSessionResponsePgw, error) {
+	err := validateDeleteSessionRequest(req)
+	if err != nil {
+		err = fmt.Errorf("Delete Session failed for IMSI %s:, couldn't validate request: %s", req.Imsi, err)
+		glog.Error(err)
+		return nil, err
+	}
 	cPgwUDPAddr, err := s.configOrRequestedPgwAddress(req.PgwAddrs)
 	if err != nil {
 		err = fmt.Errorf("Delete Session failed for IMSI %s: %s", req.Imsi, err)
@@ -155,6 +161,13 @@ func (s *S8Proxy) configOrRequestedPgwAddress(pgwAddrsFromRequest string) (*net.
 func validateCreateSessionRequest(csr *protos.CreateSessionRequestPgw) error {
 	if csr.BearerContext == nil || csr.BearerContext.UserPlaneFteid == nil || csr.BearerContext.Id == 0 {
 		return fmt.Errorf("CreateSessionRequest missing fields %+v", csr)
+	}
+	return nil
+}
+
+func validateDeleteSessionRequest(dsr *protos.DeleteSessionRequestPgw) error {
+	if dsr.CPgwFteid == nil || dsr.Imsi == "" {
+		return fmt.Errorf("DeleteSessionRequest missing fields %+v", dsr)
 	}
 	return nil
 }


### PR DESCRIPTION
Signed-off-by: Oriol Batalla <obatalla@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary

Add capability to run the client from AGW through orcr8r

## Test Plan

make precommit
used in terravm

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
