### PR TITLE
[Pylint] Add back redirectd/pkt_tester/monitord/smsd/health service to pylint test

### DIFF
--- a/lte/gateway/python/magma/health/health_service.py
+++ b/lte/gateway/python/magma/health/health_service.py
@@ -33,8 +33,10 @@ from orc8r.protos.common_pb2 import Void
 class AGWHealth:
 
     def get_allocated_ips(self):
-        chan = ServiceRegistry.get_rpc_channel('mobilityd',
-                                               ServiceRegistry.LOCAL)
+        chan = ServiceRegistry.get_rpc_channel(
+            'mobilityd',
+            ServiceRegistry.LOCAL,
+        )
         client = MobilityServiceStub(chan)
         res = []
 
@@ -53,8 +55,10 @@ class AGWHealth:
         return res
 
     def get_subscriber_table(self):
-        chan = ServiceRegistry.get_rpc_channel('mobilityd',
-                                               ServiceRegistry.LOCAL)
+        chan = ServiceRegistry.get_rpc_channel(
+            'mobilityd',
+            ServiceRegistry.LOCAL,
+        )
         client = MobilityServiceStub(chan)
 
         table = client.GetSubscriberIPTable(Void())
@@ -66,12 +70,15 @@ class AGWHealth:
 
         return RegistrationSuccessRate(
             attach_requests=log.count('Attach Request'),
-            attach_accepts=log.count('Attach Accept'))
+            attach_accepts=log.count('Attach Accept'),
+        )
 
-    def get_core_dumps(self,
-                       directory='/var/core',
-                       start_timestamp=0,
-                       end_timestamp=math.inf):
+    def get_core_dumps(
+        self,
+        directory='/var/core',
+        start_timestamp=0,
+        end_timestamp=math.inf,
+    ):
         res = []
         for filename in glob.glob(path.join(directory, 'core-*')):
             # core-1565125801-python3-8042_bundle
@@ -84,7 +91,9 @@ class AGWHealth:
         config = load_service_mconfig_as_json('mme')
 
         # eNB status for #eNBs connected
-        chan = ServiceRegistry.get_rpc_channel('enodebd', ServiceRegistry.LOCAL)
+        chan = ServiceRegistry.get_rpc_channel(
+            'enodebd', ServiceRegistry.LOCAL,
+        )
         client = EnodebdStub(chan)
         status = client.GetStatus(Void())
 
@@ -96,7 +105,7 @@ class AGWHealth:
             subscriber_table=self.get_subscriber_table(),
             core_dumps=self.get_core_dumps(),
             registration_success_rate=self.get_registration_success_rate(
-                mme_log_path
+                mme_log_path,
             ),
         )
         return health_summary

--- a/lte/gateway/python/magma/monitord/cpe_monitoring.py
+++ b/lte/gateway/python/magma/monitord/cpe_monitoring.py
@@ -26,15 +26,21 @@ from magma.monitord.icmp_state import ICMPMonitoringResponse
 from orc8r.protos.common_pb2 import Void
 from prometheus_client import Histogram
 
-subscriber_icmp_latency_ms = Histogram('subscriber_icmp_latency_ms',
-                                       'Reported latency for subscriber '
-                                       'in milliseconds',
-                                       ['imsi'],
-                                       buckets=[50, 100, 200, 500, 1000, 2000])
+subscriber_icmp_latency_ms = Histogram(
+    'subscriber_icmp_latency_ms',
+    'Reported latency for subscriber '
+    'in milliseconds',
+    ['imsi'],
+    buckets=[50, 100, 200, 500, 1000, 2000],
+)
 
-PingedTargets = NamedTuple('PingedTargets',
-                           [('ping_targets', Dict['str', IPAddress]),
-                            ('ping_addresses', List[IPAddress])])
+PingedTargets = NamedTuple(
+    'PingedTargets',
+    [
+        ('ping_targets', Dict['str', IPAddress]),
+        ('ping_addresses', List[IPAddress]),
+    ],
+)
 
 
 def _get_addr_from_subscribers(sub_ip) -> str:
