### PR TITLE
Add log forwarding to fluentd configuration to Federation gateway deployment

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -713,6 +713,7 @@ jobs:
       MAGMA_ROOT: /home/circleci/project
     steps:
       - checkout
+      - docker/install-dc
       - build/determinator:
           <<: *federated_build_verify
       - run:

--- a/feg/gateway/docker/docker-compose.yml
+++ b/feg/gateway/docker/docker-compose.yml
@@ -84,9 +84,9 @@ services:
 
   feg_hello:
     <<: *goservice
+    <<: *depends_on_logs
     container_name: feg_hello
     command: envdir /var/opt/magma/envdir /var/opt/magma/bin/feg_hello -logtostderr=true -v=0
-    <<: *depends_on_logs
 
   health:
     <<: *goservice

--- a/feg/gateway/docker/docker-compose.yml
+++ b/feg/gateway/docker/docker-compose.yml
@@ -30,17 +30,21 @@ x-generic-service: &service
   restart: always
   network_mode: host
 
-# Use generic python anchor to avoid repetition for python services
+# Use generic anchor to defined dependencie on td-agent-bit container
+  x-log-forward: &depends_on_logs
+  depends_on:
+    td-agent-bit:
+      condition: service_healthy
+
 # Use generic python anchor to avoid repetition for python services
 x-pyservice_base: &pyservice_base
   <<: *service
   image: ${DOCKER_REGISTRY}gateway_python:${IMAGE_VERSION}
-  
+
 # Use generic python anchor with logging capabilities to avoid repetition for python services
 x-pyservice: &pyservice
   <<: *pyservice_base
   <<: *depends_on_logs
-
 
 # Use generic go anchor to avoid repetition for go services
 x-goservice: &goservice
@@ -48,10 +52,6 @@ x-goservice: &goservice
   <<: *depends_on_logs
   image: ${DOCKER_REGISTRY}gateway_go:${IMAGE_VERSION}
 
-x-log-forward: &depends_on_logs
-  depends_on:
-    td-agent-bit:
-      condition: service_healthy
 
 services:
   csfb:

--- a/feg/gateway/docker/docker-compose.yml
+++ b/feg/gateway/docker/docker-compose.yml
@@ -40,11 +40,17 @@ x-goservice: &goservice
   <<: *service
   image: ${DOCKER_REGISTRY}gateway_go:${IMAGE_VERSION}
 
+x-log-forward: &depends_on_logs
+  depends_on:
+    td-agent-bit:
+      condition: service_healthy
+
 services:
   csfb:
     <<: *goservice
     container_name: csfb
     command: envdir /var/opt/magma/envdir /var/opt/magma/bin/csfb -logtostderr=true -v=0
+    <<: *depends_on_logs
 
   eap_aka:
     <<: *goservice
@@ -52,6 +58,7 @@ services:
     environment:
       USE_REMOTE_SWX_PROXY: 0
     command: envdir /var/opt/magma/envdir /var/opt/magma/bin/eap_aka -logtostderr=true -v=0
+    <<: *depends_on_logs
 
   eap_sim:
     <<: *goservice
@@ -59,11 +66,13 @@ services:
     environment:
       USE_REMOTE_SWX_PROXY: 0
     command: envdir /var/opt/magma/envdir /var/opt/magma/bin/eap_sim -logtostderr=true -v=0
+    <<: *depends_on_logs
 
   eventd:
     <<: *pyservice
     container_name: eventd
     command: python3.8 -m magma.eventd.main
+    <<: *depends_on_logs
 
   aaa_server:
     <<: *goservice
@@ -71,17 +80,20 @@ services:
     environment:
       USE_REMOTE_SWX_PROXY: 0
     command: envdir /var/opt/magma/envdir /var/opt/magma/bin/aaa_server -logtostderr=true -v=0
+    <<: *depends_on_logs
 
   feg_hello:
     <<: *goservice
     container_name: feg_hello
     command: envdir /var/opt/magma/envdir /var/opt/magma/bin/feg_hello -logtostderr=true -v=0
+    <<: *depends_on_logs
 
   health:
     <<: *goservice
     volumes: *snowflake_volumes
     container_name: health
     command: envdir /var/opt/magma/envdir /var/opt/magma/bin/gateway_health -logtostderr=true -v=0
+    <<: *depends_on_logs
 
   session_proxy:
     <<: *goservice
