### PR TITLE
Fix nil exception in TestGyReAuth

### DIFF
--- a/cwf/gateway/go.sum
+++ b/cwf/gateway/go.sum
@@ -379,12 +379,14 @@ github.com/mailru/easyjson v0.0.0-20190626092158-b2ccc519800e/go.mod h1:C1wdFJiN
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
 github.com/mattn/go-colorable v0.1.2 h1:/bC9yWikZXAL9uJdulbSfyVNIR3n3trXl+v8+1sx8mU=
 github.com/mattn/go-colorable v0.1.2/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=
+github.com/mattn/go-colorable v0.1.8 h1:c1ghPdyEDarC70ftn0y+A/Ee++9zz8ljHG1b13eJ0s8=
 github.com/mattn/go-colorable v0.1.8/go.mod h1:u6P/XSegPjTcexA+o6vUJrdnUu04hMope9wVRipJSqc=
 github.com/mattn/go-isatty v0.0.3/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNxMWT7Zi4=
 github.com/mattn/go-isatty v0.0.4/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNxMWT7Zi4=
 github.com/mattn/go-isatty v0.0.8/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hdxcsrc5s=
 github.com/mattn/go-isatty v0.0.9 h1:d5US/mDsogSGW37IV293h//ZFaeajb69h+EHFsv2xGg=
 github.com/mattn/go-isatty v0.0.9/go.mod h1:YNRxwqDuOph6SZLI9vUUz6OYw3QyUt7WiY2yME+cCiQ=
+github.com/mattn/go-isatty v0.0.12 h1:wuysRhFDzyxgEmMf5xjvJ2M9dZoWAXNNr5LSBS7uHXY=
 github.com/mattn/go-isatty v0.0.12/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Kysco4FUpU=
 github.com/mattn/go-runewidth v0.0.4/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=
 github.com/mattn/go-sqlite3 v1.11.0 h1:LDdKkqtYlom37fkvqs8rMPFKAMe8+SgjbwZ6ex1/A/Q=
@@ -623,6 +625,7 @@ golang.org/x/crypto v0.0.0-20200510223506-06a226fb4e37/go.mod h1:LzIPMQfyMNhhGPh
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20201016220609-9e8e0b390897 h1:pLI5jrR7OSLijeIDcmRxNmw2api+jEfxLoykJVice/E=
 golang.org/x/crypto v0.0.0-20201016220609-9e8e0b390897/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
+golang.org/x/crypto v0.0.0-20210421170649-83a5a9bb288b h1:7mWr3k41Qtv8XlltBkDkl8LoP3mpSgBW8BUoxtEdbXg=
 golang.org/x/crypto v0.0.0-20210421170649-83a5a9bb288b/go.mod h1:T9bdIzuCu7OtxOm1hfPfRQxPLYneinmdGuTeoZ9dtd4=
 golang.org/x/exp v0.0.0-20180321215751-8460e604b9de/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
@@ -666,6 +669,7 @@ golang.org/x/net v0.0.0-20201006153459-a7d1128ccaa0/go.mod h1:sp8m0HH+o8qH0wwXwY
 golang.org/x/net v0.0.0-20201021035429-f5854403a974/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/net v0.0.0-20201110031124-69a78807bb2b h1:uwuIcX0g4Yl1NC5XAz37xsr2lTtcqevgzYNVt49waME=
 golang.org/x/net v0.0.0-20201110031124-69a78807bb2b/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
+golang.org/x/net v0.0.0-20210226172049-e18ecbb05110 h1:qWPm9rbaAMKs8Bq/9LRpbMqxWRVUAQwMI9fVrssnTfw=
 golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
@@ -719,6 +723,7 @@ golang.org/x/sys v0.0.0-20201018230417-eeed37f84f13 h1:5jaG59Zhd+8ZXe8C+lgiAGqkO
 golang.org/x/sys v0.0.0-20201018230417-eeed37f84f13/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210119212857-b64e53b001e4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210426080607-c94f62235c83 h1:kHSDPqCtsHZOg0nVylfTo20DDhE9gG4Y0jn7hKQ0QAM=
 golang.org/x/sys v0.0.0-20210426080607-c94f62235c83/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210422114643-f5beecf764ed/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=

