### PR TITLE
apply formatter to all files in orc8r/gateway/python/magma

### DIFF
--- a/orc8r/gateway/python/magma/common/cert_utils.py
+++ b/orc8r/gateway/python/magma/common/cert_utils.py
@@ -37,7 +37,8 @@ def load_key(key_file):
     with open(key_file, 'rb') as f:
         key_bytes = f.read()
     return serialization.load_pem_private_key(
-        key_bytes, None, default_backend())
+        key_bytes, None, default_backend(),
+    )
 
 
 def write_key(key, key_file):
@@ -50,7 +51,8 @@ def write_key(key, key_file):
     key_pem = key.private_bytes(
         serialization.Encoding.PEM,
         serialization.PrivateFormat.TraditionalOpenSSL,
-        serialization.NoEncryption())
+        serialization.NoEncryption(),
+    )
     write_to_file_atomically(key_file, key_pem.decode("utf-8"))
 
 
@@ -74,14 +76,17 @@ def load_public_key_to_base64der(key_file):
     pub_key = key.public_key()
     pub_bytes = pub_key.public_bytes(
         encoding=serialization.Encoding.DER,
-        format=serialization.PublicFormat.SubjectPublicKeyInfo)
+        format=serialization.PublicFormat.SubjectPublicKeyInfo,
+    )
     encoded = base64.b64encode(pub_bytes)
     return encoded
 
 
-def create_csr(key, common_name,
-               country=None, state=None, city=None, org=None,
-               org_unit=None, email_address=None):
+def create_csr(
+    key, common_name,
+    country=None, state=None, city=None, org=None,
+    org_unit=None, email_address=None,
+):
     """Create csr and sign it with key.
 
     Args:
@@ -102,20 +107,23 @@ def create_csr(key, common_name,
         name_attrs.append(x509.NameAttribute(NameOID.COUNTRY_NAME, country))
     if state:
         name_attrs.append(
-            x509.NameAttribute(NameOID.STATE_OR_PROVINCE_NAME, state))
+            x509.NameAttribute(NameOID.STATE_OR_PROVINCE_NAME, state),
+        )
     if city:
         name_attrs.append(x509.NameAttribute(NameOID.LOCALITY_NAME, city))
     if org:
         name_attrs.append(x509.NameAttribute(NameOID.ORGANIZATION_NAME, org))
     if org_unit:
         name_attrs.append(
-            x509.NameAttribute(NameOID.ORGANIZATIONAL_UNIT_NAME, org_unit))
+            x509.NameAttribute(NameOID.ORGANIZATIONAL_UNIT_NAME, org_unit),
+        )
     if email_address:
         name_attrs.append(
-            x509.NameAttribute(NameOID.EMAIL_ADDRESS, email_address))
+            x509.NameAttribute(NameOID.EMAIL_ADDRESS, email_address),
+        )
 
     csr = x509.CertificateSigningRequestBuilder().subject_name(
-        x509.Name(name_attrs)
+        x509.Name(name_attrs),
     ).sign(key, hashes.SHA256(), default_backend())
 
     return csr

--- a/orc8r/gateway/python/magma/common/grpc_client_manager.py
+++ b/orc8r/gateway/python/magma/common/grpc_client_manager.py
@@ -20,8 +20,10 @@ from magma.common.service_registry import ServiceRegistry
 
 
 class GRPCClientManager:
-    def __init__(self, service_name: str, service_stub,
-                 max_client_reuse: int = 60):
+    def __init__(
+        self, service_name: str, service_stub,
+        max_client_reuse: int = 60,
+    ):
         self._client = None
         self._service_stub = service_stub
         self._service_name = service_name

--- a/orc8r/gateway/python/magma/common/health/docker_health_service.py
+++ b/orc8r/gateway/python/magma/common/health/docker_health_service.py
@@ -46,23 +46,28 @@ class DockerHealthChecker(GenericHealthChecker):
 
         for container in client.containers.list():
             service_start_time = dateutil.parser.parse(
-                container.attrs['State']['StartedAt']
+                container.attrs['State']['StartedAt'],
             )
             current_time = datetime.now(service_start_time.tzinfo)
             time_running = current_time - service_start_time
-            services_health_summary.append(ServiceHealth(
-                service_name=container.name,
-                active_state=container.status,
-                sub_state=container.status,
-                time_running=str(time_running).split('.', 1)[0],
-                errors=self.get_error_summary([container.name])[
-                    container.name],
-            ))
+            services_health_summary.append(
+                ServiceHealth(
+                    service_name=container.name,
+                    active_state=container.status,
+                    sub_state=container.status,
+                    time_running=str(time_running).split('.', 1)[0],
+                    errors=self.get_error_summary([container.name])[
+                        container.name
+                    ],
+                ),
+            )
         return services_health_summary
 
     def get_magma_version(self):
         client = docker.from_env()
         container = client.containers.get('magmad')
 
-        return Version(version_code=container.attrs['Config']['Image'],
-                       last_update_time='-')
+        return Version(
+            version_code=container.attrs['Config']['Image'],
+            last_update_time='-',
+        )

--- a/orc8r/gateway/python/magma/common/health/entities.py
+++ b/orc8r/gateway/python/magma/common/health/entities.py
@@ -82,8 +82,10 @@ class Version:
 
 
 class ServiceHealth:
-    def __init__(self, service_name, active_state, sub_state,
-                 time_running, errors):
+    def __init__(
+        self, service_name, active_state, sub_state,
+        time_running, errors,
+    ):
         self.service_name = service_name
         self.active_state = active_state
         self.sub_state = sub_state
@@ -103,10 +105,12 @@ class ServiceHealth:
 
 
 class HealthSummary:
-    def __init__(self, version, platform,
-                 services_health,
-                 internet_health, dns_health,
-                 unexpected_restarts):
+    def __init__(
+        self, version, platform,
+        services_health,
+        internet_health, dns_health,
+        unexpected_restarts,
+    ):
         self.version = version
         self.platform = platform
         self.services_health = services_health
@@ -115,8 +119,10 @@ class HealthSummary:
         self.unexpected_restarts = unexpected_restarts
 
     def __str__(self):
-        any_restarts = any([restarts.count
-                            for restarts in self.unexpected_restarts.values()])
+        any_restarts = any([
+            restarts.count
+            for restarts in self.unexpected_restarts.values()
+        ])
         return textwrap.dedent("""
             Running on {}
             Version: {}:
@@ -128,13 +134,17 @@ class HealthSummary:
 
             Restart summary:
             {}
-        """).format(self.version, self.platform,
-                    'Service', 'Status', 'SubState', 'Running for', 'Log level',
-                    'Errors since last restart',
-                    '\n'.join([str(h) for h in self.services_health]),
-                    self.internet_health, self.dns_health,
-                    '\n'.join(['{:20} {}'.format(name, restarts)
-                              for name, restarts
-                              in self.unexpected_restarts.items()])
-                    if any_restarts
-                    else "No restarts since the gateway started")
+        """).format(
+            self.version, self.platform,
+            'Service', 'Status', 'SubState', 'Running for', 'Log level',
+            'Errors since last restart',
+            '\n'.join([str(h) for h in self.services_health]),
+            self.internet_health, self.dns_health,
+            '\n'.join([
+                '{:20} {}'.format(name, restarts)
+                for name, restarts
+                in self.unexpected_restarts.items()
+            ])
+            if any_restarts
+            else "No restarts since the gateway started",
+        )

--- a/orc8r/gateway/python/magma/common/health/health_service.py
+++ b/orc8r/gateway/python/magma/common/health/health_service.py
@@ -46,10 +46,16 @@ class GenericHealthChecker:
         chan = ServiceRegistry.get_rpc_channel('magmad', ServiceRegistry.LOCAL)
         client = MagmadStub(chan)
 
-        response = client.RunNetworkTests(magmad_pb2.NetworkTestRequest(
-            pings=[magmad_pb2.PingParams(host_or_ip=host,
-                                         num_packets=num_packets)]
-        ))
+        response = client.RunNetworkTests(
+            magmad_pb2.NetworkTestRequest(
+                pings=[
+                    magmad_pb2.PingParams(
+                        host_or_ip=host,
+                        num_packets=num_packets,
+                    ),
+                ],
+            ),
+        )
         return response.pings
 
     def ping_status(self, host):
@@ -73,19 +79,26 @@ class GenericHealthChecker:
         Raises:
             PermissionError: User has no permision to exectue the command
         """
-        configs = {service_name: load_service_mconfig_as_json(service_name)
-                   for service_name in service_names}
-        res = {service_name: Errors(
-               log_level=configs[service_name].get('logLevel', 'INFO'),
-               error_count=0)
-               for service_name in service_names}
+        configs = {
+            service_name: load_service_mconfig_as_json(service_name)
+            for service_name in service_names
+        }
+        res = {
+            service_name: Errors(
+            log_level=configs[service_name].get('logLevel', 'INFO'),
+            error_count=0,
+            )
+            for service_name in service_names
+        }
 
         syslog_path = '/var/log/syslog'
         if not os.access(syslog_path, os.R_OK):
-            raise PermissionError('syslog is not readable. '
-                                  'Try `sudo chmod a+r {}`. '
-                                  'Or execute the command with sudo '
-                                  'permissions: `venvsudo`'.format(syslog_path))
+            raise PermissionError(
+                'syslog is not readable. '
+                'Try `sudo chmod a+r {}`. '
+                'Or execute the command with sudo '
+                'permissions: `venvsudo`'.format(syslog_path),
+            )
         with open(syslog_path, 'r') as f:
             for line in f:
                 for service_name in service_names:
@@ -112,30 +125,37 @@ class GenericHealthChecker:
         services_errors = self.get_error_summary(service_names=service_names)
 
         for service_name in service_names:
-            unit = Unit('magma@{}.service'.format(service_name),
-                        _autoload=True)
+            unit = Unit(
+                'magma@{}.service'.format(service_name),
+                _autoload=True,
+            )
             active_state = ActiveState.dbus2state[unit.Unit.ActiveState]
             sub_state = str(unit.Unit.SubState, 'utf-8')
             if active_state == ActiveState.ACTIVE:
                 pid = unit.Service.MainPID
                 process = subprocess.Popen(
                     'ps -o etime= -p {}'.format(pid).split(),
-                    stdout=subprocess.PIPE)
+                    stdout=subprocess.PIPE,
+                )
 
                 time_running, error = process.communicate()
                 if error:
-                    raise ValueError('Cannot get time running for the service '
-                                     '{} `ps -o etime= -p {}`'
-                                     .format(service_name, pid))
+                    raise ValueError(
+                        'Cannot get time running for the service '
+                        '{} `ps -o etime= -p {}`'
+                        .format(service_name, pid),
+                    )
             else:
                 time_running = b'00'
 
-            services_health_summary.append(ServiceHealth(
-                service_name=service_name,
-                active_state=active_state, sub_state=sub_state,
-                time_running=str(time_running, 'utf-8').strip(),
-                errors=services_errors[service_name]
-            ))
+            services_health_summary.append(
+                ServiceHealth(
+                    service_name=service_name,
+                    active_state=active_state, sub_state=sub_state,
+                    time_running=str(time_running, 'utf-8').strip(),
+                    errors=services_errors[service_name],
+                ),
+            )
         return services_health_summary
 
     def get_unexpected_restart_summary(self):
@@ -151,12 +171,14 @@ class GenericHealthChecker:
             restart_frequencies = {}
             await service_poller._get_service_info()
             for service_name in service_poller.service_info.keys():
-                restarts = int(UNEXPECTED_SERVICE_RESTARTS
-                               .labels(service_name=service_name)
-                               ._value.get())
+                restarts = int(
+                    UNEXPECTED_SERVICE_RESTARTS
+                    .labels(service_name=service_name)
+                    ._value.get(),
+                )
                 restart_frequencies[service_name] = RestartFrequency(
                     count=restarts,
-                    time_interval=''
+                    time_interval='',
                 )
 
             return restart_frequencies
@@ -164,8 +186,10 @@ class GenericHealthChecker:
         return service.loop.run_until_complete(fetch_info())
 
     def get_kernel_version(self):
-        info, error = subprocess.Popen('uname -a'.split(),
-                                       stdout=subprocess.PIPE).communicate()
+        info, error = subprocess.Popen(
+            'uname -a'.split(),
+            stdout=subprocess.PIPE,
+        ).communicate()
 
         if error:
             raise ValueError('Cannot get the kernel version')
@@ -176,18 +200,22 @@ class GenericHealthChecker:
 
         # Return the python version if magma is not there
         if 'magma' not in cache:
-            return Version(version_code=cache['python3'].versions[0],
-                           last_update_time='-')
+            return Version(
+                version_code=cache['python3'].versions[0],
+                last_update_time='-',
+            )
 
         pkg = str(cache['magma'].versions[0])
         version = pkg.split('-')[0].split('=')[-1]
         timestamp = int(pkg.split('-')[1])
 
-        return Version(version_code=version,
-                       last_update_time=datetime.utcfromtimestamp(timestamp)
-                       .replace(tzinfo=tz.tzutc())
-                       .astimezone(tz=tz.tzlocal())
-                       .strftime('%Y-%m-%d %H:%M:%S'))
+        return Version(
+            version_code=version,
+            last_update_time=datetime.utcfromtimestamp(timestamp)
+            .replace(tzinfo=tz.tzutc())
+            .astimezone(tz=tz.tzlocal())
+            .strftime('%Y-%m-%d %H:%M:%S'),
+        )
 
     def get_health_summary(self):
 

--- a/orc8r/gateway/python/magma/common/health/service_state_wrapper.py
+++ b/orc8r/gateway/python/magma/common/health/service_state_wrapper.py
@@ -30,13 +30,17 @@ class ServiceStateWrapper:
     REDIS_VALUE_TYPE = "systemd_status"
 
     def __init__(self):
-        serde = RedisSerde(self.REDIS_VALUE_TYPE,
-                           get_proto_serializer(),
-                           get_proto_deserializer(ServiceExitStatus))
+        serde = RedisSerde(
+            self.REDIS_VALUE_TYPE,
+            get_proto_serializer(),
+            get_proto_deserializer(ServiceExitStatus),
+        )
         self._flat_dict = RedisFlatDict(get_default_client(), serde)
 
-    def update_service_status(self, service_name: str,
-                              service_status: ServiceExitStatus) -> None:
+    def update_service_status(
+        self, service_name: str,
+        service_status: ServiceExitStatus,
+    ) -> None:
         """
         Update the service exit status for a given service
         """

--- a/orc8r/gateway/python/magma/common/job.py
+++ b/orc8r/gateway/python/magma/common/job.py
@@ -32,7 +32,8 @@ class Job(abc.ABC):
     def __init__(
             self,
             interval: int,
-            loop: Optional[asyncio.AbstractEventLoop] = None) -> None:
+            loop: Optional[asyncio.AbstractEventLoop] = None,
+    ) -> None:
         if loop is None:
             self._loop = asyncio.get_event_loop()
         else:

--- a/orc8r/gateway/python/magma/common/metrics.py
+++ b/orc8r/gateway/python/magma/common/metrics.py
@@ -12,9 +12,13 @@ limitations under the License.
 """
 from prometheus_client import Counter
 
-STREAMER_RESPONSES = Counter('streamer_responses',
-                             'The number of responses by label',
-                             ['result'])
+STREAMER_RESPONSES = Counter(
+    'streamer_responses',
+    'The number of responses by label',
+    ['result'],
+)
 
-SERVICE_ERRORS = Counter('service_errors',
-                         'The number of errors logged')
+SERVICE_ERRORS = Counter(
+    'service_errors',
+    'The number of errors logged',
+)

--- a/orc8r/gateway/python/magma/common/metrics_export.py
+++ b/orc8r/gateway/python/magma/common/metrics_export.py
@@ -114,8 +114,10 @@ def encode_summary(family, timestamp_ms):
         quantile = sample[1].pop('quantile', None)  # Remove from label set
         # Each time series identified by label set excluding the quantile
         metric_proto = \
-            metric_protos.setdefault(frozenset(sample[1].items()),
-                                     metrics_pb2.Metric())
+            metric_protos.setdefault(
+                frozenset(sample[1].items()),
+                metrics_pb2.Metric(),
+            )
         if sample[0].endswith('_count'):
             metric_proto.summary.sample_count = int(sample[2])
         elif sample[0].endswith('_sum'):
@@ -159,8 +161,10 @@ def encode_histogram(family, timestamp_ms):
     for sample in family.samples:
         upper_bound = sample[1].pop('le', None)  # Remove from label set
         metric_proto = \
-            metric_protos.setdefault(frozenset(sample[1].items()),
-                                     metrics_pb2.Metric())
+            metric_protos.setdefault(
+                frozenset(sample[1].items()),
+                metrics_pb2.Metric(),
+            )
         if sample[0].endswith('_count'):
             metric_proto.histogram.sample_count = int(sample[2])
         elif sample[0].endswith('_sum'):

--- a/orc8r/gateway/python/magma/common/misc_utils.py
+++ b/orc8r/gateway/python/magma/common/misc_utils.py
@@ -39,8 +39,10 @@ def get_if_ip_with_netmask(interface, preference=IpPreference.IPV4_PREFERRED):
     ip_addresses = netifaces.ifaddresses(interface)
 
     try:
-        ipv4_address = (ip_addresses[netifaces.AF_INET][0]['addr'],
-                        ip_addresses[netifaces.AF_INET][0]['netmask'])
+        ipv4_address = (
+            ip_addresses[netifaces.AF_INET][0]['addr'],
+            ip_addresses[netifaces.AF_INET][0]['netmask'],
+        )
     except KeyError:
         ipv4_address = None
 
@@ -85,8 +87,10 @@ def get_if_ip_with_netmask(interface, preference=IpPreference.IPV4_PREFERRED):
         raise ValueError('Unknown IP preference %s' % preference)
 
 
-def get_all_if_ips_with_netmask(interface,
-                                preference=IpPreference.IPV4_PREFERRED):
+def get_all_if_ips_with_netmask(
+    interface,
+    preference=IpPreference.IPV4_PREFERRED,
+):
     """
     Get all IP addresses and netmasks (in form /255.255.255.0)
     from interface name and return as a list of tuple (ip, netmask).
@@ -121,7 +125,8 @@ def get_all_if_ips_with_netmask(interface,
             return ipv6_addresses
         else:
             raise ValueError(
-                'Error getting IPv4/6 addresses for %s' % interface)
+                'Error getting IPv4/6 addresses for %s' % interface,
+            )
 
     elif preference == IpPreference.IPV6_PREFERRED:
         if ipv6_addresses is not None:
@@ -130,7 +135,8 @@ def get_all_if_ips_with_netmask(interface,
             return ipv4_addresses
         else:
             raise ValueError(
-                'Error getting IPv6/4 addresses for %s' % interface)
+                'Error getting IPv6/4 addresses for %s' % interface,
+            )
 
     elif preference == IpPreference.IPV6_ONLY:
         if ipv6_addresses is not None:
@@ -155,8 +161,10 @@ def get_all_ips_from_if(iface_name, preference=IpPreference.IPV4_PREFERRED):
     Get all ip addresses from interface name and return as a list of string.
     Extract only ip address from (ip, netmask)
     """
-    return [ip[0] for ip in
-            get_all_if_ips_with_netmask(iface_name, preference)]
+    return [
+        ip[0] for ip in
+        get_all_if_ips_with_netmask(iface_name, preference)
+    ]
 
 
 def get_ip_from_if_cidr(iface_name, preference=IpPreference.IPV4_PREFERRED):
@@ -171,8 +179,10 @@ def get_ip_from_if_cidr(iface_name, preference=IpPreference.IPV4_PREFERRED):
     return interface
 
 
-def get_all_ips_from_if_cidr(iface_name,
-                             preference=IpPreference.IPV4_PREFERRED):
+def get_all_ips_from_if_cidr(
+    iface_name,
+    preference=IpPreference.IPV4_PREFERRED,
+):
     """
     Get all IPAddresses with netmask from interface name and
     transform into CIDR (eth1 -> 192.168.60.142/24) notation
@@ -239,9 +249,12 @@ def is_interface_up(interface):
 
 def call_process(cmd, callback, loop):
     loop = loop or asyncio.get_event_loop()
-    loop.create_task(loop.subprocess_shell(
+    loop.create_task(
+        loop.subprocess_shell(
         lambda: SubprocessProtocol(callback), "nohup " + cmd,
-        preexec_fn=os.setsid))
+        preexec_fn=os.setsid,
+        ),
+    )
 
 
 class SubprocessProtocol(asyncio.SubprocessProtocol):

--- a/orc8r/gateway/python/magma/common/redis/containers.py
+++ b/orc8r/gateway/python/magma/common/redis/containers.py
@@ -157,7 +157,8 @@ class RedisHashDict(redis_collections.DefaultDict):
         self._pickle_value = serialize
         self._unpickle = deserialize
         super().__init__(
-            default_factory, redis=client, key=key, writeback=writeback)
+            default_factory, redis=client, key=key, writeback=writeback,
+        )
 
     def __setitem__(self, key, value):
         """Set ``d[key]`` to *value*.
@@ -201,8 +202,10 @@ class RedisFlatDict(MutableMapping[str, T]):
     dict stores key directly (i.e. without a hashmap).
     """
 
-    def __init__(self, client: redis.Redis, serde: RedisSerde[T],
-                 writethrough: bool = False):
+    def __init__(
+        self, client: redis.Redis, serde: RedisSerde[T],
+        writethrough: bool = False,
+    ):
         """
         Args:
             client (redis.Redis): Redis client object

