### PR TITLE
[component:agw] Handling of the UEContextRequest present information …

### DIFF
--- a/lte/gateway/c/oai/include/ngap_messages_types.h
+++ b/lte/gateway/c/oai/include/ngap_messages_types.h
@@ -237,6 +237,10 @@ typedef struct itti_ngap_paging_request_s {
 
 } itti_ngap_paging_request_t;
 
+typedef enum m5g_uecontextrequest {  // ue context requested supported enum
+  M5G_UEContextRequest_requested = 1,
+} m5g_uecontextrequest_t;
+
 typedef struct itti_ngap_initial_ue_message_s {
   sctp_assoc_id_t sctp_assoc_id;  // key stored in AMF_APP for AMF_APP forward
                                   // NAS response to NGAP
@@ -249,7 +253,8 @@ typedef struct itti_ngap_initial_ue_message_s {
   ecgi_t ecgi; /* Indicating the cell from which the UE has sent the NAS
                   message. */
   m5g_rrc_establishment_cause_t
-      m5g_rrc_establishment_cause; /* Establishment cause */
+      m5g_rrc_establishment_cause;           /* Establishment cause */
+  m5g_uecontextrequest_t ue_context_request; /* UeContextRequest */
   bool is_s_tmsi_valid;
   bool is_csg_id_valid;
   bool is_guamfi_valid;

--- a/lte/gateway/c/oai/tasks/amf/amf_Security_Mode.cpp
+++ b/lte/gateway/c/oai/tasks/amf/amf_Security_Mode.cpp
@@ -68,16 +68,14 @@ int amf_handle_security_complete_response(
      * TODO:Stop timer T3560 This to be taken care in upcoming PR
      */
 
-    OAILOG_ERROR(
-        LOG_AMF_APP, "Timer: Calling SMC MODE stop timer with id = %d\n",
-        smc_proc->T3560.id);
     stop_timer(&amf_app_task_zmq_ctx, smc_proc->T3560.id);
-    OAILOG_ERROR(LOG_AMF_APP, "Timer: After stopping SMC MODE timer \n");
+    OAILOG_DEBUG(LOG_AMF_APP, "Timer: After stopping SMC MODE timer \n");
     smc_proc->T3560.id = NAS5G_TIMER_INACTIVE_ID;
 
-    ue_mm_context->ue_context_request_present = true;
+    OAILOG_DEBUG(
+          LOG_AMF_APP, "ue_context_request : %d", ue_mm_context->ue_context_request);
     if (amf_ctx && IS_AMF_CTXT_PRESENT_SECURITY(amf_ctx)) {
-      if (ue_mm_context->ue_context_request_present == false) {
+      if (M5G_UEContextRequest_requested != ue_mm_context->ue_context_request) {
         /*
          * Notify AMF that the authentication procedure successfully completed
          */

--- a/lte/gateway/c/oai/tasks/amf/amf_app_handler.cpp
+++ b/lte/gateway/c/oai/tasks/amf/amf_app_handler.cpp
@@ -413,6 +413,12 @@ imsi64_t amf_app_handle_initial_ue_message(
     ue_context_p->sctp_assoc_id_key = initial_pP->sctp_assoc_id;
     ue_context_p->gnb_ue_ngap_id    = initial_pP->gnb_ue_ngap_id;
 
+    // UEContextRequest
+    ue_context_p->ue_context_request = initial_pP->ue_context_request;
+    OAILOG_DEBUG(
+        LOG_AMF_APP, "ue_context_requext received: %d\n ",
+        ue_context_p->ue_context_request);
+
     notify_ngap_new_ue_amf_ngap_id_association(ue_context_p);
     s_tmsi_m5_t s_tmsi = {0};
     if (initial_pP->is_s_tmsi_valid) {

--- a/lte/gateway/c/oai/tasks/amf/amf_app_ue_context_and_proc.h
+++ b/lte/gateway/c/oai/tasks/amf/amf_app_ue_context_and_proc.h
@@ -357,7 +357,7 @@ typedef struct ue_m5gmm_context_s {
   amf_app_timer_t m5_ulr_response_timer;
 
   // UEContextRequest in  INITIAL UE MESSAGE
-  bool ue_context_request_present;
+  m5g_uecontextrequest_t ue_context_request;
 } ue_m5gmm_context_t;
 
 /* Operation on UE context structure

--- a/lte/gateway/c/oai/tasks/ngap/ngap_amf_itti_messaging.c
+++ b/lte/gateway/c/oai/tasks/ngap/ngap_amf_itti_messaging.c
@@ -96,8 +96,8 @@ void ngap_amf_itti_ngap_initial_ue_message(
     const guamfi_t const* opt_guamfi,
     const void const* opt_cell_access_mode,           // unused
     const void const* opt_cell_gw_transport_address,  // unused
-    const void const* opt_relay_node_indicator)       // unused
-{
+    const void const* opt_relay_node_indicator,       // unused
+    const long ue_ctx_req) {
   MessageDef* message_p = NULL;
 
   OAILOG_FUNC_IN(LOG_NGAP);
@@ -124,6 +124,9 @@ void ngap_amf_itti_ngap_initial_ue_message(
   NGAP_INITIAL_UE_MESSAGE(message_p).nas = blk2bstr(nas_msg, nas_msg_length);
   NGAP_INITIAL_UE_MESSAGE(message_p).m5g_rrc_establishment_cause =
       rrc_cause + 1;
+
+  OAILOG_INFO(LOG_NGAP, "ue context request recvd at ngap : %d", ue_ctx_req);
+  NGAP_INITIAL_UE_MESSAGE(message_p).ue_context_request = ue_ctx_req;
 
   if (opt_s_tmsi) {
     NGAP_INITIAL_UE_MESSAGE(message_p).is_s_tmsi_valid = true;

--- a/lte/gateway/c/oai/tasks/ngap/ngap_amf_itti_messaging.h
+++ b/lte/gateway/c/oai/tasks/ngap/ngap_amf_itti_messaging.h
@@ -79,8 +79,8 @@ void ngap_amf_itti_ngap_initial_ue_message(
     const guamfi_t const* opt_guamfi,
     const void const* opt_cell_access_mode,          /* unused*/
     const void const* opt_cell_gw_transport_address, /* unused*/
-    const void const* opt_relay_node_indicator       /* unused*/
-);
+    const void const* opt_relay_node_indicator,      /* unused*/
+    const long ue_ctx_req);
 
 void ngap_amf_itti_nas_non_delivery_ind(
     const amf_ue_ngap_id_t ue_id, uint8_t* const nas_msg,

--- a/lte/gateway/c/oai/tasks/ngap/ngap_amf_nas_procedures.c
+++ b/lte/gateway/c/oai/tasks/ngap/ngap_amf_nas_procedures.c
@@ -207,6 +207,17 @@ int ngap_amf_handle_initial_ue_message(
     NGAP_FIND_PROTOCOLIE_BY_ID(
         Ngap_InitialUEMessage_IEs_t, ie_cause, container,
         Ngap_ProtocolIE_ID_id_RRCEstablishmentCause, true);
+    // optional UeContextRequest
+    Ngap_InitialUEMessage_IEs_t* ie_uecontextrequest = NULL;
+    NGAP_FIND_PROTOCOLIE_BY_ID(
+        Ngap_InitialUEMessage_IEs_t, ie_uecontextrequest, container,
+        Ngap_ProtocolIE_ID_id_UEContextRequest, false);
+    long ue_context_request = 0;
+    if (ie_uecontextrequest) {
+      ue_context_request =
+          ie_uecontextrequest->value.choice.UEContextRequest + 1;
+    }
+
     ngap_amf_itti_ngap_initial_ue_message(
         assoc_id, gNB_ref->gnb_id, ue_ref->gnb_ue_ngap_id,
         ie->value.choice.NAS_PDU.buf, ie->value.choice.NAS_PDU.size, &tai,
@@ -215,8 +226,8 @@ int ngap_amf_handle_initial_ue_message(
         ie_guamfi ? &guamfi : NULL,
         NULL,  // CELL ACCESS MODE
         NULL,  // GW Transport Layer Address
-        NULL   // Relay Node Indicator
-    );
+        NULL,  // Relay Node Indicator
+        ue_context_request);
 
   } else {
     OAILOG_ERROR(


### PR DESCRIPTION
…in UE and populating in AMF

Fixes:
 1. NGAP decodes UEContextRequest IE received from InitialUEMessage and Passes to AMF thread
 2. AMF will trigger InitialContextSetupRequest based on UEContextRequest parameter

Test case:
 1. Tested Registration with UEContextRequest IE  using UERANSIM
 2. Tested Registration without UEContextRequest IE  using UERANSIM

Signed-off-by: ganeshg87 <ganesh.gedela@wavelabs.ai>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
