### PR TITLE
[nms] Add NMS DB data migration scripts, readme, and docs for 1.5

### DIFF
--- a/docs/readmes/orc8r/upgrade_1_5.md
+++ b/docs/readmes/orc8r/upgrade_1_5.md
@@ -1,0 +1,22 @@
+---
+id: upgrade_1_5
+title: Upgrade to v1.5
+hide_title: true
+---
+
+# Upgrade to v1.5
+
+This guide covers upgrading Orchestrator deployments from v1.4 to v1.5.
+
+The v1.5 upgrade follows a standard procedure:
+
+- Migrate NMS DB data to orc8r DB
+- etc.
+
+## NMS DB Data Migration
+
+Run on a machine with access to the kubernetes cluster you are using to run Magma.
+
+*Paste in shell prompt:*
+
+`wget https://gist.githubusercontent.com/andreilee/7aa7d533e2e8f425222b1e6a016a6f5a/raw/286abea80fbec8d03df9949d74f6f2dd298d8222/pre-upgrade-migration.sh && chmod +x pre-upgrade-migration.sh && ./pre-upgrade-migration.sh`

--- a/nms/app/packages/magmalte/scripts/fuji-upgrade/README.md
+++ b/nms/app/packages/magmalte/scripts/fuji-upgrade/README.md
@@ -1,0 +1,13 @@
+# Magma Pre 1.5 Upgrade NMS DB Data Migration
+
+Magma versions 1.4 and prior use a separate database for the NMS and the orc8r.
+This provides a process to combine these two databases together, a necessary
+process before completing the rest of the upgrade from 1.4 to 1.5.
+
+## Usage
+
+Run on a machine with access to the kubernetes cluster you are using to run Magma.
+
+*Paste in shell prompt:*
+
+`wget https://gist.githubusercontent.com/andreilee/7aa7d533e2e8f425222b1e6a016a6f5a/raw/286abea80fbec8d03df9949d74f6f2dd298d8222/pre-upgrade-migration.sh && chmod +x pre-upgrade-migration.sh && ./pre-upgrade-migration.sh`

--- a/nms/app/packages/magmalte/scripts/fuji-upgrade/pre-upgrade-migration.sh
+++ b/nms/app/packages/magmalte/scripts/fuji-upgrade/pre-upgrade-migration.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+################################################################################
+# Copyright 2020 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+NMS_SCRIPT_URI="https://gist.githubusercontent.com/andreilee/7aa7d533e2e8f425222b1e6a016a6f5a/raw/5b3c9346dedca6dcfb8d0a13c5f3b4d9100b9279/runs-on-nms.sh"
+
+cat << EOF
+================================================================================
+                  Magma Pre-1.5-Upgrade NMS DB Data Migration
+================================================================================
+
+This script will guide you through the process of copying NMS DB data to the
+orc8r DB.
+
+This process is required to be completed prior to the rest of the 1.5 upgrade
+process. When this process is completed, you are ready to complete the rest of
+your 1.5 upgrade.
+
+PRE-REQUISITES
+* You will want to make sure that you have some understanding of your
+  kubernetes setup on which you have Magma orc8r and NMS running.
+* Ensure that you have access to your kubernetes cluster which is running the
+  Magma orc8r and NMS.
+
+--------------------------------------------------------------------------------
+EOF
+
+# Get the Magma k8s namespace
+read -p "Enter Kubernetes namespace [magma]: " magma_namespace
+magma_namespace=${magma_namespace:-magma}
+echo ""
+
+# Find NMS pod name
+nms_pod_name=$(kubectl -n magma get pods --no-headers -o custom-columns=":metadata.name" | grep nms-magmalte)
+echo "Found Magma NMS pod name: $nms_pod_name"
+read -p "Enter NMS pod name [$nms_pod_name]: " input
+nms_pod_name=${input:-$nms_pod_name}
+echo ""
+
+# Find configurator pod name
+orc8r_pod_name=$(kubectl -n magma get pods --no-headers -o custom-columns=":metadata.name" | grep orc8r-configurator)
+echo "Found Magma configurator pod name: $orc8r_pod_name"
+read -p "Enter configurator pod name [$orc8r_pod_name]: " input
+orc8r_pod_name=${input:-$orc8r_pod_name}
+echo ""
+
+# Get DB connection parameters automatically from an orc8r pod env
+# Can't do this through the NMS pod
+database_source=$(kubectl -n $magma_namespace exec $orc8r_pod_name -- /bin/bash -c 'echo $DATABASE_SOURCE')
+orc8r_db_host=$(echo $database_source | grep -E -o '(?:host=)\S*' | sed 's/host=//')
+orc8r_db_port=$(echo $database_source | grep -E -o '(?:port=)\S*' | sed 's/port=//')
+orc8r_db_name=$(echo $database_source | grep -E -o '(?:dbname=)\S*' | sed 's/dbname=//')
+orc8r_db_username=$(echo $database_source | grep -E -o '(?:user=)\S*' | sed 's/user=//')
+orc8r_db_password=$(echo $database_source | grep -E -o '(?:password=)\S*' | sed 's/password=//')
+orc8r_db_dialect=$(kubectl -n $magma_namespace exec $orc8r_pod_name -- /bin/bash -c 'echo $SQL_DRIVER')
+
+# Extra whitespacing
+echo ""
+
+nms_command="wget $NMS_SCRIPT_URI -O - | bash /dev/stdin -u $orc8r_db_username -w $orc8r_db_password -h $orc8r_db_host -p $orc8r_db_port -b $orc8r_db_name -d $orc8r_db_dialect --confirm"
+
+kubectl -n $magma_namespace exec $nms_pod_name -- /bin/bash -c "$nms_command"

