### PR TITLE
[CI] Add CodeCov.io flags to disambiguate reports

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -512,6 +512,7 @@ jobs:
             python3 build.py --coverage
       - codecov/upload:
           file: /home/circleci/project/orc8r/cloud/coverage/all.gocov
+          flags: cloud_lint
       - magma_slack_notify
 
   # Fail if checked-in generated code doesn't match output from
@@ -621,6 +622,7 @@ jobs:
             make -C ${MAGMA_ROOT}/feg/gateway cover
       - codecov/upload:
           file: /home/circleci/project/feg/gateway/coverage/feg.gocov
+          flags: feg-lint
       - magma_slack_notify
 
   feg-precommit:
@@ -797,7 +799,7 @@ jobs:
             cd $MAGMA_ROOT/lte/gateway/docker/mme
             docker build -t magma/c_cpp_build -f Dockerfile.ubuntu20.04 ../../../../
             ci_env=`bash <(curl -s https://codecov.io/env)`
-            docker run $ci_env -e CI=true -v /home/circleci/project:/magma -v /home/circleci/project/lte/gateway/configs:/etc/magma -i -t magma/c_cpp_build:latest /bin/bash -c "cd /magma/lte/gateway;make coverage;ls -al /tmp/;bash <(curl -s https://codecov.io/bash) -f /build/c/coverage.info"
+            docker run $ci_env -e CI=true -v /home/circleci/project:/magma -v /home/circleci/project/lte/gateway/configs:/etc/magma -i -t magma/c_cpp_build:latest /bin/bash -c "cd /magma/lte/gateway;make coverage;ls -al /tmp/;bash <(curl -s https://codecov.io/bash) -f /build/c/coverage.info -F c_cpp"
       - magma_slack_notify
 
   mme-clang-warnings:
@@ -853,8 +855,10 @@ jobs:
           path: /var/tmp/test_results
       - codecov/upload:
           file: /var/tmp/codecovs/cover_lte.xml
+          flags: lte-test
       - codecov/upload:
           file: /var/tmp/codecovs/cover_orc8r.xml
+          flags: lte-test
       - magma_slack_notify
 
   lte-integ-test:

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,26 @@
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 0%
+      cloud_lint:
+        target: auto
+        threshold: 0%
+        flags:
+          - cloud_lint
+      feg-lint:
+        target: auto
+        threshold: 0%
+        flags:
+          - feg-lint 
+      lte-test:
+        target: auto
+        threshold: 0%
+        flags:
+          - lte-test
+      c_cpp:
+        target: auto
+        threshold: 0%
+        flags:
+          - c_cpp


### PR DESCRIPTION
## Summary

We are observing erratic coverage reporting as CodeCov.io wants every git hash being reported to have complete coverage statistics - which we are not doing for latency / CPU / cost reasons (e.g. if a PR does not touch c/c++ targets we are omtting the hour+ of testing and upload of coverage).  This PR attempts to use per-coverage-domain codecov.io flags to alleviate the issue (why do they call them flags and not tags! ARG).

The strategy is to apply a codecov.io project flag per CircleCI pipeline stage that pushes a coverage report - to ensure each can be run in isolation of any others.

## Test Plan

Test-ability of CircleCI / CodeCov configuration does not seem great - particular for the multi-target PR such as this.  I think given the current broken codecov behavior, we might as well merge this and then iterate.

Signed-off-by: Scott Harrison Moeller <smoeller@fb.com>