### PR TITLE
refactor: Cleanup ChargingGrant output parameter types

### DIFF
--- a/lte/gateway/c/session_manager/ChargingGrant.h
+++ b/lte/gateway/c/session_manager/ChargingGrant.h
@@ -57,14 +57,14 @@ struct ChargingGrant {
         reauth_state(REAUTH_NOT_NEEDED),
         suspended(false) {}
 
-  ChargingGrant(const StoredChargingGrant& marshaled);
+  explicit ChargingGrant(const StoredChargingGrant& marshaled);
 
   // ChargingGrant -> StoredChargingGrant
   StoredChargingGrant marshal();
 
   void receive_charging_grant(
       const CreditUpdateResponse& update,
-      SessionCreditUpdateCriteria* uc = NULL);
+      SessionCreditUpdateCriteria* credit_uc = NULL);
 
   // Returns true if the credit returned from the Policy component is valid and
   // good to be installed.
@@ -82,7 +82,7 @@ struct ChargingGrant {
 
   // get_action returns the action to take on the credit based on the last
   // update. If no action needs to take place, CONTINUE_SERVICE is returned.
-  ServiceActionType get_action(SessionCreditUpdateCriteria& update_criteria);
+  ServiceActionType get_action(SessionCreditUpdateCriteria* update_criteria);
 
   // Get unreported usage from credit and return as part of CreditUsage
   // The update_type is also included in CreditUsage
@@ -90,12 +90,8 @@ struct ChargingGrant {
   // usage, otherwise we only include unreported usage up to the allocated
   // amount.
   CreditUsage get_credit_usage(
-      CreditUsage::UpdateType update_type, SessionCreditUpdateCriteria* uc,
-      bool is_terminate);
-
-  // get_requested_units returns total, tx and rx needed to cover one worth of
-  // grant
-  RequestedUnits get_requested_units();
+      CreditUsage::UpdateType update_type,
+      SessionCreditUpdateCriteria* credit_uc, bool is_terminate);
 
   // Return true if the service needs to be deactivated
   bool should_deactivate_service() const;
@@ -107,22 +103,18 @@ struct ChargingGrant {
   ServiceActionType final_action_to_action_on_suspension(
       const ChargingCredit_FinalAction action) const;
 
-  // Set is_final_grant and final_action_info values
-  void set_final_action_info(
-      const magma::lte::ChargingCredit& credit,
-      SessionCreditUpdateCriteria* uc = NULL);
-
   bool get_suspended();
 
-  void set_suspended(bool suspended, SessionCreditUpdateCriteria* uc);
+  void set_suspended(bool suspended, SessionCreditUpdateCriteria* credit_uc);
 
   // Set the object and update criteria's reauth state to new_state.
   void set_reauth_state(
-      const ReAuthState new_state, SessionCreditUpdateCriteria& uc);
+      const ReAuthState new_state, SessionCreditUpdateCriteria* credit_uc);
 
   // Set the object and update criteria's service state to new_state.
   void set_service_state(
-      const ServiceState new_service_state, SessionCreditUpdateCriteria& uc);
+      const ServiceState new_service_state,
+      SessionCreditUpdateCriteria* credit_uc);
 
   // Set the flag reporting. Used to signal this credit is waiting to receive
   // a response from the core
