### PR TITLE
Output enforced rules in dp_probe

### DIFF
--- a/docs/docusaurus/versioned_docs/version-1.5.0/lte/debug_dp_probe.md
+++ b/docs/docusaurus/versioned_docs/version-1.5.0/lte/debug_dp_probe.md
@@ -11,29 +11,48 @@ The datapath probe CLI helps an operator to probe the Datapath to the UE.
 
 ## Usage
 
+On your GW host, run the following command
+
+```$ dp_probe_cli.py -i <IMSI> --direction <DL/UL> list_rules```
+
+For example:
 ```sh
-# On your GW host, run the following command
-$ dp_probe_cli.py -i <IMSI> --direction <DL/UL>
 $ dp_probe_cli.py -i 1010000051013 --direction DL
 IMSI: 1010000051013, IP: 192.168.128.13
 Running: sudo ovs-appctl ofproto/trace gtp_br0 tcp,in_port=local,ip_dst=192.168.128.13,ip_src=8.8.8.8,tcp_src=80,tcp_dst=3372
 Datapath Actions: set(tunnel(tun_id=0x1000008,dst=10.0.2.241,ttl=64,tp_dst=2152,flags(df|key))),pop_eth,2
+Downlink rules: allowlist_sid-IMSI1010000051013-magma.ipv4
+```
 
+```sh
 dp_probe_cli.py -i 1010000051013 --direction UL
 IMSI: 1010000051013, IP: 192.168.128.13
 Running: sudo ovs-appctl ofproto/trace gtp_br0 tcp,in_port=4,tun_id=0x2,ip_dst=8.8.8.8,ip_src=192.168.128.13,tcp_src=3372,tcp_dst=80
 Datapath Actions: set(eth(src=02:00:00:00:00:01,dst=92:9d:a2:1f:ea:44)),1
+Uplink rules: allowlist_sid-IMSI1010000051013-magma.ipv4
+```
 
-# You can also supply the followin options
+You can also supply the followin options
+```
+# list_rules
 # -I <External IP Address>
 # -P <External Port>
 # -UP <UE Port>
 # -p <Protocol tcp/udp/icmp>
+```
 
+```sh
 dp_probe_cli.py -i 1010000051013 --direction UL -p tcp -I 4.2.2.2 -P 8080 -UP 3172
 IMSI: 1010000051013, IP: 192.168.128.13
 Running: sudo ovs-appctl ofproto/trace gtp_br0 tcp,in_port=4,tun_id=0x2,ip_dst=4.2.2.2,ip_src=192.168.128.13,tcp_src=3172,tcp_dst=8080
 Datapath Actions: set(eth(src=02:00:00:00:00:01,dst=92:9d:a2:1f:ea:44)),1
+Uplink rules: allowlist_sid-IMSI1010000051013-magma.ipv4
+```
+
+```sh
+dp_probe_cli.py -i 1010000051013 --direction UL list_rules
+IMSI: 1010000051013, IP: 192.168.128.13
+Uplink rules: allowlist_sid-IMSI1010000051013-magma.ipv4
 ```
 
 ## What is this command doing?
@@ -43,5 +62,8 @@ This command is a wrapper around *ovs-appctl ofproto/trace* which simulates the 
 ## How to read the output?
 
 Based on the *IMSI* supplied to this command
+- If the UE is connected it prints:
+    - The *IP Address* of the UE and the Datapath Actions based on the ovs-appctl ofproto/trace
+    - The enforced uplink or downlink rules in pipelined obtained from the script ```pipelined_cli.py enforcement display_flows```
+    - If the parameter `list_rules` was set, only the enforced rules in pipelined will be shown
 - If the UE is not connected, the command will output ***UE is not connected***
-- If the UE is connected, it prints the *IP Address* of the UE and the Datapath Actions based on the ovs-appctl ofproto/trace

--- a/docs/readmes/lte/debug_dp_probe.md
+++ b/docs/readmes/lte/debug_dp_probe.md
@@ -10,29 +10,48 @@ The datapath probe CLI helps an operator to probe the Datapath to the UE.
 
 ## Usage
 
