### PR TITLE
improve error log that's seen on mobilityd start

### DIFF
--- a/lte/gateway/python/magma/mobilityd/main.py
+++ b/lte/gateway/python/magma/mobilityd/main.py
@@ -88,7 +88,9 @@ def _get_ip_block(ip_block_str: str) -> Optional[ipaddress.ip_network]:
             ip_block(ipaddress.ip_network)
     """
     if not ip_block_str:
-        logging.error("Empty IP block")
+        logging.warning(
+            "given ip block str is empty, cannot convert  to ipaddress.ip_network",
+        )
         return None
     try:
         ip_block = ipaddress.ip_network(ip_block_str)

--- a/lte/gateway/python/magma/mobilityd/main.py
+++ b/lte/gateway/python/magma/mobilityd/main.py
@@ -12,7 +12,7 @@ limitations under the License.
 """
 import ipaddress
 import logging
-from typing import Optional
+from typing import Any, Optional
 
 from lte.protos.mconfig import mconfigs_pb2
 from lte.protos.subscriberdb_pb2_grpc import SubscriberDBStub
@@ -31,6 +31,8 @@ from magma.mobilityd.mobility_store import MobilityStore
 from magma.mobilityd.rpc_servicer import MobilityServiceRpcServicer
 
 DEFAULT_IPV6_PREFIX_ALLOC_MODE = 'RANDOM'
