### PR TITLE
[DO NOT MERGE][AGW][MME][RHEL8] Fix event size

### DIFF
--- a/ci-scripts/docker/Dockerfile.mme.ci.rhel8
+++ b/ci-scripts/docker/Dockerfile.mme.ci.rhel8
@@ -36,7 +36,7 @@ RUN yum update -y && \
       libubsan \
       libasan \
       psmisc \
-      psmisc \
+      tcpdump \
       openssl \
       net-tools \
       tzdata && \

--- a/lte/gateway/c/sctpd/util.cpp
+++ b/lte/gateway/c/sctpd/util.cpp
@@ -102,8 +102,12 @@ int set_sctp_opts(
   event.sctp_association_event = on;
   event.sctp_shutdown_event    = on;
   event.sctp_data_io_event     = on;
+  int event_size               = sizeof(event);
+  if (event_size > 10) {
+    event_size = 10;
+  }
 
-  if (setsockopt(sd, IPPROTO_SCTP, SCTP_EVENTS, &event, sizeof(event)) < 0) {
+  if (setsockopt(sd, IPPROTO_SCTP, SCTP_EVENTS, &event, event_size) < 0) {
     MLOG_perror("setsockopt");
     return -1;
   }

--- a/lte/gateway/docker/mme/Dockerfile.rhel8
+++ b/lte/gateway/docker/mme/Dockerfile.rhel8
@@ -456,7 +456,7 @@ RUN yum update -y && \
       libubsan \
       libasan \
       psmisc \
-      psmisc \
+      tcpdump \
       openssl \
       net-tools \
       tzdata && \


### PR DESCRIPTION
Signed-off-by: Raphael Defosseux <raphael.defosseux@openairinterface.org>

## Summary

This is a problem we at OAI have been aware for quite a long time. Just making it upstream.

Let make an example:

```c
#include <iostream>
#include <netinet/sctp.h>

int main() {
  struct sctp_event_subscribe event;
  std::cout << "sizeof(event) = "  << sizeof(event) << std::endl;
  return 0;
}
```

Inside my Ubuntu18 container:

```bash
# ./event-size.exe 
sizeof(event) = 10
# dpkg --list | grep sctp
ii  libsctp-dev:amd64                      1.0.17+dfsg-2                       amd64        user-space access to Linux kernel SCTP - development files
ii  libsctp1:amd64                         1.0.17+dfsg-2                       amd64        user-space access to Linux kernel SCTP - shared library
```

Inside my RHEL8 container:

```bash
# ./event-size.exe 
sizeof(event) = 14
# yum list installed | grep sctp
lksctp-tools.x86_64                           1.0.18-3.el8                             @rhel-8-for-x86_64-baseos-rpms           
lksctp-tools-devel.x86_64                     1.0.18-3.el8                             @rhel-8-for-x86_64-baseos-rpms           
```

Here comes the reason for the value `10`.

## Test Plan

I was able to test w/ and w/o the patch locally. 

- Without patch --> no HSS connection, no eNB connection
- With patch, everything is OK.

This patch is required for me to move forward on CI tasks (as I mentioned yesterday in the `devops` meeting.

## Additional Information

- [ ] This change is backwards-breaking

