### PR TITLE
[MME][OAI][DOCKER] a bit of cleanup in MME docker files [Tech-Debt 2021 April]

### DIFF
--- a/ci-scripts/docker/Dockerfile.mme.ci.rhel8
+++ b/ci-scripts/docker/Dockerfile.mme.ci.rhel8
@@ -7,7 +7,6 @@ ARG FEATURES=mme_oai
 ENV MAGMA_ROOT=/magma
 ENV BUILD_TYPE=Debug
 ENV C_BUILD=/build/c
-ENV TZ=Europe/Paris
 
 # Remove any old CI artifact
 RUN rm -Rf $MAGMA_ROOT $C_BUILD && mkdir -p $C_BUILD
@@ -36,7 +35,7 @@ RUN yum update -y && \
       libubsan \
       libasan \
       psmisc \
-      psmisc \
+      tcpdump \
       openssl \
       net-tools \
       tzdata && \
@@ -85,7 +84,7 @@ WORKDIR /usr/local/lib/freeDiameter
 COPY --from=magma-mme-builder /usr/local/lib/freeDiameter/* ./
 
 # Refresh library cache
-RUN ldconfig -v
+RUN ldconfig
 
 # Copy pre-built binaries for MME and SCTPD
 WORKDIR /magma-mme/bin
@@ -96,8 +95,6 @@ COPY --from=magma-mme-builder $C_BUILD/sctpd/sctpd .
 WORKDIR /var/opt/magma/configs
 # Adding mme configuration for stateful run
 RUN echo "use_stateless: false" > mme.yml
-WORKDIR /usr/local/etc/redis
-COPY --from=magma-mme-builder $MAGMA_ROOT/lte/gateway/docker/mme/configs/redis_for_container.conf redis.conf
 
 WORKDIR /etc/magma
 COPY --from=magma-mme-builder $MAGMA_ROOT/lte/gateway/configs/control_proxy.yml .
@@ -107,8 +104,11 @@ COPY --from=magma-mme-builder $MAGMA_ROOT/lte/gateway/configs/service_registry.y
 # Adding means to re-generate certificates
 WORKDIR /magma-mme/scripts
 COPY --from=magma-mme-builder $MAGMA_ROOT/lte/gateway/c/oai/test/check_mme_s6a_certificate .
-RUN sed -i -e "s@^.*THIS_SCRIPT_PATH@#@" -e "s@\$SUDO@@" check_mme_s6a_certificate
-RUN sed -i -e "s@echo_error@echo@" -e "s@echo_success@echo@" -e "s@echo_warning@echo@" check_mme_s6a_certificate
+RUN sed -i -e "s@^.*THIS_SCRIPT_PATH@#@" \
+           -e "s@\$SUDO@@" \
+           -e "s@echo_error@echo@" \
+           -e "s@echo_success@echo@" \
+           -e "s@echo_warning@echo@" check_mme_s6a_certificate
 
 WORKDIR /magma-mme
 RUN openssl rand -out /root/.rnd 128

--- a/ci-scripts/docker/Dockerfile.mme.ci.ubuntu18
+++ b/ci-scripts/docker/Dockerfile.mme.ci.ubuntu18
@@ -7,8 +7,6 @@ ARG FEATURES=mme_oai
 ENV MAGMA_ROOT=/magma
 ENV BUILD_TYPE=RelWithDebInfo
 ENV C_BUILD=/build/c
-ENV TZ=Europe/Paris
-ENV DEBIAN_FRONTEND=noninteractive
 
 # Remove any old CI artifact
 RUN rm -Rf $MAGMA_ROOT $C_BUILD && mkdir -p $C_BUILD
@@ -107,8 +105,6 @@ COPY --from=magma-mme-builder $C_BUILD/sctpd/sctpd .
 WORKDIR /var/opt/magma/configs
 # Adding mme configuration for stateful run
 RUN echo "use_stateless: false" > mme.yml
-WORKDIR /usr/local/etc/redis
-COPY --from=magma-mme-builder $MAGMA_ROOT/lte/gateway/docker/mme/configs/redis_for_container.conf redis.conf
 
 WORKDIR /etc/magma
 COPY --from=magma-mme-builder $MAGMA_ROOT/lte/gateway/configs/control_proxy.yml .
@@ -118,8 +114,11 @@ COPY --from=magma-mme-builder $MAGMA_ROOT/lte/gateway/configs/service_registry.y
 # Scripts to re-generate certificates
 WORKDIR /magma-mme/scripts
 COPY --from=magma-mme-builder $MAGMA_ROOT/lte/gateway/c/oai/test/check_mme_s6a_certificate .
-RUN sed -i -e "s@^.*THIS_SCRIPT_PATH@#@" -e "s@\$SUDO@@" check_mme_s6a_certificate
-RUN sed -i -e "s@echo_error@echo@" -e "s@echo_success@echo@" -e "s@echo_warning@echo@" check_mme_s6a_certificate
+RUN sed -i -e "s@^.*THIS_SCRIPT_PATH@#@" \
+           -e "s@\$SUDO@@" \
+           -e "s@echo_error@echo@" \
+           -e "s@echo_success@echo@" \
+           -e "s@echo_warning@echo@" check_mme_s6a_certificate
 
 WORKDIR /magma-mme
 RUN openssl rand -out /root/.rnd 128

--- a/lte/gateway/docker/mme/Dockerfile.rhel8
+++ b/lte/gateway/docker/mme/Dockerfile.rhel8
@@ -425,8 +425,6 @@ RUN cp $MAGMA_ROOT/lte/gateway/docker/mme/configs/mme_fd.conf .
 WORKDIR /var/opt/magma/configs
 # Adding mme configuration for stateful run
 RUN echo "use_stateless: false" > mme.yml
-WORKDIR /usr/local/etc/redis
-RUN cp $MAGMA_ROOT/lte/gateway/docker/mme/configs/redis_for_container.conf redis.conf
 
 WORKDIR /etc/magma
 RUN cp $MAGMA_ROOT/lte/gateway/configs/control_proxy.yml .
@@ -434,9 +432,12 @@ RUN cp $MAGMA_ROOT/lte/gateway/configs/redis.yml .
 RUN cp $MAGMA_ROOT/lte/gateway/configs/service_registry.yml .
 
 WORKDIR /magma-mme/scripts
-RUN cp $MAGMA_ROOT/lte/gateway/c/oai/test/check_mme_s6a_certificate .
-RUN sed -i -e "s@^.*THIS_SCRIPT_PATH@#@" -e "s@\$SUDO@@" check_mme_s6a_certificate
-RUN sed -i -e "s@echo_error@echo@" -e "s@echo_success@echo@" -e "s@echo_warning@echo@" check_mme_s6a_certificate
+RUN cp $MAGMA_ROOT/lte/gateway/c/oai/test/check_mme_s6a_certificate . && \
+    sed -i -e "s@^.*THIS_SCRIPT_PATH@#@" \
+           -e "s@\$SUDO@@" \
+           -e "s@echo_error@echo@" \
+           -e "s@echo_success@echo@" \
+           -e "s@echo_warning@echo@" check_mme_s6a_certificate
 
 WORKDIR /magma-mme
 RUN openssl rand -out /root/.rnd 128
@@ -455,7 +456,7 @@ RUN yum update -y && \
       libubsan \
       libasan \
       psmisc \
-      psmisc \
+      tcpdump \
       openssl \
       net-tools \
       tzdata && \
@@ -504,7 +505,7 @@ WORKDIR /usr/local/lib/freeDiameter
 COPY --from=magma-mme-builder /usr/local/lib/freeDiameter/* ./
 
 # Refresh library cache
-RUN ldconfig -v
+RUN ldconfig
 
 # Copy pre-built binaries for MME and SCTPD
 WORKDIR /magma-mme/bin
@@ -520,8 +521,6 @@ COPY --from=magma-mme-builder $MAGMA_ROOT/lte/gateway/docker/mme/configs/mme_fd.
 WORKDIR /var/opt/magma/configs
 # Adding mme configuration for stateful run
 RUN echo "use_stateless: false" > mme.yml
-WORKDIR /usr/local/etc/redis
-COPY --from=magma-mme-builder $MAGMA_ROOT/lte/gateway/docker/mme/configs/redis_for_container.conf redis.conf
 
 WORKDIR /etc/magma
 COPY --from=magma-mme-builder $MAGMA_ROOT/lte/gateway/configs/control_proxy.yml .
@@ -531,8 +530,11 @@ COPY --from=magma-mme-builder $MAGMA_ROOT/lte/gateway/configs/service_registry.y
 # Adding means to re-generate certificates
 WORKDIR /magma-mme/scripts
 COPY --from=magma-mme-builder $MAGMA_ROOT/lte/gateway/c/oai/test/check_mme_s6a_certificate .
-RUN sed -i -e "s@^.*THIS_SCRIPT_PATH@#@" -e "s@\$SUDO@@" check_mme_s6a_certificate
-RUN sed -i -e "s@echo_error@echo@" -e "s@echo_success@echo@" -e "s@echo_warning@echo@" check_mme_s6a_certificate
+RUN sed -i -e "s@^.*THIS_SCRIPT_PATH@#@" \
+           -e "s@\$SUDO@@" \
+           -e "s@echo_error@echo@" \
+           -e "s@echo_success@echo@" \
+           -e "s@echo_warning@echo@" check_mme_s6a_certificate
 
 WORKDIR /magma-mme
 RUN openssl rand -out /root/.rnd 128

--- a/lte/gateway/docker/mme/Dockerfile.ubuntu18.04
+++ b/lte/gateway/docker/mme/Dockerfile.ubuntu18.04
@@ -13,7 +13,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 RUN mkdir -p $C_BUILD
 
-RUN ["/bin/bash", "-c", "echo \"Install general purpouse packages\" && \
+RUN [ "/bin/bash", "-c", "echo \"Install general purpose packages\" && \
     apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get upgrade -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y gnupg wget software-properties-common autoconf automake \
@@ -28,7 +28,7 @@ RUN ["/bin/bash", "-c", "echo \"Install general purpouse packages\" && \
     echo \"Add required package repository for CMake\" && \
     wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | apt-key add - && \
     apt-add-repository 'deb https://apt.kitware.com/ubuntu/ bionic main' && \
-    ln -s /usr/bin/clang-format-7 /usr/bin/clang-format"]
+    ln -s /usr/bin/clang-format-7 /usr/bin/clang-format" ]
 
 RUN echo "Install 3rd party dependencies" && \
     apt-get update && \
@@ -210,24 +210,6 @@ RUN git clone https://github.com/OPENAIRINTERFACE/opencord.org.freeDiameter.git 
     make -j`nproc` && \
     make install
 
-### Following  is required to build MME with OVS support
-# WARNING!!! for the moment it'snot working well cause libfluid linked with Ubuntu incorrectly
-# ENV FEATURES=agw_of
-# RUN git clone https://github.com/facebookincubator/magma.git /fb_magma
-# Clone repos and checkout latest commit
-# ENV LIBFLUID_BASE_COMMIT=56df5e20c49387ab8e6b5cd363c6c10d309f263e
-# Latest master commit with fixes passed v0.1.0
-# ENV LIBFLUID_MSG_COMMIT=71a4fccdedfabece730082fbe87ef8ae5f92059f
-# ENV SCRIPT_DIR=/fb_magma/third_party/libfluid
-# RUN git clone https://github.com/OpenNetworkingFoundation/libfluid_base.git && \
-#     git -C libfluid_base checkout $LIBFLUID_BASE_COMMIT
-# RUN git clone https://github.com/OpenNetworkingFoundation/libfluid_msg.git && \
-#     git -C libfluid_msg checkout $LIBFLUID_MSG_COMMIT
-# TODO(119vik): (move patch_libfluid.sh in to main magma repo third_party folder)
-# COPY patch_libfluid.sh /patch_libfluid.sh
-# COPY patch_libfluid.sh /
-# RUN . /patch_libfluid.sh
-
 # Build MME executables
 RUN ldconfig && \
     cd $MAGMA_ROOT/lte/gateway && \
@@ -277,8 +259,6 @@ RUN cp $MAGMA_ROOT/lte/gateway/docker/mme/configs/mme_fd.conf .
 WORKDIR /var/opt/magma/configs
 # Adding mme configuration for stateful run
 RUN echo "use_stateless: false" > mme.yml
-WORKDIR /usr/local/etc/redis
-RUN cp $MAGMA_ROOT/lte/gateway/docker/mme/configs/redis_for_container.conf redis.conf
 
 WORKDIR /etc/magma
 RUN cp $MAGMA_ROOT/lte/gateway/configs/control_proxy.yml .
@@ -286,9 +266,12 @@ RUN cp $MAGMA_ROOT/lte/gateway/configs/redis.yml .
 RUN cp $MAGMA_ROOT/lte/gateway/configs/service_registry.yml .
 
 WORKDIR /magma-mme/scripts
-RUN cp $MAGMA_ROOT/lte/gateway/c/oai/test/check_mme_s6a_certificate .
-RUN sed -i -e "s@^.*THIS_SCRIPT_PATH@#@" -e "s@\$SUDO@@" check_mme_s6a_certificate
-RUN sed -i -e "s@echo_error@echo@" -e "s@echo_success@echo@" -e "s@echo_warning@echo@" check_mme_s6a_certificate
+RUN cp $MAGMA_ROOT/lte/gateway/c/oai/test/check_mme_s6a_certificate . && \
+    sed -i -e "s@^.*THIS_SCRIPT_PATH@#@" \
+           -e "s@\$SUDO@@" \
+           -e "s@echo_error@echo@" \
+           -e "s@echo_success@echo@" \
+           -e "s@echo_warning@echo@" check_mme_s6a_certificate
 
 WORKDIR /magma-mme
 RUN openssl rand -out /root/.rnd 128
@@ -380,8 +363,6 @@ COPY --from=magma-mme-builder $MAGMA_ROOT/lte/gateway/docker/mme/configs/mme_fd.
 WORKDIR /var/opt/magma/configs
 # Adding mme configuration for stateful run
 RUN echo "use_stateless: false" > mme.yml
-WORKDIR /usr/local/etc/redis
-COPY --from=magma-mme-builder $MAGMA_ROOT/lte/gateway/docker/mme/configs/redis_for_container.conf redis.conf
 
 WORKDIR /etc/magma
 COPY --from=magma-mme-builder $MAGMA_ROOT/lte/gateway/configs/control_proxy.yml .
@@ -391,8 +372,11 @@ COPY --from=magma-mme-builder $MAGMA_ROOT/lte/gateway/configs/service_registry.y
 # Adding means to re-generate certificates
 WORKDIR /magma-mme/scripts
 COPY --from=magma-mme-builder $MAGMA_ROOT/lte/gateway/c/oai/test/check_mme_s6a_certificate .
-RUN sed -i -e "s@^.*THIS_SCRIPT_PATH@#@" -e "s@\$SUDO@@" check_mme_s6a_certificate
-RUN sed -i -e "s@echo_error@echo@" -e "s@echo_success@echo@" -e "s@echo_warning@echo@" check_mme_s6a_certificate
+RUN sed -i -e "s@^.*THIS_SCRIPT_PATH@#@" \
+           -e "s@\$SUDO@@" \
+           -e "s@echo_error@echo@" \
+           -e "s@echo_success@echo@" \
+           -e "s@echo_warning@echo@" check_mme_s6a_certificate
 
 WORKDIR /magma-mme
 RUN openssl rand -out /root/.rnd 128


### PR DESCRIPTION
Signed-off-by: Raphael Defosseux <raphael.defosseux@openairinterface.org>

## Summary

  - RHEL8: missing tcpdump package in target images
  - Removed redis.conf since we are running redis in another container
  - Adaptation of check_mme_s6a_certificate in one line to limit layers

I tried to tar the packages in the builder images and untar in the target images:

- It reduces the number of layers
- **But the image size was hit by a big increase.**

So I did not push it.

## Test Plan

## Additional Information

- [ ] This change is backwards-breaking

