### PR TITLE
[NMS] Add predefined alert around duplicate attach requests

### DIFF
--- a/nms/app/packages/magmalte/alerts/lteAlerts.js
+++ b/nms/app/packages/magmalte/alerts/lteAlerts.js
@@ -102,6 +102,15 @@ export default function getLteAlerts(
       labels: {severity: 'minor'},
       annotations: {description: 'Alerts when we have UE attach failures'},
     },
+    'High duplicate attach requests': {
+      alert: 'High duplicate attach requests',
+      expr: `increase(duplicate_attach_request{networkID="${networkID}"}[5m]) > 100`,
+      labels: {severity: 'critical'},
+      annotations: {
+        description:
+          'Alert when there are a large number of duplicate attach requests',
+      },
+    },
     'Gateway Checkin Failure': {
       alert: 'Gateway Checkin Failure',
       expr: `checkin_status{networkID=~"${networkID}"} < 1`,


### PR DESCRIPTION
Signed-off-by: Karthik Subraveti <ksubraveti@fb.com>

## Summary
Add predefined alert around high duplicate attach requests

## Test Plan
Was able to sync alerts containing 'High duplicate attach requests' alert
<img width="1680" alt="Screen Shot 2021-04-28 at 10 31 42 AM" src="https://user-images.githubusercontent.com/8224854/116447523-efbac200-a80c-11eb-8e3d-6b71efe0f8ec.png">

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->

<!--
    Final note

    Please take a moment to read through the Magma project's
    - Contributing conventions: https://docs.magmacore.org/docs/next/contributing/contribute_conventions

    If this is your first time opening a PR, also consider reading
    - Developer onboarding: https://docs.magmacore.org/docs/next/contributing/contribute_onboarding
    - Development workflow: https://docs.magmacore.org/docs/next/contributing/contribute_workflow
-->
