### PR TITLE
[AGW][PyFormat] Apply isort to MobilityD

### DIFF
--- a/lte/gateway/python/magma/mobilityd/dhcp_client.py
+++ b/lte/gateway/python/magma/mobilityd/dhcp_client.py
@@ -16,20 +16,18 @@ import datetime
 import logging
 import threading
 import time
-from typing import Optional, MutableMapping
-
-
 from ipaddress import IPv4Network, ip_address
+from threading import Condition
+from typing import MutableMapping, Optional
+
+from magma.mobilityd.dhcp_desc import DHCPDescriptor, DHCPState
+from magma.mobilityd.mac import MacAddress, hex_to_mac
+from magma.mobilityd.uplink_gw import UplinkGatewayInfo
 from scapy.all import AsyncSniffer
 from scapy.layers.dhcp import BOOTP, DHCP
-from scapy.layers.l2 import Ether, Dot1Q
 from scapy.layers.inet import IP, UDP
+from scapy.layers.l2 import Dot1Q, Ether
 from scapy.sendrecv import sendp
-from threading import Condition
-
-from magma.mobilityd.mac import MacAddress, hex_to_mac
-from magma.mobilityd.dhcp_desc import DHCPState, DHCPDescriptor
-from magma.mobilityd.uplink_gw import UplinkGatewayInfo
 
 LOG = logging.getLogger('mobilityd.dhcp.sniff')
 DHCP_ACTIVE_STATES = [DHCPState.ACK, DHCPState.OFFER]

--- a/lte/gateway/python/magma/mobilityd/dhcp_desc.py
+++ b/lte/gateway/python/magma/mobilityd/dhcp_desc.py
@@ -10,8 +10,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
-from datetime import datetime
-from datetime import timedelta
+from datetime import datetime, timedelta
 from enum import IntEnum
 from typing import Optional
 

--- a/lte/gateway/python/magma/mobilityd/ip_address_man.py
+++ b/lte/gateway/python/magma/mobilityd/ip_address_man.py
@@ -40,8 +40,8 @@ during it's life cycle in the IP allocator:
         to age IPs for a certain period of time before freeing.
 """
 
-from __future__ import absolute_import, division, print_function, \
-    unicode_literals
+from __future__ import (absolute_import, division, print_function,
+                        unicode_literals)
 
 import ipaddress
 import logging
@@ -50,12 +50,11 @@ from ipaddress import ip_address, ip_network
 from typing import List, Optional, Tuple
 
 from lte.protos.mobilityd_pb2 import GWInfo, IPAddress
-
 from magma.mobilityd.ip_descriptor import IPState
-from magma.mobilityd.metrics import (IP_ALLOCATED_TOTAL, IP_RELEASED_TOTAL)
-from .ip_allocator_base import DuplicateIPAssignmentError, IPAllocator, \
-    IPNotInUseError, \
-    MappingNotFoundError
+from magma.mobilityd.metrics import IP_ALLOCATED_TOTAL, IP_RELEASED_TOTAL
+
+from .ip_allocator_base import (DuplicateIPAssignmentError, IPAllocator,
+                                IPNotInUseError, MappingNotFoundError)
 from .mobility_store import MobilityStore
 
 DEFAULT_IP_RECYCLE_INTERVAL = 15

--- a/lte/gateway/python/magma/mobilityd/ip_allocator_base.py
+++ b/lte/gateway/python/magma/mobilityd/ip_allocator_base.py
@@ -11,11 +11,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-from __future__ import absolute_import, division, print_function, \
-    unicode_literals
+from __future__ import (absolute_import, division, print_function,
+                        unicode_literals)
 
 from abc import ABC, abstractmethod
-
 from ipaddress import ip_address, ip_network
 from typing import List
 

--- a/lte/gateway/python/magma/mobilityd/ip_allocator_dhcp.py
+++ b/lte/gateway/python/magma/mobilityd/ip_allocator_dhcp.py
@@ -13,21 +13,21 @@ limitations under the License.
 Allocates IP address as per DHCP server in the uplink network.
 """
 
