### PR TITLE
[nms] Fix infinite 302 for default generated admin users

### DIFF
--- a/nms/app/packages/magmalte/scripts/setPassword.js
+++ b/nms/app/packages/magmalte/scripts/setPassword.js
@@ -50,6 +50,7 @@ async function createUser(userObject: UserObject) {
     password: passwordHash,
     role,
     networkIDs: [],
+    tabs: ['nms'],
     organization: org.name,
     readOnly: false,
   });


### PR DESCRIPTION
Signed-off-by: Andrei Lee <andreilee@fb.com>

*Note: will look into a follow-up fix on `@fbcnms/sequelize-models`*

## Summary

<!-- Enumerate changes you made and why you made them -->

Fix an issue that would cause logged-in NMS users to be infinitely redirected via HTTP `302` responses to path `/[`.

In the case of the development docker setup, this would end up at `http://magma-test.localhost:8081/[`, if the user initially tried to visit `http://magma-test.localhost:8081/`. This issue is not present for all requests to the NMS. For example, visiting `http://magma-test.localhost:8081/nms` directly would avoid this redirect issue.

On investigation, it's been discovered that the default routing set up for the NMS through [Express.js](https://expressjs.com/) will redirect the user to whatever 'tab' or feature has been enabled for them. See [here](https://github.com/magma/magma/blob/master/nms/app/packages/magmalte/server/main/routes.js#L119). Typically, what this means in practice is that if a user requests a page such as `http://magma-test.localhost:8081/does_not_exist` or any other page which should `404`, our routing is set up to redirect the user to `http://magma-test.localhost:8081/admin/networks`, for example, depending on what 'tabs' the user has set up. See [here](https://github.com/facebookincubator/fbc-js-core/blob/master/fbcnms-packages/fbcnms-sequelize-models/models/user.js#L61) for the definition of 'tabs' in the `@fbcnms/sequelize-models` dependency.

What's causing this issue is that for the default admin users created through the yarn command `setAdminPassword` ([Link](https://github.com/magma/magma/blob/master/nms/app/packages/magmalte/scripts/setPassword.js) to the script it calls), the rows in Postgres are mis-typed.

**Before Fix**
```
nms=# select tabs from "Users";
 tabs
------
 "[]"
 "[]"
(2 rows)
```

The tabs column is expected to be of JSON type. When our routing redirects users to the first 'tab' they have enabled, this ends up redirecting the user to tab `/[`. A regular `tabs` value would be something like `['nms', 'admin']`.

**After Fix**
```
nms=# select tabs from "Users";
 tabs
------
 []
 []
(2 rows)
```

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

Checked 'tabs' column after the fix for a default admin user. Also tried visiting `http://magma-test.localhost:8081/` and verified that I was redirected to `http://magma-test.localhost:8081/nms` or something else that actually worked.

## Additional Information

- [ ] This change is backwards-breaking

<!--
    Final note

    Please take a moment to read through the Magma project's
    - Contributing conventions: https://docs.magmacore.org/docs/next/contributing/contribute_conventions

    If this is your first time opening a PR, also consider reading
    - Developer onboarding: https://docs.magmacore.org/docs/next/contributing/contribute_onboarding
    - Development workflow: https://docs.magmacore.org/docs/next/contributing/contribute_workflow
-->
