### PR TITLE
[CODEOWNERS] Add feg-approvers to CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -12,7 +12,7 @@ orc8r/cloud/deploy/bare-metal/ @tmdzk @mattymo @119Vik
 
 orc8r/gateway/c/ @themarwhal @ardzoht
 
-feg/ @themarwhal @mpgermano @uri200 @emakeev
+feg/ @magma/feg-approvers 
 cwf/ @themarwhal @mpgermano @uri200 @emakeev
 cwf/gateway/Vagrantfile @mattymo @119Vik @tmdzk
 


### PR DESCRIPTION
<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary
Round 2 on trying a team based review.
The previous PR didn't work because the team didn't have write permission to the magma repo.

The FeG approvers team (https://github.com/orgs/magma/teams/feg-approvers) has the same set of people and it's integrated to the #github-feg slack channel for posting stats.
<!-- Enumerate changes you made and why you made them -->

![Screen Shot 2021-03-29 at 3 23 27 PM](https://user-images.githubusercontent.com/37634144/112895438-bf172980-90a2-11eb-94b0-7097321001cc.png)

## Test Plan
Tested on a non-protected branch and it seemed to assign a reviewer appropriately. 
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
