### PR TITLE
[AGW][PyFormat] Apply isort to all integration tests - round 2

### DIFF
--- a/lte/gateway/python/integ_tests/cloud/cloud_manager.py
+++ b/lte/gateway/python/integ_tests/cloud/cloud_manager.py
@@ -15,11 +15,13 @@ from typing import Any, Dict, List
 
 import requests
 import swagger_client
+from integ_tests.cloud.fixtures import (
+    DEFAULT_GATEWAY_CELLULAR_CONFIG,
+    DEFAULT_GATEWAY_CONFIG,
+    DEFAULT_NETWORK_CELLULAR_CONFIG,
+    DEFAULT_NETWORK_DNSD_CONFIG,
+)
 from swagger_client.rest import ApiException
-
-from integ_tests.cloud.fixtures import DEFAULT_GATEWAY_CELLULAR_CONFIG, \
-    DEFAULT_GATEWAY_CONFIG, DEFAULT_NETWORK_CELLULAR_CONFIG, \
-    DEFAULT_NETWORK_DNSD_CONFIG
 
 TEST_CLOUD_HOSTNAME = 'controller.magma.test'
 TEST_CLOUD_PORT = '9443'

--- a/lte/gateway/python/integ_tests/cloud_tests/checkin_test.py
+++ b/lte/gateway/python/integ_tests/cloud_tests/checkin_test.py
@@ -12,13 +12,12 @@ limitations under the License.
 """
 import time
 import unittest
-
 import warnings
-from swagger_client import rest
 
 from integ_tests.cloud.cloud_manager import CloudManager
 from integ_tests.cloud.fixtures import GATEWAY_ID, NETWORK_ID
 from integ_tests.gateway.rpc import get_gateway_hw_id
+from swagger_client import rest
 
 MAX_GATEWAY_CHECKS = 12
 GATEWAY_POLL_INTERVAL_SEC = 10

--- a/lte/gateway/python/integ_tests/cloud_tests/config_test.py
+++ b/lte/gateway/python/integ_tests/cloud_tests/config_test.py
@@ -14,7 +14,6 @@ import time
 import unittest
 
 import swagger_client
-
 from integ_tests.cloud import cloud_manager, fixtures
 from integ_tests.cloud.cloud_manager import CloudManager
 from integ_tests.gateway import rpc

--- a/lte/gateway/python/integ_tests/common/mobility_service_client.py
+++ b/lte/gateway/python/integ_tests/common/mobility_service_client.py
@@ -11,18 +11,17 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
+import abc
 import ipaddress
 import logging
 import time
 
-import abc
 import grpc
-from orc8r.protos.common_pb2 import Void
-from lte.protos.mobilityd_pb2 import IPAddress, IPBlock, RemoveIPBlockRequest
-from lte.protos.mobilityd_pb2_grpc import MobilityServiceStub
-
 # from integ_tests.cloud.fixtures import GATEWAY_ID, NETWORK_ID
 from integ_tests.gateway.rpc import get_gateway_hw_id, get_rpc_channel
+from lte.protos.mobilityd_pb2 import IPAddress, IPBlock, RemoveIPBlockRequest
+from lte.protos.mobilityd_pb2_grpc import MobilityServiceStub
+from orc8r.protos.common_pb2 import Void
 
 
 class MobilityServiceClient(metaclass=abc.ABCMeta):

--- a/lte/gateway/python/integ_tests/common/service303_utils.py
+++ b/lte/gateway/python/integ_tests/common/service303_utils.py
@@ -15,13 +15,12 @@ import logging
 import time
 
 import grpc
-import orc8r.protos.metricsd_pb2 as metricsd
 import metrics_pb2 as metrics_proto
+import orc8r.protos.metricsd_pb2 as metricsd
+from integ_tests.gateway.rpc import get_rpc_channel
 from orc8r.protos.common_pb2 import Void
 from orc8r.protos.service303_pb2 import ServiceInfo
 from orc8r.protos.service303_pb2_grpc import Service303Stub
-
-from integ_tests.gateway.rpc import get_rpc_channel
 
 
 class MetricNotFoundException(Exception):

--- a/lte/gateway/python/integ_tests/common/subscriber_db_client.py
+++ b/lte/gateway/python/integ_tests/common/subscriber_db_client.py
@@ -11,26 +11,24 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-import logging
-import time
-
 import abc
 import base64
-import grpc
+import logging
 import subprocess
+import time
 
-from orc8r.protos.common_pb2 import Void
+import grpc
+from integ_tests.gateway.rpc import get_gateway_hw_id, get_rpc_channel
 from lte.protos.subscriberdb_pb2 import (
     LTESubscription,
     SubscriberData,
-    SubscriberState,
     SubscriberID,
+    SubscriberState,
     SubscriberUpdate,
 )
 from lte.protos.subscriberdb_pb2_grpc import SubscriberDBStub
-
-from integ_tests.gateway.rpc import get_gateway_hw_id, get_rpc_channel
 from magma.subscriberdb.sid import SIDUtils
+from orc8r.protos.common_pb2 import Void
 
 KEY = '000102030405060708090A0B0C0D0E0F'
 #OP='11111111111111111111111111111111' -> OPc='24c05f7c2f2b368de10f252f25f6cfc2'

--- a/lte/gateway/python/integ_tests/gateway/rpc.py
+++ b/lte/gateway/python/integ_tests/gateway/rpc.py
@@ -10,15 +10,14 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
-from typing import Any, Dict, List
-
 import os
-from orc8r.protos.common_pb2 import Void
-from orc8r.protos.magmad_pb2_grpc import MagmadStub
-from orc8r.protos.mconfig import mconfigs_pb2
+from typing import Any, Dict, List
 
 from magma.common.service_registry import create_grpc_channel
 from magma.configuration.mconfigs import unpack_mconfig_any
+from orc8r.protos.common_pb2 import Void
+from orc8r.protos.magmad_pb2_grpc import MagmadStub
+from orc8r.protos.mconfig import mconfigs_pb2
 
 
 def get_rpc_channel(service):

--- a/lte/gateway/python/integ_tests/gxgy_tests/policies.py
+++ b/lte/gateway/python/integ_tests/gxgy_tests/policies.py
@@ -11,7 +11,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 from lte.protos.policydb_pb2 import FlowDescription, FlowMatch, PolicyRule
-
 from magma.pipelined.tests.app.packet_builder import IPPacketBuilder
 
 MAC_DEST = "5e:cc:cc:b1:49:4b"

--- a/lte/gateway/python/integ_tests/gxgy_tests/session_manager.py
+++ b/lte/gateway/python/integ_tests/gxgy_tests/session_manager.py
@@ -11,9 +11,14 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 from lte.protos import session_manager_pb2, session_manager_pb2_grpc
-from lte.protos.session_manager_pb2 import ChargingCredit, CreditUnit, \
-    CreditUpdateResponse, GrantedUnits, UsageMonitoringCredit, \
-    UsageMonitoringUpdateResponse
+from lte.protos.session_manager_pb2 import (
+    ChargingCredit,
+    CreditUnit,
+    CreditUpdateResponse,
+    GrantedUnits,
+    UsageMonitoringCredit,
+    UsageMonitoringUpdateResponse,
+)
 from ryu.lib import hub
 
 

--- a/lte/gateway/python/integ_tests/gxgy_tests/test_credit_tracking.py
+++ b/lte/gateway/python/integ_tests/gxgy_tests/test_credit_tracking.py
@@ -13,16 +13,21 @@ limitations under the License.
 import unittest
 from unittest.mock import Mock
 
+from integ_tests.gxgy_tests.policies import (
+    create_uplink_rule,
+    get_packets_for_flows,
+)
+from integ_tests.gxgy_tests.session_manager import (
+    create_update_response,
+    get_from_queue,
+    get_standard_update_response,
+)
+from integ_tests.gxgy_tests.utils import GxGyTestUtil as TestUtil
 from lte.protos import session_manager_pb2
 from lte.protos.policydb_pb2 import PolicyRule
 from lte.protos.subscriberdb_pb2 import SubscriberID
 from magma.pipelined.tests.app.subscriber import SubContextConfig
 from ryu.lib import hub
-
-from .policies import create_uplink_rule, get_packets_for_flows
-from .session_manager import create_update_response, get_from_queue, \
-    get_standard_update_response
-from .utils import GxGyTestUtil as TestUtil
 
 
 class CreditTrackingTest(unittest.TestCase):

--- a/lte/gateway/python/integ_tests/gxgy_tests/test_failure_scenarios.py
+++ b/lte/gateway/python/integ_tests/gxgy_tests/test_failure_scenarios.py
@@ -13,15 +13,23 @@ limitations under the License.
 import unittest
 from unittest.mock import Mock
 
+from integ_tests.gxgy_tests.policies import (
+    create_uplink_rule,
+    get_packets_for_flows,
+)
+from integ_tests.gxgy_tests.session_manager import (
+    create_update_response,
+    get_from_queue,
+    get_standard_update_response,
+)
+from integ_tests.gxgy_tests.utils import GxGyTestUtil as TestUtil
 from lte.protos import session_manager_pb2
 from lte.protos.subscriberdb_pb2 import SubscriberID
-from magma.pipelined.tests.app.subscriber import SubContextConfig, default_ambr_config
+from magma.pipelined.tests.app.subscriber import (
+    SubContextConfig,
+    default_ambr_config,
+)
 from ryu.lib import hub
-
-from .policies import create_uplink_rule, get_packets_for_flows
-from .session_manager import create_update_response, get_from_queue, \
-    get_standard_update_response
-from .utils import GxGyTestUtil as TestUtil
 
 
 class FailureScenarioTest(unittest.TestCase):

--- a/lte/gateway/python/integ_tests/gxgy_tests/test_gx_reauth.py
+++ b/lte/gateway/python/integ_tests/gxgy_tests/test_gx_reauth.py
@@ -14,18 +14,26 @@ import itertools
 import unittest
 from unittest.mock import Mock
 
-from integ_tests.gxgy_tests.policies import create_uplink_rule, \
-    get_packets_for_flows
+from integ_tests.gxgy_tests.policies import (
+    create_uplink_rule,
+    get_packets_for_flows,
+)
 from integ_tests.gxgy_tests.session_manager import create_update_response
+from integ_tests.gxgy_tests.utils import GxGyTestUtil as TestUtil
 from lte.protos import session_manager_pb2
 from lte.protos.policydb_pb2 import PolicyRule
-from lte.protos.session_manager_pb2 import CreateSessionResponse, \
-    LocalCreateSessionRequest, PolicyReAuthRequest, SessionTerminateResponse
+from lte.protos.session_manager_pb2 import (
+    CreateSessionResponse,
+    LocalCreateSessionRequest,
+    PolicyReAuthRequest,
+    SessionTerminateResponse,
+)
 from lte.protos.subscriberdb_pb2 import SubscriberID
-from magma.pipelined.tests.app.subscriber import SubContextConfig, default_ambr_config
+from magma.pipelined.tests.app.subscriber import (
+    SubContextConfig,
+    default_ambr_config,
+)
 from ryu.lib import hub
-
-from .utils import GxGyTestUtil as TestUtil
 
 
 class GxReauthTest(unittest.TestCase):

--- a/lte/gateway/python/integ_tests/gxgy_tests/test_usage_monitors.py
+++ b/lte/gateway/python/integ_tests/gxgy_tests/test_usage_monitors.py
@@ -13,16 +13,25 @@ limitations under the License.
 import unittest
 from unittest.mock import Mock
 
+from integ_tests.gxgy_tests.policies import (
+    create_uplink_rule,
+    get_packets_for_flows,
+)
+from integ_tests.gxgy_tests.session_manager import (
+    create_monitor_response,
+    create_update_response,
+    get_from_queue,
+    get_standard_update_response,
+)
+from integ_tests.gxgy_tests.utils import GxGyTestUtil as TestUtil
 from lte.protos import session_manager_pb2
 from lte.protos.policydb_pb2 import PolicyRule
 from lte.protos.subscriberdb_pb2 import SubscriberID
-from magma.pipelined.tests.app.subscriber import SubContextConfig, default_ambr_config
+from magma.pipelined.tests.app.subscriber import (
+    SubContextConfig,
+    default_ambr_config,
+)
 from ryu.lib import hub
-
-from .policies import create_uplink_rule, get_packets_for_flows
-from .session_manager import create_monitor_response, create_update_response, \
-    get_from_queue, get_standard_update_response
-from .utils import GxGyTestUtil as TestUtil
 
 
 class UsageMonitorTest(unittest.TestCase):

--- a/lte/gateway/python/integ_tests/gxgy_tests/utils.py
+++ b/lte/gateway/python/integ_tests/gxgy_tests/utils.py
@@ -14,22 +14,27 @@ from concurrent.futures import Future, ThreadPoolExecutor
 from contextlib import ExitStack
 
 import grpc
+from integ_tests.gxgy_tests.session_manager import MockSessionManager
 from lte.protos import session_manager_pb2_grpc
 from magma.common.service_registry import ServiceRegistry
 from magma.configuration.service_configs import load_service_config
 from magma.pipelined.bridge_util import BridgeTools
-from magma.pipelined.tests.app.flow_query import RyuDirectFlowQuery \
-    as FlowQuery
+from magma.pipelined.tests.app.flow_query import RyuDirectFlowQuery as FlowQuery
 from magma.pipelined.tests.app.packet_injector import ScapyPacketInjector
-from magma.pipelined.tests.app.start_pipelined import PipelinedController, \
-    TestSetup
-from magma.pipelined.tests.app.table_isolation import RyuDirectTableIsolator, \
-    RyuForwardFlowArgsBuilder
-from magma.pipelined.tests.pipelined_test_util import start_ryu_app_thread, \
-    stop_ryu_app_thread, wait_after_send
+from magma.pipelined.tests.app.start_pipelined import (
+    PipelinedController,
+    TestSetup,
+)
+from magma.pipelined.tests.app.table_isolation import (
+    RyuDirectTableIsolator,
+    RyuForwardFlowArgsBuilder,
+)
+from magma.pipelined.tests.pipelined_test_util import (
+    start_ryu_app_thread,
+    stop_ryu_app_thread,
+    wait_after_send,
+)
 from magma.policydb.rule_store import PolicyRuleDict
-
-from .session_manager import MockSessionManager
 
 
 class GxGyTestUtil(object):

--- a/lte/gateway/python/integ_tests/s1aptests/ovs/rest_api.py
+++ b/lte/gateway/python/integ_tests/s1aptests/ovs/rest_api.py
@@ -16,8 +16,7 @@ import logging
 import time
 
 import requests
-
-from integ_tests.s1aptests.ovs import DEV_VM_URL, OF_REST_PORT, MAX_RETRIES
+from integ_tests.s1aptests.ovs import DEV_VM_URL, MAX_RETRIES, OF_REST_PORT
 
 
 def get_flows(datapath, fields, ip=DEV_VM_URL):

--- a/lte/gateway/python/integ_tests/s1aptests/s1ap_wrapper.py
+++ b/lte/gateway/python/integ_tests/s1aptests/s1ap_wrapper.py
@@ -11,19 +11,18 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
+import ctypes
 import os
 import time
-import ctypes
 
 import s1ap_types
 from integ_tests.common.magmad_client import MagmadServiceGrpc
-
 # from integ_tests.cloud.cloud_manager import CloudManager
 from integ_tests.common.mobility_service_client import MobilityServiceGrpc
 from integ_tests.common.service303_utils import GatewayServicesUtil
 from integ_tests.common.subscriber_db_client import (
-    SubscriberDbGrpc,
     SubscriberDbCassandra,
+    SubscriberDbGrpc,
 )
 from integ_tests.s1aptests.s1ap_utils import (
     MagmadUtil,

--- a/lte/gateway/python/integ_tests/s1aptests/test_3495_timer_for_dedicated_bearer_with_mme_restart.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_3495_timer_for_dedicated_bearer_with_mme_restart.py
@@ -11,10 +11,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-import unittest
-import s1ap_types
 import time
+import unittest
 
+import s1ap_types
 from integ_tests.s1aptests import s1ap_wrapper
 from integ_tests.s1aptests.s1ap_utils import SpgwUtil
 from s1ap_utils import MagmadUtil

--- a/lte/gateway/python/integ_tests/s1aptests/test_3495_timer_for_default_bearer_with_mme_restart.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_3495_timer_for_default_bearer_with_mme_restart.py
@@ -11,10 +11,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-import unittest
-import s1ap_types
 import time
+import unittest
 
+import s1ap_types
 from integ_tests.s1aptests import s1ap_wrapper
 from integ_tests.s1aptests.s1ap_utils import SpgwUtil
 from s1ap_utils import MagmadUtil

--- a/lte/gateway/python/integ_tests/s1aptests/test_activate_deactivate_multiple_dedicated.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_activate_deactivate_multiple_dedicated.py
@@ -11,10 +11,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-import unittest
-import s1ap_types
 import time
+import unittest
 
+import s1ap_types
 from integ_tests.s1aptests import s1ap_wrapper
 from integ_tests.s1aptests.s1ap_utils import SpgwUtil
 

--- a/lte/gateway/python/integ_tests/s1aptests/test_agw_offload_idle_active_ue.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_agw_offload_idle_active_ue.py
@@ -11,10 +11,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-import unittest
-import s1ap_types
 import time
+import unittest
 
+import s1ap_types
 from integ_tests.s1aptests import s1ap_wrapper
 from integ_tests.s1aptests.s1ap_utils import HaUtil
 

--- a/lte/gateway/python/integ_tests/s1aptests/test_agw_offload_mixed_idle_active_multiue.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_agw_offload_mixed_idle_active_multiue.py
@@ -11,13 +11,12 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
+import math
+import time
 import unittest
 
 import gpp_types
-import math
 import s1ap_types
-import time
-
 from integ_tests.s1aptests import s1ap_wrapper
 from integ_tests.s1aptests.s1ap_utils import HaUtil
 

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_act_dflt_ber_ctxt_rej.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_act_dflt_ber_ctxt_rej.py
@@ -12,11 +12,11 @@ limitations under the License.
 """
 
 
