### PR TITLE
[lte][agw] Fix bug on referenced value assignment

### DIFF
--- a/lte/gateway/c/oai/tasks/s1ap/s1ap_mme_nas_procedures.c
+++ b/lte/gateway/c/oai/tasks/s1ap/s1ap_mme_nas_procedures.c
@@ -520,7 +520,7 @@ int s1ap_generate_downlink_nas_transport(
     if (hashtable_uint64_ts_insert(
             imsi_map->mme_ue_id_imsi_htbl, (const hash_key_t) ue_id, imsi64) ==
         HASH_TABLE_SAME_KEY_VALUE_EXISTS) {
-      is_state_same = true;
+      *is_state_same = true;
     }
 
     S1ap_DownlinkNASTransport_IEs_t* ie = NULL;


### PR DESCRIPTION
## Summary

Rather than writing the referenced value, pointer value was written. It is a benign bug with no functional side effects or illegal access. However, this effectively did not have impact on the intended optimization. 

## Test Plan

integ tests.

## Additional Information

- [ ] This change is backwards-breaking