--- a/nms/app/packages/magmalte/scripts/fuji-upgrade/runs-on-nms.sh
+++ b/nms/app/packages/magmalte/scripts/fuji-upgrade/runs-on-nms.sh
@@ -1,0 +1,75 @@
+#!/bin/bash
+###############################################################################
+# Copyright 2020 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+###############################################################################
+
+# Script arguments (specifies source DB only):
+# -u: DB username
+# -w: DB password
+# -h: DB host
+# -p: DB port
+# -b: DB name
+# -d: DB SQL dialect
+#
+# EXAMPLE USAGE
+# ./runs-on-nms.sh -h postgres -p 5432 -b nms -d postgres -u root -w password
+
+while getopts ":h:p:b:d:u:w:" opt; do
+  case $opt in
+    h) arg_host="$OPTARG"
+    ;;
+    p) arg_port="$OPTARG"
+    ;;
+    b) arg_db="$OPTARG"
+    ;;
+    d) arg_dialect="$OPTARG"
+    ;;
+    u) arg_username="$OPTARG"
+    ;;
+    w) arg_password="$OPTARG"
+    ;;
+    \?) echo "Invalid option -$OPTARG" >&2
+    ;;
+  esac
+done
+
+cat << EOF
+--------------------------------------------------------------------------------
+              Upgrading @fbcnms/sequelize-models to ^0.1.4
+--------------------------------------------------------------------------------
+EOF
+pushd /usr/src/packages/magmalte
+yarn upgrade @fbcnms/sequelize-models@^0.1.4
+yarn
+popd
+cat << EOF
+--------------------------------------------------------------------------------
+              Successfully upgraded @fbcnms/sequelize-models
+--------------------------------------------------------------------------------
+EOF
+
+cat << EOF
+--------------------------------------------------------------------------------
+              Running yarn script for NMS DB data migration
+--------------------------------------------------------------------------------
+EOF
+pushd /usr/src/node_modules/\@fbcnms/sequelize-models
+yarn dbDataMigrate --host=$arg_host --port=$arg_port --database=$arg_db --dialect=$arg_dialect --username=$arg_username --password=$arg_password --export --confirm
+if [ $? -eq 0 ]
+then
+  echo "SUCCESS"
+  echo "You are now ready to upgrade to 1.5"
+  exit 0
+else
+  echo "Failed to migrate NMS DB data: " >&2
+  exit 1
+fi


### PR DESCRIPTION
Signed-off-by: Andrei Lee <andreilee@fb.com>

## Summary

**NOTE: Some of the links inside the scripts, docs, and README point to my personal github gist. After this PR lands, I'll need to put out additional PRs to fix these links, pointing them back to the Magma repository.**

Adds scripts to migrate NMS DB data to orc8r, so that 1.5 deployments will be able to use a single AWS RDS instance for both NMS and orc8r DB.

The process is initiated like so, on macOS:

```
curl -O https://gist.githubusercontent.com/andreilee/7aa7d533e2e8f425222b1e6a016a6f5a/raw/36115f6b4d3e7466dfb2db8f25a7b3e90b9e4f4a/pre-upgrade-migration.sh && chmod +x pre-upgrade-migration.sh && ./pre-upgrade-migration.sh
```

Running that line downloads the DB migration script, bootstrapping a process which continues to run on the k8s NMS pod.

See the gist at https://gist.github.com/andreilee/7aa7d533e2e8f425222b1e6a016a6f5a

## Test Plan

Manually tested using a minikube deployment, and the gist at

https://gist.github.com/andreilee/7aa7d533e2e8f425222b1e6a016a6f5a

## Additional Information

- [x] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
