### PR TITLE
Enable IPFIX For LTE Setups (#4679)

### DIFF
--- a/lte/gateway/deploy/roles/magma/files/nx_actions.py
+++ b/lte/gateway/deploy/roles/magma/files/nx_actions.py
@@ -1,0 +1,3195 @@
+# Copyright (C) 2015 Nippon Telegraph and Telephone Corporation.
+# Copyright (C) 2015 YAMAMOTO Takashi <yamamoto at valinux co jp>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import six
+
+import struct
+
+from ryu import utils
+from ryu.lib import type_desc
+from ryu.ofproto import nicira_ext
+from ryu.ofproto import ofproto_common
+from ryu.lib.pack_utils import msg_pack_into
+from ryu.ofproto.ofproto_parser import StringifyMixin
+
+
+def generate(ofp_name, ofpp_name):
+    import sys
+
+    ofp = sys.modules[ofp_name]
+    ofpp = sys.modules[ofpp_name]
+
+    class _NXFlowSpec(StringifyMixin):
+        _hdr_fmt_str = '!H'  # 2 bit 0s, 1 bit src, 2 bit dst, 11 bit n_bits
+        _dst_type = None
+        _subclasses = {}
+        _TYPE = {
+            'nx-flow-spec-field': [
+                'src',
+                'dst',
+            ]
+        }
+
+        def __init__(self, src, dst, n_bits):
+            self.src = src
+            self.dst = dst
+            self.n_bits = n_bits
+
+        @classmethod
+        def register(cls, subcls):
+            assert issubclass(subcls, cls)
+            assert subcls._dst_type not in cls._subclasses
+            cls._subclasses[subcls._dst_type] = subcls
+
+        @classmethod
+        def parse(cls, buf):
+            (hdr,) = struct.unpack_from(cls._hdr_fmt_str, buf, 0)
+            rest = buf[struct.calcsize(cls._hdr_fmt_str):]
+            if hdr == 0:
+                return None, rest  # all-0 header is no-op for padding
+            src_type = (hdr >> 13) & 0x1
+            dst_type = (hdr >> 11) & 0x3
+            n_bits = hdr & 0x3ff
+            subcls = cls._subclasses[dst_type]
+            if src_type == 0:  # subfield
+                src = cls._parse_subfield(rest)
+                rest = rest[6:]
+            elif src_type == 1:  # immediate
+                src_len = (n_bits + 15) // 16 * 2
+                src_bin = rest[:src_len]
+                src = type_desc.IntDescr(size=src_len).to_user(src_bin)
+                rest = rest[src_len:]
+            if dst_type == 0:  # match
+                dst = cls._parse_subfield(rest)
+                rest = rest[6:]
+            elif dst_type == 1:  # load
+                dst = cls._parse_subfield(rest)
+                rest = rest[6:]
+            elif dst_type == 2:  # output
+                dst = ''  # empty
+            return subcls(src=src, dst=dst, n_bits=n_bits), rest
+
+        def serialize(self):
+            buf = bytearray()
+            if isinstance(self.src, tuple):
+                src_type = 0  # subfield
+            else:
+                src_type = 1  # immediate
+            # header
+            val = (src_type << 13) | (self._dst_type << 11) | self.n_bits
+            msg_pack_into(self._hdr_fmt_str, buf, 0, val)
+            # src
+            if src_type == 0:  # subfield
+                buf += self._serialize_subfield(self.src)
+            elif src_type == 1:  # immediate
+                src_len = (self.n_bits + 15) // 16 * 2
+                buf += type_desc.IntDescr(size=src_len).from_user(self.src)
+            # dst
+            if self._dst_type == 0:  # match
+                buf += self._serialize_subfield(self.dst)
+            elif self._dst_type == 1:  # load
+                buf += self._serialize_subfield(self.dst)
+            elif self._dst_type == 2:  # output
+                pass  # empty
+            return buf
+
+        @staticmethod
+        def _parse_subfield(buf):
+            (n, len) = ofp.oxm_parse_header(buf, 0)
+            assert len == 4  # only 4-bytes NXM/OXM are defined
+            field = ofp.oxm_to_user_header(n)
+            rest = buf[len:]
+            (ofs,) = struct.unpack_from('!H', rest, 0)
+            return (field, ofs)
+
+        @staticmethod
+        def _serialize_subfield(subfield):
+            (field, ofs) = subfield
+            buf = bytearray()
+            n = ofp.oxm_from_user_header(field)
+            ofp.oxm_serialize_header(n, buf, 0)
+            assert len(buf) == 4  # only 4-bytes NXM/OXM are defined
+            msg_pack_into('!H', buf, 4, ofs)
+            return buf
+
+    class NXFlowSpecMatch(_NXFlowSpec):
+        """
+        Specification for adding match criterion
+
+        This class is used by ``NXActionLearn``.
+
+        For the usage of this class, please refer to ``NXActionLearn``.
+
+        ================ ======================================================
+        Attribute        Description
+        ================ ======================================================
+        src              OXM/NXM header and Start bit for source field
+        dst              OXM/NXM header and Start bit for destination field
+        n_bits           The number of bits from the start bit
+        ================ ======================================================
+        """
+        # Add a match criteria
+        # an example of the corresponding ovs-ofctl syntax:
+        #    NXM_OF_VLAN_TCI[0..11]
+        _dst_type = 0
+
+    class NXFlowSpecLoad(_NXFlowSpec):
+        """
+        Add NXAST_REG_LOAD actions
+
+        This class is used by ``NXActionLearn``.
+
+        For the usage of this class, please refer to ``NXActionLearn``.
+
+        ================ ======================================================
+        Attribute        Description
+        ================ ======================================================
+        src              OXM/NXM header and Start bit for source field
+        dst              OXM/NXM header and Start bit for destination field
+        n_bits           The number of bits from the start bit
+        ================ ======================================================
+        """
+        # Add NXAST_REG_LOAD actions
+        # an example of the corresponding ovs-ofctl syntax:
+        #    NXM_OF_ETH_DST[]=NXM_OF_ETH_SRC[]
+        _dst_type = 1
+
+    class NXFlowSpecOutput(_NXFlowSpec):
+        """
+        Add an OFPAT_OUTPUT action
+
+        This class is used by ``NXActionLearn``.
+
+        For the usage of this class, please refer to ``NXActionLearn``.
+
+        ================ ======================================================
+        Attribute        Description
+        ================ ======================================================
+        src              OXM/NXM header and Start bit for source field
+        dst              Must be ''
+        n_bits           The number of bits from the start bit
+        ================ ======================================================
+        """
+        # Add an OFPAT_OUTPUT action
+        # an example of the corresponding ovs-ofctl syntax:
+        #    output:NXM_OF_IN_PORT[]
+        _dst_type = 2
+
+        def __init__(self, src, n_bits, dst=''):
+            assert dst == ''
+            super(NXFlowSpecOutput, self).__init__(src=src, dst=dst,
+                                                   n_bits=n_bits)
+
+    class NXAction(ofpp.OFPActionExperimenter):
+        _fmt_str = '!H'  # subtype
+        _subtypes = {}
+        _experimenter = ofproto_common.NX_EXPERIMENTER_ID
+
+        def __init__(self):
+            super(NXAction, self).__init__(self._experimenter)
+            self.subtype = self._subtype
+
+        @classmethod
+        def parse(cls, buf):
+            fmt_str = NXAction._fmt_str
+            (subtype,) = struct.unpack_from(fmt_str, buf, 0)
+            subtype_cls = cls._subtypes.get(subtype)
+            rest = buf[struct.calcsize(fmt_str):]
+            if subtype_cls is None:
+                return NXActionUnknown(subtype, rest)
+            return subtype_cls.parser(rest)
+
+        def serialize(self, buf, offset):
+            data = self.serialize_body()
+            payload_offset = (
+                    ofp.OFP_ACTION_EXPERIMENTER_HEADER_SIZE +
+                    struct.calcsize(NXAction._fmt_str)
+            )
+            self.len = utils.round_up(payload_offset + len(data), 8)
+            super(NXAction, self).serialize(buf, offset)
+            msg_pack_into(NXAction._fmt_str,
+                          buf,
+                          offset + ofp.OFP_ACTION_EXPERIMENTER_HEADER_SIZE,
+                          self.subtype)
+            buf += data
+
+        @classmethod
+        def register(cls, subtype_cls):
+            assert subtype_cls._subtype is not cls._subtypes
+            cls._subtypes[subtype_cls._subtype] = subtype_cls
+
+    class NXActionUnknown(NXAction):
+        def __init__(self, subtype, data=None,
+                     type_=None, len_=None, experimenter=None):
+            self._subtype = subtype
+            super(NXActionUnknown, self).__init__()
+            self.data = data
+
+        @classmethod
+        def parser(cls, buf):
+            return cls(data=buf)
+
+        def serialize_body(self):
+            # fixup
+            return bytearray() if self.data is None else self.data
+
+    # For OpenFlow1.0 only
+    class NXActionSetQueue(NXAction):
+        r"""
+        Set queue action
+
+        This action sets the queue that should be used to queue
+        when packets are output.
+
+        And equivalent to the followings action of ovs-ofctl command.
+
+        ..
+          set_queue:queue
+        ..
+
+        +-------------------------+
+        | **set_queue**\:\ *queue*|
+        +-------------------------+
+
+        ================ ======================================================
+        Attribute        Description
+        ================ ======================================================
+        queue_id         Queue ID for the packets
+        ================ ======================================================
+
+        .. note::
+            This actions is supported by
+            ``OFPActionSetQueue``
+            in OpenFlow1.2 or later.
+
+        Example::
+
+            actions += [parser.NXActionSetQueue(queue_id=10)]
+        """
+        _subtype = nicira_ext.NXAST_SET_QUEUE
+
+        # queue_id
+        _fmt_str = '!2xI'
+
+        def __init__(self, queue_id,
+                     type_=None, len_=None, vendor=None, subtype=None):
+            super(NXActionSetQueue, self).__init__()
+            self.queue_id = queue_id
+
+        @classmethod
+        def parser(cls, buf):
+            (queue_id,) = struct.unpack_from(cls._fmt_str, buf, 0)
+            return cls(queue_id)
+
+        def serialize_body(self):
+            data = bytearray()
+            msg_pack_into(self._fmt_str, data, 0, self.queue_id)
+            return data
+
+    class NXActionPopQueue(NXAction):
+        """
+        Pop queue action
+
+        This action restors the queue to the value it was before any
+        set_queue actions were applied.
+
+        And equivalent to the followings action of ovs-ofctl command.
+
+        ..
+          pop_queue
+        ..
+
+        +---------------+
+        | **pop_queue** |
+        +---------------+
+
+        Example::
+
+            actions += [parser.NXActionPopQueue()]
+        """
+        _subtype = nicira_ext.NXAST_POP_QUEUE
+
+        _fmt_str = '!6x'
+
+        def __init__(self,
+                     type_=None, len_=None, experimenter=None, subtype=None):
+            super(NXActionPopQueue, self).__init__()
+
+        @classmethod
+        def parser(cls, buf):
+            return cls()
+
+        def serialize_body(self):
+            data = bytearray()
+            msg_pack_into(self._fmt_str, data, 0)
+            return data
+
+    class NXActionRegLoad(NXAction):
+        r"""
+        Load literal value action
+
+        This action loads a literal value into a field or part of a field.
+
+        And equivalent to the followings action of ovs-ofctl command.
+
+        ..
+          load:value->dst[start..end]
+        ..
+
+        +-----------------------------------------------------------------+
+        | **load**\:\ *value*\->\ *dst*\ **[**\ *start*\..\ *end*\ **]**  |
+        +-----------------------------------------------------------------+
+
+        ================ ======================================================
+        Attribute        Description
+        ================ ======================================================
+        ofs_nbits        Start and End for the OXM/NXM field.
+                         Setting method refer to the ``nicira_ext.ofs_nbits``
+        dst              OXM/NXM header for destination field
+        value            OXM/NXM value to be loaded
+        ================ ======================================================
+
+        Example::
+
+            actions += [parser.NXActionRegLoad(
+                            ofs_nbits=nicira_ext.ofs_nbits(4, 31),
+                            dst="eth_dst",
+                            value=0x112233)]
+        """
+        _subtype = nicira_ext.NXAST_REG_LOAD
+        _fmt_str = '!HIQ'  # ofs_nbits, dst, value
+        _TYPE = {
+            'ascii': [
+                'dst',
+            ]
+        }
+
+        def __init__(self, ofs_nbits, dst, value,
+                     type_=None, len_=None, experimenter=None,
+                     subtype=None):
+            super(NXActionRegLoad, self).__init__()
+            self.ofs_nbits = ofs_nbits
+            self.dst = dst
+            self.value = value
+
+        @classmethod
+        def parser(cls, buf):
+            (ofs_nbits, dst, value,) = struct.unpack_from(
+                cls._fmt_str, buf, 0)
+            # Right-shift instead of using oxm_parse_header for simplicity...
+            dst_name = ofp.oxm_to_user_header(dst >> 9)
+            return cls(ofs_nbits, dst_name, value)
+
+        def serialize_body(self):
+            hdr_data = bytearray()
+            n = ofp.oxm_from_user_header(self.dst)
+            ofp.oxm_serialize_header(n, hdr_data, 0)
+            (dst_num,) = struct.unpack_from('!I', six.binary_type(hdr_data), 0)
+
+            data = bytearray()
+            msg_pack_into(self._fmt_str, data, 0,
+                          self.ofs_nbits, dst_num, self.value)
+            return data
+
+    class NXActionRegLoad2(NXAction):
+        r"""
+        Load literal value action
+
+        This action loads a literal value into a field or part of a field.
+
+        And equivalent to the followings action of ovs-ofctl command.
+
+        ..
+          set_field:value[/mask]->dst
+        ..
+
+        +------------------------------------------------------------+
+        | **set_field**\:\ *value*\ **[**\/\ *mask*\ **]**\->\ *dst* |
+        +------------------------------------------------------------+
+
+        ================ ======================================================
+        Attribute        Description
+        ================ ======================================================
+        value            OXM/NXM value to be loaded
+        mask             Mask for destination field
+        dst              OXM/NXM header for destination field
+        ================ ======================================================
+
+        Example::
+
+            actions += [parser.NXActionRegLoad2(dst="tun_ipv4_src",
+                                                value="192.168.10.0",
+                                                mask="255.255.255.0")]
+        """
+        _subtype = nicira_ext.NXAST_REG_LOAD2
+        _TYPE = {
+            'ascii': [
+                'dst',
+                'value',
+            ]
+        }
+
+        def __init__(self, dst, value, mask=None,
+                     type_=None, len_=None, experimenter=None, subtype=None):
+            super(NXActionRegLoad2, self).__init__()
+            self.dst = dst
+            self.value = value
+            self.mask = mask
+
+        @classmethod
+        def parser(cls, buf):
+            (n, uv, mask, _len) = ofp.oxm_parse(buf, 0)
+            dst, value = ofp.oxm_to_user(n, uv, mask)
+
+            if isinstance(value, (tuple, list)):
+                return cls(dst, value[0], value[1])
+            else:
+                return cls(dst, value, None)
+
+        def serialize_body(self):
+            data = bytearray()
+            if self.mask is None:
+                value = self.value
+            else:
+                value = (self.value, self.mask)
+                self._TYPE['ascii'].append('mask')
+
+            n, value, mask = ofp.oxm_from_user(self.dst, value)
+            len_ = ofp.oxm_serialize(n, value, mask, data, 0)
+            msg_pack_into("!%dx" % (14 - len_), data, len_)
+
+            return data
+
+    class NXActionNote(NXAction):
+        r"""
+        Note action
+
+        This action does nothing at all.
+
+        And equivalent to the followings action of ovs-ofctl command.
+
+        ..
+          note:[hh]..
+        ..
+
+        +-----------------------------------+
+        | **note**\:\ **[**\ *hh*\ **]**\.. |
+        +-----------------------------------+
+
+        ================ ======================================================
+        Attribute        Description
+        ================ ======================================================
+        note             A list of integer type values
+        ================ ======================================================
+
+        Example::
+
+            actions += [parser.NXActionNote(note=[0xaa,0xbb,0xcc,0xdd])]
+        """
+        _subtype = nicira_ext.NXAST_NOTE
+
+        # note
+        _fmt_str = '!%dB'
+
+        # set the integer array in a note
+        def __init__(self,
+                     note,
+                     type_=None, len_=None, experimenter=None, subtype=None):
+            super(NXActionNote, self).__init__()
+            self.note = note
+
+        @classmethod
+        def parser(cls, buf):
+            note = struct.unpack_from(
+                cls._fmt_str % len(buf), buf, 0)
+            return cls(list(note))
+
+        def serialize_body(self):
+            assert isinstance(self.note, (tuple, list))
+            for n in self.note:
+                assert isinstance(n, six.integer_types)
+
+            pad = (len(self.note) + nicira_ext.NX_ACTION_HEADER_0_SIZE) % 8
+            if pad:
+                self.note += [0x0 for i in range(8 - pad)]
+            note_len = len(self.note)
+            data = bytearray()
+            msg_pack_into(self._fmt_str % note_len, data, 0,
+                          *self.note)
+            return data
+
+    class _NXActionSetTunnelBase(NXAction):
+        # _subtype, _fmt_str must be attributes of subclass.
+
+        def __init__(self,
+                     tun_id,
+                     type_=None, len_=None, experimenter=None, subtype=None):
+            super(_NXActionSetTunnelBase, self).__init__()
+            self.tun_id = tun_id
+
+        @classmethod
+        def parser(cls, buf):
+            (tun_id,) = struct.unpack_from(
+                cls._fmt_str, buf, 0)
+            return cls(tun_id)
+
+        def serialize_body(self):
+            data = bytearray()
+            msg_pack_into(self._fmt_str, data, 0,
+                          self.tun_id)
+            return data
+
+    class NXActionSetTunnel(_NXActionSetTunnelBase):
+        r"""
+        Set Tunnel action
+
+        This action sets the identifier (such as GRE) to the specified id.
+
+        And equivalent to the followings action of ovs-ofctl command.
+
+        .. note::
+            This actions is supported by
+            ``OFPActionSetField``
+            in OpenFlow1.2 or later.
+
+        ..
+          set_tunnel:id
+        ..
+
+        +------------------------+
+        | **set_tunnel**\:\ *id* |
+        +------------------------+
+
+        ================ ======================================================
+        Attribute        Description
+        ================ ======================================================
+        tun_id           Tunnel ID(32bits)
+        ================ ======================================================
+
+        Example::
+
+            actions += [parser.NXActionSetTunnel(tun_id=0xa)]
+        """
+        _subtype = nicira_ext.NXAST_SET_TUNNEL
+
+        # tun_id
+        _fmt_str = '!2xI'
+
+    class NXActionSetTunnel64(_NXActionSetTunnelBase):
+        r"""
+        Set Tunnel action
+
+        This action outputs to a port that encapsulates
+        the packet in a tunnel.
+
+        And equivalent to the followings action of ovs-ofctl command.
+
+        .. note::
+            This actions is supported by
+            ``OFPActionSetField``
+            in OpenFlow1.2 or later.
+
+        ..
+          set_tunnel64:id
+        ..
+
+        +--------------------------+
+        | **set_tunnel64**\:\ *id* |
+        +--------------------------+
+
+        ================ ======================================================
+        Attribute        Description
+        ================ ======================================================
+        tun_id           Tunnel ID(64bits)
+        ================ ======================================================
+
+        Example::
+
+            actions += [parser.NXActionSetTunnel64(tun_id=0xa)]
+        """
+        _subtype = nicira_ext.NXAST_SET_TUNNEL64
+
+        # tun_id
+        _fmt_str = '!6xQ'
+
+    class NXActionRegMove(NXAction):
+        r"""
+        Move register action
+
+        This action copies the src to dst.
+
+        And equivalent to the followings action of ovs-ofctl command.
+
+        ..
+          move:src[start..end]->dst[start..end]
+        ..
+
+        +--------------------------------------------------------+
+        | **move**\:\ *src*\ **[**\ *start*\..\ *end*\ **]**\->\ |
+        | *dst*\ **[**\ *start*\..\ *end* \ **]**                |
+        +--------------------------------------------------------+
+
+        ================ ======================================================
+        Attribute        Description
+        ================ ======================================================
+        src_field        OXM/NXM header for source field
+        dst_field        OXM/NXM header for destination field
+        n_bits           Number of bits
+        src_ofs          Starting bit offset in source
+        dst_ofs          Starting bit offset in destination
+        ================ ======================================================
+
+        .. CAUTION::
+            **src_start**\  and \ **src_end**\  difference and \ **dst_start**\
+             and \ **dst_end**\  difference must be the same.
+
+        Example::
+
+            actions += [parser.NXActionRegMove(src_field="reg0",
+                                               dst_field="reg1",
+                                               n_bits=5,
+                                               src_ofs=0
+                                               dst_ofs=10)]
+        """
+        _subtype = nicira_ext.NXAST_REG_MOVE
+        _fmt_str = '!HHH'  # n_bits, src_ofs, dst_ofs
+        # Followed by OXM fields (src, dst) and padding to 8 bytes boundary
+        _TYPE = {
+            'ascii': [
+                'src_field',
+                'dst_field',
+            ]
+        }
+
+        def __init__(self, src_field, dst_field, n_bits, src_ofs=0, dst_ofs=0,
+                     type_=None, len_=None, experimenter=None, subtype=None):
+            super(NXActionRegMove, self).__init__()
+            self.n_bits = n_bits
+            self.src_ofs = src_ofs
+            self.dst_ofs = dst_ofs
+            self.src_field = src_field
+            self.dst_field = dst_field
+
+        @classmethod
+        def parser(cls, buf):
+            (n_bits, src_ofs, dst_ofs,) = struct.unpack_from(
+                cls._fmt_str, buf, 0)
+            rest = buf[struct.calcsize(NXActionRegMove._fmt_str):]
+
+            # src field
+            (n, len) = ofp.oxm_parse_header(rest, 0)
+            src_field = ofp.oxm_to_user_header(n)
+            rest = rest[len:]
+            # dst field
+            (n, len) = ofp.oxm_parse_header(rest, 0)
+            dst_field = ofp.oxm_to_user_header(n)
+            rest = rest[len:]
+            # ignore padding
+            return cls(src_field, dst_field=dst_field, n_bits=n_bits,
+                       src_ofs=src_ofs, dst_ofs=dst_ofs)
+
+        def serialize_body(self):
+            # fixup
+            data = bytearray()
+            msg_pack_into(self._fmt_str, data, 0,
+                          self.n_bits, self.src_ofs, self.dst_ofs)
+            # src field
+            n = ofp.oxm_from_user_header(self.src_field)
+            ofp.oxm_serialize_header(n, data, len(data))
+            # dst field
+            n = ofp.oxm_from_user_header(self.dst_field)
+            ofp.oxm_serialize_header(n, data, len(data))
+            return data
+
+    class NXActionResubmit(NXAction):
+        r"""
+        Resubmit action
+
+        This action searches one of the switch's flow tables.
+
+        And equivalent to the followings action of ovs-ofctl command.
+
+        ..
+          resubmit:port
+        ..
+
+        +------------------------+
+        | **resubmit**\:\ *port* |
+        +------------------------+
+
+        ================ ======================================================
+        Attribute        Description
+        ================ ======================================================
+        in_port          New in_port for checking flow table
+        ================ ======================================================
+
+        Example::
+
+            actions += [parser.NXActionResubmit(in_port=8080)]
+        """
+        _subtype = nicira_ext.NXAST_RESUBMIT
+
+        # in_port
+        _fmt_str = '!H4x'
+
+        def __init__(self,
+                     in_port=0xfff8,
+                     type_=None, len_=None, experimenter=None, subtype=None):
+            super(NXActionResubmit, self).__init__()
+            self.in_port = in_port
+
+        @classmethod
+        def parser(cls, buf):
+            (in_port,) = struct.unpack_from(
+                cls._fmt_str, buf, 0)
+            return cls(in_port)
+
+        def serialize_body(self):
+            data = bytearray()
+            msg_pack_into(self._fmt_str, data, 0,
+                          self.in_port)
+            return data
+
+    class NXActionResubmitTable(NXAction):
+        r"""
+        Resubmit action
+
+        This action searches one of the switch's flow tables.
+
+        And equivalent to the followings action of ovs-ofctl command.
+
+        ..
+          resubmit([port],[table])
+        ..
+
+        +------------------------------------------------+
+        | **resubmit(**\[\ *port*\]\,[\ *table*\]\ **)** |
+        +------------------------------------------------+
+
+        ================ ======================================================
+        Attribute        Description
+        ================ ======================================================
+        in_port          New in_port for checking flow table
+        table_id         Checking flow tables
+        ================ ======================================================
+
+        Example::
+
+            actions += [parser.NXActionResubmit(in_port=8080,
+                                                table_id=10)]
+        """
+        _subtype = nicira_ext.NXAST_RESUBMIT_TABLE
+
+        # in_port, table_id
+        _fmt_str = '!HB3x'
+
+        def __init__(self,
+                     in_port=0xfff8,
+                     table_id=0xff,
+                     type_=None, len_=None, experimenter=None, subtype=None):
+            super(NXActionResubmitTable, self).__init__()
+            self.in_port = in_port
+            self.table_id = table_id
+
+        @classmethod
+        def parser(cls, buf):
+            (in_port,
+             table_id) = struct.unpack_from(
+                cls._fmt_str, buf, 0)
+            return cls(in_port, table_id)
+
+        def serialize_body(self):
+            data = bytearray()
+            msg_pack_into(self._fmt_str, data, 0,
+                          self.in_port, self.table_id)
+            return data
+
+    class NXActionOutputReg(NXAction):
+        r"""
+        Add output action
+
+        This action outputs the packet to the OpenFlow port number read from
+        src.
+
+        And equivalent to the followings action of ovs-ofctl command.
+
+        ..
+          output:src[start...end]
+        ..
+
+        +-------------------------------------------------------+
+        | **output**\:\ *src*\ **[**\ *start*\...\ *end*\ **]** |
+        +-------------------------------------------------------+
+
+        ================ ======================================================
+        Attribute        Description
+        ================ ======================================================
+        ofs_nbits        Start and End for the OXM/NXM field.
+                         Setting method refer to the ``nicira_ext.ofs_nbits``
+        src              OXM/NXM header for source field
+        max_len          Max length to send to controller
+        ================ ======================================================
+
+        Example::
+
+            actions += [parser.NXActionOutputReg(
+                            ofs_nbits=nicira_ext.ofs_nbits(4, 31),
+                            src="reg0",
+                            max_len=1024)]
+        """
+        _subtype = nicira_ext.NXAST_OUTPUT_REG
+
+        # ofs_nbits, src, max_len
+        _fmt_str = '!H4sH6x'
+        _TYPE = {
+            'ascii': [
+                'src',
+            ]
+        }
+
+        def __init__(self,
+                     ofs_nbits,
+                     src,
+                     max_len,
+                     type_=None, len_=None, experimenter=None, subtype=None):
+            super(NXActionOutputReg, self).__init__()
+            self.ofs_nbits = ofs_nbits
+            self.src = src
+            self.max_len = max_len
+
+        @classmethod
+        def parser(cls, buf):
+            (ofs_nbits, oxm_data, max_len) = struct.unpack_from(
+                cls._fmt_str, buf, 0)
+            (n, len_) = ofp.oxm_parse_header(oxm_data, 0)
+            src = ofp.oxm_to_user_header(n)
+            return cls(ofs_nbits,
+                       src,
+                       max_len)
+
+        def serialize_body(self):
+            data = bytearray()
+            src = bytearray()
+            oxm = ofp.oxm_from_user_header(self.src)
+            ofp.oxm_serialize_header(oxm, src, 0),
+            msg_pack_into(self._fmt_str, data, 0,
+                          self.ofs_nbits,
+                          six.binary_type(src),
+                          self.max_len)
+            return data
+
+    class NXActionOutputReg2(NXAction):
+        r"""
+        Add output action
+
+        This action outputs the packet to the OpenFlow port number read from
+        src.
+
+        And equivalent to the followings action of ovs-ofctl command.
+
+        ..
+          output:src[start...end]
+        ..
+
+        +-------------------------------------------------------+
+        | **output**\:\ *src*\ **[**\ *start*\...\ *end*\ **]** |
+        +-------------------------------------------------------+
+
+        .. NOTE::
+             Like the ``NXActionOutputReg`` but organized so
+             that there is room for a 64-bit experimenter OXM as 'src'.
+
+        ================ ======================================================
+        Attribute        Description
+        ================ ======================================================
+        ofs_nbits        Start and End for the OXM/NXM field.
+                         Setting method refer to the ``nicira_ext.ofs_nbits``
+        src              OXM/NXM header for source field
+        max_len          Max length to send to controller
+        ================ ======================================================
+
+        Example::
+
+            actions += [parser.NXActionOutputReg2(
+                            ofs_nbits=nicira_ext.ofs_nbits(4, 31),
+                            src="reg0",
+                            max_len=1024)]
+        """
+        _subtype = nicira_ext.NXAST_OUTPUT_REG2
+
+        # ofs_nbits, src, max_len
+        _fmt_str = '!HH4s'
+        _TYPE = {
+            'ascii': [
+                'src',
+            ]
+        }
+
+        def __init__(self,
+                     ofs_nbits,
+                     src,
+                     max_len,
+                     type_=None, len_=None, experimenter=None, subtype=None):
+            super(NXActionOutputReg2, self).__init__()
+            self.ofs_nbits = ofs_nbits
+            self.src = src
+            self.max_len = max_len
+
+        @classmethod
+        def parser(cls, buf):
+            (ofs_nbits,
+             max_len,
+             oxm_data) = struct.unpack_from(
+                cls._fmt_str, buf, 0)
+            (n, len_) = ofp.oxm_parse_header(oxm_data, 0)
+            src = ofp.oxm_to_user_header(n)
+            return cls(ofs_nbits,
+                       src,
+                       max_len)
+
+        def serialize_body(self):
+            data = bytearray()
+            oxm_data = bytearray()
+            oxm = ofp.oxm_from_user_header(self.src)
+            ofp.oxm_serialize_header(oxm, oxm_data, 0),
+            msg_pack_into(self._fmt_str, data, 0,
+                          self.ofs_nbits,
+                          self.max_len,
+                          six.binary_type(oxm_data))
+            offset = len(data)
+            msg_pack_into("!%dx" % (14 - offset), data, offset)
+            return data
+
+    class NXActionLearn(NXAction):
+        r"""
+        Adds or modifies flow action
+
+        This action adds or modifies a flow in OpenFlow table.
+
+        And equivalent to the followings action of ovs-ofctl command.
+
+        ..
+          learn(argument[,argument]...)
+        ..
+
+        +---------------------------------------------------+
+        | **learn(**\ *argument*\[,\ *argument*\]...\ **)** |
+        +---------------------------------------------------+
+
+        ================ ======================================================
+        Attribute        Description
+        ================ ======================================================
+        table_id         The table in which the new flow should be inserted
+        specs            Adds a match criterion to the new flow
+
+                         Please use the
+                         ``NXFlowSpecMatch``
+                         in order to set the following format
+
+                         ..
+                           field=value
+                           field[start..end]=src[start..end]
+                           field[start..end]
+                         ..
+
+                         | *field*\=\ *value*
+                         | *field*\ **[**\ *start*\..\ *end*\ **]**\  =\
+                         *src*\ **[**\ *start*\..\ *end*\ **]**
+                         | *field*\ **[**\ *start*\..\ *end*\ **]**
+                         |
+
+                         Please use the
+                         ``NXFlowSpecLoad``
+                         in order to set the following format
+
+                         ..
+                           load:value->dst[start..end]
+                           load:src[start..end]->dst[start..end]
+                         ..
+
+                         | **load**\:\ *value*\ **->**\ *dst*\
+                         **[**\ *start*\..\ *end*\ **]**
+                         | **load**\:\ *src*\ **[**\ *start*\..\ *end*\
+                         **] ->**\ *dst*\ **[**\ *start*\..\ *end*\ **]**
+                         |
+
+                         Please use the
+                         ``NXFlowSpecOutput``
+                         in order to set the following format
+
+                         ..
+                           output:field[start..end]
+                         ..
+
+                         | **output:**\ field\ **[**\ *start*\..\ *end*\ **]**
+
+        idle_timeout     Idle time before discarding(seconds)
+        hard_timeout     Max time before discarding(seconds)
+        priority         Priority level of flow entry
+        cookie           Cookie for new flow
+        flags            send_flow_rem
+        fin_idle_timeout Idle timeout after FIN(seconds)
+        fin_hard_timeout Hard timeout after FIN(seconds)
+        ================ ======================================================
+
+        .. CAUTION::
+            The arguments specify the flow's match fields, actions,
+            and other properties, as follows.
+            At least one match criterion and one action argument
+            should ordinarily be specified.
+
+        Example::
+
+            actions += [
+                parser.NXActionLearn(able_id=10,
+                     specs=[parser.NXFlowSpecMatch(src=0x800,
+                                                   dst=('eth_type_nxm', 0),
+                                                   n_bits=16),
+                            parser.NXFlowSpecMatch(src=('reg1', 1),
+                                                   dst=('reg2', 3),
+                                                   n_bits=5),
+                            parser.NXFlowSpecMatch(src=('reg3', 1),
+                                                   dst=('reg3', 1),
+                                                   n_bits=5),
+                            parser.NXFlowSpecLoad(src=0,
+                                                  dst=('reg4', 3),
+                                                  n_bits=5),
+                            parser.NXFlowSpecLoad(src=('reg5', 1),
+                                                  dst=('reg6', 3),
+                                                  n_bits=5),
+                            parser.NXFlowSpecOutput(src=('reg7', 1),
+                                                    dst="",
+                                                    n_bits=5)],
+                     idle_timeout=180,
+                     hard_timeout=300,
+                     priority=1,
+                     cookie=0x64,
+                     flags=ofproto.OFPFF_SEND_FLOW_REM,
+                     fin_idle_timeout=180,
+                     fin_hard_timeout=300)]
+        """
+        _subtype = nicira_ext.NXAST_LEARN
+
+        # idle_timeout, hard_timeout, priority, cookie, flags,
+        # table_id, pad, fin_idle_timeout, fin_hard_timeout
+        _fmt_str = '!HHHQHBxHH'
+        # Followed by flow_mod_specs
+
+        def __init__(self,
+                     table_id,
+                     specs,
+                     idle_timeout=0,
+                     hard_timeout=0,
+                     priority=ofp.OFP_DEFAULT_PRIORITY,
+                     cookie=0,
+                     flags=0,
+                     fin_idle_timeout=0,
+                     fin_hard_timeout=0,
+                     type_=None, len_=None, experimenter=None, subtype=None):
+            super(NXActionLearn, self).__init__()
+            self.idle_timeout = idle_timeout
+            self.hard_timeout = hard_timeout
+            self.priority = priority
+            self.cookie = cookie
+            self.flags = flags
+            self.table_id = table_id
+            self.fin_idle_timeout = fin_idle_timeout
+            self.fin_hard_timeout = fin_hard_timeout
+            self.specs = specs
+
+        @classmethod
+        def parser(cls, buf):
+            (idle_timeout,
+             hard_timeout,
+             priority,
+             cookie,
+             flags,
+             table_id,
+             fin_idle_timeout,
+             fin_hard_timeout,) = struct.unpack_from(
+                cls._fmt_str, buf, 0)
+            rest = buf[struct.calcsize(cls._fmt_str):]
+            # specs
+            specs = []
+            while len(rest) > 0:
+                spec, rest = _NXFlowSpec.parse(rest)
+                if spec is None:
+                    continue
+                specs.append(spec)
+            return cls(idle_timeout=idle_timeout,
+                       hard_timeout=hard_timeout,
+                       priority=priority,
+                       cookie=cookie,
+                       flags=flags,
+                       table_id=table_id,
+                       fin_idle_timeout=fin_idle_timeout,
+                       fin_hard_timeout=fin_hard_timeout,
+                       specs=specs)
+
+        def serialize_body(self):
+            # fixup
+            data = bytearray()
+            msg_pack_into(self._fmt_str, data, 0,
+                          self.idle_timeout,
+                          self.hard_timeout,
+                          self.priority,
+                          self.cookie,
+                          self.flags,
+                          self.table_id,
+                          self.fin_idle_timeout,
+                          self.fin_hard_timeout)
+            for spec in self.specs:
+                data += spec.serialize()
+            return data
+
+    class NXActionExit(NXAction):
+        """
+        Halt action
+
+        This action causes OpenvSwitch to immediately halt
+        execution of further actions.
+
+        And equivalent to the followings action of ovs-ofctl command.
+
+        ..
+          exit
+        ..
+
+        +----------+
+        | **exit** |
+        +----------+
+
+        Example::
+
+            actions += [parser.NXActionExit()]
+        """
+        _subtype = nicira_ext.NXAST_EXIT
+
+        _fmt_str = '!6x'
+
+        def __init__(self,
+                     type_=None, len_=None, experimenter=None, subtype=None):
+            super(NXActionExit, self).__init__()
+
+        @classmethod
+        def parser(cls, buf):
+            return cls()
+
+        def serialize_body(self):
+            data = bytearray()
+            msg_pack_into(self._fmt_str, data, 0)
+            return data
+
+    # For OpenFlow1.0 only
+    class NXActionDecTtl(NXAction):
+        """
+        Decrement IP TTL action
+
+        This action decrements TTL of IPv4 packet or
+        hop limit of IPv6 packet.
+
+        And equivalent to the followings action of ovs-ofctl command.
+
+        ..
+          dec_ttl
+        ..
+
+        +-------------+
+        | **dec_ttl** |
+        +-------------+
+
+        .. NOTE::
+            This actions is supported by
+            ``OFPActionDecNwTtl``
+            in OpenFlow1.2 or later.
+
+        Example::
+
+            actions += [parser.NXActionDecTtl()]
+        """
+        _subtype = nicira_ext.NXAST_DEC_TTL
+
+        _fmt_str = '!6x'
+
+        def __init__(self,
+                     type_=None, len_=None, vendor=None, subtype=None):
+            super(NXActionDecTtl, self).__init__()
+
+        @classmethod
+        def parser(cls, buf):
+            return cls()
+
+        def serialize_body(self):
+            data = bytearray()
+            msg_pack_into(self._fmt_str, data, 0)
+            return data
+
+    class NXActionController(NXAction):
+        r"""
+        Send packet in message action
+
+        This action sends the packet to the OpenFlow controller as
+        a packet in message.
+
+        And equivalent to the followings action of ovs-ofctl command.
+
+        ..
+          controller(key=value...)
+        ..
+
+        +----------------------------------------------+
+        | **controller(**\ *key*\=\ *value*\...\ **)** |
+        +----------------------------------------------+
+
+        ================ ======================================================
+        Attribute        Description
+        ================ ======================================================
+        max_len          Max length to send to controller
+        controller_id    Controller ID to send packet-in
+        reason           Reason for sending the message
+        ================ ======================================================
+
+        Example::
+
+            actions += [
+                parser.NXActionController(max_len=1024,
+                                          controller_id=1,
+                                          reason=ofproto.OFPR_INVALID_TTL)]
+        """
+        _subtype = nicira_ext.NXAST_CONTROLLER
+
+        # max_len, controller_id, reason
+        _fmt_str = '!HHBx'
+
+        def __init__(self,
+                     max_len,
+                     controller_id,
+                     reason,
+                     type_=None, len_=None, experimenter=None, subtype=None):
+            super(NXActionController, self).__init__()
+            self.max_len = max_len
+            self.controller_id = controller_id
+            self.reason = reason
+
+        @classmethod
+        def parser(cls, buf):
+            (max_len,
+             controller_id,
+             reason) = struct.unpack_from(
+                cls._fmt_str, buf)
+            return cls(max_len,
+                       controller_id,
+                       reason)
+
+        def serialize_body(self):
+            data = bytearray()
+            msg_pack_into(self._fmt_str, data, 0,
+                          self.max_len,
+                          self.controller_id,
+                          self.reason)
+            return data
+
+    class NXActionController2(NXAction):
+        r"""
+        Send packet in message action
+
+        This action sends the packet to the OpenFlow controller as
+        a packet in message.
+
+        And equivalent to the followings action of ovs-ofctl command.
+
+        ..
+          controller(key=value...)
+        ..
+
+        +----------------------------------------------+
+        | **controller(**\ *key*\=\ *value*\...\ **)** |
+        +----------------------------------------------+
+
+        ================ ======================================================
+        Attribute        Description
+        ================ ======================================================
+        max_len          Max length to send to controller
+        controller_id    Controller ID to send packet-in
+        reason           Reason for sending the message
+        userdata         Additional data to the controller in the packet-in
+                         message
+        pause            Flag to pause pipeline to resume later
+        ================ ======================================================
+
+        Example::
+
+            actions += [
+                parser.NXActionController(max_len=1024,
+                                          controller_id=1,
+                                          reason=ofproto.OFPR_INVALID_TTL,
+                                          userdata=[0xa,0xb,0xc],
+                                          pause=True)]
+        """
+        _subtype = nicira_ext.NXAST_CONTROLLER2
+        _fmt_str = '!6x'
+        _PACK_STR = '!HH'
+
+        def __init__(self,
+                     type_=None, len_=None, vendor=None, subtype=None,
+                     **kwargs):
+            super(NXActionController2, self).__init__()
+
+            for arg in kwargs:
+                if arg in NXActionController2Prop._NAMES:
+                    setattr(self, arg, kwargs[arg])
+
+        @classmethod
+        def parser(cls, buf):
+            cls_data = {}
+            offset = 6
+            buf_len = len(buf)
+            while buf_len > offset:
+                (type_, length) = struct.unpack_from(cls._PACK_STR, buf, offset)
+                offset += 4
+                try:
+                    subcls = NXActionController2Prop._TYPES[type_]
+                except KeyError:
+                    subcls = NXActionController2PropUnknown
+                data, size = subcls.parser_prop(buf[offset:], length - 4)
+                offset += size
+                cls_data[subcls._arg_name] = data
+            return cls(**cls_data)
+
+        def serialize_body(self):
+            body = bytearray()
+            msg_pack_into(self._fmt_str, body, 0)
+            prop_list = []
+            for arg in self.__dict__:
+                if arg in NXActionController2Prop._NAMES:
+                    prop_list.append((NXActionController2Prop._NAMES[arg],
+                                      self.__dict__[arg]))
+            prop_list.sort(key=lambda x: x[0].type)
+
+            for subcls, value in prop_list:
+                body += subcls.serialize_prop(value)
+
+            return body
+
+    class NXActionController2Prop(object):
+        _TYPES = {}
+        _NAMES = {}
+
+        @classmethod
+        def register_type(cls, type_):
+            def _register_type(subcls):
+                subcls.type = type_
+                NXActionController2Prop._TYPES[type_] = subcls
+                NXActionController2Prop._NAMES[subcls._arg_name] = subcls
+                return subcls
+
+            return _register_type
+
+    class NXActionController2PropUnknown(NXActionController2Prop):
+
+        @classmethod
+        def parser_prop(cls, buf, length):
+            size = 4
+            return buf, size
+
+        @classmethod
+        def serialize_prop(cls, argment):
+            data = bytearray()
+            return data
+
+    @NXActionController2Prop.register_type(nicira_ext.NXAC2PT_MAX_LEN)
+    class NXActionController2PropMaxLen(NXActionController2Prop):
+        # max_len
+        _fmt_str = "!H2x"
+        _arg_name = "max_len"
+
+        @classmethod
+        def parser_prop(cls, buf, length):
+            size = 4
+            (max_len,) = struct.unpack_from(
+                cls._fmt_str, buf, 0)
+            return max_len, size
+
+        @classmethod
+        def serialize_prop(cls, max_len):
+            data = bytearray()
+            msg_pack_into("!HHH2x", data, 0,
+                          nicira_ext.NXAC2PT_MAX_LEN,
+                          8,
+                          max_len)
+            return data
+
+    @NXActionController2Prop.register_type(nicira_ext.NXAC2PT_CONTROLLER_ID)
+    class NXActionController2PropControllerId(NXActionController2Prop):
+        # controller_id
+        _fmt_str = "!H2x"
+        _arg_name = "controller_id"
+
+        @classmethod
+        def parser_prop(cls, buf, length):
+            size = 4
+            (controller_id,) = struct.unpack_from(
+                cls._fmt_str, buf, 0)
+            return controller_id, size
+
+        @classmethod
+        def serialize_prop(cls, controller_id):
+            data = bytearray()
+            msg_pack_into("!HHH2x", data, 0,
+                          nicira_ext.NXAC2PT_CONTROLLER_ID,
+                          8,
+                          controller_id)
+            return data
+
+    @NXActionController2Prop.register_type(nicira_ext.NXAC2PT_REASON)
+    class NXActionController2PropReason(NXActionController2Prop):
+        # reason
+        _fmt_str = "!B3x"
+        _arg_name = "reason"
+
+        @classmethod
+        def parser_prop(cls, buf, length):
+            size = 4
+            (reason,) = struct.unpack_from(
+                cls._fmt_str, buf, 0)
+            return reason, size
+
+        @classmethod
+        def serialize_prop(cls, reason):
+            data = bytearray()
+            msg_pack_into("!HHB3x", data, 0,
+                          nicira_ext.NXAC2PT_REASON,
+                          5,
+                          reason)
+            return data
+
+    @NXActionController2Prop.register_type(nicira_ext.NXAC2PT_USERDATA)
+    class NXActionController2PropUserData(NXActionController2Prop):
+        # userdata
+        _fmt_str = "!B"
+        _arg_name = "userdata"
+
+        @classmethod
+        def parser_prop(cls, buf, length):
+            userdata = []
+            offset = 0
+
+            while offset < length:
+                u = struct.unpack_from(cls._fmt_str, buf, offset)
+                userdata.append(u[0])
+                offset += 1
+
+            user_size = utils.round_up(length, 4)
+
+            if user_size > 4 and (user_size % 8) == 0:
+                size = utils.round_up(length, 4) + 4
+            else:
+                size = utils.round_up(length, 4)
+
+            return userdata, size
+
+        @classmethod
+        def serialize_prop(cls, userdata):
+            data = bytearray()
+            user_buf = bytearray()
+            user_offset = 0
+            for user in userdata:
+                msg_pack_into('!B', user_buf, user_offset,
+                              user)
+                user_offset += 1
+
+            msg_pack_into("!HH", data, 0,
+                          nicira_ext.NXAC2PT_USERDATA,
+                          4 + user_offset)
+            data += user_buf
+
+            if user_offset > 4:
+                user_len = utils.round_up(user_offset, 4)
+                brank_size = 0
+                if (user_len % 8) == 0:
+                    brank_size = 4
+                msg_pack_into("!%dx" % (user_len - user_offset + brank_size),
+                              data, 4 + user_offset)
+            else:
+                user_len = utils.round_up(user_offset, 4)
+
+                msg_pack_into("!%dx" % (user_len - user_offset),
+                              data, 4 + user_offset)
+            return data
+
+    @NXActionController2Prop.register_type(nicira_ext.NXAC2PT_PAUSE)
+    class NXActionController2PropPause(NXActionController2Prop):
+        _arg_name = "pause"
+
+        @classmethod
+        def parser_prop(cls, buf, length):
+            pause = True
+            size = 4
+            return pause, size
+
+        @classmethod
+        def serialize_prop(cls, pause):
+            data = bytearray()
+            msg_pack_into("!HH4x", data, 0,
+                          nicira_ext.NXAC2PT_PAUSE,
+                          4)
+            return data
+
+    class NXActionDecTtlCntIds(NXAction):
+        r"""
+        Decrement TTL action
+
+        This action decrements TTL of IPv4 packet or
+        hop limits of IPv6 packet.
+
+        And equivalent to the followings action of ovs-ofctl command.
+
+        ..
+          dec_ttl(id1[,id2]...)
+        ..
+
+        +-------------------------------------------+
+        | **dec_ttl(**\ *id1*\[,\ *id2*\]...\ **)** |
+        +-------------------------------------------+
+
+        ================ ======================================================
+        Attribute        Description
+        ================ ======================================================
+        cnt_ids          Controller ids
+        ================ ======================================================
+
+        Example::
+
+            actions += [parser.NXActionDecTtlCntIds(cnt_ids=[1,2,3])]
+
+        .. NOTE::
+            If you want to set the following ovs-ofctl command.
+            Please use ``OFPActionDecNwTtl``.
+
+        +-------------+
+        | **dec_ttl** |
+        +-------------+
+        """
+        _subtype = nicira_ext.NXAST_DEC_TTL_CNT_IDS
+
+        # controllers
+        _fmt_str = '!H4x'
+        _fmt_len = 6
+
+        def __init__(self,
+                     cnt_ids,
+                     type_=None, len_=None, experimenter=None, subtype=None):
+            super(NXActionDecTtlCntIds, self).__init__()
+
+            self.cnt_ids = cnt_ids
+
+        @classmethod
+        def parser(cls, buf):
+            (controllers,) = struct.unpack_from(
+                cls._fmt_str, buf)
+
+            offset = cls._fmt_len
+            cnt_ids = []
+
+            for i in range(0, controllers):
+                id_ = struct.unpack_from('!H', buf, offset)
+                cnt_ids.append(id_[0])
+                offset += 2
+
+            return cls(cnt_ids)
+
+        def serialize_body(self):
+            assert isinstance(self.cnt_ids, (tuple, list))
+            for i in self.cnt_ids:
+                assert isinstance(i, six.integer_types)
+
+            controllers = len(self.cnt_ids)
+
+            data = bytearray()
+            msg_pack_into(self._fmt_str, data, 0,
+                          controllers)
+            offset = self._fmt_len
+
+            for id_ in self.cnt_ids:
+                msg_pack_into('!H', data, offset, id_)
+                offset += 2
+
+            id_len = (utils.round_up(controllers, 4) -
+                      controllers)
+
+            if id_len != 0:
+                msg_pack_into('%dx' % id_len * 2, data, offset)
+
+            return data
+
+    # Use in only OpenFlow1.0
+    class NXActionMplsBase(NXAction):
+        # ethertype
+        _fmt_str = '!H4x'
+
+        def __init__(self,
+                     ethertype,
+                     type_=None, len_=None, vendor=None, subtype=None):
+            super(NXActionMplsBase, self).__init__()
+            self.ethertype = ethertype
+
+        @classmethod
+        def parser(cls, buf):
+            (ethertype,) = struct.unpack_from(
+                cls._fmt_str, buf)
+            return cls(ethertype)
+
+        def serialize_body(self):
+            data = bytearray()
+            msg_pack_into(self._fmt_str, data, 0,
+                          self.ethertype)
+            return data
+
+    # For OpenFlow1.0 only
+    class NXActionPushMpls(NXActionMplsBase):
+        r"""
+        Push MPLS action
+
+        This action pushes a new MPLS header to the packet.
+
+        And equivalent to the followings action of ovs-ofctl command.
+
+        ..
+          push_mpls:ethertype
+        ..
+
+        +-------------------------------+
+        | **push_mpls**\:\ *ethertype*  |
+        +-------------------------------+
+
+        ================ ======================================================
+        Attribute        Description
+        ================ ======================================================
+        ethertype        Ether type(The value must be either 0x8847 or 0x8848)
+        ================ ======================================================
+
+        .. NOTE::
+            This actions is supported by
+            ``OFPActionPushMpls``
+            in OpenFlow1.2 or later.
+
+        Example::
+
+            match = parser.OFPMatch(dl_type=0x0800)
+            actions += [parser.NXActionPushMpls(ethertype=0x8847)]
+        """
+        _subtype = nicira_ext.NXAST_PUSH_MPLS
+
+    # For OpenFlow1.0 only
+    class NXActionPopMpls(NXActionMplsBase):
+        r"""
+        Pop MPLS action
+
+        This action pops the MPLS header from the packet.
+
+        And equivalent to the followings action of ovs-ofctl command.
+
+        ..
+          pop_mpls:ethertype
+        ..
+
+        +------------------------------+
+        | **pop_mpls**\:\ *ethertype*  |
+        +------------------------------+
+
+        ================ ======================================================
+        Attribute        Description
+        ================ ======================================================
+        ethertype        Ether type
+        ================ ======================================================
+
+        .. NOTE::
+            This actions is supported by
+            ``OFPActionPopMpls``
+            in OpenFlow1.2 or later.
+
+        Example::
+
+            match = parser.OFPMatch(dl_type=0x8847)
+            actions += [parser.NXActionPushMpls(ethertype=0x0800)]
+        """
+        _subtype = nicira_ext.NXAST_POP_MPLS
+
+    # For OpenFlow1.0 only
+    class NXActionSetMplsTtl(NXAction):
+        r"""
+        Set MPLS TTL action
+
+        This action sets the MPLS TTL.
+
+        And equivalent to the followings action of ovs-ofctl command.
+
+        ..
+          set_mpls_ttl:ttl
+        ..
+
+        +---------------------------+
+        | **set_mpls_ttl**\:\ *ttl* |
+        +---------------------------+
+
+        ================ ======================================================
+        Attribute        Description
+        ================ ======================================================
+        ttl              MPLS TTL
+        ================ ======================================================
+
+        .. NOTE::
+            This actions is supported by
+            ``OFPActionSetMplsTtl``
+            in OpenFlow1.2 or later.
+
+        Example::
+
+            actions += [parser.NXActionSetMplsTil(ttl=128)]
+        """
+        _subtype = nicira_ext.NXAST_SET_MPLS_TTL
+
+        # ethertype
+        _fmt_str = '!B5x'
+
+        def __init__(self,
+                     ttl,
+                     type_=None, len_=None, vendor=None, subtype=None):
+            super(NXActionSetMplsTtl, self).__init__()
+            self.ttl = ttl
+
+        @classmethod
+        def parser(cls, buf):
+            (ttl,) = struct.unpack_from(
+                cls._fmt_str, buf)
+            return cls(ttl)
+
+        def serialize_body(self):
+            data = bytearray()
+            msg_pack_into(self._fmt_str, data, 0,
+                          self.ttl)
+            return data
+
+    # For OpenFlow1.0 only
+    class NXActionDecMplsTtl(NXAction):
+        """
+        Decrement MPLS TTL action
+
+        This action decrements the MPLS TTL.
+
+        And equivalent to the followings action of ovs-ofctl command.
+
+        ..
+          dec_mpls_ttl
+        ..
+
+        +------------------+
+        | **dec_mpls_ttl** |
+        +------------------+
+
+        .. NOTE::
+            This actions is supported by
+            ``OFPActionDecMplsTtl``
+            in OpenFlow1.2 or later.
+
+        Example::
+
+            actions += [parser.NXActionDecMplsTil()]
+        """
+        _subtype = nicira_ext.NXAST_DEC_MPLS_TTL
+
+        # ethertype
+        _fmt_str = '!6x'
+
+        def __init__(self,
+                     type_=None, len_=None, vendor=None, subtype=None):
+            super(NXActionDecMplsTtl, self).__init__()
+
+        @classmethod
+        def parser(cls, buf):
+            return cls()
+
+        def serialize_body(self):
+            data = bytearray()
+            msg_pack_into(self._fmt_str, data, 0)
+            return data
+
+    # For OpenFlow1.0 only
+    class NXActionSetMplsLabel(NXAction):
+        r"""
+        Set MPLS Lavel action
+
+        This action sets the MPLS Label.
+
+        And equivalent to the followings action of ovs-ofctl command.
+
+        ..
+          set_mpls_label:label
+        ..
+
+        +-------------------------------+
+        | **set_mpls_label**\:\ *label* |
+        +-------------------------------+
+
+        ================ ======================================================
+        Attribute        Description
+        ================ ======================================================
+        label            MPLS Label
+        ================ ======================================================
+
+        .. NOTE::
+            This actions is supported by
+            ``OFPActionSetField(mpls_label=label)``
+            in OpenFlow1.2 or later.
+
+        Example::
+
+            actions += [parser.NXActionSetMplsLabel(label=0x10)]
+        """
+        _subtype = nicira_ext.NXAST_SET_MPLS_LABEL
+
+        # ethertype
+        _fmt_str = '!2xI'
+
+        def __init__(self,
+                     label,
+                     type_=None, len_=None, vendor=None, subtype=None):
+            super(NXActionSetMplsLabel, self).__init__()
+            self.label = label
+
+        @classmethod
+        def parser(cls, buf):
+            (label,) = struct.unpack_from(
+                cls._fmt_str, buf)
+            return cls(label)
+
+        def serialize_body(self):
+            data = bytearray()
+            msg_pack_into(self._fmt_str, data, 0,
+                          self.label)
+            return data
+
+    # For OpenFlow1.0 only
+    class NXActionSetMplsTc(NXAction):
+        r"""
+        Set MPLS Tc action
+
+        This action sets the MPLS Tc.
+
+        And equivalent to the followings action of ovs-ofctl command.
+
+        ..
+          set_mpls_tc:tc
+        ..
+
+        +-------------------------+
+        | **set_mpls_tc**\:\ *tc* |
+        +-------------------------+
+
+        ================ ======================================================
+        Attribute        Description
+        ================ ======================================================
+        tc               MPLS Tc
+        ================ ======================================================
+
+        .. NOTE::
+            This actions is supported by
+            ``OFPActionSetField(mpls_label=tc)``
+            in OpenFlow1.2 or later.
+
+        Example::
+
+            actions += [parser.NXActionSetMplsLabel(tc=0x10)]
+        """
+        _subtype = nicira_ext.NXAST_SET_MPLS_TC
+
+        # ethertype
+        _fmt_str = '!B5x'
+
+        def __init__(self,
+                     tc,
+                     type_=None, len_=None, vendor=None, subtype=None):
+            super(NXActionSetMplsTc, self).__init__()
+            self.tc = tc
+
+        @classmethod
+        def parser(cls, buf):
+            (tc,) = struct.unpack_from(
+                cls._fmt_str, buf)
+            return cls(tc)
+
+        def serialize_body(self):
+            data = bytearray()
+            msg_pack_into(self._fmt_str, data, 0,
+                          self.tc)
+            return data
+
+    class NXActionStackBase(NXAction):
+        # start, field, end
+        _fmt_str = '!H4sH'
+        _TYPE = {
+            'ascii': [
+                'field',
+            ]
+        }
+
+        def __init__(self,
+                     field,
+                     start,
+                     end,
+                     type_=None, len_=None, experimenter=None, subtype=None):
+            super(NXActionStackBase, self).__init__()
+            self.field = field
+            self.start = start
+            self.end = end
+
+        @classmethod
+        def parser(cls, buf):
+            (start, oxm_data, end) = struct.unpack_from(
+                cls._fmt_str, buf, 0)
+            (n, len_) = ofp.oxm_parse_header(oxm_data, 0)
+            field = ofp.oxm_to_user_header(n)
+            return cls(field, start, end)
+
+        def serialize_body(self):
+            data = bytearray()
+            oxm_data = bytearray()
+            oxm = ofp.oxm_from_user_header(self.field)
+            ofp.oxm_serialize_header(oxm, oxm_data, 0)
+            msg_pack_into(self._fmt_str, data, 0,
+                          self.start,
+                          six.binary_type(oxm_data),
+                          self.end)
+            offset = len(data)
+            msg_pack_into("!%dx" % (12 - offset), data, offset)
+            return data
+
+    class NXActionStackPush(NXActionStackBase):
+        r"""
+        Push field action
+
+        This action pushes field to top of the stack.
+
+        And equivalent to the followings action of ovs-ofctl command.
+
+        ..
+          pop:dst[start...end]
+        ..
+
+        +----------------------------------------------------+
+        | **pop**\:\ *dst*\ **[**\ *start*\...\ *end*\ **]** |
+        +----------------------------------------------------+
+
+        ================ ======================================================
+        Attribute        Description
+        ================ ======================================================
+        field            OXM/NXM header for source field
+        start            Start bit for source field
+        end              End bit for source field
+        ================ ======================================================
+
+        Example::
+
+            actions += [parser.NXActionStackPush(field="reg2",
+                                                 start=0,
+                                                 end=5)]
+        """
+        _subtype = nicira_ext.NXAST_STACK_PUSH
+
+    class NXActionStackPop(NXActionStackBase):
+        r"""
+        Pop field action
+
+        This action pops field from top of the stack.
+
+        And equivalent to the followings action of ovs-ofctl command.
+
+        ..
+          pop:src[start...end]
+        ..
+
+        +----------------------------------------------------+
+        | **pop**\:\ *src*\ **[**\ *start*\...\ *end*\ **]** |
+        +----------------------------------------------------+
+
+        ================ ======================================================
+        Attribute        Description
+        ================ ======================================================
+        field            OXM/NXM header for destination field
+        start            Start bit for destination field
+        end              End bit for destination field
+        ================ ======================================================
+
+        Example::
+
+            actions += [parser.NXActionStackPop(field="reg2",
+                                                start=0,
+                                                end=5)]
+        """
+        _subtype = nicira_ext.NXAST_STACK_POP
+
+    class NXActionSample(NXAction):
+        r"""
+        Sample packets action
+
+        This action samples packets and sends one sample for
+        every sampled packet.
+
+        And equivalent to the followings action of ovs-ofctl command.
+
+        ..
+          sample(argument[,argument]...)
+        ..
+
+        +----------------------------------------------------+
+        | **sample(**\ *argument*\[,\ *argument*\]...\ **)** |
+        +----------------------------------------------------+
+
+        ================ ======================================================
+        Attribute        Description
+        ================ ======================================================
+        probability      The number of sampled packets
+        collector_set_id The unsigned 32-bit integer identifier of
+                         the set of sample collectors to send sampled packets
+                         to
+        obs_domain_id    The Unsigned 32-bit integer Observation Domain ID
+        obs_point_id     The unsigned 32-bit integer Observation Point ID
+        ================ ======================================================
+
+        Example::
+
+            actions += [parser.NXActionSample(probability=3,
+                                              collector_set_id=1,
+                                              obs_domain_id=2,
+                                              obs_point_id=3,)]
+        """
+        _subtype = nicira_ext.NXAST_SAMPLE
+
+        # probability, collector_set_id, obs_domain_id, obs_point_id
+        _fmt_str = '!HIII'
+
+        def __init__(self,
+                     probability,
+                     collector_set_id=0,
+                     obs_domain_id=0,
+                     obs_point_id=0,
+                     type_=None, len_=None, experimenter=None, subtype=None):
+            super(NXActionSample, self).__init__()
+            self.probability = probability
+            self.collector_set_id = collector_set_id
+            self.obs_domain_id = obs_domain_id
+            self.obs_point_id = obs_point_id
+
+        @classmethod
+        def parser(cls, buf):
+            (probability,
+             collector_set_id,
+             obs_domain_id,
+             obs_point_id) = struct.unpack_from(
+                cls._fmt_str, buf, 0)
+            return cls(probability,
+                       collector_set_id,
+                       obs_domain_id,
+                       obs_point_id)
+
+        def serialize_body(self):
+            data = bytearray()
+            msg_pack_into(self._fmt_str, data, 0,
+                          self.probability,
+                          self.collector_set_id,
+                          self.obs_domain_id,
+                          self.obs_point_id)
+            return data
+
+    class NXActionSample2(NXAction):
+        r"""
+        Sample packets action
+
+        This action samples packets and sends one sample for
+        every sampled packet.
+        'sampling_port' can be equal to ingress port or one of egress ports.
+
+        And equivalent to the followings action of ovs-ofctl command.
+
+        ..
+          sample(argument[,argument]...)
+        ..
+
+        +----------------------------------------------------+
+        | **sample(**\ *argument*\[,\ *argument*\]...\ **)** |
+        +----------------------------------------------------+
+
+        ================ ======================================================
+        Attribute        Description
+        ================ ======================================================
+        probability      The number of sampled packets
+        collector_set_id The unsigned 32-bit integer identifier of
+                         the set of sample collectors to send sampled packets to
+        obs_domain_id    The Unsigned 32-bit integer Observation Domain ID
+        obs_point_id     The unsigned 32-bit integer Observation Point ID
+        sampling_port    Sampling port number
+        ================ ======================================================
+
+        Example::
+
+            actions += [parser.NXActionSample2(probability=3,
+                                               collector_set_id=1,
+                                               obs_domain_id=2,
+                                               obs_point_id=3,
+                                               apn_mac_addr=0a:00:27:00:00:05,
+                                               msisdn=magmaIsTheBest,
+                                               apn_name=big_tower123,
+                                               pdp_start_epoch=100,
+                                               sampling_port=8080)]
+        """
+        _subtype = nicira_ext.NXAST_SAMPLE2
+
+        # probability, collector_set_id, obs_domain_id,
+        # obs_point_id, msisdn, apn_mac_addr, apn_name, sampling_port
+        _fmt_str = '!HIIIH16s6B24s8s6x'
+
+        def __init__(self,
+                     probability,
+                     msisdn,
+                     apn_mac_addr,
+                     apn_name,
+                     pdp_start_epoch,
+                     collector_set_id=0,
+                     obs_domain_id=0,
+                     obs_point_id=0,
+                     sampling_port=0,
+                     type_=None, len_=None, experimenter=None, subtype=None):
+            super(NXActionSample2, self).__init__()
+            self.probability = probability
+            self.collector_set_id = collector_set_id
+            self.obs_domain_id = obs_domain_id
+            self.obs_point_id = obs_point_id
+            self.sampling_port = sampling_port
+
+            self.msisdn = msisdn.encode('ascii')
+            self.apn_mac_addr = apn_mac_addr
+            self.apn_name = apn_name.encode('ascii')
+            self.pdp_start_epoch = pdp_start_epoch.to_bytes(8, byteorder='little')
+
+
+        @classmethod
+        def parser(cls, buf):
+            (probability,
+             collector_set_id,
+             obs_domain_id,
+             obs_point_id,
+             sampling_port,
+             msisdn,
+             apn_mac_addr,
+             apn_name,
+             pdp_start_epoch) = struct.unpack_from(
+                cls._fmt_str, buf, 0)
+
+            return cls(probability,
+                       msisdn,
+                       apn_mac_addr,
+                       apn_name,
+                       pdp_start_epoch,
+                       collector_set_id,
+                       obs_domain_id,
+                       obs_point_id,
+                       sampling_port)
+
+        def serialize_body(self):
+            data = bytearray()
+            msg_pack_into(self._fmt_str, data, 0,
+                          self.probability,
+                          self.collector_set_id,
+                          self.obs_domain_id,
+                          self.obs_point_id,
+                          self.sampling_port,
+                          self.msisdn,
+                          *self.apn_mac_addr,
+                          self.apn_name,
+                          self.pdp_start_epoch)
+
+            return data
+
+    class NXActionFinTimeout(NXAction):
+        r"""
+        Change TCP timeout action
+
+        This action changes the idle timeout or hard timeout or
+        both, of this OpenFlow rule when the rule matches a TCP
+        packet with the FIN or RST flag.
+
+        And equivalent to the followings action of ovs-ofctl command.
+
+        ..
+          fin_timeout(argument[,argument]...)
+        ..
+
+        +---------------------------------------------------------+
+        | **fin_timeout(**\ *argument*\[,\ *argument*\]...\ **)** |
+        +---------------------------------------------------------+
+
+        ================ ======================================================
+        Attribute        Description
+        ================ ======================================================
+        fin_idle_timeout Causes the flow to expire after the given number
+                         of seconds of inactivity
+        fin_idle_timeout Causes the flow to expire after the given number
+                         of second, regardless of activity
+        ================ ======================================================
+
+        Example::
+
+            match = parser.OFPMatch(ip_proto=6, eth_type=0x0800)
+            actions += [parser.NXActionFinTimeout(fin_idle_timeout=30,
+                                                  fin_hard_timeout=60)]
+        """
+        _subtype = nicira_ext.NXAST_FIN_TIMEOUT
+
+        # fin_idle_timeout, fin_hard_timeout
+        _fmt_str = '!HH2x'
+
+        def __init__(self,
+                     fin_idle_timeout,
+                     fin_hard_timeout,
+                     type_=None, len_=None, experimenter=None, subtype=None):
+            super(NXActionFinTimeout, self).__init__()
+            self.fin_idle_timeout = fin_idle_timeout
+            self.fin_hard_timeout = fin_hard_timeout
+
+        @classmethod
+        def parser(cls, buf):
+            (fin_idle_timeout,
+             fin_hard_timeout) = struct.unpack_from(
+                cls._fmt_str, buf, 0)
+            return cls(fin_idle_timeout,
+                       fin_hard_timeout)
+
+        def serialize_body(self):
+            data = bytearray()
+            msg_pack_into(self._fmt_str, data, 0,
+                          self.fin_idle_timeout,
+                          self.fin_hard_timeout)
+            return data
+
+    class NXActionConjunction(NXAction):
+        r"""
+        Conjunctive matches action
+
+        This action ties groups of individual OpenFlow flows into
+        higher-level conjunctive flows.
+        Please refer to the ovs-ofctl command manual for details.
+
+        And equivalent to the followings action of ovs-ofctl command.
+
+        ..
+          conjunction(id,k/n)
+        ..
+
+        +--------------------------------------------------+
+        | **conjunction(**\ *id*\,\ *k*\ **/**\ *n*\ **)** |
+        +--------------------------------------------------+
+
+        ================ ======================================================
+        Attribute        Description
+        ================ ======================================================
+        clause           Number assigned to the flow's dimension
+        n_clauses        Specify the conjunctive flow's match condition
+        id\_             Conjunction ID
+        ================ ======================================================
+
+        Example::
+
+            actions += [parser.NXActionConjunction(clause=1,
+                                                   n_clauses=2,
+                                                   id_=10)]
+        """
+        _subtype = nicira_ext.NXAST_CONJUNCTION
+
+        # clause, n_clauses, id
+        _fmt_str = '!BBI'
+
+        def __init__(self,
+                     clause,
+                     n_clauses,
+                     id_,
+                     type_=None, len_=None, experimenter=None, subtype=None):
+            super(NXActionConjunction, self).__init__()
+            self.clause = clause
+            self.n_clauses = n_clauses
+            self.id = id_
+
+        @classmethod
+        def parser(cls, buf):
+            (clause,
+             n_clauses,
+             id_,) = struct.unpack_from(
+                cls._fmt_str, buf, 0)
+            return cls(clause, n_clauses, id_)
+
+        def serialize_body(self):
+            data = bytearray()
+            msg_pack_into(self._fmt_str, data, 0,
+                          self.clause,
+                          self.n_clauses,
+                          self.id)
+            return data
+
+    class NXActionMultipath(NXAction):
+        r"""
+        Select multipath link action
+
+        This action selects multipath link based on the specified parameters.
+        Please refer to the ovs-ofctl command manual for details.
+
+        And equivalent to the followings action of ovs-ofctl command.
+
+        ..
+          multipath(fields, basis, algorithm, n_links, arg, dst[start..end])
+        ..
+
+        +-------------------------------------------------------------+
+        | **multipath(**\ *fields*\, \ *basis*\, \ *algorithm*\,      |
+        | *n_links*\, \ *arg*\, \ *dst*\[\ *start*\..\ *end*\]\ **)** |
+        +-------------------------------------------------------------+
+
+        ================ ======================================================
+        Attribute        Description
+        ================ ======================================================
+        fields           One of NX_HASH_FIELDS_*
+        basis            Universal hash parameter
+        algorithm        One of NX_MP_ALG_*.
+        max_link         Number of output links
+        arg              Algorithm-specific argument
+        ofs_nbits        Start and End for the OXM/NXM field.
+                         Setting method refer to the ``nicira_ext.ofs_nbits``
+        dst              OXM/NXM header for source field
+        ================ ======================================================
+
+        Example::
+
+            actions += [parser.NXActionMultipath(
+                            fields=nicira_ext.NX_HASH_FIELDS_SYMMETRIC_L4,
+                            basis=1024,
+                            algorithm=nicira_ext.NX_MP_ALG_HRW,
+                            max_link=5,
+                            arg=0,
+                            ofs_nbits=nicira_ext.ofs_nbits(4, 31),
+                            dst="reg2")]
+        """
+        _subtype = nicira_ext.NXAST_MULTIPATH
+
+        # fields, basis, algorithm, max_link,
+        # arg, ofs_nbits, dst
+        _fmt_str = '!HH2xHHI2xH4s'
+        _TYPE = {
+            'ascii': [
+                'dst',
+            ]
+        }
+
+        def __init__(self,
+                     fields,
+                     basis,
+                     algorithm,
+                     max_link,
+                     arg,
+                     ofs_nbits,
+                     dst,
+                     type_=None, len_=None, experimenter=None, subtype=None):
+            super(NXActionMultipath, self).__init__()
+            self.fields = fields
+            self.basis = basis
+            self.algorithm = algorithm
+            self.max_link = max_link
+            self.arg = arg
+            self.ofs_nbits = ofs_nbits
+            self.dst = dst
+
+        @classmethod
+        def parser(cls, buf):
+            (fields,
+             basis,
+             algorithm,
+             max_link,
+             arg,
+             ofs_nbits,
+             oxm_data) = struct.unpack_from(
+                cls._fmt_str, buf, 0)
+            (n, len_) = ofp.oxm_parse_header(oxm_data, 0)
+            dst = ofp.oxm_to_user_header(n)
+            return cls(fields,
+                       basis,
+                       algorithm,
+                       max_link,
+                       arg,
+                       ofs_nbits,
+                       dst)
+
+        def serialize_body(self):
+            data = bytearray()
+            dst = bytearray()
+            oxm = ofp.oxm_from_user_header(self.dst)
+            ofp.oxm_serialize_header(oxm, dst, 0),
+            msg_pack_into(self._fmt_str, data, 0,
+                          self.fields,
+                          self.basis,
+                          self.algorithm,
+                          self.max_link,
+                          self.arg,
+                          self.ofs_nbits,
+                          six.binary_type(dst))
+
+            return data
+
+    class _NXActionBundleBase(NXAction):
+        # algorithm, fields, basis, slave_type, n_slaves
+        # ofs_nbits
+        _fmt_str = '!HHHIHH'
+
+        def __init__(self, algorithm, fields, basis, slave_type, n_slaves,
+                     ofs_nbits, dst, slaves):
+            super(_NXActionBundleBase, self).__init__()
+            self.len = utils.round_up(
+                nicira_ext.NX_ACTION_BUNDLE_0_SIZE + len(slaves) * 2, 8)
+
+            self.algorithm = algorithm
+            self.fields = fields
+            self.basis = basis
+            self.slave_type = slave_type
+            self.n_slaves = n_slaves
+            self.ofs_nbits = ofs_nbits
+            self.dst = dst
+
+            assert isinstance(slaves, (list, tuple))
+            for s in slaves:
+                assert isinstance(s, six.integer_types)
+
+            self.slaves = slaves
+
+        @classmethod
+        def parser(cls, buf):
+            # Add dst ('I') to _fmt_str
+            (algorithm, fields, basis,
+             slave_type, n_slaves, ofs_nbits, dst) = struct.unpack_from(
+                cls._fmt_str + 'I', buf, 0)
+
+            offset = (nicira_ext.NX_ACTION_BUNDLE_0_SIZE -
+                      nicira_ext.NX_ACTION_HEADER_0_SIZE - 8)
+
+            if dst != 0:
+                (n, len_) = ofp.oxm_parse_header(buf, offset)
+                dst = ofp.oxm_to_user_header(n)
+
+            slave_offset = (nicira_ext.NX_ACTION_BUNDLE_0_SIZE -
+                            nicira_ext.NX_ACTION_HEADER_0_SIZE)
+
+            slaves = []
+            for i in range(0, n_slaves):
+                s = struct.unpack_from('!H', buf, slave_offset)
+                slaves.append(s[0])
+                slave_offset += 2
+
+            return cls(algorithm, fields, basis, slave_type,
+                       n_slaves, ofs_nbits, dst, slaves)
+
+        def serialize_body(self):
+            data = bytearray()
+            slave_offset = (nicira_ext.NX_ACTION_BUNDLE_0_SIZE -
+                            nicira_ext.NX_ACTION_HEADER_0_SIZE)
+            self.n_slaves = len(self.slaves)
+            for s in self.slaves:
+                msg_pack_into('!H', data, slave_offset, s)
+                slave_offset += 2
+            pad_len = (utils.round_up(self.n_slaves, 4) -
+                       self.n_slaves)
+
+            if pad_len != 0:
+                msg_pack_into('%dx' % pad_len * 2, data, slave_offset)
+
+            msg_pack_into(self._fmt_str, data, 0,
+                          self.algorithm, self.fields, self.basis,
+                          self.slave_type, self.n_slaves,
+                          self.ofs_nbits)
+            offset = (nicira_ext.NX_ACTION_BUNDLE_0_SIZE -
+                      nicira_ext.NX_ACTION_HEADER_0_SIZE - 8)
+
+            if self.dst == 0:
+                msg_pack_into('I', data, offset, self.dst)
+            else:
+                oxm_data = ofp.oxm_from_user_header(self.dst)
+                ofp.oxm_serialize_header(oxm_data, data, offset)
+            return data
+
+    class NXActionBundle(_NXActionBundleBase):
+        r"""
+        Select bundle link action
+
+        This action selects bundle link based on the specified parameters.
+        Please refer to the ovs-ofctl command manual for details.
+
+        And equivalent to the followings action of ovs-ofctl command.
+
+        ..
+          bundle(fields, basis, algorithm, slave_type, slaves:[ s1, s2,...])
+        ..
+
+        +-----------------------------------------------------------+
+        | **bundle(**\ *fields*\, \ *basis*\, \ *algorithm*\,       |
+        | *slave_type*\, \ *slaves*\:[ \ *s1*\, \ *s2*\,...]\ **)** |
+        +-----------------------------------------------------------+
+
+        ================ ======================================================
+        Attribute        Description
+        ================ ======================================================
+        algorithm        One of NX_MP_ALG_*.
+        fields           One of NX_HASH_FIELDS_*
+        basis            Universal hash parameter
+        slave_type       Type of slaves(must be NXM_OF_IN_PORT)
+        n_slaves         Number of slaves
+        ofs_nbits        Start and End for the OXM/NXM field. (must be zero)
+        dst              OXM/NXM header for source field(must be zero)
+        slaves           List of slaves
+        ================ ======================================================
+
+
+        Example::
+
+            actions += [parser.NXActionBundle(
+                            algorithm=nicira_ext.NX_MP_ALG_HRW,
+                            fields=nicira_ext.NX_HASH_FIELDS_ETH_SRC,
+                            basis=0,
+                            slave_type=nicira_ext.NXM_OF_IN_PORT,
+                            n_slaves=2,
+                            ofs_nbits=0,
+                            dst=0,
+                            slaves=[2, 3])]
+        """
+        _subtype = nicira_ext.NXAST_BUNDLE
+
+        def __init__(self, algorithm, fields, basis, slave_type, n_slaves,
+                     ofs_nbits, dst, slaves):
+            # NXAST_BUNDLE actions should have 'sofs_nbits' and 'dst' zeroed.
+            super(NXActionBundle, self).__init__(
+                algorithm, fields, basis, slave_type, n_slaves,
+                ofs_nbits=0, dst=0, slaves=slaves)
+
+    class NXActionBundleLoad(_NXActionBundleBase):
+        r"""
+        Select bundle link action
+
+        This action has the same behavior as the bundle action,
+        with one exception.
+        Please refer to the ovs-ofctl command manual for details.
+
+        And equivalent to the followings action of ovs-ofctl command.
+
+        ..
+          bundle_load(fields, basis, algorithm, slave_type,
+                      dst[start..end], slaves:[ s1, s2,...])
+        ..
+
+        +-----------------------------------------------------------+
+        | **bundle_load(**\ *fields*\, \ *basis*\, \ *algorithm*\,  |
+        | *slave_type*\, \ *dst*\[\ *start*\... \*emd*\],           |
+        | \ *slaves*\:[ \ *s1*\, \ *s2*\,...]\ **)** |              |
+        +-----------------------------------------------------------+
+
+        ================ ======================================================
+        Attribute        Description
+        ================ ======================================================
+        algorithm        One of NX_MP_ALG_*.
+        fields           One of NX_HASH_FIELDS_*
+        basis            Universal hash parameter
+        slave_type       Type of slaves(must be NXM_OF_IN_PORT)
+        n_slaves         Number of slaves
+        ofs_nbits        Start and End for the OXM/NXM field.
+                         Setting method refer to the ``nicira_ext.ofs_nbits``
+        dst              OXM/NXM header for source field
+        slaves           List of slaves
+        ================ ======================================================
+
+
+        Example::
+
+            actions += [parser.NXActionBundleLoad(
+                            algorithm=nicira_ext.NX_MP_ALG_HRW,
+                            fields=nicira_ext.NX_HASH_FIELDS_ETH_SRC,
+                            basis=0,
+                            slave_type=nicira_ext.NXM_OF_IN_PORT,
+                            n_slaves=2,
+                            ofs_nbits=nicira_ext.ofs_nbits(4, 31),
+                            dst="reg0",
+                            slaves=[2, 3])]
+        """
+        _subtype = nicira_ext.NXAST_BUNDLE_LOAD
+        _TYPE = {
+            'ascii': [
+                'dst',
+            ]
+        }
+
+        def __init__(self, algorithm, fields, basis, slave_type, n_slaves,
+                     ofs_nbits, dst, slaves):
+            super(NXActionBundleLoad, self).__init__(
+                algorithm, fields, basis, slave_type, n_slaves,
+                ofs_nbits, dst, slaves)
+
+    class NXActionCT(NXAction):
+        r"""
+        Pass traffic to the connection tracker action
+
+        This action sends the packet through the connection tracker.
+
+        And equivalent to the followings action of ovs-ofctl command.
+
+        ..
+          ct(argument[,argument]...)
+        ..
+
+        +------------------------------------------------+
+        | **ct(**\ *argument*\[,\ *argument*\]...\ **)** |
+        +------------------------------------------------+
+
+        ================ ======================================================
+        Attribute        Description
+        ================ ======================================================
+        flags            Zero or more(Unspecified flag bits must be zero.)
+        zone_src         OXM/NXM header for source field
+        zone_ofs_nbits   Start and End for the OXM/NXM field.
+                         Setting method refer to the ``nicira_ext.ofs_nbits``.
+                         If you need set the Immediate value for zone,
+                         zone_src must be set to None or empty character string.
+        recirc_table     Recirculate to a specific table
+        alg              Well-known port number for the protocol
+        actions          Zero or more actions may immediately follow this
+                         action
+        ================ ======================================================
+
+        .. NOTE::
+
+            If you set number to zone_src,
+            Traceback occurs when you run the to_jsondict.
+
+        Example::
+
+            match = parser.OFPMatch(eth_type=0x0800, ct_state=(0,32))
+            actions += [parser.NXActionCT(
+                            flags = 1,
+                            zone_src = "reg0",
+                            zone_ofs_nbits = nicira_ext.ofs_nbits(4, 31),
+                            recirc_table = 4,
+                            alg = 0,
+                            actions = [])]
+        """
+        _subtype = nicira_ext.NXAST_CT
+
+        # flags, zone_src, zone_ofs_nbits, recirc_table,
+        # pad, alg
+        _fmt_str = '!H4sHB3xH'
+        _TYPE = {
+            'ascii': [
+                'zone_src',
+            ]
+        }
+
+        # Followed by actions
+
+        def __init__(self,
+                     flags,
+                     zone_src,
+                     zone_ofs_nbits,
+                     recirc_table,
+                     alg,
+                     actions,
+                     type_=None, len_=None, experimenter=None, subtype=None):
+            super(NXActionCT, self).__init__()
+            self.flags = flags
+            self.zone_src = zone_src
+            self.zone_ofs_nbits = zone_ofs_nbits
+            self.recirc_table = recirc_table
+            self.alg = alg
+            self.actions = actions
+
+        @classmethod
+        def parser(cls, buf):
+            (flags,
+             oxm_data,
+             zone_ofs_nbits,
+             recirc_table,
+             alg,) = struct.unpack_from(
+                cls._fmt_str, buf, 0)
+            rest = buf[struct.calcsize(cls._fmt_str):]
+
+            # OXM/NXM field
+            if oxm_data == b'\x00' * 4:
+                zone_src = ""
+            else:
+                (n, len_) = ofp.oxm_parse_header(oxm_data, 0)
+                zone_src = ofp.oxm_to_user_header(n)
+
+            # actions
+            actions = []
+            while len(rest) > 0:
+                action = ofpp.OFPAction.parser(rest, 0)
+                actions.append(action)
+                rest = rest[action.len:]
+
+            return cls(flags, zone_src, zone_ofs_nbits, recirc_table,
+                       alg, actions)
+
+        def serialize_body(self):
+            data = bytearray()
+            # If zone_src is zero, zone_ofs_nbits is zone_imm
+            if not self.zone_src:
+                zone_src = b'\x00' * 4
+            elif isinstance(self.zone_src, six.integer_types):
+                zone_src = struct.pack("!I", self.zone_src)
+            else:
+                zone_src = bytearray()
+                oxm = ofp.oxm_from_user_header(self.zone_src)
+                ofp.oxm_serialize_header(oxm, zone_src, 0)
+
+            msg_pack_into(self._fmt_str, data, 0,
+                          self.flags,
+                          six.binary_type(zone_src),
+                          self.zone_ofs_nbits,
+                          self.recirc_table,
+                          self.alg)
+            for a in self.actions:
+                a.serialize(data, len(data))
+            return data
+
+    class NXActionCTClear(NXAction):
+        """
+        Clear connection tracking state action
+
+        This action clears connection tracking state from packets.
+
+        And equivalent to the followings action of ovs-ofctl command.
+
+        ..
+          ct_clear
+        ..
+
+        +--------------+
+        | **ct_clear** |
+        +--------------+
+
+        Example::
+
+            actions += [parser.NXActionCTClear()]
+        """
+        _subtype = nicira_ext.NXAST_CT_CLEAR
+
+        _fmt_str = '!6x'
+
+        def __init__(self,
+                     type_=None, len_=None, experimenter=None, subtype=None):
+            super(NXActionCTClear, self).__init__()
+
+        @classmethod
+        def parser(cls, buf):
+            return cls()
+
+        def serialize_body(self):
+            data = bytearray()
+            msg_pack_into(self._fmt_str, data, 0)
+            return data
+
+    class NXActionNAT(NXAction):
+        r"""
+        Network address translation action
+
+        This action sends the packet through the connection tracker.
+
+        And equivalent to the followings action of ovs-ofctl command.
+
+        .. NOTE::
+            The following command image does not exist in ovs-ofctl command
+            manual and has been created from the command response.
+
+        ..
+          nat(src=ip_min-ip_max : proto_min-proto-max)
+        ..
+
+        +--------------------------------------------------+
+        | **nat(src**\=\ *ip_min*\ **-**\ *ip_max*\  **:** |
+        | *proto_min*\ **-**\ *proto-max*\ **)**           |
+        +--------------------------------------------------+
+
+        ================ ======================================================
+        Attribute        Description
+        ================ ======================================================
+        flags            Zero or more(Unspecified flag bits must be zero.)
+        range_ipv4_min   Range ipv4 address minimun
+        range_ipv4_max   Range ipv4 address maximun
+        range_ipv6_min   Range ipv6 address minimun
+        range_ipv6_max   Range ipv6 address maximun
+        range_proto_min  Range protocol minimum
+        range_proto_max  Range protocol maximun
+        ================ ======================================================
+
+        .. CAUTION::
+            ``NXActionNAT`` must be defined in the actions in the
+            ``NXActionCT``.
+
+        Example::
+
+            match = parser.OFPMatch(eth_type=0x0800)
+            actions += [
+                parser.NXActionCT(
+                    flags = 1,
+                    zone_src = "reg0",
+                    zone_ofs_nbits = nicira_ext.ofs_nbits(4, 31),
+                    recirc_table = 255,
+                    alg = 0,
+                    actions = [
+                        parser.NXActionNAT(
+                            flags = 1,
+                            range_ipv4_min = "10.1.12.0",
+                            range_ipv4_max = "10.1.13.255",
+                            range_ipv6_min = "",
+                            range_ipv6_max = "",
+                            range_proto_min = 1,
+                            range_proto_max = 1023
+                        )
+                    ]
+                )
+            ]
+        """
+        _subtype = nicira_ext.NXAST_NAT
+
+        # pad, flags, range_present
+        _fmt_str = '!2xHH'
+        # Followed by optional parameters
+
+        _TYPE = {
+            'ascii': [
+                'range_ipv4_max',
+                'range_ipv4_min',
+                'range_ipv6_max',
+                'range_ipv6_min',
+            ]
+        }
+
+        def __init__(self,
+                     flags,
+                     range_ipv4_min='',
+                     range_ipv4_max='',
+                     range_ipv6_min='',
+                     range_ipv6_max='',
+                     range_proto_min=None,
+                     range_proto_max=None,
+                     type_=None, len_=None, experimenter=None, subtype=None):
+            super(NXActionNAT, self).__init__()
+            self.flags = flags
+            self.range_ipv4_min = range_ipv4_min
+            self.range_ipv4_max = range_ipv4_max
+            self.range_ipv6_min = range_ipv6_min
+            self.range_ipv6_max = range_ipv6_max
+            self.range_proto_min = range_proto_min
+            self.range_proto_max = range_proto_max
+
+        @classmethod
+        def parser(cls, buf):
+            (flags,
+             range_present) = struct.unpack_from(
+                cls._fmt_str, buf, 0)
+            rest = buf[struct.calcsize(cls._fmt_str):]
+            # optional parameters
+            kwargs = dict()
+            if range_present & nicira_ext.NX_NAT_RANGE_IPV4_MIN:
+                kwargs['range_ipv4_min'] = type_desc.IPv4Addr.to_user(rest[:4])
+                rest = rest[4:]
+            if range_present & nicira_ext.NX_NAT_RANGE_IPV4_MAX:
+                kwargs['range_ipv4_max'] = type_desc.IPv4Addr.to_user(rest[:4])
+                rest = rest[4:]
+            if range_present & nicira_ext.NX_NAT_RANGE_IPV6_MIN:
+                kwargs['range_ipv6_min'] = (
+                    type_desc.IPv6Addr.to_user(rest[:16]))
+                rest = rest[16:]
+            if range_present & nicira_ext.NX_NAT_RANGE_IPV6_MAX:
+                kwargs['range_ipv6_max'] = (
+                    type_desc.IPv6Addr.to_user(rest[:16]))
+                rest = rest[16:]
+            if range_present & nicira_ext.NX_NAT_RANGE_PROTO_MIN:
+                kwargs['range_proto_min'] = type_desc.Int2.to_user(rest[:2])
+                rest = rest[2:]
+            if range_present & nicira_ext.NX_NAT_RANGE_PROTO_MAX:
+                kwargs['range_proto_max'] = type_desc.Int2.to_user(rest[:2])
+
+            return cls(flags, **kwargs)
+
+        def serialize_body(self):
+            # Pack optional parameters first, as range_present needs
+            # to be calculated.
+            optional_data = b''
+            range_present = 0
+            if self.range_ipv4_min != '':
+                range_present |= nicira_ext.NX_NAT_RANGE_IPV4_MIN
+                optional_data += type_desc.IPv4Addr.from_user(
+                    self.range_ipv4_min)
+            if self.range_ipv4_max != '':
+                range_present |= nicira_ext.NX_NAT_RANGE_IPV4_MAX
+                optional_data += type_desc.IPv4Addr.from_user(
+                    self.range_ipv4_max)
+            if self.range_ipv6_min != '':
+                range_present |= nicira_ext.NX_NAT_RANGE_IPV6_MIN
+                optional_data += type_desc.IPv6Addr.from_user(
+                    self.range_ipv6_min)
+            if self.range_ipv6_max != '':
+                range_present |= nicira_ext.NX_NAT_RANGE_IPV6_MAX
+                optional_data += type_desc.IPv6Addr.from_user(
+                    self.range_ipv6_max)
+            if self.range_proto_min is not None:
+                range_present |= nicira_ext.NX_NAT_RANGE_PROTO_MIN
+                optional_data += type_desc.Int2.from_user(
+                    self.range_proto_min)
+            if self.range_proto_max is not None:
+                range_present |= nicira_ext.NX_NAT_RANGE_PROTO_MAX
+                optional_data += type_desc.Int2.from_user(
+                    self.range_proto_max)
+
+            data = bytearray()
+            msg_pack_into(self._fmt_str, data, 0,
+                          self.flags,
+                          range_present)
+            msg_pack_into('!%ds' % len(optional_data), data, len(data),
+                          optional_data)
+
+            return data
+
+    class NXActionOutputTrunc(NXAction):
+        r"""
+        Truncate output action
+
+        This action truncate a packet into the specified size and outputs it.
+
+        And equivalent to the followings action of ovs-ofctl command.
+
+        ..
+          output(port=port,max_len=max_len)
+        ..
+
+        +--------------------------------------------------------------+
+        | **output(port**\=\ *port*\,\ **max_len**\=\ *max_len*\ **)** |
+        +--------------------------------------------------------------+
+
+        ================ ======================================================
+        Attribute        Description
+        ================ ======================================================
+        port             Output port
+        max_len          Max bytes to send
+        ================ ======================================================
+
+        Example::
+
+            actions += [parser.NXActionOutputTrunc(port=8080,
+                                                   max_len=1024)]
+        """
+        _subtype = nicira_ext.NXAST_OUTPUT_TRUNC
+
+        # port, max_len
+        _fmt_str = '!HI'
+
+        def __init__(self,
+                     port,
+                     max_len,
+                     type_=None, len_=None, experimenter=None, subtype=None):
+            super(NXActionOutputTrunc, self).__init__()
+            self.port = port
+            self.max_len = max_len
+
+        @classmethod
+        def parser(cls, buf):
+            (port,
+             max_len) = struct.unpack_from(
+                cls._fmt_str, buf, 0)
+            return cls(port, max_len)
+
+        def serialize_body(self):
+            data = bytearray()
+            msg_pack_into(self._fmt_str, data, 0,
+                          self.port,
+                          self.max_len)
+            return data
+
+    class NXActionEncapEther(NXAction):
+        """
+        Encap Ether
+
+        This action encaps package with ethernet
+
+        And equivalent to the followings action of ovs-ofctl command.
+
+        ::
+
+            encap(ethernet)
+
+        Example::
+
+            actions += [parser.NXActionEncapEther()]
+        """
+        _subtype = nicira_ext.NXAST_RAW_ENCAP
+
+        _fmt_str = '!HI'
+
+        def __init__(self,
+                     type_=None, len_=None, vendor=None, subtype=None):
+            super(NXActionEncapEther, self).__init__()
+            self.hdr_size = 0
+            self.new_pkt_type = 0x00000000
+
+        @classmethod
+        def parser(cls, buf):
+            return cls()
+
+        def serialize_body(self):
+            data = bytearray()
+            msg_pack_into(self._fmt_str, data, 0, self.hdr_size, self.new_pkt_type)
+            return data
+
+    class NXActionEncapNsh(NXAction):
+        """
+        Encap nsh
+
+        This action encaps package with nsh
+
+        And equivalent to the followings action of ovs-ofctl command.
+
+        ::
+
+            encap(nsh(md_type=1))
+
+        Example::
+
+            actions += [parser.NXActionEncapNsh()]
+        """
+        _subtype = nicira_ext.NXAST_RAW_ENCAP
+
+        _fmt_str = '!HI'
+
+        def __init__(self,
+                     type_=None, len_=None, vendor=None, subtype=None):
+            super(NXActionEncapNsh, self).__init__()
+            self.hdr_size = hdr_size
+            self.new_pkt_type = 0x0001894F
+
+        @classmethod
+        def parser(cls, buf):
+            return cls()
+
+        def serialize_body(self):
+            data = bytearray()
+            msg_pack_into(self._fmt_str, data, 0, self.hdr_size, self.new_pkt_type)
+            return data
+
+    class NXActionDecNshTtl(NXAction):
+        """
+        Decrement NSH TTL action
+
+        This action decrements the TTL in the Network Service Header(NSH).
+
+        This action was added in OVS v2.9.
+
+        And equivalent to the followings action of ovs-ofctl command.
+
+        ::
+
+            dec_nsh_ttl
+
+        Example::
+
+            actions += [parser.NXActionDecNshTtl()]
+        """
+        _subtype = nicira_ext.NXAST_DEC_NSH_TTL
+
+        _fmt_str = '!6x'
+
+        def __init__(self,
+                     type_=None, len_=None, vendor=None, subtype=None):
+            super(NXActionDecNshTtl, self).__init__()
+
+        @classmethod
+        def parser(cls, buf):
+            return cls()
+
+        def serialize_body(self):
+            data = bytearray()
+            msg_pack_into(self._fmt_str, data, 0)
+            return data
+
+    def add_attr(k, v):
+        v.__module__ = ofpp.__name__  # Necessary for stringify stuff
+        setattr(ofpp, k, v)
+
+    add_attr('NXAction', NXAction)
+    add_attr('NXActionUnknown', NXActionUnknown)
+
+    classes = [
+        'NXActionSetQueue',
+        'NXActionPopQueue',
+        'NXActionRegLoad',
+        'NXActionRegLoad2',
+        'NXActionNote',
+        'NXActionSetTunnel',
+        'NXActionSetTunnel64',
+        'NXActionRegMove',
+        'NXActionResubmit',
+        'NXActionResubmitTable',
+        'NXActionOutputReg',
+        'NXActionOutputReg2',
+        'NXActionLearn',
+        'NXActionExit',
+        'NXActionDecTtl',
+        'NXActionController',
+        'NXActionController2',
+        'NXActionDecTtlCntIds',
+        'NXActionPushMpls',
+        'NXActionPopMpls',
+        'NXActionSetMplsTtl',
+        'NXActionDecMplsTtl',
+        'NXActionSetMplsLabel',
+        'NXActionSetMplsTc',
+        'NXActionStackPush',
+        'NXActionStackPop',
+        'NXActionSample',
+        'NXActionSample2',
+        'NXActionFinTimeout',
+        'NXActionConjunction',
+        'NXActionMultipath',
+        'NXActionBundle',
+        'NXActionBundleLoad',
+        'NXActionCT',
+        'NXActionCTClear',
+        'NXActionNAT',
+        'NXActionOutputTrunc',
+        '_NXFlowSpec',  # exported for testing
+        'NXFlowSpecMatch',
+        'NXFlowSpecLoad',
+        'NXFlowSpecOutput',
+        'NXActionEncapNsh',
+        'NXActionEncapEther',
+        'NXActionDecNshTtl',
+    ]
+    vars = locals()
+    for name in classes:
+        cls = vars[name]
+        add_attr(name, cls)
+        if issubclass(cls, NXAction):
+            NXAction.register(cls)
+        if issubclass(cls, _NXFlowSpec):
+            _NXFlowSpec.register(cls)

--- a/lte/gateway/deploy/roles/magma/tasks/main.yml
+++ b/lte/gateway/deploy/roles/magma/tasks/main.yml
@@ -269,3 +269,10 @@
     - mtr0
     - ipfix0
   when: full_provision
+
+- name: Copy ryu ipfix patch
+  copy:
+    src: nx_actions.py
+    dest: /home/vagrant/build/python/lib/python3.5/site-packages/ryu/ofproto/
+  when: full_provision
+

--- a/lte/gateway/python/magma/pipelined/app/ipfix.py
+++ b/lte/gateway/python/magma/pipelined/app/ipfix.py
@@ -48,12 +48,13 @@ class IPFIXController(MagmaController):
         self.tbl_num = self._service_manager.get_table_num(self.APP_NAME)
         self.next_main_table = self._service_manager.get_next_table_num(
             self.APP_NAME)
+        self._dpi_enabled = kwargs['config']['dpi']['enabled']
+        self._bridge_name = kwargs['config']['bridge_name']
+        self._conntrackd_enabled = kwargs['config']['conntrackd']['enabled']
         self.ipfix_config = self._get_ipfix_config(kwargs['config'],
                                                    kwargs['mconfig'])
-        self._bridge_name = kwargs['config']['bridge_name']
-        self._dpi_enabled = kwargs['config']['dpi']['enabled']
         # If DPI enabled don't sample normal traffic, sample only internal pkts
-        if self._dpi_enabled:
+        if self._dpi_enabled or self._conntrackd_enabled:
             self._ipfix_sample_tbl_num = \
                 self._service_manager.INTERNAL_IPFIX_SAMPLE_TABLE_NUM
         else:
@@ -88,7 +89,7 @@ class IPFIXController(MagmaController):
                 obs_domain_id=0, obs_point_id=0, cache_timeout=0,
                 sampling_port=0)
 
