### PR TITLE
[Bug_Fix] [MME] Fixed MME crash for stale ENB cleanup issue

### DIFF
--- a/lte/gateway/c/oai/tasks/s1ap/s1ap_mme_handlers.c
+++ b/lte/gateway/c/oai/tasks/s1ap/s1ap_mme_handlers.c
@@ -362,13 +362,20 @@ void clean_stale_enb_state(
     ue_description_t* ue_ref = NULL;
     for (int i = 0; i < keys->num_keys; i++) {
       ue_ref = s1ap_state_get_ue_mmeid((mme_ue_s1ap_id_t) keys->keys[i]);
+      /* The function s1ap_remove_ue will take care of removing the enb also,
+       * when the last UE is removed
+       */
       s1ap_remove_ue(state, ue_ref);
     }
     FREE_HASHTABLE_KEY_ARRAY(keys);
+  } else {
+    // Remove the old eNB association
+    OAILOG_INFO(
+        LOG_S1AP, "Deleting eNB: %s (Sctp_assoc_id = %u)",
+        stale_enb_association->enb_name, stale_enb_association->sctp_assoc_id);
+    s1ap_remove_enb(state, stale_enb_association);
   }
 
-  // Remove the old eNB association
-  s1ap_remove_enb(state, stale_enb_association);
   OAILOG_DEBUG(LOG_S1AP, "Removed stale eNB and all associated UEs.");
 }
 


### PR DESCRIPTION
## Title
[Bug_Fix] [MME] Fixed MME crash for stale enb cleanup issue

## Summary
MME was crashing sometimes when running test case test_continuous_random_attach.py in loop for large number of UEs. The reason was that sometimes the stale ENB entry was not cleaned up before the next test case execution and while cleaning the stale ENB entry during next s1ap association, the old ENB association was tried to get removed twice. This was leading to access of invalid pointer and crashing the MME. This PR fixes the issue.

## Test Plan
Verified with sanity and multiple executions of test case test_continuous_random_attach.py

Signed-off-by: VinashakAnkitAman <ankit.aman@radisys.com>