### PR TITLE
Revert "[DevExp] Migrate container to clang-format 7 for backwards compatibility"

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -47,7 +47,6 @@ RUN echo "Install general purpose packages" && \
         automake \
         build-essential \
         ca-certificates \
-        clang-format-7 \
         clang-format-11 \
         clang-tidy-11 \
         curl \
@@ -79,7 +78,6 @@ RUN echo "Install general purpose packages" && \
         gem install fpm && \
         update-alternatives --install /usr/bin/clang clang /usr/lib/llvm-11/bin/clang 10 && \
         update-alternatives --install /usr/bin/clang++ clang++ /usr/lib/llvm-11/bin/clang++ 10 && \
-        update-alternatives --install /usr/bin/clang-format clang-format /usr/lib/llvm-7/bin/clang-format 10 && \
         update-alternatives --install /usr/bin/clang-tidy clang-tidy /usr/lib/llvm-11/bin/clang-tidy 10 && \
         update-alternatives --install /usr/bin/clang-apply-replacements clang-apply-replacements /usr/lib/llvm-11/bin/clang-apply-replacements 10
 

--- a/lte/gateway/docker/mme/Dockerfile.ubuntu20.04
+++ b/lte/gateway/docker/mme/Dockerfile.ubuntu20.04
@@ -25,7 +25,6 @@ RUN echo "Install general purpouse packages" && \
         build-essential \
         ca-certificates \
         clang-11 \
-        clang-format-7 \
         clang-format-11 \
         clang-tidy-11 \
         curl \
@@ -56,11 +55,9 @@ RUN echo "Install general purpouse packages" && \
         vim \
         wget && \
         gem install fpm && \
-        update-alternatives --install /usr/bin/clang clang /usr/lib/llvm-11/bin/clang 10 && \
-        update-alternatives --install /usr/bin/clang++ clang++ /usr/lib/llvm-11/bin/clang++ 10 \
-        update-alternatives --install /usr/bin/clang-format clang-format /usr/lib/llvm-7/bin/clang-format 10 && \
         update-alternatives --install /usr/bin/clang-tidy clang-tidy /usr/lib/llvm-11/bin/clang-tidy 10 && \
-        update-alternatives --install /usr/bin/clang-apply-replacements clang-apply-replacements /usr/lib/llvm-11/bin/clang-apply-replacements 10
+        update-alternatives --install /usr/bin/clang clang /usr/lib/llvm-11/bin/clang 10 && \
+        update-alternatives --install /usr/bin/clang++ clang++ /usr/lib/llvm-11/bin/clang++ 10
 
 RUN echo "Install 3rd party dependencies" && \
     apt-get update && \


### PR DESCRIPTION
Reverts magma/magma#5939. This appears to be breaking CircleCI Container builds.