### PR TITLE
Adding missing header function definitions

### DIFF
--- a/lte/gateway/c/oai/tasks/sgw_s8/sgw_s8_s11_handlers.h
+++ b/lte/gateway/c/oai/tasks/sgw_s8/sgw_s8_s11_handlers.h
@@ -33,3 +33,13 @@ void sgw_s8_handle_modify_bearer_request(
 void sgw_s8_handle_delete_session_response(
     sgw_state_t* sgw_state, s8_delete_session_response_t* session_rsp_p,
     imsi64_t imsi64);
+
+void sgw_s8_handle_release_access_bearers_request(
+    const itti_s11_release_access_bearers_request_t* const
+    release_access_bearers_req_pP,
+    imsi64_t imsi64);
+
+void sgw_s8_handle_s11_delete_session_request(
+    sgw_state_t* sgw_state,
+    const itti_s11_delete_session_request_t* const delete_session_req_p,
+    imsi64_t imsi64);


### PR DESCRIPTION
Add missing header definitions for sgw_s8_s11 handlers

Fixes compile issues once warning flags are passed correctly

Signed-off-by: Amar Padmanabhan <amarpadmanabhan@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
