### PR TITLE
[orc8r][api] Increase MMEGroupId limit to 16bits

### DIFF
--- a/lte/cloud/go/services/lte/obsidian/models/cellular_gateway_pool_configs_swaggergen.go
+++ b/lte/cloud/go/services/lte/obsidian/models/cellular_gateway_pool_configs_swaggergen.go
@@ -19,7 +19,7 @@ type CellularGatewayPoolConfigs struct {
 
 	// mme group id
 	// Required: true
-	// Maximum: 255
+	// Maximum: 65535
 	// Minimum: 0
 	MmeGroupID uint32 `json:"mme_group_id"`
 }
@@ -48,7 +48,7 @@ func (m *CellularGatewayPoolConfigs) validateMmeGroupID(formats strfmt.Registry)
 		return err
 	}
 
-	if err := validate.MaximumInt("mme_group_id", "body", int64(m.MmeGroupID), 255, false); err != nil {
+	if err := validate.MaximumInt("mme_group_id", "body", int64(m.MmeGroupID), 65535, false); err != nil {
 		return err
 	}
 

--- a/lte/cloud/go/services/lte/obsidian/models/swagger.v1.yml
+++ b/lte/cloud/go/services/lte/obsidian/models/swagger.v1.yml
@@ -2502,7 +2502,7 @@ definitions:
         type: integer
         format: uint32
         minimum: 0
-        maximum: 255
+        maximum: 65535
         example: 1
         default: 1
 

--- a/orc8r/cloud/go/obsidian/swagger/v1/models/cellular_gateway_pool_configs.go
+++ b/orc8r/cloud/go/obsidian/swagger/v1/models/cellular_gateway_pool_configs.go
@@ -19,7 +19,7 @@ type CellularGatewayPoolConfigs struct {
 
 	// mme group id
 	// Required: true
-	// Maximum: 255
+	// Maximum: 65535
 	// Minimum: 0
 	MmeGroupID uint32 `json:"mme_group_id"`
 }
@@ -48,7 +48,7 @@ func (m *CellularGatewayPoolConfigs) validateMmeGroupID(formats strfmt.Registry)
 		return err
 	}
 
-	if err := validate.MaximumInt("mme_group_id", "body", int64(m.MmeGroupID), 255, false); err != nil {
+	if err := validate.MaximumInt("mme_group_id", "body", int64(m.MmeGroupID), 65535, false); err != nil {
 		return err
 	}
 

--- a/orc8r/cloud/go/obsidian/swagger/v1/swagger.yml
+++ b/orc8r/cloud/go/obsidian/swagger/v1/swagger.yml
@@ -7324,7 +7324,7 @@ definitions:
         default: 1
         example: 1
         format: uint32
-        maximum: 255
+        maximum: 65535
         minimum: 0
         type: integer
         x-nullable: false


### PR DESCRIPTION
Signed-off-by: Joary Paulo Wanzeler Fortuna <joarypl@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->
Changed API limit of mme_group_id from 255 (8bits) to 65535 (16bits)

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->


## Test API

Running Orc8r locally.

Added MME gateway_pool with a mme_group_id higher than 255

![image](https://user-images.githubusercontent.com/1166157/119204904-1ca97000-ba6d-11eb-8cc3-f63fa586df4f.png)

List of added gateway_pools:

![image](https://user-images.githubusercontent.com/1166157/119204939-2cc14f80-ba6d-11eb-99e2-c4dd1919acc1.png)

## Test AGW 

Added AGW VM into locall orc8r:
![image](https://user-images.githubusercontent.com/1166157/119400848-1a375800-bcb1-11eb-99d7-3c89a2b9a144.png)

Checked the AGW MMEGID in streamed gateway.mconfig
![image](https://user-images.githubusercontent.com/1166157/119401024-4fdc4100-bcb1-11eb-93f8-6f7ae154a288.png)

Configured Gateway Pool with MMEGID higher than 255
![image](https://user-images.githubusercontent.com/1166157/119400954-3a671700-bcb1-11eb-84bd-e949dcf8bd2a.png)

Checked the AGW MMEGID in streamed gateway.mconfig
![image](https://user-images.githubusercontent.com/1166157/119401061-5cf93000-bcb1-11eb-9e90-aa32ecc7b41b.png)

Restarted AGW services and checked health
![image](https://user-images.githubusercontent.com/1166157/119401138-79956800-bcb1-11eb-8ab1-d5ed2801ea16.png)

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
