### PR TITLE
[ci] Add missing Slack notifications to all jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -781,6 +781,7 @@ jobs:
             cd $MAGMA_ROOT/lte/gateway/docker/mme
             docker build -t magma-mme-build -f Dockerfile.ubuntu20.04 ../../../../
             docker run --env BRANCH=$BRANCH --env REVISION=$REVISION -v $MAGMA_ROOT:/magma -i -t magma-mme-build:latest /bin/bash -c 'cd /magma/lte/gateway;make clang_tidy_oai_upload'
+      - magma_slack_notify
 
   c-cpp-codecov:
     machine:
@@ -798,6 +799,7 @@ jobs:
             docker build -t magma/c_cpp_build -f Dockerfile.ubuntu20.04 ../../../../
             ci_env=`bash <(curl -s https://codecov.io/env)`
             docker run $ci_env -e CI=true -v /home/circleci/project:/magma -v /home/circleci/project/lte/gateway/configs:/etc/magma -i -t magma/c_cpp_build:latest /bin/bash -c "cd /magma/lte/gateway;make coverage;ls -al /tmp/;bash <(curl -s https://codecov.io/bash) -f /build/c/coverage.info"
+      - magma_slack_notify
 
   mme-clang-warnings:
     machine:
@@ -814,6 +816,7 @@ jobs:
             cd $MAGMA_ROOT/lte/gateway/docker/mme
             docker build -t magma-mme-build -f Dockerfile.ubuntu20.04 ../../../../
             docker run --env BRANCH=$BRANCH --env REVISION=$REVISION -v /home/circleci/project:/magma -v /home/circleci/project/lte/gateway/configs:/etc/magma -i -t magma-mme-build:latest /bin/bash -c "cd /magma/lte/gateway;make clang_warning_oai_upload"
+      - magma_slack_notify
 
   lte-test:
     machine:
@@ -1006,7 +1009,6 @@ jobs:
             ./e2e_test_setup.sh
       - store_artifacts:
           path: /tmp/nms_artifacts
-
       - magma_slack_notify
 
   nms-build:
@@ -1080,6 +1082,7 @@ jobs:
             echo "machine github.com login mamga-docusaurus-bot password $GITHUB_TOKEN" > ~/.netrc
             cd website && yarn install
             CUSTOM_COMMIT_MESSAGE="[skip ci] Deploy website" GIT_USER=mamga-docusaurus-bot yarn run publish-gh-pages
+      - magma_slack_notify
 
   ### XWF
 
@@ -1116,7 +1119,8 @@ jobs:
             docker-compose build --parallel && docker-compose up -d && docker exec tests pytest --log-cli-level=info code/tests.py
       - when:
           condition: <<parameters.notify_magma_ci>>
-          steps: magma_slack_notify
+          steps:
+            - magma_slack_notify
       - when:
           condition: <<parameters.notify_xwfm_ci>>
           steps:


### PR DESCRIPTION
## Summary

Docusuarus job was failing but we didn't realize because Slack channel wasn't being notified. Fix for Docusaurus job and a few others.

## Test Plan

n/a

## Additional Information

- [ ] This change is backwards-breaking