### PR TITLE
Add retry logic to cwag build/deploy

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -785,11 +785,10 @@ jobs:
       - checkout
       - build/determinator:
           <<: *cwf_build_verify
-      - run:
-          name: Build CWAG containers
-          command: |
-            cd $MAGMA_ROOT/cwf/gateway/docker
-            docker-compose build --parallel
+      - run-with-retry:
+          retry-count: 2
+          workdir: $MAGMA_ROOT/cwf/gateway/docker
+          command: docker-compose build --parallel
       # TODO bring up the containers and check for crashloops
 
   cwf-integ-test:
@@ -828,11 +827,10 @@ jobs:
       - build/determinator:
           <<: *cwf_build_verify
       - docker/install-dc
-      - run:
-          name: Build CWAG containers
-          command: |
-            cd ${MAGMA_ROOT}/cwf/gateway/docker
-            docker-compose -f docker-compose.yml -f docker-compose.override.yml build --parallel
+      - run-with-retry:
+          retry-count: 2
+          workdir: $MAGMA_ROOT/cwf/gateway/docker
+          command: docker-compose -f docker-compose.yml -f docker-compose.override.yml build --parallel
       - tag-push-docker:
           project: cwf
           images: <<parameters.images>>


### PR DESCRIPTION
Signed-off-by: Marie Bremner <marwhal@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary
The cwag build fails occasionally when magmad fails to build. (Like [here](https://app.circleci.com/pipelines/github/magma/magma/20967/workflows/290baa8f-3930-4773-a6ae-0fc5878856ae/jobs/217930)) This issue seems to be flake most of the times, so retry the build at least once if it fails the first time. 
<!-- Enumerate changes you made and why you made them -->

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->

<!--
    Final note

    Please take a moment to read through the Magma project's
    - Contributing conventions: https://docs.magmacore.org/docs/next/contributing/contribute_conventions

    If this is your first time opening a PR, also consider reading
    - Developer onboarding: https://docs.magmacore.org/docs/next/contributing/contribute_onboarding
    - Development workflow: https://docs.magmacore.org/docs/next/contributing/contribute_workflow
-->
