### PR TITLE
refactor: Clean up process_rules_to_install to prepare for separating out default and dedicated bearer policies

### DIFF
--- a/lte/gateway/c/session_manager/LocalEnforcer.h
+++ b/lte/gateway/c/session_manager/LocalEnforcer.h
@@ -399,10 +399,10 @@ class LocalEnforcer {
    */
   void process_rules_to_install(
       SessionState& session, const std::string& imsi,
-      std::vector<StaticRuleInstall> static_rule_installs,
-      std::vector<DynamicRuleInstall> dynamic_rule_installs,
-      RulesToProcess& rules_to_activate, RulesToProcess& rules_to_deactivate,
-      SessionStateUpdateCriteria& uc);
+      const std::vector<StaticRuleInstall>& static_rule_installs,
+      const std::vector<DynamicRuleInstall>& dynamic_rule_installs,
+      RulesToProcess* to_activate, RulesToProcess* to_deactivate,
+      SessionStateUpdateCriteria* session_uc);
 
   /**
    * propagate_rule_updates_to_pipelined calls the PipelineD RPC calls to

--- a/lte/gateway/c/session_manager/SessionState.h
+++ b/lte/gateway/c/session_manager/SessionState.h
@@ -574,6 +574,40 @@ class SessionState {
   bool is_dynamic_rule_scheduled(const std::string& rule_id);
 
   /**
+   * @brief Go through static rule install instructions and return
+   * what needs to be propagated to PipelineD
+   *
+   * @param static_rule_installs StaticRuleInstall received from
+   * PCF/PCRF/PolicyDB
+   * @param rules_to_activate output parameter
+   * @param rules_to_deactivate output parameter
+   * @param rules_to_schedule output parameter
+   * @param session_uc
+   */
+  void process_static_rule_installs(
+      const std::vector<StaticRuleInstall>& static_rule_installs,
+      RulesToProcess* rules_to_activate, RulesToProcess* rules_to_deactivate,
+      RulesToSchedule* rules_to_schedule,
+      SessionStateUpdateCriteria* session_uc);
+
+  /**
+   * @brief Go through dynamic rule install instructions and return
+   * what needs to be propagated to PipelineD
+   *
+   * @param dynamic_rule_installs DynamicRuleInstall received from
+   * PCF/PCRF/PolicyDB
+   * @param rules_to_activate output parameter
+   * @param rules_to_deactivate output parameter
+   * @param rules_to_schedule output parameter
+   * @param session_uc
+   */
+  void process_dynamic_rule_installs(
+      const std::vector<DynamicRuleInstall>& dynamic_rule_installs,
+      RulesToProcess* rules_to_activate, RulesToProcess* rules_to_deactivate,
+      RulesToSchedule* rules_to_schedule,
+      SessionStateUpdateCriteria* session_uc);
+
+  /**
    * Clear all per-session metrics
    */
   void clear_session_metrics();

--- a/lte/gateway/c/session_manager/StoredState.cpp
+++ b/lte/gateway/c/session_manager/StoredState.cpp
@@ -586,11 +586,15 @@ bool RuleLifetime::is_within_lifetime(std::time_t time) {
 }
 
 bool RuleLifetime::exceeded_lifetime(std::time_t time) {
-  return deactivation_time != 0 && deactivation_time < time;
+  return deactivation_time != 0 && deactivation_time <= time;
 }
 
 bool RuleLifetime::before_lifetime(std::time_t time) {
   return time < activation_time;
+}
+
+bool RuleLifetime::should_schedule_deactivation(std::time_t time) {
+  return deactivation_time != 0 && time <= deactivation_time;
 }
 
 };  // namespace magma

--- a/lte/gateway/c/session_manager/Types.h
+++ b/lte/gateway/c/session_manager/Types.h
@@ -149,6 +149,7 @@ struct RuleLifetime {
   bool is_within_lifetime(std::time_t time);
   bool exceeded_lifetime(std::time_t time);
   bool before_lifetime(std::time_t time);
+  bool should_schedule_deactivation(std::time_t time);
 };
 
 // QoS Management
@@ -200,6 +201,28 @@ struct RuleToProcess {
 };
 
 typedef std::vector<RuleToProcess> RulesToProcess;
+
+enum PolicyAction {
+  ACTIVATE   = 0,
+  DEACTIVATE = 1,
+};
+
+struct RuleToSchedule {
+  PolicyType p_type;
+  std::string rule_id;
+  PolicyAction p_action;
+  std::time_t scheduled_time;
+  RuleToSchedule() {}
+  RuleToSchedule(
+      PolicyType _p_type, std::string _rule_id, PolicyAction _p_action,
+      std::time_t _time)
+      : p_type(_p_type),
+        rule_id(_rule_id),
+        p_action(_p_action),
+        scheduled_time(_time) {}
+};
+
+typedef std::vector<RuleToSchedule> RulesToSchedule;
 
 struct StatsPerPolicy {
   // The version maintained by SessionD for this rule


### PR DESCRIPTION
Signed-off-by: Marie Bremner <marwhal@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary
In order to fully migrate to Teid based flow/policy identification as opposed to IP, we will need to separate out policies that are served by the default bearer from ones that are served by dedicated bearers. (Each bearer has a unique set of teids)

For policies that are served by dedicated bearers, we will need to delay the flow activation until we receive the matching teids from MME. 

This PR is just a cosmetic change to prepare for the actual change described above. 
More specifically, I cleaned up `process_rules_to_install` in `LocalEnforcer` by splitting the function into two functions (`process_static_rule_installs` and `process_dynamic_rule_installs` in `SessionState`).
<!-- Enumerate changes you made and why you made them -->

## Test Plan
existing unit tests
CI integration tests
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->

<!--
    Final note

    Please take a moment to read through the Magma project's
    - Contributing conventions: https://docs.magmacore.org/docs/next/contributing/contribute_conventions

    If this is your first time opening a PR, also consider reading
    - Developer onboarding: https://docs.magmacore.org/docs/next/contributing/contribute_onboarding
    - Development workflow: https://docs.magmacore.org/docs/next/contributing/contribute_workflow
-->
