### PR TITLE
[SessionD] Add a new field to track per-rule versions

### DIFF
--- a/lte/gateway/c/session_manager/LocalEnforcer.cpp
+++ b/lte/gateway/c/session_manager/LocalEnforcer.cpp
@@ -681,9 +681,8 @@ void LocalEnforcer::schedule_static_rule_deactivation(
     const std::string& imsi, const std::string& session_id,
     const std::string& rule_id, const std::time_t deactivation_time) {
   auto delta = magma::time_difference_from_now(deactivation_time);
-  MLOG(MDEBUG) << "Scheduling session " << session_id << " static rule "
-               << rule_id << " deactivation in " << (delta.count() / 1000)
-               << " secs";
+  MLOG(MDEBUG) << "Scheduling " << session_id << " static rule " << rule_id
+               << " deactivation in " << (delta.count() / 1000) << " secs";
   evb_->runAfterDelay(
       [=] {
         auto session_map = session_store_.read_sessions(SessionRead{imsi});
@@ -729,9 +728,8 @@ void LocalEnforcer::schedule_dynamic_rule_deactivation(
     const std::string& imsi, const std::string& session_id,
     const std::string& rule_id, const std::time_t deactivation_time) {
   auto delta = magma::time_difference_from_now(deactivation_time);
-  MLOG(MDEBUG) << "Scheduling subscriber " << imsi << " dynamic rule "
-               << rule_id << " deactivation in " << (delta.count() / 1000)
-               << " secs";
+  MLOG(MDEBUG) << "Scheduling " << session_id << " dynamic rule " << rule_id
+               << " deactivation in " << (delta.count() / 1000) << " secs";
   evb_->runAfterDelay(
       [=] {
         auto session_map = session_store_.read_sessions(SessionRead{imsi});
@@ -1688,7 +1686,7 @@ void LocalEnforcer::process_rules_to_install(
     std::vector<DynamicRuleInstall> dynamic_rule_installs,
     RulesToProcess& rules_to_activate, RulesToProcess& rules_to_deactivate,
     SessionStateUpdateCriteria& uc) {
-  std::time_t current_time     = time(nullptr);
+  std::time_t current_time     = std::time(nullptr);
   std::string ip_addr          = session.get_config().common_context.ue_ipv4();
   std::string ipv6_addr        = session.get_config().common_context.ue_ipv6();
   const std::string session_id = session.get_session_id();

--- a/lte/gateway/c/session_manager/RuleStore.cpp
+++ b/lte/gateway/c/session_manager/RuleStore.cpp
@@ -194,14 +194,15 @@ bool PolicyRuleBiMap::get_monitoring_key_for_rule_id(
     const std::string& rule_id, std::string* monitoring_key) {
   std::lock_guard<std::mutex> lock(map_mutex_);
   auto it = rules_by_rule_id_.find(rule_id);
-  if (it == rules_by_rule_id_.end()) {
+  if (it == rules_by_rule_id_.end() ||
+      !should_track_monitoring_key(it->second->tracking_type())) {
     return false;
   }
-  if (should_track_monitoring_key(it->second->tracking_type())) {
+  // nullptr means the caller does not care about retrieving the value
+  if (monitoring_key != nullptr) {
     monitoring_key->assign(it->second->monitoring_key());
-    return true;
   }
-  return false;
+  return true;
 }
 
 bool PolicyRuleBiMap::get_rule_ids_for_charging_key(

--- a/lte/gateway/c/session_manager/SessionState.cpp
+++ b/lte/gateway/c/session_manager/SessionState.cpp
@@ -46,6 +46,12 @@ using magma::service303::increment_counter;
 using magma::service303::remove_counter;
 
 namespace magma {
+
+template<class T>
+void remove_from_vec_by_value(std::vector<T>& vec, T value) {
+  vec.erase(std::remove(vec.begin(), vec.end(), value), vec.end());
+}
+
 std::unique_ptr<SessionState> SessionState::unmarshal(
     const StoredSessionState& marshaled, StaticRuleStore& rule_store) {
   return std::make_unique<SessionState>(marshaled, rule_store);
@@ -113,7 +119,7 @@ StoredSessionState SessionState::marshal() {
   for (auto& it : rule_lifetimes_) {
     marshaled.rule_lifetimes[it.first] = it.second;
   }
-
+  marshaled.policy_version_and_stats = policy_version_and_stats_;
   return marshaled;
 }
 
@@ -132,6 +138,7 @@ SessionState::SessionState(
       subscriber_quota_state_(marshaled.subscriber_quota_state),
       tgpp_context_(marshaled.tgpp_context),
       create_session_response_(marshaled.create_session_response),
+      policy_version_and_stats_(marshaled.policy_version_and_stats),
       static_rules_(rule_store),
       pending_event_triggers_(marshaled.pending_event_triggers),
       revalidation_time_(marshaled.revalidation_time),
@@ -319,7 +326,6 @@ SessionCreditUpdateCriteria* SessionState::get_credit_uc(
 }
 
 bool SessionState::apply_update_criteria(SessionStateUpdateCriteria& uc) {
-  SessionStateUpdateCriteria _;
   if (uc.is_fsm_updated) {
     curr_state_ = uc.updated_fsm_state;
   }
@@ -350,114 +356,72 @@ bool SessionState::apply_update_criteria(SessionStateUpdateCriteria& uc) {
     config_ = uc.updated_config;
   }
 
+  // Rule versions
+  if (uc.policy_version_and_stats) {
+    policy_version_and_stats_ = *uc.policy_version_and_stats;
+  }
+
+  // Manually update these policy structures to avoid incrementing version
   // Static rules
   for (const auto& rule_id : uc.static_rules_to_uninstall) {
     if (is_static_rule_installed(rule_id)) {
-      deactivate_static_rule(rule_id, _);
-    } else if (is_static_rule_scheduled(rule_id)) {
-      install_scheduled_static_rule(rule_id, _);
-      deactivate_static_rule(rule_id, _);
-    } else {
-      MLOG(MERROR) << "Failed to merge: " << session_id_
-                   << " because static rule already uninstalled: " << rule_id;
-      return false;
+      remove_from_vec_by_value<std::string>(active_static_rules_, rule_id);
     }
+    if (is_static_rule_scheduled(rule_id)) {
+      scheduled_static_rules_.erase(rule_id);
+    }
+    rule_lifetimes_.erase(rule_id);
   }
   for (const auto& rule_id : uc.static_rules_to_install) {
-    if (is_static_rule_installed(rule_id)) {
-      MLOG(MERROR) << "Failed to merge: " << session_id_
-                   << " because static rule already installed: " << rule_id;
-      return false;
+    if (!is_static_rule_installed(rule_id)) {
+      active_static_rules_.push_back(rule_id);
     }
     if (uc.new_rule_lifetimes.find(rule_id) != uc.new_rule_lifetimes.end()) {
-      auto lifetime = uc.new_rule_lifetimes[rule_id];
-      activate_static_rule(rule_id, lifetime, _);
-    } else if (is_static_rule_scheduled(rule_id)) {
-      install_scheduled_static_rule(rule_id, _);
-    } else {
-      MLOG(MERROR) << "Failed to merge: " << session_id_
-                   << " because rule lifetime is unspecified: " << rule_id;
-      return false;
+      rule_lifetimes_[rule_id] = uc.new_rule_lifetimes[rule_id];
+    }
+    if (is_static_rule_scheduled(rule_id)) {
+      scheduled_static_rules_.erase(rule_id);
     }
   }
   for (const auto& rule_id : uc.new_scheduled_static_rules) {
     if (is_static_rule_scheduled(rule_id)) {
-      MLOG(MERROR) << "Failed to merge: " << session_id_
-                   << " because static rule already scheduled: " << rule_id;
-      return false;
+      continue;
     }
-    auto lifetime = uc.new_rule_lifetimes[rule_id];
-    schedule_static_rule(rule_id, lifetime, _);
+    if (uc.new_rule_lifetimes.find(rule_id) != uc.new_rule_lifetimes.end()) {
+      rule_lifetimes_[rule_id] = uc.new_rule_lifetimes[rule_id];
+    }
+    scheduled_static_rules_.insert(rule_id);
   }
 
   // Dynamic rules
   for (const auto& rule_id : uc.dynamic_rules_to_uninstall) {
-    if (is_dynamic_rule_installed(rule_id)) {
-      dynamic_rules_.remove_rule(rule_id, NULL);
-    } else if (is_dynamic_rule_scheduled(rule_id)) {
-      install_scheduled_static_rule(rule_id, _);
-      dynamic_rules_.remove_rule(rule_id, NULL);
-    } else {
-      MLOG(MERROR) << "Failed to merge: " << session_id_
-                   << " because dynamic rule already uninstalled: " << rule_id;
-      return false;
-    }
+    scheduled_dynamic_rules_.remove_rule(rule_id, nullptr);
+    dynamic_rules_.remove_rule(rule_id, nullptr);
+    rule_lifetimes_.erase(rule_id);
   }
   for (const auto& rule : uc.dynamic_rules_to_install) {
-    if (is_dynamic_rule_installed(rule.id())) {
-      MLOG(MERROR) << "Failed to merge: " << session_id_
-                   << " because dynamic rule already installed: " << rule.id();
-      return false;
-    }
     if (uc.new_rule_lifetimes.find(rule.id()) != uc.new_rule_lifetimes.end()) {
-      auto lifetime = uc.new_rule_lifetimes[rule.id()];
-      insert_dynamic_rule(rule, lifetime, _);
-    } else if (is_dynamic_rule_scheduled(rule.id())) {
-      install_scheduled_dynamic_rule(rule.id(), _);
-    } else {
-      MLOG(MERROR) << "Failed to merge: " << session_id_
-                   << " because rule lifetime is unspecified: " << rule.id();
-      return false;
+      rule_lifetimes_[rule.id()] = uc.new_rule_lifetimes[rule.id()];
     }
+    dynamic_rules_.insert_rule(rule);
+    scheduled_dynamic_rules_.remove_rule(rule.id(), nullptr);
   }
   for (const auto& rule : uc.new_scheduled_dynamic_rules) {
-    if (is_dynamic_rule_scheduled(rule.id())) {
-      MLOG(MERROR) << "Failed to merge: " << session_id_
-                   << " because dynamic rule already scheduled: " << rule.id();
-      return false;
+    if (uc.new_rule_lifetimes.find(rule.id()) != uc.new_rule_lifetimes.end()) {
+      rule_lifetimes_[rule.id()] = uc.new_rule_lifetimes[rule.id()];
     }
-    auto lifetime = uc.new_rule_lifetimes[rule.id()];
-    schedule_dynamic_rule(rule, lifetime, _);
+    scheduled_dynamic_rules_.insert_rule(rule);
   }
 
   // Gy Dynamic rules
   for (const auto& rule : uc.gy_dynamic_rules_to_install) {
-    if (is_gy_dynamic_rule_installed(rule.id())) {
-      MLOG(MERROR) << "Failed to merge: " << session_id_
-                   << " because gy dynamic rule already installed: "
-                   << rule.id();
-      return false;
-    }
     if (uc.new_rule_lifetimes.find(rule.id()) != uc.new_rule_lifetimes.end()) {
-      auto lifetime = uc.new_rule_lifetimes[rule.id()];
-      insert_gy_dynamic_rule(rule, lifetime, _);
-      MLOG(MERROR) << "Merge: " << session_id_ << " gy dynamic rule "
-                   << rule.id();
-    } else {
-      MLOG(MERROR) << "Failed to merge: " << session_id_
-                   << " because gy dynamic rule lifetime is not found";
-      return false;
+      rule_lifetimes_[rule.id()] = uc.new_rule_lifetimes[rule.id()];
     }
+    gy_dynamic_rules_.insert_rule(rule);
   }
   for (const auto& rule_id : uc.gy_dynamic_rules_to_uninstall) {
-    if (is_gy_dynamic_rule_installed(rule_id)) {
-      gy_dynamic_rules_.remove_rule(rule_id, NULL);
-    } else {
-      MLOG(MERROR) << "Failed to merge: " << session_id_
-                   << " because gy dynamic rule already uninstalled: "
-                   << rule_id;
-      return false;
-    }
+    gy_dynamic_rules_.remove_rule(rule_id, nullptr);
   }
 
   // Charging credit
@@ -484,8 +448,7 @@ bool SessionState::apply_update_criteria(SessionStateUpdateCriteria& uc) {
   for (const auto& it : uc.monitor_credit_to_install) {
     auto key            = it.first;
     auto stored_monitor = it.second;
-    set_monitor(key, Monitor(stored_monitor), _);
-    monitor_map_[key] = std::make_unique<Monitor>(stored_monitor);
+    monitor_map_[key]   = std::make_unique<Monitor>(stored_monitor);
   }
 
   if (uc.updated_pdp_end_time > 0) {
@@ -1135,10 +1098,7 @@ uint32_t SessionState::total_monitored_rules_count() {
   uint32_t monitored_dynamic_rules = dynamic_rules_.monitored_rules_count();
   uint32_t monitored_static_rules  = 0;
   for (auto& rule_id : active_static_rules_) {
-    std::string _;
-    auto is_monitored =
-        static_rules_.get_monitoring_key_for_rule_id(rule_id, &_);
-    if (is_monitored) {
+    if (static_rules_.get_monitoring_key_for_rule_id(rule_id, nullptr)) {
       monitored_static_rules++;
     }
   }
@@ -2151,8 +2111,7 @@ bool SessionState::policy_has_qos(
   return false;
 }
 
-std::experimental::optional<PolicyRule>
-SessionState::policy_needs_bearer_creation(
+optional<PolicyRule> SessionState::policy_needs_bearer_creation(
     const PolicyType policy_type, const std::string& id,
     const SessionConfig& config) {
   if (!config.rat_specific_context.has_lte_context()) {

--- a/lte/gateway/c/session_manager/SessionState.h
+++ b/lte/gateway/c/session_manager/SessionState.h
@@ -515,7 +515,7 @@ class SessionState {
    * @param config
    * @return an optional wrapped PolicyRule if creation is needed, {} otherwise
    */
-  std::experimental::optional<PolicyRule> policy_needs_bearer_creation(
+  optional<PolicyRule> policy_needs_bearer_creation(
       const PolicyType policy_type, const std::string& rule_id,
       const SessionConfig& config);
   /**
@@ -575,6 +575,9 @@ class SessionState {
 
   // Used between create session and activate session. Empty afterwards
   CreateSessionResponse create_session_response_;
+
+  // Track version tracking information
+  PolicyStatsMap policy_version_and_stats_;
 
   // All static rules synced from policy DB
   StaticRuleStore& static_rules_;

--- a/lte/gateway/c/session_manager/StoredState.h
+++ b/lte/gateway/c/session_manager/StoredState.h
@@ -27,6 +27,7 @@
 #include "Types.h"
 
 namespace magma {
+using std::experimental::optional;
 
 struct StoredSessionCredit {
   bool reporting;
@@ -82,11 +83,13 @@ struct StoredSessionState {
   std::set<std::string> scheduled_static_rules;
   std::vector<PolicyRule> scheduled_dynamic_rules;
   std::unordered_map<std::string, RuleLifetime> rule_lifetimes;
+  PolicyStatsMap policy_stats;
   uint32_t request_number;
   EventTriggerStatus pending_event_triggers;
   google::protobuf::Timestamp revalidation_time;
   BearerIDByPolicyID bearer_id_by_policy;
   std::vector<SetGroupPDR> PdrList;
+  PolicyStatsMap policy_version_and_stats;
 };
 
 // Update Criteria
@@ -113,6 +116,9 @@ struct SessionCreditUpdateCriteria {
   uint64_t time_of_last_usage;
 
   bool suspended;
+
+  // Map to maintain per-policy versions. Contains all values, not delta.
+  optional<PolicyStatsMap> policy_version_and_stats;
 };
 
 struct SessionStateUpdateCriteria {
@@ -134,6 +140,9 @@ struct SessionStateUpdateCriteria {
   google::protobuf::Timestamp revalidation_time;
   uint32_t request_number_increment;
   uint64_t updated_pdp_end_time;
+
+  // Map to maintain per-policy versions. Contains all values, not delta.
+  optional<PolicyStatsMap> policy_version_and_stats;
 
   std::set<std::string> static_rules_to_install;
   std::set<std::string> static_rules_to_uninstall;
@@ -202,4 +211,8 @@ std::string serialize_bearer_id_by_policy(BearerIDByPolicyID bearer_map);
 std::string serialize_stored_session(StoredSessionState& stored);
 
 StoredSessionState deserialize_stored_session(std::string& serialized);
+
+std::string serialize_policy_stats_map(PolicyStatsMap stats_map);
+
+PolicyStatsMap deserialize_policy_stats_map(std::string& serialized);
 }  // namespace magma

--- a/lte/gateway/c/session_manager/Types.h
+++ b/lte/gateway/c/session_manager/Types.h
@@ -25,6 +25,7 @@
 
 #include "CreditKey.h"
 
+// NOTE:
 // This file is intended for declaring types that are shared across classes.
 // If a type has a clear owner, do NOT put in this file
 
@@ -186,5 +187,13 @@ struct RulesToProcess {
   std::vector<PolicyRule> rules;
   bool empty() const;
 };
+
+struct StatsPerPolicy {
+  // The version maintained by SessionD for this rule
+  uint32_t current_version;
+  // The last reported version from PipelineD
+  uint32_t last_reported_version;
+};
+typedef std::unordered_map<std::string, StatsPerPolicy> PolicyStatsMap;
 
 }  // namespace magma

--- a/lte/gateway/c/session_manager/test/test_local_enforcer.cpp
+++ b/lte/gateway/c/session_manager/test/test_local_enforcer.cpp
@@ -768,6 +768,11 @@ TEST_F(LocalEnforcerTest, test_sync_sessions_on_restart) {
   session_map_2[IMSI1].front()->schedule_static_rule("rule3", lifetime3, uc);
   session_map_2[IMSI1].front()->schedule_static_rule("rule4", lifetime4, uc);
 
+  EXPECT_EQ(uc.static_rules_to_install.count("rule1"), 1);
+  EXPECT_EQ(uc.new_scheduled_static_rules.count("rule2"), 1);
+  EXPECT_EQ(uc.new_scheduled_static_rules.count("rule3"), 1);
+  EXPECT_EQ(uc.new_scheduled_static_rules.count("rule4"), 1);
+
   PolicyRule d1, d2, d3, d4;
   d1.set_id("dynamic_rule1");
   d2.set_id("dynamic_rule2");
@@ -779,9 +784,8 @@ TEST_F(LocalEnforcerTest, test_sync_sessions_on_restart) {
   session_map_2[IMSI1].front()->schedule_dynamic_rule(d3, lifetime3, uc);
   session_map_2[IMSI1].front()->schedule_dynamic_rule(d4, lifetime4, uc);
 
-  EXPECT_EQ(uc.new_scheduled_static_rules.count("rule2"), 1);
-  EXPECT_EQ(uc.new_scheduled_static_rules.count("rule3"), 1);
-  EXPECT_EQ(uc.new_scheduled_static_rules.count("rule4"), 1);
+  EXPECT_EQ(uc.dynamic_rules_to_install.size(), 1);
+  EXPECT_EQ(uc.new_scheduled_dynamic_rules.size(), 3);
 
   success = session_store->update_sessions(session_update);
   EXPECT_TRUE(success);

--- a/lte/gateway/c/session_manager/test/test_stored_state.cpp
+++ b/lte/gateway/c/session_manager/test/test_stored_state.cpp
@@ -349,6 +349,42 @@ TEST_F(StoredStateTest, test_stored_session) {
   EXPECT_EQ(deserialized.pdp_end_time, 332211);
 }
 
+TEST_F(StoredStateTest, test_policy_stats_map) {
+  PolicyStatsMap original;
+  StatsPerPolicy og_stats1, og_stats2;
+  const std::string rule1 = "rule1";
+  const std::string rule2 = "rule2";
+
+  og_stats1.current_version       = 2;
+  og_stats1.last_reported_version = 1;
+  original[rule1]                 = og_stats1;
+
+  og_stats2.current_version       = 4;
+  og_stats2.last_reported_version = 3;
+  original[rule2]                 = og_stats2;
+
+  std::string serialized      = serialize_policy_stats_map(original);
+  PolicyStatsMap deserialized = deserialize_policy_stats_map(serialized);
+
+  EXPECT_EQ(2, deserialized.size());
+
+  StatsPerPolicy deserialized_stats1 = deserialized[rule1];
+  StatsPerPolicy deserialized_stats2 = deserialized[rule2];
+
+  EXPECT_EQ(og_stats1.current_version, deserialized_stats1.current_version);
+  EXPECT_EQ(
+      og_stats1.last_reported_version,
+      deserialized_stats1.last_reported_version);
+
+  EXPECT_EQ(og_stats2.current_version, deserialized_stats2.current_version);
+  EXPECT_EQ(
+      og_stats2.last_reported_version,
+      deserialized_stats2.last_reported_version);
+
+  // Check that the value is empty by default
+  EXPECT_FALSE(get_default_update_criteria().policy_version_and_stats);
+}
+
 int main(int argc, char** argv) {
   ::testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();


### PR DESCRIPTION
<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary
1. Cleanup rule manipulation logic in SessionState. We should only use the deactivet_* activate_* rule functions if we want to activate/deactivate rules. Otherwise, we should work with the object directly. 
2. Add a new PolicyAndStats map to track per-policy versioning. Eventually, this will store flatrate values when we migrate to flat rate reporting from PipelineD. 


<!-- Enumerate changes you made and why you made them -->

## Test Plan
make precommit_sm
CWF integration test
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
Signed-off-by: Marie Bremner <marwhal@fb.com>