### PR TITLE
[orc8r] Fix get-all for prometheus alerts in REST API

### DIFF
--- a/orc8r/cloud/go/services/metricsd/prometheus/handlers/alert_config_handler.go
+++ b/orc8r/cloud/go/services/metricsd/prometheus/handlers/alert_config_handler.go
@@ -174,10 +174,9 @@ func sendConfig(payload interface{}, url string, method string, client HttpClien
 
 func retrieveAlertRule(c echo.Context, url string, client HttpClient) error {
 	alertName := c.QueryParam(AlertNameQueryParam)
-	if alertName == "" {
-		return obsidian.HttpError(fmt.Errorf("alert_name required"), http.StatusBadRequest)
+	if alertName != "" {
+		url += fmt.Sprintf("/%s", neturl.PathEscape(alertName))
 	}
-	url += fmt.Sprintf("/%s", neturl.PathEscape(alertName))
 
 	resp, err := client.Get(url)
 	if err != nil {

--- a/orc8r/cloud/go/services/metricsd/prometheus/handlers/alert_config_handler_test.go
+++ b/orc8r/cloud/go/services/metricsd/prometheus/handlers/alert_config_handler_test.go
@@ -111,11 +111,6 @@ func TestGetRetrieveAlertRuleHandler(t *testing.T) {
 			ExpectedError: "code=400, message=Missing Network ID",
 		},
 		{
-			Name:          "no alert name",
-			RequestURL:    "http://url.com",
-			ExpectedError: "code=400, message=alert_name required",
-		},
-		{
 			Name:                 "server non-200 response",
 			ClientExpectedReturn: []interface{}{empty500Response, nil},
 			ExpectedError:        "code=500, message=error reading rules: <nil>",


### PR DESCRIPTION
Signed-off-by: Andrei Lee <andreilee@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary

Behavior was changed in #5105

This is a fix for the alerts REST API in orchestrator. Get-all behavior was broken accidentally in #5105 and was preventing NMS alerts page from working correctly. This fix changes the API behavior and allows for an empty `alert_name` to specify a get-all again.

## Test Plan

Verified through swagger API:

<img width="1437" alt="Screen Shot 2021-04-22 at 10 40 18 AM" src="https://user-images.githubusercontent.com/804385/115761459-344ee500-a357-11eb-909e-2a42a096021b.png">

Also verified that `Sync Predefined Rules` for alerts on the NMS works. Results after syncing on a new network:

<img width="1104" alt="Screen Shot 2021-04-22 at 10 38 44 AM" src="https://user-images.githubusercontent.com/804385/115761518-43ce2e00-a357-11eb-841e-3ee92fb85ea8.png">


<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->

<!--
    Final note

    Please take a moment to read through the Magma project's
    - Contributing conventions: https://docs.magmacore.org/docs/next/contributing/contribute_conventions

    If this is your first time opening a PR, also consider reading
    - Developer onboarding: https://docs.magmacore.org/docs/next/contributing/contribute_onboarding
    - Development workflow: https://docs.magmacore.org/docs/next/contributing/contribute_workflow
-->
