### PR TITLE
[feg] Issue 6870 fix

### DIFF
--- a/feg/cloud/go/services/feg/obsidian/models/mutable_federation_gateway_swaggergen.go
+++ b/feg/cloud/go/services/feg/obsidian/models/mutable_federation_gateway_swaggergen.go
@@ -28,8 +28,7 @@ type MutableFederationGateway struct {
 	Device *models5.GatewayDevice `json:"device"`
 
 	// federation
-	// Required: true
-	Federation *GatewayFederationConfigs `json:"federation"`
+	Federation *GatewayFederationConfigs `json:"federation,omitempty"`
 
 	// id
 	// Required: true
@@ -118,8 +117,8 @@ func (m *MutableFederationGateway) validateDevice(formats strfmt.Registry) error
 
 func (m *MutableFederationGateway) validateFederation(formats strfmt.Registry) error {
 
-	if err := validate.Required("federation", "body", m.Federation); err != nil {
-		return err
+	if swag.IsZero(m.Federation) { // not required
+		return nil
 	}
 
 	if m.Federation != nil {

--- a/feg/cloud/go/services/feg/obsidian/models/swagger.v1.yml
+++ b/feg/cloud/go/services/feg/obsidian/models/swagger.v1.yml
@@ -1466,7 +1466,6 @@ definitions:
     - description
     - magmad
     - tier
-    - federation
     properties:
       device:
         $ref: './orc8r-swagger.yml#/definitions/gateway_device'

--- a/orc8r/cloud/go/obsidian/swagger/v1/models/mutable_federation_gateway.go
+++ b/orc8r/cloud/go/obsidian/swagger/v1/models/mutable_federation_gateway.go
@@ -26,8 +26,7 @@ type MutableFederationGateway struct {
 	Device *GatewayDevice `json:"device"`
 
 	// federation
-	// Required: true
-	Federation *GatewayFederationConfigs `json:"federation"`
+	Federation *GatewayFederationConfigs `json:"federation,omitempty"`
 
 	// id
 	// Required: true
@@ -116,8 +115,8 @@ func (m *MutableFederationGateway) validateDevice(formats strfmt.Registry) error
 
 func (m *MutableFederationGateway) validateFederation(formats strfmt.Registry) error {
 
-	if err := validate.Required("federation", "body", m.Federation); err != nil {
-		return err
+	if swag.IsZero(m.Federation) { // not required
+		return nil
 	}
 
 	if m.Federation != nil {

--- a/orc8r/cloud/go/obsidian/swagger/v1/swagger.yml
+++ b/orc8r/cloud/go/obsidian/swagger/v1/swagger.yml
@@ -9642,7 +9642,6 @@ definitions:
     - description
     - magmad
     - tier
-    - federation
     type: object
   mutable_lte_gateway:
     description: LTE gateway object with read-only fields omitted


### PR DESCRIPTION
Signed-off-by: Evgeniy Makeev <evgeniym@fb.com>


## Summary

A possible fix fo https://github.com/magma/magma/issues/6870. This change makes federation section optional for Federation Gateways.

## Test Plan

unit tests; test on staging: TBD

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
