### PR TITLE
[lte][agw] Propagate TEID for dedicated bearers back to sessiond

### DIFF
--- a/lte/gateway/c/oai/lib/pcef/pcef_handlers.cpp
+++ b/lte/gateway/c/oai/lib/pcef/pcef_handlers.cpp
@@ -173,9 +173,9 @@ bool pcef_end_session(char* imsi, char* apn) {
 }
 
 void pcef_send_policy2bearer_binding(
-    const char* imsi, uint8_t default_bearer_id, char* policy_rule_name,
-    uint8_t eps_bearer_id, uint32_t eps_bearer_agw_teid,
-    uint32_t eps_bearer_enb_teid) {
+    const char* imsi, const uint8_t default_bearer_id,
+    const char* policy_rule_name, const uint8_t eps_bearer_id,
+    const uint32_t eps_bearer_agw_teid, const uint32_t eps_bearer_enb_teid) {
   magma::PolicyBearerBindingRequest request;
   request.mutable_sid()->set_id("IMSI" + std::string(imsi));
   request.set_linked_bearer_id(default_bearer_id);

--- a/lte/gateway/c/oai/lib/pcef/pcef_handlers.cpp
+++ b/lte/gateway/c/oai/lib/pcef/pcef_handlers.cpp
@@ -174,12 +174,15 @@ bool pcef_end_session(char* imsi, char* apn) {
 
 void pcef_send_policy2bearer_binding(
     const char* imsi, uint8_t default_bearer_id, char* policy_rule_name,
-    uint8_t eps_bearer_id) {
+    uint8_t eps_bearer_id, uint32_t eps_bearer_agw_teid,
+    uint32_t eps_bearer_enb_teid) {
   magma::PolicyBearerBindingRequest request;
   request.mutable_sid()->set_id("IMSI" + std::string(imsi));
   request.set_linked_bearer_id(default_bearer_id);
   request.set_policy_rule_id(policy_rule_name);
   request.set_bearer_id(eps_bearer_id);
+  request.mutable_teids()->set_enb_teid(eps_bearer_enb_teid);
+  request.mutable_teids()->set_agw_teid(eps_bearer_agw_teid);
   magma::PCEFClient::bind_policy2bearer(
       request,
       [&](grpc::Status status, magma::PolicyBearerBindingResponse response) {

--- a/lte/gateway/c/oai/lib/pcef/pcef_handlers.h
+++ b/lte/gateway/c/oai/lib/pcef/pcef_handlers.h
@@ -75,9 +75,9 @@ bool pcef_end_session(char* imsi, char* apn);
  * uniquely identified by imsi and default bearer id.
  */
 void pcef_send_policy2bearer_binding(
-    const char* imsi, uint8_t default_bearer_id, char* policy_rule_name,
-    uint8_t eps_bearer_id, uint32_t eps_bearer_agw_teid,
-    uint32_t eps_bearer_enb_teid);
+    const char* imsi, const uint8_t default_bearer_id,
+    const char* policy_rule_name, const uint8_t eps_bearer_id,
+    const uint32_t eps_bearer_agw_teid, const uint32_t eps_bearer_enb_teid);
 
 void get_session_req_data(
     spgw_state_t* spgw_state,

--- a/lte/gateway/c/oai/lib/pcef/pcef_handlers.h
+++ b/lte/gateway/c/oai/lib/pcef/pcef_handlers.h
@@ -76,7 +76,8 @@ bool pcef_end_session(char* imsi, char* apn);
  */
 void pcef_send_policy2bearer_binding(
     const char* imsi, uint8_t default_bearer_id, char* policy_rule_name,
-    uint8_t eps_bearer_id);
+    uint8_t eps_bearer_id, uint32_t eps_bearer_agw_teid,
+    uint32_t eps_bearer_enb_teid);
 
 void get_session_req_data(
     spgw_state_t* spgw_state,

--- a/lte/gateway/c/oai/tasks/sgw/pgw_handlers.c
+++ b/lte/gateway/c/oai/tasks/sgw/pgw_handlers.c
@@ -477,7 +477,8 @@ static int32_t spgw_build_and_send_s11_deactivate_bearer_req(
 
 //------------------------------------------------------------------------------
 int spgw_send_nw_init_activate_bearer_rsp(
-    gtpv2c_cause_value_t cause, imsi64_t imsi64, uint8_t eps_bearer_id,
+    gtpv2c_cause_value_t cause, imsi64_t imsi64,
+    bearer_context_within_create_bearer_response_t* bearer_ctx,
     uint8_t default_bearer_id, char* policy_rule_name) {
   OAILOG_FUNC_IN(LOG_SPGW_APP);
   uint32_t rc = RETURNok;
@@ -486,19 +487,21 @@ int spgw_send_nw_init_activate_bearer_rsp(
       LOG_SPGW_APP, imsi64,
       "Sending Create Bearer Rsp to PCRF with EBI %d with "
       "cause: %d linked bearer id: %d policy rule name: %s\n",
-      eps_bearer_id, cause, default_bearer_id, policy_rule_name);
+      bearer_ctx->eps_bearer_id, cause, default_bearer_id, policy_rule_name);
   // Send Dedicated Bearer ID and Policy Rule ID binding to PCRF
   char imsi_str[IMSI_BCD_DIGITS_MAX + 1];
   IMSI64_TO_STRING(imsi64, (char*) imsi_str, IMSI_BCD_DIGITS_MAX);
   if (cause == REQUEST_ACCEPTED) {
     pcef_send_policy2bearer_binding(
-        imsi_str, default_bearer_id, policy_rule_name, eps_bearer_id);
+        imsi_str, default_bearer_id, policy_rule_name,
+        bearer_ctx->eps_bearer_id, bearer_ctx->s1u_sgw_fteid.teid,
+        bearer_ctx->s1u_enb_fteid.teid);
   } else {
     // Send 0 as dedicated bearer id if the create bearer request
     // was not accepted. Session manager should delete the policy rule
-    // for this bearer.
+    // for this bearer. Set the tunnel IDs to zero as well.
     pcef_send_policy2bearer_binding(
-        imsi_str, default_bearer_id, policy_rule_name, 0);
+        imsi_str, default_bearer_id, policy_rule_name, 0, 0, 0);
   }
 
   OAILOG_FUNC_RETURN(LOG_SPGW_APP, rc);

--- a/lte/gateway/c/oai/tasks/sgw/pgw_handlers.h
+++ b/lte/gateway/c/oai/tasks/sgw/pgw_handlers.h
@@ -50,6 +50,7 @@ int32_t spgw_handle_nw_initiated_bearer_deactv_req(
     imsi64_t imsi64);
 
 int spgw_send_nw_init_activate_bearer_rsp(
-    gtpv2c_cause_value_t cause, imsi64_t imsi64, uint8_t eps_bearer_id,
+    gtpv2c_cause_value_t cause, imsi64_t imsi64,
+    bearer_context_within_create_bearer_response_t* bearer_ctx,
     uint8_t default_bearer_id, char* policy_rule_name);
 #endif /* FILE_PGW_HANDLERS_SEEN */

--- a/lte/gateway/c/session_manager/LocalSessionManagerHandler.cpp
+++ b/lte/gateway/c/session_manager/LocalSessionManagerHandler.cpp
@@ -559,7 +559,9 @@ void LocalSessionManagerHandlerImpl::BindPolicy2Bearer(
              << request->sid().id()
              << " with default bearerID: " << request->linked_bearer_id()
              << " policyID: " << request->policy_rule_id()
-             << " created dedicated bearerID: " << request->bearer_id();
+             << " created dedicated bearerID: " << request->bearer_id()
+             << " agw TEID: " << request->teids().agw_teid()
+             << " eNB TEID: " << request->teids().enb_teid();
   enforcer_->get_event_base().runInEventBaseThread([this, request_cpy]() {
     auto session_map = session_store_.read_sessions({request_cpy.sid().id()});
     SessionUpdate update =


### PR DESCRIPTION
Signed-off-by: Ulas Kozat <kozat@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->

PR propagates TEID information for the created dedicated bearer back to sessiond as a result of the sessiond triggered dedicated bearer creation. 

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->
Run the s1ap test scenario `test_attach_detach_setsessionrules_tcp_data.py ` and check the log messages on the sessiond side to confirm that TEID pairs are received correctly.
```
May 05 21:38:42 magma-dev sessiond[10182]: I0505 21:38:42.332942 10182 LocalSessionManagerHandler.cpp:664] Received a LocalCreateSessionRequest for IMSI001010000000001 with APN:internet, default bearer ID:5, PLMN ID:00101, IMSI PLMN ID:00101, User location: 82 00 f1 10 00 01 00 f1 10 00 00 0a 0a
May 05 21:38:42 magma-dev sessiond[10182]: I0505 21:38:42.333343 10182 LocalSessionManagerHandler.cpp:295] Sending a CreateSessionRequest to fetch policies for IMSI001010000000001-798233
May 05 21:38:42 magma-dev sessiond[10182]: I0505 21:38:42.336704 10182 LocalSessionManagerHandler.cpp:305] Processing a CreateSessionResponse for IMSI001010000000001-798233
May 05 21:38:42 magma-dev sessiond[10182]: I0505 21:38:42.338032 10182 LocalSessionManagerHandler.cpp:312] Successfully initialized new session IMSI001010000000001-798233 in SessionD for subscriber IMSI001010000000001
May 05 21:38:42 magma-dev sessiond[10182]: I0505 21:38:42.384953 10182 LocalEnforcer.cpp:588] Activating untracked rule allowlist_sid-IMSI001010000000001-internet
May 05 21:38:42 magma-dev sessiond[10182]: I0505 21:38:42.385859 10182 LocalEnforcer.cpp:1974] Failed mac/name parsiong for apn internet
May 05 21:38:42 magma-dev sessiond[10182]: I0505 21:38:42.392134 10270 SessionEvents.cpp:112] Could not log session_created event {"mac_addr":"","session_id":"IMSI001010000000001-798233","pdp_start_time":1620250722,"ip_addr":"192.168.128.12","msisdn":"","user_location":" 82 00 f1 10 00 01 00 f1 10 00 00 0a 0a","ipv6_addr":"","imsi":"IMSI001010000000001","charging_characteristics":"","imei":"\u0004\b\u0006\u0004\u0005\u0000\b\u0003\u0001\u0003\u0001\u0001\u0002\u0003\u0001\u0007","apn":"internet","spgw_ip":"192.168.60.142"}, Error Message: Could not connect to FluentBit locally, Details: [Errno 111] Connection refused
May 05 21:38:47 magma-dev sessiond[10182]: I0505 21:38:47.369570 10182 SessionState.cpp:569] Installing dynamic rule allow_list_IMSI001010000000001 for IMSI001010000000001-798233
May 05 21:38:47 magma-dev sessiond[10182]: I0505 21:38:47.369683 10182 SessionState.cpp:569] Installing dynamic rule tcp_udp_1 for IMSI001010000000001-798233
May 05 21:38:47 magma-dev sessiond[10182]: I0505 21:38:47.369856 10182 SessionState.cpp:579] Removing dynamic rule allowlist_sid-IMSI001010000000001-internet for IMSI001010000000001-798233
May 05 21:38:47 magma-dev sessiond[10182]: I0505 21:38:47.370476 10182 SpgwServiceClient.cpp:121] Creating dedicated bearers for IMSI001010000000001, 192.168.128.12, rules={ tcp_udp_1 }
May 05 21:38:47 magma-dev sessiond[10182]: I0505 21:38:47.384050 10463 LocalSessionManagerHandler.cpp:558] Received a BindPolicy2Bearer request for IMSI001010000000001 with default bearerID: 5 policyID: tcp_udp_1 created dedicated bearerID: 6 agw TEID: 2 eNB TEID: 167772464
May 05 21:38:47 magma-dev sessiond[10182]: I0505 21:38:47.385355 10182 SessionState.cpp:2002] IMSI001010000000001-798233 now has policy tcp_udp_1 tied to bearerID 6
May 05 21:38:52 magma-dev sessiond[10182]: I0505 21:38:52.385942 10182 SessionState.cpp:569] Installing dynamic rule tcp_udp_2 for IMSI001010000000001-798233
May 05 21:38:52 magma-dev sessiond[10182]: I0505 21:38:52.386080 10182 SessionState.cpp:579] Removing dynamic rule tcp_udp_1 for IMSI001010000000001-798233
May 05 21:38:52 magma-dev sessiond[10182]: I0505 21:38:52.386595 10182 SpgwServiceClient.cpp:100] Deleting dedicated bearers for IMSI001010000000001, 192.168.128.12, default bearer id=5, dedicated bearer ids={ 6 }
May 05 21:38:52 magma-dev sessiond[10182]: I0505 21:38:52.386725 10182 SpgwServiceClient.cpp:121] Creating dedicated bearers for IMSI001010000000001, 192.168.128.12, rules={ tcp_udp_2 }
May 05 21:38:52 magma-dev sessiond[10182]: I0505 21:38:52.404541 10463 LocalSessionManagerHandler.cpp:558] Received a BindPolicy2Bearer request for IMSI001010000000001 with default bearerID: 5 policyID: tcp_udp_2 created dedicated bearerID: 7 agw TEID: 3 eNB TEID: 167772472
May 05 21:38:52 magma-dev sessiond[10182]: I0505 21:38:52.406630 10182 SessionState.cpp:2002] IMSI001010000000001-798233 now has policy tcp_udp_2 tied to bearerID 7
May 05 21:38:55 magma-dev sessiond[10182]: I0505 21:38:55.466533 10182 LocalEnforcer.cpp:255] IMSI001010000000001-798233 used 2662 tx bytes and 0 rx bytes for rule tcp_udp_2
May 05 21:38:55 magma-dev sessiond[10182]: I0505 21:38:55.466704 10182 LocalEnforcer.cpp:255] IMSI001010000000001-798233 used 0 tx bytes and 592 rx bytes for rule allow_list_IMSI001010000000001
May 05 21:38:57 magma-dev sessiond[10182]: I0505 21:38:57.466287 10182 LocalEnforcer.cpp:255] IMSI001010000000001-798233 used 5652 tx bytes and 0 rx bytes for rule tcp_udp_2
May 05 21:38:57 magma-dev sessiond[10182]: I0505 21:38:57.466447 10182 LocalEnforcer.cpp:255] IMSI001010000000001-798233 used 0 tx bytes and 660 rx bytes for rule allow_list_IMSI001010000000001
May 05 21:38:59 magma-dev sessiond[10182]: I0505 21:38:59.466914 10182 LocalEnforcer.cpp:255] IMSI001010000000001-798233 used 5024 tx bytes and 0 rx bytes for rule tcp_udp_2
May 05 21:38:59 magma-dev sessiond[10182]: I0505 21:38:59.467061 10182 LocalEnforcer.cpp:255] IMSI001010000000001-798233 used 0 tx bytes and 832 rx bytes for rule allow_list_IMSI001010000000001
```

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
