### PR TITLE
[fuji] NMS DB data migration uses sequelize-models ^0.1.6

### DIFF
--- a/nms/app/packages/magmalte/scripts/fuji-upgrade/runs-on-nms.sh
+++ b/nms/app/packages/magmalte/scripts/fuji-upgrade/runs-on-nms.sh
@@ -44,11 +44,11 @@ done
 
 cat << EOF
 --------------------------------------------------------------------------------
-              Upgrading @fbcnms/sequelize-models to ^0.1.5
+              Upgrading @fbcnms/sequelize-models to ^0.1.6
 --------------------------------------------------------------------------------
 EOF
 pushd /usr/src/packages/magmalte
-yarn upgrade @fbcnms/sequelize-models@^0.1.5
+yarn upgrade @fbcnms/sequelize-models@^0.1.6
 yarn
 popd
 cat << EOF


### PR DESCRIPTION
Signed-off-by: Andrei Lee <andreilee@fb.com>

## Summary

For NMS/orc8r DB unification, the `@fbcnms/sequelize-models` package is used. Version 0.1.6 includes a fix for migrating the `SequelizeMeta` table.

## Test Plan

[See here](https://github.com/facebookincubator/fbc-js-core/pull/84)

## Additional Information

- [ ] This change is backwards-breaking

<!--
    Final note

    Please take a moment to read through the Magma project's
    - Contributing conventions: https://docs.magmacore.org/docs/next/contributing/contribute_conventions

    If this is your first time opening a PR, also consider reading
    - Developer onboarding: https://docs.magmacore.org/docs/next/contributing/contribute_onboarding
    - Development workflow: https://docs.magmacore.org/docs/next/contributing/contribute_workflow
-->
