### PR TITLE
<feat:>[SessionD]: Store teids from PolicyBearerBindingRequest

### DIFF
--- a/lte/gateway/c/session_manager/StoredState.cpp
+++ b/lte/gateway/c/session_manager/StoredState.cpp
@@ -405,8 +405,14 @@ BearerIDByPolicyID deserialize_bearer_id_by_policy(std::string& serialized) {
   for (auto& bearer_id_by_policy : marshaled) {
     PolicyType policy_type = PolicyType(bearer_id_by_policy["type"].getInt());
     std::string rule_id    = bearer_id_by_policy["rule_id"].getString();
-    stored[PolicyID(policy_type, rule_id)] =
+    auto policy_id         = PolicyID(policy_type, rule_id);
+    stored[policy_id]      = BearerIDAndTeid();
+    stored[policy_id].bearer_id =
         static_cast<uint32_t>(bearer_id_by_policy["bearer_id"].getInt());
+    stored[policy_id].teids.set_agw_teid(
+        static_cast<uint32_t>(bearer_id_by_policy["agw_teid"].getInt()));
+    stored[policy_id].teids.set_enb_teid(
+        static_cast<uint32_t>(bearer_id_by_policy["enb_teid"].getInt()));
   }
   return stored;
 }
@@ -418,7 +424,11 @@ std::string serialize_bearer_id_by_policy(BearerIDByPolicyID bearer_map) {
     folly::dynamic bearer_id_by_policy = folly::dynamic::object;
     bearer_id_by_policy["type"]      = static_cast<int>(pair.first.policy_type);
     bearer_id_by_policy["rule_id"]   = pair.first.rule_id;
-    bearer_id_by_policy["bearer_id"] = static_cast<int>(pair.second);
+    bearer_id_by_policy["bearer_id"] = static_cast<int>(pair.second.bearer_id);
+    bearer_id_by_policy["agw_teid"] =
+        static_cast<int>(pair.second.teids.agw_teid());
+    bearer_id_by_policy["enb_teid"] =
+        static_cast<int>(pair.second.teids.enb_teid());
     marshaled.push_back(bearer_id_by_policy);
   }
   std::string serialized = folly::toJson(marshaled);

--- a/lte/gateway/c/session_manager/Types.h
+++ b/lte/gateway/c/session_manager/Types.h
@@ -179,7 +179,19 @@ struct PolicyIDHash {
   }
 };
 
