### PR TITLE
[codeowners] Move entire-org to maintainers

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -32,8 +32,8 @@ lte/gateway/python/magma/pipelined @koolzz @pshelar
 lte/gateway/python/integ_tests @ssanadhya @ulaskozat @ardzoht
 lte/gateway/Vagrantfile @mattymo @119Vik @tmdzk
 
-**/*.pb.go @magma/entire-org
-**/*_swaggergen.go @magma/entire-org
+**/*.pb.go @magma/repo-magma-maintain
+**/*_swaggergen.go @magma/repo-magma-maintain
 
 # xwf Magma integrations
 xwf/ @AyliD @aharonnovo @r-i-g


### PR DESCRIPTION
## Summary

As part of https://github.com/magma/magma/discussions/6301, we are coalescing entire-org's functionality into the maintainers team.

## Test Plan

n/a

## Additional Information

- [ ] This change is backwards-breaking