### PR TITLE
[eventd] Add newline to fluentbit conf template to avoid newline strip

### DIFF
--- a/orc8r/gateway/configs/templates/td-agent-bit.conf.template
+++ b/orc8r/gateway/configs/templates/td-agent-bit.conf.template
@@ -145,3 +145,6 @@
 [OUTPUT]
     Name              stdout
     Match_Regex       eventd*
+
+# LEAVE THIS LINE HERE, FLUENT-BIT REQUIRES NEWLINE
+


### PR DESCRIPTION
Signed-off-by: Andrei Lee <andreilee@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary

Adds more newlines to `td-agent-bit.conf.template`, as td-agent-bit requires a linebreak at the end of `td-agent-bit.conf`. When `td-agent-bit.conf` was being generated, a line break was removed from the template file. This change should account for that issue.

<!-- Enumerate changes you made and why you made them -->

## Test Plan

Tested on a development VM AGW to verify that newline characters were being stripped somehow when the conf file was being generated from the template.

```
cat -e td-agent-bit.conf.template
...
[OUTPUT]$
    Name              stdout$
    Match_Regex       eventd*$
root@agw2:/var/opt/magma/tmp#
```

```
cat -e td-agent-bit.conf
...
[OUTPUT]$
    Name              stdout$
    Match_Regex       eventd*root@agw2:/var/opt/magma/tmp#
```

Also verified that enough newline characters were left after the change to `td-agent-bit.conf.template` was made.

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->

<!--
    Final note

    Please take a moment to read through the Magma project's
    - Contributing conventions: https://docs.magmacore.org/docs/next/contributing/contribute_conventions

    If this is your first time opening a PR, also consider reading
    - Developer onboarding: https://docs.magmacore.org/docs/next/contributing/contribute_onboarding
    - Development workflow: https://docs.magmacore.org/docs/next/contributing/contribute_workflow
-->
