### PR TITLE
bump docker compose to 1.29.1 cause it supports better container dependencies definitions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,7 +70,7 @@ orbs:
           compose_version:
             description: Docker-compose version to install
             type: string
-            default: "1.25.4"
+            default: "1.29.1"
         steps:
           - run:
               name: Install Docker Compose


### PR DESCRIPTION
Signed-off-by: Vitalii Kostenko <vitalii@freedomfi.com>

## Summary

Starting from v1.29.0  docker-compose now supports better  depends_on definition. It allows us to use initContainer like definitions until we migrate all the workloads to k8s. FEG and CWAG are good examples of such workloads.

Release notes https://docs.docker.com/compose/release-notes/.
Examples of using such extended depends_on instruction: https://github.com/magma/magma/pull/6361.
