### PR TITLE
[lte][agw] Add HandoverNotify support

### DIFF
--- a/lte/gateway/c/oai/include/s1ap_messages_def.h
+++ b/lte/gateway/c/oai/include/s1ap_messages_def.h
@@ -102,3 +102,5 @@ MESSAGE_DEF(
 MESSAGE_DEF(
     S1AP_HANDOVER_REQUEST_ACK, itti_s1ap_handover_request_ack_t,
     s1ap_handover_request_ack)
+MESSAGE_DEF(
+    S1AP_HANDOVER_NOTIFY, itti_s1ap_handover_notify_t, s1ap_handover_notify)

--- a/lte/gateway/c/oai/include/s1ap_messages_types.h
+++ b/lte/gateway/c/oai/include/s1ap_messages_types.h
@@ -89,6 +89,7 @@
 #define S1AP_HANDOVER_REQUIRED(mSGpTR) (mSGpTR)->ittiMsg.s1ap_handover_required
 #define S1AP_HANDOVER_REQUEST_ACK(mSGpTR)                                      \
   (mSGpTR)->ittiMsg.s1ap_handover_request_ack
+#define S1AP_HANDOVER_NOTIFY(mSGpTR) (mSGpTR)->ittiMsg.s1ap_handover_notify
 
 // NOT a ITTI message
 typedef struct s1ap_initial_ue_message_s {
@@ -401,4 +402,13 @@ typedef struct itti_s1ap_handover_request_ack_s {
   S1ap_HandoverType_t handover_type;
   bstring tgt_src_container;
 } itti_s1ap_handover_request_ack_t;
+
+typedef struct itti_s1ap_handover_notify_s {
+  mme_ue_s1ap_id_t mme_ue_s1ap_id;
+  uint32_t target_enb_id;
+  uint32_t target_sctp_assoc_id;
+  ecgi_t ecgi;
+  enb_ue_s1ap_id_t target_enb_ue_s1ap_id;
+  e_rab_admitted_list_t e_rab_admitted_list;
+} itti_s1ap_handover_notify_t;
 #endif /* FILE_S1AP_MESSAGES_TYPES_SEEN */

--- a/lte/gateway/c/oai/tasks/mme_app/mme_app_defs.h
+++ b/lte/gateway/c/oai/tasks/mme_app/mme_app_defs.h
@@ -290,6 +290,10 @@ void mme_app_handle_handover_request_ack(
     mme_app_desc_t* mme_app_desc_p,
     itti_s1ap_handover_request_ack_t* const handover_request_ack_p);
 
+void mme_app_handle_handover_notify(
+    mme_app_desc_t* mme_app_desc_p,
+    itti_s1ap_handover_notify_t* const handover_notify_p);
+
 void mme_app_handle_path_switch_request(
     mme_app_desc_t* mme_app_desc_p,
     itti_s1ap_path_switch_request_t* const path_switch_req_p);

--- a/lte/gateway/c/oai/tasks/mme_app/mme_app_main.c
+++ b/lte/gateway/c/oai/tasks/mme_app/mme_app_main.c
@@ -391,6 +391,11 @@ static int handle_message(zloop_t* loop, zsock_t* reader, void* arg) {
           mme_app_desc_p, &S1AP_HANDOVER_REQUEST_ACK(received_message_p));
     } break;
 
+    case S1AP_HANDOVER_NOTIFY: {
+      mme_app_handle_handover_notify(
+          mme_app_desc_p, &S1AP_HANDOVER_NOTIFY(received_message_p));
+    } break;
+
     case S6A_AUTH_INFO_ANS: {
       /*
        * We received the authentication vectors from HSS,

--- a/lte/gateway/c/oai/tasks/s1ap/s1ap_mme_handlers.h
+++ b/lte/gateway/c/oai/tasks/s1ap/s1ap_mme_handlers.h
@@ -76,6 +76,10 @@ int s1ap_mme_handle_enb_status_transfer(
     s1ap_state_t* state, const sctp_assoc_id_t assoc_id,
     const sctp_stream_id_t stream, S1ap_S1AP_PDU_t* pdu);
 
+int s1ap_mme_handle_handover_notify(
+    s1ap_state_t* state, const sctp_assoc_id_t assoc_id,
+    const sctp_stream_id_t stream, S1ap_S1AP_PDU_t* message_p);
+
 int s1ap_mme_handle_path_switch_request(
     s1ap_state_t* state, const sctp_assoc_id_t assoc_id,
     const sctp_stream_id_t stream, S1ap_S1AP_PDU_t* message_p);

--- a/lte/gateway/c/oai/tasks/s1ap/s1ap_mme_itti_messaging.c
+++ b/lte/gateway/c/oai/tasks/s1ap/s1ap_mme_itti_messaging.c
@@ -373,3 +373,29 @@ int s1ap_mme_itti_s1ap_handover_request_ack(
   send_msg_to_task(&s1ap_task_zmq_ctx, TASK_MME_APP, message_p);
   OAILOG_FUNC_RETURN(LOG_S1AP, RETURNok);
 }
+
+int s1ap_mme_itti_s1ap_handover_notify(
+    const mme_ue_s1ap_id_t mme_ue_s1ap_id,
+    const s1ap_handover_state_t handover_state,
+    const enb_ue_s1ap_id_t target_enb_ue_s1ap_id,
+    const sctp_assoc_id_t target_sctp_assoc_id, const ecgi_t const ecgi,
+    imsi64_t imsi64) {
+  MessageDef* message_p = NULL;
+  message_p = itti_alloc_new_message(TASK_S1AP, S1AP_HANDOVER_NOTIFY);
+  if (message_p == NULL) {
+    OAILOG_ERROR_UE(LOG_S1AP, imsi64, "itti_alloc_new_message Failed");
+    OAILOG_FUNC_RETURN(LOG_S1AP, RETURNerror);
+  }
+
+  S1AP_HANDOVER_NOTIFY(message_p).mme_ue_s1ap_id = mme_ue_s1ap_id;
+  S1AP_HANDOVER_NOTIFY(message_p).target_enb_id  = handover_state.target_enb_id;
+  S1AP_HANDOVER_NOTIFY(message_p).target_sctp_assoc_id  = target_sctp_assoc_id;
+  S1AP_HANDOVER_NOTIFY(message_p).ecgi                  = ecgi;
+  S1AP_HANDOVER_NOTIFY(message_p).target_enb_ue_s1ap_id = target_enb_ue_s1ap_id;
+  S1AP_HANDOVER_NOTIFY(message_p).e_rab_admitted_list =
+      handover_state.e_rab_admitted_list;
+
+  message_p->ittiMsgHeader.imsi = imsi64;
+  send_msg_to_task(&s1ap_task_zmq_ctx, TASK_MME_APP, message_p);
+  OAILOG_FUNC_RETURN(LOG_S1AP, RETURNok);
+}

--- a/lte/gateway/c/oai/tasks/s1ap/s1ap_mme_itti_messaging.h
+++ b/lte/gateway/c/oai/tasks/s1ap/s1ap_mme_itti_messaging.h
@@ -94,4 +94,11 @@ int s1ap_mme_itti_s1ap_handover_request_ack(
     const sctp_assoc_id_t source_assoc_id,
     const bstring const tgt_src_container, const uint32_t source_enb_id,
     const uint32_t target_enb_id, imsi64_t imsi64);
+
+int s1ap_mme_itti_s1ap_handover_notify(
+    const mme_ue_s1ap_id_t mme_ue_s1ap_id,
+    const s1ap_handover_state_t handover_state,
+    const enb_ue_s1ap_id_t target_ue_s1ap_id,
+    const sctp_assoc_id_t target_sctp_assoc_id, const ecgi_t const ecgi,
+    imsi64_t imsi64);
 #endif /* FILE_S1AP_MME_ITTI_MESSAGING_SEEN */


### PR DESCRIPTION
## Summary

Adds support for HandoverNotify procedure. When we receive a HO Notify, handover has completed successfully on the target UE, so we modify bearers and clean up any state associated with the old UE<>eNBassociation.

Signed-off-by: Shaddi Hasan <shasan@fb.com>

## Test Plan

- TeraVM