### PR TITLE
git: Ignore build/lib not lib in gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,11 +29,8 @@ env/
 develop-eggs/
 dist/
 eggs/
-lib/
+build/lib/
 lib64/
-!orc8r/lib/
-!feg/radius/lib/
-!lte/gateway/c/oai/lib
 parts/
 sdist/
 var/


### PR DESCRIPTION
Signed-off-by: Marie Bremner <marwhal@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary
We have several non generated directories that are named 'lib' that we don't want to ignore in git.
Instead of blindly ignoring '/lib' and adding exception rules, just ignore 'build/lib' which covers the everything we want. (I think)

From a quick search in my local setup, here are the list of directories with 'lib' (excluding node_modules)
```
.//lte/gateway/python/build/lib # ok to ignore
.//lte/gateway/c/oai/lib # don't want to ignore
.//lte/gateway/c/oai/code_coverage/lib # already covered by another gitignore
.//feg/radius/lib # don't want ignore
.//build/oai/lib # ok to ignore
.//third_party/build/lib # ok to ignore
# .cache is already covered by another gitignore
.//.cache/go/pkg/mod/cache/download/github.com/facebookincubator/magma/orc8r/lib
.//.cache/go/pkg/mod/cache/download/github.com/lib
.//.cache/go/pkg/mod/github.com/lib
.//orc8r/lib # don't want to ignore
.//orc8r/gateway/python/build/lib # ok to ignore
```
<!-- Enumerate changes you made and why you made them -->

## Test Plan
I built orc8r/agw/nms and checked that my git status looks reasonable
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
