### PR TITLE
AGW: pipelined: fix pylinter issue related asyncio sleep.

### DIFF
--- a/lte/gateway/python/magma/pipelined/ifaces.py
+++ b/lte/gateway/python/magma/pipelined/ifaces.py
@@ -19,7 +19,7 @@ POLL_INTERVAL_SECONDS = 3
 
 
 @asyncio.coroutine
-def monitor_ifaces(iface_names, loop):
+def monitor_ifaces(iface_names):
     """
     Call to poll the network interfaces and set the corresponding metric
     """
@@ -28,4 +28,4 @@ def monitor_ifaces(iface_names, loop):
         for iface in iface_names:
             status = 1 if iface in active else 0
             NETWORK_IFACE_STATUS.labels(iface_name=iface).set(status)
-        yield from asyncio.sleep(POLL_INTERVAL_SECONDS, loop=loop)
+        yield from asyncio.sleep(POLL_INTERVAL_SECONDS)

--- a/lte/gateway/python/magma/pipelined/main.py
+++ b/lte/gateway/python/magma/pipelined/main.py
@@ -124,8 +124,7 @@ def main():
                      )
 
     service.loop.create_task(monitor_ifaces(
-        service.config['monitored_ifaces'],
-        service.loop),
+        service.config['monitored_ifaces']),
     )
 
     manager = AppManager.get_instance()


### PR DESCRIPTION
---8<---
FAIL: test_pylint (tests.pylint_tests.MagmaPyLintTest)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/vagrant/magma/lte/gateway/python/magma/tests/pylint_tests.py", line 60, in test_pylint
    py_wrap.assertNoLintErrors(path)
  File "/home/vagrant/magma/lte/gateway/python/magma/tests/pylint_wrapper.py", line 88, in assertNoLintErrors
    raise AssertionError(msg)
AssertionError: PyLint found errors:
************* Module pipelined.ifaces
W1511: 31, 19: Using deprecated argument loop of method sleep() (deprecated-argument)

Signed-off-by: Pravin B Shelar <pbshelar@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->

## Test Plan
`make test`
sanity integ test
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
