### PR TITLE
[lte][agw] Remove hardwired APN APMBR over S1

### DIFF
--- a/lte/gateway/c/oai/tasks/mme_app/mme_app_pdn_context.c
+++ b/lte/gateway/c/oai/tasks/mme_app/mme_app_pdn_context.c
@@ -93,7 +93,9 @@ pdn_context_t* mme_app_create_pdn_context(
             &pdn_context->default_bearer_eps_subscribed_qos_profile,
             &apn_configuration->subscribed_qos,
             sizeof(eps_subscribed_qos_profile_t));
-        // pdn_context->subscribed_apn_ambr = ;
+        memcpy(
+            &pdn_context->subscribed_apn_ambr, &apn_configuration->ambr,
+            sizeof(ambr_t));
         // pdn_context->pgw_apn_ambr = ;
         pdn_context->is_active      = true;
         pdn_context->apn_subscribed = blk2bstr(

--- a/lte/gateway/c/oai/tasks/nas/emm/sap/emm_cn.c
+++ b/lte/gateway/c/oai/tasks/nas/emm/sap/emm_cn.c
@@ -571,8 +571,8 @@ static int emm_cn_cs_response_success(emm_cn_cs_response_success_t* msg_pP) {
   rc = esm_send_activate_default_eps_bearer_context_request(
       msg_pP->pti, msg_pP->ebi,
       &esm_msg.activate_default_eps_bearer_context_request,
-      ue_mm_context->pdn_contexts[pdn_cid]->apn_subscribed, &msg_pP->pco,
-      esm_pdn_type, msg_pP->pdn_addr, &qos,
+      ue_mm_context->pdn_contexts[pdn_cid], &msg_pP->pco, esm_pdn_type,
+      msg_pP->pdn_addr, &qos,
       ue_mm_context->pdn_contexts[pdn_cid]->esm_data.esm_cause);
   clear_protocol_configuration_options(&msg_pP->pco);
   if (rc != RETURNerror) {

--- a/lte/gateway/c/oai/tasks/nas/esm/sap/esm_send.h
+++ b/lte/gateway/c/oai/tasks/nas/esm/sap/esm_send.h
@@ -51,6 +51,7 @@ Description Defines functions executed at the ESM Service Access
 #include "3gpp_24.008.h"
 #include "EpsQualityOfService.h"
 #include "bstrlib.h"
+#include "mme_app_ue_context.h"
 
 /****************************************************************************/
 /*********************  G L O B A L    C O N S T A N T S  *******************/
@@ -94,8 +95,9 @@ int esm_send_pdn_disconnect_reject(
  */
 int esm_send_activate_default_eps_bearer_context_request(
     pti_t pti, ebi_t ebi, activate_default_eps_bearer_context_request_msg* msg,
-    bstring apn, const protocol_configuration_options_t* pco, int pdn_type,
-    bstring pdn_addr, const EpsQualityOfService* qos, int esm_cause);
+    pdn_context_t* pdn_context_p, const protocol_configuration_options_t* pco,
+    int pdn_type, bstring pdn_addr, const EpsQualityOfService* qos,
+    int esm_cause);
 
 int esm_send_activate_dedicated_eps_bearer_context_request(
     pti_t pti, ebi_t ebi,

--- a/lte/gateway/c/oai/tasks/nas/ies/ApnAggregateMaximumBitRate.c
+++ b/lte/gateway/c/oai/tasks/nas/ies/ApnAggregateMaximumBitRate.c
@@ -107,3 +107,57 @@ int encode_apn_aggregate_maximum_bit_rate(
   *lenPtr = encoded - 1 - ((iei > 0) ? 1 : 0);
   return encoded;
 }
+
+void bit_rate_value_to_eps_qos(
+    ApnAggregateMaximumBitRate* apn_ambr, uint64_t ambr_dl, uint64_t ambr_ul) {
+  uint64_t ambr_dl_kbps = ambr_dl / 1000;  // ambr_dl is expected in bps
+  uint64_t ambr_ul_kbps = ambr_ul / 1000;  // ambr_ul is expected in bps
+  if (ambr_dl_kbps == 0) {
+    apn_ambr->apnambrfordownlink = 0xff;
+  } else if ((ambr_dl_kbps > 0) && (ambr_dl_kbps <= 63)) {
+    apn_ambr->apnambrfordownlink = ambr_dl_kbps;
+  } else if ((ambr_dl_kbps > 63) && (ambr_dl_kbps <= 568)) {
+    apn_ambr->apnambrfordownlink = ((ambr_dl_kbps - 64) / 8) + 64;
+  } else if ((ambr_dl_kbps > 575) && (ambr_dl_kbps <= 8640)) {
+    apn_ambr->apnambrfordownlink = ((ambr_dl_kbps - 576) / 64) + 576;
+  } else if (ambr_dl_kbps > 8640) {
+    apn_ambr->apnambrfordownlink = 0xfe;
+    apn_ambr->extensions =
+        APN_AGGREGATE_MAXIMUM_BIT_RATE_MAXIMUM_EXTENSION_PRESENT;
+    if ((ambr_dl_kbps >= 8600) && (ambr_dl_kbps <= 16000)) {
+      apn_ambr->apnambrfordownlink_extended = (ambr_dl_kbps - 8600) / 100;
+    } else if ((ambr_dl_kbps > 16000) && (ambr_dl_kbps <= 128000)) {
+      apn_ambr->apnambrfordownlink_extended =
+          ((ambr_dl_kbps - 16000) / 1000) + 74;
+    } else if ((ambr_dl_kbps > 128000) && (ambr_dl_kbps <= 256000)) {
+      apn_ambr->apnambrfordownlink_extended =
+          ((ambr_dl_kbps - 128000) / 2000) + 186;
+    }
+  }
+
+  if (ambr_ul_kbps == 0) {
+    apn_ambr->apnambrforuplink = 0xff;
+  } else if ((ambr_ul_kbps > 0) && (ambr_ul_kbps <= 63)) {
+    apn_ambr->apnambrforuplink = ambr_ul_kbps;
+  } else if ((ambr_ul_kbps > 63) && (ambr_ul_kbps <= 568)) {
+    apn_ambr->apnambrforuplink = ((ambr_ul_kbps - 64) / 8) + 64;
+  } else if ((ambr_ul_kbps > 575) && (ambr_ul_kbps <= 8640)) {
+    apn_ambr->apnambrforuplink = ((ambr_ul_kbps - 576) / 64) + 576;
+  } else if (ambr_ul_kbps > 8640) {
+    apn_ambr->apnambrforuplink = 0xfe;
+    apn_ambr->extensions =
+        APN_AGGREGATE_MAXIMUM_BIT_RATE_MAXIMUM_EXTENSION_PRESENT;
+    if ((ambr_ul_kbps >= 8600) && (ambr_ul_kbps <= 16000)) {
+      apn_ambr->apnambrforuplink_extended = (ambr_ul_kbps - 8600) / 100;
+    } else if ((ambr_ul_kbps > 16000) && (ambr_ul_kbps <= 128000)) {
+      apn_ambr->apnambrforuplink_extended =
+          ((ambr_ul_kbps - 16000) / 1000) + 74;
+    } else if ((ambr_ul_kbps > 128000) && (ambr_ul_kbps <= 256000)) {
+      apn_ambr->apnambrforuplink_extended =
+          ((ambr_ul_kbps - 128000) / 2000) + 186;
+    }
+  }
+
+  apn_ambr->apnambrfordownlink_extended2 = 0;
+  apn_ambr->apnambrforuplink_extended2   = 0;
+}

--- a/lte/gateway/c/oai/tasks/nas/ies/ApnAggregateMaximumBitRate.c
+++ b/lte/gateway/c/oai/tasks/nas/ies/ApnAggregateMaximumBitRate.c
@@ -108,6 +108,7 @@ int encode_apn_aggregate_maximum_bit_rate(
   return encoded;
 }
 
+// Use 3GPP TS 24.008 figure 10.5.136A, table 10.5.154A
 void bit_rate_value_to_eps_qos(
     ApnAggregateMaximumBitRate* apn_ambr, uint64_t ambr_dl, uint64_t ambr_ul) {
   uint64_t ambr_dl_kbps = ambr_dl / 1000;  // ambr_dl is expected in bps
@@ -116,10 +117,10 @@ void bit_rate_value_to_eps_qos(
     apn_ambr->apnambrfordownlink = 0xff;
   } else if ((ambr_dl_kbps > 0) && (ambr_dl_kbps <= 63)) {
     apn_ambr->apnambrfordownlink = ambr_dl_kbps;
-  } else if ((ambr_dl_kbps > 63) && (ambr_dl_kbps <= 568)) {
+  } else if ((ambr_dl_kbps > 63) && (ambr_dl_kbps <= 575)) {
     apn_ambr->apnambrfordownlink = ((ambr_dl_kbps - 64) / 8) + 64;
   } else if ((ambr_dl_kbps > 575) && (ambr_dl_kbps <= 8640)) {
-    apn_ambr->apnambrfordownlink = ((ambr_dl_kbps - 576) / 64) + 576;
+    apn_ambr->apnambrfordownlink = ((ambr_dl_kbps - 576) / 64) + 128;
   } else if (ambr_dl_kbps > 8640) {
     apn_ambr->apnambrfordownlink = 0xfe;
     apn_ambr->extensions =
@@ -139,10 +140,10 @@ void bit_rate_value_to_eps_qos(
     apn_ambr->apnambrforuplink = 0xff;
   } else if ((ambr_ul_kbps > 0) && (ambr_ul_kbps <= 63)) {
     apn_ambr->apnambrforuplink = ambr_ul_kbps;
-  } else if ((ambr_ul_kbps > 63) && (ambr_ul_kbps <= 568)) {
+  } else if ((ambr_ul_kbps > 63) && (ambr_ul_kbps <= 575)) {
     apn_ambr->apnambrforuplink = ((ambr_ul_kbps - 64) / 8) + 64;
   } else if ((ambr_ul_kbps > 575) && (ambr_ul_kbps <= 8640)) {
-    apn_ambr->apnambrforuplink = ((ambr_ul_kbps - 576) / 64) + 576;
+    apn_ambr->apnambrforuplink = ((ambr_ul_kbps - 576) / 64) + 128;
   } else if (ambr_ul_kbps > 8640) {
     apn_ambr->apnambrforuplink = 0xfe;
     apn_ambr->extensions =

--- a/lte/gateway/c/oai/tasks/nas/ies/ApnAggregateMaximumBitRate.h
+++ b/lte/gateway/c/oai/tasks/nas/ies/ApnAggregateMaximumBitRate.h
@@ -44,4 +44,7 @@ int decode_apn_aggregate_maximum_bit_rate(
     ApnAggregateMaximumBitRate* apnaggregatemaximumbitrate, uint8_t iei,
     uint8_t* buffer, uint32_t len);
 
+void bit_rate_value_to_eps_qos(
+    ApnAggregateMaximumBitRate* apn_ambr, uint64_t ambr_dl, uint64_t ambr_ul);
+
 #endif /* APN_AGGREGATE_MAXIMUM_BIT_RATE_SEEN */

--- a/lte/gateway/c/oai/tasks/nas/ies/EpsQualityOfService.c
+++ b/lte/gateway/c/oai/tasks/nas/ies/EpsQualityOfService.c
@@ -190,8 +190,8 @@ int qos_params_to_eps_qos(
         eps_qos->bitRates.maxBitRateForUL = mbr_ul;
       } else if ((mbr_ul > 63) && (mbr_ul <= 568)) {
         eps_qos->bitRates.maxBitRateForUL = ((mbr_ul - 64) / 8) + 64;
-      } else if ((mbr_ul >= 576) && (mbr_ul <= 8640)) {
-        eps_qos->bitRates.maxBitRateForUL = ((mbr_ul - 128) / 64) + 128;
+      } else if ((mbr_ul > 575) && (mbr_ul <= 8640)) {
+        eps_qos->bitRates.maxBitRateForUL = ((mbr_ul - 576) / 64) + 128;
       } else if (mbr_ul > 8640) {
         eps_qos->bitRates.maxBitRateForUL = 0xfe;
         eps_qos->bitRatesExtPresent       = 1;
@@ -210,8 +210,8 @@ int qos_params_to_eps_qos(
         eps_qos->bitRates.maxBitRateForDL = mbr_dl;
       } else if ((mbr_dl > 63) && (mbr_dl <= 568)) {
         eps_qos->bitRates.maxBitRateForDL = ((mbr_dl - 64) / 8) + 64;
-      } else if ((mbr_dl >= 576) && (mbr_dl <= 8640)) {
-        eps_qos->bitRates.maxBitRateForDL = ((mbr_dl - 128) / 64) + 128;
+      } else if ((mbr_dl > 575) && (mbr_dl <= 8640)) {
+        eps_qos->bitRates.maxBitRateForDL = ((mbr_dl - 576) / 64) + 128;
       } else if (mbr_dl > 8640) {
         eps_qos->bitRates.maxBitRateForDL = 0xfe;
         eps_qos->bitRatesExtPresent       = 1;
@@ -230,8 +230,8 @@ int qos_params_to_eps_qos(
         eps_qos->bitRates.guarBitRateForUL = gbr_ul;
       } else if ((gbr_ul > 63) && (gbr_ul <= 568)) {
         eps_qos->bitRates.guarBitRateForUL = ((gbr_ul - 64) / 8) + 64;
-      } else if ((gbr_ul >= 576) && (gbr_ul <= 8640)) {
-        eps_qos->bitRates.guarBitRateForUL = ((gbr_ul - 128) / 64) + 128;
+      } else if ((gbr_ul > 575) && (gbr_ul <= 8640)) {
+        eps_qos->bitRates.guarBitRateForUL = ((gbr_ul - 576) / 64) + 128;
       } else if (gbr_ul > 8640) {
         eps_qos->bitRates.guarBitRateForUL = 0xfe;
         eps_qos->bitRatesExtPresent        = 1;
@@ -251,8 +251,8 @@ int qos_params_to_eps_qos(
         eps_qos->bitRates.guarBitRateForDL = gbr_dl;
       } else if ((gbr_dl > 63) && (gbr_dl <= 568)) {
         eps_qos->bitRates.guarBitRateForDL = ((gbr_dl - 64) / 8) + 64;
-      } else if ((gbr_dl >= 576) && (gbr_dl <= 8640)) {
-        eps_qos->bitRates.guarBitRateForDL = ((gbr_dl - 128) / 64) + 128;
+      } else if ((gbr_dl >= 575) && (gbr_dl <= 8640)) {
+        eps_qos->bitRates.guarBitRateForDL = ((gbr_dl - 576) / 64) + 128;
       } else if (gbr_dl > 8640) {
         eps_qos->bitRates.guarBitRateForDL = 0xfe;
         eps_qos->bitRatesExtPresent        = 1;

--- a/lte/gateway/c/oai/tasks/nas/ies/EpsQualityOfService.c
+++ b/lte/gateway/c/oai/tasks/nas/ies/EpsQualityOfService.c
@@ -178,92 +178,98 @@ int qos_params_to_eps_qos(
     const qci_t qci, const bitrate_t mbr_dl, const bitrate_t mbr_ul,
     const bitrate_t gbr_dl, const bitrate_t gbr_ul,
     EpsQualityOfService* const eps_qos, bool is_default_bearer) {
-  // if someone volunteer for subroutines..., no time yet.
+  uint64_t mbr_dl_kbps = mbr_dl / 1000;  // mbr_dl is expected in bps
+  uint64_t mbr_ul_kbps = mbr_ul / 1000;  // mbr_ul is expected in bps
+  uint64_t gbr_dl_kbps = gbr_dl / 1000;  // mbr_dl is expected in bps
+  uint64_t gbr_ul_kbps = gbr_ul / 1000;  // mbr_ul is expected in bps
+
   if (eps_qos) {
     memset(eps_qos, 0, sizeof(EpsQualityOfService));
     eps_qos->qci = qci;
     if (!is_default_bearer) {
       eps_qos->bitRatesPresent = 1;
-      if (mbr_ul == 0) {
+      if (mbr_ul_kbps == 0) {
         eps_qos->bitRates.maxBitRateForUL = 0xff;
-      } else if ((mbr_ul > 0) && (mbr_ul <= 63)) {
-        eps_qos->bitRates.maxBitRateForUL = mbr_ul;
-      } else if ((mbr_ul > 63) && (mbr_ul <= 575)) {
-        eps_qos->bitRates.maxBitRateForUL = ((mbr_ul - 64) / 8) + 64;
-      } else if ((mbr_ul > 575) && (mbr_ul <= 8640)) {
-        eps_qos->bitRates.maxBitRateForUL = ((mbr_ul - 576) / 64) + 128;
-      } else if (mbr_ul > 8640) {
+      } else if ((mbr_ul_kbps > 0) && (mbr_ul_kbps <= 63)) {
+        eps_qos->bitRates.maxBitRateForUL = mbr_ul_kbps;
+      } else if ((mbr_ul_kbps > 63) && (mbr_ul_kbps <= 575)) {
+        eps_qos->bitRates.maxBitRateForUL = ((mbr_ul_kbps - 64) / 8) + 64;
+      } else if ((mbr_ul_kbps > 575) && (mbr_ul_kbps <= 8640)) {
+        eps_qos->bitRates.maxBitRateForUL = ((mbr_ul_kbps - 576) / 64) + 128;
+      } else if (mbr_ul_kbps > 8640) {
         eps_qos->bitRates.maxBitRateForUL = 0xfe;
         eps_qos->bitRatesExtPresent       = 1;
-        if ((mbr_ul >= 8600) && (mbr_ul <= 16000)) {
-          eps_qos->bitRatesExt.maxBitRateForUL = (mbr_ul - 8600) / 100;
-        } else if ((mbr_ul > 16000) && (mbr_ul <= 128000)) {
-          eps_qos->bitRatesExt.maxBitRateForUL = ((mbr_ul - 16000) / 1000) + 74;
-        } else if ((mbr_ul > 128000) && (mbr_ul <= 256000)) {
+        if ((mbr_ul_kbps >= 8600) && (mbr_ul_kbps <= 16000)) {
+          eps_qos->bitRatesExt.maxBitRateForUL = (mbr_ul_kbps - 8600) / 100;
+        } else if ((mbr_ul_kbps > 16000) && (mbr_ul_kbps <= 128000)) {
           eps_qos->bitRatesExt.maxBitRateForUL =
-              ((mbr_ul - 128000) / 2000) + 186;
+              ((mbr_ul_kbps - 16000) / 1000) + 74;
+        } else if ((mbr_ul_kbps > 128000) && (mbr_ul_kbps <= 256000)) {
+          eps_qos->bitRatesExt.maxBitRateForUL =
+              ((mbr_ul_kbps - 128000) / 2000) + 186;
         }
       }
-      if (mbr_dl == 0) {
+      if (mbr_dl_kbps == 0) {
         eps_qos->bitRates.maxBitRateForDL = 0xff;
-      } else if ((mbr_dl > 0) && (mbr_dl <= 63)) {
-        eps_qos->bitRates.maxBitRateForDL = mbr_dl;
-      } else if ((mbr_dl > 63) && (mbr_dl <= 575)) {
-        eps_qos->bitRates.maxBitRateForDL = ((mbr_dl - 64) / 8) + 64;
-      } else if ((mbr_dl > 575) && (mbr_dl <= 8640)) {
-        eps_qos->bitRates.maxBitRateForDL = ((mbr_dl - 576) / 64) + 128;
-      } else if (mbr_dl > 8640) {
+      } else if ((mbr_dl_kbps > 0) && (mbr_dl_kbps <= 63)) {
+        eps_qos->bitRates.maxBitRateForDL = mbr_dl_kbps;
+      } else if ((mbr_dl_kbps > 63) && (mbr_dl_kbps <= 575)) {
+        eps_qos->bitRates.maxBitRateForDL = ((mbr_dl_kbps - 64) / 8) + 64;
+      } else if ((mbr_dl_kbps > 575) && (mbr_dl_kbps <= 8640)) {
+        eps_qos->bitRates.maxBitRateForDL = ((mbr_dl_kbps - 576) / 64) + 128;
+      } else if (mbr_dl_kbps > 8640) {
         eps_qos->bitRates.maxBitRateForDL = 0xfe;
         eps_qos->bitRatesExtPresent       = 1;
-        if ((mbr_dl >= 8600) && (mbr_dl <= 16000)) {
-          eps_qos->bitRatesExt.maxBitRateForDL = (mbr_dl - 8600) / 100;
-        } else if ((mbr_dl > 16000) && (mbr_dl <= 128000)) {
-          eps_qos->bitRatesExt.maxBitRateForDL = ((mbr_dl - 16000) / 1000) + 74;
-        } else if ((mbr_dl > 128000) && (mbr_dl <= 256000)) {
+        if ((mbr_dl_kbps >= 8600) && (mbr_dl_kbps <= 16000)) {
+          eps_qos->bitRatesExt.maxBitRateForDL = (mbr_dl_kbps - 8600) / 100;
+        } else if ((mbr_dl_kbps > 16000) && (mbr_dl_kbps <= 128000)) {
           eps_qos->bitRatesExt.maxBitRateForDL =
-              ((mbr_dl - 128000) / 2000) + 186;
+              ((mbr_dl_kbps - 16000) / 1000) + 74;
+        } else if ((mbr_dl_kbps > 128000) && (mbr_dl_kbps <= 256000)) {
+          eps_qos->bitRatesExt.maxBitRateForDL =
+              ((mbr_dl_kbps - 128000) / 2000) + 186;
         }
       }
-      if (gbr_ul == 0) {
+      if (gbr_ul_kbps == 0) {
         eps_qos->bitRates.guarBitRateForUL = 0xff;
-      } else if ((gbr_ul > 0) && (gbr_ul <= 63)) {
-        eps_qos->bitRates.guarBitRateForUL = gbr_ul;
-      } else if ((gbr_ul > 63) && (gbr_ul <= 575)) {
-        eps_qos->bitRates.guarBitRateForUL = ((gbr_ul - 64) / 8) + 64;
-      } else if ((gbr_ul > 575) && (gbr_ul <= 8640)) {
-        eps_qos->bitRates.guarBitRateForUL = ((gbr_ul - 576) / 64) + 128;
-      } else if (gbr_ul > 8640) {
+      } else if ((gbr_ul_kbps > 0) && (gbr_ul_kbps <= 63)) {
+        eps_qos->bitRates.guarBitRateForUL = gbr_ul_kbps;
+      } else if ((gbr_ul_kbps > 63) && (gbr_ul_kbps <= 575)) {
+        eps_qos->bitRates.guarBitRateForUL = ((gbr_ul_kbps - 64) / 8) + 64;
+      } else if ((gbr_ul_kbps > 575) && (gbr_ul_kbps <= 8640)) {
+        eps_qos->bitRates.guarBitRateForUL = ((gbr_ul_kbps - 576) / 64) + 128;
+      } else if (gbr_ul_kbps > 8640) {
         eps_qos->bitRates.guarBitRateForUL = 0xfe;
         eps_qos->bitRatesExtPresent        = 1;
-        if ((gbr_ul >= 8600) && (gbr_ul <= 16000)) {
-          eps_qos->bitRatesExt.guarBitRateForUL = (gbr_ul - 8600) / 100;
-        } else if ((gbr_ul > 16000) && (gbr_ul <= 128000)) {
+        if ((gbr_ul_kbps >= 8600) && (gbr_ul_kbps <= 16000)) {
+          eps_qos->bitRatesExt.guarBitRateForUL = (gbr_ul_kbps - 8600) / 100;
+        } else if ((gbr_ul_kbps > 16000) && (gbr_ul_kbps <= 128000)) {
           eps_qos->bitRatesExt.guarBitRateForUL =
-              ((gbr_ul - 16000) / 1000) + 74;
-        } else if ((gbr_ul > 128000) && (gbr_ul <= 256000)) {
+              ((gbr_ul_kbps - 16000) / 1000) + 74;
+        } else if ((gbr_ul_kbps > 128000) && (gbr_ul_kbps <= 256000)) {
           eps_qos->bitRatesExt.guarBitRateForUL =
-              ((gbr_ul - 128000) / 2000) + 186;
+              ((gbr_ul_kbps - 128000) / 2000) + 186;
         }
       }
-      if (gbr_dl == 0) {
+      if (gbr_dl_kbps == 0) {
         eps_qos->bitRates.guarBitRateForDL = 0xff;
-      } else if ((gbr_dl > 0) && (gbr_dl <= 63)) {
-        eps_qos->bitRates.guarBitRateForDL = gbr_dl;
-      } else if ((gbr_dl > 63) && (gbr_dl <= 575)) {
-        eps_qos->bitRates.guarBitRateForDL = ((gbr_dl - 64) / 8) + 64;
-      } else if ((gbr_dl >= 575) && (gbr_dl <= 8640)) {
-        eps_qos->bitRates.guarBitRateForDL = ((gbr_dl - 576) / 64) + 128;
-      } else if (gbr_dl > 8640) {
+      } else if ((gbr_dl_kbps > 0) && (gbr_dl_kbps <= 63)) {
+        eps_qos->bitRates.guarBitRateForDL = gbr_dl_kbps;
+      } else if ((gbr_dl_kbps > 63) && (gbr_dl_kbps <= 575)) {
+        eps_qos->bitRates.guarBitRateForDL = ((gbr_dl_kbps - 64) / 8) + 64;
+      } else if ((gbr_dl_kbps >= 575) && (gbr_dl_kbps <= 8640)) {
+        eps_qos->bitRates.guarBitRateForDL = ((gbr_dl_kbps - 576) / 64) + 128;
+      } else if (gbr_dl_kbps > 8640) {
         eps_qos->bitRates.guarBitRateForDL = 0xfe;
         eps_qos->bitRatesExtPresent        = 1;
-        if ((gbr_dl >= 8600) && (gbr_dl <= 16000)) {
-          eps_qos->bitRatesExt.guarBitRateForDL = (gbr_dl - 8600) / 100;
-        } else if ((gbr_dl > 16000) && (gbr_dl <= 128000)) {
+        if ((gbr_dl_kbps >= 8600) && (gbr_dl_kbps <= 16000)) {
+          eps_qos->bitRatesExt.guarBitRateForDL = (gbr_dl_kbps - 8600) / 100;
+        } else if ((gbr_dl_kbps > 16000) && (gbr_dl_kbps <= 128000)) {
           eps_qos->bitRatesExt.guarBitRateForDL =
-              ((gbr_dl - 16000) / 1000) + 74;
-        } else if ((gbr_dl > 128000) && (gbr_dl <= 256000)) {
+              ((gbr_dl_kbps - 16000) / 1000) + 74;
+        } else if ((gbr_dl_kbps > 128000) && (gbr_dl_kbps <= 256000)) {
           eps_qos->bitRatesExt.guarBitRateForDL =
-              ((gbr_dl - 128000) / 2000) + 186;
+              ((gbr_dl_kbps - 128000) / 2000) + 186;
         }
       }
     }

--- a/lte/gateway/c/oai/tasks/nas/ies/EpsQualityOfService.c
+++ b/lte/gateway/c/oai/tasks/nas/ies/EpsQualityOfService.c
@@ -188,7 +188,7 @@ int qos_params_to_eps_qos(
         eps_qos->bitRates.maxBitRateForUL = 0xff;
       } else if ((mbr_ul > 0) && (mbr_ul <= 63)) {
         eps_qos->bitRates.maxBitRateForUL = mbr_ul;
-      } else if ((mbr_ul > 63) && (mbr_ul <= 568)) {
+      } else if ((mbr_ul > 63) && (mbr_ul <= 575)) {
         eps_qos->bitRates.maxBitRateForUL = ((mbr_ul - 64) / 8) + 64;
       } else if ((mbr_ul > 575) && (mbr_ul <= 8640)) {
         eps_qos->bitRates.maxBitRateForUL = ((mbr_ul - 576) / 64) + 128;
@@ -208,7 +208,7 @@ int qos_params_to_eps_qos(
         eps_qos->bitRates.maxBitRateForDL = 0xff;
       } else if ((mbr_dl > 0) && (mbr_dl <= 63)) {
         eps_qos->bitRates.maxBitRateForDL = mbr_dl;
-      } else if ((mbr_dl > 63) && (mbr_dl <= 568)) {
+      } else if ((mbr_dl > 63) && (mbr_dl <= 575)) {
         eps_qos->bitRates.maxBitRateForDL = ((mbr_dl - 64) / 8) + 64;
       } else if ((mbr_dl > 575) && (mbr_dl <= 8640)) {
         eps_qos->bitRates.maxBitRateForDL = ((mbr_dl - 576) / 64) + 128;
@@ -228,7 +228,7 @@ int qos_params_to_eps_qos(
         eps_qos->bitRates.guarBitRateForUL = 0xff;
       } else if ((gbr_ul > 0) && (gbr_ul <= 63)) {
         eps_qos->bitRates.guarBitRateForUL = gbr_ul;
-      } else if ((gbr_ul > 63) && (gbr_ul <= 568)) {
+      } else if ((gbr_ul > 63) && (gbr_ul <= 575)) {
         eps_qos->bitRates.guarBitRateForUL = ((gbr_ul - 64) / 8) + 64;
       } else if ((gbr_ul > 575) && (gbr_ul <= 8640)) {
         eps_qos->bitRates.guarBitRateForUL = ((gbr_ul - 576) / 64) + 128;
@@ -249,7 +249,7 @@ int qos_params_to_eps_qos(
         eps_qos->bitRates.guarBitRateForDL = 0xff;
       } else if ((gbr_dl > 0) && (gbr_dl <= 63)) {
         eps_qos->bitRates.guarBitRateForDL = gbr_dl;
-      } else if ((gbr_dl > 63) && (gbr_dl <= 568)) {
+      } else if ((gbr_dl > 63) && (gbr_dl <= 575)) {
         eps_qos->bitRates.guarBitRateForDL = ((gbr_dl - 64) / 8) + 64;
       } else if ((gbr_dl >= 575) && (gbr_dl <= 8640)) {
         eps_qos->bitRates.guarBitRateForDL = ((gbr_dl - 576) / 64) + 128;


### PR DESCRIPTION
## Summary

Two changes are done:
- Eliminate hardwired APN AMBR information in attach accept (which was hardwired to 200 and 100Mbps for DL and UL).
- Fix bugs in mapping QoS values

## Test Plan

Modified default APN AMBR values and dedicated QoS values in S1AP tester, run `test_attach_detach_dedicated.py`, capture pcap and check QoS parameters for APN and bearers.

E.g., for:
```
magma_default_apn = {
    "apn_name": "magma.ipv4",  # APN-name
    "qci": 9,  # qci
    "priority": 15,  # priority
    "pre_cap": 1,  # preemption-capability
    "pre_vul": 0,  # preemption-vulnerability
    "mbr_ul": 96000,  # MBR UL
    "mbr_dl": 1500000,  # MBR DL
}
```
pcap shows (discrepancy is due to specific way of quantizing the field):

```
APN aggregate maximum bit rate
    Element ID: 0x5e
    Length: 2
    APN-AMBR for downlink: 1472 kbps
    APN-AMBR for uplink: 96 kbps
```

and for:

```
qos=FlowQos(
    qci=qci_val,
    gbr_ul=48000,
    gbr_dl=64000,
    max_req_bw_ul=150000,
    max_req_bw_dl=168000,
    arp=QosArp(
        priority_level=1,
        pre_capability=1,
        pre_vulnerability=0,
    ),
),
```

pcap shows:
```
gbrQosInformation
    e-RAB-MaximumBitrateDL: 168000bits/s
    e-RAB-MaximumBitrateUL: 150000bits/s
    e-RAB-GuaranteedBitrateDL: 64000bits/s
    e-RAB-GuaranteedBitrateUL: 48000bits/s
```
```
EPS quality of service
    Length: 5
    Quality of Service Class Identifier (QCI): QCI 1 (1)
    Maximum bit rate for uplink: 144 kbps
    Maximum bit rate for downlink: 168 kbps
    Guaranteed bit rate for uplink: 48 kbps
    Guaranteed bit rate for downlink: 64 kbps
```
## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
