### PR TITLE
Add CircleCI jobs to run AGW C/C++ unit tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,6 +17,10 @@ aliases:
     paths: "orc8r lte"
   - &c_cpp_build_verify
     paths: "orc8r/gateway/c orc8r/protos lte/gateway/c lte/protos"
+  - &session_manager_build_verify
+    paths: "orc8r/gateway/c orc8r/protos lte/gateway/c/session_manager lte/protos"
+  - &mme_build_verify
+    paths: "orc8r/gateway/c orc8r/protos lte/gateway/c/oai lte/gateway/c/sctpd lte/protos"
   - &federated_build_verify
     paths: "orc8r lte feg"
   - &all_gateways_build_verify
@@ -802,6 +806,63 @@ jobs:
             docker run $ci_env -e CI=true -v /home/circleci/project:/magma -v /home/circleci/project/lte/gateway/configs:/etc/magma -i -t magma/c_cpp_build:latest /bin/bash -c "cd /magma/lte/gateway;make coverage;ls -al /tmp/;bash <(curl -s https://codecov.io/bash) -f /build/c/coverage.info -F c_cpp"
       - magma_slack_notify
 
+  session_manager_test:
+    machine:
+      image: ubuntu-2004:202010-01
+      docker_layer_caching: true
+    resource_class: large
+    environment:
+      MAGMA_ROOT: /home/circleci/project
+    steps:
+      - checkout
+      - build/determinator:
+          <<: *session_manager_build_verify
+      - run:
+          name: Build the base c/c++ container
+          command: |
+            cd $MAGMA_ROOT/lte/gateway/docker/mme
+            docker build -t magma/c_cpp_build -f Dockerfile.ubuntu20.04 ../../../../
+      - run:
+          name: Run common tests
+          command: |
+            docker run -v /home/circleci/project:/magma -v /home/circleci/project/lte/gateway/configs:/etc/magma -i -t magma/c_cpp_build:latest /bin/bash -c "cd /magma/lte/gateway;make test_common;"
+      - run:
+          name: Run session_manager tests
+          command: |
+            docker run -v /home/circleci/project:/magma -v /home/circleci/project/lte/gateway/configs:/etc/magma -i -t magma/c_cpp_build:latest /bin/bash -c "cd /magma/lte/gateway;make test_session_manager;"
+          no_output_timeout: 5m
+      - magma_slack_notify
+
+  mme_test:
+    machine:
+      image: ubuntu-2004:202010-01
+      docker_layer_caching: true
+    resource_class: large
+    environment:
+      MAGMA_ROOT: /home/circleci/project
+    steps:
+      - checkout
+      - build/determinator:
+          <<: *mme_build_verify
+      - run:
+          name: Build the base c/c++ container
+          command: |
+            cd $MAGMA_ROOT/lte/gateway/docker/mme
+            docker build -t magma/c_cpp_build -f Dockerfile.ubuntu20.04 ../../../../
+      - run:
+          name: Run common tests
+          command: |
+            docker run -v /home/circleci/project:/magma -v /home/circleci/project/lte/gateway/configs:/etc/magma -i -t magma/c_cpp_build:latest /bin/bash -c "cd /magma/lte/gateway;make test_common;"
+      - run:
+          name: Run sctpd tests
+          command: |
+            docker run -v /home/circleci/project:/magma -v /home/circleci/project/lte/gateway/configs:/etc/magma -i -t magma/c_cpp_build:latest /bin/bash -c "cd /magma/lte/gateway;make test_sctpd;"
+      - run:
+          name: Run mme tests
+          command: |
+            docker run -v /home/circleci/project:/magma -v /home/circleci/project/lte/gateway/configs:/etc/magma -i -t magma/c_cpp_build:latest /bin/bash -c "cd /magma/lte/gateway;make test_oai;"
+      - magma_slack_notify
+
   mme-clang-warnings:
     machine:
       image: ubuntu-2004:202010-01
@@ -1192,6 +1253,8 @@ workflows:
   agw:
     jobs:
       - lte-test
+      - session_manager_test
+      - mme_test
       - mme-clang-tidy:
           <<: *only_master
       - mme-clang-warnings:
@@ -1201,6 +1264,8 @@ workflows:
       - lte-agw-deploy:
           <<: *only_master
           requires:
+            - lte-test
+            - mme_test
             - lte-integ-test
       - c-cpp-codecov
 


### PR DESCRIPTION
<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary
Added 2 new required jobs
* `session_manager_test`
  * ~7-15 minutes
  * Only triggered on the following directories `orc8r/gateway/c orc8r/protos lte/gateway/c/session_manager lte/protos`
  * Runs both common and session_manager tests in separate steps
  * Ex: https://app.circleci.com/pipelines/github/magma/magma/18119/workflows/c4b74884-0ef6-4836-aff0-755f4a8e1c17/jobs/174628
* `mme_test` 
  * ~15 minutes
  * Only triggered on the following directories `orc8r/gateway/c orc8r/protos lte/gateway/c/oai lte/gateway/c/sctpd lte/protos`
  * Runs both common, oai, sctpd tests in separate steps
  * Ex: https://app.circleci.com/pipelines/github/magma/magma/18119/workflows/c4b74884-0ef6-4836-aff0-755f4a8e1c17/jobs/174628) 
<img width="347" alt="Screen Shot 2021-03-31 at 10 59 01 AM" src="https://user-images.githubusercontent.com/37634144/113174568-1edf1300-9210-11eb-8979-9c5560666cac.png">

## Note
One minor concern is that sessiond_integ_test (2 slightly involved tests that bring up most GRPC servers and clients, etc.) can be flaky. However, this job should not affect non-sessiond/c-agw changes. If the flakiness becomes a problem, we can disable the specific test until we find a solution. (One potential solution for making the tests more portable is tracked here: https://github.com/magma/magma/issues/5531)

## Future nice-to-haves
* Would be great to figure out test summary uploads for these tests. This will enable test result analysis over time.

## Test Plan
Job fails if I force a test to fail: https://app.circleci.com/pipelines/github/magma/magma/18119/workflows/c4b74884-0ef6-4836-aff0-755f4a8e1c17/jobs/174628

<img width="1370" alt="Screen Shot 2021-03-31 at 9 59 58 AM" src="https://user-images.githubusercontent.com/37634144/113165864-e0ddf100-9207-11eb-8829-13525a043a80.png">

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->

