### PR TITLE
[or8r] add test service with control_proxy.yml file

### DIFF
--- a/orc8r/cloud/go/test_utils/service.go
+++ b/orc8r/cloud/go/test_utils/service.go
@@ -15,13 +15,36 @@ package test_utils
 
 import (
 	"fmt"
+	"io/ioutil"
 	"net"
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 
+	"magma/gateway/config"
 	cloud_service "magma/orc8r/cloud/go/service"
 	"magma/orc8r/lib/go/registry"
 	platform_service "magma/orc8r/lib/go/service"
+	platform_cfg "magma/orc8r/lib/go/service/config"
 )
+
+// control_proxy.yml
+// only local_port and cloud_port are needed
+var testCPConfigYaml = `
+nghttpx_config_location: /var/tmp/nghttpx.conf
+rootca_cert: /var/opt/magma/certs/rootCA.pem
+gateway_cert: /var/opt/magma/secrets/certs/gateway.crt
+gateway_key: /var/opt/magma/secrets/certs/gateway.key
+
+local_port: %s
+cloud_address: controller.magma.foobar.com
+cloud_port: 9999
+
+bootstrap_address: bootstrapper-controller.magma.foobar.com
+bootstrap_port: 4444
+proxy_cloud_connections: True
+allow_http_proxy: True`
 
 // NewTestService creates and registers a basic test Magma service on a
 // dynamically selected available local port.
@@ -89,6 +112,24 @@ func NewTestOrchestratorService(
 	return srv, lis
 }
 
+// NewTestOrchestratorServiceWithControlProxy create a Orchestrator Service and a
+// control_proxy.yml file. This service can be used by gateway services to test
+// a cloud service. This service will configure a custom control_proxy.yml file
+// matching local_port on control proxy with the listener port of the orc8r service.
+// Remember to delete the temporary file once the test it is done os.RemoveAll(dir)
+func NewTestOrchestratorServiceWithControlProxy(
+	t *testing.T,
+	moduleName string,
+	serviceType string,
+	labels map[string]string,
+	annotations map[string]string,
+) (*cloud_service.OrchestratorService, net.Listener, string) {
+	srv, lis := NewTestOrchestratorService(
+		t, moduleName, serviceType, labels, annotations)
+	tempDir := setControlProxyConfig(t, lis.Addr())
+	return srv, lis, tempDir
+}
+
 func getOpenPort() (int, net.Listener, error) {
 	lis, err := net.Listen("tcp", "")
 	if err != nil {
@@ -99,4 +140,38 @@ func getOpenPort() (int, net.Listener, error) {
 		return 0, nil, fmt.Errorf("failed to resolve TCP address: %s", err)
 	}
 	return addr.Port, lis, err
+}
+
+// setControlProxyConfig creates a temporal control_proxy.yml and returns its
+// location. Remember to delete the temporary file once the test it is done
+// os.RemoveAll(dir)
+func setControlProxyConfig(t *testing.T, addrs net.Addr) string {
+	if addrs == nil {
+		t.Fatalf("listener address is nil. Can't create control_proxy.yml")
+	}
+	splitAddrs := strings.Split(addrs.String(), ":")
+	if len(splitAddrs) == 0 {
+		t.Fatalf("listener address is empty  %s. Can't create control_proxy.yml", splitAddrs)
+	}
+
+	dir, err := ioutil.TempDir("", "magma_cfg_test")
+	if err != nil {
+		t.Fatalf("can't create temp directory for control_proxy.yml test config: %s", err)
+	}
+	cfgFilePath := filepath.Join(dir, "control_proxy.yml")
+
+	port := splitAddrs[len(splitAddrs)-1]
+	testCPConfigYamlWithValues := fmt.Sprintf(testCPConfigYaml, port)
+
+	err = ioutil.WriteFile(cfgFilePath, []byte(testCPConfigYamlWithValues), os.ModePerm)
+	if err != nil {
+		t.Fatalf("can't write control_proxy.yml test config: %s", err)
+	}
+
+	platform_cfg.SetConfigDirectories(dir, dir+"/foo", dir+"/bar")
+	cfg := config.GetControlProxyConfigs()
+	if port != fmt.Sprint(cfg.LocalPort) {
+		t.Fatalf("control_proxy.yml doesnt have the right port (%s)\n%s", port, testCPConfigYamlWithValues)
+	}
+	return dir
 }


### PR DESCRIPTION
Signed-off-by: Oriol Batalla <obatalla@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary

Added an orc8r test service that creates a control proxy yml file which includes the port of the service. That can be used by feg services to test connectivity from FEG to thee cloud

Future PRs will use this service 

## Test Plan
make precommit at or8cr

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
