### PR TITLE
[SessionD][MME] Add service name to Sentry logs

### DIFF
--- a/lte/gateway/c/oai/common/sentry_wrapper.cpp
+++ b/lte/gateway/c/oai/common/sentry_wrapper.cpp
@@ -14,32 +14,54 @@
 #include "sentry_wrapper.h"
 #if SENTRY_ENABLED
 #include <cstdlib>
+#include <experimental/optional>
 #include "sentry.h"
 #include "ServiceConfigLoader.h"
 #include <yaml-cpp/yaml.h>  // IWYU pragma: keep
 
 #define COMMIT_HASH_ENV "COMMIT_HASH"
 #define CONTROL_PROXY_SERVICE_NAME "control_proxy"
-#define SENTRY_URL "sentry_url"
+#define SENTRY_NATIVE_URL "sentry_url_native"
+#define SHOULD_UPLOAD_MME_LOG "sentry_upload_mme_log"
+#define MME_LOG_PATH "/var/log/mme.log"
+using std::experimental::optional;
 
-void initialize_sentry(void) {
+bool should_upload_mme_log(YAML::Node control_proxy_config) {
+  if (control_proxy_config[SHOULD_UPLOAD_MME_LOG].IsDefined()) {
+    return control_proxy_config[SHOULD_UPLOAD_MME_LOG].as<bool>();
+  }
+  return false;
+}
+
+optional<std::string> get_sentry_url(YAML::Node control_proxy_config) {
+  std::string sentry_url;
+  if (control_proxy_config[SENTRY_NATIVE_URL].IsDefined()) {
+    const std::string sentry_dns =
+        control_proxy_config[SENTRY_NATIVE_URL].as<std::string>();
+    if (sentry_dns.size()) {
+      return sentry_dns;
+    }
+  }
+  return {};
+}
+
+void initialize_sentry() {
   auto control_proxy_config = magma::ServiceConfigLoader{}.load_service_config(
       CONTROL_PROXY_SERVICE_NAME);
-  if (control_proxy_config[SENTRY_URL].IsDefined()) {
-    const std::string sentry_dns =
-        control_proxy_config[SENTRY_URL].as<std::string>();
-    if (!sentry_dns.size()) {
-      return;
-    }
+  auto op_sentry_url = get_sentry_url(control_proxy_config);
+  if (op_sentry_url) {
     sentry_options_t* options = sentry_options_new();
-
-    sentry_options_set_dsn(options, sentry_dns.c_str());
+    sentry_options_set_dsn(options, op_sentry_url->c_str());
     if (const char* commit_hash_p = std::getenv(COMMIT_HASH_ENV)) {
       sentry_options_set_release(options, commit_hash_p);
+    }
+    if (should_upload_mme_log(control_proxy_config)) {
+      sentry_options_add_attachment(options, MME_LOG_PATH);
     }
 
     sentry_init(options);
 
+    sentry_set_tag("service_name", "MME");
     // Send an initial message to indicate service start
     sentry_capture_event(sentry_value_new_message_event(
         SENTRY_LEVEL_INFO, "", "Starting MME with Sentry!"));

--- a/lte/gateway/c/session_manager/sessiond_main.cpp
+++ b/lte/gateway/c/session_manager/sessiond_main.cpp
@@ -50,26 +50,37 @@ extern "C" void __gcov_flush(void);
 
 #define COMMIT_HASH_ENV "COMMIT_HASH"
 #define CONTROL_PROXY_SERVICE_NAME "control_proxy"
-#define SENTRY_URL "sentry_url"
+#define SENTRY_NATIVE_URL "sentry_url_native"
+using std::experimental::optional;
+// TODO pull sentry related logic into a common library so it can be shared with
+// MME
+optional<std::string> get_sentry_url(YAML::Node control_proxy_config) {
+  std::string sentry_url;
+  if (control_proxy_config[SENTRY_NATIVE_URL].IsDefined()) {
+    const std::string sentry_dns =
+        control_proxy_config[SENTRY_NATIVE_URL].as<std::string>();
+    if (sentry_dns.size()) {
+      return sentry_dns;
+    }
+  }
+  return {};
+}
 
 void initialize_sentry() {
   auto control_proxy_config = magma::ServiceConfigLoader{}.load_service_config(
       CONTROL_PROXY_SERVICE_NAME);
-  if (control_proxy_config[SENTRY_URL].IsDefined()) {
-    const std::string sentry_dns =
-        control_proxy_config[SENTRY_URL].as<std::string>();
-    if (!sentry_dns.size()) {
-      return;
-    }
+  auto op_sentry_url = get_sentry_url(control_proxy_config);
+  if (op_sentry_url) {
     MLOG(MINFO) << "Starting SessionD with Sentry!";
     sentry_options_t* options = sentry_options_new();
-    sentry_options_set_dsn(options, sentry_dns.c_str());
-
+    sentry_options_set_dsn(options, op_sentry_url->c_str());
     if (const char* commit_hash_p = std::getenv(COMMIT_HASH_ENV)) {
       sentry_options_set_release(options, commit_hash_p);
     }
 
     sentry_init(options);
+    sentry_set_tag("service_name", "SessionD");
+
     sentry_capture_event(sentry_value_new_message_event(
         SENTRY_LEVEL_INFO, "", "Starting SessionD with Sentry!"));
   }

--- a/lte/gateway/configs/control_proxy.yml
+++ b/lte/gateway/configs/control_proxy.yml
@@ -40,6 +40,11 @@ proxy_cloud_connections: True
 # Allows http_proxy usage if the environment variable is present
 allow_http_proxy: False
 
-# [Experimental] URL to enable Sentry logging
-# sentry_url: ""
-# entry_sample_rate: 1.0
+# [Experimental] Sentry related configs
+# If set, the Sentry Python SDK will be initialized for all python services
+sentry_url_python: ""
+# If set, the Sentry Native SDK will be initialized for MME and SessionD
+sentry_url_native: ""
+# If set, /var/log/mme.log will be uploaded along MME crashreports
+sentry_upload_mme_log: false
+sentry_sample_rate: 1.0


### PR DESCRIPTION

Signed-off-by: Marie Bremner <marwhal@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary
* Add service names to native Sentry events so that it is easier to filter by name
* Add configurable logic to upload /var/log/mme.log 
<!-- Enumerate changes you made and why you made them -->

## Test Plan
Tested locally
<img width="1044" alt="Screen Shot 2021-04-21 at 2 41 38 PM" src="https://user-images.githubusercontent.com/37634144/115611431-b257b100-a2af-11eb-8110-15663c52ee3f.png">
No events are searchable by service name
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->

<!--
    Final note

    Please take a moment to read through the Magma project's
    - Contributing conventions: https://docs.magmacore.org/docs/next/contributing/contribute_conventions

    If this is your first time opening a PR, also consider reading
    - Developer onboarding: https://docs.magmacore.org/docs/next/contributing/contribute_onboarding
    - Development workflow: https://docs.magmacore.org/docs/next/contributing/contribute_workflow
-->
