### PR TITLE
[orc8r] Fix invalid swagger scheme

### DIFF
--- a/orc8r/cloud/go/obsidian/swagger/v1/index.html
+++ b/orc8r/cloud/go/obsidian/swagger/v1/index.html
@@ -94,6 +94,7 @@ window.onload = function() {
     url: window.location.origin + '{{.URL}}',
     dom_id: '#swagger-ui',
     deepLinking: true,
+    validatorUrl: null,
     presets: [
       SwaggerUIBundle.presets.apis,
       SwaggerUIStandalonePreset


### PR DESCRIPTION
Signed-off-by: Andy Lee Khuu <andykhuu@stanford.edu>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary
We are seeing an invalid scheme error in the staging of Swagger UI. This PR adds a simple one line change to disable the validator service so that the error doesn't occur.
<!-- Enumerate changes you made and why you made them -->

## Test Plan
- [x] Manually checking that Swagger UI still works
- [x] ./build.py -t 
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
