### PR TITLE
fix: [sessiond] sanitize output parameters in SessionState and LocalEnforcer

### DIFF
--- a/lte/gateway/c/session_manager/ChargingGrant.cpp
+++ b/lte/gateway/c/session_manager/ChargingGrant.cpp
@@ -135,7 +135,7 @@ void ChargingGrant::receive_charging_grant(
   log_received_grant(update);
 
   // Update the UpdateCriteria if not nullptr
-  if (credit_uc != nullptr) {
+  if (credit_uc) {
     credit_uc->is_final          = is_final_grant;
     credit_uc->final_action_info = final_action_info;
     credit_uc->expiry_time       = expiry_time;
@@ -305,7 +305,7 @@ void ChargingGrant::set_reauth_state(
                  << reauth_state_to_str(new_state);
   }
   reauth_state = new_state;
-  if (credit_uc != nullptr) {
+  if (credit_uc) {
     credit_uc->reauth_state = new_state;
   }
 }
@@ -319,7 +319,7 @@ void ChargingGrant::set_service_state(
                  << service_state_to_str(new_service_state);
   }
   service_state = new_service_state;
-  if (credit_uc != nullptr) {
+  if (credit_uc) {
     credit_uc->service_state = new_service_state;
   }
 }
@@ -329,8 +329,10 @@ void ChargingGrant::set_suspended(
   if (suspended != new_suspended) {
     MLOG(MDEBUG) << "Credit suspension set to: " << new_suspended;
   }
-  suspended            = new_suspended;
-  credit_uc->suspended = new_suspended;
+  suspended = new_suspended;
+  if (credit_uc) {
+    credit_uc->suspended = new_suspended;
+  }
 }
 
 void ChargingGrant::reset_reporting_grant(
@@ -372,5 +374,37 @@ void ChargingGrant::log_received_grant(const CreditUpdateResponse& update) {
 
 void ChargingGrant::set_reporting(bool reporting) {
   credit.set_reporting(reporting);
+}
+
+// TODO: make session_manager.proto and policydb.proto to use common field
+static RedirectInformation_AddressType address_type_converter(
+    RedirectServer_RedirectAddressType address_type) {
+  switch (address_type) {
+    case RedirectServer_RedirectAddressType_IPV4:
+      return RedirectInformation_AddressType_IPv4;
+    case RedirectServer_RedirectAddressType_IPV6:
+      return RedirectInformation_AddressType_IPv6;
+    case RedirectServer_RedirectAddressType_URL:
+      return RedirectInformation_AddressType_URL;
+    case RedirectServer_RedirectAddressType_SIP_URI:
+      return RedirectInformation_AddressType_SIP_URI;
+    default:
+      MLOG(MERROR) << "Unknown redirect address type!";
+      return RedirectInformation_AddressType_IPv4;
+  }
+}
+
+PolicyRule ChargingGrant::make_redirect_rule() {
+  PolicyRule redirect_rule;
+  redirect_rule.set_id("redirect");
+  redirect_rule.set_priority(ChargingGrant::REDIRECT_FLOW_PRIORITY);
+  RedirectInformation* redirect_info = redirect_rule.mutable_redirect();
+  redirect_info->set_support(RedirectInformation_Support_ENABLED);
+
+  auto redirect_server = final_action_info.redirect_server;
+  redirect_info->set_address_type(
+      address_type_converter(redirect_server.redirect_address_type()));
+  redirect_info->set_server_address(redirect_server.redirect_server_address());
+  return redirect_rule;
 }
 }  // namespace magma

--- a/lte/gateway/c/session_manager/ChargingGrant.h
+++ b/lte/gateway/c/session_manager/ChargingGrant.h
@@ -49,6 +49,8 @@ struct ChargingGrant {
   // indicates the rules have been removed from pipelined
   bool suspended;
 
+  const uint32_t REDIRECT_FLOW_PRIORITY = 2000;
+
   // Default states
   ChargingGrant()
       : credit(),
@@ -134,6 +136,8 @@ struct ChargingGrant {
 
   // Log information about the grant received
   void log_received_grant(const CreditUpdateResponse& update);
+
+  PolicyRule make_redirect_rule();
 };
 
 }  // namespace magma

--- a/lte/gateway/c/session_manager/LocalEnforcer.cpp
+++ b/lte/gateway/c/session_manager/LocalEnforcer.cpp
@@ -32,9 +32,8 @@
 #include "Utilities.h"
 
 namespace magma {
-uint32_t LocalEnforcer::REDIRECT_FLOW_PRIORITY = 2000;
-bool LocalEnforcer::SEND_ACCESS_TIMEZONE       = false;
-bool LocalEnforcer::CLEANUP_DANGLING_FLOWS     = true;
+bool LocalEnforcer::SEND_ACCESS_TIMEZONE   = false;
+bool LocalEnforcer::CLEANUP_DANGLING_FLOWS = true;
 
 using google::protobuf::RepeatedPtrField;
 
@@ -108,9 +107,7 @@ void LocalEnforcer::setup(
   bool cwf = false;
   for (auto it = session_map.begin(); it != session_map.end(); it++) {
     for (const auto& session : it->second) {
-      SessionState::SessionInfo session_info;
-      session->get_session_info(session_info);
-      session_infos.push_back(session_info);
+      session_infos.push_back(session->get_session_info());
       const auto& config = session->get_config();
       msisdns.push_back(config.common_context.msisdn());
 
@@ -132,7 +129,7 @@ void LocalEnforcer::setup(
         const auto& ue_mac_addr  = wlan_context.mac_addr();
         ue_mac_addrs.push_back(ue_mac_addr);
         SubscriberQuotaUpdate update = make_subscriber_quota_update(
-            session_info.imsi, ue_mac_addr,
+            session->get_imsi(), ue_mac_addr,
             session->get_subscriber_quota_state());
         quota_updates.push_back(update);
       }
@@ -156,7 +153,7 @@ void LocalEnforcer::sync_sessions_on_restart(std::time_t current_time) {
     const auto& imsi = it.first;
     for (auto& session : it.second) {
       const std::string session_id = session->get_session_id();
-      auto& uc                     = session_update[imsi][session_id];
+      auto& session_uc             = session_update[imsi][session_id];
       // Reschedule Revalidation Timer if it was pending before
       auto triggers   = session->get_event_triggers();
       auto trigger_it = triggers.find(REVALIDATION_TIMEOUT);
@@ -164,10 +161,10 @@ void LocalEnforcer::sync_sessions_on_restart(std::time_t current_time) {
           triggers[REVALIDATION_TIMEOUT] == PENDING) {
         // the bool value indicates whether the trigger has been triggered
         const auto revalidation_time = session->get_revalidation_time();
-        schedule_revalidation(*session, revalidation_time, uc);
+        schedule_revalidation(*session, revalidation_time, &session_uc);
       }
 
-      session->sync_rules_to_time(current_time, uc);
+      session->sync_rules_to_time(current_time, &session_uc);
 
       for (std::string rule_id : session->get_static_rules()) {
         auto lifetime = session->get_rule_lifetime(rule_id);
@@ -260,7 +257,7 @@ void LocalEnforcer::aggregate_records(
 
     session->add_rule_usage(
         record.rule_id(), record.rule_version(), record.bytes_tx(),
-        record.bytes_rx(), record.dropped_tx(), record.dropped_rx(), uc);
+        record.bytes_rx(), record.dropped_tx(), record.dropped_rx(), &uc);
   }
   complete_termination_for_released_sessions(
       session_map, sessions_with_reporting_flows, session_update);
@@ -371,7 +368,7 @@ void LocalEnforcer::handle_activate_service_action(
 // Terminates sessions that correspond to the given IMSI and session.
 void LocalEnforcer::start_session_termination(
     const std::unique_ptr<SessionState>& session, bool notify_access,
-    SessionStateUpdateCriteria& session_uc) {
+    SessionStateUpdateCriteria* session_uc) {
   const std::string& imsi       = session->get_imsi();
   const std::string& session_id = session->get_session_id();
   if (session->is_terminating()) {
@@ -398,7 +395,7 @@ void LocalEnforcer::start_session_termination(
   }
   if (terminate_on_wallet_exhaust()) {
     handle_subscriber_quota_state_change(
-        *session, SubscriberQuotaUpdate_Type_TERMINATE, &session_uc);
+        *session, SubscriberQuotaUpdate_Type_TERMINATE, session_uc);
   }
   // The termination should be completed when aggregated usage record no
   // longer
@@ -439,14 +436,14 @@ void LocalEnforcer::handle_force_termination_timeout(
 
 void LocalEnforcer::remove_all_rules_for_termination(
     const std::unique_ptr<SessionState>& session,
-    SessionStateUpdateCriteria& uc) {
+    SessionStateUpdateCriteria* session_uc) {
   const std::string ip_addr = session->get_config().common_context.ue_ipv4();
   const auto ipv6_addr      = session->get_config().common_context.ue_ipv6();
   const std::vector<Teids> teids = session->get_active_teids();
   pipelined_client_->deactivate_flows_for_rules_for_termination(
       session->get_imsi(), ip_addr, ipv6_addr, teids,
       RequestOriginType::WILDCARD);
-  session->remove_all_rules_for_termination(uc);
+  session->remove_all_rules_for_termination(session_uc);
 }
 
 void LocalEnforcer::notify_termination_to_access_service(
@@ -523,8 +520,7 @@ UpdateSessionRequest LocalEnforcer::collect_updates(
     for (const auto& session : session_pair.second) {
       std::string imsi = session_pair.first;
       std::string sid  = session->get_session_id();
-      auto& uc         = session_update[imsi][sid];
-      session->get_updates(request, &actions, uc);
+      session->get_updates(&request, &actions, &session_update[imsi][sid]);
     }
   }
   return request;
@@ -544,7 +540,7 @@ void LocalEnforcer::handle_update_failure(
                    << " because it couldn't be found";
       continue;
     }
-    (**session_it)->handle_update_failure(request, updates[imsi][session_id]);
+    (**session_it)->handle_update_failure(request, &updates[imsi][session_id]);
   }
 }
 
@@ -637,7 +633,7 @@ void LocalEnforcer::schedule_static_rule_activation(
 
         RulesToProcess to_process;
         to_process.push_back(session->activate_static_rule(
-            rule_id, session->get_rule_lifetime(rule_id), uc));
+            rule_id, session->get_rule_lifetime(rule_id), &uc));
 
         pipelined_client_->activate_flows_for_rules(
             imsi, ip_addr, ipv6_addr, teids, msisdn, ambr, to_process,
@@ -676,7 +672,7 @@ void LocalEnforcer::schedule_dynamic_rule_activation(
         // don't install the rule if the current time is out of lifetime
         std::time_t current_time = time(nullptr);
         if (!session->should_rule_be_active(rule_id, current_time)) {
-          session->remove_scheduled_dynamic_rule(rule_id, nullptr, session_uc);
+          session->remove_scheduled_dynamic_rule(rule_id, nullptr, &session_uc);
           session_store_.update_sessions(session_update);
           return;
         }
@@ -690,14 +686,14 @@ void LocalEnforcer::schedule_dynamic_rule_activation(
 
         PolicyRule rule;
         if (!session->remove_scheduled_dynamic_rule(
-                rule_id, &rule, session_uc)) {
+                rule_id, &rule, &session_uc)) {
           MLOG(MWARNING) << "Dynamic rule " << rule_id << " doesn't exist for "
                          << session_id;
           return;
         }
         RulesToProcess to_process;
         to_process.push_back(session->insert_dynamic_rule(
-            rule, session->get_rule_lifetime(rule_id), session_uc));
+            rule, session->get_rule_lifetime(rule_id), &session_uc));
 
         pipelined_client_->activate_flows_for_rules(
             imsi, ip_addr, ipv6_addr, teids, msisdn, ambr, to_process,
@@ -744,7 +740,7 @@ void LocalEnforcer::schedule_static_rule_deactivation(
 
         auto& session_uc = session_update[imsi][session_id];
         optional<RuleToProcess> op_rule_info =
-            session->deactivate_static_rule(rule_id, session_uc);
+            session->deactivate_static_rule(rule_id, &session_uc);
         if (!op_rule_info) {
           MLOG(MERROR) << "Could not find rule " << rule_id << " for "
                        << session_id << " during static rule removal";
@@ -790,7 +786,7 @@ void LocalEnforcer::schedule_dynamic_rule_deactivation(
         PolicyRule policy;
         auto& uc = session_update[imsi][session_id];
         optional<RuleToProcess> remove_info =
-            session->remove_dynamic_rule(policy.id(), &policy, uc);
+            session->remove_dynamic_rule(policy.id(), &policy, &uc);
         if (remove_info) {
           RulesToProcess to_process;
           to_process.push_back(*remove_info);
@@ -898,18 +894,15 @@ bool LocalEnforcer::update_tunnel_ids(
 
   std::unordered_set<uint32_t> charging_credits_received;
   for (const auto& credit : csr.credits()) {
-    // TODO this uc is not doing anything here, modify interface
-    auto uc = get_default_update_criteria();
-    if (session->receive_charging_credit(credit, uc)) {
+    if (session->receive_charging_credit(credit, nullptr)) {
       charging_credits_received.insert(credit.charging_key());
     }
   }
   // We don't have to check 'success' field for monitors because command level
   // errors are handled in session proxy for the init exchange
   for (const auto& monitor : csr.usage_monitors()) {
-    // TODO this uc is not doing anything here, modify interface
     auto uc = get_default_update_criteria();
-    session->receive_monitor(monitor, uc);
+    session->receive_monitor(monitor, nullptr);
   }
 
   handle_session_activate_rule_updates(
@@ -921,10 +914,7 @@ bool LocalEnforcer::update_tunnel_ids(
   }
 
   if (revalidation_required(csr.event_triggers())) {
-    // TODO This might not work since the session is not initialized properly
-    // at this point
-    auto _ = get_default_update_criteria();
-    schedule_revalidation(*session, csr.revalidation_time(), _);
+    schedule_revalidation(*session, csr.revalidation_time(), nullptr);
   }
 
   // handle transient errors during first init
@@ -932,12 +922,11 @@ bool LocalEnforcer::update_tunnel_ids(
   for (const auto& credit : csr.credits()) {
     if (!credit.success() &&
         DiameterCodeHandler::is_transient_failure(credit.result_code())) {
-      auto _    = get_default_update_criteria();
       auto ckey = credit.charging_key();
 
       // set state here because during init update criteria is not used.
-      session->set_suspend_credit(ckey, true, _);
-      session->suspend_service_if_needed_for_credit(ckey, _);
+      session->set_suspend_credit(ckey, true, nullptr);
+      session->suspend_service_if_needed_for_credit(ckey, nullptr);
 
       // schedule the removal of rules to avoid problems with install-unistall
       // order
@@ -954,9 +943,8 @@ bool LocalEnforcer::update_tunnel_ids(
               return;
             }
             auto& session = **session_it;
-            auto _        = get_default_update_criteria();
             remove_rules_for_suspended_credit(
-                session, credit.charging_key(), _);
+                session, credit.charging_key(), nullptr);
           },
           500);
     }
@@ -1066,10 +1054,10 @@ void LocalEnforcer::complete_termination(
   }
   auto& session    = **session_it;
   auto& session_uc = session_updates[imsi][session_id];
-  if (!session->can_complete_termination(session_uc)) {
+  if (!session->can_complete_termination(&session_uc)) {
     return;  // error is logged in SessionState's complete_termination
   }
-  auto termination_req = session->make_termination_request(session_uc);
+  auto termination_req = session->make_termination_request(&session_uc);
   auto logging_cb = SessionReporter::get_terminate_logging_cb(termination_req);
   reporter_->report_terminate_session(termination_req, logging_cb);
   events_reporter_->session_terminated(imsi, session);
@@ -1103,8 +1091,7 @@ void LocalEnforcer::terminate_multiple_sessions(
       return;
     }
     auto& session = **session_it;
-    auto& uc      = session_update[imsi][session_id];
-    start_session_termination(session, true, uc);
+    start_session_termination(session, true, &session_update[imsi][session_id]);
   }
 }
 
@@ -1127,13 +1114,13 @@ void LocalEnforcer::remove_rules_for_multiple_suspended_credit(
     }
     auto& session    = **session_it;
     auto& session_uc = session_update[imsi][session_id];
-    remove_rules_for_suspended_credit(session, ckey, session_uc);
+    remove_rules_for_suspended_credit(session, ckey, &session_uc);
   }
 }
 
 void LocalEnforcer::remove_rules_for_suspended_credit(
     const std::unique_ptr<SessionState>& session, const CreditKey& ckey,
-    SessionStateUpdateCriteria& session_uc) {
+    SessionStateUpdateCriteria* session_uc) {
   MLOG(MWARNING) << "Suspending RG " << ckey << " for "
                  << session->get_session_id();
   // suspend this specific credit
@@ -1144,7 +1131,7 @@ void LocalEnforcer::remove_rules_for_suspended_credit(
 
   // Remove pipelined rules
   RulesToProcess rules_to_remove;
-  session->get_rules_per_credit_key(ckey, &rules_to_remove, &session_uc);
+  session->get_rules_per_credit_key(ckey, &rules_to_remove, session_uc);
   propagate_rule_updates_to_pipelined(
       session->get_config(), RulesToProcess{}, rules_to_remove, false);
 }
@@ -1168,13 +1155,13 @@ void LocalEnforcer::add_rules_for_multiple_unsuspended_credit(
     }
     auto& session    = **session_it;
     auto& session_uc = session_update[imsi][session_id];
-    add_rules_for_unsuspended_credit(session, ckey, session_uc);
+    add_rules_for_unsuspended_credit(session, ckey, &session_uc);
   }
 }
 
 void LocalEnforcer::add_rules_for_unsuspended_credit(
     const std::unique_ptr<SessionState>& session, const CreditKey& ckey,
-    SessionStateUpdateCriteria& session_uc) {
+    SessionStateUpdateCriteria* session_uc) {
   MLOG(MWARNING) << "Un-suspending RG " << ckey << " for "
                  << session->get_session_id();
   // unsuspend this credit
@@ -1182,7 +1169,7 @@ void LocalEnforcer::add_rules_for_unsuspended_credit(
 
   //  add pipelined rules
   RulesToProcess rules_to_add;
-  session->get_rules_per_credit_key(ckey, &rules_to_add, &session_uc);
+  session->get_rules_per_credit_key(ckey, &rules_to_add, session_uc);
   propagate_rule_updates_to_pipelined(
       session->get_config(), rules_to_add, RulesToProcess{}, false);
 }
@@ -1247,8 +1234,8 @@ void LocalEnforcer::update_charging_credits(
     optional<FinalActionInfo> prev_final_action =
         session->get_final_action_if_final_unit_state(credit_key);
     bool valid_credit =
-        session->receive_charging_credit(credit_update_resp, uc);
-    session->set_tgpp_context(credit_update_resp.tgpp_ctx(), uc);
+        session->receive_charging_credit(credit_update_resp, &uc);
+    session->set_tgpp_context(credit_update_resp.tgpp_ctx(), &uc);
 
     bool should_activate = session->is_credit_ready_to_be_activated(credit_key);
     if (!should_activate) {
@@ -1264,7 +1251,7 @@ void LocalEnforcer::update_charging_credits(
     // TODO( ): move it to actions vector
     if (prev_final_action) {
       RulesToProcess gy_rules =
-          session->remove_all_final_action_rules(*prev_final_action, uc);
+          session->remove_all_final_action_rules(*prev_final_action, &uc);
       if (!gy_rules.empty()) {
         auto config = session->get_config().common_context;
         // We need to cancel final unit action flows installed in pipelined here
@@ -1309,8 +1296,8 @@ void LocalEnforcer::update_monitoring_credits_and_rules(
       continue;
     }
 
-    session->receive_monitor(usage_monitor_resp, uc);
-    session->set_tgpp_context(usage_monitor_resp.tgpp_ctx(), uc);
+    session->receive_monitor(usage_monitor_resp, &uc);
+    session->set_tgpp_context(usage_monitor_resp.tgpp_ctx(), &uc);
 
     RulesToProcess pending_activation, pending_deactivation,
         pending_bearer_setup;
@@ -1346,7 +1333,7 @@ void LocalEnforcer::update_monitoring_credits_and_rules(
       // this session
       auto revalidation_time = usage_monitor_resp.revalidation_time();
       sessions_with_revalidation.insert(imsi_and_session_id);
-      schedule_revalidation(*session, revalidation_time, uc);
+      schedule_revalidation(*session, revalidation_time, &uc);
     }
 
     if (config.common_context.rat_type() == TGPP_LTE) {
@@ -1392,7 +1379,7 @@ bool LocalEnforcer::handle_termination_from_access(
   }
   auto& session                 = **session_it;
   const std::string& session_id = session->get_session_id();
-  start_session_termination(session, false, session_updates[imsi][session_id]);
+  start_session_termination(session, false, &session_updates[imsi][session_id]);
   return true;
 }
 
@@ -1405,7 +1392,7 @@ bool LocalEnforcer::find_and_terminate_session(
     return false;
   }
   auto& session = **session_it;
-  start_session_termination(session, true, session_updates[imsi][session_id]);
+  start_session_termination(session, true, &session_updates[imsi][session_id]);
   return true;
 }
 
@@ -1420,7 +1407,7 @@ bool LocalEnforcer::handle_abort_session(
   auto& session    = **session_it;
   auto& session_uc = session_updates[imsi][session_id];
   // Propagate rule removals to PipelineD and notify Access
-  start_session_termination(session, true, session_uc);
+  start_session_termination(session, true, &session_uc);
   // ASRs do not require a CCR-T, this means we can immediately terminate
   // without waiting for final usage reports.
   events_reporter_->session_terminated(imsi, session);
@@ -1467,7 +1454,7 @@ void LocalEnforcer::handle_set_session_rules(
           pending_bearer_setup;
       session->apply_session_rule_set(
           *rule_set, &pending_activation, &pending_deactivation,
-          &pending_bearer_setup, uc);
+          &pending_bearer_setup, &uc);
 
       // Propagate these rule changes to PipelineD and MME (if 4G)
       propagate_rule_updates_to_pipelined(
@@ -1498,11 +1485,11 @@ ReAuthResult LocalEnforcer::init_charging_reauth(
     case ChargingReAuthRequest::SINGLE_SERVICE: {
       MLOG(MDEBUG) << "Initiating ReAuth of RG " << request.charging_key()
                    << " for session " << session_id;
-      return session->reauth_key(CreditKey(request), uc);
+      return session->reauth_key(CreditKey(request), &uc);
     }
     case ChargingReAuthRequest::ENTIRE_SESSION: {
       MLOG(MDEBUG) << "Initiating ReAuth of all RGs for session " << session_id;
-      return session->reauth_all(uc);
+      return session->reauth_all(&uc);
     }
     default:
       MLOG(MDEBUG) << "Received ChargingReAuthType " << request.type()
@@ -1554,14 +1541,14 @@ void LocalEnforcer::init_policy_reauth_for_session(
   SessionStateUpdateCriteria& uc =
       session_update[imsi][session->get_session_id()];
 
-  receive_monitoring_credit_from_rar(request, session, uc);
+  receive_monitoring_credit_from_rar(request, session, &uc);
 
   RulesToProcess pending_activation, pending_deactivation, pending_bearer_setup;
   RulesToSchedule pending_scheduling;
 
   MLOG(MDEBUG) << "Processing policy reauth for subscriber " << request.imsi();
   if (revalidation_required(request.event_triggers())) {
-    schedule_revalidation(*session, request.revalidation_time(), uc);
+    schedule_revalidation(*session, request.revalidation_time(), &uc);
   }
 
   session->process_rules_to_remove(
@@ -1578,7 +1565,7 @@ void LocalEnforcer::init_policy_reauth_for_session(
       session->get_config(), pending_activation, pending_deactivation, false);
 
   if (terminate_on_wallet_exhaust() && is_wallet_exhausted(*session)) {
-    start_session_termination(session, true, uc);
+    start_session_termination(session, true, &uc);
     return;
   }
   if (session->get_config().common_context.rat_type() == TGPP_LTE) {
@@ -1615,7 +1602,7 @@ void LocalEnforcer::propagate_rule_updates_to_pipelined(
 void LocalEnforcer::receive_monitoring_credit_from_rar(
     const PolicyReAuthRequest& request,
     const std::unique_ptr<SessionState>& session,
-    SessionStateUpdateCriteria& uc) {
+    SessionStateUpdateCriteria* uc) {
   UsageMonitoringUpdateResponse monitoring_credit;
   monitoring_credit.set_session_id(request.session_id());
   monitoring_credit.set_sid("IMSI" + request.session_id());
@@ -1693,7 +1680,7 @@ bool LocalEnforcer::revalidation_required(
 
 void LocalEnforcer::schedule_revalidation(
     SessionState& session, const google::protobuf::Timestamp& revalidation_time,
-    SessionStateUpdateCriteria& uc) {
+    SessionStateUpdateCriteria* uc) {
   // Add revalidation info to session and mark as pending
   session.add_new_event_trigger(REVALIDATION_TIMEOUT, uc);
   session.set_revalidation_time(revalidation_time, uc);
@@ -1717,7 +1704,7 @@ void LocalEnforcer::schedule_revalidation(
         SessionUpdate update =
             SessionStore::get_default_session_update(session_map);
         auto& uc = update[imsi][session_id];
-        session->mark_event_trigger_as_triggered(REVALIDATION_TIMEOUT, uc);
+        session->mark_event_trigger_as_triggered(REVALIDATION_TIMEOUT, &uc);
         session_store_.update_sessions(update);
       },
       delta.count());
@@ -1911,11 +1898,11 @@ bool LocalEnforcer::bind_policy_to_bearer(
     // if bearer_id is 0, the rule needs to be removed since we cannot honor the
     // QoS request
     remove_rule_due_to_bearer_creation_failure(
-        *session, request.policy_rule_id(), uc);
+        *session, request.policy_rule_id(), &uc);
     return false;
   }
 
-  session->bind_policy_to_bearer(request, uc);
+  session->bind_policy_to_bearer(request, &uc);
   install_rule_after_bearer_creation(*session, request);
   return true;
 }
@@ -1939,7 +1926,7 @@ void LocalEnforcer::install_rule_after_bearer_creation(
 
 void LocalEnforcer::remove_rule_due_to_bearer_creation_failure(
     SessionState& session, const std::string& rule_id,
-    SessionStateUpdateCriteria& uc) {
+    SessionStateUpdateCriteria* uc) {
   MLOG(MINFO) << "Removing " << rule_id
               << " since we failed to create a dedicated bearer for it";
   auto policy_type = session.get_policy_type(rule_id);

--- a/lte/gateway/c/session_manager/LocalEnforcer.h
+++ b/lte/gateway/c/session_manager/LocalEnforcer.h
@@ -39,7 +39,7 @@
 namespace magma {
 using std::experimental::optional;
 
-typedef std::pair<std::string, std::string> ImsiAndSessionID;
+using ImsiAndSessionID = std::pair<std::string, std::string>;
 
 struct RuleRecord_equal {
   bool operator()(const RuleRecord& l, const RuleRecord& r) const {
@@ -59,8 +59,9 @@ struct RuleRecord_hash {
     return h1 ^ h2 ^ h3;
   }
 };
-typedef std::unordered_set<RuleRecord, RuleRecord_hash, RuleRecord_equal>
-    RuleRecordSet;
+
+using RuleRecordSet =
+    std::unordered_set<RuleRecord, RuleRecord_hash, RuleRecord_equal>;
 
 struct ImsiSessionIDAndCreditkey {
   std::string imsi;
@@ -305,7 +306,6 @@ class LocalEnforcer {
 
   std::unique_ptr<Timezone>& get_access_timezone() { return access_timezone_; };
 
-  static uint32_t REDIRECT_FLOW_PRIORITY;
   // If this is set to true, we will send the timezone along with
   // CreateSessionRequest
   static bool SEND_ACCESS_TIMEZONE;
@@ -498,7 +498,7 @@ class LocalEnforcer {
   void receive_monitoring_credit_from_rar(
       const PolicyReAuthRequest& request,
       const std::unique_ptr<SessionState>& session,
-      SessionStateUpdateCriteria& uc);
+      SessionStateUpdateCriteria* session_uc);
 
   /**
    * Send bearer creation request through the PGW client if rules were
@@ -518,7 +518,7 @@ class LocalEnforcer {
   void schedule_revalidation(
       SessionState& session,
       const google::protobuf::Timestamp& revalidation_time,
-      SessionStateUpdateCriteria& uc);
+      SessionStateUpdateCriteria* session_uc);
 
   void handle_add_ue_mac_flow_callback(
       const SubscriberID& sid, const std::string& ue_mac_addr,
@@ -541,11 +541,11 @@ class LocalEnforcer {
    * @param session
    * @param notify_access: bool to determine whether the access component needs
    * notification
-   * @param uc
+   * @param session_uc
    */
   void start_session_termination(
       const std::unique_ptr<SessionState>& session, bool notify_access,
-      SessionStateUpdateCriteria& uc);
+      SessionStateUpdateCriteria* session_uc);
 
   /**
    * handle_force_termination_timeout is scheduled to run when a termination
@@ -561,11 +561,11 @@ class LocalEnforcer {
    * remove_all_rules_for_termination talks to PipelineD and removes all rules
    * (Gx/Gy/static/dynamic/everything) attached to the session
    * @param session
-   * @param uc
+   * @param session_uc
    */
   void remove_all_rules_for_termination(
       const std::unique_ptr<SessionState>& session,
-      SessionStateUpdateCriteria& uc);
+      SessionStateUpdateCriteria* session_uc);
 
   /**
    * notify_termination_to_access_service cases on the session's rat type and
@@ -652,11 +652,11 @@ class LocalEnforcer {
    * Remove the specified rule from the session and propagate the change to
    * PipelineD
    * @param rule_id rule to be deleted
-   * @param uc
+   * @param session_uc
    */
   void remove_rule_due_to_bearer_creation_failure(
       SessionState& session, const std::string& rule_id,
-      SessionStateUpdateCriteria& uc);
+      SessionStateUpdateCriteria* session_uc);
 
   /**
    * @brief Activate the rule after successfully binding it to a dedicated
@@ -672,11 +672,11 @@ class LocalEnforcer {
 
   void remove_rules_for_suspended_credit(
       const std::unique_ptr<SessionState>& session, const CreditKey& ckey,
-      SessionStateUpdateCriteria& session_uc);
+      SessionStateUpdateCriteria* session_uc);
 
   void add_rules_for_unsuspended_credit(
       const std::unique_ptr<SessionState>& session, const CreditKey& ckey,
-      SessionStateUpdateCriteria& session_uc);
+      SessionStateUpdateCriteria* session_uc);
 
   /**
    * Given a set of IMSI+IPs that are no longer tracked in SessionD, send a

--- a/lte/gateway/c/session_manager/OperationalStatesHandler.h
+++ b/lte/gateway/c/session_manager/OperationalStatesHandler.h
@@ -36,7 +36,7 @@ const std::string SESSION_START_TIME     = "session_start_time";
 const std::string ACTIVE_DURATION_SECOND = "active_duration_sec";
 const std::string LIFECYCLE_STATE        = "lifecycle_state";
 
-typedef std::list<std::map<std::string, std::string>> OpState;
+using OpState = std::list<std::map<std::string, std::string>>;
 
 OpState get_operational_states(magma::SessionStore* session_store);
 

--- a/lte/gateway/c/session_manager/RuleStore.cpp
+++ b/lte/gateway/c/session_manager/RuleStore.cpp
@@ -225,22 +225,6 @@ bool PolicyRuleBiMap::get_rule_definitions_for_charging_key(
   return success;
 }
 
-bool PolicyRuleBiMap::get_rule_ids_for_monitoring_key(
-    const std::string& monitoring_key, std::vector<std::string>& rules_out) {
-  std::lock_guard<std::mutex> lock(map_mutex_);
-  bool success =
-      rules_by_monitoring_key_.get_rule_ids_for_key(monitoring_key, rules_out);
-  return success;
-}
-
-bool PolicyRuleBiMap::get_rule_definitions_for_monitoring_key(
-    const std::string& monitoring_key, std::vector<PolicyRule>& rules_out) {
-  std::lock_guard<std::mutex> lock(map_mutex_);
-  bool success = rules_by_monitoring_key_.get_rule_definitions_for_key(
-      monitoring_key, rules_out);
-  return success;
-}
-
 uint32_t PolicyRuleBiMap::monitored_rules_count() {
   std::lock_guard<std::mutex> lock(map_mutex_);
   return rules_by_monitoring_key_.policy_count();

--- a/lte/gateway/c/session_manager/RuleStore.h
+++ b/lte/gateway/c/session_manager/RuleStore.h
@@ -104,17 +104,11 @@ class PolicyRuleBiMap {
   virtual bool get_rule_ids_for_charging_key(
       const CreditKey& charging_key, std::vector<std::string>& rules_out);
 
-  virtual bool get_rule_ids_for_monitoring_key(
-      const std::string& monitoring_key, std::vector<std::string>& rules_out);
-
   /**
    * Get all the rules for a given key. Rule ids are copied into rules_out
    */
   virtual bool get_rule_definitions_for_charging_key(
       const CreditKey& charging_key, std::vector<PolicyRule>& rules_out);
-
-  virtual bool get_rule_definitions_for_monitoring_key(
-      const std::string& monitoring_key, std::vector<PolicyRule>& rules_out);
 
   /**
    * Get the number of rules tracked by a monitoring key

--- a/lte/gateway/c/session_manager/SessionCredit.h
+++ b/lte/gateway/c/session_manager/SessionCredit.h
@@ -194,7 +194,8 @@ class SessionCredit {
 
   void log_usage_report(Usage) const;
 
-  GrantTrackingType determine_grant_tracking_type(const GrantedUnits& grant);
+  GrantTrackingType determine_grant_tracking_type(
+      const GrantedUnits& grant) const;
 
   uint64_t calculate_requested_unit(
       CreditUnit cu, Bucket allowed, Bucket allowed_floor, uint64_t used) const;
@@ -204,10 +205,10 @@ class SessionCredit {
       const uint64_t grantedUnits) const;
 
   uint64_t calculate_delta_allowed_floor(
-      CreditUnit cu, Bucket allowed, Bucket floor, uint64_t volume_used);
+      CreditUnit cu, Bucket allowed, Bucket floor, uint64_t volume_used) const;
 
   uint64_t calculate_delta_allowed(
-      uint64_t gsu_volume, Bucket allowed, uint64_t volume_used);
+      uint64_t gsu_volume, Bucket allowed, uint64_t volume_used) const;
 
   void update_usage_timestamps(SessionCreditUpdateCriteria* credit_uc);
 };

--- a/lte/gateway/c/session_manager/SessionState.cpp
+++ b/lte/gateway/c/session_manager/SessionState.cpp
@@ -232,10 +232,12 @@ uint32_t SessionState::get_current_version() {
 }
 
 void SessionState::set_current_version(
-    int new_session_version, SessionStateUpdateCriteria& session_uc) {
-  current_version_                      = new_session_version;
-  session_uc.is_current_version_updated = true;
-  session_uc.updated_current_version    = new_session_version;
+    int new_session_version, SessionStateUpdateCriteria* session_uc) {
+  current_version_ = new_session_version;
+  if (session_uc) {
+    session_uc->is_current_version_updated = true;
+    session_uc->updated_current_version    = new_session_version;
+  }
   MLOG(MINFO) << " Current version is " << get_current_version();
 }
 /* Add PDR rule to this rules session list */
@@ -256,10 +258,6 @@ void SessionState::remove_all_rules() {
 /* It gets all PDR rule list of the session */
 std::vector<SetGroupPDR>& SessionState::get_all_pdr_rules() {
   return PdrList_;
-}
-
-SessionFsmState SessionState::get_state() {
-  return curr_state_;
 }
 
 magma::lte::Fsm_state_FsmState SessionState::get_proto_fsm_state() {
@@ -324,52 +322,58 @@ static UsageMonitorUpdate make_usage_monitor_update(
 }
 
 SessionCreditUpdateCriteria* SessionState::get_credit_uc(
-    const CreditKey& key, SessionStateUpdateCriteria& uc) {
-  if (uc.charging_credit_map.find(key) == uc.charging_credit_map.end()) {
-    uc.charging_credit_map[key] = credit_map_[key]->get_update_criteria();
+    const CreditKey& key, SessionStateUpdateCriteria* session_uc) {
+  if (!session_uc) {
+    return nullptr;
   }
-  return &(uc.charging_credit_map[key]);
+  if (session_uc->charging_credit_map.find(key) ==
+      session_uc->charging_credit_map.end()) {
+    session_uc->charging_credit_map[key] =
+        credit_map_[key]->get_update_criteria();
+  }
+  return &(session_uc->charging_credit_map[key]);
 }
 
-bool SessionState::apply_update_criteria(SessionStateUpdateCriteria& uc) {
-  if (uc.is_fsm_updated) {
-    curr_state_ = uc.updated_fsm_state;
+bool SessionState::apply_update_criteria(
+    SessionStateUpdateCriteria session_uc) {
+  if (session_uc.is_fsm_updated) {
+    curr_state_ = session_uc.updated_fsm_state;
   }
 
-  if (uc.is_current_version_updated) {
-    current_version_ = uc.updated_current_version;
+  if (session_uc.is_current_version_updated) {
+    current_version_ = session_uc.updated_current_version;
   }
 
-  if (uc.is_local_teid_updated) {
-    local_teid_ = uc.local_teid_updated;
+  if (session_uc.is_local_teid_updated) {
+    local_teid_ = session_uc.local_teid_updated;
   }
 
-  if (uc.is_pending_event_triggers_updated) {
-    for (auto it : uc.pending_event_triggers) {
+  if (session_uc.is_pending_event_triggers_updated) {
+    for (auto it : session_uc.pending_event_triggers) {
       pending_event_triggers_[it.first] = it.second;
       if (it.first == REVALIDATION_TIMEOUT) {
-        revalidation_time_ = uc.revalidation_time;
+        revalidation_time_ = session_uc.revalidation_time;
       }
     }
   }
   // QoS Management
-  if (uc.is_bearer_mapping_updated) {
-    bearer_id_by_policy_ = uc.bearer_id_by_policy;
+  if (session_uc.is_bearer_mapping_updated) {
+    bearer_id_by_policy_ = session_uc.bearer_id_by_policy;
   }
 
   // Config
-  if (uc.is_config_updated) {
-    config_ = uc.updated_config;
+  if (session_uc.is_config_updated) {
+    config_ = session_uc.updated_config;
   }
 
   // Rule versions
-  if (uc.policy_version_and_stats) {
-    policy_version_and_stats_ = *uc.policy_version_and_stats;
+  if (session_uc.policy_version_and_stats) {
+    policy_version_and_stats_ = *session_uc.policy_version_and_stats;
   }
 
   // Manually update these policy structures to avoid incrementing version
   // Static rules
-  for (const auto& rule_id : uc.static_rules_to_uninstall) {
+  for (const auto& rule_id : session_uc.static_rules_to_uninstall) {
     if (is_static_rule_installed(rule_id)) {
       remove_from_vec_by_value<std::string>(active_static_rules_, rule_id);
     }
@@ -378,87 +382,92 @@ bool SessionState::apply_update_criteria(SessionStateUpdateCriteria& uc) {
     }
     rule_lifetimes_.erase(rule_id);
   }
-  for (const auto& rule_id : uc.static_rules_to_install) {
+  for (const auto& rule_id : session_uc.static_rules_to_install) {
     if (!is_static_rule_installed(rule_id)) {
       active_static_rules_.push_back(rule_id);
     }
-    if (uc.new_rule_lifetimes.find(rule_id) != uc.new_rule_lifetimes.end()) {
-      rule_lifetimes_[rule_id] = uc.new_rule_lifetimes[rule_id];
+    if (session_uc.new_rule_lifetimes.find(rule_id) !=
+        session_uc.new_rule_lifetimes.end()) {
+      rule_lifetimes_[rule_id] = session_uc.new_rule_lifetimes[rule_id];
     }
     if (is_static_rule_scheduled(rule_id)) {
       scheduled_static_rules_.erase(rule_id);
     }
   }
-  for (const auto& rule_id : uc.new_scheduled_static_rules) {
+  for (const auto& rule_id : session_uc.new_scheduled_static_rules) {
     if (is_static_rule_scheduled(rule_id)) {
       continue;
     }
-    if (uc.new_rule_lifetimes.find(rule_id) != uc.new_rule_lifetimes.end()) {
-      rule_lifetimes_[rule_id] = uc.new_rule_lifetimes[rule_id];
+    if (session_uc.new_rule_lifetimes.find(rule_id) !=
+        session_uc.new_rule_lifetimes.end()) {
+      rule_lifetimes_[rule_id] = session_uc.new_rule_lifetimes[rule_id];
     }
     scheduled_static_rules_.insert(rule_id);
   }
 
   // Dynamic rules
-  for (const auto& rule_id : uc.dynamic_rules_to_uninstall) {
+  for (const auto& rule_id : session_uc.dynamic_rules_to_uninstall) {
     scheduled_dynamic_rules_.remove_rule(rule_id, nullptr);
     dynamic_rules_.remove_rule(rule_id, nullptr);
     rule_lifetimes_.erase(rule_id);
   }
-  for (const auto& rule : uc.dynamic_rules_to_install) {
-    if (uc.new_rule_lifetimes.find(rule.id()) != uc.new_rule_lifetimes.end()) {
-      rule_lifetimes_[rule.id()] = uc.new_rule_lifetimes[rule.id()];
+  for (const auto& rule : session_uc.dynamic_rules_to_install) {
+    if (session_uc.new_rule_lifetimes.find(rule.id()) !=
+        session_uc.new_rule_lifetimes.end()) {
+      rule_lifetimes_[rule.id()] = session_uc.new_rule_lifetimes[rule.id()];
     }
     dynamic_rules_.insert_rule(rule);
     scheduled_dynamic_rules_.remove_rule(rule.id(), nullptr);
   }
-  for (const auto& rule : uc.new_scheduled_dynamic_rules) {
-    if (uc.new_rule_lifetimes.find(rule.id()) != uc.new_rule_lifetimes.end()) {
-      rule_lifetimes_[rule.id()] = uc.new_rule_lifetimes[rule.id()];
+  for (const auto& rule : session_uc.new_scheduled_dynamic_rules) {
+    if (session_uc.new_rule_lifetimes.find(rule.id()) !=
+        session_uc.new_rule_lifetimes.end()) {
+      rule_lifetimes_[rule.id()] = session_uc.new_rule_lifetimes[rule.id()];
     }
     scheduled_dynamic_rules_.insert_rule(rule);
   }
 
   // Gy Dynamic rules
-  for (const auto& rule : uc.gy_dynamic_rules_to_install) {
-    if (uc.new_rule_lifetimes.find(rule.id()) != uc.new_rule_lifetimes.end()) {
-      rule_lifetimes_[rule.id()] = uc.new_rule_lifetimes[rule.id()];
+  for (const auto& rule : session_uc.gy_dynamic_rules_to_install) {
+    if (session_uc.new_rule_lifetimes.find(rule.id()) !=
+        session_uc.new_rule_lifetimes.end()) {
+      rule_lifetimes_[rule.id()] = session_uc.new_rule_lifetimes[rule.id()];
     }
     gy_dynamic_rules_.insert_rule(rule);
   }
-  for (const auto& rule_id : uc.gy_dynamic_rules_to_uninstall) {
+  for (const auto& rule_id : session_uc.gy_dynamic_rules_to_uninstall) {
     gy_dynamic_rules_.remove_rule(rule_id, nullptr);
   }
 
   // Charging credit
-  for (const auto& it : uc.charging_credit_map) {
+  for (const auto& it : session_uc.charging_credit_map) {
     auto key           = it.first;
     auto credit_update = it.second;
     apply_charging_credit_update(key, credit_update);
   }
-  for (const auto& it : uc.charging_credit_to_install) {
+  for (const auto& it : session_uc.charging_credit_to_install) {
     auto key           = it.first;
     auto stored_credit = it.second;
     credit_map_[key]   = std::make_unique<ChargingGrant>(stored_credit);
   }
 
   // Monitoring credit
-  if (uc.is_session_level_key_updated) {
-    set_session_level_key(uc.updated_session_level_key);
+  if (session_uc.is_session_level_key_updated) {
+    session_level_key_ = session_uc.updated_session_level_key;
   }
-  for (const auto& it : uc.monitor_credit_map) {
+  for (const auto& it : session_uc.monitor_credit_map) {
     auto key           = it.first;
     auto credit_update = it.second;
-    apply_monitor_updates(key, uc, credit_update);
+    apply_monitor_updates(key, credit_update);
   }
-  for (const auto& it : uc.monitor_credit_to_install) {
+  for (const auto& it : session_uc.monitor_credit_to_install) {
     auto key            = it.first;
     auto stored_monitor = it.second;
     monitor_map_[key]   = std::make_unique<Monitor>(stored_monitor);
   }
 
-  if (uc.updated_pdp_end_time > 0) {
-    pdp_end_time_ = uc.updated_pdp_end_time;
+  if (session_uc.updated_pdp_end_time > 0) {
+    pdp_end_time_ = session_uc.updated_pdp_end_time;
   }
 
   return true;
@@ -518,35 +527,36 @@ optional<RuleStats> SessionState::get_rule_delta(
   policy_version_and_stats_[rule_id].stats_map[rule_version] =
       RuleStats(used_tx, used_rx, dropped_tx, dropped_rx);
 
-  if (!session_uc->policy_version_and_stats) {
-    session_uc->policy_version_and_stats = PolicyStatsMap{};
-  }
+  if (session_uc) {
+    if (!session_uc->policy_version_and_stats) {
+      session_uc->policy_version_and_stats = PolicyStatsMap{};
+    }
 
-  if (session_uc->policy_version_and_stats.value().find(rule_id) ==
-      policy_version_and_stats_.end()) {
-    session_uc->policy_version_and_stats.value()[rule_id] = StatsPerPolicy();
+    if (session_uc->policy_version_and_stats.value().find(rule_id) ==
+        policy_version_and_stats_.end()) {
+      session_uc->policy_version_and_stats.value()[rule_id] = StatsPerPolicy();
+    }
+    auto& stats_uc = session_uc->policy_version_and_stats.value()[rule_id];
+    stats_uc.current_version =
+        policy_version_and_stats_[rule_id].current_version;
+    stats_uc.last_reported_version =
+        policy_version_and_stats_[rule_id].last_reported_version;
+    stats_uc.stats_map[rule_version] =
+        policy_version_and_stats_[rule_id].stats_map[rule_version];
   }
-  session_uc->policy_version_and_stats.value()[rule_id].current_version =
-      policy_version_and_stats_[rule_id].current_version;
-  session_uc->policy_version_and_stats.value()[rule_id].last_reported_version =
-      policy_version_and_stats_[rule_id].last_reported_version;
-  session_uc->policy_version_and_stats.value()[rule_id]
-      .stats_map[rule_version] =
-      policy_version_and_stats_[rule_id].stats_map[rule_version];
-
   return ret;
 }
 
 void SessionState::add_rule_usage(
     const std::string& rule_id, uint64_t rule_version, uint64_t used_tx,
     uint64_t used_rx, uint64_t dropped_tx, uint64_t dropped_rx,
-    SessionStateUpdateCriteria& update_criteria) {
+    SessionStateUpdateCriteria* session_uc) {
   CreditKey charging_key;
 
   // TODO: Rework logic to work with flat rate, below is a hacky solution
   auto rule_delta = get_rule_delta(
       rule_id, rule_version, used_tx, used_rx, dropped_tx, dropped_rx,
-      &update_criteria);
+      session_uc);
   if (!rule_delta) {
     return;
   }
@@ -560,7 +570,7 @@ void SessionState::add_rule_usage(
     auto it = credit_map_.find(charging_key);
     if (it != credit_map_.end()) {
       SessionCreditUpdateCriteria* credit_uc =
-          get_credit_uc(charging_key, update_criteria);
+          get_credit_uc(charging_key, session_uc);
       it->second->credit.add_used_credit(delta.tx, delta.rx, credit_uc);
       if (it->second->should_deactivate_service()) {
         it->second->set_service_state(SERVICE_NEEDS_DEACTIVATION, credit_uc);
@@ -575,11 +585,11 @@ void SessionState::add_rule_usage(
       static_rules_.get_monitoring_key_for_rule_id(rule_id, &monitoring_key)) {
     MLOG(MINFO) << "Updating used monitoring credit for Rule=" << rule_id
                 << " Monitoring Key=" << monitoring_key;
-    add_to_monitor(monitoring_key, delta.tx, delta.rx, update_criteria);
+    add_to_monitor(monitoring_key, delta.tx, delta.rx, session_uc);
   }
   if (session_level_key_ != "" && monitoring_key != session_level_key_) {
     // Update session level key if its different
-    add_to_monitor(session_level_key_, delta.tx, delta.rx, update_criteria);
+    add_to_monitor(session_level_key_, delta.tx, delta.rx, session_uc);
   }
   if (is_dynamic_rule_installed(rule_id) || is_static_rule_installed(rule_id)) {
     update_data_metrics(UE_USED_COUNTER_NAME, delta.tx, delta.rx);
@@ -591,19 +601,20 @@ void SessionState::add_rule_usage(
 void SessionState::apply_session_rule_set(
     const RuleSetToApply& rule_set, RulesToProcess* pending_activation,
     RulesToProcess* pending_deactivation, RulesToProcess* pending_bearer_setup,
-    SessionStateUpdateCriteria& uc) {
+    SessionStateUpdateCriteria* session_uc) {
   apply_session_static_rule_set(
       rule_set.static_rules, pending_activation, pending_deactivation,
-      pending_bearer_setup, uc);
+      pending_bearer_setup, session_uc);
   apply_session_dynamic_rule_set(
       rule_set.dynamic_rules, pending_activation, pending_deactivation,
-      pending_bearer_setup, uc);
+      pending_bearer_setup, session_uc);
 }
 
 void SessionState::apply_session_static_rule_set(
     const std::unordered_set<std::string> static_rules,
     RulesToProcess* pending_activation, RulesToProcess* pending_deactivation,
-    RulesToProcess* pending_bearer_setup, SessionStateUpdateCriteria& uc) {
+    RulesToProcess* pending_bearer_setup,
+    SessionStateUpdateCriteria* session_uc) {
   // No activation time / deactivation support yet for rule set interface
   RuleLifetime lifetime;
   // Go through the rule set and install any rules not yet installed
@@ -621,7 +632,7 @@ void SessionState::apply_session_static_rule_set(
     MLOG(MINFO) << "Installing static rule " << static_rule_id << " for "
                 << session_id_;
     RuleToProcess to_process =
-        activate_static_rule(static_rule_id, lifetime, uc);
+        activate_static_rule(static_rule_id, lifetime, session_uc);
     classify_policy_activation(
         to_process, STATIC, pending_activation, pending_bearer_setup);
   }
@@ -642,7 +653,7 @@ void SessionState::apply_session_static_rule_set(
     MLOG(MINFO) << "Removing static rule " << static_rule.id() << " for "
                 << session_id_;
     optional<RuleToProcess> op_rule_info =
-        deactivate_static_rule(static_rule.id(), uc);
+        deactivate_static_rule(static_rule.id(), session_uc);
     if (!op_rule_info) {
       MLOG(MWARNING) << "Failed to deactivate static rule " << static_rule.id()
                      << " for " << session_id_;
@@ -655,7 +666,8 @@ void SessionState::apply_session_static_rule_set(
 void SessionState::apply_session_dynamic_rule_set(
     const std::unordered_map<std::string, PolicyRule> dynamic_rules,
     RulesToProcess* pending_activation, RulesToProcess* pending_deactivation,
-    RulesToProcess* pending_bearer_setup, SessionStateUpdateCriteria& uc) {
+    RulesToProcess* pending_bearer_setup,
+    SessionStateUpdateCriteria* session_uc) {
   // No activation time / deactivation support yet for rule set interface
   RuleLifetime lifetime;
   for (const auto& dynamic_rule_pair : dynamic_rules) {
@@ -665,7 +677,7 @@ void SessionState::apply_session_dynamic_rule_set(
     MLOG(MINFO) << "Installing dynamic rule " << dynamic_rule_pair.first
                 << " for " << session_id_;
     RuleToProcess to_process =
-        insert_dynamic_rule(dynamic_rule_pair.second, lifetime, uc);
+        insert_dynamic_rule(dynamic_rule_pair.second, lifetime, session_uc);
     classify_policy_activation(
         to_process, DYNAMIC, pending_activation, pending_bearer_setup);
   }
@@ -676,7 +688,7 @@ void SessionState::apply_session_dynamic_rule_set(
       MLOG(MINFO) << "Removing dynamic rule " << dynamic_rule.id() << " for "
                   << session_id_;
       pending_deactivation->push_back(
-          *remove_dynamic_rule(dynamic_rule.id(), nullptr, uc));
+          *remove_dynamic_rule(dynamic_rule.id(), nullptr, session_uc));
     }
   }
 }
@@ -684,7 +696,7 @@ void SessionState::apply_session_dynamic_rule_set(
 void SessionState::set_subscriber_quota_state(
     const magma::lte::SubscriberQuotaUpdate_Type state,
     SessionStateUpdateCriteria* session_uc) {
-  if (session_uc != nullptr) {
+  if (session_uc) {
     session_uc->updated_subscriber_quota_state = state;
   }
   subscriber_quota_state_ = state;
@@ -703,8 +715,8 @@ bool SessionState::is_terminating() {
 }
 
 void SessionState::get_monitor_updates(
-    UpdateSessionRequest& update_request_out,
-    SessionStateUpdateCriteria& update_criteria) {
+    UpdateSessionRequest* update_request_out,
+    SessionStateUpdateCriteria* session_uc) {
   for (auto& monitor_pair : monitor_map_) {
     if (!monitor_pair.second->should_send_update()) {
       continue;  // no update
@@ -712,7 +724,7 @@ void SessionState::get_monitor_updates(
 
     auto mkey      = monitor_pair.first;
     auto& credit   = monitor_pair.second->credit;
-    auto credit_uc = get_monitor_uc(mkey, update_criteria);
+    auto credit_uc = get_monitor_uc(mkey, session_uc);
 
     if (curr_state_ == SESSION_RELEASED) {
       MLOG(MDEBUG)
@@ -739,13 +751,15 @@ void SessionState::get_monitor_updates(
     auto usage = credit.get_usage_for_reporting(credit_uc);
     auto update =
         make_usage_monitor_update(usage, mkey, monitor_pair.second->level);
-    auto new_req = update_request_out.mutable_usage_monitors()->Add();
+    auto new_req = update_request_out->mutable_usage_monitors()->Add();
 
     add_common_fields_to_usage_monitor_update(new_req);
     new_req->mutable_update()->CopyFrom(update);
     new_req->set_event_trigger(USAGE_REPORT);
     request_number_++;
-    update_criteria.request_number_increment++;
+    if (session_uc) {
+      session_uc->request_number_increment++;
+    }
   }
 }
 
@@ -767,20 +781,21 @@ void SessionState::add_common_fields_to_usage_monitor_update(
 }
 
 void SessionState::get_updates(
-    UpdateSessionRequest& update_request_out,
+    UpdateSessionRequest* update_request_out,
     std::vector<std::unique_ptr<ServiceAction>>* actions_out,
-    SessionStateUpdateCriteria& update_criteria) {
+    SessionStateUpdateCriteria* session_uc) {
   if (curr_state_ != SESSION_ACTIVE) return;
-  get_charging_updates(update_request_out, actions_out, update_criteria);
-  get_monitor_updates(update_request_out, update_criteria);
-  get_event_trigger_updates(update_request_out, update_criteria);
+  get_charging_updates(update_request_out, actions_out, session_uc);
+  get_monitor_updates(update_request_out, session_uc);
+  get_event_trigger_updates(update_request_out, session_uc);
 }
 
 SubscriberQuotaUpdate_Type SessionState::get_subscriber_quota_state() const {
   return subscriber_quota_state_;
 }
 
-bool SessionState::can_complete_termination(SessionStateUpdateCriteria& uc) {
+bool SessionState::can_complete_termination(
+    SessionStateUpdateCriteria* session_uc) {
   switch (curr_state_) {
     case SESSION_ACTIVE:
       MLOG(MERROR) << "Encountered unexpected state 'ACTIVE' when "
@@ -795,12 +810,12 @@ bool SessionState::can_complete_termination(SessionStateUpdateCriteria& uc) {
       break;
   }
   // mark session as terminated
-  set_fsm_state(SESSION_TERMINATED, uc);
+  set_fsm_state(SESSION_TERMINATED, session_uc);
   return true;
 }
 
 SessionTerminateRequest SessionState::make_termination_request(
-    SessionStateUpdateCriteria& uc) {
+    SessionStateUpdateCriteria* session_uc) {
   SessionTerminateRequest req;
   req.set_session_id(session_id_);
   req.set_request_number(request_number_);
@@ -822,7 +837,7 @@ SessionTerminateRequest SessionState::make_termination_request(
 
   // gx monitors
   for (auto& credit_pair : monitor_map_) {
-    auto credit_uc = get_monitor_uc(credit_pair.first, uc);
+    auto credit_uc = get_monitor_uc(credit_pair.first, session_uc);
     req.mutable_monitor_usages()->Add()->CopyFrom(make_usage_monitor_update(
         credit_pair.second->credit.get_all_unreported_usage_for_reporting(
             credit_uc),
@@ -831,7 +846,7 @@ SessionTerminateRequest SessionState::make_termination_request(
   // gy credits
   for (auto& credit_pair : credit_map_) {
     SessionCreditUpdateCriteria* credit_uc =
-        get_credit_uc(credit_pair.first, uc);
+        get_credit_uc(credit_pair.first, session_uc);
     auto credit_usage = credit_pair.second->get_credit_usage(
         CreditUsage::TERMINATED, credit_uc, true);
     credit_pair.first.set_credit_usage(&credit_usage);
@@ -908,10 +923,12 @@ uint32_t SessionState::get_local_teid() const {
 }
 
 void SessionState::set_local_teid(
-    uint32_t teid, SessionStateUpdateCriteria& uc) {
-  local_teid_              = teid;
-  uc.is_local_teid_updated = true;
-  uc.local_teid_updated    = teid;
+    uint32_t teid, SessionStateUpdateCriteria* session_uc) {
+  local_teid_ = teid;
+  if (session_uc) {
+    session_uc->is_local_teid_updated = true;
+    session_uc->local_teid_updated    = teid;
+  }
   return;
 }
 
@@ -923,7 +940,8 @@ bool SessionState::is_radius_cwf_session() const {
   return (config_.common_context.rat_type() == RATType::TGPP_WLAN);
 }
 
-void SessionState::get_session_info(SessionState::SessionInfo& info) {
+SessionState::SessionInfo SessionState::get_session_info() {
+  SessionState::SessionInfo info;
   info.imsi      = get_imsi();
   info.ip_addr   = config_.common_context.ue_ipv4();
   info.ipv6_addr = config_.common_context.ue_ipv6();
@@ -949,6 +967,7 @@ void SessionState::get_session_info(SessionState::SessionInfo& info) {
       info.gx_rules.push_back(make_rule_to_process(rule));
     }
   }
+  return info;
 }
 
 std::vector<PolicyRule> SessionState::get_all_active_policies() {
@@ -965,7 +984,7 @@ std::vector<PolicyRule> SessionState::get_all_active_policies() {
 }
 
 void SessionState::remove_all_rules_for_termination(
-    SessionStateUpdateCriteria& session_uc) {
+    SessionStateUpdateCriteria* session_uc) {
   std::vector<PolicyRule> gx_dynamic_rules, gy_dynamic_rules,
       scheduled_dynamic_rules;
   dynamic_rules_.get_rules(gx_dynamic_rules);
@@ -992,9 +1011,11 @@ void SessionState::remove_all_rules_for_termination(
 
 void SessionState::set_tgpp_context(
     const magma::lte::TgppContext& tgpp_context,
-    SessionStateUpdateCriteria& update_criteria) {
-  update_criteria.updated_tgpp_context = tgpp_context;
-  tgpp_context_                        = tgpp_context;
+    SessionStateUpdateCriteria* session_uc) {
+  if (session_uc) {
+    session_uc->updated_tgpp_context = tgpp_context;
+  }
+  tgpp_context_ = tgpp_context;
 }
 
 void SessionState::fill_protos_tgpp_context(
@@ -1023,9 +1044,11 @@ uint64_t SessionState::get_active_duration_in_seconds() {
 }
 
 void SessionState::set_pdp_end_time(
-    uint64_t epoch, SessionStateUpdateCriteria& session_uc) {
-  pdp_end_time_                   = epoch;
-  session_uc.updated_pdp_end_time = epoch;
+    uint64_t epoch, SessionStateUpdateCriteria* session_uc) {
+  pdp_end_time_ = epoch;
+  if (session_uc) {
+    session_uc->updated_pdp_end_time = epoch;
+  }
 }
 
 void SessionState::increment_request_number(uint32_t incr) {
@@ -1033,7 +1056,7 @@ void SessionState::increment_request_number(uint32_t incr) {
 }
 
 bool SessionState::is_dynamic_rule_scheduled(const std::string& rule_id) {
-  return scheduled_dynamic_rules_.get_rule(rule_id, NULL);
+  return scheduled_dynamic_rules_.get_rule(rule_id, nullptr);
 }
 
 bool SessionState::is_static_rule_scheduled(const std::string& rule_id) {
@@ -1041,11 +1064,11 @@ bool SessionState::is_static_rule_scheduled(const std::string& rule_id) {
 }
 
 bool SessionState::is_dynamic_rule_installed(const std::string& rule_id) {
-  return dynamic_rules_.get_rule(rule_id, NULL);
+  return dynamic_rules_.get_rule(rule_id, nullptr);
 }
 
 bool SessionState::is_gy_dynamic_rule_installed(const std::string& rule_id) {
-  return gy_dynamic_rules_.get_rule(rule_id, NULL);
+  return gy_dynamic_rules_.get_rule(rule_id, nullptr);
 }
 
 bool SessionState::is_static_rule_installed(const std::string& rule_id) {
@@ -1055,32 +1078,36 @@ bool SessionState::is_static_rule_installed(const std::string& rule_id) {
 }
 
 RuleToProcess SessionState::insert_dynamic_rule(
-    const PolicyRule& rule, RuleLifetime& lifetime,
-    SessionStateUpdateCriteria& session_uc) {
+    const PolicyRule& rule, const RuleLifetime& lifetime,
+    SessionStateUpdateCriteria* session_uc) {
   rule_lifetimes_[rule.id()] = lifetime;
   dynamic_rules_.insert_rule(rule);
-  session_uc.dynamic_rules_to_install.push_back(rule);
-  session_uc.new_rule_lifetimes[rule.id()] = lifetime;
+  if (session_uc) {
+    session_uc->dynamic_rules_to_install.push_back(rule);
+    session_uc->new_rule_lifetimes[rule.id()] = lifetime;
+  }
   increment_rule_stats(rule.id(), session_uc);
 
   return make_rule_to_process(rule);
 }
 
 RuleToProcess SessionState::insert_gy_rule(
-    const PolicyRule& rule, RuleLifetime& lifetime,
-    SessionStateUpdateCriteria& session_uc) {
+    const PolicyRule& rule, const RuleLifetime& lifetime,
+    SessionStateUpdateCriteria* session_uc) {
   rule_lifetimes_[rule.id()] = lifetime;
   gy_dynamic_rules_.insert_rule(rule);
-  session_uc.gy_dynamic_rules_to_install.push_back(rule);
-  session_uc.new_rule_lifetimes[rule.id()] = lifetime;
+  if (session_uc) {
+    session_uc->gy_dynamic_rules_to_install.push_back(rule);
+    session_uc->new_rule_lifetimes[rule.id()] = lifetime;
+  }
   increment_rule_stats(rule.id(), session_uc);
 
   return make_rule_to_process(rule);
 }
 
 RuleToProcess SessionState::activate_static_rule(
-    const std::string& rule_id, RuleLifetime& lifetime,
-    SessionStateUpdateCriteria& session_uc) {
+    const std::string& rule_id, const RuleLifetime& lifetime,
+    SessionStateUpdateCriteria* session_uc) {
   RuleToProcess to_process;
   PolicyRule rule;
   static_rules_.get_rule(rule_id, &rule);
@@ -1089,8 +1116,10 @@ RuleToProcess SessionState::activate_static_rule(
   if (!is_static_rule_installed(rule_id)) {
     active_static_rules_.push_back(rule_id);
   }
-  session_uc.static_rules_to_install.insert(rule_id);
-  session_uc.new_rule_lifetimes[rule_id] = lifetime;
+  if (session_uc) {
+    session_uc->static_rules_to_install.insert(rule_id);
+    session_uc->new_rule_lifetimes[rule_id] = lifetime;
+  }
   increment_rule_stats(rule_id, session_uc);
 
   return make_rule_to_process(rule);
@@ -1098,17 +1127,18 @@ RuleToProcess SessionState::activate_static_rule(
 
 optional<RuleToProcess> SessionState::remove_dynamic_rule(
     const std::string& rule_id, PolicyRule* rule_out,
-    SessionStateUpdateCriteria& session_uc) {
+    SessionStateUpdateCriteria* session_uc) {
   PolicyRule rule;
   bool removed = dynamic_rules_.remove_rule(rule_id, &rule);
   if (!removed) {
     return {};
   }
-  if (rule_out != nullptr) {
+  if (rule_out) {
     *rule_out = rule;
   }
-
-  session_uc.dynamic_rules_to_uninstall.insert(rule_id);
+  if (session_uc) {
+    session_uc->dynamic_rules_to_uninstall.insert(rule_id);
+  }
   increment_rule_stats(rule_id, session_uc);
 
   return make_rule_to_process(rule);
@@ -1116,40 +1146,43 @@ optional<RuleToProcess> SessionState::remove_dynamic_rule(
 
 bool SessionState::remove_scheduled_dynamic_rule(
     const std::string& rule_id, PolicyRule* rule_out,
-    SessionStateUpdateCriteria& update_criteria) {
+    SessionStateUpdateCriteria* session_uc) {
   bool removed = scheduled_dynamic_rules_.remove_rule(rule_id, rule_out);
-  if (removed) {
-    update_criteria.dynamic_rules_to_uninstall.insert(rule_id);
+  if (removed && session_uc) {
+    session_uc->dynamic_rules_to_uninstall.insert(rule_id);
   }
   return removed;
 }
 
 optional<RuleToProcess> SessionState::remove_gy_rule(
     const std::string& rule_id, PolicyRule* rule_out,
-    SessionStateUpdateCriteria& session_uc) {
+    SessionStateUpdateCriteria* session_uc) {
   PolicyRule rule;
   bool removed = gy_dynamic_rules_.remove_rule(rule_id, &rule);
   if (!removed) {
     return {};
   }
-  if (rule_out != nullptr) {
+  if (rule_out) {
     *rule_out = rule;
   }
-  session_uc.gy_dynamic_rules_to_uninstall.insert(rule_id);
+  if (session_uc) {
+    session_uc->gy_dynamic_rules_to_uninstall.insert(rule_id);
+  }
 
   increment_rule_stats(rule_id, session_uc);
   return make_rule_to_process(rule);
 }
 
 optional<RuleToProcess> SessionState::deactivate_static_rule(
-    const std::string rule_id, SessionStateUpdateCriteria& session_uc) {
+    const std::string rule_id, SessionStateUpdateCriteria* session_uc) {
   auto it = std::find(
       active_static_rules_.begin(), active_static_rules_.end(), rule_id);
   if (it == active_static_rules_.end()) {
     return {};
   }
-
-  session_uc.static_rules_to_uninstall.insert(rule_id);
+  if (session_uc) {
+    session_uc->static_rules_to_uninstall.insert(rule_id);
+  }
   active_static_rules_.erase(it);
 
   increment_rule_stats(rule_id, session_uc);
@@ -1245,7 +1278,7 @@ void SessionState::process_static_rule_installs(
     // continue
     if (lifetime.exceeded_lifetime(current_time)) {
       optional<RuleToProcess> op_remove_info =
-          deactivate_static_rule(rule_id, *session_uc);
+          deactivate_static_rule(rule_id, session_uc);
       if (op_remove_info) {
         pending_deactivation->push_back(*op_remove_info);
       }
@@ -1254,13 +1287,13 @@ void SessionState::process_static_rule_installs(
     // If the rule should be active now, install
     if (lifetime.is_within_lifetime(current_time)) {
       RuleToProcess to_process =
-          activate_static_rule(rule_id, lifetime, *session_uc);
+          activate_static_rule(rule_id, lifetime, session_uc);
       classify_policy_activation(
           to_process, STATIC, pending_activation, pending_bearer_setup);
     }
     // If the rule is for future activation, schedule
     if (lifetime.before_lifetime(current_time)) {
-      schedule_static_rule(rule_id, lifetime, *session_uc);
+      schedule_static_rule(rule_id, lifetime, session_uc);
       pending_scheduling->push_back(
           RuleToSchedule(STATIC, rule_id, ACTIVATE, lifetime.activation_time));
     }
@@ -1288,7 +1321,7 @@ void SessionState::process_dynamic_rule_installs(
     // continue
     if (lifetime.exceeded_lifetime(current_time)) {
       optional<RuleToProcess> op_remove_info =
-          remove_dynamic_rule(rule_id, nullptr, *session_uc);
+          remove_dynamic_rule(rule_id, nullptr, session_uc);
       if (op_remove_info) {
         pending_deactivation->push_back(*op_remove_info);
       }
@@ -1297,13 +1330,13 @@ void SessionState::process_dynamic_rule_installs(
     // If the rule should be active now, install
     if (lifetime.is_within_lifetime(current_time)) {
       RuleToProcess to_process =
-          insert_dynamic_rule(dynamic_rule, lifetime, *session_uc);
+          insert_dynamic_rule(dynamic_rule, lifetime, session_uc);
       classify_policy_activation(
           to_process, DYNAMIC, pending_activation, pending_bearer_setup);
     }
     // If the rule is for future activation, schedule
     if (lifetime.before_lifetime(current_time)) {
-      schedule_dynamic_rule(dynamic_rule, lifetime, *session_uc);
+      schedule_dynamic_rule(dynamic_rule, lifetime, session_uc);
       pending_scheduling->push_back(
           RuleToSchedule(DYNAMIC, rule_id, ACTIVATE, lifetime.activation_time));
     }
@@ -1331,12 +1364,12 @@ void SessionState::process_rules_to_remove(
     PolicyRule rule;
     switch (*p_type) {
       case DYNAMIC: {
-        remove_info = remove_dynamic_rule(rule_id, &rule, *session_uc);
+        remove_info = remove_dynamic_rule(rule_id, &rule, session_uc);
         break;
       }
       case STATIC: {
         if (static_rules_.get_rule(rule_id, &rule)) {
-          remove_info = deactivate_static_rule(rule_id, *session_uc);
+          remove_info = deactivate_static_rule(rule_id, session_uc);
         }
         break;
       }
@@ -1352,7 +1385,7 @@ void SessionState::process_rules_to_remove(
 }
 
 void SessionState::sync_rules_to_time(
-    std::time_t current_time, SessionStateUpdateCriteria& session_uc) {
+    std::time_t current_time, SessionStateUpdateCriteria* session_uc) {
   // Update active static rules
   for (const std::string& rule_id : active_static_rules_) {
     if (should_rule_be_deactivated(rule_id, current_time)) {
@@ -1375,7 +1408,7 @@ void SessionState::sync_rules_to_time(
   dynamic_rules_.get_rule_ids(dynamic_rule_ids);
   for (const std::string& rule_id : dynamic_rule_ids) {
     if (should_rule_be_deactivated(rule_id, current_time)) {
-      remove_dynamic_rule(rule_id, NULL, session_uc);
+      remove_dynamic_rule(rule_id, nullptr, session_uc);
     }
   }
   // Update scheduled dynamic rules
@@ -1387,7 +1420,7 @@ void SessionState::sync_rules_to_time(
       remove_scheduled_dynamic_rule(rule_id, &dy_rule, session_uc);
       insert_dynamic_rule(dy_rule, rule_lifetimes_[rule_id], session_uc);
     } else if (should_rule_be_deactivated(rule_id, current_time)) {
-      remove_scheduled_dynamic_rule(rule_id, NULL, session_uc);
+      remove_scheduled_dynamic_rule(rule_id, nullptr, session_uc);
     }
   }
 }
@@ -1428,25 +1461,25 @@ uint32_t SessionState::total_monitored_rules_count() {
 }
 
 void SessionState::schedule_dynamic_rule(
-    const PolicyRule& rule, RuleLifetime& lifetime,
-    SessionStateUpdateCriteria& update_criteria) {
-  update_criteria.new_rule_lifetimes[rule.id()] = lifetime;
-  update_criteria.new_scheduled_dynamic_rules.push_back(rule);
+    const PolicyRule& rule, const RuleLifetime& lifetime,
+    SessionStateUpdateCriteria* session_uc) {
+  if (session_uc) {
+    session_uc->new_rule_lifetimes[rule.id()] = lifetime;
+    session_uc->new_scheduled_dynamic_rules.push_back(rule);
+  }
   rule_lifetimes_[rule.id()] = lifetime;
   scheduled_dynamic_rules_.insert_rule(rule);
 }
 
 void SessionState::schedule_static_rule(
-    const std::string& rule_id, RuleLifetime& lifetime,
-    SessionStateUpdateCriteria& update_criteria) {
-  update_criteria.new_rule_lifetimes[rule_id] = lifetime;
-  update_criteria.new_scheduled_static_rules.insert(rule_id);
+    const std::string& rule_id, const RuleLifetime& lifetime,
+    SessionStateUpdateCriteria* session_uc) {
+  if (session_uc) {
+    session_uc->new_rule_lifetimes[rule_id] = lifetime;
+    session_uc->new_scheduled_static_rules.insert(rule_id);
+  }
   rule_lifetimes_[rule_id] = lifetime;
   scheduled_static_rules_.insert(rule_id);
-}
-
-uint32_t SessionState::get_credit_key_count() {
-  return credit_map_.size() + monitor_map_.size();
 }
 
 bool SessionState::is_active() {
@@ -1454,23 +1487,25 @@ bool SessionState::is_active() {
 }
 
 void SessionState::set_fsm_state(
-    SessionFsmState new_state, SessionStateUpdateCriteria& uc) {
+    SessionFsmState new_state, SessionStateUpdateCriteria* session_uc) {
   // Only log and reflect change into update criteria if the state is new
   if (curr_state_ != new_state) {
     MLOG(MDEBUG) << "Session " << session_id_ << " Teid " << local_teid_
                  << " FSM state change from "
                  << session_fsm_state_to_str(curr_state_) << " to "
                  << session_fsm_state_to_str(new_state);
-    curr_state_          = new_state;
-    uc.is_fsm_updated    = true;
-    uc.updated_fsm_state = new_state;
+    curr_state_ = new_state;
+    if (session_uc) {
+      session_uc->is_fsm_updated    = true;
+      session_uc->updated_fsm_state = new_state;
+    }
   }
 }
 
 // Suspend the service due to all the remaining credits are transient.
 // Use the rg to trigger redirection
 void SessionState::suspend_service_if_needed_for_credit(
-    CreditKey ckey, SessionStateUpdateCriteria& update_criteria) {
+    CreditKey ckey, SessionStateUpdateCriteria* session_uc) {
   uint suspended_count = 0;
 
   auto it = credit_map_.find(ckey);
@@ -1485,7 +1520,7 @@ void SessionState::suspend_service_if_needed_for_credit(
   }
   if (credit_map_.size() > 0 && suspended_count == credit_map_.size()) {
     it->second->set_service_state(
-        SERVICE_NEEDS_SUSPENSION, get_credit_uc(ckey, update_criteria));
+        SERVICE_NEEDS_SUSPENSION, get_credit_uc(ckey, session_uc));
   }
 }
 
@@ -1564,7 +1599,7 @@ std::vector<PolicyRule> SessionState::get_all_final_unit_rules() {
 
 void SessionState::handle_update_failure(
     const UpdateRequests& failed_requests,
-    SessionStateUpdateCriteria& session_uc) {
+    SessionStateUpdateCriteria* session_uc) {
   MLOG(MDEBUG) << "Rolling back changes due to failed updates ("
                << failed_requests.charging_requests.size()
                << " charging requests and "
@@ -1593,7 +1628,7 @@ void SessionState::handle_update_failure(
 
 bool SessionState::receive_charging_credit(
     const CreditUpdateResponse& update,
-    SessionStateUpdateCriteria& session_uc) {
+    SessionStateUpdateCriteria* session_uc) {
   auto key = CreditKey(update);
 
   auto it = credit_map_.find(key);
@@ -1638,7 +1673,7 @@ bool SessionState::receive_charging_credit(
 
 bool SessionState::init_charging_credit(
     const CreditUpdateResponse& update,
-    SessionStateUpdateCriteria& session_uc) {
+    SessionStateUpdateCriteria* session_uc) {
   const uint32_t key = update.charging_key();
   if (ChargingGrant::is_valid_credit_response(update) == INVALID_CREDIT) {
     // init failed, don't track key
@@ -1647,8 +1682,10 @@ bool SessionState::init_charging_credit(
   ChargingGrant charging_grant;
   charging_grant.credit = SessionCredit(SERVICE_ENABLED, update.limit_type());
   charging_grant.receive_charging_grant(update);
-  session_uc.charging_credit_to_install[CreditKey(update)] =
-      charging_grant.marshal();
+  if (session_uc) {
+    session_uc->charging_credit_to_install[CreditKey(update)] =
+        charging_grant.marshal();
+  }
   credit_map_[CreditKey(update)] =
       std::make_unique<ChargingGrant>(charging_grant);
   MLOG(MINFO) << "Initialized a new credit RG:" << key << " for "
@@ -1658,12 +1695,12 @@ bool SessionState::init_charging_credit(
 
 void SessionState::set_suspend_credit(
     const CreditKey& charging_key, bool new_suspended,
-    SessionStateUpdateCriteria& update_criteria) {
+    SessionStateUpdateCriteria* session_uc) {
   auto it = credit_map_.find(charging_key);
   if (it != credit_map_.end()) {
     auto& grant = it->second;
     grant->set_suspended(
-        new_suspended, get_credit_uc(charging_key, update_criteria));
+        new_suspended, get_credit_uc(charging_key, session_uc));
   }
 }
 
@@ -1697,14 +1734,14 @@ void SessionState::get_rules_per_credit_key(
     // that the rule is activated for the session
     bool is_installed = is_static_rule_installed(rule.id());
     if (is_installed) {
-      increment_rule_stats(rule.id(), *session_uc);
+      increment_rule_stats(rule.id(), session_uc);
       to_process->push_back(make_rule_to_process(rule));
     }
   }
   dynamic_rules_.get_rule_definitions_for_charging_key(
       charging_key, dynamic_rules);
   for (PolicyRule rule : dynamic_rules) {
-    increment_rule_stats(rule.id(), *session_uc);
+    increment_rule_stats(rule.id(), session_uc);
     to_process->push_back(make_rule_to_process(rule));
   }
 }
@@ -1729,14 +1766,14 @@ bool SessionState::set_credit_reporting(
   }
 
   it->second->credit.set_reporting(reporting);
-  if (session_uc != nullptr) {
-    get_credit_uc(key, *session_uc)->reporting = reporting;
+  if (session_uc) {
+    get_credit_uc(key, session_uc)->reporting = reporting;
   }
   return true;
 }
 
 ReAuthResult SessionState::reauth_key(
-    const CreditKey& charging_key, SessionStateUpdateCriteria& session_uc) {
+    const CreditKey& charging_key, SessionStateUpdateCriteria* session_uc) {
   auto it = credit_map_.find(charging_key);
   if (it != credit_map_.end()) {
     // if credit is already reporting, don't initiate update
@@ -1753,21 +1790,21 @@ ReAuthResult SessionState::reauth_key(
   grant->credit        = SessionCredit(SERVICE_DISABLED);
   grant->reauth_state  = REAUTH_REQUIRED;
   grant->service_state = SERVICE_DISABLED;
-  session_uc.charging_credit_to_install[charging_key] = grant->marshal();
-  credit_map_[charging_key]                           = std::move(grant);
+  if (session_uc) {
+    session_uc->charging_credit_to_install[charging_key] = grant->marshal();
+  }
+  credit_map_[charging_key] = std::move(grant);
   return ReAuthResult::UPDATE_INITIATED;
 }
 
-ReAuthResult SessionState::reauth_all(
-    SessionStateUpdateCriteria& update_criteria) {
+ReAuthResult SessionState::reauth_all(SessionStateUpdateCriteria* session_uc) {
   auto res = ReAuthResult::UPDATE_NOT_NEEDED;
   for (auto& credit_pair : credit_map_) {
     auto key    = credit_pair.first;
     auto& grant = credit_pair.second;
     // Only update credits that aren't reporting
     if (!grant->credit.is_reporting()) {
-      grant->set_reauth_state(
-          REAUTH_REQUIRED, get_credit_uc(key, update_criteria));
+      grant->set_reauth_state(REAUTH_REQUIRED, get_credit_uc(key, session_uc));
       res = ReAuthResult::UPDATE_INITIATED;
     }
   }
@@ -1775,7 +1812,7 @@ ReAuthResult SessionState::reauth_all(
 }
 
 void SessionState::apply_charging_credit_update(
-    const CreditKey& key, SessionCreditUpdateCriteria& credit_uc) {
+    const CreditKey& key, const SessionCreditUpdateCriteria& credit_uc) {
   auto it = credit_map_.find(key);
   if (it == credit_map_.end()) {
     return;
@@ -1800,13 +1837,6 @@ void SessionState::apply_charging_credit_update(
   charging_grant->reauth_state      = credit_uc.reauth_state;
   charging_grant->service_state     = credit_uc.service_state;
   charging_grant->suspended         = credit_uc.suspended;
-}
-
-void SessionState::set_charging_credit(
-    const CreditKey& key, ChargingGrant charging_grant,
-    SessionStateUpdateCriteria& uc) {
-  credit_map_[key] = std::make_unique<ChargingGrant>(charging_grant);
-  uc.charging_credit_to_install[key] = credit_map_[key]->marshal();
 }
 
 CreditUsageUpdate SessionState::make_credit_usage_update_req(
@@ -1836,25 +1866,25 @@ CreditUsageUpdate SessionState::make_credit_usage_update_req(
 }
 
 void SessionState::get_charging_updates(
-    UpdateSessionRequest& update_request_out,
+    UpdateSessionRequest* update_request_out,
     std::vector<std::unique_ptr<ServiceAction>>* actions_out,
-    SessionStateUpdateCriteria& uc) {
+    SessionStateUpdateCriteria* session_uc) {
   for (auto& credit_pair : credit_map_) {
     auto& key                              = credit_pair.first;
     auto& grant                            = credit_pair.second;
-    SessionCreditUpdateCriteria* credit_uc = get_credit_uc(key, uc);
+    SessionCreditUpdateCriteria* credit_uc = get_credit_uc(key, session_uc);
 
     auto action_type = grant->get_action(credit_uc);
     auto action      = std::make_unique<ServiceAction>(action_type);
     switch (action_type) {
       case CONTINUE_SERVICE: {
         optional<CreditUsageUpdate> op_update =
-            get_update_for_continue_service(key, grant, uc);
+            get_update_for_continue_service(key, grant, session_uc);
         if (!op_update) {
           // no update
           break;
         }
-        update_request_out.mutable_updates()->Add()->CopyFrom(*op_update);
+        update_request_out->mutable_updates()->Add()->CopyFrom(*op_update);
       } break;
       case REDIRECT: {
         if (grant->service_state == SERVICE_REDIRECTED) {
@@ -1863,10 +1893,10 @@ void SessionState::get_charging_updates(
         }
         grant->set_service_state(SERVICE_REDIRECTED, credit_uc);
 
-        PolicyRule redirect_rule = make_redirect_rule(grant);
+        PolicyRule redirect_rule = grant->make_redirect_rule();
         if (!is_gy_dynamic_rule_installed(redirect_rule.id())) {
           fill_service_action_for_redirect(
-              action, key, grant, redirect_rule, uc);
+              action, key, grant, redirect_rule, session_uc);
           actions_out->push_back(std::move(action));
         }
 
@@ -1879,12 +1909,12 @@ void SessionState::get_charging_updates(
         }
         grant->set_service_state(SERVICE_RESTRICTED, credit_uc);
 
-        fill_service_action_for_restrict(action, key, grant, uc);
+        fill_service_action_for_restrict(action, key, grant, session_uc);
         actions_out->push_back(std::move(action));
         break;
       }
       case ACTIVATE_SERVICE:
-        fill_service_action_for_activate(action, key, uc);
+        fill_service_action_for_activate(action, key, session_uc);
         actions_out->push_back(std::move(action));
         grant->set_suspended(false, credit_uc);
         break;
@@ -1903,7 +1933,7 @@ void SessionState::get_charging_updates(
 
 optional<CreditUsageUpdate> SessionState::get_update_for_continue_service(
     const CreditKey& key, std::unique_ptr<ChargingGrant>& grant,
-    SessionStateUpdateCriteria& session_uc) {
+    SessionStateUpdateCriteria* session_uc) {
   CreditUsage::UpdateType update_type;
   if (!grant->get_update_type(&update_type)) {
     return {};  // no update
@@ -1936,13 +1966,15 @@ optional<CreditUsageUpdate> SessionState::get_update_for_continue_service(
 
   auto request = make_credit_usage_update_req(usage);
   request_number_++;
-  session_uc.request_number_increment++;
+  if (session_uc) {
+    session_uc->request_number_increment++;
+  }
   return request;
 }
 
 void SessionState::fill_service_action_for_activate(
     std::unique_ptr<ServiceAction>& action_p, const CreditKey& key,
-    SessionStateUpdateCriteria& session_uc) {
+    SessionStateUpdateCriteria* session_uc) {
   std::vector<PolicyRule> static_rules, dynamic_rules;
   fill_service_action_with_context(action_p, ACTIVATE_SERVICE, key);
   static_rules_.get_rules_by_ids(active_static_rules_, static_rules);
@@ -1963,7 +1995,7 @@ void SessionState::fill_service_action_for_activate(
 void SessionState::fill_service_action_for_restrict(
     std::unique_ptr<ServiceAction>& action_p, const CreditKey& key,
     std::unique_ptr<ChargingGrant>& grant,
-    SessionStateUpdateCriteria& session_uc) {
+    SessionStateUpdateCriteria* session_uc) {
   fill_service_action_with_context(action_p, RESTRICT_ACCESS, key);
 
   RulesToProcess* gy_to_install = action_p->get_mutable_gy_rules_to_install();
@@ -1979,43 +2011,10 @@ void SessionState::fill_service_action_for_restrict(
   }
 }
 
-// TODO: make session_manager.proto and policydb.proto to use common field
-static RedirectInformation_AddressType address_type_converter(
-    RedirectServer_RedirectAddressType address_type) {
-  switch (address_type) {
-    case RedirectServer_RedirectAddressType_IPV4:
-      return RedirectInformation_AddressType_IPv4;
-    case RedirectServer_RedirectAddressType_IPV6:
-      return RedirectInformation_AddressType_IPv6;
-    case RedirectServer_RedirectAddressType_URL:
-      return RedirectInformation_AddressType_URL;
-    case RedirectServer_RedirectAddressType_SIP_URI:
-      return RedirectInformation_AddressType_SIP_URI;
-    default:
-      MLOG(MERROR) << "Unknown redirect address type!";
-      return RedirectInformation_AddressType_IPv4;
-  }
-}
-
-PolicyRule SessionState::make_redirect_rule(
-    std::unique_ptr<ChargingGrant>& grant) {
-  PolicyRule redirect_rule;
-  redirect_rule.set_id("redirect");
-  redirect_rule.set_priority(SessionState::REDIRECT_FLOW_PRIORITY);
-  RedirectInformation* redirect_info = redirect_rule.mutable_redirect();
-  redirect_info->set_support(RedirectInformation_Support_ENABLED);
-
-  auto redirect_server = grant->final_action_info.redirect_server;
-  redirect_info->set_address_type(
-      address_type_converter(redirect_server.redirect_address_type()));
-  redirect_info->set_server_address(redirect_server.redirect_server_address());
-  return redirect_rule;
-}
-
 void SessionState::fill_service_action_for_redirect(
     std::unique_ptr<ServiceAction>& action_p, const CreditKey& key,
     std::unique_ptr<ChargingGrant>& grant, PolicyRule redirect_rule,
-    SessionStateUpdateCriteria& session_uc) {
+    SessionStateUpdateCriteria* session_uc) {
   fill_service_action_with_context(action_p, REDIRECT, key);
 
   RulesToProcess* gy_to_install = action_p->get_mutable_gy_rules_to_install();
@@ -2041,7 +2040,7 @@ void SessionState::fill_service_action_with_context(
 // Monitors
 bool SessionState::receive_monitor(
     const UsageMonitoringUpdateResponse& update,
-    SessionStateUpdateCriteria& session_uc) {
+    SessionStateUpdateCriteria* session_uc) {
   if (!update.has_credit()) {
     // We are overloading UsageMonitoringUpdateResponse/Request with other
     // EventTriggered requests, so we could receive updates that don't affect
@@ -2057,9 +2056,10 @@ bool SessionState::receive_monitor(
   auto mkey = update.credit().monitoring_key();
   auto it   = monitor_map_.find(mkey);
 
-  if (session_uc.monitor_credit_map.find(mkey) !=
-          session_uc.monitor_credit_map.end() &&
-      session_uc.monitor_credit_map[mkey].deleted) {
+  if (session_uc &&
+      session_uc->monitor_credit_map.find(mkey) !=
+          session_uc->monitor_credit_map.end() &&
+      session_uc->monitor_credit_map[mkey].deleted) {
     // This will only happen if the PCRF responds back with more credit when
     // the monitor has already been set to be terminated
     MLOG(MDEBUG) << session_id_ << "Ignoring  update for monitor " << mkey
@@ -2102,8 +2102,7 @@ bool SessionState::receive_monitor(
 }
 
 void SessionState::apply_monitor_updates(
-    const std::string& key, SessionStateUpdateCriteria& session_uc,
-    SessionCreditUpdateCriteria& credit_uc) {
+    const std::string& key, const SessionCreditUpdateCriteria& credit_uc) {
   auto it = monitor_map_.find(key);
   if (it == monitor_map_.end()) {
     return;
@@ -2114,8 +2113,7 @@ void SessionState::apply_monitor_updates(
     if (it->second->level == MonitoringLevel::SESSION_LEVEL) {
       // session level change
       MLOG(MINFO) << "Removing Session Level monitor " << key;
-      session_uc.is_session_level_key_updated = true;
-      session_uc.updated_session_level_key    = "";
+      session_level_key_ = "";
     }
     MLOG(MINFO) << session_id_ << " Erasing monitor " << key;
     monitor_map_.erase(key);
@@ -2140,7 +2138,7 @@ uint64_t SessionState::get_monitor(
 
 bool SessionState::set_monitor_reporting(
     const std::string& key, bool reporting,
-    SessionStateUpdateCriteria* update_criteria) {
+    SessionStateUpdateCriteria* session_uc) {
   auto it = monitor_map_.find(key);
   if (it == monitor_map_.end()) {
     MLOG(MWARNING) << "Didn't set reporting flag for monitor key " << key;
@@ -2149,8 +2147,8 @@ bool SessionState::set_monitor_reporting(
 
   it->second->credit.set_reporting(reporting);
 
-  if (update_criteria != NULL) {
-    auto mon_credit_uc       = get_monitor_uc(key, *update_criteria);
+  if (session_uc != nullptr) {
+    auto mon_credit_uc       = get_monitor_uc(key, session_uc);
     mon_credit_uc->reporting = reporting;
   }
   return true;
@@ -2158,7 +2156,7 @@ bool SessionState::set_monitor_reporting(
 
 bool SessionState::add_to_monitor(
     const std::string& key, uint64_t used_tx, uint64_t used_rx,
-    SessionStateUpdateCriteria& uc) {
+    SessionStateUpdateCriteria* session_uc) {
   auto it = monitor_map_.find(key);
   if (it == monitor_map_.end()) {
     MLOG(MDEBUG) << "Monitoring Key " << key
@@ -2166,7 +2164,7 @@ bool SessionState::add_to_monitor(
     return false;
   }
 
-  auto credit_uc = get_monitor_uc(key, uc);
+  auto credit_uc = get_monitor_uc(key, session_uc);
 
   it->second->credit.add_used_credit(used_tx, used_rx, credit_uc);
 
@@ -2181,14 +2179,16 @@ bool SessionState::add_to_monitor(
 
 void SessionState::set_monitor(
     const std::string& key, Monitor monitor,
-    SessionStateUpdateCriteria& update_criteria) {
-  update_criteria.monitor_credit_to_install[key] = monitor.marshal();
+    SessionStateUpdateCriteria* session_uc) {
+  if (session_uc) {
+    session_uc->monitor_credit_to_install[key] = monitor.marshal();
+  }
   monitor_map_[key] = std::make_unique<Monitor>(monitor);
 }
 
 bool SessionState::init_new_monitor(
     const UsageMonitoringUpdateResponse& update,
-    SessionStateUpdateCriteria& update_criteria) {
+    SessionStateUpdateCriteria* session_uc) {
   if (!update.success()) {
     MLOG(MERROR) << "Monitoring init failed for imsi " << get_imsi()
                  << " and monitoring key " << update.credit().monitoring_key();
@@ -2207,17 +2207,19 @@ bool SessionState::init_new_monitor(
   // validity time and final units not used for monitors
   auto _   = SessionCreditUpdateCriteria{};
   auto gsu = update.credit().granted_units();
-  monitor->credit.receive_credit(gsu, NULL);
+  monitor->credit.receive_credit(gsu, nullptr);
 
-  update_criteria.monitor_credit_to_install[update.credit().monitoring_key()] =
-      monitor->marshal();
+  if (session_uc) {
+    session_uc->monitor_credit_to_install[update.credit().monitoring_key()] =
+        monitor->marshal();
+  }
   monitor_map_[update.credit().monitoring_key()] = std::move(monitor);
   return true;
 }
 
 void SessionState::update_session_level_key(
     const UsageMonitoringUpdateResponse& update,
-    SessionStateUpdateCriteria& uc) {
+    SessionStateUpdateCriteria* session_uc) {
   const auto& new_key = update.credit().monitoring_key();
   if (session_level_key_ != "" && session_level_key_ != new_key) {
     MLOG(MINFO) << "Session level monitoring key is updated from "
@@ -2228,12 +2230,16 @@ void SessionState::update_session_level_key(
   } else {
     session_level_key_ = new_key;
   }
-  uc.is_session_level_key_updated = true;
-  uc.updated_session_level_key    = session_level_key_;
+  set_session_level_key(new_key, session_uc);
 }
 
-void SessionState::set_session_level_key(const std::string new_key) {
+void SessionState::set_session_level_key(
+    const std::string new_key, SessionStateUpdateCriteria* session_uc) {
   session_level_key_ = new_key;
+  if (session_uc) {
+    session_uc->is_session_level_key_updated = true;
+    session_uc->updated_session_level_key    = session_level_key_;
+  }
 }
 
 BearerUpdate SessionState::get_dedicated_bearer_updates(
@@ -2262,13 +2268,14 @@ BearerUpdate SessionState::get_dedicated_bearer_updates(
     } else {
       p_type = DYNAMIC;
     }
-    update_bearer_deletion_req(p_type, rule_id, update, *session_uc);
+    update_bearer_deletion_req(p_type, rule_id, &update, session_uc);
   }
   return update;
 }
 
 void SessionState::bind_policy_to_bearer(
-    const PolicyBearerBindingRequest& request, SessionStateUpdateCriteria& uc) {
+    const PolicyBearerBindingRequest& request,
+    SessionStateUpdateCriteria* session_uc) {
   const std::string& rule_id = request.policy_rule_id();
   auto policy_type           = get_policy_type(rule_id);
   if (!policy_type) {
@@ -2283,8 +2290,10 @@ void SessionState::bind_policy_to_bearer(
   brearer_id_and_teid.bearer_id                         = request.bearer_id();
   brearer_id_and_teid.teids                             = request.teids();
   bearer_id_by_policy_[PolicyID(*policy_type, rule_id)] = brearer_id_and_teid;
-  uc.is_bearer_mapping_updated                          = true;
-  uc.bearer_id_by_policy                                = bearer_id_by_policy_;
+  if (session_uc) {
+    session_uc->is_bearer_mapping_updated = true;
+    session_uc->bearer_id_by_policy       = bearer_id_by_policy_;
+  }
 }
 
 optional<PolicyType> SessionState::get_policy_type(const std::string& rule_id) {
@@ -2314,46 +2323,50 @@ optional<PolicyRule> SessionState::get_policy_definition(
 }
 
 SessionCreditUpdateCriteria* SessionState::get_monitor_uc(
-    const std::string& key, SessionStateUpdateCriteria& uc) {
-  if (uc.monitor_credit_map.find(key) == uc.monitor_credit_map.end()) {
-    uc.monitor_credit_map[key] =
+    const std::string& key, SessionStateUpdateCriteria* session_uc) {
+  if (!session_uc) {
+    return nullptr;
+  }
+  if (session_uc->monitor_credit_map.find(key) ==
+      session_uc->monitor_credit_map.end()) {
+    session_uc->monitor_credit_map[key] =
         monitor_map_[key]->credit.get_update_criteria();
   }
-  return &(uc.monitor_credit_map[key]);
+  return &(session_uc->monitor_credit_map[key]);
 }
 
 // Event Triggers
 void SessionState::get_event_trigger_updates(
-    UpdateSessionRequest& update_request_out,
-    SessionStateUpdateCriteria& update_criteria) {
+    UpdateSessionRequest* update_request_out,
+    SessionStateUpdateCriteria* session_uc) {
   // todo We should also handle other event triggers here too
   auto it = pending_event_triggers_.find(REVALIDATION_TIMEOUT);
   if (it != pending_event_triggers_.end() && it->second == READY) {
     MLOG(MDEBUG) << "Session " << session_id_
                  << " updating due to EventTrigger: REVALIDATION_TIMEOUT"
                  << " with request number " << request_number_;
-    auto new_req = update_request_out.mutable_usage_monitors()->Add();
+    auto new_req = update_request_out->mutable_usage_monitors()->Add();
     add_common_fields_to_usage_monitor_update(new_req);
     new_req->set_event_trigger(REVALIDATION_TIMEOUT);
     request_number_++;
-    update_criteria.request_number_increment++;
+    if (session_uc) {
+      session_uc->request_number_increment++;
+    }
     // todo we might want to make sure that the update went successfully
     // before clearing here
-    remove_event_trigger(REVALIDATION_TIMEOUT, update_criteria);
+    remove_event_trigger(REVALIDATION_TIMEOUT, session_uc);
   }
 }
 
 void SessionState::add_new_event_trigger(
-    magma::lte::EventTrigger trigger,
-    SessionStateUpdateCriteria& update_criteria) {
+    magma::lte::EventTrigger trigger, SessionStateUpdateCriteria* session_uc) {
   MLOG(MINFO) << "Event Trigger " << trigger << " is pending for "
               << session_id_;
-  set_event_trigger(trigger, PENDING, update_criteria);
+  set_event_trigger(trigger, PENDING, session_uc);
 }
 
 void SessionState::mark_event_trigger_as_triggered(
-    magma::lte::EventTrigger trigger,
-    SessionStateUpdateCriteria& update_criteria) {
+    magma::lte::EventTrigger trigger, SessionStateUpdateCriteria* session_uc) {
   auto it = pending_event_triggers_.find(trigger);
   if (it == pending_event_triggers_.end() ||
       pending_event_triggers_[trigger] != PENDING) {
@@ -2362,31 +2375,34 @@ void SessionState::mark_event_trigger_as_triggered(
   }
   MLOG(MINFO) << "Event Trigger " << trigger << " is ready to update for "
               << session_id_;
-  set_event_trigger(trigger, READY, update_criteria);
+  set_event_trigger(trigger, READY, session_uc);
 }
 
 void SessionState::remove_event_trigger(
-    magma::lte::EventTrigger trigger,
-    SessionStateUpdateCriteria& update_criteria) {
+    magma::lte::EventTrigger trigger, SessionStateUpdateCriteria* session_uc) {
   MLOG(MINFO) << "Event Trigger " << trigger << " is removed for "
               << session_id_;
   pending_event_triggers_.erase(trigger);
-  set_event_trigger(trigger, CLEARED, update_criteria);
+  set_event_trigger(trigger, CLEARED, session_uc);
 }
 
 void SessionState::set_event_trigger(
     magma::lte::EventTrigger trigger, const EventTriggerState value,
-    SessionStateUpdateCriteria& update_criteria) {
-  pending_event_triggers_[trigger]                  = value;
-  update_criteria.is_pending_event_triggers_updated = true;
-  update_criteria.pending_event_triggers[trigger]   = value;
+    SessionStateUpdateCriteria* session_uc) {
+  pending_event_triggers_[trigger] = value;
+  if (session_uc) {
+    session_uc->is_pending_event_triggers_updated = true;
+    session_uc->pending_event_triggers[trigger]   = value;
+  }
 }
 
 void SessionState::set_revalidation_time(
     const google::protobuf::Timestamp& time,
-    SessionStateUpdateCriteria& update_criteria) {
-  revalidation_time_                = time;
-  update_criteria.revalidation_time = time;
+    SessionStateUpdateCriteria* session_uc) {
+  revalidation_time_ = time;
+  if (session_uc) {
+    session_uc->revalidation_time = time;
+  }
 }
 
 optional<FinalActionInfo> SessionState::get_final_action_if_final_unit_state(
@@ -2404,7 +2420,7 @@ optional<FinalActionInfo> SessionState::get_final_action_if_final_unit_state(
 
 RulesToProcess SessionState::remove_all_final_action_rules(
     const FinalActionInfo& final_action_info,
-    SessionStateUpdateCriteria& session_uc) {
+    SessionStateUpdateCriteria* session_uc) {
   RulesToProcess to_process;
   to_process = std::vector<RuleToProcess>{};
   switch (final_action_info.final_action) {
@@ -2495,7 +2511,7 @@ void SessionState::update_bearer_creation_req(
 
 void SessionState::update_bearer_deletion_req(
     const PolicyType policy_type, const std::string& rule_id,
-    BearerUpdate& update, SessionStateUpdateCriteria& uc) {
+    BearerUpdate* update, SessionStateUpdateCriteria* session_uc) {
   if (!config_.rat_specific_context.has_lte_context()) {
     return;
   }
@@ -2507,20 +2523,23 @@ void SessionState::update_bearer_deletion_req(
   const BearerIDAndTeid bearer_id_to_delete =
       bearer_id_by_policy_[PolicyID(policy_type, rule_id)];
   bearer_id_by_policy_.erase(PolicyID(policy_type, rule_id));
-  uc.is_bearer_mapping_updated = true;
-  uc.bearer_id_by_policy       = bearer_id_by_policy_;
+
+  if (session_uc) {
+    session_uc->is_bearer_mapping_updated = true;
+    session_uc->bearer_id_by_policy       = bearer_id_by_policy_;
+  }
 
   // If it is first time filling in the DeletionReq, fill in other info
-  if (!update.needs_deletion) {
-    update.needs_deletion = true;
-    auto& req             = update.delete_req;
+  if (!update->needs_deletion) {
+    update->needs_deletion = true;
+    auto& req              = update->delete_req;
     req.mutable_sid()->CopyFrom(config_.common_context.sid());
     req.set_ip_addr(config_.common_context.ue_ipv4());
     // TODO ipv6 add to the bearer request or remove ipv4
     req.set_link_bearer_id(
         config_.rat_specific_context.lte_context().bearer_id());
   }
-  update.delete_req.mutable_eps_bearer_ids()->Add(
+  update->delete_req.mutable_eps_bearer_ids()->Add(
       bearer_id_to_delete.bearer_id);
 }
 
@@ -2598,7 +2617,7 @@ void SessionState::update_data_metrics(
       DIRECTION_DOWN);
 }
 
-void SessionState::clear_session_metrics() {
+void SessionState::clear_session_metrics() const {
   const auto imsi   = get_config().common_context.sid().id();
   const auto msisdn = get_config().common_context.msisdn();
   const auto apn    = get_config().common_context.apn();
@@ -2654,7 +2673,7 @@ uint32_t SessionState::get_current_rule_version(const std::string& rule_id) {
 }
 
 void SessionState::increment_rule_stats(
-    const std::string& rule_id, SessionStateUpdateCriteria& session_uc) {
+    const std::string& rule_id, SessionStateUpdateCriteria* session_uc) {
   if (policy_version_and_stats_.find(rule_id) ==
       policy_version_and_stats_.end()) {
     policy_version_and_stats_[rule_id] = StatsPerPolicy();
@@ -2664,8 +2683,8 @@ void SessionState::increment_rule_stats(
       .stats_map[policy_version_and_stats_[rule_id].current_version] =
       RuleStats();
 
-  if (!session_uc.policy_version_and_stats) {
-    session_uc.policy_version_and_stats = policy_version_and_stats_;
+  if (session_uc && !session_uc->policy_version_and_stats) {
+    session_uc->policy_version_and_stats = policy_version_and_stats_;
   }
 }
 

--- a/lte/gateway/c/session_manager/SessionState.h
+++ b/lte/gateway/c/session_manager/SessionState.h
@@ -155,7 +155,7 @@ class SessionState {
   uint32_t get_current_version();
 
   void set_current_version(
-      int new_session_version, SessionStateUpdateCriteria& uc);
+      int new_session_version, SessionStateUpdateCriteria* session_uc);
 
   void insert_pdr(SetGroupPDR* rule);
 
@@ -177,7 +177,7 @@ class SessionState {
    *       in time.
    */
   void sync_rules_to_time(
-      std::time_t current_time, SessionStateUpdateCriteria& update_criteria);
+      std::time_t current_time, SessionStateUpdateCriteria* session_uc);
 
   /**
    * add_rule_usage adds used TX/RX bytes to a particular rule
@@ -186,7 +186,7 @@ class SessionState {
   void add_rule_usage(
       const std::string& rule_id, uint64_t version, uint64_t used_tx,
       uint64_t used_rx, uint64_t dropped_tx, uint64_t dropped_rx,
-      SessionStateUpdateCriteria& update_criteria);
+      SessionStateUpdateCriteria* session_uc);
 
   /**
    * get_updates collects updates and adds them to a UpdateSessionRequest
@@ -196,9 +196,9 @@ class SessionState {
    * @param actions (out) - actions to take on services
    */
   void get_updates(
-      UpdateSessionRequest& update_request_out,
+      UpdateSessionRequest* update_request_out,
       std::vector<std::unique_ptr<ServiceAction>>* actions_out,
-      SessionStateUpdateCriteria& update_criteria);
+      SessionStateUpdateCriteria* session_uc);
 
   bool is_terminating();
 
@@ -208,11 +208,11 @@ class SessionState {
    * anything.
    * This function will return true if the termination happened successfully.
    */
-  bool can_complete_termination(SessionStateUpdateCriteria& update_criteria);
+  bool can_complete_termination(SessionStateUpdateCriteria* session_uc);
 
   void handle_update_failure(
       const UpdateRequests& failed_requests,
-      SessionStateUpdateCriteria& session_uc);
+      SessionStateUpdateCriteria* session_uc);
 
   /**
    * Receive the credit grant if the credit update was successful
@@ -225,23 +225,18 @@ class SessionState {
    */
   bool receive_charging_credit(
       const CreditUpdateResponse& update,
-      SessionStateUpdateCriteria& session_uc);
+      SessionStateUpdateCriteria* session_uc);
 
   uint64_t get_charging_credit(const CreditKey& key, Bucket bucket) const;
 
   bool set_credit_reporting(
       const CreditKey& key, bool reporting,
-      SessionStateUpdateCriteria* update_criteria);
+      SessionStateUpdateCriteria* session_uc);
 
   ReAuthResult reauth_key(
-      const CreditKey& charging_key,
-      SessionStateUpdateCriteria& update_criteria);
+      const CreditKey& charging_key, SessionStateUpdateCriteria* session_uc);
 
-  ReAuthResult reauth_all(SessionStateUpdateCriteria& update_criteria);
-
-  void set_charging_credit(
-      const CreditKey& key, ChargingGrant charging_grant,
-      SessionStateUpdateCriteria& uc);
+  ReAuthResult reauth_all(SessionStateUpdateCriteria* session_uc);
 
   std::vector<PolicyRule> get_all_final_unit_rules();
 
@@ -260,17 +255,23 @@ class SessionState {
   std::string get_session_id() const { return session_id_; }
 
   uint32_t get_local_teid() const;
-  void set_local_teid(uint32_t teid, SessionStateUpdateCriteria& uc);
+
+  void set_local_teid(uint32_t teid, SessionStateUpdateCriteria* session_uc);
 
   SubscriberQuotaUpdate_Type get_subscriber_quota_state() const;
 
   bool is_radius_cwf_session() const;
 
-  void get_session_info(SessionState::SessionInfo& info);
+  /**
+   * @brief Get the session info object
+   *
+   * @return SessionState::SessionInfo
+   */
+  SessionState::SessionInfo get_session_info();
 
   void set_tgpp_context(
       const magma::lte::TgppContext& tgpp_context,
-      SessionStateUpdateCriteria& update_criteria);
+      SessionStateUpdateCriteria* session_uc);
 
   void set_config(const SessionConfig& config);
 
@@ -278,7 +279,7 @@ class SessionState {
 
   void set_subscriber_quota_state(
       const magma::lte::SubscriberQuotaUpdate_Type state,
-      SessionStateUpdateCriteria* update_criteria);
+      SessionStateUpdateCriteria* session_uc);
 
   bool active_monitored_rules_exist();
 
@@ -286,7 +287,7 @@ class SessionState {
 
   uint64_t get_pdp_start_time();
 
-  void set_pdp_end_time(uint64_t epoch, SessionStateUpdateCriteria& session_uc);
+  void set_pdp_end_time(uint64_t epoch, SessionStateUpdateCriteria* session_uc);
 
   uint64_t get_pdp_end_time();
 
@@ -295,7 +296,7 @@ class SessionState {
   void increment_request_number(uint32_t incr);
 
   SessionTerminateRequest make_termination_request(
-      SessionStateUpdateCriteria& uc);
+      SessionStateUpdateCriteria* session_uc);
 
   CreateSessionResponse get_create_session_response();
 
@@ -337,12 +338,12 @@ class SessionState {
    *
    * @param rule
    * @param lifetime
-   * @param session_uc
+   * @param session_uc optional output parameter
    * @return RuleToProcess
    */
   RuleToProcess insert_dynamic_rule(
-      const PolicyRule& rule, RuleLifetime& lifetime,
-      SessionStateUpdateCriteria& session_uc);
+      const PolicyRule& rule, const RuleLifetime& lifetime,
+      SessionStateUpdateCriteria* session_uc);
 
   /**
    * @brief Insert a static rule into active_static_rules_. Increment the
@@ -350,30 +351,30 @@ class SessionState {
    *
    * @param rule_id
    * @param lifetime
-   * @param session_uc
+   * @param session_uc optional output parameter
    * @return RuleToProcess
    */
   RuleToProcess activate_static_rule(
-      const std::string& rule_id, RuleLifetime& lifetime,
-      SessionStateUpdateCriteria& session_uc);
+      const std::string& rule_id, const RuleLifetime& lifetime,
+      SessionStateUpdateCriteria* session_uc);
   /**
    * @brief Insert a PolicyRule into gy_dynamic_rules_
    *
    * @param rule
    * @param lifetime
-   * @param update_criteria
+   * @param session_uc optional output parameter
    * @return RuleToProcess
    */
   RuleToProcess insert_gy_rule(
-      const PolicyRule& rule, RuleLifetime& lifetime,
-      SessionStateUpdateCriteria& session_uc);
+      const PolicyRule& rule, const RuleLifetime& lifetime,
+      SessionStateUpdateCriteria* session_uc);
 
   /**
    * Remove a currently active dynamic rule to mark it as deactivated.
    *
    * @param rule_id ID of the rule to be removed.
    * @param rule_out Will point to the removed rule if it is not nullptr
-   * @param update_criteria Tracks updates to the session. To be passed back to
+   * @param session_uc Tracks updates to the session. To be passed back to
    *                        the SessionStore to resolve issues of concurrent
    *                        updates to a session.
    * @return optional<RuleToProcess> updated RuleToProcess if success, {} if
@@ -381,11 +382,11 @@ class SessionState {
    */
   optional<RuleToProcess> remove_dynamic_rule(
       const std::string& rule_id, PolicyRule* rule_out,
-      SessionStateUpdateCriteria& update_criteria);
+      SessionStateUpdateCriteria* session_uc);
 
   bool remove_scheduled_dynamic_rule(
       const std::string& rule_id, PolicyRule* rule_out,
-      SessionStateUpdateCriteria& update_criteria);
+      SessionStateUpdateCriteria* session_uc);
 
   /**
    * @brief Remove a Gy rule from SessionState and increment the corresponding
@@ -398,7 +399,7 @@ class SessionState {
    */
   optional<RuleToProcess> remove_gy_rule(
       const std::string& rule_id, PolicyRule* rule_out,
-      SessionStateUpdateCriteria& session_uc);
+      SessionStateUpdateCriteria* session_uc);
 
   /**
    * Remove a currently active static rule to mark it as deactivated.
@@ -410,7 +411,7 @@ class SessionState {
    * @return RuleToProcess if successfully removed. otherwise returns {}
    */
   optional<RuleToProcess> deactivate_static_rule(
-      const std::string rule_id, SessionStateUpdateCriteria& session_uc);
+      const std::string rule_id, SessionStateUpdateCriteria* session_uc);
 
   bool deactivate_scheduled_static_rule(const std::string& rule_id);
 
@@ -428,8 +429,8 @@ class SessionState {
    * Schedule a dynamic rule for activation in the future.
    */
   void schedule_dynamic_rule(
-      const PolicyRule& rule, RuleLifetime& lifetime,
-      SessionStateUpdateCriteria& update_criteria);
+      const PolicyRule& rule, const RuleLifetime& lifetime,
+      SessionStateUpdateCriteria* session_uc);
 
   bool is_static_rule_scheduled(const std::string& rule_id);
 
@@ -437,12 +438,12 @@ class SessionState {
    * Schedule a static rule for activation in the future.
    */
   void schedule_static_rule(
-      const std::string& rule_id, RuleLifetime& lifetime,
-      SessionStateUpdateCriteria& update_criteria);
+      const std::string& rule_id, const RuleLifetime& lifetime,
+      SessionStateUpdateCriteria* session_uc);
 
   void set_suspend_credit(
       const CreditKey& charging_key, bool new_suspended,
-      SessionStateUpdateCriteria& update_criteria);
+      SessionStateUpdateCriteria* session_uc);
 
   bool is_credit_suspended(const CreditKey& charging_key);
 
@@ -456,9 +457,8 @@ class SessionState {
 
   bool is_active();
 
-  uint32_t get_credit_key_count();
-
-  void set_fsm_state(SessionFsmState new_state, SessionStateUpdateCriteria& uc);
+  void set_fsm_state(
+      SessionFsmState new_state, SessionStateUpdateCriteria* session_uc);
 
   StaticRuleInstall get_static_rule_install(
       const std::string& rule_id, const RuleLifetime& lifetime);
@@ -466,7 +466,7 @@ class SessionState {
   DynamicRuleInstall get_dynamic_rule_install(
       const std::string& rule_id, const RuleLifetime& lifetime);
 
-  SessionFsmState get_state();
+  SessionFsmState get_state() { return curr_state_; }
 
   void get_rules_per_credit_key(
       const CreditKey& charging_key, RulesToProcess* to_process,
@@ -477,7 +477,7 @@ class SessionState {
    * session_uc
    * @param session_uc
    */
-  void remove_all_rules_for_termination(SessionStateUpdateCriteria& session_uc);
+  void remove_all_rules_for_termination(SessionStateUpdateCriteria* session_uc);
 
   void set_teids(uint32_t enb_teid, uint32_t agw_teid);
 
@@ -485,24 +485,21 @@ class SessionState {
 
   // Event Triggers
   void add_new_event_trigger(
-      magma::lte::EventTrigger trigger,
-      SessionStateUpdateCriteria& update_criteria);
+      magma::lte::EventTrigger trigger, SessionStateUpdateCriteria* session_uc);
 
   void mark_event_trigger_as_triggered(
-      magma::lte::EventTrigger trigger,
-      SessionStateUpdateCriteria& update_criteria);
+      magma::lte::EventTrigger trigger, SessionStateUpdateCriteria* session_uc);
 
   void set_event_trigger(
       magma::lte::EventTrigger trigger, const EventTriggerState value,
-      SessionStateUpdateCriteria& update_criteria);
+      SessionStateUpdateCriteria* session_uc);
 
   void remove_event_trigger(
-      magma::lte::EventTrigger trigger,
-      SessionStateUpdateCriteria& update_criteria);
+      magma::lte::EventTrigger trigger, SessionStateUpdateCriteria* session_uc);
 
   void set_revalidation_time(
       const google::protobuf::Timestamp& time,
-      SessionStateUpdateCriteria& update_criteria);
+      SessionStateUpdateCriteria* session_uc);
 
   google::protobuf::Timestamp get_revalidation_time() {
     return revalidation_time_;
@@ -515,29 +512,34 @@ class SessionState {
 
   RulesToProcess remove_all_final_action_rules(
       const FinalActionInfo& final_action_info,
-      SessionStateUpdateCriteria& session_uc);
+      SessionStateUpdateCriteria* session_uc);
 
   // Monitors
   bool receive_monitor(
       const UsageMonitoringUpdateResponse& update,
-      SessionStateUpdateCriteria& session_uc);
+      SessionStateUpdateCriteria* session_uc);
 
   uint64_t get_monitor(const std::string& key, Bucket bucket) const;
 
   bool set_monitor_reporting(
       const std::string& key, bool reporting,
-      SessionStateUpdateCriteria* update_criteria);
+      SessionStateUpdateCriteria* session_uc);
 
   bool add_to_monitor(
       const std::string& key, uint64_t used_tx, uint64_t used_rx,
-      SessionStateUpdateCriteria& uc);
+      SessionStateUpdateCriteria* session_uc);
 
+  // TODO(@themarwhal) clean up this function as it is used for testing only
   void set_monitor(
-      const std::string& key, Monitor monitor, SessionStateUpdateCriteria& uc);
+      const std::string& key, Monitor monitor,
+      SessionStateUpdateCriteria* session_uc);
 
-  void set_session_level_key(const std::string new_key);
+  void set_session_level_key(
+      const std::string new_key, SessionStateUpdateCriteria* session_uc);
 
-  bool apply_update_criteria(SessionStateUpdateCriteria& uc);
+  std::string& get_session_level_key() { return session_level_key_; }
+
+  bool apply_update_criteria(SessionStateUpdateCriteria session_uc);
 
   StatsPerPolicy get_policy_stats(std::string rule_id);
 
@@ -586,7 +588,8 @@ class SessionState {
   void apply_session_rule_set(
       const RuleSetToApply& rule_set, RulesToProcess* pending_activation,
       RulesToProcess* pending_deactivation,
-      RulesToProcess* pending_bearer_setup, SessionStateUpdateCriteria& uc);
+      RulesToProcess* pending_bearer_setup,
+      SessionStateUpdateCriteria* session_uc);
 
   /**
    * Add the association of policy -> bearerID into bearer_id_by_policy_
@@ -594,13 +597,13 @@ class SessionState {
    */
   void bind_policy_to_bearer(
       const PolicyBearerBindingRequest& request,
-      SessionStateUpdateCriteria& uc);
+      SessionStateUpdateCriteria* session_uc);
 
   /**
    * Returns true if all the credits are suspended
    */
   void suspend_service_if_needed_for_credit(
-      CreditKey ckey, SessionStateUpdateCriteria& update_criteria);
+      CreditKey ckey, SessionStateUpdateCriteria* session_uc);
 
   /**
    * Returns true if the specified rule should be active at that time
@@ -694,16 +697,16 @@ class SessionState {
   /**
    * Clear all per-session metrics
    */
-  void clear_session_metrics();
+  void clear_session_metrics() const;
 
   // PolicyStatsMap functions
   /**
    *
    * @param rule_id
-   * @param session_uc
+   * @param session_uc optional output parameter
    */
   void increment_rule_stats(
-      const std::string& rule_id, SessionStateUpdateCriteria& session_uc);
+      const std::string& rule_id, SessionStateUpdateCriteria* session_uc);
 
  private:
   std::string imsi_;
@@ -766,7 +769,6 @@ class SessionState {
 
   // PolicyID->DedicatedBearerID used for 4G bearer/QoS management
   BearerIDByPolicyID bearer_id_by_policy_;
-  const uint32_t REDIRECT_FLOW_PRIORITY = 2000;
 
  private:
   /**
@@ -777,9 +779,9 @@ class SessionState {
    * @param actions_out Modified with additional actions to take on session
    */
   void get_charging_updates(
-      UpdateSessionRequest& update_request_out,
+      UpdateSessionRequest* update_request_out,
       std::vector<std::unique_ptr<ServiceAction>>* actions_out,
-      SessionStateUpdateCriteria& uc);
+      SessionStateUpdateCriteria* session_uc);
 
   /**
    * @brief Get a CreditUsageUpdate for the case where we want to continue
@@ -791,30 +793,28 @@ class SessionState {
    */
   optional<CreditUsageUpdate> get_update_for_continue_service(
       const CreditKey& key, std::unique_ptr<ChargingGrant>& grant,
-      SessionStateUpdateCriteria& session_uc);
+      SessionStateUpdateCriteria* session_uc);
 
   void fill_service_action_for_activate(
       std::unique_ptr<ServiceAction>& action, const CreditKey& key,
-      SessionStateUpdateCriteria& session_uc);
+      SessionStateUpdateCriteria* session_uc);
 
   void fill_service_action_for_restrict(
       std::unique_ptr<ServiceAction>& action_p, const CreditKey& key,
       std::unique_ptr<ChargingGrant>& grant,
-      SessionStateUpdateCriteria& session_uc);
-
-  PolicyRule make_redirect_rule(std::unique_ptr<ChargingGrant>& grant);
+      SessionStateUpdateCriteria* session_uc);
 
   void fill_service_action_for_redirect(
       std::unique_ptr<ServiceAction>& action_p, const CreditKey& key,
       std::unique_ptr<ChargingGrant>& grant, PolicyRule redirect_rule,
-      SessionStateUpdateCriteria& session_uc);
+      SessionStateUpdateCriteria* session_uc);
 
   void fill_service_action_with_context(
       std::unique_ptr<ServiceAction>& action, ServiceActionType action_type,
       const CreditKey& key);
 
   void apply_charging_credit_update(
-      const CreditKey& key, SessionCreditUpdateCriteria& credit_uc);
+      const CreditKey& key, const SessionCreditUpdateCriteria& credit_uc);
 
   /**
    * Receive the credit grant if the credit update was successful
@@ -827,14 +827,12 @@ class SessionState {
    */
   bool init_charging_credit(
       const CreditUpdateResponse& update,
-      SessionStateUpdateCriteria& session_uc);
+      SessionStateUpdateCriteria* session_uc);
 
   /**
    * Return true if any credit unit is valid and has non-zero volume
    */
   bool contains_credit(const GrantedUnits& gsu);
-
-  bool is_infinite_credit(const CreditUpdateResponse& response);
 
   /**
    * For this session, add the UsageMonitoringUpdateRequest to the
@@ -843,18 +841,17 @@ class SessionState {
    * @param update_request_out Modified with added UsdageMonitoringUpdateRequest
    */
   void get_monitor_updates(
-      UpdateSessionRequest& update_request_out,
-      SessionStateUpdateCriteria& update_criteria);
+      UpdateSessionRequest* update_request_out,
+      SessionStateUpdateCriteria* session_uc);
 
   /**
    * Apply SessionCreditUpdateCriteria, a per-credit diff of an update, into
    * the SessionState object
    * @param key : monitoring key for the update
-   * @param update : the diff that needs to be applied
+   * @param credit_uc : the diff that needs to be applied
    */
   void apply_monitor_updates(
-      const std::string& key, SessionStateUpdateCriteria& session_uc,
-      SessionCreditUpdateCriteria& credit_uc);
+      const std::string& key, const SessionCreditUpdateCriteria& credit_uc);
 
   void add_common_fields_to_usage_monitor_update(
       UsageMonitoringUpdateRequest* req);
@@ -865,38 +862,40 @@ class SessionState {
   bool should_rule_be_deactivated(const std::string& rule_id, std::time_t time);
 
   SessionCreditUpdateCriteria* get_credit_uc(
-      const CreditKey& key, SessionStateUpdateCriteria& uc);
+      const CreditKey& key, SessionStateUpdateCriteria* session_uc);
 
   CreditUsageUpdate make_credit_usage_update_req(CreditUsage& usage) const;
 
   bool init_new_monitor(
       const UsageMonitoringUpdateResponse& update,
-      SessionStateUpdateCriteria& update_criteria);
+      SessionStateUpdateCriteria* session_uc);
 
   void update_session_level_key(
       const UsageMonitoringUpdateResponse& update,
-      SessionStateUpdateCriteria& update_criteria);
+      SessionStateUpdateCriteria* session_uc);
 
   SessionCreditUpdateCriteria* get_monitor_uc(
-      const std::string& key, SessionStateUpdateCriteria& uc);
+      const std::string& key, SessionStateUpdateCriteria* session_uc);
 
   void fill_protos_tgpp_context(magma::lte::TgppContext* tgpp_context) const;
 
   void get_event_trigger_updates(
-      UpdateSessionRequest& update_request_out,
-      SessionStateUpdateCriteria& update_criteria);
+      UpdateSessionRequest* update_request_out,
+      SessionStateUpdateCriteria* session_uc);
 
   /** apply static_rules which is the desired state for the session's rules **/
   void apply_session_static_rule_set(
       const std::unordered_set<std::string> static_rules,
       RulesToProcess* pending_activation, RulesToProcess* pending_deactivation,
-      RulesToProcess* pending_bearer_setup, SessionStateUpdateCriteria& uc);
+      RulesToProcess* pending_bearer_setup,
+      SessionStateUpdateCriteria* session_uc);
 
   /** apply dynamic_rules which is the desired state for the session's rules **/
   void apply_session_dynamic_rule_set(
       const std::unordered_map<std::string, PolicyRule> dynamic_rules,
       RulesToProcess* pending_activation, RulesToProcess* pending_deactivation,
-      RulesToProcess* pending_bearer_setup, SessionStateUpdateCriteria& uc);
+      RulesToProcess* pending_bearer_setup,
+      SessionStateUpdateCriteria* session_uc);
 
   /**
    * Check if a new bearer has to be created for the given policy. If a creation
@@ -915,10 +914,11 @@ class SessionState {
    * @param policy_type
    * @param rule_id
    * @param update
+   * @param session_uc output parameter
    */
   void update_bearer_deletion_req(
       const PolicyType policy_type, const std::string& rule_id,
-      BearerUpdate& update, SessionStateUpdateCriteria& uc);
+      BearerUpdate* update, SessionStateUpdateCriteria* session_uc);
 
   /**
    * Set bearer_id_by_policy_ to the input

--- a/lte/gateway/c/session_manager/SessionStateEnforcer.cpp
+++ b/lte/gateway/c/session_manager/SessionStateEnforcer.cpp
@@ -137,11 +137,11 @@ void SessionStateEnforcer::handle_session_init_rule_updates(
    *
    */
   auto update_criteria = get_default_update_criteria();
-  session_state.set_local_teid(l_teid, update_criteria);
-  session_state.set_fsm_state(CREATED, update_criteria);
+  session_state.set_local_teid(l_teid, &update_criteria);
+  session_state.set_fsm_state(CREATED, &update_criteria);
   MLOG(MINFO) << " Teid " << session_state.get_local_teid();
   uint32_t cur_version = session_state.get_current_version();
-  session_state.set_current_version(++cur_version, update_criteria);
+  session_state.set_current_version(++cur_version, &update_criteria);
 
   /* Update the m5gsm_cause and prepare for respone along with actual cause*/
   prepare_response_to_access(
@@ -198,9 +198,9 @@ void SessionStateEnforcer::m5g_start_session_termination(
   /* update respective session's state and return from here before timeout
    * to update session store with state and version
    */
-  session->set_fsm_state(RELEASE, session_uc);
+  session->set_fsm_state(RELEASE, &session_uc);
   uint32_t cur_version = session->get_current_version();
-  session->set_current_version(++cur_version, session_uc);
+  session->set_current_version(++cur_version, &session_uc);
   MLOG(MINFO) << "During release state of session changed to "
               << session_fsm_state_to_str(session->get_state());
   handle_state_update_to_amf(
@@ -281,7 +281,7 @@ void SessionStateEnforcer::m5g_complete_termination(
   }
   auto& session    = **session_it;
   auto& session_uc = session_update[imsi][session_id];
-  if (!session->can_complete_termination(session_uc)) {
+  if (!session->can_complete_termination(&session_uc)) {
     return;  // error is logged in SessionState's complete_termination
   }
   // Now remove all rules
@@ -355,9 +355,9 @@ void SessionStateEnforcer::m5g_update_session_state_to_amf(
       session_update[imsi][session->get_session_id()];
   switch (session->get_state()) {
     case CREATED:
-      session->set_fsm_state(ACTIVE, session_uc);
+      session->set_fsm_state(ACTIVE, &session_uc);
       cur_version = session->get_current_version();
-      session->set_current_version(++cur_version, session_uc);
+      session->set_current_version(++cur_version, &session_uc);
       amf_update_pending = true;
       break;
     case RELEASE:

--- a/lte/gateway/c/session_manager/SessionStore.h
+++ b/lte/gateway/c/session_manager/SessionStore.h
@@ -33,10 +33,9 @@ namespace lte {
 using std::experimental::optional;
 
 // Value int represents the request numbers needed for requests to PCRF
-typedef std::set<std::string> SessionRead;
-typedef std::unordered_map<
-    std::string, std::unordered_map<std::string, SessionStateUpdateCriteria>>
-    SessionUpdate;
+using SessionRead   = std::set<std::string>;
+using SessionUpdate = std::unordered_map<
+    std::string, std::unordered_map<std::string, SessionStateUpdateCriteria>>;
 
 enum SessionSearchCriteriaType {
   IMSI_AND_APN             = 0,

--- a/lte/gateway/c/session_manager/StoreClient.h
+++ b/lte/gateway/c/session_manager/StoreClient.h
@@ -25,8 +25,8 @@
 namespace magma {
 namespace lte {
 
-typedef std::vector<std::unique_ptr<SessionState>> SessionVector;
-typedef std::unordered_map<std::string, SessionVector> SessionMap;
+using SessionVector = std::vector<std::unique_ptr<SessionState>>;
+using SessionMap    = std::unordered_map<std::string, SessionVector>;
 
 /**
  * StoreClient is responsible for reading/writing sessions to/from storage.

--- a/lte/gateway/c/session_manager/test/test_local_enforcer.cpp
+++ b/lte/gateway/c/session_manager/test/test_local_enforcer.cpp
@@ -339,7 +339,7 @@ TEST_F(LocalEnforcerTest, test_single_record) {
   auto update = SessionStore::get_default_session_update(session_map);
 
   auto uc = get_default_update_criteria();
-  session_map[IMSI1][0]->increment_rule_stats("rule1", uc);
+  session_map[IMSI1][0]->increment_rule_stats("rule1", &uc);
   local_enforcer->aggregate_records(session_map, table, update);
   assert_charging_credit(session_map, IMSI1, SESSION_ID_1, USED_RX, {{1, 16}});
   assert_charging_credit(session_map, IMSI1, SESSION_ID_1, USED_TX, {{1, 32}});
@@ -388,9 +388,9 @@ TEST_F(LocalEnforcerTest, test_aggregate_records_mixed_ips) {
   auto update = SessionStore::get_default_session_update(session_map);
 
   auto uc = get_default_update_criteria();
-  session_map[IMSI1][0]->increment_rule_stats("rule1", uc);
-  session_map[IMSI1][0]->increment_rule_stats("rule2", uc);
-  session_map[IMSI1][0]->increment_rule_stats("rule3", uc);
+  session_map[IMSI1][0]->increment_rule_stats("rule1", &uc);
+  session_map[IMSI1][0]->increment_rule_stats("rule2", &uc);
+  session_map[IMSI1][0]->increment_rule_stats("rule3", &uc);
   local_enforcer->aggregate_records(session_map, table, update);
 
   assert_charging_credit(
@@ -442,11 +442,11 @@ TEST_F(LocalEnforcerTest, test_multi_version_reporting) {
 
   auto update = SessionStore::get_default_session_update(session_map);
   auto uc     = get_default_update_criteria();
-  session_map[IMSI1][0]->increment_rule_stats("rule1", uc);
+  session_map[IMSI1][0]->increment_rule_stats("rule1", &uc);
 
-  session_map[IMSI1][0]->increment_rule_stats("rule1", uc);
+  session_map[IMSI1][0]->increment_rule_stats("rule1", &uc);
   // update to version2
-  session_map[IMSI1][0]->increment_rule_stats("rule1", uc);
+  session_map[IMSI1][0]->increment_rule_stats("rule1", &uc);
   local_enforcer->aggregate_records(session_map, table, update);
   assert_charging_credit(session_map, IMSI1, SESSION_ID_1, USED_RX, {{1, 30}});
   assert_charging_credit(session_map, IMSI1, SESSION_ID_1, USED_TX, {{1, 140}});
@@ -483,9 +483,9 @@ TEST_F(LocalEnforcerTest, test_aggregate_records_for_termination) {
       report_terminate_session(CheckTerminateRequestCount(IMSI1, 0, 2), _))
       .Times(1);
   auto uc = get_default_update_criteria();
-  session_map[IMSI1][0]->increment_rule_stats("rule1", uc);
-  session_map[IMSI1][0]->increment_rule_stats("rule2", uc);
-  session_map[IMSI1][0]->increment_rule_stats("rule3", uc);
+  session_map[IMSI1][0]->increment_rule_stats("rule1", &uc);
+  session_map[IMSI1][0]->increment_rule_stats("rule2", &uc);
+  session_map[IMSI1][0]->increment_rule_stats("rule3", &uc);
   local_enforcer->aggregate_records(session_map, table, update);
 
   RuleRecordTable empty_table;
@@ -518,7 +518,7 @@ TEST_F(LocalEnforcerTest, test_collect_updates) {
       record_list->Add());
 
   auto uc = get_default_update_criteria();
-  session_map[IMSI1][0]->increment_rule_stats("rule1", uc);
+  session_map[IMSI1][0]->increment_rule_stats("rule1", &uc);
   local_enforcer->aggregate_records(session_map, table, update);
   actions.clear();
   auto session_update =
@@ -565,7 +565,7 @@ TEST_F(LocalEnforcerTest, test_update_session_credits_and_rules) {
   create_rule_record(IMSI1, "rule1", 1024, 1024, record_list->Add());
   auto update = SessionStore::get_default_session_update(session_map);
   auto uc     = get_default_update_criteria();
-  session_map[IMSI1][0]->increment_rule_stats("rule1", uc);
+  session_map[IMSI1][0]->increment_rule_stats("rule1", &uc);
   local_enforcer->aggregate_records(session_map, table, update);
 
   session_store->create_sessions(IMSI1, std::move(session_map[IMSI1]));
@@ -632,7 +632,7 @@ TEST_F(LocalEnforcerTest, test_update_session_credits_and_rules_with_failure) {
       record_list->Add());
   auto update = SessionStore::get_default_session_update(session_map);
   auto uc     = get_default_update_criteria();
-  session_map[IMSI1][0]->increment_rule_stats("rule1", uc);
+  session_map[IMSI1][0]->increment_rule_stats("rule1", &uc);
   local_enforcer->aggregate_records(session_map, table, update);
   assert_monitor_credit(session_map, IMSI1, SESSION_ID_1, USED_RX, {{"1", 10}});
   assert_monitor_credit(session_map, IMSI1, SESSION_ID_1, USED_TX, {{"1", 20}});
@@ -708,7 +708,7 @@ TEST_F(LocalEnforcerTest, test_terminate_credit) {
 
   auto uc = get_default_update_criteria();
   session_map[IMSI1][0]->increment_rule_stats(
-      "internal_default_drop_flow_rule", uc);
+      "internal_default_drop_flow_rule", &uc);
   local_enforcer->aggregate_records(session_map, only_drop_rule_table, update);
   run_evb();
   run_evb();
@@ -746,10 +746,10 @@ TEST_F(LocalEnforcerTest, test_terminate_credit_during_reporting) {
   auto update = SessionStore::get_default_session_update(session_map);
 
   auto uc = get_default_update_criteria();
-  session_map[IMSI1][0]->increment_rule_stats("rule1", uc);
-  session_map[IMSI1][0]->increment_rule_stats("rule2", uc);
+  session_map[IMSI1][0]->increment_rule_stats("rule1", &uc);
+  session_map[IMSI1][0]->increment_rule_stats("rule2", &uc);
   session_map[IMSI1][0]->increment_rule_stats(
-      "internal_default_drop_flow_rule", uc);
+      "internal_default_drop_flow_rule", &uc);
   local_enforcer->aggregate_records(session_map, table, update);
 
   // Collect updates to put key 1 into reporting state
@@ -845,11 +845,11 @@ TEST_F(LocalEnforcerTest, test_sync_sessions_on_restart) {
   auto& uc    = session_update[IMSI1][SESSION_ID_1];
   uint32_t v1 = session_map_2[IMSI1]
                     .front()
-                    ->activate_static_rule("rule1", lifetime1, uc)
+                    ->activate_static_rule("rule1", lifetime1, &uc)
                     .version;
-  session_map_2[IMSI1].front()->schedule_static_rule("rule2", lifetime2, uc);
-  session_map_2[IMSI1].front()->schedule_static_rule("rule3", lifetime3, uc);
-  session_map_2[IMSI1].front()->schedule_static_rule("rule4", lifetime4, uc);
+  session_map_2[IMSI1].front()->schedule_static_rule("rule2", lifetime2, &uc);
+  session_map_2[IMSI1].front()->schedule_static_rule("rule3", lifetime3, &uc);
+  session_map_2[IMSI1].front()->schedule_static_rule("rule4", lifetime4, &uc);
 
   EXPECT_EQ(v1, 1);
 
@@ -867,10 +867,10 @@ TEST_F(LocalEnforcerTest, test_sync_sessions_on_restart) {
   d3.set_id("dynamic_rule3");
   d4.set_id("dynamic_rule4");
 
-  session_map_2[IMSI1].front()->insert_dynamic_rule(d1, lifetime1, uc);
-  session_map_2[IMSI1].front()->schedule_dynamic_rule(d2, lifetime2, uc);
-  session_map_2[IMSI1].front()->schedule_dynamic_rule(d3, lifetime3, uc);
-  session_map_2[IMSI1].front()->schedule_dynamic_rule(d4, lifetime4, uc);
+  session_map_2[IMSI1].front()->insert_dynamic_rule(d1, lifetime1, &uc);
+  session_map_2[IMSI1].front()->schedule_dynamic_rule(d2, lifetime2, &uc);
+  session_map_2[IMSI1].front()->schedule_dynamic_rule(d3, lifetime3, &uc);
+  session_map_2[IMSI1].front()->schedule_dynamic_rule(d4, lifetime4, &uc);
 
   EXPECT_EQ(uc.dynamic_rules_to_install.size(), 1);
   EXPECT_EQ(uc.new_scheduled_dynamic_rules.size(), 3);
@@ -908,12 +908,12 @@ TEST_F(LocalEnforcerTest, test_sync_sessions_on_restart_revalidation_timer) {
 
   // manually place revalidation timer
   SessionStateUpdateCriteria uc;
-  session_state->add_new_event_trigger(REVALIDATION_TIMEOUT, uc);
+  session_state->add_new_event_trigger(REVALIDATION_TIMEOUT, &uc);
   EXPECT_EQ(uc.is_pending_event_triggers_updated, true);
   EXPECT_EQ(uc.pending_event_triggers[REVALIDATION_TIMEOUT], false);
   google::protobuf::Timestamp time;
   time.set_seconds(0);
-  session_state->set_revalidation_time(time, uc);
+  session_state->set_revalidation_time(time, &uc);
 
   session_map[IMSI1] = SessionVector();
   session_map[IMSI1].push_back(std::move(session_state));
@@ -961,8 +961,8 @@ TEST_F(LocalEnforcerTest, test_final_unit_handling) {
   auto update = SessionStore::get_default_session_update(session_map);
 
   auto uc = get_default_update_criteria();
-  session_map[IMSI1][0]->increment_rule_stats("rule1", uc);
-  session_map[IMSI1][0]->increment_rule_stats("rule2", uc);
+  session_map[IMSI1][0]->increment_rule_stats("rule1", &uc);
+  session_map[IMSI1][0]->increment_rule_stats("rule2", &uc);
   local_enforcer->aggregate_records(session_map, table, update);
 
   // the request should has no rules so PipelineD deletes all rules
@@ -1020,8 +1020,8 @@ TEST_F(LocalEnforcerTest, test_cwf_final_unit_handling) {
   create_rule_record(IMSI1, "rule2", 1024, 2048, record_list->Add());
   auto update = SessionStore::get_default_session_update(session_map);
   auto uc     = get_default_update_criteria();
-  session_map[IMSI1][0]->increment_rule_stats("rule1", uc);
-  session_map[IMSI1][0]->increment_rule_stats("rule2", uc);
+  session_map[IMSI1][0]->increment_rule_stats("rule1", &uc);
+  session_map[IMSI1][0]->increment_rule_stats("rule2", &uc);
   local_enforcer->aggregate_records(session_map, table, update);
 
   // the request should has no rules so PipelineD deletes all rules
@@ -1089,9 +1089,9 @@ TEST_F(LocalEnforcerTest, test_all) {
       record_list->Add());
   auto update = SessionStore::get_default_session_update(session_map);
   auto uc     = get_default_update_criteria();
-  session_map[IMSI1][0]->increment_rule_stats("rule1", uc);
-  session_map[IMSI1][0]->increment_rule_stats("rule2", uc);
-  session_map[IMSI2][0]->increment_rule_stats("rule3", uc);
+  session_map[IMSI1][0]->increment_rule_stats("rule1", &uc);
+  session_map[IMSI1][0]->increment_rule_stats("rule2", &uc);
+  session_map[IMSI2][0]->increment_rule_stats("rule3", &uc);
   local_enforcer->aggregate_records(session_map, table, update);
 
   assert_charging_credit(session_map, IMSI1, SESSION_ID_1, USED_RX, {{1, 15}});
@@ -1223,7 +1223,7 @@ TEST_F(LocalEnforcerTest, test_credit_init_with_transient_error_redirect) {
       IMSI1, test_cfg_.common_context.ue_ipv4(), "rule1", 10, 20,
       record_list->Add());
   auto uc = get_default_update_criteria();
-  session_map[IMSI1][0]->increment_rule_stats("rule1", uc);
+  session_map[IMSI1][0]->increment_rule_stats("rule1", &uc);
   local_enforcer->aggregate_records(session_map, table, update);
 
   assert_charging_credit(session_map, IMSI1, SESSION_ID_1, USED_RX, {{1, 10}});
@@ -1461,8 +1461,8 @@ TEST_F(LocalEnforcerTest, test_dynamic_rules) {
 
   auto update = SessionStore::get_default_session_update(session_map);
   auto uc     = get_default_update_criteria();
-  session_map[IMSI1][0]->increment_rule_stats("rule1", uc);
-  session_map[IMSI1][0]->increment_rule_stats("rule2", uc);
+  session_map[IMSI1][0]->increment_rule_stats("rule1", &uc);
+  session_map[IMSI1][0]->increment_rule_stats("rule2", &uc);
   local_enforcer->aggregate_records(session_map, table, update);
 
   assert_charging_credit(session_map, IMSI1, SESSION_ID_1, USED_RX, {{1, 24}});
@@ -1519,8 +1519,8 @@ TEST_F(LocalEnforcerTest, test_dynamic_rule_actions) {
       record_list->Add());
   auto update = SessionStore::get_default_session_update(session_map);
   auto uc     = get_default_update_criteria();
-  session_map[IMSI1][0]->increment_rule_stats("rule1", uc);
-  session_map[IMSI1][0]->increment_rule_stats("rule2", uc);
+  session_map[IMSI1][0]->increment_rule_stats("rule1", &uc);
+  session_map[IMSI1][0]->increment_rule_stats("rule2", &uc);
   local_enforcer->aggregate_records(session_map, table, update);
 
   // the request should has no rules so PipelineD deletes all rules
@@ -1659,10 +1659,10 @@ TEST_F(LocalEnforcerTest, test_usage_monitors) {
   create_rule_record(IMSI1, ip, "pcrf_split", 10, 20, record_list->Add());
   auto update = SessionStore::get_default_session_update(session_map);
   auto uc     = get_default_update_criteria();
-  session_map[IMSI1][0]->increment_rule_stats("both_rule", uc);
-  session_map[IMSI1][0]->increment_rule_stats("ocs_rule", uc);
-  session_map[IMSI1][0]->increment_rule_stats("pcrf_only", uc);
-  session_map[IMSI1][0]->increment_rule_stats("pcrf_split", uc);
+  session_map[IMSI1][0]->increment_rule_stats("both_rule", &uc);
+  session_map[IMSI1][0]->increment_rule_stats("ocs_rule", &uc);
+  session_map[IMSI1][0]->increment_rule_stats("pcrf_only", &uc);
+  session_map[IMSI1][0]->increment_rule_stats("pcrf_split", &uc);
   local_enforcer->aggregate_records(session_map, table, update);
 
   assert_charging_credit(
@@ -1824,8 +1824,8 @@ TEST_F(LocalEnforcerTest, test_usage_monitor_disable) {
       IMSI1, ip, "pcrf_only_to_be_disabled", 2000, 0, record_list_1->Add());
 
   auto uc = get_default_update_criteria();
-  session_map[IMSI1][0]->increment_rule_stats("pcrf_only_active", uc);
-  session_map[IMSI1][0]->increment_rule_stats("pcrf_only_to_be_disabled", uc);
+  session_map[IMSI1][0]->increment_rule_stats("pcrf_only_active", &uc);
+  session_map[IMSI1][0]->increment_rule_stats("pcrf_only_to_be_disabled", &uc);
   local_enforcer->aggregate_records(session_map, table_1, update_1);
 
   // Collect updates, should have updates since all monitors got 80% exhausted
@@ -1888,8 +1888,8 @@ TEST_F(LocalEnforcerTest, test_usage_monitor_disable) {
       IMSI1, ip, "pcrf_only_to_be_disabled", 4000, 0, record_list2->Add());
 
   update_2 = SessionStore::get_default_session_update(session_map);
-  session_map[IMSI1][0]->increment_rule_stats("pcrf_only_active", uc);
-  session_map[IMSI1][0]->increment_rule_stats("pcrf_only_to_be_disabled", uc);
+  session_map[IMSI1][0]->increment_rule_stats("pcrf_only_active", &uc);
+  session_map[IMSI1][0]->increment_rule_stats("pcrf_only_to_be_disabled", &uc);
   local_enforcer->aggregate_records(session_map, table_2, update_2);
   monitor_updates_2 = update_2[IMSI1][SESSION_ID_1].monitor_credit_map;
   EXPECT_FALSE(monitor_updates_2["1"].report_last_credit);
@@ -2791,7 +2791,7 @@ TEST_F(LocalEnforcerTest, test_final_unit_redirect_activation_and_termination) {
       IMSI1, ip_addr, "static_1", 1024, 2048, record_list->Add());
   auto update = SessionStore::get_default_session_update(session_map);
   auto uc     = get_default_update_criteria();
-  session_map[IMSI1][0]->increment_rule_stats("static_1", uc);
+  session_map[IMSI1][0]->increment_rule_stats("static_1", &uc);
   local_enforcer->aggregate_records(session_map, table, update);
 
   // Collect actions and verify that restrict action is in the list
@@ -2869,9 +2869,9 @@ TEST_F(LocalEnforcerTest, test_final_unit_activation_and_canceling) {
   create_rule_record(IMSI1, ip_addr, "rule3", 1024, 2048, record_list->Add());
   auto update = SessionStore::get_default_session_update(session_map);
   auto uc     = get_default_update_criteria();
-  session_map[IMSI1][0]->increment_rule_stats("rule1", uc);
-  session_map[IMSI1][0]->increment_rule_stats("rule2", uc);
-  session_map[IMSI1][0]->increment_rule_stats("rule3", uc);
+  session_map[IMSI1][0]->increment_rule_stats("rule1", &uc);
+  session_map[IMSI1][0]->increment_rule_stats("rule2", &uc);
+  session_map[IMSI1][0]->increment_rule_stats("rule3", &uc);
   local_enforcer->aggregate_records(session_map, table, update);
 
   // Collect actions and verify that restrict action is in the list
@@ -2974,7 +2974,7 @@ TEST_F(LocalEnforcerTest, test_final_unit_action_no_update) {
       IMSI1, ip_addr, "static_rule1", 1023, 0, record_list->Add());
   auto update = SessionStore::get_default_session_update(session_map);
   auto uc     = get_default_update_criteria();
-  session_map[IMSI1][0]->increment_rule_stats("static_rule1", uc);
+  session_map[IMSI1][0]->increment_rule_stats("static_rule1", &uc);
   local_enforcer->aggregate_records(session_map, table, update);
 
   std::vector<std::unique_ptr<ServiceAction>> actions;

--- a/lte/gateway/c/session_manager/test/test_proxy_responder_handler.cpp
+++ b/lte/gateway/c/session_manager/test/test_proxy_responder_handler.cpp
@@ -164,16 +164,17 @@ TEST_F(SessionProxyResponderHandlerTest, test_policy_reauth) {
   auto uc      = get_default_update_criteria();
   auto session = get_session(rule_store);
   RuleLifetime lifetime;
-  session->activate_static_rule(rule_id_1, lifetime, uc);
+  session->activate_static_rule(rule_id_1, lifetime, nullptr);
   EXPECT_EQ(session->get_session_id(), SESSION_ID_1);
   EXPECT_EQ(session->get_request_number(), 1);
   EXPECT_EQ(session->is_static_rule_installed(rule_id_1), true);
 
   auto monitor_update = get_monitoring_update();
-  session->receive_monitor(monitor_update, uc);
+  session->receive_monitor(monitor_update, &uc);
 
   // Add some used credit
-  session->add_to_monitor(monitoring_key, uint64_t(111), uint64_t(333), uc);
+  session->add_to_monitor(
+      monitoring_key, uint64_t(111), uint64_t(333), nullptr);
   EXPECT_EQ(session->get_monitor(monitoring_key, USED_TX), 111);
   EXPECT_EQ(session->get_monitor(monitoring_key, USED_RX), 333);
 
@@ -235,7 +236,7 @@ TEST_F(SessionProxyResponderHandlerTest, test_abort_session) {
   auto uc      = get_default_update_criteria();
   auto session = get_session(rule_store);
   RuleLifetime lifetime;
-  session->activate_static_rule(rule_id_1, lifetime, uc);
+  session->activate_static_rule(rule_id_1, lifetime, &uc);
   EXPECT_EQ(session->get_session_id(), SESSION_ID_1);
   EXPECT_EQ(session->get_request_number(), 1);
   EXPECT_EQ(session->is_static_rule_installed(rule_id_1), true);

--- a/lte/gateway/c/session_manager/test/test_session_state.cpp
+++ b/lte/gateway/c/session_manager/test/test_session_state.cpp
@@ -53,10 +53,10 @@ TEST_F(SessionStateTest, test_session_rules) {
 
   // Test rule removals
   PolicyRule rule_out;
-  session_state->deactivate_static_rule("rule2", update_criteria);
+  session_state->deactivate_static_rule("rule2", &update_criteria);
   EXPECT_EQ(1, session_state->total_monitored_rules_count());
   EXPECT_TRUE(
-      session_state->remove_dynamic_rule("rule1", &rule_out, update_criteria));
+      session_state->remove_dynamic_rule("rule1", &rule_out, &update_criteria));
   EXPECT_EQ("m1", rule_out.monitoring_key());
   EXPECT_EQ(0, session_state->total_monitored_rules_count());
 
@@ -65,10 +65,7 @@ TEST_F(SessionStateTest, test_session_rules) {
   session_state->get_dynamic_rules().get_rule_ids(rules_out_ptr);
   EXPECT_EQ(rules_out_ptr.size(), 0);
 
-  rules_out = {};
-  session_state->get_dynamic_rules().get_rule_ids_for_monitoring_key(
-      "m1", rules_out);
-  EXPECT_EQ(0, rules_out.size());
+  EXPECT_EQ(0, get_monitored_rule_count("m1"));
 
   std::string mkey;
   // searching for non-existent rule should fail
@@ -86,8 +83,6 @@ TEST_F(SessionStateTest, test_session_rules) {
  * tracking in SessionState
  */
 TEST_F(SessionStateTest, test_rule_scheduling) {
-  auto _uc = get_default_update_criteria();  // unused
-
   // First schedule a dynamic and static rule. They are treated as inactive.
   schedule_rule(1, "m1", "rule1", DYNAMIC, 0, 0);
   EXPECT_EQ(0, session_state->total_monitored_rules_count());
@@ -101,14 +96,14 @@ TEST_F(SessionStateTest, test_rule_scheduling) {
   // as active. The responsibility is given to the session owner to make
   // these calls
   PolicyRule rule;
-  session_state->remove_scheduled_dynamic_rule("rule1", &rule, _uc);
+  session_state->remove_scheduled_dynamic_rule("rule1", &rule, nullptr);
   session_state->insert_dynamic_rule(
-      rule, session_state->get_rule_lifetime("rule1"), _uc);
+      rule, session_state->get_rule_lifetime("rule1"), nullptr);
   EXPECT_EQ(1, session_state->total_monitored_rules_count());
   EXPECT_TRUE(session_state->is_dynamic_rule_installed("rule1"));
 
   session_state->activate_static_rule(
-      "rule2", session_state->get_rule_lifetime("rule2"), _uc);
+      "rule2", session_state->get_rule_lifetime("rule2"), nullptr);
   EXPECT_EQ(2, session_state->total_monitored_rules_count());
   EXPECT_TRUE(session_state->is_static_rule_installed("rule2"));
 
@@ -144,7 +139,7 @@ TEST_F(SessionStateTest, test_rule_time_sync) {
 
   // Update the time, and sync the rule states, then check our expectations
   std::time_t test_time(10);
-  session_state->sync_rules_to_time(test_time, uc);
+  session_state->sync_rules_to_time(test_time, &uc);
 
   EXPECT_TRUE(session_state->is_dynamic_rule_installed("d1"));
   EXPECT_FALSE(session_state->is_dynamic_rule_installed("d2"));
@@ -163,7 +158,7 @@ TEST_F(SessionStateTest, test_rule_time_sync) {
   // Update the time once more, sync again, and check expectations
   test_time = std::time_t(16);
   uc        = get_default_update_criteria();
-  session_state->sync_rules_to_time(test_time, uc);
+  session_state->sync_rules_to_time(test_time, &uc);
 
   EXPECT_FALSE(session_state->is_dynamic_rule_installed("d1"));
   EXPECT_TRUE(session_state->is_dynamic_rule_installed("d2"));
@@ -208,13 +203,13 @@ TEST_F(SessionStateTest, test_marshal_unmarshal) {
   EXPECT_EQ(session_state->get_monitor("m1", ALLOWED_TOTAL), 1024);
   EXPECT_EQ(update_criteria.monitor_credit_to_install.size(), 1);
 
-  session_state->add_rule_usage("rule1", 1, 2000, 1000, 0, 0, update_criteria);
+  session_state->add_rule_usage("rule1", 1, 2000, 1000, 0, 0, nullptr);
   EXPECT_EQ(session_state->get_charging_credit(1, USED_TX), 2000);
   EXPECT_EQ(session_state->get_charging_credit(1, USED_RX), 1000);
   EXPECT_EQ(session_state->get_monitor("m1", USED_TX), 2000);
   EXPECT_EQ(session_state->get_monitor("m1", USED_RX), 1000);
-  session_state->increment_rule_stats("rule1", update_criteria);
-  session_state->add_rule_usage("rule1", 2, 1000, 500, 10, 20, update_criteria);
+  session_state->increment_rule_stats("rule1", nullptr);
+  session_state->add_rule_usage("rule1", 2, 1000, 500, 10, 20, nullptr);
   EXPECT_EQ(session_state->get_charging_credit(1, USED_TX), 3000);
   EXPECT_EQ(session_state->get_charging_credit(1, USED_RX), 1500);
   EXPECT_EQ(session_state->get_monitor("m1", USED_TX), 3000);
@@ -284,7 +279,7 @@ TEST_F(SessionStateTest, test_add_rule_usage) {
           .credit.buckets[ALLOWED_TOTAL],
       3000);
 
-  session_state->add_rule_usage("rule1", 1, 2000, 1000, 0, 0, update_criteria);
+  session_state->add_rule_usage("rule1", 1, 2000, 1000, 0, 0, &update_criteria);
   EXPECT_EQ(session_state->get_charging_credit(1, USED_TX), 2000);
   EXPECT_EQ(session_state->get_charging_credit(1, USED_RX), 1000);
   EXPECT_EQ(session_state->get_monitor("m1", USED_TX), 2000);
@@ -296,7 +291,7 @@ TEST_F(SessionStateTest, test_add_rule_usage) {
       update_criteria.monitor_credit_map["m1"].bucket_deltas[USED_RX], 1000);
 
   session_state->add_rule_usage(
-      "dyn_rule1", 1, 4000, 2000, 0, 0, update_criteria);
+      "dyn_rule1", 1, 4000, 2000, 0, 0, &update_criteria);
   EXPECT_EQ(session_state->get_charging_credit(2, USED_TX), 4000);
   EXPECT_EQ(session_state->get_charging_credit(2, USED_RX), 2000);
   EXPECT_EQ(session_state->get_monitor("m2", USED_TX), 4000);
@@ -309,15 +304,15 @@ TEST_F(SessionStateTest, test_add_rule_usage) {
 
   UpdateSessionRequest update;
   std::vector<std::unique_ptr<ServiceAction>> actions;
-  session_state->get_updates(update, &actions, update_criteria);
+  session_state->get_updates(&update, &actions, &update_criteria);
   EXPECT_EQ(actions.size(), 0);
   EXPECT_EQ(update.updates_size(), 2);
   EXPECT_EQ(update.usage_monitors_size(), 2);
 
   PolicyRule policy_out;
   EXPECT_TRUE(session_state->remove_dynamic_rule(
-      "dyn_rule1", &policy_out, update_criteria));
-  EXPECT_TRUE(session_state->deactivate_static_rule("rule1", update_criteria));
+      "dyn_rule1", &policy_out, &update_criteria));
+  EXPECT_TRUE(session_state->deactivate_static_rule("rule1", &update_criteria));
   EXPECT_FALSE(session_state->active_monitored_rules_exist());
   EXPECT_TRUE(
       std::find(
@@ -351,7 +346,7 @@ TEST_F(SessionStateTest, test_mixed_tracking_rules) {
       3000);
 
   session_state->add_rule_usage(
-      "dyn_rule1", 1, 2000, 1000, 0, 0, update_criteria);
+      "dyn_rule1", 1, 2000, 1000, 0, 0, &update_criteria);
   EXPECT_EQ(session_state->get_monitor("m1", USED_TX), 2000);
   EXPECT_EQ(session_state->get_monitor("m1", USED_RX), 1000);
 
@@ -361,14 +356,14 @@ TEST_F(SessionStateTest, test_mixed_tracking_rules) {
       update_criteria.monitor_credit_map["m1"].bucket_deltas[USED_RX], 1000);
 
   session_state->add_rule_usage(
-      "dyn_rule2", 1, 4000, 2000, 0, 0, update_criteria);
+      "dyn_rule2", 1, 4000, 2000, 0, 0, &update_criteria);
   EXPECT_EQ(session_state->get_charging_credit(2, USED_TX), 4000);
   EXPECT_EQ(session_state->get_charging_credit(2, USED_RX), 2000);
   EXPECT_EQ(
       update_criteria.charging_credit_map[CreditKey(2)].bucket_deltas[USED_TX],
       4000);
   session_state->add_rule_usage(
-      "dyn_rule3", 1, 5000, 3000, 0, 0, update_criteria);
+      "dyn_rule3", 1, 5000, 3000, 0, 0, &update_criteria);
   EXPECT_EQ(session_state->get_charging_credit(3, USED_TX), 5000);
   EXPECT_EQ(session_state->get_charging_credit(3, USED_RX), 3000);
   EXPECT_EQ(
@@ -381,7 +376,7 @@ TEST_F(SessionStateTest, test_mixed_tracking_rules) {
 
   UpdateSessionRequest update;
   std::vector<std::unique_ptr<ServiceAction>> actions;
-  session_state->get_updates(update, &actions, update_criteria);
+  session_state->get_updates(&update, &actions, nullptr);
   EXPECT_EQ(actions.size(), 0);
   EXPECT_EQ(update.updates_size(), 2);
   EXPECT_EQ(update.usage_monitors_size(), 2);
@@ -399,7 +394,7 @@ TEST_F(SessionStateTest, test_session_level_key) {
   EXPECT_EQ(update_criteria.updated_session_level_key, "m1");
 
   // add usage to go over quota
-  session_state->add_rule_usage("rule1", 1, 5000, 2000, 0, 0, update_criteria);
+  session_state->add_rule_usage("rule1", 1, 5000, 2000, 0, 0, &update_criteria);
   EXPECT_EQ(session_state->get_policy_stats("rule1").current_version, 1);
   EXPECT_EQ(session_state->get_policy_stats("rule1").last_reported_version, 1);
   EXPECT_EQ(session_state->get_monitor("m1", USED_TX), 5000);
@@ -412,7 +407,7 @@ TEST_F(SessionStateTest, test_session_level_key) {
   // check one updates will be sent
   UpdateSessionRequest update;
   std::vector<std::unique_ptr<ServiceAction>> actions;
-  session_state->get_updates(update, &actions, update_criteria);
+  session_state->get_updates(&update, &actions, &update_criteria);
   EXPECT_EQ(actions.size(), 0);
   EXPECT_EQ(update.usage_monitors_size(), 1);
   auto& single_update = update.usage_monitors(0).update();
@@ -425,7 +420,7 @@ TEST_F(SessionStateTest, test_session_level_key) {
   receive_credit_from_pcrf("m1", 0, MonitoringLevel::SESSION_LEVEL);
 
   // add usage to go over quota
-  session_state->add_rule_usage("rule1", 1, 6001, 2001, 0, 0, update_criteria);
+  session_state->add_rule_usage("rule1", 1, 6001, 2001, 0, 0, &update_criteria);
   EXPECT_EQ(session_state->get_monitor("m1", USED_TX), 6001);
   EXPECT_EQ(session_state->get_monitor("m1", USED_RX), 2001);
   EXPECT_TRUE(update_criteria.monitor_credit_map["m1"].report_last_credit);
@@ -433,7 +428,7 @@ TEST_F(SessionStateTest, test_session_level_key) {
   // check final update will be sent
   UpdateSessionRequest update_2;
   std::vector<std::unique_ptr<ServiceAction>> actions_2;
-  session_state->get_updates(update_2, &actions_2, update_criteria);
+  session_state->get_updates(&update_2, &actions_2, &update_criteria);
   // TODO: session level seemsd to be adding total values, no deltas
   // EXPECT_EQ(
   //   update_criteria.monitor_credit_map["m1"].bucket_deltas[USED_TX], 1001);
@@ -453,8 +448,7 @@ TEST_F(SessionStateTest, test_session_level_key) {
   session_state->apply_update_criteria(update_criteria);
   EXPECT_EQ(session_state->get_monitor("m1", USED_TX), 0);
   EXPECT_EQ(session_state->get_monitor("m1", USED_RX), 0);
-  EXPECT_TRUE(update_criteria.is_session_level_key_updated);
-  EXPECT_EQ(update_criteria.updated_session_level_key, "");
+  EXPECT_EQ(session_state->get_session_level_key(), "");
   EXPECT_TRUE(update_criteria.monitor_credit_map["m1"].deleted);
 }
 
@@ -463,11 +457,11 @@ TEST_F(SessionStateTest, test_reauth_key) {
 
   receive_credit_from_ocs(1, 1500);
 
-  session_state->add_rule_usage("rule1", 1, 1000, 500, 0, 0, update_criteria);
+  session_state->add_rule_usage("rule1", 1, 1000, 500, 0, 0, &update_criteria);
 
   UpdateSessionRequest update;
   std::vector<std::unique_ptr<ServiceAction>> actions;
-  session_state->get_updates(update, &actions, update_criteria);
+  session_state->get_updates(&update, &actions, &update_criteria);
   EXPECT_EQ(update.updates_size(), 1);
   EXPECT_EQ(session_state->get_charging_credit(1, REPORTING_TX), 1000);
   EXPECT_EQ(session_state->get_charging_credit(1, REPORTING_RX), 500);
@@ -482,17 +476,17 @@ TEST_F(SessionStateTest, test_reauth_key) {
       0);
   // credit is already reporting, no update needed
   auto uc         = get_default_update_criteria();
-  auto reauth_res = session_state->reauth_key(1, uc);
+  auto reauth_res = session_state->reauth_key(1, &uc);
   EXPECT_EQ(reauth_res, ReAuthResult::UPDATE_NOT_NEEDED);
   receive_credit_from_ocs(1, 1024);
   EXPECT_EQ(session_state->get_charging_credit(1, REPORTING_TX), 0);
   EXPECT_EQ(session_state->get_charging_credit(1, REPORTING_RX), 0);
-  reauth_res = session_state->reauth_key(1, uc);
+  reauth_res = session_state->reauth_key(1, &uc);
   EXPECT_EQ(reauth_res, ReAuthResult::UPDATE_INITIATED);
 
-  session_state->add_rule_usage("rule1", 1, 1002, 501, 0, 0, update_criteria);
+  session_state->add_rule_usage("rule1", 1, 1002, 501, 0, 0, &update_criteria);
   UpdateSessionRequest reauth_update;
-  session_state->get_updates(reauth_update, &actions, update_criteria);
+  session_state->get_updates(&reauth_update, &actions, nullptr);
   EXPECT_EQ(reauth_update.updates_size(), 1);
   auto& usage = reauth_update.updates(0).usage();
   EXPECT_EQ(usage.bytes_tx(), 2);
@@ -501,7 +495,7 @@ TEST_F(SessionStateTest, test_reauth_key) {
 
 TEST_F(SessionStateTest, test_reauth_new_key) {
   // credit is already reporting, no update needed
-  auto reauth_res = session_state->reauth_key(1, update_criteria);
+  auto reauth_res = session_state->reauth_key(1, &update_criteria);
   EXPECT_EQ(reauth_res, ReAuthResult::UPDATE_INITIATED);
 
   // assert stored charging grant fields are updated to reflect reauth state
@@ -511,7 +505,7 @@ TEST_F(SessionStateTest, test_reauth_new_key) {
 
   UpdateSessionRequest reauth_update;
   std::vector<std::unique_ptr<ServiceAction>> actions;
-  session_state->get_updates(reauth_update, &actions, update_criteria);
+  session_state->get_updates(&reauth_update, &actions, &update_criteria);
   EXPECT_EQ(reauth_update.updates_size(), 1);
   auto& usage = reauth_update.updates(0).usage();
   EXPECT_EQ(usage.charging_key(), 1);
@@ -550,11 +544,11 @@ TEST_F(SessionStateTest, test_reauth_all) {
   receive_credit_from_ocs(1, 1024);
   receive_credit_from_ocs(2, 1024);
 
-  session_state->add_rule_usage("rule1", 1, 10, 20, 0, 0, update_criteria);
-  session_state->add_rule_usage("dyn_rule1", 1, 30, 40, 0, 0, update_criteria);
+  session_state->add_rule_usage("rule1", 1, 10, 20, 0, 0, &update_criteria);
+  session_state->add_rule_usage("dyn_rule1", 1, 30, 40, 0, 0, &update_criteria);
   // If any charging key isn't reporting, an update is needed
   auto uc         = get_default_update_criteria();
-  auto reauth_res = session_state->reauth_all(uc);
+  auto reauth_res = session_state->reauth_all(&uc);
   EXPECT_EQ(reauth_res, ReAuthResult::UPDATE_INITIATED);
 
   // assert stored charging grant fields are updated to reflect reauth state
@@ -566,7 +560,7 @@ TEST_F(SessionStateTest, test_reauth_all) {
 
   UpdateSessionRequest reauth_update;
   std::vector<std::unique_ptr<ServiceAction>> actions;
-  session_state->get_updates(reauth_update, &actions, uc);
+  session_state->get_updates(&reauth_update, &actions, &uc);
   EXPECT_EQ(reauth_update.updates_size(), 2);
 
   EXPECT_EQ(uc.charging_credit_map.size(), 2);
@@ -576,7 +570,7 @@ TEST_F(SessionStateTest, test_reauth_all) {
   EXPECT_EQ(credit_uc_2.reauth_state, REAUTH_PROCESSING);
 
   // All charging keys are reporting, no update needed
-  reauth_res = session_state->reauth_all(uc);
+  reauth_res = session_state->reauth_all(&uc);
   EXPECT_EQ(reauth_res, ReAuthResult::UPDATE_NOT_NEEDED);
 
   EXPECT_EQ(uc.charging_credit_map.size(), 2);
@@ -590,7 +584,7 @@ TEST_F(SessionStateTest, test_tgpp_context_is_set_on_update) {
   receive_credit_from_pcrf("m1", 1024, MonitoringLevel::PCC_RULE_LEVEL);
   receive_credit_from_ocs(1, 1024);
   insert_rule(1, "m1", "rule1", STATIC, 0, 0);
-  session_state->add_rule_usage("rule1", 1, 1024, 0, 0, 0, update_criteria);
+  session_state->add_rule_usage("rule1", 1, 1024, 0, 0, 0, &update_criteria);
   EXPECT_EQ(true, session_state->active_monitored_rules_exist());
 
   EXPECT_EQ(session_state->get_monitor("m1", ALLOWED_TOTAL), 1024);
@@ -606,7 +600,7 @@ TEST_F(SessionStateTest, test_tgpp_context_is_set_on_update) {
 
   UpdateSessionRequest update;
   std::vector<std::unique_ptr<ServiceAction>> actions;
-  session_state->get_updates(update, &actions, update_criteria);
+  session_state->get_updates(&update, &actions, nullptr);
   EXPECT_EQ(actions.size(), 0);
   EXPECT_EQ(update.updates_size(), 1);
   EXPECT_EQ(update.updates().Get(0).tgpp_ctx().gx_dest_host(), "gx.dest.com");
@@ -620,7 +614,7 @@ TEST_F(SessionStateTest, test_tgpp_context_is_set_on_update) {
 
 TEST_F(SessionStateTest, test_get_total_credit_usage_single_rule_no_key) {
   insert_rule(0, "", "rule1", STATIC, 0, 0);
-  session_state->add_rule_usage("rule1", 1, 2000, 1000, 0, 0, update_criteria);
+  session_state->add_rule_usage("rule1", 1, 2000, 1000, 0, 0, &update_criteria);
   TotalCreditUsage actual = session_state->get_total_credit_usage();
   EXPECT_EQ(actual.monitoring_tx, 0);
   EXPECT_EQ(actual.monitoring_rx, 0);
@@ -631,7 +625,7 @@ TEST_F(SessionStateTest, test_get_total_credit_usage_single_rule_no_key) {
 TEST_F(SessionStateTest, test_get_total_credit_usage_single_rule_single_key) {
   insert_rule(1, "", "rule1", STATIC, 0, 0);
   receive_credit_from_ocs(1, 3000);
-  session_state->add_rule_usage("rule1", 1, 2000, 1000, 0, 0, update_criteria);
+  session_state->add_rule_usage("rule1", 1, 2000, 1000, 0, 0, &update_criteria);
   TotalCreditUsage actual = session_state->get_total_credit_usage();
   EXPECT_EQ(actual.monitoring_tx, 0);
   EXPECT_EQ(actual.monitoring_rx, 0);
@@ -643,7 +637,7 @@ TEST_F(SessionStateTest, test_get_total_credit_usage_single_rule_multiple_key) {
   insert_rule(1, "m1", "rule1", STATIC, 0, 0);
   receive_credit_from_ocs(1, 3000);
   receive_credit_from_pcrf("m1", 3000, MonitoringLevel::PCC_RULE_LEVEL);
-  session_state->add_rule_usage("rule1", 1, 2000, 1000, 0, 0, update_criteria);
+  session_state->add_rule_usage("rule1", 1, 2000, 1000, 0, 0, &update_criteria);
   TotalCreditUsage actual = session_state->get_total_credit_usage();
   EXPECT_EQ(actual.monitoring_tx, 2000);
   EXPECT_EQ(actual.monitoring_rx, 1000);
@@ -658,8 +652,8 @@ TEST_F(SessionStateTest, test_get_total_credit_usage_multiple_rule_shared_key) {
   insert_rule(0, "m1", "rule2", DYNAMIC, 0, 0);
   receive_credit_from_ocs(1, 3000);
   receive_credit_from_pcrf("m1", 3000, MonitoringLevel::PCC_RULE_LEVEL);
-  session_state->add_rule_usage("rule1", 1, 1000, 10, 0, 0, update_criteria);
-  session_state->add_rule_usage("rule2", 1, 500, 5, 0, 0, update_criteria);
+  session_state->add_rule_usage("rule1", 1, 1000, 10, 0, 0, nullptr);
+  session_state->add_rule_usage("rule2", 1, 500, 5, 0, 0, nullptr);
   TotalCreditUsage actual = session_state->get_total_credit_usage();
   EXPECT_EQ(actual.monitoring_tx, 1500);
   EXPECT_EQ(actual.monitoring_rx, 15);
@@ -683,7 +677,7 @@ TEST_F(SessionStateTest, test_install_gy_rules) {
 
   PolicyRule rule_out;
   optional<RuleToProcess> op_to_process =
-      session_state->remove_gy_rule("redirect", &rule_out, update_criteria);
+      session_state->remove_gy_rule("redirect", &rule_out, &update_criteria);
   EXPECT_TRUE(op_to_process);
   EXPECT_EQ(op_to_process->version, 2);
 
@@ -695,10 +689,7 @@ TEST_F(SessionStateTest, test_install_gy_rules) {
   EXPECT_FALSE(session_state->is_gy_dynamic_rule_installed("redirect"));
   EXPECT_EQ(update_criteria.gy_dynamic_rules_to_uninstall.size(), 1);
 
-  rules_out = {};
-  session_state->get_gy_dynamic_rules().get_rule_ids_for_monitoring_key(
-      "m1", rules_out);
-  EXPECT_EQ(0, rules_out.size());
+  EXPECT_EQ(0, get_monitored_rule_count("m1"));
 
   std::string mkey;
   // searching for non-existent rule should fail
@@ -725,7 +716,7 @@ TEST_F(SessionStateTest, test_final_credit_redirect_install) {
   redirect->set_redirect_address_type(RedirectServer_RedirectAddressType_URL);
   p_credit->set_final_action(ChargingCredit_FinalAction_REDIRECT);
 
-  session_state->receive_charging_credit(charge_resp, update_criteria);
+  session_state->receive_charging_credit(charge_resp, &update_criteria);
 
   // Test that the update criteria is filled out properly
   EXPECT_EQ(update_criteria.charging_credit_to_install.size(), 1);
@@ -753,7 +744,7 @@ TEST_F(SessionStateTest, test_final_restrict_credit_install) {
   p_credit->add_restrict_rules("restrict-rule");
   p_credit->set_final_action(ChargingCredit_FinalAction_RESTRICT_ACCESS);
 
-  session_state->receive_charging_credit(charge_resp, update_criteria);
+  session_state->receive_charging_credit(charge_resp, &update_criteria);
 
   // Test that the update criteria is filled out properly
   EXPECT_EQ(update_criteria.charging_credit_to_install.size(), 1);
@@ -776,7 +767,7 @@ TEST_F(SessionStateTest, test_empty_gsu_credit_grant) {
   charge_resp.mutable_credit()->set_type(ChargingCredit::BYTES);
   // Should return false to indicate credit installation did not go through
   EXPECT_FALSE(
-      session_state->receive_charging_credit(charge_resp, update_criteria));
+      session_state->receive_charging_credit(charge_resp, &update_criteria));
   // Test that the update criteria is untouched
   EXPECT_EQ(update_criteria.charging_credit_to_install.size(), 0);
 }
@@ -799,7 +790,7 @@ TEST_F(SessionStateTest, test_zero_gsu_credit_grant) {
   create_granted_units(&zero, &zero, &zero, p_credit->mutable_granted_units());
 
   EXPECT_TRUE(
-      session_state->receive_charging_credit(charge_resp, update_criteria));
+      session_state->receive_charging_credit(charge_resp, &update_criteria));
 
   // Test that the update criteria is filled out properly
   EXPECT_EQ(update_criteria.charging_credit_to_install.size(), 1);
@@ -817,7 +808,7 @@ TEST_F(SessionStateTest, test_zero_gsu_credit_grant) {
   EXPECT_EQ(u_credit.credit.buckets[ALLOWED_RX], 0);
 
   // Report some rule usage, and ensure the final action gets triggered
-  session_state->add_rule_usage("rule1", 1, 100, 100, 0, 0, update_criteria);
+  session_state->add_rule_usage("rule1", 1, 100, 100, 0, 0, &update_criteria);
   auto credit_uc = update_criteria.charging_credit_map[1];
   EXPECT_EQ(credit_uc.service_state, SERVICE_NEEDS_DEACTIVATION);
 }
@@ -843,18 +834,18 @@ TEST_F(SessionStateTest, test_multiple_final_action_empty_grant) {
   EXPECT_EQ(credit.received_granted_units.rx().volume(), 2000);
 
   // add usage for 2 times to go over quota
-  session_state->add_rule_usage("rule1", 1, 2000, 1000, 0, 0, update_criteria);
+  session_state->add_rule_usage("rule1", 1, 2000, 1000, 0, 0, &update_criteria);
   EXPECT_EQ(session_state->get_charging_credit(1, USED_TX), 2000);
   EXPECT_EQ(session_state->get_charging_credit(1, USED_RX), 1000);
 
-  session_state->add_rule_usage("rule1", 1, 4000, 2000, 0, 0, update_criteria);
+  session_state->add_rule_usage("rule1", 1, 4000, 2000, 0, 0, &update_criteria);
   EXPECT_EQ(session_state->get_charging_credit(1, USED_TX), 4000);
   EXPECT_EQ(session_state->get_charging_credit(1, USED_RX), 2000);
 
   // check if we need to report the usage
   UpdateSessionRequest update;
   std::vector<std::unique_ptr<ServiceAction>> actions;
-  session_state->get_updates(update, &actions, update_criteria);
+  session_state->get_updates(&update, &actions, &update_criteria);
   EXPECT_EQ(actions.size(), 0);
   EXPECT_EQ(update.updates_size(), 1);
   auto credit_uc = update_criteria.charging_credit_map[CreditKey(1)];
@@ -910,7 +901,7 @@ TEST_F(SessionStateTest, test_apply_session_rule_set) {
   RulesToProcess pending_activation, pending_deactivation, pending_bearer_setup;
   session_state->apply_session_rule_set(
       rules_to_apply, &pending_activation, &pending_deactivation,
-      &pending_bearer_setup, uc);
+      &pending_bearer_setup, &uc);
 
   // First check the active rules in session
   EXPECT_TRUE(!session_state->is_static_rule_installed("rule-static-1"));
@@ -992,7 +983,7 @@ TEST_F(SessionStateTest, test_monitor_cycle) {
   // reset update_criteria (before any add_rule_usage)
   // update_criteria = get_default_update_criteria();
   // add usage for 2 times to go over quota
-  session_state->add_rule_usage("rule1", 1, 2000, 1000, 0, 0, update_criteria);
+  session_state->add_rule_usage("rule1", 1, 2000, 1000, 0, 0, &update_criteria);
   EXPECT_EQ(session_state->get_monitor("m1", USED_TX), 2000);
   EXPECT_EQ(session_state->get_monitor("m1", USED_RX), 1000);
   EXPECT_FALSE(update_criteria.monitor_credit_map["m1"].report_last_credit);
@@ -1003,7 +994,7 @@ TEST_F(SessionStateTest, test_monitor_cycle) {
   receive_credit_from_pcrf("m1", 0, 100, 200, MonitoringLevel::PCC_RULE_LEVEL);
   // reset update_criteria (before any add_rule_usage)
   // update_criteria = get_default_update_criteria();
-  session_state->add_rule_usage("rule1", 1, 4000, 2000, 0, 0, update_criteria);
+  session_state->add_rule_usage("rule1", 1, 4000, 2000, 0, 0, &update_criteria);
   EXPECT_EQ(session_state->get_monitor("m1", USED_TX), 4000);
   EXPECT_EQ(session_state->get_monitor("m1", USED_RX), 2000);
   EXPECT_TRUE(update_criteria.monitor_credit_map["m1"].report_last_credit);
@@ -1012,7 +1003,7 @@ TEST_F(SessionStateTest, test_monitor_cycle) {
   // Get the updates that will be sent to core
   UpdateSessionRequest update;
   std::vector<std::unique_ptr<ServiceAction>> actions;
-  session_state->get_updates(update, &actions, update_criteria);
+  session_state->get_updates(&update, &actions, &update_criteria);
   EXPECT_EQ(actions.size(), 0);
   EXPECT_EQ(update.usage_monitors_size(), 1);
   EXPECT_EQ(
@@ -1044,12 +1035,11 @@ TEST_F(SessionStateTest, test_get_charging_credit_summaries) {
           .credit.buckets[ALLOWED_TOTAL],
       3000);
 
-  session_state->add_rule_usage("rule1", 1, 2000, 1000, 0, 0, update_criteria);
+  session_state->add_rule_usage("rule1", 1, 2000, 1000, 0, 0, nullptr);
   EXPECT_EQ(session_state->get_charging_credit(1, USED_TX), 2000);
   EXPECT_EQ(session_state->get_charging_credit(1, USED_RX), 1000);
 
-  session_state->add_rule_usage(
-      "dyn_rule1", 1, 4000, 2000, 0, 0, update_criteria);
+  session_state->add_rule_usage("dyn_rule1", 1, 4000, 2000, 0, 0, nullptr);
   EXPECT_EQ(session_state->get_charging_credit(2, USED_TX), 4000);
   EXPECT_EQ(session_state->get_charging_credit(2, USED_RX), 2000);
 
@@ -1065,7 +1055,6 @@ TEST_F(SessionStateTest, test_get_charging_credit_summaries) {
 
 TEST_F(SessionStateTest, test_process_static_rule_installs) {
   initialize_session_with_qos();
-  auto uc = get_default_update_criteria();
 
   // Insert 2 static rules without qos into static rule store
   insert_static_rule_into_store(0, "mkey1", "static-1");
@@ -1076,8 +1065,8 @@ TEST_F(SessionStateTest, test_process_static_rule_installs) {
 
   // activate static-1 and static-qos-3 in advance
   RuleLifetime lifetime;
-  session_state->activate_static_rule("static-1", lifetime, uc);
-  session_state->activate_static_rule("static-qos-3", lifetime, uc);
+  session_state->activate_static_rule("static-1", lifetime, nullptr);
+  session_state->activate_static_rule("static-qos-3", lifetime, nullptr);
 
   // Create a StaticRuleInstall with all four rules above
   std::vector<StaticRuleInstall> rule_installs{
@@ -1094,7 +1083,7 @@ TEST_F(SessionStateTest, test_process_static_rule_installs) {
   RulesToSchedule pending_scheduling;
   session_state->process_static_rule_installs(
       rule_installs, &pending_activation, &pending_deactivation,
-      &pending_bearer_setup, &pending_scheduling, &uc);
+      &pending_bearer_setup, &pending_scheduling, nullptr);
   EXPECT_EQ(1, pending_activation.size());
   EXPECT_EQ("static-2", pending_activation[0].rule.id());
   EXPECT_EQ(1, pending_bearer_setup.size());
@@ -1103,7 +1092,6 @@ TEST_F(SessionStateTest, test_process_static_rule_installs) {
 
 TEST_F(SessionStateTest, test_process_dynamic_rule_installs) {
   initialize_session_with_qos();
-  auto uc = get_default_update_criteria();
 
   PolicyRule dynamic_1 = create_policy_rule("dynamic-1", "", 0);
   PolicyRule dynamic_2 = create_policy_rule("dynamic-2", "", 0);
@@ -1114,8 +1102,8 @@ TEST_F(SessionStateTest, test_process_dynamic_rule_installs) {
 
   // Install dynamic rules for dynamic-1 and dynamic-qos-3
   RuleLifetime lifetime;
-  session_state->insert_dynamic_rule(dynamic_1, lifetime, uc);
-  session_state->insert_dynamic_rule(dynamic_qos_3, lifetime, uc);
+  session_state->insert_dynamic_rule(dynamic_1, lifetime, nullptr);
+  session_state->insert_dynamic_rule(dynamic_qos_3, lifetime, nullptr);
 
   // Create a StaticRuleInstall with all four rules above
   std::vector<DynamicRuleInstall> rule_installs{
@@ -1132,7 +1120,7 @@ TEST_F(SessionStateTest, test_process_dynamic_rule_installs) {
   RulesToSchedule pending_scheduling;
   session_state->process_dynamic_rule_installs(
       rule_installs, &pending_activation, &pending_deactivation,
-      &pending_bearer_setup, &pending_scheduling, &uc);
+      &pending_bearer_setup, &pending_scheduling, nullptr);
   EXPECT_EQ(2, pending_activation.size());
   EXPECT_EQ(2, pending_bearer_setup.size());
 }

--- a/lte/gateway/c/session_manager/test/test_session_store.cpp
+++ b/lte/gateway/c/session_manager/test/test_session_store.cpp
@@ -303,7 +303,7 @@ TEST_F(SessionStoreTest, test_read_and_write) {
 
   auto uc = get_default_update_criteria();
   RuleLifetime lifetime;
-  session->activate_static_rule(rule_id_3, lifetime, uc);
+  session->activate_static_rule(rule_id_3, lifetime, nullptr);
   EXPECT_EQ(session->get_session_id(), SESSION_ID_1);
   EXPECT_EQ(session->get_request_number(), 1);
   EXPECT_EQ(session->is_static_rule_installed(rule_id_3), true);
@@ -312,10 +312,10 @@ TEST_F(SessionStoreTest, test_read_and_write) {
       response1.DebugString());
 
   auto monitor_update = get_monitoring_update();
-  session->receive_monitor(monitor_update, uc);
+  session->receive_monitor(monitor_update, &uc);
 
   // Add some used credit
-  session->add_to_monitor(monitoring_key, uint64_t(111), uint64_t(333), uc);
+  session->add_to_monitor(monitoring_key, uint64_t(111), uint64_t(333), &uc);
   EXPECT_EQ(session->get_monitor(monitoring_key, USED_TX), 111);
   EXPECT_EQ(session->get_monitor(monitoring_key, USED_RX), 333);
 
@@ -377,7 +377,8 @@ TEST_F(SessionStoreTest, test_read_and_write) {
   // Check for installation of new monitoring credit
   session_map[IMSI1].front()->set_monitor(
       monitoring_key2,
-      Monitor(update_criteria.monitor_credit_to_install[monitoring_key2]), uc);
+      Monitor(update_criteria.monitor_credit_to_install[monitoring_key2]),
+      nullptr);
   EXPECT_EQ(
       session_map[IMSI1].front()->get_monitor(monitoring_key2, USED_TX), 100);
   EXPECT_EQ(

--- a/lte/gateway/c/session_manager/test/test_store_client.cpp
+++ b/lte/gateway/c/session_manager/test/test_store_client.cpp
@@ -97,7 +97,7 @@ TEST_F(StoreClientTest, test_read_and_write) {
   EXPECT_EQ(session2->get_session_id(), sid2);
 
   RuleLifetime lifetime{};
-  session->activate_static_rule("rule1", lifetime, uc);
+  session->activate_static_rule("rule1", lifetime, &uc);
   EXPECT_EQ(session->is_static_rule_installed("rule1"), true);
 
   EXPECT_EQ(session_map.size(), 2);

--- a/lte/gateway/c/session_manager/test/test_usage_monitor.cpp
+++ b/lte/gateway/c/session_manager/test/test_usage_monitor.cpp
@@ -45,7 +45,6 @@ TEST_F(SessionStateTest, test_insert_monitor) {
 // Insert a monitor, then remove. Assert that the update criteria reflects the
 // deletion
 TEST_F(SessionStateTest, test_remove_monitor) {
-  update_criteria = get_default_update_criteria();
   EXPECT_EQ(update_criteria.static_rules_to_install.size(), 0);
   insert_rule(0, "m1", "rule1", STATIC, 0, 0);
 
@@ -56,7 +55,7 @@ TEST_F(SessionStateTest, test_remove_monitor) {
           .credit.buckets[ALLOWED_TOTAL],
       1000);
 
-  session_state->add_rule_usage("rule1", 1, 1000, 0, 0, 0, update_criteria);
+  session_state->add_rule_usage("rule1", 1, 1000, 0, 0, 0, nullptr);
   EXPECT_EQ(session_state->get_monitor("m1", USED_TX), 1000);
   EXPECT_EQ(session_state->get_monitor("m1", USED_RX), 0);
 
@@ -66,7 +65,7 @@ TEST_F(SessionStateTest, test_remove_monitor) {
   update_criteria = get_default_update_criteria();
 
   // add usage to trigger the quota exhaustion
-  session_state->add_rule_usage("rule1", 1, 1001, 0, 0, 0, update_criteria);
+  session_state->add_rule_usage("rule1", 1, 1001, 0, 0, 0, &update_criteria);
   EXPECT_EQ(session_state->get_monitor("m1", USED_TX), 1001);
   EXPECT_EQ(session_state->get_monitor("m1", USED_RX), 0);
   EXPECT_TRUE(update_criteria.monitor_credit_map["m1"].report_last_credit);
@@ -74,7 +73,7 @@ TEST_F(SessionStateTest, test_remove_monitor) {
   // check last update will be sent
   UpdateSessionRequest update;
   std::vector<std::unique_ptr<ServiceAction>> actions;
-  session_state->get_updates(update, &actions, update_criteria);
+  session_state->get_updates(&update, &actions, &update_criteria);
   EXPECT_EQ(actions.size(), 0);
   EXPECT_EQ(update.usage_monitors_size(), 1);
   auto& single_update = update.usage_monitors(0).update();


### PR DESCRIPTION
<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary
Sorry about the massive PR :( 

There are some bad typing practices that I wanted to fix up before we welcome an intern to make some changes.

* fix up the update criteria output parameters to be pointers instead of mutable references. This is better in terms of style, but also this will allow us to get rid of all instances where we pass an unused update criteria to get around the fact. (I've found this confusing when reading code)
* I've also fixed up some functions to return by value not by output parameter when possible
  * `PolicyRule make_redirect_rule();`
  * `SessionState::SessionInfo get_session_info();`
* in general tried standardized on `session_uc` for `SessionStateUpdateCriteria` and `credit_uc` for `SessionCreditUpdateCriteria`
* `NULL` -> `nullptr`
* my eternal battle to mark const functions as const (doesn't modify internal state)
<!-- Enumerate changes you made and why you made them -->

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
Signed-off-by: Marie Bremner <marwhal@fb.com>