### PR TITLE
[AGW] Modify postinst script to append or replace the COMMIT_HASH env var

### DIFF
--- a/lte/gateway/release/magma-postinst
+++ b/lte/gateway/release/magma-postinst
@@ -16,7 +16,13 @@ sed -i "s/.*OVS_CTL_OPTS.*/OVS_CTL_OPTS='--delete-bridges'/" /etc/default/openvs
 # Create /var/core directory
 mkdir -p /var/core
 
-sudo cat /usr/local/share/magma/commit_hash > /etc/environment
+value=`cat /usr/local/share/magma/commit_hash`
+if sudo grep -q "COMMIT_HASH" /etc/environment
+then
+    sudo sed -i -e "s/^COMMIT_HASH.*/$value/" /etc/environment
+else
+    sudo cat "$value" >> /etc/environment
+fi
 
 # Set magmad service to start on boot
 systemctl enable -f magma@magmad.service

--- a/lte/gateway/release/magma.lockfile
+++ b/lte/gateway/release/magma.lockfile
@@ -438,6 +438,12 @@
       "sysdep": "python3-scapy",
       "version": "2.4.4"
     },
+    "sentry-sdk": {
+      "root": true,
+      "source": "pypi",
+      "sysdep": "python3-sentry-sdk",
+      "version": "1.0.0"
+    },
     "simplejson": {
       "root": false,
       "source": "apt",
@@ -1152,6 +1158,9 @@
     },
     "scapy": {
       "version": "2.4.4"
+    },
+    "sentry-sdk": {
+      "version": "1.0.0"
     },
     "setuptools": {
       "version": "49.6.0"


### PR DESCRIPTION
<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary
Instead of rewriting the entire /etc/environment file, replace/append the specific variable
<!-- Enumerate changes you made and why you made them -->

## Test Plan
Before upgrading...
```
magma@magma:~$ cat /etc/environment
COMMIT_HASH="5ec8e1fa"
MAGMA_PRINT_GRPC_PAYLOAD="1"
```
After upgrading...
```
magma@magma:~$ cat /etc/environment
COMMIT_HASH="e427a993"
MAGMA_PRINT_GRPC_PAYLOAD="1"
```
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
