### PR TITLE
[Orc8r] Add scripts to verify if tf variables and helm chart versions are in sync

### DIFF
--- a/orc8r/cloud/deploy/orc8r_deployer/docker/root/data/README.md
+++ b/orc8r/cloud/deploy/orc8r_deployer/docker/root/data/README.md
@@ -1,0 +1,14 @@
+## vars.yml
+
+vars.yml is used by orcl tool to get the user input for orc8r deployment. This file should contain all the input variables in orc8r and orc8r-app module which require user input. The input variables in orc8r and orc8r-app are specified in variables.tf file in their respective modules.
+
+### Note:
+
+* Some input variables in orc8r-app derives its value from orc8r module output, these input variables needn't be included in this file.
+* We needn't copy all default values from variables.tf in here. We can only copy those values which might be useful to have pre checks against. For e.g. we set the defaults for chart versions, so that we can verify if helm repo contains the associated chart versions
+
+### Check if the file is in sync
+
+check_vars_sync.py can be used to check if this file is in sync with variables in terraform modules and add any missing variables in here.
+
+

--- a/orc8r/cloud/deploy/orc8r_deployer/docker/root/data/vars.yml
+++ b/orc8r/cloud/deploy/orc8r_deployer/docker/root/data/vars.yml
@@ -1,506 +1,676 @@
 infra:
-   aws_access_key_id:
-      Description:  AWS access key id.
-      Type: string
-      Required:  true
-      ConfigApps:
-        -awscli
-   aws_secret_access_key:
-      Description:  AWS access secret.
-      Type: string
-      Required:  true
-      ConfigApps:
-        -awscli
-   region:
-      Description:  AWS region to deploy Orchestrator components into. The chosen region must provide EKS.
-      Type: string
-      Required:  true
-      ConfigApps:
-        -awscli
-        -tf
-   cluster_name:
-      Description:  Name for the Orchestrator EKS cluster.
-      Type:  string
-      Required:  false
-      Default: "orc8r"
-      ConfigApps:
-        -tf
-   cluster_version:
-      Description:  Kubernetes version for the EKS cluster
-      Type:  string
-      Required:  false
-      Default: "1.17"
-      ConfigApps:
-        -tf
-   eks_map_roles:
-      Description:  EKS IAM role mapping. Note that by default, the creator of the cluster will be in the system:master group.
-      Type: list(object({rolearn  = string, username = string, groups   = list(string), }))
-      Required:  false
-      ConfigApps:
-        -tf
-   eks_map_users:
-      Description:  Additional IAM users to add to the aws-auth ConfigMap.
-      Type: list(object({userarn  = string, username = string, groups   = list(string)}))
-      Required:  false
-      ConfigApps:
-        -tf
-   eks_worker_additional_policy_arns:
-      Description:  Additional IAM policy ARNs to attach to EKS worker nodes.
-      Type:  list(string)
-      Required:  false
-      ConfigApps:
-        -tf
-   eks_worker_additional_sg_ids:
-      Description:  Additional security group IDs to attach to EKS worker nodes.
-      Type:  list(string)
-      Required:  false
-      ConfigApps:
-        -tf
-   eks_worker_group_key:
-      Description:  If specified, the worker nodes for EKS will use this EC2 keypair.
-      Type:  string
-      Required:  false
-      ConfigApps:
-        -tf
-   eks_worker_groups:
-      Description:  Worker group configuration for EKS. Default value is 1 worker group consisting of 3 t3.large instances.
-      Type:  any
-      Required:  false
-      ConfigApps:
-        -tf
-   vpc_cidr:
-      Description:  CIDR block for the VPC.
-      Type:  string
-      Required:  false
-      ConfigApps:
-        -tf
-   vpc_database_subnets:
-      Description: ' CIDR blocks for the VPC''s database subnets. '
-      Type:  list(string)
-      Required:  false
-      ConfigApps:
-        -tf
-   vpc_extra_tags:
-      Description:  Tags to add to the VPC.
-      Type:  map
-      Required:  false
-      ConfigApps:
-        -tf
-   vpc_name:
-      Description:  Name for the VPC that will contain all the Orchestrator components.
-      Type:  string
-      Required:  false
-      ConfigApps:
-        -tf
-   vpc_private_subnets:
-      Description: ' CIDR blocks for the VPC''s private subnets. '
-      Type:  list(string)
-      Required:  false
-      ConfigApps:
-        -tf
-   vpc_public_subnets:
-      Description: ' CIDR blocks for the VPC''s public subnets. '
-      Type:  list(string)
-      Required:  false
-      ConfigApps:
-        -tf
-   orc8r_domain_name:
-      Description:  Base domain name for AWS Route 53 hosted zone.
-      Type:  string
-      Required:  true
-      ConfigApps:
-        -tf
-   secretsmanager_orc8r_secret:
-      Description:  AWS Secret Manager secret to store Orchestrator secrets.
-      Type:  string
-      Required:  true
-      ConfigApps:
-        -tf
-
+  aws_access_key_id:
+    Description: AWS access key id.
+    Type: string
+    Required: true
+    ConfigApps:
+      - awscli
+  aws_secret_access_key:
+    Description: AWS access secret.
+    Type: string
+    Required: true
+    ConfigApps:
+      - awscli
+  region:
+    Description: >-
+      AWS region to deploy Orchestrator components into. The chosen region must
+      provide EKS.
+    Type: string
+    Required: true
+    ConfigApps:
+      - awscli
+      - tf
+  cluster_name:
+    Description: Name for the Orchestrator EKS cluster.
+    Type: string
+    Required: false
+    Default: orc8r
+    ConfigApps:
+      - tf
+  cluster_version:
+    Description: Kubernetes version for the EKS cluster
+    Type: string
+    Required: false
+    Default: '1.17'
+    ConfigApps:
+      - tf
+  eks_map_roles:
+    Description: >-
+      EKS IAM role mapping. Note that by Default, the creator of the cluster
+      will be in the system:master group.
+    Type: list
+    Required: false
+    ConfigApps:
+      - tf
+  eks_map_users:
+    Description: Additional IAM users to add to the aws-auth ConfigMap.
+    Type: list
+    Required: false
+    ConfigApps:
+      - tf
+  eks_worker_additional_policy_arns:
+    Description: Additional IAM policy ARNs to attach to EKS worker nodes.
+    Type: list(string)
+    Required: false
+    ConfigApps:
+      - tf
+  eks_worker_additional_sg_ids:
+    Description: Additional security group IDs to attach to EKS worker nodes.
+    Type: list(string)
+    Required: false
+    ConfigApps:
+      - tf
+  eks_worker_group_key:
+    Description: 'If specified, the worker nodes for EKS will use this EC2 keypair.'
+    Type: string
+    Required: false
+    ConfigApps:
+      - tf
+  eks_worker_groups:
+    Description: >-
+      Worker group configuration for EKS. Default value is 1 worker group
+      consisting of 3 t3.large instances.
+    Type: any
+    Required: false
+    ConfigApps:
+      - tf
+  vpc_cidr:
+    Description: CIDR block for the VPC.
+    Type: string
+    Required: false
+    ConfigApps:
+      - tf
+  vpc_database_subnets:
+    Description: ' CIDR blocks for the VPC''s database subnets. '
+    Type: list(string)
+    Required: false
+    ConfigApps:
+      - tf
+  vpc_extra_tags:
+    Description: Tags to add to the VPC.
+    Type: map
+    Required: false
+    ConfigApps:
+      - tf
+  vpc_name:
+    Description: Name for the VPC that will contain all the Orchestrator components.
+    Type: string
+    Required: false
+    ConfigApps:
+      - tf
+  vpc_private_subnets:
+    Description: ' CIDR blocks for the VPC''s private subnets. '
+    Type: list(string)
+    Required: false
+    ConfigApps:
+      - tf
+  vpc_public_subnets:
+    Description: ' CIDR blocks for the VPC''s public subnets. '
+    Type: list(string)
+    Required: false
+    ConfigApps:
+      - tf
+  orc8r_domain_name:
+    Description: Base domain name for AWS Route 53 hosted zone.
+    Type: string
+    Required: true
+    ConfigApps:
+      - tf
+  secretsmanager_orc8r_secret:
+    Description: AWS Secret Manager secret to store Orchestrator secrets.
+    Type: string
+    Required: true
+    ConfigApps:
+      - tf
+  thanos_worker_groups:
+    Description: >-
+      Worker group configuration for Thanos. Default consists of 1 group
+      consisting of 1 m5d.xlarge for thanos.
+    Type: any
+    Required: false
+    ConfigApps:
+      - tf
 platform:
