### PR TITLE
AGW: OVS-2.14: add patch to allow GTP L3-to-L3 connectivity.

### DIFF
--- a/third_party/gtp_ovs/ovs-gtp-patches/2.14/0016-ODP-action-Fix-L3-port-to-L3-port-traffic.patch
+++ b/third_party/gtp_ovs/ovs-gtp-patches/2.14/0016-ODP-action-Fix-L3-port-to-L3-port-traffic.patch
@@ -1,0 +1,65 @@
+From da9cd274d99621523cbb2e7f392acb6ee362a12a Mon Sep 17 00:00:00 2001
+From: Pravin B Shelar <pbshelar@fb.com>
+Date: Sun, 18 Apr 2021 17:17:56 +0000
+Subject: [PATCH 16/16] ODP-action: Fix L3 port to L3 port traffic.
+
+Signed-off-by: Pravin B Shelar <pbshelar@fb.com>
+---
+ lib/odp-util.c | 27 +++++++++++++++++++++++++--
+ 1 file changed, 25 insertions(+), 2 deletions(-)
+
+diff --git a/lib/odp-util.c b/lib/odp-util.c
+index ec8fb313e..681350698 100644
+--- a/lib/odp-util.c
++++ b/lib/odp-util.c
+@@ -8605,6 +8605,27 @@ odp_put_push_nsh_action(struct ofpbuf *odp_actions,
+     nl_msg_end_nested(odp_actions, offset);
+ }
+ 
++static void OVS_PRINTF_FORMAT(2, 3)
++log_flow(const struct flow *flow, const char *format, ...)
++{
++    static struct vlog_rate_limit rl = VLOG_RATE_LIMIT_INIT(1, 5);
++    if (VLOG_DROP_DBG(&rl)) {
++        return;
++    }
++
++    struct ds s = DS_EMPTY_INITIALIZER;
++    va_list args;
++    va_start(args, format);
++    ds_put_format_valist(&s, format, args);
++    va_end(args);
++
++    ds_put_cstr(&s, " Unexpected state while processing ");
++    flow_format(&s, flow, NULL);
++    VLOG_DBG("%s", ds_cstr(&s));
++    ds_destroy(&s);
++}
++
++
+ static void
+ commit_encap_decap_action(const struct flow *flow,
+                           struct flow *base_flow,
+@@ -8635,7 +8656,8 @@ commit_encap_decap_action(const struct flow *flow,
+         default:
+             /* Only the above protocols are supported for encap.
+              * The check is done at action translation. */
+-            OVS_NOT_REACHED();
++            log_flow(flow, "pending encap");
++            return;
+         }
+     } else if (pending_decap || flow->packet_type != base_flow->packet_type) {
+         /* This is an explicit or implicit decap case. */
+@@ -8656,7 +8678,8 @@ commit_encap_decap_action(const struct flow *flow,
+                 break;
+             default:
+                 /* Checks are done during translation. */
+-                OVS_NOT_REACHED();
++                log_flow(flow, "pending dencap");
++                return;
+             }
+         }
+     }
+-- 
+2.17.1
+

--- a/third_party/gtp_ovs/ovs-gtp-patches/2.14/README.md
+++ b/third_party/gtp_ovs/ovs-gtp-patches/2.14/README.md
@@ -18,7 +18,7 @@ Steps to build package from source code.
 2. cd $MAGMA_ROOT/third_party/gtp_ovs/ovs/2.14/
 3. git clone https://github.com/openvswitch/ovs
 4. cd ovs/
-5. git checkout f8ea6e0cab75f8f6675272fff6d99191150bb1cb /* Checkout ovs2.14.1 */
+5. git checkout branch-2.14 /* Checkout ovs2.14.1 */
 6. git am ../00*
 7. DEB_BUILD_OPTIONS='parallel=8 nocheck' fakeroot debian/rules binary
 8. Packages are copied in parent (..) dir


### PR DESCRIPTION
OVS action transation code throws asserts on packet that traverse
from L3 to L3 port. This is due to incorrect assumpltion of packet
state. Following patch removes incurrect assert.

Signed-off-by: Pravin B Shelar <pbshelar@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->

<!--
    Final note

    Please take a moment to read through the Magma project's
    - Contributing conventions: https://docs.magmacore.org/docs/next/contributing/contribute_conventions

    If this is your first time opening a PR, also consider reading
    - Developer onboarding: https://docs.magmacore.org/docs/next/contributing/contribute_onboarding
    - Development workflow: https://docs.magmacore.org/docs/next/contributing/contribute_workflow
-->
