### PR TITLE
[DevExp] Migrate container to clang-format 7 for backwards compatibility

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -47,6 +47,7 @@ RUN echo "Install general purpose packages" && \
         automake \
         build-essential \
         ca-certificates \
+        clang-format-7 \
         clang-format-11 \
         clang-tidy-11 \
         curl \
@@ -78,6 +79,7 @@ RUN echo "Install general purpose packages" && \
         gem install fpm && \
         update-alternatives --install /usr/bin/clang clang /usr/lib/llvm-11/bin/clang 10 && \
         update-alternatives --install /usr/bin/clang++ clang++ /usr/lib/llvm-11/bin/clang++ 10 && \
+        update-alternatives --install /usr/bin/clang-format clang-format /usr/lib/llvm-7/bin/clang-format 10 && \
         update-alternatives --install /usr/bin/clang-tidy clang-tidy /usr/lib/llvm-11/bin/clang-tidy 10 && \
         update-alternatives --install /usr/bin/clang-apply-replacements clang-apply-replacements /usr/lib/llvm-11/bin/clang-apply-replacements 10
 

--- a/lte/gateway/docker/mme/Dockerfile.ubuntu20.04
+++ b/lte/gateway/docker/mme/Dockerfile.ubuntu20.04
@@ -25,6 +25,7 @@ RUN echo "Install general purpouse packages" && \
         build-essential \
         ca-certificates \
         clang-11 \
+        clang-format-7 \
         clang-format-11 \
         clang-tidy-11 \
         curl \
@@ -55,9 +56,11 @@ RUN echo "Install general purpouse packages" && \
         vim \
         wget && \
         gem install fpm && \
-        update-alternatives --install /usr/bin/clang-tidy clang-tidy /usr/lib/llvm-11/bin/clang-tidy 10 && \
         update-alternatives --install /usr/bin/clang clang /usr/lib/llvm-11/bin/clang 10 && \
-        update-alternatives --install /usr/bin/clang++ clang++ /usr/lib/llvm-11/bin/clang++ 10
+        update-alternatives --install /usr/bin/clang++ clang++ /usr/lib/llvm-11/bin/clang++ 10 \
+        update-alternatives --install /usr/bin/clang-format clang-format /usr/lib/llvm-7/bin/clang-format 10 && \
+        update-alternatives --install /usr/bin/clang-tidy clang-tidy /usr/lib/llvm-11/bin/clang-tidy 10 && \
+        update-alternatives --install /usr/bin/clang-apply-replacements clang-apply-replacements /usr/lib/llvm-11/bin/clang-apply-replacements 10
 
 RUN echo "Install 3rd party dependencies" && \
     apt-get update && \


### PR DESCRIPTION
## Test Plan

Loaded branch in GH Code Spaces, modify a file in `lte/gateway/c/oai/` with incorrect formatting for clang-format. Then confirmed that the following fixed-up ONLY that modified file and no others.

```
cd lte/gateway/
make build_oai
```

Signed-off-by: Scott Harrison Moeller <smoeller@fb.com>