### PR TITLE
Move Pipelined to Flat Rate Enforcement

### DIFF
--- a/lte/gateway/python/magma/pipelined/app/enforcement.py
+++ b/lte/gateway/python/magma/pipelined/app/enforcement.py
@@ -318,6 +318,3 @@ class EnforcementController(PolicyMixin, RestartMixin, MagmaController):
         else:
             for rule_id in rule_ids:
                 self._deactivate_flow_for_rule(imsi, ip_addr, rule_id)
-
-    def recover_state(self, _):
-        pass

--- a/lte/gateway/python/magma/pipelined/app/enforcement_stats.py
+++ b/lte/gateway/python/magma/pipelined/app/enforcement_stats.py
@@ -32,7 +32,9 @@ from magma.pipelined.openflow.registers import (DIRECTION_REG, IMSI_REG,
                                                 RULE_VERSION_REG, SCRATCH_REGS,
                                                 Direction)
 from magma.pipelined.policy_converters import (get_eth_type,
-                                               get_ue_ip_match_args)
+                                               get_ue_ip_match_args,
+                                               convert_ipv4_str_to_ip_proto,
+                                               convert_ipv6_str_to_ip_proto)
 from magma.pipelined.utils import Utils
 from ryu.controller import dpset, ofp_event
 from ryu.controller.handler import MAIN_DISPATCHER, set_ev_cls
@@ -80,8 +82,6 @@ class EnforcementStatsController(PolicyMixin, RestartMixin, MagmaController):
         self._clean_restart = kwargs['config']['clean_restart']
         self._redis_enabled = kwargs['config'].get('redis_enabled', False)
         # Store last usage excluding deleted flows for calculating deltas
-        self.last_usage_for_delta = defaultdict(RuleRecord)
-        self.failed_usage = {}  # Store failed usage to retry rpc to sessiond
         self._unmatched_bytes = 0  # Store bytes matched by default rule if any
         self._default_drop_flow_name = \
             kwargs['config']['enforcement']['default_drop_flow_name']
@@ -101,9 +101,7 @@ class EnforcementStatsController(PolicyMixin, RestartMixin, MagmaController):
         """
         self.unhandled_stats_msgs = []
         self.total_usage = {}
-        self.failed_usage = {}
         self._unmatched_bytes = 0
-        self.last_usage_for_delta = defaultdict(RuleRecord)
 
     def initialize_on_connect(self, datapath):
         """
@@ -365,30 +363,12 @@ class EnforcementStatsController(PolicyMixin, RestartMixin, MagmaController):
                     self.logger.error('Failed processing stats, redis unavailable')
                     self.unhandled_stats_msgs.append(stats_msgs)
                     return
-
-        # Calculate the delta values from last stat update
-        try:
-            delta_usage = self._delta_usage_maps(current_usage,
-                                                 self.last_usage_for_delta)
-        except ConnectionError:
-            self.logger.error('Failed processing delta stats, redis unavailable')
-            self.unhandled_stats_msgs.append(stats_msgs)
-            return
-        self.total_usage = current_usage
-
-        # Append any records which we couldn't send to session manager earlier
-        delta_usage = _merge_usage_maps(delta_usage, self.failed_usage)
-        self.failed_usage = {}
-
         # Send report even if usage is empty. Sessiond uses empty reports to
         # recognize when flows have ended
-        self._report_usage(delta_usage)
+        self._report_usage(current_usage)
 
-        try:
-            self._delete_old_flows(stats_msgs)
-        except ConnectionError:
-            self.logger.error('Failed remove old flows, redis unavailable')
-            return
+        # This is done primarily for CWF integration tests, TODO rm
+        self.total_usage = current_usage
 
     def deactivate_default_flow(self, imsi, ip_addr):
         if self._datapath is None:
@@ -415,17 +395,21 @@ class EnforcementStatsController(PolicyMixin, RestartMixin, MagmaController):
             record_table, self.SESSIOND_RPC_TIMEOUT)
         future.add_done_callback(
             lambda future: self.loop.call_soon_threadsafe(
-                self._report_usage_done, future, delta_usage))
+                self._report_usage_done, future, delta_usage.values()))
 
-    def _report_usage_done(self, future, delta_usage):
+    def _report_usage_done(self, future, records):
         """
         Callback after sessiond RPC completion
         """
         err = future.exception()
         if err:
             self.logger.error('Couldnt send flow records to sessiond: %s', err)
