### PR TITLE
[ctraced] Change call tracing interface to 'any'

### DIFF
--- a/cwf/gateway/configs/ctraced.yml
+++ b/cwf/gateway/configs/ctraced.yml
@@ -17,7 +17,7 @@ trace_directory: /var/opt/magma/tmp/trace
 
 # Interface to capture on
 trace_interfaces:
-  - eth0
+  - any
 
 # Options available:
 #   - tshark

--- a/feg/gateway/configs/ctraced.yml
+++ b/feg/gateway/configs/ctraced.yml
@@ -17,7 +17,7 @@ trace_directory: /var/opt/magma/tmp/trace
 
 # Interface to capture on
 trace_interfaces:
-  - eth0
+  - any
 
 # Options available:
 #   - tshark

--- a/lte/gateway/configs/ctraced.yml
+++ b/lte/gateway/configs/ctraced.yml
@@ -17,7 +17,7 @@ trace_directory: /var/opt/magma/tmp/trace
 
 # Interface to capture on
 trace_interfaces:
-  - eth0
+  - any
 
 # Options available:
 #   - tshark

--- a/orc8r/gateway/python/magma/ctraced/command_builder.py
+++ b/orc8r/gateway/python/magma/ctraced/command_builder.py
@@ -11,7 +11,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-from abc import ABC, abstractmethod
 from typing import List
 
 


### PR DESCRIPTION
Signed-off-by: Andrei Lee <andreilee@fb.com>

## Summary

Changed `ctraced.yml` configs across gateways to default to capturing call traces on `any` interface, rather than `eth0`. This addresses #5917 

## Test Plan

N/A. Only config change

## Additional Information

- [ ] This change is backwards-breaking

<!--
    Final note

    Please take a moment to read through the Magma project's
    - Contributing conventions: https://docs.magmacore.org/docs/next/contributing/contribute_conventions

    If this is your first time opening a PR, also consider reading
    - Developer onboarding: https://docs.magmacore.org/docs/next/contributing/contribute_onboarding
    - Development workflow: https://docs.magmacore.org/docs/next/contributing/contribute_workflow
-->
