### PR TITLE
Adding upgrade_1_5 docs to 1.5 sidebar

### DIFF
--- a/docs/docusaurus/versioned_sidebars/version-1.5.0-sidebars.json
+++ b/docs/docusaurus/versioned_sidebars/version-1.5.0-sidebars.json
@@ -135,6 +135,7 @@
         "type": "subcategory",
         "label": "Access Gateway",
         "ids": [
+          "version-1.5.0-lte/upgrade_1_5",
           "version-1.5.0-lte/upgrade_1_4",
           "version-1.5.0-lte/upgrade_1_3",
           "version-1.5.0-lte/upgrade_1_2",


### PR DESCRIPTION
Signed-off-by: Alex Rodriguez <ardzoht@gmail.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->
- Adds 1.5 upgrade docs to 1.5 versioned sidebars, missed this on #6680 

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->
- ./create_docusaurus_website.sh

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
