### PR TITLE
[lte][agw] Fixing attach type update on guti identity attach proc

### DIFF
--- a/lte/gateway/c/oai/tasks/nas/emm/Attach.c
+++ b/lte/gateway/c/oai/tasks/nas/emm/Attach.c
@@ -334,6 +334,8 @@ int emm_proc_attach_request(
       nas_proc_implicit_detach_ue_ind(guti_ue_mm_ctx->mme_ue_s1ap_id);
       OAILOG_FUNC_RETURN(LOG_NAS_EMM, RETURNok);
     }
+    // Allocate new context and process the new request as fresh attach request
+    clear_emm_ctxt = true;
   }
   if (ies->imsi) {
     imsi_ue_mm_ctx =


### PR DESCRIPTION
Signed-off-by: Alex Rodriguez <ardzoht@gmail.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->
- There was a regression on the handling of GUTI attach type introduced on #4769 , when creating and allocating the `emm_ctxt` struct, this PR fixes this

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->
- tested locally by modifying `test_attach_via_guti` with specifying EPS/IMSI attach type to ensure attach result contains same attach type on the request

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->

<!--
    Final note

    Please take a moment to read through the Magma project's
    - Contributing conventions: https://docs.magmacore.org/docs/next/contributing/contribute_conventions

    If this is your first time opening a PR, also consider reading
    - Developer onboarding: https://docs.magmacore.org/docs/next/contributing/contribute_onboarding
    - Development workflow: https://docs.magmacore.org/docs/next/contributing/contribute_workflow
-->
