### PR TITLE
[Non_Sanity_Testing] Fixed invalid function call for non-sanity dedicated bearer test cases

### DIFF
--- a/lte/gateway/python/integ_tests/s1aptests/test_ipv4v6_secondary_pdn_with_ded_bearer.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_ipv4v6_secondary_pdn_with_ded_bearer.py
@@ -173,7 +173,11 @@ class TestIPv4v6SecondaryPdnWithDedBearer(unittest.TestCase):
         print(
             "********************** Added default bearer for apn-%s,"
             " bearer id-%d, pdn type-%d"
-            % (apn, act_def_bearer_req.m.pdnInfo.epsBearerId, pdn_type,)
+            % (
+                apn,
+                act_def_bearer_req.m.pdnInfo.epsBearerId,
+                pdn_type,
+            )
         )
 
         # Receive Router Advertisement message
@@ -202,7 +206,7 @@ class TestIPv4v6SecondaryPdnWithDedBearer(unittest.TestCase):
             "********************** Sending RAR for IMSI",
             "".join([str(i) for i in req.imsi]),
         )
-        self._sessionManager_util.create_ReAuthRequest(
+        self._sessionManager_util.send_ReAuthRequest(
             "IMSI" + "".join([str(i) for i in req.imsi]),
             policy_id,
             flow_list,

--- a/lte/gateway/python/integ_tests/s1aptests/test_ipv4v6_secondary_pdn_with_ded_bearer_multi_ue.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_ipv4v6_secondary_pdn_with_ded_bearer_multi_ue.py
@@ -25,7 +25,7 @@ class TestIPv4v6SecondaryPdnWithDedBearerMultiUe(unittest.TestCase):
         self._s1ap_wrapper.cleanup()
 
     def test_ipv4v6_secondary_pdn_with_ded_bearer_multi_ue(self):
-        """ Attach a single UE + add a secondary pdn with
+        """Attach a single UE + add a secondary pdn with
         IPv4v6 + add dedicated bearer + detach
         Repeat for 4 UEs"""
         num_ues = 4
@@ -179,7 +179,11 @@ class TestIPv4v6SecondaryPdnWithDedBearerMultiUe(unittest.TestCase):
             print(
                 "********************** Added default bearer for apn-%s,"
                 " bearer id-%d, pdn type-%d"
-                % (apn, act_def_bearer_req.m.pdnInfo.epsBearerId, pdn_type,)
+                % (
+                    apn,
+                    act_def_bearer_req.m.pdnInfo.epsBearerId,
+                    pdn_type,
+                )
             )
 
             # Receive Router Advertisement message
@@ -208,7 +212,7 @@ class TestIPv4v6SecondaryPdnWithDedBearerMultiUe(unittest.TestCase):
                 "********************** Sending RAR for IMSI",
                 "".join([str(i) for i in req.imsi]),
             )
-            self._sessionManager_util.create_ReAuthRequest(
+            self._sessionManager_util.send_ReAuthRequest(
                 "IMSI" + "".join([str(i) for i in req.imsi]),
                 policy_id,
                 flow_list,

--- a/lte/gateway/python/integ_tests/s1aptests/test_ipv6_secondary_pdn_with_ded_bearer.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_ipv6_secondary_pdn_with_ded_bearer.py
@@ -149,7 +149,11 @@ class TestIPv6SecondaryPdnWithDedBearer(unittest.TestCase):
         print(
             "********************** Added default bearer for apn-%s,"
             " bearer id-%d, pdn type-%d"
-            % (apn, act_def_bearer_req.m.pdnInfo.epsBearerId, pdn_type,)
+            % (
+                apn,
+                act_def_bearer_req.m.pdnInfo.epsBearerId,
+                pdn_type,
+            )
         )
 
         # Receive Router Advertisement message
@@ -178,7 +182,7 @@ class TestIPv6SecondaryPdnWithDedBearer(unittest.TestCase):
             "********************** Sending RAR for IMSI",
             "".join([str(i) for i in req.imsi]),
         )
-        self._sessionManager_util.create_ReAuthRequest(
+        self._sessionManager_util.send_ReAuthRequest(
             "IMSI" + "".join([str(i) for i in req.imsi]),
             policy_id,
             flow_list,

--- a/lte/gateway/python/integ_tests/s1aptests/test_outoforder_erab_setup_rsp_dedicated_bearer.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_outoforder_erab_setup_rsp_dedicated_bearer.py
@@ -30,7 +30,7 @@ class TestOutOfOrderErabSetupRspDedicatedBearer(unittest.TestCase):
         self._s1ap_wrapper.cleanup()
 
     def test_outoforder_erab_setup_rsp_dedicated_bearer(self):
-        """ Attach a single UE + add dedicated bearer + send erab setup rsp
+        """Attach a single UE + add dedicated bearer + send erab setup rsp
         message out of order for the dedicated bearer"""
         num_ue = 1
 
@@ -168,7 +168,7 @@ class TestOutOfOrderErabSetupRspDedicatedBearer(unittest.TestCase):
             "********************** Sending RAR for IMSI",
             "".join([str(i) for i in req.imsi]),
         )
-        self._sessionManager_util.create_ReAuthRequest(
+        self._sessionManager_util.send_ReAuthRequest(
             "IMSI" + "".join([str(i) for i in req.imsi]),
             policy_id,
             flow_list,


### PR DESCRIPTION
## Title
[Non_Sanity_Testing] Fixed invalid function call for non-sanity ipv6 dedicated bearer test cases

## Summary
This PR is partial fix for a subset of issues from github issue #5842 (Also refer PR #5840 which adds all these non-sanity test cases as part of defs.mk file)

Following non-sanity dedicated bearer test cases were failing because of calling unknown function. The function **sessionManager_util.create_ReAuthRequest** was called from the test script, but this function had been renamed with **_sessionManager_util.send_ReAuthRequest** as part of commit-id: 0dbe87cb0d2eec16e90476987cc026164aac5eaa. This PR corrects the called function name for these test cases to pass

```
s1aptests/test_ipv4v6_secondary_pdn_with_ded_bearer.py
s1aptests/test_ipv6_secondary_pdn_with_ded_bearer.py
s1aptests/test_ipv4v6_secondary_pdn_with_ded_bearer_multi_ue.py
s1aptests/test_outoforder_erab_setup_rsp_dedicated_bearer.py
```

The error thrown from test script is as follows:
```
with_ded_bearer
    self._sessionManager_util.create_ReAuthRequest(
AttributeError: 'SessionManagerUtil' object has no attribute 'create_ReAuthRequest'
-------------------- >> begin captured logging << --------------------
root: ERROR: Could not load magmad yml config for mconfig modules
urllib3.connectionpool: DEBUG: Starting new HTTP connection (1): 192.168.60.142:3333
urllib3.connectionpool: DEBUG: http://192.168.60.142:3333 "GET /stats/switches HTTP/1.1" 200 16
root: INFO: Adding subscriber : IMSI001010000000001
root: DEBUG: s1ap response expected, received: 12, 12
root: DEBUG: s1ap message expected, received: 68, 68
root: INFO: Deleting subscriber : IMSI001010000000001
--------------------- >> end captured logging << ---------------------

----------------------------------------------------------------------
Ran 1 test in 22.608s

FAILED (errors=1)
Makefile:42: recipe for target 'integ_test' failed
```

## Test Plan
Verified after running the test cases multiple time.

The terminal success log with this PR changes from S1APTester VM has been attached here for reference:
[s1aptester_terminal_log.txt](https://github.com/magma/magma/files/6269232/s1aptester_terminal_log.txt)
 

Signed-off-by: VinashakAnkitAman <ankit.aman@radisys.com>