### PR TITLE
[SessionD] Light ServiceAction refactor to use RulesToProcess struct

### DIFF
--- a/lte/gateway/c/session_manager/CMakeLists.txt
+++ b/lte/gateway/c/session_manager/CMakeLists.txt
@@ -172,6 +172,7 @@ add_library(SESSION_MANAGER
     Utilities.h
     OperationalStatesHandler.cpp
     OperationalStatesHandler.h
+    Types.h
     ${PROTO_SRCS}
     ${PROTO_HDRS})
 

--- a/lte/gateway/c/session_manager/LocalEnforcer.h
+++ b/lte/gateway/c/session_manager/LocalEnforcer.h
@@ -574,15 +574,13 @@ class LocalEnforcer {
       SessionUpdate& session_update);
 
   void handle_activate_service_action(
-      SessionMap& session_map, const std::unique_ptr<ServiceAction>& action_p,
-      SessionUpdate& session_update);
+      const std::unique_ptr<ServiceAction>& action_p);
 
   /**
    * Install final action flows through pipelined
    */
   void install_final_unit_action_flows(
-      SessionMap& session_map, const std::unique_ptr<ServiceAction>& action,
-      SessionUpdate& session_update);
+      const std::unique_ptr<ServiceAction>& action);
 
   /**
    * Create redirection rule

--- a/lte/gateway/c/session_manager/PipelinedClient.h
+++ b/lte/gateway/c/session_manager/PipelinedClient.h
@@ -21,7 +21,7 @@
 #include <lte/protos/subscriberdb.pb.h>
 
 #include "GRPCReceiver.h"
-#include "SessionState.h"
+#include "Types.h"
 
 #define M5G_MIN_TEID (UINT32_MAX / 2)
 

--- a/lte/gateway/c/session_manager/PipelinedClient.h
+++ b/lte/gateway/c/session_manager/PipelinedClient.h
@@ -22,6 +22,7 @@
 
 #include "GRPCReceiver.h"
 #include "Types.h"
+#include "SessionState.h"
 
 #define M5G_MIN_TEID (UINT32_MAX / 2)
 

--- a/lte/gateway/c/session_manager/ServiceAction.h
+++ b/lte/gateway/c/session_manager/ServiceAction.h
@@ -18,6 +18,7 @@
 #include <experimental/optional>
 
 #include "CreditKey.h"
+#include "Types.h"
 
 namespace magma {
 using namespace lte;
@@ -72,11 +73,6 @@ class ServiceAction {
     return *this;
   }
 
-  ServiceAction& set_redirect_server(const RedirectServer& redirect_server) {
-    redirect_server_ = std::make_unique<RedirectServer>(redirect_server);
-    return *this;
-  }
-
   ServiceAction& set_ambr(const optional<AggregatedMaximumBitrate> ambr) {
     ambr_ = ambr;
     return *this;
@@ -111,43 +107,16 @@ class ServiceAction {
 
   const CreditKey& get_credit_key() const { return credit_key_; }
 
-  const std::vector<PolicyRule>& get_rule_definitions() const {
-    return rule_definitions_;
-  }
-
-  /**
-   * get_restrict_rules returns the associated restrict rules
-   * for the RESTRICT action
-   */
-  const std::vector<PolicyRule>& get_restrict_rules() const {
-    return restrict_rules_;
-  }
-
-  std::vector<PolicyRule>* get_mutable_rule_definitions() {
-    return &rule_definitions_;
-  }
-
-  const RedirectServer& get_redirect_server() const {
-    return *redirect_server_;
-  }
-
   const optional<AggregatedMaximumBitrate> get_ambr() const { return ambr_; }
 
   const std::string& get_msisdn() const { return *msisdn_; }
 
-  /**
-   * get_mutable_restrict_rules returns a mutable list of the associated
-   * restrict rules
-   */
-  std::vector<PolicyRule>* get_mutable_restrict_rules() {
-    return &restrict_rules_;
-  }
+  // RulesToProcess
+  RulesToProcess get_gx_rules_to_install() const { return gx_to_install_; }
+  RulesToProcess* get_mutable_gx_rules_to_install() { return &gx_to_install_; }
 
