### PR TITLE
[agw][mme] Add S5_S8 interface config into spgw.conf

### DIFF
--- a/lte/gateway/c/oai/tasks/sgw/pgw_config.c
+++ b/lte/gateway/c/oai/tasks/sgw/pgw_config.c
@@ -111,26 +111,33 @@ int pgw_config_process(pgw_config_t* config_pP) {
     strncpy(
         ifr.ifr_name, (const char*) config_pP->ipv4.if_name_S5_S8->data,
         IFNAMSIZ - 1);
-    ioctl(fd, SIOCGIFADDR, &ifr);
-    struct sockaddr_in* ipaddr = (struct sockaddr_in*) &ifr.ifr_addr;
-    if (inet_ntop(
-            AF_INET, (const void*) &ipaddr->sin_addr, str, INET_ADDRSTRLEN) ==
-        NULL) {
-      OAILOG_ERROR(LOG_SPGW_APP, "inet_ntop");
-      return RETURNerror;
-    }
-    config_pP->ipv4.S5_S8.s_addr = ipaddr->sin_addr.s_addr;
+    if (ioctl(fd, SIOCGIFADDR, &ifr)) {
+      OAILOG_INFO(
+          LOG_SPGW_APP, "No interface for S5_S8 user plane: error %s\n",
+          strerror(errno));
+      close(fd);
+    } else {
+      struct sockaddr_in* ipaddr = (struct sockaddr_in*) &ifr.ifr_addr;
+      if (inet_ntop(
+              AF_INET, (const void*) &ipaddr->sin_addr, str, INET_ADDRSTRLEN) ==
+          NULL) {
+        OAILOG_ERROR(LOG_SPGW_APP, "inet_ntop");
+        close(fd);
+        return RETURNerror;
+      }
+      config_pP->ipv4.S5_S8.s_addr = ipaddr->sin_addr.s_addr;
 
-    ifr.ifr_addr.sa_family = AF_INET;
-    strncpy(
-        ifr.ifr_name, (const char*) config_pP->ipv4.if_name_S5_S8->data,
-        IFNAMSIZ - 1);
-    ioctl(fd, SIOCGIFMTU, &ifr);
-    config_pP->ipv4.mtu_S5_S8 = ifr.ifr_mtu;
-    OAILOG_DEBUG(
-        LOG_SPGW_APP, "Foung S5_S8 interface MTU=%d\n",
-        config_pP->ipv4.mtu_S5_S8);
-    close(fd);
+      /*ifr.ifr_addr.sa_family = AF_INET;
+      strncpy(
+          ifr.ifr_name, (const char*) config_pP->ipv4.if_name_S5_S8->data,
+          IFNAMSIZ - 1);*/
+      ioctl(fd, SIOCGIFMTU, &ifr);
+      config_pP->ipv4.mtu_S5_S8 = ifr.ifr_mtu;
+      OAILOG_DEBUG(
+          LOG_SPGW_APP, "Foung S5_S8 interface MTU=%d\n",
+          config_pP->ipv4.mtu_S5_S8);
+      close(fd);
+    }
   }
   // Get IP block information
   if (config_pP->enable_nat) {
@@ -360,8 +367,6 @@ int pgw_config_parse_file(pgw_config_t* config_pP) {
           config_setting_lookup_string(
               setting_pgw, PGW_CONFIG_STRING_DEFAULT_DNS_SEC_IPV4_ADDRESS,
               (const char**) &default_dns_sec)) {
-        bdestroy_wrapper(&config_pP->ipv4.if_name_S5_S8);
-        config_pP->ipv4.if_name_S5_S8 = bfromcstr(if_S5_S8);
         IPV4_STR_ADDR_TO_INADDR(
             default_dns, config_pP->ipv4.default_dns,
             "BAD IPv4 ADDRESS FORMAT FOR DEFAULT DNS !\n");

--- a/lte/gateway/c/oai/tasks/sgw/spgw_config.c
+++ b/lte/gateway/c/oai/tasks/sgw/spgw_config.c
@@ -63,14 +63,6 @@ static int spgw_config_process(spgw_config_t* config_pP) {
     return RETURNerror;
   }
 
-#define SPGW_NOT_SPLITTED 1
-#if SPGW_NOT_SPLITTED
-  // fake split
-  bdestroy_wrapper(&config_pP->pgw_config.ipv4.if_name_S5_S8);
-  config_pP->pgw_config.ipv4.if_name_S5_S8 =
-      bstrcpy(config_pP->sgw_config.ipv4.if_name_S1u_S12_S4_up);
-#endif
-
   if (RETURNok != pgw_config_process(&config_pP->pgw_config)) {
     return RETURNerror;
   }

--- a/lte/gateway/configs/spgw.yml
+++ b/lte/gateway/configs/spgw.yml
@@ -13,6 +13,7 @@
 
 s11_iface_name: "lo"  # 'sgw_s11_ip' will be filled automatically
 s1u_iface_name: "eth1"  # 's1_ip' will be filled automatically
+sgw_s5s8_up_iface_name: "eth0"  # 'sgw_s5s8_up_ip' will be filled automatically
 masquerade: "no"
 ipv4_dns: "8.8.8.8" # will be replaced by dnsd if caching is enabled
 ipv4_sec_dns: "8.8.4.4"

--- a/lte/gateway/configs/templates/spgw.conf.template
+++ b/lte/gateway/configs/templates/spgw.conf.template
@@ -25,8 +25,8 @@ S-GW :
         SGW_IPV4_PORT_FOR_S1U_S12_S4_UP         = 2152;                         # INTEGER, port number, PREFER NOT CHANGE UNLESS YOU KNOW WHAT YOU ARE DOING
 
         # S-GW binded interface for S5 or S8 communication, not implemented, so leave it to none
-        SGW_INTERFACE_NAME_FOR_S5_S8_UP         = "none";                       # STRING, interface name, DO NOT CHANGE (NOT IMPLEMENTED YET)
-        SGW_IPV4_ADDRESS_FOR_S5_S8_UP           = "0.0.0.0/24";                 # STRING, CIDR, DO NOT CHANGE (NOT IMPLEMENTED YET)
+        SGW_INTERFACE_NAME_FOR_S5_S8_UP         = "{{ sgw_s5s8_up_iface_name }}";         # STRING, interface name
+        SGW_IPV4_ADDRESS_FOR_S5_S8_UP           = "{{ sgw_s5s8_up_ip }}";                 # STRING, CIDR
     };
 
     INTERTASK_INTERFACE :

--- a/lte/gateway/python/scripts/generate_oai_config.py
+++ b/lte/gateway/python/scripts/generate_oai_config.py
@@ -198,6 +198,7 @@ def _get_context():
     context = {
         "mme_s11_ip": _get_iface_ip("mme", "s11_iface_name"),
         "sgw_s11_ip": _get_iface_ip("spgw", "s11_iface_name"),
+        "sgw_s5s8_up_ip": _get_iface_ip("spgw", "sgw_s5s8_up_iface_name"),
         "remote_sgw_ip": get_service_config_value("mme",
                                                   "remote_sgw_ip", ""),
         "s1ap_ip": _get_iface_ip("mme", "s1ap_iface_name"),


### PR DESCRIPTION
Signed-off-by: Shruti Sanadhya <ssanadhya@fb.com>

**NOTE: Re-provision magma dev VM to get the changes to generate_oai_config.py from this PR**

## Summary

To support Inbound Roaming, the SGW_S8 task in MME service needs to advertise the user plane IP address in the Create Session Request to the roaming network PGW. This change:

- Adds the interface name as a configuration in `spgw.yml`, note that `eth0` is not the SGI interface in dev VM, but it is the SGI interface that is used in TeraVM, prod and bare metal installs
- Modifies the `spgw.conf.template` to remove hardcoded interface name and IP addresses for S5_S8
- Modifies the `generate_oai_config.py` to lookup the IP address based on the interface name in `spgw.yml`
- Modifies the config parsing in SPGW task within MME

## Test Plan

MME log before the change:
```
tasks/sgw/sgw_config.c          :0382    - S5-S8:
tasks/sgw/sgw_config.c          :0385        S5_S8 iface ..........: none
tasks/sgw/sgw_config.c          :0388        S5_S8 ip .............: 0.0.0.0/24
tasks/sgw/pgw_config.c          :0573    - S5-S8:
tasks/sgw/pgw_config.c          :0576        S5_S8 iface ..........: eth1
tasks/sgw/pgw_config.c          :0579        S5_S8 ip  (read)......: 192.168.60.142
tasks/sgw/pgw_config.c          :0582        S5_S8 MTU (read)......: 1500
```

MME log after the change:
```
tasks/sgw/sgw_config.c          :0382    - S5-S8:
tasks/sgw/sgw_config.c          :0385        S5_S8 iface ..........: eth0
tasks/sgw/sgw_config.c          :0388        S5_S8 ip .............: 10.0.2.15/24
tasks/sgw/pgw_config.c          :0578    - S5-S8:
tasks/sgw/pgw_config.c          :0581        S5_S8 iface ..........: none
tasks/sgw/pgw_config.c          :0584        S5_S8 ip  (read)......: 0.0.0.0
tasks/sgw/pgw_config.c          :0587        S5_S8 MTU (read)......: 0
```
Note that the PGW S5_S8 config is not relevant here, just cleaning it to be uninitialized.

Regression testing: S1ap integration tests
Functional testing: Will be tested with #5638 on TeraVM
