### PR TITLE
improvement: Only provision VMs the first time accessing it for integ…

### DIFF
--- a/lte/gateway/fabfile.py
+++ b/lte/gateway/fabfile.py
@@ -11,19 +11,19 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-from distutils.util import strtobool
-
 import sys
+sys.path.append('../../orc8r')
+
+from distutils.util import strtobool
 from time import sleep
 
-from fabric.api import cd, env, execute, local, run, settings
-from fabric.operations import get
-
-sys.path.append('../../orc8r')
 import tools.fab.dev_utils as dev_utils
 import tools.fab.pkg as pkg
+from fabric.api import cd, env, execute, local, run, settings
+from fabric.operations import get
 from tools.fab.hosts import ansible_setup, split_hoststring, vagrant_setup
 from tools.fab.vagrant import setup_env_vagrant
+
 
 """
 Magma Gateway packaging tool:
@@ -70,10 +70,12 @@ def test():
     env.debug_mode = False
 
 
-def package(vcs='git', all_deps="False",
-            cert_file=DEFAULT_CERT, proxy_config=DEFAULT_PROXY,
-            destroy_vm='False',
-            vm='magma', os="debian"):
+def package(
+    vcs='git', all_deps="False",
+    cert_file=DEFAULT_CERT, proxy_config=DEFAULT_PROXY,
+    destroy_vm='False',
+    vm='magma', os="debian",
+):
     """ Builds the magma package """
     all_deps = False if all_deps == "False" else True
     destroy_vm = bool(strtobool(destroy_vm))
@@ -83,8 +85,10 @@ def package(vcs='git', all_deps="False",
         vagrant_setup(vm, destroy_vm=destroy_vm)
 
     if not hasattr(env, 'debug_mode'):
-        print("Error: The Deploy target isn't specified. Specify one with\n\n"
-              "\tfab [dev|test] package")
+        print(
+            "Error: The Deploy target isn't specified. Specify one with\n\n"
+            "\tfab [dev|test] package",
+        )
         exit(1)
 
     hash = pkg.get_commit_hash(vcs)
@@ -94,19 +98,24 @@ def package(vcs='git', all_deps="False",
         run('mkdir -p ~/magma-deps')
         print(
             'Generating lte/setup.py and orc8r/setup.py '
-            'magma dependency packages')
-        run('./release/pydep finddep --install-from-repo -b --build-output '
+            'magma dependency packages',
+        )
+        run(
+            './release/pydep finddep --install-from-repo -b --build-output '
             + '~/magma-deps'
             + (' -l ./release/magma.lockfile.%s' % os)
             + ' python/setup.py'
-            + (' %s/setup.py' % ORC8R_AGW_PYTHON_ROOT))
+            + (' %s/setup.py' % ORC8R_AGW_PYTHON_ROOT),
+        )
 
         print('Building magma package, picking up commit %s...' % hash)
         run('make clean')
         build_type = "Debug" if env.debug_mode else "RelWithDebInfo"
 
-        run('./release/build-magma.sh -h "%s" -t %s --cert %s --proxy %s --os %s' %
-            (hash, build_type, cert_file, proxy_config, os))
+        run(
+            './release/build-magma.sh -h "%s" -t %s --cert %s --proxy %s --os %s' %
+            (hash, build_type, cert_file, proxy_config, os),
+        )
 
         run('rm -rf ~/magma-packages')
         run('mkdir -p ~/magma-packages')
@@ -122,8 +131,10 @@ def package(vcs='git', all_deps="False",
             if vm and vm.startswith('magma_'):
                 mirrored_packages_file += vm[5:]
 
-            run('cat {}'.format(mirrored_packages_file)
-                + ' | xargs -I% sudo aptitude download -q2 %')
+            run(
+                'cat {}'.format(mirrored_packages_file)
+                + ' | xargs -I% sudo aptitude download -q2 %',
+            )
             run('cp *.deb ~/magma-packages')
             run('sudo rm -f *.deb')
 
@@ -163,8 +174,10 @@ def copy_packages():
     pkg.copy_packages()
 
 
-def connect_gateway_to_cloud(control_proxy_setting_path=None,
-                             cert_path=DEFAULT_CERT):
+def connect_gateway_to_cloud(
+    control_proxy_setting_path=None,
+    cert_path=DEFAULT_CERT,
+):
     """
     Setup the gateway VM to connects to the cloud
     Path to control_proxy.yml and rootCA.pem could be specified to use
