### PR TITLE
apply formatting script to lte/gateway/python/magma

### DIFF
--- a/lte/gateway/python/magma/health/entities.py
+++ b/lte/gateway/python/magma/health/entities.py
@@ -74,9 +74,11 @@ class CoreDumps:
 
 
 class AGWHealthSummary:
-    def __init__(self, hss_relay_enabled, nb_enbs_connected,
-                 allocated_ips, subscriber_table, core_dumps,
-                 registration_success_rate):
+    def __init__(
+        self, hss_relay_enabled, nb_enbs_connected,
+        allocated_ips, subscriber_table, core_dumps,
+        registration_success_rate,
+    ):
         self.hss_relay_enabled = hss_relay_enabled
         self.nb_enbs_connected = nb_enbs_connected
         self.allocated_ips = allocated_ips

--- a/lte/gateway/python/magma/mobilityd/dhcp_client.py
+++ b/lte/gateway/python/magma/mobilityd/dhcp_client.py
@@ -32,15 +32,18 @@ from scapy.sendrecv import sendp
 LOG = logging.getLogger('mobilityd.dhcp.sniff')
 DHCP_ACTIVE_STATES = [DHCPState.ACK, DHCPState.OFFER]
 
+
 class DHCPClient:
     THREAD_YIELD_TIME = .1
 
-    def __init__(self,
-                 dhcp_store: MutableMapping[str, DHCPDescriptor],
-                 gw_info: UplinkGatewayInfo,
-                 dhcp_wait: Condition,
-                 iface: str = "dhcp0",
-                 lease_renew_wait_min: int = 200):
+    def __init__(
+        self,
+        dhcp_store: MutableMapping[str, DHCPDescriptor],
+        gw_info: UplinkGatewayInfo,
+        dhcp_wait: Condition,
+        iface: str = "dhcp0",
+        lease_renew_wait_min: int = 200,
+    ):
         """
         Implement DHCP client to allocate IP for given Mac address.
         DHCP client state is maintained in user provided hash table.
@@ -50,10 +53,12 @@ class DHCPClient:
             dhcp_wait: notify users on new DHCP packet
             iface: DHCP egress and ingress interface.
         """
-        self._sniffer = AsyncSniffer(iface=iface,
-                                     filter="udp and (port 67 or 68)",
-                                     store=False,
-                                     prn=self._rx_dhcp_pkt)
+        self._sniffer = AsyncSniffer(
+            iface=iface,
+            filter="udp and (port 67 or 68)",
+            store=False,
+            prn=self._rx_dhcp_pkt,
+        )
 
         self.dhcp_client_state = dhcp_store  # mac => DHCP_State
         self.dhcp_gw_info = gw_info
@@ -61,7 +66,9 @@ class DHCPClient:
         self._dhcp_interface = iface
         self._msg_xid = 0
         self._lease_renew_wait_min = lease_renew_wait_min
-        self._monitor_thread = threading.Thread(target=self._monitor_dhcp_state)
+        self._monitor_thread = threading.Thread(
+            target=self._monitor_dhcp_state,
+        )
         self._monitor_thread.daemon = True
         self._monitor_thread_event = threading.Event()
 
@@ -81,9 +88,11 @@ class DHCPClient:
         self._sniffer.stop()
         self._monitor_thread_event.set()
 
-    def send_dhcp_packet(self, mac: MacAddress, vlan: str,
-                         state: DHCPState,
-                         dhcp_desc: DHCPDescriptor = None):
+    def send_dhcp_packet(
+        self, mac: MacAddress, vlan: str,
+        state: DHCPState,
+        dhcp_desc: DHCPDescriptor = None,
+    ):
         """
         Send DHCP packet and record state in dhcp_client_state.
 
@@ -98,26 +107,36 @@ class DHCPClient:
         # generate DHCP request packet
         if state == DHCPState.DISCOVER:
             dhcp_opts = [("message-type", "discover")]
-            dhcp_desc = DHCPDescriptor(mac=mac, ip="", vlan=vlan,
-                                       state_requested=DHCPState.DISCOVER)
+            dhcp_desc = DHCPDescriptor(
+                mac=mac, ip="", vlan=vlan,
+                state_requested=DHCPState.DISCOVER,
+            )
             self._msg_xid = self._msg_xid + 1
             pkt_xid = self._msg_xid
         elif state == DHCPState.REQUEST:
-            dhcp_opts = [("message-type", "request"),
-                         ("requested_addr", dhcp_desc.ip),
-                         ("server_id", dhcp_desc.server_ip)]
+            dhcp_opts = [
+                ("message-type", "request"),
+                ("requested_addr", dhcp_desc.ip),
+                ("server_id", dhcp_desc.server_ip),
+            ]
             dhcp_desc.state_requested = DHCPState.REQUEST
             pkt_xid = dhcp_desc.xid
             ciaddr = dhcp_desc.ip
         elif state == DHCPState.RELEASE:
-            dhcp_opts = [("message-type", "release"),
-                         ("server_id", dhcp_desc.server_ip)]
+            dhcp_opts = [
+                ("message-type", "release"),
+                ("server_id", dhcp_desc.server_ip),
+            ]
             dhcp_desc.state_requested = DHCPState.RELEASE
             self._msg_xid = self._msg_xid + 1
             pkt_xid = self._msg_xid
             ciaddr = dhcp_desc.ip
         else:
-            LOG.warning("Unknown egress request mac %s state %s", str(mac), state)
+            LOG.warning(
+                "Unknown egress request mac %s state %s",
+                str(mac),
+                state,
+            )
             return
 
         dhcp_opts.append("end")
@@ -136,7 +155,10 @@ class DHCPClient:
 
         sendp(pkt, iface=self._dhcp_interface, verbose=0)
 
-    def get_dhcp_desc(self, mac: MacAddress, vlan: str) -> Optional[DHCPDescriptor]:
+    def get_dhcp_desc(
+        self, mac: MacAddress,
+        vlan: str,
+    ) -> Optional[DHCPDescriptor]:
         """
                 Get DHCP description for given MAC.
         Args:
@@ -168,7 +190,12 @@ class DHCPClient:
             return
 
         dhcp_desc = self.dhcp_client_state[key]
-        self.send_dhcp_packet(mac, dhcp_desc.vlan, DHCPState.RELEASE, dhcp_desc)
+        self.send_dhcp_packet(
+            mac,
+            dhcp_desc.vlan,
+            DHCPState.RELEASE,
+            dhcp_desc,
+        )
         del self.dhcp_client_state[key]
 
     def _monitor_dhcp_state(self):
@@ -193,12 +220,16 @@ class DHCPClient:
 
                     if now >= dhcp_record.lease_renew_deadline:
                         logging.debug("sending lease renewal")
-                        self.send_dhcp_packet(dhcp_record.mac, dhcp_record.vlan,
-                                              request_state, dhcp_record)
+                        self.send_dhcp_packet(
+                            dhcp_record.mac, dhcp_record.vlan,
+                            request_state, dhcp_record,
+                        )
                     else:
                         # Find next renewal wait time.
                         time_to_renew = dhcp_record.lease_renew_deadline - now
-                        wait_time = min(wait_time, time_to_renew.total_seconds())
+                        wait_time = min(
+                            wait_time, time_to_renew.total_seconds(),
+                        )
 
             # default in wait is 30 sec
             wait_time = max(wait_time, self._lease_renew_wait_min)
@@ -233,9 +264,13 @@ class DHCPClient:
                 ip_offered = packet[BOOTP].yiaddr
                 subnet_mask = self._get_option(packet, "subnet_mask")
                 if subnet_mask is not None:
-                    ip_subnet = IPv4Network(ip_offered + "/" + subnet_mask, strict=False)
+                    ip_subnet = IPv4Network(
+                        ip_offered + "/" + subnet_mask, strict=False,
+                    )
                 else:
-                    ip_subnet = IPv4Network(ip_offered + "/" + "32", strict=False)
+                    ip_subnet = IPv4Network(
+                        ip_offered + "/" + "32", strict=False,
+                    )
 
                 dhcp_server_ip = None
                 if IP in packet:
@@ -250,25 +285,34 @@ class DHCPClient:
                 self.dhcp_gw_info.update_ip(router_ip_addr, vlan)
 
                 lease_expiration_time = self._get_option(packet, "lease_time")
-                dhcp_state = DHCPDescriptor(mac=mac_addr,
-                                             ip=ip_offered,
-                                             state=state,
-                                             vlan=vlan,
-                                             state_requested=state_requested,
-                                             subnet=str(ip_subnet),
-                                             server_ip=dhcp_server_ip,
-                                             router_ip=router_ip_addr,
-                                             lease_expiration_time=lease_expiration_time,
-                                             xid=packet[BOOTP].xid)
-                LOG.info("Record DHCP for: %s state: %s", mac_addr_key, dhcp_state)
+                dhcp_state = DHCPDescriptor(
+                    mac=mac_addr,
+                    ip=ip_offered,
+                    state=state,
+                    vlan=vlan,
+                    state_requested=state_requested,
+                    subnet=str(ip_subnet),
+                    server_ip=dhcp_server_ip,
+                    router_ip=router_ip_addr,
+                    lease_expiration_time=lease_expiration_time,
+                    xid=packet[BOOTP].xid,
+                )
+                LOG.info(
+                    "Record DHCP for: %s state: %s",
+                    mac_addr_key,
+                    dhcp_state,
+                )
 
                 self.dhcp_client_state[mac_addr_key] = dhcp_state
                 self._dhcp_notify.notifyAll()
 
                 if state == DHCPState.OFFER:
-                    #  let other thread work on fulfilling IP allocation request.
+                    # let other thread work on fulfilling IP allocation
+                    # request.
                     threading.Event().wait(self.THREAD_YIELD_TIME)
-                    self.send_dhcp_packet(mac_addr, vlan, DHCPState.REQUEST, dhcp_state)
+                    self.send_dhcp_packet(
+                        mac_addr, vlan, DHCPState.REQUEST, dhcp_state,
+                    )
             else:
                 LOG.debug("Unknown MAC: %s " % packet.summary())
                 return

--- a/lte/gateway/python/magma/mobilityd/dhcp_desc.py
+++ b/lte/gateway/python/magma/mobilityd/dhcp_desc.py
@@ -34,12 +34,14 @@ class DHCPState(IntEnum):
 
 
 class DHCPDescriptor:
-    def __init__(self, mac: MacAddress, ip: str,
-                 state_requested: DHCPState, vlan: str,
-                 state: DHCPState = DHCPState.UNKNOWN,
-                 subnet: str = None, server_ip: str = None,
-                 router_ip: str = None, lease_expiration_time: int = 0,
-                 xid: str = None):
+    def __init__(
+        self, mac: MacAddress, ip: str,
+        state_requested: DHCPState, vlan: str,
+        state: DHCPState = DHCPState.UNKNOWN,
+        subnet: str = None, server_ip: str = None,
+        router_ip: str = None, lease_expiration_time: int = 0,
+        xid: str = None,
+    ):
         """
         DHCP descriptor. This object maintains all information for
         given DHCP protocol transactions.
@@ -64,7 +66,8 @@ class DHCPDescriptor:
         self.state_requested = state_requested
         self.server_ip = server_ip
         self.xid = xid
-        self.lease_expiration_time = datetime.now() + timedelta(seconds=lease_expiration_time)
+        self.lease_expiration_time = datetime.now(
+        ) + timedelta(seconds=lease_expiration_time)
         self.router_ip = router_ip
         if self.state == DHCPState.ACK:
             new_deadline = datetime.now() + timedelta(seconds=(lease_expiration_time / 2))
@@ -76,10 +79,12 @@ class DHCPDescriptor:
         return "state: {:8s} requested state: {:8s} mac {} ip {} subnet {} " \
                "DHCP: {} router {} " \
                "lease time {}, renew {} xid {} vlan {}" \
-            .format(self.state.name, self.state_requested.name,
-                    str(self.mac), self.ip, self.subnet,
-                    self.server_ip, self.router_ip, self.lease_expiration_time,
-                    self.lease_renew_deadline, self.xid, self.vlan)
+            .format(
+                self.state.name, self.state_requested.name,
+                str(self.mac), self.ip, self.subnet,
+                self.server_ip, self.router_ip, self.lease_expiration_time,
+                self.lease_renew_deadline, self.xid, self.vlan,
+            )
 
     def get_ip_address(self) -> Optional[str]:
         """
@@ -96,6 +101,8 @@ class DHCPDescriptor:
 
         :return: True or False
         """
-        return (self.state == DHCPState.OFFER
-                or self.state == DHCPState.REQUEST
-                or self.state == DHCPState.ACK)
+        return (
+            self.state == DHCPState.OFFER
+            or self.state == DHCPState.REQUEST
+            or self.state == DHCPState.ACK
+        )

--- a/lte/gateway/python/magma/mobilityd/ip_allocator_dhcp.py
+++ b/lte/gateway/python/magma/mobilityd/ip_allocator_dhcp.py
@@ -41,8 +41,10 @@ LOG = logging.getLogger('mobilityd.dhcp.alloc')
 
 
 class IPAllocatorDHCP(IPAllocator):
-    def __init__(self, store: MobilityStore, retry_limit: int = 300,
-                 iface: str = "dhcp0"):
+    def __init__(
+        self, store: MobilityStore, retry_limit: int = 300,
+        iface: str = "dhcp0",
+    ):
         """
         Allocate IP address for SID using DHCP server.
         SID is mapped to MAC address using function defined in mac.py
@@ -58,21 +60,29 @@ class IPAllocatorDHCP(IPAllocator):
         """
         self._store = store
         self.dhcp_wait = Condition()
-        self._dhcp_client = DHCPClient(dhcp_wait=self.dhcp_wait,
-                                       dhcp_store=store.dhcp_store,
-                                       gw_info=store.dhcp_gw_info,
-                                       iface=iface)
+        self._dhcp_client = DHCPClient(
+            dhcp_wait=self.dhcp_wait,
+            dhcp_store=store.dhcp_store,
+            gw_info=store.dhcp_gw_info,
+            iface=iface,
+        )
         self._retry_limit = retry_limit  # default wait for two minutes
         self._dhcp_client.run()
 
     def add_ip_block(self, ipblock: ip_network):
-        logging.warning("No need to allocate block for DHCP allocator: %s",
-                        ipblock)
+        logging.warning(
+            "No need to allocate block for DHCP allocator: %s",
+            ipblock,
+        )
 
-    def remove_ip_blocks(self, *ipblocks: List[ip_network],
-                         force: bool = False) -> List[ip_network]:
-        logging.warning("Trying to delete ipblock from DHCP allocator: %s",
-                        ipblocks)
+    def remove_ip_blocks(
+        self, *ipblocks: List[ip_network],
+        force: bool = False
+    ) -> List[ip_network]:
+        logging.warning(
+            "Trying to delete ipblock from DHCP allocator: %s",
+            ipblocks,
+        )
         return []
 
     def list_added_ip_blocks(self) -> List[ip_network]:
@@ -89,9 +99,11 @@ class IPAllocatorDHCP(IPAllocator):
             list of IP addresses (ipaddress.ip_address)
 
         """
-        return [ip for ip in
-                self._store.ip_state_map.list_ips(IPState.ALLOCATED)
-                if ip in ipblock]
+        return [
+            ip for ip in
+            self._store.ip_state_map.list_ips(IPState.ALLOCATED)
+            if ip in ipblock
+        ]
 
     def alloc_ip_address(self, sid: str, vlan: int) -> IPDesc:
         """
@@ -110,26 +122,31 @@ class IPAllocatorDHCP(IPAllocator):
         mac = create_mac_from_sid(sid)
 
         dhcp_desc = self._dhcp_client.get_dhcp_desc(mac, vlan)
-        LOG.debug("allocate IP for %s mac %s dhcp_desc %s", sid, mac,
-                  dhcp_desc)
+        LOG.debug(
+            "allocate IP for %s mac %s dhcp_desc %s", sid, mac,
+            dhcp_desc,
+        )
 
         if dhcp_allocated_ip(dhcp_desc) is not True:
             dhcp_desc = self._alloc_ip_address_from_dhcp(mac, vlan)
 
         if dhcp_allocated_ip(dhcp_desc):
             ip_block = ip_network(dhcp_desc.subnet)
-            ip_desc = IPDesc(ip=ip_address(dhcp_desc.ip),
-                             state=IPState.ALLOCATED,
-                             sid=sid,
-                             ip_block=ip_block,
-                             ip_type=IPType.DHCP,
-                             vlan_id=vlan)
+            ip_desc = IPDesc(
+                ip=ip_address(dhcp_desc.ip),
+                state=IPState.ALLOCATED,
+                sid=sid,
+                ip_block=ip_block,
+                ip_type=IPType.DHCP,
+                vlan_id=vlan,
+            )
             self._store.assigned_ip_blocks.add(ip_block)
 
             return ip_desc
         else:
             msg = "No available IP addresses From DHCP for SID: {} MAC {}".format(
-                sid, mac)
+                sid, mac,
+            )
             raise NoAvailableIPError(msg)
 
     def release_ip(self, ip_desc: IPDesc):
@@ -145,14 +162,17 @@ class IPAllocatorDHCP(IPAllocator):
                 IP block of the IP address, vlan id of the APN.
         Returns: None
         """
-        self._dhcp_client.release_ip_address(create_mac_from_sid(ip_desc.sid),
-                                             ip_desc.vlan_id)
+        self._dhcp_client.release_ip_address(
+            create_mac_from_sid(ip_desc.sid),
+            ip_desc.vlan_id,
+        )
         # Remove the IP from free IP list, since DHCP is the
         # owner of this IP
         self._store.ip_state_map.remove_ip_from_state(ip_desc.ip, IPState.FREE)
 
         list_allocated_ips = self._store.ip_state_map.list_ips(
-            IPState.ALLOCATED)
+            IPState.ALLOCATED,
+        )
         for ipaddr in list_allocated_ips:
             if ipaddr in ip_desc.ip_block:
                 # found the IP, do not remove this ip_block
@@ -161,23 +181,31 @@ class IPAllocatorDHCP(IPAllocator):
         ip_block_network = ip_network(ip_desc.ip_block)
         if ip_block_network in self._store.assigned_ip_blocks:
             self._store.assigned_ip_blocks.remove(ip_block_network)
-        logging.debug("del: _assigned_ip_blocks %s ipblock %s",
-                      self._store.assigned_ip_blocks, ip_desc.ip_block)
+        logging.debug(
+            "del: _assigned_ip_blocks %s ipblock %s",
+            self._store.assigned_ip_blocks, ip_desc.ip_block,
+        )
 
     def stop_dhcp_sniffer(self):
         self._dhcp_client.stop()
 
-    def _alloc_ip_address_from_dhcp(self, mac: MacAddress,
-                                    vlan: int) -> DHCPDescriptor:
+    def _alloc_ip_address_from_dhcp(
+        self, mac: MacAddress,
+        vlan: int,
+    ) -> DHCPDescriptor:
         retry_count = 0
         with self.dhcp_wait:
             dhcp_desc = None
-            while (retry_count < self._retry_limit and
-                   dhcp_allocated_ip(dhcp_desc) is not True):
+            while (
+                retry_count < self._retry_limit
+                and dhcp_allocated_ip(dhcp_desc) is not True
+            ):
 
                 if retry_count % DEFAULT_DHCP_REQUEST_RETRY_FREQUENCY == 0:
-                    self._dhcp_client.send_dhcp_packet(mac, vlan,
-                                                       DHCPState.DISCOVER)
+                    self._dhcp_client.send_dhcp_packet(
+                        mac, vlan,
+                        DHCPState.DISCOVER,
+                    )
                 self.dhcp_wait.wait(timeout=DEFAULT_DHCP_REQUEST_RETRY_DELAY)
 
                 dhcp_desc = self._dhcp_client.get_dhcp_desc(mac, vlan)

--- a/lte/gateway/python/magma/mobilityd/ip_allocator_pool.py
+++ b/lte/gateway/python/magma/mobilityd/ip_allocator_pool.py
@@ -72,15 +72,19 @@ class IpAllocatorPool(IPAllocator):
         for ip in ipblock.hosts():
             state = IPState.RESERVED if num_reserved_addresses > 0 \
                 else IPState.FREE
-            ip_desc = IPDesc(ip=ip, state=state,
-                             ip_block=ipblock, sid=None,
-                             ip_type=IPType.IP_POOL)
+            ip_desc = IPDesc(
+                ip=ip, state=state,
+                ip_block=ipblock, sid=None,
+                ip_type=IPType.IP_POOL,
+            )
             self._store.ip_state_map.add_ip_to_state(ip, ip_desc, state)
             if num_reserved_addresses > 0:
                 num_reserved_addresses -= 1
 
-    def remove_ip_blocks(self, ipblocks: List[ip_network],
-                         force: bool = False) -> List[ip_network]:
+    def remove_ip_blocks(
+        self, ipblocks: List[ip_network],
+        force: bool = False,
+    ) -> List[ip_network]:
         """ Makes the indicated block(s) unavailable for allocation
 
         If force is False, blocks that have any addresses currently allocated
@@ -107,15 +111,19 @@ class IpAllocatorPool(IPAllocator):
         """
 
         remove_blocks = set(ipblocks) & self._store.assigned_ip_blocks
-        logging.warning("_assigned_ip_blocks %s",
-                        self._store.assigned_ip_blocks)
+        logging.warning(
+            "_assigned_ip_blocks %s",
+            self._store.assigned_ip_blocks,
+        )
         logging.warning("arg ipblocks %s", ipblocks)
 
         extraneous_blocks = set(ipblocks) ^ remove_blocks
         # check unknown ip blocks
         if extraneous_blocks:
-            logging.warning("Cannot remove unknown IP block(s): %s",
-                            extraneous_blocks)
+            logging.warning(
+                "Cannot remove unknown IP block(s): %s",
+                extraneous_blocks,
+            )
         del extraneous_blocks
 
         # "soft" removal does not remove blocks have IPs allocated
@@ -131,11 +139,15 @@ class IpAllocatorPool(IPAllocator):
             for state in (IPState.FREE, IPState.RELEASED, IPState.REAPED):
                 self._store.ip_state_map.remove_ip_from_state(ip, state)
             if force:
-                self._store.ip_state_map.remove_ip_from_state(ip,
-                                                              IPState.ALLOCATED)
+                self._store.ip_state_map.remove_ip_from_state(
+                    ip,
+                    IPState.ALLOCATED,
+                )
             else:
-                assert not self._store.ip_state_map.test_ip_state(ip,
-                                                                  IPState.ALLOCATED), \
+                assert not self._store.ip_state_map.test_ip_state(
+                    ip,
+                    IPState.ALLOCATED,
+                ), \
                     "Unexpected ALLOCATED IP %s from a soft IP block " \
                     "removal "
 
@@ -147,8 +159,10 @@ class IpAllocatorPool(IPAllocator):
         self._store.assigned_ip_blocks -= remove_blocks
 
         # Can't use generators here
-        remove_sids = tuple(sid for sid in self._store.sid_ips_map
-                            if not self._store.sid_ips_map[sid])
+        remove_sids = tuple(
+            sid for sid in self._store.sid_ips_map
+            if not self._store.sid_ips_map[sid]
+        )
         for sid in remove_sids:
             self._store.sid_ips_map.pop(sid)
 
@@ -182,8 +196,10 @@ class IpAllocatorPool(IPAllocator):
             logging.error("Listing an unknown IP block: %s", ipblock)
             raise IPBlockNotFoundError(ipblock)
 
-        res = [ip for ip in ipblock \
-               if self._store.ip_state_map.test_ip_state(ip, IPState.ALLOCATED)]
+        res = [
+            ip for ip in ipblock
+            if self._store.ip_state_map.test_ip_state(ip, IPState.ALLOCATED)
+        ]
         return res
 
     def alloc_ip_address(self, sid: str, vlan: int) -> IPDesc:

--- a/lte/gateway/python/magma/mobilityd/ip_descriptor.py
+++ b/lte/gateway/python/magma/mobilityd/ip_descriptor.py
@@ -46,9 +46,11 @@ class IPDesc:
         vlan_id (int)
     """
 
-    def __init__(self, ip: ipaddress.ip_address = None, state: IPState = None,
-                 sid: str = None, ip_block: ipaddress.ip_network = None,
-                 ip_type: IPType = None, vlan_id: int = 0):
+    def __init__(
+        self, ip: ipaddress.ip_address = None, state: IPState = None,
+        sid: str = None, ip_block: ipaddress.ip_network = None,
+        ip_type: IPType = None, vlan_id: int = 0,
+    ):
         self.ip = ip
         self.ip_block = ip_block
         self.state = state
@@ -65,7 +67,8 @@ class IPDesc:
                      self.ip_block,
                      self.state,
                      self.sid,
-                     self.type)
+                     self.type,
+                 )
 
         if self.vlan_id != 0:
             as_str = as_str + " vlan_is: {}".format(self.vlan_id)

--- a/lte/gateway/python/magma/mobilityd/ip_descriptor_map.py
+++ b/lte/gateway/python/magma/mobilityd/ip_descriptor_map.py
@@ -57,8 +57,10 @@ class IpDescriptorMap:
         """
         self.ip_states = ip_states
 
-    def add_ip_to_state(self, ip: ip_address, ip_desc: IPDesc,
-                        state: IPState):
+    def add_ip_to_state(
+        self, ip: ip_address, ip_desc: IPDesc,
+        state: IPState,
+    ):
         """ Add ip=>ip_desc pairs to a internal dict """
         assert ip_desc.state == state, \
             "ip_desc.state %s does not match with state %s" \

--- a/lte/gateway/python/magma/mobilityd/ipv6_allocator_pool.py
+++ b/lte/gateway/python/magma/mobilityd/ipv6_allocator_pool.py
@@ -47,7 +47,8 @@ class IPv6AllocatorPool(IPAllocator):
         Returns:
         """
         if self._assigned_ip_block and ipblock.overlaps(
-                self._assigned_ip_block):
+                self._assigned_ip_block,
+        ):
             logging.warning("Overlapped IP block: %s", ipblock)
             raise OverlappedIPBlocksError(ipblock)
 
@@ -59,8 +60,10 @@ class IPv6AllocatorPool(IPAllocator):
         # For now only one IPv6 network is supported
         self._assigned_ip_block = ipblock
 
-    def remove_ip_blocks(self, ipblocks: List[ip_network],
-                         force: bool = False) -> List[ip_network]:
+    def remove_ip_blocks(
+        self, ipblocks: List[ip_network],
+        force: bool = False,
+    ) -> List[ip_network]:
         """
         Removes assigned IP block (as it only supports one for now)
 
@@ -91,16 +94,21 @@ class IPv6AllocatorPool(IPAllocator):
         for sid in list(self._store.sid_ips_map):
             ip_desc = self._store.sid_ips_map[sid]
             if ip_desc.ip.version == 6:
-                self._store.ipv6_state_map.remove_ip_from_state(ip_desc.ip,
-                                                                IPState.FREE)
+                self._store.ipv6_state_map.remove_ip_from_state(
+                    ip_desc.ip,
+                    IPState.FREE,
+                )
                 if force:
                     self._store.ipv6_state_map.remove_ip_from_state(
-                        ip_desc.ip, IPState.ALLOCATED)
+                        ip_desc.ip, IPState.ALLOCATED,
+                    )
                 self._store.sid_ips_map.pop(sid)
 
         removed_blocks.append(self._assigned_ip_block)
-        logging.info('Removed IP block %s from IPv6 address pool',
-                     self._assigned_ip_block)
+        logging.info(
+            'Removed IP block %s from IPv6 address pool',
+            self._assigned_ip_block,
+        )
         self._assigned_ip_block = None
         return removed_blocks
 
@@ -126,19 +134,23 @@ class IPv6AllocatorPool(IPAllocator):
         if not session_prefix_part:
             logging.error('Could not get IPv6 session prefix for sid: %s', sid)
             raise MaxCalculationError(
-                'Could not get IPv6 session prefix for sid: %s', sid)
+                'Could not get IPv6 session prefix for sid: %s', sid,
+            )
 
         # Get interface identifier from 64 bits fixed length
         iid_part = self._get_ipv6_iid_part(sid, IID_PART_LEN)
         if not iid_part:
             logging.error('Could not get IPv6 IID for sid: %s', sid)
             raise MaxCalculationError(
-                'Could not get IPv6 IID for sid: %s', sid)
+                'Could not get IPv6 IID for sid: %s', sid,
+            )
 
         ipv6_addr = ipv6_addr_part + (session_prefix_part * iid_part)
-        ip_desc = IPDesc(ip=ipv6_addr, state=IPState.ALLOCATED, sid=sid,
-                         ip_block=self._assigned_ip_block,
-                         ip_type=IPType.IP_POOL)
+        ip_desc = IPDesc(
+            ip=ipv6_addr, state=IPState.ALLOCATED, sid=sid,
+            ip_block=self._assigned_ip_block,
+            ip_type=IPType.IP_POOL,
+        )
         return ip_desc
 
     def release_ip(self, ip_desc: IPDesc):
@@ -161,7 +173,8 @@ class IPv6AllocatorPool(IPAllocator):
         if ip_addr in self._assigned_ip_block and session_prefix:
             # Extract IID part of the given IPv6 prefix and session prefix
             iid_part = float(
-                (int(ip_addr) - ipv6_addr_part) / int(session_prefix))
+                (int(ip_addr) - ipv6_addr_part) / int(session_prefix),
+            )
 
             if iid_part in self._store.allocated_iid.values():
                 del self._store.sid_session_prefix_allocated[sid]
