### PR TITLE
[lte][agw] Congestion control

### DIFF
--- a/lte/gateway/c/oai/include/mme_config.h
+++ b/lte/gateway/c/oai/include/mme_config.h
@@ -199,6 +199,13 @@
 #define MME_CONFIG_STRING_ENABLE_GTPU_PRIVATE_IP_CORRECTION                    \
   "ENABLE_GTPU_PRIVATE_IP_CORRECTION"
 
+// Congestion Control
+#define MME_CONFIG_STRING_S1AP_ZMQ_TH "S1AP_ZMQ_TH"
+#define MME_CONFIG_STRING_MME_APP_ZMQ_CONGEST_TH "MME_APP_ZMQ_CONGEST_TH"
+#define MME_CONFIG_STRING_MME_APP_ZMQ_AUTH_TH "MME_APP_ZMQ_AUTH_TH"
+#define MME_CONFIG_STRING_MME_APP_ZMQ_IDENT_TH "MME_APP_ZMQ_IDENT_TH"
+#define MME_CONFIG_STRING_MME_APP_ZMQ_SMC_TH "MME_APP_ZMQ_SMC_TH"
+
 // INBOUND ROAMING
 #define MME_CONFIG_STRING_FED_MODE_MAP "FEDERATED_MODE_MAP"
 #define MME_CONFIG_STRING_MODE "MODE"
@@ -391,6 +398,12 @@ typedef struct mme_config_s {
   bool use_ha;
   bool enable_gtpu_private_ip_correction;
   bool enable_converged_core;
+
+  long s1ap_zmq_th;
+  long mme_app_zmq_congest_th;
+  long mme_app_zmq_auth_th;
+  long mme_app_zmq_ident_th;
+  long mme_app_zmq_smc_th;
 } mme_config_t;
 
 extern mme_config_t mme_config;

--- a/lte/gateway/c/oai/lib/itti/intertask_interface.h
+++ b/lte/gateway/c/oai/lib/itti/intertask_interface.h
@@ -59,6 +59,8 @@
   itti_get_task_name(ITTI_MSG_DESTINATION_ID(mSGpTR))
 #define ITTI_MSG_LATENCY(mSGpTR)                                               \
   itti_get_message_latency((mSGpTR)->ittiMsgHeader.timestamp)
+#define ITTI_MSG_LASTHOP_LATENCY(mSGpTR)                                       \
+  ((mSGpTR)->ittiMsgHeader.last_hop_latency)
 
 /* Make the message number platform specific */
 typedef unsigned long message_number_t;

