### PR TITLE
[lib][agw] Free keysp values in obj_hashtable

### DIFF
--- a/lte/gateway/c/oai/lib/hashtable/obj_hashtable.c
+++ b/lte/gateway/c/oai/lib/hashtable/obj_hashtable.c
@@ -1014,6 +1014,7 @@ hashtable_rc_t obj_hashtable_get_keys(
       }
     }
 
+    free(keysP);
     PRINT_HASHTABLE(hashtblP, "return OK\n");
     return HASH_TABLE_OK;
   }
@@ -1049,6 +1050,7 @@ hashtable_rc_t obj_hashtable_ts_get_keys(
       pthread_mutex_unlock(&hashtblP->lock_nodes[n]);
     }
 
+    free(keysP);
     PRINT_HASHTABLE(hashtblP, "return OK\n");
     return HASH_TABLE_OK;
   }


### PR DESCRIPTION
## Summary
clang-tidy currently shows two  warnings in the
file obj_hashtable.c due to two allocated keysP
values that are never freed. Free those values
prior to returning if that value is populated by
the original calloc() call.

Signed-off-by: Anusha Datar anushadatar@gmail.com

## Test Plan

```
cd lte/gateway
make build_oai
```
And CI Pipelines.