### PR TITLE
[MagmaD] Improve error message for when a dynamic service is not registered

### DIFF
--- a/orc8r/gateway/python/magma/magmad/service_manager.py
+++ b/orc8r/gateway/python/magma/magmad/service_manager.py
@@ -89,17 +89,20 @@ class ServiceManager(object):
             return init_systems[init_system]
         except KeyError:
             raise ValueError(
-                'Init system {} not found'.format(init_system)
+                'Init system {} not found'.format(init_system),
             )
 
     async def start_services(self):
         await asyncio.gather(
-            *[self._service_control[s].start_process() for s in self._services]
+            *[
+                self._service_control[s].start_process()
+                for s in self._services
+            ],
         )
 
     async def stop_services(self):
         await asyncio.gather(
-            *[self._service_control[s].stop_process() for s in self._services]
+            *[self._service_control[s].stop_process() for s in self._services],
         )
 
     async def restart_services(self, services=None):
@@ -109,7 +112,7 @@ class ServiceManager(object):
         for service in services:
             self._service_poller.process_service_restart(service)
         await asyncio.gather(
-            *[self._service_control[s].restart_process() for s in services]
+            *[self._service_control[s].restart_process() for s in services],
         )
         magmad_events.restarted_services(services)
 
@@ -124,7 +127,7 @@ class ServiceManager(object):
 
         await asyncio.gather(
             *[self._service_control[s].stop_process() for s in stop],
-            *[self._service_control[s].start_process() for s in start]
+            *[self._service_control[s].start_process() for s in start],
         )
 
     def _parse_dynamic_services(
@@ -148,21 +151,27 @@ class ServiceManager(object):
                 stop.append(s)
         return start, stop
 
-    def _clean_dynamic_services(self, dynamic_services: List[str]) -> List[str]:
+    def _clean_dynamic_services(
+            self, dynamic_services: List[str],
+    ) -> List[str]:
         """Filter out any dynamic services that are not registered
 
         Args:
             dynamic_services (List[str]): list of services specified in mconfig
 
         Returns:
-            List[str]: intersection of dynamic_services and registered_dynamic_services
+            List[str]: intersection of dynamic_services and
+            registered_dynamic_services
         """
         clean_dynamic_services = []
-        for s in dynamic_services:
-            if s not in self._registered_dynamic_services:
-                logging.error("Not enabling %s as it is not listed as a registered dynamic service in magmad.yml", s)
+        for service_name in dynamic_services:
+            if service_name not in self._registered_dynamic_services:
+                logging.error(
+                    "Not enabling %s as it is not listed as a registered dynamic service in magmad.yml",
+                    service_name,
+                )
             else:
-                clean_dynamic_services.append(s)
+                clean_dynamic_services.append(service_name)
         return clean_dynamic_services
 
     class ServiceControl(object):
@@ -204,21 +213,21 @@ class ServiceManager(object):
         async def start_process(self):
             """Starts a process by name."""
             ret = await self._run_command_async(
-                self._init_system_spec.start_cmd
+                self._init_system_spec.start_cmd,
             )
             return ret.status_code
 
         async def stop_process(self):
             """Stops a process by name."""
             ret = await self._run_command_async(
-                self._init_system_spec.stop_cmd
+                self._init_system_spec.stop_cmd,
             )
             return ret.status_code
 
         async def restart_process(self):
             """Restarts a process by name."""
             ret = await self._run_command_async(
-                self._init_system_spec.restart_cmd
+                self._init_system_spec.restart_cmd,
             )
             return ret.status_code
 

--- a/orc8r/gateway/python/magma/magmad/service_manager.py
+++ b/orc8r/gateway/python/magma/magmad/service_manager.py
@@ -148,14 +148,19 @@ class ServiceManager(object):
                 stop.append(s)
         return start, stop
 
-    def _clean_dynamic_services(self, dynamic_services):
-        """ Check for invalid service names, remove them from list """
+    def _clean_dynamic_services(self, dynamic_services: List[str]) -> List[str]:
+        """Filter out any dynamic services that are not registered
+
+        Args:
+            dynamic_services (List[str]): list of services specified in mconfig
+
+        Returns:
+            List[str]: intersection of dynamic_services and registered_dynamic_services
+        """
         clean_dynamic_services = []
         for s in dynamic_services:
             if s not in self._registered_dynamic_services:
-                error_msg = "Magmad mconfig error: " +\
-                    "service {} is not a registered dynamic service".format(s)
-                logging.error(error_msg)
+                logging.error("Not enabling %s as it is not listed as a registered dynamic service in magmad.yml", s)
             else:
                 clean_dynamic_services.append(s)
         return clean_dynamic_services


### PR DESCRIPTION
Signed-off-by: Marie Bremner <marwhal@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary
Improving the error message "Magmad mconfig error: service eventd is not a registered dynamic service" so that a person who forgot the meaning of dynamic services (like me) can figure out how to get rid of the error message.

First commit is the actual message change
Second commit is format

<!-- Enumerate changes you made and why you made them -->

## Test Plan
unit tests + running the service locally
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
