### PR TITLE
[lte][agw] Adding role in ansible to install and build ghz load test

### DIFF
--- a/docs/docusaurus/i18n/en.json
+++ b/docs/docusaurus/i18n/en.json
@@ -346,6 +346,9 @@
       "proposals/p012_resource-tagging": {
         "title": "proposals/p012_resource-tagging"
       },
+      "proposals/p013_Ubuntu_upgrade": {
+        "title": "AGW Ubuntu upgrade"
+      },
       "proposals/qos_enforcement": {
         "title": "proposals/qos_enforcement"
       },

--- a/lte/gateway/deploy/roles/dev_common/tasks/main.yml
+++ b/lte/gateway/deploy/roles/dev_common/tasks/main.yml
@@ -354,6 +354,13 @@
     CODEGEN_ROOT: "{{ codegen_root }}"
   when: preburn
 
+- name: Download gHZ binary from artifactory
+  get_url:
+    url: https://artifactory.magmacore.org:443/artifactory/blob-prod/ghz
+    dest: /usr/local/bin/ghz
+    mode: 0755
+  when: full_provision
+
 - name: Fix kernel commandline for interface naming.
   shell: |
     sed -i 's/enp0s3/eth0/g' /etc/netplan/50-cloud-init.yaml


### PR DESCRIPTION
Signed-off-by: Alex Rodriguez <ardzoht@gmail.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary

- Adds ghz ansible steps to install tool to launch load tests for gRPC services 

## Test Plan

- tested locally to ensure ghz is properly installed and called 

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
