### PR TITLE
[NMS] Fix users created without valid 'tabs'

### DIFF
--- a/nms/app/packages/magmalte/package.json
+++ b/nms/app/packages/magmalte/package.json
@@ -33,7 +33,7 @@
     "@fbcnms/magma-api": "^0.1.0",
     "@fbcnms/platform-server": "^0.1.25",
     "@fbcnms/projects": "^0.1.0",
-    "@fbcnms/sequelize-models": "^0.1.6",
+    "@fbcnms/sequelize-models": "^0.1.7",
     "@fbcnms/strings": "^0.1.0",
     "@fbcnms/types": "^0.1.11",
     "@fbcnms/ui": "^0.1.8",

--- a/nms/app/yarn.lock
+++ b/nms/app/yarn.lock
@@ -1525,7 +1525,7 @@
   resolved "https://registry.yarnpkg.com/@fbcnms/projects/-/projects-0.1.0.tgz#7e1d6641e6dbe0f8137560f25c6d89b1d5cd9354"
   integrity sha512-vdP5+Y4XWkdVR3H97NCbZiuMpi2xSelyUFg5AR7vZXWzXLFKVziSQEvvqG442U3PQbuLV15LShfYJhEHDc13fA==
 
-"@fbcnms/sequelize-models@^0.1.1", "@fbcnms/sequelize-models@^0.1.6":
+"@fbcnms/sequelize-models@^0.1.1":
   version "0.1.6"
   resolved "https://registry.yarnpkg.com/@fbcnms/sequelize-models/-/sequelize-models-0.1.6.tgz#4d4278b9c59469f17e7851f514189cff703173ea"
   integrity sha512-xQoF4w+6qo18gwS+kQYo5aCPpSvX9ZYIrAEp4EalQs+X5QkeKeHJs3a5c6SO8/wnMKsOX7Tdo0bg2Oa9Fgdc/w==
@@ -1534,6 +1534,18 @@
     inquirer "^8.0.0"
     mariadb "^2.4.2"
     minimist "^1.2.5"
+    sequelize "^5.8.5"
+
+"@fbcnms/sequelize-models@^0.1.7":
+  version "0.1.7"
+  resolved "https://registry.yarnpkg.com/@fbcnms/sequelize-models/-/sequelize-models-0.1.7.tgz#ac9f2d6e43b3071a8d192d14dd819143b0973531"
+  integrity sha512-UQULNmVFpqovNii6W8B9I/qQSOdb0MEZnz6HVzVnDlMmiK3jvIG2QGs3YJPj6GfKFxbvTBhRFJChlRx5kVcSRA==
+  dependencies:
+    "@fbcnms/babel-register" "^0.1.0"
+    inquirer "^8.0.0"
+    mariadb "^2.4.2"
+    minimist "^1.2.5"
+    pg "^8.6.0"
     sequelize "^5.8.5"
 
 "@fbcnms/strings@^0.1.0":
@@ -10689,6 +10701,11 @@ pg-connection-string@^2.4.0:
   resolved "https://registry.yarnpkg.com/pg-connection-string/-/pg-connection-string-2.4.0.tgz#c979922eb47832999a204da5dbe1ebf2341b6a10"
   integrity sha512-3iBXuv7XKvxeMrIgym7njT+HlZkwZqqGX4Bu9cci8xHZNT+Um1gWKqCsAzcC0d95rcKMU5WBg6YRUcHyV0HZKQ==
 
+pg-connection-string@^2.5.0:
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/pg-connection-string/-/pg-connection-string-2.5.0.tgz#538cadd0f7e603fc09a12590f3b8a452c2c0cf34"
+  integrity sha512-r5o/V/ORTA6TmUnyWZR9nCj1klXCO2CEKNRlVuJptZe85QuhFayC7WeMic7ndayT5IRIR0S0xFxFi2ousartlQ==
+
 pg-int8@1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/pg-int8/-/pg-int8-1.0.1.tgz#943bd463bf5b71b4170115f80f8efc9a0c0eb78c"
@@ -10699,10 +10716,20 @@ pg-pool@^3.2.2:
   resolved "https://registry.yarnpkg.com/pg-pool/-/pg-pool-3.2.2.tgz#a560e433443ed4ad946b84d774b3f22452694dff"
   integrity sha512-ORJoFxAlmmros8igi608iVEbQNNZlp89diFVx6yV5v+ehmpMY9sK6QgpmgoXbmkNaBAx8cOOZh9g80kJv1ooyA==
 
