### PR TITLE
AGW: deploy: ubuntu: Delete cloned magma repo after installation.

### DIFF
--- a/docs/readmes/lte/deploy_install_ubuntu.md
+++ b/docs/readmes/lte/deploy_install_ubuntu.md
@@ -53,7 +53,7 @@ installation process to get an IP using DHCP.
 ```bash
 su
 wget https://raw.githubusercontent.com/magma/magma/master/lte/gateway/deploy/agw_install_ubuntu.sh
-bash agw_post_install_ubuntu.sh
+bash agw_install_ubuntu.sh
 ```
 
 The script will run a pre-check script that will prompt you what will change
@@ -90,7 +90,6 @@ service magma@* status
 Make sure you have `control_proxy.yml` file in directory /var/opt/magma/configs/
 before running post install script.
 
-``` bash
-cd ~/magma/lte/gateway/deploy
-./agw_post_install_ubuntu.sh
+```bash
+bash /root/agw_post_install_ubuntu.sh
 ```

--- a/lte/gateway/deploy/agw_install_ubuntu.sh
+++ b/lte/gateway/deploy/agw_install_ubuntu.sh
@@ -156,7 +156,7 @@ if [ "$MAGMA_INSTALLED" != "$SUCCESS_MESSAGE" ]; then
   alias python=python3
   pip3 install ansible
 
-  git clone "${GIT_URL}" /home/$MAGMA_USER/magma
+  git clone --depth=1 "${GIT_URL}" /home/$MAGMA_USER/magma
   cd /home/$MAGMA_USER/magma || exit
   git checkout "$MAGMA_VERSION"
 
@@ -167,11 +167,14 @@ if [ "$MAGMA_INSTALLED" != "$SUCCESS_MESSAGE" ]; then
   # install magma and its dependencies including OVS.
   su - $MAGMA_USER -c "ansible-playbook -e \"MAGMA_ROOT='/home/$MAGMA_USER/magma' OUTPUT_DIR='/tmp'\" -i $DEPLOY_PATH/agw_hosts $DEPLOY_PATH/magma_deploy.yml"
 
-  echo "Deleting boot script if it exists"
+  echo "Cleanup temp files"
+  cd /root || exit
   rm -rf $AGW_INSTALL_CONFIG
   rm -rf /home/$MAGMA_USER/build
+  rm -rf /home/$MAGMA_USER/magma
+
   echo "AGW installation is done, Run agw_post_install_ubuntu.sh install script after reboot to finish installation"
-  wget https://raw.githubusercontent.com/magma/magma/"$MAGMA_VERSION"/lte/gateway/deploy/agw_post_install_ubuntu.sh
+  wget https://raw.githubusercontent.com/magma/magma/"$MAGMA_VERSION"/lte/gateway/deploy/agw_post_install_ubuntu.sh -P /root/
 
   reboot
 else

--- a/lte/gateway/deploy/agw_post_install_ubuntu.sh
+++ b/lte/gateway/deploy/agw_post_install_ubuntu.sh
@@ -1,16 +1,14 @@
 #!/bin/bash
-"""
-Copyright 2021 The Magma Authors.
-
-This source code is licensed under the BSD-style license found in the
-LICENSE file in the root directory of this source tree.
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an AS IS BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-"""
+#Copyright 2021 The Magma Authors.
+#
+#This source code is licensed under the BSD-style license found in the
+#LICENSE file in the root directory of this source tree.
+#
+#Unless required by applicable law or agreed to in writing, software
+#distributed under the License is distributed on an AS IS BASIS,
+#WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#See the License for the specific language governing permissions and
+#limitations under the License.
 
 
 # Setting up env variable, user and project path


### PR DESCRIPTION
AGW installation process needs to clone magma git repo.
The Following patch removes the code from AGW after installation.

Signed-off-by: Pravin B Shelar <pbshelar@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->

## Test Plan
Test installation on virtual AGW.

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
