### PR TITLE
[Sentry][SessionD][MME] Only initialize sentry if the URL length is g…

### DIFF
--- a/lte/gateway/c/oai/common/sentry_wrapper.cpp
+++ b/lte/gateway/c/oai/common/sentry_wrapper.cpp
@@ -28,6 +28,9 @@ void initialize_sentry(void) {
   if (control_proxy_config[SENTRY_URL].IsDefined()) {
     const std::string sentry_dns =
         control_proxy_config[SENTRY_URL].as<std::string>();
+    if (!sentry_dns.size()) {
+      return;
+    }
     sentry_options_t* options = sentry_options_new();
 
     sentry_options_set_dsn(options, sentry_dns.c_str());

--- a/lte/gateway/c/session_manager/sessiond_main.cpp
+++ b/lte/gateway/c/session_manager/sessiond_main.cpp
@@ -58,6 +58,10 @@ void initialize_sentry() {
   if (control_proxy_config[SENTRY_URL].IsDefined()) {
     const std::string sentry_dns =
         control_proxy_config[SENTRY_URL].as<std::string>();
+    if (!sentry_dns.size()) {
+      return;
+    }
+    MLOG(MINFO) << "Starting SessionD with Sentry!";
     sentry_options_t* options = sentry_options_new();
     sentry_options_set_dsn(options, sentry_dns.c_str());
 
@@ -205,16 +209,17 @@ int main(int argc, char* argv[]) {
   __gcov_flush();
 #endif
 
-#ifdef SENTRY_ENABLED
-  initialize_sentry();
-#endif
-
   magma::init_logging(argv[0]);
 
   auto mconfig = load_mconfig();
   auto config =
       magma::ServiceConfigLoader{}.load_service_config(SESSIOND_SERVICE);
   magma::set_verbosity(get_log_verbosity(config, mconfig));
+
+#ifdef SENTRY_ENABLED
+  initialize_sentry();
+#endif
+
   bool converged_access = false;
   // Check converged SessionD is enabled or not
   if (config["converged_access"].IsDefined() &&

--- a/lte/gateway/configs/control_proxy.yml
+++ b/lte/gateway/configs/control_proxy.yml
@@ -40,7 +40,6 @@ proxy_cloud_connections: True
 # Allows http_proxy usage if the environment variable is present
 allow_http_proxy: False
 
-# Dummy URL to Sentry logging -> Modify to local sentry instance in order
-# to pipe error handling to sentry
-sentry_url: ""
-sentry_sample_rate: 1.0
+# [Experimental] URL to enable Sentry logging
+# sentry_url: ""
+# entry_sample_rate: 1.0


### PR DESCRIPTION
…reater than 1

Signed-off-by: Marie Bremner <marwhal@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary
* For MME/SessionD only initialize sentry if the URL length is greater than 0 (sentry.py already checks for this)
* Add a log to indicate when running with SessionD so it is clear && initialize sentry after glog is set up
* I think it's clearer to have the config commented out rather than set to empty string. So changing it here. (Works either way, but I just want to make it crystal clear it's still experimental)

<!-- Enumerate changes you made and why you made them -->

## Test Plan
Run with config commented out -> no sentry log
Run with config set to "" -> no sentry log
Run with a valid config -> sentry log
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->

<!--
    Final note

    Please take a moment to read through the Magma project's
    - Contributing conventions: https://docs.magmacore.org/docs/next/contributing/contribute_conventions

    If this is your first time opening a PR, also consider reading
    - Developer onboarding: https://docs.magmacore.org/docs/next/contributing/contribute_onboarding
    - Development workflow: https://docs.magmacore.org/docs/next/contributing/contribute_workflow
-->
