### PR TITLE
[lte][agw] Fixing netmask parsing for Ipv6 address

### DIFF
--- a/orc8r/gateway/python/magma/common/misc_utils.py
+++ b/orc8r/gateway/python/magma/common/misc_utils.py
@@ -47,7 +47,7 @@ def get_if_ip_with_netmask(interface, preference=IpPreference.IPV4_PREFERRED):
     try:
         ipv6_address = (
             ip_addresses[netifaces.AF_INET6][0]["addr"].split("%")[0],
-            ip_addresses[netifaces.AF_INET6][0]["netmask"].split("/")[1],
+            ip_addresses[netifaces.AF_INET6][0]["netmask"],
         )
 
     except KeyError:


### PR DESCRIPTION
Signed-off-by: Alex Rodriguez <ardzoht@gmail.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->
- There is a regression introduced on #6712 while parsing ipv6 netmask for OAI config generation:
```
May 12 14:01:08 phy-u5 mme[202957]: Traceback (most recent call last):
May 12 14:01:08 phy-u5 mme[202957]:   File "/usr/local/bin/generate_oai_config.py", line 279, in <module>
May 12 14:01:08 phy-u5 mme[202957]:     main()
May 12 14:01:08 phy-u5 mme[202957]:   File "/usr/local/bin/generate_oai_config.py", line 270, in main
May 12 14:01:08 phy-u5 mme[202957]:     context = _get_context()
May 12 14:01:08 phy-u5 mme[202957]:   File "/usr/local/bin/generate_oai_config.py", line 215, in _get_context
May 12 14:01:08 phy-u5 mme[202957]:     "mme_s11_ip": _get_iface_ip("mme", "s11_iface_name"),
May 12 14:01:08 phy-u5 mme[202957]:   File "/usr/local/bin/generate_oai_config.py", line 44, in _get_iface_ip
May 12 14:01:08 phy-u5 mme[202957]:     return get_ip_from_if_cidr(iface_name)
May 12 14:01:08 phy-u5 mme[202957]:   File "/usr/local/lib/python3.8/dist-packages/magma/common/misc_utils.py", line 168, in get_ip_from_if_cidr
May 12 14:01:08 phy-u5 mme[202957]:     ip, netmask = get_if_ip_with_netmask(iface_name, preference)
May 12 14:01:08 phy-u5 mme[202957]:   File "/usr/local/lib/python3.8/dist-packages/magma/common/misc_utils.py", line 50, in get_if_ip_with_netmask
May 12 14:01:08 phy-u5 mme[202957]:     ip_addresses[netifaces.AF_INET6][0]["netmask"].split("/")[1],
May 12 14:01:08 phy-u5 mme[202957]: IndexError: list index out of range
```
 this PR fixes it.

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->
- Validated parsing works after change
- make integ_test

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
