### PR TITLE
feat: [SessionD] Delay activation for policies with dedicated bearers

### DIFF
--- a/lte/gateway/c/session_manager/AAAClient.cpp
+++ b/lte/gateway/c/session_manager/AAAClient.cpp
@@ -48,7 +48,7 @@ aaa::add_sessions_request create_add_sessions_req(
         continue;
       }
       const auto& wlan_context = config.rat_specific_context.wlan_context();
-      ctx.set_imsi(config.common_context.sid().id());
+      ctx.set_imsi(session->get_imsi());
       ctx.set_session_id(wlan_context.radius_session_id());
       ctx.set_acct_session_id(session->get_session_id());
       ctx.set_mac_addr(wlan_context.mac_addr());

--- a/lte/gateway/c/session_manager/LocalEnforcer.h
+++ b/lte/gateway/c/session_manager/LocalEnforcer.h
@@ -576,14 +576,11 @@ class LocalEnforcer {
    * to the desired new_state and propagate that state PipelineD.
    * @param session
    * @param new_state
-   * @param uc
+   * @param session_uc
    */
   void handle_subscriber_quota_state_change(
       SessionState& session, SubscriberQuotaUpdate_Type new_state,
-      SessionStateUpdateCriteria& uc);
-
-  void handle_subscriber_quota_state_change(
-      SessionState& session, SubscriberQuotaUpdate_Type new_state);
+      SessionStateUpdateCriteria* session_uc);
 
   /**
    * Start the termination process for multiple sessions

--- a/lte/gateway/c/session_manager/LocalEnforcer.h
+++ b/lte/gateway/c/session_manager/LocalEnforcer.h
@@ -184,8 +184,7 @@ class LocalEnforcer {
    * CreateSessionResponse.
    */
   void handle_session_activate_rule_updates(
-      const std::string& imsi, SessionState& session,
-      const CreateSessionResponse& response,
+      SessionState& session, const CreateSessionResponse& response,
       std::unordered_set<uint32_t>& charging_credits_received);
 
   void schedule_session_init_dedicated_bearer_creations(
@@ -387,18 +386,18 @@ class LocalEnforcer {
   /**
    * @brief For rules mentioned in both static_rule_installs and
    * dynamic_rule_installs, classify them into the three RulesToProcess vectors.
-   * to_activate, to_deactivate, to_get_bearer will not intersect in the set of
-   * rules they contain to_schedule may contain some deactivation scheduling for
-   * rules mentioned in the above three sets
+   * pending_activation, pending_deactivation, pending_bearer_setup will not
+   * intersect in the set of rules they contain pending_scheduling may contain
+   * some deactivation scheduling for rules mentioned in the above three sets
    * @param session
    * @param static_rule_installs
    * @param dynamic_rule_installs
-   * @param to_activate contains rules that need to be activated now
-   * @param to_deactivate contains rules that need to be deactivated now
-   * @param to_get_bearer contains rules that need to get dedicated bearers
-   * before they can be activated. The rules will be activated once MME sends a
-   * BindPolicy2Bearer with the dedicated bearer Teids.
-   * @param to_schedule contains rules that need to be scheduled to be
+   * @param pending_activation contains rules that need to be activated now
+   * @param pending_deactivation contains rules that need to be deactivated now
+   * @param pending_bearer_setup contains rules that need to get dedicated
+   * bearers before they can be activated. The rules will be activated once MME
+   * sends a BindPolicy2Bearer with the dedicated bearer Teids.
+   * @param pending_scheduling contains rules that need to be scheduled to be
    * activated/deactivated
    * @param session_uc
    */
@@ -406,22 +405,22 @@ class LocalEnforcer {
       SessionState& session,
       const std::vector<StaticRuleInstall>& static_rule_installs,
       const std::vector<DynamicRuleInstall>& dynamic_rule_installs,
-      RulesToProcess* to_activate, RulesToProcess* to_deactivate,
-      RulesToProcess* to_get_bearer, RulesToSchedule* to_schedule,
+      RulesToProcess* pending_activation, RulesToProcess* pending_deactivation,
+      RulesToProcess* pending_bearer_setup, RulesToSchedule* pending_scheduling,
       SessionStateUpdateCriteria* session_uc);
 
   /**
    * propagate_rule_updates_to_pipelined calls the PipelineD RPC calls to
    * install/uninstall flows
    * @param config
-   * @param to_activate
-   * @param to_deactivate
+   * @param pending_activation
+   * @param pending_deactivation
    * @param always_send_activate : if this is set activate call will be sent
-   * even if to_activate is empty
+   * even if pending_activation is empty
    */
   void propagate_rule_updates_to_pipelined(
-      const SessionConfig& config, const RulesToProcess& to_activate,
-      const RulesToProcess& to_deactivate, bool always_send_activate);
+      const SessionConfig& config, const RulesToProcess& pending_activation,
+      const RulesToProcess& pending_deactivation, bool always_send_activate);
 
   /**
    * @brief for each element in RulesToSchedule, schedule rule
@@ -429,11 +428,11 @@ class LocalEnforcer {
    *
    * @param imsi
    * @param session_id
-   * @param to_schedules
+   * @param pending_scheduling
    */
   void handle_rule_scheduling(
       const std::string& imsi, const std::string& session_id,
-      const RulesToSchedule& to_schedules);
+      const RulesToSchedule& pending_scheduling);
 
   /**
    * For the matching session ID, activate and/or deactivate the specified

--- a/lte/gateway/c/session_manager/LocalEnforcer.h
+++ b/lte/gateway/c/session_manager/LocalEnforcer.h
@@ -510,7 +510,7 @@ class LocalEnforcer {
       const google::protobuf::RepeatedField<int>& event_triggers);
 
   void schedule_revalidation(
-      const std::string& imsi, SessionState& session,
+      SessionState& session,
       const google::protobuf::Timestamp& revalidation_time,
       SessionStateUpdateCriteria& uc);
 
@@ -532,15 +532,14 @@ class LocalEnforcer {
    * 4. Propagate subscriber wallet status
    * 5. Schedule a callback to force termination if termination is not completed
    *    in a set amount of time
-   * @param imsi
    * @param session
    * @param notify_access: bool to determine whether the access component needs
    * notification
    * @param uc
    */
   void start_session_termination(
-      const std::string& imsi, const std::unique_ptr<SessionState>& session,
-      bool notify_access, SessionStateUpdateCriteria& uc);
+      const std::unique_ptr<SessionState>& session, bool notify_access,
+      SessionStateUpdateCriteria& uc);
 
   /**
    * handle_force_termination_timeout is scheduled to run when a termination
@@ -555,12 +554,11 @@ class LocalEnforcer {
   /**
    * remove_all_rules_for_termination talks to PipelineD and removes all rules
    * (Gx/Gy/static/dynamic/everything) attached to the session
-   * @param imsi
    * @param session
    * @param uc
    */
   void remove_all_rules_for_termination(
-      const std::string& imsi, const std::unique_ptr<SessionState>& session,
+      const std::unique_ptr<SessionState>& session,
       SessionStateUpdateCriteria& uc);
 
   /**
@@ -568,28 +566,24 @@ class LocalEnforcer {
    * communicates to the appropriate access client to notify the session's
    * termination.
    * LTE -> MME, WLAN -> AAA
-   * @param imsi
    * @param session_id
    * @param config
    */
   void notify_termination_to_access_service(
-      const std::string& imsi, const std::string& session_id,
-      const SessionConfig& config);
+      const std::string& session_id, const SessionConfig& config);
   /**
    * handle_subscriber_quota_state_change will update the session's wallet state
    * to the desired new_state and propagate that state PipelineD.
-   * @param imsi
    * @param session
    * @param new_state
    * @param uc
    */
   void handle_subscriber_quota_state_change(
-      const std::string& imsi, SessionState& session,
-      SubscriberQuotaUpdate_Type new_state, SessionStateUpdateCriteria& uc);
+      SessionState& session, SubscriberQuotaUpdate_Type new_state,
+      SessionStateUpdateCriteria& uc);
 
   void handle_subscriber_quota_state_change(
-      const std::string& imsi, SessionState& session,
-      SubscriberQuotaUpdate_Type new_state);
+      SessionState& session, SubscriberQuotaUpdate_Type new_state);
 
   /**
    * Start the termination process for multiple sessions
@@ -641,8 +635,7 @@ class LocalEnforcer {
    * Otherwise, mark the subscriber as out of quota to pipelined, and schedule
    * the session to be terminated in a configured amount of time.
    */
