### PR TITLE
[backport 1.5] AGW: datapath: Fix iptable rule config.

### DIFF
--- a/lte/gateway/deploy/roles/magma/files/magma_ifaces_gtp
+++ b/lte/gateway/deploy/roles/magma/files/magma_ifaces_gtp
@@ -9,8 +9,8 @@ iface gtp_br0 inet static
     pre-up ip link add proxy_port type veth peer name proxy_port_ns || true
     pre-up ip link set proxy_port up || true
     up sysctl net.ipv4.ip_forward=1
-    up iptables -t mangle -A FORWARD -i gtp_br0 -p tcp --tcp-flags SYN,RST SYN -j TCPMSS --set-mss 1400
-    up iptables -t mangle -A FORWARD -o gtp_br0 -p tcp --tcp-flags SYN,RST SYN -j TCPMSS --set-mss 1400
+    up iptables -t mangle -C FORWARD -i gtp_br0 -p tcp --tcp-flags SYN,RST SYN -j TCPMSS --set-mss 1400 || iptables -t mangle -A FORWARD -i gtp_br0 -p tcp --tcp-flags SYN,RST SYN -j TCPMSS --set-mss 1400
+    up iptables -t mangle -C FORWARD -o gtp_br0 -p tcp --tcp-flags SYN,RST SYN -j TCPMSS --set-mss 1400 || iptables -t mangle -A FORWARD -o gtp_br0 -p tcp --tcp-flags SYN,RST SYN -j TCPMSS --set-mss 1400
     ovs_type OVSBridge
     ovs_ports gtp0 mtr0 ipfix0 patch-up proxy_port
 

--- a/lte/gateway/python/magma/pipelined/main.py
+++ b/lte/gateway/python/magma/pipelined/main.py
@@ -127,8 +127,11 @@ def main():
 
     # TODO fix this hack for XWF
     if enable_nat is True or service.config.get('setup_type') == 'XWF':
-        call_process('iptables -t nat -A POSTROUTING -o %s -j MASQUERADE'
-                     % service.config['nat_iface'],
+        ip_table_rule = 'POSTROUTING -o %s -j MASQUERADE' % service.config['nat_iface']
+        check_and_add = 'iptables -t nat -C %s || iptables -t nat -A %s' % \
+                        (ip_table_rule, ip_table_rule)
+        logging.debug("check_and_add: %s", check_and_add)
+        call_process(check_and_add,
                      callback,
                      service.loop
                      )


### PR DESCRIPTION
Rather than adding rule on every restart, check for rule.
this avoids accumulation of iptable rules on every service restart.

Signed-off-by: Pravin B Shelar <pbshelar@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->

## Test Plan
tested on lab AGW.
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