--- a/orc8r/gateway/python/magma/common/redis/serializers.py
+++ b/orc8r/gateway/python/magma/common/redis/serializers.py
@@ -28,10 +28,12 @@ class RedisSerde(Generic[T]):
                 function called to deserialize a value
     """
 
-    def __init__(self,
-                 redis_type: str,
-                 serializer: Callable[[T, int], str],
-                 deserializer: Callable[[str], T]):
+    def __init__(
+        self,
+        redis_type: str,
+        serializer: Callable[[T, int], str],
+        deserializer: Callable[[str], T],
+    ):
         self.redis_type = redis_type
         self.serializer = serializer
         self.deserializer = deserializer

--- a/orc8r/gateway/python/magma/common/redis/tests/dict_tests.py
+++ b/orc8r/gateway/python/magma/common/redis/tests/dict_tests.py
@@ -34,11 +34,14 @@ class RedisDictTests(TestCase):
             client,
             "unittest",
             get_proto_serializer(),
-            get_proto_deserializer(LogVerbosity))
+            get_proto_deserializer(LogVerbosity),
+        )
 
-        serde = RedisSerde('log_verbosity',
-                           get_proto_serializer(),
-                           get_proto_deserializer(LogVerbosity))
+        serde = RedisSerde(
+            'log_verbosity',
+            get_proto_serializer(),
+            get_proto_deserializer(LogVerbosity),
+        )
         self._flat_dict = RedisFlatDict(client, serde)
 
     def test_hash_insert(self):
@@ -99,12 +102,18 @@ class RedisDictTests(TestCase):
 
     def test_flat_bad_key(self):
         expected = LogVerbosity(verbosity=2)
-        self.assertRaises(ValueError, self._flat_dict.__setitem__,
-                          'bad:key', expected)
-        self.assertRaises(ValueError, self._flat_dict.__getitem__,
-                          'bad:key')
-        self.assertRaises(ValueError, self._flat_dict.__delitem__,
-                          'bad:key')
+        self.assertRaises(
+            ValueError, self._flat_dict.__setitem__,
+            'bad:key', expected,
+        )
+        self.assertRaises(
+            ValueError, self._flat_dict.__getitem__,
+            'bad:key',
+        )
+        self.assertRaises(
+            ValueError, self._flat_dict.__delitem__,
+            'bad:key',
+        )
 
     def test_flat_delete(self):
         expected = LogVerbosity(verbosity=2)
@@ -114,8 +123,10 @@ class RedisDictTests(TestCase):
         self.assertEqual(expected, actual)
 
         del self._flat_dict['key3']
-        self.assertRaises(KeyError, self._flat_dict.__getitem__,
-                          'key3')
+        self.assertRaises(
+            KeyError, self._flat_dict.__getitem__,
+            'key3',
+        )
         self.assertEqual(None, self._flat_dict.get('key3'))
 
     def test_flat_clear(self):

--- a/orc8r/gateway/python/magma/common/rpc_utils.py
+++ b/orc8r/gateway/python/magma/common/rpc_utils.py
@@ -94,9 +94,11 @@ def cloud_grpc_wrapper(func):
     return wrapper
 
 
-def set_grpc_err(context: grpc.ServicerContext,
-                 code: grpc.StatusCode,
-                 details: str):
+def set_grpc_err(
+    context: grpc.ServicerContext,
+    code: grpc.StatusCode,
+    details: str,
+):
     """
     Sets status code and details for a gRPC context. Removes commas from
     the details message (see https://github.com/grpc/grpc-node/issues/769)
@@ -129,7 +131,7 @@ def grpc_async_wrapper(gf, loop=None):
     if loop is None:
         loop = asyncio.get_event_loop()
     gf.add_done_callback(
-        lambda _: loop.call_soon_threadsafe(_grpc_async_wrapper, f, gf)
+        lambda _: loop.call_soon_threadsafe(_grpc_async_wrapper, f, gf),
     )
     return f
 
@@ -138,8 +140,10 @@ def is_grpc_error_retryable(error: grpc.RpcError) -> bool:
     status_code = error.code()
     error_details = error.details()
     if status_code == grpc.StatusCode.UNAVAILABLE and \
-            any(err_msg.value in error_details for err_msg in
-                RetryableGrpcErrorDetails):
+            any(
+                err_msg.value in error_details for err_msg in
+                RetryableGrpcErrorDetails
+            ):
         # server end closed connection.
         return True
     return False

--- a/orc8r/gateway/python/magma/common/sdwatchdog.py
+++ b/orc8r/gateway/python/magma/common/sdwatchdog.py
@@ -42,7 +42,8 @@ class SDWatchdog(object):
             self,
             tasks: Optional[List[SDWatchdogTask]],
             update_status: bool = False,  # update systemd status field
-            period: float = 30) -> None:
+            period: float = 30,
+    ) -> None:
         """
         coroutine that will check each task's time_last_completed_loop to
         ensure that it was updated every in the last timeout_s seconds.
@@ -58,7 +59,8 @@ class SDWatchdog(object):
             for t in tasks:
                 if not issubclass(type(t), SDWatchdogTask):
                     logging.warning(
-                        "'%s' is not a 'SDWatchdogTask', skipping", repr(t))
+                        "'%s' is not a 'SDWatchdogTask', skipping", repr(t),
+                    )
                 else:
                     self.tasks.add(t)
 
@@ -81,7 +83,8 @@ class SDWatchdog(object):
             for task in self.tasks:
                 if task.not_completed(current_time):
                     errmsg = "SDWatchdog service '%s' has not completed %s" % (
-                        repr(task), time.asctime(time.gmtime(current_time)))
+                        repr(task), time.asctime(time.gmtime(current_time)),
+                    )
                     if self.update_status:
                         systemd.daemon.notify("STATUS=%s\n" % errmsg)
                     logging.info(errmsg)
@@ -90,7 +93,8 @@ class SDWatchdog(object):
             if not anyStuck:
                 systemd.daemon.notify(
                     'STATUS=SDWatchdog success %s\n' %
-                    time.asctime(time.gmtime(current_time)))
+                    time.asctime(time.gmtime(current_time)),
+                )
                 systemd.daemon.notify("WATCHDOG=1")
                 systemd.daemon.notify("READY=1")  # only active if Type=notify
 

--- a/orc8r/gateway/python/magma/common/service_registry.py
+++ b/orc8r/gateway/python/magma/common/service_registry.py
@@ -93,8 +93,10 @@ class ServiceRegistry:
             grpc channel
         """
         proxy_config = ServiceRegistry.get_proxy_config()
-        (ip, port) = (proxy_config['bootstrap_address'],
-                      proxy_config['bootstrap_port'])
+        (ip, port) = (
+            proxy_config['bootstrap_address'],
+            proxy_config['bootstrap_port'],
+        )
         authority = proxy_config['bootstrap_address']
 
         try:
@@ -106,8 +108,10 @@ class ServiceRegistry:
         return create_grpc_channel(ip, port, authority, ssl_creds)
 
     @staticmethod
-    def get_rpc_channel(service, destination, proxy_cloud_connections=True,
-                        grpc_options=None):
+    def get_rpc_channel(
+        service, destination, proxy_cloud_connections=True,
+        grpc_options=None,
+    ):
         """
         Returns a RPC channel to the service. The connection params
         are obtained from the service registry and used.
@@ -154,26 +158,33 @@ class ServiceRegistry:
         if destination == ServiceRegistry.LOCAL:
             # Connect to the local service directly
             (ip, port) = ServiceRegistry.get_service_address(service)
-            channel = create_grpc_channel(ip, port, authority,
-                                          options=grpc_options)
+            channel = create_grpc_channel(
+                ip, port, authority,
+                options=grpc_options,
+            )
         elif should_use_proxy:
             # Connect to the cloud via local control proxy
             try:
                 (ip, unused_port) = ServiceRegistry.get_service_address(
-                    "control_proxy")
+                    "control_proxy",
+                )
                 port = proxy_config['local_port']
             except ValueError as err:
                 logging.error(err)
                 (ip, port) = ('127.0.0.1', proxy_config['local_port'])
-            channel = create_grpc_channel(ip, port, authority,
-                                          options=grpc_options)
+            channel = create_grpc_channel(
+                ip, port, authority,
+                options=grpc_options,
+            )
         else:
             # Connect to the cloud directly
             ip = proxy_config['cloud_address']
             port = proxy_config['cloud_port']
             ssl_creds = get_ssl_creds()
-            channel = create_grpc_channel(ip, port, authority, ssl_creds,
-                                          options=grpc_options)
+            channel = create_grpc_channel(
+                ip, port, authority, ssl_creds,
+                options=grpc_options,
+            )
         if should_reuse_channel:
             ServiceRegistry._CHANNELS_CACHE[authority] = channel
         return channel
@@ -204,11 +215,12 @@ class ServiceRegistry:
         if not ServiceRegistry._PROXY_CONFIG:
             try:
                 ServiceRegistry._PROXY_CONFIG = load_service_config(
-                    'control_proxy')
+                    'control_proxy',
+                )
             except LoadConfigError as err:
                 logging.error(err)
                 ServiceRegistry._PROXY_CONFIG = {
-                    'proxy_cloud_connections': True
+                    'proxy_cloud_connections': True,
                 }
         return ServiceRegistry._PROXY_CONFIG
 
@@ -248,7 +260,8 @@ def get_ssl_creds():
         ssl_creds = grpc.ssl_channel_credentials(
             root_certificates=rootca,
             certificate_chain=cert,
-            private_key=key)
+            private_key=key,
+        )
     except FileNotFoundError as exp:
         raise ValueError("SSL cert not found: %s" % exp)
     return ssl_creds
@@ -275,9 +288,11 @@ def create_grpc_channel(ip, port, authority, ssl_creds=None, options=None):
         channel = grpc.secure_channel(
             target='%s:%s' % (ip, port),
             credentials=ssl_creds,
-            options=grpc_options)
+            options=grpc_options,
+        )
     else:
         channel = grpc.insecure_channel(
             target='%s:%s' % (ip, port),
-            options=grpc_options)
+            options=grpc_options,
+        )
     return channel

--- a/orc8r/gateway/python/magma/common/stateless_agw.py
+++ b/orc8r/gateway/python/magma/common/stateless_agw.py
@@ -48,7 +48,8 @@ def check_stateless_agw():
 
     logging.debug(
         "Check returning %s", magmad_pb2.CheckStatelessResponse.AGWMode.Name(
-            res)
+            res,
+        ),
     )
     return res
 

--- a/orc8r/gateway/python/magma/common/tests/cert_utils_tests.py
+++ b/orc8r/gateway/python/magma/common/tests/cert_utils_tests.py
@@ -34,11 +34,13 @@ class CertUtilsTest(TestCase):
         key_bytes = key.private_bytes(
             serialization.Encoding.PEM,
             serialization.PrivateFormat.TraditionalOpenSSL,
-            serialization.NoEncryption())
+            serialization.NoEncryption(),
+        )
         key_load_bytes = key_load.private_bytes(
             serialization.Encoding.PEM,
             serialization.PrivateFormat.TraditionalOpenSSL,
-            serialization.NoEncryption())
+            serialization.NoEncryption(),
+        )
         self.assertEqual(key_bytes, key_load_bytes)
 
     def load_public_key_to_base64der(self):
@@ -46,30 +48,38 @@ class CertUtilsTest(TestCase):
             key = ec.generate_private_key(ec.SECP384R1(), default_backend())
             cu.write_key(key, os.path.join(temp_dir, 'test.key'))
             base64der = cu.load_public_key_to_base64der(
-                os.path.join(temp_dir, 'test.key'))
+                os.path.join(temp_dir, 'test.key'),
+            )
             der = base64.b64decode(base64der)
             pub_key = serialization.load_der_public_key(der, default_backend())
             self.assertEqual(pub_key, key.public_key())
 
     def test_csr(self):
         key = ec.generate_private_key(ec.SECP384R1(), default_backend())
-        csr = cu.create_csr(key, 'i am dummy test',
-                            'US', 'CA', 'MPK', 'FB', 'magma', 'magma@fb.com')
+        csr = cu.create_csr(
+            key, 'i am dummy test',
+            'US', 'CA', 'MPK', 'FB', 'magma', 'magma@fb.com',
+        )
         self.assertTrue(csr.is_signature_valid)
         public_key_bytes = key.public_key().public_bytes(
             serialization.Encoding.OpenSSH,
-            serialization.PublicFormat.OpenSSH)
+            serialization.PublicFormat.OpenSSH,
+        )
         csr_public_key_bytes = csr.public_key().public_bytes(
             serialization.Encoding.OpenSSH,
-            serialization.PublicFormat.OpenSSH)
+            serialization.PublicFormat.OpenSSH,
+        )
         self.assertEqual(public_key_bytes, csr_public_key_bytes)
 
     def test_cert(self):
         with TemporaryDirectory(prefix='/tmp/test_cert_utils') as temp_dir:
             cert = _create_dummy_cert()
             cert_file = os.path.join(temp_dir, 'test.cert')
-            cu.write_cert(cert.public_bytes(
-                serialization.Encoding.DER), cert_file)
+            cu.write_cert(
+                cert.public_bytes(
+                serialization.Encoding.DER,
+                ), cert_file,
+            )
             cert_load = cu.load_cert(cert_file)
         self.assertEqual(cert, cert_load)
 
@@ -84,16 +94,16 @@ def _create_dummy_cert():
         x509.NameAttribute(x509.oid.NameOID.COMMON_NAME, u"mysite.com"),
     ])
     cert = x509.CertificateBuilder().subject_name(
-        subject
+        subject,
     ).issuer_name(
-        issuer
+        issuer,
     ).public_key(
-        key.public_key()
+        key.public_key(),
     ).serial_number(
-        x509.random_serial_number()
+        x509.random_serial_number(),
     ).not_valid_before(
-        datetime.datetime.utcnow()
+        datetime.datetime.utcnow(),
     ).not_valid_after(
-        datetime.datetime.utcnow() + datetime.timedelta(days=10)
+        datetime.datetime.utcnow() + datetime.timedelta(days=10),
     ).sign(key, hashes.SHA256(), default_backend())
     return cert

--- a/orc8r/gateway/python/magma/common/tests/cert_validity_tests.py
+++ b/orc8r/gateway/python/magma/common/tests/cert_validity_tests.py
@@ -96,10 +96,14 @@ class CertValidityTests(TestCase):
             ssl=mock_context,
         )
 
-    @patch('magma.common.cert_validity.create_ssl_connection',
-           new_callable=AsyncMock)
-    @patch('magma.common.cert_validity.create_tcp_connection',
-           new_callable=AsyncMock)
+    @patch(
+        'magma.common.cert_validity.create_ssl_connection',
+        new_callable=AsyncMock,
+    )
+    @patch(
+        'magma.common.cert_validity.create_tcp_connection',
+        new_callable=AsyncMock,
+    )
     def test_cert_is_invalid_both_ok(self, mock_create_tcp, mock_create_ssl):
         """
         Test the appropriate calls and return value for cert_is_invalid()
@@ -133,8 +137,10 @@ class CertValidityTests(TestCase):
         )
         self.assertEqual(ret_val, False)
 
-    @patch('magma.common.cert_validity.create_ssl_connection',
-           new_callable=AsyncMock)
+    @patch(
+        'magma.common.cert_validity.create_ssl_connection',
+        new_callable=AsyncMock,
+    )
     @patch('magma.common.cert_validity.create_tcp_connection', AsyncMock())
     def test_cert_is_invalid_ssl_fail(self, mock_create_ssl):
         """
@@ -159,8 +165,10 @@ class CertValidityTests(TestCase):
         ret_val = self.loop.run_until_complete(go())
         self.assertEqual(ret_val, True)
 
-    @patch('magma.common.cert_validity.create_ssl_connection',
-           new_callable=AsyncMock)
+    @patch(
+        'magma.common.cert_validity.create_ssl_connection',
+        new_callable=AsyncMock,
+    )
     @patch('magma.common.cert_validity.create_tcp_connection', AsyncMock())
     def test_cert_is_invalid_ssl_fail_none_errno(self, mock_create_ssl):
         """
@@ -186,8 +194,10 @@ class CertValidityTests(TestCase):
         self.assertEqual(ret_val, True)
 
     @patch('magma.common.cert_validity.create_ssl_connection', AsyncMock())
-    @patch('magma.common.cert_validity.create_tcp_connection',
-           new_callable=AsyncMock)
+    @patch(
+        'magma.common.cert_validity.create_tcp_connection',
+        new_callable=AsyncMock,
+    )
     def test_cert_is_invalid_tcp_fail_none_errno(self, mock_create_tcp):
         """
         Test cert_is_invalid() == False when TCP fails w/o errno and SSL succeeds
@@ -212,8 +222,10 @@ class CertValidityTests(TestCase):
         self.assertEqual(ret_val, False)
 
     @patch('magma.common.cert_validity.create_ssl_connection', AsyncMock())
-    @patch('magma.common.cert_validity.create_tcp_connection',
-           new_callable=AsyncMock)
+    @patch(
+        'magma.common.cert_validity.create_tcp_connection',
+        new_callable=AsyncMock,
+    )
     def test_cert_is_invalid_tcp_fail(self, mock_create_tcp):
         """
         Test cert_is_invalid() == False when TCP fails and SSL succeeds
@@ -237,10 +249,14 @@ class CertValidityTests(TestCase):
         ret_val = self.loop.run_until_complete(go())
         self.assertEqual(ret_val, False)
 