-typedef std::unordered_map<PolicyID, uint32_t, PolicyIDHash> BearerIDByPolicyID;
+bool operator==(const Teids& lhs, const Teids& rhs);
+
+struct BearerIDAndTeid {
+  uint32_t bearer_id;
+  Teids teids;
+
+  bool operator==(const BearerIDAndTeid& id) const {
+    return bearer_id == id.bearer_id && teids == id.teids;
+  }
+};
+
+typedef std::unordered_map<PolicyID, BearerIDAndTeid, PolicyIDHash>
+    BearerIDByPolicyID;
 
 struct RulesToProcess {
   // If this vector is set, then it has PolicyRule definitions for both static

--- a/lte/gateway/c/session_manager/test/ProtobufCreators.cpp
+++ b/lte/gateway/c/session_manager/test/ProtobufCreators.cpp
@@ -434,12 +434,15 @@ magma::mconfig::SessionD get_default_mconfig() {
 
 PolicyBearerBindingRequest create_policy_bearer_bind_req(
     const std::string& imsi, const uint32_t linked_bearer_id,
-    const std::string& rule_id, const uint32_t bearer_id) {
+    const std::string& rule_id, const uint32_t bearer_id,
+    const uint32_t agw_teid, const uint32_t enb_teid) {
   PolicyBearerBindingRequest bearer_bind_req;
   bearer_bind_req.mutable_sid()->set_id(imsi);
   bearer_bind_req.set_linked_bearer_id(linked_bearer_id);
   bearer_bind_req.set_policy_rule_id(rule_id);
   bearer_bind_req.set_bearer_id(bearer_id);
+  bearer_bind_req.mutable_teids()->set_agw_teid(agw_teid);
+  bearer_bind_req.mutable_teids()->set_enb_teid(enb_teid);
   return bearer_bind_req;
 }
 

--- a/lte/gateway/c/session_manager/test/ProtobufCreators.h
+++ b/lte/gateway/c/session_manager/test/ProtobufCreators.h
@@ -188,7 +188,8 @@ magma::mconfig::SessionD get_default_mconfig();
 
 PolicyBearerBindingRequest create_policy_bearer_bind_req(
     const std::string& imsi, const uint32_t linked_bearer_id,
-    const std::string& rule_id, const uint32_t bearer_id);
+    const std::string& rule_id, const uint32_t bearer_id,
+    const uint32_t agw_teid, const uint32_t enb_teid);
 
 UpdateTunnelIdsRequest create_update_tunnel_ids_request(
     const std::string& imsi, const uint32_t bearer_id, const Teids teids);

--- a/lte/gateway/c/session_manager/test/test_local_enforcer.cpp
+++ b/lte/gateway/c/session_manager/test/test_local_enforcer.cpp
@@ -1895,8 +1895,9 @@ TEST_F(LocalEnforcerTest, test_dedicated_bearer_creation_on_session_init) {
   // the policy to be tied a bearer already
   session_map = session_store->read_sessions({IMSI1});
   auto update = SessionStore::get_default_session_update(session_map);
-  auto bearer_bind_req_success1 = create_policy_bearer_bind_req(
-      IMSI1, default_bearer_id, "rule1", bearer_1);
+  PolicyBearerBindingRequest bearer_bind_req_success1 =
+      create_policy_bearer_bind_req(
+          IMSI1, default_bearer_id, "rule1", bearer_1, 1, 2);
   local_enforcer->bind_policy_to_bearer(
       session_map, bearer_bind_req_success1, update);
   // Write + Read in/from SessionStore
@@ -1997,10 +1998,12 @@ TEST_F(LocalEnforcerTest, test_dedicated_bearer_lifecycle) {
   // Progress the loop to run the scheduled bearer creation request
   evb->loopOnce();
   // Test successful creation of dedicated bearer for rule1 + rule2
-  auto bearer_bind_req_success1 = create_policy_bearer_bind_req(
-      IMSI1, default_bearer_id, "rule1", bearer_1);
-  auto bearer_bind_req_success2 = create_policy_bearer_bind_req(
-      IMSI1, default_bearer_id, "rule2", bearer_2);
+  PolicyBearerBindingRequest bearer_bind_req_success1 =
+      create_policy_bearer_bind_req(
+          IMSI1, default_bearer_id, "rule1", bearer_1, 1, 2);
+  PolicyBearerBindingRequest bearer_bind_req_success2 =
+      create_policy_bearer_bind_req(
+          IMSI1, default_bearer_id, "rule2", bearer_2, 3, 4);
   std::unordered_set<std::string> rule_ids({"rule1", "rule2"});
   // Expect NO call to PipelineD for rule1
   EXPECT_CALL(
@@ -2014,8 +2017,8 @@ TEST_F(LocalEnforcerTest, test_dedicated_bearer_lifecycle) {
       session_map, bearer_bind_req_success2, update);
 
   // Test unsuccessful creation of dedicated bearer for rule3 (bearer_id = 0)
-  auto bearer_bind_req_fail =
-      create_policy_bearer_bind_req(IMSI1, default_bearer_id, "rule3", 0);
+  PolicyBearerBindingRequest bearer_bind_req_fail =
+      create_policy_bearer_bind_req(IMSI1, default_bearer_id, "rule3", 0, 0, 0);
   EXPECT_CALL(
       *pipelined_client, deactivate_flows_for_rules(
                              IMSI1, testing::_, testing::_, testing::_,

--- a/lte/gateway/c/session_manager/test/test_stored_state.cpp
+++ b/lte/gateway/c/session_manager/test/test_stored_state.cpp
@@ -115,8 +115,12 @@ class StoredStateTest : public ::testing::Test {
 
   BearerIDByPolicyID get_bearer_id_by_policy() {
     BearerIDByPolicyID stored;
-    stored[PolicyID(DYNAMIC, "rule1")] = 32;
-    stored[PolicyID(STATIC, "rule1")]  = 64;
+    stored[PolicyID(DYNAMIC, "rule1")].bearer_id = 32;
+    stored[PolicyID(DYNAMIC, "rule1")].teids.set_agw_teid(1);
+    stored[PolicyID(DYNAMIC, "rule1")].teids.set_enb_teid(2);
+    stored[PolicyID(STATIC, "rule1")].bearer_id = 64;
+    stored[PolicyID(STATIC, "rule1")].teids.set_agw_teid(3);
+    stored[PolicyID(STATIC, "rule1")].teids.set_enb_teid(4);
     return stored;
   }
 
@@ -202,7 +206,7 @@ TEST_F(StoredStateTest, test_stored_bearer_id_by_policy) {
   auto stored       = get_bearer_id_by_policy();
   auto serialized   = serialize_bearer_id_by_policy(stored);
   auto deserialized = deserialize_bearer_id_by_policy(serialized);
-  EXPECT_EQ(stored[PolicyID(DYNAMIC, "rule1")], 32);
+  EXPECT_EQ(stored[PolicyID(DYNAMIC, "rule1")].bearer_id, 32);
   EXPECT_EQ(stored.size(), deserialized.size());
   EXPECT_EQ(
       stored[PolicyID(DYNAMIC, "rule1")],


### PR DESCRIPTION
Signed-off-by: Marie Bremner <marwhal@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary
* In order to migrate to TEID based PipelineD interactions, we will need to send down teids that are consistent with the bearer each policy is served by.
* https://github.com/magma/magma/pull/6638 added dedicated bearer teids to `PolicyBearerBindingRequest`
* This PR will store the TEID values into the bearerIDsByPolicyID map that already exists
<!-- Enumerate changes you made and why you made them -->

## Test Plan
unit tests
should not affect existing flows
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->

<!--
    Final note

    Please take a moment to read through the Magma project's
    - Contributing conventions: https://docs.magmacore.org/docs/next/contributing/contribute_conventions

    If this is your first time opening a PR, also consider reading
    - Developer onboarding: https://docs.magmacore.org/docs/next/contributing/contribute_onboarding
    - Development workflow: https://docs.magmacore.org/docs/next/contributing/contribute_workflow
-->
