### PR TITLE
[feg] s8_proxy fix PCO issues and remove some grpc deprecated fields

### DIFF
--- a/cwf/gateway/go.sum
+++ b/cwf/gateway/go.sum
@@ -581,6 +581,7 @@ github.com/wmnsk/go-gtp v0.7.15/go.mod h1:v1psjZ7skpPSDegH23Amg9rNufs0BoXNM+GBtW
 github.com/wmnsk/go-gtp v0.7.17/go.mod h1:IQ5tTgk1EDaKLLAum2vzYheKX9JeRngM1fm9ohdXAac=
 github.com/wmnsk/go-gtp v0.7.19/go.mod h1:qdjTIBWIWjsNJdGs1EpmbcLjakUDPP7nRcEfKr2g1GQ=
 github.com/wmnsk/go-gtp v0.7.20/go.mod h1:qdjTIBWIWjsNJdGs1EpmbcLjakUDPP7nRcEfKr2g1GQ=
+github.com/wmnsk/go-gtp v0.7.21/go.mod h1:qdjTIBWIWjsNJdGs1EpmbcLjakUDPP7nRcEfKr2g1GQ=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
 github.com/xlab/treeprint v0.0.0-20180616005107-d6fb6747feb6/go.mod h1:ce1O1j6UtZfjr22oyGxGLbauSBp2YVXpARAosm7dHBg=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=

