### PR TITLE
[CI] Turn up Github Action for Shellcheck

### DIFF
--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -1,0 +1,20 @@
+name: Shellcheck by Reviewdog 
+on: [pull_request]
+jobs:
+  shellcheck:
+    name: runner / shellcheck
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - name: shellcheck
+        uses: reviewdog/action-shellcheck@v1
+        with:
+          github_token: ${{ secrets.github_token }}
+          filter_mode: diff_context # Any changed content.
+          reporter: github-pr-review # Post code review comments.
+          pattern: "*.sh" # Optional.
+          # Other options omitted here but possible.
+          # - fail_on_error
+          # - path
+          # - exclude
+          # - shellcheck_flags


### PR DESCRIPTION
[ShellCheck - A shell script static analysis tool](https://github.com/koalaman/shellcheck).

Here we use a GH Action provided by the Reviewdog library - which will drop review comments onto the PR with the findings.  These review comments can be "resolved" or commented on.

The mode will presently filter based upon `filter_mode: diff_context` -> meaning only modified lines will be reported for findings.

Example output:

![Screen Shot 2021-03-31 at 10 39 40 AM](https://user-images.githubusercontent.com/3752618/113162590-6f08a600-920d-11eb-81e8-bb63fecb4de6.png)


Signed-off-by: Scott Harrison Moeller <smoeller@fb.com>