### PR TITLE
reduce noisy error level log in sessiond

### DIFF
--- a/lte/gateway/c/session_manager/ChargingGrant.cpp
+++ b/lte/gateway/c/session_manager/ChargingGrant.cpp
@@ -389,7 +389,7 @@ static RedirectInformation_AddressType address_type_converter(
     case RedirectServer_RedirectAddressType_SIP_URI:
       return RedirectInformation_AddressType_SIP_URI;
     default:
-      MLOG(MERROR) << "Unknown redirect address type!";
+      MLOG(MWARNING) << "Unknown redirect address type!";
       return RedirectInformation_AddressType_IPv4;
   }
 }

--- a/lte/gateway/c/session_manager/LocalEnforcer.cpp
+++ b/lte/gateway/c/session_manager/LocalEnforcer.cpp
@@ -217,9 +217,7 @@ void LocalEnforcer::sync_sessions_on_restart(std::time_t current_time) {
     }
   }
   bool success = session_store_.update_sessions(session_update);
-  if (success) {
-    MLOG(MDEBUG) << "Successfully synced sessions after restart";
-  } else {
+  if (!success) {
     MLOG(MERROR) << "Failed to sync sessions after restart";
   }
 }
@@ -1826,8 +1824,8 @@ void LocalEnforcer::update_ipfix_flow(
   std::string apn_mac_addr;
   std::string apn_name;
   if (!parse_apn(config.common_context.apn(), apn_mac_addr, apn_name)) {
-    MLOG(MWARNING) << "Failed mac/name parsiong for apn "
-                   << config.common_context.apn();
+    MLOG(MDEBUG) << "Failed mac/name parsiong for apn "
+                 << config.common_context.apn();
     apn_mac_addr = "";
     apn_name     = config.common_context.apn();
   }

--- a/orc8r/gateway/c/common/policydb/PolicyLoader.cpp
+++ b/orc8r/gateway/c/common/policydb/PolicyLoader.cpp
@@ -66,9 +66,6 @@ bool do_loop(
     MLOG(MERROR) << "Failed to get rules from map because map error " << result;
     return false;
   }
-  if (rules.size() > 0) {
-    MLOG(MDEBUG) << rules.size() << " rules synced";
-  }
   processor(rules);
   return true;
 }


### PR DESCRIPTION
Signed-off-by: Marie Bremner <marwhal@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary
I'm seeing tons of noisy error level logs like these:
```
May 21 16:52:17 phy-u2 sessiond[1067372]: I0521 16:52:17.786420 1067372 SessionState.cpp:473] Reported rule (internal_default_drop_flow_rule) not found, ignoring
May 21 16:52:17 phy-u2 sessiond[1067372]: I0521 16:52:17.786453 1067372 SessionState.cpp:473] Reported rule (internal_default_drop_flow_rule) not found, ignoring
May 21 16:52:17 phy-u2 sessiond[1067372]: I0521 16:52:17.786485 1067372 SessionState.cpp:473] Reported rule (internal_default_drop_flow_rule) not found, ignoring
May 21 16:52:17 phy-u2 sessiond[1067372]: I0521 16:52:17.786516 1067372 SessionState.cpp:473] Reported rule (internal_default_drop_flow_rule) not found, ignoring
```
Logging about the drop flow is not very useful, so adding a condition to only log if it's not that rule.
<!-- Enumerate changes you made and why you made them -->

## Test Plan
make precommit_sm
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
