### PR TITLE
AGW: deploy: installation for AGW on Ubuntu 20.04

### DIFF
--- a/lte/gateway/deploy/agw_install_ubuntu.sh
+++ b/lte/gateway/deploy/agw_install_ubuntu.sh
@@ -1,0 +1,162 @@
+#!/bin/bash
+# Copyright 2021 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Setting up env variable, user and project path
+MAGMA_USER="magma"
+AGW_INSTALL_CONFIG="/etc/systemd/system/multi-user.target.wants/agw_installation.service"
+AGW_SCRIPT_PATH="/root/agw_install_ubuntu.sh"
+DEPLOY_PATH="/home/$MAGMA_USER/magma/lte/gateway/deploy"
+SUCCESS_MESSAGE="ok"
+NEED_REBOOT=0
+WHOAMI=$(whoami)
+MAGMA_VERSION="${MAGMA_VERSION:-v1.5}"
+CLOUD_INSTALL="cloud"
+GIT_URL="${GIT_URL:-https://github.com/magma/magma.git}"
+
+echo "Checking if the script has been executed by root user"
+if [ "$WHOAMI" != "root" ]; then
+  echo "You're executing the script as $WHOAMI instead of root.. exiting"
+  exit 1
+fi
+
+if [ "$SKIP_PRECHECK" != "$SUCCESS_MESSAGE" ]; then
+  wget https://raw.githubusercontent.com/magma/magma/"$MAGMA_VERSION"/lte/gateway/deploy/agw_pre_check_ubuntu.sh
+  if [[ -f ./agw_pre_check_ubuntu.sh ]]; then
+    bash agw_pre_check_ubuntu.sh
+    while true; do
+        read -p "Do you accept those modifications and want to proceed with magma installation?(y/n)" yn
+        case $yn in
+            [Yy]* ) break;;
+            [Nn]* ) exit;;
+            * ) echo "Please answer yes or no.";;
+        esac
+    done
+  else
+    echo "agw_pre_check_ubuntu.sh is not available in your version"
+  fi
+fi
+
+echo "Checking if Ubuntu is installed"
+if ! grep -q 'Ubuntu' /etc/issue; then
+  echo "Ubuntu is not installed"
+  exit 1
+fi
+
+echo "Making sure $MAGMA_USER user is sudoers"
+if ! grep -q "$MAGMA_USER ALL=(ALL) NOPASSWD:ALL" /etc/sudoers; then
+  apt install -y sudo
+  adduser --disabled-password --gecos "" $MAGMA_USER
+  adduser $MAGMA_USER sudo
+  echo "$MAGMA_USER ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers
+fi
+
+echo "Need to check if both interfaces are named eth0 and eth1"
+INTERFACES=$(ip -br a)
+if [[ $1 != "$CLOUD_INSTALL" ]] && ( [[ ! $INTERFACES == *'eth0'*  ]] || [[ ! $INTERFACES == *'eth1'* ]] || ! grep -q 'GRUB_CMDLINE_LINUX="net.ifnames=0 biosdevname=0"' /etc/default/grub); then
+  # changing intefaces name
+  sed -i 's/GRUB_CMDLINE_LINUX=""/GRUB_CMDLINE_LINUX="net.ifnames=0 biosdevname=0"/g' /etc/default/grub
+  sed -i 's/enp0s3/eth0/g' /etc/netplan/50-cloud-init.yaml
+  # changing interface name
+  grub-mkconfig -o /boot/grub/grub.cfg
+
+  # interface config
+  apt install ifupdown
+  echo "auto eth0
+  iface eth0 inet dhcp" > /etc/network/interfaces.d/eth0
+  # configuring eth1
+  echo "auto eth1
+  iface eth1 inet static
+  address 10.0.2.1
+  netmask 255.255.255.0" > /etc/network/interfaces.d/eth1
+  # name server config
+  ln -sf /var/run/systemd/resolve/resolv.conf /etc/resolv.conf
+
+  # get rid of netplan
+  systemctl unmask networking
+  systemctl enable networking
+
+  apt-get --assume-yes purge nplan netplan.i
+
+  # Setting REBOOT flag to 1 because we need to reload new interface and network services.
+  NEED_REBOOT=1
+else
+  echo "Interfaces name are correct, let's check if network and DNS are up"
+  while ! ping -c 1 -W 1 -I eth0 google.com; do
+    echo "Network not ready yet"
+    sleep 1
+  done
+fi
+
+if [ $NEED_REBOOT = 1 ]; then
+  echo "Will reboot in a few seconds, loading a boot script in order to install magma"
+  if [ ! -f "$AGW_SCRIPT_PATH" ]; then
+      cp "$(realpath $0)" "${AGW_SCRIPT_PATH}"
+  fi
+  cat <<EOF > $AGW_INSTALL_CONFIG
+[Unit]
+Description=AGW Installation
+After=network-online.target
+Wants=network-online.target
+[Service]
+Environment=MAGMA_VERSION=${MAGMA_VERSION}
+Environment=GIT_URL=${GIT_URL}
+Environment=REPO_PROTO=${REPO_PROTO}
+Environment=REPO_HOST=${REPO_HOST}
+Environment=REPO_DIST=${REPO_DIST}
+Environment=REPO_COMPONENT=${REPO_COMPONENT}
+Environment=REPO_KEY=${REPO_KEY}
+Environment=REPO_KEY_FINGERPRINT=${REPO_KEY_FINGERPRINT}
+Environment=SKIP_PRECHECK=${SUCCESS_MESSAGE}
+Type=oneshot
+ExecStart=/bin/bash ${AGW_SCRIPT_PATH}
+TimeoutStartSec=3800
+TimeoutSec=3600
+User=root
+Group=root
+[Install]
+WantedBy=multi-user.target
+EOF
+  chmod 644 $AGW_INSTALL_CONFIG
+  reboot
+fi
+
+echo "Checking if magma has been installed"
+MAGMA_INSTALLED=$(apt-cache show magma >  /dev/null 2>&1 echo "$SUCCESS_MESSAGE")
+if [ "$MAGMA_INSTALLED" != "$SUCCESS_MESSAGE" ]; then
+  echo "Magma not installed, processing installation"
+  apt-get update
+  apt-get -y install curl make virtualenv zip rsync git software-properties-common python3-pip python-dev apt-transport-https
+
+  alias python=python3
+  pip3 install ansible
+
+  git clone "${GIT_URL}" /home/$MAGMA_USER/magma
+  cd /home/$MAGMA_USER/magma || exit
+  git checkout "$MAGMA_VERSION"
+
+  echo "Generating localhost hostfile for Ansible"
+  echo "[magma_deploy]
+  127.0.0.1 ansible_connection=local" > $DEPLOY_PATH/agw_hosts
+
+  # install magma and its dependencies including OVS.
+  su - $MAGMA_USER -c "ansible-playbook -e \"MAGMA_ROOT='/home/$MAGMA_USER/magma' OUTPUT_DIR='/tmp'\" -i $DEPLOY_PATH/agw_hosts $DEPLOY_PATH/magma_deploy.yml"
+
+  echo "Deleting boot script if it exists"
+  if [ -f "$AGW_INSTALL_CONFIG" ]; then
+    rm -rf $AGW_INSTALL_CONFIG
+  fi
+  rm -rf /home/$MAGMA_USER/build
+  echo "AGW installation is done, make sure all services above are running correctly.. rebooting"
+  reboot
+else
+  echo "Magma already installed, skipping.."
+fi

