### PR TITLE
[MME] Clean up assorted library linking

### DIFF
--- a/lte/gateway/c/oai/common/CMakeLists.txt
+++ b/lte/gateway/c/oai/common/CMakeLists.txt
@@ -68,10 +68,15 @@ set(COMMON_SRC
 add_subdirectory(glogwrapper)
 add_subdirectory(redis_utils)
 
+pkg_search_module(CRYPTO libcrypto REQUIRED)
+
 add_library(COMMON ${COMMON_SRC})
 target_link_libraries (COMMON
   lfds710
   LIB_3GPP LIB_BSTR LIB_HASHTABLE LIB_ITTI glogwrapper
+  ${CRYPTO_LIBRARIES}
+  yaml-cpp
+  prometheus-cpp
 )
 
 ## Find + link sentry if it exists

--- a/lte/gateway/c/oai/oai_mme/CMakeLists.txt
+++ b/lte/gateway/c/oai/oai_mme/CMakeLists.txt
@@ -13,9 +13,6 @@ include_directories(${LIBXML2_INCLUDE_DIRS})
 pkg_search_module(OPENSSL openssl REQUIRED)
 include_directories(${OPENSSL_INCLUDE_DIRS})
 
-pkg_search_module(CRYPTO libcrypto REQUIRED)
-include_directories(${CRYPTO_INCLUDE_DIRS})
-
 pkg_search_module(NETTLE nettle REQUIRED)
 include_directories(${NETTLE_INCLUDE_DIRS})
 
@@ -47,9 +44,9 @@ target_link_libraries(mme
         TASK_S6A TASK_MME_APP TASK_GRPC_SERVICE TASK_NAS TASK_HA
          ${ITTI_LIB} ${GCOV_LIB}
     -Wl,--end-group
-    ${LFDS} pthread m sctp  rt crypt ${CRYPTO_LIBRARIES} ${OPENSSL_LIBRARIES}
+    ${LFDS} pthread m sctp rt ${OPENSSL_LIBRARIES}
     ${NETTLE_LIBRARIES} ${CONFIG_LIBRARIES} gnutls ${SERVICE303_LIB}
-    prometheus-cpp grpc grpc++ yaml-cpp
+    prometheus-cpp grpc grpc++
 )
 
 if ( NOT EMBEDDED_SGW )


### PR DESCRIPTION
libcrypto, prometheus-cpp and yaml-cpp should be linked via the Common's CmakeList, as that is the true dependency, not mme_app. This PR moves these linkage directives. While here, I was unsure of why a crypt dependency existed - and removal had no impact on build success. So I remove it.

This works towards #6904.

Signed-off-by: GitHub <noreply@github.com>