### PR TITLE
AGW: build: python: Add support for ubuntu package dependency

### DIFF
--- a/lte/gateway/python/setup.py
+++ b/lte/gateway/python/setup.py
@@ -12,14 +12,145 @@ limitations under the License.
 """
 
 import os
+import sys
 
 from setuptools import setup
+
+
+def os_release():
+    release_info = {}
+    with open('/etc/os-release', 'r') as f:
+        for line in f:
+            try:
+                k, v = line.rstrip().split('=')
+                release_info[k] = v.strip('"')
+            except Exception:
+                pass
+    return release_info
+
 
 # We can use an environment variable to pass in the package version during
 # build. Since we don't distribute this on its own, we don't really care what
 # version this represents. 'None' defaults to 0.0.0.
 VERSION = os.environ.get('PKG_VERSION', None)
 
+release_info = os_release()
+if release_info.get('VERSION_CODENAME', '') == 'focal':
+    setup(
+        name='lte',
+        version=VERSION,
+        packages=[
+            'magma.enodebd',
+            'magma.enodebd.data_models',
+            'magma.enodebd.device_config',
+            'magma.enodebd.devices',
+            'magma.enodebd.devices.experimental',
+            'magma.enodebd.state_machines',
+            'magma.enodebd.tr069',
+            'magma.health',
+            'magma.mobilityd',
+            'magma.monitord',
+            'magma.pipelined',
+            'magma.pipelined.app',
+            'magma.pipelined.ng_manager',
+            'magma.pipelined.openflow',
+            'magma.pipelined.qos',
+            'magma.pkt_tester',
+            'magma.policydb',
+            'magma.policydb.servicers',
+            'magma.redirectd',
+            'magma.redirectd.templates',
+            'magma.smsd',
+            'magma.health',
+            'magma.subscriberdb',
+            'magma.subscriberdb.crypto',
+            'magma.subscriberdb.protocols',
+            'magma.subscriberdb.protocols.diameter',
+            'magma.subscriberdb.protocols.diameter.application',
+            'magma.subscriberdb.store',
+        ],
+        scripts=[
+            'scripts/agw_health_cli.py',
+            'scripts/config_stateless_agw.py',
+            'scripts/create_oai_certs.py',
+            'scripts/enodebd_cli.py',
+            'scripts/fake_user.py',
+            'scripts/feg_hello_cli.py',
+            'scripts/generate_dnsd_config.py',
+            'scripts/generate_oai_config.py',
+            'scripts/ha_cli.py',
+            'scripts/hello_cli.py',
+            'scripts/mobility_cli.py',
+            'scripts/mobility_dhcp_cli.py',
+            'scripts/ocs_cli.py',
+            'scripts/packet_tracer_cli.py',
+            'scripts/packet_ryu_cli.py',
+            'scripts/pcrf_cli.py',
+            'scripts/pipelined_cli.py',
+            'scripts/policydb_cli.py',
+            'scripts/s6a_proxy_cli.py',
+            'scripts/s6a_service_cli.py',
+            'scripts/session_manager_cli.py',
+            'scripts/sgs_cli.py',
+            'scripts/sms_cli.py',
+            'scripts/subscriber_cli.py',
+            'scripts/spgw_service_cli.py',
+            'scripts/cpe_monitoring_cli.py',
+            'scripts/state_cli.py',
+        ],
+        package_data={'magma.redirectd.templates': ['*.html']},
+        install_requires=[
+            'Cython>=0.29.1',
+            'pystemd>=0.5.0',
+            'fire>=0.2.0',
+            'envoy>=0.0.3',
+            'glob2>=0.7',
+            # lxml required by spyne.
+            'lxml==4.6.2',
+            'ryu>=4.30',
+            'spyne>=2.13.15',
+            'scapy==2.4.4',
+            'flask>=1.0.2',
+            'sentry_sdk>=1.0.0',
+            'aiodns>=1.1.1',
+            'pymemoize>=1.0.2',
+            'wsgiserver>=1.3',
+            # pin recursive dependencies of ryu and others
+            'chardet==3.0.4',
+            'docker==4.0.2',
+            'urllib3>=1.25.3',
+            'websocket-client==0.56.0',
+            'requests>=2.22.0',
+            'certifi>=2019.6.16',
+            'idna==2.8',
+            'python-dateutil==2.8.1',
+            'six>=1.12.0',
+            'eventlet>=0.24',
+            'h2>=3.2.0',
+            'hpack>=3.0',
+            'freezegun>=0.3.15',
+            'pycryptodome>=3.9.9',
+            'pyroute2==0.5.14',
+            'aiohttp==3.6.2',
+            'json-pointer>=0.1.2',
+            'ovs>=2.13',
+            'prometheus-client==0.3.1',
+            'aioeventlet==0.5.1'   # aioeventlet-build.sh
+        ],
+        extras_require={
+            'dev': [
+                # Keep grpcio and grpcio-tools on same version for now
+                # If you update this version here, you probably also want to
+                # update it in lte/gateway/python/Makefile
+                'grpcio-tools>=1.16.1',
+                'nose==1.3.7',
+                'iperf3',
+            ]
+        },
+    )
+    sys.exit(0)
+
+# debian stretch packages:-
 setup(
     name='lte',
     version=VERSION,

--- a/lte/gateway/release/magma.lockfile.ubuntu
+++ b/lte/gateway/release/magma.lockfile.ubuntu
@@ -560,7 +560,7 @@
           "root": true,
           "source": "apt",
           "sysdep": "python3-aioh2",
-          "version": "0.2.2"
+          "version": "0.2.3"
         },
         "aiohttp": {
           "root": true,
@@ -582,7 +582,7 @@
         },
         "attrs": {
           "root": false,
-          "source": "pypi",
+          "source": "apt",
           "sysdep": "python3-attrs",
           "version": "19.3.0"
         },
@@ -869,7 +869,7 @@
           "version": "234"
         },
         "pytz": {
-          "root": true,
+          "root": false,
           "source": "apt",
           "sysdep": "python3-pytz",
           "version": "2020.1"
@@ -942,9 +942,9 @@
         },
         "spyne": {
           "root": true,
-          "source": "pypi",
+          "source": "apt",
           "sysdep": "python3-spyne",
-          "version": "2.13.16"
+          "version": "2.13.15"
         },
         "strict-rfc3339": {
           "root": true,
@@ -1012,7 +1012,7 @@
           "version": "2.0.0"
         },
         "aioh2": {
-          "version": "0.2.2"
+          "version": "0.2.3"
         },
         "aiohttp": {
           "version": "3.6.2"
@@ -1105,7 +1105,7 @@
           "version": "0.0.3"
         },
         "spyne": {
-          "version": "2.13.16"
+          "version": "2.13.15"
         },
         "strict-rfc3339": {
           "version": "0.7"

--- a/orc8r/gateway/python/setup.py
+++ b/orc8r/gateway/python/setup.py
@@ -12,14 +12,112 @@ limitations under the License.
 """
 
 import os