-    @patch('magma.common.cert_validity.create_ssl_connection',
-           new_callable=AsyncMock)
-    @patch('magma.common.cert_validity.create_tcp_connection',
-           new_callable=AsyncMock)
+    @patch(
+        'magma.common.cert_validity.create_ssl_connection',
+        new_callable=AsyncMock,
+    )
+    @patch(
+        'magma.common.cert_validity.create_tcp_connection',
+        new_callable=AsyncMock,
+    )
     def test_cert_is_invalid_both_fail(self, mock_create_tcp, mock_create_ssl):
         """
         Test cert_is_invalid() == False when TCP and SSL fail

--- a/orc8r/gateway/python/magma/common/tests/metrics_tests.py
+++ b/orc8r/gateway/python/magma/common/tests/metrics_tests.py
@@ -38,8 +38,10 @@ class Service303MetricTests(unittest.TestCase):
     def test_counter(self):
         """Test that we can track counters in Service303"""
         # Add a counter with a label to the regisry
-        c = Counter('process_max_fds', 'A counter', ['result'],
-                    registry=self.registry)
+        c = Counter(
+            'process_max_fds', 'A counter', ['result'],
+            registry=self.registry,
+        )
 
         # Create two series for value1 and value2
         c.labels('success').inc(1.23)
@@ -48,31 +50,42 @@ class Service303MetricTests(unittest.TestCase):
         # Build proto outputs
         counter1 = metrics_pb2.Counter(value=1.23)
         counter2 = metrics_pb2.Counter(value=2.34)
-        metric1 = metrics_pb2.Metric(counter=counter1,
-                                     timestamp_ms=1234000)
-        metric2 = metrics_pb2.Metric(counter=counter2,
-                                     timestamp_ms=1234000)
+        metric1 = metrics_pb2.Metric(
+            counter=counter1,
+            timestamp_ms=1234000,
+        )
+        metric2 = metrics_pb2.Metric(
+            counter=counter2,
+            timestamp_ms=1234000,
+        )
         family = metrics_pb2.MetricFamily(
             name=str(metricsd_pb2.process_max_fds),
-            type=metrics_pb2.COUNTER)
+            type=metrics_pb2.COUNTER,
+        )
         metric1.label.add(
             name=str(metricsd_pb2.result),
-            value='success')
+            value='success',
+        )
         metric2.label.add(
             name=str(metricsd_pb2.result),
-            value='failure')
+            value='failure',
+        )
         family.metric.extend([metric1, metric2])
 
         with unittest.mock.patch('time.time') as mock_time:
             mock_time.side_effect = lambda: 1234
-            self.assertCountEqual(list(metrics_export.get_metrics(self.registry))[0].metric,
-                                  family.metric)
+            self.assertCountEqual(
+                list(metrics_export.get_metrics(self.registry))[0].metric,
+                family.metric,
+            )
 
     def test_gauge(self):
         """Test that we can track gauges in Service303"""
         # Add a gauge with a label to the regisry
-        c = Gauge('process_max_fds', 'A gauge', ['result'],
-                  registry=self.registry)
+        c = Gauge(
+            'process_max_fds', 'A gauge', ['result'],
+            registry=self.registry,
+        )
 
         # Create two series for value1 and value2
         c.labels('success').inc(1.23)
@@ -81,62 +94,85 @@ class Service303MetricTests(unittest.TestCase):
         # Build proto outputs
         gauge1 = metrics_pb2.Gauge(value=1.23)
         gauge2 = metrics_pb2.Gauge(value=2.34)
-        metric1 = metrics_pb2.Metric(gauge=gauge1,
-                                     timestamp_ms=1234000)
-        metric2 = metrics_pb2.Metric(gauge=gauge2,
-                                     timestamp_ms=1234000)
+        metric1 = metrics_pb2.Metric(
+            gauge=gauge1,
+            timestamp_ms=1234000,
+        )
+        metric2 = metrics_pb2.Metric(
+            gauge=gauge2,
+            timestamp_ms=1234000,
+        )
         family = metrics_pb2.MetricFamily(
             name=str(metricsd_pb2.process_max_fds),
-            type=metrics_pb2.GAUGE)
+            type=metrics_pb2.GAUGE,
+        )
         metric1.label.add(
             name=str(metricsd_pb2.result),
-            value='success')
+            value='success',
+        )
         metric2.label.add(
             name=str(metricsd_pb2.result),
-            value='failure')
+            value='failure',
+        )
         family.metric.extend([metric1, metric2])
 
         with unittest.mock.patch('time.time') as mock_time:
             mock_time.side_effect = lambda: 1234
-            self.assertCountEqual(list(metrics_export.get_metrics(self.registry))[0].metric,
-                                  family.metric)
+            self.assertCountEqual(
+                list(metrics_export.get_metrics(self.registry))[0].metric,
+                family.metric,
+            )
 
     def test_summary(self):
         """Test that we can track summaries in Service303"""
         # Add a summary with a label to the regisry
-        c = Summary('process_max_fds', 'A summary', [
-                    'result'], registry=self.registry)
+        c = Summary(
+            'process_max_fds', 'A summary', [
+            'result',
+            ], registry=self.registry,
+        )
         c.labels('success').observe(1.23)
         c.labels('failure').observe(2.34)
 
         # Build proto outputs
         summary1 = metrics_pb2.Summary(sample_count=1, sample_sum=1.23)
         summary2 = metrics_pb2.Summary(sample_count=1, sample_sum=2.34)
-        metric1 = metrics_pb2.Metric(summary=summary1,
-                                     timestamp_ms=1234000)
-        metric2 = metrics_pb2.Metric(summary=summary2,
-                                     timestamp_ms=1234000)
+        metric1 = metrics_pb2.Metric(
+            summary=summary1,
+            timestamp_ms=1234000,
+        )
+        metric2 = metrics_pb2.Metric(
+            summary=summary2,
+            timestamp_ms=1234000,
+        )
         family = metrics_pb2.MetricFamily(
             name=str(metricsd_pb2.process_max_fds),
-            type=metrics_pb2.SUMMARY)
+            type=metrics_pb2.SUMMARY,
+        )
         metric1.label.add(
             name=str(metricsd_pb2.result),
-            value='success')
+            value='success',
+        )
         metric2.label.add(
             name=str(metricsd_pb2.result),
-            value='failure')
+            value='failure',
+        )
         family.metric.extend([metric1, metric2])
 
         with unittest.mock.patch('time.time') as mock_time:
             mock_time.side_effect = lambda: 1234
-            self.assertCountEqual(list(metrics_export.get_metrics(self.registry))[0].metric,
-                                  family.metric)
+            self.assertCountEqual(
+                list(metrics_export.get_metrics(self.registry))[0].metric,
+                family.metric,
+            )
 
     def test_histogram(self):
         """Test that we can track histogram in Service303"""
         # Add a histogram with a label to the regisry
-        c = Histogram('process_max_fds', 'A summary', ['result'],
-                      registry=self.registry, buckets=[0, 2, float('inf')])
+        c = Histogram(
+            'process_max_fds', 'A summary', ['result'],
+            registry=self.registry, buckets=[0, 2, float('inf')],
+        )
         c.labels('success').observe(1.23)
         c.labels('failure').observe(2.34)
 
@@ -149,39 +185,52 @@ class Service303MetricTests(unittest.TestCase):
         histogram2.bucket.add(upper_bound=0, cumulative_count=0)
         histogram2.bucket.add(upper_bound=2, cumulative_count=0)
         histogram2.bucket.add(upper_bound=float('inf'), cumulative_count=1)
-        metric1 = metrics_pb2.Metric(histogram=histogram1,
-                                     timestamp_ms=1234000)
-        metric2 = metrics_pb2.Metric(histogram=histogram2,
-                                     timestamp_ms=1234000)
+        metric1 = metrics_pb2.Metric(
+            histogram=histogram1,
+            timestamp_ms=1234000,
+        )
+        metric2 = metrics_pb2.Metric(
+            histogram=histogram2,
+            timestamp_ms=1234000,
+        )
         family = metrics_pb2.MetricFamily(
             name=str(metricsd_pb2.process_max_fds),
-            type=metrics_pb2.HISTOGRAM)
+            type=metrics_pb2.HISTOGRAM,
+        )
         metric1.label.add(
             name=str(metricsd_pb2.result),
-            value='success')
+            value='success',
+        )
         metric2.label.add(
             name=str(metricsd_pb2.result),
-            value='failure')
+            value='failure',
+        )
         family.metric.extend([metric1, metric2])
 
         with unittest.mock.patch('time.time') as mock_time:
             mock_time.side_effect = lambda: 1234
-            self.assertCountEqual(list(metrics_export.get_metrics(self.registry))[0].metric,
-                                  family.metric)
+            self.assertCountEqual(
+                list(metrics_export.get_metrics(self.registry))[0].metric,
+                family.metric,
+            )
 
     def test_converted_enums(self):
         """ Test that metric names and labels are auto converted """
         # enum values (from metricsd.proto):
         # mme_new_association => 500, result => 0
-        c = Counter('mme_new_association', 'A counter', ['result'],
-                    registry=self.registry)
+        c = Counter(
+            'mme_new_association', 'A counter', ['result'],
+            registry=self.registry,
+        )
 
         c.labels('success').inc(1.23)
 
         metric_family = list(metrics_export.get_metrics(self.registry))[0]
 
-        self.assertEqual(metric_family.name,
-                         str(metricsd_pb2.mme_new_association))
+        self.assertEqual(
+            metric_family.name,
+            str(metricsd_pb2.mme_new_association),
+        )
         metric_labels = metric_family.metric[0].label
         # Order not guaranteed=
         self.assertEqual(metric_labels[0].name, str(metricsd_pb2.result))

--- a/orc8r/gateway/python/magma/common/tests/service303_tests.py
+++ b/orc8r/gateway/python/magma/common/tests/service303_tests.py
@@ -42,7 +42,8 @@ class Service303Tests(TestCase):
         asyncio.set_event_loop(self._service.loop)
 
     @mock.patch(
-        'magma.common.service_registry.ServiceRegistry.get_proxy_config')
+        'magma.common.service_registry.ServiceRegistry.get_proxy_config',
+    )
     def test_service_run(self, mock_get_proxy_config):
         """
         Test if the service starts and stops gracefully.
@@ -52,7 +53,7 @@ class Service303Tests(TestCase):
 
         mock_get_proxy_config.return_value = {
             'cloud_address': '127.0.0.1',
-            'proxy_cloud_connections': True
+            'proxy_cloud_connections': True,
         }
 
         # Start the service and pause the loop
@@ -64,15 +65,19 @@ class Service303Tests(TestCase):
 
         # Create a rpc stub and query the Service303 interface
         ServiceRegistry.add_service('test', '0.0.0.0', self._service.port)
-        channel = ServiceRegistry.get_rpc_channel('test',
-                                                  ServiceRegistry.LOCAL)
+        channel = ServiceRegistry.get_rpc_channel(
+            'test',
+            ServiceRegistry.LOCAL,
+        )
         self._stub = Service303Stub(channel)
 
-        info = ServiceInfo(name='test',
-                           version='0.0.0',
-                           state=ServiceInfo.ALIVE,
-                           health=ServiceInfo.APP_HEALTHY,
-                           start_time_secs=12345)
+        info = ServiceInfo(
+            name='test',
+            version='0.0.0',
+            state=ServiceInfo.ALIVE,
+            health=ServiceInfo.APP_HEALTHY,
+            start_time_secs=12345,
+        )
         self.assertEqual(self._stub.GetServiceInfo(Void()), info)
 
         # Stop the service

--- a/orc8r/gateway/python/magma/configuration/events.py
+++ b/orc8r/gateway/python/magma/configuration/events.py
@@ -23,7 +23,7 @@ def deleted_stored_mconfig():
             event_type="deleted_stored_mconfig",
             tag=snowflake.snowflake(),
             value="{}",
-        )
+        ),
     )
 
 
@@ -34,5 +34,5 @@ def updated_stored_mconfig():
             event_type="updated_stored_mconfig",
             tag=snowflake.snowflake(),
             value="{}",
-        )
+        ),
     )

--- a/orc8r/gateway/python/magma/configuration/service_configs.py
+++ b/orc8r/gateway/python/magma/configuration/service_configs.py
@@ -120,7 +120,7 @@ def get_service_config_value(service: str, param: str, default: Any) -> Any:
     else:
         logging.error(
             'Error retrieving config for %s, key not found: %s',
-            service, param
+            service, param,
         )
         return default
 

--- a/orc8r/gateway/python/magma/configuration/tests/mconfigs_tests.py
+++ b/orc8r/gateway/python/magma/configuration/tests/mconfigs_tests.py
@@ -98,5 +98,6 @@ class MconfigsTest(unittest.TestCase):
         )
 
         actual = mconfigs.unpack_mconfig_any(
-            magmad_any, mconfigs_pb2.DirectoryD())
+            magmad_any, mconfigs_pb2.DirectoryD(),
+        )
         self.assertEqual(directoryd_mconfig, actual)

--- a/orc8r/gateway/python/magma/directoryd/rpc_servicer.py
+++ b/orc8r/gateway/python/magma/directoryd/rpc_servicer.py
@@ -96,7 +96,7 @@ class GatewayDirectoryServiceRpcServicer(GatewayDirectoryServiceServicer):
                     DirectoryRecord(
                         location_history=[hwid],
                         identifiers={},
-                )
+                    )
 
                 if record.location_history[0] != hwid:
                     record.location_history = [hwid] + record.location_history

--- a/orc8r/gateway/python/magma/directoryd/tests/rpc_servicer_tests.py
+++ b/orc8r/gateway/python/magma/directoryd/tests/rpc_servicer_tests.py
@@ -46,7 +46,8 @@ class DirectorydRpcServiceTests(TestCase):
             mock.MagicMock(return_value=fakeredis.FakeStrictRedis())
         with mock.patch(
                 'magma.directoryd.rpc_servicer.get_default_client',
-                func_mock):
+                func_mock,
+        ):
             # Add the servicer
             self._servicer = GatewayDirectoryServiceRpcServicer(False)
             self._servicer.add_to_server(self._rpc_server)
@@ -76,10 +77,14 @@ class DirectorydRpcServiceTests(TestCase):
         self._stub.UpdateRecord(req)
         actual_record2 = self._servicer._redis_dict[req.id]
         self.assertEqual(actual_record2.location_history, ["aaa-bbb"])
-        self.assertEqual(actual_record2.identifiers['mac_addr'],
-                         "aa:aa:bb:bb:cc:cc")
-        self.assertEqual(actual_record2.identifiers['ipv4_addr'],
-                         "192.168.172.12")
+        self.assertEqual(
+            actual_record2.identifiers['mac_addr'],
+            "aa:aa:bb:bb:cc:cc",
+        )
+        self.assertEqual(
+            actual_record2.identifiers['ipv4_addr'],
+            "192.168.172.12",
+        )
 
     @mock.patch('snowflake.snowflake', get_mock_snowflake)
     def test_update_record_bad_location(self):
@@ -156,8 +161,10 @@ class DirectorydRpcServiceTests(TestCase):
             if record.id == "IMSI556":
                 self.assertEqual(record.fields["ipv4_addr"], "192.168.127.11")
             elif record.id == "IMSI557":
-                self.assertEqual(record.fields["mac_addr"],
-                                 "aa:bb:aa:bb:aa:bb")
+                self.assertEqual(
+                    record.fields["mac_addr"],
+                    "aa:bb:aa:bb:aa:bb",
+                )
             else:
                 raise AssertionError()
 

--- a/orc8r/gateway/python/magma/eventd/event_validator.py
+++ b/orc8r/gateway/python/magma/eventd/event_validator.py
@@ -55,15 +55,18 @@ class EventValidator(object):
         if event_type not in self.event_registry:
             logging.debug(
                 'Event type %s not among registered event types (%s)',
-                event_type, self.event_registry)
+                event_type, self.event_registry,
+            )
             raise KeyError(
                 'Event type {} not registered, '
-                'please add it to the EventD config'.format(event_type))
+                'please add it to the EventD config'.format(event_type),
+            )
         filename = self.event_registry[event_type][FILENAME]
         bravado_validate(
             self.specs_by_filename[filename][BRAVADO_SPEC],
             self.specs_by_filename[filename][SWAGGER_SPEC][event_type],
-            event)
+            event,
+        )
 
     def _load_specs_from_registry(self) -> Dict[str, Any]:
         """
@@ -86,13 +89,15 @@ class EventValidator(object):
             if not pkg_resources.resource_exists(module, filename):
                 raise LookupError(
                     'File {} not found under {}/swagger, please ensure that '
-                    'it exists'.format(filename, info[MODULE]))
+                    'it exists'.format(filename, info[MODULE]),
+                )
 
             stream = pkg_resources.resource_stream(module, filename)
             with closing(stream) as spec_file:
                 swagger_spec = yaml.safe_load(spec_file)
                 self._check_event_exists_in_spec(
-                    swagger_spec[DEFINITIONS], filename, event_type)
+                    swagger_spec[DEFINITIONS], filename, event_type,
+                )
 
                 config = {'validate_swagger_spec': False}
                 bravado_spec = Spec.from_dict(swagger_spec, config=config)
@@ -116,4 +121,5 @@ class EventValidator(object):
             raise KeyError(
                 'Event type {} is not defined in {}, '
                 'please add the definition and re-generate '
-                'swagger specifications'.format(event_type, filename))
+                'swagger specifications'.format(event_type, filename),
+            )

--- a/orc8r/gateway/python/magma/eventd/eventd_client.py
+++ b/orc8r/gateway/python/magma/eventd/eventd_client.py
@@ -28,7 +28,7 @@ def log_event(event: Event) -> None:
     """
     try:
         chan = ServiceRegistry.get_rpc_channel(
-            EVENTD_SERVICE_NAME, ServiceRegistry.LOCAL
+            EVENTD_SERVICE_NAME, ServiceRegistry.LOCAL,
         )
     except ValueError:
         logging.error("Cant get RPC channel to %s", EVENTD_SERVICE_NAME)
@@ -39,8 +39,10 @@ def log_event(event: Event) -> None:
         client.LogEvent(event, DEFAULT_GRPC_TIMEOUT)
     except grpc.RpcError as err:
         if err.code() == grpc.StatusCode.UNAVAILABLE:
-            logging.debug("LogEvent will not occur unless eventd configuration "
-                          "is set up.")
+            logging.debug(
+                "LogEvent will not occur unless eventd configuration "
+                "is set up.",
+            )
         else:
             logging.error(
                 "LogEvent error for event: %s, [%s] %s",

--- a/orc8r/gateway/python/magma/eventd/rpc_servicer.py
+++ b/orc8r/gateway/python/magma/eventd/rpc_servicer.py
@@ -56,7 +56,8 @@ class EventDRpcServicer(eventd_pb2_grpc.EventServiceServicer):
             logging.error("KeyError for log: %s. Error: %s", request, e)
             context.set_code(grpc.StatusCode.INVALID_ARGUMENT)
             context.set_details(
-                'Event validation failed, Details: {}'.format(e))
+                'Event validation failed, Details: {}'.format(e),
+            )
             return
 
         value = {
@@ -67,19 +68,25 @@ class EventDRpcServicer(eventd_pb2_grpc.EventServiceServicer):
             'retry_on_failure': self._needs_retries(request.event_type),
         }
         try:
-            with closing(socket.create_connection(
-                    ('localhost', self._fluent_bit_port),
-                    timeout=self._tcp_timeout)) as sock:
+            with closing(
+                socket.create_connection(
+                ('localhost', self._fluent_bit_port),
+                timeout=self._tcp_timeout,
+                ),
+            ) as sock:
                 logging.debug('Sending log to FluentBit')
                 sock.sendall(json.dumps(value).encode('utf-8'))
         except socket.error as e:
             logging.error('Connection to FluentBit failed: %s', e)
-            logging.info('FluentBit (td-agent-bit) may not be enabled '
-                         'or configured correctly')
+            logging.info(
+                'FluentBit (td-agent-bit) may not be enabled '
+                'or configured correctly',
+            )
             context.set_code(grpc.StatusCode.UNAVAILABLE)
             context.set_details(
                 'Could not connect to FluentBit locally, Details: {}'
-                .format(e))
+                .format(e),
+            )
             return
 
         logging.debug("Successfully logged event: %s", request)

--- a/orc8r/gateway/python/magma/eventd/tests/event_validation_tests.py
+++ b/orc8r/gateway/python/magma/eventd/tests/event_validation_tests.py
@@ -24,7 +24,7 @@ class EventValidationTests(TestCase):
         # A test event registry that specifies the test events
         test_events_location = {
             'module': 'orc8r',
-            'filename': 'test_event_definitions.yml'
+            'filename': 'test_event_definitions.yml',
         }
         config = {
             'fluent_bit_port': '',
@@ -40,7 +40,7 @@ class EventValidationTests(TestCase):
     def test_event_registration(self):
         data = json.dumps({
             'foo': 'magma',  # required
-            'bar': 123
+            'bar': 123,
         })
         # Errors when event is not registered
         with self.assertRaises(Exception):
@@ -54,7 +54,7 @@ class EventValidationTests(TestCase):
         with self.assertRaises(ValidationError):
             # foo is missing
             data = json.dumps({
-                'bar': 123
+                'bar': 123,
             })
             self.validator.validate_event(data, 'simple_event')
 
@@ -63,7 +63,7 @@ class EventValidationTests(TestCase):
             data = json.dumps({
                 'extra_field': 12,
                 'foo': 'asdf',
-                'bar': 123
+                'bar': 123,
             })
             self.validator.validate_event(data, 'simple_event')
 
@@ -71,7 +71,7 @@ class EventValidationTests(TestCase):
         with self.assertRaises(ValidationError):
             data = json.dumps({
                 'extra_field': 12,
-                'bar': 123
+                'bar': 123,
             })
             # foo is missing
             self.validator.validate_event(data, 'simple_event')
@@ -79,7 +79,7 @@ class EventValidationTests(TestCase):
         # Does not error when the fields are equivalent
         data = json.dumps({
             'foo': 'magma',  # required
-            'bar': 123
+            'bar': 123,
         })
         self.validator.validate_event(data, 'simple_event')
 
@@ -91,8 +91,8 @@ class EventValidationTests(TestCase):
             'an_array': ["a", "b"],
             'an_object': {
                 "a_key": 1,
-                "b_key": 1
-            }
+                "b_key": 1,
+            },
         })
         # Does not error when the types match
         self.validator.validate_event(data, 'array_and_object_event')
@@ -101,7 +101,7 @@ class EventValidationTests(TestCase):
         with self.assertRaises(ValidationError):
             data = json.dumps({
                 'foo': 123,
-                'bar': 'asdf'
+                'bar': 'asdf',
             })
             self.validator.validate_event(data, 'simple_event')
 
@@ -109,7 +109,7 @@ class EventValidationTests(TestCase):
         with self.assertRaises(ValidationError):
             data = json.dumps({
                 'an_array': [1, 2, 3],
-                'an_object': {}
+                'an_object': {},
             })
             self.validator.validate_event(data, 'array_and_object_event')
 
@@ -118,7 +118,7 @@ class EventValidationTests(TestCase):
             data = json.dumps({
                 'an_array': ["a", "b"],
                 'an_object': {
-                    "a_key": "wrong_value"
-                }
+                    "a_key": "wrong_value",
+                },
             })
             self.validator.validate_event(data, 'array_and_object_event')

--- a/orc8r/gateway/python/magma/magmad/bootstrap_manager.py
+++ b/orc8r/gateway/python/magma/magmad/bootstrap_manager.py
@@ -69,7 +69,7 @@ class BootstrapManager(SDWatchdogTask):
     def __init__(self, service, bootstrap_success_cb):
         super().__init__(
             self.PERIODIC_BOOTSTRAP_CHECK_INTERVAL.total_seconds(),
-            service.loop
+            service.loop,
         )
 
         control_proxy_config = load_service_config('control_proxy')
@@ -120,10 +120,13 @@ class BootstrapManager(SDWatchdogTask):
     def _maybe_create_challenge_key(self):
         """Generate key the first time it runs if key does not exist"""
         if not os.path.exists(self._challenge_key_file):
-            logging.info('Generating challenge key and written into %s',
-                         self._challenge_key_file)
+            logging.info(
+                'Generating challenge key and written into %s',
+                self._challenge_key_file,
+            )
             challenge_key = ec.generate_private_key(
-                ec.SECP384R1(), default_backend())
+                ec.SECP384R1(), default_backend(),
+            )
             cert_utils.write_key(challenge_key, self._challenge_key_file)
 
     async def _bootstrap_check(self):
@@ -147,12 +150,14 @@ class BootstrapManager(SDWatchdogTask):
         if now + self.PREEXPIRY_BOOTSTRAP_INTERVAL > cert.not_valid_after:
             logging.info(
                 'Certificate is expiring soon at %s, start bootstrapping',
-                cert.not_valid_after)
+                cert.not_valid_after,
+            )
             await self._bootstrap_now()
             return
         if now < cert.not_valid_before:
             logging.error(
-                'Certificate is not valid until %s', cert.not_valid_before)
+                'Certificate is not valid until %s', cert.not_valid_before,
+            )
             await self._bootstrap_now()
             return
 
