### PR TITLE
Fixing 2nd TEID onwards missmatch to AMF

### DIFF
--- a/lte/gateway/c/session_manager/SessionStateEnforcer.cpp
+++ b/lte/gateway/c/session_manager/SessionStateEnforcer.cpp
@@ -672,7 +672,8 @@ void SessionStateEnforcer::prepare_response_to_access(
   char teidar[5];
   memset(teidar, '\0', 5);
   memcpy(&teidar[0], &teid_value, 4);
-  rsp->mutable_upf_endpoint()->set_teid(teidar);
+  rsp->mutable_upf_endpoint()->set_teid(teidar, 4);
+
   rsp->mutable_upf_endpoint()->set_end_ipv4_addr(
       config.rat_specific_context.m5gsm_session_context()
           .upf_endpoint()


### PR DESCRIPTION
Signed-off-by: Venu Kumar Gurrapu <venukumar.g@altencalsoftlabs.com>

<!--
     Fixing 2nd TEID onwards missmatch to AMF
-->

## Summary
copied as 4 bytes instead of string, especially zero containing values are not getting copied
<!---->

## Test Plan

<!--
   Tests for 6ue 4 pdu cases.  Attached the log on AMF side 
-->

## Additional Information
[6ue-4pdu.txt](https://github.com/magma/magma/files/6270929/6ue-4pdu.txt)
- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->

<!--
    Final note

    Please take a moment to read through the Magma project's
    - Contributing conventions: https://docs.magmacore.org/docs/next/contributing/contribute_conventions

    If this is your first time opening a PR, also consider reading
    - Developer onboarding: https://docs.magmacore.org/docs/next/contributing/contribute_onboarding
    - Development workflow: https://docs.magmacore.org/docs/next/contributing/contribute_workflow
-->
