### PR TITLE
[swagger] Fix styling for swagger page

### DIFF
--- a/orc8r/cloud/go/obsidian/swagger/v1/css/sidebar.css
+++ b/orc8r/cloud/go/obsidian/swagger/v1/css/sidebar.css
@@ -39,5 +39,5 @@
 
 /* Prevent overlap with fixed sidebar*/
 .swagger-ui {
-  margin-left: 5%;
+  margin-left: 200px;
 }


### PR DESCRIPTION
Signed-off-by: Andrei Lee <andreilee@fb.com>

## Summary

<!-- Enumerate changes you made and why you made them -->

Small styling change for our swagger API page to account for various window widths.

Before:
<img width="682" alt="Screen Shot 2021-04-12 at 4 23 14 PM" src="https://user-images.githubusercontent.com/804385/114474632-7e8fd380-9bab-11eb-9b0a-5927e7acf468.png">

After:
<img width="937" alt="Screen Shot 2021-04-12 at 4 23 19 PM" src="https://user-images.githubusercontent.com/804385/114474645-83ed1e00-9bab-11eb-8fa2-811bbaf660ae.png">


## Test Plan

N/A

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->

<!--
    Final note

    Please take a moment to read through the Magma project's
    - Contributing conventions: https://docs.magmacore.org/docs/next/contributing/contribute_conventions

    If this is your first time opening a PR, also consider reading
    - Developer onboarding: https://docs.magmacore.org/docs/next/contributing/contribute_onboarding
    - Development workflow: https://docs.magmacore.org/docs/next/contributing/contribute_workflow
-->
