### PR TITLE
[flake8][config] Remove noisy lint flags from flake8 check

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,11 +1,14 @@
 [flake8]
 ignore = 
+    W503, # line break before binary operator
     # wemake-python-styleguide warnings
+    WPS102, # Found incorrect module name pattern
     WPS110, # Found wrong variable name
     WPS111, # Found too short name
     WPS115, # Found upper-case constant in a class
     WPS201, # Found module with too many imports
     WPS202, # Found too many module members
+    WPS204, # Found overused expression
     WPS210, # Found too many local variables
     WPS211, # Found too many arguments
     WPS212, # Found too many return statements
@@ -19,9 +22,12 @@ ignore =
     WPS319, # Found bracket in wrong position
     WPS323, # Found percent string formatting
     WPS326, # Found implicit string concatenation
+    WPS336, # Found explicit string concatenation
     WPS420, # Found wrong keyword
     WPS421, # Found wrong function
     WPS428, # Found statement that has no effect
+    WPS437, # Found protected attribute usage
+    WPS440, # Found block variables overlap
     WPS463, # Found a getter without a return value
     WPS504, # Found negated condition
     # flake8-quotes warnings
@@ -31,6 +37,10 @@ ignore =
     DAR102, # Excess parameter(s) in Docstring
     # pydocstyle warnings
     D400   # First line should end with a period
+
+per-file-ignores =
+    lte/gateway/python/integ_tests/s1aptests/*: WPS118, # Found too long name  
+                                                WPS219  # Found too deep access level
 
 [isort]
 profile=wemake


### PR DESCRIPTION
Signed-off-by: Marie Bremner <marwhal@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary
Ignore W503, WPS102, WPS204, WPS336, WPS437 for all files
Ignore WPS118 (long function name) and WPS219 (deep access level) for s1ap tests
<!-- Enumerate changes you made and why you made them -->

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->

<!--
    Final note

    Please take a moment to read through the Magma project's
    - Contributing conventions: https://docs.magmacore.org/docs/next/contributing/contribute_conventions

    If this is your first time opening a PR, also consider reading
    - Developer onboarding: https://docs.magmacore.org/docs/next/contributing/contribute_onboarding
    - Development workflow: https://docs.magmacore.org/docs/next/contributing/contribute_workflow
-->
