### PR TITLE
[feg] Replaced golang.org/x/net/context with context

### DIFF
--- a/feg/gateway/registry/registry_test.go
+++ b/feg/gateway/registry/registry_test.go
@@ -14,6 +14,7 @@ limitations under the License.
 package registry_test
 
 import (
+	"context"
 	"fmt"
 	"net"
 	"strconv"
@@ -21,14 +22,12 @@ import (
 	"testing"
 	"time"
 
-	"magma/feg/gateway/registry"
-
 	"github.com/stretchr/testify/assert"
-	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/metadata"
 
 	"magma/feg/cloud/go/protos"
+	"magma/feg/gateway/registry"
 	"magma/gateway/service_registry"
 	platform_registry "magma/orc8r/lib/go/registry"
 	"magma/orc8r/lib/go/service/config"

--- a/feg/gateway/services/aaa/aaa_server/aaa_aka_auth_test.go
+++ b/feg/gateway/services/aaa/aaa_server/aaa_aka_auth_test.go
@@ -14,12 +14,11 @@ limitations under the License.
 package main_test
 
 import (
+	"context"
 	"os"
 	"reflect"
 	"testing"
 	"time"
-
-	"golang.org/x/net/context"
 
 	cp "magma/feg/cloud/go/protos"
 	"magma/feg/cloud/go/protos/mconfig"

--- a/feg/gateway/services/aaa/client/client_api.go
+++ b/feg/gateway/services/aaa/client/client_api.go
@@ -17,11 +17,11 @@ limitations under the License.
 package client
 
 import (
+	"context"
 	"errors"
 	"fmt"
 
 	"github.com/golang/glog"
-	"golang.org/x/net/context"
 
 	"magma/feg/gateway/registry"
 	"magma/feg/gateway/services/aaa/protos"

--- a/feg/gateway/services/aaa/servicers/accounting.go
+++ b/feg/gateway/services/aaa/servicers/accounting.go
@@ -15,13 +15,13 @@ limitations under the License.
 package servicers
 
 import (
+	"context"
 	"fmt"
 	"net"
 	"strings"
 	"time"
 
 	"github.com/golang/glog"
-	"golang.org/x/net/context"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 

--- a/feg/gateway/services/aaa/servicers/authenticator.go
+++ b/feg/gateway/services/aaa/servicers/authenticator.go
@@ -15,12 +15,12 @@ limitations under the License.
 package servicers
 
 import (
+	"context"
 	"fmt"
 	"time"
 
 	"github.com/emakeev/snowflake"
 	"github.com/golang/glog"
-	"golang.org/x/net/context"
 	"google.golang.org/grpc/codes"
 
 	"magma/feg/cloud/go/protos/mconfig"

--- a/feg/gateway/services/aaa/servicers/responders.go
+++ b/feg/gateway/services/aaa/servicers/responders.go
@@ -15,12 +15,12 @@ limitations under the License.
 package servicers
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
 	"github.com/golang/glog"
 	"github.com/golang/protobuf/proto"
-	"golang.org/x/net/context"
 	"google.golang.org/grpc/codes"
 
 	fegprotos "magma/feg/cloud/go/protos"

--- a/feg/gateway/services/aaa/session_manager/client_api.go
+++ b/feg/gateway/services/aaa/session_manager/client_api.go
@@ -15,11 +15,11 @@ limitations under the License.
 package session_manager
 
 import (
+	"context"
 	"errors"
 	"fmt"
 
 	"github.com/golang/glog"
-	"golang.org/x/net/context"
 
 	"magma/feg/gateway/registry"
 	"magma/lte/cloud/go/protos"

--- a/feg/gateway/services/aaa/test/mock_pipelined/services.go
+++ b/feg/gateway/services/aaa/test/mock_pipelined/services.go
@@ -14,12 +14,12 @@
 package mock_pipelined
 
 import (
+	"context"
 	"fmt"
 	"net"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"golang.org/x/net/context"
 
 	"magma/feg/gateway/registry"
 	"magma/lte/cloud/go/protos"

--- a/feg/gateway/services/aaa/test/mock_sessiond/services.go
+++ b/feg/gateway/services/aaa/test/mock_sessiond/services.go
@@ -15,10 +15,9 @@
 package mock_sessiond
 
 import (
+	"context"
 	"fmt"
 	"testing"
-
-	"golang.org/x/net/context"
 
 	"magma/feg/gateway/registry"
 	"magma/lte/cloud/go/protos"

--- a/feg/gateway/services/aaa/test/pipelined/main.go
+++ b/feg/gateway/services/aaa/test/pipelined/main.go
@@ -14,12 +14,12 @@
 package main
 
 import (
+	"context"
 	"flag"
 	"net"
 	"time"
 
 	"github.com/golang/glog"
-	"golang.org/x/net/context"
 
 	"magma/feg/gateway/registry"
 	"magma/lte/cloud/go/protos"

--- a/feg/gateway/services/csfb/servicers/csfb.go
+++ b/feg/gateway/services/csfb/servicers/csfb.go
@@ -14,13 +14,14 @@ limitations under the License.
 package servicers
 
 import (
+	"context"
+
 	"magma/feg/cloud/go/protos"
 	"magma/feg/cloud/go/protos/mconfig"
 	"magma/feg/gateway/services/csfb/servicers/encode/message"
 	orcprotos "magma/orc8r/lib/go/protos"
 
 	"github.com/golang/glog"
-	"golang.org/x/net/context"
 )
 
 type PortNumber = int

--- a/feg/gateway/services/csfb/servicers/test/csfb_sctp_integration_test.go
+++ b/feg/gateway/services/csfb/servicers/test/csfb_sctp_integration_test.go
@@ -14,18 +14,18 @@ limitations under the License.
 package test
 
 import (
+	"context"
 	"testing"
 	"unsafe"
+
+	"github.com/ishidawataru/sctp"
+	"github.com/stretchr/testify/assert"
 
 	"magma/feg/cloud/go/protos"
 	"magma/feg/gateway/services/csfb/servicers"
 	"magma/feg/gateway/services/csfb/servicers/encode/message"
 	"magma/feg/gateway/services/csfb/test_init"
 	orcprotos "magma/orc8r/lib/go/protos"
-
-	"github.com/ishidawataru/sctp"
-	"github.com/stretchr/testify/assert"
-	"golang.org/x/net/context"
 )
 
 func TestCsfbServer_EPSDetach_Integration(t *testing.T) {

--- a/feg/gateway/services/csfb/servicers/test/csfb_test.go
+++ b/feg/gateway/services/csfb/servicers/test/csfb_test.go
@@ -14,6 +14,7 @@ limitations under the License.
 package test
 
 import (
+	"context"
 	"testing"
 
 	"magma/feg/cloud/go/protos"
@@ -24,7 +25,6 @@ import (
 	orcprotos "magma/orc8r/lib/go/protos"
 
 	"github.com/stretchr/testify/assert"
-	"golang.org/x/net/context"
 )
 
 const mandatoryFieldLength = decode.LengthIEI + decode.LengthLengthIndicator

--- a/feg/gateway/services/eap/eap_router/eap_router_test.go
+++ b/feg/gateway/services/eap/eap_router/eap_router_test.go
@@ -14,23 +14,22 @@ limitations under the License.
 package main_test
 
 import (
+	"context"
 	"os"
 	"reflect"
 	"testing"
 	"time"
 
-	"magma/feg/gateway/services/eap"
-	"magma/feg/gateway/services/eap/providers/aka"
-
-	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 
 	cp "magma/feg/cloud/go/protos"
 	"magma/feg/cloud/go/protos/mconfig"
 	"magma/feg/gateway/registry"
 	"magma/feg/gateway/services/aaa/protos"
+	"magma/feg/gateway/services/eap"
 	eap_client "magma/feg/gateway/services/eap/client"
 	eapp "magma/feg/gateway/services/eap/protos"
+	"magma/feg/gateway/services/eap/providers/aka"
 	"magma/feg/gateway/services/eap/providers/aka/servicers"
 	_ "magma/feg/gateway/services/eap/providers/aka/servicers/handlers"
 	eap_test "magma/feg/gateway/services/eap/test"

--- a/feg/gateway/services/eap/eap_router/main.go
+++ b/feg/gateway/services/eap/eap_router/main.go
@@ -15,8 +15,9 @@ limitations under the License.
 package main
 
 import (
+	"context"
+
 	"github.com/golang/glog"
-	"golang.org/x/net/context"
 
 	"magma/feg/gateway/registry"
 	"magma/feg/gateway/services/aaa/protos"

--- a/feg/gateway/services/eap/eap_router/sample_eap_client/grpc_client.go
+++ b/feg/gateway/services/eap/eap_router/sample_eap_client/grpc_client.go
@@ -15,13 +15,13 @@ limitations under the License.
 package main
 
 import (
+	"context"
 	"flag"
 	"log"
 	"reflect"
 	"time"
 
 	"github.com/golang/glog"
-	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 
 	"magma/feg/gateway/services/aaa/protos"

--- a/feg/gateway/services/eap/providers/aka/provider/client_api.go
+++ b/feg/gateway/services/eap/providers/aka/provider/client_api.go
@@ -17,6 +17,7 @@ limitations under the License.
 package provider
 
 import (
+	"context"
 	"errors"
 	"fmt"
 
@@ -24,7 +25,6 @@ import (
 	"magma/feg/gateway/services/eap/providers/aka/servicers"
 
 	"github.com/golang/glog"
-	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 
 	"magma/feg/gateway/registry"

--- a/feg/gateway/services/eap/providers/aka/servicers/handlers/aka_identity_test.go
+++ b/feg/gateway/services/eap/providers/aka/servicers/handlers/aka_identity_test.go
@@ -13,14 +13,13 @@ limitations under the License.
 package handlers
 
 import (
+	"context"
 	"os"
 	"reflect"
 	"testing"
 
 	"magma/feg/gateway/services/eap"
 	"magma/feg/gateway/services/eap/providers/aka"
-
-	"golang.org/x/net/context"
 
 	cp "magma/feg/cloud/go/protos"
 	"magma/feg/gateway/registry"

--- a/feg/gateway/services/eap/providers/aka/servicers/rpc.go
+++ b/feg/gateway/services/eap/providers/aka/servicers/rpc.go
@@ -15,9 +15,9 @@ limitations under the License.
 package servicers
 
 import (
+	"context"
 	"io"
 
-	"golang.org/x/net/context"
 	"google.golang.org/grpc/codes"
 
 	"magma/feg/gateway/services/aaa/protos"

--- a/feg/gateway/services/eap/providers/sim/provider/client_api.go
+++ b/feg/gateway/services/eap/providers/sim/provider/client_api.go
@@ -17,19 +17,18 @@ limitations under the License.
 package provider
 
 import (
+	"context"
 	"errors"
 	"fmt"
 
-	"magma/feg/gateway/services/eap/providers"
-	"magma/feg/gateway/services/eap/providers/sim/servicers"
-
 	"github.com/golang/glog"
-	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 
 	"magma/feg/gateway/registry"
 	"magma/feg/gateway/services/aaa/protos"
 	eapp "magma/feg/gateway/services/eap/protos"
+	"magma/feg/gateway/services/eap/providers"
+	"magma/feg/gateway/services/eap/providers/sim/servicers"
 	_ "magma/feg/gateway/services/eap/providers/sim/servicers/handlers"
 )
 

--- a/feg/gateway/services/eap/providers/sim/servicers/handlers/sim_start_test.go
+++ b/feg/gateway/services/eap/providers/sim/servicers/handlers/sim_start_test.go
@@ -13,14 +13,13 @@ limitations under the License.
 package handlers
 
 import (
+	"context"
 	"os"
 	"reflect"
 	"testing"
 
 	"magma/feg/gateway/services/eap"
 	"magma/feg/gateway/services/eap/providers/sim"
-
-	"golang.org/x/net/context"
 
 	cp "magma/feg/cloud/go/protos"
 	"magma/feg/gateway/registry"

--- a/feg/gateway/services/eap/providers/sim/servicers/rpc.go
+++ b/feg/gateway/services/eap/providers/sim/servicers/rpc.go
@@ -15,9 +15,9 @@ limitations under the License.
 package servicers
 
 import (
+	"context"
 	"io"
 
-	"golang.org/x/net/context"
 	"google.golang.org/grpc/codes"
 
 	"magma/feg/gateway/services/aaa/protos"

--- a/feg/gateway/services/eap/test/services.go
+++ b/feg/gateway/services/eap/test/services.go
@@ -15,11 +15,11 @@ limitations under the License.
 package test
 
 import (
+	"context"
 	"fmt"
 	"math/rand"
 	"time"
 
-	"golang.org/x/net/context"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 

--- a/feg/gateway/services/envoy_controller/servicers/envoy_controller.go
+++ b/feg/gateway/services/envoy_controller/servicers/envoy_controller.go
@@ -15,11 +15,12 @@ limitations under the License.
 package servicers
 
 import (
+	"context"
+
 	"magma/feg/cloud/go/protos"
 	"magma/feg/gateway/services/envoy_controller/control_plane"
 
 	"github.com/golang/glog"
-	"golang.org/x/net/context"
 )
 
 type envoyControllerService struct {

--- a/feg/gateway/services/envoy_controller/servicers/envoy_controller_test.go
+++ b/feg/gateway/services/envoy_controller/servicers/envoy_controller_test.go
@@ -14,6 +14,7 @@ limitations under the License.
 package servicers_test
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -33,7 +34,6 @@ import (
 	"github.com/golang/protobuf/ptypes"
 	"github.com/golang/protobuf/ptypes/wrappers"
 	"github.com/stretchr/testify/assert"
-	"golang.org/x/net/context"
 )
 
 const (

--- a/feg/gateway/services/feg_hello/servicers/hello.go
+++ b/feg/gateway/services/feg_hello/servicers/hello.go
@@ -14,13 +14,13 @@ limitations under the License.
 package servicers
 
 import (
+	"context"
 	"fmt"
 
 	"magma/feg/cloud/go/protos"
 	"magma/orc8r/cloud/go/http2"
 
 	"github.com/golang/glog"
-	"golang.org/x/net/context"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )

--- a/feg/gateway/services/gateway_health/health_manager/health_manager_test.go
+++ b/feg/gateway/services/gateway_health/health_manager/health_manager_test.go
@@ -14,6 +14,7 @@ limitations under the License.
 package health_manager_test
 
 import (
+	"context"
 	"fmt"
 	"testing"
 	"time"
@@ -28,7 +29,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
-	"golang.org/x/net/context"
 )
 
 type MockHealthServicer struct {

--- a/feg/gateway/services/hlr_proxy/client_api.go
+++ b/feg/gateway/services/hlr_proxy/client_api.go
@@ -17,6 +17,7 @@ limitations under the License.
 package hlr_proxy
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"log"
@@ -25,7 +26,6 @@ import (
 	"magma/feg/cloud/go/protos/hlr"
 	"magma/feg/gateway/registry"
 
-	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 )
 

--- a/feg/gateway/services/s6a_proxy/servicers/s6a_proxy.go
+++ b/feg/gateway/services/s6a_proxy/servicers/s6a_proxy.go
@@ -16,6 +16,7 @@ limitations under the License.
 package servicers
 
 import (
+	"context"
 	"fmt"
 	"time"
 
@@ -24,7 +25,6 @@ import (
 	"github.com/fiorix/go-diameter/v4/diam/datatype"
 	"github.com/fiorix/go-diameter/v4/diam/dict"
 	"github.com/fiorix/go-diameter/v4/diam/sm"
-	"golang.org/x/net/context"
 
 	"magma/feg/cloud/go/protos"
 	"magma/feg/gateway/diameter"

--- a/feg/gateway/services/s6a_proxy/servicers/s6a_proxy_test.go
+++ b/feg/gateway/services/s6a_proxy/servicers/s6a_proxy_test.go
@@ -15,6 +15,7 @@ package servicers_test
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"math/rand"
 	"net"
@@ -23,7 +24,6 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
-	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 
 	"magma/feg/cloud/go/protos"

--- a/feg/gateway/services/session_proxy/credit_control/asr.go
+++ b/feg/gateway/services/session_proxy/credit_control/asr.go
@@ -14,11 +14,12 @@ limitations under the License.
 package credit_control
 
 import (
+	"context"
+
 	"github.com/fiorix/go-diameter/v4/diam"
 	"github.com/fiorix/go-diameter/v4/diam/avp"
 	"github.com/fiorix/go-diameter/v4/diam/datatype"
 	"github.com/golang/glog"
-	"golang.org/x/net/context"
 
 	"magma/feg/gateway/diameter"
 	"magma/feg/gateway/services/session_proxy/relay"

--- a/feg/gateway/services/session_proxy/credit_control/gx/gx_client_test.go
+++ b/feg/gateway/services/session_proxy/credit_control/gx/gx_client_test.go
@@ -15,6 +15,7 @@ limitations under the License.
 package gx_test
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"net"
@@ -34,7 +35,6 @@ import (
 	"github.com/fiorix/go-diameter/v4/diam/avp"
 	"github.com/fiorix/go-diameter/v4/diam/datatype"
 	"github.com/stretchr/testify/assert"
-	"golang.org/x/net/context"
 )
 
 const (

--- a/feg/gateway/services/session_proxy/credit_control/gy/gy_client_test.go
+++ b/feg/gateway/services/session_proxy/credit_control/gy/gy_client_test.go
@@ -15,6 +15,7 @@ limitations under the License.
 package gy_test
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"testing"
@@ -22,7 +23,6 @@ import (
 
 	"github.com/fiorix/go-diameter/v4/diam"
 	"github.com/stretchr/testify/assert"
-	"golang.org/x/net/context"
 
 	fegprotos "magma/feg/cloud/go/protos"
 	"magma/feg/cloud/go/protos/mconfig"

--- a/feg/gateway/services/session_proxy/credit_control/gy/handlers.go
+++ b/feg/gateway/services/session_proxy/credit_control/gy/handlers.go
@@ -14,9 +14,10 @@ limitations under the License.
 package gy
 
 import (
+	"context"
+
 	"github.com/fiorix/go-diameter/v4/diam"
 	"github.com/golang/glog"
-	"golang.org/x/net/context"
 
 	"magma/feg/gateway/diameter"
 	"magma/feg/gateway/services/session_proxy/relay"

--- a/feg/gateway/services/session_proxy/servicers/multiple_session_controller.go
+++ b/feg/gateway/services/session_proxy/servicers/multiple_session_controller.go
@@ -14,6 +14,7 @@
 package servicers
 
 import (
+	"context"
 	"fmt"
 	"sync"
 
@@ -27,7 +28,6 @@ import (
 	orcprotos "magma/orc8r/lib/go/protos"
 
 	"github.com/golang/glog"
-	"golang.org/x/net/context"
 )
 
 // How CentralSessionControllers works

--- a/feg/gateway/services/session_proxy/servicers/session_controller.go
+++ b/feg/gateway/services/session_proxy/servicers/session_controller.go
@@ -14,6 +14,7 @@ limitations under the License.
 package servicers
 
 import (
+	"context"
 	"fmt"
 	"sync"
 	"time"
@@ -31,7 +32,6 @@ import (
 
 	"github.com/golang/glog"
 	"github.com/thoas/go-funk"
-	"golang.org/x/net/context"
 )
 
 // CentralSessionController acts as the gRPC server for accepting calls from

--- a/feg/gateway/services/session_proxy/servicers/session_controller_test.go
+++ b/feg/gateway/services/session_proxy/servicers/session_controller_test.go
@@ -14,6 +14,7 @@ limitations under the License.
 package servicers_test
 
 import (
+	"context"
 	"fmt"
 	"testing"
 	"time"
@@ -37,7 +38,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/thoas/go-funk"
-	"golang.org/x/net/context"
 )
 
 const (

--- a/feg/gateway/services/swx_proxy/client_api.go
+++ b/feg/gateway/services/swx_proxy/client_api.go
@@ -17,12 +17,12 @@ limitations under the License.
 package swx_proxy
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"strings"
 
 	"github.com/golang/glog"
-	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 
 	"magma/feg/cloud/go/protos"

--- a/feg/gateway/services/swx_proxy/servicers/multiple_swx_proxy.go
+++ b/feg/gateway/services/swx_proxy/servicers/multiple_swx_proxy.go
@@ -14,6 +14,7 @@
 package servicers
 
 import (
+	"context"
 	"fmt"
 
 	"magma/feg/cloud/go/protos"
@@ -21,8 +22,6 @@ import (
 	"magma/feg/gateway/multiplex"
 	"magma/orc8r/lib/go/errors"
 	orcprotos "magma/orc8r/lib/go/protos"
-
-	"golang.org/x/net/context"
 )
 
 // How SwxProxies works

--- a/feg/gateway/services/swx_proxy/servicers/rt.go
+++ b/feg/gateway/services/swx_proxy/servicers/rt.go
@@ -14,13 +14,13 @@
 package servicers
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/fiorix/go-diameter/v4/diam"
 	"github.com/fiorix/go-diameter/v4/diam/avp"
 	"github.com/fiorix/go-diameter/v4/diam/datatype"
 	"github.com/golang/glog"
-	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 
 	"magma/feg/cloud/go/protos"

--- a/feg/gateway/services/swx_proxy/servicers/swx_proxy.go
+++ b/feg/gateway/services/swx_proxy/servicers/swx_proxy.go
@@ -16,10 +16,9 @@ limitations under the License.
 package servicers
 
 import (
+	"context"
 	"fmt"
 	"time"
-
-	"magma/feg/gateway/services/hlr_proxy"
 
 	"github.com/fiorix/go-diameter/v4/diam"
 	"github.com/fiorix/go-diameter/v4/diam/avp"
@@ -27,12 +26,12 @@ import (
 	"github.com/fiorix/go-diameter/v4/diam/dict"
 	"github.com/fiorix/go-diameter/v4/diam/sm"
 	"github.com/golang/glog"
-	"golang.org/x/net/context"
 
 	"magma/feg/cloud/go/protos"
 	"magma/feg/gateway/diameter"
 	"magma/feg/gateway/plmn_filter"
 	"magma/feg/gateway/registry"
+	"magma/feg/gateway/services/hlr_proxy"
 	"magma/feg/gateway/services/swx_proxy/cache"
 	"magma/feg/gateway/services/swx_proxy/metrics"
 	orcprotos "magma/orc8r/lib/go/protos"

--- a/feg/gateway/services/testcore/hss/client_api.go
+++ b/feg/gateway/services/testcore/hss/client_api.go
@@ -17,6 +17,7 @@
 package hss
 
 import (
+	"context"
 	"errors"
 	"fmt"
 
@@ -25,7 +26,6 @@ import (
 	lteprotos "magma/lte/cloud/go/protos"
 
 	"github.com/golang/glog"
-	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 )
 

--- a/feg/gateway/services/testcore/hss/servicers/hss.go
+++ b/feg/gateway/services/testcore/hss/servicers/hss.go
@@ -14,6 +14,7 @@ limitations under the License.
 package servicers
 
 import (
+	"context"
 	"time"
 
 	"github.com/emakeev/milenage"
@@ -22,7 +23,6 @@ import (
 	"github.com/fiorix/go-diameter/v4/diam/datatype"
 	"github.com/fiorix/go-diameter/v4/diam/dict"
 	"github.com/fiorix/go-diameter/v4/diam/sm"
-	"golang.org/x/net/context"
 
 	"magma/feg/cloud/go/protos/mconfig"
 	"magma/feg/gateway/diameter"

--- a/feg/gateway/services/testcore/ocs/mock_ocs/ocs.go
+++ b/feg/gateway/services/testcore/ocs/mock_ocs/ocs.go
@@ -14,6 +14,7 @@ limitations under the License.
 package mock_ocs
 
 import (
+	"context"
 	"fmt"
 	"net"
 	"time"
@@ -32,7 +33,6 @@ import (
 	"github.com/fiorix/go-diameter/v4/diam/sm/smpeer"
 	"github.com/golang/glog"
 	"github.com/pkg/errors"
-	"golang.org/x/net/context"
 )
 
 const DiameterCreditLimitReached = 4012


### PR DESCRIPTION
Signed-off-by: Oriol Batalla <obatalla@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary

We are still using `golang.org/x/net/context`. That module was  introduced to go in 1.7, so we should be using just `context`


## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

make precommit

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->

<!--
    Final note

    Please take a moment to read through the Magma project's
    - Contributing conventions: https://docs.magmacore.org/docs/next/contributing/contribute_conventions

    If this is your first time opening a PR, also consider reading
    - Developer onboarding: https://docs.magmacore.org/docs/next/contributing/contribute_onboarding
    - Development workflow: https://docs.magmacore.org/docs/next/contributing/contribute_workflow
-->
