### PR TITLE
[lte][agw] Restore formatting for various OAI files

### DIFF
--- a/lte/gateway/c/oai/common/log.c
+++ b/lte/gateway/c/oai/common/log.c
@@ -1482,8 +1482,8 @@ error_event:
   if (!(g_oai_log.is_async)) {
     LOG_FREE_ITEM(sync_context_p);
   } else if (async_context_p == NULL) {
-      return;
-  } else {  
+    return;
+  } else {
     LOG_FREE_ITEM_ASYNC(*async_context_p);
   }
 }

--- a/lte/gateway/c/oai/include/service303_messages_types.h
+++ b/lte/gateway/c/oai/include/service303_messages_types.h
@@ -19,16 +19,16 @@
 
 #include <stdint.h>
 
-// Nothing needed in message for now, but an empty struct is a c-c++ compatibility
-// risk (sizeof zero bytes in c, sizeof one byte in c++). Therefore we allocate an
-// unused uint8_t to ensure sizes are always 1 byte.
+// Nothing needed in message for now, but an empty struct is a c-c++
+// compatibility risk (sizeof zero bytes in c, sizeof one byte in c++).
+// Therefore we allocate an unused uint8_t to ensure sizes are always 1 byte.
 typedef struct application_healthy_msg {
   uint8_t unused;
 } application_healthy_msg_t;
 
-// Nothing needed in message for now, but an empty struct is a c-c++ compatibility
-// risk (sizeof zero bytes in c, sizeof one byte in c++). Therefore we allocate an
-// unused int32_t to ensure sizes are always 1 byte.
+// Nothing needed in message for now, but an empty struct is a c-c++
+// compatibility risk (sizeof zero bytes in c, sizeof one byte in c++).
+// Therefore we allocate an unused int32_t to ensure sizes are always 1 byte.
 typedef struct application_unhealthy_msg {
   uint8_t unused;
 } application_unhealthy_msg_t;

--- a/lte/gateway/c/oai/lib/itti/intertask_messages_types.h
+++ b/lte/gateway/c/oai/lib/itti/intertask_messages_types.h
@@ -40,9 +40,9 @@
 
 #include <stdint.h>
 
-// Nothing needed in message for now, but an empty struct is a c-c++ compatibility
-// risk (sizeof zero bytes in c, sizeof one byte in c++). Therefore we allocate an
-// unused uint8_t to ensure sizes are always 1 byte.
+// Nothing needed in message for now, but an empty struct is a c-c++
+// compatibility risk (sizeof zero bytes in c, sizeof one byte in c++).
+// Therefore we allocate an unused uint8_t to ensure sizes are always 1 byte.
 typedef struct IttiMsgEmpty_s {
   uint8_t unused;
 } IttiMsgEmpty;

--- a/lte/gateway/c/oai/lib/s6a_proxy/s6a_client_api.cpp
+++ b/lte/gateway/c/oai/lib/s6a_proxy/s6a_client_api.cpp
@@ -115,8 +115,7 @@ bool s6a_authentication_info_req(const s6a_auth_info_req_t* const air_p) {
       air_p,
       [imsiStr = std::string(air_p->imsi), imsi_len](
           grpc::Status status, feg::AuthenticationInformationAnswer response) {
-        s6a_handle_authentication_info_ans(
-            imsiStr, imsi_len, status, response);
+        s6a_handle_authentication_info_ans(imsiStr, imsi_len, status, response);
       });
   return true;
 }

