### PR TITLE
[NMS] Add new alarms dashboard to FEG

### DIFF
--- a/nms/app/packages/magmalte/app/components/feg/FEGSections.js
+++ b/nms/app/packages/magmalte/app/components/feg/FEGSections.js
@@ -16,7 +16,7 @@
 import type {SectionsConfigs} from '@fbcnms/magmalte/app/components/layout/Section';
 
 import AlarmIcon from '@material-ui/icons/Alarm';
-import Alarms from '@fbcnms/ui/insights/Alarms/Alarms';
+import AlarmsDashboard from '../../views/alarms/Alarms';
 import CellWifiIcon from '@material-ui/icons/CellWifi';
 import FEGConfigure from './FEGConfigure';
 import FEGGateways from './FEGGateways';
@@ -43,7 +43,7 @@ export function getFEGSections(dashboardV2Enabled: boolean): SectionsConfigs {
       path: 'alerts',
       label: 'Alerts',
       icon: <AlarmIcon />,
-      component: Alarms,
+      component: AlarmsDashboard,
     },
     {
       path: 'metrics',


### PR DESCRIPTION
Signed-off-by: Karthik Subraveti <ksubraveti@fb.com>


## Summary

Found FEG to be still using old alarms dashboard. Updated it.

## Test Plan
![Screen Shot 2021-04-28 at 6 56 45 AM](https://user-images.githubusercontent.com/8224854/116416093-e7ec2500-a7ee-11eb-853e-dc6f680facb9.png)
 
New dashboard
![Screen Shot 2021-04-28 at 6 57 09 AM](https://user-images.githubusercontent.com/8224854/116416143-f4707d80-a7ee-11eb-8598-3d3d193a7297.png)



<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->

<!--
    Final note

    Please take a moment to read through the Magma project's
    - Contributing conventions: https://docs.magmacore.org/docs/next/contributing/contribute_conventions

    If this is your first time opening a PR, also consider reading
    - Developer onboarding: https://docs.magmacore.org/docs/next/contributing/contribute_onboarding
    - Development workflow: https://docs.magmacore.org/docs/next/contributing/contribute_workflow
-->
