### PR TITLE
Fixed formatting for some code changes introduced as part of some recent commits

### DIFF
--- a/lte/gateway/c/oai/tasks/mme_app/mme_app_bearer.c
+++ b/lte/gateway/c/oai/tasks/mme_app/mme_app_bearer.c
@@ -3264,8 +3264,8 @@ void mme_app_handle_handover_required(
   ho_request_p->target_enb_id        = handover_required_p->enb_id;
   ho_request_p->cause                = handover_required_p->cause;
   ho_request_p->handover_type        = handover_required_p->handover_type;
-  ho_request_p->src_tgt_container =
-      bstrcpy(handover_required_p->src_tgt_container); // ownership passed to receiver
+  ho_request_p->src_tgt_container    = bstrcpy(
+      handover_required_p->src_tgt_container);  // ownership passed to receiver
 
   // get the ambr
   ho_request_p->ue_ambr = ue_context_p->subscribed_ue_ambr;

--- a/lte/gateway/c/oai/tasks/ngap/ngap_state_converter.cpp
+++ b/lte/gateway/c/oai/tasks/ngap/ngap_state_converter.cpp
@@ -44,7 +44,7 @@ void NgapStateConverter::state_to_proto(ngap_state_t* state, NgapState* proto) {
   amf_ue_ngap_id_t amfid;
   // Helper ptr so sctp_assoc_id can be casted from double ptr on
   // hashtable_ts_get
-  void* sctp_id_ptr = nullptr;
+  void* sctp_id_ptr  = nullptr;
   auto amfid2associd = proto->mutable_amfid2associd();
 
   hashtable_key_array_t* keys = hashtable_ts_get_keys(&state->amfid2associd);


### PR DESCRIPTION
## Title
[File_Formatting] Fixed formatting for some code changes introduced as part of commits ce958358f80e9b84fe2db45a42926e6f949ec1c5 and 4660e6632e4bfb440983fd6371df8add1dc00e7c

## Summary
This PR fixes clang8-formatting for some of the files introduced as part of recent commits ce958358f80e9b84fe2db45a42926e6f949ec1c5 and 4660e6632e4bfb440983fd6371df8add1dc00e7c

## Test Plan
Verified with sanity
 

Signed-off-by: VinashakAnkitAman <ankit.aman@radisys.com>