### PR TITLE
[CODEOWNERS] Update all non-CI related directories to point to teams

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -11,33 +11,37 @@ orc8r/tools/packer/ @rdefosse @tmdzk @mattymo @119Vik
 orc8r/cloud/deploy/bare-metal/ @rdefosse @tmdzk @mattymo @119Vik
 orc8r/cloud/deploy/bare-metal-ansible/ @rdefosse @mattymo @119Vik
 
-orc8r/gateway/c/ @themarwhal @ardzoht
+orc8r/gateway/c/ @magma/approvers-agw-c
 
 feg/ @magma/feg-approvers
 
 cwf/ @magma/approvers-cwf
 cwf/gateway/Vagrantfile @rdefosse @mattymo @119Vik @tmdzk
 
-openwrt/ @emakeev @uri200
+openwrt/ @magma/approvers-openwrt
 
 # More specific mappings for lte/gateway will override this top-level one
-lte/gateway @ardzoht @pshelar
-lte/gateway/c/session_manager @themarwhal @uri200
-lte/gateway/c/oai @ssanadhya @ulaskozat @lionelgo @ardzoht
-lte/gateway/c/sctpd @ssanadhya @ulaskozat
+lte/gateway @magma/approvers-agw
+lte/gateway/python @magma/approvers-agw-python
+lte/gateway/c @magma/approvers-agw-c
+
+lte/gateway/c/session_manager @magma/approvers-agw-sessiond
+lte/gateway/c/oai @magma/approvers-agw-mme
+lte/gateway/c/sctpd @magma/approvers-agw-mme
 lte/gateway/c/connection_tracker @koolzz
+lte/gateway/python/magma/pipelined @magma/approvers-agw-pipelined
+lte/gateway/python/integ_tests @magma/approvers-agw-integtests
+
 lte/gateway/docker @rdefosse @119Vik @tmdzk
 lte/gateway/release @rdefosse @119Vik @tmdzk
-lte/gateway/python/magma/pipelined @koolzz @pshelar
-lte/gateway/python/integ_tests @ssanadhya @ulaskozat @ardzoht
 lte/gateway/Vagrantfile @rdefosse @mattymo @119Vik @tmdzk
 
 **/*.pb.go @magma/repo-magma-maintain
 **/*_swaggergen.go @magma/repo-magma-maintain
 
 # xwf Magma integrations
-xwf/ @AyliD @aharonnovo @r-i-g
-feg/radius @AyliD @aharonnovo @r-i-g @magma/approvers-cwf
+xwf/ @magma/approvers-xwf
+feg/radius @magma/approvers-xwf @magma/approvers-cwf
 
 nms/ @magma/approvers-nms
 


### PR DESCRIPTION
Signed-off-by: Marie Bremner <marwhal@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary
Discussion on the approvers-* team based PR reviews: https://github.com/magma/magma/discussions/6218

This PR covers all non-CI related migration. (We still have one more vote pending on that)

New teams created:
* https://github.com/orgs/magma/teams/approvers-agw
* https://github.com/orgs/magma/teams/approvers-agw-c
* https://github.com/orgs/magma/teams/approvers-agw-python
* https://github.com/orgs/magma/teams/approvers-agw-mme
* https://github.com/orgs/magma/teams/approvers-agw-sessiond
* https://github.com/orgs/magma/teams/approvers-agw-pipelined
* https://github.com/orgs/magma/teams/approvers-agw-integtests
* https://github.com/orgs/magma/teams/approvers-xwf
* https://github.com/orgs/magma/teams/approvers-openwrt


<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->

<!--
    Final note

    Please take a moment to read through the Magma project's
    - Contributing conventions: https://docs.magmacore.org/docs/next/contributing/contribute_conventions

    If this is your first time opening a PR, also consider reading
    - Developer onboarding: https://docs.magmacore.org/docs/next/contributing/contribute_onboarding
    - Development workflow: https://docs.magmacore.org/docs/next/contributing/contribute_workflow
-->