+import time
 import unittest
 
 import s1ap_types
 import s1ap_wrapper
-import time
 
 
 class TestAttachCompleteWithActvDfltBearCtxtRej(unittest.TestCase):

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_active_tau_with_combined_tala_update_reattach.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_active_tau_with_combined_tala_update_reattach.py
@@ -11,8 +11,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-import unittest
 import time
+import unittest
 
 import gpp_types
 import s1ap_types

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_and_mme_restart_loop_detach_and_mme_restart_loop_multi_ue.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_and_mme_restart_loop_detach_and_mme_restart_loop_multi_ue.py
@@ -11,13 +11,13 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
+import random
 import time
 import unittest
 
 import s1ap_types
 import s1ap_wrapper
 from s1ap_utils import MagmadUtil
-import random
 
 
 class TestAttachAndMmeRestartLoopDetachAndMmeRestartLoopMultiUe(unittest.TestCase):

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_asr.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_asr.py
@@ -11,14 +11,13 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-import unittest
-import s1ap_types
 import time
+import unittest
 
+import s1ap_types
 from integ_tests.s1aptests import s1ap_wrapper
-from integ_tests.s1aptests.s1ap_utils import SpgwUtil
-from integ_tests.s1aptests.s1ap_utils import SessionManagerUtil
 from integ_tests.s1aptests.ovs.rest_api import get_datapath, get_flows