@@ -191,8 +204,10 @@ def s1ap_setup_cloud():
     run("sudo systemctl restart magma@magmad")
 
 
-def integ_test(gateway_host=None, test_host=None, trf_host=None,
-               destroy_vm='True', provision_vm='True'):
+def integ_test(
+    gateway_host=None, test_host=None, trf_host=None,
+    destroy_vm='True', provision_vm='True',
+):
     """
     Run the integration tests. This defaults to running on local vagrant
     machines, but can also be pointed to an arbitrary host (e.g. amazon) by
@@ -221,7 +236,13 @@ def integ_test(gateway_host=None, test_host=None, trf_host=None,
     if gateway_host:
         gateway_ip = gateway_host.split('@')[1].split(':')[0]
 
-    _switch_to_vm(gateway_host, "magma", "magma_dev.yml", destroy_vm=destroy_vm, provision_vm=provision_vm)
+    _switch_to_vm(
+        gateway_host,
+        "magma",
+        "magma_dev.yml",
+        destroy_vm=destroy_vm,
+        provision_vm=provision_vm,
+    )
 
     execute(_dist_upgrade)
     execute(_build_magma)
@@ -236,12 +257,24 @@ def integ_test(gateway_host=None, test_host=None, trf_host=None,
 
     # Setup the trfserver: use the provided trfserver if given, else default to the
     # vagrant machine
-     _switch_to_vm(gateway_host, "magma_trfserver", "magma_trfserver.yml", destroy_vm=destroy_vm, provision_vm=provision_vm)
+    _switch_to_vm(
+        gateway_host,
+        "magma_trfserver",
+        "magma_trfserver.yml",
+        destroy_vm=destroy_vm,
+        provision_vm=provision_vm,
+    )
     execute(_start_trfserver)
 
     # Run the tests: use the provided test machine if given, else default to
     # the vagrant machine
-     _switch_to_vm(gateway_host, "test", "magma_test.yml", destroy_vm=destroy_vm, provision_vm=provision_vm)
+    _switch_to_vm(
+        gateway_host,
+        "test",
+        "magma_test.yml",
+        destroy_vm=destroy_vm,
+        provision_vm=provision_vm,
+    )
 
     execute(_make_integ_tests)
     execute(_run_integ_tests, gateway_ip)
@@ -282,20 +315,35 @@ def run_integ_tests(tests=None):
 def get_test_summaries(
         gateway_host=None,
         test_host=None,
-        dst_path="/tmp"):
+        dst_path="/tmp",
+):
     local('mkdir -p ' + dst_path)
-    _switch_to_vm(gateway_host, "magma", "magma_dev.yml", destroy_vm=False, provision_vm=False)
+    _switch_to_vm(
+        gateway_host,
+        "magma",
+        "magma_dev.yml",
+        destroy_vm=False,
+        provision_vm=False,
+    )
     with settings(warn_only=True):
         get(remote_path=TEST_SUMMARY_GLOB, local_path=dst_path)
-    _switch_to_vm(test_host, "magma_test", "magma_test.yml", destroy_vm=False, provision_vm=False)
+    _switch_to_vm(
+        test_host,
+        "magma_test",
+        "magma_test.yml",
+        destroy_vm=False,
+        provision_vm=False,
+    )
     with settings(warn_only=True):
         get(remote_path=TEST_SUMMARY_GLOB, local_path=dst_path)
 
 
-def get_test_logs(gateway_host=None,
-                  test_host=None,
-                  trf_host=None,
-                  dst_path="/tmp/build_logs.tar.gz"):
+def get_test_logs(
+    gateway_host=None,
+    test_host=None,
+    trf_host=None,
+    dst_path="/tmp/build_logs.tar.gz",
+):
     """
     Download the relevant magma logs from the given gateway and test machines.
     Place the logs in a path specified in 'dst_path' or
