### PR TITLE
[PyLint] Add missing directories to pylint test

### DIFF
--- a/lte/gateway/python/magma/tests/pylint_tests.py
+++ b/lte/gateway/python/magma/tests/pylint_tests.py
@@ -41,14 +41,17 @@ class MagmaPyLintTest(unittest.TestCase):
             ],
             show_categories=["warning", "error", "fatal"],
         )
-
+        # TODO look up directories in magma/lte/gateway/python/magma
         directories = [
             'enodebd',
+            # 'health',
             # 'mobilityd',
+            # 'monitord',
             'pipelined',
             # 'pkt_tester',
             'policydb',
             # 'redirectd',
+            # 'smsd',
             'subscriberdb',
         ]
         parent_path = os.path.dirname(os.path.dirname(__file__))

--- a/orc8r/gateway/python/magma/tests/pylint_tests.py
+++ b/orc8r/gateway/python/magma/tests/pylint_tests.py
@@ -41,11 +41,13 @@ class MagmaPyLintTest(unittest.TestCase):
             ],
             show_categories=["warning", "error", "fatal"],
         )
-
+        # TODO look up directories in magma/orc8r/gateway/python/magma
         directories = [
             'common',
             'configuration',
+            # 'ctraced',
             'directoryd',
+            'eventd',
             'magmad',
             'state',
         ]


### PR DESCRIPTION
Signed-off-by: Marie Bremner <marwhal@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary
We currently have a python unit test to assert on pylint checks for both `orc8r/gateway/python` and `lte/gateway/python`. However, these files don't contain service names so ones that were added recently. Since the pylint tests fail for all newer services except eventd, I'll keep the names commented out and file issues to add them back in.

I added a TODO to eventually just look up all modules in the directory programatically. This would help  with enforcing pylint for any future services.

GH Issues:
* ctraced: https://github.com/magma/magma/issues/6097
* mobilityd: https://github.com/magma/magma/issues/6099
* smsd: https://github.com/magma/magma/issues/6100
* health: https://github.com/magma/magma/issues/6101
* monitord: https://github.com/magma/magma/issues/6102
* pkt_tester: https://github.com/magma/magma/issues/6103
* redirectd: https://github.com/magma/magma/issues/6104

<!-- Enumerate changes you made and why you made them -->

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->

<!--
    Final note

    Please take a moment to read through the Magma project's
    - Contributing conventions: https://docs.magmacore.org/docs/next/contributing/contribute_conventions

    If this is your first time opening a PR, also consider reading
    - Developer onboarding: https://docs.magmacore.org/docs/next/contributing/contribute_onboarding
    - Development workflow: https://docs.magmacore.org/docs/next/contributing/contribute_workflow
-->
