### PR TITLE
[feg] S8_proxy add more logs to TestS8proxyManyCreateAndDeleteSession

### DIFF
--- a/feg/gateway/services/s8_proxy/servicers/mock_pgw/cs.go
+++ b/feg/gateway/services/s8_proxy/servicers/mock_pgw/cs.go
@@ -37,25 +37,27 @@ func (mPgw *MockPgw) getHandleCreateSessionRequest() gtpv2.HandlerFunc {
 		var err error
 		csReqFromSGW := msg.(*message.CreateSessionRequest)
 		if imsiIE := csReqFromSGW.IMSI; imsiIE != nil {
-			imsi, err := imsiIE.IMSI()
-			if err != nil {
-				return err
+			imsi, err2 := imsiIE.IMSI()
+			if err2 != nil {
+				return err2
 			}
 			session.IMSI = imsi
 
 			// remove previous session for the same subscriber if exists.
-			sess, err := c.GetSessionByIMSI(imsi)
-			if err != nil {
-				switch err.(type) {
+			sess, err2 := c.GetSessionByIMSI(imsi)
+			if err2 != nil {
+				switch err2.(type) {
 				case *gtpv2.UnknownIMSIError:
 					// whole new session. just ignore.
 				default:
-					return errors.Wrap(err, "got something unexpected")
+					return errors.Wrap(err2, "got something unexpected")
 				}
 			} else {
+				fmt.Printf("Existing IMSI during Create Session Request on PGW (%s). Deleting previous session\n", imsi)
 				c.RemoveSession(sess)
 			}
 		} else {
+			fmt.Println("Missing IE (IMSI) on Create Session Request that PGW received")
 			return &gtpv2.RequiredIEMissingError{Type: ie.IMSI}
 		}
 		if msisdnIE := csReqFromSGW.MSISDN; msisdnIE != nil {

--- a/feg/gateway/services/s8_proxy/servicers/mock_pgw/ds.go
+++ b/feg/gateway/services/s8_proxy/servicers/mock_pgw/ds.go
@@ -31,15 +31,16 @@ func (mPgw *MockPgw) getHandleDeleteSessionRequest() gtpv2.HandlerFunc {
 		var err error
 		dsReqFromSGW := msg.(*message.DeleteSessionRequest)
 
-		session, err := c.GetSessionByTEID(dsReqFromSGW.TEID(), sgwAddr)
-		mPgw.LastTEIDc = dsReqFromSGW.TEID()
+		pgwTeidC := dsReqFromSGW.TEID()
+		session, err := c.GetSessionByTEID(pgwTeidC, sgwAddr)
+		mPgw.LastTEIDc = pgwTeidC
 		if err != nil {
 			return fmt.Errorf("PGW can't find session for PGWC teid %d, %s\n ",
-				dsReqFromSGW.TEID(), err)
+				pgwTeidC, err)
 		}
 
-		// get teid
-		teid, err := session.GetTEID(gtpv2.IFTypeS5S8SGWGTPC)
+		// get TEUD
+		sgwTeidC, err := session.GetTEID(gtpv2.IFTypeS5S8SGWGTPC)
 		if err != nil {
 			err = errors.Wrap(err, "Error")
 			return err
@@ -48,7 +49,7 @@ func (mPgw *MockPgw) getHandleDeleteSessionRequest() gtpv2.HandlerFunc {
 		// check bearer is n there
 		if dsReqFromSGW.LinkedEBI == nil {
 			dsr := message.NewDeleteSessionResponse(
-				teid, msg.Sequence(),
+				sgwTeidC, msg.Sequence(),
 				ie.NewCause(gtpv2.CauseMandatoryIEMissing, 0, 0, 0, ie.NewEPSBearerID(0)),
 			)
 			if err := c.RespondTo(sgwAddr, msg, dsr); err != nil {
@@ -62,7 +63,7 @@ func (mPgw *MockPgw) getHandleDeleteSessionRequest() gtpv2.HandlerFunc {
 		_, err = session.LookupBearerByEBI(dsReqFromSGW.LinkedEBI.MustEPSBearerID())
 		if err != nil {
 			dsr := message.NewDeleteBearerResponse(
-				teid, msg.Sequence(),
+				sgwTeidC, msg.Sequence(),
 				ie.NewCause(gtpv2.CauseContextNotFound, 0, 0, 0, nil),
 			)
 			if err := c.RespondTo(sgwAddr, msg, dsr); err != nil {
@@ -73,7 +74,7 @@ func (mPgw *MockPgw) getHandleDeleteSessionRequest() gtpv2.HandlerFunc {
 
 		// respond to S-GW with DeleteSessionResponse.
 		dsr := message.NewDeleteSessionResponse(
-			teid, msg.Sequence(),
+			sgwTeidC, msg.Sequence(),
 			ie.NewCause(gtpv2.CauseRequestAccepted, 0, 0, 0, nil),
 		)
 		if err := c.RespondTo(sgwAddr, msg, dsr); err != nil {


### PR DESCRIPTION
Signed-off-by: Oriol Batalla <obatalla@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary

Done some changes to `TestS8proxyManyCreateAndDeleteSession` test to try to fix issues like this
https://app.circleci.com/pipelines/github/magma/magma/19202/workflows/5af9ba49-73b4-4b6d-8381-17d50b3d812b/jobs/191959

## Test Plan

make precommit

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->

<!--
    Final note

    Please take a moment to read through the Magma project's
    - Contributing conventions: https://docs.magmacore.org/docs/next/contributing/contribute_conventions

    If this is your first time opening a PR, also consider reading
    - Developer onboarding: https://docs.magmacore.org/docs/next/contributing/contribute_onboarding
    - Development workflow: https://docs.magmacore.org/docs/next/contributing/contribute_workflow
-->
