### PR TITLE
[codeowners] add auto-generated swagger files to @magma/repo-magma-maintain approval list

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -38,6 +38,9 @@ lte/gateway/Vagrantfile @magma/approvers-ci
 
 **/*.pb.go @magma/repo-magma-maintain
 **/*_swaggergen.go @magma/repo-magma-maintain
+orc8r/cloud/go/obsidian/swagger/v1/swagger.yml @magma/repo-magma-maintain
+orc8r/cloud/go/obsidian/swagger/v1/client/ @magma/repo-magma-maintain
+orc8r/cloud/go/obsidian/swagger/v1/models/ @magma/repo-magma-maintain
 **/go.mod @magma/repo-magma-maintain
 **/go.sum @magma/repo-magma-maintain
 


### PR DESCRIPTION

## Summary

add auto-generated swagger files which somehow lost their '_swaggergen' suffix & not covered by the existing "**/*_swaggergen.go @magma/repo-magma-maintain" codeowners rule anymore to @magma/repo-magma-maintain approval list.

Not having the files under @magma/repo-magma-maintain creates unnecessary PR review bottlenecks.

## Test Plan

N/A

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
