### PR TITLE
[MobilityD] Remove unused imports

### DIFF
--- a/lte/gateway/python/magma/mobilityd/ip_allocator_base.py
+++ b/lte/gateway/python/magma/mobilityd/ip_allocator_base.py
@@ -34,8 +34,10 @@ class IPAllocator(ABC):
         ...
 
     @abstractmethod
-    def remove_ip_blocks(self, *ipblocks: List[ip_network],
-                         force: bool) -> List[ip_network]:
+    def remove_ip_blocks(
+        self, *ipblocks: List[ip_network],
+        force: bool
+    ) -> List[ip_network]:
         ...
 
     @abstractmethod

--- a/lte/gateway/python/magma/mobilityd/ip_allocator_base.py
+++ b/lte/gateway/python/magma/mobilityd/ip_allocator_base.py
@@ -22,7 +22,7 @@ from abc import ABC, abstractmethod
 from ipaddress import ip_address, ip_network
 from typing import List
 
-from magma.mobilityd.ip_descriptor import IPDesc, IPType
+from magma.mobilityd.ip_descriptor import IPDesc
 
 DEFAULT_IP_RECYCLE_INTERVAL = 15
 

--- a/lte/gateway/python/magma/mobilityd/ip_allocator_multi_apn.py
+++ b/lte/gateway/python/magma/mobilityd/ip_allocator_multi_apn.py
@@ -35,9 +35,11 @@ DEFAULT_IP_RECYCLE_INTERVAL = 15
 
 class IPAllocatorMultiAPNWrapper(IPAllocator):
 
-    def __init__(self, store: MobilityStore,
-                 subscriberdb_rpc_stub,
-                 ip_allocator: IPAllocator):
+    def __init__(
+        self, store: MobilityStore,
+        subscriberdb_rpc_stub,
+        ip_allocator: IPAllocator,
+    ):
         """ Initializes a Multi APN IP allocator
             This is wrapper around other configured Ip allocator. If subscriber
             has vlan configured in APN config, it would be used for allocating
@@ -54,8 +56,10 @@ class IPAllocatorMultiAPNWrapper(IPAllocator):
         """
         self._ip_allocator.add_ip_block(ipblock)
 
-    def remove_ip_blocks(self, ipblocks: List[ip_network],
-                         force: bool = False) -> List[ip_network]:
+    def remove_ip_blocks(
+        self, ipblocks: List[ip_network],
+        force: bool = False,
+    ) -> List[ip_network]:
         """ Remove allocated IP blocks.
         """
         return self._ip_allocator.remove_ip_blocks(ipblocks, force)
@@ -76,12 +80,16 @@ class IPAllocatorMultiAPNWrapper(IPAllocator):
         """ Check if subscriber has APN configuration and vlan.
         once we have APN specific info use IP allocator to assign an IP.
         """
-        network_info = self._subscriber_client.get_subscriber_apn_network_info(sid)
+        network_info = self._subscriber_client.get_subscriber_apn_network_info(
+            sid,
+        )
         # Update GW info from subscriber DB data.
         # This could be overwritten by DHCP response.
-        self._store.dhcp_gw_info.update_mac(network_info.gw_ip,
-                                            network_info.gw_mac,
-                                            network_info.vlan)
+        self._store.dhcp_gw_info.update_mac(
+            network_info.gw_ip,
+            network_info.gw_mac,
+            network_info.vlan,
+        )
         return self._ip_allocator.alloc_ip_address(sid, network_info.vlan)
 
     def release_ip(self, ip_desc: IPDesc):

--- a/lte/gateway/python/magma/mobilityd/ip_allocator_multi_apn.py
+++ b/lte/gateway/python/magma/mobilityd/ip_allocator_multi_apn.py
@@ -22,12 +22,11 @@ from __future__ import (
     unicode_literals,
 )
 
-import logging
 from ipaddress import ip_address, ip_network
 from typing import List
 
 from magma.mobilityd.ip_allocator_base import IPAllocator
-from magma.mobilityd.ip_descriptor import IPDesc, IPState, IPType
+from magma.mobilityd.ip_descriptor import IPDesc
 from magma.mobilityd.mobility_store import MobilityStore
 from magma.mobilityd.subscriberdb_client import SubscriberDbClient
 

