### PR TITLE
Add sentry transation tag to OperationalStatesHandler

### DIFF
--- a/lte/gateway/c/session_manager/sessiond_main.cpp
+++ b/lte/gateway/c/session_manager/sessiond_main.cpp
@@ -324,6 +324,7 @@ int main(int argc, char* argv[]) {
     std::promise<magma::OpState> result;
     std::future<magma::OpState> future = result.get_future();
     evb->runInEventBaseThread([session_store, &result, &future]() {
+      set_sentry_transaction("GetOperationalStates");
       result.set_value(magma::get_operational_states(session_store));
     });
     return future.get();


### PR DESCRIPTION
Signed-off-by: Marie Bremner <marwhal@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary
On sentry, the trasnaction value shows up in the issue to signify what chunk of logic the crash appeared in. (In most cases this is easy to infer from the stacktrace, but sometimes it is useful to have.)

In the picture, `UpdateTunnelIds` is the transaction tag I added back in https://github.com/magma/magma/pull/6864
<img width="547" alt="Screen Shot 2021-05-17 at 12 34 09 PM" src="https://user-images.githubusercontent.com/37634144/118532093-2ef17a00-b70c-11eb-84ca-c9c21ac454e8.png">


When we see redis related crashes when handling the operational state handler, we don't usually see a useful stacktrace as it is wrapped in multiple lambda functions. So thought this tag could be useful.


<!-- Enumerate changes you made and why you made them -->

## Test Plan
make precommit_sm
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
