### PR TITLE
[feg][CI] Check FEG crash looping

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -714,9 +714,27 @@ jobs:
       - build/determinator:
           <<: *federated_build_verify
       - run:
+          name: generate test certs and snowflake
+          command: |
+            # TODO add rootCA.pem and snowflake files in the ubuntu-1604:201903-01 image
+            # create directories
+            cd ${MAGMA_ROOT} && mkdir -p .cache/test_certs/ && mkdir -p .cache/feg/
+            # create test certs
+            cd ${MAGMA_ROOT}/.cache/test_certs/
+            openssl genrsa -out rootCA.key 2048
+            openssl req -x509 -new -nodes -key rootCA.key -sha256 -days 365000 -out rootCA.pem -subj "/C=US/CN=rootca.magma.test"
+            # create snowflake
+            cd ${MAGMA_ROOT}/.cache/feg/ && touch snowflake
+      - run:
+          name: build docker
           command: |
             cd ${MAGMA_ROOT}/feg/gateway/docker
             DOCKER_REGISTRY=feg_ docker-compose build --parallel
+      - run:
+          name: run docker containers and check health
+          command: |
+            cd ${MAGMA_ROOT}/feg/gateway
+            DOCKER_REGISTRY=feg_ make -C ${MAGMA_ROOT}/feg/gateway docker_healthcheck
       - tag-push-docker:
           project: feg
           images: "gateway_go|gateway_python"

--- a/feg/gateway/Makefile
+++ b/feg/gateway/Makefile
@@ -6,11 +6,11 @@ endif
 export MAGMA_ROOT
 
 COVER_DIR:=$(MAGMA_ROOT)/feg/gateway/coverage
-COVER_FILE:=$(COVER_DIR)/feg.gocov
 export COVER_DIR
+COVER_FILE:=$(COVER_DIR)/feg.gocov
+DOCKER_DIR := ${MAGMA_ROOT}/feg/gateway/docker
 
-
-all: fmt test vet install
+all: fmt lint test vet install
 
 build: install
 
@@ -47,7 +47,7 @@ clean:
 	go clean ./...
 
 fmt:
-	gofmt -l -s -w . 
+	gofmt -l -s -w .
 
 gen:
 	go generate ./...
@@ -59,8 +59,11 @@ lint: lint_tools
 	golangci-lint run
 
 lint_tools:
-	if which golangci-lint 2>/dev/null; then echo "-> golangci-lint already installed"; \
-	else curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh \
+	@if which golangci-lint 2>/dev/null; then \
+		echo "-> golangci-lint already installed"; \
+	else \
+		echo "-> installing golangci " && \
+			curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh \
 			| sudo sh -s -- -b /usr/sbin/ v1.35.2; \
 	fi
 
@@ -70,7 +73,7 @@ build_only:
 run_local_hss:
 	sudo service magma@hss start
 
-precommit: tools fmt test vet
+precommit: tools fmt lint test vet
 
 cover: tools
 	mkdir -p $(COVER_DIR)
@@ -79,11 +82,24 @@ cover: tools
 	awk '!/\.pb\.go|_swaggergen\.go|\/mocks\/|\/tools\/|\/blobstore\/ent\//' $(COVER_FILE) > $(COVER_FILE).tmp && \
 		mv $(COVER_FILE).tmp $(COVER_FILE)
 
+docker_build:
+	cd ${DOCKER_DIR}; docker-compose build --parallel
+
+docker_start:
+	cd ${DOCKER_DIR}; docker-compose up -d
+
+docker_stop:
+	cd  ${DOCKER_DIR}; docker-compose down
+
+docker_healthcheck: docker_start
+	cd ${DOCKER_DIR}/tools/; ./docker_ps_healthcheck.sh ${DOCKER_DIR}
+
 # Tool dependencies
 TOOL_DEPS:= \
 	github.com/ory/go-acc \
 	github.com/wadey/gocovmerge \
 	gotest.tools/gotestsum
+
 tools:: $(TOOL_DEPS)
 $(TOOL_DEPS): %:
 	go install $*

--- a/feg/gateway/docker/tools/docker_ps_healthcheck.sh
+++ b/feg/gateway/docker/tools/docker_ps_healthcheck.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+# add the path to the command if docker-compose.yml is not in the same folder
+cd "$1" || exit 1
+
+# check if docker services are really running or not
+sleep 3
+if ! (docker-compose ps | grep "...   Up"); then
+  echo "--- ERROR: Docker services are not running ---"
+  exit 2
+fi
+
+echo "--- Waiting 10 seconds... --- "
+sleep 10
+printf "\n--- Checking docker services --- \n"
+
+for _ in {1..10}
+do
+  if (docker-compose ps | grep -q Restarting); then
+    printf "\n--- ERROR: Docker services are restarting ---\n"
+    docker-compose ps
+    exit 3
+  else
+    printf "."
+  fi
+done
+
+printf "\n--- Docker services are running ---\n"