@@ -52,7 +58,8 @@ class CpeMonitoringModule:
         self.ping_targets = {}
 
     def set_manually_configured_targets(
-            self, configured_ping_targets: Optional[Dict] = None):
+            self, configured_ping_targets: Optional[Dict] = None,
+    ):
         if configured_ping_targets:
             self.ping_targets = configured_ping_targets.copy()
             for value in self.ping_targets.values():
@@ -67,31 +74,41 @@ class CpeMonitoringModule:
         """
 
         try:
-            mobilityd_chan = ServiceRegistry.get_rpc_channel('mobilityd',
-                                                             ServiceRegistry.LOCAL)
+            mobilityd_chan = ServiceRegistry.get_rpc_channel(
+                'mobilityd',
+                ServiceRegistry.LOCAL,
+            )
             mobilityd_stub = MobilityServiceStub(mobilityd_chan)
             response = await grpc_async_wrapper(
-                mobilityd_stub.GetSubscriberIPTable.future(Void(),
-                                                           10), service_loop)
+                mobilityd_stub.GetSubscriberIPTable.future(
+                    Void(),
+                    10,
+                ), service_loop,
+            )
             for sub in response.entries:
                 ip = _get_addr_from_subscribers(sub.ip)
                 self.ping_addresses.append(ip)
                 self.ping_targets[sub.sid.id] = ip
         except grpc.RpcError as err:
             logging.error(
-                "GetSubscribers Error for %s! %s", err.code(), err.details())
+                "GetSubscribers Error for %s! %s", err.code(), err.details(),
+            )
         return PingedTargets(self.ping_targets, self.ping_addresses)
 
-    def save_ping_response(self, sid: str, ip_addr: str,
-                           ping_resp: PingCommandResult) -> None:
+    def save_ping_response(
+        self, sid: str, ip_addr: str,
+        ping_resp: PingCommandResult,
+    ) -> None:
         reported_time = int(round(time() * 1000))
         self._subscriber_state[sid] = ICMPMonitoringResponse(
             last_reported_time=reported_time,
-            latency_ms=ping_resp.stats.rtt_avg)
+            latency_ms=ping_resp.stats.rtt_avg,
+        )
         subscriber_icmp_latency_ms.labels(sid).observe(ping_resp.stats.rtt_avg)
         logging.info(
             '%s:%s => %sms', sid, ip_addr,
-                                   self._subscriber_state[sid].latency_ms)
+            self._subscriber_state[sid].latency_ms,
+        )
 
     def get_subscriber_state(self) -> Dict[str, ICMPMonitoringResponse]:
         return self._subscriber_state

--- a/lte/gateway/python/magma/monitord/cpe_monitoring.py
+++ b/lte/gateway/python/magma/monitord/cpe_monitoring.py
@@ -17,7 +17,7 @@ from time import time
 from typing import Dict, List, NamedTuple, Optional
 
 import grpc
-from lte.protos.mobilityd_pb2 import IPAddress, SubscriberIPTable
+from lte.protos.mobilityd_pb2 import IPAddress
 from lte.protos.mobilityd_pb2_grpc import MobilityServiceStub
 from magma.common.rpc_utils import grpc_async_wrapper
 from magma.common.service_registry import ServiceRegistry
@@ -90,8 +90,8 @@ class CpeMonitoringModule:
             latency_ms=ping_resp.stats.rtt_avg)
         subscriber_icmp_latency_ms.labels(sid).observe(ping_resp.stats.rtt_avg)
         logging.info(
-            '{}:{} => {}ms'.format(sid, ip_addr,
-                                   self._subscriber_state[sid].latency_ms))
+            '%s:%s => %sms', sid, ip_addr,
+                                   self._subscriber_state[sid].latency_ms)
 
     def get_subscriber_state(self) -> Dict[str, ICMPMonitoringResponse]:
         return self._subscriber_state

--- a/lte/gateway/python/magma/monitord/icmp_monitoring.py
+++ b/lte/gateway/python/magma/monitord/icmp_monitoring.py
@@ -36,7 +36,7 @@ class ICMPMonitoring(Job):
                  mtr_interface: str):
         super().__init__(interval=CHECKIN_INTERVAL, loop=service_loop)
         self._MTR_PORT = mtr_interface
-        logging.info("Running on interface %s..." % self._MTR_PORT)
+        logging.info("Running on interface %s...", self._MTR_PORT)
         # Matching response time output to get latency
         self._polling_interval = max(polling_interval,
                                      DEFAULT_POLLING_INTERVAL)

--- a/lte/gateway/python/magma/monitord/icmp_monitoring.py
+++ b/lte/gateway/python/magma/monitord/icmp_monitoring.py
@@ -32,19 +32,25 @@ class ICMPMonitoring(Job):
     Class that handles main loop to send ICMP ping to valid subscribers.
     """
 