@@ -183,7 +188,7 @@ class BootstrapManager(SDWatchdogTask):
         try:
             result = await grpc_async_wrapper(
                 client.GetChallenge.future(AccessGatewayID(id=self._hw_id)),
-                self._loop
+                self._loop,
             )
             await self._get_challenge_done_success(result)
 
@@ -199,12 +204,15 @@ class BootstrapManager(SDWatchdogTask):
             # nghttpx handles the handshake, but if you have a P384 cert and
             # don't proxy your cloud connections, every authenticated Python
             # GRPC call will fail.
-            self._gateway_key = ec.generate_private_key(ec.SECP256R1(),
-                                                        default_backend())
+            self._gateway_key = ec.generate_private_key(
+                ec.SECP256R1(),
+                default_backend(),
+            )
         except InternalError as exp:
             logging.error('Fail to generate private key: %s', exp)
             BOOTSTRAP_EXCEPTION.labels(
-                cause='GetChallengeDonePrivateKey').inc()
+                cause='GetChallengeDonePrivateKey',
+            ).inc()
             self._schedule_next_bootstrap(hard_failure=True)
             return
         # create csr and send for signing
@@ -214,14 +222,17 @@ class BootstrapManager(SDWatchdogTask):
             logging.error('Fail to create csr: %s', exp)
             BOOTSTRAP_EXCEPTION.labels(
                 cause='GetChallengeDoneCreateCSR:%s' % type(
-                    exp).__name__).inc()
+                    exp,
+                ).__name__,
+            ).inc()
 
         try:
             response = self._construct_response(challenge, csr)
         except BootstrapError as exp:
             logging.error('Fail to create response: %s', exp)
             BOOTSTRAP_EXCEPTION.labels(
-                cause='GetChallengeDoneCreateResponse').inc()
+                cause='GetChallengeDoneCreateResponse',
+            ).inc()
             self._schedule_next_bootstrap(hard_failure=True)
             return
         await self._request_sign(response)
@@ -252,7 +263,7 @@ class BootstrapManager(SDWatchdogTask):
             client = BootstrapperStub(chan)
             result = await grpc_async_wrapper(
                 client.RequestSign.future(response),
-                self._loop
+                self._loop,
             )
             await self._request_sign_done_success(result)
 
@@ -262,7 +273,8 @@ class BootstrapManager(SDWatchdogTask):
     async def _request_sign_done_success(self, cert):
         if not self._is_valid_certificate(cert):
             BOOTSTRAP_EXCEPTION.labels(
-                cause='RequestSignDoneInvalidCert').inc()
+                cause='RequestSignDoneInvalidCert',
+            ).inc()
             self._schedule_next_bootstrap(hard_failure=True)
             return
         try:
@@ -270,7 +282,8 @@ class BootstrapManager(SDWatchdogTask):
             cert_utils.write_cert(cert.cert_der, self._gateway_cert_file)
         except Exception as exp:
             BOOTSTRAP_EXCEPTION.labels(
-                cause='RequestSignDoneWriteCert:%s' % type(exp).__name__).inc()
+                cause='RequestSignDoneWriteCert:%s' % type(exp).__name__,
+            ).inc()
             logging.error('Failed to write cert: %s', exp)
 
         # need to restart control_proxy
@@ -302,7 +315,7 @@ class BootstrapManager(SDWatchdogTask):
     def _schedule_next_bootstrap_check(self):
         """Schedule a bootstrap_check"""
         self.set_interval(
-            int(self.PERIODIC_BOOTSTRAP_CHECK_INTERVAL.total_seconds())
+            int(self.PERIODIC_BOOTSTRAP_CHECK_INTERVAL.total_seconds()),
         )
         self._state = BootstrapState.SCHEDULED_CHECK
 
@@ -372,7 +385,8 @@ class BootstrapManager(SDWatchdogTask):
         not_before = cert.not_before.ToDatetime()
         if now < not_before:
             logging.error(
-                'Current system time indicates certificate received is not yet valid (notBefore: %s). Consider checking NTP.', not_before)
+                'Current system time indicates certificate received is not yet valid (notBefore: %s). Consider checking NTP.', not_before,
+            )
             return False
 
         not_after = cert.not_after.ToDatetime()
@@ -400,14 +414,17 @@ class BootstrapManager(SDWatchdogTask):
             challenge_key = cert_utils.load_key(self._challenge_key_file)
         except (IOError, ValueError, TypeError) as e:
             raise BootstrapError(
-                'Gateway does not have a proper challenge key: %s' % e)
+                'Gateway does not have a proper challenge key: %s' % e,
+            )
 
         try:
             signature = challenge_key.sign(
-                challenge, ec.ECDSA(hashes.SHA256()))
+                challenge, ec.ECDSA(hashes.SHA256()),
+            )
         except TypeError:
             raise BootstrapError(
-                'Challenge key cannot be used for ECDSA signature')
+                'Challenge key cannot be used for ECDSA signature',
+            )
 
         r_int, s_int = decode_dss_signature(signature)
         r_bytes = r_int.to_bytes((r_int.bit_length() + 7) // 8, 'big')

--- a/orc8r/gateway/python/magma/magmad/check/kernel_check/kernel_versions.py
+++ b/orc8r/gateway/python/magma/magmad/check/kernel_check/kernel_versions.py
@@ -20,8 +20,10 @@ from collections import namedtuple
 from magma.magmad.check import subprocess_workflow
 
 DpkgCommandParams = namedtuple('DpkgCommandParams', [])
-DpkgCommandResult = namedtuple('DpkgCommandResult',
-                               ['error', 'kernel_versions_installed'])
+DpkgCommandResult = namedtuple(
+    'DpkgCommandResult',
+    ['error', 'kernel_versions_installed'],
+)
 
 
 def get_kernel_versions():
@@ -74,5 +76,5 @@ def parse_dpkg_output(stdout, stderr, _):
         installed = re.findall(r'\S*linux-image\S*', str(stdout))
         return DpkgCommandResult(
             kernel_versions_installed=installed,
-            error=None
+            error=None,
         )

--- a/orc8r/gateway/python/magma/magmad/check/kernel_check/tests/kernel_versions_tests.py
+++ b/orc8r/gateway/python/magma/magmad/check/kernel_check/tests/kernel_versions_tests.py
@@ -23,17 +23,20 @@ from magma.magmad.check.kernel_check import kernel_versions
 class DpkgArgFactoryTests(unittest.TestCase):
     def test_function(self):
         actual = kernel_versions._get_dpkg_command_args_list(
-            kernel_versions.DpkgCommandParams())
+            kernel_versions.DpkgCommandParams(),
+        )
         self.assertEqual(
             ['dpkg', '--list'],
-            actual)
+            actual,
+        )
 
 
 class DpkgParseTests(unittest.TestCase):
 
     def setUp(self):
         self.param = kernel_versions._get_dpkg_command_args_list(
-            kernel_versions.DpkgCommandParams())
+            kernel_versions.DpkgCommandParams(),
+        )
 
     def test_parse_with_errors(self):
         param = kernel_versions.DpkgCommandParams()

--- a/orc8r/gateway/python/magma/magmad/check/network_check/routing_table.py
+++ b/orc8r/gateway/python/magma/magmad/check/network_check/routing_table.py
@@ -18,13 +18,21 @@ from typing import Any, Dict, List, NamedTuple, Optional
 from magma.magmad.check import subprocess_workflow
 
 RouteCommandParams = NamedTuple('RouteCommandParams', [])
-Route = NamedTuple('Route',
-                   [('destination_ip', str), ('gateway_ip', str),
-                    ('genmask', str), ('network_interface_id', str)])
+Route = NamedTuple(
+    'Route',
+    [
+        ('destination_ip', str), ('gateway_ip', str),
+        ('genmask', str), ('network_interface_id', str),
+    ],
+)
 
-RouteCommandResult = NamedTuple('RouteCommandResult',
-                                [('error', Optional[str]),
-                                 ('routing_table', List[Dict[str, Any]])])
+RouteCommandResult = NamedTuple(
+    'RouteCommandResult',
+    [
+        ('error', Optional[str]),
+        ('routing_table', List[Dict[str, Any]]),
+    ],
+)
 
 # TODO: This relies on the SO language being English. Maybe there is a way to
 #  get the info another way.
@@ -35,11 +43,13 @@ def get_routing_table() -> RouteCommandResult:
     Execute route command via subprocess. Blocks while waiting for output.
     Returns the routing table in the form of a list of routes.
     """
-    return list(subprocess_workflow.exec_and_parse_subprocesses(
-        [RouteCommandParams()],
-        _get_route_command_args_list,
-        parse_route_output,
-    ))[0]
+    return list(
+        subprocess_workflow.exec_and_parse_subprocesses(
+            [RouteCommandParams()],
+            _get_route_command_args_list,
+            parse_route_output,
+        ),
+    )[0]
 
 
 def _get_route_command_args_list(_):
@@ -55,10 +65,14 @@ def parse_route_output(stdout, stderr, _):
 
     stdout_decoded = stdout.decode().strip()
     heading = stdout_decoded.split('\n')[1]
-    if heading.split() != ['Destination', 'Gateway', 'Genmask', 'Flags',
-                           'Metric', 'Ref', 'Use', 'Iface']:
-        return RouteCommandResult(error='Unexpected heading: %s' % heading,
-                                  routing_table=[])
+    if heading.split() != [
+        'Destination', 'Gateway', 'Genmask', 'Flags',
+        'Metric', 'Ref', 'Use', 'Iface',
+    ]:
+        return RouteCommandResult(
+            error='Unexpected heading: %s' % heading,
+            routing_table=[],
+        )
 
     # Ignore the title and heading
     lines = stdout_decoded.split('\n')[2:]
@@ -71,7 +85,7 @@ def parse_route_output(stdout, stderr, _):
                 gateway_ip=attrs[1],
                 genmask=attrs[2],
                 network_interface_id=attrs[7],
-            )._asdict()
+            )._asdict(),
         )
     return RouteCommandResult(
         error=None,

--- a/orc8r/gateway/python/magma/magmad/check/network_check/tests/ping_tests.py
+++ b/orc8r/gateway/python/magma/magmad/check/network_check/tests/ping_tests.py
@@ -22,23 +22,29 @@ from magma.magmad.check.network_check import ping
 
 class PingArgFactoryTests(unittest.TestCase):
     def test_function(self):
-        actual = ping._get_ping_command_args_list(ping.PingCommandParams(
-            host_or_ip='google.com',
-            num_packets=4,
-            timeout_secs=5,
-        ))
+        actual = ping._get_ping_command_args_list(
+            ping.PingCommandParams(
+                host_or_ip='google.com',
+                num_packets=4,
+                timeout_secs=5,
+            ),
+        )
         self.assertEqual(
             ['ping', 'google.com', '-c', '4', '-w', '5'],
-            actual)
+            actual,
+        )
 
-        actual = ping._get_ping_command_args_list(ping.PingCommandParams(
-            host_or_ip='google.com',
-            num_packets=None,
-            timeout_secs=None,
-        ))
+        actual = ping._get_ping_command_args_list(
+            ping.PingCommandParams(
+                host_or_ip='google.com',
+                num_packets=None,
+                timeout_secs=None,
+            ),
+        )
         self.assertEqual(
             ['ping', 'google.com', '-c', '4', '-w', '20'],
-            actual)
+            actual,
+        )
 
 
 class PingParseTests(unittest.TestCase):
@@ -54,12 +60,15 @@ class PingParseTests(unittest.TestCase):
         param = ping.PingCommandParams(
             host_or_ip='localhost',
             num_packets=None,
-            timeout_secs=None)
+            timeout_secs=None,
+        )
         actual = ping.parse_ping_output('test', 'test', param)
-        expected = ping.PingCommandResult(error='test',
-                                          host_or_ip='localhost',
-                                          num_packets=ping.DEFAULT_NUM_PACKETS,
-                                          stats=None)
+        expected = ping.PingCommandResult(
+            error='test',
+            host_or_ip='localhost',
+            num_packets=ping.DEFAULT_NUM_PACKETS,
+            stats=None,
+        )
         self.assertEqual(expected, actual)
 
     def test_parse_good_output(self):

--- a/orc8r/gateway/python/magma/magmad/check/network_check/tests/routing_table_tests.py
+++ b/orc8r/gateway/python/magma/magmad/check/network_check/tests/routing_table_tests.py
@@ -18,8 +18,10 @@ from magma.magmad.check.network_check import routing_table
 
 class RoutingTableParseTests(unittest.TestCase):
     def test_parse_bad_output(self):
-        expected = routing_table.RouteCommandResult(error='err',
-                                                    routing_table=[])
+        expected = routing_table.RouteCommandResult(
+            error='err',
+            routing_table=[],
+        )
         actual = routing_table.parse_route_output('output', 'err', None)
         self.assertEqual(expected, actual)
 
@@ -29,7 +31,8 @@ class RoutingTableParseTests(unittest.TestCase):
         ''').strip().encode('ascii')
         expected = routing_table.RouteCommandResult(
             error='Unexpected heading: bad',
-            routing_table=[])
+            routing_table=[],
+        )
         actual = routing_table.parse_route_output(output, '', None)
         self.assertEqual(expected, actual)
 
@@ -84,7 +87,8 @@ class RoutingTableParseTests(unittest.TestCase):
                     genmask='255.255.255.0',
                     network_interface_id='eth2',
                 )._asdict(),
-            ])
+            ],
+        )
         actual = routing_table.parse_route_output(output, '', None)
         self.assertEqual(expected, actual)
 

--- a/orc8r/gateway/python/magma/magmad/check/network_check/tests/traceroute_tests.py
+++ b/orc8r/gateway/python/magma/magmad/check/network_check/tests/traceroute_tests.py
@@ -31,14 +31,18 @@ class TracerouteArgFactoryTests(unittest.TestCase):
         )
         self.assertEqual(
             ['traceroute', '-m', '10', 'google.com', '30'],
-            actual)
+            actual,
+        )
 
         actual = traceroute._get_traceroute_command_args_list(
             traceroute.TracerouteParams(
-                host_or_ip='google.com', max_hops=None, bytes_per_packet=None))
+                host_or_ip='google.com', max_hops=None, bytes_per_packet=None,
+            ),
+        )
         self.assertEqual(
             ['traceroute', '-m', '30', 'google.com', '60'],
-            actual)
+            actual,
+        )
 
 
 class TracerouteParsingTests(unittest.TestCase):
@@ -58,7 +62,8 @@ class TracerouteParsingTests(unittest.TestCase):
         expected = traceroute.TracerouteResult(
             error='test',
             host_or_ip='google.com',
-            stats=None)
+            stats=None,
+        )
         self.assertEqual(expected, actual)
 
     def test_parse_good_output(self):
@@ -74,51 +79,72 @@ class TracerouteParsingTests(unittest.TestCase):
         10  prn1-sidf-cenet-fw1-ae4.corp.tfbnw.net (172.24.4.23)  30.686 ms prn1-sidf-cenet-fw1-ae8.corp.tfbnw.net (172.24.4.25)  23.317 ms prn1-sidf-cenet-fw1-ae4.corp.tfbnw.net (172.24.4.23)  30.546 ms
         '''
         actual = traceroute.TracerouteParser().parse(
-            self._configure_output(output))
+            self._configure_output(output),
+        )
         expected = traceroute.TracerouteStats(
             [
-                traceroute.TracerouteHop(1, [
-                    traceroute.TracerouteProbe(
-                        '10.0.2.2', '10.0.2.2', 0.332),
-                    traceroute.TracerouteProbe(
-                        '10.0.2.2', '10.0.2.2', 0.262),
-                    traceroute.TracerouteProbe(
-                        '10.0.2.2', '10.0.2.2', 0.223),
-                ]),
-                traceroute.TracerouteHop(2, [
-                    traceroute.TracerouteProbe(
-                        'mpk14-21-off-dgw1-vl301.corp.tfbnw.net',
-                        '172.25.164.2', 0.926),
-                    traceroute.TracerouteProbe(
-                        'mpk14-21-off-dgw1-vl301.corp.tfbnw.net',
-                        '172.25.164.2', 0),
-                    traceroute.TracerouteProbe(
-                        'mpk14-21-off-dgw1-vl301.corp.tfbnw.net',
-                        '172.25.164.2', 0),
-                ]),
-                traceroute.TracerouteHop(7, [
-                    traceroute.TracerouteProbe(
-                        'prn1-sidf-cenet-cgw1-be6.corp.tfbnw.net',
-                        '172.24.4.7', 31.895),
-                    traceroute.TracerouteProbe(
-                        'prn1-sidf-cenet-cgw1-be6.corp.tfbnw.net',
-                        '172.24.4.7', 25.105),
-                    traceroute.TracerouteProbe(
-                        'prn1-sidf-cenet-cgw1-be6.corp.tfbnw.net',
-                        '172.24.4.7', 31.396),
-                ]),
-                traceroute.TracerouteHop(10, [
-                    traceroute.TracerouteProbe(
-                        'prn1-sidf-cenet-fw1-ae4.corp.tfbnw.net',
-                        '172.24.4.23', 30.686),
-                    traceroute.TracerouteProbe(
-                        'prn1-sidf-cenet-fw1-ae8.corp.tfbnw.net',
-                        '172.24.4.25', 23.317),
-                    traceroute.TracerouteProbe(
-                        'prn1-sidf-cenet-fw1-ae4.corp.tfbnw.net',
-                        '172.24.4.23', 30.546),
-                ]),
-            ]
+                traceroute.TracerouteHop(
+                    1, [
+                        traceroute.TracerouteProbe(
+                            '10.0.2.2', '10.0.2.2', 0.332,
+                        ),
+                        traceroute.TracerouteProbe(
+                            '10.0.2.2', '10.0.2.2', 0.262,
+                        ),
+                        traceroute.TracerouteProbe(
+                            '10.0.2.2', '10.0.2.2', 0.223,
+                        ),
+                    ],
+                ),
+                traceroute.TracerouteHop(
+                    2, [
+                        traceroute.TracerouteProbe(
+                            'mpk14-21-off-dgw1-vl301.corp.tfbnw.net',
+                            '172.25.164.2', 0.926,
+                        ),
+                        traceroute.TracerouteProbe(
+                            'mpk14-21-off-dgw1-vl301.corp.tfbnw.net',
+                            '172.25.164.2', 0,
+                        ),
+                        traceroute.TracerouteProbe(
+                            'mpk14-21-off-dgw1-vl301.corp.tfbnw.net',
+                            '172.25.164.2', 0,
+                        ),
+                    ],
+                ),
+                traceroute.TracerouteHop(
+                    7, [
+                        traceroute.TracerouteProbe(
+                            'prn1-sidf-cenet-cgw1-be6.corp.tfbnw.net',
+                            '172.24.4.7', 31.895,
+                        ),
+                        traceroute.TracerouteProbe(
+                            'prn1-sidf-cenet-cgw1-be6.corp.tfbnw.net',
+                            '172.24.4.7', 25.105,
+                        ),
+                        traceroute.TracerouteProbe(
+                            'prn1-sidf-cenet-cgw1-be6.corp.tfbnw.net',
+                            '172.24.4.7', 31.396,
+                        ),
+                    ],
+                ),
+                traceroute.TracerouteHop(
+                    10, [
+                        traceroute.TracerouteProbe(
+                            'prn1-sidf-cenet-fw1-ae4.corp.tfbnw.net',
+                            '172.24.4.23', 30.686,
+                        ),
+                        traceroute.TracerouteProbe(
+                            'prn1-sidf-cenet-fw1-ae8.corp.tfbnw.net',
+                            '172.24.4.25', 23.317,
+                        ),
+                        traceroute.TracerouteProbe(
+                            'prn1-sidf-cenet-fw1-ae4.corp.tfbnw.net',
+                            '172.24.4.23', 30.546,
+                        ),
+                    ],
+                ),
+            ],
         )
         self.assertEqual(expected, actual)
 
@@ -145,15 +171,16 @@ class TracerouteParsingTests(unittest.TestCase):
          5  * * *
         '''
         actual = traceroute.TracerouteParser().parse(
-            self._configure_output(output))
+            self._configure_output(output),
+        )
         expected = traceroute.TracerouteStats([
             traceroute.TracerouteHop(
                 4,
-                [traceroute.TracerouteProbe(None, None, 0)] * 3
+                [traceroute.TracerouteProbe(None, None, 0)] * 3,
             ),
             traceroute.TracerouteHop(
                 5,
-                [traceroute.TracerouteProbe(None, None, 0)] * 3
+                [traceroute.TracerouteProbe(None, None, 0)] * 3,
             ),
         ])
         self.assertEqual(expected, actual)

--- a/orc8r/gateway/python/magma/magmad/check/network_check/traceroute.py
+++ b/orc8r/gateway/python/magma/magmad/check/network_check/traceroute.py
@@ -22,18 +22,24 @@ DEFAULT_TTL = 30
 DEFAULT_BYTES_PER_PACKET = 60
 
 
-TracerouteParams = namedtuple('TracerouteParams',
-                              ['host_or_ip', 'max_hops', 'bytes_per_packet'])
+TracerouteParams = namedtuple(
+    'TracerouteParams',
+    ['host_or_ip', 'max_hops', 'bytes_per_packet'],
+)
 
-TracerouteResult = namedtuple('TracerouteResult',
-                              ['error', 'host_or_ip', 'stats'])
+TracerouteResult = namedtuple(
+    'TracerouteResult',
+    ['error', 'host_or_ip', 'stats'],
+)
 
 TracerouteStats = namedtuple('TracerouteStats', ['hops'])
 
 TracerouteHop = namedtuple('TracerouteHop', ['idx', 'probes'])
 
-TracerouteProbe = namedtuple('TracerouteProbe',
-                             ['hostname', 'ip_addr', 'rtt_ms'])
+TracerouteProbe = namedtuple(
+    'TracerouteProbe',
+    ['hostname', 'ip_addr', 'rtt_ms'],
+)
 
 
 def traceroute(params):
@@ -148,17 +154,23 @@ class TracerouteParser(object):
     def _parse_next_probe(self, tokens):
         head_token = tokens.pop(0)
         if head_token == '*':
-            return TracerouteProbe(hostname=self._probe_endpoint.hostname,
-                                   ip_addr=self._probe_endpoint.ip,
-                                   rtt_ms=0)
+            return TracerouteProbe(
+                hostname=self._probe_endpoint.hostname,
+                ip_addr=self._probe_endpoint.ip,
+                rtt_ms=0,
+            )
 
         lookahead_token = tokens.pop(0)
         if lookahead_token == 'ms':
-            return TracerouteProbe(hostname=self._probe_endpoint.hostname,
-                                   ip_addr=self._probe_endpoint.ip,
-                                   rtt_ms=float(head_token))
+            return TracerouteProbe(
+                hostname=self._probe_endpoint.hostname,
+                ip_addr=self._probe_endpoint.ip,
+                rtt_ms=float(head_token),
+            )
         else:
             ip_addr = lookahead_token[1:-1]
-            self._probe_endpoint = self.HostnameAndIP(hostname=head_token,
-                                                      ip=ip_addr)
+            self._probe_endpoint = self.HostnameAndIP(
+                hostname=head_token,
+                ip=ip_addr,
+            )
             return None

--- a/orc8r/gateway/python/magma/magmad/check/tests/subprocess_workflow_tests.py
+++ b/orc8r/gateway/python/magma/magmad/check/tests/subprocess_workflow_tests.py
@@ -27,10 +27,12 @@ class SubprocessWorkflowTests(unittest.TestCase):
         self.mock_parser_callback.return_value = 42
 
         self.process_communicate_mock = mock.Mock(
-            wraps=self._mock_process_communicate)
+            wraps=self._mock_process_communicate,
+        )
         self.process_mock = mock.Mock()
         self.process_mock.configure_mock(
-            communicate=self.process_communicate_mock)
+            communicate=self.process_communicate_mock,
+        )
 
         loop = asyncio.new_event_loop()
         asyncio.set_event_loop(loop)
@@ -73,7 +75,7 @@ class SubprocessWorkflowTests(unittest.TestCase):
                 ['param2', 'a', 'b'],
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
-            )
+            ),
         ])
         self.mock_parser_callback.assert_has_calls([
             mock.call('stdout', 'stderr', 'param1'),
@@ -83,7 +85,7 @@ class SubprocessWorkflowTests(unittest.TestCase):
     def test_async_subprocess_exec(self):
         with mock.patch.object(
                 asyncio, 'create_subprocess_exec',
-                mock.Mock(wraps=self._mock_async_subprocess)
+                mock.Mock(wraps=self._mock_async_subprocess),
         ) as m:
             loop = asyncio.get_event_loop()
             actual = loop.run_until_complete(
@@ -91,7 +93,7 @@ class SubprocessWorkflowTests(unittest.TestCase):
                     self.mock_params,
                     self._mock_arg_factory,
                     self.mock_parser_callback,
-                )
+                ),
             )
 
             self.assertEqual([42, 42], list(actual))
@@ -107,7 +109,7 @@ class SubprocessWorkflowTests(unittest.TestCase):
                     stdout=subprocess.PIPE,
                     stderr=subprocess.PIPE,
                     loop=loop,
-                )
+                ),
             ])
             self.mock_parser_callback.assert_has_calls([
                 mock.call('stdout', 'stderr', 'param1'),
@@ -120,8 +122,10 @@ class SubprocessWorkflowTests(unittest.TestCase):
         def mock_subprocess_raises(*args, **kwargs):
             raise ValueError('oops')
 
-        with mock.patch.object(asyncio, 'create_subprocess_exec',
-                               mock.Mock(wraps=mock_subprocess_raises)):
+        with mock.patch.object(
+            asyncio, 'create_subprocess_exec',
+            mock.Mock(wraps=mock_subprocess_raises),
+        ):
             loop = asyncio.get_event_loop()
             with self.assertRaises(ValueError) as e:
                 loop.run_until_complete(
@@ -129,7 +133,7 @@ class SubprocessWorkflowTests(unittest.TestCase):
                         self.mock_params,
                         self._mock_arg_factory,
                         self.mock_parser_callback,
-                    )
+                    ),
                 )
             self.assertEqual('oops', e.exception.args[0])
 
@@ -143,7 +147,7 @@ class SubprocessWorkflowTests(unittest.TestCase):
         with mock.patch.object(
                 asyncio,
                 'create_subprocess_exec',
-                mock.Mock(wraps=self._mock_async_subprocess)
+                mock.Mock(wraps=self._mock_async_subprocess),
         ) as m:
             loop = asyncio.get_event_loop()
             with self.assertRaises(ValueError) as e:
@@ -152,7 +156,7 @@ class SubprocessWorkflowTests(unittest.TestCase):
                         self.mock_params,
                         self._mock_arg_factory,
                         self.mock_parser_callback,
-                    )
+                    ),
                 )
             self.assertEqual('oops', e.exception.args[0])
             m.assert_has_calls([
@@ -167,13 +171,13 @@ class SubprocessWorkflowTests(unittest.TestCase):
                     stdout=subprocess.PIPE,
                     stderr=subprocess.PIPE,
                     loop=loop,
-                )
+                ),
             ])
 
     def test_async_subprocess_empty_params(self):
         with mock.patch.object(
                 asyncio, 'create_subprocess_exec',
-                mock.Mock(wraps=self._mock_async_subprocess)
+                mock.Mock(wraps=self._mock_async_subprocess),
         ) as m:
             loop = asyncio.get_event_loop()
             actual = loop.run_until_complete(
@@ -181,7 +185,7 @@ class SubprocessWorkflowTests(unittest.TestCase):
                     [],
                     self._mock_arg_factory,
                     self.mock_parser_callback,
-                )
+                ),
             )
 
             self.assertEqual([], list(actual))

--- a/orc8r/gateway/python/magma/magmad/config_manager.py
+++ b/orc8r/gateway/python/magma/magmad/config_manager.py
@@ -36,9 +36,11 @@ class ConfigManager(StreamerClient.Callback):
     JSON format.
     """
 
