### PR TITLE
Fix loading all subscriber state

### DIFF
--- a/lte/cloud/go/services/subscriberdb/obsidian/handlers/handlers_test.go
+++ b/lte/cloud/go/services/subscriberdb/obsidian/handlers/handlers_test.go
@@ -1045,7 +1045,7 @@ func TestGetSubscriber(t *testing.T) {
 }
 
 func TestGetSubscriberByExactIMSI(t *testing.T) {
-	// regression test to ensure we are loading states with the exact same IMSI
+	// Regression test to ensure we are loading states with the exact same IMSI
 	// key as the subscriber
 
 	configuratorTestInit.StartTestService(t)
@@ -1116,7 +1116,7 @@ func TestGetSubscriberByExactIMSI(t *testing.T) {
 	ctx := test_utils.GetContextWithCertificate(t, "hw1")
 	test_utils.ReportState(t, ctx, lte.ICMPStateType, "IMSI1234567890", icmpStatus, serdes.State)
 
-	// sub1 and sub2 differ in their mme states
+	// Sub1 and sub2 differ in their mme states
 	mmeState1 := state.ArbitraryJSON{"mme": "foo"}
 	test_utils.ReportState(t, ctx, lte.MMEStateType, "IMSI1234567890", &mmeState1, serdes.State)
 	mmeState2 := state.ArbitraryJSON{"mme": "foo"}
@@ -1125,7 +1125,6 @@ func TestGetSubscriberByExactIMSI(t *testing.T) {
 	sub1_with_state := sub1.ToSubscriber()
 	sub1_with_state.Monitoring = &subscriberModels.SubscriberStatus{
 		Icmp: &subscriberModels.IcmpStatus{
-			// LastReportedTime is calculated in milliseconds
 			LastReportedTime: frozenClock * 1000,
 			LatencyMs:        f32Ptr(12.34),
 		},
@@ -1134,7 +1133,7 @@ func TestGetSubscriberByExactIMSI(t *testing.T) {
 		Mme: mmeState1,
 	}
 
-	// should only report states for IMSI1234567890, not IMSI123456789000
+	// Should only report states for IMSI1234567890, not IMSI123456789000
 	tc = tests.Test{
 		Method:         "GET",
 		URL:            getSubscriberURL,

--- a/lte/cloud/go/services/subscriberdb/obsidian/handlers/handlers_test.go
+++ b/lte/cloud/go/services/subscriberdb/obsidian/handlers/handlers_test.go
@@ -1045,10 +1045,9 @@ func TestGetSubscriber(t *testing.T) {
 	tests.RunUnitTest(t, e, tc)
 }
 
+// TestGetSubscriberByExactIMSI is a regression test to ensure we are loading
+// states with the exact same IMSI key as the subscriber
 func TestGetSubscriberByExactIMSI(t *testing.T) {
-	// Regression test to ensure we are loading states with the exact same IMSI
-	// key as the subscriber
-
 	configuratorTestInit.StartTestService(t)
 	deviceTestInit.StartTestService(t)
 	stateTestInit.StartTestService(t)

--- a/lte/cloud/go/services/subscriberdb/obsidian/handlers/handlers_test.go
+++ b/lte/cloud/go/services/subscriberdb/obsidian/handlers/handlers_test.go
@@ -1169,7 +1169,7 @@ func TestGetSubscriberByExactIMSI(t *testing.T) {
 		ParamValues:    []string{"n1", "IMSI123"},
 		ExpectedStatus: 200,
 		ExpectedResult: &subscriberModels.Subscriber{
-			ID: "IMSI123",
+			ID:   "IMSI123",
 			Name: "Jane Doe",
 			Lte: &subscriberModels.LteSubscription{
 				AuthAlgo:   "MILENAGE",
@@ -1197,7 +1197,7 @@ func TestGetSubscriberByExactIMSI(t *testing.T) {
 				},
 			},
 			State: &subscriberModels.SubscriberState{
-				Mme:  mmeState,
+				Mme: mmeState,
 			},
 		},
 	}

--- a/orc8r/cloud/go/services/state/client_api.go
+++ b/orc8r/cloud/go/services/state/client_api.go
@@ -15,7 +15,6 @@ package state
 
 import (
 	"context"
-	"regexp"
 
 	"magma/orc8r/cloud/go/serde"
 	state_types "magma/orc8r/cloud/go/services/state/types"
@@ -25,14 +24,6 @@ import (
 
 	"github.com/golang/glog"
 	"github.com/thoas/go-funk"
-)
-
-const (
-	IMSIExpectedMatchCount = 2
-)
-
-var (
-	IMSIKeyRe = regexp.MustCompile(`^(?P<imsi>IMSI\d+).*$`)
 )
 
 // GetStateClient returns a client to the state service.

--- a/orc8r/cloud/go/services/state/client_api.go
+++ b/orc8r/cloud/go/services/state/client_api.go
@@ -113,26 +113,7 @@ func SearchStates(networkID string, typeFilter []string, keyFilter []string, key
 		return nil, err
 	}
 
-	states, err := state_types.MakeStatesByID(res.States, serdes)
-	if err != nil {
-		return nil, err
-	}
-
-	// check if all state IDs have the exact IMSI prefix (if keyPrefix was specified)
-	if !funk.IsEmpty(keyPrefix) {
-		for stateID := range states {
-			matches := IMSIKeyRe.FindStringSubmatch(stateID.DeviceID)
-			if len(matches) != IMSIExpectedMatchCount {
-				glog.Errorf("state device ID %s did not match IMSI-prefixed regex", stateID.DeviceID)
-				continue
-			}
-			if matches[1] != *keyPrefix {
-				delete(states, stateID)
-			}
-		}
-	}
-
-	return states, nil
+	return state_types.MakeStatesByID(res.States, serdes)
 }
 
 // DeleteStates deletes states specified by the networkID and a list of

--- a/orc8r/cloud/go/services/state/client_api.go
+++ b/orc8r/cloud/go/services/state/client_api.go
@@ -120,7 +120,7 @@ func SearchStates(networkID string, typeFilter []string, keyFilter []string, key
 
 	// check if all state IDs have the exact IMSI prefix (if keyPrefix was specified)
 	if !funk.IsEmpty(keyPrefix) {
-		for stateID, _ := range states {
+		for stateID := range states {
 			matches := IMSIKeyRe.FindStringSubmatch(stateID.DeviceID)
 			if len(matches) != IMSIExpectedMatchCount {
 				glog.Errorf("state device ID %s did not match IMSI-prefixed regex", stateID.DeviceID)


### PR DESCRIPTION
Signed-off-by: Yuanyuting Wang <yuanyutingwang@fb.com><!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->
1. Add step in [SearchStates](https://github.com/magma/magma/blob/0a16e586054d0a416bbd9a2d2c547fffd3e610c6/orc8r/cloud/go/services/state/client_api.go#L80-L107) of `subscriberdb` to filter for states with exact match of the IMSI prefix (if specified) 
2. Add regression test to highlight this functionality

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->
1. Run the existing test suites; all tests should pass
*Note*: augmented test case `TestGetSubscriberByExactIMSI` is located in [the handlers_test.go for the subscriberdb service](https://github.com/magma/magma/blob/0a16e586054d0a416bbd9a2d2c547fffd3e610c6/lte/cloud/go/services/subscriberdb/obsidian/handlers/handlers_test.go).

## Additional Information


<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