-    def __init__(self, monitoring_module, polling_interval: int, service_loop,
-                 mtr_interface: str):
+    def __init__(
+        self, monitoring_module, polling_interval: int, service_loop,
+        mtr_interface: str,
+    ):
         super().__init__(interval=CHECKIN_INTERVAL, loop=service_loop)
         self._MTR_PORT = mtr_interface
         logging.info("Running on interface %s...", self._MTR_PORT)
         # Matching response time output to get latency
-        self._polling_interval = max(polling_interval,
-                                     DEFAULT_POLLING_INTERVAL)
+        self._polling_interval = max(
+            polling_interval,
+            DEFAULT_POLLING_INTERVAL,
+        )
         self._loop = service_loop
         self._module = monitoring_module
 
-    async def _ping_targets(self, hosts: List[str],
-                            targets: Optional[Dict] = None):
+    async def _ping_targets(
+        self, hosts: List[str],
+        targets: Optional[Dict] = None,
+    ):
         """
         Sends a count of ICMP pings to target IP address, returns response.
         Args:
@@ -55,15 +61,20 @@ class ICMPMonitoring(Job):
         """
         if targets:
             ping_params = [
-                PingInterfaceCommandParams(host, NUM_PACKETS, self._MTR_PORT,
-                                           TIMEOUT_SECS) for host in hosts]
+                PingInterfaceCommandParams(
+                    host, NUM_PACKETS, self._MTR_PORT,
+                    TIMEOUT_SECS,
+                ) for host in hosts
+            ]
             ping_results = await ping_interface_async(ping_params, self._loop)
             ping_results_list = list(ping_results)
             for host, sub, result in zip(hosts, targets, ping_results_list):
                 self._save_ping_response(sub, host, result)
 
-    def _save_ping_response(self, target_id: str, ip_addr: str,
-                            ping_resp: PingCommandResult) -> None:
+    def _save_ping_response(
+        self, target_id: str, ip_addr: str,
+        ping_resp: PingCommandResult,
+    ) -> None:
         """
         Saves ping response to in-memory subscriber dict.
         Args:
@@ -72,8 +83,10 @@ class ICMPMonitoring(Job):
             ping_resp: response of ICMP ping command
         """
         if ping_resp.error:
-            logging.debug('Failed to ping %s with error: %s',
-                          target_id, ping_resp.error)
+            logging.debug(
+                'Failed to ping %s with error: %s',
+                target_id, ping_resp.error,
+            )
         else:
             self._module.save_ping_response(target_id, ip_addr, ping_resp)
 

--- a/lte/gateway/python/magma/monitord/main.py
+++ b/lte/gateway/python/magma/monitord/main.py
@@ -43,11 +43,14 @@ def main():
         targets = load_service_config("monitord")["ping_targets"]
         for target, data in targets.items():
             if "ip" in data:
-                ip = IPAddress(version=IPAddress.IPV4,
-                               address=str.encode(data["ip"]))
+                ip = IPAddress(
+                    version=IPAddress.IPV4,
+                    address=str.encode(data["ip"]),
+                )
                 logging.debug(
-                    'Adding %s:%s:%s to ping target',target, ip.version,
-                                                            ip.address)
+                    'Adding %s:%s:%s to ping target', target, ip.version,
+                    ip.address,
+                )
                 manual_ping_targets[target] = ip
     except KeyError:
         logging.warning("No ping targets configured")
@@ -55,14 +58,17 @@ def main():
     cpe_monitor = CpeMonitoringModule()
     cpe_monitor.set_manually_configured_targets(manual_ping_targets)
 
