### PR TITLE
fix: [sessiond] only unsuspend credits that have non 0 quota (#7037)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,10 +29,8 @@ env/
 develop-eggs/
 dist/
 eggs/
-lib/
 lib64/
-!orc8r/lib/
-!feg/radius/lib/
+build/lib/
 parts/
 sdist/
 var/

--- a/cwf/gateway/integ_tests/gx_reauth_test.go
+++ b/cwf/gateway/integ_tests/gx_reauth_test.go
@@ -181,7 +181,10 @@ func TestGxReAuthWithMidSessionPoliciesRemoval(t *testing.T) {
 	)
 	assert.NoError(t, err)
 	assert.Eventually(t, tr.WaitForPolicyReAuthToProcess(raa, imsi), time.Minute, 2*time.Second)
-	assert.Equal(t, diam.Success, int(raa.ResultCode))
+	assert.NotNil(t, raa)
+	if raa != nil {
+		assert.Equal(t, diam.Success, int(raa.ResultCode))
+	}
 
 	// Check that all UE mac flows are deleted
 	tr.WaitForEnforcementStatsToSync()

--- a/lte/gateway/c/session_manager/ChargingGrant.cpp
+++ b/lte/gateway/c/session_manager/ChargingGrant.cpp
@@ -207,19 +207,26 @@ bool ChargingGrant::get_update_type(
 }
 
 bool ChargingGrant::should_deactivate_service() const {
-  if ((final_action_info.final_action ==
-       ChargingCredit_FinalAction_TERMINATE) &&
+  const bool final_action_is_terminate =
+      final_action_info.final_action == ChargingCredit_FinalAction_TERMINATE;
+  const bool is_final_and_credit_exhausted =
+      is_final_grant && credit.is_quota_exhausted(1);
+
+  if (!is_final_and_credit_exhausted) {
+    return false;
+  }
+
+  if (final_action_is_terminate &&
       !SessionCredit::TERMINATE_SERVICE_WHEN_QUOTA_EXHAUSTED) {
     // configured in sessiond.yml
     return false;
   }
-  if (service_state != SERVICE_ENABLED) {
-    // service is not enabled
-    return false;
-  }
-  if (is_final_grant && credit.is_quota_exhausted(1)) {
-    // We only deactivate service when we receive a Final Unit
-    // Indication (final Grant) and we've exhausted all quota
+
+  // 1. Disable if the credit is out of quota and final action is terminate
+  // 2. Disable if the credit is out of quota and final action is
+  //    redirect/restrict IF if it hasn't been acted on already (state is
+  //    ENABLED)
+  if (final_action_is_terminate || service_state == SERVICE_ENABLED) {
     MLOG(MINFO) << "Deactivating service because we have exhausted the given "
                 << "quota and it is the final grant."
                 << "action="
@@ -247,6 +254,18 @@ ServiceActionType ChargingGrant::get_action(SessionCreditUpdateCriteria& uc) {
     default:
       return CONTINUE_SERVICE;
   }
+}
+
+bool ChargingGrant::should_be_unsuspended() const {
+  // transitioning out of FUA-redirect/restrict
+  if (service_state == SERVICE_NEEDS_ACTIVATION) {
+    return true;
+  }
+  // transitioning out of credit suspension
+  if (suspended && !credit.is_quota_exhausted(1)) {
+    return true;
+  }
+  return false;
 }
 
 ServiceActionType ChargingGrant::final_action_to_action(
@@ -304,10 +323,6 @@ void ChargingGrant::set_suspended(
   }
   suspended     = new_suspended;
   uc->suspended = new_suspended;
-}
-
-bool ChargingGrant::get_suspended() {
-  return suspended;
 }
 
 void ChargingGrant::reset_reporting_grant(

--- a/lte/gateway/c/session_manager/ChargingGrant.h
+++ b/lte/gateway/c/session_manager/ChargingGrant.h
@@ -84,6 +84,11 @@ struct ChargingGrant {
   // update. If no action needs to take place, CONTINUE_SERVICE is returned.
   ServiceActionType get_action(SessionCreditUpdateCriteria& update_criteria);
 
+  // Return if the service needs activation
+  bool should_be_unsuspended() const;
+
+  bool get_suspended() const { return suspended; }
+
   // Get unreported usage from credit and return as part of CreditUsage
   // The update_type is also included in CreditUsage
   // If the grant is final or is_terminate is true, we include all unreported
@@ -97,7 +102,13 @@ struct ChargingGrant {
   // grant
   RequestedUnits get_requested_units();
 
-  // Return true if the service needs to be deactivated
+  // Return true if the service needs to be deactivated.
+  // In order to deactivate, a few things are considered in order.
+  // 1. Credit must be exhausted
+  // 2. TERMINATE_SERVICE_WHEN_QUOTA_EXHAUSTED is not set
+  // 3. FUA must be set
+  //    3a. For FUA-terminate, always deactivate
+  //    3b. For FUA-redirect/restrict, deactivate if not already deactivated
   bool should_deactivate_service() const;
 
   // Convert FinalAction enum to ServiceActionType
@@ -107,14 +118,7 @@ struct ChargingGrant {
   ServiceActionType final_action_to_action_on_suspension(
       const ChargingCredit_FinalAction action) const;
 
-  // Set is_final_grant and final_action_info values
-  void set_final_action_info(
-      const magma::lte::ChargingCredit& credit,
-      SessionCreditUpdateCriteria* uc = NULL);
-
-  bool get_suspended();
-
-  void set_suspended(bool suspended, SessionCreditUpdateCriteria* uc);
+  void set_suspended(bool suspended, SessionCreditUpdateCriteria* credit_uc);
 
   // Set the object and update criteria's reauth state to new_state.
   void set_reauth_state(

--- a/lte/gateway/c/session_manager/LocalEnforcer.cpp
+++ b/lte/gateway/c/session_manager/LocalEnforcer.cpp
@@ -1259,69 +1259,84 @@ void LocalEnforcer::add_rules_for_unsuspended_credit(
       imsi, session->get_config(), rules_to_add, RulesToProcess{}, false);
 }
 
+bool LocalEnforcer::handle_credit_update_failure(
+    const CreditUpdateResponse& credit_update_resp,
+    UpdateChargingCreditActions* actions) const {
+  const std::string& imsi       = credit_update_resp.sid();
+  const std::string& session_id = credit_update_resp.session_id();
+  const uint32_t& ckey          = credit_update_resp.charging_key();
+  const uint32_t& result_code   = credit_update_resp.result_code();
+
+  if (credit_update_resp.success()) {
+    return true;
+  }
+  // handle permanent failure -> terminate
+  if (DiameterCodeHandler::is_permanent_failure(result_code)) {
+    MLOG(MERROR) << session_id << " Received permanent failure result code "
+                 << result_code << " during update" << session_id;
+    actions->sessions_to_terminate.insert(ImsiAndSessionID(imsi, session_id));
+    return false;
+  } else if (DiameterCodeHandler::is_transient_failure(result_code)) {
+    // handle transient failure -> suspend
+    MLOG(MERROR) << session_id << " Received transient failure result code "
+                 << result_code << " during update" << session_id;
+    actions->suspended_credits.insert(
+        ImsiSessionIDAndCreditkey{imsi, session_id, ckey});
+  } else {
+    // TODO( ): deal with other error codes
+    MLOG(MERROR) << "Received Unimplemented result code " << result_code
+                 << " for " << session_id << " during update. Not action taken";
+  }
+  return true;
+}
+
 void LocalEnforcer::update_charging_credits(
     SessionMap& session_map, const UpdateSessionResponse& response,
     UpdateChargingCreditActions& actions, SessionUpdate& session_update) {
   for (const auto& credit_update_resp : response.responses()) {
     const std::string& imsi       = credit_update_resp.sid();
     const std::string& session_id = credit_update_resp.session_id();
-    const auto ckey               = credit_update_resp.charging_key();
+    const uint32_t& charging_key  = credit_update_resp.charging_key();
     SessionSearchCriteria criteria(imsi, IMSI_AND_SESSION_ID, session_id);
     auto session_it = session_store_.find_session(session_map, criteria);
     if (!session_it) {
       MLOG(MERROR) << "Could not find session " << session_id
-                   << " during charging update for RG " << ckey;
+                   << " during charging update for RG " << charging_key;
       continue;
     }
-    auto& session    = **session_it;
-    auto& uc         = session_update[imsi][session_id];
-    auto result_code = credit_update_resp.result_code();
+    auto& session = **session_it;
+    auto& uc      = session_update[imsi][session_id];
 
-    // handle permanent failure -> terminate
-    if (!credit_update_resp.success() &&
-        DiameterCodeHandler::is_permanent_failure(result_code)) {
-      MLOG(MERROR) << session_id << " Received permanent failure result code "
-                   << result_code << " during update" << session_id;
-      actions.sessions_to_terminate.insert(ImsiAndSessionID(imsi, session_id));
+    // handle credit level result code / success field
+    // this function will return true if the credit should further be processed
+    if (!handle_credit_update_failure(credit_update_resp, &actions)) {
       continue;
     }
 
     const auto& credit_key(credit_update_resp);
     // We need to retrieve restrict_rules and is_final_action_state
     // prior to receiving charging credit as they will be updated.
-    optional<FinalActionInfo> final_action_info =
+    optional<FinalActionInfo> prev_final_action =
         session->get_final_action_if_final_unit_state(credit_key);
     bool valid_credit =
         session->receive_charging_credit(credit_update_resp, uc);
     session->set_tgpp_context(credit_update_resp.tgpp_ctx(), uc);
 
+    bool should_activate = session->is_credit_ready_to_be_activated(credit_key);
+    if (!should_activate) {
+      continue;
+    }
+    // This credit is now out of quota and need to be acted on
     // handle suspended credits -> unsuspend
     if (valid_credit && session->is_credit_suspended(credit_key)) {
       actions.unsuspended_credits.insert(
-          ImsiSessionIDAndCreditkey{imsi, session_id, ckey});
+          ImsiSessionIDAndCreditkey{imsi, session_id, charging_key});
     }
 
-    // handle other failures
-    if (!credit_update_resp.success()) {
-      // handle transient failure -> suspend
-      if (DiameterCodeHandler::is_transient_failure(
-              credit_update_resp.result_code())) {
-        MLOG(MERROR) << session_id << " Received transient failure result code "
-                     << result_code << " during update" << session_id;
-        actions.suspended_credits.insert(
-            ImsiSessionIDAndCreditkey{imsi, session_id, ckey});
-      } else {
-        // TODO: deal with other error codes
-        MLOG(MERROR) << "Received Unimplemented result code " << result_code
-                     << " for " << session_id
-                     << " during update. Not action taken";
-      }
-    }
-
-    // TODO: move it to actions vector
-    if (final_action_info) {
+    // TODO( ): move it to actions vector
+    if (prev_final_action) {
       RulesToProcess gy_rules =
-          session->remove_all_final_action_rules(*final_action_info, uc);
+          session->remove_all_final_action_rules(*prev_final_action, uc);
       if (!gy_rules.rules.empty()) {
         auto config = session->get_config().common_context;
         // We need to cancel final unit action flows installed in pipelined here

--- a/lte/gateway/c/session_manager/LocalEnforcer.h
+++ b/lte/gateway/c/session_manager/LocalEnforcer.h
@@ -363,6 +363,17 @@ class LocalEnforcer {
           dynamic_rule_installs);
 
   /**
+   * @brief
+   *
+   * @param credit_update_resp
+   * @param actions output parameter
+   * @return true if the credit should be processed further, false otherwise
+   */
+  bool handle_credit_update_failure(
+      const CreditUpdateResponse& credit_update_resp,
+      UpdateChargingCreditActions* actions) const;
+
+  /**
    * Processes the charging component of UpdateSessionResponse.
    * Updates charging credits according to the response.
    */

--- a/lte/gateway/c/session_manager/SessionState.cpp
+++ b/lte/gateway/c/session_manager/SessionState.cpp
@@ -1341,6 +1341,9 @@ bool SessionState::receive_charging_credit(
                 << " Activating service RG: " << key << " for " << session_id_;
     grant->set_service_state(SERVICE_NEEDS_ACTIVATION, *credit_uc);
   }
+  if (grant->should_deactivate_service()) {
+    grant->set_service_state(SERVICE_NEEDS_DEACTIVATION, *credit_uc);
+  }
   return true;
 }
 
@@ -1380,6 +1383,16 @@ bool SessionState::is_credit_suspended(const CreditKey& charging_key) {
   if (it != credit_map_.end()) {
     auto& grant = it->second;
     return grant->get_suspended();
+  }
+  return false;
+}
+
+bool SessionState::is_credit_ready_to_be_activated(
+    const CreditKey& charging_key) {
+  auto it = credit_map_.find(charging_key);
+  if (it != credit_map_.end()) {
+    auto& grant = it->second;
+    return grant->should_be_unsuspended();
   }
   return false;
 }

--- a/lte/gateway/c/session_manager/SessionState.h
+++ b/lte/gateway/c/session_manager/SessionState.h
@@ -427,6 +427,8 @@ class SessionState {
 
   bool is_credit_suspended(const CreditKey& charging_key);
 
+  bool is_credit_ready_to_be_activated(const CreditKey& charging_key);
+
   RuleLifetime& get_rule_lifetime(const std::string& rule_id);
 
   DynamicRuleStore& get_gy_dynamic_rules();

--- a/lte/gateway/c/session_manager/test/ProtobufCreators.cpp
+++ b/lte/gateway/c/session_manager/test/ProtobufCreators.cpp
@@ -112,7 +112,8 @@ void create_rule_record(
 
 void create_charging_credit(
     uint64_t volume, bool is_final, ChargingCredit* credit) {
-  create_granted_units(&volume, NULL, NULL, credit->mutable_granted_units());
+  create_granted_units(
+      &volume, nullptr, nullptr, credit->mutable_granted_units());
   credit->set_type(ChargingCredit::BYTES);
   credit->set_is_final(is_final);
 }
@@ -121,7 +122,8 @@ void create_charging_credit(
     uint64_t volume, ChargingCredit_FinalAction action,
     std::string redirect_server, std::string restrict_rule,
     ChargingCredit* credit) {
-  create_granted_units(&volume, NULL, NULL, credit->mutable_granted_units());
+  create_granted_units(
+      &volume, nullptr, nullptr, credit->mutable_granted_units());
   credit->set_type(ChargingCredit::BYTES);
   credit->set_is_final(true);
   credit->set_final_action(action);
@@ -408,15 +410,15 @@ void create_policy_rule(
 
 void create_granted_units(
     uint64_t* total, uint64_t* tx, uint64_t* rx, GrantedUnits* gsu) {
-  if (total != NULL) {
+  if (total != nullptr) {
     gsu->mutable_total()->set_is_valid(true);
     gsu->mutable_total()->set_volume(*total);
   }
-  if (tx != NULL) {
+  if (tx != nullptr) {
     gsu->mutable_tx()->set_is_valid(true);
     gsu->mutable_tx()->set_volume(*tx);
   }
-  if (rx != NULL) {
+  if (rx != nullptr) {
     gsu->mutable_rx()->set_is_valid(true);
     gsu->mutable_rx()->set_volume(*rx);
   }

--- a/lte/gateway/c/session_manager/test/test_charging_grant.cpp
+++ b/lte/gateway/c/session_manager/test/test_charging_grant.cpp
@@ -169,12 +169,21 @@ TEST_F(ChargingGrantTest, test_should_deactivate_service) {
   grant.service_state                  = SERVICE_ENABLED;
   EXPECT_TRUE(grant.should_deactivate_service());
 
-  // If service state is not ENABLED we should not deactivate service
+  // If service state is not ENABLED we should not deactivate service for FUA
+  // redirect / restrict
+  SessionCredit::TERMINATE_SERVICE_WHEN_QUOTA_EXHAUSTED = true;
+  grant.is_final_grant                                  = true;
+  grant.final_action_info.final_action = ChargingCredit_FinalAction_REDIRECT;
+  grant.service_state                  = SERVICE_DISABLED;
+  EXPECT_FALSE(grant.should_deactivate_service());
+
+  // If service state is not ENABLED we should deactivate service for FUA
+  // terminate
   SessionCredit::TERMINATE_SERVICE_WHEN_QUOTA_EXHAUSTED = true;
   grant.is_final_grant                                  = true;
   grant.final_action_info.final_action = ChargingCredit_FinalAction_TERMINATE;
   grant.service_state                  = SERVICE_DISABLED;
-  EXPECT_FALSE(grant.should_deactivate_service());
+  EXPECT_TRUE(grant.should_deactivate_service());
 }
 
 TEST_F(ChargingGrantTest, test_get_action) {


### PR DESCRIPTION
Signed-off-by: Marie Bremner <marwhal@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary
backport https://github.com/magma/magma/pull/7037

<!-- Enumerate changes you made and why you made them -->

## Test Plan
CircleCI cwf : https://app.circleci.com/pipelines/github/magma/magma/23527/workflows/5d4c44ce-f74b-43f7-ae3d-49cfe71b7849/jobs/249014
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
