### PR TITLE
<:fix>[CWFIntegrationTest] Fix nil dereference in ASR tests

### DIFF
--- a/cwf/gateway/integ_tests/gx_enforcement_test.go
+++ b/cwf/gateway/integ_tests/gx_enforcement_test.go
@@ -381,8 +381,11 @@ func TestGxAbortSessionRequest(t *testing.T) {
 	// module throws this error here. coa_dynamic module isn't enabled during
 	// authentication and hence it isn't aware of the sessionID used when
 	// processing disconnect
-	assert.Contains(t, asa.SessionId, "IMSI"+imsi)
-	assert.Equal(t, uint32(diam.LimitedSuccess), asa.ResultCode)
+	assert.NotNil(t, asa)
+	if asa != nil {
+		assert.Contains(t, asa.SessionId, "IMSI"+imsi)
+		assert.Equal(t, uint32(diam.LimitedSuccess), asa.ResultCode)
+	}
 	tr.AssertEventuallyAllRulesRemovedAfterDisconnect(imsi)
 }
 

--- a/cwf/gateway/integ_tests/gy_enforcement_test.go
+++ b/cwf/gateway/integ_tests/gy_enforcement_test.go
@@ -640,8 +640,11 @@ func TestGyAbortSessionRequest(t *testing.T) {
 	// module throws this error here. coa_dynamic module isn't enabled during
 	// authentication and hence it isn't aware of the sessionID used when
 	// processing disconnect
-	assert.Contains(t, asa.SessionId, "IMSI"+imsi)
-	assert.Equal(t, uint32(diam.LimitedSuccess), asa.ResultCode)
+	assert.NotNil(t, asa)
+	if asa != nil {
+		assert.Contains(t, asa.SessionId, "IMSI"+imsi)
+		assert.Equal(t, uint32(diam.LimitedSuccess), asa.ResultCode)
+	}
 
 	// check if all session related info is cleaned up
 	tr.AssertEventuallyAllRulesRemovedAfterDisconnect(imsi)


### PR DESCRIPTION
<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary
Trying to fix the nil dereference error seen here: https://app.circleci.com/pipelines/github/magma/magma/21416/workflows/19c1a9a3-4d56-45d5-808e-aa9edc809bac/jobs/224055
The nil dereference prevents the test from being rerun. (Usually the connection errors go away when it is run again.)

<!-- Enumerate changes you made and why you made them -->

## Test Plan
CI
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
Signed-off-by: Marie Bremner <marwhal@fb.com>