--- a/lte/gateway/python/magma/mobilityd/ip_allocator_static.py
+++ b/lte/gateway/python/magma/mobilityd/ip_allocator_static.py
@@ -33,7 +33,7 @@ from magma.mobilityd.ip_allocator_base import (
 )
 from magma.mobilityd.ip_descriptor import IPDesc, IPState, IPType
 from magma.mobilityd.mobility_store import MobilityStore
-from magma.mobilityd.subscriberdb_client import StaticIPInfo, SubscriberDbClient
+from magma.mobilityd.subscriberdb_client import SubscriberDbClient
 
 DEFAULT_IP_RECYCLE_INTERVAL = 15
 

--- a/lte/gateway/python/magma/mobilityd/ip_allocator_static.py
+++ b/lte/gateway/python/magma/mobilityd/ip_allocator_static.py
@@ -40,9 +40,11 @@ DEFAULT_IP_RECYCLE_INTERVAL = 15
 
 class IPAllocatorStaticWrapper(IPAllocator):
 
-    def __init__(self, store: MobilityStore,
-                 subscriberdb_rpc_stub: SubscriberDBStub,
-                 ip_allocator: IPAllocator):
+    def __init__(
+        self, store: MobilityStore,
+        subscriberdb_rpc_stub: SubscriberDBStub,
+        ip_allocator: IPAllocator,
+    ):
         """ Initializes a static IP allocator
             This is wrapper around other configured Ip allocator. If subscriber
             does have static IP, it uses underlying IP allocator to allocate IP
@@ -57,8 +59,10 @@ class IPAllocatorStaticWrapper(IPAllocator):
         """
         self._ip_allocator.add_ip_block(ipblock)
 
-    def remove_ip_blocks(self, ipblocks: List[ip_network],
-                         force: bool = False) -> List[ip_network]:
+    def remove_ip_blocks(
+        self, ipblocks: List[ip_network],
+        force: bool = False,
+    ) -> List[ip_network]:
         """ Remove allocated IP blocks.
         """
         return self._ip_allocator.remove_ip_blocks(ipblocks, force)
