### PR TITLE
[MME]  Free cid in mme_app_edns_emulation

### DIFF
--- a/lte/gateway/c/oai/tasks/mme_app/mme_app_edns_emulation.c
+++ b/lte/gateway/c/oai/tasks/mme_app/mme_app_edns_emulation.c
@@ -57,8 +57,12 @@ int mme_app_edns_add_sgw_entry(bstring id, struct in_addr in_addr) {
 
       hashtable_rc_t rc =
           obj_hashtable_insert(g_e_dns_entries, cid, strlen(cid), data);
-      if (HASH_TABLE_OK == rc) return RETURNok;
+      if (HASH_TABLE_OK == rc) {
+        free(cid);
+        return RETURNok;
+      }
     }
+    free(cid);
   }
   return RETURNerror;
 }


### PR DESCRIPTION
## Summary
clang-tidy currently shows a warning in the file
mme_app_edns_emulation.c due to an allocated cid
value that is never freed. Free that value prior
to returning.

Signed-off-by: Anusha Datar <anushadatar@gmail.com>


## Test Plan

```
cd lte/gateway
make build_oai
```
And CI Pipelines.

