### PR TITLE
AGW: pipelineD: set first IP address from UE-IP-Block to gtp-br0

### DIFF
--- a/lte/gateway/configs/pipelined.yml
+++ b/lte/gateway/configs/pipelined.yml
@@ -103,8 +103,6 @@ enodeb_iface: eth1
 
 # Bridge name comes from magma_magmad.service.j2
 bridge_name: gtp_br0
-# Bridge ip comes from magma_ifaces_gtp
-bridge_ip_address: 192.168.128.1
 # For ipv6 router solicitation app
 ipv6_router_addr: 'd88d:aba4:472f:fc95:7e7d:8457:5301:ebce'
 

--- a/lte/gateway/configs/pipelined.yml_prod
+++ b/lte/gateway/configs/pipelined.yml_prod
@@ -104,8 +104,6 @@ dp_router_enabled: true
 
 # Bridge name comes from magma_magmad.service.j2
 bridge_name: gtp_br0
-# Bridge ip comes from magma_ifaces_gtp
-bridge_ip_address: 192.168.128.1
 # For ipv6 router solicitation app
 ipv6_router_addr: 'd88d:aba4:472f:fc95:7e7d:8457:5301:ebce'
 

--- a/lte/gateway/python/magma/pipelined/app/arp.py
+++ b/lte/gateway/python/magma/pipelined/app/arp.py
@@ -65,11 +65,11 @@ class ArpController(MagmaController):
         self.local_eth_addr = kwargs['config']['local_ue_eth_addr']
         self.setup_type = kwargs['config']['setup_type']
         self.allow_unknown_uplink_arps = kwargs['config']['allow_unknown_arps']
-        self.config = self._get_config(kwargs['config'], kwargs['mconfig'])
+        self.config = self._get_config(kwargs['config'])
         self._current_ues = []
         self._datapath = None
 
-    def _get_config(self, config_dict, mconfig):
+    def _get_config(self, config_dict):
         def get_virtual_iface_mac(iface):
             virt_ifaddresses = netifaces.ifaddresses(iface)
             return virt_ifaddresses[netifaces.AF_LINK][0]['addr']
@@ -102,7 +102,7 @@ class ArpController(MagmaController):
             virtual_iface=virtual_iface,
             virtual_mac=virtual_mac,
             # TODO deprecate this, use mobilityD API to get ip-blocks
-            ue_ip_blocks=[cidr_to_ip_netmask_tuple(mconfig.ue_ip_block)],
+            ue_ip_blocks=[cidr_to_ip_netmask_tuple(config_dict['ue_ip_block'])],
             cwf_check_quota_ip=config_dict.get('quota_check_ip', None),
             cwf_bridge_mac=get_virtual_iface_mac(config_dict['bridge_name']),
             mtr_ip=mtr_ip,

