### PR TITLE
[lte][agw] Support nonconsecutive PLMNS

### DIFF
--- a/lte/gateway/c/oai/tasks/mme_app/mme_config.c
+++ b/lte/gateway/c/oai/tasks/mme_app/mme_config.c
@@ -763,6 +763,11 @@ int mme_config_parse_file(mme_config_t* config_pP) {
                 config_pP->served_tai.plmn_mnc[i];
             config_pP->served_tai.plmn_mnc[i] = swap16;
 
+            swap16 = config_pP->served_tai.plmn_mnc_len[i - 1];
+            config_pP->served_tai.plmn_mnc_len[i - 1] =
+                config_pP->served_tai.plmn_mnc_len[i];
+            config_pP->served_tai.plmn_mnc_len[i] = swap16;
+
             swap16                           = config_pP->served_tai.tac[i - 1];
             config_pP->served_tai.tac[i - 1] = config_pP->served_tai.tac[i];
             config_pP->served_tai.tac[i]     = swap16;

--- a/lte/gateway/c/oai/tasks/nas/api/mme/mme_api.c
+++ b/lte/gateway/c/oai/tasks/nas/api/mme/mme_api.c
@@ -174,7 +174,7 @@ int mme_api_get_emm_config(
             &(config->tai_list.partial_tai_list[tai_list_i]
                   .u.tai_many_plmn[tac_i]
                   .plmn));
-        AssertFatal(rc == RETURNok, "BAD MNC length for GUMMEI");
+        AssertFatal(rc == RETURNok, "BAD MNC length in SERVED TAI");
         config->tai_list.partial_tai_list[tai_list_i].u.tai_many_plmn[i].tac =
             mme_config_p->served_tai.tac[i];
         ++tac_i;
@@ -206,7 +206,7 @@ int mme_api_get_emm_config(
             &(mme_config_p->served_tai), i,
             &(config->tai_list.partial_tai_list[tai_list_i]
                   .u.tai_one_plmn_non_consecutive_tacs.plmn));
-        AssertFatal(rc == RETURNok, "BAD MNC length for GUMMEI");
+        AssertFatal(rc == RETURNok, "BAD MNC length in SERVED TAI");
         config->tai_list.partial_tai_list[tai_list_i]
             .u.tai_one_plmn_non_consecutive_tacs.tac[tac_i] =
             mme_config_p->served_tai.tac[i];

--- a/lte/gateway/c/oai/tasks/nas/api/mme/mme_api.c
+++ b/lte/gateway/c/oai/tasks/nas/api/mme/mme_api.c
@@ -107,8 +107,9 @@ int mme_api_get_emm_config(
       LOG_NAS, "Number of GUMMEIs supported = %d\n", mme_config_p->gummei.nb);
 
   config->tai_list.numberoflists = 0;
-  // TODO actually we support only one partial TAI list.
-  // reminder mme_config_p->served_tai is sorted in ascending order of TAIs
+  // We can store 16 TAIs per list and have 16 partial lists maximum
+  // As per TS 124.301 V15.4.0 Section 9.9.3.33, we will be sending at most
+  // 16 TAIs for which UE data is set during
   switch (mme_config_p->served_tai.list_type) {
     case TRACKING_AREA_IDENTITY_LIST_TYPE_ONE_PLMN_CONSECUTIVE_TACS: {
       int tai_list_i = 0, tac_i = 0;
@@ -528,6 +529,16 @@ int mme_api_new_guti(
         AssertFatal(
             0, "BAD TAI list configuration, unknown TAI list type %u",
             _emm_data.conf.tai_list.partial_tai_list[i].typeoflist);
+    }
+
+    // TS 124.301 V15.4.0 Section 9.9.3.33:
+    // "The Tracking area identity list is a type 4 information element,
+    // with a minimum length of 8 octets and a maximum length of 98 octets.
+    // The list can contain a maximum of 16 different tracking area identities."
+    // We will limit the number to 1 partial list which can have maximum of 16
+    // TAIs.
+    if (j == 1) {
+      break;  // for loop
     }
   }
   tai_list->numberoflists = j;

--- a/lte/gateway/c/oai/tasks/nas/api/mme/mme_api.c
+++ b/lte/gateway/c/oai/tasks/nas/api/mme/mme_api.c
@@ -73,6 +73,8 @@ static int mme_api_pdn_id = 0;
 
 static tmsi_t generate_random_TMSI(void);
 
+static int copy_plmn_from_config(const served_tai_t*, int index, plmn_t*);
+
 /****************************************************************************/
 /******************  E X P O R T E D    F U N C T I O N S  ******************/
 /****************************************************************************/
@@ -107,153 +109,115 @@ int mme_api_get_emm_config(
   // TODO actually we support only one partial TAI list.
   // reminder mme_config_p->served_tai is sorted in ascending order of TAIs
   switch (mme_config_p->served_tai.list_type) {
-    case TRACKING_AREA_IDENTITY_LIST_TYPE_ONE_PLMN_CONSECUTIVE_TACS:
-      config->tai_list.numberoflists = 1;
-      config->tai_list.partial_tai_list[0].typeoflist =
-          mme_config_p->served_tai.list_type;
-      // LW: number of elements is coded as N-1 (0 -> 1 element, 1 -> 2
-      // elements...), see 3GPP TS 24.301, section 9.9.3.33.1
-      config->tai_list.partial_tai_list[0].numberofelements =
-          mme_config_p->served_tai.nb_tai - 1;
-      config->tai_list.partial_tai_list[0]
-          .u.tai_one_plmn_consecutive_tacs.plmn.mcc_digit1 =
-          (mme_config_p->served_tai.plmn_mcc[0] / 100) % 10;
-      config->tai_list.partial_tai_list[0]
-          .u.tai_one_plmn_consecutive_tacs.plmn.mcc_digit2 =
-          (mme_config_p->served_tai.plmn_mcc[0] / 10) % 10;
-      config->tai_list.partial_tai_list[0]
-          .u.tai_one_plmn_consecutive_tacs.plmn.mcc_digit3 =
-          mme_config_p->served_tai.plmn_mcc[0] % 10;
-      if (mme_config_p->served_tai.plmn_mnc_len[0] == 2) {
-        config->tai_list.partial_tai_list[0]
-            .u.tai_one_plmn_consecutive_tacs.plmn.mnc_digit1 =
-            (mme_config_p->served_tai.plmn_mnc[0] / 10) % 10;
-        config->tai_list.partial_tai_list[0]
-            .u.tai_one_plmn_consecutive_tacs.plmn.mnc_digit2 =
-            mme_config_p->served_tai.plmn_mnc[0] % 10;
-        config->tai_list.partial_tai_list[0]
-            .u.tai_one_plmn_consecutive_tacs.plmn.mnc_digit3 = 0xf;
-      } else if (mme_config_p->served_tai.plmn_mnc_len[0] == 3) {
-        config->tai_list.partial_tai_list[0]
-            .u.tai_one_plmn_consecutive_tacs.plmn.mnc_digit1 =
-            (mme_config_p->served_tai.plmn_mnc[0] / 100) % 10;
-        config->tai_list.partial_tai_list[0]
-            .u.tai_one_plmn_consecutive_tacs.plmn.mnc_digit2 =
-            (mme_config_p->served_tai.plmn_mnc[0] / 10) % 10;
-        config->tai_list.partial_tai_list[0]
-            .u.tai_one_plmn_consecutive_tacs.plmn.mnc_digit3 =
-            mme_config_p->served_tai.plmn_mnc[0] % 10;
-      } else {
-        AssertFatal(
-            (mme_config_p->served_tai.plmn_mnc_len[0] >= 2) &&
-                (mme_config_p->served_tai.plmn_mnc_len[0] <= 3),
-            "BAD MNC length for GUMMEI");
-      }
-      config->tai_list.partial_tai_list[0].u.tai_one_plmn_consecutive_tacs.tac =
-          mme_config_p->served_tai.tac[0];
-      break;
-
-    case TRACKING_AREA_IDENTITY_LIST_TYPE_MANY_PLMNS:
-      config->tai_list.numberoflists = 1;
-      config->tai_list.partial_tai_list[0].typeoflist =
-          mme_config_p->served_tai.list_type;
-      config->tai_list.partial_tai_list[0].numberofelements =
-          mme_config_p->served_tai.nb_tai - 1;
-      for (int i = 0; i < mme_config_p->served_tai.nb_tai; i++) {
-        config->tai_list.partial_tai_list[0]
-            .u.tai_many_plmn[i]
-            .plmn.mcc_digit1 =
-            (mme_config_p->served_tai.plmn_mcc[i] / 100) % 10;
-        config->tai_list.partial_tai_list[0]
-            .u.tai_many_plmn[i]
-            .plmn.mcc_digit2 = (mme_config_p->served_tai.plmn_mcc[i] / 10) % 10;
-        config->tai_list.partial_tai_list[0]
-            .u.tai_many_plmn[i]
-            .plmn.mcc_digit3 = mme_config_p->served_tai.plmn_mcc[i] % 10;
-        if (mme_config_p->served_tai.plmn_mnc_len[0] == 2) {
-          config->tai_list.partial_tai_list[0]
-              .u.tai_many_plmn[i]
-              .plmn.mnc_digit1 =
-              (mme_config_p->served_tai.plmn_mnc[i] / 10) % 10;
-          config->tai_list.partial_tai_list[0]
-              .u.tai_many_plmn[i]
-              .plmn.mnc_digit2 = mme_config_p->served_tai.plmn_mnc[i] % 10;
-          config->tai_list.partial_tai_list[0]
-              .u.tai_many_plmn[i]
-              .plmn.mnc_digit3 = 0xf;
-        } else if (mme_config_p->served_tai.plmn_mnc_len[0] == 3) {
-          config->tai_list.partial_tai_list[0]
-              .u.tai_many_plmn[i]
-              .plmn.mnc_digit1 =
-              (mme_config_p->served_tai.plmn_mnc[i] / 100) % 10;
-          config->tai_list.partial_tai_list[0]
-              .u.tai_many_plmn[i]
-              .plmn.mnc_digit2 =
-              (mme_config_p->served_tai.plmn_mnc[i] / 10) % 10;
-          config->tai_list.partial_tai_list[0]
-              .u.tai_many_plmn[i]
-              .plmn.mnc_digit3 = mme_config_p->served_tai.plmn_mnc[i] % 10;
-        } else {
-          AssertFatal(
-              (mme_config_p->served_tai.plmn_mnc_len[0] >= 2) &&
-                  (mme_config_p->served_tai.plmn_mnc_len[i] <= 3),
-              "BAD MNC length for GUMMEI");
+    case TRACKING_AREA_IDENTITY_LIST_TYPE_ONE_PLMN_CONSECUTIVE_TACS: {
+      int list_i = 0, tac_i = 0;
+      for (int i = 0; i < mme_config_p->served_tai.nb_tai; ++i) {
+        if (tac_i == 16) {  // cannot have more than 16 TACs per partial list
+          // LW: number of elements is coded as N-1 (0 -> 1 element, 1 -> 2
+          // elements...), see 3GPP TS 24.301, section 9.9.3.33.1
+          config->tai_list.partial_tai_list[list_i].numberofelements =
+              tac_i - 1;
+          ++list_i;
+          tac_i = 0;
         }
-        config->tai_list.partial_tai_list[0].u.tai_many_plmn[i].tac =
-            mme_config_p->served_tai.tac[i];
-        // LW: number of elements is coded as N-1 (0 -> 1 element, 1 -> 2
-        // elements...), see 3GPP TS 24.301, section 9.9.3.33.1
+        config->tai_list.partial_tai_list[list_i].typeoflist =
+            mme_config_p->served_tai.list_type;
+        int rc = copy_plmn_from_config(
+            &(mme_config_p->served_tai), i,
+            &(config->tai_list.partial_tai_list[list_i]
+                  .u.tai_one_plmn_consecutive_tacs.plmn));
+        AssertFatal(rc == RETURNok, "BAD MNC length for GUMMEI");
+        config->tai_list.partial_tai_list[list_i]
+            .u.tai_one_plmn_consecutive_tacs.tac =
+            mme_config_p->served_tai.tac[16 * list_i];
+        ++tac_i;
       }
-      break;
-
-    case TRACKING_AREA_IDENTITY_LIST_TYPE_ONE_PLMN_NON_CONSECUTIVE_TACS:
-      config->tai_list.numberoflists = 1;
-      config->tai_list.partial_tai_list[0].typeoflist =
-          mme_config_p->served_tai.list_type;
-      config->tai_list.partial_tai_list[0]
-          .u.tai_one_plmn_non_consecutive_tacs.plmn.mcc_digit1 =
-          (mme_config_p->served_tai.plmn_mcc[0] / 100) % 10;
-      config->tai_list.partial_tai_list[0]
-          .u.tai_one_plmn_non_consecutive_tacs.plmn.mcc_digit2 =
-          (mme_config_p->served_tai.plmn_mcc[0] / 10) % 10;
-      config->tai_list.partial_tai_list[0]
-          .u.tai_one_plmn_non_consecutive_tacs.plmn.mcc_digit3 =
-          mme_config_p->served_tai.plmn_mcc[0] % 10;
-      if (mme_config_p->served_tai.plmn_mnc_len[0] == 2) {
-        config->tai_list.partial_tai_list[0]
-            .u.tai_one_plmn_non_consecutive_tacs.plmn.mnc_digit1 =
-            (mme_config_p->served_tai.plmn_mnc[0] / 10) % 10;
-        config->tai_list.partial_tai_list[0]
-            .u.tai_one_plmn_non_consecutive_tacs.plmn.mnc_digit2 =
-            mme_config_p->served_tai.plmn_mnc[0] % 10;
-        config->tai_list.partial_tai_list[0]
-            .u.tai_one_plmn_non_consecutive_tacs.plmn.mnc_digit3 = 0xf;
-      } else if (mme_config_p->served_tai.plmn_mnc_len[0] == 3) {
-        config->tai_list.partial_tai_list[0]
-            .u.tai_one_plmn_non_consecutive_tacs.plmn.mnc_digit1 =
-            (mme_config_p->served_tai.plmn_mnc[0] / 100) % 10;
-        config->tai_list.partial_tai_list[0]
-            .u.tai_one_plmn_non_consecutive_tacs.plmn.mnc_digit2 =
-            (mme_config_p->served_tai.plmn_mnc[0] / 10) % 10;
-        config->tai_list.partial_tai_list[0]
-            .u.tai_one_plmn_non_consecutive_tacs.plmn.mnc_digit3 =
-            mme_config_p->served_tai.plmn_mnc[0] % 10;
-      } else {
-        AssertFatal(
-            (mme_config_p->served_tai.plmn_mnc_len[0] >= 2) &&
-                (mme_config_p->served_tai.plmn_mnc_len[0] <= 3),
-            "BAD MNC length for GUMMEI");
-      }
-      for (int i = 0; i < mme_config_p->served_tai.nb_tai; i++) {
-        config->tai_list.partial_tai_list[0]
-            .u.tai_one_plmn_non_consecutive_tacs.tac[i] =
-            mme_config_p->served_tai.tac[i];
-      }
+      AssertFatal(
+          list_i < TRACKING_AREA_IDENTITY_LIST_MAXIMUM_NUM_TAI,
+          "Too many TAI partial list in TAI list");
       // LW: number of elements is coded as N-1 (0 -> 1 element, 1 -> 2
       // elements...), see 3GPP TS 24.301, section 9.9.3.33.1
-      config->tai_list.partial_tai_list[0].numberofelements =
-          mme_config_p->served_tai.nb_tai - 1;
+      config->tai_list.partial_tai_list[list_i].numberofelements = tac_i - 1;
+      config->tai_list.numberoflists                             = list_i + 1;
+
       break;
+    }
+    case TRACKING_AREA_IDENTITY_LIST_TYPE_MANY_PLMNS: {
+      // no need to optimize here as we do not really support multi PLMN
+      // use case in Magma yet
+      int list_i = 0, tac_i = 0;
+      uint16_t last_mcc = mme_config_p->served_tai.plmn_mcc[0];
+      uint16_t last_mnc = mme_config_p->served_tai.plmn_mnc[0];
+      for (int i = 0; i < mme_config_p->served_tai.nb_tai; i++) {
+        bool is_plmn_changed = false;
+        if ((mme_config_p->served_tai.plmn_mcc[i] != last_mcc) ||
+            (mme_config_p->served_tai.plmn_mnc[i] != last_mnc)) {
+          last_mcc        = mme_config_p->served_tai.plmn_mcc[i];
+          last_mnc        = mme_config_p->served_tai.plmn_mnc[i];
+          is_plmn_changed = true;
+        }
+        if ((tac_i == 16) || is_plmn_changed) {  // cannot have more than 16
+                                                 // TACs per partial list
+          // LW: number of elements is coded as N-1 (0 -> 1 element, 1 -> 2
+          // elements...), see 3GPP TS 24.301, section 9.9.3.33.1
+          config->tai_list.partial_tai_list[list_i].numberofelements =
+              tac_i - 1;
+          ++list_i;
+          tac_i = 0;
+        }
+        config->tai_list.partial_tai_list[list_i].typeoflist =
+            mme_config_p->served_tai.list_type;
+        int rc = copy_plmn_from_config(
+            &(mme_config_p->served_tai), i,
+            &(config->tai_list.partial_tai_list[list_i]
+                  .u.tai_many_plmn[tac_i]
+                  .plmn));
+        AssertFatal(rc == RETURNok, "BAD MNC length for GUMMEI");
+        config->tai_list.partial_tai_list[list_i].u.tai_many_plmn[i].tac =
+            mme_config_p->served_tai.tac[i];
+        ++tac_i;
+      }
+      AssertFatal(
+          list_i < TRACKING_AREA_IDENTITY_LIST_MAXIMUM_NUM_TAI,
+          "Too many TAI partial list in TAI list");
+      // LW: number of elements is coded as N-1 (0 -> 1 element, 1 -> 2
+      // elements...), see 3GPP TS 24.301, section 9.9.3.33.1
+      config->tai_list.partial_tai_list[list_i].numberofelements = tac_i - 1;
+      config->tai_list.numberoflists                             = list_i + 1;
+      break;
+    }
+    case TRACKING_AREA_IDENTITY_LIST_TYPE_ONE_PLMN_NON_CONSECUTIVE_TACS: {
+      int list_i = 0, tac_i = 0;
+      for (int i = 0; i < mme_config_p->served_tai.nb_tai; ++i) {
+        if (tac_i == 16) {  // cannot have more than 16 TACs per partial list
+          // LW: number of elements is coded as N-1 (0 -> 1 element, 1 -> 2
+          // elements...), see 3GPP TS 24.301, section 9.9.3.33.1
+          config->tai_list.partial_tai_list[list_i].numberofelements =
+              tac_i - 1;
+          ++list_i;
+          tac_i = 0;
+        }
+        config->tai_list.partial_tai_list[list_i].typeoflist =
+            mme_config_p->served_tai.list_type;
+        int rc = copy_plmn_from_config(
+            &(mme_config_p->served_tai), i,
+            &(config->tai_list.partial_tai_list[list_i]
+                  .u.tai_one_plmn_non_consecutive_tacs.plmn));
+        AssertFatal(rc == RETURNok, "BAD MNC length for GUMMEI");
+        config->tai_list.partial_tai_list[list_i]
+            .u.tai_one_plmn_non_consecutive_tacs.tac[tac_i] =
+            mme_config_p->served_tai.tac[i];
+        ++tac_i;
+      }
+      AssertFatal(
+          list_i < TRACKING_AREA_IDENTITY_LIST_MAXIMUM_NUM_TAI,
+          "Too many TAI partial list in TAI list");
+      // LW: number of elements is coded as N-1 (0 -> 1 element, 1 -> 2
+      // elements...), see 3GPP TS 24.301, section 9.9.3.33.1
+      config->tai_list.partial_tai_list[list_i].numberofelements = tac_i - 1;
+      config->tai_list.numberoflists                             = list_i + 1;
+      break;
+    }
     default:
       AssertFatal(
           0, "BAD TAI list configuration, unknown TAI list type %u",
@@ -400,26 +364,26 @@ int mme_api_notify_new_guti(const mme_ue_s1ap_id_t id, guti_t* const guti) {
   OAILOG_FUNC_RETURN(LOG_NAS, RETURNerror);
 }
 
-/****************************************************************************
- **                                                                        **
+/************************************************************************
+ **                                                                    **
  ** Name:    mme_api_new_guti()                                        **
- **                                                                        **
- ** Description: Requests the MME to assign a new GUTI to the UE identi-   **
- **      fied by the given IMSI.                                   **
- **                                                                        **
- ** Description: Requests the MME to assign a new GUTI to the UE identi-   **
- **      fied by the given IMSI and returns the list of consecu-   **
- **      tive tracking areas the UE is registered to.              **
- **                                                                        **
- ** Inputs:  imsi:      International Mobile Subscriber Identity   **
- **      Others:    None                                       **
- **                                                                        **
+ **                                                                    **
+ ** Description: Requests the MME to assign a new GUTI to the UE       **
+ **      identified by the given IMSI.                                 **
+ **                                                                    **
+ ** Description: Requests the MME to assign a new GUTI to the UE       **
+ **      identified by the given IMSI and returns the list of          **
+ **      consecutive tracking areas the UE is registered to.           **
+ **                                                                    **
+ ** Inputs:  imsi:      International Mobile Subscriber Identity       **
+ **      Others:    None                                               **
+ **                                                                    **
  ** Outputs:     guti:      The new assigned GUTI                      **
- **      tai_list:       TAIs belonging to the PLMN **
- **      Return:    RETURNok, RETURNerror                      **
- **      Others:    None                                       **
- **                                                                        **
- ***************************************************************************/
+ **      tai_list:       TAIs belonging to the PLMN                    **
+ **      Return:    RETURNok, RETURNerror                              **
+ **      Others:    None                                               **
+ **                                                                    **
+ ***********************************************************************/
 int mme_api_new_guti(
     const imsi_t* const imsi, const guti_t* const old_guti, guti_t* const guti,
     const tai_t* const originating_tai, tai_list_t* const tai_list) {
@@ -450,7 +414,7 @@ int mme_api_new_guti(
       OAILOG_ERROR(LOG_NAS, "Serving PLMN not matching with GUMMEI List!\n");
       OAILOG_FUNC_RETURN(LOG_NAS, RETURNerror);
     }
-    is_plmn_equal = false;
+
     // TODO Find another way to generate m_tmsi
     guti->m_tmsi = generate_random_TMSI();
     if (guti->m_tmsi == INVALID_M_TMSI) {
@@ -461,7 +425,7 @@ int mme_api_new_guti(
     OAILOG_FUNC_RETURN(LOG_NAS, RETURNerror);
   }
 
-  int j = 0;
+  int j = 0;  // keeps track of number of partial lists with matching PLMN
   for (int i = 0; i < _emm_data.conf.tai_list.numberoflists; i++) {
     /* Comparing mme configuration plmn of TAI_LIST with plmn of GUMMEI_LIST
      * if PLMN matches, _emm_data.conf.tai_list value gets updated with TAI_LIST
@@ -524,46 +488,36 @@ int mme_api_new_guti(
         }
         break;
       case TRACKING_AREA_IDENTITY_LIST_MANY_PLMNS:
-        for (uint8_t p_cnt = 0;
-             p_cnt <
-             (_emm_data.conf.tai_list.partial_tai_list[i].numberofelements + 1);
-             p_cnt++) {
-          if (IS_PLMN_EQUAL(
-                  _emm_data.conf.tai_list.partial_tai_list[i]
-                      .u.tai_many_plmn[p_cnt]
-                      .plmn,
-                  guti->gummei.plmn)) {
-            is_plmn_equal = true;
-            tai_list->partial_tai_list[j].numberofelements =
-                _emm_data.conf.tai_list.partial_tai_list[i].numberofelements;
-            tai_list->partial_tai_list[j].typeoflist =
-                _emm_data.conf.tai_list.partial_tai_list[i].typeoflist;
+        // Each partial list has the same plmn
+        if (IS_PLMN_EQUAL(
+                _emm_data.conf.tai_list.partial_tai_list[i]
+                    .u.tai_many_plmn[0]
+                    .plmn,
+                guti->gummei.plmn)) {
+          tai_list->partial_tai_list[j].numberofelements =
+              _emm_data.conf.tai_list.partial_tai_list[i].numberofelements;
+          tai_list->partial_tai_list[j].typeoflist =
+              _emm_data.conf.tai_list.partial_tai_list[i].typeoflist;
 
-            for (int t = 0;
-                 t < (tai_list->partial_tai_list[j].numberofelements + 1);
-                 t++) {
-              COPY_PLMN(
-                  tai_list->partial_tai_list[j].u.tai_many_plmn[t].plmn,
-                  _emm_data.conf.tai_list.partial_tai_list[i]
-                      .u.tai_many_plmn[t]
-                      .plmn);
+          for (int t = 0;
+               t < (tai_list->partial_tai_list[j].numberofelements + 1); t++) {
+            COPY_PLMN(
+                tai_list->partial_tai_list[j].u.tai_many_plmn[t].plmn,
+                _emm_data.conf.tai_list.partial_tai_list[i]
+                    .u.tai_many_plmn[t]
+                    .plmn);
 
-              // _emm_data.conf.tai_list is sorted
-              tai_list->partial_tai_list[j].u.tai_many_plmn[t].tac =
-                  _emm_data.conf.tai_list.partial_tai_list[i]
-                      .u.tai_many_plmn[t]
-                      .tac;
-            }
-            j += 1;
-            break;
+            // _emm_data.conf.tai_list is sorted
+            tai_list->partial_tai_list[j].u.tai_many_plmn[t].tac =
+                _emm_data.conf.tai_list.partial_tai_list[i]
+                    .u.tai_many_plmn[t]
+                    .tac;
           }
-        }
-        if (!is_plmn_equal) {
+          j += 1;
+        } else {
           OAILOG_ERROR(
               LOG_NAS,
               "GUTI PLMN does not match with mme configuration tai list\n");
-        } else {
-          is_plmn_equal = false;
         }
         break;
       default:
@@ -574,8 +528,10 @@ int mme_api_new_guti(
   }
   tai_list->numberoflists = j;
   OAILOG_INFO(
-      LOG_NAS, "UE " MME_UE_S1AP_ID_FMT "  Got GUTI " GUTI_FMT "\n",
-      ue_context->mme_ue_s1ap_id, GUTI_ARG(guti));
+      LOG_NAS,
+      "UE " MME_UE_S1AP_ID_FMT "  Got GUTI " GUTI_FMT
+      ". The number of TAI partial lists: %d",
+      ue_context->mme_ue_s1ap_id, GUTI_ARG(guti), tai_list->numberoflists);
   OAILOG_FUNC_RETURN(LOG_NAS, RETURNok);
 }
 
@@ -644,4 +600,39 @@ int mme_api_unsubscribe(bstring apn) {
 static tmsi_t generate_random_TMSI() {
   // note srand with seed is init at main
   return (tmsi_t) rand();
+}
+
+/****************************************************************************
+ **                                                                        **
+ ** Name:        copy_plmn_from_config()                                   **
+ **                                                                        **
+ ** Description: Copies the tai list configuration to partial tai list.    **
+ **                                                                        **
+ ** Inputs:  served_tai:        Served tai constructed from MME config.    **
+ **          index:             Index to used on served_tai                **
+ **                  Others:    None                                       **
+ **                                                                        **
+ ** Outputs:     None                                                      **
+ **          plmn:   PLMN filled from served_tai                           **
+ **                  Return:    RETURNok, RETURNerror                      **
+ **                  Others:                                               **
+ **                                                                        **
+ ***************************************************************************/
+static int copy_plmn_from_config(
+    const served_tai_t* served_tai, int index, plmn_t* plmn) {
+  plmn->mcc_digit1 = (served_tai->plmn_mcc[index] / 100) % 10;
+  plmn->mcc_digit2 = (served_tai->plmn_mcc[index] / 10) % 10;
+  plmn->mcc_digit3 = served_tai->plmn_mcc[index] % 10;
+  if (served_tai->plmn_mnc_len[index] == 2) {
+    plmn->mnc_digit1 = (served_tai->plmn_mnc[index] / 10) % 10;
+    plmn->mnc_digit2 = served_tai->plmn_mnc[index] % 10;
+    plmn->mnc_digit3 = 0xf;
+  } else if (served_tai->plmn_mnc_len[index] == 3) {
+    plmn->mnc_digit1 = (served_tai->plmn_mnc[index] / 100) % 10;
+    plmn->mnc_digit2 = (served_tai->plmn_mnc[index] / 10) % 10;
+    plmn->mnc_digit3 = served_tai->plmn_mnc[index] % 10;
+  } else {
+    return RETURNerror;
+  }
+  return RETURNok;
 }

--- a/lte/gateway/c/oai/tasks/nas/emm/sap/emm_send.c
+++ b/lte/gateway/c/oai/tasks/nas/emm/sap/emm_send.c
@@ -329,8 +329,7 @@ int emm_send_attach_accept(
       "TRACKING_AREA_IDENTITY_LIST_LENGTH(%d*%d)  (%d) for (ue_id = %u)\n",
       TRACKING_AREA_IDENTITY_LIST_MINIMUM_LENGTH,
       emm_msg->tailist.numberoflists, size, ue_id);
-  AssertFatal(
-      emm_msg->tailist.numberoflists <= 16, "Too many TAIs in TAI list");
+
   for (int p = 0; p < emm_msg->tailist.numberoflists; p++) {
     if (TRACKING_AREA_IDENTITY_LIST_ONE_PLMN_NON_CONSECUTIVE_TACS ==
         emm_msg->tailist.partial_tai_list[p].typeoflist) {


### PR DESCRIPTION
Signed-off-by: Ulas Kozat <kozat@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->
- Fixed bug in handling of non-consecutive TACs in TAI list, where the partial lists were not encoded correctly.
- Refactored the code for readability and simplicity.
- Fixed a bug that was not swapping the MNC length during sorting TAIs.

PR limits the TAI list communicated to UE to one partial list that can have up to 16 TAIs. As per the spec TS 124.301 Table 9.9.3.33.1: Tracking area identity list information element:
"The value part of the Tracking area identity list information element consists of one or several partial tracking area identity lists. The length of each partial tracking area identity list can be determined from the 'type of list' field and the 'number of elements'
field in the first octet of the partial tracking area identity list. The UE shall store the complete list received. If more than 16 TAIs are included in this information element, the UE shall store the first 16 TAIs and ignore the remaining
octets of the information element." 

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->
Integ tests.

Tested with different entries for consecutive and non-consecutive tacs (by modifying `attachedEnodebTacs` in `gateway.mconfig` and restarting the services) and multi-plmn inputs (by modifying the TAC_LIST and TAI_LIST in `mme.conf.template` file). Checked the pcap entries.

E.g., for 
` "attachedEnodebTacs": [10181,10183,10185,10187,10188,10283,10284,10287,10288,10383,10384,10387,10388,10483,10487,10488,10583,10584,10587,10588,10683,10684,10687,10783,10784,10787,10883,10884,10887,10983,10984,10987,11083,11084,11183,11184,11283,11288,12888,12988,13088,13188,13288,13388,13488,13588,13684,13688,13784,13788,13884,13888,13984,13988,14084,14088,14184,14188,14284,14384,14484,14584,14684,14784]`

```
Tracking area identity list - TAI list
    Length: 36
    0... .... = Spare bit(s): 0x00
    .00. .... = Type of list: list of TACs belonging to one PLMN, with non-consecutive TAC values (0)
    ...0 1111 = Number of elements: 15
    Mobile Country Code (MCC): Unknown (1)
    Mobile Network Code (MNC): Unknown (01)
    Tracking area code(TAC): 10181
    Tracking area code(TAC): 10183
    Tracking area code(TAC): 10185
    Tracking area code(TAC): 10187
    Tracking area code(TAC): 10188
    Tracking area code(TAC): 10283
    Tracking area code(TAC): 10284
    Tracking area code(TAC): 10287
    Tracking area code(TAC): 10288
    Tracking area code(TAC): 10383
    Tracking area code(TAC): 10384
    Tracking area code(TAC): 10387
    Tracking area code(TAC): 10388
    Tracking area code(TAC): 10483
    Tracking area code(TAC): 10487
    Tracking area code(TAC): 10488
```


## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->

<!--
    Final note

    Please take a moment to read through the Magma project's
    - Contributing conventions: https://docs.magmacore.org/docs/next/contributing/contribute_conventions

    If this is your first time opening a PR, also consider reading
    - Developer onboarding: https://docs.magmacore.org/docs/next/contributing/contribute_onboarding
    - Development workflow: https://docs.magmacore.org/docs/next/contributing/contribute_workflow
-->