-  void handle_session_activate_subscriber_quota_state(
-      const std::string& imsi, SessionState& session);
+  void handle_session_activate_subscriber_quota_state(SessionState& session);
 
   bool is_wallet_exhausted(SessionState& session);
 

--- a/lte/gateway/c/session_manager/LocalSessionManagerHandler.cpp
+++ b/lte/gateway/c/session_manager/LocalSessionManagerHandler.cpp
@@ -244,9 +244,9 @@ void LocalSessionManagerHandlerImpl::CreateSession(
   PrintGrpcMessage(static_cast<const google::protobuf::Message&>(request_cpy));
   enforcer_->get_event_base().runInEventBaseThread(
       [this, context, response_callback, request_cpy]() {
-        const auto& imsi       = request_cpy.common_context().sid().id();
-        const auto& session_id = id_gen_.gen_session_id(imsi);
         SessionConfig cfg(request_cpy);
+        const std::string& imsi = cfg.get_imsi();
+        const auto& session_id  = id_gen_.gen_session_id(imsi);
         log_create_session(cfg);
         if (pipelined_state_ != READY) {
           MLOG(MINFO) << "Rejecting LocalCreateSessionRequest for " << imsi
@@ -296,7 +296,7 @@ void LocalSessionManagerHandlerImpl::send_create_session(
     SessionMap& session_map, const std::string& session_id,
     const SessionConfig& cfg,
     std::function<void(grpc::Status, LocalCreateSessionResponse)> cb) {
-  const auto& imsi = cfg.common_context.sid().id();
+  const auto& imsi = cfg.get_imsi();
   auto create_req  = make_create_session_request(
       cfg, session_id, enforcer_->get_access_timezone());
   MLOG(MINFO) << "Sending a CreateSessionRequest to fetch policies for "
@@ -344,7 +344,7 @@ void LocalSessionManagerHandlerImpl::send_create_session(
 void LocalSessionManagerHandlerImpl::handle_create_session_cwf(
     SessionMap& session_map, const std::string& session_id, SessionConfig cfg,
     std::function<void(Status, LocalCreateSessionResponse)> cb) {
-  auto imsi = cfg.common_context.sid().id();
+  auto imsi = cfg.get_imsi();
 
   auto it = session_map.find(imsi);
   if (it != session_map.end()) {
@@ -387,7 +387,7 @@ void LocalSessionManagerHandlerImpl::recycle_cwf_session(
 void LocalSessionManagerHandlerImpl::handle_create_session_lte(
     SessionMap& session_map, const std::string& session_id, SessionConfig cfg,
     std::function<void(Status, LocalCreateSessionResponse)> cb) {
-  auto imsi = cfg.common_context.sid().id();
+  auto imsi = cfg.get_imsi();
 
   // If there are no existing sessions for the IMSI, just create a new one
   auto it = session_map.find(imsi);
@@ -658,8 +658,8 @@ void LocalSessionManagerHandlerImpl::SetSessionRules(
 }
 
 void LocalSessionManagerHandlerImpl::log_create_session(SessionConfig& cfg) {
-  const auto& imsi = cfg.common_context.sid().id();
-  const auto& apn  = cfg.common_context.apn();
+  const std::string& imsi = cfg.get_imsi();
+  const auto& apn         = cfg.common_context.apn();
   std::string create_message =
       "Received a LocalCreateSessionRequest for " + imsi + " with APN:" + apn;
   if (cfg.rat_specific_context.has_lte_context()) {

--- a/lte/gateway/c/session_manager/SessionEvents.cpp
+++ b/lte/gateway/c/session_manager/SessionEvents.cpp
@@ -119,7 +119,7 @@ void EventsReporterImpl::session_created(
 void EventsReporterImpl::session_create_failure(
     const SessionConfig& session_context, const std::string& failure_reason) {
   auto event             = magma::orc8r::Event();
-  const std::string imsi = session_context.common_context.sid().id();
+  const std::string imsi = session_context.get_imsi();
   event.set_stream_name(SESSIOND_SERVICE_EV);
   event.set_event_type(SESSION_CREATE_FAILURE_EV);
   event.set_tag(imsi);
@@ -146,7 +146,7 @@ void EventsReporterImpl::session_updated(
     const std::string& session_id, const SessionConfig& session_context,
     const UpdateRequests& update_request) {
   auto event             = magma::orc8r::Event();
-  const std::string imsi = session_context.common_context.sid().id();
+  const std::string imsi = session_context.get_imsi();
 
   event.set_stream_name(SESSIOND_SERVICE_EV);
   event.set_event_type(SESSION_UPDATED_EV);
@@ -177,7 +177,7 @@ void EventsReporterImpl::session_update_failure(
     const std::string& session_id, const SessionConfig& session_context,
     const UpdateRequests& failed_request, const std::string& failure_reason) {
   auto event             = magma::orc8r::Event();
-  const std::string imsi = session_context.common_context.sid().id();
+  const std::string imsi = session_context.get_imsi();
 
   event.set_stream_name(SESSIOND_SERVICE_EV);
   event.set_event_type(SESSION_UPDATE_FAILURE_EV);

--- a/lte/gateway/c/session_manager/SessionState.cpp
+++ b/lte/gateway/c/session_manager/SessionState.cpp
@@ -1072,7 +1072,6 @@ RuleToProcess SessionState::make_rule_to_process(const PolicyRule& rule) {
   RuleToProcess to_process;
   to_process.version = get_current_rule_version(rule.id());
   to_process.rule    = rule;
-  to_process.teids   = config_.common_context.teids();
 
   // At this point, we know the rule exists, so just check if it exists in the
   // static rule store or not
@@ -1081,10 +1080,12 @@ RuleToProcess SessionState::make_rule_to_process(const PolicyRule& rule) {
 
   // If there is a dedicated bearer TEID already in map, use it
   PolicyID policy_id = PolicyID(p_type, rule.id());
-  bool bearer_exists =
+  bool dedicated_bearer_exists =
       bearer_id_by_policy_.find(policy_id) != bearer_id_by_policy_.end();
-  if (bearer_exists) {
+  if (dedicated_bearer_exists) {
     to_process.teids = bearer_id_by_policy_[policy_id].teids;
+  } else {
+    to_process.teids = config_.common_context.teids();
   }
 
   return to_process;

--- a/lte/gateway/c/session_manager/SessionState.cpp
+++ b/lte/gateway/c/session_manager/SessionState.cpp
@@ -593,9 +593,11 @@ void SessionState::apply_session_dynamic_rule_set(
 
 void SessionState::set_subscriber_quota_state(
     const magma::lte::SubscriberQuotaUpdate_Type state,
-    SessionStateUpdateCriteria& update_criteria) {
-  update_criteria.updated_subscriber_quota_state = state;
-  subscriber_quota_state_                        = state;
+    SessionStateUpdateCriteria* session_uc) {
+  if (session_uc != nullptr) {
+    session_uc->updated_subscriber_quota_state = state;
+  }
+  subscriber_quota_state_ = state;
 }
 
 bool SessionState::active_monitored_rules_exist() {

--- a/lte/gateway/c/session_manager/SessionState.cpp
+++ b/lte/gateway/c/session_manager/SessionState.cpp
@@ -63,7 +63,7 @@ StoredSessionState SessionState::marshal() {
 
   marshaled.fsm_state  = curr_state_;
   marshaled.config     = config_;
-  marshaled.imsi       = imsi_;
+  marshaled.imsi       = get_imsi();
   marshaled.session_id = session_id_;
   marshaled.local_teid = local_teid_;
   // 5G session version handling
@@ -287,7 +287,7 @@ void SessionState::sess_infocopy(struct SessionInfo* info) {
   std::string imsi_num;
   // TODO we cud eventually  migrate to SMF-UPF proto enum directly.
   info->state = get_proto_fsm_state();
-  info->subscriber_id.assign(imsi_);
+  info->subscriber_id.assign(get_imsi());
   info->ver_no              = get_current_version();
   info->nodeId.node_id_type = SessionInfo::IPv4;
   strcpy(info->nodeId.node_id, "192.168.2.1");
@@ -661,7 +661,7 @@ void SessionState::add_common_fields_to_usage_monitor_update(
     UsageMonitoringUpdateRequest* req) {
   req->set_session_id(session_id_);
   req->set_request_number(request_number_);
-  req->set_sid(imsi_);
+  req->set_sid(get_imsi());
   req->set_ue_ipv4(config_.common_context.ue_ipv4());
   req->set_rat_type(config_.common_context.rat_type());
   fill_protos_tgpp_context(req->mutable_tgpp_ctx());
@@ -831,7 +831,7 @@ bool SessionState::is_radius_cwf_session() const {
 }
 
 void SessionState::get_session_info(SessionState::SessionInfo& info) {
-  info.imsi      = imsi_;
+  info.imsi      = get_imsi();
   info.ip_addr   = config_.common_context.ue_ipv4();
   info.ipv6_addr = config_.common_context.ue_ipv6();
   info.teids     = config_.common_context.teids();
@@ -1820,7 +1820,7 @@ optional<CreditUsageUpdate> SessionState::get_update_for_continue_service(
   }
 
   // Create Update struct
-  MLOG(MDEBUG) << "Subscriber " << imsi_ << " rating group " << key
+  MLOG(MDEBUG) << "Subscriber " << get_imsi() << " rating group " << key
                << " updating due to type "
                << credit_update_type_to_str(update_type)
                << " with request number " << request_number_;
@@ -1924,10 +1924,10 @@ void SessionState::fill_service_action_for_redirect(
 void SessionState::fill_service_action_with_context(
     std::unique_ptr<ServiceAction>& action, ServiceActionType action_type,
     const CreditKey& key) {
-  MLOG(MDEBUG) << "Subscriber " << imsi_ << " rating group " << key
+  MLOG(MDEBUG) << "Subscriber " << get_imsi() << " rating group " << key
                << " action type " << service_action_type_to_str(action_type);
   action->set_credit_key(key);
-  action->set_imsi(imsi_);
+  action->set_imsi(get_imsi());
   action->set_ambr(config_.get_apn_ambr());
   action->set_ip_addr(config_.common_context.ue_ipv4());
   action->set_ipv6_addr(config_.common_context.ue_ipv6());
@@ -2088,13 +2088,13 @@ bool SessionState::init_new_monitor(
     const UsageMonitoringUpdateResponse& update,
     SessionStateUpdateCriteria& update_criteria) {
   if (!update.success()) {
-    MLOG(MERROR) << "Monitoring init failed for imsi " << imsi_
+    MLOG(MERROR) << "Monitoring init failed for imsi " << get_imsi()
                  << " and monitoring key " << update.credit().monitoring_key();
     return false;
   }
   if (update.credit().action() == UsageMonitoringCredit::DISABLE) {
     MLOG(MWARNING) << "Monitoring init has action disabled for subscriber "
-                   << imsi_ << " and monitoring key "
+                   << get_imsi() << " and monitoring key "
                    << update.credit().monitoring_key();
     return false;
   }

--- a/lte/gateway/c/session_manager/SessionState.h
+++ b/lte/gateway/c/session_manager/SessionState.h
@@ -277,7 +277,7 @@ class SessionState {
 
   void set_subscriber_quota_state(
       const magma::lte::SubscriberQuotaUpdate_Type state,
-      SessionStateUpdateCriteria& update_criteria);
+      SessionStateUpdateCriteria* update_criteria);
 
   bool active_monitored_rules_exist();
 

--- a/lte/gateway/c/session_manager/SessionState.h
+++ b/lte/gateway/c/session_manager/SessionState.h
@@ -940,6 +940,17 @@ class SessionState {
   void increment_rule_stats(
       const std::string& rule_id, SessionStateUpdateCriteria& session_uc);
 
+  /**
+   * @brief Given a policy (to_process) append to either pending_activation or
+   * pending_bearer_setup If a dedicated bearer needs to be created for the
+   * policy, it will be appended to pending_bearer_setup. Otherwise, it will be
+   * appended to pending_activation
+   *
+   * @param to_process
+   * @param p_type
+   * @param pending_activation output parameter
+   * @param pending_bearer_setup output parameter
+   */
   void classify_policy_activation(
       const RuleToProcess& to_process, const PolicyType p_type,
       RulesToProcess* pending_activation, RulesToProcess* pending_bearer_setup);

--- a/lte/gateway/c/session_manager/Types.h
+++ b/lte/gateway/c/session_manager/Types.h
@@ -39,6 +39,7 @@ struct SessionConfig {
   explicit SessionConfig(const LocalCreateSessionRequest& request);
   bool operator==(const SessionConfig& config) const;
   std::experimental::optional<AggregatedMaximumBitrate> get_apn_ambr() const;
+  std::string get_imsi() const { return common_context.sid().id(); }
 };
 
 // Session Credit

--- a/lte/gateway/c/session_manager/test/Matchers.h
+++ b/lte/gateway/c/session_manager/test/Matchers.h
@@ -57,6 +57,23 @@ MATCHER_P(CheckRuleNames, list_static_rules, "") {
   return true;
 }
 
+MATCHER_P(CheckRulesToProcess, expected, "") {
+  std::vector<RuleToProcess> to_process = arg;
+  // basic size check
+  if (to_process.size() != expected.size()) {
+    return false;
+  }
+  for (RuleToProcess val : to_process) {
+    for (uint32_t i = 0; i < expected.size(); i++) {
+      if (val.rule.id() == expected[i].rule.id()) {
+        // check teids
+        return val.teids == expected[i].teids;
+      }
+    }
+  }
+  return false;
+}
+
 MATCHER_P(CheckTeids, configured_teids, "") {
   Teids pipelined_req_teids = static_cast<const Teids>(arg);
 

--- a/lte/gateway/c/session_manager/test/ProtobufCreators.cpp
+++ b/lte/gateway/c/session_manager/test/ProtobufCreators.cpp
@@ -392,21 +392,30 @@ void create_session_create_response(
   }
 }
 
-void create_policy_rule(
-    const std::string& rule_id, const std::string& m_key, uint32_t rating_group,
-    PolicyRule* rule) {
-  rule->set_id(rule_id);
-  rule->set_rating_group(rating_group);
-  rule->set_monitoring_key(m_key);
-  if (rating_group == 0 && m_key.length() > 0) {
-    rule->set_tracking_type(PolicyRule::ONLY_PCRF);
-  } else if (rating_group > 0 && m_key.length() == 0) {
-    rule->set_tracking_type(PolicyRule::ONLY_OCS);
-  } else if (rating_group > 0 && m_key.length() > 0) {
-    rule->set_tracking_type(PolicyRule::OCS_AND_PCRF);
+PolicyRule create_policy_rule(
+    const std::string& rule_id, const std::string& m_key, const uint32_t rg) {
+  PolicyRule rule;
+  rule.set_id(rule_id);
+  rule.set_rating_group(rg);
+  rule.set_monitoring_key(m_key);
+  if (rg == 0 && m_key.length() > 0) {
+    rule.set_tracking_type(PolicyRule::ONLY_PCRF);
+  } else if (rg > 0 && m_key.length() == 0) {
+    rule.set_tracking_type(PolicyRule::ONLY_OCS);
+  } else if (rg > 0 && m_key.length() > 0) {
+    rule.set_tracking_type(PolicyRule::OCS_AND_PCRF);
   } else {
-    rule->set_tracking_type(PolicyRule::NO_TRACKING);
+    rule.set_tracking_type(PolicyRule::NO_TRACKING);
   }
+  return rule;
+}
+
+PolicyRule create_policy_rule_with_qos(
+    const std::string& rule_id, const std::string& m_key, const uint32_t rg,
+    const int qci) {
+  PolicyRule rule = create_policy_rule(rule_id, m_key, rg);
+  rule.mutable_qos()->set_qci(static_cast<magma::lte::FlowQos_Qci>(qci));
+  return rule;
 }
 
 void create_granted_units(
@@ -464,6 +473,18 @@ UpdateTunnelIdsRequest create_update_tunnel_ids_request(
   req.set_agw_teid(agw_teid);
   req.set_enb_teid(enb_teid);
   return req;
+}
+
+StaticRuleInstall create_static_rule_install(const std::string& rule_id) {
+  StaticRuleInstall rule_install;
+  rule_install.set_rule_id(rule_id);
+  return rule_install;
+}
+
+DynamicRuleInstall create_dynamic_rule_install(const PolicyRule& rule) {
+  DynamicRuleInstall rule_install;
+  rule_install.mutable_policy_rule()->CopyFrom(rule);
+  return rule_install;
 }
 
 }  // namespace magma

--- a/lte/gateway/c/session_manager/test/ProtobufCreators.h
+++ b/lte/gateway/c/session_manager/test/ProtobufCreators.h
@@ -180,9 +180,12 @@ void create_session_create_response(
     const std::string& monitoring_key, std::vector<std::string>& static_rules,
     CreateSessionResponse* response);
 
-void create_policy_rule(
-    const std::string& rule_id, const std::string& m_key, uint32_t rating_group,
-    PolicyRule* rule);
+PolicyRule create_policy_rule(
+    const std::string& rule_id, const std::string& m_key, const uint32_t rg);
+
+PolicyRule create_policy_rule_with_qos(
+    const std::string& rule_id, const std::string& m_key, const uint32_t rg,
+    const int qci);
 
 void create_granted_units(
     uint64_t* total, uint64_t* tx, uint64_t* rx, GrantedUnits* gsu);
@@ -200,4 +203,9 @@ UpdateTunnelIdsRequest create_update_tunnel_ids_request(
 UpdateTunnelIdsRequest create_update_tunnel_ids_request(
     const std::string& imsi, const uint32_t bearer_id, const uint32_t agw_teid,
     const uint32_t enb_teid);
+
+StaticRuleInstall create_static_rule_install(const std::string& rule_id);
+
+DynamicRuleInstall create_dynamic_rule_install(const PolicyRule& rule);
+
 }  // namespace magma

--- a/lte/gateway/c/session_manager/test/SessionStateTester.h
+++ b/lte/gateway/c/session_manager/test/SessionStateTester.h
@@ -18,6 +18,7 @@
 #include <string>
 #include <utility>
 
+#include "Consts.h"
 #include "ProtobufCreators.h"
 #include "SessiondMocks.h"
 #include "SessionState.h"

--- a/lte/gateway/c/session_manager/test/test_local_enforcer.cpp
+++ b/lte/gateway/c/session_manager/test/test_local_enforcer.cpp
@@ -1293,12 +1293,12 @@ TEST_F(LocalEnforcerTest, test_reauth_with_redirected_suspended_credit) {
   UpdateSessionResponse update_response;
   auto updates = update_response.mutable_responses();
   create_credit_update_response(IMSI1, SESSION_ID_1, 1, 4096, updates->Add());
-  std::vector<std::string> rules_to_activate = {"rule1"};
+  std::vector<std::string> pending_activation = {"rule1"};
   EXPECT_CALL(
       *pipelined_client, activate_flows_for_rules(
                              testing::_, testing::_, testing::_, testing::_,
                              test_cfg_.common_context.msisdn(), testing::_,
-                             CheckRuleNames(rules_to_activate), testing::_))
+                             CheckRuleNames(pending_activation), testing::_))
       .Times(1);
   local_enforcer->update_session_credits_and_rules(
       session_map, update_response, update);

--- a/lte/gateway/c/session_manager/test/test_local_enforcer_wallet_exhaust.cpp
+++ b/lte/gateway/c/session_manager/test/test_local_enforcer_wallet_exhaust.cpp
@@ -87,9 +87,7 @@ class LocalEnforcerTest : public ::testing::Test {
   void insert_static_rule(
       uint32_t rating_group, const std::string& m_key,
       const std::string& rule_id) {
-    PolicyRule rule;
-    create_policy_rule(rule_id, m_key, rating_group, &rule);
-    rule_store->insert_rule(rule);
+    rule_store->insert_rule(create_policy_rule(rule_id, m_key, rating_group));
   }
 
  protected:

--- a/lte/gateway/c/session_manager/test/test_proxy_responder_handler.cpp
+++ b/lte/gateway/c/session_manager/test/test_proxy_responder_handler.cpp
@@ -136,9 +136,7 @@ class SessionProxyResponderHandlerTest : public ::testing::Test {
   }
 
   void insert_static_rule(const std::string& rule_id) {
-    PolicyRule rule;
-    create_policy_rule(rule_id, "", 0, &rule);
-    rule_store->insert_rule(rule);
+    rule_store->insert_rule(create_policy_rule(rule_id, "", 0));
   }
 
  protected:

--- a/lte/gateway/c/session_manager/test/test_session_state.cpp
+++ b/lte/gateway/c/session_manager/test/test_session_state.cpp
@@ -935,16 +935,15 @@ TEST_F(SessionStateTest, test_apply_session_rule_set) {
   rules_to_apply.static_rules.insert("rule-static-2");
   rules_to_apply.static_rules.insert("rule-static-3");
 
-  PolicyRule dynamic_2, dynamic_3;
-  create_policy_rule("rule-dynamic-2", "m1", 2, &dynamic_2);
-  create_policy_rule("rule-dynamic-3", "m1", 3, &dynamic_3);
+  PolicyRule dynamic_2 = create_policy_rule("rule-dynamic-2", "m1", 2);
+  PolicyRule dynamic_3 = create_policy_rule("rule-dynamic-3", "m1", 3);
   rules_to_apply.dynamic_rules["rule-dynamic-2"] = dynamic_2;
   rules_to_apply.dynamic_rules["rule-dynamic-3"] = dynamic_3;
 
   SessionStateUpdateCriteria uc;
-  RulesToProcess to_activate, to_deactivate;
+  RulesToProcess to_activate, to_deactivate, to_get_bearer;
   session_state->apply_session_rule_set(
-      rules_to_apply, &to_activate, &to_deactivate, uc);
+      rules_to_apply, &to_activate, &to_deactivate, &to_get_bearer, uc);
 
   // First check the active rules in session
   EXPECT_TRUE(!session_state->is_static_rule_installed("rule-static-1"));
@@ -1094,6 +1093,80 @@ TEST_F(SessionStateTest, test_get_charging_credit_summaries) {
   EXPECT_EQ(2000, summary_rg1.usage.bytes_tx);
   EXPECT_EQ(2000, summary_rg2.usage.bytes_rx);
   EXPECT_EQ(4000, summary_rg2.usage.bytes_tx);
+}
+
+TEST_F(SessionStateTest, test_process_static_rule_installs) {
+  initialize_session_with_qos();
+  auto uc = get_default_update_criteria();
+
+  // Insert 2 static rules without qos into static rule store
+  insert_static_rule_into_store(0, "mkey1", "static-1");
+  insert_static_rule_into_store(0, "mkey1", "static-2");
+  // Insert 2 static rules with qos into static rule store
+  insert_static_rule_with_qos_into_store(0, "mkey1", 1, "static-qos-3");
+  insert_static_rule_with_qos_into_store(0, "mkey1", 2, "static-qos-4");
+
+  // activate static-1 and static-qos-3 in advance
+  RuleLifetime lifetime;
+  session_state->activate_static_rule("static-1", lifetime, uc);
+  session_state->activate_static_rule("static-qos-3", lifetime, uc);
+
+  // Create a StaticRuleInstall with all four rules above
+  std::vector<StaticRuleInstall> rule_installs{
+      // should be ignored as it is already active
+      create_static_rule_install("static-1"),
+      // new non-qos rule
+      create_static_rule_install("static-2"),
+      // should be ignored as it is already active
+      create_static_rule_install("static-qos-3"),
+      // new qos rule
+      create_static_rule_install("static-qos-4"),
+  };
+  RulesToProcess to_activate, to_deactivate, to_get_bearer;
+  RulesToSchedule to_schedule;
+  session_state->process_static_rule_installs(
+      rule_installs, &to_activate, &to_deactivate, &to_get_bearer, &to_schedule,
+      &uc);
+  EXPECT_EQ(1, to_activate.size());
+  EXPECT_EQ("static-2", to_activate[0].rule.id());
+  EXPECT_EQ(1, to_get_bearer.size());
+  EXPECT_EQ("static-qos-4", to_get_bearer[0].rule.id());
+}
+
+TEST_F(SessionStateTest, test_process_dynamic_rule_installs) {
+  initialize_session_with_qos();
+  auto uc = get_default_update_criteria();
+
+  PolicyRule dynamic_1 = create_policy_rule("dynamic-1", "", 0);
+  PolicyRule dynamic_2 = create_policy_rule("dynamic-2", "", 0);
+  PolicyRule dynamic_qos_3 =
+      create_policy_rule_with_qos("dynamic-qos-3", "", 0, 1);
+  PolicyRule dynamic_qos_4 =
+      create_policy_rule_with_qos("dynamic-qos-4", "", 0, 2);
+
+  // Install dynamic rules for dynamic-1 and dynamic-qos-3
+  RuleLifetime lifetime;
+  session_state->insert_dynamic_rule(dynamic_1, lifetime, uc);
+  session_state->insert_dynamic_rule(dynamic_qos_3, lifetime, uc);
+
+  // Create a StaticRuleInstall with all four rules above
+  std::vector<DynamicRuleInstall> rule_installs{
+      // should be installed even though it is already active
+      create_dynamic_rule_install(dynamic_1),
+      // new non-qos rule
+      create_dynamic_rule_install(dynamic_2),
+      // should be installed even though it is already active
+      create_dynamic_rule_install(dynamic_qos_3),
+      // new qos rule
+      create_dynamic_rule_install(dynamic_qos_4),
+  };
+  RulesToProcess to_activate, to_deactivate, to_get_bearer;
+  RulesToSchedule to_schedule;
+  session_state->process_dynamic_rule_installs(
+      rule_installs, &to_activate, &to_deactivate, &to_get_bearer, &to_schedule,
+      &uc);
+  EXPECT_EQ(2, to_activate.size());
+  EXPECT_EQ(2, to_get_bearer.size());
 }
 
 int main(int argc, char** argv) {

--- a/lte/gateway/c/session_manager/test/test_session_state.cpp
+++ b/lte/gateway/c/session_manager/test/test_session_state.cpp
@@ -941,9 +941,10 @@ TEST_F(SessionStateTest, test_apply_session_rule_set) {
   rules_to_apply.dynamic_rules["rule-dynamic-3"] = dynamic_3;
 
   SessionStateUpdateCriteria uc;
-  RulesToProcess to_activate, to_deactivate, to_get_bearer;
+  RulesToProcess pending_activation, pending_deactivation, pending_bearer_setup;
   session_state->apply_session_rule_set(
-      rules_to_apply, &to_activate, &to_deactivate, &to_get_bearer, uc);
+      rules_to_apply, &pending_activation, &pending_deactivation,
+      &pending_bearer_setup, uc);
 
   // First check the active rules in session
   EXPECT_TRUE(!session_state->is_static_rule_installed("rule-static-1"));
@@ -954,11 +955,11 @@ TEST_F(SessionStateTest, test_apply_session_rule_set) {
   EXPECT_TRUE(session_state->is_dynamic_rule_installed("rule-dynamic-3"));
 
   // Check the RulesToProcess is properly filled out
-  EXPECT_EQ(to_activate.size(), 2);
-  const std::string activate_rule1   = to_activate[0].rule.id();
-  const std::string activate_rule2   = to_activate[1].rule.id();
-  const std::string deactivate_rule1 = to_deactivate[0].rule.id();
-  const std::string deactivate_rule2 = to_deactivate[1].rule.id();
+  EXPECT_EQ(pending_activation.size(), 2);
+  const std::string activate_rule1   = pending_activation[0].rule.id();
+  const std::string activate_rule2   = pending_activation[1].rule.id();
+  const std::string deactivate_rule1 = pending_deactivation[0].rule.id();
+  const std::string deactivate_rule2 = pending_deactivation[1].rule.id();
   EXPECT_TRUE(
       activate_rule1 == "rule-static-3" || activate_rule1 == "rule-dynamic-3");
   EXPECT_TRUE(
@@ -1122,15 +1123,15 @@ TEST_F(SessionStateTest, test_process_static_rule_installs) {
       // new qos rule
       create_static_rule_install("static-qos-4"),
   };
-  RulesToProcess to_activate, to_deactivate, to_get_bearer;
-  RulesToSchedule to_schedule;
+  RulesToProcess pending_activation, pending_deactivation, pending_bearer_setup;
+  RulesToSchedule pending_scheduling;
   session_state->process_static_rule_installs(
-      rule_installs, &to_activate, &to_deactivate, &to_get_bearer, &to_schedule,
-      &uc);
-  EXPECT_EQ(1, to_activate.size());
-  EXPECT_EQ("static-2", to_activate[0].rule.id());
-  EXPECT_EQ(1, to_get_bearer.size());
-  EXPECT_EQ("static-qos-4", to_get_bearer[0].rule.id());
+      rule_installs, &pending_activation, &pending_deactivation,
+      &pending_bearer_setup, &pending_scheduling, &uc);
+  EXPECT_EQ(1, pending_activation.size());
+  EXPECT_EQ("static-2", pending_activation[0].rule.id());
+  EXPECT_EQ(1, pending_bearer_setup.size());
+  EXPECT_EQ("static-qos-4", pending_bearer_setup[0].rule.id());
 }
 
 TEST_F(SessionStateTest, test_process_dynamic_rule_installs) {
@@ -1160,13 +1161,13 @@ TEST_F(SessionStateTest, test_process_dynamic_rule_installs) {
       // new qos rule
       create_dynamic_rule_install(dynamic_qos_4),
   };
-  RulesToProcess to_activate, to_deactivate, to_get_bearer;
-  RulesToSchedule to_schedule;
+  RulesToProcess pending_activation, pending_deactivation, pending_bearer_setup;
+  RulesToSchedule pending_scheduling;
   session_state->process_dynamic_rule_installs(
-      rule_installs, &to_activate, &to_deactivate, &to_get_bearer, &to_schedule,
-      &uc);
-  EXPECT_EQ(2, to_activate.size());
-  EXPECT_EQ(2, to_get_bearer.size());
+      rule_installs, &pending_activation, &pending_deactivation,
+      &pending_bearer_setup, &pending_scheduling, &uc);
+  EXPECT_EQ(2, pending_activation.size());
+  EXPECT_EQ(2, pending_bearer_setup.size());
 }
 
 int main(int argc, char** argv) {

--- a/lte/gateway/c/session_manager/test/test_sessiond_integ.cpp
+++ b/lte/gateway/c/session_manager/test/test_sessiond_integ.cpp
@@ -208,9 +208,7 @@ class SessiondTest : public ::testing::Test {
 
   void insert_static_rule(uint32_t charging_key, const std::string& rule_id) {
     auto mkey = "";
-    PolicyRule rule;
-    create_policy_rule(rule_id, mkey, charging_key, &rule);
-    rule_store->insert_rule(rule);
+    rule_store->insert_rule(create_policy_rule(rule_id, mkey, charging_key));
   }
 
   // Timeout to not block test

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_rar_tcp_data.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_rar_tcp_data.py
@@ -186,6 +186,8 @@ class TestAttachDetachRarTcpData(unittest.TestCase):
             self._s1ap_wrapper.sendActDedicatedBearerAccept(
                 req.ue_id, act_ded_ber_ctxt_req.bearerId
             )
+            print("Sleeping again for flow to be installed")
+            time.sleep(2)
 
             # Check if UL and DL OVS flows are created
             # UPLINK


### PR DESCRIPTION
Signed-off-by: Marie Bremner <marwhal@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary
A short summary is that when we transition into IMSI+teid based identification, we have to fetch the correct set of teids. For non-qos policies or polices that are served by default bearers, we can use the Teids given by the `UpdateTunnelIds` GRPC call from MME to SessionD. However, for any QoS policies that are served by dedicated bearers, we have to get the teids associated with that particular dedicated bearer. 
This means that when activating a flow that's served by a dedicated bearer, we have to hold off on the activation until we receive a call from MME `BindPolicy2Bearer`. 

The key change here is that `process_rules_to_install` now intakes an output parameter `RulesToProcess to_get_bearer` that has a vector of policies that need dedicated bearers created. Whether a rule ends up in `to_activate` or `to_get_bearer` is determined by `policy_needs_bearer_creation`, which returns true if a session/policy fits all of the following cirteria:
1. session is an LTE session
2. policy has qos and has a qci that is different from the default qos
3. policy is not already mapped to a bearer
The rules will be activated when handling `BindPolicy2Bearer`.


## GRPC flow diagram
A flow diagram on all the relevant GRPC messaging for a successful session activation+policy install.
![SessionD-policy-activation-flow](https://user-images.githubusercontent.com/37634144/117686393-714f1000-b17c-11eb-9415-28ba7718315b.png)



## Some minor changes
```
void create_policy_rule(..., const uint32_t rg, PolicyRule* rule)
``` 
to 
```
PolicyRule create_policy_rule(..., const uint32_t rg)
```

Moving
```
LocalEnforcer::process_rules_to_install
LocalEnforcer::process_rules_to_remove
```
to 
```
SessionState::process_rules_to_install
SessionState::process_rules_to_remove
```

<!-- Enumerate changes you made and why you made them -->

## Test Plan
sessiond unit tests + ci + integ tests 
https://app.circleci.com/pipelines/github/magma/magma/21855/workflows/b6c8f789-c50c-45e6-9ebc-e0e784b9cf22

When running `s1aptests/test_attach_detach_setsessionrules_tcp_data.py`
UpdateTunnelIDs with default teids
```
May 10 17:22:36 magma-dev sessiond[32393]:   magma.lte.UpdateTunnelIdsRequest {
May 10 17:22:36 magma-dev sessiond[32393]:       sid {
May 10 17:22:36 magma-dev sessiond[32393]:         id: "IMSI001010000000001"
May 10 17:22:36 magma-dev sessiond[32393]:       }
May 10 17:22:36 magma-dev sessiond[32393]:       bearer_id: 5
May 10 17:22:36 magma-dev sessiond[32393]:       enb_teid: 167772456
May 10 17:22:36 magma-dev sessiond[32393]:       agw_teid: 10
May 10 17:22:36 magma-dev sessiond[32393]:   }
```
then SessionSet to activate `tcp_udp_1`
```
May 10 17:22:41 magma-dev sessiond[32393]:   magma.lte.SessionRules {
May 10 17:22:41 magma-dev sessiond[32393]:       rules_per_subscriber {
May 10 17:22:41 magma-dev sessiond[32393]:         imsi: "IMSI001010000000001"
May 10 17:22:41 magma-dev sessiond[32393]:         rule_set {
May 10 17:22:41 magma-dev sessiond[32393]:           apply_subscriber_wide: true
May 10 17:22:41 magma-dev sessiond[32393]:           dynamic_rules {
May 10 17:22:41 magma-dev sessiond[32393]:             policy_rule {
May 10 17:22:41 magma-dev sessiond[32393]:               id: "tcp_udp_1"
May 10 17:22:41 magma-dev sessiond[32393]:               rating_group: 1
May 10 17:22:41 magma-dev sessiond[32393]:               flow_list {
May 10 17:22:41 magma-dev sessiond[32393]:                 match {
May 10 17:22:41 magma-dev sessiond[32393]:                   tcp_dst: 5001
May 10 17:22:41 magma-dev sessiond[32393]:                   ip_proto: IPPROTO_TCP
May 10 17:22:41 magma-dev sessiond[32393]:                 }
May 10 17:22:41 magma-dev sessiond[32393]:               }
```
followed by
```
May 10 17:22:41 magma-dev sessiond[32393]: I0510 17:22:41.206774 32393 SpgwServiceClient.cpp:121] Creating dedicated bearers for IMSI001010000000001, 192.168.128.12, rules={ tcp_udp_1 }
May 10 17:22:41 magma-dev sessiond[32393]: I0510 17:22:41.220302 32410 GrpcMagmaUtils.cpp:42]
May 10 17:22:41 magma-dev sessiond[32393]:   magma.lte.PolicyBearerBindingRequest {
May 10 17:22:41 magma-dev sessiond[32393]:       sid {
May 10 17:22:41 magma-dev sessiond[32393]:         id: "IMSI001010000000001"
May 10 17:22:41 magma-dev sessiond[32393]:       }
May 10 17:22:41 magma-dev sessiond[32393]:       linked_bearer_id: 5
May 10 17:22:41 magma-dev sessiond[32393]:       policy_rule_id: "tcp_udp_1"
May 10 17:22:41 magma-dev sessiond[32393]:       bearer_id: 6
May 10 17:22:41 magma-dev sessiond[32393]:       teids {
May 10 17:22:41 magma-dev sessiond[32393]:         enb_teid: 167772464
May 10 17:22:41 magma-dev sessiond[32393]:         agw_teid: 11
May 10 17:22:41 magma-dev sessiond[32393]:       }
May 10 17:22:41 magma-dev sessiond[32393]:   }
```
and then finally installing the rule
```
May 10 17:22:41 magma-dev sessiond[32393]:   magma.lte.ActivateFlowsRequest {
May 10 17:22:41 magma-dev sessiond[32393]:       sid {
May 10 17:22:41 magma-dev sessiond[32393]:         id: "IMSI001010000000001"
May 10 17:22:41 magma-dev sessiond[32393]:       }
May 10 17:22:41 magma-dev sessiond[32393]:       ip_addr: "192.168.128.12"
May 10 17:22:41 magma-dev sessiond[32393]:       request_origin {
May 10 17:22:41 magma-dev sessiond[32393]:       }
May 10 17:22:41 magma-dev sessiond[32393]:       apn_ambr {
May 10 17:22:41 magma-dev sessiond[32393]:         max_bandwidth_ul: 100000
May 10 17:22:41 magma-dev sessiond[32393]:         max_bandwidth_dl: 150000
May 10 17:22:41 magma-dev sessiond[32393]:       }
May 10 17:22:41 magma-dev sessiond[32393]:       uplink_tunnel: 11
May 10 17:22:41 magma-dev sessiond[32393]:       downlink_tunnel: 167772464
May 10 17:22:41 magma-dev sessiond[32393]:       policies {
May 10 17:22:41 magma-dev sessiond[32393]:         rule {
May 10 17:22:41 magma-dev sessiond[32393]:           id: "tcp_udp_1"
May 10 17:22:41 magma-dev sessiond[32393]:           rating_group: 1
May 10 17:22:41 magma-dev sessiond[32393]:           flow_list {
```
after a while deactivating the rule...
```
May 10 17:22:46 magma-dev sessiond[32393]: I0510 17:22:46.226804 32393 GrpcMagmaUtils.cpp:42]
May 10 17:22:46 magma-dev sessiond[32393]:   magma.lte.DeactivateFlowsRequest {
May 10 17:22:46 magma-dev sessiond[32393]:       sid {
May 10 17:22:46 magma-dev sessiond[32393]:         id: "IMSI001010000000001"
May 10 17:22:46 magma-dev sessiond[32393]:       }
May 10 17:22:46 magma-dev sessiond[32393]:       request_origin {
May 10 17:22:46 magma-dev sessiond[32393]:       }
May 10 17:22:46 magma-dev sessiond[32393]:       ip_addr: "192.168.128.12"
May 10 17:22:46 magma-dev sessiond[32393]:       uplink_tunnel: 11
May 10 17:22:46 magma-dev sessiond[32393]:       downlink_tunnel: 167772464
May 10 17:22:46 magma-dev sessiond[32393]:       policies {
May 10 17:22:46 magma-dev sessiond[32393]:         rule_id: "tcp_udp_1"
May 10 17:22:46 magma-dev sessiond[32393]:         version: 1
May 10 17:22:46 magma-dev sessiond[32393]:       }
May 10 17:22:46 magma-dev sessiond[32393]:   }
```

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