-  /**
-   * is_redirect_server_set returns true if redirect server is set,
-   * false otherwise.
-   */
-  bool is_redirect_server_set() const { return (redirect_server_ != NULL); }
+  RulesToProcess get_gy_rules_to_install() const { return gy_to_install_; }
+  RulesToProcess* get_mutable_gy_rules_to_install() { return &gy_to_install_; }
 
  private:
   ServiceActionType action_type_;
@@ -158,11 +127,9 @@ class ServiceAction {
   std::unique_ptr<Teids> teids_;
   std::unique_ptr<std::string> msisdn_;
   CreditKey credit_key_;
-  std::vector<std::string> rule_ids_;
-  std::vector<PolicyRule> rule_definitions_;
-  std::unique_ptr<RedirectServer> redirect_server_;
   optional<AggregatedMaximumBitrate> ambr_;
-  std::vector<PolicyRule> restrict_rules_;
+  RulesToProcess gx_to_install_;
+  RulesToProcess gy_to_install_;
 };
 
 }  // namespace magma

--- a/lte/gateway/c/session_manager/SessionState.h
+++ b/lte/gateway/c/session_manager/SessionState.h
@@ -612,6 +612,7 @@ class SessionState {
 
   // PolicyID->DedicatedBearerID used for 4G bearer/QoS management
   BearerIDByPolicyID bearer_id_by_policy_;
+  const uint32_t REDIRECT_FLOW_PRIORITY = 2000;
 
  private:
   /**
@@ -626,7 +627,32 @@ class SessionState {
       std::vector<std::unique_ptr<ServiceAction>>* actions_out,
       SessionStateUpdateCriteria& uc);
 
-  void fill_service_action(
+  /**
+   * @brief Get a CreditUsageUpdate for the case where we want to continue
+   * service
+   *
+   * @param grant
+   * @param session_uc
+   * @return optional<CreditUsageUpdate>
+   */
+  optional<CreditUsageUpdate> get_update_for_continue_service(
+      const CreditKey& key, std::unique_ptr<ChargingGrant>& grant,
+      SessionStateUpdateCriteria& session_uc);
+
+  void fill_service_action_for_activate(
+      std::unique_ptr<ServiceAction>& action, const CreditKey& key);
+
+  void fill_service_action_for_restrict(
+      std::unique_ptr<ServiceAction>& action_p, const CreditKey& key,
+      std::unique_ptr<ChargingGrant>& grant);
+
+  PolicyRule make_redirect_rule(std::unique_ptr<ChargingGrant>& grant);
+
+  void fill_service_action_for_redirect(
+      std::unique_ptr<ServiceAction>& action_p, const CreditKey& key,
+      std::unique_ptr<ChargingGrant>& grant, PolicyRule redirect_rule);
+
+  void fill_service_action_with_context(
       std::unique_ptr<ServiceAction>& action, ServiceActionType action_type,
       const CreditKey& key);
 

--- a/lte/gateway/c/session_manager/SessionState.h
+++ b/lte/gateway/c/session_manager/SessionState.h
@@ -26,6 +26,7 @@
 #include "SessionCredit.h"
 #include "Monitor.h"
 #include "ChargingGrant.h"
+#include "Types.h"
 
 namespace magma {
 using std::experimental::optional;
@@ -38,13 +39,6 @@ typedef std::unordered_map<
     ChargingCreditSummaries;
 typedef std::unordered_map<std::string, std::unique_ptr<Monitor>> MonitorMap;
 static SessionStateUpdateCriteria UNUSED_UPDATE_CRITERIA;
-
-struct RulesToProcess {
-  // If this vector is set, then it has PolicyRule definitions for both static
-  // and dynamic rules
-  std::vector<PolicyRule> rules;
-  bool empty() const;
-};
 
 // Used to transform the proto message RuleSet into a more useful structure
 struct RuleSetToApply {

--- a/lte/gateway/c/session_manager/StoredState.h
+++ b/lte/gateway/c/session_manager/StoredState.h
@@ -24,114 +24,9 @@
 #include <lte/protos/session_manager.grpc.pb.h>
 
 #include "CreditKey.h"
+#include "Types.h"
 
 namespace magma {
-struct SessionConfig {
-  CommonSessionContext common_context;
-  RatSpecificContext rat_specific_context;
-
-  SessionConfig(){};
-  SessionConfig(const LocalCreateSessionRequest& request);
-  bool operator==(const SessionConfig& config) const;
-  std::experimental::optional<AggregatedMaximumBitrate> get_apn_ambr() const;
-};
-
-// Session Credit
-struct FinalActionInfo {
-  ChargingCredit_FinalAction final_action;
-  RedirectServer redirect_server;
-  std::vector<std::string> restrict_rules;
-};
-
-enum EventTriggerState {
-  PENDING = 0,  // trigger installed
-  READY   = 1,  // ready to be reported on
-  CLEARED = 2,  // successfully reported
-};
-typedef std::unordered_map<magma::lte::EventTrigger, EventTriggerState>
-    EventTriggerStatus;
-
-/**
- * A bucket is a counter used for tracking credit volume across sessiond.
- * These are independently incremented and reset
- * Each value is in terms of a volume unit - either bytes or seconds
- */
-enum Bucket {
-  // USED: the actual used quota by the UE.
-  // USED = REPORTED + REPORTING
-  USED_TX = 0,
-  USED_RX = 1,
-  // ALLOWED: the granted units received
-  ALLOWED_TOTAL = 2,
-  ALLOWED_TX    = 3,
-  ALLOWED_RX    = 4,
-  // REPORTING: quota that is in transit to be acknowledged by OCS/PCRF
-  REPORTING_TX = 5,
-  REPORTING_RX = 6,
-  // REPORTED: quota that has been acknowledged by OCS/PCRF
-  REPORTED_TX = 7,
-  REPORTED_RX = 8,
-  // ALLOWED_FLOOR: saves the previous ALLOWED value after a new grant is
-  // received
-  // last_valid_nonzero_received_grant = ALLOWED - ALLOWED_FLOOR
-  ALLOWED_FLOOR_TOTAL = 9,
-  ALLOWED_FLOOR_TX    = 10,
-  ALLOWED_FLOOR_RX    = 11,
-
-  // delimiter to iterate enum
-  MAX_VALUES = 12,
-};
-
-enum ReAuthState {
-  REAUTH_NOT_NEEDED = 0,
-  REAUTH_REQUIRED   = 1,
-  REAUTH_PROCESSING = 2,
-};
-
-enum ServiceState {
-  SERVICE_ENABLED            = 0,
-  SERVICE_NEEDS_DEACTIVATION = 1,
-  SERVICE_NEEDS_SUSPENSION   = 2,
-  SERVICE_DISABLED           = 3,
-  SERVICE_NEEDS_ACTIVATION   = 4,
-  SERVICE_REDIRECTED         = 5,
-  SERVICE_RESTRICTED         = 6,
-};
-
-enum GrantTrackingType {
-  TRACKING_UNSET  = -1,
-  TOTAL_ONLY      = 0,
-  TX_ONLY         = 1,
-  RX_ONLY         = 2,
-  TX_AND_RX       = 3,
-  ALL_TOTAL_TX_RX = 4,
-};
-
-/**
- * State transitions of a session:
- * SESSION_ACTIVE
- *       |
- *       |
- *       |
- *       V
- * SESSION_RELEASED
- *       |
- *       | (PipelineD enforcement flows get deleted OR forced timeout)
- *       |      -> complete_termination
- *       V
- * SESSION_TERMINATED
- */
-enum SessionFsmState {
-  SESSION_ACTIVE                = 0,
-  SESSION_TERMINATED            = 4,
-  SESSION_TERMINATION_SCHEDULED = 5,
-  SESSION_RELEASED              = 6,
-  CREATING                      = 7,
-  CREATED                       = 8,
-  ACTIVE                        = 9,
-  INACTIVE                      = 10,
-  RELEASE                       = 11,
-};
 
 struct StoredSessionCredit {
   bool reporting;
@@ -159,53 +54,10 @@ struct StoredChargingGrant {
   bool suspended;
 };
 
-struct RuleLifetime {
-  std::time_t activation_time;    // Unix timestamp
-  std::time_t deactivation_time;  // Unix timestamp
-  RuleLifetime() : activation_time(0), deactivation_time(0){};
-  RuleLifetime(const time_t activation, const time_t deactivation)
-      : activation_time(activation), deactivation_time(deactivation){};
-  RuleLifetime(const StaticRuleInstall& rule_install);
-  RuleLifetime(const DynamicRuleInstall& rule_install);
-  bool is_within_lifetime(std::time_t time);
-  bool exceeded_lifetime(std::time_t time);
-  bool before_lifetime(std::time_t time);
-};
-
-// QoS Management
-enum PolicyType {
-  STATIC  = 1,
-  DYNAMIC = 2,
-};
-
-struct PolicyID {
-  PolicyType policy_type;
-  std::string rule_id;
-
-  PolicyID(PolicyType p_type, std::string r_id) {
-    policy_type = p_type;
-    rule_id     = r_id;
-  }
-
-  bool operator==(const PolicyID& id) const {
-    return rule_id == id.rule_id && policy_type == id.policy_type;
-  }
-};
-
-// Custom hash for PolicyID
-struct PolicyIDHash {
-  std::size_t operator()(const PolicyID& id) const {
-    std::size_t h1 = std::hash<std::string>{}(id.rule_id);
-    std::size_t h2 = std::hash<int>{}(int(id.policy_type));
-    return h1 ^ (h2 << 1);
-  }
-};
-
 typedef std::unordered_map<std::string, StoredMonitor> StoredMonitorMap;
 typedef std::unordered_map<
     CreditKey, StoredChargingGrant, decltype(&ccHash), decltype(&ccEqual)>
     StoredChargingCreditMap;
-typedef std::unordered_map<PolicyID, uint32_t, PolicyIDHash> BearerIDByPolicyID;
 
 struct StoredSessionState {
   SessionFsmState fsm_state;

--- a/lte/gateway/c/session_manager/Types.h
+++ b/lte/gateway/c/session_manager/Types.h
@@ -25,6 +25,9 @@
 
 #include "CreditKey.h"
 
+// This file is intended for declaring types that are shared across classes.
+// If a type has a clear owner, do NOT put in this file
+
 namespace magma {
 struct SessionConfig {
   CommonSessionContext common_context;

--- a/lte/gateway/c/session_manager/Types.h
+++ b/lte/gateway/c/session_manager/Types.h
@@ -1,0 +1,187 @@
+/**
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <functional>
+#include <experimental/optional>
+
+#include <folly/Format.h>
+#include <folly/dynamic.h>
+#include <folly/json.h>
+
+#include <lte/protos/pipelined.grpc.pb.h>
+#include <lte/protos/session_manager.grpc.pb.h>
+#include <lte/protos/session_manager.grpc.pb.h>
+
+#include "CreditKey.h"
+
+namespace magma {
+struct SessionConfig {
+  CommonSessionContext common_context;
+  RatSpecificContext rat_specific_context;
+
+  SessionConfig(){};
+  SessionConfig(const LocalCreateSessionRequest& request);
+  bool operator==(const SessionConfig& config) const;
+  std::experimental::optional<AggregatedMaximumBitrate> get_apn_ambr() const;
+};
+
+// Session Credit
+struct FinalActionInfo {
+  ChargingCredit_FinalAction final_action;
+  RedirectServer redirect_server;
+  std::vector<std::string> restrict_rules;
+};
+
+enum EventTriggerState {
+  PENDING = 0,  // trigger installed
+  READY   = 1,  // ready to be reported on
+  CLEARED = 2,  // successfully reported
+};
+typedef std::unordered_map<magma::lte::EventTrigger, EventTriggerState>
+    EventTriggerStatus;
+
+/**
+ * A bucket is a counter used for tracking credit volume across sessiond.
+ * These are independently incremented and reset
+ * Each value is in terms of a volume unit - either bytes or seconds
+ */
+enum Bucket {
+  // USED: the actual used quota by the UE.
+  // USED = REPORTED + REPORTING
+  USED_TX = 0,
+  USED_RX = 1,
+  // ALLOWED: the granted units received
+  ALLOWED_TOTAL = 2,
+  ALLOWED_TX    = 3,
+  ALLOWED_RX    = 4,
+  // REPORTING: quota that is in transit to be acknowledged by OCS/PCRF
+  REPORTING_TX = 5,
+  REPORTING_RX = 6,
+  // REPORTED: quota that has been acknowledged by OCS/PCRF
+  REPORTED_TX = 7,
+  REPORTED_RX = 8,
+  // ALLOWED_FLOOR: saves the previous ALLOWED value after a new grant is
+  // received
+  // last_valid_nonzero_received_grant = ALLOWED - ALLOWED_FLOOR
+  ALLOWED_FLOOR_TOTAL = 9,
+  ALLOWED_FLOOR_TX    = 10,
+  ALLOWED_FLOOR_RX    = 11,
+
+  // delimiter to iterate enum
+  MAX_VALUES = 12,
+};
+
+enum ReAuthState {
+  REAUTH_NOT_NEEDED = 0,
+  REAUTH_REQUIRED   = 1,
+  REAUTH_PROCESSING = 2,
+};
+
+enum ServiceState {
+  SERVICE_ENABLED            = 0,
+  SERVICE_NEEDS_DEACTIVATION = 1,
+  SERVICE_NEEDS_SUSPENSION   = 2,
+  SERVICE_DISABLED           = 3,
+  SERVICE_NEEDS_ACTIVATION   = 4,
+  SERVICE_REDIRECTED         = 5,
+  SERVICE_RESTRICTED         = 6,
+};
+
+enum GrantTrackingType {
+  TRACKING_UNSET  = -1,
+  TOTAL_ONLY      = 0,
+  TX_ONLY         = 1,
+  RX_ONLY         = 2,
+  TX_AND_RX       = 3,
+  ALL_TOTAL_TX_RX = 4,
+};
+
+/**
+ * State transitions of a session:
+ * SESSION_ACTIVE
+ *       |
+ *       |
+ *       |
+ *       V
+ * SESSION_RELEASED
+ *       |
+ *       | (PipelineD enforcement flows get deleted OR forced timeout)
+ *       |      -> complete_termination
+ *       V
+ * SESSION_TERMINATED
+ */
+enum SessionFsmState {
+  SESSION_ACTIVE                = 0,
+  SESSION_TERMINATED            = 4,
+  SESSION_TERMINATION_SCHEDULED = 5,
+  SESSION_RELEASED              = 6,
+  CREATING                      = 7,
+  CREATED                       = 8,
+  ACTIVE                        = 9,
+  INACTIVE                      = 10,
+  RELEASE                       = 11,
+};
+
+struct RuleLifetime {
+  std::time_t activation_time;    // Unix timestamp
+  std::time_t deactivation_time;  // Unix timestamp
+  RuleLifetime() : activation_time(0), deactivation_time(0){};
+  RuleLifetime(const time_t activation, const time_t deactivation)
+      : activation_time(activation), deactivation_time(deactivation){};
+  RuleLifetime(const StaticRuleInstall& rule_install);
+  RuleLifetime(const DynamicRuleInstall& rule_install);
+  bool is_within_lifetime(std::time_t time);
+  bool exceeded_lifetime(std::time_t time);
+  bool before_lifetime(std::time_t time);
+};
+
+// QoS Management
+enum PolicyType {
+  STATIC  = 1,
+  DYNAMIC = 2,
+};
+
+struct PolicyID {
+  PolicyType policy_type;
+  std::string rule_id;
+
+  PolicyID(PolicyType p_type, std::string r_id) {
+    policy_type = p_type;
+    rule_id     = r_id;
+  }
+
+  bool operator==(const PolicyID& id) const {
+    return rule_id == id.rule_id && policy_type == id.policy_type;
+  }
+};
+
+// Custom hash for PolicyID
+struct PolicyIDHash {
+  std::size_t operator()(const PolicyID& id) const {
+    std::size_t h1 = std::hash<std::string>{}(id.rule_id);
+    std::size_t h2 = std::hash<int>{}(int(id.policy_type));
+    return h1 ^ (h2 << 1);
+  }
+};
+
+typedef std::unordered_map<PolicyID, uint32_t, PolicyIDHash> BearerIDByPolicyID;
+
+struct RulesToProcess {
+  // If this vector is set, then it has PolicyRule definitions for both static
+  // and dynamic rules
+  std::vector<PolicyRule> rules;
+  bool empty() const;
+};
+
+}  // namespace magma

--- a/lte/gateway/c/session_manager/test/test_local_enforcer.cpp
+++ b/lte/gateway/c/session_manager/test/test_local_enforcer.cpp
@@ -2669,8 +2669,8 @@ TEST_F(LocalEnforcerTest, test_final_unit_redirect_activation_and_termination) {
       local_enforcer->collect_updates(session_map, actions, update);
   EXPECT_EQ(actions.size(), 1);
   EXPECT_EQ(actions[0]->get_type(), REDIRECT);
-  EXPECT_EQ(
-      actions[0]->get_redirect_server().redirect_server_address(), "12.7.7.4");
+  PolicyRule redirect_rule = actions[0]->get_gy_rules_to_install().rules[0];
+  EXPECT_EQ(redirect_rule.redirect().server_address(), "12.7.7.4");
 
   EXPECT_CALL(
       *pipelined_client,
@@ -2750,7 +2750,7 @@ TEST_F(LocalEnforcerTest, test_final_unit_activation_and_canceling) {
       local_enforcer->collect_updates(session_map, actions, update);
   EXPECT_EQ(actions.size(), 1);
   EXPECT_EQ(actions[0]->get_type(), RESTRICT_ACCESS);
-  EXPECT_EQ(actions[0]->get_restrict_rules()[0].id(), "rule1");
+  EXPECT_EQ(actions[0]->get_gy_rules_to_install().rules[0].id(), "rule1");
 
   EXPECT_CALL(
       *pipelined_client, add_gy_final_action_flow(
@@ -2863,7 +2863,8 @@ TEST_F(LocalEnforcerTest, test_final_unit_action_no_update) {
   usage_updates = local_enforcer->collect_updates(session_map, actions, update);
   EXPECT_EQ(actions.size(), 1);
   EXPECT_EQ(actions[0]->get_type(), RESTRICT_ACCESS);
-  EXPECT_EQ(actions[0]->get_restrict_rules()[0].id(), "restrict_rule");
+  EXPECT_EQ(
+      actions[0]->get_gy_rules_to_install().rules[0].id(), "restrict_rule");
 
   EXPECT_CALL(
       *pipelined_client,


### PR DESCRIPTION
<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary
Similar to https://github.com/magma/magma/pull/5702

Essentially, I want to use RulesToProcess to do transfer all Policy+Version propagation. For this I need to migrate ServiceAction as well. :'( 
Although I think this refactor made some logic around ServiceAction cleaner.

Some big changes
1. Split `get_charging_updates` into multiple functions for each switch case. This function was really long and covers all the service action types. (Activate/Redirect/Restrict/Terminate.. etc.)
    -  get_update_for_continue_service for doing the logic to construct a charging update request
    - `fill_service_action_for_activate`, `fill_service_action_for_restrict`, `fill_service_action_for_redirect` for each of the cases
2. Introduce a new `Types.h` to add shared types. The dependency chain of type includes were getting out of hand so introducing a new file to store shared structs/types.

<!-- Enumerate changes you made and why you made them -->

## Test Plan
Run sessiond unit tests
CWF Integration test to make sure GY credit activation / suspension is still ok
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
Signed-off-by: Marie Bremner <marwhal@fb.com>