### PR TITLE
[lte][agw] Updating deletion of s1ap imsi map entry when UE context is deleted

### DIFF
--- a/lte/gateway/c/oai/lib/hashtable/hashtable.h
+++ b/lte/gateway/c/oai/lib/hashtable/hashtable.h
@@ -235,8 +235,6 @@ hashtable_rc_t hashtable_uint64_ts_dump_content(
 hashtable_rc_t hashtable_uint64_ts_insert(
     hash_table_uint64_ts_t* const hashtbl, const hash_key_t key,
     const uint64_t dataP);
-hashtable_rc_t hashtable_uint64_ts_free(
-    hash_table_uint64_ts_t* const hashtbl, const hash_key_t key);
 hashtable_rc_t hashtable_uint64_ts_remove(
     hash_table_uint64_ts_t* const hashtbl, const hash_key_t key);
 hashtable_rc_t hashtable_uint64_ts_get(

--- a/lte/gateway/c/oai/tasks/s1ap/s1ap_mme.c
+++ b/lte/gateway/c/oai/tasks/s1ap/s1ap_mme.c
@@ -71,9 +71,6 @@
 #define UE_LIST_OUT(x, args...)
 #endif
 
-bool s1ap_dump_enb_hash_cb(
-    const hash_key_t keyP, void* const enb_void, void* unused_param,
-    void** unused_res);
 bool s1ap_dump_ue_hash_cb(
     const hash_key_t keyP, void* const ue_void, void* parameter,
     void** unused_res);
@@ -395,25 +392,6 @@ void s1ap_mme_exit(void) {
 }
 
 //------------------------------------------------------------------------------
-void s1ap_dump_enb_list(s1ap_state_t* state) {
-  hashtable_ts_apply_callback_on_elements(
-      &state->enbs, s1ap_dump_enb_hash_cb, NULL, NULL);
-}
-
-//------------------------------------------------------------------------------
-bool s1ap_dump_enb_hash_cb(
-    __attribute__((unused)) const hash_key_t keyP, void* const eNB_void,
-    void __attribute__((unused)) * unused_parameterP,
-    void __attribute__((unused)) * *unused_resultP) {
-  const enb_description_t* const enb_ref = (const enb_description_t*) eNB_void;
-  if (enb_ref == NULL) {
-    return false;
-  }
-  s1ap_dump_enb(enb_ref);
-  return false;
-}
-
-//------------------------------------------------------------------------------
 void s1ap_dump_enb(const enb_description_t* const enb_ref) {
 #ifdef S1AP_DEBUG_LIST
   // Reset indentation
@@ -569,7 +547,7 @@ void s1ap_remove_ue(s1ap_state_t* state, ue_description_t* ue_ref) {
   hash_table_ts_t* state_ue_ht = get_s1ap_ue_state();
   hashtable_ts_free(state_ue_ht, ue_ref->comp_s1ap_id);
   hashtable_ts_free(&state->mmeid2associd, mme_ue_s1ap_id);
-  hashtable_uint64_ts_free(&enb_ref->ue_id_coll, mme_ue_s1ap_id);
+  hashtable_uint64_ts_remove(&enb_ref->ue_id_coll, mme_ue_s1ap_id);
 
   imsi64_t imsi64                = INVALID_IMSI64;
   s1ap_imsi_map_t* s1ap_imsi_map = get_s1ap_imsi_map();
@@ -577,6 +555,8 @@ void s1ap_remove_ue(s1ap_state_t* state, ue_description_t* ue_ref) {
       s1ap_imsi_map->mme_ue_id_imsi_htbl, (const hash_key_t) mme_ue_s1ap_id,
       &imsi64);
   delete_s1ap_ue_state(imsi64);
+  hashtable_uint64_ts_remove(
+      s1ap_imsi_map->mme_ue_id_imsi_htbl, mme_ue_s1ap_id);
 
   OAILOG_DEBUG(
       LOG_S1AP, "Num UEs associated %u num ue_id_coll %zu",

--- a/lte/gateway/c/oai/tasks/s1ap/s1ap_mme.h
+++ b/lte/gateway/c/oai/tasks/s1ap/s1ap_mme.h
@@ -43,11 +43,6 @@ int s1ap_mme_init(const mme_config_t* mme_config);
  **/
 void s1ap_mme_exit(void);
 
-/** \brief Dump the eNB list
- * Calls dump_enb for each eNB in list
- **/
-void s1ap_dump_enb_list(s1ap_state_t* state);
-
 /** \brief Dump eNB related information.
  * Calls dump_ue for each UE in list
  * \param enb_ref eNB structure reference to dump

--- a/lte/gateway/c/oai/tasks/s1ap/s1ap_mme_handlers.c
+++ b/lte/gateway/c/oai/tasks/s1ap/s1ap_mme_handlers.c
@@ -3796,10 +3796,6 @@ void s1ap_mme_handle_ue_context_rel_comp_timer_expiry(
       (uint32_t) ue_ref_p->mme_ue_s1ap_id);
   s1ap_remove_ue(state, ue_ref_p);
 
-  hashtable_uint64_ts_remove(
-      imsi_map->mme_ue_id_imsi_htbl,
-      (const hash_key_t) ue_ref_p->mme_ue_s1ap_id);
-
   OAILOG_FUNC_OUT(LOG_S1AP);
 }
 

--- a/lte/gateway/c/oai/tasks/s1ap/s1ap_mme_nas_procedures.c
+++ b/lte/gateway/c/oai/tasks/s1ap/s1ap_mme_nas_procedures.c
@@ -245,11 +245,18 @@ int s1ap_mme_handle_initial_ue_message(
     );
 
   } else {
-    OAILOG_ERROR(
-        LOG_S1AP,
+    imsi64_t imsi64                = INVALID_IMSI64;
+    s1ap_imsi_map_t* s1ap_imsi_map = get_s1ap_imsi_map();
+    hashtable_uint64_ts_get(
+        s1ap_imsi_map->mme_ue_id_imsi_htbl,
+        (const hash_key_t) ue_ref->mme_ue_s1ap_id, &imsi64);
+
+    OAILOG_ERROR_UE(
+        LOG_S1AP, imsi64,
         "Initial UE Message- Duplicate ENB_UE_S1AP_ID. Ignoring the "
-        "message, eNB UE S1AP ID:" ENB_UE_S1AP_ID_FMT "\n",
-        enb_ue_s1ap_id);
+        "message, eNB UE S1AP ID:" ENB_UE_S1AP_ID_FMT
+        "\n, mme UE s1ap ID: " MME_UE_S1AP_ID_FMT "UE state %u",
+        enb_ue_s1ap_id, ue_ref->mme_ue_s1ap_id, ue_ref->s1_ue_state);
   }
 
   OAILOG_FUNC_RETURN(LOG_S1AP, RETURNok);

--- a/lte/gateway/c/oai/tasks/s1ap/s1ap_state.cpp
+++ b/lte/gateway/c/oai/tasks/s1ap/s1ap_state.cpp
@@ -188,6 +188,7 @@ void remove_ues_without_imsi_from_ue_id_coll() {
 
   hashtable_rc_t ht_rc;
   hash_key_t* mme_ue_id_no_imsi_list;
+  s1ap_imsi_map_t* s1ap_imsi_map = get_s1ap_imsi_map();
   uint32_t num_ues_checked;
 
   // get each eNB in s1ap_state
@@ -215,8 +216,10 @@ void remove_ues_without_imsi_from_ue_id_coll() {
 
     // remove all the mme_ue_s1ap_ids
     for (uint32_t i = 0; i < num_ues_checked; i++) {
-      hashtable_uint64_ts_free(
+      hashtable_uint64_ts_remove(
           &enb_association_p->ue_id_coll, mme_ue_id_no_imsi_list[i]);
+      hashtable_uint64_ts_remove(
+          s1ap_imsi_map->mme_ue_id_imsi_htbl, mme_ue_id_no_imsi_list[i]);
       enb_association_p->nb_ue_associated--;
 
       OAILOG_DEBUG(

--- a/lte/gateway/python/integ_tests/s1aptests/s1ap_utils.py
+++ b/lte/gateway/python/integ_tests/s1aptests/s1ap_utils.py
@@ -1090,11 +1090,17 @@ class MagmadUtil(object):
                 keys_to_be_cleaned.append(state)
             elif "htbl" in state:
                 num_htbl_entries += 1
+
+        s1ap_imsi_map_cmd = "state_cli.py parse s1ap_imsi_map"
+        s1ap_imsi_map_state = self.exec_command_output(magtivate_cmd + " && " + s1ap_imsi_map_cmd)
+        # Remove state version output to get only hashmap entries
+        s1ap_imsi_map_entries = len(s1ap_imsi_map_state.split("\n")[0])
         print(
             "Keys left in Redis (list should be empty)[\n",
             "\n".join(keys_to_be_cleaned),
             "\n]",
         )
+        print("Entries in s1ap_imsi_map (should be zero):", s1ap_imsi_map_entries)
         print("Entries left in hashtables (should be zero):", num_htbl_entries)
 
 

--- a/lte/gateway/python/scripts/state_cli.py
+++ b/lte/gateway/python/scripts/state_cli.py
@@ -151,7 +151,7 @@ class StateCLI(object):
             # Try parsing as json first, if there's decoding error, parse proto
             try:
                 self._parse_state_json(value)
-            except (UnicodeDecodeError, JSONDecodeError):
+            except (UnicodeDecodeError, JSONDecodeError, AttributeError):
                 self._parse_state_proto(key_type, value)
 
     def corrupt(self, key):

--- a/lte/gateway/python/scripts/state_cli.py
+++ b/lte/gateway/python/scripts/state_cli.py
@@ -22,7 +22,7 @@ import fire
 import jsonpickle
 from lte.protos.keyval_pb2 import IPDesc
 from lte.protos.oai.mme_nas_state_pb2 import MmeNasState, UeContext
-from lte.protos.oai.s1ap_state_pb2 import S1apState, UeDescription
+from lte.protos.oai.s1ap_state_pb2 import S1apState, UeDescription, S1apImsiMap
 from lte.protos.oai.spgw_state_pb2 import SpgwState, SpgwUeContext
 from lte.protos.policydb_pb2 import InstalledPolicies, PolicyRule
 from magma.common.redis.client import get_default_client
@@ -99,6 +99,7 @@ class StateCLI(object):
         'mme_nas_state': MmeNasState,
         'spgw_state': SpgwState,
         's1ap_state': S1apState,
+        's1ap_imsi_map': S1apImsiMap,
         'mme': UeContext,
         'spgw': SpgwUeContext,
         's1ap': UeDescription,


### PR DESCRIPTION
Signed-off-by: Alex Rodriguez <ardzoht@gmail.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->
- `s1ap_imsi_map` entries were not always being deleted when UE context was removed, previously they were only deleted on `s1ap_mme_handle_ue_context_rel_comp_timer_expiry` function handler, this PR updates the removal of the entry when the S1AP UE context is deleted as well.
- Removing dead code on s1ap_state 
- Updating `state_cli` to parse `s1ap_imsi_map`

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->
- Running scale tests on spirent to ensure s1ap_imsi_map is not leaving stale entries (300 UEs with 5 UE/sec attach rate, stable for 12 hours)

![image](https://user-images.githubusercontent.com/6800940/117333433-c70a7c00-ae4d-11eb-8033-30cd340272c1.png)

- `state_cli.py parse s1ap_imsi_map` entries (master) => 3376
- `state_cli.py parse s1ap_imsi_map` entries (PR) => 300

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
