### PR TITLE
[feg] Add Go Lint for FEG and Fix code coverage makefile endpoint

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -660,6 +660,11 @@ jobs:
          command: go mod download
          workdir: ${MAGMA_ROOT}/cwf/gateway
       - run:
+          name: GO lint code
+          command: |
+            cd ${MAGMA_ROOT}/feg/gateway
+            make -C ${MAGMA_ROOT}/feg/gateway lint
+      - run:
           name: Generate test coverage
           command: |
             cd ${MAGMA_ROOT}/feg/gateway

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -660,7 +660,7 @@ jobs:
          command: go mod download
          workdir: ${MAGMA_ROOT}/cwf/gateway
       - run:
-          name: GO lint code
+          name: Go lint code
           command: |
             cd ${MAGMA_ROOT}/feg/gateway
             make -C ${MAGMA_ROOT}/feg/gateway lint

--- a/cwf/gateway/services/uesim/servicers/radius.go
+++ b/cwf/gateway/services/uesim/servicers/radius.go
@@ -90,7 +90,7 @@ func (srv *UESimServer) EapToRadius(eapP eap.Packet, imsi string, calledStationI
 	if err != nil {
 		return nil, err
 	}
-	err = rfc2869.EAPMessage_Set(radiusP, []byte(eapP))
+	err = rfc2869.EAPMessage_Set(radiusP, eapP)
 	if err != nil {
 		return nil, err
 	}

--- a/feg/gateway/Makefile
+++ b/feg/gateway/Makefile
@@ -53,8 +53,19 @@ gen:
 vet:
 	go vet ./...
 
-lint:
-	golint -min_confidence 1. ./...
+lint: lint_tools
+	golangci-lint run
+
+lint_tools:
+	#if which golangci-lint 2>/dev/null; then echo "-> golangci-lint already installed"; \
+	#else curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh \
+	#		| sh -s -- -b $$(go env GOBIN) v1.35.2; \
+	#fi
+	if which golangci-lint 2>/dev/null; then echo "-> golangci-lint already installed"; \
+	else curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh \
+			| sudo sh -s -- -b /usr/sbin/ v1.35.2; \
+	fi
+
 
 build_only:
 	go build ./...

--- a/feg/gateway/Makefile
+++ b/feg/gateway/Makefile
@@ -5,7 +5,8 @@ MAGMA_ROOT = /home/$USER/magma
 endif
 export MAGMA_ROOT
 
-COVER_DIR := $(MAGMA_ROOT)/feg/gateway/coverage
+COVER_DIR:=$(MAGMA_ROOT)/feg/gateway/coverage
+COVER_FILE:=$(COVER_DIR)/feg.gocov
 export COVER_DIR
 
 
@@ -63,6 +64,14 @@ run_local_hss:
 
 precommit: fmt test vet
 
+cover: tools
+	mkdir -p $(COVER_DIR)
+	go-acc ./... --covermode count --output $(COVER_FILE)
+	# skip some unnecessary files for coverage
+	awk '!/\.pb\.go|_swaggergen\.go|\/mocks\/|\/tools\/|\/blobstore\/ent\//' $(COVER_FILE) > $(COVER_FILE).tmp && \
+		mv $(COVER_FILE).tmp $(COVER_FILE)
+
+# Tool dependencies
 TOOL_DEPS:= \
 	github.com/ory/go-acc \
 	github.com/wadey/gocovmerge
@@ -70,12 +79,4 @@ tools:: $(TOOL_DEPS)
 $(TOOL_DEPS): %:
 	go install $*
 
-cover: tools cover_pre
 
-COVER_FILE=$(COVER_DIR)/feg.gocov
-cover: tools cover_pre
-	go-acc ./... --covermode count --output $(COVER_FILE)
-	# skip some unnecessary files for coverage
-	awk '!/\.pb\.go|_swaggergen\.go|\/mocks\/|\/tools\/|\/blobstore\/ent\//' $(COVER_FILE) > $(COVER_FILE).tmp && mv $(COVER_FILE).tmp $(COVER_FILE)
-cover_pre:
-	mkdir -p $(COVER_DIR)

--- a/feg/gateway/Makefile
+++ b/feg/gateway/Makefile
@@ -57,15 +57,10 @@ lint: lint_tools
 	golangci-lint run
 
 lint_tools:
-	#if which golangci-lint 2>/dev/null; then echo "-> golangci-lint already installed"; \
-	#else curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh \
-	#		| sh -s -- -b $$(go env GOBIN) v1.35.2; \
-	#fi
 	if which golangci-lint 2>/dev/null; then echo "-> golangci-lint already installed"; \
 	else curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh \
 			| sudo sh -s -- -b /usr/sbin/ v1.35.2; \
 	fi
-
 
 build_only:
 	go build ./...

--- a/feg/gateway/diameter/connection_manager_test.go
+++ b/feg/gateway/diameter/connection_manager_test.go
@@ -50,7 +50,7 @@ func TestConnectionManager(t *testing.T) {
 			OriginHost:  ClientHost,
 			OriginRealm: ClientRealm,
 			VendorID:    datatype.Unsigned32(Vendor3GPP),
-			ProductName: datatype.UTF8String("connection manager"),
+			ProductName: "connection manager",
 		})
 		cli = &sm.Client{
 			Dict:               dict.Default,
@@ -78,7 +78,7 @@ func TestConnectionManager(t *testing.T) {
 			OriginHost:  ServerHost,
 			OriginRealm: ServerRealm,
 			VendorID:    datatype.Unsigned32(Vendor3GPP),
-			ProductName: datatype.UTF8String("hello"),
+			ProductName: "hello",
 		})
 
 		serverStarted = make(chan struct{})

--- a/feg/gateway/services/aaa/aaa_server/aaa_aka_auth_test.go
+++ b/feg/gateway/services/aaa/aaa_server/aaa_aka_auth_test.go
@@ -141,21 +141,21 @@ func TestEAPPeerNak(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Unexpected Error: %v", err)
 	}
