### PR TITLE
[AGW][UPGRADE]Make sure apt-transport-https gnupg2 are installed

### DIFF
--- a/lte/gateway/release/upgrade_magma.sh
+++ b/lte/gateway/release/upgrade_magma.sh
@@ -24,7 +24,7 @@ if grep -q 'Debian' /etc/issue; then
   OS_VERSION="stretch"
 fi
 
-#
+apt update
 apt install -y apt-transport-https gnupg2
 
 # We have changed the name too many time we have to wipe all versions

--- a/lte/gateway/release/upgrade_magma.sh
+++ b/lte/gateway/release/upgrade_magma.sh
@@ -24,6 +24,9 @@ if grep -q 'Debian' /etc/issue; then
   OS_VERSION="stretch"
 fi
 
+#
+apt install -y apt-transport-https gnupg2
+
 # We have changed the name too many time we have to wipe all versions
 rm -rf /etc/apt/sources.list.d/*
 


### PR DESCRIPTION
Signed-off-by: Timothée Dzik <timdzik@fb.com>

[AGW][UPGRADE]Make sure apt-transport-https gnupg2 are installed

## Summary

If you upgrade from 1.3 you don't have apt-transport-https, adding it to the upgrade script 

## Test Plan

Tested on partner's infra 