### PR TITLE
[orc8r] Update helm chart versions in vars and variables

### DIFF
--- a/orc8r/cloud/deploy/orc8r_deployer/docker/root/data/vars.yml
+++ b/orc8r/cloud/deploy/orc8r_deployer/docker/root/data/vars.yml
@@ -384,7 +384,7 @@ service:
     Required: false
     ConfigApps:
       - tf
-    Default: 0.2.2
+    Default: 0.2.3
   helm_deployment_name:
     Description: Name for the Helm release.
     Type: string

--- a/orc8r/cloud/deploy/orc8r_deployer/docker/root/scripts/test_helm_charts_sync.py
+++ b/orc8r/cloud/deploy/orc8r_deployer/docker/root/scripts/test_helm_charts_sync.py
@@ -42,6 +42,7 @@ def read_all_chart_versions(constants : dict) -> dict:
     for chart_name, chart_fn in charts_fn_map.items():
         with open(f'{magma_root}/{chart_fn}') as chart_f:
             chart_info = yaml.load(chart_f, Loader=yaml.FullLoader)
+            chart_name = chart_name.replace('-', '_')
             chart_versions[chart_name] = chart_info['version']
     return chart_versions
 

--- a/orc8r/cloud/deploy/terraform/orc8r-helm-aws/variables.tf
+++ b/orc8r/cloud/deploy/terraform/orc8r-helm-aws/variables.tf
@@ -185,13 +185,13 @@ variable "fbinternal_orc8r_chart_version" {
 variable "feg_orc8r_chart_version" {
   description = "Version of the orchestrator feg module Helm chart to install."
   type        = string
-  default     = "0.2.2"
+  default     = "0.2.3"
 }
 
 variable "lte_orc8r_chart_version" {
   description = "Version of the orchestrator lte module Helm chart to install."
   type        = string
-  default     = "0.2.2"
+  default     = "0.2.4"
 }
 
 variable "wifi_orc8r_chart_version" {


### PR DESCRIPTION
Signed-off-by: Karthik Subraveti <ksubraveti@fb.com>

## Summary
Update chart versions across the board.

## Test Plan
Updated the helm chart sync testcase. Was incorrectly parsing the chart names.
Chart names with '-'  have dashes replaced by underscores in corresponding variable
names.

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->

<!--
    Final note

    Please take a moment to read through the Magma project's
    - Contributing conventions: https://docs.magmacore.org/docs/next/contributing/contribute_conventions

    If this is your first time opening a PR, also consider reading
    - Developer onboarding: https://docs.magmacore.org/docs/next/contributing/contribute_onboarding
    - Development workflow: https://docs.magmacore.org/docs/next/contributing/contribute_workflow
-->