-    def __init__(self, services: List[str], service_manager: ServiceManager,
-                 magmad_service: MagmaService, mconfig_manager: MconfigManager,
-                 allow_unknown_fields: bool = True, loop=None) -> None:
+    def __init__(
+        self, services: List[str], service_manager: ServiceManager,
+        magmad_service: MagmaService, mconfig_manager: MconfigManager,
+        allow_unknown_fields: bool = True, loop=None,
+    ) -> None:
         """
         Args:
             services: List of services to manage
@@ -65,7 +67,8 @@ class ConfigManager(StreamerClient.Callback):
         if digest is None:
             return None
         mconfig_digest_proto = GatewayConfigsDigest(
-            md5_hex_digest=digest.md5_hex_digest)
+            md5_hex_digest=digest.md5_hex_digest,
+        )
         return mconfig_digest_proto
 
     def process_update(self, stream_name, updates, resync):
@@ -112,7 +115,7 @@ class ConfigManager(StreamerClient.Callback):
                 self._service_manager.update_dynamic_services(
                     load_service_mconfig('magmad', mconfigs_pb2.MagmaD())
                     .dynamic_services,
-                )
+                ),
             )
 
         services_to_restart = [

--- a/orc8r/gateway/python/magma/magmad/events.py
+++ b/orc8r/gateway/python/magma/magmad/events.py
@@ -30,7 +30,7 @@ def processed_updates(configs_by_service):
             event_type="processed_updates",
             tag=snowflake.snowflake(),
             value=json.dumps(configs),
-        )
+        ),
     )
 
 
@@ -43,7 +43,7 @@ def restarted_services(services):
             event_type="restarted_services",
             tag=snowflake.snowflake(),
             value=json.dumps(RestartedServices(services=services).to_dict()),
-        )
+        ),
     )
 
 
@@ -53,8 +53,8 @@ def established_sync_rpc_stream():
             stream_name="magmad",
             event_type="established_sync_rpc_stream",
             tag=snowflake.snowflake(),
-            value="{}"
-        )
+            value="{}",
+        ),
     )
 
 
@@ -64,6 +64,6 @@ def disconnected_sync_rpc_stream():
             stream_name="magmad",
             event_type="disconnected_sync_rpc_stream",
             tag=snowflake.snowflake(),
-            value="{}"
-        )
+            value="{}",
+        ),
     )

--- a/orc8r/gateway/python/magma/magmad/gateway_status.py
+++ b/orc8r/gateway/python/magma/magmad/gateway_status.py
@@ -39,55 +39,79 @@ from magma.magmad.service_poller import ServicePoller
 
 GatewayStatus = NamedTuple(
     'GatewayStatus',
-    [('machine_info', Dict[str, Any]), ('meta', Dict[str, str]),
-     ('platform_info', Dict[str, Any]), ('system_status', Dict[str, Any])])
+    [
+        ('machine_info', Dict[str, Any]), ('meta', Dict[str, str]),
+        ('platform_info', Dict[str, Any]), ('system_status', Dict[str, Any]),
+    ],
+)
 
 SystemStatus = NamedTuple(
     'SystemStatus',
-    [('time', int), ('uptime_secs', int), ('cpu_user', int),
-     ('cpu_system', int), ('cpu_idle', int), ('mem_total', int),
-     ('mem_available', int), ('mem_used', int), ('mem_free', int),
-     ('swap_total', int), ('swap_used', int), ('swap_free', int),
-     ('disk_partitions', List[Dict[str, Any]])])
+    [
+        ('time', int), ('uptime_secs', int), ('cpu_user', int),
+        ('cpu_system', int), ('cpu_idle', int), ('mem_total', int),
+        ('mem_available', int), ('mem_used', int), ('mem_free', int),
+        ('swap_total', int), ('swap_used', int), ('swap_free', int),
+        ('disk_partitions', List[Dict[str, Any]]),
+    ],
+)
 
 PlatformInfo = NamedTuple(
     'PlatformInfo',
-    [('vpn_ip', str), ('packages', List[Dict[str, Any]]),
-     ('kernel_version', str), ('kernel_versions_installed', List[str]),
-     ('config_info', Dict[str, Any])])
+    [
+        ('vpn_ip', str), ('packages', List[Dict[str, Any]]),
+        ('kernel_version', str), ('kernel_versions_installed', List[str]),
+        ('config_info', Dict[str, Any]),
+    ],
+)
 
 MachineInfo = NamedTuple(
     'MachineInfo',
-    [('cpu_info', Dict[str, Any]), ('network_info', Dict[str, Any])])
+    [('cpu_info', Dict[str, Any]), ('network_info', Dict[str, Any])],
+)
 
 NetworkInfo = NamedTuple(
     'NetworkInfo',
-    [('network_interfaces', List[Dict[str, Any]]),
-     ('routing_table', List[Dict[str, Any]])])
+    [
+        ('network_interfaces', List[Dict[str, Any]]),
+        ('routing_table', List[Dict[str, Any]]),
+    ],
+)
 
 DiskPartition = NamedTuple(
     'DiskPartition',
-    [('device', str), ('mount_point', str), ('total', int), ('used', int),
-     ('free', int)])
+    [
+        ('device', str), ('mount_point', str), ('total', int), ('used', int),
+        ('free', int),
+    ],
+)
 
 ConfigInfo = NamedTuple(
     'ConfigInfo',
-    [('mconfig_created_at', int)])
+    [('mconfig_created_at', int)],
+)
 
 Package = NamedTuple(
     'Package',
-    [('name', str), ('version', str)])
+    [('name', str), ('version', str)],
+)
 
 CPUInfo = NamedTuple(
     'CPUInfo',
-    [('core_count', int), ('threads_per_core', int), ('architecture', str),
-     ('model_name', str)])
+    [
+        ('core_count', int), ('threads_per_core', int), ('architecture', str),
+        ('model_name', str),
+    ],
+)
 
 NetworkInterface = NamedTuple(
     'NetworkInterface',
-    [('network_interface_id', str), ('mac_address', str),
-     ('ip_addresses', List[str]), ('status', str),
-     ('ipv6_addresses', List[str])])
+    [
+        ('network_interface_id', str), ('mac_address', str),
+        ('ip_addresses', List[str]), ('status', str),
+        ('ipv6_addresses', List[str]),
+    ],
+)
 
 
 class KernelVersionsPoller(Job):
@@ -100,7 +124,7 @@ class KernelVersionsPoller(Job):
     def __init__(self, service):
         super().__init__(
             interval=service.mconfig.checkin_interval,
-            loop=service.loop
+            loop=service.loop,
         )
         self._kernel_versions_installed = []
 
@@ -125,9 +149,11 @@ class GatewayStatusFactory:
     GatewayStatus defined in the orc8r.
     """
 
-    def __init__(self, service: MagmaService,
-                 service_poller: ServicePoller,
-                 kernel_version_poller: Optional[KernelVersionsPoller]):
+    def __init__(
+        self, service: MagmaService,
+        service_poller: ServicePoller,
+        kernel_version_poller: Optional[KernelVersionsPoller],
+    ):
         self._service = service
         self._service_poller = service_poller
 
@@ -141,7 +167,8 @@ class GatewayStatusFactory:
         # track services that are required to have non empty meta in order to
         # check-in
         self._required_service_metas = frozenset(
-            service.config.get("skip_checkin_if_missing_meta_services", []))
+            service.config.get("skip_checkin_if_missing_meta_services", []),
+        )
 
     def get_serialized_status(self) -> Tuple[str, bool]:
         """
@@ -168,7 +195,7 @@ class GatewayStatusFactory:
             has_required_service_meta
 
     def _fill_in_meta(
-        self, gw_status: GatewayStatus
+        self, gw_status: GatewayStatus,
     ) -> Tuple[GatewayStatus, KeysView]:
         service_status_meta = self._gather_service_status_meta()
         for statusmeta in service_status_meta.values():
@@ -228,8 +255,10 @@ class GatewayStatusFactory:
             swap_total=swap.total,
             swap_used=swap.used,
             swap_free=swap.free,
-            disk_partitions=[partition._asdict() for partition in
-                             partition_gen()],
+            disk_partitions=[
+                partition._asdict() for partition in
+                partition_gen()
+            ],
         )
         return system_status
 
@@ -278,13 +307,15 @@ class GatewayStatusFactory:
 
                 try:
                     ip_addresses = get_all_ips_from_if_cidr(
-                        interface, IpPreference.IPV4_ONLY)
+                        interface, IpPreference.IPV4_ONLY,
+                    )
                 except ValueError:
                     ip_addresses = []
 
                 try:
                     ipv6_addresses = get_all_ips_from_if_cidr(
-                        interface, IpPreference.IPV6_ONLY)
+                        interface, IpPreference.IPV6_ONLY,
+                    )
                 except ValueError:
                     ipv6_addresses = []
 
@@ -298,13 +329,16 @@ class GatewayStatusFactory:
 
         routing_cmd_result = get_routing_table()
         if routing_cmd_result.error is not None:
-            logging.error("Failed to get routing table: %s",
-                          routing_cmd_result.error)
+            logging.error(
+                "Failed to get routing table: %s",
+                routing_cmd_result.error,
+            )
 
         network_info = NetworkInfo(
             network_interfaces=[
                 network_interface._asdict() for network_interface in
-                network_interface_gen()],
+                network_interface_gen()
+            ],
             routing_table=routing_cmd_result.routing_table,
         )
         return network_info
@@ -324,6 +358,7 @@ class GatewayStatusFactory:
             logging.warning(
                 "Missing meta from services: %s "
                 "(specified in cfg skip_checkin_if_missing_meta_services)",
-                ", ".join(self._required_service_metas - got_meta_services))
+                ", ".join(self._required_service_metas - got_meta_services),
+            )
 
         return has_required_services

--- a/orc8r/gateway/python/magma/magmad/generic_command/command_executor.py
+++ b/orc8r/gateway/python/magma/magmad/generic_command/command_executor.py
@@ -61,8 +61,10 @@ def get_command_executor_impl(service):
     impl_class = config.get('class', None)
     assert module is not None, 'generic command module not found'
     assert impl_class is not None, 'generic command class not found'
-    command_executor_class = getattr(importlib.import_module(module),
-                                     impl_class)
+    command_executor_class = getattr(
+        importlib.import_module(module),
+        impl_class,
+    )
     command_executor = command_executor_class(service.config, service.loop)
     assert isinstance(command_executor, CommandExecutor), \
         'command_executor is not an instance of CommandExecutor'

--- a/orc8r/gateway/python/magma/magmad/generic_command/shell_command_executor.py
+++ b/orc8r/gateway/python/magma/magmad/generic_command/shell_command_executor.py
@@ -38,13 +38,13 @@ class ShellCommandExecutor(CommandExecutor):
         self._dispatch_table = get_shell_commands_from_config(config)
 
     def get_command_dispatch(
-            self
+            self,
     ) -> Dict[str, ExecutorFuncT]:
         return self._dispatch_table
 
 
 def get_shell_commands_from_config(
-        config: Dict[str, Any]
+        config: Dict[str, Any],
 ) -> Dict[str, ExecutorFuncT]:
     """
     Gets a list of shell commands from the config. Creates subprocess
