### PR TITLE
[ci][githubActions][slack] Add slack notifications to failing github actions job

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -68,3 +68,16 @@ jobs:
       uses: github/codeql-action/analyze@v1
       env:
         NODE_OPTIONS: --max-old-space-size=5120
+
+    # Notify ci-info channel when failing
+    # Plugin info: https://github.com/marketplace/actions/slack-notify
+
+    - name: Notify failure to slack
+      if: failure() && github.ref == 'refs/heads/master'
+      uses: rtCamp/action-slack-notify@v2.0.2
+      env:
+        SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+        SLACK_TITLE: "Github action CodeQL-analysis ${{ matrix.language }} failed"
+        SLACK_USERNAME: "CodeQL-analysis ${{ matrix.language }} "
+        SLACK_ICON_EMOJI: ":boom:"
+        SLACK_COLOR: "#FF0000"


### PR DESCRIPTION
## Summary

Add slack notifications when github actions jobs fail on master
<img width="692" alt="Screen Shot 2021-05-11 at 4 49 18 PM" src="https://user-images.githubusercontent.com/15911421/117898808-a80b5000-b27a-11eb-9c11-f661a8b65436.png">


## Test Plan

Tested in my own repository with my branch name and own SLACK_WEBHOOK secret.

## Additional Information

If adding additional github actions job running on master, we will need to add this step in the corresponding job.

