### PR TITLE
[5G: MVC][component: agw] AMF Startup Scripts

### DIFF
--- a/lte/gateway/c/oai/include/mme_config.h
+++ b/lte/gateway/c/oai/include/mme_config.h
@@ -392,9 +392,8 @@ int mme_config_find_mnc_length(
     const char mnc_digit1P, const char mnc_digit2P, const char mnc_digit3P);
 
 void mme_config_init(mme_config_t*);
-int mme_config_parse_opt_line(
-    int argc, char* argv[], mme_config_t* mme_config, amf_config_t* amf_config);
-int mme_config_parse_file(mme_config_t*, amf_config_t*);
+int mme_config_parse_opt_line(int argc, char* argv[], mme_config_t* mme_config);
+int mme_config_parse_file(mme_config_t*);
 void mme_config_display(mme_config_t*);
 
 void mme_config_exit(void);

--- a/lte/gateway/c/oai/tasks/amf/amf_config.c
+++ b/lte/gateway/c/oai/tasks/amf/amf_config.c
@@ -10,11 +10,19 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
+#include <libconfig.h>
 #include "log.h"
 #include "3gpp_24.501.h"
 #include "amf_config.h"
 #include "amf_default_values.h"
+#include "mme_config.h"
+#include "TrackingAreaIdentity.h"
+#include "dynamic_memory_check.h"
+#include "assertions.h"
+
+static bool parse_bool(const char* str);
+
+struct amf_config_s amf_config = {.rw_lock = PTHREAD_RWLOCK_INITIALIZER, 0};
 
 /***************************************************************************
 **                                                                        **
@@ -117,7 +125,10 @@ void ngap_config_init(ngap_config_t* ngap_conf) {
 **                                                                        **
 ***************************************************************************/
 void amf_config_init(amf_config_t* config) {
+  memset(config, 0, sizeof(*config));
+
   pthread_rwlock_init(&config->rw_lock, NULL);
+
   config->max_gnbs                       = 2;
   config->max_ues                        = 2;
   config->unauthenticated_imsi_supported = 0;
@@ -141,7 +152,364 @@ void amf_config_init(amf_config_t* config) {
 ***************************************************************************/
 int amf_config_parse_opt_line(
     int argc, char* argv[],
-    amf_config_t* config_pP) {  // This function will be removed in upcoming PR
-  amf_config_init(config_pP);
+    amf_config_t* config_aA) {  // This function will be removed in upcoming PR
+  amf_config_init(config_aA);
   return 0;
+}
+
+/***************************************************************************
+**                                                                        **
+** Name:    amf_config_parse_opt_line()                                   **
+**                                                                        **
+** Description: Invokes amf_config_init() to initialize                   **
+**              default values of AMF                                     **
+**                                                                        **
+**                                                                        **
+***************************************************************************/
+int amf_config_parse_file(amf_config_t* config_aA) {
+  config_t cfg                  = {0};
+  config_setting_t* setting_mme = NULL;
+  config_setting_t* setting     = NULL;
+  config_setting_t* subsetting  = NULL;
+  config_setting_t* sub2setting = NULL;
+  int aint                      = 0;
+  int i = 0, n = 0, stop_index = 0, num = 0;
+  const char* astring      = NULL;
+  const char* tac          = NULL;
+  const char* mcc          = NULL;
+  const char* mnc          = NULL;
+  bool swap                = false;
+  const char* imsi_prefix  = NULL;
+
+  config_init(&cfg);
+
+  if (config_aA->config_file != NULL) {
+    /*
+     * Read the file. If there is an error, report it and exit.
+     */
+    if (!config_read_file(&cfg, bdata(config_aA->config_file))) {
+      OAILOG_CRITICAL(
+          LOG_CONFIG, "Failed to parse AMF configuration file: %s:%d - %s\n",
+          bdata(config_aA->config_file), config_error_line(&cfg),
+          config_error_text(&cfg));
+      config_destroy(&cfg);
+      AssertFatal(
+          1 == 0, "Failed to parse AMF configuration file %s!\n",
+          bdata(config_aA->config_file));
+    }
+  } else {
+    config_destroy(&cfg);
+    AssertFatal(0, "No AMF configuration file provided!\n");
+  }
+
+  setting_mme = config_lookup(&cfg, MME_CONFIG_STRING_MME_CONFIG);
+
+  if (setting_mme != NULL) {
+    // LOGGING setting
+    setting = config_setting_get_member(setting_mme, LOG_CONFIG_STRING_LOGGING);
+
+    if (setting != NULL) {
+      if (config_setting_lookup_string(
+              setting, LOG_CONFIG_STRING_OUTPUT, (const char**) &astring)) {
+        if (astring != NULL) {
+          if (config_aA->log_config.output) {
+            bassigncstr(config_aA->log_config.output, astring);
+          } else {
+            config_aA->log_config.output = bfromcstr(astring);
+          }
+        }
+      }
+
+      if (config_setting_lookup_string(
+              setting, LOG_CONFIG_STRING_OUTPUT_THREAD_SAFE,
+              (const char**) &astring)) {
+        if (astring != NULL) {
+          config_aA->log_config.is_output_thread_safe = parse_bool(astring);
+        }
+      }
+
+      if (config_setting_lookup_string(
+              setting, LOG_CONFIG_STRING_COLOR, (const char**) &astring)) {
+        if (strcasecmp("yes", astring) == 0)
+          config_aA->log_config.color = true;
+        else
+          config_aA->log_config.color = false;
+      }
+
+      if (config_setting_lookup_string(
+              setting, LOG_CONFIG_STRING_SCTP_LOG_LEVEL,
+              (const char**) &astring))
+        config_aA->log_config.sctp_log_level = OAILOG_LEVEL_STR2INT(astring);
+
+      if (config_setting_lookup_string(
+              setting, LOG_CONFIG_STRING_S1AP_LOG_LEVEL,
+              (const char**) &astring))
+        config_aA->log_config.s1ap_log_level = OAILOG_LEVEL_STR2INT(astring);
+
+      if (config_setting_lookup_string(
+              setting, LOG_CONFIG_STRING_NAS_LOG_LEVEL,
+              (const char**) &astring))
+        config_aA->log_config.nas_log_level = OAILOG_LEVEL_STR2INT(astring);
+
+      if (config_setting_lookup_string(
+              setting, LOG_CONFIG_STRING_MME_APP_LOG_LEVEL,
+              (const char**) &astring))
+        config_aA->log_config.amf_app_log_level = OAILOG_LEVEL_STR2INT(astring);
+
+      if (config_setting_lookup_string(
+              setting, LOG_CONFIG_STRING_SECU_LOG_LEVEL,
+              (const char**) &astring))
+        config_aA->log_config.secu_log_level = OAILOG_LEVEL_STR2INT(astring);
+
+      if (config_setting_lookup_string(
+              setting, LOG_CONFIG_STRING_UDP_LOG_LEVEL,
+              (const char**) &astring))
+        config_aA->log_config.udp_log_level = OAILOG_LEVEL_STR2INT(astring);
+
+      if (config_setting_lookup_string(
+              setting, LOG_CONFIG_STRING_UTIL_LOG_LEVEL,
+              (const char**) &astring))
+        config_aA->log_config.util_log_level = OAILOG_LEVEL_STR2INT(astring);
+
+      if (config_setting_lookup_string(
+              setting, LOG_CONFIG_STRING_ITTI_LOG_LEVEL,
+              (const char**) &astring))
+        config_aA->log_config.itti_log_level = OAILOG_LEVEL_STR2INT(astring);
+      if (config_setting_lookup_string(
+              setting, LOG_CONFIG_STRING_GTPV1U_LOG_LEVEL,
+              (const char**) &astring))
+        config_aA->log_config.gtpv1u_log_level = OAILOG_LEVEL_STR2INT(astring);
+
+      if ((config_setting_lookup_string(
+              setting_mme, MME_CONFIG_STRING_ASN1_VERBOSITY,
+              (const char**) &astring))) {
+        if (strcasecmp(astring, MME_CONFIG_STRING_ASN1_VERBOSITY_NONE) == 0)
+          config_aA->log_config.asn1_verbosity_level = 0;
+        else if (
+            strcasecmp(astring, MME_CONFIG_STRING_ASN1_VERBOSITY_ANNOYING) == 0)
+          config_aA->log_config.asn1_verbosity_level = 2;
+        else if (
+            strcasecmp(astring, MME_CONFIG_STRING_ASN1_VERBOSITY_INFO) == 0)
+          config_aA->log_config.asn1_verbosity_level = 1;
+        else
+          config_aA->log_config.asn1_verbosity_level = 0;
+      }
+    }
+
+    // GENERAL AMF SETTINGS
+    if ((config_setting_lookup_string(
+            setting_mme, MME_CONFIG_STRING_REALM, (const char**) &astring))) {
+      config_aA->realm = bfromcstr(astring);
+    }
+
+    if ((config_setting_lookup_string(
+            setting_mme, MME_CONFIG_STRING_FULL_NETWORK_NAME,
+            (const char**) &astring))) {
+      config_aA->full_network_name = bfromcstr(astring);
+    }
+
+    if ((config_setting_lookup_string(
+            setting_mme, MME_CONFIG_STRING_SHORT_NETWORK_NAME,
+            (const char**) &astring))) {
+      config_aA->short_network_name = bfromcstr(astring);
+    }
+
+    if ((config_setting_lookup_int(
+            setting_mme, MME_CONFIG_STRING_DAYLIGHT_SAVING_TIME, &aint))) {
+      config_aA->daylight_saving_time = (uint32_t) aint;
+    }
+
+    if ((config_setting_lookup_string(
+            setting_mme, MME_CONFIG_STRING_PID_DIRECTORY,
+            (const char**) &astring))) {
+      config_aA->pid_dir = bfromcstr(astring);
+    }
+
+    if ((config_setting_lookup_int(
+            setting_mme, MME_CONFIG_STRING_MAXENB, &aint))) {
+      config_aA->max_gnbs = (uint32_t) aint;
+    }
+
+    if ((config_setting_lookup_int(
+            setting_mme, MME_CONFIG_STRING_MAXUE, &aint))) {
+      config_aA->max_ues = (uint32_t) aint;
+    }
+
+    if ((config_setting_lookup_int(
+            setting_mme, MME_CONFIG_STRING_RELATIVE_CAPACITY, &aint))) {
+      config_aA->relative_capacity = (uint8_t) aint;
+    }
+
+    if ((config_setting_lookup_string(
+            setting_mme, MME_CONFIG_STRING_USE_STATELESS,
+            (const char**) &astring))) {
+      config_aA->use_stateless = parse_bool(astring);
+    }
+
+    if ((config_setting_lookup_string(
+            setting_mme, MME_CONFIG_STRING_UNAUTHENTICATED_IMSI_SUPPORTED,
+            (const char**) &astring))) {
+      config_aA->unauthenticated_imsi_supported = parse_bool(astring);
+    }
+
+    // TAI list setting
+    setting =
+        config_setting_get_member(setting_mme, MME_CONFIG_STRING_TAI_LIST);
+    if (setting != NULL) {
+      num = config_setting_length(setting);
+      if (num < MIN_TAI_SUPPORTED) {
+        fprintf(
+            stderr,
+            "ERROR: No TAI is configured.  At least one TAI must be "
+            "configured.\n");
+      }
+
+      if (config_aA->served_tai.nb_tai != num) {
+        if (config_aA->served_tai.plmn_mcc != NULL)
+          free_wrapper((void**) &config_aA->served_tai.plmn_mcc);
+
+        if (config_aA->served_tai.plmn_mnc != NULL)
+          free_wrapper((void**) &config_aA->served_tai.plmn_mnc);
+
+        if (config_aA->served_tai.plmn_mnc_len != NULL)
+          free_wrapper((void**) &config_aA->served_tai.plmn_mnc_len);
+
+        if (config_aA->served_tai.tac != NULL)
+          free_wrapper((void**) &config_aA->served_tai.tac);
+
+        config_aA->served_tai.plmn_mcc =
+            calloc(num, sizeof(*config_aA->served_tai.plmn_mcc));
+        config_aA->served_tai.plmn_mnc =
+            calloc(num, sizeof(*config_aA->served_tai.plmn_mnc));
+        config_aA->served_tai.plmn_mnc_len =
+            calloc(num, sizeof(*config_aA->served_tai.plmn_mnc_len));
+        config_aA->served_tai.tac =
+            calloc(num, sizeof(*config_aA->served_tai.tac));
+      }
+
+      config_aA->served_tai.nb_tai = num;
+
+      for (i = 0; i < num; i++) {
+        sub2setting = config_setting_get_elem(setting, i);
+
+        if (sub2setting != NULL) {
+          if ((config_setting_lookup_string(
+                  sub2setting, MME_CONFIG_STRING_MCC, &mcc))) {
+            config_aA->served_tai.plmn_mcc[i] = (uint16_t) atoi(mcc);
+          }
+
+          if ((config_setting_lookup_string(
+                  sub2setting, MME_CONFIG_STRING_MNC, &mnc))) {
+            config_aA->served_tai.plmn_mnc[i]     = (uint16_t) atoi(mnc);
+            config_aA->served_tai.plmn_mnc_len[i] = strlen(mnc);
+
+            AssertFatal(
+                (config_aA->served_tai.plmn_mnc_len[i] == MIN_MNC_LENGTH) ||
+                    (config_aA->served_tai.plmn_mnc_len[i] == MAX_MNC_LENGTH),
+                "Bad MNC length %u, must be %d or %d",
+                config_aA->served_tai.plmn_mnc_len[i], MIN_MNC_LENGTH,
+                MAX_MNC_LENGTH);
+          }
+
+          if ((config_setting_lookup_string(
+                  sub2setting, MME_CONFIG_STRING_TAC, &tac))) {
+            config_aA->served_tai.tac[i] = (uint16_t) atoi(tac);
+
+            if (!TAC_IS_VALID(config_aA->served_tai.tac[i])) {
+              fprintf(
+                  stderr, "ERROR: Invalid TAC value " TAC_FMT,
+                  config_aA->served_tai.tac[i]);
+            }
+          }
+        }
+      }
+
+      // sort TAI list
+      n = config_aA->served_tai.nb_tai;
+      do {
+        stop_index = 0;
+        for (i = 1; i < n; i++) {
+          swap = false;
+          if (config_aA->served_tai.plmn_mcc[i - 1] >
+              config_aA->served_tai.plmn_mcc[i]) {
+            swap = true;
+          } else if (
+              config_aA->served_tai.plmn_mcc[i - 1] ==
+              config_aA->served_tai.plmn_mcc[i]) {
+            if (config_aA->served_tai.plmn_mnc[i - 1] >
+                config_aA->served_tai.plmn_mnc[i]) {
+              swap = true;
+            } else if (
+                config_aA->served_tai.plmn_mnc[i - 1] ==
+                config_aA->served_tai.plmn_mnc[i]) {
+              if (config_aA->served_tai.tac[i - 1] >
+                  config_aA->served_tai.tac[i]) {
+                swap = true;
+              }
+            }
+          }
+          if (true == swap) {
+            uint16_t swap16;
+            swap16 = config_aA->served_tai.plmn_mcc[i - 1];
+            config_aA->served_tai.plmn_mcc[i - 1] =
+                config_aA->served_tai.plmn_mcc[i];
+            config_aA->served_tai.plmn_mcc[i] = swap16;
+
+            swap16 = config_aA->served_tai.plmn_mnc[i - 1];
+            config_aA->served_tai.plmn_mnc[i - 1] =
+                config_aA->served_tai.plmn_mnc[i];
+            config_aA->served_tai.plmn_mnc[i] = swap16;
+
+            swap16                           = config_aA->served_tai.tac[i - 1];
+            config_aA->served_tai.tac[i - 1] = config_aA->served_tai.tac[i];
+            config_aA->served_tai.tac[i]     = swap16;
+
+            stop_index = i;
+          }
+        }
+        n = stop_index;
+      } while (0 != n);
+
+      // helper for determination of list type (global view), we could make
+      // sublists with different types, but keep things simple for now
+      config_aA->served_tai.list_type =
+          TRACKING_AREA_IDENTITY_LIST_TYPE_ONE_PLMN_CONSECUTIVE_TACS;
+      for (i = 1; i < config_aA->served_tai.nb_tai; i++) {
+        if ((config_aA->served_tai.plmn_mcc[i] !=
+             config_aA->served_tai.plmn_mcc[0]) ||
+            (config_aA->served_tai.plmn_mnc[i] !=
+             config_aA->served_tai.plmn_mnc[0])) {
+          config_aA->served_tai.list_type =
+              TRACKING_AREA_IDENTITY_LIST_TYPE_MANY_PLMNS;
+          break;
+        } else if (
+            (config_aA->served_tai.plmn_mcc[i] !=
+             config_aA->served_tai.plmn_mcc[i - 1]) ||
+            (config_aA->served_tai.plmn_mnc[i] !=
+             config_aA->served_tai.plmn_mnc[i - 1])) {
+          config_aA->served_tai.list_type =
+              TRACKING_AREA_IDENTITY_LIST_TYPE_MANY_PLMNS;
+          break;
+        }
+        if (config_aA->served_tai.tac[i] !=
+            (config_aA->served_tai.tac[i - 1] + 1)) {
+          config_aA->served_tai.list_type =
+              TRACKING_AREA_IDENTITY_LIST_TYPE_ONE_PLMN_NON_CONSECUTIVE_TACS;
+        }
+      }
+    }
+  }
+
+  config_destroy(&cfg);
+  return 0;
+}
+
+static bool parse_bool(const char* str) {
+  if (strcasecmp(str, "yes") == 0) return true;
+  if (strcasecmp(str, "true") == 0) return true;
+  if (strcasecmp(str, "no") == 0) return false;
+  if (strcasecmp(str, "false") == 0) return false;
+  if (strcasecmp(str, "") == 0) return false;
+
+  Fatal("Error in config file: got \"%s\" but expected bool\n", str);
 }

--- a/lte/gateway/c/oai/tasks/mme_app/mme_app_embedded_spgw.c
+++ b/lte/gateway/c/oai/tasks/mme_app/mme_app_embedded_spgw.c
@@ -56,6 +56,7 @@ int mme_config_embedded_spgw_parse_opt_line(
 
   mme_config_init(mme_config_p);
   spgw_config_init(spgw_config_p);
+  amf_config_init(amf_config_p);
 
   while ((c = getopt(argc, argv, "c:hi:Ks:v:V")) != -1) {
     switch (c) {
@@ -117,6 +118,10 @@ int mme_config_embedded_spgw_parse_opt_line(
     mme_config_p->config_file = bfromcstr("/usr/local/etc/oai/mme.conf");
   }
 
+  if (!amf_config_p->config_file) {
+    amf_config_p->config_file = mme_config_p->config_file;
+  }
+
   if (!spgw_config_p->config_file) {
     spgw_config_p->config_file = bfromcstr("/usr/local/etc/oai/spgw.conf");
     spgw_config_p->pgw_config.config_file =
@@ -125,11 +130,15 @@ int mme_config_embedded_spgw_parse_opt_line(
         bfromcstr("/usr/local/etc/oai/spgw.conf");
   }
 
-  if (mme_config_parse_file(mme_config_p, &amf_config) != 0) {
+  if (mme_config_parse_file(mme_config_p) != 0) {
     return RETURNerror;
   }
 
   if (spgw_config_parse_file(spgw_config_p) != 0) {
+    return RETURNerror;
+  }
+
+  if (amf_config_parse_file(amf_config_p) != 0) {
     return RETURNerror;
   }
 

--- a/lte/gateway/c/oai/tasks/ngap/ngap_amf.c
+++ b/lte/gateway/c/oai/tasks/ngap/ngap_amf.c
@@ -50,7 +50,6 @@
 #include "timer_messages_types.h"
 #include "ngap_amf.h"
 
-amf_config_t amf_config;
 task_zmq_ctx_t ngap_task_zmq_ctx;
 
 static int ngap_send_init_sctp(void) {
@@ -206,19 +205,6 @@ static void* ngap_amf_thread(__attribute__((unused)) void* args) {
 int ngap_amf_init(const amf_config_t* amf_config_p) {
   OAILOG_DEBUG(LOG_NGAP, "Initializing NGAP interface\n");
   amf_config_t* config = amf_config_p;
-
-  memset(config, 0, sizeof(*config));
-
-  pthread_rwlock_init(&config->rw_lock, NULL);
-
-  config->config_file                    = NULL;
-  config->max_gnbs                       = 2;
-  config->max_ues                        = 2;
-  config->unauthenticated_imsi_supported = 0;
-  config->relative_capacity              = RELATIVE_CAPACITY;
-  config->amf_statistic_timer            = AMF_STATISTIC_TIMER_S;
-
-  guamfi_config_init(&config->guamfi);
 
   if (ngap_state_init(
           amf_config_p->max_ues, amf_config_p->max_gnbs,

--- a/lte/gateway/c/oai/tasks/ngap/ngap_amf_encoder.c
+++ b/lte/gateway/c/oai/tasks/ngap/ngap_amf_encoder.c
@@ -70,6 +70,7 @@ int ngap_amf_encode_pdu(
           (int) pdu->present);
       break;
   }
+
   ASN_STRUCT_FREE_CONTENTS_ONLY(asn_DEF_Ngap_NGAP_PDU, pdu);
   return ret;
 }
@@ -99,7 +100,7 @@ static inline int ngap_amf_encode_initiating(
   memset(&res, 0, sizeof(res));
   res = asn_encode_to_new_buffer(
       NULL, ATS_ALIGNED_CANONICAL_PER, &asn_DEF_Ngap_NGAP_PDU, pdu);
-  *buffer = res.buffer;
+  *buffer = (uint8_t*) res.buffer;
   *length = res.result.encoded;
   return 0;
 }
@@ -156,6 +157,7 @@ static inline int ngap_amf_encode_unsuccessfull_outcome(
   memset(&res, 0, sizeof(res));
   res = asn_encode_to_new_buffer(
       NULL, ATS_ALIGNED_CANONICAL_PER, &asn_DEF_Ngap_NGAP_PDU, pdu);
+
   *buffer = res.buffer;
   *length = res.result.encoded;
   return 0;

--- a/lte/gateway/c/oai/tasks/ngap/ngap_amf_handlers.c
+++ b/lte/gateway/c/oai/tasks/ngap/ngap_amf_handlers.c
@@ -270,6 +270,10 @@ int ngap_amf_generate_ng_setup_failure(
   bstring b = blk2bstr(buffer_p, length);
   free(buffer_p);
   rc = ngap_amf_itti_send_sctp_request(&b, assoc_id, 0, INVALID_AMF_UE_NGAP_ID);
+
+  /* Free up the bstring */
+  bdestroy(b);
+
   OAILOG_FUNC_RETURN(LOG_NGAP, rc);
 }
 

--- a/lte/gateway/c/oai/tasks/ngap/ngap_amf_ta.c
+++ b/lte/gateway/c/oai/tasks/ngap/ngap_amf_ta.c
@@ -103,7 +103,7 @@ static int ngap_amf_compare_tac(const Ngap_TAC_t* tac) {
   uint16_t tac_value = 0;
 
   DevAssert(tac != NULL);
-  OCTET_STRING_TO_TAC(tac, tac_value);
+  OCTET_STRING_TO_TAC_5G(tac, tac_value);
   amf_config_read_lock(&amf_config);
 
   for (i = 0; i < amf_config.served_tai.nb_tai; i++) {


### PR DESCRIPTION
Fix Summary
------------
1. Add the code to have a seperate startup
   script for AMF.
2. Fix the issue of NGAPSetup Request TAC
   length
3. bstring memory free.

Test Logs
----------
1. NGAPSetup Request with default  mconfig
2. NGAPSetup Request with modified mconfig
3. Tested with UERANSIM tool

Signed-off-by: YOGESH PANDEY <yogesh@wavelabs.ai>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->

<!--
    Final note

    Please take a moment to read through the Magma project's
    - Contributing conventions: https://docs.magmacore.org/docs/next/contributing/contribute_conventions

    If this is your first time opening a PR, also consider reading
    - Developer onboarding: https://docs.magmacore.org/docs/next/contributing/contribute_onboarding
    - Development workflow: https://docs.magmacore.org/docs/next/contributing/contribute_workflow
-->
