### PR TITLE
[lte][agw] Add S1 Handover preparation message types

### DIFF
--- a/lte/gateway/c/oai/include/mme_app_messages_def.h
+++ b/lte/gateway/c/oai/include/mme_app_messages_def.h
@@ -60,3 +60,9 @@ MESSAGE_DEF(
     MME_APP_DOWNLINK_DATA_CNF, itti_mme_app_dl_data_cnf_t, mme_app_dl_data_cnf)
 MESSAGE_DEF(
     MME_APP_DOWNLINK_DATA_REJ, itti_mme_app_dl_data_rej_t, mme_app_dl_data_rej)
+MESSAGE_DEF(
+    MME_APP_HANDOVER_REQUEST, itti_mme_app_handover_request_t,
+    mme_app_handover_request)
+MESSAGE_DEF(
+    MME_APP_HANDOVER_COMMAND, itti_mme_app_handover_command_t,
+    mme_app_handover_command)

--- a/lte/gateway/c/oai/include/mme_app_messages_types.h
+++ b/lte/gateway/c/oai/include/mme_app_messages_types.h
@@ -47,6 +47,9 @@
 #include "nas/as_message.h"
 #include "s1ap_messages_types.h"
 
+#include "S1ap_Source-ToTarget-TransparentContainer.h"
+#include "S1ap_HandoverType.h"
+
 #define MME_APP_CONNECTION_ESTABLISHMENT_CNF(mSGpTR)                           \
   (mSGpTR)->ittiMsg.mme_app_connection_establishment_cnf
 #define MME_APP_INITIAL_CONTEXT_SETUP_RSP(mSGpTR)                              \
@@ -58,6 +61,10 @@
 #define MME_APP_UL_DATA_IND(mSGpTR) (mSGpTR)->ittiMsg.mme_app_ul_data_ind
 #define MME_APP_DL_DATA_CNF(mSGpTR) (mSGpTR)->ittiMsg.mme_app_dl_data_cnf
 #define MME_APP_DL_DATA_REJ(mSGpTR) (mSGpTR)->ittiMsg.mme_app_dl_data_rej
