### PR TITLE
Update NMS db migration script to use @fbcnms/sequelize-models 0.1.5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -94,6 +94,7 @@ test_results_magma_converged_mme.html
 
 # VS Code
 .vscode/
+.venv/
 
 # Internal
 fb

--- a/nms/app/packages/magmalte/scripts/fuji-upgrade/pre-upgrade-migration.sh
+++ b/nms/app/packages/magmalte/scripts/fuji-upgrade/pre-upgrade-migration.sh
@@ -36,19 +36,19 @@ PRE-REQUISITES
 EOF
 
 # Get the Magma k8s namespace
-read -p "Enter Kubernetes namespace [magma]: " magma_namespace
-magma_namespace=${magma_namespace:-magma}
+read -p "Enter Kubernetes namespace [orc8r]: " magma_namespace
+magma_namespace=${magma_namespace:-orc8r}
 echo ""
 
 # Find NMS pod name
-nms_pod_name=$(kubectl -n magma get pods --no-headers -o custom-columns=":metadata.name" | grep nms-magmalte)
+nms_pod_name=$(kubectl -n $magma_namespace get pods --no-headers -o custom-columns=":metadata.name" | grep nms-magmalte)
 echo "Found Magma NMS pod name: $nms_pod_name"
 read -p "Enter NMS pod name [$nms_pod_name]: " input
 nms_pod_name=${input:-$nms_pod_name}
 echo ""
 
 # Find configurator pod name
-orc8r_pod_name=$(kubectl -n magma get pods --no-headers -o custom-columns=":metadata.name" | grep orc8r-configurator)
+orc8r_pod_name=$(kubectl -n $magma_namespace get pods --no-headers -o custom-columns=":metadata.name" | grep orc8r-configurator)
 echo "Found Magma configurator pod name: $orc8r_pod_name"
 read -p "Enter configurator pod name [$orc8r_pod_name]: " input
 orc8r_pod_name=${input:-$orc8r_pod_name}

--- a/nms/app/packages/magmalte/scripts/fuji-upgrade/runs-on-nms.sh
+++ b/nms/app/packages/magmalte/scripts/fuji-upgrade/runs-on-nms.sh
@@ -44,11 +44,11 @@ done
 
 cat << EOF
 --------------------------------------------------------------------------------
-              Upgrading @fbcnms/sequelize-models to ^0.1.4
+              Upgrading @fbcnms/sequelize-models to ^0.1.5
 --------------------------------------------------------------------------------
 EOF
 pushd /usr/src/packages/magmalte
-yarn upgrade @fbcnms/sequelize-models@^0.1.4
+yarn upgrade @fbcnms/sequelize-models@^0.1.5
 yarn
 popd
 cat << EOF


### PR DESCRIPTION
Signed-off-by: GitHub <noreply@github.com>
Signed-off-by: Andrei Lee <andreilee@fb.com>

## Summary

Updated fuji db migration script to use `@fbcnms/sequelize-models` version `^0.1.5` which incorporates some bug fixes.

## Test Plan

Sanity checked by running manually
```
#-> ./pre-upgrade-migration.sh
================================================================================
                  Magma Pre-1.5-Upgrade NMS DB Data Migration
================================================================================

This script will guide you through the process of copying NMS DB data to the
orc8r DB.

This process is required to be completed prior to the rest of the 1.5 upgrade
process. When this process is completed, you are ready to complete the rest of
your 1.5 upgrade.

PRE-REQUISITES
* You will want to make sure that you have some understanding of your
  kubernetes setup on which you have Magma orc8r and NMS running.
* Ensure that you have access to your kubernetes cluster which is running the
  Magma orc8r and NMS.

--------------------------------------------------------------------------------
Enter Kubernetes namespace [orc8r]:

Found Magma NMS pod name: nms-magmalte-6df5fb6698-6wcf6
Enter NMS pod name [nms-magmalte-6df5fb6698-6wcf6]:

Found Magma configurator pod name: orc8r-configurator-68fd8d69c9-57blk
orc8r-configurator-68fd8d69c9-gx5tp
Enter configurator pod name [orc8r-configurator-68fd8d69c9-57blk
orc8r-configurator-68fd8d69c9-gx5tp]:


wget https://raw.githubusercontent.com/magma/magma/master/nms/app/packages/magmalte/scripts/fuji-upgrade/runs-on-nms.sh -O - | bash /dev/stdin -u magma -w password -h host -p 5432 -b magma -d postgres --confirm
```

## Additional Information

- [ ] This change is backwards-breaking
