### PR TITLE
[lte][agw] Fixing _get_restricted_plmns service_mconfig oai generation

### DIFF
--- a/lte/gateway/python/scripts/generate_oai_config.py
+++ b/lte/gateway/python/scripts/generate_oai_config.py
@@ -184,7 +184,7 @@ def _get_federated_mode_map(service_mconfig):
         return service_mconfig.federated_mode_map.mapping
     return {}
 
-def _get_restricted_plmns(mme_service_config):
+def _get_restricted_plmns(service_mconfig):
     if service_mconfig.restricted_plmns:
         return service_mconfig.restricted_plmns
     return {}


### PR DESCRIPTION
Signed-off-by: Alex Rodriguez <ardzoht@gmail.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary

- Fixes variable capture of service_mconfig on generate_oai_config for `restricted_plmns`

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->
- Destroyed and `vagrant up` magma VM to test `generate_oai_config`

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