+#define MME_APP_HANDOVER_REQUEST(mSGpTR)                                       \
+  (mSGpTR)->ittiMsg.mme_app_handover_request
+#define MME_APP_HANDOVER_COMMAND(mSGpTR)                                       \
+  (mSGpTR)->ittiMsg.mme_app_handover_command
 
 typedef struct itti_mme_app_connection_establishment_cnf_s {
   mme_ue_s1ap_id_t ue_id;
@@ -156,5 +163,28 @@ typedef struct itti_mme_app_ul_data_ind_s {
   /* Indicating the cell from which the UE has sent the NAS message  */
   ecgi_t cgi;
 } itti_mme_app_ul_data_ind_t;
+
+typedef struct itti_mme_app_handover_request_s {
+  uint32_t target_sctp_assoc_id;
+  uint32_t target_enb_id;
+  S1ap_Cause_t cause;
+  S1ap_HandoverType_t handover_type;
+  mme_ue_s1ap_id_t mme_ue_s1ap_id;
+  ambr_t ue_ambr;
+  e_rab_to_be_setup_list_ho_req_t e_rab_list;
+  bstring src_tgt_container;
+  uint16_t encryption_algorithm_capabilities;
+  uint16_t integrity_algorithm_capabilities;
+  uint8_t nh[AUTH_NEXT_HOP_SIZE]; /* Next Hop security key*/
+  uint8_t ncc;                    /* next hop chaining count */
+} itti_mme_app_handover_request_t;
+
+typedef struct itti_mme_app_handover_command_s {
+  uint32_t source_assoc_id;
+  mme_ue_s1ap_id_t mme_ue_s1ap_id;
+  enb_ue_s1ap_id_t src_enb_ue_s1ap_id;
+  S1ap_HandoverType_t handover_type;
+  bstring tgt_src_container;
+} itti_mme_app_handover_command_t;
 
 #endif /* FILE_MME_APP_MESSAGES_TYPES_SEEN */

--- a/lte/gateway/c/oai/include/s1ap_messages_def.h
+++ b/lte/gateway/c/oai/include/s1ap_messages_def.h
@@ -96,3 +96,9 @@ MESSAGE_DEF(
 MESSAGE_DEF(
     S1AP_REMOVE_STALE_UE_CONTEXT, itti_s1ap_remove_stale_ue_context_t,
     s1ap_remove_stale_ue_context)
+MESSAGE_DEF(
+    S1AP_HANDOVER_REQUIRED, itti_s1ap_handover_required_t,
+    s1ap_handover_required)
+MESSAGE_DEF(
+    S1AP_HANDOVER_REQUEST_ACK, itti_s1ap_handover_request_ack_t,
+    s1ap_handover_request_ack)

--- a/lte/gateway/c/oai/include/s1ap_messages_types.h
+++ b/lte/gateway/c/oai/include/s1ap_messages_types.h
@@ -45,6 +45,9 @@
 #include "TrackingAreaIdentity.h"
 #include "nas/securityDef.h"
 
+#include "S1ap_Source-ToTarget-TransparentContainer.h"
+#include "S1ap_HandoverType.h"
+
 #define S1AP_ENB_DEREGISTERED_IND(mSGpTR)                                      \
   (mSGpTR)->ittiMsg.s1ap_eNB_deregistered_ind
 #define S1AP_ENB_INITIATED_RESET_REQ(mSGpTR)                                   \
@@ -83,6 +86,9 @@
   (mSGpTR)->ittiMsg.s1ap_path_switch_request_failure
 #define S1AP_REMOVE_STALE_UE_CONTEXT(mSGpTR)                                   \
   (mSGpTR)->ittiMsg.s1ap_remove_stale_ue_context
+#define S1AP_HANDOVER_REQUIRED(mSGpTR) (mSGpTR)->ittiMsg.s1ap_handover_required
+#define S1AP_HANDOVER_REQUEST_ACK(mSGpTR)                                      \
+  (mSGpTR)->ittiMsg.s1ap_handover_request_ack
 
 // NOT a ITTI message
 typedef struct s1ap_initial_ue_message_s {
@@ -374,4 +380,23 @@ typedef struct itti_s1ap_e_rab_modification_cnf_s {
   // Optional
   e_rab_list_t e_rab_failed_to_modify_list;
 } itti_s1ap_e_rab_modification_cnf_t;
+
+typedef struct itti_s1ap_handover_required_s {
+  uint32_t sctp_assoc_id;
+  uint32_t enb_id;
+  S1ap_Cause_t cause;
+  S1ap_HandoverType_t handover_type;
+  mme_ue_s1ap_id_t mme_ue_s1ap_id;
+  bstring src_tgt_container;
+} itti_s1ap_handover_required_t;
+
+typedef struct itti_s1ap_handover_request_ack_s {
+  uint32_t source_assoc_id;
+  uint32_t target_assoc_id;
+  mme_ue_s1ap_id_t mme_ue_s1ap_id;
+  enb_ue_s1ap_id_t src_enb_ue_s1ap_id;
+  enb_ue_s1ap_id_t tgt_enb_ue_s1ap_id;
+  S1ap_HandoverType_t handover_type;
+  bstring tgt_src_container;
+} itti_s1ap_handover_request_ack_t;
 #endif /* FILE_S1AP_MESSAGES_TYPES_SEEN */

--- a/lte/gateway/c/oai/lib/3gpp/3gpp_36.413.h
+++ b/lte/gateway/c/oai/lib/3gpp/3gpp_36.413.h
@@ -140,6 +140,20 @@ typedef struct e_rab_to_be_switched_in_downlink_list_s {
   e_rab_switched_in_downlink_item_t item[MAX_NO_OF_E_RABS];
 } e_rab_to_be_switched_in_downlink_list_t;
 
+// 9.1.5.4 HANDOVER REQUEST
+typedef struct e_rab_to_be_setup_item_ho_req_s {
+  e_rab_id_t e_rab_id;
+  bstring transport_layer_address;
+  teid_t gtp_teid;
+  e_rab_level_qos_parameters_t e_rab_level_qos_parameters;
+  // TODO: Include optional data-forwarding-not-possible IE
+} e_rab_to_be_setup_item_ho_req_t;
+
+typedef struct e_rab_to_be_setup_list_ho_req_s {
+  uint16_t no_of_items;
+  e_rab_to_be_setup_item_ho_req_t item[MAX_NO_OF_E_RABS];
+} e_rab_to_be_setup_list_ho_req_t;
+
 // E-RAB TO BE MODIFIED ITEM BEARER MOD IND
 typedef struct e_rab_to_be_modified_bearer_mod_ind_s {
   e_rab_id_t e_rab_id;


### PR DESCRIPTION
## Summary

Adds message types for HandoverPreparation and HandoverResourceAllocation to MME. 

## Test Plan
 
Local testbed (2x Baicells eNBs + Pixel 3), build, CI