--- a/lte/gateway/deploy/agw_pre_check_ubuntu.sh
+++ b/lte/gateway/deploy/agw_pre_check_ubuntu.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+# Copyright 2021 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Check for system changes before magma deploy
+# Setting up env variable, user and project path
+MAGMA_USER="magma"
+
+echo "- Check if Ubuntu is installed"
+if ! grep -q 'Ubuntu' /etc/issue; then
+  echo "Ubuntu is not installed"
+else
+  echo "Ubuntu is installed"
+fi
+
+echo "- Check for magma user"
+if ! (getent passwd | grep -q 'magma'); then
+    echo "magma user is not Installed"
+elif  ! grep -q "$MAGMA_USER ALL=(ALL) NOPASSWD:ALL" /etc/sudoers; then
+    echo "magma will be added to sudoers"
+else
+    echo "magma user configured"
+fi
+
+echo "- Check if both interfaces are named eth0 and eth1"
+INTERFACES=$(ip -br a)
+if [[ ! $INTERFACES == *'eth0'*  ]] || [[ ! $INTERFACES == *'eth1'* ]] || ! grep -q 'GRUB_CMDLINE_LINUX="net.ifnames=0 biosdevname=0"' /etc/default/grub; then
+  echo "Interfaces will be renamed to eth0 and eth1"
+  echo "eth0 will be set to dhcp and eth1 10.0.2.1"
+else
+  echo "eth0 will be set to dhcp and eth1 10.0.2.1"
+fi

--- a/lte/gateway/deploy/magma_deploy.yml
+++ b/lte/gateway/deploy/magma_deploy.yml
@@ -1,0 +1,16 @@
+---
+# Copyright 2021 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+- name: Deploy Magma
+  hosts: magma_deploy
+  roles:
+    - role: magma_deploy

