### PR TITLE
[lte][agw] Generate final config file

### DIFF
--- a/lte/gateway/configs/templates/mme.conf.template
+++ b/lte/gateway/configs/templates/mme.conf.template
@@ -108,13 +108,20 @@ MME :
 
     # List of blocked IMEIs
     # By default this list is empty
-    # Max number of blocked IMEI is 10
+    # Stored in a hash table on mme side
     # Length of IMEI=15 digits, length of IMEISV=16 digits
     BLOCKED_IMEI_LIST = (
         # Sample IMEI: TAC(8 digits) + SNR (6 digits)
-        #{ TAC="99000482"; SNR="351037"}
+        #{ IMEI_TAC="99000482"; SNR="351037"}
         # Sample IMEI without SNR: TAC(8 digits)
-        #{ TAC="99000482";}
+        #{ IMEI_TAC="99000482";}
+        # ImeiConfig values can be found at magma/lte/protos/mconfig/mconfigs.proto
+        {% for imei_config in restrictedImeis -%}
+        {
+          IMEI_TAC   = "{{ imei_config.tac }}"
+          SNR        = "{{ imei_config.snr }}"
+        }{% if not loop.last %},{% endif %}
+        {% endfor %}
     );
 
     CSFB :

--- a/lte/gateway/deploy/roles/magma/files/update_mme_config_for_sanity.sh
+++ b/lte/gateway/deploy/roles/magma/files/update_mme_config_for_sanity.sh
@@ -89,7 +89,7 @@ function configure_restricted_plmn {
 
 function configure_blocked_imei {
   # Remove default blocked imei(s) from MME configuration file
-  sed -i -e '/BLOCKED_IMEI_LIST/{n;N;N;N;d}' \
+  sed -i -e '/BLOCKED_IMEI_LIST/{n;N;N;N;N;N;N;N;N;N;N;d}' \
     "$mme_config_file"
 
   # Configure blocked imei(s) in MME configuration file

--- a/lte/gateway/python/scripts/generate_oai_config.py
+++ b/lte/gateway/python/scripts/generate_oai_config.py
@@ -177,22 +177,28 @@ def _get_apn_correction_map_list(service_mconfig):
         return service_mconfig.apn_correction_map_list
     return get_service_config_value("mme", "apn_correction_map_list", None)
 
+
 def _get_federated_mode_map(service_mconfig):
-    if service_mconfig.federated_mode_map and \
-            service_mconfig.federated_mode_map.enabled and \
-            len(service_mconfig.federated_mode_map.mapping) != 0:
+    if (
+        service_mconfig.federated_mode_map
+        and service_mconfig.federated_mode_map.enabled
+        and len(service_mconfig.federated_mode_map.mapping) != 0
+    ):
         return service_mconfig.federated_mode_map.mapping
     return {}
+
 
 def _get_restricted_plmns(service_mconfig):
     if service_mconfig.restricted_plmns:
         return service_mconfig.restricted_plmns
     return {}
 
+
 def _get_restricted_imeis(service_mconfig):
     if service_mconfig.restricted_imeis:
         return service_mconfig.restricted_imeis
     return {}
+
 
 def _get_context():
     """
@@ -204,65 +210,61 @@ def _get_context():
         "mme_s11_ip": _get_iface_ip("mme", "s11_iface_name"),
         "sgw_s11_ip": _get_iface_ip("spgw", "s11_iface_name"),
         "sgw_s5s8_up_ip": _get_iface_ip("spgw", "sgw_s5s8_up_iface_name"),
-        "remote_sgw_ip": get_service_config_value("mme",
-                                                  "remote_sgw_ip", ""),
+        "remote_sgw_ip": get_service_config_value("mme", "remote_sgw_ip", ""),
         "s1ap_ip": _get_iface_ip("mme", "s1ap_iface_name"),
         "oai_log_level": _get_oai_log_level(),
-        "ipv4_dns": _get_primary_dns_ip(mme_service_config,
-                                        'dns_iface_name'),
+        "ipv4_dns": _get_primary_dns_ip(mme_service_config, "dns_iface_name"),
         "ipv4_sec_dns": _get_secondary_dns_ip(mme_service_config),
         "ipv4_p_cscf_address": _get_ipv4_pcscf_ip(mme_service_config),
         "ipv6_dns": _get_ipv6_dns_ip(mme_service_config),
         "ipv6_p_cscf_address": _get_ipv6_pcscf_ip(mme_service_config),
         "identity": _get_identity(),
         "relay_enabled": _get_relay_enabled(mme_service_config),
-        "non_eps_service_control": _get_non_eps_service_control(
-            mme_service_config),
+        "non_eps_service_control": _get_non_eps_service_control(mme_service_config),
         "csfb_mcc": _get_csfb_mcc(mme_service_config),
         "csfb_mnc": _get_csfb_mnc(mme_service_config),
         "lac": _get_lac(mme_service_config),
-        "use_stateless": get_service_config_value("mme",
-                                                  "use_stateless", ""),
+        "use_stateless": get_service_config_value("mme", "use_stateless", ""),
         "attached_enodeb_tacs": _get_attached_enodeb_tacs(mme_service_config),
         "enable_nat": _get_enable_nat(mme_service_config),
-        "federated_mode_map" : _get_federated_mode_map(mme_service_config),
-        "restricted_plmns" : _get_restricted_plmns(mme_service_config),
-        "restricted_imeis" : _get_restricted_imeis(mme_service_config)
+        "federated_mode_map": _get_federated_mode_map(mme_service_config),
+        "restricted_plmns": _get_restricted_plmns(mme_service_config),
+        "restricted_imeis": _get_restricted_imeis(mme_service_config),
     }
 
-    context["s1u_ip"] = mme_service_config.ipv4_sgw_s1u_addr or \
-                        _get_iface_ip("spgw", "s1u_iface_name")
+    context["s1u_ip"] = mme_service_config.ipv4_sgw_s1u_addr or _get_iface_ip(
+        "spgw", "s1u_iface_name"
+    )
 
     # set ovs params
     for key in (
-            "ovs_bridge_name",
-            "ovs_gtp_port_number",
-            "ovs_mtr_port_number",
-            "ovs_internal_sampling_port_number",
-            "ovs_internal_sampling_fwd_tbl",
-            "ovs_uplink_port_number",
-            "ovs_uplink_mac",
+        "ovs_bridge_name",
+        "ovs_gtp_port_number",
+        "ovs_mtr_port_number",
+        "ovs_internal_sampling_port_number",
+        "ovs_internal_sampling_fwd_tbl",
+        "ovs_uplink_port_number",
+        "ovs_uplink_mac",
     ):
         context[key] = get_service_config_value("spgw", key, "")
-    context["enable_apn_correction"] = \
-        get_service_config_value("mme", "enable_apn_correction", "")
-    context["apn_correction_map_list"] = \
-        _get_apn_correction_map_list(mme_service_config)
+    context["enable_apn_correction"] = get_service_config_value(
+        "mme", "enable_apn_correction", ""
+    )
+    context["apn_correction_map_list"] = _get_apn_correction_map_list(
+        mme_service_config
+    )
 
     return context
 
 
 def main():
     logging.basicConfig(
-        level=logging.INFO,
-        format="[%(asctime)s %(levelname)s %(name)s] %(message)s"
+        level=logging.INFO, format="[%(asctime)s %(levelname)s %(name)s] %(message)s"
     )
     context = _get_context()
-    generate_template_config("spgw", "spgw", CONFIG_OVERRIDE_DIR,
-                             context.copy())
+    generate_template_config("spgw", "spgw", CONFIG_OVERRIDE_DIR, context.copy())
     generate_template_config("mme", "mme", CONFIG_OVERRIDE_DIR, context.copy())
-    generate_template_config("mme", "mme_fd", CONFIG_OVERRIDE_DIR,
-                             context.copy())
+    generate_template_config("mme", "mme_fd", CONFIG_OVERRIDE_DIR, context.copy())
     cert_dir = get_service_config_value("mme", "cert_dir", "")
     generate_mme_certs(os.path.join(cert_dir, "freeDiameter"))
 

--- a/lte/gateway/python/scripts/generate_oai_config.py
+++ b/lte/gateway/python/scripts/generate_oai_config.py
@@ -189,6 +189,11 @@ def _get_restricted_plmns(service_mconfig):
         return service_mconfig.restricted_plmns
     return {}
 
+def _get_restricted_imeis(service_mconfig):
+    if service_mconfig.restricted_imeis:
+        return service_mconfig.restricted_imeis
+    return {}
+
 def _get_context():
     """
     Create the context which has the interface IP and the OAI log level to use.
@@ -221,7 +226,8 @@ def _get_context():
         "attached_enodeb_tacs": _get_attached_enodeb_tacs(mme_service_config),
         "enable_nat": _get_enable_nat(mme_service_config),
         "federated_mode_map" : _get_federated_mode_map(mme_service_config),
-        "restricted_plmns" : _get_restricted_plmns(mme_service_config)
+        "restricted_plmns" : _get_restricted_plmns(mme_service_config),
+        "restricted_imeis" : _get_restricted_imeis(mme_service_config)
     }
 
     context["s1u_ip"] = mme_service_config.ipv4_sgw_s1u_addr or \


### PR DESCRIPTION
## Summary

PR combines the streamed down configurations with templated fields to generate the final mme.conf file for IMEI restrictions.

## Test Plan

Applied the code changes on the latest build in AGW connected to the staging orchestrator. Applied the following config on end point `/lte/{network_id}/cellular/epc`:

```
{
  "gx_gy_relay_enabled": false,
  "hss_relay_enabled": false,
  "lte_auth_amf": "gAA=",
  "lte_auth_op": "EREREREREREREREREREREQ==",
  "mcc": "001",
  "mnc": "01",
  "restricted_imeis": [
    {
      "snr": "176148",
      "tac": "01300600"
    },
    {
      "tac": "01300601"
    }
  ],
  "restricted_plmns": [
    {
      "mcc": "001",
      "mnc": "01"
    },
    {
      "mcc": "112",
      "mnc": "796"
    },
    {
      "mcc": "112",
      "mnc": "76"
    }
  ],
  "tac": 1
}
```
 
Checked the IMEI field in the final generated mme.conf file under ` /var/opt/magma/tmp/mme.conf` file:

```
...
    # List of blocked IMEIs
    # By default this list is empty
    # Max number of blocked IMEI is 10
    # Length of IMEI=15 digits, length of IMEISV=16 digits
    BLOCKED_IMEI_LIST = (
        # Sample IMEI: TAC(8 digits) + SNR (6 digits)
        #{ TAC="99000482"; SNR="351037"}
        # Sample IMEI without SNR: TAC(8 digits)
        #{ TAC="99000482";}
    	# ImeiConfig values can be found at magma/lte/protos/mconfig/mconfigs.proto
	{
	  IMEI_TAC   = "01300600"
	  SNR        = "176148"
	},
	{
	  IMEI_TAC   = "01300601"
	  SNR        = ""
	}
	
    );
...
```

## Additional Information

- [ ] This change is backwards-breaking