### PR TITLE
Remove startup sentry message from MME/SessionD

### DIFF
--- a/lte/gateway/c/oai/common/sentry_wrapper.cpp
+++ b/lte/gateway/c/oai/common/sentry_wrapper.cpp
@@ -80,9 +80,6 @@ void initialize_sentry() {
 
     sentry_set_tag(SERVICE_NAME, "MME");
     sentry_set_tag(HWID, get_snowflake().c_str());
-    // Send an initial message to indicate service start
-    sentry_capture_event(sentry_value_new_message_event(
-        SENTRY_LEVEL_INFO, "", "Starting MME with Sentry!"));
   }
 }
 

--- a/lte/gateway/c/oai/oai_mme/oai_mme.c
+++ b/lte/gateway/c/oai/oai_mme/oai_mme.c
@@ -99,6 +99,13 @@ int main(int argc, char* argv[]) {
   CHECK_INIT_RETURN(itti_init(
       TASK_MAX, THREAD_MAX, MESSAGES_ID_MAX, tasks_info, messages_info, NULL,
       NULL));
+
+  // Initialize Sentry error collection (Currently only supported on
+  // Ubuntu 20.04)
+  // We have to initialize here for now since itti_init asserts on there being
+  // only 1 thread
+  initialize_sentry();
+
   CHECK_INIT_RETURN(timer_init());
   // Could not be launched before ITTI initialization
   shared_log_itti_connect();
@@ -121,10 +128,6 @@ int main(int argc, char* argv[]) {
     exit(-EDEADLK);
   }
   free_wrapper((void**) &pid_file_name);
-
-  // Initialize Sentry error collection (Currently only supported on
-  // Ubuntu 20.04)
-  initialize_sentry();
 
   /*
    * Calling each layer init function

--- a/lte/gateway/c/session_manager/SentryWrappers.cpp
+++ b/lte/gateway/c/session_manager/SentryWrappers.cpp
@@ -35,6 +35,8 @@
 
 using std::experimental::optional;
 
+// TODO(@themarwhal) pull common sentry functions into lib common
+
 optional<std::string> get_sentry_url(YAML::Node control_proxy_config) {
   std::string sentry_url;
   if (control_proxy_config[SENTRY_NATIVE_URL].IsDefined()) {
@@ -69,9 +71,6 @@ void initialize_sentry() {
     sentry_init(options);
     sentry_set_tag(SERVICE_NAME, "SessionD");
     sentry_set_tag(HWID, get_snowflake().c_str());
-
-    sentry_capture_event(sentry_value_new_message_event(
-        SENTRY_LEVEL_INFO, "", "Starting SessionD with Sentry!"));
   }
 }
 

--- a/lte/gateway/configs/control_proxy.yml
+++ b/lte/gateway/configs/control_proxy.yml
@@ -47,4 +47,6 @@ sentry_url_python: ""
 sentry_url_native: ""
 # If set, /var/log/mme.log will be uploaded along MME crashreports
 sentry_upload_mme_log: false
-sentry_sample_rate: 1.0
+# Rate at which we want to sample Python error events
+# Should be a number between 0 (0% of errors sent) and 1 (100% of errors sent)
+sentry_sample_rate: 0.5


### PR DESCRIPTION
Signed-off-by: Marie Bremner <marwhal@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary
Sentry charges by the number of events, so sometimes it's not great to send an event every time the service starts up. This event was useful at first, but getting rid of them as it doesn't provide useful information.

<!-- Enumerate changes you made and why you made them -->

## Test Plan
tested locally 
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
