### PR TITLE
[CODEOWNERS] Change orc8r/feg team names from *-approvers to approvers-*

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -3,17 +3,17 @@ circleci/ @rdefosse @tmdzk @mattymo @119Vik
 
 ci-scripts/ @rdefosse @tmdzk @mattymo @119Vik
 
-*/cloud/ @magma/orc8r-approvers
-.golangci.yml @magma/orc8r-approvers
+*/cloud/ @magma/approvers-orc8r
+.golangci.yml @magma/approvers-orc8r
 
-orc8r/ @magma/orc8r-approvers
+orc8r/ @magma/approvers-orc8r
 orc8r/tools/packer/ @rdefosse @tmdzk @mattymo @119Vik
 orc8r/cloud/deploy/bare-metal/ @rdefosse @tmdzk @mattymo @119Vik
 orc8r/cloud/deploy/bare-metal-ansible/ @rdefosse @mattymo @119Vik
 
 orc8r/gateway/c/ @themarwhal @ardzoht
 
-feg/ @magma/feg-approvers
+feg/ @magma/approvers-feg
 
 cwf/ @magma/approvers-cwf
 cwf/gateway/Vagrantfile @rdefosse @mattymo @119Vik @tmdzk


### PR DESCRIPTION
Signed-off-by: Marie Bremner <marwhal@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary
Renaming orc8r-approvers and feg-approvers to approvers-orc8r and approvers-feg 
I will rename the actual github teams once this PR is ready to be merged. 
<!-- Enumerate changes you made and why you made them -->

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [X] This change is backwards-breaking
After this PR is merged, I'll make an announcement to have anyone dealing with PRs in feg/orc8r directories to rebase onto master. This way the codeownership changes will get applied properly. 

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->

<!--
    Final note

    Please take a moment to read through the Magma project's
    - Contributing conventions: https://docs.magmacore.org/docs/next/contributing/contribute_conventions

    If this is your first time opening a PR, also consider reading
    - Developer onboarding: https://docs.magmacore.org/docs/next/contributing/contribute_onboarding
    - Development workflow: https://docs.magmacore.org/docs/next/contributing/contribute_workflow
-->
