### PR TITLE
[lte][agw] Bug fix for missing IE in attach accept

### DIFF
--- a/lte/gateway/c/oai/tasks/nas/emm/Attach.c
+++ b/lte/gateway/c/oai/tasks/nas/emm/Attach.c
@@ -1797,11 +1797,8 @@ static int emm_send_attach_accept(emm_context_t* emm_context) {
     //----------------------------------------
     REQUIREMENT_3GPP_24_301(R10_5_5_1_2_4__14);
     emm_sap.u.emm_as.u.establish.eps_network_feature_support =
-        calloc(1, sizeof(eps_network_feature_support_t));
-    emm_sap.u.emm_as.u.establish.eps_network_feature_support->b1 =
-        _emm_data.conf.eps_network_feature_support[0];
-    emm_sap.u.emm_as.u.establish.eps_network_feature_support->b2 =
-        _emm_data.conf.eps_network_feature_support[1];
+        (eps_network_feature_support_t*) &_emm_data.conf
+            .eps_network_feature_support;
 
     /*
      * Delete any preexisting UE radio capabilities, pursuant to
@@ -1810,8 +1807,7 @@ static int emm_send_attach_accept(emm_context_t* emm_context) {
     // Note: this is safe from double-free errors because it sets to NULL
     // after freeing, which free treats as a no-op.
     bdestroy_wrapper(&ue_mm_context_p->ue_radio_capability);
-    free_wrapper(
-        (void**) &emm_sap.u.emm_as.u.establish.eps_network_feature_support);
+
     /*
      * Setup EPS NAS security data
      */
@@ -1972,14 +1968,9 @@ static int emm_attach_accept_retx(emm_context_t* emm_context) {
         "message\n",
         ue_id);
     emm_sap.u.emm_as.u.establish.eps_network_feature_support =
-        calloc(1, sizeof(eps_network_feature_support_t));
+        (eps_network_feature_support_t*) &_emm_data.conf
+            .eps_network_feature_support;
     emm_sap.u.emm_as.u.data.new_guti = &emm_context->_guti;
-    emm_sap.u.emm_as.u.establish.eps_network_feature_support->b1 =
-        _emm_data.conf.eps_network_feature_support[0];
-    emm_sap.u.emm_as.u.establish.eps_network_feature_support->b2 =
-        _emm_data.conf.eps_network_feature_support[1];
-    free_wrapper(
-        (void**) &emm_sap.u.emm_as.u.establish.eps_network_feature_support);
 
     /*
      * Setup EPS NAS security data


### PR DESCRIPTION
## Summary

This PR fixes a regression/bug introduced by https://github.com/magma/magma/pull/4513 that was leading to no sending of EPS Network Feature Support IE in attach accept. 

## Test Plan

Integ tests.

Run attach detach test and collect pcap result. Below sample shows the IE with the defaults:

```
EPS network feature support
    Element ID: 0x64
    Length: 2
    0... .... = Control plane CIoT EPS optimization: Not supported
    .0.. .... = EMM-REGISTERED w/o PDN connectivity: Not supported
    ..0. .... = Support of EXTENDED SERVICE REQUEST for packet services: Not supported
    ...0 0... = CS-LCS: no information about support of location services via CS domain is available (0)
    .... .0.. = Location services via EPC: Not supported
    .... ..0. = Emergency bearer services in S1 mode: Not supported
    .... ...0 = IMS voice over PS session in S1 mode: Not supported
    0... .... = Signalling for a maximum number of 15 EPS bearer contexts: Not supported
    .0.. .... = Interworking without N26 interface: Not supported
    ..0. .... = Restriction on the use of dual connectivity with NR: Not restricted
    ...0 .... = Restriction on enhanced coverage: Not restricted
    .... 0... = Extended protocol configuration options: Not supported
    .... .0.. = Header compression for control plane CIoT EPS optimization: Not supported
    .... ..0. = S1-u data transfer: Not supported
    .... ...0 = User plane CIoT EPS optimization: Not supported
```

And the following shows the result when VoLTE feature is enabled by setting  `EPS_NETWORK_FEATURE_SUPPORT_IMS_VOICE_OVER_PS_SESSION_IN_S1      = "yes"; ` in mme.conf.template.

```
EPS network feature support
    Element ID: 0x64
    Length: 2
    0... .... = Control plane CIoT EPS optimization: Not supported
    .0.. .... = EMM-REGISTERED w/o PDN connectivity: Not supported
    ..0. .... = Support of EXTENDED SERVICE REQUEST for packet services: Not supported
    ...0 0... = CS-LCS: no information about support of location services via CS domain is available (0)
    .... .0.. = Location services via EPC: Not supported
    .... ..0. = Emergency bearer services in S1 mode: Not supported
    .... ...1 = IMS voice over PS session in S1 mode: Supported
    0... .... = Signalling for a maximum number of 15 EPS bearer contexts: Not supported
    .0.. .... = Interworking without N26 interface: Not supported
    ..0. .... = Restriction on the use of dual connectivity with NR: Not restricted
    ...0 .... = Restriction on enhanced coverage: Not restricted
    .... 0... = Extended protocol configuration options: Not supported
    .... .0.. = Header compression for control plane CIoT EPS optimization: Not supported
    .... ..0. = S1-u data transfer: Not supported
    .... ...0 = User plane CIoT EPS optimization: Not supported
```




## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->

<!--
    Final note

    Please take a moment to read through the Magma project's
    - Contributing conventions: https://docs.magmacore.org/docs/next/contributing/contribute_conventions

    If this is your first time opening a PR, also consider reading
    - Developer onboarding: https://docs.magmacore.org/docs/next/contributing/contribute_onboarding
    - Development workflow: https://docs.magmacore.org/docs/next/contributing/contribute_workflow
-->
