### PR TITLE
Format cmakelist files consistently

### DIFF
--- a/orc8r/gateway/c/common/async_grpc/CMakeLists.txt
+++ b/orc8r/gateway/c/common/async_grpc/CMakeLists.txt
@@ -23,13 +23,14 @@ list(APPEND PROTO_SRCS "")
 list(APPEND PROTO_HDRS "")
 
 set(ASYNC_ORC8R_CPP_PROTOS common redis eventd)
-set(ASYNC_LTE_CPP_PROTOS session_manager abort_session policydb subscriberdb mobilityd pipelined)
+set(ASYNC_LTE_CPP_PROTOS session_manager abort_session policydb subscriberdb
+    mobilityd pipelined)
 set(ASYNC_LTE_GRPC_PROTOS session_manager abort_session mobilityd pipelined)
 set(ASYNC_ORC8R_GRPC_PROTOS eventd)
 
 generate_all_protos("${ASYNC_LTE_CPP_PROTOS}" "${ASYNC_ORC8R_CPP_PROTOS}"
-  "${ASYNC_LTE_GRPC_PROTOS}"
-  "${ASYNC_ORC8R_GRPC_PROTOS}" "${PROTO_SRCS}" "${PROTO_HDRS}")
+    "${ASYNC_LTE_GRPC_PROTOS}"
+    "${ASYNC_ORC8R_GRPC_PROTOS}" "${PROTO_SRCS}" "${PROTO_HDRS}")
 
 message("Async Proto_srcs are ${PROTO_SRCS}")
 
