### PR TITLE
[lte][agw] Change AGW ubuntu install script to not perform shallow clone of repository

### DIFF
--- a/lte/gateway/deploy/agw_install_ubuntu.sh
+++ b/lte/gateway/deploy/agw_install_ubuntu.sh
@@ -156,7 +156,7 @@ if [ "$MAGMA_INSTALLED" != "$SUCCESS_MESSAGE" ]; then
   alias python=python3
   pip3 install ansible
 
-  git clone --depth=1 "${GIT_URL}" /home/$MAGMA_USER/magma
+  git clone "${GIT_URL}" /home/$MAGMA_USER/magma
   cd /home/$MAGMA_USER/magma || exit
   git checkout "$MAGMA_VERSION"
 


### PR DESCRIPTION
Signed-off-by: Babis Kaidos <babis_k@outlook.com>

## Summary

The Ubuntu install script of AGW performs a shallow clone of the magma repository, thus the subsequent version checkout fails and the master branch ends up being installed instead of the selected (or default) one. This change reverts to performing a full clone to fix the issue.

## Test Plan

Redeployed on a new host and the clone/checkout process works as intended.
