### PR TITLE
[Orc8r] Add post deployment checks to orcl

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -103,3 +103,6 @@ fb
 orc8r/cloud/coverage/
 feg/gateway/coverage/
 lte/gateway/c/oai/code_coverage/
+
+# go modules
+pkg/mod

--- a/orc8r/cloud/deploy/orc8r_deployer/docker/Dockerfile
+++ b/orc8r/cloud/deploy/orc8r_deployer/docker/Dockerfile
@@ -61,6 +61,7 @@ RUN pip3 install .
 # in the deployment directory even when container is removed
 ENV AWS_CONFIG_FILE=/root/project/.aws/config
 ENV AWS_SHARED_CREDENTIALS_FILE=/root/project/.aws/credentials
+ENV AWS_DEFAULT_OUTPUT=json
 
 WORKDIR /root/project
 CMD ["/bin/bash"]

--- a/orc8r/cloud/deploy/orc8r_deployer/docker/Dockerfile
+++ b/orc8r/cloud/deploy/orc8r_deployer/docker/Dockerfile
@@ -1,0 +1,66 @@
+FROM python:3.9-slim-buster
+
+ARG HELM_VERSION="3.5.1"
+ARG TERRAFORM_VERSION="0.14.7"
+ARG KUBECTL_VERSION="1.20.2"
+ARG ANSIBLE_VERSION="3.0.0"
+
+RUN apt-get update && \
+    apt-get upgrade -y && \
+    apt-get install -y \
+            git \
+            wget \
+            unzip \
+            curl \
+            vim && \
+    apt-get clean -y && \
+    apt-get autoclean -y && \
+    apt-get autoremove -y && \
+    rm -rf /var/lib/apt/lists/* && \
+    rm -rf /var/cache/apt/archives/*
+
+RUN pip3 install --no-cache-dir \
+                        boto3 \
+                        ansible==${ANSIBLE_VERSION} \
+                        prettytable \
+                        requests \
+                        docker \
+                        pyOpenSSL \
+                        unittest2
+WORKDIR /root/download
+
+# Install aws cli
+RUN wget "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -O "/root/download/awscli2.zip" && \
+    unzip awscli2.zip && \
+    ./aws/install
+
+# Install aws iam authenticator
+RUN wget https://amazon-eks.s3.us-west-2.amazonaws.com/1.18.9/2020-11-02/bin/linux/amd64/aws-iam-authenticator -O /usr/local/bin/aws-iam-authenticator && \
+    chmod +x /usr/local/bin/aws-iam-authenticator
+
+# Install helm
+RUN mkdir helm3 && \
+    curl -SsL --retry 5 "https://get.helm.sh/helm-v$HELM_VERSION-linux-amd64.tar.gz" | tar xz -C ./helm3 && \
+    cp /root/download/helm3/linux-amd64/helm /usr/local/bin/helm
+
+# Install terraform
+RUN wget https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform\_${TERRAFORM_VERSION}\_linux_amd64.zip && \
+    unzip ./terraform\_${TERRAFORM_VERSION}\_linux_amd64.zip -d terraform14_cli && \
+    cp /root/download/terraform14_cli/terraform /usr/local/bin/terraform && \
+    wget https://storage.googleapis.com/kubernetes-release/release/v$KUBECTL_VERSION/bin/linux/amd64/kubectl -O /usr/local/bin/kubectl && \
+    chmod +x /usr/local/bin/kubectl && \
+    rm -rf /root/download/*
+
+COPY root/ /root/
+
+# Install the orc8r cli(orcl)
+WORKDIR /root/scripts
+RUN pip3 install .
+
+# Set these environment variables to ensure aws configuration remains
+# in the deployment directory even when container is removed
+ENV AWS_CONFIG_FILE=/root/project/.aws/config
+ENV AWS_SHARED_CREDENTIALS_FILE=/root/project/.aws/credentials
+
+WORKDIR /root/project
+CMD ["/bin/bash"]

--- a/orc8r/cloud/deploy/orc8r_deployer/docker/Dockerfile
+++ b/orc8r/cloud/deploy/orc8r_deployer/docker/Dockerfile
@@ -12,7 +12,8 @@ RUN apt-get update && \
             wget \
             unzip \
             curl \
-            vim && \
+            vim \
+            jq && \
     apt-get clean -y && \
     apt-get autoclean -y && \
     apt-get autoremove -y && \

--- a/orc8r/cloud/deploy/orc8r_deployer/docker/README.md
+++ b/orc8r/cloud/deploy/orc8r_deployer/docker/README.md
@@ -1,0 +1,252 @@
+# Orc8r Deployer
+
+Orc8r deployer is a docker image which contains all the necessary prerequisites to deploy orc8r. This docker image ships with orc8r deployer cli(orcl) which enables a user to configure, run installation prechecks, run upgrade prechecks, run post deployment checks and finally perform deployment cleanup if necessary.
+(note: this tool is still in development)
+
+## Requirements
+
+The host machine must have docker engine installed.
+
+## Usage
+
+```
+./run_deployer -d <deploy_dir>
+-d - deployment directory containing config and secrets
+-b - build the deployer image(optional)
+-r - magma root directory (optional)
+```
+
+Deployment directory initially can either be empty or can contain config files. Once configured, the deployment directory will contain config and secrets directory.
+
+Config directory will contain the terraform config files.
+
+* infra.tfvars.json - configuration
+* platform.tfvars.json
+* service.tfvars.json
+
+Secrets directory will contain the certificates generated through the cli.
+
+### Orc8r Deployer CLI (orcl)
+
+```
+# orcl --help
+Usage: orcl [OPTIONS] COMMAND [ARGS]...
+
+  Orchestrator Deployment CLI
+
+Options:
+  --version  Show the version and exit.
+  --help     Show this message and exit.
+
+Commands:
+  configure  Configure enables user to configure values needed for Orc8r...
+  install    Install command enables user to run subcommands in context of...
+```
+
+**orcl configure**
+
+```
+# orcl configure --help
+Usage: orcl configure [OPTIONS] COMMAND [ARGS]...
+
+  Configure enables user to configure values needed for Orc8r deployment. It
+  additionally provides subcommands to see configured values, check if all
+  required values are configured and finally provide detailed description on
+  all options available to be configured
+
+Options:
+  -c, --component [infra|platform|service]
+  --help                          Show this message and exit.
+
+Commands:
+  check
+  info
+  set
+  show
+```
+
+
+**orcl install**
+
+```
+# orcl install --help
+Usage: orcl install [OPTIONS] COMMAND [ARGS]...
+
+  Install command enables user to run subcommands in context of Orc8r
+  installation. It provides subcommands like - precheck which runs various
+  checks to ensure successful installation - addcerts which lets user create
+  certificates for the installation
+
+Options:
+  --help  Show this message and exit.
+
+Commands:
+  addcerts
+  precheck
+```
+
+## Work done so far
+
+* Docker image containing all pre reqs necessary for Orc8r deployment
+* Configuration tool which enables
+    * user to configure infra, platform and services
+    * See the local configuration
+    * View the detail information about all config knobs available
+    * check if all required values are present
+* Ability to add secrets (copied existing ansible script from cloudstrapper)
+    * option to skip self signed certs
+* scripts to perform installation prechecks
+    * Infra
+        * Check if all mandatory infra values have been configured
+        * Check if we have atleast 3 availabiliity zones
+        * Check if secrets manager secrets exists
+    * Platform
+        * Check if all mandatory platform values have been configured
+        * Check if cloud watch related log groups are present
+    * Service
+        * Check if all mandatory service values have been configured
+        * Check if Orc8r deployment type is valid
+        * Check if helm repo is valid and it contains helm charts of right version and matches the deployment requirements
+        * Check if docker repo is valid and if it contains images with expected tags
+
+## Examples
+
+### CLI configure examples:
+
+```
+root@f6664a7e4de7:~/project# orcl configure -c platform
+Configuring platform deployment variables
+
+nms_db_password[password1234]:
+orc8r_db_password[password1234]:
+
+root@1233a8960a8e:~/project# orcl configure set
+component to configure (infra, platform, service): infra
+name of the variable: cluster_name
+value of the variable: foobar
+
+root@f6664a7e4de7:~/project# orcl configure check -c platform
+Checking platform deployment variables
+
+root@f6664a7e4de7:~/project# orcl configure show -c platform
+platform Configuration
++-------------------+---------------+
+| Name              | Configuration |
++-------------------+---------------+
+| nms_db_password   | password1234  |
+| orc8r_db_password | password1234  |
++-------------------+---------------+
+
+root@f6664a7e4de7:~/project# orcl configure info -c platform
+platform Configuration Options
++------------------------------------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------+--------+----------+-----------+
+| Name                                     | Description                                                                                                                                                                 | Type   | Required | Component |
++------------------------------------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------+--------+----------+-----------+
+| deploy_elasticsearch                     | Flag to deploy AWS Elasticsearch service as the datasink for aggregated logs.                                                                                               | bool   | False    | tf        |
+| deploy_elasticsearch_service_linked_role |  Flag to deploy AWS Elasticsearch service linked role with cluster. If you've already created an ES service linked role for another cluster, you should set this to false.  | bool   | False    | tf        |
+| efs_project_name                         | Project name for EFS file system                                                                                                                                            | string | False    | tf        |
+| elasticsearch_az_count                   | AZ count for ES.                                                                                                                                                            | number | False    | tf        |
+| elasticsearch_dedicated_master_count     | Number of dedicated ES master nodes.                                                                                                                                        | number | False    | tf        |
+| elasticsearch_dedicated_master_enabled   | Enable/disable dedicated master nodes for ES.                                                                                                                               | bool   | False    | tf        |
+| elasticsearch_dedicated_master_type      | Instance type for ES dedicated master nodes.                                                                                                                                | string | False    | tf        |
+| elasticsearch_domain_name                | Name for the ES domain.                                                                                                                                                     | string | False    | tf        |
+| elasticsearch_domain_tags                | Extra tags for the ES domain.                                                                                                                                               | map    | False    | tf        |
+| elasticsearch_ebs_enabled                | Use EBS for ES storage.                                                                                                                                                     | bool   | False    | tf        |
+| elasticsearch_ebs_iops                   | IOPS for ES EBS volumes.                                                                                                                                                    | number | False    | tf        |
+| elasticsearch_ebs_volume_size            | Size in GB to allocate for ES EBS data volumes.                                                                                                                             | number | False    | tf        |
+| elasticsearch_ebs_volume_type            | EBS volume type for ES data volumes.                                                                                                                                        | string | False    | tf        |
+| elasticsearch_instance_count             | Number of instances to allocate for ES domain.                                                                                                                              | number | False    | tf        |
+| elasticsearch_instance_type              | AWS instance type for ES domain.                                                                                                                                            | string | False    | tf        |
+| elasticsearch_version                    | ES version for ES domain.                                                                                                                                                   | string | False    | tf        |
+| global_tags                              | n/a                                                                                                                                                                         | map    | False    | tf        |
+| nms_db_engine_version                    | MySQL engine version for NMS DB.                                                                                                                                            | string | False    | tf        |
+| nms_db_identifier                        | Identifier for the RDS instance for NMS.                                                                                                                                    | string | False    | tf        |
+| nms_db_instance_class                    | RDS instance type for NMS DB.                                                                                                                                               | string | False    | tf        |
+| nms_db_name                              | DB name for NMS RDS instance.                                                                                                                                               | string | False    | tf        |
+| nms_db_password                          | Password for the NMS DB.                                                                                                                                                    | string | True     | tf        |
+| nms_db_storage_gb                        | Capacity in GB to allocate for NMS RDS instance.                                                                                                                            | number | False    | tf        |
+| nms_db_username                          | Username for default DB user for NMS DB.                                                                                                                                    | string | False    | tf        |
+| orc8r_db_engine_version                  | Postgres engine version for Orchestrator DB.                                                                                                                                | string | False    | tf        |
+| orc8r_db_identifier                      | Identifier for the RDS instance for Orchestrator.                                                                                                                           | string | False    | tf        |
+| orc8r_db_instance_class                  | RDS instance type for Orchestrator DB.                                                                                                                                      | string | False    | tf        |
+| orc8r_db_name                            | DB name for Orchestrator RDS instance.                                                                                                                                      | string | False    | tf        |
+| orc8r_db_password                        | Password for the Orchestrator DB.                                                                                                                                           | string | True     | tf        |
+| orc8r_db_storage_gb                      | Capacity in GB to allocate for Orchestrator RDS instance.                                                                                                                   | number | False    | tf        |
+| orc8r_db_username                        | Username for default DB user for Orchestrator DB.                                                                                                                           | string | False    | tf        |
++------------------------------------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------+--------+----------+-----------+
+
+
+```
+
+
+
+### CLI install example:
+
+```
+root@f6664a7e4de7:~/project# orcl install precheck
+[WARNING]: No inventory was parsed, only implicit localhost is available
+[WARNING]: provided hosts list is empty, only localhost is available. Note that
+the implicit localhost does not match 'all'
+['No config file found; using defaults',
+ '',
+ 'PLAY [localhost] '
+ '***************************************************************',
+ '',
+ 'TASK [infra : check if required infra variables are set] '
+ '***********************',
+ 'changed: [localhost] => {"changed": true, "cmd": ["orcl", "configure", '
+ '"check", "-c", "infra"], "delta": "0:00:00.155063", "end": "2021-03-26 '
+ '02:30:14.708979", "failed_when_result": false, "rc": 0, "start": "2021-03-26 '
+ '02:30:14.553916", "stderr": "", "stderr_lines": [], "stdout": "Checking '
+ 'infra deployment variables", "stdout_lines": ["Checking infra deployment '
+ 'variables"]}',
+ '',
+ 'TASK [infra : Open configuration file] '
+ '*****************************************',
+ 'changed: [localhost] => {"changed": true, "cmd": "cat '
+ '/root/project/configs/infra.tfvars.json", "delta": "0:00:00.004723", "end": '
+ '"2021-03-26 02:30:14.903529", "rc": 0, "start": "2021-03-26 '
+
+ root@f6664a7e4de7:~/project# orcl install addcerts
+[WARNING]: No inventory was parsed, only implicit localhost is available
+[WARNING]: provided hosts list is empty, only localhost is available. Note that
+the implicit localhost does not match 'all'
+['No config file found; using defaults',
+```
+
+## Terraform Installation
+
+Currently terraform installation is still manual. All configuration values are pushed into ‘terraform.tfvars.json’ which is automatically loaded by terraform.
+
+```
+cd /root/project
+
+# initialize terraform
+terraform init
+
+# bring up infra and platform resources
+`terraform apply ``-``target``=``module``.``orc8r`
+`export`` KUBECONFIG``=``$``(``realpath kubeconfig_orc8r``)`
+
+`# seed the certificates`
+`terraform apply ``-``target``=``module``.``orc8r``-``app``.``null_resource``.``orc8r_seed_secrets `
+
+# bring up the orc8r services
+`terraform apply`
+
+```
+
+## Tasks Remaining
+
+* Adding upgrade prechecks
+* Adding post deployment checks
+* Adding deployment cleanup
+* Automating installation
+
+## Note:
+
+* vars.yml - currently a static file which holds all the configuration variables. It contains variables to be configured for AWS and terraform. It could be generated when we are able to parse the tf files to JSON. That’s probably the next step once the tool changes are complete.
+* main.tf.j2 and vars.tf.j2 are the jinja templates for main terraform and variable terraform file. It is mainly templatized to include the configurable variables added.
+
+
+

--- a/orc8r/cloud/deploy/orc8r_deployer/docker/root/config.yml
+++ b/orc8r/cloud/deploy/orc8r_deployer/docker/root/config.yml
@@ -1,0 +1,17 @@
+project_dir: /root/project
+config_dir: /root/project/configs
+secret_dir: /root/project/secrets
+scripts_dir: /root/scripts
+tf_dir: /root/tf
+main_tf: /root/project/main.tf
+vars_tf: /root/project/vars.tf
+auto_tf: /root/project/terraform.tfvars.json
+data_dir: /root/data
+magma_root: /root/magma
+vars_definition: /root/data/vars.yml
+playbooks: /root/scripts/playbooks
+
+components:
+  - infra
+  - platform
+  - service

--- a/orc8r/cloud/deploy/orc8r_deployer/docker/root/data/vars.yml
+++ b/orc8r/cloud/deploy/orc8r_deployer/docker/root/data/vars.yml
@@ -1,0 +1,530 @@
+infra:
+   aws_access_key_id:
+      Description:  AWS access key id.
+      Type: string
+      Required:  true
+      ConfigApps:
+        -awscli
+   aws_secret_access_key:
+      Description:  AWS access secret.
+      Type: string
+      Required:  true
+      ConfigApps:
+        -awscli
+   region:
+      Description:  AWS region to deploy Orchestrator components into. The chosen region must provide EKS.
+      Type: string
+      Required:  true
+      ConfigApps:
+        -awscli
+        -tf
+   cluster_name:
+      Description:  Name for the Orchestrator EKS cluster.
+      Type:  string
+      Required:  false
+      Default: "orc8r"
+      ConfigApps:
+        -tf
+   eks_map_roles:
+      Description:  EKS IAM role mapping. Note that by default, the creator of the cluster will be in the system:master group.
+      Type: list(object({rolearn  = string, username = string, groups   = list(string), }))
+      Required:  false
+      ConfigApps:
+        -tf
+   eks_map_users:
+      Description:  Additional IAM users to add to the aws-auth ConfigMap.
+      Type: list(object({userarn  = string, username = string, groups   = list(string)}))
+      Required:  false
+      ConfigApps:
+        -tf
+   eks_worker_additional_policy_arns:
+      Description:  Additional IAM policy ARNs to attach to EKS worker nodes.
+      Type:  list(string)
+      Required:  false
+      ConfigApps:
+        -tf
+   eks_worker_additional_sg_ids:
+      Description:  Additional security group IDs to attach to EKS worker nodes.
+      Type:  list(string)
+      Required:  false
+      ConfigApps:
+        -tf
+   eks_worker_group_key:
+      Description:  If specified, the worker nodes for EKS will use this EC2 keypair.
+      Type:  string
+      Required:  false
+      ConfigApps:
+        -tf
+   eks_worker_groups:
+      Description:  Worker group configuration for EKS. Default value is 1 worker group consisting of 3 t3.large instances.
+      Type:  any
+      Required:  false
+      ConfigApps:
+        -tf
+   vpc_cidr:
+      Description:  CIDR block for the VPC.
+      Type:  string
+      Required:  false
+      ConfigApps:
+        -tf
+   vpc_database_subnets:
+      Description: ' CIDR blocks for the VPC''s database subnets. '
+      Type:  list(string)
+      Required:  false
+      ConfigApps:
+        -tf
+   vpc_extra_tags:
+      Description:  Tags to add to the VPC.
+      Type:  map
+      Required:  false
+      ConfigApps:
+        -tf
+   vpc_name:
+      Description:  Name for the VPC that will contain all the Orchestrator components.
+      Type:  string
+      Required:  false
+      ConfigApps:
+        -tf
+   vpc_private_subnets:
+      Description: ' CIDR blocks for the VPC''s private subnets. '
+      Type:  list(string)
+      Required:  false
+      ConfigApps:
+        -tf
+   vpc_public_subnets:
+      Description: ' CIDR blocks for the VPC''s public subnets. '
+      Type:  list(string)
+      Required:  false
+      ConfigApps:
+        -tf
+   orc8r_domain_name:
+      Description:  Base domain name for AWS Route 53 hosted zone.
+      Type:  string
+      Required:  true
+      ConfigApps:
+        -tf
+   secretsmanager_orc8r_secret:
+      Description:  AWS Secret Manager secret to store Orchestrator secrets.
+      Type:  string
+      Required:  true
+      ConfigApps:
+        -tf
+
+platform:
+   deploy_elasticsearch:
+      Description:  Flag to deploy AWS Elasticsearch service as the datasink for aggregated logs.
+      Type:  bool
+      Required:  false
+      ConfigApps:
+        -tf
+   deploy_elasticsearch_service_linked_role:
+      Description: ' Flag to deploy AWS Elasticsearch service linked role with cluster. If you''ve already created an ES service linked role for another cluster, you should set this to false. '
+      Type:  bool
+      Required:  false
+      ConfigApps:
+        -tf
+   efs_project_name:
+      Description:  Project name for EFS file system
+      Type:  string
+      Required:  false
+      ConfigApps:
+        -tf
+   elasticsearch_az_count:
+      Description:  AZ count for ES.
+      Type:  number
+      Required:  false
+      ConfigApps:
+        -tf
+   elasticsearch_dedicated_master_count:
+      Description:  Number of dedicated ES master nodes.
+      Type:  number
+      Required:  false
+      ConfigApps:
+        -tf
+   elasticsearch_dedicated_master_enabled:
+      Description:  Enable/disable dedicated master nodes for ES.
+      Type:  bool
+      Required:  false
+      ConfigApps:
+        -tf
+   elasticsearch_dedicated_master_type:
+      Description:  Instance type for ES dedicated master nodes.
+      Type:  string
+      Required:  false
+      ConfigApps:
+        -tf
+   elasticsearch_domain_name:
+      Description:  Name for the ES domain.
+      Type:  string
+      Required:  false
+      ConfigApps:
+        -tf
+   elasticsearch_domain_tags:
+      Description:  Extra tags for the ES domain.
+      Type:  map
+      Required:  false
+      ConfigApps:
+        -tf
+   elasticsearch_ebs_enabled:
+      Description:  Use EBS for ES storage.
+      Type:  bool
+      Required:  false
+      ConfigApps:
+        -tf
+   elasticsearch_ebs_iops:
+      Description:  IOPS for ES EBS volumes.
+      Type:  number
+      Required:  false
+      ConfigApps:
+        -tf
+   elasticsearch_ebs_volume_size:
+      Description:  Size in GB to allocate for ES EBS data volumes.
+      Type:  number
+      Required:  false
+      ConfigApps:
+        -tf
+   elasticsearch_ebs_volume_type:
+      Description:  EBS volume type for ES data volumes.
+      Type:  string
+      Required:  false
+      ConfigApps:
+        -tf
+   elasticsearch_instance_count:
+      Description:  Number of instances to allocate for ES domain.
+      Type:  number
+      Required:  false
+      ConfigApps:
+        -tf
+   elasticsearch_instance_type:
+      Description:  AWS instance type for ES domain.
+      Type:  string
+      Required:  false
+      ConfigApps:
+        -tf
+   elasticsearch_version:
+      Description:  ES version for ES domain.
+      Type:  string
+      Required:  false
+      ConfigApps:
+        -tf
+   global_tags:
+      Description:  n/a
+      Type:  map
+      Required:  false
+      ConfigApps:
+        -tf
+   nms_db_engine_version:
+      Description:  MySQL engine version for NMS DB.
+      Type:  string
+      Required:  false
+      ConfigApps:
+        -tf
+   nms_db_identifier:
+      Description:  Identifier for the RDS instance for NMS.
+      Type:  string
+      Required:  false
+      ConfigApps:
+        -tf
+   nms_db_instance_class:
+      Description:  RDS instance type for NMS DB.
+      Type:  string
+      Required:  false
+      ConfigApps:
+        -tf
+   nms_db_name:
+      Description:  DB name for NMS RDS instance.
+      Type:  string
+      Required:  false
+      ConfigApps:
+        -tf
+   nms_db_password:
+      Description:  Password for the NMS DB.
+      Type:  string
+      Required:  true
+      ConfigApps:
+        -tf
+   nms_db_storage_gb:
+      Description:  Capacity in GB to allocate for NMS RDS instance.
+      Type:  number
+      Required:  false
+      ConfigApps:
+        -tf
+   nms_db_username:
+      Description:  Username for default DB user for NMS DB.
+      Type:  string
+      Required:  false
+      ConfigApps:
+        -tf
+   orc8r_db_engine_version:
+      Description:  Postgres engine version for Orchestrator DB.
+      Type:  string
+      Required:  false
+      ConfigApps:
+        -tf
+   orc8r_db_identifier:
+      Description:  Identifier for the RDS instance for Orchestrator.
+      Type:  string
+      Required:  false
+      ConfigApps:
+        -tf
+   orc8r_db_instance_class:
+      Description:  RDS instance type for Orchestrator DB.
+      Type:  string
+      Required:  false
+      ConfigApps:
+        -tf
+   orc8r_db_name:
+      Description:  DB name for Orchestrator RDS instance.
+      Type:  string
+      Required:  false
+      ConfigApps:
+        -tf
+   orc8r_db_password:
+      Description:  Password for the Orchestrator DB.
+      Type:  string
+      Required:  true
+      ConfigApps:
+        -tf
+   orc8r_db_storage_gb:
+      Description:  Capacity in GB to allocate for Orchestrator RDS instance.
+      Type:  number
+      Required:  false
+      ConfigApps:
+        -tf
+   orc8r_db_username:
+      Description:  Username for default DB user for Orchestrator DB.
+      Type:  string
+      Required:  false
+      ConfigApps:
+        -tf
+service:
+   cwf_orc8r_chart_version:
+      Description:  Version of the Orchestrator cwf module Helm chart to install.
+      Type: string
+      Required:  false
+      ConfigApps:
+        -tf
+      Default: "0.2.1"
+   deploy_nms:
+      Description:  Flag to deploy NMS.
+      Type: bool
+      Required:  false
+      ConfigApps:
+        -tf
+   deploy_openvpn:
+      Description:  Flag to deploy OpenVPN server into cluster. This is useful if you want to remotely access AGWs.
+      Type: bool
+      Required:  false
+      ConfigApps:
+        -tf
+   docker_pass:
+      Description:  Docker registry password.
+      Type: string
+      Required:  true
+      ConfigApps:
+        -tf
+   docker_registry:
+      Description:  Docker registry to pull Orchestrator containers from.
+      Type: string
+      Required:  true
+      ConfigApps:
+        -tf
+   docker_user:
+      Description:  Docker username to login to registry with.
+      Type: string
+      Required:  true
+      ConfigApps:
+        -tf
+   efs_file_system_id:
+      Description:  ID of the EFS file system to use for K8s persistent volumes.
+      Type: string
+      Required:  false
+      ConfigApps:
+        -tf
+   efs_provisioner_role_arn:
+      Description:  ARN of the IAM role for the EFS provisioner.
+      Type: string
+      Required:  false
+      ConfigApps:
+        -tf
+   eks_cluster_id:
+      Description:  EKS cluster ID for the K8s cluster.
+      Type: string
+      Required:  false
+      ConfigApps:
+        -tf
+   elasticsearch_endpoint:
+      Description:  Endpoint of the Elasticsearch datasink for aggregated logs and events.
+      Type: string
+      Required:  false
+      ConfigApps:
+        -tf
+   elasticsearch_retention_days:
+      Description:  Retention period in days of Elasticsearch indices.
+      Type: number
+      Required:  false
+      ConfigApps:
+        -tf
+   existing_tiller_service_account_name:
+      Description:  Name of existing Tiller service account to use for Helm.
+      Type: string
+      Required:  false
+      ConfigApps:
+        -tf
+   external_dns_role_arn:
+      Description:  IAM role ARN for ExternalDNS.
+      Type: string
+      Required:  false
+      ConfigApps:
+        -tf
+   fbinternal_orc8r_chart_version:
+      Description:  Version of the Orchestrator fbinternal module Helm chart to install.
+      Type: string
+      Required:  false
+      ConfigApps:
+        -tf
+      Default: "0.2.1"
+   feg_orc8r_chart_version:
+      Description:  Version of the Orchestrator feg module Helm chart to install.
+      Type: string
+      Required:  false
+      ConfigApps:
+        -tf
+      Default: "0.2.2"
+   helm_deployment_name:
+      Description:  Name for the Helm release.
+      Type: string
+      Required:  false
+      ConfigApps:
+        -tf
+   helm_pass:
+      Description:  Helm repository password.
+      Type: string
+      Required:  true
+      ConfigApps:
+        -tf
+   helm_repo:
+      Description:  Helm repository URL for Orchestrator charts.
+      Type: string
+      Required:  true
+      ConfigApps:
+        -tf
+   helm_user:
+      Description:  Helm username to login to repository with.
+      Type: string
+      Required:  true
+      ConfigApps:
+        -tf
+   install_tiller:
+      Description:  Install Tiller in the cluster or not.
+      Type: bool
+      Required:  false
+      ConfigApps:
+        -tf
+   lte_orc8r_chart_version:
+      Description:  Version of the Orchestrator lte module Helm chart to install.
+      Type: string
+      Required:  false
+      ConfigApps:
+        -tf
+      Default: "0.2.4"
+   monitoring_kubernetes_namespace:
+      Description:  K8s namespace to install Orchestrator monitoring components into.
+      Type: string
+      Required:  false
+      ConfigApps:
+        -tf
+   orc8r_chart_version:
+      Description:  Version of the core Orchestrator Helm chart to install.
+      Type: string
+      Required:  false
+      ConfigApps:
+        -tf
+      Default: "1.5.18"
+   orc8r_controller_replicas:
+      Description:  Replica count for Orchestrator controller pods.
+      Type: number
+      Required:  false
+      ConfigApps:
+        -tf
+   orc8r_db_port:
+      Description:  DB port for Orchestrator database connection.
+      Type: number
+      Required:  false
+      ConfigApps:
+        -tf
+
+   orc8r_deployment_type:
+      Description:  Deployment type of Orchestrator (FWA, Federated FWA, ALL).
+      Type: string
+      Required:  true
+      ConfigApps:
+        -tf
+   orc8r_kubernetes_namespace:
+      Description:  K8s namespace to install main Orchestrator components into.
+      Type: string
+      Required:  false
+      ConfigApps:
+        -tf
+   orc8r_proxy_replicas:
+      Description:  Replica count for Orchestrator proxy pods.
+      Type: number
+      Required:  false
+      ConfigApps:
+        -tf
+   orc8r_route53_zone_id:
+      Description:  Route53 zone ID of Orchestrator domain name for ExternalDNS.
+      Type: string
+      Required:  false
+      ConfigApps:
+        -tf
+   orc8r_tag:
+      Description:  Image tag for Orchestrator components.
+      Type: string
+      Required:  true
+      ConfigApps:
+        -tf
+   secretsmanager_orc8r_name:
+      Description:  Name of the AWS Secrets Manager secret where Orchestrator deployment secrets will be stored.
+      Type: string
+      Required:  false
+      ConfigApps:
+        -tf
+   seed_certs_dir:
+      Description:  Directory on LOCAL disk where Orchestrator certificates are stored to seed Secrets Manager values. Home directory and env vars will be expanded.
+      Type: string
+      Required:  false
+      ConfigApps:
+        -tf
+   state_backend:
+      Description:  State backend for terraform (e.g. s3, local).
+      Type: string
+      Required:  false
+      ConfigApps:
+        -tf
+   state_config:
+      Description:  Optional config for state backend. The object type will depend on your backend.
+      Type: any
+      Required:  false
+      ConfigApps:
+        -tf
+   tiller_namespace:
+      Description:  Namespace where Tiller is installed or should be installed into.
+      Type: string
+      Required:  false
+      ConfigApps:
+        -tf
+   wifi_orc8r_chart_version:
+      Description:  Version of the Orchestrator wifi module Helm chart to install.
+      Type: string
+      Required:  false
+      ConfigApps:
+        -tf
+      Default: "0.2.1"
+   seed_certs_dir:
+      Description: Directory on LOCAL disk where Orchestrator certificates are stored to seed Secrets Manager values. Home directory and env vars will be expanded.
+      Type       : string
+      Required:  false
+      ConfigApps:
+        -tf
+      Default    : "/root/project/secrets"

--- a/orc8r/cloud/deploy/orc8r_deployer/docker/root/data/vars.yml
+++ b/orc8r/cloud/deploy/orc8r_deployer/docker/root/data/vars.yml
@@ -25,6 +25,13 @@ infra:
       Default: "orc8r"
       ConfigApps:
         -tf
+   cluster_version:
+      Description:  Kubernetes version for the EKS cluster
+      Type:  string
+      Required:  false
+      Default: "1.17"
+      ConfigApps:
+        -tf
    eks_map_roles:
       Description:  EKS IAM role mapping. Note that by default, the creator of the cluster will be in the system:master group.
       Type: list(object({rolearn  = string, username = string, groups   = list(string), }))
@@ -112,12 +119,14 @@ infra:
 
 platform:
    deploy_elasticsearch:
+      Default: true
       Description:  Flag to deploy AWS Elasticsearch service as the datasink for aggregated logs.
       Type:  bool
       Required:  false
       ConfigApps:
         -tf
    deploy_elasticsearch_service_linked_role:
+      Default: true
       Description: ' Flag to deploy AWS Elasticsearch service linked role with cluster. If you''ve already created an ES service linked role for another cluster, you should set this to false. '
       Type:  bool
       Required:  false
@@ -130,6 +139,7 @@ platform:
       ConfigApps:
         -tf
    elasticsearch_az_count:
+      Default: 2
       Description:  AZ count for ES.
       Type:  number
       Required:  false
@@ -154,6 +164,7 @@ platform:
       ConfigApps:
         -tf
    elasticsearch_domain_name:
+      Default: "orc8r-es"
       Description:  Name for the ES domain.
       Type:  string
       Required:  false
@@ -166,6 +177,7 @@ platform:
       ConfigApps:
         -tf
    elasticsearch_ebs_enabled:
+      Default: true
       Description:  Use EBS for ES storage.
       Type:  bool
       Required:  false
@@ -178,30 +190,35 @@ platform:
       ConfigApps:
         -tf
    elasticsearch_ebs_volume_size:
+      Default: 32
       Description:  Size in GB to allocate for ES EBS data volumes.
       Type:  number
       Required:  false
       ConfigApps:
         -tf
    elasticsearch_ebs_volume_type:
+      Default: gp2
       Description:  EBS volume type for ES data volumes.
       Type:  string
       Required:  false
       ConfigApps:
         -tf
    elasticsearch_instance_count:
+      Default: 2
       Description:  Number of instances to allocate for ES domain.
       Type:  number
       Required:  false
       ConfigApps:
         -tf
    elasticsearch_instance_type:
+      Default:  "t2.medium.elasticsearch"
       Description:  AWS instance type for ES domain.
       Type:  string
       Required:  false
       ConfigApps:
         -tf
    elasticsearch_version:
+      Default: "7.7"
       Description:  ES version for ES domain.
       Type:  string
       Required:  false
@@ -256,12 +273,14 @@ platform:
       ConfigApps:
         -tf
    orc8r_db_engine_version:
+      Default: "9.6.15"
       Description:  Postgres engine version for Orchestrator DB.
       Type:  string
       Required:  false
       ConfigApps:
         -tf
    orc8r_db_identifier:
+      Default: "orc8rdb"
       Description:  Identifier for the RDS instance for Orchestrator.
       Type:  string
       Required:  false

--- a/orc8r/cloud/deploy/orc8r_deployer/docker/root/scripts/configlib.py
+++ b/orc8r/cloud/deploy/orc8r_deployer/docker/root/scripts/configlib.py
@@ -1,0 +1,205 @@
+# Copyright 2021 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import sys
+import json
+import yaml
+import csv
+from subprocess import check_call, CalledProcessError
+from jinja2 import Environment, FileSystemLoader
+from prettytable import PrettyTable
+import click
+from jinja2 import Environment, PackageLoader
+
+def get_input(text):
+    return input(text)
+
+def get_json(fn: str) -> dict:
+    try:
+        with open(fn) as f:
+            return json.load(f)
+    except OSError:
+        pass
+    return {}
+
+def put_json(fn: str, cfgs: dict):
+    with open(fn, 'w') as outfile:
+        json.dump(cfgs, outfile)
+
+def add_pretty_table(fields, items):
+    table = PrettyTable()
+    table.field_names = fields
+    for field in fields:
+        table.align[field] = 'l'
+
+    for item in items:
+        table.add_row(item)
+    return table
+
+def render_j2_template(src_dir, dst_fn, cfg):
+    env = Environment(loader=FileSystemLoader(searchpath=src_dir))
+    fn = os.path.basename(dst_fn)
+    template = env.get_template('%s.j2' % fn)
+    try:
+        with open(dst_fn, "w") as f:
+            f.write(template.render(cfg=cfg))
+    except Exception as err:
+        click.echo("Error: %s rendering %s file " % (fn, repr(err)))
+
+class ConfigManager(object):
+    '''
+    ConfigManager manages the orcl configuration. It reads the variable
+    definitions during init and uses the information parsed to configure
+    the various component attributes.
+    Currently the variables are used to configure aws cli and
+    terraform.
+    '''
+    def _get_config_fn(self, component: str):
+        config_dir = self.constants['config_dir']
+        return "%s/%s.tfvars.json" % (config_dir, component)
+
+    def set(self, component: str, key: str, value: str):
+        click.echo("Setting key %s value %s for component %s" %
+                    (key, value, component))
+        cfgs = get_json(self._get_config_fn(component))
+        config_vars = self.config_vars[component]
+
+        if not config_vars.get(key):
+            click.echo("not a valid key")
+            return
+        cfgs[key] = value
+
+        self._configure_aws(component, cfgs)
+        self._configure_tf(component, cfgs)
+        put_json(self._get_config_fn(component), cfgs)
+
+    def configure(self, component: str):
+        click.echo("Configuring %s deployment variables\n" % component)
+        cfgs = self.configs[component]
+        # TODO: use a different yaml loader to ensure we load inorder
+        # sort the variables to group the inputs together
+        config_vars = self.config_vars[component].items()
+        for k, v in sorted(config_vars, key=lambda s: s[0]):
+            defaultValue = v.get('Default')
+            # add defaults to the json configs to ensure we can run prechecks
+            if defaultValue:
+                cfgs[k] = defaultValue
+                continue
+
+            if not v['Required']:
+                continue
+
+            v = cfgs.get(k)
+            if v:
+                inp = get_input('%s[%s]:' % (k, v))
+            else:
+                inp = get_input('%s:' % k)
+            if inp:
+                cfgs[k] = inp
+
+        self.configs[component] = cfgs
+        self._configure_aws(component, cfgs)
+        self._configure_tf(component, cfgs)
+        put_json(self._get_config_fn(component), cfgs)
+
+    def _configure_aws(self, component: str, cfgs: dict):
+        ''' configures aws cli with configuration '''
+        for k, v in cfgs.items():
+            if k in self.aws_vars:
+                check_call(["aws", "configure", "set", k, v])
+
+    def _configure_tf(self, component: str, cfgs: dict):
+        ''' updates the terraform auto configuration and main.tf '''
+        auto_tf = self.constants['auto_tf']
+        auto_cfgs = get_json(auto_tf)
+        for k, v in cfgs.items():
+            if k in self.tf_vars:
+                auto_cfgs[k] = v
+        put_json(auto_tf, auto_cfgs)
+
+        # render main.tf with terraform variables alone
+        tf_cfgs = {}
+        for component in self.configs:
+            tf_cfgs[component] = {}
+            for k, v in self.configs[component].items():
+                if k in self.tf_vars:
+                    tf_cfgs[component][k] = v
+
+        render_j2_template(
+            self.constants['tf_dir'],
+            self.constants['main_tf'],
+            tf_cfgs)
+        render_j2_template(
+            self.constants['tf_dir'],
+            self.constants['vars_tf'],
+            self.tf_vars)
+
+
+    def check(self, component: str) -> bool:
+        ''' check if all mandatory options of a specific component is set '''
+        click.echo("Checking %s deployment variables\n" % component)
+        cfgs = self.configs[component]
+        valid = True
+        for k, v in self.config_vars[component].items():
+            if v['Required'] and not cfgs.get(k):
+                click.echo("%s not configured\n" % k)
+                valid = False
+        return valid
+
+    def info(self, component: str):
+        ''' pretty click.echo vars yml '''
+        click.echo ("%s Configuration Options" % component)
+        fields = ["Name", "Description", "Type", "Required", "Component"]
+        items = []
+        for k, v in self.config_vars[component].items():
+            items.append([
+                k,
+                v["Description"],
+                v["Type"],
+                v["Required"],
+                v["Component"]
+            ])
+        click.echo(add_pretty_table(fields, items))
+
+    def show(self, component: str):
+        ''' pretty click.echo existing configuration '''
+        click.echo ("%s Configuration" % component)
+        items = [[k, v] for k, v in self.configs[component].items()]
+        fields = ["Name", "Configuration"]
+
+        click.echo(add_pretty_table(fields, items))
+
+    def __init__(self, constants: dict):
+        self.config_vars = {}
+        self.configs = {}
+        self.tf_vars = set()
+        self.aws_vars = set()
+        self.constants = constants
+        vars_fn = constants['vars_definition']
+        try:
+            with open(vars_fn) as f:
+                self.config_vars = yaml.load(f, Loader=yaml.FullLoader)
+        except OSError:
+            click.echo("Failed opening vars file " + vars_fn)
+
+        # read all configs
+        for component in constants['components']:
+            try:
+                fn = self._get_config_fn(component)
+                self.configs[component] = get_json(fn)
+                for k, v in self.config_vars[component].items():
+                    if 'tf' in v["ConfigApps"]:
+                        self.tf_vars.add(k)
+                    elif 'awscli' in v["ConfigApps"]:
+                        self.aws_vars.add(k)
+            except OSError:
+                pass

--- a/orc8r/cloud/deploy/orc8r_deployer/docker/root/scripts/configlib.py
+++ b/orc8r/cloud/deploy/orc8r_deployer/docker/root/scripts/configlib.py
@@ -78,6 +78,7 @@ class ConfigManager(object):
             return
         cfgs[key] = value
 
+        self.configs[component] = cfgs
         self._configure_aws(component, cfgs)
         self._configure_tf(component, cfgs)
         put_json(self._get_config_fn(component), cfgs)
@@ -110,6 +111,7 @@ class ConfigManager(object):
         self._configure_aws(component, cfgs)
         self._configure_tf(component, cfgs)
         put_json(self._get_config_fn(component), cfgs)
+
 
     def _configure_aws(self, component: str, cfgs: dict):
         ''' configures aws cli with configuration '''

--- a/orc8r/cloud/deploy/orc8r_deployer/docker/root/scripts/configlib_test.py
+++ b/orc8r/cloud/deploy/orc8r_deployer/docker/root/scripts/configlib_test.py
@@ -1,0 +1,237 @@
+# Copyright 2021 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import shutil
+import yaml
+import configlib
+from tempfile import mkdtemp
+from unittest import TestCase, main
+from unittest.mock import patch, Mock
+
+class TestConfigManager(TestCase):
+    def setUp(self):
+        self.root_dir = mkdtemp()
+        self.constants = {
+            'project_dir':  self.root_dir,
+            'config_dir':  '%s/configs' % self.root_dir,
+            'vars_definition': '%s/vars.yml' % self.root_dir,
+            'components': ['infra', 'platform', 'service'],
+            'auto_tf': self.root_dir + '/terraform.tfvars.json',
+            'tf_dir': self.root_dir,
+            'main_tf': self.root_dir + '/main.tf',
+            'vars_tf': self.root_dir + '/vars.tf'
+        }
+        # add config directory
+        os.makedirs(self.constants["config_dir"])
+        test_vars = {
+            "infra": {
+                "aws_access_key_id": {
+                    "Required":  True,
+                    "ConfigApps": ["awscli"]
+                },
+                "aws_secret_access_key": {
+                    "Required":  True,
+                    "ConfigApps": ["awscli"]
+                },
+                "cluster_name": {
+                    "Required": False,
+                    "ConfigApps": ["tf"]
+                },
+                "secretsmanager_orc8r_secret": {
+                    "Required":  True,
+                    "ConfigApps": ["tf"]
+                }
+            },
+            "platform": {
+                "deploy_elastic": {
+                    "Required":  False,
+                    "ConfigApps": ["tf"]
+                },
+                "nms_db_password": {
+                    "Required":  True,
+                    "ConfigApps": ["tf"]
+                }
+            },
+            "service": {
+                "lte_orc8r_chart_version": {
+                    "Required":  False,
+                    "Default": "0.2.4",
+                    "ConfigApps": ["tf"]
+                },
+            }
+        }
+        with open(self.constants['vars_definition'], 'w') as f:
+            yaml.dump(test_vars, f)
+
+        # write a simple jinja template file
+        jinja_template = (
+'''
+{% for k in cfg['infra'] %}
+{{k}}=var.{{k}}{% endfor %}
+''')
+        with open(self.constants['tf_dir'] + '/main.tf.j2', 'w') as f:
+            f.write(jinja_template)
+
+        jinja_template = (
+'''
+{% for k in cfg %}
+variable "{{k}}" {}{% endfor %}
+''')
+        with open(self.constants['tf_dir'] + '/vars.tf.j2', 'w') as f:
+            f.write(jinja_template)
+
+    def tearDown(self):
+        try:
+            shutil.rmtree(self.root_dir)
+        except:
+            pass
+
+    @patch("configlib.get_input")
+    @patch("configlib.check_call")
+    def test_configure_sanity(self, mock_check_call, mock_get_input):
+        mock_vals = {
+            'aws_access_key_id': 'foo',
+            'aws_secret_access_key': 'bar',
+            'secretsmanager_orc8r_secret': 'jar',
+        }
+        mock_get_input.side_effect = [
+            mock_vals['aws_access_key_id'],
+            mock_vals['aws_secret_access_key'],
+            mock_vals['secretsmanager_orc8r_secret'],
+        ]
+        # verify if components tfvars json is created
+        mgr = configlib.ConfigManager(self.constants)
+        mgr.configure('infra')
+
+        # verify if configs are set in infra tfvars json
+        fn = "%s/infra.tfvars.json" % self.constants['config_dir']
+        cfg = configlib.get_json(fn)
+        self.assertEqual(len(cfg.keys()), 3)
+        self.assertEqual(cfg['aws_access_key_id'], "foo")
+        self.assertEqual(cfg['aws_secret_access_key'], "bar")
+        self.assertEqual(cfg['secretsmanager_orc8r_secret'], "jar")
+
+        # check if aws configs are set
+        aws_config_cmd = ['aws', 'configure', 'set']
+        mock_check_call.assert_any_call(
+            aws_config_cmd + ['aws_access_key_id', 'foo'])
+        mock_check_call.assert_any_call(
+            aws_config_cmd + ['aws_secret_access_key', 'bar'])
+
+        # verify that platform tfvars json file isn't present
+        fn = "%s/platform.tfvars.json" % self.constants['config_dir']
+        self.assertEqual(os.path.isfile(fn), False)
+
+        # reset mocks
+        mock_get_input.reset_mock()
+        mock_check_call.reset_mock()
+
+        mock_vals = {
+            'nms_db_password': 'foo',
+        }
+        mock_get_input.side_effect = [
+            mock_vals['nms_db_password'],
+        ]
+
+        # configure platform
+        mgr.configure('platform')
+
+        # verify that no aws call was invoked
+        self.assertEqual(mock_check_call.call_count, 0)
+
+        # check if we only invoked input for nms_db_password
+        self.assertEqual(mock_get_input.call_count, 1)
+        fn = "%s/platform.tfvars.json" % self.constants['config_dir']
+        cfg = configlib.get_json(fn)
+        self.assertEqual(len(cfg.keys()), 1)
+        self.assertEqual(cfg['nms_db_password'], "foo")
+
+
+        # verify that service tfvars json file isn't present
+        fn = "%s/service.tfvars.json" % self.constants['config_dir']
+        self.assertEqual(os.path.isfile(fn), False)
+
+        # reset mocks
+        mock_get_input.reset_mock()
+        mock_check_call.reset_mock()
+
+        # configure service
+        mgr.configure('service')
+
+        # verify that no input or aws call was invoked
+        self.assertEqual(mock_check_call.call_count, 0)
+        self.assertEqual(mock_get_input.call_count, 0)
+
+        fn = "%s/service.tfvars.json" % self.constants['config_dir']
+        cfg = configlib.get_json(fn)
+        # verify that default value was set
+        self.assertEqual(len(cfg.keys()), 1)
+        self.assertEqual(cfg['lte_orc8r_chart_version'], "0.2.4")
+
+        # finally verify if all configs required by tf is present
+        cfg = configlib.get_json(self.constants['auto_tf'])
+        self.assertEqual(len(cfg.keys()), 3)
+        self.assertEqual(cfg['secretsmanager_orc8r_secret'], "jar")
+        self.assertEqual(cfg['nms_db_password'], "foo")
+        self.assertEqual(cfg['lte_orc8r_chart_version'], "0.2.4")
+
+        # verify if jinja template has been rendered accordingly
+        with open(self.constants['main_tf']) as f:
+            jinja_cfg = dict(ln.split('=') for ln in f.readlines() if ln.strip())
+
+        # all infra terraform keys should be present in the jinja template
+        self.assertEqual(
+            set(jinja_cfg.keys()),
+            set(['secretsmanager_orc8r_secret']))
+
+        # variable tf is of the form variable "var_name" {}
+        # get the middle element and remove the quotes
+        with open(self.constants['vars_tf']) as f:
+            jinja_cfg = [ln.split()[1][1:-1] for ln in f.readlines() if ln.strip()]
+
+        # all infra terraform keys should be present in the jinja template
+        self.assertEqual(set(jinja_cfg), set(mgr.tf_vars))
+
+    @patch("configlib.get_input")
+    @patch("configlib.check_call")
+    def test_configure_set(self, mock_check_call, mock_get_input):
+        mock_vals = {
+            'nms_db_password': 'foo',
+        }
+        mock_get_input.side_effect = [
+            mock_vals['nms_db_password'],
+        ]
+
+        # configure platform
+        mgr = configlib.ConfigManager(self.constants)
+        mgr.configure('platform')
+
+        # check if we only invoked input for nms_db_password
+        self.assertEqual(mock_get_input.call_count, 1)
+        fn = "%s/platform.tfvars.json" % self.constants['config_dir']
+        cfg = configlib.get_json(fn)
+        self.assertEqual(len(cfg.keys()), 1)
+        self.assertEqual(cfg['nms_db_password'], "foo")
+
+        mgr.set('platform', 'deploy_elastic', 'true')
+        cfg = configlib.get_json(fn)
+        self.assertEqual(len(cfg.keys()), 2)
+        self.assertEqual(cfg['deploy_elastic'], "true")
+
+        # finally verify if all configs required by tf is present
+        cfg = configlib.get_json(self.constants['auto_tf'])
+        self.assertEqual(len(cfg.keys()), 2)
+        self.assertEqual(cfg['nms_db_password'], "foo")
+        self.assertEqual(cfg['deploy_elastic'], "true")
+
+if __name__ == '__main__':
+    main()

--- a/orc8r/cloud/deploy/orc8r_deployer/docker/root/scripts/orcl.py
+++ b/orc8r/cloud/deploy/orc8r_deployer/docker/root/scripts/orcl.py
@@ -125,8 +125,8 @@ def install():
     """
     pass
 
-@install.command()
-def precheck():
+@install.command('precheck')
+def install_precheck():
     run_playbook([
         "ansible-playbook",
         "-v",
@@ -159,6 +159,27 @@ def addcerts(self_signed):
             "--skip-tags",
             "self_signed",
             "%s/main.yml" % constants["playbooks"]])
+
+
+@cli.group()
+def upgrade():
+    """
+    Upgrade command enables user to run subcommands in context of Orc8r upgrade.
+    It provides subcommands like
+    - precheck which runs various checks to ensure successful upgrade
+    """
+    pass
+
+@upgrade.command('precheck')
+def upgrade_precheck():
+    run_playbook([
+        "ansible-playbook",
+        "-v",
+        "-e",
+        "@/root/config.yml",
+        "-t",
+        "upgrade_precheck",
+        "%s/main.yml" % constants["playbooks"]])
 
 def run_playbook(args):
     pb_cli = PlaybookCLI(args)

--- a/orc8r/cloud/deploy/orc8r_deployer/docker/root/scripts/orcl.py
+++ b/orc8r/cloud/deploy/orc8r_deployer/docker/root/scripts/orcl.py
@@ -1,0 +1,166 @@
+#!/usr/local/bin/python
+# Copyright 2021 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import List
+import os
+import sys
+import argparse
+import subprocess
+import pprint
+import yaml
+import click
+from ansible.cli.playbook import PlaybookCLI
+from configlib import ConfigManager
+
+constants = {}
+def init_cli():
+    global constants
+    try:
+        with open("/root/config.yml") as f:
+            constants = yaml.load(f, Loader=yaml.FullLoader)
+    except OSError:
+        click.echo("Failed opening config.yml file")
+
+    if not os.path.isdir(constants["config_dir"]):
+        try:
+            os.makedirs(constants["config_dir"])
+        except OSError as error:
+            click.echo("failed creating config directories ", error)
+            sys.exit(1)
+
+    if not os.path.isdir(constants["secret_dir"]):
+        try:
+            os.makedirs(constants["secret_dir"])
+        except OSError as error:
+            click.echo("failed creating secret directories ", error)
+            sys.exit(1)
+    return constants
+
+# initiialize CLI
+init_cli()
+
+@click.group()
+@click.version_option()
+def cli():
+    """Orchestrator Deployment CLI"""
+
+########################## CONFIGURE COMMANDS ###################################
+@cli.group(invoke_without_command=True)
+@click.pass_context
+@click.option('-c', '--component',
+              type=click.Choice(constants['components'],case_sensitive=False),
+              multiple=True,
+              default=constants['components'])
+def configure(ctx, component):
+    """
+    Configure enables user to configure values needed for Orc8r deployment.
+    It additionally provides subcommands to see configured values, check
+    if all required values are configured and finally provide detailed
+    description on all options available to be configured
+    """
+    if ctx.invoked_subcommand is None:
+        mgr = ConfigManager(constants)
+        for c in component:
+            mgr.configure(c)
+
+@configure.command()
+@click.option('-c', '--component',
+              type=click.Choice(constants['components'],case_sensitive=False),
+              multiple=True,
+              default=constants['components'])
+def show(component):
+    mgr = ConfigManager(constants)
+    for c in component:
+        mgr.show(c)
+
+@configure.command()
+@click.option('-c', '--component',
+              type=click.Choice(constants['components'],case_sensitive=False),
+              multiple=True,
+              default=constants['components'])
+def info(component):
+    mgr = ConfigManager(constants)
+    for c in component:
+        mgr.info(c)
+
+@configure.command()
+@click.option('-c', '--component',
+              type=click.Choice(constants['components'],case_sensitive=False),
+              multiple=True,
+              default=constants['components'])
+def check(component):
+    mgr = ConfigManager(constants)
+    valid = True
+    for c in component:
+        valid = mgr.check(c)
+    if not valid:
+        sys.exit(1)
+
+@configure.command()
+@click.option('-c', '--component',
+              type=click.Choice(constants['components'],case_sensitive=False),
+              prompt='component to configure')
+@click.option('-k', '--key', prompt='name of the variable')
+@click.option('-v', '--value', prompt='value of the variable')
+def set(component, key, value):
+    ConfigManager(constants).set(component, key, value)
+
+########################## INSTALL COMMANDS ###################################
+@cli.group()
+def install():
+    """
+    Install command enables user to run subcommands in context of Orc8r installation.
+    It provides subcommands like
+    - precheck which runs various checks to ensure successful installation
+    - addcerts which lets user create certificates for the installation
+    """
+    pass
+
+@install.command()
+def precheck():
+    run_playbook([
+        "ansible-playbook",
+        "-v",
+        "-e",
+        "@/root/config.yml",
+        "-t",
+        "install_precheck",
+        "%s/main.yml" % constants["playbooks"]])
+
+@install.command()
+@click.option('--self-signed', is_flag=True)
+def addcerts(self_signed):
+    if self_signed:
+        run_playbook([
+            "ansible-playbook",
+            "-v",
+            "-e",
+            "@/root/config.yml",
+            "-t",
+            "addcerts",
+            "%s/main.yml" % constants["playbooks"]])
+    else:
+        run_playbook([
+            "ansible-playbook",
+            "-v",
+            "-e",
+            "@/root/config.yml",
+            "-t",
+            "addcerts",
+            "--skip-tags",
+            "self_signed",
+            "%s/main.yml" % constants["playbooks"]])
+
+def run_playbook(args):
+    pb_cli = PlaybookCLI(args)
+    pb_cli.parse()
+    pb_cli.run()

--- a/orc8r/cloud/deploy/orc8r_deployer/docker/root/scripts/playbooks/deploy.yml
+++ b/orc8r/cloud/deploy/orc8r_deployer/docker/root/scripts/playbooks/deploy.yml
@@ -1,29 +1,57 @@
-- name: Deployment Playbook
-  hosts: localhost
-  tasks:
-    - name: Gather terraform state facts
-      ansible.builtin.command: terraform state list
-      register: result
-      args:
-        chdir: "{{project_dir}}"
-      tags: 'upgrade_precheck'
+  - name: Deployment Playbook
+    hosts: localhost
+    vars:
+      orc8r_namespace_query: "values.root_module.child_modules[*].resources[?address=='module.orc8r-app.kubernetes_namespace.orc8r'].values.metadata[*].name"
+      orc8r_secrets_query: "values.root_module.child_modules[*].resources[?address=='module.orc8r-app.kubernetes_secret.orc8r_certs'].values.data"
+      orc8r_api_endpoint_query: "values.root_module.child_modules[*].resources[?address=='module.orc8r-app.data.template_file.orc8r_values'].values.vars.api_hostname"
+    tasks:
+      - name: Gather terraform state facts
+        ansible.builtin.command: terraform show -json
+        register: result
+        args:
+          chdir: "{{project_dir}}"
+        tags:
+          - 'upgrade_precheck'
+          - 'verify_sanity'
 
-    - name: Check if terraform state command errors out
-      assert:
-        that:
-          - result.rc == 0
-        msg: [
-          "Error attempting to run 'terraform state' command",
-          "Terraform state not found",
-          "Check if the deployment directory {{project_dir}} contains terraform files"
-        ]
-      tags: 'upgrade_precheck'
+      - name: Check if terraform state command errors out
+        assert:
+          that:
+            - result.rc == 0
+          msg: [
+            "Error attempting to run 'terraform show' command",
+            "Terraform state not found",
+            "Check if the deployment directory {{project_dir}} contains terraform files"
+          ]
+        tags:
+          - 'upgrade_precheck'
+          - 'verify_sanity'
 
-    - name: Check if any resources are present in terraform state
-      assert:
-        that:
-          - result.stdout|length != 0
-        msg: [
-          "No resources found in terraform state"
-        ]
-      tags: 'upgrade_precheck'
+      - name: Check if any resources are present in terraform state
+        assert:
+          that:
+            - "{{ (result.stdout | from_json) | json_query('values') != None }}"
+          msg: [
+            "No resources found in terraform state"
+          ]
+        tags:
+          - 'upgrade_precheck'
+          - 'verify_sanity'
+
+      - name: set terraform state fact
+        set_fact:
+          terraform_state: "{{result.stdout | from_json}}"
+          orc8r_namespace: "{{lookup('flattened', result.stdout | from_json | json_query(orc8r_namespace_query))}}"
+          orc8r_secrets: "{{lookup('flattened', result.stdout | from_json | json_query(orc8r_secrets_query))}}"
+          orc8r_api_endpoint: "{{lookup('flattened', result.stdout | from_json | json_query(orc8r_api_endpoint_query))}}"
+        tags:
+          - 'upgrade_precheck'
+          - 'verify_sanity'
+
+      - name: Debug terraform facts
+        debug:
+          msg: "{{orc8r_secrets.keys()}}"
+        tags:
+          - 'upgrade_precheck'
+          - 'verify_sanity'
+

--- a/orc8r/cloud/deploy/orc8r_deployer/docker/root/scripts/playbooks/deploy.yml
+++ b/orc8r/cloud/deploy/orc8r_deployer/docker/root/scripts/playbooks/deploy.yml
@@ -1,0 +1,29 @@
+- name: Deployment Playbook
+  hosts: localhost
+  tasks:
+    - name: Gather terraform state facts
+      ansible.builtin.command: terraform state list
+      register: result
+      args:
+        chdir: "{{project_dir}}"
+      tags: 'upgrade_precheck'
+
+    - name: Check if terraform state command errors out
+      assert:
+        that:
+          - result.rc == 0
+        msg: [
+          "Error attempting to run 'terraform state' command",
+          "Terraform state not found",
+          "Check if the deployment directory {{project_dir}} contains terraform files"
+        ]
+      tags: 'upgrade_precheck'
+
+    - name: Check if any resources are present in terraform state
+      assert:
+        that:
+          - result.stdout|length != 0
+        msg: [
+          "No resources found in terraform state"
+        ]
+      tags: 'upgrade_precheck'

--- a/orc8r/cloud/deploy/orc8r_deployer/docker/root/scripts/playbooks/infra.yml
+++ b/orc8r/cloud/deploy/orc8r_deployer/docker/root/scripts/playbooks/infra.yml
@@ -1,8 +1,9 @@
 # check if configuration contains all required variables
 - hosts: localhost
   roles:
-    - infra
-    - infra/az
-    - infra/dns
-    - infra/secrets
-    - infra/k8s
+    - role: infra
+    - role: infra/az
+    - role: infra/dns
+    - role: infra/secrets
+      tags: secrets
+    - role: infra/k8s

--- a/orc8r/cloud/deploy/orc8r_deployer/docker/root/scripts/playbooks/infra.yml
+++ b/orc8r/cloud/deploy/orc8r_deployer/docker/root/scripts/playbooks/infra.yml
@@ -1,0 +1,8 @@
+# check if configuration contains all required variables
+- hosts: localhost
+  roles:
+    - infra
+    - infra/az
+    - infra/dns
+    - infra/secrets
+    - infra/k8s

--- a/orc8r/cloud/deploy/orc8r_deployer/docker/root/scripts/playbooks/main.yml
+++ b/orc8r/cloud/deploy/orc8r_deployer/docker/root/scripts/playbooks/main.yml
@@ -14,3 +14,8 @@
   import_playbook: service.yml
   tags:
     - service
+
+- name: Deploy
+  import_playbook: deploy.yml
+  tags:
+    - deploy

--- a/orc8r/cloud/deploy/orc8r_deployer/docker/root/scripts/playbooks/main.yml
+++ b/orc8r/cloud/deploy/orc8r_deployer/docker/root/scripts/playbooks/main.yml
@@ -1,5 +1,10 @@
 # top level playbook
 
+- name: Deploy
+  import_playbook: deploy.yml
+  tags:
+    - deploy
+
 - name: Infra
   import_playbook: infra.yml
   tags:
@@ -14,8 +19,3 @@
   import_playbook: service.yml
   tags:
     - service
-
-- name: Deploy
-  import_playbook: deploy.yml
-  tags:
-    - deploy

--- a/orc8r/cloud/deploy/orc8r_deployer/docker/root/scripts/playbooks/main.yml
+++ b/orc8r/cloud/deploy/orc8r_deployer/docker/root/scripts/playbooks/main.yml
@@ -1,0 +1,16 @@
+# top level playbook
+
+- name: Infra
+  import_playbook: infra.yml
+  tags:
+    - infra
+
+- name: Platform
+  import_playbook: platform.yml
+  tags:
+    - platform
+
+- name: Service
+  import_playbook: service.yml
+  tags:
+    - service

--- a/orc8r/cloud/deploy/orc8r_deployer/docker/root/scripts/playbooks/platform.yml
+++ b/orc8r/cloud/deploy/orc8r_deployer/docker/root/scripts/playbooks/platform.yml
@@ -5,3 +5,5 @@
   roles:
     - platform
     - platform/cloudwatch
+    - platform/rds
+    - platform/elastic

--- a/orc8r/cloud/deploy/orc8r_deployer/docker/root/scripts/playbooks/platform.yml
+++ b/orc8r/cloud/deploy/orc8r_deployer/docker/root/scripts/playbooks/platform.yml
@@ -1,0 +1,7 @@
+# check log manager is cleaned up
+# check elastic search instances are removed
+# check RDS instances are cleaned up
+- hosts: localhost
+  roles:
+    - platform
+    - platform/cloudwatch

--- a/orc8r/cloud/deploy/orc8r_deployer/docker/root/scripts/playbooks/platform.yml
+++ b/orc8r/cloud/deploy/orc8r_deployer/docker/root/scripts/playbooks/platform.yml
@@ -3,7 +3,10 @@
 # check RDS instances are cleaned up
 - hosts: localhost
   roles:
-    - platform
-    - platform/cloudwatch
-    - platform/rds
-    - platform/elastic
+    - role: platform
+    - role: platform/cloudwatch
+      tags: cloudwatch
+    - role: platform/rds
+      tags: rds
+    - role: platform/elastic
+      tags: elastic

--- a/orc8r/cloud/deploy/orc8r_deployer/docker/root/scripts/playbooks/roles/infra/az/tasks/main.yml
+++ b/orc8r/cloud/deploy/orc8r_deployer/docker/root/scripts/playbooks/roles/infra/az/tasks/main.yml
@@ -2,4 +2,6 @@
   amazon.aws.aws_az_info:
   register: aws_az_info
   failed_when: aws_az_info.availability_zones | length < 3
-  tags: install_precheck
+  tags:
+    - install_precheck
+    - upgrade_precheck

--- a/orc8r/cloud/deploy/orc8r_deployer/docker/root/scripts/playbooks/roles/infra/az/tasks/main.yml
+++ b/orc8r/cloud/deploy/orc8r_deployer/docker/root/scripts/playbooks/roles/infra/az/tasks/main.yml
@@ -1,0 +1,5 @@
+- name: Check if we have atleast 3 availability zones in our deployment
+  amazon.aws.aws_az_info:
+  register: aws_az_info
+  failed_when: aws_az_info.availability_zones | length < 3
+  tags: install_precheck

--- a/orc8r/cloud/deploy/orc8r_deployer/docker/root/scripts/playbooks/roles/infra/k8s/tasks/main.yml
+++ b/orc8r/cloud/deploy/orc8r_deployer/docker/root/scripts/playbooks/roles/infra/k8s/tasks/main.yml
@@ -1,0 +1,13 @@
+- name: Get EKS cluster information
+  ansible.builtin.shell: aws eks describe-cluster --name {{ infra_configs.cluster_name | quote }} || /bin/true
+  register: result
+  tags: upgrade_precheck
+
+- name: Check if deployed EKS cluster version is greater than version specified in values
+  assert:
+    that: "{{ infra_configs.cluster_version is version((result.stdout | from_json).cluster.version, '>=') }}"
+    msg:
+      - "deployed version higher than to be configured version"
+      - "Configure the cluster_version to be >= {{(result.stdout | from_json).cluster.version}}"
+      - "For e.g: orcl configure set -c infra -k cluster_version -v {{(result.stdout | from_json).cluster.version}}"
+  tags: upgrade_precheck

--- a/orc8r/cloud/deploy/orc8r_deployer/docker/root/scripts/playbooks/roles/infra/secrets/tasks/main.yml
+++ b/orc8r/cloud/deploy/orc8r_deployer/docker/root/scripts/playbooks/roles/infra/secrets/tasks/main.yml
@@ -1,0 +1,5 @@
+- name: Query secrets manager to check if secretsID is already present
+  ansible.builtin.shell: aws secretsmanager get-secret-value --secret-id {{ infra_configs.secretsmanager_orc8r_secret | quote }} || /bin/true
+  register: result
+  failed_when: '"ResourceNotFoundException" not in result.stderr'
+  tags: install_precheck

--- a/orc8r/cloud/deploy/orc8r_deployer/docker/root/scripts/playbooks/roles/infra/secrets/tasks/main.yml
+++ b/orc8r/cloud/deploy/orc8r_deployer/docker/root/scripts/playbooks/roles/infra/secrets/tasks/main.yml
@@ -1,5 +1,13 @@
-- name: Query secrets manager to check if secretsID is already present
+- name: Query secrets manager
   ansible.builtin.shell: aws secretsmanager get-secret-value --secret-id {{ infra_configs.secretsmanager_orc8r_secret | quote }} || /bin/true
   register: result
-  failed_when: '"ResourceNotFoundException" not in result.stderr'
   tags: install_precheck
+
+- name: Verify if secrets already present
+  assert:
+    that: '"ResourceNotFoundException" in result.stderr'
+    fail_msg:
+      - "secret {{ infra_configs.secretsmanager_orc8r_secret}} already present"
+      - "Remove secrets 'aws secretsmanager delete-secret  --force-delete --secret-id {{ infra_configs.secretsmanager_orc8r_secret | quote }}'"
+  tags: install_precheck
+

--- a/orc8r/cloud/deploy/orc8r_deployer/docker/root/scripts/playbooks/roles/infra/tasks/main.yml
+++ b/orc8r/cloud/deploy/orc8r_deployer/docker/root/scripts/playbooks/roles/infra/tasks/main.yml
@@ -1,0 +1,15 @@
+- name: check if required infra variables are set
+  ansible.builtin.command: "orcl configure check -c infra"
+  register: result
+  failed_when: result.rc != 0
+  tags: install_precheck
+
+- name: Open configuration file
+  shell: "cat {{config_dir}}/infra.tfvars.json"
+  register: result
+  tags: install_precheck
+
+- name: Set Infra Configs
+  set_fact:
+    infra_configs: "{{ result.stdout | from_json }}"
+  tags: install_precheck

--- a/orc8r/cloud/deploy/orc8r_deployer/docker/root/scripts/playbooks/roles/infra/tasks/main.yml
+++ b/orc8r/cloud/deploy/orc8r_deployer/docker/root/scripts/playbooks/roles/infra/tasks/main.yml
@@ -2,14 +2,21 @@
   ansible.builtin.command: "orcl configure check -c infra"
   register: result
   failed_when: result.rc != 0
-  tags: install_precheck
+  tags:
+    - install_precheck
+    - upgrade_precheck
 
 - name: Open configuration file
   shell: "cat {{config_dir}}/infra.tfvars.json"
   register: result
-  tags: install_precheck
+  tags:
+    - install_precheck
+    - upgrade_precheck
 
 - name: Set Infra Configs
   set_fact:
     infra_configs: "{{ result.stdout | from_json }}"
-  tags: install_precheck
+  tags:
+    - install_precheck
+    - upgrade_precheck
+

--- a/orc8r/cloud/deploy/orc8r_deployer/docker/root/scripts/playbooks/roles/platform/cloudwatch/tasks/main.yml
+++ b/orc8r/cloud/deploy/orc8r_deployer/docker/root/scripts/playbooks/roles/platform/cloudwatch/tasks/main.yml
@@ -1,0 +1,30 @@
+---
+- name: check if required infra variables are set
+  ansible.builtin.command: "orcl configure check -c infra"
+  register: result
+  failed_when: result.rc != 0
+  tags: install_precheck
+
+- name: Open configuration file
+  shell: "cat {{ config_dir }}/infra.tfvars.json"
+  register: result
+  tags: install_precheck
+
+- name: Set Infra Configs
+  set_fact:
+    infra_configs: "{{ result.stdout | from_json }}"
+  tags: install_precheck
+
+- name: Get all cloudwatch log groups
+  ansible.builtin.shell: aws logs describe-log-groups --output json
+  register: result
+  tags: install_precheck
+
+- name: Check if orc8r cloudwatch log group exists
+  fail:
+    msg: "Cloudwatch Log group still exists"
+  when: '"eks/{{infra_configs.cluster_name}}/cluster" in item.logGroupName'
+  with_items: "{{ (result.stdout|from_json).logGroups }}"
+  tags: install_precheck
+
+

--- a/orc8r/cloud/deploy/orc8r_deployer/docker/root/scripts/playbooks/roles/platform/elastic/tasks/main.yml
+++ b/orc8r/cloud/deploy/orc8r_deployer/docker/root/scripts/playbooks/roles/platform/elastic/tasks/main.yml
@@ -1,0 +1,21 @@
+- name: Get AWS IAM roles information
+  ansible.builtin.shell: aws iam list-roles || /bin/true
+  register: result
+  when: platform_configs.deploy_elasticsearch
+  tags:
+    - install_precheck
+    - upgrade_precheck
+
+- name: Check if AWSServiceRoleForAmazonElasticsearchService is present already
+  assert:
+    that:
+      - "{{ platform_configs.deploy_elasticsearch_service_linked_role not in (true, 'true') or item.RoleName != 'AWSServiceRoleForAmazonElasticsearchService' }}"
+    msg:
+      - "IAM role AWSServiceRoleForAmazonElasticsearchService already exists"
+      - "Configure deploy_elasticsearch_service_linked_role to be false"
+      - "For e.g: orcl configure set -c platform -k deploy_elasticsearch_service_linked_role -v false"
+  when: platform_configs.deploy_elasticsearch
+  with_items: "{{(result.stdout | from_json).Roles}}"
+  tags:
+    - install_precheck
+    - upgrade_precheck

--- a/orc8r/cloud/deploy/orc8r_deployer/docker/root/scripts/playbooks/roles/platform/rds/tasks/main.yml
+++ b/orc8r/cloud/deploy/orc8r_deployer/docker/root/scripts/playbooks/roles/platform/rds/tasks/main.yml
@@ -1,0 +1,15 @@
+- name: Get RDS information
+  ansible.builtin.shell: aws rds describe-db-instances || /bin/true
+  register: result
+  tags: upgrade_precheck
+
+- name: Check if deployed RDS db instance version is greater than version specified in values
+  assert:
+    that: "{{ platform_configs.orc8r_db_engine_version is version(item.EngineVersion, '>=') }}"
+    msg:
+      - "deployed version higher than to be configured version"
+      - "Configure the db engine version to be >= {{item.EngineVersion}}"
+      - "For e.g: orcl configure set -c infra -k orc8r_db_engine_version -v {{item.EngineVersion}}"
+  when: item.DBInstanceIdentifier == platform_configs.orc8r_db_identifier
+  with_items: "{{(result.stdout | from_json).DBInstances}}"
+  tags: upgrade_precheck

--- a/orc8r/cloud/deploy/orc8r_deployer/docker/root/scripts/playbooks/roles/platform/tasks/main.yml
+++ b/orc8r/cloud/deploy/orc8r_deployer/docker/root/scripts/playbooks/roles/platform/tasks/main.yml
@@ -1,0 +1,6 @@
+- name: check if required platform variables are set
+  ansible.builtin.command: "orcl configure check -c platform"
+  register: result
+  failed_when: result.rc != 0
+  tags: install_precheck
+

--- a/orc8r/cloud/deploy/orc8r_deployer/docker/root/scripts/playbooks/roles/platform/tasks/main.yml
+++ b/orc8r/cloud/deploy/orc8r_deployer/docker/root/scripts/playbooks/roles/platform/tasks/main.yml
@@ -2,5 +2,21 @@
   ansible.builtin.command: "orcl configure check -c platform"
   register: result
   failed_when: result.rc != 0
-  tags: install_precheck
+  tags:
+    - install_precheck
+    - upgrade_precheck
+
+- name: Open configuration file
+  shell: "cat {{config_dir}}/platform.tfvars.json"
+  register: result
+  tags:
+    - install_precheck
+    - upgrade_precheck
+
+- name: Set platform Configs
+  set_fact:
+    platform_configs: "{{ result.stdout | from_json }}"
+  tags:
+    - install_precheck
+    - upgrade_precheck
 

--- a/orc8r/cloud/deploy/orc8r_deployer/docker/root/scripts/playbooks/roles/services/docker/tasks/main.yml
+++ b/orc8r/cloud/deploy/orc8r_deployer/docker/root/scripts/playbooks/roles/services/docker/tasks/main.yml
@@ -1,0 +1,17 @@
+- name: Verify docker credentials
+  docker_login:
+    registry: "{{service_configs.docker_registry}}"
+    username: "{{service_configs.docker_user}}"
+    password: "{{service_configs.docker_pass}}"
+    reauthorize: yes
+  tags: install_precheck
+
+- name: Attempting to pull the docker images
+  docker_image:
+    tag: "{{service_configs.orc8r_tag}}"
+    name: "{{service_configs.docker_registry}}/{{item}}"
+    force_source: true
+    source: pull
+  tags: install_precheck
+  with_items:
+  - "{{vars.ORC8R_IMAGES}}"

--- a/orc8r/cloud/deploy/orc8r_deployer/docker/root/scripts/playbooks/roles/services/helm/tasks/main.yml
+++ b/orc8r/cloud/deploy/orc8r_deployer/docker/root/scripts/playbooks/roles/services/helm/tasks/main.yml
@@ -1,0 +1,55 @@
+- name: Verify the helm repo
+  ansible.builtin.shell: helm repo add test --username "{{service_configs.helm_user}}" --password "{{service_configs.helm_pass}}"  "{{service_configs.helm_repo}}"
+  tags: install_precheck
+
+- name: Get all charts present in the helm repo
+  ansible.builtin.shell: helm search repo test -o json
+  register: helm_chart_info
+  tags: install_precheck
+
+- name: Get chart name and version from helm list
+  set_fact:
+    chart_version_map: "{{ chart_version_map | default({})  | combine({item.name.split('/')[1]: item.version}) }}"
+  with_items: "{{ helm_chart_info.stdout }}"
+  tags: install_precheck
+
+- name: Set chart version map
+  set_fact:
+    exp_chart_version_map: "{{ exp_chart_version_map | default({})  | combine({item.name: item.version}) }}"
+  with_items:
+    - { name: orc8r, version: "{{service_configs.orc8r_chart_version}}"}
+    - { name: lte-orc8r, version: "{{service_configs.lte_orc8r_chart_version}}" }
+    - { name: feg-orc8r, version: "{{service_configs.feg_orc8r_chart_version}}" }
+    - { name: cwf-orc8r, version: "{{service_configs.cwf_orc8r_chart_version}}" }
+    - { name: fbinternal-orc8r, version: "{{service_configs.fbinternal_orc8r_chart_version}}" }
+    - { name: wifi-orc8r, version: "{{service_configs.wifi_orc8r_chart_version}}" }
+  tags: install_precheck
+
+- name: Deployment to module mapping
+  set_fact:
+    deployment_module_map: "{{ deployment_module_map | default({})  | combine({item.name: item.modules}) }}"
+  with_items:
+    - { name: fwa, modules: ['orc8r', 'lte-orc8r']}
+    - { name: ffwa, modules: ['orc8r', 'lte-orc8r', 'feg-orc8r'] }
+    - { name: all, modules: ['orc8r', 'lte-orc8r', 'feg-orc8r', 'cwf-orc8r', 'fbinternal-orc8r', 'wifi-orc8r'] }
+  tags: install_precheck
+
+- name: Validate if necessary charts are present for deployment
+  assert:
+    that: item in chart_version_map
+    fail_msg: "{{item}} chart not found"
+  with_items: "{{deployment_module_map[service_configs.orc8r_deployment_type]}}"
+  tags: install_precheck
+
+
+- name: Validate if chart versions present match the expected version
+  assert:
+    that: chart_version_map[item] == exp_chart_version_map[item]
+    fail_msg: "{{item}} chart version mismatch expected version {{exp_chart_version_map[item]}} found version {{chart_version_map[item]}}"
+  with_items: "{{deployment_module_map[service_configs.orc8r_deployment_type]}}"
+  tags: install_precheck
+
+- name: Remove the test repo
+  ansible.builtin.shell: helm repo remove test
+  ignore_errors: yes
+  tags: install_precheck

--- a/orc8r/cloud/deploy/orc8r_deployer/docker/root/scripts/playbooks/roles/services/helm/tasks/main.yml
+++ b/orc8r/cloud/deploy/orc8r_deployer/docker/root/scripts/playbooks/roles/services/helm/tasks/main.yml
@@ -41,7 +41,6 @@
   with_items: "{{deployment_module_map[service_configs.orc8r_deployment_type]}}"
   tags: install_precheck
 
-
 - name: Validate if chart versions present match the expected version
   assert:
     that: chart_version_map[item] == exp_chart_version_map[item]
@@ -53,3 +52,15 @@
   ansible.builtin.shell: helm repo remove test
   ignore_errors: yes
   tags: install_precheck
+
+- name: Get list of installed charts
+  ansible.builtin.shell: helm list -o json -n "{{orc8r_namespace}}"
+  register: deployed_chart_info
+  tags: verify_sanity
+
+- name: Verify if charts have been deployed
+  assert:
+    that: item.status == "deployed"
+    fail_msg: "chart {{item.name}} status {{item.status}} not deployed successfully"
+  tags: verify_sanity
+  with_items: "{{deployed_chart_info.stdout}}"

--- a/orc8r/cloud/deploy/orc8r_deployer/docker/root/scripts/playbooks/roles/services/orc8r/tasks/main.yml
+++ b/orc8r/cloud/deploy/orc8r_deployer/docker/root/scripts/playbooks/roles/services/orc8r/tasks/main.yml
@@ -1,0 +1,80 @@
+- name: Gather kubernetes pod status for orc8r namespace
+  ansible.builtin.shell: kubectl get pods -o json -n "{{orc8r_namespace}}"
+  register: kubectl_output
+  tags: verify_sanity
+
+- name: Check if any pods are unhealthy
+  assert:
+    that:
+      - "{{pod_status | length == 0}}"
+    fail_msg:  "found pods {{pod_status}} not in running state"
+  vars:
+    status_query: "items[?status.phase != 'Running'].metadata.name"
+    pod_status: "{{kubectl_output.stdout | from_json | json_query(status_query)}}"
+  tags: verify_sanity
+
+- name: Get the logs for pods in unhealthy state
+  ansible.builtin.shell: kubectl -n "{{orc8r_namespace}}" logs --tail=50 "{{item}}"
+  register: result
+  vars:
+    status_query: "items[?status.phase != 'Running'].metadata.name"
+    pod_status: "{{kubectl_output.stdout | from_json | json_query(status_query)}}"
+  with_items: "{{pod_status}}"
+  tags: verify_sanity
+
+- name: Dump the logs for pods in unhealthy state
+  debug: msg="Logs for {{item.item}} \n {{item.stdout_lines}}"
+  with_items: "{{result.results}}"
+  tags: verify_sanity
+
+- name: Get orchestrator pod name
+  ansible.builtin.shell: kubectl get pod -n "{{orc8r_namespace}}"  -l app.kubernetes.io/component=orchestrator -o json
+  register: result
+  tags: verify_sanity
+
+- name: Set orchestrator pod name
+  set_fact:
+    orc_pod: "{{result.stdout | from_json | json_query(pod_query)}}"
+  vars:
+    pod_query: "items[0].metadata.name"
+
+  tags:
+    - 'verify_sanity'
+
+- name: Get NMS pod name
+  ansible.builtin.shell: kubectl get pod -n "{{orc8r_namespace}}"  -l app.kubernetes.io/component=magmalte -o json
+  register: result
+  tags: verify_sanity
+
+- name: Set orchestrator pod name
+  set_fact:
+    nms_pod: "{{result.stdout | from_json | json_query(pod_query)}}"
+    api_cert: "{{lookup('flattened', result.stdout | from_json | json_query(api_cert_query))}}"
+    api_key: "{{lookup('flattened', result.stdout | from_json | json_query(api_key_query))}}"
+  vars:
+    pod_query: "items[0].metadata.name"
+    api_cert_query: "items[0].spec.containers[*].env[?name == 'API_CERT_FILENAME'].value"
+    api_key_query: "items[0].spec.containers[*].env[?name == 'API_PRIVATE_KEY_FILENAME'].value"
+  tags:
+    - 'verify_sanity'
+
+- name: Add admin cert to orchestrator pod
+  ansible.builtin.shell: kubectl -n "{{orc8r_namespace}}" exec "{{orc_pod}}" -- envdir /var/opt/magma/envdir /var/opt/magma/bin/accessc add-existing -admin -cert /var/opt/magma/certs/admin_operator.pem admin_operator
+  register: result
+  failed_when: result.rc != 0 and 'AlreadyExists' not in result.stderr
+  tags: verify_sanity
+
+
+- name: List admin certs in orchestrator pod
+  ansible.builtin.shell: kubectl -n "{{orc8r_namespace}}" exec "{{orc_pod}}" -- envdir /var/opt/magma/envdir /var/opt/magma/bin/accessc list-certs
+  register: result
+  failed_when: result.rc != 0 or 'admin_operator' not in result.stdout
+  tags: verify_sanity
+
+- name: Get all configured networks from NMS pod
+  ansible.builtin.shell: kubectl -n "{{orc8r_namespace}}" exec "{{nms_pod}}" -- curl --cert "{{api_cert}}" --key "{{api_key}}" -k -X GET https://"{{orc8r_api_endpoint}}"/"{{item}}"
+  register:  result
+  tags: verify_sanity
+  with_items:
+    - magma/v1/networks
+    - magma/v1/lte

--- a/orc8r/cloud/deploy/orc8r_deployer/docker/root/scripts/playbooks/roles/services/tasks/addcerts.yml
+++ b/orc8r/cloud/deploy/orc8r_deployer/docker/root/scripts/playbooks/roles/services/tasks/addcerts.yml
@@ -1,0 +1,39 @@
+---
+- name: check if required infra variables are set
+  ansible.builtin.command: "orcl configure check -c infra"
+  register: result
+  failed_when: result.rc != 0
+
+- name: Open configuration file
+  shell: "cat {{ config_dir }}/infra.tfvars.json"
+  register: result
+
+- name: Set Infra Configs
+  set_fact:
+    infra_configs: "{{ result.stdout | from_json }}"
+
+- name: create certs directory
+  file:
+    name: "{{ secret_dir }}"
+    state: directory
+    mode: '0775'
+
+- name: generate self-signed certs
+  command: "{{ magma_root }}/orc8r/cloud/deploy/scripts/self_sign_certs.sh {{ infra_configs.orc8r_domain_name }}"
+  args:
+    chdir: "{{ secret_dir }}"
+  tags: self_signed
+
+- name: generate domain certs
+  command: "{{ magma_root }}/orc8r/cloud/deploy/scripts/create_application_certs.sh {{ infra_configs.orc8r_domain_name }}"
+  args:
+    chdir: "{{ secret_dir }}"
+
+- name: generate pfx file
+  openssl_pkcs12:
+    action: export
+    path: "{{ secret_dir }}/admin_operator.pfx"
+    friendly_name: orc8rpfx
+    privatekey_path: "{{ secret_dir }}/admin_operator.key.pem"
+    certificate_path: "{{ secret_dir }}/admin_operator.pem"
+    state: present

--- a/orc8r/cloud/deploy/orc8r_deployer/docker/root/scripts/playbooks/roles/services/tasks/main.yml
+++ b/orc8r/cloud/deploy/orc8r_deployer/docker/root/scripts/playbooks/roles/services/tasks/main.yml
@@ -1,0 +1,24 @@
+- name: check if required services variables are set
+  ansible.builtin.command: "orcl configure check -c service"
+  register: result
+  failed_when: result.rc != 0
+  tags: install_precheck
+
+- name: Open configuration file
+  shell: "cat {{ config_dir }}/service.tfvars.json"
+  register: result
+  tags: install_precheck
+
+- name: Set Service Configs
+  set_fact:
+    service_configs: "{{ result.stdout | from_json }}"
+  tags: install_precheck
+
+- name: Validate Orc8r deployment type
+  assert:
+    that: service_configs.orc8r_deployment_type in ['fwa', 'ffwa', 'all']
+    fail_msg: 'orc8r_deployment_type can only be one of these options [fwa, ffwa, all]'
+  tags: install_precheck
+
+- include: addcerts.yml
+  tags: addcerts

--- a/orc8r/cloud/deploy/orc8r_deployer/docker/root/scripts/playbooks/roles/services/vars/all.yml
+++ b/orc8r/cloud/deploy/orc8r_deployer/docker/root/scripts/playbooks/roles/services/vars/all.yml
@@ -1,0 +1,4 @@
+ORC8R_IMAGES:
+  - nginx
+  - controller
+  - magmalte

--- a/orc8r/cloud/deploy/orc8r_deployer/docker/root/scripts/playbooks/service.yml
+++ b/orc8r/cloud/deploy/orc8r_deployer/docker/root/scripts/playbooks/service.yml
@@ -4,5 +4,6 @@
     - services
     - services/docker
     - services/helm
+    - services/orc8r
   vars_files:
     - roles/services/vars/all.yml

--- a/orc8r/cloud/deploy/orc8r_deployer/docker/root/scripts/playbooks/service.yml
+++ b/orc8r/cloud/deploy/orc8r_deployer/docker/root/scripts/playbooks/service.yml
@@ -1,0 +1,8 @@
+# check if we have all the secrets necessary in the seed directory
+- hosts: localhost
+  roles:
+    - services
+    - services/docker
+    - services/helm
+  vars_files:
+    - roles/services/vars/all.yml

--- a/orc8r/cloud/deploy/orc8r_deployer/docker/root/scripts/setup.py
+++ b/orc8r/cloud/deploy/orc8r_deployer/docker/root/scripts/setup.py
@@ -1,0 +1,24 @@
+# Copyright 2021 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from setuptools import setup
+
+setup(
+    name='deployer',
+    version='0.1',
+    py_modules=['configlib', 'orcl'],
+    install_requires=[
+        'Click',
+    ],
+    entry_points='''
+        [console_scripts]
+        orcl=orcl:cli
+    ''',
+)

--- a/orc8r/cloud/deploy/orc8r_deployer/docker/root/tf/main.tf.j2
+++ b/orc8r/cloud/deploy/orc8r_deployer/docker/root/tf/main.tf.j2
@@ -1,0 +1,58 @@
+################################################################################
+# Copyright 2020 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+module "orc8r" {
+  source = "/root/magma/orc8r/cloud/deploy/terraform/orc8r-aws"
+
+  {% for k in cfg['infra'] %}
+  {{k}}=var.{{k}}
+  {% endfor %}
+
+  {% for k in cfg['platform'] %}
+  {{k}}=var.{{k}}
+  {% endfor %}
+}
+
+module "orc8r-app" {
+  source = "/root/magma/orc8r/cloud/deploy/terraform/orc8r-helm-aws"
+
+  {% for k in cfg['service'] %}
+  {{k}}=var.{{k}}
+  {% endfor %}
+
+  region = var.region
+  orc8r_domain_name = module.orc8r.orc8r_domain_name
+  orc8r_route53_zone_id = module.orc8r.route53_zone_id
+  external_dns_role_arn = module.orc8r.external_dns_role_arn
+  secretsmanager_orc8r_name = module.orc8r.secretsmanager_secret_name
+
+  # these values are really just copied over from db_username
+  # and db_password
+  orc8r_db_host = module.orc8r.orc8r_db_host
+  orc8r_db_name = module.orc8r.orc8r_db_name
+  orc8r_db_user = module.orc8r.orc8r_db_user
+  orc8r_db_pass = module.orc8r.orc8r_db_pass
+
+  nms_db_host = module.orc8r.nms_db_host
+  nms_db_name = module.orc8r.nms_db_name
+  nms_db_user = module.orc8r.nms_db_user
+  nms_db_pass = module.orc8r.nms_db_pass
+  eks_cluster_id = module.orc8r.eks_cluster_id
+  efs_file_system_id = module.orc8r.efs_file_system_id
+  efs_provisioner_role_arn = module.orc8r.efs_provisioner_role_arn
+  elasticsearch_endpoint = module.orc8r.es_endpoint
+}
+
+output "nameservers" {
+  value = module.orc8r.route53_nameservers
+}

--- a/orc8r/cloud/deploy/orc8r_deployer/docker/root/tf/vars.tf.j2
+++ b/orc8r/cloud/deploy/orc8r_deployer/docker/root/tf/vars.tf.j2
@@ -1,0 +1,4 @@
+{% for k in cfg %}
+variable "{{k}}" {
+    default     = {}
+}{% endfor %}

--- a/orc8r/cloud/deploy/orc8r_deployer/docker/run_deployer
+++ b/orc8r/cloud/deploy/orc8r_deployer/docker/run_deployer
@@ -1,0 +1,73 @@
+#!/bin/bash
+
+Print_Help()
+{
+   echo "./run_deployer runs the orc8r deployer container"
+   echo "orc8r deployer contains scripts which enable user to configure, run prechecks"
+   echo "install, upgrade, verify and cleanup an orc8r deployment"
+   echo
+   echo "Syntax: run_deployer [-d|-r|-b|-h]"
+   echo "options:"
+   echo "-h     Print this Help"
+   echo "-d  deployment dir containing configs and secrets"
+   echo "-r  magma root directory"
+   echo "-b  build the deployer container"
+   echo "note: -deploy_root is mandatory"
+   echo "example: ./run_deployer -deploy_root /tmp/orc8r_14_deployment"
+   echo
+}
+
+if (( $# < 2 )); then
+    # TODO: print usage
+    Print_Help
+    exit 1
+fi
+
+DOCKER_BUILD=false
+while [ -n "$1" ]; do # while loop starts
+	case "$1" in
+	-d)
+        DEPLOY_WORKDIR="$2"
+        shift
+        ;;
+	-r)
+        MAGMA_ROOT="$2"
+        shift
+        ;;
+    -b)
+        DOCKER_BUILD=true
+        shift
+        ;;
+    -h)
+        Print_Help
+        exit;;
+
+	*) echo "Option $1 not recognized" ;;
+	esac
+    shift
+done
+
+if [[ ! -d $DEPLOY_WORKDIR ]]
+then
+    echo "Error ${DEPLOY_WORKDIR} not a directory."
+    exit
+fi
+
+MAGMA_ROOT=${PWD/\/orc8r\/cloud\/deploy\/orc8r_deployer\/docker}
+echo "MAGMA ROOT $MAGMA_ROOT"
+
+if $DOCKER_BUILD; then
+docker build --pull -t ksubraveti/orc8r_deployer:latest .
+fi
+
+# copy terraform files to the deployment directory
+if [ ! -f "${DEPLOY_WORKDIR}/vars.tf" ]; then
+    cp root/tf/vars.tf ${DEPLOY_WORKDIR}
+fi
+if [[ $? -eq 0 ]]; then
+docker run -it \
+    -v "${DEPLOY_WORKDIR}":/root/project \
+    -v "${MAGMA_ROOT}":/root/magma \
+    -v /var/run/docker.sock:/var/run/docker.sock \
+    --rm ksubraveti/orc8r_deployer:latest bash
+fi

--- a/orc8r/cloud/deploy/terraform/orc8r-aws/providers.tf
+++ b/orc8r/cloud/deploy/terraform/orc8r-aws/providers.tf
@@ -41,3 +41,18 @@ provider "kubernetes" {
   # See https://github.com/terraform-providers/terraform-provider-kubernetes/issues/759
   version = "~> 1.10.0"
 }
+
+provider "template" {
+  version = "~> 2.0"
+}
+
+provider "helm" {
+  kubernetes {
+    host                   = data.aws_eks_cluster.cluster.endpoint
+    cluster_ca_certificate = base64decode(data.aws_eks_cluster.cluster.certificate_authority.0.data)
+    token                  = data.aws_eks_cluster_auth.cluster.token
+    load_config_file       = false
+  }
+
+  version = "~> 1.0"
+}

--- a/orc8r/cloud/deploy/terraform/orc8r-aws/vpc.tf
+++ b/orc8r/cloud/deploy/terraform/orc8r-aws/vpc.tf
@@ -14,7 +14,6 @@
 module "vpc" {
   source  = "terraform-aws-modules/vpc/aws"
   version = "~> 2.17.0"
-
   name = var.vpc_name
   azs  = data.aws_availability_zones.available.names
 


### PR DESCRIPTION
## Summary

Following PR adds following post verification steps
- Helm charts were properly deployed
- Kubernetes pods are in running state
- Get all networks and LTE networks from Orc8r and verify if API calls are working as expected

## Test Plan
- Ran this manually and it worked as expected
```
TASK [services/orc8r : Get all configured networks from NMS pod] **************************************************************************************************************************************************************************
changed: [localhost] => (item=magma/v1/networks) => {"ansible_loop_var": "item", "changed": true, "cmd": "kubectl -n \"orc8r\" exec \"nms-magmalte-749b744d5b-rdkbk\" -- curl --cert \"/run/secrets/admin_operator.pem\" --key \"/run/secrets/admin_operator.key.pem\" -k -X GET https://\"api.staging.testminster.com\"/\"magma/v1/networks\"", "delta": "0:00:00.789331", "end": "2021-03-31 20:04:15.315769", "item": "magma/v1/networks", "rc": 0, "start": "2021-03-31 20:04:14.526438", "stderr": "  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current\n                                 Dload  Upload   Total   Spent    Left  Speed\n\r  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0\r100     3  100     3    0     0     24      0 --:--:-- --:--:-- --:--:--    24", "stderr_lines": ["  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current", "                                 Dload  Upload   Total   Spent    Left  Speed", "", "  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0", "100     3  100     3    0     0     24      0 --:--:-- --:--:-- --:--:--    24"], "stdout": "[]", "stdout_lines": ["[]"]}
changed: [localhost] => (item=magma/v1/lte) => {"ansible_loop_var": "item", "changed": true, "cmd": "kubectl -n \"orc8r\" exec \"nms-magmalte-749b744d5b-rdkbk\" -- curl --cert \"/run/secrets/admin_operator.pem\" --key \"/run/secrets/admin_operator.key.pem\" -k -X GET https://\"api.staging.testminster.com\"/\"magma/v1/lte\"", "delta": "0:00:00.750913", "end": "2021-03-31 20:04:16.249109", "item": "magma/v1/lte", "rc": 0, "start": "2021-03-31 20:04:15.498196", "stderr": "  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current\n                                 Dload  Upload   Total   Spent    Left  Speed\n\r  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0\r100     3  100     3    0     0     53      0 --:--:-- --:--:-- --:--:--    53", "stderr_lines": ["  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current", "                                 Dload  Upload   Total   Spent    Left  Speed", "", "  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0", "100     3  100     3    0     0     53      0 --:--:-- --:--:-- --:--:--    53"], "stdout": "[]", "stdout_lines": ["[]"]}

PLAY RECAP ********************************************************************************************************************************************************************************************************************************
localhost                  : ok=16   changed=8    unreachable=0    failed=0    skipped=2    rescued=0    ignored=0
```
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
