### PR TITLE
[DevExp] Add Include-What-You-Use tooling to Dockerfile env

### DIFF
--- a/lte/gateway/docker/mme/Dockerfile.ubuntu20.04
+++ b/lte/gateway/docker/mme/Dockerfile.ubuntu20.04
@@ -35,6 +35,7 @@ RUN echo "Install general purpouse packages" && \
         git \
         gnupg \
         golang \
+        libclang-11-dev \
         libgmp3-dev \
         libpcap-dev \
         libssl-dev \
@@ -230,6 +231,20 @@ RUN git clone --branch v4.3 https://github.com/mfontanini/libtins.git && \
     make install && \
     cd / && \
     rm -rf libtins
+
+###### Install Include What You Use for c/cpp header include fixup tooling
+# Tag 0.15 tracks Clang 11.0 per https://github.com/include-what-you-use/include-what-you-use/tags
+RUN git clone https://github.com/include-what-you-use/include-what-you-use && \
+    cd include-what-you-use && \
+    git checkout 0.15 && \
+    cd .. && \
+    mkdir build_iwyu && cd build_iwyu && \
+    cmake -G "Unix Makefiles" -DIWHYU_LLVM_ROOT_PATH=/usr/lib/llvm-11 ../include-what-you-use/ && \
+    make && \
+    make install && \
+    cd / && \
+    rm -rf include-what-you-use && \
+    rm -rf build_liwyu
 
 # Add Converged MME sources to the container
 # Must be done prior to FreeDiameter build as we need the patches from Magma repo


### PR DESCRIPTION
# Summary

Enables automated fixup / advice for missing or excessive c/cpp header includes. Enables Issue #4868.

Followed [Github Repo instructions for installation](https://github.com/include-what-you-use/include-what-you-use).

Example use - modify`/lte/gateway/Makefile` as follows and then `make build_session_manager`.  The same Makefile mods can be applied to other targets. It might be worth making these official / supported by ENV settings or other. But for now I just want tooling available in our container.

```makefile
diff --git a/lte/gateway/Makefile b/lte/gateway/Makefile
index 2411d6b56..398395db7 100644
--- a/lte/gateway/Makefile
+++ b/lte/gateway/Makefile
@@ -182,7 +182,7 @@ build_sctpd: format_sctpd build_common ## Build SCTPD
        $(call run_cmake, $(C_BUILD)/sctpd, $(GATEWAY_C_DIR)/sctpd, )

 build_session_manager: format_session_manager build_common ## Build session manager
-       $(call run_cmake, $(C_BUILD)/session_manager, $(GATEWAY_C_DIR)/session_manager, )
+       $(call run_cmake, $(C_BUILD)/session_manager, $(GATEWAY_C_DIR)/session_manager, -DCMAKE_CXX_INCLUDE_WHAT_YOU_USE="/usr/local/bin/include-what-you-use;-Xiwyu;any;-Xiwyu;iwyu;-Xiwyu;args")

 build_connection_tracker: format_connection_tracker build_common ## Build connection tracker
        $(call run_cmake, $(C_BUILD)/connection_tracker, $(GATEWAY_C_DIR)/connection_tracker, )
```

# Sample Output

This [Gist for Session Manager Build](https://gist.github.com/electronjoe/13674205801b04e0e545d7895534d6bd) is a full log output example.  Here is a snippet from one compilation unit.

```c
[17/62] Building CXX object CMakeFiles/SESSION_MANAGER.dir/ChargingGrant.cpp.o
Warning: include-what-you-use reported diagnostics:

/magma/lte/gateway/c/session_manager/ChargingGrant.h should add these lines:
#include <stdint.h>                         // for uint32_t
#include <ctime>                            // for NULL, time_t
#include "lte/protos/session_manager.pb.h"  // for CreditUpdateResponse (ptr...

/magma/lte/gateway/c/session_manager/ChargingGrant.h should remove these lines:
- #include "DiameterCodes.h"  // lines 18-18

The full include-list for /magma/lte/gateway/c/session_manager/ChargingGrant.h:
#include <stdint.h>                         // for uint32_t
#include <ctime>                            // for NULL, time_t
#include "ServiceAction.h"                  // for ServiceActionType
#include "SessionCredit.h"                  // for SessionCredit
#include "StoredState.h"                    // for ReAuthState, ServiceState
#include "lte/protos/session_manager.pb.h"  // for CreditUpdateResponse (ptr...
```

# Possible Problems

I believe the include-what-you-use tooling may not be processing c targets (only c++?), as I'm not seeing outputs for them. This requires exploration, possibly related to our CMake configs (this has been the case before).

# Test Plan

Applied above patch to `lte/gateway/Makefile` then.

```shell
make build_session_manager 2>&1 | tee build.log
```

The `build.log` will contain detailed log output for fixup of all header includes, per file - as the compilation units are built.

Signed-off-by: Scott Harrison Moeller <smoeller@fb.com>