### PR TITLE
[feg] Add gy CLI tool option to pass RatingGroup => ServiceIdentifier mapping

### DIFF
--- a/feg/gateway/tools/gy_client_cli/main.go
+++ b/feg/gateway/tools/gy_client_cli/main.go
@@ -56,6 +56,7 @@ type cliConfig struct {
 	ueIP         string
 	spgwIP       string
 	ratingGroups []uint32
+	rg2ServiceId map[uint32]uint32
 	usedCredit   uint64
 	msisdn       string
 	apn          string
@@ -73,7 +74,7 @@ func init() {
 	flag.StringVar(&sid, "sid", "1234", "session id")
 	flag.StringVar(&ueIP, "ue_ip", "192.168.1.1", "UE IPv4 address")
 	flag.StringVar(&spgwIP, "spgw_ip", "192.168.128.1", "SPGW IPv4 address")
-	flag.StringVar(&ratingGroupString, "rating_groups", "1,2,33", "Rating groups to request credit for (comma separated)")
+	flag.StringVar(&ratingGroupString, "rating_groups", "1,2:200,33", "Rating groups to request credit for (comma separated)")
 	flag.Uint64Var(&usedCredit, "used_credit", 10000000, "# of bytes to report as used in CCR-Update and Terminate")
 	flag.BoolVar(&wait, "wait", true, "wait for key input in between calls")
 	flag.StringVar(&commands, "commands", "", "CCR commands to run keyed by letter, e.g. IT. I = Init, T = Terminate")
@@ -119,6 +120,8 @@ func main() {
 	gyGobalCfg := gy.GetGyGlobalConfig()
 	fmt.Printf("Gy global config: %+v\n", gyGobalCfg)
 
+	rgs, rg2sid := parseRatingGroups(ratingGroupString)
+
 	config := &cliConfig{
 		serverCfg:    serverCfg,
 		gyClient:     gy.NewGyClient(clientCfg, serverCfg, handleReAuth, nil, gyGobalCfg),
@@ -126,7 +129,8 @@ func main() {
 		sessionID:    fmt.Sprintf("%s-%s", imsi, sid),
 		ueIP:         ueIP,
 		spgwIP:       spgwIP,
-		ratingGroups: parseRatingGroups(ratingGroupString),
+		ratingGroups: rgs,
+		rg2ServiceId: rg2sid,
 		usedCredit:   usedCredit,
 		msisdn:       msisdn,
 		apn:          apn,
@@ -165,14 +169,19 @@ func sendCreditCall(config *cliConfig, requestType credit_control.CreditRequestT
 
 	credits := make([]*gy.UsedCredits, 0, len(config.ratingGroups))
 	for _, rg := range config.ratingGroups {
+		var serviceId *uint32
+		if sid, ok := config.rg2ServiceId[rg]; ok {
+			serviceId = &sid
+		}
 		if requestType == credit_control.CRTInit {
-			credits = append(credits, &gy.UsedCredits{RatingGroup: rg})
+			credits = append(credits, &gy.UsedCredits{RatingGroup: rg, ServiceIdentifier: serviceId})
 		} else {
 			credits = append(credits, &gy.UsedCredits{
-				RatingGroup:  rg,
-				InputOctets:  0, // make all used credit output for simplicity
-				OutputOctets: config.usedCredit,
-				TotalOctets:  config.usedCredit,
+				RatingGroup:       rg,
+				ServiceIdentifier: serviceId,
+				InputOctets:       0, // make all used credit output for simplicity
+				OutputOctets:      config.usedCredit,
+				TotalOctets:       config.usedCredit,
 			})
 		}
 	}
@@ -208,12 +217,29 @@ func handleReAuth(request *gy.ChargingReAuthRequest) *gy.ChargingReAuthAnswer {
 	return nil
 }
 
-func parseRatingGroups(ratingGroupString string) []uint32 {
+func parseRatingGroups(ratingGroupString string) (ratingGroups []uint32, ratingGrpToServiceId map[uint32]uint32) {
 	tokens := strings.Split(ratingGroupString, ",")
-	ratingGroups := make([]uint32, 0, len(tokens))
+	ratingGroups = make([]uint32, 0, len(tokens))
+	ratingGrpToServiceId = map[uint32]uint32{}
 	for _, rgStr := range tokens {
+		if i := strings.IndexRune(rgStr, ':'); i > 0 {
+			k := strings.TrimSpace(rgStr[0:i])
+			v := strings.TrimSpace(rgStr[i+1:])
+			if len(k) > 0 && len(v) > 0 {
+				rg, err := strconv.ParseUint(k, 10, 32)
+				if err == nil {
+					si, err := strconv.ParseUint(v, 10, 32)
+					if err == nil {
+						ratingGroups = append(ratingGroups, uint32(rg))
+						ratingGrpToServiceId[uint32(rg)] = uint32(si)
+						continue
+					}
+
+				}
+			}
+		}
 		rg, _ := strconv.ParseUint(rgStr, 10, 32)
 		ratingGroups = append(ratingGroups, uint32(rg))
 	}
-	return ratingGroups
+	return ratingGroups, ratingGrpToServiceId
 }


### PR DESCRIPTION

Signed-off-by: Evgeniy Makeev <evgeniym@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary

Add gy CLI tool option to pass RatingGroup => ServiceIdentifier mapping

## Test Plan

unit tests; run tool

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