-   deploy_elasticsearch:
-      Default: true
-      Description:  Flag to deploy AWS Elasticsearch service as the datasink for aggregated logs.
-      Type:  bool
-      Required:  false
-      ConfigApps:
-        -tf
-   deploy_elasticsearch_service_linked_role:
-      Default: true
-      Description: ' Flag to deploy AWS Elasticsearch service linked role with cluster. If you''ve already created an ES service linked role for another cluster, you should set this to false. '
-      Type:  bool
-      Required:  false
-      ConfigApps:
-        -tf
-   efs_project_name:
-      Description:  Project name for EFS file system
-      Type:  string
-      Required:  false
-      ConfigApps:
-        -tf
-   elasticsearch_az_count:
-      Default: 2
-      Description:  AZ count for ES.
-      Type:  number
-      Required:  false
-      ConfigApps:
-        -tf
-   elasticsearch_dedicated_master_count:
-      Description:  Number of dedicated ES master nodes.
-      Type:  number
-      Required:  false
-      ConfigApps:
-        -tf
-   elasticsearch_dedicated_master_enabled:
-      Description:  Enable/disable dedicated master nodes for ES.
-      Type:  bool
-      Required:  false
-      ConfigApps:
-        -tf
-   elasticsearch_dedicated_master_type:
-      Description:  Instance type for ES dedicated master nodes.
-      Type:  string
-      Required:  false
-      ConfigApps:
-        -tf
-   elasticsearch_domain_name:
-      Default: "orc8r-es"
-      Description:  Name for the ES domain.
-      Type:  string
-      Required:  false
-      ConfigApps:
-        -tf
-   elasticsearch_domain_tags:
-      Description:  Extra tags for the ES domain.
-      Type:  map
-      Required:  false
-      ConfigApps:
-        -tf
-   elasticsearch_ebs_enabled:
-      Default: true
-      Description:  Use EBS for ES storage.
-      Type:  bool
-      Required:  false
-      ConfigApps:
-        -tf
-   elasticsearch_ebs_iops:
-      Description:  IOPS for ES EBS volumes.
-      Type:  number
-      Required:  false
-      ConfigApps:
-        -tf
-   elasticsearch_ebs_volume_size:
-      Default: 32
-      Description:  Size in GB to allocate for ES EBS data volumes.
-      Type:  number
-      Required:  false
-      ConfigApps:
-        -tf
-   elasticsearch_ebs_volume_type:
-      Default: gp2
-      Description:  EBS volume type for ES data volumes.
-      Type:  string
-      Required:  false
-      ConfigApps:
-        -tf
-   elasticsearch_instance_count:
-      Default: 2
-      Description:  Number of instances to allocate for ES domain.
-      Type:  number
-      Required:  false
-      ConfigApps:
-        -tf
-   elasticsearch_instance_type:
-      Default:  "t2.medium.elasticsearch"
-      Description:  AWS instance type for ES domain.
-      Type:  string
-      Required:  false
-      ConfigApps:
-        -tf
-   elasticsearch_version:
-      Default: "7.7"
-      Description:  ES version for ES domain.
-      Type:  string
-      Required:  false
-      ConfigApps:
-        -tf
-   global_tags:
-      Description:  n/a
-      Type:  map
-      Required:  false
-      ConfigApps:
-        -tf
-   orc8r_db_engine_version:
-      Default: "9.6.15"
-      Description:  Postgres engine version for Orchestrator DB.
-      Type:  string
-      Required:  false
-      ConfigApps:
-        -tf
-   orc8r_db_identifier:
-      Default: "orc8rdb"
-      Description:  Identifier for the RDS instance for Orchestrator.
-      Type:  string
-      Required:  false
-      ConfigApps:
-        -tf
-   orc8r_db_instance_class:
-      Description:  RDS instance type for Orchestrator DB.
-      Type:  string
-      Required:  false
-      ConfigApps:
-        -tf
-   orc8r_db_name:
-      Description:  DB name for Orchestrator RDS instance.
-      Type:  string
-      Required:  false
-      ConfigApps:
-        -tf
-   orc8r_db_password:
-      Description:  Password for the Orchestrator DB.
-      Type:  string
-      Required:  true
-      ConfigApps:
-        -tf
-   orc8r_db_storage_gb:
-      Description:  Capacity in GB to allocate for Orchestrator RDS instance.
-      Type:  number
-      Required:  false
-      ConfigApps:
-        -tf
-   orc8r_db_username:
-      Description:  Username for default DB user for Orchestrator DB.
-      Type:  string
-      Required:  false
-      ConfigApps:
-        -tf
+  deploy_elasticsearch:
+    Default: true
+    Description: >-
+      Flag to deploy AWS Elasticsearch service as the datasink for aggregated
+      logs.
+    Type: bool
+    Required: false
+    ConfigApps:
+      - tf
+  deploy_elasticsearch_service_linked_role:
+    Default: true
+    Description: ' Flag to deploy AWS Elasticsearch service linked role with cluster. If you''ve already created an ES service linked role for another cluster, you should set this to false. '
+    Type: bool
+    Required: false
+    ConfigApps:
+      - tf
+  efs_project_name:
+    Description: Project name for EFS file system
+    Type: string
+    Required: false
+    ConfigApps:
+      - tf
+  elasticsearch_az_count:
+    Default: 2
+    Description: AZ count for ES.
+    Type: number
+    Required: false
+    ConfigApps:
+      - tf
+  elasticsearch_dedicated_master_count:
+    Description: Number of dedicated ES master nodes.
+    Type: number
+    Required: false
+    ConfigApps:
+      - tf
+  elasticsearch_dedicated_master_enabled:
+    Description: Enable/disable dedicated master nodes for ES.
+    Type: bool
+    Required: false
+    ConfigApps:
+      - tf
+  elasticsearch_dedicated_master_type:
+    Description: Instance Type for ES dedicated master nodes.
+    Type: string
+    Required: false
+    ConfigApps:
+      - tf
+  elasticsearch_domain_name:
+    Default: orc8r-es
+    Description: Name for the ES domain.
+    Type: string
+    Required: false
+    ConfigApps:
+      - tf
+  elasticsearch_domain_tags:
+    Description: Extra tags for the ES domain.
+    Type: map
+    Required: false
+    ConfigApps:
+      - tf
+  elasticsearch_ebs_enabled:
+    Default: true
+    Description: Use EBS for ES storage.
+    Type: bool
+    Required: false
+    ConfigApps:
+      - tf
+  elasticsearch_ebs_iops:
+    Description: IOPS for ES EBS volumes.
+    Type: number
+    Required: false
+    ConfigApps:
+      - tf
+  elasticsearch_ebs_volume_size:
+    Default: 32
+    Description: Size in GB to allocate for ES EBS data volumes.
+    Type: number
+    Required: false
+    ConfigApps:
+      - tf
+  elasticsearch_ebs_volume_type:
+    Default: gp2
+    Description: EBS volume Type for ES data volumes.
+    Type: string
+    Required: false
+    ConfigApps:
+      - tf
+  elasticsearch_instance_count:
+    Default: 2
+    Description: Number of instances to allocate for ES domain.
+    Type: number
+    Required: false
+    ConfigApps:
+      - tf
+  elasticsearch_instance_type:
+    Default: t2.medium.elasticsearch
+    Description: AWS instance Type for ES domain.
+    Type: string
+    Required: false
+    ConfigApps:
+      - tf
+  elasticsearch_version:
+    Default: '7.7'
+    Description: ES version for ES domain.
+    Type: string
+    Required: false
+    ConfigApps:
+      - tf
+  global_tags:
+    Description: n/a
+    Type: map
+    Required: false
+    ConfigApps:
+      - tf
+  orc8r_db_engine_version:
+    Default: 9.6.15
+    Description: Postgres engine version for Orchestrator DB.
+    Type: string
+    Required: false
+    ConfigApps:
+      - tf
+  orc8r_db_identifier:
+    Default: orc8rdb
+    Description: Identifier for the RDS instance for Orchestrator.
+    Type: string
+    Required: false
+    ConfigApps:
+      - tf
+  orc8r_db_instance_class:
+    Description: RDS instance Type for Orchestrator DB.
+    Type: string
+    Required: false
+    ConfigApps:
+      - tf
+  orc8r_db_name:
+    Description: DB name for Orchestrator RDS instance.
+    Type: string
+    Required: false
+    ConfigApps:
+      - tf
+  orc8r_db_password:
+    Description: Password for the Orchestrator DB.
+    Type: string
+    Required: true
+    ConfigApps:
+      - tf
+  orc8r_db_storage_gb:
+    Description: Capacity in GB to allocate for Orchestrator RDS instance.
+    Type: number
+    Required: false
+    ConfigApps:
+      - tf
+  orc8r_db_username:
+    Description: Username for Default DB user for Orchestrator DB.
+    Type: string
+    Required: false
+    ConfigApps:
+      - tf
 service:
