### PR TITLE
devex: Fix PR bot line-break

### DIFF
--- a/.github/workflows/pr_bot.yml
+++ b/.github/workflows/pr_bot.yml
@@ -21,7 +21,7 @@ jobs:
 
             - ***Reviews.*** The "Reviewers" listed for this PR are the Magma maintainers who will shepherd it.
             - ***Checks.*** All required CI checks must pass before merge.
-            - ***Merge.*** Once approved and passing all CI checks, use the [\`ready2merge\`](https://github.com/magma/magma/labels/ready2merge) label to indicate the maintainers can merge your PR.
+            - ***Merge.*** Once approved and passing CI checks, use the [\`ready2merge\`](https://github.com/magma/magma/labels/ready2merge) label to indicate the maintainers can merge your PR.
 
             ### More info
 


### PR DESCRIPTION
<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->

The extraneous line is annoying

<img width="900" alt="Screen Shot 2021-05-05 at 8 51 06 PM" src="https://user-images.githubusercontent.com/8029544/117239456-669b2080-adf4-11eb-8dac-631b2398458c.png">


## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->