### PR TITLE
[fuji] NMS DB data migration uses sequelize-models ^0.1.7

### DIFF
--- a/nms/app/packages/magmalte/scripts/fuji-upgrade/runs-on-nms.sh
+++ b/nms/app/packages/magmalte/scripts/fuji-upgrade/runs-on-nms.sh
@@ -44,11 +44,11 @@ done
 
 cat << EOF
 --------------------------------------------------------------------------------
-              Upgrading @fbcnms/sequelize-models to ^0.1.6
+              Upgrading @fbcnms/sequelize-models to ^0.1.7
 --------------------------------------------------------------------------------
 EOF
 pushd /usr/src/packages/magmalte
-yarn upgrade @fbcnms/sequelize-models@^0.1.6
+yarn upgrade @fbcnms/sequelize-models@^0.1.7
 yarn
 popd
 cat << EOF


### PR DESCRIPTION
Signed-off-by: Andrei Lee <andreilee@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary

For NMS/orc8r DB unification, the `@fbcnms/sequelize-models` package is used. Version 0.1.7 includes a fix for installing the `pg` package

## Test Plan

N/A

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->

<!--
    Final note

    Please take a moment to read through the Magma project's
    - Contributing conventions: https://docs.magmacore.org/docs/next/contributing/contribute_conventions

    If this is your first time opening a PR, also consider reading
    - Developer onboarding: https://docs.magmacore.org/docs/next/contributing/contribute_onboarding
    - Development workflow: https://docs.magmacore.org/docs/next/contributing/contribute_workflow
-->
