### PR TITLE
Change ownership of swagger/proto generated files to ghost

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,30 +1,40 @@
+# approvers-ci
 .circleci/ @magma/approvers-ci
 circleci/ @magma/approvers-ci
-
 ci-scripts/ @magma/approvers-ci
-
-*/cloud/ @magma/approvers-orc8r
-.golangci.yml @magma/approvers-orc8r
-
-orc8r/ @magma/approvers-orc8r
 orc8r/tools/packer/ @magma/approvers-ci
 orc8r/cloud/deploy/bare-metal/ @magma/approvers-ci
 orc8r/cloud/deploy/bare-metal-ansible/ @magma/approvers-ci
-
-orc8r/gateway/c/ @magma/approvers-agw-c
-
-feg/ @magma/approvers-feg
-
-cwf/ @magma/approvers-cwf
+lte/gateway/docker @magma/approvers-ci
+lte/gateway/release @magma/approvers-ci
+lte/gateway/Vagrantfile @magma/approvers-ci
 cwf/gateway/Vagrantfile @magma/approvers-ci
 
+# approvers-orc8r
+*/cloud/ @magma/approvers-orc8r
+.golangci.yml @magma/approvers-orc8r
+orc8r/ @magma/approvers-orc8r
+
+# approvers-nms
+nms/ @magma/approvers-nms
+
+# approvers-feg
+feg/ @magma/approvers-feg
+
+# approvers-cwf
+cwf/ @magma/approvers-cwf
+
+# approvers-openwrt
 openwrt/ @magma/approvers-openwrt
 
-# More specific mappings for lte/gateway will override this top-level one
+# approvers-agw / approvers-agw-python / approvers-agw-c
 lte/gateway @magma/approvers-agw
+lte/protos @magma/approvers-agw
 lte/gateway/python @magma/approvers-agw-python
 lte/gateway/c @magma/approvers-agw-c
+orc8r/gateway/c/ @magma/approvers-agw-c
 
+# approvers-agw-<subsection>
 lte/gateway/c/session_manager @magma/approvers-agw-sessiond
 lte/gateway/c/oai @magma/approvers-agw-mme
 lte/gateway/c/sctpd @magma/approvers-agw-mme
@@ -32,21 +42,9 @@ lte/gateway/c/connection_tracker @koolzz
 lte/gateway/python/magma/pipelined @magma/approvers-agw-pipelined
 lte/gateway/python/integ_tests @magma/approvers-agw-integtests
 
-lte/gateway/docker @magma/approvers-ci
-lte/gateway/release @magma/approvers-ci
-lte/gateway/Vagrantfile @magma/approvers-ci
-
-**/*.pb.go @magma/repo-magma-maintain
-**/*_swaggergen.go @magma/repo-magma-maintain
-orc8r/cloud/go/obsidian/swagger/v1/swagger.yml @magma/repo-magma-maintain
-orc8r/cloud/go/obsidian/swagger/v1/client/ @magma/repo-magma-maintain
-orc8r/cloud/go/obsidian/swagger/v1/models/ @magma/repo-magma-maintain
-
 # XWF Magma integrations
 xwf/ @magma/approvers-xwf
 feg/radius @magma/approvers-xwf @magma/approvers-cwf
-
-nms/ @magma/approvers-nms
 
 docs/ @magma/approvers-docs
 docs/readmes/proposals @electronjoe
@@ -56,3 +54,8 @@ CODEOWNERS @amarpad @electronjoe
 # Paths excluded from code ownership
 **/go.mod @ghost
 **/go.sum @ghost
+**/*.pb.go @ghost
+**/*_swaggergen.go @ghost
+orc8r/cloud/go/obsidian/swagger/v1/swagger.yml @ghost
+orc8r/cloud/go/obsidian/swagger/v1/client/ @ghost
+orc8r/cloud/go/obsidian/swagger/v1/models/ @ghost


### PR DESCRIPTION
Signed-off-by: Marie Bremner <marwhal@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary
I landed https://github.com/magma/magma/pull/7082 (same change for go.mod/go.sum) this morning and it seems to be working fine. (Ex: https://github.com/magma/magma/pull/7126)

This PR makes it so that the swagger/proto generated files are also not owned by anyone. The insync check will not allow anyone to make changes in the generated files directly without modifying the source template. And since the source template is still owned by an appropriate set of owners, we should be good to go. 
<!-- Enumerate changes you made and why you made them -->

## Test Plan
Did codeowners syntax check
```
➜  magma git:(remove-code-ownership-from-generated-files) ✗ docker run --rm -v $(pwd):/repo -w /repo \
  -e REPOSITORY_PATH="." \
  -e GITHUB_ACCESS_TOKEN="$GH_TOKEN" \
  -e OWNER_CHECKER_REPOSITORY="magma/magma" \
  mszostok/codeowners-validator:v0.6.0
==> Executing Duplicated Pattern Checker (73.162µs)
    Check OK
==> Executing Valid Syntax Checker (149.066µs)
    Check OK
==> Executing Valid Owner Checker (5.126020519s)
    Check OK
==> Executing File Exist Checker (10.51958363s)
    Check OK

4 check(s) executed, no failure(s)
```
test in master?
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
