### PR TITLE
add a Github Action to check for any leftover python formatting 

### DIFF
--- a/.github/workflows/python-formatting-check.yml
+++ b/.github/workflows/python-formatting-check.yml
@@ -1,0 +1,54 @@
+---
+name: Python Format Check
+on:  # yamllint disable-line rule:truthy
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+    paths:  # order matters here, always put includes then excludes
+      - 'lte/gateway/python/**.py'
+      - 'orc8r/gateway/python/**.py'
+      - '!**/scripts/**.py'
+      - '!lte/gateway/python/magma/pipelined/**.py'  # TODO add back
+      - '!lte/gateway/python/integ_tests/**.py'  # TODO add back
+
+jobs:
+  run-formatters-and-check-for-errors:
+    name: Run Python formatters and check for errors
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Get changed files
+        id: py-changes
+        # Set outputs.py to be a list of modified python files
+        run: |
+          echo "::set-output name=py::$(git diff --name-only --diff-filter=ACMRT ${{ github.event.pull_request.base.sha }} ${{ github.sha }} | grep .py$ | xargs)"
+      - if: ${{ steps.py-changes.outputs.py }}
+        name: Docker Build
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: ./lte/gateway/docker/python-precommit/Dockerfile
+          push: false
+          tags: magma/py-lint:latest
+      - uses: addnab/docker-run-action@v3
+        with:
+          image: magma/py-lint:latest
+          options: -u 0 -v ${{ github.workspace }}:/code
+          run: |
+            for file in ${{ steps.py-changes.outputs.py }};
+            do
+              echo "Running formatting commands for $file...";
+              set -e
+              isort --check-only $file;
+              autopep8 --exit-code --select W291,W293,E2,E3 -r --in-place  $file;
+              add-trailing-comma --py35-plus $file;
+            done;
+      - name: Look here for instructions for when the check fails
+        # TODO figure out how to post this as a PR comment (permission issues with forked PRs)
+        run: |
+          echo "::error Use the formatter script 'lte/gateway/python/precommit.py' to run the formatters locally."
+          echo "::error Run './precommit.py --build' to build the setup, and then run './precommit.py --format --diff'"

--- a/lte/gateway/docker/python-precommit/Dockerfile
+++ b/lte/gateway/docker/python-precommit/Dockerfile
@@ -3,7 +3,7 @@ FROM python:3.8-alpine as builder
 RUN addgroup -S linter && adduser -S -G linter linter
 RUN apk add --no-cache git gcc musl-dev # temp
 
-COPY requirements.txt /
+COPY lte/gateway/docker/python-precommit/requirements.txt /
 RUN pip wheel -r /requirements.txt --wheel-dir=/wheelhouse/
 
 


### PR DESCRIPTION
Signed-off-by: Marie Bremner <marwhal@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary
Few things:
1. refactor precommit.py/Dockerfile script so that the docker command can be run from anywhere in the codebase. (It previously had to be run in `lte/gateway/python`.) This adds a new dependency where the script requires the MAGMA_ROOT environment variable to be set. But I put in an additional warning log to indicate this and most dev setups have this env var already.
2. add a GitHub action to run the same set of formatting commands and fail if any changes are needed. This is non-required for now, but once I get around to fixing up the relevant python files, we can make this mandatory. (Note that the check currently excludes PipelineD as there is a lot of pending formatting changes there)
<!-- Enumerate changes you made and why you made them -->

## Test Plan
Ran the check with multiple failing python files
Shouldn't greatly affect anything as this check is not mandatory yet.
(What it looks like when there is pending formatting change)
<img width="1013" alt="Screen Shot 2021-06-03 at 11 50 15 AM" src="https://user-images.githubusercontent.com/37634144/120682256-e05d1300-c461-11eb-83e6-2cd80026d315.png">

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
