### PR TITLE
[SessionD] Use teid from RuleRecords to look up sessions

### DIFF
--- a/lte/gateway/c/session_manager/LocalEnforcer.cpp
+++ b/lte/gateway/c/session_manager/LocalEnforcer.cpp
@@ -239,12 +239,12 @@ void LocalEnforcer::aggregate_records(
   RuleRecordSet dead_sessions_to_cleanup;
 
   for (const RuleRecord& record : records.records()) {
-    const std::string &imsi = record.sid(), &ip = record.ue_ipv4();
-    // TODO IPv6 add ipv6 to search criteria
-    SessionSearchCriteria criteria(imsi, IMSI_AND_UE_IPV4_OR_IPV6, ip);
+    const std::string& imsi = record.sid();
+    const uint32_t teid     = record.teid();
+    SessionSearchCriteria criteria(imsi, IMSI_AND_TEID, teid);
     auto session_it = session_store_.find_session(session_map, criteria);
     if (!session_it) {
-      MLOG(MERROR) << "Could not find session for " << imsi << " and " << ip
+      MLOG(MERROR) << "Could not find session for " << imsi << " and " << teid
                    << " during record aggregation";
       dead_sessions_to_cleanup.insert(record);
       continue;

--- a/lte/gateway/c/session_manager/LocalEnforcer.h
+++ b/lte/gateway/c/session_manager/LocalEnforcer.h
@@ -43,20 +43,14 @@ typedef std::pair<std::string, std::string> ImsiAndSessionID;
 
 struct RuleRecord_equal {
   bool operator()(const RuleRecord& l, const RuleRecord& r) const {
-    // TODO replace IP comparison to tunnelID comparison
-    // return l.sid() == r.sid() && l.teid();
-    return l.sid() == r.sid() && l.ue_ipv4() == r.ue_ipv4() &&
-           l.ue_ipv6() == r.ue_ipv6();
+    return l.sid() == r.sid() && l.teid() == r.teid();
   }
 };
 struct RuleRecord_hash {
   std::size_t operator()(const RuleRecord& el) const {
     size_t h1 = std::hash<std::string>()(el.sid());
-    // TODO replace IP hash to tunnelID hash
-    // size_t h2 = std::hash<uint32_t>()(el.teid());
-    size_t h2 = std::hash<std::string>()(el.ue_ipv4());
-    size_t h3 = std::hash<std::string>()(el.ue_ipv6());
-    return h1 ^ h2 ^ h3;
+    size_t h2 = std::hash<uint32_t>()(el.teid());
+    return h1 ^ h2;
   }
 };
 typedef std::unordered_set<RuleRecord, RuleRecord_hash, RuleRecord_equal>

--- a/lte/gateway/c/session_manager/LocalSessionManagerHandler.cpp
+++ b/lte/gateway/c/session_manager/LocalSessionManagerHandler.cpp
@@ -602,8 +602,8 @@ void LocalSessionManagerHandlerImpl::UpdateTunnelIds(
   PrintGrpcMessage(static_cast<const google::protobuf::Message&>(request_cpy));
   MLOG(MDEBUG) << "Received a UpdateTunnelIds request for " << imsi
                << " with default bearer id: " << request->bearer_id()
-               << " enb_teid= " << request->enb_teid()
-               << " agw_teid= " << request->agw_teid();
+               << ", enb teid: " << request->enb_teid()
+               << ", agw teid: " << request->agw_teid();
   enforcer_->get_event_base().runInEventBaseThread([this, request_cpy, imsi,
                                                     response_callback]() {
     auto session_map = session_store_.read_sessions({imsi});

--- a/lte/gateway/c/session_manager/SessionState.cpp
+++ b/lte/gateway/c/session_manager/SessionState.cpp
@@ -285,7 +285,7 @@ void SessionState::sess_infocopy(struct SessionInfo* info) {
   // Static SessionInfo vlaue till UPF node value implementation
   // gets stablized.
   std::string imsi_num;
-  // TODO we cud eventually  migrate to SMF-UPF proto enum directly.
+  // TODO we could eventually  migrate to SMF-UPF proto enum directly.
   info->state = get_proto_fsm_state();
   info->subscriber_id.assign(get_imsi());
   info->ver_no              = get_current_version();

--- a/lte/gateway/c/session_manager/test/ProtobufCreators.cpp
+++ b/lte/gateway/c/session_manager/test/ProtobufCreators.cpp
@@ -84,33 +84,24 @@ void create_rule_record(
   rule_record->set_rule_id(rule_id);
   rule_record->set_bytes_rx(bytes_rx);
   rule_record->set_bytes_tx(bytes_tx);
+  rule_record->set_dropped_rx(0);
+  rule_record->set_dropped_tx(0);
 }
 
 void create_rule_record(
-    const std::string& imsi, const std::string& ip, const std::string& rule_id,
-    uint64_t bytes_rx, uint64_t bytes_tx, uint32_t teid,
-    RuleRecord* rule_record) {
-  create_rule_record(imsi, ip, rule_id, bytes_rx, bytes_tx, rule_record);
+    const std::string& imsi, const uint32_t teid, const std::string& rule_id,
+    uint64_t bytes_rx, uint64_t bytes_tx, RuleRecord* rule_record) {
+  create_rule_record(imsi, rule_id, bytes_rx, bytes_tx, rule_record);
   rule_record->set_teid(teid);
 }
 
 void create_rule_record(
-    const std::string& imsi, const std::string& ip, const std::string& rule_id,
-    uint64_t bytes_rx, uint64_t bytes_tx, RuleRecord* rule_record) {
-  create_rule_record(imsi, rule_id, bytes_rx, bytes_tx, rule_record);
-  rule_record->set_dropped_rx(0);
-  rule_record->set_dropped_tx(0);
-  rule_record->set_ue_ipv4(ip);
-}
-
-void create_rule_record(
-    const std::string& imsi, const std::string& ip, const std::string& rule_id,
+    const std::string& imsi, const uint32_t teid, const std::string& rule_id,
     uint64_t bytes_rx, uint64_t bytes_tx, uint64_t dropped_rx,
     uint64_t dropped_tx, RuleRecord* rule_record) {
-  create_rule_record(imsi, rule_id, bytes_rx, bytes_tx, rule_record);
+  create_rule_record(imsi, teid, rule_id, bytes_rx, bytes_tx, rule_record);
   rule_record->set_dropped_rx(dropped_rx);
   rule_record->set_dropped_tx(dropped_tx);
-  rule_record->set_ue_ipv4(ip);
 }
 
 void create_charging_credit(

--- a/lte/gateway/c/session_manager/test/ProtobufCreators.h
+++ b/lte/gateway/c/session_manager/test/ProtobufCreators.h
@@ -49,16 +49,11 @@ void create_rule_record(
     uint64_t bytes_tx, RuleRecord* rule_record);
 
 void create_rule_record(
-    const std::string& imsi, const std::string& ip, const std::string& rule_id,
-    uint64_t bytes_rx, uint64_t bytes_tx, uint32_t teid,
-    RuleRecord* rule_record);
-
-void create_rule_record(
-    const std::string& imsi, const std::string& ip, const std::string& rule_id,
+    const std::string& imsi, const uint32_t teid, const std::string& rule_id,
     uint64_t bytes_rx, uint64_t bytes_tx, RuleRecord* rule_record);
 
 void create_rule_record(
-    const std::string& imsi, const std::string& ip, const std::string& rule_id,
+    const std::string& imsi, const uint32_t teid, const std::string& rule_id,
     uint64_t bytes_rx, uint64_t bytes_tx, uint64_t dropped_rx,
     uint64_t dropped_tx, RuleRecord* rule_record);
 

--- a/lte/gateway/c/session_manager/test/test_local_enforcer.cpp
+++ b/lte/gateway/c/session_manager/test/test_local_enforcer.cpp
@@ -333,8 +333,7 @@ TEST_F(LocalEnforcerTest, test_single_record) {
   RuleRecordTable table;
   auto record_list = table.mutable_records();
   create_rule_record(
-      IMSI1, test_cfg_.common_context.ue_ipv4(), "rule1", 16, 32,
-      record_list->Add());
+      IMSI1, teids1.agw_teid(), "rule1", 16, 32, record_list->Add());
 
   auto update = SessionStore::get_default_session_update(session_map);
   local_enforcer->aggregate_records(session_map, table, update);
@@ -372,15 +371,12 @@ TEST_F(LocalEnforcerTest, test_aggregate_records_mixed_ips) {
   auto record_list = table.mutable_records();
   // ipv4 usage
   create_rule_record(
-      IMSI1, test_cfg_.common_context.ue_ipv4(), "rule1", 10, 20,
-      record_list->Add());
+      IMSI1, teids1.agw_teid(), "rule1", 10, 20, record_list->Add());
   // ipv6 usage for the same charging key and subscriber
   create_rule_record(
-      IMSI1, test_cfg_.common_context.ue_ipv6(), "rule2", 5, 15,
-      record_list->Add());
+      IMSI1, teids1.agw_teid(), "rule2", 5, 15, record_list->Add());
   create_rule_record(
-      IMSI1, test_cfg_.common_context.ue_ipv4(), "rule3", 100, 150,
-      record_list->Add());
+      IMSI1, teids1.agw_teid(), "rule3", 100, 150, record_list->Add());
 
   auto update = SessionStore::get_default_session_update(session_map);
   local_enforcer->aggregate_records(session_map, table, update);
@@ -427,9 +423,12 @@ TEST_F(LocalEnforcerTest, test_aggregate_records_for_termination) {
 
   RuleRecordTable table;
   auto record_list = table.mutable_records();
-  create_rule_record(IMSI1, "rule1", 10, 20, record_list->Add());
-  create_rule_record(IMSI1, "rule2", 5, 15, record_list->Add());
-  create_rule_record(IMSI1, "rule3", 100, 150, record_list->Add());
+  create_rule_record(
+      IMSI1, teids1.agw_teid(), "rule1", 10, 20, record_list->Add());
+  create_rule_record(
+      IMSI1, teids1.agw_teid(), "rule2", 5, 15, record_list->Add());
+  create_rule_record(
+      IMSI1, teids1.agw_teid(), "rule3", 100, 150, record_list->Add());
 
   EXPECT_CALL(
       *reporter,
@@ -463,8 +462,7 @@ TEST_F(LocalEnforcerTest, test_collect_updates) {
   RuleRecordTable table;
   auto record_list = table.mutable_records();
   create_rule_record(
-      IMSI1, test_cfg_.common_context.ue_ipv4(), "rule1", 1024, 2048,
-      record_list->Add());
+      IMSI1, teids1.agw_teid(), "rule1", 1024, 2048, record_list->Add());
 
   local_enforcer->aggregate_records(session_map, table, update);
   actions.clear();
@@ -509,7 +507,8 @@ TEST_F(LocalEnforcerTest, test_update_session_credits_and_rules) {
 
   RuleRecordTable table;
   auto record_list = table.mutable_records();
-  create_rule_record(IMSI1, "rule1", 1024, 1024, record_list->Add());
+  create_rule_record(
+      IMSI1, teids1.agw_teid(), "rule1", 1024, 1024, record_list->Add());
   auto update = SessionStore::get_default_session_update(session_map);
   local_enforcer->aggregate_records(session_map, table, update);
 
@@ -573,8 +572,7 @@ TEST_F(LocalEnforcerTest, test_update_session_credits_and_rules_with_failure) {
   RuleRecordTable table;
   auto record_list = table.mutable_records();
   create_rule_record(
-      IMSI1, test_cfg_.common_context.ue_ipv4(), "rule1", 10, 20,
-      record_list->Add());
+      IMSI1, teids1.agw_teid(), "rule1", 10, 20, record_list->Add());
   auto update = SessionStore::get_default_session_update(session_map);
   local_enforcer->aggregate_records(session_map, table, update);
   assert_monitor_credit(session_map, IMSI1, SESSION_ID_1, USED_RX, {{"1", 10}});
@@ -646,8 +644,8 @@ TEST_F(LocalEnforcerTest, test_terminate_credit) {
   RuleRecordTable only_drop_rule_table;
   auto record_list = only_drop_rule_table.mutable_records();
   create_rule_record(
-      IMSI1, test_cfg_.common_context.ue_ipv4(),
-      "internal_default_drop_flow_rule", 0, 0, record_list->Add());
+      IMSI1, teids1.agw_teid(), "internal_default_drop_flow_rule", 0, 0,
+      record_list->Add());
 
   local_enforcer->aggregate_records(session_map, only_drop_rule_table, update);
   run_evb();
@@ -681,8 +679,7 @@ TEST_F(LocalEnforcerTest, test_terminate_credit_during_reporting) {
   RuleRecordTable table;
   auto record_list = table.mutable_records();
   create_rule_record(
-      IMSI1, default_cfg_1.common_context.ue_ipv4(), "rule1", 1024, 2048,
-      record_list->Add());
+      IMSI1, teids1.agw_teid(), "rule1", 1024, 2048, record_list->Add());
   auto update = SessionStore::get_default_session_update(session_map);
   local_enforcer->aggregate_records(session_map, table, update);
 
@@ -718,11 +715,10 @@ TEST_F(LocalEnforcerTest, test_terminate_credit_during_reporting) {
   RuleRecordTable only_drop_rule_table;
   record_list = only_drop_rule_table.mutable_records();
   create_rule_record(
-      IMSI1, default_cfg_1.common_context.ue_ipv4(), "rule1", 0, 0, 1000, 2000,
-      record_list->Add());
+      IMSI1, teids1.agw_teid(), "rule1", 0, 0, 1000, 2000, record_list->Add());
   create_rule_record(
-      IMSI1, default_cfg_1.common_context.ue_ipv4(),
-      "internal_default_drop_flow_rule", 0, 0, record_list->Add());
+      IMSI1, teids1.agw_teid(), "internal_default_drop_flow_rule", 0, 0,
+      record_list->Add());
 
   local_enforcer->aggregate_records(session_map, only_drop_rule_table, update);
   run_evb();
@@ -887,11 +883,9 @@ TEST_F(LocalEnforcerTest, test_final_unit_handling) {
   RuleRecordTable table;
   auto record_list = table.mutable_records();
   create_rule_record(
-      IMSI1, test_cfg_.common_context.ue_ipv4(), "rule1", 1024, 2048,
-      record_list->Add());
+      IMSI1, teids1.agw_teid(), "rule1", 1024, 2048, record_list->Add());
   create_rule_record(
-      IMSI1, test_cfg_.common_context.ue_ipv4(), "rule2", 1024, 2048,
-      record_list->Add());
+      IMSI1, teids1.agw_teid(), "rule2", 1024, 2048, record_list->Add());
   auto update = SessionStore::get_default_session_update(session_map);
   local_enforcer->aggregate_records(session_map, table, update);
 
@@ -946,8 +940,10 @@ TEST_F(LocalEnforcerTest, test_cwf_final_unit_handling) {
   // Insert record for key 1
   RuleRecordTable table;
   auto record_list = table.mutable_records();
-  create_rule_record(IMSI1, "rule1", 1024, 2048, record_list->Add());
-  create_rule_record(IMSI1, "rule2", 1024, 2048, record_list->Add());
+  create_rule_record(
+      IMSI1, teids1.agw_teid(), "rule1", 1024, 2048, record_list->Add());
+  create_rule_record(
+      IMSI1, teids1.agw_teid(), "rule2", 1024, 2048, record_list->Add());
   auto update = SessionStore::get_default_session_update(session_map);
   local_enforcer->aggregate_records(session_map, table, update);
 
@@ -1007,13 +1003,11 @@ TEST_F(LocalEnforcerTest, test_all) {
   RuleRecordTable table;
   auto record_list = table.mutable_records();
   create_rule_record(
-      IMSI1, cfg1.common_context.ue_ipv4(), "rule1", 10, 20,
-      record_list->Add());
+      IMSI1, teids1.agw_teid(), "rule1", 10, 20, record_list->Add());
   create_rule_record(
-      IMSI1, cfg1.common_context.ue_ipv4(), "rule2", 5, 15, record_list->Add());
+      IMSI1, teids1.agw_teid(), "rule2", 5, 15, record_list->Add());
   create_rule_record(
-      IMSI2, cfg2.common_context.ue_ipv4(), "rule3", 1024, 1024,
-      record_list->Add());
+      IMSI2, teids2.agw_teid(), "rule3", 1024, 1024, record_list->Add());
   auto update = SessionStore::get_default_session_update(session_map);
   local_enforcer->aggregate_records(session_map, table, update);
 
@@ -1143,8 +1137,7 @@ TEST_F(LocalEnforcerTest, test_credit_init_with_transient_error_redirect) {
   RuleRecordTable table;
   auto record_list = table.mutable_records();
   create_rule_record(
-      IMSI1, test_cfg_.common_context.ue_ipv4(), "rule1", 10, 20,
-      record_list->Add());
+      IMSI1, teids1.agw_teid(), "rule1", 10, 20, record_list->Add());
   local_enforcer->aggregate_records(session_map, table, update);
 
   assert_charging_credit(session_map, IMSI1, SESSION_ID_1, USED_RX, {{1, 10}});
@@ -1374,11 +1367,9 @@ TEST_F(LocalEnforcerTest, test_dynamic_rules) {
   RuleRecordTable table;
   auto record_list = table.mutable_records();
   create_rule_record(
-      IMSI1, test_cfg_.common_context.ue_ipv4(), "rule1", 16, 32,
-      record_list->Add());
+      IMSI1, teids1.agw_teid(), "rule1", 16, 32, record_list->Add());
   create_rule_record(
-      IMSI1, test_cfg_.common_context.ue_ipv4(), "rule2", 8, 8,
-      record_list->Add());
+      IMSI1, teids1.agw_teid(), "rule2", 8, 8, record_list->Add());
 
   auto update = SessionStore::get_default_session_update(session_map);
   local_enforcer->aggregate_records(session_map, table, update);
@@ -1430,11 +1421,9 @@ TEST_F(LocalEnforcerTest, test_dynamic_rule_actions) {
   RuleRecordTable table;
   auto record_list = table.mutable_records();
   create_rule_record(
-      IMSI1, default_cfg_1.common_context.ue_ipv4(), "rule1", 1024, 2048,
-      record_list->Add());
+      IMSI1, teids1.agw_teid(), "rule1", 1024, 2048, record_list->Add());
   create_rule_record(
-      IMSI1, default_cfg_1.common_context.ue_ipv4(), "rule2", 1024, 2048,
-      record_list->Add());
+      IMSI1, teids1.agw_teid(), "rule2", 1024, 2048, record_list->Add());
   auto update = SessionStore::get_default_session_update(session_map);
   local_enforcer->aggregate_records(session_map, table, update);
 
@@ -1567,11 +1556,14 @@ TEST_F(LocalEnforcerTest, test_usage_monitors) {
   // receive usages from pipelined
   RuleRecordTable table;
   auto record_list = table.mutable_records();
-  auto& ip         = test_cfg_.common_context.ue_ipv4();
-  create_rule_record(IMSI1, ip, "both_rule", 10, 20, record_list->Add());
-  create_rule_record(IMSI1, ip, "ocs_rule", 5, 15, record_list->Add());
-  create_rule_record(IMSI1, ip, "pcrf_only", 1024, 1024, record_list->Add());
-  create_rule_record(IMSI1, ip, "pcrf_split", 10, 20, record_list->Add());
+  create_rule_record(
+      IMSI1, teids1.agw_teid(), "both_rule", 10, 20, record_list->Add());
+  create_rule_record(
+      IMSI1, teids1.agw_teid(), "ocs_rule", 5, 15, record_list->Add());
+  create_rule_record(
+      IMSI1, teids1.agw_teid(), "pcrf_only", 1024, 1024, record_list->Add());
+  create_rule_record(
+      IMSI1, teids1.agw_teid(), "pcrf_split", 10, 20, record_list->Add());
   auto update = SessionStore::get_default_session_update(session_map);
   local_enforcer->aggregate_records(session_map, table, update);
 
@@ -1727,11 +1719,12 @@ TEST_F(LocalEnforcerTest, test_usage_monitor_disable) {
   // reports for all monitors receive usages from pipelined
   RuleRecordTable table_1;
   auto record_list_1 = table_1.mutable_records();
-  auto ip            = test_cfg_.common_context.ue_ipv4();
   create_rule_record(
-      IMSI1, ip, "pcrf_only_active", 2000, 0, record_list_1->Add());
+      IMSI1, teids1.agw_teid(), "pcrf_only_active", 2000, 0,
+      record_list_1->Add());
   create_rule_record(
-      IMSI1, ip, "pcrf_only_to_be_disabled", 2000, 0, record_list_1->Add());
+      IMSI1, teids1.agw_teid(), "pcrf_only_to_be_disabled", 2000, 0,
+      record_list_1->Add());
   local_enforcer->aggregate_records(session_map, table_1, update_1);
 
   // Collect updates, should have updates since all monitors got 80% exhausted
@@ -1789,9 +1782,11 @@ TEST_F(LocalEnforcerTest, test_usage_monitor_disable) {
   RuleRecordTable table_2;
   auto record_list2 = table_2.mutable_records();
   create_rule_record(
-      IMSI1, ip, "pcrf_only_active", 2000, 0, record_list2->Add());
+      IMSI1, teids1.agw_teid(), "pcrf_only_active", 2000, 0,
+      record_list2->Add());
   create_rule_record(
-      IMSI1, ip, "pcrf_only_to_be_disabled", 2000, 0, record_list2->Add());
+      IMSI1, teids1.agw_teid(), "pcrf_only_to_be_disabled", 2000, 0,
+      record_list2->Add());
 
   update_2 = SessionStore::get_default_session_update(session_map);
   local_enforcer->aggregate_records(session_map, table_2, update_2);
@@ -2756,7 +2751,7 @@ TEST_F(LocalEnforcerTest, test_final_unit_redirect_activation_and_termination) {
   RuleRecordTable table;
   auto record_list = table.mutable_records();
   create_rule_record(
-      IMSI1, ip_addr, "static_1", 1024, 2048, record_list->Add());
+      IMSI1, teids1.agw_teid(), "static_1", 1024, 2048, record_list->Add());
   auto update = SessionStore::get_default_session_update(session_map);
   local_enforcer->aggregate_records(session_map, table, update);
 
@@ -2830,9 +2825,12 @@ TEST_F(LocalEnforcerTest, test_final_unit_activation_and_canceling) {
   // Insert record and aggregate over them
   RuleRecordTable table;
   auto record_list = table.mutable_records();
-  create_rule_record(IMSI1, ip_addr, "rule1", 1024, 2048, record_list->Add());
-  create_rule_record(IMSI1, ip_addr, "rule2", 1024, 2048, record_list->Add());
-  create_rule_record(IMSI1, ip_addr, "rule3", 1024, 2048, record_list->Add());
+  create_rule_record(
+      IMSI1, teids.agw_teid(), "rule1", 1024, 2048, record_list->Add());
+  create_rule_record(
+      IMSI1, teids.agw_teid(), "rule2", 1024, 2048, record_list->Add());
+  create_rule_record(
+      IMSI1, teids.agw_teid(), "rule3", 1024, 2048, record_list->Add());
   auto update = SessionStore::get_default_session_update(session_map);
   local_enforcer->aggregate_records(session_map, table, update);
 
@@ -2933,7 +2931,7 @@ TEST_F(LocalEnforcerTest, test_final_unit_action_no_update) {
   RuleRecordTable table;
   auto record_list = table.mutable_records();
   create_rule_record(
-      IMSI1, ip_addr, "static_rule1", 1023, 0, record_list->Add());
+      IMSI1, teids.agw_teid(), "static_rule1", 1023, 0, record_list->Add());
   auto update = SessionStore::get_default_session_update(session_map);
   local_enforcer->aggregate_records(session_map, table, update);
 
@@ -2947,7 +2945,7 @@ TEST_F(LocalEnforcerTest, test_final_unit_action_no_update) {
   table.Clear();
   record_list = table.mutable_records();
   create_rule_record(
-      IMSI1, ip_addr, "static_rule1", 1024, 0, record_list->Add());
+      IMSI1, teids1.agw_teid(), "static_rule1", 1024, 0, record_list->Add());
   update = SessionStore::get_default_session_update(session_map);
   local_enforcer->aggregate_records(session_map, table, update);
 
@@ -3055,13 +3053,13 @@ TEST_F(LocalEnforcerTest, test_dead_session_in_usage_report) {
   EXPECT_CALL(
       *pipelined_client,
       deactivate_flows_for_rules_for_termination(
-          IMSI1, IP1, testing::_, CheckTeidVector(expected_teids_vec),
+          IMSI1, testing::_, testing::_, CheckTeidVector(expected_teids_vec),
           RequestOriginType::WILDCARD))
       .Times(1);
 
   RuleRecordTable table;
   create_rule_record(
-      IMSI1, IP1, "rule1", 16, 32, teid, table.mutable_records()->Add());
+      IMSI1, teid, "rule1", 16, 32, table.mutable_records()->Add());
   auto update = SessionStore::get_default_session_update(session_map);
   local_enforcer->aggregate_records(session_map, table, update);
 }

--- a/lte/gateway/c/session_manager/test/test_session_manager_handler.cpp
+++ b/lte/gateway/c/session_manager/test/test_session_manager_handler.cpp
@@ -427,7 +427,8 @@ TEST_F(SessionManagerHandlerTest, test_report_rule_stats) {
   grpc::ServerContext server_context;
   RuleRecordTable table;
   auto record_list = table.mutable_records();
-  create_rule_record(IMSI1, IP1, "rule1", 512, 512, record_list->Add());
+  create_rule_record(
+      IMSI1, teids0.agw_teid(), "rule1", 512, 512, record_list->Add());
 
   EXPECT_CALL(
       *reporter, report_updates(CheckUpdateRequestNumber(1), testing::_))

--- a/lte/gateway/c/session_manager/test/test_sessiond_integ.cpp
+++ b/lte/gateway/c/session_manager/test/test_sessiond_integ.cpp
@@ -429,9 +429,9 @@ TEST_F(SessiondTest, end_to_end_success) {
   // 3- ReportRuleStats Trigger
   RuleRecordTable table;
   auto record_list = table.mutable_records();
-  create_rule_record(IMSI1, ipv4_addrs, "rule1", 512, 512, record_list->Add());
-  create_rule_record(IMSI1, ipv6_addrs, "rule2", 512, 0, record_list->Add());
-  create_rule_record(IMSI1, ipv4_addrs, "rule3", 32, 32, record_list->Add());
+  create_rule_record(IMSI1, agw_teid, "rule1", 512, 512, record_list->Add());
+  create_rule_record(IMSI1, agw_teid, "rule2", 512, 0, record_list->Add());
+  create_rule_record(IMSI1, agw_teid, "rule3", 32, 32, record_list->Add());
   send_update_pipelined_table(stub, table);
 
   // The thread needs to be halted before proceeding to call EndSession()
@@ -550,8 +550,10 @@ TEST_F(SessiondTest, end_to_end_cloud_down) {
   }
 
   RuleRecordTable table1;
-  create_rule_record(IMSI1, "rule1", 0, 512, table1.mutable_records()->Add());
-  create_rule_record(IMSI1, "rule2", 512, 0, table1.mutable_records()->Add());
+  create_rule_record(
+      IMSI1, agw_teid, "rule1", 0, 512, table1.mutable_records()->Add());
+  create_rule_record(
+      IMSI1, agw_teid, "rule2", 512, 0, table1.mutable_records()->Add());
   send_update_pipelined_table(stub, table1);
 
   // Need to wait for cloud response to come back and usage monitor to reset.
@@ -575,8 +577,10 @@ TEST_F(SessiondTest, end_to_end_cloud_down) {
   }
 
   RuleRecordTable table2;
-  create_rule_record(IMSI1, "rule1", 512, 0, table2.mutable_records()->Add());
-  create_rule_record(IMSI1, "rule2", 0, 512, table2.mutable_records()->Add());
+  create_rule_record(
+      IMSI1, agw_teid, "rule1", 512, 0, table2.mutable_records()->Add());
+  create_rule_record(
+      IMSI1, agw_teid, "rule2", 0, 512, table2.mutable_records()->Add());
   send_update_pipelined_table(stub, table2);
 
   set_timeout(5000, end_promise);


### PR DESCRIPTION
Signed-off-by: Marie Bremner <marwhal@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary
- Migrate the session look with `RuleRecord`s to use Teids instead of IPs
- MUST be merged with https://github.com/magma/magma/pull/5625
   - Will combine with Nick's PR once this is approved to merge as 1 commit. (Wanted to make review easier for now)
<!-- Enumerate changes you made and why you made them -->

## Test Plan
make precommit_sm
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->

<!--
    Final note

    Please take a moment to read through the Magma project's
    - Contributing conventions: https://docs.magmacore.org/docs/next/contributing/contribute_conventions

    If this is your first time opening a PR, also consider reading
    - Developer onboarding: https://docs.magmacore.org/docs/next/contributing/contribute_onboarding
    - Development workflow: https://docs.magmacore.org/docs/next/contributing/contribute_workflow
-->
