### PR TITLE
[lte][agw] Ansible libprotobuf-mutator install

### DIFF
--- a/lte/gateway/deploy/roles/dev_common/defaults/main.yml
+++ b/lte/gateway/deploy/roles/dev_common/defaults/main.yml
@@ -3,4 +3,5 @@ codegen_root: /var/tmp/codegen
 mvn_version: 3.5.4
 mvn_sha1: 22cac91b3557586bb1eba326f2f7727543ff15e3
 mvn_dir: '/var/tmp/apache-maven-{{ mvn_version }}'
+tmp_libprotobuf_mutator_dir: '/var/tmp/libprotobuf-mutator'
 swagger_codegen_jar: '{{ codegen_root }}/modules/swagger-codegen-cli/target/swagger-codegen-cli.jar'

--- a/lte/gateway/deploy/roles/dev_common/tasks/main.yml
+++ b/lte/gateway/deploy/roles/dev_common/tasks/main.yml
@@ -268,6 +268,36 @@
       - libssl-dev
 
 ###############################################
+# Download and build libprotobuf-mutator
+###############################################
+
+- name: Clone libprotobuf-mutator repo
+  become: yes
+  git:
+    repo: 'https://github.com/google/libprotobuf-mutator'
+    dest: "{{ tmp_libprotobuf_mutator_dir }}"
+    version: v1.0
+    force: yes
+  when: preburn and ansible_distribution == "Ubuntu"
+
+- name: Create a build directory for libprotobuf-mutator
+  file:
+    path: "{{ tmp_libprotobuf_mutator_dir }}/build"
+    state: directory
+  when: preburn and ansible_distribution == "Ubuntu"
+
+# Fails build unless we add -DLIB_PROTO_MUTATOR_DOWNLOAD_PROTOBUF=ON
+#  to download and build updated proto lib.
+- name: Build libprotobuf-mutator
+  become: yes
+  shell: |
+    cd {{ tmp_libprotobuf_mutator_dir }}/build && \
+    cmake .. -GNinja -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++ -DCMAKE_BUILD_TYPE=Debug -DLIB_PROTO_MUTATOR_DOWNLOAD_PROTOBUF=ON && \
+    ninja && \
+    ninja install
+  when: preburn and ansible_distribution == "Ubuntu"
+
+###############################################
 # Download and build sentry-native
 ###############################################
 


### PR DESCRIPTION
## Summary

This to enable property tests in which ~random proto -> state struct -> proto' and we compare the initial random proto with proto'.

## Test Plan

```
vagrant destroy magma_focal
vagrant up magma_focal
```

And then `vagrant ssh magma_focal` and validate library install.


Signed-off-by: Scott Harrison Moeller <smoeller@fb.com>
