### PR TITLE
[Doc] Add doc for Python conventions

### DIFF
--- a/docs/readmes/contributing/contribute_conventions.md
+++ b/docs/readmes/contributing/contribute_conventions.md
@@ -196,27 +196,51 @@ Orc8r's cloud code has some basic [CI lint checks](https://github.com/magma/magm
 
 ### Python
 
-In general, we follow the [PEP 8 style guide](https://www.python.org/dev/peps/pep-0008/). 
+The [PEP 8 style guide](https://www.python.org/dev/peps/pep-0008/) is authoritative.
 
-**Type Annotation**
+**Type annotations**
 
-- All new code should be fully type-annotated. 
-  - For reference, please look at this [type hints cheat sheet for Python 3](https://mypy.readthedocs.io/en/stable/cheat_sheet_py3.html). 
+- All new code should be fully type-annotated
+  - For reference, please look at this [type hints cheat sheet for Python 3](https://mypy.readthedocs.io/en/stable/cheat_sheet_py3.html)
 
-**Linter**
+**Documentation**
 
-- For mandatory lint checks, we have a unit test that runs [Pylint](https://pypi.org/project/pylint/) on all gateway services. 
-  - On CI, this gets run as part of the `lte-test` job
-  - TODO: @marie link to AGW unit test instructions
-- Additionally, we have a [reviewdog](https://github.com/reviewdog/reviewdog) based lint checker with [wemake-python-styleguide](https://wemake-python-stylegui.de/en/latest/) enabled to aid the code review process. 
+- Document all public functions and *keep those docs up to date* when you make changes
+- We use [Google style docstrings](https://google.github.io/styleguide/pyguide.html#383-functions-and-methods) in our codebase
+  - For VSCode users, [Python Docstring Generator](https://marketplace.visualstudio.com/items?itemName=njpwerner.autodocstring) plugin is recommended
+  - For IntelliJ users, you can configure a doc string format via `Preferences->Tools->Python Integrated Tools->Docstring format`
 
-**Formatters**
+Example:
+```
+def foo(arg1: str) -> int:
+    """Returns the length of arg1.
 
-- We recommend [autopep8](https://pypi.org/project/autopep8/) as it conforms to [pep8](https://www.python.org/dev/peps/pep-0008/). 
-  - We do *not* recommend other formatters such as [black](https://black.readthedocs.io/en/stable/installation_and_usage.html), as it diverges from pep8 on basic things like line numbers, etc.   
+    Args:
+        arg1 (str): string to calculate the length of
+
+    Returns: the length of the provided parameter
+    """
+    return len(arg1)
+```
 
 **Logging**
 - Use the [logging](https://docs.python.org/3/library/logging.html) module for all logging 
+- Refer to the Go logging section for deciding between log levels
+
+
+**Linter**
+
+- For mandatory lint checks, we have a unit test that runs [Pylint](https://pypi.org/project/pylint/) on all gateway services 
+  - On CI, the check gets run as part of the `lte-test` job
+- Additionally, we have a [Reviewdog](https://github.com/reviewdog/reviewdog) linter using [wemake-python-styleguide](https://wemake-python-stylegui.de/en/latest/) enabled to aid the code review process
+  - To run the linter locally, use the [precommit script](https://github.com/magma/magma/blob/master/lte/gateway/python/precommit.py)
+
+**Formatters**
+
+- We recommend [autopep8](https://pypi.org/project/autopep8/) as it conforms to [pep8](https://www.python.org/dev/peps/pep-0008/)
+  - The above-mentioned [precommit script](https://github.com/magma/magma/blob/master/lte/gateway/python/precommit.py) also has an option to format your changes with 
+  [isort](https://pypi.org/project/isort/), [autopep8](https://pypi.org/project/autopep8/), and [add-trailing-comma](https://pypi.org/project/add-trailing-comma/)
+- We do *not* recommend other formatters such as [black](https://black.readthedocs.io/en/stable/installation_and_usage.html), as it diverges from pep8 on basic things like line length, etc.   
 
 
 ### Shell

--- a/docs/readmes/contributing/contribute_conventions.md
+++ b/docs/readmes/contributing/contribute_conventions.md
@@ -194,6 +194,31 @@ Orc8r's cloud code has some basic [CI lint checks](https://github.com/magma/magm
 - When import aliasing is required, prefer to alias with `snake_case` rather than `camelCase`
 - Prefer readable code over rigid adherence to max line lengths. Capping around 140 characters feels about right.
 
+### Python
+
+In general, we follow the [PEP 8 style guide](https://www.python.org/dev/peps/pep-0008/). 
+
+**Type Annotation**
+
+- All new code should be fully type-annotated. 
+  - For reference, please look at this [type hints cheat sheet for Python 3](https://mypy.readthedocs.io/en/stable/cheat_sheet_py3.html). 
+
+**Linter**
+
+- For mandatory lint checks, we have a unit test that runs [Pylint](https://pypi.org/project/pylint/) on all gateway services. 
+  - On CI, this gets run as part of the `lte-test` job
+  - TODO: @marie link to AGW unit test instructions
+- Additionally, we have a [reviewdog](https://github.com/reviewdog/reviewdog) based lint checker with [wemake-python-styleguide](https://wemake-python-stylegui.de/en/latest/) enabled to aid the code review process. 
+
+**Formatters**
+
+- We recommend [autopep8](https://pypi.org/project/autopep8/) as it conforms to [pep8](https://www.python.org/dev/peps/pep-0008/). 
+  - We do *not* recommend other formatters such as [black](https://black.readthedocs.io/en/stable/installation_and_usage.html), as it diverges from pep8 on basic things like line numbers, etc.   
+
+**Logging**
+- Use the [logging](https://docs.python.org/3/library/logging.html) module for all logging 
+
+
 ### Shell
 
 - Shell script names should be suffixed with the proper file extension

--- a/docs/readmes/contributing/contribute_workflow.md
+++ b/docs/readmes/contributing/contribute_workflow.md
@@ -43,6 +43,8 @@ See the [opinionated workflow](#opinionated-workflow) section below for a low-fr
         - [Open in IntelliJ](https://sourcegraph.com/extensions/sourcegraph/open-in-intellij): Sourcegraph extension to open a file in your dev machine's IntelliJ instance
 - IntelliJ
     - [Native support for GitHub code reviews](https://www.youtube.com/watch?v=MoXxF3aWW8k&ab_channel=IntelliJIDEAbyJetBrains)
+- Slack 
+    - [Scheduled Reminders](https://docs.github.com/en/github/setting-up-and-managing-your-github-user-account/managing-your-scheduled-reminders): GitHub integration to enable PR/Issue related notifications via Slack messages
 
 ## Opinionated workflow
 

--- a/docs/readmes/contributing/contribute_workflow.md
+++ b/docs/readmes/contributing/contribute_workflow.md
@@ -43,8 +43,6 @@ See the [opinionated workflow](#opinionated-workflow) section below for a low-fr
         - [Open in IntelliJ](https://sourcegraph.com/extensions/sourcegraph/open-in-intellij): Sourcegraph extension to open a file in your dev machine's IntelliJ instance
 - IntelliJ
     - [Native support for GitHub code reviews](https://www.youtube.com/watch?v=MoXxF3aWW8k&ab_channel=IntelliJIDEAbyJetBrains)
-- Slack 
-    - [Scheduled Reminders](https://docs.github.com/en/github/setting-up-and-managing-your-github-user-account/managing-your-scheduled-reminders): GitHub integration to enable PR/Issue related notifications via Slack messages
 
 ## Opinionated workflow
 


### PR DESCRIPTION
<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary
Add a few guidelines for Python development.
I aimed to capture the items included in the wiki here https://github.com/magma/magma/wiki/Contributing:-Python-Code-Conventions, but things like imports and line length are included in the pep8 guidelines so didn't explicitly put it in.

I'll remove the wiki page once this lands.
<!-- Enumerate changes you made and why you made them -->

## Test Plan
no test
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->

<!--
    Final note

    Please take a moment to read through the Magma project's
    - Contributing conventions: https://docs.magmacore.org/docs/next/contributing/contribute_conventions

    If this is your first time opening a PR, also consider reading
    - Developer onboarding: https://docs.magmacore.org/docs/next/contributing/contribute_onboarding
    - Development workflow: https://docs.magmacore.org/docs/next/contributing/contribute_workflow
-->
Signed-off-by: Marie Bremner <marwhal@fb.com>