### PR TITLE
run xwfm test daily not hourly

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1466,10 +1466,10 @@ workflows:
           requires:
             - cwf-operator-precommit
 
-  hourly_xwfm:
+  daily_xwfm:
     triggers:
       - schedule:
-          cron: "0 * * * *"
+          cron: "0 0 * * *"
           <<: *only_master
     jobs:
       - xwfm-test:


### PR DESCRIPTION
Signed-off-by: Marie Bremner <marwhal@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary
running the xwfm test hourly seems a bit much, so reducing to daily
(This test is also run whenever a commit is merged into master as well)
<!-- Enumerate changes you made and why you made them -->

## Test Plan
test on master?
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
