### PR TITLE
[CI] Update GH gen_build_container GH Action Cache key

### DIFF
--- a/.github/workflows/gcc-problems.yml
+++ b/.github/workflows/gcc-problems.yml
@@ -35,9 +35,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-buildx-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-buildx-
+          key: ${{ runner.os }}-buildx
       - 
         name: Docker Build
         id: docker_build


### PR DESCRIPTION
## Summary

The docker buildx cache is being mounted using the GH cache Action.  Here we update the key, which previously involved a per-commit sha and would result in no cache re-use across PRs.  I believe it's reasonable to share the cache key for all PRs, as the majority of use will involve no updates to the docker build - though I am unclear on cache sharing behavior and synchronization (I presume GH cache handles conflicts sanely... that is if two PRs write to the cache and then upload it, last one wins).

We might want to include some sort of rotation by week or month, however - though I suspect we should have a separate mechanism for ensuring Dockerfile dependencies aren't breaking over time (different from this cache rotation).

## Test Plan

These GH Cache changes are a bit tricky to test - as they cross PR boundaries. I may commit and validate after merge.

Signed-off-by: Scott Harrison Moeller <smoeller@fb.com>