-            self.failed_usage = _merge_usage_maps(
-                delta_usage, self.failed_usage)
+            return
+        try:
+            self._delete_old_flows(records)
+        except ConnectionError:
+            self.logger.error('Failed remove old flows, redis unavailable')
+            return
 
     def _update_usage_from_flow_stat(self, current_usage, flow_stat):
         """
@@ -459,17 +443,22 @@ class EnforcementStatsController(PolicyMixin, RestartMixin, MagmaController):
         # use a compound key to separate flows for the same rule but for
         # different subscribers
         key = sid + "|" + rule_id
+
         if ipv4_addr:
             key += "|" + ipv4_addr
         elif ipv6_addr:
             key += "|" + ipv6_addr
-        record = current_usage[key]
-        record.rule_id = rule_id
-        record.sid = sid
 
         rule_version = _get_version(flow_stat)
         if not rule_version:
             rule_version = 0
+
+        key += "|" + str(rule_version)
+
+        record = current_usage[key]
+        record.rule_id = rule_id
+        record.sid = sid
+
         record.rule_version = rule_version
 
         if ipv4_addr:
@@ -496,81 +485,60 @@ class EnforcementStatsController(PolicyMixin, RestartMixin, MagmaController):
         current_usage[key] = record
         return current_usage
 
-    def _delete_old_flows(self, stats_msgs):
+    def _delete_old_flows(self, records):
         """
-        Check if the version of any flow is older than the current version. If
-        so, delete the flow and update last_usage_for_delta so we calculate the
-        correct usage delta for the next poll.
+        Check if the version of any record is older than the current version.
+        If so, delete the flow.
         """
-        deleted_flow_usage = defaultdict(RuleRecord)
-        for deletable_stat in self._old_flow_stats(stats_msgs):
-            stat_rule_id = self._get_rule_id(deletable_stat)
-            stat_sid = _get_sid(deletable_stat)
-            ipv4_addr_str = _get_ipv4(deletable_stat)
-            ipv6_addr_str = _get_ipv6(deletable_stat)
+        for record in self._old_records(records):
             ip_addr = None
-            if ipv4_addr_str:
-                ip_addr = IPAddress(version=IPAddress.IPV4,
-                                    address=ipv4_addr_str.encode('utf-8'))
-            elif ipv6_addr_str:
-                ip_addr = IPAddress(version=IPAddress.IPV6,
-                                    address=ipv6_addr_str.encode('utf-8'))
-            rule_version = _get_version(deletable_stat)
+            if record.ue_ipv4:
+                ip_addr = convert_ipv4_str_to_ip_proto(record.ue_ipv4)
+            else:
+                ip_addr = convert_ipv6_str_to_ip_proto(record.ue_ipv6)
 
             try:
-                self._delete_flow(deletable_stat, stat_sid, ip_addr,
-                                  rule_version)
-                # Only remove the usage of the deleted flow if deletion
-                # is successful.
-                self._update_usage_from_flow_stat(deleted_flow_usage,
-                                                  deletable_stat)
+                self._delete_flow(record.sid, ip_addr,
+                                  record.rule_id, record.rule_version)
             except MagmaOFError as e:
                 self.logger.error(
-                    'Failed to delete rule %s for subscriber %s '
-                    '(version: %s): %s', stat_rule_id,
-                    stat_sid, rule_version, e)
+                    'Failed to delete rule %s for subscriber %s ('
+                    'version: %s): %s', record.rule_id,
+                    record.sid, record.rule_version, e)
 
-        self.last_usage_for_delta = self._delta_usage_maps(self.total_usage,
-            deleted_flow_usage)
 
-    def _old_flow_stats(self, stats_msgs):
+    def _old_records(self, records):
         """
