### PR TITLE
[CI]Only run release job on release branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1321,6 +1321,7 @@ workflows:
   release:
     jobs:
       - release-hold:
+          <<: *only_release
           type: approval
       - lte-agw-deploy:
           <<: *only_release


### PR DESCRIPTION
Signed-off-by: Timothée Dzik <timdzik@fb.com>

[CI]Only run release job on release branch

## Summary

[CI]Only run release job on release branch

## Test Plan

let it go and make sure it's not popping on master runs within CI 