### PR TITLE
[SessionD] Refactor PipelineDClient to take in RulesToProcess struct into requests

### DIFF
--- a/lte/gateway/c/session_manager/LocalEnforcer.h
+++ b/lte/gateway/c/session_manager/LocalEnforcer.h
@@ -481,9 +481,7 @@ class LocalEnforcer {
 
   void handle_activate_ue_flows_callback(
       const std::string& imsi, const std::string& ip_addr,
-      const std::string& ipv6_addr, const Teids teids,
-      const std::string& msisdn, optional<AggregatedMaximumBitrate> ambr,
-      const std::vector<PolicyRule>& dynamic_rules, Status status,
+      const std::string& ipv6_addr, const Teids teids, Status status,
       ActivateFlowsResult resp);
 
   /**

--- a/lte/gateway/c/session_manager/PipelinedClient.cpp
+++ b/lte/gateway/c/session_manager/PipelinedClient.cpp
@@ -305,13 +305,13 @@ void AsyncPipelinedClient::activate_flows_for_rules(
     const std::string& imsi, const std::string& ip_addr,
     const std::string& ipv6_addr, const Teids teids, const std::string& msisdn,
     const optional<AggregatedMaximumBitrate>& ambr,
-    const std::vector<PolicyRule>& rules,
+    const RulesToProcess to_process,
     std::function<void(Status status, ActivateFlowsResult)> callback) {
-  MLOG(MDEBUG) << "Activating " << rules.size() << " rules for " << imsi
-               << " msisdn " << msisdn << " and ip " << ip_addr << " "
+  MLOG(MDEBUG) << "Activating " << to_process.rules.size() << " rules for "
+               << imsi << " msisdn " << msisdn << " and ip " << ip_addr << " "
                << ipv6_addr;
   auto req = create_activate_req(
-      imsi, ip_addr, ipv6_addr, teids, msisdn, ambr, rules,
+      imsi, ip_addr, ipv6_addr, teids, msisdn, ambr, to_process.rules,
       RequestOriginType::GX);
   activate_flows_rpc(req, callback);
 }

--- a/lte/gateway/c/session_manager/PipelinedClient.cpp
+++ b/lte/gateway/c/session_manager/PipelinedClient.cpp
@@ -51,7 +51,7 @@ magma::SessionSet create_session_set_req(
 magma::DeactivateFlowsRequest create_deactivate_req(
     const std::string& imsi, const std::string& ip_addr,
     const std::string& ipv6_addr, const magma::Teids teids,
-    const std::vector<magma::PolicyRule>& rules,
+    const magma::RulesToProcess& to_process,
     const magma::RequestOriginType_OriginType origin_type,
     const bool remove_default_drop_rules) {
   magma::DeactivateFlowsRequest req;
@@ -63,7 +63,7 @@ magma::DeactivateFlowsRequest create_deactivate_req(
   req.set_remove_default_drop_flows(remove_default_drop_rules);
   req.mutable_request_origin()->set_type(origin_type);
   auto ids = req.mutable_rule_ids();
-  for (const auto& rule : rules) {
+  for (const auto& rule : to_process.rules) {
     ids->Add()->assign(rule.id());
   }
   return req;
@@ -74,7 +74,7 @@ magma::ActivateFlowsRequest create_activate_req(
     const std::string& ipv6_addr, const magma::Teids teids,
     const std::string& msisdn,
     const optional<magma::AggregatedMaximumBitrate>& ambr,
-    const std::vector<magma::PolicyRule>& dynamic_rules,
+    const magma::RulesToProcess& to_process,
     const magma::RequestOriginType_OriginType origin_type) {
   magma::ActivateFlowsRequest req;
   req.mutable_sid()->set_id(imsi);
@@ -88,7 +88,7 @@ magma::ActivateFlowsRequest create_activate_req(
     req.mutable_apn_ambr()->CopyFrom(*ambr);
   }
   auto mut_dyn_rules = req.mutable_dynamic_rules();
-  for (const auto& dyn_rule : dynamic_rules) {
+  for (const auto& dyn_rule : to_process.rules) {
     mut_dyn_rules->Add()->CopyFrom(dyn_rule);
   }
   return req;
@@ -130,18 +130,9 @@ magma::SetupPolicyRequest create_setup_policy_req(
   std::vector<magma::ActivateFlowsRequest> activation_reqs;
 
   for (auto it = infos.begin(); it != infos.end(); it++) {
-    std::vector<magma::lte::PolicyRule> gx_rules = {};
-    // combine gx_static_rules and gy_dynamic_rules
-    for (magma::PolicyRule rule : it->gx_static_rules) {
-      gx_rules.push_back(rule);
-    }
-    for (magma::lte::PolicyRule rule : it->gx_dynamic_rules) {
-      gx_rules.push_back(rule);
-    }
-
     auto gx_activate_req = create_activate_req(
         it->imsi, it->ip_addr, it->ipv6_addr, it->teids, it->msisdn, it->ambr,
-        gx_rules, magma::RequestOriginType::GX);
+        it->gx_rules, magma::RequestOriginType::GX);
     activation_reqs.push_back(gx_activate_req);
     if (!it->gy_dynamic_rules.empty()) {
       auto gy_activate_req = create_activate_req(
@@ -259,8 +250,10 @@ void AsyncPipelinedClient::deactivate_flows_for_rules_for_termination(
          "for subscriber "
       << imsi << " IP " << ip_addr << " " << ipv6_addr;
 
-  auto req = create_deactivate_req(
-      imsi, ip_addr, ipv6_addr, teids, {}, origin_type, true);
+  RulesToProcess empty_to_process;
+  empty_to_process.rules = std::vector<PolicyRule>{};
+  auto req               = create_deactivate_req(
+      imsi, ip_addr, ipv6_addr, teids, empty_to_process, origin_type, true);
   deactivate_flows(req);
 }
 
@@ -274,7 +267,7 @@ void AsyncPipelinedClient::deactivate_flows_for_rules(
                << " " << ipv6_addr;
 
   auto req = create_deactivate_req(
-      imsi, ip_addr, ipv6_addr, teids, to_process.rules, origin_type, false);
+      imsi, ip_addr, ipv6_addr, teids, to_process, origin_type, false);
   deactivate_flows(req);
 }
 
@@ -299,7 +292,7 @@ void AsyncPipelinedClient::activate_flows_for_rules(
                << imsi << " msisdn " << msisdn << " and ip " << ip_addr << " "
                << ipv6_addr;
   auto req = create_activate_req(
-      imsi, ip_addr, ipv6_addr, teids, msisdn, ambr, to_process.rules,
+      imsi, ip_addr, ipv6_addr, teids, msisdn, ambr, to_process,
       RequestOriginType::GX);
   activate_flows_rpc(req, callback);
 }
@@ -355,7 +348,7 @@ void AsyncPipelinedClient::add_gy_final_action_flow(
     const RulesToProcess to_process) {
   MLOG(MDEBUG) << "Activating GY final action for subscriber " << imsi;
   auto req = create_activate_req(
-      imsi, ip_addr, ipv6_addr, teids, msisdn, {}, to_process.rules,
+      imsi, ip_addr, ipv6_addr, teids, msisdn, {}, to_process,
       RequestOriginType::GY);
   activate_flows_rpc(req, [imsi](Status status, ActivateFlowsResult resp) {
     if (!status.ok()) {

--- a/lte/gateway/c/session_manager/PipelinedClient.h
+++ b/lte/gateway/c/session_manager/PipelinedClient.h
@@ -98,7 +98,7 @@ class PipelinedClient {
       const std::string& imsi, const std::string& ip_addr,
       const std::string& ipv6_addr, const Teids teids,
       const std::string& msisdn, const optional<AggregatedMaximumBitrate>& ambr,
-      const std::vector<PolicyRule>& rules,
+      const RulesToProcess to_process,
       std::function<void(Status status, ActivateFlowsResult)> callback) = 0;
 
   /**
@@ -227,7 +227,7 @@ class AsyncPipelinedClient : public GRPCReceiver, public PipelinedClient {
       const std::string& imsi, const std::string& ip_addr,
       const std::string& ipv6_addr, const Teids teids,
       const std::string& msisdn, const optional<AggregatedMaximumBitrate>& ambr,
-      const std::vector<PolicyRule>& rules,
+      const RulesToProcess to_process,
       std::function<void(Status status, ActivateFlowsResult)> callback);
 
   /**

--- a/lte/gateway/c/session_manager/PipelinedClient.h
+++ b/lte/gateway/c/session_manager/PipelinedClient.h
@@ -64,12 +64,6 @@ class PipelinedClient {
       std::function<void(Status status, SetupFlowsResult)> callback) = 0;
 
   /**
-   * Deactivate all flows for a subscriber's session
-   * @param imsi - UE to delete all policy flows for
-   */
-  virtual void deactivate_all_flows(const std::string& imsi) = 0;
-
-  /**
    * Deactivate all flows for the specified rules plus any drop default rule
    * added by pipelined
    * @param imsi - UE to delete flows for
@@ -88,7 +82,7 @@ class PipelinedClient {
   virtual void deactivate_flows_for_rules(
       const std::string& imsi, const std::string& ip_addr,
       const std::string& ipv6_addr, const Teids teids,
-      const std::vector<PolicyRule>& dynamic_rules,
+      const RulesToProcess to_process,
       const RequestOriginType_OriginType origin_type) = 0;
 
   /**
@@ -138,7 +132,7 @@ class PipelinedClient {
   virtual void add_gy_final_action_flow(
       const std::string& imsi, const std::string& ip_addr,
       const std::string& ipv6_addr, const Teids teids,
-      const std::string& msisdn, const std::vector<PolicyRule>& rules) = 0;
+      const std::string& msisdn, const RulesToProcess to_process) = 0;
 
   /**
    * Set up a Session of type SetMessage to be sent to UPF
@@ -187,12 +181,6 @@ class AsyncPipelinedClient : public GRPCReceiver, public PipelinedClient {
       std::function<void(Status status, SetupFlowsResult)> callback);
 
   /**
-   * Deactivate all flows for a subscriber's session
-   * @param imsi - UE to delete all policy flows for
-   */
-  void deactivate_all_flows(const std::string& imsi);
-
-  /**
    * Deactivate all flows related to a specific charging key plus any default
    * rule installed by pipelined. Used for session termination.
    * @param imsi - UE to delete flows for
@@ -211,7 +199,7 @@ class AsyncPipelinedClient : public GRPCReceiver, public PipelinedClient {
   void deactivate_flows_for_rules(
       const std::string& imsi, const std::string& ip_addr,
       const std::string& ipv6_addr, const Teids teids,
-      const std::vector<PolicyRule>& dynamic_rules,
+      const RulesToProcess to_process,
       const RequestOriginType_OriginType origin_type);
 
   /**
@@ -260,7 +248,7 @@ class AsyncPipelinedClient : public GRPCReceiver, public PipelinedClient {
   void add_gy_final_action_flow(
       const std::string& imsi, const std::string& ip_addr,
       const std::string& ipv6_addr, const Teids teids,
-      const std::string& msisdn, const std::vector<PolicyRule>& rules);
+      const std::string& msisdn, const RulesToProcess to_process);
 
   void set_upf_session(
       const SessionState::SessionInfo info,

--- a/lte/gateway/c/session_manager/SessionState.cpp
+++ b/lte/gateway/c/session_manager/SessionState.cpp
@@ -870,14 +870,13 @@ void SessionState::get_session_info(SessionState::SessionInfo& info) {
   info.msisdn    = config_.common_context.msisdn();
   info.ambr      = config_.get_apn_ambr();
 
-  dynamic_rules_.get_rules(info.gx_dynamic_rules);
-  gy_dynamic_rules_.get_rules(info.gy_dynamic_rules);
-  info.static_rules = active_static_rules_;
+  dynamic_rules_.get_rules(info.gx_rules.rules);
+  gy_dynamic_rules_.get_rules(info.gy_dynamic_rules.rules);
 
   for (const std::string& rule_id : active_static_rules_) {
     PolicyRule rule;
     if (static_rules_.get_rule(rule_id, &rule)) {
-      info.gx_static_rules.push_back(rule);
+      info.gx_rules.rules.push_back(rule);
     }
   }
 }

--- a/lte/gateway/c/session_manager/SessionState.cpp
+++ b/lte/gateway/c/session_manager/SessionState.cpp
@@ -2042,22 +2042,23 @@ optional<FinalActionInfo> SessionState::get_final_action_if_final_unit_state(
   return it->second->final_action_info;
 }
 
-std::vector<PolicyRule> SessionState::remove_all_final_action_rules(
+RulesToProcess SessionState::remove_all_final_action_rules(
     const FinalActionInfo& final_action_info,
     SessionStateUpdateCriteria& session_uc) {
-  std::vector<PolicyRule> rules;
+  RulesToProcess to_process;
+  to_process.rules = std::vector<PolicyRule>{};
   switch (final_action_info.final_action) {
     case ChargingCredit_FinalAction_REDIRECT: {
       PolicyRule rule;
       if (remove_gy_dynamic_rule("redirect", &rule, session_uc)) {
-        rules.push_back(rule);
+        to_process.rules.push_back(rule);
       }
     } break;
     case ChargingCredit_FinalAction_RESTRICT_ACCESS:
       for (std::string rule_id : final_action_info.restrict_rules) {
         PolicyRule rule;
         if (static_rules_.get_rule(rule_id, &rule)) {
-          rules.push_back(rule);
+          to_process.rules.push_back(rule);
           deactivate_static_rule(rule_id, session_uc);
         }
       }
@@ -2065,7 +2066,7 @@ std::vector<PolicyRule> SessionState::remove_all_final_action_rules(
     default:
       break;
   }
-  return rules;
+  return to_process;
 }
 
 // QoS/Bearer Management

--- a/lte/gateway/c/session_manager/SessionState.h
+++ b/lte/gateway/c/session_manager/SessionState.h
@@ -87,6 +87,8 @@ struct BearerUpdate {
  */
 class SessionState {
  public:
+  // SessionInfo is a struct used to bundle necessary information
+  // PipelineDClient needs to make requests
   struct SessionInfo {
     enum upfNodeType {
       IPv4 = 0,
@@ -110,11 +112,8 @@ class SessionState {
 
     uint32_t local_f_teid;
     std::string msisdn;
-    // TODO deprecate std::vector<std::string> static_rules
-    std::vector<std::string> static_rules;
-    std::vector<PolicyRule> gx_static_rules;
-    std::vector<PolicyRule> gx_dynamic_rules;
-    std::vector<PolicyRule> gy_dynamic_rules;
+    RulesToProcess gx_rules;
+    RulesToProcess gy_dynamic_rules;
     optional<AggregatedMaximumBitrate> ambr;
     // 5G specific extensions
     std::vector<SetGroupPDR> Pdr_rules_;

--- a/lte/gateway/c/session_manager/SessionState.h
+++ b/lte/gateway/c/session_manager/SessionState.h
@@ -476,7 +476,7 @@ class SessionState {
   optional<FinalActionInfo> get_final_action_if_final_unit_state(
       const CreditKey& ckey) const;
 
-  std::vector<PolicyRule> remove_all_final_action_rules(
+  RulesToProcess remove_all_final_action_rules(
       const FinalActionInfo& final_action_info,
       SessionStateUpdateCriteria& session_uc);
 

--- a/lte/gateway/c/session_manager/test/Matchers.h
+++ b/lte/gateway/c/session_manager/test/Matchers.h
@@ -162,7 +162,7 @@ MATCHER_P3(CheckDeleteOneBearerReq, imsi, link_bearer_id, eps_bearer_id, "") {
 }
 
 MATCHER_P(CheckSubset, ids, "") {
-  auto request = static_cast<const std::vector<PolicyRule>>(arg);
+  auto request = static_cast<const std::vector<PolicyRule>>(arg.rules);
   for (size_t i = 0; i < request.size(); i++) {
     if (ids.find(request[i].id()) != ids.end()) {
       return true;
@@ -172,7 +172,7 @@ MATCHER_P(CheckSubset, ids, "") {
 }
 
 MATCHER_P(CheckPolicyID, id, "") {
-  auto request = static_cast<const std::vector<PolicyRule>>(arg);
+  auto request = static_cast<const std::vector<PolicyRule>>(arg.rules);
   for (size_t i = 0; i < request.size(); i++) {
     if (request[i].id() == id) {
       return true;
@@ -182,7 +182,7 @@ MATCHER_P(CheckPolicyID, id, "") {
 }
 
 MATCHER_P2(CheckPolicyIDs, count, ids, "") {
-  auto request = static_cast<const std::vector<PolicyRule>>(arg);
+  auto request = static_cast<const std::vector<PolicyRule>>(arg.rules);
   if (request.size() != (unsigned int) count) {
     return false;
   }

--- a/lte/gateway/c/session_manager/test/Matchers.h
+++ b/lte/gateway/c/session_manager/test/Matchers.h
@@ -31,8 +31,14 @@ MATCHER_P(CheckCount, count, "") {
   return arg_count == count;
 }
 
+MATCHER_P(CheckRuleCount, count, "") {
+  int arg_count = arg.rules.size();
+  return arg_count == count;
+}
+
 MATCHER_P(CheckRuleNames, list_static_rules, "") {
-  std::vector<PolicyRule> rules = arg;
+  RulesToProcess to_process     = arg;
+  std::vector<PolicyRule> rules = to_process.rules;
   if (rules.size() != list_static_rules.size()) {
     return false;
   }

--- a/lte/gateway/c/session_manager/test/SessiondMocks.h
+++ b/lte/gateway/c/session_manager/test/SessiondMocks.h
@@ -102,13 +102,12 @@ class MockPipelinedClient : public PipelinedClient {
           const std::vector<SessionState::SessionInfo>& infos,
           const std::uint64_t& epoch,
           std::function<void(Status status, SetupFlowsResult)> callback));
-  MOCK_METHOD1(deactivate_all_flows, void(const std::string& imsi));
   MOCK_METHOD6(
       deactivate_flows_for_rules,
       void(
           const std::string& imsi, const std::string& ip_addr,
           const std::string& ipv6_addr, const Teids teids,
-          const std::vector<PolicyRule>& dynamic_rules,
+          const RulesToProcess to_process,
           const RequestOriginType_OriginType origin_type));
   MOCK_METHOD5(
       deactivate_flows_for_rules_for_termination,
@@ -149,7 +148,7 @@ class MockPipelinedClient : public PipelinedClient {
       void(
           const std::string& imsi, const std::string& ip_addr,
           const std::string& ipv6_addr, const Teids teids,
-          const std::string& msisdn, const std::vector<PolicyRule>& rules));
+          const std::string& msisdn, const RulesToProcess to_process));
   MOCK_METHOD2(
       set_upf_session,
       void(

--- a/lte/gateway/c/session_manager/test/SessiondMocks.h
+++ b/lte/gateway/c/session_manager/test/SessiondMocks.h
@@ -123,7 +123,7 @@ class MockPipelinedClient : public PipelinedClient {
           const std::string& ipv6_addr, const Teids teids,
           const std::string& msisdn,
           const std::experimental::optional<AggregatedMaximumBitrate>& ambr,
-          const std::vector<PolicyRule>& dynamic_rules,
+          const RulesToProcess to_process,
           std::function<void(Status status, ActivateFlowsResult)> callback));
   MOCK_METHOD6(
       add_ue_mac_flow,

--- a/lte/gateway/c/session_manager/test/test_local_enforcer.cpp
+++ b/lte/gateway/c/session_manager/test/test_local_enforcer.cpp
@@ -194,7 +194,7 @@ TEST_F(LocalEnforcerTest, test_init_cwf_session_credit) {
       *pipelined_client, activate_flows_for_rules(
                              IMSI1, testing::_, testing::_, testing::_,
                              test_cwf_cfg.common_context.msisdn(), testing::_,
-                             CheckCount(0), testing::_))
+                             CheckRuleCount(0), testing::_))
       .Times(1);
 
   EXPECT_CALL(
@@ -232,7 +232,7 @@ TEST_F(LocalEnforcerTest, test_init_infinite_metered_credit) {
       *pipelined_client, activate_flows_for_rules(
                              IMSI1, IP1, IPv6_1, CheckTeids(teids1),
                              test_cfg_.common_context.msisdn(), testing::_,
-                             CheckCount(1), testing::_))
+                             CheckRuleCount(1), testing::_))
       .Times(1);
   local_enforcer->init_session(
       session_map, IMSI1, SESSION_ID_1, test_cfg_, response);
@@ -263,7 +263,7 @@ TEST_F(LocalEnforcerTest, test_init_no_credit) {
       activate_flows_for_rules(
           IMSI1, test_cfg_.common_context.ue_ipv4(),
           test_cfg_.common_context.ue_ipv6(), CheckTeids(teids1),
-          test_cfg_.common_context.msisdn(), testing::_, CheckCount(1),
+          test_cfg_.common_context.msisdn(), testing::_, CheckRuleCount(1),
           testing::_))
       .Times(1);
   local_enforcer->init_session(
@@ -1387,7 +1387,7 @@ TEST_F(LocalEnforcerTest, test_dynamic_rule_actions) {
       *pipelined_client, activate_flows_for_rules(
                              testing::_, testing::_, testing::_, testing::_,
                              test_cfg_.common_context.msisdn(), testing::_,
-                             CheckCount(3), testing::_))
+                             CheckRuleCount(3), testing::_))
       .Times(1);
 
   local_enforcer->init_session(
@@ -1476,7 +1476,7 @@ TEST_F(LocalEnforcerTest, test_installing_rules_with_activation_time) {
       *pipelined_client, activate_flows_for_rules(
                              IMSI1, ip_addr, ipv6_addr, CheckTeids(teids),
                              test_cfg_.common_context.msisdn(), testing::_,
-                             CheckCount(4), testing::_))
+                             CheckRuleCount(4), testing::_))
       .Times(1);
 
   // We do not expect rule5 and rule2 to be activated since they are scheduled a
@@ -1644,7 +1644,7 @@ TEST_F(LocalEnforcerTest, test_usage_monitors) {
       *pipelined_client, activate_flows_for_rules(
                              IMSI1, testing::_, testing::_, testing::_,
                              test_cfg_.common_context.msisdn(), testing::_,
-                             CheckCount(1), testing::_))
+                             CheckRuleCount(1), testing::_))
       .Times(1);
   local_enforcer->update_session_credits_and_rules(
       session_map, update_response, update);
@@ -2141,7 +2141,7 @@ TEST_F(LocalEnforcerTest, test_set_session_rules) {
       *pipelined_client,
       activate_flows_for_rules(
           IMSI1, IP1, testing::_, CheckTeids(config1.common_context.teids()),
-          config1.common_context.msisdn(), testing::_, CheckCount(2),
+          config1.common_context.msisdn(), testing::_, CheckRuleCount(2),
           testing::_))
       .Times(1);
   // PipelineD expectations for Session2
@@ -2149,7 +2149,7 @@ TEST_F(LocalEnforcerTest, test_set_session_rules) {
       *pipelined_client,
       activate_flows_for_rules(
           IMSI1, IP2, testing::_, CheckTeids(config2.common_context.teids()),
-          config2.common_context.msisdn(), testing::_, CheckCount(1),
+          config2.common_context.msisdn(), testing::_, CheckRuleCount(1),
           testing::_))
       .Times(1);
   // For both Session1 + Session2
@@ -2651,7 +2651,7 @@ TEST_F(LocalEnforcerTest, test_final_unit_redirect_activation_and_termination) {
       *pipelined_client, activate_flows_for_rules(
                              IMSI1, ip_addr, ipv6_addr, CheckTeids(teids),
                              test_cfg_.common_context.msisdn(), testing::_,
-                             CheckCount(1), testing::_))
+                             CheckRuleCount(1), testing::_))
       .Times(1);
   local_enforcer->init_session(
       session_map, IMSI1, SESSION_ID_1, test_cfg_, response);
@@ -2729,7 +2729,7 @@ TEST_F(LocalEnforcerTest, test_final_unit_activation_and_canceling) {
   EXPECT_CALL(
       *pipelined_client, activate_flows_for_rules(
                              IMSI1, ip_addr, ipv6_addr, CheckTeids(teids),
-                             msisdn, testing::_, CheckCount(3), testing::_))
+                             msisdn, testing::_, CheckRuleCount(3), testing::_))
       .Times(1);
 
   local_enforcer->init_session(
@@ -2830,7 +2830,7 @@ TEST_F(LocalEnforcerTest, test_final_unit_action_no_update) {
   EXPECT_CALL(
       *pipelined_client, activate_flows_for_rules(
                              IMSI1, ip_addr, ipv6_addr, CheckTeids(teids),
-                             msisdn, testing::_, CheckCount(1), testing::_))
+                             msisdn, testing::_, CheckRuleCount(1), testing::_))
       .Times(1);
 
   local_enforcer->init_session(
@@ -2900,7 +2900,7 @@ TEST_F(LocalEnforcerTest, test_rar_dynamic_rule_modification) {
       *pipelined_client, activate_flows_for_rules(
                              IMSI1, testing::_, testing::_, testing::_,
                              test_cfg_.common_context.msisdn(), testing::_,
-                             CheckCount(1), testing::_))
+                             CheckRuleCount(1), testing::_))
       .Times(1);
 
   local_enforcer->init_session(
@@ -2937,7 +2937,7 @@ TEST_F(LocalEnforcerTest, test_rar_dynamic_rule_modification) {
         *pipelined_client, activate_flows_for_rules(
                                IMSI1, testing::_, testing::_, testing::_,
                                test_cfg_.common_context.msisdn(), testing::_,
-                               CheckCount(1), testing::_))
+                               CheckRuleCount(1), testing::_))
         .Times(1);
   }
   local_enforcer->init_policy_reauth(session_map, rar, raa, session_ucs);

--- a/lte/gateway/c/session_manager/test/test_local_enforcer.cpp
+++ b/lte/gateway/c/session_manager/test/test_local_enforcer.cpp
@@ -2458,12 +2458,11 @@ TEST_F(LocalEnforcerTest, test_pipelined_cwf_setup) {
   local_enforcer->update_tunnel_ids(
       session_map, create_update_tunnel_ids_request(IMSI2, 0, teids0));
 
-  std::vector<std::string> imsi_list                      = {IMSI2, IMSI1};
-  std::vector<std::string> ip_address_list                = {IP1, IP1};
-  std::vector<std::string> ipv6_address_list              = {"", ""};
-  std::vector<std::vector<std::string>> static_rule_list  = {{}, {"rule2"}};
-  std::vector<std::vector<std::string>> dynamic_rule_list = {{"rule22"},
-                                                             {"rule1"}};
+  std::vector<std::string> imsi_list              = {IMSI2, IMSI1};
+  std::vector<std::string> ip_address_list        = {IP1, IP1};
+  std::vector<std::string> ipv6_address_list      = {"", ""};
+  std::vector<std::vector<std::string>> rule_list = {{"rule22"},
+                                                     {"rule1", "rule2"}};
 
   std::vector<std::string> ue_mac_addrs  = {"00:00:00:00:00:02",
                                            "11:22:00:00:22:11"};
@@ -2472,13 +2471,12 @@ TEST_F(LocalEnforcerTest, test_pipelined_cwf_setup) {
                                             "01-a1-20-c2-0f-bb"};
   std::vector<std::string> apn_names     = {"Magma", "CWC_OFFLOAD"};
   EXPECT_CALL(
-      *pipelined_client,
-      setup_cwf(
-          CheckSessionInfos(
-              imsi_list, ip_address_list, ipv6_address_list, test_cwf_cfg2,
-              static_rule_list, dynamic_rule_list),
-          testing::_, ue_mac_addrs, msisdns, apn_mac_addrs, apn_names,
-          testing::_, testing::_, testing::_))
+      *pipelined_client, setup_cwf(
+                             CheckSessionInfos(
+                                 imsi_list, ip_address_list, ipv6_address_list,
+                                 test_cwf_cfg2, rule_list),
+                             testing::_, ue_mac_addrs, msisdns, apn_mac_addrs,
+                             apn_names, testing::_, testing::_, testing::_))
       .Times(1);
 
   local_enforcer->setup(
@@ -2527,12 +2525,11 @@ TEST_F(LocalEnforcerTest, test_pipelined_lte_setup) {
       session_map,
       create_update_tunnel_ids_request(IMSI2, BEARER_ID_2, teids2));
 
-  std::vector<std::string> imsi_list                      = {IMSI2, IMSI1};
-  std::vector<std::string> ip_address_list                = {IP1, IP1};
-  std::vector<std::string> ipv6_address_list              = {IPv6_1, ""};
-  std::vector<std::vector<std::string>> static_rule_list  = {{}, {"rule2"}};
-  std::vector<std::vector<std::string>> dynamic_rule_list = {{"rule22"},
-                                                             {"rule1"}};
+  std::vector<std::string> imsi_list              = {IMSI2, IMSI1};
+  std::vector<std::string> ip_address_list        = {IP1, IP1};
+  std::vector<std::string> ipv6_address_list      = {IPv6_1, ""};
+  std::vector<std::vector<std::string>> rule_list = {{"rule22"},
+                                                     {"rule1", "rule2"}};
 
   std::vector<std::string> ue_mac_addrs  = {"00:00:00:00:00:02",
                                            "11:22:00:00:22:11"};
@@ -2541,12 +2538,11 @@ TEST_F(LocalEnforcerTest, test_pipelined_lte_setup) {
                                             "01-a1-20-c2-0f-bb"};
   std::vector<std::string> apn_names     = {"Magma", "CWC_OFFLOAD"};
   EXPECT_CALL(
-      *pipelined_client,
-      setup_lte(
-          CheckSessionInfos(
-              imsi_list, ip_address_list, ipv6_address_list, test_cfg_,
-              static_rule_list, dynamic_rule_list),
-          testing::_, testing::_))
+      *pipelined_client, setup_lte(
+                             CheckSessionInfos(
+                                 imsi_list, ip_address_list, ipv6_address_list,
+                                 test_cfg_, rule_list),
+                             testing::_, testing::_))
       .Times(1);
 
   local_enforcer->setup(

--- a/lte/gateway/c/session_manager/test/test_local_enforcer.cpp
+++ b/lte/gateway/c/session_manager/test/test_local_enforcer.cpp
@@ -1091,7 +1091,7 @@ TEST_F(LocalEnforcerTest, test_credit_init_with_transient_error_redirect) {
   EXPECT_CALL(
       *pipelined_client, deactivate_flows_for_rules(
                              testing::_, testing::_, testing::_, testing::_,
-                             CheckCount(1), testing::_))
+                             CheckRuleCount(1), testing::_))
       .Times(1);
   local_enforcer->init_session(
       session_map, IMSI1, SESSION_ID_1, test_cfg_, response);
@@ -1145,7 +1145,7 @@ TEST_F(LocalEnforcerTest, test_credit_init_with_transient_error_redirect) {
       add_gy_final_action_flow(
           IMSI1, test_cfg_.common_context.ue_ipv4(),
           test_cfg_.common_context.ue_ipv6(), CheckTeids(teids1),
-          test_cfg_.common_context.msisdn(), CheckCount(1)))
+          test_cfg_.common_context.msisdn(), CheckRuleCount(1)))
       .Times(1);
   local_enforcer->execute_actions(session_map, actions, update);
   EXPECT_EQ(session_update.updates_size(), 0);
