### PR TITLE
[SessionD] Remove non-versioned policies from Activate/Deactivate req…

### DIFF
--- a/lte/gateway/c/session_manager/PipelinedClient.cpp
+++ b/lte/gateway/c/session_manager/PipelinedClient.cpp
@@ -62,10 +62,6 @@ magma::DeactivateFlowsRequest create_deactivate_req(
   req.set_uplink_tunnel(teids.agw_teid());
   req.set_remove_default_drop_flows(remove_default_drop_rules);
   req.mutable_request_origin()->set_type(origin_type);
-  auto ids = req.mutable_rule_ids();
-  for (const auto& rule : to_process.rules) {
-    ids->Add()->assign(rule.id());
-  }
   auto mut_versioned_rules = req.mutable_policies();
   for (uint index = 0; index < to_process.rules.size(); ++index) {
     auto versioned_policy = mut_versioned_rules->Add();
@@ -92,11 +88,6 @@ magma::ActivateFlowsRequest create_activate_req(
   req.mutable_request_origin()->set_type(origin_type);
   if (ambr) {
     req.mutable_apn_ambr()->CopyFrom(*ambr);
-  }
-  // TODO depracate dynamic rules fields
-  auto mut_dyn_rules = req.mutable_dynamic_rules();
-  for (const auto& dyn_rule : to_process.rules) {
-    mut_dyn_rules->Add()->CopyFrom(dyn_rule);
   }
   auto mut_versioned_rules = req.mutable_policies();
   for (uint index = 0; index < to_process.rules.size(); ++index) {

--- a/lte/gateway/c/session_manager/test/Matchers.h
+++ b/lte/gateway/c/session_manager/test/Matchers.h
@@ -248,13 +248,12 @@ MATCHER_P6(
     CheckActivateFlowsForTunnIds, imsi, ipv4, ipv6, enb_teid, agw_teid,
     rule_count, "") {
   auto request = static_cast<const ActivateFlowsRequest*>(arg);
-  std::cerr << "Got dynamic size : " << request->dynamic_rules_size()
-            << std::endl;
+  std::cerr << "Got " << request->policies_size() << " rules" << std::endl;
   auto res = request->sid().id() == imsi && request->ip_addr() == ipv4 &&
              request->ipv6_addr() == ipv6 &&
              request->uplink_tunnel() == agw_teid &&
              request->downlink_tunnel() == enb_teid &&
-             request->dynamic_rules_size() == rule_count;
+             request->policies_size() == rule_count;
   return res;
 }
 


### PR DESCRIPTION
…uests

Signed-off-by: Marie Bremner <marwhal@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary
- Remove the old policy fields in Activate/DeactivateFlows request as we have already transitioned to the version policy fields on PipelineD's end. (https://github.com/magma/magma/pull/5689)
<!-- Enumerate changes you made and why you made them -->

## Test Plan
make precommit_sm
lte integ test
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->

<!--
    Final note

    Please take a moment to read through the Magma project's
    - Contributing conventions: https://docs.magmacore.org/docs/next/contributing/contribute_conventions

    If this is your first time opening a PR, also consider reading
    - Developer onboarding: https://docs.magmacore.org/docs/next/contributing/contribute_onboarding
    - Development workflow: https://docs.magmacore.org/docs/next/contributing/contribute_workflow
-->
