### PR TITLE
AGW: deploy: ubuntu: install net-tools

### DIFF
--- a/lte/gateway/deploy/agw_install_ubuntu.sh
+++ b/lte/gateway/deploy/agw_install_ubuntu.sh
@@ -69,7 +69,7 @@ if [[ $1 != "$CLOUD_INSTALL" ]] && ( [[ ! $INTERFACES == *'eth0'*  ]] || [[ ! $I
   service systemd-resolved restart
 
   # interface config
-  apt install -y ifupdown
+  apt install -y ifupdown net-tools
   echo "auto eth0
   iface eth0 inet dhcp" > /etc/network/interfaces.d/eth0
   # configuring eth1


### PR DESCRIPTION
In some deployment scenarios net-tools package is missing.
install it before setting up the networking.

Signed-off-by: Pravin B Shelar <pbshelar@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->

<!--
    Final note

    Please take a moment to read through the Magma project's
    - Contributing conventions: https://docs.magmacore.org/docs/next/contributing/contribute_conventions

    If this is your first time opening a PR, also consider reading
    - Developer onboarding: https://docs.magmacore.org/docs/next/contributing/contribute_onboarding
    - Development workflow: https://docs.magmacore.org/docs/next/contributing/contribute_workflow
-->