@@ -199,14 +212,16 @@ class IPv6AllocatorPool(IPAllocator):
         """
         session_prefix_len = IPV6_PREFIX_PART_LEN - self._assigned_ip_block.prefixlen
         session_prefix_allocated = self._store.sid_session_prefix_allocated.get(
-            sid)
+            sid,
+        )
         # TODO: Support multiple alloc modes
         if self._ipv6_session_prefix_alloc_mode == IPv6SessionAllocType.RANDOM:
             for i in range(MAX_CALC_TRIES):
                 session_prefix_part = random.getrandbits(session_prefix_len)
                 if session_prefix_part != session_prefix_allocated:
                     self._store.sid_session_prefix_allocated[
-                        sid] = session_prefix_part
+                        sid
+                    ] = session_prefix_part
                     return session_prefix_part
         return None
 

--- a/lte/gateway/python/magma/mobilityd/metrics.py
+++ b/lte/gateway/python/magma/mobilityd/metrics.py
@@ -14,7 +14,11 @@ limitations under the License.
 from prometheus_client import Counter
 
 # Counters for IP address management
-IP_ALLOCATED_TOTAL = Counter('ip_address_allocated',
-                             'Total IP addresses allocated')
-IP_RELEASED_TOTAL = Counter('ip_address_released',
-                             'Total IP addresses released')
+IP_ALLOCATED_TOTAL = Counter(
+    'ip_address_allocated',
+    'Total IP addresses allocated',
+)
+IP_RELEASED_TOTAL = Counter(
+    'ip_address_released',
+    'Total IP addresses released',
+)

--- a/lte/gateway/python/magma/mobilityd/mobility_store.py
+++ b/lte/gateway/python/magma/mobilityd/mobility_store.py
@@ -36,12 +36,16 @@ ALLOCATED_SESSION_PREFIX_TYPE = "mobilityd_allocated_session_prefix"
 
 
 class MobilityStore(object):
-    def __init__(self, client: redis.Redis, persist_to_redis: bool,
-                 redis_port: int):
+    def __init__(
+        self, client: redis.Redis, persist_to_redis: bool,
+        redis_port: int,
+    ):
         self.init_store(client, persist_to_redis, redis_port)
 
-    def init_store(self, client: redis.Redis, persist_to_redis: bool,
-                   redis_port: int):
+    def init_store(
+        self, client: redis.Redis, persist_to_redis: bool,
+        redis_port: int,
+    ):
         if not persist_to_redis:
             self.ip_state_map = IpDescriptorMap(defaultdict(dict))
             self.ipv6_state_map = IpDescriptorMap(defaultdict(dict))
@@ -54,11 +58,14 @@ class MobilityStore(object):
         else:
             if not redis_port:
                 raise ValueError(
-                    'Must specify a redis_port in mobilityd config.')
+                    'Must specify a redis_port in mobilityd config.',
+                )
             self.ip_state_map = IpDescriptorMap(
-                defaultdict_key(lambda key: ip_states(client, key)))
+                defaultdict_key(lambda key: ip_states(client, key)),
+            )
             self.ipv6_state_map = IpDescriptorMap(
-                defaultdict_key(lambda key: ip_states(client, key)))
+                defaultdict_key(lambda key: ip_states(client, key)),
+            )
             self.assigned_ip_blocks = AssignedIpBlocksSet(client)
             self.sid_ips_map = IPDescDict(client)
             self.dhcp_gw_info = UplinkGatewayInfo(GatewayInfoMap())
@@ -79,10 +86,11 @@ class AssignedIpBlocksSet(RedisSet):
 
 class IPDescDict(RedisFlatDict):
     def __init__(self, client):
-        serde = RedisSerde(IPDESC_REDIS_TYPE,
-                           serialize_utils.serialize_ip_desc,
-                           serialize_utils.deserialize_ip_desc,
-                           )
+        serde = RedisSerde(
+            IPDESC_REDIS_TYPE,
+            serialize_utils.serialize_ip_desc,
+            serialize_utils.deserialize_ip_desc,
+        )
         super().__init__(client, serde, writethrough=True)
 
 
@@ -117,8 +125,10 @@ class MacToIP(RedisFlatDict):
 
     def __init__(self):
         client = get_default_client()
-        serde = RedisSerde(MAC_TO_IP_REDIS_TYPE,
-                           get_json_serializer(), get_json_deserializer())
+        serde = RedisSerde(
+            MAC_TO_IP_REDIS_TYPE,
+            get_json_serializer(), get_json_deserializer(),
+        )
         super().__init__(client, serde)
 
     def __missing__(self, key):
@@ -133,8 +143,10 @@ class GatewayInfoMap(RedisFlatDict):
 
     def __init__(self):
         client = get_default_client()
-        serde = RedisSerde(DHCP_GW_INFO_REDIS_TYPE,
-                           get_json_serializer(), get_json_deserializer())
+        serde = RedisSerde(
+            DHCP_GW_INFO_REDIS_TYPE,
+            get_json_serializer(), get_json_deserializer(),
+        )
         super().__init__(client, serde)
 
     def __missing__(self, key):
@@ -150,8 +162,10 @@ class AllocatedIID(RedisFlatDict):
 
     def __init__(self):
         client = get_default_client()
-        serde = RedisSerde(ALLOCATED_IID_REDIS_TYPE,
-                           get_json_serializer(), get_json_deserializer())
+        serde = RedisSerde(
+            ALLOCATED_IID_REDIS_TYPE,
+            get_json_serializer(), get_json_deserializer(),
+        )
         super().__init__(client, serde)
 
     def __missing__(self, key):
@@ -166,8 +180,10 @@ class AllocatedSessionPrefix(RedisFlatDict):
 
     def __init__(self):
         client = get_default_client()
-        serde = RedisSerde(ALLOCATED_SESSION_PREFIX_TYPE,
-                           get_json_serializer(), get_json_deserializer())
+        serde = RedisSerde(
+            ALLOCATED_SESSION_PREFIX_TYPE,
+            get_json_serializer(), get_json_deserializer(),
+        )
         super().__init__(client, serde)
 
     def __missing__(self, key):

--- a/lte/gateway/python/magma/mobilityd/serialize_utils.py
+++ b/lte/gateway/python/magma/mobilityd/serialize_utils.py
@@ -95,8 +95,10 @@ def _ip_desc_to_proto(desc):
         type=SubscriberID.IMSI,
     )
     ip_type = _desc_type_str_to_proto(desc.type)
-    return IPDesc(ip=ip, ip_block=ip_block, state=state, sid=sid,
-                  type=ip_type, vlan_id=desc.vlan_id)
+    return IPDesc(
+        ip=ip, ip_block=ip_block, state=state, sid=sid,
+        type=ip_type, vlan_id=desc.vlan_id,
+    )
 
 
 def _ip_desc_from_proto(proto):
@@ -110,13 +112,18 @@ def _ip_desc_from_proto(proto):
     """
     ip = ip_address(proto.ip.address)
     ip_block_addr = ip_address(proto.ip_block.net_address).exploded
-    ip_block = ip_network('{}/{}'.format(
-        ip_block_addr, proto.ip_block.prefix_len))
+    ip_block = ip_network(
+        '{}/{}'.format(
+        ip_block_addr, proto.ip_block.prefix_len,
+        ),
+    )
     state = _desc_state_proto_to_str(proto.state)
     sid = proto.sid.id
     ip_type = _desc_type_proto_to_str(proto.type)
-    return ip_descriptor.IPDesc(ip=ip, ip_block=ip_block, state=state,
-                                sid=sid, ip_type=ip_type, vlan_id=proto.vlan_id)
+    return ip_descriptor.IPDesc(
+        ip=ip, ip_block=ip_block, state=state,
+        sid=sid, ip_type=ip_type, vlan_id=proto.vlan_id,
+    )
 
 
 def serialize_ip_block(block):
@@ -167,7 +174,8 @@ def serialize_ip_desc(desc, version):
     serialized = proto.SerializeToString()
     redis_state = RedisState(
         serialized_msg=serialized,
-        version=version)
+        version=version,
+    )
     return redis_state.SerializeToString()
 
 

--- a/lte/gateway/python/magma/mobilityd/subscriberdb_client.py
+++ b/lte/gateway/python/magma/mobilityd/subscriberdb_client.py
@@ -21,8 +21,10 @@ from magma.subscriberdb.sid import SIDUtils
 
 
 class NetworkInfo:
-    def __init__(self, gw_ip: Optional[str] = None, gw_mac: Optional[str] = None,
-                 vlan: int = 0):
+    def __init__(
+        self, gw_ip: Optional[str] = None, gw_mac: Optional[str] = None,
+        vlan: int = 0,
+    ):
         gw_ip_parsed = None
         try:
             gw_ip_parsed = ipaddress.ip_address(gw_ip)
@@ -34,9 +36,11 @@ class NetworkInfo:
         self.vlan = vlan
 
     def __str__(self):
-        return "GW-IP: {} GW-MAC: {} VLAN: {}".format(self.gw_ip,
-                                                      self.gw_mac,
-                                                      self.vlan)
+        return "GW-IP: {} GW-MAC: {} VLAN: {}".format(
+            self.gw_ip,
+            self.gw_mac,
+            self.vlan,
+        )
 
 
 class StaticIPInfo:
@@ -46,10 +50,12 @@ class StaticIPInfo:
     configuration.
     """
 
-    def __init__(self, ip: Optional[str],
-                 gw_ip: Optional[str],
-                 gw_mac: Optional[str],
-                 vlan: int):
+    def __init__(
+        self, ip: Optional[str],
+        gw_ip: Optional[str],
+        gw_mac: Optional[str],
+        vlan: int,
+    ):
         if ip:
             self.ip = ipaddress.ip_address(ip)
         else:
@@ -76,13 +82,17 @@ class SubscriberDbClient:
             apn_config = self._find_ip_and_apn_config(sid)
             logging.debug("ip: Got APN: %s", apn_config)
             if apn_config and apn_config.assigned_static_ip:
-                return StaticIPInfo(ip=apn_config.assigned_static_ip,
-                                    gw_ip=apn_config.resource.gateway_ip,
-                                    gw_mac=apn_config.resource.gateway_mac,
-                                    vlan=apn_config.resource.vlan_id)
+                return StaticIPInfo(
+                    ip=apn_config.assigned_static_ip,
+                    gw_ip=apn_config.resource.gateway_ip,
+                    gw_mac=apn_config.resource.gateway_mac,
+                    vlan=apn_config.resource.vlan_id,
+                )
 
         except ValueError as ex:
-            logging.warning("static Ip: Invalid or missing data for sid %s: ", sid)
+            logging.warning(
+                "static Ip: Invalid or missing data for sid %s: ", sid,
+            )
             logging.debug(ex)
             raise SubscriberDBStaticIPValueError(sid)
 
@@ -104,12 +114,16 @@ class SubscriberDbClient:
                 apn_config = self._find_ip_and_apn_config(sid)
                 logging.debug("vlan: Got APN: %s", apn_config)
                 if apn_config and apn_config.resource.vlan_id:
-                    return NetworkInfo(gw_ip=apn_config.resource.gateway_ip,
-                                       gw_mac=apn_config.resource.gateway_mac,
-                                       vlan=apn_config.resource.vlan_id)
+                    return NetworkInfo(
+                        gw_ip=apn_config.resource.gateway_ip,
+                        gw_mac=apn_config.resource.gateway_mac,
+                        vlan=apn_config.resource.vlan_id,
+                    )
 
             except ValueError as ex:
-                logging.warning("vlan: Invalid or missing data for sid %s", sid)
+                logging.warning(
+                    "vlan: Invalid or missing data for sid %s", sid,
+                )
                 logging.debug(ex)
                 raise SubscriberDBMultiAPNValueError(sid)
 
@@ -122,7 +136,9 @@ class SubscriberDbClient:
         return NetworkInfo()
 
     # use same API to retrieve IP address and related config.
-    def _find_ip_and_apn_config(self, sid: str) -> (Optional[APNConfiguration]):
+    def _find_ip_and_apn_config(
+            self, sid: str,
+    ) -> (Optional[APNConfiguration]):
         if '.' in sid:
             imsi, apn_name_part = sid.split('.', maxsplit=1)
             apn_name, _ = apn_name_part.split(',', maxsplit=1)

--- a/lte/gateway/python/magma/mobilityd/tests/ip_alloc_dhcp_test.py
+++ b/lte/gateway/python/magma/mobilityd/tests/ip_alloc_dhcp_test.py
@@ -56,21 +56,29 @@ class DhcpIPAllocEndToEndTest(unittest.TestCase):
         setup_dhcp_server = SCRIPT_PATH + "scripts/setup-test-dhcp-srv.sh"
         subprocess.check_call([setup_dhcp_server, "t0"])
 
-        setup_uplink_br = [SCRIPT_PATH + "scripts/setup-uplink-br.sh",
-                           self._br,
-                           "t0uplink_p0",
-                           "t0_dhcp1"]
+        setup_uplink_br = [
+            SCRIPT_PATH + "scripts/setup-uplink-br.sh",
+            self._br,
+            "t0uplink_p0",
+            "t0_dhcp1",
+        ]
         subprocess.check_call(setup_uplink_br)
 
         store = MobilityStore(get_default_client(), False, 3980)
-        ipv4_allocator = IPAllocatorDHCP(store, iface='t0uplink_p0',
-                                         retry_limit=50)
-        ipv6_allocator = IPv6AllocatorPool(store,
-                                           session_prefix_alloc_mode='RANDOM')
-        self._dhcp_allocator = IPAddressManager(ipv4_allocator,
-                                                ipv6_allocator,
-                                                store,
-                                                recycling_interval=2)
+        ipv4_allocator = IPAllocatorDHCP(
+            store, iface='t0uplink_p0',
+            retry_limit=50,
+        )
+        ipv6_allocator = IPv6AllocatorPool(
+            store,
+            session_prefix_alloc_mode='RANDOM',
+        )
+        self._dhcp_allocator = IPAddressManager(
+            ipv4_allocator,
+            ipv6_allocator,
+            store,
+            recycling_interval=2,
+        )
 
     def tearDown(self):
         self._dhcp_allocator.ip_allocator.stop_dhcp_sniffer()
@@ -104,8 +112,10 @@ class DhcpIPAllocEndToEndTest(unittest.TestCase):
 
         ip1, _ = self._dhcp_allocator.alloc_ip_address("IMSI02918")
         self.assertEqual(str(ip1), "192.168.128.146")
-        self.assertEqual(self._dhcp_allocator.list_added_ip_blocks(),
-                         [ip_network('192.168.128.0/24')])
+        self.assertEqual(
+            self._dhcp_allocator.list_added_ip_blocks(),
+            [ip_network('192.168.128.0/24')],
+        )
 
         ip2, _ = self._dhcp_allocator.alloc_ip_address("IMSI029192")
         self.assertNotEqual(ip1, ip2)
@@ -114,20 +124,26 @@ class DhcpIPAllocEndToEndTest(unittest.TestCase):
         self.assertNotEqual(ip1, ip3)
         self.assertNotEqual(ip2, ip3)
         # release unallocated IP of SID
-        ip_unallocated = IPDesc(ip=ip3, state=IPState.ALLOCATED,
-                                sid="IMSI033",
-                                ip_block=ip_network("1.1.1.0/24"),
-                                ip_type=IPType.DHCP)
+        ip_unallocated = IPDesc(
+            ip=ip3, state=IPState.ALLOCATED,
+            sid="IMSI033",
+            ip_block=ip_network("1.1.1.0/24"),
+            ip_type=IPType.DHCP,
+        )
         self._dhcp_allocator.ip_allocator.release_ip(ip_unallocated)
-        self.assertEqual(self._dhcp_allocator.list_added_ip_blocks(),
-                         [ip_network('192.168.128.0/24')])
+        self.assertEqual(
+            self._dhcp_allocator.list_added_ip_blocks(),
+            [ip_network('192.168.128.0/24')],
+        )
 
         sid4 = "IMSI54321"
         ip4, _ = self._dhcp_allocator.alloc_ip_address(sid4)
         threading.Event().wait(1)
         self._dhcp_allocator.release_ip_address(sid4, ip4)
-        self.assertEqual(self._dhcp_allocator.list_added_ip_blocks(),
-                         [ip_network('192.168.128.0/24')])
+        self.assertEqual(
+            self._dhcp_allocator.list_added_ip_blocks(),
+            [ip_network('192.168.128.0/24')],
+        )
 
         # wait for DHCP release
         threading.Event().wait(7)

--- a/lte/gateway/python/magma/mobilityd/tests/ip_allocator_tests.py
+++ b/lte/gateway/python/magma/mobilityd/tests/ip_allocator_tests.py
@@ -54,12 +54,16 @@ class IPAllocatorTests(unittest.TestCase):
         store = MobilityStore(get_default_client(), False, 3980)
         store.dhcp_gw_info.read_default_gw()
         ip_allocator = IpAllocatorPool(store)
-        ipv6_allocator = IPv6AllocatorPool(store,
-                                           session_prefix_alloc_mode='RANDOM')
-        self._allocator = IPAddressManager(ip_allocator,
-                                           ipv6_allocator,
-                                           store,
-                                           recycling_interval)
+        ipv6_allocator = IPv6AllocatorPool(
+            store,
+            session_prefix_alloc_mode='RANDOM',
+        )
+        self._allocator = IPAddressManager(
+            ip_allocator,
+            ipv6_allocator,
+            store,
+            recycling_interval,
+        )
         self._allocator.add_ip_block(self._block)
 
     def setUp(self):
@@ -99,19 +103,27 @@ class IPAllocatorTests(unittest.TestCase):
         ip1, _ = self._allocator.alloc_ip_address('SID1')
         self.assertTrue(ip1 in [self._ip0, self._ip1, self._ip2])
         self.assertNotEqual(ip1, ip0)
-        self.assertEqual({ip0, ip1},
-                         set(self._allocator.list_allocated_ips(self._block)))
-        self.assertEqual(set(self._allocator.get_sid_ip_table()),
-                         {('SID0', ip0), ('SID1', ip1)})
+        self.assertEqual(
+            {ip0, ip1},
+            set(self._allocator.list_allocated_ips(self._block)),
+        )
+        self.assertEqual(
+            set(self._allocator.get_sid_ip_table()),
+            {('SID0', ip0), ('SID1', ip1)},
+        )
 
         ip2, _ = self._allocator.alloc_ip_address('SID2')
         self.assertTrue(ip2 in [self._ip0, self._ip1, self._ip2])
         self.assertNotEqual(ip2, ip0)
         self.assertNotEqual(ip2, ip1)
-        self.assertEqual({ip0, ip1, ip2},
-                         set(self._allocator.list_allocated_ips(self._block)))
-        self.assertEqual(set(self._allocator.get_sid_ip_table()),
-                         {('SID0', ip0), ('SID1', ip1), ('SID2', ip2)})
+        self.assertEqual(
+            {ip0, ip1, ip2},
+            set(self._allocator.list_allocated_ips(self._block)),
+        )
+        self.assertEqual(
+            set(self._allocator.get_sid_ip_table()),
+            {('SID0', ip0), ('SID1', ip1), ('SID2', ip2)},
+        )
 
         # allocate from empty free set
         with self.assertRaises(NoAvailableIPError):
@@ -126,12 +138,14 @@ class IPAllocatorTests(unittest.TestCase):
         # release ip
         self._allocator.release_ip_address('SID0', ip0)
         self.assertFalse(
-            ip0 in self._allocator.list_allocated_ips(self._block)
+            ip0 in self._allocator.list_allocated_ips(self._block),
         )
 
         # check not recyled
-        self.assertEqual(set(self._allocator.get_sid_ip_table()),
-                         {('SID0', ip0), ('SID1', ip1), ('SID2', ip2)})
+        self.assertEqual(
+            set(self._allocator.get_sid_ip_table()),
+            {('SID0', ip0), ('SID1', ip1), ('SID2', ip2)},
+        )
         with self.assertRaises(NoAvailableIPError):
             self._allocator.alloc_ip_address('SID3')
 
@@ -174,7 +188,8 @@ class IPAllocatorTests(unittest.TestCase):
     def test_get_sid_for_unknown_ip(self):
         """ Getting sid for non allocated ip address should return None """
         self.assertIsNone(
-            self._allocator.get_sid_for_ip(ipaddress.ip_address('1.1.1.1')))
+            self._allocator.get_sid_for_ip(ipaddress.ip_address('1.1.1.1')),
+        )
 
     def test_allocate_allocate(self):
         """ Duplicated IP requests for the same UE returns same IP """
@@ -261,13 +276,15 @@ class IPAllocatorTests(unittest.TestCase):
     def test_remove_unallocated_block(self):
         """ test removing the allocator for an unallocated block """
         self.assertEqual(
-            [self._block], self._allocator.remove_ip_blocks(self._block))
+            [self._block], self._allocator.remove_ip_blocks(self._block),
+        )
 
     def test_remove_allocated_block_without_force(self):
         """ test removing the allocator for an allocated block unforcibly """
         self._allocator.alloc_ip_address('SID0')
         self.assertEqual(
-            [], self._allocator.remove_ip_blocks(self._block, force=False))
+            [], self._allocator.remove_ip_blocks(self._block, force=False),
+        )
 
     def test_remove_unforcible_is_default_behavior(self):
         """ test that removing by default is unforcible remove """
@@ -279,7 +296,8 @@ class IPAllocatorTests(unittest.TestCase):
         self._allocator.alloc_ip_address('SID0')
         self.assertEqual(
             [self._block],
-            self._allocator.remove_ip_blocks(self._block, force=True))
+            self._allocator.remove_ip_blocks(self._block, force=True),
+        )
 
     def test_remove_after_releasing_all_addresses(self):
         """ removing after releasing all allocated addresses """
@@ -289,14 +307,16 @@ class IPAllocatorTests(unittest.TestCase):
         ip1, _ = self._allocator.alloc_ip_address('SID1')
 
         self.assertEqual(
-            [], self._allocator.remove_ip_blocks(self._block, force=False))
+            [], self._allocator.remove_ip_blocks(self._block, force=False),
+        )
 
         self._allocator.release_ip_address('SID0', ip0)
         self._allocator.release_ip_address('SID1', ip1)
 
         self.assertEqual(
             [self._block],
-            self._allocator.remove_ip_blocks(self._block, force=False))
+            self._allocator.remove_ip_blocks(self._block, force=False),
+        )
 
     def test_remove_after_releasing_some_addresses(self):
         """ removing after releasing all allocated addresses """
@@ -306,17 +326,21 @@ class IPAllocatorTests(unittest.TestCase):
         ip1, _ = self._allocator.alloc_ip_address('SID1')
 
         self.assertEqual(
-            [], self._allocator.remove_ip_blocks(self._block, force=False))
+            [], self._allocator.remove_ip_blocks(self._block, force=False),
+        )
 
         self._allocator.release_ip_address('SID0', ip0)
 
         self.assertEqual(
-            [], self._allocator.remove_ip_blocks(self._block, force=False))
+            [], self._allocator.remove_ip_blocks(self._block, force=False),
+        )
 
         self.assertTrue(
-            ip0 not in self._allocator.list_allocated_ips(self._block))
+            ip0 not in self._allocator.list_allocated_ips(self._block),
+        )
         self.assertTrue(
-            ip1 in self._allocator.list_allocated_ips(self._block))
+            ip1 in self._allocator.list_allocated_ips(self._block),
+        )
 
     def test_reap_after_forced_remove(self):
         """
@@ -331,7 +355,8 @@ class IPAllocatorTests(unittest.TestCase):
         self._allocator.release_ip_address('SID0', ip0)
         self.assertEqual(
             [self._block],
-            self._allocator.remove_ip_blocks(self._block, force=True))
+            self._allocator.remove_ip_blocks(self._block, force=True),
+        )
         self._allocator.add_ip_block(self._block)
         ip0, _ = self._allocator.alloc_ip_address('SID0')
         ip1, _ = self._allocator.alloc_ip_address('SID1')
@@ -341,6 +366,8 @@ class IPAllocatorTests(unittest.TestCase):
 
         # Ensure that released-then-allocated address doesn't get reaped
         self.assertTrue(
-            ip0 in self._allocator.list_allocated_ips(self._block))
+            ip0 in self._allocator.list_allocated_ips(self._block),
+        )
         self.assertTrue(
-            ip1 in self._allocator.list_allocated_ips(self._block))
+            ip1 in self._allocator.list_allocated_ips(self._block),
+        )

--- a/lte/gateway/python/magma/mobilityd/tests/test_ipv6_allocator.py
+++ b/lte/gateway/python/magma/mobilityd/tests/test_ipv6_allocator.py
@@ -91,5 +91,7 @@ class TestIPV6Allocator(unittest.TestCase):
         self._allocator.release_ip(ip_desc1)
         self._allocator.release_ip(ip_desc2)
 
-        self.assertEqual({},
-                         self._allocator._store.sid_session_prefix_allocated)
+        self.assertEqual(
+            {},
+            self._allocator._store.sid_session_prefix_allocated,
+        )

--- a/lte/gateway/python/magma/mobilityd/tests/test_uplink_gw.py
+++ b/lte/gateway/python/magma/mobilityd/tests/test_uplink_gw.py
@@ -25,8 +25,10 @@ LOG.isEnabledFor(logging.DEBUG)
 
 def _get_gw_info(ip, mac="", vlan=NO_VLAN):
     ip_addr = ipaddress.ip_address(ip)
-    gw_ip = IPAddress(version=IPAddress.IPV4,
-                      address=ip_addr.packed)
+    gw_ip = IPAddress(
+        version=IPAddress.IPV4,
+        address=ip_addr.packed,
+    )
     return GWInfo(ip=gw_ip, mac=mac, vlan=vlan)
 
 
@@ -57,9 +59,11 @@ class DefGwTest(unittest.TestCase):
         self.dhcp_gw_info.read_default_gw()
 
         def_gw_cmd = "ip route show |grep default| awk '{print $3}'"
-        p = subprocess.Popen([def_gw_cmd],
-                             stdout=subprocess.PIPE,
-                             shell=True)
+        p = subprocess.Popen(
+            [def_gw_cmd],
+            stdout=subprocess.PIPE,
+            shell=True,
+        )
         def_ip = p.stdout.read().decode("utf-8").strip()
 
         self.assertEqual(self.dhcp_gw_info.get_gw_ip(), str(def_ip))

--- a/lte/gateway/python/magma/mobilityd/uplink_gw.py
+++ b/lte/gateway/python/magma/mobilityd/uplink_gw.py
@@ -85,8 +85,10 @@ class UplinkGatewayInfo:
             logging.debug("could not parse GW IP: %s", ip)
             return
 
-        gw_ip = IPAddress(version=IPAddress.IPV4,
-                          address=ip_addr.packed)
+        gw_ip = IPAddress(
+            version=IPAddress.IPV4,
+            address=ip_addr.packed,
+        )
         # keep mac address same if its same GW IP
         vlan_key = _get_vlan_key(vlan_id)
         if vlan_key in self._backing_map:
@@ -128,11 +130,15 @@ class UplinkGatewayInfo:
 
         # TODO: enhance check for MAC address sanity.
         if mac is None or ':' not in mac:
-            logging.error("Incorrect mac format: %s for IP %s (vlan_key %s)",
-                          mac, ip, vlan_id)
+            logging.error(
+                "Incorrect mac format: %s for IP %s (vlan_key %s)",
+                mac, ip, vlan_id,
+            )
             return
-        gw_ip = IPAddress(version=IPAddress.IPV4,
-                          address=ip_addr.packed)
+        gw_ip = IPAddress(
+            version=IPAddress.IPV4,
+            address=ip_addr.packed,
+        )
         updated_info = GWInfo(ip=gw_ip, mac=mac, vlan=vlan_key)
         self._backing_map[vlan_key] = updated_info
         logging.info("GW update: GW IP[%s]: %s : mac %s" % (vlan_key, ip, mac))

--- a/lte/gateway/python/magma/monitord/__init__.py
+++ b/lte/gateway/python/magma/monitord/__init__.py
@@ -10,4 +10,3 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
-

--- a/lte/gateway/python/magma/monitord/icmp_state.py
+++ b/lte/gateway/python/magma/monitord/icmp_state.py
@@ -17,21 +17,25 @@ from orc8r.protos.service303_pb2 import State
 
 ICMP_STATE_TYPE = "icmp_monitoring"
 
-ICMPMonitoringResponse = NamedTuple('ICMPMonitoringResponse',
-                                    [('last_reported_time', int),
-                                     ('latency_ms', float)])
+ICMPMonitoringResponse = NamedTuple(
+    'ICMPMonitoringResponse',
+    [
+        ('last_reported_time', int),
+        ('latency_ms', float),
+    ],
+)
 
 
 def serialize_subscriber_states(
-        sub_table: Dict[str, ICMPMonitoringResponse]) -> List[State]:
+        sub_table: Dict[str, ICMPMonitoringResponse],
+) -> List[State]:
     states = []
     for sub, icmp_resp in sub_table.items():
         serialized = json.dumps(icmp_resp._asdict())
         state = State(
             type=ICMP_STATE_TYPE,
             deviceID=sub,
-            value=serialized.encode('utf-8')
+            value=serialized.encode('utf-8'),
         )
         states.append(state)
     return states
-

--- a/lte/gateway/python/magma/monitord/tests/test_icmp_monitor.py
+++ b/lte/gateway/python/magma/monitord/tests/test_icmp_monitor.py
@@ -21,6 +21,7 @@ from magma.monitord.icmp_monitoring import ICMPMonitoring
 
 LOCALHOST = '127.0.0.1'
 
+
 class ICMPMonitoringTests(unittest.TestCase):
     """
     Test class for the ICMPMonitor class
@@ -31,8 +32,10 @@ class ICMPMonitoringTests(unittest.TestCase):
         self.subscribers[imsi] = ip
 
     async def _ping_local(self):
-        return await self._monitor._ping_targets([LOCALHOST],
-                                                     self.subscribers)
+        return await self._monitor._ping_targets(
+            [LOCALHOST],
+            self.subscribers,
+        )
 
     def setUp(self):
         """
@@ -41,9 +44,11 @@ class ICMPMonitoringTests(unittest.TestCase):
         self.loop = asyncio.get_event_loop()
         self.subscribers = {}
         self.obj = CpeMonitoringModule()
-        self._monitor = ICMPMonitoring(self.obj, polling_interval=5,
-                                       service_loop=self.loop,
-                                       mtr_interface=LOCALHOST)
+        self._monitor = ICMPMonitoring(
+            self.obj, polling_interval=5,
+            service_loop=self.loop,
+            mtr_interface=LOCALHOST,
+        )
 
     def test_ping_subscriber_saves_response(self):
         imsi = 'IMSI00000000001'

--- a/lte/gateway/python/magma/pkt_tester/tests/test_topology_builder.py
+++ b/lte/gateway/python/magma/pkt_tester/tests/test_topology_builder.py
@@ -65,9 +65,11 @@ class TestTopologyBuilder(unittest.TestCase):
             ip_address = self.TEST_IP_PREFIX + str(i + 2)
             iface_name = self.TEST_INT_PREFIX + str(i)
             self._topology_builder.bind(iface_name, bridge)
-            self._topology_builder.create_interface(iface_name,
-                                                    ip_address,
-                                                    self.TEST_NETMASK)
+            self._topology_builder.create_interface(
+                iface_name,
+                ip_address,
+                self.TEST_NETMASK,
+            )
 
         self.assertFalse(self._topology_builder.invalid_devices())
 
@@ -86,8 +88,10 @@ class TestTopologyBuilder(unittest.TestCase):
         iface_name = self.TEST_INT_PREFIX + "0"
 
         port = self._topology_builder.bind(iface_name, bridge)
-        self._topology_builder.create_interface(iface_name, ip_address,
-                                                self.TEST_NETMASK)
+        self._topology_builder.create_interface(
+            iface_name, ip_address,
+            self.TEST_NETMASK,
+        )
 
         self.assertEqual(port.bridge_name, self.TEST_BRIDGE_NAME)
         self.assertEqual(port.iface_name, iface_name)
@@ -114,9 +118,11 @@ class TestTopologyBuilder(unittest.TestCase):
         iface_name = self.TEST_INT_PREFIX + "0"
         bridge = self._topology_builder.create_bridge(self.TEST_BRIDGE_NAME)
         self._topology_builder.bind(iface_name, bridge)
-        iface = self._topology_builder.create_interface(iface_name,
-                                                        ip_address,
-                                                        self.TEST_NETMASK)
+        iface = self._topology_builder.create_interface(
+            iface_name,
+            ip_address,
+            self.TEST_NETMASK,
+        )
         self.assertEqual(iface.name, iface_name)
         self.assertEqual(iface.ip_address, ip_address)
         self.assertEqual(iface.netmask, self.TEST_NETMASK)
@@ -140,8 +146,12 @@ class TestTopologyBuilder(unittest.TestCase):
         self.assertEqual(bridge.name, self.TEST_BRIDGE_NAME)
         bridge.destroy()
         iface_name = self.TEST_INT_PREFIX + "0"
-        self.assertRaises(UseAfterFreeException, bridge.add_virtual_port,
-                          iface_name, "internal")
-        self.assertRaises(UseAfterFreeException, bridge.add_physical_port,
-                          "eth0")
+        self.assertRaises(
+            UseAfterFreeException, bridge.add_virtual_port,
+            iface_name, "internal",
+        )
+        self.assertRaises(
+            UseAfterFreeException, bridge.add_physical_port,
+            "eth0",
+        )
         self.assertRaises(UseAfterFreeException, bridge.sanity_check)

--- a/lte/gateway/python/magma/policydb/apn_rule_map_store.py
+++ b/lte/gateway/python/magma/policydb/apn_rule_map_store.py
@@ -37,6 +37,6 @@ class ApnRuleAssignmentsDict(RedisHashDict):
             client,
             self._DICT_HASH,
             get_proto_serializer(),
-            get_proto_deserializer(SubscriberPolicySet)
+            get_proto_deserializer(SubscriberPolicySet),
         )
         self._clear()

--- a/lte/gateway/python/magma/policydb/basename_store.py
+++ b/lte/gateway/python/magma/policydb/basename_store.py
@@ -35,7 +35,8 @@ class BaseNameDict(RedisHashDict):
             client,
             self._DICT_HASH,
             get_proto_serializer(),
-            get_proto_deserializer(ChargingRuleNameSet))
+            get_proto_deserializer(ChargingRuleNameSet),
+        )
 
     def send_update_notification(self):
         """

--- a/lte/gateway/python/magma/policydb/rating_group_store.py
+++ b/lte/gateway/python/magma/policydb/rating_group_store.py
@@ -35,7 +35,8 @@ class RatingGroupsDict(RedisHashDict):
             client,
             self._DICT_HASH,
             get_proto_serializer(),
-            get_proto_deserializer(RatingGroup))
+            get_proto_deserializer(RatingGroup),
+        )
 
     def send_update_notification(self):
         """

