### PR TITLE
[Docs][S1APTester] Add doc on how to connect s1aptester to physical AGW

### DIFF
--- a/docs/readmes/lte/dev_notes.md
+++ b/docs/readmes/lte/dev_notes.md
@@ -80,6 +80,44 @@ IMSI>`
 
 1. On the UE, turn airplane mode on, then off, to trigger a fresh attach
 
+### Connecting a physical AGW to S1AP test VM
+Another useful combination is to run the [S1ap integration tests](s1ap_tests.md)
+on a physical AGW directly connected to the host machine running the
+*magma_test* VM.
+
+**On the magma_test host machine**
+- Connect `eth1` of the physical AGW to a port on the host machine, say it is
+interface `en9`.
+- From the VirtualBox GUI, switch the Adapter 1 (for `eth1` interface) from
+`Host-only` to `Bridged` mode and bridge it to interface `en9` from above.
+
+**On the physical AGW**
+- Change the static IP address of `eth1` to match the one expected by the test
+VM
+  - `sudo sed -i 's/address 10.0.2.1/address 192.168.60.142/g'`
+  ` /etc/network/interfaces.d/eth1`
+  - `sudo ifdown eth1`
+  - `sudo ifup eth1`
+  - `sudo ip addr del 10.0.2.1/24 dev eth1`
+- Enable DEV_MODE
+  - `sudo bash -c 'echo "MAGMA_DEV_MODE=1" >> /etc/environment'`
+- Enable Pipelined `ryu_rest_service`
+  - `grep -qF 'ryu_rest_service' /etc/magma/pipelined.yml || sudo sed -i `
+`"s/static_services: \[/static_services: \[ \'ryu_rest_service\',/g"`
+` /etc/magma/pipelined.yml`
+- Restart all services
+  - `sudo service sctpd restart`
+
+**On the test VM**
+- Change credentials
+  - `sudo sed -i 's/"vagrant"/"magma"/g'`
+` /home/vagrant/magma/lte/gateway/python/integ_tests/s1aptests/s1ap_utils.py`
+- Disable use of `magtivate`
+  - `sudo sed -i 's/magtivate_cmd + " && " + //g'`
+` /home/vagrant/magma/lte/gateway/python/integ_tests/s1aptests/s1ap_utils.py`
+
+Now, you can run the [S1ap integration tests](s1ap_tests.md) as usual.
+
 ## Debugging
 ### Logs
 To change the logging level for a particular service, please modify the


### PR DESCRIPTION
Signed-off-by: Tariq Al-Khasib <talkhasib@fb.com>
## Summary

Adding documentation on how to connect the S1APtester VM to a physical AGW that is directly connected to the host machine.
This enables running LTE integration tests directly on bare metal installation of the AGW

## Test Plan
Procedure tested on local setup