### PR TITLE
[lte][agw] Some optimizations and log level changes for blocked IMEI

### DIFF
--- a/lte/gateway/c/oai/common/conversions.h
+++ b/lte/gateway/c/oai/common/conversions.h
@@ -525,36 +525,32 @@ imsi64_t imsi_to_imsi64(const imsi_t* const imsi);
 
 #define IMEI_MOBID_TO_IMEI64(iMeI_t_PtR, iMEI64)                               \
   {                                                                            \
-    /*len = TAC((8 digits + SNR (6 digits) - 1)*/                              \
-    int len = 13;                                                              \
-    (*iMEI64) += (uint64_t)((iMeI_t_PtR)->u.num.tac1 * (pow(10, (len--))));    \
-    (*iMEI64) += (uint64_t)((iMeI_t_PtR)->u.num.tac2 * (pow(10, (len--))));    \
-    (*iMEI64) += (uint64_t)((iMeI_t_PtR)->u.num.tac3 * (pow(10, (len--))));    \
-    (*iMEI64) += (uint64_t)((iMeI_t_PtR)->u.num.tac4 * (pow(10, (len--))));    \
-    (*iMEI64) += (uint64_t)((iMeI_t_PtR)->u.num.tac5 * (pow(10, (len--))));    \
-    (*iMEI64) += (uint64_t)((iMeI_t_PtR)->u.num.tac6 * (pow(10, (len--))));    \
-    (*iMEI64) += (uint64_t)((iMeI_t_PtR)->u.num.tac7 * (pow(10, (len--))));    \
-    (*iMEI64) += (uint64_t)((iMeI_t_PtR)->u.num.tac8 * (pow(10, (len--))));    \
-    (*iMEI64) += (uint64_t)((iMeI_t_PtR)->u.num.snr1 * (pow(10, (len--))));    \
-    (*iMEI64) += (uint64_t)((iMeI_t_PtR)->u.num.snr2 * (pow(10, (len--))));    \
-    (*iMEI64) += (uint64_t)((iMeI_t_PtR)->u.num.snr3 * (pow(10, (len--))));    \
-    (*iMEI64) += (uint64_t)((iMeI_t_PtR)->u.num.snr4 * (pow(10, (len--))));    \
-    (*iMEI64) += (uint64_t)((iMeI_t_PtR)->u.num.snr5 * (pow(10, (len--))));    \
-    (*iMEI64) += (uint64_t)((iMeI_t_PtR)->u.num.snr6 * (pow(10, (len--))));    \
+    (*iMEI64) = (uint64_t)((iMeI_t_PtR)->u.num.tac1);                          \
+    (*iMEI64) = (10 * (*iMEI64)) + ((uint64_t)((iMeI_t_PtR)->u.num.tac2));     \
+    (*iMEI64) = (10 * (*iMEI64)) + ((uint64_t)((iMeI_t_PtR)->u.num.tac3));     \
+    (*iMEI64) = (10 * (*iMEI64)) + ((uint64_t)((iMeI_t_PtR)->u.num.tac4));     \
+    (*iMEI64) = (10 * (*iMEI64)) + ((uint64_t)((iMeI_t_PtR)->u.num.tac5));     \
+    (*iMEI64) = (10 * (*iMEI64)) + ((uint64_t)((iMeI_t_PtR)->u.num.tac6));     \
+    (*iMEI64) = (10 * (*iMEI64)) + ((uint64_t)((iMeI_t_PtR)->u.num.tac7));     \
+    (*iMEI64) = (10 * (*iMEI64)) + ((uint64_t)((iMeI_t_PtR)->u.num.tac8));     \
+    (*iMEI64) = (10 * (*iMEI64)) + ((uint64_t)((iMeI_t_PtR)->u.num.snr1));     \
+    (*iMEI64) = (10 * (*iMEI64)) + ((uint64_t)((iMeI_t_PtR)->u.num.snr2));     \
+    (*iMEI64) = (10 * (*iMEI64)) + ((uint64_t)((iMeI_t_PtR)->u.num.snr3));     \
+    (*iMEI64) = (10 * (*iMEI64)) + ((uint64_t)((iMeI_t_PtR)->u.num.snr4));     \
+    (*iMEI64) = (10 * (*iMEI64)) + ((uint64_t)((iMeI_t_PtR)->u.num.snr5));     \
+    (*iMEI64) = (10 * (*iMEI64)) + ((uint64_t)((iMeI_t_PtR)->u.num.snr6));     \
   }
 
 #define IMEI_MOBID_TO_IMEI_TAC64(iMeI_t_PtR, tAc_PtR)                          \
   {                                                                            \
-    /* len = TAC length(8 digits) - 1*/                                        \
-    int len = 7;                                                               \
-    (*tAc_PtR) += (uint64_t)((iMeI_t_PtR)->u.num.tac1 * (pow(10, (len--))));   \
-    (*tAc_PtR) += (uint64_t)((iMeI_t_PtR)->u.num.tac2 * (pow(10, (len--))));   \
-    (*tAc_PtR) += (uint64_t)((iMeI_t_PtR)->u.num.tac3 * (pow(10, (len--))));   \
-    (*tAc_PtR) += (uint64_t)((iMeI_t_PtR)->u.num.tac4 * (pow(10, (len--))));   \
-    (*tAc_PtR) += (uint64_t)((iMeI_t_PtR)->u.num.tac5 * (pow(10, (len--))));   \
-    (*tAc_PtR) += (uint64_t)((iMeI_t_PtR)->u.num.tac6 * (pow(10, (len--))));   \
-    (*tAc_PtR) += (uint64_t)((iMeI_t_PtR)->u.num.tac7 * (pow(10, (len--))));   \
-    (*tAc_PtR) += (uint64_t)((iMeI_t_PtR)->u.num.tac8 * (pow(10, (len))));     \
+    (*tAc_PtR) = (uint64_t)((iMeI_t_PtR)->u.num.tac1);                         \
+    (*tAc_PtR) = (10 * (*tAc_PtR)) + ((uint64_t)((iMeI_t_PtR)->u.num.tac2));   \
+    (*tAc_PtR) = (10 * (*tAc_PtR)) + ((uint64_t)((iMeI_t_PtR)->u.num.tac3));   \
+    (*tAc_PtR) = (10 * (*tAc_PtR)) + ((uint64_t)((iMeI_t_PtR)->u.num.tac4));   \
+    (*tAc_PtR) = (10 * (*tAc_PtR)) + ((uint64_t)((iMeI_t_PtR)->u.num.tac5));   \
+    (*tAc_PtR) = (10 * (*tAc_PtR)) + ((uint64_t)((iMeI_t_PtR)->u.num.tac6));   \
+    (*tAc_PtR) = (10 * (*tAc_PtR)) + ((uint64_t)((iMeI_t_PtR)->u.num.tac7));   \
+    (*tAc_PtR) = (10 * (*tAc_PtR)) + ((uint64_t)((iMeI_t_PtR)->u.num.tac8));   \
   }
 
 #define IMSI_TO_OCTET_STRING(iMsI_sTr, iMsI_len, aSN)                          \

