### PR TITLE
AGW: Fix flow create for non-nat bootup.

### DIFF
--- a/lte/gateway/python/magma/pipelined/app/uplink_bridge.py
+++ b/lte/gateway/python/magma/pipelined/app/uplink_bridge.py
@@ -393,10 +393,6 @@ class UplinkBridgeController(MagmaController):
             self.logger.info("could not flush ip addr: %s, %s", if_name, ex)
 
         self.logger.info("SGi DHCP: port [%s] ip removed", if_name)
-        while True:
-            # keep updating flow to handle IP address change.
-            self._set_sgi_interface_ingress_flows()
-            hub.sleep(self.SGI_INGRESS_FLOW_UPDATE_FREQ)
 
 
     def _restart_dhclient_if(self, if_name):
@@ -410,6 +406,10 @@ class UplinkBridgeController(MagmaController):
                              setup_dhclient, ex)
 
         self.logger.info("SGi DHCP: restart for %s done", if_name)
+        while True:
+            # keep updating flow to handle IP address change.
+            self._set_sgi_interface_ingress_flows()
+            hub.sleep(self.SGI_INGRESS_FLOW_UPDATE_FREQ)
 
     def _set_arp_ignore(self, if_name: str, val: str):
         sysctl_setting = 'net.ipv4.conf.' + if_name + '.arp_ignore=' + val


### PR DESCRIPTION
while bringing the AGW uplink-bridge, flows needs to
be created when DHCP ip is allocated.

Signed-off-by: Pravin B Shelar <pbshelar@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->

## Test Plan
tested on bare metal AGW
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
