### PR TITLE
AGW: S1ap-test: add retry to check HE state.

### DIFF
--- a/lte/gateway/python/integ_tests/s1aptests/s1ap_utils.py
+++ b/lte/gateway/python/integ_tests/s1aptests/s1ap_utils.py
@@ -1688,11 +1688,20 @@ class HeaderEnrichmentUtils:
         print("restarting envoy done")
 
     def get_envoy_config(self):
-        output = self.magma_utils.exec_command_output(
-            "sudo ip netns exec envoy_ns1 curl 127.0.0.1:9000/config_dump")
-        self.dump = json.loads(output)
+        retry = 0
+        max = 60
+        while retry < max:
+            try:
+                output = self.magma_utils.exec_command_output(
+                    "sudo ip netns exec envoy_ns1 curl 127.0.0.1:9000/config_dump")
+                self.dump = json.loads(output)
+                return self.dump
+            except subprocess.CalledProcessError as e:
+                logging.debug("cmd error: %s", e)
+                retry = retry + 1
+                time.sleep(1)
 
-        return self.dump
+        assert False
 
     def get_route_config(self):
         self.dump = self.get_envoy_config()


### PR DESCRIPTION
the HE config check can fail to to recent service restart, its better to retry
before failing the test.

Signed-off-by: Pravin B Shelar <pbshelar@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->

## Test Plan
Ran the HE integ test with failure scenario.

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->

<!--
    Final note

    Please take a moment to read through the Magma project's
    - Contributing conventions: https://docs.magmacore.org/docs/next/contributing/contribute_conventions

    If this is your first time opening a PR, also consider reading
    - Developer onboarding: https://docs.magmacore.org/docs/next/contributing/contribute_onboarding
    - Development workflow: https://docs.magmacore.org/docs/next/contributing/contribute_workflow
-->