@@ -65,16 +65,18 @@ def get_shell_commands_from_config(
         allow_params = shell_command.get('allow_params', False)
 
         logging.debug("Loading command %s", name)
-        command_dispatch_table[name] = partial(_run_subprocess,
-                                               command,
-                                               allow_params)
+        command_dispatch_table[name] = partial(
+            _run_subprocess,
+            command,
+            allow_params,
+        )
     return command_dispatch_table
 
 
 async def _run_subprocess(
         cmd: str,
         allow_params: bool,
-        params: Dict[str, ParamValueT]
+        params: Dict[str, ParamValueT],
 ) -> Dict[str, Any]:
     """
     Runs a command given params (optional), and returns the return code,
@@ -99,5 +101,5 @@ async def _run_subprocess(
     return {
         "returncode": process.returncode,
         "stdout": stdout.decode(),
-        "stderr": stderr.decode()
+        "stderr": stderr.decode(),
     }

--- a/orc8r/gateway/python/magma/magmad/generic_command/tests/command_executor_test.py
+++ b/orc8r/gateway/python/magma/magmad/generic_command/tests/command_executor_test.py
@@ -23,7 +23,7 @@ class FakeCommandExecutor(CommandExecutor):
 
         async def test_func_1(_):
             return {
-                "success": True
+                "success": True,
             }
 
         async def test_func_2(params):
@@ -46,7 +46,7 @@ class CommandExecutorTest(unittest.TestCase):
 
     def test_execute_command(self):
         result = asyncio.get_event_loop().run_until_complete(
-            self.command_executor.execute_command("test_1", {})
+            self.command_executor.execute_command("test_1", {}),
         )
         self.assertEqual(result["success"], True)
 
@@ -56,6 +56,6 @@ class CommandExecutorTest(unittest.TestCase):
             "b": "c",
         }
         result = asyncio.get_event_loop().run_until_complete(
-            self.command_executor.execute_command("test_2", params)
+            self.command_executor.execute_command("test_2", params),
         )
         self.assertEqual(result, params)

--- a/orc8r/gateway/python/magma/magmad/generic_command/tests/shell_command_executor_test.py
+++ b/orc8r/gateway/python/magma/magmad/generic_command/tests/shell_command_executor_test.py
@@ -30,8 +30,8 @@ class ShellCommandExecutorTest(unittest.TestCase):
                 'shell_commands': [
                     {'name': 'test_1', 'command': '/bin/true'},
                     {'name': 'test_2', 'command': '/bin/false'},
-                ]
-            }
+                ],
+            },
         }
         table = get_shell_commands_from_config(self.service.config)
         self.assertIn('test_1', table)
@@ -44,7 +44,7 @@ class ShellCommandExecutorTest(unittest.TestCase):
 
     def test_get_shell_cmds_missing_shell_commands_list(self):
         self.service.config = {
-            'generic_command_config': {}
+            'generic_command_config': {},
         }
         table = get_shell_commands_from_config(self.service.config)
         self.assertEqual(table, {})
@@ -55,8 +55,8 @@ class ShellCommandExecutorTest(unittest.TestCase):
                 'shell_commands': [
                     {'name': 'test_1'},
                     {'command': '/bin/false'},
-                ]
-            }
+                ],
+            },
         }
         table = get_shell_commands_from_config(self.service.config)
         self.assertEqual(table, {})
@@ -66,18 +66,20 @@ class ShellCommandExecutorTest(unittest.TestCase):
             'generic_command_config': {
                 'shell_commands': [
                     {'name': 'test_1', 'command': 'echo'},
-                ]
-            }
+                ],
+            },
         }
 
         table = get_shell_commands_from_config(self.service.config)
         func_1 = table['test_1']
         result_1 = asyncio.get_event_loop().run_until_complete(
-            func_1(mock.Mock())
+            func_1(mock.Mock()),
         )
 
-        self.assertEqual(result_1,
-                         {'stdout': '\n', 'stderr': '', 'returncode': 0})
+        self.assertEqual(
+            result_1,
+            {'stdout': '\n', 'stderr': '', 'returncode': 0},
+        )
 
     def test_get_shell_cmds_funcs_with_params(self):
         self.service.config = {
@@ -86,24 +88,24 @@ class ShellCommandExecutorTest(unittest.TestCase):
                     {
                         'name': 'test_1',
                         'command': 'echo {} {}',
-                        'allow_params': True
+                        'allow_params': True,
                     },
-                ]
-            }
+                ],
+            },
         }
         params = {
-            "shell_params": ["Hello", "world!"]
+            "shell_params": ["Hello", "world!"],
         }
 
         table = get_shell_commands_from_config(self.service.config)
         func_1 = table['test_1']
         result_1 = asyncio.get_event_loop().run_until_complete(
-            func_1(params)
+            func_1(params),
         )
 
         self.assertEqual(
             result_1,
-            {'stdout': 'Hello world!\n', 'stderr': '', 'returncode': 0}
+            {'stdout': 'Hello world!\n', 'stderr': '', 'returncode': 0},
         )
         pass
 
@@ -112,15 +114,15 @@ class ShellCommandExecutorTest(unittest.TestCase):
             'generic_command_config': {
                 'shell_commands': [
                     {'name': 'test_1', 'command': 'nonexistent/command foo'},
-                ]
-            }
+                ],
+            },
         }
 
         table = get_shell_commands_from_config(self.service.config)
         func_1 = table['test_1']
         try:
             asyncio.get_event_loop().run_until_complete(
-                func_1(mock.Mock())
+                func_1(mock.Mock()),
             )
             self.fail('An exception should have been raised')
         except FileNotFoundError:

--- a/orc8r/gateway/python/magma/magmad/service_health_watchdog.py
+++ b/orc8r/gateway/python/magma/magmad/service_health_watchdog.py
@@ -32,13 +32,15 @@ class ServiceHealthWatchdog(Job):
     # Default number of continuous timeouts before doing a service restart
     DEFAULT_RESTART_TIMEOUT_THRESHOLD = 15
 
-    def __init__(self, config: Any,
-                 loop: asyncio.AbstractEventLoop,
-                 service_poller: ServicePoller,
-                 service_manager: ServiceManager):
+    def __init__(
+        self, config: Any,
+        loop: asyncio.AbstractEventLoop,
+        service_poller: ServicePoller,
+        service_manager: ServiceManager,
+    ):
         super().__init__(
             interval=self.CHECK_STATUS_INTERVAL,
-            loop=loop
+            loop=loop,
         )
         self._loop = loop
         self._config = config
@@ -71,5 +73,5 @@ class ServiceHealthWatchdog(Job):
                 self._service_poller.reset_timeout_counter(service)
         if services_to_restart:
             await asyncio.gather(
-                self._service_manager.restart_services(services_to_restart)
+                self._service_manager.restart_services(services_to_restart),
             )

--- a/orc8r/gateway/python/magma/magmad/state_reporter.py
+++ b/orc8r/gateway/python/magma/magmad/state_reporter.py
@@ -43,11 +43,13 @@ class StateReporterErrorHandler:
     permission issues.
     """
 
-    def __init__(self,
-                 loop: asyncio.AbstractEventLoop,
-                 config: Any,
-                 grpc_client_manager: GRPCClientManager,
-                 bootstrap_manager: BootstrapManager):
+    def __init__(
+        self,
+        loop: asyncio.AbstractEventLoop,
+        config: Any,
+        grpc_client_manager: GRPCClientManager,
+        bootstrap_manager: BootstrapManager,
+    ):
         self._loop = loop
         # Number of consecutive failed state reporting before we check for an
         # outdated cert
@@ -73,15 +75,19 @@ class StateReporterErrorHandler:
         the threshold specified in the config. If it does, it will trigger a
         bootstrap if the certificate is invalid.
         """
-        logging.error("Checkin Error! Failed to report states. [%s] %s",
-                      err.code(), err.details())
+        logging.error(
+            "Checkin Error! Failed to report states. [%s] %s",
+            err.code(), err.details(),
+        )
         CHECKIN_STATUS.set(0)
         self.num_failed_state_reporting += 1
         if self.num_failed_state_reporting >= self.fail_threshold:
-            logging.info('StateReporting (Checkin) failure threshold met, '
-                         'remediating...')
+            logging.info(
+                'StateReporting (Checkin) failure threshold met, '
+                'remediating...',
+            )
             asyncio.ensure_future(
-                self._schedule_bootstrap_if_cert_is_invalid(err.code())
+                self._schedule_bootstrap_if_cert_is_invalid(err.code()),
             )
         self._grpc_client_manager.on_grpc_fail(err.code())
 
@@ -104,8 +110,10 @@ class StateReporterErrorHandler:
             await self._bootstrap_manager.schedule_bootstrap_now()
             return
         else:
-            logging.error('StateReporting failure likely '
-                          'not due to invalid cert')
+            logging.error(
+                'StateReporting failure likely '
+                'not due to invalid cert',
+            )
 
 
 class StateReporter(SDWatchdogTask):
@@ -118,14 +126,16 @@ class StateReporter(SDWatchdogTask):
     states to the cloud.
     """
 
-    def __init__(self, config: Any, mconfig: Any,
-                 loop: asyncio.AbstractEventLoop,
-                 bootstrap_manager: BootstrapManager,
-                 gw_status_factory: GatewayStatusFactory,
-                 grpc_client_manager: GRPCClientManager):
+    def __init__(
+        self, config: Any, mconfig: Any,
+        loop: asyncio.AbstractEventLoop,
+        bootstrap_manager: BootstrapManager,
+        gw_status_factory: GatewayStatusFactory,
+        grpc_client_manager: GRPCClientManager,
+    ):
         super().__init__(
             interval=max(mconfig.checkin_interval, 5),
-            loop=loop
+            loop=loop,
         )
         self._loop = loop
         # keep a pointer to mconfig since config stored can change over time
@@ -150,7 +160,7 @@ class StateReporter(SDWatchdogTask):
         # A dictionary of all services registered with a service303 interface.
         # Holds service name to service info gathered from the config
         self._service_info_by_name = self._construct_service_info_by_name(
-            config=config
+            config=config,
         )
 
         # Initially set status to 1, otherwise on the first round we report a
@@ -186,7 +196,8 @@ class StateReporter(SDWatchdogTask):
 
     async def _send_to_state_service(
             self,
-            request: ReportStatesRequest) -> None:
+            request: ReportStatesRequest,
+    ) -> None:
         state_client = self._grpc_client_manager.get_client()
         try:
             response = await grpc_async_wrapper(
@@ -194,16 +205,20 @@ class StateReporter(SDWatchdogTask):
                     request,
                     self._mconfig.checkin_timeout,
                 ),
-                self._loop)
+                self._loop,
+            )
             for idAndError in response.unreportedStates:
                 logging.error(
                     "Failed to report state for (%s,%s): %s",
-                    idAndError.type, idAndError.deviceID, idAndError.error)
+                    idAndError.type, idAndError.deviceID, idAndError.error,
+                )
             # Report that the gateway successfully connected to the cloud
             CHECKIN_STATUS.set(1)
             self._error_handler.num_failed_state_reporting = 0
-            logging.info("Checkin Successful! "
-                         "Successfully sent states to the cloud!")
+            logging.info(
+                "Checkin Successful! "
+                "Successfully sent states to the cloud!",
+            )
         except grpc.RpcError as err:
             self._error_handler.report_to_cloud_error(err)
         finally:
@@ -225,8 +240,10 @@ class StateReporter(SDWatchdogTask):
                 states.append(result.states[i])
             return states
         except Exception as err:
-            logging.error("GetOperationalStates Error for %s! [%s] %s",
-                          service, err.code(), err.details())
+            logging.error(
+                "GetOperationalStates Error for %s! [%s] %s",
+                service, err.code(), err.details(),
+            )
             return []
 
     def _get_gw_state(self) -> Optional[State]:
@@ -243,7 +260,8 @@ class StateReporter(SDWatchdogTask):
             logging.warning(
                 "Number of skipped checkins exceeds %d "
                 "(cfg: max_skipped_checkins). Checking in anyway.",
-                self._error_handler.max_skipped_gw_states)
+                self._error_handler.max_skipped_gw_states,
+            )
             # intentionally don't reset num_skipped_gateway_states here
             return self._make_state(gw_type, snowflake.snowflake(), gw_state)
 

--- a/orc8r/gateway/python/magma/magmad/tests/collector_tests.py
+++ b/orc8r/gateway/python/magma/magmad/tests/collector_tests.py
@@ -65,17 +65,21 @@ class MetricsCollectorTests(unittest.TestCase):
 
     def setUp(self):
         ServiceRegistry.add_service('test', '0.0.0.0', 0)
-        ServiceRegistry._PROXY_CONFIG = {'local_port': 1234,
-                                         'cloud_address': 'test',
-                                         'proxy_cloud_connections': True}
+        ServiceRegistry._PROXY_CONFIG = {
+            'local_port': 1234,
+            'cloud_address': 'test',
+            'proxy_cloud_connections': True,
+        }
 
         self._services = ['test']
         self.gateway_id = "2876171d-bf38-4254-b4da-71a713952904"
         self.timeout = 1
-        self._collector = MetricsCollector(self._services, 5, 10,
-                                           self.timeout,
-                                           grpc_max_msg_size_mb=4,
-                                           loop=asyncio.new_event_loop())
+        self._collector = MetricsCollector(
+            self._services, 5, 10,
+            self.timeout,
+            grpc_max_msg_size_mb=4,
+            loop=asyncio.new_event_loop(),
+        )
 
     @unittest.mock.patch('magma.magmad.metrics_collector.MetricsControllerStub')
     def test_sync(self, controller_mock):
@@ -87,7 +91,8 @@ class MetricsCollectorTests(unittest.TestCase):
         mock.Collect.future.side_effect = [
             unittest.mock.Mock(),
             unittest.mock.Mock(),
-            unittest.mock.Mock()]
+            unittest.mock.Mock(),
+        ]
         controller_mock.side_effect = [mock, mock, mock]
 
         # Call with no samples
@@ -105,11 +110,14 @@ class MetricsCollectorTests(unittest.TestCase):
         mock.Collect.future.assert_called_once_with(
             MetricsContainer(
                 gatewayId=self.gateway_id,
-                family=samples),
-            self.timeout)
+                family=samples,
+            ),
+            self.timeout,
+        )
         self.assertCountEqual(
             self._collector._samples_for_service[service_name],
-            [])
+            [],
+        )
 
         # Reduce max msg size to trigger msg chunking
         self._collector.grpc_max_msg_size_bytes = 1500
@@ -124,16 +132,21 @@ class MetricsCollectorTests(unittest.TestCase):
         mock.Collect.future.assert_any_call(
             MetricsContainer(
                 gatewayId=self.gateway_id,
-                family=chunk1),
-            self.timeout)
+                family=chunk1,
+            ),
+            self.timeout,
+        )
         mock.Collect.future.assert_any_call(
             MetricsContainer(
                 gatewayId=self.gateway_id,
-                family=chunk2),
-            self.timeout)
+                family=chunk2,
+            ),
+            self.timeout,
+        )
         self.assertCountEqual(
             self._collector._samples_for_service[service_name],
-            [])
+            [],
+        )
 
     def test_collect(self):
         """
@@ -152,7 +165,8 @@ class MetricsCollectorTests(unittest.TestCase):
         # collector should add one more metric for collection success/failure
         self.assertEqual(
             len(self._collector._samples_for_service[service_name]),
-            len(samples * 2) + 1)
+            len(samples * 2) + 1,
+        )
 
     def test_collect_start_time(self):
         """
@@ -176,10 +190,12 @@ class MetricsCollectorTests(unittest.TestCase):
         # should have uptime, start time, and collection success
         self.assertEqual(
             len(self._collector._samples_for_service[service_name]),
-            3)
+            3,
+        )
         uptime_list = [
             fam for fam in self._collector._samples_for_service[service_name]
-            if fam.name == str(metricsd_pb2.process_uptime_seconds)]
+            if fam.name == str(metricsd_pb2.process_uptime_seconds)
+        ]
         self.assertEqual(len(uptime_list), 1)
         self.assertEqual(len(uptime_list[0].metric), 1)
         self.assertGreater(uptime_list[0].metric[0].gauge.value, 0)
@@ -260,21 +276,33 @@ class MetricsCollectorTests(unittest.TestCase):
         )
         # Add first unique labelset metrics
         test_summary.add_metric(["val1"], 10, 0.1)
-        test_summary.add_sample("test",
-                                {"quantile": "0.0", "testLabel": "val1"}, 0.01)
-        test_summary.add_sample("test",
-                                {"quantile": "0.5", "testLabel": "val1"}, 0.02)
-        test_summary.add_sample("test",
-                                {"quantile": "1.0", "testLabel": "val1"}, 0.03)
+        test_summary.add_sample(
+            "test",
+            {"quantile": "0.0", "testLabel": "val1"}, 0.01,
+        )
+        test_summary.add_sample(
+            "test",
+            {"quantile": "0.5", "testLabel": "val1"}, 0.02,
+        )
+        test_summary.add_sample(
+            "test",
+            {"quantile": "1.0", "testLabel": "val1"}, 0.03,
+        )
 
         # Add second unique labelset metrics
         test_summary.add_metric(["val2"], 20, 0.2)
-        test_summary.add_sample("test",
-                                {"quantile": "0.0", "testLabel": "val2"}, 0.02)
-        test_summary.add_sample("test",
-                                {"quantile": "0.5", "testLabel": "val2"}, 0.04)
-        test_summary.add_sample("test",
-                                {"quantile": "1.0", "testLabel": "val2"}, 0.06)
+        test_summary.add_sample(
+            "test",
+            {"quantile": "0.0", "testLabel": "val2"}, 0.02,
+        )
+        test_summary.add_sample(
+            "test",
+            {"quantile": "0.5", "testLabel": "val2"}, 0.04,
+        )
+        test_summary.add_sample(
+            "test",
+            {"quantile": "1.0", "testLabel": "val2"}, 0.06,
+        )
 
         protos = _summary_to_proto(test_summary)
         self.assertEqual(2, len(protos))
@@ -287,23 +315,35 @@ class MetricsCollectorTests(unittest.TestCase):
                 self.assertEqual(10, proto.metric[0].summary.sample_count)
                 self.assertEqual(0.1, proto.metric[0].summary.sample_sum)
                 self.assertEqual(3, len(proto.metric[0].summary.quantile))
-                self.assertEqual(0.01,
-                                 proto.metric[0].summary.quantile[0].value)
-                self.assertEqual(0.02,
-                                 proto.metric[0].summary.quantile[1].value)
-                self.assertEqual(0.03,
-                                 proto.metric[0].summary.quantile[2].value)
+                self.assertEqual(
+                    0.01,
+                    proto.metric[0].summary.quantile[0].value,
+                )
+                self.assertEqual(
+                    0.02,
+                    proto.metric[0].summary.quantile[1].value,
+                )
+                self.assertEqual(
+                    0.03,
+                    proto.metric[0].summary.quantile[2].value,
+                )
             else:
                 self.assertEqual(1, len(proto.metric))
                 self.assertEqual(20, proto.metric[0].summary.sample_count)
                 self.assertEqual(0.2, proto.metric[0].summary.sample_sum)
                 self.assertEqual(3, len(proto.metric[0].summary.quantile))
-                self.assertEqual(0.02,
-                                 proto.metric[0].summary.quantile[0].value)
-                self.assertEqual(0.04,
-                                 proto.metric[0].summary.quantile[1].value)
-                self.assertEqual(0.06,
-                                 proto.metric[0].summary.quantile[2].value)
+                self.assertEqual(
+                    0.02,
+                    proto.metric[0].summary.quantile[0].value,
+                )
+                self.assertEqual(
+                    0.04,
+                    proto.metric[0].summary.quantile[1].value,
+                )
+                self.assertEqual(
+                    0.06,
+                    proto.metric[0].summary.quantile[2].value,
+                )
 
     def test_histogram_to_proto(self):
         test_hist = prometheus_client.core.HistogramMetricFamily(
@@ -328,23 +368,41 @@ class MetricsCollectorTests(unittest.TestCase):
                 self.assertEqual(3, proto.metric[0].histogram.sample_count)
                 self.assertEqual(6, proto.metric[0].histogram.sample_sum)
                 self.assertEqual(3, len(proto.metric[0].histogram.bucket))
-                self.assertEqual(1, proto.metric[0].histogram.bucket[
-                    0].cumulative_count)
-                self.assertEqual(2, proto.metric[0].histogram.bucket[
-                    1].cumulative_count)
-                self.assertEqual(3, proto.metric[0].histogram.bucket[
-                    2].cumulative_count)
+                self.assertEqual(
+                    1, proto.metric[0].histogram.bucket[
+                    0
+                    ].cumulative_count,
+                )
+                self.assertEqual(
+                    2, proto.metric[0].histogram.bucket[
+                    1
+                    ].cumulative_count,
+                )
+                self.assertEqual(
+                    3, proto.metric[0].histogram.bucket[
+                    2
+                    ].cumulative_count,
+                )
             else:
                 self.assertEqual(1, len(proto.metric))
                 self.assertEqual(4, proto.metric[0].histogram.sample_count)
                 self.assertEqual(9, proto.metric[0].histogram.sample_sum)
                 self.assertEqual(3, len(proto.metric[0].histogram.bucket))
-                self.assertEqual(2, proto.metric[0].histogram.bucket[
-                    0].cumulative_count)
-                self.assertEqual(3, proto.metric[0].histogram.bucket[
-                    1].cumulative_count)
-                self.assertEqual(4, proto.metric[0].histogram.bucket[
-                    2].cumulative_count)
+                self.assertEqual(
+                    2, proto.metric[0].histogram.bucket[
+                    0
+                    ].cumulative_count,
+                )
+                self.assertEqual(
+                    3, proto.metric[0].histogram.bucket[
+                    1
+                    ].cumulative_count,
+                )
+                self.assertEqual(
+                    4, proto.metric[0].histogram.bucket[
+                    2
+                    ].cumulative_count,
+                )
 
     def _generate_samples(self, number):
         samples = []

--- a/orc8r/gateway/python/magma/magmad/tests/config_manager_tests.py
+++ b/orc8r/gateway/python/magma/magmad/tests/config_manager_tests.py
@@ -101,8 +101,10 @@ class ConfigManagerTest(TestCase):
             update_str = MessageToJson(updated_mconfig)
             updates = [
                 DataUpdate(value=''.encode('utf-8'), key='some key'),
-                DataUpdate(value=update_str.encode('utf-8'),
-                           key='last key'),
+                DataUpdate(
+                    value=update_str.encode('utf-8'),
+                    key='last key',
+                ),
             ]
             config_manager.process_update(CONFIG_STREAM_NAME, updates, False)
 

--- a/orc8r/gateway/python/magma/magmad/tests/proxy_client_tests.py
+++ b/orc8r/gateway/python/magma/magmad/tests/proxy_client_tests.py
@@ -105,54 +105,76 @@ class ProxyClientTests(unittest.TestCase):
         asyncio.set_event_loop(loop)
         self._loop = loop
         self._proxy_client = ControlProxyHttpClient()
-        ServiceRegistry._REGISTRY = {"services": {"mobilityd":
-                                                  {"ip_address": "0.0.0.0",
-                                                   "port": 3456}}
-                                     }
+        ServiceRegistry._REGISTRY = {
+            "services": {
+                "mobilityd":
+                {
+                    "ip_address": "0.0.0.0",
+                    "port": 3456,
+                },
+            },
+        }
         ServiceRegistry.add_service('test', '0.0.0.0', 0)
-        self._req_body = GatewayRequest(gwId="test id", authority='mobilityd',
-                                        path='/magma.MobilityService'
-                                             '/ListAddedIPv4Blocks',
-                                        headers={'te': 'trailers',
-                                                 'content-type':
-                                                     'application/grpc',
-                                                 'user-agent':
-                                                     'grpc-python/1.4.0',
-                                                 'grpc-accept-encoding':
-                                                     'identity'},
-                                        payload=bytes.fromhex('0000000000'))
+        self._req_body = GatewayRequest(
+            gwId="test id", authority='mobilityd',
+            path='/magma.MobilityService'
+                 '/ListAddedIPv4Blocks',
+            headers={
+                'te': 'trailers',
+                'content-type':
+                    'application/grpc',
+                'user-agent':
+                    'grpc-python/1.4.0',
+                'grpc-accept-encoding':
+                    'identity',
+            },
+            payload=bytes.fromhex('0000000000'),
+        )
 
     @unittest.mock.patch('aioh2.open_connection')
     def test_http_client_unary(self, mock_conn):
-        req_body = GatewayRequest(gwId="test id", authority='mobilityd',
-                                  path='/magma.MobilityService'
-                                       '/ListAddedIPv4Blocks',
-                                  headers={'te': 'trailers',
-                                           'content-type': 'application/grpc',
-                                           'user-agent': 'grpc-python/1.4.0',
-                                           'grpc-accept-encoding': 'identity'},
-                                  payload=bytes.fromhex('0000000000'))
+        req_body = GatewayRequest(
+            gwId="test id", authority='mobilityd',
+            path='/magma.MobilityService'
+                 '/ListAddedIPv4Blocks',
+            headers={
+                'te': 'trailers',
+                'content-type': 'application/grpc',
+                'user-agent': 'grpc-python/1.4.0',
+                'grpc-accept-encoding': 'identity',
+            },
+            payload=bytes.fromhex('0000000000'),
+        )
         expected_payload = \
             b'\x00\x00\x00\x00\n\n\x08\x12\x04\xc0\xa8\x80\x00\x18\x18'
-        expected_header = [(':status', '200'),
-                           ('content-type', 'application/grpc')]
+        expected_header = [
+            (':status', '200'),
+            ('content-type', 'application/grpc'),
+        ]
         expected_trailers = [('grpc-status', '0'), ('grpc-message', '')]
 
         mock_conn.side_effect = asyncio.coroutine(
             unittest.mock.MagicMock(
-                return_value=MockUnaryClient(expected_payload, expected_header,
-                                             expected_trailers, req_body)))
+                return_value=MockUnaryClient(
+                    expected_payload, expected_header,
+                    expected_trailers, req_body,
+                ),
+            ),
+        )
 
         request_queue = queue.Queue()
         conn_closed_table = {
-            1234: False
+            1234: False,
         }
 
         future = asyncio.ensure_future(
-            self._proxy_client.send(self._req_body,
-                                    1234,
-                                    request_queue,
-                                    conn_closed_table))
+            self._proxy_client.send(
+                self._req_body,
+                1234,
+                request_queue,
+                conn_closed_table,
+            ),
+        )
 
         self._loop.run_until_complete(future)
 