@@ -319,10 +367,12 @@ def get_test_logs(gateway_host=None,
     local('mkdir /tmp/build_logs/dev')
     local('mkdir /tmp/build_logs/test')
     local('mkdir /tmp/build_logs/trfserver')
-    dev_files = ['/var/log/mme.log',
-                 '/var/log/syslog',
-                 '/var/log/envoy.log',
-                 '/var/log/openvswitch/ovs*.log']
+    dev_files = [
+        '/var/log/mme.log',
+        '/var/log/syslog',
+        '/var/log/envoy.log',
+        '/var/log/openvswitch/ovs*.log',
+    ]
     test_files = ['/var/log/syslog', '/tmp/fw/']
     trf_files = ['/home/admin/nohup.out']
 
@@ -336,8 +386,10 @@ def get_test_logs(gateway_host=None,
     # Don't fail if the logs don't exists
     for p in dev_files:
         with settings(warn_only=True):
-            get(remote_path=p, local_path='/tmp/build_logs/dev/',
-                use_sudo=True)
+            get(
+                remote_path=p, local_path='/tmp/build_logs/dev/',
+                use_sudo=True,
+            )
 
     # Set up to enter the trfserver host
     env.host_string = trf_host
@@ -349,8 +401,10 @@ def get_test_logs(gateway_host=None,
     # Don't fail if the logs don't exists
     for p in trf_files:
         with settings(warn_only=True):
-            get(remote_path=p, local_path='/tmp/build_logs/trfserver/',
-                use_sudo=True)
+            get(
+                remote_path=p, local_path='/tmp/build_logs/trfserver/',
+                use_sudo=True,
+            )
 
     # Set up to enter the test host
     env.host_string = test_host
@@ -367,8 +421,10 @@ def get_test_logs(gateway_host=None,
     # Don't fail if the logs don't exists
     for p in test_files:
         with settings(warn_only=True):
-            get(remote_path=p, local_path='/tmp/build_logs/test/',
-                use_sudo=True)
+            get(
+                remote_path=p, local_path='/tmp/build_logs/test/',
+                use_sudo=True,
+            )
 
     local("tar -czvf /tmp/build_logs.tar.gz /tmp/build_logs/*")
     local(f'mv /tmp/build_logs.tar.gz {dst_path}')
@@ -394,7 +450,13 @@ def load_test(gateway_host=None, destroy_vm=True):
     if gateway_host:
         gateway_ip = gateway_host.split('@')[1].split(':')[0]
 
-    _switch_to_vm(gateway_host, "magma", "magma_dev.yml", destroy_vm=destroy_vm, provision_vm=True)
+    _switch_to_vm(
+        gateway_host,
+        "magma",
+        "magma_dev.yml",
+        destroy_vm=destroy_vm,
+        provision_vm=True,
+    )
 
     execute(_build_magma)
     execute(_start_gateway)
@@ -457,8 +519,11 @@ def _run_local_integ_tests():
 
 def _set_service_config_var(service, var_name, value):
     """ Sets variable in config file by value """
-    run("echo '%s: %s' | sudo tee -a /var/opt/magma/configs/%s.yml" % (
-        var_name, str(value), service))
+    run(
+        "echo '%s: %s' | sudo tee -a /var/opt/magma/configs/%s.yml" % (
+        var_name, str(value), service,
+        ),
+    )
 
 
 def _start_trfserver():
@@ -469,12 +534,14 @@ def _start_trfserver():
     port = env.hosts[0].split(':')[1]
     key = env.key_filename
     # set tty on cbreak mode as background ssh process breaks indentation
-    local('ssh -f -i %s -o UserKnownHostsFile=/dev/null'
-          ' -o StrictHostKeyChecking=no -tt %s -p %s'
-          ' sh -c "sudo ethtool --offload eth1 rx off tx off; sudo ethtool --offload eth2 rx off tx off; '
-          'nohup sudo /usr/local/bin/traffic_server.py 192.168.60.144 62462 > /dev/null 2>&1";'
-          'stty cbreak'
-          % (key, host, port))
+    local(
+        'ssh -f -i %s -o UserKnownHostsFile=/dev/null'
+        ' -o StrictHostKeyChecking=no -tt %s -p %s'
+        ' sh -c "sudo ethtool --offload eth1 rx off tx off; sudo ethtool --offload eth2 rx off tx off; '
+        'nohup sudo /usr/local/bin/traffic_server.py 192.168.60.144 62462 > /dev/null 2>&1";'
+        'stty cbreak'
+        % (key, host, port),
+    )
 
 
 def _make_integ_tests():
@@ -509,16 +576,18 @@ def _run_integ_tests(gateway_ip='192.168.60.142', tests=None):
         -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no: have ssh
          never prompt to confirm the host fingerprints
     """
-    local('ssh -i %s -o UserKnownHostsFile=/dev/null'
-          ' -o StrictHostKeyChecking=no -tt %s -p %s'
-          ' \'cd $MAGMA_ROOT/lte/gateway/python/integ_tests; '
-          # We don't have a proper shell, so the `magtivate` alias isn't
-          # available. We instead directly source the activate file
-          ' sudo ethtool --offload eth1 rx off tx off; sudo ethtool --offload eth2 rx off tx off;'
-          ' source ~/build/python/bin/activate;'
-          ' export GATEWAY_IP=%s;'
-          ' make integ_test %s\''
-          % (key, host, port, gateway_ip, tests))
+    local(
+        'ssh -i %s -o UserKnownHostsFile=/dev/null'
+        ' -o StrictHostKeyChecking=no -tt %s -p %s'
+        ' \'cd $MAGMA_ROOT/lte/gateway/python/integ_tests; '
+        # We don't have a proper shell, so the `magtivate` alias isn't
+        # available. We instead directly source the activate file
+        ' sudo ethtool --offload eth1 rx off tx off; sudo ethtool --offload eth2 rx off tx off;'
+        ' source ~/build/python/bin/activate;'
+        ' export GATEWAY_IP=%s;'
+        ' make integ_test %s\''
+        % (key, host, port, gateway_ip, tests),
+    )
 
 
 def _run_load_tests(gateway_ip='192.168.60.142'):
@@ -538,19 +607,24 @@ def _run_load_tests(gateway_ip='192.168.60.142'):
     port = env.hosts[0].split(':')[1]
     key = env.key_filename
 
-    local('ssh -i %s -o UserKnownHostsFile=/dev/null'
-          ' -o StrictHostKeyChecking=no -tt %s -p %s'
-          ' \'cd $MAGMA_ROOT/lte/gateway/python/load_tests; '
-          # We don't have a proper shell, so the `magtivate` alias isn't
-          # available. We instead directly source the activate file
-          ' sudo ethtool --offload eth1 rx off tx off; sudo ethtool --offload eth2 rx off tx off;'
-          ' source ~/build/python/bin/activate;'
-          ' export GATEWAY_IP=%s;'
-          ' make load_test\''
-          % (key, host, port, gateway_ip))
+    local(
+        'ssh -i %s -o UserKnownHostsFile=/dev/null'
+        ' -o StrictHostKeyChecking=no -tt %s -p %s'
+        ' \'cd $MAGMA_ROOT/lte/gateway/python/load_tests; '
+        # We don't have a proper shell, so the `magtivate` alias isn't
+        # available. We instead directly source the activate file
+        ' sudo ethtool --offload eth1 rx off tx off; sudo ethtool --offload eth2 rx off tx off;'
+        ' source ~/build/python/bin/activate;'
+        ' export GATEWAY_IP=%s;'
+        ' make load_test\''
+        % (key, host, port, gateway_ip),
+    )
 
 
-def _switch_to_vm(addr: str, host_name: str, ansible_file: str, destroy_vm: bool, provision_vm: bool):
+def _switch_to_vm(
+    addr: str, host_name: str, ansible_file: str,
+    destroy_vm: bool, provision_vm: bool,
+):
     if not addr:
         vagrant_setup(host_name, destroy_vm, provision_vm)
     else:


### PR DESCRIPTION
…ration test

Signed-off-by: Marie Bremner <marwhal@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary
We recently made it so that even if `destroy_vm` is not passed into the fab command, we force provision all VMs when running with ansible. This is great but when we access a VM that's already been accessed before, we should not bother re-provisioning the VM. 

I've modified the function
```
def _switch_to_vm(
    addr: str, host_name: str, ansible_file: str,
    destroy_vm: bool, provision_vm: bool,
)
``` 
to take in a provision_vm variable to clean this up a bit.

## Note for the reviewer
The first commit has the logical change
The second commit is just a formatting command (I ran `./precommit.py -f -d`)
(To get rid of the annotations press `a`)

<!-- Enumerate changes you made and why you made them -->

## Test Plan
run fab integ_test locally
run agw package locally
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