--- a/lte/gateway/deploy/roles/magma_deploy/tasks/main.yml
+++ b/lte/gateway/deploy/roles/magma_deploy/tasks/main.yml
@@ -1,0 +1,138 @@
+---
+# Copyright 2021 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+- name: Include vars of all.yaml
+  include_vars:
+    file: all.yaml
+
+- name: Configuring private package manager.
+  copy:
+    content: >
+      deb {{ magma_pkgrepo_proto }}://{{ magma_pkgrepo_host }}{{ magma_pkgrepo_path}}
+      {{ magma_pkgrepo_dist }} {{ magma_pkgrepo_component }}
+    dest: /etc/apt/sources.list.d/{{ magma_pkgrepo_name }}.list
+  become: yes
+
+- name: Add unvalidated Apt signing key.
+  when: magma_pkgrepo_key_fingerprint == ""
+  become: yes
+  block:
+    - name: Download key
+      apt_key:
+        url: "{{ magma_pkgrepo_key }}"
+        state: present
+        validate_certs: no
+    - name: Ignore server ssl cert
+      copy:
+        dest: /etc/apt/apt.conf.d/99insecurehttpsrepo
+        content: |
+          Acquire::https::{{ magma_pkgrepo_host }} {
+          Verify-Peer "false";
+          Verify-Host "false";
+          };
+
+- name: Add validated Apt signing key.
+  when: magma_pkgrepo_key_fingerprint != ""
+  become: yes
+  apt_key:
+    url: "{{ magma_pkgrepo_key }}"
+    id: "{{ magma_pkgrepo_key_fingerprint }}"
+    state: present
+
+- name: Update and upgrade apt packages
+  become: yes
+  apt:
+    update_cache: yes
+
+- name: Install runtime dependencies.
+  become: yes
+  apt:
+    name: "{{ packages }}"
+  vars:
+    packages:
+      - graphviz
+      - python-all
+      - module-assistant
+      - openssl
+      - dkms
+      - uuid-runtime
+
+- name: Preconfigure wireshark (tshark) SUID property
+  become: yes
+  ignore_errors: yes
+  shell: bash -c 'echo "wireshark-common wireshark-common/install-setuid boolean true" | debconf-set-selections'
+
+- name: Installing magma.
+  become: yes
+  apt:
+    name: "{{ packages }}"
+    dpkg_options: 'force-confold,force-confdef,force-overwrite'
+  vars:
+    packages:
+      - magma
+
+- name: Start service openvswitch-switch.
+  become: yes
+  service:
+    name: openvswitch-switch
+    state: started
+  tags:
+    - skipfirstinstall
+
+# Ansible's service module doesn't support wildcards so we have to use shell
+- name: Stop all magma services.
+  become: yes
+  shell: service magma@* stop
+  tags:
+    - skipfirstinstall
+
+- name: Bring up gtp_br0
+  shell: ifup gtp_br0
+  become: yes
+  tags:
+    - skipfirstinstall
+
+- name: Bring up mtr0
+  shell: ifup mtr0
+  become: yes
+  tags:
+    - skipfirstinstall
+
+- name: Bring up uplink_br0
+  shell: ifup uplink_br0
+  become: yes
+  tags:
+    - skipfirstinstall
+
+- name: Bring up ipfix0
+  shell: ifup ipfix0
+  become: yes
+  tags:
+    - skipfirstinstall
+
+- name: Bring up dhcp0
+  shell: ifup dhcp0
+  become: yes
+  tags:
+    - skipfirstinstall
+
+- name: Start service magma@magmad.
+  become: yes
+  service:
+    name: magma@magmad
+    state: started
+  tags:
+    - skipfirstinstall
+
+- name: Install ansible community collection
+  shell: ansible-galaxy collection install community.general

--- a/lte/gateway/deploy/roles/magma_deploy/vars/all.yaml
+++ b/lte/gateway/deploy/roles/magma_deploy/vars/all.yaml
@@ -1,0 +1,23 @@
+################################################################################
+# Copyright 2021 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+magma_pkgrepo_proto: http
+magma_pkgrepo_host: facebookconnectivity.jfrog.io
+magma_pkgrepo_path: "/artifactory/list/dev-focal/"
+magma_pkgrepo_dist: focal
+magma_pkgrepo_component: main
+magma_pkgrepo_name: "magma_package_repo"
+
+magma_pkgrepo_key: "https://facebookconnectivity.jfrog.io/artifactory/api/gpg/key/public"
+magma_pkgrepo_key_fingerprint: ""
+magma_use_pkgrepo: yes


### PR DESCRIPTION
Following patch adds script to install AGW on Ubuntu focal.
This is done primarily using magma-deploy role that deploys
magma package and its dependencies and execute post deploy steps.

Signed-off-by: Pravin B Shelar <pbshelar@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->

<!--
    Final note

    Please take a moment to read through the Magma project's
    - Contributing conventions: https://docs.magmacore.org/docs/next/contributing/contribute_conventions

    If this is your first time opening a PR, also consider reading
    - Developer onboarding: https://docs.magmacore.org/docs/next/contributing/contribute_onboarding
    - Development workflow: https://docs.magmacore.org/docs/next/contributing/contribute_workflow
-->