+from integ_tests.s1aptests.s1ap_utils import SessionManagerUtil, SpgwUtil
 
 
 class TestAttachASR(unittest.TestCase):

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_auth_failure.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_auth_failure.py
@@ -14,7 +14,6 @@ limitations under the License.
 import unittest
 
 import s1ap_types
-
 from integ_tests.s1aptests import s1ap_wrapper
 
 

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_auth_mac_failure.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_auth_mac_failure.py
@@ -14,7 +14,6 @@ limitations under the License.
 import unittest
 
 import s1ap_types
-
 from integ_tests.s1aptests import s1ap_wrapper
 
 

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_detach.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_detach.py
@@ -12,8 +12,8 @@ limitations under the License.
 """
 
 import unittest
-import s1ap_types
 
+import s1ap_types
 from integ_tests.s1aptests import s1ap_wrapper
 
 

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_after_ue_context_release.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_after_ue_context_release.py
@@ -11,13 +11,12 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
+import time
 import unittest
-
 
 import gpp_types
 import s1ap_types
 import s1ap_wrapper
-import time
 
 
 class TestAttachDetachAfterUeContextRelease(unittest.TestCase):

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_dedicated.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_dedicated.py
@@ -11,10 +11,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-import unittest
-import s1ap_types
 import time
+import unittest
 
+import s1ap_types
 from integ_tests.s1aptests import s1ap_wrapper
 from integ_tests.s1aptests.s1ap_utils import SpgwUtil
 

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_dedicated_activation_reject.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_dedicated_activation_reject.py
@@ -11,10 +11,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-import unittest
-import s1ap_types
 import time
+import unittest
 
+import s1ap_types
 from integ_tests.s1aptests import s1ap_wrapper
 from integ_tests.s1aptests.s1ap_utils import SpgwUtil
 

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_dedicated_activation_timer_expiry.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_dedicated_activation_timer_expiry.py
@@ -11,10 +11,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-import unittest
-import s1ap_types
 import time
+import unittest
 
+import s1ap_types
 from integ_tests.s1aptests import s1ap_wrapper
 from integ_tests.s1aptests.s1ap_utils import SpgwUtil
 

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_dedicated_bearer_activation_invalid_imsi.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_dedicated_bearer_activation_invalid_imsi.py
@@ -11,10 +11,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-import unittest
-import s1ap_types
 import time
+import unittest
 
+import s1ap_types
 from integ_tests.s1aptests import s1ap_wrapper
 from integ_tests.s1aptests.s1ap_utils import SpgwUtil
 

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_dedicated_bearer_activation_invalid_lbi.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_dedicated_bearer_activation_invalid_lbi.py
@@ -11,10 +11,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-import unittest
-import s1ap_types
 import time
+import unittest
 
+import s1ap_types
 from integ_tests.s1aptests import s1ap_wrapper
 from integ_tests.s1aptests.s1ap_utils import SpgwUtil
 

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_dedicated_bearer_deactivation_invalid_ebi.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_dedicated_bearer_deactivation_invalid_ebi.py
@@ -11,10 +11,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-import unittest
-import s1ap_types
 import time
+import unittest
 
+import s1ap_types
 from integ_tests.s1aptests import s1ap_wrapper
 from integ_tests.s1aptests.s1ap_utils import SpgwUtil
 

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_dedicated_bearer_deactivation_invalid_imsi.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_dedicated_bearer_deactivation_invalid_imsi.py
@@ -11,10 +11,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-import unittest
-import s1ap_types
 import time
+import unittest
 
+import s1ap_types
 from integ_tests.s1aptests import s1ap_wrapper
 from integ_tests.s1aptests.s1ap_utils import SpgwUtil
 

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_dedicated_bearer_deactivation_invalid_lbi.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_dedicated_bearer_deactivation_invalid_lbi.py
@@ -11,10 +11,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-import unittest
-import s1ap_types
 import time
+import unittest
 
+import s1ap_types
 from integ_tests.s1aptests import s1ap_wrapper
 from integ_tests.s1aptests.s1ap_utils import SpgwUtil
 

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_dedicated_deactivation_timer_expiry.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_dedicated_deactivation_timer_expiry.py
@@ -11,10 +11,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-import unittest
-import s1ap_types
 import time
+import unittest
 
+import s1ap_types
 from integ_tests.s1aptests import s1ap_wrapper
 from integ_tests.s1aptests.s1ap_utils import SpgwUtil
 

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_dedicated_looped.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_dedicated_looped.py
@@ -11,10 +11,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-import unittest
-import s1ap_types
 import time
+import unittest
 
+import s1ap_types
 from integ_tests.s1aptests import s1ap_wrapper
 from integ_tests.s1aptests.s1ap_utils import SpgwUtil
 

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_dedicated_multi_ue.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_dedicated_multi_ue.py
@@ -11,10 +11,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-import unittest
-import s1ap_types
 import time
+import unittest
 
+import s1ap_types
 from integ_tests.s1aptests import s1ap_wrapper
 from integ_tests.s1aptests.s1ap_utils import SpgwUtil
 

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_disconnect_default_pdn.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_disconnect_default_pdn.py
@@ -11,8 +11,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-import unittest
 import time
+import unittest
 
 import s1ap_types
 import s1ap_wrapper

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_emm_status.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_emm_status.py
@@ -11,13 +11,12 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
+import time
 import unittest
-
 
 import gpp_types
 import s1ap_types
 import s1ap_wrapper
-import time
 
 
 class TestAttachDetachEmmStatusMsg(unittest.TestCase):

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_enb_rlf_initial_ue_msg.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_enb_rlf_initial_ue_msg.py
@@ -12,12 +12,12 @@ limitations under the License.
 """
 
 
+import time
 import unittest
 
+import gpp_types
 import s1ap_types
 import s1ap_wrapper
-import time
-import gpp_types
 
 
 class TestAttachEnbRlf(unittest.TestCase):

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_maxbearers_twopdns.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_maxbearers_twopdns.py
@@ -11,8 +11,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-import unittest
 import time
+import unittest
 
 import s1ap_types
 import s1ap_wrapper

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_multi_ue.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_multi_ue.py
@@ -13,7 +13,6 @@ limitations under the License.
 
 import unittest
 
-
 import s1ap_types
 import s1ap_wrapper
 

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_multiple_dedicated.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_multiple_dedicated.py
@@ -11,10 +11,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-import unittest
-import s1ap_types
 import time
+import unittest
 
+import s1ap_types
 from integ_tests.s1aptests import s1ap_wrapper
 from integ_tests.s1aptests.s1ap_utils import SpgwUtil
 

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_multiple_ip_blocks_mobilityd_restart.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_multiple_ip_blocks_mobilityd_restart.py
@@ -18,6 +18,7 @@ import s1ap_types
 import s1ap_wrapper
 from s1ap_utils import MagmadUtil
 
