### PR TITLE
[orc8r][deploy][bare-metal] Update Versions of the Images

### DIFF
--- a/orc8r/cloud/deploy/bare-metal-ansible/roles/magma/orc8r/defaults/main.yml
+++ b/orc8r/cloud/deploy/bare-metal-ansible/roles/magma/orc8r/defaults/main.yml
@@ -29,13 +29,13 @@ orc8r_nms_admin_pass: "{{ lookup('password', credentials_dir + '/orc8r_nms_admin
 
 # Monitoring component settings
 orc8r_alertmanager_configurer_image_repo: docker.io/facebookincubator/alertmanager-configurer
-orc8r_alertmanager_configurer_image_tag: 1.0.0
+orc8r_alertmanager_configurer_image_tag: 1.0.4
 orc8r_prometheus_cache_image_repo: docker.io/facebookincubator/prometheus-edge-hub
-orc8r_prometheus_cache_image_tag: 1.0.0
+orc8r_prometheus_cache_image_tag: 1.1.0
 orc8r_prometheus_configurer_image_repo: docker.io/facebookincubator/prometheus-configurer
-orc8r_prometheus_configurer_image_tag: 1.0.0
+orc8r_prometheus_configurer_image_tag: 1.0.4
 orc8r_alertmanager_image_repo: docker.io/facebookincubator/alertmanager-configurer
-orc8r_alertmanager_image_tag: 1.0.0
+orc8r_alertmanager_image_tag: 1.0.4
 orc8r_grafana_image_repo: docker.io/grafana/grafana
 orc8r_grafana_image_tag: 6.6.2
 


### PR DESCRIPTION

## Summary

Updated the Image versions. This is fixing a bug that the alertmanager-configurer and prometheus_cache don't come up after install.

## Test Plan

Run the deploy.sh in a bare metal environment

## Additional Information

- This changes are necessary back until 1.4 to make the install work.