@@ -167,18 +189,24 @@ class ProxyClientTests(unittest.TestCase):
 
     @unittest.mock.patch('aioh2.open_connection')
     def test_http_client_stream(self, mock_conn):
-        req_body = GatewayRequest(gwId="test id", authority='mobilityd',
-                                  path='/magma.MobilityService'
-                                       '/ListAddedIPv4Blocks',
-                                  headers={'te': 'trailers',
-                                           'content-type': 'application/grpc',
-                                           'user-agent': 'grpc-python/1.4.0',
-                                           'grpc-accept-encoding': 'identity'},
-                                  payload=bytes.fromhex('0000000000'))
+        req_body = GatewayRequest(
+            gwId="test id", authority='mobilityd',
+            path='/magma.MobilityService'
+                 '/ListAddedIPv4Blocks',
+            headers={
+                'te': 'trailers',
+                'content-type': 'application/grpc',
+                'user-agent': 'grpc-python/1.4.0',
+                'grpc-accept-encoding': 'identity',
+            },
+            payload=bytes.fromhex('0000000000'),
+        )
         expected_payload = \
             b'\x00\x00\x00\x00\n\n\x08\x12\x04\xc0\xa8\x80\x00\x18\x18'
-        expected_header = [(':status', '200'),
-                           ('content-type', 'application/grpc')]
+        expected_header = [
+            (':status', '200'),
+            ('content-type', 'application/grpc'),
+        ]
         expected_trailers = [('grpc-status', '0'), ('grpc-message', '')]
 
         mock_conn.side_effect = asyncio.coroutine(
@@ -187,21 +215,24 @@ class ProxyClientTests(unittest.TestCase):
                     expected_payload,
                     expected_header,
                     expected_trailers,
-                    req_body
-                )
-            )
+                    req_body,
+                ),
+            ),
         )
 
         request_queue = queue.Queue()
         conn_closed_table = {
-            1234: False
+            1234: False,
         }
 
         future = asyncio.ensure_future(
-            self._proxy_client.send(self._req_body,
-                                    1234,
-                                    request_queue,
-                                    conn_closed_table))
+            self._proxy_client.send(
+                self._req_body,
+                1234,
+                request_queue,
+                conn_closed_table,
+            ),
+        )
 
         self._loop.run_until_complete(future)
 

--- a/orc8r/gateway/python/magma/magmad/tests/service_manager_tests.py
+++ b/orc8r/gateway/python/magma/magmad/tests/service_manager_tests.py
@@ -48,7 +48,7 @@ class ServiceManagerSystemdTest(TestCase):
         #  Ensure test process is stopped
         self.dummy_service = ServiceManager.ServiceControl(
             name='dummy_service',
-            init_system_spec=ServiceManager.SystemdInitSystem
+            init_system_spec=ServiceManager.SystemdInitSystem,
         )
         self._loop.run_until_complete(self.dummy_service.stop_process())
 
@@ -81,22 +81,32 @@ class ServiceManagerSystemdTest(TestCase):
         This test exercises the ServiceManager functions, but doesn't really
         verify functionality beyond the tests above
         """
-        mgr = ServiceManager(['dummy1', 'dummy2'], init_system='systemd',
-                             service_poller=MagicMock())
+        mgr = ServiceManager(
+            ['dummy1', 'dummy2'], init_system='systemd',
+            service_poller=MagicMock(),
+        )
 
         self._loop.run_until_complete(mgr.start_services())
         self.subprocess_mock.return_value = b'active\n'
-        self.assertEqual(mgr._service_control['dummy1'].status(),
-                         ServiceState.Active)
-        self.assertEqual(mgr._service_control['dummy2'].status(),
-                         ServiceState.Active)
+        self.assertEqual(
+            mgr._service_control['dummy1'].status(),
+            ServiceState.Active,
+        )
+        self.assertEqual(
+            mgr._service_control['dummy2'].status(),
+            ServiceState.Active,
+        )
 
         self._loop.run_until_complete(mgr.stop_services())
         self.subprocess_mock.return_value = b'inactive\n'
-        self.assertEqual(mgr._service_control['dummy1'].status(),
-                         ServiceState.Inactive)
-        self.assertEqual(mgr._service_control['dummy2'].status(),
-                         ServiceState.Inactive)
+        self.assertEqual(
+            mgr._service_control['dummy1'].status(),
+            ServiceState.Inactive,
+        )
+        self.assertEqual(
+            mgr._service_control['dummy2'].status(),
+            ServiceState.Inactive,
+        )
 
     def test_dynamic_service_manager_start_stop(self):
         """
@@ -104,23 +114,30 @@ class ServiceManagerSystemdTest(TestCase):
         verify functionality beyond the tests above
         """
         mgr = ServiceManager(
-            ['dummy1', 'dummy2'], 'systemd', MagicMock(), ['redirectd'], []
+            ['dummy1', 'dummy2'], 'systemd', MagicMock(), ['redirectd'], [],
         )
 
         self.subprocess_mock.return_value = b'inactive\n'
-        self.assertEqual(mgr._service_control['redirectd'].status(),
-                         ServiceState.Inactive)
+        self.assertEqual(
+            mgr._service_control['redirectd'].status(),
+            ServiceState.Inactive,
+        )
 
         self._loop.run_until_complete(
-            mgr.update_dynamic_services(['redirectd']))
+            mgr.update_dynamic_services(['redirectd']),
+        )
         self.subprocess_mock.return_value = b'active\n'
-        self.assertEqual(mgr._service_control['redirectd'].status(),
-                         ServiceState.Active)
+        self.assertEqual(
+            mgr._service_control['redirectd'].status(),
+            ServiceState.Active,
+        )
 
         self._loop.run_until_complete(mgr.update_dynamic_services([]))
         self.subprocess_mock.return_value = b'inactive\n'
-        self.assertEqual(mgr._service_control['redirectd'].status(),
-                         ServiceState.Inactive)
+        self.assertEqual(
+            mgr._service_control['redirectd'].status(),
+            ServiceState.Inactive,
+        )
 
 
 class ServiceManagerRunitTest(TestCase):
@@ -134,7 +151,7 @@ class ServiceManagerRunitTest(TestCase):
         Run before each test
         """
         self.is_integration_test = bool(
-            os.environ.get('MAGMA_INTEGRATION_TEST')
+            os.environ.get('MAGMA_INTEGRATION_TEST'),
         )
         #  Only patch if this is a unit test. Otherwise create dummy mock so
         #  code that affects the mock can run.
@@ -169,16 +186,20 @@ class ServiceManagerRunitTest(TestCase):
         self.subprocess_mock.return_value = (
             'down: e2e_controller: 268195s; run: log: (pid 2275) 268195s\n'
         )
-        self.assertEqual(self.dummy_service.status(),
-                         ServiceState.Inactive)
+        self.assertEqual(
+            self.dummy_service.status(),
+            ServiceState.Inactive,
+        )
 
         self.subprocess_mock.return_value = (
             'run: e2e_controller: 268195s; run: log: (pid 2275) 268195s\n'
         )
         self.dummy_service.start_process()
         time.sleep(1)  # Make sure that process doesnt immediately die
-        self.assertEqual(self.dummy_service.status(),
-                         ServiceState.Active)
+        self.assertEqual(
+            self.dummy_service.status(),
+            ServiceState.Active,
+        )
 
         self.subprocess_mock.return_value = (
             "fail: blabla: can't change to service directory: "
@@ -186,7 +207,7 @@ class ServiceManagerRunitTest(TestCase):
         )
         self.assertEqual(
             self.dummy_service.status(),
-            ServiceState.Failed
+            ServiceState.Failed,
         )
 
     def test_service_manager_start_stop(self):
@@ -199,26 +220,36 @@ class ServiceManagerRunitTest(TestCase):
         if self.is_integration_test:
             return
 
-        mgr = ServiceManager(['dummy1', 'dummy2'], init_system='runit',
-                             service_poller=MagicMock())
+        mgr = ServiceManager(
+            ['dummy1', 'dummy2'], init_system='runit',
+            service_poller=MagicMock(),
+        )
 
         mgr.start_services()
         self.subprocess_mock.return_value = (
             'run: e2e_controller: 268195s; run: log: (pid 2275) 268195s\n'
         )
-        self.assertEqual(mgr._service_control['dummy1'].status(),
-                         ServiceState.Active)
-        self.assertEqual(mgr._service_control['dummy2'].status(),
-                         ServiceState.Active)
+        self.assertEqual(
+            mgr._service_control['dummy1'].status(),
+            ServiceState.Active,
+        )
+        self.assertEqual(
+            mgr._service_control['dummy2'].status(),
+            ServiceState.Active,
+        )
 
         mgr.stop_services()
         self.subprocess_mock.return_value = (
             'down: e2e_controller: 268195s; run: log: (pid 2275) 268195s\n'
         )
-        self.assertEqual(mgr._service_control['dummy1'].status(),
-                         ServiceState.Inactive)
-        self.assertEqual(mgr._service_control['dummy2'].status(),
-                         ServiceState.Inactive)
+        self.assertEqual(
+            mgr._service_control['dummy1'].status(),
+            ServiceState.Inactive,
+        )
+        self.assertEqual(
+            mgr._service_control['dummy2'].status(),
+            ServiceState.Inactive,
+        )
 
     def test_dynamic_service_manager_start_stop(self):
         """
@@ -231,28 +262,34 @@ class ServiceManagerRunitTest(TestCase):
             return
 
         mgr = ServiceManager(
-            ['dummy1', 'dummy2'], 'runit', MagicMock(), ['redirectd'], []
+            ['dummy1', 'dummy2'], 'runit', MagicMock(), ['redirectd'], [],
         )
 
         self.subprocess_mock.return_value = (
             'down: e2e_controller: 268195s; run: log: (pid 2275) 268195s\n'
         )
-        self.assertEqual(mgr._service_control['redirectd'].status(),
-                         ServiceState.Inactive)
+        self.assertEqual(
+            mgr._service_control['redirectd'].status(),
+            ServiceState.Inactive,
+        )
 
         mgr.update_dynamic_services(['redirectd'])
         self.subprocess_mock.return_value = (
             'run: e2e_controller: 268195s; run: log: (pid 2275) 268195s\n'
         )
-        self.assertEqual(mgr._service_control['redirectd'].status(),
-                         ServiceState.Active)
+        self.assertEqual(
+            mgr._service_control['redirectd'].status(),
+            ServiceState.Active,
+        )
 
         mgr.update_dynamic_services([])
         self.subprocess_mock.return_value = (
             'down: e2e_controller: 268195s; run: log: (pid 2275) 268195s\n'
         )
-        self.assertEqual(mgr._service_control['redirectd'].status(),
-                         ServiceState.Inactive)
+        self.assertEqual(
+            mgr._service_control['redirectd'].status(),
+            ServiceState.Inactive,
+        )
 
 
 class ServiceManagerDockerTest(TestCase):
@@ -279,7 +316,7 @@ class ServiceManagerDockerTest(TestCase):
         #  Ensure test process is stopped
         self.dummy_service = ServiceManager.ServiceControl(
             name='dummy_service',
-            init_system_spec=ServiceManager.DockerInitSystem
+            init_system_spec=ServiceManager.DockerInitSystem,
         )
         try:
             self._loop.run_until_complete(self.dummy_service.stop_process())
@@ -324,25 +361,35 @@ class ServiceManagerDockerTest(TestCase):
         This test exercises the ServiceManager functions, but doesn't really
         verify functionality beyond the tests above
         """
-        mgr = ServiceManager(['dummy1', 'dummy2'], init_system='docker',
-                             service_poller=MagicMock())
+        mgr = ServiceManager(
+            ['dummy1', 'dummy2'], init_system='docker',
+            service_poller=MagicMock(),
+        )
 
         try:
             self._loop.run_until_complete(mgr.start_services())
         except FileNotFoundError:
             pass
         self.subprocess_mock.return_value = b'[{"State": {"Status": "running"}}]'
-        self.assertEqual(mgr._service_control['dummy1'].status(),
-                         ServiceState.Active)
-        self.assertEqual(mgr._service_control['dummy2'].status(),
-                         ServiceState.Active)
+        self.assertEqual(
+            mgr._service_control['dummy1'].status(),
+            ServiceState.Active,
+        )
+        self.assertEqual(
+            mgr._service_control['dummy2'].status(),
+            ServiceState.Active,
+        )
 
         try:
             self._loop.run_until_complete(mgr.stop_services())
         except FileNotFoundError:
             pass
         self.subprocess_mock.return_value = b'[{"State": {"Status": "exited"}}]'
-        self.assertEqual(mgr._service_control['dummy1'].status(),
-                         ServiceState.Inactive)
-        self.assertEqual(mgr._service_control['dummy2'].status(),
-                         ServiceState.Inactive)
+        self.assertEqual(
+            mgr._service_control['dummy1'].status(),
+            ServiceState.Inactive,
+        )
+        self.assertEqual(
+            mgr._service_control['dummy2'].status(),
+            ServiceState.Inactive,
+        )

--- a/orc8r/gateway/python/magma/magmad/tests/service_poller_tests.py
+++ b/orc8r/gateway/python/magma/magmad/tests/service_poller_tests.py
@@ -35,7 +35,7 @@ class ServicePollerTests(unittest.TestCase):
         ServiceRegistry.add_service('test2', '0.0.0.0', 0)
         config = {
             'magma_services': ['test1', 'test2'],
-            'non_service303_services': ['test2']
+            'non_service303_services': ['test2'],
         }
         self._loop = asyncio.new_event_loop()
         asyncio.set_event_loop(self._loop)
@@ -57,7 +57,8 @@ class ServicePollerTests(unittest.TestCase):
             await self._service_poller._get_service_info()
 
             mock.GetServiceInfo.future.assert_called_once_with(
-                Void(), self._service_poller.GET_STATUS_TIMEOUT)
+                Void(), self._service_poller.GET_STATUS_TIMEOUT,
+            )
         self._loop.run_until_complete(test())
 
     @unittest.mock.patch('%s.Service303Stub' % SP)
@@ -83,7 +84,8 @@ class ServicePollerTests(unittest.TestCase):
             await self._service_poller._get_service_info()
 
             mock.GetServiceInfo.future.assert_called_once_with(
-                Void(), self._service_poller.GET_STATUS_TIMEOUT)
+                Void(), self._service_poller.GET_STATUS_TIMEOUT,
+            )
         self._loop.run_until_complete(test())
 
 

--- a/orc8r/gateway/python/magma/magmad/tests/state_reporter_test.py
+++ b/orc8r/gateway/python/magma/magmad/tests/state_reporter_test.py
@@ -80,7 +80,7 @@ class StateReporterTests(TestCase):
 
         # Bind the rpc server to a free port
         self._rpc_server = grpc.server(
-            futures.ThreadPoolExecutor(max_workers=10)
+            futures.ThreadPoolExecutor(max_workers=10),
         )
         port = self._rpc_server.add_insecure_port('0.0.0.0:0')
         # Add the servicer
@@ -145,14 +145,16 @@ class StateReporterTests(TestCase):
             -> unittest.mock.Mock:
         mock = unittest.mock.Mock()
         future = asyncio.Future()
-        future.set_result(GetOperationalStatesResponse(
-            states=[
-                State(
-                    type="test",
-                    deviceID=device_id,
-                    value="hello!".encode('utf-8'),
-                )
-            ])
+        future.set_result(
+            GetOperationalStatesResponse(
+                states=[
+                    State(
+                        type="test",
+                        deviceID=device_id,
+                        value="hello!".encode('utf-8'),
+                    ),
+                ],
+            ),
         )
         mock.GetOperationalStates.future.side_effect = [future]
         return mock
@@ -211,8 +213,10 @@ class StateReporterTests(TestCase):
     @unittest.mock.patch('%s.ServiceRegistry.get_proxy_config' % SReg)
     @unittest.mock.patch('%s.cert_is_invalid' % SR)
     @unittest.mock.patch('%s.ServiceRegistry.get_rpc_channel' % SReg)
-    def test__report_states_failure(self, get_rpc_mock, cert_is_invalid_mock,
-                                    get_proxy_config_mock):
+    def test__report_states_failure(
+        self, get_rpc_mock, cert_is_invalid_mock,
+        get_proxy_config_mock,
+    ):
         bootstrap_manager = \
             self.state_reporter._error_handler._bootstrap_manager
         bootstrap_manager.schedule_bootstrap_now = unittest.mock.Mock()
@@ -247,7 +251,7 @@ class StateReporterTests(TestCase):
         # the failure threshold is 0 so assert _schedule_bootstrap_now is
         # called
         bootstrap_manager.schedule_bootstrap_now.assert_has_calls(
-            [unittest.mock.call()]
+            [unittest.mock.call()],
         )
 
     @staticmethod

--- a/orc8r/gateway/python/magma/magmad/upgrade/docker_upgrader.py
+++ b/orc8r/gateway/python/magma/magmad/upgrade/docker_upgrader.py
@@ -53,11 +53,15 @@ class DockerUpgrader(Upgrader2):
         current_version = version_info[0].current_version
         tgt_version = self.service.mconfig.package_version
         if tgt_version is None or tgt_version == "":
-            logging.warning('magmad package_version not found, '
-                            'using current tag: %s as target tag.',
-                            current_version)
-            return UpgradeIntent(stable=VersionT(current_version),
-                                 canary=VersionT(""))
+            logging.warning(
+                'magmad package_version not found, '
+                'using current tag: %s as target tag.',
+                current_version,
+            )
+            return UpgradeIntent(
+                stable=VersionT(current_version),
+                canary=VersionT(""),
+            )
 
         return UpgradeIntent(stable=VersionT(tgt_version), canary=VersionT(""))
 
@@ -77,25 +81,33 @@ class DockerUpgrader(Upgrader2):
         )
 
     async def prepare_upgrade(
-        self, version: VersionT, path_to_image: pathlib.Path
+        self, version: VersionT, path_to_image: pathlib.Path,
     ) -> None:
         """Install the new docker-compose file"""
         gw_module = self.service.config["upgrader_factory"]\
             .get("gateway_module")
 
         # Update any mounted static configs
-        await run_command("cp -TR {}/magma/{}/gateway/configs /etc/magma".
-                          format(MAGMA_GITHUB_PATH, gw_module),
-                          shell=True, check=True)
+        await run_command(
+            "cp -TR {}/magma/{}/gateway/configs /etc/magma".
+            format(MAGMA_GITHUB_PATH, gw_module),
+            shell=True, check=True,
+        )
         # Update any mounted template configs
-        await run_command("cp -TR {}/magma/orc8r/gateway/configs/templates "
-                          "/etc/magma/templates".format(MAGMA_GITHUB_PATH),
-                          shell=True, check=True)
+        await run_command(
+            "cp -TR {}/magma/orc8r/gateway/configs/templates "
+            "/etc/magma/templates".format(MAGMA_GITHUB_PATH),
+            shell=True, check=True,
+        )
         # Copy updated docker-compose
