### PR TITLE
[Ubuntu20.04][SentryNative] Build and install sentry native SDK in ubuntu VM

### DIFF
--- a/lte/gateway/deploy/roles/dev_common/defaults/main.yml
+++ b/lte/gateway/deploy/roles/dev_common/defaults/main.yml
@@ -1,3 +1,4 @@
+tmp_directory: /var/tmp
 codegen_root: /var/tmp/codegen
 mvn_version: 3.5.4
 mvn_sha1: 22cac91b3557586bb1eba326f2f7727543ff15e3

--- a/lte/gateway/deploy/roles/dev_common/tasks/main.yml
+++ b/lte/gateway/deploy/roles/dev_common/tasks/main.yml
@@ -238,6 +238,7 @@
       - libpcap-dev
       - libtins-dev
       - libmnl-dev
+      - libcurl4-openssl-dev
   retries: 5
   when: preburn
 
@@ -264,6 +265,40 @@
       - libprotobuf-lite17
       - libprotoc17
       - libssl-dev
+
+###############################################
+# Download and build sentry-native
+###############################################
+
+- name: Install Sentry Native SDK
+  vars:
+    sentry_native_version: "0.4.8"
+  get_url:
+    url: "https://github.com/getsentry/sentry-native/releases/download/{{ sentry_native_version }}/sentry-native.zip"
+    dest: "{{ tmp_directory }}/sentry-native.zip"
+  when: preburn and ansible_distribution == "Ubuntu"
+
+- name: Create a directory for Sentry Native
+  file:
+    path: "{{ tmp_directory }}/sentry-native"
+    state: directory
+  when: preburn and ansible_distribution == "Ubuntu"
+
+- name: Unpack Sentry Native SDK
+  unarchive:
+    src: "{{ tmp_directory }}/sentry-native.zip"
+    dest: "{{ tmp_directory }}/sentry-native"
+    remote_src: yes
+  when: preburn and ansible_distribution == "Ubuntu"
+
+- name: Build and Install Sentry Native SDK
+  shell: |
+    cd {{ tmp_directory }}/sentry-native && \
+    cmake -B build -DCMAKE_BUILD_TYPE=RelWithDebInfo && \
+    cmake --build build --parallel && \
+    cmake --install build --prefix install --config RelWithDebInfo && \
+    cd build && make install
+  when: preburn and ansible_distribution == "Ubuntu"
 
 ###############################################
 # Download and build swagger-codegen


### PR DESCRIPTION
<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary
* Ubuntu20.04 allows us to use sentry native SDK for all C/C++ services as the GCC version is higher than 9. 
* This PR adds some steps in the VM provisioning step to build+install sentry.

<!-- Enumerate changes you made and why you made them -->

## Test Plan
Provision steps on magma_focal VM. This combined with https://github.com/magma/magma/pull/5904 builds services with sentry.
Provision steps on magma_dev VM. This is a no-op as the steps only get applied for ubuntu.
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
