### PR TITLE
[component:agw] Handling AUTH Failure with Reason #71(ngKSI is alread…

### DIFF
--- a/lte/gateway/c/oai/tasks/amf/amf_authentication.h
+++ b/lte/gateway/c/oai/tasks/amf/amf_authentication.h
@@ -56,6 +56,8 @@ int amf_proc_authentication(
 int amf_proc_authentication_complete(
     amf_ue_ngap_id_t ue_id, AuthenticationResponseMsg* msg, int amf_cause,
     const unsigned char* res);
+int amf_proc_authentication_failure(
+    amf_ue_ngap_id_t ue_id, AuthenticationFailureMsg* msg, int amf_cause);
 int amf_registration_security(amf_context_t* amf_context);
 int amf_send_authentication_request(
     amf_context_t* amf_context, nas5g_amf_auth_proc_t* auth_proc);

--- a/lte/gateway/c/oai/tasks/amf/amf_recv.cpp
+++ b/lte/gateway/c/oai/tasks/amf/amf_recv.cpp
@@ -511,6 +511,44 @@ int amf_handle_authentication_response(
 
   OAILOG_FUNC_RETURN(LOG_NAS_AMF, rc);
 }
+
+/****************************************************************************
+ **                                                                        **
+ ** Name:    amf_handle_authentication_failure()                           **
+ **                                                                        **
+ ** Description: Processes Authentication failure  message                 **
+ **                                                                        **
+ ** Inputs:  ue_id:      UE lower layer identifier                         **
+ **      msg:       The received AMF message                               **
+ **      Others:    None                                                   **
+ **                                                                        **
+ ** Outputs:     amf_cause: AMF cause code                                 **
+ **      Return:    RETURNok, RETURNerror                                  **
+ **      Others:    None                                                   **
+ **                                                                        **
+ ***************************************************************************/
+int amf_handle_authentication_failure(
+    amf_ue_ngap_id_t ue_id, AuthenticationFailureMsg* msg, int amf_cause,
+    amf_nas_message_decode_status_t status) {
+  OAILOG_FUNC_IN(LOG_NAS_AMF);
+  int rc = RETURNok;
+  OAILOG_DEBUG(LOG_NAS_AMF, "Received AUTHENTICATION_FAILURE message\n");
+
+  /*
+   * Handle message checking error
+   */
+  if (amf_cause != AMF_CAUSE_SUCCESS) {
+    OAILOG_FUNC_RETURN(LOG_NAS_AMF, RETURNerror);
+  }
+
+  /*
+   * Execute the authentication failure procedure
+   */
+  rc = amf_proc_authentication_failure(ue_id, msg, AMF_CAUSE_SUCCESS);
+
+  OAILOG_FUNC_RETURN(LOG_NAS_AMF, rc);
+}
+
 /****************************************************************************
  **                                                                        **
  ** Name:    lookup_ue_ctxt_by_imsi()                                      **

--- a/lte/gateway/c/oai/tasks/amf/amf_recv.h
+++ b/lte/gateway/c/oai/tasks/amf/amf_recv.h
@@ -34,6 +34,9 @@ int amf_handle_identity_response(
 int amf_handle_authentication_response(
     amf_ue_ngap_id_t ue_id, AuthenticationResponseMsg* msg, int amf_cause,
     amf_nas_message_decode_status_t status);
+int amf_handle_authentication_failure(
+    amf_ue_ngap_id_t ue_id, AuthenticationFailureMsg* msg, int amf_cause,
+    amf_nas_message_decode_status_t status);
 int amf_handle_security_complete_response(
     amf_ue_ngap_id_t ue_id, amf_nas_message_decode_status_t decode_status);
 int amf_handle_registration_complete_response(

--- a/lte/gateway/c/oai/tasks/nas5g/include/ies/M5GMMCause.h
+++ b/lte/gateway/c/oai/tasks/nas5g/include/ies/M5GMMCause.h
@@ -15,6 +15,10 @@ limitations under the License.
 
 using namespace std;
 namespace magma5g {
+enum class m5gmm_cause : uint8_t {
+  NGKSI_ALREADY_IN_USE = 71,  // ngKSI already in use
+  M5GMM_CAUSE_MAX
+};
 // M5GMMCause IE Class
 class M5GMMCauseMsg {
  public:


### PR DESCRIPTION
…y in use)

Fix:
  1. In UE rejects AUTH failure Response with Reason #71, AMF reinitiate AUTH with
      restart AUTH procedure with new ngKSI
Test case :
1. Tested Registration  using UT/(ueRanSImulator)

Signed-off-by: ganeshg87 <ganesh.gedela@wavelabs.ai>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
