### PR TITLE
[CODEOWNERS] Experiment with excluding codeowner paths

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -41,8 +41,6 @@ lte/gateway/Vagrantfile @magma/approvers-ci
 orc8r/cloud/go/obsidian/swagger/v1/swagger.yml @magma/repo-magma-maintain
 orc8r/cloud/go/obsidian/swagger/v1/client/ @magma/repo-magma-maintain
 orc8r/cloud/go/obsidian/swagger/v1/models/ @magma/repo-magma-maintain
-**/go.mod @magma/repo-magma-maintain
-**/go.sum @magma/repo-magma-maintain
 
 # XWF Magma integrations
 xwf/ @magma/approvers-xwf
@@ -54,3 +52,7 @@ docs/ @magma/approvers-docs
 docs/readmes/proposals @electronjoe
 
 CODEOWNERS @amarpad @electronjoe
+
+# Paths excluded from code ownership
+**/go.mod @ghost
+**/go.sum @ghost


### PR DESCRIPTION
Signed-off-by: Marie Bremner <marwhal@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary
I'm still getting feedback that there's review notification for generated files :'( 

Some repos seem to get around this by using @ghost   
https://github.com/coq/coq/blob/master/.github/CODEOWNERS
<!-- Enumerate changes you made and why you made them -->

## Test Plan
Basic syntax check passes 
```
➜  magma git:(experiment_codeowners_exclude) ✗ docker run --rm -v $(pwd):/repo -w /repo \
  -e REPOSITORY_PATH="." \
  -e GITHUB_ACCESS_TOKEN="$GH_TOKEN" \
  -e OWNER_CHECKER_REPOSITORY="magma/magma" \
  mszostok/codeowners-validator:v0.6.0
==> Executing Duplicated Pattern Checker (409.259µs)
    Check OK
==> Executing Valid Syntax Checker (311.294µs)
    Check OK
==> Executing Valid Owner Checker (4.330140493s)
    Check OK
==> Executing File Exist Checker (53.75709544s)
    Check OK

4 check(s) executed, no failure(s)
➜  magma git:(experiment_codeowners_exclude) ✗
```

test on master unfortunately, but will revert quickly if it doesn't work or breaks something
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
