### PR TITLE
[nms][upgrade] Fix nms DB migration script so it works on linux

### DIFF
--- a/nms/app/packages/magmalte/scripts/fuji-upgrade/pre-upgrade-migration.sh
+++ b/nms/app/packages/magmalte/scripts/fuji-upgrade/pre-upgrade-migration.sh
@@ -64,11 +64,11 @@ echo ""
 # Get DB connection parameters automatically from an orc8r pod env
 # Can't do this through the NMS pod
 database_source=$(kubectl -n $magma_namespace exec $orc8r_pod_name -- /bin/bash -c 'echo $DATABASE_SOURCE')
-orc8r_db_host=$(echo $database_source | grep -E -o '(?:host=)\S*' | sed 's/host=//')
-orc8r_db_port=$(echo $database_source | grep -E -o '(?:port=)\S*' | sed 's/port=//')
-orc8r_db_name=$(echo $database_source | grep -E -o '(?:dbname=)\S*' | sed 's/dbname=//')
-orc8r_db_username=$(echo $database_source | grep -E -o '(?:user=)\S*' | sed 's/user=//')
-orc8r_db_password=$(echo $database_source | grep -E -o '(?:password=)\S*' | sed 's/password=//')
+orc8r_db_host=$(echo $database_source | awk -F= 'BEGIN { RS=" "; } /host/ { print $2; }')
+orc8r_db_port=$(echo $database_source | awk -F= 'BEGIN { RS=" "; } /port/ { print $2; }')
+orc8r_db_name=$(echo $database_source | awk -F= 'BEGIN { RS=" "; } /dbname/ { print $2; }')
+orc8r_db_username=$(echo $database_source | awk -F= 'BEGIN { RS=" "; } /user/ { print $2; }')
+orc8r_db_password=$(echo $database_source | awk -F= 'BEGIN { RS=" "; } /password/ { print $2; }')
 orc8r_db_dialect=$(kubectl -n $magma_namespace exec $orc8r_pod_name -- /bin/bash -c 'echo $SQL_DRIVER')
 
 # Extra whitespacing


### PR DESCRIPTION
## Summary

Replaces non-capture group usage in grep with awk because this feature is missing in GNU grep. The script in its current form would only work on a Mac OS system.
<!-- Enumerate changes you made and why you made them -->

## Test Plan

Tested manually using Fedora/Ubuntu and Mac via a colleague.

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
