### PR TITLE
fix: configure the flake8 command in precommit.py to always return 0 

### DIFF
--- a/lte/gateway/python/precommit.py
+++ b/lte/gateway/python/precommit.py
@@ -75,7 +75,7 @@ def _run_add_trailing_comma(path: str):
 
 def _run_flake8(paths: List[str]):
     for path in paths:
-        _run_docker_cmd(['flake8', path])
+        _run_docker_cmd(['flake8', '--exit-zero', path])
 
 
 def _run_docker_cmd(commands: List[str]):


### PR DESCRIPTION
Signed-off-by: Marie Bremner <marwhal@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary
The precommit script when running flake8 was terminating earlier than expected. This was due to flake8 returning a non-0 value when it found lint warnings in the file it inspected. When running `--lint` with the `--diff` option, we want to run flake8 on multiple files, so this was not ideal.
Thankfully, flake8 has a `--exit-zero` option probably for this exact reason.
<!-- Enumerate changes you made and why you made them -->

## Test Plan
run `./precommit.py -l -d` with a commit that has multiple python changes.
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
