### PR TITLE
refactor: Clean up process_rules_to_install to prepare for separating out default and dedicated bearer policies

### DIFF
--- a/lte/gateway/c/session_manager/LocalEnforcer.cpp
+++ b/lte/gateway/c/session_manager/LocalEnforcer.cpp
@@ -284,8 +284,9 @@ void LocalEnforcer::cleanup_dead_sessions(
   for (const RuleRecord& record : dead_sessions_to_cleanup) {
     Teids teids;
     teids.set_agw_teid(record.teid());
+    const std::vector<Teids> teids_vec{teids};
     pipelined_client_->deactivate_flows_for_rules_for_termination(
-        record.sid(), record.ue_ipv4(), record.ue_ipv6(), teids,
+        record.sid(), record.ue_ipv4(), record.ue_ipv6(), teids_vec,
         RequestOriginType::WILDCARD);
   }
 }
@@ -440,7 +441,7 @@ void LocalEnforcer::remove_all_rules_for_termination(
     SessionStateUpdateCriteria& uc) {
   const std::string ip_addr = session->get_config().common_context.ue_ipv4();
   const auto ipv6_addr      = session->get_config().common_context.ue_ipv6();
-  const Teids teids         = session->get_config().common_context.teids();
+  const std::vector<Teids> teids = session->get_active_teids();
   pipelined_client_->deactivate_flows_for_rules_for_termination(
       imsi, ip_addr, ipv6_addr, teids, RequestOriginType::WILDCARD);
   session->remove_all_rules_for_termination(uc);

--- a/lte/gateway/c/session_manager/PipelinedClient.cpp
+++ b/lte/gateway/c/session_manager/PipelinedClient.cpp
@@ -50,10 +50,9 @@ magma::SessionSet create_session_set_req(
   return req;
 }
 
-magma::DeactivateFlowsRequest create_deactivate_req(
+magma::DeactivateFlowsRequest make_deactivate_req(
     const std::string& imsi, const std::string& ip_addr,
     const std::string& ipv6_addr, const magma::Teids teids,
-    const magma::RulesToProcess& to_process,
     const magma::RequestOriginType_OriginType origin_type,
     const bool remove_default_drop_rules) {
   magma::DeactivateFlowsRequest req;
@@ -64,21 +63,59 @@ magma::DeactivateFlowsRequest create_deactivate_req(
   req.set_uplink_tunnel(teids.agw_teid());
   req.set_remove_default_drop_flows(remove_default_drop_rules);
   req.mutable_request_origin()->set_type(origin_type);
-  auto mut_versioned_rules = req.mutable_policies();
-  for (const magma::RuleToProcess& val : to_process) {
-    auto versioned_policy = mut_versioned_rules->Add();
-    versioned_policy->set_version(val.version);
-    versioned_policy->set_rule_id(val.rule.id());
-  }
   return req;
 }
 
-magma::ActivateFlowsRequest create_activate_req(
+/**
+ * @brief Create a map of Teids -> DeactivateFlowsRequest
+ * If to_process is empty, create one default_teids -> DeactivateFlowsRequest
+ * with no rules. For each to_process item, create item.teid ->
+ * DeactivateFlowsRequest with item.rules
+ * @param imsi
+ * @param ip_addr
+ * @param ipv6_addr
+ * @param default_teids this value is only used if to_process is empty
+ * @param to_process
+ * @param origin_type
+ * @param remove_default_drop_rules
+ * @return magma::DeactivateReqByTeids
+ */
+magma::DeactivateReqByTeids make_deactivate_req_by_teid(
+    const std::string& imsi, const std::string& ip_addr,
+    const std::string& ipv6_addr, const magma::Teids default_teids,
+    const magma::RulesToProcess& to_process,
+    const magma::RequestOriginType_OriginType origin_type,
+    const bool remove_default_drop_rules) {
+  magma::DeactivateReqByTeids deactivate_req_by_teids;
+  if (to_process.empty()) {
+    // Send an empty request with the default teid
+    deactivate_req_by_teids[default_teids] = make_deactivate_req(
+        imsi, ip_addr, ipv6_addr, default_teids, origin_type,
+        remove_default_drop_rules);
+    return deactivate_req_by_teids;
+  }
+
+  for (const magma::RuleToProcess& val : to_process) {
+    const magma::Teids& dedicated_teids = val.teids;
+    if (deactivate_req_by_teids.find(dedicated_teids) ==
+        deactivate_req_by_teids.end()) {
+      deactivate_req_by_teids[dedicated_teids] = make_deactivate_req(
+          imsi, ip_addr, ipv6_addr, dedicated_teids, origin_type,
+          remove_default_drop_rules);
+    }
+    auto versioned_policy =
+        deactivate_req_by_teids[dedicated_teids].mutable_policies()->Add();
+    versioned_policy->set_version(val.version);
+    versioned_policy->set_rule_id(val.rule.id());
+  }
+  return deactivate_req_by_teids;
+}
+
+magma::ActivateFlowsRequest make_activate_req(
     const std::string& imsi, const std::string& ip_addr,
     const std::string& ipv6_addr, const magma::Teids teids,
     const std::string& msisdn,
     const optional<magma::AggregatedMaximumBitrate>& ambr,
-    const magma::RulesToProcess& to_process,
     const magma::RequestOriginType_OriginType origin_type) {
   magma::ActivateFlowsRequest req;
   req.mutable_sid()->set_id(imsi);
@@ -91,13 +128,52 @@ magma::ActivateFlowsRequest create_activate_req(
   if (ambr) {
     req.mutable_apn_ambr()->CopyFrom(*ambr);
   }
-  auto mut_versioned_rules = req.mutable_policies();
+  return req;
+}
+
+/**
+ * @brief Create a map of Teids -> ActivateFlowsRequest
+ * If to_process is empty, create one default_teids -> ActivateFlowsRequest with
+ * no rules. For each to_process item, create item.teid -> ActivateFlowsRequest
+ * with item.rules
+ * @param imsi
+ * @param ip_addr
+ * @param ipv6_addr
+ * @param default_teids
+ * @param msisdn
+ * @param ambr
+ * @param to_process
+ * @param origin_type
+ * @return magma::ActivateReqByTeids
+ */
+magma::ActivateReqByTeids make_activate_req_by_teid(
+    const std::string& imsi, const std::string& ip_addr,
+    const std::string& ipv6_addr, const magma::Teids default_teids,
+    const std::string& msisdn,
+    const optional<magma::AggregatedMaximumBitrate>& ambr,
+    const magma::RulesToProcess& to_process,
+    const magma::RequestOriginType_OriginType origin_type) {
+  magma::ActivateReqByTeids activate_req_by_teids;
+  if (to_process.empty()) {
+    // Send an empty request with the default teid
+    activate_req_by_teids[default_teids] = make_activate_req(
+        imsi, ip_addr, ipv6_addr, default_teids, msisdn, ambr, origin_type);
+    return activate_req_by_teids;
+  }
+
   for (const magma::RuleToProcess& val : to_process) {
-    auto versioned_policy = mut_versioned_rules->Add();
+    const magma::Teids& dedicated_teids = val.teids;
+    if (activate_req_by_teids.find(dedicated_teids) ==
+        activate_req_by_teids.end()) {
+      activate_req_by_teids[dedicated_teids] = make_activate_req(
+          imsi, ip_addr, ipv6_addr, dedicated_teids, msisdn, ambr, origin_type);
+    }
+    auto versioned_policy =
+        activate_req_by_teids[dedicated_teids].mutable_policies()->Add();
     versioned_policy->set_version(val.version);
     versioned_policy->mutable_rule()->CopyFrom(val.rule);
   }
-  return req;
+  return activate_req_by_teids;
 }
 
 magma::UEMacFlowRequest create_add_ue_mac_flow_req(
@@ -133,25 +209,24 @@ magma::SetupPolicyRequest create_setup_policy_req(
     const std::vector<magma::SessionState::SessionInfo>& infos,
     const std::uint64_t& epoch) {
   magma::SetupPolicyRequest req;
-  std::vector<magma::ActivateFlowsRequest> activation_reqs;
+  req.set_epoch(epoch);
+  auto mut_requests = req.mutable_requests();
 
   for (auto it = infos.begin(); it != infos.end(); it++) {
-    auto gx_activate_req = create_activate_req(
+    magma::ActivateReqByTeids gx_activate_reqs = make_activate_req_by_teid(
         it->imsi, it->ip_addr, it->ipv6_addr, it->teids, it->msisdn, it->ambr,
         it->gx_rules, magma::RequestOriginType::GX);
-    activation_reqs.push_back(gx_activate_req);
-    if (!it->gy_dynamic_rules.empty()) {
-      auto gy_activate_req = create_activate_req(
-          it->imsi, it->ip_addr, it->ipv6_addr, it->teids, it->msisdn, {},
-          it->gy_dynamic_rules, magma::RequestOriginType::GY);
-      activation_reqs.push_back(gy_activate_req);
+    for (auto& activate_pair : gx_activate_reqs) {
+      mut_requests->Add()->CopyFrom(activate_pair.second);
+    }
+
+    magma::ActivateReqByTeids gy_activate_reqs = make_activate_req_by_teid(
+        it->imsi, it->ip_addr, it->ipv6_addr, it->teids, it->msisdn, {},
+        it->gy_dynamic_rules, magma::RequestOriginType::GY);
+    for (auto& activate_pair : gy_activate_reqs) {
+      mut_requests->Add()->CopyFrom(activate_pair.second);
     }
   }
-  auto mut_requests = req.mutable_requests();
-  for (const auto& act_req : activation_reqs) {
-    mut_requests->Add()->CopyFrom(act_req);
-  }
-  req.set_epoch(epoch);
   return req;
 }
 
@@ -249,18 +324,18 @@ void AsyncPipelinedClient::set_upf_session(
 
 void AsyncPipelinedClient::deactivate_flows_for_rules_for_termination(
     const std::string& imsi, const std::string& ip_addr,
-    const std::string& ipv6_addr, const Teids teids,
+    const std::string& ipv6_addr, const std::vector<Teids>& teids,
     const RequestOriginType_OriginType origin_type) {
-  MLOG(MDEBUG) << "Deactivating all rules and default drop flows "
-               << "for " << imsi << ", ipv4: " << ip_addr
-               << ", ipv6: " << ipv6_addr << ", agw teid: " << teids.agw_teid()
-               << ", enb teid: " << teids.enb_teid()
-               << ", origin_type: " << request_origin_type_to_str(origin_type);
-
-  RulesToProcess empty_to_process = std::vector<RuleToProcess>{};
-  auto req                        = create_deactivate_req(
-      imsi, ip_addr, ipv6_addr, teids, empty_to_process, origin_type, true);
-  deactivate_flows(req);
+  for (const Teids& t : teids) {
+    MLOG(MDEBUG) << "Deactivating all rules and default drop flows "
+                 << "for " << imsi << ", ipv4: " << ip_addr
+                 << ", ipv6: " << ipv6_addr << ", agw teid: " << t.agw_teid()
+                 << ", enb teid: " << t.enb_teid() << ", origin_type: "
+                 << request_origin_type_to_str(origin_type);
+    DeactivateFlowsRequest req =
+        make_deactivate_req(imsi, ip_addr, ipv6_addr, t, origin_type, true);
+    deactivate_flows(req);
+  }
 }
 
 void AsyncPipelinedClient::deactivate_flows_for_rules(
@@ -272,9 +347,11 @@ void AsyncPipelinedClient::deactivate_flows_for_rules(
                << " rules and for subscriber " << imsi << " IP " << ip_addr
                << " " << ipv6_addr;
 
-  auto req = create_deactivate_req(
+  DeactivateReqByTeids reqs = make_deactivate_req_by_teid(
       imsi, ip_addr, ipv6_addr, teids, to_process, origin_type, false);
-  deactivate_flows(req);
+  for (auto& req_pair : reqs) {
+    deactivate_flows(req_pair.second);
+  }
 }
 
 void AsyncPipelinedClient::deactivate_flows(DeactivateFlowsRequest& request) {
@@ -297,10 +374,12 @@ void AsyncPipelinedClient::activate_flows_for_rules(
   MLOG(MDEBUG) << "Activating " << to_process.size() << " rules for " << imsi
                << " msisdn " << msisdn << " and ip " << ip_addr << " "
                << ipv6_addr;
-  auto req = create_activate_req(
+  ActivateReqByTeids reqs = make_activate_req_by_teid(
       imsi, ip_addr, ipv6_addr, teids, msisdn, ambr, to_process,
       RequestOriginType::GX);
-  activate_flows_rpc(req, callback);
+  for (auto& activate_pair : reqs) {
+    activate_flows_rpc(activate_pair.second, callback);
+  }
 }
 
 void AsyncPipelinedClient::add_ue_mac_flow(
@@ -353,15 +432,19 @@ void AsyncPipelinedClient::add_gy_final_action_flow(
     const std::string& ipv6_addr, const Teids teids, const std::string& msisdn,
     const RulesToProcess to_process) {
   MLOG(MDEBUG) << "Activating GY final action for subscriber " << imsi;
-  auto req = create_activate_req(
+  ActivateReqByTeids reqs = make_activate_req_by_teid(
       imsi, ip_addr, ipv6_addr, teids, msisdn, {}, to_process,
       RequestOriginType::GY);
-  activate_flows_rpc(req, [imsi](Status status, ActivateFlowsResult resp) {
+  auto cb = [imsi](Status status, ActivateFlowsResult resp) {
     if (!status.ok()) {
       MLOG(MERROR) << "Could not activate GY flows through pipelined for UE "
                    << imsi << ": " << status.error_message();
     }
-  });
+  };
+
+  for (auto& activate_pair : reqs) {
+    activate_flows_rpc(activate_pair.second, cb);
+  }
 }
 
 // RPC definition to Send Set Session request to UPF

--- a/lte/gateway/c/session_manager/SessionState.cpp
+++ b/lte/gateway/c/session_manager/SessionState.cpp
@@ -1071,6 +1071,8 @@ RuleToProcess SessionState::make_rule_to_process(const PolicyRule& rule) {
   RuleToProcess to_process;
   to_process.version = get_current_rule_version(rule.id());
   to_process.rule    = rule;
+  // TODO(@themarwhal): look up teids from PolicyID -> BearerID map
+  to_process.teids = config_.common_context.teids();
   return to_process;
 }
 
@@ -2230,6 +2232,15 @@ void SessionState::update_bearer_deletion_req(
   }
   update.delete_req.mutable_eps_bearer_ids()->Add(
       bearer_id_to_delete.bearer_id);
+}
+
+std::vector<Teids> SessionState::get_active_teids() {
+  std::vector<Teids> teids = {config_.common_context.teids()};
+  // TODO(@themarwhal): uncomment the block below once MME starts sending the
+  // teids for (auto bearer_pair : bearer_id_by_policy_) {
+  //   teids.push_back(bearer_pair.second.teids);
+  // }
+  return teids;
 }
 
 RuleSetToApply::RuleSetToApply(const magma::lte::RuleSet& rule_set) {

--- a/lte/gateway/c/session_manager/SessionState.h
+++ b/lte/gateway/c/session_manager/SessionState.h
@@ -542,6 +542,15 @@ class SessionState {
   optional<PolicyRule> policy_needs_bearer_creation(
       const PolicyType policy_type, const std::string& rule_id,
       const SessionConfig& config);
+
+  /**
+   * @brief Return the list of teids used in this session
+   * The teids will be the union of config.common_context.teids and any teids
+   * tied to dedicated bearers in bearer_id_by_policy_
+   * @return std::vector<Teids>
+   */
+  std::vector<Teids> get_active_teids();
+
   /**
    *
    * @param rule_set

--- a/lte/gateway/c/session_manager/Types.h
+++ b/lte/gateway/c/session_manager/Types.h
@@ -14,6 +14,7 @@
 
 #include <functional>
 #include <vector>
+#include <unordered_map>
 #include <experimental/optional>
 
 #include <folly/Format.h>
@@ -197,6 +198,7 @@ typedef std::unordered_map<PolicyID, BearerIDAndTeid, PolicyIDHash>
 struct RuleToProcess {
   PolicyRule rule;
   uint32_t version;
+  Teids teids;
 };
 
 typedef std::vector<RuleToProcess> RulesToProcess;
@@ -208,5 +210,22 @@ struct StatsPerPolicy {
   uint32_t last_reported_version;
 };
 typedef std::unordered_map<std::string, StatsPerPolicy> PolicyStatsMap;
+
+struct TeidHash {
+  std::size_t operator()(const Teids& teid) const {
+    std::size_t h1 = std::hash<uint32_t>{}(teid.enb_teid());
+    std::size_t h2 = std::hash<uint32_t>{}(teid.agw_teid());
+    return h1 ^ h2;
+  }
+};
+struct TeidEqual {
+  bool operator()(const Teids& lhs, const Teids& rhs) const {
+    return lhs.agw_teid() == rhs.agw_teid() && lhs.enb_teid() == rhs.enb_teid();
+  }
+};
+typedef std::unordered_map<Teids, ActivateFlowsRequest, TeidHash, TeidEqual>
+    ActivateReqByTeids;
+typedef std::unordered_map<Teids, DeactivateFlowsRequest, TeidHash, TeidEqual>
+    DeactivateReqByTeids;
 
 }  // namespace magma

--- a/lte/gateway/c/session_manager/test/Matchers.h
+++ b/lte/gateway/c/session_manager/test/Matchers.h
@@ -67,6 +67,24 @@ MATCHER_P(CheckTeids, configured_teids, "") {
   return false;
 }
 
+MATCHER_P(CheckTeidVector, expected, "") {
+  const std::vector<Teids> req_teids =
+      static_cast<const std::vector<Teids>>(arg);
+  if (expected.size() != req_teids.size()) {
+    return false;
+  }
+  for (uint32_t i = 0; i < req_teids.size(); i++) {
+    const Teids& expected_teids = expected[i];
+    const Teids& actual_teids   = req_teids[i];
+    if ((expected_teids.agw_teid() != actual_teids.agw_teid()) ||
+        (expected_teids.enb_teid() != actual_teids.enb_teid())) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
 MATCHER_P2(CheckUpdateRequestCount, monitorCount, chargingCount, "") {
   auto req = static_cast<const UpdateSessionRequest>(arg);
   return req.updates().size() == chargingCount &&

--- a/lte/gateway/c/session_manager/test/SessiondMocks.h
+++ b/lte/gateway/c/session_manager/test/SessiondMocks.h
@@ -113,7 +113,7 @@ class MockPipelinedClient : public PipelinedClient {
       deactivate_flows_for_rules_for_termination,
       void(
           const std::string& imsi, const std::string& ip_addr,
-          const std::string& ipv6_addr, const Teids teids,
+          const std::string& ipv6_addr, const std::vector<Teids>& teids,
           const RequestOriginType_OriginType origin_type));
   MOCK_METHOD8(
       activate_flows_for_rules,

--- a/lte/gateway/c/session_manager/test/test_local_enforcer.cpp
+++ b/lte/gateway/c/session_manager/test/test_local_enforcer.cpp
@@ -2707,10 +2707,12 @@ TEST_F(LocalEnforcerTest, test_final_unit_redirect_activation_and_termination) {
       session_map, IMSI1, SESSION_ID_1, credit_key, true);
 
   // the request should has no rules so PipelineD deletes all rules
+  std::vector<Teids> expected_teids_vec{teids};
   EXPECT_CALL(
-      *pipelined_client, deactivate_flows_for_rules_for_termination(
-                             IMSI1, ip_addr, ipv6_addr, CheckTeids(teids),
-                             RequestOriginType::WILDCARD));
+      *pipelined_client,
+      deactivate_flows_for_rules_for_termination(
+          IMSI1, ip_addr, ipv6_addr, CheckTeidVector(expected_teids_vec),
+          RequestOriginType::WILDCARD));
   local_enforcer->handle_termination_from_access(
       session_map, IMSI1, APN1, update);
 }
@@ -2971,12 +2973,14 @@ TEST_F(LocalEnforcerTest, test_dead_session_in_usage_report) {
   Teids expected_teids;
   expected_teids.set_agw_teid(teid);
   expected_teids.set_enb_teid(0);  // we don't care about this one
+  std::vector<Teids> expected_teids_vec{expected_teids};
   // no sessions exist at this point
   // We expect to empty calls for both Gx + Gy
   EXPECT_CALL(
-      *pipelined_client, deactivate_flows_for_rules_for_termination(
-                             IMSI1, IP1, testing::_, CheckTeids(expected_teids),
-                             RequestOriginType::WILDCARD))
+      *pipelined_client,
+      deactivate_flows_for_rules_for_termination(
+          IMSI1, IP1, testing::_, CheckTeidVector(expected_teids_vec),
+          RequestOriginType::WILDCARD))
       .Times(1);
 
   RuleRecordTable table;


### PR DESCRIPTION
<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary
Another Teid related refactor.. The following will only apply to LTE sessions.


Each policy in a session is served by either the default bearer or dedicated bearer. 
```
default   bearer  <default teid pair>    -- serves --> policyA, policyB
dedicated bearer1 <dedicated teid pair1> -- serves --> policyC
dedicated bearer2 <dedicated teid pair2> -- serves --> policyD
```
This means that when we activate policyA, we want to send down the default teid pair. Similarly for PolicyD, we want to send down dedicated teid pair2. 
In order to make sense out of this, I'm modifying the PipelineDClient interface slightly so that we send separate requests for different teid values.

## The big changes
`create_activate_req` -> `make_activate_req_by_teid` : This function will now return a map of Teid -> ActivateFlows. It will go through all the rules passed in and bundle them based on the teids. If RulesToProcess is empty, it will simple create an ActivateFlowsRequest with default teid. (This is consistent with the current behavior.)

`create_deactivate_req` -> `make_deactivate_req_by_teid` : This function will now return a map of Teid -> DeactivateFlows. It will go through all the rules passed in and bundle them based on the teids. If RulesToProcess is empty, it will simple create an DectivateFlowsRequest with default teid. (This is consistent with the current behavior.)

`RuleToProcess` now includes a Teid field. This value currently always contains the default teid. (Again, this is consistent with the current behavior.) Once we start receiving dedicated bearer teids from MME, we can fill it out accordingly. 

`deactivate_flows_for_rules_for_termination` now takes in a vector of teids. (At the moment, we only pass in the default teid, so this is the same as the current behavior.) Once we get teids from MME, we can send DeactivateFlowsRequest for all IMSI+teids that are associated with the session.


## Test Plan
CI
sessiond unit tests
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
Signed-off-by: Marie Bremner <marwhal@fb.com>