### PR TITLE
[LTE][timers] Migrate S6A timer to ZMQ loop

### DIFF
--- a/lte/gateway/c/oai/tasks/s6a/s6a_c_iface.h
+++ b/lte/gateway/c/oai/tasks/s6a/s6a_c_iface.h
@@ -31,7 +31,6 @@ bool s6a_viface_update_location_req(s6a_update_location_req_t* ulr_p);
 bool s6a_viface_authentication_info_req(s6a_auth_info_req_t* air_p);
 bool s6a_viface_send_cancel_location_ans(s6a_cancel_location_ans_t* cla_pP);
 bool s6a_viface_purge_ue(const char* imsi);
-void s6a_viface_timer_expired(const long timer_idP);
 #ifdef __cplusplus
 }
 #endif

--- a/lte/gateway/c/oai/tasks/s6a/s6a_fd_iface.h
+++ b/lte/gateway/c/oai/tasks/s6a/s6a_fd_iface.h
@@ -38,7 +38,6 @@ class S6aFdIface : public S6aViface {
   bool authentication_info_req(s6a_auth_info_req_t* air_p);
   bool send_cancel_location_ans(s6a_cancel_location_ans_t* cla_pP);
   bool purge_ue(const char* imsi);
-  void timer_expired(const long timer_idP);
   ~S6aFdIface();
 };
 

--- a/lte/gateway/c/oai/tasks/s6a/s6a_grpc_iface.h
+++ b/lte/gateway/c/oai/tasks/s6a/s6a_grpc_iface.h
@@ -27,7 +27,6 @@ class S6aGrpcIface : public S6aViface {
   bool authentication_info_req(s6a_auth_info_req_t* const air_p);
   bool send_cancel_location_ans(s6a_cancel_location_ans_t* cla_pP);
   bool purge_ue(const char* imsi);
-  void timer_expired(const long timer_idP){};
 
   ~S6aGrpcIface(){};
 };

--- a/lte/gateway/c/oai/tasks/s6a/s6a_iface.cpp
+++ b/lte/gateway/c/oai/tasks/s6a/s6a_iface.cpp
@@ -87,9 +87,3 @@ bool s6a_viface_purge_ue(const char* imsi) {
   }
   return false;
 }
-//------------------------------------------------------------------------------
-void s6a_viface_timer_expired(const long timer_idP) {
-  if (s6a_interface) {
-    s6a_interface->timer_expired(timer_idP);
-  }
-}

--- a/lte/gateway/c/oai/tasks/s6a/s6a_task.c
+++ b/lte/gateway/c/oai/tasks/s6a/s6a_task.c
@@ -34,7 +34,6 @@
 #include "itti_types.h"
 #include "s6a_messages_types.h"
 #include "service303.h"
-#include "timer_messages_types.h"
 #if HAVE_CONFIG_H
 #include "config.h"
 #endif
@@ -46,7 +45,6 @@
 #include "s6a_defs.h"
 #include "s6a_messages.h"
 #include "mme_config.h"
-#include "timer.h"
 #include "s6a_client_api.h"
 #include "s6a_c_iface.h"
 
@@ -88,10 +86,6 @@ static int handle_message(zloop_t* loop, zsock_t* reader, void* arg) {
             LOG_S6A, "Failure in sending s6a AIR for imsi=%s\n",
             received_message_p->ittiMsg.s6a_auth_info_req.imsi);
       }
-    } break;
-    case TIMER_HAS_EXPIRED: {
-      s6a_viface_timer_expired(
-          received_message_p->ittiMsg.timer_has_expired.timer_id);
     } break;
     case S6A_CANCEL_LOCATION_ANS: {
       s6a_viface_send_cancel_location_ans(

--- a/lte/gateway/c/oai/tasks/s6a/s6a_viface.h
+++ b/lte/gateway/c/oai/tasks/s6a/s6a_viface.h
@@ -34,7 +34,6 @@ class S6aViface {
   virtual bool authentication_info_req(s6a_auth_info_req_t* air_p)         = 0;
   virtual bool send_cancel_location_ans(s6a_cancel_location_ans_t* cla_pP) = 0;
   virtual bool purge_ue(const char* imsi)                                  = 0;
-  virtual void timer_expired(const long timer_idP)                         = 0;
   virtual ~S6aViface(){};
 };
 


### PR DESCRIPTION
Signed-off-by: Tariq Al-Khasib <talkhasib@fb.com>

## Summary

One in a number of PRs to migrate the last few timers to using ZMQ loop.
This PR migrates S6aFdIface timer to establish peer connection.

## Test Plan

This code is exercised only with OAI s6a integration. Will monitor the OAI CI for pass signal.
Tested with few LTE integtests for sanity