### PR TITLE
[Non_Sanity_Testing] Generate failure instead of getting stuck for AGW offload test cases

### DIFF
--- a/lte/gateway/python/integ_tests/s1aptests/s1ap_utils.py
+++ b/lte/gateway/python/integ_tests/s1aptests/s1ap_utils.py
@@ -1494,11 +1494,13 @@ class SessionManagerUtil(object):
             )
         )
 
+
 class GTPBridgeUtils:
     def __init__(self):
         self.magma_utils = MagmadUtil(None)
         ret = self.magma_utils.exec_command_output(
-            "sudo grep ovs_multi_tunnel  /etc/magma/spgw.yml")
+            "sudo grep ovs_multi_tunnel  /etc/magma/spgw.yml"
+        )
         if "false" in ret:
             self.gtp_port_name = "gtp0"
         else:
@@ -1507,42 +1509,48 @@ class GTPBridgeUtils:
 
     def get_gtp_port_no(self) -> Optional[int]:
         output = self.magma_utils.exec_command_output(
-            "sudo ovsdb-client dump Interface name ofport")
-        for line in output.split('\n'):
+            "sudo ovsdb-client dump Interface name ofport"
+        )
+        for line in output.split("\n"):
             if self.gtp_port_name in line:
                 port_info = line.split()
                 return port_info[1]
 
     def get_proxy_port_no(self) -> Optional[int]:
         output = self.magma_utils.exec_command_output(
-            "sudo ovsdb-client dump Interface name ofport")
-        for line in output.split('\n'):
+            "sudo ovsdb-client dump Interface name ofport"
+        )
+        for line in output.split("\n"):
             if self.proxy_port in line:
                 port_info = line.split()
                 return port_info[1]
+
     # RYU rest API is not able dump flows from non zero table.
     # this adds similar API using `ovs-ofctl` cmd
     def get_flows(self, table_id) -> []:
         output = self.magma_utils.exec_command_output(
-            "sudo ovs-ofctl dump-flows gtp_br0 table={}".format(table_id))
-        return output.split('\n')
+            "sudo ovs-ofctl dump-flows gtp_br0 table={}".format(table_id)
+        )
+        return output.split("\n")
+
 
 class HaUtil:
     def __init__(self):
-        self._ha_stub = HaServiceStub(
-            get_rpc_channel("spgw_service")
-        )
+        self._ha_stub = HaServiceStub(get_rpc_channel("spgw_service"))
 
     def offload_agw(self, imsi, enbID, offloadtype=0):
         req = StartAgwOffloadRequest(
-            enb_id = enbID,
-            enb_offload_type = offloadtype,
-            imsi = imsi,
-            )
+            enb_id=enbID,
+            enb_offload_type=offloadtype,
+            imsi=imsi,
+        )
         try:
             self._ha_stub.StartAgwOffload(req)
         except grpc.RpcError as e:
             print("gRPC failed with %s: %s" % (e.code(), e.details()))
+            return False
+
+        return True
 
 
 class HeaderEnrichmentUtils:

--- a/lte/gateway/python/integ_tests/s1aptests/test_agw_offload_idle_active_ue.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_agw_offload_idle_active_ue.py
@@ -18,8 +18,8 @@ import time
 from integ_tests.s1aptests import s1ap_wrapper
 from integ_tests.s1aptests.s1ap_utils import HaUtil
 
-class TestAgwOffloadIdleActiveUe(unittest.TestCase):
 
+class TestAgwOffloadIdleActiveUe(unittest.TestCase):
     def setUp(self):
         self._s1ap_wrapper = s1ap_wrapper.TestWrapper()
         self._ha_util = HaUtil()
@@ -30,7 +30,8 @@ class TestAgwOffloadIdleActiveUe(unittest.TestCase):
     def test_agw_offload_idle_active_ue(self):
         """ Basic attach/detach test with a single UE """
         # column is a enb parameter,  row is a number of enbs
-        # column description: 1.Cell Id, 2.Tac, 3.EnbType, 4.PLMN Id 5. PLMN length
+        # column description:
+        #     1.Cell Id, 2.Tac, 3.EnbType, 4.PLMN Id 5. PLMN length
         enb_list = [(1, 1, 1, "00101", 5)]
 
         self._s1ap_wrapper.multiEnbConfig(len(enb_list), enb_list)
