### PR TITLE
[DevEx] VS Code remote-containers setup

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,258 @@
+# Note: You can use any Debian/Ubuntu based image you want. 
+FROM ubuntu:focal as magma-mme-builder
+
+# [Option] Install zsh
+ARG INSTALL_ZSH="true"
+# [Option] Upgrade OS packages to their latest versions
+ARG UPGRADE_PACKAGES="false"
+# [Option] Enable non-root Docker access in container
+ARG ENABLE_NONROOT_DOCKER="true"
+# [Option] Use the OSS Moby CLI instead of the licensed Docker CLI
+ARG USE_MOBY="true"
+
+# Install needed packages and setup non-root user. Use a separate RUN statement to add your
+# own dependencies. A user of "automatic" attempts to reuse an user ID if one already exists.
+ARG USERNAME=automatic
+ARG USER_UID=1000
+ARG USER_GID=$USER_UID
+COPY .devcontainer/library-scripts/*.sh /tmp/library-scripts/
+RUN apt-get update \
+    && /bin/bash /tmp/library-scripts/common-debian.sh "${INSTALL_ZSH}" "${USERNAME}" "${USER_UID}" "${USER_GID}" "${UPGRADE_PACKAGES}" \
+    # Use Docker script from script library to set things up
+    && /bin/bash /tmp/library-scripts/docker-debian.sh "${ENABLE_NONROOT_DOCKER}" "/var/run/docker-host.sock" "/var/run/docker.sock" "${USERNAME}" "${USE_MOBY}" \
+    # Clean up
+    && apt-get autoremove -y && apt-get clean -y && rm -rf /var/lib/apt/lists/* /tmp/library-scripts/
+
+# Setting the ENTRYPOINT to docker-init.sh will configure non-root access to 
+# the Docker socket if "overrideCommand": false is set in devcontainer.json. 
+# The script will also execute CMD if you need to alter startup behaviors.
+ENTRYPOINT [ "/usr/local/share/docker-init.sh" ]
+CMD [ "sleep", "infinity" ]
+
+ARG GIT_PROXY
+ARG FEATURES=mme_oai
+ENV MAGMA_ROOT=/workspaces/magma
+ENV BUILD_TYPE=Debug
+ENV C_BUILD=/workspaces/magma/build/c
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN echo "Install general purpose packages" && \
+    apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get upgrade -y && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y \
+        apt-transport-https \
+        apt-utils \
+        autoconf \
+        autoconf automake \
+        automake \
+        build-essential \
+        ca-certificates \
+        clang-format-11 \
+        clang-tidy-11 \
+        curl \
+        g++ \
+        g++-9 \
+        gcc-9 \
+        lcov \
+        git \
+        gnupg \
+        golang \
+        libgmp3-dev \
+        libssl-dev \
+        libtool \
+        make \
+        ninja-build \
+        perl \
+        pkg-config \
+        python2.7 \
+        redis-server \
+        ruby \
+        rubygems \
+        ruby-dev \
+        software-properties-common \
+        tig \
+        tzdata \
+        unzip \
+        vim \
+        wget && \
+        gem install fpm && \
+        update-alternatives --install /usr/bin/clang clang /usr/lib/llvm-11/bin/clang 10 && \
+        update-alternatives --install /usr/bin/clang++ clang++ /usr/lib/llvm-11/bin/clang++ 10 && \
+        update-alternatives --install /usr/bin/clang-tidy clang-tidy /usr/lib/llvm-11/bin/clang-tidy 10 && \
+        update-alternatives --install /usr/bin/clang-format clang-format /usr/lib/llvm-11/bin/clang-format 10 && \
+        update-alternatives --install /usr/bin/clang-apply-replacements clang-apply-replacements /usr/lib/llvm-11/bin/clang-apply-replacements 10
+
+RUN echo "Install 3rd party dependencies" && \
+    apt-get update && \
+    echo "Install CMake" && \
+    apt-get -y install cmake && \
+    echo "Install FMT lib requirements" && \
+    apt-get -y install libunwind8-dev libelf-dev libdwarf-dev bzip2 && \
+    echo "Install Folly requirements" && \
+    apt-get -y install libboost-all-dev libevent-dev libdouble-conversion-dev \
+    libgoogle-glog-dev libgflags-dev libiberty-dev liblz4-dev liblzma-dev \
+    libsnappy-dev binutils-dev libjemalloc-dev libssl-dev pkg-config libunwind-dev && \
+    echo "Install check for test support" && \
+    apt-get -y install check && \
+    echo "Install gtest for test support" && \
+    apt-get -y install libgtest-dev && \
+    echo "Install FreeDiameter requirements" && \
+    apt-get -y install libsctp1 libsctp-dev libgcrypt-dev \
+    bison flex libidn11-dev && \
+    echo "Install libgtpnl requirements" && \
+    apt-get -y install libmnl-dev && \
+    echo "Install Nettle requirements" && \
+    apt-get install -y libgoogle-glog-dev libconfig-dev libxml2-dev \
+    libyaml-cpp-dev nlohmann-json3-dev && \
+    echo "Install ZeroMQ" && \
+    apt-get install -y libczmq-dev && \
+    ln -s /usr/bin/python2.7 /usr/local/bin/python && \
+    # TODO(fixup this include in source code @ MConfigLoader.cpp)
+    ln -s /usr/include/nlohmann/json.hpp /usr/include/json.hpp
+
+RUN ["/bin/bash", "-c", "if [[ -v GIT_PROXY ]]; then git config --global http.proxy $GIT_PROXY; fi"]
+
+##### NETTLE and GNUTLS
+# TODO Upgrade these - requires us to update our use of libnettle due to API migration.
+#  see https://gist.github.com/electronjoe/a899e4bfbc2904cb353444386296c38e
+# Note the CFLAGS define below due to glibc deprecation of critical flag,
+#  see https://github.com/rdslw/openwrt/blob/e5d47f32131849a69a9267de51a30d6be1f0d0ac/tools/bison/patches/110-glibc-change-work-around.patch
+RUN wget https://ftp.gnu.org/gnu/nettle/nettle-2.5.tar.gz && \
+    tar -xf nettle-2.5.tar.gz && \
+    cd nettle-2.5 && \
+    mkdir build && \
+    cd build/ && \
+    ../configure --disable-openssl --enable-shared --libdir=/usr/local/lib && \
+    make -j`nproc` && \
+    make install && \
+    ldconfig -v && \
+    cd / && \
+    wget http://mirrors.dotsrc.org/gcrypt/gnutls/v3.1/gnutls-3.1.23.tar.xz && \
+    tar xf gnutls-3.1.23.tar.xz && \
+    cd gnutls-3.1.23 && \
+    mkdir build && cd build && \
+    CFLAGS=-D_IO_ftrylockfile ../configure --with-libnettle-prefix=/usr/local && \
+    make -j`nproc` && \
+    make install && \
+    ldconfig -v && \
+    cd / && \
+    rm -rf nettle* && \
+    rm -rf gnutls*
+
+##### GRPC and it's dependencies
+RUN git clone --recurse-submodules -b v1.35.0 https://github.com/grpc/grpc && \
+    cd grpc && \
+    mkdir -p cmake/build && \
+    cd cmake/build && \
+    cmake -DgRPC_INSTALL=ON -DgRPC_BUILD_TESTS=OFF -DBUILD_SHARED_LIBS=ON ../.. && \
+    make -j`nproc` && \
+    make install && \
+    cd / && \
+    rm -rf grpc
+
+##### Prometheus CPP
+RUN git clone https://github.com/jupp0r/prometheus-cpp.git && \
+    cd prometheus-cpp && \
+    git checkout d8326b2bba945a435f299e7526c403d7a1f68c1f && \
+    git submodule init && git submodule update && \
+    mkdir _build && \
+    cd _build/ && \
+    cmake .. && \
+    make -j`nproc` && \
+    make install && \
+    rm -rf /prometheus-cpp
+
+##### Redis CPP
+RUN git clone https://github.com/cpp-redis/cpp_redis.git && \
+    cd cpp_redis && \
+    git checkout bbe38a7f83de943ffcc90271092d689ae02b3489 && \
+    git submodule init && git submodule update && \
+    mkdir build && cd build && \
+    cmake .. -DCMAKE_BUILD_TYPE=Release && \
+    make -j`nproc` && \
+    make install && \
+    rm -rf /cpp_redis
+
+##### liblfds
+# https://www.liblfds.org/mediawiki/index.php?title=r7.1.0:Building_Guide_(liblfds)
+RUN wget https://liblfds.org/downloads/liblfds%20release%207.1.0%20source.tar.bz2  && \
+    tar -xf liblfds\ release\ 7.1.0\ source.tar.bz2  && \
+    cd liblfds/liblfds7.1.0/liblfds710/build/gcc_gnumake/ && \
+    make -j`nproc` && \
+    make ar_install && \
+    rm -rf liblfds
+
+##### libgtpnl
+# review https://github.com/OPENAIRINTERFACE/openair-cn/blob/master/build/tools/build_helper.gtpnl
+RUN git clone https://git.osmocom.org/libgtpnl && \
+    cd libgtpnl && \
+    git reset --hard 345d687 && \
+    autoreconf -fi && \
+    ./configure && \
+    make -j`nproc` && \
+    make install && \
+    ldconfig && \
+    rm -rf libgtpnl
+
+#####  asn1c
+RUN git clone https://gitlab.eurecom.fr/oai/asn1c.git && \
+    cd asn1c && \
+    git checkout f12568d617dbf48497588f8e227d70388fa217c9 && \
+    autoreconf -iv && \
+    ./configure && \
+    make -j`nproc` && \
+    make install && \
+    ldconfig
+
+
+## Install Fmt (Folly Dep)
+RUN git clone https://github.com/fmtlib/fmt.git && cd fmt && \
+    mkdir _build && cd _build && \
+    cmake -DBUILD_SHARED_LIBS=ON .. && \
+    make -j$(nproc) && \
+    make install && \
+    cd / && \
+    rm -rf fmt
+
+##### Facebook Folly C++ lib
+# Note: "Because folly does not provide any ABI compatibility guarantees from
+#        commit to commit, we generally recommend building folly as a static library."
+# Here we checkout the hash for v2021.02.22.00 (arbitrary recent version)
+RUN git clone https://github.com/facebook/folly && cd folly && \
+    git checkout tags/v2021.02.15.00 && \
+    mkdir _build && cd _build && \
+    cmake -DBUILD_SHARED_LIBS=ON .. && \
+    make -j$(nproc) && \
+    make install && \
+    cd / && \
+    rm -rf folly
+    
+##### Build and install libgtest and gmock
+RUN cd /usr/src/googletest && \
+    mkdir build && \
+    cd build && \
+    cmake -DBUILD_SHARED_LIBS=ON .. && \
+    echo "Build gtest and gmock" && \
+    make && \
+    echo "Install gtest and gmock" && \
+    make install && \
+    ldconfig -v
+
+##### FreeDiameter
+COPY lte/gateway/c/oai/patches/ /tmp/
+RUN git clone https://github.com/OPENAIRINTERFACE/opencord.org.freeDiameter.git freediameter && \
+    cd freediameter && \
+    patch -p1 < /tmp/0001-opencoord.org.freeDiameter.patch && \
+    mkdir build && \
+    cd build && \
+    cmake -DDISABLE_SCTP:BOOL=ON ../ && \
+    make -j`nproc` && \
+    make install && \
+    cd / && \
+    rm -rf freediameter
+
+#### libfluid is requird to build MME with OVS support
+COPY third_party /tmp/third_party/
+RUN /tmp/third_party/build/bin/libfluid_build.sh && \
+     find . -name magma-libfluid_0.1* -exec dpkg -i {} \; && \
+     rm -rf /tmp/*

--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -1,0 +1,146 @@
+# VS Code Container Dev Environment
+
+For a comprehensive developer environnment supporting AGW c / c++ workflows (extensible with ~effort to other Magma uses) - see the instructions below.
+
+## Setup
+
+- Install Docker
+- Configure Docker
+  - In some operating systems (e.g. MAC) docker runs in a VM and you must allocate memory / CPU / etc
+  - Some targets in Magma can be built with e.g. 7 Gigs of VM RAM
+    - e.g. `make test_oai` and `make build_oai` within `lte/gateway/`
+  - Others require 12 Gigs of VM RAM
+    - e.g. `make test_connection_manager` within `lte/gateway/`
+- Install VS Code
+  - Install Microsoft's VS Code [Remote - Containers](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers) Extension
+- `F1` For command search
+  - Type `Remote-Containers: Clone Repository in Containers Volume...`
+  - In dialog box that pops up, paste `https://github.com/electronjoe/magma/tree/experimental-vscode-dockerized`
+    - Once this PR is committed, you could instead point at any Magma Github {branch or PR}
+  - When prompted, select `Create a Unique Volume`
+    - As our goal is to only work on this one Git target
+  - Sit back and relax for awhile (10-15 min)
+    - VS Code will build Dockerfile
+    - Checkout Repo
+    - Install plugins within Docker instance
+  - Test your setup by opening a terminal and testing OAI
+    - `Terminal->New Terminal`
+    - `cd lte/gateway`
+    - `make test_oai`
+
+## Using Clang-Tidy in VS Code
+
+While we could commit / build a compilation database (compile_commands.json), at this time we are not doing so. Instead we will explicitly call out the Include paths for VS Code / Clang-Tidy as follows (open to ammending this if a clean mechanism of generating compile commands is found):
+
+You should not have to ask for Clang-Tidy to run on the open file, it should do so automatically. But if not try `F1` and type `Clang-Tidy: Lint File`. You can monitor behavior by `View->Output` tab in VS code -> select `Clang-Tidy` from the Drop down menu top right. 
+
+For any header include that is undiscovered by Clang-Tidy (e.g. `error: 'bstrlib.h' file not found [clang-diagnostic-error]`):
+
+**note! note to be confused with `cannot open source file` of type `C/C++` -> this indicates that Intellisense is missing includes, see [below](#Fixing-Intellisense) for how to fix.**
+
+- Fix locally in docker and test
+  - Update of `clang-tidy.compilerArgs` in your **container** settings.json file
+    - Press `F1` and then search for `Preferences: Open Remote Settings (Dev Container)` Hit enter
+    - Update the `clang-tidy.compilerArgs` with additional include directory paths
+      - These may be in Magma codebase, or ...
+      - environmental within docker (`find / -name <header_name.h> to discover`)
+  - Update of settings.json for Dev Container should immediately take effect for Clang-Tidy
+- Once tested locally, add to .devcontainer for future users
+  - Open `.devcontainer/devcontainer.json` and update its `clang-tidy.compilerArgs`
+
+### Fixing Intellisense
+
+If you see `View->Problems` pane outputs of the shape `cannot open source file "bstrlib.h" C/C++`, this is an Intellisense warning.  We want to work on cleaning these up as well.
+
+To address these, we want to modify the repo's `.vscode/c_cpp_properties.json` file to add the additional Include paths.  Test the change in your Docker container, then upstream to the repo!
+
+### Using Clang-Tidy broadly
+
+To run it over the entire code base, it's advised to use [run-clang-tidy.py](https://github.com/llvm-mirror/clang-tools-extra/blob/master/clang-tidy/tool/run-clang-tidy.py) provided by LLVM team. This handles concurrency of analysis and edits to the many files.
+
+This tool wants a `compile_commands.json` list of compiler directives, which we can achieve by setting an environment variable for CMake: [`CMAKE_EXPORT_COMPILE_COMMANDS`](https://cmake.org/cmake/help/latest/variable/CMAKE_EXPORT_COMPILE_COMMANDS.html).
+
+```shell
+cd lte/gateway
+make build_oai
+cd /build/c/
+wget https://raw.githubusercontent.com/llvm-mirror/clang-tools-extra/master/clang-tidy/tool/run-clang-tidy.py
+python run-clang-tidy.py -checks='-*,clang-analyzer-security*,android-*,cert-*,clang-analyzer-*,concurrency-*,misc-*,bugprone-*' 2>&1 | tee clang-tidy.findings | grep warning:
+```
+
+Note that we are only using clang-tidy fimndings that are possibly bugs / alarming (or at least htat is the intent) - and are diabling the readability / formatting / code structure best practices.  We should come back and look at what automatic fixes clang-tidy can apply in these domains.
+
+Detailed outputs will be available in clang-tidy.findings.
+
+For an explanation of all checks see [Clang-Tidy Documentation](https://clang.llvm.org/extra/clang-tidy/checks/list.html).
+
+Note that some builds are not generating build_commands.json - even with CMake flags set in CMakeFiles.txt. I have not yet found an explanation - but one solution is to manually build the projects like so:
+
+```bash
+cd lte/gateway/c/session_manager
+mkdir build
+cd build
+cmake ../
+vim CMakeCache.txt -> edit the CMAKE_EXPORT_COMPILE_COMMANDS to set it ON
+cmake --build .
+```
+
+### Converting Clang-Tidy Output to CI Friendly things
+
+```shell
+root@ecee08edef4b:/build/c/oai# cat clang.findings | egrep "android|bugprone|cert|clang|concurrency|misc" | awk -F'[][]' '{print $2}' | sort | uniq -c
+   1315 
+      3 android-cloexec-fopen
+      1 android-cloexec-open
+     34 bugprone-branch-clone
+     43 bugprone-macro-parentheses
+    338 bugprone-narrowing-conversions
+    219 bugprone-reserved-identifier,cert-dcl37-c,cert-dcl51-cpp
+      9 bugprone-signed-char-misuse,cert-str34-c
+     92 bugprone-sizeof-expression
+      9 bugprone-suspicious-string-compare
+      9 bugprone-too-small-loop-variable
+      9 bugprone-undefined-memory-manipulation
+      3 cert-dcl16-c
+      7 cert-env33-c
+     66 cert-err34-c
+     64 cert-err58-cpp
+      1 cert-msc30-c,cert-msc50-cpp
+      1 cert-msc32-c,cert-msc51-cpp
+     59 clang-analyzer-core.CallAndMessage
+      6 clang-analyzer-core.NonNullParamChecker
+     56 clang-analyzer-core.NullDereference
+      3 clang-analyzer-core.UndefinedBinaryOperatorResult
+      4 clang-analyzer-core.uninitialized.Assign
+     69 clang-analyzer-deadcode.DeadStores
+      3 clang-analyzer-optin.cplusplus.VirtualCall
+      1 clang-analyzer-optin.performance.Padding
+      4 clang-analyzer-optin.portability.UnixAPI
+     23 clang-analyzer-security.insecureAPI.strcpy
+     12 clang-analyzer-unix.Malloc
+     16 clang-analyzer-unix.MallocSizeof
+      5 misc-misplaced-const
+     11 misc-no-recursion
+      1 misc-non-private-member-variables-in-classes
+      5 misc-redundant-expression
+     15 misc-unused-using-decls
+```
+
+
+
+## Sharp Edges
+
+- Your Docker Container Volume contains your work!
+  - Be careful not to delete the container until outstanding work is pushed to your personal Github Fork
+  - Note cleanup for disk space below - and the danger here
+  - TODO: How to re-attach a Volume if you close VS Code?
+- Docker running out of disk on Mac VM
+  - Docker just leaks resources like mad
+  - Eventually you'll get a "out of space" error
+  - Or an error about apt-get failure
+  - TODO: find good docker command to wipe everything
+
+## TODOs
+
+- Get the Docker image up to DockerHub?
+  - Want easy way to build from Dockerfile locally though..

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,63 @@
+{
+	"extensions": [
+		"CoenraadS.bracket-pair-colorizer-2",
+		"xaver.clang-format",
+		"notskm.clang-tidy",
+		"ms-vscode.cpptools",
+		"eamodio.gitlens",
+		"yzhang.markdown-all-in-one",
+		"christian-kohler.path-intellisense",
+		"vscodevim.vim",
+		"vscode-icons-team.vscode-icons",
+		"ms-vsliveshare.vsliveshare",
+		"ms-azuretools.vscode-docker"
+	],
+	"dockerFile": "Dockerfile",
+	"context": "..",
+	"settings": {
+		"terminal.integrated.shell.linux": "/bin/bash",
+		"clang-tidy.compilerArgs": [
+			// TODO: see if there is a way to use environment variables for workspace root (I tried)
+			"-I/workspaces/magma/build/c/oai/tasks/s1ap/r15/",  // Requires `make build_oai` to generate
+			"-I/workspaces/magma/lte/gateway/c/oai/common/",
+			"-I//workspaces/magma/lte/gateway/c/oai/include/",
+			"-I/workspaces/magma/lte/gateway/c/oai/lib/3gpp/",
+			"-I/workspaces/magma/lte/gateway/c/oai/lib/bstr/",
+			"-I/workspaces/magma/lte/gateway/c/oai/lib/directoryd/",
+			"-I/workspaces/magma/lte/gateway/c/oai/lib/event_client/",
+			"-I/workspaces/magma/lte/gateway/c/oai/lib/gtpv2-c/",
+			"-I/workspaces/magma/lte/gateway/c/oai/lib/hashtable/",
+			"-I/workspaces/magma/lte/gateway/c/oai/lib/itti/",
+			"-I/workspaces/magma/lte/gateway/c/oai/lib/message_utils/",
+			"-I/workspaces/magma/lte/gateway/c/oai/lib/mobility_client/",
+			"-I/workspaces/magma/lte/gateway/c/oai/lib/n11/",
+			"-I/workspaces/magma/lte/gateway/c/oai/lib/openflow/",
+			"-I/workspaces/magma/lte/gateway/c/oai/lib/pcef/",
+			"-I/workspaces/magma/lte/gateway/c/oai/lib/s6a_proxy/",
+			"-I/workspaces/magma/lte/gateway/c/oai/lib/secu/",
+			"-I/workspaces/magma/lte/gateway/c/oai/lib/sgs_client/",
+			"-I/workspaces/magma/lte/gateway/c/oai/lib/sms_orc8r_client/",
+			"-I/workspaces/magma/lte/gateway/c/oai/tasks/mme_app/",
+			"-I/workspaces/magma/lte/gateway/c/oai/tasks/nas/",
+			"-I/workspaces/magma/lte/gateway/c/oai/tasks/nas/api/mme/",
+			"-I/workspaces/magma/lte/gateway/c/oai/tasks/nas/api/network/",
+			"-I/workspaces/magma/lte/gateway/c/oai/tasks/nas/emm/",
+			"-I/workspaces/magma/lte/gateway/c/oai/tasks/nas/emm/msg/",
+			"-I/workspaces/magma/lte/gateway/c/oai/tasks/nas/emm/sap/",
+			"-I/workspaces/magma/lte/gateway/c/oai/tasks/nas/esm/",
+			"-I/workspaces/magma/lte/gateway/c/oai/tasks/nas/esm/msg/",
+			"-I/workspaces/magma/lte/gateway/c/oai/tasks/nas/ies/",
+			"-I/workspaces/magma/lte/gateway/c/oai/tasks/nas/util/"
+		]
+	},
+	"mounts": [
+		"source=/var/run/docker.sock,target=/var/run/docker-host.sock,type=bind"
+	],
+	"runArgs": [
+		"--init"
+	],
+	"remoteEnv": {
+		"LOCAL_WORKSPACE_FOLDER": "${localWorkspaceFolder}"
+	},
+	"remoteUser": "vscode",
+}

--- a/.devcontainer/library-scripts/common-debian.sh
+++ b/.devcontainer/library-scripts/common-debian.sh
@@ -1,0 +1,340 @@
+#!/usr/bin/env bash
+#-------------------------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
+#-------------------------------------------------------------------------------------------------------------
+#
+# Docs: https://github.com/microsoft/vscode-dev-containers/blob/master/script-library/docs/common.md
+#
+# Syntax: ./common-debian.sh [install zsh flag] [username] [user UID] [user GID] [upgrade packages flag] [install Oh My *! flag]
+
+INSTALL_ZSH=${1:-"true"}
+USERNAME=${2:-"automatic"}
+USER_UID=${3:-"automatic"}
+USER_GID=${4:-"automatic"}
+UPGRADE_PACKAGES=${5:-"true"}
+INSTALL_OH_MYS=${6:-"true"}
+
+set -e
+
+if [ "$(id -u)" -ne 0 ]; then
+    echo -e 'Script must be run as root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
+    exit 1
+fi
+
+# Ensure that login shells get the correct path if the user updated the PATH using ENV.
+rm -f /etc/profile.d/00-restore-env.sh
+echo "export PATH=${PATH//$(sh -lc 'echo $PATH')/\$PATH}" > /etc/profile.d/00-restore-env.sh
+chmod +x /etc/profile.d/00-restore-env.sh
+
+# If in automatic mode, determine if a user already exists, if not use vscode
+if [ "${USERNAME}" = "auto" ] || [ "${USERNAME}" = "automatic" ]; then
+    USERNAME=""
+    POSSIBLE_USERS=("vscode" "node" "codespace" "$(awk -v val=1000 -F ":" '$3==val{print $1}' /etc/passwd)")
+    for CURRENT_USER in ${POSSIBLE_USERS[@]}; do
+        if id -u ${CURRENT_USER} > /dev/null 2>&1; then
+            USERNAME=${CURRENT_USER}
+            break
+        fi
+    done
+    if [ "${USERNAME}" = "" ]; then
+        USERNAME=vscode
+    fi
+elif [ "${USERNAME}" = "none" ]; then
+    USERNAME=root
+    USER_UID=0
+    USER_GID=0
+fi
+
+# Load markers to see which steps have already run
+MARKER_FILE="/usr/local/etc/vscode-dev-containers/common"
+if [ -f "${MARKER_FILE}" ]; then
+    echo "Marker file found:"
+    cat "${MARKER_FILE}"
+    source "${MARKER_FILE}"
+fi
+
+# Ensure apt is in non-interactive to avoid prompts
+export DEBIAN_FRONTEND=noninteractive
+
+# Function to call apt-get if needed
+apt-get-update-if-needed()
+{
+    if [ ! -d "/var/lib/apt/lists" ] || [ "$(ls /var/lib/apt/lists/ | wc -l)" = "0" ]; then
+        echo "Running apt-get update..."
+        apt-get update
+    else
+        echo "Skipping apt-get update."
+    fi
+}
+
+# Run install apt-utils to avoid debconf warning then verify presence of other common developer tools and dependencies
+if [ "${PACKAGES_ALREADY_INSTALLED}" != "true" ]; then
+    apt-get-update-if-needed
+
+    PACKAGE_LIST="apt-utils \
+        git \
+        openssh-client \
+        gnupg2 \
+        iproute2 \
+        procps \
+        lsof \
+        htop \
+        net-tools \
+        psmisc \
+        curl \
+        wget \
+        rsync \
+        ca-certificates \
+        unzip \
+        zip \
+        nano \
+        vim-tiny \
+        less \
+        jq \
+        lsb-release \
+        apt-transport-https \
+        dialog \
+        libc6 \
+        libgcc1 \
+        libkrb5-3 \
+        libgssapi-krb5-2 \
+        libicu[0-9][0-9] \
+        liblttng-ust0 \
+        libstdc++6 \
+        zlib1g \
+        locales \
+        sudo \
+        ncdu \
+        man-db \
+        strace"
+
+    # Install libssl1.1 if available
+    if [[ ! -z $(apt-cache --names-only search ^libssl1.1$) ]]; then
+        PACKAGE_LIST="${PACKAGE_LIST}       libssl1.1"
+    fi
+    
+    # Install appropriate version of libssl1.0.x if available
+    LIBSSL=$(dpkg-query -f '${db:Status-Abbrev}\t${binary:Package}\n' -W 'libssl1\.0\.?' 2>&1 || echo '')
+    if [ "$(echo "$LIBSSL" | grep -o 'libssl1\.0\.[0-9]:' | uniq | sort | wc -l)" -eq 0 ]; then
+        if [[ ! -z $(apt-cache --names-only search ^libssl1.0.2$) ]]; then
+            # Debian 9
+            PACKAGE_LIST="${PACKAGE_LIST}       libssl1.0.2"
+        elif [[ ! -z $(apt-cache --names-only search ^libssl1.0.0$) ]]; then
+            # Ubuntu 18.04, 16.04, earlier
+            PACKAGE_LIST="${PACKAGE_LIST}       libssl1.0.0"
+        fi
+    fi
+
+    echo "Packages to verify are installed: ${PACKAGE_LIST}"
+    apt-get -y install --no-install-recommends ${PACKAGE_LIST} 2> >( grep -v 'debconf: delaying package configuration, since apt-utils is not installed' >&2 )
+        
+    PACKAGES_ALREADY_INSTALLED="true"
+fi
+
+# Get to latest versions of all packages
+if [ "${UPGRADE_PACKAGES}" = "true" ]; then
+    apt-get-update-if-needed
+    apt-get -y upgrade --no-install-recommends
+    apt-get autoremove -y
+fi
+
+# Ensure at least the en_US.UTF-8 UTF-8 locale is available.
+# Common need for both applications and things like the agnoster ZSH theme.
+if [ "${LOCALE_ALREADY_SET}" != "true" ] && ! grep -o -E '^\s*en_US.UTF-8\s+UTF-8' /etc/locale.gen > /dev/null; then
+    echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen 
+    locale-gen
+    LOCALE_ALREADY_SET="true"
+fi
+
+# Create or update a non-root user to match UID/GID.
+if id -u ${USERNAME} > /dev/null 2>&1; then
+    # User exists, update if needed
+    if [ "${USER_GID}" != "automatic" ] && [ "$USER_GID" != "$(id -G $USERNAME)" ]; then 
+        groupmod --gid $USER_GID $USERNAME 
+        usermod --gid $USER_GID $USERNAME
+    fi
+    if [ "${USER_UID}" != "automatic" ] && [ "$USER_UID" != "$(id -u $USERNAME)" ]; then 
+        usermod --uid $USER_UID $USERNAME
+    fi
+else
+    # Create user
+    if [ "${USER_GID}" = "automatic" ]; then
+        groupadd $USERNAME
+    else
+        groupadd --gid $USER_GID $USERNAME
+    fi
+    if [ "${USER_UID}" = "automatic" ]; then 
+        useradd -s /bin/bash --gid $USERNAME -m $USERNAME
+    else
+        useradd -s /bin/bash --uid $USER_UID --gid $USERNAME -m $USERNAME
+    fi
+fi
+
+# Add add sudo support for non-root user
+if [ "${USERNAME}" != "root" ] && [ "${EXISTING_NON_ROOT_USER}" != "${USERNAME}" ]; then
+    echo $USERNAME ALL=\(root\) NOPASSWD:ALL > /etc/sudoers.d/$USERNAME
+    chmod 0440 /etc/sudoers.d/$USERNAME
+    EXISTING_NON_ROOT_USER="${USERNAME}"
+fi
+
+# ** Shell customization section **
+if [ "${USERNAME}" = "root" ]; then 
+    USER_RC_PATH="/root"
+else
+    USER_RC_PATH="/home/${USERNAME}"
+fi
+
+# .bashrc/.zshrc snippet
+RC_SNIPPET="$(cat << EOF
+export USER=\$(whoami)
+if [[ "\${PATH}" != *"\$HOME/.local/bin"* ]]; then export PATH="\${PATH}:\$HOME/.local/bin"; fi
+EOF
+)"
+
+# code shim, it fallbacks to code-insiders if code is not available
+cat << 'EOF' > /usr/local/bin/code
+#!/bin/sh
+
+get_in_path_except_current() {
+    which -a "$1" | grep -A1 "$0" | grep -v "$0"
+}
+
+code="$(get_in_path_except_current code)"
+
+if [ -n "$code" ]; then
+    exec "$code" "$@"
+elif [ "$(command -v code-insiders)" ]; then
+    exec code-insiders "$@"
+else
+    echo "code or code-insiders is not installed" >&2
+    exit 127
+fi
+EOF
+chmod +x /usr/local/bin/code
+
+# Codespaces themes - partly inspired by https://github.com/ohmyzsh/ohmyzsh/blob/master/themes/robbyrussell.zsh-theme
+CODESPACES_BASH="$(cat \
+<<EOF
+#!/usr/bin/env bash
+prompt() {
+    if [ "\$?" != "0" ]; then
+        local arrow_color=\${bold_red}
+    else
+        local arrow_color=\${reset_color}
+    fi
+    if [ ! -z "\${GITHUB_USER}" ]; then
+        local USERNAME="@\${GITHUB_USER}"
+    else
+        local USERNAME="\\u"
+    fi
+    local cwd="\$(pwd | sed "s|^\${HOME}|~|")"
+    PS1="\${green}\${USERNAME} \${arrow_color}➜\${reset_color} \${bold_blue}\${cwd}\${reset_color} \$(scm_prompt_info)\${white}$ \${reset_color}"
+    
+    # Prepend Python virtual env version to prompt
+    if [[ -n \$VIRTUAL_ENV ]]; then
+        if [ -z "\${VIRTUAL_ENV_DISABLE_PROMPT:-}" ]; then
+            PS1="(\`basename \"\$VIRTUAL_ENV\"\`) \${PS1:-}"
+        fi
+    fi
+}
+
+SCM_THEME_PROMPT_PREFIX="\${reset_color}\${cyan}(\${bold_red}"
+SCM_THEME_PROMPT_SUFFIX="\${reset_color} "
+SCM_THEME_PROMPT_DIRTY=" \${bold_yellow}✗\${reset_color}\${cyan})"
+SCM_THEME_PROMPT_CLEAN="\${reset_color}\${cyan})"
+SCM_GIT_SHOW_MINIMAL_INFO="true"
+safe_append_prompt_command prompt
+EOF
+)"
+CODESPACES_ZSH="$(cat \
+<<EOF
+prompt() {
+    if [ ! -z "\${GITHUB_USER}" ]; then
+        local USERNAME="@\${GITHUB_USER}"
+    else
+        local USERNAME="%n"
+    fi
+    PROMPT="%{\$fg[green]%}\${USERNAME} %(?:%{\$reset_color%}➜ :%{\$fg_bold[red]%}➜ )"
+    PROMPT+='%{\$fg_bold[blue]%}%~%{\$reset_color%} \$(git_prompt_info)%{\$fg[white]%}$ %{\$reset_color%}'
+}
+ZSH_THEME_GIT_PROMPT_PREFIX="%{\$fg_bold[cyan]%}(%{\$fg_bold[red]%}"
+ZSH_THEME_GIT_PROMPT_SUFFIX="%{\$reset_color%} "
+ZSH_THEME_GIT_PROMPT_DIRTY=" %{\$fg_bold[yellow]%}✗%{\$fg_bold[cyan]%})"
+ZSH_THEME_GIT_PROMPT_CLEAN="%{\$fg_bold[cyan]%})"
+prompt
+EOF
+)"
+
+# Adapted Oh My Zsh! install step to work with both "Oh Mys" rather than relying on an installer script
+# See https://github.com/ohmyzsh/ohmyzsh/blob/master/tools/install.sh for offical script.
+install-oh-my()
+{
+    local OH_MY=$1
+    local OH_MY_INSTALL_DIR="${USER_RC_PATH}/.oh-my-${OH_MY}"
+    local TEMPLATE="${OH_MY_INSTALL_DIR}/templates/$2"
+    local OH_MY_GIT_URL=$3
+    local USER_RC_FILE="${USER_RC_PATH}/.${OH_MY}rc"
+
+    if [ -d "${OH_MY_INSTALL_DIR}" ] || [ "${INSTALL_OH_MYS}" != "true" ]; then
+        return 0
+    fi
+
+    umask g-w,o-w
+    mkdir -p ${OH_MY_INSTALL_DIR}
+    git clone --depth=1 \
+        -c core.eol=lf \
+        -c core.autocrlf=false \
+        -c fsck.zeroPaddedFilemode=ignore \
+        -c fetch.fsck.zeroPaddedFilemode=ignore \
+        -c receive.fsck.zeroPaddedFilemode=ignore \
+        ${OH_MY_GIT_URL} ${OH_MY_INSTALL_DIR} 2>&1
+    echo -e "$(cat "${TEMPLATE}")\nDISABLE_AUTO_UPDATE=true\nDISABLE_UPDATE_PROMPT=true" > ${USER_RC_FILE}
+    if [ "${OH_MY}" = "bash" ]; then
+        sed -i -e 's/OSH_THEME=.*/OSH_THEME="codespaces"/g' ${USER_RC_FILE}
+        mkdir -p ${OH_MY_INSTALL_DIR}/custom/themes/codespaces
+        echo "${CODESPACES_BASH}" > ${OH_MY_INSTALL_DIR}/custom/themes/codespaces/codespaces.theme.sh
+    else
+        sed -i -e 's/ZSH_THEME=.*/ZSH_THEME="codespaces"/g' ${USER_RC_FILE}
+        mkdir -p ${OH_MY_INSTALL_DIR}/custom/themes
+        echo "${CODESPACES_ZSH}" > ${OH_MY_INSTALL_DIR}/custom/themes/codespaces.zsh-theme
+    fi
+    # Shrink git while still enabling updates
+    cd ${OH_MY_INSTALL_DIR} 
+    git repack -a -d -f --depth=1 --window=1
+
+    if [ "${USERNAME}" != "root" ]; then
+        cp -rf ${USER_RC_FILE} ${OH_MY_INSTALL_DIR} /root
+        chown -R ${USERNAME}:${USERNAME} ${USER_RC_PATH}
+    fi
+}
+
+if [ "${RC_SNIPPET_ALREADY_ADDED}" != "true" ]; then
+    echo "${RC_SNIPPET}" >> /etc/bash.bashrc
+    RC_SNIPPET_ALREADY_ADDED="true"
+fi
+install-oh-my bash bashrc.osh-template https://github.com/ohmybash/oh-my-bash
+
+# Optionally install and configure zsh and Oh My Zsh!
+if [ "${INSTALL_ZSH}" = "true" ]; then
+    if ! type zsh > /dev/null 2>&1; then
+        apt-get-update-if-needed
+        apt-get install -y zsh
+    fi
+    if [ "${ZSH_ALREADY_INSTALLED}" != "true" ]; then
+        echo "${RC_SNIPPET}" >> /etc/zsh/zshrc
+        ZSH_ALREADY_INSTALLED="true"
+    fi
+    install-oh-my zsh zshrc.zsh-template https://github.com/ohmyzsh/ohmyzsh
+fi
+
+# Write marker file
+mkdir -p "$(dirname "${MARKER_FILE}")"
+echo -e "\
+    PACKAGES_ALREADY_INSTALLED=${PACKAGES_ALREADY_INSTALLED}\n\
+    LOCALE_ALREADY_SET=${LOCALE_ALREADY_SET}\n\
+    EXISTING_NON_ROOT_USER=${EXISTING_NON_ROOT_USER}\n\
+    RC_SNIPPET_ALREADY_ADDED=${RC_SNIPPET_ALREADY_ADDED}\n\
+    ZSH_ALREADY_INSTALLED=${ZSH_ALREADY_INSTALLED}" > "${MARKER_FILE}"
+
+echo "Done!"

