### PR TITLE
AGW: MME: add mac header to L3 packets

### DIFF
--- a/lte/gateway/c/oai/lib/openflow/controller/GTPApplication.cpp
+++ b/lte/gateway/c/oai/lib/openflow/controller/GTPApplication.cpp
@@ -377,6 +377,10 @@ void GTPApplication::add_tunnel_flow_action(
   of13::SetFieldAction set_tunnel_port(new of13::NXMReg8(gtp_port));
   apply_dl_inst.add_action(set_tunnel_port);
 
+  EthAddress uplink_port(uplink_mac_);
+  of13::SetFieldAction set_eth_dst(new of13::EthDst(uplink_port));
+  apply_dl_inst.add_action(set_eth_dst);
+
   if (passthrough) {
     // Set register6, this is pipelineD internal details.
     // Once GTP app is moved to pipelineD we can remove this hack.


### PR DESCRIPTION
This makes OVS happily remove the L2 header on egress and avoid
crash.

Signed-off-by: Pravin B Shelar <pbshelar@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
