### PR TITLE
[AGW][Sentry-Native] Add linking/build setup logic in C/C++ CmakeLists.txt

### DIFF
--- a/lte/gateway/c/connection_tracker/CMakeLists.txt
+++ b/lte/gateway/c/connection_tracker/CMakeLists.txt
@@ -101,6 +101,21 @@ add_library(CONNECTION_TRACKER
     ${PROTO_SRCS}
     ${PROTO_HDRS})
 
+## Find + link sentry if it exists
+## TODO we can enable by default after we migrate to ubuntu 20.04
+find_library(SENTRY_LIB NAMES sentry sentry-native)
+if (SENTRY_LIB)
+message("Building with sentry!")
+# Include dir
+find_path(SENTRY_INCLUDE_DIR
+    NAMES
+    sentry.h
+)
+target_link_libraries(CONNECTION_TRACKER ${SENTRY_LIB})
+set (CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -DSENTRY_ENABLED=1")
+set (CMAKE_CXX_FLAGS_RELWITHDEBINFO "${CMAKE_CXX_FLAGS_RELWITHDEBINFO} -DSENTRY_ENABLED=1")
+endif()
+
 target_link_libraries(CONNECTION_TRACKER
   SERVICE303_LIB SERVICE_REGISTRY CONFIG
   glog gflags folly pthread ${GCOV_LIB} grpc++ grpc yaml-cpp protobuf cpp_redis

--- a/lte/gateway/c/oai/CMakeLists.txt
+++ b/lte/gateway/c/oai/CMakeLists.txt
@@ -58,6 +58,17 @@ set(CMAKE_EXE_LINKER_FLAGS_DEBUG  "${CMAKE_EXE_LINKER_FLAGS_DEBUG} -fprofile-arc
 set(CMAKE_C_FLAGS_RELWITHDEBINFO "${CMAKE_C_FLAGS_RELWITHDEBINFO} -fsanitize=leak -fno-omit-frame-pointer")
 set(CMAKE_EXE_LINKER_FLAGS_RELWITHDEBINFO  "${CMAKE_EXE_LINKER_FLAGS_RELWITHDEBINFO} -fsanitize=leak")
 
+# Add a flag to enable sentry if it is exists
+## TODO we can enable by default after we migrate to ubuntu 20.04
+find_library(SENTRY_LIB NAMES sentry sentry-native)
+if (SENTRY_LIB)
+message("Building with sentry!")
+set (CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} -DSENTRY_ENABLED=1")
+set (CMAKE_C_FLAGS_RELWITHDEBINFO "${CMAKE_C_FLAGS_RELWITHDEBINFO} -DSENTRY_ENABLED=1")
+set (CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -DSENTRY_ENABLED=1")
+set (CMAKE_CXX_FLAGS_RELWITHDEBINFO "${CMAKE_CXX_FLAGS_RELWITHDEBINFO} -DSENTRY_ENABLED=1")
+endif()
+
 ################################################################
 # Set proto directory for state proto definitions
 ################################################################

--- a/lte/gateway/c/oai/oai_mme/CMakeLists.txt
+++ b/lte/gateway/c/oai/oai_mme/CMakeLists.txt
@@ -41,7 +41,7 @@ add_executable(mme
 target_link_libraries(mme
     -Wl,--start-group
         COMMON
-	LIB_3GPP LIB_S1AP LIB_NGAP LIB_SECU LIB_DIRECTORYD LIB_SGS_CLIENT LIB_BSTR
+        LIB_3GPP LIB_S1AP LIB_NGAP LIB_SECU LIB_DIRECTORYD LIB_SGS_CLIENT LIB_BSTR
         LIB_HASHTABLE LIB_S6A_PROXY
         TASK_S1AP TASK_NGAP TASK_SCTP_SERVER TASK_SGS TASK_SMS_ORC8R
         TASK_S6A TASK_MME_APP TASK_GRPC_SERVICE TASK_NAS TASK_HA
@@ -51,6 +51,18 @@ target_link_libraries(mme
     ${NETTLE_LIBRARIES} ${CONFIG_LIBRARIES} gnutls ${SERVICE303_LIB}
     prometheus-cpp grpc grpc++ yaml-cpp
 )
+
+## Find + link sentry if it exists
+## TODO we can enable by default after we migrate to ubuntu 20.04
+find_library(SENTRY_LIB NAMES sentry sentry-native)
+if (SENTRY_LIB)
+# Include dir
+find_path(SENTRY_INCLUDE_DIR
+    NAMES
+    sentry.h
+)
+target_link_libraries(mme ${SENTRY_LIB})
+endif()
 
 if ( NOT EMBEDDED_SGW )
  target_link_libraries(mme

--- a/lte/gateway/c/sctpd/CMakeLists.txt
+++ b/lte/gateway/c/sctpd/CMakeLists.txt
@@ -41,6 +41,20 @@ add_library(SCTPD_LIB
   ${PROTO_HDRS}
 )
 
+## Find + link sentry if it exists
+find_library(SENTRY_LIB NAMES sentry sentry-native)
+if (SENTRY_LIB)
+message("Building with sentry!")
+# Include dir
+find_path(SENTRY_INCLUDE_DIR
+    NAMES
+    sentry.h
+)
+target_link_libraries(SCTPD_LIB ${SENTRY_LIB})
+set (CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -DSENTRY_ENABLED=1")
+set (CMAKE_CXX_FLAGS_RELWITHDEBINFO "${CMAKE_CXX_FLAGS_RELWITHDEBINFO} -DSENTRY_ENABLED=1")
+endif()
+
 target_compile_definitions(SCTPD_LIB PUBLIC LOG_WITH_GLOG)
 
 target_link_libraries(SCTPD_LIB

--- a/lte/gateway/c/session_manager/CMakeLists.txt
+++ b/lte/gateway/c/session_manager/CMakeLists.txt
@@ -176,7 +176,19 @@ add_library(SESSION_MANAGER
     ${PROTO_SRCS}
     ${PROTO_HDRS})
 
-
+## Find + link sentry if it exists
+find_library(SENTRY_LIB NAMES sentry sentry-native)
+if (SENTRY_LIB)
+# Include dir
+message("Building with sentry!")
+find_path(SENTRY_INCLUDE_DIR
+    NAMES
+    sentry.h
+)
+target_link_libraries(SESSION_MANAGER ${SENTRY_LIB})
+set (CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -DSENTRY_ENABLED=1")
+set (CMAKE_CXX_FLAGS_RELWITHDEBINFO "${CMAKE_CXX_FLAGS_RELWITHDEBINFO} -DSENTRY_ENABLED=1")
+endif()
 
 target_link_libraries(SESSION_MANAGER
   SERVICE303_LIB SERVICE_REGISTRY ASYNC_GRPC CONFIG POLICYDB EVENTD


### PR DESCRIPTION
<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary
Add baseline CmakeLists.txt to build / link MME/SessionD/ConnectionD/SctpD with sentry if the library is found on the system. (I will have a separate PR to install sentry in Ubuntu 20.04 VM/Docker)

If Sentry library is found, compile with SENTRY_ENABLED tag. This will be used from inside the code to decide if sentry should be initialized

Until we fully migrate to Ubuntu 20.04 in 1.6, we will have to guard all sentry usages with
```
#if SENTRY_ENABLED
// blah blah
#endif 
```
<!-- Enumerate changes you made and why you made them -->

## Test Plan
Build services on Debian VM + Ubuntu20.04 VM. This PR should be a no-op because sentry library is not yet installed on any system.

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
Signed-off-by: Marie Bremner <marwhal@fb.com>