@@ -91,26 +103,31 @@ services:
       GY_SERVICE_CONTEXT_ID: ${GY_SERVICE_CONTEXT_ID}
     container_name: session_proxy
     command: envdir /var/opt/magma/envdir /var/opt/magma/bin/session_proxy -logtostderr=true -v=0
+    <<: *depends_on_logs
 
   swx_proxy:
     <<: *goservice
     container_name: swx_proxy
     command: envdir /var/opt/magma/envdir /var/opt/magma/bin/swx_proxy -logtostderr=true -v=0
+    <<: *depends_on_logs
 
   s6a_proxy:
     <<: *goservice
     container_name: s6a_proxy
     command: envdir /var/opt/magma/envdir /var/opt/magma/bin/s6a_proxy -logtostderr=true -v=0
+    <<: *depends_on_logs
 
   s8_proxy:
     <<: *goservice
     container_name: s8_proxy
     command: envdir /var/opt/magma/envdir /var/opt/magma/bin/s8_proxy -logtostderr=true -v=0
+    <<: *depends_on_logs
 
   radiusd:
     <<: *goservice
     container_name: radiusd
     command: envdir /var/opt/magma/envdir /var/opt/magma/bin/radiusd -logtostderr=true -v=0
+    <<: *depends_on_logs
 
   control_proxy:
     <<: *pyservice
@@ -119,6 +136,7 @@ services:
     command: >
       /bin/bash -c "/usr/local/bin/generate_nghttpx_config.py &&
              /usr/bin/env nghttpx --conf /var/opt/magma/tmp/nghttpx.conf /var/opt/magma/certs/controller.key /var/opt/magma/certs/controller.crt"
+    <<: *depends_on_logs  
 
   magmad:
     <<: *pyservice
@@ -138,6 +156,7 @@ services:
       DOCKER_USERNAME: ${DOCKER_USERNAME}
       DOCKER_PASSWORD: ${DOCKER_PASSWORD}
     command: python3.8 -m magma.magmad.main
+    <<: *depends_on_logs
 
   redis:
     <<: *pyservice
@@ -146,12 +165,19 @@ services:
       /bin/bash -c "/usr/local/bin/generate_service_config.py --service=redis --template=redis &&
              /usr/bin/redis-server /var/opt/magma/tmp/redis.conf --daemonize no &&
              /usr/bin/redis-cli shutdown"
+    <<: *depends_on_logs
 
   td-agent-bit:
     <<: *pyservice
     container_name: td-agent-bit
     logging:
       driver: json-file
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://127.0.0.1:2020"]
+      interval: 5s
+      timeout: 5s
+      retries: 3
+      start_period: 10s
     command: >
         /bin/bash -c "/usr/local/bin/generate_fluent_bit_config.py &&
         /opt/td-agent-bit/bin/td-agent-bit -c /var/opt/magma/tmp/td-agent-bit.conf"

--- a/feg/gateway/docker/docker-compose.yml
+++ b/feg/gateway/docker/docker-compose.yml
@@ -30,7 +30,7 @@ x-generic-service: &service
   restart: always
   network_mode: host
 
-# Use generic anchor to defined dependencie on td-agent-bit container
+# Use generic anchor to defined dependence on td-agent-bit container
 x-log-forward: &depends_on_logs
   depends_on:
     td-agent-bit:

--- a/feg/gateway/docker/docker-compose.yml
+++ b/feg/gateway/docker/docker-compose.yml
@@ -31,13 +31,21 @@ x-generic-service: &service
   network_mode: host
 
 # Use generic python anchor to avoid repetition for python services
-x-pyservice: &pyservice
+# Use generic python anchor to avoid repetition for python services
+x-pyservice_base: &pyservice_base
   <<: *service
   image: ${DOCKER_REGISTRY}gateway_python:${IMAGE_VERSION}
+  
+# Use generic python anchor with logging capabilities to avoid repetition for python services
+x-pyservice: &pyservice
+  <<: *pyservice_base
+  <<: *depends_on_logs
+
 
 # Use generic go anchor to avoid repetition for go services
 x-goservice: &goservice
   <<: *service
+  <<: *depends_on_logs
   image: ${DOCKER_REGISTRY}gateway_go:${IMAGE_VERSION}
 
 x-log-forward: &depends_on_logs
@@ -48,13 +56,11 @@ x-log-forward: &depends_on_logs
 services:
   csfb:
     <<: *goservice
-    <<: *depends_on_logs
     container_name: csfb
     command: envdir /var/opt/magma/envdir /var/opt/magma/bin/csfb -logtostderr=true -v=0
 
   eap_aka:
     <<: *goservice
