### PR TITLE
[AGW][logrotate] fix logrotate config

### DIFF
--- a/lte/gateway/deploy/roles/magma/files/logrotate_rsyslog.conf
+++ b/lte/gateway/deploy/roles/magma/files/logrotate_rsyslog.conf
@@ -1,14 +1,14 @@
 /var/log/syslog
 {
         rotate 7
-        hourly
+        daily
         missingok
         notifempty
         delaycompress
         compress
         maxsize 50M
         postrotate
-                invoke-rc.d rsyslog rotate > /dev/null
+                invoke-rc.d rsyslog restart > /dev/null
         endscript
 }
 
@@ -33,6 +33,6 @@
         delaycompress
         sharedscripts
         postrotate
-                invoke-rc.d rsyslog rotate > /dev/null
+                invoke-rc.d rsyslog restart > /dev/null
         endscript
 }


### PR DESCRIPTION
Signed-off-by: Tariq Al-Khasib <talkhasib@fb.com>

## Summary

syslog log rotation is broken for Ubuntu. On the first log rotation, syslog gets empty and all logs are redirected to syslog.1

This PR forces a restart of rsyslog post rotation. This was tested and achieves the desirable behaviour on Ubuntu.
This PR also changes the syslog rotation config to "daily" since the logrotate cron job is run daily anyways.

## Test Plan
Configuration changes tested on lab Ubuntu AGW.
