### PR TITLE
[orc8r][indexer] Add reindex logs for debugging flaky CI

### DIFF
--- a/orc8r/cloud/go/services/state/indexer/reindex/reindexer.go
+++ b/orc8r/cloud/go/services/state/indexer/reindex/reindexer.go
@@ -117,12 +117,15 @@ func (r *reindexerImpl) Run(ctx context.Context) {
 
 func (r *reindexerImpl) RunUnsafe(ctx context.Context, indexerID string, sendUpdate func(string)) error {
 	batches := r.getReindexBatches(ctx)
+	glog.Infof("Reindex for indexer '%s' with state batches: %+v", indexerID, batches)
 	jobs, err := r.getJobs(indexerID)
 	if err != nil || len(jobs) == 0 {
 		return err
 	}
+	glog.Infof("Reindex for indexer '%s' with reindex jobs: %+v", indexerID, jobs)
 
 	for _, j := range jobs {
+		glog.Infof("Reindex for indexer '%s', execute job %+v", indexerID, j)
 		err = executeJob(ctx, j, batches)
 		if err != nil {
 			return err

--- a/orc8r/cloud/go/services/state/indexer/reindex/reindexer_test.go
+++ b/orc8r/cloud/go/services/state/indexer/reindex/reindexer_test.go
@@ -21,6 +21,7 @@ package reindex_test
 
 import (
 	"context"
+	"flag"
 	"fmt"
 	"testing"
 	"time"
@@ -103,7 +104,8 @@ var (
 )
 
 func init() {
-	// _ = flag.Set("alsologtostderr", "true") // uncomment to view logs during test
+	// TODO(hcgatewood) after resolving racy CI issue, revert most changes from #6329
+	_ = flag.Set("alsologtostderr", "true") // uncomment to view logs during test
 }
 
 func TestRun(t *testing.T) {


### PR DESCRIPTION
## Summary

Reindex test is infrequently failing with weird error. Adding additional logging, and turning on info logs during tests, to try to catch this next time it occurs.

## Test Plan

Manual inspection of new logs during test

## Additional Information

- [ ] This change is backwards-breaking