### PR TITLE
Add HORequestAck and HOCommand handlers

### DIFF
--- a/lte/gateway/c/oai/tasks/mme_app/mme_app_defs.h
+++ b/lte/gateway/c/oai/tasks/mme_app/mme_app_defs.h
@@ -286,6 +286,10 @@ void mme_app_handle_handover_required(
     mme_app_desc_t* mme_app_desc_p,
     itti_s1ap_handover_required_t* const handover_required_p);
 
+void mme_app_handle_handover_request_ack(
+    mme_app_desc_t* mme_app_desc_p,
+    itti_s1ap_handover_request_ack_t* const handover_request_ack_p);
+
 void mme_app_handle_path_switch_request(
     mme_app_desc_t* mme_app_desc_p,
     itti_s1ap_path_switch_request_t* const path_switch_req_p);

--- a/lte/gateway/c/oai/tasks/mme_app/mme_app_main.c
+++ b/lte/gateway/c/oai/tasks/mme_app/mme_app_main.c
@@ -386,6 +386,11 @@ static int handle_message(zloop_t* loop, zsock_t* reader, void* arg) {
           mme_app_desc_p, &S1AP_HANDOVER_REQUIRED(received_message_p));
     } break;
 
+    case S1AP_HANDOVER_REQUEST_ACK: {
+      mme_app_handle_handover_request_ack(
+          mme_app_desc_p, &S1AP_HANDOVER_REQUEST_ACK(received_message_p));
+    } break;
+
     case S6A_AUTH_INFO_ANS: {
       /*
        * We received the authentication vectors from HSS,

--- a/lte/gateway/c/oai/tasks/s1ap/s1ap_mme.c
+++ b/lte/gateway/c/oai/tasks/s1ap/s1ap_mme.c
@@ -260,6 +260,11 @@ static int handle_message(zloop_t* loop, zsock_t* reader, void* arg) {
           state, &MME_APP_HANDOVER_REQUEST(received_message_p));
     } break;
 
+    case MME_APP_HANDOVER_COMMAND: {
+      s1ap_mme_handle_handover_command(
+          state, &MME_APP_HANDOVER_COMMAND(received_message_p));
+    } break;
+
     case TIMER_HAS_EXPIRED: {
       if (!timer_exists(
               received_message_p->ittiMsg.timer_has_expired.timer_id)) {

--- a/lte/gateway/c/oai/tasks/s1ap/s1ap_mme_handlers.h
+++ b/lte/gateway/c/oai/tasks/s1ap/s1ap_mme_handlers.h
@@ -62,8 +62,15 @@ int s1ap_mme_handle_handover_required(
     s1ap_state_t* state, const sctp_assoc_id_t assoc_id,
     const sctp_stream_id_t stream, S1ap_S1AP_PDU_t* message_p);
 
+int s1ap_mme_handle_handover_command(
+    s1ap_state_t* state, const itti_mme_app_handover_command_t* ho_command_p);
+
 int s1ap_mme_handle_handover_request(
     s1ap_state_t* state, const itti_mme_app_handover_request_t* ho_request_p);
+
+int s1ap_mme_handle_handover_request_ack(
+    s1ap_state_t* state, const sctp_assoc_id_t assoc_id,
+    const sctp_stream_id_t stream, S1ap_S1AP_PDU_t* message_p);
 
 int s1ap_mme_handle_path_switch_request(
     s1ap_state_t* state, const sctp_assoc_id_t assoc_id,

--- a/lte/gateway/c/oai/tasks/s1ap/s1ap_mme_itti_messaging.c
+++ b/lte/gateway/c/oai/tasks/s1ap/s1ap_mme_itti_messaging.c
@@ -340,3 +340,35 @@ int s1ap_mme_itti_s1ap_handover_required(
   send_msg_to_task(&s1ap_task_zmq_ctx, TASK_MME_APP, message_p);
   OAILOG_FUNC_RETURN(LOG_S1AP, RETURNok);
 }
+
+int s1ap_mme_itti_s1ap_handover_request_ack(
+    const mme_ue_s1ap_id_t mme_ue_s1ap_id,
+    const enb_ue_s1ap_id_t src_enb_ue_s1ap_id,
+    const enb_ue_s1ap_id_t tgt_enb_ue_s1ap_id,
+    const S1ap_HandoverType_t const handover_type,
+    const sctp_assoc_id_t source_assoc_id,
+    const sctp_assoc_id_t target_assoc_id,
+    const bstring const tgt_src_container, imsi64_t imsi64) {
+  MessageDef* message_p = NULL;
+  message_p = itti_alloc_new_message(TASK_S1AP, S1AP_HANDOVER_REQUEST_ACK);
+  if (message_p == NULL) {
+    OAILOG_ERROR_UE(LOG_S1AP, imsi64, "itti_alloc_new_message Failed");
+    OAILOG_FUNC_RETURN(LOG_S1AP, RETURNerror);
+  }
+  S1AP_HANDOVER_REQUEST_ACK(message_p).mme_ue_s1ap_id     = mme_ue_s1ap_id;
+  S1AP_HANDOVER_REQUEST_ACK(message_p).src_enb_ue_s1ap_id = src_enb_ue_s1ap_id;
+  S1AP_HANDOVER_REQUEST_ACK(message_p).tgt_enb_ue_s1ap_id = tgt_enb_ue_s1ap_id;
+  S1AP_HANDOVER_REQUEST_ACK(message_p).source_assoc_id    = source_assoc_id;
+  S1AP_HANDOVER_REQUEST_ACK(message_p).target_assoc_id    = target_assoc_id;
+  S1AP_HANDOVER_REQUEST_ACK(message_p).handover_type      = handover_type;
+  S1AP_HANDOVER_REQUEST_ACK(message_p).tgt_src_container  = tgt_src_container;
+
+  OAILOG_DEBUG_UE(
+      LOG_S1AP, imsi64,
+      "sending Handover Request Ack to MME_APP for mme_ue_s1ap_id %d\n",
+      mme_ue_s1ap_id);
+
+  message_p->ittiMsgHeader.imsi = imsi64;
+  send_msg_to_task(&s1ap_task_zmq_ctx, TASK_MME_APP, message_p);
+  OAILOG_FUNC_RETURN(LOG_S1AP, RETURNok);
+}

--- a/lte/gateway/c/oai/tasks/s1ap/s1ap_mme_itti_messaging.h
+++ b/lte/gateway/c/oai/tasks/s1ap/s1ap_mme_itti_messaging.h
@@ -86,4 +86,12 @@ int s1ap_mme_itti_s1ap_handover_required(
     const mme_ue_s1ap_id_t mme_ue_s1ap_id,
     const bstring const src_tgt_container, imsi64_t imsi64);
 
+int s1ap_mme_itti_s1ap_handover_request_ack(
+    const mme_ue_s1ap_id_t mme_ue_s1ap_id,
+    const enb_ue_s1ap_id_t src_enb_ue_s1ap_id,
+    const enb_ue_s1ap_id_t tgt_enb_ue_s1ap_id,
+    const S1ap_HandoverType_t const handover_type,
+    const sctp_assoc_id_t source_assoc_id,
+    const sctp_assoc_id_t target_assoc_id,
+    const bstring const tgt_src_container, imsi64_t imsi64);
 #endif /* FILE_S1AP_MME_ITTI_MESSAGING_SEEN */


### PR DESCRIPTION
## Summary

This adds HandoverRequestAcknowledge and HandoverCommand message flow to the MME, which are step two of the HandoverResourceAllocation and HandoverPreparation procedures respectively. Note that this explicitly does not do setup of new bearers in the MME; we'll do this in a later PR along with data forwarding.

Signed-off-by: Shaddi Hasan <shasan@fb.com>

## Test Plan

- Local testing (2x Baicells eNB + Pixel 3)
- TeraVM test cases
