### PR TITLE
[NMS]Made Gateways register only unregistered enodeB's

### DIFF
--- a/nms/app/packages/magmalte/app/views/equipment/GatewayDetailConfigEdit.js
+++ b/nms/app/packages/magmalte/app/views/equipment/GatewayDetailConfigEdit.js
@@ -72,7 +72,7 @@ import {
 } from '../../components/GatewayUtils';
 import {colors, typography} from '../../theme/default';
 import {makeStyles} from '@material-ui/styles';
-import {useContext, useEffect, useState} from 'react';
+import {useCallback, useContext, useEffect, useState} from 'react';
 import {useEnqueueSnackbar} from '@fbcnms/ui/hooks/useSnackbar';
 import {useRouter} from '@fbcnms/ui/hooks';
 
@@ -782,7 +782,7 @@ export function RanEdit(props: Props) {
   const handleDnsChange = (key: string, val) => {
     setDnsConfig({...dnsConfig, [key]: val});
   };
-  const isEnodebUnregistered = React.useCallback(
+  const isEnodebUnregistered = useCallback(
     (enb: enodeb, currentGateway: lte_gateway) => {
       const gatewaysList = Object.keys(ctx.state);
       for (const gatewayId of gatewaysList) {

--- a/nms/app/packages/magmalte/app/views/equipment/GatewayDetailConfigEdit.js
+++ b/nms/app/packages/magmalte/app/views/equipment/GatewayDetailConfigEdit.js
@@ -72,7 +72,7 @@ import {
 } from '../../components/GatewayUtils';
 import {colors, typography} from '../../theme/default';
 import {makeStyles} from '@material-ui/styles';
-import {useCallback, useContext, useEffect, useState} from 'react';
+import {useContext, useEffect, useState} from 'react';
 import {useEnqueueSnackbar} from '@fbcnms/ui/hooks/useSnackbar';
 import {useRouter} from '@fbcnms/ui/hooks';
 
@@ -782,8 +782,8 @@ export function RanEdit(props: Props) {
   const handleDnsChange = (key: string, val) => {
     setDnsConfig({...dnsConfig, [key]: val});
   };
-  const isEnodebUnregistered = useCallback(
-    (enb: enodeb, currentGateway: lte_gateway) => {
+  useEffect(() => {
+    const isEnodebUnregistered = (enb: enodeb, currentGateway: lte_gateway) => {
       const gatewaysList = Object.keys(ctx.state);
       for (const gatewayId of gatewaysList) {
         if (
@@ -794,10 +794,7 @@ export function RanEdit(props: Props) {
         }
       }
       return true;
-    },
-    [ctx?.state],
-  );
-  useEffect(() => {
+    };
     const newUnregisteredEnodebs = {};
     if (enbsCtx?.state?.enbInfo) {
       Object.keys(enbsCtx.state.enbInfo).map(enbSerial => {
@@ -808,7 +805,7 @@ export function RanEdit(props: Props) {
       });
     }
     setUnregisteredEnodebs(newUnregisteredEnodebs);
-  }, [enbsCtx?.state?.enbInfo, isEnodebUnregistered, props?.gateway]);
+  }, [ctx?.state, enbsCtx?.state?.enbInfo, props?.gateway]);
   const onSave = async () => {
     try {
       const gateway = {

--- a/nms/app/packages/magmalte/app/views/equipment/GatewayDetailConfigEdit.js
+++ b/nms/app/packages/magmalte/app/views/equipment/GatewayDetailConfigEdit.js
@@ -775,7 +775,7 @@ export function RanEdit(props: Props) {
   const [connectedEnodebs, setConnectedEnodebs] = useState<enodeb_serials>(
     props.gateway.connected_enodeb_serials,
   );
-  const [unregisteredEnodebs, setUnregisteredEnodebs] = useState({});
+  const [unregisteredEnbsInfo, setUnregisteredEnbsInfo] = useState([]);
   const handleRanChange = (key: string, val) => {
     setRanConfig({...ranConfig, [key]: val});
   };
@@ -795,16 +795,22 @@ export function RanEdit(props: Props) {
       }
       return true;
     };
-    const newUnregisteredEnodebs = {};
+    const newUnregisteredEnbsInfo = [];
     if (enbsCtx?.state?.enbInfo) {
       Object.keys(enbsCtx.state.enbInfo).map(enbSerial => {
-        newUnregisteredEnodebs[enbSerial] = isEnodebUnregistered(
-          enbsCtx.state.enbInfo[enbSerial].enb,
-          props.gateway,
-        );
+        if (
+          isEnodebUnregistered(
+            enbsCtx.state.enbInfo[enbSerial].enb,
+            props.gateway,
+          )
+        ) {
+          newUnregisteredEnbsInfo.push({
+            [enbSerial]: enbsCtx.state.enbInfo[enbSerial],
+          });
+        }
       });
     }
-    setUnregisteredEnodebs(newUnregisteredEnodebs);
+    setUnregisteredEnbsInfo(newUnregisteredEnbsInfo);
   }, [ctx?.state, enbsCtx?.state?.enbInfo, props?.gateway]);
   const onSave = async () => {
     try {
@@ -878,24 +884,18 @@ export function RanEdit(props: Props) {
                   className={connectedEnodebs.length ? '' : classes.placeholder}
                 />
               }>
-              {enbsCtx?.state &&
-                Object.keys(enbsCtx.state.enbInfo).map(enbSerial => {
-                  if (unregisteredEnodebs[enbSerial]) {
-                    return (
-                      <MenuItem key={enbSerial} value={enbSerial}>
-                        <Checkbox
-                          checked={connectedEnodebs.includes(enbSerial)}
-                        />
-                        <ListItemText
-                          primary={enbsCtx.state.enbInfo[enbSerial].enb.name}
-                          secondary={enbSerial}
-                        />
-                      </MenuItem>
-                    );
-                  } else {
-                    return null;
-                  }
-                })}
+              {unregisteredEnbsInfo.map(unregisteredEnbInfo => {
+                const enbSerial = Object.keys(unregisteredEnbInfo)[0];
+                return (
+                  <MenuItem key={enbSerial} value={enbSerial}>
+                    <Checkbox checked={connectedEnodebs.includes(enbSerial)} />
+                    <ListItemText
+                      primary={unregisteredEnbInfo[enbSerial].enb.name}
+                      secondary={enbSerial}
+                    />
+                  </MenuItem>
+                );
+              })}
             </Select>
           </AltFormField>
           <AltFormField label={'Transmit Enabled'}>

--- a/nms/app/packages/magmalte/app/views/equipment/GatewayDetailConfigEdit.js
+++ b/nms/app/packages/magmalte/app/views/equipment/GatewayDetailConfigEdit.js
@@ -16,6 +16,7 @@
 import type {
   apn_resources,
   challenge_key,
+  enodeb,
   enodeb_serials,
   gateway_device,
   gateway_dns_configs,
@@ -808,7 +809,21 @@ export function RanEdit(props: Props) {
       setError(e.response?.data?.message ?? e.message);
     }
   };
-
+  const isEnodebUnregistered = React.useCallback(
+    (enb: enodeb, currentGateway: lte_gateway) => {
+      const gatewaysList = Object.keys(ctx.state);
+      for (const gatewayId of gatewaysList) {
+        if (
+          ctx.state[gatewayId].connected_enodeb_serials?.includes(enb.serial) &&
+          ctx.state[gatewayId].id != currentGateway.id
+        ) {
+          return false;
+        }
+      }
+      return true;
+    },
+    [ctx.state],
+  );
   return (
     <>
       <DialogContent data-testid="ranEdit">
@@ -855,15 +870,28 @@ export function RanEdit(props: Props) {
                 />
               }>
               {enbsCtx?.state &&
-                Object.keys(enbsCtx.state.enbInfo).map(enbSerial => (
-                  <MenuItem key={enbSerial} value={enbSerial}>
-                    <Checkbox checked={connectedEnodebs.includes(enbSerial)} />
-                    <ListItemText
-                      primary={enbsCtx.state.enbInfo[enbSerial].enb.name}
-                      secondary={enbSerial}
-                    />
-                  </MenuItem>
-                ))}
+                Object.keys(enbsCtx.state.enbInfo).map(enbSerial => {
+                  if (
+                    isEnodebUnregistered(
+                      enbsCtx.state.enbInfo[enbSerial].enb,
+                      props.gateway,
+                    )
+                  ) {
+                    return (
+                      <MenuItem key={enbSerial} value={enbSerial}>
+                        <Checkbox
+                          checked={connectedEnodebs.includes(enbSerial)}
+                        />
+                        <ListItemText
+                          primary={enbsCtx.state.enbInfo[enbSerial].enb.name}
+                          secondary={enbSerial}
+                        />
+                      </MenuItem>
+                    );
+                  } else {
+                    return null;
+                  }
+                })}
             </Select>
           </AltFormField>
           <AltFormField label={'Transmit Enabled'}>


### PR DESCRIPTION
Signed-off-by: Dani Menewuyelet <dmenewuy@fb.com>



## Summary

In the GatewayDetailConfigEdit.js file, I made the ran edit component to filter out an already registered eNodeB's under a different gateway. This way, when trying to register eNodeBs, it now shows only unregistered eNodeBs. Therefore it makes sure that an eNodeB can not be registered to more than one Gateway.

## Test Plan

Tested it by creating eNodeBs and access gateways and registering the eNodeBs to some access gateway and seeing what happens when trying to register the same eNodeB to another gateway. Video is provided. Also, I ran the previous tests that were written and made sure it is compatible.

## Additional Information


![unregistered_eNodeB_test_part_1](https://user-images.githubusercontent.com/34602743/120717052-ef10ed80-c494-11eb-8fba-709257b77da2.gif)
![unregistered_eNodeB_test_part_2](https://user-images.githubusercontent.com/34602743/120717058-f2a47480-c494-11eb-9175-74fb468df4df.gif)

