### PR TITLE
[SessionD] Lightly refactor the final action rule deactivation logic

### DIFF
--- a/lte/gateway/c/session_manager/LocalEnforcer.h
+++ b/lte/gateway/c/session_manager/LocalEnforcer.h
@@ -587,14 +587,6 @@ class LocalEnforcer {
       SessionUpdate& session_update);
 
   /**
-   * Remove final action flows through pipelined
-   */
-  void cancel_final_unit_action(
-      const std::unique_ptr<SessionState>& session,
-      std::vector<PolicyRule> gy_rules_to_deactivate,
-      SessionStateUpdateCriteria& uc);
-
-  /**
    * Create redirection rule
    */
   PolicyRule create_redirect_rule(const std::unique_ptr<ServiceAction>& action);

--- a/lte/gateway/c/session_manager/SessionState.cpp
+++ b/lte/gateway/c/session_manager/SessionState.cpp
@@ -2029,29 +2029,41 @@ void SessionState::set_revalidation_time(
   update_criteria.revalidation_time = time;
 }
 
-bool SessionState::is_credit_in_final_unit_state(
+optional<FinalActionInfo> SessionState::get_final_action_if_final_unit_state(
     const CreditKey& charging_key) const {
   auto it = credit_map_.find(charging_key);
   if (it == credit_map_.end()) {
-    return false;
+    return {};
   }
-  return (
-      it->second->service_state == SERVICE_REDIRECTED ||
-      it->second->service_state == SERVICE_RESTRICTED);
+  if (it->second->service_state != SERVICE_REDIRECTED &&
+      it->second->service_state != SERVICE_RESTRICTED) {
+    return {};
+  }
+  return it->second->final_action_info;
 }
 
-std::vector<PolicyRule> SessionState::get_final_action_restrict_rules(
-    const CreditKey& charging_key) const {
+std::vector<PolicyRule> SessionState::remove_all_final_action_rules(
+    const FinalActionInfo& final_action_info,
+    SessionStateUpdateCriteria& session_uc) {
   std::vector<PolicyRule> rules;
-  auto it = credit_map_.find(charging_key);
-  if (it == credit_map_.end()) {
-    return rules;
-  }
-  for (std::string rule_id : it->second->final_action_info.restrict_rules) {
-    PolicyRule rule;
-    if (static_rules_.get_rule(rule_id, &rule)) {
-      rules.push_back(rule);
-    }
+  switch (final_action_info.final_action) {
+    case ChargingCredit_FinalAction_REDIRECT: {
+      PolicyRule rule;
+      if (remove_gy_dynamic_rule("redirect", &rule, session_uc)) {
+        rules.push_back(rule);
+      }
+    } break;
+    case ChargingCredit_FinalAction_RESTRICT_ACCESS:
+      for (std::string rule_id : final_action_info.restrict_rules) {
+        PolicyRule rule;
+        if (static_rules_.get_rule(rule_id, &rule)) {
+          rules.push_back(rule);
+          deactivate_static_rule(rule_id, session_uc);
+        }
+      }
+      break;
+    default:
+      break;
   }
   return rules;
 }

--- a/lte/gateway/c/session_manager/SessionState.h
+++ b/lte/gateway/c/session_manager/SessionState.h
@@ -473,10 +473,12 @@ class SessionState {
 
   EventTriggerStatus get_event_triggers() { return pending_event_triggers_; }
 
-  bool is_credit_in_final_unit_state(const CreditKey& charging_key) const;
+  optional<FinalActionInfo> get_final_action_if_final_unit_state(
+      const CreditKey& ckey) const;
 
-  std::vector<PolicyRule> get_final_action_restrict_rules(
-      const CreditKey& charging_key) const;
+  std::vector<PolicyRule> remove_all_final_action_rules(
+      const FinalActionInfo& final_action_info,
+      SessionStateUpdateCriteria& session_uc);
 
   // Monitors
   bool receive_monitor(

--- a/lte/gateway/c/session_manager/test/test_local_enforcer.cpp
+++ b/lte/gateway/c/session_manager/test/test_local_enforcer.cpp
@@ -154,8 +154,13 @@ class LocalEnforcerTest : public ::testing::Test {
     EXPECT_TRUE(session_map.find(imsi) != session_map.end());
     for (const auto& session : session_map.find(imsi)->second) {
       if (session->get_session_id() == session_id) {
-        EXPECT_EQ(
-            session->is_credit_in_final_unit_state(charging_key), is_final);
+        optional<FinalActionInfo> fai =
+            session->get_final_action_if_final_unit_state(charging_key);
+        if (is_final) {
+          EXPECT_TRUE(fai);
+        } else {
+          EXPECT_FALSE(fai);
+        }
       }
     }
   }


### PR DESCRIPTION
Signed-off-by: Marie Bremner <marwhal@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary
I have a stack of PRs to add policy version generation to SessionD. For this SessionD will need to generate policy versions and propagate the value to PipelineD. (See https://github.com/magma/magma/pull/5699)

Since this change touches a lot of code, I'm trying to break it off into independent chunks so here is one. :) 
It is useful for the upcoming PRs to consolidate the logic of collecting policies to be removed. 
<!-- Enumerate changes you made and why you made them -->

## Test Plan
run unit tests / integ tests 
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
