### PR TITLE
[AGW][UPGRADE] Upgrade Script

### DIFF
--- a/lte/gateway/release/upgrade_magma.sh
+++ b/lte/gateway/release/upgrade_magma.sh
@@ -1,0 +1,34 @@
+WHOAMI=$(whoami)
+MAGMA_VERSION="1.5.0"
+# Default is focal
+OS_VERSION="focal"
+
+echo "Checking if the script has been executed by root user"
+if [ "$WHOAMI" != "root" ]; then
+  echo "You're executing the script as $WHOAMI instead of root.. exiting"
+  exit 1
+fi
+
+while true; do
+    read -p "You're about to upgrade magma to $MAGMA_VERSION, are you sure?(y/n)" yn
+    case $yn in
+        [Yy]* ) break;;
+        [Nn]* ) exit;;
+        * ) echo "Please answer yes or no.";;
+    esac
+done
+
+if grep -q 'Debian' /etc/issue; then
+  OS_VERSION="stretch"
+fi
+
+# We have changed the name too many time we have to wipe all versions
+rm -rf /etc/apt/sources.list.d/*
+
+wget https://artifactory.magmacore.org:443/artifactory/api/gpg/key/public -O /tmp/public
+apt-key add /tmp/public
+
+echo "deb https://artifactory.magmacore.org/artifactory/debian $OS_VERSION-$MAGMA_VERSION main" >> /etc/apt/sources.list.d/magma
+
+apt udpate
+apt install -y magma

--- a/lte/gateway/release/upgrade_magma.sh
+++ b/lte/gateway/release/upgrade_magma.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 WHOAMI=$(whoami)
 MAGMA_VERSION="1.5.0"
 # Default is focal
@@ -28,7 +30,7 @@ rm -rf /etc/apt/sources.list.d/*
 wget https://artifactory.magmacore.org:443/artifactory/api/gpg/key/public -O /tmp/public
 apt-key add /tmp/public
 
-echo "deb https://artifactory.magmacore.org/artifactory/debian $OS_VERSION-$MAGMA_VERSION main" >> /etc/apt/sources.list.d/magma
+echo "deb https://artifactory.magmacore.org/artifactory/debian $OS_VERSION-$MAGMA_VERSION main" >> /etc/apt/sources.list.d/magma.list
 
 apt udpate
 apt install -y magma


### PR DESCRIPTION
Signed-off-by: Timothée Dzik <timdzik@fb.com>

[AGW][UPGRADE] Upgrade Script

## Summary

We have multiple agw already deployed in the field, those are mapping to old registries. 
The old registries had their own file in `/etc/apt/sources.list.d/`, however now with the new registry we only need one `artifactory.magmacore.org` that will host all debian/docker/helm

This script upgrade to latest magma and make sure to remove all mapping to the old registries. 

## Test Plan

Lab testing 