-        Generator function to filter the flow stats that should be deleted from
-        the stats messages.
+        Generator function to filter the records that are for old rules
         """
-        for flow_stats in stats_msgs:
-            for stat in flow_stats:
-                if stat.table_id != self.tbl_num:
-                    # this update is not intended for policy
-                    return
+        for record in records:
+            ip_addr = None
+            if record.ue_ipv4:
+                ip_addr = convert_ipv4_str_to_ip_proto(record.ue_ipv4)
+            else:
+                ip_addr = convert_ipv6_str_to_ip_proto(record.ue_ipv6)
 
-                rule_id = self._get_rule_id(stat)
-                sid = _get_sid(stat)
-                ipv4_addr_str = _get_ipv4(stat)
-                ipv4_addr = None
-                if ipv4_addr_str:
-                    ipv4_addr = IPAddress(version=IPAddress.IPV4,
-                                          address=ipv4_addr_str.encode('utf-8'))
-                rule_version = _get_version(stat)
-                if rule_id == "" or rule_version == None:
-                    continue
+            current_ver = self._session_rule_version_mapper.get_version(
+                    record.sid, ip_addr, record.rule_id)
+            if current_ver != record.rule_version:
+                yield record
 
-                current_ver = \
-                    self._session_rule_version_mapper.get_version(sid,
-                                                                  ipv4_addr,
-                                                                  rule_id)
-                if current_ver != rule_version:
-                    yield stat
-
-    def _delete_flow(self, flow_stat, sid, ip_addr, version):
-        cookie, mask = (
-            flow_stat.cookie, flows.OVS_COOKIE_MATCH_ALL)
-        match = _generate_rule_match(
-            sid, ip_addr, flow_stat.cookie, version,
-            Direction(flow_stat.match[DIRECTION_REG]))
+    def _delete_flow(self, imsi, ip_addr, rule_id, rule_version):
+        rule_num = self._rule_mapper.get_or_create_rule_num(rule_id)
+        cookie, mask = (rule_num, flows.OVS_COOKIE_MATCH_ALL)
+        match_in = _generate_rule_match(imsi, ip_addr, cookie, rule_version,
+                                        Direction.IN)
+        match_out = _generate_rule_match(imsi, ip_addr, cookie, rule_version,
+                                         Direction.OUT)
         flows.delete_flow(self._datapath,
                           self.tbl_num,
-                          match,
+                          match_in,
+                          cookie=cookie,
+                          cookie_mask=mask)
+
+        flows.delete_flow(self._datapath,
+                          self.tbl_num,
+                          match_out,
                           cookie=cookie,
                           cookie_mask=mask)
 
@@ -589,74 +557,14 @@ class EnforcementStatsController(PolicyMixin, RestartMixin, MagmaController):
                               rule_num, e)
             return ""
 
-    def _delta_usage_maps(self, current_usage, last_usage):
-        """
-        Calculate the delta between the 2 usage maps and returns a new
-        usage map.
-        """
-        if len(last_usage) == 0:
-            return current_usage
-        new_usage = {}
-        for key, current in current_usage.items():
-            last = last_usage.get(key, None)
-            if last is not None:
-                rec = RuleRecord()
-                rec.MergeFrom(current)  # copy metadata
-                if current.bytes_rx < last.bytes_rx or \
-                        current.bytes_tx < last.bytes_tx:
-                    self.logger.error(
-                        'Resetting usage for rule %s, for subscriber %s, '
-                        'current usage(rx/tx) %d/%d, last usage %d/%d',
-                        rec.sid, rec.rule_id, current.bytes_rx,
-                        current.bytes_tx, last.bytes_rx, last.bytes_tx)
-                    rec.bytes_rx = last.bytes_rx
-                    rec.bytes_tx = last.bytes_tx
-                else:
-                    rec.bytes_rx = current.bytes_rx - last.bytes_rx
-                    rec.bytes_tx = current.bytes_tx - last.bytes_tx
-                new_usage[key] = rec
-            else:
-                new_usage[key] = current
-        return new_usage
-
-    def recover_state(self, stat_flows):
-        for flow in stat_flows[self.tbl_num]:
-            self.last_usage_for_delta = self._update_usage_from_flow_stat(
-                self.last_usage_for_delta, flow)
-        self.logger.info("Recovered enforcement stats")
-        self.logger.debug(self.last_usage_for_delta)
-
-
 def _generate_rule_match(imsi, ip_addr, rule_num, version, direction):
     """
     Return a MagmaMatch that matches on the rule num and the version.
     """
     ip_match = get_ue_ip_match_args(ip_addr, direction)
-
     return MagmaMatch(imsi=encode_imsi(imsi), eth_type=get_eth_type(ip_addr),
                       direction=direction, rule_num=rule_num,
                       rule_version=version, **ip_match)
-
-
-def _merge_usage_maps(current_usage, last_usage):
-    """
-    Merge the usage records from 2 map into a single map
-    """
-    if len(last_usage) == 0:
-        return current_usage
-    new_usage = {}
-    for key, current in current_usage.items():
-        last = last_usage.get(key, None)
-        if last is not None:
-            rec = RuleRecord()
-            rec.MergeFrom(current)  # copy metadata
-            rec.bytes_rx = current.bytes_rx + last.bytes_rx
-            rec.bytes_tx = current.bytes_tx + last.bytes_tx
-            new_usage[key] = rec
-        else:
-            new_usage[key] = current
-    return new_usage
-
 
 def _get_sid(flow):
     if IMSI_REG not in flow.match:

--- a/lte/gateway/python/magma/pipelined/app/gy.py
+++ b/lte/gateway/python/magma/pipelined/app/gy.py
@@ -317,6 +317,3 @@ class GYController(PolicyMixin, RestartMixin, MagmaController):
     @set_ev_cls(ofp_event.EventOFPErrorMsg, MAIN_DISPATCHER)
     def _handle_error(self, ev):
         self._msg_hub.handle_error(ev)
-
-    def recover_state(self, _):
-        pass

--- a/lte/gateway/python/magma/pipelined/app/inout.py
+++ b/lte/gateway/python/magma/pipelined/app/inout.py
@@ -528,9 +528,6 @@ class InOutController(RestartMixin, MagmaController):
     def _get_ue_specific_flow_msgs(self, _):
         return {}
 
-    def recover_state(self, _):
-        pass
-
     def finish_init(self, _):
         pass
 

--- a/lte/gateway/python/magma/pipelined/app/restart_mixin.py
+++ b/lte/gateway/python/magma/pipelined/app/restart_mixin.py
@@ -72,8 +72,6 @@ class RestartMixin(metaclass=ABCMeta):
                               tbl,
                               [flow.match for flow in startup_flows_map[tbl]])
 
-        self.recover_state(startup_flows_map)
-        
         default_msgs = self._get_default_flow_msgs(dp)
         for table, msgs_to_install in default_msgs.items():
             msgs, remaining_flows = self._msg_hub \

--- a/lte/gateway/python/magma/pipelined/policy_converters.py
+++ b/lte/gateway/python/magma/pipelined/policy_converters.py
@@ -244,6 +244,11 @@ def convert_ipv4_str_to_ip_proto(ipv4_str):
                      address=ipv4_str.encode('utf-8'))
 
 
+def convert_ipv6_str_to_ip_proto(ipv6_str):
+    return IPAddress(version=IPAddress.IPV6,
+                     address=ipv6_str.encode('utf-8'))
+
+
 def convert_ipv6_bytes_to_ip_proto(ipv6_bytes):
     return IPAddress(version=IPAddress.IPV6,
                      address=ipv6_bytes)

--- a/lte/gateway/python/magma/pipelined/tests/snapshots/test_restart_resilience.RestartResilienceTest.test_enforcement_ipv6_restart.after_restart.snapshot
+++ b/lte/gateway/python/magma/pipelined/tests/snapshots/test_restart_resilience.RestartResilienceTest.test_enforcement_ipv6_restart.after_restart.snapshot
@@ -1,5 +1,7 @@
  cookie=0x1, table=enforcement(main_table), n_packets=0, n_bytes=0, priority=65533,ipv6,reg1=0x1,metadata=0x48c274b89cc3,ipv6_src=fe80:24c3:d0ff:fef3:9d21:4407:d337:1928,ipv6_dst=fe80:: actions=note:b'ipv6_rule',set_field:0x1->reg2,set_field:0x1->reg4,resubmit(,enforcement_stats(main_table)),resubmit(,egress(main_table))
  cookie=0xfffffffffffffffe, table=enforcement(main_table), n_packets=0, n_bytes=0, priority=0 actions=resubmit(,enforcement_stats(main_table)),set_field:0->reg0,set_field:0->reg3
+ cookie=0x1, table=enforcement_stats(main_table), n_packets=0, n_bytes=0, priority=10,ipv6,reg1=0x10,reg2=0x1,reg3=0,reg4=0x1,metadata=0x48c274b89cc3,ipv6_dst=fe80:24c3:d0ff:fef3:9d21:4407:d337:1928 actions=drop
+ cookie=0x1, table=enforcement_stats(main_table), n_packets=0, n_bytes=0, priority=10,ipv6,reg1=0x1,reg2=0x1,reg3=0,reg4=0x1,metadata=0x48c274b89cc3,ipv6_src=fe80:24c3:d0ff:fef3:9d21:4407:d337:1928 actions=drop
  cookie=0x0, table=enforcement_stats(main_table), n_packets=0, n_bytes=0, priority=1,ipv6,reg1=0x10,reg2=0,reg4=0,metadata=0x48c274b89cc3,ipv6_dst=fe80:24c3:d0ff:fef3:9d21:4407:d337:1928 actions=drop
  cookie=0x0, table=enforcement_stats(main_table), n_packets=0, n_bytes=0, priority=1,ipv6,reg1=0x1,reg2=0,reg4=0,metadata=0x48c274b89cc3,ipv6_src=fe80:24c3:d0ff:fef3:9d21:4407:d337:1928 actions=drop
  cookie=0xfffffffffffffffe, table=enforcement_stats(main_table), n_packets=0, n_bytes=0, priority=0 actions=drop

--- a/lte/gateway/python/magma/pipelined/tests/test_enforcement_stats.py
+++ b/lte/gateway/python/magma/pipelined/tests/test_enforcement_stats.py
@@ -191,8 +191,8 @@ class EnforcementStatsTest(unittest.TestCase):
                 version=1,
             )
         ]
-        enf_stat_name = [imsi + '|tx_match' + '|' + sub_ip,
-                         imsi + '|rx_match' + '|' + sub_ip]
+        enf_stat_name = [imsi + '|tx_match' + '|' + sub_ip + '|' + "1",
+                         imsi + '|rx_match' + '|' + sub_ip + '|' + "1"]
         self.service_manager.session_rule_version_mapper.save_version(
             imsi, convert_ipv4_str_to_ip_proto(sub_ip), 'tx_match', 1)
         self.service_manager.session_rule_version_mapper.save_version(
@@ -280,7 +280,7 @@ class EnforcementStatsTest(unittest.TestCase):
             ),
             version=1,
         )
-        stat_name = imsi + '|redir_test' + '|' + sub_ip
+        stat_name = imsi + '|redir_test' + '|' + sub_ip + '|' + "1"
         self.service_manager.session_rule_version_mapper.save_version(
             imsi, convert_ipv4_str_to_ip_proto(sub_ip), 'redir_test', 1)
 
@@ -419,8 +419,8 @@ class EnforcementStatsTest(unittest.TestCase):
 
         with isolator, sub_context, snapshot_verifier:
             pkt_sender.send(packet)
-
-        enf_stat_name = imsi + '|' + self.DEFAULT_DROP_FLOW_NAME + '|' + sub_ip
+        enf_stat_name = imsi + '|' + self.DEFAULT_DROP_FLOW_NAME + '|' \
+                        + sub_ip + '|' + "0"
         wait_for_enforcement_stats(self.enforcement_stats_controller,
                                    [enf_stat_name])
         stats = get_enforcement_stats(
@@ -502,7 +502,7 @@ class EnforcementStatsTest(unittest.TestCase):
             rule=PolicyRule(id='rule1', priority=3, flow_list=flow_list),
             version=1,
         )
-        enf_stat_name = imsi + '|rule1' + '|' + sub_ip
+        enf_stat_name = imsi + '|rule1' + '|' + sub_ip + '|' + "1"
         self.service_manager.session_rule_version_mapper.save_version(
             imsi, convert_ipv4_str_to_ip_proto(sub_ip), 'rule1', 1)
 
@@ -543,10 +543,13 @@ class EnforcementStatsTest(unittest.TestCase):
             self.enforcement_controller.deactivate_rules(
                 imsi, convert_ipv4_str_to_ip_proto(sub_ip), [policy.rule.id])
 
-        wait_for_enforcement_stats(self.enforcement_stats_controller,
-                                   [enf_stat_name])
-        stats = get_enforcement_stats(
-            self.enforcement_stats_controller._report_usage.call_args_list)
+            wait_for_enforcement_stats(self.enforcement_stats_controller,
+                                       [enf_stat_name])
+            stats = get_enforcement_stats(
+                self.enforcement_stats_controller._report_usage.call_args_list)
+            for args in self.enforcement_stats_controller._report_usage.call_args_list:
+                self.enforcement_stats_controller._delete_old_flows(args[0][0].values())
+
 
         self.assertEqual(stats[enf_stat_name].sid, imsi)
         self.assertEqual(stats[enf_stat_name].rule_id, "rule1")
@@ -593,7 +596,6 @@ class EnforcementStatsTest(unittest.TestCase):
             rule=PolicyRule(id='rule1', priority=3, flow_list=flow_list),
             version=1,
         )
-        enf_stat_name = imsi + '|rule1' + '|' + sub_ip
         self.service_manager.session_rule_version_mapper.save_version(
             imsi, convert_ipv4_str_to_ip_proto(sub_ip), 'rule1', 1)
 
@@ -626,10 +628,8 @@ class EnforcementStatsTest(unittest.TestCase):
         packet. Wait until it is received by ovs and enf stats.
         """
         with isolator, sub_context, snapshot_verifier:
