### PR TITLE
[nginx][conf] Fix bootstrapping for on-prem orc8r deployments

### DIFF
--- a/orc8r/cloud/docker/nginx/templates/nginx.conf.j2
+++ b/orc8r/cloud/docker/nginx/templates/nginx.conf.j2
@@ -133,7 +133,7 @@ http {
       if ($srv ~* "(\w+)[_](\w+)") {
         set $srv "$1-$2";
       }
-      grpc_pass grpc://orc8r-$srv.{{ backend }}:9180;
+      grpc_pass grpc://orc8r-bootstrapper.{{ backend }}:9180;
       {%- else %}
       grpc_pass grpc://{{ backend }}:$open_srvport;
       {%- endif %}


### PR DESCRIPTION
Signed-off-by: Michael Germano <mgermano@fb.com>

## Summary

This PR fixes a bug occurring on version v1.4. Currently the nginx conf parses out the authority name set in the request
to properly forward the request to the appropriate orc8r service. For bootstrapping requests, the authority name is not
set on the gateway, resulting in a failure to forward the request to bootstrapper. 

To fix this we can hardcode the bootstrapper service name into the config as port 8444 is only used for bootstrapping. In the future, if we have more open port services, we can update the gateway code to correctly set the request authority.

## Test Plan

Fix in on-prem deployment and ensure gateways can bootstrap.