-    icmp_monitor = ICMPMonitoring(cpe_monitor,
-                                  service.mconfig.polling_interval,
-                                  service.loop, mtr_interface)
+    icmp_monitor = ICMPMonitoring(
+        cpe_monitor,
+        service.mconfig.polling_interval,
+        service.loop, mtr_interface,
+    )
     icmp_monitor.start()
 
     # Register a callback function for GetOperationalStates
     service.register_operational_states_callback(
-        _get_serialized_subscriber_states(cpe_monitor))
+        _get_serialized_subscriber_states(cpe_monitor),
+    )
 
     # Run the service loop
     service.run()

--- a/lte/gateway/python/magma/monitord/main.py
+++ b/lte/gateway/python/magma/monitord/main.py
@@ -46,8 +46,8 @@ def main():
                 ip = IPAddress(version=IPAddress.IPV4,
                                address=str.encode(data["ip"]))
                 logging.debug(
-                    'Adding {}:{}:{} to ping target'.format(target, ip.version,
-                                                            ip.address))
+                    'Adding %s:%s:%s to ping target',target, ip.version,
+                                                            ip.address)
                 manual_ping_targets[target] = ip
     except KeyError:
         logging.warning("No ping targets configured")

--- a/lte/gateway/python/magma/redirectd/redirect_server.py
+++ b/lte/gateway/python/magma/redirectd/redirect_server.py
@@ -18,7 +18,7 @@ import wsgiserver
 from flask import Flask, redirect, render_template, request
 from magma.redirectd.redirect_store import RedirectDict
 
-""" Use 404 when subscriber not found, 302 for 'Found' redirect """
+# Use 404 when subscriber not found, 302 for 'Found' redirect
 HTTP_NOT_FOUND = 404
 HTTP_REDIRECT = 302
 
@@ -26,7 +26,7 @@ NOT_FOUND_HTML = '404.html'
 
 RedirectInfo = namedtuple('RedirectInfo', ['subscriber_ip', 'server_response'])
 ServerResponse = namedtuple(
-    'ServerResponse', ['redirect_address', 'http_code']
+    'ServerResponse', ['redirect_address', 'http_code'],
 )
 
 
@@ -36,16 +36,15 @@ def flask_redirect(**kwargs):
     redirect_info = RedirectInfo(request.remote_addr, response)
 
     logging.info(
-        "Request from {}: sent http code {} - redirected to {}".format(
-            redirect_info.subscriber_ip, response.http_code,
-            response.redirect_address
-        )
+        "Request from %s: sent http code %s - redirected to %s",
+        redirect_info.subscriber_ip, response.http_code,
+        response.redirect_address,
     )
 
     if response.http_code is HTTP_NOT_FOUND:
         return render_template(
             response.redirect_address,
-            subscriber={'ip': redirect_info.subscriber_ip}
+            subscriber={'ip': redirect_info.subscriber_ip},
         ), HTTP_NOT_FOUND
 
     return redirect(response.redirect_address, code=response.http_code)
@@ -81,14 +80,14 @@ def setup_flask_server():
         '/<path:path>',
         'index',
         flask_redirect,
-        defaults={'get_redirect_response': get_redirect_response}
+        defaults={'get_redirect_response': get_redirect_response},
     )
     return app
 
 
 def run_flask(ip, port, exit_callback):
     """
-    Runs the flask server, this is a daemon, so it exits when redirectd exits
+    Run the flask server. this is a daemon, so it exits when redirectd exits
     """
 
     app = setup_flask_server()