-        if config_dict['dpi']['enabled']:
+        if self._dpi_enabled or self._conntrackd_enabled:
             probability = 65535
         else:
             probability = config_dict['ipfix']['probability']
@@ -222,7 +223,7 @@ class IPFIXController(MagmaController):
             sampling_port=self.ipfix_config.sampling_port)]
 
         match = MagmaMatch(imsi=encode_imsi(imsi))
-        if self._dpi_enabled:
+        if self._dpi_enabled or self._conntrackd_enabled:
             flows.add_drop_flow(
                 self._datapath, self._ipfix_sample_tbl_num, match, actions,
                 priority=flows.UE_FLOW_PRIORITY)

--- a/third_party/gtp_ovs/kernel-4.9/2.8.9/0001-datapath-add-vport-gtp-for-GPRS-Tunneling-Protocol.patch
+++ b/third_party/gtp_ovs/kernel-4.9/2.8.9/0001-datapath-add-vport-gtp-for-GPRS-Tunneling-Protocol.patch
@@ -1,7 +1,7 @@
-From 210e7e9c43cf8fe900fafaa0f8620cce39cb6f7a Mon Sep 17 00:00:00 2001
+From 824b89cbee63c1c6e06b2a04497c701104d05c78 Mon Sep 17 00:00:00 2001
 From: Jiannan Ouyang <ouyangj@fb.com>
 Date: Wed, 14 Jun 2017 22:28:11 +0000