-from __future__ import absolute_import, division, print_function, \
-    unicode_literals
+from __future__ import (absolute_import, division, print_function,
+                        unicode_literals)
 
 import logging
 from copy import deepcopy
 from ipaddress import ip_address, ip_network
-from typing import List
 from threading import Condition
+from typing import List
 
-from magma.mobilityd.ip_descriptor import IPState, IPDesc, IPType
+from magma.mobilityd.ip_descriptor import IPDesc, IPState, IPType
 
-from .ip_allocator_base import IPAllocator, NoAvailableIPError
 from .dhcp_client import DHCPClient
+from .dhcp_desc import DHCPDescriptor, DHCPState
+from .ip_allocator_base import IPAllocator, NoAvailableIPError
 from .mac import MacAddress, create_mac_from_sid
-from .dhcp_desc import DHCPState, DHCPDescriptor
 from .mobility_store import MobilityStore
 
 DEFAULT_DHCP_REQUEST_RETRY_FREQUENCY = 10

--- a/lte/gateway/python/magma/mobilityd/ip_allocator_multi_apn.py
+++ b/lte/gateway/python/magma/mobilityd/ip_allocator_multi_apn.py
@@ -15,18 +15,17 @@ The IP allocator accepts IP blocks (range of IP addresses), and supports
 allocating and releasing IP addresses from the assigned IP blocks.
 """
 
-from __future__ import absolute_import, division, print_function, \
-    unicode_literals
+from __future__ import (absolute_import, division, print_function,
+                        unicode_literals)
 
+import logging
 from ipaddress import ip_address, ip_network
 from typing import List
-import logging
 
-from magma.mobilityd.ip_descriptor import IPDesc, IPState, IPType
 from magma.mobilityd.ip_allocator_base import IPAllocator
-from magma.mobilityd.subscriberdb_client import SubscriberDbClient
-
+from magma.mobilityd.ip_descriptor import IPDesc, IPState, IPType
 from magma.mobilityd.mobility_store import MobilityStore
+from magma.mobilityd.subscriberdb_client import SubscriberDbClient
 
 DEFAULT_IP_RECYCLE_INTERVAL = 15
 

--- a/lte/gateway/python/magma/mobilityd/ip_allocator_pool.py
+++ b/lte/gateway/python/magma/mobilityd/ip_allocator_pool.py
@@ -15,17 +15,18 @@ The IP allocator accepts IP blocks (range of IP addresses), and supports
 allocating and releasing IP addresses from the assigned IP blocks.
 """
 
-from __future__ import absolute_import, division, print_function, \
-    unicode_literals
+from __future__ import (absolute_import, division, print_function,
+                        unicode_literals)
 
 import logging
+from copy import deepcopy
 from ipaddress import ip_address, ip_network
 from typing import List
-from copy import deepcopy
 
 from magma.mobilityd.ip_descriptor import IPDesc, IPState, IPType
-from .ip_allocator_base import IPAllocator, NoAvailableIPError, \
-    IPBlockNotFoundError, OverlappedIPBlocksError
+
+from .ip_allocator_base import (IPAllocator, IPBlockNotFoundError,
+                                NoAvailableIPError, OverlappedIPBlocksError)
 from .mobility_store import MobilityStore
 
 DEFAULT_IP_RECYCLE_INTERVAL = 15

