### PR TITLE
[DevExp] Commit yamllint config, drop line length linting

### DIFF
--- a/.github/workflows/yamlint.yml
+++ b/.github/workflows/yamlint.yml
@@ -14,3 +14,4 @@ jobs:
           level: warning
           filter_mode: added  # Any added or changed content.
           reporter: github-pr-review  # Comments on PR with review comments.
+          yamllint_flags: "-d .github/workflows/yamllint_config.yml ."

--- a/.github/workflows/yamllint_config.yml
+++ b/.github/workflows/yamllint_config.yml
@@ -1,0 +1,38 @@
+---
+# For configuration options see the official yamllint documentation at
+# https://yamllint.readthedocs.io/en/stable/configuration.html
+
+yaml-files:
+  - '*.yaml'
+  - '*.yml'
+  - '.yamllint'
+
+ignore: |
+  **/templates/*.yaml
+
+rules:
+  braces: enable
+  brackets: enable
+  colons: enable
+  commas: enable
+  comments:
+    level: warning
+  comments-indentation:
+    level: warning
+  document-end: disable
+  document-start:
+    level: warning
+  empty-lines: enable
+  empty-values: disable
+  hyphens: enable
+  indentation: enable
+  key-duplicates: enable
+  key-ordering: disable
+  line-length: disable
+  new-line-at-end-of-file: enable
+  new-lines: enable
+  octal-values: disable
+  quoted-strings: disable
+  trailing-spaces: enable
+  truthy:
+    level: warning


### PR DESCRIPTION
Based on feedback from @hcgatewood and personal experience in YAML linting, disabled yaml lint of line length and omit helm template directories.

For the new yamllint configuration file, [this is the official config file documentation](https://yamllint.readthedocs.io/en/stable/configuration.html).

## Test plan

Cherry-picked this PR on top of the [PR Hunter was reviewing](https://github.com/magma/magma/pull/6135/files) and confirmed appropriate behavior.

Signed-off-by: Scott Harrison Moeller <smoeller@fb.com>