### PR TITLE
[LTE][threads] Use meaningful names for mme threads

### DIFF
--- a/lte/gateway/c/oai/lib/itti/intertask_interface.c
+++ b/lte/gateway/c/oai/lib/itti/intertask_interface.c
@@ -326,10 +326,8 @@ int itti_create_task(
       result >= 0, "Thread creation for task %d, thread %d failed (%d)!\n",
       task_id, thread_id, result);
 
-  char name[16];
-
-  snprintf(name, sizeof(name), "ITTI %d", thread_id);
-  pthread_setname_np(itti_desc.threads[thread_id].task_thread, name);
+  pthread_setname_np(
+      itti_desc.threads[thread_id].task_thread, itti_get_task_name(task_id));
   itti_desc.created_tasks++;
 
   // Wait till the thread is completely ready


### PR DESCRIPTION
Signed-off-by: Tariq Al-Khasib <talkhasib@fb.com>

## Summary

Use the task name as the thread name for easier identification of threads
Other threads that exist and not have nice names
1- zmq internal threads are all named "mme". Changing this is supported on CZMQ master, not in the stable release yet
2- Few grpc threads have hard coded names by grpc

## Test Plan
Build on VM and check thread names using "top" command
![tasks](https://user-images.githubusercontent.com/23385821/113030188-2e902600-9142-11eb-966e-b21e9c431ceb.png)
