### PR TITLE
[codeowners] Fix script to pull codeowners

### DIFF
--- a/scripts/codeowners.bash
+++ b/scripts/codeowners.bash
@@ -12,16 +12,35 @@
 
 # codeowners.bash prints information on the current set of Magma codeowners.
 
-codeowners=$(curl --silent --show-error https://raw.githubusercontent.com/magma/magma/master/CODEOWNERS \
-    | egrep --only-matching '@\S+' \
-    | grep --invert-match '@magma/' \
-    | sort \
-    | uniq
+function usage() {
+    echo ${1}
+    exit 1
+}
+
+token=${GITHUB_TOKEN}
+username=${1}
+
+[[ ${token} == '' ]] && usage 'GITHUB_TOKEN environment variable must be set to a GitHub personal access token'
+[[ ${username} == '' ]] && usage 'Usage: codeowners.bash YOUR_GITHUB_USERNAME'
+
+codeowners=$(curl --silent --show-error -u ${username}:${token} \
+    -H "Accept: application/vnd.github.v3+json" \
+    https://api.github.com/organizations/66266171/team/4477370/members \
+    | jq '.[].login' \
+    | tr -d '"' \
+    | sort
 )
 n_codeowners=$(echo ${codeowners} | wc -w)
 n_majority=$(python3 -c "import math; print(math.floor((${n_codeowners}/2)+1))")
 
-echo ${codeowners}
+echo ''
+echo 'This script pulls the set of codeowners as defined by the magma/magma-maintainers GitHub team.'
+echo 'That team is expected to be kept manually updated to reflect the magma/magma CODEOWNERS file.'
+echo 'To double-check, consider looking through'
+echo '    - CODEOWNERS file: https://github.com/magma/magma/blob/master/CODEOWNERS'
+echo '    - All Magma teams: https://github.com/orgs/magma/teams'
+echo ''
+echo "${codeowners}"
 echo ''
 echo ${n_codeowners} total codeowners
 echo ${n_majority} constitutes majority


### PR DESCRIPTION
## Summary

As we move to team-based approvers, the flat curl of CODEOWNERS file is insufficient. Instead, we'll rely on the magma maintainers team remaining in-sync with actual set of codeowners.

## Test Plan

- [x] Manual inspection

```
~/magma co *4                                                                                                                                                    1m 4s
$ ./scripts/codeowners.bash hcgatewood

This script pulls the set of codeowners as defined by the magma/magma-maintainers GitHub team.
That team is expected to be kept manually updated to reflect the magma/magma CODEOWNERS file.
To double-check, consider looking through
    - CODEOWNERS file: https://github.com/magma/magma/blob/master/CODEOWNERS
    - All Magma teams: https://github.com/orgs/magma/teams

119Vik
AyliD
HannaFar
Scott8440
aharonnovo
amarpad
andreilee
ardzoht
arunuke
electronjoe
emakeev
hcgatewood
karthiksubraveti
koolzz
lionelgo
mattymo
mcallahan
mpgermano
pshelar
r-i-g
rdefosse
ssanadhya
themarwhal
tmdzk
ulaskozat
uri200

26 total codeowners
14 constitutes majority
```

## Additional Information

- [ ] This change is backwards-breaking