### PR TITLE
Fix minor bug in precommit.py for python lint/format

### DIFF
--- a/lte/gateway/python/precommit.py
+++ b/lte/gateway/python/precommit.py
@@ -67,7 +67,10 @@ def _run_add_trailing_comma(path: str):
     abs_path = os.path.join(HOST_MAGMA_ROOT, path)
     if os.path.isfile(abs_path):
         # TODO upgrade to --py36-plus eventually
-        _run_docker_cmd(['add-trailing-comma', '--py35-plus', path])
+        _run_docker_cmd([
+            'add-trailing-comma', '--py35-plus',
+            '--exit-zero-even-if-changed', path,
+        ])
 
 
 def _run_flake8(paths: List[str]):
@@ -87,6 +90,7 @@ def _run(cmd: List[str]) -> None:
     try:
         subprocess.run(cmd, check=True)  # noqa: S603
     except subprocess.CalledProcessError as err:
+        print(err)
         exit(err.returncode)
 
 


### PR DESCRIPTION
Signed-off-by: Marie Bremner <marwhal@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary
The current script terminates as soon as `add-trailing-comma` modifies one file. This is because for some reason the script returns 1 when that happens. This can be changed by passing in the `--exit-zero-even-if-changed`.
<!-- Enumerate changes you made and why you made them -->

## Test Plan
Run format on multiple files
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->

<!--
    Final note

    Please take a moment to read through the Magma project's
    - Contributing conventions: https://docs.magmacore.org/docs/next/contributing/contribute_conventions

    If this is your first time opening a PR, also consider reading
    - Developer onboarding: https://docs.magmacore.org/docs/next/contributing/contribute_onboarding
    - Development workflow: https://docs.magmacore.org/docs/next/contributing/contribute_workflow
-->
