### PR TITLE
[IWYU] Non-functional fixup of or8r c includes

### DIFF
--- a/lte/gateway/c/oai/common/redis_utils/redis_client.cpp
+++ b/lte/gateway/c/oai/common/redis_utils/redis_client.cpp
@@ -28,6 +28,7 @@ extern "C" {
 #endif
 
 #include "ServiceConfigLoader.h"
+#include <yaml-cpp/yaml.h> // IWYU pragma: keep
 
 using google::protobuf::Message;
 

--- a/lte/gateway/c/oai/lib/mobility_client/MobilityClientAPI.cpp
+++ b/lte/gateway/c/oai/lib/mobility_client/MobilityClientAPI.cpp
@@ -28,6 +28,7 @@
 #include "spgw_types.h"
 #include "intertask_interface.h"
 #include "common_types.h"
+#include "log.h"
 
 #include "MobilityServiceClient.h"
 

--- a/lte/gateway/c/session_manager/GrpcMagmaUtils.cpp
+++ b/lte/gateway/c/session_manager/GrpcMagmaUtils.cpp
@@ -11,10 +11,14 @@
  * limitations under the License.
  */
 
-#include <string>
-#include "magma_logging.h"
-#include <sstream>
 #include "GrpcMagmaUtils.h"
+#include <glog/logging.h>                // for COMPACT_GOOGLE_LOG_INFO, Log...
+#include <google/protobuf/descriptor.h>  // for Descriptor
+#include <google/protobuf/message.h>     // for Message
+#include <stdlib.h>                      // for getenv, NULL
+#include <sstream>                       // for operator<<, basic_ostream
+#include <string>                        // for string, operator<<, operator==
+#include "magma_logging.h"               // for MINFO, MLOG
 
 #define MAGMA_PRINT_GRPC_PAYLOAD "MAGMA_PRINT_GRPC_PAYLOAD"
 

--- a/lte/gateway/c/session_manager/GrpcMagmaUtils.h
+++ b/lte/gateway/c/session_manager/GrpcMagmaUtils.h
@@ -12,7 +12,8 @@
  */
 #pragma once
 
-#include "GRPCReceiver.h"
+#include <string>  // for string
+namespace google { namespace protobuf { class Message; } }
 
 std::string get_env_var(std::string const& key);
 

--- a/lte/gateway/c/session_manager/RedisStoreClient.cpp
+++ b/lte/gateway/c/session_manager/RedisStoreClient.cpp
@@ -11,9 +11,29 @@
  * limitations under the License.
  */
 
-#include "SessionState.h"
 #include "RedisStoreClient.h"
-#include "magma_logging.h"
+#include <folly/Range.h>              // for operator<<, StringPiece
+#include <folly/dynamic-inl.h>        // for dynamic::dynamic, dynamic::~dyn...
+#include <folly/dynamic.h>            // for dynamic
+#include <folly/json.h>               // for parseJson, toJson
+#include <glog/logging.h>             // for COMPACT_GOOGLE_LOG_INFO, LogMes...
+#include <stddef.h>                   // for size_t
+#include <stdint.h>                   // for uint32_t
+#include <yaml-cpp/yaml.h>            // IWYU pragma: keep
+#include <algorithm>                  // for max
+#include <cpp_redis/core/client.hpp>  // for client, client::connect_state
+#include <cpp_redis/core/reply.hpp>   // for reply
+#include <cpp_redis/misc/error.hpp>   // for redis_error
+#include <future>                     // for future
+#include <ostream>                    // for operator<<, basic_ostream, size_t
+#include <unordered_map>              // for _Node_iterator, unordered_map
+#include <utility>                    // for move, pair
+#include <vector>                     // for vector
+#include "ServiceConfigLoader.h"      // for ServiceConfigLoader
+#include "SessionState.h"             // for SessionState
+#include "StoredState.h"              // for deserialize_stored_session, ser...
+#include "magma_logging.h"            // for MERROR, MLOG
+namespace magma { class StaticRuleStore; }
 
 namespace magma {
 namespace lte {

--- a/lte/gateway/c/session_manager/RedisStoreClient.h
+++ b/lte/gateway/c/session_manager/RedisStoreClient.h
@@ -14,13 +14,12 @@
 #pragma once
 
 #include <cpp_redis/cpp_redis>
-#include <folly/Format.h>
-#include <folly/dynamic.h>
-#include <folly/json.h>
-
-#include "StoreClient.h"
-#include "StoredState.h"
-#include "ServiceConfigLoader.h"
+#include <exception>         // IWYU pragma: keep
+#include <memory>            // for shared_ptr
+#include <set>               // for set
+#include <string>            // for string
+#include "StoreClient.h"     // for SessionMap, SessionVector, StoreClient
+namespace magma { class StaticRuleStore; }
 
 namespace magma {
 namespace lte {

--- a/lte/gateway/c/session_manager/SpgwServiceClient.cpp
+++ b/lte/gateway/c/session_manager/SpgwServiceClient.cpp
@@ -12,8 +12,20 @@
  */
 
 #include "SpgwServiceClient.h"
-#include "ServiceRegistrySingleton.h"
-#include "magma_logging.h"
+#include <glog/logging.h>                          // for COMPACT_GOOGLE_LOG...
+#include <grpcpp/channel.h>                        // for Channel
+#include <grpcpp/impl/codegen/async_unary_call.h>  // for default_delete
+#include <grpcpp/impl/codegen/status.h>            // for Status
+#include <algorithm>                               // for copy
+#include <cstdint>                                 // for uint32_t
+#include <ostream>                                 // for operator<<, basic_...
+#include <utility>                                 // for move
+#include "ServiceRegistrySingleton.h"              // for ServiceRegistrySin...
+#include "lte/protos/policydb.pb.h"                // for RepeatedField, Rep...
+#include "lte/protos/spgw_service.grpc.pb.h"       // for SpgwService::Stub
+#include "lte/protos/spgw_service.pb.h"            // for DeleteBearerRequest
+#include "magma_logging.h"                         // for MLOG, MERROR, MINFO
+namespace grpc { class Channel; }
 
 using grpc::Status;
 

--- a/lte/gateway/c/session_manager/SpgwServiceClient.h
+++ b/lte/gateway/c/session_manager/SpgwServiceClient.h
@@ -12,12 +12,21 @@
  */
 #pragma once
 
-#include <mutex>
-
-#include <lte/protos/policydb.pb.h>
-#include <lte/protos/spgw_service.grpc.pb.h>
-
-#include "GRPCReceiver.h"
+#include <lte/protos/spgw_service.grpc.pb.h>  // for SpgwService::Stub, Spgw...
+#include <stdint.h>                           // for uint32_t
+#include <functional>                         // for function
+#include <memory>                             // for shared_ptr, unique_ptr
+#include <string>                             // for string
+#include <vector>                             // for vector
+#include "GRPCReceiver.h"                     // for GRPCReceiver
+#include "lte/protos/subscriberdb.pb.h"       // for lte
+namespace grpc { class Channel; }
+namespace grpc { class Status; }
+namespace grpc { class Status; }
+namespace magma { namespace lte { class CreateBearerRequest; } }
+namespace magma { namespace lte { class CreateBearerResult; } }
+namespace magma { namespace lte { class DeleteBearerRequest; } }
+namespace magma { namespace lte { class DeleteBearerResult; } }
 
 using grpc::Status;
 

--- a/orc8r/gateway/c/common/async_grpc/GRPCReceiver.cpp
+++ b/orc8r/gateway/c/common/async_grpc/GRPCReceiver.cpp
@@ -10,8 +10,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 #include "GRPCReceiver.h"
-#include "magma_logging.h"
+#include <ostream>          // for operator<<, char_traits
+#include "magma_logging.h"  // for MLOG
 
 namespace magma {
 

--- a/orc8r/gateway/c/common/async_grpc/GRPCReceiver.h
+++ b/orc8r/gateway/c/common/async_grpc/GRPCReceiver.h
@@ -12,9 +12,15 @@
  */
 #pragma once
 
-#include <atomic>
-#include <grpc++/grpc++.h>
-#include <lte/protos/session_manager.grpc.pb.h>
+#include <grpcpp/impl/codegen/client_context.h>    // for ClientContext
+#include <grpcpp/impl/codegen/completion_queue.h>  // for CompletionQueue
+#include <grpcpp/impl/codegen/status.h>            // for Status
+#include <stdint.h>                                // for uint32_t
+#include <atomic>                                  // for atomic
+#include <chrono>                                  // for operator+, seconds
+#include <functional>                              // for function
+#include <memory>                                  // for unique_ptr
+namespace grpc { template <class R> class ClientAsyncResponseReader; }
 
 namespace magma {
 

--- a/orc8r/gateway/c/common/config/MConfigLoader.cpp
+++ b/orc8r/gateway/c/common/config/MConfigLoader.cpp
@@ -11,15 +11,14 @@
  * limitations under the License.
  */
 
-#include <iostream>
-#include <fstream>
-#include <cstdlib>
-#include <json.hpp>  // JSON library
-#include <google/protobuf/message.h>
-#include <google/protobuf/util/json_util.h>
-
 #include "MConfigLoader.h"
-#include "magma_logging.h"
+#include <google/protobuf/stubs/status.h>    // for Status
+#include <google/protobuf/util/json_util.h>  // for JsonStringToMessage
+#include <cstdlib>                           // for getenv
+#include <fstream>                           // for operator<<, char_traits
+#include <json.hpp>                          // for basic_json<>::iterator
+#include "magma_logging.h"                   // for MLOG
+namespace google { namespace protobuf { class Message; } }
 
 using json = nlohmann::json;
 

--- a/orc8r/gateway/c/common/config/MConfigLoader.h
+++ b/orc8r/gateway/c/common/config/MConfigLoader.h
@@ -12,7 +12,9 @@
  */
 #pragma once
 
-#include <google/protobuf/message.h>
+#include <iosfwd>  // for ifstream
+#include <string>  // for string
+namespace google { namespace protobuf { class Message; } }
 
 namespace magma {
 

--- a/orc8r/gateway/c/common/config/ServiceConfigLoader.cpp
+++ b/orc8r/gateway/c/common/config/ServiceConfigLoader.cpp
@@ -11,12 +11,14 @@
  * limitations under the License.
  */
 
-#include <string>
-#include <iostream>
-
 #include "ServiceConfigLoader.h"
-#include "YAMLUtils.h"
-#include "magma_logging.h"
+#include <yaml-cpp/exceptions.h>  // for BadFile
+#include <yaml-cpp/node/impl.h>   // for Node::Node, Node::~Node
+#include <yaml-cpp/node/parse.h>  // for LoadFile
+#include <iostream>               // for operator<<, basic_ostream
+#include <string>                 // for allocator, operator+, char_traits
+#include "YAMLUtils.h"            // for YAMLUtils
+#include "magma_logging.h"        // for MLOG
 
 namespace magma {
 

--- a/orc8r/gateway/c/common/config/ServiceConfigLoader.h
+++ b/orc8r/gateway/c/common/config/ServiceConfigLoader.h
@@ -12,8 +12,8 @@
  */
 #pragma once
 
-#include <string>
-#include "yaml-cpp/yaml.h"
+#include <yaml-cpp/node/node.h>  // for Node
+#include <string>                // for string
 
 namespace magma {
 

--- a/orc8r/gateway/c/common/config/YAMLUtils.cpp
+++ b/orc8r/gateway/c/common/config/YAMLUtils.cpp
@@ -11,10 +11,10 @@
  * limitations under the License.
  */
 
-#include <string>
-
 #include "YAMLUtils.h"
-#include "magma_logging.h"
+#include <yaml-cpp/yaml.h>                     // IWYU pragma: keep
+#include <boost/iterator/iterator_facade.hpp>  // for operator!=, iterator_f...
+#include <string>                              // for string
 
 namespace magma {
 

--- a/orc8r/gateway/c/common/config/YAMLUtils.h
+++ b/orc8r/gateway/c/common/config/YAMLUtils.h
@@ -12,8 +12,7 @@
  */
 #pragma once
 
-#include <string>
-#include "yaml-cpp/yaml.h"
+#include <yaml-cpp/node/node.h>  // for Node
 
 namespace magma {
 

--- a/orc8r/gateway/c/common/datastore/Serializers.cpp
+++ b/orc8r/gateway/c/common/datastore/Serializers.cpp
@@ -10,8 +10,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 #include "Serializers.h"
-#include <orc8r/protos/redis.pb.h>
+#include <google/protobuf/message.h>  // for Message
+#include <orc8r/protos/redis.pb.h>    // for RedisState
 
 using google::protobuf::Message;
 using magma::orc8r::RedisState;

--- a/orc8r/gateway/c/common/datastore/Serializers.h
+++ b/orc8r/gateway/c/common/datastore/Serializers.h
@@ -12,8 +12,10 @@
  */
 #pragma once
 
-#include <functional>
-#include <google/protobuf/message.h>
+#include <stdint.h>    // for uint64_t
+#include <functional>  // for function
+#include <string>      // for string
+namespace google { namespace protobuf { class Message; } }
 
 using google::protobuf::Message;
 namespace magma {

--- a/orc8r/gateway/c/common/eventd/EventdClient.cpp
+++ b/orc8r/gateway/c/common/eventd/EventdClient.cpp
@@ -11,16 +11,21 @@
  * limitations under the License.
  */
 #include "EventdClient.h"
-
-#include "ServiceRegistrySingleton.h"
-
-using grpc::ClientContext;
-using grpc::Status;
-using magma::orc8r::Event;
-using magma::orc8r::EventService;
-using magma::orc8r::Void;
+#include <grpcpp/channel.h>                        // for Channel
+#include <grpcpp/impl/codegen/async_unary_call.h>  // for default_delete
+#include <utility>                                 // for move
+#include "ServiceRegistrySingleton.h"              // for ServiceRegistrySin...
+#include "orc8r/protos/common.pb.h"                // for Void
+#include "orc8r/protos/eventd.grpc.pb.h"           // for EventService::Stub
+namespace grpc { class ClientContext; }
+namespace grpc { class Status; }
+namespace magma { namespace orc8r { class Event; } }
 
 namespace magma {
+
+using orc8r::Event;
+using orc8r::EventService;
+using orc8r::Void;
 
 AsyncEventdClient& AsyncEventdClient::getInstance() {
   static AsyncEventdClient instance;

--- a/orc8r/gateway/c/common/eventd/EventdClient.h
+++ b/orc8r/gateway/c/common/eventd/EventdClient.h
@@ -12,13 +12,14 @@
  */
 #pragma once
 
-#include <memory>
-#include <utility>
-
-#include <orc8r/protos/eventd.pb.h>
-#include <orc8r/protos/eventd.grpc.pb.h>
-
-#include "GRPCReceiver.h"
+#include <orc8r/protos/eventd.grpc.pb.h>  // for EventService::Stub, EventSe...
+#include <stdint.h>                       // for uint32_t
+#include <functional>                     // for function
+#include <memory>                         // for unique_ptr
+#include "GRPCReceiver.h"                 // for GRPCReceiver
+namespace grpc { class Status; }
+namespace magma { namespace orc8r { class Event; } }
+namespace magma { namespace orc8r { class Void; } }
 
 using grpc::Status;
 

--- a/orc8r/gateway/c/common/policydb/PolicyLoader.cpp
+++ b/orc8r/gateway/c/common/policydb/PolicyLoader.cpp
@@ -10,11 +10,23 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include "RedisMap.hpp"
-#include "Serializers.h"
 #include "PolicyLoader.h"
-#include "ServiceConfigLoader.h"
-#include "magma_logging.h"
+#include <glog/logging.h>             // for COMPACT_GOOGLE_LOG_INFO, LogMes...
+#include <yaml-cpp/yaml.h>            // IWYU pragma: keep
+#include <chrono>                     // for seconds
+#include <cpp_redis/core/client.hpp>  // for client, client::connect_state
+#include <cpp_redis/misc/error.hpp>   // for redis_error
+#include <cstdint>                    // for uint32_t
+#include <memory>                     // for make_shared, __shared_ptr, shar...
+#include <ostream>                    // for operator<<, basic_ostream, size_t
+#include <string>                     // for string, char_traits, operator<<
+#include <thread>                     // for sleep_for
+#include "ObjectMap.h"                // for SUCCESS
+#include "RedisMap.hpp"               // for RedisMap
+#include "Serializers.h"              // for get_proto_deserializer, get_pro...
+#include "ServiceConfigLoader.h"      // for ServiceConfigLoader
+#include "lte/protos/policydb.pb.h"   // for PolicyRule
+#include "magma_logging.h"            // for MLOG, MERROR, MDEBUG, MINFO
 
 namespace magma {
 

--- a/orc8r/gateway/c/common/policydb/PolicyLoader.h
+++ b/orc8r/gateway/c/common/policydb/PolicyLoader.h
@@ -10,10 +10,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include <atomic>
-#include <functional>
-#include <cpp_redis/cpp_redis>
-#include <lte/protos/policydb.pb.h>
+#include <stdint.h>                      // for uint32_t
+#include <atomic>                        // for atomic
+#include <functional>                    // for function
+#include <vector>                        // for vector
+#include "lte/protos/subscriberdb.pb.h"  // for lte
+namespace magma { namespace lte { class PolicyRule; } }
 
 namespace magma {
 using namespace lte;

--- a/orc8r/gateway/c/common/service303/MagmaService.cpp
+++ b/orc8r/gateway/c/common/service303/MagmaService.cpp
@@ -10,27 +10,34 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include <string>
-#include <csignal>
-#include <ctime>
-#include <chrono>
-#include <ratio>
-
-#include <iostream>
-
-#include <orc8r/protos/service303.grpc.pb.h>
-#include <orc8r/protos/service303.pb.h>
-#include <orc8r/protos/common.pb.h>
 
 #include "MagmaService.h"
-#include "MetricsRegistry.h"
-#include "MetricsSingleton.h"
-#include "ProcFileUtils.h"
-#include "ServiceRegistrySingleton.h"
-#include "magma_logging.h"
+#include <google/protobuf/map.h>                   // for Map
+#include <grpcpp/impl/codegen/completion_queue.h>  // for ServerCompletionQueue
+#include <grpcpp/security/server_credentials.h>    // for InsecureServerCred...
+#include <orc8r/protos/common.pb.h>                // for FATAL, LogLevel
+#include <orc8r/protos/service303.pb.h>            // for ServiceInfo, Reloa...
+#include <stdarg.h>                                // for va_list
+#include <chrono>                                  // for seconds, duration
+#include <csignal>                                 // for raise, SIGTERM
+#include <ctime>                                   // for time
+#include <string>                                  // for string, stoi
+#include <type_traits>                             // for enable_if<>::type
+#include <unordered_map>                           // for operator==
+#include <utility>                                 // for move
+#include <vector>                                  // for vector
+#include "MetricsRegistry.h"                       // for Registry
+#include "MetricsSingleton.h"                      // for MetricsSingleton
+#include "ProcFileUtils.h"                         // for ProcFileUtils::mem...
+#include "ServiceRegistrySingleton.h"              // for ServiceRegistrySin...
+#include "magma_logging.h"                         // for set_verbosity
+#include "orc8r/protos/metrics.pb.h"               // for MetricFamily
+#include "orc8r/protos/metricsd.pb.h"              // for MetricsContainer
+#include "registry.h"                              // for Registry
+namespace grpc { class ServerContext; }
+namespace grpc { class Service; }
 
 using grpc::InsecureServerCredentials;
-using grpc::ServerContext;
 using grpc::Status;
 using io::prometheus::client::MetricFamily;
 using magma::orc8r::GetOperationalStatesResponse;

--- a/orc8r/gateway/c/common/service303/MagmaService.h
+++ b/orc8r/gateway/c/common/service303/MagmaService.h
@@ -12,16 +12,31 @@
  */
 #pragma once
 
-#include <grpc++/grpc++.h>
-#include <orc8r/protos/service303.grpc.pb.h>
-#include <chrono>
-
-#include "MetricsRegistry.h"
-#include "MetricsSingleton.h"
+#include <grpcpp/grpcpp.h>                    // for Server, ServerBuilder
+#include <grpcpp/impl/codegen/status.h>       // for Status
+#include <orc8r/protos/service303.grpc.pb.h>  // for Service303, Service303:...
+#include <chrono>                             // for steady_clock, steady_cl...
+#include <functional>                         // for function
+#include <list>                               // for list
+#include <map>                                // for map
+#include <memory>                             // for unique_ptr
+#include <string>                             // for string
+#include "orc8r/protos/service303.pb.h"       // for ServiceInfo, ServiceInf...
+namespace grpc { class ServerCompletionQueue; }
+namespace grpc { class ServerContext; }
+namespace grpc { class ServerContext; }
+namespace grpc { class Service; }
+namespace magma { namespace orc8r { class MetricsContainer; } }
+namespace magma { namespace orc8r { class Void; } }
+namespace magma { namespace service303 { class MetricsSingleton; } }
 
 using grpc::Server;
 using grpc::ServerContext;
 using grpc::Status;
+using magma::orc8r::GetOperationalStatesResponse;
+using magma::orc8r::LogLevelMessage;
+using magma::orc8r::MetricsContainer;
+using magma::orc8r::ReloadConfigResponse;
 using magma::orc8r::Service303;
 using magma::orc8r::ServiceInfo;
 using magma::orc8r::State;

--- a/orc8r/gateway/c/common/service303/MetricsHelpers.cpp
+++ b/orc8r/gateway/c/common/service303/MetricsHelpers.cpp
@@ -12,7 +12,8 @@
  */
 
 #include "MetricsHelpers.h"
-#include "MetricsSingleton.h"
+#include <stdarg.h>            // for va_end, va_list, va_start
+#include "MetricsSingleton.h"  // for MetricsSingleton
 
 namespace magma {
 namespace service303 {

--- a/orc8r/gateway/c/common/service303/MetricsHelpers.h
+++ b/orc8r/gateway/c/common/service303/MetricsHelpers.h
@@ -13,8 +13,7 @@
 
 #pragma once
 
-#include <stdio.h>
-#include <stdarg.h>
+#include <stdio.h>  // for size_t
 
 namespace magma {
 namespace service303 {

--- a/orc8r/gateway/c/common/service303/MetricsSingleton.cpp
+++ b/orc8r/gateway/c/common/service303/MetricsSingleton.cpp
@@ -10,7 +10,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 #include "MetricsSingleton.h"
+#include <vector>               // for vector
+#include "counter.h"            // for Counter
+#include "counter_builder.h"    // for BuildCounter, CounterBuilder
+#include "gauge.h"              // for Gauge
+#include "gauge_builder.h"      // for GaugeBuilder, BuildGauge
+#include "histogram.h"          // for Histogram, Histogram::BucketBoundaries
+#include "histogram_builder.h"  // for BuildHistogram, HistogramBuilder
+#include "registry.h"           // for Registry
 
 using magma::service303::MetricsSingleton;
 using prometheus::BuildCounter;

--- a/orc8r/gateway/c/common/service303/MetricsSingleton.h
+++ b/orc8r/gateway/c/common/service303/MetricsSingleton.h
@@ -12,12 +12,20 @@
  */
 #pragma once
 
-#include <stdarg.h>
-
-#include <prometheus/registry.h>
-#include <grpc++/grpc++.h>
-
-#include "MetricsRegistry.h"
+#include <stdarg.h>           // for va_list
+#include <stddef.h>           // for size_t
+#include <map>                // for map
+#include <memory>             // for shared_ptr
+#include <string>             // for string
+#include "MetricsRegistry.h"  // for MetricsRegistry, Registry
+namespace grpc { class Server; }
+namespace prometheus { class Counter; }
+namespace prometheus { class Gauge; }
+namespace prometheus { class Histogram; }
+namespace prometheus { class Registry; }
+namespace prometheus { namespace detail { class CounterBuilder; } }
+namespace prometheus { namespace detail { class GaugeBuilder; } }
+namespace prometheus { namespace detail { class HistogramBuilder; } }
 
 using grpc::Server;
 using magma::service303::MetricsRegistry;

--- a/orc8r/gateway/c/common/service303/ProcFileUtils.cpp
+++ b/orc8r/gateway/c/common/service303/ProcFileUtils.cpp
@@ -12,12 +12,9 @@
  * limitations under the License.
  */
 
-#include <string>
-#include <ratio>
-#include <fstream>
-#include <iostream>
-
 #include "ProcFileUtils.h"
+#include <fstream>  // for basic_istream, ifstream
+#include <string>   // for string, operator>>, stod
 
 namespace magma {
 namespace service303 {

--- a/orc8r/gateway/c/common/service303/ProcFileUtils.h
+++ b/orc8r/gateway/c/common/service303/ProcFileUtils.h
@@ -12,7 +12,8 @@
  */
 #pragma once
 
-#include <string>
+#include <iosfwd>  // for ifstream
+#include <string>  // for stringnamespace magma {
 
 namespace magma {
 namespace service303 {

--- a/orc8r/gateway/c/common/service_registry/ServiceRegistrySingleton.cpp
+++ b/orc8r/gateway/c/common/service_registry/ServiceRegistrySingleton.cpp
@@ -10,13 +10,17 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include <string>
-#include <iostream>
-#include <fstream>
-#include <sstream>
 #include "ServiceRegistrySingleton.h"
+#include <assert.h>                            // for assert
+#include <grpcpp/create_channel.h>             // for CreateCustomChannel
+#include <grpcpp/impl/codegen/config.h>        // for string
+#include <grpcpp/security/credentials.h>       // for SslCredentials, SslCre...
+#include <grpcpp/support/channel_arguments.h>  // for ChannelArguments
+#include <fstream>                             // for basic_ostream, basic_o...
+#include <stdexcept>                           // for invalid_argument
+#include <string>                              // for string, allocator, ope...
+namespace grpc { class Channel; }
 
-using grpc::Channel;
 using grpc::CreateCustomChannel;
 using grpc::InsecureChannelCredentials;
 using grpc::SslCredentials;

--- a/orc8r/gateway/c/common/service_registry/ServiceRegistrySingleton.h
+++ b/orc8r/gateway/c/common/service_registry/ServiceRegistrySingleton.h
@@ -11,11 +11,13 @@
  * limitations under the License.
  */
 #pragma once
-#include <string>
-#include <grpc++/grpc++.h>
-#include "yaml-cpp/yaml.h"
 
-#include "ServiceConfigLoader.h"
+#include <yaml-cpp/yaml.h>        // IWYU pragma: keep
+#include <memory>                 // for shared_ptr, unique_ptr
+#include <string>                 // for string
+#include "ServiceConfigLoader.h"  // for ServiceConfigLoader
+namespace grpc { class Channel; }
+namespace grpc { class ChannelCredentials; }
 
 using grpc::Channel;
 using grpc::ChannelCredentials;


### PR DESCRIPTION
Applied IWYU tooling to the `orc8r/gateway/c` sub-targets and corrected all findings (missing and extraneous include headers). This to work towards #4868 which regularly causes build failures as we migrate or update includes / build infrastructure.

Signed-off-by: Scott Harrison Moeller <smoeller@fb.com>