### PR TITLE
[feg] s6a_proxy add Extended-Max-Requested-BW

### DIFF
--- a/feg/gateway/services/s6a_proxy/servicers/s6a_definitions.go
+++ b/feg/gateway/services/s6a_proxy/servicers/s6a_definitions.go
@@ -151,6 +151,8 @@ type AIA struct {
 type AMBR struct {
 	MaxRequestedBandwidthUL uint32 `avp:"Max-Requested-Bandwidth-UL"`
 	MaxRequestedBandwidthDL uint32 `avp:"Max-Requested-Bandwidth-DL"`
+	ExtendMaxRequestedBwUL  uint32 `avp:"Extended-Max-Requested-BW-UL"`
+	ExtendMaxRequestedBwDL  uint32 `avp:"Extended-Max-Requested-BW-DL"`
 }
 
 type AllocationRetentionPriority struct {

--- a/feg/gateway/services/s6a_proxy/servicers/s6a_proxy_test.go
+++ b/feg/gateway/services/s6a_proxy/servicers/s6a_proxy_test.go
@@ -121,6 +121,14 @@ func TestS6aProxyService(t *testing.T) {
 		assert.NotEmpty(t, ulResp.FeatureListId_2)
 		assert.True(t, ulResp.FeatureListId_2.NrAsSecondaryRat)
 
+		assert.NotNil(t, ulResp.TotalAmbr)
+		assert.Equal(t, uint32(500), ulResp.TotalAmbr.MaxBandwidthDl)
+		assert.Equal(t, uint32(600), ulResp.TotalAmbr.MaxBandwidthUl)
+		assert.Equal(t, protos.UpdateLocationAnswer_AggregatedMaximumBitrate_KBPS, ulResp.TotalAmbr.Unit)
+		assert.NotEmpty(t, ulResp.Apn)
+		assert.Equal(t, uint32(50), ulResp.Apn[0].Ambr.MaxBandwidthDl)
+		assert.Equal(t, uint32(60), ulResp.Apn[0].Ambr.MaxBandwidthUl)
+		assert.Equal(t, protos.UpdateLocationAnswer_AggregatedMaximumBitrate_BPS, ulResp.Apn[0].Ambr.Unit)
 		puReq := &protos.PurgeUERequest{
 			UserName: test.TEST_IMSI,
 		}

--- a/feg/gateway/services/s6a_proxy/servicers/test/test_s6a_server.go
+++ b/feg/gateway/services/s6a_proxy/servicers/test/test_s6a_server.go
@@ -17,6 +17,7 @@ import (
 	"bytes"
 	"fmt"
 	"io"
+	"math"
 	"strconv"
 	"time"
 
@@ -348,9 +349,13 @@ func testSendULA(settings *sm.Settings, w io.Writer, m *diam.Message) (n int64, 
 			diam.NewAVP(avp.AMBR, avp.Mbit|avp.Vbit, VENDOR_3GPP, &diam.GroupedAVP{
 				AVP: []*diam.AVP{
 					diam.NewAVP(
-						avp.MaxRequestedBandwidthDL, avp.Mbit|avp.Vbit, VENDOR_3GPP, datatype.Unsigned32(500)),
+						avp.MaxRequestedBandwidthDL, avp.Mbit|avp.Vbit, VENDOR_3GPP, datatype.Unsigned32(math.MaxUint32)),
 					diam.NewAVP(
-						avp.MaxRequestedBandwidthUL, avp.Mbit|avp.Vbit, VENDOR_3GPP, datatype.Unsigned32(500)),
+						avp.MaxRequestedBandwidthUL, avp.Mbit|avp.Vbit, VENDOR_3GPP, datatype.Unsigned32(math.MaxUint32)),
+					diam.NewAVP(
+						avp.ExtendedMaxRequestedBWDL, avp.Mbit|avp.Vbit, VENDOR_3GPP, datatype.Unsigned32(500)),
+					diam.NewAVP(
+						avp.ExtendedMaxRequestedBWUL, avp.Mbit|avp.Vbit, VENDOR_3GPP, datatype.Unsigned32(600)),
 				},
 			}),
 			diam.NewAVP(avp.APNConfigurationProfile, avp.Mbit|avp.Vbit, VENDOR_3GPP, &diam.GroupedAVP{
@@ -363,6 +368,12 @@ func testSendULA(settings *sm.Settings, w io.Writer, m *diam.Message) (n int64, 
 							diam.NewAVP(avp.ContextIdentifier, avp.Mbit|avp.Vbit, VENDOR_3GPP, datatype.Unsigned32(0)),
 							diam.NewAVP(avp.PDNType, avp.Mbit|avp.Vbit, VENDOR_3GPP, datatype.Unsigned32(0)),
 							diam.NewAVP(avp.ServiceSelection, avp.Mbit|avp.Vbit, VENDOR_3GPP, datatype.UTF8String("oai.ipv4")),
+							diam.NewAVP(avp.AMBR, avp.Mbit|avp.Vbit, VENDOR_3GPP, &diam.GroupedAVP{
+								AVP: []*diam.AVP{
+									diam.NewAVP(avp.MaxRequestedBandwidthDL, avp.Mbit|avp.Vbit, VENDOR_3GPP, datatype.Unsigned32(50)),
+									diam.NewAVP(avp.MaxRequestedBandwidthUL, avp.Mbit|avp.Vbit, VENDOR_3GPP, datatype.Unsigned32(60)),
+								},
+							}),
 							diam.NewAVP(avp.EPSSubscribedQoSProfile, avp.Mbit|avp.Vbit, VENDOR_3GPP, &diam.GroupedAVP{
 								AVP: []*diam.AVP{
 									diam.NewAVP(avp.QoSClassIdentifier, avp.Mbit|avp.Vbit, VENDOR_3GPP, datatype.Unsigned32(9)),
@@ -375,12 +386,6 @@ func testSendULA(settings *sm.Settings, w io.Writer, m *diam.Message) (n int64, 
 									}),
 								},
 							}),
-						},
-					}),
-					diam.NewAVP(avp.AMBR, avp.Mbit|avp.Vbit, VENDOR_3GPP, &diam.GroupedAVP{
-						AVP: []*diam.AVP{
-							diam.NewAVP(avp.MaxRequestedBandwidthDL, avp.Mbit|avp.Vbit, VENDOR_3GPP, datatype.Unsigned32(500)),
-							diam.NewAVP(avp.MaxRequestedBandwidthUL, avp.Mbit|avp.Vbit, VENDOR_3GPP, datatype.Unsigned32(500)),
 						},
 					}),
 				},

--- a/feg/gateway/services/s6a_proxy/servicers/ul.go
+++ b/feg/gateway/services/s6a_proxy/servicers/ul.go
@@ -148,10 +148,7 @@ func (s *s6aProxy) UpdateLocationImpl(req *protos.UpdateLocationRequest) (*proto
 					res.ErrorCode = protos.ErrorCode(ula.ExperimentalResult.ExperimentalResultCode)
 					res.Msisdn = ula.SubscriptionData.MSISDN.Serialize()
 					res.DefaultContextId = ula.SubscriptionData.APNConfigurationProfile.ContextIdentifier
-					res.TotalAmbr = &protos.UpdateLocationAnswer_AggregatedMaximumBitrate{
-						MaxBandwidthUl: ula.SubscriptionData.AMBR.MaxRequestedBandwidthUL,
-						MaxBandwidthDl: ula.SubscriptionData.AMBR.MaxRequestedBandwidthDL,
-					}
+					res.TotalAmbr = ula.SubscriptionData.AMBR.getProtoAmbr()
 					res.DefaultChargingCharacteristics = ula.SubscriptionData.TgppChargingCharacteristics
 					res.AllApnsIncluded =
 						ula.SubscriptionData.APNConfigurationProfile.AllAPNConfigurationsIncludedIndicator == 0
@@ -174,10 +171,7 @@ func (s *s6aProxy) UpdateLocationImpl(req *protos.UpdateLocationRequest) (*proto
 									PreemptionCapability:    apnCfg.EPSSubscribedQoSProfile.AllocationRetentionPriority.PreemptionCapability == 0,
 									PreemptionVulnerability: apnCfg.EPSSubscribedQoSProfile.AllocationRetentionPriority.PreemptionVulnerability == 0,
 								},
-								Ambr: &protos.UpdateLocationAnswer_AggregatedMaximumBitrate{
-									MaxBandwidthUl: apnCfg.AMBR.MaxRequestedBandwidthUL,
-									MaxBandwidthDl: apnCfg.AMBR.MaxRequestedBandwidthDL,
-								},
+								Ambr:                    apnCfg.AMBR.getProtoAmbr(),
 								ChargingCharacteristics: apnCfg.TgppChargingCharacteristics,
 							})
 					}
