### PR TITLE
[AGW][PyFormat] Apply isort to all smaller lte python services

### DIFF
--- a/lte/gateway/python/magma/health/health_service.py
+++ b/lte/gateway/python/magma/health/health_service.py
@@ -14,18 +14,17 @@ limitations under the License.
 """
 import glob
 import ipaddress
-
 import math
 from os import path
 
 from lte.protos.enodebd_pb2_grpc import EnodebdStub
-from lte.protos.mobilityd_pb2_grpc import MobilityServiceStub
 from lte.protos.mobilityd_pb2 import IPAddress
-from orc8r.protos.common_pb2 import Void
+from lte.protos.mobilityd_pb2_grpc import MobilityServiceStub
 from magma.common.service_registry import ServiceRegistry
 from magma.configuration.mconfig_managers import load_service_mconfig_as_json
-from magma.health.entities import AGWHealthSummary, RegistrationSuccessRate, \
-    CoreDumps
+from magma.health.entities import (AGWHealthSummary, CoreDumps,
+                                   RegistrationSuccessRate)
+from orc8r.protos.common_pb2 import Void
 
 
 class AGWHealth:

--- a/lte/gateway/python/magma/health/main.py
+++ b/lte/gateway/python/magma/health/main.py
@@ -15,7 +15,6 @@ from magma.common.health.service_state_wrapper import ServiceStateWrapper
 from magma.common.sentry import sentry_init
 from magma.common.service import MagmaService
 from magma.configuration.service_configs import load_service_config
-
 from magma.health.state_recovery import StateRecoveryJob
 
 

--- a/lte/gateway/python/magma/health/state_recovery.py
+++ b/lte/gateway/python/magma/health/state_recovery.py
@@ -10,10 +10,9 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
+import logging
 import os
 import shutil
-import logging
-
 from time import time
 from typing import Dict, List, NamedTuple, Optional
 
@@ -21,7 +20,6 @@ from magma.common.health.service_state_wrapper import ServiceStateWrapper
 from magma.common.job import Job
 from magma.magmad.check import subprocess_workflow
 from orc8r.protos.service_status_pb2 import ServiceExitStatus
-
 from redis.exceptions import ConnectionError
 
 SystemdServiceParams = NamedTuple('SystemdServiceParams', [('service', str)])

--- a/lte/gateway/python/magma/monitord/cpe_monitoring.py
+++ b/lte/gateway/python/magma/monitord/cpe_monitoring.py
@@ -10,11 +10,11 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
+import ipaddress
 import logging
 from collections import defaultdict
 from time import time
 from typing import Dict, List, NamedTuple, Optional
-import ipaddress
 
 import grpc
 from lte.protos.mobilityd_pb2 import IPAddress, SubscriberIPTable

--- a/lte/gateway/python/magma/monitord/icmp_monitoring.py
+++ b/lte/gateway/python/magma/monitord/icmp_monitoring.py
@@ -15,9 +15,9 @@ import logging
 from typing import Dict, List, Optional
 
 from magma.common.job import Job
-from magma.magmad.check.network_check.ping import PingInterfaceCommandParams, \
-    ping_interface_async
-from magma.magmad.check.network_check.ping import PingCommandResult
+from magma.magmad.check.network_check.ping import (PingCommandResult,
+                                                   PingInterfaceCommandParams,
+                                                   ping_interface_async)
 
 NUM_PACKETS = 4
 DEFAULT_POLLING_INTERVAL = 60

--- a/lte/gateway/python/magma/monitord/main.py
+++ b/lte/gateway/python/magma/monitord/main.py
@@ -13,14 +13,15 @@ limitations under the License.
 
 import logging
 
-from lte.protos.mconfig import mconfigs_pb2
-from magma.common.service import MagmaService
+from lte.protos.mobilityd_pb2 import IPAddress
 from magma.common.sentry import sentry_init
+from magma.common.service import MagmaService
 from magma.configuration import load_service_config
+from magma.monitord.cpe_monitoring import CpeMonitoringModule
 from magma.monitord.icmp_monitoring import ICMPMonitoring
 from magma.monitord.icmp_state import serialize_subscriber_states
-from magma.monitord.cpe_monitoring import CpeMonitoringModule
-from lte.protos.mobilityd_pb2 import IPAddress
+
+from lte.protos.mconfig import mconfigs_pb2
 
 
 def _get_serialized_subscriber_states(cpe_monitor: CpeMonitoringModule):

--- a/lte/gateway/python/magma/monitord/tests/test_icmp_monitor.py
+++ b/lte/gateway/python/magma/monitord/tests/test_icmp_monitor.py
@@ -16,8 +16,8 @@ import asyncio
 import unittest
 
 from lte.protos.mobilityd_pb2 import IPAddress, SubscriberIPTable
-from magma.monitord.icmp_monitoring import ICMPMonitoring
 from magma.monitord.cpe_monitoring import CpeMonitoringModule
+from magma.monitord.icmp_monitoring import ICMPMonitoring
 
 LOCALHOST = '127.0.0.1'
 

--- a/lte/gateway/python/magma/pkt_tester/tests/test_ovs_gtp.py
+++ b/lte/gateway/python/magma/pkt_tester/tests/test_ovs_gtp.py
@@ -13,11 +13,10 @@ limitations under the License.
 
 import unittest
 
+import test_topology_builder
 from nose.plugins.skip import SkipTest
 from scapy.all import IP, UDP, L2Socket  # pylint: disable=no-name-in-module
 from scapy.contrib.gtp import GTPCreatePDPContextRequest, GTPHeader
-
-import test_topology_builder
 
 
 class TestOvsGtp(unittest.TestCase):

--- a/lte/gateway/python/magma/pkt_tester/tests/test_topology_builder.py
+++ b/lte/gateway/python/magma/pkt_tester/tests/test_topology_builder.py
@@ -13,6 +13,7 @@ limitations under the License.
 
 import os
 import unittest
+
 from nose.plugins.skip import SkipTest
 
 

--- a/lte/gateway/python/magma/pkt_tester/topology_builder.py
+++ b/lte/gateway/python/magma/pkt_tester/topology_builder.py
@@ -11,13 +11,12 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-import logging
 import copy
+import logging
 import re
 
 from ovstest import util  # pylint: disable=import-error
 from ovstest import vswitch  # pylint: disable=import-error
-
 
 logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
 

--- a/lte/gateway/python/magma/redirectd/main.py
+++ b/lte/gateway/python/magma/redirectd/main.py
@@ -14,11 +14,11 @@ limitations under the License.
 import logging
 import threading
 
-from magma.common.service import MagmaService
+from lte.protos.mconfig import mconfigs_pb2
 from magma.common.sentry import sentry_init
+from magma.common.service import MagmaService
 from magma.configuration.service_configs import get_service_config_value
 from magma.redirectd.redirect_server import run_flask
-from lte.protos.mconfig import mconfigs_pb2
 
 
 def main():

--- a/lte/gateway/python/magma/redirectd/redirect_server.py
+++ b/lte/gateway/python/magma/redirectd/redirect_server.py
@@ -14,10 +14,9 @@ limitations under the License.
 import logging
 from collections import namedtuple
 
-from magma.redirectd.redirect_store import RedirectDict
-
 import wsgiserver
-from flask import Flask, redirect, request, render_template
+from flask import Flask, redirect, render_template, request
+from magma.redirectd.redirect_store import RedirectDict
 
 """ Use 404 when subscriber not found, 302 for 'Found' redirect """
 HTTP_NOT_FOUND = 404

--- a/lte/gateway/python/magma/redirectd/redirect_store.py
+++ b/lte/gateway/python/magma/redirectd/redirect_store.py
@@ -12,11 +12,10 @@ limitations under the License.
 """
 
 from lte.protos.policydb_pb2 import RedirectInformation