--- a/lte/gateway/c/oai/lib/itti/intertask_interface_types.h
+++ b/lte/gateway/c/oai/lib/itti/intertask_interface_types.h
@@ -131,6 +131,7 @@ typedef struct MessageHeader_s {
       struct timespec timestamp;   /** Time msg got created */
       instance_t instance;         /**< Task instance for virtualization */
       imsi64_t imsi;               /** IMSI associated to sender task */
+      long last_hop_latency;       /** Last hop zmq latency */
 
       MessageHeaderSize
           ittiMsgSize; /**< Message size (not including header size) */

--- a/lte/gateway/c/oai/tasks/mme_app/mme_app_defs.h
+++ b/lte/gateway/c/oai/tasks/mme_app/mme_app_defs.h
@@ -42,14 +42,23 @@
 #define IPV6_ADDRESS_SIZE 16
 #define IPV4_ADDRESS_SIZE 4
 
-#define MME_APP_ZMQ_LATENCY_AUTH_TH 200000   // microseconds
-#define MME_APP_ZMQ_LATENCY_IDENT_TH 400000  // microseconds
-#define MME_APP_ZMQ_LATENCY_SMC_TH 1000000   // microseconds
-
-#define UPPER_RELATIVE_TH 200  // times the minimum ZMQ Latency observed
-#define LOWER_RELATIVE_TH 50   // times the minimum ZMQ latency observed
+#define MME_APP_ZMQ_LATENCY_CONGEST_TH                                         \
+  (mme_congestion_params.mme_app_zmq_congest_th)  // microseconds
+#define MME_APP_ZMQ_LATENCY_AUTH_TH                                            \
+  (mme_congestion_params.mme_app_zmq_auth_th)  // microseconds
+#define MME_APP_ZMQ_LATENCY_IDENT_TH                                           \
+  (mme_congestion_params.mme_app_zmq_ident_th)  // microseconds
+#define MME_APP_ZMQ_LATENCY_SMC_TH                                             \
+  (mme_congestion_params.mme_app_zmq_smc_th)  // microseconds
 
 extern task_zmq_ctx_t mme_app_task_zmq_ctx;
+
+typedef struct mme_congestion_params_s {
+  long mme_app_zmq_congest_th;
+  long mme_app_zmq_auth_th;
+  long mme_app_zmq_ident_th;
+  long mme_app_zmq_smc_th;
+} mme_congestion_params_t;
 
 int mme_app_handle_s1ap_ue_capabilities_ind(
     const itti_s1ap_ue_cap_ind_t* const s1ap_ue_cap_ind_pP);

--- a/lte/gateway/c/oai/tasks/mme_app/mme_app_defs.h
+++ b/lte/gateway/c/oai/tasks/mme_app/mme_app_defs.h
@@ -42,6 +42,13 @@
 #define IPV6_ADDRESS_SIZE 16
 #define IPV4_ADDRESS_SIZE 4
 
+#define MME_APP_ZMQ_LATENCY_AUTH_TH 200000   // microseconds
+#define MME_APP_ZMQ_LATENCY_IDENT_TH 400000  // microseconds
+#define MME_APP_ZMQ_LATENCY_SMC_TH 1000000   // microseconds
+
+#define UPPER_RELATIVE_TH 200  // times the minimum ZMQ Latency observed
+#define LOWER_RELATIVE_TH 50   // times the minimum ZMQ latency observed
+
 extern task_zmq_ctx_t mme_app_task_zmq_ctx;
 
 int mme_app_handle_s1ap_ue_capabilities_ind(

--- a/lte/gateway/c/oai/tasks/mme_app/mme_config.c
+++ b/lte/gateway/c/oai/tasks/mme_app/mme_config.c
@@ -246,6 +246,11 @@ void mme_config_init(mme_config_t* config) {
   config->unauthenticated_imsi_supported = 0;
   config->relative_capacity              = RELATIVE_CAPACITY;
   config->mme_statistic_timer            = MME_STATISTIC_TIMER_S;
+  config->s1ap_zmq_th                    = LONG_MAX;
+  config->mme_app_zmq_congest_th         = LONG_MAX;
+  config->mme_app_zmq_auth_th            = LONG_MAX;
+  config->mme_app_zmq_ident_th           = LONG_MAX;
+  config->mme_app_zmq_smc_th             = LONG_MAX;
 
   log_config_init(&config->log_config);
   eps_network_feature_config_init(&config->eps_network_feature_support);
@@ -532,6 +537,31 @@ int mme_config_parse_file(mme_config_t* config_pP) {
             setting_mme, MME_CONFIG_STRING_ENABLE_GTPU_PRIVATE_IP_CORRECTION,
             (const char**) &astring))) {
       config_pP->enable_gtpu_private_ip_correction = parse_bool(astring);
+    }
+
+    if ((config_setting_lookup_int(
+            setting_mme, MME_CONFIG_STRING_S1AP_ZMQ_TH, &aint))) {
+      config_pP->s1ap_zmq_th = (long) aint;
+    }
+
+    if ((config_setting_lookup_int(
+            setting_mme, MME_CONFIG_STRING_MME_APP_ZMQ_CONGEST_TH, &aint))) {
+      config_pP->mme_app_zmq_congest_th = (long) aint;
+    }
+
+    if ((config_setting_lookup_int(
+            setting_mme, MME_CONFIG_STRING_MME_APP_ZMQ_AUTH_TH, &aint))) {
+      config_pP->mme_app_zmq_auth_th = (long) aint;
+    }
+
+    if ((config_setting_lookup_int(
+            setting_mme, MME_CONFIG_STRING_MME_APP_ZMQ_IDENT_TH, &aint))) {
+      config_pP->mme_app_zmq_ident_th = (long) aint;
+    }
+
+    if ((config_setting_lookup_int(
+            setting_mme, MME_CONFIG_STRING_MME_APP_ZMQ_SMC_TH, &aint))) {
+      config_pP->mme_app_zmq_smc_th = (long) aint;
     }
 
     if ((config_setting_lookup_string(
@@ -1565,6 +1595,31 @@ void mme_config_display(mme_config_t* config_pP) {
       LOG_CONFIG, "- Statistics timer .....................: %u (seconds)\n\n",
       config_pP->mme_statistic_timer);
   OAILOG_INFO(
+      LOG_CONFIG,
+      "- S1AP ZMQ Threshold ...........................: %10ld "
+      "(microseconds)\n",
+      config_pP->s1ap_zmq_th);
+  OAILOG_INFO(
+      LOG_CONFIG,
+      "- MME APP ZMQ Congestion Threshold .............: %10ld "
+      "(microseconds)\n",
+      config_pP->mme_app_zmq_congest_th);
+  OAILOG_INFO(
+      LOG_CONFIG,
+      "- MME APP ZMQ Auth Complete Threshold...........: %10ld "
+      "(microseconds)\n",
+      config_pP->mme_app_zmq_auth_th);
+  OAILOG_INFO(
+      LOG_CONFIG,
+      "- MME APP ZMQ Identity Complete Threshold.......: %10ld "
+      "(microseconds)\n",
+      config_pP->mme_app_zmq_ident_th);
+  OAILOG_INFO(
+      LOG_CONFIG,
+      "- MME APP ZMQ SMC Complete Threshold ...........: %10ld "
+      "(microseconds)\n\n",
+      config_pP->mme_app_zmq_smc_th);
+  OAILOG_INFO(
       LOG_CONFIG, "- Use Stateless ........................: %s\n\n",
       config_pP->use_stateless ? "true" : "false");
   OAILOG_INFO(
@@ -1747,7 +1802,8 @@ void mme_config_display(mme_config_t* config_pP) {
 
   OAILOG_INFO(
       LOG_CONFIG,
-      "      APN CORRECTION MAP LIST (IMSI_PREFIX | APN_OVERRIDE):\n");
+      "      APN CORRECTION MAP LIST (IMSI_PREFIX | "
+      "APN_OVERRIDE):\n");
   for (j = 0; j < config_pP->nas_config.apn_map_config.nb; j++) {
     OAILOG_INFO(
         LOG_CONFIG, "                                %s | %s \n",

--- a/lte/gateway/c/oai/tasks/nas/emm/Authentication.c
+++ b/lte/gateway/c/oai/tasks/nas/emm/Authentication.c
@@ -61,6 +61,7 @@
 /****************************************************************************/
 extern long mme_app_last_msg_latency;
 extern long pre_mme_task_msg_latency;
+extern mme_congestion_params_t mme_congestion_params;
 
 /****************************************************************************/
 /*******************  L O C A L    D E F I N I T I O N S  *******************/

--- a/lte/gateway/c/oai/tasks/nas/emm/Authentication.c
+++ b/lte/gateway/c/oai/tasks/nas/emm/Authentication.c
@@ -913,7 +913,7 @@ int emm_proc_authentication_complete(
           LOG_NAS_EMM, emm_ctx->_imsi64,
           "Discarding authentication complete as cumulative ZMQ latency "
           "( %ld + %ld ) for ueid " MME_UE_S1AP_ID_FMT
-          "is higher than the threshold.",
+          " is higher than the threshold.",
           mme_app_last_msg_latency, pre_mme_task_msg_latency, ue_id);
       OAILOG_FUNC_RETURN(LOG_NAS_EMM, RETURNok);
     }

--- a/lte/gateway/c/oai/tasks/nas/emm/Authentication.c
+++ b/lte/gateway/c/oai/tasks/nas/emm/Authentication.c
@@ -46,6 +46,9 @@
 #include "emm_asDef.h"
 #include "emm_cnDef.h"
 #include "emm_fsm.h"
+#include "emm_regDef.h"
+#include "mme_app_defs.h"
+#include "mme_app_state.h"
 #include "nas_procedures.h"
 #include "s6a_messages_types.h"
 #include "nas/securityDef.h"
@@ -56,6 +59,8 @@
 /****************************************************************************/
 /****************  E X T E R N A L    D E F I N I T I O N S  ****************/
 /****************************************************************************/
+extern long mme_app_last_msg_latency;
+extern long pre_mme_task_msg_latency;
 
 /****************************************************************************/
 /*******************  L O C A L    D E F I N I T I O N S  *******************/
@@ -886,6 +891,33 @@ int emm_proc_authentication_complete(
       get_nas_common_procedure_authentication(emm_ctx);
 
   if (auth_proc) {
+    /* Process authentication complete msg only if T3460 timer is running.
+     * If it is not running it means that response was already received for
+     * an earlier attempt.
+     */
+    if (auth_proc->T3460.id == NAS_TIMER_INACTIVE_ID) {
+      OAILOG_WARNING_UE(
+          LOG_NAS_EMM, emm_ctx->_imsi64,
+          "Discarding authentication complete as T3460 timer is not active "
+          "for ueid " MME_UE_S1AP_ID_FMT "\n",
+          ue_id);
+      OAILOG_FUNC_RETURN(LOG_NAS_EMM, RETURNok);
+    }
+
+    /* If spent too much in ZMQ, then discard the packet.
+     * MME is congested and this would create some relief in processing.
+     */
+    if (mme_app_last_msg_latency + pre_mme_task_msg_latency >
+        MME_APP_ZMQ_LATENCY_AUTH_TH) {
+      OAILOG_WARNING_UE(
+          LOG_NAS_EMM, emm_ctx->_imsi64,
+          "Discarding authentication complete as cumulative ZMQ latency "
+          "( %ld + %ld ) for ueid " MME_UE_S1AP_ID_FMT
+          "is higher than the threshold.",
+          mme_app_last_msg_latency, pre_mme_task_msg_latency, ue_id);
+      OAILOG_FUNC_RETURN(LOG_NAS_EMM, RETURNok);
+    }
+
     // Stop timer T3460
     REQUIREMENT_3GPP_24_301(R10_5_4_2_4__1);
     void* callback_arg = NULL;

--- a/lte/gateway/c/oai/tasks/nas/emm/Identification.c
+++ b/lte/gateway/c/oai/tasks/nas/emm/Identification.c
@@ -48,6 +48,8 @@
 /****************************************************************************/
 extern long mme_app_last_msg_latency;
 extern long pre_mme_task_msg_latency;
+extern mme_congestion_params_t mme_congestion_params;
+
 extern int check_plmn_restriction(imsi_t imsi);
 extern int validate_imei(imeisv_t* imeisv);
 /****************************************************************************/

--- a/lte/gateway/c/oai/tasks/nas/emm/Identification.c
+++ b/lte/gateway/c/oai/tasks/nas/emm/Identification.c
@@ -238,7 +238,7 @@ int emm_proc_identification_complete(
             LOG_NAS_EMM, emm_ctx->_imsi64,
             "Discarding identification complete as cumulative ZMQ latency "
             "( %ld + %ld ) for ueid " MME_UE_S1AP_ID_FMT
-            "is higher than the threshold.",
+            " is higher than the threshold.",
             mme_app_last_msg_latency, pre_mme_task_msg_latency, ue_id);
         OAILOG_FUNC_RETURN(LOG_NAS_EMM, RETURNok);
       }

--- a/lte/gateway/c/oai/tasks/nas/emm/Identification.c
+++ b/lte/gateway/c/oai/tasks/nas/emm/Identification.c
@@ -39,12 +39,15 @@
 #include "emm_fsm.h"
 #include "emm_regDef.h"
 #include "emm_cause.h"
+#include "mme_app_defs.h"
 #include "mme_app_state.h"
 #include "nas_procedures.h"
 
 /****************************************************************************/
 /****************  E X T E R N A L    D E F I N I T I O N S  ****************/
 /****************************************************************************/
+extern long mme_app_last_msg_latency;
+extern long pre_mme_task_msg_latency;
 extern int check_plmn_restriction(imsi_t imsi);
 extern int validate_imei(imeisv_t* imeisv);
 /****************************************************************************/
@@ -213,6 +216,33 @@ int emm_proc_identification_complete(
         get_nas_common_procedure_identification(emm_ctx);
 
     if (ident_proc) {
+      /* Process identification complete msg only if T3470 timer is running.
+       * If it is not running it means that response was already received for
+       * an earlier attempt.
+       */
+      if (ident_proc->T3470.id == NAS_TIMER_INACTIVE_ID) {
+        OAILOG_WARNING_UE(
+            LOG_NAS_EMM, emm_ctx->_imsi64,
+            "Discarding identification complete as T3470 timer is not active "
+            "for ueid " MME_UE_S1AP_ID_FMT "\n",
+            ue_id);
+        OAILOG_FUNC_RETURN(LOG_NAS_EMM, RETURNok);
+      }
+
+      /* If spent too much in ZMQ, then discard the packet.
+       * MME is congested and this would create some relief in processing.
+       */
+      if (mme_app_last_msg_latency + pre_mme_task_msg_latency >
+          MME_APP_ZMQ_LATENCY_IDENT_TH) {
+        OAILOG_WARNING_UE(
+            LOG_NAS_EMM, emm_ctx->_imsi64,
+            "Discarding identification complete as cumulative ZMQ latency "
+            "( %ld + %ld ) for ueid " MME_UE_S1AP_ID_FMT
+            "is higher than the threshold.",
+            mme_app_last_msg_latency, pre_mme_task_msg_latency, ue_id);
+        OAILOG_FUNC_RETURN(LOG_NAS_EMM, RETURNok);
+      }
+
       REQUIREMENT_3GPP_24_301(R10_5_4_4_4);
       /*
        * Stop timer T3470

--- a/lte/gateway/c/oai/tasks/nas/emm/SecurityModeControl.c
+++ b/lte/gateway/c/oai/tasks/nas/emm/SecurityModeControl.c
@@ -81,6 +81,7 @@
 /****************************************************************************/
 extern long mme_app_last_msg_latency;
 extern long pre_mme_task_msg_latency;
+extern mme_congestion_params_t mme_congestion_params;
 
 /****************************************************************************/
 /*******************  L O C A L    D E F I N I T I O N S  *******************/

--- a/lte/gateway/c/oai/tasks/nas/emm/SecurityModeControl.c
+++ b/lte/gateway/c/oai/tasks/nas/emm/SecurityModeControl.c
@@ -499,7 +499,7 @@ int emm_proc_security_mode_complete(
       OAILOG_WARNING_UE(
           LOG_NAS_EMM, emm_ctx->_imsi64,
           "Discarding SMC complete as cumulative ZMQ latency ( %ld + %ld ) for "
-          "ueid " MME_UE_S1AP_ID_FMT "is higher than the threshold.",
+          "ueid " MME_UE_S1AP_ID_FMT " is higher than the threshold.",
           mme_app_last_msg_latency, pre_mme_task_msg_latency, ue_id);
       OAILOG_FUNC_RETURN(LOG_NAS_EMM, RETURNok);
     }

--- a/lte/gateway/c/oai/tasks/nas/emm/SecurityModeControl.c
+++ b/lte/gateway/c/oai/tasks/nas/emm/SecurityModeControl.c
@@ -79,6 +79,8 @@
 /****************************************************************************/
 /****************  E X T E R N A L    D E F I N I T I O N S  ****************/
 /****************************************************************************/
+extern long mme_app_last_msg_latency;
+extern long pre_mme_task_msg_latency;
 
 /****************************************************************************/
 /*******************  L O C A L    D E F I N I T I O N S  *******************/
@@ -476,6 +478,32 @@ int emm_proc_security_mode_complete(
   nas_emm_smc_proc_t* smc_proc = get_nas_common_procedure_smc(emm_ctx);
 
   if (smc_proc) {
+    /* Process SMC complete msg only if T3460 timer is running.
+     * If it is not running it means that response was already received for
+     * an earlier attempt.
+     */
+    if (smc_proc->T3460.id == NAS_TIMER_INACTIVE_ID) {
+      OAILOG_WARNING_UE(
+          LOG_NAS_EMM, emm_ctx->_imsi64,
+          "Discarding SMC complete as T3460 timer is not active for "
+          "ueid " MME_UE_S1AP_ID_FMT "\n",
+          ue_id);
+      OAILOG_FUNC_RETURN(LOG_NAS_EMM, RETURNok);
+    }
+
+    /* If spent too much in ZMQ, then discard the packet.
+     * MME is congested and this would create some relief in processing.
+     */
+    if (mme_app_last_msg_latency + pre_mme_task_msg_latency >
+        MME_APP_ZMQ_LATENCY_SMC_TH) {
+      OAILOG_WARNING_UE(
+          LOG_NAS_EMM, emm_ctx->_imsi64,
+          "Discarding SMC complete as cumulative ZMQ latency ( %ld + %ld ) for "
+          "ueid " MME_UE_S1AP_ID_FMT "is higher than the threshold.",
+          mme_app_last_msg_latency, pre_mme_task_msg_latency, ue_id);
+      OAILOG_FUNC_RETURN(LOG_NAS_EMM, RETURNok);
+    }
+
     /*
      * Stop timer T3460
      */

--- a/lte/gateway/c/oai/tasks/nas/emm/sap/emm_recv.c
+++ b/lte/gateway/c/oai/tasks/nas/emm/sap/emm_recv.c
@@ -54,8 +54,9 @@
 /****************************************************************************/
 /****************  E X T E R N A L    D E F I N I T I O N S  ****************/
 /****************************************************************************/
-extern long mme_app_min_msg_latency;
 extern long mme_app_last_msg_latency;
+extern long pre_mme_task_msg_latency;
+extern mme_congestion_params_t mme_congestion_params;
 
 /****************************************************************************/
 /*******************  L O C A L    D E F I N I T I O N S  *******************/
@@ -206,12 +207,14 @@ int emm_recv_attach_request(
    */
   // Currently a simple logic, when a more complex logic added
   // refactor this part via helper functions is_mme_congested.
-  if (mme_app_last_msg_latency > UPPER_RELATIVE_TH * mme_app_min_msg_latency) {
+  if (mme_app_last_msg_latency + pre_mme_task_msg_latency >
+      MME_APP_ZMQ_LATENCY_CONGEST_TH) {
     OAILOG_WARNING(
         LOG_NAS_EMM,
         "EMMAS-SAP - Sending Attach Reject for ue_id = (%08x), emm_cause = "
-        "(EMM_CAUSE_CONGESTION) min. latency: %ld, last packet latency: %ld\n",
-        ue_id, mme_app_min_msg_latency, mme_app_last_msg_latency);
+        "(EMM_CAUSE_CONGESTION) last packet latency: %ld prev hop latency: "
+        "%ld\n",
+        ue_id, mme_app_last_msg_latency, pre_mme_task_msg_latency);
     rc         = emm_proc_attach_reject(ue_id, EMM_CAUSE_CONGESTION);
     *emm_cause = EMM_CAUSE_SUCCESS;
     OAILOG_FUNC_RETURN(LOG_NAS_EMM, rc);

--- a/lte/gateway/c/oai/tasks/s1ap/s1ap_mme.c
+++ b/lte/gateway/c/oai/tasks/s1ap/s1ap_mme.c
@@ -79,7 +79,7 @@ bool hss_associated = false;
 static int indent   = 0;
 task_zmq_ctx_t s1ap_task_zmq_ctx;
 long s1ap_last_msg_latency = 0;
-long s1ap_min_msg_latency  = LONG_MAX;
+long s1ap_zmq_th           = LONG_MAX;
 
 //------------------------------------------------------------------------------
 static int s1ap_send_init_sctp(void) {
@@ -113,15 +113,9 @@ static int handle_message(zloop_t* loop, zsock_t* reader, void* arg) {
 
   bool is_task_state_same = false;
   bool is_ue_state_same   = false;
-  bool is_congested       = false;
 
   s1ap_last_msg_latency = ITTI_MSG_LATENCY(received_message_p);  // microseconds
-  s1ap_min_msg_latency =
-      1000;  // 1 msec
-             // MIN(s1ap_min_msg_latency, s1ap_last_msg_latency);
-  if (s1ap_last_msg_latency > LOWER_RELATIVE_TH * s1ap_min_msg_latency) {
-    // is_congested = true;
-  }
+
   OAILOG_INFO(LOG_S1AP, "S1AP ZMQ latency: %ld.", s1ap_last_msg_latency);
 
   switch (ITTI_MSG_ID(received_message_p)) {
@@ -349,15 +343,14 @@ static int handle_message(zloop_t* loop, zsock_t* reader, void* arg) {
     } break;
   }
 
-  if (!is_congested) {
-    if (!is_task_state_same) {
-      put_s1ap_state();
-    }
-    if (!is_ue_state_same) {
-      put_s1ap_imsi_map();
-      put_s1ap_ue_state(imsi64);
-    }
+  if (!is_task_state_same) {
+    put_s1ap_state();
   }
+  if (!is_ue_state_same) {
+    put_s1ap_imsi_map();
+    put_s1ap_ue_state(imsi64);
+  }
+
   itti_free_msg_content(received_message_p);
   free(received_message_p);
   return 0;
@@ -391,6 +384,8 @@ int s1ap_mme_init(const mme_config_t* mme_config_p) {
   }
 
   OAILOG_DEBUG(LOG_S1AP, "ASN1C version %d\n", get_asn1c_environment_version());
+
+  s1ap_zmq_th = mme_config_p->s1ap_zmq_th;
 
   if (s1ap_state_init(
           mme_config_p->max_ues, mme_config_p->max_enbs,

--- a/lte/gateway/c/oai/tasks/s1ap/s1ap_mme.h
+++ b/lte/gateway/c/oai/tasks/s1ap/s1ap_mme.h
@@ -32,10 +32,8 @@
 #include "s1ap_state.h"
 #include "s1ap_types.h"
 
-#define UPPER_RELATIVE_TH 1000000  // times the minimum ZMQ Latency observed
-#define LOWER_RELATIVE_TH 50       // times the minimum ZMQ latency observed
 #define S1AP_ZMQ_LATENCY_TH                                                    \
-  2000000  // absolute threshold to be used for initial UE messages
+  s1ap_zmq_th  // absolute threshold to be used for initial UE messages
 
 extern bool hss_associated;
 

--- a/lte/gateway/c/oai/tasks/s1ap/s1ap_mme.h
+++ b/lte/gateway/c/oai/tasks/s1ap/s1ap_mme.h
@@ -32,6 +32,9 @@
 #include "s1ap_state.h"
 #include "s1ap_types.h"
 
+#define UPPER_RELATIVE_TH 1000000  // times the minimum ZMQ Latency observed
+#define LOWER_RELATIVE_TH 50       // times the minimum ZMQ latency observed
+
 extern bool hss_associated;
 
 /** \brief S1AP layer top init

--- a/lte/gateway/c/oai/tasks/s1ap/s1ap_mme.h
+++ b/lte/gateway/c/oai/tasks/s1ap/s1ap_mme.h
@@ -34,6 +34,8 @@
 
 #define UPPER_RELATIVE_TH 1000000  // times the minimum ZMQ Latency observed
 #define LOWER_RELATIVE_TH 50       // times the minimum ZMQ latency observed
+#define S1AP_ZMQ_LATENCY_TH                                                    \
+  2000000  // absolute threshold to be used for initial UE messages
 
 extern bool hss_associated;
 

--- a/lte/gateway/c/oai/tasks/s1ap/s1ap_mme_itti_messaging.c
+++ b/lte/gateway/c/oai/tasks/s1ap/s1ap_mme_itti_messaging.c
@@ -86,6 +86,7 @@ int s1ap_mme_itti_nas_uplink_ind(
         " MME_APP_UPLINK_DATA_IND \n");
     OAILOG_FUNC_RETURN(LOG_S1AP, RETURNerror);
   }
+  ITTI_MSG_LASTHOP_LATENCY(message_p)    = s1ap_last_msg_latency;
   MME_APP_UL_DATA_IND(message_p).ue_id   = ue_id;
   MME_APP_UL_DATA_IND(message_p).nas_msg = *payload;
   *payload                               = NULL;
@@ -174,6 +175,7 @@ void s1ap_mme_itti_s1ap_initial_ue_message(
       ": " ENB_UE_S1AP_ID_FMT "\n",
       enb_ue_s1ap_id);
 
+  ITTI_MSG_LASTHOP_LATENCY(message_p)               = s1ap_last_msg_latency;
   S1AP_INITIAL_UE_MESSAGE(message_p).sctp_assoc_id  = assoc_id;
   S1AP_INITIAL_UE_MESSAGE(message_p).enb_ue_s1ap_id = enb_ue_s1ap_id;
   S1AP_INITIAL_UE_MESSAGE(message_p).enb_id         = enb_id;

--- a/lte/gateway/c/oai/tasks/s1ap/s1ap_mme_itti_messaging.h
+++ b/lte/gateway/c/oai/tasks/s1ap/s1ap_mme_itti_messaging.h
@@ -42,6 +42,7 @@
 #include "s1ap_state.h"
 
 extern task_zmq_ctx_t s1ap_task_zmq_ctx;
+extern long s1ap_last_msg_latency;
 
 int s1ap_mme_itti_send_sctp_request(
     STOLEN_REF bstring* payload, const uint32_t sctp_assoc_id_t,

--- a/lte/gateway/c/oai/tasks/s1ap/s1ap_mme_nas_procedures.c
+++ b/lte/gateway/c/oai/tasks/s1ap/s1ap_mme_nas_procedures.c
@@ -78,7 +78,7 @@
 #include "s1ap_common.h"
 
 extern long s1ap_last_msg_latency;
-extern long s1ap_min_msg_latency;
+extern long s1ap_zmq_th;
 
 //------------------------------------------------------------------------------
 int s1ap_mme_handle_initial_ue_message(
@@ -108,10 +108,9 @@ int s1ap_mme_handle_initial_ue_message(
     OAILOG_WARNING(
         LOG_S1AP,
         "Discarding S1AP INITIAL_UE_MESSAGE for "
-        "ENB_UE_S1AP_ID: " ENB_UE_S1AP_ID_FMT
-        " ZMQ latency: %ld; min. latency: %ld",
+        "ENB_UE_S1AP_ID: " ENB_UE_S1AP_ID_FMT " ZMQ latency: %ld",
         (enb_ue_s1ap_id_t) ie->value.choice.ENB_UE_S1AP_ID,
-        s1ap_last_msg_latency, s1ap_min_msg_latency);
+        s1ap_last_msg_latency);
     OAILOG_FUNC_RETURN(LOG_S1AP, RETURNerror);
   }
 
@@ -352,16 +351,6 @@ int s1ap_mme_handle_uplink_nas_transport(
       s1ap_mme_remove_stale_ue_context(enb_ue_s1ap_id, enb_ref->enb_id);
       OAILOG_FUNC_RETURN(LOG_S1AP, RETURNerror);
     }
-  }
-
-  if (s1ap_last_msg_latency > UPPER_RELATIVE_TH * s1ap_min_msg_latency) {
-    OAILOG_WARNING(
-        LOG_S1AP,
-        "Discarding S1AP UPLINK_NAS_TRANSPORT for this "
-        "mme_ue_s1ap_id: " MME_UE_S1AP_ID_FMT
-        " ZMQ latency: %ld; min. latency: %ld",
-        mme_ue_s1ap_id, s1ap_last_msg_latency, s1ap_min_msg_latency);
-    OAILOG_FUNC_RETURN(LOG_S1AP, RETURNerror);
   }
 
   if (S1AP_UE_CONNECTED != ue_ref->s1_ue_state) {

--- a/lte/gateway/c/oai/tasks/s1ap/s1ap_mme_nas_procedures.c
+++ b/lte/gateway/c/oai/tasks/s1ap/s1ap_mme_nas_procedures.c
@@ -77,6 +77,9 @@
 #include "S1ap_ProtocolIE-Field.h"
 #include "s1ap_common.h"
 
+extern long s1ap_last_msg_latency;
+extern long s1ap_min_msg_latency;
+
 //------------------------------------------------------------------------------
 int s1ap_mme_handle_initial_ue_message(
     s1ap_state_t* state, const sctp_assoc_id_t assoc_id,
@@ -338,6 +341,16 @@ int s1ap_mme_handle_uplink_nas_transport(
       s1ap_mme_remove_stale_ue_context(enb_ue_s1ap_id, enb_ref->enb_id);
       OAILOG_FUNC_RETURN(LOG_S1AP, RETURNerror);
     }
+  }
+
+  if (s1ap_last_msg_latency > UPPER_RELATIVE_TH * s1ap_min_msg_latency) {
+    OAILOG_WARNING(
+        LOG_S1AP,
+        "Discarding S1AP UPLINK_NAS_TRANSPORT for this "
+        "mme_ue_s1ap_id: " MME_UE_S1AP_ID_FMT
+        " ZMQ latency: %ld; min. latency: %ld",
+        mme_ue_s1ap_id, s1ap_last_msg_latency, s1ap_min_msg_latency);
+    OAILOG_FUNC_RETURN(LOG_S1AP, RETURNerror);
   }
 
   if (S1AP_UE_CONNECTED != ue_ref->s1_ue_state) {

--- a/lte/gateway/c/oai/tasks/s1ap/s1ap_mme_nas_procedures.c
+++ b/lte/gateway/c/oai/tasks/s1ap/s1ap_mme_nas_procedures.c
@@ -104,6 +104,17 @@ int s1ap_mme_handle_initial_ue_message(
       " assoc-id:%d \n",
       (enb_ue_s1ap_id_t) ie->value.choice.ENB_UE_S1AP_ID, assoc_id);
 
+  if (s1ap_last_msg_latency > S1AP_ZMQ_LATENCY_TH) {
+    OAILOG_WARNING(
+        LOG_S1AP,
+        "Discarding S1AP INITIAL_UE_MESSAGE for "
+        "ENB_UE_S1AP_ID: " ENB_UE_S1AP_ID_FMT
+        " ZMQ latency: %ld; min. latency: %ld",
+        (enb_ue_s1ap_id_t) ie->value.choice.ENB_UE_S1AP_ID,
+        s1ap_last_msg_latency, s1ap_min_msg_latency);
+    OAILOG_FUNC_RETURN(LOG_S1AP, RETURNerror);
+  }
+
   if ((eNB_ref = s1ap_state_get_enb(state, assoc_id)) == NULL) {
     OAILOG_ERROR(LOG_S1AP, "Unknown eNB on assoc_id %d\n", assoc_id);
     OAILOG_FUNC_RETURN(LOG_S1AP, RETURNerror);

--- a/lte/gateway/configs/mme.yml
+++ b/lte/gateway/configs/mme.yml
@@ -27,3 +27,8 @@ enable_apn_correction: false
 apn_correction_map_list:
         - imsi_prefix: "00101"
           apn_override: "magma.ipv4"
+s1ap_zmq_th: 2000000 # microseconds (delay threshold used for dropping initial UE message)
+mme_app_zmq_congest_th: 100000 # microseconds (delay threshold used for rejecting attach requests)
+mme_app_zmq_auth_th: 200000 # microseconds (delay threshold used for dropping Authentication Complete)
+mme_app_zmq_ident_th: 400000 # microseconds (delay threshold used for dropping Identification Complete)
+mme_app_zmq_smc_th: 1000000 # microseconds (delay threshold used for dropping SMC Complete)

--- a/lte/gateway/configs/templates/mme.conf.template
+++ b/lte/gateway/configs/templates/mme.conf.template
@@ -37,6 +37,11 @@ MME :
     USE_HA = "{{ use_ha }}";
     ENABLE_GTPU_PRIVATE_IP_CORRECTION = "{{ enable_gtpu_private_ip_correction }}";
     ENABLE_CONVERGED_CORE = "{{ enable_converged_core }}";
+    S1AP_ZMQ_TH = {{ s1ap_zmq_th }};
+    MME_APP_ZMQ_CONGEST_TH = {{ mme_app_zmq_congest_th }};
+    MME_APP_ZMQ_AUTH_TH = {{ mme_app_zmq_auth_th }};
+    MME_APP_ZMQ_IDENT_TH = {{ mme_app_zmq_ident_th }};
+    MME_APP_ZMQ_SMC_TH = {{ mme_app_zmq_smc_th }};
 
     INTERTASK_INTERFACE :
     {


### PR DESCRIPTION
<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->
- Adds zmq delay logging for S1AP and MME APP tasks.
- Adds a basic congestion control mechanism based on absolute latency thresholds to eliminate MME and AGW instability. The packets are dropped at points where UE based retries can be done and attach requests are rejected explicitly in the case of congestion.
- Adds configuration parameters for the threshold values to be used by S1AP and MME APP tasks. 

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->
- Spirent tests where the system is loaded above, at and under its capacity. 
- Integ tests.

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