-   cwf_orc8r_chart_version:
-      Description:  Version of the Orchestrator cwf module Helm chart to install.
-      Type: string
-      Required:  false
-      ConfigApps:
-        -tf
-      Default: "0.2.1"
-   deploy_nms:
-      Description:  Flag to deploy NMS.
-      Type: bool
-      Required:  false
-      ConfigApps:
-        -tf
-   deploy_openvpn:
-      Description:  Flag to deploy OpenVPN server into cluster. This is useful if you want to remotely access AGWs.
-      Type: bool
-      Required:  false
-      ConfigApps:
-        -tf
-   docker_pass:
-      Description:  Docker registry password.
-      Type: string
-      Required:  true
-      ConfigApps:
-        -tf
-   docker_registry:
-      Description:  Docker registry to pull Orchestrator containers from.
-      Type: string
-      Required:  true
-      ConfigApps:
-        -tf
-   docker_user:
-      Description:  Docker username to login to registry with.
-      Type: string
-      Required:  true
-      ConfigApps:
-        -tf
-   efs_file_system_id:
-      Description:  ID of the EFS file system to use for K8s persistent volumes.
-      Type: string
-      Required:  false
-      ConfigApps:
-        -tf
-   efs_provisioner_role_arn:
-      Description:  ARN of the IAM role for the EFS provisioner.
-      Type: string
-      Required:  false
-      ConfigApps:
-        -tf
-   eks_cluster_id:
-      Description:  EKS cluster ID for the K8s cluster.
-      Type: string
-      Required:  false
-      ConfigApps:
-        -tf
-   elasticsearch_endpoint:
-      Description:  Endpoint of the Elasticsearch datasink for aggregated logs and events.
-      Type: string
-      Required:  false
-      ConfigApps:
-        -tf
-   elasticsearch_retention_days:
-      Description:  Retention period in days of Elasticsearch indices.
-      Type: number
-      Required:  false
-      ConfigApps:
-        -tf
-   existing_tiller_service_account_name:
-      Description:  Name of existing Tiller service account to use for Helm.
-      Type: string
-      Required:  false
-      ConfigApps:
-        -tf
-   external_dns_role_arn:
-      Description:  IAM role ARN for ExternalDNS.
-      Type: string
-      Required:  false
-      ConfigApps:
-        -tf
-   fbinternal_orc8r_chart_version:
-      Description:  Version of the Orchestrator fbinternal module Helm chart to install.
-      Type: string
-      Required:  false
-      ConfigApps:
-        -tf
-      Default: "0.2.1"
-   feg_orc8r_chart_version:
-      Description:  Version of the Orchestrator feg module Helm chart to install.
-      Type: string
-      Required:  false
-      ConfigApps:
-        -tf
-      Default: "0.2.2"
-   helm_deployment_name:
-      Description:  Name for the Helm release.
-      Type: string
-      Required:  false
-      ConfigApps:
-        -tf
-   helm_pass:
-      Description:  Helm repository password.
-      Type: string
-      Required:  true
-      ConfigApps:
-        -tf
-   helm_repo:
-      Description:  Helm repository URL for Orchestrator charts.
-      Type: string
-      Required:  true
-      ConfigApps:
-        -tf
-   helm_user:
-      Description:  Helm username to login to repository with.
-      Type: string
-      Required:  true
-      ConfigApps:
-        -tf
-   install_tiller:
-      Description:  Install Tiller in the cluster or not.
-      Type: bool
-      Required:  false
-      ConfigApps:
-        -tf
-   lte_orc8r_chart_version:
-      Description:  Version of the Orchestrator lte module Helm chart to install.
-      Type: string
-      Required:  false
-      ConfigApps:
-        -tf
-      Default: "0.2.4"
-   monitoring_kubernetes_namespace:
-      Description:  K8s namespace to install Orchestrator monitoring components into.
-      Type: string
-      Required:  false
-      ConfigApps:
-        -tf
-   orc8r_chart_version:
-      Description:  Version of the core Orchestrator Helm chart to install.
-      Type: string
-      Required:  false
-      ConfigApps:
-        -tf
-      Default: "1.5.19"
-   orc8r_controller_replicas:
-      Description:  Replica count for Orchestrator controller pods.
-      Type: number
-      Required:  false
-      ConfigApps:
-        -tf
-   orc8r_db_port:
-      Description:  DB port for Orchestrator database connection.
-      Type: number
-      Required:  false
-      ConfigApps:
-        -tf
-   orc8r_deployment_type:
-      Description:  Deployment type of Orchestrator (fwa, federated fwa(ffwa), all).
-      Type: string
-      Required:  true
-      ConfigApps:
-        -tf
-   orc8r_kubernetes_namespace:
-      Description:  K8s namespace to install main Orchestrator components into.
-      Type: string
-      Required:  false
-      ConfigApps:
-        -tf
-   orc8r_proxy_replicas:
-      Description:  Replica count for Orchestrator proxy pods.
-      Type: number
-      Required:  false
-      ConfigApps:
-        -tf
-   orc8r_route53_zone_id:
-      Description:  Route53 zone ID of Orchestrator domain name for ExternalDNS.
-      Type: string
-      Required:  false
-      ConfigApps:
-        -tf
-   orc8r_tag:
-      Description:  Image tag for Orchestrator components.
-      Type: string
-      Required:  true
-      ConfigApps:
-        -tf
-   secretsmanager_orc8r_name:
-      Description:  Name of the AWS Secrets Manager secret where Orchestrator deployment secrets will be stored.
-      Type: string
-      Required:  false
-      ConfigApps:
-        -tf
-   seed_certs_dir:
-      Description:  Directory on LOCAL disk where Orchestrator certificates are stored to seed Secrets Manager values. Home directory and env vars will be expanded.
-      Type: string
-      Required:  false
-      ConfigApps:
-        -tf
-   state_backend:
-      Description:  State backend for terraform (e.g. s3, local).
-      Type: string
-      Required:  false
-      ConfigApps:
-        -tf
-   state_config:
-      Description:  Optional config for state backend. The object type will depend on your backend.
-      Type: any
-      Required:  false
-      ConfigApps:
-        -tf
-   tiller_namespace:
-      Description:  Namespace where Tiller is installed or should be installed into.
-      Type: string
-      Required:  false
-      ConfigApps:
-        -tf
-   wifi_orc8r_chart_version:
-      Description:  Version of the Orchestrator wifi module Helm chart to install.
-      Type: string
-      Required:  false
-      ConfigApps:
-        -tf
-      Default: "0.2.1"
-   seed_certs_dir:
-      Description: Directory on LOCAL disk where Orchestrator certificates are stored to seed Secrets Manager values. Home directory and env vars will be expanded.
-      Type       : string
-      Required:  false
-      ConfigApps:
-        -tf
-      Default    : "/root/project/secrets"
+  cwf_orc8r_chart_version:
+    Description: Version of the Orchestrator cwf module Helm chart to install.
+    Type: string
+    Required: false
+    ConfigApps:
+      - tf
+    Default: 0.2.1
+  deploy_nms:
+    Description: Flag to deploy NMS.
+    Type: bool
+    Required: false
+    ConfigApps:
+      - tf
+  deploy_openvpn:
+    Description: >-
+      Flag to deploy OpenVPN server into cluster. This is useful if you want to
+      remotely access AGWs.
+    Type: bool
+    Required: false
+    ConfigApps:
+      - tf
+  docker_pass:
+    Description: Docker registry password.
+    Type: string
+    Required: true
+    ConfigApps:
+      - tf
+  docker_registry:
+    Description: Docker registry to pull Orchestrator containers from.
+    Type: string
+    Required: true
+    ConfigApps:
+      - tf
+  docker_user:
+    Description: Docker username to login to registry with.
+    Type: string
+    Required: true
+    ConfigApps:
+      - tf
+  efs_file_system_id:
+    Description: ID of the EFS file system to use for K8s persistent volumes.
+    Type: string
+    Required: false
+    ConfigApps:
+      - tf
+  efs_provisioner_role_arn:
+    Description: ARN of the IAM role for the EFS provisioner.
+    Type: string
+    Required: false
+    ConfigApps:
+      - tf
+  eks_cluster_id:
+    Description: EKS cluster ID for the K8s cluster.
+    Type: string
+    Required: false
+    ConfigApps:
+      - tf
+  elasticsearch_endpoint:
+    Description: Endpoint of the Elasticsearch datasink for aggregated logs and events.
+    Type: string
+    Required: false
+    ConfigApps:
+      - tf
+  elasticsearch_retention_days:
+    Description: Retention period in days of Elasticsearch indices.
+    Type: number
+    Required: false
+    ConfigApps:
+      - tf
+  existing_tiller_service_account_name:
+    Description: Name of existing Tiller service account to use for Helm.
+    Type: string
+    Required: false
+    ConfigApps:
+      - tf
+  external_dns_role_arn:
+    Description: IAM role ARN for ExternalDNS.
+    Type: string
+    Required: false
+    ConfigApps:
+      - tf
+  fbinternal_orc8r_chart_version:
+    Description: Version of the Orchestrator fbinternal module Helm chart to install.
+    Type: string
+    Required: false
+    ConfigApps:
+      - tf
+    Default: 0.2.1
+  feg_orc8r_chart_version:
+    Description: Version of the Orchestrator feg module Helm chart to install.
+    Type: string
+    Required: false
+    ConfigApps:
+      - tf
+    Default: 0.2.2
+  helm_deployment_name:
+    Description: Name for the Helm release.
+    Type: string
+    Required: false
+    ConfigApps:
+      - tf
+  helm_pass:
+    Description: Helm repository password.
+    Type: string
+    Required: true
+    ConfigApps:
+      - tf
+  helm_repo:
+    Description: Helm repository URL for Orchestrator charts.
+    Type: string
+    Required: true
+    ConfigApps:
+      - tf
+  helm_user:
+    Description: Helm username to login to repository with.
+    Type: string
+    Required: true
+    ConfigApps:
+      - tf
+  install_tiller:
+    Description: Install Tiller in the cluster or not.
+    Type: bool
+    Required: false
+    ConfigApps:
+      - tf
+  lte_orc8r_chart_version:
+    Description: Version of the Orchestrator lte module Helm chart to install.
+    Type: string
+    Required: false
+    ConfigApps:
+      - tf
+    Default: 0.2.4
+  monitoring_kubernetes_namespace:
+    Description: K8s namespace to install Orchestrator monitoring components into.
+    Type: string
+    Required: false
+    ConfigApps:
+      - tf
+  orc8r_chart_version:
+    Description: Version of the core Orchestrator Helm chart to install.
+    Type: string
+    Required: false
+    ConfigApps:
+      - tf
+    Default: 1.5.19
+  orc8r_controller_replicas:
+    Description: Replica count for Orchestrator controller pods.
+    Type: number
+    Required: false
+    ConfigApps:
+      - tf
+  orc8r_db_port:
+    Description: DB port for Orchestrator database connection.
+    Type: number
+    Required: false
+    ConfigApps:
+      - tf
+  orc8r_deployment_type:
+    Description: 'Deployment Type of Orchestrator (fwa, federated fwa(ffwa), all).'
+    Type: string
+    Required: true
+    ConfigApps:
+      - tf
+  orc8r_kubernetes_namespace:
+    Description: K8s namespace to install main Orchestrator components into.
+    Type: string
+    Required: false
+    ConfigApps:
+      - tf
+  orc8r_proxy_replicas:
+    Description: Replica count for Orchestrator proxy pods.
+    Type: number
+    Required: false
+    ConfigApps:
+      - tf
+  orc8r_route53_zone_id:
+    Description: Route53 zone ID of Orchestrator domain name for ExternalDNS.
+    Type: string
+    Required: false
+    ConfigApps:
+      - tf
+  orc8r_tag:
+    Description: Image tag for Orchestrator components.
+    Type: string
+    Required: true
+    ConfigApps:
+      - tf
+  secretsmanager_orc8r_name:
+    Description: >-
+      Name of the AWS Secrets Manager secret where Orchestrator deployment
+      secrets will be stored.
+    Type: string
+    Required: false
+    ConfigApps:
+      - tf
+  state_backend:
+    Description: 'State backend for terraform (e.g. s3, local).'
+    Type: string
+    Required: false
+    ConfigApps:
+      - tf
+  state_config:
+    Description: >-
+      Optional config for state backend. The object Type will depend on your
+      backend.
+    Type: any
+    Required: false
+    ConfigApps:
+      - tf
+  tiller_namespace:
+    Description: Namespace where Tiller is installed or should be installed into.
+    Type: string
+    Required: false
+    ConfigApps:
+      - tf
+  wifi_orc8r_chart_version:
+    Description: Version of the Orchestrator wifi module Helm chart to install.
+    Type: string
+    Required: false
+    Default: 0.2.1
+    ConfigApps:
+      - tf
+  seed_certs_dir:
+    Description: >-
+      Directory on LOCAL disk where Orchestrator certificates are stored to seed
+      Secrets Manager values. Home directory and env vars will be expanded.
+    Type: string
+    Required: false
+    Default: /root/project/secrets
+    ConfigApps:
+      - tf
+  prometheus_configurer_version:
+    Description: Image version for prometheus configurer.
+    Type: string
+    Default: 1.0.4
+    Required: false
+    ConfigApps:
+      - tf
+  alertmanager_configurer_version:
+    Description: Image version for alertmanager configurer.
+    Type: string
+    Default: 1.0.4
+    Required: false
+    ConfigApps:
+      - tf
+  external_dns_deployment_name:
+    Description: Name of the external dns helm deployment
+    Type: string
+    Default: external-dns
+    Required: false
+    ConfigApps:
+      - tf
+  analytics_export_enabled:
+    Description: Deploy thanos components and object storage
+    Type: bool
+    Default: false
+    Required: false
+    ConfigApps:
+      - tf
+  fluentd_deployment_name:
+    Description: Name of the fluentd helm deployment
+    Type: string
+    Default: fluentd
+    Required: false
+    ConfigApps:
+      - tf
+  analytics_metrics_prefix:
+    Description: Bucket name for s3 object storage. Must be globally unique
+    Type: string
+    Default: ''
+    Required: false
+    ConfigApps:
+      - tf
+  analytics_app_secret:
+    Description: App secret for which the metrics is to be exported to
+    Type: string
+    Default: ''
+    Required: false
+    ConfigApps:
+      - tf
+  analytics_app_id:
+    Description: App ID for which the metrics is to be exported to
+    Type: string
+    Default: ''
+    Required: false
+    ConfigApps:
+      - tf
+  analytics_metric_export_url:
+    Description: Metric Export URL
+    Type: string
+    Default: ''
+    Required: false
+    ConfigApps:
+      - tf
+  analytics_category_name:
+    Description: Category under which the exported metrics will be placed under
+    Type: string
+    Default: magma
+    Required: false
+    ConfigApps:
+      - tf
+  elasticsearch_curator_name:
+    Description: Name of the elasticsearch-curator helm deployment
+    Type: string
+    Default: elasticsearch-curator
+    Required: false
+    ConfigApps:
+      - tf
+  elasticsearch_curator_log_level:
+    Description: Defines Elasticsearch curator logging level.
+    Type: string
+    Default: INFO
+    Required: false
+    ConfigApps:
+      - tf
+  elasticsearch_use_ssl:
+    Description: Defines if elasicsearch curator should speak to ELK HTTP or HTTPS.
+    Type: string
+    Default: 'True'
+    Required: false
+    ConfigApps:
+      - tf
+  elasticsearch_port:
+    Description: Port Elastic search is listening.
+    Type: number
+    Default: 443
+    Required: false
+    ConfigApps:
+      - tf
+  thanos_enabled:
+    Description: Deploy thanos components and object storage
+    Type: bool
+    Default: false
+    Required: false
+    ConfigApps:
+      - tf
+  thanos_store_node_selector:
+    Description: >-
+      NodeSelector value to specify which node to run thanos store pod on. Label
+      is 'compute-Type:<value>'
+    Type: string
+    Default: ''
+    Required: false
+    ConfigApps:
+      - tf
+  thanos_compact_node_selector:
+    Description: >-
+      NodeSelector value to specify which node to run thanos compact pod on.
+      Label is 'compute-Type:<value>'
+    Type: string
+    Default: ''
+    Required: false
+    ConfigApps:
+      - tf
+  thanos_query_node_selector:
+    Description: >-
+      NodeSelector value to specify which node to run thanos query pod on.
+      Default is 'thanos' to be deployed on the Default thanos worker group.
+    Type: string
+    Default: thanos
+    Required: false
+    ConfigApps:
+      - tf
+  thanos_object_store_bucket_name:
+    Description: Bucket name for s3 object storage. Must be globally unique
+    Type: string
+    Default: ''
+    Required: false
+    ConfigApps:
+      - tf
+  efs_storage_class_name:
+    Description: Name of the Storage class
+    Type: string
+    Default: efs
+    Required: false
+    ConfigApps:
+      - tf
+  efs_provisioner_name:
+    Description: Name of the efs provisioner helm deployment
+    Type: string
+    Default: efs-provisioner
+    Required: false
+    ConfigApps:
+      - tf