--- a/lte/gateway/python/magma/policydb/reauth_handler.py
+++ b/lte/gateway/python/magma/policydb/reauth_handler.py
@@ -47,15 +47,19 @@ class ReAuthHandler():
         success.
         """
         if not self._is_valid_rar(rar):
-            logging.error('Invalid RAR: Either installing already installed '
-                          'rules, or uninstalling rules that are not installed')
+            logging.error(
+                'Invalid RAR: Either installing already installed '
+                'rules, or uninstalling rules that are not installed',
+            )
             return False
         try:
             resp = self._sessiond_stub.PolicyReAuth(rar)
             return self._handle_rar_answer(rar, resp)
         except grpc.RpcError:
-            logging.error('Unable to apply policy updates for subscriber %s',
-                          rar.imsi)
+            logging.error(
+                'Unable to apply policy updates for subscriber %s',
+                rar.imsi,
+            )
             return False
 
     def _is_valid_rar(self, rar: PolicyReAuthRequest) -> bool:
@@ -78,8 +82,10 @@ class ReAuthHandler():
         answer: PolicyReAuthAnswer,
     ) -> bool:
         if answer.result == ReAuthResult.Value('OTHER_FAILURE'):
-            logging.error('Failed to apply policy updates for subscriber %s',
-                          rar.imsi)
+            logging.error(
+                'Failed to apply policy updates for subscriber %s',
+                rar.imsi,
+            )
             return False
         self._rules_by_sid[rar.imsi] = InstalledPolicies(
             installed_policies=list(self._get_updated_rules(rar, answer)),

--- a/lte/gateway/python/magma/policydb/rule_map_store.py
+++ b/lte/gateway/python/magma/policydb/rule_map_store.py
@@ -34,7 +34,7 @@ class RuleAssignmentsDict(RedisHashDict):
             client,
             self._DICT_HASH,
             get_proto_serializer(),
-            get_proto_deserializer(InstalledPolicies)
+            get_proto_deserializer(InstalledPolicies),
         )
         # TODO: Remove when sessiond becomes stateless
         self._clear()

--- a/lte/gateway/python/magma/policydb/rule_store.py
+++ b/lte/gateway/python/magma/policydb/rule_store.py
@@ -35,7 +35,8 @@ class PolicyRuleDict(RedisHashDict):
             client,
             self._DICT_HASH,
             get_proto_serializer(),
-            get_proto_deserializer(PolicyRule))
+            get_proto_deserializer(PolicyRule),
+        )
 
     def send_update_notification(self):
         """

--- a/lte/gateway/python/magma/policydb/servicers/policy_servicer.py
+++ b/lte/gateway/python/magma/policydb/servicers/policy_servicer.py
@@ -71,13 +71,17 @@ class PolicyRpcServicer(PolicyDBServicer):
         try:
             self._subscriberdb_stub.EnableStaticRules(request)
         except grpc.RpcError:
-            logging.error('Unable to enable rules for subscriber %s. ',
-                          request.imsi)
+            logging.error(
+                'Unable to enable rules for subscriber %s. ',
+                request.imsi,
+            )
             context.set_code(grpc.StatusCode.NOT_FOUND)
             context.set_details('Failed to update rule assignments in orc8r')
             return Void()
 
-        rules_to_install = self._get_rules(request.rule_ids, request.base_names)
+        rules_to_install = self._get_rules(
+            request.rule_ids, request.base_names,
+        )
         rar = PolicyReAuthRequest(
             # Leave session id empty, re-auth for all sessions
             imsi=request.imsi,
@@ -89,8 +93,10 @@ class PolicyRpcServicer(PolicyDBServicer):
         success = self._reauth_handler.handle_policy_re_auth(rar)
         if not success:
             context.set_code(grpc.StatusCode.UNKNOWN)
-            context.set_details('Failed to enable all static rules for '
-                                'subscriber. Partial update may have succeeded')
+            context.set_details(
+                'Failed to enable all static rules for '
+                'subscriber. Partial update may have succeeded',
+            )
         return Void()
 
     def DisableStaticRules(
@@ -106,8 +112,10 @@ class PolicyRpcServicer(PolicyDBServicer):
         try:
             self._subscriberdb_stub.DisableStaticRules(request)
         except grpc.RpcError:
-            logging.error('Unable to disable rules for subscriber %s. ',
-                          request.imsi)
+            logging.error(
+                'Unable to disable rules for subscriber %s. ',
+                request.imsi,
+            )
             context.set_code(grpc.StatusCode.NOT_FOUND)
             context.set_details('Failed to update rule assignments in orc8r')
             return Void()
@@ -115,15 +123,19 @@ class PolicyRpcServicer(PolicyDBServicer):
         rar = PolicyReAuthRequest(
             # Leave session id empty, re-auth for all sessions
             imsi=request.imsi,
-            rules_to_remove=self._get_rules(request.rule_ids,
-                                            request.base_names)
+            rules_to_remove=self._get_rules(
+                request.rule_ids,
+                request.base_names,
+            ),
         )
 
         success = self._reauth_handler.handle_policy_re_auth(rar)
         if not success:
             context.set_code(grpc.StatusCode.UNKNOWN)
-            context.set_details('Failed to enable all static rules for '
-                                'subscriber. Partial update may have succeeded')
+            context.set_details(
+                'Failed to enable all static rules for '
+                'subscriber. Partial update may have succeeded',
+            )
         return Void()
 
     def _get_rules(

--- a/lte/gateway/python/magma/policydb/servicers/session_servicer.py
+++ b/lte/gateway/python/magma/policydb/servicers/session_servicer.py
@@ -153,7 +153,8 @@ class SessionRpcServicer(CentralSessionControllerServicer):
         """
         return [
             DynamicRuleInstall(
-                policy_rule=get_allow_all_policy_rule(subscriber_id, apn)),
+                policy_rule=get_allow_all_policy_rule(subscriber_id, apn),
+            ),
         ]
 
     def _get_session_static_rules(
@@ -169,12 +170,16 @@ class SessionRpcServicer(CentralSessionControllerServicer):
             return []
 
         sub_apn_policies = self._apn_rules_by_sid[imsi]
-        assigned_static_rules = [] # type: List[StaticRuleInstall]
+        assigned_static_rules = []  # type: List[StaticRuleInstall]
         # Add global rules
         global_rules = self._get_global_static_rules(sub_apn_policies)
         assigned_static_rules += \
-            list(map(lambda id: StaticRuleInstall(rule_id=id),
-                     global_rules))
+            list(
+                map(
+                    lambda id: StaticRuleInstall(rule_id=id),
+                    global_rules,
+                ),
+            )
         # Add APN specific rules
         for apn_policy_set in sub_apn_policies.rules_per_apn:
             if apn_policy_set.apn != apn:
@@ -182,8 +187,12 @@ class SessionRpcServicer(CentralSessionControllerServicer):
             # Only add rules if the APN matches
             static_rule_ids = self._get_static_rules(apn_policy_set)
             assigned_static_rules +=\
-                list(map(lambda id: StaticRuleInstall(rule_id=id),
-                         static_rule_ids))
+                list(
+                    map(
+                        lambda id: StaticRuleInstall(rule_id=id),
+                        static_rule_ids,
+                    ),
+                )
 
         return assigned_static_rules
 
@@ -197,7 +206,8 @@ class SessionRpcServicer(CentralSessionControllerServicer):
                 # Eventually, basename definition will be streamed from orc8r
                 continue
             global_rules.update(
-                self._rules_by_basename[basename].RuleNames)
+                self._rules_by_basename[basename].RuleNames,
+            )
         return global_rules
 
     def _get_static_rules(
@@ -210,7 +220,8 @@ class SessionRpcServicer(CentralSessionControllerServicer):
                 # Eventually, basename definition will be streamed from orc8r
                 continue
             desired_rules.update(
-                self._rules_by_basename[basename].RuleNames)
+                self._rules_by_basename[basename].RuleNames,
+            )
         return desired_rules
 
     def _get_credits(self, sid: str) -> List[CreditUpdateResponse]:
@@ -218,17 +229,21 @@ class SessionRpcServicer(CentralSessionControllerServicer):
         postpay_keys = self._get_postpay_charging_keys()
         credit_updates = []
         for charging_key in infinite_credit_keys:
-            credit_updates.append(CreditUpdateResponse(
-                success=True,
-                sid=sid,
-                charging_key=charging_key,
-                limit_type=CreditLimitType.Value("INFINITE_UNMETERED")
-            ))
+            credit_updates.append(
+                CreditUpdateResponse(
+                    success=True,
+                    sid=sid,
+                    charging_key=charging_key,
+                    limit_type=CreditLimitType.Value("INFINITE_UNMETERED"),
+                ),
+            )
         for charging_key in postpay_keys:
-            credit_updates.append(CreditUpdateResponse(
-                success=True,
-                sid=sid,
-                charging_key=charging_key,
-                limit_type=CreditLimitType.Value("INFINITE_METERED")
-            ))
+            credit_updates.append(
+                CreditUpdateResponse(
+                    success=True,
+                    sid=sid,
+                    charging_key=charging_key,
+                    limit_type=CreditLimitType.Value("INFINITE_METERED"),
+                ),
+            )
         return credit_updates

--- a/lte/gateway/python/magma/policydb/tests/mock_stubs.py
+++ b/lte/gateway/python/magma/policydb/tests/mock_stubs.py
@@ -24,6 +24,7 @@ class MockLocalSessionManagerStub:
     """
     This Mock LocalSessionManagerStub will always respond with a Void
     """
+
     def __init__(self):
         pass
 
@@ -36,12 +37,13 @@ class MockSessionProxyResponderStub1:
     This Mock SessionProxyResponderStub will always respond with a success to
     a received RAR
     """
+
     def __init__(self):
         pass
 
     def PolicyReAuth(self, _: PolicyReAuthRequest) -> PolicyReAuthAnswer:
         return PolicyReAuthAnswer(
-            result=ReAuthResult.Value('UPDATE_INITIATED')
+            result=ReAuthResult.Value('UPDATE_INITIATED'),
         )
 
 
@@ -50,12 +52,13 @@ class MockSessionProxyResponderStub2:
     This Mock SessionProxyResponderStub will always respond with a failure to
     a received RAR
     """
+
     def __init__(self):
         pass
 
     def PolicyReAuth(self, _: PolicyReAuthRequest) -> PolicyReAuthAnswer:
         return PolicyReAuthAnswer(
-            result=ReAuthResult.Value('OTHER_FAILURE')
+            result=ReAuthResult.Value('OTHER_FAILURE'),
         )
 
 
@@ -63,6 +66,7 @@ class MockSessionProxyResponderStub3:
     """
     This Mock SessionProxyResponderStub will always fail to install rule p2
     """
+
     def __init__(self):
         pass
 

--- a/lte/gateway/python/magma/policydb/tests/test_policy_servicer.py
+++ b/lte/gateway/python/magma/policydb/tests/test_policy_servicer.py
@@ -37,17 +37,19 @@ class MockSessionProxyResponderStub:
     This Mock SessionProxyResponderStub will always respond with a success to
     a received RAR
     """
+
     def __init__(self):
         pass
 
     def PolicyReAuth(self, _: PolicyReAuthRequest) -> PolicyReAuthAnswer:
         return PolicyReAuthAnswer(
-            result=ReAuthResult.Value('UPDATE_INITIATED')
+            result=ReAuthResult.Value('UPDATE_INITIATED'),
         )
 
 
 class MockPolicyAssignmentControllerStub:
     """ Always succeeds by not raising an error """
+
     def __init__(self):
         pass
 
@@ -60,6 +62,7 @@ class MockPolicyAssignmentControllerStub:
 
 class MockPolicyAssignmentControllerStub2:
     """ Always fails """
+
     def __init__(self):
         pass
 
@@ -81,12 +84,16 @@ class PolicyRpcServicerTest(unittest.TestCase):
                 RuleNames=["p4", "p5"],
             ),
         }
-        reauth_handler = ReAuthHandler(rules_by_sid,
-                                       MockSessionProxyResponderStub())
+        reauth_handler = ReAuthHandler(
+            rules_by_sid,
+            MockSessionProxyResponderStub(),
+        )
 
-        servicer = PolicyRpcServicer(reauth_handler,
-                                           rules_by_basename,
-                                           MockPolicyAssignmentControllerStub())
+        servicer = PolicyRpcServicer(
+            reauth_handler,
+            rules_by_basename,
+            MockPolicyAssignmentControllerStub(),
+        )
 
         # Bind the rpc server to a free port
         thread_pool = futures.ThreadPoolExecutor(max_workers=10)
@@ -113,9 +120,11 @@ class PolicyRpcServicerTest(unittest.TestCase):
             base_names=["bn1"],
         )
         stub.EnableStaticRules(req)
-        self.assertEqual(len(rules_by_sid["s1"].installed_policies), 5,
-                         'After a successful update, Redis should be tracking '
-                         '5 active rules.')
+        self.assertEqual(
+            len(rules_by_sid["s1"].installed_policies), 5,
+            'After a successful update, Redis should be tracking '
+            '5 active rules.',
+        )
 
     def test_FailOrc8r(self):
         """ Check that nothing is updated if orc8r is unreachable """
@@ -125,8 +134,10 @@ class PolicyRpcServicerTest(unittest.TestCase):
                 RuleNames=["p4", "p5"],
             ),
         }
