### PR TITLE
[subscriberdb][magmad] add print GRPC to other RPC servicers

### DIFF
--- a/lte/gateway/configs/magmad.yml
+++ b/lte/gateway/configs/magmad.yml
@@ -14,7 +14,7 @@
 
 # log_level is set in mconfig. it can be overridden here
 
-print_grpc_payload: false
+print_grpc_payload: False
 
 # List of services for magmad to control
 magma_services:

--- a/lte/gateway/configs/subscriberdb.yml
+++ b/lte/gateway/configs/subscriberdb.yml
@@ -14,7 +14,7 @@
 # log_level is set in mconfig. it can be overridden here
 
 # Append GRPC content to the log
-print_grpc_payload: false
+print_grpc_payload: False
 
 # Host address of the Diameter/S6A MME server
 host_address: 0.0.0.0 # Bind to all interfaces

--- a/lte/gateway/python/magma/subscriberdb/main.py
+++ b/lte/gateway/python/magma/subscriberdb/main.py
@@ -70,7 +70,9 @@ def main():
 
         if service.config['s6a_over_grpc']:
             logging.info('Running s6a over grpc')
-            s6a_proxy_servicer = S6aProxyRpcServicer(processor)
+            s6a_proxy_servicer = S6aProxyRpcServicer(
+                processor,
+                service.config.get('print_grpc_payload', False))
             s6a_proxy_servicer.add_to_server(service.rpc_server)
         else:
             logging.info('Running s6a over DIAMETER')

--- a/lte/gateway/python/magma/subscriberdb/rpc_servicer.py
+++ b/lte/gateway/python/magma/subscriberdb/rpc_servicer.py
@@ -46,10 +46,7 @@ class SubscriberDBRpcServicer(subscriberdb_pb2_grpc.SubscriberDBServicer):
         """
         Adds a subscriber to the store
         """
-        try:
-            self._print_grpc(request)
-        except Exception as e:  # pylint: disable=broad-except
-            logging.debug("Exception while trying to log GRPC: %s", e)
+        self._print_grpc(request)
         sid = SIDUtils.to_str(request.sid)
         logging.debug("Add subscriber rpc for sid: %s", sid)
         try:
@@ -63,10 +60,7 @@ class SubscriberDBRpcServicer(subscriberdb_pb2_grpc.SubscriberDBServicer):
         """
         Deletes a subscriber from the store
         """
-        try:
-            self._print_grpc(request)
-        except Exception as e:  # pylint: disable=broad-except
-            logging.debug("Exception while trying to log GRPC: %s", e)
+        self._print_grpc(request)
         sid = SIDUtils.to_str(request)
         logging.debug("Delete subscriber rpc for sid: %s", sid)
         self._store.delete_subscriber(sid)
@@ -94,10 +88,7 @@ class SubscriberDBRpcServicer(subscriberdb_pb2_grpc.SubscriberDBServicer):
         """
         Returns the subscription data for the subscriber
         """
-        try:
-            self._print_grpc(request)
-        except Exception as e:  # pylint: disable=broad-except
-            logging.debug("Exception while trying to log GRPC: %s", e)
+        self._print_grpc(request)
         sid = SIDUtils.to_str(request)
         try:
             return self._store.get_subscriber_data(sid)
@@ -110,22 +101,22 @@ class SubscriberDBRpcServicer(subscriberdb_pb2_grpc.SubscriberDBServicer):
         """
         Returns a list of subscribers from the store
         """
-        try:
-            self._print_grpc(request)
-        except Exception as e:  # pylint: disable=broad-except
-            logging.debug("Exception while trying to log GRPC: %s", e)
+        self._print_grpc(request)
         sids = self._store.list_subscribers()
         sid_msgs = [SIDUtils.to_pb(sid) for sid in sids]
         return subscriberdb_pb2.SubscriberIDSet(sids=sid_msgs)
 
     def _print_grpc(self, message):
         if self._print_grpc_payload:
-            log_msg = "{} {}".format(message.DESCRIPTOR.full_name,
+            try:
+                log_msg = "{} {}".format(message.DESCRIPTOR.full_name,
                                      MessageToJson(message))
-            # add indentation
-            padding = 2 * ' '
-            log_msg =''.join( "{}{}".format(padding, line)
+                # add indentation
+                padding = 2 * ' '
+                log_msg =''.join( "{}{}".format(padding, line)
                               for line in log_msg.splitlines(True))
 
-            log_msg = "GRPC message:\n{}".format(log_msg)
-            logging.info(log_msg)
+                log_msg = "GRPC message:\n{}".format(log_msg)
+                logging.info(log_msg)
+            except Exception as e:  # pylint: disable=broad-except
+                logging.debug("Exception while trying to log GRPC: %s", e)

--- a/orc8r/gateway/python/magma/magmad/main.py
+++ b/orc8r/gateway/python/magma/magmad/main.py
@@ -116,7 +116,9 @@ def main():
     # Create sync rpc client with a heartbeat of 30 seconds (timeout = 60s)
     sync_rpc_client = None
     if service.config.get('enable_sync_rpc', False):
-        sync_rpc_client = SyncRPCClient(service.loop, 30)
+        sync_rpc_client = SyncRPCClient(
+            service.loop, 30,
+            service.config.get('print_grpc_payload', False))
 
     first_time_bootstrap = True
 


### PR DESCRIPTION
Signed-off-by: Oriol Batalla <obatalla@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary

Added some more GRPC printing messages from magmad `rpc_sync_grpc` and from `s6a_proxy_servicer.py` on subscriberdb


## Test Plan

fab integ_test

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
