### PR TITLE
[AGW][PIPELINED] Fix pyroute2 package by bumping to 0.5.16

### DIFF
--- a/lte/gateway/python/setup.py
+++ b/lte/gateway/python/setup.py
@@ -115,7 +115,7 @@ setup(
         'hpack>=3.0',
         'freezegun>=0.3.15',
         'pycryptodome>=3.9.9',
-        'pyroute2==0.5.14'
+        'pyroute2==0.5.16'
     ],
     extras_require={
         'dev': [

--- a/lte/gateway/release/magma.lockfile
+++ b/lte/gateway/release/magma.lockfile
@@ -1118,7 +1118,7 @@
       "version": "1.0.2"
     },
     "pyroute2": {
-      "version": "0.5.14"
+      "version": "0.5.16"
     },
     "pystemd": {
       "version": "0.8.0"


### PR DESCRIPTION
Signed-off-by: Timothée Dzik <timdzik@fb.com>

[AGW][PIPELINED] Fix pyroute2 package by bumping to 0.5.16

## Summary

In pyroute2 In the latest 0.5.15 [this line](https://github.com/svinota/pyroute2/blame/master/pyroute2/ndb/main.py#L307)  has been included which work on Python >= 3.6 but not on Python < 3.6
Simple fix, change the way to inject the var in the warning. PR approved and @svinota gently created a new release for us. 

PR: https://github.com/svinota/pyroute2/pull/776

## Test Plan

vagrant up && make run 
