### PR TITLE
[Pylint] Add back health service to pylint test

### DIFF
--- a/lte/gateway/python/magma/health/health_service.py
+++ b/lte/gateway/python/magma/health/health_service.py
@@ -84,7 +84,8 @@ class AGWHealth:
         config = load_service_mconfig_as_json('mme')
 
         # eNB status for #eNBs connected
-        chan = ServiceRegistry.get_rpc_channel('enodebd', ServiceRegistry.LOCAL)
+        chan = ServiceRegistry.get_rpc_channel(
+            'enodebd', ServiceRegistry.LOCAL)
         client = EnodebdStub(chan)
         status = client.GetStatus(Void())
 

--- a/lte/gateway/python/magma/tests/pylint_tests.py
+++ b/lte/gateway/python/magma/tests/pylint_tests.py
@@ -24,8 +24,8 @@ class MagmaPyLintTest(unittest.TestCase):
             self.skipTest(
                 'Pylint not available, probably because this test is running '
                 'under @mode/opt: {}'.format(
-                    pylint_wrapper.PYLINT_IMPORT_PROBLEM
-                )
+                    pylint_wrapper.PYLINT_IMPORT_PROBLEM,
+                ),
             )
 
         py_wrap = pylint_wrapper.PyLintWrapper(
@@ -44,7 +44,7 @@ class MagmaPyLintTest(unittest.TestCase):
         # TODO look up directories in magma/lte/gateway/python/magma
         directories = [
             'enodebd',
-            # 'health',
+            'health',
             # 'mobilityd',
             # 'monitord',
             'pipelined',


### PR DESCRIPTION
Signed-off-by: Marie Bremner <marwhal@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary
Addressed the following pylint error to enable pylint testing for health service
```
======================================================================
FAIL: test_pylint (tests.pylint_tests.MagmaPyLintTest)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/vagrant/magma/lte/gateway/python/magma/tests/pylint_tests.py", line 60, in test_pylint
    py_wrap.assertNoLintErrors(path)
  File "/home/vagrant/magma/lte/gateway/python/magma/tests/pylint_wrapper.py", line 88, in assertNoLintErrors
    raise AssertionError(msg)
AssertionError: PyLint found errors:
************* Module health.state_recovery
W0622: 23, 0: Redefining built-in 'ConnectionError' (redefined-builtin)
W1201: 64, 12: Use lazy % formatting in logging functions (logging-not-lazy)


----------------------------------------------------------------------
Ran 1 test in 20.766s

FAILED (failures=1)
```
<!-- Enumerate changes you made and why you made them -->

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->

<!--
    Final note

    Please take a moment to read through the Magma project's
    - Contributing conventions: https://docs.magmacore.org/docs/next/contributing/contribute_conventions

    If this is your first time opening a PR, also consider reading
    - Developer onboarding: https://docs.magmacore.org/docs/next/contributing/contribute_onboarding
    - Development workflow: https://docs.magmacore.org/docs/next/contributing/contribute_workflow
-->
