### PR TITLE
[agw][mme] Remove unused MAX_TAI_SUPPORTED config restriction

### DIFF
--- a/lte/gateway/c/oai/include/mme_config.h
+++ b/lte/gateway/c/oai/include/mme_config.h
@@ -52,7 +52,6 @@
 #define MIN_GUMMEI 1
 #define MAX_GUMMEI 5
 #define MIN_TAI_SUPPORTED 1
-#define MAX_TAI_SUPPORTED 16
 #define MAX_MCC_LENGTH 3
 #define MAX_MNC_LENGTH 3
 #define MIN_MNC_LENGTH 2

--- a/lte/gateway/c/oai/tasks/mme_app/mme_config.c
+++ b/lte/gateway/c/oai/tasks/mme_app/mme_config.c
@@ -642,10 +642,11 @@ int mme_config_parse_file(mme_config_t* config_pP) {
         config_setting_get_member(setting_mme, MME_CONFIG_STRING_TAI_LIST);
     if (setting != NULL) {
       num = config_setting_length(setting);
-      if (num <= MIN_TAI_SUPPORTED) {
+      if (num < MIN_TAI_SUPPORTED) {
         fprintf(
             stderr,
-            "Not even one TAI is configured, configure minimum one TAI\n");
+            "ERROR: No TAI is configured.  At least one TAI must be "
+            "configured.\n");
       }
 
       if (config_pP->served_tai.nb_tai != num) {
@@ -701,7 +702,7 @@ int mme_config_parse_file(mme_config_t* config_pP) {
 
             if (!TAC_IS_VALID(config_pP->served_tai.tac[i])) {
               fprintf(
-                  stderr, "Invalid TAC value " TAC_FMT,
+                  stderr, "ERROR: Invalid TAC value " TAC_FMT,
                   config_pP->served_tai.tac[i]);
             }
           }

--- a/lte/gateway/c/oai/tasks/mme_app/mme_config.c
+++ b/lte/gateway/c/oai/tasks/mme_app/mme_config.c
@@ -642,14 +642,11 @@ int mme_config_parse_file(mme_config_t* config_pP) {
         config_setting_get_member(setting_mme, MME_CONFIG_STRING_TAI_LIST);
     if (setting != NULL) {
       num = config_setting_length(setting);
-      OAILOG_INFO(LOG_MME_APP, "Number of TAIs configured: %d\n", num);
-      AssertFatal(
-          num >= MIN_TAI_SUPPORTED,
-          "Not even one TAI is configured, configure minimum one TAI\n");
-      AssertFatal(
-          num <= MAX_TAI_SUPPORTED,
-          "Too many TAIs configured: %d (Maximum supported: %d)", num,
-          MAX_TAI_SUPPORTED);
+      if (num <= MIN_TAI_SUPPORTED) {
+        fprintf(
+            stderr,
+            "Not even one TAI is configured, configure minimum one TAI\n");
+      }
 
       if (config_pP->served_tai.nb_tai != num) {
         if (config_pP->served_tai.plmn_mcc != NULL)
@@ -702,9 +699,11 @@ int mme_config_parse_file(mme_config_t* config_pP) {
                   sub2setting, MME_CONFIG_STRING_TAC, &tac))) {
             config_pP->served_tai.tac[i] = (uint16_t) atoi(tac);
 
-            AssertFatal(
-                TAC_IS_VALID(config_pP->served_tai.tac[i]),
-                "Invalid TAC value " TAC_FMT, config_pP->served_tai.tac[i]);
+            if (!TAC_IS_VALID(config_pP->served_tai.tac[i])) {
+              fprintf(
+                  stderr, "Invalid TAC value " TAC_FMT,
+                  config_pP->served_tai.tac[i]);
+            }
           }
         }
       }


### PR DESCRIPTION
Signed-off-by: Shruti Sanadhya <ssanadhya@fb.com>

## Summary

MME was crashing if more than 16 TAIs are configured via NMS (#5766 ). The `MAX_TAI_SUPPORTED` value is only used while reading config, hence removing it.

Also replaced some AssertFatals with stderr logs, so as to avoid service crashes.

## Test Plan

Regression testing: `make integ_test`
Function testing: Tested on Spirent AGW with 20 eNBs, each with different TAC value, and confirmed that 
- MME does not go into crash loop
- All 20 eNBs are able to do S1 Setup
- Able to attach/detach 10 UEs per eNB (total 200 UEs)
