### PR TITLE
[lte][agw] Bug fix in handling ULA message

### DIFF
--- a/lte/gateway/c/oai/tasks/mme_app/mme_app_location.c
+++ b/lte/gateway/c/oai/tasks/mme_app/mme_app_location.c
@@ -258,10 +258,19 @@ int mme_app_handle_s6a_update_location_ans(
     }
   }
 
-  // Stop ULR Response timer if running
+  // Stop ULR Response timer.
+  // If expired its timer id should be MME_APP_TIMER_INACTIVE_ID and
+  // it should be already treated as failure
   if (ue_mm_context->ulr_response_timer.id != MME_APP_TIMER_INACTIVE_ID) {
     mme_app_stop_timer(ue_mm_context->ulr_response_timer.id);
     ue_mm_context->ulr_response_timer.id = MME_APP_TIMER_INACTIVE_ID;
+  } else {
+    OAILOG_ERROR(
+        LOG_MME_APP,
+        "ULR Response Timer has invalid id. This implies that the timer has "
+        "expired and ULR has been handled as failure. \n ",
+        ue_mm_context->mme_ue_s1ap_id);
+    OAILOG_FUNC_RETURN(LOG_MME_APP, RETURNerror);
   }
 
   ue_mm_context->subscription_known = SUBSCRIPTION_KNOWN;


### PR DESCRIPTION
## Summary

On loading tests, this particular bug is observed. ULA message is received after timer has expired and while a detach process is ongoing, the attach procedure continues. The bug fix logic is simple: when ULA message is received, the timer should be still running. If it is not, then it indicates that ULA failure is handled already and this message can be ignored.

## Test Plan

Integration tests and loading tests on spirent.

## Additional Information

- [ ] This change is backwards-breaking

