### PR TITLE
[1.5] Update NMS DB Migration script download reference

### DIFF
--- a/docs/readmes/orc8r/upgrade_1_5.md
+++ b/docs/readmes/orc8r/upgrade_1_5.md
@@ -19,4 +19,4 @@ Run on a machine with access to the kubernetes cluster you are using to run Magm
 
 *Paste in shell prompt:*
 
-`wget https://gist.githubusercontent.com/andreilee/7aa7d533e2e8f425222b1e6a016a6f5a/raw/286abea80fbec8d03df9949d74f6f2dd298d8222/pre-upgrade-migration.sh && chmod +x pre-upgrade-migration.sh && ./pre-upgrade-migration.sh`
+`wget https://raw.githubusercontent.com/magma/magma/master/nms/app/packages/magmalte/scripts/fuji-upgrade/pre-upgrade-migration.sh && chmod +x pre-upgrade-migration.sh && ./pre-upgrade-migration.sh`

--- a/nms/app/packages/magmalte/scripts/fuji-upgrade/README.md
+++ b/nms/app/packages/magmalte/scripts/fuji-upgrade/README.md
@@ -10,4 +10,4 @@ Run on a machine with access to the kubernetes cluster you are using to run Magm
 
 *Paste in shell prompt:*
 
-`wget https://gist.githubusercontent.com/andreilee/7aa7d533e2e8f425222b1e6a016a6f5a/raw/286abea80fbec8d03df9949d74f6f2dd298d8222/pre-upgrade-migration.sh && chmod +x pre-upgrade-migration.sh && ./pre-upgrade-migration.sh`
+`wget https://raw.githubusercontent.com/magma/magma/master/nms/app/packages/magmalte/scripts/fuji-upgrade/pre-upgrade-migration.sh && chmod +x pre-upgrade-migration.sh && ./pre-upgrade-migration.sh`

--- a/nms/app/packages/magmalte/scripts/fuji-upgrade/pre-upgrade-migration.sh
+++ b/nms/app/packages/magmalte/scripts/fuji-upgrade/pre-upgrade-migration.sh
@@ -12,7 +12,7 @@
 # limitations under the License.
 ################################################################################
 
-NMS_SCRIPT_URI="https://raw.githubusercontent.com/magma/magma/231fc6e27cf18a2f9c8bae94306897cbf4471e42/nms/app/packages/magmalte/scripts/fuji-upgrade/pre-upgrade-migration.sh"
+NMS_SCRIPT_URI="https://raw.githubusercontent.com/magma/magma/master/nms/app/packages/magmalte/scripts/fuji-upgrade/runs-on-nms.sh"
 
 cat << EOF
 ================================================================================

--- a/nms/app/packages/magmalte/scripts/fuji-upgrade/pre-upgrade-migration.sh
+++ b/nms/app/packages/magmalte/scripts/fuji-upgrade/pre-upgrade-migration.sh
@@ -12,7 +12,7 @@
 # limitations under the License.
 ################################################################################
 
-NMS_SCRIPT_URI="https://gist.githubusercontent.com/andreilee/7aa7d533e2e8f425222b1e6a016a6f5a/raw/5b3c9346dedca6dcfb8d0a13c5f3b4d9100b9279/runs-on-nms.sh"
+NMS_SCRIPT_URI="https://raw.githubusercontent.com/magma/magma/231fc6e27cf18a2f9c8bae94306897cbf4471e42/nms/app/packages/magmalte/scripts/fuji-upgrade/pre-upgrade-migration.sh"
 
 cat << EOF
 ================================================================================


### PR DESCRIPTION
Signed-off-by: Andrei Lee <andreilee@fb.com>

## Summary

Modifying download URLs for the scripts added in #5709 - these now link to the magma repo rather than my personal Github gist.

## Test Plan

Verified previously with minikube in #5709 

## Additional Information

- [ ] This change is backwards-breaking
