### PR TITLE
[Sentry][AGW] Handle env var lookup error better in sentry init

### DIFF
--- a/orc8r/gateway/python/magma/common/sentry.py
+++ b/orc8r/gateway/python/magma/common/sentry.py
@@ -12,21 +12,36 @@ limitations under the License.
 """
 
 import os
+
 import sentry_sdk
 import snowflake
-
 from magma.configuration.service_configs import get_service_config_value
 
+CONTROL_PROXY = 'control_proxy'
+SENTRY_URL = 'sentry_url'
+SENTRY_SAMPLE_RATE = 'sentry_sample_rate'
+COMMIT_HASH = 'COMMIT_HASH'
+HWID = 'hwid'
+
+
 def sentry_init():
-    """
-    Initialize connection and start piping errors to sentry.io
-    """
-    sentry_url = get_service_config_value('control_proxy', 'sentry_url', default="")
-    if sentry_url:
-        sentry_sample_rate = get_service_config_value('control_proxy', 'sentry_sample_rate', default=1.0)
-        sentry_sdk.init(
-            dsn=sentry_url, 
-            release=os.environ['COMMIT_HASH'],
-            traces_sample_rate=sentry_sample_rate, 
-        )
-        sentry_sdk.set_tag("hwid", snowflake.snowflake())
+    """Initialize connection and start piping errors to sentry.io."""
+    sentry_url = get_service_config_value(
+        CONTROL_PROXY,
+        SENTRY_URL,
+        default='',
+    )
+    if not sentry_url:
+        return
+
+    sentry_sample_rate = get_service_config_value(
+        CONTROL_PROXY,
+        SENTRY_SAMPLE_RATE,
+        default=1.0,
+    )
+    sentry_sdk.init(
+        dsn=sentry_url,
+        release=os.getenv(COMMIT_HASH),
+        traces_sample_rate=sentry_sample_rate,
+    )
+    sentry_sdk.set_tag(HWID, snowflake.snowflake())


### PR DESCRIPTION
Signed-off-by: Marie Bremner <marwhal@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary
- `os.environ['COMMIT_HASH']` can throw an error when the environment doesn't exist so using `os.getenv` instead.
- Addressing all lint warnings from the file along the way
<!-- Enumerate changes you made and why you made them -->

## Test Plan
Ran through the case where the environment doesn't exist locally
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->

<!--
    Final note

    Please take a moment to read through the Magma project's
    - Contributing conventions: https://docs.magmacore.org/docs/next/contributing/contribute_conventions

    If this is your first time opening a PR, also consider reading
    - Developer onboarding: https://docs.magmacore.org/docs/next/contributing/contribute_onboarding
    - Development workflow: https://docs.magmacore.org/docs/next/contributing/contribute_workflow
-->
