### PR TITLE
[CI][OAI][MME] Fix the OAI pipeline when no build is required

### DIFF
--- a/ci-scripts/JenkinsFile-OAI-Container-GitHub
+++ b/ci-scripts/JenkinsFile-OAI-Container-GitHub
@@ -129,7 +129,8 @@ pipeline {
                       // Check if the pull request has files that will impact MME behavior
                       // If so, we will run the OAI pipeline
                       // For security reasons, we retrieve from a trusted forked repository
-                      sh 'wget --quiet https://raw.githubusercontent.com/' + trustedGHuser + '/magma/' + trustedBranch + '/ci-scripts/check_pr_modified_files_for_oai_pipeline.py -O ci-scripts/ci-check_pr_modified_files_for_oai_pipeline.py'
+                      sh 'wget --quiet https://raw.githubusercontent.com/' + trustedGHuser + '/magma/' + trustedBranch + '/ci-scripts/check_pr_modified_files_for_oai_pipeline.py -O ci-scripts/ci-check_pr_modified_files_for_oai_pipeline.py || true'
+                      sh 'git fetch --unshallow || true'
                       sh 'python3 ci-scripts/ci-check_pr_modified_files_for_oai_pipeline.py'
                       // If the previous command is OK, no need to run
                       // All the following stages will be bypassed and the CI
@@ -235,7 +236,8 @@ pipeline {
                   )
                   if (!params.REGRESSION_TEST) {
                     try {
-                      sh 'wget --quiet https://raw.githubusercontent.com/' + trustedGHuser + '/magma/' + trustedBranch + '/ci-scripts/check_pr_modified_files_for_oai_pipeline.py -O ci-scripts/ci-check_pr_modified_files_for_oai_pipeline.py'
+                      sh 'wget --quiet https://raw.githubusercontent.com/' + trustedGHuser + '/magma/' + trustedBranch + '/ci-scripts/check_pr_modified_files_for_oai_pipeline.py -O ci-scripts/ci-check_pr_modified_files_for_oai_pipeline.py || true'
+                      sh 'git fetch --unshallow || true'
                       sh 'python3 ci-scripts/ci-check_pr_modified_files_for_oai_pipeline.py'
                       runAllRHELPipelineStages = false
                     } catch (Exception e) {

--- a/ci-scripts/JenkinsFile-OAI-Container-GitHub
+++ b/ci-scripts/JenkinsFile-OAI-Container-GitHub
@@ -305,31 +305,33 @@ pipeline {
       post {
         always {
           script {
-            // Again for security reason
-            sh 'wget --quiet https://raw.githubusercontent.com/' + trustedGHuser + '/magma/' + trustedBranch + '/ci-scripts/generateHtmlReport-OAI-pipeline.py -O ci-scripts/ci-generateHtmlReport-OAI-pipeline.py'
-            if (runAllRHELPipelineStages) {
-              unstash 'podmanBuildLog'
-            }
-            if (env.ghprbPullId != null) {
-              commitID = sh returnStdout: true, script: 'git rev-parse origin/master'
-              commitID = commitID.trim()
-              sh 'python3 ./ci-scripts/ci-generateHtmlReport-OAI-pipeline.py --mode=Build --job_name=' + JOB_NAME + ' --job_id=' + BUILD_ID + ' --job_url=' + BUILD_URL + ' --git_url=' + GIT_URL + ' --git_merge_request=True --git_src_branch=' + env.ghprbSourceBranch + ' --git_src_commit=' + env.ghprbActualCommit + ' --git_target_branch=master --git_target_commit=' + commitID
-              if (fileExists('build_results_magma_oai_mme.html')) {
-                sh 'sed -i -e "s#TEMPLATE_PULL_REQUEST_LINK#' + env.ghprbPullLink + '#g" build_results_magma_oai_mme.html'
-                if (env.ghprbPullTitle.contains('#')) {
-                  sh 'sed -i -e "s@TEMPLATE_PULL_REQUEST_TEMPLATE@' + env.ghprbPullTitle + '@g" build_results_magma_oai_mme.html'
-                } else {
-                  sh 'sed -i -e "s#TEMPLATE_PULL_REQUEST_TEMPLATE#' + env.ghprbPullTitle + '#g" build_results_magma_oai_mme.html'
-                }
+            if (runAllPipelineStages) {
+              // Again for security reason
+              sh 'wget --quiet https://raw.githubusercontent.com/' + trustedGHuser + '/magma/' + trustedBranch + '/ci-scripts/generateHtmlReport-OAI-pipeline.py -O ci-scripts/ci-generateHtmlReport-OAI-pipeline.py'
+              if (runAllRHELPipelineStages) {
+                unstash 'podmanBuildLog'
               }
-            } else {
-              commitID = sh returnStdout: true, script: 'git rev-parse HEAD'
-              commitID = commitID.trim()
-              sh 'python3 ./ci-scripts/ci-generateHtmlReport-OAI-pipeline.py --mode=Build --job_name=' + JOB_NAME + ' --job_id=' + BUILD_ID + ' --job_url=' + BUILD_URL + ' --git_url=' + GIT_URL + ' --git_src_branch=' + GIT_BRANCH + ' --git_src_commit=' + commitID
-            }
-            sh "sed -i -e 's#TEMPLATE_TIME#${JOB_TIMESTAMP}#' build_results_magma_oai_mme.html"
-            if (fileExists('build_results_magma_oai_mme.html')) {
-              archiveArtifacts artifacts: 'build_results_magma_oai_mme.html'
+              if (env.ghprbPullId != null) {
+                commitID = sh returnStdout: true, script: 'git rev-parse origin/master'
+                commitID = commitID.trim()
+                sh 'python3 ./ci-scripts/ci-generateHtmlReport-OAI-pipeline.py --mode=Build --job_name=' + JOB_NAME + ' --job_id=' + BUILD_ID + ' --job_url=' + BUILD_URL + ' --git_url=' + GIT_URL + ' --git_merge_request=True --git_src_branch=' + env.ghprbSourceBranch + ' --git_src_commit=' + env.ghprbActualCommit + ' --git_target_branch=master --git_target_commit=' + commitID
+                if (fileExists('build_results_magma_oai_mme.html')) {
+                  sh 'sed -i -e "s#TEMPLATE_PULL_REQUEST_LINK#' + env.ghprbPullLink + '#g" build_results_magma_oai_mme.html'
+                  if (env.ghprbPullTitle.contains('#')) {
+                    sh 'sed -i -e "s@TEMPLATE_PULL_REQUEST_TEMPLATE@' + env.ghprbPullTitle + '@g" build_results_magma_oai_mme.html'
+                  } else {
+                    sh 'sed -i -e "s#TEMPLATE_PULL_REQUEST_TEMPLATE#' + env.ghprbPullTitle + '#g" build_results_magma_oai_mme.html'
+                  }
+                }
+              } else {
+                commitID = sh returnStdout: true, script: 'git rev-parse HEAD'
+                commitID = commitID.trim()
+                sh 'python3 ./ci-scripts/ci-generateHtmlReport-OAI-pipeline.py --mode=Build --job_name=' + JOB_NAME + ' --job_id=' + BUILD_ID + ' --job_url=' + BUILD_URL + ' --git_url=' + GIT_URL + ' --git_src_branch=' + GIT_BRANCH + ' --git_src_commit=' + commitID
+              }
+              sh "sed -i -e 's#TEMPLATE_TIME#${JOB_TIMESTAMP}#' build_results_magma_oai_mme.html"
+              if (fileExists('build_results_magma_oai_mme.html')) {
+                archiveArtifacts artifacts: 'build_results_magma_oai_mme.html'
+              }
             }
           }
         }


### PR DESCRIPTION
Signed-off-by: Raphael Defosseux <raphael.defosseux@openairinterface.org>

## Summary

When I activated the new version this morning after last night merge, it fails on PR that are not tested in OAI.

[Example](https://jenkins-oai.eurecom.fr/job/MAGMA-MME-production/1583/)

I did not test that use case on my development pipeline.

## Test Plan

Already in production --> [fixed](https://jenkins-oai.eurecom.fr/job/MAGMA-MME-production/1587/)

## Additional Information

- [ ] This change is backwards-breaking

