### PR TITLE
[lte][agw] Fix the check for all flow rule but the default ones

### DIFF
--- a/lte/gateway/python/integ_tests/s1aptests/s1ap_utils.py
+++ b/lte/gateway/python/integ_tests/s1aptests/s1ap_utils.py
@@ -408,9 +408,6 @@ class S1ApUtil(object):
         with self._lock:
             del self._ue_ip_map[ue_id]
 
-        # Verify that all UL/DL flows are deleted
-        self.verify_flow_rules_deletion()
-
 
     def _verify_dl_flow(self, dl_flow_rules=None):
         # try at least 5 times before failing as gateway
@@ -583,7 +580,7 @@ class S1ApUtil(object):
         print("Checking if all uplink/downlink flows were deleted")
         dpath = get_datapath()
         flows = get_flows(
-            dpath, {"table_id": self.SPGW_TABLE, "priority": 0}
+            dpath, {"table_id": self.SPGW_TABLE}
         )
         assert(
             len(flows) == 2), "There should only be 2 default table 0 flows"

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_asr.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_asr.py
@@ -87,13 +87,9 @@ class TestAttachASR(unittest.TestCase):
         print("Sleeping for 5 seconds")
         time.sleep(5)
 
-        print("Checking that uplink/downlink flows were deleted")
-        flows = get_flows(
-            datapath, {"table_id": self.SPGW_TABLE, "priority": 0}
-        )
-        self.assertEqual(
-            len(flows), 2, "There should only be 2 default table 0 flows"
-        )
+        # Verify that all UL/DL flows are deleted
+        self._s1ap_wrapper.s1_util.verify_flow_rules_deletion()
+
 
 
 if __name__ == "__main__":

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_multiple_rar_tcp_data.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_multiple_rar_tcp_data.py
@@ -336,13 +336,8 @@ class TestAttachDetachMultipleRarTcpData(unittest.TestCase):
                 req.ue_id, detach_type[i], wait_for_s1[i]
             )
 
-            print("Checking that uplink/downlink flows were deleted")
-            flows = get_flows(
-                datapath, {"table_id": self.SPGW_TABLE, "priority": 0}
-            )
-            self.assertEqual(
-                len(flows), 2, "There should only be 2 default table 0 flows"
-            )
+        # Verify that all UL/DL flows are deleted
+        self._s1ap_wrapper.s1_util.verify_flow_rules_deletion()
 
 
 if __name__ == "__main__":

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_rar_tcp_data.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_rar_tcp_data.py
@@ -291,13 +291,9 @@ class TestAttachDetachRarTcpData(unittest.TestCase):
                 req.ue_id, detach_type[i], wait_for_s1[i]
             )
 
-            print("Checking that uplink/downlink flows were deleted")
-            flows = get_flows(
-                datapath, {"table_id": self.SPGW_TABLE, "priority": 0}
-            )
-            self.assertEqual(
-                len(flows), 2, "There should only be 2 default table 0 flows"
-            )
+        # Verify that all UL/DL flows are deleted
+        self._s1ap_wrapper.s1_util.verify_flow_rules_deletion()
+
 
 
 if __name__ == "__main__":

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_rar_tcp_he.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_rar_tcp_he.py
@@ -300,15 +300,11 @@ class TestAttachDetachRarTcpDataWithHE(unittest.TestCase):
                 req.ue_id, detach_type[i], wait_for_s1[i]
             )
 
-            print("Checking that uplink/downlink flows were deleted")
-            flows = get_flows(
-                datapath, {"table_id": self.SPGW_TABLE, "priority": 0}
-            )
-            self.assertEqual(
-                len(flows), 2, "There should only be 2 default table 0 flows"
-            )
             time.sleep(20)
             assert utils.he_count_record_of_imsi_to_domain(imsi, he_domain1) == 0
+
+        # Verify that all UL/DL flows are deleted
+        self._s1ap_wrapper.s1_util.verify_flow_rules_deletion()
 
 if __name__ == "__main__":
     unittest.main()

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_setsessionrules_tcp_data.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_setsessionrules_tcp_data.py
@@ -354,13 +354,9 @@ class TestAttachDetachSetSessionRulesTcpData(unittest.TestCase):
             req.ue_id, s1ap_types.ueDetachType_t.UE_NORMAL_DETACH.value, True
         )
 
-        print("Checking that uplink/downlink flows were deleted")
-        flows = get_flows(
-            datapath, {"table_id": self.SPGW_TABLE, "priority": 0}
-        )
-        self.assertEqual(
-            len(flows), 2, "There should only be 2 default table 0 flows"
-        )
+        # Verify that all UL/DL flows are deleted
+        self._s1ap_wrapper.s1_util.verify_flow_rules_deletion()
+
 
 
 if __name__ == "__main__":

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_with_he_policy.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_with_he_policy.py
@@ -183,15 +183,11 @@ class TestAttachDetachWithHE(unittest.TestCase):
                 req.ue_id, detach_type[i], wait_for_s1[i]
             )
 
-            print("Checking that uplink/downlink flows were deleted")
-            flows = get_flows(
-                datapath, {"table_id": self.SPGW_TABLE, "priority": 0}
-            )
-            self.assertEqual(
-                len(flows), 2, "There should only be 2 default table 0 flows"
-            )
             time.sleep(20)
             assert utils.he_count_record_of_imsi_to_domain(imsi, he_domain1) == 0
+
+        # Verify that all UL/DL flows are deleted
+        self._s1ap_wrapper.s1_util.verify_flow_rules_deletion()
 
 
 if __name__ == "__main__":

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_with_ovs.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_with_ovs.py
@@ -53,8 +53,7 @@ class TestAttachDetachWithOVS(unittest.TestCase):
         MAX_NUM_RETRIES = 5
 
         print("Checking for default table 0 flows")
-        flows = get_flows(datapath, {"table_id": self.SPGW_TABLE,
-                                     "priority": 0})
+        flows = get_flows(datapath, {"table_id": self.SPGW_TABLE})
         self.assertEqual(len(flows), 2,
                          "There should only be 2 default table 0 flows")
 
@@ -125,8 +124,7 @@ class TestAttachDetachWithOVS(unittest.TestCase):
             req.ue_id, s1ap_types.ueDetachType_t.UE_NORMAL_DETACH.value, True)
 
         print("Checking that uplink/downlink flows were deleted")
-        flows = get_flows(datapath, {"table_id": self.SPGW_TABLE,
-                                     "priority": 0})
+        flows = get_flows(datapath, {"table_id": self.SPGW_TABLE})
         self.assertEqual(len(flows), 2,
                          "There should only be 2 default table 0 flows")
 


### PR DESCRIPTION
Signed-off-by: Ulas Kozat <kozat@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->
Following issues are fixed
- Verification for the deletion of all flow rules were actually checking only the priority zero flows at table-0. Instead it should check all remaining flows and verify that only the default flow rules remain. 
- Detach function should not check whether all the flow rules are deleted as we have multi-ue attach/detach tests. Individual tests should call the verification step after all the UEs are detached.
 
## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->
Full sanity test suit via `make integ_test`.

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
