### PR TITLE
[nms] NMS startup creates a default master user and organization if none exist

### DIFF
--- a/docs/readmes/orc8r/legacy/nms_setup.md
+++ b/docs/readmes/orc8r/legacy/nms_setup.md
@@ -19,11 +19,8 @@ In the `magmalte` directory, start docker containers and create a test user:
 ```bash
 HOST [magma]$ cd nms/fbcnms-projects/magmalte
 HOST [magma/nms/fbcnms-projects/magmalte]$ docker-compose up -d
-HOST [magma/nms/fbcnms-projects/magmalte]$ ./scripts/dev_setup.sh
 ```
-You may get an error if you run `dev_setup.sh` immediately after `docker-compose up -d`. To resolve this, wait a bit before running the script to let migrations run.
-
-Once you have started the docker containers and created a test user using the `dev_setup.sh` script, go to https://localhost and login with test credentials `admin@magma.test` and `password1234`.
+Once you have started the docker containers, go to https://localhost and login with test credentials `admin@magma.test` and `password1234`.
 
 Note: if you want to name a user other than `admin@magma.test`, you can run `setAdminPassword`, like so:
 ```bash

--- a/nms/app/packages/magmalte/scripts/server.js
+++ b/nms/app/packages/magmalte/scripts/server.js
@@ -23,6 +23,7 @@ if (!process.env.NODE_ENV) {
 
 import app from '../server/app';
 import logging from '@fbcnms/logging';
+import {createDefaultUserIfNoneExist} from './setPassword';
 import {runMigrations} from './runMigrations';
 
 const logger = logging.getLogger(module);
@@ -30,6 +31,7 @@ const port = parseInt(process.env.PORT || 80);
 
 (async function main() {
   await runMigrations();
+  await createDefaultUserIfNoneExist();
   app.listen(port, '', err => {
     if (err) {
       logger.error(err.toString());

--- a/nms/app/packages/magmalte/scripts/setPassword.js
+++ b/nms/app/packages/magmalte/scripts/setPassword.js
@@ -30,6 +30,13 @@ type UserObject = {
   role: number,
 };
 
+const DEFAULT_USER: UserObject = {
+  organization: 'master',
+  email: 'admin@magma.test',
+  password: 'password1234',
+  role: AccessRoles.SUPERUSER,
+};
+
 async function updateUser(user: User, userObject: UserObject) {
   const {password, role} = userObject;
   const salt = await bcrypt.genSalt(SALT_GEN_ROUNDS);
@@ -96,7 +103,22 @@ async function createOrFetchOrganization(
   return org;
 }
 
+export async function createDefaultUserIfNoneExist(userObject: ?UserObject) {
+  const userCount = await User.count();
+  if (userCount > 0) {
+    return;
+  }
+  if (userObject != null) {
+    await createUser(userObject);
+    return;
+  }
+  await createUser(DEFAULT_USER);
+}
+
 function main() {
+  if (require.main !== module) {
+    return;
+  }
   const args = process.argv.slice(2);
   if (args.length !== 3) {
     console.log('Usage: setPassword.js <organization> <email> <password>');


### PR DESCRIPTION
Signed-off-by: Andrei Lee <andreilee@fb.com>
## Summary

Currently when the NMS is started for the first time, there are no organizations and users. There is no way to resolve this by creating an organization through the UI because you need to be logged in to create one.

This is currently resolved with the script `dev_setup.sh`, or with the `yarn` command `setAdminPassword` which can help you create a user and organization.

Rather than require a script to be run, this pull request adds in a check on NMS startup which creates a default user and organization with the following credentials:

**Email:** `admin@magma.test`
**Password**: `password1234`

If somebody has a suggestion on making this default user configurable, that would be great.

## Test Plan

Tested manually by clearing my local development NMS DB of users, and restarting the NMS pod:

**Before NMS pod restart**
```
nms=# select * from "Users";
 id |      email       |                           password                           | role |         createdAt          |         updatedAt          | networkIDs | verificationType | organization | readOnly |  tabs
----+------------------+--------------------------------------------------------------+------+----------------------------+----------------------------+------------+------------------+--------------+----------+---------
  1 | admin@magma.test | $2a$10$ix5uz3Lt85oRu9DDUmGxQONyse7OCm2gPI4nLoDd/hCUdRWJc1v8i |    3 | 2021-04-28 00:22:52.541+00 | 2021-04-28 00:22:52.541+00 | []         |                0 | magma-test   | f        | ["nms"]
  2 | admin@magma.test | $2a$10$ddQlzG03I5FTebskqO8WA.IY1XR.gyacdpZQKIrfZfe082wJmgp4m |    3 | 2021-04-28 00:22:55.142+00 | 2021-04-28 00:22:55.142+00 | []         |                0 | master       | f        | ["nms"]
  3 | test@magma.test  | $2a$10$g18t5kCZVlh/k8eMTfatGOdmkdNed5yz9hTOiw9/8NnxMIeNXzbbS |    0 | 2021-04-28 00:23:31.527+00 | 2021-04-28 00:23:31.527+00 | []         |                0 | magma-test   | f        | []
(3 rows)

nms=# DELETE from "Users";
DELETE 3
nms=# select * from "Users";
 id | email | password | role | createdAt | updatedAt | networkIDs | verificationType | organization | readOnly | tabs
----+-------+----------+------+-----------+-----------+------------+------------------+--------------+----------+------
(0 rows)
```

**After NMS pod restart**
```
nms=# select * from "Users";
 id |      email       |                           password                           | role |         createdAt         |         updatedAt         | networkIDs | verificationType | organization | readOnly |  tabs
----+------------------+--------------------------------------------------------------+------+---------------------------+---------------------------+------------+------------------+--------------+----------+---------
  4 | admin@magma.test | $2a$10$t7LjdKd0jS1e7RRwpAI93OzjTbiJNQBzJDPrIkyQ8KvF7Q9BJaqj. |    3 | 2021-05-26 00:57:43.67+00 | 2021-05-26 00:57:43.67+00 | []         |                0 | master       | f        | ["nms"]
(1 row)
```

## Additional Information

- [ ] This change is backwards-breaking
