### PR TITLE
[Pylint] Add back smsd service to pylint test

### DIFF
--- a/lte/gateway/python/magma/smsd/relay.py
+++ b/lte/gateway/python/magma/smsd/relay.py
@@ -49,15 +49,17 @@ class SmsRelay(Job):
     async def _run(self) -> None:
         if not self._is_enabled():
             # sleep, and don't poll for messages
-            logging.info("mme non_eps_service_config is not SMS_ORC8R, sleeping.")
-            return 
+            logging.info(
+                "mme non_eps_service_config is not SMS_ORC8R, sleeping.",
+            )
+            return
 
         imsis = await self._get_attached_imsis()
         if len(imsis) == 0:
             logging.debug("No active subs")
             return
 
-        logging.info("Checking SMS for %d IMSIs" % len(imsis))
+        logging.info("Checking SMS for %d IMSIs", len(imsis))
         try:
             smsd_resp = await grpc_async_wrapper(
                 self._smsd.GetMessages.future(
@@ -96,19 +98,23 @@ class SmsRelay(Job):
 
     @return_void
     def SMOUplink(self, request: sms_orc8r_pb2.SMOUplinkUnitdata, context):
-        logging.debug("got an uplink: %s: %s",
-                      request.imsi, request.nas_message_container.hex())
+        logging.debug(
+            "got an uplink: %s: %s",
+            request.imsi, request.nas_message_container.hex(),
+        )
 
         if not self._is_enabled():
             # sleep, and don't poll for messages
-            logging.info("mme non_eps_service_config is not SMS_ORC8R, ignoring uplink message.")
-            return 
+            logging.info(
+                "mme non_eps_service_config is not SMS_ORC8R, ignoring uplink message.",
+            )
+            return
 
         try:
             self._smsd.ReportDelivery(
                 sms_orc8r_pb2.ReportDeliveryRequest(
                     report=sms_orc8r_pb2.SMOUplinkUnitdata(
-                        imsi="IMSI"+request.imsi,
+                        imsi="IMSI" + request.imsi,
                         nas_message_container=request.nas_message_container,
                     ),
                 ),
@@ -118,14 +124,14 @@ class SmsRelay(Job):
             context.set_code(grpc.StatusCode.INTERNAL)
             return
 
-    def _is_enabled(self):
-        """ 
-        Returns True if MME's NON_EPS_SERVICE_CONFIG is set to SMS_ORC8R, False
-        otherwise. smsd should only act as a relay when that config paramater
-        is set to SMS_ORC8R (value 3).
+    def _is_enabled(self) -> bool:
+        """Return whether SMS should act as a relay
+
+        SMS_ORC8R has value 3
+        Returns:
+        bool: True if MME's NON_EPS_SERVICE_CONFIG is set to SMS_ORC8R
+        False otherwise
         """
         mme_service_config = load_service_mconfig("mme", MME())
         non_eps_service_control = mme_service_config.non_eps_service_control
-        if non_eps_service_control and non_eps_service_control == 3:
-            return True
-        return False
+        return non_eps_service_control and non_eps_service_control == 3

--- a/lte/gateway/python/magma/tests/pylint_tests.py
+++ b/lte/gateway/python/magma/tests/pylint_tests.py
@@ -24,8 +24,8 @@ class MagmaPyLintTest(unittest.TestCase):
             self.skipTest(
                 'Pylint not available, probably because this test is running '
                 'under @mode/opt: {}'.format(
-                    pylint_wrapper.PYLINT_IMPORT_PROBLEM
-                )
+                    pylint_wrapper.PYLINT_IMPORT_PROBLEM,
+                ),
             )
 
         py_wrap = pylint_wrapper.PyLintWrapper(
@@ -51,7 +51,7 @@ class MagmaPyLintTest(unittest.TestCase):
             # 'pkt_tester',
             'policydb',
             # 'redirectd',
-            # 'smsd',
+            'smsd',
             'subscriberdb',
         ]
         parent_path = os.path.dirname(os.path.dirname(__file__))


### PR DESCRIPTION
Signed-off-by: Marie Bremner <marwhal@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary
Had to resolve the following pylint error to enable pylint test for smsd
```
F
======================================================================
FAIL: test_pylint (tests.pylint_tests.MagmaPyLintTest)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/vagrant/magma/lte/gateway/python/magma/tests/pylint_tests.py", line 60, in test_pylint
    py_wrap.assertNoLintErrors(path)
  File "/home/vagrant/magma/lte/gateway/python/magma/tests/pylint_wrapper.py", line 88, in assertNoLintErrors
    raise AssertionError(msg)
AssertionError: PyLint found errors:
************* Module smsd.main
W0611: 14, 0: Unused SMSOrc8rServiceStub imported from lte.protos.sms_orc8r_pb2_grpc (unused-import)
************* Module smsd.relay
W1201: 60, 8: Use lazy % formatting in logging functions (logging-not-lazy)


----------------------------------------------------------------------
Ran 1 test in 57.214s

```
<!-- Enumerate changes you made and why you made them -->

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->

<!--
    Final note

    Please take a moment to read through the Magma project's
    - Contributing conventions: https://docs.magmacore.org/docs/next/contributing/contribute_conventions

    If this is your first time opening a PR, also consider reading
    - Developer onboarding: https://docs.magmacore.org/docs/next/contributing/contribute_onboarding
    - Development workflow: https://docs.magmacore.org/docs/next/contributing/contribute_workflow
-->