-        reauth_handler = ReAuthHandler(rules_by_sid,
-                                       MockSessionProxyResponderStub())
+        reauth_handler = ReAuthHandler(
+            rules_by_sid,
+            MockSessionProxyResponderStub(),
+        )
 
         servicer = PolicyRpcServicer(
             reauth_handler,
@@ -158,5 +169,7 @@ class PolicyRpcServicerTest(unittest.TestCase):
         with self.assertRaises(grpc.RpcError):
             stub.EnableStaticRules(req)
 
-        self.assertFalse("s1" in rules_by_sid,
-                         "There should be no installed policies for s1")
+        self.assertFalse(
+            "s1" in rules_by_sid,
+            "There should be no installed policies for s1",
+        )

--- a/lte/gateway/python/magma/policydb/tests/test_reauth_handler.py
+++ b/lte/gateway/python/magma/policydb/tests/test_reauth_handler.py
@@ -27,12 +27,13 @@ class MockSessionProxyResponderStub:
     This Mock SessionProxyResponderStub will always respond with a success to
     a received RAR
     """
+
     def __init__(self):
         pass
 
     def PolicyReAuth(self, _: PolicyReAuthRequest) -> PolicyReAuthAnswer:
         return PolicyReAuthAnswer(
-            result=ReAuthResult.Value('UPDATE_INITIATED')
+            result=ReAuthResult.Value('UPDATE_INITIATED'),
         )
 
 
@@ -57,10 +58,14 @@ class RuleMappingsStreamerCallbackTest(unittest.TestCase):
         handler.handle_policy_re_auth(rar)
         s1_policies = install_dict['s1'].installed_policies
         expected = 2
-        self.assertEqual(len(s1_policies), expected,
-                         'There should be 2 installed policies for s1')
-        self.assertTrue('p1' in s1_policies,
-                        'Policy p1 should be marked installed for p1')
+        self.assertEqual(
+            len(s1_policies), expected,
+            'There should be 2 installed policies for s1',
+        )
+        self.assertTrue(
+            'p1' in s1_policies,
+            'Policy p1 should be marked installed for p1',
+        )
 
         rar = PolicyReAuthRequest(
             imsi='s1',
@@ -69,7 +74,11 @@ class RuleMappingsStreamerCallbackTest(unittest.TestCase):
         handler.handle_policy_re_auth(rar)
         s1_policies = install_dict['s1'].installed_policies
         expected = 3
-        self.assertEqual(len(s1_policies), expected,
-                         'There should be 3 installed policies for s1')
-        self.assertTrue('p3' in s1_policies,
-                        'Policy p1 should be marked installed for p1')
+        self.assertEqual(
+            len(s1_policies), expected,
+            'There should be 3 installed policies for s1',
+        )
+        self.assertTrue(
+            'p3' in s1_policies,
+            'Policy p1 should be marked installed for p1',
+        )

--- a/lte/gateway/python/magma/policydb/tests/test_session_servicer.py
+++ b/lte/gateway/python/magma/policydb/tests/test_session_servicer.py
@@ -114,10 +114,12 @@ class SessionRpcServicerTest(unittest.TestCase):
                 ],
             ),
         }
-        self.servicer = SessionRpcServicer(self._get_mconfig(),
-                                           rating_groups_by_id,
-                                           basenames_dict,
-                                           apn_rules_by_sid)
+        self.servicer = SessionRpcServicer(
+            self._get_mconfig(),
+            rating_groups_by_id,
+            basenames_dict,
+            apn_rules_by_sid,
+        )
 
     def _get_mconfig(self) -> mconfigs_pb2.PolicyDB:
         return mconfigs_pb2.PolicyDB(
@@ -147,9 +149,9 @@ class SessionRpcServicerTest(unittest.TestCase):
                 ),
                 apn='apn1',
             ),
-            rat_specific_context = RatSpecificContext(
-                lte_context = LTESessionContext(
-                    imsi_plmn_id = '00101',
+            rat_specific_context=RatSpecificContext(
+                lte_context=LTESessionContext(
+                    imsi_plmn_id='00101',
                 ),
             ),
         )
@@ -158,14 +160,18 @@ class SessionRpcServicerTest(unittest.TestCase):
         # There should be a static rule installed for the redirection
         static_rules = self._rm_whitespace(str(resp.static_rules))
         expected = self._rm_whitespace(CSR_STATIC_RULES)
-        self.assertEqual(static_rules, expected, 'There should be one static '
-                         'rule installed for redirection.')
+        self.assertEqual(
+            static_rules, expected, 'There should be one static '
+            'rule installed for redirection.',
+        )
 
         # Credit granted should be unlimited and un-metered
         credit_limit_type = resp.credits[0].limit_type
         expected = CreditLimitType.Value("INFINITE_UNMETERED")
-        self.assertEqual(credit_limit_type, expected, 'There should be an '
-                         'infinite, unmetered credit grant')
+        self.assertEqual(
+            credit_limit_type, expected, 'There should be an '
+            'infinite, unmetered credit grant',
+        )
 
         msg_2 = CreateSessionRequest(
             session_id='2345',
@@ -175,9 +181,9 @@ class SessionRpcServicerTest(unittest.TestCase):
                 ),
                 apn='apn2',
             ),
-            rat_specific_context = RatSpecificContext(
-                lte_context = LTESessionContext(
-                    imsi_plmn_id = '00101',
+            rat_specific_context=RatSpecificContext(
+                lte_context=LTESessionContext(
+                    imsi_plmn_id='00101',
                 ),
             ),
         )
@@ -186,14 +192,18 @@ class SessionRpcServicerTest(unittest.TestCase):
         # There should be a static rule installed
         static_rules = self._rm_whitespace(str(resp.static_rules))
         expected = self._rm_whitespace(CSR_STATIC_RULES_2)
-        self.assertEqual(static_rules, expected, 'There should be one static '
-                                                 'rule installed.')
+        self.assertEqual(
+            static_rules, expected, 'There should be one static '
+            'rule installed.',
+        )
 
         # Credit granted should be unlimited and un-metered
         credit_limit_type = resp.credits[0].limit_type
         expected = CreditLimitType.Value("INFINITE_UNMETERED")
-        self.assertEqual(credit_limit_type, expected,
-                         'There should be an infinite, unmetered credit grant')
+        self.assertEqual(
+            credit_limit_type, expected,
+            'There should be an infinite, unmetered credit grant',
+        )
 
         msg_3 = CreateSessionRequest(
             session_id='3456',
@@ -203,9 +213,9 @@ class SessionRpcServicerTest(unittest.TestCase):
                 ),
                 apn='apn1',
             ),
-            rat_specific_context = RatSpecificContext(
-                lte_context = LTESessionContext(
-                    imsi_plmn_id = '00101',
+            rat_specific_context=RatSpecificContext(
+                lte_context=LTESessionContext(
+                    imsi_plmn_id='00101',
                 ),
             ),
         )
@@ -214,14 +224,18 @@ class SessionRpcServicerTest(unittest.TestCase):
         # There should be a static rule installed
         static_rules = self._rm_whitespace(str(resp.static_rules))
         expected = self._rm_whitespace(CSR_STATIC_RULES_3)
-        self.assertEqual(static_rules, expected, 'There should be one static '
-                                                 'rule installed.')
+        self.assertEqual(
+            static_rules, expected, 'There should be one static '
+            'rule installed.',
+        )
 
         # Credit granted should be unlimited and un-metered
         credit_limit_type = resp.credits[0].limit_type
         expected = CreditLimitType.Value("INFINITE_UNMETERED")
-        self.assertEqual(credit_limit_type, expected,
-                         'There should be an infinite, unmetered credit grant')
+        self.assertEqual(
+            credit_limit_type, expected,
+            'There should be an infinite, unmetered credit grant',
+        )
 
     def test_UpdateSession(self):
         """
@@ -237,9 +251,11 @@ class SessionRpcServicerTest(unittest.TestCase):
         resp = self.servicer.UpdateSession(msg, None)
         session_response = self._rm_whitespace(str(resp))
         expected = self._rm_whitespace(USR)
-        self.assertEqual(session_response, expected, 'There should be an '
-                         'infinite, unmetered credit grant and an infinite, '
-                         'metered credit grant')
+        self.assertEqual(
+            session_response, expected, 'There should be an '
+            'infinite, unmetered credit grant and an infinite, '
+            'metered credit grant',
+        )
 
     def test_TerminateSession(self):
         """
@@ -253,8 +269,10 @@ class SessionRpcServicerTest(unittest.TestCase):
         msg.session_id = 'session_id_123'
         resp = self.servicer.TerminateSession(msg, None)
         self.assertEqual(resp.sid, 'abc', 'SID should be same as request')
-        self.assertEqual(resp.session_id, 'session_id_123', 'session ID should '
-                         'be same as request')
+        self.assertEqual(
+            resp.session_id, 'session_id_123', 'session ID should '
+            'be same as request',
+        )
 
     def _rm_whitespace(self, inp: str) -> str:
         return inp.replace(' ', '').replace('\n', '')

--- a/lte/gateway/python/magma/policydb/tests/test_streamer_callback.py
+++ b/lte/gateway/python/magma/policydb/tests/test_streamer_callback.py
@@ -57,20 +57,24 @@ class ApnRuleMappingsStreamerCallbackTest(unittest.TestCase):
             FlowDescription(
                 match=FlowMatch(
                     direction=FlowMatch.Direction.Value(
-                        "UPLINK"),
+                        "UPLINK",
+                    ),
                 ),
                 action=FlowDescription.Action.Value(
-                    "PERMIT"),
+                    "PERMIT",
+                ),
             ),
             FlowDescription(
                 match=FlowMatch(
                     direction=FlowMatch.Direction.Value(
-                        "DOWNLINK"),
+                        "DOWNLINK",
+                    ),
                 ),
                 action=FlowDescription.Action.Value(
-                    "PERMIT"),
+                    "PERMIT",
+                ),
             ),
-        ] # type: List[FlowDescription]
+        ]  # type: List[FlowDescription]
         no_tracking_type = PolicyRule.TrackingType.Value("NO_TRACKING")
         expected = SessionRules(
             rules_per_subscriber=[
@@ -90,11 +94,11 @@ class ApnRuleMappingsStreamerCallbackTest(unittest.TestCase):
                                         priority=2,
                                         flow_list=allow_all_flow_list,
                                         tracking_type=no_tracking_type,
-                                    )
-                                )
+                                    ),
+                                ),
                             ],
                         ),
-                    ]
+                    ],
                 ),
                 RulesPerSubscriber(
                     imsi='imsi_2',
@@ -112,13 +116,13 @@ class ApnRuleMappingsStreamerCallbackTest(unittest.TestCase):
                                         priority=2,
                                         flow_list=allow_all_flow_list,
                                         tracking_type=no_tracking_type,
-                                    )
-                                )
+                                    ),
+                                ),
                             ],
                         ),
-                    ]
-                )
-            ]
+                    ],
+                ),
+            ],
         )
 
         # Setup the test
@@ -129,10 +133,9 @@ class ApnRuleMappingsStreamerCallbackTest(unittest.TestCase):
         }
         stub = MockLocalSessionManagerStub()
 
-        stub_call_args = [] # type: List[SessionRules]
+        stub_call_args = []  # type: List[SessionRules]
         side_effect = get_SetSessionRules_side_effect(stub_call_args)
         stub.SetSessionRules = Mock(side_effect=side_effect)
-
 
         callback = ApnRuleMappingsStreamerCallback(
             stub,
@@ -173,13 +176,19 @@ class ApnRuleMappingsStreamerCallbackTest(unittest.TestCase):
         # Since we used a stub which always succeeds when a RAR is made,
         # We should expect the assignments_dict to be updated
         imsi_1_policies = apn_rules_dict["imsi_1"]
-        self.assertEqual(len(imsi_1_policies.rules_per_apn), 1,
-                         'There should be 1 active APNs for imsi_1')
-        self.assertEqual(len(stub_call_args), 1,
-                         'Stub should have been called once')
+        self.assertEqual(
+            len(imsi_1_policies.rules_per_apn), 1,
+            'There should be 1 active APNs for imsi_1',
+        )
+        self.assertEqual(
+            len(stub_call_args), 1,
+            'Stub should have been called once',
+        )
         called_with = stub_call_args[0].SerializeToString()
-        self.assertEqual(called_with, expected.SerializeToString(),
-                         'SetSessionRules call has incorrect arguments')
+        self.assertEqual(
+            called_with, expected.SerializeToString(),
+            'SetSessionRules call has incorrect arguments',
+        )
 
         # Stream down a second update, and now IMSI_1 gets access to a new APN
         updates_2 = [
@@ -228,11 +237,11 @@ class ApnRuleMappingsStreamerCallbackTest(unittest.TestCase):
                                         priority=2,
                                         flow_list=allow_all_flow_list,
                                         tracking_type=no_tracking_type,
-                                    )
-                                )
+                                    ),
+                                ),
                             ],
                         ),
-                    ]
+                    ],
                 ),
                 RulesPerSubscriber(
                     imsi='imsi_2',
@@ -250,22 +259,28 @@ class ApnRuleMappingsStreamerCallbackTest(unittest.TestCase):
                                         priority=2,
                                         flow_list=allow_all_flow_list,
                                         tracking_type=no_tracking_type,
-                                    )
-                                )
+                                    ),
+                                ),
                             ],
                         ),
-                    ]
+                    ],
                 ),
-            ]
+            ],
         )
 
         callback.process_update("stream", updates_2, False)
 
         imsi_1_policies = apn_rules_dict["imsi_1"]
-        self.assertEqual(len(imsi_1_policies.rules_per_apn), 1,
-                         'There should be 1 active APNs for imsi_1')
-        self.assertEqual(len(stub_call_args), 2,
-                         'Stub should have been called twice')
+        self.assertEqual(
+            len(imsi_1_policies.rules_per_apn), 1,
+            'There should be 1 active APNs for imsi_1',
+        )
+        self.assertEqual(
+            len(stub_call_args), 2,
+            'Stub should have been called twice',
+        )
         called_with = stub_call_args[1].SerializeToString()
-        self.assertEqual(called_with, expected_2.SerializeToString(),
-                         'SetSessionRules call has incorrect arguments')
+        self.assertEqual(
+            called_with, expected_2.SerializeToString(),
+            'SetSessionRules call has incorrect arguments',
+        )

--- a/lte/gateway/python/magma/redirectd/redirect_store.py
+++ b/lte/gateway/python/magma/redirectd/redirect_store.py
@@ -34,7 +34,8 @@ class RedirectDict(RedisHashDict):
             client,
             self._DICT_HASH,
             get_proto_serializer(),
-            get_proto_deserializer(RedirectInformation))
+            get_proto_deserializer(RedirectInformation),
+        )
 
     def __missing__(self, key):
         """Instead of throwing a key error, return None when key not found"""

--- a/lte/gateway/python/magma/subscriberdb/crypto/lte.py
+++ b/lte/gateway/python/magma/subscriberdb/crypto/lte.py
@@ -35,7 +35,7 @@ class BaseLTEAuthAlgo(metaclass=abc.ABCMeta):
         Generate the E-EUTRAN key vector.
         Args:
             key (bytes): 128 bit subscriber key
-            opc (bytes): 128 bit operator variant algorithm configuration field            
+            opc (bytes): 128 bit operator variant algorithm configuration field
             sqn (int): 48 bit sequence number
             rand (bytes): 128 bit random challenge
             plmn (bytes): 24 bit network identifer

--- a/lte/gateway/python/magma/subscriberdb/crypto/milenage.py
+++ b/lte/gateway/python/magma/subscriberdb/crypto/milenage.py
@@ -345,5 +345,10 @@ def rotate(input_s, bytes_):
     Returns:
         (bytes) s1 rotated by n bytes
     """
-    return bytes(input_s[(i + bytes_) % len(input_s)] for i in range(len(
-        input_s)))
+    return bytes(
+        input_s[(i + bytes_) % len(input_s)] for i in range(
+            len(
+            input_s,
+            ),
+        )
+    )

--- a/lte/gateway/python/magma/subscriberdb/processor.py
+++ b/lte/gateway/python/magma/subscriberdb/processor.py
@@ -108,8 +108,10 @@ class Processor(GSMProcessor, LTEProcessor):
     subscriber stores.
     """
 
-    def __init__(self, store, default_sub_profile,
-                 sub_profiles, op=None, amf=None):
+    def __init__(
+        self, store, default_sub_profile,
+        sub_profiles, op=None, amf=None,
+    ):
         """
         Init the Processor with all the components.
 
@@ -125,8 +127,10 @@ class Processor(GSMProcessor, LTEProcessor):
         if len(op) != 16:
             raise ValueError("OP is invalid len=%d value=%s" % (len(op), op))
         if len(amf) != 2:
-            raise ValueError("AMF has invalid length len=%d value=%s" %
-                             (len(amf), amf))
+            raise ValueError(
+                "AMF has invalid length len=%d value=%s" %
+                (len(amf), amf),
+            )
 
     def get_sub_profile(self, imsi):
         """
@@ -142,8 +146,10 @@ class Processor(GSMProcessor, LTEProcessor):
         """
         sid = SIDUtils.to_str(SubscriberID(id=imsi, type=SubscriberID.IMSI))
         subs = self._store.get_subscriber_data(sid)
-        return self._sub_profiles.get(subs.sub_profile,
-                                      self._default_sub_profile)
+        return self._sub_profiles.get(
+            subs.sub_profile,
+            self._default_sub_profile,
+        )
 
     def get_gsm_auth_vector(self, imsi):
         """
@@ -158,8 +164,10 @@ class Processor(GSMProcessor, LTEProcessor):
 
         # The only GSM crypto algo we support now
         if subs.gsm.auth_algo != GSMSubscription.PRECOMPUTED_AUTH_TUPLES:
-            raise CryptoError("Unknown crypto (%s) for %s" %
-                              (subs.gsm.auth_algo, sid))
+            raise CryptoError(
+                "Unknown crypto (%s) for %s" %
+                (subs.gsm.auth_algo, sid),
+            )
         gsm_crypto = UnsafePreComputedA3A8()
 
         if len(subs.gsm.auth_tuples) == 0:
@@ -179,8 +187,10 @@ class Processor(GSMProcessor, LTEProcessor):
             raise CryptoError("LTE service not active for %s" % sid)
 
         if subs.lte.auth_algo != LTESubscription.MILENAGE:
-            raise CryptoError("Unknown crypto (%s) for %s" %
-                              (subs.lte.auth_algo, sid))
+            raise CryptoError(
+                "Unknown crypto (%s) for %s" %
+                (subs.lte.auth_algo, sid),
+            )
 
         if len(subs.lte.auth_key) != 16:
             raise CryptoError("Subscriber key not valid for %s" % sid)
@@ -194,8 +204,10 @@ class Processor(GSMProcessor, LTEProcessor):
 
         sqn = self.seq_to_sqn(self.get_next_lte_auth_seq(imsi))
         milenage = Milenage(self._amf)
-        return milenage.generate_eutran_vector(subs.lte.auth_key,
-                                               opc, sqn, plmn)
+        return milenage.generate_eutran_vector(
+            subs.lte.auth_key,
+            opc, sqn, plmn,
+        )
 
     def resync_lte_auth_seq(self, imsi, rand, auts):
         """
@@ -209,8 +221,10 @@ class Processor(GSMProcessor, LTEProcessor):
             raise CryptoError("LTE service not active for %s" % sid)
 
         if subs.lte.auth_algo != LTESubscription.MILENAGE:
-            raise CryptoError("Unknown crypto (%s) for %s" %
-                              (subs.lte.auth_algo, sid))
+            raise CryptoError(
+                "Unknown crypto (%s) for %s" %
+                (subs.lte.auth_algo, sid),
+            )
 
         if len(subs.lte.auth_key) != 16:
             raise CryptoError("Subscriber key not valid for %s" % sid)
@@ -243,8 +257,10 @@ class Processor(GSMProcessor, LTEProcessor):
                 self.set_next_lte_auth_seq(imsi, seq_ms + 1)
             else:
                 # This shouldn't have happened
-                raise CryptoError("Re-sync delta in range but UE rejected "
-                                  "auth: %d" % seq_delta)
+                raise CryptoError(
+                    "Re-sync delta in range but UE rejected "
+                    "auth: %d" % seq_delta,
+                )
 
     def get_next_lte_auth_seq(self, imsi):
         """

--- a/lte/gateway/python/magma/subscriberdb/protocols/diameter/application/base.py
+++ b/lte/gateway/python/magma/subscriberdb/protocols/diameter/application/base.py
@@ -31,6 +31,7 @@ class BaseApplicationCommands(IntEnum):
     DEVICE_WATCHDOG = 280
     DISCONNECT_PEER = 282
 
+
 class BaseApplication(abc.Application):
     """
     This is where we implement the Diameter Base Protocol Application which
@@ -51,11 +52,13 @@ class BaseApplication(abc.Application):
     # Required fields for requests of each command type
     REQUIRED_FIELDS = {
         BaseApplicationCommands.CAPABILITIES_EXCHANGE:
-            ['Host-IP-Address',
-            'Inband-Security-Id',
-            'Vendor-Id',
-            'Supported-Vendor-Id',
-            'Vendor-Specific-Application-Id'],
+            [
+                'Host-IP-Address',
+                'Inband-Security-Id',
+                'Vendor-Id',
+                'Supported-Vendor-Id',
+                'Vendor-Specific-Application-Id',
+            ],
         BaseApplicationCommands.DEVICE_WATCHDOG:
             [],
         BaseApplicationCommands.DISCONNECT_PEER:
@@ -87,10 +90,14 @@ class BaseApplication(abc.Application):
         # Validate we have all required fields
         required_fields = self.REQUIRED_FIELDS[msg.header.command_code]
         if not msg.has_fields(required_fields):
-            logging.error("Missing AVP for diameter command %d",
-                          msg.header.command_code)
-            resp = self._gen_response(state_id, msg,
-                                 avp.ResultCode.DIAMETER_MISSING_AVP)
+            logging.error(
+                "Missing AVP for diameter command %d",
+                msg.header.command_code,
+            )
+            resp = self._gen_response(
+                state_id, msg,
+                avp.ResultCode.DIAMETER_MISSING_AVP,
+            )
             self.writer.send_msg(resp)
             return False
         return True
@@ -181,9 +188,11 @@ class BaseApplication(abc.Application):
                 body_avps.extend(application.CAPABILITIES_EXCHANGE_AVPS)
             body_avps.append(avp.AVP('Product-Name', avp.PRODUCT_NAME))
             DIAMETER_CEX_TOTAL.inc()
-            resp = self._gen_response(state_id, msg,
-                                      avp.ResultCode.DIAMETER_SUCCESS,
-                                      body_avps)
+            resp = self._gen_response(
+                state_id, msg,
+                avp.ResultCode.DIAMETER_SUCCESS,
+                body_avps,
+            )
             self.writer.send_msg(resp)
 
     def _send_device_watchdog(self, state_id, msg):
@@ -198,7 +207,9 @@ class BaseApplication(abc.Application):
             None
         """
         if self.validate_message(state_id, msg):
-            resp = self._gen_response(state_id, msg, avp.ResultCode.DIAMETER_SUCCESS)
+            resp = self._gen_response(
+                state_id, msg, avp.ResultCode.DIAMETER_SUCCESS,
+            )
             DIAMETER_WATCHDOG_TOTAL.inc()
             self.writer.send_msg(resp)
 
@@ -215,6 +226,8 @@ class BaseApplication(abc.Application):
         """
         logging.info('Received disconnect request, state id: %d', state_id)
         if self.validate_message(state_id, msg):
-            resp = self._gen_response(state_id, msg, avp.ResultCode.DIAMETER_SUCCESS)
+            resp = self._gen_response(
+                state_id, msg, avp.ResultCode.DIAMETER_SUCCESS,
+            )
             DIAMETER_DISCONECT_TOTAL.inc()
             self.writer.send_msg(resp)

--- a/lte/gateway/python/magma/subscriberdb/protocols/diameter/application/s6a_relay.py
+++ b/lte/gateway/python/magma/subscriberdb/protocols/diameter/application/s6a_relay.py
@@ -39,14 +39,19 @@ class S6ARelayApplication(S6AApplication):
     """
     grpc_timeout = 60
 
-    def __init__(self, lte_processor, realm, host, host_ip,
-                 loop=None, proxy_client=None, retry_count=0):
+    def __init__(
+        self, lte_processor, realm, host, host_ip,
+        loop=None, proxy_client=None, retry_count=0,
+    ):
         super(S6ARelayApplication, self).__init__(
-            lte_processor, realm, host, host_ip, loop)
+            lte_processor, realm, host, host_ip, loop,
+        )
         self.retry_count = retry_count
         if proxy_client is None:
-            chan = ServiceRegistry.get_rpc_channel('s6a_proxy',
-                                                   ServiceRegistry.CLOUD)
+            chan = ServiceRegistry.get_rpc_channel(
+                's6a_proxy',
+                ServiceRegistry.CLOUD,
+            )
             self._client = S6aProxyStub(chan)
         else:
             self._client = proxy_client
@@ -71,34 +76,39 @@ class S6ARelayApplication(S6AApplication):
         user_name = msg.find_avp(*avp.resolve('User-Name')).value
         visited_plmn = msg.find_avp(*avp.resolve('Visited-PLMN-Id')).value
         request_eutran_info = msg.find_avp(
-            *avp.resolve('Requested-EUTRAN-Authentication-Info'))
+            *avp.resolve('Requested-EUTRAN-Authentication-Info'),
+        )
 
         num_requested_eutran_vectors = request_eutran_info.find_avp(
-            *avp.resolve('Number-Of-Requested-Vectors')).value
+            *avp.resolve('Number-Of-Requested-Vectors'),
+        ).value
         immediate_response_preferred = request_eutran_info.find_avp(
-            *avp.resolve('Immediate-Response-Preferred')).value
+            *avp.resolve('Immediate-Response-Preferred'),
+        ).value
         resync_info = request_eutran_info.find_avp(
-            *avp.resolve('Re-Synchronization-Info'))
+            *avp.resolve('Re-Synchronization-Info'),
+        )
 
         request = AuthenticationInformationRequest(
             user_name=user_name,
             visited_plmn=visited_plmn,
             num_requested_eutran_vectors=num_requested_eutran_vectors,
             immediate_response_preferred=immediate_response_preferred,
-            resync_info=resync_info.value if resync_info else None
+            resync_info=resync_info.value if resync_info else None,
         )
         future = self._client.AuthenticationInformation.future(
             request,
             self.grpc_timeout,
         )
-        future.add_done_callback(lambda answer:
+        future.add_done_callback(
+            lambda answer:
             self._loop.call_soon_threadsafe(
                 self._relay_auth_answer,
                 state_id,
                 msg,
                 answer,
                 retries_left,
-            )
+            ),
         )
 
     def _relay_auth_answer(self, state_id, msg, answer_future, retries_left):
@@ -106,8 +116,10 @@ class S6ARelayApplication(S6AApplication):
         err = answer_future.exception()
         if err and retries_left > 0:
             # TODO: retry only on network failure and not application failures
-            logging.info("Auth %s Error! [%s] %s, retrying...",
-                         user_name, err.code(), err.details())
+            logging.info(
+                "Auth %s Error! [%s] %s, retrying...",
+                user_name, err.code(), err.details(),
+            )
             self._send_auth_with_retries(
                 state_id,
                 msg,
@@ -115,36 +127,55 @@ class S6ARelayApplication(S6AApplication):
             )
             return
         elif err:
-            logging.warning("Auth %s Error! [%s] %s",
-                            user_name, err.code(), err.details())
+            logging.warning(
+                "Auth %s Error! [%s] %s",
+                user_name, err.code(), err.details(),
+            )
             resp = self._gen_response(
-                state_id, msg, avp.ResultCode.DIAMETER_UNABLE_TO_COMPLY)
+                state_id, msg, avp.ResultCode.DIAMETER_UNABLE_TO_COMPLY,
+            )
             S6A_AUTH_FAILURE_TOTAL.labels(
-                code=avp.ResultCode.DIAMETER_UNABLE_TO_COMPLY).inc()
+                code=avp.ResultCode.DIAMETER_UNABLE_TO_COMPLY,
+            ).inc()
         else:
             answer = answer_future.result()
             error_code = answer.error_code
             if answer.error_code:
-                result_info = avp.AVP('Experimental-Result', [
+                result_info = avp.AVP(
+                    'Experimental-Result', [
                     avp.AVP('Vendor-Id', 10415),
-                    avp.AVP('Experimental-Result-Code', error_code)])
+                    avp.AVP('Experimental-Result-Code', error_code),
+                    ],
+                )
                 resp = self._gen_response(
-                    state_id, msg, error_code, [result_info])
-                logging.warning("Auth S6a %s Error! [%s]",
-                                user_name, error_code)
+                    state_id, msg, error_code, [result_info],
+                )
+                logging.warning(
+                    "Auth S6a %s Error! [%s]",
+                    user_name, error_code,
+                )
                 S6A_AUTH_FAILURE_TOTAL.labels(
-                    code=error_code).inc()
+                    code=error_code,
+                ).inc()
             else:
-                auth_info = avp.AVP('Authentication-Info', [
-                    avp.AVP('E-UTRAN-Vector', [
+                auth_info = avp.AVP(
+                    'Authentication-Info', [
+                    avp.AVP(
+                        'E-UTRAN-Vector', [
                         avp.AVP('RAND', vector.rand),
                         avp.AVP('XRES', vector.xres),
                         avp.AVP('AUTN', vector.autn),
-                        avp.AVP('KASME', vector.kasme)]) for vector in answer.eutran_vectors ])
+                        avp.AVP('KASME', vector.kasme),
+                        ],
+                    ) for vector in answer.eutran_vectors
+                    ],
+                )
 
-                resp = self._gen_response(state_id, msg,
-                                          avp.ResultCode.DIAMETER_SUCCESS,
-                                          [auth_info])
+                resp = self._gen_response(
+                    state_id, msg,
+                    avp.ResultCode.DIAMETER_SUCCESS,
+                    [auth_info],
+                )
                 S6A_AUTH_SUCCESS_TOTAL.inc()
         self.writer.send_msg(resp)
 
@@ -162,7 +193,9 @@ class S6ARelayApplication(S6AApplication):
         # Validate the message
         if not self.validate_message(state_id, msg):
             return
-        return self._send_location_request_with_retries(state_id, msg, self.retry_count)
+        return self._send_location_request_with_retries(
+            state_id, msg, self.retry_count,
+        )
 
     def _send_location_request_with_retries(self, state_id, msg, retries_left):
         user_name = msg.find_avp(*avp.resolve('User-Name')).value
@@ -176,23 +209,28 @@ class S6ARelayApplication(S6AApplication):
             initial_attach=ulr_flags & 1 << 5,
         )
         future = self._client.UpdateLocation.future(request, self.grpc_timeout)
-        future.add_done_callback(lambda answer:
+        future.add_done_callback(
+            lambda answer:
             self._loop.call_soon_threadsafe(
                 self._relay_update_location_answer,
                 state_id,
                 msg,
                 answer,
-                retries_left
-            )
+                retries_left,
+            ),
         )
 
-    def _relay_update_location_answer(self, state_id, msg, answer_future, retries_left):
+    def _relay_update_location_answer(
+            self, state_id, msg, answer_future, retries_left,
+    ):
         err = answer_future.exception()
         if err and retries_left > 0:
             # TODO: retry only on network failure and not application failures
             user_name = msg.find_avp(*avp.resolve('User-Name')).value
-            logging.info("Location Update %s Error! [%s] %s, retrying...",
-                         user_name, err.code(), err.details())
+            logging.info(
+                "Location Update %s Error! [%s] %s, retrying...",
+                user_name, err.code(), err.details(),
+            )
             self._send_location_request_with_retries(
                 state_id,
                 msg,
@@ -201,59 +239,114 @@ class S6ARelayApplication(S6AApplication):
             return
         elif err:
             user_name = msg.find_avp(*avp.resolve('User-Name')).value
-            logging.warning("Location Update %s Error! [%s] %s",
-                            user_name, err.code(), err.details())
+            logging.warning(
+                "Location Update %s Error! [%s] %s",
+                user_name, err.code(), err.details(),
+            )
             resp = self._gen_response(
-                state_id, msg, avp.ResultCode.DIAMETER_UNABLE_TO_COMPLY)
+                state_id, msg, avp.ResultCode.DIAMETER_UNABLE_TO_COMPLY,
+            )
         else:
             answer = answer_future.result()
             error_code = answer.error_code
             if error_code:
-                result_info = avp.AVP('Experimental-Result', [
-                                      avp.AVP('Vendor-Id', 10415),
-                                      avp.AVP('Experimental-Result-Code', error_code)])
+                result_info = avp.AVP(
+                    'Experimental-Result', [
+                    avp.AVP('Vendor-Id', 10415),
+                    avp.AVP('Experimental-Result-Code', error_code),
+                    ],
+                )
                 resp = self._gen_response(
-                    state_id, msg, error_code, [result_info])
+                    state_id, msg, error_code, [result_info],
+                )
             else:
 
                 # Stubbed out Subscription Data from OAI
-                subscription_data = avp.AVP('Subscription-Data', [
-                    avp.AVP('MSISDN', answer.msisdn),
-                    avp.AVP('Access-Restriction-Data', 47),
-                    avp.AVP('Subscriber-Status', 0),
-                    avp.AVP('Network-Access-Mode', 2),
-                    avp.AVP('AMBR', [
-                        avp.AVP('Max-Requested-Bandwidth-UL', answer.total_ambr.max_bandwidth_ul),
-                        avp.AVP('Max-Requested-Bandwidth-DL', answer.total_ambr.max_bandwidth_dl),
-                    ]),
-                    avp.AVP('APN-Configuration-Profile', [
-                        avp.AVP('Context-Identifier', answer.default_context_id),
-                        avp.AVP('All-APN-Configurations-Included-Indicator', 1 if answer.all_apns_included else 0),
-                        *[avp.AVP('APN-Configuration', [
-                            avp.AVP('Context-Identifier', apn.context_id),
-                            avp.AVP('PDN-Type', apn.pdn),
-                            avp.AVP('Service-Selection', apn.service_selection),
-                            avp.AVP('EPS-Subscribed-QoS-Profile', [
-                                avp.AVP('QoS-Class-Identifier', apn.qos_profile.class_id),
-                                avp.AVP('Allocation-Retention-Priority', [
-                                    avp.AVP('Priority-Level', apn.qos_profile.priority_level),
-                                    avp.AVP('Pre-emption-Capability', 1 if apn.qos_profile.preemption_capability else 0),
-                                    avp.AVP('Pre-emption-Vulnerability', 1 if apn.qos_profile.preemption_vulnerability else 0),
-                                ]),
-                            ]),
-                            avp.AVP('AMBR', [
-                                avp.AVP('Max-Requested-Bandwidth-UL',
-                                        apn.ambr.max_bandwidth_ul),
-                                avp.AVP('Max-Requested-Bandwidth-DL',
-                                        apn.ambr.max_bandwidth_dl),
-                            ]),
-                        ]) for apn in answer.apn]
-                    ]),
-                ])
+                subscription_data = avp.AVP(
+                    'Subscription-Data', [
+                        avp.AVP('MSISDN', answer.msisdn),
+                        avp.AVP('Access-Restriction-Data', 47),
+                        avp.AVP('Subscriber-Status', 0),
+                        avp.AVP('Network-Access-Mode', 2),
+                        avp.AVP(
+                            'AMBR', [
+                                avp.AVP(
+                                    'Max-Requested-Bandwidth-UL',
+                                    answer.total_ambr.max_bandwidth_ul,
+                                ),
+                                avp.AVP(
+                                    'Max-Requested-Bandwidth-DL',
+                                    answer.total_ambr.max_bandwidth_dl,
+                                ),
+                            ],
+                        ),
+                        avp.AVP(
+                            'APN-Configuration-Profile', [
+                                avp.AVP(
+                                    'Context-Identifier',
+                                    answer.default_context_id,
+                                ),
+                                avp.AVP(
+                                    'All-APN-Configurations-Included-Indicator',
+                                    1 if answer.all_apns_included else 0,
+                                ),
+                                *[
+                                    avp.AVP(
+                                        'APN-Configuration', [
+                                            avp.AVP('Context-Identifier', apn.context_id),
+                                            avp.AVP('PDN-Type', apn.pdn),
+                                            avp.AVP(
+                                                'Service-Selection',
+                                                apn.service_selection,
+                                            ),
+                                            avp.AVP(
+                                                'EPS-Subscribed-QoS-Profile', [
+                                                    avp.AVP(
+                                                        'QoS-Class-Identifier',
+                                                        apn.qos_profile.class_id,
+                                                    ),
+                                                    avp.AVP(
+                                                        'Allocation-Retention-Priority', [
+                                                            avp.AVP(
+                                                                'Priority-Level', apn.qos_profile.priority_level,
+                                                            ),
+                                                            avp.AVP(
+                                                                'Pre-emption-Capability',
+                                                                1 if apn.qos_profile.preemption_capability else 0,
+                                                            ),
+                                                            avp.AVP(
+                                                                'Pre-emption-Vulnerability',
+                                                                1 if apn.qos_profile.preemption_vulnerability else 0,
+                                                            ),
+                                                        ],
+                                                    ),
+                                                ],
+                                            ),
+                                            avp.AVP(
+                                                'AMBR', [
+                                                    avp.AVP(
+                                                        'Max-Requested-Bandwidth-UL',
+                                                        apn.ambr.max_bandwidth_ul,
+                                                    ),
+                                                    avp.AVP(
+                                                        'Max-Requested-Bandwidth-DL',
+                                                        apn.ambr.max_bandwidth_dl,
+                                                    ),
+                                                ],
+                                            ),
+                                        ],
+                                    ) for apn in answer.apn
+                                ],
+                            ],
+                        ),
+                    ],
+                )
 
                 ula_flags = avp.AVP('ULA-Flags', 1)
-                resp = self._gen_response(state_id, msg,
-                                          avp.ResultCode.DIAMETER_SUCCESS,
-                                          [ula_flags, subscription_data])
+                resp = self._gen_response(
+                    state_id, msg,
+                    avp.ResultCode.DIAMETER_SUCCESS,
+                    [ula_flags, subscription_data],
+                )
         self.writer.send_msg(resp)
         S6A_LUR_TOTAL.inc()

--- a/lte/gateway/python/magma/subscriberdb/protocols/diameter/avp.py
+++ b/lte/gateway/python/magma/subscriberdb/protocols/diameter/avp.py
@@ -62,8 +62,10 @@ class BaseAVP(metaclass=abc.ABCMeta):
 
     """
 
-    def __init__(self, code, value=None, flags=0, name='',
-                 vendor=VendorId.DEFAULT):
+    def __init__(
+        self, code, value=None, flags=0, name='',
+        vendor=VendorId.DEFAULT,
+    ):
         self.code = code
         self.vendor = vendor
         self.name = name
@@ -130,17 +132,21 @@ class BaseAVP(metaclass=abc.ABCMeta):
         flags_str += 'M' if self.mandatory else ''
         flags_str += 'P' if self.protected else ''
         flags_str += 'V' if self.vendor_specific else ''
-        return ("%s: type=%s vendor=%s, code=%s, "
-                "flags=%s(0x%x) length=%d payload_len=%d: %s" %
-                (self.name,
-                 self.__class__.__name__,
-                 self.vendor,
-                 self.code,
-                 flags_str,
-                 self.flags,
-                 self.length,
-                 self._payload_length(),
-                 self.value))
+        return (
+            "%s: type=%s vendor=%s, code=%s, "
+            "flags=%s(0x%x) length=%d payload_len=%d: %s" %
+            (
+                self.name,
+                self.__class__.__name__,
+                self.vendor,
+                self.code,
+                flags_str,
+                self.flags,
+                self.length,
+                self._payload_length(),
+                self.value,
+            )
+        )
 
     def __eq__(self, other):
         """
@@ -208,10 +214,11 @@ class BaseAVP(metaclass=abc.ABCMeta):
         offset = begin
 
         # Write the header
-        struct.pack_into("!II", buf, offset,
-                         self.code,
-                         self.flags << 24 | self._encoded_length(),
-                         )
+        struct.pack_into(
+            "!II", buf, offset,
+            self.code,
+            self.flags << 24 | self._encoded_length(),
+        )
         offset += HEADER_LEN
 
         # Do we need to add a vendor?
@@ -253,15 +260,21 @@ class BaseAVP(metaclass=abc.ABCMeta):
 
     # Convenience flag properties
     # If an AVP is mandatory the responder must handle it to return success
-    mandatory = property(flag_getter(FLAG_MANDATORY),
-                         flag_setter(FLAG_MANDATORY))
+    mandatory = property(
+        flag_getter(FLAG_MANDATORY),
+        flag_setter(FLAG_MANDATORY),
+    )
     # This bit indicated the data has been end to end encrypted
-    protected = property(flag_getter(FLAG_PROTECTED),
-                         flag_setter(FLAG_PROTECTED))
+    protected = property(
+        flag_getter(FLAG_PROTECTED),
+        flag_setter(FLAG_PROTECTED),
+    )
     # This bit inidicated that there are four bytes of vendor ID before the
     # payload
-    vendor_specific = property(flag_getter(FLAG_VENDOR),
-                               flag_setter(FLAG_VENDOR))
+    vendor_specific = property(
+        flag_getter(FLAG_VENDOR),
+        flag_setter(FLAG_VENDOR),
+    )
 
 
 class OctetStringAVP(BaseAVP):
@@ -343,8 +356,10 @@ class GroupedAVP(BaseAVP):
         Return:
             an iterator on all AVPs that match
         """
-        return filter(lambda element: element.vendor == vendor \
-                                      and element.code == code, self.value)
+        return filter(
+            lambda element: element.vendor == vendor
+            and element.code == code, self.value,
+        )
 
     def find_avp(self, vendor, code):
         """
@@ -388,6 +403,7 @@ class AddressAVP(BaseAVP):
 
         raise exception.CodecException("Not a valid address")
 
+
 class EnumAVP(Unsigned32AVP):
     """
     Decode Enum AVPs given a Enum type
@@ -401,6 +417,7 @@ class EnumAVP(Unsigned32AVP):
             return cls.enum(val)
         except ValueError:
             return val
+
 
 @unique
 class ResultCode(IntEnum):
@@ -423,6 +440,7 @@ class ResultCodeAVP(EnumAVP):
     """
     enum = ResultCode
 
+
 @unique
 class DisconnectCause(IntEnum):
     """
@@ -431,6 +449,7 @@ class DisconnectCause(IntEnum):
     REBOOTING = 0
     BUSY = 1
     DO_NOT_WANT_TO_TALK_TO_YOU = 2
+
 
 class DisconnectCauseAVP(EnumAVP):
     """
@@ -476,13 +495,13 @@ def AVP(ident, value=None, **kwargs):
     avp_unknown = ('Unknown-AVP', UnknownAVP, 0)
     vendor = None
     code = None
-    if type(ident) == int:
+    if isinstance(ident, int):
         vendor = VendorId.DEFAULT
         code = ident
-    elif type(ident) == tuple:
+    elif isinstance(ident, tuple):
         vendor = ident[0]
         code = ident[1]
-    elif type(ident) == str:
+    elif isinstance(ident, str):
         vendor, code = resolve(ident)
     else:
         raise TypeError('Invalid key type')
@@ -490,8 +509,10 @@ def AVP(ident, value=None, **kwargs):
     name = avp_def[0]
     avp_type = avp_def[1]
     flags = kwargs.pop('flags', avp_def[2])
-    return avp_type(code, value=value,
-                    vendor=vendor, flags=flags, name=name, **kwargs)
+    return avp_type(
+        code, value=value,
+        vendor=vendor, flags=flags, name=name, **kwargs,
+    )
 
 
 def resolve(name):
@@ -580,71 +601,127 @@ AVPDict = {
         299: ('Inband-Security-Id', Unsigned32AVP, FLAG_MANDATORY),
     },
     VendorId.TGPP: {
-        493: ('Service-Selection', UTF8StringAVP,
-              FLAG_MANDATORY | FLAG_VENDOR),
+        493: (
+            'Service-Selection', UTF8StringAVP,
+            FLAG_MANDATORY | FLAG_VENDOR,
+        ),
         # 3GPP 29.214-b80 (11.8.0 2013.03.15) Section 5.3
-        515: ('Max-Requested-Bandwidth-DL', Unsigned32AVP,
-              FLAG_MANDATORY | FLAG_VENDOR),
-        516: ('Max-Requested-Bandwidth-UL', Unsigned32AVP,
-              FLAG_MANDATORY | FLAG_VENDOR),
+        515: (
+            'Max-Requested-Bandwidth-DL', Unsigned32AVP,
+            FLAG_MANDATORY | FLAG_VENDOR,
+        ),
+        516: (
+            'Max-Requested-Bandwidth-UL', Unsigned32AVP,
+            FLAG_MANDATORY | FLAG_VENDOR,
+        ),
         # 3GPP 29.140-700 (7.0.0 2007.07.05) Section 6.3
         701: ('MSISDN', OctetStringAVP, FLAG_MANDATORY | FLAG_VENDOR),
         # 3GPP 29.212-c00 (12.0.0 2013.03.15) Section 5.3
-        1028: ('QoS-Class-Identifier', Unsigned32AVP,
-               FLAG_MANDATORY | FLAG_VENDOR),
-        1032: ('RAT-Type', Unsigned32AVP,
-               FLAG_MANDATORY | FLAG_VENDOR),
-        1034: ('Allocation-Retention-Priority', GroupedAVP,
-               FLAG_MANDATORY | FLAG_VENDOR),
-        1046: ('Priority-Level', Unsigned32AVP,
-               FLAG_MANDATORY | FLAG_VENDOR),
-        1047: ('Pre-emption-Capability', Unsigned32AVP,
-               FLAG_MANDATORY | FLAG_VENDOR),
-        1048: ('Pre-emption-Vulnerability', Unsigned32AVP,
-               FLAG_MANDATORY | FLAG_VENDOR),
+        1028: (
+            'QoS-Class-Identifier', Unsigned32AVP,
+            FLAG_MANDATORY | FLAG_VENDOR,
+        ),
+        1032: (
+            'RAT-Type', Unsigned32AVP,
+            FLAG_MANDATORY | FLAG_VENDOR,
+        ),
+        1034: (
+            'Allocation-Retention-Priority', GroupedAVP,
+            FLAG_MANDATORY | FLAG_VENDOR,
+        ),
+        1046: (
+            'Priority-Level', Unsigned32AVP,
+            FLAG_MANDATORY | FLAG_VENDOR,
+        ),
+        1047: (
+            'Pre-emption-Capability', Unsigned32AVP,
+            FLAG_MANDATORY | FLAG_VENDOR,
+        ),
+        1048: (
+            'Pre-emption-Vulnerability', Unsigned32AVP,
+            FLAG_MANDATORY | FLAG_VENDOR,
+        ),
         # 3GPP 29.272-c00 (12.0.0 2013.03.13) Section 7.3
-        1400: ('Subscription-Data', GroupedAVP,
-               FLAG_MANDATORY | FLAG_VENDOR),
-        1405: ('ULR-Flags', Unsigned32AVP,
-               FLAG_MANDATORY | FLAG_VENDOR),
-        1406: ('ULA-Flags', Unsigned32AVP,
-               FLAG_MANDATORY | FLAG_VENDOR),
-        1407: ('Visited-PLMN-Id', OctetStringAVP,
-               FLAG_MANDATORY | FLAG_VENDOR),
-        1408: ('Requested-EUTRAN-Authentication-Info', GroupedAVP,
-               FLAG_MANDATORY | FLAG_VENDOR),
-        1410: ('Number-Of-Requested-Vectors', Unsigned32AVP,
-               FLAG_MANDATORY | FLAG_VENDOR),
-        1411: ('Re-Synchronization-Info', OctetStringAVP,
-               FLAG_MANDATORY | FLAG_VENDOR),
-        1412: ('Immediate-Response-Preferred', Unsigned32AVP,
-               FLAG_MANDATORY | FLAG_VENDOR),
-        1413: ('Authentication-Info', GroupedAVP,
-               FLAG_MANDATORY | FLAG_VENDOR),
-        1414: ('E-UTRAN-Vector', GroupedAVP,
-               FLAG_MANDATORY | FLAG_VENDOR),
-        1417: ('Network-Access-Mode', Unsigned32AVP,
-               FLAG_MANDATORY | FLAG_VENDOR),
-        1423: ('Context-Identifier', Unsigned32AVP,
-               FLAG_MANDATORY | FLAG_VENDOR),
-        1424: ('Subscriber-Status', Unsigned32AVP,
-               FLAG_MANDATORY | FLAG_VENDOR),
-        1426: ('Access-Restriction-Data', Unsigned32AVP,
-               FLAG_MANDATORY | FLAG_VENDOR),
-        1428: ('All-APN-Configurations-Included-Indicator', Unsigned32AVP,
-               FLAG_MANDATORY | FLAG_VENDOR),
-        1429: ('APN-Configuration-Profile', GroupedAVP,
-               FLAG_MANDATORY | FLAG_VENDOR),
-        1430: ('APN-Configuration', GroupedAVP,
-               FLAG_MANDATORY | FLAG_VENDOR),
-        1431: ('EPS-Subscribed-QoS-Profile', GroupedAVP,
-               FLAG_MANDATORY | FLAG_VENDOR),
+        1400: (
+            'Subscription-Data', GroupedAVP,
+            FLAG_MANDATORY | FLAG_VENDOR,
+        ),
+        1405: (
+            'ULR-Flags', Unsigned32AVP,
+            FLAG_MANDATORY | FLAG_VENDOR,
+        ),
+        1406: (
+            'ULA-Flags', Unsigned32AVP,
+            FLAG_MANDATORY | FLAG_VENDOR,
+        ),
+        1407: (
+            'Visited-PLMN-Id', OctetStringAVP,
+            FLAG_MANDATORY | FLAG_VENDOR,
+        ),
+        1408: (
+            'Requested-EUTRAN-Authentication-Info', GroupedAVP,
+            FLAG_MANDATORY | FLAG_VENDOR,
+        ),
+        1410: (
+            'Number-Of-Requested-Vectors', Unsigned32AVP,
+            FLAG_MANDATORY | FLAG_VENDOR,
+        ),
+        1411: (
+            'Re-Synchronization-Info', OctetStringAVP,
+            FLAG_MANDATORY | FLAG_VENDOR,
+        ),
+        1412: (
+            'Immediate-Response-Preferred', Unsigned32AVP,
+            FLAG_MANDATORY | FLAG_VENDOR,
+        ),
+        1413: (
+            'Authentication-Info', GroupedAVP,
+            FLAG_MANDATORY | FLAG_VENDOR,
+        ),
+        1414: (
+            'E-UTRAN-Vector', GroupedAVP,
+            FLAG_MANDATORY | FLAG_VENDOR,
+        ),
+        1417: (
+            'Network-Access-Mode', Unsigned32AVP,
+            FLAG_MANDATORY | FLAG_VENDOR,
+        ),
+        1423: (
+            'Context-Identifier', Unsigned32AVP,
+            FLAG_MANDATORY | FLAG_VENDOR,
+        ),
+        1424: (
+            'Subscriber-Status', Unsigned32AVP,
+            FLAG_MANDATORY | FLAG_VENDOR,
+        ),
+        1426: (
+            'Access-Restriction-Data', Unsigned32AVP,
+            FLAG_MANDATORY | FLAG_VENDOR,
+        ),
+        1428: (
+            'All-APN-Configurations-Included-Indicator', Unsigned32AVP,
+            FLAG_MANDATORY | FLAG_VENDOR,
+        ),
+        1429: (
+            'APN-Configuration-Profile', GroupedAVP,
+            FLAG_MANDATORY | FLAG_VENDOR,
+        ),
+        1430: (
+            'APN-Configuration', GroupedAVP,
+            FLAG_MANDATORY | FLAG_VENDOR,
+        ),
+        1431: (
+            'EPS-Subscribed-QoS-Profile', GroupedAVP,
+            FLAG_MANDATORY | FLAG_VENDOR,
+        ),
         1435: ('AMBR', GroupedAVP, FLAG_MANDATORY | FLAG_VENDOR),
         1447: ('RAND', OctetStringAVP, FLAG_MANDATORY | FLAG_VENDOR),
         1448: ('XRES', OctetStringAVP, FLAG_MANDATORY | FLAG_VENDOR),
         1449: ('AUTN', OctetStringAVP, FLAG_MANDATORY | FLAG_VENDOR),
         1450: ('KASME', OctetStringAVP, FLAG_MANDATORY | FLAG_VENDOR),
-        1456: ('PDN-Type', Unsigned32AVP,
-               FLAG_MANDATORY | FLAG_VENDOR),
-    }
+        1456: (
+            'PDN-Type', Unsigned32AVP,
+            FLAG_MANDATORY | FLAG_VENDOR,
+        ),
+    },
 }

--- a/lte/gateway/python/magma/subscriberdb/protocols/diameter/exception.py
+++ b/lte/gateway/python/magma/subscriberdb/protocols/diameter/exception.py
@@ -11,9 +11,11 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
+
 class CodecException(Exception):
     """Exception used for decoding Diameter messages"""
     pass
+
 
 class TooShortException(Exception):
     """Exception used when we try to decode a payload but it is TooShortException

--- a/lte/gateway/python/magma/subscriberdb/protocols/diameter/message.py
+++ b/lte/gateway/python/magma/subscriberdb/protocols/diameter/message.py
@@ -26,6 +26,7 @@ FLAG_RETRANSMITTED = 0x10
 
 def flag_getter(mask):
     """Convenience method for reading command flags"""
+
     def func(self):
         return self.command_flags & mask != 0
     return func
@@ -33,6 +34,7 @@ def flag_getter(mask):
 
 def flag_setter(mask):
     """Convenience method for setting command flags"""
+
     def func(self, value):
         self.command_flags &= ~mask
         if value:
@@ -131,12 +133,14 @@ class MessageHeader(object):
             the number of bytes written to the buffer
         """
         self.validate(length)
-        struct.pack_into('!IIIII', buf, offset,
-                         self.version << 24 | length,
-                         self.command_flags << 24 | self.command_code,
-                         self.application_id,
-                         self.hop_by_hop_id,
-                         self.end_to_end_id)
+        struct.pack_into(
+            '!IIIII', buf, offset,
+            self.version << 24 | length,
+            self.command_flags << 24 | self.command_code,
+            self.application_id,
+            self.hop_by_hop_id,
+            self.end_to_end_id,
+        )
         return HEADER_LEN
 
     @classmethod
@@ -171,15 +175,19 @@ class MessageHeader(object):
         flags_str += 'P' if self.proxiable else ''
         flags_str += 'E' if self.error else ''
         flags_str += 'T' if self.retransmitted else ''
-        return ("Header version=%d, application=%d, command=%d, "
-                "hbh=0x%x, ete=0x%x, flags=%s(0x%x)" %
-                (self.version,
-                 self.application_id,
-                 self.command_code,
-                 self.hop_by_hop_id,
-                 self.end_to_end_id,
-                 flags_str,
-                 self.command_flags))
+        return (
+            "Header version=%d, application=%d, command=%d, "
+            "hbh=0x%x, ete=0x%x, flags=%s(0x%x)" %
+            (
+                self.version,
+                self.application_id,
+                self.command_code,
+                self.hop_by_hop_id,
+                self.end_to_end_id,
+                flags_str,
+                self.command_flags,
+            )
+        )
 
     def __eq__(self, other):
         """Two message headers are equal if they represent the same payload"""
@@ -190,14 +198,22 @@ class MessageHeader(object):
         """Message header encode length"""
         return HEADER_LEN
 
-    request = property(flag_getter(FLAG_REQUEST),
-                       flag_setter(FLAG_REQUEST))
-    proxiable = property(flag_getter(FLAG_PROXIABLE),
-                         flag_setter(FLAG_PROXIABLE))
-    error = property(flag_getter(FLAG_ERROR),
-                     flag_setter(FLAG_ERROR))
-    retransmitted = property(flag_getter(FLAG_RETRANSMITTED),
-                             flag_setter(FLAG_RETRANSMITTED))
+    request = property(
+        flag_getter(FLAG_REQUEST),
+        flag_setter(FLAG_REQUEST),
+    )
+    proxiable = property(
+        flag_getter(FLAG_PROXIABLE),
+        flag_setter(FLAG_PROXIABLE),
+    )
+    error = property(
+        flag_getter(FLAG_ERROR),
+        flag_setter(FLAG_ERROR),
+    )
+    retransmitted = property(
+        flag_getter(FLAG_RETRANSMITTED),
+        flag_setter(FLAG_RETRANSMITTED),
+    )
 
 
 class Message(object):
@@ -224,9 +240,13 @@ class Message(object):
         return resp
 
     def __repr__(self):
-        return ("DiameterMessage length=%d:\n\t%s\nAVPs:\n\t%s" %
-                (self.length, self.header,
-                 "\n\t".join([str(x) for x in self._avps])))
+        return (
+            "DiameterMessage length=%d:\n\t%s\nAVPs:\n\t%s" %
+            (
+                self.length, self.header,
+                "\n\t".join([str(x) for x in self._avps]),
+            )
+        )
 
     @property
     def length(self):
@@ -275,8 +295,10 @@ class Message(object):
         Return:
             an iterator on all AVPs that match
         """
-        return filter(lambda element: element.vendor == vendor and
-                                      element.code == code, self._avps)
+        return filter(
+            lambda element: element.vendor == vendor
+            and element.code == code, self._avps,
+        )
 
     def find_avp(self, vendor, code):
         """

--- a/lte/gateway/python/magma/subscriberdb/protocols/diameter/server.py
+++ b/lte/gateway/python/magma/subscriberdb/protocols/diameter/server.py
@@ -49,8 +49,10 @@ class S6aServer(asyncio.Protocol):
         logging.info("Connection received, state id: %d", self.state_id)
         # bytesarray is more efficient to append fragments of reads
         self._readbuf = bytearray()
-        self.writer = Writer(self.realm, self.host,
-                             self.state_id, transport)
+        self.writer = Writer(
+            self.realm, self.host,
+            self.state_id, transport,
+        )
         self._base_manager.set_writer(self.writer)
         self._s6a_manager.set_writer(self.writer)
 
@@ -125,8 +127,10 @@ class S6aServer(asyncio.Protocol):
         elif application_id == s6a.S6AApplication.APP_ID:
             self._s6a_manager.handle_msg(self.state_id, msg)
         else:
-            logging.error("Unknown application: %d",
-                          msg.header.application_id)
+            logging.error(
+                "Unknown application: %d",
+                msg.header.application_id,
+            )
 
 
 class Writer:

--- a/lte/gateway/python/magma/subscriberdb/protocols/s6a_proxy_servicer.py
+++ b/lte/gateway/python/magma/subscriberdb/protocols/s6a_proxy_servicer.py
@@ -71,7 +71,8 @@ class S6aProxyRpcServicer(s6a_proxy_pb2_grpc.S6aProxyServicer):
         except CryptoError as e:
             logging.error("Auth error for %s: %s", imsi, e)
             metrics.S6A_AUTH_FAILURE_TOTAL.labels(
-                code=metrics.DIAMETER_AUTHENTICATION_REJECTED).inc()
+                code=metrics.DIAMETER_AUTHENTICATION_REJECTED,
+            ).inc()
             aia.error_code = metrics.DIAMETER_AUTHENTICATION_REJECTED
             self._print_grpc(aia)
             return aia
@@ -79,7 +80,8 @@ class S6aProxyRpcServicer(s6a_proxy_pb2_grpc.S6aProxyServicer):
         except SubscriberNotFoundError as e:
             logging.warning("Subscriber not found: %s", e)
             metrics.S6A_AUTH_FAILURE_TOTAL.labels(
-                code=metrics.DIAMETER_ERROR_USER_UNKNOWN).inc()
+                code=metrics.DIAMETER_ERROR_USER_UNKNOWN,
+            ).inc()
             aia.error_code = metrics.DIAMETER_ERROR_USER_UNKNOWN
             self._print_grpc(aia)
             return aia
@@ -127,7 +129,7 @@ class S6aProxyRpcServicer(s6a_proxy_pb2_grpc.S6aProxyServicer):
             sec_apn.ambr.max_bandwidth_ul = apn.ambr.max_bandwidth_ul
             sec_apn.ambr.max_bandwidth_dl = apn.ambr.max_bandwidth_dl
             sec_apn.ambr.unit = (
-                s6a_proxy_pb2.UpdateLocationAnswer \
+                s6a_proxy_pb2.UpdateLocationAnswer
                 .AggregatedMaximumBitrate.BitrateUnitsAMBR.BPS
             )
             sec_apn.pdn = (
@@ -140,8 +142,10 @@ class S6aProxyRpcServicer(s6a_proxy_pb2_grpc.S6aProxyServicer):
         return ula
 
     def PurgeUE(self, request, context):
-        logging.warning("Purge request not implemented: %s %s",
-                        request.DESCRIPTOR.full_name, MessageToJson(request))
+        logging.warning(
+            "Purge request not implemented: %s %s",
+            request.DESCRIPTOR.full_name, MessageToJson(request),
+        )
         res = s6a_proxy_pb2.PurgeUEAnswer()
         self._print_grpc(res)
         return res
@@ -149,12 +153,16 @@ class S6aProxyRpcServicer(s6a_proxy_pb2_grpc.S6aProxyServicer):
     def _print_grpc(self, message):
         if self._print_grpc_payload:
             try:
-                log_msg = "{} {}".format(message.DESCRIPTOR.full_name,
-                                     MessageToJson(message))
+                log_msg = "{} {}".format(
+                    message.DESCRIPTOR.full_name,
+                    MessageToJson(message),
+                )
                 # add indentation
                 padding = 2 * ' '
-                log_msg =''.join( "{}{}".format(padding, line)
-                              for line in log_msg.splitlines(True))
+                log_msg = ''.join(
+                    "{}{}".format(padding, line)
+                    for line in log_msg.splitlines(True)
+                )
 
                 log_msg = "GRPC message:\n{}".format(log_msg)
                 logging.info(log_msg)

--- a/lte/gateway/python/magma/subscriberdb/rpc_servicer.py
+++ b/lte/gateway/python/magma/subscriberdb/rpc_servicer.py
@@ -77,7 +77,7 @@ class SubscriberDBRpcServicer(subscriberdb_pb2_grpc.SubscriberDBServicer):
         try:
             with self._store.edit_subscriber(sid) as subs:
                 request.mask.MergeMessage(
-                    request.data, subs, replace_message_field=True
+                    request.data, subs, replace_message_field=True,
                 )
         except SubscriberNotFoundError:
             context.set_details("Subscriber not found: %s" % sid)
@@ -108,12 +108,16 @@ class SubscriberDBRpcServicer(subscriberdb_pb2_grpc.SubscriberDBServicer):
     def _print_grpc(self, message):
         if self._print_grpc_payload:
             try:
-                log_msg = "{} {}".format(message.DESCRIPTOR.full_name,
-                                     MessageToJson(message))
+                log_msg = "{} {}".format(
+                    message.DESCRIPTOR.full_name,
+                    MessageToJson(message),
+                )
                 # add indentation
                 padding = 2 * ' '
-                log_msg =''.join( "{}{}".format(padding, line)
-                              for line in log_msg.splitlines(True))
+                log_msg = ''.join(
+                    "{}{}".format(padding, line)
+                    for line in log_msg.splitlines(True)
+                )
 
                 log_msg = "GRPC message:\n{}".format(log_msg)
                 logging.info(log_msg)

--- a/lte/gateway/python/magma/subscriberdb/sid.py
+++ b/lte/gateway/python/magma/subscriberdb/sid.py
@@ -33,8 +33,10 @@ class SIDUtils:
         """
         if sid_pb.type == SubscriberID.IMSI:
             return 'IMSI' + sid_pb.id
-        raise ValueError('Invalid sid! type:%s id:%s' %
-                         (sid_pb.type, sid_pb.id))
+        raise ValueError(
+            'Invalid sid! type:%s id:%s' %
+            (sid_pb.type, sid_pb.id),
+        )
 
     @staticmethod
     def to_pb(sid_str):

--- a/lte/gateway/python/magma/subscriberdb/store/sqlite.py
+++ b/lte/gateway/python/magma/subscriberdb/store/sqlite.py
@@ -32,24 +32,32 @@ class SqliteStore(BaseStore):
     """
 
     def __init__(self, db_location, loop=None, sid_digits=2):
-        self._sid_digits = sid_digits # last digits to be included from subscriber id
+        self._sid_digits = sid_digits  # last digits to be included from subscriber id
         self._n_shards = 10**sid_digits
-        self._db_locations = self._create_db_locations(db_location, self._n_shards)
+        self._db_locations = self._create_db_locations(
+            db_location, self._n_shards,
+        )
         self._create_store()
         self._on_ready = OnDataReady(loop=loop)
-
 
     def _create_db_locations(self, db_location, n_shards):
         # in memory if db_location is not specified
         if not db_location:
             db_location = "/var/opt/magma/"
 
-        # construct db_location items as: file:<path>subscriber<shard>.db?cache=shared
+        # construct db_location items as:
+        # file:<path>subscriber<shard>.db?cache=shared
         db_location_list = []
 
         # file name is passed, use it as a base
         for shard in range(n_shards):
-            db_location_list.append('file:' + db_location + 'subscriber' + str(shard) + ".db?cache=shared")
+            db_location_list.append(
+                'file:'
+                + db_location
+                + 'subscriber'
+                + str(shard)
+                + ".db?cache=shared",
+            )
             logging.info("db location: %s", db_location_list[shard])
         return db_location_list
 
@@ -61,8 +69,10 @@ class SqliteStore(BaseStore):
             conn = sqlite3.connect(db_location, uri=True)
             try:
                 with conn:
-                    conn.execute("CREATE TABLE IF NOT EXISTS subscriberdb"
-                                      "(subscriber_id text PRIMARY KEY, data text)")
+                    conn.execute(
+                        "CREATE TABLE IF NOT EXISTS subscriberdb"
+                        "(subscriber_id text PRIMARY KEY, data text)",
+                    )
             finally:
                 conn.close()
 
@@ -76,13 +86,17 @@ class SqliteStore(BaseStore):
         conn = sqlite3.connect(db_location, uri=True)
         try:
             with conn:
-                res = conn.execute("SELECT data FROM subscriberdb WHERE "
-                                        "subscriber_id = ?", (sid, ))
+                res = conn.execute(
+                    "SELECT data FROM subscriberdb WHERE "
+                    "subscriber_id = ?", (sid,),
+                )
                 if res.fetchone():
                     raise DuplicateSubscriberError(sid)
 
-                conn.execute("INSERT INTO subscriberdb(subscriber_id, data) "
-                                "VALUES (?, ?)", (sid, data_str))
+                conn.execute(
+                    "INSERT INTO subscriberdb(subscriber_id, data) "
+                    "VALUES (?, ?)", (sid, data_str),
+                )
         finally:
             conn.close()
         self._on_ready.add_subscriber(subscriber_data)
@@ -149,8 +163,10 @@ class SqliteStore(BaseStore):
         conn = sqlite3.connect(db_location, uri=True)
         try:
             with conn:
-                res = conn.execute("SELECT data FROM subscriberdb WHERE "
-                                        "subscriber_id = ?", (subscriber_id, ))
+                res = conn.execute(
+                    "SELECT data FROM subscriberdb WHERE "
+                    "subscriber_id = ?", (subscriber_id,),
+                )
                 row = res.fetchone()
                 if not row:
                     raise SubscriberNotFoundError(subscriber_id)
@@ -169,7 +185,9 @@ class SqliteStore(BaseStore):
             conn = sqlite3.connect(db_location, uri=True)
             try:
                 with conn:
-                    res = conn.execute("SELECT subscriber_id FROM subscriberdb")
+                    res = conn.execute(
+                        "SELECT subscriber_id FROM subscriberdb",
+                    )
                     sub_list.extend([row[0] for row in res])
             finally:
                 conn.close()
@@ -194,8 +212,10 @@ class SqliteStore(BaseStore):
         conn = sqlite3.connect(db_location, uri=True)
         try:
             with conn:
-                res = conn.execute("UPDATE subscriberdb SET data = ? "
-                                        "WHERE subscriber_id = ?", (data_str, sid))
+                res = conn.execute(
+                    "UPDATE subscriberdb SET data = ? "
+                    "WHERE subscriber_id = ?", (data_str, sid),
+                )
                 if not res.rowcount:
                     raise SubscriberNotFoundError(sid)
         finally:
@@ -220,7 +240,9 @@ class SqliteStore(BaseStore):
             try:
                 with conn:
                     # Capture the current state of the subscribers
-                    res = conn.execute("SELECT subscriber_id, data FROM subscriberdb")
+                    res = conn.execute(
+                        "SELECT subscriber_id, data FROM subscriberdb",
+                    )
                     current_state = {}
                     for row in res:
                         sub = SubscriberData()
@@ -236,8 +258,10 @@ class SqliteStore(BaseStore):
                         if sid in current_state:
                             sub.state.CopyFrom(current_state[sid])
                         data_str = sub.SerializeToString()
-                        conn.execute("INSERT INTO subscriberdb(subscriber_id, data) "
-                                     "VALUES (?, ?)", (sid, data_str))
+                        conn.execute(
+                            "INSERT INTO subscriberdb(subscriber_id, data) "
+                            "VALUES (?, ?)", (sid, data_str),
+                        )
             finally:
                 conn.close()
         self._on_ready.resync(subscribers)
@@ -263,7 +287,6 @@ class SqliteStore(BaseStore):
         apn_config.ambr.max_bandwidth_ul = apn_data.ambr.max_bandwidth_ul
         apn_config.ambr.max_bandwidth_dl = apn_data.ambr.max_bandwidth_dl
 
-
     def _sid2bucket(self, subscriber_id):
         """
         Maps Subscriber ID to bucket
@@ -271,7 +294,9 @@ class SqliteStore(BaseStore):
         try:
             bucket = int(subscriber_id[-self._sid_digits:])
         except (TypeError, ValueError):
-            logging.info("Last %d digits of subscriber id %s cannot mapped to a bucket:"
-                         " default to bucket 0", self._sid_digits, subscriber_id)
+            logging.info(
+                "Last %d digits of subscriber id %s cannot mapped to a bucket:"
+                " default to bucket 0", self._sid_digits, subscriber_id,
+            )
             bucket = 0
         return bucket

--- a/lte/gateway/python/magma/subscriberdb/streamer_callback.py
+++ b/lte/gateway/python/magma/subscriberdb/streamer_callback.py
@@ -42,8 +42,10 @@ class SubscriberDBStreamerCallback(StreamerClient.Callback):
         TODO we can optimize a bit on the MME side to not detach already
         detached subscribers.
         """
-        logging.info("Processing %d subscriber updates (resync=%s)",
-                     len(updates), resync)
+        logging.info(
+            "Processing %d subscriber updates (resync=%s)",
+            len(updates), resync,
+        )
 
         if resync:
             # TODO:
@@ -92,13 +94,17 @@ class SubscriberDBStreamerCallback(StreamerClient.Callback):
                 new_sub_ids,
             ),
         )
-        deleted_sub_ids = [sub_id for sub_id in old_sub_ids
-                           if sub_id not in set(new_sub_ids)]
+        deleted_sub_ids = [
+            sub_id for sub_id in old_sub_ids
+            if sub_id not in set(new_sub_ids)
+        ]
         if len(deleted_sub_ids) == 0:
             return
         # send detach request to mme for all deleted subscribers.
-        chan = ServiceRegistry.get_rpc_channel('s6a_service',
-                                               ServiceRegistry.LOCAL)
+        chan = ServiceRegistry.get_rpc_channel(
+            's6a_service',
+            ServiceRegistry.LOCAL,
+        )
         client = S6aServiceStub(chan)
         req = DeleteSubscriberRequest()
 
@@ -107,11 +113,13 @@ class SubscriberDBStreamerCallback(StreamerClient.Callback):
 
         req.imsi_list.extend(imsis_to_delete_without_prefix)
         future = client.DeleteSubscriber.future(req)
-        future.add_done_callback(lambda future:
-                                 self._loop.call_soon_threadsafe(
-                                     self.detach_deleted_subscribers_done,
-                                     future)
-                                 )
+        future.add_done_callback(
+            lambda future:
+            self._loop.call_soon_threadsafe(
+                self.detach_deleted_subscribers_done,
+                future,
+            ),
+        )
 
     @staticmethod
     def detach_deleted_subscribers_done(delete_future):
@@ -120,5 +128,7 @@ class SubscriberDBStreamerCallback(StreamerClient.Callback):
         """
         err = delete_future.exception()
         if err:
-            logging.error("Detach Deleted Subscribers Error! [%s] %s",
-                          err.code(), err.details())
+            logging.error(
+                "Detach Deleted Subscribers Error! [%s] %s",
+                err.code(), err.details(),
+            )

--- a/lte/gateway/python/magma/subscriberdb/subscription_profile.py
+++ b/lte/gateway/python/magma/subscriberdb/subscription_profile.py
@@ -25,5 +25,5 @@ def get_default_sub_profile(service):
     # in the code.
     return SubscriberDB.SubscriptionProfile(
         max_ul_bit_rate=service.config['default_max_ul_bit_rate'],
-        max_dl_bit_rate=service.config['default_max_dl_bit_rate']
+        max_dl_bit_rate=service.config['default_max_dl_bit_rate'],
     )

--- a/lte/gateway/python/magma/subscriberdb/tests/crypto/crypto_tests.py
+++ b/lte/gateway/python/magma/subscriberdb/tests/crypto/crypto_tests.py
@@ -35,7 +35,8 @@ class CryptoTests(unittest.TestCase):
         input_k = rand + sres + cipher_key
         self.assertEqual(
             crypto.generate_auth_tuple(input_k),
-            (rand, sres, cipher_key))
+            (rand, sres, cipher_key),
+        )
 
         # If the length is not 28 bytes, CryptoError will be thrown
         input_k = rand + sres

--- a/lte/gateway/python/magma/subscriberdb/tests/crypto/milenage_tests.py
+++ b/lte/gateway/python/magma/subscriberdb/tests/crypto/milenage_tests.py
@@ -20,6 +20,7 @@ class MilenageRandomTests(unittest.TestCase):
     """
     Test class RAND method
     """
+
     def test_rand(self):
         """Tests the random generator"""
         rand = Milenage.generate_rand()
@@ -58,8 +59,10 @@ class MilenageTests(unittest.TestCase):
         mac_s = b'\x01\xcf\xaf\x9e\xc4\xe8\x71\xe9'
 
         self.assertEqual(Milenage.generate_opc(k, op), opc)
-        self.assertEqual(Milenage.f1(k, sqn, self.rand, opc, amf),
-                         (mac_a, mac_s))
+        self.assertEqual(
+            Milenage.f1(k, sqn, self.rand, opc, amf),
+            (mac_a, mac_s),
+        )
 
     def test_f2_f3_f5(self):
         """ Tests that the f2 and f5 functions work as expected.
@@ -141,13 +144,17 @@ class MilenageTests(unittest.TestCase):
         crypto = Milenage(amf)
         self.assertEqual(crypto.generate_opc(k, op), op_c)
         auts = crypto.generate_auts(k, op_c, rand, sqn)
-        self.assertEqual(crypto.generate_resync(auts, k, op_c, rand),
-                          (sqn, mac_s))
+        self.assertEqual(
+            crypto.generate_resync(auts, k, op_c, rand),
+            (sqn, mac_s),
+        )
 
     def test_eutran_vector(self):
         """Can we compute the vector that OAI generates?"""
-        self.rand = (b'\x00\x01\x02\x03\x04\x05\x06\x07\x08\t\n\x0b'
-                     b'\x0c\r\x0e\x0f')
+        self.rand = (
+            b'\x00\x01\x02\x03\x04\x05\x06\x07\x08\t\n\x0b'
+            b'\x0c\r\x0e\x0f'
+        )
 
         # Inputs extracted from OAI logs
         key = b'\x8b\xafG?/\x8f\xd0\x94\x87\xcc\xcb\xd7\t|hb'
@@ -160,8 +167,10 @@ class MilenageTests(unittest.TestCase):
         op_c = b"\x8e'\xb6\xaf\x0ei.u\x0f2fz;\x14`]"
         xres = b'\x2d\xaf\x87\x3d\x73\xf3\x10\xc6'
         autn = b'o\xbf\xa3\x80\x1fW\x80\x00{\xdeY\x88n\x96\xe4\xfe'
-        kasme = (b'\x87H\xc1\xc0\xa2\x82o\xa4\x05\xb1\xe2~\xa1\x04CJ\xe5V\xc7e'
-                 b'\xe8\xf0a\xeb\xdb\x8a\xe2\x86\xc4F\x16\xc2')
+        kasme = (
+            b'\x87H\xc1\xc0\xa2\x82o\xa4\x05\xb1\xe2~\xa1\x04CJ\xe5V\xc7e'
+            b'\xe8\xf0a\xeb\xdb\x8a\xe2\x86\xc4F\x16\xc2'
+        )
 
         crypto = Milenage(amf)
         self.assertEqual(crypto.generate_opc(key, op), op_c)

--- a/lte/gateway/python/magma/subscriberdb/tests/processor_tests.py
+++ b/lte/gateway/python/magma/subscriberdb/tests/processor_tests.py
@@ -40,13 +40,15 @@ def _dummy_eutran_vector():
     rand = b'\x00\x01\x02\x03\x04\x05\x06\x07\x08\t\n\x0b\x0c\r\x0e\x0f'
     xres = b'\x2d\xaf\x87\x3d\x73\xf3\x10\xc6'
     autn = b'o\xbf\xa3\x80\x1fW\x80\x00{\xdeY\x88n\x96\xe4\xfe'
-    kasme = (b'\x87H\xc1\xc0\xa2\x82o\xa4\x05\xb1\xe2~\xa1\x04CJ\xe5V\xc7e'
-            b'\xe8\xf0a\xeb\xdb\x8a\xe2\x86\xc4F\x16\xc2')
+    kasme = (
+        b'\x87H\xc1\xc0\xa2\x82o\xa4\x05\xb1\xe2~\xa1\x04CJ\xe5V\xc7e'
+        b'\xe8\xf0a\xeb\xdb\x8a\xe2\x86\xc4F\x16\xc2'
+    )
     return (rand, xres, autn, kasme)
 
 
 def _dummy_resync_vector():
-    mac_s = 8*b'\x00'
+    mac_s = 8 * b'\x00'
     sqn = 2**28 + 1 << 5
     return (sqn, mac_s)
 
@@ -86,43 +88,66 @@ class ProcessorTests(unittest.TestCase):
     def setUp(self):
         # Create sqlite3 database for testing
         self._tmpfile = tempfile.TemporaryDirectory()
-        store = SqliteStore(self._tmpfile.name +'/')
-        op = 16*b'\x11'
+        store = SqliteStore(self._tmpfile.name + '/')
+        op = 16 * b'\x11'
         amf = b'\x80\x00'
         self._sub_profiles = {
             'superfast': SubscriberDB.SubscriptionProfile(
-                max_ul_bit_rate=100000, max_dl_bit_rate=50000)
+                max_ul_bit_rate=100000, max_dl_bit_rate=50000,
+            ),
         }
         self._default_sub_profile = SubscriberDB.SubscriptionProfile(
-            max_ul_bit_rate=10000, max_dl_bit_rate=5000)
+            max_ul_bit_rate=10000, max_dl_bit_rate=5000,
+        )
 
         self._processor = processor.Processor(
-            store, self._default_sub_profile, self._sub_profiles, op, amf)
+            store, self._default_sub_profile, self._sub_profiles, op, amf,
+        )
 
         # Add some test users
         (rand, sres, gsm_key) = _dummy_auth_tuple()
-        gsm = GSMSubscription(state=GSMSubscription.ACTIVE,
-                              auth_tuples=[rand + sres + gsm_key])
-        lte_key = 16*b'\x00'
-        lte = LTESubscription(state=LTESubscription.ACTIVE,
-                              auth_key=lte_key)
-        lte_opc = LTESubscription(state=LTESubscription.ACTIVE,
-                                  auth_key=lte_key,
-                                  auth_opc=Milenage.generate_opc(lte_key, op))
-        lte_opc_short = LTESubscription(state=LTESubscription.ACTIVE,
-                                  auth_key=lte_key,
-                                  auth_opc=b'\x00')
+        gsm = GSMSubscription(
+            state=GSMSubscription.ACTIVE,
+            auth_tuples=[rand + sres + gsm_key],
+        )
+        lte_key = 16 * b'\x00'
+        lte = LTESubscription(
+            state=LTESubscription.ACTIVE,
+            auth_key=lte_key,
+        )
+        lte_opc = LTESubscription(
+            state=LTESubscription.ACTIVE,
+            auth_key=lte_key,
+            auth_opc=Milenage.generate_opc(lte_key, op),
+        )
+        lte_opc_short = LTESubscription(
+            state=LTESubscription.ACTIVE,
+            auth_key=lte_key,
+            auth_opc=b'\x00',
+        )
         state = SubscriberState(lte_auth_next_seq=1)
-        sub1 = SubscriberData(sid=SIDUtils.to_pb('IMSI11111'), gsm=gsm, lte=lte,
-                              state=state, sub_profile='superfast')
-        sub2 = SubscriberData(sid=SIDUtils.to_pb('IMSI22222'), # No auth keys
-                              gsm=GSMSubscription(state=GSMSubscription.ACTIVE),
-                              lte=LTESubscription(state=LTESubscription.ACTIVE))
-        sub3 = SubscriberData(sid=SIDUtils.to_pb('IMSI33333')) # No subscribtion
-        sub4 = SubscriberData(sid=SIDUtils.to_pb('IMSI44444'), lte=lte_opc,
-                              state=state)
-        sub5 = SubscriberData(sid=SIDUtils.to_pb('IMSI55555'), lte=lte_opc_short,
-                              state=state)
+        sub1 = SubscriberData(
+            sid=SIDUtils.to_pb('IMSI11111'), gsm=gsm, lte=lte,
+            state=state, sub_profile='superfast',
+        )
+        sub2 = SubscriberData(
+            sid=SIDUtils.to_pb('IMSI22222'),  # No auth keys
+            gsm=GSMSubscription(
+                state=GSMSubscription.ACTIVE,
+            ),
+            lte=LTESubscription(state=LTESubscription.ACTIVE),
+        )
+        sub3 = SubscriberData(
+            sid=SIDUtils.to_pb('IMSI33333'),
+        )  # No subscribtion
+        sub4 = SubscriberData(
+            sid=SIDUtils.to_pb('IMSI44444'), lte=lte_opc,
+            state=state,
+        )
+        sub5 = SubscriberData(
+            sid=SIDUtils.to_pb('IMSI55555'), lte=lte_opc_short,
+            state=state,
+        )
         store.add_subscriber(sub1)
         store.add_subscriber(sub2)
         store.add_subscriber(sub3)
@@ -136,8 +161,10 @@ class ProcessorTests(unittest.TestCase):
         """
         Test if we get the correct auth tuple on success
         """
-        self.assertEqual(self._processor.get_gsm_auth_vector('11111'),
-                         _dummy_auth_tuple())
+        self.assertEqual(
+            self._processor.get_gsm_auth_vector('11111'),
+            _dummy_auth_tuple(),
+        )
 
     def test_gsm_auth_imsi_unknown(self):
         """
@@ -180,46 +207,54 @@ class ProcessorTests(unittest.TestCase):
         Test if we get the auth vector
         """
         eutran_vector = _dummy_eutran_vector()
-        self.assertEqual(self._processor.generate_lte_auth_vector('11111',
-                         3*b'\x00'),
-                         eutran_vector)
+        self.assertEqual(
+            self._processor.generate_lte_auth_vector(
+                '11111',
+                3 * b'\x00',
+            ),
+            eutran_vector,
+        )
 
     def test_lte_auth_success_opc(self):
         """
         Test if we get the auth vector using passed OPc
         """
         eutran_vector = _dummy_eutran_vector()
-        self.assertEqual(self._processor.generate_lte_auth_vector('44444',
-                         3*b'\x00'),
-                         eutran_vector)
+        self.assertEqual(
+            self._processor.generate_lte_auth_vector(
+                '44444',
+                3 * b'\x00',
+            ),
+            eutran_vector,
+        )
 
     def test_lte_auth_fail_opc_short(self):
         """
         Test if we get the a crypto error if the OPc is too short
         """
         with self.assertRaises(CryptoError):
-            self._processor.generate_lte_auth_vector('55555', 3*b'\x00')
+            self._processor.generate_lte_auth_vector('55555', 3 * b'\x00')
 
     def test_lte_auth_imsi_unknown(self):
         """
         Test if we get SubscriberNotFoundError exception
         """
         with self.assertRaises(SubscriberNotFoundError):
-            self._processor.generate_lte_auth_vector('12345', 3*b'\x00')
+            self._processor.generate_lte_auth_vector('12345', 3 * b'\x00')
 
     def test_lte_auth_key_missing(self):
         """
         Test if we get CryptoError if auth key is missing
         """
         with self.assertRaises(CryptoError):
-            self._processor.generate_lte_auth_vector('22222', 3*b'\x00')
+            self._processor.generate_lte_auth_vector('22222', 3 * b'\x00')
 
     def test_lte_auth_no_subscription(self):
         """
         Test if we get CryptoError if there is no LTE subscription
         """
         with self.assertRaises(CryptoError):
-            self._processor.generate_lte_auth_vector('33333', 3*b'\x00')
+            self._processor.generate_lte_auth_vector('33333', 3 * b'\x00')
 
     def test_lte_resync_seq_overflow_protect(self):
         """
@@ -227,10 +262,12 @@ class ProcessorTests(unittest.TestCase):
         2 **28 if the ue_seq number is higher than the network seq number
         """
         self._processor.set_next_lte_auth_seq('11111', 0)
-        auts = 14*b'\x00'
-        self._processor.resync_lte_auth_seq('11111', 16*b'\x00', auts)
-        self.assertEqual(self._processor.get_next_lte_auth_seq('11111'),
-                         2 ** 28 + 2)
+        auts = 14 * b'\x00'
+        self._processor.resync_lte_auth_seq('11111', 16 * b'\x00', auts)
+        self.assertEqual(
+            self._processor.get_next_lte_auth_seq('11111'),
+            2 ** 28 + 2,
+        )
 
     def test_lte_resync_seq_smaller(self):
         """
@@ -238,10 +275,12 @@ class ProcessorTests(unittest.TestCase):
         next SQN and the MAC_S is correct. We start with a SEQ of 1 and a SEQ_MS
         of 2**28+1 to get a final SEQ of 2**28 + 2
         """
-        auts = 14*b'\x00'
-        self._processor.resync_lte_auth_seq('11111', 16*b'\x00', auts)
-        self.assertEqual(self._processor.get_next_lte_auth_seq('11111'),
-            2**28 + 2)
+        auts = 14 * b'\x00'
+        self._processor.resync_lte_auth_seq('11111', 16 * b'\x00', auts)
+        self.assertEqual(
+            self._processor.get_next_lte_auth_seq('11111'),
+            2**28 + 2,
+        )
 
     def test_lte_resync_seq_equal(self):
         """
@@ -249,10 +288,12 @@ class ProcessorTests(unittest.TestCase):
         has. We start with a SEQ of 2**28 + 1 and SEQ_MS is equal so we add 1.
         """
         self._processor.set_next_lte_auth_seq('11111', 2**28 + 1)
-        auts = 14*b'\x00'
-        self._processor.resync_lte_auth_seq('11111', 16*b'\x00', auts)
-        self.assertEqual(self._processor.get_next_lte_auth_seq('11111'),
-                         2**28 + 2)
+        auts = 14 * b'\x00'
+        self._processor.resync_lte_auth_seq('11111', 16 * b'\x00', auts)
+        self.assertEqual(
+            self._processor.get_next_lte_auth_seq('11111'),
+            2**28 + 2,
+        )
 
     def test_lte_resync_seq_larger(self):
         """
@@ -263,24 +304,28 @@ class ProcessorTests(unittest.TestCase):
         NOTE: this test assumes that we've prematurely incremented the
         SEQ on auth failure.
         """
-        self._processor.set_next_lte_auth_seq('11111',
-                                              2**28 + 3)
-        auts = 14*b'\x00'
+        self._processor.set_next_lte_auth_seq(
+            '11111',
+            2**28 + 3,
+        )
+        auts = 14 * b'\x00'
         with self.assertRaises(CryptoError):
             # seq_ms is stubbed to be 2**28 + 1, and we've set seq_network
             # to be 2**28 + 3. seq_ms will be incremented to 2**28 + 2,
             # meaning we still _don't_ allow a resync.
-            self._processor.resync_lte_auth_seq('11111', 16*b'\x00', auts)
-        self.assertEqual(self._processor.get_next_lte_auth_seq('11111'),
-                         2**28 + 3)
+            self._processor.resync_lte_auth_seq('11111', 16 * b'\x00', auts)
+        self.assertEqual(
+            self._processor.get_next_lte_auth_seq('11111'),
+            2**28 + 3,
+        )
 
     def test_lte_resync_bad_mac_s(self):
         """
         Test if we ignore the seq update when the MAC_S is incorrect
         """
-        auts = 14*b'\x01'
+        auts = 14 * b'\x01'
         with self.assertRaises(CryptoError):
-            self._processor.resync_lte_auth_seq('11111', 16*b'\x00', auts)
+            self._processor.resync_lte_auth_seq('11111', 16 * b'\x00', auts)
         self.assertEqual(self._processor.get_next_lte_auth_seq('11111'), 1)
 
     def test_lte_resync_imsi_unknown(self):
@@ -288,21 +333,27 @@ class ProcessorTests(unittest.TestCase):
         Test if we get SubscriberNotFoundError exception
         """
         with self.assertRaises(SubscriberNotFoundError):
-            self._processor.resync_lte_auth_seq('12345', 16*b'\x00', 14*b'\x00')
+            self._processor.resync_lte_auth_seq(
+                '12345', 16 * b'\x00', 14 * b'\x00',
+            )
 
     def test_lte_resync_key_missing(self):
         """
         Test if we get CryptoError if auth key is missing
         """
         with self.assertRaises(CryptoError):
-            self._processor.resync_lte_auth_seq('22222', 16*b'\x00', 14*b'\x00')
+            self._processor.resync_lte_auth_seq(
+                '22222', 16 * b'\x00', 14 * b'\x00',
+            )
 
     def test_lte_resync_no_subscription(self):
         """
         Test if we get CryptoError if there is no LTE subscription
         """
         with self.assertRaises(CryptoError):
-            self._processor.resync_lte_auth_seq('33333', 16*b'\x00', 3*b'\x00')
+            self._processor.resync_lte_auth_seq(
+                '33333', 16 * b'\x00', 3 * b'\x00',
+            )
 
     def test_sub_profile(self):
         """
@@ -310,10 +361,14 @@ class ProcessorTests(unittest.TestCase):
         """
         with self.assertRaises(SubscriberNotFoundError):
             self._processor.get_sub_profile('12345')
-        self.assertEqual(self._processor.get_sub_profile('11111'),
-                         self._sub_profiles['superfast'])
-        self.assertEqual(self._processor.get_sub_profile('33333'),
-                         self._default_sub_profile)
+        self.assertEqual(
+            self._processor.get_sub_profile('11111'),
+            self._sub_profiles['superfast'],
+        )
+        self.assertEqual(
+            self._processor.get_sub_profile('33333'),
+            self._default_sub_profile,
+        )
 
 
 if __name__ == "__main__":

--- a/lte/gateway/python/magma/subscriberdb/tests/protocols/diameter/avp_tests.py
+++ b/lte/gateway/python/magma/subscriberdb/tests/protocols/diameter/avp_tests.py
@@ -46,46 +46,64 @@ class AVPHeaderTests(unittest.TestCase):
         """
         Tests we can encode and decode AVPs with different flags
         """
-        self._compare_avp(avp.UnknownAVP(0, b''),
-            memoryview(b'\x00\x00\x00\x00\x00\x00\x00\x08'))
+        self._compare_avp(
+            avp.UnknownAVP(0, b''),
+            memoryview(b'\x00\x00\x00\x00\x00\x00\x00\x08'),
+        )
 
         avp_val = avp.UnknownAVP(0, b'', flags=avp.FLAG_MANDATORY)
-        self._compare_avp(avp_val,
-            b'\x00\x00\x00\x00@\x00\x00\x08')
+        self._compare_avp(
+            avp_val,
+            b'\x00\x00\x00\x00@\x00\x00\x08',
+        )
         self.assertFalse(avp_val.vendor_specific)
         self.assertTrue(avp_val.mandatory)
         self.assertFalse(avp_val.protected)
 
         avp_val = avp.UnknownAVP(0, b'', flags=avp.FLAG_PROTECTED)
-        self._compare_avp(avp_val,
-            b'\x00\x00\x00\x00 \x00\x00\x08')
+        self._compare_avp(
+            avp_val,
+            b'\x00\x00\x00\x00 \x00\x00\x08',
+        )
         self.assertFalse(avp_val.vendor_specific)
         self.assertFalse(avp_val.mandatory)
         self.assertTrue(avp_val.protected)
 
-        avp_val = avp.UnknownAVP(0, b'', flags=avp.FLAG_VENDOR,
-                                 vendor=avp.VendorId.TGPP)
-        self._compare_avp(avp_val,
-            b'\x00\x00\x00\x00\x80\x00\x00\x0c\x00\x00(\xaf')
+        avp_val = avp.UnknownAVP(
+            0, b'', flags=avp.FLAG_VENDOR,
+            vendor=avp.VendorId.TGPP,
+        )
+        self._compare_avp(
+            avp_val,
+            b'\x00\x00\x00\x00\x80\x00\x00\x0c\x00\x00(\xaf',
+        )
         self.assertTrue(avp_val.vendor_specific)
         self.assertFalse(avp_val.mandatory)
         self.assertFalse(avp_val.protected)
 
-        avp_val = avp.UnknownAVP(0, b'', flags=avp.FLAG_VENDOR |
-                                 avp.FLAG_MANDATORY,
-                                 vendor=avp.VendorId.TGPP)
-        self._compare_avp(avp_val,
-            b'\x00\x00\x00\x00\xc0\x00\x00\x0c\x00\x00(\xaf')
+        avp_val = avp.UnknownAVP(
+            0, b'', flags=avp.FLAG_VENDOR
+            | avp.FLAG_MANDATORY,
+            vendor=avp.VendorId.TGPP,
+        )
+        self._compare_avp(
+            avp_val,
+            b'\x00\x00\x00\x00\xc0\x00\x00\x0c\x00\x00(\xaf',
+        )
         self.assertTrue(avp_val.vendor_specific)
         self.assertTrue(avp_val.mandatory)
         self.assertFalse(avp_val.protected)
 
-        avp_val = avp.UnknownAVP(0, b'', flags=avp.FLAG_VENDOR |
-                                 avp.FLAG_MANDATORY |
-                                 avp.FLAG_PROTECTED,
-                                 vendor=avp.VendorId.TGPP)
-        self._compare_avp(avp_val,
-            b'\x00\x00\x00\x00\xe0\x00\x00\x0c\x00\x00(\xaf')
+        avp_val = avp.UnknownAVP(
+            0, b'', flags=avp.FLAG_VENDOR
+            | avp.FLAG_MANDATORY
+            | avp.FLAG_PROTECTED,
+            vendor=avp.VendorId.TGPP,
+        )
+        self._compare_avp(
+            avp_val,
+            b'\x00\x00\x00\x00\xe0\x00\x00\x0c\x00\x00(\xaf',
+        )
         self.assertTrue(avp_val.vendor_specific)
         self.assertTrue(avp_val.mandatory)
         self.assertTrue(avp_val.protected)
@@ -97,21 +115,21 @@ class AVPHeaderTests(unittest.TestCase):
 
         avp_val = avp.UnknownAVP(0, b'')
         out_buf = bytearray(avp_val.length)
-        avp_val.encode(out_buf,0)
+        avp_val.encode(out_buf, 0)
 
         avp_val = avp.UnknownAVP(0xFFFFFFFF, b'')
         out_buf = bytearray(avp_val.length)
-        avp_val.encode(out_buf,0)
+        avp_val.encode(out_buf, 0)
 
         with self.assertRaises(CodecException):
             avp_val = avp.UnknownAVP(-1, b'')
             out_buf = bytearray(avp_val.length)
-            avp_val.encode(out_buf,0)
+            avp_val.encode(out_buf, 0)
 
         with self.assertRaises(CodecException):
             avp_val = avp.UnknownAVP(0xFFFFFFFF + 1, b'')
             out_buf = bytearray(avp_val.length)
-            avp_val.encode(out_buf,0)
+            avp_val.encode(out_buf, 0)
 
     def test_avp_vendor(self):
         """
@@ -119,41 +137,51 @@ class AVPHeaderTests(unittest.TestCase):
         """
         # Vendor specific flags means you need a non default vendor ID
         with self.assertRaises(CodecException):
-            avp_val = avp.UnknownAVP(0, b'',
+            avp_val = avp.UnknownAVP(
+                0, b'',
                 flags=avp.FLAG_VENDOR,
-                vendor=avp.VendorId.DEFAULT)
+                vendor=avp.VendorId.DEFAULT,
+            )
             out_buf = bytearray(avp_val.length)
-            avp_val.encode(out_buf,0)
+            avp_val.encode(out_buf, 0)
 
-        avp_val = avp.UnknownAVP(0, b'',
+        avp_val = avp.UnknownAVP(
+            0, b'',
             flags=avp.FLAG_VENDOR,
-            vendor=1)
+            vendor=1,
+        )
         out_buf = bytearray(avp_val.length)
-        avp_val.encode(out_buf,0)
+        avp_val.encode(out_buf, 0)
         self._compare_avp(avp_val, out_buf)
 
-        avp_val = avp.UnknownAVP(0, b'',
+        avp_val = avp.UnknownAVP(
+            0, b'',
             flags=avp.FLAG_VENDOR,
-            vendor=0x00FFFFFF)
+            vendor=0x00FFFFFF,
+        )
         out_buf = bytearray(avp_val.length)
-        avp_val.encode(out_buf,0)
+        avp_val.encode(out_buf, 0)
         self._compare_avp(avp_val, out_buf)
 
         # Avp vendor in range
         with self.assertRaises(CodecException):
-            avp_val = avp.UnknownAVP(0, b'',
+            avp_val = avp.UnknownAVP(
+                0, b'',
                 flags=avp.FLAG_VENDOR,
-                vendor=-1)
+                vendor=-1,
+            )
             out_buf = bytearray(avp_val.length)
-            avp_val.encode(out_buf,0)
+            avp_val.encode(out_buf, 0)
 
         # Avp vendor in range
         with self.assertRaises(CodecException):
-            avp_val = avp.UnknownAVP(0, b'',
+            avp_val = avp.UnknownAVP(
+                0, b'',
                 flags=avp.FLAG_VENDOR,
-                vendor=0xFFFFFFFF + 1)
+                vendor=0xFFFFFFFF + 1,
+            )
             out_buf = bytearray(avp_val.length)
-            avp_val.encode(out_buf,0)
+            avp_val.encode(out_buf, 0)
 
     def test_avp_length(self):
         """
@@ -175,18 +203,22 @@ class AVPHeaderTests(unittest.TestCase):
             avp.decode(b'\x00\x00\x00\x00\x80\x00\x00\x00')
 
         # Max allowable length of payload
-        avp_val = avp.UTF8StringAVP(1,
-            'a'*(0x00FFFFFF - avp.HEADER_LEN))
+        avp_val = avp.UTF8StringAVP(
+            1,
+            'a' * (0x00FFFFFF - avp.HEADER_LEN),
+        )
         out_buf = bytearray(avp_val.length)
-        avp_val.encode(out_buf,0)
+        avp_val.encode(out_buf, 0)
         self._compare_avp(avp_val, out_buf)
 
         # Avp length out of range
         with self.assertRaises(CodecException):
-            avp_val = avp.UTF8StringAVP(1,
-                'a'*(0x00FFFFFF - avp.HEADER_LEN + 1))
+            avp_val = avp.UTF8StringAVP(
+                1,
+                'a' * (0x00FFFFFF - avp.HEADER_LEN + 1),
+            )
             out_buf = bytearray(avp_val.length)
-            avp_val.encode(out_buf,0)
+            avp_val.encode(out_buf, 0)
 
 
 class AVPValueTests(unittest.TestCase):
@@ -202,7 +234,7 @@ class AVPValueTests(unittest.TestCase):
     def _encode_check(self, avp_val, msg_bytes):
         out_buf = bytearray(avp_val.length)
         out_len = avp_val.encode(out_buf, 0)
-        self.assertEqual(out_len % 4, 0) # encoded AVP is end aligned
+        self.assertEqual(out_len % 4, 0)  # encoded AVP is end aligned
         self.assertEqual(out_buf, bytes(msg_bytes))
 
     def _compare_avp(self, avp_val, msg_bytes):
@@ -216,8 +248,10 @@ class AVPValueTests(unittest.TestCase):
         """
         Tests we can encode and decode octet strings
         """
-        self._compare_avp(avp.UnknownAVP(0, b'hello\x23'),
-            memoryview(b'\x00\x00\x00\x00\x00\x00\x00\x0ehello#\x00\x00'))
+        self._compare_avp(
+            avp.UnknownAVP(0, b'hello\x23'),
+            memoryview(b'\x00\x00\x00\x00\x00\x00\x00\x0ehello#\x00\x00'),
+        )
 
         # Unicode strings won't load
         with self.assertRaises(CodecException):
@@ -227,8 +261,10 @@ class AVPValueTests(unittest.TestCase):
         """
         Tests we can encode and decode unicode strings
         """
-        self._compare_avp(avp.UTF8StringAVP(1, u'\u0123\u0490'),
-            memoryview(b'\x00\x00\x00\x01\x00\x00\x00\x0c\xc4\xa3\xd2\x90'))
+        self._compare_avp(
+            avp.UTF8StringAVP(1, u'\u0123\u0490'),
+            memoryview(b'\x00\x00\x00\x01\x00\x00\x00\x0c\xc4\xa3\xd2\x90'),
+        )
 
         # Octet strings won't load
         with self.assertRaises(CodecException):
@@ -239,8 +275,10 @@ class AVPValueTests(unittest.TestCase):
         Tests we can encode and decode unsigned integers
         """
 
-        self._compare_avp(avp.Unsigned32AVP(299, 1234),
-            memoryview(b'\x00\x00\x01+\x00\x00\x00\x0c\x00\x00\x04\xd2'))
+        self._compare_avp(
+            avp.Unsigned32AVP(299, 1234),
+            memoryview(b'\x00\x00\x01+\x00\x00\x00\x0c\x00\x00\x04\xd2'),
+        )
 
         with self.assertRaises(CodecException):
             avp.Unsigned32AVP(299, -1234)
@@ -251,29 +289,43 @@ class AVPValueTests(unittest.TestCase):
         """
         # pylint:disable=expression-not-assigned
 
-        self._compare_avp(avp.AddressAVP(257, '127.0.0.1'),
-            memoryview(b'\x00\x00\x01\x01\x00\x00\x00\x0e'
-                       b'\x00\x01\x7f\x00\x00\x01\x00\x00'))
+        self._compare_avp(
+            avp.AddressAVP(257, '127.0.0.1'),
+            memoryview(
+                b'\x00\x00\x01\x01\x00\x00\x00\x0e'
+                b'\x00\x01\x7f\x00\x00\x01\x00\x00',
+            ),
+        )
 
-        self._compare_avp(avp.AddressAVP(257, '2001:db8::1'),
-            memoryview(b'\x00\x00\x01\x01\x00\x00\x00\x1a\x00\x02 \x01\r'
-                       b'\xb8\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
-                       b'\x01\x00\x00'))
+        self._compare_avp(
+            avp.AddressAVP(257, '2001:db8::1'),
+            memoryview(
+                b'\x00\x00\x01\x01\x00\x00\x00\x1a\x00\x02 \x01\r'
+                b'\xb8\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
+                b'\x01\x00\x00',
+            ),
+        )
 
         # Can't read invalid address type \x03
         with self.assertRaises(CodecException):
-            avp.decode(b'\x00\x00\x01\x01\x00\x00\x00\x0e'
-                       b'\x00\x03\x7f\x00\x00\x01\x00\x00').value
+            avp.decode(
+                b'\x00\x00\x01\x01\x00\x00\x00\x0e'
+                b'\x00\x03\x7f\x00\x00\x01\x00\x00',
+            ).value
 
         # Can't read too short IPV4
         with self.assertRaises(CodecException):
-            avp.decode(b'\x00\x00\x01\x01\x00\x00\x00\x0e'
-                       b'\x00\x01\x7f').value
+            avp.decode(
+                b'\x00\x00\x01\x01\x00\x00\x00\x0e'
+                b'\x00\x01\x7f',
+            ).value
 
         # Can't read too short IPV6
         with self.assertRaises(CodecException):
-            avp.decode(b'\x00\x00\x01\x01\x00\x00\x00\x0e'
-                       b'\x00\x02\x7f\x00\x00\x01\x00\x00').value
+            avp.decode(
+                b'\x00\x00\x01\x01\x00\x00\x00\x0e'
+                b'\x00\x02\x7f\x00\x00\x01\x00\x00',
+            ).value
 
         # Cant encode non-ips
         with self.assertRaises(CodecException):
@@ -285,41 +337,56 @@ class AVPValueTests(unittest.TestCase):
         """
         self._compare_avp(
             avp.ResultCodeAVP(268, avp.ResultCode.DIAMETER_SUCCESS),
-            memoryview(b'\x00\x00\x01\x0c\x00\x00\x00\x0c\x00\x00\x07\xd1'))
+            memoryview(b'\x00\x00\x01\x0c\x00\x00\x00\x0c\x00\x00\x07\xd1'),
+        )
 
         # Test a value we haven't defined
         self._compare_avp(
             avp.ResultCodeAVP(268, 1337),
-            memoryview(b'\x00\x00\x01\x0c\x00\x00\x00\x0c\x00\x00\x059'))
+            memoryview(b'\x00\x00\x01\x0c\x00\x00\x00\x0c\x00\x00\x059'),
+        )
 
     def test_grouped(self):
         """
         Tests we can encode and decode grouped AVPs
         """
 
