### PR TITLE
[AGW][CodeCov] Add C++ flags for codecov as well

### DIFF
--- a/lte/gateway/c/oai/CMakeLists.txt
+++ b/lte/gateway/c/oai/CMakeLists.txt
@@ -49,6 +49,7 @@ set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "${CMAKE_CXX_FLAGS_DEBUG} -DDEBUG_IS_ON=1")
 
 # Add Gcov flags
 set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} -g -O0 -fprofile-arcs -ftest-coverage")
+set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -g -O0 -fprofile-arcs -ftest-coverage")
 # Add gcov linker flags
 set(CMAKE_EXE_LINKER_FLAGS_DEBUG  "${CMAKE_EXE_LINKER_FLAGS_DEBUG} -fprofile-arcs -ftest-coverage")
 


### PR DESCRIPTION
Signed-off-by: Marie Bremner <marwhal@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary
The OAI directory was missing C++ flags for codecov, leading the coverage to ignore all C++ files. 😅 
Moving the connection tracker out of the conditional check since it is not necessary.

TODO: 
1. Add codecov for connection_tracking service
2. Add codecov for orc8r/gateway/c/common
<!-- Enumerate changes you made and why you made them -->

## Test Plan
run `make coverage` and see new stats :)
The cpp files now show up and there's a bit of coverage there
<img width="1235" alt="Screen Shot 2021-03-25 at 11 58 24 AM" src="https://user-images.githubusercontent.com/37634144/112512517-70dfee80-8d61-11eb-8887-a72cd47ac125.png">

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
