### PR TITLE
[mme] Modify directoryd api to include fields

### DIFF
--- a/lte/gateway/c/oai/lib/directoryd/GatewayDirectorydClient.cpp
+++ b/lte/gateway/c/oai/lib/directoryd/GatewayDirectorydClient.cpp
@@ -57,22 +57,26 @@ GatewayDirectoryServiceClient::GatewayDirectoryServiceClient() {
 bool GatewayDirectoryServiceClient::UpdateRecord(
     const std::string& id, const std::string& location,
     std::function<void(Status, Void)> callback) {
-  GatewayDirectoryServiceClient& client = get_instance();
-
   UpdateRecordRequest request;
-  Void response;
-
   request.set_id(id);
   request.set_location(location);
+  return GatewayDirectoryServiceClient::updateRecordImpl(request, callback);
+}
 
-  // No values for fields param in UpdateRecord
-  auto fields = request.fields();
-  std::unordered_map<std::string, std::string> fields_map;
+bool GatewayDirectoryServiceClient::UpdateRecordField(
+    const std::string& id, const std::string& field_key,
+    const std::string& field_value,
+    std::function<void(Status, Void)> callback) {
+  UpdateRecordRequest request;
+  request.set_id(id);
+  auto update_fields = request.mutable_fields();
+  update_fields->insert({field_key, field_value});
+  return GatewayDirectoryServiceClient::updateRecordImpl(request, callback);
+}
 
-  Map<std::string, std::string> proto_fields(
-      fields_map.begin(), fields_map.end());
-  fields = proto_fields;
-
+bool GatewayDirectoryServiceClient::updateRecordImpl(
+    UpdateRecordRequest& request, std::function<void(Status, Void)> callback) {
+  GatewayDirectoryServiceClient& client = get_instance();
   // Create a raw response pointer that stores a callback to be called when the
   // gRPC call is answered
   auto local_response =

--- a/lte/gateway/c/oai/lib/directoryd/GatewayDirectorydClient.h
+++ b/lte/gateway/c/oai/lib/directoryd/GatewayDirectorydClient.h
@@ -53,8 +53,17 @@ class GatewayDirectoryServiceClient : public GRPCReceiver {
       const std::string& id, const std::string& location,
       std::function<void(Status, Void)> callback);
 
+  static bool UpdateRecordField(
+      const std::string& id, const std::string& field_key,
+      const std::string& field_value,
+      std::function<void(Status, Void)> callback);
+
   static bool DeleteRecord(
       const std::string& id, std::function<void(Status, Void)> callback);
+
+ private:
+  static bool updateRecordImpl(
+      UpdateRecordRequest& request, std::function<void(Status, Void)> callback);
 
  public:
   GatewayDirectoryServiceClient(GatewayDirectoryServiceClient const&) = delete;

--- a/lte/gateway/c/oai/lib/directoryd/directoryd.cpp
+++ b/lte/gateway/c/oai/lib/directoryd/directoryd.cpp
@@ -54,6 +54,16 @@ bool directoryd_update_location(char* imsi, char* location) {
   return true;
 }
 
+bool directoryd_update_field(char* imsi, char* key, char* value) {
+  // Actual GW_ID will be filled in the cloud
+  magma::GatewayDirectoryServiceClient::UpdateRecordField(
+      "IMSI" + std::string(imsi), std::string(key), std::string(value),
+      [&](grpc::Status status, magma::Void response) {
+        directoryd_rpc_call_done(status);
+      });
+  return true;
+}
+
 void directoryd_rpc_call_done(const grpc::Status& status) {
   if (!status.ok()) {
     std::cerr << "Directoryd RPC failed with code " << status.error_code()

--- a/lte/gateway/c/oai/lib/directoryd/directoryd.cpp
+++ b/lte/gateway/c/oai/lib/directoryd/directoryd.cpp
@@ -54,7 +54,7 @@ bool directoryd_update_location(char* imsi, char* location) {
   return true;
 }
 
-bool directoryd_update_field(char* imsi, char* key, char* value) {
+bool directoryd_update_record_field(char* imsi, char* key, char* value) {
   // Actual GW_ID will be filled in the cloud
   magma::GatewayDirectoryServiceClient::UpdateRecordField(
       "IMSI" + std::string(imsi), std::string(key), std::string(value),

--- a/lte/gateway/c/oai/lib/directoryd/directoryd.h
+++ b/lte/gateway/c/oai/lib/directoryd/directoryd.h
@@ -36,6 +36,8 @@ bool directoryd_remove_location(char* imsi);
 
 bool directoryd_update_location(char* imsi, char* location);
 
+bool directoryd_update_field(char* imsi, char* key, char* value);
+
 #ifdef __cplusplus
 }
 #endif

--- a/lte/gateway/c/oai/lib/directoryd/directoryd.h
+++ b/lte/gateway/c/oai/lib/directoryd/directoryd.h
@@ -36,7 +36,7 @@ bool directoryd_remove_location(char* imsi);
 
 bool directoryd_update_location(char* imsi, char* location);
 
-bool directoryd_update_field(char* imsi, char* key, char* value);
+bool directoryd_update_record_field(char* imsi, char* key, char* value);
 
 #ifdef __cplusplus
 }

--- a/lte/gateway/c/oai/tasks/sgw_s8/sgw_s8_handlers.c
+++ b/lte/gateway/c/oai/tasks/sgw_s8/sgw_s8_handlers.c
@@ -25,6 +25,8 @@ limitations under the License.
 #include "gtpv1u.h"
 #include "dynamic_memory_check.h"
 #include "sgw_handlers.h"
+#include "directoryd.h"
+#include "conversions.h"
 
 extern task_zmq_ctx_t sgw_s8_task_zmq_ctx;
 extern struct gtp_tunnel_ops* gtp_tunnel_ops;
@@ -506,6 +508,13 @@ void sgw_s8_handle_create_session_response(
     sgw_remove_sgw_bearer_context_information(
         sgw_state, session_rsp_p->context_teid, imsi64);
   }
+
+  char imsi_str[IMSI_BCD_DIGITS_MAX + 1];
+  IMSI64_TO_STRING(imsi64, (char*) imsi_str, IMSI_BCD_DIGITS_MAX);
+  char teidString[16];
+  sprintf(teidString, "%u", session_rsp_p->context_teid);
+  directoryd_update_field(imsi_str, "sgw_c_teid", teidString);
+
   OAILOG_FUNC_OUT(LOG_SGW_S8);
 }
 

--- a/lte/gateway/c/oai/tasks/sgw_s8/sgw_s8_handlers.c
+++ b/lte/gateway/c/oai/tasks/sgw_s8/sgw_s8_handlers.c
@@ -25,8 +25,6 @@ limitations under the License.
 #include "gtpv1u.h"
 #include "dynamic_memory_check.h"
 #include "sgw_handlers.h"
-#include "directoryd.h"
-#include "conversions.h"
 
 extern task_zmq_ctx_t sgw_s8_task_zmq_ctx;
 extern struct gtp_tunnel_ops* gtp_tunnel_ops;
@@ -508,13 +506,6 @@ void sgw_s8_handle_create_session_response(
     sgw_remove_sgw_bearer_context_information(
         sgw_state, session_rsp_p->context_teid, imsi64);
   }
-
-  char imsi_str[IMSI_BCD_DIGITS_MAX + 1];
-  IMSI64_TO_STRING(imsi64, (char*) imsi_str, IMSI_BCD_DIGITS_MAX);
-  char teidString[16];
-  sprintf(teidString, "%u", session_rsp_p->context_teid);
-  directoryd_update_field(imsi_str, "sgw_c_teid", teidString);
-
   OAILOG_FUNC_OUT(LOG_SGW_S8);
 }
 


### PR DESCRIPTION
Signed-off-by: Oriol Batalla <obatalla@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary

This PRs adds the ability on directoryd client at MME to add store fields 

This results on directoryd entries like
```
{
  "identifiers": {
    "sgw_c_teid": "1"
  },
  "location_history": [
    "d35eb697-ad83-4dee-a049-6e15273dd0ee"
  ],
  "py/object": "magma.directoryd.rpc_servicer.DirectoryRecord"
}
```

Right now this is just an easy way to have teid available on directoryd. This way we can see the feasibility of finding a subscriber based on TEID from the FEG. 

As you can see the record has teid and location_history (AGW HwID). So the FEG should be able to find the AGW just with a TEID.

The idea is to add the `sgw_c_teid` every time we create session for a subscriber.
The whole record will be deleted on delete_session.

The entries at `sgw_c_teid` will be modified every time there is a addition or deletion of default bearer (this is still pending to find out where in the code place it)


Note right now AGW assigns TEID starting from 1. We will change this to a random assignment at https://github.com/magma/magma/issues/6829


## Test Plan

make test
## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