@@ -42,21 +43,30 @@ class TestAgwOffloadIdleActiveUe(unittest.TestCase):
         self._s1ap_wrapper.configUEDevice(num_ues)
 
         req = self._s1ap_wrapper.ue_req
-        print("************************* Running End to End attach for ",
-                "UE id ", req.ue_id)
+        print(
+            "************************* Running End to End attach for ",
+            "UE id ",
+            req.ue_id,
+        )
         # Now actually complete the attach
         self._s1ap_wrapper._s1_util.attach(
-            req.ue_id, s1ap_types.tfwCmd.UE_END_TO_END_ATTACH_REQUEST,
+            req.ue_id,
+            s1ap_types.tfwCmd.UE_END_TO_END_ATTACH_REQUEST,
             s1ap_types.tfwCmd.UE_ATTACH_ACCEPT_IND,
-            s1ap_types.ueAttachAccept_t)
+            s1ap_types.ueAttachAccept_t,
+        )
 
         # Wait on EMM Information from MME
         self._s1ap_wrapper._s1_util.receive_emm_info()
 
-        print("*************************  Offloading UE at state ECM-CONNECTED")
+        print(
+            "*************************  Offloading UE at state ECM-CONNECTED"
+        )
         # Send offloading request
-        self._ha_util.offload_agw(
-            "IMSI" + "".join([str(i) for i in req.imsi]), enb_list[0][0]
+        self.assertTrue(
+            self._ha_util.offload_agw(
+                "IMSI" + "".join([str(i) for i in req.imsi]), enb_list[0][0]
+            )
         )
 
         response = self._s1ap_wrapper.s1_util.get_response()
@@ -66,8 +76,10 @@ class TestAgwOffloadIdleActiveUe(unittest.TestCase):
 
         print("*************************  Offloading UE at state ECM-IDLE")
         # Send offloading request
-        self._ha_util.offload_agw(
-            "IMSI" + "".join([str(i) for i in req.imsi]), enb_list[0][0]
+        self.assertTrue(
+            self._ha_util.offload_agw(
+                "IMSI" + "".join([str(i) for i in req.imsi]), enb_list[0][0]
+            )
         )
 
         response = self._s1ap_wrapper.s1_util.get_response()
@@ -105,11 +117,13 @@ class TestAgwOffloadIdleActiveUe(unittest.TestCase):
         print("************************* SLEEPING for 2 sec")
         time.sleep(2)
 
-        print("************************* Running UE detach for UE id ",
-                req.ue_id)
+        print(
+            "************************* Running UE detach for UE id ", req.ue_id
+        )
         # Now detach the UE
         self._s1ap_wrapper.s1_util.detach(
-            req.ue_id, s1ap_types.ueDetachType_t.UE_NORMAL_DETACH.value, True)
+            req.ue_id, s1ap_types.ueDetachType_t.UE_NORMAL_DETACH.value, True
+        )
 
 
 if __name__ == "__main__":

--- a/lte/gateway/python/integ_tests/s1aptests/test_agw_offload_mixed_idle_active_multiue.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_agw_offload_mixed_idle_active_multiue.py
@@ -21,8 +21,8 @@ import time
 from integ_tests.s1aptests import s1ap_wrapper
 from integ_tests.s1aptests.s1ap_utils import HaUtil
 
-class TestAgwOffloadMixedIdleActiveMultiUe(unittest.TestCase):
 
+class TestAgwOffloadMixedIdleActiveMultiUe(unittest.TestCase):
     def setUp(self):
         self._s1ap_wrapper = s1ap_wrapper.TestWrapper()
         self._ha_util = HaUtil()
@@ -34,7 +34,8 @@ class TestAgwOffloadMixedIdleActiveMultiUe(unittest.TestCase):
         """ Basic attach/detach test with a single UE """
         num_ues = 100
         # column is a enb parameter,  row is a number of enbs
-        # column description: 1.Cell Id, 2.Tac, 3.EnbType, 4.PLMN Id 5. PLMN length
+        # column description:
+        #     1.Cell Id, 2.Tac, 3.EnbType, 4.PLMN Id 5. PLMN length
         enb_list = [(1, 1, 1, "00101", 5)]
         self._s1ap_wrapper.multiEnbConfig(len(enb_list), enb_list)
 
@@ -44,13 +45,18 @@ class TestAgwOffloadMixedIdleActiveMultiUe(unittest.TestCase):
         ue_ids = []
         for _ in range(num_ues):
             req = self._s1ap_wrapper.ue_req
-            print("************************* Running End to End attach for ",
-                    "UE id ", req.ue_id)
+            print(
+                "************************* Running End to End attach for ",
+                "UE id ",
+                req.ue_id,
+            )
             # Now actually complete the attach
             self._s1ap_wrapper._s1_util.attach(
-                req.ue_id, s1ap_types.tfwCmd.UE_END_TO_END_ATTACH_REQUEST,
+                req.ue_id,
+                s1ap_types.tfwCmd.UE_END_TO_END_ATTACH_REQUEST,
                 s1ap_types.tfwCmd.UE_ATTACH_ACCEPT_IND,
-                s1ap_types.ueAttachAccept_t)
+                s1ap_types.ueAttachAccept_t,
+            )
 
             # Wait on EMM Information from MME
             self._s1ap_wrapper._s1_util.receive_emm_info()
