### PR TITLE
[CWAG] Fix PipelineD build failure for CWAG

### DIFF
--- a/cwf/gateway/docker/python/Dockerfile
+++ b/cwf/gateway/docker/python/Dockerfile
@@ -114,7 +114,11 @@ RUN python3.8 -m pip install --no-cache-dir \
     click \
     pycares \
     python-dateutil \
+    aioeventlet>=0.4 \ 
     jsonpickle
+
+# TODO: aioeventlet>=0.4 was manually added to fix regression tracked with GH issue 6152
+# Fix to pull the patched aioeventlet build deployed by the aioeventlet_build.sh script
 
 COPY cwf/gateway/deploy/roles/ovs/files/nx_actions.py /usr/local/lib/python3.8/dist-packages/ryu/ofproto/
 

--- a/cwf/gateway/go.sum
+++ b/cwf/gateway/go.sum
@@ -224,6 +224,7 @@ github.com/go-stack/stack v1.8.0 h1:5SgMzNM5HxrEjV0ww2lTmX6E2Izsfxas4+YHWRs3Lsk=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
 github.com/go-swagger/go-swagger v0.21.0/go.mod h1:tDb8PdDVFcaE8EPXkMOsuxpL3UEPiwu1UDZar9Z/1RY=
 github.com/go-swagger/scan-repo-boundary v0.0.0-20180623220736-973b3573c013/go.mod h1:b65mBPzqzZWxOZGxSWrqs4GInLIn+u99Q9q7p+GKni0=
+github.com/gofrs/uuid v4.0.0+incompatible/go.mod h1:b2aQJv3Z4Fp6yNu3cdSllBxTCLRxnplIgP/c0N/04lM=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.2.0/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.2.1/go.mod h1:hp+jE20tsWTFYpLwKvXlhS1hjn+gTNwPg2I6zVXpSg4=


### PR DESCRIPTION
Signed-off-by: Marie Bremner <marwhal@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary
the CWAG pipelined uses a focal image. https://github.com/magma/magma/issues/6152 split up python dependencies between focal and debian, which broke some python dependencies.

Also modifying the fabfile to only force provision if it is the first time accessing the VM. (was slowing down my testing) + ran ran formatter. (Will address other lints in a separate PR)

I think there's a better way to fix this, but since CWAG/XWF has been broken for ~2 weeks and we want a clean 1.5 release, I'm going to go with this approach unless someone suggests otherwise.
<!-- Enumerate changes you made and why you made them -->

## Test Plan
`docker-compose build pipelined` in both `cwf/gateway/docker` and `xwf/docker` work
running integration tests...
[X] passes locally (DONE 40 tests, 11 skipped in 542.147s)
[ ] passes on circleci
[ ] passes on jenkins

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->

<!--
    Final note

    Please take a moment to read through the Magma project's
    - Contributing conventions: https://docs.magmacore.org/docs/next/contributing/contribute_conventions

    If this is your first time opening a PR, also consider reading
    - Developer onboarding: https://docs.magmacore.org/docs/next/contributing/contribute_onboarding
    - Development workflow: https://docs.magmacore.org/docs/next/contributing/contribute_workflow
-->
