### PR TITLE
[docs][orc8r] Fix wrong v1.4 apidocs URL

### DIFF
--- a/docs/docusaurus/versioned_docs/version-1.4.0/faq/faq_magma.md
+++ b/docs/docusaurus/versioned_docs/version-1.4.0/faq/faq_magma.md
@@ -93,7 +93,7 @@ This section lists some of the commonly asked questions related to Magma operati
   - Login to Gateway, then run `sudo checkin_cli.py`.
 
 ### Where can I find API endpoint?
-  - If you have followed the [install guide](https://magma.github.io/magma/docs/orc8r/deploy_install), it'll be at `https://api.youdomain.com/swagger/v1/ui/`.
+  - If you have followed the [install guide](https://magma.github.io/magma/docs/orc8r/deploy_install), it'll be at `https://api.youdomain.com/apidocs/v1/`.
   - You will need to load the `admin_operator.pfx` certificate into your keychain/browser, otherwise, API access will be blocked.
 
 ### How can I use Swagger UI to trigger API request?

--- a/docs/docusaurus/versioned_docs/version-1.4.0/feg/deploy_install.md
+++ b/docs/docusaurus/versioned_docs/version-1.4.0/feg/deploy_install.md
@@ -139,7 +139,7 @@ registered with the Orchestrator. At this time, NMS support for FeG
 registration is still in-progress.
 
 To register the FeG, go to the Orchestrator's Swagger UI in your browser.
-(i.e. https://controller.url.sample:9443/swagger/v1/ui/).
+(i.e. https://controller.url.sample:9443/apidocs/v1/).
 
 Now, create a Federation Network. This is found at `/feg` under the
 **Federation Networks** section. Then register the gateway under the

--- a/docs/docusaurus/versioned_docs/version-1.4.0/orc8r/deploy_install.md
+++ b/docs/docusaurus/versioned_docs/version-1.4.0/orc8r/deploy_install.md
@@ -326,7 +326,7 @@ will rightfully complain. Either ignore the browser warnings at your own risk
 ](https://stackoverflow.com/questions/7580508/getting-chrome-to-accept-self-signed-localhost-certificate).
 
 For interacting with the Orchestrator REST API, a good starting point is the
-Swagger UI available at `https://api.yoursubdomain.yourdomain.com/swagger/v1/ui/`.
+Swagger UI available at `https://api.yoursubdomain.yourdomain.com/apidocs/v1/`.
 
 If desired, you can also visit the AWS endpoints directly. The relevant
 services are `nginx-proxy` for NMS and `orc8r-nginx-proxy` for Orchestrator


### PR DESCRIPTION
## Summary

New URL wasn't used as of v1.4, so revert the changes to those versioned docs.

## Test Plan

n/a

## Additional Information

- [ ] This change is backwards-breaking