-        grouped_avp = avp.GroupedAVP(260,[avp.UTF8StringAVP(1, 'Hello'),
-                                          avp.UTF8StringAVP(1, 'World')])
-        self._compare_avp(grouped_avp,
-                          (b'\x00\x00\x01\x04\x00\x00\x00(\x00\x00'
-                           b'\x00\x01\x00\x00\x00\rHello\x00\x00\x00'
-                           b'\x00\x00\x00\x01\x00\x00\x00\rWorld\x00'
-                           b'\x00\x00'))
+        grouped_avp = avp.GroupedAVP(
+            260, [
+                avp.UTF8StringAVP(1, 'Hello'),
+                avp.UTF8StringAVP(1, 'World'),
+            ],
+        )
+        self._compare_avp(
+            grouped_avp,
+            (
+                b'\x00\x00\x01\x04\x00\x00\x00(\x00\x00'
+                b'\x00\x01\x00\x00\x00\rHello\x00\x00\x00'
+                b'\x00\x00\x00\x01\x00\x00\x00\rWorld\x00'
+                b'\x00\x00'
+            ),
+        )
 
-        self._compare_avp(avp.GroupedAVP(260, [grouped_avp, grouped_avp]),
-                          (b'\x00\x00\x01\x04\x00\x00\x00X\x00\x00\x01\x04'
-                           b'\x00\x00\x00(\x00\x00\x00\x01\x00\x00\x00\rHello'
-                           b'\x00\x00\x00\x00\x00\x00\x01\x00\x00\x00\rWorld'
-                           b'\x00\x00\x00\x00\x00\x01\x04\x00\x00\x00(\x00\x00'
-                           b'\x00\x01\x00\x00\x00\rHello\x00\x00\x00\x00\x00'
-                           b'\x00\x01\x00\x00\x00\rWorld\x00\x00\x00'))
+        self._compare_avp(
+            avp.GroupedAVP(260, [grouped_avp, grouped_avp]),
+            (
+                b'\x00\x00\x01\x04\x00\x00\x00X\x00\x00\x01\x04'
+                b'\x00\x00\x00(\x00\x00\x00\x01\x00\x00\x00\rHello'
+                b'\x00\x00\x00\x00\x00\x00\x01\x00\x00\x00\rWorld'
+                b'\x00\x00\x00\x00\x00\x01\x04\x00\x00\x00(\x00\x00'
+                b'\x00\x01\x00\x00\x00\rHello\x00\x00\x00\x00\x00'
+                b'\x00\x01\x00\x00\x00\rWorld\x00\x00\x00'
+            ),
+        )
 
         # Test filtering
