### PR TITLE
[CI] Fail gcc-problems checker if builds fail

### DIFF
--- a/.github/workflows/gcc-problems.yml
+++ b/.github/workflows/gcc-problems.yml
@@ -113,9 +113,11 @@ jobs:
           run: |
             cd /magma/lte/gateway/
             CPPFLAGS="-Wextra -Wshadow -Wimplicit-fallthrough -Wduplicated-cond -Wduplicated-branches -Wlogical-op -Wnull-dereference -Wjump-misses-init -Wformat=2 -Wstrict-overflow=4 -Wuninitialized -Wshift-overflow=2" make build_oai 2>&1 > /magma/compile.log
+            BUILD_EXIT_CODE=$?
             for file in ${{ steps.changed_files.outputs.all }};
-            do grep $file /magma/compile.log | xo '/\/magma\/((.*):(\d+):(\d+):\s+(?:fatal\s)?(warning|error):\s+(.*))/$1/' || true;
+            do grep "$file" /magma/compile.log | xo "/\/magma\/((.*):(\d+):(\d+):\s+(?:fatal\s)?(warning|error):\s+(.*))/$1/" || true;
             done;
+            exit $BUILD_EXIT_CODE
       -
         name: Store build_logs_oai Artifact
         uses: actions/upload-artifact@v2
@@ -171,9 +173,11 @@ jobs:
           run: |
             cd /magma/lte/gateway/
             CPPFLAGS="-Wextra -Wshadow -Wimplicit-fallthrough -Wduplicated-cond -Wduplicated-branches -Wlogical-op -Wnull-dereference -Wjump-misses-init -Wformat=2 -Wstrict-overflow=4 -Wuninitialized -Wshift-overflow=2" make build_session_manager 2>&1 > /magma/compile.log
+            BUILD_EXIT_CODE=$?
             for file in ${{ steps.changed_files.outputs.all }};
-            do grep $file /magma/compile.log | xo '/\/magma\/((.*):(\d+):(\d+):\s+(?:fatal\s)?(warning|error):\s+(.*))/$1/' || true;
+            do grep "$file" /magma/compile.log | xo "/\/magma\/((.*):(\d+):(\d+):\s+(?:fatal\s)?(warning|error):\s+(.*))/$1/" || true;
             done;
+            exit $BUILD_EXIT_CODE
       -
         name: Store build_logs_session_manager Artifact
         uses: actions/upload-artifact@v2


### PR DESCRIPTION
## Summary

Capture the build status for OAI, session_manager when doing GCC warning annotations - return failure status if build fails.

This can then be used as a Required check by Github for a PR Merge.

Making the status of these stages blocking for Github Merge requires UI involvement by an admin, separate from this PR.

## Test

Pushed a [master-breaking OAI change](https://github.com/magma/magma/actions/runs/705306327) and observed the check failure for the following job.

- `build_oai`
- or `build_session_manager`

Signed-off-by: Scott Harrison Moeller <smoeller@fb.com>