### PR TITLE
fix: mobilitydclient no return value warning

### DIFF
--- a/lte/gateway/c/oai/lib/mobility_client/MobilityClientAPI.cpp
+++ b/lte/gateway/c/oai/lib/mobility_client/MobilityClientAPI.cpp
@@ -18,19 +18,19 @@
 #include "MobilityClientAPI.h"
 
 #include <grpcpp/security/credentials.h>
+
 #include <cstdint>
 #include <cstring>
 #include <string>
 
-#include "conversions.h"
 #include "common_defs.h"
+#include "common_types.h"
+#include "conversions.h"
+#include "intertask_interface.h"
+#include "log.h"
+#include "MobilityServiceClient.h"
 #include "service303.h"
 #include "spgw_types.h"
-#include "intertask_interface.h"
-#include "common_types.h"
-#include "log.h"
-
-#include "MobilityServiceClient.h"
 
 using grpc::Channel;
 using grpc::ChannelCredentials;
@@ -192,7 +192,6 @@ int pgw_handle_allocate_ipv6_address(
               LOG_UTIL,
               " Error in allocating ipv6 address for IMSI <%s> apn <%s>\n",
               subscriber_id_str.c_str(), apn_str.c_str());
-          OAILOG_FUNC_RETURN(LOG_SPGW_APP, RETURNerror);
         }
 
         memcpy(&ip6_addr.s6_addr, ipv6_addr_str.c_str(), sizeof(in6_addr));
@@ -293,7 +292,6 @@ int pgw_handle_allocate_ipv4v6_address(
               " Error in allocating IPv4 and IPv6 addresses for IMSI <%s> apn "
               "<%s>\n",
               subscriber_id_str.c_str(), apn_str.c_str());
-          OAILOG_FUNC_RETURN(LOG_SPGW_APP, RETURNerror);
         }
         memcpy(&ip4_addr, ipv4_addr_str.c_str(), sizeof(in_addr));
         memcpy(&ip6_addr, ipv6_addr_str.c_str(), sizeof(in6_addr));

--- a/lte/gateway/c/oai/lib/mobility_client/MobilityClientAPI.h
+++ b/lte/gateway/c/oai/lib/mobility_client/MobilityClientAPI.h
@@ -23,10 +23,10 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
-#include "log.h"
-#include "ip_forward_messages_types.h"
-#include "intertask_interface.h"
 #include "dynamic_memory_check.h"
+#include "intertask_interface.h"
+#include "ip_forward_messages_types.h"
+#include "log.h"
 #include "spgw_state.h"
 
 // Status codes from gRPC

--- a/lte/gateway/c/oai/lib/mobility_client/MobilityServiceClient.cpp
+++ b/lte/gateway/c/oai/lib/mobility_client/MobilityServiceClient.cpp
@@ -17,21 +17,22 @@
 
 #include "MobilityServiceClient.h"
 
-#include <cassert>
 #include <grpcpp/impl/codegen/client_context.h>
 #include <grpcpp/impl/codegen/status.h>
 #include <netinet/in.h>
+
+#include <cassert>
 #include <cstring>
 #include <iostream>
 #include <memory>
 #include <string>
 #include <thread>
+#include <utility>
 
 #include "lte/protos/mobilityd.grpc.pb.h"
 #include "lte/protos/mobilityd.pb.h"
-#include "orc8r/protos/common.pb.h"
 #include "lte/protos/subscriberdb.pb.h"
-
+#include "orc8r/protos/common.pb.h"
 #include "ServiceRegistrySingleton.h"
 
 using grpc::Channel;

--- a/lte/gateway/c/oai/lib/mobility_client/MobilityServiceClient.h
+++ b/lte/gateway/c/oai/lib/mobility_client/MobilityServiceClient.h
@@ -18,15 +18,14 @@
 
 #include <arpa/inet.h>
 #include <grpc++/grpc++.h>
-#include <cstdint>
-#include <memory>
-#include <functional>
-#include <string>
-#include <memory>
 
-#include "lte/protos/mobilityd.grpc.pb.h"
+#include <cstdint>
+#include <functional>
+#include <memory>
+#include <string>
 
 #include "GRPCReceiver.h"
+#include "lte/protos/mobilityd.grpc.pb.h"
 
 namespace grpc {
 class Channel;


### PR DESCRIPTION
Signed-off-by: Marie Bremner <marwhal@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary
warning error I was seeing:
```
[1403/1851] Building CXX object lib/mobility_client/CMakeFiles/LIB_MOBILITY_CLIENT.dir/MobilityClientAPI.cpp.o
/home/vagrant/magma/lte/gateway/c/oai/lib/mobility_client/MobilityClientAPI.cpp: In lambda function:
/home/vagrant/magma/lte/gateway/c/oai/lib/mobility_client/MobilityClientAPI.cpp:204:7: warning: control reaches end of non-void function [-Wreturn-type]
  204 |       });
      |       ^
/home/vagrant/magma/lte/gateway/c/oai/lib/mobility_client/MobilityClientAPI.cpp: In lambda function:
/home/vagrant/magma/lte/gateway/c/oai/lib/mobility_client/MobilityClientAPI.cpp:304:7: warning: control reaches end of non-void function [-Wreturn-type]
  304 |       });
      |       ^
```
The return type of the lambda function is void.

Also sorted include headers for all cpp/h files in the mobilityclient directory

## Test Plan
mme unit tests
CI
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