+On your GW host, run the following command
+
+```$ dp_probe_cli.py -i <IMSI> --direction <DL/UL> list_rules```
+
+For example:
 ```sh
-# On your GW host, run the following command
-$ dp_probe_cli.py -i <IMSI> --direction <DL/UL>
 $ dp_probe_cli.py -i 1010000051013 --direction DL
 IMSI: 1010000051013, IP: 192.168.128.13
 Running: sudo ovs-appctl ofproto/trace gtp_br0 tcp,in_port=local,ip_dst=192.168.128.13,ip_src=8.8.8.8,tcp_src=80,tcp_dst=3372
 Datapath Actions: set(tunnel(tun_id=0x1000008,dst=10.0.2.241,ttl=64,tp_dst=2152,flags(df|key))),pop_eth,2
+Downlink rules: allowlist_sid-IMSI1010000051013-magma.ipv4
+```
 
+```sh
 dp_probe_cli.py -i 1010000051013 --direction UL
 IMSI: 1010000051013, IP: 192.168.128.13
 Running: sudo ovs-appctl ofproto/trace gtp_br0 tcp,in_port=4,tun_id=0x2,ip_dst=8.8.8.8,ip_src=192.168.128.13,tcp_src=3372,tcp_dst=80
 Datapath Actions: set(eth(src=02:00:00:00:00:01,dst=92:9d:a2:1f:ea:44)),1
+Uplink rules: allowlist_sid-IMSI1010000051013-magma.ipv4
+```
 
-# You can also supply the followin options
+You can also supply the followin options
+```
+# list_rules
 # -I <External IP Address>
 # -P <External Port>
 # -UP <UE Port>
 # -p <Protocol tcp/udp/icmp>
+```
 
+```sh
 dp_probe_cli.py -i 1010000051013 --direction UL -p tcp -I 4.2.2.2 -P 8080 -UP 3172
 IMSI: 1010000051013, IP: 192.168.128.13
 Running: sudo ovs-appctl ofproto/trace gtp_br0 tcp,in_port=4,tun_id=0x2,ip_dst=4.2.2.2,ip_src=192.168.128.13,tcp_src=3172,tcp_dst=8080
 Datapath Actions: set(eth(src=02:00:00:00:00:01,dst=92:9d:a2:1f:ea:44)),1
+Uplink rules: allowlist_sid-IMSI1010000051013-magma.ipv4
+```
+
+```sh
+dp_probe_cli.py -i 1010000051013 --direction UL list_rules
+IMSI: 1010000051013, IP: 192.168.128.13
+Uplink rules: allowlist_sid-IMSI1010000051013-magma.ipv4
 ```
 
 ## What is this command doing?
@@ -42,5 +61,8 @@ This command is a wrapper around *ovs-appctl ofproto/trace* which simulates the 
 ## How to read the output?
 
 Based on the *IMSI* supplied to this command
+- If the UE is connected it prints:
+    - The *IP Address* of the UE and the Datapath Actions based on the ovs-appctl ofproto/trace
+    - The enforced uplink or downlink rules in pipelined obtained from the script ```pipelined_cli.py enforcement display_flows```
+    - If the parameter `list_rules` was set, only the enforced rules in pipelined will be shown
 - If the UE is not connected, the command will output ***UE is not connected***
-- If the UE is connected, it prints the *IP Address* of the UE and the Datapath Actions based on the ovs-appctl ofproto/trace


### PR DESCRIPTION
Signed-off-by: Wally Rodriguez B <wallyrb@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary

Add UE rules  in output of dp_probe script.  These are obtained from pipelined  script matching the UE IP address. 
 - nw_dst ip address(for egress traffic)
 - nw_src ip address(from ingress traffic)

Rules are obtained from command ```pipelined_cli.py enforcement display_flows```
Documentation has been updated with this addition

## Test Plan

Tested in VM with s1ap integration tests

```
(python) vagrant@magma-dev:~/magma$ python lte/gateway/python/scripts/dp_probe_cli.py -i 001010000000001 --direction DL
IMSI: 001010000000001, IP: 192.168.128.12
Running: sudo ovs-appctl ofproto/trace gtp_br0 tcp,in_port=local,ip_dst=192.168.128.12,ip_src=8.8.8.8,tcp_src=80,tcp_dst=3372
Datapath Actions: set(tunnel(tun_id=0xa000128,dst=192.168.60.141,ttl=64,tp_dst=2152,flags(df|key))),pop_eth,set(skb_mark(0x7)),2
Ingress rules: allowlist_sid-IMSI001010000000001-magma.ipv4
```

```
(python) vagrant@magma-dev:~/magma$ python lte/gateway/python/scripts/dp_probe_cli.py -i 001010000000001 --direction DL list_rules
IMSI: 001010000000001, IP: 192.168.128.12
Downlink rules: allowlist_sid-IMSI001010000000001-magma.ipv4
```
