### PR TITLE
[Pipelined]Patch aioeventlet python crash

### DIFF
--- a/lte/gateway/deploy/roles/magma/files/patches/aioeventlet_fd_exception.patch
+++ b/lte/gateway/deploy/roles/magma/files/patches/aioeventlet_fd_exception.patch
@@ -1,0 +1,14 @@
+--- a/aioeventlet.py
++++ b/aioeventlet.py
+@@ -159,7 +159,10 @@ class _Selector(asyncio.selectors._BaseSelectorImpl):
+         self._notified = {}
+         ready = []
+         for fd, events in notified.items():
+-            key = self.get_key(fd)
++            try:
++                key = self.get_key(fd)
++            except KeyError:
++                continue
+             ready.append((key, events & key.events))
+         return ready
+

--- a/lte/gateway/deploy/roles/magma/tasks/main.yml
+++ b/lte/gateway/deploy/roles/magma/tasks/main.yml
@@ -370,7 +370,7 @@
     ifdown gtp_br0
     /etc/init.d/openvswitch-switch  force-reload-kmod
   when: ansible_distribution == "Ubuntu"
- 
+
 - name: Bring up ovs bridge
   shell: ifup -i /etc/network/interfaces.d/gtp {{ item }}
   with_items:
@@ -405,3 +405,15 @@
     src: patches/aioeventlet.py38.patch
     dest: /usr/local/lib/python3.8/dist-packages/aioeventlet.py
   when: ansible_distribution == "Ubuntu"
+
+- name: Patch python aioeventlet lib crash ubuntu
+  patch:
+    src: patches/aioeventlet_fd_exception.patch
+    dest: /usr/local/lib/python3.8/dist-packages/aioeventlet.py
+  when: ansible_distribution == "Ubuntu"
+
+- name: Patch python aioeventlet lib crash debian
+  patch:
+    src: patches/aioeventlet_fd_exception.patch
+    dest: /usr/lib/python3/dist-packages/aioeventlet.py
+  when: ansible_distribution == "Debian"

--- a/third_party/build/patches/aioeventlet/aioeventlet_fd_exception.patch
+++ b/third_party/build/patches/aioeventlet/aioeventlet_fd_exception.patch
@@ -1,0 +1,1 @@
+../../../../lte/gateway/deploy/roles/magma/files/patches/aioeventlet_fd_exception.patch


### PR DESCRIPTION
Signed-off-by: Nick Yurchenko <koolzz@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary

Attempts to gracefully recover from
```
Apr 23 13:42:06 phy-u1 pipelined[3348494]: Traceback (most recent call last):
Apr 23 13:42:06 phy-u1 pipelined[3348494]:   File "/usr/lib/python3.8/runpy.py", line 194, in _run_module_as_main
Apr 23 13:42:06 phy-u1 pipelined[3348494]:     return _run_code(code, main_globals, None,
Apr 23 13:42:06 phy-u1 pipelined[3348494]:   File "/usr/lib/python3.8/runpy.py", line 87, in _run_code
Apr 23 13:42:06 phy-u1 pipelined[3348494]:     exec(code, run_globals)
Apr 23 13:42:06 phy-u1 pipelined[3348494]:   File "/usr/local/lib/python3.8/dist-packages/magma/pipelined/main.py", line 190, in <module>
Apr 23 13:42:06 phy-u1 pipelined[3348494]:     main()
Apr 23 13:42:06 phy-u1 pipelined[3348494]:   File "/usr/local/lib/python3.8/dist-packages/magma/pipelined/main.py", line 174, in main
Apr 23 13:42:06 phy-u1 pipelined[3348494]:     service.run()
Apr 23 13:42:06 phy-u1 pipelined[3348494]:   File "/usr/local/lib/python3.8/dist-packages/magma/common/service.py", line 243, in run
Apr 23 13:42:06 phy-u1 pipelined[3348494]:     self._loop.run_forever()
Apr 23 13:42:06 phy-u1 pipelined[3348494]:   File "/usr/local/lib/python3.8/dist-packages/aioeventlet.py", line 259, in run_forever
Apr 23 13:42:06 phy-u1 pipelined[3348494]:     super(EventLoop, self).run_forever()
Apr 23 13:42:06 phy-u1 pipelined[3348494]:   File "/usr/lib/python3.8/asyncio/base_events.py", line 570, in run_forever
Apr 23 13:42:06 phy-u1 pipelined[3348494]:     self._run_once()
Apr 23 13:42:06 phy-u1 pipelined[3348494]:   File "/usr/lib/python3.8/asyncio/base_events.py", line 1823, in _run_once
Apr 23 13:42:06 phy-u1 pipelined[3348494]:     event_list = self._selector.select(timeout)
Apr 23 13:42:06 phy-u1 pipelined[3348494]:   File "/usr/local/lib/python3.8/dist-packages/aioeventlet.py", line 173, in select
Apr 23 13:42:06 phy-u1 pipelined[3348494]:     events = self._read_events()
Apr 23 13:42:06 phy-u1 pipelined[3348494]:   File "/usr/local/lib/python3.8/dist-packages/aioeventlet.py", line 168, in _read_events
Apr 23 13:42:06 phy-u1 pipelined[3348494]:     key = self.get_key(fd)
Apr 23 13:42:06 phy-u1 pipelined[3348494]:   File "/usr/lib/python3.8/selectors.py", line 192, in get_key
Apr 23 13:42:06 phy-u1 pipelined[3348494]:     raise KeyError("{!r} is not registered".format(fileobj)) from None
Apr 23 13:42:06 phy-u1 pipelined[3348494]: KeyError: '20 is not registered'
Apr 23 13:42:06 phy-u1 pipelined[3348494]: Exception in thread Thread-1:
Apr 23 13:42:06 phy-u1 pipelined[3348494]: Traceback (most recent call last):
Apr 23 13:42:06 phy-u1 pipelined[3348494]:   File "/usr/lib/python3.8/threading.py", line 932, in _bootstrap_inner
Apr 23 13:42:06 phy-u1 pipelined[3348494]:     self.run()
Apr 23 13:42:06 phy-u1 pipelined[3348494]:   File "/usr/local/lib/python3.8/dist-packages/sentry_sdk/integrations/threading.py", line 69, in run
Apr 23 13:42:06 phy-u1 pipelined[3348494]:     reraise(*_capture_exception())
Apr 23 13:42:06 phy-u1 pipelined[3348494]:   File "/usr/local/lib/python3.8/dist-packages/sentry_sdk/_compat.py", line 54, in reraise
Apr 23 13:42:06 phy-u1 pipelined[3348494]:     raise value
Apr 23 13:42:06 phy-u1 pipelined[3348494]:   File "/usr/local/lib/python3.8/dist-packages/sentry_sdk/integrations/threading.py", line 67, in run
Apr 23 13:42:06 phy-u1 pipelined[3348494]:     return old_run_func(self, *a, **kw)
Apr 23 13:42:06 phy-u1 pipelined[3348494]:   File "/usr/lib/python3.8/threading.py", line 870, in run
Apr 23 13:42:06 phy-u1 pipelined[3348494]:     self._target(*self._args, **self._kwargs)
Apr 23 13:42:06 phy-u1 pipelined[3348494]:   File "/usr/local/lib/python3.8/dist-packages/grpc/_server.py", line 875, in _serve
Apr 23 13:42:06 phy-u1 pipelined[3348494]:     if not _process_event_and_continue(state, event):
Apr 23 13:42:06 phy-u1 pipelined[3348494]:   File "/usr/local/lib/python3.8/dist-packages/grpc/_server.py", line 839, in _process_event_and_continue
Apr 23 13:42:06 phy-u1 pipelined[3348494]:     rpc_state, rpc_future = _handle_call(event, state.generic_handlers,
Apr 23 13:42:06 phy-u1 pipelined[3348494]:   File "/usr/local/lib/python3.8/dist-packages/grpc/_server.py", line 749, in _handle_call
Apr 23 13:42:06 phy-u1 pipelined[3348494]:     return _handle_with_method_handler(rpc_event, method_handler,
Apr 23 13:42:06 phy-u1 pipelined[3348494]:   File "/usr/local/lib/python3.8/dist-packages/grpc/_server.py", line 725, in _handle_with_method_handler
Apr 23 13:42:06 phy-u1 pipelined[3348494]:     return state, _handle_unary_unary(rpc_event, state,
Apr 23 13:42:06 phy-u1 pipelined[3348494]:   File "/usr/local/lib/python3.8/dist-packages/grpc/_server.py", line 629, in _handle_unary_unary
Apr 23 13:42:06 phy-u1 pipelined[3348494]:     return thread_pool.submit(_unary_response_in_pool, rpc_event, state,
Apr 23 13:42:06 phy-u1 pipelined[3348494]:   File "/usr/lib/python3.8/concurrent/futures/thread.py", line 181, in submit
Apr 23 13:42:06 phy-u1 pipelined[3348494]:     raise RuntimeError('cannot schedule new futures after '
Apr 23 13:42:06 phy-u1 pipelined[3348494]: RuntimeError: cannot schedule new futures after interpreter shutdown
```
<!-- Enumerate changes you made and why you made them -->

## Test Plan
@ardzoht , @pshelar  is there an easy way to reproduce?

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->

<!--
    Final note

    Please take a moment to read through the Magma project's
    - Contributing conventions: https://docs.magmacore.org/docs/next/contributing/contribute_conventions

    If this is your first time opening a PR, also consider reading
    - Developer onboarding: https://docs.magmacore.org/docs/next/contributing/contribute_onboarding
    - Development workflow: https://docs.magmacore.org/docs/next/contributing/contribute_workflow
-->
