### PR TITLE
[lte] [agw] Add unit test for attach request decoding

### DIFF
--- a/lte/gateway/c/oai/test/mme_app_task/CMakeLists.txt
+++ b/lte/gateway/c/oai/test/mme_app_task/CMakeLists.txt
@@ -17,18 +17,35 @@ find_package(Check REQUIRED)
 find_package(Threads REQUIRED)
 
 include_directories("/usr/src/googletest/googlemock/include/")
+link_directories(/usr/src/googletest/googlemock/lib/)
+
 set(MME_APP_UE_CONTEXT_IMSI_SRC
     test_mme_app_ue_context.c
     )
+set(MME_APP_EMM_DECODE_SRC
+    test_mme_app_emm_decode.cpp
+    )
 
 add_executable(test_mme_app_ue_context_imsi ${MME_APP_UE_CONTEXT_IMSI_SRC})
+add_executable(test_mme_app_emm_decode ${MME_APP_EMM_DECODE_SRC})
+
 target_link_libraries(test_mme_app_ue_context_imsi
     TASK_MME_APP ${CHECK_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT}
     LIB_BSTR LIB_HASHTABLE
     )
+target_link_libraries(test_mme_app_emm_decode
+    TASK_MME_APP TASK_NAS ${CHECK_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT}
+    LIB_BSTR gtest gtest_main
+    )
+
 target_include_directories(test_mme_app_ue_context_imsi PUBLIC
+    ${CMAKE_CURRENT_SOURCE_DIR}
+    ${CHECK_INCLUDE_DIRS}
+    )
+target_include_directories(test_mme_app_emm_decode PUBLIC
     ${CMAKE_CURRENT_SOURCE_DIR}
     ${CHECK_INCLUDE_DIRS}
     )
 
 add_test(NAME test_mme_app_ue_context COMMAND test_mme_app_ue_context_imsi)
+add_test(NAME test_mme_app_emm_decode COMMAND test_mme_app_emm_decode)

--- a/lte/gateway/c/oai/test/mme_app_task/test_mme_app_emm_decode.cpp
+++ b/lte/gateway/c/oai/test/mme_app_task/test_mme_app_emm_decode.cpp
@@ -18,9 +18,9 @@ extern "C" {
 #include "log.h"
 }
 
