### PR TITLE
rename yamlint and python linter to be consistent as other reviewdog…

### DIFF
--- a/.github/workflows/wemake-python-styleguide.yml
+++ b/.github/workflows/wemake-python-styleguide.yml
@@ -1,4 +1,5 @@
-name: Python linting by Reviewdog
+---
+name: reviewdog
 on: [pull_request]
 jobs:
   wemake-python-styleguide:

--- a/.github/workflows/yamlint.yml
+++ b/.github/workflows/yamlint.yml
@@ -1,5 +1,5 @@
 ---
-name: YAML linting by Reviewdog
+name: reviewdog
 on:  # yamllint disable-line rule:truthy
   pull_request:
     types:


### PR DESCRIPTION
… jobs

Signed-off-by: Marie Bremner <marwhal@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary
It was annoying me a bit that the reviewdog job names were not consistent
<img width="859" alt="Screen Shot 2021-05-27 at 10 35 42 AM" src="https://user-images.githubusercontent.com/37634144/119855322-6b289580-bed7-11eb-8674-eb372ccebd6f.png">
So fixing them all to be named `reviewdog`
<!-- Enumerate changes you made and why you made them -->

## Test Plan
CI section
<img width="866" alt="Screen Shot 2021-05-27 at 10 37 24 AM" src="https://user-images.githubusercontent.com/37634144/119855454-898e9100-bed7-11eb-9ad4-1dd1bad7333f.png">
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->

