### PR TITLE
AGW: non-nat: handle UE and management network in same subnet.

### DIFF
--- a/lte/gateway/python/magma/pipelined/app/uplink_bridge.py
+++ b/lte/gateway/python/magma/pipelined/app/uplink_bridge.py
@@ -193,7 +193,7 @@ class UplinkBridgeController(MagmaController):
     def _set_sgi_interface_ingress_flows(self):
         if_addrs = netifaces.ifaddresses(self.config.uplink_bridge).get(netifaces.AF_INET, [])
         for addr in if_addrs:
-            addr = "/".join((addr['addr'], addr['netmask']))
+            addr = addr['addr']
 
             match = "in_port=%s,ip,ip_dst=%s" % (self.config.uplink_eth_port_name,
                                                  addr)

--- a/lte/gateway/python/magma/pipelined/tests/snapshots/test_uplink_bridge.UplinkBridgeWithNonNATTest_IP_VLAN_GW.testFlowSnapshotMatch.snapshot
+++ b/lte/gateway/python/magma/pipelined/tests/snapshots/test_uplink_bridge.UplinkBridgeWithNonNATTest_IP_VLAN_GW.testFlowSnapshotMatch.snapshot
@@ -3,7 +3,7 @@
  priority=65534,in_port=1 actions=output:3
  priority=100,in_port=2 actions=mod_dl_src:02:bb:5e:36:06:4b,output:3
  priority=65534,udp,in_port=3,tp_dst=68 actions=output:1,LOCAL
- priority=101,ip,in_port=3,nw_dst=1.6.5.0/24 actions=LOCAL
+ priority=101,ip,in_port=3,nw_dst=1.6.5.7 actions=LOCAL
  priority=100,ip,in_port=3,vlan_tci=0x0000/0x1000,dl_dst=02:bb:5e:36:06:4b actions=output:2
  priority=100,ipv6,in_port=3,vlan_tci=0x0000/0x1000,dl_dst=02:bb:5e:36:06:4b actions=output:2
  priority=100,ip,in_port=3,vlan_tci=0x1000/0x1000,dl_dst=02:bb:5e:36:06:4b actions=strip_vlan,output:70


### PR DESCRIPTION
router mode added flow that forward all management traffic to
uplink-br0. This would break setup that shares UE subnet with
management subnet. Following patch fixes it by filtering
management traffic on management IP rather than subnet.

Signed-off-by: Pravin B Shelar <pbshelar@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
