### PR TITLE
Add CWAG build step to precommit checks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,7 +34,7 @@ aliases:
   - &orc8r_build_verify
     paths: "orc8r"
   - &cwf_build_verify
-    paths: "cwf"
+    paths: "cwf lte feg"
   - &docs_only
     paths: "docs"
 
@@ -747,6 +747,24 @@ jobs:
             make -C ${MAGMA_ROOT}/cwf/gateway/integ_tests precommit
       - magma_slack_notify
 
+  cwag-build:
+    machine:
+      image: ubuntu-1604:201903-01
+      docker_layer_caching: true
+    resource_class: large
+    environment:
+      MAGMA_ROOT: /home/circleci/project
+    steps:
+      - checkout
+      - build/determinator:
+          <<: *cwf_build_verify
+      - run:
+          name: Build CWAG containers
+          command: |
+            cd $MAGMA_ROOT/cwf/gateway/docker
+            docker-compose build --parallel
+      # TODO bring up the containers and check for crashloops
+
   cwf-integ-test:
     machine:
       image: ubuntu-1604:201903-01
@@ -1360,6 +1378,7 @@ workflows:
   cwag:
     jobs:
       - cwag-precommit
+      - cwag-build
       - cwf-integ-test:
           <<: *master_and_develop
       - xwfm-test:


### PR DESCRIPTION
Signed-off-by: Marie Bremner <marwhal@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary
We recently had a regression where the PipelineD CWAG container was broken for ~3 weeks. In order to prevent these types of regression in the future, we will add this basic build check at the precommit level. 

This new job takes ~ 8 minutes *if* there are no significant changes to the codebase

I'll wait a few days and make this test mandatory.

(Some potential hiccup is that the magmad build maybe flaky :/ )
<!-- Enumerate changes you made and why you made them -->

## Test Plan
https://app.circleci.com/pipelines/github/magma/magma/20711/workflows/105237cd-77ed-43d2-a06b-44d829871cde/jobs/213872
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->

<!--
    Final note

    Please take a moment to read through the Magma project's
    - Contributing conventions: https://docs.magmacore.org/docs/next/contributing/contribute_conventions

    If this is your first time opening a PR, also consider reading
    - Developer onboarding: https://docs.magmacore.org/docs/next/contributing/contribute_onboarding
    - Development workflow: https://docs.magmacore.org/docs/next/contributing/contribute_workflow
-->
