### PR TITLE
[AGW][BUILD] Typo in dependency

### DIFF
--- a/lte/gateway/release/build-magma.sh
+++ b/lte/gateway/release/build-magma.sh
@@ -164,7 +164,7 @@ if [[ "$OS" == "debian" ]]; then
         "libopenvswitch >= 2.8.10"
         "openvswitch-switch >= 2.8.10"
         "openvswitch-common >= 2.8.10"
-        "python-openvswitch >= 2.8.10"
+        "python3-openvswitch >= 2.8.10"
         "openvswitch-datapath-module-4.9.0-9-amd64 >= 2.8.10"
         )
 else
@@ -173,7 +173,7 @@ else
         "libopenvswitch >= 2.14"
         "openvswitch-switch >= 2.14"
         "openvswitch-common >= 2.14"
-        "python-openvswitch >= 2.14"
+        "python3-openvswitch >= 2.14"
         "openvswitch-datapath-dkms >= 2.14"
         )
 fi


### PR DESCRIPTION
Signed-off-by: Timothée Dzik <timdzik@fb.com>

[AGW][BUILD] Typo in dependency

## Summary

Typo in the python3-openvswithch package

## Test Plan

`cd lte/gateway && fab dev package:vcs=git`