### PR TITLE
[NMS] Update the datasource when url or certs change.

### DIFF
--- a/nms/app/packages/magmalte/grafana/handlers.js
+++ b/nms/app/packages/magmalte/grafana/handlers.js
@@ -352,8 +352,12 @@ async function updateDatasourceIfChanged({
   errorTask?: Task,
 }> {
   const completedTasks: Array<Task> = [];
-  // Make sure API Endpoint matches
-  if (oldDS.url === makeAPIUrl(newDSParams.apiHost, newDSParams.nmsOrgID)) {
+  // Make sure API Endpoint matches and certs match
+  if (
+    oldDS.url === makeAPIUrl(newDSParams.apiHost, newDSParams.nmsOrgID) &&
+    oldDS.secureJsonData?.tlsClientCert === newDSParams.cert.toString() &&
+    oldDS.secureJsonData?.tlsClientKey === newDSParams.key.toString()
+  ) {
     return {completedTasks};
   }
   const updatedDS = makeDatasourceConfig(newDSParams);


### PR DESCRIPTION
Signed-off-by: Karthik Subraveti <ksubraveti@fb.com>

## Summary
When certs are updated in NMS pod and when a datasource for grafana already exists, we don't update the datasource. 
We only update the datasource when the datasource URL changes. This change adds a check to ensure that we update
datasource even when certs change.

## Test Plan
Manually verified it in magma cloud account. 

Closes #6044
## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->

<!--
    Final note

    Please take a moment to read through the Magma project's
    - Contributing conventions: https://docs.magmacore.org/docs/next/contributing/contribute_conventions

    If this is your first time opening a PR, also consider reading
    - Developer onboarding: https://docs.magmacore.org/docs/next/contributing/contribute_onboarding
    - Development workflow: https://docs.magmacore.org/docs/next/contributing/contribute_workflow
-->