--- a/orc8r/cloud/deploy/orc8r_deployer/docker/root/scripts/cli/cleanup.py
+++ b/orc8r/cloud/deploy/orc8r_deployer/docker/root/scripts/cli/cleanup.py
@@ -21,6 +21,7 @@ from .common import (
     run_command,
     run_playbook,
     print_error_msg,
+    print_warning_msg,
     print_success_msg)
 
 def setup_aws_creds():
@@ -68,6 +69,7 @@ def raw(ctx, dryrun, state, values):
     """
     Individually cleans up resources deployed for orc8r
     """
+    click.confirm(click.style('This is irreversable!! Do you want to continue with cleanup?', fg='red'), abort=True)
     if state:
         ctx.obj['cleanup_state'] = state
 

--- a/orc8r/cloud/deploy/orc8r_deployer/docker/root/scripts/cli/configlib_test.py
+++ b/orc8r/cloud/deploy/orc8r_deployer/docker/root/scripts/cli/configlib_test.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 """
 Copyright 2021 The Magma Authors.
 

--- a/orc8r/cloud/deploy/orc8r_deployer/docker/root/scripts/cli/install.py
+++ b/orc8r/cloud/deploy/orc8r_deployer/docker/root/scripts/cli/install.py
@@ -53,7 +53,7 @@ def install(ctx):
                     return
 
                 # set the kubectl after bringing up the infra
-                if tf_cmd == tf_orc8r or tf_orc8r_app:
+                if tf_cmd in (tf_orc8r, tf_orc8r_app):
                     kubeconfigs = glob.glob(constants['project_dir'] + "/kubeconfig_*")
                     if len(kubeconfigs) != 1:
                         if len(kubeconfigs) == 0:

--- a/orc8r/cloud/deploy/orc8r_deployer/docker/root/scripts/test_helm_charts_sync.py
+++ b/orc8r/cloud/deploy/orc8r_deployer/docker/root/scripts/test_helm_charts_sync.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python
+"""
+Copyright 2021 The Magma Authors.
+
+This source code is licensed under the BSD-style license found in the
+LICENSE file in the root directory of this source tree.
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+
+import sys
+import re
+import yaml
+import logging
+logging.basicConfig(stream=sys.stdout, level=logging.INFO)
+
+charts_fn_map = {
+    'orc8r'           : 'orc8r/cloud/helm/orc8r/Chart.yaml',
+    'fbinternal-orc8r': 'fbinternal/cloud/helm/fbinternal-orc8r/Chart.yaml',
+    'feg-orc8r'       : 'feg/cloud/helm/feg-orc8r/Chart.yaml',
+    'lte-orc8r'       : 'lte/cloud/helm/lte-orc8r/Chart.yaml',
+    'wifi-orc8r'      : 'wifi/cloud/helm/wifi-orc8r/Chart.yaml',
+    'cwf-orc8r'       : 'cwf/cloud/helm/cwf-orc8r/Chart.yaml',
+}
+
+
+def read_all_chart_versions(constants : dict) -> dict:
+    """
+    Read the version information from helm charts and return chart version map
+    Args:
+        constants: config read from config.yml
+    Returns:
+        map of chart name to versions
+    """
+    magma_root = constants['magma_root']
+    chart_versions = {}
+    for chart_name, chart_fn in charts_fn_map.items():
+        with open(f'{magma_root}/{chart_fn}') as chart_f:
+            chart_info = yaml.load(chart_f, Loader=yaml.FullLoader)
+            chart_versions[chart_name] = chart_info['version']
+    return chart_versions
+
+
+def read_tf_chart_versions(constants : dict) -> dict:
+    """Read the version information in variables.tf and return chart version map
+    Args:
+        constants: config read from config.yml
+    Returns:
+        map of chart name to versions
+    """
+    magma_root = constants['magma_root']
+    tf_root = f'{magma_root}/orc8r/cloud/deploy/terraform'
+
+    # parse input variables
+    orc8r_app_tf = f'{tf_root}/orc8r-helm-aws/variables.tf'
+    tf_chart_versions = {}
+    version_search_re = r'variable\s\"(?P<chart_name>\w+?)_chart_version\"\s\{.*?default\s*=\s*\"(?P<chart_version>\d+\.\d+\.\d+)\".*?\}'
+    with open(orc8r_app_tf) as f:
+        # parse variables
+        vars_content = f.read()
+        for m in re.finditer(version_search_re, vars_content, re.MULTILINE|re.DOTALL):
+            chart_name = (m.group('chart_name'))
+            chart_version = (m.group('chart_version'))
+            tf_chart_versions[chart_name] = chart_version
+    return tf_chart_versions
+
+
+def read_orcl_chart_versions(constants) -> dict:
+    """Read the version information in vars.yml and return chart version map
+    Args:
+        constants: config read from config.yml
+    Returns:
+        map of chart name to versions
+    """
+    vars_fn = constants['vars_definition']
+    try:
+        with open(vars_fn) as f:
+            config_vars = yaml.load(f, Loader=yaml.FullLoader)
+    except OSError:
+        print(f"Failed opening vars file {vars_fn}")
+
+    orcl_chart_versions = {}
+    for component in constants['components']:
+        for k, v in config_vars[component].items():
+            if k.endswith('_chart_version'):
+                chart_name = k.split('_chart_version')[0]
+                orcl_chart_versions[chart_name] = v['Default']
+    return orcl_chart_versions
+
+
+if __name__ == '__main__':
+    try:
+        with open("/root/config.yml") as f:
+            constants = yaml.load(f, Loader=yaml.FullLoader)
+    except OSError:
+        print("Failed opening config.yml file")
+        sys.exit(1)
+
+    chart_versions = read_all_chart_versions(constants)
+    tf_chart_versions = read_tf_chart_versions(constants)
+    orcl_chart_versions = read_orcl_chart_versions(constants)
+
+    logging.debug('Actual Chart Versions %s', repr(chart_versions))
+    logging.debug('Chart versions in tf variables file %s', repr(tf_chart_versions))
+    logging.debug('Chart versions in orcl %s', repr(orcl_chart_versions))
+
+    tf_charts_in_sync = True
+    orcl_charts_in_sync = True
+    for k, v in chart_versions.items():
+        tf_chart_version = tf_chart_versions.get(k)
+        if tf_chart_version and tf_chart_version != v:
+            print(f'Actual chart version for {k} = {v}, tf variables chart version is {tf_chart_version}')
+            tf_charts_in_sync = False
+
+        orcl_chart_version = orcl_chart_versions.get(k)
+        if orcl_chart_version and orcl_chart_version != v:
+            print(f'Actual chart version for {k} = {v}, orcl variables chart version is {orcl_charts_in_sync}')
+            orcl_charts_in_sync = False
+
+    assert tf_charts_in_sync and orcl_charts_in_sync
+    print("helm charts are in sync")

