### PR TITLE
[NMS] Add checks to ensure mutation is only allowed for non readonly users

### DIFF
--- a/nms/app/packages/magmalte/server/apicontroller/__tests__/proxy-test.js
+++ b/nms/app/packages/magmalte/server/apicontroller/__tests__/proxy-test.js
@@ -14,10 +14,10 @@
  * @format
  */
 
-import {networkIdFilter, networksResponseDecorator} from '../routes';
+import {apiFilter, networksResponseDecorator} from '../routes';
 
 // $FlowIgnore Ignoring error for tests.
-const testNetworkIdFilter = async req => await networkIdFilter(req);
+const testApiFilter = async req => await apiFilter(req);
 
 const testNetworksResponseDecorator = async (
   proxyResponse,
@@ -74,7 +74,7 @@ const createDataNoOrg = (
 };
 
 describe('Proxy test', () => {
-  describe('networkIdFilter', () => {
+  describe('apiFilter', () => {
     const params = {
       networkID: 'test',
     };
@@ -90,7 +90,7 @@ describe('Proxy test', () => {
           networkIDs: [],
         },
       };
-      const isAllowed = await testNetworkIdFilter(req);
+      const isAllowed = await testApiFilter(req);
       expect(isAllowed).toBe(true);
     });
 
@@ -102,7 +102,7 @@ describe('Proxy test', () => {
           networkIDs: [],
         },
       };
-      const isAllowed = await testNetworkIdFilter(req);
+      const isAllowed = await testApiFilter(req);
       expect(isAllowed).toBe(true);
     });
 
@@ -117,7 +117,7 @@ describe('Proxy test', () => {
           networkIDs: [],
         },
       };
-      const isAllowed = await testNetworkIdFilter(req);
+      const isAllowed = await testApiFilter(req);
       expect(isAllowed).toBe(false);
     });
 
@@ -132,7 +132,7 @@ describe('Proxy test', () => {
           networkIDs: ['test'],
         },
       };
-      const isAllowed = await testNetworkIdFilter(req);
+      const isAllowed = await testApiFilter(req);
       expect(isAllowed).toBe(true);
     });
 
@@ -144,7 +144,7 @@ describe('Proxy test', () => {
           networkIDs: ['test'],
         },
       };
-      const isAllowed = await testNetworkIdFilter(req);
+      const isAllowed = await testApiFilter(req);
       expect(isAllowed).toBe(true);
     });
 
@@ -159,7 +159,7 @@ describe('Proxy test', () => {
           networkIDs: ['test'],
         },
       };
-      const isAllowed = await testNetworkIdFilter(req);
+      const isAllowed = await testApiFilter(req);
       expect(isAllowed).toBe(false);
     });
 
@@ -174,7 +174,7 @@ describe('Proxy test', () => {
           networkIDs: ['not-test'],
         },
       };
-      const isAllowed = await testNetworkIdFilter(req);
+      const isAllowed = await testApiFilter(req);
       expect(isAllowed).toBe(false);
     });
 
@@ -186,7 +186,20 @@ describe('Proxy test', () => {
           networkIDs: ['not-test'],
         },
       };
-      const isAllowed = await testNetworkIdFilter(req);
+      const isAllowed = await testApiFilter(req);
+      expect(isAllowed).toBe(false);
+    });
+
+    it('disallows readonlyuser making mutating changes', async () => {
+      const req = {
+        method: 'PUT',
+        params,
+        user: {
+          isReadOnlyUser: true,
+          networkIDs: ['test'],
+        },
+      };
+      const isAllowed = await testApiFilter(req);
       expect(isAllowed).toBe(false);
     });
   });

--- a/nms/app/packages/magmalte/server/apicontroller/routes.js
+++ b/nms/app/packages/magmalte/server/apicontroller/routes.js
@@ -29,6 +29,7 @@ import {intersection} from 'lodash';
 const router: express.Router<FBCNMSRequest, ExpressResponse> = express.Router();
 
 const PROXY_TIMEOUT_MS = 30000;
+const MUTATORS = ['POST', 'PUT', 'DELETE'];
 
 let agent = null;
 if (process.env.HTTPS_PROXY) {
@@ -52,7 +53,11 @@ const PROXY_OPTIONS = {
     req.originalUrl.replace(/^\/nms\/apicontroller/, ''),
 };
 
-export async function networkIdFilter(req: FBCNMSRequest): Promise<boolean> {
+export async function apiFilter(req: FBCNMSRequest): Promise<boolean> {
+  if (req.user.isReadOnlyUser && MUTATORS.includes(req.method)) {
+    return false;
+  }
+
   if (req.organization) {
     const organization = await req.organization();
 
@@ -131,7 +136,7 @@ router.use(
   '/magma/v1/networks/:networkID',
   proxy(API_HOST, {
     ...PROXY_OPTIONS,
-    filter: networkIdFilter,
+    filter: apiFilter,
     userResDecorator: auditLoggingDecorator,
     proxyErrorHandler,
   }),
@@ -142,7 +147,7 @@ router.use(
   `/magma/v1/:networkType(${networkTypeRegex})/:networkID`,
   proxy(API_HOST, {
     ...PROXY_OPTIONS,
-    filter: networkIdFilter,
+    filter: apiFilter,
     userResDecorator: auditLoggingDecorator,
     proxyErrorHandler,
   }),
@@ -176,7 +181,7 @@ router.use(
   '/magma/v1/events/:networkID',
   proxy(API_HOST, {
     ...PROXY_OPTIONS,
-    filter: networkIdFilter,
+    filter: apiFilter,
     proxyErrorHandler,
   }),
 );
@@ -185,12 +190,16 @@ router.use(
   '/magma/v1/events/:networkID/:streamName',
   proxy(API_HOST, {
     ...PROXY_OPTIONS,
-    filter: networkIdFilter,
+    filter: apiFilter,
     proxyErrorHandler,
   }),
 );
 
 router.use('', (req: FBCNMSRequest, res: ExpressResponse) => {
+  if (req.user.isReadOnlyUser && MUTATORS.includes(req.method)) {
+    res.status(403).send('Mutation forbidden. Readonly access');
+    return;
+  }
   res.status(404).send('Not Found');
 });
 


### PR DESCRIPTION
Signed-off-by: Karthik Subraveti <ksubraveti@fb.com>

## Summary
Add checks to ensure read only user cannot make mutations. 

## Test Plan
Enhanced existing test to include this filter check
![Screen Shot 2021-04-15 at 10 54 04 AM](https://user-images.githubusercontent.com/8224854/114916119-466dd800-9dd9-11eb-8447-4c9a217cf9a6.png)


## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->

<!--
    Final note

    Please take a moment to read through the Magma project's
    - Contributing conventions: https://docs.magmacore.org/docs/next/contributing/contribute_conventions

    If this is your first time opening a PR, also consider reading
    - Developer onboarding: https://docs.magmacore.org/docs/next/contributing/contribute_onboarding
    - Development workflow: https://docs.magmacore.org/docs/next/contributing/contribute_workflow
-->