-    <<: *depends_on_logs
     container_name: eap_aka
     environment:
       USE_REMOTE_SWX_PROXY: 0
@@ -62,7 +68,6 @@ services:
 
   eap_sim:
     <<: *goservice
-    <<: *depends_on_logs
     container_name: eap_sim
     environment:
       USE_REMOTE_SWX_PROXY: 0
@@ -70,13 +75,11 @@ services:
 
   eventd:
     <<: *pyservice
-    <<: *depends_on_logs
     container_name: eventd
     command: python3.8 -m magma.eventd.main
 
   aaa_server:
     <<: *goservice
-    <<: *depends_on_logs
     container_name: aaa_server
     environment:
       USE_REMOTE_SWX_PROXY: 0
@@ -84,20 +87,17 @@ services:
 
   feg_hello:
     <<: *goservice
-    <<: *depends_on_logs
     container_name: feg_hello
     command: envdir /var/opt/magma/envdir /var/opt/magma/bin/feg_hello -logtostderr=true -v=0
 
   health:
     <<: *goservice
-    <<: *depends_on_logs
     volumes: *snowflake_volumes
     container_name: health
     command: envdir /var/opt/magma/envdir /var/opt/magma/bin/gateway_health -logtostderr=true -v=0
 
   session_proxy:
     <<: *goservice
-    <<: *depends_on_logs
     environment:
       USE_GY_FOR_AUTH_ONLY: ${USE_GY_FOR_AUTH_ONLY}
       GY_SUPPORTED_VENDOR_IDS: ${GY_SUPPORTED_VENDOR_IDS}
@@ -107,32 +107,27 @@ services:
 
   swx_proxy:
     <<: *goservice
-    <<: *depends_on_logs
     container_name: swx_proxy
     command: envdir /var/opt/magma/envdir /var/opt/magma/bin/swx_proxy -logtostderr=true -v=0
 
   s6a_proxy:
     <<: *goservice
-    <<: *depends_on_logs
     container_name: s6a_proxy
     command: envdir /var/opt/magma/envdir /var/opt/magma/bin/s6a_proxy -logtostderr=true -v=0
 
 
   s8_proxy:
     <<: *goservice
-    <<: *depends_on_logs
     container_name: s8_proxy
     command: envdir /var/opt/magma/envdir /var/opt/magma/bin/s8_proxy -logtostderr=true -v=0
 
   radiusd:
     <<: *goservice
-    <<: *depends_on_logs
     container_name: radiusd
     command: envdir /var/opt/magma/envdir /var/opt/magma/bin/radiusd -logtostderr=true -v=0
 
   control_proxy:
     <<: *pyservice
-    <<: *depends_on_logs
     container_name: control_proxy
     volumes: *snowflake_volumes
     command: >
@@ -141,7 +136,6 @@ services:
 
   magmad:
     <<: *pyservice
-    <<: *depends_on_logs
     container_name: magmad
     volumes:
       - ${ROOTCA_PATH}:/var/opt/magma/certs/rootCA.pem
@@ -161,7 +155,6 @@ services:
 
   redis:
     <<: *pyservice
-    <<: *depends_on_logs
     container_name: redis
     command: >
       /bin/bash -c "/usr/local/bin/generate_service_config.py --service=redis --template=redis &&
@@ -169,7 +162,7 @@ services:
              /usr/bin/redis-cli shutdown"
 
   td-agent-bit:
-    <<: *pyservice
+    <<: *pyservice_base
     container_name: td-agent-bit
     logging:
       driver: json-file

--- a/feg/gateway/docker/docker-compose.yml
+++ b/feg/gateway/docker/docker-compose.yml
@@ -31,7 +31,7 @@ x-generic-service: &service
   network_mode: host
 
 # Use generic anchor to defined dependencie on td-agent-bit container
-  x-log-forward: &depends_on_logs
+x-log-forward: &depends_on_logs
   depends_on:
     td-agent-bit:
       condition: service_healthy

--- a/feg/gateway/docker/docker-compose.yml
+++ b/feg/gateway/docker/docker-compose.yml
@@ -48,39 +48,39 @@ x-log-forward: &depends_on_logs
 services:
   csfb:
     <<: *goservice
+    <<: *depends_on_logs
     container_name: csfb
     command: envdir /var/opt/magma/envdir /var/opt/magma/bin/csfb -logtostderr=true -v=0
-    <<: *depends_on_logs
 
   eap_aka:
     <<: *goservice