--- a/lte/gateway/python/magma/mobilityd/ip_allocator_static.py
+++ b/lte/gateway/python/magma/mobilityd/ip_allocator_static.py
@@ -15,20 +15,20 @@ The IP allocator accepts IP blocks (range of IP addresses), and supports
 allocating and releasing IP addresses from the assigned IP blocks.
 """
 
-from __future__ import absolute_import, division, print_function, \
-    unicode_literals
+from __future__ import (absolute_import, division, print_function,
+                        unicode_literals)
 
 import logging
 from ipaddress import ip_address, ip_network
 from typing import List, Optional
 
 from lte.protos.subscriberdb_pb2_grpc import SubscriberDBStub
+from magma.mobilityd.ip_allocator_base import (DuplicateIPAssignmentError,
+                                               IPAllocator)
 from magma.mobilityd.ip_descriptor import IPDesc, IPState, IPType
-from magma.mobilityd.ip_allocator_base import IPAllocator, \
-    DuplicateIPAssignmentError
-from magma.mobilityd.subscriberdb_client import SubscriberDbClient, \
-    StaticIPInfo
 from magma.mobilityd.mobility_store import MobilityStore
+from magma.mobilityd.subscriberdb_client import (StaticIPInfo,
+                                                 SubscriberDbClient)
 
 DEFAULT_IP_RECYCLE_INTERVAL = 15
 

--- a/lte/gateway/python/magma/mobilityd/ip_descriptor_map.py
+++ b/lte/gateway/python/magma/mobilityd/ip_descriptor_map.py
@@ -32,8 +32,8 @@ during it's life cycle in the IP allocator:
         to age IPs for a certain period of time before freeing.
 """
 
-from __future__ import absolute_import, division, print_function, \
-    unicode_literals
+from __future__ import (absolute_import, division, print_function,
+                        unicode_literals)
 
 from ipaddress import ip_address, ip_network
 from typing import Dict, List, MutableMapping, Optional, Set

