### PR TITLE
[NMS] Enable audit logging view in NMS by default

### DIFF
--- a/nms/app/packages/magmalte/app/components/admin/Admin.js
+++ b/nms/app/packages/magmalte/app/components/admin/Admin.js
@@ -17,7 +17,6 @@
 import * as React from 'react';
 import AdminContextProvider from './AdminContextProvider';
 import AdminMain from './AdminMain';
-import AppContext from '@fbcnms/ui/context/AppContext';
 import ApplicationMain from '../ApplicationMain';
 import AssignmentIcon from '@material-ui/icons/Assignment';
 import AuditLog from './AuditLog';
@@ -41,8 +40,6 @@ const useStyles = makeStyles(theme => ({
 
 function NavItems() {
   const {relativeUrl} = useRouter();
-  const {isFeatureEnabled} = React.useContext(AppContext);
-  const auditLogEnabled = isFeatureEnabled('audit_log_view');
 
   return (
     <>
@@ -51,13 +48,11 @@ function NavItems() {
         path={relativeUrl('/users')}
         icon={<PeopleIcon />}
       />
-      {auditLogEnabled && (
-        <NavListItem
-          label="Audit Log"
-          path={relativeUrl('/audit_log')}
-          icon={<AssignmentIcon />}
-        />
-      )}
+      <NavListItem
+        label="Audit Log"
+        path={relativeUrl('/audit_log')}
+        icon={<AssignmentIcon />}
+      />
       <NavListItem
         label="Networks"
         path={relativeUrl('/networks')}

--- a/nms/app/packages/magmalte/app/components/admin/AuditLog.js
+++ b/nms/app/packages/magmalte/app/components/admin/AuditLog.js
@@ -13,157 +13,132 @@
  * @flow
  * @format
  */
-
-import Button from '@fbcnms/ui/components/design-system/Button';
+import ActionTable from '../ActionTable';
+import CardTitleRow from '../../components/layout/CardTitleRow';
 import DeviceStatusCircle from '@fbcnms/ui/components/icons/DeviceStatusCircle';
 import Dialog from '@material-ui/core/Dialog';
-import DialogActions from '@material-ui/core/DialogActions';
 import DialogContent from '@material-ui/core/DialogContent';
 import DialogTitle from '@material-ui/core/DialogTitle';
-import IconButton from '@material-ui/core/IconButton';
-import JSONTree from 'react-json-tree';
+import Grid from '@material-ui/core/Grid';
+import ListAltIcon from '@material-ui/icons/ListAlt';
 import LoadingFiller from '@fbcnms/ui/components/LoadingFiller';
-import MoreVert from '@material-ui/icons/MoreVert';
-import NestedRouteLink from '@fbcnms/ui/components/NestedRouteLink';
-import Paper from '@material-ui/core/Paper';
 import React from 'react';
-import Table from '@material-ui/core/Table';
-import TableBody from '@material-ui/core/TableBody';
-import TableCell from '@material-ui/core/TableCell';
-import TableHead from '@material-ui/core/TableHead';
-import TableRow from '@material-ui/core/TableRow';
-import Text from '../../theme/design-system/Text';
-import {colors} from '../../theme/default';
+import ReactJson from 'react-json-view';
 
-import {Route} from 'react-router-dom';
 import {makeStyles} from '@material-ui/styles';
 import {useAxios} from '@fbcnms/ui/hooks';
-import {useRouter} from '@fbcnms/ui/hooks';
+import {useState} from 'react';
 
 const useStyles = makeStyles(theme => ({
-  actionsCell: {
-    textAlign: 'right',
-  },
-  actionsColumn: {
-    width: '160px',
-  },
-  header: {
-    margin: '10px',
-    display: 'flex',
-    justifyContent: 'space-between',
-  },
-  paper: {
-    margin: theme.spacing(3),
-  },
-  iconButton: {
-    color: colors.primary.brightGray,
-    padding: '5px',
+  dashboardRoot: {
+    margin: theme.spacing(5),
   },
 }));
 
-const THEME = {
-  scheme: 'monokai',
-  base00: '#272822',
-  base01: '#383830',
-  base02: '#49483e',
-  base03: '#75715e',
-  base04: '#a59f85',
-  base05: '#f8f8f2',
-  base06: '#f5f4f1',
-  base07: '#f9f8f5',
-  base08: '#f92672',
-  base09: '#fd971f',
-  base0A: '#f4bf75',
-  base0B: '#a6e22e',
-  base0C: '#a1efe4',
-  base0D: '#66d9ef',
-  base0E: '#ae81ff',
-  base0F: '#cc6633',
+export type AuditLogRowType = {
+  id: string,
+  actingUserEmail: string,
+  mutationType: string,
+  objectType: string,
+  objectId: string,
+  mutationData: {},
 };
 
-export default function () {
+const DEFAULT_PAGE_SIZE = 25;
+
+/**
+ * AuditLog functional component to display audit logs in a tabular format
+ */
+function AuditLog() {
   const classes = useStyles();
-  const {history, relativeUrl, relativePath} = useRouter();
   const {response, error, isLoading} = useAxios({
     url: '/admin/auditlog/async',
     method: 'get',
   });
+  const [currRow, setCurrRow] = useState<AuditLogRowType>({});
+  const onClose = () => setJsonDialog(false);
+  const [jsonDialog, setJsonDialog] = useState(false);
 
   if (error || isLoading || !response || !response.data) {
     return <LoadingFiller />;
   }
-
-  const rows = response.data.map(log => (
-    <TableRow key={log.id}>
-      <TableCell>{log.actingUserId}</TableCell>
-      <TableCell>
-        <DeviceStatusCircle
-          isGrey={false}
-          isActive={log.status === 'SUCCESS'}
-        />
-        {log.mutationType}
-      </TableCell>
-      <TableCell>{log.objectType}</TableCell>
-      <TableCell>{log.objectId}</TableCell>
-      <TableCell className={classes.actionsCell}>
-        <NestedRouteLink to={`/details/${log.id}`}>
-          <IconButton>
-            <MoreVert />
-          </IconButton>
-        </NestedRouteLink>
-      </TableCell>
-    </TableRow>
-  ));
-
   return (
-    <>
-      <div className={classes.paper}>
-        <div className={classes.header}>
-          <Text variant="h5">Audit Log</Text>
-        </div>
-        <Paper elevation={2}>
-          <Table>
-            <TableHead>
-              <TableRow>
-                <TableCell>User</TableCell>
-                <TableCell>Action</TableCell>
-                <TableCell>Object Type</TableCell>
-                <TableCell>Object ID</TableCell>
-                <TableCell className={classes.actionsColumn} />
-              </TableRow>
-            </TableHead>
-            <TableBody>{rows}</TableBody>
-          </Table>
-        </Paper>
-      </div>
-      <Route
-        path={relativePath('/details/:id')}
-        render={routeProps => (
-          <JSONDialog
-            json={
-              response.data.find(log => log.id == routeProps.match.params.id)
-                .mutationData
-            }
-            onClose={() => history.push(relativeUrl(''))}
+    <div className={classes.dashboardRoot}>
+      <Grid container spacing={4}>
+        <Grid item xs={12}>
+          <CardTitleRow
+            icon={ListAltIcon}
+            label={`Audit Logs (${response?.data?.length ?? 0})`}
           />
-        )}
-      />
-    </>
+        </Grid>
+        <Grid item xs={12}>
+          <JsonDialog open={jsonDialog} onClose={onClose} row={currRow} />
+          <ActionTable
+            data={response.data}
+            columns={[
+              {title: 'User', field: 'actingUserEmail'},
+              {title: 'Action', field: 'mutationType'},
+              {title: 'Object Type', field: 'objectType'},
+              {title: 'Object ID', field: 'objectId'},
+              {
+                title: 'Status',
+                field: 'status',
+                render: currRow => (
+                  <>
+                    <DeviceStatusCircle
+                      isGrey={false}
+                      isActive={currRow.status === 'SUCCESS'}
+                    />
+                    {currRow.status}
+                  </>
+                ),
+              },
+            ]}
+            options={{
+              actionsColumnIndex: -1,
+              pageSize: DEFAULT_PAGE_SIZE,
+              pageSizeOptions: [DEFAULT_PAGE_SIZE],
+            }}
+            handleCurrRow={row => setCurrRow(row)}
+            menuItems={[
+              {
+                name: 'View JSON',
+                handleFunc: () => {
+                  setJsonDialog(true);
+                },
+              },
+            ]}
+          />
+        </Grid>
+      </Grid>
+    </div>
   );
 }
 
-const JSONDialog = props => {
+type DialogProps = {
+  row: AuditLogRowType,
+  open: boolean,
+  onClose: () => void,
+};
+
+/**
+ * JSONDialog functional component is used to display the audit log data
+ * in a JSON view
+ * @param {*} props
+ */
+function JsonDialog(props: DialogProps) {
   return (
-    <Dialog open={true} onClose={props.onClose}>
-      <DialogTitle>Details</DialogTitle>
+    <Dialog open={props.open} onClose={props.onClose} fullWidth={true}>
+      <DialogTitle>Log Entry</DialogTitle>
       <DialogContent>
-        <JSONTree data={props.json} theme={THEME} />
+        <ReactJson
+          src={props.row.mutationData}
+          enableClipboard={false}
+          displayDataTypes={false}
+        />
       </DialogContent>
-      <DialogActions>
-        <Button onClick={props.onClose} skin="regular">
-          Close
-        </Button>
-      </DialogActions>
     </Dialog>
   );
-};
+}
+
+export default AuditLog;

--- a/nms/app/packages/magmalte/server/admin/routes.js
+++ b/nms/app/packages/magmalte/server/admin/routes.js
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @flow
+ * @format
+ */
+
+import type {ExpressResponse} from 'express';
+import type {FBCNMSRequest} from '@fbcnms/auth/access';
+
+import asyncHandler from '@fbcnms/util/asyncHandler';
+import express from 'express';
+
+import {AuditLogEntry, User} from '@fbcnms/sequelize-models';
+
+const MAX_AUDITLOG_ROWS = 5000;
+const router: express.Router<FBCNMSRequest, ExpressResponse> = express.Router();
+router.get(
+  '/auditlog/async',
+  asyncHandler(async (req: FBCNMSRequest, res: ExpressResponse) => {
+    const organization = await req.organization();
+    const data = await AuditLogEntry.findAll({
+      where: {organization: organization.name},
+      limit: MAX_AUDITLOG_ROWS,
+    });
+
+    // cleaner way would be to define association.
+    // will do that post db migration release
+    const userMap = {};
+    const allUsers = await User.findAll();
+    allUsers.forEach(item => {
+      userMap[item.id] = item.email;
+    });
+    const userLogData = data.map(item => ({
+      id: item.id,
+      item: item,
+      status: item.status,
+      objectId: item.objectId,
+      objectType: item.objectType,
+      mutationType: item.mutationType,
+      mutationData: item.mutationData,
+      actingUserId: item.actingUserId,
+      actingUserEmail: userMap[item.actingUserId] ?? 'undefined',
+    }));
+    res.status(200).send(userLogData);
+  }),
+);
+
+export default router;

--- a/nms/app/packages/magmalte/server/apicontroller/auditLoggingDecorator.js
+++ b/nms/app/packages/magmalte/server/apicontroller/auditLoggingDecorator.js
@@ -51,18 +51,6 @@ const PATHS: Array<{
     type: 'gateway cellular config',
   },
   {
-    path: '/magma/networks/:networkId/gateways/:objectId/configs/wifi',
-    type: 'gateway wifi config',
-  },
-  {
-    path: '/magma/networks/:networkId/gateways/:objectId/configs/tarazed',
-    type: 'gateway tarazed config',
-  },
-  {
-    path: '/magma/networks/:networkId/gateways/:objectId/configs/devmand',
-    type: 'gateway devmand config',
-  },
-  {
     path: '/magma/networks/:networkId/gateways/:objectId/configs',
     type: 'gateway config',
   },
@@ -72,55 +60,95 @@ const PATHS: Array<{
   },
   {
     path: '/magma/networks/:networkId/subscribers',
-    resolver: (req: FBCNMSRequest) => [req.body.id, 'subscriber'],
+    resolver: (req: FBCNMSRequest) => [req.body.id, 'Subscriber'],
   },
   {
     path: '/magma/networks/:networkId/tiers/:objectId',
-    type: 'network tier',
+    type: 'Network tier',
   },
   {
     path: '/magma/networks/:networkId/tiers',
-    resolver: (req: FBCNMSRequest) => [req.body.id, 'network tier'],
+    resolver: (req: FBCNMSRequest) => [req.body.id, 'Network tier'],
   },
   {
     path: '/magma/networks/:networkId/configs/cellular',
-    resolver: (_, params) => [params[2], 'network cellular configs'],
+    resolver: (_, params) => [params[2], 'Network cellular configs'],
   },
   {
     path: '/magma/networks/:networkId/configs/wifi',
-    resolver: (_, params) => [params[2], 'network wifi configs'],
+    resolver: (_, params) => [params[2], 'Network wifi configs'],
   },
   {
     path: '/magma/v1/networks/:networkId',
-    resolver: (_, params) => [params[1], 'network'],
+    resolver: (_, params) => [params[1], 'Network'],
+  },
+  {
+    path: '/magma/v1/feg_lte/:networkId',
+    resolver: (_, params) => [params[1], 'Federated LTE network'],
+  },
+  {
+    path: '/magma/v1/feg_lte/:networkId/federation',
+    resolver: (_, params) => [params[1], 'Federated LTE federation'],
+  },
+  {
+    path: '/magma/v1/feg_lte/:networkId/subscriber_config',
+    resolver: (_, params) => [params[1], 'Federated LTE subscriber config'],
+  },
+  {
+    path: '/magma/v1/feg/:networkId',
+    resolver: (_, params) => [params[1], 'Federation network'],
+  },
+  {
+    path: '/magma/v1/lte/:networkId',
+    resolver: (_, params) => [params[1], 'LTE network'],
+  },
+  {
+    path: '/magma/v1/lte/:networkId/gateways',
+    resolver: req => [req.body.id, 'LTE gateway'],
+  },
+  {
+    path: '/magma/v1/lte/:networkId/gateways/:objectId',
+    resolver: (_, params) => [params[2], 'LTE gateway'],
+  },
+  {
+    path: '/magma/v1/lte/:networkId/subscribers/:objectId',
+    type: 'subscriber',
+  },
+  {
+    path: '/magma/v1/lte/:networkId/subscribers',
+    resolver: (req: FBCNMSRequest) => [req.body.id, 'Subscriber'],
+  },
+  {
+    path: '/magma/v1/lte/:networkId/policy_qos_profiles',
+    resolver: (req: FBCNMSRequest) => [req.body.id, 'Policy qos profiles'],
   },
   {
     path: '/magma/v1/cwf/:networkId/gateways',
-    resolver: req => [req.body.id, 'carrier wifi gateway'],
+    resolver: req => [req.body.id, 'Carrier wifi gateway'],
   },
   {
     path: '/magma/v1/cwf/:networkId/gateways/:objectId',
-    resolver: (_, params) => [params[2], 'carrier wifi gateway'],
+    resolver: (_, params) => [params[2], 'Carrier wifi gateway'],
   },
   {
     path: '/magma/v1/feg/:networkId/gateways',
-    resolver: req => [req.body.id, 'federation gateway'],
+    resolver: req => [req.body.id, 'Federation gateway'],
   },
   {
     path: '/magma/v1/feg/:networkId/gateways/:objectId',
-    resolver: (_, params) => [params[2], 'federation gateway'],
+    resolver: (_, params) => [params[2], 'Federation gateway'],
   },
   {
     path: '/magma/v1/feg/:networkId/gateways/:objectId/federation',
-    resolver: (_, params) => [params[2], 'federation gateway config'],
+    resolver: (_, params) => [params[2], 'Federation gateway config'],
   },
   {
     path: '/magma/v1/networks/:networkId/rules/policies',
-    resolver: req => [req.body.id, 'policy'],
+    resolver: req => [req.body.id, 'Policy'],
   },
   {
     path: '/magma/v1/networks/:networkId/policies/rules/:objectId',
-    resolver: (_, params) => [params[2], 'policy'],
+    resolver: (_, params) => [params[2], 'Policy'],
   },
 ];
 

--- a/nms/app/packages/magmalte/server/main/routes.js
+++ b/nms/app/packages/magmalte/server/main/routes.js
@@ -18,6 +18,7 @@ import type {AppContextAppData} from '@fbcnms/ui/context/AppContext';
 import type {ExpressResponse} from 'express';
 import type {FBCNMSRequest} from '@fbcnms/auth/access';
 
+import adminRoutes from '../admin/routes';
 import apiControllerRoutes from '../apicontroller/routes';
 import asyncHandler from '@fbcnms/util/asyncHandler';
 import express from 'express';
@@ -70,11 +71,7 @@ const handleReact = tab =>
   };
 
 router.use('/healthz', (req: FBCNMSRequest, res) => res.send('OK'));
-router.use(
-  '/admin',
-  access(AccessRoles.SUPERUSER),
-  require('@fbcnms/platform-server/admin/routes').default,
-);
+router.use('/admin', access(AccessRoles.SUPERUSER), adminRoutes);
 router.get('/admin*', access(AccessRoles.SUPERUSER), handleReact('admin'));
 router.use('/nms/apicontroller', apiControllerRoutes);
 router.use('/nms/network', networkRoutes);


### PR DESCRIPTION
Signed-off-by: Karthik Subraveti <ksubraveti@fb.com>
## Summary
NMS already has audit log capability. We don't enable by default.  Also we only dump last 20 entries. 
- Modified that to dump last 5k entries and always display audit log entries in admin page
- Modified audit log to display user email instead of userID
- Modified AuditLog component to use ActionTable instead of native table and get features like filtering for free. 

## Test Plan
Tested this manually
![Screen Shot 2021-04-15 at 9 20 41 AM](https://user-images.githubusercontent.com/8224854/114903640-dad13e00-9dcb-11eb-8131-cc79451a755e.png)

![Screen Shot 2021-04-15 at 9 12 44 AM](https://user-images.githubusercontent.com/8224854/114902652-e1ab8100-9dca-11eb-8531-a84dbe424aef.png)



## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->

<!--
    Final note

    Please take a moment to read through the Magma project's
    - Contributing conventions: https://docs.magmacore.org/docs/next/contributing/contribute_conventions

    If this is your first time opening a PR, also consider reading
    - Developer onboarding: https://docs.magmacore.org/docs/next/contributing/contribute_onboarding
    - Development workflow: https://docs.magmacore.org/docs/next/contributing/contribute_workflow
-->
