### PR TITLE
[DRAFT] AGW: deploy: Fix rsyslog config for better stability of logging

### DIFF
--- a/lte/gateway/deploy/magma_deploy.yml
+++ b/lte/gateway/deploy/magma_deploy.yml
@@ -14,3 +14,4 @@
   hosts: magma_deploy
   roles:
     - role: magma_deploy
+    - role: magma_deploy_common

--- a/lte/gateway/deploy/magma_dev_focal.yml
+++ b/lte/gateway/deploy/magma_dev_focal.yml
@@ -50,3 +50,4 @@
     - role: fluent_bit
     - role: pyvenv
     - role: focal_hacks
+    - role: magma_deploy_common

--- a/lte/gateway/deploy/roles/magma_deploy_common/tasks/main.yml
+++ b/lte/gateway/deploy/roles/magma_deploy_common/tasks/main.yml
@@ -1,0 +1,61 @@
+---
+# Copyright 2021 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+# This role is common deployment steps between magma-focal and production AGW.
+
+- name: Fix rsyslog conf 1
+  replace:
+        dest: /etc/rsyslog.conf
+        regexp: '^\$FileOwner'
+        replace: '#$FileOwner'
+
+- name: Fix rsyslog conf 2
+  replace:
+        dest: /etc/rsyslog.conf
+        regexp: '^\$FileGroup'
+        replace: '#$FileGroup'
+
+- name: Fix rsyslog conf 3
+  replace:
+        dest: /etc/rsyslog.conf
+        regexp: '^\$FileCreateMode'
+        replace: '#$FileCreateMode'
+
+- name: Fix rsyslog conf 4
+  replace:
+        dest: /etc/rsyslog.conf
+        regexp: '^\$DirCreateMode'
+        replace: '#$DirCreateMode'
+
+- name: Fix rsyslog conf 5
+  replace:
+        dest: /etc/rsyslog.conf
+        regexp: '^\$Umask'
+        replace: '#$Umask'
+
+- name: Fix rsyslog conf 6
+  replace:
+        dest: /etc/rsyslog.conf
+        regexp: '^\$PrivDropToUser'
+        replace: '#$PrivDropToUser'
+
+- name: Fix rsyslog conf 5
+  replace:
+        dest: /etc/rsyslog.conf
+        regexp: '^\$PrivDropToGroup'
+        replace: '#$PrivDropToGroup'
+
+- name: Restart service syslog
+  ansible.builtin.service:
+    name: rsyslog
+    state: restarted


### PR DESCRIPTION
We have seen rsyslg daemon stuck with no log captured in syslog.
one of fix suggested on stack-overflow is to turn off optional
parameters. following patch does it using ansible role.

This PR introduces magma_deploy_common role, which is common
deployment steps between magma-focal and production AGW. Going
forward we will restructure role to avoid duplication of roles.

Signed-off-by: Pravin B Shelar <pbshelar@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->

## Test Plan
validate magma-focal provision and validated manually.
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->

<!--
    Final note

    Please take a moment to read through the Magma project's
    - Contributing conventions: https://docs.magmacore.org/docs/next/contributing/contribute_conventions

    If this is your first time opening a PR, also consider reading
    - Developer onboarding: https://docs.magmacore.org/docs/next/contributing/contribute_onboarding
    - Development workflow: https://docs.magmacore.org/docs/next/contributing/contribute_workflow
-->