--- a/lte/gateway/python/magma/mobilityd/ipv6_allocator_pool.py
+++ b/lte/gateway/python/magma/mobilityd/ipv6_allocator_pool.py
@@ -12,14 +12,12 @@ limitations under the License.
 """
 import logging
 import random
-
 from ipaddress import ip_address, ip_network
 from typing import List, Optional
 
-from .ip_descriptor import IPDesc, IPState, IPType
-from .ip_allocator_base import IPAllocator, \
-    NoAvailableIPError, OverlappedIPBlocksError, IPNotInUseError
-from .ip_descriptor import IPv6SessionAllocType
+from .ip_allocator_base import (IPAllocator, IPNotInUseError,
+                                NoAvailableIPError, OverlappedIPBlocksError)
+from .ip_descriptor import IPDesc, IPState, IPType, IPv6SessionAllocType
 from .mobility_store import MobilityStore
 
 IPV6_PREFIX_PART_LEN = 64

--- a/lte/gateway/python/magma/mobilityd/main.py
+++ b/lte/gateway/python/magma/mobilityd/main.py
@@ -14,6 +14,8 @@ import ipaddress
 import logging
 from typing import Optional
 
+from lte.protos.mconfig import mconfigs_pb2
+from lte.protos.subscriberdb_pb2_grpc import SubscriberDBStub
 from magma.common.redis.client import get_default_client
 from magma.common.sentry import sentry_init
 from magma.common.service import MagmaService
@@ -21,14 +23,12 @@ from magma.common.service_registry import ServiceRegistry
 from magma.mobilityd.ip_address_man import IPAddressManager
 from magma.mobilityd.ip_allocator_base import OverlappedIPBlocksError
 from magma.mobilityd.ip_allocator_dhcp import IPAllocatorDHCP
+from magma.mobilityd.ip_allocator_multi_apn import IPAllocatorMultiAPNWrapper
 from magma.mobilityd.ip_allocator_pool import IpAllocatorPool
 from magma.mobilityd.ip_allocator_static import IPAllocatorStaticWrapper
-from magma.mobilityd.ip_allocator_multi_apn import IPAllocatorMultiAPNWrapper
 from magma.mobilityd.ipv6_allocator_pool import IPv6AllocatorPool
-from magma.mobilityd.rpc_servicer import MobilityServiceRpcServicer
 from magma.mobilityd.mobility_store import MobilityStore
-from lte.protos.mconfig import mconfigs_pb2
-from lte.protos.subscriberdb_pb2_grpc import SubscriberDBStub
+from magma.mobilityd.rpc_servicer import MobilityServiceRpcServicer
 
 DEFAULT_IPV6_PREFIX_ALLOC_MODE = 'RANDOM'
 

--- a/lte/gateway/python/magma/mobilityd/metrics.py
+++ b/lte/gateway/python/magma/mobilityd/metrics.py
@@ -13,7 +13,6 @@ limitations under the License.
 
 from prometheus_client import Counter
 
-
 # Counters for IP address management
 IP_ALLOCATED_TOTAL = Counter('ip_address_allocated',
                              'Total IP addresses allocated')

--- a/lte/gateway/python/magma/mobilityd/mobility_store.py
+++ b/lte/gateway/python/magma/mobilityd/mobility_store.py
@@ -14,12 +14,11 @@ from collections import defaultdict
 
 import redis
 from lte.protos.mobilityd_pb2 import GWInfo
-
 from magma.common.redis.client import get_default_client
-from magma.common.redis.containers import RedisFlatDict, RedisHashDict, \
-    RedisSet
-from magma.common.redis.serializers import RedisSerde, get_json_deserializer, \
-    get_json_serializer
+from magma.common.redis.containers import (RedisFlatDict, RedisHashDict,
+                                           RedisSet)
+from magma.common.redis.serializers import (RedisSerde, get_json_deserializer,
+                                            get_json_serializer)
 from magma.mobilityd import serialize_utils
 from magma.mobilityd.ip_descriptor import IPDesc
 from magma.mobilityd.ip_descriptor_map import IpDescriptorMap

--- a/lte/gateway/python/magma/mobilityd/rpc_servicer.py
+++ b/lte/gateway/python/magma/mobilityd/rpc_servicer.py
@@ -14,26 +14,31 @@ limitations under the License.
 import ipaddress
 import logging
 
-import grpc
 from google.protobuf.json_format import MessageToJson
-from lte.protos.mobilityd_pb2 import AllocateIPAddressResponse, \
-    AllocateIPRequest, IPAddress, IPBlock, ListAddedIPBlocksResponse, \
-    ListAllocatedIPsResponse, ListGWInfoResponse, RemoveIPBlockResponse, \
-    SubscriberIPTable
-from lte.protos.mobilityd_pb2_grpc import MobilityServiceServicer, \
-    add_MobilityServiceServicer_to_server
-from lte.protos.subscriberdb_pb2 import SubscriberID
 
+import grpc
+from lte.protos.mobilityd_pb2 import (AllocateIPAddressResponse,
+                                      AllocateIPRequest, IPAddress, IPBlock,
+                                      ListAddedIPBlocksResponse,
+                                      ListAllocatedIPsResponse,
+                                      ListGWInfoResponse,
+                                      RemoveIPBlockResponse, SubscriberIPTable)
+from lte.protos.mobilityd_pb2_grpc import (MobilityServiceServicer,
+                                           add_MobilityServiceServicer_to_server)
+from lte.protos.subscriberdb_pb2 import SubscriberID
 from magma.common.rpc_utils import return_void
 from magma.subscriberdb.sid import SIDUtils
-from .ip_address_man import IPAddressManager, IPNotInUseError, \
-    MappingNotFoundError
-from .ip_allocator_base import DuplicateIPAssignmentError, \
-    DuplicatedIPAllocationError, IPBlockNotFoundError, NoAvailableIPError, \
-    OverlappedIPBlocksError
+
+from .ip_address_man import (IPAddressManager, IPNotInUseError,
+                             MappingNotFoundError)
+from .ip_allocator_base import (DuplicatedIPAllocationError,
+                                DuplicateIPAssignmentError,
+                                IPBlockNotFoundError, NoAvailableIPError,
+                                OverlappedIPBlocksError)
 from .ipv6_allocator_pool import MaxCalculationError
-from .subscriberdb_client import SubscriberDBConnectionError, \
-    SubscriberDBMultiAPNValueError, SubscriberDBStaticIPValueError
+from .subscriberdb_client import (SubscriberDBConnectionError,
+                                  SubscriberDBMultiAPNValueError,
+                                  SubscriberDBStaticIPValueError)
 
 
 class MobilityServiceRpcServicer(MobilityServiceServicer):

--- a/lte/gateway/python/magma/mobilityd/subscriberdb_client.py
+++ b/lte/gateway/python/magma/mobilityd/subscriberdb_client.py
@@ -12,12 +12,12 @@ limitations under the License.
 """
 
 import ipaddress
+import logging
 from typing import Optional
