### PR TITLE
[feg_relay] Add CreateBearerRequest responder for s8_proxy

### DIFF
--- a/feg/cloud/go/services/feg_relay/servicers/create_bearer_pgw.go
+++ b/feg/cloud/go/services/feg_relay/servicers/create_bearer_pgw.go
@@ -1,0 +1,60 @@
+/*
+Copyright 2021 The Magma Authors.
+
+This source code is licensed under the BSD-style license found in the
+LICENSE file in the root directory of this source tree.
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package servicers
+
+import (
+	"context"
+	"fmt"
+
+	fegprotos "magma/feg/cloud/go/protos"
+	"magma/orc8r/cloud/go/services/dispatcher/gateway_registry"
+	"magma/orc8r/lib/go/errors"
+
+	"github.com/golang/glog"
+)
+
+const GTPCauseNotAvailable = 73 // gtp CauseNoResourcesAvailable
+
+// CreateBearerPGW relays the CreateBearerRequest from S8_proxy to a corresponding
+// dispatcher service instance, who will in turn relay the request to the
+// corresponding AGW gateway
+func (srv *FegToGwRelayServer) CreateBearerPGW(
+	ctx context.Context,
+	req *fegprotos.CreateBearerRequestPgw,
+) (*fegprotos.CreateBearerResponsePgw, error) {
+	if err := validateFegContext(ctx); err != nil {
+		return nil, err
+	}
+	if req == nil || req.BearerContext == nil || req.BearerContext.UserPlaneFteid == nil {
+		glog.Errorf("unable to send CreateBearerPGWUnverified, Teid not found  %v", req)
+		return &fegprotos.CreateBearerResponsePgw{Cause: 73}, nil
+	}
+	teid := fmt.Sprint(req.BearerContext.UserPlaneFteid.Teid)
+	hwId, err := getHwIDFromTeid(ctx, teid)
+	if err != nil {
+		glog.Errorf("unable to get HwID from TEID %s. err: %v", teid, err)
+		if _, ok := err.(errors.ClientInitError); ok {
+			// CauseNoResourcesAvailable uint8 = 73
+			return &fegprotos.CreateBearerResponsePgw{Cause: GTPCauseNotAvailable}, nil
+		}
+	}
+	conn, ctx, err := gateway_registry.GetGatewayConnection(
+		gateway_registry.GwS8Service, hwId)
+	if err != nil {
+		glog.Errorf("unable to get connection to the gateway ID: %s", hwId)
+		return &fegprotos.CreateBearerResponsePgw{Cause: GTPCauseNotAvailable}, nil
+	}
+	client := fegprotos.NewS8ProxyResponderClient(conn)
+	return client.CreateBearer(ctx, req)
+}

--- a/feg/cloud/go/services/feg_relay/test_init/test_service_init.go
+++ b/feg/cloud/go/services/feg_relay/test_init/test_service_init.go
@@ -14,6 +14,7 @@ limitations under the License.
 package test_init
 
 import (
+	"context"
 	"testing"
 
 	"magma/feg/cloud/go/feg"
@@ -21,8 +22,6 @@ import (
 	"magma/feg/cloud/go/services/feg_relay"
 	"magma/feg/cloud/go/services/feg_relay/servicers"
 	"magma/orc8r/cloud/go/test_utils"
-
-	"golang.org/x/net/context"
 )
 
 // A little Go "polymorphism" magic for testing

--- a/feg/cloud/go/services/feg_relay/utils/get_all_gateways.go
+++ b/feg/cloud/go/services/feg_relay/utils/get_all_gateways.go
@@ -15,6 +15,7 @@ limitations under the License.
 package utils
 
 import (
+	"context"
 	"fmt"
 
 	"magma/feg/cloud/go/feg"
@@ -30,7 +31,6 @@ import (
 	"github.com/go-openapi/swag"
 	"github.com/golang/glog"
 	"github.com/pkg/errors"
-	"golang.org/x/net/context"
 	"google.golang.org/grpc/metadata"
 )
 

--- a/feg/gateway/go.sum
+++ b/feg/gateway/go.sum
@@ -447,6 +447,7 @@ github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czP
 github.com/magiconair/properties v1.8.1 h1:ZC2Vc7/ZFkGmsVC9KvOjumD+G5lXy2RtTKyzRKO2BQ4=
 github.com/magiconair/properties v1.8.1/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
 github.com/magma/augmented-networks/accounting/protos v0.1.0/go.mod h1:Hpfg8aAxldUN7qlVtR5xwlAf8pcetFm8DWwRKZsh2J4=
+github.com/magma/augmented-networks/accounting/protos v0.1.1/go.mod h1:Hpfg8aAxldUN7qlVtR5xwlAf8pcetFm8DWwRKZsh2J4=
 github.com/mailru/easyjson v0.0.0-20160728113105-d5b7844b561a/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
 github.com/mailru/easyjson v0.0.0-20180823135443-60711f1a8329/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
 github.com/mailru/easyjson v0.0.0-20190312143242-1de009706dbe/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=

--- a/orc8r/cloud/go/services/dispatcher/gateway_registry/gw_registry.go
+++ b/orc8r/cloud/go/services/dispatcher/gateway_registry/gw_registry.go
@@ -37,6 +37,7 @@ const (
 	GwS6aService          GwServiceType = "s6a_service"
 	GwSgsService          GwServiceType = "sgs_service"
 	GwSessiondService     GwServiceType = "sessiond"
+	GwS8Service           GwServiceType = "s8_service"
 	GwSpgwService         GwServiceType = "spgw_service"
 	GwAbortSessionService GwServiceType = "abort_session_service"
 	GwAAAService          GwServiceType = "aaa_server"
@@ -63,6 +64,7 @@ var services = []GwServiceType{
 	GwS6aService,
 	GwSgsService,
 	GwSessiondService,
+	GwS8Service,
 	GwSpgwService,
 	GwAbortSessionService,
 	GwAAAService,
@@ -122,7 +124,6 @@ func GetGatewayConnection(service GwServiceType, hwId string) (*grpc.ClientConn,
 	customHeader := metadata.New(map[string]string{GatewayIdHeaderKey: hwId})
 	ctxToRet := metadata.NewOutgoingContext(context.Background(), customHeader)
 	return conn, ctxToRet, nil
-
 }
 
 func ListAllGwServices() []GwServiceType {


### PR DESCRIPTION
Signed-off-by: Oriol Batalla <obatalla@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary

This PR adds the necessary functions on Feg Relay to send CreateBearerRequest from S8_proxy to AGW

## Test Plan

make precommit feg 
make precommit or8r

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
