### PR TITLE
[MME] Drop build over-ride to Debug type for ngap sub-task

### DIFF
--- a/lte/gateway/c/oai/tasks/ngap/CMakeLists.txt
+++ b/lte/gateway/c/oai/tasks/ngap/CMakeLists.txt
@@ -1,6 +1,5 @@
 add_list1_option(NGAP_VERSION R16 "NGAP Asn.1 grammar version" R16)
 add_definitions(-DASN1_MINIMUM_VERSION=923)
-set(CMAKE_BUILD_TYPE Debug)
 set(ASN1RELDIR r16)
 set(NGAP_DIR ${CMAKE_CURRENT_SOURCE_DIR})
 set(asn1_generated_dir ${CMAKE_CURRENT_BINARY_DIR})


### PR DESCRIPTION
## Summary 

Setting the ngap sub-task to always build Debug variant is incompatible with top level binary build specifications for e.g. production. And therefore cause linking errors when we `make build_oai BUILD_TYPE=RelWithDebInfo`

This works to address #7244