### PR TITLE
[MME] Add an empty spgw ue conversion test

### DIFF
--- a/lte/gateway/c/oai/test/spgw_task/test_spgw_state_converter.cpp
+++ b/lte/gateway/c/oai/test/spgw_task/test_spgw_state_converter.cpp
@@ -14,6 +14,7 @@
 #include <gtest/gtest.h>
 
 #include "spgw_state_converter.h"
+#include "spgw_state_manager.h"
 #include "sgw_defs.h"
 #include "state_creators.h"
 
@@ -21,9 +22,12 @@ namespace magma {
 namespace lte {
 
 class SPGWStateConverterTest : public ::testing::Test {
-  virtual void SetUp() {}
+  virtual void SetUp() {
+    spgw_config_t config;
+    SpgwStateManager::getInstance().init(false, &config);
+  }
 
-  virtual void TearDown() {}
+  virtual void TearDown() { SpgwStateManager::getInstance().free_state(); }
 };
 
 TEST_F(SPGWStateConverterTest, TestSPGWStateConversion) {
@@ -49,6 +53,18 @@ TEST_F(SPGWStateConverterTest, TestSPGWStateConversion) {
     EXPECT_EQ(initial_gtp_data.fd0, final_gtp_data.fd0);
     EXPECT_EQ(initial_gtp_data.fd1u, final_gtp_data.fd1u);
   }
+}
+
+TEST_F(SPGWStateConverterTest, TestEmptySPGWUeConversion) {
+  spgw_ue_context_t original_state, final_state;
+  oai::SpgwUeContext proto_state;
+  LIST_INIT(&original_state.sgw_s11_teid_list);
+
+  SpgwStateConverter::ue_to_proto(&original_state, &proto_state);
+  SpgwStateConverter::proto_to_ue(proto_state, &final_state);
+
+  EXPECT_TRUE(LIST_EMPTY(&(original_state.sgw_s11_teid_list)));
+  EXPECT_TRUE(LIST_EMPTY(&(final_state.sgw_s11_teid_list)));
 }
 
 // TODO add a state conversion test for UE context


### PR DESCRIPTION
<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary
Adding a basic basecase UE conversion test for SPGW. 
(Will write a more involved testcase in future PRs)
Some caveats
* This test only works with Alex's changes
	* https://github.com/magma/magma/pull/6417
	* https://github.com/magma/magma/pull/6449/
<!-- Enumerate changes you made and why you made them -->

## Test Plan
Once the PRs above have merged, I'll run basic unit tests and s1ap tests
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->

<!--
    Final note

    Please take a moment to read through the Magma project's
    - Contributing conventions: https://docs.magmacore.org/docs/next/contributing/contribute_conventions

    If this is your first time opening a PR, also consider reading
    - Developer onboarding: https://docs.magmacore.org/docs/next/contributing/contribute_onboarding
    - Development workflow: https://docs.magmacore.org/docs/next/contributing/contribute_workflow
-->
Signed-off-by: Alex Rodriguez <ardzoht@gmail.com>