-        self.assertEqual(len(list(grouped_avp.filter_avps(0,1))), 2)
-        self.assertEqual(len(list(grouped_avp.filter_avps(0,2))), 0)
+        self.assertEqual(len(list(grouped_avp.filter_avps(0, 1))), 2)
+        self.assertEqual(len(list(grouped_avp.filter_avps(0, 2))), 0)
 
         # Test find returns first
-        self.assertEqual(grouped_avp.find_avp(0,1).value, 'Hello')
-        self.assertEqual(grouped_avp.find_avp(0,2), None)
+        self.assertEqual(grouped_avp.find_avp(0, 1).value, 'Hello')
+        self.assertEqual(grouped_avp.find_avp(0, 2), None)
+
 
 class AVPConstructorTests(unittest.TestCase):
     """
@@ -334,7 +401,7 @@ class AVPConstructorTests(unittest.TestCase):
     def _encode_check(self, avp_val, msg_bytes):
         out_buf = bytearray(avp_val.length)
         out_len = avp_val.encode(out_buf, 0)
-        self.assertEqual(out_len % 4, 0) # encoded AVP is end aligned
+        self.assertEqual(out_len % 4, 0)  # encoded AVP is end aligned
         self.assertEqual(out_buf, bytes(msg_bytes))
 
     def _compare_avp(self, avp1, avp2):
@@ -343,7 +410,6 @@ class AVPConstructorTests(unittest.TestCase):
         self.assertEqual(avp1.flags, avp2.flags)
         self.assertEqual(avp1.payload, avp2.payload)
         self.assertEqual(avp1.name, avp2.name)
-
 
     def test_empty_value(self):
         """
@@ -369,46 +435,70 @@ class AVPConstructorTests(unittest.TestCase):
         """
 
         # This will resolve to the Username AVP
-        self._compare_avp(avp.AVP((avp.VendorId.DEFAULT,1), 'a username'),
-            avp.UTF8StringAVP(1, value='a username', vendor=avp.VendorId.DEFAULT,
-                              flags=avp.FLAG_MANDATORY,
-                              name='User-Name'))
+        self._compare_avp(
+            avp.AVP((avp.VendorId.DEFAULT, 1), 'a username'),
+            avp.UTF8StringAVP(
+                1, value='a username', vendor=avp.VendorId.DEFAULT,
+                flags=avp.FLAG_MANDATORY,
+                name='User-Name',
+            ),
+        )
 
-        self._compare_avp(avp.AVP((avp.VendorId.TGPP,701), b'msisdn'),
-            avp.OctetStringAVP(701, value=b'msisdn', vendor=avp.VendorId.TGPP,
-                              flags=avp.FLAG_MANDATORY|avp.FLAG_VENDOR,
-                              name='MSISDN'))
+        self._compare_avp(
+            avp.AVP((avp.VendorId.TGPP, 701), b'msisdn'),
+            avp.OctetStringAVP(
+                701, value=b'msisdn', vendor=avp.VendorId.TGPP,
+                flags=avp.FLAG_MANDATORY | avp.FLAG_VENDOR,
+                name='MSISDN',
+            ),
+        )
 
         # Unknown AVPs default to unknown AVP
-        self._compare_avp(avp.AVP((0xfac3b00c,1), b'wut'),
-            avp.UnknownAVP(1, value=b'wut', vendor=0xfac3b00c,
-                              flags=0, name='Unknown-AVP'))
+        self._compare_avp(
+            avp.AVP((0xfac3b00c, 1), b'wut'),
+            avp.UnknownAVP(
+                1, value=b'wut', vendor=0xfac3b00c,
+                flags=0, name='Unknown-AVP',
+            ),
+        )
 
     def test_integer_identifier(self):
         """
         Tests we can create an AVP with a code and it defaults to the defaults
         vendor.
         """
-        self._compare_avp(avp.AVP(1, 'Hello'),
-            avp.UTF8StringAVP(1, value='Hello', vendor=avp.VendorId.DEFAULT,
-                              flags=avp.FLAG_MANDATORY,
-                              name='User-Name'))
+        self._compare_avp(
+            avp.AVP(1, 'Hello'),
+            avp.UTF8StringAVP(
+                1, value='Hello', vendor=avp.VendorId.DEFAULT,
+                flags=avp.FLAG_MANDATORY,
+                name='User-Name',
+            ),
+        )
 
         # Unknown AVPs default to unknown AVP
-        self._compare_avp(avp.AVP(0xdeadb33f, b'wut'),
-            avp.UnknownAVP(0xdeadb33f, value=b'wut',
-                              vendor=avp.VendorId.DEFAULT,
-                              flags=0, name='Unknown-AVP'))
+        self._compare_avp(
+            avp.AVP(0xdeadb33f, b'wut'),
+            avp.UnknownAVP(
+                0xdeadb33f, value=b'wut',
+                vendor=avp.VendorId.DEFAULT,
+                flags=0, name='Unknown-AVP',
+            ),
+        )
 
     def test_string_identifier(self):
         """
         Tests we can create an AVP with a code and it defaults to the defaults
         vendor.
         """
-        self._compare_avp(avp.AVP('User-Name', 'Hello'),
-            avp.UTF8StringAVP(1, value='Hello', vendor=avp.VendorId.DEFAULT,
-                              flags=avp.FLAG_MANDATORY,
-                              name='User-Name'))
+        self._compare_avp(
+            avp.AVP('User-Name', 'Hello'),
+            avp.UTF8StringAVP(
+                1, value='Hello', vendor=avp.VendorId.DEFAULT,
+                flags=avp.FLAG_MANDATORY,
+                name='User-Name',
+            ),
+        )
 
         # Unknown names will cause an error
         with self.assertRaises(ValueError):
@@ -422,12 +512,14 @@ class AVPConstructorTests(unittest.TestCase):
         result_avp = avp.AVP('Result-Code', avp.ResultCode.DIAMETER_SUCCESS)
         self.assertEqual(result_avp.value, avp.ResultCode.DIAMETER_SUCCESS)
 
-
         self._compare_avp(
             avp.AVP('Result-Code', avp.ResultCode.DIAMETER_SUCCESS),
-            avp.ResultCodeAVP(268, 2001, vendor=avp.VendorId.DEFAULT,
-                              flags=avp.FLAG_MANDATORY,
-                              name='Result-Code'))
+            avp.ResultCodeAVP(
+                268, 2001, vendor=avp.VendorId.DEFAULT,
+                flags=avp.FLAG_MANDATORY,
+                name='Result-Code',
+            ),
+        )
 
     def test_unknown_identifier(self):
         """

