### PR TITLE
[orc8r][nprobe] expose an eventd client package for nprobe

### DIFF
--- a/orc8r/cloud/go/services/eventd/eventd_client/eventd_client.go
+++ b/orc8r/cloud/go/services/eventd/eventd_client/eventd_client.go
@@ -1,0 +1,229 @@
+/*
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package eventd_client
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"magma/orc8r/cloud/go/orc8r"
+	"magma/orc8r/cloud/go/services/eventd/obsidian/models"
+	"magma/orc8r/lib/go/service/config"
+
+	"github.com/golang/glog"
+	"github.com/olivere/elastic/v7"
+	"github.com/thoas/go-funk"
+)
+
+const (
+	pathParamStreamName  = "stream_name"
+	pathParamNetworkID   = "network_id"
+	queryParamEventType  = "event_type"
+	queryParamHardwareID = "hardware_id"
+	queryParamTag        = "tag"
+
+	defaultQuerySize = 50
+
+	// We use the ES "keyword" type for exact match
+	dotKeyword              = ".keyword"
+	elasticFilterStreamName = pathParamStreamName + dotKeyword
+	elasticFilterNetworkID  = pathParamNetworkID + dotKeyword
+	elasticFilterEventType  = queryParamEventType + dotKeyword
+	elasticFilterHardwareID = "hw_id" + dotKeyword
+	elasticFilterEventTag   = "event_tag" + dotKeyword // We use event_tag as fluentd uses the "tag" field
+	elasticFilterTimestamp  = "@timestamp"
+)
+
+// GetElasticClient parses es config and instanciates a new es client
+func GetElasticClient() (*elastic.Client, error) {
+	elasticConfig, err := config.GetServiceConfig(orc8r.ModuleName, "elastic")
+	if err != nil {
+		return nil, fmt.Errorf("Failed to instantiate elastic config")
+	}
+	elasticHost := elasticConfig.MustGetString("elasticHost")
+	elasticPort := elasticConfig.MustGetInt("elasticPort")
+
+	client, err := elastic.NewSimpleClient(elastic.SetURL(fmt.Sprintf("http://%s:%d", elasticHost, elasticPort)))
+	if err != nil {
+		return nil, fmt.Errorf("Failed to instantiate elastic client")
+	}
+	return client, nil
+}
+
+// EventQueryParams represents a single stream es query
+type EventQueryParams struct {
+	StreamName string
+	EventType  string
+	HardwareID string
+	NetworkID  string
+	Tag        string
+}
+
+func (b *EventQueryParams) toElasticBoolQuery() *elastic.BoolQuery {
+	query := elastic.NewBoolQuery()
+	query.Filter(elastic.NewTermQuery(elasticFilterStreamName, b.StreamName))
+	query.Filter(elastic.NewTermQuery(elasticFilterNetworkID, b.NetworkID))
+	if len(b.EventType) > 0 {
+		query.Filter(elastic.NewTermQuery(elasticFilterEventType, b.EventType))
+	}
+	if len(b.HardwareID) > 0 {
+		query.Filter(elastic.NewTermQuery(elasticFilterHardwareID, b.HardwareID))
+	}
+	if len(b.Tag) > 0 {
+		query.Filter(elastic.NewTermQuery(elasticFilterEventTag, b.Tag))
+	}
+	return query
+}
+
+// MultiStreamEventQueryParams exposes more query options.
+// Primarily the ability to query across multiple streams/tags and specifying
+// a time range. It also accepts an optional query size limit and offset for
+// paginated queries.
+type MultiStreamEventQueryParams struct {
+	NetworkID   string
+	Streams     []string
+	Events      []string
+	Tags        []string
+	HardwareIDs []string
+	From        int
+	Size        int
+	Start       *time.Time
+	End         *time.Time
+}
+
+func (m *MultiStreamEventQueryParams) toElasticBoolQuery() *elastic.BoolQuery {
+	ret := elastic.NewBoolQuery().Filter(elastic.NewTermQuery(elasticFilterNetworkID, m.NetworkID))
+	if !funk.IsEmpty(m.Streams) {
+		ret.Filter(elastic.NewTermsQuery(elasticFilterStreamName, stringsToInterfaces(m.Streams)...))
+	}
+	if !funk.IsEmpty(m.Events) {
+		ret.Filter(elastic.NewTermsQuery(elasticFilterEventType, stringsToInterfaces(m.Events)...))
+	}
+	if !funk.IsEmpty(m.Tags) {
+		ret.Filter(elastic.NewTermsQuery(elasticFilterEventTag, stringsToInterfaces(m.Tags)...))
+	}
+	if !funk.IsEmpty(m.HardwareIDs) {
+		ret.Filter(elastic.NewTermsQuery(elasticFilterHardwareID, stringsToInterfaces(m.HardwareIDs)...))
+	}
+	if m.Start != nil || m.End != nil {
+		ret.Must(elastic.NewRangeQuery(elasticFilterTimestamp).From(m.Start).To(m.End))
+	}
+	return ret
+}
+
+// GetEvents query es and return a list of events for a specific stream
+func GetEvents(ctx context.Context, params EventQueryParams, client *elastic.Client) ([]models.Event, error) {
+	elasticQuery := params.toElasticBoolQuery()
+	search := client.Search().
+		Index("").
+		Size(defaultQuerySize).
+		Sort(elasticFilterTimestamp, false).
+		Query(elasticQuery)
+	return doSearch(ctx, search)
+}
+
+//  GetMultiStreamEvents exposes more query options than EventsHandler,
+func GetMultiStreamEvents(ctx context.Context, params MultiStreamEventQueryParams, client *elastic.Client) ([]models.Event, error) {
+	query := params.toElasticBoolQuery()
+	search := client.Search().
+		Index("eventd*").
+		From(params.From).
+		Size(params.Size).
+		Sort(elasticFilterTimestamp, false).
+		Query(query)
+	return doSearch(ctx, search)
+}
+
+// GetEventCount queries es and returns the number of events based on the provided query options.
+func GetEventCount(ctx context.Context, params MultiStreamEventQueryParams, client *elastic.Client) (int64, error) {
+	query := params.toElasticBoolQuery()
+	result, err := client.Count().
+		Index("eventd*").
+		Query(query).
+		Do(ctx)
+	if err != nil {
+		return 0, err
+	}
+	return result, nil
+}
+
+func doSearch(ctx context.Context, search *elastic.SearchService) ([]models.Event, error) {
+	result, err := search.Do(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if result.Error != nil {
+		return nil, fmt.Errorf("Elastic Error Type: %s, Reason: %s", result.Error.Type, result.Error.Reason)
+	}
+
+	eventResults, err := GetEventResults(result.Hits.Hits)
+	if err != nil {
+		glog.Error(err)
+		return nil, err
+	}
+	return eventResults, nil
+}
+
+type eventElasticHit struct {
+	StreamName string `json:"stream_name"`
+	EventType  string `json:"event_type"`
+	// FluentBit logs sent from AGW are tagged with hw_id
+	HardwareID string `json:"hw_id"`
+	// We use event_tag as fluentd uses the "tag" field
+	Tag       string `json:"event_tag"`
+	Timestamp string `json:"@timestamp"`
+	Value     string `json:"value"`
+}
+
+// Retrieve Event properties from the _source of
+// ES Hits, including event metadata
+func GetEventResults(hits []*elastic.SearchHit) ([]models.Event, error) {
+	results := []models.Event{}
+	for _, hit := range hits {
+		var eventHit eventElasticHit
+		// Get Value from the _source
+		if err := json.Unmarshal(hit.Source, &eventHit); err != nil {
+			return nil, fmt.Errorf("Unable to Unmarshal JSON from elastic.Hit. "+
+				"elastic.Hit.Source: %s, Error: %s", hit.Source, err)
+		}
+		// Skip hits without an event value
+		if eventHit.Value == "" {
+			return nil, fmt.Errorf("eventResult %s does not contain a value", eventHit)
+		}
+		var eventValue map[string]interface{}
+		if err := json.Unmarshal([]byte(eventHit.Value), &eventValue); err != nil {
+			return nil, fmt.Errorf("Unable to Unmarshal JSON from eventResult.Value. "+
+				"eventHit.Value: %s, Error: %s", hit.Source, err)
+		}
+		results = append(results, models.Event{
+			StreamName: eventHit.StreamName,
+			EventType:  eventHit.EventType,
+			HardwareID: eventHit.HardwareID,
+			Tag:        eventHit.Tag,
+			Timestamp:  eventHit.Timestamp,
+			Value:      eventValue,
+		})
+	}
+	return results, nil
+}
+
+func stringsToInterfaces(st []string) []interface{} {
+	ret := make([]interface{}, 0, len(st))
+	for _, s := range st {
+		ret = append(ret, s)
+	}
+	return ret
+}

--- a/orc8r/cloud/go/services/eventd/eventd_client/eventd_client_test.go
+++ b/orc8r/cloud/go/services/eventd/eventd_client/eventd_client_test.go
@@ -1,0 +1,158 @@
+/*
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package eventd_client
+
+import (
+	"testing"
+
+	"magma/orc8r/cloud/go/services/eventd/obsidian/models"
+
+	"github.com/olivere/elastic/v7"
+	"github.com/stretchr/testify/assert"
+)
+
+type elasticTestCase struct {
+	name     string
+	params   EventQueryParams
+	expected *elastic.BoolQuery
+}
+
+type eventResultTestCase struct {
+	name            string
+	jsonSource      string
+	expectedResults []models.Event
+	expectsError    bool
+}
+
+var (
+	elasticCases = []elasticTestCase{
+		{
+			name: "full query params",
+			params: EventQueryParams{
+				StreamName: "streamOne",
+				EventType:  "an_event",
+				HardwareID: "hardware-2",
+				NetworkID:  "test_network",
+				Tag:        "critical",
+			},
+			expected: elastic.NewBoolQuery().
+				Filter(elastic.NewTermQuery("stream_name.keyword", "streamOne")).
+				Filter(elastic.NewTermQuery("network_id.keyword", "test_network")).
+				Filter(elastic.NewTermQuery("event_type.keyword", "an_event")).
+				Filter(elastic.NewTermQuery("hw_id.keyword", "hardware-2")).
+				Filter(elastic.NewTermQuery("event_tag.keyword", "critical")),
+		},
+		{
+			name: "partial query params",
+			params: EventQueryParams{
+				StreamName: "streamTwo",
+				NetworkID:  "test_network_two",
+				EventType:  "an_event",
+			},
+			expected: elastic.NewBoolQuery().
+				Filter(elastic.NewTermQuery("stream_name.keyword", "streamTwo")).
+				Filter(elastic.NewTermQuery("network_id.keyword", "test_network_two")).
+				Filter(elastic.NewTermQuery("event_type.keyword", "an_event")),
+		},
+		{
+			name: "only required Path params",
+			params: EventQueryParams{
+				StreamName: "streamThree",
+				NetworkID:  "test_network_three",
+			},
+			expected: elastic.NewBoolQuery().
+				Filter(elastic.NewTermQuery("stream_name.keyword", "streamThree")).
+				Filter(elastic.NewTermQuery("network_id.keyword", "test_network_three")),
+		},
+	}
+
+	eventResultTestCases = []eventResultTestCase{
+		{
+			name: "all fields",
+			jsonSource: `{
+				"stream_name": "a",
+				"event_type": "b",
+				"hw_id": "c",
+				"event_tag": "d",
+				"value":"{ \"some_property\": true }"
+			}`,
+			expectedResults: []models.Event{
+				{
+					StreamName: "a",
+					EventType:  "b",
+					HardwareID: "c",
+					Tag:        "d",
+					Value:      map[string]interface{}{"some_property": true},
+				},
+			},
+		},
+		{
+			name: "partial fields with value present",
+			jsonSource: `{
+				"stream_name": "a",
+				"event_type": "b",
+				"value":"{}"
+			}`,
+			expectedResults: []models.Event{
+				{
+					StreamName: "a",
+					EventType:  "b",
+					Value:      map[string]interface{}{},
+				},
+			},
+		},
+		{
+			name: "partial fields without a value",
+			jsonSource: `{
+				"stream_name": "a",
+				"event_type": "b"
+			}`,
+			expectsError: true,
+		},
+	}
+)
+
+func TestElasticBoolQuery(t *testing.T) {
+	for _, test := range elasticCases {
+		t.Run(test.name, func(t *testing.T) {
+			runToElasticBoolQueryTestCase(t, test)
+		})
+	}
+}
+
+func runToElasticBoolQueryTestCase(t *testing.T, tc elasticTestCase) {
+	query := tc.params.toElasticBoolQuery()
+	assert.Equal(t, tc.expected, query)
+}
+
+func TestGetEventResults(t *testing.T) {
+	for _, test := range eventResultTestCases {
+		t.Run(test.name, func(t *testing.T) {
+			runEventResultTestCase(t, test)
+		})
+	}
+}
+
+func runEventResultTestCase(t *testing.T, tc eventResultTestCase) {
+	hit := elastic.SearchHit{
+		Source: []byte(tc.jsonSource),
+	}
+	results, err := GetEventResults([]*elastic.SearchHit{&hit})
+	if tc.expectsError {
+		assert.Error(t, err)
+	} else {
+		assert.NoError(t, err)
+		assert.Equal(t, tc.expectedResults, results)
+	}
+}

--- a/orc8r/cloud/go/services/eventd/obsidian/handlers/handlers.go
+++ b/orc8r/cloud/go/services/eventd/obsidian/handlers/handlers.go
@@ -14,7 +14,6 @@
 package handlers
 
 import (
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"strconv"
@@ -22,23 +21,17 @@ import (
 	"time"
 
 	"magma/orc8r/cloud/go/obsidian"
-	"magma/orc8r/cloud/go/orc8r"
+	eventdC "magma/orc8r/cloud/go/services/eventd/eventd_client"
 	logH "magma/orc8r/cloud/go/services/eventd/log/handlers"
-	"magma/orc8r/cloud/go/services/eventd/obsidian/models"
-	"magma/orc8r/lib/go/service/config"
 
 	"github.com/go-openapi/strfmt"
 	"github.com/golang/glog"
 	"github.com/labstack/echo"
 	"github.com/olivere/elastic/v7"
-	"github.com/thoas/go-funk"
 )
 
 const (
-	Events          = "events"
-	EventsRootPath  = obsidian.V1Root + Events + obsidian.UrlSep + ":" + pathParamNetworkID
-	EventsPath      = EventsRootPath + obsidian.UrlSep + ":" + pathParamStreamName
-	EventsCountPath = EventsRootPath + obsidian.UrlSep + "about" + obsidian.UrlSep + "count"
+	defaultQuerySize = 50
 
 	pathParamStreamName  = "stream_name"
 	pathParamNetworkID   = "network_id"
@@ -46,16 +39,19 @@ const (
 	queryParamHardwareID = "hardware_id"
 	queryParamTag        = "tag"
 
-	defaultQuerySize = 50
+	// multi-stream endpoint query args
+	pathParamStreams     = "streams"
+	pathParamEvents      = "events"
+	pathParamTags        = "tags"
+	pathParamHardwareIDs = "hw_ids"
+	pathParamFrom        = "from"
+	pathParamSize        = "size"
+	pathParamStart       = "start"
+	pathParamEnd         = "end"
 
-	// We use the ES "keyword" type for exact match
-	dotKeyword              = ".keyword"
-	elasticFilterStreamName = pathParamStreamName + dotKeyword
-	elasticFilterNetworkID  = pathParamNetworkID + dotKeyword
-	elasticFilterEventType  = queryParamEventType + dotKeyword
-	elasticFilterHardwareID = "hw_id" + dotKeyword
-	elasticFilterEventTag   = "event_tag" + dotKeyword // We use event_tag as fluentd uses the "tag" field
-	elasticFilterTimestamp  = "@timestamp"
+	EventsRootPath  = obsidian.V1Root + "events" + obsidian.UrlSep + ":" + pathParamNetworkID
+	EventsPath      = EventsRootPath + obsidian.UrlSep + ":" + pathParamStreamName
+	EventsCountPath = EventsRootPath + obsidian.UrlSep + "about" + obsidian.UrlSep + "count"
 
 	ManageNetworkPath  = obsidian.V1Root + "networks" + obsidian.UrlSep + ":network_id"
 	LogSearchQueryPath = ManageNetworkPath + obsidian.UrlSep + "logs" + obsidian.UrlSep + "search"
@@ -66,17 +62,7 @@ const (
 func GetObsidianHandlers() []obsidian.Handler {
 	var ret []obsidian.Handler
 
-	// Elastic
-	elasticConfig, err := config.GetServiceConfig(orc8r.ModuleName, "elastic")
-	if err != nil {
-		ret = append(ret, setInitErrorHandlers(err)...)
-		return ret
-	}
-
-	elasticHost := elasticConfig.MustGetString("elasticHost")
-	elasticPort := elasticConfig.MustGetInt("elasticPort")
-
-	client, err := elastic.NewSimpleClient(elastic.SetURL(fmt.Sprintf("http://%s:%d", elasticHost, elasticPort)))
+	client, err := eventdC.GetElasticClient()
 	if err != nil {
 		ret = append(ret, setInitErrorHandlers(err)...)
 		return ret
@@ -87,8 +73,23 @@ func GetObsidianHandlers() []obsidian.Handler {
 	ret = append(ret, obsidian.Handler{Path: EventsRootPath, Methods: obsidian.GET, HandlerFunc: GetMultiStreamEventsHandler(client)})
 	ret = append(ret, obsidian.Handler{Path: EventsCountPath, Methods: obsidian.GET, HandlerFunc: GetEventCountHandler(client)})
 	ret = append(ret, obsidian.Handler{Path: EventsPath, Methods: obsidian.GET, HandlerFunc: GetEventsHandler(client)})
-
 	return ret
+}
+
+func setInitErrorHandlers(err error) []obsidian.Handler {
+	return []obsidian.Handler{
+		{Path: LogSearchQueryPath, Methods: obsidian.GET, HandlerFunc: getInitErrorHandler(err)},
+		{Path: LogCountQueryPath, Methods: obsidian.GET, HandlerFunc: getInitErrorHandler(err)},
+		{Path: EventsRootPath, Methods: obsidian.GET, HandlerFunc: getInitErrorHandler(err)},
+		{Path: EventsPath, Methods: obsidian.GET, HandlerFunc: getInitErrorHandler(err)},
+		{Path: EventsCountPath, Methods: obsidian.GET, HandlerFunc: getInitErrorHandler(err)},
+	}
+}
+
+func getInitErrorHandler(err error) func(c echo.Context) error {
+	return func(c echo.Context) error {
+		return obsidian.HttpError(fmt.Errorf("initialization Error: %v", err), http.StatusInternalServerError)
+	}
 }
 
 // GetEventsHandler returns a Handler that uses the provided elastic client
@@ -106,10 +107,27 @@ func GetMultiStreamEventsHandler(client *elastic.Client) func(c echo.Context) er
 	}
 }
 
+// GetEventCountHandler returns a handler for multi-stream elastic
+// event count query endpoint.
 func GetEventCountHandler(client *elastic.Client) func(c echo.Context) error {
 	return func(c echo.Context) error {
 		return EventCountHandler(c, client)
 	}
+}
+
+// EventsHandler handles event querying using ES
+func EventsHandler(c echo.Context, client *elastic.Client) error {
+	queryParams, err := getQueryParameters(c)
+	if err != nil {
+		return obsidian.HttpError(err, http.StatusBadRequest)
+	}
+
+	results, err := eventdC.GetEvents(c.Request().Context(), queryParams, client)
+	if err != nil {
+		glog.Error(err)
+		return obsidian.HttpError(err, http.StatusInternalServerError)
+	}
+	return c.JSON(http.StatusOK, results)
 }
 
 // MultiStreamEventsHandler exposes more query options than EventsHandler,
@@ -122,138 +140,39 @@ func MultiStreamEventsHandler(c echo.Context, client *elastic.Client) error {
 		return obsidian.HttpError(err, http.StatusBadRequest)
 	}
 
-	query := params.toElasticBoolQuery()
-	search := client.Search().
-		Index("eventd*").
-		From(params.from).
-		Size(params.size).
-		Sort(elasticFilterTimestamp, false).
-		Query(query)
-	return doSearch(c, search)
+	results, err := eventdC.GetMultiStreamEvents(c.Request().Context(), params, client)
+	if err != nil {
+		glog.Error(err)
+		return obsidian.HttpError(err, http.StatusInternalServerError)
+	}
+	return c.JSON(http.StatusOK, results)
 }
 
+// EventCountHandler handles event counting queries using ES
 func EventCountHandler(c echo.Context, client *elastic.Client) error {
 	params, err := getMultiStreamQueryParameters(c)
 	if err != nil {
 		return obsidian.HttpError(err, http.StatusBadRequest)
 	}
 
-	query := params.toElasticBoolQuery()
-	result, err := client.Count().
-		Index("eventd*").
-		Query(query).
-		Do(c.Request().Context())
+	result, err := eventdC.GetEventCount(c.Request().Context(), params, client)
 	if err != nil {
+		glog.Error(err)
 		return obsidian.HttpError(err, http.StatusInternalServerError)
 	}
 	return c.JSON(http.StatusOK, result)
 }
 
-// EventsHandler handles event querying using ES
-func EventsHandler(c echo.Context, client *elastic.Client) error {
-	queryParams, err := getQueryParameters(c)
-	if err != nil {
-		return obsidian.HttpError(err, http.StatusBadRequest)
-	}
-
-	elasticQuery := queryParams.ToElasticBoolQuery()
-	search := client.Search().
-		Index("").
-		Size(defaultQuerySize).
-		Sort(elasticFilterTimestamp, false).
-		Query(elasticQuery)
-	return doSearch(c, search)
-}
-
-func setInitErrorHandlers(err error) []obsidian.Handler {
-	return []obsidian.Handler{
-		{Path: LogSearchQueryPath, Methods: obsidian.GET, HandlerFunc: getInitErrorHandler(err)},
-		{Path: LogCountQueryPath, Methods: obsidian.GET, HandlerFunc: getInitErrorHandler(err)},
-		{Path: EventsRootPath, Methods: obsidian.GET, HandlerFunc: getInitErrorHandler(err)},
-		{Path: EventsPath, Methods: obsidian.GET, HandlerFunc: getInitErrorHandler(err)},
-		{Path: EventsCountPath, Methods: obsidian.GET, HandlerFunc: getInitErrorHandler(err)},
-	}
-}
-func getInitErrorHandler(err error) func(c echo.Context) error {
-	return func(c echo.Context) error {
-		return obsidian.HttpError(fmt.Errorf("initialization Error: %v", err), http.StatusInternalServerError)
-	}
-}
-
-func doSearch(c echo.Context, search *elastic.SearchService) error {
-	result, err := search.Do(c.Request().Context())
-	if err != nil {
-		glog.Errorf("Error getting response from Elastic: %s", err)
-		return obsidian.HttpError(err, http.StatusInternalServerError)
-	}
-	if result.Error != nil {
-		return obsidian.HttpError(fmt.Errorf(
-			"Elastic Error Type: %s, Reason: %s",
-			result.Error.Type,
-			result.Error.Reason))
-	}
-
-	eventResults, err := getEventResults(result.Hits.Hits)
-	if err != nil {
-		glog.Error(err)
-		return obsidian.HttpError(err, http.StatusInternalServerError)
-	}
-	return c.JSON(http.StatusOK, eventResults)
-}
-
-type eventElasticHit struct {
-	StreamName string `json:"stream_name"`
-	EventType  string `json:"event_type"`
-	// FluentBit logs sent from AGW are tagged with hw_id
-	HardwareID string `json:"hw_id"`
-	// We use event_tag as fluentd uses the "tag" field
-	Tag       string `json:"event_tag"`
-	Timestamp string `json:"@timestamp"`
-	Value     string `json:"value"`
-}
-
-// Retrieve Event properties from the _source of
-// ES Hits, including event metadata
-func getEventResults(hits []*elastic.SearchHit) ([]models.Event, error) {
-	results := []models.Event{}
-	for _, hit := range hits {
-		var eventHit eventElasticHit
-		// Get Value from the _source
-		if err := json.Unmarshal(hit.Source, &eventHit); err != nil {
-			return nil, fmt.Errorf("Unable to Unmarshal JSON from elastic.Hit. "+
-				"elastic.Hit.Source: %s, Error: %s", hit.Source, err)
-		}
-		// Skip hits without an event value
-		if eventHit.Value == "" {
-			return nil, fmt.Errorf("eventResult %s does not contain a value", eventHit)
-		}
-		var eventValue map[string]interface{}
-		if err := json.Unmarshal([]byte(eventHit.Value), &eventValue); err != nil {
-			return nil, fmt.Errorf("Unable to Unmarshal JSON from eventResult.Value. "+
-				"eventHit.Value: %s, Error: %s", hit.Source, err)
-		}
-		results = append(results, models.Event{
-			StreamName: eventHit.StreamName,
-			EventType:  eventHit.EventType,
-			HardwareID: eventHit.HardwareID,
-			Tag:        eventHit.Tag,
-			Timestamp:  eventHit.Timestamp,
-			Value:      eventValue,
-		})
-	}
-	return results, nil
-}
-
-func getQueryParameters(c echo.Context) (eventQueryParams, error) {
+func getQueryParameters(c echo.Context) (eventdC.EventQueryParams, error) {
 	streamName := c.Param(pathParamStreamName)
 	if streamName == "" {
-		return eventQueryParams{}, StreamNameHTTPErr()
+		return eventdC.EventQueryParams{}, StreamNameHTTPErr()
 	}
 	networkID, nerr := obsidian.GetNetworkId(c)
 	if nerr != nil {
-		return eventQueryParams{}, nerr
+		return eventdC.EventQueryParams{}, nerr
 	}
-	params := eventQueryParams{
+	params := eventdC.EventQueryParams{
 		StreamName: streamName,
 		EventType:  c.QueryParam(queryParamEventType),
 		HardwareID: c.QueryParam(queryParamHardwareID),
@@ -263,120 +182,52 @@ func getQueryParameters(c echo.Context) (eventQueryParams, error) {
 	return params, nil
 }
 
-type eventQueryParams struct {
-	StreamName string
-	EventType  string
-	HardwareID string
-	NetworkID  string
-	Tag        string
-}
-
-func (b *eventQueryParams) ToElasticBoolQuery() *elastic.BoolQuery {
-	query := elastic.NewBoolQuery()
-	query.Filter(elastic.NewTermQuery(elasticFilterStreamName, b.StreamName))
-	query.Filter(elastic.NewTermQuery(elasticFilterNetworkID, b.NetworkID))
-	if len(b.EventType) > 0 {
-		query.Filter(elastic.NewTermQuery(elasticFilterEventType, b.EventType))
-	}
-	if len(b.HardwareID) > 0 {
-		query.Filter(elastic.NewTermQuery(elasticFilterHardwareID, b.HardwareID))
-	}
-	if len(b.Tag) > 0 {
-		query.Filter(elastic.NewTermQuery(elasticFilterEventTag, b.Tag))
-	}
-	return query
-}
-
 // StreamNameHTTPErr indicates that stream_name is missing
 func StreamNameHTTPErr() *echo.HTTPError {
 	return obsidian.HttpError(fmt.Errorf("Missing stream name"), http.StatusBadRequest)
 }
 
-// multi-stream endpoint query args
-const (
-	pathParamStreams     = "streams"
-	pathParamEvents      = "events"
-	pathParamTags        = "tags"
-	pathParamHardwareIDs = "hw_ids"
-	pathParamFrom        = "from"
-	pathParamSize        = "size"
-	pathParamStart       = "start"
-	pathParamEnd         = "end"
-)
-
-func getMultiStreamQueryParameters(c echo.Context) (multiStreamEventQueryParams, error) {
+func getMultiStreamQueryParameters(c echo.Context) (eventdC.MultiStreamEventQueryParams, error) {
 	networkID, nerr := obsidian.GetNetworkId(c)
 	if nerr != nil {
-		return multiStreamEventQueryParams{}, nerr
+		return eventdC.MultiStreamEventQueryParams{}, nerr
 	}
-	ret := multiStreamEventQueryParams{
-		networkID:   networkID,
-		streams:     getStringListParam(c, pathParamStreams),
-		events:      getStringListParam(c, pathParamEvents),
-		tags:        getStringListParam(c, pathParamTags),
-		hardwareIDs: getStringListParam(c, pathParamHardwareIDs),
-		size:        defaultQuerySize,
+	ret := eventdC.MultiStreamEventQueryParams{
+		NetworkID:   networkID,
+		Streams:     getStringListParam(c, pathParamStreams),
+		Events:      getStringListParam(c, pathParamEvents),
+		Tags:        getStringListParam(c, pathParamTags),
+		HardwareIDs: getStringListParam(c, pathParamHardwareIDs),
+		Size:        defaultQuerySize,
 	}
 
 	fromVal, err := getIntegerParam(c, pathParamFrom)
 	if err != nil {
-		return multiStreamEventQueryParams{}, err
+		return eventdC.MultiStreamEventQueryParams{}, err
 	}
-	ret.from = fromVal
+	ret.From = fromVal
 
 	sizeVal, err := getIntegerParam(c, pathParamSize)
 	if err != nil {
-		return multiStreamEventQueryParams{}, err
+		return eventdC.MultiStreamEventQueryParams{}, err
 	}
 	if sizeVal > 0 {
-		ret.size = sizeVal
+		ret.Size = sizeVal
 	}
 
 	startTime, err := getTimeParam(c, pathParamStart)
 	if err != nil {
-		return multiStreamEventQueryParams{}, err
+		return eventdC.MultiStreamEventQueryParams{}, err
 	}
-	ret.start = startTime
+	ret.Start = startTime
 
 	endTime, err := getTimeParam(c, pathParamEnd)
 	if err != nil {
-		return multiStreamEventQueryParams{}, err
+		return eventdC.MultiStreamEventQueryParams{}, err
 	}
-	ret.end = endTime
+	ret.End = endTime
 
 	return ret, nil
-}
-
-type multiStreamEventQueryParams struct {
-	networkID   string
-	streams     []string
-	events      []string
-	tags        []string
-	hardwareIDs []string
-	from        int
-	size        int
-	start       *time.Time
-	end         *time.Time
-}
-
-func (m multiStreamEventQueryParams) toElasticBoolQuery() *elastic.BoolQuery {
-	ret := elastic.NewBoolQuery().Filter(elastic.NewTermQuery(elasticFilterNetworkID, m.networkID))
-	if !funk.IsEmpty(m.streams) {
-		ret.Filter(elastic.NewTermsQuery(elasticFilterStreamName, stringsToInterfaces(m.streams)...))
-	}
-	if !funk.IsEmpty(m.events) {
-		ret.Filter(elastic.NewTermsQuery(elasticFilterEventType, stringsToInterfaces(m.events)...))
-	}
-	if !funk.IsEmpty(m.tags) {
-		ret.Filter(elastic.NewTermsQuery(elasticFilterEventTag, stringsToInterfaces(m.tags)...))
-	}
-	if !funk.IsEmpty(m.hardwareIDs) {
-		ret.Filter(elastic.NewTermsQuery(elasticFilterHardwareID, stringsToInterfaces(m.hardwareIDs)...))
-	}
-	if m.start != nil || m.end != nil {
-		ret.Must(elastic.NewRangeQuery(elasticFilterTimestamp).From(m.start).To(m.end))
-	}
-	return ret
 }
 
 const urlListDelimiter = ","
@@ -405,12 +256,4 @@ func getTimeParam(c echo.Context, param string) (*time.Time, error) {
 		return &nativeDT, nil
 	}
 	return nil, nil
-}
-
-func stringsToInterfaces(st []string) []interface{} {
-	ret := make([]interface{}, 0, len(st))
-	for _, s := range st {
-		ret = append(ret, s)
-	}
-	return ret
 }


### PR DESCRIPTION
Signed-off-by: YOUSSEF EL MASMOUDI <ymasmoudi@fb.com>

## Summary

An elastic client is needed to collect events from fluentd in the nprobe service. This PR exposes the current implementation in eventd as a separate package to avoid code duplication.

For more details, see: https://github.com/magma/magma/pull/5995

## Test Plan
```
$ go test ./...
?       magma/orc8r/cloud/go/services/eventd    [no test files]
?       magma/orc8r/cloud/go/services/eventd/eventd     [no test files]
ok      magma/orc8r/cloud/go/services/eventd/eventd_client      (cached)
ok      magma/orc8r/cloud/go/services/eventd/log/handlers       (cached)
ok      magma/orc8r/cloud/go/services/eventd/obsidian/handlers  0.874s
?       magma/orc8r/cloud/go/services/eventd/obsidian/models    [no test files]
```

Tested eventd on a local orc8r

<img width="1080" alt="Screenshot 2021-04-14 at 13 41 47" src="https://user-images.githubusercontent.com/8215369/114660075-444b4100-9d27-11eb-9de3-8524b04672fc.png">


