### PR TITLE
[lib][agw] Free keysp value in obj_hashtable_uint64

### DIFF
--- a/lte/gateway/c/oai/lib/hashtable/obj_hashtable_uint64.c
+++ b/lte/gateway/c/oai/lib/hashtable/obj_hashtable_uint64.c
@@ -994,6 +994,7 @@ hashtable_rc_t obj_hashtable_uint64_get_keys(
       }
     }
 
+    free(keysP);
     PRINT_HASHTABLE(hashtblP, "return OK\n");
     return HASH_TABLE_OK;
   }


### PR DESCRIPTION
## Summary

clang-tidy currently shows a warning in the file
obj_hashtable_uint64.c due to an allocated keysP
value that is never freed. Free that value prior
to returning if that value is populated by the
original calloc() call.

Signed-off-by: Anusha Datar anushadatar@gmail.com

## Test Plan

```
cd lte/gateway
make build_oai
```
And CI Pipelines.
