### PR TITLE
[ready2merge][orc8r][helm] Promote script for helm charts

### DIFF
--- a/orc8r/tools/helm/promote.sh
+++ b/orc8r/tools/helm/promote.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+
+# Copyright 2020 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# promote.sh copies specified artifacts from one repo to another
+
+set -e -o pipefail
+
+
+promote_artifact () {
+  ARTIFACT="$1"
+  curl -X POST -u "$HELM_CHART_MUSEUM_USERNAME":"$HELM_CHART_MUSEUM_TOKEN" --fail \
+   "$HELM_CHART_MUSEUM_API_URL/copy/$HELM_CHART_MUSEUM_ORIGIN_REPO/$ARTIFACT?to=/$HELM_CHART_MUSEUM_DEST_REPO/$ARTIFACT"
+} 
+
+usage() {
+  echo "Supply at least one artifact to promote: $0 ARTIFACT_PATH"
+  exit 2
+}
+
+exitmsg() {
+  echo "$1"
+  exit 1
+}
+
+# Check if the required args and env-vars present
+[ $# -eq 0 ] && usage
+
+if [[ -z $HELM_CHART_MUSEUM_API_URL ]]; then
+  exitmsg "Environment variable HELM_CHART_MUSEUM_API_URL must be set"
+fi
+
+if [[ -z $HELM_CHART_MUSEUM_ORIGIN_REPO ]]; then
+  exitmsg "Environment variable HELM_CHART_MUSEUM_ORIGIN_REPO must be set"
+fi
+
+if [[ -z $HELM_CHART_MUSEUM_DEST_REPO ]]; then
+  exitmsg "Environment variable HELM_CHART_MUSEUM_DEST_REPO must be set"
+fi
+
+if [[ -z $HELM_CHART_MUSEUM_USERNAME ]]; then
+  exitmsg "Environment variable HELM_CHART_MUSEUM_USERNAME must be set"
+fi
+
+if [[ -z $HELM_CHART_MUSEUM_TOKEN ]]; then
+  exitmsg "Environment variable HELM_CHART_MUSEUM_TOKEN must be set"
+fi
+
+# iterate through artifacts to promote
+for artifact in "$@"
+do
+    promote_artifact "$artifact"
+done
+
+printf '\n'
+echo "Promoted orc8r chart artifacts $* from $HELM_CHART_MUSEUM_ORIGIN_REPO to $HELM_CHART_MUSEUM_DEST_REPO successfully."

--- a/orc8r/tools/helm/promote.sh
+++ b/orc8r/tools/helm/promote.sh
@@ -61,7 +61,9 @@ if [[ -z $HELM_CHART_MUSEUM_TOKEN ]]; then
 fi
 
 # Trim last backslash if exists
+# shellcheck disable=SC2001
 HELM_CHART_ARTIFACTORY_URL="$(echo "$HELM_CHART_ARTIFACTORY_URL" | sed 's:/$::')"
+# shellcheck enable=SC2001
 
 # Verify existence of the helm repo
 set +e +o pipefail

--- a/orc8r/tools/helm/promote.sh
+++ b/orc8r/tools/helm/promote.sh
@@ -19,13 +19,13 @@ promote_artifact () {
   ARTIFACT="$1"
   curl --request POST --user "$HELM_CHART_MUSEUM_USERNAME":"$HELM_CHART_MUSEUM_TOKEN" --fail \
    "$HELM_CHART_MUSEUM_API_URL/copy/$HELM_CHART_MUSEUM_ORIGIN_REPO/$ARTIFACT?to=/$HELM_CHART_MUSEUM_DEST_REPO/$ARTIFACT"
-} 
+}
 
 get_artifact () {
   ARTIFACT="$1"
   curl --output /dev/null --silent  --write-out "%{http_code}" \
    "$HELM_CHART_ARTIFACTORY_URL/$HELM_CHART_MUSEUM_ORIGIN_REPO/$ARTIFACT" || :
-} 
+}
 
 usage() {
   echo "Supply at least one artifact to promote: $0 ARTIFACT_PATH"
@@ -56,7 +56,6 @@ fi
 # Trim last backslash if exists
 # shellcheck disable=SC2001
 HELM_CHART_ARTIFACTORY_URL="$(echo "$HELM_CHART_ARTIFACTORY_URL" | sed 's:/$::')"
-# shellcheck enable=SC2001
 
 # Verify existence of the helm repo
 RESPONSE_CODE_REPO="$(curl --output /dev/null --stderr /dev/null --silent --write-out "%{http_code}"  "$HELM_CHART_ARTIFACTORY_URL/$HELM_CHART_MUSEUM_ORIGIN_REPO/" || :)"

--- a/orc8r/tools/helm/promote.sh
+++ b/orc8r/tools/helm/promote.sh
@@ -61,7 +61,7 @@ HELM_CHART_ARTIFACTORY_URL="$(echo "$HELM_CHART_ARTIFACTORY_URL" | sed 's:/$::')
 # Verify existence of the helm repo
 RESPONSE_CODE_REPO="$(curl --output /dev/null --stderr /dev/null --silent --write-out "%{http_code}"  "$HELM_CHART_ARTIFACTORY_URL/$HELM_CHART_MUSEUM_ORIGIN_REPO/" || :)"
 if [ "$RESPONSE_CODE_REPO" != "200" ]; then
-  exitmsg "There was an error connecting to the artifactory repository $HELM_CHART_MUSEUM_ORIGIN_REPO"
+  exitmsg "There was an error connecting to the artifactory repository $HELM_CHART_MUSEUM_ORIGIN_REPO, the http error code was $RESPONSE_CODE_REPO"
 fi
 
 # Form API URL
@@ -76,7 +76,7 @@ do
     elif [ "$RESPONSE_CODE_ARTIFACT" == "404" ]; then
       exitmsg "The artifact $artifact was not found in repository $HELM_CHART_MUSEUM_ORIGIN_REPO"
     else
-      exitmsg "There was an error retrieving $artifact from repository $HELM_CHART_MUSEUM_ORIGIN_REPO"
+      exitmsg "There was an error retrieving $artifact from repository $HELM_CHART_MUSEUM_ORIGIN_REPO, the http error code was $RESPONSE_CODE_ARTIFACT"
     fi
 done
 

--- a/orc8r/tools/helm/promote.sh
+++ b/orc8r/tools/helm/promote.sh
@@ -15,11 +15,16 @@
 
 set -e -o pipefail
 
-
 promote_artifact () {
   ARTIFACT="$1"
   curl -X POST -u "$HELM_CHART_MUSEUM_USERNAME":"$HELM_CHART_MUSEUM_TOKEN" --fail \
    "$HELM_CHART_MUSEUM_API_URL/copy/$HELM_CHART_MUSEUM_ORIGIN_REPO/$ARTIFACT?to=/$HELM_CHART_MUSEUM_DEST_REPO/$ARTIFACT"
+} 
+
+get_artifact () {
+  ARTIFACT="$1"
+  curl -o /dev/null -s -w "%{http_code}" \
+   "$HELM_CHART_ARTIFACTORY_URL/$HELM_CHART_MUSEUM_ORIGIN_REPO/$ARTIFACT"
 } 
 
 usage() {
@@ -35,16 +40,16 @@ exitmsg() {
 # Check if the required args and env-vars present
 [ $# -eq 0 ] && usage
 
-if [[ -z $HELM_CHART_MUSEUM_API_URL ]]; then
-  exitmsg "Environment variable HELM_CHART_MUSEUM_API_URL must be set"
+if [[ -z $HELM_CHART_ARTIFACTORY_URL ]]; then
+  HELM_CHART_ARTIFACTORY_URL="https://artifactory.magmacore.org:443/artifactory"
 fi
 
 if [[ -z $HELM_CHART_MUSEUM_ORIGIN_REPO ]]; then
-  exitmsg "Environment variable HELM_CHART_MUSEUM_ORIGIN_REPO must be set"
+  HELM_CHART_MUSEUM_ORIGIN_REPO="helm-test"
 fi
 
 if [[ -z $HELM_CHART_MUSEUM_DEST_REPO ]]; then
-  exitmsg "Environment variable HELM_CHART_MUSEUM_DEST_REPO must be set"
+  HELM_CHART_MUSEUM_DEST_REPO="helm-prod"
 fi
 
 if [[ -z $HELM_CHART_MUSEUM_USERNAME ]]; then
@@ -55,10 +60,33 @@ if [[ -z $HELM_CHART_MUSEUM_TOKEN ]]; then
   exitmsg "Environment variable HELM_CHART_MUSEUM_TOKEN must be set"
 fi
 
+# Trim last backslash if exists
+HELM_CHART_ARTIFACTORY_URL="$(echo "$HELM_CHART_ARTIFACTORY_URL" | sed 's:/$::')"
+
+# Verify existence of the helm repo
+set +e +o pipefail
+RESPONSE_CODE_REPO="$(curl -o /dev/null -s -w "%{http_code}"  "$HELM_CHART_ARTIFACTORY_URL/$HELM_CHART_MUSEUM_ORIGIN_REPO/")"
+if [ "$RESPONSE_CODE_REPO" != "200" ]; then
+  exitmsg "There was an error connecting to the artifactory repository $HELM_CHART_MUSEUM_ORIGIN_REPO"
+fi
+set -e -o pipefail
+
+# Form API URL
+HELM_CHART_MUSEUM_API_URL="$HELM_CHART_ARTIFACTORY_URL/api"
+
 # iterate through artifacts to promote
 for artifact in "$@"
 do
-    promote_artifact "$artifact"
+    set +e +o pipefail
+    RESPONSE_CODE_ARTIFACT="$(get_artifact "$artifact")"
+    set -e -o pipefail
+    if [ "$RESPONSE_CODE_ARTIFACT" == "200" ]; then
+      promote_artifact "$artifact"
+    elif [ "$RESPONSE_CODE_ARTIFACT" == "404" ]; then
+      exitmsg "The artifact $artifact was not found in repository $HELM_CHART_MUSEUM_ORIGIN_REPO"
+    else
+      exitmsg "There was an error retrieving $artifact from repository $HELM_CHART_MUSEUM_ORIGIN_REPO"
+    fi
 done
 
 printf '\n'


### PR DESCRIPTION
## Summary

Script is copying specified artifacts from one repo to another
Aimed to be used to promote helm charts artifacts after tests passed

## Test Plan

Tested to promote helm-test artifacts to helm-prod successfully.
(Did not kept artifacts in helm-prod as not entirely tested)

## Additional Information

Needed Environment variables:
HELM_CHART_ARTIFACT_URL: https://artifactory.magmacore.org:443/artifactory/
HELM_CHART_MUSEUM_ORIGIN_REPO: helm-test
HELM_CHART_MUSEUM_DEST_REPO: helm-prod
HELM_CHART_MUSEUM_USERNAME
HELM_CHART_MUSEUM_TOKEN

Usage : $MAGMA_ROOT/orc8r/tools/helm/promote.sh orc8r-1.5.tgz fbinternal_orc8r-0.2.1.tgz