### PR TITLE
<:refactor> Refactor RuleToProcess to clean up the PipelineD interface 

### DIFF
--- a/lte/gateway/c/session_manager/LocalEnforcer.h
+++ b/lte/gateway/c/session_manager/LocalEnforcer.h
@@ -486,7 +486,7 @@ class LocalEnforcer {
   void create_bearer(
       const std::unique_ptr<SessionState>& session,
       const PolicyReAuthRequest& request,
-      const std::vector<PolicyRule>& dynamic_rules);
+      const std::vector<RuleToProcess>& dynamic_rules);
 
   /**
    * Check if REVALIDATION_TIMEOUT is one of the event triggers

--- a/lte/gateway/c/session_manager/SessionState.cpp
+++ b/lte/gateway/c/session_manager/SessionState.cpp
@@ -523,9 +523,9 @@ void SessionState::apply_session_static_rule_set(
     if (!is_static_rule_installed(static_rule_id)) {
       MLOG(MINFO) << "Installing static rule " << static_rule_id << " for "
                   << session_id_;
-      uint32_t version = activate_static_rule(static_rule_id, lifetime, uc);
       // Set up rules_to_activate
-      rules_to_activate.append_versioned_policy(rule, version);
+      rules_to_activate.push_back(
+          activate_static_rule(static_rule_id, lifetime, uc));
     }
   }
   std::vector<PolicyRule> static_rules_to_deactivate;
@@ -547,13 +547,13 @@ void SessionState::apply_session_static_rule_set(
   for (const PolicyRule static_rule : static_rules_to_deactivate) {
     MLOG(MINFO) << "Removing static rule " << static_rule.id() << " for "
                 << session_id_;
-    optional<uint32_t> op_version =
+    optional<RuleToProcess> op_rule_info =
         deactivate_static_rule(static_rule.id(), uc);
-    if (!op_version) {
+    if (!op_rule_info) {
       MLOG(MWARNING) << "Failed to deactivate static rule " << static_rule.id()
                      << " for " << session_id_;
     } else {
-      rules_to_deactivate.append_versioned_policy(static_rule, *op_version);
+      rules_to_deactivate.push_back(*op_rule_info);
     }
   }
 }
@@ -568,21 +568,18 @@ void SessionState::apply_session_dynamic_rule_set(
     if (!is_dynamic_rule_installed(dynamic_rule_pair.first)) {
       MLOG(MINFO) << "Installing dynamic rule " << dynamic_rule_pair.first
                   << " for " << session_id_;
-      uint32_t version =
-          insert_dynamic_rule(dynamic_rule_pair.second, lifetime, uc);
-      rules_to_activate.append_versioned_policy(
-          dynamic_rule_pair.second, version);
+      rules_to_activate.push_back(
+          insert_dynamic_rule(dynamic_rule_pair.second, lifetime, uc));
     }
   }
   std::vector<PolicyRule> active_dynamic_rules;
   dynamic_rules_.get_rules(active_dynamic_rules);
   for (const auto& dynamic_rule : active_dynamic_rules) {
     if (dynamic_rules.find(dynamic_rule.id()) == dynamic_rules.end()) {
-      optional<uint32_t> op_version =
-          remove_dynamic_rule(dynamic_rule.id(), nullptr, uc);
       MLOG(MINFO) << "Removing dynamic rule " << dynamic_rule.id() << " for "
                   << session_id_;
-      rules_to_deactivate.append_versioned_policy(dynamic_rule, *op_version);
+      rules_to_deactivate.push_back(
+          *remove_dynamic_rule(dynamic_rule.id(), nullptr, uc));
     }
   }
 }
@@ -842,23 +839,22 @@ void SessionState::get_session_info(SessionState::SessionInfo& info) {
   info.msisdn    = config_.common_context.msisdn();
   info.ambr      = config_.get_apn_ambr();
 
-  dynamic_rules_.get_rules(info.gx_rules.rules);
-  gy_dynamic_rules_.get_rules(info.gy_dynamic_rules.rules);
+  std::vector<PolicyRule> gx_dynamic_rules, gy_dynamic_rules;
+  dynamic_rules_.get_rules(gx_dynamic_rules);
+  gy_dynamic_rules_.get_rules(gy_dynamic_rules);
 
   // Set versions
-  for (const PolicyRule rule : info.gx_rules.rules) {
-    info.gx_rules.versions.push_back(get_current_rule_version(rule.id()));
+  for (const PolicyRule rule : gx_dynamic_rules) {
+    info.gx_rules.push_back(make_rule_to_process(rule));
   }
-  for (const PolicyRule rule : info.gy_dynamic_rules.rules) {
-    info.gy_dynamic_rules.versions.push_back(
-        get_current_rule_version(rule.id()));
+  for (const PolicyRule rule : gy_dynamic_rules) {
+    info.gy_dynamic_rules.push_back(make_rule_to_process(rule));
   }
 
   for (const std::string& rule_id : active_static_rules_) {
     PolicyRule rule;
     if (static_rules_.get_rule(rule_id, &rule)) {
-      info.gx_rules.append_versioned_policy(
-          rule, get_current_rule_version(rule_id));
+      info.gx_rules.push_back(make_rule_to_process(rule));
     }
   }
 }
@@ -966,53 +962,62 @@ bool SessionState::is_static_rule_installed(const std::string& rule_id) {
              rule_id) != active_static_rules_.end();
 }
 
-uint32_t SessionState::insert_dynamic_rule(
+RuleToProcess SessionState::insert_dynamic_rule(
     const PolicyRule& rule, RuleLifetime& lifetime,
     SessionStateUpdateCriteria& session_uc) {
   rule_lifetimes_[rule.id()] = lifetime;
   dynamic_rules_.insert_rule(rule);
   session_uc.dynamic_rules_to_install.push_back(rule);
   session_uc.new_rule_lifetimes[rule.id()] = lifetime;
-
   increment_rule_stats(rule.id(), session_uc);
-  return get_current_rule_version(rule.id());
+
+  return make_rule_to_process(rule);
 }
 
-uint32_t SessionState::insert_gy_rule(
+RuleToProcess SessionState::insert_gy_rule(
     const PolicyRule& rule, RuleLifetime& lifetime,
     SessionStateUpdateCriteria& session_uc) {
   rule_lifetimes_[rule.id()] = lifetime;
   gy_dynamic_rules_.insert_rule(rule);
   session_uc.gy_dynamic_rules_to_install.push_back(rule);
   session_uc.new_rule_lifetimes[rule.id()] = lifetime;
-
   increment_rule_stats(rule.id(), session_uc);
-  return get_current_rule_version(rule.id());
+
+  return make_rule_to_process(rule);
 }
 
-uint32_t SessionState::activate_static_rule(
+RuleToProcess SessionState::activate_static_rule(
     const std::string& rule_id, RuleLifetime& lifetime,
     SessionStateUpdateCriteria& session_uc) {
+  RuleToProcess to_process;
+  PolicyRule rule;
+  static_rules_.get_rule(rule_id, &rule);
+
   rule_lifetimes_[rule_id] = lifetime;
   active_static_rules_.push_back(rule_id);
   session_uc.static_rules_to_install.insert(rule_id);
   session_uc.new_rule_lifetimes[rule_id] = lifetime;
-
   increment_rule_stats(rule_id, session_uc);
-  return get_current_rule_version(rule_id);
+
+  return make_rule_to_process(rule);
 };
 
-optional<uint32_t> SessionState::remove_dynamic_rule(
+optional<RuleToProcess> SessionState::remove_dynamic_rule(
     const std::string& rule_id, PolicyRule* rule_out,
     SessionStateUpdateCriteria& session_uc) {
-  bool removed = dynamic_rules_.remove_rule(rule_id, rule_out);
+  PolicyRule rule;
+  bool removed = dynamic_rules_.remove_rule(rule_id, &rule);
   if (!removed) {
     return {};
+  }
+  if (rule_out != nullptr) {
+    *rule_out = rule;
   }
 
   session_uc.dynamic_rules_to_uninstall.insert(rule_id);
   increment_rule_stats(rule_id, session_uc);
-  return get_current_rule_version(rule_id);
+
+  return make_rule_to_process(rule);
 }
 
 bool SessionState::remove_scheduled_dynamic_rule(
@@ -1025,20 +1030,24 @@ bool SessionState::remove_scheduled_dynamic_rule(
   return removed;
 }
 
-optional<uint32_t> SessionState::remove_gy_rule(
+optional<RuleToProcess> SessionState::remove_gy_rule(
     const std::string& rule_id, PolicyRule* rule_out,
     SessionStateUpdateCriteria& session_uc) {
-  bool removed = gy_dynamic_rules_.remove_rule(rule_id, rule_out);
+  PolicyRule rule;
+  bool removed = gy_dynamic_rules_.remove_rule(rule_id, &rule);
   if (!removed) {
     return {};
+  }
+  if (rule_out != nullptr) {
+    *rule_out = rule;
   }
   session_uc.gy_dynamic_rules_to_uninstall.insert(rule_id);
 
   increment_rule_stats(rule_id, session_uc);
-  return get_current_rule_version(rule_id);
+  return make_rule_to_process(rule);
 }
 
-optional<uint32_t> SessionState::deactivate_static_rule(
+optional<RuleToProcess> SessionState::deactivate_static_rule(
     const std::string& rule_id, SessionStateUpdateCriteria& session_uc) {
   auto it = std::find(
       active_static_rules_.begin(), active_static_rules_.end(), rule_id);
@@ -1050,7 +1059,19 @@ optional<uint32_t> SessionState::deactivate_static_rule(
   active_static_rules_.erase(it);
 
   increment_rule_stats(rule_id, session_uc);
-  return get_current_rule_version(rule_id);
+
+  PolicyRule rule;
+  if (!static_rules_.get_rule(rule_id, &rule)) {
+    rule.set_id(rule_id);
+  }
+  return make_rule_to_process(rule);
+}
+
+RuleToProcess SessionState::make_rule_to_process(const PolicyRule& rule) {
+  RuleToProcess to_process;
+  to_process.version = get_current_rule_version(rule.id());
+  to_process.rule    = rule;
+  return to_process;
 }
 
 bool SessionState::deactivate_scheduled_static_rule(
@@ -1385,7 +1406,7 @@ bool SessionState::is_credit_suspended(const CreditKey& charging_key) {
 }
 
 void SessionState::get_rules_per_credit_key(
-    CreditKey charging_key, RulesToProcess& to_process,
+    CreditKey charging_key, RulesToProcess& to_activate,
     SessionStateUpdateCriteria& session_uc) {
   std::vector<PolicyRule> static_rules, dynamic_rules;
   static_rules_.get_rule_definitions_for_charging_key(
@@ -1396,16 +1417,14 @@ void SessionState::get_rules_per_credit_key(
     bool is_installed = is_static_rule_installed(rule.id());
     if (is_installed) {
       increment_rule_stats(rule.id(), session_uc);
-      to_process.append_versioned_policy(
-          rule, get_current_rule_version(rule.id()));
+      to_activate.push_back(make_rule_to_process(rule));
     }
   }
   dynamic_rules_.get_rule_definitions_for_charging_key(
       charging_key, dynamic_rules);
   for (PolicyRule rule : dynamic_rules) {
     increment_rule_stats(rule.id(), session_uc);
-    to_process.append_versioned_policy(
-        rule, get_current_rule_version(rule.id()));
+    to_activate.push_back(make_rule_to_process(rule));
   }
 }
 
@@ -1655,13 +1674,12 @@ void SessionState::fill_service_action_for_activate(
   RulesToProcess* to_install = action_p->get_mutable_gx_rules_to_install();
   for (PolicyRule rule : static_rules) {
     RuleLifetime lifetime;
-    uint32_t version = activate_static_rule(rule.id(), lifetime, session_uc);
-    to_install->append_versioned_policy(rule, version);
+    to_install->push_back(
+        activate_static_rule(rule.id(), lifetime, session_uc));
   }
   for (PolicyRule rule : dynamic_rules) {
     RuleLifetime lifetime;
-    uint32_t version = insert_dynamic_rule(rule, lifetime, session_uc);
-    to_install->append_versioned_policy(rule, version);
+    to_install->push_back(insert_dynamic_rule(rule, lifetime, session_uc));
   }
 }
 
@@ -1680,8 +1698,7 @@ void SessionState::fill_service_action_for_restrict(
       continue;
     }
     RuleLifetime lifetime;
-    uint32_t version = insert_gy_rule(rule, lifetime, session_uc);
-    gy_to_install->append_versioned_policy(rule, version);
+    gy_to_install->push_back(insert_gy_rule(rule, lifetime, session_uc));
   }
 }
 
@@ -1726,8 +1743,7 @@ void SessionState::fill_service_action_for_redirect(
 
   RulesToProcess* gy_to_install = action_p->get_mutable_gy_rules_to_install();
   RuleLifetime lifetime;
-  uint32_t version = insert_gy_rule(redirect_rule, lifetime, session_uc);
-  gy_to_install->append_versioned_policy(redirect_rule, version);
+  gy_to_install->push_back(insert_gy_rule(redirect_rule, lifetime, session_uc));
 }
 
 void SessionState::fill_service_action_with_context(
@@ -1948,8 +1964,8 @@ BearerUpdate SessionState::get_dedicated_bearer_updates(
     SessionStateUpdateCriteria& uc) {
   BearerUpdate update;
   // Rule Installs
-  for (const auto& rule : rules_to_activate.rules) {
-    const auto& rule_id = rule.id();
+  for (const auto& to_process : rules_to_activate) {
+    const auto& rule_id = to_process.rule.id();
     PolicyType p_type;
     if (static_rules_.get_rule(rule_id, nullptr)) {
       p_type = STATIC;
@@ -1960,8 +1976,8 @@ BearerUpdate SessionState::get_dedicated_bearer_updates(
   }
 
   // Rule Removals
-  for (const auto& rule : rules_to_deactivate.rules) {
-    const auto& rule_id = rule.id();
+  for (const auto& to_process : rules_to_deactivate) {
+    const auto& rule_id = to_process.rule.id();
     PolicyType p_type;
     if (static_rules_.get_rule(rule_id, nullptr)) {
       p_type = STATIC;
@@ -2096,23 +2112,23 @@ RulesToProcess SessionState::remove_all_final_action_rules(
     const FinalActionInfo& final_action_info,
     SessionStateUpdateCriteria& session_uc) {
   RulesToProcess to_process;
-  to_process.rules = std::vector<PolicyRule>{};
+  to_process = std::vector<RuleToProcess>{};
   switch (final_action_info.final_action) {
     case ChargingCredit_FinalAction_REDIRECT: {
       PolicyRule rule;
-      optional<uint32_t> op_version =
+      optional<RuleToProcess> op_rule_info =
           remove_gy_rule("redirect", &rule, session_uc);
-      if (op_version) {
-        to_process.append_versioned_policy(rule, *op_version);
+      if (op_rule_info) {
+        to_process.push_back(*op_rule_info);
       }
     } break;
     case ChargingCredit_FinalAction_RESTRICT_ACCESS:
       for (std::string rule_id : final_action_info.restrict_rules) {
         PolicyRule rule;
-        optional<uint32_t> op_version =
+        optional<RuleToProcess> op_rule_info =
             remove_gy_rule(rule_id, &rule, session_uc);
-        if (op_version) {
-          to_process.append_versioned_policy(rule, *op_version);
+        if (op_rule_info) {
+          to_process.push_back(*op_rule_info);
         }
       }
       break;
@@ -2316,16 +2332,6 @@ CreateSessionResponse SessionState::get_create_session_response() {
 
 void SessionState::clear_create_session_response() {
   create_session_response_ = CreateSessionResponse();
-}
-
-bool RulesToProcess::empty() const {
-  return rules.empty();
-}
-
-void RulesToProcess::append_versioned_policy(
-    PolicyRule rule, uint32_t version) {
-  rules.push_back(rule);
-  versions.push_back(version);
 }
 
 uint32_t SessionState::get_current_rule_version(const std::string& rule_id) {

--- a/lte/gateway/c/session_manager/SessionState.h
+++ b/lte/gateway/c/session_manager/SessionState.h
@@ -320,9 +320,9 @@ class SessionState {
    * @param rule
    * @param lifetime
    * @param session_uc
-   * @return uint32_t updated version
+   * @return RuleToProcess
    */