--- a/cwf/gateway/integ_tests/assertions.go
+++ b/cwf/gateway/integ_tests/assertions.go
@@ -33,8 +33,8 @@ func (tr *TestRunner) AuthenticateAndAssertSuccess(imsi string) {
 	assert.NoError(tr.t, err)
 
 	eapMessage := radiusP.Attributes.Get(rfc2869.EAPMessage_Type)
-	assert.NotNil(tr.t, eapMessage, fmt.Sprintf("EAP Message from authentication is nil"))
-	assert.True(tr.t, reflect.DeepEqual(int(eapMessage[0]), eap.SuccessCode), fmt.Sprintf("UE Authentication did not return success"))
+	assert.NotNil(tr.t, eapMessage, "EAP Message from authentication is nil")
+	assert.True(tr.t, reflect.DeepEqual(int(eapMessage[0]), eap.SuccessCode), "UE Authentication did not return success")
 }
 
 // Trigger a UE Authentication with the IMSI and called station ID.
@@ -44,8 +44,8 @@ func (tr *TestRunner) AuthenticateWithCalledIDAndAssertSuccess(imsi, calledStati
 	assert.NoError(tr.t, err)
 
 	eapMessage := radiusP.Attributes.Get(rfc2869.EAPMessage_Type)
-	assert.NotNil(tr.t, eapMessage, fmt.Sprintf("EAP Message from authentication is nil"))
-	assert.True(tr.t, reflect.DeepEqual(int(eapMessage[0]), eap.SuccessCode), fmt.Sprintf("UE Authentication did not return success"))
+	assert.NotNil(tr.t, eapMessage, "EAP Message from authentication is nil")
+	assert.True(tr.t, reflect.DeepEqual(int(eapMessage[0]), eap.SuccessCode), "UE Authentication did not return success")
 }
 
 // AuthenticateAndAssertSuccessWithRetries triggers a UE Authentication with the IMSI. Assert that the authentication
@@ -71,7 +71,7 @@ func (tr *TestRunner) AuthenticateAndAssertSuccessWithRetries(imsi string, maxRe
 				time.Sleep(1 * time.Second)
 				continue
 			}