--- a/lte/gateway/c/oai/lib/secu/snow3g.c
+++ b/lte/gateway/c/oai/lib/secu/snow3g.c
@@ -285,7 +285,7 @@ void snow3g_generate_key_stream(
 
   for (t = 0; t < n; t++) {
     F     = snow3g_clock_fsm(snow_3g_context_pP); /* STEP 1 */
-    ks[t] = F ^ snow_3g_context_pP->LFSR_S0;       /* STEP 2 */
+    ks[t] = F ^ snow_3g_context_pP->LFSR_S0;      /* STEP 2 */
     /*
      * Note that ks[t] corresponds to z_{t+1} in section 4.2
      */

--- a/lte/gateway/c/oai/tasks/nas/api/network/nas_message.c
+++ b/lte/gateway/c/oai/tasks/nas/api/network/nas_message.c
@@ -499,8 +499,7 @@ int nas_message_decode(
     /*
      * Decode plain NAS message
      */
-    bytes =
-        nas_message_plain_decode(buffer, &msg->header, &msg->plain, length);
+    bytes = nas_message_plain_decode(buffer, &msg->header, &msg->plain, length);
   }
 
   if (bytes < 0) {
@@ -631,8 +630,7 @@ int nas_message_encode(
     /*
      * Encode plain NAS message
      */
-    bytes =
-        nas_message_plain_encode(buffer, &msg->header, &msg->plain, length);
+    bytes = nas_message_plain_encode(buffer, &msg->header, &msg->plain, length);
   }
 
   if (bytes < 0) {

--- a/lte/gateway/c/oai/tasks/nas/emm/Attach.c
+++ b/lte/gateway/c/oai/tasks/nas/emm/Attach.c
@@ -109,7 +109,7 @@
 
 /* String representation of the EPS attach type */
 static const char* emm_attach_type_str[] = {"EPS", "IMSI", "EMERGENCY",
-                                             "RESERVED"};
+                                            "RESERVED"};
 
 /*
    --------------------------------------------------------------------------

--- a/lte/gateway/c/oai/tasks/nas/emm/Authentication.c
+++ b/lte/gateway/c/oai/tasks/nas/emm/Authentication.c
@@ -280,8 +280,7 @@ int emm_proc_authentication(
     auth_proc->emm_com_proc.emm_proc.base_proc.failure_notif = failure;
     auth_proc->emm_com_proc.emm_proc.base_proc.abort   = authentication_abort;
     auth_proc->emm_com_proc.emm_proc.base_proc.fail_in = NULL;  // only response
-    auth_proc->emm_com_proc.emm_proc.base_proc.fail_out =
-        authentication_reject;
+    auth_proc->emm_com_proc.emm_proc.base_proc.fail_out = authentication_reject;
     auth_proc->emm_com_proc.emm_proc.base_proc.time_out = NULL;
 
     bool run_auth_info_proc = false;

--- a/lte/gateway/c/oai/tasks/nas/emm/Detach.c
+++ b/lte/gateway/c/oai/tasks/nas/emm/Detach.c
@@ -54,19 +54,19 @@
 
 /* String representation of the detach type */
 static const char* emm_detach_type_str[] = {"EPS",
-                                             "IMSI",
-                                             "EPS/IMSI",
-                                             "RE-ATTACH REQUIRED",
-                                             "RE-ATTACH NOT REQUIRED",
-                                             "RESERVED"};
+                                            "IMSI",
+                                            "EPS/IMSI",
+                                            "RE-ATTACH REQUIRED",
+                                            "RE-ATTACH NOT REQUIRED",
+                                            "RESERVED"};
 
 /* String representation of the sgs detach type */
 static const char* emm_sgs_detach_type_str[] = {"EPS",
-                                                 "UE-INITIATED-EXPLICIT-NONEPS",
-                                                 "COMBINED",
-                                                 "NW-INITIATED-EPS",
-                                                 "NW-INITIATED-IMPLICIT-NONEPS",
-                                                 "RESERVED"};
+                                                "UE-INITIATED-EXPLICIT-NONEPS",
+                                                "COMBINED",
+                                                "NW-INITIATED-EPS",
+                                                "NW-INITIATED-IMPLICIT-NONEPS",
+                                                "RESERVED"};
 /****************************************************************************
  **                                                                        **
  ** Name:    detach_t3422_handler()                                       **

--- a/lte/gateway/c/oai/tasks/nas/emm/Identification.c
+++ b/lte/gateway/c/oai/tasks/nas/emm/Identification.c
@@ -53,7 +53,7 @@ extern int check_plmn_restriction(imsi_t imsi);
 
 /* String representation of the requested identity type */
 static const char* emm_identity_type_str[] = {"NOT AVAILABLE", "IMSI", "IMEI",
-                                               "IMEISV", "TMSI"};
+                                              "IMEISV", "TMSI"};
 
 // callbacks for identification procedure
 static void identification_t3470_handler(void* args, imsi64_t* imsi64);

