### PR TITLE
Loosen formatting to be less aggressive

### DIFF
--- a/lte/gateway/python/precommit.py
+++ b/lte/gateway/python/precommit.py
@@ -58,7 +58,8 @@ def _build_docker_image():
 
 def _format_diff(paths: List[str]):
     for path in paths:
-        _run_docker_cmd(['autopep8', '-r', '-a', '--in-place', path])
+        autopep8_checks = 'E1,E2,E3,W'
+        _run_docker_cmd(['autopep8', '--select', autopep8_checks, '-r', '--in-place', path])
         _run_docker_cmd(['isort', path])
         _run_add_trailing_comma(path)
 


### PR DESCRIPTION
Signed-off-by: Marie Bremner <marwhal@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary
Only take a subset of the following formatting tools to make the script less aggressive.
Planning on adding a check for all python PRs to adhere to the formatting guidelines, so we want the bar to be a bit less potentially destructive.

List of all the fixes, and we only take `E1,E2,E3,W` for the basic white space fixes
```
➜  python git:(loosen-precommit-script) ✗ autopep8 --list
E101 - Reindent all lines.
E112 - Fix under-indented comments.
E113 - Fix unexpected indentation.
E115 - Fix under-indented comments.
E116 - Fix over-indented comments.
E117 - Fix over-indented.
E121 - Fix a badly indented line.
E122 - Fix a badly indented line.
E123 - Fix a badly indented line.
E124 - Fix a badly indented line.
E125 - Fix indentation undistinguish from the next logical line.
E126 - Fix a badly indented line.
E127 - Fix a badly indented line.
E128 - Fix a badly indented line.
E129 - Fix a badly indented line.
E131 - Fix indentation undistinguish from the next logical line.
E133 - Fix indentation undistinguish from the next logical line.
E201 - Remove extraneous whitespace.
E202 - Remove extraneous whitespace.
E203 - Remove extraneous whitespace.
E211 - Remove extraneous whitespace.
E221 - Fix extraneous whitespace around keywords.
E222 - Fix extraneous whitespace around keywords.
E223 - Fix extraneous whitespace around keywords.
E224 - Remove extraneous whitespace around operator.
E225 - Fix missing whitespace around operator.
E226 - Fix missing whitespace around operator.
E227 - Fix missing whitespace around operator.
E228 - Fix missing whitespace around operator.
E231 - Add missing whitespace.
E231 - Fix various deprecated code (via lib2to3).
E241 - Fix extraneous whitespace around keywords.
E242 - Remove extraneous whitespace around operator.
E251 - Remove whitespace around parameter '=' sign.
E252 - Fix missing whitespace around operator.
E261 - Fix spacing after comment hash.
E262 - Fix spacing after comment hash.
E265 - Format block comments.
E271 - Fix extraneous whitespace around keywords.
E272 - Fix extraneous whitespace around keywords.
E273 - Fix extraneous whitespace around keywords.
E274 - Fix extraneous whitespace around keywords.
E301 - Add missing blank line.
E302 - Add missing 2 blank lines.
E303 - Remove extra blank lines.
E304 - Remove blank line following function decorator.
E305 - Add missing 2 blank lines after end of function or class.
E306 - Add missing blank line.
E401 - Put imports on separate lines.
E402 -
E501 - Try to make lines fit within --max-line-length characters.
E502 - Remove extraneous escape of newline.
E701 - Put colon-separated compound statement on separate lines.
E702 - Put semicolon-separated compound statement on separate lines.
E703 - Put semicolon-separated compound statement on separate lines.
E704 - Fix multiple statements on one line def
E711 - Fix comparison with None.
E712 - Fix (trivial case of) comparison with boolean.
E713 - Fix (trivial case of) non-membership check.
E714 - Fix object identity should be 'is not' case.
E721 - Fix various deprecated code (via lib2to3).
E722 - fix bare except
E731 - Fix do not assign a lambda expression check.
W291 - Remove trailing whitespace.
W293 - Remove trailing whitespace.
W391 - Remove trailing blank lines.
W503 -
W504 -
W601 - Fix various deprecated code (via lib2to3).
W602 - Fix deprecated form of raising exception.
W603 - Fix various deprecated code (via lib2to3).
W604 - Fix various deprecated code (via lib2to3).
W605 -
W690 - Fix various deprecated code (via lib2to3).
```
<!-- Enumerate changes you made and why you made them -->

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