-
 from magma.common.redis.client import get_default_client
 from magma.common.redis.containers import RedisHashDict
-from magma.common.redis.serializers import get_proto_deserializer, \
-    get_proto_serializer
+from magma.common.redis.serializers import (get_proto_deserializer,
+                                            get_proto_serializer)
 
 
 class RedirectDict(RedisHashDict):

--- a/lte/gateway/python/magma/redirectd/tests/test_redirect.py
+++ b/lte/gateway/python/magma/redirectd/tests/test_redirect.py
@@ -15,8 +15,10 @@ import unittest
 from unittest.mock import MagicMock
 
 from lte.protos.policydb_pb2 import RedirectInformation
-from magma.redirectd.redirect_server import HTTP_NOT_FOUND, HTTP_REDIRECT, \
-    NOT_FOUND_HTML, RedirectInfo, ServerResponse, setup_flask_server
+from magma.redirectd.redirect_server import (HTTP_NOT_FOUND, HTTP_REDIRECT,
+                                             NOT_FOUND_HTML, RedirectInfo,
+                                             ServerResponse,
+                                             setup_flask_server)
 
 
 class RedirectdTest(unittest.TestCase):

--- a/lte/gateway/python/magma/smsd/main.py
+++ b/lte/gateway/python/magma/smsd/main.py
@@ -11,12 +11,16 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
+from lte.protos.sms_orc8r_pb2_grpc import (SmsDStub,
+                                           SMSOrc8rGatewayServiceStub,
+                                           SMSOrc8rServiceStub)
 from magma.common.sentry import sentry_init
 from magma.common.service import MagmaService
 from magma.common.service_registry import ServiceRegistry
-from lte.protos.sms_orc8r_pb2_grpc import SMSOrc8rServiceStub, SMSOrc8rGatewayServiceStub, SmsDStub
 from orc8r.protos.directoryd_pb2_grpc import GatewayDirectoryServiceStub
+
 from .relay import SmsRelay
+
 
 def main():
     """ main() for smsd """

--- a/lte/gateway/python/magma/smsd/relay.py
+++ b/lte/gateway/python/magma/smsd/relay.py
@@ -15,13 +15,12 @@ import logging
 from typing import List
 
 import grpc
+import lte.protos.sms_orc8r_pb2 as sms_orc8r_pb2
+import lte.protos.sms_orc8r_pb2_grpc as sms_orc8r_pb2_grpc
+from lte.protos.mconfig.mconfigs_pb2 import MME
 from magma.common.job import Job
-
 from magma.common.rpc_utils import grpc_async_wrapper, return_void
 from magma.configuration.mconfig_managers import load_service_mconfig
-from lte.protos.mconfig.mconfigs_pb2 import MME
-import lte.protos.sms_orc8r_pb2_grpc as sms_orc8r_pb2_grpc
-import lte.protos.sms_orc8r_pb2 as sms_orc8r_pb2
 from orc8r.protos.common_pb2 import Void
 from orc8r.protos.directoryd_pb2_grpc import GatewayDirectoryServiceStub
 


### PR DESCRIPTION
<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary
Prep work for enforcing some import sorting standards to the contributing doc. Will have a GH action to enforce this on future PRs.

- Apply isort (https://pypi.org/project/isort/) to redirectd/smsd/pkt_tester/health/monitord service
- no-op logic wise

![](https://media0.giphy.com/media/3ohzAvBVvOQktruXwQ/giphy.gif)
<!-- Enumerate changes you made and why you made them -->

## Test Plan
unit tests
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
