### PR TITLE
refactor: Clean up process_rules_to_install to prepare for separating

### DIFF
--- a/lte/gateway/c/session_manager/LocalEnforcer.cpp
+++ b/lte/gateway/c/session_manager/LocalEnforcer.cpp
@@ -836,11 +836,10 @@ void LocalEnforcer::filter_rule_installs(
 }
 
 void LocalEnforcer::handle_session_activate_rule_updates(
-    const std::string& imsi, SessionState& session_state,
+    const std::string& imsi, SessionState& session,
     const CreateSessionResponse& response,
     std::unordered_set<uint32_t>& charging_credits_received) {
-  RulesToProcess rules_to_activate;
-  RulesToProcess rules_to_deactivate;
+  RulesToProcess to_activate, to_deactivate;
   std::vector<StaticRuleInstall> static_rule_installs =
       to_vec(response.static_rules());
   std::vector<DynamicRuleInstall> dynamic_rule_installs =
@@ -850,24 +849,23 @@ void LocalEnforcer::handle_session_activate_rule_updates(
 
   SessionStateUpdateCriteria uc;  // TODO remove unused UC
   process_rules_to_install(
-      session_state, imsi, static_rule_installs, dynamic_rule_installs,
-      rules_to_activate, rules_to_deactivate, uc);
+      session, imsi, static_rule_installs, dynamic_rule_installs, &to_activate,
+      &to_deactivate, &uc);
 
   // activate_flows_for_rules() should be called even if there is no rule
   // to activate, because pipelined activates a "drop all packet" rule
   // when no rule is provided as the parameter.
-  const auto& config = session_state.get_config();
-  propagate_rule_updates_to_pipelined(
-      imsi, config, rules_to_activate, rules_to_deactivate, true);
+  const SessionConfig& config = session.get_config();
+  propagate_rule_updates_to_pipelined(config, to_activate, to_deactivate, true);
 
   if (config.common_context.rat_type() == TGPP_LTE) {
-    auto bearer_updates = session_state.get_dedicated_bearer_updates(
-        rules_to_activate, rules_to_deactivate, uc);
+    BearerUpdate bearer_updates =
+        session.get_dedicated_bearer_updates(to_activate, to_deactivate, &uc);
     if (bearer_updates.needs_creation) {
       // If a bearer creation is needed, we need to delay this by a few seconds
       // so that the attach fully completes before.
       schedule_session_init_dedicated_bearer_creations(
-          imsi, session_state.get_session_id(), bearer_updates);
+          imsi, session.get_session_id(), bearer_updates);
     }
   }
 }
@@ -914,8 +912,7 @@ void LocalEnforcer::schedule_session_init_dedicated_bearer_creations(
             it = rules->erase(it);
             continue;
           }
