### PR TITLE
[5G: MVC][component: agw][type: enhancement]  AMF Base Timers

### DIFF
--- a/lte/gateway/c/oai/tasks/amf/Registration.cpp
+++ b/lte/gateway/c/oai/tasks/amf/Registration.cpp
@@ -578,7 +578,8 @@ int amf_send_registration_accept(amf_context_t* amf_context) {
       OAILOG_INFO(LOG_AMF_APP, "Timer: registration_accept timer start\n");
       registration_proc->T3550.id = start_timer(
           &amf_app_task_zmq_ctx, REGISTRATION_ACCEPT_TIMER_EXPIRY_MSECS,
-          TIMER_REPEAT_ONCE, registration_accept_t3550_handler, NULL);
+          TIMER_REPEAT_ONCE, registration_accept_t3550_handler,
+          (void*) registration_proc->ue_id);
       OAILOG_INFO(
           LOG_AMF_APP,
           "Timer: Registration_accept timer T3550 with id  %d Started\n",
@@ -594,18 +595,22 @@ static int registration_accept_t3550_handler(
   amf_context_t* amf_ctx                         = NULL;
   ue_m5gmm_context_s* ue_amf_context             = NULL;
   nas_amf_registration_proc_t* registration_proc = NULL;
+  amf_ue_ngap_id_t ue_id                         = 0;
+
+  ue_id = *((amf_ue_ngap_id_t*) (arg));
   /*
    * Get the UE context
    */
-  //  ue_amf_context = amf_ue_context_exists_amf_ue_ngap_id(ue_id);
-  ue_amf_context =
-      &ue_m5gmm_global_context;  // TODO AMF_TEST global var to temporarily
+  ue_amf_context = amf_ue_context_exists_amf_ue_ngap_id(ue_id);
 
-  if (ue_amf_context) {
-    registration_proc =
-        (nas_amf_registration_proc_t*)
-            ue_amf_context->amf_context.amf_procedures->amf_specific_proc;
+  if (ue_amf_context == NULL) {
+    OAILOG_INFO(LOG_AMF_APP, "AMF_TEST: ue_context is NULL\n");
+    return -1;
   }
+
+  registration_proc =
+      (nas_amf_registration_proc_t*)
+          ue_amf_context->amf_context.amf_procedures->amf_specific_proc;
 
   OAILOG_INFO(
       LOG_AMF_APP, "Timer: In _registration_t3550_handler - T3550 id %p\n",

--- a/lte/gateway/c/oai/tasks/amf/Registration.cpp
+++ b/lte/gateway/c/oai/tasks/amf/Registration.cpp
@@ -18,6 +18,8 @@ extern "C" {
 #include "log.h"
 #include "3gpp_24.501.h"
 #include "conversions.h"
+#include "intertask_interface_types.h"
+#include "intertask_interface.h"
 #ifdef __cplusplus
 }
 #endif
@@ -34,7 +36,7 @@ extern "C" {
 #define INVALID_AMF_UE_NGAP_ID 0x0
 
 namespace magma5g {
-
+extern task_zmq_ctx_s amf_app_task_zmq_ctx;
 amf_as_data_t amf_data_sec;
 nas_amf_smc_proc_t smc_proc;
 static int amf_registration_failure_authentication_cb(
@@ -48,6 +50,8 @@ static int amf_registration_failure_security_cb(amf_context_t* amf_context);
 
 static int amf_registration_reject(
     amf_context_t* amf_context, nas_amf_registration_proc_t* nas_base_proc);
+static int registration_accept_t3550_handler(
+    zloop_t* loop, int timer_id, void* arg);
 
 /***************************************************************************
 **                                                                        **
@@ -569,27 +573,71 @@ int amf_send_registration_accept(amf_context_t* amf_context) {
       amf_sap.u.amf_as.u.establish.guti = amf_context->m5_guti;
 
       /*
-       * Get the activate default 5GMM PDu Session context request message to
-       * transfer within the SMF container of the Registration accept message
+       * Start T3550 timer
        */
-      amf_sap.u.amf_as.u.establish.nas_msg = registration_proc->amf_msg_out;
-      OAILOG_TRACE(
-          LOG_NAS_AMF,
-          "ue_id= " AMF_UE_NGAP_ID_FMT
-          " AMF-PROC  - nas_msg  src size = %d nas_msg  dst size = %d \n",
-          ue_id, blength(registration_proc->amf_msg_out),
-          blength(amf_sap.u.amf_as.u.establish.nas_msg));
-
-      rc = amf_sap_send(&amf_sap);
-
-      if (RETURNerror == rc) {
-        OAILOG_DEBUG(
-            LOG_NAS_AMF, " AMF-PROC  - Sending to access point failed\n");
-      }
-    } else {
-      OAILOG_ERROR(
-          LOG_NAS_AMF, " AMF-PROC  - Registration Procedure not found\n");
+      OAILOG_INFO(LOG_AMF_APP, "Timer: registration_accept timer start\n");
+      registration_proc->T3550.id = start_timer(
+          &amf_app_task_zmq_ctx, REGISTRATION_ACCEPT_TIMER_EXPIRY_MSECS,
+          TIMER_REPEAT_ONCE, registration_accept_t3550_handler, NULL);
+      OAILOG_INFO(
+          LOG_AMF_APP,
+          "Timer: Registration_accept timer T3550 with id  %d Started\n",
+          registration_proc->T3550.id);
     }
+  } 
+  OAILOG_FUNC_RETURN(LOG_NAS_AMF, rc);
+}
+
+static int registration_accept_t3550_handler(
+    zloop_t* loop, int timer_id, void* arg) {
+  OAILOG_INFO(LOG_AMF_APP, "Timer: In registration_accept_t3550 handler\n");
+  amf_context_t* amf_ctx                         = NULL;
+  ue_m5gmm_context_s* ue_amf_context             = NULL;
+  nas_amf_registration_proc_t* registration_proc = NULL;
+  /*
+   * Get the UE context
+   */
+  //  ue_amf_context = amf_ue_context_exists_amf_ue_ngap_id(ue_id);
+  ue_amf_context =
+      &ue_m5gmm_global_context;  // TODO AMF_TEST global var to temporarily
+
+  if (ue_amf_context) {
+    registration_proc =
+        (nas_amf_registration_proc_t*)
+            ue_amf_context->amf_context.amf_procedures->amf_specific_proc;
+  }
+
+  OAILOG_INFO(
+      LOG_AMF_APP, "Timer: In _registration_t3550_handler - T3550 id %p\n",
+      registration_proc);
+  if (registration_proc) {
+    OAILOG_WARNING(
+        LOG_AMF_APP, "T3550 timer   timer id %d ue id %d\n",
+        registration_proc->T3550.id, registration_proc->ue_id);
+    registration_proc->T3550.id = -1;
+
+    registration_proc->retransmission_count += 1;
+    OAILOG_ERROR(
+        LOG_AMF_APP, "Timer: Incrementing retransmission_count to %d\n",
+        registration_proc->retransmission_count);
+    if (registration_proc->retransmission_count < REGISTRATION_COUNTER_MAX) {
+      /* Send entity Registration request message to the UE */
+
+      OAILOG_ERROR(
+          LOG_AMF_APP,
+          "Timer: timer has expired Sending Registration request again\n");
+      // amf_registration_request(registration_proc); /* TO DO for negative scenario */
+    } else {
+      /* Abort the registration procedure */
+
+      OAILOG_ERROR(
+          LOG_AMF_APP,
+          "Timer: Maximum retires done hence Abort the registration "
+          "procedure\n");
+      return -1;
+    }
+
+    return 0;
   }
   OAILOG_FUNC_RETURN(LOG_NAS_AMF, rc);
 }
@@ -726,6 +774,12 @@ int amf_proc_registration_complete(
           (nas_amf_registration_proc_t*)
               ue_amf_context->amf_context.amf_procedures->amf_specific_proc;
       amf_ctx = &ue_amf_context->amf_context;
+
+      stop_timer(&amf_app_task_zmq_ctx, registration_proc->T3550.id);
+      OAILOG_INFO(
+          LOG_AMF_APP, "Timer: after stop registration timer with id = %d\n",
+          registration_proc->T3550.id);
+
       /*
        * Upon receiving an REGISTRATION COMPLETE message, the AMF shall enter
        * state AMF-REGISTERED and consider the GUTI sent in the REGISTRATION

--- a/lte/gateway/c/oai/tasks/amf/Registration.cpp
+++ b/lte/gateway/c/oai/tasks/amf/Registration.cpp
@@ -256,7 +256,7 @@ int amf_proc_registration_reject(
 **                                                                        **
 **                                                                        **
 ***************************************************************************/
-static int amf_registration_reject(
+int amf_registration_reject(
     amf_context_t* amf_context, nas_amf_registration_proc_t* nas_base_proc) {
   OAILOG_FUNC_IN(LOG_NAS_AMF);
   int rc = RETURNerror;
@@ -584,7 +584,7 @@ int amf_send_registration_accept(amf_context_t* amf_context) {
           "Timer: Registration_accept timer T3550 with id  %d Started\n",
           registration_proc->T3550.id);
     }
-  } 
+  }
   OAILOG_FUNC_RETURN(LOG_NAS_AMF, rc);
 }
 
@@ -626,7 +626,8 @@ static int registration_accept_t3550_handler(
       OAILOG_ERROR(
           LOG_AMF_APP,
           "Timer: timer has expired Sending Registration request again\n");
-      // amf_registration_request(registration_proc); /* TO DO for negative scenario */
+      // amf_registration_request(registration_proc); /* TO DO for negative
+      // scenario */
     } else {
       /* Abort the registration procedure */
 
@@ -639,7 +640,7 @@ static int registration_accept_t3550_handler(
 
     return 0;
   }
-  OAILOG_FUNC_RETURN(LOG_NAS_AMF, rc);
+  OAILOG_FUNC_RETURN(LOG_NAS_AMF, 0);
 }
 
 /****************************************************************************
@@ -824,6 +825,37 @@ int amf_proc_registration_complete(
      * resquest comes along with Inital Registration request.
      */
   }
+  OAILOG_FUNC_RETURN(LOG_NAS_AMF, rc);
+}
+
+/****************************************************************************
+ **                                                                        **
+ ** Name:    amf_handle_registration_complete_response()                    **
+ **                                                                        **
+ ** Description: Processes registration Complete message                   **
+ **                                                                        **
+ ** Inputs:  ue_id:      UE lower layer identifier                         **
+ **      msg:       The received AMF message                               **
+ **      Others:    None                                                   **
+ **                                                                        **
+ ** Outputs:     amf_cause: AMF cause code                                 **
+ **      Return:    RETURNok, RETURNerror                                  **
+ **      Others:    None                                                   **
+ **                                                                        **
+ ***************************************************************************/
+int amf_handle_registration_complete_response(
+    amf_ue_ngap_id_t ue_id, RegistrationCompleteMsg* msg, int amf_cause,
+    amf_nas_message_decode_status_t status) {
+  OAILOG_FUNC_IN(LOG_NAS_AMF);
+  int rc;
+  OAILOG_DEBUG(
+      LOG_NAS_AMF,
+      "AMFAS-SAP - received registration complete message for ue_id = (%u)\n",
+      ue_id);
+  /*
+   * Execute the registration procedure completion
+   */
+  rc = amf_proc_registration_complete(ue_id, msg->smf_pdu, amf_cause, status);
   OAILOG_FUNC_RETURN(LOG_NAS_AMF, rc);
 }
 

--- a/lte/gateway/c/oai/tasks/amf/Registration.cpp
+++ b/lte/gateway/c/oai/tasks/amf/Registration.cpp
@@ -256,7 +256,7 @@ int amf_proc_registration_reject(
 **                                                                        **
 **                                                                        **
 ***************************************************************************/
-int amf_registration_reject(
+static int amf_registration_reject(
     amf_context_t* amf_context, nas_amf_registration_proc_t* nas_base_proc) {
   OAILOG_FUNC_IN(LOG_NAS_AMF);
   int rc = RETURNerror;
@@ -699,48 +699,6 @@ int amf_send_registration_accept_dl_nas(
   offset++;
   amf_msg->mobile_id.mobile_identity.guti.tmsi3 = *offset;
   OAILOG_FUNC_RETURN(LOG_NAS_AMF, size);
-}
-
-/****************************************************************************
- **                                                                        **
- ** Name:    amf_handle_registration_complete_response()                    **
- **                                                                        **
- ** Description: Processes registration Complete message                   **
- **                                                                        **
- ** Inputs:  ue_id:      UE lower layer identifier                         **
- **      msg:       The received AMF message                               **
- **      Others:    None                                                   **
- **                                                                        **
- ** Outputs:     amf_cause: AMF cause code                                 **
- **      Return:    RETURNok, RETURNerror                                  **
- **      Others:    None                                                   **
- **                                                                        **
- ***************************************************************************/
-int amf_handle_registration_complete_response(
-    amf_ue_ngap_id_t ue_id, RegistrationCompleteMsg* msg, int amf_cause,
-    amf_nas_message_decode_status_t status) {
-  OAILOG_FUNC_IN(LOG_NAS_AMF);
-  int rc;
-  ue_m5gmm_context_s* ue_m5gmm_context = NULL;
-  OAILOG_DEBUG(
-      LOG_NAS_AMF,
-      "AMFAS-SAP - received registration complete message for ue_id = (%u)\n",
-      ue_id);
-  /*
-   * Execute the registration procedure completion
-   */
-
-  ue_m5gmm_context = amf_ue_context_exists_amf_ue_ngap_id(ue_id);
-  if (ue_m5gmm_context == NULL) {
-    OAILOG_ERROR(LOG_AMF_APP, "ue context not found for the ue_id=%u\n", ue_id);
-    OAILOG_FUNC_RETURN(LOG_AMF_APP, rc);
-  }
-
-  rc = ue_state_handle_message_reg_conn(
-      ue_m5gmm_context->mm_state, STATE_EVENT_REG_COMPLETE, SESSION_NULL,
-      ue_m5gmm_context, ue_id, msg->smf_pdu, amf_cause, status);
-
-  OAILOG_FUNC_RETURN(LOG_NAS_AMF, rc);
 }
 
 /****************************************************************************

--- a/lte/gateway/c/oai/tasks/amf/amf_Security_Mode.cpp
+++ b/lte/gateway/c/oai/tasks/amf/amf_Security_Mode.cpp
@@ -18,6 +18,8 @@ extern "C" {
 #include "log.h"
 #include "3gpp_24.501.h"
 #include "conversions.h"
+#include "intertask_interface.h"
+#include "intertask_interface_types.h"
 #ifdef __cplusplus
 }
 #endif
@@ -28,6 +30,7 @@ extern "C" {
 #include "amf_sap.h"
 
 namespace magma5g {
+extern task_zmq_ctx_s amf_app_task_zmq_ctx;
 
 /****************************************************************************
  **                                                                        **
@@ -62,8 +65,15 @@ int amf_handle_security_complete_response(
   nas_amf_smc_proc_t* smc_proc = get_nas5g_common_procedure_smc(amf_ctx);
   if (smc_proc) {
     /*
-     * TODO:Stop timer T3570 This to be taken care in upcoming PR
+     * TODO:Stop timer T3560 This to be taken care in upcoming PR
      */
+
+    OAILOG_ERROR(
+        LOG_AMF_APP, "Timer: Calling SMC MODE stop timer with id = %d\n",
+        smc_proc->T3560.id);
+    stop_timer(&amf_app_task_zmq_ctx, smc_proc->T3560.id);
+    OAILOG_ERROR(LOG_AMF_APP, "Timer: After stopping SMC MODE timer \n");
+
     if (amf_ctx && IS_AMF_CTXT_PRESENT_SECURITY(amf_ctx)) {
       /*
        * Notify AMF that the authentication procedure successfully completed

--- a/lte/gateway/c/oai/tasks/amf/amf_app_handler.cpp
+++ b/lte/gateway/c/oai/tasks/amf/amf_app_handler.cpp
@@ -863,7 +863,7 @@ void amf_app_handle_cm_idle_on_ue_context_release(
 
   ue_context = amf_ue_context_exists_amf_ue_ngap_id(ue_id);
   if (ue_context == NULL) {
-    OAILOG_INFO(LOG_AMF_APP, " ue_context is NULL\n");
+    OAILOG_INFO(LOG_AMF_APP, "AMF_APP: ue_context is NULL\n");
   }
 
   // if UE on REGISTERED_IDLE, so no need to do anyting
@@ -977,11 +977,11 @@ static int paging_t3513_handler(zloop_t* loop, int timer_id, void* arg) {
     /*
      * ReSend Paging request message to the UE
      */
-    OAILOG_INFO(LOG_AMF_APP, "In Handler Starting PAGING Timer\n");
+    OAILOG_INFO(LOG_AMF_APP, "AMF_APP: In Handler Starting PAGING Timer\n");
     paging_ctx->m5_paging_response_timer.id = start_timer(
         &amf_app_task_zmq_ctx, PAGING_TIMER_EXPIRY_MSECS, TIMER_REPEAT_ONCE,
         paging_t3513_handler, NULL);
-    OAILOG_INFO(LOG_AMF_APP, "After Starting PAGING Timer\n");
+    OAILOG_INFO(LOG_AMF_APP, "AMF_APP: After Starting PAGING Timer\n");
     // Fill the itti msg based on context info produced in amf core
 
     message_p = itti_alloc_new_message(TASK_AMF_APP, NGAP_PAGING_REQUEST);
@@ -994,11 +994,12 @@ static int paging_t3513_handler(zloop_t* loop, int timer_id, void* arg) {
         amf_ctx->m5_guti.guamfi.amf_pointer;
     OAILOG_INFO(
         LOG_AMF_APP,
-        "Filling NGAP structure for Downlink amf_ctx dec m_tmsi=%d",
+        "AMF_APP: Filling NGAP structure for Downlink amf_ctx dec "
+        "m_tmsi=%d",
         amf_ctx->m5_guti.m_tmsi);
     ngap_paging_notify->UEPagingIdentity.m_tmsi = amf_ctx->m5_guti.m_tmsi;
     OAILOG_INFO(
-        LOG_AMF_APP, "Filling NGAP structure for Downlink m_tmsi=%d",
+        LOG_AMF_APP, "AMF_APP: Filling NGAP structure for Downlink m_tmsi=%d",
         ngap_paging_notify->UEPagingIdentity.m_tmsi);
     ngap_paging_notify->TAIListForPaging.tai_list[0].plmn.mcc_digit1 =
         amf_ctx->m5_guti.guamfi.plmn.mcc_digit1;
@@ -1015,7 +1016,7 @@ static int paging_t3513_handler(zloop_t* loop, int timer_id, void* arg) {
     ngap_paging_notify->TAIListForPaging.no_of_items     = 1;
     ngap_paging_notify->TAIListForPaging.tai_list[0].tac = 2;
 
-    OAILOG_INFO(LOG_AMF_APP, " sending downlink message to NGAP");
+    OAILOG_INFO(LOG_AMF_APP, "AMF_APP: sending downlink message to NGAP");
     rc = send_msg_to_task(&amf_app_task_zmq_ctx, TASK_NGAP, message_p);
     OAILOG_ERROR(
         LOG_AMF_APP, "Timer: timer has expired Sending Paging request again\n");
@@ -1044,41 +1045,46 @@ int amf_app_handle_notification_received(
   itti_ngap_paging_request_t* ngap_paging_notify = nullptr;
   int rc                                         = RETURNok;
 
-  OAILOG_INFO(LOG_AMF_APP, " PAGING NOTIFICATION received from SMF\n");
+  OAILOG_INFO(LOG_AMF_APP, "AMF_APP: PAGING NOTIFICATION received from SMF\n");
   imsi64_t imsi64;
   IMSI_STRING_TO_IMSI64(notification->imsi, &imsi64);
 
+  OAILOG_INFO(
+      LOG_AMF_APP, "AMF_APP: IMSI is %s %lu\n", notification->imsi, imsi64);
   // Handle smf_context
   ue_context = lookup_ue_ctxt_by_imsi(imsi64);
 
   if (ue_context == NULL) {
     OAILOG_INFO(LOG_AMF_APP, "ue_context is NULL\n");
+    return -1;
   }
 
-  OAILOG_INFO(LOG_AMF_APP, "IMSI is %d\n", notification->notify_ue_evnt);
+
+  OAILOG_INFO(
+      LOG_AMF_APP, "AMF_APP: IMSI is %d\n", notification->notify_ue_evnt);
   switch (notification->notify_ue_evnt) {
     case UE_PAGING_NOTIFY:
-      OAILOG_INFO(LOG_AMF_APP, "PAGING NOTIFICATION received\n");
+      OAILOG_INFO(LOG_AMF_APP, "AMF_APP: PAGING NOTIFICATION received\n");
 
       // Get Paging Context
       amf_ctx    = &ue_context->amf_context;
       paging_ctx = &ue_context->paging_context;
 
-      OAILOG_INFO(LOG_AMF_APP, "Starting PAGING Timer\n");
+      OAILOG_INFO(LOG_AMF_APP, "AMF_APP: Starting PAGING Timer\n");
       /* Start Paging Timer T3513 */
       paging_ctx->m5_paging_response_timer.id = start_timer(
           &amf_app_task_zmq_ctx, PAGING_TIMER_EXPIRY_MSECS, TIMER_REPEAT_ONCE,
           paging_t3513_handler, NULL);
       // Fill the itti msg based on context info produced in amf core
-      OAILOG_INFO(LOG_AMF_APP, "After Starting PAGING Timer\n");
-      OAILOG_INFO(LOG_AMF_APP, "Allocating memory ");
+      OAILOG_INFO(LOG_AMF_APP, "AMF_APP: After Starting PAGING Timer\n");
+      OAILOG_INFO(LOG_AMF_APP, "AMF_APP: Allocating memory ");
       message_p = itti_alloc_new_message(TASK_AMF_APP, NGAP_PAGING_REQUEST);
 
-      OAILOG_INFO(LOG_AMF_APP, "ngap_paging_notify");
+      OAILOG_INFO(LOG_AMF_APP, "AMF_APP: ngap_paging_notify");
 
       ngap_paging_notify = &message_p->ittiMsg.ngap_paging_request;
       memset(ngap_paging_notify, 0, sizeof(itti_ngap_paging_request_t));
-      OAILOG_INFO(LOG_AMF_APP, "Filling NGAP structure for Downlink");
+      OAILOG_INFO(LOG_AMF_APP, "AMF_APP: Filling NGAP structure for Downlink");
       ngap_paging_notify->UEPagingIdentity.amf_set_id =
           amf_ctx->m5_guti.guamfi.amf_set_id;
       ngap_paging_notify->UEPagingIdentity.amf_pointer =
@@ -1098,16 +1104,16 @@ int amf_app_handle_notification_received(
           amf_ctx->m5_guti.guamfi.plmn.mnc_digit3;
       ngap_paging_notify->TAIListForPaging.no_of_items     = 1;
       ngap_paging_notify->TAIListForPaging.tai_list[0].tac = 2;
-      OAILOG_INFO(LOG_AMF_APP, "sending downlink message to NGAP");
+      OAILOG_INFO(LOG_AMF_APP, "AMF_APP: sending downlink message to NGAP");
       rc = send_msg_to_task(&amf_app_task_zmq_ctx, TASK_NGAP, message_p);
       break;
 
     case UE_SERVICE_REQUEST_ON_PAGING:
-      OAILOG_INFO(LOG_AMF_APP, "SERVICE ACCEPT NOTIFICATION received\n");
-      /* TODO : SERVICE ACCEPT will be added as part of upcoming PR */
-      break;
+      OAILOG_INFO(
+          LOG_AMF_APP, "AMF_APP: SERVICE ACCEPT NOTIFICATION received\n");
+      // TODO: Service Accept code to be implemented in upcoming PR
     default:
-      OAILOG_INFO(LOG_AMF_APP, "default case nothing to do Returning\n");
+      OAILOG_INFO(LOG_AMF_APP, "AMF_APP : default case nothing to do\n");
       break;
   }
   OAILOG_FUNC_RETURN(LOG_NAS_AMF, rc);

--- a/lte/gateway/c/oai/tasks/amf/amf_app_handler.cpp
+++ b/lte/gateway/c/oai/tasks/amf/amf_app_handler.cpp
@@ -1059,7 +1059,6 @@ int amf_app_handle_notification_received(
     return -1;
   }
 
-
   OAILOG_INFO(
       LOG_AMF_APP, "AMF_APP: IMSI is %d\n", notification->notify_ue_evnt);
   switch (notification->notify_ue_evnt) {

--- a/lte/gateway/c/oai/tasks/amf/amf_app_ue_context_and_proc.h
+++ b/lte/gateway/c/oai/tasks/amf/amf_app_ue_context_and_proc.h
@@ -624,7 +624,8 @@ typedef struct nas_amf_common_procedure_s {
 // Recheck and change to nas5g, comment
 typedef struct nas_amf_ident_proc_s {
   nas_amf_common_proc_t amf_com_proc;
-  nas5g_timer_t T3570;  // Identification timer
+  nas5g_timer_t T3570; /* Identification timer         */
+#define IDENTIFICATION_COUNTER_MAX 5
   unsigned int retransmission_count;
   amf_ue_ngap_id_t ue_id;
   bool is_cause_is_registered;  //  could also be done by seeking parent
@@ -679,6 +680,8 @@ struct nas_amf_registration_proc_t {
 class nas_amf_smc_proc_t {
  public:
   nas_amf_common_proc_t amf_com_proc;
+  nas5g_timer_t T3560; /* Authentication timer         */
+#define SECURITY_COUNTER_MAX 5
   amf_ue_ngap_id_t ue_id;
   unsigned int retransmission_count;  // Retransmission counter
   int ksi;                            // NAS key set identifier

--- a/lte/gateway/c/oai/tasks/amf/amf_authentication.cpp
+++ b/lte/gateway/c/oai/tasks/amf/amf_authentication.cpp
@@ -36,8 +36,6 @@ namespace magma5g {
 extern task_zmq_ctx_t amf_app_task_zmq_ctx;
 
 amf_as_data_t amf_data_sec_auth;
-amf_sap_c amf_sap_auth;
-nas_proc nas_proc_autn;
 static int authenthication_t3560_handler(
     zloop_t* loop, int timer_id, void* output);
 /****************************************************************************
@@ -526,7 +524,10 @@ int amf_proc_authentication_complete(
 
   if (auth_proc) {
     /*  Stop Timer T3560 */
-    OAILOG_ERROR(LOG_NAS_EMM, "Timer:  Stopping Authentication Timer T3560 with id = %d\n", auth_proc->T3560.id);
+    OAILOG_ERROR(
+        LOG_NAS_EMM,
+        "Timer:  Stopping Authentication Timer T3560 with id = %d\n",
+        auth_proc->T3560.id);
     stop_timer(&amf_app_task_zmq_ctx, auth_proc->T3560.id);
     OAILOG_ERROR(LOG_NAS_EMM, "Timer: After Stopping T3560 Timer\n");
 
@@ -602,19 +603,21 @@ int amf_send_authentication_request(
     amf_data_sec_auth.amf_as_set_security_data(
         &amf_sap.u.amf_as.u.security.sctx, &amf_ctx->_security, false, true);
 
-    rc = amf_sap_auth.amf_sap_send(&amf_sap);
+    rc = amf_sap_send(&amf_sap);
 
     if (rc != RETURNerror) {
-     OAILOG_ERROR(LOG_NAS_EMM, "Timer:Start Authenthication Timer T3560\n");
-     auth_proc->T3560.id = start_timer(
-         &amf_app_task_zmq_ctx, AUTHENTICATION_TIMER_EXPIRY_MSECS, TIMER_REPEAT_ONCE, authenthication_t3560_handler,
-            NULL);
-     OAILOG_INFO(LOG_AMF_APP, "Timer: Authenthication timer T3560 started \n");
-     OAILOG_INFO(LOG_AMF_APP, "Timer: Authenthication timer T3560 id is %d\n", auth_proc->T3560.id);
-}
-    if (rc != RETURNerror) {
-      }
+      OAILOG_ERROR(LOG_NAS_EMM, "Timer:Start Authenthication Timer T3560\n");
+      auth_proc->T3560.id = start_timer(
+          &amf_app_task_zmq_ctx, AUTHENTICATION_TIMER_EXPIRY_MSECS,
+          TIMER_REPEAT_ONCE, authenthication_t3560_handler, NULL);
+      OAILOG_INFO(LOG_AMF_APP, "Timer: Authenthication timer T3560 started \n");
+      OAILOG_INFO(
+          LOG_AMF_APP, "Timer: Authenthication timer T3560 id is %d\n",
+          auth_proc->T3560.id);
     }
+    if (rc != RETURNerror) {
+    }
+  }
   OAILOG_FUNC_RETURN(LOG_NAS_AMF, rc);
 }
 
@@ -641,7 +644,7 @@ static int authenthication_t3560_handler(
     // OAILOG_FUNC_OUT(LOG_AMF_APP);
   }
 
-  nas_amf_auth_proc_t* auth_proc =
+  nas5g_amf_auth_proc_t* auth_proc =
       get_nas5g_common_procedure_authentication(amf_ctx);
   amf_ue_ngap_id_t ue_id;
 
@@ -683,7 +686,7 @@ static int authenthication_t3560_handler(
       OAILOG_ERROR(
           LOG_AMF_APP,
           "Timer: T3560 Calling amf_send_authentication_request again\n");
-      authentication.amf_send_authentication_request(amf_ctx, auth_proc);
+      amf_send_authentication_request(amf_ctx, auth_proc);
     } else {
       OAILOG_ERROR(
           LOG_AMF_APP,

--- a/lte/gateway/c/oai/tasks/amf/amf_authentication.cpp
+++ b/lte/gateway/c/oai/tasks/amf/amf_authentication.cpp
@@ -15,6 +15,7 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
+#include "intertask_interface_types.h"
 #include "intertask_interface.h"
 #include "conversions.h"
 #include "log.h"
@@ -35,7 +36,10 @@ namespace magma5g {
 extern task_zmq_ctx_t amf_app_task_zmq_ctx;
 
 amf_as_data_t amf_data_sec_auth;
-
+amf_sap_c amf_sap_auth;
+nas_proc nas_proc_autn;
+static int authenthication_t3560_handler(
+    zloop_t* loop, int timer_id, void* output);
 /****************************************************************************
  **                                                                        **
  ** Name:        nas_itti_auth_info_req()                                  **
@@ -244,7 +248,7 @@ static int amf_authentication_abort(
         "AMF-PROC  - Abort authentication procedure invoked "
         "(ue_id= " AMF_UE_NGAP_ID_FMT ")\n",
         ue_mm_context->amf_ue_ngap_id);
-    // TODO in future need to be implemented.
+
     rc = RETURNok;
   }
   OAILOG_FUNC_RETURN(LOG_NAS_AMF, rc);
@@ -521,6 +525,11 @@ int amf_proc_authentication_complete(
       get_nas5g_common_procedure_authentication(amf_ctx);
 
   if (auth_proc) {
+    /*  Stop Timer T3560 */
+    OAILOG_ERROR(LOG_NAS_EMM, "Timer:  Stopping Authentication Timer T3560 with id = %d\n", auth_proc->T3560.id);
+    stop_timer(&amf_app_task_zmq_ctx, auth_proc->T3560.id);
+    OAILOG_ERROR(LOG_NAS_EMM, "Timer: After Stopping T3560 Timer\n");
+
     nas_amf_smc_proc_autn.amf_ctx_set_security_eksi(amf_ctx, auth_proc->ksi);
 
     for (idx = 0; idx < amf_ctx->_vector[auth_proc->ksi].xres_size; idx++) {
@@ -592,9 +601,98 @@ int amf_send_authentication_request(
      */
     amf_data_sec_auth.amf_as_set_security_data(
         &amf_sap.u.amf_as.u.security.sctx, &amf_ctx->_security, false, true);
-    rc = amf_sap_send(&amf_sap);
-  }
+
+    rc = amf_sap_auth.amf_sap_send(&amf_sap);
+
+    if (rc != RETURNerror) {
+     OAILOG_ERROR(LOG_NAS_EMM, "Timer:Start Authenthication Timer T3560\n");
+     auth_proc->T3560.id = start_timer(
+         &amf_app_task_zmq_ctx, AUTHENTICATION_TIMER_EXPIRY_MSECS, TIMER_REPEAT_ONCE, authenthication_t3560_handler,
+            NULL);
+     OAILOG_INFO(LOG_AMF_APP, "Timer: Authenthication timer T3560 started \n");
+     OAILOG_INFO(LOG_AMF_APP, "Timer: Authenthication timer T3560 id is %d\n", auth_proc->T3560.id);
+}
+    if (rc != RETURNerror) {
+      }
+    }
   OAILOG_FUNC_RETURN(LOG_NAS_AMF, rc);
+}
+
+/* Timer Expiry Handler for AUTHENTHICATION Timer T3560 */
+static int authenthication_t3560_handler(
+    zloop_t* loop, int timer_id, void* arg) {
+  OAILOG_FUNC_IN(LOG_NAS_EMM);
+
+  amf_context_t* amf_ctx = NULL;
+  OAILOG_INFO(
+      LOG_AMF_APP, "Timer: ZMQ In _identification_t3560_handler - T3560\n");
+
+  ue_m5gmm_context_s* ue_mm_context = &ue_m5gmm_global_context;
+
+  OAILOG_INFO(
+      LOG_AMF_APP,
+      "Timer: ZMQ Created ue_mm_context from global context - T3560\n");
+  amf_ctx = &ue_mm_context->amf_context;
+  OAILOG_INFO(
+      LOG_AMF_APP, "Timer: ZMQ got amf ctx and calling common procedure\n");
+  if (!(amf_ctx)) {
+    OAILOG_ERROR(LOG_AMF_APP, "T3560 timer expired No AMF context\n");
+    return 1;
+    // OAILOG_FUNC_OUT(LOG_AMF_APP);
+  }
+
+  nas_amf_auth_proc_t* auth_proc =
+      get_nas5g_common_procedure_authentication(amf_ctx);
+  amf_ue_ngap_id_t ue_id;
+
+  if (auth_proc) {
+    /*
+     *Increment the retransmission counter
+     */
+
+    OAILOG_INFO(
+        LOG_AMF_APP,
+        "Timer: In authenthication timer handler - auth_proc id %p\n",
+        auth_proc);
+    OAILOG_INFO(
+        LOG_AMF_APP, "Timer: In t3560_handler - T3560 id %d\n",
+        auth_proc->T3560.id);
+    OAILOG_INFO(
+        LOG_AMF_APP, "Timer:  In t3560_handler - T3560 ue id %d\n",
+        auth_proc->ue_id);
+
+    auth_proc->retransmission_count += 1;
+    OAILOG_WARNING(
+        LOG_NAS_EMM,
+        "EMM-PROC  - T3560 timer expired, retransmission "
+        "counter = %d\n",
+        auth_proc->retransmission_count);
+    ue_id = auth_proc->ue_id;
+    OAILOG_ERROR(LOG_AMF_APP, "Timer: T3560 timer expired, retransmission\n");
+    if (auth_proc->retransmission_count < AUTHENTICATION_COUNTER_MAX) {
+      /*
+       * Send authentication request message to the UE
+       *
+       */
+      OAILOG_INFO(
+          LOG_NGAP, "AMF_TEST: Timer  retransmission_count  = %d\n",
+          auth_proc->retransmission_count);
+      OAILOG_INFO(
+          LOG_NGAP, "AMF_TEST: Timer AUTHENTICATION_COUNTER_MAX  = %d\n",
+          AUTHENTICATION_COUNTER_MAX);
+      OAILOG_ERROR(
+          LOG_AMF_APP,
+          "Timer: T3560 Calling amf_send_authentication_request again\n");
+      authentication.amf_send_authentication_request(amf_ctx, auth_proc);
+    } else {
+      OAILOG_ERROR(
+          LOG_AMF_APP,
+          "Timer: Maximum retires done hence Abort the identification "
+          "procedure\n");
+      return -1;
+    }
+    return 0;
+  }
 }
 
 }  // namespace magma5g

--- a/lte/gateway/c/oai/tasks/amf/amf_identity.cpp
+++ b/lte/gateway/c/oai/tasks/amf/amf_identity.cpp
@@ -19,6 +19,8 @@ extern "C" {
 #include "assertions.h"
 #include "conversions.h"
 #include "amf_config.h"
+#include "intertask_interface.h"
+#include "intertask_interface_types.h"
 #ifdef __cplusplus
 }
 #endif
@@ -31,6 +33,7 @@ extern "C" {
 extern amf_config_t amf_config;
 namespace magma5g {
 
+extern task_zmq_ctx_s amf_app_task_zmq_ctx;
 // Global map of supi to guti along with amf_ue_ngap_id
 std::unordered_map<imsi64_t, guti_and_amf_id_t> amf_supi_guti_map;
 
@@ -129,6 +132,22 @@ int amf_proc_identification_complete(
 
   if (ue_mm_context) {
     amf_ctx = &ue_mm_context->amf_context;
+    OAILOG_INFO(
+        LOG_AMF_APP, "AMF-TEST:amf_procedures:%p\n", amf_ctx->amf_procedures);
+    nas_amf_ident_proc_t* ident_proc =
+        get_5g_nas_common_procedure_identification(amf_ctx);
+
+    // if (ident_proc) {
+    /*
+     * Stop timer T3570
+     */
+
+    OAILOG_INFO(LOG_AMF_APP, "Timer: Identity Timer stop\n");
+    OAILOG_INFO(
+        LOG_AMF_APP, "Timer: Stopping Identity timer with ID %d\n",
+        ident_proc->T3570.id);
+    stop_timer(&amf_app_task_zmq_ctx, ident_proc->T3570.id);
+    OAILOG_INFO(LOG_AMF_APP, "Timer: After Stopping Identity timer \n");
 
     if (imsi) {
       /*

--- a/lte/gateway/c/oai/tasks/amf/amf_recv.h
+++ b/lte/gateway/c/oai/tasks/amf/amf_recv.h
@@ -27,6 +27,8 @@ int amf_handle_registration_request(
 int amf_handle_service_request(
     amf_ue_ngap_id_t ue_id, ServiceRequestMsg* msg,
     const amf_nas_message_decode_status_t decode_status);
+int amf_registration_run_procedure(amf_context_t* amf_context);
+>>>>>>> compilation errors fixed
 int amf_handle_identity_response(
     amf_ue_ngap_id_t ue_id, M5GSMobileIdentityMsg* msg, int amf_cause,
     amf_nas_message_decode_status_t decode_status);
@@ -53,8 +55,14 @@ int amf_registration_success_authentication_cb(amf_context_t* amf_context);
 int amf_registration_success_security_cb(amf_context_t* amf_context);
 int amf_proc_registration_reject(
     const amf_ue_ngap_id_t ue_id, amf_cause_t amf_cause);
+int amf_registration_reject(
+    amf_context_t* amf_context, nas_amf_registration_proc_t* nas_base_proc);
+
 int amf_send_registration_accept_dl_nas(
     const amf_as_data_t* msg, RegistrationAcceptMsg* amf_msg);
+int amf_proc_registration_complete(
+    amf_ue_ngap_id_t ue_id, bstring smf_msg_p, int amf_cause,
+    const amf_nas_message_decode_status_t status);
 
 void amf_app_handle_cm_idle_on_ue_context_release(
     itti_ngap_ue_context_release_req_t cm_idle_req);

--- a/lte/gateway/c/oai/tasks/amf/amf_recv.h
+++ b/lte/gateway/c/oai/tasks/amf/amf_recv.h
@@ -54,9 +54,6 @@ int amf_registration_success_authentication_cb(amf_context_t* amf_context);
 int amf_registration_success_security_cb(amf_context_t* amf_context);
 int amf_proc_registration_reject(
     const amf_ue_ngap_id_t ue_id, amf_cause_t amf_cause);
-int amf_registration_reject(
-    amf_context_t* amf_context, nas_amf_registration_proc_t* nas_base_proc);
-
 int amf_send_registration_accept_dl_nas(
     const amf_as_data_t* msg, RegistrationAcceptMsg* amf_msg);
 int amf_proc_registration_complete(

--- a/lte/gateway/c/oai/tasks/amf/amf_recv.h
+++ b/lte/gateway/c/oai/tasks/amf/amf_recv.h
@@ -28,7 +28,6 @@ int amf_handle_service_request(
     amf_ue_ngap_id_t ue_id, ServiceRequestMsg* msg,
     const amf_nas_message_decode_status_t decode_status);
 int amf_registration_run_procedure(amf_context_t* amf_context);
->>>>>>> compilation errors fixed
 int amf_handle_identity_response(
     amf_ue_ngap_id_t ue_id, M5GSMobileIdentityMsg* msg, int amf_cause,
     amf_nas_message_decode_status_t decode_status);

--- a/lte/gateway/c/oai/tasks/amf/amf_security_mode_control.cpp
+++ b/lte/gateway/c/oai/tasks/amf/amf_security_mode_control.cpp
@@ -201,7 +201,7 @@ static int amf_security_request(nas_amf_smc_proc_t* const smc_proc) {
     amf_data_sec_ctrl.amf_as_set_security_data(
         &amf_sap.u.amf_as.u.security.sctx, &amf_ctx->_security,
         smc_proc->is_new, false);
-    rc = amf_sap_sec.amf_sap_send(&amf_sap);
+    rc = amf_sap_send(&amf_sap);
     if (rc != RETURNerror) {
       OAILOG_INFO(
           LOG_AMF_APP,
@@ -218,7 +218,6 @@ static int amf_security_request(nas_amf_smc_proc_t* const smc_proc) {
   }
   OAILOG_FUNC_RETURN(LOG_NAS_AMF, rc);
 }
-#endif
 
 /* Timer Expiry Handler for SECURITY COMMAND MODE Timer 3560 */
 static int security_mode_t3560_handler(zloop_t* loop, int timer_id, void* arg) {

--- a/lte/gateway/c/oai/tasks/amf/amf_security_mode_control.cpp
+++ b/lte/gateway/c/oai/tasks/amf/amf_security_mode_control.cpp
@@ -17,6 +17,8 @@ extern "C" {
 #endif
 #include "log.h"
 #include "secu_defs.h"
+#include "intertask_interface_types.h"
+#include "intertask_interface.h"
 #ifdef __cplusplus
 }
 #endif
@@ -66,6 +68,7 @@ extern "C" {
 
 namespace magma5g {
 
+extern task_zmq_ctx_s amf_app_task_zmq_ctx;
 nas5g_config_t amf_data;
 nas_amf_smc_proc_t smc_ctrl;
 amf_as_data_t amf_data_sec_ctrl;
@@ -105,6 +108,8 @@ void format_plmn(amf_plmn_t* plmn) {
   }
 }
 
+static int security_mode_t3560_handler(zloop_t* loop, int timer_id, void* arg);
+
 /****************************************************************************
  **                                                                        **
  ** Name:    nas5g_new_smc_procedure()                                     **
@@ -123,6 +128,11 @@ nas_amf_smc_proc_t* nas5g_new_smc_procedure(amf_context_t* const amf_context) {
   smc_proc->amf_com_proc.amf_proc.base_proc.type = NAS_PROC_TYPE_AMF;
   smc_proc->amf_com_proc.amf_proc.type           = NAS_AMF_PROC_TYPE_COMMON;
   smc_proc->amf_com_proc.type                    = AMF_COMM_PROC_SMC;
+
+  // smc_proc->T3460.sec = mme_config.nas_config.t3460_sec;
+  // smc_proc->T3460.id  = NAS5G_TIMER_INACTIVE_ID;
+
+  // nas_amf_common_procedure_t* wrapper = calloc(1, sizeof(*wrapper));
   nas_amf_common_procedure_t* wrapper = new nas_amf_common_procedure_t;
   if (wrapper) {
     wrapper->proc = &smc_proc->amf_com_proc;
@@ -191,10 +201,89 @@ static int amf_security_request(nas_amf_smc_proc_t* const smc_proc) {
     amf_data_sec_ctrl.amf_as_set_security_data(
         &amf_sap.u.amf_as.u.security.sctx, &amf_ctx->_security,
         smc_proc->is_new, false);
-    rc = amf_sap_send(&amf_sap);
+    rc = amf_sap_sec.amf_sap_send(&amf_sap);
+    if (rc != RETURNerror) {
+      OAILOG_INFO(
+          LOG_AMF_APP,
+          "AMF_TEST: Timer: Security Mode Calling start_timer_T3560 \n");
+      smc_proc->T3560.id = start_timer(
+          &amf_app_task_zmq_ctx, SECURITY_MODE_TIMER_EXPIRY_MSECS,
+          TIMER_REPEAT_ONCE, security_mode_t3560_handler, NULL);
+      OAILOG_INFO(
+          LOG_AMF_APP,
+          "AMF_TEST: Timer:  After starting SECURITY_MODE_TIMER timer T3560 "
+          "with id %d\n",
+          smc_proc->T3560.id);
+    }
   }
   OAILOG_FUNC_RETURN(LOG_NAS_AMF, rc);
 }
+#endif
+
+/* Timer Expiry Handler for SECURITY COMMAND MODE Timer 3560 */
+static int security_mode_t3560_handler(zloop_t* loop, int timer_id, void* arg) {
+  OAILOG_INFO(LOG_AMF_APP, "Timer: In security_mode_t3560_handler - T3560\n");
+  amf_context_t* amf_ctx = NULL;
+
+  ue_m5gmm_context_s* ue_mm_context = &ue_m5gmm_global_context;
+
+  OAILOG_INFO(
+      LOG_AMF_APP,
+      "Timer: Created ue_mm_context from global context - T3560\n");
+  amf_ctx = &ue_mm_context->amf_context;
+  OAILOG_INFO(LOG_AMF_APP, "Timer: got amf ctx and calling common procedure\n");
+  if (!(amf_ctx)) {
+    OAILOG_ERROR(LOG_AMF_APP, "T3560 timer expired No AMF context\n");
+    return 1;
+    // OAILOG_FUNC_OUT(LOG_AMF_APP);
+  }
+
+  nas_amf_smc_proc_t* smc_proc = get_nas5g_common_procedure_smc(amf_ctx);
+
+  OAILOG_ERROR(LOG_AMF_APP, "Timer:In Identity Expiration Handler ZMQ TIMER\n");
+
+  if (smc_proc) {
+    OAILOG_WARNING(
+        LOG_AMF_APP, "T3560 timer   timer id %d ue id %d\n", smc_proc->T3560.id,
+        smc_proc->ue_id);
+    smc_proc->T3560.id = -1;
+  }
+
+  /*
+   * Increment the retransmission counter
+   */
+  smc_proc->retransmission_count += 1;
+  OAILOG_ERROR(
+      LOG_AMF_APP, "Timer: Incrementing retransmission_count to %d\n",
+      smc_proc->retransmission_count);
+
+  if (smc_proc->retransmission_count < SECURITY_COUNTER_MAX) {
+    /*
+     * Send identity request message to the UE
+     */
+    OAILOG_ERROR(
+        LOG_AMF_APP,
+        "Timer: timer has expired Sending Security Command Mode request "
+        "again\n");
+    amf_security_request(smc_proc);
+  } else {
+    /*
+     * Abort the smc procedure
+     */
+    OAILOG_ERROR(
+        LOG_AMF_APP,
+        "Timer: Maximum retires done hence Abort the smc procedure\n");
+    return -1;
+  }
+
+  return 0;
+}
+
+/*
+--------------------------------------------------------------------------
+        Security mode control procedure executed by the AMF
+--------------------------------------------------------------------------
+*/
 
 /****************************************************************************
  **                                                                        **

--- a/lte/gateway/c/oai/tasks/amf/nas_proc.cpp
+++ b/lte/gateway/c/oai/tasks/amf/nas_proc.cpp
@@ -34,7 +34,7 @@ extern task_zmq_ctx_s amf_app_task_zmq_ctx;
 extern ue_m5gmm_context_s ue_m5gmm_global_context;
 AmfMsg amf_msg_obj;
 static int identification_t3570_handler(zloop_t* loop, int timer_id, void* arg);
-int nas_proc::nas_proc_establish_ind(
+int nas_proc_establish_ind(
     const amf_ue_ngap_id_t ue_id, const bool is_mm_ctx_new,
     const tai_t originating_tai, const ecgi_t ecgi,
     const m5g_rrc_establishment_cause_t as_cause, const s_tmsi_m5_t s_tmsi,
@@ -189,7 +189,7 @@ nas_amf_ident_proc_t* nas5g_new_identification_procedure(
   ident_proc->amf_com_proc.amf_proc.type = NAS_AMF_PROC_TYPE_COMMON;
   ident_proc->T3570.sec                  = amf_config.nas_config.t3570_sec;
   ident_proc->T3570.id                   = AMF_APP_TIMER_INACTIVE_ID;
-  ident_proc->amf_com_proc.type = AMF_COMM_PROC_IDENT;
+  ident_proc->amf_com_proc.type          = AMF_COMM_PROC_IDENT;
   nas_amf_common_procedure_t* wrapper    = new nas_amf_common_procedure_t;
   if (wrapper) {
     wrapper->proc = &ident_proc->amf_com_proc;
@@ -307,7 +307,7 @@ static int identification_t3570_handler(
 }
 
 //-------------------------------------------------------------------------------------
-int identification::amf_proc_identification(
+int amf_proc_identification(
     amf_context_t* const amf_context, nas_amf_proc_t* const amf_proc,
     const identity_type2_t type, success_cb_t success, failure_cb_t failure) {
   OAILOG_FUNC_IN(LOG_NAS_AMF);


### PR DESCRIPTION
<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary
AMF Base Timers implementation. List of Timers Supported Timers

1) IDENTITY TIMER T3570:
Start Cause: Transmission of IDENTITY REQUEST message 
Stop Cause:IDENTITY RESPONSE message received 

2) AUTHENTICATION TIMER T3560:
Start Cause: Transmission of AUTHENTICATION REQUEST message 
Stop Cause:AUTHENTICATION RESPONSE message received


3) SECURITY MODE COMMAND TIMER T3560:
Start Cause: Transmission of SECURITY MODE COMMAND message
Stop Cause:SECURITY MODE COMPLETE message received

4) REGISTRATION TIMER T3550: 
Start Cause: On Transmission of REGISTRATION ACCEPT
Stop Cause: REGISTRATION COMPLETE message received

5) PAGING TIMER T3513:
Start Cause: Paging procedure initiated 
Stop Cause:  Paging procedure completed 



<!-- Enumerate changes you made and why you made them -->

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->

<!--
    Final note

    Please take a moment to read through the Magma project's
    - Contributing conventions: https://docs.magmacore.org/docs/next/contributing/contribute_conventions

    If this is your first time opening a PR, also consider reading
    - Developer onboarding: https://docs.magmacore.org/docs/next/contributing/contribute_onboarding
    - Development workflow: https://docs.magmacore.org/docs/next/contributing/contribute_workflow
-->
