### PR TITLE
Specify orc8r db dialect and port through helm and terraform

### DIFF
--- a/orc8r/cloud/deploy/terraform/orc8r-aws/outputs.tf
+++ b/orc8r/cloud/deploy/terraform/orc8r-aws/outputs.tf
@@ -67,6 +67,11 @@ output "orc8r_db_port" {
   value       = aws_db_instance.default.port
 }
 
+output "orc8r_db_dialect" {
+  description = "Database dialect for Orchestrator RDS instance"
+  value       = var.orc8r_db_dialect
+}
+
 output "orc8r_db_user" {
   description = "Database username for Orchestrator RDS instance"
   value       = aws_db_instance.default.username

--- a/orc8r/cloud/deploy/terraform/orc8r-aws/variables.tf
+++ b/orc8r/cloud/deploy/terraform/orc8r-aws/variables.tf
@@ -239,6 +239,12 @@ variable "orc8r_db_engine_version" {
   default     = "9.6.15"
 }
 
+variable "orc8r_db_dialect" {
+  description = "Database dialect for Orchestrator DB."
+  type        = string
+  default     = "postgres"
+}
+
 ##############################################################################
 # Secretmanager configuration
 ##############################################################################

--- a/orc8r/cloud/deploy/terraform/orc8r-helm-aws/examples/basic/main.tf
+++ b/orc8r/cloud/deploy/terraform/orc8r-helm-aws/examples/basic/main.tf
@@ -49,10 +49,12 @@ module "orc8r-app" {
   secretsmanager_orc8r_name = module.orc8r.secretsmanager_secret_name
   seed_certs_dir            = "~/secrets/certs"
 
-  orc8r_db_host = module.orc8r.orc8r_db_host
-  orc8r_db_name = module.orc8r.orc8r_db_name
-  orc8r_db_user = module.orc8r.orc8r_db_user
-  orc8r_db_pass = module.orc8r.orc8r_db_pass
+  orc8r_db_host    = module.orc8r.orc8r_db_host
+  orc8r_db_port    = module.orc8r.orc8r_db_port
+  orc8r_db_dialect = module.orc8r.orc8r_db_dialect
+  orc8r_db_name    = module.orc8r.orc8r_db_name
+  orc8r_db_user    = module.orc8r.orc8r_db_user
+  orc8r_db_pass    = module.orc8r.orc8r_db_pass
 
   # Note that this can be any container registry provider -- the example below
   # provides the URL format for Docker Hub, where the user and pass are your

--- a/orc8r/cloud/deploy/terraform/orc8r-helm-aws/examples/online-upgrade/main.tf
+++ b/orc8r/cloud/deploy/terraform/orc8r-helm-aws/examples/online-upgrade/main.tf
@@ -113,10 +113,11 @@ module orc8r-app {
   existing_tiller_service_account_name = "tiller"
   helm_deployment_name                 = var.new_deployment_name
 
-  orc8r_db_host = module.orc8r.orc8r_db_host
-  orc8r_db_name = module.orc8r.orc8r_db_name
-  orc8r_db_user = module.orc8r.orc8r_db_user
-  orc8r_db_pass = module.orc8r.orc8r_db_pass
+  orc8r_db_host    = module.orc8r.orc8r_db_host
+  orc8r_db_dialect = module.orc8r.orc8r_db_dialect
+  orc8r_db_name    = module.orc8r.orc8r_db_name
+  orc8r_db_user    = module.orc8r.orc8r_db_user
+  orc8r_db_pass    = module.orc8r.orc8r_db_pass
 
   docker_registry = var.docker_registry
   docker_user     = var.docker_user

--- a/orc8r/cloud/deploy/terraform/orc8r-helm-aws/examples/remote/main.tf
+++ b/orc8r/cloud/deploy/terraform/orc8r-helm-aws/examples/remote/main.tf
@@ -111,10 +111,12 @@ module "orc8r-app" {
   secretsmanager_orc8r_name = module.orc8r.secretsmanager_secret_name
   seed_certs_dir            = "~/orc8r.test.secrets/certs"
 
-  orc8r_db_host = module.orc8r.orc8r_db_host
-  orc8r_db_name = module.orc8r.orc8r_db_name
-  orc8r_db_user = module.orc8r.orc8r_db_user
-  orc8r_db_pass = module.orc8r.orc8r_db_pass
+  orc8r_db_host    = module.orc8r.orc8r_db_host
+  orc8r_db_port    = module.orc8r.orc8r_db_port
+  orc8r_db_dialect = module.orc8r.orc8r_db_dialect
+  orc8r_db_name    = module.orc8r.orc8r_db_name
+  orc8r_db_user    = module.orc8r.orc8r_db_user
+  orc8r_db_pass    = module.orc8r.orc8r_db_pass
 
   docker_registry = jsondecode(data.aws_secretsmanager_secret_version.root_secrets.secret_string)["docker_registry"]
   docker_user     = jsondecode(data.aws_secretsmanager_secret_version.root_secrets.secret_string)["docker_user"]

--- a/orc8r/cloud/deploy/terraform/orc8r-helm-aws/main.tf
+++ b/orc8r/cloud/deploy/terraform/orc8r-helm-aws/main.tf
@@ -173,10 +173,11 @@ data "template_file" "orc8r_values" {
     api_hostname        = format("api.%s", var.orc8r_domain_name)
     nms_hostname        = format("*.nms.%s", var.orc8r_domain_name)
 
-    orc8r_db_name = var.orc8r_db_name
-    orc8r_db_host = var.orc8r_db_host
-    orc8r_db_port = var.orc8r_db_port
-    orc8r_db_user = var.orc8r_db_user
+    orc8r_db_name    = var.orc8r_db_name
+    orc8r_db_host    = var.orc8r_db_host
+    orc8r_db_port    = var.orc8r_db_port
+    orc8r_db_dialect = var.orc8r_db_dialect
+    orc8r_db_user    = var.orc8r_db_user
 
     deploy_nms  = var.deploy_nms
 

--- a/orc8r/cloud/deploy/terraform/orc8r-helm-aws/templates/orc8r-values.tpl
+++ b/orc8r/cloud/deploy/terraform/orc8r-helm-aws/templates/orc8r-values.tpl
@@ -184,8 +184,11 @@ nms:
     env:
       api_host: ${api_hostname}
       mysql_db: ${orc8r_db_name}
+      mysql_dialect: ${orc8r_db_dialect}
       mysql_host: ${orc8r_db_host}
+      mysql_port: ${orc8r_db_port}
       mysql_user: ${orc8r_db_user}
+      mysql_pass: ${orc8r_db_password}
       grafana_address: ${user_grafana_hostname}
 
   nginx:

--- a/orc8r/cloud/deploy/terraform/orc8r-helm-aws/variables.tf
+++ b/orc8r/cloud/deploy/terraform/orc8r-helm-aws/variables.tf
@@ -96,6 +96,11 @@ variable "orc8r_db_name" {
   type        = string
 }
 
+variable "orc8r_db_dialect" {
+  description = "DB dialect for Orchestrator database connection."
+  type        = string
+}
+
 variable "orc8r_db_host" {
   description = "DB hostname for Orchestrator database connection."
   type        = string
@@ -156,7 +161,7 @@ variable "orc8r_deployment_type" {
 variable "orc8r_chart_version" {
   description = "Version of the core orchestrator Helm chart to install."
   type        = string
-  default     = "1.5.18"
+  default     = "1.5.19"
 }
 
 variable "cwf_orc8r_chart_version" {

--- a/orc8r/cloud/helm/orc8r/Chart.lock
+++ b/orc8r/cloud/helm/orc8r/Chart.lock
@@ -7,12 +7,12 @@ dependencies:
   version: 1.4.22
 - name: nms
   repository: ""
-  version: 0.1.10
+  version: 0.1.11
 - name: logging
   repository: ""
   version: 0.1.10
 - name: orc8rlib
   repository: file://../orc8rlib
   version: 0.1.2
-digest: sha256:7a49d5fba17dce594a8a6c4c89a7204678acca652c4b4d4727fc07f00132117d
-generated: "2021-03-05T11:56:20.589138693+05:30"
+digest: sha256:73383945a6f49b14bad2d42ffc0223286cd1d3f106319efc3739dc494547f08c
+generated: "2021-04-06T16:10:45.754709-07:00"

--- a/orc8r/cloud/helm/orc8r/Chart.yaml
+++ b/orc8r/cloud/helm/orc8r/Chart.yaml
@@ -13,7 +13,7 @@ apiVersion: v2
 appVersion: "1.0"
 description: A Helm chart for magma orchestrator
 name: orc8r
-version: 1.5.18
+version: 1.5.19
 engine: gotpl
 sources:
   - https://github.com/magma/magma
@@ -31,7 +31,7 @@ dependencies:
     repository: ""
     condition: metrics.enabled
   - name: nms
-    version: 0.1.10
+    version: 0.1.11
     repository: ""
     condition: nms.enabled
   - name: logging

--- a/orc8r/cloud/helm/orc8r/charts/nms/Chart.yaml
+++ b/orc8r/cloud/helm/orc8r/charts/nms/Chart.yaml
@@ -12,7 +12,7 @@
 apiVersion: v1
 description: Magma NMS
 name: nms
-version: 0.1.10
+version: 0.1.11
 home: https://github.com/magma/magma
 sources:
   - https://github.com/magma/magma

--- a/orc8r/cloud/helm/orc8r/charts/nms/templates/magmalte-deployment.yaml
+++ b/orc8r/cloud/helm/orc8r/charts/nms/templates/magmalte-deployment.yaml
@@ -80,6 +80,8 @@ spec:
               value: {{ .Values.magmalte.env.mysql_db | quote }}
             - name: MYSQL_HOST
               value: {{ .Values.magmalte.env.mysql_host | quote }}
+            - name: MYSQL_PORT
+              value: {{ .Values.magmalte.env.mysql_port | quote }}
             - name: MYSQL_DIALECT
               value: {{ .Values.magmalte.env.mysql_dialect | quote }}
             - name: MYSQL_PASS

--- a/orc8r/cloud/helm/orc8r/charts/nms/values.yaml
+++ b/orc8r/cloud/helm/orc8r/charts/nms/values.yaml
@@ -30,10 +30,11 @@ magmalte:
     port: 8081
     mapbox_access_token: ""
     mysql_host: mariadb.magma.svc.cluster.local
+    mysql_port: 5432
     mysql_db: magma
     mysql_user: magma
     mysql_pass: password
-    mysql_dialect: mysql
+    mysql_dialect: postgres
     grafana_address: orc8r-user-grafana:3000
 
   labels: {}


### PR DESCRIPTION
Signed-off-by: Andrei Lee <andreilee@fb.com>

## Summary

NMS uses the environment variables `MYSQL_DIALECT` and `MYSQL_PORT` to help understand which database to connect to for use through the Sequelize ORM. This pull request updates helm charts and terraform files so that these do not use the defaults which are useful for MariaDB only.

## Test Plan

To be tested in Facebook's Magma staging setup

## Additional Information

- [ ] This change is backwards-breaking
