### PR TITLE
[lte][agw] Reduce SPGW state writes if state has not changed

### DIFF
--- a/lte/gateway/c/oai/tasks/mme_app/mme_app_bearer.c
+++ b/lte/gateway/c/oai/tasks/mme_app/mme_app_bearer.c
@@ -978,10 +978,14 @@ void mme_app_handle_delete_session_rsp(
        Do not send UE Context Release Command to eNB before receiving SGs IMSI
        Detach Ack from MSC/VLR */
     if (ue_context_p->sgs_context != NULL) {
-      if ((ue_context_p->sgs_detach_type == SGS_EXPLICIT_UE_INITIATED_IMSI_DETACH_FROM_NONEPS) ||
-           (ue_context_p->sgs_detach_type == SGS_COMBINED_UE_INITIATED_IMSI_DETACH_FROM_EPS_N_NONEPS)) {
-          OAILOG_FUNC_OUT(LOG_MME_APP);
-      } else if (ue_context_p->sgs_context->ts9_timer.id == MME_APP_TIMER_INACTIVE_ID) {
+      if ((ue_context_p->sgs_detach_type ==
+           SGS_EXPLICIT_UE_INITIATED_IMSI_DETACH_FROM_NONEPS) ||
+          (ue_context_p->sgs_detach_type ==
+           SGS_COMBINED_UE_INITIATED_IMSI_DETACH_FROM_EPS_N_NONEPS)) {
+        OAILOG_FUNC_OUT(LOG_MME_APP);
+      } else if (
+          ue_context_p->sgs_context->ts9_timer.id ==
+          MME_APP_TIMER_INACTIVE_ID) {
         /* Notify S1AP to send UE Context Release Command to eNB or free
          * s1 context locally.
          */

--- a/lte/gateway/c/oai/tasks/nas/emm/Attach.c
+++ b/lte/gateway/c/oai/tasks/nas/emm/Attach.c
@@ -2489,10 +2489,14 @@ void proc_new_attach_req(struct ue_mm_context_s* ue_context_p) {
        Do not send UE Context Release Command to eNB before receiving SGs IMSI
        Detach Ack from MSC/VLR */
     if (ue_context_p->sgs_context != NULL) {
-      if ((ue_context_p->sgs_detach_type == SGS_EXPLICIT_UE_INITIATED_IMSI_DETACH_FROM_NONEPS) ||
-           (ue_context_p->sgs_detach_type == SGS_COMBINED_UE_INITIATED_IMSI_DETACH_FROM_EPS_N_NONEPS)) {
-          OAILOG_FUNC_OUT(LOG_NAS_EMM);
-      } else if (ue_context_p->sgs_context->ts9_timer.id == MME_APP_TIMER_INACTIVE_ID) {
+      if ((ue_context_p->sgs_detach_type ==
+           SGS_EXPLICIT_UE_INITIATED_IMSI_DETACH_FROM_NONEPS) ||
+          (ue_context_p->sgs_detach_type ==
+           SGS_COMBINED_UE_INITIATED_IMSI_DETACH_FROM_EPS_N_NONEPS)) {
+        OAILOG_FUNC_OUT(LOG_NAS_EMM);
+      } else if (
+          ue_context_p->sgs_context->ts9_timer.id ==
+          MME_APP_TIMER_INACTIVE_ID) {
         /* Notify S1AP to send UE Context Release Command to eNB or free
          * s1 context locally.
          */

--- a/lte/gateway/c/oai/tasks/sgw/sgw_handlers.c
+++ b/lte/gateway/c/oai/tasks/sgw/sgw_handlers.c
@@ -1034,7 +1034,6 @@ int sgw_handle_modify_bearer_request(
 
 //------------------------------------------------------------------------------
 int sgw_handle_delete_session_request(
-    spgw_state_t* spgw_state,
     const itti_s11_delete_session_request_t* const delete_session_req_pP,
     imsi64_t imsi64) {
   OAILOG_FUNC_IN(LOG_SPGW_APP);

--- a/lte/gateway/c/oai/tasks/sgw/sgw_handlers.h
+++ b/lte/gateway/c/oai/tasks/sgw/sgw_handlers.h
@@ -46,7 +46,6 @@ int sgw_handle_modify_bearer_request(
     const itti_s11_modify_bearer_request_t* const modify_bearer_p,
     imsi64_t imsi64);
 int sgw_handle_delete_session_request(
-    spgw_state_t* spgw_state,
     const itti_s11_delete_session_request_t* const delete_session_p,
     imsi64_t imsi64);
 void sgw_handle_release_access_bearers_request(

--- a/lte/gateway/c/oai/tasks/sgw/sgw_task.c
+++ b/lte/gateway/c/oai/tasks/sgw/sgw_task.c
@@ -192,6 +192,7 @@ static int handle_message(zloop_t* loop, zsock_t* reader, void* arg) {
     } break;
   }
 
+  put_spgw_state();
   put_spgw_ue_state(imsi64);
 
   itti_free_msg_content(received_message_p);

--- a/lte/gateway/c/oai/tasks/sgw/sgw_task.c
+++ b/lte/gateway/c/oai/tasks/sgw/sgw_task.c
@@ -192,7 +192,6 @@ static int handle_message(zloop_t* loop, zsock_t* reader, void* arg) {
     } break;
   }
 
-  put_spgw_state();
   put_spgw_ue_state(imsi64);
 
   itti_free_msg_content(received_message_p);

--- a/lte/gateway/c/oai/tasks/sgw/spgw_state_manager.cpp
+++ b/lte/gateway/c/oai/tasks/sgw/spgw_state_manager.cpp
@@ -53,7 +53,7 @@ void SpgwStateManager::create_state() {
   // Allocating spgw_state_p
   state_cache_p = (spgw_state_t*) calloc(1, sizeof(spgw_state_t));
 
-  bstring b     = bfromcstr(S11_BEARER_CONTEXT_INFO_HT_NAME);
+  bstring b      = bfromcstr(S11_BEARER_CONTEXT_INFO_HT_NAME);
   state_teid_ht_ = hashtable_ts_create(
       SGW_STATE_CONTEXT_HT_MAX_SIZE, nullptr,
       (void (*)(void**)) spgw_free_s11_bearer_context_information, b);

--- a/lte/gateway/c/oai/tasks/sgw/spgw_state_manager.cpp
+++ b/lte/gateway/c/oai/tasks/sgw/spgw_state_manager.cpp
@@ -53,7 +53,7 @@ void SpgwStateManager::create_state() {
   // Allocating spgw_state_p
   state_cache_p = (spgw_state_t*) calloc(1, sizeof(spgw_state_t));
 
-  bstring b      = bfromcstr(S11_BEARER_CONTEXT_INFO_HT_NAME);
+  bstring b     = bfromcstr(S11_BEARER_CONTEXT_INFO_HT_NAME);
   state_teid_ht_ = hashtable_ts_create(
       SGW_STATE_CONTEXT_HT_MAX_SIZE, nullptr,
       (void (*)(void**)) spgw_free_s11_bearer_context_information, b);


### PR DESCRIPTION
<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->
- This PR removes the need to write `SPGW` state to redis if the state content has not been changed after processing the message, SPGW UE state will still be written since pretty much every processed message updates SPGW UE context.
- Some clang-format changes for `Attach.c` and `mme_app_bearer.c`

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->
- make integ_test as sanity
- Tested with `test_continuous_random_attach.py` s1ap test, and compared the number of times the spgw state is updated:
```
Continuous random attach test (200 UEs) (5 runs)

*master*         *This revision*
313 writes        198 writes
287                   190
337			195
352			195
338			195
```

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->

<!--
    Final note

    Please take a moment to read through the Magma project's
    - Contributing conventions: https://docs.magmacore.org/docs/next/contributing/contribute_conventions

    If this is your first time opening a PR, also consider reading
    - Developer onboarding: https://docs.magmacore.org/docs/next/contributing/contribute_onboarding
    - Development workflow: https://docs.magmacore.org/docs/next/contributing/contribute_workflow
-->
