### PR TITLE
[backport v1.4] AGW: pipelined: QoS: Fix max bandwidth calculation.

### DIFF
--- a/lte/gateway/python/magma/pipelined/qos/common.py
+++ b/lte/gateway/python/magma/pipelined/qos/common.py
@@ -363,7 +363,7 @@ class QosManager(object):
                 LOG.debug("add_subscriber_qos: not enabled or initialized")
                 return None, None
 
-            LOG.debug("adding qos for imsi %s rule_num %d direction %d apn_ambr %d, qos_info %s",
+            LOG.debug("adding qos for imsi %s rule_num %d direction %d apn_ambr %d, %s",
                       imsi, rule_num, direction, apn_ambr, qos_info)
 
             imsi = normalize_imsi(imsi)

--- a/lte/gateway/python/magma/pipelined/qos/tc_ops_pyroute2.py
+++ b/lte/gateway/python/magma/pipelined/qos/tc_ops_pyroute2.py
@@ -35,9 +35,24 @@ class TcOpsPyRoute2(TcOpsBase):
 
     def create_htb(self, iface: str, qid: str, max_bw: int, rate: str,
                    parent_qid: str = None) -> int:
-        LOG.debug("Create HTB iface %s qid %s", iface, qid)
+        """
+        Create HTB class for a UE session.
 
+        Args:
+            iface: Egress interface name.
+            qid: qid number.
+            max_bw: ceiling in bits per sec.
+            rate: rate limiting.
+            parent_qid: HTB parent queue.
+
+        Returns:
+            zero on success.
+        """
+
+        LOG.debug("Create HTB iface %s qid %s max_bw %s rate %s", iface, qid, max_bw, rate)
         try:
+            # API needs ceiling in bytes per sec.
+            max_bw = max_bw / 8
             if_index = self._get_if_index(iface)
             htb_queue = QUEUE_PREFIX + qid
             ret = self._ipr.tc("add-class", "htb", if_index,
@@ -51,6 +66,15 @@ class TcOpsPyRoute2(TcOpsBase):
         return 0
 
     def del_htb(self, iface: str, qid: str) -> int:
+        """
+        Delete given queue from HTB classed
+
+        Args:
+            iface: interface name
+            qid: queue-id of the HTB class
+
+        Returns:
+        """
         LOG.debug("Delete HTB iface %s qid %s", iface, qid)
 
         try:
@@ -66,8 +90,11 @@ class TcOpsPyRoute2(TcOpsBase):
         return 0
 
     def create_filter(self, iface: str, mark: str, qid: str, proto: int = PROTOCOL) -> int:
-        LOG.debug("Create Filter iface %s qid %s", iface, qid)
+        """
+        Create TC Filter for given HTB class.
+        """
 
+        LOG.debug("Create Filter iface %s qid %s", iface, qid)
         try:
             if_index = self._get_if_index(iface)
 
@@ -86,8 +113,11 @@ class TcOpsPyRoute2(TcOpsBase):
         return 0
 
     def del_filter(self, iface: str, mark: str, qid: str, proto: int = PROTOCOL) -> int:
-        LOG.debug("Del Filter iface %s qid %s", iface, qid)
+        """
+        Delete TC filter.
+        """
 
+        LOG.debug("Del Filter iface %s qid %s", iface, qid)
         try:
             if_index = self._get_if_index(iface)
 


### PR DESCRIPTION
Pyroute2 API expects max-bandwidth parameter in bytes rather than
bit rate.

Signed-off-by: Pravin B Shelar <pbshelar@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->

## Test Plan
verified on master.

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