+RETRY_LIMIT = 300
+DEFAULT_REDIS_PORT = 6380
 
 
 def _get_ipv4_allocator(
@@ -77,19 +79,24 @@ def _get_ipv4_allocator(
     return ip_allocator
 
 
-def _get_ip_block(ip_block_str: str) -> Optional[ipaddress.ip_network]:
-    """ Convert string into ipaddress.ip_network. Support both IPv4 or IPv6
-    addresses.
+def _get_ip_block(
+    ip_block_str: str,
+    ip_type: str,
+) -> Optional[ipaddress.ip_network]:
+    """Convert string into ipaddress.ip_network
 
-        Args:
-            ip_block_str(string): network address, e.g. "192.168.0.0/24".
+    Support both IPv4 or IPv6 addresses
 
-        Returns:
-            ip_block(ipaddress.ip_network)
+    Args:
+        ip_block_str (str): network address, e.g. "192.168.0.0/24"
+        ip_type (str): ipv4 or ipv6 used for logging
+
+    Returns:
+        Optional[ipaddress.ip_network]:
     """
     if not ip_block_str:
         logging.warning(
-            "given ip block str is empty, cannot convert  to ipaddress.ip_network",
+            "%s ip block is not specified in mconfig, skipping", ip_type,
         )
         return None
     try:
@@ -100,8 +107,12 @@ def _get_ip_block(ip_block_str: str) -> Optional[ipaddress.ip_network]:
     return ip_block
 
 
+def _get_value_or_default(val: Any, default: Any) -> Any:
+    return val or default
+
+
 def main():
-    """ main() for MobilityD """
+    """Start mobilityd"""
     service = MagmaService('mobilityd', mconfigs_pb2.MobilityD())
 
     # Optionally pipe errors to Sentry
@@ -116,14 +127,14 @@ def main():
     allocator_type = mconfig.ip_allocator_type
 
     dhcp_iface = config.get('dhcp_iface', 'dhcp0')
-    dhcp_retry_limit = config.get('retry_limit', 300)
+    dhcp_retry_limit = config.get('retry_limit', RETRY_LIMIT)
 
     # TODO: consider adding gateway mconfig to decide whether to
     # persist to Redis
     client = get_default_client()
     store = MobilityStore(
         client, config.get('persist_to_redis', False),
-        config.get('redis_port', 6380),
+        config.get('redis_port', DEFAULT_REDIS_PORT),
     )
 
     chan = ServiceRegistry.get_rpc_channel(
@@ -138,10 +149,12 @@ def main():
     )
 
     # Init IPv6 allocator, for now only IP_POOL mode is supported for IPv6
-    ipv6_prefix_allocation_type = mconfig.ipv6_prefix_allocation_type or \
-        DEFAULT_IPV6_PREFIX_ALLOC_MODE
     ipv6_allocator = IPv6AllocatorPool(
-        store=store, session_prefix_alloc_mode=ipv6_prefix_allocation_type,
+        store=store,
+        session_prefix_alloc_mode=_get_value_or_default(
+            mconfig.ipv6_prefix_allocation_type,
+            DEFAULT_IPV6_PREFIX_ALLOC_MODE,
+        ),
     )
 
     # Load IPAddressManager
@@ -155,17 +168,17 @@ def main():
 
     # Load IPv4 and IPv6 blocks from the configurable mconfig file
     # No dynamic reloading support for now, assume restart after updates
-    logging.info('Adding IPv4 block')
-    ipv4_block = _get_ip_block(mconfig.ip_block)
+    ipv4_block = _get_ip_block(mconfig.ip_block, "IPv4")
     if ipv4_block is not None:
+        logging.info('Adding IPv4 block')
         try:
             mobility_service_servicer.add_ip_block(ipv4_block)
         except OverlappedIPBlocksError:
             logging.warning("Overlapped IPv4 block: %s", ipv4_block)
 
-    logging.info('Adding IPv6 block')
-    ipv6_block = _get_ip_block(mconfig.ipv6_block)
+    ipv6_block = _get_ip_block(mconfig.ipv6_block, "IPv6")
     if ipv6_block is not None:
+        logging.info('Adding IPv6 block')
         try:
             mobility_service_servicer.add_ip_block(ipv6_block)
         except OverlappedIPBlocksError:


### PR DESCRIPTION
<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary
When pipelined/mme/sessiond/mobilityd restarts, we see this `Empty IP Block` error message. Since this error message is expected on service restart, downgrading the level to warning. Additionally, improving the message so that it's a bit more clear.

In the second commit, I just addressed all lint messages that showed up for this file.
```
➜  python git:(master) ✗ ./precommit.py -l -p lte/gateway/python/magma/mobilityd/main.py
Running 'docker run -it -u 0 -v /Users/marwhal/Desktop/magma:/code magma/py-lint:latest flake8 lte/gateway/python/magma/mobilityd/main.py'...
lte/gateway/python/magma/mobilityd/main.py:81:1: D205 1 blank line required between summary line and description
lte/gateway/python/magma/mobilityd/main.py:81:1: D210 No whitespaces allowed surrounding docstring text
lte/gateway/python/magma/mobilityd/main.py:81:1: DAR101 Missing parameter(s) in Docstring: - ip_block_str
lte/gateway/python/magma/mobilityd/main.py:81:1: DAR201 Missing "Returns" in Docstring: - return
lte/gateway/python/magma/mobilityd/main.py:102:1: D210 No whitespaces allowed surrounding docstring text
lte/gateway/python/magma/mobilityd/main.py:102:1: D401 First line should be in imperative mood; try rephrasing
lte/gateway/python/magma/mobilityd/main.py:102:1: D402 First line should not be the function's "signature"
lte/gateway/python/magma/mobilityd/main.py:117:50: WPS432 Found magic number: 300
lte/gateway/python/magma/mobilityd/main.py:124:34: WPS432 Found magic number: 6380
lte/gateway/python/magma/mobilityd/main.py:139:5: N400: Found backslash that is used for line breaking
Command '['docker', 'run', '-it', '-u', '0', '-v', '/Users/marwhal/Desktop/magma:/code', 'magma/py-lint:latest', 'flake8', 'lte/gateway/python/magma/mobilityd/main.py']' returned non-zero exit status 1.
➜  python git:(master) ✗
```

<!-- Enumerate changes you made and why you made them -->

## Test Plan
unit tests
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
Signed-off-by: Marie Bremner <marwhal@fb.com>