@@ -130,10 +122,6 @@ struct ChargingGrant {
 
   // Rollback reporting changes for failed updates
   void reset_reporting_grant(SessionCreditUpdateCriteria* credit_uc);
-
-  // Convert rel_time_sec, which is a delta value in seconds, into a timestamp
-  // and assign it to expiry_time
-  void set_expiry_time_as_timestamp(uint32_t rel_time_sec);
 
   // Log information about the grant received
   void log_received_grant(const CreditUpdateResponse& update);

--- a/lte/gateway/c/session_manager/test/test_charging_grant.cpp
+++ b/lte/gateway/c/session_manager/test/test_charging_grant.cpp
@@ -189,7 +189,7 @@ TEST_F(ChargingGrantTest, test_get_action) {
   grant.is_final_grant = false;
   grant.credit.receive_credit(gsu, &uc);
   grant.credit.add_used_credit(1024, 0, &uc);
-  auto cont_action = grant.get_action(uc);
+  auto cont_action = grant.get_action(&uc);
   EXPECT_EQ(cont_action, CONTINUE_SERVICE);
   // Check both the grant's service_state and update criteria
   EXPECT_EQ(grant.service_state, CONTINUE_SERVICE);
@@ -203,12 +203,12 @@ TEST_F(ChargingGrantTest, test_get_action) {
   grant.credit.add_used_credit(2048, 0, &uc);
   grant.credit.add_used_credit(30, 20, &uc);
   grant.service_state = SERVICE_NEEDS_DEACTIVATION;
-  auto term_action    = grant.get_action(uc);
+  auto term_action    = grant.get_action(&uc);
   // Check that the update criteria also includes the changes
   EXPECT_EQ(term_action, TERMINATE_SERVICE);
 
   // Termination action only returned once
-  auto repeated_action = grant.get_action(uc);
+  auto repeated_action = grant.get_action(&uc);
   EXPECT_EQ(repeated_action, CONTINUE_SERVICE);
 }
 
@@ -227,12 +227,12 @@ TEST_F(ChargingGrantTest, test_get_action_redirect) {
   grant.credit.add_used_credit(2048, 0, &uc);
   grant.credit.add_used_credit(30, 20, &uc);
   grant.service_state = SERVICE_NEEDS_DEACTIVATION;
-  auto term_action    = grant.get_action(uc);
+  auto term_action    = grant.get_action(&uc);
   // Check that the update criteria also includes the changes
   EXPECT_EQ(term_action, REDIRECT);
 
   // Termination action only returned once
-  auto repeated_action = grant.get_action(uc);
+  auto repeated_action = grant.get_action(&uc);
   EXPECT_EQ(repeated_action, CONTINUE_SERVICE);
 }
 
@@ -251,12 +251,12 @@ TEST_F(ChargingGrantTest, test_get_action_restrict) {
   grant.credit.add_used_credit(2048, 0, &uc);
   grant.credit.add_used_credit(30, 20, &uc);
   grant.service_state = SERVICE_NEEDS_DEACTIVATION;
-  auto term_action    = grant.get_action(uc);
+  auto term_action    = grant.get_action(&uc);
   // Check that the update criteria also includes the changes
   EXPECT_EQ(term_action, RESTRICT_ACCESS);
 
   // Termination action only returned once
-  auto repeated_action = grant.get_action(uc);
+  auto repeated_action = grant.get_action(&uc);
   EXPECT_EQ(repeated_action, CONTINUE_SERVICE);
 }
 
@@ -280,7 +280,7 @@ TEST_F(ChargingGrantTest, test_tolerance_quota_exhausted) {
   EXPECT_EQ(uc.bucket_deltas[USED_TX], 2000);
   EXPECT_TRUE(credit.is_quota_exhausted(0.8));
   // continue the service even we are over the quota (but not final unit)
-  EXPECT_EQ(grant.get_action(uc), CONTINUE_SERVICE);
+  EXPECT_EQ(grant.get_action(&uc), CONTINUE_SERVICE);
 
   // Check how much we will report (we will report everything, even if
   // we go have gone over the allowed quota)
@@ -331,7 +331,7 @@ TEST_F(ChargingGrantTest, test_tolerance_quota_exhausted) {
   EXPECT_EQ(credit.get_credit(USED_TX), 4000);
   EXPECT_TRUE(credit.is_quota_exhausted(1));  // 100% exceeded
   EXPECT_TRUE(grant.should_deactivate_service());
-  grant.set_service_state(SERVICE_NEEDS_DEACTIVATION, uc);
+  grant.set_service_state(SERVICE_NEEDS_DEACTIVATION, &uc);
 
   // Since this is the final grant, we should not report anything
   EXPECT_FALSE(grant.get_update_type(&update_type));


### PR DESCRIPTION
Signed-off-by: Marie Bremner <marwhal@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary
Some cosmetic changes
`uc`, `update_criteria` -> `credit_uc` for consistency
All output parameters are now pointers

Remove the following unused functions:
* `get_requested_units`
* `set_final_action_info`
* `set_expiry_time_as_timestamp`

<!-- Enumerate changes you made and why you made them -->

## Test Plan
make precommit_sm
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
