### PR TITLE
[lte][agw] Fixing closing parentheses on load_test Makefile

### DIFF
--- a/lte/gateway/python/load_tests/Makefile
+++ b/lte/gateway/python/load_tests/Makefile
@@ -2,7 +2,7 @@ include $(MAGMA_ROOT)/orc8r/gateway/python/python.mk
 include defs.mk
 
 load_test_file = $(firstword $(subst :, ,$1))
-method = $(or $(word 2,$(subst :, ,$1))
+method = $(or $(word 2,$(subst :, ,$1)))
 
 define execute_test
 	echo "Running load test: $(1)"


### PR DESCRIPTION
Signed-off-by: Alex Rodriguez <ardzoht@gmail.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->
- as title

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->
- running `make load_test`

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->

<!--
    Final note

    Please take a moment to read through the Magma project's
    - Contributing conventions: https://docs.magmacore.org/docs/next/contributing/contribute_conventions

    If this is your first time opening a PR, also consider reading
    - Developer onboarding: https://docs.magmacore.org/docs/next/contributing/contribute_onboarding
    - Development workflow: https://docs.magmacore.org/docs/next/contributing/contribute_workflow
-->
