### PR TITLE
fix: [sessiond] only unsuspend credits that have non 0 quota

### DIFF
--- a/lte/gateway/c/session_manager/ChargingGrant.h
+++ b/lte/gateway/c/session_manager/ChargingGrant.h
@@ -84,6 +84,11 @@ struct ChargingGrant {
   // update. If no action needs to take place, CONTINUE_SERVICE is returned.
   ServiceActionType get_action(SessionCreditUpdateCriteria* update_criteria);
 
+  // Return if the service needs activation
+  bool should_be_unsuspended() const;
+
+  bool get_suspended() const { return suspended; }
+
   // Get unreported usage from credit and return as part of CreditUsage
   // The update_type is also included in CreditUsage
   // If the grant is final or is_terminate is true, we include all unreported
@@ -93,7 +98,13 @@ struct ChargingGrant {
       CreditUsage::UpdateType update_type,
       SessionCreditUpdateCriteria* credit_uc, bool is_terminate);
 
-  // Return true if the service needs to be deactivated
+  // Return true if the service needs to be deactivated.
+  // In order to deactivate, a few things are considered in order.
+  // 1. Credit must be exhausted
+  // 2. TERMINATE_SERVICE_WHEN_QUOTA_EXHAUSTED is not set
+  // 3. FUA must be set
+  //    3a. For FUA-terminate, always deactivate
+  //    3b. For FUA-redirect/restrict, deactivate if not already deactivated
   bool should_deactivate_service() const;
 
   // Convert FinalAction enum to ServiceActionType
@@ -102,8 +113,6 @@ struct ChargingGrant {
 
   ServiceActionType final_action_to_action_on_suspension(
       const ChargingCredit_FinalAction action) const;
-
-  bool get_suspended();
 
   void set_suspended(bool suspended, SessionCreditUpdateCriteria* credit_uc);
 

--- a/lte/gateway/c/session_manager/LocalEnforcer.h
+++ b/lte/gateway/c/session_manager/LocalEnforcer.h
@@ -360,6 +360,17 @@ class LocalEnforcer {
           dynamic_rule_installs);
 
   /**
+   * @brief
+   *
+   * @param credit_update_resp
+   * @param actions output parameter
+   * @return true if the credit should be processed further, false otherwise
+   */
+  bool handle_credit_update_failure(
+      const CreditUpdateResponse& credit_update_resp,
+      UpdateChargingCreditActions* actions) const;
+
+  /**
    * Processes the charging component of UpdateSessionResponse.
    * Updates charging credits according to the response.
    */

--- a/lte/gateway/c/session_manager/SessionState.cpp
+++ b/lte/gateway/c/session_manager/SessionState.cpp
@@ -1630,6 +1630,9 @@ bool SessionState::receive_charging_credit(
                 << " Activating service RG: " << key << " for " << session_id_;
     grant->set_service_state(SERVICE_NEEDS_ACTIVATION, credit_uc);
   }
+  if (grant->should_deactivate_service()) {
+    grant->set_service_state(SERVICE_NEEDS_DEACTIVATION, credit_uc);
+  }
   return true;
 }
 
@@ -1669,6 +1672,16 @@ bool SessionState::is_credit_suspended(const CreditKey& charging_key) {
   if (it != credit_map_.end()) {
     auto& grant = it->second;
     return grant->get_suspended();
+  }
+  return false;
+}
+
+bool SessionState::is_credit_ready_to_be_activated(
+    const CreditKey& charging_key) {
+  auto it = credit_map_.find(charging_key);
+  if (it != credit_map_.end()) {
+    auto& grant = it->second;
+    return grant->should_be_unsuspended();
   }
   return false;
 }

--- a/lte/gateway/c/session_manager/SessionState.h
+++ b/lte/gateway/c/session_manager/SessionState.h
@@ -446,6 +446,8 @@ class SessionState {
 
   bool is_credit_suspended(const CreditKey& charging_key);
 
+  bool is_credit_ready_to_be_activated(const CreditKey& charging_key);
+
   RuleLifetime& get_rule_lifetime(const std::string& rule_id);
 
   DynamicRuleStore& get_gy_dynamic_rules();

--- a/lte/gateway/c/session_manager/test/ProtobufCreators.cpp
+++ b/lte/gateway/c/session_manager/test/ProtobufCreators.cpp
@@ -130,7 +130,8 @@ void create_rule_record(
 
 void create_charging_credit(
     uint64_t volume, bool is_final, ChargingCredit* credit) {
-  create_granted_units(&volume, NULL, NULL, credit->mutable_granted_units());
+  create_granted_units(
+      &volume, nullptr, nullptr, credit->mutable_granted_units());
   credit->set_type(ChargingCredit::BYTES);
   credit->set_is_final(is_final);
 }
@@ -139,7 +140,8 @@ void create_charging_credit(
     uint64_t volume, ChargingCredit_FinalAction action,
     std::string redirect_server, std::string restrict_rule,
     ChargingCredit* credit) {
-  create_granted_units(&volume, NULL, NULL, credit->mutable_granted_units());
+  create_granted_units(
+      &volume, nullptr, nullptr, credit->mutable_granted_units());
   credit->set_type(ChargingCredit::BYTES);
   credit->set_is_final(true);
   credit->set_final_action(action);
@@ -435,15 +437,15 @@ PolicyRule create_policy_rule_with_qos(
 
 void create_granted_units(
     uint64_t* total, uint64_t* tx, uint64_t* rx, GrantedUnits* gsu) {
-  if (total != NULL) {
+  if (total != nullptr) {
     gsu->mutable_total()->set_is_valid(true);
     gsu->mutable_total()->set_volume(*total);
   }
-  if (tx != NULL) {
+  if (tx != nullptr) {
     gsu->mutable_tx()->set_is_valid(true);
     gsu->mutable_tx()->set_volume(*tx);
   }
-  if (rx != NULL) {
+  if (rx != nullptr) {
     gsu->mutable_rx()->set_is_valid(true);
     gsu->mutable_rx()->set_volume(*rx);
   }

--- a/lte/gateway/c/session_manager/test/test_charging_grant.cpp
+++ b/lte/gateway/c/session_manager/test/test_charging_grant.cpp
@@ -170,12 +170,21 @@ TEST_F(ChargingGrantTest, test_should_deactivate_service) {
   grant.service_state                  = SERVICE_ENABLED;
   EXPECT_TRUE(grant.should_deactivate_service());
 
-  // If service state is not ENABLED we should not deactivate service
+  // If service state is not ENABLED we should not deactivate service for FUA
+  // redirect / restrict
+  SessionCredit::TERMINATE_SERVICE_WHEN_QUOTA_EXHAUSTED = true;
+  grant.is_final_grant                                  = true;
+  grant.final_action_info.final_action = ChargingCredit_FinalAction_REDIRECT;
+  grant.service_state                  = SERVICE_DISABLED;
+  EXPECT_FALSE(grant.should_deactivate_service());
+
+  // If service state is not ENABLED we should deactivate service for FUA
+  // terminate
   SessionCredit::TERMINATE_SERVICE_WHEN_QUOTA_EXHAUSTED = true;
   grant.is_final_grant                                  = true;
   grant.final_action_info.final_action = ChargingCredit_FinalAction_TERMINATE;
   grant.service_state                  = SERVICE_DISABLED;
-  EXPECT_FALSE(grant.should_deactivate_service());
+  EXPECT_TRUE(grant.should_deactivate_service());
 }
 
 TEST_F(ChargingGrantTest, test_get_action) {

--- a/lte/gateway/c/session_manager/test/test_local_enforcer.cpp
+++ b/lte/gateway/c/session_manager/test/test_local_enforcer.cpp
@@ -3106,6 +3106,156 @@ TEST_F(LocalEnforcerTest, test_dead_session_in_usage_report) {
   local_enforcer->aggregate_records(session_map, table, update);
 }
 
+TEST_F(
+    LocalEnforcerTest, test_no_credit_reauth_with_redirected_suspended_credit) {
+  // insert key rule mapping
+  insert_static_rule(1, "", "rule1");
+
+  // 1- INITIAL SET UP TO CREATE A REDIRECTED due to SUSPENDED CREDIT
+  // insert initial suspended and redirected credit
+  CreateSessionResponse response;
+  response.mutable_static_rules()->Add()->set_rule_id("rule1");
+  auto credits = response.mutable_credits();
+  test_cfg_.common_context.mutable_sid()->set_id(IMSI1);
+  create_credit_update_response_with_error(
+      IMSI1, SESSION_ID_1, 1, false, DIAMETER_CREDIT_LIMIT_REACHED,
+      ChargingCredit_FinalAction_REDIRECT, "12.7.7.4", "", credits->Add());
+  local_enforcer->init_session(
+      session_map, IMSI1, SESSION_ID_1, test_cfg_, response);
+  local_enforcer->update_tunnel_ids(
+      session_map,
+      create_update_tunnel_ids_request(IMSI1, BEARER_ID_1, teids1));
+
+  // execute redirection
+  auto update = SessionStore::get_default_session_update(session_map);
+  std::vector<std::unique_ptr<ServiceAction>> actions;
+  auto session_update =
+      local_enforcer->collect_updates(session_map, actions, update);
+  local_enforcer->execute_actions(session_map, actions, update);
+  EXPECT_EQ(actions.size(), 1);
+  EXPECT_EQ(session_update.updates_size(), 0);
+  EXPECT_EQ(
+      update[IMSI1][SESSION_ID_1].charging_credit_map[1].service_state,
+      SERVICE_REDIRECTED);
+  EXPECT_TRUE(update[IMSI1][SESSION_ID_1].charging_credit_map[1].suspended);
+
+  // 2- SETUP REAUTH ON A SUSPENDED CREDIT
+  // reset update and actions
+  update = SessionStore::get_default_session_update(session_map);
+  actions.clear();
+
+  ChargingReAuthRequest reauth;
+  reauth.set_sid(IMSI1);
+  reauth.set_session_id(SESSION_ID_1);
+  reauth.set_type(ChargingReAuthRequest::ENTIRE_SESSION);
+  auto result =
+      local_enforcer->init_charging_reauth(session_map, reauth, update);
+  EXPECT_EQ(result, ReAuthResult::UPDATE_INITIATED);
+
+  // check suspended credit is requested
+  auto update_req =
+      local_enforcer->collect_updates(session_map, actions, update);
+  local_enforcer->execute_actions(session_map, actions, update);
+  EXPECT_EQ(update_req.updates_size(), 1);
+  EXPECT_EQ(update_req.updates(0).common_context().sid().id(), IMSI1);
+  EXPECT_EQ(update_req.updates(0).usage().type(), CreditUsage::REAUTH_REQUIRED);
+
+  // 3- SUSPENSION IS NOT CLEARED DUE TO CREDIT STILL BEING EMPTY
+  // receive credit from OCS as a reauth answer
+  UpdateSessionResponse update_response;
+  auto updates = update_response.mutable_responses();
+  create_credit_update_response(IMSI1, SESSION_ID_1, 1, 0, updates->Add());
+  std::vector<std::string> pending_activation = {"rule1"};
+  EXPECT_CALL(
+      *pipelined_client, activate_flows_for_rules(
+                             testing::_, testing::_, testing::_, testing::_,
+                             test_cfg_.common_context.msisdn(), testing::_,
+                             CheckRuleNames(pending_activation), testing::_))
+      .Times(0);
+  local_enforcer->update_session_credits_and_rules(
+      session_map, update_response, update);
+  EXPECT_TRUE(update[IMSI1][SESSION_ID_1].charging_credit_map[1].suspended);
+}
+
+// This test case tests the following case
+// 1. we receive a credit in suspension with FUA-redirect
+// 2. we get an update by RAR with 0 grant but now with fua-terminate
+// 3. we expect the session to be terminated
+TEST_F(
+    LocalEnforcerTest,
+    test_terminate_credit_reauth_with_redirected_suspended_credit) {
+  // insert key rule mapping
+  insert_static_rule(1, "", "rule1");
+
+  // 1- INITIAL SET UP TO CREATE A REDIRECTED due to SUSPENDED CREDIT
+  // insert initial suspended and redirected credit
+  CreateSessionResponse response;
+  response.mutable_static_rules()->Add()->set_rule_id("rule1");
+  auto credits = response.mutable_credits();
+  test_cfg_.common_context.mutable_sid()->set_id(IMSI1);
+  create_credit_update_response_with_error(
+      IMSI1, SESSION_ID_1, 1, false, DIAMETER_CREDIT_LIMIT_REACHED,
+      ChargingCredit_FinalAction_REDIRECT, "12.7.7.4", "", credits->Add());
+  local_enforcer->init_session(
+      session_map, IMSI1, SESSION_ID_1, test_cfg_, response);
+  local_enforcer->update_tunnel_ids(
+      session_map,
+      create_update_tunnel_ids_request(IMSI1, BEARER_ID_1, teids1));
+
+  // execute redirection
+  auto update = SessionStore::get_default_session_update(session_map);
+  std::vector<std::unique_ptr<ServiceAction>> actions;
+  auto session_update =
+      local_enforcer->collect_updates(session_map, actions, update);
+  local_enforcer->execute_actions(session_map, actions, update);
+  EXPECT_EQ(actions.size(), 1);
+  EXPECT_EQ(session_update.updates_size(), 0);
+  EXPECT_EQ(
+      update[IMSI1][SESSION_ID_1].charging_credit_map[1].service_state,
+      SERVICE_REDIRECTED);
+  EXPECT_TRUE(update[IMSI1][SESSION_ID_1].charging_credit_map[1].suspended);
+
+  // 2- SETUP REAUTH ON A SUSPENDED CREDIT
+  // reset update and actions
+  update = SessionStore::get_default_session_update(session_map);
+  actions.clear();
+
+  ChargingReAuthRequest reauth;
+  reauth.set_sid(IMSI1);
+  reauth.set_session_id(SESSION_ID_1);
+  reauth.set_type(ChargingReAuthRequest::ENTIRE_SESSION);
+  auto result =
+      local_enforcer->init_charging_reauth(session_map, reauth, update);
+  EXPECT_EQ(result, ReAuthResult::UPDATE_INITIATED);
+
+  // check suspended credit is requested
+  auto update_req =
+      local_enforcer->collect_updates(session_map, actions, update);
+  local_enforcer->execute_actions(session_map, actions, update);
+  EXPECT_EQ(update_req.updates_size(), 1);
+  EXPECT_EQ(update_req.updates(0).common_context().sid().id(), IMSI1);
+  EXPECT_EQ(update_req.updates(0).usage().type(), CreditUsage::REAUTH_REQUIRED);
+
+  // 3- SUSPENSION IS NOT CLEARED DUE TO CREDIT STILL BEING EMPTY
+  // receive credit from OCS as a reauth answer
+  UpdateSessionResponse update_response;
+  auto updates = update_response.mutable_responses();
+
+  create_credit_update_response(
+      IMSI1, SESSION_ID_1, 1, 0, ChargingCredit_FinalAction_TERMINATE, "", "",
+      updates->Add());
+  EXPECT_CALL(
+      *pipelined_client,
+      deactivate_flows_for_rules_for_termination(
+          IMSI1, testing::_, testing::_, testing::_, testing::_))
+      .Times(1);
+  local_enforcer->update_session_credits_and_rules(
+      session_map, update_response, update);
+
+  local_enforcer->collect_updates(session_map, actions, update);
+  local_enforcer->execute_actions(session_map, actions, update);
+}
+
 int main(int argc, char** argv) {
   ::testing::InitGoogleTest(&argc, argv);
   FLAGS_logtostderr = 1;

--- a/lte/gateway/c/session_manager/test/test_session_state.cpp
+++ b/lte/gateway/c/session_manager/test/test_session_state.cpp
@@ -833,34 +833,14 @@ TEST_F(SessionStateTest, test_multiple_final_action_empty_grant) {
 
   receive_credit_from_ocs(1, 3000, 2000, 2000, false);
   EXPECT_EQ(update_criteria.charging_credit_to_install.size(), 1);
-  EXPECT_EQ(
-      update_criteria.charging_credit_to_install[CreditKey(1)]
-          .credit.buckets[ALLOWED_TOTAL],
-      3000);
-  EXPECT_EQ(
-      update_criteria.charging_credit_to_install[CreditKey(1)]
-          .credit.buckets[ALLOWED_TX],
-      2000);
-  EXPECT_EQ(
-      update_criteria.charging_credit_to_install[CreditKey(1)]
-          .credit.buckets[ALLOWED_RX],
-      2000);
+  auto credit = update_criteria.charging_credit_to_install[CreditKey(1)].credit;
+  EXPECT_EQ(credit.buckets[ALLOWED_TOTAL], 3000);
+  EXPECT_EQ(credit.buckets[ALLOWED_TX], 2000);
+  EXPECT_EQ(credit.buckets[ALLOWED_RX], 2000);
   // received granted units
-  EXPECT_EQ(
-      update_criteria.charging_credit_to_install[CreditKey(1)]
-          .credit.received_granted_units.total()
-          .volume(),
-      3000);
-  EXPECT_EQ(
-      update_criteria.charging_credit_to_install[CreditKey(1)]
-          .credit.received_granted_units.tx()
-          .volume(),
-      2000);
-  EXPECT_EQ(
-      update_criteria.charging_credit_to_install[CreditKey(1)]
-          .credit.received_granted_units.rx()
-          .volume(),
-      2000);
+  EXPECT_EQ(credit.received_granted_units.total().volume(), 3000);
+  EXPECT_EQ(credit.received_granted_units.tx().volume(), 2000);
+  EXPECT_EQ(credit.received_granted_units.rx().volume(), 2000);
 
   // add usage for 2 times to go over quota
   session_state->add_rule_usage("rule1", 1, 2000, 1000, 0, 0, update_criteria);
@@ -877,60 +857,26 @@ TEST_F(SessionStateTest, test_multiple_final_action_empty_grant) {
   session_state->get_updates(update, &actions, update_criteria);
   EXPECT_EQ(actions.size(), 0);
   EXPECT_EQ(update.updates_size(), 1);
-  EXPECT_EQ(
-      update_criteria.charging_credit_map[CreditKey(1)].bucket_deltas[USED_TX],
-      4000);
-  EXPECT_EQ(
-      update_criteria.charging_credit_map[CreditKey(1)].bucket_deltas[USED_RX],
-      2000);
-  EXPECT_EQ(
-      update_criteria.charging_credit_map[CreditKey(1)].service_state,
-      SERVICE_ENABLED);
+  auto credit_uc = update_criteria.charging_credit_map[CreditKey(1)];
+  EXPECT_EQ(credit_uc.bucket_deltas[USED_TX], 4000);
+  EXPECT_EQ(credit_uc.bucket_deltas[USED_RX], 2000);
+  EXPECT_EQ(credit_uc.service_state, SERVICE_ENABLED);
   EXPECT_FALSE(update_criteria.charging_credit_map[CreditKey(1)].is_final);
   EXPECT_TRUE(update_criteria.charging_credit_map[CreditKey(1)].reporting);
 
   // recive final unit without grant
   receive_credit_from_ocs(1, 0, 0, 0, true);
   EXPECT_EQ(update_criteria.charging_credit_to_install.size(), 1);
-  EXPECT_EQ(
-      update_criteria.charging_credit_map[CreditKey(1)]
-          .bucket_deltas[REPORTED_TX],
-      4000);
-  EXPECT_EQ(
-      update_criteria.charging_credit_map[CreditKey(1)]
-          .bucket_deltas[REPORTED_RX],
-      2000);
-  EXPECT_TRUE(update_criteria.charging_credit_map[CreditKey(1)].is_final);
-  EXPECT_EQ(
-      update_criteria.charging_credit_map[CreditKey(1)].service_state,
-      SERVICE_ENABLED);
-  EXPECT_FALSE(update_criteria.charging_credit_map[CreditKey(1)].reporting);
+  credit_uc = update_criteria.charging_credit_map[CreditKey(1)];
+  EXPECT_EQ(credit_uc.bucket_deltas[REPORTED_TX], 4000);
+  EXPECT_EQ(credit_uc.bucket_deltas[REPORTED_RX], 2000);
+  EXPECT_TRUE(credit_uc.is_final);
+  EXPECT_EQ(credit_uc.service_state, SERVICE_NEEDS_DEACTIVATION);
+  EXPECT_FALSE(credit_uc.reporting);
   // received granted units
-  EXPECT_EQ(
-      update_criteria.charging_credit_map[CreditKey(1)]
-          .received_granted_units.total()
-          .volume(),
-      0);
-  EXPECT_EQ(
-      update_criteria.charging_credit_map[CreditKey(1)]
-          .received_granted_units.tx()
-          .volume(),
-      0);
-  EXPECT_EQ(
-      update_criteria.charging_credit_map[CreditKey(1)]
-          .received_granted_units.rx()
-          .volume(),
-      0);
-
-  // force to check for the state (no traffic sent)
-  session_state->add_rule_usage("rule1", 1, 4000, 2000, 0, 0, update_criteria);
-  EXPECT_EQ(session_state->get_charging_credit(1, USED_TX), 4000);
-  EXPECT_EQ(session_state->get_charging_credit(1, USED_RX), 2000);
-  EXPECT_TRUE(update_criteria.charging_credit_map[CreditKey(1)].is_final);
-  EXPECT_EQ(
-      update_criteria.charging_credit_map[CreditKey(1)].service_state,
-      SERVICE_NEEDS_DEACTIVATION);
-  EXPECT_FALSE(update_criteria.charging_credit_map[CreditKey(1)].reporting);
+  EXPECT_EQ(credit_uc.received_granted_units.total().volume(), 0);
+  EXPECT_EQ(credit_uc.received_granted_units.tx().volume(), 0);
+  EXPECT_EQ(credit_uc.received_granted_units.rx().volume(), 0);
 }
 
 TEST_F(SessionStateTest, test_apply_session_rule_set) {


### PR DESCRIPTION
<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary
See attached issue for the reported problem.

In short, we have to make sure that a credit has >0 quota before un-suspending. 
We currently only check for these two things:
1. credit received is valid
2. credit is in suspension

But since we could receive a valid credit with 0 grant, we should also check that the there is quota available.

The logic is slightly messy as we handle 'suspended' credits slightly differently from credits that have been deactivated due to FUA-redirect/restrict. 

In order to make this work, I've had to make two changes:

When determining whether to remove Gy rules, check that the credit needs to be activated. This is done by the logic check:
```
// in update_charging_credits
bool should_activate = session->is_credit_ready_to_be_activated(credit_key);
if (!should_activate) {
  continue;
}
...
if (prev_final_action) {
  // uninstall gy rules
}
```
When receiving a new credit, determine if the credit needs to be deactivated. We didn't check for this before, but this is useful for the edge case where we receive a FUA-terminate for an already empty quota.


## Unit tests added
`test_no_credit_reauth_with_redirected_suspended_credit` (fails on master w/o the changes)
`test_terminate_credit_reauth_with_redirected_suspended_credit` (fails on master w/o the changes)

<!-- Enumerate changes you made and why you made them -->
## Test Plan
make precommit_sm

the new unit test fails on master w/o this change
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
