### PR TITLE
[feg] S8_proxy fix create session request validator

### DIFF
--- a/feg/gateway/services/s8_proxy/servicers/ie_conversions.go
+++ b/feg/gateway/services/s8_proxy/servicers/ie_conversions.go
@@ -97,15 +97,36 @@ func buildDeleteSessionRequestMsg(req *protos.DeleteSessionRequestPgw) message.M
 }
 
 func getPDNAddressAllocation(req *protos.CreateSessionRequestPgw) *ie.IE {
-	var res *ie.IE
+	var (
+		res        *ie.IE
+		ipv4       string
+		ipv6       string
+		ipv6Prefix uint8
+	)
+	// extract ips of default values
+	if req.Paa == nil || req.Paa.Ipv4Address == "" {
+		ipv4 = "0.0.0.0"
+	} else {
+		ipv4 = req.Paa.Ipv4Address
+	}
+
+	if req.Paa == nil || req.Paa.Ipv6Address == "" {
+		ipv6 = "::"
+		ipv6Prefix = 0
+	} else {
+		ipv6 = req.Paa.Ipv6Address
+		ipv6Prefix = uint8(req.Paa.Ipv6Prefix)
+	}
+
+	// create the IE based on the type
 	if req.PdnType == protos.PDNType_IPV4 {
-		res = ie.NewPDNAddressAllocation(req.Paa.Ipv4Address)
+		res = ie.NewPDNAddressAllocation(ipv4)
 	}
 	if req.PdnType == protos.PDNType_IPV6 {
-		res = ie.NewPDNAddressAllocationIPv6(req.Paa.Ipv6Address, uint8(req.Paa.Ipv6Prefix))
+		res = ie.NewPDNAddressAllocationIPv6(ipv6, ipv6Prefix)
 	}
 	if req.PdnType == protos.PDNType_IPV4V6 {
-		res = ie.NewPDNAddressAllocationDual(req.Paa.Ipv4Address, req.Paa.Ipv6Address, uint8(req.Paa.Ipv6Prefix))
+		res = ie.NewPDNAddressAllocationDual(ipv4, ipv6, ipv6Prefix)
 	}
 	return res
 }

--- a/feg/gateway/services/s8_proxy/servicers/proto_conversions.go
+++ b/feg/gateway/services/s8_proxy/servicers/proto_conversions.go
@@ -50,6 +50,9 @@ func parseCreateSessionResponse(msg message.Message) (csRes *protos.CreateSessio
 		return
 	}
 
+	// get C AGW Teid (is the same used on Create Session Request by MME)
+	csRes.CAgwTeid = msg.TEID()
+
 	// get PDN Allocation from PGW
 	if paaIE := csResGtp.PAA; paaIE != nil {
 		paa, pdnType, err2 := handlePDNAddressAllocation(paaIE)

--- a/feg/gateway/services/s8_proxy/servicers/senders.go
+++ b/feg/gateway/services/s8_proxy/servicers/senders.go
@@ -34,8 +34,10 @@ func (s *S8Proxy) sendAndReceiveCreateSession(
 	csReq *protos.CreateSessionRequestPgw,
 	cPgwUDPAddr *net.UDPAddr,
 	csReqMsg message.Message) (*protos.CreateSessionResponsePgw, error) {
-	glog.V(2).Infof("Send Create Session Request (gtp) to %s:\n%s",
+	glog.V(2).Infof("Send Create Session Request (grpc) to %s:\n%s",
 		cPgwUDPAddr.String(), csReq.String())
+	glog.V(2).Infof("Send Create Session Request (gtp) to %s:\n%s",
+		cPgwUDPAddr.String(), csReqMsg.(*message.CreateSessionRequest).String())
 
 	grpcMessage, err := s.gtpClient.SendMessageAndExtractGrpc(csReq.Imsi, csReq.CAgwTeid, cPgwUDPAddr, csReqMsg)
 	if err != nil {
@@ -57,9 +59,10 @@ func (s *S8Proxy) sendAndReceiveCreateSession(
 func (s *S8Proxy) sendAndReceiveDeleteSession(req *protos.DeleteSessionRequestPgw,
 	cPgwUDPAddr *net.UDPAddr,
 	dsReqMsg message.Message) (*protos.DeleteSessionResponsePgw, error) {
-
-	glog.V(2).Infof("Send Delete Session Request (gtp) to %s:\n%s", cPgwUDPAddr,
+	glog.V(2).Infof("Send Delete Session Request (grpc) to %s:\n%s", cPgwUDPAddr,
 		dsReqMsg)
+	glog.V(2).Infof("Send Delete Session Request (gtp) to %s:\n%s",
+		cPgwUDPAddr.String(), dsReqMsg.(*message.DeleteSessionRequest).String())
 	grpcMessage, err := s.gtpClient.SendMessageAndExtractGrpc(req.Imsi, req.CAgwTeid, cPgwUDPAddr, dsReqMsg)
 	if err != nil {
 		return nil, fmt.Errorf("no response message to DeleteSessionRequest: %s", err)


### PR DESCRIPTION
Signed-off-by: Oriol Batalla <obatalla@fb.com>

Removing a condition that was preventing the s8_proxy to move ahead when teid = 0

## Summary

<!-- Enumerate changes you made and why you made them -->

## Test Plan

make precommit

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