@@ -90,8 +94,10 @@ class IPAllocatorStaticWrapper(IPAllocator):
         ip release
         """
         if ip_desc.type == IPType.STATIC:
-            self._store.ip_state_map.remove_ip_from_state(ip_desc.ip,
-                                                          IPState.FREE)
+            self._store.ip_state_map.remove_ip_from_state(
+                ip_desc.ip,
+                IPState.FREE,
+            )
             ip_block_network = ip_network(ip_desc.ip_block)
             if ip_block_network in self._store.assigned_ip_blocks:
                 self._store.assigned_ip_blocks.remove(ip_block_network)
@@ -106,27 +112,36 @@ class IPAllocatorStaticWrapper(IPAllocator):
         ip_addr_info = self._subscriber_client.get_subscriber_ip(sid)
         if ip_addr_info is None:
             return None
-        logging.debug("Found static IP: sid: %s ip_addr_info: %s",
-                      sid, str(ip_addr_info))
+        logging.debug(
+            "Found static IP: sid: %s ip_addr_info: %s",
+            sid, str(ip_addr_info),
+        )
         # Validate static IP is not in any of IP pool.
         for ip_pool in self._store.assigned_ip_blocks:
             if ip_addr_info.ip in ip_pool:
                 error_msg = "Static Ip {} Overlap with IP-POOL: {}".format(
-                    ip_addr_info.ip, ip_pool)
+                    ip_addr_info.ip, ip_pool,
+                )
                 logging.error(error_msg)
                 raise DuplicateIPAssignmentError(error_msg)
 
         # update gw info if available.
         if ip_addr_info.net_info.gw_ip:
-            self._store.dhcp_gw_info.update_ip(ip_addr_info.net_info.gw_ip,
-                                               ip_addr_info.net_info.vlan)
+            self._store.dhcp_gw_info.update_ip(
+                ip_addr_info.net_info.gw_ip,
+                ip_addr_info.net_info.vlan,
+            )
             # update mac if IP is present.
             if ip_addr_info.net_info.gw_mac != "":
-                self._store.dhcp_gw_info.update_mac(ip_addr_info.net_info.gw_ip,
-                                                    ip_addr_info.net_info.gw_mac,
-                                                    ip_addr_info.net_info.vlan)
+                self._store.dhcp_gw_info.update_mac(
+                    ip_addr_info.net_info.gw_ip,
+                    ip_addr_info.net_info.gw_mac,
+                    ip_addr_info.net_info.vlan,
+                )
         ip_block = ip_network(ip_addr_info.ip)
         self._store.assigned_ip_blocks.add(ip_block)
-        return IPDesc(ip=ip_addr_info.ip, state=IPState.ALLOCATED,
-                      sid=sid, ip_block=ip_block, ip_type=IPType.STATIC,
-                      vlan_id=ip_addr_info.net_info.vlan)
+        return IPDesc(
+            ip=ip_addr_info.ip, state=IPState.ALLOCATED,
+            sid=sid, ip_block=ip_block, ip_type=IPType.STATIC,
+            vlan_id=ip_addr_info.net_info.vlan,
+        )

--- a/lte/gateway/python/magma/mobilityd/tests/ip_allocator_dhcp_mac_addr_test.py
+++ b/lte/gateway/python/magma/mobilityd/tests/ip_allocator_dhcp_mac_addr_test.py
@@ -13,7 +13,7 @@ limitations under the License.
 
 import unittest
 
-from magma.mobilityd.mac import MacAddress, create_mac_from_sid
+from magma.mobilityd.mac import create_mac_from_sid
 
 
 class MacAddressGenTests(unittest.TestCase):

--- a/lte/gateway/python/magma/mobilityd/tests/test_multi_apn_ip_alloc.py
+++ b/lte/gateway/python/magma/mobilityd/tests/test_multi_apn_ip_alloc.py
@@ -24,15 +24,11 @@ from lte.protos.subscriberdb_pb2 import (
     SubscriberState,
 )
 from magma.common.redis.client import get_default_client
-from magma.mobilityd.ip_address_man import (
-    IPAddressManager,
-    IPNotInUseError,
-    MappingNotFoundError,
-)
+from magma.mobilityd.ip_address_man import IPAddressManager
 from magma.mobilityd.ip_allocator_multi_apn import IPAllocatorMultiAPNWrapper
 from magma.mobilityd.ip_allocator_pool import IpAllocatorPool
 from magma.mobilityd.ip_allocator_static import IPAllocatorStaticWrapper
-from magma.mobilityd.ip_descriptor import IPDesc, IPType
+from magma.mobilityd.ip_descriptor import IPType
 from magma.mobilityd.ipv6_allocator_pool import IPv6AllocatorPool
 from magma.mobilityd.mobility_store import MobilityStore
 from magma.subscriberdb.sid import SIDUtils

--- a/lte/gateway/python/magma/mobilityd/tests/test_multi_apn_ip_alloc.py
+++ b/lte/gateway/python/magma/mobilityd/tests/test_multi_apn_ip_alloc.py
@@ -46,16 +46,20 @@ class MockedSubscriberDBStub:
         return cls.subs.get(str(sid), None)
 
     @classmethod
-    def add_sub(cls, sid: str, apn: str, ip: str, vlan: str = None,
-                gw_ip=None, gw_mac=None):
+    def add_sub(
+        cls, sid: str, apn: str, ip: str, vlan: str = None,
+        gw_ip=None, gw_mac=None,
+    ):
         sub_db_sid = SIDUtils.to_pb(sid)
         lte = LTESubscription()
         lte.state = LTESubscription.ACTIVE
         state = SubscriberState()
         state.lte_auth_next_seq = 1
         non_3gpp = Non3GPPUserProfile()
-        subs_data = SubscriberData(sid=sub_db_sid, lte=lte, state=state,
-                                   non_3gpp=non_3gpp)
+        subs_data = SubscriberData(
+            sid=sub_db_sid, lte=lte, state=state,
+            non_3gpp=non_3gpp,
+        )
 
         cls.subs[str(sub_db_sid)] = subs_data
         cls.add_sub_ip(sid, apn, ip, vlan, gw_ip, gw_mac)
@@ -71,8 +75,10 @@ class MockedSubscriberDBStub:
         cls.subs[str(sub_db_sid)] = subs_data
 
     @classmethod
-    def add_sub_ip(cls, sid: str, apn: str, ip: str, vlan: str = None,
-                   gw_ip=None, gw_mac=None):
+    def add_sub_ip(
+        cls, sid: str, apn: str, ip: str, vlan: str = None,
+        gw_ip=None, gw_mac=None,
+    ):
         sub_db_sid = SIDUtils.to_pb(sid)
         apn_config = APNConfiguration()
         apn_config.context_id = 1
@@ -107,16 +113,23 @@ class MultiAPNIPAllocationTests(unittest.TestCase):
         store = MobilityStore(get_default_client(), False, 3980)
         ip_allocator = IpAllocatorPool(store)
         ip_allocator_static = IPAllocatorStaticWrapper(
-            store, MockedSubscriberDBStub(), ip_allocator)
-        ipv4_allocator = IPAllocatorMultiAPNWrapper(store,
-                                                    subscriberdb_rpc_stub=MockedSubscriberDBStub(),
-                                                    ip_allocator=ip_allocator_static)
-        ipv6_allocator = IPv6AllocatorPool(store,
-                                           session_prefix_alloc_mode='RANDOM')
-        self._allocator = IPAddressManager(ipv4_allocator,
-                                           ipv6_allocator,
-                                           store,
-                                           recycling_interval)
+            store, MockedSubscriberDBStub(), ip_allocator,
+        )
+        ipv4_allocator = IPAllocatorMultiAPNWrapper(
+            store,
+            subscriberdb_rpc_stub=MockedSubscriberDBStub(),
+            ip_allocator=ip_allocator_static,
+        )
+        ipv6_allocator = IPv6AllocatorPool(
+            store,
+            session_prefix_alloc_mode='RANDOM',
+        )
+        self._allocator = IPAddressManager(
+            ipv4_allocator,
+            ipv6_allocator,
+            store,
+            recycling_interval,
+        )
         self._allocator.add_ip_block(self._block)
 
     def setUp(self):
@@ -132,12 +145,16 @@ class MultiAPNIPAllocationTests(unittest.TestCase):
 
     def check_vlan(self, sid: str, vlan: str):
         ip_desc = self._allocator._store.sid_ips_map[sid]
-        logging.info("type ip_desc.vlan_id %s vlan %s", type(ip_desc.vlan_id),
-                     type(vlan))
+        logging.info(
+            "type ip_desc.vlan_id %s vlan %s", type(ip_desc.vlan_id),
+            type(vlan),
+        )
         self.assertEqual(ip_desc.vlan_id, vlan)
 
-    def check_gw_info(self, vlan: Optional[int], gw_ip: str,
-                      gw_mac: Optional[str]):
+    def check_gw_info(
+        self, vlan: Optional[int], gw_ip: str,
+        gw_mac: Optional[str],
+    ):
         gw_info_ip = self._allocator._store.dhcp_gw_info.get_gw_ip(vlan)
         self.assertEqual(gw_info_ip, gw_ip)
         gw_info_mac = self._allocator._store.dhcp_gw_info.get_gw_mac(vlan)
@@ -161,8 +178,10 @@ class MultiAPNIPAllocationTests(unittest.TestCase):
         sid = imsi + '.' + apn + ",ipv4"
         assigned_ip = '1.2.3.4'
         vlan = 132
-        MockedSubscriberDBStub.add_sub(sid=imsi, apn=apn, ip=assigned_ip,
-                                       vlan=vlan)
+        MockedSubscriberDBStub.add_sub(
+            sid=imsi, apn=apn, ip=assigned_ip,
+            vlan=vlan,
+        )
 
         ip0, _ = self._allocator.alloc_ip_address(sid)
         ip0_returned = self._allocator.get_ip_for_sid(sid)
@@ -181,8 +200,10 @@ class MultiAPNIPAllocationTests(unittest.TestCase):
         sid = imsi + '.' + apn + ",ipv4"
         assigned_ip = '1.2.3.4'
         vlan = 188
-        MockedSubscriberDBStub.add_sub(sid=imsi, apn="xyz", ip=assigned_ip,
-                                       vlan=vlan)
+        MockedSubscriberDBStub.add_sub(
+            sid=imsi, apn="xyz", ip=assigned_ip,
+            vlan=vlan,
+        )
 
         ip0, _ = self._allocator.alloc_ip_address(sid)
         ip0_returned = self._allocator.get_ip_for_sid(sid)
@@ -202,8 +223,10 @@ class MultiAPNIPAllocationTests(unittest.TestCase):
         assigned_ip = '1.2.3.4'
         vlan = 166
 
-        MockedSubscriberDBStub.add_sub(sid=imsi, apn="*", ip=assigned_ip,
-                                       vlan=vlan)
+        MockedSubscriberDBStub.add_sub(
+            sid=imsi, apn="*", ip=assigned_ip,
+            vlan=vlan,
+        )
 
         ip0, _ = self._allocator.alloc_ip_address(sid)
         ip0_returned = self._allocator.get_ip_for_sid(sid)
@@ -226,10 +249,14 @@ class MultiAPNIPAllocationTests(unittest.TestCase):
         vlan = 44
         vlan_wild = 66
 
-        MockedSubscriberDBStub.add_sub(sid=imsi, apn="*", ip=wild_assigned_ip,
-                                       vlan=vlan_wild)
-        MockedSubscriberDBStub.add_sub_ip(sid=imsi, apn=apn, ip=assigned_ip,
-                                          vlan=vlan)
+        MockedSubscriberDBStub.add_sub(
+            sid=imsi, apn="*", ip=wild_assigned_ip,
+            vlan=vlan_wild,
+        )
+        MockedSubscriberDBStub.add_sub_ip(
+            sid=imsi, apn=apn, ip=assigned_ip,
+            vlan=vlan,
+        )
 
         ip0, _ = self._allocator.alloc_ip_address(sid)
         ip0_returned = self._allocator.get_ip_for_sid(sid)
@@ -249,8 +276,10 @@ class MultiAPNIPAllocationTests(unittest.TestCase):
         assigned_ip = '1.2.3.hh'
         vlan = 111
 
-        MockedSubscriberDBStub.add_sub(sid=imsi, apn=apn, ip=assigned_ip,
-                                       vlan=vlan)
+        MockedSubscriberDBStub.add_sub(
+            sid=imsi, apn=apn, ip=assigned_ip,
+            vlan=vlan,
+        )
 
         ip0, _ = self._allocator.alloc_ip_address(sid)
         ip0_returned = self._allocator.get_ip_for_sid(sid)
@@ -271,10 +300,14 @@ class MultiAPNIPAllocationTests(unittest.TestCase):
         vlan = 31
         vlan_wild = 552
 
-        MockedSubscriberDBStub.add_sub(sid=imsi, apn="abc", ip=assigned_ip,
-                                       vlan=vlan_wild)
-        MockedSubscriberDBStub.add_sub_ip(sid=imsi, apn="xyz", ip=assigned_ip,
-                                          vlan=vlan)
+        MockedSubscriberDBStub.add_sub(
+            sid=imsi, apn="abc", ip=assigned_ip,
+            vlan=vlan_wild,
+        )
+        MockedSubscriberDBStub.add_sub_ip(
+            sid=imsi, apn="xyz", ip=assigned_ip,
+            vlan=vlan,
+        )
 
         ip0, _ = self._allocator.alloc_ip_address(sid)
         ip0_returned = self._allocator.get_ip_for_sid(sid)
@@ -308,8 +341,10 @@ class MultiAPNIPAllocationTests(unittest.TestCase):
         assigned_ip = '1.2.3.4'
         vlan = 122
 
-        MockedSubscriberDBStub.add_sub(sid=imsi, apn="*", ip=assigned_ip,
-                                       vlan=vlan)
+        MockedSubscriberDBStub.add_sub(
+            sid=imsi, apn="*", ip=assigned_ip,
+            vlan=vlan,
+        )
 
         ip0, _ = self._allocator.alloc_ip_address(sid)
         ip0_returned = self._allocator.get_ip_for_sid(sid)
@@ -329,8 +364,10 @@ class MultiAPNIPAllocationTests(unittest.TestCase):
         assigned_ip = '1.2.3.4'
         vlan = 165
 
-        MockedSubscriberDBStub.add_sub(sid=imsi, apn=apn, ip=assigned_ip,
-                                       vlan=vlan)
+        MockedSubscriberDBStub.add_sub(
+            sid=imsi, apn=apn, ip=assigned_ip,
+            vlan=vlan,
+        )
 
         ip0, _ = self._allocator.alloc_ip_address(sid)
         ip0_returned = self._allocator.get_ip_for_sid(sid)
@@ -353,10 +390,14 @@ class MultiAPNIPAllocationTests(unittest.TestCase):
         vlan = 0
         vlan_wild = 66
 
-        MockedSubscriberDBStub.add_sub(sid=imsi, apn="*", ip=wild_assigned_ip,
-                                       vlan=vlan_wild)
-        MockedSubscriberDBStub.add_sub_ip(sid=imsi, apn="xyz", ip=assigned_ip,
-                                          vlan=vlan)
+        MockedSubscriberDBStub.add_sub(
+            sid=imsi, apn="*", ip=wild_assigned_ip,
+            vlan=vlan_wild,
+        )
+        MockedSubscriberDBStub.add_sub_ip(
+            sid=imsi, apn="xyz", ip=assigned_ip,
+            vlan=vlan,
+        )
 
         ip0, _ = self._allocator.alloc_ip_address(sid)
         ip0_returned = self._allocator.get_ip_for_sid(sid)
@@ -369,7 +410,8 @@ class MultiAPNIPAllocationTests(unittest.TestCase):
         self.check_gw_info(vlan, None, None)
 
     def test_get_ip_vlan_for_subscriber_with_wildcard_and_exact_apn_no_ip(
-            self):
+            self,
+    ):
         """ test IP assignement from multiple  APNs"""
         apn = 'magma'
         imsi = 'IMSI110'
@@ -379,10 +421,14 @@ class MultiAPNIPAllocationTests(unittest.TestCase):
         vlan = 44
         vlan_wild = 66
 
-        MockedSubscriberDBStub.add_sub(sid=imsi, apn="*", ip=wild_assigned_ip,
-                                       vlan=vlan_wild)
-        MockedSubscriberDBStub.add_sub_ip(sid=imsi, apn=apn, ip=None,
-                                          vlan=vlan)
+        MockedSubscriberDBStub.add_sub(
+            sid=imsi, apn="*", ip=wild_assigned_ip,
+            vlan=vlan_wild,
+        )
+        MockedSubscriberDBStub.add_sub_ip(
+            sid=imsi, apn=apn, ip=None,
+            vlan=vlan,
+        )
 
         ip0, _ = self._allocator.alloc_ip_address(sid)
         ip0_returned = self._allocator.get_ip_for_sid(sid)

--- a/lte/gateway/python/magma/mobilityd/tests/test_static_ip_alloc.py
+++ b/lte/gateway/python/magma/mobilityd/tests/test_static_ip_alloc.py
@@ -20,12 +20,10 @@ import fakeredis
 from magma.mobilityd.ip_address_man import (
     DuplicateIPAssignmentError,
     IPAddressManager,
-    IPNotInUseError,
-    MappingNotFoundError,
 )
 from magma.mobilityd.ip_allocator_pool import IpAllocatorPool
 from magma.mobilityd.ip_allocator_static import IPAllocatorStaticWrapper
-from magma.mobilityd.ip_descriptor import IPDesc, IPType
+from magma.mobilityd.ip_descriptor import IPType
 from magma.mobilityd.ipv6_allocator_pool import IPv6AllocatorPool
 from magma.mobilityd.mobility_store import MobilityStore
 from magma.mobilityd.subscriberdb_client import SubscriberDBStaticIPValueError

--- a/lte/gateway/python/magma/mobilityd/tests/test_static_ip_alloc.py
+++ b/lte/gateway/python/magma/mobilityd/tests/test_static_ip_alloc.py
@@ -44,15 +44,21 @@ class StaticIPAllocationTests(unittest.TestCase):
 
         store = MobilityStore(fakeredis.FakeStrictRedis(), False, 3980)
         ip_allocator = IpAllocatorPool(store)
-        ipv4_allocator = IPAllocatorStaticWrapper(store,
-                                                  subscriberdb_rpc_stub=MockedSubscriberDBStub(),
-                                                  ip_allocator=ip_allocator)
-        ipv6_allocator = IPv6AllocatorPool(store,
-                                           session_prefix_alloc_mode='RANDOM')
-        self._allocator = IPAddressManager(ipv4_allocator,
-                                           ipv6_allocator,
-                                           store,
-                                           recycling_interval)
+        ipv4_allocator = IPAllocatorStaticWrapper(
+            store,
+            subscriberdb_rpc_stub=MockedSubscriberDBStub(),
+            ip_allocator=ip_allocator,
+        )
+        ipv6_allocator = IPv6AllocatorPool(
+            store,
+            session_prefix_alloc_mode='RANDOM',
+        )
+        self._allocator = IPAddressManager(
+            ipv4_allocator,
+            ipv6_allocator,
+            store,
+            recycling_interval,
+        )
         self._allocator.add_ip_block(self._block)
 
     def setUp(self):
@@ -71,8 +77,10 @@ class StaticIPAllocationTests(unittest.TestCase):
             ip_block = ipaddress.ip_network(ip_desc.ip)
         self.assertEqual(ip_desc.ip_block, ip_block)
 
-    def check_gw_info(self, vlan: Optional[int], gw_ip: str,
-                      gw_mac: Optional[str]):
+    def check_gw_info(
+        self, vlan: Optional[int], gw_ip: str,
+        gw_mac: Optional[str],
+    ):
         gw_info_ip = self._allocator._store.dhcp_gw_info.get_gw_ip(vlan)
         self.assertEqual(gw_info_ip, gw_ip)
         gw_info_mac = self._allocator._store.dhcp_gw_info.get_gw_mac(vlan)
@@ -180,8 +188,10 @@ class StaticIPAllocationTests(unittest.TestCase):
         sid = imsi + '.' + apn + ",ipv4"
         assigned_ip = '1.2.3.4'
         assigned_ip_wild = '22.22.22.22'
-        MockedSubscriberDBStub.add_sub(sid=imsi, apn="abc",
-                                       ip=assigned_ip_wild)
+        MockedSubscriberDBStub.add_sub(
+            sid=imsi, apn="abc",
+            ip=assigned_ip_wild,
+        )
         MockedSubscriberDBStub.add_sub_ip(sid=imsi, apn="xyz", ip=assigned_ip)
 
         ip0, _ = self._allocator.alloc_ip_address(sid)
@@ -280,8 +290,10 @@ class StaticIPAllocationTests(unittest.TestCase):
         assigned_ip = '1.2.3.4'
         gw_ip = "1.2.3.1"
         gw_mac = "11:22:33:11:77:28"
-        MockedSubscriberDBStub.add_sub(sid=imsi, apn=apn, ip=assigned_ip,
-                                       gw_ip=gw_ip, gw_mac=gw_mac)
+        MockedSubscriberDBStub.add_sub(
+            sid=imsi, apn=apn, ip=assigned_ip,
+            gw_ip=gw_ip, gw_mac=gw_mac,
+        )
 
         ip0, _ = self._allocator.alloc_ip_address(sid)
         ip0_returned = self._allocator.get_ip_for_sid(sid)
@@ -300,8 +312,10 @@ class StaticIPAllocationTests(unittest.TestCase):
         assigned_ip = '1.2.3.4'
         gw_ip = "1.2.3.100"
         gw_mac = "11:22:33:11:77:81"
-        MockedSubscriberDBStub.add_sub(sid=imsi, apn="*", ip=assigned_ip,
-                                       gw_ip=gw_ip, gw_mac=gw_mac)
+        MockedSubscriberDBStub.add_sub(
+            sid=imsi, apn="*", ip=assigned_ip,
+            gw_ip=gw_ip, gw_mac=gw_mac,
+        )
 
         ip0, _ = self._allocator.alloc_ip_address(sid)
         ip0_returned = self._allocator.get_ip_for_sid(sid)
@@ -320,8 +334,10 @@ class StaticIPAllocationTests(unittest.TestCase):
         gw_ip = "1.2.3.1"
         gw_mac = "11:22:33:11:77:44"
         vlan = "200"
-        MockedSubscriberDBStub.add_sub(sid=imsi, apn=apn, ip=assigned_ip,
-                                       gw_ip=gw_ip, gw_mac=gw_mac, vlan=vlan)
+        MockedSubscriberDBStub.add_sub(
+            sid=imsi, apn=apn, ip=assigned_ip,
+            gw_ip=gw_ip, gw_mac=gw_mac, vlan=vlan,
+        )
 
         ip0, _ = self._allocator.alloc_ip_address(sid)
         ip0_returned = self._allocator.get_ip_for_sid(sid)
@@ -341,8 +357,10 @@ class StaticIPAllocationTests(unittest.TestCase):
         gw_ip = "1.2.3.1333"
         gw_mac = "11:22:33:11:77:76"
         vlan = "200"
-        MockedSubscriberDBStub.add_sub(sid=imsi, apn=apn, ip=assigned_ip,
-                                       gw_ip=gw_ip, gw_mac=gw_mac, vlan=vlan)
+        MockedSubscriberDBStub.add_sub(
+            sid=imsi, apn=apn, ip=assigned_ip,
+            gw_ip=gw_ip, gw_mac=gw_mac, vlan=vlan,
+        )
 
         ip0, _ = self._allocator.alloc_ip_address(sid)
         ip0_returned = self._allocator.get_ip_for_sid(sid)
@@ -362,8 +380,10 @@ class StaticIPAllocationTests(unittest.TestCase):
         gw_ip = ""
         gw_mac = "11:22:33:11:77:45"
         vlan = "200"
-        MockedSubscriberDBStub.add_sub(sid=imsi, apn=apn, ip=assigned_ip,
-                                       gw_ip=gw_ip, gw_mac=gw_mac, vlan=vlan)
+        MockedSubscriberDBStub.add_sub(
+            sid=imsi, apn=apn, ip=assigned_ip,
+            gw_ip=gw_ip, gw_mac=gw_mac, vlan=vlan,
+        )
 
         ip0, _ = self._allocator.alloc_ip_address(sid)
         ip0_returned = self._allocator.get_ip_for_sid(sid)
@@ -383,8 +403,10 @@ class StaticIPAllocationTests(unittest.TestCase):
         gw_ip = "1.2.3.55"
         gw_mac = None
         vlan = "200"
-        MockedSubscriberDBStub.add_sub(sid=imsi, apn=apn, ip=assigned_ip,
-                                       gw_ip=gw_ip, gw_mac=gw_mac, vlan=vlan)
+        MockedSubscriberDBStub.add_sub(
+            sid=imsi, apn=apn, ip=assigned_ip,
+            gw_ip=gw_ip, gw_mac=gw_mac, vlan=vlan,
+        )
 
         ip0, _ = self._allocator.alloc_ip_address(sid)
         ip0_returned = self._allocator.get_ip_for_sid(sid)
@@ -405,19 +427,23 @@ class StaticIPAllocationTests(unittest.TestCase):
         gw_mac = "11:22:33:11:77:81"
         vlan = "300"
 
-        MockedSubscriberDBStub.add_sub(sid=imsi, apn=apn, ip=assigned_ip,
-                                       gw_ip=gw_ip, gw_mac=gw_mac, vlan=vlan)
+        MockedSubscriberDBStub.add_sub(
+            sid=imsi, apn=apn, ip=assigned_ip,
+            gw_ip=gw_ip, gw_mac=gw_mac, vlan=vlan,
+        )
 
         wildcard_assigned_ip = "20.20.20.20"
         wildcard_gw_ip = "1.2.7.7"
         wildcard_gw_mac = "11:22:33:88:77:99"
         wildcard_vlan = "400"
 
-        MockedSubscriberDBStub.add_sub_ip(sid=imsi, apn="*",
-                                          ip=wildcard_assigned_ip,
-                                          gw_ip=wildcard_gw_ip,
-                                          gw_mac=wildcard_gw_mac,
-                                          vlan=wildcard_vlan)
+        MockedSubscriberDBStub.add_sub_ip(
+            sid=imsi, apn="*",
+            ip=wildcard_assigned_ip,
+            gw_ip=wildcard_gw_ip,
+            gw_mac=wildcard_gw_mac,
+            vlan=wildcard_vlan,
+        )
 
         ip0, _ = self._allocator.alloc_ip_address(sid)
         ip0_returned = self._allocator.get_ip_for_sid(sid)
@@ -438,8 +464,10 @@ class StaticIPAllocationTests(unittest.TestCase):
         gw_ip = "1.2.3.1"
         gw_mac = "11:22:33:11:77:44"
         vlan = "20000"
-        MockedSubscriberDBStub.add_sub(sid=imsi, apn=apn, ip=assigned_ip,
-                                       gw_ip=gw_ip, gw_mac=gw_mac, vlan=vlan)
+        MockedSubscriberDBStub.add_sub(
+            sid=imsi, apn=apn, ip=assigned_ip,
+            gw_ip=gw_ip, gw_mac=gw_mac, vlan=vlan,
+        )
 
         with self.assertRaises(InvalidVlanId):
             ip0, _ = self._allocator.alloc_ip_address(sid)


### PR DESCRIPTION
fixes #6055

## Summary

Remove unused imports according to pylint

## Test Plan

`./precommit.py --lint -p lte/gateway/python/magma/mobilityd | grep -i "imported but unused"` is clean