### PR TITLE
feg: cwf: Fix feg_lte missing serdes

### DIFF
--- a/cwf/cloud/go/serdes/serdes.go
+++ b/cwf/cloud/go/serdes/serdes.go
@@ -17,6 +17,8 @@ import (
 	"magma/cwf/cloud/go/cwf"
 	"magma/cwf/cloud/go/services/cwf/obsidian/models"
 	feg_models "magma/feg/cloud/go/services/feg/obsidian/models"
+	lte_models "magma/lte/cloud/go/services/lte/obsidian/models"
+	policydb_models "magma/lte/cloud/go/services/policydb/obsidian/models"
 	"magma/orc8r/cloud/go/serde"
 	"magma/orc8r/cloud/go/serdes"
 	"magma/orc8r/cloud/go/services/state"
@@ -27,7 +29,11 @@ var (
 	// used in the CWF module
 	Network = serdes.Network.
 		MustMerge(models.NetworkSerdes).
-		MustMerge(feg_models.NetworkSerdes)
+		// FeG serdes
+		MustMerge(feg_models.NetworkSerdes).
+		// LTE serdes
+		MustMerge(lte_models.NetworkSerdes).
+		MustMerge(policydb_models.NetworkSerdes)
 	// Entity contains the full set of configurator network entity serdes used
 	// in the CWF module
 	Entity = serdes.Entity.

--- a/feg/cloud/go/serdes/serdes.go
+++ b/feg/cloud/go/serdes/serdes.go
@@ -16,6 +16,7 @@ package serdes
 import (
 	"magma/feg/cloud/go/services/feg/obsidian/models"
 	lte_models "magma/lte/cloud/go/services/lte/obsidian/models"
+	policydb_models "magma/lte/cloud/go/services/policydb/obsidian/models"
 	"magma/orc8r/cloud/go/serdes"
 )
 
@@ -24,7 +25,9 @@ var (
 	// used in the FeG module
 	Network = serdes.Network.
 		MustMerge(models.NetworkSerdes).
-		MustMerge(lte_models.NetworkSerdes)
+		// LTE serdes
+		MustMerge(lte_models.NetworkSerdes).
+		MustMerge(policydb_models.NetworkSerdes)
 	// Entity contains the full set of configurator network entity serdes used
 	// in the FeG module
 	Entity = serdes.Entity.

--- a/feg/cloud/go/services/feg/obsidian/handlers/handlers.go
+++ b/feg/cloud/go/services/feg/obsidian/handlers/handlers.go
@@ -56,7 +56,7 @@ const (
 
 	FederatedLteNetworks              = "feg_lte"
 	ListFegLteNetworksPath            = obsidian.V1Root + FederatedLteNetworks
-	ManageFegLteNetworkPath           = ListFegLteNetworksPath + "/:network_id"
+	ManageFegLteNetworkPath           = ListFegLteNetworksPath + obsidian.UrlSep + ":network_id"
 	ManageFegLteNetworkFederationPath = ManageFegLteNetworkPath + obsidian.UrlSep + "federation"
 	ManageFegLteNetworkSubscriberPath = ManageFegLteNetworkPath + obsidian.UrlSep + "subscriber_config"
 	ManageFegLteNetworkBaseNamesPath  = ManageFegLteNetworkSubscriberPath + obsidian.UrlSep + "base_names"


### PR DESCRIPTION
## Summary

FeG was including serdes from *lte service* rather than all serdes in *lte module*. Side note: we have to do per-service like this otherwise we run into merge conflicts later up in the hierarchy.

Reported issue:

```
$ curl -X PUT "https://api.example.com/magma/v1/feg_lte/feg_lte/subscriber_config" -H "accept: application/json" -H "content-type: application/json" -d "{ \"network_wide_base_names\": [ \"base_1\" ], \"network_wide_rule_names\": [ \"omni_1\" ]}"

{
  "message": "failed to marshal update: failed to serialize config network_subscriber_config: no serde in registry for type network_subscriber_config"
}
```

## Test Plan

Added regression test -- failed before fix, passes after.

## Additional Information

- [ ] This change is backwards-breaking