### PR TITLE
[lte][agw] Store admitted E-RABs during handover

### DIFF
--- a/lte/gateway/c/oai/include/s1ap_types.h
+++ b/lte/gateway/c/oai/include/s1ap_types.h
@@ -20,6 +20,7 @@
 #include <stdint.h>
 
 #include "3gpp_36.401.h"
+#include "3gpp_36.413.h"
 
 #include "common_types.h"
 #include "hashtable.h"
@@ -87,6 +88,7 @@ typedef struct s1ap_handover_state_s {
       target_enb_ue_s1ap_id : 24;  ///< Unique UE id over eNB (24 bits wide)
   sctp_stream_id_t target_sctp_stream_recv;  ///< eNB -> MME stream
   sctp_stream_id_t target_sctp_stream_send;  ///< MME -> eNB stream
+  e_rab_admitted_list_t e_rab_admitted_list;
 } s1ap_handover_state_t;
 
 /** Main structure representing UE association over s1ap
@@ -116,7 +118,9 @@ typedef struct ue_description_s {
   // UE Context Release procedure guard timer
   struct s1ap_timer_t s1ap_ue_context_rel_timer;
 
-  // Handover status
+  // Handover status. We intentionally do not persist all of this state since
+  // it's time sensitive; if the MME restarts during a HO procedure the RAN
+  // will abort the procedure due to timeouts, rendering this state useless.
   s1ap_handover_state_t s1ap_handover_state;
 } ue_description_t;
 

--- a/lte/gateway/c/oai/lib/3gpp/3gpp_36.413.h
+++ b/lte/gateway/c/oai/lib/3gpp/3gpp_36.413.h
@@ -154,6 +154,19 @@ typedef struct e_rab_to_be_setup_list_ho_req_s {
   e_rab_to_be_setup_item_ho_req_t item[MAX_NO_OF_E_RABS];
 } e_rab_to_be_setup_list_ho_req_t;
 
+// 9.1.5.5 HANDOVER REQUEST ACK
+typedef struct e_rab_admitted_item_s {
+  e_rab_id_t e_rab_id;
+  bstring transport_layer_address;
+  teid_t gtp_teid;
+  // TODO: Include optional UL and DL tunnels for indirect forwarding
+} e_rab_admitted_item_t;
+
+typedef struct e_rab_admitted_list_s {
+  uint16_t no_of_items;
+  e_rab_admitted_item_t item[MAX_NO_OF_E_RABS];
+} e_rab_admitted_list_t;
+
 // E-RAB TO BE MODIFIED ITEM BEARER MOD IND
 typedef struct e_rab_to_be_modified_bearer_mod_ind_s {
   e_rab_id_t e_rab_id;

--- a/lte/gateway/c/oai/tasks/mme_app/mme_app_bearer.c
+++ b/lte/gateway/c/oai/tasks/mme_app/mme_app_bearer.c
@@ -3381,8 +3381,6 @@ void mme_app_handle_handover_request_ack(
       bstrcpy(handover_request_ack_p
                   ->tgt_src_container);  // ownership passed to receiver
 
-  // TODO: set up E-RABs. As is, HO will proceed, but we will drop packets.
-
   OAILOG_INFO_UE(
       LOG_MME_APP, ue_context_p->emm_context._imsi64,
       "MME_APP send HANDOVER_COMMAND to S1AP for ue_id %d \n",


### PR DESCRIPTION
## Summary

Indicate no data forwarding supported during S1 handover, and store resulting E-RABs from the target eNBs in the UE state for updating bearers when procedure is complete.

Signed-off-by: Shaddi Hasan <shasan@fb.com>

## Test Plan

- Local testing (2x Baicells eNB + Pixel 3)
- TeraVM test case 1b (basic handover)