### PR TITLE
prevent nil dereference in cwf integration test

### DIFF
--- a/cwf/gateway/integ_tests/omni_rules_test.go
+++ b/cwf/gateway/integ_tests/omni_rules_test.go
@@ -121,8 +121,12 @@ func TestOmnipresentRules(t *testing.T) {
 	assert.NotNil(t, omniRecord, fmt.Sprintf("No policy usage omniRecord for imsi: %v", imsi))
 	assert.NotNil(t, blockAllRecord, fmt.Sprintf("Block all record was not installed for imsi %v", imsi))
 
-	assert.True(t, omniRecord.BytesTx > uint64(0), fmt.Sprintf("%s did not pass any data", omniRecord.RuleId))
-	assert.Equal(t, uint64(0x0), blockAllRecord.BytesTx)
+	if omniRecord != nil {
+		assert.True(t, omniRecord.BytesTx > uint64(0), fmt.Sprintf("%s did not pass any data", omniRecord.RuleId))
+	}
+	if blockAllRecord != nil {
+		assert.Equal(t, uint64(0x0), blockAllRecord.BytesTx)
+	}
 
 	tr.AssertAllGyExpectationsMetNoError()
 	tr.AssertAllGxExpectationsMetNoError()


### PR DESCRIPTION
Signed-off-by: Marie Bremner <marwhal@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary
preventing the nil dereference seen here: https://app.circleci.com/pipelines/github/magma/magma/22108/workflows/582dbff6-d203-470b-9752-05508f0e072b/jobs/234175
<!-- Enumerate changes you made and why you made them -->

## Test Plan
ci
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