-from lte.protos.subscriberdb_pb2 import APNConfiguration
-from magma.subscriberdb.sid import SIDUtils
 
 import grpc
-import logging
+from lte.protos.subscriberdb_pb2 import APNConfiguration
+from magma.subscriberdb.sid import SIDUtils
 
 
 class NetworkInfo:

--- a/lte/gateway/python/magma/mobilityd/tests/ip_alloc_dhcp_test.py
+++ b/lte/gateway/python/magma/mobilityd/tests/ip_alloc_dhcp_test.py
@@ -17,22 +17,17 @@ import subprocess
 import sys
 import threading
 import unittest.mock
-
 from ipaddress import ip_network
+
 from magma.common.redis.client import get_default_client
-
-from magma.mobilityd.ip_address_man import IPAddressManager, \
-    MappingNotFoundError
+from magma.mobilityd.ip_address_man import (IPAddressManager,
+                                            MappingNotFoundError)
 from magma.mobilityd.ip_allocator_dhcp import IPAllocatorDHCP
-from magma.pipelined.bridge_util import BridgeTools
-from magma.mobilityd.ip_descriptor import IPDesc, IPType, IPState
-
+from magma.mobilityd.ip_descriptor import IPDesc, IPState, IPType
+from magma.mobilityd.ipv6_allocator_pool import IPv6AllocatorPool
 from magma.mobilityd.mac import create_mac_from_sid
-
-from magma.mobilityd.ipv6_allocator_pool import \
-    IPv6AllocatorPool
-
 from magma.mobilityd.mobility_store import MobilityStore
+from magma.pipelined.bridge_util import BridgeTools
 
 LOG = logging.getLogger('mobilityd.dhcp.test')
 LOG.isEnabledFor(logging.DEBUG)

--- a/lte/gateway/python/magma/mobilityd/tests/ip_allocator_tests.py
+++ b/lte/gateway/python/magma/mobilityd/tests/ip_allocator_tests.py
@@ -11,26 +11,22 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
+from __future__ import (absolute_import, division, print_function,
+                        unicode_literals)
 
 import ipaddress
-import unittest
 import time
+import unittest
 
 from magma.common.redis.client import get_default_client
-
-from magma.mobilityd.ip_address_man import IPAddressManager, \
-    IPNotInUseError, MappingNotFoundError
-from magma.mobilityd.ip_allocator_pool import IPBlockNotFoundError, \
-    NoAvailableIPError
-from magma.mobilityd.ip_allocator_pool import \
-    IpAllocatorPool
-from magma.mobilityd.ipv6_allocator_pool import \
-    IPv6AllocatorPool
+from magma.mobilityd.ip_address_man import (IPAddressManager, IPNotInUseError,
+                                            MappingNotFoundError)
+from magma.mobilityd.ip_allocator_pool import (IpAllocatorPool,
+                                               IPBlockNotFoundError,
+                                               NoAvailableIPError)
+from magma.mobilityd.ipv6_allocator_pool import IPv6AllocatorPool
 from magma.mobilityd.mobility_store import MobilityStore
+
 
 # If the preallocated IP addresses in ip_address_man.py code
 # changes, then the test cases must be updated

--- a/lte/gateway/python/magma/mobilityd/tests/rpc_servicer_tests.py
+++ b/lte/gateway/python/magma/mobilityd/tests/rpc_servicer_tests.py
@@ -18,23 +18,22 @@ import unittest.mock
 from concurrent import futures
 
 import grpc
-from lte.protos.mobilityd_pb2 import AllocateIPRequest, IPAddress, IPBlock, \
-    ListAddedIPBlocksResponse, ListAllocatedIPsResponse, ReleaseIPRequest, \
-    RemoveIPBlockRequest, RemoveIPBlockResponse, SubscriberIPTableEntry, \
-    IPLookupRequest, GWInfo
+from lte.protos.mobilityd_pb2 import (AllocateIPRequest, GWInfo, IPAddress,
+                                      IPBlock, IPLookupRequest,
+                                      ListAddedIPBlocksResponse,
+                                      ListAllocatedIPsResponse,
+                                      ReleaseIPRequest, RemoveIPBlockRequest,
+                                      RemoveIPBlockResponse,
+                                      SubscriberIPTableEntry)
 from lte.protos.mobilityd_pb2_grpc import MobilityServiceStub
 from magma.common.redis.client import get_default_client
 from magma.mobilityd.ip_address_man import IPAddressManager
