### PR TITLE
AGW: pipelined: avoid reconfiguring SGi

### DIFF
--- a/lte/gateway/python/magma/pipelined/app/uplink_bridge.py
+++ b/lte/gateway/python/magma/pipelined/app/uplink_bridge.py
@@ -283,6 +283,11 @@ class UplinkBridgeController(MagmaController):
             if if_name == self.config.uplink_bridge:
                 self._restart_dhclient(if_name)
             else:
+                if_addrs = netifaces.ifaddresses(if_name).get(netifaces.AF_INET, [])
+                if len(if_addrs) != 0:
+                    self.logger.info("SGi has valid IP, skip reconfiguration %s", if_addrs)
+                    return
+
                 # for system port, use networking config
                 try:
                     self._flush_ip(if_name)


### PR DESCRIPTION
in case of SGi interface is already configured, skip
forcing reconfig.

Signed-off-by: Pravin B Shelar <pbshelar@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->

<!--
    Final note

    Please take a moment to read through the Magma project's
    - Contributing conventions: https://docs.magmacore.org/docs/next/contributing/contribute_conventions

    If this is your first time opening a PR, also consider reading
    - Developer onboarding: https://docs.magmacore.org/docs/next/contributing/contribute_onboarding
    - Development workflow: https://docs.magmacore.org/docs/next/contributing/contribute_workflow
-->
