### PR TITLE
Fix clearing of PCO attributes to preserve const correctness

### DIFF
--- a/lte/gateway/c/oai/tasks/nas/esm/esm_information.c
+++ b/lte/gateway/c/oai/tasks/nas/esm/esm_information.c
@@ -133,7 +133,6 @@ int esm_proc_esm_information_response(
     }
     copy_protocol_configuration_options(
         &emm_context_p->esm_ctx.esm_proc_data->pco, pco);
-    clear_protocol_configuration_options(pco);
   }
 
   *esm_cause = ESM_CAUSE_SUCCESS;

--- a/lte/gateway/c/oai/tasks/nas/esm/sap/esm_sap.c
+++ b/lte/gateway/c/oai/tasks/nas/esm/sap/esm_sap.c
@@ -694,6 +694,8 @@ static int esm_sap_recv(
       case ESM_INFORMATION_RESPONSE:
         esm_cause = esm_recv_information_response(
             emm_context, pti, ebi, &esm_msg.esm_information_response);
+        clear_protocol_configuration_options(
+            &esm_msg.esm_information_response.protocolconfigurationoptions);
         OAILOG_DEBUG(
             LOG_NAS_ESM,
             "ESM-SAP   - ESM Message type = ESM_INFORMATION_RESPONSE(0x%x)"


### PR DESCRIPTION
Move clearing of PCO to caller to preseve const correctness of
attribtes


Signed-off-by: Amar Padmanabhan <amarpadmanabhan@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
