### PR TITLE
[NMS] Made the subscriber add button to now call the new bulk add endpoint instead of adding subscribers singly

### DIFF
--- a/nms/app/packages/fbcnms-magma-api/__generated__/MagmaAPIBindings.js
+++ b/nms/app/packages/fbcnms-magma-api/__generated__/MagmaAPIBindings.js
@@ -17,6 +17,7 @@
 
 export type aaa_server = {
     accounting_enabled ? : boolean,
+    acct_reporting_enabled ? : boolean,
     create_session_on_auth ? : boolean,
     event_logging_enabled ? : boolean,
     idle_session_timeout_ms ? : number,
@@ -856,7 +857,7 @@ export type mutable_enodebd_e2e_test = {
 export type mutable_federation_gateway = {
     description: gateway_description,
     device: gateway_device,
-    federation: gateway_federation_configs,
+    federation ? : gateway_federation_configs,
     id: gateway_id,
     magmad: magmad_gateway_configs,
     name: gateway_name,
@@ -891,6 +892,8 @@ export type mutable_subscriber = {
     name ? : string,
     static_ips ? : subscriber_static_ips,
 };
+export type mutable_subscribers = Array < mutable_subscriber >
+;
 export type mutable_wifi_gateway = {
     description: gateway_description,
     device: gateway_device,
@@ -1007,6 +1010,11 @@ export type network_interface = {
     status ? : "UP" | "DOWN" | "UNKNOWN",
 };
 export type network_name = string;
+export type network_probe_data = {
+    last_exported: string,
+    sequence_number: number,
+    target_id: string,
+};
 export type network_probe_destination = {
     destination_details: network_probe_destination_details,
     destination_id: network_probe_destination_id,
@@ -7095,6 +7103,31 @@ export default class MagmaAPIBindings {
 
             return await this.request(path, 'GET', query, body);
         }
+    static async postLteByNetworkIdSubscribersV2(
+        parameters: {
+            'networkId': string,
+            'subscribers': mutable_subscribers,
+        }
+    ): Promise < "Success" > {
+        let path = '/lte/{network_id}/subscribers_v2';
+        let body;
+        let query = {};
+        if (parameters['networkId'] === undefined) {
+            throw new Error('Missing required  parameter: networkId');
+        }
+
+        path = path.replace('{network_id}', `${parameters['networkId']}`);
+
+        if (parameters['subscribers'] === undefined) {
+            throw new Error('Missing required  parameter: subscribers');
+        }
+
+        if (parameters['subscribers'] !== undefined) {
+            body = parameters['subscribers'];
+        }
+
+        return await this.request(path, 'POST', query, body);
+    }
     static async getNetworks(): Promise < Array < string >
         >
         {

--- a/nms/app/packages/magmalte/app/components/context/SubscriberContext.js
+++ b/nms/app/packages/magmalte/app/components/context/SubscriberContext.js
@@ -16,6 +16,7 @@
 import type {
   gateway_id,
   mutable_subscriber,
+  mutable_subscribers,
   subscriber,
   subscriber_id,
   subscriber_state,
@@ -42,7 +43,7 @@ export type SubscriberContextType = {
   gwSubscriberMap: {[gateway_id]: Array<subscriber_id>},
   setState?: (
     key: string,
-    val?: mutable_subscriber,
+    val?: mutable_subscriber | mutable_subscribers,
     newState?: {[string]: subscriber},
     newSessionState?: {[string]: subscriber_state},
   ) => Promise<void>,

--- a/nms/app/packages/magmalte/app/components/lte/LteContext.js
+++ b/nms/app/packages/magmalte/app/components/lte/LteContext.js
@@ -39,6 +39,7 @@ import type {
   lte_network,
   mutable_call_trace,
   mutable_subscriber,
+  mutable_subscribers,
   network_id,
   network_ran_configs,
   network_type,
@@ -271,7 +272,7 @@ export function SubscriberContextProvider(props: Props) {
         gwSubscriberMap: getGatewaySubscriberMap(sessionState),
         setState: (
           key: subscriber_id,
-          value?: mutable_subscriber,
+          value?: mutable_subscriber | mutable_subscribers,
           newState?,
           newSessionState?,
         ) =>

--- a/nms/app/packages/magmalte/app/state/lte/SubscriberState.js
+++ b/nms/app/packages/magmalte/app/state/lte/SubscriberState.js
@@ -20,6 +20,7 @@ import type {SubscriberContextType} from '../../components/context/SubscriberCon
 import type {SubscriberRowType} from '../../views/subscriber/SubscriberOverview';
 import type {
   mutable_subscriber,
+  mutable_subscribers,
   network_id,
   subscriber,
   subscriber_state,
@@ -187,7 +188,7 @@ type SubscriberStateProps = {
   setSubscriberMap: ({[string]: subscriber}) => void,
   setSessionState: ({[string]: subscriber_state}) => void,
   key: string,
-  value?: mutable_subscriber,
+  value?: mutable_subscriber | mutable_subscribers,
   newState?: {[string]: subscriber},
   newSessionState?: {[string]: subscriber_state},
 };
@@ -210,6 +211,18 @@ export async function setSubscriberState(props: SubscriberStateProps) {
   if (newSessionState) {
     // $FlowIgnore
     setSessionState(newSessionState.sessionState);
+    return;
+  }
+  if (Array.isArray(value)) {
+    await MagmaV1API.postLteByNetworkIdSubscribersV2({
+      networkId,
+      subscribers: value,
+    });
+    const newSubscriberMap = {};
+    value.map(newSubscriber => {
+      newSubscriberMap[newSubscriber.id] = newSubscriber;
+    });
+    setSubscriberMap({...subscriberMap, newSubscriberMap});
     return;
   }
   if (value != null) {

--- a/nms/app/packages/magmalte/app/views/subscriber/SubscriberAddDialog.js
+++ b/nms/app/packages/magmalte/app/views/subscriber/SubscriberAddDialog.js
@@ -564,6 +564,7 @@ function AddSubscriberDetails(props: DialogProps) {
       } catch (e) {
         const errMsg = e.response?.data?.message ?? e.message ?? e;
         setError('error saving subscribers to the api : ' + errMsg);
+        return;
       }
     }
     enqueueSnackbar(

--- a/nms/app/packages/magmalte/app/views/subscriber/SubscriberAddDialog.js
+++ b/nms/app/packages/magmalte/app/views/subscriber/SubscriberAddDialog.js
@@ -536,6 +536,7 @@ function AddSubscriberDetails(props: DialogProps) {
       return success;
     }
   };
+
   const saveSubscribers = async () => {
     let addedSubscribers = [];
     let subscriberErrors = '';

--- a/nms/app/packages/magmalte/app/views/subscriber/SubscriberAddDialog.js
+++ b/nms/app/packages/magmalte/app/views/subscriber/SubscriberAddDialog.js
@@ -42,11 +42,7 @@ import Tabs from '@material-ui/core/Tabs';
 import TypedSelect from '@fbcnms/ui/components/TypedSelect';
 import nullthrows from '@fbcnms/util/nullthrows';
 
-import {
-  AltFormField,
-  LinearProgressWithLabel,
-  PasswordInput,
-} from '../../components/FormField';
+import {AltFormField, PasswordInput} from '../../components/FormField';
 import {SelectEditComponent} from '../../components/ActionTable';
 import {base64ToHex, hexToBase64, isValidHex} from '@fbcnms/util/strings';
 import {colors, typography} from '../../theme/default';
@@ -503,7 +499,6 @@ function AddSubscriberDetails(props: DialogProps) {
   const policyCtx = useContext(PolicyContext);
   const [error, setError] = useState('');
   const [subscribers, setSubscribers] = useState<Array<SubscriberInfo>>([]);
-  const successCountRef = useRef(0);
 
   const fileInput = useRef(null);
   const enqueueSnackbar = useEnqueueSnackbar();
@@ -519,7 +514,6 @@ function AddSubscriberDetails(props: DialogProps) {
     new Set(Object.keys(policyCtx.state || {})).add('default'),
   );
   const saveSubscribers = async () => {
-    successCountRef.current = 0;
     const addedSubscribers = [];
     for (const subscriber of subscribers) {
       try {
@@ -549,12 +543,12 @@ function AddSubscriberDetails(props: DialogProps) {
             sub_profile: subscriber.dataPlan,
           },
         };
-        successCountRef.current = successCountRef.current + 1;
         addedSubscribers.push(newSubscriber);
       } catch (e) {
         const errMsg = e.response?.data?.message ?? e.message ?? e;
-        setError('error saving ' + subscriber.imsi + ' : ' + errMsg);
-        return;
+        enqueueSnackbar('Error saving ' + subscriber.imsi + ' : ' + errMsg, {
+          variant: 'error',
+        });
       }
     }
     //bulk add subscribers at the end
@@ -570,7 +564,7 @@ function AddSubscriberDetails(props: DialogProps) {
     }
     enqueueSnackbar(
       ` Subscriber${
-        successCountRef.current > 0 ? 's ' : ''
+        addedSubscribers.length > 0 ? 's ' : ''
       } saved successfully`,
       {
         variant: 'success',
@@ -582,14 +576,6 @@ function AddSubscriberDetails(props: DialogProps) {
   return (
     <>
       <DialogContent>
-        {successCountRef.current > 0 && subscribers.length > 0 && (
-          <LinearProgressWithLabel
-            value={Math.round(
-              (successCountRef.current * 100) / subscribers.length,
-            )}
-            text={`${successCountRef.current}/${subscribers.length}`}
-          />
-        )}
         {error !== '' && <FormLabel error>{error}</FormLabel>}
         <input
           type="file"

--- a/nms/app/packages/magmalte/app/views/subscriber/SubscriberAddDialog.js
+++ b/nms/app/packages/magmalte/app/views/subscriber/SubscriberAddDialog.js
@@ -521,12 +521,7 @@ function AddSubscriberDetails(props: DialogProps) {
   const saveSubscribers = async () => {
     successCountRef.current = 0;
     const addedSubscribers = [];
-    for (
-      let subscriberIdx = 0;
-      subscriberIdx < subscribers.length;
-      ++subscriberIdx
-    ) {
-      const subscriber = subscribers[subscriberIdx];
+    for (const subscriber of subscribers) {
       try {
         const err = validateSubscriberInfo(subscriber, ctx.state);
         if (err.length > 0) {
@@ -556,14 +551,19 @@ function AddSubscriberDetails(props: DialogProps) {
         };
         successCountRef.current = successCountRef.current + 1;
         addedSubscribers.push(newSubscriber);
-        //bulk add subscribers at the end
-        if (subscriberIdx == subscribers.length - 1) {
-          await ctx.setState?.('', addedSubscribers);
-        }
       } catch (e) {
         const errMsg = e.response?.data?.message ?? e.message ?? e;
         setError('error saving ' + subscriber.imsi + ' : ' + errMsg);
         return;
+      }
+    }
+    //bulk add subscribers at the end
+    if (addedSubscribers.length > 0) {
+      try {
+        await ctx.setState?.('', addedSubscribers);
+      } catch (e) {
+        const errMsg = e.response?.data?.message ?? e.message ?? e;
+        setError('error saving subscribers to the api : ' + errMsg);
       }
     }
     enqueueSnackbar(

--- a/nms/app/packages/magmalte/app/views/subscriber/SubscriberAddDialog.js
+++ b/nms/app/packages/magmalte/app/views/subscriber/SubscriberAddDialog.js
@@ -562,8 +562,12 @@ function AddSubscriberDetails(props: DialogProps) {
       try {
         await ctx.setState?.('', addedSubscribers);
       } catch (e) {
-        const errMsg = e.response?.data?.message ?? e.message ?? e;
-        setError('error saving subscribers to the api : ' + errMsg);
+        enqueueSnackbar(
+          'Saving subscribers to the api failed',
+          {
+            variant: 'error',
+          },
+        );
         return;
       }
     }

--- a/nms/app/packages/magmalte/app/views/subscriber/SubscriberAddDialog.js
+++ b/nms/app/packages/magmalte/app/views/subscriber/SubscriberAddDialog.js
@@ -539,7 +539,7 @@ function AddSubscriberDetails(props: DialogProps) {
   const saveSubscribers = async () => {
     let addedSubscribers = [];
     let subscriberErrors = '';
-    for (const subscriber of subscribers) {
+    for (const [i, subscriber] of subscribers.entries()) {
       try {
         const err = validateSubscriberInfo(subscriber, ctx.state);
         if (err.length > 0) {
@@ -569,7 +569,10 @@ function AddSubscriberDetails(props: DialogProps) {
         };
         addedSubscribers.push(newSubscriber);
         // bulk add chunked subscribers
-        if (addedSubscribers.length == SUBSCRIBERS_CHUNK_SIZE) {
+        if (
+          addedSubscribers.length == SUBSCRIBERS_CHUNK_SIZE ||
+          i == subscribers.length - 1
+        ) {
           const success = await bulkAdd(addedSubscribers, subscriberErrors);
           if (success) {
             successCountRef.current =
@@ -586,16 +589,6 @@ function AddSubscriberDetails(props: DialogProps) {
         const errMsg = e.response?.data?.message ?? e.message ?? e;
         subscriberErrors +=
           'error saving ' + subscriber.imsi + ' : ' + errMsg + '\n';
-      }
-    }
-    //bulk add left subscribers
-    if (addedSubscribers.length > 0) {
-      const success = await bulkAdd(addedSubscribers, subscriberErrors);
-      if (!success) {
-        enqueueSnackbar('Saving subscribers to the api failed: ', {
-          variant: 'error',
-        });
-        return;
       }
     }
     enqueueSnackbar(

--- a/nms/app/packages/magmalte/app/views/subscriber/SubscriberAddDialog.js
+++ b/nms/app/packages/magmalte/app/views/subscriber/SubscriberAddDialog.js
@@ -520,7 +520,13 @@ function AddSubscriberDetails(props: DialogProps) {
   );
   const saveSubscribers = async () => {
     successCountRef.current = 0;
-    for (const subscriber of subscribers) {
+    const addedSubscribers = [];
+    for (
+      let subscriberIdx = 0;
+      subscriberIdx < subscribers.length;
+      ++subscriberIdx
+    ) {
+      const subscriber = subscribers[subscriberIdx];
       try {
         const err = validateSubscriberInfo(subscriber, ctx.state);
         if (err.length > 0) {
@@ -535,7 +541,7 @@ function AddSubscriberDetails(props: DialogProps) {
           subscriber.authOpc !== undefined && isValidHex(subscriber.authOpc)
             ? hexToBase64(subscriber.authOpc)
             : '';
-        await ctx.setState?.(subscriber.imsi, {
+        const newSubscriber = {
           active_apns: subscriber.apns,
           active_policies: subscriber.policies,
           id: subscriber.imsi,
@@ -547,8 +553,13 @@ function AddSubscriberDetails(props: DialogProps) {
             state: subscriber.state,
             sub_profile: subscriber.dataPlan,
           },
-        });
+        };
         successCountRef.current = successCountRef.current + 1;
+        addedSubscribers.push(newSubscriber);
+        //bulk add subscribers at the end
+        if (subscriberIdx == subscribers.length - 1) {
+          await ctx.setState?.('', addedSubscribers);
+        }
       } catch (e) {
         const errMsg = e.response?.data?.message ?? e.message ?? e;
         setError('error saving ' + subscriber.imsi + ' : ' + errMsg);

--- a/nms/app/packages/magmalte/app/views/subscriber/SubscriberAddDialog.js
+++ b/nms/app/packages/magmalte/app/views/subscriber/SubscriberAddDialog.js
@@ -562,12 +562,9 @@ function AddSubscriberDetails(props: DialogProps) {
       try {
         await ctx.setState?.('', addedSubscribers);
       } catch (e) {
-        enqueueSnackbar(
-          'Saving subscribers to the api failed',
-          {
-            variant: 'error',
-          },
-        );
+        enqueueSnackbar('Saving subscribers to the api failed', {
+          variant: 'error',
+        });
         return;
       }
     }

--- a/nms/app/packages/magmalte/app/views/subscriber/__tests__/SubscriberAddEditTest.js
+++ b/nms/app/packages/magmalte/app/views/subscriber/__tests__/SubscriberAddEditTest.js
@@ -426,10 +426,12 @@ describe('<AddSubscriberButton />', () => {
 
     // Save subscriber
     fireEvent.click(getByTestId('saveSubscriber'));
-    expect(MagmaAPIBindings.postLteByNetworkIdSubscribers).toHaveBeenCalledWith(
-      {
-        networkId: 'test',
-        subscriber: {
+    expect(
+      MagmaAPIBindings.postLteByNetworkIdSubscribersV2,
+    ).toHaveBeenCalledWith({
+      networkId: 'test',
+      subscribers: [
+        {
           active_apns: undefined,
           active_policies: undefined,
           id: 'IMSI00000000001004',
@@ -442,8 +444,8 @@ describe('<AddSubscriberButton />', () => {
           },
           name: 'IMSI00000000001004',
         },
-      },
-    );
+      ],
+    });
   });
 
   it('Verify Subscriber edit', async () => {


### PR DESCRIPTION

## Summary
I changed the subscribers add logic to call the new API endpoint which allows us to add more than one subscriber at a time. So, when a user uploads a csv file to add a list of subscribers, it now adds all of the subscribers calling the API endpoint only once instead of calling the API one by one for each to be added subscriber. To do this, I also changed the subscriber's value property to now also accept the mutable_subscribers type and also regenerated the magma api bindings file to use the new API end point. 
<!-- Enumerate changes you made and why you made them -->

## Test Plan
I edited the existing subscribers add test which used to call the previous API endpoint that used to add only one subscriber at a time, to the now call the new endpoint. This worked without errors. There is also a gif and some photos which shows that the add button works properly.


## Additional Information

<img width="1792" alt="Screen Shot 2021-06-03 at 7 03 20 PM" src="https://user-images.githubusercontent.com/34602743/120723176-3dc38500-c49f-11eb-8fbd-59c0c1a5b736.png">
![bulkadd](https://user-images.githubusercontent.com/34602743/120723184-42883900-c49f-11eb-83a9-1631c6656fc2.gif)


https://user-images.githubusercontent.com/34602743/120723663-2d5fda00-c4a0-11eb-9098-c5d72c038449.mov

