### PR TITLE
AGW: vagrant-vm: rename magma-focal to magma

### DIFF
--- a/lte/gateway/Vagrantfile
+++ b/lte/gateway/Vagrantfile
@@ -20,24 +20,24 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   # Mount magma directory in all VMs
   config.vm.synced_folder "../..", "/home/vagrant/magma"
 
-  config.vm.define :magma, primary: true do |magma|
+  config.vm.define :magma_debian, primary: true do |magma_debian|
     # Get our prepackaged box from the atlas cloud, based on
     # - debian/contrib-jessie64
     # - linux kernel from debian jessie backports
     # - updated vbguest-tool
-    magma.vm.box = "magmacore/magma_dev"
-    magma.vm.hostname = "magma-dev"
-    magma.vm.box_version = "1.1.20210326"
+    magma_debian.vm.box = "magmacore/magma_dev"
+    magma_debian.vm.hostname = "magma-dev"
+    magma_debian.vm.box_version = "1.1.20210326"
 
-    magma.vbguest.auto_update = false
+    magma_debian.vbguest.auto_update = false
 
     # Create a private network, which allows host-only access to the machine
     # using a specific IP.
-    magma.vm.network "private_network", ip: "192.168.60.142", nic_type: "82540EM"
+    magma_debian.vm.network "private_network", ip: "192.168.60.142", nic_type: "82540EM"
     # iperf3 trfserver routable IP.
-    magma.vm.network "private_network", ip: "192.168.129.1", nic_type: "82540EM"
+    magma_debian.vm.network "private_network", ip: "192.168.129.1", nic_type: "82540EM"
 
-    magma.vm.provider "virtualbox" do |vb|
+    magma_debian.vm.provider "virtualbox" do |vb|
       vb.name = "magma-dev"
       vb.linked_clone = true
       vb.customize ["modifyvm", :id, "--memory", "6144"]
@@ -65,7 +65,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       domain.graphics_ip = "0.0.0.0"
     end
 
-    magma.vm.provision "ansible" do |ansible|
+    magma_debian.vm.provision "ansible" do |ansible|
       ansible.host_key_checking = false
       ansible.playbook = "deploy/magma_dev.yml"
       ansible.inventory_path = "deploy/hosts"
@@ -75,23 +75,23 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     end
   end
 
-  config.vm.define :magma_focal, primary: false do |magma_focal|
+  config.vm.define :magma, primary: false do |magma|
     # Get our prepackaged box from the atlas cloud, based on
     # - debian/contrib-jessie64
     # - linux kernel from debian jessie backports
     # - updated vbguest-tool
-    magma_focal.vm.box = "ubuntu/focal64"
-    magma_focal.vm.hostname = "magma-dev-focal"
-    magma_focal.vm.box_version = "20210415.0.0"
-    magma_focal.vbguest.auto_update = false
+    magma.vm.box = "ubuntu/focal64"
+    magma.vm.hostname = "magma-dev"
+    magma.vm.box_version = "20210415.0.0"
+    magma.vbguest.auto_update = false
 
     # Create a private network, which allows host-only access to the machine
     # using a specific IP.
-    magma_focal.vm.network "private_network", ip: "192.168.60.142", nic_type: "82540EM"
+    magma.vm.network "private_network", ip: "192.168.60.142", nic_type: "82540EM"
     # iperf3 trfserver routable IP.
-    magma_focal.vm.network "private_network", ip: "192.168.129.1", nic_type: "82540EM"
+    magma.vm.network "private_network", ip: "192.168.129.1", nic_type: "82540EM"
 
-    magma_focal.vm.provider "virtualbox" do |vb|
+    magma.vm.provider "virtualbox" do |vb|
       vb.name = "magma-focal-dev"
       vb.linked_clone = true
       vb.customize ["modifyvm", :id, "--memory", "8192"]
@@ -99,7 +99,28 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       vb.customize ["modifyvm", :id, "--nicpromisc2", "allow-all"]
       vb.customize ["guestproperty", "set", :id, "/VirtualBox/GuestAdd/VBoxService/--timesync-set-threshold", 10000 ]
     end
-    magma_focal.vm.provision "ansible" do |ansible|
+
+    config.vm.provider :libvirt do |domain, override|
+      override.vm.synced_folder "../..", "/home/vagrant/magma", type: 'nfs', linux__nfs_options: ['rw','no_subtree_check','no_root_squash'], mount_options: ['nolock']
+      domain.uri = "qemu+unix:///system"
+      domain.memory = 6144
+      domain.cpus = 4
+      domain.driver = "kvm"
+      domain.host = "localhost"
+      domain.connect_via_ssh = false
+      domain.username = $user
+      domain.storage_pool_name = "default"
+      domain.nic_model_type = "virtio"
+      domain.management_network_name = "magma-mgmt-net"
+      domain.management_network_address = "172.17.2.0/24"
+      domain.nested = true
+      domain.cpu_mode = "host-passthrough"
+      domain.volume_cache = "unsafe"
+      domain.disk_bus = "virtio"
+      domain.graphics_ip = "0.0.0.0"
+    end
+
+    magma.vm.provision "ansible" do |ansible|
       ansible.host_key_checking = false
       ansible.playbook = "deploy/magma_dev_focal.yml"
       ansible.inventory_path = "deploy/hosts"


### PR DESCRIPTION
From 1.6 ubuntu is going to be platform for AGW. This PR
renames the debian based AGW to magma_debian and magma_focal
to magma. This would allow all development to move to ubuntu
based AGW for 1.6 development cycle.

Signed-off-by: Pravin B Shelar <pbshelar@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->

<!--
    Final note

    Please take a moment to read through the Magma project's
    - Contributing conventions: https://docs.magmacore.org/docs/next/contributing/contribute_conventions

    If this is your first time opening a PR, also consider reading
    - Developer onboarding: https://docs.magmacore.org/docs/next/contributing/contribute_onboarding
    - Development workflow: https://docs.magmacore.org/docs/next/contributing/contribute_workflow
-->
