### PR TITLE
[AGW][PyFormat] Apply isort to monitord

### DIFF
--- a/lte/gateway/python/magma/monitord/cpe_monitoring.py
+++ b/lte/gateway/python/magma/monitord/cpe_monitoring.py
@@ -10,11 +10,11 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
+import ipaddress
 import logging
 from collections import defaultdict
 from time import time
 from typing import Dict, List, NamedTuple, Optional
-import ipaddress
 
 import grpc
 from lte.protos.mobilityd_pb2 import IPAddress, SubscriberIPTable

--- a/lte/gateway/python/magma/monitord/icmp_monitoring.py
+++ b/lte/gateway/python/magma/monitord/icmp_monitoring.py
@@ -15,9 +15,9 @@ import logging
 from typing import Dict, List, Optional
 
 from magma.common.job import Job
-from magma.magmad.check.network_check.ping import PingInterfaceCommandParams, \
-    ping_interface_async
-from magma.magmad.check.network_check.ping import PingCommandResult
+from magma.magmad.check.network_check.ping import (PingCommandResult,
+                                                   PingInterfaceCommandParams,
+                                                   ping_interface_async)
 
 NUM_PACKETS = 4
 DEFAULT_POLLING_INTERVAL = 60

--- a/lte/gateway/python/magma/monitord/icmp_state.py
+++ b/lte/gateway/python/magma/monitord/icmp_state.py
@@ -34,4 +34,3 @@ def serialize_subscriber_states(
         )
         states.append(state)
     return states
-

--- a/lte/gateway/python/magma/monitord/main.py
+++ b/lte/gateway/python/magma/monitord/main.py
@@ -14,13 +14,13 @@ limitations under the License.
 import logging
 
 from lte.protos.mconfig import mconfigs_pb2
-from magma.common.service import MagmaService
+from lte.protos.mobilityd_pb2 import IPAddress
 from magma.common.sentry import sentry_init
+from magma.common.service import MagmaService
 from magma.configuration import load_service_config
+from magma.monitord.cpe_monitoring import CpeMonitoringModule
 from magma.monitord.icmp_monitoring import ICMPMonitoring
 from magma.monitord.icmp_state import serialize_subscriber_states
-from magma.monitord.cpe_monitoring import CpeMonitoringModule
-from lte.protos.mobilityd_pb2 import IPAddress
 
 
 def _get_serialized_subscriber_states(cpe_monitor: CpeMonitoringModule):

--- a/lte/gateway/python/magma/monitord/tests/test_icmp_monitor.py
+++ b/lte/gateway/python/magma/monitord/tests/test_icmp_monitor.py
@@ -16,8 +16,8 @@ import asyncio
 import unittest
 
 from lte.protos.mobilityd_pb2 import IPAddress, SubscriberIPTable
-from magma.monitord.icmp_monitoring import ICMPMonitoring
 from magma.monitord.cpe_monitoring import CpeMonitoringModule
+from magma.monitord.icmp_monitoring import ICMPMonitoring
 
 LOCALHOST = '127.0.0.1'
 


### PR DESCRIPTION
<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary
Prep work for enforcing some import sorting standards to the contributing doc. Will have a GH action to enforce this on future PRs.

- Apply isort (https://pypi.org/project/isort/) to monitord service
- no-op logic wise

![](https://media3.giphy.com/media/HIrYP4RI9DpLy/giphy.gif)
<!-- Enumerate changes you made and why you made them -->

## Test Plan
unit tests
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
