### PR TITLE
[DevExp] Fixup shellcheck configuration

### DIFF
--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -1,4 +1,4 @@
-name: Shellcheck by Reviewdog 
+name: reviewdog
 on: [pull_request]
 jobs:
   shellcheck:
@@ -10,8 +10,8 @@ jobs:
         uses: reviewdog/action-shellcheck@v1
         with:
           github_token: ${{ secrets.github_token }}
-          filter_mode: diff_context # Any changed content.
-          reporter: github-pr-review # Post code review comments.
+          filter_mode: added # Any added or changed content.
+          reporter: github-pr-review # Post code review comments. Falls back to Annotations.
           pattern: "*.sh" # Optional.
           # Other options omitted here but possible.
           # - fail_on_error


### PR DESCRIPTION
I have learned three things, this PR fixes them.

First, `name: reviewdog` is the canonical name used by these linters which enables them to be grouped by GH in the UI (nice).

Second, I used an incorrect `filter_mode: diff_context`, which only captures modified lines not added + modified lines.

Third, I updated comments to make clear that `reporter: github-pr-review` will fall back to annotations if permissions fail (as they do today).

Signed-off-by: Scott Harrison Moeller <smoeller@fb.com>