-        await run_command("cp {}/magma/{}/gateway/docker/docker-compose.yml "
-                          "/var/opt/magma/docker".format(MAGMA_GITHUB_PATH,
-                                                         gw_module),
-                          shell=True, check=True)
+        await run_command(
+            "cp {}/magma/{}/gateway/docker/docker-compose.yml "
+            "/var/opt/magma/docker".format(
+                MAGMA_GITHUB_PATH,
+                gw_module,
+            ),
+            shell=True, check=True,
+        )
 
     async def upgrade(
             self, version: VersionT, path_to_image: pathlib.Path,
@@ -116,7 +128,7 @@ class DockerUpgrader(Upgrader2):
 
     async def _do_docker_upgrade(self) -> None:
         upgrade_intent, version_info = await asyncio.gather(
-            self.get_upgrade_intent(), self.get_versions()
+            self.get_upgrade_intent(), self.get_versions(),
         )
         current_version = version_info.current_version
         target_image = upgrade_intent.stable
@@ -140,16 +152,20 @@ class DockerUpgrader(Upgrader2):
 
             # As a last step, update the IMAGE_VERSION in .env
             sed_args = "sed -i s/IMAGE_VERSION={}/IMAGE_VERSION={}/g " \
-                       "var/opt/magma/docker/.env".format(current_version,
-                                                          target_image)
-            logging.info("Successfully downloaded version %s! Awaiting docker "
-                         "container recreation...", target_image)
+                       "var/opt/magma/docker/.env".format(
+                           current_version,
+                           target_image,
+                       )
+            logging.info(
+                "Successfully downloaded version %s! Awaiting docker "
+                "container recreation...", target_image,
+            )
             await run_command(sed_args, shell=True, check=True)
         else:
             logging.info(
                 'Service is currently on image tag %s, '
                 'ignoring upgrade to tag %s, since they\'re equal.',
-                current_version, target_image
+                current_version, target_image,
             )
 
 
@@ -160,25 +176,34 @@ async def download_update(
     """
     Download the images for the given tag and clones the github repo.
     """
-    await run_command("rm -rf {}".format(MAGMA_GITHUB_PATH), shell=True,
-                      check=True)
-    await run_command("mkdir -p {}".format(MAGMA_GITHUB_PATH), shell=True,
-                      check=True)
+    await run_command(
+        "rm -rf {}".format(MAGMA_GITHUB_PATH), shell=True,
+        check=True,
+    )
+    await run_command(
+        "mkdir -p {}".format(MAGMA_GITHUB_PATH), shell=True,
+        check=True,
+    )
 
     control_proxy_config = load_service_config('control_proxy')
-    await run_command("cp {} /usr/local/share/ca-certificates/rootCA.crt".
-                      format(control_proxy_config['rootca_cert']), shell=True,
-                      check=True)
+    await run_command(
+        "cp {} /usr/local/share/ca-certificates/rootCA.crt".
+        format(control_proxy_config['rootca_cert']), shell=True,
+        check=True,
+    )
     await run_command("update-ca-certificates", shell=True, check=True)
 
     if use_proxy:
         git_clone_cmd = "git -c http.proxy=https://{}:{} -C {} clone {}".format(
             control_proxy_config['bootstrap_address'],
             control_proxy_config['bootstrap_port'], MAGMA_GITHUB_PATH,
-            MAGMA_GITHUB_URL)
+            MAGMA_GITHUB_URL,
+        )
     else:
-        git_clone_cmd = "git -C {} clone {}".format(MAGMA_GITHUB_PATH,
-                                                    MAGMA_GITHUB_URL)
+        git_clone_cmd = "git -C {} clone {}".format(
+            MAGMA_GITHUB_PATH,
+            MAGMA_GITHUB_URL,
+        )
 
     await run_command(git_clone_cmd, shell=True, check=True)
 

--- a/orc8r/gateway/python/magma/magmad/upgrade/tests/magma_upgrader_tests.py
+++ b/orc8r/gateway/python/magma/magmad/upgrade/tests/magma_upgrader_tests.py
@@ -44,19 +44,26 @@ class VersionComparisonTests(unittest.TestCase):
         for test_case in greater_test_cases:
             self.assertEqual(
                 1,
-                magma_upgrader.compare_package_versions(test_case.v1,
-                                                        test_case.v2)
+                magma_upgrader.compare_package_versions(
+                    test_case.v1,
+                    test_case.v2,
+                ),
             )
         for test_case in less_test_cases:
             self.assertEqual(
                 -1,
-                magma_upgrader.compare_package_versions(test_case.v1,
-                                                        test_case.v2)
+                magma_upgrader.compare_package_versions(
+                    test_case.v1,
+                    test_case.v2,
+                ),
             )
         self.assertEqual(
             0,
-            magma_upgrader.compare_package_versions(equal_test_case.v1,
-                                                    equal_test_case.v2))
+            magma_upgrader.compare_package_versions(
+                equal_test_case.v1,
+                equal_test_case.v2,
+            ),
+        )
 
     def test_bad_version_strings(self):
         test_cases = [
@@ -72,7 +79,8 @@ class VersionComparisonTests(unittest.TestCase):
             except ValueError as e:
                 self.assertEqual(
                     'Could not parse target package version {}'.format(ver),
-                    str(e))
+                    str(e),
+                )
 
             try:
                 magma_upgrader.compare_package_versions(ver, '1.0.0-0')
@@ -80,7 +88,8 @@ class VersionComparisonTests(unittest.TestCase):
             except ValueError as e:
                 self.assertEqual(
                     'Could not parse current package version {}'.format(ver),
-                    str(e))
+                    str(e),
+                )
 
 
 class MagmaUpgraderTests(unittest.TestCase):
@@ -107,7 +116,8 @@ class MagmaUpgraderTests(unittest.TestCase):
     def test_full_upgrade_workflow(self):
         with patch(
                 'magma.magmad.upgrade.magma_upgrader.call_process',
-                mock.Mock(wraps=self._mock_call_process_success)) as m:
+                mock.Mock(wraps=self._mock_call_process_success),
+        ) as m:
             upgrader = self._get_upgrader('1.0.0-0')
             upgrader.perform_upgrade_if_necessary('1.1.0-0')
 
@@ -119,7 +129,8 @@ class MagmaUpgraderTests(unittest.TestCase):
                     '-o Dpkg::Options::="--force-confnew" '
                     '--assume-yes --force-yes --only-upgrade --dry-run '
                     'magma=1.1.0-0',
-                    mock.ANY, mock.ANY),
+                    mock.ANY, mock.ANY,
+                ),
                 mock.call(
                     'apt-get install '
                     '-o Dpkg::Options::="--force-confnew" '
@@ -132,7 +143,8 @@ class MagmaUpgraderTests(unittest.TestCase):
     def test_apt_update_failure(self):
         with patch(
                 'magma.magmad.upgrade.magma_upgrader.call_process',
-                mock.Mock(wraps=self._mock_call_process_fail)) as m:
+                mock.Mock(wraps=self._mock_call_process_fail),
+        ) as m:
             upgrader = self._get_upgrader('1.0.0-0')
             upgrader.perform_upgrade_if_necessary('1.1.0-0')
 
@@ -144,7 +156,8 @@ class MagmaUpgraderTests(unittest.TestCase):
     def test_upgrade_dry_run_failure(self):
         with patch(
                 'magma.magmad.upgrade.magma_upgrader.call_process',
-                mock.Mock(wraps=self._mock_call_process_fail_on_install)) as m:
+                mock.Mock(wraps=self._mock_call_process_fail_on_install),
+        ) as m:
             upgrader = self._get_upgrader('1.0.0-0')
             upgrader.perform_upgrade_if_necessary('1.1.0-0')
 
@@ -156,13 +169,15 @@ class MagmaUpgraderTests(unittest.TestCase):
                     '-o Dpkg::Options::="--force-confnew" '
                     '--assume-yes --force-yes --only-upgrade --dry-run '
                     'magma=1.1.0-0',
-                    mock.ANY, mock.ANY),
+                    mock.ANY, mock.ANY,
+                ),
             ])
 
     def test_already_in_newest_version(self):
         with patch(
                 'magma.magmad.upgrade.magma_upgrader.call_process',
-                mock.Mock(wraps=self._mock_call_process_success)) as m:
+                mock.Mock(wraps=self._mock_call_process_success),
+        ) as m:
             upgrader = self._get_upgrader('1.1.0-0')
             upgrader.perform_upgrade_if_necessary('1.1.0-0')
             self.assertEqual(0, m.call_count)
@@ -170,7 +185,8 @@ class MagmaUpgraderTests(unittest.TestCase):
     def test_downgrade_is_ignored(self):
         with patch(
                 'magma.magmad.upgrade.magma_upgrader.call_process',
-                mock.Mock(wraps=self._mock_call_process_success)) as m:
+                mock.Mock(wraps=self._mock_call_process_success),
+        ) as m:
             upgrader = self._get_upgrader('1.2.0-0')
             upgrader.perform_upgrade_if_necessary('1.1.0-0')
 

--- a/orc8r/gateway/python/magma/magmad/upgrade/tests/upgrader2_test.py
+++ b/orc8r/gateway/python/magma/magmad/upgrade/tests/upgrader2_test.py
@@ -38,7 +38,7 @@ class FakeUpgrader(upgrader2.Upgrader2):
 
     async def get_upgrade_intent(self) -> upgrader2.UpgradeIntent:
         return upgrader2.UpgradeIntent(
-            stable=self.stable_version, canary=self.canary_version
+            stable=self.stable_version, canary=self.canary_version,
         )
 
     async def get_versions(self) -> upgrader2.VersionInfo:
@@ -48,12 +48,12 @@ class FakeUpgrader(upgrader2.Upgrader2):
         )
 
     async def prepare_upgrade(
-        self, version: upgrader2.VersionT, path_to_image: pathlib.Path
+        self, version: upgrader2.VersionT, path_to_image: pathlib.Path,
     ) -> None:
         self.installed_versions.add(version)
 
     async def upgrade(
-        self, version: upgrader2.VersionT, path_to_image: pathlib.Path
+        self, version: upgrader2.VersionT, path_to_image: pathlib.Path,
     ) -> None:
         self.installed_versions.remove(version)
         self.current_version = version
@@ -94,35 +94,41 @@ class Upgrader2Test(unittest.TestCase):
 
     def run_upgrade_loop(self):
         asyncio.get_event_loop().run_until_complete(
-            upgrader2.do_upgrade2(self.wrapped_upgrader)
+            upgrader2.do_upgrade2(self.wrapped_upgrader),
         )
 
     def test_version_info(self):
         self.assertEqual(
-            set(), upgrader2.VersionInfo(self.version_none, {}).all_versions
+            set(), upgrader2.VersionInfo(self.version_none, {}).all_versions,
         )
         self.assertEqual(
             {self.version_a}, upgrader2.VersionInfo(
-                self.version_a, {}).all_versions
+                self.version_a, {},
+            ).all_versions,
         )
         self.assertEqual(
             {self.version_a},
-            upgrader2.VersionInfo(self.version_none, {
-                                  self.version_a}).all_versions,
+            upgrader2.VersionInfo(
+                self.version_none, {
+                self.version_a,
+                },
+            ).all_versions,
         )
         self.assertEqual(
             {self.version_a}, upgrader2.VersionInfo(
-                self.version_a, {}).all_versions
+                self.version_a, {},
+            ).all_versions,
         )
         self.assertEqual(
             {self.version_a, self.version_b},
             upgrader2.VersionInfo(
-                self.version_a, {self.version_b}).all_versions,
+                self.version_a, {self.version_b},
+            ).all_versions,
         )
         self.assertEqual(
             {self.version_a, self.version_b},
             upgrader2.VersionInfo(
-                self.version_a, {self.version_a, self.version_b}
+                self.version_a, {self.version_a, self.version_b},
             ).all_versions,
         )
 
@@ -132,45 +138,54 @@ class Upgrader2Test(unittest.TestCase):
             available_versions={self.version_b, self.version_c},
         )
         intent = upgrader2.UpgradeIntent(
-            stable=self.version_none, canary=self.version_none
+            stable=self.version_none, canary=self.version_none,
         )
-        self.assertEqual(self.version_none,
-                         intent.version_to_prepare(version_info))
         self.assertEqual(
-            self.version_none, intent.version_to_force_upgrade(version_info)
+            self.version_none,
+            intent.version_to_prepare(version_info),
+        )
+        self.assertEqual(
+            self.version_none, intent.version_to_force_upgrade(version_info),
         )
 
         # If version is already the one intended, no actions should be taken
         intent = upgrader2.UpgradeIntent(
-            stable=version_info.current_version, canary=version_info.current_version
+            stable=version_info.current_version, canary=version_info.current_version,
         )
 
-        self.assertEqual(self.version_none,
-                         intent.version_to_prepare(version_info))
         self.assertEqual(
-            self.version_none, intent.version_to_force_upgrade(version_info)
+            self.version_none,
+            intent.version_to_prepare(version_info),
+        )
+        self.assertEqual(
+            self.version_none, intent.version_to_force_upgrade(version_info),
         )
 
         # If upgrade is already prepared, then no reason to prepare again
         intent = upgrader2.UpgradeIntent(
-            stable=self.version_none, canary=self.version_b
+            stable=self.version_none, canary=self.version_b,
         )
 
-        self.assertEqual(self.version_none,
-                         intent.version_to_prepare(version_info))
+        self.assertEqual(
+            self.version_none,
+            intent.version_to_prepare(version_info),
+        )
 
         # Unprepared version
         intent = upgrader2.UpgradeIntent(
-            stable=self.version_none, canary=self.version_d
+            stable=self.version_none, canary=self.version_d,
         )
         self.assertEqual(
-            self.version_d, intent.version_to_prepare(version_info))
+            self.version_d, intent.version_to_prepare(version_info),
+        )
 
         # Force upgrade needed
         intent = upgrader2.UpgradeIntent(
-            stable=self.version_b, canary=self.version_b)
+            stable=self.version_b, canary=self.version_b,
+        )
         self.assertEqual(
-            self.version_b, intent.version_to_force_upgrade(version_info))
+            self.version_b, intent.version_to_force_upgrade(version_info),
+        )
 
     def test_do_nothing_upgrade(self):
         self.upgrader.stable_version = ""
@@ -182,7 +197,8 @@ class Upgrader2Test(unittest.TestCase):
 
         # Old-style upgrade method not called
         self.assertIs(
-            0, self.wrapped_upgrader.perform_upgrade_if_necessary.call_count)
+            0, self.wrapped_upgrader.perform_upgrade_if_necessary.call_count,
+        )
         # New style methods called
         self.assertIs(1, self.wrapped_upgrader.get_upgrade_intent.call_count)
         self.assertIs(1, self.wrapped_upgrader.get_versions.call_count)
@@ -202,7 +218,8 @@ class Upgrader2Test(unittest.TestCase):
 
         # Old-style upgrade method not called
         self.assertIs(
-            0, self.wrapped_upgrader.perform_upgrade_if_necessary.call_count)
+            0, self.wrapped_upgrader.perform_upgrade_if_necessary.call_count,
+        )
         self.assertIs(1, self.ensure_downloaded.call_count)
         self.assertEqual(
             [mock.call("canary_version", canary_path)],
@@ -222,7 +239,8 @@ class Upgrader2Test(unittest.TestCase):
 
         # Old-style upgrade method not called
         self.assertIs(
-            0, self.wrapped_upgrader.perform_upgrade_if_necessary.call_count)
+            0, self.wrapped_upgrader.perform_upgrade_if_necessary.call_count,
+        )
         # New style methods called
         self.assertIs(2, self.ensure_downloaded.call_count)
         self.assertIs(1, self.wrapped_upgrader.get_upgrade_intent.call_count)

--- a/orc8r/gateway/python/magma/magmad/upgrade/upgrader.py
+++ b/orc8r/gateway/python/magma/magmad/upgrade/upgrader.py
@@ -86,7 +86,7 @@ def start_upgrade_loop(magmad_service, upgrader):
             upgrader.perform_upgrade_if_necessary(target_ver)
         except Exception:  # pylint: disable=broad-except
             logging.exception(
-                'Error encountered while upgrading, will try again after delay'
+                'Error encountered while upgrading, will try again after delay',
             )
         poll_interval = max(  # No faster than 1/minute
             60,
@@ -97,8 +97,10 @@ def start_upgrade_loop(magmad_service, upgrader):
 
 def _get_target_version(magmad_mconfig):
     if magmad_mconfig.package_version is None:
-        logging.warning('magmad package_version config not found, '
-                        'returning 0.0.0-0 as target package version.')
+        logging.warning(
+            'magmad package_version config not found, '
+            'returning 0.0.0-0 as target package version.',
+        )
         return '0.0.0-0'
 
     return magmad_mconfig.package_version

--- a/orc8r/gateway/python/magma/state/garbage_collector.py
+++ b/orc8r/gateway/python/magma/state/garbage_collector.py
@@ -31,9 +31,11 @@ class GarbageCollector:
     RPC call succeeds, it then deletes the state from Redis
     """
 
-    def __init__(self,
-                 service: MagmaService,
-                 grpc_client_manager: GRPCClientManager):
+    def __init__(
+        self,
+        service: MagmaService,
+        grpc_client_manager: GRPCClientManager,
+    ):
         self._service = service
         # Redis dicts for each type of state to replicate
         self._redis_dicts = []
@@ -69,7 +71,8 @@ class GarbageCollector:
                 state_client.DeleteStates.future(
                     request,
                     DEFAULT_GRPC_TIMEOUT,
-                ))
+                ),
+            )
 
         except grpc.RpcError as err:
             logging.error("GRPC call failed for state deletion: %s", err)
@@ -78,17 +81,23 @@ class GarbageCollector:
                 for key in redis_dict.garbage_keys():
                     await self._delete_state_from_redis(redis_dict, key)
 
-    async def _delete_state_from_redis(self,
-                                       redis_dict: RedisFlatDict,
-                                       key: str) -> None:
+    async def _delete_state_from_redis(
+        self,
+        redis_dict: RedisFlatDict,
+        key: str,
+    ) -> None:
         # Ensure that the object isn't updated before deletion
         with redis_dict.lock(key):
             deleted = redis_dict.delete_garbage(key)
             if deleted:
-                logging.debug("Successfully garbage collected "
-                              "state for key: %s", key)
+                logging.debug(
+                    "Successfully garbage collected "
+                    "state for key: %s", key,
+                )
             else:
-                logging.debug("Successfully garbage collected "
-                              "state in cloud for key %s. "
-                              "Didn't delete locally as the "
-                              "object is no longer garbage", key)
+                logging.debug(
+                    "Successfully garbage collected "
+                    "state in cloud for key %s. "
+                    "Didn't delete locally as the "
+                    "object is no longer garbage", key,
+                )

--- a/orc8r/gateway/python/magma/state/redis_dicts.py
+++ b/orc8r/gateway/python/magma/state/redis_dicts.py
@@ -50,21 +50,29 @@ def get_proto_redis_dicts(config):
                          'redis_key' not in proto_cfg or \
                          'state_scope' not in proto_cfg
         if is_invalid_cfg:
-            logging.warning("Invalid proto config found in state_protos "
-                            "configuration: %s", proto_cfg)
+            logging.warning(
+                "Invalid proto config found in state_protos "
+                "configuration: %s", proto_cfg,
+            )
             continue
         try:
             proto_module = importlib.import_module(proto_cfg['proto_file'])
             msg = getattr(proto_module, proto_cfg['proto_msg'])
             redis_key = proto_cfg['redis_key']
-            logging.info('Initializing RedisSerde for proto state %s',
-                         proto_cfg['redis_key'])
-            serde = RedisSerde(redis_key,
-                               get_proto_serializer(),
-                               get_proto_deserializer(msg))
-            redis_dict = StateDict(serde,
-                                   proto_cfg['state_scope'],
-                                   PROTO_FORMAT)
+            logging.info(
+                'Initializing RedisSerde for proto state %s',
+                proto_cfg['redis_key'],
+            )
+            serde = RedisSerde(
+                redis_key,
+                get_proto_serializer(),
+                get_proto_deserializer(msg),
+            )
+            redis_dict = StateDict(
+                serde,
+                proto_cfg['state_scope'],
+                PROTO_FORMAT,
+            )
             redis_dicts.append(redis_dict)
 
         except (ImportError, AttributeError) as err:
@@ -80,19 +88,27 @@ def get_json_redis_dicts(config):
         is_invalid_cfg = 'redis_key' not in json_cfg or \
                          'state_scope' not in json_cfg
         if is_invalid_cfg:
-            logging.warning("Invalid json state config found in json_state"
-                            "configuration: %s", json_cfg)
+            logging.warning(
+                "Invalid json state config found in json_state"
+                "configuration: %s", json_cfg,
+            )
             continue
 
-        logging.info('Initializing RedisSerde for json state %s',
-                     json_cfg['redis_key'])
+        logging.info(
+            'Initializing RedisSerde for json state %s',
+            json_cfg['redis_key'],
+        )
         redis_key = json_cfg['redis_key']
-        serde = RedisSerde(redis_key,
-                           get_json_serializer(),
-                           get_json_deserializer())
-        redis_dict = StateDict(serde,
-                               json_cfg['state_scope'],
-                               JSON_FORMAT)
+        serde = RedisSerde(
+            redis_key,
+            get_json_serializer(),
+            get_json_deserializer(),
+        )
+        redis_dict = StateDict(
+            serde,
+            json_cfg['state_scope'],
+            JSON_FORMAT,
+        )
         redis_dicts.append(redis_dict)
 
     return redis_dicts


### PR DESCRIPTION
Signed-off-by: Marie Bremner <marwhal@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary
Noticing while reviewing https://github.com/magma/magma/pull/7269/ that my previous PR to apply formatting script missed a few files. 
(This is due to the way I ran the precommit script, the `add-trailing-comma` only takes files as an argument not directory for some reason. :( )
So this time I manually ran the command with bash for this one time cleanup.
```
for i in `find . -name "*.py" -type f`; do
    add-trailing-comma "$i"
done
```

omitting `orc8r/gateway/python/magma/magmad/metrics_collector.py` changes so that there is not a merge conflict with https://github.com/magma/magma/pull/7269/
<!-- Enumerate changes you made and why you made them -->

## Test Plan
CI
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
