### PR TITLE
add step in agw package to copy out c executables for sentry

### DIFF
--- a/lte/gateway/fabfile.py
+++ b/lte/gateway/fabfile.py
@@ -422,6 +422,10 @@ def load_test(gateway_host=None, destroy_vm=True):
         env.hosts = [gateway_host]
 
 
+def _copy_out_c_execs():
+    pass
+
+
 def _dist_upgrade():
     """ Upgrades OS packages on dev box """
     run('sudo apt-get update')


### PR DESCRIPTION
<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary
This PR adds changes to copy out C/C++ executables out to the CI node / artifactory so that they can be uploaded to Sentry separately.

## Test Plan
initially,
```
vagrant@magma-dev:~/magma/lte/gateway$ ls ~/magma-packages/
```
Run the function manually:
```
➜  gateway git:(add-deploy-sentry) ✗ fab copy_out_c_execs
[localhost] local: pwd
[localhost] local: vagrant status magma
[localhost] local: vagrant ssh-config magma
[vagrant@127.0.0.1:2222] run: cp /usr/local/bin/sessiond ~/magma-packages
[vagrant@127.0.0.1:2222] run: cp /usr/local/bin/mme ~/magma-packages
[vagrant@127.0.0.1:2222] run: cp /usr/local/sbin/sctpd ~/magma-packages
[vagrant@127.0.0.1:2222] run: cp /usr/local/bin/connectiond ~/magma-packages

Done.
Disconnecting from vagrant@127.0.0.1:2222... done.
```
finally,
```
vagrant@magma-dev:~/magma/lte/gateway$ ls ~/magma-packages/
connectiond  mme  sctpd  sessiond
```

Currently running `fab test package` to make sure there is no regression there

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
Signed-off-by: Marie Bremner <marwhal@fb.com>