### PR TITLE
[fuji] Fix ID of versioned fuji upgrade guide

### DIFF
--- a/docs/docusaurus/versioned_docs/version-1.5.0/orc8r/upgrade_1_5.md
+++ b/docs/docusaurus/versioned_docs/version-1.5.0/orc8r/upgrade_1_5.md
@@ -1,5 +1,5 @@
 ---
-id: upgrade_1_5
+id: version-1.5.0-upgrade_1_5
 title: Upgrade to v1.5
 hide_title: true
 original_id: upgrade_1_5


### PR DESCRIPTION
Signed-off-by: Andrei Lee <andreilee@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary

Adding the prefix `version-1.5.0-` to the id field of `upgrade_1_5.md`, which was expected for versioned docs.

<!-- Enumerate changes you made and why you made them -->

## Test Plan

Logs from starting docusaurus container before this fix:
```
docusaurus_1  | The 'id' field in /app/website/versioned_docs/version-1.5.0/orc8r/upgrade_1_5.md is missing the expected 'version-XX-' prefix. Perhaps you forgot to add it when importing prior versions of your docs?
docusaurus_1  | /app/website/node_modules/docusaurus/lib/server/versionFallback.js:75
docusaurus_1  |     throw new Error("The 'id' field in ".concat(file, " is missing the expected 'version-XX-' prefix. Perhaps you forgot to add it when importing prior versions of your docs?"));
docusaurus_1  |     ^
docusaurus_1  |
docusaurus_1  | Error: The 'id' field in /app/website/versioned_docs/version-1.5.0/orc8r/upgrade_1_5.md is missing the expected 'version-XX-' prefix. Perhaps you forgot to add it when importing prior versions of your docs?
docusaurus_1  |     at forEach (/app/website/node_modules/docusaurus/lib/server/versionFallback.js:75:11)
docusaurus_1  |     at Array.forEach (<anonymous>)
docusaurus_1  |     at Object.<anonymous> (/app/website/node_modules/docusaurus/lib/server/versionFallback.js:52:7)
docusaurus_1  |     at Module._compile (internal/modules/cjs/loader.js:1063:30)
docusaurus_1  |     at Module._compile (/app/website/node_modules/pirates/lib/index.js:99:24)
docusaurus_1  |     at Module._extensions..js (internal/modules/cjs/loader.js:1092:10)
docusaurus_1  |     at Object.newLoader [as .js] (/app/website/node_modules/pirates/lib/index.js:104:7)
docusaurus_1  |     at Module.load (internal/modules/cjs/loader.js:928:32)
docusaurus_1  |     at Function.Module._load (internal/modules/cjs/loader.js:769:14)
docusaurus_1  |     at Module.require (internal/modules/cjs/loader.js:952:19)
docusaurus_1  | error Command failed with exit code 1.
```

Logs after the fix:
```
➜  docusaurus git:(1-5-fuji-upgrade-guide2) docker-compose logs -f docusaurus
Attaching to docusaurus_docusaurus_1
docusaurus_1  | yarn install v1.22.5
docusaurus_1  | warning package.json: No license field
docusaurus_1  | warning No license field
docusaurus_1  | [1/4] Resolving packages...
docusaurus_1  | success Already up-to-date.
docusaurus_1  | Done in 0.63s.
docusaurus_1  | yarn run v1.22.5
docusaurus_1  | warning package.json: No license field
docusaurus_1  | $ docusaurus-start
docusaurus_1  | Browserslist: caniuse-lite is outdated. Please run:
docusaurus_1  | npx browserslist@latest --update-db
docusaurus_1  |
docusaurus_1  | Why you should do it regularly:
docusaurus_1  | https://github.com/browserslist/browserslist#browsers-data-updating
docusaurus_1  | LiveReload server started on port 35729
docusaurus_1  | Docusaurus server started on port 3000
```

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
