### PR TITLE
[subscriberdb] remove print grpc from purge

### DIFF
--- a/lte/gateway/python/magma/subscriberdb/protocols/s6a_proxy_servicer.py
+++ b/lte/gateway/python/magma/subscriberdb/protocols/s6a_proxy_servicer.py
@@ -130,11 +130,8 @@ class S6aProxyRpcServicer(s6a_proxy_pb2_grpc.S6aProxyServicer):
         return ula
 
     def PurgeUE(self, request, context):
-        self._print_grpc(request)
-        logging.getLevelName()
         logging.warning("Purge request not implemented: %s %s",
                         request.DESCRIPTOR.full_name, MessageToJson(request))
-
         return s6a_proxy_pb2.PurgeUEAnswer()
 
     @staticmethod


### PR DESCRIPTION
Signed-off-by: Oriol Batalla <obatalla@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary

Remove printing of grpc due to wrong implementation. 
Will be added in a future PR

## Test Plan

terravm tests

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
