### PR TITLE
[NMS] Add date, url and ip address to audit logs and add missing paths

### DIFF
--- a/nms/app/packages/magmalte/app/components/admin/AuditLog.js
+++ b/nms/app/packages/magmalte/app/components/admin/AuditLog.js
@@ -37,6 +37,9 @@ const useStyles = makeStyles(theme => ({
 
 export type AuditLogRowType = {
   id: string,
+  updatedAt: Date,
+  ipAddress: string,
+  url: string,
   actingUserEmail: string,
   mutationType: string,
   objectType: string,
@@ -76,6 +79,8 @@ function AuditLog() {
           <ActionTable
             data={response.data}
             columns={[
+              {title: 'Time', field: 'updatedAt', type: 'datetime'},
+              {title: 'IP Address', field: 'ipAddress'},
               {title: 'User', field: 'actingUserEmail'},
               {title: 'Action', field: 'mutationType'},
               {title: 'Object Type', field: 'objectType'},
@@ -128,8 +133,12 @@ type DialogProps = {
  */
 function JsonDialog(props: DialogProps) {
   return (
-    <Dialog open={props.open} onClose={props.onClose} fullWidth={true}>
-      <DialogTitle>Log Entry</DialogTitle>
+    <Dialog
+      open={props.open}
+      onClose={props.onClose}
+      maxWidth="lg"
+      fullWidth={true}>
+      <DialogTitle>{props.row.url}</DialogTitle>
       <DialogContent>
         <ReactJson
           src={props.row.mutationData}

--- a/nms/app/packages/magmalte/server/admin/routes.js
+++ b/nms/app/packages/magmalte/server/admin/routes.js
@@ -28,6 +28,7 @@ router.get(
   '/auditlog/async',
   asyncHandler(async (req: FBCNMSRequest, res: ExpressResponse) => {
     const organization = await req.organization();
+    //$FlowFixMe[incompatible-call]
     const data = await AuditLogEntry.findAll({
       where: {organization: organization.name},
       limit: MAX_AUDITLOG_ROWS,
@@ -50,6 +51,10 @@ router.get(
       mutationData: item.mutationData,
       actingUserId: item.actingUserId,
       actingUserEmail: userMap[item.actingUserId] ?? 'undefined',
+      createdAt: item.createdAt,
+      updatedAt: item.updatedAt,
+      url: item.url,
+      ipAddress: item.ipAddress,
     }));
     res.status(200).send(userLogData);
   }),

--- a/nms/app/packages/magmalte/server/apicontroller/auditLoggingDecorator.js
+++ b/nms/app/packages/magmalte/server/apicontroller/auditLoggingDecorator.js
@@ -56,11 +56,27 @@ const PATHS: Array<{
   },
   {
     path: '/magma/networks/:networkId/subscribers/:objectId',
-    type: 'subscriber',
+    type: 'Subscriber',
+  },
+  {
+    path: '/magma/v1/lte/:networkId/subscribers/:objectId/(.*)',
+    type: 'Subscriber',
   },
   {
     path: '/magma/networks/:networkId/subscribers',
     resolver: (req: FBCNMSRequest) => [req.body.id, 'Subscriber'],
+  },
+  {
+    path: '/magma/networks/:networkId/tracing',
+    type: 'Call Tracing',
+  },
+  {
+    path: '/magma/networks/:networkId/tracing/(.*)',
+    type: 'Call Tracing',
+  },
+  {
+    path: '/magma/networks/:networkId/alerts/(.*)',
+    type: 'Alerts',
   },
   {
     path: '/magma/networks/:networkId/tiers/:objectId',
@@ -103,11 +119,55 @@ const PATHS: Array<{
     resolver: (_, params) => [params[1], 'LTE network'],
   },
   {
+    path: '/magma/v1/lte/:networkId/cellular/(.*)',
+    resolver: (_, params) => [params[2], 'LTE network'],
+  },
+  {
+    path: '/magma/v1/lte/:networkId/apns',
+    resolver: (_, params) => [params[2], 'LTE network'],
+  },
+  {
+    path: '/magma/v1/lte/:networkId/apns/(.*)',
+    resolver: (_, params) => [params[2], 'LTE network'],
+  },
+  {
+    path: '/magma/v1/lte/:networkId/gateway_pools/(.*)',
+    resolver: (_, params) => [params[2], 'LTE network pools'],
+  },
+  {
+    path: '/magma/v1/lte/:networkId/gateway_pools/(.*)',
+    resolver: (_, params) => [params[2], 'LTE network pools'],
+  },
+  {
+    path: '/magma/v1/lte/:networkId/cellular/(.*)',
+    resolver: (_, params) => [params[2], 'LTE network'],
+  },
+  {
+    path: '/magma/v1/lte/:networkId/dns/(.*)',
+    resolver: (_, params) => [params[2], 'LTE network'],
+  },
+  {
+    path: '/magma/v1/lte/:networkId/enodebs',
+    resolver: (_, params) => [params[2], 'LTE managed eNodeBs'],
+  },
+  {
+    path: '/magma/v1/lte/:networkId/enodebs/(.*)',
+    resolver: (_, params) => [params[2], 'LTE network'],
+  },
+  {
+    path: '/magma/v1/lte/:networkId/description',
+    resolver: (_, params) => [params[2], 'LTE network'],
+  },
+  {
     path: '/magma/v1/lte/:networkId/gateways',
     resolver: req => [req.body.id, 'LTE gateway'],
   },
   {
     path: '/magma/v1/lte/:networkId/gateways/:objectId',
+    resolver: (_, params) => [params[2], 'LTE gateway'],
+  },
+  {
+    path: '/magma/v1/lte/:networkId/gateways/:objectId/(.*)',
     resolver: (_, params) => [params[2], 'LTE gateway'],
   },
   {
@@ -120,6 +180,10 @@ const PATHS: Array<{
   },
   {
     path: '/magma/v1/lte/:networkId/policy_qos_profiles',
+    resolver: (req: FBCNMSRequest) => [req.body.id, 'Policy qos profiles'],
+  },
+  {
+    path: '/magma/v1/lte/:networkId/policy_qos_profiles/(.*)',
     resolver: (req: FBCNMSRequest) => [req.body.id, 'Policy qos profiles'],
   },
   {


### PR DESCRIPTION
Signed-off-by: Karthik Subraveti <ksubraveti@fb.com>

## Summary
This PR adds date, url and ip address to audit logs and adds missing paths including (subscriber, gateway, alerts, enodeb paths) to audit logs.

## Test Plan
OLD 
<img width="1680" alt="Screen Shot 2021-04-28 at 10 12 31 AM" src="https://user-images.githubusercontent.com/8224854/116445021-3f4bbe80-a80a-11eb-95c3-34459bab6f45.png">

NEW
<img width="1680" alt="Screen Shot 2021-04-28 at 10 11 37 AM" src="https://user-images.githubusercontent.com/8224854/116444915-1fb49600-a80a-11eb-8f86-3a2b667d1090.png">
<img width="1680" alt="Screen Shot 2021-04-28 at 10 11 46 AM" src="https://user-images.githubusercontent.com/8224854/116444940-26430d80-a80a-11eb-9ebe-3d9f63f6f22d.png">



<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->

<!--
    Final note

    Please take a moment to read through the Magma project's
    - Contributing conventions: https://docs.magmacore.org/docs/next/contributing/contribute_conventions

    If this is your first time opening a PR, also consider reading
    - Developer onboarding: https://docs.magmacore.org/docs/next/contributing/contribute_onboarding
    - Development workflow: https://docs.magmacore.org/docs/next/contributing/contribute_workflow
-->