--- a/lte/gateway/python/magma/pipelined/bridge_util.py
+++ b/lte/gateway/python/magma/pipelined/bridge_util.py
@@ -12,6 +12,7 @@ limitations under the License.
 """
 import binascii
 import logging
+import ipaddress
 import re
 import subprocess
 from collections import defaultdict
@@ -243,6 +244,11 @@ class BridgeTools:
                 '/'.join(sorted(apps)))
         return annotated_tables
 
+    @staticmethod
+    def get_ip_addr_gtp_br(ue_ip_block):
+        block = ipaddress.ip_network(ue_ip_block)
+        return list(block.hosts())[0]
+
     @classmethod
     def get_annotated_flows_for_bridge(cls, bridge_name: str,
                                        table_assignments: 'Dict[str, Tables]',
@@ -317,3 +323,4 @@ class BridgeTools:
         return [parse_flow(flow) for flow in
                 filter_apps(cls.get_flows_for_bridge(bridge_name,
                     include_stats=include_stats))]
+

--- a/lte/gateway/python/magma/pipelined/main.py
+++ b/lte/gateway/python/magma/pipelined/main.py
@@ -115,6 +115,14 @@ def main():
         mtr_ip = get_ip_from_if(mtr_interface)
         service.config['mtr_ip'] = mtr_ip
 
+    # UE IP range.
+    ue_ip_block = service.config.get('ue_ip_block', None)
+    if service.mconfig.ue_ip_block:
+        ue_ip_block = service.mconfig.ue_ip_block
+    service.config['ue_ip_block'] = ue_ip_block
+
+    service.config['bridge_ip_address'] = BridgeTools.get_ip_addr_gtp_br(ue_ip_block)
+
     # Load the ryu apps
     service_manager = ServiceManager(service)
     service_manager.load()

--- a/lte/gateway/python/magma/pipelined/tests/test_arp.py
+++ b/lte/gateway/python/magma/pipelined/tests/test_arp.py
@@ -103,6 +103,7 @@ class ArpTableTest(unittest.TestCase):
                 'quota_check_ip': '1.2.3.4',
                 'clean_restart': True,
                 'enable_nat': True,
+                'ue_ip_block': cls.UE_BLOCK,
             },
             mconfig=PipelineD(
                 ue_ip_block=cls.UE_BLOCK,

--- a/lte/gateway/python/magma/pipelined/tests/test_arp_non_nat.py
+++ b/lte/gateway/python/magma/pipelined/tests/test_arp_non_nat.py
@@ -136,6 +136,7 @@ class ArpTableTest(unittest.TestCase):
                 'enable_nat': False,
                 'mtr_ip': cls.MTR_IP,
                 'mtr_mac': cls.MTR_MAC,
+                'ue_ip_block': cls.UE_BLOCK,
             },
             mconfig=PipelineD(
                 ue_ip_block=cls.UE_BLOCK,
@@ -322,6 +323,7 @@ class ArpTableTestRouterIP(unittest.TestCase):
                 'enable_nat': False,
                 'mtr_ip': cls.MTR_IP,
                 'mtr_mac': cls.MTR_MAC,
+                'ue_ip_block': cls.UE_BLOCK,
             },
             mconfig=PipelineD(
                 ue_ip_block=cls.UE_BLOCK,

--- a/lte/gateway/python/magma/pipelined/tests/test_check_quota.py
+++ b/lte/gateway/python/magma/pipelined/tests/test_check_quota.py
@@ -39,6 +39,7 @@ class UEMacAddressTest(unittest.TestCase):
     BRIDGE_IP = '192.168.130.1'
     DPI_PORT = 'mon1'
     DPI_IP = '1.1.1.1'
+    UE_BLOCK = '192.168.128.0/24'
 
     @classmethod
     @unittest.mock.patch('netifaces.ifaddresses',
@@ -95,6 +96,7 @@ class UEMacAddressTest(unittest.TestCase):
                     'mon_port_number': 32769,
                     'idle_timeout': 42,
                 },
+                'ue_ip_block': cls.UE_BLOCK,
             },
             mconfig=PipelineD(
                 ue_ip_block='192.168.128.0/24',

--- a/lte/gateway/python/magma/pipelined/tests/test_cwf_restart_resilience.py
+++ b/lte/gateway/python/magma/pipelined/tests/test_cwf_restart_resilience.py
@@ -111,6 +111,7 @@ class CWFRestartResilienceTest(unittest.TestCase):
                     'mon_port_number': 32769,
                     'idle_timeout': 42,
                 },
+                'ue_ip_block': cls.UE_BLOCK,
             },
             mconfig=PipelineD(
                 ue_ip_block=cls.UE_BLOCK,

--- a/lte/gateway/python/magma/pipelined/tests/test_gy.py
+++ b/lte/gateway/python/magma/pipelined/tests/test_gy.py
@@ -63,6 +63,7 @@ class GYTableTest(unittest.TestCase):
     BRIDGE = 'testing_br'
     IFACE = 'testing_br'
     MAC_DEST = "5e:cc:cc:b1:49:4b"
+    UE_BLOCK = '192.168.128.0/24'
 
     @classmethod
     @unittest.mock.patch('netifaces.ifaddresses',
@@ -114,6 +115,7 @@ class GYTableTest(unittest.TestCase):
                 'qos': {'enable': False},
                 'dpi': {'enable': False},
                 'clean_restart': True,
+                'ue_ip_block': cls.UE_BLOCK,
             },
             mconfig=PipelineD(
                 ue_ip_block='192.168.128.0/24'

--- a/lte/gateway/python/magma/pipelined/tests/test_inout.py
+++ b/lte/gateway/python/magma/pipelined/tests/test_inout.py
@@ -35,6 +35,7 @@ class InOutTest(unittest.TestCase):
     IFACE = 'testing_br'
     MAC_DEST = "5e:cc:cc:b1:49:4b"
     BRIDGE_IP = '192.168.128.1'
+    UE_BLOCK = '192.168.128.0/24'
 
     @classmethod
     def setUpClass(cls):
@@ -70,7 +71,8 @@ class InOutTest(unittest.TestCase):
                 'clean_restart': True,
                 'enable_nat': True,
                 'uplink_gw_mac': '11:22:33:44:55:66',
-                'uplink_port': OFPP_LOCAL
+                'uplink_port': OFPP_LOCAL,
+                'ue_ip_block': cls.UE_BLOCK,
             },
             mconfig=None,
             loop=None,
@@ -99,6 +101,7 @@ class InOutTestLTE(unittest.TestCase):
     IFACE = 'testing_br'
     MAC_DEST = "5e:cc:cc:b1:49:4b"
     BRIDGE_IP = '192.168.128.1'
+    UE_BLOCK = '192.168.128.0/24'
 
     @classmethod
     def setUpClass(cls):
@@ -137,7 +140,8 @@ class InOutTestLTE(unittest.TestCase):
                 'uplink_gw_mac': '11:22:33:44:55:66',
                 'mtr_ip': '1.2.3.4',
                 'ovs_mtr_port_number': 211,
-                'uplink_port': OFPP_LOCAL
+                'uplink_port': OFPP_LOCAL,
+                'ue_ip_block': cls.UE_BLOCK,
             },
             mconfig=None,
             loop=None,
@@ -166,6 +170,7 @@ class InOutTestXWF(unittest.TestCase):
     IFACE = 'testing_br'
     MAC_DEST = "5e:cc:cc:b1:49:4b"
     BRIDGE_IP = '192.168.128.1'
+    UE_BLOCK = '192.168.128.0/24'
 
     @classmethod
     def setUpClass(cls):
@@ -200,7 +205,8 @@ class InOutTestXWF(unittest.TestCase):
                 'bridge_ip_address': cls.BRIDGE_IP,
                 'ovs_gtp_port_number': 32768,
                 'clean_restart': True,
-                'uplink_port': OFPP_LOCAL
+                'uplink_port': OFPP_LOCAL,
+                'ue_ip_block': cls.UE_BLOCK,
             },
             mconfig=None,
             loop=None,

--- a/lte/gateway/python/magma/pipelined/tests/test_inout_non_nat.py
+++ b/lte/gateway/python/magma/pipelined/tests/test_inout_non_nat.py
@@ -69,6 +69,7 @@ class InOutNonNatTest(unittest.TestCase):
     UPLINK_BR = "up_inout_br0"
     DHCP_PORT = "tino_dhcp"
     UPLINK_VLAN_SW = "vlan_inout"
+    UE_BLOCK = '192.168.128.0/24'
 
     @classmethod
     def setup_uplink_br(cls):
@@ -157,6 +158,7 @@ class InOutNonNatTest(unittest.TestCase):
                 'non_nat_arp_egress_port': non_nat_arp_egress_port,
                 'uplink_port': patch_up_port_no,
                 'uplink_gw_mac': gw_mac_addr,
+                'ue_ip_block': cls.UE_BLOCK,
             },
             mconfig=None,
             loop=None,
@@ -345,6 +347,7 @@ class InOutTestNonNATBasicFlows(unittest.TestCase):
     IFACE = 'testing_br'
     MAC_DEST = "5e:cc:cc:b1:49:4b"
     BRIDGE_IP = '192.168.128.1'
+    UE_BLOCK = '192.168.128.0/24'
 
     @classmethod
     def setUpClass(cls):
@@ -380,7 +383,8 @@ class InOutTestNonNATBasicFlows(unittest.TestCase):
                 'clean_restart': True,
                 'enable_nat': False,
                 'uplink_gw_mac': '11:22:33:44:55:66',
-                'uplink_port': OFPP_LOCAL
+                'uplink_port': OFPP_LOCAL,
+                'ue_ip_block': cls.UE_BLOCK,
             },
             mconfig=None,
             loop=None,

--- a/lte/gateway/python/magma/pipelined/tests/test_internal_pkt_ipfix_export.py
+++ b/lte/gateway/python/magma/pipelined/tests/test_internal_pkt_ipfix_export.py
@@ -40,6 +40,7 @@ class InternalPktIpfixExportTest(unittest.TestCase):
     BRIDGE_IP = '192.168.128.1'
     DPI_PORT = 'mon1'
     DPI_IP = '1.1.1.1'
+    UE_BLOCK = '192.168.128.0/24'
 
     @classmethod
     def setUpClass(cls):
@@ -94,6 +95,7 @@ class InternalPktIpfixExportTest(unittest.TestCase):
                     'mon_port_number': 32769,
                     'idle_timeout': 42,
                 },
+                'ue_ip_block': cls.UE_BLOCK,
             },
             mconfig=PipelineD(),
             loop=None,

--- a/lte/gateway/python/magma/pipelined/tests/test_li_mirror.py
+++ b/lte/gateway/python/magma/pipelined/tests/test_li_mirror.py
@@ -40,6 +40,7 @@ class LIMirrorTest(unittest.TestCase):
     BRIDGE_IP = '192.168.128.1'
     LI_LOCAL_IP = '1.1.1.1'
     LI_DST_IP = '2.2.3.3'
+    UE_BLOCK = '192.168.128.0/24'
 
     @classmethod
     def setUpClass(cls):
@@ -82,7 +83,8 @@ class LIMirrorTest(unittest.TestCase):
                 'li_mirror_all': True,
                 'li_local_iface': cls.LI_LOCAL_IFACE,
                 'li_dst_iface': cls.LI_DST_IFACE,
-                'uplink_port': OFPP_LOCAL
+                'uplink_port': OFPP_LOCAL,
+                'ue_ip_block': cls.UE_BLOCK
             },
             mconfig=None,
             loop=None,

--- a/lte/gateway/python/magma/pipelined/tests/test_ue_mac.py
+++ b/lte/gateway/python/magma/pipelined/tests/test_ue_mac.py
@@ -44,6 +44,7 @@ class UEMacAddressTest(unittest.TestCase):
     BRIDGE_IP = '192.168.130.1'
     DPI_PORT = 'mon1'
     DPI_IP = '1.1.1.1'
+    UE_BLOCK = '192.168.128.0/24'
 
     @classmethod
     def setUpClass(cls):
@@ -89,6 +90,7 @@ class UEMacAddressTest(unittest.TestCase):
                     'mon_port_number': 32769,
                     'idle_timeout': 42,
                 },
+                'ue_ip_block': cls.UE_BLOCK,
             },
             mconfig=None,
             loop=None,

--- a/lte/gateway/python/magma/pipelined/tests/test_ue_passthrough.py
+++ b/lte/gateway/python/magma/pipelined/tests/test_ue_passthrough.py
@@ -53,6 +53,7 @@ class UEMacAddressTest(unittest.TestCase):
     BRIDGE_IP = '192.168.130.1'
     DPI_PORT = 'mon1'
     DPI_IP = '1.1.1.1'
+    UE_BLOCK = '192.168.128.0/24'
 
     @classmethod
     @unittest.mock.patch('netifaces.ifaddresses',
@@ -113,9 +114,10 @@ class UEMacAddressTest(unittest.TestCase):
                     'idle_timeout': 42,
                 },
                 'uplink_port': OFPP_LOCAL,
+                'ue_ip_block': cls.UE_BLOCK,
             },
             mconfig=PipelineD(
-                ue_ip_block="192.168.128.0/24",
+                ue_ip_block=cls.UE_BLOCK,
             ),
             loop=None,
             service_manager=cls.service_manager,


### PR DESCRIPTION
Today the IP address is hardcoded in config file. This patch sets the
IP address from configured UE IP block.
This safely allow any CIDR as a UE block.

Signed-off-by: Pravin B Shelar <pbshelar@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->

## Test Plan
`make test`
sanity integ tests.

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
