### PR TITLE
Update C_BUILD path for vagrant VMs

### DIFF
--- a/lte/gateway/deploy/magma_dev.yml
+++ b/lte/gateway/deploy/magma_dev.yml
@@ -37,12 +37,12 @@
         config_dir: "lte/gateway/configs"
     - role: dev_common
       vars:
-        c_build: /home/{{ ansible_user }}/build/c/
+        c_build: /home/{{ ansible_user }}/build/c
         oai_build: "{{ c_build }}/oai"
         go_build: /home/{{ ansible_user }}/go/bin/
     - role: magma
       vars:
-        c_build: /home/{{ ansible_user }}/build/c/
+        c_build: /home/{{ ansible_user }}/build/c
         oai_build: "{{ c_build }}/oai"
         go_build: /home/{{ ansible_user }}/go/bin/
         magma_repo: /home/{{ ansible_user }}/magma-packages

--- a/lte/gateway/deploy/magma_dev_focal.yml
+++ b/lte/gateway/deploy/magma_dev_focal.yml
@@ -37,12 +37,12 @@
         config_dir: "lte/gateway/configs"
     - role: dev_common
       vars:
-        c_build: /home/{{ ansible_user }}/build/c/
+        c_build: /home/{{ ansible_user }}/build/c
         oai_build: "{{ c_build }}/oai"
         go_build: /home/{{ ansible_user }}/go/bin/
     - role: magma
       vars:
-        c_build: /home/{{ ansible_user }}/build/c/
+        c_build: /home/{{ ansible_user }}/build/c
         oai_build: "{{ c_build }}/oai"
         go_build: /home/{{ ansible_user }}/go/bin/
         magma_repo: /home/{{ ansible_user }}/magma-packages

--- a/lte/gateway/deploy/magma_test.yml
+++ b/lte/gateway/deploy/magma_test.yml
@@ -19,7 +19,7 @@
     - role: python_dev
     - role: dev_common
       vars:
-        c_build: /home/{{ ansible_user }}/build/c/
+        c_build: /home/{{ ansible_user }}/build/c
         oai_build: "{{ c_build }}/oai"
         go_build: /home/{{ ansible_user }}/go/bin/
     - role: magma_test


### PR DESCRIPTION


<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary
Make the vagrant VM C_BUILDs consistent with docker by removing trailing "/"
Also, visually corrects related paths like oai_build which had a //


Signed-off-by: Amar Padmanabhan <amarpadmanabhan@fb.com>

<!-- Enumerate changes you made and why you made them -->

## Test Plan

reprovisioned VMs and make integ_tests

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
