### PR TITLE
AGW: ubuntu: python: Fix linter issue related loop arg

### DIFF
--- a/orc8r/gateway/python/magma/common/cert_validity.py
+++ b/orc8r/gateway/python/magma/common/cert_validity.py
@@ -85,7 +85,8 @@ def cert_is_invalid(host, port, certfile, keyfile, loop):
     ssl_coro = create_ssl_connection(host, port, certfile, keyfile, loop)
 
     coros = tcp_coro, ssl_coro
-    res = yield from asyncio.gather(*coros, loop=loop, return_exceptions=True)
+    asyncio.set_event_loop(loop)
+    res = yield from asyncio.gather(*coros, return_exceptions=True)
     tcp_res, ssl_res = res
 
     if isinstance(tcp_res, Exception):


### PR DESCRIPTION
asyncio lib functions no longer needs loop arg on python 3.5.3
onward. ref: https://github.com/python/asyncio/pull/452.

on python 3.8 linter is throwing error due to deprecated arg.
Following patch removes this arg.

Signed-off-by: Pravin B Shelar <pbshelar@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->

## Test Plan
`make test`

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
