### PR TITLE
[MME][DOCKER][RHEL8] Only using cmake3

### DIFF
--- a/lte/gateway/docker/mme/Dockerfile.rhel8
+++ b/lte/gateway/docker/mme/Dockerfile.rhel8
@@ -30,6 +30,7 @@ RUN rm /etc/rhsm-host && \
     libselinux-python3 \
     vim \
     gcc \
+    cmake3 \
     automake \
     autoconf \
     tmux \
@@ -44,7 +45,8 @@ RUN rm /etc/rhsm-host && \
     protobuf-compiler \
     ruby \
     ruby-devel \
-  && ln -s /usr/bin/python3 /usr/bin/python
+  && ln -s /usr/bin/python3 /usr/bin/python \
+  && ln -s /usr/bin/cmake3 /usr/bin/cmake
 
 RUN yum install -y \
     gnupg \
@@ -74,7 +76,6 @@ RUN yum install -y \
     elfutils-libelf-devel-static \
     libdwarf-devel \
     # Install Folly requirements
-    cmake \
     boost \
     boost-devel \
     libevent-devel \
@@ -311,8 +312,8 @@ RUN echo "Install fmtlib required by Folly" && \
     patch -p1 < /patches/folly-gflagslib-fix.patch && \
     mkdir _build && \
     cd _build && \
-    # cmake "-DFPHSA_NAME_MISMATCHED=true" .. && \
-    cmake \
+    # cmake3 "-DFPHSA_NAME_MISMATCHED=true" .. && \
+    cmake3 \
    "-DCMAKE_INCLUDE_PATH=/usr/local/include/double-conversion" \
    "-DCMAKE_LIBRARY_PATH=/usr/local/lib:/usr/local/lib64" \
     .. && \
@@ -341,7 +342,7 @@ RUN cd json && \
     git log -n1 && \
     mkdir _build && \
     cd _build && \
-    cmake -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=Release .. && \
+    cmake3 -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=Release .. && \
     make -j`nproc` && \
     make install && \
     cp /usr/local/include/nlohmann/json.hpp /usr/local/include/
@@ -352,7 +353,7 @@ RUN cd yaml-cpp && \
     git checkout -f yaml-cpp-0.6.3 && \
     mkdir _build && \
     cd _build && \
-    cmake -DYAML_BUILD_SHARED_LIBS=ON .. && \
+    cmake3 -DYAML_BUILD_SHARED_LIBS=ON .. && \
     make -j`nproc` && \
     make install
 


### PR DESCRIPTION
Signed-off-by: Raphael Defosseux <raphael.defosseux@openairinterface.org>

## Summary

Since last night, `cmake3` is not implicitly installed on `RHEL8` Ubi images.
I also forced all commands to be using that version (vs `cmake`)

## Test Plan

I did a manual build.

## Additional Information

- [ ] This change is backwards-breaking