-	if !reflect.DeepEqual([]byte(peap.GetPayload()), permIdReq) {
+	if !reflect.DeepEqual(peap.GetPayload(), permIdReq) {
 		t.Fatalf("Unexpected Identity Responsen\tReceived: %.3v\n\tExpected: %.3v", peap.GetPayload(), permIdReq)
 	}
 	peap, err = aaa_client.Handle(&protos.Eap{Payload: akaPrimeNak, Ctx: peap.Ctx})
 	if err != nil {
 		t.Fatalf("Unexpected Error: %v", err)
 	}
-	if !reflect.DeepEqual([]byte(peap.GetPayload()), failureEAP) {
+	if !reflect.DeepEqual(peap.GetPayload(), failureEAP) {
 		t.Fatalf("Unexpected AKA' Nak Response\n\tReceived: %.3v\n\tExpected: %.3v", peap.GetPayload(), failureEAP)
 	}
 	peap, err = aaa_client.Handle(&protos.Eap{Payload: akaAkaPrimeNak, Ctx: eapCtx})
 	if err != nil {
 		t.Fatalf("Unexpected Error: %v", err)
 	}
-	if !reflect.DeepEqual([]byte(peap.GetPayload()), permIdReq) {
+	if !reflect.DeepEqual(peap.GetPayload(), permIdReq) {
 		t.Fatalf("Unexpected AKA['] Nak Response\n\tReceived: %.3v\n\tExpected: %.3v", peap.GetPayload(), permIdReq)
 	}
 }
@@ -187,7 +187,7 @@ func TestEAPAkaWrongPlmnId(t *testing.T) {
 		t.Fatalf("Error Handling Test EAP: %v", err)
 	}
 	notifAkaEap := aka.NewAKANotificationReq(eap.Packet(tst.EapIdentityResp).Identifier(), aka.NOTIFICATION_FAILURE)
-	if !reflect.DeepEqual([]byte(peap.GetPayload()), []byte(notifAkaEap)) {
+	if !reflect.DeepEqual(peap.GetPayload(), []byte(notifAkaEap)) {
 		t.Fatalf(
 			"Unexpected identityResponse Notification\n\tReceived: %.3v\n\tExpected: %.3v",
 			peap.GetPayload(), notifAkaEap)
@@ -222,7 +222,7 @@ func TestEAPAkaPlmnId5(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Error Handling Test EAP: %v", err)
 	}
-	if !reflect.DeepEqual([]byte(peap.GetPayload()), tst.ExpectedChallengeReq) {
+	if !reflect.DeepEqual(peap.GetPayload(), tst.ExpectedChallengeReq) {
 		t.Fatalf(
 			"Unexpected identityResponse EAP\n\tReceived: %.3v\n\tExpected: %.3v",
 			peap.GetPayload(), tst.ExpectedChallengeReq)
@@ -256,7 +256,7 @@ func TestEAPAkaPlmnId6(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Error Handling Test EAP: %v", err)
 	}
-	if !reflect.DeepEqual([]byte(peap.GetPayload()), tst.ExpectedChallengeReq) {
+	if !reflect.DeepEqual(peap.GetPayload(), tst.ExpectedChallengeReq) {
 		t.Fatalf(
 			"Unexpected identityResponse EAP\n\tReceived: %.3v\n\tExpected: %.3v",
 			peap.GetPayload(), tst.ExpectedChallengeReq)

--- a/feg/gateway/services/aaa/radius/auth.go
+++ b/feg/gateway/services/aaa/radius/auth.go
@@ -151,13 +151,13 @@ func (s *AuthServer) ServeRADIUS(w radius.ResponseWriter, r *radius.Request) {
 	eapPacket := eap.Packet(eapRes.Payload)
 	eapCode := eapPacket.Code()
 	resp := p.Response(ToRadiusCode(eapCode))
-	resp.Add(rfc2869.EAPMessage_Type, radius.Attribute(eapRes.Payload))
+	resp.Add(rfc2869.EAPMessage_Type, eapRes.Payload)
 
 	// Add key material for Access-Accept/EAP-Success message
 	if resp.Code == radius.CodeAccessAccept {
 		userNameAttr := p.Get(rfc2865.UserName_Type)
 		if userNameAttr == nil {
-			userNameAttr = radius.Attribute([]byte(postHandlerCtx.GetIdentity()))
+			userNameAttr = []byte(postHandlerCtx.GetIdentity())
 		}
 		resp.Add(rfc2865.UserName_Type, userNameAttr)
 		// Add optional Acct-Interim-Interval AVP to indicate that we want periodic Interim Updates from the client
@@ -183,9 +183,9 @@ func (s *AuthServer) ServeRADIUS(w radius.ResponseWriter, r *radius.Request) {
 	}
 }
 
-// GenSessionID creates syntetic radius session ID if none is supplied by the client
+// GenSessionID creates synthetic radius session ID if none is supplied by the client
 func GenSessionID(calling string, called string) string {
-	return fmt.Sprintf("%s__%s", string(calling), string(called))
+	return fmt.Sprintf("%s__%s", calling, called)
 }
 
 // ToRadiusCode returs the RADIUS packet code which, as per RFCxxxx

--- a/feg/gateway/services/aaa/radius/encr_test.go
+++ b/feg/gateway/services/aaa/radius/encr_test.go
@@ -43,7 +43,7 @@ func encodeWithMessageAuthenticator(p *rad.Packet) []byte {
 		panic(err)
 	}
 	size := binary.BigEndian.Uint16(encoded[2:4]) + 18
-	binary.BigEndian.PutUint16(encoded[2:4], uint16(size))
+	binary.BigEndian.PutUint16(encoded[2:4], size)
 
 	// Add Message Authenticator Attribute, 0 padded, and flatten
 	zeroedOutMsgAuthenticator := [16]byte{}

--- a/feg/gateway/services/aaa/store/in_memory.go
+++ b/feg/gateway/services/aaa/store/in_memory.go
@@ -260,7 +260,7 @@ func cleanupTimer(ctx *cleanupTimerCtx) {
 		ctx.owner.rwl.Lock()
 		if ctx.owner.sm != nil {
 			if ms, ok := ctx.owner.sm[ctx.sidKey]; ok && ms == ctx.s {
-				if atomic.CompareAndSwapPointer((*unsafe.Pointer)(&ms.cleanupTimerCtx), unsafe.Pointer(ctx), nil) {
+				if atomic.CompareAndSwapPointer(&ms.cleanupTimerCtx, unsafe.Pointer(ctx), nil) {
 					delete(ctx.owner.sm, ctx.sidKey)
 					if oldSid, ok := ctx.owner.sids[ms.imsi]; ok && oldSid == ctx.sidKey {
 						delete(ctx.owner.sids, ms.imsi)

--- a/feg/gateway/services/csfb/servicers/decode/message/decoder.go
+++ b/feg/gateway/services/csfb/servicers/decode/message/decoder.go
@@ -16,6 +16,7 @@ package message
 import (
 	"errors"
 	"fmt"
+
 	"magma/feg/cloud/go/protos"
 	"magma/feg/gateway/services/csfb/servicers/decode"
 	"magma/feg/gateway/services/csfb/servicers/decode/ie"
@@ -145,7 +146,6 @@ func DecodeSGsAPLocationUpdateReject(chunk []byte) (*any.Any, error) {
 	}
 
 	rejectCause := chunk[readIdx : readIdx+decode.LengthRejectCause]
-	readIdx += decode.LengthRejectCause
 
 	marshalledMsg, err := ptypes.MarshalAny(&protos.LocationUpdateReject{
 		Imsi:                   imsi,

--- a/feg/gateway/services/eap/attribute.go
+++ b/feg/gateway/services/eap/attribute.go
@@ -108,7 +108,7 @@ func NewAttributeScanner(eapData Packet) (*attributeScanner, error) {
 	if el <= EapFirstAttribute {
 		return nil, fmt.Errorf("EAP Message is too short (%d bytes) to include attributes", el)
 	}
-	if err := Packet(eapData).Validate(); err != nil {
+	if err := eapData.Validate(); err != nil {
 		return nil, err
 	}
 	dataLen := el - EapFirstAttribute

--- a/feg/gateway/services/eap/client/client_api_test.go
+++ b/feg/gateway/services/eap/client/client_api_test.go
@@ -86,7 +86,7 @@ func TestEAPClientApi(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Error Handling Test EAP: %v", err)
 	}
-	if !reflect.DeepEqual([]byte(peap.GetPayload()), tst.ExpectedChallengeReq) {
+	if !reflect.DeepEqual(peap.GetPayload(), tst.ExpectedChallengeReq) {
 		t.Fatalf(
 			"Unexpected identityResponse EAP\n\tReceived: %.3v\n\tExpected: %.3v",
 			peap.GetPayload(), tst.ExpectedChallengeReq)
@@ -99,10 +99,10 @@ func TestEAPClientApi(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Error Handling Test Challenge EAP: %v", err)
 	}
-	if !reflect.DeepEqual([]byte(peap.GetPayload()), []byte(eap_test.SuccessEAP)) {
+	if !reflect.DeepEqual(peap.GetPayload(), eap_test.SuccessEAP) {
 		t.Fatalf(
 			"Unexpected Challenge Response EAP\n\tReceived: %.3v\n\tExpected: %.3v",
-			peap.GetPayload(), []byte(eap_test.SuccessEAP))
+			peap.GetPayload(), eap_test.SuccessEAP)
 	}
 	// Check that we got expected MSISDN with the success EAP
 	if peap.GetCtx().Msisdn != tst.MSISDN {
@@ -111,23 +111,23 @@ func TestEAPClientApi(t *testing.T) {
 
 	// We should get a valid MSR within the auth success EAP Ctx, verify that we generated valid
 	// MS-MPPE-Recv-Key & MS-MPPE-Send-Key according to https://tools.ietf.org/html/rfc2548
-	genMS_MPPE_Recv_Key := append(
+	genMsMppeRecvKey := append(
 		expectedMppeRecvKeySalt,
 		eap.EncodeMsMppeKey(expectedMppeRecvKeySalt, peap.GetCtx().Msk[0:32], authenticator, sharedSecret)...)
 
-	genMS_MPPE_Send_Key := append(
+	genMsMppeSendKey := append(
 		expectedMppeSendKeySalt,
 		eap.EncodeMsMppeKey(expectedMppeSendKeySalt, peap.GetCtx().Msk[32:], authenticator, sharedSecret)...)
 
-	if !reflect.DeepEqual(genMS_MPPE_Recv_Key, expectedMppeRecvKey) {
+	if !reflect.DeepEqual(genMsMppeRecvKey, expectedMppeRecvKey) {
 		t.Fatalf(
 			"MS_MPPE_Recv_Keys mismatch.\n\tGenerated MS_MPPE_Recv_Key(%d): %v\n\tExpected  MS_MPPE_Recv_Key(%d): %v",
-			len(genMS_MPPE_Recv_Key), genMS_MPPE_Recv_Key, len(expectedMppeRecvKey), expectedMppeRecvKey)
+			len(genMsMppeRecvKey), genMsMppeRecvKey, len(expectedMppeRecvKey), expectedMppeRecvKey)
 	}
-	if !reflect.DeepEqual(genMS_MPPE_Send_Key, expectedMppeSendKey) {
+	if !reflect.DeepEqual(genMsMppeSendKey, expectedMppeSendKey) {
 		t.Fatalf(
 			"MS_MPPE_Send_Keys mismatch.\n\tGenerated MS_MPPE_Send_Key(%d): %v\n\tExpected  MS_MPPE_Send_Key(%d): %v",
-			len(genMS_MPPE_Send_Key), genMS_MPPE_Send_Key, len(expectedMppeSendKey), expectedMppeSendKey)
+			len(genMsMppeSendKey), genMsMppeSendKey, len(expectedMppeSendKey), expectedMppeSendKey)
 	}
 
 	time.Sleep(time.Millisecond * 10)
@@ -137,10 +137,10 @@ func TestEAPClientApi(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Error Handling Second Test Challenge EAP within Auth timeout window: %v", err)
 	}
-	if !reflect.DeepEqual([]byte(peap.GetPayload()), []byte(eap_test.SuccessEAP)) {
+	if !reflect.DeepEqual(peap.GetPayload(), eap_test.SuccessEAP) {
 		t.Fatalf(
 			"Unexpected Challenge Response EAP\n\tReceived: %.3v\n\tExpected: %.3v",
-			peap.GetPayload(), []byte(eap_test.SuccessEAP))
+			peap.GetPayload(), eap_test.SuccessEAP)
 	}
 
 	time.Sleep(servicer.SessionAuthenticatedTimeout() + time.Millisecond*100)

--- a/feg/gateway/services/eap/eap_router/eap_router_test.go
+++ b/feg/gateway/services/eap/eap_router/eap_router_test.go
@@ -42,7 +42,7 @@ type testEapRouter struct {
 	supportedMethods []byte
 }
 
-func (s *testEapRouter) HandleIdentity(ctx context.Context, in *protos.EapIdentity) (*protos.Eap, error) {
+func (s *testEapRouter) HandleIdentity(_ context.Context, in *protos.EapIdentity) (*protos.Eap, error) {
 	resp, err := eap_client.HandleIdentityResponse(
 		uint8(in.GetMethod()), &protos.Eap{Payload: in.Payload, Ctx: in.Ctx})
 	if err != nil && resp != nil && len(resp.GetPayload()) > 0 {
@@ -50,7 +50,7 @@ func (s *testEapRouter) HandleIdentity(ctx context.Context, in *protos.EapIdenti
 	}
 	return resp, err
 }
-func (s *testEapRouter) Handle(ctx context.Context, in *protos.Eap) (*protos.Eap, error) {
+func (s *testEapRouter) Handle(_ context.Context, in *protos.Eap) (*protos.Eap, error) {
 	resp, err := eap_client.Handle(in)
 	if err != nil && resp != nil && len(resp.GetPayload()) > 0 {
 		err = nil
@@ -58,7 +58,7 @@ func (s *testEapRouter) Handle(ctx context.Context, in *protos.Eap) (*protos.Eap
 	return resp, err
 
 }
-func (s *testEapRouter) SupportedMethods(ctx context.Context, in *protos.Void) (*protos.EapMethodList, error) {
+func (s *testEapRouter) SupportedMethods(_ context.Context, _ *protos.Void) (*protos.EapMethodList, error) {
 	return &protos.EapMethodList{Methods: s.supportedMethods}, nil
 }
 
@@ -156,21 +156,21 @@ func TestEAPPeerNak(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Unexpected Error: %v", err)
 	}
-	if !reflect.DeepEqual([]byte(peap.GetPayload()), permIdReq) {
+	if !reflect.DeepEqual(peap.GetPayload(), permIdReq) {
 		t.Fatalf("Unexpected Identity Responsen\tReceived: %.3v\n\tExpected: %.3v", peap.GetPayload(), permIdReq)
 	}
 	peap, err = client.Handle(&protos.Eap{Payload: akaPrimeNak, Ctx: peap.Ctx})
 	if err != nil {
 		t.Fatalf("Unexpected Error: %v", err)
 	}
-	if !reflect.DeepEqual([]byte(peap.GetPayload()), failureEAP) {
+	if !reflect.DeepEqual(peap.GetPayload(), failureEAP) {
 		t.Fatalf("Unexpected AKA' Nak Response\n\tReceived: %.3v\n\tExpected: %.3v", peap.GetPayload(), failureEAP)
 	}
 	peap, err = client.Handle(&protos.Eap{Payload: akaAkaPrimeNak, Ctx: eapCtx})
 	if err != nil {
 		t.Fatalf("Unexpected Error: %v", err)
 	}
-	if !reflect.DeepEqual([]byte(peap.GetPayload()), permIdReq) {
+	if !reflect.DeepEqual(peap.GetPayload(), permIdReq) {
 		t.Fatalf("Unexpected AKA['] Nak Response\n\tReceived: %.3v\n\tExpected: %.3v", peap.GetPayload(), permIdReq)
 	}
 }
@@ -204,7 +204,7 @@ func TestEAPAkaWrongPlmnId(t *testing.T) {
 		t.Fatalf("Error Handling Test EAP: %v", err)
 	}
 	notifAkaEap := aka.NewAKANotificationReq(eap.Packet(tst.EapIdentityResp).Identifier(), aka.NOTIFICATION_FAILURE)
-	if !reflect.DeepEqual([]byte(peap.GetPayload()), []byte(notifAkaEap)) {
+	if !reflect.DeepEqual(peap.GetPayload(), []byte(notifAkaEap)) {
 		t.Fatalf(
 			"Unexpected identityResponse Notification\n\tReceived: %.3v\n\tExpected: %.3v",
 			peap.GetPayload(), notifAkaEap)
@@ -241,7 +241,7 @@ func TestEAPAkaPlmnId5(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Error Handling Test EAP: %v", err)
 	}
-	if !reflect.DeepEqual([]byte(peap.GetPayload()), tst.ExpectedChallengeReq) {
+	if !reflect.DeepEqual(peap.GetPayload(), tst.ExpectedChallengeReq) {
 		t.Fatalf(
 			"Unexpected identityResponse EAP\n\tReceived: %.3v\n\tExpected: %.3v",
 			peap.GetPayload(), tst.ExpectedChallengeReq)
@@ -277,7 +277,7 @@ func TestEAPAkaPlmnId6(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Error Handling Test EAP: %v", err)
 	}
-	if !reflect.DeepEqual([]byte(peap.GetPayload()), tst.ExpectedChallengeReq) {
+	if !reflect.DeepEqual(peap.GetPayload(), tst.ExpectedChallengeReq) {
 		t.Fatalf(
 			"Unexpected identityResponse EAP\n\tReceived: %.3v\n\tExpected: %.3v",
 			peap.GetPayload(), tst.ExpectedChallengeReq)

--- a/feg/gateway/services/eap/providers/aka/servicers/handlers/aka_challenge_test.go
+++ b/feg/gateway/services/eap/providers/aka/servicers/handlers/aka_challenge_test.go
@@ -54,7 +54,7 @@ func TestAkaChallengeResp(t *testing.T) {
 	if len(eapCtx.SessionId) == 0 {
 		t.Fatal("Empty Session ID")
 	}
-	if !reflect.DeepEqual([]byte(p), []byte(expectedTestEapChallengeResp)) {
+	if !reflect.DeepEqual([]byte(p), expectedTestEapChallengeResp) {
 		t.Fatalf("Unexpected identityResponse EAP\n\tReceived: %v\n\tExpected: %v", p, expectedTestEapChallengeResp)
 	}
 

--- a/feg/gateway/services/eap/providers/aka/servicers/handlers/aka_identity_test.go
+++ b/feg/gateway/services/eap/providers/aka/servicers/handlers/aka_identity_test.go
@@ -193,10 +193,10 @@ func TestAkaChallenge(t *testing.T) {
 	if attr == nil {
 		t.Fatal("Nil AT_MAC Attribute")
 	}
-	if attr.Type() != aka.AT_MAC || !reflect.DeepEqual(attr.Marshaled(), []byte(expectedTestMac)) {
-		t.Fatalf("Invalid AT_MAC:\n\tExpected: %v\n\tReceived: %v\n", []byte(expectedTestMac), attr.Marshaled())
+	if attr.Type() != aka.AT_MAC || !reflect.DeepEqual(attr.Marshaled(), expectedTestMac) {
+		t.Fatalf("Invalid AT_MAC:\n\tExpected: %v\n\tReceived: %v\n", expectedTestMac, attr.Marshaled())
 	}
-	if !reflect.DeepEqual([]byte(p), []byte(expectedTestEapChallengeResp)) {
+	if !reflect.DeepEqual([]byte(p), expectedTestEapChallengeResp) {
 		t.Fatalf("Unexpected identityResponse EAP\n\tReceived: %.3v\n\tExpected: %.3v",
 			p, expectedTestEapChallengeResp)
 	}

--- a/feg/gateway/services/eap/providers/sim/definitions.go
+++ b/feg/gateway/services/eap/providers/sim/definitions.go
@@ -100,9 +100,9 @@ const (
 	DefaultErrorNotificationTimeout    = time.Second * 10
 	DefaultSessionTimeout              = time.Hour * 12
 	DefaultSessionAuthenticatedTimeout = time.Second * 5
+	GsmTripletsNumber                  = 3
 
-	Version           byte = 1 // SIM's Supported Version
-	GsmTripletsNumber      = 3
+	Version byte = 1 // SIM's Supported Version
 )
 
 type IMSI string

--- a/feg/gateway/services/eap/providers/sim/mac_test.go
+++ b/feg/gateway/services/eap/providers/sim/mac_test.go
@@ -166,20 +166,20 @@ func TestMacGeneration(t *testing.T) {
 		t.Fatalf("Invalid MAC Len: %d", len(mac))
 	}
 	// compare generated MAC with expected
-	if !reflect.DeepEqual(mac, []byte(expectedMac)) {
+	if !reflect.DeepEqual(mac, expectedMac) {
 		t.Fatalf(
 			"MACs don't match.\n\tGenerated MAC(%d): %v\n\tExpected  MAC(%d): %v",
-			len(mac), mac, len(expectedMac), []byte(expectedMac))
+			len(mac), mac, len(expectedMac), expectedMac)
 	}
 	mac = GenChallengeMac(challengeTestData, sres, K_aut)
 	if len(mac) != 16 {
 		t.Fatalf("Invalid Challenge MAC Len: %d", len(mac))
 	}
 	// compare generated ChallengeMAC with expected
-	if !reflect.DeepEqual(mac, []byte(expectedChellengeMac)) {
+	if !reflect.DeepEqual(mac, expectedChellengeMac) {
 		t.Fatalf(
 			"Challenge MACs don't match.\n\tGenerated MAC(%d): %v\n\tExpected  MAC(%d): %v",
-			len(mac), mac, len(expectedChellengeMac), []byte(expectedChellengeMac))
+			len(mac), mac, len(expectedChellengeMac), expectedChellengeMac)
 	}
 }
 

--- a/feg/gateway/services/eap/test/utils.go
+++ b/feg/gateway/services/eap/test/utils.go
@@ -60,7 +60,7 @@ func Auth(t *testing.T, client EapClient, imsi string, iter int, done chan error
 			err = fmt.Errorf("Error Handling Test EAP: %v", err)
 			return
 		}
-		if !reflect.DeepEqual([]byte(peap.GetPayload()), tst.ExpectedChallengeReq) {
+		if !reflect.DeepEqual(peap.GetPayload(), tst.ExpectedChallengeReq) {
 			err = fmt.Errorf("Unexpected identityResponse EAP\n\tReceived: %s\n\tExpected: %s",
 				eap_client.BytesToStr(peap.GetPayload()), eap_client.BytesToStr(tst.ExpectedChallengeReq))
 			return
@@ -73,10 +73,10 @@ func Auth(t *testing.T, client EapClient, imsi string, iter int, done chan error
 			return
 		}
 		successp := []byte{eap.SuccessCode, eap.Packet(tst.EapChallengeResp).Identifier(), 0, 4}
-		if !reflect.DeepEqual([]byte(peap.GetPayload()), []byte(successp)) {
+		if !reflect.DeepEqual(peap.GetPayload(), successp) {
 			err = fmt.Errorf(
 				"Unexpected Challenge Response EAP for Session: %s in %s\n\tReceived: %.3v\n\tExpected: %.3v",
-				peap.GetCtx().GetSessionId(), time.Since(startTime), peap.GetPayload(), []byte(successp))
+				peap.GetCtx().GetSessionId(), time.Since(startTime), peap.GetPayload(), successp)
 			return
 		}
 		// Check that we got expected MSISDN with the success EAP

--- a/feg/gateway/services/radiusd/collection/fetch.go
+++ b/feg/gateway/services/radiusd/collection/fetch.go
@@ -14,7 +14,6 @@ limitations under the License.
 package collection
 
 import (
-	"errors"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -49,14 +48,14 @@ func NewMetricsRequester() (*MetricsRequester, error) {
 func (r *MetricsRequester) FetchMetrics() (string, error) {
 	resp, err := http.Get(r.metricsUrl)
 	if err != nil {
-		return "", errors.New(fmt.Sprintf("Failed GET request: %s", err))
+		return "", fmt.Errorf("Failed GET request: %s", err)
 	}
 
 	defer resp.Body.Close()
 
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
-		return "", errors.New(fmt.Sprintf("Failed to read GET response body: %s", err))
+		return "", fmt.Errorf("Failed to read GET response body: %s", err)
 	}
 
 	return string(body), nil

--- a/feg/gateway/services/radiusd/collection/metric_aggregate.go
+++ b/feg/gateway/services/radiusd/collection/metric_aggregate.go
@@ -14,7 +14,6 @@ limitations under the License.
 package collection
 
 import (
-	"errors"
 	"fmt"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -52,7 +51,7 @@ func CreateMetricAggregate(metricName string, metricFamily *dto.MetricFamily) (M
 	metricType := metricFamily.GetType()
 	labelArr, err := getLabelNames(metricFamily)
 	if err != nil {
-		return nil, errors.New(fmt.Sprintf("Failed to build metric collector: %s\n", err))
+		return nil, fmt.Errorf("Failed to build metric collector: %s\n", err)
 	}
 	metricHelp := metricFamily.GetHelp()
 
@@ -96,7 +95,7 @@ func CreateMetricAggregate(metricName string, metricFamily *dto.MetricFamily) (M
 		}
 	}
 	// Do not parse other metric types
-	return nil, errors.New(fmt.Sprintf("Not building MetricAggregate for metric type %s", metricType))
+	return nil, fmt.Errorf("Not building MetricAggregate for metric type %s", metricType)
 }
 
 func (ma *GaugeMetricAggregate) Update(metricFamily *dto.MetricFamily) {

--- a/feg/gateway/services/radiusd/collection/parse.go
+++ b/feg/gateway/services/radiusd/collection/parse.go
@@ -14,7 +14,6 @@ limitations under the License.
 package collection
 
 import (
-	"errors"
 	"fmt"
 	"strings"
 
@@ -31,7 +30,7 @@ func ParsePrometheusText(prometheusText string) (map[string]*dto.MetricFamily, e
 	parser := expfmt.TextParser{}
 	metricFamilies, err := parser.TextToMetricFamilies(reader)
 	if err != nil {
-		return nil, errors.New(fmt.Sprintf("Error parsing metric families from text: %s", err))
+		return nil, fmt.Errorf("Error parsing metric families from text: %s", err)
 	}
 
 	return metricFamilies, nil

--- a/feg/gateway/services/s6a_proxy/servicers/ul.go
+++ b/feg/gateway/services/s6a_proxy/servicers/ul.go
@@ -43,8 +43,8 @@ func (s *s6aProxy) sendULR(sid string, req *protos.UpdateLocationRequest, retryC
 	s.addDiamOriginAVPs(m)
 	m.NewAVP(avp.UserName, avp.Mbit, 0, datatype.UTF8String(req.UserName))
 	m.NewAVP(avp.AuthSessionState, avp.Mbit, 0, datatype.Enumerated(1))
-	m.NewAVP(avp.RATType, avp.Mbit, uint32(diameter.Vendor3GPP), datatype.Enumerated(ULR_RAT_TYPE))
-	m.NewAVP(avp.ULRFlags, avp.Vbit|avp.Mbit, uint32(diameter.Vendor3GPP), datatype.Unsigned32(createULR_Flags(req)))
+	m.NewAVP(avp.RATType, avp.Mbit, diameter.Vendor3GPP, datatype.Enumerated(ULR_RAT_TYPE))
+	m.NewAVP(avp.ULRFlags, avp.Vbit|avp.Mbit, diameter.Vendor3GPP, datatype.Unsigned32(createULR_Flags(req)))
 	m.NewAVP(avp.VisitedPLMNID, avp.Vbit|avp.Mbit, diameter.Vendor3GPP, datatype.OctetString(req.VisitedPlmn))
 
 	// Supported feature-List-id-2

--- a/feg/gateway/services/s8_proxy/servicers/ie_conversions.go
+++ b/feg/gateway/services/s8_proxy/servicers/ie_conversions.go
@@ -72,7 +72,7 @@ func buildCreateSessionRequestMsg(cPgwUDPAddr *net.UDPAddr, req *protos.CreateSe
 		getRatType(req.RatType),
 		getSelectionModeType(req.SelectionMode),
 		getProtocolConfigurationOptions(req.ProtocolConfigurationOptions),
-		ie.NewMSISDN(string(req.Msisdn[:])),
+		ie.NewMSISDN(req.Msisdn[:]),
 		ie.NewMobileEquipmentIdentity(req.Mei),
 		ie.NewServingNetwork(req.ServingNetwork.Mcc, req.ServingNetwork.Mnc),
 		ie.NewAccessPointName(req.Apn),

--- a/feg/gateway/services/session_proxy/credit_control/gx/model_conversion_test.go
+++ b/feg/gateway/services/session_proxy/credit_control/gx/model_conversion_test.go
@@ -37,10 +37,10 @@ func TestReAuthRequest_ToProto(t *testing.T) {
 	bearerID := "bearer1"
 	var ratingGroup uint32 = 42
 	var totalOctets uint64 = 2048
-	var monitorSupport_0 gx.MonitoringSupport = gx.UsageMonitoringDisabled
-	var monitorReport_0 gx.MonitoringReport = gx.UsageMonitoringReport
+	var monitorSupport0 = gx.UsageMonitoringDisabled
+	var monitorReport0 = gx.UsageMonitoringReport
 	var qci uint32 = 1
-	var monitoringLevel gx.MonitoringLevel = gx.SessionLevel
+	var monitoringLevel = gx.SessionLevel
 	currentTime := time.Now()
 	protoTimestamp, err := ptypes.TimestampProto(currentTime)
 	assert.NoError(t, err)
@@ -59,7 +59,7 @@ func TestReAuthRequest_ToProto(t *testing.T) {
 				RuleBaseNames: nil,
 				RuleDefinitions: []*gx.RuleDefinition{
 					{RuleName: "dynamic1",
-						MonitoringKey: []byte(monitoringKey),
+						MonitoringKey: monitoringKey,
 						Precedence:    100,
 						RatingGroup:   &ratingGroup},
 				},
@@ -85,13 +85,13 @@ func TestReAuthRequest_ToProto(t *testing.T) {
 					TotalOctets:  &totalOctets,
 				},
 				Level:   monitoringLevel,
-				Support: &monitorSupport_0,
+				Support: &monitorSupport0,
 			},
 			{
 				MonitoringKey:      monitoringKey3,
 				GrantedServiceUnit: nil,
 				Level:              monitoringLevel,
-				Report:             &monitorReport_0,
+				Report:             &monitorReport0,
 			},
 		},
 		Qos: &gx.QosInformation{
@@ -134,7 +134,7 @@ func TestReAuthRequest_ToProto(t *testing.T) {
 				PolicyRule: &protos.PolicyRule{
 					Id:            "dynamic1",
 					RatingGroup:   42,
-					MonitoringKey: []byte(monitoringKey),
+					MonitoringKey: monitoringKey,
 					Priority:      100,
 					TrackingType:  protos.PolicyRule_OCS_AND_PCRF,
 					Redirect:      &protos.RedirectInformation{},
@@ -149,7 +149,7 @@ func TestReAuthRequest_ToProto(t *testing.T) {
 		UsageMonitoringCredits: []*protos.UsageMonitoringCredit{
 			{
 				Action:        protos.UsageMonitoringCredit_CONTINUE,
-				MonitoringKey: []byte(monitoringKey),
+				MonitoringKey: monitoringKey,
 				GrantedUnits: &protos.GrantedUnits{
 					Total: &protos.CreditUnit{IsValid: true, Volume: totalOctets},
 					Tx:    &protos.CreditUnit{IsValid: false},
@@ -159,7 +159,7 @@ func TestReAuthRequest_ToProto(t *testing.T) {
 			},
 			{
 				Action:        protos.UsageMonitoringCredit_DISABLE,
-				MonitoringKey: []byte(monitoringKey2),
+				MonitoringKey: monitoringKey2,
 				GrantedUnits: &protos.GrantedUnits{
 					Total: &protos.CreditUnit{IsValid: true, Volume: totalOctets},
 					Tx:    &protos.CreditUnit{IsValid: true, Volume: totalOctets},
@@ -174,7 +174,7 @@ func TestReAuthRequest_ToProto(t *testing.T) {
 					Tx:    &protos.CreditUnit{IsValid: false},
 					Rx:    &protos.CreditUnit{IsValid: false},
 				},
-				MonitoringKey: []byte(monitoringKey3),
+				MonitoringKey: monitoringKey3,
 				Level:         protos.MonitoringLevel(monitoringLevel),
 			},
 		},

--- a/feg/gateway/services/swx_proxy/servicers/auth.go
+++ b/feg/gateway/services/swx_proxy/servicers/auth.go
@@ -249,15 +249,15 @@ func (s *swxProxy) createMAR(sid string, req *protos.AuthenticationRequest) (*di
 	msg.NewAVP(avp.OriginRealm, avp.Mbit, 0, datatype.DiameterIdentity(s.config.ClientCfg.Realm))
 	msg.NewAVP(avp.UserName, avp.Mbit, 0, datatype.UTF8String(req.GetUserName()))
 	msg.NewAVP(avp.AuthSessionState, avp.Mbit, 0, datatype.Enumerated(1))
-	msg.NewAVP(avp.SIPNumberAuthItems, avp.Mbit|avp.Vbit, uint32(diameter.Vendor3GPP), datatype.Unsigned32(req.GetSipNumAuthVectors()))
+	msg.NewAVP(avp.SIPNumberAuthItems, avp.Mbit|avp.Vbit, diameter.Vendor3GPP, datatype.Unsigned32(req.GetSipNumAuthVectors()))
 	msg.NewAVP(avp.RATType, avp.Mbit|avp.Vbit, diameter.Vendor3GPP, datatype.Enumerated(RadioAccessTechnologyType_WLAN))
 	authDataAvp := []*diam.AVP{
-		diam.NewAVP(avp.SIPAuthenticationScheme, avp.Mbit|avp.Vbit, uint32(diameter.Vendor3GPP), datatype.UTF8String(authScheme)),
+		diam.NewAVP(avp.SIPAuthenticationScheme, avp.Mbit|avp.Vbit, diameter.Vendor3GPP, datatype.UTF8String(authScheme)),
 	}
 	if len(req.GetResyncInfo()) > 0 {
 		authDataAvp = append(
 			authDataAvp,
-			diam.NewAVP(avp.SIPAuthorization, avp.Mbit|avp.Vbit, uint32(diameter.Vendor3GPP), datatype.OctetString(req.GetResyncInfo())),
+			diam.NewAVP(avp.SIPAuthorization, avp.Mbit|avp.Vbit, diameter.Vendor3GPP, datatype.OctetString(req.GetResyncInfo())),
 		)
 	}
 	msg.NewAVP(avp.SIPAuthDataItem, avp.Mbit|avp.Vbit, diameter.Vendor3GPP, &diam.GroupedAVP{AVP: authDataAvp})
@@ -295,7 +295,7 @@ func getSIPAuthenticationVectors(items []SIPAuthDataItem) []*protos.Authenticati
 		authVectors = append(
 			authVectors,
 			&protos.AuthenticationAnswer_SIPAuthVector{
-				AuthenticationScheme: protos.AuthenticationScheme(authScheme),
+				AuthenticationScheme: authScheme,
 				RandAutn:             item.Authenticate.Serialize(),
 				Xres:                 item.Authorization.Serialize(),
 				ConfidentialityKey:   item.ConfidentialityKey.Serialize(),
@@ -306,17 +306,17 @@ func getSIPAuthenticationVectors(items []SIPAuthDataItem) []*protos.Authenticati
 
 func validateAuthRequest(req *protos.AuthenticationRequest) error {
 	if req == nil {
-		return fmt.Errorf("Nil authentication request provided")
+		return fmt.Errorf("nil authentication request provided")
 	}
 	if len(req.GetUserName()) == 0 {
-		return fmt.Errorf("Empty user-name provided in authentication request")
+		return fmt.Errorf("empty user-name provided in authentication request")
 	}
 	if req.SipNumAuthVectors == 0 {
 		return fmt.Errorf("SIPNumAuthVectors in authentication request must be greater than 0")
 	}
 	// imsi cannot be greater than 15 digits according to 3GPP Spec 23.003
 	if len(req.GetUserName()) > 15 {
-		return fmt.Errorf("Provided username %s is greater than 15 digits", req.GetUserName())
+		return fmt.Errorf("provided username %s is greater than 15 digits", req.GetUserName())
 	}
 	return nil
 }
@@ -328,7 +328,7 @@ func convertStringToAuthScheme(maaScheme string) (protos.AuthenticationScheme, e
 	case SipAuthScheme_EAP_AKA_PRIME:
 		return protos.AuthenticationScheme_EAP_AKA_PRIME, nil
 	default:
-		return protos.AuthenticationScheme_EAP_AKA, fmt.Errorf("Unrecognized Authentication Scheme returned: %s", maaScheme)
+		return protos.AuthenticationScheme_EAP_AKA, fmt.Errorf("unrecognized Authentication Scheme returned: %s", maaScheme)
 	}
 }
 
@@ -339,6 +339,6 @@ func convertAuthSchemeToString(scheme protos.AuthenticationScheme) (string, erro
 	case protos.AuthenticationScheme_EAP_AKA_PRIME:
 		return SipAuthScheme_EAP_AKA_PRIME, nil
 	default:
-		return "", fmt.Errorf("Unrecognized Authentication Scheme returned: %v", scheme)
+		return "", fmt.Errorf("unrecognized Authentication Scheme returned: %v", scheme)
 	}
 }

--- a/feg/gateway/services/swx_proxy/servicers/rt.go
+++ b/feg/gateway/services/swx_proxy/servicers/rt.go
@@ -132,7 +132,7 @@ func handleRTR(s *swxProxy) diam.HandlerFunc {
 func (s *swxProxy) sendRTA(c diam.Conn, m *diam.Message, code protos.ErrorCode, rtr *RTR, retries uint) error {
 	ans := m.Answer(uint32(code))
 	// SessionID is required to be the AVP in position 1
-	ans.InsertAVP(diam.NewAVP(avp.SessionID, avp.Mbit, 0, datatype.UTF8String(rtr.SessionID)))
+	ans.InsertAVP(diam.NewAVP(avp.SessionID, avp.Mbit, 0, rtr.SessionID))
 	ans.NewAVP(avp.AuthSessionState, avp.Mbit, 0, datatype.Enumerated(rtr.AuthSessionState))
 	m.NewAVP(avp.OriginHost, avp.Mbit, 0, datatype.DiameterIdentity(s.config.ClientCfg.Host))
 	m.NewAVP(avp.OriginRealm, avp.Mbit, 0, datatype.DiameterIdentity(s.config.ClientCfg.Realm))

--- a/feg/gateway/services/swx_proxy/servicers/swx_proxy_test.go
+++ b/feg/gateway/services/swx_proxy/servicers/swx_proxy_test.go
@@ -102,7 +102,7 @@ func TestSwxProxyService_ValidationErrors(t *testing.T) {
 
 	emptyAuthReq := &protos.AuthenticationRequest{}
 	_, err = client.Authenticate(context.Background(), emptyAuthReq)
-	assert.EqualError(t, err, "rpc error: code = InvalidArgument desc = Empty user-name provided in authentication request")
+	assert.EqualError(t, err, "rpc error: code = InvalidArgument desc = empty user-name provided in authentication request")
 
 	badNumVectorsReq := &protos.AuthenticationRequest{
 		UserName:             "10111011000110",

--- a/feg/gateway/services/swx_proxy/servicers/test/test_swx_server.go
+++ b/feg/gateway/services/swx_proxy/servicers/test/test_swx_server.go
@@ -158,7 +158,7 @@ func testSendMAA(w io.Writer, m *diam.Message, vectors int) (n int64, err error)
 		m.NewAVP(avp.SIPAuthDataItem, avp.Mbit|avp.Vbit, VENDOR_3GPP, &diam.GroupedAVP{
 			AVP: []*diam.AVP{
 				diam.NewAVP(avp.SIPAuthenticationScheme, avp.Mbit|avp.Vbit, VENDOR_3GPP, datatype.UTF8String("EAP-AKA")),
-				diam.NewAVP(avp.SIPAuthenticate, avp.Mbit|avp.Vbit, VENDOR_3GPP, datatype.OctetString(DefaultSIPAuthenticate+strconv.Itoa(int(14+i)))),
+				diam.NewAVP(avp.SIPAuthenticate, avp.Mbit|avp.Vbit, VENDOR_3GPP, datatype.OctetString(DefaultSIPAuthenticate+strconv.Itoa(14+i))),
 				diam.NewAVP(avp.SIPAuthorization, avp.Mbit|avp.Vbit, VENDOR_3GPP, datatype.OctetString(DefaultSIPAuthorization)),
 				diam.NewAVP(avp.ConfidentialityKey, avp.Mbit|avp.Vbit, VENDOR_3GPP, datatype.OctetString(DefaultCK)),
 				diam.NewAVP(avp.IntegrityKey, avp.Mbit|avp.Vbit, VENDOR_3GPP, datatype.OctetString(DefaultIK)),

--- a/feg/gateway/services/testcore/hss/servicers/hss_diameter_integration_test.go
+++ b/feg/gateway/services/testcore/hss/servicers/hss_diameter_integration_test.go
@@ -164,10 +164,10 @@ func getConnectionToTestHSS(t *testing.T, clientHandler diam.HandlerFunc) (diam.
 
 	// Create a client to receive the server's messages.
 	clientMux := sm.New(&sm.Settings{
-		OriginHost:       datatype.DiameterIdentity("magma.com"),
-		OriginRealm:      datatype.DiameterIdentity("magma.com"),
+		OriginHost:       "magma.com",
+		OriginRealm:      "magma.com",
 		VendorID:         datatype.Unsigned32(diameter.Vendor3GPP),
-		ProductName:      datatype.UTF8String("magma"),
+		ProductName:      "magma",
 		OriginStateID:    datatype.Unsigned32(time.Now().Unix()),
 		FirmwareRevision: 1,
 	})

--- a/feg/radius/src/modules/eap/methods/akamagma/aka_magma.go
+++ b/feg/radius/src/modules/eap/methods/akamagma/aka_magma.go
@@ -202,7 +202,7 @@ func (m EapAkaMagmaMethod) Handle(
 		// Add User-Name attribute, which is mandatory
 		result.ExtraAttributes[rfc2865.UserName_Type] =
 			[]radius.Attribute{
-				radius.Attribute([]byte(postHandlerContext.Identity)),
+				radius.Attribute(postHandlerContext.Identity),
 			}
 	}
 	return result, nil

--- a/feg/radius/src/modules/eap/methods/akatataipx/akatataipx.go
+++ b/feg/radius/src/modules/eap/methods/akatataipx/akatataipx.go
@@ -140,7 +140,7 @@ func (m EapAkaTataIpxMethod) Handle(
 		// Add required User-Name
 		result.ExtraAttributes[rfc2865.UserName_Type] =
 			[]radius.Attribute{
-				radius.Attribute([]byte(currentState.Identity)),
+				radius.Attribute(currentState.Identity),
 			}
 	}
 


### PR DESCRIPTION
Signed-off-by: Oriol Batalla <obatalla@fb.com><!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary

Add linter for golang in FEG
Also fix some mistakes on code coverage endpoint at Makefile for feg

## Test Plan

make lint
make cover

```
golangci-lint run
mconfig_test/mconfig_test.go:309: File is not `gofmt`-ed with `-s` (gofmt)
					&fegmcfg.DiamClientConfig{
multiplex/multiplex_test.go:40: File is not `gofmt`-ed with `-s` (gofmt)
		muxSelectorsScenario{"IMSI******789012345-54321", "IMSI******789012345", ******789012345, false},
		muxSelectorsScenario{"IMSI999999999999999-54321", "IMSI999999999999999", 999999999999999, false},
		muxSelectorsScenario{"IMSI000000000000010-54321", "IMSI000000000000010", 10, false},
		muxSelectorsScenario{"IMSI1234AAAAA012345-54321", "IMSI1234AAAAA012345", 0, true},
policydb/streamer.go:88: File is not `gofmt`-ed with `-s` (gofmt)
	for key, _ := range currMap {
services/aaa/session_manager/client_api.go:19: File is not `goimports`-ed (goimports)
	"fmt"
services/envoy_controller/servicers/envoy_controller.go:19: File is not `goimports`-ed (goimports)
	"magma/feg/gateway/services/envoy_controller/control_plane"
services/swx_proxy/servicers/multiple_swx_proxy.go:24: File is not `goimports`-ed (goimports)
	"golang.org/x/net/context"
services/csfb/servicers/encode/ie/encoder_test.go:63:26: ineffectual assignment to `err` (ineffassign)
	expectedEncodedMMEName, err := ie.EncodeFixedLengthIE(
	                        ^
services/csfb/servicers/decode/ie/decoder_test.go:162:10: ineffectual assignment to `ieLength` (ineffassign)
	mmInfo, ieLength, err = ie.DecodeVariableLengthIE(wrongChunk3[:3], decode.IELengthMMInformationMin, decode.IEIMMInformation)
	        ^
services/csfb/servicers/decode/message/decoder.go:148:2: ineffectual assignment to `readIdx` (ineffassign)
	readIdx += decode.LengthRejectCause
	^
diameter/connection_manager_test.go:170:8: ineffectual assignment to `err` (ineffassign)
	c, _, err = conn.getDiamConnection()
	      ^
services/s8_proxy/servicers/s8_proxy_test.go:234:2: ineffectual assignment to `dsReq` (ineffassign)
	dsReq := &protos.DeleteSessionRequestPgw{Imsi: "000000000000015"}
```

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->

<!--
    Final note

    Please take a moment to read through the Magma project's
    - Contributing conventions: https://docs.magmacore.org/docs/next/contributing/contribute_conventions

    If this is your first time opening a PR, also consider reading
    - Developer onboarding: https://docs.magmacore.org/docs/next/contributing/contribute_onboarding
    - Development workflow: https://docs.magmacore.org/docs/next/contributing/contribute_workflow
-->
