### PR TITLE
[FeG] Fix FeG magmad crashloop

### DIFF
--- a/orc8r/gateway/python/setup.py
+++ b/orc8r/gateway/python/setup.py
@@ -28,6 +28,7 @@ def os_release():
                 pass
     return release_info
 
+
 # We can use an environment variable to pass in the package version during
 # build. Since we don't distribute this on its own, we don't really care what
 # version this represents. 'None' defaults to 0.0.0.
@@ -108,10 +109,11 @@ if release_info.get('VERSION_CODENAME', '') == 'focal':
             "strict-rfc3339>=0.7",
             "rfc3987>=1.3.0",
             "webcolors>=1.11.1",
+            'systemd-python>=234',
         ],
         extras_require={
             'dev': [
-                "fakeredis[lua]"
+                "fakeredis[lua]",
             ],
         },
     )
@@ -196,7 +198,7 @@ setup(
     ],
     extras_require={
         'dev': [
-            "fakeredis[lua]"
+            "fakeredis[lua]",
         ],
     },
 )


### PR DESCRIPTION
Signed-off-by: Marie Bremner <marwhal@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary

https://github.com/magma/magma/pull/6092 broke feg magmad. It was complaining that it didn't have the systemd dependency. 

feg magmad runs on a focal image, so adding the systemd dependency to the focal section in setup.py

### ISSUE
Magmad crashlooping in FEG

To reproduce this, 

```
cd ~/magma/feg/gateway/docker
docker-compose build 

# if you are in mac comment #LOG_DRIVER=journald in .env
vim .env 

docker-compose up -d
docker-compose logs -f magmad 
```
<!-- Enumerate changes you made and why you made them -->

## Test Plan
rebuild magmad + down + up
```
➜  magma git:(fix-feg-magmad) ✗ docker ps
CONTAINER ID   IMAGE                       COMMAND                  CREATED              STATUS              PORTS                                              NAMES
e6d3fb8791cd   feg_gateway_python:latest   "python3.8 -m magma.…"   About a minute ago   Up About a minute                                                      magmad
b1157b6469c6   feg_gateway_python:latest   "/bin/bash -c '/usr/…"   About a minute ago   Up About a minute                                                      control_proxy
985142fbbefa   feg_gateway_go:latest       "envdir /var/opt/mag…"   About a minute ago   Up About a minute                                                      csfb
e74e58a02ef4   feg_gateway_python:latest   "/bin/bash -c '/usr/…"   About a minute ago   Up About a minute                                                      redis
223b3c6c9dcf   feg_gateway_go:latest       "envdir /var/opt/mag…"   About a minute ago   Up About a minute                                                      s6a_proxy
d9ddb5af1d62   feg_gateway_go:latest       "envdir /var/opt/mag…"   About a minute ago   Up About a minute                                                      health
d897a3e20266   feg_gateway_go:latest       "envdir /var/opt/mag…"   About a minute ago   Up About a minute                                                      eap_sim
337b3f445ff0   feg_gateway_go:latest       "envdir /var/opt/mag…"   About a minute ago   Up About a minute                                                      aaa_server
6fe6e44a8d24   feg_gateway_python:latest   "/bin/bash -c '/usr/…"   About a minute ago   Up About a minute                                                      td-agent-bit
782c06bc163b   feg_gateway_python:latest   "python3.8 -m magma.…"   About a minute ago   Up About a minute                                                      eventd
d89247fca344   feg_gateway_go:latest       "envdir /var/opt/mag…"   About a minute ago   Up About a minute                                                      radiusd
e785c5a765b5   feg_gateway_go:latest       "envdir /var/opt/mag…"   About a minute ago   Up About a minute                                                      session_proxy
72301269932a   feg_gateway_go:latest       "envdir /var/opt/mag…"   About a minute ago   Up About a minute                                                      swx_proxy
10177cbb8b9d   feg_gateway_go:latest       "envdir /var/opt/mag…"   About a minute ago   Up About a minute                                                      eap_aka
cd2a46256ae2   feg_gateway_go_base         "/bin/bash -c 'mkdir…"   About a minute ago   Up About a minute                                                      test
33a46ef9b497   feg_gateway_go:latest       "envdir /var/opt/mag…"   About a minute ago   Up About a minute                                                      s8_proxy
3604d0d1e126   feg_gateway_go:latest       "envdir /var/opt/mag…"   About a minute ago   Up About a minute                                                      feg_hello
14ccfeae9b64   feg_gateway_go              "envdir /var/opt/mag…"   About a minute ago   Up About a minute                                                      hss
f7a6f2e993cc   magma_docusaurus            "docker-entrypoint.s…"   27 minutes ago       Up 27 minutes       0.0.0.0:3000->3000/tcp, 0.0.0.0:35729->35729/tcp   docusaurus_docusaurus_1
➜  magma git:(fix-feg-magmad) ✗
```
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->

<!--
    Final note

    Please take a moment to read through the Magma project's
    - Contributing conventions: https://docs.magmacore.org/docs/next/contributing/contribute_conventions

    If this is your first time opening a PR, also consider reading
    - Developer onboarding: https://docs.magmacore.org/docs/next/contributing/contribute_onboarding
    - Development workflow: https://docs.magmacore.org/docs/next/contributing/contribute_workflow
-->