-Subject: [PATCH 1/4] datapath: add vport-gtp for GPRS Tunneling Protocol
+Subject: [PATCH 1/7] datapath: add vport-gtp for GPRS Tunneling Protocol
 
 Add vport-gtp which uses gtp_create_flow_based_dev exported by the Linux GTP
 module to create a flow based net_device
@@ -50,7 +50,7 @@ index eec9f2338..fc4a6efcd 100644
  	linux/compat/include/net/inet_frag.h \
  	linux/compat/include/net/inetpeer.h \
 diff --git a/datapath/linux/compat/include/linux/openvswitch.h b/datapath/linux/compat/include/linux/openvswitch.h
-index bc6c94b8d..abd3e779d 100644
+index 561f89502..72d16aabf 100644
 --- a/datapath/linux/compat/include/linux/openvswitch.h
 +++ b/datapath/linux/compat/include/linux/openvswitch.h
 @@ -236,6 +236,7 @@ enum ovs_vport_type {
@@ -104,7 +104,7 @@ index 000000000..d76b03a66
 +#endif /* __NET_GTP_WRAPPER_H */
 diff --git a/datapath/vport-gtp.c b/datapath/vport-gtp.c
 new file mode 100644
-index 000000000..cf4f81f85
+index 000000000..7d9df6dce
 --- /dev/null
 +++ b/datapath/vport-gtp.c
 @@ -0,0 +1,146 @@

--- a/third_party/gtp_ovs/kernel-4.9/2.8.9/0002-userspace-Add-L3-tunnel-type-GTP.patch
+++ b/third_party/gtp_ovs/kernel-4.9/2.8.9/0002-userspace-Add-L3-tunnel-type-GTP.patch
@@ -1,7 +1,7 @@
-From fe2085621027dc3515fd223c2af069167fbeced2 Mon Sep 17 00:00:00 2001
+From cf5c1e6a34e4458577902a8e5c76d1a229b60e59 Mon Sep 17 00:00:00 2001
 From: Jiannan Ouyang <ouyangj@fb.com>
 Date: Thu, 6 Jul 2017 19:45:05 +0000
-Subject: [PATCH 2/4] userspace: Add L3 tunnel type GTP
+Subject: [PATCH 2/7] userspace: Add L3 tunnel type GTP
 
 Userspace support for L3 vport type OVS_VPORT_TYPE_GTP
 
@@ -15,10 +15,10 @@ Signed-off-by: Jiannan Ouyang <ouyangj@fb.com>
  5 files changed, 44 insertions(+), 3 deletions(-)
 
 diff --git a/lib/dpif-netlink.c b/lib/dpif-netlink.c
-index 29001fbe4..7308a03d6 100644
+index d29dad351..80381d2ee 100644
 --- a/lib/dpif-netlink.c
 +++ b/lib/dpif-netlink.c
-@@ -776,6 +776,9 @@ get_vport_type(const struct dpif_netlink_vport *vport)
+@@ -678,6 +678,9 @@ get_vport_type(const struct dpif_netlink_vport *vport)
      case OVS_VPORT_TYPE_GRE:
          return "gre";
  
@@ -28,7 +28,7 @@ index 29001fbe4..7308a03d6 100644
      case OVS_VPORT_TYPE_VXLAN:
          return "vxlan";
  
-@@ -808,6 +811,8 @@ netdev_to_ovs_vport_type(const char *type)
+@@ -710,6 +713,8 @@ netdev_to_ovs_vport_type(const char *type)
          return OVS_VPORT_TYPE_GENEVE;
      } else if (strstr(type, "gre")) {
          return OVS_VPORT_TYPE_GRE;
@@ -38,7 +38,7 @@ index 29001fbe4..7308a03d6 100644
          return OVS_VPORT_TYPE_VXLAN;
      } else if (!strcmp(type, "lisp")) {
 diff --git a/lib/netdev-vport.c b/lib/netdev-vport.c
-index d11c5ccdd..8a734b945 100644
+index 89c8bde77..3d3bff83a 100644
 --- a/lib/netdev-vport.c
 +++ b/lib/netdev-vport.c
 @@ -54,6 +54,7 @@ VLOG_DEFINE_THIS_MODULE(netdev_vport);
@@ -143,7 +143,7 @@ index 5549b4951..b93330612 100644
          dip->tunnel_type = DPIF_IPFIX_TUNNEL_GENEVE;
          dip->tunnel_key_length = 3;
 diff --git a/ofproto/ofproto-dpif-sflow.c b/ofproto/ofproto-dpif-sflow.c
-index 65a2003a7..e21f56d2d 100644
+index 621a98732..df62c70e4 100644
 --- a/ofproto/ofproto-dpif-sflow.c
 +++ b/ofproto/ofproto-dpif-sflow.c
 @@ -61,7 +61,8 @@ enum dpif_sflow_tunnel_type {
@@ -174,10 +174,10 @@ index 65a2003a7..e21f56d2d 100644
          ipproto = IPPROTO_UDP;
  
 diff --git a/vswitchd/vswitch.xml b/vswitchd/vswitch.xml
-index 074535b58..5a9cf792a 100644
+index 3b6dddb4d..eb3b59639 100644
 --- a/vswitchd/vswitch.xml
 +++ b/vswitchd/vswitch.xml
-@@ -2204,6 +2204,22 @@
+@@ -2211,6 +2211,22 @@
              </p>
            </dd>
  

--- a/third_party/gtp_ovs/kernel-4.9/2.8.9/0003-Build-symbols-for-gtp-vport-linux-4.9-module-require.patch
+++ b/third_party/gtp_ovs/kernel-4.9/2.8.9/0003-Build-symbols-for-gtp-vport-linux-4.9-module-require.patch
@@ -1,7 +1,7 @@
-From 3a14b601584fa645adbb82a22bec4404c65160fb Mon Sep 17 00:00:00 2001
+From f86aa76748d9df9c034c39501d04516306756b78 Mon Sep 17 00:00:00 2001
 From: Omar Ramadan <oramadan@fb.com>
 Date: Tue, 17 Oct 2017 16:46:14 +0000
-Subject: [PATCH 3/4] Build symbols for gtp-vport linux 4.9 module required for
+Subject: [PATCH 3/7] Build symbols for gtp-vport linux 4.9 module required for
  openvswitch module
 
 This is required until the gtp-vport module lands to netnext repos

--- a/third_party/gtp_ovs/kernel-4.9/2.8.9/0004-ovs-datapath-fix-stretch-kernel-update.patch
+++ b/third_party/gtp_ovs/kernel-4.9/2.8.9/0004-ovs-datapath-fix-stretch-kernel-update.patch
@@ -1,0 +1,80 @@
+From 3490ec1e597d9a24aa1d61764c9ff1df79b26225 Mon Sep 17 00:00:00 2001
+From: Debian <admin@ip-172-31-7-251.us-west-1.compute.internal>
+Date: Thu, 17 Dec 2020 03:32:01 +0000
+Subject: [PATCH 4/7] ovs: datapath: fix stretch kernel update
+
+---
+ acinclude.m4                                                      | 6 ++++++
+ datapath/linux/compat/include/linux/random.h                      | 3 +++
+ datapath/linux/compat/include/net/netfilter/ipv6/nf_defrag_ipv6.h | 3 ++-
+ 3 files changed, 11 insertions(+), 1 deletion(-)
+
+diff --git a/acinclude.m4 b/acinclude.m4
+index 20a0eee1c..1c1563f8e 100644
+--- a/acinclude.m4
++++ b/acinclude.m4
+@@ -452,6 +452,7 @@ AC_DEFUN([OVS_CHECK_LINUX_COMPAT], [
+   OVS_GREP_IFELSE([$KSRC/include/linux/err.h], [PTR_ERR_OR_ZERO])
+ 
+   OVS_GREP_IFELSE([$KSRC/include/linux/etherdevice.h], [eth_hw_addr_random])
++  OVS_GREP_IFELSE([$KSRC/include/linux/prandom.h], [_LINUX_PRANDOM_H])
+   OVS_GREP_IFELSE([$KSRC/include/linux/etherdevice.h], [ether_addr_copy])
+ 
+   OVS_GREP_IFELSE([$KSRC/include/uapi/linux/if_link.h], [IFLA_GENEVE_TOS])
+@@ -606,6 +607,10 @@ AC_DEFUN([OVS_CHECK_LINUX_COMPAT], [
+   OVS_GREP_IFELSE([$KSRC/include/linux/random.h], [prandom_u32])
+   OVS_GREP_IFELSE([$KSRC/include/linux/random.h], [prandom_u32_max])
+ 
++  OVS_GREP_IFELSE([$KSRC/include/linux/prandom.h], [prandom_u32])
++  OVS_GREP_IFELSE([$KSRC/include/linux/prandom.h], [prandom_u32_max])
++
++
+   OVS_GREP_IFELSE([$KSRC/include/net/rtnetlink.h], [get_link_net])
+   OVS_GREP_IFELSE([$KSRC/include/net/rtnetlink.h], [name_assign_type])
+   OVS_GREP_IFELSE([$KSRC/include/net/rtnetlink.h], [rtnl_create_link.*src_net],
+@@ -740,6 +745,7 @@ AC_DEFUN([OVS_CHECK_LINUX_COMPAT], [
+                   [OVS_GREP_IFELSE([$KSRC/include/net/udp.h], [inet_get_local_port_range(net],
+                                    [OVS_DEFINE([HAVE_UDP_FLOW_SRC_PORT])])])
+   OVS_GREP_IFELSE([$KSRC/include/net/udp.h], [udp_v4_check])
++  OVS_GREP_IFELSE([$KSRC/include/net/ipv6.h], [ip6_frag_init])
+   OVS_GREP_IFELSE([$KSRC/include/net/udp_tunnel.h], [udp_tunnel_gro_complete])
+   OVS_GREP_IFELSE([$KSRC/include/net/udp_tunnel.h], [sk_buff.*udp_tunnel_handle_offloads],
+                   [OVS_DEFINE([HAVE_UDP_TUNNEL_HANDLE_OFFLOAD_RET_SKB])])
+diff --git a/datapath/linux/compat/include/linux/random.h b/datapath/linux/compat/include/linux/random.h
+index 5c088a2d8..2e9288444 100644
+--- a/datapath/linux/compat/include/linux/random.h
++++ b/datapath/linux/compat/include/linux/random.h
+@@ -2,6 +2,9 @@
+ #define __LINUX_RANDOM_WRAPPER_H 1
+ 
+ #include_next <linux/random.h>
++#ifdef HAVE__LINUX_PRANDOM_H
++#include <linux/prandom.h>
++#endif
+ 
+ #ifndef HAVE_PRANDOM_U32
+ #define prandom_u32()		random32()
+diff --git a/datapath/linux/compat/include/net/netfilter/ipv6/nf_defrag_ipv6.h b/datapath/linux/compat/include/net/netfilter/ipv6/nf_defrag_ipv6.h
+index c4c0f79ab..d5ec52a16 100644
+--- a/datapath/linux/compat/include/net/netfilter/ipv6/nf_defrag_ipv6.h
++++ b/datapath/linux/compat/include/net/netfilter/ipv6/nf_defrag_ipv6.h
+@@ -12,7 +12,7 @@
+  * a bug that requires all kernels prior to this fix, i.e. kernel < 4.11.0
+  * to be backported.
+  */
+-#if LINUX_VERSION_CODE < KERNEL_VERSION(4,11,0)
++#if LINUX_VERSION_CODE < KERNEL_VERSION(4,11,0) && defined(HAVE_IP6_FRAG_INIT)
+ #define OVS_NF_DEFRAG6_BACKPORT 1
+ int rpl_nf_ct_frag6_gather(struct net *net, struct sk_buff *skb, u32 user);
+ #define nf_ct_frag6_gather rpl_nf_ct_frag6_gather
+@@ -31,6 +31,7 @@ void rpl_nf_ct_frag6_cleanup(void);
+ void ovs_netns_frags6_init(struct net *net);
+ void ovs_netns_frags6_exit(struct net *net);
+ #else /* !OVS_NF_DEFRAG6_BACKPORT */
++#include <net/ipv6_frag.h>
+ static inline int __init rpl_nf_ct_frag6_init(void) { return 0; }
+ static inline void rpl_nf_ct_frag6_cleanup(void) { }
+ static inline void ovs_netns_frags6_init(struct net *net) { }
+-- 
+2.11.0
+

--- a/third_party/gtp_ovs/kernel-4.9/2.8.9/0005-Add-custom-IPDR-fields-for-IPFIX-export.patch
+++ b/third_party/gtp_ovs/kernel-4.9/2.8.9/0005-Add-custom-IPDR-fields-for-IPFIX-export.patch
@@ -1,0 +1,289 @@
+From 8672760286760e552a80cb82c8d64d74e6cb9e0e Mon Sep 17 00:00:00 2001
+From: vagrant <vagrant@magma-dev>
+Date: Fri, 12 Feb 2021 23:26:48 +0000
+Subject: [PATCH 5/7] Add custom IPDR fields for IPFIX export
+
+Signed-off-by: vagrant <vagrant@magma-dev>
+---
+ include/openvswitch/ofp-actions.h     |  3 +++
+ lib/odp-util.h                        |  7 +++++-
+ lib/ofp-actions.c                     | 36 +++++++++++++++++++++++++---
+ ofproto/ipfix-enterprise-entities.def |  7 ++++++
+ ofproto/ofproto-dpif-ipfix.c          | 44 +++++++++++++++++++++++++++++++++++
+ ofproto/ofproto-dpif-xlate.c          |  5 ++++
+ 6 files changed, 98 insertions(+), 4 deletions(-)
+
+diff --git a/include/openvswitch/ofp-actions.h b/include/openvswitch/ofp-actions.h
+index 0629ef1b5..238ac7892 100644
+--- a/include/openvswitch/ofp-actions.h
++++ b/include/openvswitch/ofp-actions.h
+@@ -912,6 +912,9 @@ struct ofpact_sample {
+     uint32_t obs_point_id;
+     ofp_port_t sampling_port;
+     enum nx_action_sample_direction direction;
++    uint8_t msisdn[16];
++    struct eth_addr apn_mac_addr;
++    uint8_t apn_name[24];
+ };
+ 
+ /* OFPACT_DEC_TTL.
+diff --git a/lib/odp-util.h b/lib/odp-util.h
+index 420fe3bed..57d03d07a 100644
+--- a/lib/odp-util.h
++++ b/lib/odp-util.h
+@@ -321,6 +321,11 @@ union user_action_cookie {
+         uint32_t obs_point_id;  /* Observation Point ID. */
+         odp_port_t output_odp_port; /* The output odp port. */
+         enum nx_action_sample_direction direction;
++        ovs_be64 flow_metadata;
++        uint32_t app_name;
++        uint8_t msisdn[16];
++        struct eth_addr apn_mac_addr;
++        uint8_t apn_name[24];
+     } flow_sample;
+ 
+     struct {
+@@ -328,7 +333,7 @@ union user_action_cookie {
+         odp_port_t output_odp_port; /* The output odp port. */
+     } ipfix;
+ };
+-BUILD_ASSERT_DECL(sizeof(union user_action_cookie) == 24);
++BUILD_ASSERT_DECL(sizeof(union user_action_cookie) == 88);
+ 
+ size_t odp_put_userspace_action(uint32_t pid,
+                                 const void *userdata, size_t userdata_size,
+diff --git a/lib/ofp-actions.c b/lib/ofp-actions.c
+index 47913eb0c..1b7089d97 100644
+--- a/lib/ofp-actions.c
++++ b/lib/ofp-actions.c
+@@ -5620,10 +5620,13 @@ struct nx_action_sample2 {
+     ovs_be32 obs_domain_id;         /* ID of sampling observation domain. */
+     ovs_be32 obs_point_id;          /* ID of sampling observation point. */
+     ovs_be16 sampling_port;         /* Sampling port. */
++    uint8_t  msisdn[16];
++    struct   eth_addr apn_mac_addr;
++    uint8_t  apn_name[24];
+     uint8_t  direction;             /* NXAST_SAMPLE3 only. */
+     uint8_t  zeros[5];              /* Pad to a multiple of 8 bytes */
+  };
+- OFP_ASSERT(sizeof(struct nx_action_sample2) == 32);
++ OFP_ASSERT(sizeof(struct nx_action_sample2) == 80);
+ 
+ static enum ofperr
+ decode_NXAST_RAW_SAMPLE(const struct nx_action_sample *nas,
+@@ -5660,6 +5663,9 @@ decode_SAMPLE2(const struct nx_action_sample2 *nas,
+     sample->obs_domain_id = ntohl(nas->obs_domain_id);
+     sample->obs_point_id = ntohl(nas->obs_point_id);
+     sample->sampling_port = u16_to_ofp(ntohs(nas->sampling_port));
++    sample->apn_mac_addr = nas->apn_mac_addr;
++    memcpy(&sample->msisdn, &nas->msisdn, 16);
++    memcpy(&sample->apn_name, &nas->apn_name, 24);
+     sample->direction = direction;
+ 
+     if (sample->probability == 0) {
+@@ -5706,6 +5712,9 @@ encode_SAMPLE2(const struct ofpact_sample *sample,
+     nas->obs_point_id = htonl(sample->obs_point_id);
+     nas->sampling_port = htons(ofp_to_u16(sample->sampling_port));
+     nas->direction = sample->direction;
++    memcpy(&nas->msisdn, &sample->msisdn, 16);
++    nas->apn_mac_addr = sample->apn_mac_addr;
++    memcpy(&nas->apn_name, &sample->apn_name, 24);
+ }
+ 
+ static void
+@@ -5742,6 +5751,7 @@ parse_SAMPLE(char *arg, const struct ofputil_port_map *port_map,
+     os->direction = NX_ACTION_SAMPLE_DEFAULT;
+ 
+     char *key, *value;
++    int i;
+     while (ofputil_parse_key_value(&arg, &key, &value)) {
+         char *error = NULL;
+ 
+@@ -5750,6 +5760,20 @@ parse_SAMPLE(char *arg, const struct ofputil_port_map *port_map,
+             if (!error && os->probability == 0) {
+                 error = xasprintf("invalid probability value \"%s\"", value);
+             }
++        } else if (!strcmp(key, "apn_name")) {
++            for (i = 0; i < 24; i++) {
++                os->apn_name[i] = (uint8_t)value[i];
++                if ((char)value[i] == '\0')
++                    break;
++            }
++        } else if (!strcmp(key, "msisdn")) {
++            for (i = 0; i < 16; i++) {
++                os->msisdn[i] = (uint8_t)value[i];
++                if ((char)value[i] == '\0')
++                    break;
++            }
++        } else if (!strcmp(key, "apn_mac_addr")) {
++            error = str_to_mac(value, &os->apn_mac_addr);
+         } else if (!strcmp(key, "collector_set_id")) {
+             error = str_to_u32(value, &os->collector_set_id);
+         } else if (!strcmp(key, "obs_domain_id")) {
+@@ -5787,12 +5811,18 @@ format_SAMPLE(const struct ofpact_sample *a,
+     ds_put_format(s, "%ssample(%s%sprobability=%s%"PRIu16
+                   ",%scollector_set_id=%s%"PRIu32
+                   ",%sobs_domain_id=%s%"PRIu32
+-                  ",%sobs_point_id=%s%"PRIu32,
++                  ",%sobs_point_id=%s%"PRIu32
++                  ",%sapn_mac_addr=%s"ETH_ADDR_FMT
++                  ",%smsisdn=%s%s"
++                  ",%sapn_name=%s%s",
+                   colors.paren, colors.end,
+                   colors.param, colors.end, a->probability,
+                   colors.param, colors.end, a->collector_set_id,
+                   colors.param, colors.end, a->obs_domain_id,
+-                  colors.param, colors.end, a->obs_point_id);
++                  colors.param, colors.end, a->obs_point_id,
++                  colors.param, colors.end, ETH_ADDR_ARGS(a->apn_mac_addr),
++                  colors.param, colors.end, a->msisdn,
++                  colors.param, colors.end, a->apn_name);
+     if (a->sampling_port != OFPP_NONE) {
+         ds_put_format(s, ",%ssampling_port=%s", colors.param, colors.end);
+         ofputil_format_port(a->sampling_port, port_map, s);
+diff --git a/ofproto/ipfix-enterprise-entities.def b/ofproto/ipfix-enterprise-entities.def
+index 73a520c25..89e77ec45 100644
+--- a/ofproto/ipfix-enterprise-entities.def
++++ b/ofproto/ipfix-enterprise-entities.def
+@@ -14,4 +14,11 @@ IPFIX_ENTERPRISE_ENTITY(TUNNEL_SOURCE_TRANSPORT_PORT, 896, 2, tunnelSourceTransp
+ IPFIX_ENTERPRISE_ENTITY(TUNNEL_DESTINATION_TRANSPORT_PORT, 897, 2, tunnelDestinationTransportPort, IPFIX_ENTERPRISE_VMWARE)
+ IPFIX_ENTERPRISE_ENTITY(VIRTUAL_OBS_ID, 898, 0, virtualObsID, IPFIX_ENTERPRISE_VMWARE)
+ 
++#define IPFIX_ENTERPRISE_IPDR 6888
++IPFIX_ENTERPRISE_ENTITY(IMSI_REG, 899, 8, imsiRegister, IPFIX_ENTERPRISE_IPDR)
++IPFIX_ENTERPRISE_ENTITY(MSISDN, 900, 16, msisdn, IPFIX_ENTERPRISE_IPDR)
++IPFIX_ENTERPRISE_ENTITY(APN_MAC_ADDRESS, 901, 6, apnMacAddress, IPFIX_ENTERPRISE_IPDR)
++IPFIX_ENTERPRISE_ENTITY(APN_NAME, 902, 24, apnName, IPFIX_ENTERPRISE_IPDR)
++IPFIX_ENTERPRISE_ENTITY(APP_NAME, 903, 4, appName, IPFIX_ENTERPRISE_IPDR)
++
+ #undef IPFIX_ENTERPRISE_ENTITY
+diff --git a/ofproto/ofproto-dpif-ipfix.c b/ofproto/ofproto-dpif-ipfix.c
+index b93330612..7d7c7842f 100644
+--- a/ofproto/ofproto-dpif-ipfix.c
++++ b/ofproto/ofproto-dpif-ipfix.c
+@@ -388,6 +388,16 @@ struct ipfix_data_record_flow_key_tunnel {
+ });
+ BUILD_ASSERT_DECL(sizeof(struct ipfix_data_record_flow_key_tunnel) == 15);
+ 
++OVS_PACKED(
++struct ipfix_data_ipdr_fields {
++    ovs_be64 imsi;  /* IMSI_REGISTER*/
++    uint8_t msisdn[16];  /* MSISDN */
++    struct eth_addr apn_mac_address;  /* APN_MAC_ADDRESS */
++    uint8_t apn_name[24];  /* APN_NAME */
++    uint32_t app_name;  /* APP_NAME */
++});
++BUILD_ASSERT_DECL(sizeof(struct ipfix_data_ipdr_fields) == 58);
++
+ /* Cf. IETF RFC 5102 Section 5.11.3. */
+ enum ipfix_flow_end_reason {
+     IDLE_TIMEOUT = 0x01,
+@@ -508,6 +518,7 @@ BUILD_ASSERT_DECL(sizeof(struct ipfix_data_record_aggregated_tcp) == 48);
+      + MAX(sizeof(struct ipfix_data_record_flow_key_icmp),      \
+            sizeof(struct ipfix_data_record_flow_key_transport)) \
+      + sizeof(struct ipfix_data_record_flow_key_tunnel)         \
++     + sizeof(struct ipfix_data_ipdr_fields)                    \
+      + MAX_TUNNEL_KEY_LEN)
+ 
+ #define MAX_DATA_RECORD_LEN                                 \
+@@ -1401,6 +1412,13 @@ ipfix_define_template_fields(enum ipfix_proto_l2 l2, enum ipfix_proto_l3 l3,
+         DEF(TUNNEL_KEY);
+     }
+ 
++    /* Custom IPDR fields */
++    DEF(IMSI_REG);
++    DEF(MSISDN);
++    DEF(APN_MAC_ADDRESS);
++    DEF(APN_NAME);
++    DEF(APP_NAME);
++
+     /* 2. Virtual observation ID, which is not a part of flow key. */
+     if (virtual_obs_id_set) {
+         DEF(VIRTUAL_OBS_ID);
+@@ -1913,6 +1931,9 @@ ipfix_cache_entry_init(struct ipfix_flow_cache_entry *entry,
+                        uint64_t packet_delta_count, uint32_t obs_domain_id,
+                        uint32_t obs_point_id, odp_port_t output_odp_port,
+                        enum nx_action_sample_direction direction,
++                       ovs_be64 flow_metadata, uint8_t *msisdn,
++                       struct eth_addr *apn_mac_addr, uint8_t *apn_name,
++                       uint32_t app_name,
+                        const struct dpif_ipfix_port *tunnel_port,
+                        const struct flow_tnl *tunnel_key,
+                        struct dpif_ipfix_global_stats *stats,
+@@ -2100,6 +2121,19 @@ ipfix_cache_entry_init(struct ipfix_flow_cache_entry *entry,
+                tunnel_port->tunnel_key_length);
+     }
+ 
++    /* Add custom IPDR fields */
++    struct ipfix_data_ipdr_fields *ipdr_data;
++
++    ipdr_data = dp_packet_put_zeros(&msg, sizeof *ipdr_data);
++    ipdr_data->imsi = flow_metadata;
++    ipdr_data->app_name = app_name;
++    if (msisdn != NULL)
++        memcpy(&ipdr_data->msisdn, msisdn, 16);
++    if (apn_mac_addr != NULL)
++        memcpy(&ipdr_data->apn_mac_address, apn_mac_addr, sizeof(struct eth_addr));
++    if (apn_name != NULL)
++        memcpy(&ipdr_data->apn_name, apn_name, 24);
++
+     flow_key->flow_key_msg_part_size = dp_packet_size(&msg);
+ 
+     if (eth_addr_is_broadcast(flow->dl_dst)) {
+@@ -2474,6 +2508,9 @@ dpif_ipfix_sample(struct dpif_ipfix_exporter *exporter,
+                   uint64_t packet_delta_count, uint32_t obs_domain_id,
+                   uint32_t obs_point_id, odp_port_t output_odp_port,
+                   enum nx_action_sample_direction direction,
++                  ovs_be64 flow_metadata, uint8_t *msisdn,
++                  struct eth_addr *apn_mac_addr, uint8_t *apn_name,
++                  uint32_t app_name,
+                   const struct dpif_ipfix_port *tunnel_port,
+                   const struct flow_tnl *tunnel_key,
+                   const struct dpif_ipfix_actions *ipfix_actions)
+@@ -2488,6 +2525,9 @@ dpif_ipfix_sample(struct dpif_ipfix_exporter *exporter,
+                                    flow, packet_delta_count,
+                                    obs_domain_id, obs_point_id,
+                                    output_odp_port, direction,
++                                   flow_metadata, msisdn,
++                                   apn_mac_addr, apn_name,
++                                   app_name,
+                                    tunnel_port, tunnel_key,
+                                    &exporter->ipfix_global_stats,
+                                    ipfix_actions);
+@@ -2556,6 +2596,7 @@ dpif_ipfix_bridge_sample(struct dpif_ipfix *di, const struct dp_packet *packet,
+                       di->bridge_exporter.options->obs_domain_id,
+                       di->bridge_exporter.options->obs_point_id,
+                       output_odp_port, NX_ACTION_SAMPLE_DEFAULT,
++                      0, NULL, NULL, NULL, 0, //not available for bridge export
+                       tunnel_port, tunnel_key, ipfix_actions);
+     ovs_mutex_unlock(&mutex);
+ }
+@@ -2601,6 +2642,9 @@ dpif_ipfix_flow_sample(struct dpif_ipfix *di, const struct dp_packet *packet,
+                           cookie->flow_sample.obs_domain_id,
+                           cookie->flow_sample.obs_point_id,
+                           output_odp_port, cookie->flow_sample.direction,
++                          cookie->flow_sample.flow_metadata, (uint8_t *)&cookie->flow_sample.msisdn,
++                          (struct eth_addr *)&cookie->flow_sample.apn_mac_addr, (uint8_t *)&cookie->flow_sample.apn_name,
++                          cookie->flow_sample.app_name,
+                           tunnel_port, tunnel_key, ipfix_actions);
+     }
+     ovs_mutex_unlock(&mutex);
+diff --git a/ofproto/ofproto-dpif-xlate.c b/ofproto/ofproto-dpif-xlate.c
+index ea1815e41..66e933182 100644
+--- a/ofproto/ofproto-dpif-xlate.c
++++ b/ofproto/ofproto-dpif-xlate.c
+@@ -5408,6 +5408,11 @@ xlate_sample_action(struct xlate_ctx *ctx,
+     cookie.flow_sample.obs_point_id = os->obs_point_id;
+     cookie.flow_sample.output_odp_port = output_odp_port;
+     cookie.flow_sample.direction = os->direction;
++    cookie.flow_sample.flow_metadata = ctx->xin->flow.metadata;
++    cookie.flow_sample.app_name = ctx->xin->flow.regs[10];
++    memcpy(&cookie.flow_sample.msisdn, &os->msisdn, 16);
++    memcpy(&cookie.flow_sample.apn_mac_addr, &os->apn_mac_addr, sizeof(struct eth_addr));
++    memcpy(&cookie.flow_sample.apn_name, &os->apn_name, 24);
+ 
+     compose_sample_action(ctx, probability, &cookie, sizeof cookie.flow_sample,
+                           tunnel_out_port, false);
+-- 
+2.11.0
+

--- a/third_party/gtp_ovs/kernel-4.9/2.8.9/0006-ovs-Handle-spaces-in-ovs-arguments.patch
+++ b/third_party/gtp_ovs/kernel-4.9/2.8.9/0006-ovs-Handle-spaces-in-ovs-arguments.patch
@@ -1,0 +1,149 @@
+From e51a245559bdbee1c0c8bbb81e50c917a46020ed Mon Sep 17 00:00:00 2001
+From: Nick Yurchenko <urchennko@gmail.com>
+Date: Sat, 13 Feb 2021 00:28:20 +0000
+Subject: [PATCH 6/7] ovs: Handle spaces in ovs arguments
+
+---
+ lib/ofp-actions.c | 28 +++++++++++++++++++---------
+ lib/ofp-util.c    | 20 +++++++++++++++++---
+ lib/string.c      | 24 ++++++++++++++++++++++++
+ lib/string.h.in   |  1 +
+ 4 files changed, 61 insertions(+), 12 deletions(-)
+
+diff --git a/lib/ofp-actions.c b/lib/ofp-actions.c
+index 1b7089d97..facc60636 100644
+--- a/lib/ofp-actions.c
++++ b/lib/ofp-actions.c
+@@ -5761,8 +5761,11 @@ parse_SAMPLE(char *arg, const struct ofputil_port_map *port_map,
+                 error = xasprintf("invalid probability value \"%s\"", value);
+             }
+         } else if (!strcmp(key, "apn_name")) {
++            int j = 0;
+             for (i = 0; i < 24; i++) {
+-                os->apn_name[i] = (uint8_t)value[i];
++                if (value[i] == '"')
++                    continue;
++                os->apn_name[j++] = (uint8_t)value[i];
+                 if ((char)value[i] == '\0')
+                     break;
+             }
+@@ -5811,18 +5814,25 @@ format_SAMPLE(const struct ofpact_sample *a,
+     ds_put_format(s, "%ssample(%s%sprobability=%s%"PRIu16
+                   ",%scollector_set_id=%s%"PRIu32
+                   ",%sobs_domain_id=%s%"PRIu32
+-                  ",%sobs_point_id=%s%"PRIu32
+-                  ",%sapn_mac_addr=%s"ETH_ADDR_FMT
+-                  ",%smsisdn=%s%s"
+-                  ",%sapn_name=%s%s",
++                  ",%sobs_point_id=%s%"PRIu32,
+                   colors.paren, colors.end,
+                   colors.param, colors.end, a->probability,
+                   colors.param, colors.end, a->collector_set_id,
+                   colors.param, colors.end, a->obs_domain_id,
+-                  colors.param, colors.end, a->obs_point_id,
+-                  colors.param, colors.end, ETH_ADDR_ARGS(a->apn_mac_addr),
+-                  colors.param, colors.end, a->msisdn,
+-                  colors.param, colors.end, a->apn_name);
++                  colors.param, colors.end, a->obs_point_id);
++    if (!eth_addr_is_zero(a->apn_mac_addr)) {
++        ds_put_format(s,  ",%sapn_mac_addr=%s"ETH_ADDR_FMT,
++                  colors.param, colors.end, ETH_ADDR_ARGS(a->apn_mac_addr));
++
++    }
++    if (strlen((const char *)a->msisdn)) {
++        ds_put_format(s, ",%smsisdn=%s%s", colors.param, colors.end, a->msisdn);
++    }
++    if (strlen((const char *)a->apn_name)) {
++        char buf[32], *name;
++        name = str_quotify((char *)a->apn_name, 24, buf);
++        ds_put_format(s, ",%sapn_name=%s%s", colors.param, colors.end, name);
++    }
+     if (a->sampling_port != OFPP_NONE) {
+         ds_put_format(s, ",%ssampling_port=%s", colors.param, colors.end);
+         ofputil_format_port(a->sampling_port, port_map, s);
+diff --git a/lib/ofp-util.c b/lib/ofp-util.c
+index a712f2126..e15541bb3 100644
+--- a/lib/ofp-util.c
++++ b/lib/ofp-util.c
+@@ -7906,9 +7906,16 @@ ofputil_parse_key_value(char **stringp, char **keyp, char **valuep)
+      *     - If key_delim is "(", the value extends until ")".
+      *
+      * If there is no value, we are done. */
++    char *value = *stringp;
+     const char *value_delims;
++    bool value_with_quote = false;
+     if (key_delim == ':' || key_delim == '=') {
+-        value_delims = ", \t\r\n";
++        if (*value == '\"') {
++            value_delims = "\"";
++            value_with_quote = true;
++        } else {
++            value_delims = ", \t\r\n";
++        }
+     } else if (key_delim == '(') {
+         value_delims = ")";
+     } else {
+@@ -7919,9 +7926,16 @@ ofputil_parse_key_value(char **stringp, char **keyp, char **valuep)
+ 
+     /* Extract the value.  Advance the input position past the value and
+      * delimiter. */
+-    char *value = *stringp;
+-    size_t value_len = parse_value(value, value_delims);
++    size_t value_len;
++    if (value_with_quote) {
++        value_len = parse_value(value + 1, value_delims);
++    } else {
++        value_len = parse_value(value, value_delims);
++    }
+     char value_delim = value[value_len];
++    if (value_with_quote) {
++        value_len += 2;
++    }
+     value[value_len] = '\0';
+     *stringp += value_len + (value_delim != '\0');
+ 
+diff --git a/lib/string.c b/lib/string.c
+index e7e265bdf..b0bc80359 100644
+--- a/lib/string.c
++++ b/lib/string.c
+@@ -44,3 +44,27 @@ char *strcasestr(const char *str, const char *substr)
+     return NULL;
+ }
+ #endif
++
++/* Expect string 'd' is atleast three char longer than 's'. */
++char *
++str_quotify(const char *s, int len, char *d)
++{
++    bool found_space = false;
++    int i = 0;
++
++    d[0] = '"';
++    while(s[i] != '\0' && i <= len) {
++        d[i + 1] = s[i];
++        if (s[i] == ' ') {
++            found_space = true;
++        }
++        i++;
++    }
++    if (found_space) {
++        d[i + 1] = '"';
++        d[i + 2] = '\0';
++        return d;
++    } else {
++        return &d[1];
++    }
++}
+diff --git a/lib/string.h.in b/lib/string.h.in
+index 7a8e18f41..69565c9a9 100644
+--- a/lib/string.h.in
++++ b/lib/string.h.in
+@@ -45,4 +45,5 @@ char *strcasestr(const char *, const char *);
+ size_t strnlen(const char *, size_t maxlen);
+ #endif
+ 
++char *str_quotify(const char *s, int len, char *d);
+ #endif /* string.h wrapper */
+-- 
+2.11.0
+

--- a/third_party/gtp_ovs/kernel-4.9/2.8.9/0007-Add-pdp_start_epoch-custom-field-to-IPFIX-export.patch
+++ b/third_party/gtp_ovs/kernel-4.9/2.8.9/0007-Add-pdp_start_epoch-custom-field-to-IPFIX-export.patch
@@ -1,0 +1,209 @@
+From edaedc266044b4320bc9e8b5e16cb27bebb77ad2 Mon Sep 17 00:00:00 2001
+From: Nick Yurchenko <urchennko@gmail.com>
+Date: Sat, 13 Feb 2021 02:57:25 +0000
+Subject: [PATCH 7/7] Add pdp_start_epoch custom field to IPFIX export
+
+Signed-off-by: Nick Yurchenko <urchennko@gmail.com>
+---
+ include/openvswitch/ofp-actions.h     |  1 +
+ lib/odp-util.h                        |  3 ++-
+ lib/ofp-actions.c                     | 13 ++++++++++---
+ ofproto/ipfix-enterprise-entities.def |  1 +
+ ofproto/ofproto-dpif-ipfix.c          | 15 +++++++++------
+ ofproto/ofproto-dpif-xlate.c          |  1 +
+ 6 files changed, 24 insertions(+), 10 deletions(-)
+
+diff --git a/include/openvswitch/ofp-actions.h b/include/openvswitch/ofp-actions.h
+index 238ac7892..44994511b 100644
+--- a/include/openvswitch/ofp-actions.h
++++ b/include/openvswitch/ofp-actions.h
+@@ -915,6 +915,7 @@ struct ofpact_sample {
+     uint8_t msisdn[16];
+     struct eth_addr apn_mac_addr;
+     uint8_t apn_name[24];
++    uint64_t pdp_start_epoch;
+ };
+ 
+ /* OFPACT_DEC_TTL.
+diff --git a/lib/odp-util.h b/lib/odp-util.h
+index 57d03d07a..374192e1c 100644
+--- a/lib/odp-util.h
++++ b/lib/odp-util.h
+@@ -326,6 +326,7 @@ union user_action_cookie {
+         uint8_t msisdn[16];
+         struct eth_addr apn_mac_addr;
+         uint8_t apn_name[24];
++        uint64_t pdp_start_epoch;
+     } flow_sample;
+ 
+     struct {
+@@ -333,7 +334,7 @@ union user_action_cookie {
+         odp_port_t output_odp_port; /* The output odp port. */
+     } ipfix;
+ };
+-BUILD_ASSERT_DECL(sizeof(union user_action_cookie) == 88);
++BUILD_ASSERT_DECL(sizeof(union user_action_cookie) == 96);
+ 
+ size_t odp_put_userspace_action(uint32_t pid,
+                                 const void *userdata, size_t userdata_size,
+diff --git a/lib/ofp-actions.c b/lib/ofp-actions.c
+index facc60636..78ceb4a04 100644
+--- a/lib/ofp-actions.c
++++ b/lib/ofp-actions.c
+@@ -5623,10 +5623,11 @@ struct nx_action_sample2 {
+     uint8_t  msisdn[16];
+     struct   eth_addr apn_mac_addr;
+     uint8_t  apn_name[24];
++    uint64_t pdp_start_epoch;
+     uint8_t  direction;             /* NXAST_SAMPLE3 only. */
+     uint8_t  zeros[5];              /* Pad to a multiple of 8 bytes */
+  };
+- OFP_ASSERT(sizeof(struct nx_action_sample2) == 80);
++ OFP_ASSERT(sizeof(struct nx_action_sample2) == 88);
+ 
+ static enum ofperr
+ decode_NXAST_RAW_SAMPLE(const struct nx_action_sample *nas,
+@@ -5664,6 +5665,7 @@ decode_SAMPLE2(const struct nx_action_sample2 *nas,
+     sample->obs_point_id = ntohl(nas->obs_point_id);
+     sample->sampling_port = u16_to_ofp(ntohs(nas->sampling_port));
+     sample->apn_mac_addr = nas->apn_mac_addr;
++    sample->pdp_start_epoch = nas->pdp_start_epoch;
+     memcpy(&sample->msisdn, &nas->msisdn, 16);
+     memcpy(&sample->apn_name, &nas->apn_name, 24);
+     sample->direction = direction;
+@@ -5715,6 +5717,7 @@ encode_SAMPLE2(const struct ofpact_sample *sample,
+     memcpy(&nas->msisdn, &sample->msisdn, 16);
+     nas->apn_mac_addr = sample->apn_mac_addr;
+     memcpy(&nas->apn_name, &sample->apn_name, 24);
++    nas->pdp_start_epoch = sample->pdp_start_epoch;
+ }
+ 
+ static void
+@@ -5777,6 +5780,8 @@ parse_SAMPLE(char *arg, const struct ofputil_port_map *port_map,
+             }
+         } else if (!strcmp(key, "apn_mac_addr")) {
+             error = str_to_mac(value, &os->apn_mac_addr);
++        } else if (!strcmp(key, "pdp_start_epoch")) {
++            error = str_to_u64(value, &os->pdp_start_epoch);
+         } else if (!strcmp(key, "collector_set_id")) {
+             error = str_to_u32(value, &os->collector_set_id);
+         } else if (!strcmp(key, "obs_domain_id")) {
+@@ -5814,12 +5819,14 @@ format_SAMPLE(const struct ofpact_sample *a,
+     ds_put_format(s, "%ssample(%s%sprobability=%s%"PRIu16
+                   ",%scollector_set_id=%s%"PRIu32
+                   ",%sobs_domain_id=%s%"PRIu32
+-                  ",%sobs_point_id=%s%"PRIu32,
++                  ",%sobs_point_id=%s%"PRIu32
++                  ",%spdp_start_epoch=%s%"PRIu64,
+                   colors.paren, colors.end,
+                   colors.param, colors.end, a->probability,
+                   colors.param, colors.end, a->collector_set_id,
+                   colors.param, colors.end, a->obs_domain_id,
+-                  colors.param, colors.end, a->obs_point_id);
++                  colors.param, colors.end, a->obs_point_id,
++                  colors.param, colors.end, a->pdp_start_epoch);
+     if (!eth_addr_is_zero(a->apn_mac_addr)) {
+         ds_put_format(s,  ",%sapn_mac_addr=%s"ETH_ADDR_FMT,
+                   colors.param, colors.end, ETH_ADDR_ARGS(a->apn_mac_addr));
+diff --git a/ofproto/ipfix-enterprise-entities.def b/ofproto/ipfix-enterprise-entities.def
+index 89e77ec45..f59b69115 100644
+--- a/ofproto/ipfix-enterprise-entities.def
++++ b/ofproto/ipfix-enterprise-entities.def
+@@ -20,5 +20,6 @@ IPFIX_ENTERPRISE_ENTITY(MSISDN, 900, 16, msisdn, IPFIX_ENTERPRISE_IPDR)
+ IPFIX_ENTERPRISE_ENTITY(APN_MAC_ADDRESS, 901, 6, apnMacAddress, IPFIX_ENTERPRISE_IPDR)
+ IPFIX_ENTERPRISE_ENTITY(APN_NAME, 902, 24, apnName, IPFIX_ENTERPRISE_IPDR)
+ IPFIX_ENTERPRISE_ENTITY(APP_NAME, 903, 4, appName, IPFIX_ENTERPRISE_IPDR)
++IPFIX_ENTERPRISE_ENTITY(PDP_START_EPOCH, 904, 8, pdpStartEpoch, IPFIX_ENTERPRISE_IPDR)
+ 
+ #undef IPFIX_ENTERPRISE_ENTITY
+diff --git a/ofproto/ofproto-dpif-ipfix.c b/ofproto/ofproto-dpif-ipfix.c
+index 7d7c7842f..7e23efe41 100644
+--- a/ofproto/ofproto-dpif-ipfix.c
++++ b/ofproto/ofproto-dpif-ipfix.c
+@@ -395,8 +395,9 @@ struct ipfix_data_ipdr_fields {
+     struct eth_addr apn_mac_address;  /* APN_MAC_ADDRESS */
+     uint8_t apn_name[24];  /* APN_NAME */
+     uint32_t app_name;  /* APP_NAME */
++    uint64_t pdp_start_epoch; /* PDP_START_EPOCH */
+ });
+-BUILD_ASSERT_DECL(sizeof(struct ipfix_data_ipdr_fields) == 58);
++BUILD_ASSERT_DECL(sizeof(struct ipfix_data_ipdr_fields) == 66);
+ 
+ /* Cf. IETF RFC 5102 Section 5.11.3. */
+ enum ipfix_flow_end_reason {
+@@ -1418,6 +1419,7 @@ ipfix_define_template_fields(enum ipfix_proto_l2 l2, enum ipfix_proto_l3 l3,
+     DEF(APN_MAC_ADDRESS);
+     DEF(APN_NAME);
+     DEF(APP_NAME);
++    DEF(PDP_START_EPOCH);
+ 
+     /* 2. Virtual observation ID, which is not a part of flow key. */
+     if (virtual_obs_id_set) {
+@@ -1933,7 +1935,7 @@ ipfix_cache_entry_init(struct ipfix_flow_cache_entry *entry,
+                        enum nx_action_sample_direction direction,
+                        ovs_be64 flow_metadata, uint8_t *msisdn,
+                        struct eth_addr *apn_mac_addr, uint8_t *apn_name,
+-                       uint32_t app_name,
++                       uint32_t app_name, uint64_t pdp_start_epoch,
+                        const struct dpif_ipfix_port *tunnel_port,
+                        const struct flow_tnl *tunnel_key,
+                        struct dpif_ipfix_global_stats *stats,
+@@ -2127,6 +2129,7 @@ ipfix_cache_entry_init(struct ipfix_flow_cache_entry *entry,
+     ipdr_data = dp_packet_put_zeros(&msg, sizeof *ipdr_data);
+     ipdr_data->imsi = flow_metadata;
+     ipdr_data->app_name = app_name;
++    ipdr_data->pdp_start_epoch = pdp_start_epoch;
+     if (msisdn != NULL)
+         memcpy(&ipdr_data->msisdn, msisdn, 16);
+     if (apn_mac_addr != NULL)
+@@ -2510,7 +2513,7 @@ dpif_ipfix_sample(struct dpif_ipfix_exporter *exporter,
+                   enum nx_action_sample_direction direction,
+                   ovs_be64 flow_metadata, uint8_t *msisdn,
+                   struct eth_addr *apn_mac_addr, uint8_t *apn_name,
+-                  uint32_t app_name,
++                  uint32_t app_name, uint64_t pdp_start_epoch,
+                   const struct dpif_ipfix_port *tunnel_port,
+                   const struct flow_tnl *tunnel_key,
+                   const struct dpif_ipfix_actions *ipfix_actions)
+@@ -2527,7 +2530,7 @@ dpif_ipfix_sample(struct dpif_ipfix_exporter *exporter,
+                                    output_odp_port, direction,
+                                    flow_metadata, msisdn,
+                                    apn_mac_addr, apn_name,
+-                                   app_name,
++                                   app_name, pdp_start_epoch,
+                                    tunnel_port, tunnel_key,
+                                    &exporter->ipfix_global_stats,
+                                    ipfix_actions);
+@@ -2596,7 +2599,7 @@ dpif_ipfix_bridge_sample(struct dpif_ipfix *di, const struct dp_packet *packet,
+                       di->bridge_exporter.options->obs_domain_id,
+                       di->bridge_exporter.options->obs_point_id,
+                       output_odp_port, NX_ACTION_SAMPLE_DEFAULT,
+-                      0, NULL, NULL, NULL, 0, //not available for bridge export
++                      0, NULL, NULL, NULL, 0, 0, //not available for bridge export
+                       tunnel_port, tunnel_key, ipfix_actions);
+     ovs_mutex_unlock(&mutex);
+ }
+@@ -2644,7 +2647,7 @@ dpif_ipfix_flow_sample(struct dpif_ipfix *di, const struct dp_packet *packet,
+                           output_odp_port, cookie->flow_sample.direction,
+                           cookie->flow_sample.flow_metadata, (uint8_t *)&cookie->flow_sample.msisdn,
+                           (struct eth_addr *)&cookie->flow_sample.apn_mac_addr, (uint8_t *)&cookie->flow_sample.apn_name,
+-                          cookie->flow_sample.app_name,
++                          cookie->flow_sample.app_name, cookie->flow_sample.pdp_start_epoch,
+                           tunnel_port, tunnel_key, ipfix_actions);
+     }
+     ovs_mutex_unlock(&mutex);
+diff --git a/ofproto/ofproto-dpif-xlate.c b/ofproto/ofproto-dpif-xlate.c
+index 66e933182..cded34be1 100644
+--- a/ofproto/ofproto-dpif-xlate.c
++++ b/ofproto/ofproto-dpif-xlate.c
+@@ -5410,6 +5410,7 @@ xlate_sample_action(struct xlate_ctx *ctx,
+     cookie.flow_sample.direction = os->direction;
+     cookie.flow_sample.flow_metadata = ctx->xin->flow.metadata;
+     cookie.flow_sample.app_name = ctx->xin->flow.regs[10];
++    cookie.flow_sample.pdp_start_epoch = os->pdp_start_epoch;
+     memcpy(&cookie.flow_sample.msisdn, &os->msisdn, 16);
+     memcpy(&cookie.flow_sample.apn_mac_addr, &os->apn_mac_addr, sizeof(struct eth_addr));
+     memcpy(&cookie.flow_sample.apn_name, &os->apn_name, 24);
+-- 
+2.11.0
+

--- a/third_party/gtp_ovs/ovs-gtp-patches/2.14/0001-of-match-expand-NXM_NX_TUN_FLAGS-to-include-all-tunn.patch
+++ b/third_party/gtp_ovs/ovs-gtp-patches/2.14/0001-of-match-expand-NXM_NX_TUN_FLAGS-to-include-all-tunn.patch
@@ -1,7 +1,7 @@
-From b1912129aed550273521f6fb76a25e0399a009be Mon Sep 17 00:00:00 2001
+From 4c116172e0059872ddecafda61ce3c2ee95d6ce3 Mon Sep 17 00:00:00 2001
 From: Pravin B Shelar <pbshelar@fb.com>
 Date: Sun, 28 Jun 2020 21:49:40 +0000
-Subject: [PATCH 01/10] of-match: expand NXM_NX_TUN_FLAGS to include all tunnel
+Subject: [PATCH 01/14] of-match: expand NXM_NX_TUN_FLAGS to include all tunnel
  flags
 
 This allows OVS flows to match tunnel key and df flags. maching on
@@ -12,13 +12,13 @@ flags.
 Signed-off-by: Pravin B Shelar <pbshelar@fb.com>
 ---
  include/openvswitch/meta-flow.h |  2 +-
- include/openvswitch/packets.h   |  4 +--
+ include/openvswitch/packets.h   |  4 +---
  lib/netdev-vport.c              |  1 +
  lib/netdev.h                    |  1 +
- ofproto/tunnel.c                | 12 +++++++++
+ ofproto/tunnel.c                | 12 +++++++++++
  tests/tunnel-push-pop-ipv6.at   |  2 +-
  tests/tunnel-push-pop.at        |  2 +-
- tests/tunnel.at                 | 48 +++++++++++++++++++++++++++++++++
+ tests/tunnel.at                 | 48 +++++++++++++++++++++++++++++++++++++++++
  8 files changed, 66 insertions(+), 6 deletions(-)
 
 diff --git a/include/openvswitch/meta-flow.h b/include/openvswitch/meta-flow.h
@@ -50,7 +50,7 @@ index a65cb0d04..236ae26cc 100644
  #define FLOW_TNL_F_CSUM (1 << 2)
  #define FLOW_TNL_F_KEY (1 << 3)
 diff --git a/lib/netdev-vport.c b/lib/netdev-vport.c
-index 0252b61de..e7ddf1547 100644
+index 7c99f790d..2a7d14e99 100644
 --- a/lib/netdev-vport.c
 +++ b/lib/netdev-vport.c
 @@ -649,6 +649,7 @@ set_tunnel_config(struct netdev *dev_, const struct smap *args, char **errp)
@@ -186,5 +186,5 @@ index e08fd1e04..f17d91d77 100644
 +OVS_VSWITCHD_STOP
 +AT_CLEANUP
 -- 
-2.17.1
+2.13.5
 

--- a/third_party/gtp_ovs/ovs-gtp-patches/2.14/0002-userspace-IPFIX-Add-tunnel-type-GTP.patch
+++ b/third_party/gtp_ovs/ovs-gtp-patches/2.14/0002-userspace-IPFIX-Add-tunnel-type-GTP.patch
@@ -1,7 +1,7 @@
-From c9044a563d6ab0956e0c3cd73aeeb746c9b05f22 Mon Sep 17 00:00:00 2001
+From 5cc9f1c716c2d580b0e7ee4a91b81315e3c883cc Mon Sep 17 00:00:00 2001
 From: Pravin B Shelar <pbshelar@fb.com>
 Date: Mon, 24 Feb 2020 04:29:56 +0000
-Subject: [PATCH 02/10] userspace: IPFIX: Add tunnel type GTP
+Subject: [PATCH 02/14] userspace: IPFIX: Add tunnel type GTP
 
 Add support for ingress/egress tunnel type GTP
 in IPFIX.
@@ -56,7 +56,7 @@ index b89dfdd52..50f95e637 100644
  
  int
 diff --git a/lib/netdev-vport.c b/lib/netdev-vport.c
-index e7ddf1547..7158ef428 100644
+index 2a7d14e99..0f3d587e0 100644
 --- a/lib/netdev-vport.c
 +++ b/lib/netdev-vport.c
 @@ -578,6 +578,7 @@ set_tunnel_config(struct netdev *dev_, const struct smap *args, char **errp)
@@ -194,5 +194,5 @@ index a87b6777c..530752444 100644
  AT_CHECK([ovs-ofctl del-flows int-br])
  
 -- 
-2.17.1
+2.13.5
 

--- a/third_party/gtp_ovs/ovs-gtp-patches/2.14/0003-datapath-add-vport-gtp-for-GPRS-Tunneling-Protocol.patch
+++ b/third_party/gtp_ovs/ovs-gtp-patches/2.14/0003-datapath-add-vport-gtp-for-GPRS-Tunneling-Protocol.patch
@@ -1,7 +1,7 @@
-From 25741ac307902cee2c8851f38c5e26a79879430d Mon Sep 17 00:00:00 2001
+From f30ddbf373f84aca77a967469b8f8311cd40e677 Mon Sep 17 00:00:00 2001
 From: Pravin B Shelar <pbshelar@fb.com>
-Date: Mon, 24 Feb 2020 04:45:17 +0000
-Subject: [PATCH 03/10] datapath: add vport-gtp for GPRS Tunneling Protocol
+Date: Sat, 28 Nov 2020 00:55:30 -0800
+Subject: [PATCH 03/14] datapath: add vport-gtp for GPRS Tunneling Protocol
 
 Add vport-gtp which uses gtp_create_flow_based_dev exported by the Linux GTP
 module to create a flow based net_device
@@ -10,23 +10,23 @@ tested with ubuntu kernel 5.6.19-050619-generic.
 
 Signed-off-by: Pravin B Shelar <pbshelar@fb.com>
 ---
- acinclude.m4                                  |    4 +
- datapath/Modules.mk                           |    2 +
- datapath/linux/Modules.mk                     |    3 +
- datapath/linux/compat/gtp.c                   | 1797 +++++++++++++++++
- datapath/linux/compat/include/linux/gtp.h     |   10 +
- datapath/linux/compat/include/linux/if_link.h |   16 +
- datapath/linux/compat/include/net/dst_cache.h |    1 -
- datapath/linux/compat/include/net/gtp.h       |   24 +
- .../linux/compat/include/net/udp_tunnel.h     |    2 +-
- datapath/linux/compat/nf_conntrack_reasm.c    |    1 +
- datapath/linux/compat/udp_tunnel.c            |    2 +-
- datapath/vport-gtp.c                          |  147 ++
- datapath/vport.c                              |    8 +-
- tests/automake.mk                             |    2 +-
- tests/system-common-macros.at                 |    7 +
- tests/system-layer3-tunnels.at                |   53 +
- tests/tunnel.at                               |   28 +
+ acinclude.m4                                   |    4 +
+ datapath/Modules.mk                            |    2 +
+ datapath/linux/Modules.mk                      |    3 +
+ datapath/linux/compat/gtp.c                    | 1797 ++++++++++++++++++++++++
+ datapath/linux/compat/include/linux/gtp.h      |   10 +
+ datapath/linux/compat/include/linux/if_link.h  |   16 +
+ datapath/linux/compat/include/net/dst_cache.h  |    1 -
+ datapath/linux/compat/include/net/gtp.h        |   24 +
+ datapath/linux/compat/include/net/udp_tunnel.h |    2 +-
+ datapath/linux/compat/nf_conntrack_reasm.c     |    1 +
+ datapath/linux/compat/udp_tunnel.c             |    2 +-
+ datapath/vport-gtp.c                           |  147 ++
+ datapath/vport.c                               |    8 +-
+ tests/automake.mk                              |    2 +-
+ tests/system-common-macros.at                  |    7 +
+ tests/system-layer3-tunnels.at                 |   53 +
+ tests/tunnel.at                                |   28 +
  17 files changed, 2102 insertions(+), 5 deletions(-)
  create mode 100644 datapath/linux/compat/gtp.c
  create mode 100644 datapath/linux/compat/include/linux/gtp.h
@@ -2362,5 +2362,5 @@ index f17d91d77..e5d899ea1 100644
 +OVS_VSWITCHD_STOP
 +AT_CLEANUP
 -- 
-2.17.1
+2.13.5
 

--- a/third_party/gtp_ovs/ovs-gtp-patches/2.14/0004-ovs-Add-support-to-set-GTP-header-fields.patch
+++ b/third_party/gtp_ovs/ovs-gtp-patches/2.14/0004-ovs-Add-support-to-set-GTP-header-fields.patch
@@ -1,7 +1,7 @@
-From 02d660b3cbaeab7ba5375a1a4e7016d2ba68f328 Mon Sep 17 00:00:00 2001
+From ff384089a8c19feb63873534c9a13df92131b117 Mon Sep 17 00:00:00 2001
 From: Pravin B Shelar <pbshelar@fb.com>
-Date: Fri, 21 Aug 2020 04:54:53 +0000
-Subject: [PATCH 04/10] ovs: Add support to set GTP header fields.
+Date: Sat, 28 Nov 2020 00:58:18 -0800
+Subject: [PATCH 04/14] ovs: Add support to set GTP header fields.
 
 This allows OVS to match and set GTP header fields.
 This is useful when controller wants to send GTP
@@ -9,6 +9,7 @@ echo or end marker type msgs ovs GTP-U.
 
 Signed-off-by: Pravin B Shelar <pbshelar@fb.com>
 ---
+<<<<<<< HEAD
  datapath/flow_netlink.c                       |  54 +++++-
  datapath/linux/compat/gtp.c                   | 137 ++++++++++-----
  datapath/linux/compat/include/linux/gtp.h     |   9 +
@@ -24,6 +25,23 @@ Signed-off-by: Pravin B Shelar <pbshelar@fb.com>
  tests/ofproto.at                              |   2 +-
  tests/tunnel.at                               |  26 +++
  14 files changed, 331 insertions(+), 127 deletions(-)
+=======
+ datapath/flow_netlink.c                        |  54 +++++++++-
+ datapath/linux/compat/gtp.c                    | 137 ++++++++++++++++---------
+ datapath/linux/compat/include/linux/gtp.h      |   9 ++
+ datapath/linux/compat/include/net/ip_tunnels.h |   8 +-
+ datapath/vport.c                               |   1 +
+ include/openvswitch/meta-flow.h                |   6 +-
+ lib/dpif-netlink.c                             |   3 +-
+ lib/meta-flow.xml                              |  11 ++
+ lib/netdev-native-tnl.c                        |  18 ++--
+ lib/odp-util.c                                 |  60 ++++++++---
+ lib/packets.h                                  |  21 +++-
+ tests/odp.at                                   |   1 +
+ tests/ofproto.at                               |   2 +-
+ tests/tunnel.at                                |  26 +++++
+ 14 files changed, 275 insertions(+), 82 deletions(-)
+>>>>>>> 14cf17623... Enable IPFIX For LTE Setups (#4679)
 
 diff --git a/datapath/flow_netlink.c b/datapath/flow_netlink.c
 index d3fd77106..f7e54cfc1 100644
@@ -545,7 +563,11 @@ index 50f95e637..ea0896456 100644
      }
      ovs_mutex_unlock(&dev->mutex);
 diff --git a/lib/odp-util.c b/lib/odp-util.c
+<<<<<<< HEAD
 index 5989381e9..38bca86de 100644
+=======
+index d65ebb541..99bc25a0e 100644
+>>>>>>> 14cf17623... Enable IPFIX For LTE Setups (#4679)
 --- a/lib/odp-util.c
 +++ b/lib/odp-util.c
 @@ -764,7 +764,7 @@ format_odp_tnl_push_header(struct ds *ds, struct ovs_action_push_tnl *data)
@@ -557,7 +579,7 @@ index 5989381e9..38bca86de 100644
                        ntohl(get_16aligned_be32(&gtph->teid)));
      }
  
-@@ -1751,8 +1751,8 @@ ovs_parse_tnl_push(const char *s, struct ovs_action_push_tnl *data)
+@@ -1757,8 +1757,8 @@ ovs_parse_tnl_push(const char *s, struct ovs_action_push_tnl *data)
                  &gtpu_flags, &gtpu_msgtype, &teid)) {
          struct gtpuhdr *gtph = (struct gtpuhdr *) (udp + 1);
  
@@ -568,7 +590,7 @@ index 5989381e9..38bca86de 100644
          put_16aligned_be32(&gtph->teid, htonl(teid));
          tnl_type = OVS_VPORT_TYPE_GTPU;
          header_len = sizeof *eth + ip_len +
-@@ -2441,6 +2441,11 @@ parse_odp_action__(struct parse_odp_context *context, const char *s,
+@@ -2447,6 +2447,11 @@ parse_odp_action__(struct parse_odp_context *context, const char *s,
          return 8;
      }
  
@@ -580,7 +602,7 @@ index 5989381e9..38bca86de 100644
      {
          unsigned long long int meter_id;
          int n = -1;
-@@ -3077,8 +3082,12 @@ odp_tun_key_from_attr__(const struct nlattr *attr, bool is_mask,
+@@ -3083,8 +3088,12 @@ odp_tun_key_from_attr__(const struct nlattr *attr, bool is_mask,
          case OVS_TUNNEL_KEY_ATTR_GTPU_OPTS: {
              const struct gtpu_metadata *opts = nl_attr_get(a);
  
@@ -595,7 +617,7 @@ index 5989381e9..38bca86de 100644
              break;
          }
  
-@@ -3201,7 +3210,8 @@ tun_key_to_attr(struct ofpbuf *a, const struct flow_tnl *tun_key,
+@@ -3207,7 +3216,8 @@ tun_key_to_attr(struct ofpbuf *a, const struct flow_tnl *tun_key,
  
          opts.flags = tun_key->gtpu_flags;
          opts.msgtype = tun_key->gtpu_msgtype;
@@ -605,7 +627,7 @@ index 5989381e9..38bca86de 100644
                            &opts, sizeof(opts));
      }
      nl_msg_end_nested(a, tun_key_ofs);
-@@ -3462,8 +3472,8 @@ format_ipv6_label(struct ds *ds, const char *name, ovs_be32 key,
+@@ -3468,8 +3478,8 @@ format_ipv6_label(struct ds *ds, const char *name, ovs_be32 key,
  }
  
  static void
@@ -616,7 +638,7 @@ index 5989381e9..38bca86de 100644
  {
      bool mask_empty = mask && !*mask;
  
-@@ -3474,10 +3484,19 @@ format_u8x(struct ds *ds, const char *name, uint8_t key,
+@@ -3480,11 +3490,20 @@ format_u8x(struct ds *ds, const char *name, uint8_t key,
          if (!mask_full) { /* Partially masked. */
              ds_put_format(ds, "/%#"PRIx8, *mask);
          }
@@ -627,17 +649,18 @@ index 5989381e9..38bca86de 100644
      }
  }
  
-+static void
+ static void
 +format_u8x(struct ds *ds, const char *name, uint8_t key,
 +           const uint8_t *mask, bool verbose)
 +{
 +    format_u8x___(ds, name, key, mask, verbose, true);
 +}
 +
- static void
++static void
  format_u8u(struct ds *ds, const char *name, uint8_t key,
             const uint8_t *mask, bool verbose)
-@@ -3702,18 +3721,29 @@ format_odp_tun_erspan_opt(const struct nlattr *attr,
+ {
+@@ -3708,18 +3727,29 @@ format_odp_tun_erspan_opt(const struct nlattr *attr,
  
  static void
  format_odp_tun_gtpu_opt(const struct nlattr *attr,
@@ -834,7 +857,7 @@ index 395bc869e..c326bf1bb 100644
      ovs_16aligned_be32 teid;
  };
 diff --git a/tests/odp.at b/tests/odp.at
-index 1ebdf0515..d5b0b7fe1 100644
+index b762ebb2b..8658fce87 100644
 --- a/tests/odp.at
 +++ b/tests/odp.at
 @@ -325,6 +325,7 @@ pop_vlan
@@ -893,5 +916,5 @@ index e5d899ea1..8f448949f 100644
 +OVS_VSWITCHD_STOP
 +AT_CLEANUP
 -- 
-2.17.1
+2.13.5
 

--- a/third_party/gtp_ovs/ovs-gtp-patches/2.14/0005-OVS-gtp-echo-handling.patch
+++ b/third_party/gtp_ovs/ovs-gtp-patches/2.14/0005-OVS-gtp-echo-handling.patch
@@ -1,7 +1,7 @@
-From 4b30b6d91010528a43bbc571864851435b7731aa Mon Sep 17 00:00:00 2001
+From a2116901673d283795a430721a6aa914991a7a9f Mon Sep 17 00:00:00 2001
 From: Pravin B Shelar <pbshelar@fb.com>
 Date: Mon, 29 Jun 2020 02:45:36 +0000
-Subject: [PATCH 05/10] OVS: gtp echo handling
+Subject: [PATCH 05/14] OVS: gtp echo handling
 
 This uses OVS BFD module to send ech msgs.
 
@@ -9,23 +9,23 @@ testing done using ./tests/test-gtp 1.11.1.1 3201000a0000000000010000ff0003000a0
 
 Signed-off-by: Pravin B Shelar <pbshelar@fb.com>
 ---
- include/openvswitch/packets.h  |  16 ++
- lib/bfd.c                      |  81 ++++++++--
+ include/openvswitch/packets.h  |  16 +++
+ lib/bfd.c                      |  81 ++++++++++--
  lib/bfd.h                      |   4 +-
- lib/netdev-provider.h          |   8 +
+ lib/netdev-provider.h          |   8 ++
  lib/netdev-vport-private.h     |   1 +
- lib/netdev-vport.c             | 267 +++++++++++++++++++++++++++++++-
- lib/netdev.c                   |  38 +++++
+ lib/netdev-vport.c             | 267 +++++++++++++++++++++++++++++++++++++++-
+ lib/netdev.c                   |  38 ++++++
  lib/netdev.h                   |  11 ++
  ofproto/ofproto-dpif-monitor.c |  13 +-
- ofproto/ofproto-dpif-xlate.c   |  35 +++--
+ ofproto/ofproto-dpif-xlate.c   |  35 ++++--
  ofproto/ofproto-dpif-xlate.h   |   2 +
- ofproto/ofproto-dpif.c         |  17 ++
+ ofproto/ofproto-dpif.c         |  17 +++
  ofproto/ofproto-dpif.h         |   2 +
  tests/automake.mk              |   3 +
  tests/system-common-macros.at  |  19 +++
- tests/system-layer3-tunnels.at | 273 ++++++++++++++++++++++++++-------
- tests/test-gtp.c               | 111 ++++++++++++++
+ tests/system-layer3-tunnels.at | 273 +++++++++++++++++++++++++++++++++--------
+ tests/test-gtp.c               | 111 +++++++++++++++++
  17 files changed, 818 insertions(+), 83 deletions(-)
  create mode 100644 tests/test-gtp.c
 
@@ -287,7 +287,7 @@ index d89a28c66..3c82d5837 100644
  
  int netdev_vport_construct(struct netdev *);
 diff --git a/lib/netdev-vport.c b/lib/netdev-vport.c
-index 7158ef428..4e9696b98 100644
+index 0f3d587e0..1db1b7c0d 100644
 --- a/lib/netdev-vport.c
 +++ b/lib/netdev-vport.c
 @@ -29,6 +29,7 @@
@@ -324,7 +324,7 @@ index 7158ef428..4e9696b98 100644
      has_seq = strstr(type, "gre");
      memset(&tnl_cfg, 0, sizeof tnl_cfg);
  
-@@ -1121,6 +1125,256 @@ netdev_vport_get_pt_mode(const struct netdev *netdev)
+@@ -1129,6 +1133,256 @@ netdev_vport_get_pt_mode(const struct netdev *netdev)
  
  
  #ifdef __linux__
@@ -581,7 +581,7 @@ index 7158ef428..4e9696b98 100644
  static int
  netdev_vport_get_ifindex(const struct netdev *netdev_)
  {
-@@ -1246,6 +1500,11 @@ netdev_vport_tunnel_register(void)
+@@ -1254,6 +1508,11 @@ netdev_vport_tunnel_register(void)
                .build_header = netdev_gtpu_build_header,
                .push_header = netdev_gtpu_push_header,
                .pop_header = netdev_gtpu_pop_header,
@@ -593,7 +593,7 @@ index 7158ef428..4e9696b98 100644
            },
            {{NULL, NULL, 0, 0}}
          },
-@@ -1264,6 +1523,12 @@ netdev_vport_tunnel_register(void)
+@@ -1272,6 +1531,12 @@ netdev_vport_tunnel_register(void)
          unixctl_command_register("tnl/egress_port_range", "min max", 0, 2,
                                   netdev_tnl_egress_port_range, NULL);
  
@@ -708,7 +708,7 @@ index bb0e49091..42bf211e9 100644
                  MSEC_TO_PRIO(next_wake_time));
  }
 diff --git a/ofproto/ofproto-dpif-xlate.c b/ofproto/ofproto-dpif-xlate.c
-index e0ede2cab..6b5f8051a 100644
+index 1f78da105..1ee6845e6 100644
 --- a/ofproto/ofproto-dpif-xlate.c
 +++ b/ofproto/ofproto-dpif-xlate.c
 @@ -7954,17 +7954,14 @@ xlate_resume(struct ofproto_dpif *ofproto,
@@ -1275,5 +1275,5 @@ index 000000000..aede93daf
 +    return 0;
 +}
 -- 
-2.17.1
+2.13.5
 

--- a/third_party/gtp_ovs/ovs-gtp-patches/2.14/0006-ovs-test-add-gtp-marker-test.patch
+++ b/third_party/gtp_ovs/ovs-gtp-patches/2.14/0006-ovs-test-add-gtp-marker-test.patch
@@ -1,11 +1,11 @@
-From a53097b10391af0e92361adfa883f3dedc7dcfea Mon Sep 17 00:00:00 2001
+From 1ab1e72a6487d830c480f4f2a4dc1cfd235fcccb Mon Sep 17 00:00:00 2001
 From: Pravin B Shelar <pbshelar@fb.com>
 Date: Mon, 29 Jun 2020 06:54:04 +0000
-Subject: [PATCH 06/10] ovs: test: add gtp marker test
+Subject: [PATCH 06/14] ovs: test: add gtp marker test
 
 Signed-off-by: Pravin B Shelar <pbshelar@fb.com>
 ---
- tests/system-layer3-tunnels.at | 60 ++++++++++++++++++++++++++++++++++
+ tests/system-layer3-tunnels.at | 60 ++++++++++++++++++++++++++++++++++++++++++
  1 file changed, 60 insertions(+)
 
 diff --git a/tests/system-layer3-tunnels.at b/tests/system-layer3-tunnels.at
@@ -77,5 +77,5 @@ index 4bbb2198e..5587d6cde 100644
 +OVS_TRAFFIC_VSWITCHD_STOP
 +AT_CLEANUP
 -- 
-2.17.1
+2.13.5
 

--- a/third_party/gtp_ovs/ovs-gtp-patches/2.14/0007-datapath-Fixes-for-4.9-kernel.patch
+++ b/third_party/gtp_ovs/ovs-gtp-patches/2.14/0007-datapath-Fixes-for-4.9-kernel.patch
@@ -1,7 +1,7 @@
-From d58da2f572dff55df4d6af5c6465169297af8568 Mon Sep 17 00:00:00 2001
+From ca88f58b1ae945019039802e8576f882a83d3c94 Mon Sep 17 00:00:00 2001
 From: Pravin B Shelar <pbshelar@fb.com>
 Date: Tue, 7 Jul 2020 01:46:36 +0000
-Subject: [PATCH 07/10] datapath: Fixes for 4.9 kernel
+Subject: [PATCH 07/14] datapath: Fixes for 4.9 kernel
 
 Signed-off-by: Pravin B Shelar <pbshelar@fb.com>
 ---
@@ -64,5 +64,5 @@ index 5587d6cde..57f39e3ad 100644
  NS_CHECK_EXEC([at_ns0], [ip addr add dev at_gtp1 10.1.1.1/24])
  NS_CHECK_EXEC([at_ns0], [ip link set dev at_gtp1 mtu 1450 up])
 -- 
-2.17.1
+2.13.5
 

--- a/third_party/gtp_ovs/ovs-gtp-patches/2.14/0008-ovs-datapath-enable-kernel-5.6.patch
+++ b/third_party/gtp_ovs/ovs-gtp-patches/2.14/0008-ovs-datapath-enable-kernel-5.6.patch
@@ -1,7 +1,7 @@
-From d0cc60411748b45dce5b3c6edb3cb471ed3a0abc Mon Sep 17 00:00:00 2001
+From a2e83d027029e1c6a45641f5b7c9e9195f974851 Mon Sep 17 00:00:00 2001
 From: Pravin B Shelar <pbshelar@fb.com>
 Date: Fri, 21 Aug 2020 05:35:16 +0000
-Subject: [PATCH 08/10] ovs: datapath enable kernel 5.6
+Subject: [PATCH 08/14] ovs: datapath enable kernel 5.6
 
 Signed-off-by: Pravin B Shelar <pbshelar@fb.com>
 ---
@@ -26,5 +26,5 @@ index e712cdfd2..fe0419de2 100644
      elif test "$version" = 4; then
         : # Linux 4.x
 -- 
-2.17.1
+2.13.5
 

--- a/third_party/gtp_ovs/ovs-gtp-patches/2.14/0009-AGW-OVS-handle-gtp-tunnel-type.patch
+++ b/third_party/gtp_ovs/ovs-gtp-patches/2.14/0009-AGW-OVS-handle-gtp-tunnel-type.patch
@@ -1,7 +1,7 @@
-From 52fc1ed034847c5d5f725f45fe03a67571260a8e Mon Sep 17 00:00:00 2001
+From d1a84965a64c893ac9b12ec67a15e736da8bef8a Mon Sep 17 00:00:00 2001
 From: Pravin B Shelar <pbshelar@fb.com>
 Date: Wed, 23 Sep 2020 04:01:59 +0000
-Subject: [PATCH 09/10] AGW: OVS: handle gtp tunnel type
+Subject: [PATCH 09/14] AGW: OVS: handle gtp tunnel type
 
 magma GTP implementation defines gtp as tunnel type for OVS tunnel.
 But upstream ovs it is defined as gtpu. This patch maps older name to
@@ -49,5 +49,5 @@ index 0955c0e1f..14f133888 100755
                          -- --if-exists del-port "$OVS_BRIDGE" "$DEVICE" \
                          -- add-port "$OVS_BRIDGE" "$DEVICE" $OVS_OPTIONS \
 -- 
-2.17.1
+2.13.5
 

--- a/third_party/gtp_ovs/ovs-gtp-patches/2.14/0010-native-tnl-routing-tunnel-lookup-with-pkt-mark.patch
+++ b/third_party/gtp_ovs/ovs-gtp-patches/2.14/0010-native-tnl-routing-tunnel-lookup-with-pkt-mark.patch
@@ -1,7 +1,7 @@
-From 5bdca1f30a3f82c5cd7e1da408bcd86401d593c0 Mon Sep 17 00:00:00 2001
+From e77e9fb167e59f17322cf208a8accef2743709e9 Mon Sep 17 00:00:00 2001
 From: Pravin B Shelar <pbshelar@fb.com>
 Date: Sun, 27 Sep 2020 19:46:24 +0000
-Subject: [PATCH 10/10] native-tnl: routing: tunnel lookup with pkt-mark
+Subject: [PATCH 10/14] native-tnl: routing: tunnel lookup with pkt-mark
 
 In case of zero packet mark ignore packet mark in lookup.
 
@@ -108,5 +108,5 @@ index 6dacc2954..6d6e648a5 100644
  AT_CHECK([ovs-appctl ovs/route/show | grep User | sort], [0], [dnl
  User: 2001:db8:babe::/64 dev br0 GW 2001:db8:cafe::2 SRC 2001:db8:cafe::1
 -- 
-2.17.1
+2.13.5
 

--- a/third_party/gtp_ovs/ovs-gtp-patches/2.14/0011-fixes-for-2.14.patch
+++ b/third_party/gtp_ovs/ovs-gtp-patches/2.14/0011-fixes-for-2.14.patch
@@ -1,0 +1,231 @@
+From 9571fe78e1dd4de4a4307bc0650ef0fb710d21d6 Mon Sep 17 00:00:00 2001
+From: Pravin B Shelar <pbshelar@fb.com>
+Date: Sat, 28 Nov 2020 23:09:50 -0800
+Subject: [PATCH 11/14] fixes for 2.14
+
+---
+ datapath/flow_netlink.c                           |  2 ++
+ datapath/linux/compat/gtp.c                       | 34 +++++++++++++++--------
+ datapath/linux/compat/include/linux/openvswitch.h |  3 --
+ datapath/linux/compat/include/net/ip_tunnels.h    |  7 +++--
+ lib/odp-util.c                                    | 16 +++++++++++
+ manpages.mk                                       |  5 ++--
+ 6 files changed, 47 insertions(+), 20 deletions(-)
+
+diff --git a/datapath/flow_netlink.c b/datapath/flow_netlink.c
+index f7e54cfc1..a1842e1c3 100644
+--- a/datapath/flow_netlink.c
++++ b/datapath/flow_netlink.c
+@@ -41,9 +41,11 @@
+ #include <linux/icmp.h>
+ #include <linux/icmpv6.h>
+ #include <linux/rculist.h>
++#include <linux/openvswitch.h>
+ #include <net/geneve.h>
+ #include <net/ip.h>
+ #include <net/ipv6.h>
++#include <net/ip_tunnels.h>
+ #include <net/ndisc.h>
+ #include <net/mpls.h>
+ #include <net/vxlan.h>
+diff --git a/datapath/linux/compat/gtp.c b/datapath/linux/compat/gtp.c
+index 46add66dc..20ad23ecb 100644
+--- a/datapath/linux/compat/gtp.c
++++ b/datapath/linux/compat/gtp.c
+@@ -21,7 +21,6 @@
+ #include <linux/file.h>
+ #include <linux/gtp.h>
+ 
+-#include <net/dst_cache.h>
+ #include <net/dst_metadata.h>
+ #include <net/net_namespace.h>
+ #include <net/protocol.h>
+@@ -190,6 +189,15 @@ static bool gtp_check_ms(struct sk_buff *skb, struct pdp_ctx *pctx,
+ 	return false;
+ }
+ 
++static int check_header(struct sk_buff *skb, int len)
++{
++	if (unlikely(skb->len < len))
++		return -EINVAL;
++	if (unlikely(!pskb_may_pull(skb, len)))
++		return -ENOMEM;
++	return 0;
++}
++
+ static int gtp_rx(struct gtp_dev *gtp, struct sk_buff *skb,
+ 			unsigned int hdrlen, u8 gtp_version, unsigned int role,
+ 			__be64 tid, u8 flags, u8 type)
+@@ -283,6 +291,20 @@ static int gtp_rx(struct gtp_dev *gtp, struct sk_buff *skb,
+ 	 * calculate the transport header.
+ 	 */
+ 	skb_reset_network_header(skb);
++	if (!check_header(skb, sizeof(struct iphdr))) {
++		struct iphdr *iph;
++
++		iph = ip_hdr(skb);
++		if (iph->version == 4) {
++			netdev_dbg(gtp->dev, "inner pkt: ipv4");
++			skb->protocol = htons(ETH_P_IP);
++		} else if (iph->version == 6) {
++			netdev_dbg(gtp->dev, "inner pkt: ipv6");
++			skb->protocol = htons(ETH_P_IPV6);
++		} else {
++			netdev_dbg(gtp->dev, "inner pkt: control pkt");
++		}
++	}
+ 
+ 	skb->dev = gtp->dev;
+ 
+@@ -582,8 +604,6 @@ static struct rtable *gtp_get_v4_rt(struct sk_buff *skb,
+                                        struct flowi4 *fl4,
+                                        const struct ip_tunnel_info *info)
+ {
+-	bool use_cache = ip_tunnel_dst_cache_usable(skb, info);
+-	struct dst_cache *dst_cache;
+ 	struct rtable *rt = NULL;
+ 
+ 	if (!gs4)
+@@ -596,12 +616,6 @@ static struct rtable *gtp_get_v4_rt(struct sk_buff *skb,
+ 	fl4->saddr = info->key.u.ipv4.src;
+ 	fl4->flowi4_tos = RT_TOS(info->key.tos);
+ 
+-	dst_cache = (struct dst_cache *)&info->dst_cache;
+-	if (use_cache) {
+-		rt = dst_cache_get_ip4(dst_cache, &fl4->saddr);
+-		if (rt)
+-			return rt;
+-	}
+ 	rt = ip_route_output_key(dev_net(dev), fl4);
+ 	if (IS_ERR(rt)) {
+ 		netdev_dbg(dev, "no route to %pI4\n", &fl4->daddr);
+@@ -612,8 +626,6 @@ static struct rtable *gtp_get_v4_rt(struct sk_buff *skb,
+ 		ip_rt_put(rt);
+ 		return ERR_PTR(-ELOOP);
+ 	}
+-	if (use_cache)
+-		dst_cache_set_ip4(dst_cache, &rt->dst, fl4->saddr);
+ 	return rt;
+ }
+ 
+diff --git a/datapath/linux/compat/include/linux/openvswitch.h b/datapath/linux/compat/include/linux/openvswitch.h
+index 2d884312f..cc41bbea4 100644
+--- a/datapath/linux/compat/include/linux/openvswitch.h
++++ b/datapath/linux/compat/include/linux/openvswitch.h
+@@ -405,10 +405,7 @@ enum ovs_tunnel_key_attr {
+ 	OVS_TUNNEL_KEY_ATTR_IPV6_DST,		/* struct in6_addr dst IPv6 address. */
+ 	OVS_TUNNEL_KEY_ATTR_PAD,
+ 	OVS_TUNNEL_KEY_ATTR_ERSPAN_OPTS,	/* struct erspan_metadata */
+-#ifndef __KERNEL__
+-	/* Only used within userspace data path. */
+ 	OVS_TUNNEL_KEY_ATTR_GTPU_OPTS,		/* struct gtpu_metadata */
+-#endif
+ 	__OVS_TUNNEL_KEY_ATTR_MAX
+ };
+ 
+diff --git a/datapath/linux/compat/include/net/ip_tunnels.h b/datapath/linux/compat/include/net/ip_tunnels.h
+index 66bd252ea..21f3676e8 100644
+--- a/datapath/linux/compat/include/net/ip_tunnels.h
++++ b/datapath/linux/compat/include/net/ip_tunnels.h
+@@ -9,9 +9,6 @@
+  * be used. Those needs to be explicitly defined in this header file. */
+ #include_next <net/ip_tunnels.h>
+ 
+-#ifndef TUNNEL_ERSPAN_OPT
+-#define TUNNEL_ERSPAN_OPT	__cpu_to_be16(0x4000)
+-#endif
+ #define ovs_ip_tunnel_encap ip_tunnel_encap
+ 
+ #ifndef HAVE_IP_TUNNEL_INFO_OPTS_SET_FLAGS
+@@ -514,6 +511,10 @@ static inline int iptunnel_pull_offloads(struct sk_buff *skb)
+ #define skb_is_encapsulated ovs_skb_is_encapsulated
+ bool ovs_skb_is_encapsulated(struct sk_buff *skb);
+ 
++#ifndef TUNNEL_ERSPAN_OPT
++#define TUNNEL_ERSPAN_OPT	__cpu_to_be16(0x4000)
++#endif
++
+ #ifndef TUNNEL_GTPU_OPT
+ #define TUNNEL_GTPU_OPT          __cpu_to_be16(0x8000)
+ #endif
+diff --git a/lib/odp-util.c b/lib/odp-util.c
+index 99bc25a0e..2591833f6 100644
+--- a/lib/odp-util.c
++++ b/lib/odp-util.c
+@@ -5222,10 +5222,24 @@ scan_gtpu_metadata(const char *s,
+                    struct gtpu_metadata *mask)
+ {
+     const char *s_base = s;
++    uint8_t ver = 0, ver_ma = 0;
+     uint8_t flags = 0, flags_ma = 0;
+     uint8_t msgtype = 0, msgtype_ma = 0;
+     int len;
+ 
++    if (!strncmp(s, "ver=", 4)) {
++        s += 4;
++        len = scan_u8(s, &ver, mask ? &ver_ma : NULL);
++        if (len == 0) {
++            return 0;
++        }
++        s += len;
++    }
++    if (s[0] == ',') {
++        s++;
++    }
++
++
+     if (!strncmp(s, "flags=", 6)) {
+         s += 6;
+         len = scan_u8(s, &flags, mask ? &flags_ma : NULL);
+@@ -5250,9 +5264,11 @@ scan_gtpu_metadata(const char *s,
+ 
+     if (!strncmp(s, ")", 1)) {
+         s += 1;
++        key->ver = ver;
+         key->flags = flags;
+         key->msgtype = msgtype;
+         if (mask) {
++            mask->ver = ver_ma;
+             mask->flags = flags_ma;
+             mask->msgtype = msgtype_ma;
+         }
+diff --git a/manpages.mk b/manpages.mk
+index dc201484c..5f04b9c2c 100644
+--- a/manpages.mk
++++ b/manpages.mk
+@@ -104,7 +104,6 @@ utilities/bugtool/ovs-bugtool.8: \
+ utilities/bugtool/ovs-bugtool.8.in:
+ lib/ovs.tmac:
+ 
+-
+ utilities/ovs-dpctl-top.8: \
+ 	utilities/ovs-dpctl-top.8.in \
+ 	lib/ovs.tmac
+@@ -155,8 +154,6 @@ lib/common-syn.man:
+ lib/common.man:
+ lib/ovs.tmac:
+ 
+-lib/ovs.tmac:
+-
+ utilities/ovs-testcontroller.8: \
+ 	utilities/ovs-testcontroller.8.in \
+ 	lib/common.man \
+@@ -211,6 +208,7 @@ vswitchd/ovs-vswitchd.8: \
+ 	lib/coverage-unixctl.man \
+ 	lib/daemon.man \
+ 	lib/dpctl.man \
++	lib/dpdk-unixctl.man \
+ 	lib/dpif-netdev-unixctl.man \
+ 	lib/memory-unixctl.man \
+ 	lib/netdev-dpdk-unixctl.man \
+@@ -230,6 +228,7 @@ lib/common.man:
+ lib/coverage-unixctl.man:
+ lib/daemon.man:
+ lib/dpctl.man:
++lib/dpdk-unixctl.man:
+ lib/dpif-netdev-unixctl.man:
+ lib/memory-unixctl.man:
+ lib/netdev-dpdk-unixctl.man:
+-- 
+2.13.5
+

--- a/third_party/gtp_ovs/ovs-gtp-patches/2.14/0012-Add-custom-IPDR-fields-for-IPFIX-export.patch
+++ b/third_party/gtp_ovs/ovs-gtp-patches/2.14/0012-Add-custom-IPDR-fields-for-IPFIX-export.patch
@@ -1,0 +1,293 @@
+From 116bd3fe04cd69c5322b32e076dbf5f8d0e5e671 Mon Sep 17 00:00:00 2001
+From: Nick Yurchenko <koolzz@fb.com>
+Date: Mon, 1 Feb 2021 21:25:00 -0500
+Subject: [PATCH 12/14] Add custom IPDR fields for IPFIX export
+
+Signed-off-by: Nick Yurchenko <koolzz@fb.com>
+---
+ include/openvswitch/ofp-actions.h     |  3 +++
+ lib/odp-util.h                        |  7 +++++-
+ lib/ofp-actions.c                     | 38 +++++++++++++++++++++++++++---
+ ofproto/ipfix-enterprise-entities.def |  7 ++++++
+ ofproto/ofproto-dpif-ipfix.c          | 44 +++++++++++++++++++++++++++++++++++
+ ofproto/ofproto-dpif-xlate.c          |  5 ++++
+ 6 files changed, 100 insertions(+), 4 deletions(-)
+
+diff --git a/include/openvswitch/ofp-actions.h b/include/openvswitch/ofp-actions.h
+index 226e86d0b..02f17fa7e 100644
+--- a/include/openvswitch/ofp-actions.h
++++ b/include/openvswitch/ofp-actions.h
+@@ -1018,6 +1018,9 @@ struct ofpact_sample {
+         uint32_t obs_point_id;
+         ofp_port_t sampling_port;
+         enum nx_action_sample_direction direction;
++        uint8_t msisdn[16];
++        struct eth_addr apn_mac_addr;
++        uint8_t apn_name[24];
+     );
+ };
+ 
+diff --git a/lib/odp-util.h b/lib/odp-util.h
+index a1d0d0fba..9dbff67a4 100644
+--- a/lib/odp-util.h
++++ b/lib/odp-util.h
+@@ -335,6 +335,11 @@ struct user_action_cookie {
+             uint32_t obs_point_id;  /* Observation Point ID. */
+             odp_port_t output_odp_port; /* The output odp port. */
+             enum nx_action_sample_direction direction;
++            ovs_be64 flow_metadata;
++            uint32_t app_name;
++            uint8_t msisdn[16];
++            struct eth_addr apn_mac_addr;
++            uint8_t apn_name[24];
+         } flow_sample;
+ 
+         struct {
+@@ -354,7 +359,7 @@ struct user_action_cookie {
+         } controller;
+     };
+ };
+-BUILD_ASSERT_DECL(sizeof(struct user_action_cookie) == 48);
++BUILD_ASSERT_DECL(sizeof(struct user_action_cookie) == 112);
+ 
+ int odp_put_userspace_action(uint32_t pid,
+                              const void *userdata, size_t userdata_size,
+diff --git a/lib/ofp-actions.c b/lib/ofp-actions.c
+index be08a53fd..ddbb4fc46 100644
+--- a/lib/ofp-actions.c
++++ b/lib/ofp-actions.c
+@@ -6127,10 +6127,13 @@ struct nx_action_sample2 {
+     ovs_be32 obs_domain_id;         /* ID of sampling observation domain. */
+     ovs_be32 obs_point_id;          /* ID of sampling observation point. */
+     ovs_be16 sampling_port;         /* Sampling port. */
++    uint8_t  msisdn[16];
++    struct   eth_addr apn_mac_addr;
++    uint8_t  apn_name[24];
+     uint8_t  direction;             /* NXAST_SAMPLE3 only. */
+     uint8_t  zeros[5];              /* Pad to a multiple of 8 bytes */
+  };
+- OFP_ASSERT(sizeof(struct nx_action_sample2) == 32);
++ OFP_ASSERT(sizeof(struct nx_action_sample2) == 80);
+ 
+ static enum ofperr
+ decode_NXAST_RAW_SAMPLE(const struct nx_action_sample *nas,
+@@ -6167,6 +6170,9 @@ decode_SAMPLE2(const struct nx_action_sample2 *nas,
+     sample->obs_domain_id = ntohl(nas->obs_domain_id);
+     sample->obs_point_id = ntohl(nas->obs_point_id);
+     sample->sampling_port = u16_to_ofp(ntohs(nas->sampling_port));
++    sample->apn_mac_addr = nas->apn_mac_addr;
++    memcpy(&sample->msisdn, &nas->msisdn, 16);
++    memcpy(&sample->apn_name, &nas->apn_name, 24);
+     sample->direction = direction;
+ 
+     if (sample->probability == 0) {
+@@ -6213,6 +6219,9 @@ encode_SAMPLE2(const struct ofpact_sample *sample,
+     nas->obs_point_id = htonl(sample->obs_point_id);
+     nas->sampling_port = htons(ofp_to_u16(sample->sampling_port));
+     nas->direction = sample->direction;
++    memcpy(&nas->msisdn, &sample->msisdn, 16);
++    nas->apn_mac_addr = sample->apn_mac_addr;
++    memcpy(&nas->apn_name, &sample->apn_name, 24);
+ }
+ 
+ static void
+@@ -6245,8 +6254,11 @@ parse_SAMPLE(char *arg, const struct ofpact_parse_params *pp)
+     struct ofpact_sample *os = ofpact_put_SAMPLE(pp->ofpacts);
+     os->sampling_port = OFPP_NONE;
+     os->direction = NX_ACTION_SAMPLE_DEFAULT;
++    memset(&os->msisdn, 0, 16);
++    memset(&os->apn_name, 0, 24);
+ 
+     char *key, *value;
++    int i;
+     while (ofputil_parse_key_value(&arg, &key, &value)) {
+         char *error = NULL;
+ 
+@@ -6255,6 +6267,20 @@ parse_SAMPLE(char *arg, const struct ofpact_parse_params *pp)
+             if (!error && os->probability == 0) {
+                 error = xasprintf("invalid probability value \"%s\"", value);
+             }
++        } else if (!strcmp(key, "apn_name")) {
++            for (i = 0; i < 24; i++) {
++                os->apn_name[i] = (uint8_t)value[i];
++                if ((char)value[i] == '\0')
++                    break;
++            }
++        } else if (!strcmp(key, "msisdn")) {
++            for (i = 0; i < 16; i++) {
++                os->msisdn[i] = (uint8_t)value[i];
++                if ((char)value[i] == '\0')
++                    break;
++            }
++        } else if (!strcmp(key, "apn_mac_addr")) {
++            error = str_to_mac(value, &os->apn_mac_addr);
+         } else if (!strcmp(key, "collector_set_id")) {
+             error = str_to_u32(value, &os->collector_set_id);
+         } else if (!strcmp(key, "obs_domain_id")) {
+@@ -6292,12 +6318,18 @@ format_SAMPLE(const struct ofpact_sample *a,
+     ds_put_format(fp->s, "%ssample(%s%sprobability=%s%"PRIu16
+                   ",%scollector_set_id=%s%"PRIu32
+                   ",%sobs_domain_id=%s%"PRIu32
+-                  ",%sobs_point_id=%s%"PRIu32,
++                  ",%sobs_point_id=%s%"PRIu32
++                  ",%sapn_mac_addr=%s"ETH_ADDR_FMT
++                  ",%smsisdn=%s%s"
++                  ",%sapn_name=%s%s",
+                   colors.paren, colors.end,
+                   colors.param, colors.end, a->probability,
+                   colors.param, colors.end, a->collector_set_id,
+                   colors.param, colors.end, a->obs_domain_id,
+-                  colors.param, colors.end, a->obs_point_id);
++                  colors.param, colors.end, a->obs_point_id,
++                  colors.param, colors.end, ETH_ADDR_ARGS(a->apn_mac_addr),
++                  colors.param, colors.end, a->msisdn,
++                  colors.param, colors.end, a->apn_name);
+     if (a->sampling_port != OFPP_NONE) {
+         ds_put_format(fp->s, ",%ssampling_port=%s", colors.param, colors.end);
+         ofputil_format_port(a->sampling_port, fp->port_map, fp->s);
+diff --git a/ofproto/ipfix-enterprise-entities.def b/ofproto/ipfix-enterprise-entities.def
+index 73a520c25..89e77ec45 100644
+--- a/ofproto/ipfix-enterprise-entities.def
++++ b/ofproto/ipfix-enterprise-entities.def
+@@ -14,4 +14,11 @@ IPFIX_ENTERPRISE_ENTITY(TUNNEL_SOURCE_TRANSPORT_PORT, 896, 2, tunnelSourceTransp
+ IPFIX_ENTERPRISE_ENTITY(TUNNEL_DESTINATION_TRANSPORT_PORT, 897, 2, tunnelDestinationTransportPort, IPFIX_ENTERPRISE_VMWARE)
+ IPFIX_ENTERPRISE_ENTITY(VIRTUAL_OBS_ID, 898, 0, virtualObsID, IPFIX_ENTERPRISE_VMWARE)
+ 
++#define IPFIX_ENTERPRISE_IPDR 6888
++IPFIX_ENTERPRISE_ENTITY(IMSI_REG, 899, 8, imsiRegister, IPFIX_ENTERPRISE_IPDR)
++IPFIX_ENTERPRISE_ENTITY(MSISDN, 900, 16, msisdn, IPFIX_ENTERPRISE_IPDR)
++IPFIX_ENTERPRISE_ENTITY(APN_MAC_ADDRESS, 901, 6, apnMacAddress, IPFIX_ENTERPRISE_IPDR)
++IPFIX_ENTERPRISE_ENTITY(APN_NAME, 902, 24, apnName, IPFIX_ENTERPRISE_IPDR)
++IPFIX_ENTERPRISE_ENTITY(APP_NAME, 903, 4, appName, IPFIX_ENTERPRISE_IPDR)
++
+ #undef IPFIX_ENTERPRISE_ENTITY
+diff --git a/ofproto/ofproto-dpif-ipfix.c b/ofproto/ofproto-dpif-ipfix.c
+index ed0a4ace0..dda89f409 100644
+--- a/ofproto/ofproto-dpif-ipfix.c
++++ b/ofproto/ofproto-dpif-ipfix.c
+@@ -406,6 +406,16 @@ struct ipfix_data_record_flow_key_tunnel {
+ });
+ BUILD_ASSERT_DECL(sizeof(struct ipfix_data_record_flow_key_tunnel) == 15);
+ 
++OVS_PACKED(
++struct ipfix_data_ipdr_fields {
++    ovs_be64 imsi;  /* IMSI_REGISTER*/
++    uint8_t msisdn[16];  /* MSISDN */
++    struct eth_addr apn_mac_address;  /* APN_MAC_ADDRESS */
++    uint8_t apn_name[24];  /* APN_NAME */
++    uint32_t app_name;  /* APP_NAME */
++});
++BUILD_ASSERT_DECL(sizeof(struct ipfix_data_ipdr_fields) == 58);
++
+ /* Cf. IETF RFC 5102 Section 5.11.3. */
+ enum ipfix_flow_end_reason {
+     IDLE_TIMEOUT = 0x01,
+@@ -539,6 +549,7 @@ BUILD_ASSERT_DECL(sizeof(struct ipfix_data_record_aggregated_tcp) == 48);
+      + MAX(sizeof(struct ipfix_data_record_flow_key_icmp),      \
+            sizeof(struct ipfix_data_record_flow_key_transport)) \
+      + sizeof(struct ipfix_data_record_flow_key_tunnel)         \
++     + sizeof(struct ipfix_data_ipdr_fields)                    \
+      + MAX_TUNNEL_KEY_LEN)
+ 
+ #define MAX_DATA_RECORD_LEN                                 \
+@@ -1483,6 +1494,13 @@ ipfix_define_template_fields(enum ipfix_proto_l2 l2, enum ipfix_proto_l3 l3,
+         DEF(TUNNEL_KEY);
+     }
+ 
++    /* Custom IPDR fields */
++    DEF(IMSI_REG);
++    DEF(MSISDN);
++    DEF(APN_MAC_ADDRESS);
++    DEF(APN_NAME);
++    DEF(APP_NAME);
++
+     /* 2. Virtual observation ID, which is not a part of flow key. */
+     if (virtual_obs_id_set) {
+         DEF(VIRTUAL_OBS_ID);
+@@ -2098,6 +2116,9 @@ ipfix_cache_entry_init(const struct dpif_ipfix *di,
+                        uint64_t packet_delta_count, uint32_t obs_domain_id,
+                        uint32_t obs_point_id, odp_port_t output_odp_port,
+                        enum nx_action_sample_direction direction,
++                       ovs_be64 flow_metadata, uint8_t *msisdn,
++                       struct eth_addr *apn_mac_addr, uint8_t *apn_name,
++                       uint32_t app_name,
+                        const struct dpif_ipfix_port *tunnel_port,
+                        const struct flow_tnl *tunnel_key,
+                        struct dpif_ipfix_global_stats *stats,
+@@ -2294,6 +2315,19 @@ ipfix_cache_entry_init(const struct dpif_ipfix *di,
+                tunnel_port->tunnel_key_length);
+     }
+ 
++    /* Add custom IPDR fields */
++    struct ipfix_data_ipdr_fields *ipdr_data;
++
++    ipdr_data = dp_packet_put_zeros(&msg, sizeof *ipdr_data);
++    ipdr_data->imsi = flow_metadata;
++    ipdr_data->app_name = app_name;
++    if (msisdn != NULL)
++        memcpy(&ipdr_data->msisdn, msisdn, 16);
++    if (apn_mac_addr != NULL)
++        memcpy(&ipdr_data->apn_mac_address, apn_mac_addr, sizeof(struct eth_addr));
++    if (apn_name != NULL)
++        memcpy(&ipdr_data->apn_name, apn_name, 24);
++
+     flow_key->flow_key_msg_part_size = dp_packet_size(&msg);
+ 
+     if (eth_addr_is_broadcast(flow->dl_dst)) {
+@@ -2667,6 +2701,9 @@ dpif_ipfix_sample(const struct dpif_ipfix *di,
+                   uint64_t packet_delta_count, uint32_t obs_domain_id,
+                   uint32_t obs_point_id, odp_port_t output_odp_port,
+                   enum nx_action_sample_direction direction,
++                  ovs_be64 flow_metadata, uint8_t *msisdn,
++                  struct eth_addr *apn_mac_addr, uint8_t *apn_name,
++                  uint32_t app_name,
+                   const struct dpif_ipfix_port *tunnel_port,
+                   const struct flow_tnl *tunnel_key,
+                   const struct dpif_ipfix_actions *ipfix_actions)
+@@ -2682,6 +2719,9 @@ dpif_ipfix_sample(const struct dpif_ipfix *di,
+                                    flow, packet_delta_count,
+                                    obs_domain_id, obs_point_id,
+                                    output_odp_port, direction,
++                                   flow_metadata, msisdn,
++                                   apn_mac_addr, apn_name,
++                                   app_name,
+                                    tunnel_port, tunnel_key,
+                                    &exporter->ipfix_global_stats,
+                                    ipfix_actions);
+@@ -2750,6 +2790,7 @@ dpif_ipfix_bridge_sample(struct dpif_ipfix *di, const struct dp_packet *packet,
+                       di->bridge_exporter.options->obs_domain_id,
+                       di->bridge_exporter.options->obs_point_id,
+                       output_odp_port, NX_ACTION_SAMPLE_DEFAULT,
++                      0, NULL, NULL, NULL, 0, //not available for bridge export
+                       tunnel_port, tunnel_key, ipfix_actions);
+     ovs_mutex_unlock(&mutex);
+ }
+@@ -2795,6 +2836,9 @@ dpif_ipfix_flow_sample(struct dpif_ipfix *di, const struct dp_packet *packet,
+                           cookie->flow_sample.obs_domain_id,
+                           cookie->flow_sample.obs_point_id,
+                           output_odp_port, cookie->flow_sample.direction,
++                          cookie->flow_sample.flow_metadata, (uint8_t *)&cookie->flow_sample.msisdn,
++                          (struct eth_addr *)&cookie->flow_sample.apn_mac_addr, (uint8_t *)&cookie->flow_sample.apn_name,
++                          cookie->flow_sample.app_name,
+                           tunnel_port, tunnel_key, ipfix_actions);
+     }
+     ovs_mutex_unlock(&mutex);
+diff --git a/ofproto/ofproto-dpif-xlate.c b/ofproto/ofproto-dpif-xlate.c
+index 1ee6845e6..395fec9bc 100644
+--- a/ofproto/ofproto-dpif-xlate.c
++++ b/ofproto/ofproto-dpif-xlate.c
+@@ -5642,6 +5642,11 @@ xlate_sample_action(struct xlate_ctx *ctx,
+     cookie.flow_sample.obs_point_id = os->obs_point_id;
+     cookie.flow_sample.output_odp_port = output_odp_port;
+     cookie.flow_sample.direction = os->direction;
++    cookie.flow_sample.flow_metadata = ctx->xin->flow.metadata;
++    cookie.flow_sample.app_name = ctx->xin->flow.regs[10];
++    memcpy(&cookie.flow_sample.msisdn, &os->msisdn, 16);
++    memcpy(&cookie.flow_sample.apn_mac_addr, &os->apn_mac_addr, sizeof(struct eth_addr));
++    memcpy(&cookie.flow_sample.apn_name, &os->apn_name, 24);
+ 
+     compose_sample_action(ctx, probability, &cookie, tunnel_out_port, false);
+ }
+-- 
+2.13.5
+

--- a/third_party/gtp_ovs/ovs-gtp-patches/2.14/0013-ovs-Handle-spaces-in-ovs-arguments.patch
+++ b/third_party/gtp_ovs/ovs-gtp-patches/2.14/0013-ovs-Handle-spaces-in-ovs-arguments.patch
@@ -1,0 +1,158 @@
+From 6807607471f52e522a50357aa7f550ad3573c301 Mon Sep 17 00:00:00 2001
+From: Pravin B Shelar <pbshelar@fb.com>
+Date: Fri, 13 Mar 2020 19:18:40 +0000
+Subject: [PATCH 13/14] ovs: Handle spaces in ovs arguments
+
+Signed-off-by: Pravin B Shelar <pbshelar@fb.com>
+---
+ lib/ofp-actions.c | 28 +++++++++++++++++++---------
+ lib/ofp-parse.c   | 21 ++++++++++++++++++---
+ lib/string.c      | 24 ++++++++++++++++++++++++
+ lib/string.h.in   |  1 +
+ 4 files changed, 62 insertions(+), 12 deletions(-)
+
+diff --git a/lib/ofp-actions.c b/lib/ofp-actions.c
+index ddbb4fc46..0da43d1a9 100644
+--- a/lib/ofp-actions.c
++++ b/lib/ofp-actions.c
+@@ -6268,8 +6268,11 @@ parse_SAMPLE(char *arg, const struct ofpact_parse_params *pp)
+                 error = xasprintf("invalid probability value \"%s\"", value);
+             }
+         } else if (!strcmp(key, "apn_name")) {
++            int j = 0;
+             for (i = 0; i < 24; i++) {
+-                os->apn_name[i] = (uint8_t)value[i];
++                if (value[i] == '"')
++                    continue;
++                os->apn_name[j++] = (uint8_t)value[i];
+                 if ((char)value[i] == '\0')
+                     break;
+             }
+@@ -6318,18 +6321,25 @@ format_SAMPLE(const struct ofpact_sample *a,
+     ds_put_format(fp->s, "%ssample(%s%sprobability=%s%"PRIu16
+                   ",%scollector_set_id=%s%"PRIu32
+                   ",%sobs_domain_id=%s%"PRIu32
+-                  ",%sobs_point_id=%s%"PRIu32
+-                  ",%sapn_mac_addr=%s"ETH_ADDR_FMT
+-                  ",%smsisdn=%s%s"
+-                  ",%sapn_name=%s%s",
++                  ",%sobs_point_id=%s%"PRIu32,
+                   colors.paren, colors.end,
+                   colors.param, colors.end, a->probability,
+                   colors.param, colors.end, a->collector_set_id,
+                   colors.param, colors.end, a->obs_domain_id,
+-                  colors.param, colors.end, a->obs_point_id,
+-                  colors.param, colors.end, ETH_ADDR_ARGS(a->apn_mac_addr),
+-                  colors.param, colors.end, a->msisdn,
+-                  colors.param, colors.end, a->apn_name);
++                  colors.param, colors.end, a->obs_point_id);
++    if (!eth_addr_is_zero(a->apn_mac_addr)) {
++        ds_put_format(fp->s,  ",%sapn_mac_addr=%s"ETH_ADDR_FMT,
++                  colors.param, colors.end, ETH_ADDR_ARGS(a->apn_mac_addr));
++
++    }
++    if (strlen((const char *)a->msisdn)) {
++        ds_put_format(fp->s, ",%smsisdn=%s%s", colors.param, colors.end, a->msisdn);
++    }
++    if (strlen((const char *)a->apn_name)) {
++        char buf[32], *name;
++        name = str_quotify((char *)a->apn_name, 24, buf);
++        ds_put_format(fp->s, ",%sapn_name=%s%s", colors.param, colors.end, name);
++    }
+     if (a->sampling_port != OFPP_NONE) {
+         ds_put_format(fp->s, ",%ssampling_port=%s", colors.param, colors.end);
+         ofputil_format_port(a->sampling_port, fp->port_map, fp->s);
+diff --git a/lib/ofp-parse.c b/lib/ofp-parse.c
+index a90b926ef..100cd911d 100644
+--- a/lib/ofp-parse.c
++++ b/lib/ofp-parse.c
+@@ -319,9 +319,16 @@ ofputil_parse_key_value(char **stringp, char **keyp, char **valuep)
+      *     - If key_delim is "(", the value extends until ")".
+      *
+      * If there is no value, we are done. */
++    char *value = *stringp;
+     const char *value_delims;
++    bool value_with_quote = false;
+     if (key_delim == ':' || key_delim == '=') {
+-        value_delims = ", \t\r\n";
++        if (*value == '\"') {
++            value_delims = "\"";
++            value_with_quote = true;
++        } else {
++            value_delims = ", \t\r\n";
++        }
+     } else if (key_delim == '(') {
+         value_delims = ")";
+     } else {
+@@ -332,8 +339,12 @@ ofputil_parse_key_value(char **stringp, char **keyp, char **valuep)
+ 
+     /* Extract the value.  Advance the input position past the value and
+      * delimiter. */
+-    char *value = *stringp;
+-    size_t value_len = parse_value(value, value_delims);
++    size_t value_len;
++    if (value_with_quote) {
++        value_len = parse_value(value + 1, value_delims);
++    } else {
++        value_len = parse_value(value, value_delims);
++    }
+     char value_delim = value[value_len];
+ 
+     /* Handle the special case if the value is of the form "(x)->y".
+@@ -345,7 +356,11 @@ ofputil_parse_key_value(char **stringp, char **keyp, char **valuep)
+         value_len += parse_value(&value[value_len], value_delims);
+         value_delim = value[value_len];
+     }
++    if (value_with_quote) {
++        value_len += 2;
++    }
+     value[value_len] = '\0';
++
+     *stringp += value_len + (value_delim != '\0');
+ 
+     *keyp = key;
+diff --git a/lib/string.c b/lib/string.c
+index e7e265bdf..b0bc80359 100644
+--- a/lib/string.c
++++ b/lib/string.c
+@@ -44,3 +44,27 @@ char *strcasestr(const char *str, const char *substr)
+     return NULL;
+ }
+ #endif
++
++/* Expect string 'd' is atleast three char longer than 's'. */
++char *
++str_quotify(const char *s, int len, char *d)
++{
++    bool found_space = false;
++    int i = 0;
++
++    d[0] = '"';
++    while(s[i] != '\0' && i <= len) {
++        d[i + 1] = s[i];
++        if (s[i] == ' ') {
++            found_space = true;
++        }
++        i++;
++    }
++    if (found_space) {
++        d[i + 1] = '"';
++        d[i + 2] = '\0';
++        return d;
++    } else {
++        return &d[1];
++    }
++}
+diff --git a/lib/string.h.in b/lib/string.h.in
+index 7a8e18f41..69565c9a9 100644
+--- a/lib/string.h.in
++++ b/lib/string.h.in
+@@ -45,4 +45,5 @@ char *strcasestr(const char *, const char *);
+ size_t strnlen(const char *, size_t maxlen);
+ #endif
+ 
++char *str_quotify(const char *s, int len, char *d);
+ #endif /* string.h wrapper */
+-- 
+2.13.5
+

--- a/third_party/gtp_ovs/ovs-gtp-patches/2.14/0014-Add-pdp_start_epoch-custom-field-to-IPFIX-export.patch
+++ b/third_party/gtp_ovs/ovs-gtp-patches/2.14/0014-Add-pdp_start_epoch-custom-field-to-IPFIX-export.patch
@@ -1,0 +1,209 @@
+From 3dab94a37938541f7c01a025690f94f2aa62f581 Mon Sep 17 00:00:00 2001
+From: Nick Yurchenko <koolzz@fb.com>
+Date: Mon, 1 Feb 2021 21:46:32 -0500
+Subject: [PATCH 14/14] Add pdp_start_epoch custom field to IPFIX export
+
+Signed-off-by: Nick Yurchenko <koolzz@fb.com>
+---
+ include/openvswitch/ofp-actions.h     |  1 +
+ lib/odp-util.h                        |  3 ++-
+ lib/ofp-actions.c                     | 13 ++++++++++---
+ ofproto/ipfix-enterprise-entities.def |  1 +
+ ofproto/ofproto-dpif-ipfix.c          | 15 +++++++++------
+ ofproto/ofproto-dpif-xlate.c          |  1 +
+ 6 files changed, 24 insertions(+), 10 deletions(-)
+
+diff --git a/include/openvswitch/ofp-actions.h b/include/openvswitch/ofp-actions.h
+index 02f17fa7e..9d1f7c6a1 100644
+--- a/include/openvswitch/ofp-actions.h
++++ b/include/openvswitch/ofp-actions.h
+@@ -1021,6 +1021,7 @@ struct ofpact_sample {
+         uint8_t msisdn[16];
+         struct eth_addr apn_mac_addr;
+         uint8_t apn_name[24];
++        uint64_t pdp_start_epoch;
+     );
+ };
+ 
+diff --git a/lib/odp-util.h b/lib/odp-util.h
+index 9dbff67a4..a32ab220b 100644
+--- a/lib/odp-util.h
++++ b/lib/odp-util.h
+@@ -340,6 +340,7 @@ struct user_action_cookie {
+             uint8_t msisdn[16];
+             struct eth_addr apn_mac_addr;
+             uint8_t apn_name[24];
++            uint64_t pdp_start_epoch;
+         } flow_sample;
+ 
+         struct {
+@@ -359,7 +360,7 @@ struct user_action_cookie {
+         } controller;
+     };
+ };
+-BUILD_ASSERT_DECL(sizeof(struct user_action_cookie) == 112);
++BUILD_ASSERT_DECL(sizeof(struct user_action_cookie) == 120);
+ 
+ int odp_put_userspace_action(uint32_t pid,
+                              const void *userdata, size_t userdata_size,
+diff --git a/lib/ofp-actions.c b/lib/ofp-actions.c
+index 0da43d1a9..202259a93 100644
+--- a/lib/ofp-actions.c
++++ b/lib/ofp-actions.c
+@@ -6130,10 +6130,11 @@ struct nx_action_sample2 {
+     uint8_t  msisdn[16];
+     struct   eth_addr apn_mac_addr;
+     uint8_t  apn_name[24];
++    uint64_t pdp_start_epoch;
+     uint8_t  direction;             /* NXAST_SAMPLE3 only. */
+     uint8_t  zeros[5];              /* Pad to a multiple of 8 bytes */
+  };
+- OFP_ASSERT(sizeof(struct nx_action_sample2) == 80);
++ OFP_ASSERT(sizeof(struct nx_action_sample2) == 88);
+ 
+ static enum ofperr
+ decode_NXAST_RAW_SAMPLE(const struct nx_action_sample *nas,
+@@ -6171,6 +6172,7 @@ decode_SAMPLE2(const struct nx_action_sample2 *nas,
+     sample->obs_point_id = ntohl(nas->obs_point_id);
+     sample->sampling_port = u16_to_ofp(ntohs(nas->sampling_port));
+     sample->apn_mac_addr = nas->apn_mac_addr;
++    sample->pdp_start_epoch = nas->pdp_start_epoch;
+     memcpy(&sample->msisdn, &nas->msisdn, 16);
+     memcpy(&sample->apn_name, &nas->apn_name, 24);
+     sample->direction = direction;
+@@ -6222,6 +6224,7 @@ encode_SAMPLE2(const struct ofpact_sample *sample,
+     memcpy(&nas->msisdn, &sample->msisdn, 16);
+     nas->apn_mac_addr = sample->apn_mac_addr;
+     memcpy(&nas->apn_name, &sample->apn_name, 24);
++    nas->pdp_start_epoch = sample->pdp_start_epoch;
+ }
+ 
+ static void
+@@ -6284,6 +6287,8 @@ parse_SAMPLE(char *arg, const struct ofpact_parse_params *pp)
+             }
+         } else if (!strcmp(key, "apn_mac_addr")) {
+             error = str_to_mac(value, &os->apn_mac_addr);
++        } else if (!strcmp(key, "pdp_start_epoch")) {
++            error = str_to_u64(value, &os->pdp_start_epoch);
+         } else if (!strcmp(key, "collector_set_id")) {
+             error = str_to_u32(value, &os->collector_set_id);
+         } else if (!strcmp(key, "obs_domain_id")) {
+@@ -6321,12 +6326,14 @@ format_SAMPLE(const struct ofpact_sample *a,
+     ds_put_format(fp->s, "%ssample(%s%sprobability=%s%"PRIu16
+                   ",%scollector_set_id=%s%"PRIu32
+                   ",%sobs_domain_id=%s%"PRIu32
+-                  ",%sobs_point_id=%s%"PRIu32,
++                  ",%sobs_point_id=%s%"PRIu32
++                  ",%spdp_start_epoch=%s%"PRIu64,
+                   colors.paren, colors.end,
+                   colors.param, colors.end, a->probability,
+                   colors.param, colors.end, a->collector_set_id,
+                   colors.param, colors.end, a->obs_domain_id,
+-                  colors.param, colors.end, a->obs_point_id);
++                  colors.param, colors.end, a->obs_point_id,
++                  colors.param, colors.end, a->pdp_start_epoch);
+     if (!eth_addr_is_zero(a->apn_mac_addr)) {
+         ds_put_format(fp->s,  ",%sapn_mac_addr=%s"ETH_ADDR_FMT,
+                   colors.param, colors.end, ETH_ADDR_ARGS(a->apn_mac_addr));
+diff --git a/ofproto/ipfix-enterprise-entities.def b/ofproto/ipfix-enterprise-entities.def
+index 89e77ec45..f59b69115 100644
+--- a/ofproto/ipfix-enterprise-entities.def
++++ b/ofproto/ipfix-enterprise-entities.def
+@@ -20,5 +20,6 @@ IPFIX_ENTERPRISE_ENTITY(MSISDN, 900, 16, msisdn, IPFIX_ENTERPRISE_IPDR)
+ IPFIX_ENTERPRISE_ENTITY(APN_MAC_ADDRESS, 901, 6, apnMacAddress, IPFIX_ENTERPRISE_IPDR)
+ IPFIX_ENTERPRISE_ENTITY(APN_NAME, 902, 24, apnName, IPFIX_ENTERPRISE_IPDR)
+ IPFIX_ENTERPRISE_ENTITY(APP_NAME, 903, 4, appName, IPFIX_ENTERPRISE_IPDR)
++IPFIX_ENTERPRISE_ENTITY(PDP_START_EPOCH, 904, 8, pdpStartEpoch, IPFIX_ENTERPRISE_IPDR)
+ 
+ #undef IPFIX_ENTERPRISE_ENTITY
+diff --git a/ofproto/ofproto-dpif-ipfix.c b/ofproto/ofproto-dpif-ipfix.c
+index dda89f409..1639bf683 100644
+--- a/ofproto/ofproto-dpif-ipfix.c
++++ b/ofproto/ofproto-dpif-ipfix.c
+@@ -413,8 +413,9 @@ struct ipfix_data_ipdr_fields {
+     struct eth_addr apn_mac_address;  /* APN_MAC_ADDRESS */
+     uint8_t apn_name[24];  /* APN_NAME */
+     uint32_t app_name;  /* APP_NAME */
++    uint64_t pdp_start_epoch; /* PDP_START_EPOCH */
+ });
+-BUILD_ASSERT_DECL(sizeof(struct ipfix_data_ipdr_fields) == 58);
++BUILD_ASSERT_DECL(sizeof(struct ipfix_data_ipdr_fields) == 66);
+ 
+ /* Cf. IETF RFC 5102 Section 5.11.3. */
+ enum ipfix_flow_end_reason {
+@@ -1500,6 +1501,7 @@ ipfix_define_template_fields(enum ipfix_proto_l2 l2, enum ipfix_proto_l3 l3,
+     DEF(APN_MAC_ADDRESS);
+     DEF(APN_NAME);
+     DEF(APP_NAME);
++    DEF(PDP_START_EPOCH);
+ 
+     /* 2. Virtual observation ID, which is not a part of flow key. */
+     if (virtual_obs_id_set) {
+@@ -2118,7 +2120,7 @@ ipfix_cache_entry_init(const struct dpif_ipfix *di,
+                        enum nx_action_sample_direction direction,
+                        ovs_be64 flow_metadata, uint8_t *msisdn,
+                        struct eth_addr *apn_mac_addr, uint8_t *apn_name,
+-                       uint32_t app_name,
++                       uint32_t app_name, uint64_t pdp_start_epoch,
+                        const struct dpif_ipfix_port *tunnel_port,
+                        const struct flow_tnl *tunnel_key,
+                        struct dpif_ipfix_global_stats *stats,
+@@ -2321,6 +2323,7 @@ ipfix_cache_entry_init(const struct dpif_ipfix *di,
+     ipdr_data = dp_packet_put_zeros(&msg, sizeof *ipdr_data);
+     ipdr_data->imsi = flow_metadata;
+     ipdr_data->app_name = app_name;
++    ipdr_data->pdp_start_epoch = pdp_start_epoch;
+     if (msisdn != NULL)
+         memcpy(&ipdr_data->msisdn, msisdn, 16);
+     if (apn_mac_addr != NULL)
+@@ -2703,7 +2706,7 @@ dpif_ipfix_sample(const struct dpif_ipfix *di,
+                   enum nx_action_sample_direction direction,
+                   ovs_be64 flow_metadata, uint8_t *msisdn,
+                   struct eth_addr *apn_mac_addr, uint8_t *apn_name,
+-                  uint32_t app_name,
++                  uint32_t app_name, uint64_t pdp_start_epoch,
+                   const struct dpif_ipfix_port *tunnel_port,
+                   const struct flow_tnl *tunnel_key,
+                   const struct dpif_ipfix_actions *ipfix_actions)
+@@ -2721,7 +2724,7 @@ dpif_ipfix_sample(const struct dpif_ipfix *di,
+                                    output_odp_port, direction,
+                                    flow_metadata, msisdn,
+                                    apn_mac_addr, apn_name,
+-                                   app_name,
++                                   app_name, pdp_start_epoch,
+                                    tunnel_port, tunnel_key,
+                                    &exporter->ipfix_global_stats,
+                                    ipfix_actions);
+@@ -2790,7 +2793,7 @@ dpif_ipfix_bridge_sample(struct dpif_ipfix *di, const struct dp_packet *packet,
+                       di->bridge_exporter.options->obs_domain_id,
+                       di->bridge_exporter.options->obs_point_id,
+                       output_odp_port, NX_ACTION_SAMPLE_DEFAULT,
+-                      0, NULL, NULL, NULL, 0, //not available for bridge export
++                      0, NULL, NULL, NULL, 0, 0, //not available for bridge export
+                       tunnel_port, tunnel_key, ipfix_actions);
+     ovs_mutex_unlock(&mutex);
+ }
+@@ -2838,7 +2841,7 @@ dpif_ipfix_flow_sample(struct dpif_ipfix *di, const struct dp_packet *packet,
+                           output_odp_port, cookie->flow_sample.direction,
+                           cookie->flow_sample.flow_metadata, (uint8_t *)&cookie->flow_sample.msisdn,
+                           (struct eth_addr *)&cookie->flow_sample.apn_mac_addr, (uint8_t *)&cookie->flow_sample.apn_name,
+-                          cookie->flow_sample.app_name,
++                          cookie->flow_sample.app_name, cookie->flow_sample.pdp_start_epoch,
+                           tunnel_port, tunnel_key, ipfix_actions);
+     }
+     ovs_mutex_unlock(&mutex);
+diff --git a/ofproto/ofproto-dpif-xlate.c b/ofproto/ofproto-dpif-xlate.c
+index 395fec9bc..87e3c2d84 100644
+--- a/ofproto/ofproto-dpif-xlate.c
++++ b/ofproto/ofproto-dpif-xlate.c
+@@ -5644,6 +5644,7 @@ xlate_sample_action(struct xlate_ctx *ctx,
+     cookie.flow_sample.direction = os->direction;
+     cookie.flow_sample.flow_metadata = ctx->xin->flow.metadata;
+     cookie.flow_sample.app_name = ctx->xin->flow.regs[10];
++    cookie.flow_sample.pdp_start_epoch = os->pdp_start_epoch;
+     memcpy(&cookie.flow_sample.msisdn, &os->msisdn, 16);
+     memcpy(&cookie.flow_sample.apn_mac_addr, &os->apn_mac_addr, sizeof(struct eth_addr));
+     memcpy(&cookie.flow_sample.apn_name, &os->apn_name, 24);
+-- 
+2.13.5
+

--- a/third_party/gtp_ovs/ovs-gtp-patches/2.14/README.md
+++ b/third_party/gtp_ovs/ovs-gtp-patches/2.14/README.md
@@ -18,7 +18,7 @@ Steps to build package from source code.
 2. cd $MAGMA_ROOT/third_party/gtp_ovs/ovs/2.14/
 3. git clone https://github.com/openvswitch/ovs
 4. cd ovs/
-5. git checkout 42f667e223c005683185a97dd092545d27f29a04
+5. git checkout 4c116172e0059872ddecafda61ce3c2ee95d6ce3
 6. git am ../000*
 7. DEB_BUILD_OPTIONS='parallel=8 nocheck' fakeroot debian/rules binary
 8. Packages are copied in parent (..) dir


### PR DESCRIPTION
This PR adds support for IPFIX record exports for LTE based deployments(previously only supported for CWF)

Commit log:

* Enable IPFIX for lte setups

Signed-off-by: Nick Yurchenko <koolzz@fb.com>

* Update ovs patches

Signed-off-by: Nick Yurchenko <koolzz@fb.com>

* Fix sessiond if

Signed-off-by: Nick Yurchenko <koolzz@fb.com>

* Update playbook for ipfix ryu patch

Signed-off-by: Nick Yurchenko <koolzz@fb.com>

* Add patches to 2.8.9

Signed-off-by: Nick Yurchenko <koolzz@fb.com>

* Fix spacing

Signed-off-by: Nick Yurchenko <koolzz@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
