### PR TITLE
devops: Turn off Golang dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,3 @@ updates:
   directory: nms/app
   schedule:
     interval: daily
-- package-ecosystem: gomod
-  directory: orc8r/cloud/go
-  schedule:
-    interval: daily


### PR DESCRIPTION
## Summary

Dependabot PRs will always fail insync-checkin. Until we determine a solution for that (not high-pri), turning off to avoid noise.

## Test Plan

## Additional Information

- [ ] This change is backwards-breaking