--- a/lte/gateway/python/magma/redirectd/tests/test_redirect.py
+++ b/lte/gateway/python/magma/redirectd/tests/test_redirect.py
@@ -12,14 +12,12 @@ limitations under the License.
 """
 
 import unittest
-from unittest.mock import MagicMock
 
 from lte.protos.policydb_pb2 import RedirectInformation
 from magma.redirectd.redirect_server import (
     HTTP_NOT_FOUND,
     HTTP_REDIRECT,
     NOT_FOUND_HTML,
-    RedirectInfo,
     ServerResponse,
     setup_flask_server,
 )
@@ -38,17 +36,18 @@ class RedirectdTest(unittest.TestCase):
                 RedirectInformation(
                     support=1,
                     address_type=2,
-                    server_address='http://www.example.com/'
-                )
+                    server_address='http://www.example.com/',
+                ),
         }
 
         def get_resp(src_ip):
             if src_ip not in test_dict:
                 return ServerResponse(NOT_FOUND_HTML, HTTP_NOT_FOUND)
             return ServerResponse(
-                test_dict[src_ip].server_address, HTTP_REDIRECT
+                test_dict[src_ip].server_address, HTTP_REDIRECT,
             )
         # Replaces all url_dict polls with a mocked dict (for all url rules)
+        # pylint: disable=protected-access
         for rule in app.url_map._rules:
             if rule is not None and rule.defaults is not None:
                 rule.defaults['get_redirect_response'] = get_resp
@@ -67,8 +66,10 @@ class RedirectdTest(unittest.TestCase):
         """
         Assert 302 http response, proper reponse headers with new dest url
         """
-        resp = self.client.get('/generate_204',
-                               environ_base={'REMOTE_ADDR': '192.5.82.1'})
+        resp = self.client.get(
+            '/generate_204',
+            environ_base={'REMOTE_ADDR': '192.5.82.1'},
+        )
 
         self.assertEqual(resp.status_code, HTTP_REDIRECT)
         self.assertEqual(resp.headers['Location'], 'http://www.example.com/')

--- a/lte/gateway/python/magma/smsd/relay.py
+++ b/lte/gateway/python/magma/smsd/relay.py
@@ -49,15 +49,17 @@ class SmsRelay(Job):
     async def _run(self) -> None:
         if not self._is_enabled():
             # sleep, and don't poll for messages
-            logging.info("mme non_eps_service_config is not SMS_ORC8R, sleeping.")
-            return 
+            logging.info(
+                "mme non_eps_service_config is not SMS_ORC8R, sleeping.",
+            )
+            return
 
         imsis = await self._get_attached_imsis()
         if len(imsis) == 0:
             logging.debug("No active subs")
             return
 
-        logging.info("Checking SMS for %d IMSIs" % len(imsis))
+        logging.info("Checking SMS for %d IMSIs", len(imsis))
         try:
             smsd_resp = await grpc_async_wrapper(
                 self._smsd.GetMessages.future(
@@ -96,19 +98,23 @@ class SmsRelay(Job):
 
     @return_void
     def SMOUplink(self, request: sms_orc8r_pb2.SMOUplinkUnitdata, context):
-        logging.debug("got an uplink: %s: %s",
-                      request.imsi, request.nas_message_container.hex())
+        logging.debug(
+            "got an uplink: %s: %s",
+            request.imsi, request.nas_message_container.hex(),
+        )
 
         if not self._is_enabled():
             # sleep, and don't poll for messages
-            logging.info("mme non_eps_service_config is not SMS_ORC8R, ignoring uplink message.")
-            return 
+            logging.info(
+                "mme non_eps_service_config is not SMS_ORC8R, ignoring uplink message.",
+            )
+            return
 
         try:
             self._smsd.ReportDelivery(
                 sms_orc8r_pb2.ReportDeliveryRequest(
                     report=sms_orc8r_pb2.SMOUplinkUnitdata(
-                        imsi="IMSI"+request.imsi,
+                        imsi="IMSI" + request.imsi,
                         nas_message_container=request.nas_message_container,
                     ),
                 ),
@@ -118,14 +124,14 @@ class SmsRelay(Job):
             context.set_code(grpc.StatusCode.INTERNAL)
             return
 
-    def _is_enabled(self):
-        """ 
-        Returns True if MME's NON_EPS_SERVICE_CONFIG is set to SMS_ORC8R, False
-        otherwise. smsd should only act as a relay when that config paramater
-        is set to SMS_ORC8R (value 3).
+    def _is_enabled(self) -> bool:
+        """Return whether SMS should act as a relay
+
+        SMS_ORC8R has value 3
+        Returns:
+        bool: True if MME's NON_EPS_SERVICE_CONFIG is set to SMS_ORC8R
+        False otherwise
         """
         mme_service_config = load_service_mconfig("mme", MME())
         non_eps_service_control = mme_service_config.non_eps_service_control
-        if non_eps_service_control and non_eps_service_control == 3:
-            return True
-        return False
+        return non_eps_service_control and non_eps_service_control == 3

