### PR TITLE
[feg] s8_proxy fix duplicate create session with different teid

### DIFF
--- a/feg/gateway/gtp/gtp_client_test.go
+++ b/feg/gateway/gtp/gtp_client_test.go
@@ -30,11 +30,11 @@ import (
 // MockProto is a mock protobuf message to mimick Encanced messages
 type MockProto struct {
 	protoiface.MessageV1
-	Teid uint32
+	PgwCFteid uint32
 }
 
 func (mp MockProto) String() string {
-	return fmt.Sprint(mp.Teid)
+	return fmt.Sprintf("%d", mp.PgwCFteid)
 }
 
 const (
@@ -83,7 +83,7 @@ func TestGtpClient(t *testing.T) {
 
 	// add a dummy handler at the server for create session request
 	gtpServer.AddHandlers(map[uint8]gtpv2.HandlerFunc{
-		message.MsgTypeCreateSessionRequest: getHandleCreateSessionRequest(actualServerIPAndPort, bearerId1),
+		message.MsgTypeCreateSessionRequest: getHandleCreateSessionRequest(actualServerIPAndPort, cSgwTeid, bearerId1),
 	})
 
 	// add a dummy handler at tlient client for create session response
@@ -91,23 +91,34 @@ func TestGtpClient(t *testing.T) {
 		message.MsgTypeCreateSessionResponse: getHandleCreateSessionResponse(gtpClient),
 	})
 
-	csr := getCreateSessionRequest(t, gtpClient, localIP, actualServerIPAndPort, bearerId1, qci1)
+	csr := getCreateSessionRequest(t, gtpClient, localIP, actualServerIPAndPort, cSgwTeid, bearerId1, qci1)
 	msg := message.NewCreateSessionRequest(0, 0, csr...)
 	resMsg, err := gtpClient.SendMessageAndExtractGrpc(IMSI1, cSgwTeid, remoteAddr, msg)
 	assert.NoError(t, err)
 	csRes := resMsg.(MockProto)
 	assert.NotEmpty(t, csRes)
-	assert.Equal(t, cPgwTeid, csRes.Teid)
+	assert.Equal(t, cPgwTeid, csRes.PgwCFteid)
+	// session shouldn't exist after create sesion has been sent
+	_, err = gtpClient.GetSessionByIMSI(IMSI1)
+	assert.Error(t, err)
 
-	// create same session with differnt QCI
-	csr = getCreateSessionRequest(t, gtpClient, localIP, actualServerIPAndPort, bearerId1, qci2)
+	// create same session with differnt QCI and different C-Sgw TEID
+	newCSgwTeid := cSgwTeid + 1
+	csr = getCreateSessionRequest(t, gtpClient, localIP, actualServerIPAndPort, newCSgwTeid, bearerId1, qci2)
+	gtpServer.AddHandlers(map[uint8]gtpv2.HandlerFunc{
+		message.MsgTypeCreateSessionRequest: getHandleCreateSessionRequest(actualServerIPAndPort, newCSgwTeid, bearerId1),
+	})
 
 	msg = message.NewCreateSessionRequest(0, 0, csr...)
-	resMsg, err = gtpClient.SendMessageAndExtractGrpc(IMSI1, cSgwTeid, remoteAddr, msg)
+	resMsg, err = gtpClient.SendMessageAndExtractGrpc(IMSI1, newCSgwTeid, remoteAddr, msg)
 	assert.NoError(t, err)
+	// session shouldn't exist after create sesion has been sent
+	_, err = gtpClient.GetSessionByIMSI(IMSI1)
+	assert.Error(t, err)
+
 	csRes = resMsg.(MockProto)
 	assert.NotEmpty(t, csRes)
-	assert.Equal(t, cPgwTeid, csRes.Teid)
+	assert.Equal(t, cPgwTeid, csRes.PgwCFteid)
 }
 
 func startGTPServer(t *testing.T) *Client {
@@ -116,9 +127,9 @@ func startGTPServer(t *testing.T) *Client {
 	return pgwConn
 }
 
-func getCreateSessionRequest(t *testing.T, cli *Client, laddrs net.IP, raddrs string, bearerId, qci uint8) []*ie.IE {
+func getCreateSessionRequest(t *testing.T, cli *Client, laddrs net.IP, raddrs string, c_sgw_teid uint32, bearerId, qci uint8) []*ie.IE {
 	// SGW control plane teid
-	cSgwFTeid := ie.NewFullyQualifiedTEID(gtpv2.IFTypeS5S8SGWGTPC, cSgwTeid, raddrs, "").WithInstance(0)
+	cSgwFTeid := ie.NewFullyQualifiedTEID(gtpv2.IFTypeS5S8SGWGTPC, c_sgw_teid, raddrs, "").WithInstance(0)
 
 	// SGW user plane teid
 	uSgwFTeid := ie.NewFullyQualifiedTEID(gtpv2.IFTypeS5S8SGWGTPU, 11, raddrs, "").WithInstance(2)
@@ -148,14 +159,14 @@ func getCreateSessionRequest(t *testing.T, cli *Client, laddrs net.IP, raddrs st
 }
 
 // getHandleCreateSessionRequest dummy create sesson request handler
-func getHandleCreateSessionRequest(pgwAddrs string, bearerId uint8) gtpv2.HandlerFunc {
+func getHandleCreateSessionRequest(pgwAddrs string, c_sgw_teid uint32, bearerId uint8) gtpv2.HandlerFunc {
 	return func(c *gtpv2.Conn, sgwAddr net.Addr, msg message.Message) error {
 
 		cPgwFTeid := ie.NewFullyQualifiedTEID(gtpv2.IFTypeS5S8PGWGTPC, cPgwTeid, pgwAddrs, "").WithInstance(1)
 		uPgwFTeid := ie.NewFullyQualifiedTEID(gtpv2.IFTypeS5S8PGWGTPU, uPgwTeid, pgwAddrs, "").WithInstance(2)
 
 		csRspFromPGW := message.NewCreateSessionResponse(
-			cSgwTeid, msg.Sequence(),
+			c_sgw_teid, msg.Sequence(),
 			ie.NewCause(gtpv2.CauseRequestAccepted, 0, 0, 0, nil),
 			cPgwFTeid,
 			ie.NewAPNRestriction(gtpv2.APNRestrictionPublic2),
@@ -178,11 +189,11 @@ func getHandleCreateSessionResponse(cli *Client) gtpv2.HandlerFunc {
 		csResGtp := msg.(*message.CreateSessionResponse)
 		mockProto := MockProto{}
 		if pgwCFteidIE := csResGtp.PGWS5S8FTEIDC; pgwCFteidIE != nil {
-			teid, err := pgwCFteidIE.TEID()
+			pgw_c_fteid_IE, err := pgwCFteidIE.TEID()
 			if err != nil {
 				return err
 			}
-			mockProto.Teid = teid
+			mockProto.PgwCFteid = pgw_c_fteid_IE
 
 		} else {
 			return &gtpv2.RequiredIEMissingError{Type: ie.FullyQualifiedTEID}

--- a/feg/gateway/gtp/session_manager.go
+++ b/feg/gateway/gtp/session_manager.go
@@ -36,6 +36,8 @@ func (c *Client) SendMessageAndExtractGrpc(imsi string, srcTEID uint32, peerAddr
 	proto.Message, error) {
 	// Receive Create Session Response
 	session := c.getSessionOrCreateNew(imsi, srcTEID, peerAddr)
+	// session will be removed once we are done. No need to keep it
+	defer c.RemoveSession(session)
 
 	sequence, err := c.SendMessageTo(msg, session.PeerAddr())
 	if err != nil {
@@ -48,7 +50,6 @@ func (c *Client) SendMessageAndExtractGrpc(imsi string, srcTEID uint32, peerAddr
 	}
 	grpcMsg, err := enriched_message.ExtractGrpcMessageFromGtpMessage(incomingMsg)
 	if err != nil {
-		c.RemoveSession(session)
 		return nil, fmt.Errorf("GTP server return an error: %s", err)
 	}
 	return grpcMsg, nil

--- a/feg/gateway/services/s8_proxy/servicers/mock_pgw/cs.go
+++ b/feg/gateway/services/s8_proxy/servicers/mock_pgw/cs.go
@@ -152,10 +152,10 @@ func (mPgw *MockPgw) getHandleCreateSessionRequest() gtpv2.HandlerFunc {
 		// create PGW control plane FTeids
 		cIP := strings.Split(c.LocalAddr().String(), ":")[0]
 		var pgwFTEIDc *ie.IE
-		if mPgw.CreateSessionOptions.PgwFTEIDc != 0 {
+		if mPgw.CreateSessionOptions.PgwTEIDc != 0 {
 			// use passed options value
 			pgwFTEIDc = ie.NewFullyQualifiedTEID(
-				gtpv2.IFTypeS5S8PGWGTPC, mPgw.CreateSessionOptions.PgwFTEIDc, cIP, "").WithInstance(1)
+				gtpv2.IFTypeS5S8PGWGTPC, mPgw.CreateSessionOptions.PgwTEIDc, cIP, "").WithInstance(1)
 		} else {
 			pgwFTEIDc = c.NewSenderFTEID(cIP, "").WithInstance(1)
 		}
@@ -163,9 +163,9 @@ func (mPgw *MockPgw) getHandleCreateSessionRequest() gtpv2.HandlerFunc {
 		// create PGW user plane FTeids
 		uIP := strings.Split(dummyUserPlanePgwIP, ":")[0]
 		var pgwUteid uint32
-		if mPgw.CreateSessionOptions.PgwFTEIDu != 0 {
+		if mPgw.CreateSessionOptions.PgwTEIDu != 0 {
 			// use passed options value
-			pgwUteid = mPgw.CreateSessionOptions.PgwFTEIDu
+			pgwUteid = mPgw.CreateSessionOptions.PgwTEIDu
 		} else {
 			mPgw.randGenMux.Lock()
 			pgwUteid = (rand.Uint32() / 1000) * 1000 // for easy identification, this teid will always end in 000
@@ -175,9 +175,9 @@ func (mPgw *MockPgw) getHandleCreateSessionRequest() gtpv2.HandlerFunc {
 
 		// get SGW user plane Teid
 		var sgwTEIDc uint32
-		if mPgw.CreateSessionOptions.SgwTeidc != 0 {
+		if mPgw.CreateSessionOptions.SgwTEIDc != 0 {
 			// used passed options value
-			sgwTEIDc = mPgw.CreateSessionOptions.SgwTeidc
+			sgwTEIDc = mPgw.CreateSessionOptions.SgwTEIDc
 		} else {
 			// get the teid received by the request and stored in the seession previously
 			sgwTEIDc, err = session.GetTEID(gtpv2.IFTypeS5S8SGWGTPC)

--- a/feg/gateway/services/s8_proxy/servicers/mock_pgw/mock_pgw.go
+++ b/feg/gateway/services/s8_proxy/servicers/mock_pgw/mock_pgw.go
@@ -51,9 +51,9 @@ type LastValues struct {
 
 // CreateSessionOptions to control Create Session Response values to produce errors
 type CreateSessionOptions struct {
-	SgwTeidc  uint32
-	PgwFTEIDc uint32
-	PgwFTEIDu uint32
+	SgwTEIDc uint32
+	PgwTEIDc uint32
+	PgwTEIDu uint32
 }
 
 func NewStarted(ctx context.Context, pgwAddrsStr string) (*MockPgw, error) {

--- a/feg/gateway/services/s8_proxy/servicers/s8_proxy.go
+++ b/feg/gateway/services/s8_proxy/servicers/s8_proxy.go
@@ -121,8 +121,6 @@ func (s *S8Proxy) DeleteSession(ctx context.Context, req *protos.DeleteSessionRe
 		glog.Error(err)
 		return nil, err
 	}
-	// remove session from the s8_proxy client
-	s.gtpClient.RemoveSessionByIMSI(req.Imsi)
 	return cdRes, nil
 }
 


### PR DESCRIPTION
Signed-off-by: Oriol Batalla <obatalla@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary

When we were creating two sessions without deleting one, s8_proxy was holding the teid for the first create session as a key. When the second create session was received (which included an new teid), the client was not able to find the response (since it was still waiting for a response for the first teid). 

To fix that, instead of correcting the teid, we will delete the session after each interaction with PGW. The reason is s8_proxy should not keep any state, and holding the teid for a created session is state.

The session on s8_proxy only will live during transit of request/response. Once the request is received the session on s8_proxy is terminated. This termination does not have any implication on gtp session. In fact the s8_proxy session it is just a go channel  that is kept open.

## Test Plan

make precommit

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