+    <<: *depends_on_logs
     container_name: eap_aka
     environment:
       USE_REMOTE_SWX_PROXY: 0
     command: envdir /var/opt/magma/envdir /var/opt/magma/bin/eap_aka -logtostderr=true -v=0
-    <<: *depends_on_logs
 
   eap_sim:
     <<: *goservice
+    <<: *depends_on_logs
     container_name: eap_sim
     environment:
       USE_REMOTE_SWX_PROXY: 0
     command: envdir /var/opt/magma/envdir /var/opt/magma/bin/eap_sim -logtostderr=true -v=0
-    <<: *depends_on_logs
 
   eventd:
     <<: *pyservice
+    <<: *depends_on_logs
     container_name: eventd
     command: python3.8 -m magma.eventd.main
-    <<: *depends_on_logs
 
   aaa_server:
     <<: *goservice
+    <<: *depends_on_logs
     container_name: aaa_server
     environment:
       USE_REMOTE_SWX_PROXY: 0
     command: envdir /var/opt/magma/envdir /var/opt/magma/bin/aaa_server -logtostderr=true -v=0
-    <<: *depends_on_logs
 
   feg_hello:
     <<: *goservice
@@ -90,56 +90,58 @@ services:
 
   health:
     <<: *goservice
+    <<: *depends_on_logs
     volumes: *snowflake_volumes
     container_name: health
     command: envdir /var/opt/magma/envdir /var/opt/magma/bin/gateway_health -logtostderr=true -v=0
-    <<: *depends_on_logs
 
   session_proxy:
     <<: *goservice
+    <<: *depends_on_logs
     environment:
       USE_GY_FOR_AUTH_ONLY: ${USE_GY_FOR_AUTH_ONLY}
       GY_SUPPORTED_VENDOR_IDS: ${GY_SUPPORTED_VENDOR_IDS}
       GY_SERVICE_CONTEXT_ID: ${GY_SERVICE_CONTEXT_ID}
     container_name: session_proxy
     command: envdir /var/opt/magma/envdir /var/opt/magma/bin/session_proxy -logtostderr=true -v=0
-    <<: *depends_on_logs
 
   swx_proxy:
     <<: *goservice
+    <<: *depends_on_logs
     container_name: swx_proxy
     command: envdir /var/opt/magma/envdir /var/opt/magma/bin/swx_proxy -logtostderr=true -v=0
-    <<: *depends_on_logs
 
   s6a_proxy:
     <<: *goservice
+    <<: *depends_on_logs
     container_name: s6a_proxy
     command: envdir /var/opt/magma/envdir /var/opt/magma/bin/s6a_proxy -logtostderr=true -v=0
-    <<: *depends_on_logs
+
 
   s8_proxy:
     <<: *goservice
+    <<: *depends_on_logs
     container_name: s8_proxy
     command: envdir /var/opt/magma/envdir /var/opt/magma/bin/s8_proxy -logtostderr=true -v=0
-    <<: *depends_on_logs
 
   radiusd:
     <<: *goservice
+    <<: *depends_on_logs
     container_name: radiusd
     command: envdir /var/opt/magma/envdir /var/opt/magma/bin/radiusd -logtostderr=true -v=0
-    <<: *depends_on_logs
 
   control_proxy:
     <<: *pyservice
+    <<: *depends_on_logs
     container_name: control_proxy
     volumes: *snowflake_volumes
     command: >
       /bin/bash -c "/usr/local/bin/generate_nghttpx_config.py &&
              /usr/bin/env nghttpx --conf /var/opt/magma/tmp/nghttpx.conf /var/opt/magma/certs/controller.key /var/opt/magma/certs/controller.crt"
-    <<: *depends_on_logs  
 
   magmad:
     <<: *pyservice
+    <<: *depends_on_logs
     container_name: magmad
     volumes:
       - ${ROOTCA_PATH}:/var/opt/magma/certs/rootCA.pem
@@ -156,16 +158,15 @@ services:
       DOCKER_USERNAME: ${DOCKER_USERNAME}
       DOCKER_PASSWORD: ${DOCKER_PASSWORD}
     command: python3.8 -m magma.magmad.main
-    <<: *depends_on_logs
 
   redis:
     <<: *pyservice
+    <<: *depends_on_logs
     container_name: redis
     command: >
       /bin/bash -c "/usr/local/bin/generate_service_config.py --service=redis --template=redis &&
              /usr/bin/redis-server /var/opt/magma/tmp/redis.conf --daemonize no &&
              /usr/bin/redis-cli shutdown"
