### PR TITLE
[feg] S8_proxy fix TestS8proxyManyCreateAndDeleteSession  - mock PGW message flow issue

### DIFF
--- a/feg/gateway/services/s8_proxy/servicers/mock_pgw/cs.go
+++ b/feg/gateway/services/s8_proxy/servicers/mock_pgw/cs.go
@@ -221,9 +221,6 @@ func (mPgw *MockPgw) getHandleCreateSessionRequest() gtpv2.HandlerFunc {
 		session.AddTEID(gtpv2.IFTypeS5S8PGWGTPC, pgwFTEIDc.MustTEID())
 		session.AddTEID(gtpv2.IFTypeS5S8PGWGTPU, pgwFTEIDu.MustTEID())
 
-		if err := c.RespondTo(sgwAddr, csReqFromSGW, csRspFromPGW); err != nil {
-			return err
-		}
 		s5pgwTEID, err := session.GetTEID(gtpv2.IFTypeS5S8PGWGTPC)
 		if err != nil {
 			return err
@@ -240,6 +237,11 @@ func (mPgw *MockPgw) getHandleCreateSessionRequest() gtpv2.HandlerFunc {
 		}
 		mPgw.LastTEIDu, err = pgwFTEIDu.TEID()
 		if err != nil {
+			return err
+		}
+		if err := c.RespondTo(sgwAddr, csReqFromSGW, csRspFromPGW); err != nil {
+			fmt.Printf("mock PGW couldnt create a session for %s\n", session.IMSI)
+			c.RemoveSession(session)
 			return err
 		}
 		fmt.Printf("mock PGW created a session for: %s\n", session.IMSI)

--- a/feg/gateway/services/s8_proxy/servicers/mock_pgw/ds.go
+++ b/feg/gateway/services/s8_proxy/servicers/mock_pgw/ds.go
@@ -77,11 +77,10 @@ func (mPgw *MockPgw) getHandleDeleteSessionRequest() gtpv2.HandlerFunc {
 			sgwTeidC, msg.Sequence(),
 			ie.NewCause(gtpv2.CauseRequestAccepted, 0, 0, 0, nil),
 		)
+		c.RemoveSession(session)
 		if err := c.RespondTo(sgwAddr, msg, dsr); err != nil {
 			return err
 		}
-
-		c.RemoveSession(session)
 		fmt.Printf("mock PGW deleted a session for: %s\n", session.IMSI)
 		return nil
 	}

--- a/feg/gateway/services/s8_proxy/servicers/s8_proxy_test.go
+++ b/feg/gateway/services/s8_proxy/servicers/s8_proxy_test.go
@@ -357,7 +357,7 @@ func TestS8proxyManyCreateAndDeleteSession(t *testing.T) {
 
 	// ------------------------
 	// ---- Create Sessions ----
-	nRequest := 10
+	nRequest := 100
 	pgwActualAddrs := mockPgw.LocalAddr().String()
 	csReqs := getMultipleCreateSessionRequest(nRequest, pgwActualAddrs)
 


### PR DESCRIPTION
Signed-off-by: Oriol Batalla <obatalla@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary

Not sure if this PR will fix the issues seen at s8_proxy but it may help. 
Changing the location when we send the message during create session at mock pgw. This way we make sure that when the message is received by the client the session is created.

This avoid a possible issue where the session is still to be created when the test issues the delete session.

## Test Plan
make precommit

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->

<!--
    Final note

    Please take a moment to read through the Magma project's
    - Contributing conventions: https://docs.magmacore.org/docs/next/contributing/contribute_conventions

    If this is your first time opening a PR, also consider reading
    - Developer onboarding: https://docs.magmacore.org/docs/next/contributing/contribute_onboarding
    - Development workflow: https://docs.magmacore.org/docs/next/contributing/contribute_workflow
-->
