### PR TITLE
[orc8r] missing obsidian_handlers plugin for eventd

### DIFF
--- a/orc8r/cloud/configs/service_registry.yml
+++ b/orc8r/cloud/configs/service_registry.yml
@@ -92,6 +92,7 @@ services:
     echo_port: 10121
     proxy_type: "clientcert"
     labels:
+      orc8r.io/obsidian_handlers: "true"
       orc8r.io/swagger_spec: "true"
     annotations:
       orc8r.io/obsidian_handlers_path_prefixes: >

--- a/orc8r/cloud/helm/orc8r/Chart.yaml
+++ b/orc8r/cloud/helm/orc8r/Chart.yaml
@@ -13,7 +13,7 @@ apiVersion: v2
 appVersion: "1.0"
 description: A Helm chart for magma orchestrator
 name: orc8r
-version: 1.5.19
+version: 1.5.20
 engine: gotpl
 sources:
   - https://github.com/magma/magma

--- a/orc8r/cloud/helm/orc8r/values.yaml
+++ b/orc8r/cloud/helm/orc8r/values.yaml
@@ -238,6 +238,7 @@ dispatcher:
 eventd:
   service:
     labels:
+      orc8r.io/obsidian_handlers: "true"
       orc8r.io/swagger_spec: "true"
     annotations:
       orc8r.io/obsidian_handlers_path_prefixes: >


### PR DESCRIPTION
Signed-off-by: YOUSSEF EL MASMOUDI <ymasmoudi@fb.com>

## Summary

EventD swagger endpoints are returning 404 erros due to missing obsidian_handlers label.

```
1005 obsidian stderr | I0407 08:09:51.308453     571 rest_middleware.go:41] Received request in access middleware: &{Method:GET URL:/magma/v1/events/test Proto:HTTP/1.0 ProtoMajor:1 ProtoMinor:0 Header:map[Accept:[application/json] Accept     -Encoding:[gzip, deflate, br] Accept-Language:[en-US,en;q=0.9,fr;q=0.8,ar;q=0.7] Connection:[close] Dnt:[1] Referer:[https://localhost:9443/swagger/v1/ui/eventd] Sec-Ch-Ua:["Google Chrome";v="89", "Chromium";v="89", ";Not A Brand";v=     "99"] Sec-Ch-Ua-Mobile:[?0] Sec-Fetch-Dest:[empty] Sec-Fetch-Mode:[cors] Sec-Fetch-Site:[same-origin] User-Agent:[Mozilla/5.0 (Macintosh; Intel Mac OS X 11_2_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/89.0.4389.114 Safari/537.3     6] X-Magma-Client-Cert-Cn:[admin_operator] X-Magma-Client-Cert-Serial:[123AD124FB73FFB7DEE7B1CE8E61B073]] Body:{} GetBody:<nil> ContentLength:0 TransferEncoding:[] Close:true Host:controller:9081 Form:map[] PostForm:map[] MultipartFo     rm:<nil> Trailer:map[] RemoteAddr:172.24.0.12:45624 RequestURI:/magma/v1/events/test TLS:<nil> Cancel:<nil> Response:<nil> ctx:0xc0000d3980}
1006 obsidian stderr | I0407 08:09:51.313869     571 rest_middleware.go:70] Access middleware successfully verified permissions. Sending request to the next middleware.
1007 obsidian stderr | I0407 08:09:51.315993     571 metrics.go:53] REST API code: 404, method: GET, url: /magma/v1/events/test
```

## Test Plan

Tested on a local orc8r.
<img width="1397" alt="Screenshot 2021-04-07 at 16 21 00" src="https://user-images.githubusercontent.com/8215369/113834462-7277d080-97bd-11eb-914c-9f3ad3f4720b.png">