+from magma.mobilityd.ip_allocator_pool import IpAllocatorPool
+from magma.mobilityd.ipv6_allocator_pool import IPv6AllocatorPool
+from magma.mobilityd.mobility_store import MobilityStore
 from magma.mobilityd.rpc_servicer import MobilityServiceRpcServicer
 from magma.subscriberdb.sid import SIDUtils
 from orc8r.protos.common_pb2 import Void
-
-from magma.mobilityd.mobility_store import MobilityStore
-
-from magma.mobilityd.ip_allocator_pool import \
-    IpAllocatorPool
-from magma.mobilityd.ipv6_allocator_pool import \
-    IPv6AllocatorPool
 
 
 class RpcTests(unittest.TestCase):

--- a/lte/gateway/python/magma/mobilityd/tests/test_dhcp_client.py
+++ b/lte/gateway/python/magma/mobilityd/tests/test_dhcp_client.py
@@ -19,16 +19,15 @@ import sys
 import threading
 import time
 import unittest
+
 from freezegun import freeze_time
-
-from magma.pipelined.bridge_util import BridgeTools
-
 from magma.mobilityd.dhcp_client import DHCPClient
+from magma.mobilityd.dhcp_desc import DHCPDescriptor, DHCPState
 from magma.mobilityd.mac import MacAddress
-from magma.mobilityd.dhcp_desc import DHCPState, DHCPDescriptor
 from magma.mobilityd.uplink_gw import UplinkGatewayInfo
+from magma.pipelined.bridge_util import BridgeTools
 from scapy.layers.dhcp import DHCP
-from scapy.layers.l2 import Ether, Dot1Q
+from scapy.layers.l2 import Dot1Q, Ether
 from scapy.sendrecv import AsyncSniffer
 
 LOG = logging.getLogger('mobilityd.dhcp.test')

--- a/lte/gateway/python/magma/mobilityd/tests/test_ipv6_allocator.py
+++ b/lte/gateway/python/magma/mobilityd/tests/test_ipv6_allocator.py
@@ -11,19 +11,16 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
+from __future__ import (absolute_import, division, print_function,
+                        unicode_literals)
 
 import ipaddress
 import unittest
-import fakeredis
 
+import fakeredis
+from magma.mobilityd.ip_address_man import IPNotInUseError
 from magma.mobilityd.ip_descriptor import IPDesc
 from magma.mobilityd.ipv6_allocator_pool import IPv6AllocatorPool
-from magma.mobilityd.ip_address_man import IPNotInUseError
-
 from magma.mobilityd.mobility_store import MobilityStore
 
 

