### PR TITLE
pyroute2 exception handling issue.

### DIFF
--- a/lte/gateway/python/setup.py
+++ b/lte/gateway/python/setup.py
@@ -115,7 +115,7 @@ setup(
         'hpack>=3.0',
         'freezegun>=0.3.15',
         'pycryptodome>=3.9.9',
-        'pyroute2>=0.5.14'
+        'pyroute2==0.5.14'
     ],
     extras_require={
         'dev': [


### PR DESCRIPTION
Signed-off-by: prabina pattnaik <prabinak@wavelabs.ai>

## Summary

Getting below error in latest master. Issue with NDB module in python3.5 for exception handling.

Mar 29 11:58:12 magma-dev pipelined[24816]:   import cryptography
Mar 29 11:58:12 magma-dev pipelined[24816]: Traceback (most recent call last):
Mar 29 11:58:12 magma-dev pipelined[24816]:   File "/usr/lib/python3.5/runpy.py", line 193, in _run_module_as_main
Mar 29 11:58:12 magma-dev pipelined[24816]:     "__main__", mod_spec)
Mar 29 11:58:12 magma-dev pipelined[24816]:   File "/usr/lib/python3.5/runpy.py", line 85, in _run_code
Mar 29 11:58:12 magma-dev pipelined[24816]:     exec(code, run_globals)
Mar 29 11:58:12 magma-dev pipelined[24816]:   File "/home/vagrant/magma/lte/gateway/python/magma/pipelined/main.py", line 34, in <module>
Mar 29 11:58:12 magma-dev pipelined[24816]:     from magma.pipelined.service_manager import ServiceManager
Mar 29 11:58:12 magma-dev pipelined[24816]:   File "/home/vagrant/magma/lte/gateway/python/magma/pipelined/service_manager.py", line 58, in <module>
Mar 29 11:58:12 magma-dev pipelined[24816]:     from magma.pipelined.app.gy import GYController
Mar 29 11:58:12 magma-dev pipelined[24816]:   File "/home/vagrant/magma/lte/gateway/python/magma/pipelined/app/gy.py", line 27, in <module>
Mar 29 11:58:12 magma-dev pipelined[24816]:     from magma.pipelined.qos.common import QosManager
Mar 29 11:58:12 magma-dev pipelined[24816]:   File "/home/vagrant/magma/lte/gateway/python/magma/pipelined/qos/common.py", line 20, in <module>
Mar 29 11:58:12 magma-dev pipelined[24816]:     from magma.pipelined.qos.qos_tc_impl import TCManager, TrafficClass
Mar 29 11:58:12 magma-dev pipelined[24816]:   File "/home/vagrant/magma/lte/gateway/python/magma/pipelined/qos/qos_tc_impl.py", line 20, in <module>
Mar 29 11:58:12 magma-dev pipelined[24816]:     from .tc_ops_pyroute2 import TcOpsPyRoute2
Mar 29 11:58:12 magma-dev pipelined[24816]:   File "/home/vagrant/magma/lte/gateway/python/magma/pipelined/qos/tc_ops_pyroute2.py", line 17, in <module>
Mar 29 11:58:12 magma-dev pipelined[24816]:     from pyroute2 import IPRoute, NetlinkError
Mar 29 11:58:12 magma-dev pipelined[24816]:   File "/home/vagrant/build/python/lib/python3.5/site-packages/pyroute2/__init__.py", line 93, in <module>
Mar 29 11:58:12 magma-dev pipelined[24816]:     from pyroute2.ndb.main import NDB
Mar 29 11:58:12 magma-dev pipelined[24816]:   File "/home/vagrant/build/python/lib/python3.5/site-packages/pyroute2/ndb/main.py", line 307
Mar 29 11:58:12 magma-dev pipelined[24816]:     self.log.warning(f'ignore rollback exception: {e}')
Mar 29 11:58:12 magma-dev pipelined[24816]:                                                      ^
Mar 29 11:58:12 magma-dev pipelined[24816]: SyntaxError: invalid syntax
## Test Plan

freeze the iproute2 version at 0.5.14.

## Additional Information
vagrant@magma-dev:~/magma/lte/gateway$ systemctl |grep magma@
magma@control_proxy.service                                                              loaded active running   Magma control_proxy service                 
magma@ctraced.service                                                                    loaded active running   Magma ctraced service                       
magma@directoryd.service                                                                 loaded active running   Magma directoryd service                    
magma@dnsd.service                                                                       loaded active running   Magma dnsd service                          
magma@enodebd.service                                                                    loaded active running   Magma enodebd service                       
magma@envoy_controller.service                                                           loaded active running   Magma envoy controller service              
magma@eventd.service                                                                     loaded active running   Magma eventd service                        
magma@health.service                                                                     loaded active running   Magma health service                        
magma@magmad.service                                                                     loaded active running   Magma magmad service                        
magma@mme.service                                                                        loaded active running   Magma OAI MME service                       
magma@mobilityd.service                                                                  loaded active running   Magma mobilityd service                     
magma@pipelined.service                                                                  loaded active running   Magma pipelined service                     
magma@policydb.service                                                                   loaded active running   Magma policydb service                      
magma@redis.service                                                                      loaded active running   Magma Redis datastore service               
magma@sessiond.service                                                                   loaded active running   Magma session manager service               
magma@smsd.service                                                                       loaded active running   Magma smsd service                          
magma@state.service                                                                      loaded active running   Magma state service                         
magma@subscriberdb.service                                                               loaded active running   Magma subscriberdb service         