### PR TITLE
fix for skipping Identity procedure for suci based registration

### DIFF
--- a/lte/gateway/c/oai/tasks/amf/Registration.cpp
+++ b/lte/gateway/c/oai/tasks/amf/Registration.cpp
@@ -106,15 +106,6 @@ static int amf_start_registration_proc_authentication(
 ***************************************************************************/
 nas_amf_registration_proc_t* nas_new_registration_procedure(
     ue_m5gmm_context_s* ue_ctxt) {
-  ue_m5gmm_context_s* ue_m5gmm_context =
-      amf_ue_context_exists_amf_ue_ngap_id(ue_ctxt->amf_ue_ngap_id);
-
-  if (ue_m5gmm_context == NULL) {
-    OAILOG_ERROR(
-        LOG_AMF_APP, "ue context not found for the ue_id=%u\n",
-        ue_ctxt->amf_ue_ngap_id);
-    OAILOG_FUNC_RETURN(LOG_AMF_APP, NULL);
-  }
   amf_context_t* amf_context = &ue_ctxt->amf_context;
 
   if (!(amf_context->amf_procedures)) {
@@ -137,7 +128,6 @@ nas_amf_registration_proc_t* nas_new_registration_procedure(
       (nas_amf_registration_proc_t*)
           amf_context->amf_procedures->amf_specific_proc;
 
-  ue_m5gmm_context->amf_context.amf_procedures = amf_context->amf_procedures;
   OAILOG_TRACE(
       LOG_NAS_AMF, "New AMF_SPEC_PROC_TYPE_REGISTRATION initialized\n");
   return proc;
@@ -192,24 +182,25 @@ int amf_proc_registration_request(
         ue_id, imei_str);
   }
 
-  // Initialize the temporary UE context
-  memset(&ue_ctx, 0, sizeof(ue_m5gmm_context_s));
-  ue_ctx.amf_context.is_dynamic = false;
-  ue_ctx.amf_ue_ngap_id         = ue_id;
-
-  if (!(is_nas_specific_procedure_registration_running(&ue_ctx.amf_context))) {
-    amf_proc_create_procedure_registration_request(&ue_ctx, ies);
-  }
   ue_m5gmm_context = amf_ue_context_exists_amf_ue_ngap_id(ue_id);
   if (ue_m5gmm_context == NULL) {
     OAILOG_ERROR(LOG_AMF_APP, "ue context not found for the ue_id=%u\n", ue_id);
     OAILOG_FUNC_RETURN(LOG_AMF_APP, rc);
   }
 
+  ue_m5gmm_context->amf_context.amf_procedures = NULL;
+  ue_m5gmm_context->amf_context.is_dynamic     = false;
+  ue_m5gmm_context->amf_ue_ngap_id             = ue_id;
+
+  if (!(is_nas_specific_procedure_registration_running(
+          &ue_m5gmm_context->amf_context))) {
+    amf_proc_create_procedure_registration_request(ue_m5gmm_context, ies);
+  }
+
   OAILOG_INFO(LOG_AMF_APP, "ue_m5gmm_context %p\n", ue_m5gmm_context);
   rc = ue_state_handle_message_initial(
       ue_m5gmm_context->mm_state, STATE_EVENT_REG_REQUEST, SESSION_NULL,
-      ue_m5gmm_context, &ue_ctx.amf_context);
+      ue_m5gmm_context, &ue_m5gmm_context->amf_context);
 
   OAILOG_FUNC_RETURN(LOG_NAS_AMF, rc);
 }
@@ -329,6 +320,20 @@ int amf_registration_run_procedure(amf_context_t* amf_context) {
             //{
           (registration_proc->ies->decode_status.integrity_protected_message)) {
         // force authentication, even if not necessary
+        imsi64_t imsi64 = amf_imsi_to_imsi64(registration_proc->ies->imsi);
+        amf_ctx_set_valid_imsi(
+            amf_context, registration_proc->ies->imsi, imsi64);
+        rc = amf_start_registration_proc_authentication(
+            amf_context, registration_proc);
+        if (rc != RETURNok) {
+          OAILOG_ERROR(
+              LOG_NAS_AMF,
+              "Failed to start registration authentication procedure! \n");
+        }
+      } else if (amf_context->reg_id_type == M5GSMobileIdentityMsg_SUCI_IMSI) {
+        OAILOG_INFO(
+            LOG_AMF_APP,
+            "In SUCI Initial request case Send Auth Req directly\n");
         imsi64_t imsi64 = amf_imsi_to_imsi64(registration_proc->ies->imsi);
         amf_ctx_set_valid_imsi(
             amf_context, registration_proc->ies->imsi, imsi64);

--- a/lte/gateway/c/oai/tasks/amf/amf_app_ue_context_and_proc.h
+++ b/lte/gateway/c/oai/tasks/amf/amf_app_ue_context_and_proc.h
@@ -303,6 +303,7 @@ typedef struct amf_context_s {
                                              AMF24.501R15_5.5.3.2.4_4*/
   std::string smf_msg; /* SMF message contained within the initial request*/
   bool is_imsi_only_detach;
+  uint8_t reg_id_type;
 } amf_context_t;
 
 typedef struct amf_ue_context_s {

--- a/lte/gateway/c/oai/tasks/amf/amf_recv.cpp
+++ b/lte/gateway/c/oai/tasks/amf/amf_recv.cpp
@@ -203,6 +203,47 @@ int amf_handle_registration_request(
             params->imsi->u.value[2], params->imsi->u.value[3],
             params->imsi->u.value[4], params->imsi->u.value[5],
             params->imsi->u.value[6], params->imsi->u.value[7]);
+
+        ue_context->amf_context.m5_guti.guamfi.plmn.mcc_digit1 =
+            supi_imsi.plmn.mcc_digit1;
+        ue_context->amf_context.m5_guti.guamfi.plmn.mcc_digit2 =
+            supi_imsi.plmn.mcc_digit2;
+        ue_context->amf_context.m5_guti.guamfi.plmn.mcc_digit3 =
+            supi_imsi.plmn.mcc_digit3;
+        ue_context->amf_context.m5_guti.guamfi.plmn.mnc_digit1 =
+            supi_imsi.plmn.mnc_digit1;
+        ue_context->amf_context.m5_guti.guamfi.plmn.mnc_digit2 =
+            supi_imsi.plmn.mnc_digit2;
+        ue_context->amf_context.m5_guti.guamfi.plmn.mnc_digit3 =
+            supi_imsi.plmn.mnc_digit3;
+
+        ue_context->amf_context.reg_id_type = M5GSMobileIdentityMsg_SUCI_IMSI;
+
+        amf_app_generate_guti_on_supi(&amf_guti, &supi_imsi);
+
+        ue_context->amf_context.m5_guti.m_tmsi = amf_guti.m_tmsi;
+        imsi64_t imsi64                = amf_imsi_to_imsi64(params->imsi);
+        guti_and_amf_id.amf_guti       = amf_guti;
+        guti_and_amf_id.amf_ue_ngap_id = ue_id;
+        if (amf_supi_guti_map.size() == 0) {
+          // first entry.
+          amf_supi_guti_map.insert(
+              std::pair<imsi64_t, guti_and_amf_id_t>(imsi64, guti_and_amf_id));
+        } else {
+          /* already elements exist then check if same imsi already present
+           * if same imsi then update/overwrite the element
+           */
+          std::unordered_map<imsi64_t, guti_and_amf_id_t>::iterator found_imsi =
+              amf_supi_guti_map.find(imsi64);
+          if (found_imsi == amf_supi_guti_map.end()) {
+            // it is new entry to map
+            amf_supi_guti_map.insert(std::pair<imsi64_t, guti_and_amf_id_t>(
+                imsi64, guti_and_amf_id));
+          } else {
+            // Overwrite the second element.
+            found_imsi->second = guti_and_amf_id;
+          }
+        }
       }
     }
   }  // end of AMF_REGISTRATION_TYPE_INITIAL


### PR DESCRIPTION
 [5G: MVC][component: agw] [type: enhancement] 5G Skipping Identity Procedure 

## Summary

1. Modified AMF code to Skip Identity Procedure if SUCI is received in Registration request

## Test Plan

1. Tested Registration with NGAP Tester
2. No Identity procedure observed if SUCI is received 

## Additional Information