-            self.enforcement_stats_controller._report_usage.reset_mock()
             pkt_sender.send(packet)
 
-            self.enforcement_stats_controller._report_usage.reset_mock()
             self.service_manager.session_rule_version_mapper. \
                 save_version(imsi, convert_ipv4_str_to_ip_proto(sub_ip),
                              'rule1', 2)
@@ -644,18 +644,36 @@ class EnforcementStatsTest(unittest.TestCase):
                 [policy])
             pkt_sender.send(packet)
 
+            enf_stat_names = [
+                imsi + '|rule1' + '|' + sub_ip + '|' + "1",
+                imsi + '|rule1' + '|' + sub_ip + '|' + "2"
+            ]
+            wait_for_enforcement_stats(self.enforcement_stats_controller,
+                                       enf_stat_names)
+            stats = get_enforcement_stats(
+                self.enforcement_stats_controller._report_usage.call_args_list)
+            for args in self.enforcement_stats_controller._report_usage.call_args_list:
+                self.enforcement_stats_controller._delete_old_flows(args[0][0].values())
+
+            self.assertEqual(stats[enf_stat_names[0]].sid, imsi)
+            self.assertEqual(stats[enf_stat_names[0]].rule_id, "rule1")
+            self.assertEqual(stats[enf_stat_names[0]].rule_version, 1)
+            self.assertEqual(stats[enf_stat_names[0]].bytes_rx, 0)
+            self.assertEqual(len(stats), 3)
+
+        self.enforcement_stats_controller._report_usage.reset_mock()
         wait_for_enforcement_stats(self.enforcement_stats_controller,
-                                   [enf_stat_name])
+                                   [enf_stat_names[1]])
         stats = get_enforcement_stats(
             self.enforcement_stats_controller._report_usage.call_args_list)
 
         """
         Verify both packets are reported after reactivation.
         """
