### PR TITLE
[MME] Add libprotobuf-mutator to dockerfile for test

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -153,6 +153,16 @@ RUN git clone --recurse-submodules -b v1.35.0 https://github.com/grpc/grpc && \
     cd / && \
     rm -rf grpc
 
+##### libprotobuf-mutator is used for randomized proto unit tests / property tests
+RUN git clone -b v1.0 https://github.com/google/libprotobuf-mutator && \
+    mkdir -p libprotobuf-mutator/build && \
+    cd libprotobuf-mutator/build && \
+    cmake .. -GNinja -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++ -DCMAKE_BUILD_TYPE=Debug && \
+    ninja && \
+    ninja install && \
+    cd / && \
+    rm -rf libprotobuf-mutator
+
 ##### Prometheus CPP
 RUN git clone https://github.com/jupp0r/prometheus-cpp.git && \
     cd prometheus-cpp && \

--- a/lte/gateway/docker/mme/Dockerfile.ubuntu20.04
+++ b/lte/gateway/docker/mme/Dockerfile.ubuntu20.04
@@ -134,6 +134,16 @@ RUN git clone --recurse-submodules -b v1.35.0 https://github.com/grpc/grpc && \
     cd / && \
     rm -rf grpc
 
+##### libprotobuf-mutator is used for randomized proto unit tests / property tests
+RUN git clone -b v1.0 https://github.com/google/libprotobuf-mutator && \
+    mkdir -p libprotobuf-mutator/build && \
+    cd libprotobuf-mutator/build && \
+    cmake .. -GNinja -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++ -DCMAKE_BUILD_TYPE=Debug && \
+    ninja && \
+    ninja install && \
+    cd / && \
+    rm -rf libprotobuf-mutator
+
 ##### Prometheus CPP
 RUN git clone https://github.com/jupp0r/prometheus-cpp.git && \
     cd prometheus-cpp && \


### PR DESCRIPTION
## Summary

This library will be useful in writing protobuf based property testing (e.g. #6903, #5042, #4996) and possibly in fuzzers that validate healthy behavior on random protobufs.

## Test Plan

Confirmed health of Docker builds (via GH Action that checks this already).
Confirmed ability to add new unit test using the library (see draft PR #6892).

Signed-off-by: Scott Harrison Moeller <smoeller@fb.com>
