### PR TITLE
[component:agw] Fix for IA2 changes in AMF

### DIFF
--- a/lte/gateway/c/oai/tasks/amf/amf_as.cpp
+++ b/lte/gateway/c/oai/tasks/amf/amf_as.cpp
@@ -1164,11 +1164,10 @@ static int amf_as_security_req(
         if (ue_context) {
           amf_security_context_t* amf_security_context =
               &ue_context->amf_context._security;
-          amf_security_context->selected_algorithms.integrity = 0;
-          //   M5G_NAS_SECURITY_ALGORITHMS_128_5G_IA2;  // TODO get this
-          //   computed
-          amf_security_context->selected_algorithms.encryption = 0;
-          //  M5G_NAS_SECURITY_ALGORITHMS_5G_EA0;  // TODO get this computed
+          amf_security_context->selected_algorithms.integrity =
+              M5G_NAS_SECURITY_ALGORITHMS_128_5G_IA2;  // TODO get this computed
+          amf_security_context->selected_algorithms.encryption =
+              M5G_NAS_SECURITY_ALGORITHMS_5G_EA0;  // TODO get this computed
           nas_msg.security_protected.plain.amf.msg.securitymodecommandmsg
               .nas_sec_algorithms.tca =
               amf_security_context->selected_algorithms.encryption;

--- a/lte/gateway/c/oai/tasks/amf/amf_security_mode_control.cpp
+++ b/lte/gateway/c/oai/tasks/amf/amf_security_mode_control.cpp
@@ -30,6 +30,7 @@ extern "C" {
 #include "amf_config.h"
 #include "amf_app_ue_context_and_proc.h"
 #include "amf_identity.h"
+#include "conversions.h"
 
 #define IMSI64_TO_IMSI15(iMsI64_t, imsi15)                                     \
   {                                                                            \
@@ -399,38 +400,17 @@ int amf_proc_security_mode_control(
        * SN value 5G:mnc095.mcc208.3gppnetwork.org
        * mcc and mnc retrive saved _imsi from amf_context
        */
-      snni[0]  = 0x35;  // 5
-      snni[1]  = 0x47;  // G
-      snni[2]  = 0x3A;  //:
-      snni[3]  = 0x6D;  // m
-      snni[4]  = 0x6E;  // n
-      snni[5]  = 0x63;  // c
-      snni[6]  = 0x30 + plmn.mnc_digit1;
-      snni[7]  = 0x30 + plmn.mnc_digit2;
-      snni[8]  = 0x30 + plmn.mnc_digit3;
-      snni[9]  = 0x2E;  //.
-      snni[10] = 0x6D;  // m
-      snni[11] = 0x63;  // c
-      snni[12] = 0x63;  // c
-      snni[13] = 0x30 + plmn.mcc_digit1;
-      snni[14] = 0x30 + plmn.mcc_digit2;
-      snni[15] = 0x30 + plmn.mcc_digit3;
-      snni[16] = 0x2E;  //.
-      snni[17] = 0x33;  // 3
-      snni[18] = 0x67;  // g
-      snni[19] = 0x70;  // p
-      snni[20] = 0x70;  // p
-      snni[21] = 0x6E;  // n
-      snni[22] = 0x65;  // e
-      snni[23] = 0x74;  // t
-      snni[24] = 0x77;  // w
-      snni[25] = 0x6F;  // o
-      snni[26] = 0x72;  // r
-      snni[27] = 0x6B;  // k
-      snni[28] = 0x2E;  //.
-      snni[29] = 0x6F;  // o
-      snni[30] = 0x72;  // r
-      snni[31] = 0x67;  // g
+      uint32_t mcc              = 0;
+      uint32_t mnc              = 0;
+      uint32_t mnc_digit_length = 0;
+
+      PLMN_T_TO_MCC_MNC(plmn, mcc, mnc, mnc_digit_length);
+      uint32_t snni_buf_len =
+          sprintf((char*) snni, "5G:mnc%03d.mcc%03d.3gppnetwork.org", mnc, mcc);
+      if (snni_buf_len != 32) {
+        OAILOG_ERROR(LOG_NAS_AMF, "Failed to create SNNI String\n");
+        OAILOG_FUNC_RETURN(LOG_NAS_AMF, RETURNerror);
+      }
 
       memcpy(
           ak_sqn,

--- a/lte/gateway/c/oai/tasks/amf/nas5g_message.cpp
+++ b/lte/gateway/c/oai/tasks/amf/nas5g_message.cpp
@@ -244,7 +244,7 @@ int nas5g_message_encode(
           "offset %d = %d - %lu, hdr encode = %d, length = %lu bytes = %d\n",
           offset, size, sizeof(uint8_t), size, length, bytes);
       uint32_t mac = _nas5g_message_get_mac(
-          buffer + offset, bytes + size - (offset + 3),
+          buffer + offset, bytes + size - offset,
           amf_security_context->direction_encode, amf_security_context);
       /*
        * Set the message authentication code of the NAS message


### PR DESCRIPTION
Fixes:
  1. Changed the Default algoritm  to E0/IA2
  2. Fixed the offset calculation for mac

Test case:
  1. Tested in UERANSIM
  2. Tested in DSTester

Signed-off-by: ganeshg87 <ganesh.gedela@wavelabs.ai>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
