### PR TITLE
[lte][agw] Updating redis_client instance and applying clang lints on state managers

### DIFF
--- a/lte/gateway/c/oai/common/redis_utils/redis_client.h
+++ b/lte/gateway/c/oai/common/redis_utils/redis_client.h
@@ -29,7 +29,7 @@ namespace lte {
 
 class RedisClient {
  public:
-  RedisClient();
+  explicit RedisClient(bool init_connection);
   ~RedisClient() = default;
 
   /**
@@ -68,7 +68,7 @@ class RedisClient {
    * @param proto_msg
    * @param str_to_serialize
    */
-  int serialize(
+  static int serialize(
       const google::protobuf::Message& proto_msg,
       std::string& str_to_serialize);
 
@@ -83,7 +83,7 @@ class RedisClient {
 
   std::vector<std::string> get_keys(const std::string& pattern);
 
-  bool is_connected() { return is_connected_; }
+  bool is_connected() const { return is_connected_; }
 
  private:
   std::unique_ptr<cpp_redis::client> db_client_;
@@ -98,19 +98,11 @@ class RedisClient {
   int read_redis_state(const std::string& key, orc8r::RedisState& state_out);
 
   /**
-   * Check for existence of a key in Redis.
-   * @param key
-   * @throws std::runtime_error if the Redis call fails
-   * @return
-   */
-  bool key_exists(const std::string& key);
-
-  /**
    * Takes a string and parses it to protobuf Message
    * @param proto_msg
    * @param str_to_deserialize
    */
-  int deserialize(
+  static int deserialize(
       google::protobuf::Message& proto_msg,
       const std::string& str_to_deserialize);
 };

--- a/lte/gateway/c/oai/include/state_manager.h
+++ b/lte/gateway/c/oai/include/state_manager.h
@@ -214,14 +214,14 @@ class StateManager {
   StateManager()
       : state_cache_p(nullptr),
         state_ue_ht(nullptr),
-        redis_client(std::make_unique<RedisClient>()),
+        redis_client(nullptr),
         is_initialized(false),
         state_dirty(false),
         persist_state_enabled(false),
-        task_state_hash(0),
-        ue_state_hash(0),
         task_state_version(0),
         ue_state_version(0),
+        task_state_hash(0),
+        ue_state_hash(0),
         log_task(LOG_UTIL) {}
   virtual ~StateManager() = default;
 

--- a/lte/gateway/c/oai/tasks/s1ap/s1ap_state.cpp
+++ b/lte/gateway/c/oai/tasks/s1ap/s1ap_state.cpp
@@ -191,7 +191,7 @@ void remove_ues_without_imsi_from_ue_id_coll() {
   uint32_t num_ues_checked;
 
   // get each eNB in s1ap_state
-  for (uint32_t i = 0; i < ht_keys->num_keys; i++) {
+  for (int i = 0; i < ht_keys->num_keys; i++) {
     enb_description_t* enb_association_p = nullptr;
     ht_rc                                = hashtable_ts_get(
         &s1ap_state_p->enbs, (hash_key_t) ht_keys->keys[i],

--- a/lte/gateway/c/oai/tasks/s1ap/s1ap_state_manager.h
+++ b/lte/gateway/c/oai/tasks/s1ap/s1ap_state_manager.h
@@ -58,9 +58,11 @@ class S1apStateManager
 
   /**
    * Function to initialize member variables
-   * @param mme_config mme_config_t struct
+   * @param max_ues number of max UEs in hashtable
+   * @param max_enbs number of max eNBs in hashtable
+   * @param persist_state should persist state in redis
    */
-  void init(uint32_t max_ues, uint32_t max_enbs, bool use_stateless);
+  void init(uint32_t max_ues, uint32_t max_enbs, bool persist_state);
 
   // Copy constructor and assignment operator are marked as deleted functions
   S1apStateManager(S1apStateManager const&) = delete;
@@ -101,8 +103,8 @@ class S1apStateManager
 
   uint32_t max_ues_;
   uint32_t max_enbs_;
-  s1ap_imsi_map_t* s1ap_imsi_map_;
   std::size_t s1ap_imsi_map_hash_;
+  s1ap_imsi_map_t* s1ap_imsi_map_;
 };
 }  // namespace lte
 }  // namespace magma

--- a/lte/gateway/c/oai/tasks/sgw/spgw_state_manager.cpp
+++ b/lte/gateway/c/oai/tasks/sgw/spgw_state_manager.cpp
@@ -41,6 +41,7 @@ void SpgwStateManager::init(bool persist_state, const spgw_config_t* config) {
   table_key             = SPGW_STATE_TABLE_NAME;
   persist_state_enabled = persist_state;
   config_               = config;
+  redis_client          = std::make_unique<RedisClient>(persist_state);
   create_state();
   if (read_state_from_db() != RETURNok) {
     OAILOG_ERROR(LOG_SPGW_APP, "Failed to read state from redis");
@@ -117,7 +118,7 @@ int SpgwStateManager::read_ue_state_from_db() {
   auto keys = redis_client->get_keys("IMSI*" + task_name + "*");
   for (const auto& key : keys) {
     oai::SpgwUeContext ue_proto = oai::SpgwUeContext();
-    if (redis_client->read_proto(key.c_str(), ue_proto) != RETURNok) {
+    if (redis_client->read_proto(key, ue_proto) != RETURNok) {
       return RETURNerror;
     }
     OAILOG_DEBUG(log_task, "Reading UE state from db for key %s", key.c_str());


### PR DESCRIPTION
Signed-off-by: Alex Rodriguez <ardzoht@gmail.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->
- Currently, redis_client is being initiated as part of StateManager implicit constructor, which makes it hard to unit test the state conversion functions, this PR moves the initialization to the `init` function, and adds `init_connection` flag to control if it should start connection to redis.
- Applying multiple clang lint suggestions on state manager classes

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->
- make integ_test, with `stateless` mode enabled and disabled
- multiple runs of `test_continuous_random_attach` s1ap test

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->

<!--
    Final note

    Please take a moment to read through the Magma project's
    - Contributing conventions: https://docs.magmacore.org/docs/next/contributing/contribute_conventions

    If this is your first time opening a PR, also consider reading
    - Developer onboarding: https://docs.magmacore.org/docs/next/contributing/contribute_onboarding
    - Development workflow: https://docs.magmacore.org/docs/next/contributing/contribute_workflow
-->
