### PR TITLE
[orc8r] Clear prod image apt cache

### DIFF
--- a/orc8r/cloud/docker/controller/Dockerfile
+++ b/orc8r/cloud/docker/controller/Dockerfile
@@ -85,7 +85,8 @@ RUN apt-get update && apt-get install -y \
   openssl \
   supervisor \
   unzip \
-  wget
+  wget \
+&& rm -rf /var/lib/apt/lists/*
 
 # Swagger UI
 # See: https://github.com/swagger-api/swagger-ui


### PR DESCRIPTION
## Summary

Best practice is to [clear apt cache](https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#run) in prod images. In this case, saves 30 mb in Orc8r prod image, a 2% size reduction.

## Test Plan

n/a

## Additional Information

- [ ] This change is backwards-breaking