--- a/lte/gateway/python/magma/tests/pylint_tests.py
+++ b/lte/gateway/python/magma/tests/pylint_tests.py
@@ -24,8 +24,8 @@ class MagmaPyLintTest(unittest.TestCase):
             self.skipTest(
                 'Pylint not available, probably because this test is running '
                 'under @mode/opt: {}'.format(
-                    pylint_wrapper.PYLINT_IMPORT_PROBLEM
-                )
+                    pylint_wrapper.PYLINT_IMPORT_PROBLEM,
+                ),
             )
 
         py_wrap = pylint_wrapper.PyLintWrapper(
@@ -46,12 +46,12 @@ class MagmaPyLintTest(unittest.TestCase):
             'enodebd',
             # 'health',
             # 'mobilityd',
-            # 'monitord',
+            'monitord',
             'pipelined',
-            # 'pkt_tester',
+            'pkt_tester',
             'policydb',
-            # 'redirectd',
-            # 'smsd',
+            'redirectd',
+            'smsd',
             'subscriberdb',
         ]
         parent_path = os.path.dirname(os.path.dirname(__file__))

--- a/lte/gateway/python/magma/tests/pylint_tests.py
+++ b/lte/gateway/python/magma/tests/pylint_tests.py
@@ -44,7 +44,7 @@ class MagmaPyLintTest(unittest.TestCase):
         # TODO look up directories in magma/lte/gateway/python/magma
         directories = [
             'enodebd',
-            # 'health',
+            'health',
             # 'mobilityd',
             'monitord',
             'pipelined',


### PR DESCRIPTION
Signed-off-by: Marie Bremner <marwhal@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary
- enable pylint testing for redirectd/pkt_tester/smsd/monitord/health
- basic formatting with autopep8, isort, comma
Pylint errors fixed:
```
vagrant@magma-dev:~/magma/lte/gateway/python$ . /home/vagrant/build/python/bin/activate; /home/vagrant/build/python/bin/nosetests -s magma/tests
F
======================================================================
FAIL: test_pylint (tests.pylint_tests.MagmaPyLintTest)
----------------------------------------------------------------------
AssertionError: PyLint found errors:
************* Module magma.redirectd.redirect_server
W0105: 21, 0: String statement has no effect (pointless-string-statement)
W1202: 39, 8: Use lazy % formatting in logging functions (logging-format-interpolation)
************* Module magma.redirectd.tests.test_redirect
W0212: 52, 20: Access to a protected member _rules of a client class (protected-access)
W0611: 15, 0: Unused MagicMock imported from unittest.mock (unused-import)
W0611: 18, 0: Unused RedirectInfo imported from magma.redirectd.redirect_server (unused-import)
************* Module monitord.icmp_monitoring
W1201: 39, 8: Use lazy % formatting in logging functions (logging-not-lazy)
************* Module monitord.cpe_monitoring
W1202: 93, 12: Use lazy % formatting in logging functions (logging-format-interpolation)
W0611: 20, 0: Unused SubscriberIPTable imported from lte.protos.mobilityd_pb2 (unused-import)
************* Module monitord.main
W1202: 49, 20: Use lazy % formatting in logging functions (logging-format-interpolation)
************* Module smsd.main
W0611: 14, 0: Unused SMSOrc8rServiceStub imported from lte.protos.sms_orc8r_pb2_grpc (unused-import)
************* Module smsd.relay
W1201: 60, 8: Use lazy % formatting in logging functions (logging-not-lazy)
************* Module health.state_recovery
W0622: 23, 0: Redefining built-in 'ConnectionError' (redefined-builtin)
W1201: 64, 12: Use lazy % formatting in logging functions (logging-not-lazy)

```
<!-- Enumerate changes you made and why you made them -->

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->

<!--
    Final note

    Please take a moment to read through the Magma project's
    - Contributing conventions: https://docs.magmacore.org/docs/next/contributing/contribute_conventions

    If this is your first time opening a PR, also consider reading
    - Developer onboarding: https://docs.magmacore.org/docs/next/contributing/contribute_onboarding
    - Development workflow: https://docs.magmacore.org/docs/next/contributing/contribute_workflow
-->
