### PR TITLE
[Gateway] Fix gateway install script so it can deploy specific version of AGW

### DIFF
--- a/cwf/gateway/docker/.prod_env
+++ b/cwf/gateway/docker/.prod_env
@@ -14,6 +14,7 @@ DOCKER_REGISTRY=cwf_
 DOCKER_USERNAME=
 DOCKER_PASSWORD=
 IMAGE_VERSION=latest
+GIT_HASH=master
 
 BUILD_CONTEXT=https://github.com/magma/magma.git#master
 

--- a/docs/docusaurus/versioned_docs/version-1.4.0/feg/deploy_install.md
+++ b/docs/docusaurus/versioned_docs/version-1.4.0/feg/deploy_install.md
@@ -84,6 +84,7 @@ DOCKER_REGISTRY=<registry>
 DOCKER_USERNAME=<username>
 DOCKER_PASSWORD=<password>
 IMAGE_VERSION=latest
+GIT_HASH=master
 
 ROOTCA_PATH=/var/opt/magma/certs/rootCA.pem
 CONTROL_PROXY_PATH=/etc/magma/control_proxy.yml

--- a/docs/readmes/cwf/deploy_install.md
+++ b/docs/readmes/cwf/deploy_install.md
@@ -80,6 +80,7 @@ DOCKER_REGISTRY=<registry>
 DOCKER_USERNAME=<username>
 DOCKER_PASSWORD=<password>
 IMAGE_VERSION=latest
+GIT_HASH=master
 
 BUILD_CONTEXT=https://github.com/facebookincubator/magma.git#master
 

--- a/docs/readmes/feg/deploy_install.md
+++ b/docs/readmes/feg/deploy_install.md
@@ -84,6 +84,7 @@ DOCKER_REGISTRY=<registry>
 DOCKER_USERNAME=<username>
 DOCKER_PASSWORD=<password>
 IMAGE_VERSION=latest
+GIT_HASH=master
 
 ROOTCA_PATH=/var/opt/magma/certs/rootCA.pem
 CONTROL_PROXY_PATH=/etc/magma/control_proxy.yml

--- a/feg/gateway/docker/.env
+++ b/feg/gateway/docker/.env
@@ -14,6 +14,7 @@ DOCKER_REGISTRY=feg_
 DOCKER_USERNAME=
 DOCKER_PASSWORD=
 IMAGE_VERSION=latest
+GIT_HASH=master
 BUILD_CONTEXT=../../../
 
 ROOTCA_PATH=../../../.cache/test_certs/rootCA.pem

--- a/feg/gateway/docker/.prod_env
+++ b/feg/gateway/docker/.prod_env
@@ -14,6 +14,7 @@ DOCKER_REGISTRY=feg_
 DOCKER_USERNAME=
 DOCKER_PASSWORD=
 IMAGE_VERSION=latest
+GIT_HASH=master
 BUILD_CONTEXT=https://github.com/facebookincubator/magma.git#master
 
 ROOTCA_PATH=/var/opt/magma/certs/rootCA.pem

--- a/orc8r/gateway/docker/.env
+++ b/orc8r/gateway/docker/.env
@@ -12,6 +12,7 @@
 COMPOSE_PROJECT_NAME=magmad
 DOCKER_REGISTRY=magmad_
 IMAGE_VERSION=latest
+GIT_HASH=master
 BUILD_CONTEXT=../../../
 
 ROOTCA_PATH=../../../.cache/test_certs/rootCA.pem

--- a/orc8r/gateway/docker/.prod_env
+++ b/orc8r/gateway/docker/.prod_env
@@ -12,6 +12,7 @@
 COMPOSE_PROJECT_NAME=magmad
 DOCKER_REGISTRY=magmad_
 IMAGE_VERSION=latest
+GIT_HASH=master
 BUILD_CONTEXT=https://github.com/magma/magma.git#master
 
 ROOTCA_PATH=/var/opt/magma/certs/rootCA.pem

--- a/orc8r/tools/docker/install_gateway.sh
+++ b/orc8r/tools/docker/install_gateway.sh
@@ -13,13 +13,15 @@
 
 # This script is intended to install a docker-based gateway deployment
 
+# Both ENV vars are moved in to .env file:
+# GIT_HASH="v1.3.3"
+# IMAGE_VERSION="docker-tag-1.3.3"
 set -e
 
 CWAG="cwag"
 FEG="feg"
 XWF="xwf"
 INSTALL_DIR="/tmp/magmagw_install"
-GIT_HASH="master"
 
 # TODO: Update docker-compose to stable version
 
@@ -69,10 +71,6 @@ MAGMA_GITHUB_URL="https://github.com/magma/magma.git"
 git -C "$INSTALL_DIR" clone "$MAGMA_GITHUB_URL"
 
 source .env
-if [[ $IMAGE_VERSION == *"|"* ]]; then
-  GIT_HASH=$(cut -d'|' -f2 <<< "$IMAGE_VERSION")
-  IMAGE_VERSION=$(cut -d'|' -f1 <<< "$IMAGE_VERSION")
-fi
 
 if [ "$IMAGE_VERSION" != "latest" ]; then
     git -C $INSTALL_DIR/magma checkout "$GIT_HASH"


### PR DESCRIPTION
## Summary
To deploy a specific version of FeG  one should define  **IMAGE_VERSION** in **.env** file as 
```
IMAGE_VERSION="<image-tag>|<magma-tag>"
```
**install_gateway.sh** partially handles this trick but it doe not share any results of **IMAGE_VERSION** parsing with docker-compose or **recreate_services.sh**. So both are failing cause they read the original **IMAGE_VERSION** from **.env**.
Everything works well with default values (which are the magma master branch and the latest image tag) and does not work if we try to redeploy non latest version.

## Test Plan

Deploy FeG with default and version-specific values.