@@ -212,4 +206,19 @@ func getFeatureListID2(supportedFeatures []SupportedFeatures) *protos.FeatureLis
 		}
 	}
 	return protoFeatureList
+}
+
+func (ambr *AMBR) getProtoAmbr() *protos.UpdateLocationAnswer_AggregatedMaximumBitrate {
+	if ambr.ExtendMaxRequestedBwDL != 0 && ambr.ExtendMaxRequestedBwUL != 0 {
+		return &protos.UpdateLocationAnswer_AggregatedMaximumBitrate{
+			MaxBandwidthUl: ambr.ExtendMaxRequestedBwUL,
+			MaxBandwidthDl: ambr.ExtendMaxRequestedBwDL,
+			Unit:           protos.UpdateLocationAnswer_AggregatedMaximumBitrate_KBPS,
+		}
+	}
+	return &protos.UpdateLocationAnswer_AggregatedMaximumBitrate{
+		MaxBandwidthUl: ambr.MaxRequestedBandwidthUL,
+		MaxBandwidthDl: ambr.MaxRequestedBandwidthDL,
+		Unit:           protos.UpdateLocationAnswer_AggregatedMaximumBitrate_BPS,
+	}
 }


### PR DESCRIPTION
Signed-off-by: Oriol Batalla <obatalla@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary

Added support for Extended-Max-Requested-BW on s6a_proxy requested in this issue https://github.com/magma/magma/issues/5676

## Test Plan

make precommit at feg

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
