### PR TITLE
[orc8r] Add certificate lifespan metric and alert

### DIFF
--- a/nms/app/packages/magmalte/alerts/cwfAlerts.js
+++ b/nms/app/packages/magmalte/alerts/cwfAlerts.js
@@ -20,6 +20,14 @@ export default function getCwfAlerts(
   networkID: string,
 ): {[string]: prom_alert_config} {
   return {
+    'Certificate Expiring Soon': {
+      alert: 'Certificate Expiring Soon',
+      expr: `cert_expires_in_hours > 720`,
+      labels: {severity: 'major'},
+      annotations: {
+        description: `Alerts when certificate necessary for Orc8r function is expiring soon`,
+      },
+    },
     'Container Restarts': {
       alert: 'Container Restarts',
       expr: `time() - container_start_time_seconds{name=~".+",name!="cadvisor", networkID=~"${networkID}"} < 300`,

--- a/nms/app/packages/magmalte/alerts/fegAlerts.js
+++ b/nms/app/packages/magmalte/alerts/fegAlerts.js
@@ -20,6 +20,14 @@ export default function getFegAlerts(
   networkID: string,
 ): {[string]: prom_alert_config} {
   return {
+    'Certificate Expiring Soon': {
+      alert: 'Certificate Expiring Soon',
+      expr: `cert_expires_in_hours > 720`,
+      labels: {severity: 'major'},
+      annotations: {
+        description: `Alerts when certificate necessary for Orc8r function is expiring soon`,
+      },
+    },
     'Service Restart Alert': {
       alert: 'Service Restart Alert',
       expr: `avg_over_time(service_restart_status{networkID=~"${networkID}"}[5m]) > 0`,

--- a/nms/app/packages/magmalte/alerts/lteAlerts.js
+++ b/nms/app/packages/magmalte/alerts/lteAlerts.js
@@ -20,6 +20,14 @@ export default function getLteAlerts(
   networkID: string,
 ): {[string]: prom_alert_config} {
   return {
+    'Certificate Expiring Soon': {
+      alert: 'Certificate Expiring Soon',
+      expr: `cert_expires_in_hours > 720`,
+      labels: {severity: 'major'},
+      annotations: {
+        description: `Alerts when certificate necessary for Orc8r function is expiring soon`,
+      },
+    },
     'Service Restart Alert': {
       alert: 'Service Restart Alert',
       expr: `increase(service_restart_status{networkID=~"${networkID}"}[5m]) > 0`,

--- a/orc8r/cloud/configs/certifier.yml
+++ b/orc8r/cloud/configs/certifier.yml
@@ -9,3 +9,27 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+# All orchestratorCerts are assumed to live in this directory
+certsDirectory: "/var/opt/magma/certs/"
+
+# These certs will be alerted on when near expiry, so only include
+# certs that are necessary for Orc8r function
+orchestratorCerts:
+  - "rootCA.pem"
+  - "admin_operator.pem"
+  - "controller.crt"
+  - "certifier.pem"
+  - "fluentd.pem"
+
+analytics:
+  # Metrics in this certifier configuration should strictly be generic in
+  # nature independent of the type of deployment. It is to be also free of any
+  # user level metrics
+  metrics:
+    # cert metrics
+    cert_expires_in_hours:
+      register: true
+      export: false
+      labels:
+        class: reliability

--- a/orc8r/cloud/configs/service_registry.yml
+++ b/orc8r/cloud/configs/service_registry.yml
@@ -75,6 +75,8 @@ services:
     host: "localhost"
     port: 9086
     proxy_type: "internal"
+    labels:
+      orc8r.io/analytics_collector: "true"
 
   bootstrapper:
     host: "localhost"

--- a/orc8r/cloud/go/services/analytics/analyzer.go
+++ b/orc8r/cloud/go/services/analytics/analyzer.go
@@ -77,7 +77,7 @@ func (a *PrometheusAnalyzer) Schedule() error {
 
 // Analyze methods runs through collectors and exports their metrics
 func (a *PrometheusAnalyzer) Analyze() {
-	glog.Info("Running  Analyze")
+	glog.V(2).Info("Running Analyze")
 	collectorClients, err := getRemoteCollectors()
 	if err != nil {
 		glog.Infof("err %v failed to get remote collectors", err)

--- a/orc8r/cloud/go/services/certifier/analytics/analytics.go
+++ b/orc8r/cloud/go/services/certifier/analytics/analytics.go
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package analytics
+
+import (
+	"magma/orc8r/cloud/go/services/analytics/calculations"
+	"magma/orc8r/cloud/go/services/certifier"
+	certifier_calcs "magma/orc8r/cloud/go/services/certifier/analytics/calculations"
+)
+
+// GetAnalyticsCalculations returns all calculations computed by the component
+func GetAnalyticsCalculations(serviceConfig *certifier.Config) []calculations.Calculation {
+	calcs := make([]calculations.Calculation, 0)
+	calcs = append(calcs, &certifier_calcs.CertLifespanCalculation{
+		CertsDirectory: serviceConfig.CertsDirectory,
+		Certs:          serviceConfig.Certs,
+		BaseCalculation: calculations.BaseCalculation{
+			CalculationParams: calculations.CalculationParams{AnalyticsConfig: &serviceConfig.Analytics},
+		},
+	})
+	return calcs
+}

--- a/orc8r/cloud/go/services/certifier/analytics/calculations/lifespan.go
+++ b/orc8r/cloud/go/services/certifier/analytics/calculations/lifespan.go
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package calculations
+
+import (
+	"crypto/x509"
+	"encoding/pem"
+	"io/ioutil"
+	"log"
+	"math"
+	"strings"
+	"time"
+
+	"magma/orc8r/cloud/go/services/analytics/calculations"
+	"magma/orc8r/cloud/go/services/analytics/protos"
+	"magma/orc8r/cloud/go/services/analytics/query_api"
+	"magma/orc8r/lib/go/metrics"
+
+	"github.com/golang/glog"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+type CertLifespanCalculation struct {
+	CertsDirectory string
+	Certs          []string
+	calculations.BaseCalculation
+}
+
+func (x *CertLifespanCalculation) Calculate(prometheusClient query_api.PrometheusAPI) ([]*protos.CalculationResult, error) {
+	glog.V(2).Infof("Calculating %s", metrics.CertExpiresInHoursMetric)
+	var results []*protos.CalculationResult
+
+	metricConfig, ok := x.AnalyticsConfig.Metrics[metrics.CertExpiresInHoursMetric]
+	if !ok {
+		glog.Errorf("%s metric not found in metric config", metrics.CertExpiresInHoursMetric)
+		return results, nil
+	}
+
+	for _, certName := range x.Certs {
+		result, err := calculateCertLifespanHours(x.CertsDirectory, certName, metricConfig.Labels)
+		if err != nil {
+			glog.Errorf("Could not get lifespan for cert %s: %+v", certName, err)
+			continue
+		}
+		results = append(results, result)
+	}
+
+	return results, nil
+}
+
+func calculateCertLifespanHours(certsDirectory string, certName string, metricConfigLabels map[string]string) (*protos.CalculationResult, error) {
+	dat, err := getCert(certsDirectory + certName)
+	if err != nil {
+		return nil, err
+	}
+	cert, err := x509.ParseCertificate(dat)
+	if err != nil {
+		return nil, err
+	}
+	// Hours remaining
+	hoursLeft := math.Floor(time.Until(cert.NotAfter).Hours())
+	labels := prometheus.Labels{
+		metrics.CertNameLabel: certName,
+	}
+	labels = calculations.CombineLabels(labels, metricConfigLabels)
+	result := calculations.NewResult(hoursLeft, metrics.CertExpiresInHoursMetric, labels)
+	glog.V(2).Infof("Calculated metric %s for %s: %f", metrics.CertExpiresInHoursMetric, certName, hoursLeft)
+	return result, nil
+}
+
+func getCert(certPath string) ([]byte, error) {
+	dat, err := ioutil.ReadFile(certPath)
+	if err != nil {
+		return nil, err
+	}
+	if strings.HasSuffix(certPath, ".pem") || strings.HasSuffix(certPath, ".crt") {
+		block, _ := pem.Decode(dat)
+		if block == nil || block.Type != "PUBLIC KEY" {
+			log.Fatal("failed to decode PEM block containing public key")
+		}
+		return block.Bytes, nil
+	}
+	return dat, nil
+}

--- a/orc8r/cloud/go/services/certifier/config.go
+++ b/orc8r/cloud/go/services/certifier/config.go
@@ -1,0 +1,25 @@
+/*
+ Copyright 2020 The Magma Authors.
+
+ This source code is licensed under the BSD-style license found in the
+ LICENSE file in the root directory of this source tree.
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package certifier
+
+import (
+	"magma/orc8r/cloud/go/services/analytics/calculations"
+)
+
+// Config represents the configuration provided to lte service
+type Config struct {
+	Analytics      calculations.AnalyticsConfig `yaml:"analytics"`
+	CertsDirectory string                       `yaml:"certsDirectory"`
+	Certs          []string                     `yaml:"orchestratorCerts"`
+}

--- a/orc8r/cloud/helm/orc8r/values.yaml
+++ b/orc8r/cloud/helm/orc8r/values.yaml
@@ -209,7 +209,8 @@ bootstrapper:
 
 certifier:
   service:
-    labels: {}
+    labels:
+      orc8r.io/analytics_collector: "true"
     annotations: {}
 
 configurator:

--- a/orc8r/lib/go/metrics/metrics_export.go
+++ b/orc8r/lib/go/metrics/metrics_export.go
@@ -22,6 +22,9 @@ import (
 )
 
 const (
+	// CertExpiryMetric
+	CertExpiresInHoursMetric = "cert_expires_in_hours"
+
 	// NetworkTypeMetric racks different network types in a deployment.
 	NetworkTypeMetric = "network_type"
 
@@ -58,6 +61,7 @@ const (
 	GatewayMagmaVersionLabel = "version"
 	QuantileLabel            = "quantile"
 	ImsiLabelName            = "IMSI"
+	CertNameLabel            = "certName"
 )
 
 // GetMetrics gathers metrics from Prometheus' default registry,


### PR DESCRIPTION
## Summary

Adds an Orc8r metric, `cert_life_hours`, which counts the remaining lifespan of a certificate used on the orchestrator. Specifically, this checks the certificate's `NotAfter` property, and compares it to the current time.

This remaining lifespan is published for the following certificate files on the Orc8r:
- `rootCA.pem`
- `admin_operator.pem`
- `controller.crt`
- `certifier.pem`
- `fluentd.pem`

The responsibility of getting and publishing this metric is placed in the `certifier` service, which currently has some responsibilities around cert management. The `analytics` service will periodically query the `certifier` service for the cert lifespan metric.

## Test Plan

Tested manually using a docker setup for Orc8r. With additional logs whenever the `analytics` service queries `certifier`, the following logs were reported:

```
controller_1     | certifier stderr | I0524 01:00:00.363915     113 lifespan.go:57] Calculate Cert Lifespan
controller_1     | certifier stderr | I0524 01:00:00.366429     113 lifespan.go:98] Calculated metric for rootCA.pem
controller_1     | certifier stderr | I0524 01:00:00.366465     113 lifespan.go:99] value:2.562047e+06 metricName:"cert_life_hours" labels:<key:"certName" value:"rootCA.pem" > labels:<key:"class" value:"reliability" >
controller_1     | certifier stderr | I0524 01:00:00.366531     113 lifespan.go:75] value:2.562047e+06 metricName:"cert_life_hours" labels:<key:"certName" value:"rootCA.pem" > labels:<key:"class" value:"reliability" >
controller_1     | certifier stderr | I0524 01:00:00.368093     113 lifespan.go:98] Calculated metric for admin_operator.pem
controller_1     | certifier stderr | I0524 01:00:00.368123     113 lifespan.go:99] value:1774 metricName:"cert_life_hours" labels:<key:"certName" value:"admin_operator.pem" > labels:<key:"class" value:"reliability" >
controller_1     | certifier stderr | I0524 01:00:00.368148     113 lifespan.go:75] value:1774 metricName:"cert_life_hours" labels:<key:"certName" value:"admin_operator.pem" > labels:<key:"class" value:"reliability" >
controller_1     | certifier stderr | I0524 01:00:00.368892     113 lifespan.go:98] Calculated metric for controller.crt
controller_1     | certifier stderr | I0524 01:00:00.368901     113 lifespan.go:99] value:866495 metricName:"cert_life_hours" labels:<key:"certName" value:"controller.crt" > labels:<key:"class" value:"reliability" >
controller_1     | certifier stderr | I0524 01:00:00.368921     113 lifespan.go:75] value:866495 metricName:"cert_life_hours" labels:<key:"certName" value:"controller.crt" > labels:<key:"class" value:"reliability" >
controller_1     | certifier stderr | I0524 01:00:00.370022     113 lifespan.go:98] Calculated metric for certifier.pem
controller_1     | certifier stderr | I0524 01:00:00.370055     113 lifespan.go:99] value:2.562047e+06 metricName:"cert_life_hours" labels:<key:"certName" value:"certifier.pem" > labels:<key:"class" value:"reliability" >
```

Synced pre-defined alerts with development setup:
<img width="905" alt="Screen Shot 2021-05-24 at 10 59 30 PM" src="https://user-images.githubusercontent.com/804385/119446702-b7ab7f80-bce3-11eb-8bf2-cd4b23254c86.png">


## Additional Information

- [ ] This change is backwards-breaking
