### PR TITLE
[AGW][Sentry] Add release and hwid information to sentry initialization

### DIFF
--- a/orc8r/gateway/python/magma/common/sentry.py
+++ b/orc8r/gateway/python/magma/common/sentry.py
@@ -11,7 +11,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
+import os
 import sentry_sdk
+import snowflake
 
 from magma.configuration.service_configs import get_service_config_value
 
@@ -22,4 +24,9 @@ def sentry_init():
     sentry_url = get_service_config_value('control_proxy', 'sentry_url', default="")
     if sentry_url:
         sentry_sample_rate = get_service_config_value('control_proxy', 'sentry_sample_rate', default=1.0)
-        sentry_sdk.init(dsn=sentry_url, traces_sample_rate=sentry_sample_rate)
+        sentry_sdk.init(
+            dsn=sentry_url, 
+            release=os.environ['COMMIT_HASH'],
+            traces_sample_rate=sentry_sample_rate, 
+        )
+        sentry_sdk.set_tag("hwid", snowflake.snowflake())


### PR DESCRIPTION
<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary
- In order to sift through logs reported to sentry, it is useful to be able to tell apart different AGWs and versions. 
- For versioning, use the `COMMIT_HASH` environment variable that is set at agw packaging time. 
   - This will be doubly useful when we integrate Sentry with GitHub. 
- For unique AGW ID, use the HWID. 
<!-- Enumerate changes you made and why you made them -->

## Test Plan
Tested in dogfooding
<img width="1116" alt="Screen Shot 2021-03-24 at 1 27 13 PM" src="https://user-images.githubusercontent.com/37634144/112364592-b1c5fd80-8ca4-11eb-8d20-38001086aa59.png">

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
