### PR TITLE
[teravm] Add restart of sctpd after update AGW

### DIFF
--- a/ci-scripts/teravm/fabfile.py
+++ b/ci-scripts/teravm/fabfile.py
@@ -174,6 +174,9 @@ def upgrade_teravm_agw(setup, hash, key_filename=DEFAULT_KEY_FILENAME):
                         hash=hash
                     )
                 )
+            # restart sctpd to force clean start
+            sudo("service sctpd restart")
+
         except Exception:
             err = (
                 "Error during install of version {} on AGW. "


### PR DESCRIPTION
Signed-off-by: Oriol Batalla <obatalla@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary

Restart sctpd after update agw to make sure all the redis tables are cleared (especially the ones at sessiond that may have non terminated sessions from previous runs)

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->

<!--
    Final note

    Please take a moment to read through the Magma project's
    - Contributing conventions: https://docs.magmacore.org/docs/next/contributing/contribute_conventions

    If this is your first time opening a PR, also consider reading
    - Developer onboarding: https://docs.magmacore.org/docs/next/contributing/contribute_onboarding
    - Development workflow: https://docs.magmacore.org/docs/next/contributing/contribute_workflow
-->
