### PR TITLE
AGW: MME: GTP: add S8 TEID args

### DIFF
--- a/lte/gateway/c/oai/lib/openflow/controller/ControllerEvents.cpp
+++ b/lte/gateway/c/oai/lib/openflow/controller/ControllerEvents.cpp
@@ -144,6 +144,8 @@ AddGTPTunnelEvent::AddGTPTunnelEvent(
       pgw_ip_(INADDR_ZERO),
       in_tei_(in_tei),
       out_tei_(out_tei),
+      pgw_in_tei_(0),
+      pgw_out_tei_(0),
       imsi_(imsi),
       dl_flow_valid_(false),
       dl_flow_(),
@@ -162,6 +164,8 @@ AddGTPTunnelEvent::AddGTPTunnelEvent(
       pgw_ip_(INADDR_ZERO),
       in_tei_(in_tei),
       out_tei_(out_tei),
+      pgw_in_tei_(0),
+      pgw_out_tei_(0),
       imsi_(imsi),
       dl_flow_valid_(true),
       dl_flow_(*dl_flow),
@@ -173,7 +177,8 @@ AddGTPTunnelEvent::AddGTPTunnelEvent(
 AddGTPTunnelEvent::AddGTPTunnelEvent(
     const struct in_addr ue_ip, struct in6_addr* ue_ipv6, int vlan,
     const struct in_addr enb_ip, const struct in_addr pgw_ip,
-    const uint32_t in_tei, const uint32_t out_tei, const char* imsi,
+    const uint32_t in_tei, const uint32_t out_tei, const uint32_t pgw_in_tei,
+    const uint32_t pgw_out_tei, const char* imsi,
     const struct ip_flow_dl* dl_flow, const uint32_t dl_flow_precedence,
     uint32_t enb_gtp_port, uint32_t pgw_gtp_port)
     : ue_info_(ue_ip, ue_ipv6, vlan),
@@ -181,6 +186,8 @@ AddGTPTunnelEvent::AddGTPTunnelEvent(
       pgw_ip_(pgw_ip),
       in_tei_(in_tei),
       out_tei_(out_tei),
+      pgw_in_tei_(pgw_in_tei),
+      pgw_out_tei_(pgw_out_tei),
       imsi_(imsi),
       dl_flow_valid_(false),
       dl_flow_(),
@@ -192,13 +199,16 @@ AddGTPTunnelEvent::AddGTPTunnelEvent(
 AddGTPTunnelEvent::AddGTPTunnelEvent(
     const struct in_addr ue_ip, struct in6_addr* ue_ipv6, int vlan,
     const struct in_addr enb_ip, const struct in_addr pgw_ip,
-    const uint32_t in_tei, const uint32_t out_tei, const char* imsi,
-    uint32_t enb_gtp_port, uint32_t pgw_gtp_port)
+    const uint32_t in_tei, const uint32_t out_tei, const uint32_t pgw_in_tei,
+    const uint32_t pgw_out_tei, const char* imsi, uint32_t enb_gtp_port,
+    uint32_t pgw_gtp_port)
     : ue_info_(ue_ip, vlan),
       enb_ip_(enb_ip),
       pgw_ip_(pgw_ip),
       in_tei_(in_tei),
       out_tei_(out_tei),
+      pgw_in_tei_(pgw_in_tei),
+      pgw_out_tei_(pgw_out_tei),
       imsi_(imsi),
       dl_flow_valid_(false),
       dl_flow_(),
@@ -229,6 +239,14 @@ const uint32_t AddGTPTunnelEvent::get_in_tei() const {
 
 const uint32_t AddGTPTunnelEvent::get_out_tei() const {
   return out_tei_;
+}
+
+const uint32_t AddGTPTunnelEvent::get_pgw_in_tei() const {
+  return pgw_in_tei_;
+}
+
+const uint32_t AddGTPTunnelEvent::get_pgw_out_tei() const {
+  return pgw_out_tei_;
 }
 
 const std::string& AddGTPTunnelEvent::get_imsi() const {

--- a/lte/gateway/c/oai/lib/openflow/controller/ControllerEvents.h
+++ b/lte/gateway/c/oai/lib/openflow/controller/ControllerEvents.h
@@ -187,15 +187,17 @@ class AddGTPTunnelEvent : public ExternalEvent {
   AddGTPTunnelEvent(
       const struct in_addr ue_ip, struct in6_addr* ue_ipv6, int vlan,
       const struct in_addr enb_ip, const struct in_addr pgw_ip,
-      const uint32_t in_tei, const uint32_t out_tei, const char* imsi,
+      const uint32_t in_tei, const uint32_t out_tei, const uint32_t pgw_in_tei,
+      const uint32_t pgw_out_tei, const char* imsi,
       const struct ip_flow_dl* dl_flow, const uint32_t dl_flow_precedence,
       uint32_t enb_gtp_port, uint32_t pgw_gtp_port);
 
   AddGTPTunnelEvent(
       const struct in_addr ue_ip, struct in6_addr* ue_ipv6, int vlan,
       const struct in_addr enb_ip, const struct in_addr pgw_ip,
-      const uint32_t in_tei, const uint32_t out_tei, const char* imsi,
-      uint32_t enb_gtp_port, uint32_t pgw_gtp_port);
+      const uint32_t in_tei, const uint32_t out_tei, const uint32_t pgw_in_tei,
+      const uint32_t pgw_out_tei, const char* imsi, uint32_t enb_gtp_port,
+      uint32_t pgw_gtp_port);
 
   const struct UeNetworkInfo& get_ue_info() const;
   const struct in_addr& get_ue_ip() const;
@@ -206,6 +208,9 @@ class AddGTPTunnelEvent : public ExternalEvent {
 
   const uint32_t get_in_tei() const;
   const uint32_t get_out_tei() const;
+  const uint32_t get_pgw_in_tei() const;
+  const uint32_t get_pgw_out_tei() const;
+
   const std::string& get_imsi() const;
   const bool is_dl_flow_valid() const;
   const struct ip_flow_dl& get_dl_flow() const;
@@ -219,6 +224,8 @@ class AddGTPTunnelEvent : public ExternalEvent {
   const struct in_addr pgw_ip_;
   const uint32_t in_tei_;
   const uint32_t out_tei_;
+  const uint32_t pgw_in_tei_;
+  const uint32_t pgw_out_tei_;
   const std::string imsi_;
   const struct ip_flow_dl dl_flow_;
   const bool dl_flow_valid_;

--- a/lte/gateway/c/oai/lib/openflow/controller/ControllerMain.cpp
+++ b/lte/gateway/c/oai/lib/openflow/controller/ControllerMain.cpp
@@ -126,18 +126,18 @@ int openflow_controller_del_gtp_tunnel(
 
 int openflow_controller_add_gtp_s8_tunnel(
     struct in_addr ue, struct in6_addr* ue_ipv6, int vlan, struct in_addr enb,
-    struct in_addr pgw, uint32_t i_tei, uint32_t o_tei, const char* imsi,
-    struct ip_flow_dl* flow_dl, uint32_t flow_precedence_dl,
-    uint32_t enb_gtp_port, uint32_t pgw_gtp_port) {
+    struct in_addr pgw, uint32_t i_tei, uint32_t o_tei, uint32_t pgw_i_tei,
+    uint32_t pgw_o_tei, const char* imsi, struct ip_flow_dl* flow_dl,
+    uint32_t flow_precedence_dl, uint32_t enb_gtp_port, uint32_t pgw_gtp_port) {
   if (flow_dl) {
     auto add_tunnel = std::make_shared<openflow::AddGTPTunnelEvent>(
-        ue, ue_ipv6, vlan, enb, pgw, i_tei, o_tei, imsi, flow_dl,
-        flow_precedence_dl, enb_gtp_port, pgw_gtp_port);
+        ue, ue_ipv6, vlan, enb, pgw, i_tei, o_tei, pgw_i_tei, pgw_o_tei, imsi,
+        flow_dl, flow_precedence_dl, enb_gtp_port, pgw_gtp_port);
     ctrl.inject_external_event(add_tunnel, external_event_callback);
   } else {
     auto add_tunnel = std::make_shared<openflow::AddGTPTunnelEvent>(
-        ue, ue_ipv6, vlan, enb, pgw, i_tei, o_tei, imsi, enb_gtp_port,
-        pgw_gtp_port);
+        ue, ue_ipv6, vlan, enb, pgw, i_tei, o_tei, pgw_i_tei, pgw_o_tei, imsi,
+        enb_gtp_port, pgw_gtp_port);
     ctrl.inject_external_event(add_tunnel, external_event_callback);
   }
   OAILOG_FUNC_RETURN(LOG_GTPV1U, RETURNok);

--- a/lte/gateway/c/oai/lib/openflow/controller/ControllerMain.h
+++ b/lte/gateway/c/oai/lib/openflow/controller/ControllerMain.h
@@ -56,9 +56,9 @@ int openflow_controller_delete_paging_rule(struct in_addr ue_ip);
 
 int openflow_controller_add_gtp_s8_tunnel(
     struct in_addr ue, struct in6_addr* ue_ipv6, int vlan, struct in_addr enb,
-    struct in_addr pgw, uint32_t i_tei, uint32_t o_tei, const char* imsi,
-    struct ip_flow_dl* flow_dl, uint32_t flow_precedence_dl,
-    uint32_t enb_gtp_port, uint32_t pgw_gtp_port);
+    struct in_addr pgw, uint32_t i_tei, uint32_t o_tei, uint32_t pgw_i_tei,
+    uint32_t pgw_o_tei, const char* imsi, struct ip_flow_dl* flow_dl,
+    uint32_t flow_precedence_dl, uint32_t enb_gtp_port, uint32_t pgw_gtp_port);
 
 int openflow_controller_del_gtp_s8_tunnel(
     struct in_addr ue, struct in6_addr* ue_ipv6, uint32_t i_tei,

--- a/lte/gateway/c/oai/lib/openflow/controller/GTPApplication.cpp
+++ b/lte/gateway/c/oai/lib/openflow/controller/GTPApplication.cpp
@@ -49,12 +49,12 @@ GTPApplication::GTPApplication(
 void GTPApplication::event_callback(
     const ControllerEvent& ev, const OpenflowMessenger& messenger) {
   if (ev.get_type() == EVENT_ADD_GTP_TUNNEL) {
-    printf("pbs: reg add tun");
     auto add_tunnel_event = static_cast<const AddGTPTunnelEvent&>(ev);
     add_uplink_tunnel_flow(add_tunnel_event, messenger);
     add_downlink_tunnel_flow(
-        add_tunnel_event, messenger, uplink_port_num_, false);
-    add_downlink_tunnel_flow(add_tunnel_event, messenger, mtr_port_num_, false);
+        add_tunnel_event, messenger, uplink_port_num_, false, false);
+    add_downlink_tunnel_flow(
+        add_tunnel_event, messenger, mtr_port_num_, false, false);
     add_downlink_arp_flow(add_tunnel_event, messenger, uplink_port_num_);
     add_downlink_arp_flow(add_tunnel_event, messenger, mtr_port_num_);
   } else if (ev.get_type() == EVENT_DELETE_GTP_TUNNEL) {
@@ -65,16 +65,22 @@ void GTPApplication::event_callback(
     delete_downlink_arp_flow(del_tunnel_event, messenger, uplink_port_num_);
     delete_downlink_arp_flow(del_tunnel_event, messenger, mtr_port_num_);
   } else if (ev.get_type() == EVENT_ADD_GTP_S8_TUNNEL) {
-    printf("pbs: S8 add tun");
 
     auto add_tunnel_event = static_cast<const AddGTPTunnelEvent&>(ev);
+    auto imsi = IMSIEncoder::compact_imsi(add_tunnel_event.get_imsi());
+
+    OAILOG_DEBUG_UE(LOG_GTPV1U, imsi, "s8: add: TEID: s1-in %u s1-out %u s8-in %u s8-out %u\n",
+    add_tunnel_event.get_in_tei(), add_tunnel_event.get_out_tei(),
+    add_tunnel_event.get_pgw_in_tei(), add_tunnel_event.get_pgw_out_tei());
+
     add_uplink_s8_tunnel_flow(add_tunnel_event, messenger);
     int pgw_port = add_tunnel_event.get_pgw_gtp_portno();
     if (pgw_port == 0) {
       pgw_port = GTPApplication::gtp0_port_num_;
     }
-    add_downlink_tunnel_flow(add_tunnel_event, messenger, pgw_port, true);
-    add_downlink_tunnel_flow(add_tunnel_event, messenger, mtr_port_num_, true);
+    add_downlink_tunnel_flow(add_tunnel_event, messenger, pgw_port, true, true);
+    add_downlink_tunnel_flow(
+        add_tunnel_event, messenger, mtr_port_num_, true, true);
     add_downlink_arp_flow(add_tunnel_event, messenger, mtr_port_num_);
   } else if (ev.get_type() == EVENT_DELETE_GTP_S8_TUNNEL) {
     auto del_tunnel_event = static_cast<const DeleteGTPTunnelEvent&>(ev);
@@ -207,7 +213,7 @@ void GTPApplication::add_uplink_s8_tunnel_flow(
   add_tunnel_match(uplink_fm, ev.get_enb_gtp_portno(), ev.get_in_tei());
 
   add_tunnel_flow_action(
-      ev.get_out_tei(), ev.get_in_tei(), ev.get_imsi(), ev.get_pgw_ip(),
+      ev.get_pgw_out_tei(), ev.get_in_tei(), ev.get_imsi(), ev.get_pgw_ip(),
       ev.get_pgw_gtp_portno(), ev.get_connection(), messenger, uplink_fm,
       "S8 Uplink", true);
 }
@@ -412,28 +418,36 @@ void GTPApplication::add_tunnel_flow_action(
 
 void GTPApplication::add_downlink_tunnel_flow_action(
     const AddGTPTunnelEvent& ev, const OpenflowMessenger& messenger,
-    of13::FlowMod downlink_fm, bool passthrough) {
+    of13::FlowMod downlink_fm, bool passthrough, bool from_pgw) {
+  uint32_t in_teid;
+  if (from_pgw) {
+    in_teid = ev.get_in_tei();
+  } else {
+    in_teid = ev.get_in_tei();
+  }
+
   add_tunnel_flow_action(
-      ev.get_out_tei(), ev.get_in_tei(), ev.get_imsi(), ev.get_enb_ip(),
+      ev.get_out_tei(), in_teid, ev.get_imsi(), ev.get_enb_ip(),
       ev.get_enb_gtp_portno(), ev.get_connection(), messenger, downlink_fm,
       "S1 Downlink", passthrough);
 }
 
 void GTPApplication::add_downlink_tunnel_flow_ipv4(
     const AddGTPTunnelEvent& ev, const OpenflowMessenger& messenger,
-    uint32_t ingress_port, bool passthrough) {
+    uint32_t ingress_port, bool passthrough, bool from_pgw) {
   uint32_t flow_priority =
       convert_precedence_to_priority(ev.get_dl_flow_precedence());
   of13::FlowMod downlink_fm =
       messenger.create_default_flow_mod(0, of13::OFPFC_ADD, flow_priority);
 
   add_downlink_match(downlink_fm, ev.get_ue_ip(), ingress_port);
-  add_downlink_tunnel_flow_action(ev, messenger, downlink_fm, passthrough);
+  add_downlink_tunnel_flow_action(
+      ev, messenger, downlink_fm, passthrough, from_pgw);
 }
 
 void GTPApplication::add_downlink_tunnel_flow_ipv6(
     const AddGTPTunnelEvent& ev, const OpenflowMessenger& messenger,
-    uint32_t ingress_port, bool passthrough) {
+    uint32_t ingress_port, bool passthrough, bool from_pgw) {
   uint32_t flow_priority =
       convert_precedence_to_priority(ev.get_dl_flow_precedence());
   of13::FlowMod downlink_fm =
@@ -441,35 +455,40 @@ void GTPApplication::add_downlink_tunnel_flow_ipv6(
 
   add_downlink_match_ipv6(
       downlink_fm, ev.get_ue_info().get_ipv6(), ingress_port);
-  add_downlink_tunnel_flow_action(ev, messenger, downlink_fm, passthrough);
+  add_downlink_tunnel_flow_action(
+      ev, messenger, downlink_fm, passthrough, from_pgw);
 }
 
 void GTPApplication::add_downlink_tunnel_flow_ded_brr(
     const AddGTPTunnelEvent& ev, const OpenflowMessenger& messenger,
-    uint32_t ingress_port, bool passthrough) {
+    uint32_t ingress_port, bool passthrough, bool from_pgw) {
   uint32_t flow_priority =
       convert_precedence_to_priority(ev.get_dl_flow_precedence());
   of13::FlowMod downlink_fm =
       messenger.create_default_flow_mod(0, of13::OFPFC_ADD, flow_priority);
 
   add_ded_brr_dl_match(downlink_fm, ev.get_dl_flow(), ingress_port);
-  add_downlink_tunnel_flow_action(ev, messenger, downlink_fm, passthrough);
+  add_downlink_tunnel_flow_action(
+      ev, messenger, downlink_fm, passthrough, from_pgw);
 }
 
 void GTPApplication::add_downlink_tunnel_flow(
     const AddGTPTunnelEvent& ev, const OpenflowMessenger& messenger,
-    uint32_t ingress_port, bool passthrough) {
+    uint32_t ingress_port, bool passthrough, bool from_pgw) {
   if (ev.is_dl_flow_valid()) {
-    add_downlink_tunnel_flow_ded_brr(ev, messenger, ingress_port, passthrough);
+    add_downlink_tunnel_flow_ded_brr(
+        ev, messenger, ingress_port, passthrough, from_pgw);
     return;
   }
   UeNetworkInfo ue_info = ev.get_ue_info();
 
   if (ue_info.is_ue_ipv4_addr_valid()) {
-    add_downlink_tunnel_flow_ipv4(ev, messenger, ingress_port, passthrough);
+    add_downlink_tunnel_flow_ipv4(
+        ev, messenger, ingress_port, passthrough, from_pgw);
   }
   if (ue_info.is_ue_ipv6_addr_valid()) {
-    add_downlink_tunnel_flow_ipv6(ev, messenger, ingress_port, passthrough);
+    add_downlink_tunnel_flow_ipv6(
+        ev, messenger, ingress_port, passthrough, from_pgw);
   }
 }
 

--- a/lte/gateway/c/oai/lib/openflow/controller/GTPApplication.cpp
+++ b/lte/gateway/c/oai/lib/openflow/controller/GTPApplication.cpp
@@ -421,7 +421,7 @@ void GTPApplication::add_downlink_tunnel_flow_action(
     of13::FlowMod downlink_fm, bool passthrough, bool from_pgw) {
   uint32_t in_teid;
   if (from_pgw) {
-    in_teid = ev.get_in_tei();
+    in_teid = ev.get_pgw_in_tei();
   } else {
     in_teid = ev.get_in_tei();
   }

--- a/lte/gateway/c/oai/lib/openflow/controller/GTPApplication.h
+++ b/lte/gateway/c/oai/lib/openflow/controller/GTPApplication.h
@@ -63,7 +63,7 @@ class GTPApplication : public Application {
    */
   void add_downlink_tunnel_flow(
       const AddGTPTunnelEvent& ev, const OpenflowMessenger& messenger,
-      uint32_t port_number, bool passthrough);
+      uint32_t port_number, bool passthrough, bool from_pgw);
 
   /*
    * Add downlink tunnel flow for S8
@@ -181,17 +181,17 @@ class GTPApplication : public Application {
 
   void add_downlink_tunnel_flow_action(
       const AddGTPTunnelEvent& ev, const OpenflowMessenger& messenger,
-      of13::FlowMod downlink_fm, bool passthrough);
+      of13::FlowMod downlink_fm, bool passthrough, bool from_pgw);
 
   void add_downlink_tunnel_flow_ipv4(
       const AddGTPTunnelEvent& ev, const OpenflowMessenger& messenger,
-      uint32_t port_number, bool passthrough);
+      uint32_t port_number, bool passthrough, bool from_pgw);
   void add_downlink_tunnel_flow_ipv6(
       const AddGTPTunnelEvent& ev, const OpenflowMessenger& messenger,
-      uint32_t port_number, bool passthrough);
+      uint32_t port_number, bool passthrough, bool from_pgw);
   void add_downlink_tunnel_flow_ded_brr(
       const AddGTPTunnelEvent& ev, const OpenflowMessenger& messenger,
-      uint32_t port_number, bool passthrough);
+      uint32_t port_number, bool passthrough, bool from_pgw);
 
   void delete_downlink_tunnel_flow_ipv4(
       const DeleteGTPTunnelEvent& ev, const OpenflowMessenger& messenger,

--- a/lte/gateway/c/oai/tasks/gtpv1-u/gtp_tunnel_openflow.c
+++ b/lte/gateway/c/oai/tasks/gtpv1-u/gtp_tunnel_openflow.c
@@ -270,14 +270,16 @@ int openflow_del_tunnel(
 /* S8 tunnel related APIs */
 int openflow_add_s8_tunnel(
     struct in_addr ue, struct in6_addr* ue_ipv6, int vlan, struct in_addr enb,
-    struct in_addr pgw, uint32_t i_tei, uint32_t o_tei, Imsi_t imsi,
-    struct ip_flow_dl* flow_dl, uint32_t flow_precedence_dl) {
+    struct in_addr pgw, uint32_t i_tei, uint32_t o_tei, uint32_t pgw_i_tei,
+    uint32_t pgw_o_tei, Imsi_t imsi, struct ip_flow_dl* flow_dl,
+    uint32_t flow_precedence_dl) {
   uint32_t enb_portno = find_gtp_port_no(enb);
   uint32_t pgw_portno = find_gtp_port_no(pgw);
 
   return openflow_controller_add_gtp_s8_tunnel(
-      ue, ue_ipv6, vlan, enb, pgw, i_tei, o_tei, (const char*) imsi.digit,
-      flow_dl, flow_precedence_dl, enb_portno, pgw_portno);
+      ue, ue_ipv6, vlan, enb, pgw, i_tei, o_tei, pgw_i_tei, pgw_o_tei,
+      (const char*) imsi.digit, flow_dl, flow_precedence_dl, enb_portno,
+      pgw_portno);
 }
 
 int openflow_del_s8_tunnel(

--- a/lte/gateway/c/oai/tasks/gtpv1-u/gtpv1u.h
+++ b/lte/gateway/c/oai/tasks/gtpv1-u/gtpv1u.h
@@ -145,8 +145,9 @@ struct gtp_tunnel_ops {
       uint32_t i_tei, uint32_t o_tei, struct ip_flow_dl* flow_dl);
   int (*add_s8_tunnel)(
       struct in_addr ue, struct in6_addr* ue_ipv6, int vlan, struct in_addr enb,
-      struct in_addr pgw, uint32_t i_tei, uint32_t o_tei, Imsi_t imsi,
-      struct ip_flow_dl* flow_dl, uint32_t flow_precedence_dl);
+      struct in_addr pgw, uint32_t i_tei, uint32_t o_tei, uint32_t pgw_i_tei,
+      uint32_t pgw_o_tei, Imsi_t imsi, struct ip_flow_dl* flow_dl,
+      uint32_t flow_precedence_dl);
   int (*del_s8_tunnel)(
       struct in_addr enb, struct in_addr pgw, struct in_addr ue,
       struct in6_addr* ue_ipv6, uint32_t i_tei, uint32_t o_tei,
@@ -176,6 +177,7 @@ int gtpv1u_add_tunnel(
 
 int gtpv1u_add_s8_tunnel(
     struct in_addr ue, struct in6_addr* ue_ipv6, int vlan, struct in_addr enb,
-    struct in_addr pgw, uint32_t i_tei, uint32_t o_tei, Imsi_t imsi,
-    struct ip_flow_dl* flow_dl, uint32_t flow_precedence_dl);
+    struct in_addr pgw, uint32_t i_tei, uint32_t o_tei, uint32_t pgw_i_tei,
+    uint32_t pgw_o_tei, Imsi_t imsi, struct ip_flow_dl* flow_dl,
+    uint32_t flow_precedence_dl);
 #endif /* FILE_GTPV1_U_SEEN */

--- a/lte/gateway/c/oai/tasks/gtpv1-u/gtpv1u_task.c
+++ b/lte/gateway/c/oai/tasks/gtpv1-u/gtpv1u_task.c
@@ -202,13 +202,14 @@ int gtpv1u_add_tunnel(
 
 int gtpv1u_add_s8_tunnel(
     struct in_addr ue, struct in6_addr* ue_ipv6, int vlan, struct in_addr enb,
-    struct in_addr pgw, uint32_t i_tei, uint32_t o_tei, Imsi_t imsi,
-    struct ip_flow_dl* flow_dl, uint32_t flow_precedence_dl) {
+    struct in_addr pgw, uint32_t i_tei, uint32_t o_tei, uint32_t pgw_i_tei,
+    uint32_t pgw_o_tei, Imsi_t imsi, struct ip_flow_dl* flow_dl,
+    uint32_t flow_precedence_dl) {
   OAILOG_DEBUG(LOG_GTPV1U, "Add S8 tunnel ue %s", inet_ntoa(ue));
   if (gtp_tunnel_ops->add_s8_tunnel) {
     return gtp_tunnel_ops->add_s8_tunnel(
-        ue, ue_ipv6, vlan, enb, pgw, i_tei, o_tei, imsi, flow_dl,
-        flow_precedence_dl);
+        ue, ue_ipv6, vlan, enb, pgw, i_tei, o_tei, pgw_i_tei, pgw_o_tei, imsi,
+        flow_dl, flow_precedence_dl);
   } else {
     return -EINVAL;
   }

--- a/lte/gateway/c/oai/tasks/sgw_s8/sgw_s8_handlers.c
+++ b/lte/gateway/c/oai/tasks/sgw_s8/sgw_s8_handlers.c
@@ -551,7 +551,8 @@ static int sgw_s8_add_gtp_tunnel(
       rv = gtpv1u_add_s8_tunnel(
           ue_ipv4, ue_ipv6, vlan, enb, pgw,
           eps_bearer_ctxt_p->s_gw_teid_S1u_S12_S4_up,
-          eps_bearer_ctxt_p->enb_teid_S1u, imsi, NULL, DEFAULT_PRECEDENCE);
+          eps_bearer_ctxt_p->enb_teid_S1u, 0, 0, imsi, NULL,
+          DEFAULT_PRECEDENCE);
       if (rv < 0) {
         OAILOG_ERROR_UE(
             LOG_SGW_S8, sgw_context_p->imsi64,

--- a/lte/gateway/c/oai/test/openflow/test_gtp_app.cpp
+++ b/lte/gateway/c/oai/test/openflow/test_gtp_app.cpp
@@ -911,17 +911,20 @@ TEST_F(GTPApplicationTest, TestAddTunnelS8) {
   struct in_addr enb_ip;
   enb_ip.s_addr = inet_addr("0.0.0.2");
   struct in_addr pgw_ip;
-  enb_ip.s_addr    = inet_addr("0.0.0.22");
-  uint32_t in_tei  = 1;
-  uint32_t out_tei = 2;
-  char imsi[]      = "001010000000013";
-  int vlan         = 0;
-  int enb_port     = 100;
-  int pgw_port     = 200;
+  enb_ip.s_addr        = inet_addr("0.0.0.22");
+  uint32_t in_tei      = 1;
+  uint32_t out_tei     = 2;
+  uint32_t pgw_in_tei  = 3;
+  uint32_t pgw_out_tei = 4;
+
+  char imsi[]  = "001010000000013";
+  int vlan     = 0;
+  int enb_port = 100;
+  int pgw_port = 200;
 
   AddGTPTunnelEvent add_tunnel(
-      ue_ip, NULL, vlan, enb_ip, pgw_ip, in_tei, out_tei, imsi, enb_port,
-      pgw_port);
+      ue_ip, NULL, vlan, enb_ip, pgw_ip, in_tei, out_tei, pgw_in_tei,
+      pgw_out_tei, imsi, enb_port, pgw_port);
   // Uplink
   EXPECT_CALL(
       *messenger,


### PR DESCRIPTION
Add missing TEIDs to program flow from eNB to PGW and vice-versa.
now the API takes in in and out TEID for S1 (eNB) tunnel as well as
S8 (PGW) tunnel.

Signed-off-by: Pravin B Shelar <pbshelar@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->

<!--
    Final note

    Please take a moment to read through the Magma project's
    - Contributing conventions: https://docs.magmacore.org/docs/next/contributing/contribute_conventions

    If this is your first time opening a PR, also consider reading
    - Developer onboarding: https://docs.magmacore.org/docs/next/contributing/contribute_onboarding
    - Development workflow: https://docs.magmacore.org/docs/next/contributing/contribute_workflow
-->
