### PR TITLE
[lte][agw] Fixing test_attach detach corrupt stateless mme s1ap test

### DIFF
--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_with_corrupt_stateless_mme.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_with_corrupt_stateless_mme.py
@@ -60,8 +60,8 @@ class TestAttachDetachWithCorruptStatelessMME(unittest.TestCase):
             self._s1ap_wrapper.magmad_util.corrupt_agw_state(
                 services_state_dict[s])
 
-            print("************************* Restarting %s service on" % s)
-            self._s1ap_wrapper.magmad_util.restart_services(s)
+            print("************************* Restarting %s service" % s)
+            self._s1ap_wrapper.magmad_util.restart_services([s])
 
             for j in range(100):
                 print("Waiting for", j, "seconds")


### PR DESCRIPTION
Signed-off-by: Alex Rodriguez <ardzoht@gmail.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->
- Corrupt stateless MME s1ap test was failing due to incorrect parsing of check of service status on s1ap_utils, this PR fixes it, also it fixes the restart_services call on the test

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->
- running s1ap test
```
************************* S1 setup
************************* Re-running End to End attach for  UE id  1
ue id 1 found
PDN_TYPE: 1
IPv4 PDN_ADDRESS:192 168 128 12

*************NbUiNbuHdlUeRadioCapMsg: Send UE cap msg SUCCESS*********
************************* Running UE detach for UE id  1
Deleting Ue Context from Traffic Handler
************************* send SCTP SHUTDOWN
Keys left in Redis (list should be empty)[

nb_enb_connected: 1
]
Entries left in hashtables (should be zero): 0
.
----------------------------------------------------------------------
Ran 1 test in 104.385s

OK
sleep 1
```

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->

<!--
    Final note

    Please take a moment to read through the Magma project's
    - Contributing conventions: https://docs.magmacore.org/docs/next/contributing/contribute_conventions

    If this is your first time opening a PR, also consider reading
    - Developer onboarding: https://docs.magmacore.org/docs/next/contributing/contribute_onboarding
    - Development workflow: https://docs.magmacore.org/docs/next/contributing/contribute_workflow
-->
