### PR TITLE
refactor: [helm][docker][orc8r][REGISTRY] Map code to new registry for helm & Docker

### DIFF
--- a/cwf/gateway/docker/.env
+++ b/cwf/gateway/docker/.env
@@ -10,9 +10,9 @@
 # limitations under the License.
 
 COMPOSE_PROJECT_NAME=cwf
-DOCKER_REGISTRY=cwf_
 DOCKER_USERNAME=
 DOCKER_PASSWORD=
+DOCKER_REGISTRY=cwf-test.artifactory.magmacore.org/
 IMAGE_VERSION=latest
 
 BUILD_CONTEXT=../../..

--- a/cwf/gateway/docker/.prod_env
+++ b/cwf/gateway/docker/.prod_env
@@ -10,9 +10,9 @@
 # limitations under the License.
 
 COMPOSE_PROJECT_NAME=cwf
-DOCKER_REGISTRY=cwf_
 DOCKER_USERNAME=
 DOCKER_PASSWORD=
+DOCKER_REGISTRY=docker.artifactory.magmacore.org/
 IMAGE_VERSION=latest
 GIT_HASH=master
 

--- a/experimental/cloudstrapper/playbooks/roles/control/templates/main.tf.j2.custom
+++ b/experimental/cloudstrapper/playbooks/roles/control/templates/main.tf.j2.custom
@@ -57,20 +57,15 @@ module "orc8r-app" {
   orc8r_db_user    = module.orc8r.orc8r_db_user
   orc8r_db_pass    = module.orc8r.orc8r_db_pass
 
-  # Note that this can be any container registry provider -- the example below
-  # provides the URL format for Docker Hub, where the user and pass are your
-  # Docker Hub username and access token, respectively
-  docker_registry = "registry.hub.docker.com/{{ dockerUser }}"
-  docker_user     = "{{ dockerUser }}"
-  docker_pass     = "{{ dockerPassword }}"
+  # Note that this can be any container registry provider
+  docker_registry = "https://docker.artifactory.magmacore.org/artifactory/docker"
+  docker_user = ""
+  docker_pass = ""
 
-  # Note that this can be any Helm chart repo provider -- the example below
-  # provides the URL format for using a raw GitHub repo, where the user and
-  # pass are your GitHub username and access token, respectively
-  helm_repo = "https://raw.githubusercontent.com/{{ gitUser }}/{{ gitHelmRepo }}/master/"
-  helm_user = "{{ gitUser }}"
-  helm_pass = "{{ gitPat }}"
-
+  # Note that this can be any Helm chart repo provider
+  helm_repo = "https://docker.artifactory.magmacore.org/artifactory/helm"
+  helm_user = ""
+  helm_pass = ""
   eks_cluster_id = module.orc8r.eks_cluster_id
 
   efs_file_system_id       = module.orc8r.efs_file_system_id

--- a/feg/gateway/docker/.env
+++ b/feg/gateway/docker/.env
@@ -10,9 +10,9 @@
 # limitations under the License.
 
 COMPOSE_PROJECT_NAME=feg
-DOCKER_REGISTRY=feg_
 DOCKER_USERNAME=
 DOCKER_PASSWORD=
+DOCKER_REGISTRY=feg-test.artifactory.magmacore.org/
 IMAGE_VERSION=latest
 GIT_HASH=master
 BUILD_CONTEXT=../../../

--- a/feg/gateway/docker/.prod_env
+++ b/feg/gateway/docker/.prod_env
@@ -10,9 +10,9 @@
 # limitations under the License.
 
 COMPOSE_PROJECT_NAME=feg
-DOCKER_REGISTRY=feg_
 DOCKER_USERNAME=
 DOCKER_PASSWORD=
+DOCKER_REGISTRY=docker.artifactory.magmacore.org/
 IMAGE_VERSION=latest
 GIT_HASH=master
 BUILD_CONTEXT=https://github.com/facebookincubator/magma.git#master

--- a/orc8r/cloud/deploy/terraform/orc8r-aws/eks.tf
+++ b/orc8r/cloud/deploy/terraform/orc8r-aws/eks.tf
@@ -42,6 +42,8 @@ module "eks" {
     "scheduler",
   ]
 
+  cluster_create_timeout   = "30m"
+
   workers_group_defaults = {
     key_name = var.eks_worker_group_key == null ? aws_key_pair.eks_workers[0].key_name : var.eks_worker_group_key
   }

--- a/orc8r/cloud/deploy/terraform/orc8r-helm-aws/artifactory.tf
+++ b/orc8r/cloud/deploy/terraform/orc8r-helm-aws/artifactory.tf
@@ -12,13 +12,18 @@
 ################################################################################
 
 locals {
-  dockercfg = {
+  dockercfg_without_cred = {
+    (var.docker_registry) = {
+
+    }
+  }
+  dockercfg_with_cred = {
     (var.docker_registry) = {
       username = var.docker_user
       password = var.docker_pass
     }
   }
-
+  dockercfg = var.docker_user != "" ? local.dockercfg_with_cred : local.dockercfg_without_cred
   stable_helm_repo    = "https://charts.helm.sh/stable"
   incubator_helm_repo = "https://charts.helm.sh/incubator"
 }

--- a/orc8r/cloud/deploy/terraform/orc8r-helm-aws/examples/basic/main.tf
+++ b/orc8r/cloud/deploy/terraform/orc8r-helm-aws/examples/basic/main.tf
@@ -64,19 +64,15 @@ module "orc8r-app" {
   orc8r_db_user    = module.orc8r.orc8r_db_user
   orc8r_db_pass    = module.orc8r.orc8r_db_pass
 
-  # Note that this can be any container registry provider -- the example below
-  # provides the URL format for Docker Hub, where the user and pass are your
-  # Docker Hub username and access token, respectively
+  # Note that this can be any container registry provider
   docker_registry = "https://docker.artifactory.magmacore.org/artifactory/docker"
-  # docker_user     = "MY_USERNAME"
-  # docker_pass     = "MY_PASSWORD"
+  docker_user     = ""
+  docker_pass     = ""
 
-  # Note that this can be any Helm chart repo provider -- the example below
-  # provides the URL format for using a raw GitHub repo, where the user and
-  # pass are your GitHub username and access token, respectively
-  helm_repo = "https://docker.artifactory.magmacore.org/artifactory/helm-prod"
-  # helm_user       = "MY_USERNAME"
-  # helm_pass       = "MY_PASSWORD"
+  # Note that this can be any Helm chart repo provider
+  helm_repo       = "https://docker.artifactory.magmacore.org/artifactory/helm"
+  helm_user       = ""
+  helm_pass       = ""
   eks_cluster_id = module.orc8r.eks_cluster_id
 
   efs_file_system_id       = module.orc8r.efs_file_system_id

--- a/orc8r/cloud/deploy/terraform/orc8r-helm-aws/examples/basic/main.tf
+++ b/orc8r/cloud/deploy/terraform/orc8r-helm-aws/examples/basic/main.tf
@@ -64,16 +64,19 @@ module "orc8r-app" {
   orc8r_db_user    = module.orc8r.orc8r_db_user
   orc8r_db_pass    = module.orc8r.orc8r_db_pass
 
-  # If you want to use your own container images or Helm charts, override the
-  # following relevant variables. These examples assume DockerHub for the
-  # container image registry and a GitHub repo for the charts repo.
-  # docker_registry = "registry.hub.docker.com/MY_USERNAME"
+  # Note that this can be any container registry provider -- the example below
+  # provides the URL format for Docker Hub, where the user and pass are your
+  # Docker Hub username and access token, respectively
+  docker_registry = "https://docker.artifactory.magmacore.org/artifactory/docker"
   # docker_user     = "MY_USERNAME"
   # docker_pass     = "MY_PASSWORD"
-  # helm_repo       = "https://raw.githubusercontent.com/MY_USERNAME/MY_REPONAME/master/"
+
+  # Note that this can be any Helm chart repo provider -- the example below
+  # provides the URL format for using a raw GitHub repo, where the user and
+  # pass are your GitHub username and access token, respectively
+  helm_repo = "https://docker.artifactory.magmacore.org/artifactory/helm-prod"
   # helm_user       = "MY_USERNAME"
   # helm_pass       = "MY_PASSWORD"
-
   eks_cluster_id = module.orc8r.eks_cluster_id
 
   efs_file_system_id       = module.orc8r.efs_file_system_id

--- a/orc8r/cloud/deploy/terraform/orc8r-helm-aws/examples/online-upgrade/variables.tf
+++ b/orc8r/cloud/deploy/terraform/orc8r-helm-aws/examples/online-upgrade/variables.tf
@@ -143,8 +143,8 @@ variable "elasticsearch_domain_configuration" {
 variable "docker_registry" {
   description = "URL to your Docker registry"
   type        = string
+  default     = "https://docker.artifactory.magmacore.org/artifactory/docker"
 }
-
 variable "docker_user" {
   description = "Username for your Docker registry"
   type        = string
@@ -152,12 +152,13 @@ variable "docker_user" {
 
 variable "docker_pass" {
   description = "Password for your Docker user"
-  type        = string
+  type = string
 }
 
 variable "helm_repo" {
   description = "URL to your Helm repo. Don't forget the protocol prefix (e.g. https://)"
   type        = string
+  default     = "https://docker.artifactory.magmacore.org/artifactory/helm-prod"
 }
 
 variable "helm_user" {
@@ -167,7 +168,7 @@ variable "helm_user" {
 
 variable "helm_pass" {
   description = "Password for your Helm user"
-  type        = string
+  type = string
 }
 
 variable "seed_certs_dir" {
@@ -183,7 +184,7 @@ variable "new_deployment_name" {
 variable "orc8r_chart_version" {
   description = "Chart version for the Helm deployment"
   type        = string
-  default     = "1.4.21"
+  default     = "1.5.21"
 }
 
 variable "orc8r_container_tag" {

--- a/orc8r/cloud/deploy/terraform/orc8r-helm-aws/variables.tf
+++ b/orc8r/cloud/deploy/terraform/orc8r-helm-aws/variables.tf
@@ -203,7 +203,7 @@ variable "wifi_orc8r_chart_version" {
 variable "orc8r_tag" {
   description = "Image tag for Orchestrator components."
   type        = string
-  default     = "latest"
+  default     = "1.6.0"
 }
 
 variable "magma_uuid" {

--- a/orc8r/cloud/deploy/terraform/orc8r-helm-aws/variables.tf
+++ b/orc8r/cloud/deploy/terraform/orc8r-helm-aws/variables.tf
@@ -203,7 +203,7 @@ variable "wifi_orc8r_chart_version" {
 variable "orc8r_tag" {
   description = "Image tag for Orchestrator components."
   type        = string
-  default     = "1.5.0"
+  default     = "latest"
 }
 
 variable "magma_uuid" {

--- a/orc8r/gateway/python/magma/magmad/upgrade/docker_upgrader.py
+++ b/orc8r/gateway/python/magma/magmad/upgrade/docker_upgrader.py
@@ -13,6 +13,7 @@ limitations under the License.
 
 import asyncio
 import logging
+import os
 import pathlib
 
 from magma.common.service import MagmaService
@@ -211,9 +212,10 @@ async def download_update(
         MAGMA_GITHUB_PATH, target_version,
     )
     await run_command(git_checkout_cmd, shell=True, check=True)
-    docker_login_cmd = "docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD " \
-                       "$DOCKER_REGISTRY"
-    await run_command(docker_login_cmd, shell=True, check=True)
+    if os.getenv("DOCKER_USERNAME"):
+        docker_login_cmd = "docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD " \
+                           "$DOCKER_REGISTRY"
+        await run_command(docker_login_cmd, shell=True, check=True)
     docker_pull_cmd = "IMAGE_VERSION={} docker-compose --project-directory " \
                       "/var/opt/magma/docker -f " \
                       "/var/opt/magma/docker/docker-compose.yml pull -q".\

--- a/orc8r/tools/ansible/roles/docker/tasks/main.yml
+++ b/orc8r/tools/ansible/roles/docker/tasks/main.yml
@@ -24,6 +24,7 @@
     that: registry_url != ""
 
 - name: Log into the Docker registry
+  when: registry_username != ''
   docker_login:
     registry_url: "{{ registry_url }}"
     username: "{{ registry_username }}"


### PR DESCRIPTION

## Summary

Replaced the registries endpoint with the new artifactory ones.
Only 1.5.0 artifacts are available right now.

## Test Plan

Used terraform to deploy orc8r in aws us-east-2.

## Additional Information

waiting for domain registration to be available on fb-magma to fully test deployment
