### PR TITLE
refactor: remove bearer scheduling for create session

### DIFF
--- a/lte/gateway/c/session_manager/LocalEnforcer.h
+++ b/lte/gateway/c/session_manager/LocalEnforcer.h
@@ -187,10 +187,6 @@ class LocalEnforcer {
       SessionState& session, const CreateSessionResponse& response,
       std::unordered_set<uint32_t>& charging_credits_received);
 
-  void schedule_session_init_dedicated_bearer_creations(
-      const std::string& imsi, const std::string& session_id,
-      BearerUpdate& bearer_updates);
-
   /**
    * Initialize session on session map. Adds some information comming from
    * the core (cloud). Rules will be installed by init_session_credit
@@ -310,7 +306,6 @@ class LocalEnforcer {
   std::unique_ptr<Timezone>& get_access_timezone() { return access_timezone_; };
 
   static uint32_t REDIRECT_FLOW_PRIORITY;
-  static uint32_t BEARER_CREATION_DELAY_ON_SESSION_INIT;
   // If this is set to true, we will send the timezone along with
   // CreateSessionRequest
   static bool SEND_ACCESS_TIMEZONE;

--- a/lte/gateway/c/session_manager/sessiond_main.cpp
+++ b/lte/gateway/c/session_manager/sessiond_main.cpp
@@ -119,10 +119,6 @@ void set_consts(const YAML::Node& config) {
   magma::SessionCredit::TERMINATE_SERVICE_WHEN_QUOTA_EXHAUSTED =
       config["terminate_service_when_quota_exhausted"].as<bool>();
 
-  if (config["bearer_creation_delay_on_session_init"].IsDefined()) {
-    magma::LocalEnforcer::BEARER_CREATION_DELAY_ON_SESSION_INIT =
-        config["bearer_creation_delay_on_session_init"].as<uint32_t>();
-  }
   if (config["send_access_timezone"].IsDefined()) {
     magma::LocalEnforcer::SEND_ACCESS_TIMEZONE =
         config["send_access_timezone"].as<bool>();

--- a/lte/gateway/c/session_manager/test/test_local_enforcer.cpp
+++ b/lte/gateway/c/session_manager/test/test_local_enforcer.cpp
@@ -1870,23 +1870,14 @@ TEST_F(LocalEnforcerTest, test_rar_create_dedicated_bearer) {
   EXPECT_EQ(raa.result(), ReAuthResult::UPDATE_INITIATED);
 }
 
-// This test covers some edge cases for the dedicated bearer creation scheduling
-// for a new session. For session creation, we delay the actual call to create
-// bearer by a few seconds. (BEARER_CREATION_DELAY_ON_SESSION_INIT)
-// But since we could have a case where the rule state is modified during the
-// scheduling and the actual call, we want to ensure that we do not create
-// bearers if:
-// 1. Policy is no longer installed.
-// 2. Policy no longer needs a bearer for some reason. One case of this could be
-// that it is already tied to a bearer.
-// The success case where the creation takes place is covered by another test
-// "test_dedicated_bearer_lifecycle"
+// This test covers the case where a dedicated bearer needs to be created when
+// the session is created. See another test 'test_dedicated_bearer_lifecycle'
+// for the update/reauth dedicated bearer flow
 TEST_F(LocalEnforcerTest, test_dedicated_bearer_creation_on_session_init) {
   CreateSessionResponse response1, response2;
   const uint32_t default_bearer_id = 5;
   const uint32_t bearer_1          = 6;
-  insert_static_rule_with_qos(0, "m1", "rule1", 1);             // QCI=1
-  LocalEnforcer::BEARER_CREATION_DELAY_ON_SESSION_INIT = 1000;  // 1 sec
+  insert_static_rule_with_qos(0, "m1", "qos-rule1", 1);  // QCI=1
 
   // test_cfg_ is initialized with QoSInfo field w/ QCI 5
   test_cfg_.common_context.mutable_sid()->set_id(IMSI1);
@@ -1895,75 +1886,21 @@ TEST_F(LocalEnforcerTest, test_dedicated_bearer_creation_on_session_init) {
   lte_context->mutable_qos_info()->set_qos_class_id(5);
   lte_context->set_bearer_id(default_bearer_id);  // linked_bearer_id
 
-  // CASE 1: policy has a bearer by the time the scheduled function is executed
-  response1.mutable_static_rules()->Add()->set_rule_id("rule1");
-  // Schedules default bearer install in 1 sec
+  response1.mutable_static_rules()->Add()->set_rule_id("qos-rule1");
   local_enforcer->init_session(
       session_map, IMSI1, SESSION_ID_1, test_cfg_, response1);
+  EXPECT_CALL(*spgw_client, create_dedicated_bearer(testing::_)).Times(1);
   local_enforcer->update_tunnel_ids(
       session_map,
-      create_update_tunnel_ids_request(IMSI1, BEARER_ID_1, teids1));
-  // Write + Read in/from SessionStore
-  bool write_success =
-      session_store->create_sessions(IMSI1, std::move(session_map[IMSI1]));
-  EXPECT_TRUE(write_success);
+      create_update_tunnel_ids_request(IMSI1, default_bearer_id, teids1));
 
-  // Before we hit the 1 second, simulate a case where another call triggered
-  // the policy to be tied a bearer already
-  session_map = session_store->read_sessions({IMSI1});
-  auto update = SessionStore::get_default_session_update(session_map);
   PolicyBearerBindingRequest bearer_bind_req_success1 =
       create_policy_bearer_bind_req(
-          IMSI1, default_bearer_id, "rule1", bearer_1, 1, 2);
+          IMSI1, default_bearer_id, "qos-rule1", bearer_1, 1, 2);
+
+  auto update = SessionStore::get_default_session_update(session_map);
   local_enforcer->bind_policy_to_bearer(
       session_map, bearer_bind_req_success1, update);
-  // Write + Read in/from SessionStore
-  write_success = session_store->update_sessions(update);
-  EXPECT_TRUE(write_success);
-  // Since the policy is already tied to a bearer, we should not see an
-  // additional create bearer request when the scheduled creation happens
-  EXPECT_CALL(
-      *spgw_client, create_dedicated_bearer(CheckCreateBearerReq(IMSI1, 1)))
-      .Times(0);
-  evb->loopOnce();
-
-  // CASE 2: policy has been removed
-  session_map = session_store->read_all_sessions();
-  response2.mutable_static_rules()->Add()->set_rule_id("rule1");
-
-  // Schedules default bearer install in 1 sec
-  auto test_cfg_2 = test_cfg_;
-  test_cfg_2.common_context.mutable_teids()->CopyFrom(teids2);
-  test_cfg_2.rat_specific_context.mutable_lte_context()->set_bearer_id(
-      BEARER_ID_2);
-
-  local_enforcer->init_session(
-      session_map, IMSI2, SESSION_ID_2, test_cfg_2, response2);
-  local_enforcer->update_tunnel_ids(
-      session_map,
-      create_update_tunnel_ids_request(IMSI2, BEARER_ID_2, teids2));
-
-  // Write + Read in/from SessionStore
-  write_success =
-      session_store->create_sessions(IMSI2, std::move(session_map[IMSI2]));
-  EXPECT_TRUE(write_success);
-  // Before we hit the 1 second, remove the policy
-  session_map = session_store->read_sessions({IMSI2});
-  update      = SessionStore::get_default_session_update(session_map);
-  SessionRules session_rules;
-  auto rule_set_per_sub = session_rules.mutable_rules_per_subscriber()->Add();
-  rule_set_per_sub->set_imsi(IMSI2);
-  rule_set_per_sub->mutable_rule_set()->Add()->CopyFrom(
-      create_rule_set(false, "apn1", {}, {}));  // Remove all rules
-  local_enforcer->handle_set_session_rules(session_map, session_rules, update);
-  // Write + Read in/from SessionStore
-  write_success = session_store->update_sessions(update);
-  EXPECT_TRUE(write_success);
-  // Rule is removed, expect no bearer creation
-  EXPECT_CALL(
-      *spgw_client, create_dedicated_bearer(CheckCreateBearerReq(IMSI1, 1)))
-      .Times(0);
-  evb->loopOnce();
 }
 
 // Create multiple rules with QoS and assert dedicated bearers are created
@@ -2021,7 +1958,6 @@ TEST_F(LocalEnforcerTest, test_dedicated_bearer_lifecycle) {
       .Times(1)
       .WillOnce(testing::Return(true));
   // For testing change the delay to 0 ms.
-  LocalEnforcer::BEARER_CREATION_DELAY_ON_SESSION_INIT = 0;
   local_enforcer->init_session(
       session_map, IMSI1, SESSION_ID_1, test_cfg_, response);
   local_enforcer->update_tunnel_ids(

--- a/lte/gateway/configs/sessiond.yml
+++ b/lte/gateway/configs/sessiond.yml
@@ -38,11 +38,6 @@ support_carrier_wifi: false
 # quota.
 cwf_quota_exhaustion_termination_on_init_ms: 30000
 
-# On session creation, we want to delay the bearer creation requests to after
-# the attach has completed. This value indicates how many ms to wait before
-# sending the bearer create request.
-bearer_creation_delay_on_session_init: 2000
-
 # If this flag is set, we will send the GW's timezone information to the policy
 # component as part of CreateSessionRequest.
 send_access_timezone: true


### PR DESCRIPTION
Signed-off-by: Marie Bremner <marwhal@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary
A few months ago, we made a change in SessionD to not process any rule installs for new sessions until we receive `UpdateTunnelIds` from MME. This means that by the time we install rules and potentially make dedicated bearer requests to MME, the default bearer is already created and ready. (We know this because the `UpdateTunnelIds` request from MME contains the teid for the default bearer.)
PR that introduced the delay: https://github.com/magma/magma/pull/2718

When we initially added logic to optionally send dedicated bearer requests upon processing the initial policies, we did not have this two phase session creation. In order to get around the fact that MME is not prepared to create dedicated bearers at the time when `CreateSession` request/response is made, we added few seconds of delay before sending the dedicated bearer request. 

As described above, we do not need this delay anymore since we don't process any rules until we receive `UpdateTunnelIds`.

This PR removes the config value / logic relating to the dedicated bearer creation delay for initial policy processing. 

<!-- Enumerate changes you made and why you made them -->

## Test Plan
unit tests
CI / integration test
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