-			if eapMessage == nil || reflect.DeepEqual(int(eapMessage[0]), eap.SuccessCode) == false {
+			if eapMessage == nil || !reflect.DeepEqual(int(eapMessage[0]), eap.SuccessCode) {
 				fmt.Printf("...Authentication failed with eap message either nul or not succelful: %+v. Retrying...!\n", eapMessage)
 				time.Sleep(1 * time.Second)
 				continue
@@ -80,8 +80,8 @@ func (tr *TestRunner) AuthenticateAndAssertSuccessWithRetries(imsi string, maxRe
 		break
 	}
 	assert.NoError(tr.t, err)
-	assert.NotNil(tr.t, eapMessage, fmt.Sprintf("EAP Message from authentication is nil"))
-	assert.True(tr.t, reflect.DeepEqual(int(eapMessage[0]), eap.SuccessCode), fmt.Sprintf("UE Authentication did not return success"))
+	assert.NotNil(tr.t, eapMessage, "EAP Message from authentication is nil")
+	assert.True(tr.t, reflect.DeepEqual(int(eapMessage[0]), eap.SuccessCode), "UE Authentication did not return success")
 
 }
 

--- a/cwf/gateway/integ_tests/gx_qos_enforcement_test.go
+++ b/cwf/gateway/integ_tests/gx_qos_enforcement_test.go
@@ -402,7 +402,10 @@ func TestGxQosDowngradeWithReAuth(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Eventually(t, tr.WaitForPolicyReAuthToProcess(raa, imsi), time.Minute, 2*time.Second)
 
-	assert.Equal(t, diam.Success, int(raa.ResultCode))
+	assert.NotNil(t, raa)
+	if raa != nil {
+		assert.Equal(t, diam.Success, int(raa.ResultCode))
+	}
 
 	_, err = tr.GenULTraffic(req)
 	assert.NoError(t, err)

--- a/cwf/gateway/integ_tests/gx_reauth_test.go
+++ b/cwf/gateway/integ_tests/gx_reauth_test.go
@@ -112,7 +112,10 @@ func TestGxReAuthWithMidSessionPolicyRemoval(t *testing.T) {
 
 	assert.Eventually(t, tr.WaitForPolicyReAuthToProcess(raa, imsi), time.Minute, 2*time.Second)
 
-	assert.Equal(t, diam.Success, int(raa.ResultCode))
+	assert.NotNil(t, raa)
+	if raa != nil {
+		assert.Equal(t, diam.Success, int(raa.ResultCode))
+	}
 
 	// Check that enforcement flows were deleted for rule 2 and 3
 	tr.WaitForEnforcementStatsToSync()
@@ -181,8 +184,10 @@ func TestGxReAuthWithMidSessionPoliciesRemoval(t *testing.T) {
 	)
 	assert.NoError(t, err)
 	assert.Eventually(t, tr.WaitForPolicyReAuthToProcess(raa, imsi), time.Minute, 2*time.Second)
-	assert.Equal(t, diam.Success, int(raa.ResultCode))
-
+	assert.NotNil(t, raa)
+	if raa != nil {
+		assert.Equal(t, diam.Success, int(raa.ResultCode))
+	}
 	// Check that all UE mac flows are deleted
 	tr.WaitForEnforcementStatsToSync()
 
@@ -268,8 +273,10 @@ func TestGxReAuthWithMidSessionPolicyInstall(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Eventually(t, tr.WaitForPolicyReAuthToProcess(raa, imsi), time.Minute, 2*time.Second)
 
-	assert.Equal(t, diam.Success, int(raa.ResultCode))
-
+	assert.NotNil(t, raa)
+	if raa != nil {
+		assert.Equal(t, diam.Success, int(raa.ResultCode))
+	}
 	// Generate more traffic
 	_, err = tr.GenULTraffic(req)
 	assert.NoError(t, err)
@@ -358,8 +365,10 @@ func TestGxReAuthWithMidSessionPolicyInstallAndRemoval(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Eventually(t, tr.WaitForPolicyReAuthToProcess(raa, imsi), time.Minute, 2*time.Second)
 
-	assert.Equal(t, diam.Success, int(raa.ResultCode))
-
+	assert.NotNil(t, raa)
+	if raa != nil {
+		assert.Equal(t, diam.Success, int(raa.ResultCode))
+	}
 	// Generate more traffic
 	_, err = tr.GenULTraffic(req)
 	assert.NoError(t, err)
@@ -423,8 +432,10 @@ func TestGxReAuthQuotaRefill(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Eventually(t, tr.WaitForPolicyReAuthToProcess(raa, imsi), time.Minute, 2*time.Second)
 
-	assert.Equal(t, diam.Success, int(raa.ResultCode))
-
+	assert.NotNil(t, raa)
+	if raa != nil {
+		assert.Equal(t, diam.Success, int(raa.ResultCode))
+	}
 	// Generate more traffic
 	_, err = tr.GenULTraffic(req)
 	assert.NoError(t, err)

--- a/cwf/gateway/integ_tests/gy_enforcement_test.go
+++ b/cwf/gateway/integ_tests/gy_enforcement_test.go
@@ -463,8 +463,11 @@ func TestGyCreditExhaustionRedirect(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Eventually(t, tr.WaitForChargingReAuthToProcess(raa, imsi), time.Minute, 2*time.Second)
 
-	// Check ReAuth success
-	assert.Equal(t, diam.LimitedSuccess, int(raa.ResultCode))
+	assert.NotNil(t, raa)
+	if raa != nil {
+		// Check ReAuth success
+		assert.Equal(t, diam.LimitedSuccess, int(raa.ResultCode))
+	}
 
 	// Assert that a CCR-I and CCR-U were sent to the OCS
 	tr.AssertAllGyExpectationsMetNoError()
@@ -544,8 +547,11 @@ func TestGyCreditUpdateCommandLevelFail(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Eventually(t, tr.WaitForChargingReAuthToProcess(raa, imsi), time.Minute, 2*time.Second)
 
-	// Check ReAuth success
-	assert.Equal(t, diam.LimitedSuccess, int(raa.ResultCode))
+	assert.NotNil(t, raa)
+	if raa != nil {
+		// Check ReAuth success
+		assert.Equal(t, diam.LimitedSuccess, int(raa.ResultCode))
+	}
 
 	// Wait for a termination to propagate
 	tr.AssertEventuallyAllRulesRemovedAfterDisconnect(imsi)
@@ -733,8 +739,11 @@ func TestGyCreditExhaustionRestrict(t *testing.T) {
 	raa, err := sendChargingReAuthRequest(imsi, 1)
 	assert.NoError(t, err)
 	assert.Eventually(t, tr.WaitForChargingReAuthToProcess(raa, imsi), time.Minute, 2*time.Second)
-	// Check ReAuth success
-	assert.Equal(t, diam.LimitedSuccess, int(raa.ResultCode))
+	assert.NotNil(t, raa)
+	if raa != nil {
+		// Check ReAuth success
+		assert.Equal(t, diam.LimitedSuccess, int(raa.ResultCode))
+	}
 
 	// Assert that a CCR-I and CCR-U were sent to the OCS
 	tr.AssertAllGyExpectationsMetNoError()
@@ -856,8 +865,11 @@ func TestGyCreditTransientErrorRestrict(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Eventually(t, tr.WaitForChargingReAuthToProcess(raa, imsi), time.Minute, 2*time.Second)
 
-	// Check ReAuth success
-	assert.Equal(t, diam.LimitedSuccess, int(raa.ResultCode))
+	assert.NotNil(t, raa)
+	if raa != nil {
+		// Check ReAuth success
+		assert.Equal(t, diam.LimitedSuccess, int(raa.ResultCode))
+	}
 
 	// Assert that a CCR-I and reauth were sent
 	tr.AssertAllGyExpectationsMetNoError()

--- a/cwf/gateway/integ_tests/gy_reauth_test.go
+++ b/cwf/gateway/integ_tests/gy_reauth_test.go
@@ -110,7 +110,10 @@ func TestGyReAuth(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Eventually(t, tr.WaitForChargingReAuthToProcess(raa, imsi), time.Minute, 2*time.Second)
 	// Check ReAuth success
-	assert.Equal(t, diam.LimitedSuccess, int(raa.ResultCode))
+	assert.NotNil(t, raa)
+	if raa != nil {
+		assert.Equal(t, diam.LimitedSuccess, int(raa.ResultCode))
+	}
 
 	// trigger disconnection
 	tr.DisconnectAndAssertSuccess(imsi)

--- a/cwf/gateway/integ_tests/omni_rules_test.go
+++ b/cwf/gateway/integ_tests/omni_rules_test.go
@@ -23,7 +23,6 @@ import (
 	cwfprotos "magma/cwf/cloud/go/protos"
 	"magma/feg/cloud/go/protos"
 	fegprotos "magma/feg/cloud/go/protos"
-	"magma/feg/gateway/diameter"
 	"magma/lte/cloud/go/services/policydb/obsidian/models"
 
 	"github.com/fiorix/go-diameter/v4/diam"
@@ -140,8 +139,10 @@ func TestOmnipresentRules(t *testing.T) {
 	assert.Eventually(t, tr.WaitForPolicyReAuthToProcess(raa, imsi), time.Minute, 2*time.Second)
 
 	// Check ReAuth success
-	assert.Equal(t, int(raa.ResultCode), diameter.SuccessCode)
-
+	assert.NotNil(t, raa)
+	if raa != nil {
+		assert.Equal(t, diam.Success, int(raa.ResultCode))
+	}
 	// trigger disconnection
 	tr.DisconnectAndAssertSuccess(imsi)
 	tr.AssertEventuallyAllRulesRemovedAfterDisconnect(imsi)

--- a/cwf/gateway/integ_tests/rule_manager.go
+++ b/cwf/gateway/integ_tests/rule_manager.go
@@ -145,9 +145,7 @@ func (manager *RuleManager) GetInstalledRulesByIMSI() map[string][]string {
 		if !exists {
 			rules = []string{}
 		}
-		for _, ruleID := range accountRules.StaticRuleNames {
-			rules = append(rules, ruleID)
-		}
+		rules = append(rules, accountRules.StaticRuleNames...)
 		for _, dynamicRule := range accountRules.DynamicRuleDefinitions {
 			rules = append(rules, dynamicRule.RuleName)
 		}
@@ -159,7 +157,7 @@ func (manager *RuleManager) GetInstalledRulesByIMSI() map[string][]string {
 // RemoveInstalledRules removes previously installed rules from PCRF and policyDB
 func (manager *RuleManager) RemoveInstalledRules() error {
 	rulesIDsByIMSI := manager.GetInstalledRulesByIMSI()
-	for imsi, _ := range rulesIDsByIMSI {
+	for imsi := range rulesIDsByIMSI {
 		err := deactivateAllFlowsPerSub(imsi)
 		if err != nil {
 			return err

--- a/cwf/gateway/integ_tests/service_wrappers.go
+++ b/cwf/gateway/integ_tests/service_wrappers.go
@@ -540,7 +540,7 @@ func initializePolicyDBWrapper() (*policyDBWrapper, error) {
 	}
 	redisClientImpl := &object_store.RedisClientImpl{
 		RawClient: redis.NewClient(&redis.Options{
-			Addr:     fmt.Sprintf(address),
+			Addr:     address,
 			Password: "",
 			DB:       0,
 		}),

--- a/cwf/gateway/integ_tests/test_runner.go
+++ b/cwf/gateway/integ_tests/test_runner.go
@@ -249,7 +249,7 @@ func (tr *TestRunner) GenULTraffic(req *cwfprotos.GenTrafficRequest) (*cwfprotos
 // Remove subscribers, rules, flows, and monitors to clean up the state for
 // consecutive test runs
 func (tr *TestRunner) CleanUp() error {
-	for imsi, _ := range tr.imsis {
+	for imsi := range tr.imsis {
 		err := deleteSubscribersFromHSS(imsi)
 		if err != nil {
 			return err
@@ -483,7 +483,7 @@ func makeSubscriber(imsi string, key []byte, opc []byte, seq uint64) *lteprotos.
 			Msisdn:              defaultMSISDN,
 			Non_3GppIpAccess:    lteprotos.Non3GPPUserProfile_NON_3GPP_SUBSCRIPTION_ALLOWED,
 			Non_3GppIpAccessApn: lteprotos.Non3GPPUserProfile_NON_3GPP_APNS_ENABLE,
-			ApnConfig:           []*lteprotos.APNConfiguration{&lteprotos.APNConfiguration{}},
+			ApnConfig:           []*lteprotos.APNConfiguration{{}},
 		},
 	}
 }


### PR DESCRIPTION
Signed-off-by: Marie Bremner <marwhal@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary
Seeing that the reauth test gets a nil exception when the reauth response is never received. (https://app.circleci.com/pipelines/github/magma/magma/20924/workflows/b812ebf9-baac-4e40-9066-1ff403b7f787/jobs/217185/tests#failed-test-0)
This leads to an ugly test output, so adding a check to only assert on the value if raa is not nil. (The test will still fail if it is nil)

Additionally, the re-run logic doesn't get applied when there is an exception as well.
```
ERROR rerun aborted because previous run had a suspected panic and some test may not have run
```

I also fixed the golanglint issues seen in the integration tests directory
```
root@docker-desktop:/magma/cwf/gateway/integ_tests# golangci-lint run
rule_manager.go:162: File is not `gofmt`-ed with `-s` (gofmt)
	for imsi, _ := range rulesIDsByIMSI {
test_runner.go:252: File is not `gofmt`-ed with `-s` (gofmt)
	for imsi, _ := range tr.imsis {
assertions.go:36:34: S1039: unnecessary use of fmt.Sprintf (gosimple)
	assert.NotNil(tr.t, eapMessage, fmt.Sprintf("EAP Message from authentication is nil"))
	                                ^
assertions.go:37:76: S1039: unnecessary use of fmt.Sprintf (gosimple)
	assert.True(tr.t, reflect.DeepEqual(int(eapMessage[0]), eap.SuccessCode), fmt.Sprintf("UE Authentication did not return success"))
	                                                                          ^
assertions.go:47:34: S1039: unnecessary use of fmt.Sprintf (gosimple)
	assert.NotNil(tr.t, eapMessage, fmt.Sprintf("EAP Message from authentication is nil"))
	                                ^
assertions.go:74:28: S1002: should omit comparison to bool constant, can be simplified to `!reflect.DeepEqual(int(eapMessage[0]), eap.SuccessCode)` (gosimple)
			if eapMessage == nil || reflect.DeepEqual(int(eapMessage[0]), eap.SuccessCode) == false {
			                        ^
rule_manager.go:148:3: S1011: should replace loop with `rules = append(rules, accountRules.StaticRuleNames...)` (gosimple)
		for _, ruleID := range accountRules.StaticRuleNames {
		^
service_wrappers.go:543:14: SA1006: printf-style function with dynamic format string and no further arguments should use print-style function instead (staticcheck)
			Addr:     fmt.Sprintf(address),
			          ^
root@docker-desktop:/magma/cwf/gateway/integ_tests#
```
<!-- Enumerate changes you made and why you made them -->

## Test Plan
CWF integration test 
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->

<!--
    Final note

    Please take a moment to read through the Magma project's
    - Contributing conventions: https://docs.magmacore.org/docs/next/contributing/contribute_conventions

    If this is your first time opening a PR, also consider reading
    - Developer onboarding: https://docs.magmacore.org/docs/next/contributing/contribute_onboarding
    - Development workflow: https://docs.magmacore.org/docs/next/contributing/contribute_workflow
-->
