### PR TITLE
[AGW][DEV]Add https-transport to fetch Releases file throught https

### DIFF
--- a/lte/gateway/deploy/roles/dev_common/tasks/main.yml
+++ b/lte/gateway/deploy/roles/dev_common/tasks/main.yml
@@ -140,6 +140,7 @@
       - python3-setuptools
       - python-setuptools
       - libssl-dev
+      - apt-transport-https 
   retries: 5
   when: preburn
 


### PR DESCRIPTION
Signed-off-by: Timothée Dzik <timdzik@fb.com>

[AGW][DEV]Add https-transport to fetch Releases file throught https

## Summary

[AGW][DEV]Add https-transport to fetch Releases file throught https
Currently failing packer build

## Test Plan

Jenkins packer build
