### PR TITLE
[DevExp] Add PR Linting from cpplint - Google Style linter

### DIFF
--- a/.github/workflows/cpplint.yml
+++ b/.github/workflows/cpplint.yml
@@ -1,0 +1,47 @@
+---
+name: Reviewdog
+on:  # yamllint disable-line rule:truthy
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+    paths:
+      - .github/workflows/cpplint.yml
+      - lte/gateway/c/**
+      - orc8r/gateway/c/**
+
+##
+#  Cpplint aims to lint to the Google Style guide. For detailed
+#  rationale on each linting rule, see
+#  https://google.github.io/styleguide/cppguide.html
+##
+#  To suppress false-positive errors of a certain category, add a
+#  'NOLINT(category)' comment to the line.  NOLINT or NOLINT(*)
+#  suppresses errors of all categories on that line.
+##
+#  For details on cpplint optinos see the detailed comments in
+#  https://github.com/google/styleguide/blob/gh-pages/cpplint/cpplint.py
+##
+
+jobs:
+  cpplint:
+    runs-on: ubuntu-latest
+    steps:
+      -
+        uses: actions/checkout@master
+      -
+        name: Install CPP Lint and ReviewDog
+        run: |
+          wget -O - -q https://raw.githubusercontent.com/reviewdog/reviewdog/master/install.sh \
+           | sh -s -- -b .
+          pip install cpplint
+      -
+        name: Run CPP Lint and push Annotations
+        env:
+          REVIEWDOG_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          cpplint --recursive ${{ github.workspace }} \
+            --extensions=hh,c,hpp,cpp,cuh,cc,cxx,c++,hxx,h,h++,cu \
+            --linelength=120 2>&1 \
+             | ./reviewdog -efm="%f:%l: %m" -name="cpplint" -reporter="github-pr-review" -level="warning"


### PR DESCRIPTION
## Motivation

When doing a detailed C++ code review for Magma, I sometimes find that up to 25% of my feedback is with regards to the Google Style best practices.  In several instances already, lack of adherence to Google Style in Magma C++ has cost engineers time and progress. As an example among many, it is regularly unclear what is a function input and what is an output due to lack of adherence to `const ref` for inputs, and `by pointer` for mutated return parameters.

The rationale for Google Style is exceedingly well documented - and the presence of tooling like `cpplint` (of this PR) makes adherence to the style of high value (robots can help keep best practices in check - saving me ~25% of my review time for example).

## Approach

In this PR I pipe the [cpplint](https://github.com/google/styleguide/blob/gh-pages/cpplint/cpplint.py) findings through [ReviewDog](https://github.com/reviewdog/reviewdog). ReviewDog then filters them (e.g. by git diff for the PR) and posts them to the PR.  Though the mode asks for `gh-pr-review`, this mode is not yet supported for Forked github repos due to lack of write permissions to the review API for forked repos (security issue with GH action tokens).  We will be investigating fixes to this shortcoming as a group - we have many `ReviewDog` uses now in our linters - so we can hopefully fix them in a common manner.

## Potential Pitfalls

Current findings by type are enumerated here codebase-wide, and are available in [this gist](https://gist.github.com/electronjoe/713e6f23806c6a018d88116e86a9ae7f).

Note that a large subset of formating related findings could be alleviated if we used Googles clang-format style.

```
/github/workspace # cat cpplint.findings | awk -F'[][]' '{print $2}' | sort | uniq -c
   1213 
      8   
     63 build/c++11
    723 build/header_guard
     18 build/include
    255 build/include_order
   3132 build/include_subdir
    176 build/include_what_you_use
    174 build/namespaces
      4 build/namespaces_headers
      1 build/storage_class
    165 readability/alt_tokens
    334 readability/braces
   1593 readability/casting
      1 readability/fn_size
    140 readability/multiline_comment
    174 readability/multiline_string
      2 readability/namespace
      5 readability/nolint
    176 readability/todo
      3 runtime/arrays
     46 runtime/explicit
    121 runtime/int
     50 runtime/printf
    363 runtime/references
      1 runtime/string
      2 runtime/threadsafe_fn
     42 whitespace/blank_line
     88 whitespace/braces
      1 whitespace/comma
     67 whitespace/comments
      1 whitespace/empty_if_body
     15 whitespace/ending_newline
    141 whitespace/indent
    606 whitespace/line_length
     21 whitespace/newline
      9 whitespace/operators
    104 whitespace/parens
     43 whitespace/semicolon
   1091 whitespace/tab
      4 whitespace/todo
     20 year
```

- Some Style guide advice may be hard to adhere to due to library support. E.g. `avoid std::chrono` while we do not yet have available `absl::Time`.
- Some Style guide advice may be more nit than high importance. E.g. header `#ifdef` guard shape.

## Options to Alleviate Noise

### Turn off certain rules

From [cpplint documentation](https://github.com/google/styleguide/blob/6c31e522d9173e2e07f6b026ecbfe6e48fe20383/cpplint/cpplint.py#L96-L109).

```
Flags:
...
    filter=-x,+y,...
      Specify a comma-separated list of category-filters to apply: only
      error messages whose category names pass the filters will be printed.
      (Category names are printed with the message and look like
      "[whitespace/indent]".)  Filters are evaluated left to right.
      "-FOO" and "FOO" means "do not print categories that start with FOO".
      "+FOO" means "do print categories that start with FOO".
      Examples: --filter=-whitespace,+whitespace/braces
                --filter=whitespace,runtime/printf,+runtime/printf_format
                --filter=-,+build/include_what_you_use
      To see a list of all the categories used in cpplint, pass no arg:
         --filter=
```

### Adjust verbosity

Also, one can adjust the verbosity of the tool such that it emits only findings of "higher importance". From [cpplint docs](https://github.com/google/styleguide/blob/6c31e522d9173e2e07f6b026ecbfe6e48fe20383/cpplint/cpplint.py#L90-L91).

```
Flags:
...
    verbose=#
      Specify a number 0-5 to restrict errors to certain verbosity levels.
      Errors with lower verbosity levels have lower confidence and are more
      likely to be false positives.
```

### Annotate Lines

From the cpplint source code documentation.

```
 To suppress false-positive errors of a certain category, add a
  'NOLINT(category)' comment to the line.  NOLINT or NOLINT(*)
  suppresses errors of all categories on that line.
```

## Test Plan

See https://github.com/magma/magma/pull/6177 in which this PR was cherry-picked and a cpp header modified to validate Check findings.

Signed-off-by: Scott Harrison Moeller <smoeller@fb.com>