### PR TITLE
[NMS] Ensure registered eNodeBs is active when dhcp server is disabled

### DIFF
--- a/nms/app/packages/magmalte/app/views/equipment/GatewayDetailConfigEdit.js
+++ b/nms/app/packages/magmalte/app/views/equipment/GatewayDetailConfigEdit.js
@@ -841,7 +841,6 @@ export function RanEdit(props: Props) {
               onChange={({target}) => {
                 setConnectedEnodebs(Array.from(target.value));
               }}
-              data-testid="registeredEnodeb"
               MenuProps={{classes: {paper: classes.selectMenu}}}
               renderValue={selected => {
                 if (!selected.length) {
@@ -851,7 +850,7 @@ export function RanEdit(props: Props) {
               }}
               input={
                 <OutlinedInput
-                  disabled={!(dnsConfig?.dhcp_server_enabled ?? true)}
+                  data-testid="registeredEnodeb"
                   className={connectedEnodebs.length ? '' : classes.placeholder}
                 />
               }>

--- a/nms/app/packages/magmalte/app/views/equipment/__tests__/GatewayConfigTest.js
+++ b/nms/app/packages/magmalte/app/views/equipment/__tests__/GatewayConfigTest.js
@@ -499,11 +499,11 @@ describe('<AddEditGatewayButton />', () => {
     await wait();
 
     pci = getByTestId('pci').firstChild;
-    if (pci instanceof HTMLInputElement) {
-      expect(pci.disabled).toBe(true);
-    } else {
-      throw 'invalid type';
-    }
+    expect(pci).toBeDisabled();
+
+    const registeredEnodeb = getByTestId('registeredEnodeb').firstChild;
+    expect(registeredEnodeb).not.toHaveAttribute('aria-disabled');
+
     fireEvent.click(getByText('Save And Continue'));
     await wait();
     expect(


### PR DESCRIPTION
Signed-off-by: Karthik Subraveti <ksubraveti@fb.com>

## Summary

Ensure that registered eNodeBs show up as active even when dhcp server is disabled.

## Test Plan
Added a tc in existing test

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->

<!--
    Final note

    Please take a moment to read through the Magma project's
    - Contributing conventions: https://docs.magmacore.org/docs/next/contributing/contribute_conventions

    If this is your first time opening a PR, also consider reading
    - Developer onboarding: https://docs.magmacore.org/docs/next/contributing/contribute_onboarding
    - Development workflow: https://docs.magmacore.org/docs/next/contributing/contribute_workflow
-->
