### PR TITLE
AGW: build: aioeventlet package

### DIFF
--- a/third_party/build/bin/aioeventlet-build.sh
+++ b/third_party/build/bin/aioeventlet-build.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+#
+# Copyright 2021 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# build aioeventlet from locally patched aioeventlet lib
+set -e
+SCRIPT_DIR="$(dirname "$(realpath "$0")")"
+source "$SCRIPT_DIR"/../lib/util.sh
+PKGVERSION=0.5.1
+ITERATION=1
+VERSION="$PKGVERSION-$ITERATION"
+PKGNAME=python3-aioeventlet
+
+# packaging
+OUTPUT_DIR=$(pwd)
+PKGFILE="$(pkgfilename)"
+BUILD_PATH="$OUTPUT_DIR"/"$PKGFILE"
+
+# remove old packages
+if [ -f "$BUILD_PATH" ]; then
+  rm "$BUILD_PATH"
+fi
+
+fpm \
+    -s dir \
+    -t "$PKGFMT" \
+    -a "$ARCH" \
+    -n "$PKGNAME" \
+    -v "$PKGVERSION" \
+    --iteration "$ITERATION" \
+    --provides "$PKGNAME" \
+    --conflicts "$PKGNAME" \
+    --replaces "$PKGNAME" \
+    --package "$BUILD_PATH" \
+    --description 'patched aioeventlet' \
+    /usr/local/lib/python3.8/dist-packages/aioeventlet.py=/usr/local/lib/python3.8/dist-packages/aioeventlet.py \
+    /usr/local/lib/python3.8/dist-packages/aioeventlet-0.5.1-py3.8.egg-info=/usr/local/lib/python3.8/dist-packages/aioeventlet-0.5.1-py3.8.egg-info


### PR DESCRIPTION
AGW needs patched aioeventlet for python services to
run on python 3.8. This script builds this package
on vagrant VM which already has patched lib.

Signed-off-by: Pravin B Shelar <pbshelar@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->

<!--
    Final note

    Please take a moment to read through the Magma project's
    - Contributing conventions: https://docs.magmacore.org/docs/next/contributing/contribute_conventions

    If this is your first time opening a PR, also consider reading
    - Developer onboarding: https://docs.magmacore.org/docs/next/contributing/contribute_onboarding
    - Development workflow: https://docs.magmacore.org/docs/next/contributing/contribute_workflow
-->