-  uint32_t insert_dynamic_rule(
+  RuleToProcess insert_dynamic_rule(
       const PolicyRule& rule, RuleLifetime& lifetime,
       SessionStateUpdateCriteria& session_uc);
 
@@ -333,9 +333,9 @@ class SessionState {
    * @param rule_id
    * @param lifetime
    * @param session_uc
-   * @return uint32_t updated version
+   * @return RuleToProcess
    */
-  uint32_t activate_static_rule(
+  RuleToProcess activate_static_rule(
       const std::string& rule_id, RuleLifetime& lifetime,
       SessionStateUpdateCriteria& session_uc);
   /**
@@ -344,9 +344,9 @@ class SessionState {
    * @param rule
    * @param lifetime
    * @param update_criteria
-   * @return uint32_t updated version
+   * @return RuleToProcess
    */
-  uint32_t insert_gy_rule(
+  RuleToProcess insert_gy_rule(
       const PolicyRule& rule, RuleLifetime& lifetime,
       SessionStateUpdateCriteria& session_uc);
 
@@ -358,9 +358,10 @@ class SessionState {
    * @param update_criteria Tracks updates to the session. To be passed back to
    *                        the SessionStore to resolve issues of concurrent
    *                        updates to a session.
-   * @return optional<uint32_t> updated version if success, {} if failure
+   * @return optional<RuleToProcess> updated RuleToProcess if success, {} if
+   * failure
    */
-  optional<uint32_t> remove_dynamic_rule(
+  optional<RuleToProcess> remove_dynamic_rule(
       const std::string& rule_id, PolicyRule* rule_out,
       SessionStateUpdateCriteria& update_criteria);
 
@@ -375,9 +376,9 @@ class SessionState {
    * @param rule_id
    * @param rule_out
    * @param session_uc
-   * @return optional<uint32_t> updated version if success, {} if failure
+   * @return optional<RuleToProcess> if success, {} if failure
    */
-  optional<uint32_t> remove_gy_rule(
+  optional<RuleToProcess> remove_gy_rule(
       const std::string& rule_id, PolicyRule* rule_out,
       SessionStateUpdateCriteria& session_uc);
 
@@ -388,9 +389,9 @@ class SessionState {
    * @param session_uc Tracks updates to the session. To be passed back to
    *                        the SessionStore to resolve issues of concurrent
    *                        updates to a session.
-   * @return new version if successfully removed. otherwise returns {}
+   * @return RuleToProcess if successfully removed. otherwise returns {}
    */
-  optional<uint32_t> deactivate_static_rule(
+  optional<RuleToProcess> deactivate_static_rule(
       const std::string& rule_id, SessionStateUpdateCriteria& session_uc);
 
   bool deactivate_scheduled_static_rule(const std::string& rule_id);
@@ -826,6 +827,8 @@ class SessionState {
    */
   void increment_rule_stats(
       const std::string& rule_id, SessionStateUpdateCriteria& session_uc);
+
+  RuleToProcess make_rule_to_process(const PolicyRule& rule);
 };
 
 }  // namespace magma

--- a/lte/gateway/c/session_manager/Types.h
+++ b/lte/gateway/c/session_manager/Types.h
@@ -13,6 +13,7 @@
 #pragma once
 
 #include <functional>
+#include <vector>
 #include <experimental/optional>
 
 #include <folly/Format.h>
@@ -193,14 +194,12 @@ struct BearerIDAndTeid {
 typedef std::unordered_map<PolicyID, BearerIDAndTeid, PolicyIDHash>
     BearerIDByPolicyID;
 
-struct RulesToProcess {
-  // If this vector is set, then it has PolicyRule definitions for both static
-  // and dynamic rules
-  std::vector<PolicyRule> rules;
-  std::vector<uint32_t> versions;
-  bool empty() const;
-  void append_versioned_policy(PolicyRule rule, uint32_t version);
+struct RuleToProcess {
+  PolicyRule rule;
+  uint32_t version;
 };
+
+typedef std::vector<RuleToProcess> RulesToProcess;
 
 struct StatsPerPolicy {
   // The version maintained by SessionD for this rule

--- a/lte/gateway/c/session_manager/test/Matchers.h
+++ b/lte/gateway/c/session_manager/test/Matchers.h
@@ -32,20 +32,19 @@ MATCHER_P(CheckCount, count, "") {
 }
 
 MATCHER_P(CheckRuleCount, count, "") {
-  int arg_count = arg.rules.size();
+  int arg_count = arg.size();
   return arg_count == count;
 }
 
 MATCHER_P(CheckRuleNames, list_static_rules, "") {
-  RulesToProcess to_process     = arg;
-  std::vector<PolicyRule> rules = to_process.rules;
-  if (rules.size() != list_static_rules.size()) {
+  std::vector<RuleToProcess> to_process = arg;
+  if (to_process.size() != list_static_rules.size()) {
     return false;
   }
-  for (PolicyRule rule : rules) {
+  for (RuleToProcess val : to_process) {
     bool found = false;
     for (const std::string rule_to_check : list_static_rules) {
-      if (rule.id() == rule_to_check) {
+      if (val.rule.id() == rule_to_check) {
         found = true;
         break;
       }
@@ -124,17 +123,17 @@ MATCHER_P6(
     }
 
     std::vector<std::string> expected_gx_rules = rule_ids_lists[i];
-    if (info.gx_rules.rules.size() != expected_gx_rules.size()) {
+    if (info.gx_rules.size() != expected_gx_rules.size()) {
       return false;
     }
-    for (size_t r_index = 0; i < info.gx_rules.rules.size(); i++) {
-      if (info.gx_rules.rules[r_index].id() != expected_gx_rules[r_index])
+    for (size_t r_index = 0; i < info.gx_rules.size(); i++) {
+      if (info.gx_rules[r_index].rule.id() != expected_gx_rules[r_index])
         return false;
     }
 
     std::vector<uint32_t> expected_versions = versions_lists[i];
-    for (size_t r_index = 0; i < info.gx_rules.versions.size(); i++) {
-      if (info.gx_rules.versions[r_index] != expected_versions[r_index])
+    for (size_t r_index = 0; i < info.gx_rules.size(); i++) {
+      if (info.gx_rules[r_index].version != expected_versions[r_index])
         return false;
     }
 
@@ -174,9 +173,9 @@ MATCHER_P3(CheckDeleteOneBearerReq, imsi, link_bearer_id, eps_bearer_id, "") {
 }
 
 MATCHER_P(CheckSubset, ids, "") {
-  auto request = static_cast<const std::vector<PolicyRule>>(arg.rules);
+  auto request = static_cast<const RulesToProcess>(arg);
   for (size_t i = 0; i < request.size(); i++) {
-    if (ids.find(request[i].id()) != ids.end()) {
+    if (ids.find(request[i].rule.id()) != ids.end()) {
       return true;
     }
   }
@@ -184,9 +183,9 @@ MATCHER_P(CheckSubset, ids, "") {
 }
 
 MATCHER_P(CheckPolicyID, id, "") {
-  auto request = static_cast<const std::vector<PolicyRule>>(arg.rules);
+  auto request = static_cast<const RulesToProcess>(arg);
   for (size_t i = 0; i < request.size(); i++) {
-    if (request[i].id() == id) {
+    if (request[i].rule.id() == id) {
       return true;
     }
   }
@@ -194,12 +193,12 @@ MATCHER_P(CheckPolicyID, id, "") {
 }
 
 MATCHER_P2(CheckPolicyIDs, count, ids, "") {
-  auto request = static_cast<const std::vector<PolicyRule>>(arg.rules);
+  auto request = static_cast<const RulesToProcess>(arg);
   if (request.size() != (unsigned int) count) {
     return false;
   }
   for (size_t i = 0; i < request.size(); i++) {
-    if (ids.find(request[i].id()) != ids.end()) {
+    if (ids.find(request[i].rule.id()) != ids.end()) {
       return true;
     }
   }

--- a/lte/gateway/c/session_manager/test/SessionStateTester.h
+++ b/lte/gateway/c/session_manager/test/SessionStateTester.h
@@ -59,11 +59,13 @@ class SessionStateTest : public ::testing::Test {
         // insert into list of existing rules
         rule_store->insert_rule(rule);
         // mark the rule as active in session
-        return session_state->activate_static_rule(
-            rule_id, lifetime, update_criteria);
+        return session_state
+            ->activate_static_rule(rule_id, lifetime, update_criteria)
+            .version;
       case DYNAMIC:
-        return session_state->insert_dynamic_rule(
-            rule, lifetime, update_criteria);
+        return session_state
+            ->insert_dynamic_rule(rule, lifetime, update_criteria)
+            .version;
         break;
     }
     return 0;
@@ -124,8 +126,9 @@ class SessionStateTest : public ::testing::Test {
         redirect_server.redirect_server_address());
 
     RuleLifetime lifetime{};
-    return session_state->insert_gy_rule(
-        redirect_rule, lifetime, update_criteria);
+    return session_state
+        ->insert_gy_rule(redirect_rule, lifetime, update_criteria)
+        .version;
   }
 
   void receive_credit_from_ocs(uint32_t rating_group, uint64_t volume) {
@@ -171,12 +174,14 @@ class SessionStateTest : public ::testing::Test {
     switch (rule_type) {
       case STATIC:
         rule_store->insert_rule(rule);
-        return session_state->activate_static_rule(
-            rule_id, lifetime, update_criteria);
+        return session_state
+            ->activate_static_rule(rule_id, lifetime, update_criteria)
+            .version;
         break;
       case DYNAMIC:
-        return session_state->insert_dynamic_rule(
-            rule, lifetime, update_criteria);
+        return session_state
+            ->insert_dynamic_rule(rule, lifetime, update_criteria)
+            .version;
         break;
       default:
         break;

--- a/lte/gateway/c/session_manager/test/test_local_enforcer.cpp
+++ b/lte/gateway/c/session_manager/test/test_local_enforcer.cpp
@@ -763,8 +763,10 @@ TEST_F(LocalEnforcerTest, test_sync_sessions_on_restart) {
       .deactivation_time = std::time_t(20),
   };
   auto& uc    = session_update[IMSI1][SESSION_ID_1];
-  uint32_t v1 = session_map_2[IMSI1].front()->activate_static_rule(
-      "rule1", lifetime1, uc);
+  uint32_t v1 = session_map_2[IMSI1]
+                    .front()
+                    ->activate_static_rule("rule1", lifetime1, uc)
+                    .version;
   session_map_2[IMSI1].front()->schedule_static_rule("rule2", lifetime2, uc);
   session_map_2[IMSI1].front()->schedule_static_rule("rule3", lifetime3, uc);
   session_map_2[IMSI1].front()->schedule_static_rule("rule4", lifetime4, uc);
@@ -1280,8 +1282,7 @@ TEST_F(LocalEnforcerTest, test_reauth_with_redirected_suspended_credit) {
   UpdateSessionResponse update_response;
   auto updates = update_response.mutable_responses();
   create_credit_update_response(IMSI1, SESSION_ID_1, 1, 4096, updates->Add());
-  std::vector<std::string> rules_to_activate;
-  rules_to_activate.push_back("rule1");
+  std::vector<std::string> rules_to_activate = {"rule1"};
   EXPECT_CALL(
       *pipelined_client, activate_flows_for_rules(
                              testing::_, testing::_, testing::_, testing::_,
@@ -2690,7 +2691,7 @@ TEST_F(LocalEnforcerTest, test_final_unit_redirect_activation_and_termination) {
       local_enforcer->collect_updates(session_map, actions, update);
   EXPECT_EQ(actions.size(), 1);
   EXPECT_EQ(actions[0]->get_type(), REDIRECT);
-  PolicyRule redirect_rule = actions[0]->get_gy_rules_to_install().rules[0];
+  PolicyRule redirect_rule = actions[0]->get_gy_rules_to_install()[0].rule;
   EXPECT_EQ(redirect_rule.redirect().server_address(), "12.7.7.4");
 
   EXPECT_CALL(
@@ -2765,7 +2766,7 @@ TEST_F(LocalEnforcerTest, test_final_unit_activation_and_canceling) {
       local_enforcer->collect_updates(session_map, actions, update);
   EXPECT_EQ(actions.size(), 1);
   EXPECT_EQ(actions[0]->get_type(), RESTRICT_ACCESS);
-  EXPECT_EQ(actions[0]->get_gy_rules_to_install().rules[0].id(), "rule1");
+  EXPECT_EQ(actions[0]->get_gy_rules_to_install()[0].rule.id(), "rule1");
 
   EXPECT_CALL(
       *pipelined_client, add_gy_final_action_flow(
@@ -2879,7 +2880,7 @@ TEST_F(LocalEnforcerTest, test_final_unit_action_no_update) {
   EXPECT_EQ(actions.size(), 1);
   EXPECT_EQ(actions[0]->get_type(), RESTRICT_ACCESS);
   EXPECT_EQ(
-      actions[0]->get_gy_rules_to_install().rules[0].id(), "restrict_rule");
+      actions[0]->get_gy_rules_to_install()[0].rule.id(), "restrict_rule");
 
   EXPECT_CALL(
       *pipelined_client,

--- a/lte/gateway/c/session_manager/test/test_session_state.cpp
+++ b/lte/gateway/c/session_manager/test/test_session_state.cpp
@@ -662,10 +662,10 @@ TEST_F(SessionStateTest, test_install_gy_rules) {
   EXPECT_EQ(update_criteria.gy_dynamic_rules_to_install.size(), 1);
 
   PolicyRule rule_out;
-  optional<uint32_t> op_version =
+  optional<RuleToProcess> op_to_process =
       session_state->remove_gy_rule("redirect", &rule_out, update_criteria);
-  EXPECT_TRUE(op_version);
-  EXPECT_EQ(*op_version, 2);
+  EXPECT_TRUE(op_to_process);
+  EXPECT_EQ(op_to_process->version, 2);
 
   // basic sanity checks to see it's properly deleted
   rules_out = {};
@@ -955,11 +955,11 @@ TEST_F(SessionStateTest, test_apply_session_rule_set) {
   EXPECT_TRUE(session_state->is_dynamic_rule_installed("rule-dynamic-3"));
 
   // Check the RulesToProcess is properly filled out
-  EXPECT_EQ(to_activate.rules.size(), 2);
-  const std::string activate_rule1   = to_activate.rules[0].id();
-  const std::string activate_rule2   = to_activate.rules[1].id();
-  const std::string deactivate_rule1 = to_deactivate.rules[0].id();
-  const std::string deactivate_rule2 = to_deactivate.rules[1].id();
+  EXPECT_EQ(to_activate.size(), 2);
+  const std::string activate_rule1   = to_activate[0].rule.id();
+  const std::string activate_rule2   = to_activate[1].rule.id();
+  const std::string deactivate_rule1 = to_deactivate[0].rule.id();
+  const std::string deactivate_rule2 = to_deactivate[1].rule.id();
   EXPECT_TRUE(
       activate_rule1 == "rule-static-3" || activate_rule1 == "rule-dynamic-3");
   EXPECT_TRUE(


### PR DESCRIPTION
Signed-off-by: Marie Bremner <marwhal@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary
This is a cosmetic change to clean up the `SessionState` <-> `LocalEnforcer` <-> `PipelineDClient` interface in SessionD. 

In order to activate policies that are served by dedicated bearers separately, I'm trying to clean up the code around the logic to make this change easier.

this PR refactors the type of `RulesToProcess` from
```
struct RulesToProcess {
  // If this vector is set, then it has PolicyRule definitions for both static
  // and dynamic rules
  std::vector<PolicyRule> rules;
  std::vector<uint32_t> versions;
  bool empty() const;
  void append_versioned_policy(PolicyRule rule, uint32_t version);
};
```
to
```
struct RuleToProcess {
  PolicyRule rule;
  uint32_t version;
};
typedef std::vector<RuleToProcess> RulesToProcess;
```

<!-- Enumerate changes you made and why you made them -->

## Test Plan
SessionD unit tests
CWF integration test + CI
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
