### PR TITLE
[feg] fix dropped test error

### DIFF
--- a/feg/gateway/services/csfb/servicers/encode/ie/encoder_test.go
+++ b/feg/gateway/services/csfb/servicers/encode/ie/encoder_test.go
@@ -21,6 +21,7 @@ import (
 	"magma/feg/gateway/services/csfb/servicers/encode/ie"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestEncodeIMSI(t *testing.T) {
@@ -65,6 +66,7 @@ func TestEncodeMMEName(t *testing.T) {
 		decode.IELengthMMEName,
 		[]byte("mmec01.mmegi0001.mme.EPC.mnc001.mcc001.3gppnetwork.org "),
 	)
+	require.NoError(t, err)
 	// replace the ending space with 0x00
 	expectedEncodedMMEName[len(expectedEncodedMMEName)-1] = byte(0x00)
 


### PR DESCRIPTION
Signed-off-by: Lars Lehtonen <lars.lehtonen@gmail.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary
This fixes a dropped `err` variable in `feg/gateway/services/csfb/servicers/encode/ie`.

## Test Plan

I ran `go test ./...` locally.
