### PR TITLE
Migrate CI CODEOWNERS to approvers-ci

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,22 +1,22 @@
-.circleci/ @rdefosse @119Vik @tmdzk
-circleci/ @rdefosse @tmdzk @mattymo @119Vik
+.circleci/ @magma/approvers-ci
+circleci/ @magma/approvers-ci
 
-ci-scripts/ @rdefosse @tmdzk @mattymo @119Vik
+ci-scripts/ @magma/approvers-ci
 
 */cloud/ @magma/approvers-orc8r
 .golangci.yml @magma/approvers-orc8r
 
 orc8r/ @magma/approvers-orc8r
-orc8r/tools/packer/ @rdefosse @tmdzk @mattymo @119Vik
-orc8r/cloud/deploy/bare-metal/ @rdefosse @tmdzk @mattymo @119Vik
-orc8r/cloud/deploy/bare-metal-ansible/ @rdefosse @mattymo @119Vik
+orc8r/tools/packer/ @magma/approvers-ci
+orc8r/cloud/deploy/bare-metal/ @magma/approvers-ci
+orc8r/cloud/deploy/bare-metal-ansible/ @magma/approvers-ci
 
 orc8r/gateway/c/ @magma/approvers-agw-c
 
 feg/ @magma/approvers-feg
 
 cwf/ @magma/approvers-cwf
-cwf/gateway/Vagrantfile @rdefosse @mattymo @119Vik @tmdzk
+cwf/gateway/Vagrantfile @magma/approvers-ci
 
 openwrt/ @magma/approvers-openwrt
 


### PR DESCRIPTION
Signed-off-by: Marie Bremner <marwhal@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary
The last team migration!
We recently completed all necessary votes to make sure all members of approvers-ci are codeowners for these directories.

## Test Plan
no test
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