@@ -58,7 +64,7 @@ class TestAgwOffloadMixedIdleActiveMultiUe(unittest.TestCase):
 
         # Send UE context release request for half of UEs to move them
         # to ECM-IDLE state
-        for i in range(math.floor(num_ues/2)):
+        for i in range(math.floor(num_ues / 2)):
             ue_cntxt_rel_req = s1ap_types.ueCntxtRelReq_t()
             ue_cntxt_rel_req.ue_Id = ue_ids[i]
             ue_cntxt_rel_req.cause.causeVal = (
@@ -74,7 +80,7 @@ class TestAgwOffloadMixedIdleActiveMultiUe(unittest.TestCase):
 
         print("*************************  Send Offload Request to AGW")
         # Send offloading request
-        self._ha_util.offload_agw(None, enb_list[0][0])
+        self.assertTrue(self._ha_util.offload_agw(None, enb_list[0][0]))
 
         # All UEs should eventually receive Context Release Request
         # The first half should get it immediately
@@ -83,13 +89,15 @@ class TestAgwOffloadMixedIdleActiveMultiUe(unittest.TestCase):
             response = self._s1ap_wrapper.s1_util.get_response()
             self.assertIn(
                 response.msg_type,
-                [s1ap_types.tfwCmd.UE_CTX_REL_IND.value,
-                 s1ap_types.tfwCmd.UE_PAGING_IND.value],
-                 'Not a paging or ue context release message'
+                [
+                    s1ap_types.tfwCmd.UE_CTX_REL_IND.value,
+                    s1ap_types.tfwCmd.UE_PAGING_IND.value,
+                ],
+                "Not a paging or ue context release message",
             )
 
         # Send service request as paging response
-        for i in range(math.floor(num_ues/2)):
+        for i in range(math.floor(num_ues / 2)):
             # Send service request to reconnect UE
             # Auto-release should happen
             ser_req = s1ap_types.ueserviceReq_t()
@@ -127,10 +135,10 @@ class TestAgwOffloadMixedIdleActiveMultiUe(unittest.TestCase):
 
         # Now detach the UEs normally
         for ue in ue_ids:
-            print("************************* Running UE detach for UE id ",
-                    ue)
+            print("************************* Running UE detach for UE id ", ue)
             self._s1ap_wrapper.s1_util.detach(
-                ue, s1ap_types.ueDetachType_t.UE_NORMAL_DETACH.value, True)
+                ue, s1ap_types.ueDetachType_t.UE_NORMAL_DETACH.value, True
+            )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Title
[Non_Sanity_Testing] Generate failure instead of getting stuck for AGW offload test cases

## Summary
The following non-sanity AGW offload test cases were getting stuck and not even leading to test case failure. The problem was that the GRPC call is failing with exception and after that the test case gets completely stuck waiting for some response from MME. This PR generates failure for these test cases instead of getting stuck when there is GRPC exception from MME.

```
s1aptests/test_agw_offload_idle_active_ue.py
s1aptests/test_agw_offload_mixed_idle_active_multiue.py
```

This PR fixes one part of the issue #5930.

## Test Plan
The test case 

Signed-off-by: VinashakAnkitAman <ankit.aman@radisys.com>