### PR TITLE
[lte][agw] Fixing state version and hash validation for MME UE state

### DIFF
--- a/lte/gateway/c/oai/common/redis_utils/redis_client.cpp
+++ b/lte/gateway/c/oai/common/redis_utils/redis_client.cpp
@@ -117,6 +117,15 @@ int RedisClient::read_proto(const std::string& key, Message& proto_msg) {
   return RETURNok;
 }
 
+int RedisClient::read_version(const std::string& key) {
+  orc8r::RedisState wrapper_proto = orc8r::RedisState();
+  if (read_redis_state(key, wrapper_proto) != RETURNok) {
+    return RETURNerror;
+  }
+
+  return wrapper_proto.version();
+}
+
 int RedisClient::clear_keys(const std::vector<std::string>& keys_to_clear) {
   auto db_write = db_client_->del(keys_to_clear);
   db_client_->sync_commit();

--- a/lte/gateway/c/oai/common/redis_utils/redis_client.h
+++ b/lte/gateway/c/oai/common/redis_utils/redis_client.h
@@ -79,6 +79,8 @@ class RedisClient {
    */
   int read_proto(const std::string& key, google::protobuf::Message& proto_msg);
 
+  int read_version(const std::string& key);
+
   int clear_keys(const std::vector<std::string>& keys_to_clear);
 
   std::vector<std::string> get_keys(const std::string& pattern);


### PR DESCRIPTION
Signed-off-by: Alex Rodriguez <ardzoht@gmail.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->
- Updating UE state version and hash values to be tracked per-UE, previously was being tracked as aggregated version for all UEs, this PR fixes it, as each UE state should maintain own version
- Adding state version read on service start to populate last written state version

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->
- `make integ_test` as sanity
- `state_cli.py parse IMSI001010000000009:MME` on s1ap integ testing:
```
implicit_detach_timer {
  id: 18446744073709551615
  sec: 3480
}
initial_context_setup_rsp_timer {
  id: 18446744073709551615
  sec: 4
}
ue_context_modification_timer {
  id: 18446744073709551615
  sec: 2
}
paging_response_timer {
  id: 18446744073709551615
  sec: 4
}
rau_tau_timer: 10

==================
State version: 1
```

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
