### PR TITLE
[Orc8r] Fix sql query in configurator.

### DIFF
--- a/orc8r/cloud/go/services/configurator/storage/sql_entity_load_helpers.go
+++ b/orc8r/cloud/go/services/configurator/storage/sql_entity_load_helpers.go
@@ -134,9 +134,12 @@ func (store *sqlConfiguratorStorage) getBuilder(networkID string, filter EntityL
 		return fmt.Sprintf("ent.%s", c)
 	}
 	addSuffix := func(b sq.SelectBuilder) sq.SelectBuilder {
-		b = b.OrderBy(entCol(entKeyCol))
-		if loadTyp == loadEntities {
+		switch loadTyp {
+		case loadEntities:
 			b = b.Limit(uint64(pageSize))
+			fallthrough
+		case loadChildren, loadParents:
+			b = b.OrderBy(entCol(entKeyCol))
 		}
 		return b
 	}


### PR DESCRIPTION
Signed-off-by: Karthik Subraveti <ksubraveti@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary
Minor change to handle CountEntities. This fix ignores adding 'addSuffix' 
when we attempt to count entities 

I was otherwise seeing the following error in configurator
E0417 22:01:39.207065       1 handler.go:116] [ERROR /magma.orc8r.configurator.NorthboundConfigurator/CountEntities]: pq: column "ent.key" must appear in the GROUP BY clause or be used in an aggregate function

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->

<!--
    Final note

    Please take a moment to read through the Magma project's
    - Contributing conventions: https://docs.magmacore.org/docs/next/contributing/contribute_conventions

    If this is your first time opening a PR, also consider reading
    - Developer onboarding: https://docs.magmacore.org/docs/next/contributing/contribute_onboarding
    - Development workflow: https://docs.magmacore.org/docs/next/contributing/contribute_workflow
-->
