### PR TITLE
[docusaurus] Add help message to delete node_modules in case of error

### DIFF
--- a/docs/docusaurus/create_docusaurus_website.sh
+++ b/docs/docusaurus/create_docusaurus_website.sh
@@ -17,12 +17,14 @@ function exit_timeout() {
   docker-compose logs docusaurus
   echo ''
   echo "Timed out after ${1}s waiting for Docusaurus container to build. See logs above for more info."
+  echo "Possible remedies:"
+  echo '  - Remove node_modules directory (rm -rf node_modules) and try again.'
   exit 1
 }
 
 # spin until localhost:3000 returns HTTP code 200.
 function spin() {
-  maxsec=120
+  maxsec=300
   spin='-\|/'
   i=0
   while [[ "$(curl -s -o /dev/null -w '%{http_code}' localhost:3000)" != "200" ]]; do

--- a/docs/docusaurus/docker-compose.yml
+++ b/docs/docusaurus/docker-compose.yml
@@ -3,8 +3,8 @@ version: "3.7"
 services:
   docusaurus:
     volumes:
-      - $PWD/../docusaurus:/app/website
-      - $PWD/../readmes:/app/docs
+      - ./../docusaurus:/app/website
+      - ./../readmes:/app/docs
     ports:
       - 3000:3000/tcp
       - 35729:35729/tcp


### PR DESCRIPTION
Signed-off-by: Oriol Batalla <obatalla@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary

Sometimes when running docusaurus with `create_docusaurus_website.sh` the container may be stuck do to a yarn exiting prematurely. The cause may be on an out-of-date content on `node_modules`. To fix that, we just need to `rm -Rf node_modules` and run again the script to refresh all the files.

To avoid adding more automation that can slow down when we use docusaurus test VM, we will add that information on the error message so the user can take an action.

Other changes:
- Timeout increase
- Remove of PWD on docker-compose volume path.



## Test Plan

`./create_docusaurus_website.sh`

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->

<!--
    Final note

    Please take a moment to read through the Magma project's
    - Contributing conventions: https://docs.magmacore.org/docs/next/contributing/contribute_conventions

    If this is your first time opening a PR, also consider reading
    - Developer onboarding: https://docs.magmacore.org/docs/next/contributing/contribute_onboarding
    - Development workflow: https://docs.magmacore.org/docs/next/contributing/contribute_workflow
-->