--- a/orc8r/cloud/deploy/orc8r_deployer/docker/root/scripts/test_vars_sync.py
+++ b/orc8r/cloud/deploy/orc8r_deployer/docker/root/scripts/test_vars_sync.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python
+"""
+Copyright 2021 The Magma Authors.
+
+This source code is licensed under the BSD-style license found in the
+LICENSE file in the root directory of this source tree.
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+import sys
+import re
+import yaml
+
+# Following script reads all the variables in vars.yml, variables.tf and output.tf
+# identifies variables missing in vars.yml and asserts. This script is to be used
+# for flagging variables file being out of sync with orcl vars file
+def read_all_vars(constants : dict)-> set:
+    """Read all variables present in vars.yml and return the entire set
+    Args:
+        constants: config read from config.yml
+    Returns:
+        all variables defined in vars.yml
+    """
+    vars_fn = constants['vars_definition']
+    try:
+        with open(vars_fn) as f:
+            config_vars = yaml.load(f, Loader=yaml.FullLoader)
+    except OSError:
+        print(f"Failed opening vars file {vars_fn}")
+
+    existing_vars = set()
+    for component in constants['components']:
+        for k in config_vars[component]:
+            existing_vars.add(k)
+
+    return existing_vars
+
+
+def parse_tf(constants : dict) -> set:
+    """Read user configured variables in variables tf and return the entire set
+    Args:
+        constants: config read from config.yml
+    Returns:
+        all variables defined in variables.tf
+    """
+    magma_root = constants['magma_root']
+    tf_root = f'{magma_root}/orc8r/cloud/deploy/terraform'
+
+    # parse input variables
+    orc8r_var_fn_list = [
+        f'{tf_root}/orc8r-aws/variables.tf',
+        f'{tf_root}/orc8r-helm-aws/variables.tf'
+    ]
+    var_search_re = re.compile(r'variable\s\"(?P<variable_name>\w+?)\"\s\{')
+    actual_vars = set()
+    for fn in orc8r_var_fn_list:
+        with open(fn) as f:
+            # parse variables
+            for line in f.readlines():
+                m = var_search_re.search(line)
+                if m and m.group('variable_name'):
+                    actual_vars.add(m.group('variable_name'))
+
+    # parse output variables
+    orc8r_var_fn_list = [
+        f'{tf_root}/orc8r-aws/outputs.tf',
+    ]
+
+    # remove variables which are set through outputs
+    output_search_re = re.compile(r'output\s\"(?P<variable_name>\w+?)\"\s\{')
+    for fn in orc8r_var_fn_list:
+        with open(fn) as f:
+            # parse variables
+            for line in f.readlines():
+                m = output_search_re.search(line)
+                if m and m.group('variable_name'):
+                    output_var = m.group('variable_name')
+                    if output_var in actual_vars:
+                        actual_vars.remove(output_var)
+    return actual_vars
+
+if __name__ == '__main__':
+    try:
+        with open("/root/config.yml") as f:
+            constants = yaml.load(f, Loader=yaml.FullLoader)
+    except OSError:
+        print("Failed opening config.yml file")
+        sys.exit(1)
+
+    existing_vars = read_all_vars(constants)
+    actual_vars = parse_tf(constants)
+    if not actual_vars.issubset(existing_vars):
+        diff = actual_vars.difference(existing_vars)
+        print(f"missing variable definitions {diff!r}")
+        assert(not diff)
+
+    print("vars.yml found to be in sync with terraform modules")
+


### PR DESCRIPTION
## Summary

- Following change adds scripts to check if helm chart versions in helm chart matches the default value in chart variables(terraform files) and default value in vars.yml file for orcl
- We also check if user vars contained in terraform variable definitions is present in vars.yml for orcl file as well
- Finally we integrate this with orc8r deployer bash script
- Added a readme which provides more info on vars.yml file

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->

<!--
    Final note

    Please take a moment to read through the Magma project's
    - Contributing conventions: https://docs.magmacore.org/docs/next/contributing/contribute_conventions

    If this is your first time opening a PR, also consider reading
    - Developer onboarding: https://docs.magmacore.org/docs/next/contributing/contribute_onboarding
    - Development workflow: https://docs.magmacore.org/docs/next/contributing/contribute_workflow
-->
