### PR TITLE
[orc8r][helm] Add push of helm charts to jfrog Artifactory

### DIFF
--- a/docs/readmes/orc8r/deploy_build.md
+++ b/docs/readmes/orc8r/deploy_build.md
@@ -80,6 +80,25 @@ COMPOSE_PROJECT_NAME=magmalte ${PUBLISH} -r ${REGISTRY} -i magmalte -v ${MAGMA_T
 
 ## Build and publish Helm charts
 
+### First option: Publish to artifactory
+
+We'll build the Orchestrator Helm charts, as well as publish them to an artifactory.
+
+Define some necessary variables
+
+```bash
+export HELM_CHART_MUSEUM_URL=ARTIFACTORY_URL
+export HELM_CHART_MUSEUM_USERNAMEL=ARTIFACTORY_USERNAME
+export HELM_CHART_MUSEUM_TOKEN=ARTIFACTORY_ACCESS_TOKEN
+```
+
+Next we'll run the package script. This script will package and publish the
+necessary helm charts to the artifactory. The script expects a deployment
+type to be provided, which will determine which orc8r modules are deployed.
+
+
+### Second option: Publish to a private github repo
+
 We'll build the Orchestrator Helm charts, as well as publish them to a
 [GitHub repo acting as a Helm chart repo](https://blog.softwaremill.com/hosting-helm-private-repository-from-github-ff3fa940d0b7).
 
@@ -98,6 +117,11 @@ export GITHUB_ACCESS_TOKEN=GITHUB_ACCESS_TOKEN
 Next we'll run the package script. This script will package and publish the
 necessary helm charts to the `GITHUB_REPO`. The script expects a deployment
 type to be provided, which will determine which orc8r modules are deployed.
+
+
+### Run the package script
+
+
 The valid deployment type options are
 
 - `fwa`

--- a/docs/readmes/orc8r/deploy_build.md
+++ b/docs/readmes/orc8r/deploy_build.md
@@ -79,7 +79,7 @@ COMPOSE_PROJECT_NAME=magmalte ${PUBLISH} -r ${REGISTRY} -i magmalte -v ${MAGMA_T
 ```
 
 ## Build and publish Helm charts
-
+*Only Choose one option below*
 ### First option: Publish to artifactory
 
 We'll build the Orchestrator Helm charts, as well as publish them to an artifactory.
@@ -97,7 +97,7 @@ necessary helm charts to the artifactory. The script expects a deployment
 type to be provided, which will determine which orc8r modules are deployed.
 
 
-### Second option: Publish to a private github repo
+### Second option: Publish to a private Github repo
 
 We'll build the Orchestrator Helm charts, as well as publish them to a
 [GitHub repo acting as a Helm chart repo](https://blog.softwaremill.com/hosting-helm-private-repository-from-github-ff3fa940d0b7).
@@ -115,7 +115,7 @@ export GITHUB_ACCESS_TOKEN=GITHUB_ACCESS_TOKEN
 ```
 
 Next we'll run the package script. This script will package and publish the
-necessary helm charts to the `GITHUB_REPO`. The script expects a deployment
+necessary Helm charts to the `GITHUB_REPO`. The script expects a deployment
 type to be provided, which will determine which orc8r modules are deployed.
 
 

--- a/orc8r/tools/helm/package.sh
+++ b/orc8r/tools/helm/package.sh
@@ -21,6 +21,24 @@ FFWA="federated_fwa"
 ALL="all"
 ORC8R_VERSION="1.4"
 
+# package chart, update index.yaml and push it to artifactory
+update_and_send_to_artifactory () {
+  CHART_PATH=$1
+  helm dependency update $CHART_PATH
+  ARTIFACT_PATH=$(helm package $CHART_PATH | awk '{print $8}')
+  helm repo index .
+  MD5_CHECKSUM=$(md5sum $ARTIFACT_PATH | awk '{print $1}')
+  SHA1_CHECKSUM=$(shasum -a 1 $ARTIFACT_PATH | awk '{ print $1 }')
+  SHA256_CHECKSUM=$(shasum -a 256 $ARTIFACT_PATH | awk '{ print $1 }')
+  curl -u $HELM_CHART_MUSEUM_USERNAME:$HELM_CHART_MUSEUM_TOKEN \
+              --header "X-Checksum-MD5:${MD5_CHECKSUM}" \
+              --header "X-Checksum-Sha1:${SHA1_CHECKSUM}" \
+              --header "X-Checksum-Sha256:${SHA256_CHECKSUM}" \
+               -T $ARTIFACT_PATH $HELM_CHART_MUSEUM_URL/$(basename $ARTIFACT_PATH)
+
+} 
+
+
 usage() {
   echo "Usage: $0 -d DEPLOYMENT_TYPE"
   exit 2
@@ -47,78 +65,143 @@ if [ "$DEPLOYMENT_TYPE" != "$FWA" ] && [ "$DEPLOYMENT_TYPE" != "$FFWA" ] && [ "$
   ['$FWA', '$FFWA', '$ALL']"
 fi
 
-if [[ -z $GITHUB_REPO ]]; then
-  exitmsg "Environment variable GITHUB_REPO must be set"
+# Check for artifactory URL presence
+if [[ -z $HELM_CHART_MUSEUM_URL ]]; then
+
+  if [[ -z $GITHUB_REPO ]]; then
+    exitmsg "Environment variable GITHUB_REPO must be set"
+  fi
+
+  if [[ -z $GITHUB_REPO_URL ]]; then
+    exitmsg "Environment variable GITHUB_REPO_URL must be set"
+  fi
+
+  if [[ -z $GITHUB_USERNAME ]]; then
+    exitmsg "Environment variable GITHUB_USERNAME must be set"
+  fi
+
+  if [[ -z $GITHUB_ACCESS_TOKEN ]]; then
+    exitmsg "Environment variable GITHUB_ACCESS_TOKEN must be set"
+  fi
+
+  if [[ -z $MAGMA_ROOT ]]; then
+    exitmsg "Environment variable MAGMA_ROOT must be set"
+  fi
+
+  # Set up repo for charts
+  mkdir -p ~/magma-charts && cd ~/magma-charts
+  git init
+
+  # Begin packaging necessary helm charts
+  helm dependency update $MAGMA_ROOT/orc8r/cloud/helm/orc8r/
+  helm package $MAGMA_ROOT/orc8r/cloud/helm/orc8r/ && helm repo index .
+
+  if [ "$DEPLOYMENT_TYPE" == "$FWA" ]; then
+    helm dependency update $MAGMA_ROOT/lte/cloud/helm/lte-orc8r/
+    helm package $MAGMA_ROOT/lte/cloud/helm/lte-orc8r/ && helm repo index .
+  fi
+
+  if [ "$DEPLOYMENT_TYPE" == "$FFWA" ]; then
+    helm dependency update $MAGMA_ROOT/lte/cloud/helm/lte-orc8r/
+    helm package $MAGMA_ROOT/lte/cloud/helm/lte-orc8r/ && helm repo index .
+
+    helm dependency update $MAGMA_ROOT/feg/cloud/helm/feg-orc8r/
+    helm package $MAGMA_ROOT/feg/cloud/helm/feg-orc8r/ && helm repo index .
+  fi
+
+  if  [ "$DEPLOYMENT_TYPE" == "$ALL" ]; then
+    helm dependency update $MAGMA_ROOT/cwf/cloud/helm/cwf-orc8r/
+    helm package $MAGMA_ROOT/cwf/cloud/helm/cwf-orc8r/ && helm repo index .
+
+    helm dependency update $MAGMA_ROOT/lte/cloud/helm/lte-orc8r/
+    helm package $MAGMA_ROOT/lte/cloud/helm/lte-orc8r/ && helm repo index .
+
+    helm dependency update $MAGMA_ROOT/feg/cloud/helm/feg-orc8r/
+    helm package $MAGMA_ROOT/feg/cloud/helm/feg-orc8r/ && helm repo index .
+
+    helm dependency update $MAGMA_ROOT/fbinternal/cloud/helm/fbinternal-orc8r/
+    helm package $MAGMA_ROOT/fbinternal/cloud/helm/fbinternal-orc8r/ && helm repo index .
+
+    helm dependency update $MAGMA_ROOT/wifi/cloud/helm/wifi-orc8r/
+    helm package $MAGMA_ROOT/wifi/cloud/helm/wifi-orc8r/ && helm repo index .
+  fi
+
+  # Push charts
+  git add . && git commit -m "orc8r charts commit for version $ORC8R_VERSION"
+  git config remote.origin.url >&- || git remote add origin $GITHUB_REPO_URL
+  git push -u origin master
+
+  # Ensure push was successful
+  helm repo add $GITHUB_REPO --username $GITHUB_USERNAME --password $GITHUB_ACCESS_TOKEN \
+        "https://raw.githubusercontent.com/$GITHUB_USERNAME/$GITHUB_REPO/master/"
+  helm repo update
+
+  # The helm command returns 0 even when no results are found. Search for err str
+  # instead
+  HELM_SEARCH_RESULTS=$(helm search repo $GITHUB_REPO) # should list the uploaded charts
+  if [ "$HELM_SEARCH_RESULTS" == "No results found" ]; then
+    exitmsg "Error! Unable to find uploaded orc8r charts"
+  fi
+else
+
+  if [[ -z $HELM_CHART_MUSEUM_USERNAME ]]; then
+    exitmsg "Environment variable HELM_CHART_MUSEUM_USERNAME must be set"
+  fi
+
+  if [[ -z $HELM_CHART_MUSEUM_TOKEN ]]; then
+    exitmsg "Environment variable HELM_CHART_MUSEUM_TOKEN must be set"
+  fi
+
+  if [[ -z $MAGMA_ROOT ]]; then
+    exitmsg "Environment variable MAGMA_ROOT must be set"
+  fi
+
+  # Begin packaging necessary helm charts
+  update_and_send_to_artifactory $MAGMA_ROOT/orc8r/cloud/helm/orc8r/
+
+  if [ "$DEPLOYMENT_TYPE" == "$FWA" ]; then
+    update_and_send_to_artifactory $MAGMA_ROOT/lte/cloud/helm/lte-orc8r/
+  fi
+
+  if [ "$DEPLOYMENT_TYPE" == "$FFWA" ]; then
+    update_and_send_to_artifactory $MAGMA_ROOT/lte/cloud/helm/lte-orc8r/
+
+    update_and_send_to_artifactory $MAGMA_ROOT/feg/cloud/helm/feg-orc8r/
+  fi
+
+  if  [ "$DEPLOYMENT_TYPE" == "$ALL" ]; then
+    update_and_send_to_artifactory $MAGMA_ROOT/cwf/cloud/helm/cwf-orc8r/
+
+    update_and_send_to_artifactory $MAGMA_ROOT/lte/cloud/helm/lte-orc8r/
+    
+    update_and_send_to_artifactory $MAGMA_ROOT/feg/cloud/helm/feg-orc8r/
+
+    update_and_send_to_artifactory $MAGMA_ROOT/fbinternal/cloud/helm/fbinternal-orc8r/
+    
+    update_and_send_to_artifactory $MAGMA_ROOT/wifi/cloud/helm/wifi-orc8r/
+  fi
+
+  # Push index.yaml
+  INDEX_MD5_CHECKSUM=$(md5sum $MAGMA_ROOT/index.yaml | awk '{print $1}')
+  INDEX_SHA1_CHECKSUM=$(shasum -a 1 $MAGMA_ROOT/index.yaml | awk '{ print $1 }')
+  INDEX_SHA256_CHECKSUM=$(shasum -a 256 $MAGMA_ROOT/index.yaml | awk '{ print $1 }')
+  curl -u $HELM_CHART_MUSEUM_USERNAME:$HELM_CHART_MUSEUM_TOKEN \
+              --header "X-Checksum-MD5:${INDEX_MD5_CHECKSUM}" \
+              --header "X-Checksum-Sha1:${INDEX_SHA1_CHECKSUM}" \
+              --header "X-Checksum-Sha256:${INDEX_SHA256_CHECKSUM}" \
+              -T $MAGMA_ROOT/index.yaml $HELM_CHART_MUSEUM_URL/index.yaml
+
+  # Ensure push was successful
+  helm repo add $HELM_CHART_MUSEUM_URL $HELM_CHART_MUSEUM_URL --username $HELM_CHART_MUSEUM_USERNAME --password $HELM_CHART_MUSEUM_TOKEN 
+  helm repo update
+
+  # The helm command returns 0 even when no results are found. Search for err str
+  # instead
+  HELM_SEARCH_RESULTS=$(helm search repo $HELM_CHART_MUSEUM_URL) # should list the uploaded charts
+  if [ "$HELM_SEARCH_RESULTS" == "No results found" ]; then
+    exitmsg "Error! Unable to find uploaded orc8r charts"
+  fi
 fi
 
-if [[ -z $GITHUB_REPO_URL ]]; then
-  exitmsg "Environment variable GITHUB_REPO_URL must be set"
-fi
 
-if [[ -z $GITHUB_USERNAME ]]; then
-  exitmsg "Environment variable GITHUB_USERNAME must be set"
-fi
-
-if [[ -z $GITHUB_ACCESS_TOKEN ]]; then
-  exitmsg "Environment variable GITHUB_ACCESS_TOKEN must be set"
-fi
-
-if [[ -z $MAGMA_ROOT ]]; then
-  exitmsg "Environment variable MAGMA_ROOT must be set"
-fi
-
-# Set up repo for charts
-mkdir -p ~/magma-charts && cd ~/magma-charts
-git init
-
-# Begin packaging necessary helm charts
-helm dependency update $MAGMA_ROOT/orc8r/cloud/helm/orc8r/
-helm package $MAGMA_ROOT/orc8r/cloud/helm/orc8r/ && helm repo index .
-
-if [ "$DEPLOYMENT_TYPE" == "$FWA" ]; then
-  helm dependency update $MAGMA_ROOT/lte/cloud/helm/lte-orc8r/
-  helm package $MAGMA_ROOT/lte/cloud/helm/lte-orc8r/ && helm repo index .
-fi
-
-if [ "$DEPLOYMENT_TYPE" == "$FFWA" ]; then
-  helm dependency update $MAGMA_ROOT/lte/cloud/helm/lte-orc8r/
-  helm package $MAGMA_ROOT/lte/cloud/helm/lte-orc8r/ && helm repo index .
-
-  helm dependency update $MAGMA_ROOT/feg/cloud/helm/feg-orc8r/
-  helm package $MAGMA_ROOT/feg/cloud/helm/feg-orc8r/ && helm repo index .
-fi
-
-if  [ "$DEPLOYMENT_TYPE" == "$ALL" ]; then
-  helm dependency update $MAGMA_ROOT/cwf/cloud/helm/cwf-orc8r/
-  helm package $MAGMA_ROOT/cwf/cloud/helm/cwf-orc8r/ && helm repo index .
-
-  helm dependency update $MAGMA_ROOT/lte/cloud/helm/lte-orc8r/
-  helm package $MAGMA_ROOT/lte/cloud/helm/lte-orc8r/ && helm repo index .
-
-  helm dependency update $MAGMA_ROOT/feg/cloud/helm/feg-orc8r/
-  helm package $MAGMA_ROOT/feg/cloud/helm/feg-orc8r/ && helm repo index .
-
-  helm dependency update $MAGMA_ROOT/fbinternal/cloud/helm/fbinternal-orc8r/
-  helm package $MAGMA_ROOT/fbinternal/cloud/helm/fbinternal-orc8r/ && helm repo index .
-
-  helm dependency update $MAGMA_ROOT/wifi/cloud/helm/wifi-orc8r/
-  helm package $MAGMA_ROOT/wifi/cloud/helm/wifi-orc8r/ && helm repo index .
-fi
-
-# Push charts
-git add . && git commit -m "orc8r charts commit for version $ORC8R_VERSION"
-git config remote.origin.url >&- || git remote add origin $GITHUB_REPO_URL
-git push -u origin master
-
-# Ensure push was successful
-helm repo add $GITHUB_REPO --username $GITHUB_USERNAME --password $GITHUB_ACCESS_TOKEN \
-      "https://raw.githubusercontent.com/$GITHUB_USERNAME/$GITHUB_REPO/master/"
-helm repo update
-
-# The helm command returns 0 even when no results are found. Search for err str
-# instead
-HELM_SEARCH_RESULTS=$(helm search repo $GITHUB_REPO) # should list the uploaded charts
-if [ "$HELM_SEARCH_RESULTS" == "No results found" ]; then
-  exitmsg "Error! Unable to find uploaded orc8r charts"
-fi
 echo "Uploaded orc8r charts successfully."

--- a/orc8r/tools/helm/package.sh
+++ b/orc8r/tools/helm/package.sh
@@ -23,18 +23,18 @@ ORC8R_VERSION="1.4"
 
 # package chart, update index.yaml and push it to artifactory
 update_and_send_to_artifactory () {
-  CHART_PATH=$1
-  helm dependency update $CHART_PATH
-  ARTIFACT_PATH=$(helm package $CHART_PATH | awk '{print $8}')
+  CHART_PATH="$1"
+  helm dependency update "$CHART_PATH"
+  ARTIFACT_PATH="$(helm package "$CHART_PATH" | awk '{print $8}')"
   helm repo index .
-  MD5_CHECKSUM=$(md5sum $ARTIFACT_PATH | awk '{print $1}')
-  SHA1_CHECKSUM=$(shasum -a 1 $ARTIFACT_PATH | awk '{ print $1 }')
-  SHA256_CHECKSUM=$(shasum -a 256 $ARTIFACT_PATH | awk '{ print $1 }')
-  curl -u $HELM_CHART_MUSEUM_USERNAME:$HELM_CHART_MUSEUM_TOKEN \
+  MD5_CHECKSUM="$(md5sum "$ARTIFACT_PATH" | awk '{print $1}')"
+  SHA1_CHECKSUM="$(shasum -a 1 "$ARTIFACT_PATH" | awk '{ print $1 }')"
+  SHA256_CHECKSUM="$(shasum -a 256 "$ARTIFACT_PATH" | awk '{ print $1 }')"
+  curl -u "$HELM_CHART_MUSEUM_USERNAME":"$HELM_CHART_MUSEUM_TOKEN" \
               --header "X-Checksum-MD5:${MD5_CHECKSUM}" \
               --header "X-Checksum-Sha1:${SHA1_CHECKSUM}" \
               --header "X-Checksum-Sha256:${SHA256_CHECKSUM}" \
-               -T $ARTIFACT_PATH $HELM_CHART_MUSEUM_URL/$(basename $ARTIFACT_PATH)
+               -T "$ARTIFACT_PATH" "$HELM_CHART_MUSEUM_URL/$(basename "$ARTIFACT_PATH")"
 
 } 
 
@@ -93,52 +93,52 @@ if [[ -z $HELM_CHART_MUSEUM_URL ]]; then
   git init
 
   # Begin packaging necessary helm charts
-  helm dependency update $MAGMA_ROOT/orc8r/cloud/helm/orc8r/
-  helm package $MAGMA_ROOT/orc8r/cloud/helm/orc8r/ && helm repo index .
+  helm dependency update "$MAGMA_ROOT/orc8r/cloud/helm/orc8r/"
+  helm package "$MAGMA_ROOT/orc8r/cloud/helm/orc8r/" && helm repo index .
 
   if [ "$DEPLOYMENT_TYPE" == "$FWA" ]; then
-    helm dependency update $MAGMA_ROOT/lte/cloud/helm/lte-orc8r/
-    helm package $MAGMA_ROOT/lte/cloud/helm/lte-orc8r/ && helm repo index .
+    helm dependency update "$MAGMA_ROOT/lte/cloud/helm/lte-orc8r/"
+    helm package "$MAGMA_ROOT/lte/cloud/helm/lte-orc8r/" && helm repo index .
   fi
 
   if [ "$DEPLOYMENT_TYPE" == "$FFWA" ]; then
-    helm dependency update $MAGMA_ROOT/lte/cloud/helm/lte-orc8r/
-    helm package $MAGMA_ROOT/lte/cloud/helm/lte-orc8r/ && helm repo index .
+    helm dependency update "$MAGMA_ROOT/lte/cloud/helm/lte-orc8r/"
+    helm package "$MAGMA_ROOT/lte/cloud/helm/lte-orc8r/" && helm repo index .
 
-    helm dependency update $MAGMA_ROOT/feg/cloud/helm/feg-orc8r/
-    helm package $MAGMA_ROOT/feg/cloud/helm/feg-orc8r/ && helm repo index .
+    helm dependency update "$MAGMA_ROOT/feg/cloud/helm/feg-orc8r/"
+    helm package "$MAGMA_ROOT/feg/cloud/helm/feg-orc8r/" && helm repo index .
   fi
 
   if  [ "$DEPLOYMENT_TYPE" == "$ALL" ]; then
-    helm dependency update $MAGMA_ROOT/cwf/cloud/helm/cwf-orc8r/
-    helm package $MAGMA_ROOT/cwf/cloud/helm/cwf-orc8r/ && helm repo index .
+    helm dependency update "$MAGMA_ROOT/cwf/cloud/helm/cwf-orc8r/"
+    helm package "$MAGMA_ROOT/cwf/cloud/helm/cwf-orc8r/" && helm repo index .
 
-    helm dependency update $MAGMA_ROOT/lte/cloud/helm/lte-orc8r/
-    helm package $MAGMA_ROOT/lte/cloud/helm/lte-orc8r/ && helm repo index .
+    helm dependency update "$MAGMA_ROOT/lte/cloud/helm/lte-orc8r/"
+    helm package "$MAGMA_ROOT/lte/cloud/helm/lte-orc8r/" && helm repo index .
 
-    helm dependency update $MAGMA_ROOT/feg/cloud/helm/feg-orc8r/
-    helm package $MAGMA_ROOT/feg/cloud/helm/feg-orc8r/ && helm repo index .
+    helm dependency update "$MAGMA_ROOT/feg/cloud/helm/feg-orc8r/"
+    helm package "$MAGMA_ROOT/feg/cloud/helm/feg-orc8r/" && helm repo index .
 
-    helm dependency update $MAGMA_ROOT/fbinternal/cloud/helm/fbinternal-orc8r/
-    helm package $MAGMA_ROOT/fbinternal/cloud/helm/fbinternal-orc8r/ && helm repo index .
+    helm dependency update "$MAGMA_ROOT/fbinternal/cloud/helm/fbinternal-orc8r/"
+    helm package "$MAGMA_ROOT/fbinternal/cloud/helm/fbinternal-orc8r/" && helm repo index .
 
-    helm dependency update $MAGMA_ROOT/wifi/cloud/helm/wifi-orc8r/
-    helm package $MAGMA_ROOT/wifi/cloud/helm/wifi-orc8r/ && helm repo index .
+    helm dependency update "$MAGMA_ROOT/wifi/cloud/helm/wifi-orc8r/"
+    helm package "$MAGMA_ROOT/wifi/cloud/helm/wifi-orc8r/" && helm repo index .
   fi
 
   # Push charts
   git add . && git commit -m "orc8r charts commit for version $ORC8R_VERSION"
-  git config remote.origin.url >&- || git remote add origin $GITHUB_REPO_URL
+  git config remote.origin.url >&- || git remote add origin "$GITHUB_REPO_URL"
   git push -u origin master
 
   # Ensure push was successful
-  helm repo add $GITHUB_REPO --username $GITHUB_USERNAME --password $GITHUB_ACCESS_TOKEN \
+  helm repo add "$GITHUB_REPO" --username "$GITHUB_USERNAME" --password "$GITHUB_ACCESS_TOKEN" \
         "https://raw.githubusercontent.com/$GITHUB_USERNAME/$GITHUB_REPO/master/"
   helm repo update
 
   # The helm command returns 0 even when no results are found. Search for err str
   # instead
-  HELM_SEARCH_RESULTS=$(helm search repo $GITHUB_REPO) # should list the uploaded charts
+  HELM_SEARCH_RESULTS="$(helm search repo "$GITHUB_REPO")" # should list the uploaded charts
   if [ "$HELM_SEARCH_RESULTS" == "No results found" ]; then
     exitmsg "Error! Unable to find uploaded orc8r charts"
   fi
@@ -157,47 +157,47 @@ else
   fi
 
   # Begin packaging necessary helm charts
-  update_and_send_to_artifactory $MAGMA_ROOT/orc8r/cloud/helm/orc8r/
+  update_and_send_to_artifactory "$MAGMA_ROOT/orc8r/cloud/helm/orc8r/"
 
   if [ "$DEPLOYMENT_TYPE" == "$FWA" ]; then
-    update_and_send_to_artifactory $MAGMA_ROOT/lte/cloud/helm/lte-orc8r/
+    update_and_send_to_artifactory "$MAGMA_ROOT/lte/cloud/helm/lte-orc8r/"
   fi
 
   if [ "$DEPLOYMENT_TYPE" == "$FFWA" ]; then
-    update_and_send_to_artifactory $MAGMA_ROOT/lte/cloud/helm/lte-orc8r/
+    update_and_send_to_artifactory "$MAGMA_ROOT/lte/cloud/helm/lte-orc8r/"
 
-    update_and_send_to_artifactory $MAGMA_ROOT/feg/cloud/helm/feg-orc8r/
+    update_and_send_to_artifactory "$MAGMA_ROOT/feg/cloud/helm/feg-orc8r/"
   fi
 
   if  [ "$DEPLOYMENT_TYPE" == "$ALL" ]; then
-    update_and_send_to_artifactory $MAGMA_ROOT/cwf/cloud/helm/cwf-orc8r/
+    update_and_send_to_artifactory "$MAGMA_ROOT/cwf/cloud/helm/cwf-orc8r/"
 
-    update_and_send_to_artifactory $MAGMA_ROOT/lte/cloud/helm/lte-orc8r/
+    update_and_send_to_artifactory "$MAGMA_ROOT/lte/cloud/helm/lte-orc8r/"
     
-    update_and_send_to_artifactory $MAGMA_ROOT/feg/cloud/helm/feg-orc8r/
+    update_and_send_to_artifactory "$MAGMA_ROOT/feg/cloud/helm/feg-orc8r/"
 
-    update_and_send_to_artifactory $MAGMA_ROOT/fbinternal/cloud/helm/fbinternal-orc8r/
+    update_and_send_to_artifactory "$MAGMA_ROOT/fbinternal/cloud/helm/fbinternal-orc8r/"
     
-    update_and_send_to_artifactory $MAGMA_ROOT/wifi/cloud/helm/wifi-orc8r/
+    update_and_send_to_artifactory "$MAGMA_ROOT/wifi/cloud/helm/wifi-orc8r/"
   fi
 
   # Push index.yaml
-  INDEX_MD5_CHECKSUM=$(md5sum $MAGMA_ROOT/index.yaml | awk '{print $1}')
-  INDEX_SHA1_CHECKSUM=$(shasum -a 1 $MAGMA_ROOT/index.yaml | awk '{ print $1 }')
-  INDEX_SHA256_CHECKSUM=$(shasum -a 256 $MAGMA_ROOT/index.yaml | awk '{ print $1 }')
-  curl -u $HELM_CHART_MUSEUM_USERNAME:$HELM_CHART_MUSEUM_TOKEN \
+  INDEX_MD5_CHECKSUM="$(md5sum "$MAGMA_ROOT/index.yaml" | awk '{print $1}')"
+  INDEX_SHA1_CHECKSUM="$(shasum -a 1 "$MAGMA_ROOT/index.yaml" | awk '{ print $1 }')"
+  INDEX_SHA256_CHECKSUM="$(shasum -a 256 "$MAGMA_ROOT/index.yaml" | awk '{ print $1 }')"
+  curl -u "$HELM_CHART_MUSEUM_USERNAME":"$HELM_CHART_MUSEUM_TOKEN" \
               --header "X-Checksum-MD5:${INDEX_MD5_CHECKSUM}" \
               --header "X-Checksum-Sha1:${INDEX_SHA1_CHECKSUM}" \
               --header "X-Checksum-Sha256:${INDEX_SHA256_CHECKSUM}" \
-              -T $MAGMA_ROOT/index.yaml $HELM_CHART_MUSEUM_URL/index.yaml
+              -T "$MAGMA_ROOT/index.yaml" "$HELM_CHART_MUSEUM_URL/index.yaml"
 
   # Ensure push was successful
-  helm repo add $HELM_CHART_MUSEUM_URL $HELM_CHART_MUSEUM_URL --username $HELM_CHART_MUSEUM_USERNAME --password $HELM_CHART_MUSEUM_TOKEN 
+  helm repo add "$(basename "$HELM_CHART_MUSEUM_URL")" "$HELM_CHART_MUSEUM_URL" --username "$HELM_CHART_MUSEUM_USERNAME" --password "$HELM_CHART_MUSEUM_TOKEN" 
   helm repo update
 
   # The helm command returns 0 even when no results are found. Search for err str
   # instead
-  HELM_SEARCH_RESULTS=$(helm search repo $HELM_CHART_MUSEUM_URL) # should list the uploaded charts
+  HELM_SEARCH_RESULTS="$(helm search repo "$(basename "$HELM_CHART_MUSEUM_URL")")" # should list the uploaded charts
   if [ "$HELM_SEARCH_RESULTS" == "No results found" ]; then
     exitmsg "Error! Unable to find uploaded orc8r charts"
   fi

--- a/orc8r/tools/helm/package.sh
+++ b/orc8r/tools/helm/package.sh
@@ -30,7 +30,7 @@ update_and_send_to_artifactory () {
   MD5_CHECKSUM="$(md5sum "$ARTIFACT_PATH" | awk '{print $1}')"
   SHA1_CHECKSUM="$(shasum -a 1 "$ARTIFACT_PATH" | awk '{ print $1 }')"
   SHA256_CHECKSUM="$(shasum -a 256 "$ARTIFACT_PATH" | awk '{ print $1 }')"
-  curl -u "$HELM_CHART_MUSEUM_USERNAME":"$HELM_CHART_MUSEUM_TOKEN" \
+  curl -u "$HELM_CHART_MUSEUM_USERNAME":"$HELM_CHART_MUSEUM_TOKEN" --fail \
               --header "X-Checksum-MD5:${MD5_CHECKSUM}" \
               --header "X-Checksum-Sha1:${SHA1_CHECKSUM}" \
               --header "X-Checksum-Sha256:${SHA256_CHECKSUM}" \


### PR DESCRIPTION
## Summary

Added feature to build and push helm charts to a jfrog artifactory

New needed environment variables are
HELM_CHART_MUSEUM_URL for the artifactory URL
HELM_CHART_MUSEUM_USERNAME for the artifactory username
HELM_CHART_MUSEUM_TOKEN for the artifactory password token

## Test Plan

Tested to push new Helm charts of v1.5 branch to the artifactory helm-test
Artifacts correctly pushed with valid hashes

## Additional Information

Will not break old behavior

Legacy purpose of the script is still intact if not defining HELM_CHART_MUSEUM_URL
