### PR TITLE
[GITIGNORE] Ignore python build directories generated during packaging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,8 @@ var/
 *.egg-info/
 .installed.cfg
 *.egg
+orc8r/gateway/python/build
+lte/gateway/python/build
 
 # Ignore test certs
 orc8r/cloud/test_certs/*.csr


### PR DESCRIPTION
Signed-off-by: Marie Bremner <marwhal@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary
These directories get generated during the AGW packaging step. They are not meant to be committed, so adding to .gitignore.
```
➤ Untracked files
#
#      untracked: [2] lte/gateway/python/build/
#      untracked: [3] orc8r/gateway/python/build/
```
<!-- Enumerate changes you made and why you made them -->

## Test Plan
Git ignores these paths with this change!
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
