### PR TITLE
[MME] Unmask SIGSEGV so it is dealt by the default handler

### DIFF
--- a/lte/gateway/c/oai/lib/itti/signals.c
+++ b/lte/gateway/c/oai/lib/itti/signals.c
@@ -121,7 +121,6 @@ int signal_mask(void) {
   sigemptyset(&set);
   sigaddset(&set, SIGTIMER);
   sigaddset(&set, SIGABRT);
-  sigaddset(&set, SIGSEGV);
   sigaddset(&set, SIGINT);
   sigaddset(&set, SIGTERM);
 
@@ -140,7 +139,6 @@ int signal_handle(int* end, task_zmq_ctx_t* task_ctx) {
   sigemptyset(&set);
   sigaddset(&set, SIGTIMER);
   sigaddset(&set, SIGABRT);
-  sigaddset(&set, SIGSEGV);
   sigaddset(&set, SIGINT);
   sigaddset(&set, SIGTERM);
 
@@ -171,7 +169,6 @@ int signal_handle(int* end, task_zmq_ctx_t* task_ctx) {
      * Dispatch the signal to sub-handlers
      */
     switch (info.si_signo) {
-      case SIGSEGV: /* Fall through */
       case SIGABRT:
         SIG_DEBUG("Received SIGABORT\n");
         backtrace_handle_signal(&info);

--- a/lte/gateway/c/oai/test/itti/test_itti.cpp
+++ b/lte/gateway/c/oai/test/itti/test_itti.cpp
@@ -55,7 +55,6 @@ static int handle_message(zloop_t* loop, zsock_t* reader, void* arg) {
 
   switch (ITTI_MSG_ID(received_message_p)) {
     case TERMINATE_MESSAGE: {
-
     } break;
 
     case TEST_MESSAGE: {

--- a/lte/gateway/deploy/roles/dev_common/tasks/main.yml
+++ b/lte/gateway/deploy/roles/dev_common/tasks/main.yml
@@ -58,6 +58,7 @@
     -  XDG_CACHE_HOME="{{magma_root}}/.cache"
     -  SWAGGER_CODEGEN_JAR={{ swagger_codegen_jar }}
     -  CODEGEN_ROOT={{ codegen_root }}
+    -  ASAN_OPTIONS=abort_on_error=1:disable_coredump=0:unmap_shadow_on_exit=1
   when: full_provision
 
 - name: "Go export"


### PR DESCRIPTION
Signed-off-by: Marie Bremner <marwhal@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary
### Current Implementation - SIGSEGV is masked for all threads with main thread processing in a loop

In order to handler timer signals in an orderly way, we intentionally mask many signals for all threads when we start up MME. ([signal_mask](https://sourcegraph.com/github.com/magma/magma/-/blob/lte/gateway/c/oai/lib/itti/signals.c#L129))
After we initialize everything, the main thread goes into a loop where it processes the masked signals until the process is terminated. ([handle_signal](https://sourcegraph.com/github.com/magma/magma/-/blob/lte/gateway/c/oai/lib/itti/signals.c#L136:5))

We include SIGSEGV as one of the signals handled this way. [The handling logic](https://sourcegraph.com/github.com/magma/magma/-/blob/lte/gateway/c/oai/lib/itti/signals.c#L174) shows that when we get a SIGSEGV, we intend to print a backtrace and ***not*** terminate the process.

But this actually does not do what the code intends in some cases.
First of all, from my experimentations, I *think* the backtrace we print here is useless as we print the stacktrace of the main looping thread.

```
Apr 29 21:45:34 magma-dev-focal mme[491356]: [SIG][D]Received SIGABORT
Apr 29 21:45:34 magma-dev-focal mme[491356]: Obtained 7 stack frames.
Apr 29 21:45:34 magma-dev-focal mme[491356]: /usr/local/bin/mme(display_backtrace+0x33) [0x5632c0dde432]
Apr 29 21:45:34 magma-dev-focal mme[491356]: /usr/local/bin/mme(backtrace_handle_signal+0xd) [0x5632c0dde586]
Apr 29 21:45:34 magma-dev-focal mme[491356]: /usr/local/bin/mme(signal_handle+0x12a) [0x5632c144aed0]
Apr 29 21:45:34 magma-dev-focal mme[491356]: /usr/local/bin/mme(itti_wait_tasks_end+0x50) [0x5632c144a938]
Apr 29 21:45:34 magma-dev-focal mme[491356]: /usr/local/bin/mme(main+0x37d) [0x5632c0ddcde6]
```


But more importantly, [this stackoverflow post](https://stackoverflow.com/questions/21361226/is-sigsegv-special-when-generated-by-kill) explains nicely the difference between asynchronously and synchronously delivered signals.
When SIGSEGV etc. are not delivered by (`kill`, `raise`, etc.) they cannot be waited for by functions like `sigwait`.
If this is tru, SIGSEGV caused by null dereferences do not go through this signal handling mechanism.
This has not really produced issues in MME for now, but for reasons that are not clear to me yet, this makes it so that crashpad/breakpad (Sentry backend for crash reporting) cannot catch crashes due to segfaults.

Since collecting crash reports is not that useful if we can't catch segfaults, this PR will unmask the SIGSEGV signal.
If we decide we really want to print out a stacktrace before crashing, we can do this with `sigaction` later on. (Hopefully if Sentry proves to be useful we might not need it :) ) 



<!-- Enumerate changes you made and why you made them -->

## Test Plan
S1AP tests
`s1aptests/test_3495_timer_for_default_bearer_with_mme_restart.py` still results in SEGV+coredump
segfault are now caught by sentry! (YAY)
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->

<!--
    Final note

    Please take a moment to read through the Magma project's
    - Contributing conventions: https://docs.magmacore.org/docs/next/contributing/contribute_conventions

    If this is your first time opening a PR, also consider reading
    - Developer onboarding: https://docs.magmacore.org/docs/next/contributing/contribute_onboarding
    - Development workflow: https://docs.magmacore.org/docs/next/contributing/contribute_workflow
-->
