### PR TITLE
clean: clean up unused functions and param types in SessionCredit

### DIFF
--- a/lte/gateway/c/session_manager/ChargingGrant.cpp
+++ b/lte/gateway/c/session_manager/ChargingGrant.cpp
@@ -83,7 +83,7 @@ CreditValidity ChargingGrant::is_valid_credit_response(
       !gsu.total().is_valid() && !gsu.rx().is_valid() && !gsu.tx().is_valid();
   if (gsu_all_invalid) {
     if (update.credit().is_final() || credit_validity == TRANSIENT_ERROR) {
-      // TODO @themarwhal look into this case. Before I figure it out, I will
+      // TODO(@themarwhal): look into this case. Before I figure it out, I will
       // allow empty GSU credits with FUA or to be suspended
       // to be on the conservative side.
       MLOG(MWARNING)
@@ -154,10 +154,10 @@ SessionCreditUpdateCriteria ChargingGrant::get_update_criteria() {
 }
 
 CreditUsage ChargingGrant::get_credit_usage(
-    CreditUsage::UpdateType update_type, SessionCreditUpdateCriteria& uc,
+    CreditUsage::UpdateType update_type, SessionCreditUpdateCriteria* uc,
     bool is_terminate) {
   CreditUsage p_usage;
-  SessionCredit::Usage credit_usage;
+  Usage credit_usage;
 
   if (is_final_grant || is_terminate) {
     credit_usage = credit.get_all_unreported_usage_for_reporting(uc);

--- a/lte/gateway/c/session_manager/ChargingGrant.h
+++ b/lte/gateway/c/session_manager/ChargingGrant.h
@@ -90,7 +90,7 @@ struct ChargingGrant {
   // usage, otherwise we only include unreported usage up to the allocated
   // amount.
   CreditUsage get_credit_usage(
-      CreditUsage::UpdateType update_type, SessionCreditUpdateCriteria& uc,
+      CreditUsage::UpdateType update_type, SessionCreditUpdateCriteria* uc,
       bool is_terminate);
 
   // get_requested_units returns total, tx and rx needed to cover one worth of

--- a/lte/gateway/c/session_manager/MeteringReporter.cpp
+++ b/lte/gateway/c/session_manager/MeteringReporter.cpp
@@ -57,7 +57,7 @@ void MeteringReporter::report_usage(
 
 void MeteringReporter::initialize_usage(
     const std::string& imsi, const std::string& session_id,
-    SessionCredit::TotalCreditUsage usage) {
+    TotalCreditUsage usage) {
   auto tx = usage.monitoring_tx + usage.charging_tx;
   auto rx = usage.monitoring_rx + usage.charging_rx;
   report_traffic(imsi, session_id, DIRECTION_UP, tx);

--- a/lte/gateway/c/session_manager/MeteringReporter.h
+++ b/lte/gateway/c/session_manager/MeteringReporter.h
@@ -40,7 +40,7 @@ class MeteringReporter {
    */
   void initialize_usage(
       const std::string& imsi, const std::string& session_id,
-      SessionCredit::TotalCreditUsage usage);
+      TotalCreditUsage usage);
 
  private:
   /**

--- a/lte/gateway/c/session_manager/SessionCredit.cpp
+++ b/lte/gateway/c/session_manager/SessionCredit.cpp
@@ -60,7 +60,7 @@ SessionCredit::SessionCredit(const StoredSessionCredit& marshaled) {
   }
 }
 
-StoredSessionCredit SessionCredit::marshal() {
+StoredSessionCredit SessionCredit::marshal() const {
   StoredSessionCredit marshaled{};
   marshaled.reporting              = reporting_;
   marshaled.credit_limit_type      = credit_limit_type_;
@@ -77,76 +77,82 @@ StoredSessionCredit SessionCredit::marshal() {
   return marshaled;
 }
 
-SessionCreditUpdateCriteria SessionCredit::get_update_criteria() {
-  SessionCreditUpdateCriteria uc{};
-  uc.deleted                = false;
-  uc.grant_tracking_type    = grant_tracking_type_;
-  uc.received_granted_units = received_granted_units_;
-  uc.report_last_credit     = report_last_credit_;
-  uc.time_of_first_usage    = time_of_first_usage_;
-  uc.time_of_last_usage     = time_of_last_usage_;
+SessionCreditUpdateCriteria SessionCredit::get_update_criteria() const {
+  SessionCreditUpdateCriteria credit_uc{};
+  credit_uc.deleted                = false;
+  credit_uc.grant_tracking_type    = grant_tracking_type_;
+  credit_uc.received_granted_units = received_granted_units_;
+  credit_uc.report_last_credit     = report_last_credit_;
+  credit_uc.time_of_first_usage    = time_of_first_usage_;
+  credit_uc.time_of_last_usage     = time_of_last_usage_;
 
   for (int bucket_int = USED_TX; bucket_int != MAX_VALUES; bucket_int++) {
-    Bucket bucket            = static_cast<Bucket>(bucket_int);
-    uc.bucket_deltas[bucket] = 0;
+    Bucket bucket                   = static_cast<Bucket>(bucket_int);
+    credit_uc.bucket_deltas[bucket] = 0;
   }
-  return uc;
+  return credit_uc;
 }
 
 void SessionCredit::add_used_credit(
     uint64_t used_tx, uint64_t used_rx,
-    SessionCreditUpdateCriteria& credit_uc) {
+    SessionCreditUpdateCriteria* credit_uc) {
   if (used_tx > 0 || used_rx > 0) {
     buckets_[USED_TX] += used_tx;
     buckets_[USED_RX] += used_rx;
-    credit_uc.bucket_deltas[USED_TX] += used_tx;
-    credit_uc.bucket_deltas[USED_RX] += used_rx;
-    update_usage_timestamps(credit_uc);
+    if (credit_uc != nullptr) {
+      credit_uc->bucket_deltas[USED_TX] += used_tx;
+      credit_uc->bucket_deltas[USED_RX] += used_rx;
+      update_usage_timestamps(credit_uc);
+    }
   }
 
   log_quota_and_usage();
 }
 
 void SessionCredit::update_usage_timestamps(
-    SessionCreditUpdateCriteria& credit_uc) {
+    SessionCreditUpdateCriteria* credit_uc) {
   auto now = magma::get_time_in_sec_since_epoch();
   if (time_of_first_usage_ == 0) {
-    time_of_first_usage_          = now;
-    credit_uc.time_of_first_usage = now;
+    time_of_first_usage_ = now;
   }
-  time_of_last_usage_          = now;
-  credit_uc.time_of_last_usage = now;
+  time_of_last_usage_ = now;
+
+  if (credit_uc != nullptr) {
+    credit_uc->time_of_first_usage = time_of_first_usage_;
+    credit_uc->time_of_last_usage  = time_of_last_usage_;
+  }
 }
 
-void SessionCredit::reset_reporting_credit(SessionCreditUpdateCriteria* uc) {
+void SessionCredit::reset_reporting_credit(
+    SessionCreditUpdateCriteria* credit_uc) {
   buckets_[REPORTING_RX] = 0;
   buckets_[REPORTING_TX] = 0;
   reporting_             = false;
-  if (uc != NULL) {
-    uc->reporting = false;
+  if (credit_uc != NULL) {
+    credit_uc->reporting = false;
   }
 }
 
 void SessionCredit::mark_failure(
-    uint32_t code, SessionCreditUpdateCriteria* uc) {
+    uint32_t code, SessionCreditUpdateCriteria* credit_uc) {
   if (DiameterCodeHandler::is_transient_failure(code)) {
     MLOG(MDEBUG) << "Found transient failure code in mark_failure. Resetting "
                     "'REPORTING' values";
     buckets_[REPORTED_RX] += buckets_[REPORTING_RX];
     buckets_[REPORTED_TX] += buckets_[REPORTING_TX];
-    if (uc != NULL) {
-      uc->bucket_deltas[REPORTED_RX] += buckets_[REPORTING_RX];
-      uc->bucket_deltas[REPORTED_TX] += buckets_[REPORTING_TX];
+    if (credit_uc != NULL) {
+      credit_uc->bucket_deltas[REPORTED_RX] += buckets_[REPORTING_RX];
+      credit_uc->bucket_deltas[REPORTED_TX] += buckets_[REPORTING_TX];
     }
   }
-  reset_reporting_credit(uc);
+  reset_reporting_credit(credit_uc);
 }
 
 // receive_credit will add received grant to current credits. Note that if
 // there is over-usage, the extra amount will be added to the counters by
 // calculate_delta_allowed_floor and calculate_delta_allowed
 void SessionCredit::receive_credit(
-    const GrantedUnits& gsu, SessionCreditUpdateCriteria* uc) {
+    const GrantedUnits& gsu, SessionCreditUpdateCriteria* credit_uc) {
   // only decide the grant tracking type on the very first refill
   if (grant_tracking_type_ == TRACKING_UNSET) {
     grant_tracking_type_ = determine_grant_tracking_type(gsu);
@@ -197,23 +203,23 @@ void SessionCredit::receive_credit(
   buckets_[REPORTED_RX] += buckets_[REPORTING_RX];
   buckets_[REPORTED_TX] += buckets_[REPORTING_TX];
 
-  if (uc != NULL) {
-    uc->received_granted_units = gsu;
-    uc->grant_tracking_type    = grant_tracking_type_;
+  if (credit_uc != NULL) {
+    credit_uc->received_granted_units = gsu;
+    credit_uc->grant_tracking_type    = grant_tracking_type_;
 
-    uc->bucket_deltas[ALLOWED_TOTAL] += delta_allowed_total;
-    uc->bucket_deltas[ALLOWED_TX] += delta_allowed_tx;
-    uc->bucket_deltas[ALLOWED_RX] += delta_allowed_rx;
+    credit_uc->bucket_deltas[ALLOWED_TOTAL] += delta_allowed_total;
+    credit_uc->bucket_deltas[ALLOWED_TX] += delta_allowed_tx;
+    credit_uc->bucket_deltas[ALLOWED_RX] += delta_allowed_rx;
 
-    uc->bucket_deltas[REPORTED_RX] += buckets_[REPORTING_RX];
-    uc->bucket_deltas[REPORTED_TX] += buckets_[REPORTING_TX];
+    credit_uc->bucket_deltas[REPORTED_RX] += buckets_[REPORTING_RX];
+    credit_uc->bucket_deltas[REPORTED_TX] += buckets_[REPORTING_TX];
 
-    uc->bucket_deltas[ALLOWED_FLOOR_TOTAL] += delta_allowed_floor_total;
-    uc->bucket_deltas[ALLOWED_FLOOR_TX] += delta_allowed_floor_tx;
-    uc->bucket_deltas[ALLOWED_FLOOR_RX] += delta_allowed_floor_rx;
+    credit_uc->bucket_deltas[ALLOWED_FLOOR_TOTAL] += delta_allowed_floor_total;
+    credit_uc->bucket_deltas[ALLOWED_FLOOR_TX] += delta_allowed_floor_tx;
+    credit_uc->bucket_deltas[ALLOWED_FLOOR_RX] += delta_allowed_floor_rx;
   }
 
-  reset_reporting_credit(uc);
+  reset_reporting_credit(credit_uc);
   log_quota_and_usage();
 }
 
@@ -313,21 +319,23 @@ bool SessionCredit::is_quota_exhausted(float threshold) const {
   return is_exhausted;
 }
 
-SessionCredit::Usage SessionCredit::get_all_unreported_usage_for_reporting(
-    SessionCreditUpdateCriteria& update_criteria) {
+Usage SessionCredit::get_all_unreported_usage_for_reporting(
+    SessionCreditUpdateCriteria* credit_uc) {
   auto usage = get_unreported_usage();
   buckets_[REPORTING_TX] += usage.bytes_tx;
   buckets_[REPORTING_RX] += usage.bytes_rx;
-  reporting_                = true;
-  update_criteria.reporting = true;
+  reporting_ = true;
+  if (credit_uc != nullptr) {
+    credit_uc->reporting = true;
+  }
   log_usage_report(usage);
   return usage;
 }
 
-SessionCredit::Summary SessionCredit::get_credit_summary() {
+SessionCredit::Summary SessionCredit::get_credit_summary() const {
   return SessionCredit::Summary{
       .usage =
-          SessionCredit::Usage{
+          Usage{
               .bytes_tx = buckets_[USED_TX],
               .bytes_rx = buckets_[USED_RX],
           },
@@ -336,16 +344,18 @@ SessionCredit::Summary SessionCredit::get_credit_summary() {
   };
 }
 
-SessionCredit::Usage SessionCredit::get_usage_for_reporting(
-    SessionCreditUpdateCriteria& update_criteria) {
+Usage SessionCredit::get_usage_for_reporting(
+    SessionCreditUpdateCriteria* credit_uc) {
   auto usage = get_unreported_usage();
   // Apply reporting limits since the user is not getting terminated.
   // We never want to report more than the amount we've received
 
   buckets_[REPORTING_TX] += usage.bytes_tx;
   buckets_[REPORTING_RX] += usage.bytes_rx;
-  reporting_                = true;
-  update_criteria.reporting = true;
+  reporting_ = true;
+  if (credit_uc != nullptr) {
+    credit_uc->reporting = true;
+  }
 
   log_usage_report(usage);
   return usage;
@@ -359,7 +369,7 @@ RequestedUnits SessionCredit::get_initial_requested_credits_units() {
   return requestedUnits;
 }
 
-RequestedUnits SessionCredit::get_requested_credits_units() {
+RequestedUnits SessionCredit::get_requested_credits_units() const {
   RequestedUnits requestedUnits;
   uint64_t buckets_used_total = buckets_[USED_TX] + buckets_[USED_RX];
 
@@ -386,7 +396,7 @@ RequestedUnits SessionCredit::get_requested_credits_units() {
 // and the credit remaining. Prevents over requesting in case we still have
 // credit available from the previous request
 uint64_t SessionCredit::calculate_requested_unit(
-    CreditUnit cu, Bucket allowed, Bucket allowed_floor, uint64_t used) {
+    CreditUnit cu, Bucket allowed, Bucket allowed_floor, uint64_t used) const {
   if (cu.is_valid() == false) {
     return 0;
   }
@@ -402,49 +412,9 @@ uint64_t SessionCredit::calculate_requested_unit(
   return grant;
 }
 
-// Take the minimum of (grant - reported) and (reported - used)
-void SessionCredit::apply_reporting_limits(SessionCredit::Usage& usage) {
-  uint64_t tx_limit, rx_limit, total_limit, total_reported;
-
-  tx_limit =
-      compute_reporting_limit(buckets_[ALLOWED_TX], buckets_[REPORTED_TX]);
-  rx_limit =
-      compute_reporting_limit(buckets_[ALLOWED_TX], buckets_[REPORTED_TX]);
-
-  switch (grant_tracking_type_) {
-    case TX_ONLY:
-      usage.bytes_tx = std::min(usage.bytes_tx, tx_limit);
-      usage.bytes_rx = 0;  // Clear field that doesn't need to be reported
-      MLOG(MDEBUG) << "Applying a TX reporting limit of " << tx_limit;
-      break;
-    case RX_ONLY:
-      usage.bytes_rx = std::min(usage.bytes_rx, rx_limit);
-      usage.bytes_tx = 0;  // Clear field that doesn't need to be reported
-      MLOG(MDEBUG) << "Applying a RX reporting limit of " << rx_limit;
-      break;
-    case TX_AND_RX:
-      usage.bytes_tx = std::min(usage.bytes_tx, tx_limit);
-      usage.bytes_rx = std::min(usage.bytes_rx, rx_limit);
-      MLOG(MDEBUG) << "Applying TX and RX reporting limits of " << tx_limit
-                   << ", " << rx_limit;
-      break;
-    case TOTAL_ONLY:
-      total_reported = buckets_[REPORTED_RX] + buckets_[REPORTED_TX];
-      total_limit =
-          compute_reporting_limit(buckets_[ALLOWED_TOTAL], total_reported);
-      usage.bytes_tx = std::min(usage.bytes_tx, total_limit);
-      usage.bytes_rx = std::min(usage.bytes_rx, total_limit - usage.bytes_tx);
-      MLOG(MDEBUG) << "Applying a total reporting limit of " << total_limit;
-      break;
-    default:
-      MLOG(MERROR) << "Credit with this tracking type is probably unexpected: "
-                   << grant_tracking_type_;
-  }
-}
-
-SessionCredit::Usage SessionCredit::get_unreported_usage() const {
-  SessionCredit::Usage usage = {0, 0};
-  auto report                = buckets_[REPORTED_TX] + buckets_[REPORTING_TX];
+Usage SessionCredit::get_unreported_usage() const {
+  Usage usage = {0, 0};
+  auto report = buckets_[REPORTED_TX] + buckets_[REPORTING_TX];
   if (buckets_[USED_TX] > report) {
     usage.bytes_tx = buckets_[USED_TX] - report;
   }
@@ -455,15 +425,6 @@ SessionCredit::Usage SessionCredit::get_unreported_usage() const {
   MLOG(MDEBUG) << "===> Data usage since last report is tx=" << usage.bytes_tx
                << " rx=" << usage.bytes_rx;
   return usage;
-}
-
-uint64_t SessionCredit::compute_reporting_limit(
-    const uint64_t allowed, const uint64_t reported) const {
-  uint64_t limit = 0;
-  if (allowed > reported) {
-    limit = allowed - reported;
-  }
-  return limit;
 }
 
 bool SessionCredit::compute_quota_exhausted(
@@ -490,7 +451,7 @@ bool SessionCredit::compute_quota_exhausted(
   uint64_t remaining_credit      = allowed - used;
   uint64_t current_granted_units = allowed - floor;
   // this step is necessary to avoid precision issues of float
-  int integer_threshold_ratio = 100 - int(threshold_ratio * 100);
+  int integer_threshold_ratio = 100 - static_cast<int>(threshold_ratio * 100);
   uint64_t threshold = (current_granted_units * integer_threshold_ratio) / 100;
 
   return remaining_credit <= threshold;
@@ -504,33 +465,24 @@ uint64_t SessionCredit::get_credit(Bucket bucket) const {
   return buckets_[bucket];
 }
 
-void SessionCredit::set_grant_tracking_type(
-    GrantTrackingType g_type, SessionCreditUpdateCriteria& uc) {
-  grant_tracking_type_   = g_type;
-  uc.grant_tracking_type = g_type;
-}
-
-void SessionCredit::set_received_granted_units(
-    GrantedUnits& rgu, SessionCreditUpdateCriteria& uc) {
-  received_granted_units_   = rgu;
-  uc.received_granted_units = rgu;
-}
-
 void SessionCredit::set_report_last_credit(
-    bool report_last_credit, SessionCreditUpdateCriteria& uc) {
-  report_last_credit_   = report_last_credit;
-  uc.report_last_credit = report_last_credit;
+    bool report_last_credit, SessionCreditUpdateCriteria* credit_uc) {
+  report_last_credit_ = report_last_credit;
+  if (credit_uc != nullptr) {
+    credit_uc->report_last_credit = report_last_credit;
+  }
 }
 
 void SessionCredit::set_reporting(bool reporting) {
   reporting_ = reporting;
 }
 
-bool SessionCredit::is_report_last_credit() {
+bool SessionCredit::is_report_last_credit() const {
   return report_last_credit_;
 }
 
-void SessionCredit::merge(SessionCreditUpdateCriteria& credit_uc) {
+void SessionCredit::apply_update_criteria(
+    const SessionCreditUpdateCriteria& credit_uc) {
   grant_tracking_type_    = credit_uc.grant_tracking_type;
   received_granted_units_ = credit_uc.received_granted_units;
   report_last_credit_     = credit_uc.report_last_credit;
@@ -544,13 +496,6 @@ void SessionCredit::merge(SessionCreditUpdateCriteria& credit_uc) {
     auto credit   = credit_uc.bucket_deltas.find(bucket)->second;
     buckets_[bucket] += credit;
   }
-}
-
-void SessionCredit::add_credit(
-    uint64_t credit, Bucket bucket,
-    SessionCreditUpdateCriteria& update_criteria) {
-  buckets_[bucket] += credit;
-  update_criteria.bucket_deltas[bucket] += credit;
 }
 
 // Determine the grant's tracking type by looking at which values are valid.
@@ -649,8 +594,6 @@ void SessionCredit::log_quota_and_usage() const {
   MLOG(MDEBUG) << "===> Grant tracking type "
                << grant_type_to_str(grant_tracking_type_)
                << ",  Reporting: " << reporting_;
-  // TODO: delete once we tested it works for both credit and monitors
-
   MLOG(MDEBUG) << "===> Last Granted Units Received (tx/rx/total) "
                << received_granted_units_.tx().volume() << "/"
                << received_granted_units_.rx().volume() << "/"
@@ -664,7 +607,7 @@ std::string SessionCredit::get_percentage_usage(
   }
   int64_t currentGrant = allowed - floor;
   int64_t currentUsage = used - floor;
-  int currentPercent   = int(100 * currentUsage / currentGrant);
+  int currentPercent   = static_cast<int>(100 * currentUsage / currentGrant);
   // cap % in case it grows too much
   if (abs(currentPercent) >= 1000) {
     currentPercent = 999 * currentPercent / abs(currentPercent);
@@ -672,7 +615,7 @@ std::string SessionCredit::get_percentage_usage(
   return std::to_string(currentPercent) + "%";
 }
 
-void SessionCredit::log_usage_report(SessionCredit::Usage usage) const {
+void SessionCredit::log_usage_report(Usage usage) const {
   if (magma::get_verbosity() != MDEBUG) {
     return;
   }

--- a/lte/gateway/c/session_manager/SessionCredit.h
+++ b/lte/gateway/c/session_manager/SessionCredit.h
@@ -16,6 +16,7 @@
 #include <string>
 
 #include "StoredState.h"
+#include "Types.h"
 
 namespace magma {
 /**
@@ -25,40 +26,27 @@ namespace magma {
  */
 class SessionCredit {
  public:
-  struct Usage {
-    uint64_t bytes_tx;
-    uint64_t bytes_rx;
-  };
-
   struct Summary {
-    SessionCredit::Usage usage;
+    Usage usage;
     uint64_t time_of_first_usage;
     uint64_t time_of_last_usage;
   };
 
-  // TODO refactor to use the Usage struct above
-  struct TotalCreditUsage {
-    uint64_t monitoring_tx;
-    uint64_t monitoring_rx;
-    uint64_t charging_tx;
-    uint64_t charging_rx;
-  };
-
   SessionCredit();
 
-  SessionCredit(ServiceState start_state);
+  explicit SessionCredit(ServiceState start_state);
 
   SessionCredit(ServiceState start_state, CreditLimitType limit_type);
 
-  SessionCredit(const StoredSessionCredit& marshaled);
+  explicit SessionCredit(const StoredSessionCredit& marshaled);
 
-  StoredSessionCredit marshal();
+  StoredSessionCredit marshal() const;
 
   /**
    * get_update_criteria constructs a SessionCreditUpdateCriteria with default
    * values.
    */
-  SessionCreditUpdateCriteria get_update_criteria();
+  SessionCreditUpdateCriteria get_update_criteria() const;
 
   /**
    * add_used_credit increments USED_TX and USED_RX
@@ -66,32 +54,32 @@ class SessionCredit {
    */
   void add_used_credit(
       uint64_t used_tx, uint64_t used_rx,
-      SessionCreditUpdateCriteria& credit_uc);
+      SessionCreditUpdateCriteria* credit_uc);
 
   /**
    * reset_reporting_credit resets the REPORTING_* to 0
    * Also marks the session as not in reporting.
    */
-  void reset_reporting_credit(SessionCreditUpdateCriteria* uc);
+  void reset_reporting_credit(SessionCreditUpdateCriteria* credit_uc);
 
   /**
    * Credit update has failed to the OCS, so mark this credit as failed so it
    * can be cut off accordingly
    */
-  void mark_failure(uint32_t code, SessionCreditUpdateCriteria* uc);
+  void mark_failure(uint32_t code, SessionCreditUpdateCriteria* credit_uc);
   /**
    * receive_credit increments ALLOWED* and moves the REPORTING_* credit to
    * the REPORTED_* credit
    */
-  void receive_credit(const GrantedUnits& gsu, SessionCreditUpdateCriteria* uc);
+  void receive_credit(
+      const GrantedUnits& gsu, SessionCreditUpdateCriteria* credit_uc);
 
   /**
    * get_update returns a filled-in CreditUsage if an update exists, and a blank
    * one if no update exists. Check has_update before calling.
    * This method also sets the REPORTING_* credit buckets
    */
-  SessionCredit::Usage get_usage_for_reporting(
-      SessionCreditUpdateCriteria& update_criteria);
+  Usage get_usage_for_reporting(SessionCreditUpdateCriteria* credit_uc);
 
   /**
    * returns the units to be requested to OCS for the first request. Its default
@@ -103,15 +91,15 @@ class SessionCredit {
    * returns the units to be requested to OCS based on the last grant. If
    * the last grant is not totally used it will return lastGrant - usage
    */
-  RequestedUnits get_requested_credits_units();
+  RequestedUnits get_requested_credits_units() const;
 
-  SessionCredit::Usage get_all_unreported_usage_for_reporting(
-      SessionCreditUpdateCriteria& update_criteria);
+  Usage get_all_unreported_usage_for_reporting(
+      SessionCreditUpdateCriteria* credit_uc);
 
   /**
    * Returns the credit's cumulative rx/tx usage and first/last usage timestamps
    */
-  SessionCredit::Summary get_credit_summary();
+  SessionCredit::Summary get_credit_summary() const;
 
   /**
    * Returns true if either of REPORTING_* buckets are more than 0
@@ -123,34 +111,17 @@ class SessionCredit {
    */
   uint64_t get_credit(Bucket bucket) const;
 
-  void set_grant_tracking_type(
-      GrantTrackingType g_type, SessionCreditUpdateCriteria& uc);
-
-  void set_received_granted_units(
-      GrantedUnits& rgu, SessionCreditUpdateCriteria& uc);
-
   void set_report_last_credit(
-      bool report_last_credit, SessionCreditUpdateCriteria& uc);
+      bool report_last_credit, SessionCreditUpdateCriteria* credit_uc);
 
   void set_reporting(bool reporting);
 
-  bool is_report_last_credit();
+  bool is_report_last_credit() const;
 
   /**
-   * Add credit to the specified bucket. This does not necessarily correspond
-   * to allowed or used credit.
-   * NOTE: Use only for merging updates into SessionStore
-   * @param credit
-   * @param bucket
+   * Applies the given SessionCreditUpdateCriteria to credit
    */
-  void add_credit(
-      uint64_t credit, Bucket bucket,
-      SessionCreditUpdateCriteria& update_criteria);
-
-  /**
-   * Merges SessionCredit UpdateCriteria with credit
-   * */
-  void merge(SessionCreditUpdateCriteria& uc);
+  void apply_update_criteria(const SessionCreditUpdateCriteria& credit_uc);
 
   /**
    * is_quota_exhausted checks if any of the remaining quota (Allowed - Used)
@@ -219,23 +190,18 @@ class SessionCredit {
 
   bool is_received_grented_unit_zero(const CreditUnit& cu) const;
 
-  SessionCredit::Usage get_unreported_usage() const;
+  Usage get_unreported_usage() const;
 
-  void log_usage_report(SessionCredit::Usage) const;
+  void log_usage_report(Usage) const;
 
   GrantTrackingType determine_grant_tracking_type(const GrantedUnits& grant);
 
   uint64_t calculate_requested_unit(
-      CreditUnit cu, Bucket allowed, Bucket allowed_floor, uint64_t used);
+      CreditUnit cu, Bucket allowed, Bucket allowed_floor, uint64_t used) const;
 
   bool compute_quota_exhausted(
       const uint64_t allowed, const uint64_t used, float threshold_ratio,
       const uint64_t grantedUnits) const;
-
-  uint64_t compute_reporting_limit(
-      const uint64_t allowed, const uint64_t reported) const;
-
-  void apply_reporting_limits(SessionCredit::Usage& usage);
 
   uint64_t calculate_delta_allowed_floor(
       CreditUnit cu, Bucket allowed, Bucket floor, uint64_t volume_used);
@@ -243,7 +209,7 @@ class SessionCredit {
   uint64_t calculate_delta_allowed(
       uint64_t gsu_volume, Bucket allowed, uint64_t volume_used);
 
-  void update_usage_timestamps(SessionCreditUpdateCriteria& credit_uc);
+  void update_usage_timestamps(SessionCreditUpdateCriteria* credit_uc);
 };
 
 }  // namespace magma

--- a/lte/gateway/c/session_manager/SessionEvents.cpp
+++ b/lte/gateway/c/session_manager/SessionEvents.cpp
@@ -221,7 +221,7 @@ void EventsReporterImpl::session_terminated(
   event_value[APN]           = session_cfg.common_context.apn();
   event_value[SESSION_ID]    = session->get_session_id();
 
-  SessionCredit::TotalCreditUsage usage = session->get_total_credit_usage();
+  TotalCreditUsage usage      = session->get_total_credit_usage();
   event_value[TOTAL_TX]       = usage.charging_tx + usage.monitoring_tx;
   event_value[TOTAL_RX]       = usage.charging_rx + usage.monitoring_rx;
   event_value[CHARGING_TX]    = usage.charging_tx;

--- a/lte/gateway/c/session_manager/SessionState.h
+++ b/lte/gateway/c/session_manager/SessionState.h
@@ -250,7 +250,7 @@ class SessionState {
    * rules (static and dynamic)
    * Should be called after complete_termination.
    */
-  SessionCredit::TotalCreditUsage get_total_credit_usage();
+  TotalCreditUsage get_total_credit_usage();
 
   ChargingCreditSummaries get_charging_credit_summaries();
 

--- a/lte/gateway/c/session_manager/Types.h
+++ b/lte/gateway/c/session_manager/Types.h
@@ -57,6 +57,18 @@ enum EventTriggerState {
 typedef std::unordered_map<magma::lte::EventTrigger, EventTriggerState>
     EventTriggerStatus;
 
+struct Usage {
+  uint64_t bytes_tx;
+  uint64_t bytes_rx;
+};
+
+struct TotalCreditUsage {
+  uint64_t monitoring_tx;
+  uint64_t monitoring_rx;
+  uint64_t charging_tx;
+  uint64_t charging_rx;
+};
+
 /**
  * A bucket is a counter used for tracking credit volume across sessiond.
  * These are independently incremented and reset

--- a/lte/gateway/c/session_manager/test/test_charging_grant.cpp
+++ b/lte/gateway/c/session_manager/test/test_charging_grant.cpp
@@ -95,7 +95,7 @@ TEST_F(ChargingGrantTest, test_get_update_type) {
   grant.is_final_grant = false;
   EXPECT_EQ(uc.grant_tracking_type, TOTAL_ONLY);
 
-  grant.credit.add_used_credit(2000, 0, uc);
+  grant.credit.add_used_credit(2000, 0, &uc);
   EXPECT_TRUE(grant.credit.is_quota_exhausted(0.8));
   // Credit is exhausted, we expect a quota exhaustion update type
   CreditUsage::UpdateType update_type;
@@ -104,7 +104,7 @@ TEST_F(ChargingGrantTest, test_get_update_type) {
 
   // Check how much we will report (we will report everything, even if
   // we go have gone over the allowed quota)
-  auto update = grant.credit.get_usage_for_reporting(uc);
+  auto update = grant.credit.get_usage_for_reporting(&uc);
   EXPECT_EQ(update.bytes_tx, 2000);
   EXPECT_TRUE(grant.credit.is_reporting());
 
@@ -153,7 +153,7 @@ TEST_F(ChargingGrantTest, test_should_deactivate_service) {
 
   // Exhaust quota
   uc = grant.get_update_criteria();
-  grant.credit.add_used_credit(2000, 0, uc);
+  grant.credit.add_used_credit(2000, 0, &uc);
   EXPECT_TRUE(grant.credit.is_quota_exhausted(0.8));
 
   // Test TERMINATE_SERVICE_WHEN_QUOTA_EXHAUSTED flag && is_final
@@ -188,7 +188,7 @@ TEST_F(ChargingGrantTest, test_get_action) {
   // Not a final grant
   grant.is_final_grant = false;
   grant.credit.receive_credit(gsu, &uc);
-  grant.credit.add_used_credit(1024, 0, uc);
+  grant.credit.add_used_credit(1024, 0, &uc);
   auto cont_action = grant.get_action(uc);
   EXPECT_EQ(cont_action, CONTINUE_SERVICE);
   // Check both the grant's service_state and update criteria
@@ -200,8 +200,8 @@ TEST_F(ChargingGrantTest, test_get_action) {
   grant.final_action_info =
       get_final_action_info(ChargingCredit_FinalAction_TERMINATE);
   grant.credit.receive_credit(gsu, &uc);
-  grant.credit.add_used_credit(2048, 0, uc);
-  grant.credit.add_used_credit(30, 20, uc);
+  grant.credit.add_used_credit(2048, 0, &uc);
+  grant.credit.add_used_credit(30, 20, &uc);
   grant.service_state = SERVICE_NEEDS_DEACTIVATION;
   auto term_action    = grant.get_action(uc);
   // Check that the update criteria also includes the changes
@@ -224,8 +224,8 @@ TEST_F(ChargingGrantTest, test_get_action_redirect) {
   grant.final_action_info =
       get_final_action_info(ChargingCredit_FinalAction_REDIRECT);
   grant.credit.receive_credit(gsu, &uc);
-  grant.credit.add_used_credit(2048, 0, uc);
-  grant.credit.add_used_credit(30, 20, uc);
+  grant.credit.add_used_credit(2048, 0, &uc);
+  grant.credit.add_used_credit(30, 20, &uc);
   grant.service_state = SERVICE_NEEDS_DEACTIVATION;
   auto term_action    = grant.get_action(uc);
   // Check that the update criteria also includes the changes
@@ -248,8 +248,8 @@ TEST_F(ChargingGrantTest, test_get_action_restrict) {
   grant.final_action_info =
       get_final_action_info(ChargingCredit_FinalAction_RESTRICT_ACCESS);
   grant.credit.receive_credit(gsu, &uc);
-  grant.credit.add_used_credit(2048, 0, uc);
-  grant.credit.add_used_credit(30, 20, uc);
+  grant.credit.add_used_credit(2048, 0, &uc);
+  grant.credit.add_used_credit(30, 20, &uc);
   grant.service_state = SERVICE_NEEDS_DEACTIVATION;
   auto term_action    = grant.get_action(uc);
   // Check that the update criteria also includes the changes
@@ -276,7 +276,7 @@ TEST_F(ChargingGrantTest, test_tolerance_quota_exhausted) {
 
   // Not a final credit
   grant.is_final_grant = false;
-  credit.add_used_credit(2000, 0, uc);
+  credit.add_used_credit(2000, 0, &uc);
   EXPECT_EQ(uc.bucket_deltas[USED_TX], 2000);
   EXPECT_TRUE(credit.is_quota_exhausted(0.8));
   // continue the service even we are over the quota (but not final unit)
@@ -286,7 +286,7 @@ TEST_F(ChargingGrantTest, test_tolerance_quota_exhausted) {
   // we go have gone over the allowed quota)
   CreditUsage::UpdateType update_type;
   EXPECT_TRUE(grant.get_update_type(&update_type));
-  auto c_usage = grant.get_credit_usage(update_type, uc, false);
+  auto c_usage = grant.get_credit_usage(update_type, &uc, false);
   EXPECT_EQ(update_type, CreditUsage::QUOTA_EXHAUSTED);
   EXPECT_EQ(c_usage.bytes_tx(), 2000);
   EXPECT_EQ(c_usage.bytes_rx(), 0);
@@ -324,7 +324,7 @@ TEST_F(ChargingGrantTest, test_tolerance_quota_exhausted) {
 
   // Use enough credit to exceed the given quota
   uc = grant.get_update_criteria();  // reset UC
-  credit.add_used_credit(2000, 0, uc);
+  credit.add_used_credit(2000, 0, &uc);
   EXPECT_EQ(uc.bucket_deltas[USED_TX], 2000);
   EXPECT_EQ(credit.get_credit(ALLOWED_TOTAL), 4000);
   EXPECT_EQ(credit.get_credit(REPORTED_TX), 2000);

--- a/lte/gateway/c/session_manager/test/test_session_state.cpp
+++ b/lte/gateway/c/session_manager/test/test_session_state.cpp
@@ -597,8 +597,7 @@ TEST_F(SessionStateTest, test_tgpp_context_is_set_on_update) {
 TEST_F(SessionStateTest, test_get_total_credit_usage_single_rule_no_key) {
   insert_rule(0, "", "rule1", STATIC, 0, 0);
   session_state->add_rule_usage("rule1", 2000, 1000, 0, 0, update_criteria);
-  SessionCredit::TotalCreditUsage actual =
-      session_state->get_total_credit_usage();
+  TotalCreditUsage actual = session_state->get_total_credit_usage();
   EXPECT_EQ(actual.monitoring_tx, 0);
   EXPECT_EQ(actual.monitoring_rx, 0);
   EXPECT_EQ(actual.charging_tx, 0);
@@ -609,8 +608,7 @@ TEST_F(SessionStateTest, test_get_total_credit_usage_single_rule_single_key) {
   insert_rule(1, "", "rule1", STATIC, 0, 0);
   receive_credit_from_ocs(1, 3000);
   session_state->add_rule_usage("rule1", 2000, 1000, 0, 0, update_criteria);
-  SessionCredit::TotalCreditUsage actual =
-      session_state->get_total_credit_usage();
+  TotalCreditUsage actual = session_state->get_total_credit_usage();
   EXPECT_EQ(actual.monitoring_tx, 0);
   EXPECT_EQ(actual.monitoring_rx, 0);
   EXPECT_EQ(actual.charging_tx, 2000);
@@ -622,8 +620,7 @@ TEST_F(SessionStateTest, test_get_total_credit_usage_single_rule_multiple_key) {
   receive_credit_from_ocs(1, 3000);
   receive_credit_from_pcrf("m1", 3000, MonitoringLevel::PCC_RULE_LEVEL);
   session_state->add_rule_usage("rule1", 2000, 1000, 0, 0, update_criteria);
-  SessionCredit::TotalCreditUsage actual =
-      session_state->get_total_credit_usage();
+  TotalCreditUsage actual = session_state->get_total_credit_usage();
   EXPECT_EQ(actual.monitoring_tx, 2000);
   EXPECT_EQ(actual.monitoring_rx, 1000);
   EXPECT_EQ(actual.charging_tx, 2000);
@@ -639,8 +636,7 @@ TEST_F(SessionStateTest, test_get_total_credit_usage_multiple_rule_shared_key) {
   receive_credit_from_pcrf("m1", 3000, MonitoringLevel::PCC_RULE_LEVEL);
   session_state->add_rule_usage("rule1", 1000, 10, 0, 0, update_criteria);
   session_state->add_rule_usage("rule2", 500, 5, 0, 0, update_criteria);
-  SessionCredit::TotalCreditUsage actual =
-      session_state->get_total_credit_usage();
+  TotalCreditUsage actual = session_state->get_total_credit_usage();
   EXPECT_EQ(actual.monitoring_tx, 1500);
   EXPECT_EQ(actual.monitoring_rx, 15);
   EXPECT_EQ(actual.charging_tx, 1000);


### PR DESCRIPTION
Signed-off-by: Marie Bremner <marwhal@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary
Recently realized that there were a few unused functions that live in SessionCredit so cleaning those up.

### Functions Removed
* `set_grant_tracking_type`
* `set_received_granted_units`
* `compute_reporting_limit`
* `apply_reporting_limits`


### Modified funtions / variables
* We have some functions that do *not* modify state so marking those as consts
* The general guidelines for C++ is to have output parameters as pointers, not references. So modifying the type there to follow google standards. This way it's clear from looking at the signature that the variable is to be modified. 
  * Although a bigger TODO here would be to get rid of `SessionCreditUpdateCriteria` entirely. (but that is for some other time)
* rename all `SessionCreditUpdateCriteria` to be `credit_uc`
* I also moved some functions that are only used internally in SessionCredit to be marked as private

### Other
* I moved `Usage` and `TotalCreditUsage` to `Types.h` since they are used in a lot of different places. (And `TotalCreditUsage` doesn't really belong in SessionCredit anymore since it's only used outside of the class)

<!-- Enumerate changes you made and why you made them -->

## Test Plan
unit tests
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