### PR DESCRIPTION
Signed-off-by: Oriol Batalla <obatalla@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary

This PR adds some endpoints to Makefile to deal with start, stop and health check of the processes

Note if you are running this on MAC you will have to comment the `LOG_DRIVER=journald` form the .env file at `~/magma/feg/gateway/docker`

Health Check will run docker-compose up -d and check for few seconds if any of the containers restarts

This PR also adds this check on CI in every PR on as part of the `feg-build` task

## Test Plan
`ci/circleci: feg-build`  will pass once this https://github.com/magma/magma/issues/6282 is fixed
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

Output of running the command manually
```
╰─ make docker_health_check
cd /Users/obatalla/magma/feg/gateway/docker; docker-compose up -d
WARNING: The LOG_DRIVER variable is not set. Defaulting to a blank string.
WARNING: The USE_GY_FOR_AUTH_ONLY variable is not set. Defaulting to a blank string.
WARNING: The GY_SUPPORTED_VENDOR_IDS variable is not set. Defaulting to a blank string.
WARNING: The GY_SERVICE_CONTEXT_ID variable is not set. Defaulting to a blank string.
aaa_server is up-to-date
eventd is up-to-date
s8_proxy is up-to-date
td-agent-bit is up-to-date
feg_hello is up-to-date
eap_aka is up-to-date
hss is up-to-date
Recreating redis ...
eap_sim is up-to-date
s6a_proxy is up-to-date
session_proxy is up-to-date
test is up-to-date
health is up-to-date
csfb is up-to-date
swx_proxy is up-to-date
radiusd is up-to-date
control_proxy is up-to-date
Recreating redis ... done
cd /Users/obatalla/magma/feg/gateway/docker/tools/; ./health_check_docker_ps.sh /Users/obatalla/magma/feg/gateway/docker
aaa_server      envdir /var/opt/magma/envd ...   Up
control_proxy   /bin/bash -c /usr/local/bi ...   Up
csfb            envdir /var/opt/magma/envd ...   Up
eap_aka         envdir /var/opt/magma/envd ...   Up
eap_sim         envdir /var/opt/magma/envd ...   Up
eventd          python3.8 -m magma.eventd.main   Up
feg_hello       envdir /var/opt/magma/envd ...   Up
health          envdir /var/opt/magma/envd ...   Up
hss             envdir /var/opt/magma/envd ...   Up
radiusd         envdir /var/opt/magma/envd ...   Up
redis           /bin/bash -c /usr/local/bi ...   Up
s6a_proxy       envdir /var/opt/magma/envd ...   Up
s8_proxy        envdir /var/opt/magma/envd ...   Up
session_proxy   envdir /var/opt/magma/envd ...   Up
swx_proxy       envdir /var/opt/magma/envd ...   Up
td-agent-bit    /bin/bash -c /usr/local/bi ...   Up
test            /bin/bash -c mkdir -p ../. ...   Up

--- Checking docker services ---

--- ERROR: Docker services are restarting ---

    Name                   Command                 State      Ports
-------------------------------------------------------------------
aaa_server      envdir /var/opt/magma/envd ...   Up
control_proxy   /bin/bash -c /usr/local/bi ...   Up
csfb            envdir /var/opt/magma/envd ...   Up
eap_aka         envdir /var/opt/magma/envd ...   Up
eap_sim         envdir /var/opt/magma/envd ...   Up
eventd          python3.8 -m magma.eventd.main   Up
feg_hello       envdir /var/opt/magma/envd ...   Up
health          envdir /var/opt/magma/envd ...   Up
hss             envdir /var/opt/magma/envd ...   Up
magmad          python3.8 -m magma.magmad.main   Restarting
radiusd         envdir /var/opt/magma/envd ...   Up
redis           /bin/bash -c /usr/local/bi ...   Up
s6a_proxy       envdir /var/opt/magma/envd ...   Up
s8_proxy        envdir /var/opt/magma/envd ...   Up
session_proxy   envdir /var/opt/magma/envd ...   Up
swx_proxy       envdir /var/opt/magma/envd ...   Up
td-agent-bit    /bin/bash -c /usr/local/bi ...   Up
test            /bin/bash -c mkdir -p ../. ...   Up
make: *** [docker_health_check] Error 1

```
## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->

<!--
    Final note

    Please take a moment to read through the Magma project's
    - Contributing conventions: https://docs.magmacore.org/docs/next/contributing/contribute_conventions

    If this is your first time opening a PR, also consider reading
    - Developer onboarding: https://docs.magmacore.org/docs/next/contributing/contribute_onboarding
    - Development workflow: https://docs.magmacore.org/docs/next/contributing/contribute_workflow
-->
