### PR TITLE
AGW: MME: Fix null pointer deref

### DIFF
--- a/lte/gateway/c/oai/tasks/s1ap/s1ap_mme_handlers.c
+++ b/lte/gateway/c/oai/tasks/s1ap/s1ap_mme_handlers.c
@@ -3371,8 +3371,8 @@ int s1ap_mme_handle_erab_setup_response(
   S1AP_FIND_PROTOCOLIE_BY_ID(
       S1ap_E_RABSetupResponseIEs_t, ie, container,
       S1ap_ProtocolIE_ID_id_E_RABFailedToSetupListBearerSURes, false);
-  const S1ap_E_RABList_t* const e_rab_list = &ie->value.choice.E_RABList;
   if (ie) {
+    const S1ap_E_RABList_t* const e_rab_list = &ie->value.choice.E_RABList;
     int num_erab = ie->value.choice.E_RABList.list.count;
     for (int index = 0; index < num_erab; index++) {
       const S1ap_E_RABItemIEs_t* const erab_item_ies =


### PR DESCRIPTION
This patch fixes following error:
magma-dev-focal mme[72010]: c/oai/tasks/s1ap/s1ap_mme_handlers.c:3374:33: \
runtime error: member access within null pointer of type 'struct S1ap_E_RABSetupResponseIEs_t'

Signed-off-by: Pravin B Shelar <pbshelar@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->

<!--
    Final note

    Please take a moment to read through the Magma project's
    - Contributing conventions: https://docs.magmacore.org/docs/next/contributing/contribute_conventions

    If this is your first time opening a PR, also consider reading
    - Developer onboarding: https://docs.magmacore.org/docs/next/contributing/contribute_onboarding
    - Development workflow: https://docs.magmacore.org/docs/next/contributing/contribute_workflow
-->