+pg-pool@^3.3.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/pg-pool/-/pg-pool-3.3.0.tgz#12d5c7f65ea18a6e99ca9811bd18129071e562fc"
+  integrity sha512-0O5huCql8/D6PIRFAlmccjphLYWC+JIzvUhSzXSpGaf+tjTZc4nn+Lr7mLXBbFJfvwbP0ywDv73EiaBsxn7zdg==
+
 pg-protocol@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/pg-protocol/-/pg-protocol-1.4.0.tgz#43a71a92f6fe3ac559952555aa3335c8cb4908be"
   integrity sha512-El+aXWcwG/8wuFICMQjM5ZSAm6OWiJicFdNYo+VY3QP+8vI4SvLIWVe51PppTzMhikUJR+PsyIFKqfdXPz/yxA==
+
+pg-protocol@^1.5.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/pg-protocol/-/pg-protocol-1.5.0.tgz#b5dd452257314565e2d54ab3c132adc46565a6a0"
+  integrity sha512-muRttij7H8TqRNu/DxrAJQITO4Ac7RmX3Klyr/9mJEOBeIpgnF8f9jAfRz5d3XwQZl5qBjF9gLsUtMPJE0vezQ==
 
 pg-types@^2.1.0:
   version "2.2.0"
@@ -10725,6 +10752,19 @@ pg@^8.5.1:
     pg-connection-string "^2.4.0"
     pg-pool "^3.2.2"
     pg-protocol "^1.4.0"
+    pg-types "^2.1.0"
+    pgpass "1.x"
+
+pg@^8.6.0:
+  version "8.6.0"
+  resolved "https://registry.yarnpkg.com/pg/-/pg-8.6.0.tgz#e222296b0b079b280cce106ea991703335487db2"
+  integrity sha512-qNS9u61lqljTDFvmk/N66EeGq3n6Ujzj0FFyNMGQr6XuEv4tgNTXvJQTfJdcvGit5p5/DWPu+wj920hAJFI+QQ==
+  dependencies:
+    buffer-writer "2.0.0"
+    packet-reader "1.0.0"
+    pg-connection-string "^2.5.0"
+    pg-pool "^3.3.0"
+    pg-protocol "^1.5.0"
     pg-types "^2.1.0"
     pgpass "1.x"
 


### PR DESCRIPTION
Signed-off-by: Andrei Lee <andreilee@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary

Fixes a bug where NMS users created without `tabs` specified are given an invalid value of `'[]'` by default, rather than  a valid JSON array of `[]`. This would cause users to be redirected to a non-existant tab URL of `/[`.

<!-- Enumerate changes you made and why you made them -->

## Test Plan

**Before**:
```
nms=# \d "Users"
                                           Table "public.Users"
      Column      |           Type           | Collation | Nullable |               Default
------------------+--------------------------+-----------+----------+-------------------------------------
 id               | integer                  |           | not null | nextval('"Users_id_seq"'::regclass)
 email            | character varying(255)   |           | not null |
 password         | character varying(255)   |           | not null |
 role             | integer                  |           | not null | 0
 createdAt        | timestamp with time zone |           | not null |
 updatedAt        | timestamp with time zone |           | not null |
 networkIDs       | json                     |           | not null | '"[]"'::json
 verificationType | integer                  |           | not null | 0
 organization     | character varying(255)   |           | not null | 'fb-test'::character varying
 readOnly         | boolean                  |           | not null | false
 tabs             | json                     |           |          | '"[]"'::json
Indexes:
    "Users_pkey" PRIMARY KEY, btree (id)
```

**After**:
```
nms=# \d "Users"
                                           Table "public.Users"
      Column      |           Type           | Collation | Nullable |               Default
------------------+--------------------------+-----------+----------+-------------------------------------
 id               | integer                  |           | not null | nextval('"Users_id_seq"'::regclass)
 email            | character varying(255)   |           | not null |
 password         | character varying(255)   |           | not null |
 role             | integer                  |           | not null | 0
 createdAt        | timestamp with time zone |           | not null |
 updatedAt        | timestamp with time zone |           | not null |
 networkIDs       | json                     |           | not null | '"[]"'::json
 verificationType | integer                  |           | not null | 0
 organization     | character varying(255)   |           | not null | 'fb-test'::character varying
 readOnly         | boolean                  |           | not null | false
 tabs             | json                     |           |          | '[]'::json
Indexes:
    "Users_pkey" PRIMARY KEY, btree (id)
```
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->

<!--
    Final note

    Please take a moment to read through the Magma project's
    - Contributing conventions: https://docs.magmacore.org/docs/next/contributing/contribute_conventions

    If this is your first time opening a PR, also consider reading
    - Developer onboarding: https://docs.magmacore.org/docs/next/contributing/contribute_onboarding
    - Development workflow: https://docs.magmacore.org/docs/next/contributing/contribute_workflow
-->