--- a/lte/gateway/python/magma/subscriberdb/tests/protocols/diameter/base_application_tests.py
+++ b/lte/gateway/python/magma/subscriberdb/tests/protocols/diameter/base_application_tests.py
@@ -33,7 +33,9 @@ class BaseApplicationTests(unittest.TestCase):
     HOST_ADDR = "127.0.0.1"
 
     def setUp(self):
-        base_manager = base.BaseApplication(self.REALM, self.HOST, self.HOST_ADDR)
+        base_manager = base.BaseApplication(
+            self.REALM, self.HOST, self.HOST_ADDR,
+        )
         s6a_manager = s6a_relay.S6AApplication(
             Mock(),
             self.REALM,
@@ -129,10 +131,14 @@ class BaseApplicationTests(unittest.TestCase):
         msg.append_avp(avp.AVP('Host-IP-Address', self.HOST_ADDR))
         msg.append_avp(avp.AVP('Vendor-Id', 0))
         msg.append_avp(avp.AVP('Supported-Vendor-Id', avp.VendorId.TGPP))
-        msg.append_avp(avp.AVP('Vendor-Specific-Application-Id', [
-            avp.AVP('Auth-Application-Id', s6a.S6AApplication.APP_ID),
-            avp.AVP('Vendor-Id', avp.VendorId.TGPP)
-        ]))
+        msg.append_avp(
+            avp.AVP(
+                'Vendor-Specific-Application-Id', [
+                    avp.AVP('Auth-Application-Id', s6a.S6AApplication.APP_ID),
+                    avp.AVP('Vendor-Id', avp.VendorId.TGPP),
+                ],
+            ),
+        )
         msg.append_avp(avp.AVP('Product-Name', 'magma'))
         # Encode response message into buffer
         resp_buf = bytearray(msg.length)

--- a/lte/gateway/python/magma/subscriberdb/tests/protocols/diameter/common.py
+++ b/lte/gateway/python/magma/subscriberdb/tests/protocols/diameter/common.py
@@ -2,7 +2,10 @@ import asyncio
 
 # pylint: disable=W0223
 
-# We cannot create instances directly for transport we need them to be created by event loop so hacking this.
+# We cannot create instances directly for transport we need them to be
+# created by event loop so hacking this.
+
+
 class MockTransport(asyncio.Transport):
     def __init__(self, extra=None):
         self.sent = []

--- a/lte/gateway/python/magma/subscriberdb/tests/protocols/diameter/message_tests.py
+++ b/lte/gateway/python/magma/subscriberdb/tests/protocols/diameter/message_tests.py
@@ -53,40 +53,54 @@ class MessageHeaderCodecTests(unittest.TestCase):
         """Test that we can encode and decode message header"""
         # The default message header is all zeros except the version number
         header = message.MessageHeader()
-        self._compare_header(header, b'\x01' +
-                                     b'\x00'*(message.HEADER_LEN - 1), 0)
+        self._compare_header(
+            header, b'\x01' +
+            b'\x00'*(message.HEADER_LEN - 1), 0,
+        )
 
         # Next three bytes are the length
-        self._compare_header(header, b'\x01\x00\x00\x02' +
-                                     b'\x00'*(message.HEADER_LEN - 4), 2)
+        self._compare_header(
+            header, b'\x01\x00\x00\x02' +
+            b'\x00'*(message.HEADER_LEN - 4), 2,
+        )
 
         # Next is our command flags
         header.command_flags = 0x1f
-        self._compare_header(header, b'\x01\x00\x00\x02\x1f' +
-                                     b'\x00'*(message.HEADER_LEN - 5), 2)
+        self._compare_header(
+            header, b'\x01\x00\x00\x02\x1f' +
+            b'\x00'*(message.HEADER_LEN - 5), 2,
+        )
 
         # Command code is the next three bytes
         header.command_code = 0x1
-        self._compare_header(header, b'\x01\x00\x00\x02\x1f\x00\x00\x01' +
-                                     b'\x00'*(message.HEADER_LEN - 8), 2)
+        self._compare_header(
+            header, b'\x01\x00\x00\x02\x1f\x00\x00\x01' +
+            b'\x00'*(message.HEADER_LEN - 8), 2,
+        )
 
         # Application id is the next four bytes
         header.application_id = 0x7
-        self._compare_header(header, b'\x01\x00\x00\x02\x1f\x00\x00\x01' +
-                                     b'\x00\x00\x00\x07' +
-                                     b'\x00'*(message.HEADER_LEN - 12), 2)
+        self._compare_header(
+            header, b'\x01\x00\x00\x02\x1f\x00\x00\x01' +
+            b'\x00\x00\x00\x07' +
+            b'\x00'*(message.HEADER_LEN - 12), 2,
+        )
 
         # hop by hop id is the next four bytes
         header.hop_by_hop_id = 0xb33f0000
-        self._compare_header(header, b'\x01\x00\x00\x02\x1f\x00\x00\x01' +
-                                     b'\x00\x00\x00\x07\xb3\x3f\x00\x00' +
-                                     b'\x00'*(message.HEADER_LEN - 16), 2)
+        self._compare_header(
+            header, b'\x01\x00\x00\x02\x1f\x00\x00\x01' +
+            b'\x00\x00\x00\x07\xb3\x3f\x00\x00' +
+            b'\x00'*(message.HEADER_LEN - 16), 2,
+        )
 
         # end to end id is the last four
         header.end_to_end_id = 0x0000dead
-        self._compare_header(header, b'\x01\x00\x00\x02\x1f\x00\x00\x01' +
-                                     b'\x00\x00\x00\x07\xb3\x3f\x00\x00' +
-                                     b'\x00\x00\xde\xad', 2)
+        self._compare_header(
+            header, b'\x01\x00\x00\x02\x1f\x00\x00\x01' +
+            b'\x00\x00\x00\x07\xb3\x3f\x00\x00' +
+            b'\x00\x00\xde\xad', 2,
+        )
 
     def test_header_decode_validate(self):
         """
@@ -95,8 +109,10 @@ class MessageHeaderCodecTests(unittest.TestCase):
 
         # Must be at least 20 Bytes to decode
         with self.assertRaises(CodecException):
-            message.MessageHeader.decode(b'\x00' *
-                                         (message.HEADER_LEN - 1))
+            message.MessageHeader.decode(
+                b'\x00' *
+                (message.HEADER_LEN - 1),
+            )
 
     def test_header_validate_length(self):
         """
@@ -323,9 +339,11 @@ class MessageCodecTests(unittest.TestCase):
         """
         # A message with no arguments is just an empty header
         msg = message.Message()
-        self._compare_msg(msg, b'\x01' + # Version
-                               b'\x00\x00\x14' + # Length 20
-                               b'\x00'*(message.HEADER_LEN - 4))
+        self._compare_msg(
+            msg, b'\x01' + # Version
+            b'\x00\x00\x14' + # Length 20
+            b'\x00'*(message.HEADER_LEN - 4),
+        )
 
     def test_message_with_avp(self):
         """
@@ -334,10 +352,12 @@ class MessageCodecTests(unittest.TestCase):
         """
         msg = message.Message()
         msg.append_avp(avp.AVP('User-Name', 'hello'))
-        self._compare_msg(msg, b'\x01' + # Version
-                               b'\x00\x00\x24' + # Length 36
-                               b'\x00'*(message.HEADER_LEN - 4) +
-                               b'\x00\x00\x00\x01@\x00\x00\rhello\x00\x00\x00')
+        self._compare_msg(
+            msg, b'\x01' + # Version
+            b'\x00\x00\x24' + # Length 36
+            b'\x00'*(message.HEADER_LEN - 4) +
+            b'\x00\x00\x00\x01@\x00\x00\rhello\x00\x00\x00',
+        )
 
     def test_decode_validate_length(self):
         """
@@ -346,14 +366,18 @@ class MessageCodecTests(unittest.TestCase):
         """
         # Shorter than header by 1
         with self.assertRaises(TooShortException):
-            message.decode(b'\x01' +
-                           b'\x00'*(message.HEADER_LEN - 2))
+            message.decode(
+                b'\x01' +
+                b'\x00'*(message.HEADER_LEN - 2),
+            )
 
         # Header says 24 bytes but we give 23
         with self.assertRaises(TooShortException):
-            payload = (b'\x01' + # Version
-                       b'\x00\x00\x18' + # Length 24
-                       b'\x00'*(message.HEADER_LEN-1))
+            payload = (
+                b'\x01' + # Version
+                b'\x00\x00\x18' + # Length 24
+                b'\x00'*(message.HEADER_LEN-1)
+            )
             self.assertEqual(len(payload), 23)
             message.decode(payload)
 
@@ -364,15 +388,19 @@ class MessageCodecTests(unittest.TestCase):
         """
         # Gave a length that was not a multiple of 4
         with self.assertRaises(CodecException):
-            message.decode(b'\x01' + # Version
-                           b'\x00\x00\x15' + # Length 21
-                           b'\x00'*(message.HEADER_LEN-3))
+            message.decode(
+                b'\x01' + # Version
+                b'\x00\x00\x15' + # Length 21
+                b'\x00'*(message.HEADER_LEN-3),
+            )
 
         # Garbage AVPs
         with self.assertRaises(CodecException):
-            message.decode(b'\x01' + # Version
-                           b'\x00\x00\x18' + # Length 24
-                           b'\x00'*(message.HEADER_LEN))
+            message.decode(
+                b'\x01' + # Version
+                b'\x00\x00\x18' + # Length 24
+                b'\x00'*(message.HEADER_LEN),
+            )
 
     def test_respond(self):
         """

--- a/lte/gateway/python/magma/subscriberdb/tests/protocols/diameter/s6a_application_tests.py
+++ b/lte/gateway/python/magma/subscriberdb/tests/protocols/diameter/s6a_application_tests.py
@@ -34,14 +34,18 @@ def _dummy_eutran_vector():
     rand = b'\x00\x01\x02\x03\x04\x05\x06\x07\x08\t\n\x0b\x0c\r\x0e\x0f'
     xres = b'\x2d\xaf\x87\x3d\x73\xf3\x10\xc6'
     autn = b'o\xbf\xa3\x80\x1fW\x80\x00{\xdeY\x88n\x96\xe4\xfe'
-    kasme = (b'\x87H\xc1\xc0\xa2\x82o\xa4\x05\xb1\xe2~\xa1\x04CJ\xe5V\xc7e'
-            b'\xe8\xf0a\xeb\xdb\x8a\xe2\x86\xc4F\x16\xc2')
+    kasme = (
+        b'\x87H\xc1\xc0\xa2\x82o\xa4\x05\xb1\xe2~\xa1\x04CJ\xe5V\xc7e'
+        b'\xe8\xf0a\xeb\xdb\x8a\xe2\x86\xc4F\x16\xc2'
+    )
     return (rand, xres, autn, kasme)
+
 
 def _dummy_resync_vector():
     mac_s = b'\x01\xcf\xaf\x9e\xc4'
     sqn = 2000
     return (sqn, mac_s)
+
 
 class MockProcessor(LTEProcessor):
     def generate_lte_auth_vector(self, imsi, plmn):
@@ -65,7 +69,7 @@ class MockProcessor(LTEProcessor):
     def get_sub_profile(self, imsi):
         return SubscriberDB.SubscriptionProfile(
             max_ul_bit_rate=10000,
-            max_dl_bit_rate=50000
+            max_dl_bit_rate=50000,
         )
 
 
@@ -80,7 +84,9 @@ class S6AApplicationTests(unittest.TestCase):
     HOST_ADDR = "127.0.0.1"
 
     def setUp(self):
-        base_manager = base.BaseApplication(self.REALM, self.HOST, self.HOST_ADDR)
+        base_manager = base.BaseApplication(
+            self.REALM, self.HOST, self.HOST_ADDR,
+        )
         s6a_manager = s6a_relay.S6AApplication(
             MockProcessor(),
             self.REALM,
@@ -138,15 +144,23 @@ class S6AApplicationTests(unittest.TestCase):
         msg.header.application_id = s6a.S6AApplication.APP_ID
         msg.header.command_code = s6a.S6AApplicationCommands.AUTHENTICATION_INFORMATION
         msg.header.request = True
-        msg.append_avp(avp.AVP('Session-Id',
-            'enb-Lenovo-Product.openair4G.eur;1475864727;1;apps6a'))
+        msg.append_avp(
+            avp.AVP(
+                'Session-Id',
+                'enb-Lenovo-Product.openair4G.eur;1475864727;1;apps6a',
+            ),
+        )
         msg.append_avp(avp.AVP('Auth-Session-State', 1))
         msg.append_avp(avp.AVP('User-Name', '1'))
         msg.append_avp(avp.AVP('Visited-PLMN-Id', b'(Y'))
-        msg.append_avp(avp.AVP('Requested-EUTRAN-Authentication-Info', [
-            avp.AVP('Number-Of-Requested-Vectors', 1),
-            avp.AVP('Immediate-Response-Preferred', 0),
-        ]))
+        msg.append_avp(
+            avp.AVP(
+                'Requested-EUTRAN-Authentication-Info', [
+                    avp.AVP('Number-Of-Requested-Vectors', 1),
+                    avp.AVP('Immediate-Response-Preferred', 0),
+                ],
+            ),
+        )
         # Encode request message into buffer
         req_buf = bytearray(msg.length)
         msg.encode(req_buf, 0)
@@ -156,19 +170,37 @@ class S6AApplicationTests(unittest.TestCase):
         msg.header.command_code = \
             s6a.S6AApplicationCommands.AUTHENTICATION_INFORMATION
         msg.header.request = False
-        msg.append_avp(avp.AVP('Session-Id',
-            'enb-Lenovo-Product.openair4G.eur;1475864727;1;apps6a'))
-        msg.append_avp(avp.AVP('Authentication-Info', [
-            avp.AVP('E-UTRAN-Vector', [
-                avp.AVP('RAND', b'\x00\x01\x02\x03\x04\x05'
-                                b'\x06\x07\x08\x09\x0a\x0b\x0c\x0d\x0e\x0f'),
-                avp.AVP('XRES', b'\x2d\xaf\x87\x3d\x73\xf3\x10\xc6'),
-                avp.AVP('AUTN', b'\x6f\xbf\xa3\x80\x1f\x57\x80'
-                                b'\x00\x7b\xde\x59\x88\x6e\x96\xe4\xfe'),
-                avp.AVP('KASME', b'\x87\x48\xc1\xc0\xa2\x82'
-                                 b'\x6f\xa4\x05\xb1\xe2\x7e\xa1\x04\x43\x4a'
-                                 b'\xe5\x56\xc7\x65\xe8\xf0\x61\xeb\xdb\x8a'
-                                 b'\xe2\x86\xc4\x46\x16\xc2')])]))
+        msg.append_avp(
+            avp.AVP(
+                'Session-Id',
+                'enb-Lenovo-Product.openair4G.eur;1475864727;1;apps6a',
+            ),
+        )
+        msg.append_avp(
+            avp.AVP(
+                'Authentication-Info', [
+                avp.AVP(
+                    'E-UTRAN-Vector', [
+                    avp.AVP(
+                        'RAND', b'\x00\x01\x02\x03\x04\x05'
+                        b'\x06\x07\x08\x09\x0a\x0b\x0c\x0d\x0e\x0f',
+                    ),
+                    avp.AVP('XRES', b'\x2d\xaf\x87\x3d\x73\xf3\x10\xc6'),
+                    avp.AVP(
+                        'AUTN', b'\x6f\xbf\xa3\x80\x1f\x57\x80'
+                        b'\x00\x7b\xde\x59\x88\x6e\x96\xe4\xfe',
+                    ),
+                    avp.AVP(
+                        'KASME', b'\x87\x48\xc1\xc0\xa2\x82'
+                        b'\x6f\xa4\x05\xb1\xe2\x7e\xa1\x04\x43\x4a'
+                        b'\xe5\x56\xc7\x65\xe8\xf0\x61\xeb\xdb\x8a'
+                        b'\xe2\x86\xc4\x46\x16\xc2',
+                    ),
+                    ],
+                ),
+                ],
+            ),
+        )
         msg.append_avp(avp.AVP('Auth-Session-State', 1))
 
         # Host identifiers
@@ -184,7 +216,6 @@ class S6AApplicationTests(unittest.TestCase):
 
         self._check_reply(req_buf, resp_buf)
 
-
     def test_resync(self):
         """
         Test that we can respond to auth requests with an auth
@@ -194,16 +225,24 @@ class S6AApplicationTests(unittest.TestCase):
         msg.header.application_id = s6a.S6AApplication.APP_ID
         msg.header.command_code = s6a.S6AApplicationCommands.AUTHENTICATION_INFORMATION
         msg.header.request = True
-        msg.append_avp(avp.AVP('Session-Id',
-            'enb-Lenovo-Product.openair4G.eur;1475864727;1;apps6a'))
+        msg.append_avp(
+            avp.AVP(
+                'Session-Id',
+                'enb-Lenovo-Product.openair4G.eur;1475864727;1;apps6a',
+            ),
+        )
         msg.append_avp(avp.AVP('Auth-Session-State', 1))
         msg.append_avp(avp.AVP('User-Name', '1'))
         msg.append_avp(avp.AVP('Visited-PLMN-Id', b'(Y'))
-        msg.append_avp(avp.AVP('Requested-EUTRAN-Authentication-Info', [
-            avp.AVP('Number-Of-Requested-Vectors', 1),
-            avp.AVP('Immediate-Response-Preferred', 0),
-            avp.AVP('Re-Synchronization-Info', 30*b'\x00')
-        ]))
+        msg.append_avp(
+            avp.AVP(
+                'Requested-EUTRAN-Authentication-Info', [
+                    avp.AVP('Number-Of-Requested-Vectors', 1),
+                    avp.AVP('Immediate-Response-Preferred', 0),
+                    avp.AVP('Re-Synchronization-Info', 30 * b'\x00'),
+                ],
+            ),
+        )
         # Encode request message into buffer
         req_buf = bytearray(msg.length)
         msg.encode(req_buf, 0)
@@ -211,8 +250,10 @@ class S6AApplicationTests(unittest.TestCase):
         processor = self._server._s6a_manager.lte_processor
         with unittest.mock.patch.object(processor, 'resync_lte_auth_seq'):
             self._server.data_received(req_buf)
-            processor.resync_lte_auth_seq.assert_called_once_with('1',
-                16*b'\x00', 14*b'\x00')
+            processor.resync_lte_auth_seq.assert_called_once_with(
+                '1',
+                16 * b'\x00', 14 * b'\x00',
+            )
 
     def test_auth_bad_key(self):
         """
@@ -222,15 +263,23 @@ class S6AApplicationTests(unittest.TestCase):
         msg.header.application_id = s6a.S6AApplication.APP_ID
         msg.header.command_code = s6a.S6AApplicationCommands.AUTHENTICATION_INFORMATION
         msg.header.request = True
-        msg.append_avp(avp.AVP('Session-Id',
-            'enb-Lenovo-Product.openair4G.eur;1475864727;1;apps6a'))
+        msg.append_avp(
+            avp.AVP(
+                'Session-Id',
+                'enb-Lenovo-Product.openair4G.eur;1475864727;1;apps6a',
+            ),
+        )
         msg.append_avp(avp.AVP('Auth-Session-State', 1))
         msg.append_avp(avp.AVP('User-Name', '2'))
         msg.append_avp(avp.AVP('Visited-PLMN-Id', b'(Y'))
-        msg.append_avp(avp.AVP('Requested-EUTRAN-Authentication-Info', [
-            avp.AVP('Number-Of-Requested-Vectors', 1),
-            avp.AVP('Immediate-Response-Preferred', 0),
-        ]))
+        msg.append_avp(
+            avp.AVP(
+                'Requested-EUTRAN-Authentication-Info', [
+                    avp.AVP('Number-Of-Requested-Vectors', 1),
+                    avp.AVP('Immediate-Response-Preferred', 0),
+                ],
+            ),
+        )
         # Encode request message into buffer
         req_buf = bytearray(msg.length)
         msg.encode(req_buf, 0)
@@ -240,8 +289,12 @@ class S6AApplicationTests(unittest.TestCase):
         msg.header.command_code = \
             s6a.S6AApplicationCommands.AUTHENTICATION_INFORMATION
         msg.header.request = False
-        msg.append_avp(avp.AVP('Session-Id',
-            'enb-Lenovo-Product.openair4G.eur;1475864727;1;apps6a'))
+        msg.append_avp(
+            avp.AVP(
+                'Session-Id',
+                'enb-Lenovo-Product.openair4G.eur;1475864727;1;apps6a',
+            ),
+        )
         msg.append_avp(avp.AVP('Auth-Session-State', 1))
 
         # Host identifiers
@@ -250,8 +303,12 @@ class S6AApplicationTests(unittest.TestCase):
         msg.append_avp(avp.AVP('Origin-State-Id', self._server.state_id))
 
         # Response result
-        msg.append_avp(avp.AVP('Result-Code',
-            avp.ResultCode.DIAMETER_AUTHENTICATION_REJECTED))
+        msg.append_avp(
+            avp.AVP(
+                'Result-Code',
+                avp.ResultCode.DIAMETER_AUTHENTICATION_REJECTED,
+            ),
+        )
         # Encode response into buffer
         resp_buf = bytearray(msg.length)
         msg.encode(resp_buf, 0)
@@ -265,15 +322,23 @@ class S6AApplicationTests(unittest.TestCase):
         msg.header.application_id = s6a.S6AApplication.APP_ID
         msg.header.command_code = s6a.S6AApplicationCommands.AUTHENTICATION_INFORMATION
         msg.header.request = True
-        msg.append_avp(avp.AVP('Session-Id',
-            'enb-Lenovo-Product.openair4G.eur;1475864727;1;apps6a'))
+        msg.append_avp(
+            avp.AVP(
+                'Session-Id',
+                'enb-Lenovo-Product.openair4G.eur;1475864727;1;apps6a',
+            ),
+        )
         msg.append_avp(avp.AVP('Auth-Session-State', 1))
         msg.append_avp(avp.AVP('User-Name', '3'))
         msg.append_avp(avp.AVP('Visited-PLMN-Id', b'(Y'))
-        msg.append_avp(avp.AVP('Requested-EUTRAN-Authentication-Info', [
-            avp.AVP('Number-Of-Requested-Vectors', 1),
-            avp.AVP('Immediate-Response-Preferred', 0),
-        ]))
+        msg.append_avp(
+            avp.AVP(
+                'Requested-EUTRAN-Authentication-Info', [
+                    avp.AVP('Number-Of-Requested-Vectors', 1),
+                    avp.AVP('Immediate-Response-Preferred', 0),
+                ],
+            ),
+        )
         # Encode request message into buffer
         req_buf = bytearray(msg.length)
         msg.encode(req_buf, 0)
@@ -283,8 +348,12 @@ class S6AApplicationTests(unittest.TestCase):
         msg.header.command_code = \
             s6a.S6AApplicationCommands.AUTHENTICATION_INFORMATION
         msg.header.request = False
-        msg.append_avp(avp.AVP('Session-Id',
-            'enb-Lenovo-Product.openair4G.eur;1475864727;1;apps6a'))
+        msg.append_avp(
+            avp.AVP(
+                'Session-Id',
+                'enb-Lenovo-Product.openair4G.eur;1475864727;1;apps6a',
+            ),
+        )
         msg.append_avp(avp.AVP('Auth-Session-State', 1))
 
         # Host identifiers
@@ -293,8 +362,12 @@ class S6AApplicationTests(unittest.TestCase):
         msg.append_avp(avp.AVP('Origin-State-Id', self._server.state_id))
 
         # Response result
-        msg.append_avp(avp.AVP('Result-Code',
-            avp.ResultCode.DIAMETER_ERROR_USER_UNKNOWN))
+        msg.append_avp(
+            avp.AVP(
+                'Result-Code',
+                avp.ResultCode.DIAMETER_ERROR_USER_UNKNOWN,
+            ),
+        )
         # Encode response into buffer
         resp_buf = bytearray(msg.length)
         msg.encode(resp_buf, 0)
@@ -309,8 +382,12 @@ class S6AApplicationTests(unittest.TestCase):
         msg.header.application_id = s6a.S6AApplication.APP_ID
         msg.header.command_code = s6a.S6AApplicationCommands.UPDATE_LOCATION
         msg.header.request = True
-        msg.append_avp(avp.AVP('Session-Id',
-            'enb-Lenovo-Product.openair4G.eur;1475864727;1;apps6a'))
+        msg.append_avp(
+            avp.AVP(
+                'Session-Id',
+                'enb-Lenovo-Product.openair4G.eur;1475864727;1;apps6a',
+            ),
+        )
         msg.append_avp(avp.AVP('Auth-Session-State', 1))
         msg.append_avp(avp.AVP('User-Name', '208950000000001'))
         msg.append_avp(avp.AVP('Visited-PLMN-Id', b'(Y'))
@@ -324,40 +401,60 @@ class S6AApplicationTests(unittest.TestCase):
         msg.header.application_id = s6a.S6AApplication.APP_ID
         msg.header.command_code = s6a.S6AApplicationCommands.UPDATE_LOCATION
         msg.header.request = False
-        msg.append_avp(avp.AVP('Session-Id',
-            'enb-Lenovo-Product.openair4G.eur;1475864727;1;apps6a'))
+        msg.append_avp(
+            avp.AVP(
+                'Session-Id',
+                'enb-Lenovo-Product.openair4G.eur;1475864727;1;apps6a',
+            ),
+        )
         msg.append_avp(avp.AVP('ULA-Flags', 1))
-        msg.append_avp(avp.AVP('Subscription-Data', [
-            avp.AVP('MSISDN', b'333608050011'),
-            avp.AVP('Access-Restriction-Data', 47),
-            avp.AVP('Subscriber-Status', 0),
-            avp.AVP('Network-Access-Mode', 2),
-            avp.AVP('AMBR', [
-                avp.AVP('Max-Requested-Bandwidth-UL', 10000),
-                avp.AVP('Max-Requested-Bandwidth-DL', 50000),
-            ]),
-            avp.AVP('APN-Configuration-Profile', [
-                avp.AVP('Context-Identifier', 0),
-                avp.AVP('All-APN-Configurations-Included-Indicator', 0),
-                avp.AVP('APN-Configuration', [
-                    avp.AVP('Context-Identifier', 0),
-                    avp.AVP('PDN-Type', 0),
-                    avp.AVP('Service-Selection', 'oai.ipv4'),
-                    avp.AVP('EPS-Subscribed-QoS-Profile', [
-                        avp.AVP('QoS-Class-Identifier', 9),
-                        avp.AVP('Allocation-Retention-Priority', [
-                            avp.AVP('Priority-Level', 15),
-                            avp.AVP('Pre-emption-Capability', 1),
-                            avp.AVP('Pre-emption-Vulnerability', 0),
-                        ]),
-                    ]),
-                    avp.AVP('AMBR', [
-                        avp.AVP('Max-Requested-Bandwidth-UL', 10000),
-                        avp.AVP('Max-Requested-Bandwidth-DL', 50000),
-                    ]),
-                ])
-            ]),
-        ]))
+        msg.append_avp(
+            avp.AVP(
+                'Subscription-Data', [
+                    avp.AVP('MSISDN', b'333608050011'),
+                    avp.AVP('Access-Restriction-Data', 47),
+                    avp.AVP('Subscriber-Status', 0),
+                    avp.AVP('Network-Access-Mode', 2),
+                    avp.AVP(
+                        'AMBR', [
+                            avp.AVP('Max-Requested-Bandwidth-UL', 10000),
+                            avp.AVP('Max-Requested-Bandwidth-DL', 50000),
+                        ],
+                    ),
+                    avp.AVP(
+                        'APN-Configuration-Profile', [
+                            avp.AVP('Context-Identifier', 0),
+                            avp.AVP('All-APN-Configurations-Included-Indicator', 0),
+                            avp.AVP(
+                                'APN-Configuration', [
+                                    avp.AVP('Context-Identifier', 0),
+                                    avp.AVP('PDN-Type', 0),
+                                    avp.AVP('Service-Selection', 'oai.ipv4'),
+                                    avp.AVP(
+                                        'EPS-Subscribed-QoS-Profile', [
+                                            avp.AVP('QoS-Class-Identifier', 9),
+                                            avp.AVP(
+                                                'Allocation-Retention-Priority', [
+                                                    avp.AVP('Priority-Level', 15),
+                                                    avp.AVP('Pre-emption-Capability', 1),
+                                                    avp.AVP('Pre-emption-Vulnerability', 0),
+                                                ],
+                                            ),
+                                        ],
+                                    ),
+                                    avp.AVP(
+                                        'AMBR', [
+                                            avp.AVP('Max-Requested-Bandwidth-UL', 10000),
+                                            avp.AVP('Max-Requested-Bandwidth-DL', 50000),
+                                        ],
+                                    ),
+                                ],
+                            ),
+                        ],
+                    ),
+                ],
+            ),
+        )
         msg.append_avp(avp.AVP('Auth-Session-State', 1))
 
         # Host identifiers

--- a/lte/gateway/python/magma/subscriberdb/tests/protocols/diameter/s6a_relay_tests.py
+++ b/lte/gateway/python/magma/subscriberdb/tests/protocols/diameter/s6a_relay_tests.py
@@ -51,7 +51,9 @@ class S6AApplicationTests(unittest.TestCase):
             'proxy_cloud_connections': True,
         }
 
-        self._base_manager = base.BaseApplication(self.REALM, self.HOST, self.HOST_ADDR)
+        self._base_manager = base.BaseApplication(
+            self.REALM, self.HOST, self.HOST_ADDR,
+        )
         self._proxy_client = Mock()
         self._s6a_manager = s6a_relay.S6ARelayApplication(
             Mock(),
@@ -70,7 +72,7 @@ class S6AApplicationTests(unittest.TestCase):
         self.get_proxy_config_patcher = patch.object(
             s6a_relay.ServiceRegistry,
             'get_proxy_config',
-            Mock(return_value=proxy_config)
+            Mock(return_value=proxy_config),
         )
         self.mock_get_proxy_config = self.get_proxy_config_patcher.start()
         self.addCleanup(self.get_proxy_config_patcher.stop)
@@ -89,21 +91,35 @@ class S6AApplicationTests(unittest.TestCase):
         self._server.connection_made(self._transport)
 
     @staticmethod
-    def _auth_req(user_name, visited_plmn_id, num_request_vectors, immediate_response_preferred, resync_info):
+    def _auth_req(
+        user_name, visited_plmn_id, num_request_vectors,
+        immediate_response_preferred, resync_info,
+    ):
         msg = message.Message()
         msg.header.application_id = s6a.S6AApplication.APP_ID
         msg.header.command_code = s6a.S6AApplicationCommands.AUTHENTICATION_INFORMATION
         msg.header.request = True
-        msg.append_avp(avp.AVP('Session-Id',
-            'enb-Lenovo-Product.openair4G.eur;1475864727;1;apps6a'))
+        msg.append_avp(
+            avp.AVP(
+                'Session-Id',
+                'enb-Lenovo-Product.openair4G.eur;1475864727;1;apps6a',
+            ),
+        )
         msg.append_avp(avp.AVP('Auth-Session-State', 1))
         msg.append_avp(avp.AVP('User-Name', user_name))
         msg.append_avp(avp.AVP('Visited-PLMN-Id', visited_plmn_id))
-        msg.append_avp(avp.AVP('Requested-EUTRAN-Authentication-Info', [
-            avp.AVP('Number-Of-Requested-Vectors', num_request_vectors),
-            avp.AVP('Immediate-Response-Preferred', 1 if immediate_response_preferred else 0),
-            avp.AVP('Re-Synchronization-Info', resync_info),
-        ]))
+        msg.append_avp(
+            avp.AVP(
+                'Requested-EUTRAN-Authentication-Info', [
+                    avp.AVP('Number-Of-Requested-Vectors', num_request_vectors),
+                    avp.AVP(
+                        'Immediate-Response-Preferred',
+                        1 if immediate_response_preferred else 0,
+                    ),
+                    avp.AVP('Re-Synchronization-Info', resync_info),
+                ],
+            ),
+        )
         return msg
 
     @staticmethod
@@ -112,8 +128,12 @@ class S6AApplicationTests(unittest.TestCase):
         msg.header.application_id = s6a.S6AApplication.APP_ID
         msg.header.command_code = s6a.S6AApplicationCommands.UPDATE_LOCATION
         msg.header.request = True
-        msg.append_avp(avp.AVP('Session-Id',
-                               'enb-Lenovo-Product.openair4G.eur;1475864727;1;apps6a'))
+        msg.append_avp(
+            avp.AVP(
+                'Session-Id',
+                'enb-Lenovo-Product.openair4G.eur;1475864727;1;apps6a',
+            ),
+        )
         msg.append_avp(avp.AVP('Auth-Session-State', 1))
         msg.append_avp(avp.AVP('User-Name', user_name))
         msg.append_avp(avp.AVP('Visited-PLMN-Id', visited_plmn_id))
@@ -127,7 +147,9 @@ class S6AApplicationTests(unittest.TestCase):
         """
         # Mock out Collect.future
         result = Mock()
-        self._proxy_client.AuthenticationInformation.future.side_effect = [result]
+        self._proxy_client.AuthenticationInformation.future.side_effect = [
+            result,
+        ]
 
         user_name = '1'
         visited_plmn_id = b'(Y'
@@ -135,7 +157,13 @@ class S6AApplicationTests(unittest.TestCase):
         immediate_response_preferred = True
         resync_info = b'123456789'
 
-        req = self._auth_req(user_name, visited_plmn_id, num_request_vectors, immediate_response_preferred, resync_info)
+        req = self._auth_req(
+            user_name,
+            visited_plmn_id,
+            num_request_vectors,
+            immediate_response_preferred,
+            resync_info,
+        )
         # Encode request message into buffer
         req_buf = bytearray(req.length)
         req.encode(req_buf, 0)
@@ -145,7 +173,7 @@ class S6AApplicationTests(unittest.TestCase):
             visited_plmn=visited_plmn_id,
             num_requested_eutran_vectors=num_request_vectors,
             immediate_response_preferred=immediate_response_preferred,
-            resync_info=resync_info
+            resync_info=resync_info,
         )
 
         self._server.data_received(req_buf)
