### PR TITLE
Fix Pipelined Enf Stats IPv6 Removal

### DIFF
--- a/lte/gateway/python/magma/pipelined/app/enforcement_stats.py
+++ b/lte/gateway/python/magma/pipelined/app/enforcement_stats.py
@@ -547,17 +547,21 @@ class EnforcementStatsController(PolicyMixin, RestartMixin, MagmaController):
                 rule_id = self._get_rule_id(stat)
                 sid = _get_sid(stat)
                 ipv4_addr_str = _get_ipv4(stat)
-                ipv4_addr = None
+                ipv6_addr_str = _get_ipv6(stat)
+                ip_addr = None
                 if ipv4_addr_str:
-                    ipv4_addr = IPAddress(version=IPAddress.IPV4,
+                    ip_addr = IPAddress(version=IPAddress.IPV4,
                                           address=ipv4_addr_str.encode('utf-8'))
+                elif ipv6_addr_str:
+                    ip_addr = IPAddress(version=IPAddress.IPV6,
+                                          address=ipv6_addr_str.encode('utf-8'))
                 rule_version = _get_version(stat)
                 if rule_id == "" or rule_version == None:
                     continue
 
                 current_ver = \
                     self._session_rule_version_mapper.get_version(sid,
-                                                                  ipv4_addr,
+                                                                  ip_addr,
                                                                   rule_id)
                 if current_ver != rule_version:
                     yield stat

--- a/lte/gateway/python/magma/pipelined/tests/snapshots/test_restart_resilience.RestartResilienceTest.test_enforcement_ipv6_restart.after_restart.snapshot
+++ b/lte/gateway/python/magma/pipelined/tests/snapshots/test_restart_resilience.RestartResilienceTest.test_enforcement_ipv6_restart.after_restart.snapshot
@@ -1,5 +1,7 @@
  cookie=0x1, table=enforcement(main_table), n_packets=0, n_bytes=0, priority=65533,ipv6,reg1=0x1,metadata=0x48c274b89cc3,ipv6_src=fe80:24c3:d0ff:fef3:9d21:4407:d337:1928,ipv6_dst=fe80:: actions=note:b'ipv6_rule',set_field:0x1->reg2,set_field:0x1->reg4,resubmit(,enforcement_stats(main_table)),resubmit(,egress(main_table))
  cookie=0xfffffffffffffffe, table=enforcement(main_table), n_packets=0, n_bytes=0, priority=0 actions=resubmit(,enforcement_stats(main_table)),set_field:0->reg0,set_field:0->reg3
+ cookie=0x1, table=enforcement_stats(main_table), n_packets=0, n_bytes=0, priority=10,ipv6,reg1=0x10,reg2=0x1,reg3=0,reg4=0x1,metadata=0x48c274b89cc3,ipv6_dst=fe80:24c3:d0ff:fef3:9d21:4407:d337:1928 actions=drop
+ cookie=0x1, table=enforcement_stats(main_table), n_packets=0, n_bytes=0, priority=10,ipv6,reg1=0x1,reg2=0x1,reg3=0,reg4=0x1,metadata=0x48c274b89cc3,ipv6_src=fe80:24c3:d0ff:fef3:9d21:4407:d337:1928 actions=drop
  cookie=0x0, table=enforcement_stats(main_table), n_packets=0, n_bytes=0, priority=1,ipv6,reg1=0x10,reg2=0,reg4=0,metadata=0x48c274b89cc3,ipv6_dst=fe80:24c3:d0ff:fef3:9d21:4407:d337:1928 actions=drop
  cookie=0x0, table=enforcement_stats(main_table), n_packets=0, n_bytes=0, priority=1,ipv6,reg1=0x1,reg2=0,reg4=0,metadata=0x48c274b89cc3,ipv6_src=fe80:24c3:d0ff:fef3:9d21:4407:d337:1928 actions=drop
  cookie=0xfffffffffffffffe, table=enforcement_stats(main_table), n_packets=0, n_bytes=0, priority=0 actions=drop


### PR DESCRIPTION
Signed-off-by: Nick Yurchenko <koolzz@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary

Adds a ipv6 check when removing old enf stats flows

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