@@ -37,15 +38,15 @@ add_library(ASYNC_GRPC
     GRPCReceiver.cpp
     ${PROTO_SRCS}
     ${PROTO_HDRS}
-)
+    )
 
 # copy headers to build directory so they can be shared with OAI,
 # session_manager, etc.
 add_custom_command(TARGET ASYNC_GRPC POST_BUILD
-                   COMMAND ${CMAKE_COMMAND} -E copy
-                   ${PROJECT_SOURCE_DIR}/async_grpc/*.h
-                   $<TARGET_FILE_DIR:ASYNC_GRPC>)
+    COMMAND ${CMAKE_COMMAND} -E copy
+    ${PROJECT_SOURCE_DIR}/async_grpc/*.h
+    $<TARGET_FILE_DIR:ASYNC_GRPC>)
 
 target_include_directories(ASYNC_GRPC PUBLIC
-                   $<TARGET_FILE_DIR:ASYNC_GRPC>
-)
+    $<TARGET_FILE_DIR:ASYNC_GRPC>
+    )

--- a/orc8r/gateway/c/common/config/CMakeLists.txt
+++ b/orc8r/gateway/c/common/config/CMakeLists.txt
@@ -31,9 +31,9 @@ target_link_libraries(CONFIG glog)
 # copy headers to build directory so they can be shared with OAI,
 # session_manager, etc.
 add_custom_command(TARGET CONFIG POST_BUILD
-                   COMMAND ${CMAKE_COMMAND} -E copy
-                   ${PROJECT_SOURCE_DIR}/config/*.h $<TARGET_FILE_DIR:CONFIG>)
+    COMMAND ${CMAKE_COMMAND} -E copy
+    ${PROJECT_SOURCE_DIR}/config/*.h $<TARGET_FILE_DIR:CONFIG>)
 
 target_include_directories(CONFIG PUBLIC
-                  $<TARGET_FILE_DIR:CONFIG>
-)
+    $<TARGET_FILE_DIR:CONFIG>
+    )

--- a/orc8r/gateway/c/common/datastore/CMakeLists.txt
+++ b/orc8r/gateway/c/common/datastore/CMakeLists.txt
@@ -26,8 +26,8 @@ set(ASYNC_LTE_GRPC_PROTOS session_manager)
 set(ASYNC_ORC8R_GRPC_PROTOS "")
 
 generate_all_protos("${ASYNC_LTE_CPP_PROTOS}" "${ASYNC_ORC8R_CPP_PROTOS}"
-        "${ASYNC_LTE_GRPC_PROTOS}"
-        "${ASYNC_ORC8R_GRPC_PROTOS}" "${PROTO_SRCS}" "${PROTO_HDRS}")
+    "${ASYNC_LTE_GRPC_PROTOS}"
+    "${ASYNC_ORC8R_GRPC_PROTOS}" "${PROTO_SRCS}" "${PROTO_HDRS}")
 
 message("Async Proto_srcs are ${PROTO_SRCS}")
 
@@ -41,16 +41,16 @@ add_library(DATASTORE
     )
 
 target_link_libraries(DATASTORE
-   tacopie cpp_redis pthread
-   )
+    tacopie cpp_redis pthread
+    )
 
 # copy headers to build directory so they can be shared with OAI,
 # session_manager, etc.
 add_custom_command(TARGET DATASTORE POST_BUILD
-                   COMMAND ${CMAKE_COMMAND} -E copy
-                   ${PROJECT_SOURCE_DIR}/datastore/*.h*
-                   $<TARGET_FILE_DIR:DATASTORE>)
+    COMMAND ${CMAKE_COMMAND} -E copy
+    ${PROJECT_SOURCE_DIR}/datastore/*.h*
+    $<TARGET_FILE_DIR:DATASTORE>)
 
 target_include_directories(DATASTORE PUBLIC
-                  $<TARGET_FILE_DIR:DATASTORE>
-)
+    $<TARGET_FILE_DIR:DATASTORE>
+    )

--- a/orc8r/gateway/c/common/eventd/CMakeLists.txt
+++ b/orc8r/gateway/c/common/eventd/CMakeLists.txt
@@ -24,44 +24,41 @@ include_directories(${MAGMA_LIB_DIR}/async_grpc)
 include_directories(${MAGMA_LIB_DIR}/service_registry)
 include_directories("${PROJECT_SOURCE_DIR}/../common/eventd")
 
-
 list(APPEND PROTO_SRCS "")
 list(APPEND PROTO_HDRS "")
 
 create_proto_dir("orc8r" CPP_OUT_DIR)
 set(EVENTD_PROTOS common eventd)
 generate_cpp_protos("${EVENTD_PROTOS}" "${PROTO_SRCS}" "${PROTO_HDRS}"
-  ${ORC8R_PROTO_DIR} ${CPP_OUT_DIR})
+    ${ORC8R_PROTO_DIR} ${CPP_OUT_DIR})
 generate_grpc_protos("${EVENTD_PROTOS}" "${PROTO_SRCS}" "${PROTO_HDRS}"
-  ${ORC8R_PROTO_DIR} ${CPP_OUT_DIR})
-
+    ${ORC8R_PROTO_DIR} ${CPP_OUT_DIR})
 
 add_library(EVENTD
-        ${PROTO_SRCS}
-        ${PROTO_HDRS}
-        EventdClient.cpp
-        EventdClient.h
-        )
+    ${PROTO_SRCS}
+    ${PROTO_HDRS}
+    EventdClient.cpp
+    EventdClient.h
+    )
 
 link_directories(
-  ${MAGMA_LIB_DIR}/async_grpc
-  ${MAGMA_LIB_DIR}/service_registry
-  )
-
+    ${MAGMA_LIB_DIR}/async_grpc
+    ${MAGMA_LIB_DIR}/service_registry
+)
 
 target_link_libraries(
-  EVENTD
-  SERVICE_REGISTRY ASYNC_GRPC
-  grpc++ grpc
-  )
+    EVENTD
+    SERVICE_REGISTRY ASYNC_GRPC
+    grpc++ grpc
+)
 
 # copy headers to build directory so they can be shared with OAI,
 # session_manager, etc.
 add_custom_command(TARGET EVENTD POST_BUILD
-                   COMMAND ${CMAKE_COMMAND} -E copy
-                   ${PROJECT_SOURCE_DIR}/eventd/*.h
-                   $<TARGET_FILE_DIR:EVENTD>)
+    COMMAND ${CMAKE_COMMAND} -E copy
+    ${PROJECT_SOURCE_DIR}/eventd/*.h
+    $<TARGET_FILE_DIR:EVENTD>)
 
 target_include_directories(EVENTD PUBLIC
-                   $<TARGET_FILE_DIR:EVENTD>
-)
+    $<TARGET_FILE_DIR:EVENTD>
+    )

--- a/orc8r/gateway/c/common/logging/CMakeLists.txt
+++ b/orc8r/gateway/c/common/logging/CMakeLists.txt
@@ -18,4 +18,4 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 add_library(LOGGING INTERFACE)
 target_include_directories(LOGGING INTERFACE
     ${CMAKE_CURRENT_SOURCE_DIR}
-)
+    )

--- a/orc8r/gateway/c/common/policydb/CMakeLists.txt
+++ b/orc8r/gateway/c/common/policydb/CMakeLists.txt
@@ -26,11 +26,11 @@ list(APPEND PROTO_HDRS "")
 
 set(POLICYDB_ORC8R_CPP_PROTOS common)
 generate_cpp_protos("${POLICYDB_ORC8R_CPP_PROTOS}" "${PROTO_SRCS}"
-  "${PROTO_HDRS}" ${ORC8R_PROTO_DIR} ${ORC8R_CPP_OUT_DIR})
+    "${PROTO_HDRS}" ${ORC8R_PROTO_DIR} ${ORC8R_CPP_OUT_DIR})
 
 set(POLICYDB_LTE_CPP_PROTOS policydb)
 generate_cpp_protos("${POLICYDB_LTE_CPP_PROTOS}" "${PROTO_SRCS}"
-  "${PROTO_HDRS}" ${LTE_PROTO_DIR} ${LTE_CPP_OUT_DIR})
+    "${PROTO_HDRS}" ${LTE_PROTO_DIR} ${LTE_CPP_OUT_DIR})
 
 message("Proto_srcs are ${PROTO_SRCS}")
 
@@ -42,18 +42,18 @@ add_library(POLICYDB
     )
 
 target_link_libraries(POLICYDB
-   DATASTORE CONFIG
-   glog
-   )
+    DATASTORE CONFIG
+    glog
+    )
 
 # copy headers to build directory so they can be shared with OAI,
 # session_manager, etc.
 add_custom_command(TARGET POLICYDB POST_BUILD
-                   COMMAND ${CMAKE_COMMAND} -E copy
-                   ${PROJECT_SOURCE_DIR}/policydb/*.h
-                   $<TARGET_FILE_DIR:POLICYDB>)
+    COMMAND ${CMAKE_COMMAND} -E copy
+    ${PROJECT_SOURCE_DIR}/policydb/*.h
+    $<TARGET_FILE_DIR:POLICYDB>)
 
 target_compile_definitions(POLICYDB PUBLIC LOG_WITH_GLOG)
 target_include_directories(POLICYDB PUBLIC
-                  $<TARGET_FILE_DIR:POLICYDB>
-)
+    $<TARGET_FILE_DIR:POLICYDB>
+    )

--- a/orc8r/gateway/c/common/protobuf/CMakeLists.txt
+++ b/orc8r/gateway/c/common/protobuf/CMakeLists.txt
@@ -22,13 +22,13 @@ file(GLOB PROMETHEUS_SRCS "orc8r/protos/prometheus/*.pb.*")
 include_directories(".")
 
 add_library(MAGMA_PROTOBUF
-  ${PROTO_SRCS}
-  ${MCONFIG_SRCS}
-  ${PROMETHEUS_SRCS}
-)
+    ${PROTO_SRCS}
+    ${MCONFIG_SRCS}
+    ${PROMETHEUS_SRCS}
+    )
 target_link_libraries(MAGMA_PROTOBUF
-  protobuf grpc++ grpc dl prometheus-cpp
-)
+    protobuf grpc++ grpc dl prometheus-cpp
+    )
 target_include_directories(MAGMA_PROTOBUF SYSTEM PUBLIC
-  ${CMAKE_CURRENT_SOURCE_DIR}
-)
+    ${CMAKE_CURRENT_SOURCE_DIR}
+    )

--- a/orc8r/gateway/c/common/service303/CMakeLists.txt
+++ b/orc8r/gateway/c/common/service303/CMakeLists.txt
@@ -23,38 +23,38 @@ list(APPEND PROTO_HDRS "")
 
 set(SERVICE303_PROTOS common metricsd service303)
 generate_cpp_protos("${SERVICE303_PROTOS}" "${PROTO_SRCS}" "${PROTO_HDRS}"
-  ${ORC8R_PROTO_DIR} ${CPP_OUT_DIR})
+    ${ORC8R_PROTO_DIR} ${CPP_OUT_DIR})
 
 set(SERVICE303_GRPC_PROTOS service303)
 generate_grpc_protos("${SERVICE303_GRPC_PROTOS}" "${PROTO_SRCS}"
-  "${PROTO_HDRS}" ${ORC8R_PROTO_DIR} ${CPP_OUT_DIR})
+    "${PROTO_HDRS}" ${ORC8R_PROTO_DIR} ${CPP_OUT_DIR})
 
 generate_prometheus_proto("${PROTO_SRCS}" "${PROTO_HDRS}" ${CPP_OUT_DIR})
 
 message("Proto_srcs are ${PROTO_SRCS}")
 
 add_library(SERVICE303_LIB
-  MagmaService.cpp
-  MetricsSingleton.cpp
-  MetricsHelpers.cpp
-  ProcFileUtils.cpp
-  ${PROTO_SRCS}
-  ${PROTO_HDRS}
-)
+    MagmaService.cpp
+    MetricsSingleton.cpp
+    MetricsHelpers.cpp
+    ProcFileUtils.cpp
+    ${PROTO_SRCS}
+    ${PROTO_HDRS}
+    )
 
 target_link_libraries(SERVICE303_LIB
-  prometheus-cpp protobuf grpc grpc++
-  SERVICE_REGISTRY LOGGING
-)
+    prometheus-cpp protobuf grpc grpc++
+    SERVICE_REGISTRY LOGGING
+    )
 
 # copy headers to build directory so they can be shared with OAI,
 # session_manager, etc.
 add_custom_command(TARGET SERVICE303_LIB POST_BUILD
-                   COMMAND ${CMAKE_COMMAND} -E copy
-                   ${PROJECT_SOURCE_DIR}/service303/*.h
-                   $<TARGET_FILE_DIR:SERVICE303_LIB>)
+    COMMAND ${CMAKE_COMMAND} -E copy
+    ${PROJECT_SOURCE_DIR}/service303/*.h
+    $<TARGET_FILE_DIR:SERVICE303_LIB>)
 
 target_include_directories(SERVICE303_LIB PUBLIC
-  $<TARGET_FILE_DIR:SERVICE303_LIB>
-  "/usr/local/include/prometheus"
-)
+    $<TARGET_FILE_DIR:SERVICE303_LIB>
+    "/usr/local/include/prometheus"
+    )

--- a/orc8r/gateway/c/common/service_registry/CMakeLists.txt
+++ b/orc8r/gateway/c/common/service_registry/CMakeLists.txt
@@ -23,16 +23,16 @@ add_library(SERVICE_REGISTRY
     )
 
 target_link_libraries(SERVICE_REGISTRY CONFIG
-   grpc++ dl yaml-cpp
-  )
+    grpc++ dl yaml-cpp
+    )
 
 # copy headers to build directory so they can be shared with OAI,
 # session_manager, etc.
 add_custom_command(TARGET SERVICE_REGISTRY POST_BUILD
-                   COMMAND ${CMAKE_COMMAND} -E copy
-                   ${PROJECT_SOURCE_DIR}/service_registry/*.h
-                   $<TARGET_FILE_DIR:SERVICE_REGISTRY>)
+    COMMAND ${CMAKE_COMMAND} -E copy
+    ${PROJECT_SOURCE_DIR}/service_registry/*.h
+    $<TARGET_FILE_DIR:SERVICE_REGISTRY>)
 
 target_include_directories(SERVICE_REGISTRY PUBLIC
-                   $<TARGET_FILE_DIR:SERVICE_REGISTRY>
-)
+    $<TARGET_FILE_DIR:SERVICE_REGISTRY>
+    )

--- a/orc8r/gateway/c/common/test/CMakeLists.txt
+++ b/orc8r/gateway/c/common/test/CMakeLists.txt
@@ -22,13 +22,13 @@ include_directories("${PROJECT_SOURCE_DIR}/../common/service303")
 include_directories("${PROJECT_SOURCE_DIR}/../common/protobuf")
 link_directories("/usr/src/googletest/googlemock/lib/")
 
-foreach(common_test yaml_utils magma_service service_registry service303 metrics)
+foreach (common_test yaml_utils magma_service service_registry service303 metrics)
   add_executable(${common_test}_test test_${common_test}.cpp)
-  target_link_libraries(${common_test}_test 
-	  CONFIG 
-	  gmock_main gtest gtest_main gmock
-	  yaml-cpp pthread rt
-	  ${GCOV_LIB}
-	  SERVICE303_LIB)
+  target_link_libraries(${common_test}_test
+      CONFIG
+      gmock_main gtest gtest_main gmock
+      yaml-cpp pthread rt
+      ${GCOV_LIB}
+      SERVICE303_LIB)
   add_test(test_${common_test} ${common_test}_test)
-endforeach(common_test)
+endforeach (common_test)


### PR DESCRIPTION
Format cmakelist files consistently

Tab: 4 spaces
Indentation: 2
Continuing Indentation: 4

No-op change, outside just making file formats consistent

Signed-off-by: Amar Padmanabhan <amarpadmanabhan@fb.com>