### PR TITLE
[codeowners] Add @magma/repo-magma-maintain to go.mod & go.sum

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -38,6 +38,8 @@ lte/gateway/Vagrantfile @rdefosse @mattymo @119Vik @tmdzk
 
 **/*.pb.go @magma/repo-magma-maintain
 **/*_swaggergen.go @magma/repo-magma-maintain
+**/go.mod @magma/repo-magma-maintain
+**/go.sum @magma/repo-magma-maintain
 
 # xwf Magma integrations
 xwf/ @magma/approvers-xwf


### PR DESCRIPTION
Signed-off-by: Evgeniy Makeev <evgeniym@fb.com>

## Summary

go.mod & go.sum are auto-generated/updated in most cases and any regressions in them should be caught by CI builds as well as ci/circleci: insync-checkin test.
I think, it makes sense to treat them as other auto-generated Go files & allow all magma maintainers to approve changes to go.mod/sum.

## Test Plan

N/A

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
