### PR TITLE
[lte][agw]Adding state version display for parse state proto

### DIFF
--- a/lte/gateway/python/scripts/state_cli.py
+++ b/lte/gateway/python/scripts/state_cli.py
@@ -29,6 +29,7 @@ from magma.common.redis.client import get_default_client
 from magma.common.redis.serializers import (
     get_json_deserializer,
     get_proto_deserializer,
+    get_proto_version_deserializer,
 )
 from magma.mobilityd.serialize_utils import (
     deserialize_ip_block,
@@ -178,7 +179,10 @@ class StateCLI(object):
         proto = self.STATE_PROTOS.get(key_type.lower())
         if proto:
             deserializer = get_proto_deserializer(proto)
+            version_deserializer = get_proto_version_deserializer()
             print(deserializer(value))
+            print('==================')
+            print('State version: %s' % version_deserializer(value))
         else:
             raise AttributeError('Key not found on redis')
 

--- a/orc8r/gateway/python/magma/common/redis/serializers.py
+++ b/orc8r/gateway/python/magma/common/redis/serializers.py
@@ -104,3 +104,15 @@ def get_json_deserializer() -> Callable[[str], T]:
         return msg
 
     return _deserialize_json
+
+
+def get_proto_version_deserializer() -> Callable[[str], T]:
+    """
+    Return a proto deserializer that takes in a proto type to deserialize
+    the version number stored in the RedisState proto
+    """
+    def _deserialize_version(serialized_rule: str) -> T:
+        proto_wrapper = RedisState()
+        proto_wrapper.ParseFromString(serialized_rule)
+        return proto_wrapper.version
+    return _deserialize_version


### PR DESCRIPTION
Signed-off-by: Alex Rodriguez <ardzoht@gmail.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->
- Adding state proto version to parsing of protobuf state objects on `state_cli`, this should be useful to debug how many times a proto object is written / frequency of updates

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->
```
(python) vagrant@magma-dev:~/magma/lte/gateway$ state_cli.py parse spgw_state
last_tunnel_id: 2
gtpv1u_teid: 2
gtpv1u_data {
}

==================
State version: 2
```

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->

<!--
    Final note

    Please take a moment to read through the Magma project's
    - Contributing conventions: https://docs.magmacore.org/docs/next/contributing/contribute_conventions

    If this is your first time opening a PR, also consider reading
    - Developer onboarding: https://docs.magmacore.org/docs/next/contributing/contribute_onboarding
    - Development workflow: https://docs.magmacore.org/docs/next/contributing/contribute_workflow
-->