@@ -1189,7 +1189,7 @@ TEST_F(LocalEnforcerTest, test_update_with_transient_error) {
   EXPECT_CALL(
       *pipelined_client, deactivate_flows_for_rules(
                              testing::_, testing::_, testing::_, testing::_,
-                             CheckCount(2), testing::_))
+                             CheckRuleCount(2), testing::_))
       .Times(1);
 
   local_enforcer->update_session_credits_and_rules(
@@ -2677,9 +2677,10 @@ TEST_F(LocalEnforcerTest, test_final_unit_redirect_activation_and_termination) {
       actions[0]->get_redirect_server().redirect_server_address(), "12.7.7.4");
 
   EXPECT_CALL(
-      *pipelined_client, add_gy_final_action_flow(
-                             IMSI1, ip_addr, ipv6_addr, CheckTeids(teids),
-                             test_cfg_.common_context.msisdn(), CheckCount(1)))
+      *pipelined_client,
+      add_gy_final_action_flow(
+          IMSI1, ip_addr, ipv6_addr, CheckTeids(teids),
+          test_cfg_.common_context.msisdn(), CheckRuleCount(1)))
       .Times(1);
   // Execute actions and asset final action state
   local_enforcer->execute_actions(session_map, actions, update);
@@ -2756,9 +2757,9 @@ TEST_F(LocalEnforcerTest, test_final_unit_activation_and_canceling) {
   EXPECT_EQ(actions[0]->get_restrict_rules()[0].id(), "rule1");
 
   EXPECT_CALL(
-      *pipelined_client,
-      add_gy_final_action_flow(
-          IMSI1, ip_addr, ipv6_addr, CheckTeids(teids), msisdn, CheckCount(1)))
+      *pipelined_client, add_gy_final_action_flow(
+                             IMSI1, ip_addr, ipv6_addr, CheckTeids(teids),
+                             msisdn, CheckRuleCount(1)))
       .Times(1);
   // Execute actions and asset final action state
   local_enforcer->execute_actions(session_map, actions, update);
