### PR TITLE
[DevExp] Fixup hadolint YML and change filter mode

### DIFF
--- a/.github/workflows/hadolint.yml
+++ b/.github/workflows/hadolint.yml
@@ -1,5 +1,6 @@
+---
 name: Dockerfile Linting
-on: [pull_request]
+on: [pull_request]  # yamllint disable-line rule:truthy
 jobs:
   hadolint:
     name: Dockerfile Lint
@@ -11,7 +12,7 @@ jobs:
         uses: reviewdog/action-hadolint@v1
         with:
           github_token: ${{ secrets.github_token }}
-          reporter: github-pr-review # Default is github-pr-check
+          reporter: github-pr-review  # Default is github-pr-check
           # Ignore DL3005-"Do not use apt-get upgrade or dist-upgrade"
           hadolint_ignore: DL3005
-          filter_mode: file
+          filter_mode: added  # All added or modified lines


### PR DESCRIPTION
Address yamllint findings and move `filter_mode` to `added` instead of `file` to only annotate added or modified PR lines.

Signed-off-by: Scott Harrison Moeller <smoeller@fb.com>
