### PR TITLE
[Python] Fix precommit script to work in debian as well

### DIFF
--- a/lte/gateway/python/precommit.py
+++ b/lte/gateway/python/precommit.py
@@ -16,7 +16,7 @@ import os
 import subprocess  # noqa: S404 ignore security warning about subprocess
 from typing import List
 
-from git import Repo
+from git import Repo  # GitPython
 
 HOST_MAGMA_ROOT = '../../../'
 LINT_DOCKER_PATH = os.path.join(
@@ -79,9 +79,10 @@ def _run_flake8(paths: List[str]):
 
 
 def _run_docker_cmd(commands: List[str]):
-    volume_cmd = os.path.abspath(HOST_MAGMA_ROOT) + ':/code'
+    volume_cmd = ['-v', os.path.abspath(HOST_MAGMA_ROOT) + ':/code']
     docker_image = IMAGE_NAME + ':latest'
-    cmd = ['docker', 'run', '-it', '-v', volume_cmd, docker_image] + commands
+    cmd_prefix = 'docker run -it -u 0'.split(' ')
+    cmd = cmd_prefix + volume_cmd + [docker_image] + commands
     _run(cmd)
 
 


### PR DESCRIPTION
Signed-off-by: Marie Bremner <marwhal@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary
@panyogesh reported that the precommit script failed on debian machines due to permissions issues. (I also confirmed that it did not work on the ubuntu VM as well)
Error:
```
USER@debianmachine:~/SW1_BUILD/magma/lte/gateway/python$ sudo ./precommit.py --format -p lte/gateway/python/magma/pipelined/app/classifier.py
Running 'docker run -it -v /home/wlserver/SW1_BUILD/magma:/code magma/py-lint:latest autopep8 -r -a --in-place lte/gateway/python/magma/pipelined/app/classifier.py'...
[Errno 13] Permission denied: 'lte/gateway/python/magma/pipelined/app/classifier.py'
```


<!-- Enumerate changes you made and why you made them -->

## Test Plan
Tested on the ubuntu VM and confirmed with @panyogesh that the fix works.
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->

<!--
    Final note

    Please take a moment to read through the Magma project's
    - Contributing conventions: https://docs.magmacore.org/docs/next/contributing/contribute_conventions

    If this is your first time opening a PR, also consider reading
    - Developer onboarding: https://docs.magmacore.org/docs/next/contributing/contribute_onboarding
    - Development workflow: https://docs.magmacore.org/docs/next/contributing/contribute_workflow
-->
