### PR TITLE
Fixing state_manager.h list initialization params

### DIFF
--- a/lte/gateway/c/oai/include/state_manager.h
+++ b/lte/gateway/c/oai/include/state_manager.h
@@ -197,11 +197,11 @@ class StateManager {
   StateManager()
       : state_cache_p(nullptr),
         state_ue_ht(nullptr),
-        redis_client(std::make_unique<RedisClient>()) {}
+        redis_client(std::make_unique<RedisClient>()),
         is_initialized(false),
         state_dirty(false),
         persist_state_enabled(false),
-        log_task(LOG_UTIL),
+        log_task(LOG_UTIL) {}
   virtual ~StateManager() = default;
 
   /**


### PR DESCRIPTION
Signed-off-by: Alex Rodriguez <alexrod@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->
- Current `make build_oai` is failing with: 
```
/home/vagrant/magma/lte/gateway/c/oai/include/state_manager.h:141:23: error: invalid use of member function ‘int magma::lte::StateManager<StateType, UeContextType, ProtoType, ProtoUe, StateConverter>::state_dirty(int) [with StateType = sgw_state_s; UeContextType = spgw_ue_context_s; ProtoType = magma::lte::oai::SgwState; ProtoUe = magma::lte::oai::SgwUeContext; StateConverter = magma::lte::SgwStateConverter]’ (did you forget the ‘()’ ?)
```
- Due to an error on list initialization on `state_manager.h`
## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->
- make build_oai and sanity s1ap testing

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