--- a/feg/gateway/go.mod
+++ b/feg/gateway/go.mod
@@ -40,7 +40,7 @@ require (
 	github.com/stretchr/objx v0.3.0 // indirect
 	github.com/stretchr/testify v1.6.1
 	github.com/thoas/go-funk v0.7.0
-	github.com/wmnsk/go-gtp v0.7.20
+	github.com/wmnsk/go-gtp v0.7.21
 	golang.org/x/crypto v0.0.0-20201016220609-9e8e0b390897 // indirect
 	golang.org/x/net v0.0.0-20201110031124-69a78807bb2b
 	golang.org/x/sys v0.0.0-20201018230417-eeed37f84f13 // indirect

--- a/feg/gateway/go.sum
+++ b/feg/gateway/go.sum
@@ -621,8 +621,8 @@ github.com/vishvananda/netns v0.0.0-20191106174202-0a2b9b5464df/go.mod h1:JP3t17
 github.com/wadey/gocovmerge v0.0.0-20160331181800-b5bfa59ec0ad h1:W0LEBv82YCGEtcmPA3uNZBI33/qF//HAAs3MawDjRa0=
 github.com/wadey/gocovmerge v0.0.0-20160331181800-b5bfa59ec0ad/go.mod h1:Hy8o65+MXnS6EwGElrSRjUzQDLXreJlzYLlWiHtt8hM=
 github.com/warthog618/sms v0.3.0/go.mod h1:+bYZGeBxu003sxD5xhzsrIPBAjPBzTABsRTwSpd7ld4=
-github.com/wmnsk/go-gtp v0.7.20 h1:N8aobzvxWz5l/lC1qPewuPyN6jL7O2Sdoe92JiGn/MM=
-github.com/wmnsk/go-gtp v0.7.20/go.mod h1:qdjTIBWIWjsNJdGs1EpmbcLjakUDPP7nRcEfKr2g1GQ=
+github.com/wmnsk/go-gtp v0.7.21 h1:/UrMi3sKX7V4+P//iLofw//AyD4zf/n/aEwolxYmNAQ=
+github.com/wmnsk/go-gtp v0.7.21/go.mod h1:qdjTIBWIWjsNJdGs1EpmbcLjakUDPP7nRcEfKr2g1GQ=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
 github.com/xlab/treeprint v0.0.0-20180616005107-d6fb6747feb6/go.mod h1:ce1O1j6UtZfjr22oyGxGLbauSBp2YVXpARAosm7dHBg=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=

--- a/feg/gateway/services/s8_proxy/servicers/gtp_handlers.go
+++ b/feg/gateway/services/s8_proxy/servicers/gtp_handlers.go
@@ -38,7 +38,7 @@ func (s *S8Proxy) createSessionResponseHander() gtpv2.HandlerFunc {
 
 func (s *S8Proxy) deleteSessionResponseHandler() gtpv2.HandlerFunc {
 	return func(c *gtpv2.Conn, senderAddr net.Addr, msg message.Message) error {
-		dsRes, err := parseDelteSessionResponse(msg)
+		dsRes, err := parseDeleteSessionResponse(msg)
 		return s.gtpClient.PassMessage(msg.TEID(), senderAddr, msg, dsRes, err)
 	}
 }

--- a/feg/gateway/services/s8_proxy/servicers/ie_conversions.go
+++ b/feg/gateway/services/s8_proxy/servicers/ie_conversions.go
@@ -244,7 +244,7 @@ func getSelectionModeType(selMode protos.SelectionModeType) *ie.IE {
 }
 
 func getProtocolConfigurationOptions(pco *protos.ProtocolConfigurationOptions) *ie.IE {
-	if pco == nil || !pco.IsValid {
+	if pco == nil {
 		return nil
 	}
 	var options []*ie.PCOContainer

--- a/feg/gateway/services/s8_proxy/servicers/mock_pgw/cs.go
+++ b/feg/gateway/services/s8_proxy/servicers/mock_pgw/cs.go
@@ -261,8 +261,8 @@ func handleQOStoBearer(qosIE *ie.IE, br *gtpv2.Bearer) error {
 	if err != nil {
 		return err
 	}
-	br.PCI = qosIE.PreemptionCapability()
-	br.PVI = qosIE.PreemptionVulnerability()
+	br.PCI = qosIE.HasPCI()
+	br.PVI = qosIE.HasPVI()
 
 	br.MBRUL, err = qosIE.MBRForUplink()
 	if err != nil {

--- a/feg/gateway/services/s8_proxy/servicers/s8_proxy_test.go
+++ b/feg/gateway/services/s8_proxy/servicers/s8_proxy_test.go
@@ -91,7 +91,6 @@ func TestS8proxyCreateAndDeleteSession(t *testing.T) {
 	assert.NotEmpty(t, csRes.BearerContext.Qos)
 	receivedQOS := csRes.BearerContext.Qos
 
-	assert.True(t, csRes.BearerContext.ValidQos)
 	assert.Equal(t, sentQos.Gbr.BrDl, receivedQOS.Gbr.BrDl)
 	assert.Equal(t, sentQos.Gbr.BrUl, receivedQOS.Gbr.BrUl)
 	assert.Equal(t, sentQos.Mbr.BrDl, receivedQOS.Mbr.BrDl)
@@ -574,8 +573,7 @@ func TestS8proxyCreateSessionNoProtocolConfigurationOptions(t *testing.T) {
 
 	// check PCO
 	assert.NoError(t, err)
-	assert.NotEmpty(t, csRes.ProtocolConfigurationOptions)
-	assert.Equal(t, csReq.ProtocolConfigurationOptions, csRes.ProtocolConfigurationOptions)
+	assert.Empty(t, csRes.ProtocolConfigurationOptions)
 
 	// Test no PCO at all
 	// ------------------------
@@ -587,7 +585,7 @@ func TestS8proxyCreateSessionNoProtocolConfigurationOptions(t *testing.T) {
 	// ------------------------
 	// ---- Create Session ----
 	csReq = getDefaultCreateSessionRequest(mockPgw.LocalAddr().String())
-	csReq.ProtocolConfigurationOptions.IsValid = false
+	csReq.ProtocolConfigurationOptions = nil
 	csRes, err = s8p.CreateSession(context.Background(), csReq)
 
 	// check PCO
@@ -688,7 +686,6 @@ func getDefaultCreateSessionRequest(pgwAddrs string) *protos.CreateSessionReques
 			EMeNbi: 8,
 		},
 		ProtocolConfigurationOptions: &protos.ProtocolConfigurationOptions{
-			IsValid:        true,
 			ConfigProtocol: uint32(gtpv2.ConfigProtocolPPPWithIP),
 			ProtoOrContainerId: []*protos.PcoProtocolOrContainerId{
 				{
@@ -768,7 +765,6 @@ func getMultipleCreateSessionRequest(nRequest int, pgwAddrs string) []*protos.Cr
 				BrDl: 888,
 			},
 			ProtocolConfigurationOptions: &protos.ProtocolConfigurationOptions{
-				IsValid:        true,
 				ConfigProtocol: uint32(gtpv2.ConfigProtocolPPPWithIP),
 				ProtoOrContainerId: []*protos.PcoProtocolOrContainerId{
 					{

--- a/feg/gateway/tools/s8_cli/main.go
+++ b/feg/gateway/tools/s8_cli/main.go
@@ -216,7 +216,6 @@ func createSession(cmd *commands.Command, args []string) int {
 			Eci: 6,
 		},
 		ProtocolConfigurationOptions: &protos.ProtocolConfigurationOptions{
-			IsValid:        true,
 			ConfigProtocol: uint32(gtpv2.ConfigProtocolPPPWithIP),
 			ProtoOrContainerId: []*protos.PcoProtocolOrContainerId{
 				{


### PR DESCRIPTION
Signed-off-by: Oriol Batalla <obatalla@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary
This PR includes
- Remove some deprecated fields not used from the protos anymore (will be removed from protos before making this feature official)
- Replacing some functions
- Bump go-gtp to 0.7.21

## Test Plan

Make precommit

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->

<!--
    Final note

    Please take a moment to read through the Magma project's
    - Contributing conventions: https://docs.magmacore.org/docs/next/contributing/contribute_conventions

    If this is your first time opening a PR, also consider reading
    - Developer onboarding: https://docs.magmacore.org/docs/next/contributing/contribute_onboarding
    - Development workflow: https://docs.magmacore.org/docs/next/contributing/contribute_workflow
-->
