### PR TITLE
[agw][fab] Default to Git instead of Mercurial

### DIFF
--- a/lte/gateway/fabfile.py
+++ b/lte/gateway/fabfile.py
@@ -70,7 +70,7 @@ def test():
     env.debug_mode = False
 
 
-def package(vcs='hg', all_deps="False",
+def package(vcs='git', all_deps="False",
             cert_file=DEFAULT_CERT, proxy_config=DEFAULT_PROXY,
             destroy_vm='False',
             vm='magma', os="debian"):


### PR DESCRIPTION
## Summary

https://github.com/magma/magma/pull/5660 is dead PR, reopening here.

## Test Plan

See https://github.com/magma/magma/pull/5660

## Additional Information

- [ ] This change is backwards-breaking