### PR TITLE
Added code to set s6a_auth_response timer value and stop the timer on reception of AIA

### DIFF
--- a/lte/gateway/c/oai/tasks/nas/nas_procedures.c
+++ b/lte/gateway/c/oai/tasks/nas/nas_procedures.c
@@ -481,6 +481,15 @@ void nas_delete_detach_procedure(struct emm_context_s* emm_context) {
 static void nas_delete_auth_info_procedure(
     struct emm_context_s* emm_context, nas_auth_info_proc_t** auth_info_proc) {
   if (*auth_info_proc) {
+    if ((*auth_info_proc)->timer_s6a.id != NAS_TIMER_INACTIVE_ID) {
+      void* timer_callback_args = NULL;
+      nas_stop_Ts6a_auth_info(
+          (*auth_info_proc)->ue_id, &(*auth_info_proc)->timer_s6a,
+          timer_callback_args);
+
+      (*auth_info_proc)->timer_s6a.id = NAS_TIMER_INACTIVE_ID;
+    }
+
     if ((*auth_info_proc)->cn_proc.base_proc.parent) {
       (*auth_info_proc)->cn_proc.base_proc.parent->child = NULL;
     }
@@ -781,6 +790,8 @@ nas_auth_info_proc_t* nas_new_cn_auth_info_procedure(
       __sync_fetch_and_add(&nas_puid, 1);
   auth_info_proc->cn_proc.base_proc.type = NAS_PROC_TYPE_CN;
   auth_info_proc->cn_proc.type           = CN_PROC_AUTH_INFO;
+  auth_info_proc->timer_s6a.sec          = S6A_AIR_RESPONSE_TIMER;
+  auth_info_proc->timer_s6a.id           = NAS_TIMER_INACTIVE_ID;
 
   nas_cn_procedure_t* wrapper = calloc(1, sizeof(*wrapper));
   if (wrapper) {

--- a/lte/gateway/c/oai/tasks/nas/nas_procedures.h
+++ b/lte/gateway/c/oai/tasks/nas/nas_procedures.h
@@ -331,6 +331,7 @@ typedef struct nas_auth_info_proc_s {
   uint8_t nb_vectors;
   eutran_vector_t* vector[MAX_EPS_AUTH_VECTORS];
   int nas_cause;
+#define S6A_AIR_RESPONSE_TIMER 3  // In seconds
   struct nas_timer_s timer_s6a;
   mme_ue_s1ap_id_t ue_id;
   bool resync;  // Indicates whether the authentication information is requested


### PR DESCRIPTION
Signed-off-by: rashmi <rashmi.sarwad@radisys.com>

"[lte][agw]: Added code to set s6a_auth_response timer value and stop the timer on reception of AIA

## Summary
Added code to set s6a_auth_response timer value to 3 seconds same as that of s6a update location response timer.
And timer is stopped on reception Autentication Information Answer from hss.

## Test Plan
Executed s1ap sanity test suite