--- a/lte/gateway/python/magma/mobilityd/tests/test_multi_apn_ip_alloc.py
+++ b/lte/gateway/python/magma/mobilityd/tests/test_multi_apn_ip_alloc.py
@@ -12,32 +12,23 @@ limitations under the License.
 """
 
 import ipaddress
-import unittest
 import logging
+import unittest
 from typing import Optional
 
-from lte.protos.subscriberdb_pb2 import (
-    LTESubscription,
-    SubscriberData,
-    SubscriberState,
-    Non3GPPUserProfile,
-    APNConfiguration,
-)
-
+from lte.protos.subscriberdb_pb2 import (APNConfiguration, LTESubscription,
+                                         Non3GPPUserProfile, SubscriberData,
+                                         SubscriberState)
 from magma.common.redis.client import get_default_client
+from magma.mobilityd.ip_address_man import (IPAddressManager, IPNotInUseError,
+                                            MappingNotFoundError)
+from magma.mobilityd.ip_allocator_multi_apn import IPAllocatorMultiAPNWrapper
+from magma.mobilityd.ip_allocator_pool import IpAllocatorPool
+from magma.mobilityd.ip_allocator_static import IPAllocatorStaticWrapper
 from magma.mobilityd.ip_descriptor import IPDesc, IPType
-from magma.mobilityd.ip_address_man import IPAddressManager, \
-    IPNotInUseError, MappingNotFoundError
-from magma.subscriberdb.sid import SIDUtils
+from magma.mobilityd.ipv6_allocator_pool import IPv6AllocatorPool
 from magma.mobilityd.mobility_store import MobilityStore
-from magma.mobilityd.ip_allocator_pool import \
-    IpAllocatorPool
-from magma.mobilityd.ip_allocator_multi_apn import \
-    IPAllocatorMultiAPNWrapper
-from magma.mobilityd.ipv6_allocator_pool import \
-    IPv6AllocatorPool
-from magma.mobilityd.ip_allocator_static import \
-    IPAllocatorStaticWrapper
+from magma.subscriberdb.sid import SIDUtils
 
 
 class MockedSubscriberDBStub:

--- a/lte/gateway/python/magma/mobilityd/tests/test_static_ip_alloc.py
+++ b/lte/gateway/python/magma/mobilityd/tests/test_static_ip_alloc.py
@@ -12,26 +12,24 @@ limitations under the License.
 """
 
 import ipaddress
+import time
 import unittest
-import fakeredis
 from typing import Optional
 
+import fakeredis
+from magma.mobilityd.ip_address_man import (DuplicateIPAssignmentError,
+                                            IPAddressManager, IPNotInUseError,
+                                            MappingNotFoundError)
+from magma.mobilityd.ip_allocator_pool import IpAllocatorPool
+from magma.mobilityd.ip_allocator_static import IPAllocatorStaticWrapper
 from magma.mobilityd.ip_descriptor import IPDesc, IPType
-from magma.mobilityd.ip_address_man import IPAddressManager, \
-    IPNotInUseError, MappingNotFoundError, DuplicateIPAssignmentError
+from magma.mobilityd.ipv6_allocator_pool import IPv6AllocatorPool
+from magma.mobilityd.mobility_store import MobilityStore
+from magma.mobilityd.subscriberdb_client import SubscriberDBStaticIPValueError
 from magma.mobilityd.tests.test_multi_apn_ip_alloc import \
     MockedSubscriberDBStub
 from magma.mobilityd.uplink_gw import InvalidVlanId
 
-from magma.mobilityd.ip_allocator_static import \
-    IPAllocatorStaticWrapper
-from magma.mobilityd.ip_allocator_pool import \
-    IpAllocatorPool
-from magma.mobilityd.ipv6_allocator_pool import \
-    IPv6AllocatorPool
-from magma.mobilityd.mobility_store import MobilityStore
-from magma.mobilityd.subscriberdb_client import SubscriberDBStaticIPValueError
-import time
 
 class StaticIPAllocationTests(unittest.TestCase):
     """

--- a/lte/gateway/python/magma/mobilityd/tests/test_uplink_gw.py
+++ b/lte/gateway/python/magma/mobilityd/tests/test_uplink_gw.py
@@ -12,12 +12,12 @@ limitations under the License.
 """
 import ipaddress
 import logging
+import subprocess
 import unittest
 from collections import defaultdict
-import subprocess
 
-from magma.mobilityd.uplink_gw import UplinkGatewayInfo, NO_VLAN
 from lte.protos.mobilityd_pb2 import GWInfo, IPAddress
+from magma.mobilityd.uplink_gw import NO_VLAN, UplinkGatewayInfo
 
 LOG = logging.getLogger('mobilityd.def_gw.test')
 LOG.isEnabledFor(logging.DEBUG)


### PR DESCRIPTION
<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary
Prep work for enforcing some import sorting standards to the contributing doc. Will have a GH action to enforce this on future PRs.

- Apply isort (https://pypi.org/project/isort/) to mobilityd service
- no-op logic wise

![](https://media1.giphy.com/media/10zsjaH4g0GgmY/giphy.gif)
<!-- Enumerate changes you made and why you made them -->

## Test Plan
unit tests
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
