### PR TITLE
[LTE][integtests] run timeout in the foreground for it to receive CTRL+C

### DIFF
--- a/lte/gateway/python/integ_tests/Makefile
+++ b/lte/gateway/python/integ_tests/Makefile
@@ -24,7 +24,7 @@ $(PYTHON_BUILD)/setupinteg_env:
 RESULTS_DIR := /var/tmp/test_results
 define execute_test
 	echo "Running test: $(1)"
-	timeout -k 930s 900s sudo -E PATH=$(PATH) PYTHONPATH=$(PYTHONPATH):$(S1AP_TESTER_PYTHON_PATH) $(PYTHON_BUILD)/bin/nosetests --with-xunit --xunit-file=$(RESULTS_DIR)/$(basename $(notdir $(1))).xml -x -s $(1) || exit 1
+	timeout --foreground -k 930s 900s sudo -E PATH=$(PATH) PYTHONPATH=$(PYTHONPATH):$(S1AP_TESTER_PYTHON_PATH) $(PYTHON_BUILD)/bin/nosetests --with-xunit --xunit-file=$(RESULTS_DIR)/$(basename $(notdir $(1))).xml -x -s $(1) || exit 1
 	sleep 1
 endef
 


### PR DESCRIPTION
Signed-off-by: Tariq Al-Khasib <talkhasib@fb.com>

## Summary

We are currently unable to kill a running integtest using CTRL+C since timeout command places itself in its own process group. Thus not receiving the signal from the parent shell.

Run timeout in the foreground for it to receive the signal from the shell

## Test Plan
Run integtest and kill it using CTRL+C