@@ -166,21 +194,34 @@ class S6AApplicationTests(unittest.TestCase):
         num_request_vectors = 2
         immediate_response_preferred = True
         resync_info = b'123456789'
-        req = self._auth_req(user_name, visited_plmn_id, num_request_vectors, immediate_response_preferred, resync_info)
+        req = self._auth_req(
+            user_name,
+            visited_plmn_id,
+            num_request_vectors,
+            immediate_response_preferred,
+            resync_info,
+        )
 
         # response
         rand = b'rand'
         xres = b'xres'
         autn = b'autn'
         kasme = b'kasme'
-        auth_info = avp.AVP('Authentication-Info', [
-            avp.AVP('E-UTRAN-Vector', [
-                avp.AVP('RAND', rand),
-                avp.AVP('XRES', xres),
-                avp.AVP('AUTN', autn),
-                avp.AVP('KASME', kasme)])] * num_request_vectors
-                            )
-        resp = self._server._s6a_manager._gen_response(state_id, req, avp.ResultCode.DIAMETER_SUCCESS, [auth_info])
+        auth_info = avp.AVP(
+            'Authentication-Info', [
+                avp.AVP(
+                    'E-UTRAN-Vector', [
+                    avp.AVP('RAND', rand),
+                    avp.AVP('XRES', xres),
+                    avp.AVP('AUTN', autn),
+                    avp.AVP('KASME', kasme),
+                    ],
+                ),
+            ] * num_request_vectors,
+        )
+        resp = self._server._s6a_manager._gen_response(
+            state_id, req, avp.ResultCode.DIAMETER_SUCCESS, [auth_info],
+        )
         resp_buf = bytearray(resp.length)
         resp.encode(resp_buf, 0)
 
@@ -191,14 +232,17 @@ class S6AApplicationTests(unittest.TestCase):
                     rand=rand,
                     xres=xres,
                     autn=autn,
-                    kasme=kasme
-                ) ] * num_request_vectors
+                    kasme=kasme,
+                ),
+            ] * num_request_vectors,
         )
         result_future = unittest.mock.Mock()
         result_future.exception.side_effect = [None]
         result_future.result.side_effect = [result]
 
-        self._server._s6a_manager._relay_auth_answer(state_id, req, result_future, 0)
+        self._server._s6a_manager._relay_auth_answer(
+            state_id, req, result_future, 0,
+        )
         self._writes.assert_called_once_with(resp_buf)
         self._writes.reset_mock()
 
@@ -213,11 +257,22 @@ class S6AApplicationTests(unittest.TestCase):
         immediate_response_preferred = True
         resync_info = b'123456789'
 
-        result_info = avp.AVP('Experimental-Result', [
+        result_info = avp.AVP(
+            'Experimental-Result', [
             avp.AVP('Vendor-Id', 10415),
-            avp.AVP('Experimental-Result-Code', avp.ResultCode.DIAMETER_ERROR_USER_UNKNOWN)])
-        req = self._auth_req(user_name, visited_plmn_id, num_request_vectors, immediate_response_preferred, resync_info)
-        resp = self._server._s6a_manager._gen_response(state_id, req, avp.ResultCode.DIAMETER_ERROR_USER_UNKNOWN, [result_info])
+            avp.AVP('Experimental-Result-Code', avp.ResultCode.DIAMETER_ERROR_USER_UNKNOWN),
+            ],
+        )
+        req = self._auth_req(
+            user_name,
+            visited_plmn_id,
+            num_request_vectors,
+            immediate_response_preferred,
+            resync_info,
+        )
+        resp = self._server._s6a_manager._gen_response(
+            state_id, req, avp.ResultCode.DIAMETER_ERROR_USER_UNKNOWN, [result_info],
+        )
         resp_buf = bytearray(resp.length)
         resp.encode(resp_buf, 0)
 
@@ -228,7 +283,9 @@ class S6AApplicationTests(unittest.TestCase):
         result_future.exception.side_effect = [None]
         result_future.result.side_effect = [result]
 
-        self._server._s6a_manager._relay_auth_answer(state_id, req, result_future, 0)
+        self._server._s6a_manager._relay_auth_answer(
+            state_id, req, result_future, 0,
+        )
         self._writes.assert_called_once_with(resp_buf)
         self._writes.reset_mock()
 
@@ -243,8 +300,16 @@ class S6AApplicationTests(unittest.TestCase):
         immediate_response_preferred = True
         resync_info = b'123456789'
 
-        req = self._auth_req(user_name, visited_plmn_id, num_request_vectors, immediate_response_preferred, resync_info)
-        resp = self._server._s6a_manager._gen_response(state_id, req, avp.ResultCode.DIAMETER_UNABLE_TO_COMPLY, [])
+        req = self._auth_req(
+            user_name,
+            visited_plmn_id,
+            num_request_vectors,
+            immediate_response_preferred,
+            resync_info,
+        )
+        resp = self._server._s6a_manager._gen_response(
+            state_id, req, avp.ResultCode.DIAMETER_UNABLE_TO_COMPLY, [],
+        )
         resp_buf = bytearray(resp.length)
         resp.encode(resp_buf, 0)
 
@@ -255,7 +320,9 @@ class S6AApplicationTests(unittest.TestCase):
         result_future.exception.side_effect = [grpc_error]
         result_future.result.side_effect = [None]
 
-        self._server._s6a_manager._relay_auth_answer(state_id, req, result_future, 0)
+        self._server._s6a_manager._relay_auth_answer(
+            state_id, req, result_future, 0,
+        )
         self._writes.assert_called_once_with(resp_buf)
         self._writes.reset_mock()
 
@@ -280,11 +347,13 @@ class S6AApplicationTests(unittest.TestCase):
             user_name=user_name,
             visited_plmn=visited_plmn_id,
             skip_subscriber_data=True,
-            initial_attach=True
+            initial_attach=True,
         )
 
         self._server.data_received(req_buf)
-        self.assertEqual(self._proxy_client.UpdateLocation.future.call_count, 1)
+        self.assertEqual(
+            self._proxy_client.UpdateLocation.future.call_count, 1,
+        )
         req, _ = self._proxy_client.UpdateLocation.future.call_args
         self.assertEqual(repr(exp_request), repr(req[0]))
 
@@ -305,51 +374,105 @@ class S6AApplicationTests(unittest.TestCase):
         req_buf = bytearray(req.length)
         req.encode(req_buf, 0)
 
-        apns = [{'context_id': i,
-                 'service_selection': 'apn.%d' % i,
-                 'qos_profile': {
-                     'class_id': i,
-                     'priority_level': i,
-                     'preemption_capability': True if i % 2 else False,
-                     'preemption_vulnerability': False if i % 2 else True},
-                 'ambr': {
-                     'ul': 1000 * i,
-                     'dl': 2000 * i},
-                 } for i in range(2)]
+        apns = [{
+            'context_id': i,
+            'service_selection': 'apn.%d' % i,
+            'qos_profile': {
+                'class_id': i,
+                'priority_level': i,
+                'preemption_capability': True if i % 2 else False,
+                'preemption_vulnerability': False if i % 2 else True,
+            },
+            'ambr': {
+                'ul': 1000 * i,
+                'dl': 2000 * i,
+            },
+        } for i in range(2)]
 
-        resp_avps = [avp.AVP('ULA-Flags', 1),
-                     avp.AVP('Subscription-Data', [
-            avp.AVP('MSISDN', b'333608050011'),
-            avp.AVP('Access-Restriction-Data', 47),
-            avp.AVP('Subscriber-Status', 0),
-            avp.AVP('Network-Access-Mode', 2),
-            avp.AVP('AMBR', [
-                avp.AVP('Max-Requested-Bandwidth-UL', total_ambr['ul']),
-                avp.AVP('Max-Requested-Bandwidth-DL', total_ambr['dl']),
-            ]),
-            avp.AVP('APN-Configuration-Profile', [
-                avp.AVP('Context-Identifier', default_context_id),
-                avp.AVP('All-APN-Configurations-Included-Indicator', 1 if all_apns_included else 0),
-                *[avp.AVP('APN-Configuration', [
-                    avp.AVP('Context-Identifier', apn['context_id']),
-                    avp.AVP('PDN-Type', 0),
-                    avp.AVP('Service-Selection', apn['service_selection']),
-                    avp.AVP('EPS-Subscribed-QoS-Profile', [
-                        avp.AVP('QoS-Class-Identifier', apn['qos_profile']['class_id']),
-                        avp.AVP('Allocation-Retention-Priority', [
-                            avp.AVP('Priority-Level', apn['qos_profile']['priority_level']),
-                            avp.AVP('Pre-emption-Capability', apn['qos_profile']['preemption_capability']),
-                            avp.AVP('Pre-emption-Vulnerability', apn['qos_profile']['preemption_vulnerability']),
-                        ]),
-                    ]),
-                    avp.AVP('AMBR', [
-                        avp.AVP('Max-Requested-Bandwidth-UL', apn['ambr']['ul']),
-                        avp.AVP('Max-Requested-Bandwidth-DL', apn['ambr']['dl']),
-                    ]),
-                ]) for apn in apns]
-            ]),
-        ])]
-        resp = self._server._s6a_manager._gen_response(state_id, req, avp.ResultCode.DIAMETER_SUCCESS, resp_avps)
+        resp_avps = [
+            avp.AVP('ULA-Flags', 1),
+            avp.AVP(
+                'Subscription-Data', [
+                    avp.AVP('MSISDN', b'333608050011'),
+                    avp.AVP('Access-Restriction-Data', 47),
+                    avp.AVP('Subscriber-Status', 0),
+                    avp.AVP('Network-Access-Mode', 2),
+                    avp.AVP(
+                        'AMBR', [
+                            avp.AVP(
+                                'Max-Requested-Bandwidth-UL',
+                                total_ambr['ul'],
+                            ),
+                            avp.AVP(
+                                'Max-Requested-Bandwidth-DL',
+                                total_ambr['dl'],
+                            ),
+                        ],
+                    ),
+                    avp.AVP(
+                        'APN-Configuration-Profile', [
+                            avp.AVP('Context-Identifier', default_context_id),
+                            avp.AVP(
+                                'All-APN-Configurations-Included-Indicator',
+                                1 if all_apns_included else 0,
+                            ),
+                            *[
+                                avp.AVP(
+                                    'APN-Configuration', [
+                                        avp.AVP(
+                                            'Context-Identifier', apn['context_id'],
+                                        ),
+                                        avp.AVP('PDN-Type', 0),
+                                        avp.AVP(
+                                            'Service-Selection', apn['service_selection'],
+                                        ),
+                                        avp.AVP(
+                                            'EPS-Subscribed-QoS-Profile', [
+                                                avp.AVP(
+                                                    'QoS-Class-Identifier',
+                                                    apn['qos_profile']['class_id'],
+                                                ),
+                                                avp.AVP(
+                                                    'Allocation-Retention-Priority', [
+                                                        avp.AVP(
+                                                            'Priority-Level',
+                                                            apn['qos_profile']['priority_level'],
+                                                        ),
+                                                        avp.AVP(
+                                                            'Pre-emption-Capability',
+                                                            apn['qos_profile']['preemption_capability'],
+                                                        ),
+                                                        avp.AVP(
+                                                            'Pre-emption-Vulnerability',
+                                                            apn['qos_profile']['preemption_vulnerability'],
+                                                        ),
+                                                    ],
+                                                ),
+                                            ],
+                                        ),
+                                        avp.AVP(
+                                            'AMBR', [
+                                                avp.AVP(
+                                                    'Max-Requested-Bandwidth-UL',
+                                                    apn['ambr']['ul'],
+                                                ),
+                                                avp.AVP(
+                                                    'Max-Requested-Bandwidth-DL',
+                                                    apn['ambr']['dl'],
+                                                ),
+                                            ],
+                                        ),
+                                    ],
+                                ) for apn in apns
+                            ],
+                        ],
+                    ),
+                ],
+            ),
+        ]
+        resp = self._server._s6a_manager._gen_response(
+            state_id, req, avp.ResultCode.DIAMETER_SUCCESS, resp_avps,
+        )
         resp_buf = bytearray(resp.length)
         resp.encode(resp_buf, 0)
 
@@ -358,11 +481,12 @@ class S6AApplicationTests(unittest.TestCase):
             default_context_id=default_context_id,
             total_ambr=UpdateLocationAnswer.AggregatedMaximumBitrate(
                 max_bandwidth_ul=total_ambr['ul'],
-                max_bandwidth_dl=total_ambr['dl']
+                max_bandwidth_dl=total_ambr['dl'],
             ),
             msisdn=b'333608050011',
             all_apns_included=all_apns_included,
-            apn=[UpdateLocationAnswer.APNConfiguration(
+            apn=[
+                UpdateLocationAnswer.APNConfiguration(
                     context_id=apn['context_id'],
                     service_selection=apn['service_selection'],
                     qos_profile=UpdateLocationAnswer.APNConfiguration.QoSProfile(
@@ -376,13 +500,16 @@ class S6AApplicationTests(unittest.TestCase):
                         max_bandwidth_dl=apn['ambr']['dl'],
                     ),
                     pdn=UpdateLocationAnswer.APNConfiguration.IPV4,
-                ) for apn in apns]
+                ) for apn in apns
+            ],
         )
         result_future = unittest.mock.Mock()
         result_future.exception.side_effect = [None]
         result_future.result.side_effect = [result]
 
-        self._server._s6a_manager._relay_update_location_answer(state_id, req, result_future, 0)
+        self._server._s6a_manager._relay_update_location_answer(
+            state_id, req, result_future, 0,
+        )
         self._writes.assert_called_once_with(resp_buf)
         self._writes.reset_mock()
 
@@ -400,10 +527,15 @@ class S6AApplicationTests(unittest.TestCase):
         req_buf = bytearray(req.length)
         req.encode(req_buf, 0)
 
-        result_info = avp.AVP('Experimental-Result', [
+        result_info = avp.AVP(
+            'Experimental-Result', [
             avp.AVP('Vendor-Id', 10415),
-            avp.AVP('Experimental-Result-Code', avp.ResultCode.DIAMETER_ERROR_USER_UNKNOWN)])
-        resp = self._server._s6a_manager._gen_response(state_id, req, avp.ResultCode.DIAMETER_ERROR_USER_UNKNOWN, [result_info])
+            avp.AVP('Experimental-Result-Code', avp.ResultCode.DIAMETER_ERROR_USER_UNKNOWN),
+            ],
+        )
+        resp = self._server._s6a_manager._gen_response(
+            state_id, req, avp.ResultCode.DIAMETER_ERROR_USER_UNKNOWN, [result_info],
+        )
         resp_buf = bytearray(resp.length)
         resp.encode(resp_buf, 0)
 
@@ -414,7 +546,9 @@ class S6AApplicationTests(unittest.TestCase):
         result_future.exception.side_effect = [None]
         result_future.result.side_effect = [result]
 
-        self._server._s6a_manager._relay_update_location_answer(state_id, req, result_future, 0)
+        self._server._s6a_manager._relay_update_location_answer(
+            state_id, req, result_future, 0,
+        )
         self._writes.assert_called_once_with(resp_buf)
         self._writes.reset_mock()
 
@@ -432,7 +566,9 @@ class S6AApplicationTests(unittest.TestCase):
         req_buf = bytearray(req.length)
         req.encode(req_buf, 0)
 
-        resp = self._server._s6a_manager._gen_response(state_id, req, avp.ResultCode.DIAMETER_UNABLE_TO_COMPLY, [])
+        resp = self._server._s6a_manager._gen_response(
+            state_id, req, avp.ResultCode.DIAMETER_UNABLE_TO_COMPLY, [],
+        )
         resp_buf = bytearray(resp.length)
         resp.encode(resp_buf, 0)
 
@@ -443,7 +579,9 @@ class S6AApplicationTests(unittest.TestCase):
         result_future.exception.side_effect = [grpc_error]
         result_future.result.side_effect = [None]
 
-        self._server._s6a_manager._relay_update_location_answer(state_id, req, result_future, 0)
+        self._server._s6a_manager._relay_update_location_answer(
+            state_id, req, result_future, 0,
+        )
         self._writes.assert_called_once_with(resp_buf)
         self._writes.reset_mock()
 

--- a/lte/gateway/python/magma/subscriberdb/tests/protocols/diameter/server_tests.py
+++ b/lte/gateway/python/magma/subscriberdb/tests/protocols/diameter/server_tests.py
@@ -28,10 +28,12 @@ class ServerTests(unittest.TestCase):
 
     def setUp(self):
 
-        self._server = server.S6aServer(Mock(),
-                                        Mock(),
-                                        "mai.facebook.com",
-                                        "hss.mai.facebook.com")
+        self._server = server.S6aServer(
+            Mock(),
+            Mock(),
+            "mai.facebook.com",
+            "hss.mai.facebook.com",
+        )
 
         # Mock the message handler
         self._server._handle_msg = Mock()
@@ -68,8 +70,10 @@ class ServerTests(unittest.TestCase):
                 offset += step
             self.assertTrue(self._server._handle_msg.called)
             # pylint:disable=unsubscriptable-object
-            self.assertEqual(self._server._handle_msg.call_args[0][0],
-                             application_id)
+            self.assertEqual(
+                self._server._handle_msg.call_args[0][0],
+                application_id,
+            )
             self._server._handle_msg.reset_mock()
 
     def test_application_dispatch(self):
@@ -116,10 +120,12 @@ class WriterTests(unittest.TestCase):
         self._transport = MockTransport()
         self._transport.write = Mock(side_effect=convert_memview_to_bytes)
 
-        self.writer = server.Writer("mai.facebook.com",
-                                     "hss.mai.facebook.com",
-                                     "127.0.0.1",
-                                     self._transport)
+        self.writer = server.Writer(
+            "mai.facebook.com",
+            "hss.mai.facebook.com",
+            "127.0.0.1",
+            self._transport,
+        )
 
     def test_send_msg(self):
         """Test that the writer will encode a message and write
@@ -129,7 +135,8 @@ class WriterTests(unittest.TestCase):
         self._writes.assert_called_once_with(
             b'\x01\x00\x00\x14'
             b'\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
-            b'\x00\x00\x00')
+            b'\x00\x00\x00',
+        )
         self._writes.reset_mock()
 
     def test_gen_buf(self):

--- a/lte/gateway/python/magma/subscriberdb/tests/rpc_tests.py
+++ b/lte/gateway/python/magma/subscriberdb/tests/rpc_tests.py
@@ -32,11 +32,11 @@ class RpcTests(unittest.TestCase):
     def setUp(self):
         # Create an in-memory store
         self._tmpfile = tempfile.TemporaryDirectory()
-        store = SqliteStore(self._tmpfile.name +'/')
+        store = SqliteStore(self._tmpfile.name + '/')
 
         # Bind the rpc server to a free port
         self._rpc_server = grpc.server(
-            futures.ThreadPoolExecutor(max_workers=10)
+            futures.ThreadPoolExecutor(max_workers=10),
         )
         port = self._rpc_server.add_insecure_port('0.0.0.0:0')
 

--- a/lte/gateway/python/magma/subscriberdb/tests/store/cached_store_tests.py
+++ b/lte/gateway/python/magma/subscriberdb/tests/store/cached_store_tests.py
@@ -33,7 +33,7 @@ class StoreTests(unittest.TestCase):
     def setUp(self):
         cache_size = 3
         self._tmpfile = tempfile.TemporaryDirectory()
-        sqlite = SqliteStore(self._tmpfile.name +'/')
+        sqlite = SqliteStore(self._tmpfile.name + '/')
         self._store = CachedStore(sqlite, cache_size)
 
     def tearDown(self):
@@ -115,8 +115,10 @@ class StoreTests(unittest.TestCase):
         # Update from cache
         with self._store.edit_subscriber(sid1) as subs:
             subs.lte.auth_key = b'5678'
-        self.assertEqual(self._store.get_subscriber_data(sid1).lte.auth_key,
-                         b'5678')
+        self.assertEqual(
+            self._store.get_subscriber_data(sid1).lte.auth_key,
+            b'5678',
+        )
         self.assertEqual(self._store._cache_list(), [sid1])
 
         # Update from persistent store after eviction
@@ -126,8 +128,10 @@ class StoreTests(unittest.TestCase):
         self.assertEqual(self._store._cache_list(), [sid2, sid3, sid4])
         with self._store.edit_subscriber(sid1) as subs:
             subs.lte.auth_key = b'2468'
-        self.assertEqual(self._store.get_subscriber_data(sid1).lte.auth_key,
-                         b'2468')
+        self.assertEqual(
+            self._store.get_subscriber_data(sid1).lte.auth_key,
+            b'2468',
+        )
         self.assertEqual(self._store._cache_list(), [sid3, sid4, sid1])
 
         with self.assertRaises(SubscriberNotFoundError):
@@ -150,10 +154,14 @@ class StoreTests(unittest.TestCase):
 
         subs = self._store.get_subscriber_data(sid1)
         self.assertEqual(subs.lte.auth_key, b'5678')  # config updated
-        self.assertEqual(subs.state.lte_auth_next_seq, 1000)  # state left intact
+        self.assertEqual(
+            subs.state.lte_auth_next_seq,
+            1000,
+        )  # state left intact
 
         with self.assertRaises(SubscriberNotFoundError):
-            self._store.get_subscriber_data(sid2)  # sub2 was removed during resync
+            # sub2 was removed during resync
+            self._store.get_subscriber_data(sid2)
 
     def test_lru_cache_invl(self):
         """

--- a/lte/gateway/python/magma/subscriberdb/tests/store/onready_test.py
+++ b/lte/gateway/python/magma/subscriberdb/tests/store/onready_test.py
@@ -32,7 +32,7 @@ class OnReadyMixinTests(unittest.TestCase):
         cache_size = 3
         self.loop = asyncio.new_event_loop()
         self._tmpfile = tempfile.TemporaryDirectory()
-        sqlite = SqliteStore(self._tmpfile.name +'/', loop=self.loop)
+        sqlite = SqliteStore(self._tmpfile.name + '/', loop=self.loop)
         self._store = CachedStore(sqlite, cache_size, self.loop)
 
     def tearDown(self):
@@ -48,7 +48,9 @@ class OnReadyMixinTests(unittest.TestCase):
         Test if subscriber addition triggers ready
         """
         self.assertEqual(self._store._on_ready.event.is_set(), False)
-        self.assertEqual(self._store._persistent_store._on_ready.event.is_set(), False)
+        self.assertEqual(
+            self._store._persistent_store._on_ready.event.is_set(), False,
+        )
         self._add_subscriber('IMSI11111')
 
         async def defer():
@@ -56,15 +58,18 @@ class OnReadyMixinTests(unittest.TestCase):
         self.loop.run_until_complete(defer())
 
         self.assertEqual(self._store._on_ready.event.is_set(), True)
-        self.assertEqual(self._store._persistent_store._on_ready.event.is_set(), True)
-
+        self.assertEqual(
+            self._store._persistent_store._on_ready.event.is_set(), True,
+        )
 
     def test_resync(self):
         """
         Test if resync triggers ready
         """
         self.assertEqual(self._store._on_ready.event.is_set(), False)
-        self.assertEqual(self._store._persistent_store._on_ready.event.is_set(), False)
+        self.assertEqual(
+            self._store._persistent_store._on_ready.event.is_set(), False,
+        )
         self._store.resync([])
 
         async def defer():
@@ -72,4 +77,6 @@ class OnReadyMixinTests(unittest.TestCase):
         self.loop.run_until_complete(defer())
 
         self.assertEqual(self._store._on_ready.event.is_set(), True)
-        self.assertEqual(self._store._persistent_store._on_ready.event.is_set(), True)
+        self.assertEqual(
+            self._store._persistent_store._on_ready.event.is_set(), True,
+        )

--- a/lte/gateway/python/magma/subscriberdb/tests/store/store_tests.py
+++ b/lte/gateway/python/magma/subscriberdb/tests/store/store_tests.py
@@ -31,7 +31,7 @@ class StoreTests(unittest.TestCase):
     def setUp(self):
         # Create sqlite3 database for testing
         self._tmpfile = tempfile.TemporaryDirectory()
-        self._store = SqliteStore(self._tmpfile.name +'/')
+        self._store = SqliteStore(self._tmpfile.name + '/')
 
     def tearDown(self):
         self._tmpfile.cleanup()
@@ -100,13 +100,17 @@ class StoreTests(unittest.TestCase):
 
         sub1.lte.auth_key = b'1234'
         self._store.update_subscriber(sub1)
-        self.assertEqual(self._store.get_subscriber_data(sid1).lte.auth_key,
-                         b'1234')
+        self.assertEqual(
+            self._store.get_subscriber_data(sid1).lte.auth_key,
+            b'1234',
+        )
 
         with self._store.edit_subscriber(sid1) as subs:
             subs.lte.auth_key = b'5678'
-        self.assertEqual(self._store.get_subscriber_data(sid1).lte.auth_key,
-                         b'5678')
+        self.assertEqual(
+            self._store.get_subscriber_data(sid1).lte.auth_key,
+            b'5678',
+        )
 
         with self.assertRaises(SubscriberNotFoundError):
             sub1.sid.id = '30000'

--- a/lte/gateway/python/magma/subscriberdb/tests/streamer_callback_tests.py
+++ b/lte/gateway/python/magma/subscriberdb/tests/streamer_callback_tests.py
@@ -50,17 +50,24 @@ class SubscriberDBStreamerCallbackTests(unittest.TestCase):
     def setUp(self):
         # Create sqlite3 database for testing
         self._tmpfile = tempfile.TemporaryDirectory()
-        store = SqliteStore(self._tmpfile.name +'/')
+        store = SqliteStore(self._tmpfile.name + '/')
         self._streamer_callback = \
             SubscriberDBStreamerCallback(store, loop=asyncio.new_event_loop())
         ServiceRegistry.add_service('test', '0.0.0.0', 0)
-        ServiceRegistry._PROXY_CONFIG = {'local_port': 1234,
-                                         'cloud_address': '',
-                                         'proxy_cloud_connections': False}
-        ServiceRegistry._REGISTRY = {"services": {"s6a_service":
-                                                  {"ip_address": "0.0.0.0",
-                                                   "port": 2345}}
-                                     }
+        ServiceRegistry._PROXY_CONFIG = {
+            'local_port': 1234,
+            'cloud_address': '',
+            'proxy_cloud_connections': False,
+        }
+        ServiceRegistry._REGISTRY = {
+            "services": {
+                "s6a_service":
+                {
+                    "ip_address": "0.0.0.0",
+                    "port": 2345,
+                },
+            },
+        }
 
     def tearDown(self):
         self._tmpfile.cleanup()
@@ -78,19 +85,24 @@ class SubscriberDBStreamerCallbackTests(unittest.TestCase):
         # Call with no samples
         old_sub_ids = ["IMSI202", "IMSI101"]
         new_sub_ids = ["IMSI101", "IMSI202"]
-        self._streamer_callback.detach_deleted_subscribers(old_sub_ids,
-                                                           new_sub_ids)
+        self._streamer_callback.detach_deleted_subscribers(
+            old_sub_ids,
+            new_sub_ids,
+        )
         s6a_service_mock_stub.DeleteSubscriber.future.assert_not_called()
         self._streamer_callback._loop.stop()
 
         # Call with one subscriber id deleted
         old_sub_ids = ["IMSI202", "IMSI101", "IMSI303"]
         new_sub_ids = ["IMSI202"]
-        self._streamer_callback.detach_deleted_subscribers(old_sub_ids,
-                                                           new_sub_ids)
+        self._streamer_callback.detach_deleted_subscribers(
+            old_sub_ids,
+            new_sub_ids,
+        )
 
         mock.DeleteSubscriber.future.assert_called_once_with(
-            DeleteSubscriberRequest(imsi_list=["101", "303"]))
+            DeleteSubscriberRequest(imsi_list=["101", "303"]),
+        )
 
 
 if __name__ == "__main__":

--- a/lte/gateway/python/magma/tests/pylint_wrapper.py
+++ b/lte/gateway/python/magma/tests/pylint_wrapper.py
@@ -25,8 +25,10 @@ except (NotADirectoryError, ImportError, ModuleNotFoundError) as e:
 
 class PyLintWrapper():
 
-    def __init__(self, ignored_modules=None, ignored_classes=None,
-                 show_categories=None, disable_ids=None):
+    def __init__(
+        self, ignored_modules=None, ignored_classes=None,
+        show_categories=None, disable_ids=None,
+    ):
         def default(x, y):
             return x if x is not None else y
 
@@ -47,12 +49,18 @@ class PyLintWrapper():
     def run_pylint(self, path):
         with warnings.catch_warnings():
             # suppress this warnings from output
-            warnings.filterwarnings("ignore",
-                                    category=PendingDeprecationWarning)
-            warnings.filterwarnings("ignore",
-                                    category=DeprecationWarning)
-            warnings.filterwarnings("ignore",
-                                    category=ImportWarning)
+            warnings.filterwarnings(
+                "ignore",
+                category=PendingDeprecationWarning,
+            )
+            warnings.filterwarnings(
+                "ignore",
+                category=DeprecationWarning,
+            )
+            warnings.filterwarnings(
+                "ignore",
+                category=ImportWarning,
+            )
 
             linter = lint.PyLinter()
             # Register standard checkers.
@@ -80,7 +88,8 @@ class PyLintWrapper():
             msgs_for_module = [
                 "{}: {}, {}: {} ({})".format(
                     message.msg_id, message.line, message.column,
-                    message.msg, message.symbol) for message in errors
+                    message.msg, message.symbol,
+                ) for message in errors
             ]
             msg += "************* Module {}\n".format(module)
             msg += "\n".join(msgs_for_module) + "\n"


### PR DESCRIPTION
Signed-off-by: Marie Bremner <marwhal@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary
same deal as https://github.com/magma/magma/pull/7256 but with lte/gateway/python/magma minus enodebd/pipelined

(ommiting pipelined as it's owned by a different set of people, and enodebd had too many changes)

I keep noticing that running formatter script for Python PRs results in unrelated lines being formatted as well. This is annoying, so going ahead and running the formatter on magma services in lte. (Trying to get it in chunks so that we have small PRs) 
<!-- Enumerate changes you made and why you made them -->

## Test Plan
./precommit.py -f -p lte/gateway/python/magma
git add + commit

CI checks for unit tests

locally ran `make test` in agw VM
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->