### PR TITLE
Set the first 8 characters of commit hash as release version for sentry

### DIFF
--- a/.github/workflows/sentry-release.yml
+++ b/.github/workflows/sentry-release.yml
@@ -11,6 +11,9 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
+      - name: Get short SHA
+        id: slug
+        run: echo "::set-output name=sha8::$(echo ${GITHUB_SHA} | cut -c1-8)"
       - name: Create Sentry release
         uses: getsentry/action-release@v1
         env:
@@ -20,3 +23,4 @@ jobs:
         with:
           environment: staging
           projects: lab-agws-python lab-agws-native
+          version: ${{ steps.slug.outputs.sha8 }}


### PR DESCRIPTION
Signed-off-by: Marie Bremner <marwhal@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary
I recently added a sentry release github action (https://github.com/marketplace/actions/sentry-release) which sends commit information to Sentry. 
But it uses the full commit hash as the version, whereas the AGWs use the first 8 characters only. 

This PR modifies the release version to be the first 8 characters to match the one used by the AGWs.
Used this post/forum(?) for reference: https://github.community/t/add-short-sha-to-github-context/16418/10

(In the picture below the short release version is the one reported from the AGW and the long one is the one added by GitHub. We want these to match)
<img width="1082" alt="Screen Shot 2021-05-14 at 10 08 55 AM" src="https://user-images.githubusercontent.com/37634144/118290902-930e0700-b49c-11eb-808c-3da2ae5c4558.png">

<!-- Enumerate changes you made and why you made them -->

## Test Plan
test in master?
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