-          if (!session->policy_needs_bearer_creation(
-                  *policy_type, it->id(), session->get_config())) {
+          if (!session->policy_needs_bearer_creation(*policy_type, it->id())) {
             MLOG(MWARNING) << "Ignoring dedicated bearer create request from "
                            << "session creation for " << session_id
                            << " and policy ID: " << it->id()
@@ -941,10 +938,10 @@ void LocalEnforcer::init_session(
     const std::string& session_id, const SessionConfig& cfg,
     const CreateSessionResponse& response) {
   const auto time_since_epoch = magma::get_time_in_sec_since_epoch();
-  auto session_state          = std::make_unique<SessionState>(
+  auto session                = std::make_unique<SessionState>(
       imsi, session_id, cfg, *rule_store_, response.tgpp_ctx(),
       time_since_epoch, response);
-  session_map[imsi].push_back(std::move(session_state));
+  session_map[imsi].push_back(std::move(session));
 }
 
 bool LocalEnforcer::update_tunnel_ids(
@@ -985,7 +982,6 @@ bool LocalEnforcer::update_tunnel_ids(
       imsi, *session, csr, charging_credits_received);
 
   update_ipfix_flow(imsi, session->get_config(), time_since_epoch);
-  // if (session_state->get_config().common_context.rat_type() == TGPP_WLAN) {
   if (terminate_on_wallet_exhaust()) {
     handle_session_activate_subscriber_quota_state(imsi, *session);
   }
@@ -1053,10 +1049,10 @@ bool LocalEnforcer::terminate_on_wallet_exhaust() {
          mconfig_.wallet_exhaust_detection().terminate_on_exhaust();
 }
 
-bool LocalEnforcer::is_wallet_exhausted(SessionState& session_state) {
+bool LocalEnforcer::is_wallet_exhausted(SessionState& session) {
   switch (mconfig_.wallet_exhaust_detection().method()) {
     case magma::mconfig::WalletExhaustDetection_Method_GxTrackedRules:
-      return !session_state.active_monitored_rules_exist();
+      return !session.active_monitored_rules_exist();
     default:
       MLOG(MWARNING) << "This method is not yet supported...";
       return false;
@@ -1064,13 +1060,13 @@ bool LocalEnforcer::is_wallet_exhausted(SessionState& session_state) {
 }
 
 void LocalEnforcer::handle_session_activate_subscriber_quota_state(
-    const std::string& imsi, SessionState& session_state) {
-  if (is_wallet_exhausted(session_state)) {
+    const std::string& imsi, SessionState& session) {
+  if (is_wallet_exhausted(session)) {
     handle_subscriber_quota_state_change(
-        imsi, session_state, SubscriberQuotaUpdate_Type_NO_QUOTA);
+        imsi, session, SubscriberQuotaUpdate_Type_NO_QUOTA);
     // Schedule a session termination for a configured number of seconds after
     // session create
-    const auto session_id = session_state.get_session_id();
+    const auto session_id = session.get_session_id();
     MLOG(MINFO) << "Scheduling session for session " << session_id
                 << " to be terminated in "
                 << quota_exhaustion_termination_on_init_ms_ << " ms";
@@ -1082,7 +1078,7 @@ void LocalEnforcer::handle_session_activate_subscriber_quota_state(
 
   // Valid Quota
   handle_subscriber_quota_state_change(
-      imsi, session_state, SubscriberQuotaUpdate_Type_VALID_QUOTA);
+      imsi, session, SubscriberQuotaUpdate_Type_VALID_QUOTA);
   return;
 }
 
@@ -1213,10 +1209,9 @@ void LocalEnforcer::remove_rules_for_suspended_credit(
 
   // Remove pipelined rules
   RulesToProcess rules_to_remove;
-  session->get_rules_per_credit_key(ckey, rules_to_remove, session_uc);
-  auto imsi = session->get_config().common_context.sid().id();
+  session->get_rules_per_credit_key(ckey, &rules_to_remove, &session_uc);
   propagate_rule_updates_to_pipelined(
-      imsi, session->get_config(), RulesToProcess{}, rules_to_remove, false);
+      session->get_config(), RulesToProcess{}, rules_to_remove, false);
 }
 
 void LocalEnforcer::add_rules_for_multiple_unsuspended_credit(
@@ -1252,10 +1247,9 @@ void LocalEnforcer::add_rules_for_unsuspended_credit(
 
   //  add pipelined rules
   RulesToProcess rules_to_add;
-  session->get_rules_per_credit_key(ckey, rules_to_add, session_uc);
-  auto imsi = session->get_config().common_context.sid().id();
+  session->get_rules_per_credit_key(ckey, &rules_to_add, &session_uc);
   propagate_rule_updates_to_pipelined(
-      imsi, session->get_config(), rules_to_add, RulesToProcess{}, false);
+      session->get_config(), rules_to_add, RulesToProcess{}, false);
 }
 
 void LocalEnforcer::update_charging_credits(
@@ -1368,20 +1362,19 @@ void LocalEnforcer::update_monitoring_credits_and_rules(
     session->receive_monitor(usage_monitor_resp, uc);
     session->set_tgpp_context(usage_monitor_resp.tgpp_ctx(), uc);
 
-    RulesToProcess rules_to_activate;
-    RulesToProcess rules_to_deactivate;
+    RulesToProcess to_activate, to_deactivate;
 
     process_rules_to_remove(
-        imsi, session, usage_monitor_resp.rules_to_remove(),
-        rules_to_deactivate, uc);
+        imsi, session, usage_monitor_resp.rules_to_remove(), &to_deactivate,
+        &uc);
 
     process_rules_to_install(
         *session, imsi, to_vec(usage_monitor_resp.static_rules_to_install()),
-        to_vec(usage_monitor_resp.dynamic_rules_to_install()),
-        rules_to_activate, rules_to_deactivate, uc);
+        to_vec(usage_monitor_resp.dynamic_rules_to_install()), &to_activate,
+        &to_deactivate, &uc);
 
     propagate_rule_updates_to_pipelined(
-        imsi, config, rules_to_activate, rules_to_deactivate, false);
+        config, to_activate, to_deactivate, false);
 
     if (terminate_on_wallet_exhaust() && is_wallet_exhausted(*session)) {
       actions.sessions_to_terminate.insert(ImsiAndSessionID(imsi, session_id));
@@ -1403,8 +1396,8 @@ void LocalEnforcer::update_monitoring_credits_and_rules(
     }
 
     if (config.common_context.rat_type() == TGPP_LTE) {
-      const auto update = session->get_dedicated_bearer_updates(
-          rules_to_activate, rules_to_deactivate, uc);
+      const BearerUpdate update = session->get_dedicated_bearer_updates(
+          to_activate, to_deactivate, &uc);
       propagate_bearer_updates_to_mme(update);
     }
   }
@@ -1506,8 +1499,7 @@ void LocalEnforcer::handle_set_session_rules(
     RuleSetBySubscriber rule_set_by_sub(rules_per_sub);
 
     for (const auto& session : session_it->second) {
-      RulesToProcess rules_to_activate;
-      RulesToProcess rules_to_deactivate;
+      auto& uc           = session_update[imsi][session->get_session_id()];
       const auto& config = session->get_config();
 
       const auto& apn = config.common_context.apn();
@@ -1517,18 +1509,18 @@ void LocalEnforcer::handle_set_session_rules(
         continue;
       }
 
-      auto& uc = session_update[imsi][session->get_session_id()];
       // Process the rule sets and get rules that need to be
       // activated/deactivated
+      RulesToProcess to_activate, to_deactivate;
       session->apply_session_rule_set(
-          *rule_set, rules_to_activate, rules_to_deactivate, uc);
+          *rule_set, &to_activate, &to_deactivate, uc);
 
       // Propagate these rule changes to PipelineD and MME (if 4G)
       propagate_rule_updates_to_pipelined(
-          imsi, config, rules_to_activate, rules_to_deactivate, false);
+          config, to_activate, to_deactivate, false);
       if (config.common_context.rat_type() == TGPP_LTE) {
-        const auto update = session->get_dedicated_bearer_updates(
-            rules_to_activate, rules_to_deactivate, uc);
+        const BearerUpdate update = session->get_dedicated_bearer_updates(
+            to_activate, to_deactivate, &uc);
         propagate_bearer_updates_to_mme(update);
       }
     }
@@ -1610,8 +1602,7 @@ void LocalEnforcer::init_policy_reauth_for_session(
 
   receive_monitoring_credit_from_rar(request, session, uc);
 
-  RulesToProcess rules_to_activate;
-  RulesToProcess rules_to_deactivate;
+  RulesToProcess to_activate, to_deactivate;
 
   MLOG(MDEBUG) << "Processing policy reauth for subscriber " << request.imsi();
   if (revalidation_required(request.event_triggers())) {
@@ -1619,46 +1610,45 @@ void LocalEnforcer::init_policy_reauth_for_session(
   }
 
   process_rules_to_remove(
-      imsi, session, request.rules_to_remove(), rules_to_deactivate, uc);
+      imsi, session, request.rules_to_remove(), &to_deactivate, &uc);
 
   process_rules_to_install(
       *session, imsi, to_vec(request.rules_to_install()),
-      to_vec(request.dynamic_rules_to_install()), rules_to_activate,
-      rules_to_deactivate, uc);
+      to_vec(request.dynamic_rules_to_install()), &to_activate, &to_deactivate,
+      &uc);
 
   propagate_rule_updates_to_pipelined(
-      imsi, session->get_config(), rules_to_activate, rules_to_deactivate,
-      false);
+      session->get_config(), to_activate, to_deactivate, false);
 
   if (terminate_on_wallet_exhaust() && is_wallet_exhausted(*session)) {
     start_session_termination(imsi, session, true, uc);
     return;
   }
   if (session->get_config().common_context.rat_type() == TGPP_LTE) {
-    create_bearer(session, request, rules_to_activate);
+    create_bearer(session, request, to_activate);
   }
 }
 
 void LocalEnforcer::propagate_rule_updates_to_pipelined(
-    const std::string& imsi, const SessionConfig& config,
-    const RulesToProcess& rules_to_activate,
-    const RulesToProcess& rules_to_deactivate, bool always_send_activate) {
+    const SessionConfig& config, const RulesToProcess& to_activate,
+    const RulesToProcess& to_deactivate, bool always_send_activate) {
+  const std::string& imsi = config.common_context.sid().id();
+  ;
   const auto ip_addr   = config.common_context.ue_ipv4();
   const auto ipv6_addr = config.common_context.ue_ipv6();
   const Teids teids    = config.common_context.teids();
   // deactivate_flows_for_rules() should not be called when there is no rule
   // to deactivate, because pipelined deactivates all rules
   // when no rule is provided as the parameter
-  if (!rules_to_deactivate.empty()) {
+  if (!to_deactivate.empty()) {
     pipelined_client_->deactivate_flows_for_rules(
-        imsi, ip_addr, ipv6_addr, teids, rules_to_deactivate,
-        RequestOriginType::GX);
+        imsi, ip_addr, ipv6_addr, teids, to_deactivate, RequestOriginType::GX);
   }
-  if (always_send_activate || !rules_to_activate.empty()) {
+  if (always_send_activate || !to_activate.empty()) {
     const auto ambr   = config.get_apn_ambr();
     const auto msisdn = config.common_context.msisdn();
     pipelined_client_->activate_flows_for_rules(
-        imsi, ip_addr, ipv6_addr, teids, msisdn, ambr, rules_to_activate,
+        imsi, ip_addr, ipv6_addr, teids, msisdn, ambr, to_activate,
         std::bind(
             &LocalEnforcer::handle_activate_ue_flows_callback, this, imsi,
             ip_addr, ipv6_addr, teids, _1, _2));
@@ -1686,7 +1676,7 @@ void LocalEnforcer::process_rules_to_remove(
     const std::string& imsi, const std::unique_ptr<SessionState>& session,
     const google::protobuf::RepeatedPtrField<std::basic_string<char>>
         rules_to_remove,
-    RulesToProcess& rules_to_deactivate, SessionStateUpdateCriteria& uc) {
+    RulesToProcess* to_deactivate, SessionStateUpdateCriteria* uc) {
   for (const auto& rule_id : rules_to_remove) {
     optional<PolicyType> p_type = session->get_policy_type(rule_id);
     if (!p_type) {
@@ -1698,7 +1688,7 @@ void LocalEnforcer::process_rules_to_remove(
     PolicyRule rule;
     switch (*p_type) {
       case DYNAMIC: {
-        remove_info = session->remove_dynamic_rule(rule_id, &rule, uc);
+        remove_info = session->remove_dynamic_rule(rule_id, &rule, *uc);
         break;
       }
       case STATIC: {
@@ -1706,7 +1696,7 @@ void LocalEnforcer::process_rules_to_remove(
           MLOG(MERROR) << "Static rule " << rule_id << " not found";
           continue;
         }
-        remove_info = session->deactivate_static_rule(rule_id, uc);
+        remove_info = session->deactivate_static_rule(rule_id, *uc);
         break;
       }
       default:
@@ -1717,7 +1707,7 @@ void LocalEnforcer::process_rules_to_remove(
                    << session->get_session_id();
       continue;
     }
-    rules_to_deactivate.push_back(*remove_info);
+    to_deactivate->push_back(*remove_info);
   }
 }
 
@@ -1743,76 +1733,32 @@ std::vector<DynamicRuleInstall> LocalEnforcer::to_vec(
 
 void LocalEnforcer::process_rules_to_install(
     SessionState& session, const std::string& imsi,
-    std::vector<StaticRuleInstall> static_rule_installs,
-    std::vector<DynamicRuleInstall> dynamic_rule_installs,
-    RulesToProcess& rules_to_activate, RulesToProcess& rules_to_deactivate,
-    SessionStateUpdateCriteria& uc) {
-  std::time_t current_time     = std::time(nullptr);
-  std::string ip_addr          = session.get_config().common_context.ue_ipv4();
-  std::string ipv6_addr        = session.get_config().common_context.ue_ipv6();
-  const std::string session_id = session.get_session_id();
-  for (const auto& rule_install : static_rule_installs) {
-    const auto& id = rule_install.rule_id();
-    if (session.is_static_rule_installed(id)) {
-      // Session proxy may ask for duplicate rule installs.
-      // Ignore them here.
-      continue;
-    }
-    PolicyRule static_rule;
-    if (!rule_store_->get_rule(id, &static_rule)) {
-      MLOG(MERROR) << "static rule " << id
-                   << " is not found, skipping install...";
-      continue;
-    }
+    const std::vector<StaticRuleInstall>& static_rule_installs,
+    const std::vector<DynamicRuleInstall>& dynamic_rule_installs,
+    RulesToProcess* to_activate, RulesToProcess* to_deactivate,
+    SessionStateUpdateCriteria* session_uc) {
+  RulesToSchedule to_schedules;
+  session.process_static_rule_installs(
+      static_rule_installs, to_activate, to_deactivate, &to_schedules,
+      session_uc);
+  session.process_dynamic_rule_installs(
+      dynamic_rule_installs, to_activate, to_deactivate, &to_schedules,
+      session_uc);
 
-    RuleLifetime lifetime(rule_install);
-    if (lifetime.activation_time > current_time) {
-      session.schedule_static_rule(id, lifetime, uc);
-      schedule_static_rule_activation(
-          imsi, session_id, id, lifetime.activation_time);
-    } else {
-      // Set up rules_to_activate
-      rules_to_activate.push_back(
-          session.activate_static_rule(id, lifetime, uc));
-    }
-
-    if (lifetime.deactivation_time > current_time) {
-      schedule_static_rule_deactivation(
-          imsi, session_id, id, lifetime.deactivation_time);
-    } else if (lifetime.deactivation_time > 0) {
-      // 0: never scheduled to deactivate
-      optional<RuleToProcess> op_rule_info =
-          session.deactivate_static_rule(id, uc);
-      if (!op_rule_info) {
-        MLOG(MWARNING) << "Could not find rule " << id << "for " << session_id
-                       << " during static rule removal";
-      } else {
-        rules_to_deactivate.push_back(*op_rule_info);
-      }
-    }
-  }
-
-  for (auto& rule_install : dynamic_rule_installs) {
-    PolicyRule dynamic_rule = rule_install.policy_rule();
-    auto rule_id            = dynamic_rule.id();
-    RuleLifetime lifetime(rule_install);
-    if (lifetime.activation_time > current_time) {
-      session.schedule_dynamic_rule(dynamic_rule, lifetime, uc);
-      schedule_dynamic_rule_activation(
-          imsi, session_id, rule_id, lifetime.activation_time);
-    } else {
-      rules_to_activate.push_back(
-          session.insert_dynamic_rule(dynamic_rule, lifetime, uc));
-    }
-    if (lifetime.deactivation_time > current_time) {
-      schedule_dynamic_rule_deactivation(
-          imsi, session_id, rule_id, lifetime.deactivation_time);
-    } else if (lifetime.deactivation_time > 0) {
-      optional<RuleToProcess> remove_info =
-          session.remove_dynamic_rule(rule_id, nullptr, uc);
-      if (remove_info) {
-        rules_to_deactivate.push_back(*remove_info);
-      }
+  const std::string& session_id = session.get_session_id();
+  for (const RuleToSchedule& to_schedule : to_schedules) {
+    const PolicyType& p_type      = to_schedule.p_type;
+    const PolicyAction& p_action  = to_schedule.p_action;
+    const std::string& rule_id    = to_schedule.rule_id;
+    const std::time_t& sched_time = to_schedule.scheduled_time;
+    if (p_type == STATIC && p_action == ACTIVATE) {
+      schedule_static_rule_activation(imsi, session_id, rule_id, sched_time);
+    } else if (p_type == STATIC && p_action == DEACTIVATE) {
+      schedule_static_rule_deactivation(imsi, session_id, rule_id, sched_time);
+    } else if (p_type == DYNAMIC && p_action == ACTIVATE) {
+      schedule_dynamic_rule_activation(imsi, session_id, rule_id, sched_time);
+    } else if (p_type == DYNAMIC && p_action == ACTIVATE) {
+      schedule_dynamic_rule_deactivation(imsi, session_id, rule_id, sched_time);
     }
   }
 }

--- a/lte/gateway/c/session_manager/LocalEnforcer.h
+++ b/lte/gateway/c/session_manager/LocalEnforcer.h
@@ -181,7 +181,7 @@ class LocalEnforcer {
    * CreateSessionResponse.
    */
   void handle_session_activate_rule_updates(
-      const std::string& imsi, SessionState& session_state,
+      const std::string& imsi, SessionState& session,
       const CreateSessionResponse& response,
       std::unordered_set<uint32_t>& charging_credits_received);
 
@@ -382,7 +382,7 @@ class LocalEnforcer {
       UpdateChargingCreditActions& actions, SessionUpdate& session_update);
 
   /**
-   * Process the list of rule names given and fill in rules_to_deactivate by
+   * Process the list of rule names given and fill in to_deactivate by
    * determining whether each one is dynamic or static. Modifies session state.
    * TODO separate out logic that modifies state vs logic that does not.
    */
@@ -390,34 +390,32 @@ class LocalEnforcer {
       const std::string& imsi, const std::unique_ptr<SessionState>& session,
       const google::protobuf::RepeatedPtrField<std::basic_string<char>>
           rules_to_remove,
-      RulesToProcess& rules_to_deactivate, SessionStateUpdateCriteria& uc);
+      RulesToProcess* to_deactivate, SessionStateUpdateCriteria* uc);
 
   /**
    * Process protobuf StaticRuleInstalls and DynamicRuleInstalls to fill in
-   * rules_to_activate and rules_to_deactivate. Modifies session state.
+   * to_activate and to_deactivate. Modifies session state.
    * TODO separate out logic that modifies state vs logic that does not.
    */
   void process_rules_to_install(
       SessionState& session, const std::string& imsi,
-      std::vector<StaticRuleInstall> static_rule_installs,
-      std::vector<DynamicRuleInstall> dynamic_rule_installs,
-      RulesToProcess& rules_to_activate, RulesToProcess& rules_to_deactivate,
-      SessionStateUpdateCriteria& uc);
+      const std::vector<StaticRuleInstall>& static_rule_installs,
+      const std::vector<DynamicRuleInstall>& dynamic_rule_installs,
+      RulesToProcess* to_activate, RulesToProcess* to_deactivate,
+      SessionStateUpdateCriteria* session_uc);
 
   /**
    * propagate_rule_updates_to_pipelined calls the PipelineD RPC calls to
    * install/uninstall flows
-   * @param imsi
    * @param config
-   * @param rules_to_activate
-   * @param rules_to_deactivate
+   * @param to_activate
+   * @param to_deactivate
    * @param always_send_activate : if this is set activate call will be sent
-   * even if rules_to_activate is empty
+   * even if to_activate is empty
    */
   void propagate_rule_updates_to_pipelined(
-      const std::string& imsi, const SessionConfig& config,
-      const RulesToProcess& rules_to_activate,
-      const RulesToProcess& rules_to_deactivate, bool always_send_activate);
+      const SessionConfig& config, const RulesToProcess& to_activate,
+      const RulesToProcess& to_deactivate, bool always_send_activate);
 
   /**
    * For the matching session ID, activate and/or deactivate the specified
@@ -627,9 +625,9 @@ class LocalEnforcer {
    * the session to be terminated in a configured amount of time.
    */
   void handle_session_activate_subscriber_quota_state(
-      const std::string& imsi, SessionState& session_state);
+      const std::string& imsi, SessionState& session);
 
-  bool is_wallet_exhausted(SessionState& session_state);
+  bool is_wallet_exhausted(SessionState& session);
 
   bool terminate_on_wallet_exhaust();
 

--- a/lte/gateway/c/session_manager/SessionState.cpp
+++ b/lte/gateway/c/session_manager/SessionState.cpp
@@ -498,17 +498,17 @@ void SessionState::add_rule_usage(
 }
 
 void SessionState::apply_session_rule_set(
-    RuleSetToApply& rule_set, RulesToProcess& rules_to_activate,
-    RulesToProcess& rules_to_deactivate, SessionStateUpdateCriteria& uc) {
+    const RuleSetToApply& rule_set, RulesToProcess* to_activate,
+    RulesToProcess* to_deactivate, SessionStateUpdateCriteria& uc) {
   apply_session_static_rule_set(
-      rule_set.static_rules, rules_to_activate, rules_to_deactivate, uc);
+      rule_set.static_rules, to_activate, to_deactivate, uc);
   apply_session_dynamic_rule_set(
-      rule_set.dynamic_rules, rules_to_activate, rules_to_deactivate, uc);
+      rule_set.dynamic_rules, to_activate, to_deactivate, uc);
 }
 
 void SessionState::apply_session_static_rule_set(
-    std::unordered_set<std::string> static_rules,
-    RulesToProcess& rules_to_activate, RulesToProcess& rules_to_deactivate,
+    const std::unordered_set<std::string> static_rules,
+    RulesToProcess* to_activate, RulesToProcess* to_deactivate,
     SessionStateUpdateCriteria& uc) {
   // No activation time / deactivation support yet for rule set interface
   RuleLifetime lifetime;
@@ -523,12 +523,12 @@ void SessionState::apply_session_static_rule_set(
     if (!is_static_rule_installed(static_rule_id)) {
       MLOG(MINFO) << "Installing static rule " << static_rule_id << " for "
                   << session_id_;
-      // Set up rules_to_activate
-      rules_to_activate.push_back(
+      // Set up to_activate
+      to_activate->push_back(
           activate_static_rule(static_rule_id, lifetime, uc));
     }
   }
-  std::vector<PolicyRule> static_rules_to_deactivate;
+  std::vector<PolicyRule> static_to_deactivate;
 
   // Go through the existing rules and uninstall any rule not in the rule set
   for (const auto static_rule_id : active_static_rules_) {
@@ -539,12 +539,12 @@ void SessionState::apply_session_static_rule_set(
                      << " is not found. Skipping deactivation";
         continue;
       }
-      static_rules_to_deactivate.push_back(rule);
+      static_to_deactivate.push_back(rule);
     }
   }
   // Do the actual removal separately so we're not modifying the vector while
   // looping
-  for (const PolicyRule static_rule : static_rules_to_deactivate) {
+  for (const PolicyRule static_rule : static_to_deactivate) {
     MLOG(MINFO) << "Removing static rule " << static_rule.id() << " for "
                 << session_id_;
     optional<RuleToProcess> op_rule_info =
@@ -553,14 +553,14 @@ void SessionState::apply_session_static_rule_set(
       MLOG(MWARNING) << "Failed to deactivate static rule " << static_rule.id()
                      << " for " << session_id_;
     } else {
-      rules_to_deactivate.push_back(*op_rule_info);
+      to_deactivate->push_back(*op_rule_info);
     }
   }
 }
 
 void SessionState::apply_session_dynamic_rule_set(
-    std::unordered_map<std::string, PolicyRule> dynamic_rules,
-    RulesToProcess& rules_to_activate, RulesToProcess& rules_to_deactivate,
+    const std::unordered_map<std::string, PolicyRule> dynamic_rules,
+    RulesToProcess* to_activate, RulesToProcess* to_deactivate,
     SessionStateUpdateCriteria& uc) {
   // No activation time / deactivation support yet for rule set interface
   RuleLifetime lifetime;
@@ -568,7 +568,7 @@ void SessionState::apply_session_dynamic_rule_set(
     if (!is_dynamic_rule_installed(dynamic_rule_pair.first)) {
       MLOG(MINFO) << "Installing dynamic rule " << dynamic_rule_pair.first
                   << " for " << session_id_;
-      rules_to_activate.push_back(
+      to_activate->push_back(
           insert_dynamic_rule(dynamic_rule_pair.second, lifetime, uc));
     }
   }
@@ -578,7 +578,7 @@ void SessionState::apply_session_dynamic_rule_set(
     if (dynamic_rules.find(dynamic_rule.id()) == dynamic_rules.end()) {
       MLOG(MINFO) << "Removing dynamic rule " << dynamic_rule.id() << " for "
                   << session_id_;
-      rules_to_deactivate.push_back(
+      to_deactivate->push_back(
           *remove_dynamic_rule(dynamic_rule.id(), nullptr, uc));
     }
   }
@@ -994,7 +994,9 @@ RuleToProcess SessionState::activate_static_rule(
   static_rules_.get_rule(rule_id, &rule);
 
   rule_lifetimes_[rule_id] = lifetime;
-  active_static_rules_.push_back(rule_id);
+  if (!is_static_rule_installed(rule_id)) {
+    active_static_rules_.push_back(rule_id);
+  }
   session_uc.static_rules_to_install.insert(rule_id);
   session_uc.new_rule_lifetimes[rule_id] = lifetime;
   increment_rule_stats(rule_id, session_uc);
@@ -1083,6 +1085,98 @@ bool SessionState::deactivate_scheduled_static_rule(
   }
   scheduled_static_rules_.erase(rule_id);
   return true;
+}
+
+void SessionState::process_static_rule_installs(
+    const std::vector<StaticRuleInstall>& rule_installs,
+    RulesToProcess* to_activate, RulesToProcess* to_deactivate,
+    RulesToSchedule* to_schedule, SessionStateUpdateCriteria* session_uc) {
+  std::time_t current_time = std::time(nullptr);
+  for (const StaticRuleInstall& rule_install : rule_installs) {
+    const std::string& rule_id = rule_install.rule_id();
+    RuleLifetime lifetime(rule_install);
+    if (is_static_rule_installed(rule_id)) {
+      // Session proxy may ask for duplicate rule installs.
+      // Ignore them here.
+      MLOG(MWARNING) << "Ignoring static rule install for " << session_id_
+                     << " for rule " << rule_id
+                     << " since it is alreday installed";
+      continue;
+    }
+    PolicyRule static_rule;
+    if (!static_rules_.get_rule(rule_id, &static_rule)) {
+      MLOG(MERROR) << "static rule " << rule_id
+                   << " is not found, skipping install...";
+      continue;
+    }
+
+    // If the rule should be deactivated already, deactivate just in case and
+    // continue
+    if (lifetime.exceeded_lifetime(current_time)) {
+      optional<RuleToProcess> op_remove_info =
+          deactivate_static_rule(rule_id, *session_uc);
+      if (op_remove_info) {
+        to_deactivate->push_back(*op_remove_info);
+      }
+      continue;
+    }
+    // If the rule should be active now, install
+    if (lifetime.is_within_lifetime(current_time)) {
+      to_activate->push_back(
+          activate_static_rule(rule_id, lifetime, *session_uc));
+    }
+    // If the rule is for future activation, schedule
+    if (lifetime.before_lifetime(current_time)) {
+      schedule_static_rule(rule_id, lifetime, *session_uc);
+      to_schedule->push_back(
+          RuleToSchedule(STATIC, rule_id, ACTIVATE, lifetime.activation_time));
+    }
+    // Schedule deactivation time in the future
+    if (lifetime.should_schedule_deactivation(current_time)) {
+      to_schedule->push_back(RuleToSchedule(
+          STATIC, rule_id, DEACTIVATE, lifetime.deactivation_time));
+    }
+  }
+}
+
+void SessionState::process_dynamic_rule_installs(
+    const std::vector<DynamicRuleInstall>& rule_installs,
+    RulesToProcess* to_activate, RulesToProcess* to_deactivate,
+    RulesToSchedule* to_schedule, SessionStateUpdateCriteria* session_uc) {
+  std::time_t current_time = std::time(nullptr);
+
+  for (const DynamicRuleInstall& rule_install : rule_installs) {
+    const PolicyRule& dynamic_rule = rule_install.policy_rule();
+    const std::string& rule_id     = dynamic_rule.id();
+    RuleLifetime lifetime(rule_install);
+
+    // If the rule should be deactivated already, deactivate just in case and
+    // continue
+    if (lifetime.exceeded_lifetime(current_time)) {
+      optional<RuleToProcess> op_remove_info =
+          remove_dynamic_rule(rule_id, nullptr, *session_uc);
+      if (op_remove_info) {
+        to_deactivate->push_back(*op_remove_info);
+      }
+      continue;
+    }
+    // If the rule should be active now, install
+    if (lifetime.is_within_lifetime(current_time)) {
+      to_activate->push_back(
+          insert_dynamic_rule(dynamic_rule, lifetime, *session_uc));
+    }
+    // If the rule is for future activation, schedule
+    if (lifetime.before_lifetime(current_time)) {
+      schedule_dynamic_rule(dynamic_rule, lifetime, *session_uc);
+      to_schedule->push_back(
+          RuleToSchedule(DYNAMIC, rule_id, ACTIVATE, lifetime.activation_time));
+    }
+    // Schedule deactivation time in the future
+    if (lifetime.should_schedule_deactivation(current_time)) {
+      to_schedule->push_back(RuleToSchedule(
+          DYNAMIC, rule_id, DEACTIVATE, lifetime.deactivation_time));
+    }
+  }
 }
 
 void SessionState::sync_rules_to_time(
@@ -1408,8 +1502,8 @@ bool SessionState::is_credit_suspended(const CreditKey& charging_key) {
 }
 
 void SessionState::get_rules_per_credit_key(
-    CreditKey charging_key, RulesToProcess& to_activate,
-    SessionStateUpdateCriteria& session_uc) {
+    const CreditKey& charging_key, RulesToProcess* to_process,
+    SessionStateUpdateCriteria* session_uc) {
   std::vector<PolicyRule> static_rules, dynamic_rules;
   static_rules_.get_rule_definitions_for_charging_key(
       charging_key, static_rules);
@@ -1418,15 +1512,15 @@ void SessionState::get_rules_per_credit_key(
     // that the rule is activated for the session
     bool is_installed = is_static_rule_installed(rule.id());
     if (is_installed) {
-      increment_rule_stats(rule.id(), session_uc);
-      to_activate.push_back(make_rule_to_process(rule));
+      increment_rule_stats(rule.id(), *session_uc);
+      to_process->push_back(make_rule_to_process(rule));
     }
   }
   dynamic_rules_.get_rule_definitions_for_charging_key(
       charging_key, dynamic_rules);
   for (PolicyRule rule : dynamic_rules) {
-    increment_rule_stats(rule.id(), session_uc);
-    to_activate.push_back(make_rule_to_process(rule));
+    increment_rule_stats(rule.id(), *session_uc);
+    to_process->push_back(make_rule_to_process(rule));
   }
 }
 
@@ -1962,11 +2056,11 @@ void SessionState::set_session_level_key(const std::string new_key) {
 }
 
 BearerUpdate SessionState::get_dedicated_bearer_updates(
-    RulesToProcess& rules_to_activate, RulesToProcess& rules_to_deactivate,
-    SessionStateUpdateCriteria& uc) {
+    const RulesToProcess& to_activate, const RulesToProcess& to_deactivate,
+    SessionStateUpdateCriteria* session_uc) {
   BearerUpdate update;
   // Rule Installs
-  for (const auto& to_process : rules_to_activate) {
+  for (const auto& to_process : to_activate) {
     const auto& rule_id = to_process.rule.id();
     PolicyType p_type;
     if (static_rules_.get_rule(rule_id, nullptr)) {
@@ -1974,11 +2068,11 @@ BearerUpdate SessionState::get_dedicated_bearer_updates(
     } else {
       p_type = DYNAMIC;
     }
-    update_bearer_creation_req(p_type, rule_id, config_, update);
+    update_bearer_creation_req(p_type, rule_id, &update);
   }
 
   // Rule Removals
-  for (const auto& to_process : rules_to_deactivate) {
+  for (const auto& to_process : to_deactivate) {
     const auto& rule_id = to_process.rule.id();
     PolicyType p_type;
     if (static_rules_.get_rule(rule_id, nullptr)) {
@@ -1986,7 +2080,7 @@ BearerUpdate SessionState::get_dedicated_bearer_updates(
     } else {
       p_type = DYNAMIC;
     }
-    update_bearer_deletion_req(p_type, rule_id, config_, update, uc);
+    update_bearer_deletion_req(p_type, rule_id, update, *session_uc);
   }
   return update;
 }
@@ -2156,9 +2250,8 @@ bool SessionState::policy_has_qos(
 }
 
 optional<PolicyRule> SessionState::policy_needs_bearer_creation(
-    const PolicyType policy_type, const std::string& id,
-    const SessionConfig& config) {
-  if (!config.rat_specific_context.has_lte_context()) {
+    const PolicyType policy_type, const std::string& id) {
+  if (!config_.rat_specific_context.has_lte_context()) {
     return {};
   }
   if (bearer_id_by_policy_.find(PolicyID(policy_type, id)) !=
@@ -2172,7 +2265,7 @@ optional<PolicyRule> SessionState::policy_needs_bearer_creation(
     return {};
   }
   auto default_qci = FlowQos_Qci(
-      config.rat_specific_context.lte_context().qos_info().qos_class_id());
+      config_.rat_specific_context.lte_context().qos_info().qos_class_id());
   if (policy.qos().qci() == default_qci) {
     // This QCI is already covered by the default bearer
     return {};
@@ -2182,31 +2275,30 @@ optional<PolicyRule> SessionState::policy_needs_bearer_creation(
 
 void SessionState::update_bearer_creation_req(
     const PolicyType policy_type, const std::string& rule_id,
-    const SessionConfig& config, BearerUpdate& update) {
-  auto policy = policy_needs_bearer_creation(policy_type, rule_id, config);
+    BearerUpdate* update) {
+  auto policy = policy_needs_bearer_creation(policy_type, rule_id);
   if (!policy) {
     return;
   }
 
   // If it is first time filling in the CreationReq, fill in other info
-  if (!update.needs_creation) {
-    update.needs_creation = true;
-    update.create_req.mutable_sid()->CopyFrom(config.common_context.sid());
-    update.create_req.set_ip_addr(config.common_context.ue_ipv4());
+  if (!update->needs_creation) {
+    update->needs_creation = true;
+    update->create_req.mutable_sid()->CopyFrom(config_.common_context.sid());
+    update->create_req.set_ip_addr(config_.common_context.ue_ipv4());
     // TODO ipv6 add to the bearer request or remove ipv4
-    update.create_req.set_link_bearer_id(
-        config.rat_specific_context.lte_context().bearer_id());
+    update->create_req.set_link_bearer_id(
+        config_.rat_specific_context.lte_context().bearer_id());
   }
-  update.create_req.mutable_policy_rules()->Add()->CopyFrom(*policy);
+  update->create_req.mutable_policy_rules()->Add()->CopyFrom(*policy);
   // We will add the new policyID to bearerID association, once we receive a
   // message from SGW.
 }
 
 void SessionState::update_bearer_deletion_req(
     const PolicyType policy_type, const std::string& rule_id,
-    const SessionConfig& config, BearerUpdate& update,
-    SessionStateUpdateCriteria& uc) {
-  if (!config.rat_specific_context.has_lte_context()) {
+    BearerUpdate& update, SessionStateUpdateCriteria& uc) {
+  if (!config_.rat_specific_context.has_lte_context()) {
     return;
   }
   if (bearer_id_by_policy_.find(PolicyID(policy_type, rule_id)) ==
@@ -2224,11 +2316,11 @@ void SessionState::update_bearer_deletion_req(
   if (!update.needs_deletion) {
     update.needs_deletion = true;
     auto& req             = update.delete_req;
-    req.mutable_sid()->CopyFrom(config.common_context.sid());
-    req.set_ip_addr(config.common_context.ue_ipv4());
+    req.mutable_sid()->CopyFrom(config_.common_context.sid());
+    req.set_ip_addr(config_.common_context.ue_ipv4());
     // TODO ipv6 add to the bearer request or remove ipv4
     req.set_link_bearer_id(
-        config.rat_specific_context.lte_context().bearer_id());
+        config_.rat_specific_context.lte_context().bearer_id());
   }
   update.delete_req.mutable_eps_bearer_ids()->Add(
       bearer_id_to_delete.bearer_id);

--- a/lte/gateway/c/session_manager/SessionState.h
+++ b/lte/gateway/c/session_manager/SessionState.h
@@ -449,8 +449,8 @@ class SessionState {
   SessionFsmState get_state();
 
   void get_rules_per_credit_key(
-      CreditKey charging_key, RulesToProcess& rulesToProcess,
-      SessionStateUpdateCriteria& session_uc);
+      const CreditKey& charging_key, RulesToProcess* to_process,
+      SessionStateUpdateCriteria* session_uc);
 
   /**
    * Remove all active/scheduled static/dynamic rules and reflect the change in
@@ -523,25 +523,23 @@ class SessionState {
   /**
    * get_dedicated_bearer_updates processes the two rule update inputs and
    * produces a BearerUpdate based on whether a bearer has to be create/deleted.
-   * @param rules_to_activate
-   * @param rules_to_deactivate
+   * @param to_activate
+   * @param to_deactivate
    * @param uc: update criteria needs to be updated if the bearer mapping is
    * modified
    * @return BearerUpdate with Create/DeleteBearerRequest
    */
   BearerUpdate get_dedicated_bearer_updates(
-      RulesToProcess& rules_to_activate, RulesToProcess& rules_to_deactivate,
-      SessionStateUpdateCriteria& uc);
+      const RulesToProcess& to_activate, const RulesToProcess& to_deactivate,
+      SessionStateUpdateCriteria* session_uc);
   /**
    * Determine whether a policy with type+ID needs a bearer to be created
    * @param policy_type
    * @param rule_id
-   * @param config
    * @return an optional wrapped PolicyRule if creation is needed, {} otherwise
    */
   optional<PolicyRule> policy_needs_bearer_creation(
-      const PolicyType policy_type, const std::string& rule_id,
-      const SessionConfig& config);
+      const PolicyType policy_type, const std::string& rule_id);
 
   /**
    * @brief Return the list of teids used in this session
@@ -555,12 +553,12 @@ class SessionState {
    *
    * @param rule_set
    * @param subscriber_wide_rule_set
-   * @param rules_to_activate
-   * @param rules_to_deactivate
+   * @param to_activate
+   * @param to_deactivate
    */
   void apply_session_rule_set(
-      RuleSetToApply& rule_set, RulesToProcess& rules_to_activate,
-      RulesToProcess& rules_to_deactivate, SessionStateUpdateCriteria& uc);
+      const RuleSetToApply& rule_set, RulesToProcess* to_activate,
+      RulesToProcess* to_deactivate, SessionStateUpdateCriteria& uc);
 
   /**
    * Add the association of policy -> bearerID into bearer_id_by_policy_
@@ -581,6 +579,40 @@ class SessionState {
    */
   bool should_rule_be_active(const std::string& rule_id, std::time_t time);
   bool is_dynamic_rule_scheduled(const std::string& rule_id);
+
+  /**
+   * @brief Go through static rule install instructions and return
+   * what needs to be propagated to PipelineD
+   *
+   * @param rule_installs StaticRuleInstall received from
+   * PCF/PCRF/PolicyDB
+   * @param to_activate output parameter
+   * @param to_deactivate output parameter
+   * @param rules_to_schedule output parameter
+   * @param session_uc
+   */
+  void process_static_rule_installs(
+      const std::vector<StaticRuleInstall>& rule_installs,
+      RulesToProcess* to_activate, RulesToProcess* to_deactivate,
+      RulesToSchedule* rules_to_schedule,
+      SessionStateUpdateCriteria* session_uc);
+
+  /**
+   * @brief Go through dynamic rule install instructions and return
+   * what needs to be propagated to PipelineD
+   *
+   * @param rule_installs DynamicRuleInstall received from
+   * PCF/PCRF/PolicyDB
+   * @param to_activate output parameter
+   * @param to_deactivate output parameter
+   * @param rules_to_schedule output parameter
+   * @param session_uc
+   */
+  void process_dynamic_rule_installs(
+      const std::vector<DynamicRuleInstall>& rule_installs,
+      RulesToProcess* to_activate, RulesToProcess* to_deactivate,
+      RulesToSchedule* rules_to_schedule,
+      SessionStateUpdateCriteria* session_uc);
 
   /**
    * Clear all per-session metrics
@@ -770,14 +802,14 @@ class SessionState {
 
   /** apply static_rules which is the desired state for the session's rules **/
   void apply_session_static_rule_set(
-      std::unordered_set<std::string> static_rules,
-      RulesToProcess& rules_to_activate, RulesToProcess& rules_to_deactivate,
+      const std::unordered_set<std::string> static_rules,
+      RulesToProcess* to_activate, RulesToProcess* to_deactivate,
       SessionStateUpdateCriteria& uc);
 
   /** apply dynamic_rules which is the desired state for the session's rules **/
   void apply_session_dynamic_rule_set(
-      std::unordered_map<std::string, PolicyRule> dynamic_rules,
-      RulesToProcess& rules_to_activate, RulesToProcess& rules_to_deactivate,
+      const std::unordered_map<std::string, PolicyRule> dynamic_rules,
+      RulesToProcess* to_activate, RulesToProcess* to_deactivate,
       SessionStateUpdateCriteria& uc);
 
   /**
@@ -789,7 +821,7 @@ class SessionState {
    */
   void update_bearer_creation_req(
       const PolicyType policy_type, const std::string& rule_id,
-      const SessionConfig& config, BearerUpdate& update);
+      BearerUpdate* update);
 
   /**
    * Check if a bearer has to be deleted for the given policy. If a deletion is
@@ -800,8 +832,7 @@ class SessionState {
    */
   void update_bearer_deletion_req(
       const PolicyType policy_type, const std::string& rule_id,
-      const SessionConfig& config, BearerUpdate& update,
-      SessionStateUpdateCriteria& uc);
+      BearerUpdate& update, SessionStateUpdateCriteria& uc);
 
   /**
    * Set bearer_id_by_policy_ to the input

--- a/lte/gateway/c/session_manager/StoredState.cpp
+++ b/lte/gateway/c/session_manager/StoredState.cpp
@@ -586,11 +586,15 @@ bool RuleLifetime::is_within_lifetime(std::time_t time) {
 }
 
 bool RuleLifetime::exceeded_lifetime(std::time_t time) {
-  return deactivation_time != 0 && deactivation_time < time;
+  return deactivation_time != 0 && deactivation_time <= time;
 }
 
 bool RuleLifetime::before_lifetime(std::time_t time) {
   return time < activation_time;
+}
+
+bool RuleLifetime::should_schedule_deactivation(std::time_t time) {
+  return deactivation_time != 0 && time <= deactivation_time;
 }
 
 };  // namespace magma

--- a/lte/gateway/c/session_manager/Types.h
+++ b/lte/gateway/c/session_manager/Types.h
@@ -150,6 +150,7 @@ struct RuleLifetime {
   bool is_within_lifetime(std::time_t time);
   bool exceeded_lifetime(std::time_t time);
   bool before_lifetime(std::time_t time);
+  bool should_schedule_deactivation(std::time_t time);
 };
 
 // QoS Management
@@ -202,6 +203,28 @@ struct RuleToProcess {
 };
 
 typedef std::vector<RuleToProcess> RulesToProcess;
+
+enum PolicyAction {
+  ACTIVATE   = 0,
+  DEACTIVATE = 1,
+};
+
+struct RuleToSchedule {
+  PolicyType p_type;
+  std::string rule_id;
+  PolicyAction p_action;
+  std::time_t scheduled_time;
+  RuleToSchedule() {}
+  RuleToSchedule(
+      PolicyType _p_type, std::string _rule_id, PolicyAction _p_action,
+      std::time_t _time)
+      : p_type(_p_type),
+        rule_id(_rule_id),
+        p_action(_p_action),
+        scheduled_time(_time) {}
+};
+
+typedef std::vector<RuleToSchedule> RulesToSchedule;
 
 struct StatsPerPolicy {
   // The version maintained by SessionD for this rule

--- a/lte/gateway/c/session_manager/test/test_local_enforcer.cpp
+++ b/lte/gateway/c/session_manager/test/test_local_enforcer.cpp
@@ -183,7 +183,9 @@ TEST_F(LocalEnforcerTest, test_init_cwf_session_credit) {
   insert_static_rule(1, "", "rule1");
 
   SessionConfig test_cwf_cfg;
-  test_cwf_cfg.common_context.set_rat_type(TGPP_WLAN);
+  Teids teids;
+  test_cwf_cfg.common_context =
+      build_common_context(IMSI1, "", "", teids, "", "", TGPP_WLAN);
   const auto& wlan = build_wlan_context(MAC_ADDR, RADIUS_SESSION_ID);
   test_cwf_cfg.rat_specific_context.mutable_wlan_context()->CopyFrom(wlan);
 
@@ -228,6 +230,7 @@ TEST_F(LocalEnforcerTest, test_init_infinite_metered_credit) {
   rules_to_install->Add()->CopyFrom(rule1);
 
   // Expect rule1 to be activated
+  test_cfg_.common_context.mutable_sid()->set_id(IMSI1);
   EXPECT_CALL(
       *pipelined_client, activate_flows_for_rules(
                              IMSI1, IP1, IPv6_1, CheckTeids(teids1),
@@ -258,6 +261,7 @@ TEST_F(LocalEnforcerTest, test_init_no_credit) {
   rules_to_install->Add()->CopyFrom(rule1);
 
   // Expect rule1 to be activated even if the GSU is all 0s
+  test_cfg_.common_context.mutable_sid()->set_id(IMSI1);
   EXPECT_CALL(
       *pipelined_client,
       activate_flows_for_rules(
@@ -1486,6 +1490,7 @@ TEST_F(LocalEnforcerTest, test_installing_rules_with_activation_time) {
   // dynamic rules: rule1, rule3
   // static rules: rule4, rule6
   test_cfg_.common_context.set_ue_ipv4(IP3);
+  test_cfg_.common_context.mutable_sid()->set_id(IMSI1);
   std::string ip_addr   = test_cfg_.common_context.ue_ipv4();
   std::string ipv6_addr = test_cfg_.common_context.ue_ipv6();
   Teids teids           = teids1;
@@ -1536,6 +1541,7 @@ TEST_F(LocalEnforcerTest, test_usage_monitors) {
   response.mutable_static_rules()->Add()->set_rule_id("ocs_rule");
   response.mutable_static_rules()->Add()->set_rule_id("pcrf_only");
   response.mutable_static_rules()->Add()->set_rule_id("pcrf_split");
+  test_cfg_.common_context.mutable_sid()->set_id(IMSI1);
 
   local_enforcer->init_session(
       session_map, IMSI1, SESSION_ID_1, test_cfg_, response);
@@ -2653,6 +2659,7 @@ TEST_F(LocalEnforcerTest, test_invalid_apn_parsing) {
 
 TEST_F(LocalEnforcerTest, test_final_unit_redirect_activation_and_termination) {
   CreateSessionResponse response;
+  test_cfg_.common_context.mutable_sid()->set_id(IMSI1);
   create_credit_update_response(
       IMSI1, SESSION_ID_1, 1, 1024, ChargingCredit_FinalAction_REDIRECT,
       "12.7.7.4", "", response.mutable_credits()->Add());
@@ -2828,6 +2835,7 @@ TEST_F(LocalEnforcerTest, test_final_unit_activation_and_canceling) {
 // is pending
 TEST_F(LocalEnforcerTest, test_final_unit_action_no_update) {
   CreateSessionResponse response;
+  test_cfg_.common_context.mutable_sid()->set_id(IMSI1);
   create_credit_update_response(
       IMSI1, SESSION_ID_1, 1, 1024, ChargingCredit_FinalAction_RESTRICT_ACCESS,
       "", "restrict_rule", response.mutable_credits()->Add());
@@ -2905,6 +2913,7 @@ TEST_F(LocalEnforcerTest, test_final_unit_action_no_update) {
 // 3. Assert we have rule X installed with modified entry
 TEST_F(LocalEnforcerTest, test_rar_dynamic_rule_modification) {
   CreateSessionResponse response;
+  test_cfg_.common_context.mutable_sid()->set_id(IMSI1);
   create_credit_update_response(
       IMSI1, SESSION_ID_1, 1, 1024, response.mutable_credits()->Add());
   auto dynamic_rule =

--- a/lte/gateway/c/session_manager/test/test_session_state.cpp
+++ b/lte/gateway/c/session_manager/test/test_session_state.cpp
@@ -944,7 +944,7 @@ TEST_F(SessionStateTest, test_apply_session_rule_set) {
   SessionStateUpdateCriteria uc;
   RulesToProcess to_activate, to_deactivate;
   session_state->apply_session_rule_set(
-      rules_to_apply, to_activate, to_deactivate, uc);
+      rules_to_apply, &to_activate, &to_deactivate, uc);
 
   // First check the active rules in session
   EXPECT_TRUE(!session_state->is_static_rule_installed("rule-static-1"));


### PR DESCRIPTION
Signed-off-by: Marie Bremner <marwhal@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary
In order to fully migrate to Teid based flow/policy identification as opposed to IP, we will need to separate out policies that are served by the default bearer from ones that are served by dedicated bearers. (Each bearer has a unique set of teids)

For policies that are served by dedicated bearers, we will need to delay the flow activation until we receive the matching teids from MME. 

This PR is just a cosmetic change to prepare for the actual change described above. 
More specifically, I cleaned up `process_rules_to_install` in `LocalEnforcer` by splitting the function into two functions (`process_static_rule_installs` and `process_dynamic_rule_installs` in `SessionState`).
Additionally, renamed all `rules_to_activate` -> `to_activate` and `rules_to_deactivate` -> `to_deactivate`
<!-- Enumerate changes you made and why you made them -->

## Test Plan
existing unit tests
CI integration tests
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->

<!--
    Final note

    Please take a moment to read through the Magma project's
    - Contributing conventions: https://docs.magmacore.org/docs/next/contributing/contribute_conventions

    If this is your first time opening a PR, also consider reading
    - Developer onboarding: https://docs.magmacore.org/docs/next/contributing/contribute_onboarding
    - Development workflow: https://docs.magmacore.org/docs/next/contributing/contribute_workflow
-->