-        self.assertEqual(stats[enf_stat_name].sid, imsi)
-        self.assertEqual(stats[enf_stat_name].rule_id, "rule1")
-        self.assertEqual(stats[enf_stat_name].rule_version, 2)
-        self.assertEqual(stats[enf_stat_name].bytes_rx, 0)
+        self.assertEqual(stats[enf_stat_names[1]].sid, imsi)
+        self.assertEqual(stats[enf_stat_names[1]].rule_id, "rule1")
+        self.assertEqual(stats[enf_stat_names[1]].rule_version, 2)
+        self.assertEqual(stats[enf_stat_names[1]].bytes_rx, 0)
         # TODO Figure out why this one fails.
         #self.assertEqual(stats[enf_stat_name].bytes_tx,
         #                 num_pkts_tx_match * len(packet))

--- a/lte/gateway/python/magma/pipelined/tests/test_restart_resilience.py
+++ b/lte/gateway/python/magma/pipelined/tests/test_restart_resilience.py
@@ -198,7 +198,7 @@ class RestartResilienceTest(unittest.TestCase):
                 version=1,
             ),
         ]
-        enf_stat_name = [imsi + '|ipv6_rule' + '|' + str(sub_ip)]
+        enf_stat_name = [imsi + '|ipv6_rule' + '|' + str(sub_ip) + "|" + "1"]
         setup_flows_request = SetupFlowsRequest(
             requests=[ActivateFlowsRequest(
                 sid=SIDUtils.to_pb(imsi),
@@ -358,8 +358,8 @@ class RestartResilienceTest(unittest.TestCase):
                 version=1,
             ),
         ]
-        enf_stat_name = [imsi2 + '|sub2_new_rule' + '|' + sub2_ip,
-                         imsi2 + '|sub2_rule_keep' + '|' + sub2_ip]
+        enf_stat_name = [imsi2 + '|sub2_new_rule' + '|' + sub2_ip + "|" + "1",
+                         imsi2 + '|sub2_rule_keep' + '|' + sub2_ip + "|" + "1"]
         setup_flows_request = SetupFlowsRequest(
             requests=[ActivateFlowsRequest(
                 sid=SIDUtils.to_pb(imsi2),
@@ -443,8 +443,8 @@ class RestartResilienceTest(unittest.TestCase):
                 version=1,
             ),
         ]
-        enf_stat_name = [imsi + '|tx_match' + '|' + sub_ip,
-                         imsi + '|rx_match' + '|' + sub_ip]
+        enf_stat_name = [imsi + '|tx_match' + '|' + sub_ip + "|" + "1",
+                         imsi + '|rx_match' + '|' + sub_ip + "|" + "1"]
         self.service_manager.session_rule_version_mapper.save_version(
             imsi, convert_ipv4_str_to_ip_proto(sub_ip), 'tx_match', 1)
         self.service_manager.session_rule_version_mapper.save_version(


### PR DESCRIPTION
# DO NOT MERGE, review and once approved I'll cherry pick to https://github.com/magma/magma/pull/5424

Signed-off-by: Nick Yurchenko <koolzz@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary

Convert to flat rate based enforcement
 - Remove all delta calculation maps from enf stats
 - Simplify rule removal to remove rules once we successfully reported flows to sessiond
<!-- Enumerate changes you made and why you made them -->

## Test Plan
 - Unit tests pass 
 - CWF integ passes
 - TerraVM sort of passes (other issues present)
## Additional Information

- [ ] This change is backwards-breaking

Some quick metrics before this pr
```
(python) vagrant@magma-dev:~/magma/lte/gateway/python/scripts$ ./pipelined_cli.py enforcement stress_test_grpc  --test_iterations=2 --attaches_per_sec=100
/home/vagrant/build/python/lib/python3.5/site-packages/scapy/config.py:411: CryptographyDeprecationWarning: Python 3.5 support will be dropped in the next release of cryptography. Please upgrade your Python.
  import cryptography
WARNING: DO NOT USE ON PRODUCTION SETUPS
Attach every ~0.01 seconds
QOS Enabled
Starting iteration 0 of attach/detach requests
Starting attaches
Finished 600 attaches in 11.089374 seconds
Actual attach rate = 54 UEs per sec
Starting detaches
Finished 600 detaches in 6.548913 seconds
Actual detach rate = {0} UEs per sec 92
Starting iteration 1 of attach/detach requests
Starting attaches
Finished 600 attaches in 10.592679 seconds
Actual attach rate = 57 UEs per sec
Starting detaches
Finished 600 detaches in 6.518788 seconds
Actual detach rate = {0} UEs per sec 92
(python) vagrant@magma-dev:~/magma/lte/gateway/python/scripts$ ./pipelined_cli.py enforcement stress_test_grpc  --test_iterations=2 --attaches_per_sec=100
```

After ->
```
/home/vagrant/build/python/lib/python3.5/site-packages/scapy/config.py:411: CryptographyDeprecationWarning: Python 3.5 support will be dropped in the next release of cryptography. Please upgrade your Python.
  import cryptography
WARNING: DO NOT USE ON PRODUCTION SETUPS
Attach every ~0.01 seconds
QOS Enabled
Starting iteration 0 of attach/detach requests
Starting attaches
Finished 600 attaches in 8.591473 seconds
Actual attach rate = 70 UEs per sec
Starting detaches
Finished 600 detaches in 6.66619 seconds
Actual detach rate = {0} UEs per sec 90
Starting iteration 1 of attach/detach requests
Starting attaches
Finished 600 attaches in 10.006942 seconds
Actual attach rate = 60 UEs per sec
Starting detaches
Finished 600 detaches in 6.828944 seconds
Actual detach rate = {0} UEs per sec 88
```