+import sys
 
 from setuptools import setup
+
+
+def os_release():
+    release_info = {}
+    with open('/etc/os-release', 'r') as f:
+        for line in f:
+            try:
+                k, v = line.rstrip().split('=')
+                release_info[k] = v.strip('"')
+            except Exception:
+                pass
+    return release_info
 
 # We can use an environment variable to pass in the package version during
 # build. Since we don't distribute this on its own, we don't really care what
 # version this represents. 'None' defaults to 0.0.0.
 VERSION = os.environ.get('PKG_VERSION', None)
 
+release_info = os_release()
+if release_info.get('VERSION_CODENAME', '') == 'focal':
+    setup(
+        name='orc8r',
+        version=VERSION,
+        packages=[
+            'magma.common',
+            'magma.common.health',
+            'magma.common.redis',
+            'magma.configuration',
+            'magma.directoryd',
+            'magma.magmad',
+            'magma.magmad.generic_command',
+            'magma.magmad.check',
+            'magma.magmad.check.kernel_check',
+            'magma.magmad.check.machine_check',
+            'magma.magmad.check.network_check',
+            'magma.magmad.upgrade',
+            'magma.state',
+            'magma.eventd',
+            'magma.ctraced',
+        ],
+        scripts=[
+            'scripts/checkin_cli.py',
+            'scripts/ctraced_cli.py',
+            'scripts/directoryd_cli.py',
+            'scripts/generate_lighttpd_config.py',
+            'scripts/generate_nghttpx_config.py',
+            'scripts/generate_service_config.py',
+            'scripts/generate_fluent_bit_config.py',
+            'scripts/health_cli.py',
+            'scripts/magma_conditional_service.py',
+            'scripts/magma_get_config.py',
+            'scripts/magmad_cli.py',
+            'scripts/service_util.py',
+            'scripts/service303_cli.py',
+            'scripts/show_gateway_info.py',
+            'scripts/traffic_cli.py',
+        ],
+        install_requires=[
+            'setuptools==49.6.0',
+            'Cython>=0.29.1',
+            'pystemd>=0.5.0',
+            'docker>=4.0.2',
+            'fire>=0.2.0',
+            'glob2>=0.7',
+            'aioh2>=0.2.2',
+            'redis>=2.10.5',  # redis-py (Python bindings to redis)
+            'redis-collections>=0.4.2',
+            'python-redis-lock>=3.7.0',
+            'aiohttp>=0.17.2',
+            'grpcio>=1.16.1',
+            'protobuf>=3.14.0',
+            'Jinja2>=2.8',
+            'netifaces>=0.10.4',
+            'pylint>=1.7.1',
+            'PyYAML>=3.12',
+            'pytz>=2014.4',
+            'prometheus_client==0.3.1',
+            'sentry_sdk>=1.0.0',
+            'snowflake>=0.0.3',
+            'psutil==5.6.6',
+            'cryptography>=1.9',
+            'itsdangerous>=0.24',
+            'click>=5.1',
+            'pycares>=2.3.0',
+            'python-dateutil>=1.4',
+            # force same requests version as lte/gateway/python/setup.py
+            'requests==2.22.0',
+            'jsonpickle',
+            'bravado-core==5.16.1',
+            'jsonschema==3.1.0',
+            "strict-rfc3339>=0.7",
+            "rfc3987>=1.3.0",
+            "webcolors>=1.11.1",
+        ],
+        extras_require={
+            'dev': [
+                "fakeredis[lua]"
+            ],
+        },
+    )
+    sys.exit(0)
+
+# debian stretch packages:-
 setup(
     name='orc8r',
     version=VERSION,


### PR DESCRIPTION
setup.py defined python package dependencies. Following
patch adds dependencies for ubuntu. The setup() call is
done according to platform it is running on.

Signed-off-by: Pravin B Shelar <pbshelar@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->

<!--
    Final note

    Please take a moment to read through the Magma project's
    - Contributing conventions: https://docs.magmacore.org/docs/next/contributing/contribute_conventions

    If this is your first time opening a PR, also consider reading
    - Developer onboarding: https://docs.magmacore.org/docs/next/contributing/contribute_onboarding
    - Development workflow: https://docs.magmacore.org/docs/next/contributing/contribute_workflow
-->