--- a/lte/gateway/c/oai/tasks/nas/emm/SecurityModeControl.c
+++ b/lte/gateway/c/oai/tasks/nas/emm/SecurityModeControl.c
@@ -281,8 +281,7 @@ int emm_proc_security_mode_control(
     smc_proc->emm_com_proc.emm_proc.base_proc.abort         = security_abort;
     smc_proc->emm_com_proc.emm_proc.base_proc.fail_in  = NULL;  // only response
     smc_proc->emm_com_proc.emm_proc.base_proc.fail_out = NULL;
-    smc_proc->emm_com_proc.emm_proc.base_proc.time_out =
-        security_t3460_handler;
+    smc_proc->emm_com_proc.emm_proc.base_proc.time_out = security_t3460_handler;
 
     /*
      * Set the UE identifier
@@ -584,10 +583,10 @@ int emm_proc_security_mode_reject(mme_ue_s1ap_id_t ue_id) {
  */
 
 void set_callbacks_for_smc_proc(nas_emm_smc_proc_t* smc_proc) {
-  smc_proc->emm_com_proc.emm_proc.not_delivered    = security_ll_failure;
-  smc_proc->emm_com_proc.emm_proc.not_delivered_ho = security_non_delivered_ho;
-  smc_proc->emm_com_proc.emm_proc.base_proc.abort  = security_abort;
-  smc_proc->emm_com_proc.emm_proc.base_proc.fail_in  = NULL;
+  smc_proc->emm_com_proc.emm_proc.not_delivered     = security_ll_failure;
+  smc_proc->emm_com_proc.emm_proc.not_delivered_ho  = security_non_delivered_ho;
+  smc_proc->emm_com_proc.emm_proc.base_proc.abort   = security_abort;
+  smc_proc->emm_com_proc.emm_proc.base_proc.fail_in = NULL;
   smc_proc->emm_com_proc.emm_proc.base_proc.fail_out = NULL;
   smc_proc->emm_com_proc.emm_proc.base_proc.time_out = security_t3460_handler;
 }

--- a/lte/gateway/c/oai/tasks/nas/emm/TrackingAreaUpdate.c
+++ b/lte/gateway/c/oai/tasks/nas/emm/TrackingAreaUpdate.c
@@ -599,8 +599,7 @@ static int build_csfb_parameters_combined_tau(
      @returns status of operation (RETURNok, RETURNerror)
 */
 //------------------------------------------------------------------------------
-static int emm_tracking_area_update_accept(
-    nas_emm_tau_proc_t* const tau_proc) {
+static int emm_tracking_area_update_accept(nas_emm_tau_proc_t* const tau_proc) {
   OAILOG_FUNC_IN(LOG_NAS_EMM);
   int rc                         = RETURNerror;
   emm_sap_t emm_sap              = {0};

--- a/lte/gateway/c/oai/tasks/nas/emm/sap/emm_as.c
+++ b/lte/gateway/c/oai/tasks/nas/emm/sap/emm_as.c
@@ -1438,8 +1438,8 @@ static int emm_as_data_req(
       /*
        * Encode the NAS information message
        */
-      bytes = emm_as_encode(
-          &as_msg->nas_msg, &nas_msg, size, emm_security_context);
+      bytes =
+          emm_as_encode(&as_msg->nas_msg, &nas_msg, size, emm_security_context);
     } else {
       /*
        * Encrypt the NAS information message
@@ -1893,8 +1893,8 @@ static int emm_as_erab_setup_req(
       /*
        * Encode the NAS information message
        */
-      bytes = emm_as_encode(
-          &as_msg->nas_msg, &nas_msg, size, emm_security_context);
+      bytes =
+          emm_as_encode(&as_msg->nas_msg, &nas_msg, size, emm_security_context);
     } else {
       /*
        * Encrypt the NAS information message
@@ -1971,8 +1971,8 @@ static int emm_as_erab_rel_cmd(
       /*
        * Encode the NAS information message
        */
-      bytes = emm_as_encode(
-          &as_msg->nas_msg, &nas_msg, size, emm_security_context);
+      bytes =
+          emm_as_encode(&as_msg->nas_msg, &nas_msg, size, emm_security_context);
     } else {
       /*
        * Encrypt the NAS information message

--- a/lte/gateway/c/oai/tasks/nas/emm/sap/emm_recv.c
+++ b/lte/gateway/c/oai/tasks/nas/emm/sap/emm_recv.c
@@ -66,8 +66,7 @@
 /****************************************************************************/
 /*********************  L O C A L    F U N C T I O N S  *********************/
 /****************************************************************************/
-static int emm_initiate_default_bearer_re_establishment(
-    emm_context_t* emm_ctx);
+static int emm_initiate_default_bearer_re_establishment(emm_context_t* emm_ctx);
 /*
    --------------------------------------------------------------------------
    Functions executed by both the UE and the MME upon receiving EMM messages

--- a/lte/gateway/c/oai/tasks/nas/esm/DefaultEpsBearerContextActivation.c
+++ b/lte/gateway/c/oai/tasks/nas/esm/DefaultEpsBearerContextActivation.c
@@ -199,8 +199,7 @@ int esm_proc_default_eps_bearer_context_request(
     /* Send ACTIVATE DEFAULT EPS BEARER CONTEXT REQUEST
      * in ERAB SETUP REQ mesage
      */
-    rc =
-        default_eps_bearer_activate_in_bearer_setup_req(emm_context, ebi, msg);
+    rc = default_eps_bearer_activate_in_bearer_setup_req(emm_context, ebi, msg);
   } else {
     OAILOG_INFO(
         LOG_NAS_ESM,

--- a/lte/gateway/c/oai/tasks/nas/nas_procedures.c
+++ b/lte/gateway/c/oai/tasks/nas/nas_procedures.c
@@ -585,8 +585,10 @@ nas_emm_attach_proc_t* nas_new_attach_procedure(
             ->mme_ue_s1ap_id);
     return NULL;
   }
-  emm_context->emm_procedures->emm_specific_proc =
-      calloc(1, sizeof(nas_emm_attach_proc_t)); // NOLINT(clang-analyzer-unix.MallocSizeof)
+  emm_context->emm_procedures->emm_specific_proc = calloc(
+      1,
+      sizeof(
+          nas_emm_attach_proc_t));  // NOLINT(clang-analyzer-unix.MallocSizeof)
   emm_context->emm_procedures->emm_specific_proc->emm_proc.base_proc.nas_puid =
       __sync_fetch_and_add(&nas_puid, 1);
   emm_context->emm_procedures->emm_specific_proc->emm_proc.base_proc.type =
@@ -621,8 +623,9 @@ nas_emm_tau_proc_t* nas_new_tau_procedure(
             ->mme_ue_s1ap_id);
     return NULL;
   }
-  emm_context->emm_procedures->emm_specific_proc =
-      calloc(1, sizeof(nas_emm_tau_proc_t)); // NOLINT(clang-analyzer-unix.MallocSizeof)
+  emm_context->emm_procedures->emm_specific_proc = calloc(
+      1,
+      sizeof(nas_emm_tau_proc_t));  // NOLINT(clang-analyzer-unix.MallocSizeof)
   emm_context->emm_procedures->emm_specific_proc->emm_proc.base_proc.nas_puid =
       __sync_fetch_and_add(&nas_puid, 1);
   emm_context->emm_procedures->emm_specific_proc->emm_proc.base_proc.type =
@@ -655,8 +658,8 @@ nas_sr_proc_t* nas_new_service_request_procedure(
             ->mme_ue_s1ap_id);
     return NULL;
   }
-  emm_context->emm_procedures->emm_con_mngt_proc =
-      calloc(1, sizeof(nas_sr_proc_t)); // NOLINT(clang-analyzer-unix.MallocSizeof)
+  emm_context->emm_procedures->emm_con_mngt_proc = calloc(
+      1, sizeof(nas_sr_proc_t));  // NOLINT(clang-analyzer-unix.MallocSizeof)
   emm_context->emm_procedures->emm_con_mngt_proc->emm_proc.base_proc.nas_puid =
       __sync_fetch_and_add(&nas_puid, 1);
   emm_context->emm_procedures->emm_con_mngt_proc->emm_proc.base_proc.type =

--- a/lte/gateway/c/oai/tasks/nas/nas_state_converter.cpp
+++ b/lte/gateway/c/oai/tasks/nas/nas_state_converter.cpp
@@ -1124,8 +1124,11 @@ void NasStateConverter::proto_to_emm_specific_proc(
   switch (proto_emm_proc_with_type.MessageTypes_case()) {
     case oai::NasEmmProcWithType::kAttachProc: {
       OAILOG_DEBUG(LOG_MME_APP, "Reading attach proc from proto");
-      state_emm_procedures->emm_specific_proc =
-          (nas_emm_specific_proc_t*) calloc(1, sizeof(nas_emm_attach_proc_t)); // NOLINT(clang-analyzer-unix.MallocSizeof)
+      state_emm_procedures
+          ->emm_specific_proc = (nas_emm_specific_proc_t*) calloc(
+          1,
+          sizeof(
+              nas_emm_attach_proc_t));  // NOLINT(clang-analyzer-unix.MallocSizeof)
       nas_emm_attach_proc_t* attach_proc =
           (nas_emm_attach_proc_t*) state_emm_procedures->emm_specific_proc;
 
@@ -1138,8 +1141,11 @@ void NasStateConverter::proto_to_emm_specific_proc(
       break;
     }
     case oai::NasEmmProcWithType::kDetachProc: {
-      state_emm_procedures->emm_specific_proc =
-          (nas_emm_specific_proc_t*) calloc(1, sizeof(nas_emm_detach_proc_t)); // NOLINT(clang-analyzer-unix.MallocSizeof)
+      state_emm_procedures
+          ->emm_specific_proc = (nas_emm_specific_proc_t*) calloc(
+          1,
+          sizeof(
+              nas_emm_detach_proc_t));  // NOLINT(clang-analyzer-unix.MallocSizeof)
       nas_emm_detach_proc_t* detach_proc =
           (nas_emm_detach_proc_t*) state_emm_procedures->emm_specific_proc;
       // read the emm proc content


### PR DESCRIPTION
## Summary

A recent change (#5590) seems to have inadvertently changed formatting
for a number of OAI-related files. This causes noise when building OAI
inside the dev VM (`make build_oai`). This change reflects the output of
the format step from the build process.

Signed-off-by: Shaddi Hasan <shasan@fb.com>

## Test Plan

`make build_oai`, CI