### PR TITLE
[5G: MVC][component: agw][type: enhancement] Fix handling of GUTI based and SUCI based registration in AMF

### DIFF
--- a/lte/gateway/c/oai/tasks/amf/Registration.cpp
+++ b/lte/gateway/c/oai/tasks/amf/Registration.cpp
@@ -330,6 +330,20 @@ int amf_registration_run_procedure(amf_context_t* amf_context) {
               LOG_NAS_AMF,
               "Failed to start registration authentication procedure! \n");
         }
+      } else if (amf_context->reg_id_type == M5GSMobileIdentityMsg_SUCI_IMSI) {
+        OAILOG_INFO(
+            LOG_AMF_APP,
+            "In SUCI Initial request case Send Auth Req directly\n");
+        imsi64_t imsi64 = amf_imsi_to_imsi64(registration_proc->ies->imsi);
+        amf_ctx_set_valid_imsi(
+            amf_context, registration_proc->ies->imsi, imsi64);
+        rc = amf_start_registration_proc_authentication(
+            amf_context, registration_proc);
+        if (rc != RETURNok) {
+          OAILOG_ERROR(
+              LOG_NAS_AMF,
+              "Failed to start registration authentication procedure! \n");
+        }
       } else {
         // force identification, even if not necessary
         rc = amf_proc_identification(
@@ -339,7 +353,7 @@ int amf_registration_run_procedure(amf_context_t* amf_context) {
             amf_registration_success_identification_cb,
             amf_registration_failure_identification_cb);
       }
-    } else if (registration_proc->ies->guti) {
+    } else if (amf_context->reg_id_type == M5GSMobileIdentityMsg_GUTI) {
       /* TODO: Currently we are not receving GUTI during intial
        * Registration procedure and in future this code can be used.
        */

--- a/lte/gateway/c/oai/tasks/amf/amf_app_handler.cpp
+++ b/lte/gateway/c/oai/tasks/amf/amf_app_handler.cpp
@@ -316,7 +316,6 @@ imsi64_t amf_app_handle_initial_ue_message(
   bool is_mm_ctx_new                = false;
   gnb_ngap_id_key_t gnb_ngap_id_key = INVALID_GNB_UE_NGAP_ID_KEY;
   imsi64_t imsi64                   = INVALID_IMSI64;
-  paging_context_t* paging_ctx      = nullptr;
   guti_m5_t guti;
   plmn_t plmn;
   s_tmsi_m5_t s_tmsi = {0};

--- a/lte/gateway/c/oai/tasks/amf/amf_app_ue_context_and_proc.h
+++ b/lte/gateway/c/oai/tasks/amf/amf_app_ue_context_and_proc.h
@@ -302,6 +302,7 @@ typedef struct amf_context_s {
                                              AMF24.501R15_5.5.3.2.4_4*/
   std::string smf_msg; /* SMF message contained within the initial request*/
   bool is_imsi_only_detach;
+  uint8_t reg_id_type;
 } amf_context_t;
 
 typedef struct amf_ue_context_s {

--- a/lte/gateway/c/oai/tasks/amf/amf_recv.cpp
+++ b/lte/gateway/c/oai/tasks/amf/amf_recv.cpp
@@ -179,6 +179,30 @@ int amf_handle_registration_request(
         supi_imsi.plmn.mnc_digit3 =
             msg->m5gs_mobile_identity.mobile_identity.imsi.mnc_digit3;
 
+        ue_context->amf_context.m5_guti.guamfi.plmn.mcc_digit1 =
+            supi_imsi.plmn.mcc_digit1;
+        ue_context->amf_context.m5_guti.guamfi.plmn.mcc_digit2 =
+            supi_imsi.plmn.mcc_digit2;
+        ue_context->amf_context.m5_guti.guamfi.plmn.mcc_digit3 =
+            supi_imsi.plmn.mcc_digit3;
+        ue_context->amf_context.m5_guti.guamfi.plmn.mnc_digit1 =
+            supi_imsi.plmn.mnc_digit1;
+        ue_context->amf_context.m5_guti.guamfi.plmn.mnc_digit2 =
+            supi_imsi.plmn.mnc_digit2;
+        ue_context->amf_context.m5_guti.guamfi.plmn.mnc_digit3 =
+            supi_imsi.plmn.mnc_digit3;
+
+        OAILOG_DEBUG(
+            LOG_AMF_APP,
+            "AMF_TEST send msg mcc1:%2x mcc2:%2x mcc3:%2x mnc1:%2x mnc2:%2x "
+            "mnc3:%2x",
+            ue_context->amf_context.m5_guti.guamfi.plmn.mcc_digit1,
+            ue_context->amf_context.m5_guti.guamfi.plmn.mcc_digit2,
+            ue_context->amf_context.m5_guti.guamfi.plmn.mcc_digit3,
+            ue_context->amf_context.m5_guti.guamfi.plmn.mnc_digit1,
+            ue_context->amf_context.m5_guti.guamfi.plmn.mnc_digit2,
+            ue_context->amf_context.m5_guti.guamfi.plmn.mnc_digit3);
+
         amf_app_generate_guti_on_supi(&amf_guti, &supi_imsi);
         OAILOG_INFO(
             LOG_NAS_AMF,


### PR DESCRIPTION
 

Signed-off-by: ashish-acl <ashish.t@altencalsoftlabs.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary
A. Implemented handling of GUTI based registration, i.e. handled for UE-Registration exist and not-exist in AMF.
B. Fixed no-identity request to UE on SUCI based registration initial request. 
## Test Plan

For case B - Tested in DSTester and passed.
For case A (UE registration context Not-Exist in AMF)- Passed in SIT. But test pending in SIT on UE registration context exist in AMF.
[SUCI_GUTI_reg_fix.zip](https://github.com/magma/magma/files/6403250/SUCI_GUTI_reg_fix.zip)


-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->

<!--
    Final note

    Please take a moment to read through the Magma project's
    - Contributing conventions: https://docs.magmacore.org/docs/next/contributing/contribute_conventions

    If this is your first time opening a PR, also consider reading
    - Developer onboarding: https://docs.magmacore.org/docs/next/contributing/contribute_onboarding
    - Development workflow: https://docs.magmacore.org/docs/next/contributing/contribute_workflow
-->