-    <<: *depends_on_logs
 
   td-agent-bit:
     <<: *pyservice

--- a/orc8r/gateway/configs/templates/td-agent-bit.conf.template
+++ b/orc8r/gateway/configs/templates/td-agent-bit.conf.template
@@ -33,8 +33,8 @@
     # HTTP Server
     # ===========
     # Enable/Disable the built-in HTTP Server for metrics
-    HTTP_Server  Off
-    HTTP_Listen  0.0.0.0
+    HTTP_Server  On
+    HTTP_Listen  127.0.0.1
     HTTP_Port    2020
 
 [INPUT]

--- a/orc8r/tools/docker/install_gateway.sh
+++ b/orc8r/tools/docker/install_gateway.sh
@@ -194,6 +194,6 @@ fi
 
 echo "Installed successfully!!"
 # Prepare rsyslog config and restart rsyslog
-echo "If You want syslog to be forwardet to the cloud execute following commands as well"
+echo "If you want syslog to be forwarded to the cloud execute following commands as well"
 echo "sudo cp $INSTALL_DIR/magma/orc8r/tools/ansible/roles/fluent_bit/files/60-fluent-bit.conf /etc/rsyslog.d/"
 echo "sudo service rsyslog restart"

--- a/orc8r/tools/docker/install_gateway.sh
+++ b/orc8r/tools/docker/install_gateway.sh
@@ -27,7 +27,7 @@ INSTALL_DIR="/tmp/magmagw_install"
 
 # Using RC as opposed to stable (1.24.0) due to
 # SCTP port mapping support
-DOCKER_COMPOSE_VERSION=1.25.0-rc1
+DOCKER_COMPOSE_VERSION=1.29.1
 
 DIR="."
 echo "Setting working directory as: $DIR"

--- a/orc8r/tools/docker/install_gateway.sh
+++ b/orc8r/tools/docker/install_gateway.sh
@@ -164,10 +164,6 @@ cp control_proxy.yml /var/opt/magma/configs/
 cp docker-compose.yml /var/opt/magma/docker/
 cp .env /var/opt/magma/docker/
 
-# Prepare rsyslog config and restart rsyslog
-sudo cp "$INSTALL_DIR"/magma/orc8r/tools/ansible/roles/fluent_bit/files/60-fluent-bit.conf /etc/rsyslog.d/
-sudo service rsyslog restart 
-
 # Copy recreate_services scripts to complete auto-upgrades
 cp recreate_services.sh /var/opt/magma/docker/
 cp recreate_services_cron /etc/cron.d/
@@ -197,3 +193,7 @@ if [ "$GW_TYPE" == "$CWAG" ] && [ -f "$DPI_LICENSE_NAME" ]; then
 fi
 
 echo "Installed successfully!!"
+# Prepare rsyslog config and restart rsyslog
+echo "If You want syslog to be forwardet to the cloud execute following commands as well"
+echo "sudo cp $INSTALL_DIR/magma/orc8r/tools/ansible/roles/fluent_bit/files/60-fluent-bit.conf /etc/rsyslog.d/"
+echo "sudo service rsyslog restart"

--- a/orc8r/tools/docker/install_gateway.sh
+++ b/orc8r/tools/docker/install_gateway.sh
@@ -164,6 +164,10 @@ cp control_proxy.yml /var/opt/magma/configs/
 cp docker-compose.yml /var/opt/magma/docker/
 cp .env /var/opt/magma/docker/
 
+# Prepare rsyslog config and restart rsyslog
+sudo cp "$INSTALL_DIR"/magma/orc8r/tools/ansible/roles/fluent_bit/files/60-fluent-bit.conf /etc/rsyslog.d/
+sudo service rsyslog restart 
+
 # Copy recreate_services scripts to complete auto-upgrades
 cp recreate_services.sh /var/opt/magma/docker/
 cp recreate_services_cron /etc/cron.d/


### PR DESCRIPTION
Signed-off-by: Vitalii Kostenko <vitalii@freedomfi.com>

## Summary

At the moment in the scope of FEG deployment, we have a fluent-bit container which only processing eventD messages however it's preconfigured to forward system logs and docker logs. This PR updates several files to ensure that syslog and docker logs may be forwarded to fluentD by adding the correct log_driver type.

## Test Plan

deploy FEG and check that docker logs and system logs are going to ELK

## Additional Information

- in the .env file we should use LOG_DRIVER=fluentd
- docker-compose 1.29.0 + required