+
 class TestAttachDetachMultipleIpBlocksMobilitydRestart(unittest.TestCase):
     def setUp(self):
         self._s1ap_wrapper = s1ap_wrapper.TestWrapper(

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_multiple_rar_tcp_data.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_multiple_rar_tcp_data.py
@@ -11,14 +11,17 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-import unittest
-import s1ap_types
 import time
+import unittest
 
+import s1ap_types
 from integ_tests.s1aptests import s1ap_wrapper
-from integ_tests.s1aptests.s1ap_utils import SpgwUtil, GTPBridgeUtils
-from integ_tests.s1aptests.s1ap_utils import SessionManagerUtil
 from integ_tests.s1aptests.ovs.rest_api import get_datapath, get_flows
+from integ_tests.s1aptests.s1ap_utils import (
+    GTPBridgeUtils,
+    SessionManagerUtil,
+    SpgwUtil,
+)
 from lte.protos.policydb_pb2 import FlowMatch
 
 

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_multiple_secondary_pdn.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_multiple_secondary_pdn.py
@@ -11,8 +11,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-import unittest
 import time
+import unittest
 
 import s1ap_types
 import s1ap_wrapper

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_no_ueContext_release_comp.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_no_ueContext_release_comp.py
@@ -11,11 +11,11 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
+import time
 import unittest
 
 import s1ap_types
 import s1ap_wrapper
-import time
 
 
 class TestAttachDetachNoUeContextReleseComp(unittest.TestCase):

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_nw_triggered_delete_last_pdn.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_nw_triggered_delete_last_pdn.py
@@ -11,10 +11,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-import unittest
-import s1ap_types
 import time
+import unittest
 
+import s1ap_types
 from integ_tests.s1aptests import s1ap_wrapper
 from integ_tests.s1aptests.s1ap_utils import SpgwUtil
 

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_nw_triggered_delete_secondary_pdn.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_nw_triggered_delete_secondary_pdn.py
@@ -11,12 +11,11 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-import unittest
 import time
+import unittest
 
 import s1ap_types
 import s1ap_wrapper
-
 from integ_tests.s1aptests.s1ap_utils import SpgwUtil
 
 

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_ps_service_not_available.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_ps_service_not_available.py
@@ -11,13 +11,12 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
+import time
 import unittest
-
 
 import gpp_types
 import s1ap_types
 import s1ap_wrapper
-import time
 
 
 class TestUeContextReleaseWithCausePsServiceNotAvailable(unittest.TestCase):

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_rar_activation_reject.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_rar_activation_reject.py
@@ -11,10 +11,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-import unittest
-import s1ap_types
 import time
+import unittest
 
+import s1ap_types
 from integ_tests.s1aptests import s1ap_wrapper
 from integ_tests.s1aptests.s1ap_utils import SessionManagerUtil
 from lte.protos.policydb_pb2 import FlowMatch

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_rar_tcp_data.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_rar_tcp_data.py
@@ -11,14 +11,17 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-import unittest
-import s1ap_types
 import time
+import unittest
 
+import s1ap_types
 from integ_tests.s1aptests import s1ap_wrapper
-from integ_tests.s1aptests.s1ap_utils import SpgwUtil
-from integ_tests.s1aptests.s1ap_utils import SessionManagerUtil, GTPBridgeUtils
 from integ_tests.s1aptests.ovs.rest_api import get_datapath, get_flows
+from integ_tests.s1aptests.s1ap_utils import (
+    GTPBridgeUtils,
+    SessionManagerUtil,
+    SpgwUtil,
+)
 from lte.protos.policydb_pb2 import FlowMatch
 
 

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_rar_tcp_he.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_rar_tcp_he.py
@@ -11,14 +11,18 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-import unittest
-import s1ap_types
 import time
+import unittest
 
+import s1ap_types
 from integ_tests.s1aptests import s1ap_wrapper
-from integ_tests.s1aptests.s1ap_utils import SpgwUtil, HeaderEnrichmentUtils
-from integ_tests.s1aptests.s1ap_utils import SessionManagerUtil, GTPBridgeUtils
 from integ_tests.s1aptests.ovs.rest_api import get_datapath, get_flows
+from integ_tests.s1aptests.s1ap_utils import (
+    GTPBridgeUtils,
+    HeaderEnrichmentUtils,
+    SessionManagerUtil,
+    SpgwUtil,
+)
 from lte.protos.policydb_pb2 import FlowMatch, HeaderEnrichment
 
 

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_secondary_pdn.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_secondary_pdn.py
@@ -11,8 +11,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-import unittest
 import time
+import unittest
 
 import s1ap_types
 import s1ap_wrapper

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_secondary_pdn_disconnect_dedicated_bearer.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_secondary_pdn_disconnect_dedicated_bearer.py
@@ -11,8 +11,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-import unittest
 import time
+import unittest
 
 import s1ap_types
 import s1ap_wrapper

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_secondary_pdn_disconnect_invalid_bearer.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_secondary_pdn_disconnect_invalid_bearer.py
@@ -11,8 +11,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-import unittest
 import time
+import unittest
 
 import s1ap_types
 import s1ap_wrapper

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_secondary_pdn_looped.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_secondary_pdn_looped.py
@@ -11,8 +11,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-import unittest
 import time
+import unittest
 
 import s1ap_types
 import s1ap_wrapper

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_secondary_pdn_multi_ue.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_secondary_pdn_multi_ue.py
@@ -11,8 +11,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-import unittest
 import time
+import unittest
 
 import s1ap_types
 import s1ap_wrapper

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_secondary_pdn_no_disconnect.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_secondary_pdn_no_disconnect.py
@@ -11,8 +11,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-import unittest
 import time
+import unittest
 
 import s1ap_types
 import s1ap_wrapper

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_secondary_pdn_with_dedicated_bearer.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_secondary_pdn_with_dedicated_bearer.py
@@ -11,8 +11,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-import unittest
 import time
+import unittest
 
 import s1ap_types
 import s1ap_wrapper

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_secondary_pdn_with_dedicated_bearer_deactivate.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_secondary_pdn_with_dedicated_bearer_deactivate.py
@@ -11,8 +11,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-import unittest
 import time
+import unittest
 
 import s1ap_types
 import s1ap_wrapper

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_secondary_pdn_with_dedicated_bearer_looped.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_secondary_pdn_with_dedicated_bearer_looped.py
@@ -11,8 +11,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-import unittest
 import time
+import unittest
 
 import s1ap_types
 import s1ap_wrapper

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_secondary_pdn_with_dedicated_bearer_multi_ue.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_secondary_pdn_with_dedicated_bearer_multi_ue.py
@@ -11,8 +11,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-import unittest
 import time
+import unittest
 
 import s1ap_types
 import s1ap_wrapper

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_secondary_pdn_with_pcscf_address.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_secondary_pdn_with_pcscf_address.py
@@ -11,8 +11,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-import unittest
 import time
+import unittest
 
 import s1ap_types
 import s1ap_wrapper

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_security_algo_eea0_eia0.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_security_algo_eea0_eia0.py
@@ -14,7 +14,6 @@ limitations under the License.
 import unittest
 
 import s1ap_types
-
 from integ_tests.s1aptests import s1ap_wrapper
 
 

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_security_algo_eea1_eia1.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_security_algo_eea1_eia1.py
@@ -14,7 +14,6 @@ limitations under the License.
 import unittest
 
 import s1ap_types
-
 from integ_tests.s1aptests import s1ap_wrapper
 
 

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_security_algo_eea2_eia2.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_security_algo_eea2_eia2.py
@@ -14,7 +14,6 @@ limitations under the License.
 import unittest
 
 import s1ap_types
-
 from integ_tests.s1aptests import s1ap_wrapper
 
 

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_setsessionrules_tcp_data.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_setsessionrules_tcp_data.py
@@ -11,15 +11,16 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-import unittest
-import s1ap_types
 import time
+import unittest
 
+import s1ap_types
 from integ_tests.s1aptests import s1ap_wrapper
-from integ_tests.s1aptests.s1ap_utils import SessionManagerUtil
 from integ_tests.s1aptests.ovs.rest_api import get_datapath, get_flows
+from integ_tests.s1aptests.s1ap_utils import SessionManagerUtil
 from lte.protos.policydb_pb2 import FlowMatch
 from s1ap_utils import GTPBridgeUtils
+
 
 class TestAttachDetachSetSessionRulesTcpData(unittest.TestCase):
     SPGW_TABLE = 0

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_with_he_policy.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_with_he_policy.py
@@ -11,14 +11,18 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-import unittest
-import s1ap_types
 import time
+import unittest
 
+import s1ap_types
 from integ_tests.s1aptests import s1ap_wrapper
-from integ_tests.s1aptests.s1ap_utils import SpgwUtil, HeaderEnrichmentUtils
-from integ_tests.s1aptests.s1ap_utils import SessionManagerUtil, GTPBridgeUtils
 from integ_tests.s1aptests.ovs.rest_api import get_datapath, get_flows
+from integ_tests.s1aptests.s1ap_utils import (
+    GTPBridgeUtils,
+    HeaderEnrichmentUtils,
+    SessionManagerUtil,
+    SpgwUtil,
+)
 from lte.protos.policydb_pb2 import FlowMatch, HeaderEnrichment
 from ryu.lib.packet.in_proto import IPPROTO_TCP
 

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_with_ipv6_pcscf_and_dns_addr.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_with_ipv6_pcscf_and_dns_addr.py
@@ -6,12 +6,12 @@ LICENSE file in the root directory of this source tree. An additional grant
 of patent rights can be found in the PATENTS file in the same directory.
 """
 
-import unittest
+import ipaddress
 import time
+import unittest
 
 import s1ap_types
 import s1ap_wrapper
-import ipaddress
 
 
 class TestAttachDetachWithIpv6PcscfDnsAddr(unittest.TestCase):

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_with_ovs.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_with_ovs.py
@@ -16,9 +16,9 @@ import unittest
 
 import s1ap_types
 import s1ap_wrapper
-from s1ap_utils import GTPBridgeUtils
 from integ_tests.s1aptests.ovs.rest_api import get_datapath, get_flows
 from magma.pipelined.imsi import decode_imsi
+from s1ap_utils import GTPBridgeUtils
 
 
 class TestAttachDetachWithOVS(unittest.TestCase):

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_with_pcscf_address.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_with_pcscf_address.py
@@ -14,7 +14,6 @@ limitations under the License.
 import unittest
 
 import s1ap_types
-
 from integ_tests.s1aptests import s1ap_wrapper
 
 

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_esm_info_timerexpiration_max_retries.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_esm_info_timerexpiration_max_retries.py
@@ -11,14 +11,13 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
+import ctypes
+import time
 import unittest
 
-import s1ap_types
 import gpp_types
-import time
-
+import s1ap_types
 from integ_tests.s1aptests import s1ap_wrapper
-import ctypes
 
 
 class TestEsmInformationMaxRetries(unittest.TestCase):

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_esm_information.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_esm_information.py
@@ -11,13 +11,12 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
+import ctypes
+import time
 import unittest
 
 import s1ap_types
-import time
-
 from integ_tests.s1aptests import s1ap_wrapper
-import ctypes
 
 
 class TestEsmInformation(unittest.TestCase):

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_esm_information_apn_correction.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_esm_information_apn_correction.py
@@ -11,14 +11,13 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
+import ctypes
+import time
 import unittest
 
 import s1ap_types
-import time
-
 from integ_tests.s1aptests import s1ap_wrapper
 from s1ap_utils import MagmadUtil
-import ctypes
 
 
 class TestEsmInformationWithApnCorrection(unittest.TestCase):

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_esm_information_timerexpiration.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_esm_information_timerexpiration.py
@@ -11,13 +11,12 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
+import ctypes
+import time
 import unittest
 
 import s1ap_types
-import time
-
 from integ_tests.s1aptests import s1ap_wrapper
-import ctypes
 
 
 class TestEsmInformation(unittest.TestCase):

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_esm_information_wrong_apn.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_esm_information_wrong_apn.py
@@ -11,13 +11,12 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
+import ctypes
+import time
 import unittest
 
 import s1ap_types
-import time
-
 from integ_tests.s1aptests import s1ap_wrapper
-import ctypes
 
 
 class TestEsmInformationWrongApn(unittest.TestCase):

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_implicit_detach_timer_expiry.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_implicit_detach_timer_expiry.py
@@ -11,8 +11,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-import unittest
 import time
+import unittest
 
 import gpp_types
 import s1ap_types

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_inactive_tau_with_combined_tala_update_reattach.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_inactive_tau_with_combined_tala_update_reattach.py
@@ -11,8 +11,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-import unittest
 import time
+import unittest
 
 import gpp_types
 import s1ap_types

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_ipv4v6_pdn_type.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_ipv4v6_pdn_type.py
@@ -12,9 +12,10 @@ limitations under the License.
 """
 
 
+import unittest
+
 import s1ap_types
 import s1ap_wrapper
-import unittest
 
 
 class TestAttachIpv4v6PdnType(unittest.TestCase):

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_mme_restart_detach_multi_ue.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_mme_restart_detach_multi_ue.py
@@ -11,13 +11,13 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
+import random
 import time
 import unittest
 
 import s1ap_types
 import s1ap_wrapper
 from s1ap_utils import MagmadUtil
-import random
 
 
 class TestAttachMmeRestartDetachMultiUe(unittest.TestCase):

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_mobile_reachability_timer_expiry.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_mobile_reachability_timer_expiry.py
@@ -11,8 +11,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-import unittest
 import time
+import unittest
 
 import gpp_types
 import s1ap_types

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_nw_initiated_detach_with_mme_restart.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_nw_initiated_detach_with_mme_restart.py
@@ -11,13 +11,12 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-import unittest
-import s1ap_types
 import time
+import unittest
 
+import s1ap_types
 from integ_tests.s1aptests import s1ap_wrapper
-from integ_tests.s1aptests.s1ap_utils import SpgwUtil
-from integ_tests.s1aptests.s1ap_utils import MagmadUtil
+from integ_tests.s1aptests.s1ap_utils import MagmadUtil, SpgwUtil
 
 
 class TestAttachNwInitiatedDetachWithMmeRestart(unittest.TestCase):

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_restricted_plmn.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_restricted_plmn.py
@@ -12,12 +12,12 @@ limitations under the License.
 """
 
 
+import ctypes
+import time
 import unittest
 
 import s1ap_types
 import s1ap_wrapper
-import ctypes
-import time
 
 
 class TestAttachRestrictedPlmn(unittest.TestCase):

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_security_mode_reject.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_security_mode_reject.py
@@ -11,11 +11,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
+import time
 import unittest
 
 import s1ap_types
-import time
-
 from integ_tests.s1aptests import s1ap_wrapper
 
 

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_service.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_service.py
@@ -11,8 +11,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-import unittest
 import time
+import unittest
 
 import gpp_types
 import s1ap_types

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_service_multi_ue.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_service_multi_ue.py
@@ -11,8 +11,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-import unittest
 import time
+import unittest
 
 import gpp_types
 import s1ap_types

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_service_ue_radio_capability.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_service_ue_radio_capability.py
@@ -11,8 +11,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-import unittest
 import time
+import unittest
 
 import gpp_types
 import s1ap_types

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_service_with_multi_pdns_and_bearers.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_service_with_multi_pdns_and_bearers.py
@@ -11,9 +11,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-import unittest
-import time
 import ipaddress
+import time
+import unittest
+
 import gpp_types
 import s1ap_types
 import s1ap_wrapper

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_service_with_multi_pdns_and_bearers_failure.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_service_with_multi_pdns_and_bearers_failure.py
@@ -11,14 +11,14 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-import unittest
+import ipaddress
 import time
+import unittest
 
 import gpp_types
 import s1ap_types
 import s1ap_wrapper
 from integ_tests.s1aptests.s1ap_utils import SessionManagerUtil
-import ipaddress
 from lte.protos.policydb_pb2 import FlowMatch
 
 

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_service_with_multi_pdns_and_bearers_looped.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_service_with_multi_pdns_and_bearers_looped.py
@@ -11,14 +11,14 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-import unittest
+import ipaddress
 import time
+import unittest
 
 import gpp_types
 import s1ap_types
 import s1ap_wrapper
 from integ_tests.s1aptests.s1ap_utils import SessionManagerUtil
-import ipaddress
 from lte.protos.policydb_pb2 import FlowMatch
 
 

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_service_with_multi_pdns_and_bearers_mt_data.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_service_with_multi_pdns_and_bearers_mt_data.py
@@ -11,14 +11,14 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-import unittest
+import ipaddress
 import time
+import unittest
 
 import gpp_types
 import s1ap_types
 import s1ap_wrapper
 from integ_tests.s1aptests.s1ap_utils import SessionManagerUtil
-import ipaddress
 from lte.protos.policydb_pb2 import FlowMatch
 
 

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_service_with_multi_pdns_and_bearers_multi_ue.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_service_with_multi_pdns_and_bearers_multi_ue.py
@@ -11,13 +11,13 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-import unittest
+import ipaddress
 import time
+import unittest
 
 import gpp_types
 import s1ap_types
 import s1ap_wrapper
-import ipaddress
 from integ_tests.s1aptests.s1ap_utils import SessionManagerUtil
 from lte.protos.policydb_pb2 import FlowMatch
 

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_service_without_mac.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_service_without_mac.py
@@ -11,8 +11,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-import unittest
 import time
+import unittest
 
 import gpp_types
 import s1ap_types

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_standalone_act_dflt_ber_ctxt_rej.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_standalone_act_dflt_ber_ctxt_rej.py
@@ -12,12 +12,12 @@ limitations under the License.
 """
 
 
+import ipaddress
+import time
 import unittest
 
 import s1ap_types
 import s1ap_wrapper
-import time
-import ipaddress
 
 
 class TestAttachStandaloneActvDfltBearCtxtRej(unittest.TestCase):

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_standalone_act_dflt_ber_ctxt_rej_ded_bearer_activation.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_standalone_act_dflt_ber_ctxt_rej_ded_bearer_activation.py
@@ -12,12 +12,12 @@ limitations under the License.
 """
 
 
+import ipaddress
+import time
 import unittest
 
 import s1ap_types
 import s1ap_wrapper
-import time
-import ipaddress
 from integ_tests.s1aptests.s1ap_utils import SessionManagerUtil
 from lte.protos.policydb_pb2 import FlowMatch
 

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_ue_ctxt_release_cmp_delay.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_ue_ctxt_release_cmp_delay.py
@@ -12,12 +12,12 @@ limitations under the License.
 """
 
 
+import time
 import unittest
 
+import gpp_types
 import s1ap_types
 import s1ap_wrapper
-import time
-import gpp_types
 
 
 class TestAttachDelayUeContextRelComplete(unittest.TestCase):

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_ul_udp_data_with_multiple_service_restart.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_ul_udp_data_with_multiple_service_restart.py
@@ -18,6 +18,7 @@ import s1ap_types
 import s1ap_wrapper
 from s1ap_utils import MagmadUtil
 
+
 class TestAttachUlUdpDataWithMultipleServiceRestart(unittest.TestCase):
 
     def setUp(self):

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_ul_udp_data_with_pipelined_restart.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_ul_udp_data_with_pipelined_restart.py
@@ -18,6 +18,7 @@ import s1ap_types
 import s1ap_wrapper
 from s1ap_utils import MagmadUtil
 
+
 class TestAttachUlUdpDataWithPipelinedRestart(unittest.TestCase):
 
     def setUp(self):

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_ul_udp_data_with_sessiond_restart.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_ul_udp_data_with_sessiond_restart.py
@@ -18,6 +18,7 @@ import s1ap_types
 import s1ap_wrapper
 from s1ap_utils import MagmadUtil
 
+
 class TestAttachUlUdpDataWithSessiondRestart(unittest.TestCase):
 
     def setUp(self):

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_with_multiple_mme_restarts.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_with_multiple_mme_restarts.py
@@ -19,6 +19,7 @@ import s1ap_types
 import s1ap_wrapper
 from s1ap_utils import MagmadUtil
 
+
 class TestAttachWithMultipleMmeRestarts(unittest.TestCase):
 
     def setUp(self):

--- a/lte/gateway/python/integ_tests/s1aptests/test_continuous_random_attach.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_continuous_random_attach.py
@@ -11,13 +11,14 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-import unittest
-import threading
-import random
 import ipaddress
+import random
+import threading
+import unittest
 
 import s1ap_types
 import s1ap_wrapper
+
 
 class TestContinuousRandomAttach(unittest.TestCase):
 

--- a/lte/gateway/python/integ_tests/s1aptests/test_data_flow_after_service_request.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_data_flow_after_service_request.py
@@ -11,12 +11,12 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
+import time
 import unittest
 
 import gpp_types
 import s1ap_types
 import s1ap_wrapper
-import time
 
 
 class TestDataFlowAfterServiceRequest(unittest.TestCase):

--- a/lte/gateway/python/integ_tests/s1aptests/test_dedicated_bearer_activation_idle_mode.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_dedicated_bearer_activation_idle_mode.py
@@ -11,14 +11,14 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-import unittest
+import ipaddress
 import time
+import unittest
 
 import gpp_types
 import s1ap_types
 import s1ap_wrapper
 from integ_tests.s1aptests.s1ap_utils import SessionManagerUtil
-import ipaddress
 from lte.protos.policydb_pb2 import FlowMatch
 
 

--- a/lte/gateway/python/integ_tests/s1aptests/test_dedicated_bearer_activation_idle_mode_multi_ue.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_dedicated_bearer_activation_idle_mode_multi_ue.py
@@ -11,13 +11,13 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-import unittest
+import ipaddress
 import time
+import unittest
 
 import gpp_types
 import s1ap_types
 import s1ap_wrapper
-import ipaddress
 from integ_tests.s1aptests.s1ap_utils import SessionManagerUtil
 from lte.protos.policydb_pb2 import FlowMatch
 

--- a/lte/gateway/python/integ_tests/s1aptests/test_dedicated_bearer_activation_idle_mode_paging_timer_expiry.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_dedicated_bearer_activation_idle_mode_paging_timer_expiry.py
@@ -11,13 +11,13 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-import unittest
+import ipaddress
 import time
+import unittest
 
 import gpp_types
 import s1ap_types
 import s1ap_wrapper
-import ipaddress
 from integ_tests.s1aptests.s1ap_utils import SessionManagerUtil
 from lte.protos.policydb_pb2 import FlowMatch
 

--- a/lte/gateway/python/integ_tests/s1aptests/test_different_enb_s1ap_id_same_ue.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_different_enb_s1ap_id_same_ue.py
@@ -11,11 +11,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
+import time
 import unittest
 
 import s1ap_types
-import time
-
 from integ_tests.s1aptests import s1ap_wrapper
 
 

--- a/lte/gateway/python/integ_tests/s1aptests/test_enb_complete_reset.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_enb_complete_reset.py
@@ -11,8 +11,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-import unittest
 import time
+import unittest
 
 import s1ap_types
 import s1ap_wrapper

--- a/lte/gateway/python/integ_tests/s1aptests/test_enb_partial_reset.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_enb_partial_reset.py
@@ -11,8 +11,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-import unittest
 import time
+import unittest
 from builtins import range
 
 import s1ap_types

--- a/lte/gateway/python/integ_tests/s1aptests/test_enb_partial_reset_con_dereg.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_enb_partial_reset_con_dereg.py
@@ -11,9 +11,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-import unittest
-import time
 import ctypes
+import time
+import unittest
 from builtins import range
 
 import s1ap_types

--- a/lte/gateway/python/integ_tests/s1aptests/test_enb_partial_reset_multi_ue.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_enb_partial_reset_multi_ue.py
@@ -11,10 +11,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-import unittest
-import time
-from builtins import range
 import random
+import time
+import unittest
+from builtins import range
 
 import s1ap_types
 import s1ap_wrapper

--- a/lte/gateway/python/integ_tests/s1aptests/test_enb_partial_reset_multi_ue_with_mme_restart.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_enb_partial_reset_multi_ue_with_mme_restart.py
@@ -11,10 +11,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-import unittest
-import time
-from builtins import range
 import random
+import time
+import unittest
+from builtins import range
 
 import s1ap_types
 import s1ap_wrapper

--- a/lte/gateway/python/integ_tests/s1aptests/test_enb_partial_reset_with_unknown_ue_s1ap_ids.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_enb_partial_reset_with_unknown_ue_s1ap_ids.py
@@ -11,9 +11,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-import unittest
-import time
 import ctypes
+import time
+import unittest
 from builtins import range
 
 import s1ap_types

--- a/lte/gateway/python/integ_tests/s1aptests/test_ics_timer_expiry_ue_registered.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_ics_timer_expiry_ue_registered.py
@@ -11,8 +11,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-import unittest
 import time
+import unittest
 
 import gpp_types
 import s1ap_types

--- a/lte/gateway/python/integ_tests/s1aptests/test_ics_timer_expiry_with_mme_restart.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_ics_timer_expiry_with_mme_restart.py
@@ -11,8 +11,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-import unittest
 import time
+import unittest
 
 import gpp_types
 import s1ap_types

--- a/lte/gateway/python/integ_tests/s1aptests/test_idle_mode_with_mme_restart.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_idle_mode_with_mme_restart.py
@@ -11,8 +11,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-import unittest
 import time
+import unittest
 
 import gpp_types
 import s1ap_types

--- a/lte/gateway/python/integ_tests/s1aptests/test_imei_restriction_no_imeisv_in_smc.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_imei_restriction_no_imeisv_in_smc.py
@@ -12,12 +12,12 @@ limitations under the License.
 """
 
 
+import ctypes
+import time
 import unittest
 
 import s1ap_types
 import s1ap_wrapper
-import time
-import ctypes
 
 
 class TestImeiRestrictionNoImeisvInSmc(unittest.TestCase):

--- a/lte/gateway/python/integ_tests/s1aptests/test_imei_restriction_smc.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_imei_restriction_smc.py
@@ -12,12 +12,12 @@ limitations under the License.
 """
 
 
+import ctypes
+import time
 import unittest
 
 import s1ap_types
 import s1ap_wrapper
-import time
-import ctypes
 
 
 class TestImeiRestrictionSmc(unittest.TestCase):

--- a/lte/gateway/python/integ_tests/s1aptests/test_imei_restriction_wildcard_snr.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_imei_restriction_wildcard_snr.py
@@ -12,11 +12,11 @@ limitations under the License.
 """
 
 
+import ctypes
 import unittest
 
 import s1ap_types
 import s1ap_wrapper
-import ctypes
 
 
 class TestImeiRestrictionWildcardSnr(unittest.TestCase):

--- a/lte/gateway/python/integ_tests/s1aptests/test_implicit_detach_timer_with_mme_restart.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_implicit_detach_timer_with_mme_restart.py
@@ -11,8 +11,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-import unittest
 import time
+import unittest
 
 import gpp_types
 import s1ap_types

--- a/lte/gateway/python/integ_tests/s1aptests/test_ipv4v6_secondary_pdn.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_ipv4v6_secondary_pdn.py
@@ -6,12 +6,12 @@ LICENSE file in the root directory of this source tree. An additional grant
 of patent rights can be found in the PATENTS file in the same directory.
 """
 
-import unittest
+import ipaddress
 import time
+import unittest
 
 import s1ap_types
 import s1ap_wrapper
-import ipaddress
 
 
 class TestIPv4v6SecondaryPdn(unittest.TestCase):

--- a/lte/gateway/python/integ_tests/s1aptests/test_ipv4v6_secondary_pdn_multi_ue.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_ipv4v6_secondary_pdn_multi_ue.py
@@ -6,12 +6,12 @@ LICENSE file in the root directory of this source tree. An additional grant
 of patent rights can be found in the PATENTS file in the same directory.
 """
 
-import unittest
+import ipaddress
 import time
+import unittest
 
 import s1ap_types
 import s1ap_wrapper
-import ipaddress
 
 
 class TestIPv4v6SecondaryPdnMultiUE(unittest.TestCase):

--- a/lte/gateway/python/integ_tests/s1aptests/test_ipv4v6_secondary_pdn_rs_retransmit.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_ipv4v6_secondary_pdn_rs_retransmit.py
@@ -6,12 +6,12 @@ LICENSE file in the root directory of this source tree. An additional grant
 of patent rights can be found in the PATENTS file in the same directory.
 """
 
-import unittest
+import ipaddress
 import time
+import unittest
 
 import s1ap_types
 import s1ap_wrapper
-import ipaddress
 
 
 class TestIPv4v6SecondaryPdnRSRetransmit(unittest.TestCase):

--- a/lte/gateway/python/integ_tests/s1aptests/test_ipv4v6_secondary_pdn_spgw_initiated_ded_bearer.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_ipv4v6_secondary_pdn_spgw_initiated_ded_bearer.py
@@ -6,8 +6,8 @@ LICENSE file in the root directory of this source tree. An additional grant
 of patent rights can be found in the PATENTS file in the same directory.
 """
 
-import unittest
 import time
+import unittest
 
 import s1ap_types
 import s1ap_wrapper

--- a/lte/gateway/python/integ_tests/s1aptests/test_ipv4v6_secondary_pdn_with_ded_bearer.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_ipv4v6_secondary_pdn_with_ded_bearer.py
@@ -6,14 +6,14 @@ LICENSE file in the root directory of this source tree. An additional grant
 of patent rights can be found in the PATENTS file in the same directory.
 """
 
-import unittest
+import ipaddress
 import time
+import unittest
 
 import s1ap_types
 import s1ap_wrapper
-import ipaddress
-from lte.protos.policydb_pb2 import FlowMatch
 from integ_tests.s1aptests.s1ap_utils import SessionManagerUtil
+from lte.protos.policydb_pb2 import FlowMatch
 
 
 class TestIPv4v6SecondaryPdnWithDedBearer(unittest.TestCase):

--- a/lte/gateway/python/integ_tests/s1aptests/test_ipv4v6_secondary_pdn_with_ded_bearer_multi_ue.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_ipv4v6_secondary_pdn_with_ded_bearer_multi_ue.py
@@ -6,14 +6,14 @@ LICENSE file in the root directory of this source tree. An additional grant
 of patent rights can be found in the PATENTS file in the same directory.
 """
 
-import unittest
+import ipaddress
 import time
+import unittest
 
 import s1ap_types
 import s1ap_wrapper
-import ipaddress
-from lte.protos.policydb_pb2 import FlowMatch
 from integ_tests.s1aptests.s1ap_utils import SessionManagerUtil
+from lte.protos.policydb_pb2 import FlowMatch
 
 
 class TestIPv4v6SecondaryPdnWithDedBearerMultiUe(unittest.TestCase):

--- a/lte/gateway/python/integ_tests/s1aptests/test_ipv6_secondary_pdn_rs_retransmit.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_ipv6_secondary_pdn_rs_retransmit.py
@@ -6,12 +6,12 @@ LICENSE file in the root directory of this source tree. An additional grant
 of patent rights can be found in the PATENTS file in the same directory.
 """
 
-import unittest
+import ipaddress
 import time
+import unittest
 
 import s1ap_types
 import s1ap_wrapper
-import ipaddress
 
 
 class TestIPv6SecondaryPdnRSRetransmit(unittest.TestCase):

--- a/lte/gateway/python/integ_tests/s1aptests/test_ipv6_secondary_pdn_with_ded_bearer.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_ipv6_secondary_pdn_with_ded_bearer.py
@@ -6,14 +6,14 @@ LICENSE file in the root directory of this source tree. An additional grant
 of patent rights can be found in the PATENTS file in the same directory.
 """
 
-import unittest
+import ipaddress
 import time
+import unittest
 
 import s1ap_types
 import s1ap_wrapper
-import ipaddress
-from lte.protos.policydb_pb2 import FlowMatch
 from integ_tests.s1aptests.s1ap_utils import SessionManagerUtil
+from lte.protos.policydb_pb2 import FlowMatch
 
 
 class TestIPv6SecondaryPdnWithDedBearer(unittest.TestCase):

--- a/lte/gateway/python/integ_tests/s1aptests/test_mobile_reachability_timer_with_mme_restart.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_mobile_reachability_timer_with_mme_restart.py
@@ -11,8 +11,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-import unittest
 import time
+import unittest
 
 import gpp_types
 import s1ap_types

--- a/lte/gateway/python/integ_tests/s1aptests/test_multi_enb_complete_reset.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_multi_enb_complete_reset.py
@@ -12,6 +12,7 @@ limitations under the License.
 """
 import time
 import unittest
+
 import s1ap_types
 import s1ap_wrapper
 

--- a/lte/gateway/python/integ_tests/s1aptests/test_multi_enb_multi_ue.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_multi_enb_multi_ue.py
@@ -12,6 +12,7 @@ limitations under the License.
 """
 import time
 import unittest
+
 import s1ap_types
 import s1ap_wrapper
 

--- a/lte/gateway/python/integ_tests/s1aptests/test_multi_enb_multi_ue_diff_enbtype.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_multi_enb_multi_ue_diff_enbtype.py
@@ -12,6 +12,7 @@ limitations under the License.
 """
 import time
 import unittest
+
 import s1ap_types
 import s1ap_wrapper
 

--- a/lte/gateway/python/integ_tests/s1aptests/test_multi_enb_multi_ue_diff_plmn.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_multi_enb_multi_ue_diff_plmn.py
@@ -12,6 +12,7 @@ limitations under the License.
 """
 import time
 import unittest
+
 import s1ap_types
 import s1ap_wrapper
 

--- a/lte/gateway/python/integ_tests/s1aptests/test_multi_enb_multi_ue_diff_tac.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_multi_enb_multi_ue_diff_tac.py
@@ -12,6 +12,7 @@ limitations under the License.
 """
 import time
 import unittest
+
 import s1ap_types
 import s1ap_wrapper
 

--- a/lte/gateway/python/integ_tests/s1aptests/test_multi_enb_paging_request.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_multi_enb_paging_request.py
@@ -11,13 +11,12 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
+import time
 import unittest
-
 
 import gpp_types
 import s1ap_types
 import s1ap_wrapper
-import time
 
 
 class TestMultiEnbPagingRequest(unittest.TestCase):

--- a/lte/gateway/python/integ_tests/s1aptests/test_multi_enb_partial_reset.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_multi_enb_partial_reset.py
@@ -11,9 +11,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-import unittest
-import time
 import ctypes
+import time
+import unittest
 from builtins import range
 
 import s1ap_types

--- a/lte/gateway/python/integ_tests/s1aptests/test_multi_enb_sctp_shutdown.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_multi_enb_sctp_shutdown.py
@@ -12,6 +12,7 @@ limitations under the License.
 """
 import time
 import unittest
+
 import s1ap_types
 import s1ap_wrapper
 

--- a/lte/gateway/python/integ_tests/s1aptests/test_nas_non_delivery_for_auth.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_nas_non_delivery_for_auth.py
@@ -14,7 +14,6 @@ limitations under the License.
 import unittest
 
 import s1ap_types
-
 from integ_tests.s1aptests import s1ap_wrapper
 
 

--- a/lte/gateway/python/integ_tests/s1aptests/test_nas_non_delivery_for_identity_req.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_nas_non_delivery_for_identity_req.py
@@ -14,7 +14,6 @@ limitations under the License.
 import unittest
 
 import s1ap_types
-
 from integ_tests.s1aptests import s1ap_wrapper
 
 

--- a/lte/gateway/python/integ_tests/s1aptests/test_nas_non_delivery_for_smc.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_nas_non_delivery_for_smc.py
@@ -14,7 +14,6 @@ limitations under the License.
 import unittest
 
 import s1ap_types
-
 from integ_tests.s1aptests import s1ap_wrapper
 
 

--- a/lte/gateway/python/integ_tests/s1aptests/test_no_attach_complete.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_no_attach_complete.py
@@ -21,7 +21,6 @@ from python.integ_tests.common.service303_utils import (
     verify_gateway_metrics,
 )
 
-
 # This test case is to test EPC behaviour by not sending "attach complete"
 # in the response to multiple retries of  "attach accept" from EPC.
 # EPC is exepcetd to try sending attach accept 5 times when there is no

--- a/lte/gateway/python/integ_tests/s1aptests/test_no_attach_complete_with_mme_restart.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_no_attach_complete_with_mme_restart.py
@@ -11,10 +11,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
+import time
 import unittest
 
 import s1ap_types
-import time
 import s1ap_wrapper
 from s1ap_utils import MagmadUtil
 

--- a/lte/gateway/python/integ_tests/s1aptests/test_no_auth_response_with_mme_restart.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_no_auth_response_with_mme_restart.py
@@ -11,13 +11,12 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-import unittest
 import time
+import unittest
 
 import s1ap_types
 import s1ap_wrapper
 from s1ap_utils import MagmadUtil
-
 
 # This test case is to test EPC behaviour by restarting mme
 # after authentication timer expires.

--- a/lte/gateway/python/integ_tests/s1aptests/test_no_auth_response_with_mme_restart_reattach.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_no_auth_response_with_mme_restart_reattach.py
@@ -11,8 +11,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-import unittest
 import time
+import unittest
 
 import s1ap_types
 import s1ap_wrapper

--- a/lte/gateway/python/integ_tests/s1aptests/test_no_esm_information_rsp_with_mme_restart.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_no_esm_information_rsp_with_mme_restart.py
@@ -11,11 +11,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
+import time
 import unittest
 
 import s1ap_types
-import time
-
 from integ_tests.s1aptests import s1ap_wrapper
 from s1ap_utils import MagmadUtil
 
@@ -109,7 +108,6 @@ class TestNoEsmInformationRspWithMmeRestart(unittest.TestCase):
                 ue_id,
             )
             # Wait for UE_CTX_REL_IND
-            global response
             response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
             response.msg_type, s1ap_types.tfwCmd.UE_CTX_REL_IND.value

--- a/lte/gateway/python/integ_tests/s1aptests/test_no_identity_rsp_with_mme_restart.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_no_identity_rsp_with_mme_restart.py
@@ -11,11 +11,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
+import time
 import unittest
 
 import s1ap_types
-import time
-
 from integ_tests.s1aptests import s1ap_wrapper
 from s1ap_utils import MagmadUtil
 

--- a/lte/gateway/python/integ_tests/s1aptests/test_no_smc_with_mme_restart_reattach.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_no_smc_with_mme_restart_reattach.py
@@ -11,8 +11,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-import unittest
 import time
+import unittest
 
 import s1ap_types
 import s1ap_wrapper

--- a/lte/gateway/python/integ_tests/s1aptests/test_outoforder_attach_complete_ICSR.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_outoforder_attach_complete_ICSR.py
@@ -12,11 +12,11 @@ limitations under the License.
 """
 
 
+import time
 import unittest
 
 import s1ap_types
 import s1ap_wrapper
-import time
 
 
 class TestOutOfOrderAttachCompleteInitialCtxtSetupRsp(unittest.TestCase):

--- a/lte/gateway/python/integ_tests/s1aptests/test_outoforder_erab_setup_rsp_dedicated_bearer.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_outoforder_erab_setup_rsp_dedicated_bearer.py
@@ -11,14 +11,14 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-import unittest
+import ipaddress
 import time
+import unittest
 
 import s1ap_types
 import s1ap_wrapper
-import ipaddress
-from lte.protos.policydb_pb2 import FlowMatch
 from integ_tests.s1aptests.s1ap_utils import SessionManagerUtil
+from lte.protos.policydb_pb2 import FlowMatch
 
 
 class TestOutOfOrderErabSetupRspDedicatedBearer(unittest.TestCase):

--- a/lte/gateway/python/integ_tests/s1aptests/test_outoforder_erab_setup_rsp_default_bearer.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_outoforder_erab_setup_rsp_default_bearer.py
@@ -11,12 +11,12 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-import unittest
+import ipaddress
 import time
+import unittest
 
 import s1ap_types
 import s1ap_wrapper
-import ipaddress
 
 
 class TestOutOfOrderErabSetupRspDefaultBearer(unittest.TestCase):

--- a/lte/gateway/python/integ_tests/s1aptests/test_paging_request.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_paging_request.py
@@ -11,13 +11,12 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
+import time
 import unittest
-
 
 import gpp_types
 import s1ap_types
 import s1ap_wrapper
-import time
 
 
 class TestPagingRequest(unittest.TestCase):

--- a/lte/gateway/python/integ_tests/s1aptests/test_paging_with_mme_restart.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_paging_with_mme_restart.py
@@ -11,13 +11,12 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
+import time
 import unittest
-
 
 import gpp_types
 import s1ap_types
 import s1ap_wrapper
-import time
 from s1ap_utils import MagmadUtil
 
 

--- a/lte/gateway/python/integ_tests/s1aptests/test_s1setup_incorrect_plmn.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_s1setup_incorrect_plmn.py
@@ -11,8 +11,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-import unittest
 import ctypes
+import unittest
+
 import s1ap_types
 from integ_tests.s1aptests.s1ap_utils import S1ApUtil
 

--- a/lte/gateway/python/integ_tests/s1aptests/test_s1setup_incorrect_tac.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_s1setup_incorrect_tac.py
@@ -12,6 +12,7 @@ limitations under the License.
 """
 
 import unittest
+
 import s1ap_types
 from integ_tests.s1aptests.s1ap_utils import S1ApUtil
 

--- a/lte/gateway/python/integ_tests/s1aptests/test_sctp_abort_after_auth_req.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_sctp_abort_after_auth_req.py
@@ -14,7 +14,6 @@ limitations under the License.
 import unittest
 
 import s1ap_types
-
 from integ_tests.s1aptests import s1ap_wrapper
 
 

--- a/lte/gateway/python/integ_tests/s1aptests/test_sctp_abort_after_identity_req.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_sctp_abort_after_identity_req.py
@@ -14,7 +14,6 @@ limitations under the License.
 import unittest
 
 import s1ap_types
-
 from integ_tests.s1aptests import s1ap_wrapper
 
 

--- a/lte/gateway/python/integ_tests/s1aptests/test_sctp_abort_after_smc.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_sctp_abort_after_smc.py
@@ -14,7 +14,6 @@ limitations under the License.
 import unittest
 
 import s1ap_types
-
 from integ_tests.s1aptests import s1ap_wrapper
 
 

--- a/lte/gateway/python/integ_tests/s1aptests/test_sctp_shutdown_after_auth_req.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_sctp_shutdown_after_auth_req.py
@@ -14,7 +14,6 @@ limitations under the License.
 import unittest
 
 import s1ap_types
-
 from integ_tests.s1aptests import s1ap_wrapper
 
 

--- a/lte/gateway/python/integ_tests/s1aptests/test_sctp_shutdown_after_identity_req.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_sctp_shutdown_after_identity_req.py
@@ -14,7 +14,6 @@ limitations under the License.
 import unittest
 
 import s1ap_types
-
 from integ_tests.s1aptests import s1ap_wrapper
 
 

--- a/lte/gateway/python/integ_tests/s1aptests/test_sctp_shutdown_after_multi_ue_attach.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_sctp_shutdown_after_multi_ue_attach.py
@@ -12,6 +12,7 @@ limitations under the License.
 """
 
 import unittest
+
 import s1ap_types
 import s1ap_wrapper
 

--- a/lte/gateway/python/integ_tests/s1aptests/test_sctp_shutdown_after_smc.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_sctp_shutdown_after_smc.py
@@ -14,7 +14,6 @@ limitations under the License.
 import unittest
 
 import s1ap_types
-
 from integ_tests.s1aptests import s1ap_wrapper
 
 

--- a/lte/gateway/python/integ_tests/s1aptests/test_sctp_shutdown_while_mme_is_stopped.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_sctp_shutdown_while_mme_is_stopped.py
@@ -15,7 +15,6 @@ import time
 import unittest
 
 import s1ap_types
-
 from integ_tests.s1aptests import s1ap_wrapper
 
 

--- a/lte/gateway/python/integ_tests/s1aptests/test_secondary_pdn_reject_multiple_sessions_not_allowed_per_apn.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_secondary_pdn_reject_multiple_sessions_not_allowed_per_apn.py
@@ -11,8 +11,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-import unittest
 import time
+import unittest
 
 import s1ap_types
 import s1ap_wrapper

--- a/lte/gateway/python/integ_tests/s1aptests/test_secondary_pdn_reject_unknown_pdn_type.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_secondary_pdn_reject_unknown_pdn_type.py
@@ -11,8 +11,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-import unittest
 import time
+import unittest
 
 import s1ap_types
 import s1ap_wrapper

--- a/lte/gateway/python/integ_tests/s1aptests/test_secondary_pdn_with_dedicated_bearer_multiple_services_restart.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_secondary_pdn_with_dedicated_bearer_multiple_services_restart.py
@@ -11,9 +11,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-import unittest
-import time
 import ipaddress
+import time
+import unittest
+
 import s1ap_types
 import s1ap_wrapper
 from integ_tests.s1aptests.s1ap_utils import SessionManagerUtil

--- a/lte/gateway/python/integ_tests/s1aptests/test_service_req_ul_udp_data_with_mme_restart.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_service_req_ul_udp_data_with_mme_restart.py
@@ -11,8 +11,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-import unittest
 import time
+import unittest
 
 import gpp_types
 import s1ap_types

--- a/lte/gateway/python/integ_tests/s1aptests/test_standalone_pdn_conn_req.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_standalone_pdn_conn_req.py
@@ -11,14 +11,14 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
+import ctypes
 import threading
-import unittest
 import time
+import unittest
 
 import gpp_types
 import s1ap_types
 import s1ap_wrapper
-import ctypes
 
 
 class TestStandAlonePdnConnReq(unittest.TestCase):

--- a/lte/gateway/python/integ_tests/s1aptests/test_standalone_pdn_conn_req_with_apn_correction.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_standalone_pdn_conn_req_with_apn_correction.py
@@ -11,15 +11,15 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
+import ctypes
 import threading
-import unittest
 import time
+import unittest
 
-from s1ap_utils import MagmadUtil
 import gpp_types
 import s1ap_types
 import s1ap_wrapper
-import ctypes
+from s1ap_utils import MagmadUtil
 
 
 class TestStandAlonePdnConnReqWithApnCorrection(unittest.TestCase):

--- a/lte/gateway/python/integ_tests/s1aptests/test_stateless_multi_ue_mixedstate_mme_restart.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_stateless_multi_ue_mixedstate_mme_restart.py
@@ -11,16 +11,15 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
+import ctypes
+import ipaddress
+import time
 import unittest
 
 import gpp_types
-import ipaddress
 import s1ap_types
-import time
-
 from integ_tests.s1aptests import s1ap_wrapper
 from s1ap_utils import MagmadUtil
-import ctypes
 
 
 class TestStatelessMultiUeMixedStateMmeRestart(unittest.TestCase):

--- a/lte/gateway/python/integ_tests/s1aptests/test_tau_periodic_active.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_tau_periodic_active.py
@@ -12,8 +12,8 @@ limitations under the License.
 """
 
 import threading
-import unittest
 import time
+import unittest
 
 import gpp_types
 import s1ap_types

--- a/lte/gateway/python/integ_tests/s1aptests/test_tau_periodic_inactive.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_tau_periodic_inactive.py
@@ -12,8 +12,8 @@ limitations under the License.
 """
 
 import threading
-import unittest
 import time
+import unittest
 
 import gpp_types
 import s1ap_types

--- a/lte/gateway/python/integ_tests/s1aptests/test_x2_handover.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_x2_handover.py
@@ -11,11 +11,11 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
+import time
 import unittest
 
 import s1ap_types
 import s1ap_wrapper
-import time
 
 
 class TestX2HandOver(unittest.TestCase):

--- a/lte/gateway/python/integ_tests/s1aptests/test_x2_handover_ping_pong.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_x2_handover_ping_pong.py
@@ -11,11 +11,11 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
+import time
 import unittest
 
 import s1ap_types
 import s1ap_wrapper
-import time
 
 
 class TestX2HandOverPingPong(unittest.TestCase):

--- a/lte/gateway/python/integ_tests/s1aptests/util/traffic_messages.py
+++ b/lte/gateway/python/integ_tests/s1aptests/util/traffic_messages.py
@@ -12,9 +12,9 @@ limitations under the License.
 """
 
 import enum
-import iperf3  # Used by recv to reconstruct iperf3.TestResult objects
 import pickle
 
+import iperf3  # Used by recv to reconstruct iperf3.TestResult objects
 
 '''
 TrafficServerInstance and TrafficTestInstance are payloads used to coordinate

--- a/lte/gateway/python/integ_tests/s1aptests/util/traffic_util.py
+++ b/lte/gateway/python/integ_tests/s1aptests/util/traffic_util.py
@@ -14,21 +14,21 @@ limitations under the License.
 import copy
 import ctypes
 import ipaddress
-import iperf3
 import os
-import pyroute2
-import socket
-import threading
 import shlex
+import socket
 import subprocess
+import threading
 
+import iperf3
+import pyroute2
 import s1ap_types
 from util.traffic_messages import (
-    TrafficTestInstance,
+    TrafficMessage,
     TrafficRequest,
     TrafficRequestType,
     TrafficResponseType,
-    TrafficMessage,
+    TrafficTestInstance,
 )
 
 # Tests shouldn't take longer than a few minutes


### PR DESCRIPTION
<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary
Prep work for enforcing some import sorting standards to the contributing doc. Will have a GH action to enforce this on future PRs.

- Apply isort (https://pypi.org/project/isort/) to all python integration test files in lte/gateway/python/integ_tests
- no-op logic wise

![](https://media3.giphy.com/media/3oKIPCSX4UHmuS41TG/giphy-downsized-medium.gif)
<!-- Enumerate changes you made and why you made them -->

## Test Plan
unit tests
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
