### PR TITLE
[SessionD][Redis] Check session store ready state before accessing

### DIFF
--- a/lte/gateway/c/session_manager/MemoryStoreClient.h
+++ b/lte/gateway/c/session_manager/MemoryStoreClient.h
@@ -32,6 +32,8 @@ class MemoryStoreClient final : public StoreClient {
   MemoryStoreClient(MemoryStoreClient&&)      = default;
   ~MemoryStoreClient()                        = default;
 
+  bool is_ready() { return true; };
+
   SessionMap read_sessions(std::set<std::string> subscriber_ids);
 
   SessionMap read_all_sessions();

--- a/lte/gateway/c/session_manager/RedisStoreClient.h
+++ b/lte/gateway/c/session_manager/RedisStoreClient.h
@@ -50,6 +50,8 @@ class RedisStoreClient final : public StoreClient {
 
   bool try_redis_connect();
 
+  bool is_ready() { return client_->is_connected(); };
+
   SessionMap read_sessions(std::set<std::string> subscriber_ids);
 
   SessionMap read_all_sessions();

--- a/lte/gateway/c/session_manager/SessionStore.h
+++ b/lte/gateway/c/session_manager/SessionStore.h
@@ -90,6 +90,12 @@ class SessionStore {
       std::shared_ptr<RedisStoreClient> store_client);
 
   /**
+   * @brief Return a boolean to indicate whether the storage client is ready to
+   * accept requests
+   */
+  bool is_ready() { return store_client_->is_ready(); };
+
+  /**
    * Writes the session map directly to the store. Note that the existing map
    * will be overwriten
    * @param session_map

--- a/lte/gateway/c/session_manager/StoreClient.h
+++ b/lte/gateway/c/session_manager/StoreClient.h
@@ -29,6 +29,14 @@ typedef std::unordered_map<std::string, SessionVector> SessionMap;
  */
 class StoreClient {
  public:
+  virtual ~StoreClient() = default;
+
+  /**
+   * @brief Return a boolean to indicate whether the client is ready to accept
+   * requests
+   */
+  virtual bool is_ready() = 0;
+
   /**
    * Directly read the subscriber's sessions from storage
    *


### PR DESCRIPTION
Signed-off-by: Marie Bremner <marwhal@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary
We are seeing SessionD crashes due to it throwing an exception when Redis is unavailable. Specifically, SessionD would crash if PipelineD sends a ReportRuleStats to SessionD before redis client is available. 
In order to get around this, the new logic is to check the SessionStore readiness before accessing. For ReportRuleStats, we will ignore messages since the interface doesn't allow for error propagation. For LocalCreateSession, we will respond with error. 


<!-- Enumerate changes you made and why you made them -->

## Test Plan
Run `make restart` multiple times in a row to see if sessiond cores are produced. 
-> before this change -> core per-restart
-> after this change -> no cores

Run the s1ap test locally
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
