### PR TITLE
[lte][agw] Error indication handling

### DIFF
--- a/lte/gateway/c/oai/tasks/s1ap/s1ap_mme_handlers.c
+++ b/lte/gateway/c/oai/tasks/s1ap/s1ap_mme_handlers.c
@@ -2542,21 +2542,21 @@ int s1ap_mme_handle_error_ind_message(
     OAILOG_FUNC_RETURN(LOG_S1AP, RETURNerror);
   }
 
-  if ((ue_ref_p = s1ap_state_get_ue_mmeid((uint32_t) mme_ue_s1ap_id)) == NULL) {
-    OAILOG_INFO(
-        LOG_S1AP,
-        "No UE is attached to this mme UE s1ap id: " MME_UE_S1AP_ID_FMT
-        " and eNB UE s1ap id: \n" ENB_UE_S1AP_ID_FMT,
-        mme_ue_s1ap_id, enb_ue_s1ap_id);
-    OAILOG_FUNC_RETURN(LOG_S1AP, RETURNerror);
-  }
-
   S1AP_FIND_PROTOCOLIE_BY_ID(
       S1ap_ErrorIndicationIEs_t, ie, container, S1ap_ProtocolIE_ID_id_Cause,
       true);
   if (ie) {
     cause_type = ie->value.choice.Cause.present;
   } else {
+    OAILOG_FUNC_RETURN(LOG_S1AP, RETURNerror);
+  }
+
+  if ((ue_ref_p = s1ap_state_get_ue_mmeid((uint32_t) mme_ue_s1ap_id)) == NULL) {
+    OAILOG_WARNING(
+        LOG_S1AP,
+        "No UE is attached to this mme UE s1ap id: " MME_UE_S1AP_ID_FMT
+        " and eNB UE s1ap id: \n" ENB_UE_S1AP_ID_FMT,
+        mme_ue_s1ap_id, enb_ue_s1ap_id);
     OAILOG_FUNC_RETURN(LOG_S1AP, RETURNerror);
   }
 

--- a/lte/gateway/c/oai/tasks/s1ap/s1ap_mme_handlers.c
+++ b/lte/gateway/c/oai/tasks/s1ap/s1ap_mme_handlers.c
@@ -2531,15 +2531,6 @@ int s1ap_mme_handle_error_ind_message(
     OAILOG_FUNC_RETURN(LOG_S1AP, RETURNerror);
   }
 
-  if ((ue_ref_p = s1ap_state_get_ue_mmeid((uint32_t) mme_ue_s1ap_id)) == NULL) {
-    OAILOG_INFO(
-        LOG_S1AP,
-        "No UE is attached to this mme UE s1ap id: " MME_UE_S1AP_ID_FMT
-        " and eNB UE s1ap id: \n" ENB_UE_S1AP_ID_FMT,
-        mme_ue_s1ap_id, enb_ue_s1ap_id);
-    OAILOG_FUNC_RETURN(LOG_S1AP, RETURNerror);
-  }
-
   S1AP_FIND_PROTOCOLIE_BY_ID(
       S1ap_ErrorIndicationIEs_t, ie, container,
       S1ap_ProtocolIE_ID_id_eNB_UE_S1AP_ID, true);
@@ -2548,6 +2539,15 @@ int s1ap_mme_handle_error_ind_message(
     enb_ue_s1ap_id = (enb_ue_s1ap_id_t)(
         ie->value.choice.ENB_UE_S1AP_ID & ENB_UE_S1AP_ID_MASK);
   } else {
+    OAILOG_FUNC_RETURN(LOG_S1AP, RETURNerror);
+  }
+
+  if ((ue_ref_p = s1ap_state_get_ue_mmeid((uint32_t) mme_ue_s1ap_id)) == NULL) {
+    OAILOG_INFO(
+        LOG_S1AP,
+        "No UE is attached to this mme UE s1ap id: " MME_UE_S1AP_ID_FMT
+        " and eNB UE s1ap id: \n" ENB_UE_S1AP_ID_FMT,
+        mme_ue_s1ap_id, enb_ue_s1ap_id);
     OAILOG_FUNC_RETURN(LOG_S1AP, RETURNerror);
   }
 

--- a/lte/gateway/c/oai/tasks/s1ap/s1ap_mme_handlers.h
+++ b/lte/gateway/c/oai/tasks/s1ap/s1ap_mme_handlers.h
@@ -173,4 +173,8 @@ int s1ap_mme_generate_ue_context_release_command(
 
 int s1ap_mme_remove_stale_ue_context(
     enb_ue_s1ap_id_t enb_ue_s1ap_id, uint32_t enb_id);
+
+int s1ap_send_mme_ue_context_release(
+    s1ap_state_t* state, ue_description_t* ue_ref_p,
+    enum s1cause s1_release_cause, S1ap_Cause_t ie_cause, imsi64_t imsi64);
 #endif /* FILE_S1AP_MME_HANDLERS_SEEN */


### PR DESCRIPTION
## Summary

- PR extends the support of error indication handling for addressing unknown pair of UE S1AP ID. We trigger a context release request for matching MME UE S1AP ID that also leads to implicit detach for unregistered UEs.
- A minor refactoring on sending the context release request is done.

## Test Plan
Integ tests for regression. S1AP support will be added to cover error indication signals in another PR once S1AP Tester itself is updated.

Spirent tests are conducted, where the issue is observed with at scale tests.

Before changes, we had:
```
400288 Fri Apr 02 23:30:35 2021 7F495A3D9700 WARNI S1AP   tasks/s1ap/s1ap_mme_handlers.c  :2529    ERROR IND RCVD on Stream id 1, ignoring it
```

After changes, an example of this handling:
```
189784 Mon Apr 05 21:37:18 2021 7F50021D6700 WARNI S1AP   tasks/s1ap/s1ap_mme_handlers.c  :2514    ERROR IND RCVD on Stream id 1 
189785 Mon Apr 05 21:37:18 2021 7F50059DD700 ERROR MME-AP tasks/mme_app/mme_app_context.c :2005   [1011234560372] UE context release request received while UE is in Deregistered state Perform implicit detach for ue-id0x00003FE7
```

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