@@ -2869,9 +2870,10 @@ TEST_F(LocalEnforcerTest, test_final_unit_action_no_update) {
   EXPECT_EQ(actions[0]->get_restrict_rules()[0].id(), "restrict_rule");
 
   EXPECT_CALL(
-      *pipelined_client, add_gy_final_action_flow(
-                             IMSI1, ip_addr, ipv6_addr, CheckTeids(teids),
-                             test_cfg_.common_context.msisdn(), CheckCount(1)))
+      *pipelined_client,
+      add_gy_final_action_flow(
+          IMSI1, ip_addr, ipv6_addr, CheckTeids(teids),
+          test_cfg_.common_context.msisdn(), CheckRuleCount(1)))
       .Times(1);
   // Execute actions and asset final action state
   local_enforcer->execute_actions(session_map, actions, update);
@@ -2931,7 +2933,7 @@ TEST_F(LocalEnforcerTest, test_rar_dynamic_rule_modification) {
     EXPECT_CALL(
         *pipelined_client, deactivate_flows_for_rules(
                                IMSI1, testing::_, testing::_, testing::_,
-                               CheckCount(1), testing::_))
+                               CheckRuleCount(1), testing::_))
         .Times(1);
     EXPECT_CALL(
         *pipelined_client, activate_flows_for_rules(

--- a/lte/gateway/c/session_manager/test/test_proxy_responder_handler.cpp
+++ b/lte/gateway/c/session_manager/test/test_proxy_responder_handler.cpp
@@ -206,7 +206,7 @@ TEST_F(SessionProxyResponderHandlerTest, test_policy_reauth) {
   grpc::ServerContext create_context;
   EXPECT_CALL(
       *pipelined_client,
-      activate_flows_for_rules(IMSI1, _, _, _, _, _, CheckCount(1), _))
+      activate_flows_for_rules(IMSI1, _, _, _, _, _, CheckRuleCount(1), _))
       .Times(1);
   proxy_responder->PolicyReAuth(
       &create_context, &request,


### PR DESCRIPTION
<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary
Another PR in preparation for adding rule version generation to Activate/Deactivate flows request. (See here: https://github.com/magma/magma/pull/5699)
Eventually, the `RulesToProcess` struct will have
1. `std::vector<PolicyRule> rules`
2. `std::vector<uint32_t> versions`

This will help in passing the Policy+version combination into PipelineDClient->PipelineD.

## Test Plan
unit tests + integ
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
Signed-off-by: Marie Bremner <marwhal@fb.com>