### PR TITLE
AGW: pipelined: QoS: Fix max bandwidth calculation.

### DIFF
--- a/lte/gateway/python/integ_tests/defs.mk
+++ b/lte/gateway/python/integ_tests/defs.mk
@@ -130,7 +130,8 @@ s1aptests/test_attach_ul_udp_data_with_mobilityd_restart.py \
 s1aptests/test_attach_ul_udp_data_with_multiple_service_restart.py \
 s1aptests/test_attach_ul_udp_data_with_pipelined_restart.py \
 s1aptests/test_attach_ul_udp_data_with_sessiond_restart.py \
-s1aptests/test_service_req_ul_udp_data_with_mme_restart.py
+s1aptests/test_service_req_ul_udp_data_with_mme_restart.py \
+s1aptests/test_attach_detach_setsessionrules_tcp_data.py
 
 EXTENDED_TESTS = s1aptests/test_modify_mme_config_for_sanity.py \
 s1aptests/test_attach_detach_dedicated_deactivation_timer_expiry.py \

--- a/lte/gateway/python/integ_tests/s1aptests/util/traffic_util.py
+++ b/lte/gateway/python/integ_tests/s1aptests/util/traffic_util.py
@@ -127,7 +127,7 @@ class TrafficUtil(object):
         """ Update downlink route in TRF server """
         ret_code = self.exec_command(
             "sudo ip route flush via 192.168.129.1 && sudo ip route "
-            "add " + ue_ip_block + " via 192.168.129.1 dev eth2"
+            "replace " + ue_ip_block + " via 192.168.129.1 dev eth2"
         )
         if ret_code != 0:
             return False

--- a/lte/gateway/python/magma/pipelined/qos/common.py
+++ b/lte/gateway/python/magma/pipelined/qos/common.py
@@ -370,7 +370,7 @@ class QosManager(object):
                 LOG.debug("add_subscriber_qos: not enabled or initialized")
                 return None, None
 
-            LOG.debug("adding qos for imsi %s rule_num %d direction %d apn_ambr %d, qos_info %s",
+            LOG.debug("adding qos for imsi %s rule_num %d direction %d apn_ambr %d, %s",
                       imsi, rule_num, direction, apn_ambr, qos_info)
 
             imsi = normalize_imsi(imsi)

--- a/lte/gateway/python/magma/pipelined/qos/tc_ops_pyroute2.py
+++ b/lte/gateway/python/magma/pipelined/qos/tc_ops_pyroute2.py
@@ -37,9 +37,24 @@ class TcOpsPyRoute2(TcOpsBase):
 
     def create_htb(self, iface: str, qid: str, max_bw: int, rate: str,
                    parent_qid: str = None) -> int:
-        LOG.debug("Create HTB iface %s qid %s", iface, qid)
+        """
+        Create HTB class for a UE session.
 
+        Args:
+            iface: Egress interface name.
+            qid: qid number.
+            max_bw: ceiling in bits per sec.
+            rate: rate limiting.
+            parent_qid: HTB parent queue.
+
+        Returns:
+            zero on success.
+        """
+
+        LOG.debug("Create HTB iface %s qid %s max_bw %s rate %s", iface, qid, max_bw, rate)
         try:
+            # API needs ceiling in bytes per sec.
+            max_bw = max_bw / 8
             if_index = self._get_if_index(iface)
             htb_queue = QUEUE_PREFIX + qid
             ret = self._ipr.tc("add-class", "htb", if_index,
@@ -53,6 +68,15 @@ class TcOpsPyRoute2(TcOpsBase):
         return 0
 
     def del_htb(self, iface: str, qid: str) -> int:
+        """
+        Delete given queue from HTB classed
+
+        Args:
+            iface: interface name
+            qid: queue-id of the HTB class
+
+        Returns:
+        """
         LOG.debug("Delete HTB iface %s qid %s", iface, qid)
 
         try:
@@ -68,8 +92,11 @@ class TcOpsPyRoute2(TcOpsBase):
         return 0
 
     def create_filter(self, iface: str, mark: str, qid: str, proto: int = PROTOCOL) -> int:
-        LOG.debug("Create Filter iface %s qid %s", iface, qid)
+        """
+        Create TC Filter for given HTB class.
+        """
 
+        LOG.debug("Create Filter iface %s qid %s", iface, qid)
         try:
             if_index = self._get_if_index(iface)
 
@@ -88,8 +115,11 @@ class TcOpsPyRoute2(TcOpsBase):
         return 0
 
     def del_filter(self, iface: str, mark: str, qid: str, proto: int = PROTOCOL) -> int:
-        LOG.debug("Del Filter iface %s qid %s", iface, qid)
+        """
+        Delete TC filter.
+        """
 
+        LOG.debug("Del Filter iface %s qid %s", iface, qid)
         try:
             if_index = self._get_if_index(iface)
 


### PR DESCRIPTION
Pyroute2 API expects max-bandwidth parameter in bytes rather than
bit rate.

Signed-off-by: Pravin B Shelar <pbshelar@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->

<!--
    Final note

    Please take a moment to read through the Magma project's
    - Contributing conventions: https://docs.magmacore.org/docs/next/contributing/contribute_conventions

    If this is your first time opening a PR, also consider reading
    - Developer onboarding: https://docs.magmacore.org/docs/next/contributing/contribute_onboarding
    - Development workflow: https://docs.magmacore.org/docs/next/contributing/contribute_workflow
-->