--- a/lte/gateway/c/oai/tasks/mme_app/mme_config.c
+++ b/lte/gateway/c/oai/tasks/mme_app/mme_config.c
@@ -229,6 +229,11 @@ void service303_config_init(service303_data_t* service303_conf) {
   service303_conf->version = bfromcstr(SERVICE303_MME_PACKAGE_VERSION);
 }
 
+void blocked_imei_config_init(blocked_imei_list_t* blocked_imeis) {
+  blocked_imeis->num       = 0;
+  blocked_imeis->imei_htbl = NULL;
+}
+
 //------------------------------------------------------------------------------
 void mme_config_init(mme_config_t* config) {
   memset(config, 0, sizeof(*config));
@@ -253,6 +258,7 @@ void mme_config_init(mme_config_t* config) {
   gummei_config_init(&config->gummei);
   served_tai_config_init(&config->served_tai);
   service303_config_init(&config->service303_config);
+  blocked_imei_config_init(&config->blocked_imei);
 }
 
 //------------------------------------------------------------------------------

--- a/lte/gateway/c/oai/tasks/nas/emm/Attach.c
+++ b/lte/gateway/c/oai/tasks/nas/emm/Attach.c
@@ -1304,7 +1304,7 @@ static int emm_attach_success_security_cb(emm_context_t* emm_context) {
   nas_emm_attach_proc_t* attach_proc =
       get_nas_specific_procedure_attach(emm_context);
   if (!attach_proc) {
-    OAILOG_INFO_UE(
+    OAILOG_ERROR_UE(
         LOG_NAS_EMM, emm_context->_imsi64,
         "EMM-PROC  - attach_proc is NULL \n");
     OAILOG_FUNC_RETURN(LOG_NAS_EMM, RETURNerror);
@@ -1312,7 +1312,7 @@ static int emm_attach_success_security_cb(emm_context_t* emm_context) {
 
   if (emm_context->initiate_identity_after_smc) {
     emm_context->initiate_identity_after_smc = false;
-    OAILOG_INFO_UE(
+    OAILOG_DEBUG_UE(
         LOG_NAS_EMM, emm_context->_imsi64, "Trigger identity procedure\n");
     rc = emm_proc_identification(
         emm_context, (nas_emm_proc_t*) attach_proc, IDENTITY_TYPE_2_IMEISV,

--- a/lte/gateway/c/oai/tasks/nas/emm/SecurityModeControl.c
+++ b/lte/gateway/c/oai/tasks/nas/emm/SecurityModeControl.c
@@ -398,6 +398,13 @@ int validate_imei(imeisv_t* imeisv) {
    * the hashlist
    */
   imei64_t tac64 = 0;
+  if (!mme_config.blocked_imei.num) {
+    OAILOG_DEBUG(LOG_NAS_EMM, "No Blocked IMEI exists, returning success!");
+    OAILOG_FUNC_RETURN(LOG_NAS_EMM, EMM_CAUSE_SUCCESS);
+  } else {
+    OAILOG_DEBUG(
+        LOG_NAS_EMM, "Blocked IMEI exists, proceed with validation...");
+  }
   IMEI_MOBID_TO_IMEI_TAC64(imeisv, &tac64);
   hashtable_rc_t h_rc = hashtable_uint64_ts_is_key_exists(
       mme_config.blocked_imei.imei_htbl, (const hash_key_t) tac64);
@@ -405,7 +412,7 @@ int validate_imei(imeisv_t* imeisv) {
   if (HASH_TABLE_OK == h_rc) {
     OAILOG_FUNC_RETURN(LOG_NAS_EMM, EMM_CAUSE_IMEI_NOT_ACCEPTED);
   } else {
-    // Convert to imei to uint64_t
+    // Convert imei to uint64_t
     imei64_t imei64 = 0;
     IMEI_MOBID_TO_IMEI64(imeisv, &imei64);
     hashtable_rc_t h_rc = hashtable_uint64_ts_is_key_exists(


### PR DESCRIPTION
## Summary

Addressed left over comments for PR #5331:
- Add initialization
- Check whether block list exists or not before performing conversions
- Optimize the imei structure to uint64_t conversion a bit
- Change log levels 

## Test Plan

Sanity tests.
IMEI tests.

Checked log messages in debug mode.
- When blocked list does not exist:
```
002703 Fri Apr 09 20:29:36 2021 7EFFA239A700 TRACE NAS-EM tasks/nas/emm/SecurityModeContro:0395                        Entering validate_imei()
002704 Fri Apr 09 20:29:36 2021 7EFFA239A700 DEBUG NAS-EM tasks/nas/emm/SecurityModeContro:0402                           
No Blocked IMEI exists, returning success!
```
- When blocked list exists:
```
002559 Fri Apr 09 20:22:16 2021 7FD6BD8D9700 TRACE NAS-EM tasks/nas/emm/SecurityModeContro:0395                        Entering validate_imei()
002560 Fri Apr 09 20:22:16 2021 7FD6BD8D9700 DEBUG NAS-EM tasks/nas/emm/SecurityModeContro:0406                           Blocked IMEI exists, proceed with validation...
```
