### PR TITLE
[orc8r][deploy][bare-metal] Fix component search

### DIFF
--- a/orc8r/cloud/deploy/bare-metal-ansible/roles/magma/orc8r/tasks/main.yml
+++ b/orc8r/cloud/deploy/bare-metal-ansible/roles/magma/orc8r/tasks/main.yml
@@ -71,7 +71,7 @@
     - orc8r
 
 - name: orc8r | Get orc8r pod
-  command: kubectl -n {{ magma_namespace }} get pod -l app.kubernetes.io/component=controller -o jsonpath='{.items[0].metadata.name}'
+  command: kubectl -n {{ magma_namespace }} get pod -l app.kubernetes.io/component=orchestrator -o jsonpath='{.items[0].metadata.name}'
   register: orc8r_pod
 
 - name: orc8r | Get nms pod


### PR DESCRIPTION

## Summary

Replaced the component from controller to orchestrator due to the changes made in 1.4

## Test Plan

Deploy the orc8r in a bare-metal environment from branch 1.4 and higher

## Additional Information

- This change is required until branch v1.4 to make it work 