--- a/.devcontainer/library-scripts/docker-debian.sh
+++ b/.devcontainer/library-scripts/docker-debian.sh
@@ -1,0 +1,181 @@
+#!/usr/bin/env bash
+#-------------------------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
+#-------------------------------------------------------------------------------------------------------------
+#
+# Docs: https://github.com/microsoft/vscode-dev-containers/blob/master/script-library/docs/docker.md
+#
+# Syntax: ./docker-debian.sh [enable non-root docker socket access flag] [source socket] [target socket] [non-root user] [use moby]
+
+ENABLE_NONROOT_DOCKER=${1:-"true"}
+SOURCE_SOCKET=${2:-"/var/run/docker-host.sock"}
+TARGET_SOCKET=${3:-"/var/run/docker.sock"}
+USERNAME=${4:-"automatic"}
+USE_MOBY=${5:-"true"}
+
+set -e
+
+if [ "$(id -u)" -ne 0 ]; then
+    echo -e 'Script must be run as root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
+    exit 1
+fi
+
+# Determine the appropriate non-root user
+if [ "${USERNAME}" = "auto" ] || [ "${USERNAME}" = "automatic" ]; then
+    USERNAME=""
+    POSSIBLE_USERS=("vscode" "node" "codespace" "$(awk -v val=1000 -F ":" '$3==val{print $1}' /etc/passwd)")
+    for CURRENT_USER in ${POSSIBLE_USERS[@]}; do
+        if id -u ${CURRENT_USER} > /dev/null 2>&1; then
+            USERNAME=${CURRENT_USER}
+            break
+        fi
+    done
+    if [ "${USERNAME}" = "" ]; then
+        USERNAME=root
+    fi
+elif [ "${USERNAME}" = "none" ] || ! id -u ${USERNAME} > /dev/null 2>&1; then
+    USERNAME=root
+fi
+
+# Function to run apt-get if needed
+apt-get-update-if-needed()
+{
+    if [ ! -d "/var/lib/apt/lists" ] || [ "$(ls /var/lib/apt/lists/ | wc -l)" = "0" ]; then
+        echo "Running apt-get update..."
+        apt-get update
+    else
+        echo "Skipping apt-get update."
+    fi
+}
+
+# Ensure apt is in non-interactive to avoid prompts
+export DEBIAN_FRONTEND=noninteractive
+
+# Install apt-transport-https, curl, lsb-release, gpg if missing
+if ! dpkg -s apt-transport-https curl ca-certificates lsb-release > /dev/null 2>&1 || ! type gpg > /dev/null 2>&1; then
+    apt-get-update-if-needed
+    apt-get -y install --no-install-recommends apt-transport-https curl ca-certificates lsb-release gnupg2 
+fi
+
+# Install Docker / Moby CLI if not already installed
+if type docker > /dev/null 2>&1; then
+    echo "Docker / Moby CLI already installed."
+else
+    if [ "${USE_MOBY}" = "true" ]; then
+        DISTRO=$(lsb_release -is | tr '[:upper:]' '[:lower:]')
+        CODENAME=$(lsb_release -cs)
+        curl -s https://packages.microsoft.com/keys/microsoft.asc | (OUT=$(apt-key add - 2>&1) || echo $OUT)
+        echo "deb [arch=amd64] https://packages.microsoft.com/repos/microsoft-${DISTRO}-${CODENAME}-prod ${CODENAME} main" > /etc/apt/sources.list.d/microsoft.list
+        apt-get update
+        apt-get -y install --no-install-recommends moby-cli
+    else
+        curl -fsSL https://download.docker.com/linux/$(lsb_release -is | tr '[:upper:]' '[:lower:]')/gpg | (OUT=$(apt-key add - 2>&1) || echo $OUT)
+        echo "deb [arch=amd64] https://download.docker.com/linux/$(lsb_release -is | tr '[:upper:]' '[:lower:]') $(lsb_release -cs) stable" | tee /etc/apt/sources.list.d/docker.list
+        apt-get update
+        apt-get -y install --no-install-recommends docker-ce-cli
+    fi
+fi
+
+# Install Docker Compose if not already installed 
+if type docker-compose > /dev/null 2>&1; then
+    echo "Docker Compose already installed."
+else
+    LATEST_COMPOSE_VERSION=$(curl -sSL "https://api.github.com/repos/docker/compose/releases/latest" | grep -o -P '(?<="tag_name": ").+(?=")')
+    curl -sSL "https://github.com/docker/compose/releases/download/${LATEST_COMPOSE_VERSION}/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
+    chmod +x /usr/local/bin/docker-compose
+fi
+
+# If init file already exists, exit
+if [ -f "/usr/local/share/docker-init.sh" ]; then
+    exit 0
+fi
+
+# By default, make the source and target sockets the same
+if [ "${SOURCE_SOCKET}" != "${TARGET_SOCKET}" ]; then
+    touch "${SOURCE_SOCKET}"
+    ln -s "${SOURCE_SOCKET}" "${TARGET_SOCKET}"
+fi
+
+# Add a stub if not adding non-root user access, user is root
+if [ "${ENABLE_NONROOT_DOCKER}" = "false" ] || [ "${USERNAME}" = "root" ]; then
+    echo '/usr/bin/env bash -c "\$@"' > /usr/local/share/docker-init.sh
+    chmod +x /usr/local/share/docker-init.sh
+    exit 0
+fi
+
+# If enabling non-root access and specified user is found, setup socat and add script
+chown -h "${USERNAME}":root "${TARGET_SOCKET}"        
+if ! dpkg -s socat > /dev/null 2>&1; then
+    apt-get-update-if-needed
+    apt-get -y install socat
+fi
+tee /usr/local/share/docker-init.sh > /dev/null \
+<< EOF 
+#!/usr/bin/env bash
+#-------------------------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
+#-------------------------------------------------------------------------------------------------------------
+
+set -e
+
+SOCAT_PATH_BASE=/tmp/vscr-docker-from-docker
+SOCAT_LOG=\${SOCAT_PATH_BASE}.log
+SOCAT_PID=\${SOCAT_PATH_BASE}.pid
+
+# Wrapper function to only use sudo if not already root
+sudoIf()
+{
+    if [ "\$(id -u)" -ne 0 ]; then
+        sudo "\$@"
+    else
+        "\$@"
+    fi
+}
+
+# Log messages
+log()
+{
+    echo -e "[\$(date)] \$@" | sudoIf tee -a \${SOCAT_LOG} > /dev/null
+}
+
+echo -e "\n** \$(date) **" | sudoIf tee -a \${SOCAT_LOG} > /dev/null
+log "Ensuring ${USERNAME} has access to ${SOURCE_SOCKET} via ${TARGET_SOCKET}"
+
+# If enabled, try to add a docker group with the right GID. If the group is root, 
+# fall back on using socat to forward the docker socket to another unix socket so 
+# that we can set permissions on it without affecting the host.
+if [ "${ENABLE_NONROOT_DOCKER}" = "true" ] && [ "${SOURCE_SOCKET}" != "${TARGET_SOCKET}" ] && [ "${USERNAME}" != "root" ] && [ "${USERNAME}" != "0" ]; then
+    SOCKET_GID=\$(stat -c '%g' ${SOURCE_SOCKET})
+    if [ "\${SOCKET_GID}" != "0" ]; then
+        log "Adding user to group with GID \${SOCKET_GID}."
+        if [ "\$(cat /etc/group | grep :\${SOCKET_GID}:)" = "" ]; then
+            sudoIf groupadd --gid \${SOCKET_GID} docker-host
+        fi
+        # Add user to group if not already in it
+        if [ "\$(id ${USERNAME} | grep -E "groups.*(=|,)\${SOCKET_GID}\(")" = "" ]; then
+            sudoIf usermod -aG \${SOCKET_GID} ${USERNAME}
+        fi
+    else
+        # Enable proxy if not already running
+        if [ ! -f "\${SOCAT_PID}" ] || ! ps -p \$(cat \${SOCAT_PID}) > /dev/null; then
+            log "Enabling socket proxy."
+            log "Proxying ${SOURCE_SOCKET} to ${TARGET_SOCKET} for vscode"
+            sudoIf rm -rf ${TARGET_SOCKET}
+            (sudoIf socat UNIX-LISTEN:${TARGET_SOCKET},fork,mode=660,user=${USERNAME} UNIX-CONNECT:${SOURCE_SOCKET} 2>&1 | sudoIf tee -a \${SOCAT_LOG} > /dev/null & echo "\$!" | sudoIf tee \${SOCAT_PID} > /dev/null)
+        else
+            log "Socket proxy already running."
+        fi
+    fi
+    log "Success"
+fi
+
+# Execute whatever commands were passed in (if any). This allows us 
+# to set this script to ENTRYPOINT while still executing the default CMD.
+set +e
+exec "\$@"
+EOF
+chmod +x /usr/local/share/docker-init.sh
+chown ${USERNAME}:root /usr/local/share/docker-init.sh
+echo "Done!"

--- a/.dockerignore
+++ b/.dockerignore
@@ -2,6 +2,7 @@
 !.cache/test_certs
 !fb/config/
 
+!.devcontainer/
 !third_party/
 
 !cwf/cloud/

--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -1,0 +1,25 @@
+{
+    "configurations": [
+        {
+            "name": "Linux",
+            "includePath": [
+                "${workspaceFolder}/**/**",
+                "${workspaceFolder}/build/c/oai/tasks/s1ap/r15/", // Requires `make build_oai` to generate
+                "${workspaceFolder}/lte/gateway/c/oai/common/*",
+                "${workspaceFolder}/lte/gateway/c/oai/include/*",
+                "${workspaceFolder}/lte/gateway/c/oai/lib/3gpp/*",
+                "${workspaceFolder}/lte/gateway/c/oai/lib/bstr/*",
+                "${workspaceFolder}/lte/gateway/c/oai/lib/hashtable/*",
+                "${workspaceFolder}/lte/gateway/c/oai/lib/itti/*",
+                "${workspaceFolder}/lte/gateway/c/oai/tasks/mme_app/",
+                "${workspaceFolder}/lte/gateway/c/oai/tasks/nas/util/"
+            ],
+            "defines": [],
+            "compilerPath": "/usr/bin/gcc",
+            "cStandard": "gnu17",
+            "cppStandard": "gnu++14",
+            "intelliSenseMode": "linux-gcc-x64"
+        }
+    ],
+    "version": 4
+}


### PR DESCRIPTION
# Summary

This PR populates a functional .devcontainer root folder within the magma repo - enabling ~full function c/c++ **build, unit test and tooling e.g. Clang-Tidy, Clang-Format** in the following very-low-friction settings. It is a goal of mine to work towards E2E containerized test support, such that we can run E2E tests here as well.

- GH Code Spaces
  - Automatically builds container and mounts repo within
- Local vscode development
  - Install Microsoft's VS Code [Remote - Containers](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers) Extension
  - Simply hit F1 and select `Remote-Containers: Clone Repository in Containers Volume...`
  - Paste in a GH URL to a repo branch, or a PR
  - It will build the docker container, mount your repo as a docker volume, voila

The following configuration is automatically applied and available.

- Container environment
  - Software
    - All AGW c/c++ dependencies
    - Ubuntu 20.04 based container
    - GCC 9.3
    - Clang 11 tool suite (incl clang-tidy, clang-format)
  - Magma Source
    - Is mounted in container via a Docker Volume automatically
    - Resides at working directory of terminal (/workspaces/magma/)
- VS Code Configuration
  - Extensions auto-installed
    - ms-vscode.cpptools (c/c++ syntax highlighting / compilation)
    - CoenraadS.bracket-pair-colorizer-2 (color-matched parenthesis)
    - xaver.clang-format (clang-format support - see warning below)
    - notskm.clang-tidy (clang-tidy findings directly in vs code with ~squiggles)
    - eamodio.gitlens (fantastic git overlays of knowledge)
    - yzhang.markdown-all-in-one (markdown support)
    - christian-kohler.path-intellisense (path auto-complete in code)
    - vscodevim.vim (vim key bindings)
    - vscode-icons-team.vscode-icons (improved iconography)
    - ms-vsliveshare.vsliveshare (live-share support with colleagues)
    - ms-azuretools.vscode-docker (docker support, needed for local dev)
  - Settings auto-applied
    - c/c++ include paths necessary for compilation / analysis
    - clang-tidy include paths necessary for analysis
    - (these path sets are a work in progress, contributions welcome)

# Using

## With GH Code Spaces

To use in GH Code Spaces - simply open up a GH Codespace for our repo (from a branch containing this commit, select the Green code icon, drop down and select `Open with Codespaces`). Note you can work entirely in the browser if you like, or you can attach your local VS Code to the Codespaces environment.

## Locally

See `Setup` in `.devcontainer/README.md`.

# Sharp Edges

Beware that our clang-format configuration, applied with clang-format 11, results in many modifications to our codebase formatting. This will need to be resolved soon as we are moving on towards Ubuntu 20.04 and can expect Clang-11 in whatever build environment we are running. My 2 cents is that we would be better served using a standard clang-format config e.g. Googles - which I expect is better specified and does not result in motion over clang versions.

# TODO

## Add Docker Registry

Presently the configuration uses no docker registry - so the Dockerfile is built from scratch (or cache if local) every environment. This takes ~40 minutes today. Easy enough to fix with help from e.g. @tmdzk and his team.

## Add any packages / support needed for Golang / Cloud dev

Presently this Dockerfile focuses on AGW c/c++ development. I do believe vs-code can provide environments per task - or we could create one docker container with all our needs (once a registry is in use, this will have ~minimal impact?).

## Reduce Dockerfile Duplication

I'm not sure how feasible this will be - but **much** of `.devcontainer/Dockerfile` is shared with `lte/gateway/docker/mme/Dockerfile.ubuntu20.04`.  But there are substantial base image differences as well - so I'm not sure how well Docker re-use mechanisms will work here. It would be much better to share common library install / setup stages between the two - so we do not duplicate content.

# Test Plan

From this branch in my personal magma repo, checked out in GH Code Spaces and confirmed Dockerfile built.  Opened terminal and successfully did the following.

```
cd lte/gateway
make test_oai
```

Signed-off-by: Scott Harrison Moeller <smoeller@fb.com>