### PR TITLE
[SessionD] Update rule versions on install/uninstalling rules 

### DIFF
--- a/lte/gateway/c/session_manager/LocalEnforcer.cpp
+++ b/lte/gateway/c/session_manager/LocalEnforcer.cpp
@@ -587,13 +587,20 @@ void LocalEnforcer::schedule_static_rule_activation(
                          << "during installation of static rule " << rule_id;
           return;
         }
+        PolicyRule rule;
+        if (!rule_store_->get_rule(rule_id, &rule)) {
+          MLOG(MWARNING) << "Could not find static rules definition for "
+                         << rule_id;
+          return;
+        }
+
         auto& session = **session_it;
         auto& uc      = session_update[imsi][session_id];
 
         std::time_t current_time = time(nullptr);
         // don't install the rule if the current time is out of lifetime
-        if (session->should_rule_be_active(rule_id, current_time)) {
-          session->deactivate_scheduled_static_rule(rule_id, uc);
+        if (!session->should_rule_be_active(rule_id, current_time)) {
+          session->deactivate_scheduled_static_rule(rule_id);
           session_store_.update_sessions(session_update);
           return;
         }
@@ -605,15 +612,10 @@ void LocalEnforcer::schedule_static_rule_activation(
         const auto ambr           = config.get_apn_ambr();
         const std::string msisdn  = config.common_context.msisdn();
 
-        if (session->is_static_rule_scheduled(rule_id)) {
-          // scheduled_static_rules_.erase(rule_id);
-        }
         uint32_t version = session->activate_static_rule(
             rule_id, session->get_rule_lifetime(rule_id), uc);
-        PolicyRule rule;
-        rule_store_->get_rule(rule_id, &rule);
         RulesToProcess to_process;
-        to_process.rules = std::vector<PolicyRule>{rule};
+        to_process.append_versioned_policy(rule, version);
 
         pipelined_client_->activate_flows_for_rules(
             imsi, ip_addr, ipv6_addr, teids, msisdn, ambr, to_process,
@@ -651,7 +653,7 @@ void LocalEnforcer::schedule_dynamic_rule_activation(
         }
         // don't install the rule if the current time is out of lifetime
         std::time_t current_time = time(nullptr);
-        if (session->should_rule_be_active(rule_id, current_time)) {
+        if (!session->should_rule_be_active(rule_id, current_time)) {
           session->remove_scheduled_dynamic_rule(rule_id, nullptr, session_uc);
           session_store_.update_sessions(session_update);
           return;
@@ -664,11 +666,17 @@ void LocalEnforcer::schedule_dynamic_rule_activation(
         const auto ambr      = config.get_apn_ambr();
         const auto msisdn    = config.common_context.msisdn();
 
-        session->install_scheduled_dynamic_rule(rule_id, session_uc);
-        PolicyRule policy;
-        session->get_scheduled_dynamic_rules().get_rule(rule_id, &policy);
+        PolicyRule rule;
+        if (!session->remove_scheduled_dynamic_rule(
+                rule_id, &rule, session_uc)) {
+          MLOG(MWARNING) << "Dynamic rule " << rule_id << " doesn't exist for "
+                         << session_id;
+          return;
+        }
+        uint32_t version = session->insert_dynamic_rule(
+            rule, session->get_rule_lifetime(rule_id), session_uc);
         RulesToProcess to_process;
-        to_process.rules = std::vector<PolicyRule>{policy};
+        to_process.append_versioned_policy(rule, version);
 
         pipelined_client_->activate_flows_for_rules(
             imsi, ip_addr, ipv6_addr, teids, msisdn, ambr, to_process,
@@ -695,8 +703,8 @@ void LocalEnforcer::schedule_static_rule_deactivation(
         SessionSearchCriteria criteria(imsi, IMSI_AND_SESSION_ID, session_id);
         auto session_it = session_store_.find_session(session_map, criteria);
         if (!session_it) {
-          MLOG(MWARNING) << "Could not find session  " << session_id
-                         << "during removal of static rule " << rule_id;
+          MLOG(MERROR) << "Could not find session  " << session_id
+                       << "during removal of static rule " << rule_id;
           return;
         }
         auto& session = **session_it;
@@ -712,17 +720,21 @@ void LocalEnforcer::schedule_static_rule_deactivation(
         auto ip_addr      = session->get_config().common_context.ue_ipv4();
         auto ipv6_addr    = session->get_config().common_context.ue_ipv6();
         const Teids teids = session->get_config().common_context.teids();
-        RulesToProcess to_process;
-        to_process.rules = std::vector<PolicyRule>{rule};
 
+        auto& session_uc = session_update[imsi][session_id];
+        optional<uint32_t> op_version =
+            session->deactivate_static_rule(rule_id, session_uc);
+        if (!op_version) {
+          MLOG(MERROR) << "Could not find rule " << rule_id << " for "
+                       << session_id << " during static rule removal";
+          return;
+        }
+
+        RulesToProcess to_process;
+        to_process.append_versioned_policy(rule, *op_version);
         pipelined_client_->deactivate_flows_for_rules(
             imsi, ip_addr, ipv6_addr, teids, to_process, RequestOriginType::GX);
 
-        auto& session_uc = session_update[imsi][session_id];
-        if (!session->deactivate_static_rule(rule_id, session_uc)) {
-          MLOG(MWARNING) << "Could not find rule " << rule_id << " for "
-                         << session_id << " during static rule removal";
-        }
         session_store_.update_sessions(session_update);
       },
       delta.count());
@@ -755,13 +767,16 @@ void LocalEnforcer::schedule_dynamic_rule_deactivation(
         const Teids teids = session->get_config().common_context.teids();
 
         PolicyRule policy;
-        session->get_scheduled_dynamic_rules().get_rule(rule_id, &policy);
-        RulesToProcess to_process;
-        to_process.rules = std::vector<PolicyRule>{policy};
-        pipelined_client_->deactivate_flows_for_rules(
-            imsi, ip_addr, ipv6_addr, teids, to_process, RequestOriginType::GX);
         auto& uc = session_update[imsi][session_id];
-        session->remove_dynamic_rule(policy.id(), nullptr, uc);
+        optional<uint32_t> op_version =
+            session->remove_dynamic_rule(policy.id(), &policy, uc);
+        if (op_version) {
+          RulesToProcess to_process;
+          to_process.append_versioned_policy(policy, *op_version);
+          pipelined_client_->deactivate_flows_for_rules(
+              imsi, ip_addr, ipv6_addr, teids, to_process,
+              RequestOriginType::GX);
+        }
         session_store_.update_sessions(session_update);
       },
       delta.count());
@@ -1173,7 +1188,7 @@ void LocalEnforcer::remove_rules_for_suspended_credit(
 
   // Remove pipelined rules
   RulesToProcess rules_to_remove;
-  session->get_rules_per_credit_key(ckey, rules_to_remove);
+  session->get_rules_per_credit_key(ckey, rules_to_remove, session_uc);
   auto imsi = session->get_config().common_context.sid().id();
   propagate_rule_updates_to_pipelined(
       imsi, session->get_config(), RulesToProcess{}, rules_to_remove, false);
@@ -1212,7 +1227,7 @@ void LocalEnforcer::add_rules_for_unsuspended_credit(
 
   //  add pipelined rules
   RulesToProcess rules_to_add;
-  session->get_rules_per_credit_key(ckey, rules_to_add);
+  session->get_rules_per_credit_key(ckey, rules_to_add, session_uc);
   auto imsi = session->get_config().common_context.sid().id();
   propagate_rule_updates_to_pipelined(
       imsi, session->get_config(), rules_to_add, RulesToProcess{}, false);
@@ -1648,19 +1663,36 @@ void LocalEnforcer::process_rules_to_remove(
         rules_to_remove,
     RulesToProcess& rules_to_deactivate, SessionStateUpdateCriteria& uc) {
   for (const auto& rule_id : rules_to_remove) {
-    // Try to remove as dynamic rule first
-    PolicyRule dy_rule, st_rule;
-    bool is_dynamic = session->remove_dynamic_rule(rule_id, &dy_rule, uc);
-    if (is_dynamic) {  // dynamic rule
-      rules_to_deactivate.rules.push_back(dy_rule);
-    } else if (  // static rule
-        rule_store_->get_rule(rule_id, &st_rule) &&
-        session->deactivate_static_rule(rule_id, uc)) {
-      rules_to_deactivate.rules.push_back(st_rule);
-    } else {
+    optional<PolicyType> p_type = session->get_policy_type(rule_id);
+    if (!p_type) {
       MLOG(MWARNING) << "Could not find rule " << rule_id << " for " << imsi
                      << " during static rule removal";
+      continue;
     }
+    optional<uint32_t> op_version = {};
+    PolicyRule rule;
+    switch (*p_type) {
+      case DYNAMIC: {
+        op_version = session->remove_dynamic_rule(rule_id, &rule, uc);
+        break;
+      }
+      case STATIC: {
+        if (!rule_store_->get_rule(rule_id, &rule)) {
+          MLOG(MERROR) << "Static rule " << rule_id << " not found";
+          continue;
+        }
+        op_version = session->deactivate_static_rule(rule_id, uc);
+        break;
+      }
+      default:
+        break;
+    }
+    if (!op_version) {
+      MLOG(MERROR) << "Failed to remove " << rule_id << " for "
+                   << session->get_session_id();
+      continue;
+    }
+    rules_to_deactivate.append_versioned_policy(rule, *op_version);
   }
 }
 
@@ -1705,6 +1737,7 @@ void LocalEnforcer::process_rules_to_install(
     if (!rule_store_->get_rule(id, &static_rule)) {
       MLOG(MERROR) << "static rule " << id
                    << " is not found, skipping install...";
+      continue;
     }
 
     RuleLifetime lifetime(rule_install);
@@ -1715,8 +1748,7 @@ void LocalEnforcer::process_rules_to_install(
     } else {
       uint32_t version = session.activate_static_rule(id, lifetime, uc);
       // Set up rules_to_activate
-      rules_to_activate.rules.push_back(static_rule);
-      rules_to_activate.versions.push_back(version);
+      rules_to_activate.append_versioned_policy(static_rule, version);
     }
 
     if (lifetime.deactivation_time > current_time) {
@@ -1724,12 +1756,13 @@ void LocalEnforcer::process_rules_to_install(
           imsi, session_id, id, lifetime.deactivation_time);
     } else if (lifetime.deactivation_time > 0) {
       // 0: never scheduled to deactivate
-      if (!session.deactivate_static_rule(id, uc)) {
+      optional<uint32_t> op_version = session.deactivate_static_rule(id, uc);
+      if (!op_version) {
         MLOG(MWARNING) << "Could not find rule " << id << "for " << session_id
                        << " during static rule removal";
+      } else {
+        rules_to_deactivate.append_versioned_policy(static_rule, *op_version);
       }
-
-      rules_to_deactivate.rules.push_back(static_rule);
     }
   }
 
@@ -1742,15 +1775,19 @@ void LocalEnforcer::process_rules_to_install(
       schedule_dynamic_rule_activation(
           imsi, session_id, rule_id, lifetime.activation_time);
     } else {
-      session.insert_dynamic_rule(dynamic_rule, lifetime, uc);
-      rules_to_activate.rules.push_back(dynamic_rule);
+      uint32_t version =
+          session.insert_dynamic_rule(dynamic_rule, lifetime, uc);
+      rules_to_activate.append_versioned_policy(dynamic_rule, version);
     }
     if (lifetime.deactivation_time > current_time) {
       schedule_dynamic_rule_deactivation(
           imsi, session_id, rule_id, lifetime.deactivation_time);
     } else if (lifetime.deactivation_time > 0) {
-      session.remove_dynamic_rule(rule_id, nullptr, uc);
-      rules_to_deactivate.rules.push_back(dynamic_rule);
+      optional<uint32_t> op_version =
+          session.remove_dynamic_rule(rule_id, nullptr, uc);
+      if (op_version) {
+        rules_to_deactivate.append_versioned_policy(dynamic_rule, *op_version);
+      }
     }
   }
 }
@@ -2000,22 +2037,23 @@ void LocalEnforcer::remove_rule_due_to_bearer_creation_failure(
   }
 
   PolicyRule rule;
-  bool found = false;
+  optional<uint32_t> op_version = {};
 
   switch (*policy_type) {
     case STATIC:
-      session.deactivate_static_rule(rule_id, uc);
-      found = rule_store_->get_rule(rule_id, &rule);
+      if (rule_store_->get_rule(rule_id, &rule)) {
+        op_version = session.deactivate_static_rule(rule_id, uc);
+      }
       break;
     case DYNAMIC: {
-      found = session.remove_dynamic_rule(rule_id, &rule, uc);
+      op_version = session.remove_dynamic_rule(rule_id, &rule, uc);
       break;
     }
   }
-  if (found) {
+  if (op_version) {
     auto config = session.get_config().common_context;
     RulesToProcess to_process;
-    to_process.rules = std::vector<PolicyRule>{rule};
+    to_process.append_versioned_policy(rule, *op_version);
     pipelined_client_->deactivate_flows_for_rules(
         imsi, config.ue_ipv4(), config.ue_ipv6(), config.teids(), to_process,
         RequestOriginType::GX);

--- a/lte/gateway/c/session_manager/LocalEnforcer.cpp
+++ b/lte/gateway/c/session_manager/LocalEnforcer.cpp
@@ -605,7 +605,11 @@ void LocalEnforcer::schedule_static_rule_activation(
         const auto ambr           = config.get_apn_ambr();
         const std::string msisdn  = config.common_context.msisdn();
 
-        session->install_scheduled_static_rule(rule_id, uc);
+        if (session->is_static_rule_scheduled(rule_id)) {
+          // scheduled_static_rules_.erase(rule_id);
+        }
+        uint32_t version = session->activate_static_rule(
+            rule_id, session->get_rule_lifetime(rule_id), uc);
         PolicyRule rule;
         rule_store_->get_rule(rule_id, &rule);
         RulesToProcess to_process;
@@ -1709,9 +1713,10 @@ void LocalEnforcer::process_rules_to_install(
       schedule_static_rule_activation(
           imsi, session_id, id, lifetime.activation_time);
     } else {
-      session.activate_static_rule(id, lifetime, uc);
+      uint32_t version = session.activate_static_rule(id, lifetime, uc);
       // Set up rules_to_activate
       rules_to_activate.rules.push_back(static_rule);
+      rules_to_activate.versions.push_back(version);
     }
 
     if (lifetime.deactivation_time > current_time) {

--- a/lte/gateway/c/session_manager/PipelinedClient.cpp
+++ b/lte/gateway/c/session_manager/PipelinedClient.cpp
@@ -66,6 +66,12 @@ magma::DeactivateFlowsRequest create_deactivate_req(
   for (const auto& rule : to_process.rules) {
     ids->Add()->assign(rule.id());
   }
+  auto mut_versioned_rules = req.mutable_policies();
+  for (uint index = 0; index < to_process.rules.size(); ++index) {
+    auto versioned_policy = mut_versioned_rules->Add();
+    versioned_policy->set_version(to_process.versions[index]);
+    versioned_policy->set_rule_id(to_process.rules[index].id());
+  }
   return req;
 }
 
@@ -87,9 +93,16 @@ magma::ActivateFlowsRequest create_activate_req(
   if (ambr) {
     req.mutable_apn_ambr()->CopyFrom(*ambr);
   }
+  // TODO depracate dynamic rules fields
   auto mut_dyn_rules = req.mutable_dynamic_rules();
   for (const auto& dyn_rule : to_process.rules) {
     mut_dyn_rules->Add()->CopyFrom(dyn_rule);
+  }
+  auto mut_versioned_rules = req.mutable_policies();
+  for (uint index = 0; index < to_process.rules.size(); ++index) {
+    auto versioned_policy = mut_versioned_rules->Add();
+    versioned_policy->set_version(to_process.versions[index]);
+    versioned_policy->mutable_rule()->CopyFrom(to_process.rules[index]);
   }
   return req;
 }

--- a/lte/gateway/c/session_manager/SessionState.h
+++ b/lte/gateway/c/session_manager/SessionState.h
@@ -316,7 +316,7 @@ class SessionState {
   /**
    * Add a static rule to the session which is currently active.
    */
-  void activate_static_rule(
+  uint32_t activate_static_rule(
       const std::string& rule_id, RuleLifetime& lifetime,
       SessionStateUpdateCriteria& update_criteria);
 
@@ -378,6 +378,8 @@ class SessionState {
       const PolicyRule& rule, RuleLifetime& lifetime,
       SessionStateUpdateCriteria& update_criteria);
 
+  bool is_static_rule_scheduled(const std::string& rule_id);
+
   /**
    * Schedule a static rule for activation in the future.
    */
@@ -389,12 +391,6 @@ class SessionState {
    * Mark a scheduled dynamic rule as activated.
    */
   void install_scheduled_dynamic_rule(
-      const std::string& rule_id, SessionStateUpdateCriteria& update_criteria);
-
-  /**
-   * Mark a scheduled static rule as activated.
-   */
-  void install_scheduled_static_rule(
       const std::string& rule_id, SessionStateUpdateCriteria& update_criteria);
 
   void set_suspend_credit(
@@ -732,8 +728,6 @@ class SessionState {
       UpdateSessionRequest& update_request_out,
       SessionStateUpdateCriteria& update_criteria);
 
-  bool is_static_rule_scheduled(const std::string& rule_id);
-
   /** apply static_rules which is the desired state for the session's rules **/
   void apply_session_static_rule_set(
       std::unordered_set<std::string> static_rules,
@@ -793,6 +787,15 @@ class SessionState {
    */
   void update_data_metrics(
       const char* counter_name, uint64_t bytes_tx, uint64_t bytes_rx);
+
+  // PolicyStatsMap functions
+  /**
+   *
+   * @param rule_id
+   * @param session_uc
+   */
+  void increment_rule_stats(
+      const std::string& rule_id, SessionStateUpdateCriteria& session_uc);
 };
 
 }  // namespace magma

--- a/lte/gateway/c/session_manager/SessionState.h
+++ b/lte/gateway/c/session_manager/SessionState.h
@@ -38,7 +38,6 @@ typedef std::unordered_map<
     CreditKey, SessionCredit::Summary, decltype(&ccHash), decltype(&ccEqual)>
     ChargingCreditSummaries;
 typedef std::unordered_map<std::string, std::unique_ptr<Monitor>> MonitorMap;
-static SessionStateUpdateCriteria UNUSED_UPDATE_CRITERIA;
 
 // Used to transform the proto message RuleSet into a more useful structure
 struct RuleSetToApply {
@@ -300,6 +299,14 @@ class SessionState {
    */
   optional<PolicyType> get_policy_type(const std::string& rule_id);
 
+  /**
+   * @brief Get the current rule version object
+   *
+   * @param rule_id
+   * @return uint32_t
+   */
+  uint32_t get_current_rule_version(const std::string& rule_id);
+
   bool is_dynamic_rule_installed(const std::string& rule_id);
 
   bool is_gy_dynamic_rule_installed(const std::string& rule_id);
@@ -307,22 +314,41 @@ class SessionState {
   bool is_static_rule_installed(const std::string& rule_id);
 
   /**
-   * Add a dynamic rule to the session which is currently active.
+   * @brief Add a dynamic rule into dynamic rule store. Increment the associated
+   * version and return the new version.
+   *
+   * @param rule
+   * @param lifetime
+   * @param session_uc
+   * @return uint32_t updated version
    */
-  void insert_dynamic_rule(
+  uint32_t insert_dynamic_rule(
       const PolicyRule& rule, RuleLifetime& lifetime,
-      SessionStateUpdateCriteria& update_criteria);
+      SessionStateUpdateCriteria& session_uc);
 
   /**
-   * Add a static rule to the session which is currently active.
+   * @brief Insert a static rule into active_static_rules_. Increment the
+   * associated version and return the new version.
+   *
+   * @param rule_id
+   * @param lifetime
+   * @param session_uc
+   * @return uint32_t updated version
    */
   uint32_t activate_static_rule(
       const std::string& rule_id, RuleLifetime& lifetime,
-      SessionStateUpdateCriteria& update_criteria);
-
-  void insert_gy_dynamic_rule(
+      SessionStateUpdateCriteria& session_uc);
+  /**
+   * @brief Insert a PolicyRule into gy_dynamic_rules_
+   *
+   * @param rule
+   * @param lifetime
+   * @param update_criteria
+   * @return uint32_t updated version
+   */
+  uint32_t insert_gy_rule(
       const PolicyRule& rule, RuleLifetime& lifetime,
-      SessionStateUpdateCriteria& update_criteria);
+      SessionStateUpdateCriteria& session_uc);
 
   /**
    * Remove a currently active dynamic rule to mark it as deactivated.
@@ -332,9 +358,9 @@ class SessionState {
    * @param update_criteria Tracks updates to the session. To be passed back to
    *                        the SessionStore to resolve issues of concurrent
    *                        updates to a session.
-   * @return True if successfully removed.
+   * @return optional<uint32_t> updated version if success, {} if failure
    */
-  bool remove_dynamic_rule(
+  optional<uint32_t> remove_dynamic_rule(
       const std::string& rule_id, PolicyRule* rule_out,
       SessionStateUpdateCriteria& update_criteria);
 
@@ -342,24 +368,32 @@ class SessionState {
       const std::string& rule_id, PolicyRule* rule_out,
       SessionStateUpdateCriteria& update_criteria);
 
-  bool remove_gy_dynamic_rule(
+  /**
+   * @brief Remove a Gy rule from SessionState and increment the corresponding
+   * version
+   *
+   * @param rule_id
+   * @param rule_out
+   * @param session_uc
+   * @return optional<uint32_t> updated version if success, {} if failure
+   */
+  optional<uint32_t> remove_gy_rule(
       const std::string& rule_id, PolicyRule* rule_out,
-      SessionStateUpdateCriteria& update_criteria);
+      SessionStateUpdateCriteria& session_uc);
 
   /**
    * Remove a currently active static rule to mark it as deactivated.
    *
    * @param rule_id ID of the rule to be removed.
-   * @param update_criteria Tracks updates to the session. To be passed back to
+   * @param session_uc Tracks updates to the session. To be passed back to
    *                        the SessionStore to resolve issues of concurrent
    *                        updates to a session.
-   * @return True if successfully removed.
+   * @return new version if successfully removed. otherwise returns {}
    */
-  bool deactivate_static_rule(
-      const std::string& rule_id, SessionStateUpdateCriteria& update_criteria);
+  optional<uint32_t> deactivate_static_rule(
+      const std::string& rule_id, SessionStateUpdateCriteria& session_uc);
 
-  bool deactivate_scheduled_static_rule(
-      const std::string& rule_id, SessionStateUpdateCriteria& update_criteria);
+  bool deactivate_scheduled_static_rule(const std::string& rule_id);
 
   std::vector<std::string>& get_static_rules();
 
@@ -387,12 +421,6 @@ class SessionState {
       const std::string& rule_id, RuleLifetime& lifetime,
       SessionStateUpdateCriteria& update_criteria);
 
-  /**
-   * Mark a scheduled dynamic rule as activated.
-   */
-  void install_scheduled_dynamic_rule(
-      const std::string& rule_id, SessionStateUpdateCriteria& update_criteria);
-
   void set_suspend_credit(
       const CreditKey& charging_key, bool new_suspended,
       SessionStateUpdateCriteria& update_criteria);
@@ -419,10 +447,9 @@ class SessionState {
 
   SessionFsmState get_state();
 
-  void get_unsuspended_rules(RulesToProcess& rulesToProcess);
-
   void get_rules_per_credit_key(
-      CreditKey charging_key, RulesToProcess& rulesToProcess);
+      CreditKey charging_key, RulesToProcess& rulesToProcess,
+      SessionStateUpdateCriteria& session_uc);
 
   /**
    * Remove all active/scheduled static/dynamic rules and reflect the change in
@@ -572,7 +599,7 @@ class SessionState {
   // Used between create session and activate session. Empty afterwards
   CreateSessionResponse create_session_response_;
 
-  // Track version tracking information
+  // Track version tracking information used for LTE/WLAN
   PolicyStatsMap policy_version_and_stats_;
 
   // All static rules synced from policy DB
@@ -639,17 +666,20 @@ class SessionState {
       SessionStateUpdateCriteria& session_uc);
 
   void fill_service_action_for_activate(
-      std::unique_ptr<ServiceAction>& action, const CreditKey& key);
+      std::unique_ptr<ServiceAction>& action, const CreditKey& key,
+      SessionStateUpdateCriteria& session_uc);
 
   void fill_service_action_for_restrict(
       std::unique_ptr<ServiceAction>& action_p, const CreditKey& key,
-      std::unique_ptr<ChargingGrant>& grant);
+      std::unique_ptr<ChargingGrant>& grant,
+      SessionStateUpdateCriteria& session_uc);
 
   PolicyRule make_redirect_rule(std::unique_ptr<ChargingGrant>& grant);
 
   void fill_service_action_for_redirect(
       std::unique_ptr<ServiceAction>& action_p, const CreditKey& key,
-      std::unique_ptr<ChargingGrant>& grant, PolicyRule redirect_rule);
+      std::unique_ptr<ChargingGrant>& grant, PolicyRule redirect_rule,
+      SessionStateUpdateCriteria& session_uc);
 
   void fill_service_action_with_context(
       std::unique_ptr<ServiceAction>& action, ServiceActionType action_type,

--- a/lte/gateway/c/session_manager/Types.h
+++ b/lte/gateway/c/session_manager/Types.h
@@ -185,6 +185,7 @@ struct RulesToProcess {
   // If this vector is set, then it has PolicyRule definitions for both static
   // and dynamic rules
   std::vector<PolicyRule> rules;
+  std::vector<uint32_t> versions;
   bool empty() const;
 };
 

--- a/lte/gateway/c/session_manager/Types.h
+++ b/lte/gateway/c/session_manager/Types.h
@@ -187,6 +187,7 @@ struct RulesToProcess {
   std::vector<PolicyRule> rules;
   std::vector<uint32_t> versions;
   bool empty() const;
+  void append_versioned_policy(PolicyRule rule, uint32_t version);
 };
 
 struct StatsPerPolicy {

--- a/lte/gateway/c/session_manager/test/Matchers.h
+++ b/lte/gateway/c/session_manager/test/Matchers.h
@@ -102,9 +102,9 @@ MATCHER_P3(CheckTerminateRequestCount, imsi, monitorCount, chargingCount, "") {
          req.monitor_usages().size() == monitorCount;
 }
 
-MATCHER_P5(
+MATCHER_P6(
     CheckSessionInfos, imsi_list, ip_address_list, ipv6_address_list, cfg,
-    rule_ids_lists, "") {
+    rule_ids_lists, versions_lists, "") {
   auto infos = static_cast<const std::vector<SessionState::SessionInfo>>(arg);
 
   if (infos.size() != imsi_list.size()) {
@@ -131,6 +131,13 @@ MATCHER_P5(
       if (info.gx_rules.rules[r_index].id() != expected_gx_rules[r_index])
         return false;
     }
+
+    std::vector<uint32_t> expected_versions = versions_lists[i];
+    for (size_t r_index = 0; i < info.gx_rules.versions.size(); i++) {
+      if (info.gx_rules.versions[r_index] != expected_versions[r_index])
+        return false;
+    }
+
     // check ambr field if config has qos_info
     if (cfg.rat_specific_context.has_lte_context() &&
         cfg.rat_specific_context.lte_context().has_qos_info()) {

--- a/lte/gateway/c/session_manager/test/SessionStateTester.h
+++ b/lte/gateway/c/session_manager/test/SessionStateTester.h
@@ -62,8 +62,8 @@ class SessionStateTest : public ::testing::Test {
         return session_state->activate_static_rule(
             rule_id, lifetime, update_criteria);
       case DYNAMIC:
-        session_state->insert_dynamic_rule(rule, lifetime, update_criteria);
-        return 0;
+        return session_state->insert_dynamic_rule(
+            rule, lifetime, update_criteria);
         break;
     }
     return 0;
@@ -106,7 +106,7 @@ class SessionStateTest : public ::testing::Test {
     }
   }
 
-  void insert_gy_redirection_rule(const std::string& rule_id) {
+  uint32_t insert_gy_redirection_rule(const std::string& rule_id) {
     PolicyRule redirect_rule;
     redirect_rule.set_id(rule_id);
     redirect_rule.set_priority(999);
@@ -124,7 +124,7 @@ class SessionStateTest : public ::testing::Test {
         redirect_server.redirect_server_address());
 
     RuleLifetime lifetime{};
-    session_state->insert_gy_dynamic_rule(
+    return session_state->insert_gy_rule(
         redirect_rule, lifetime, update_criteria);
   }
 
@@ -161,7 +161,7 @@ class SessionStateTest : public ::testing::Test {
     session_state->receive_monitor(monitor_resp, update_criteria);
   }
 
-  void activate_rule(
+  uint32_t activate_rule(
       uint32_t rating_group, const std::string& m_key,
       const std::string& rule_id, PolicyType rule_type,
       std::time_t activation_time, std::time_t deactivation_time) {
@@ -171,12 +171,17 @@ class SessionStateTest : public ::testing::Test {
     switch (rule_type) {
       case STATIC:
         rule_store->insert_rule(rule);
-        session_state->activate_static_rule(rule_id, lifetime, update_criteria);
+        return session_state->activate_static_rule(
+            rule_id, lifetime, update_criteria);
         break;
       case DYNAMIC:
-        session_state->insert_dynamic_rule(rule, lifetime, update_criteria);
+        return session_state->insert_dynamic_rule(
+            rule, lifetime, update_criteria);
+        break;
+      default:
         break;
     }
+    return 0;
   }
 
  protected:

--- a/lte/gateway/c/session_manager/test/SessionStateTester.h
+++ b/lte/gateway/c/session_manager/test/SessionStateTester.h
@@ -38,10 +38,6 @@ class SessionStateTest : public ::testing::Test {
         pdp_start_time, CreateSessionResponse{});
     update_criteria = get_default_update_criteria();
   }
-  enum RuleType {
-    STATIC  = 0,
-    DYNAMIC = 1,
-  };
 
   void insert_static_rule_into_store(
       uint32_t rating_group, const std::string& m_key,
@@ -51,9 +47,9 @@ class SessionStateTest : public ::testing::Test {
     rule_store->insert_rule(rule);
   }
 
-  void insert_rule(
+  uint32_t insert_rule(
       uint32_t rating_group, const std::string& m_key,
-      const std::string& rule_id, RuleType rule_type,
+      const std::string& rule_id, PolicyType rule_type,
       std::time_t activation_time, std::time_t deactivation_time) {
     PolicyRule rule;
     create_policy_rule(rule_id, m_key, rating_group, &rule);
@@ -63,17 +59,19 @@ class SessionStateTest : public ::testing::Test {
         // insert into list of existing rules
         rule_store->insert_rule(rule);
         // mark the rule as active in session
-        session_state->activate_static_rule(rule_id, lifetime, update_criteria);
-        break;
+        return session_state->activate_static_rule(
+            rule_id, lifetime, update_criteria);
       case DYNAMIC:
         session_state->insert_dynamic_rule(rule, lifetime, update_criteria);
+        return 0;
         break;
     }
+    return 0;
   }
 
   void schedule_rule(
       uint32_t rating_group, const std::string& m_key,
-      const std::string& rule_id, RuleType rule_type,
+      const std::string& rule_id, PolicyType rule_type,
       std::time_t activation_time, std::time_t deactivation_time) {
     PolicyRule rule;
     create_policy_rule(rule_id, m_key, rating_group, &rule);
@@ -165,7 +163,7 @@ class SessionStateTest : public ::testing::Test {
 
   void activate_rule(
       uint32_t rating_group, const std::string& m_key,
-      const std::string& rule_id, RuleType rule_type,
+      const std::string& rule_id, PolicyType rule_type,
       std::time_t activation_time, std::time_t deactivation_time) {
     PolicyRule rule;
     create_policy_rule(rule_id, m_key, rating_group, &rule);

--- a/lte/gateway/c/session_manager/test/test_local_enforcer.cpp
+++ b/lte/gateway/c/session_manager/test/test_local_enforcer.cpp
@@ -762,11 +762,17 @@ TEST_F(LocalEnforcerTest, test_sync_sessions_on_restart) {
       .activation_time   = std::time_t(15),
       .deactivation_time = std::time_t(20),
   };
-  auto& uc = session_update[IMSI1][SESSION_ID_1];
-  session_map_2[IMSI1].front()->activate_static_rule("rule1", lifetime1, uc);
+  auto& uc    = session_update[IMSI1][SESSION_ID_1];
+  uint32_t v1 = session_map_2[IMSI1].front()->activate_static_rule(
+      "rule1", lifetime1, uc);
   session_map_2[IMSI1].front()->schedule_static_rule("rule2", lifetime2, uc);
   session_map_2[IMSI1].front()->schedule_static_rule("rule3", lifetime3, uc);
   session_map_2[IMSI1].front()->schedule_static_rule("rule4", lifetime4, uc);
+
+  EXPECT_EQ(v1, 1);
+
+  EXPECT_TRUE(uc.policy_version_and_stats);
+  EXPECT_EQ((*uc.policy_version_and_stats)["rule1"].current_version, 1);
 
   EXPECT_EQ(uc.static_rules_to_install.count("rule1"), 1);
   EXPECT_EQ(uc.new_scheduled_static_rules.count("rule2"), 1);

--- a/lte/gateway/c/session_manager/test/test_session_state.cpp
+++ b/lte/gateway/c/session_manager/test/test_session_state.cpp
@@ -102,7 +102,8 @@ TEST_F(SessionStateTest, test_rule_scheduling) {
   EXPECT_EQ(1, session_state->total_monitored_rules_count());
   EXPECT_TRUE(session_state->is_dynamic_rule_installed("rule1"));
 
-  session_state->install_scheduled_static_rule("rule2", _uc);
+  session_state->activate_static_rule(
+      "rule2", session_state->get_rule_lifetime("rule2"), _uc);
   EXPECT_EQ(2, session_state->total_monitored_rules_count());
   EXPECT_TRUE(session_state->is_static_rule_installed("rule2"));
 }
@@ -150,7 +151,6 @@ TEST_F(SessionStateTest, test_rule_time_sync) {
   EXPECT_TRUE(uc.dynamic_rules_to_uninstall.count("d3"));
 
   EXPECT_TRUE(uc.static_rules_to_install.count("s1"));
-  EXPECT_TRUE(uc.static_rules_to_uninstall.count("s3"));
 
   // Update the time once more, sync again, and check expectations
   test_time = std::time_t(16);

--- a/lte/gateway/c/session_manager/test/test_session_state.cpp
+++ b/lte/gateway/c/session_manager/test/test_session_state.cpp
@@ -48,12 +48,14 @@ TEST_F(SessionStateTest, test_session_rules) {
   EXPECT_EQ(session_state->is_static_rule_installed("rule3"), true);
   EXPECT_EQ(session_state->is_static_rule_installed("rule_DNE"), false);
 
+  EXPECT_EQ(session_state->get_current_rule_version("rule2"), 1);
+  EXPECT_EQ(session_state->get_current_rule_version("rule3"), 1);
+
   // Test rule removals
   PolicyRule rule_out;
   session_state->deactivate_static_rule("rule2", update_criteria);
   EXPECT_EQ(1, session_state->total_monitored_rules_count());
-  EXPECT_EQ(
-      true,
+  EXPECT_TRUE(
       session_state->remove_dynamic_rule("rule1", &rule_out, update_criteria));
   EXPECT_EQ("m1", rule_out.monitoring_key());
   EXPECT_EQ(0, session_state->total_monitored_rules_count());
@@ -98,7 +100,10 @@ TEST_F(SessionStateTest, test_rule_scheduling) {
   // Now suppose some time has passed, and it's time to mark scheduled rules
   // as active. The responsibility is given to the session owner to make
   // these calls
-  session_state->install_scheduled_dynamic_rule("rule1", _uc);
+  PolicyRule rule;
+  session_state->remove_scheduled_dynamic_rule("rule1", &rule, _uc);
+  session_state->insert_dynamic_rule(
+      rule, session_state->get_rule_lifetime("rule1"), _uc);
   EXPECT_EQ(1, session_state->total_monitored_rules_count());
   EXPECT_TRUE(session_state->is_dynamic_rule_installed("rule1"));
 
@@ -106,6 +111,9 @@ TEST_F(SessionStateTest, test_rule_scheduling) {
       "rule2", session_state->get_rule_lifetime("rule2"), _uc);
   EXPECT_EQ(2, session_state->total_monitored_rules_count());
   EXPECT_TRUE(session_state->is_static_rule_installed("rule2"));
+
+  EXPECT_EQ(session_state->get_current_rule_version("rule1"), 1);
+  EXPECT_EQ(session_state->get_current_rule_version("rule2"), 1);
 }
 
 /**
@@ -290,12 +298,10 @@ TEST_F(SessionStateTest, test_add_rule_usage) {
   EXPECT_EQ(update.usage_monitors_size(), 2);
 
   PolicyRule policy_out;
-  EXPECT_EQ(
-      true, session_state->remove_dynamic_rule(
-                "dyn_rule1", &policy_out, update_criteria));
-  EXPECT_EQ(
-      true, session_state->deactivate_static_rule("rule1", update_criteria));
-  EXPECT_EQ(false, session_state->active_monitored_rules_exist());
+  EXPECT_TRUE(session_state->remove_dynamic_rule(
+      "dyn_rule1", &policy_out, update_criteria));
+  EXPECT_TRUE(session_state->deactivate_static_rule("rule1", update_criteria));
+  EXPECT_FALSE(session_state->active_monitored_rules_exist());
   EXPECT_TRUE(
       std::find(
           update_criteria.dynamic_rules_to_uninstall.begin(),
@@ -642,7 +648,8 @@ TEST_F(SessionStateTest, test_get_total_credit_usage_multiple_rule_shared_key) {
 }
 
 TEST_F(SessionStateTest, test_install_gy_rules) {
-  insert_gy_redirection_rule("redirect");
+  uint32_t version = insert_gy_redirection_rule("redirect");
+  EXPECT_EQ(1, version);
 
   std::vector<std::string> rules_out{};
   std::vector<std::string>& rules_out_ptr = rules_out;
@@ -655,9 +662,11 @@ TEST_F(SessionStateTest, test_install_gy_rules) {
   EXPECT_EQ(update_criteria.gy_dynamic_rules_to_install.size(), 1);
 
   PolicyRule rule_out;
-  EXPECT_EQ(
-      true, session_state->remove_gy_dynamic_rule(
-                "redirect", &rule_out, update_criteria));
+  optional<uint32_t> op_version =
+      session_state->remove_gy_rule("redirect", &rule_out, update_criteria);
+  EXPECT_TRUE(op_version);
+  EXPECT_EQ(*op_version, 2);
+
   // basic sanity checks to see it's properly deleted
   rules_out = {};
   session_state->get_gy_dynamic_rules().get_rule_ids(rules_out_ptr);


### PR DESCRIPTION
<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary
This PR adds new logic to: 
1. Every time we enable / disable a rule (gx/gy static/dynamic), we update the version corresponding to the rule. 
2. This value is propagated down to PipelineD as part of the `Activate/DeactivateFlowsRequest`.
3. In case of where all rules are removed by providing an empty DeactivateRequest, `PipelienD` will have to figure out the correct version.


### New / Modified interfaces: 
* `get_current_rule_version` : given a rule_id, get the current version
* `insert_gy_dynamic_rule` -> `insert_gy_rule` : gy static rules were currently not tracked, so expanding the interface to also track static rules as well
* `insert_dynamic_rule`/`activate_static_rule`/`insert_gy_rule` : now returns the updated rule version after inserting a rule
* `remove_dynamic_rule`/`remove_gy_rule`/`deactivate_static_rule` : now returns a optional<uint32_t> that includes the updated version after removing a rules. If the rule removal failed, it will return {} which is a false-y value

`RulesToProcess` now has two fields and a new append method. This struct is now used for ALL interactions where we need to propagate rule definitions to `PipelineDClient`
```
struct RulesToProcess {
  // If this vector is set, then it has PolicyRule definitions for both static
  // and dynamic rules
  std::vector<PolicyRule> rules;
  std::vector<uint32_t> versions;
  bool empty() const;
  void append_versioned_policy(PolicyRule rule, uint32_t version);
};
```
<!-- Enumerate changes you made and why you made them -->

## Test Plan
CWF integration test locally
SessionD unit tests
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
Signed-off-by: Marie Bremner <marwhal@fb.com>