### PR TITLE
[CI] Fix permissions for build dir in magma vagrant vm

### DIFF
--- a/ci-scripts/JenkinsFile-GitLab
+++ b/ci-scripts/JenkinsFile-GitLab
@@ -157,6 +157,7 @@ pipeline {
                 // Manual removal of build dirs
                 try {
                   sh('cd lte/gateway && vagrant ssh magma -c "sudo rm -Rf build/c build/python"')
+
                 } catch (Exception e) {
                   echo "OK after a git clean..."
                 }
@@ -167,7 +168,7 @@ pipeline {
                 }
                 // Manually creating the c build dir
                 try {
-                  sh ('cd lte/gateway && vagrant ssh magma -c "mkdir -p build/c"' )
+                  sh('cd lte/gateway && vagrant ssh magma -c "sudo mkdir -p build/c;sudo chown -R vagrant build"')
                 } catch (Exception e) {
                   echo "It should not fail here but we still go on"
                 }


### PR DESCRIPTION
Magma dev VM ansible scripts are writing to /home/vagrant/build as root user. This should be worked around.