### PR TITLE
[lte][agw] Bug fix in handling ICS failure

### DIFF
--- a/lte/gateway/c/oai/tasks/mme_app/mme_app_bearer.c
+++ b/lte/gateway/c/oai/tasks/mme_app/mme_app_bearer.c
@@ -1970,7 +1970,7 @@ void mme_app_handle_initial_context_setup_failure(
      * the UE context.
      */
     ue_context_p->ue_context_rel_cause = S1AP_INITIAL_CONTEXT_SETUP_FAILED;
-    if (ue_context_p->mm_state == UE_UNREGISTERED) {
+    if (ue_context_p->mm_state != UE_REGISTERED) {
       // Initiate Implicit Detach for the UE
       nas_proc_implicit_detach_ue_ind(ue_context_p->mme_ue_s1ap_id);
       increment_counter(


### PR DESCRIPTION
## Summary

ICS failure when UE is not in registered state should lead to an implicit detach procedure. The current code was instead checking if the UE was in deregistered state leading to stale entries for UEs that have no pending timers and are between deregistered and registered states.

## Test Plan

Integ tests.
Spirent loading tests that induce ICS failures and create stale entries.

## Additional Information

- [ ] This change is backwards-breaking
