### PR TITLE
[docs] Move docusaurus-bot to Magma-controlled account

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1231,15 +1231,14 @@ jobs:
             mv docs/readmes readmes/
             rm -rf docs/
             mv readmes/ docs/
-      # Yeah I fucked up and created mamga-... instead of magma-... oops
       - run:
           name: Deploying to GitHub Pages
           command: |
-            git config --global user.email "mamga-docusaurus-bot@users.noreply.github.com"
-            git config --global user.name "mamga-docusaurus-bot"
-            echo "machine github.com login mamga-docusaurus-bot password $GITHUB_TOKEN" > ~/.netrc
+            git config --global user.email "bots@magmacore.org"
+            git config --global user.name "magma-docusaurus-bot"
+            echo "machine github.com login magma-docusaurus-bot password $GITHUB_TOKEN" > ~/.netrc
             cd website && yarn install
-            CUSTOM_COMMIT_MESSAGE="[skip ci] Deploy website" GIT_USER=mamga-docusaurus-bot yarn run publish-gh-pages
+            CUSTOM_COMMIT_MESSAGE="[skip ci] Deploy website" GIT_USER=magma-docusaurus-bot yarn run publish-gh-pages
       - magma_slack_notify
 
   ### XWF

--- a/.sops.yaml
+++ b/.sops.yaml
@@ -1,0 +1,3 @@
+creation_rules:
+    - pgp: >-
+        F51C27038E5B9C78CB4C8D64AD9E18E3423E391E

--- a/secrets/README.md
+++ b/secrets/README.md
@@ -1,0 +1,5 @@
+# Secrets
+
+This directory contains secrets for the Magma project, secured by [SOPS](https://github.com/mozilla/sops) using a master PGP key stored in the project's password manager.
+
+Use the `#governance-tsc-ama` Slack channel to request non-master keys for secrets files in this directory.

--- a/secrets/ci.yaml
+++ b/secrets/ci.yaml
@@ -1,0 +1,31 @@
+magma-bot:
+    gmail:
+        username: ENC[AES256_GCM,data:vVsbjRVfR422Y0ZrSsjcVMGf,iv:GwSUUAR1bcS7MQxJmrAjdZ+ZRO3EpCdBC3hi1950cSw=,tag:4cflzSkz3A2Ylw8PILSm2w==,type:str]
+        password: ENC[AES256_GCM,data:fCtfudvsxYgyqo1rsSm/m5VTcgmEIZdq3tG0EetnxH7ANvBip7imjw==,iv:i2PGcmO4+mooSBivGp+qmPHLyX0lo38GZRnSuf6hygQ=,tag:rkulxtsfVCwqIXCJmNX0tA==,type:str]
+    github:
+        username: ENC[AES256_GCM,data:5aEfakE74+36,iv:386NYGmhrIOO3TBnMXHChmjHty5wp5REMGUyR5KfTzs=,tag:m6JI7OrazaySc7wfDHzpEQ==,type:str]
+        password: ENC[AES256_GCM,data:qyOLEXpJOeuJwOdbrOLCOyrJ9QjRZVeMd9NlVbPQjYjYxQNBxkgKyw==,iv:LvZKY3RcW/+4Vdhw60OrVtzwKLhyU8rFjmAVhK8KDPE=,tag:DyZdMboeVoflRS4ET/cx7g==,type:str]
+        tokens:
+            magma-docusaurus-bot: ENC[AES256_GCM,data:y4qVGzDJeJi/EHvoAqDhNijLExivYqzhWT4Nqvqst/T4gptL9U7M1w==,iv:PCLaOEzLORyZ2KMmReEjT28UaJk7yEC/OVQLPmXNXTg=,tag:Urcc9TpaN2UuCRQqq8Vejg==,type:str]
+sops:
+    kms: []
+    gcp_kms: []
+    azure_kv: []
+    hc_vault: []
+    lastmodified: '2021-04-29T00:22:23Z'
+    mac: ENC[AES256_GCM,data:biuduGRnOdTA9Nnx54La4e98/biPVMUJxAuV+zcD3h7NybSX9W6A1PAStyPp+DuVBkHNN+RB3buglGeEf6xqdKxqmPLHGjoCEXrC6LiSjcLT/R9lKkVWrjWtE7Rjzo6nVSTxl1RTs4aX/dAqj062Fp2xPAGjXu+l4ctZeFa4k2g=,iv:6em15XVBfVa1C5dFtHm+MwkiGYzuKXK5URm/s2cUSUU=,tag:3wOmRqfMax6K2M6lG6STfw==,type:str]
+    pgp:
+    -   created_at: '2021-04-29T00:05:39Z'
+        enc: |
+            -----BEGIN PGP MESSAGE-----
+
+            hF4DddSLbSDRV9gSAQdAtjuJp2AfRzFv1MaA4ixJNYSxyiO3oITllpwL0ZgEPhQw
+            kcIND1L/sDzoTxaFN13+LceM9TLglMROUN0AB8p6/+en8yMsRLzlHccvivLdM3br
+            1GgBCQIVIWUNrtIyWA9AWL3VbTsciMZQYg8PKG2hAg3Kamoy7V/2mvAwVb7yV/ja
+            F5R/MoYfgV0K7KfRfeahi7Zf4F8bLVvvsxcAuwpzx5J/Qw3wvu2A5o2suEuPdplI
+            bOCrWX7hdRImVA==
+            =200z
+            -----END PGP MESSAGE-----
+        fp: F51C27038E5B9C78CB4C8D64AD9E18E3423E391E
+    unencrypted_suffix: _unencrypted
+    version: 3.6.1


### PR DESCRIPTION
## Summary

As part of https://github.com/magma/magma/discussions/5866, we are cleaning up Magma bots. The magma-docusaurus-bot was linked to an email address that no one has access to, so we create a new email address + GH account, and store the relevant credentials via [SOPS](https://github.com/mozilla/sops).

The master key for these secrets is a PGP key stored in the FB lastpass, with plan to move it to a TSC-specific Magmacore pw manager once we align on choice of pw manager.

## Test Plan

- doing_it_live.gif

## Additional Information

- [ ] This change is backwards-breaking