### PR TITLE
[lte][agw] Updating state conversion on SPGW to be aligned with state_converter interface

### DIFF
--- a/lte/gateway/c/oai/include/sgw_context_manager.h
+++ b/lte/gateway/c/oai/include/sgw_context_manager.h
@@ -36,7 +36,6 @@ extern "C" {
 #define INITIAL_SGW_S8_S1U_TEID 0x7FFFFFFF
 void sgw_display_sgw_eps_bearer_context(
     const sgw_eps_bearer_ctxt_t* eps_bearer_ctxt);
-void sgw_display_s11teid2mme(mme_sgw_tunnel_t* mme_sgw_tunnel);
 void sgw_display_s11_bearer_context_information(
     log_proto_t module,
     sgw_eps_bearer_context_information_t* sgw_context_information);
@@ -46,10 +45,8 @@ void sgw_get_new_S11_tunnel_id(teid_t* tunnel_id);
 mme_sgw_tunnel_t* sgw_cm_create_s11_tunnel(
     teid_t remote_teid, teid_t local_teid);
 s_plus_p_gw_eps_bearer_context_information_t*
-sgw_cm_create_bearer_context_information_in_collection(
-    spgw_state_t* spgw_state, teid_t teid, imsi64_t imsi64);
-int sgw_cm_remove_bearer_context_information(
-    spgw_state_t* state, teid_t teid, imsi64_t imsi64);
+sgw_cm_create_bearer_context_information_in_collection(teid_t teid);
+int sgw_cm_remove_bearer_context_information(teid_t teid, imsi64_t imsi64);
 sgw_eps_bearer_ctxt_t* sgw_cm_create_eps_bearer_ctxt_in_collection(
     sgw_pdn_connection_t* const sgw_pdn_connection, const ebi_t eps_bearer_idP);
 sgw_eps_bearer_ctxt_t* sgw_cm_insert_eps_bearer_ctxt_in_collection(
@@ -62,11 +59,9 @@ int sgw_cm_remove_eps_bearer_entry(
 // Returns SPGW state pointer for given UE indexed by IMSI
 s_plus_p_gw_eps_bearer_context_information_t* sgw_cm_get_spgw_context(
     teid_t teid);
-spgw_ue_context_t* spgw_create_or_get_ue_context(
-    spgw_state_t* spgw_state, imsi64_t imsi64);
+spgw_ue_context_t* spgw_create_or_get_ue_context(imsi64_t imsi64);
 
-int spgw_update_teid_in_ue_context(
-    spgw_state_t* spgw_state, imsi64_t imsi64, teid_t teid);
+int spgw_update_teid_in_ue_context(imsi64_t imsi64, teid_t teid);
 
 #ifdef __cplusplus
 }

--- a/lte/gateway/c/oai/include/spgw_state.h
+++ b/lte/gateway/c/oai/include/spgw_state.h
@@ -44,6 +44,8 @@ void put_spgw_state(void);
  */
 hash_table_ts_t* get_spgw_ue_state(void);
 
+hash_table_ts_t* get_spgw_teid_state(void);
+
 /**
  * Populates SPGW UE hashtable from db
  * @return response code
@@ -55,7 +57,7 @@ int read_spgw_ue_state_db(void);
  * @param s11_bearer_context_info SPGW ue context pointer
  * @param imsi64
  */
-void put_spgw_ue_state(spgw_state_t* spgw_state, imsi64_t imsi64);
+void put_spgw_ue_state(imsi64_t imsi64);
 
 /**
  * Removes entry for SPGW UE state in db

--- a/lte/gateway/c/oai/include/spgw_types.h
+++ b/lte/gateway/c/oai/include/spgw_types.h
@@ -102,7 +102,6 @@ typedef struct spgw_state_s {
   teid_t tunnel_id;
   uint32_t gtpv1u_teid;
   struct in_addr sgw_ip_address_S1u_S12_S4_up;
-  hash_table_ts_t* imsi_ue_context_htbl;
 } spgw_state_t;
 
 void handle_s5_create_session_response(

--- a/lte/gateway/c/oai/tasks/sgw/pgw_handlers.c
+++ b/lte/gateway/c/oai/tasks/sgw/pgw_handlers.c
@@ -236,8 +236,7 @@ int spgw_handle_nw_initiated_bearer_actv_req(
       "Received Create Bearer Req from PCRF with lbi:%d IMSI\n" IMSI_64_FMT,
       bearer_req_p->lbi, imsi64);
 
-  // TODO: Revisit this if UE context struct manages multiple PDN connections
-  hashtblP = get_spgw_ue_state();
+  hashtblP = get_spgw_teid_state();
   if (!hashtblP) {
     OAILOG_ERROR_UE(
         LOG_SPGW_APP, imsi64,
@@ -344,7 +343,7 @@ int32_t spgw_handle_nw_initiated_bearer_deactv_req(
       "Received nw_initiated_deactv_bearer_req from SPGW service \n");
   print_bearer_ids_helper(bearer_req_p->ebi, bearer_req_p->no_of_bearers);
 
-  hashtblP = get_spgw_ue_state();
+  hashtblP = get_spgw_teid_state();
   if (hashtblP == NULL) {
     OAILOG_ERROR_UE(
         LOG_SPGW_APP, imsi64,

--- a/lte/gateway/c/oai/tasks/sgw/sgw_handlers.c
+++ b/lte/gateway/c/oai/tasks/sgw/sgw_handlers.c
@@ -166,8 +166,8 @@ int sgw_handle_s11_create_session_request(
       session_req_pP->bearer_contexts_to_be_created.bearer_contexts[0]
           .eps_bearer_id);
 
-  if (spgw_update_teid_in_ue_context(
-          state, imsi64, new_endpoint_p->local_teid) == RETURNerror) {
+  if (spgw_update_teid_in_ue_context(imsi64, new_endpoint_p->local_teid) ==
+      RETURNerror) {
     OAILOG_ERROR_UE(
         LOG_SPGW_APP, imsi64,
         "Failed to update sgw_s11_teid" TEID_FMT " in UE context \n",
@@ -176,7 +176,7 @@ int sgw_handle_s11_create_session_request(
   }
   s_plus_p_gw_eps_bearer_ctxt_info_p =
       sgw_cm_create_bearer_context_information_in_collection(
-          state, new_endpoint_p->local_teid, imsi64);
+          new_endpoint_p->local_teid);
   if (s_plus_p_gw_eps_bearer_ctxt_info_p) {
     /*
      * We try to create endpoint for S11 interface. A NULL endpoint means that
@@ -1161,7 +1161,7 @@ int sgw_handle_delete_session_request(
           delete_session_req_pP->lbi);
 
       sgw_cm_remove_bearer_context_information(
-          spgw_state, delete_session_req_pP->teid, imsi64);
+          delete_session_req_pP->teid, imsi64);
       increment_counter("spgw_delete_session", 1, 1, "result", "success");
     }
 
@@ -1417,7 +1417,7 @@ void handle_s5_create_session_response(
            .pdn_connection,
       sgi_create_endpoint_resp.eps_bearer_id);
   sgw_cm_remove_bearer_context_information(
-      state, session_resp.context_teid,
+      session_resp.context_teid,
       new_bearer_ctxt_info_p->sgw_eps_bearer_context_information.imsi64);
 
   OAILOG_FUNC_OUT(LOG_SPGW_APP);
@@ -1752,7 +1752,7 @@ int sgw_handle_nw_initiated_deactv_bearer_rsp(
         &spgw_ctxt->sgw_eps_bearer_context_information.pdn_connection, ebi);
 
     sgw_cm_remove_bearer_context_information(
-        spgw_state, s11_pcrf_ded_bearer_deactv_rsp->s_gw_teid_s11_s4, imsi64);
+        s11_pcrf_ded_bearer_deactv_rsp->s_gw_teid_s11_s4, imsi64);
   } else {
     // Remove the dedicated bearer/s context
     for (i = 0; i < no_of_bearers; i++) {

--- a/lte/gateway/c/oai/tasks/sgw/sgw_task.c
+++ b/lte/gateway/c/oai/tasks/sgw/sgw_task.c
@@ -75,14 +75,12 @@ static int handle_message(zloop_t* loop, zsock_t* reader, void* arg) {
       sgw_handle_s11_create_session_request(
           spgw_state, &received_message_p->ittiMsg.s11_create_session_request,
           imsi64);
-      put_spgw_state();
     } break;
 
     case S11_DELETE_SESSION_REQUEST: {
       sgw_handle_delete_session_request(
           spgw_state, &received_message_p->ittiMsg.s11_delete_session_request,
           imsi64);
-      put_spgw_state();
     } break;
 
     case S11_MODIFY_BEARER_REQUEST: {
@@ -105,7 +103,6 @@ static int handle_message(zloop_t* loop, zsock_t* reader, void* arg) {
       sgw_handle_sgi_endpoint_created(
           spgw_state,
           &received_message_p->ittiMsg.sgi_create_end_point_response, imsi64);
-      put_spgw_state();
     } break;
 
     case SGI_UPDATE_ENDPOINT_RESPONSE: {
@@ -124,14 +121,12 @@ static int handle_message(zloop_t* loop, zsock_t* reader, void* arg) {
       sgw_handle_nw_initiated_deactv_bearer_rsp(
           spgw_state,
           &received_message_p->ittiMsg.s11_nw_init_deactv_bearer_rsp, imsi64);
-      put_spgw_state();
     } break;
 
     case PCEF_CREATE_SESSION_RESPONSE: {
       spgw_handle_pcef_create_session_response(
           spgw_state, &received_message_p->ittiMsg.pcef_create_session_response,
           imsi64);
-      put_spgw_state();
     } break;
 
     case GX_NW_INITIATED_ACTIVATE_BEARER_REQ: {
@@ -177,7 +172,6 @@ static int handle_message(zloop_t* loop, zsock_t* reader, void* arg) {
       int32_t rc = sgw_handle_ip_allocation_rsp(
           spgw_state, &received_message_p->ittiMsg.ip_allocation_response,
           imsi64);
-      put_spgw_state();
       if (rc != RETURNok) {
         OAILOG_ERROR_UE(
             LOG_SPGW_APP, imsi64,
@@ -198,6 +192,7 @@ static int handle_message(zloop_t* loop, zsock_t* reader, void* arg) {
     } break;
   }
 
+  put_spgw_state();
   put_spgw_ue_state(imsi64);
 
   itti_free_msg_content(received_message_p);

--- a/lte/gateway/c/oai/tasks/sgw/sgw_task.c
+++ b/lte/gateway/c/oai/tasks/sgw/sgw_task.c
@@ -75,12 +75,14 @@ static int handle_message(zloop_t* loop, zsock_t* reader, void* arg) {
       sgw_handle_s11_create_session_request(
           spgw_state, &received_message_p->ittiMsg.s11_create_session_request,
           imsi64);
+      put_spgw_state();
     } break;
 
     case S11_DELETE_SESSION_REQUEST: {
       sgw_handle_delete_session_request(
           spgw_state, &received_message_p->ittiMsg.s11_delete_session_request,
           imsi64);
+      put_spgw_state();
     } break;
 
     case S11_MODIFY_BEARER_REQUEST: {
@@ -103,6 +105,7 @@ static int handle_message(zloop_t* loop, zsock_t* reader, void* arg) {
       sgw_handle_sgi_endpoint_created(
           spgw_state,
           &received_message_p->ittiMsg.sgi_create_end_point_response, imsi64);
+      put_spgw_state();
     } break;
 
     case SGI_UPDATE_ENDPOINT_RESPONSE: {
@@ -121,12 +124,14 @@ static int handle_message(zloop_t* loop, zsock_t* reader, void* arg) {
       sgw_handle_nw_initiated_deactv_bearer_rsp(
           spgw_state,
           &received_message_p->ittiMsg.s11_nw_init_deactv_bearer_rsp, imsi64);
+      put_spgw_state();
     } break;
 
     case PCEF_CREATE_SESSION_RESPONSE: {
       spgw_handle_pcef_create_session_response(
           spgw_state, &received_message_p->ittiMsg.pcef_create_session_response,
           imsi64);
+      put_spgw_state();
     } break;
 
     case GX_NW_INITIATED_ACTIVATE_BEARER_REQ: {
@@ -172,6 +177,7 @@ static int handle_message(zloop_t* loop, zsock_t* reader, void* arg) {
       int32_t rc = sgw_handle_ip_allocation_rsp(
           spgw_state, &received_message_p->ittiMsg.ip_allocation_response,
           imsi64);
+      put_spgw_state();
       if (rc != RETURNok) {
         OAILOG_ERROR_UE(
             LOG_SPGW_APP, imsi64,
@@ -192,8 +198,7 @@ static int handle_message(zloop_t* loop, zsock_t* reader, void* arg) {
     } break;
   }
 
-  put_spgw_state();
-  put_spgw_ue_state(spgw_state, imsi64);
+  put_spgw_ue_state(imsi64);
 
   itti_free_msg_content(received_message_p);
   free(received_message_p);

--- a/lte/gateway/c/oai/tasks/sgw/spgw_state.cpp
+++ b/lte/gateway/c/oai/tasks/sgw/spgw_state.cpp
@@ -43,8 +43,13 @@ spgw_state_t* get_spgw_state(bool read_from_db) {
 
 hash_table_ts_t* get_spgw_ue_state() {
   OAILOG_DEBUG(
-      LOG_SPGW_APP, "get_spgw_ue_state called by thread id %u", pthread_self());
+      LOG_SPGW_APP, "get_spgw_ue_state called by thread id %lu",
+      pthread_self());
   return SpgwStateManager::getInstance().get_ue_state_ht();
+}
+
+hash_table_ts_t* get_spgw_teid_state() {
+  return SpgwStateManager::getInstance().get_state_teid_ht();
 }
 
 int read_spgw_ue_state_db() {
@@ -59,12 +64,12 @@ void put_spgw_state() {
   SpgwStateManager::getInstance().write_state_to_db();
 }
 
-void put_spgw_ue_state(spgw_state_t* spgw_state, imsi64_t imsi64) {
+void put_spgw_ue_state(imsi64_t imsi64) {
   if (SpgwStateManager::getInstance().is_persist_state_enabled()) {
-    spgw_ue_context_t* ue_context_p = NULL;
+    spgw_ue_context_t* ue_context_p = nullptr;
+    hash_table_ts_t* spgw_ue_state  = get_spgw_ue_state();
     hashtable_ts_get(
-        spgw_state->imsi_ue_context_htbl, (const hash_key_t) imsi64,
-        (void**) &ue_context_p);
+        spgw_ue_state, (const hash_key_t) imsi64, (void**) &ue_context_p);
     if (ue_context_p) {
       auto imsi_str = SpgwStateManager::getInstance().get_imsi_str(imsi64);
       SpgwStateManager::getInstance().write_ue_state_to_db(
@@ -128,7 +133,7 @@ void pgw_free_pcc_rule(void** rule) {
 void sgw_free_ue_context(spgw_ue_context_t** ue_context_p) {
   if (*ue_context_p) {
     sgw_s11_teid_t* p1 = LIST_FIRST(&(*ue_context_p)->sgw_s11_teid_list);
-    sgw_s11_teid_t* p2 = NULL;
+    sgw_s11_teid_t* p2 = nullptr;
     while (p1) {
       p2 = LIST_NEXT(p1, entries);
       LIST_REMOVE(p1, entries);

--- a/lte/gateway/c/oai/tasks/sgw/spgw_state_converter.cpp
+++ b/lte/gateway/c/oai/tasks/sgw/spgw_state_converter.cpp
@@ -15,12 +15,12 @@
  *      contact@openairinterface.org
  */
 
+#include "spgw_state_converter.h"
+
 extern "C" {
 #include "dynamic_memory_check.h"
 #include "sgw_context_manager.h"
 }
-
-#include "spgw_state_converter.h"
 
 using magma::lte::oai::CreateSessionMessage;
 using magma::lte::oai::GTPV1uData;
@@ -236,7 +236,7 @@ void SpgwStateConverter::proto_to_sgw_pdn_connection(
   bstring_to_ip_address(ip_addr_bstr, &state_pdn->p_gw_address_in_use_up);
   bdestroy_wrapper(&ip_addr_bstr);
 
-  for (uint32_t i = 0; i < BEARERS_PER_UE; i++) {
+  for (int i = 0; i < BEARERS_PER_UE; i++) {
     if (proto.eps_bearer_list(i).eps_bearer_id()) {
       auto* eps_bearer_entry =
           (sgw_eps_bearer_ctxt_t*) calloc(1, sizeof(sgw_eps_bearer_ctxt_t));
@@ -322,8 +322,7 @@ void SpgwStateConverter::sgw_create_session_message_to_proto(
   proto->mutable_ue_time_zone()->set_daylight_saving_time(
       session_request->ue_time_zone.daylight_saving_time);
 
-  for (uint32_t i = 0; i < session_request->pco.num_protocol_or_container_id;
-       i++) {
+  for (int i = 0; i < session_request->pco.num_protocol_or_container_id; i++) {
     auto* pco_protocol = &session_request->pco.protocol_or_container_ids[i];
     auto* pco_protocol_proto = proto->mutable_pco()->add_pco_protocol();
     if (pco_protocol->contents) {
@@ -333,7 +332,7 @@ void SpgwStateConverter::sgw_create_session_message_to_proto(
           pco_protocol->contents, pco_protocol_proto->mutable_contents());
     }
   }
-  for (uint32_t i = 0;
+  for (int i = 0;
        i < session_request->bearer_contexts_to_be_created.num_bearer_context;
        i++) {
     auto* bearer =
@@ -429,7 +428,7 @@ void SpgwStateConverter::proto_to_sgw_create_session_message(
   session_request->ue_time_zone.daylight_saving_time =
       proto.ue_time_zone().daylight_saving_time();
 
-  for (uint32_t i = 0; i < proto.pco().pco_protocol_size(); i++) {
+  for (int i = 0; i < proto.pco().pco_protocol_size(); i++) {
     auto* protocol_or_container_id =
         &session_request->pco.protocol_or_container_ids[i];
     auto protocol_proto              = proto.pco().pco_protocol(i);
@@ -439,7 +438,7 @@ void SpgwStateConverter::proto_to_sgw_create_session_message(
         bfromcstr(protocol_proto.contents().c_str());
   }
 
-  for (uint32_t i = 0; i < proto.bearer_contexts_to_be_created_size(); i++) {
+  for (int i = 0; i < proto.bearer_contexts_to_be_created_size(); i++) {
     auto* eps_bearer =
         &session_request->bearer_contexts_to_be_created.bearer_contexts[i];
     auto eps_bearer_proto     = proto.bearer_contexts_to_be_created(i);
@@ -551,7 +550,7 @@ void SpgwStateConverter::traffic_flow_template_to_proto(
   // parameters_list member conversion
   tft_proto->mutable_parameters_list()->set_num_parameters(
       tft_state->parameterslist.num_parameters);
-  for (uint32_t i = 0; i < tft_state->parameterslist.num_parameters; i++) {
+  for (int i = 0; i < tft_state->parameterslist.num_parameters; i++) {
     auto* parameter = &tft_state->parameterslist.parameter[i];
     if (parameter->contents) {
       auto* param_proto =
@@ -567,25 +566,25 @@ void SpgwStateConverter::traffic_flow_template_to_proto(
   auto pft_state  = tft_state->packetfilterlist;
   switch (tft_state->tftoperationcode) {
     case TRAFFIC_FLOW_TEMPLATE_OPCODE_DELETE_PACKET_FILTERS_FROM_EXISTING_TFT:
-      for (uint32_t i = 0; i < tft_state->numberofpacketfilters; i++) {
+      for (int i = 0; i < tft_state->numberofpacketfilters; i++) {
         pft_proto->add_delete_packet_filter_identifier(
             pft_state.deletepacketfilter[i].identifier);
       }
       break;
     case TRAFFIC_FLOW_TEMPLATE_OPCODE_CREATE_NEW_TFT:
-      for (uint32_t i = 0; i < tft_state->numberofpacketfilters; i++) {
+      for (int i = 0; i < tft_state->numberofpacketfilters; i++) {
         packet_filter_to_proto(
             &pft_state.createnewtft[i], pft_proto->add_create_new_tft());
       }
       break;
     case TRAFFIC_FLOW_TEMPLATE_OPCODE_ADD_PACKET_FILTER_TO_EXISTING_TFT:
-      for (uint32_t i = 0; i < tft_state->numberofpacketfilters; i++) {
+      for (int i = 0; i < tft_state->numberofpacketfilters; i++) {
         packet_filter_to_proto(
             &pft_state.createnewtft[i], pft_proto->add_add_packet_filter());
       }
       break;
     case TRAFFIC_FLOW_TEMPLATE_OPCODE_REPLACE_PACKET_FILTERS_IN_EXISTING_TFT:
-      for (uint32_t i = 0; i < tft_state->numberofpacketfilters; i++) {
+      for (int i = 0; i < tft_state->numberofpacketfilters; i++) {
         packet_filter_to_proto(
             &pft_state.createnewtft[i], pft_proto->add_replace_packet_filter());
       }
@@ -732,7 +731,7 @@ void SpgwStateConverter::proto_to_packet_filter(
       packet_filter_contents_proto.security_parameter_index();
   packet_filter_contents->flowlabel = packet_filter_contents_proto.flow_label();
 
-  for (uint32_t i = 0; i < TRAFFIC_FLOW_TEMPLATE_IPV4_ADDR_SIZE; i++) {
+  for (int i = 0; i < TRAFFIC_FLOW_TEMPLATE_IPV4_ADDR_SIZE; i++) {
     packet_filter_contents->ipv4remoteaddr[i].addr =
         packet_filter_contents_proto.ipv4_remote_addresses(i).addr();
     packet_filter_contents->ipv4remoteaddr[i].mask =
@@ -880,7 +879,7 @@ void SpgwStateConverter::insert_proc_into_sgw_pending_procedures(
 
 void SpgwStateConverter::ue_to_proto(
     const spgw_ue_context_t* ue_state, oai::SpgwUeContext* ue_proto) {
-  if (ue_state && (!(LIST_EMPTY(&ue_state->sgw_s11_teid_list)))) {
+  if (ue_state && (!LIST_EMPTY(&ue_state->sgw_s11_teid_list))) {
     sgw_s11_teid_t* s11_teid_p = nullptr;
     LIST_FOREACH(s11_teid_p, &ue_state->sgw_s11_teid_list, entries) {
       if (s11_teid_p) {
@@ -897,13 +896,12 @@ void SpgwStateConverter::ue_to_proto(
 void SpgwStateConverter::proto_to_ue(
     const oai::SpgwUeContext& ue_proto, spgw_ue_context_t* ue_context_p) {
   OAILOG_FUNC_IN(LOG_SPGW_APP);
-  spgw_state_t* spgw_state     = nullptr;
-  hash_table_ts_t* state_ue_ht = nullptr;
+  hash_table_ts_t* state_ue_ht   = nullptr;
+  hash_table_ts_t* state_teid_ht = nullptr;
   if (ue_proto.s11_bearer_context_size()) {
-    spgw_state = get_spgw_state(false);
-    if (!spgw_state) {
-      OAILOG_ERROR(
-          LOG_SPGW_APP, "Failed to get spgw_state from get_spgw_state() \n");
+    state_teid_ht = get_spgw_teid_state();
+    if (!state_teid_ht) {
+      OAILOG_ERROR(LOG_SPGW_APP, "Failed to get state_teid_ht \n");
       OAILOG_FUNC_OUT(LOG_SPGW_APP);
     }
 
@@ -912,6 +910,19 @@ void SpgwStateConverter::proto_to_ue(
       OAILOG_ERROR(
           LOG_SPGW_APP,
           "Failed to get state_ue_ht from get_spgw_ue_state() \n");
+      OAILOG_FUNC_OUT(LOG_SPGW_APP);
+    }
+
+    // All s11_bearer_context on this UE context will be of same imsi
+    imsi64_t imsi64 =
+        ue_proto.s11_bearer_context(0).sgw_eps_bearer_context().imsi64();
+    if (ue_context_p) {
+      LIST_INIT(&ue_context_p->sgw_s11_teid_list);
+      hashtable_ts_insert(
+          state_ue_ht, (const hash_key_t) imsi64, (void*) ue_context_p);
+    } else {
+      OAILOG_ERROR_UE(
+          LOG_SPGW_APP, imsi64, "Failed to allocate memory for UE context \n");
       OAILOG_FUNC_OUT(LOG_SPGW_APP);
     }
   } else {
@@ -932,11 +943,11 @@ void SpgwStateConverter::proto_to_ue(
 
     proto_to_spgw_bearer_context(S11BearerContext, spgw_context_p);
     hashtable_ts_insert(
-        state_ue_ht,
+        state_teid_ht,
         spgw_context_p->sgw_eps_bearer_context_information.s_gw_teid_S11_S4,
         (void*) spgw_context_p);
     spgw_update_teid_in_ue_context(
-        spgw_state, spgw_context_p->sgw_eps_bearer_context_information.imsi64,
+        spgw_context_p->sgw_eps_bearer_context_information.imsi64,
         spgw_context_p->sgw_eps_bearer_context_information.s_gw_teid_S11_S4);
   }
   OAILOG_FUNC_OUT(LOG_SPGW_APP);

--- a/lte/gateway/c/oai/tasks/sgw/spgw_state_manager.cpp
+++ b/lte/gateway/c/oai/tasks/sgw/spgw_state_manager.cpp
@@ -53,7 +53,7 @@ void SpgwStateManager::create_state() {
   // Allocating spgw_state_p
   state_cache_p = (spgw_state_t*) calloc(1, sizeof(spgw_state_t));
 
-  bstring b     = bfromcstr(S11_BEARER_CONTEXT_INFO_HT_NAME);
+  bstring b      = bfromcstr(S11_BEARER_CONTEXT_INFO_HT_NAME);
   state_teid_ht_ = hashtable_ts_create(
       SGW_STATE_CONTEXT_HT_MAX_SIZE, nullptr,
       (void (*)(void**)) spgw_free_s11_bearer_context_information, b);

--- a/lte/gateway/c/oai/tasks/sgw/spgw_state_manager.cpp
+++ b/lte/gateway/c/oai/tasks/sgw/spgw_state_manager.cpp
@@ -53,21 +53,20 @@ void SpgwStateManager::create_state() {
   // Allocating spgw_state_p
   state_cache_p = (spgw_state_t*) calloc(1, sizeof(spgw_state_t));
 
-  bstring b   = bfromcstr(S11_BEARER_CONTEXT_INFO_HT_NAME);
-  state_ue_ht = hashtable_ts_create(
+  bstring b     = bfromcstr(S11_BEARER_CONTEXT_INFO_HT_NAME);
+  state_teid_ht_ = hashtable_ts_create(
       SGW_STATE_CONTEXT_HT_MAX_SIZE, nullptr,
       (void (*)(void**)) spgw_free_s11_bearer_context_information, b);
+
+  state_ue_ht = hashtable_ts_create(
+      SGW_STATE_CONTEXT_HT_MAX_SIZE, nullptr,
+      (void (*)(void**)) sgw_free_ue_context, nullptr);
 
   state_cache_p->sgw_ip_address_S1u_S12_S4_up.s_addr =
       config_->sgw_config.ipv4.S1u_S12_S4_up.s_addr;
 
-  // TODO: Refactor GTPv1u_data state
   state_cache_p->gtpv1u_data.sgw_ip_address_for_S1u_S12_S4_up =
       state_cache_p->sgw_ip_address_S1u_S12_S4_up;
-
-  state_cache_p->imsi_ue_context_htbl = hashtable_ts_create(
-      SGW_STATE_CONTEXT_HT_MAX_SIZE, nullptr,
-      (void (*)(void**)) sgw_free_ue_context, nullptr);
 
   // Creating PGW related state structs
   state_cache_p->deactivated_predefined_pcc_rules = hashtable_ts_create(
@@ -99,7 +98,7 @@ void SpgwStateManager::free_state() {
         "hashtable");
   }
 
-  hashtable_ts_destroy(state_cache_p->imsi_ue_context_htbl);
+  hashtable_ts_destroy(state_teid_ht_);
 
   if (state_cache_p->deactivated_predefined_pcc_rules) {
     hashtable_ts_destroy(state_cache_p->deactivated_predefined_pcc_rules);
@@ -123,15 +122,18 @@ int SpgwStateManager::read_ue_state_from_db() {
     }
     OAILOG_DEBUG(log_task, "Reading UE state from db for key %s", key.c_str());
     spgw_ue_context_t* ue_context_p =
-        spgw_create_or_get_ue_context(state_cache_p, get_imsi_from_key(key));
-    if (ue_context_p) {
-      SpgwStateConverter::proto_to_ue(ue_proto, ue_context_p);
-    } else {
-      OAILOG_ERROR(
-          log_task, "Failed to get UE state from db for key %s", key.c_str());
-    }
+        (spgw_ue_context_t*) calloc(1, sizeof(spgw_ue_context_t));
+    SpgwStateConverter::proto_to_ue(ue_proto, ue_context_p);
   }
   return RETURNok;
+}
+
+hash_table_ts_t* SpgwStateManager::get_state_teid_ht() {
+  AssertFatal(
+      is_initialized,
+      "StateManager init() function should be called to initialize state");
+
+  return state_teid_ht_;
 }
 
 }  // namespace lte

--- a/lte/gateway/c/oai/tasks/sgw/spgw_state_manager.h
+++ b/lte/gateway/c/oai/tasks/sgw/spgw_state_manager.h
@@ -70,6 +70,8 @@ class SpgwStateManager : public StateManager<
 
   int read_ue_state_from_db() override;
 
+  hash_table_ts_t* get_state_teid_ht();
+
  private:
   SpgwStateManager();
   ~SpgwStateManager();
@@ -80,6 +82,7 @@ class SpgwStateManager : public StateManager<
    */
   void create_state() override;
 
+  hash_table_ts_t* state_teid_ht_;
   const spgw_config_t* config_;
 };
 


### PR DESCRIPTION
Signed-off-by: Alex Rodriguez <alexrod@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->
- Current usage of SPGW UE state relies on 2 hashtables (`state_imsi_ht` and `state_ue_ht`), the naming for these hashtables is confusing as they are being used for inverse purposes (which is very confusing to read, and in unit testing the interface of the state manager becomes difficult to be aligned with). 
- This PR updates `state_imsi_ht` to `state_teid_ht` (as it's actually keyed by TEID), and `state_ue_ht` is used for IMSI keyed UE context.
- This also updates `spgw_state_converter` to remove unused `spgw_state` in different functions, and uses `spgw_ue_context` as `state_manager` interface defines it.
- Removes dead code used on `sgw_context_manager.c`

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->
- make integ_test
- ensure all sanity testing passes 

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->

<!--
    Final note

    Please take a moment to read through the Magma project's
    - Contributing conventions: https://docs.magmacore.org/docs/next/contributing/contribute_conventions

    If this is your first time opening a PR, also consider reading
    - Developer onboarding: https://docs.magmacore.org/docs/next/contributing/contribute_onboarding
    - Development workflow: https://docs.magmacore.org/docs/next/contributing/contribute_workflow
-->
