### PR TITLE
[magmad] add s8_proxy as service maintained by magmad at feg

### DIFF
--- a/feg/gateway/configs/magmad.yml
+++ b/feg/gateway/configs/magmad.yml
@@ -19,6 +19,7 @@ magma_services:
   - control_proxy
   - redis
   - session_proxy
+  - s8_proxy
   - s6a_proxy
   - csfb
   - feg_hello


### PR DESCRIPTION
Signed-off-by: Oriol Batalla <obatalla@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary

Added s8_proxy to magmad maintained services 

## Test Plan

terravm 

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