-class EMMDecodeTest : public ::testing::Test{
-virtual void SetUp() {}
-virtual void TearDown() {}
+class EMMDecodeTest : public ::testing::Test {
+  virtual void SetUp() {}
+  virtual void TearDown() {}
 };
 
 TEST_F(EMMDecodeTest, TestDecodeAttachRequest1) {
@@ -31,7 +31,6 @@ TEST_F(EMMDecodeTest, TestDecodeAttachRequest1) {
                       0x04, 0x00, 0x02, 0x1c, 0x00};
   uint32_t len     = 29;
   attach_request_msg attach_request;
- 
 
   int rc = decode_attach_request(&attach_request, buffer, len);
   ASSERT_EQ(rc, len);
@@ -41,7 +40,6 @@ TEST_F(EMMDecodeTest, TestDecodeAttachRequest1) {
 
   bdestroy_wrapper(&attach_request.esmmessagecontainer);
 }
-
 
 TEST_F(EMMDecodeTest, TestDecodeAttachRequest2) {
   //   Combined attach, NAS message generated from Pixel 4
@@ -72,5 +70,5 @@ TEST_F(EMMDecodeTest, TestDecodeAttachRequest2) {
 int main(int argc, char** argv) {
   ::testing::InitGoogleTest(&argc, argv);
   OAILOG_INIT("MME", OAILOG_LEVEL_DEBUG, MAX_LOG_PROTOS);
-  return RUN_ALL_TESTS(); 
+  return RUN_ALL_TESTS();
 }

--- a/lte/gateway/c/oai/test/mme_app_task/test_mme_app_emm_decode.cpp
+++ b/lte/gateway/c/oai/test/mme_app_task/test_mme_app_emm_decode.cpp
@@ -1,0 +1,76 @@
+/**
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <gtest/gtest.h>
+
+extern "C" {
+#include "AttachRequest.h"
+#include "dynamic_memory_check.h"
+#include "log.h"
+}
+
+class EMMDecodeTest : public ::testing::Test{
+virtual void SetUp() {}
+virtual void TearDown() {}
+};
+
+TEST_F(EMMDecodeTest, TestDecodeAttachRequest1) {
+  //   Combined attach, NAS message generated from s1ap tester
+  uint8_t buffer[] = {0x72, 0x08, 0x09, 0x10, 0x10, 0x00, 0x00, 0x00,
+                      0x00, 0x10, 0x02, 0xe0, 0xe0, 0x00, 0x04, 0x02,
+                      0x01, 0xd0, 0x11, 0x40, 0x08, 0x04, 0x02, 0x60,
+                      0x04, 0x00, 0x02, 0x1c, 0x00};
+  uint32_t len     = 29;
+  attach_request_msg attach_request;
+ 
+
+  int rc = decode_attach_request(&attach_request, buffer, len);
+  ASSERT_EQ(rc, len);
+  ASSERT_EQ(attach_request.epsattachtype, 2);
+  ASSERT_EQ(attach_request.naskeysetidentifier.naskeysetidentifier, 7);
+  ASSERT_EQ(attach_request.naskeysetidentifier.tsc, 0);
+
+  bdestroy_wrapper(&attach_request.esmmessagecontainer);
+}
+
+
+TEST_F(EMMDecodeTest, TestDecodeAttachRequest2) {
+  //   Combined attach, NAS message generated from Pixel 4
+  uint8_t buffer[] = {
+      0x72, 0x08, 0x39, 0x51, 0x10, 0x00, 0x30, 0x09, 0x01, 0x07, 0x07, 0xf0,
+      0x70, 0xc0, 0x40, 0x19, 0x00, 0x80, 0x00, 0x34, 0x02, 0x0c, 0xd0, 0x11,
+      0xd1, 0x27, 0x2d, 0x80, 0x80, 0x21, 0x10, 0x01, 0x00, 0x00, 0x10, 0x81,
+      0x06, 0x00, 0x00, 0x00, 0x00, 0x83, 0x06, 0x00, 0x00, 0x00, 0x00, 0x00,
+      0x0d, 0x00, 0x00, 0x0a, 0x00, 0x00, 0x05, 0x00, 0x00, 0x10, 0x00, 0x00,
+      0x11, 0x00, 0x00, 0x1a, 0x01, 0x01, 0x00, 0x23, 0x00, 0x00, 0x24, 0x00,
+      0x5c, 0x0a, 0x01, 0x31, 0x04, 0x65, 0xe0, 0x3e, 0x00, 0x90, 0x11, 0x03,
+      0x57, 0x58, 0xa6, 0x20, 0x0d, 0x60, 0x14, 0x04, 0xef, 0x65, 0x23, 0x3b,
+      0x88, 0x00, 0x92, 0xf2, 0x00, 0x00, 0x40, 0x08, 0x04, 0x02, 0x60, 0x04,
+      0x00, 0x02, 0x1f, 0x00, 0x5d, 0x01, 0x03, 0xc1};
+
+  uint32_t len = 116;
+  attach_request_msg attach_request;
+
+  int rc = decode_attach_request(&attach_request, buffer, len);
+  ASSERT_EQ(rc, len);
+  ASSERT_EQ(attach_request.epsattachtype, 2);
+  ASSERT_EQ(attach_request.naskeysetidentifier.naskeysetidentifier, 7);
+  ASSERT_EQ(attach_request.naskeysetidentifier.tsc, 0);
+
+  bdestroy_wrapper(&attach_request.esmmessagecontainer);
+}
+
+int main(int argc, char** argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  OAILOG_INIT("MME", OAILOG_LEVEL_DEBUG, MAX_LOG_PROTOS);
+  return RUN_ALL_TESTS(); 
+}


### PR DESCRIPTION
Signed-off-by: Ulas Kozat <kozat@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary

Adding two new unit tests for decoding attach requests and provide a seed code for later add ons for other encoding/decoding tests for NAS PDUs.

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->
`make test_oai` and observe the tests are passing:

```
[1962/1962] Linking CXX executable oai_mme/mme
cd  /home/vagrant/build/c//oai && ctest --output-on-failure
Test project /home/vagrant/build/c/oai
    Start 1: test_mme_app_ue_context
1/7 Test #1: test_mme_app_ue_context ..........   Passed    0.06 sec
    Start 2: test_mme_app_emm_decode
2/7 Test #2: test_mme_app_emm_decode ..........   Passed    0.03 sec
    Start 3: test_openflow_controller
3/7 Test #3: test_openflow_controller .........   Passed    0.03 sec
    Start 4: test_imsi_encoder
4/7 Test #4: test_imsi_encoder ................   Passed    0.02 sec
    Start 5: test_gtp_app
5/7 Test #5: test_gtp_app .....................   Passed    0.03 sec
    Start 6: test_spgw_state_converter
6/7 Test #6: test_spgw_state_converter ........   Passed    0.03 sec
    Start 7: test_itti
7/7 Test #7: test_itti ........................   Passed    4.26 sec

100% tests passed, 0 tests failed out of 7

Total Test time (real) =   4.46 sec
```

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
