### PR TITLE
commit all python formatting changes in lte/gateway/python/integ_tests

### DIFF
--- a/.github/workflows/python-formatting-check.yml
+++ b/.github/workflows/python-formatting-check.yml
@@ -11,7 +11,6 @@ on:  # yamllint disable-line rule:truthy
       - 'orc8r/gateway/python/**.py'
       - '!**/scripts/**.py'
       - '!lte/gateway/python/magma/pipelined/**.py'  # TODO add back
-      - '!lte/gateway/python/integ_tests/**.py'  # TODO add back
 
 jobs:
   run-formatters-and-check-for-errors:

--- a/lte/gateway/python/integ_tests/cloud/cloud_manager.py
+++ b/lte/gateway/python/integ_tests/cloud/cloud_manager.py
@@ -15,11 +15,13 @@ from typing import Any, Dict, List
 
 import requests
 import swagger_client
+from integ_tests.cloud.fixtures import (
+    DEFAULT_GATEWAY_CELLULAR_CONFIG,
+    DEFAULT_GATEWAY_CONFIG,
+    DEFAULT_NETWORK_CELLULAR_CONFIG,
+    DEFAULT_NETWORK_DNSD_CONFIG,
+)
 from swagger_client.rest import ApiException
-
-from integ_tests.cloud.fixtures import DEFAULT_GATEWAY_CELLULAR_CONFIG, \
-    DEFAULT_GATEWAY_CONFIG, DEFAULT_NETWORK_CELLULAR_CONFIG, \
-    DEFAULT_NETWORK_DNSD_CONFIG
 
 TEST_CLOUD_HOSTNAME = 'controller.magma.test'
 TEST_CLOUD_PORT = '9443'
@@ -31,13 +33,16 @@ class CloudManager(object):
     Manager for magma cloud
     """
 
-    def __init__(self, hostname=TEST_CLOUD_HOSTNAME, port=TEST_CLOUD_PORT,
-                 ssl_ca_cert=CERT_DIR + '/rootCA.pem',
-                 cert_file=CERT_DIR + '/admin_operator.pem',
-                 key_file=CERT_DIR + '/admin_operator.key.pem'):
+    def __init__(
+        self, hostname=TEST_CLOUD_HOSTNAME, port=TEST_CLOUD_PORT,
+        ssl_ca_cert=CERT_DIR + '/rootCA.pem',
+        cert_file=CERT_DIR + '/admin_operator.pem',
+        key_file=CERT_DIR + '/admin_operator.key.pem',
+    ):
         self._hostname = hostname
         self._host = 'https://{hostname}:{port}/magma'.format(
-            hostname=hostname, port=port)
+            hostname=hostname, port=port,
+        )
         self._managed_networks = []     # type: List[str]
 
         self._ssl_ca = ssl_ca_cert
@@ -78,8 +83,10 @@ class CloudManager(object):
             return
 
         network_record = swagger_client.NetworkRecord(name='integ_net_name')
-        self.networks_api.networks_post(network_record,
-                                        requested_id=network_id)
+        self.networks_api.networks_post(
+            network_record,
+            requested_id=network_id,
+        )
 
         self.networks_api.networks_network_id_configs_cellular_post(
             network_id,
@@ -95,8 +102,10 @@ class CloudManager(object):
         if not tier_exists:
             self.tiers_api.networks_network_id_tiers_post(
                 network_id,
-                swagger_client.Tier(id='default',
-                                    name='default', version='0.0.0-0'),
+                swagger_client.Tier(
+                    id='default',
+                    name='default', version='0.0.0-0',
+                ),
             )
 
     def register_gateway(self, network_id, gateway_id, gateway_hw_id):
@@ -172,8 +181,10 @@ class CloudManager(object):
         DNS = 1
         CELLULAR = 2
 
-    def update_network_configs(self, network_id: str,
-                               configs_by_type: Dict[NetworkConfigType, Any]):
+    def update_network_configs(
+        self, network_id: str,
+        configs_by_type: Dict[NetworkConfigType, Any],
+    ):
         """
         Update multiple configs for a network.
 
@@ -188,8 +199,10 @@ class CloudManager(object):
         MAGMAD = 1
         CELLULAR = 2
 
-    def update_gateway_configs(self, network_id: str, gateway_id: str,
-                               configs_by_type: Dict[GatewayConfigType, Any]):
+    def update_gateway_configs(
+        self, network_id: str, gateway_id: str,
+        configs_by_type: Dict[GatewayConfigType, Any],
+    ):
         """
         Update multiple configs for a gateway.
 
@@ -201,8 +214,10 @@ class CloudManager(object):
         for t, value in configs_by_type.items():
             self.update_gateway_config(network_id, gateway_id, t, value)
 
-    def update_network_config(self, network_id: str,
-                              config_type: NetworkConfigType, value: Any):
+    def update_network_config(
+        self, network_id: str,
+        config_type: NetworkConfigType, value: Any,
+    ):
         """
         Update a config for a network.
 
@@ -226,8 +241,10 @@ class CloudManager(object):
                 ),
             )
 
-    def update_gateway_config(self, network_id: str, gateway_id: str,
-                              config_type: GatewayConfigType, value: Any):
+    def update_gateway_config(
+        self, network_id: str, gateway_id: str,
+        config_type: GatewayConfigType, value: Any,
+    ):
         """
         Update a config for a gateway.
 
@@ -262,7 +279,7 @@ class CloudManager(object):
         )
         resp = requests.delete(
             request_url, cert=(self._ssl_cert, self._ssl_key),
-            verify=self._ssl_ca, params={'mode': 'force'}
+            verify=self._ssl_ca, params={'mode': 'force'},
         )
         resp.raise_for_status()
 

--- a/lte/gateway/python/integ_tests/cloud_tests/checkin_test.py
+++ b/lte/gateway/python/integ_tests/cloud_tests/checkin_test.py
@@ -12,21 +12,22 @@ limitations under the License.
 """
 import time
 import unittest
-
 import warnings
-from swagger_client import rest
 
 from integ_tests.cloud.cloud_manager import CloudManager
 from integ_tests.cloud.fixtures import GATEWAY_ID, NETWORK_ID
 from integ_tests.gateway.rpc import get_gateway_hw_id
+from swagger_client import rest
 
 MAX_GATEWAY_CHECKS = 12
 GATEWAY_POLL_INTERVAL_SEC = 10
 
 
 class TestCheckin(unittest.TestCase):
-    STATUS_RESPONSE_ATTRIBUTES = ('checkin_time', 'hardware_id', 'version',
-                                  'system_status')
+    STATUS_RESPONSE_ATTRIBUTES = (
+        'checkin_time', 'hardware_id', 'version',
+        'system_status',
+    )
 
     def setUp(self):
         self._cloud_manager = CloudManager()

--- a/lte/gateway/python/integ_tests/cloud_tests/config_test.py
+++ b/lte/gateway/python/integ_tests/cloud_tests/config_test.py
@@ -14,7 +14,6 @@ import time
 import unittest
 
 import swagger_client
-
 from integ_tests.cloud import cloud_manager, fixtures
 from integ_tests.cloud.cloud_manager import CloudManager
 from integ_tests.gateway import rpc
@@ -120,8 +119,10 @@ class TestConfigUpdates(unittest.TestCase):
                 ['magmad', 'enodebd', 'dnsd', 'mme'],
             )
             if not verify_mconfigs(mconfigs):
-                print('mconfigs do not match expected values, '
-                      'will poll again')
+                print(
+                    'mconfigs do not match expected values, '
+                    'will poll again',
+                )
                 time.sleep(self.POLL_SEC)
             else:
                 return

--- a/lte/gateway/python/integ_tests/cloud_tests/metrics_export_test.py
+++ b/lte/gateway/python/integ_tests/cloud_tests/metrics_export_test.py
@@ -63,8 +63,10 @@ class TestMetricsExport(unittest.TestCase):
             get_gateway_hw_id(),
         )
 
-        self._test_server = HTTPServer((self.TEST_VM_IP, self.TEST_VM_PORT),
-                                       TestHTTPServerRequestHandler)
+        self._test_server = HTTPServer(
+            (self.TEST_VM_IP, self.TEST_VM_PORT),
+            TestHTTPServerRequestHandler,
+        )
         self._server_thread = threading.Thread(target=self.run_server)
         self._server_thread.daemon = True
 
@@ -73,8 +75,10 @@ class TestMetricsExport(unittest.TestCase):
         self._cloud_manager.clean_up()
 
     def handle_timeout(self):
-        self.assertTrue(False,
-                        "Metrics not received before timeout, test failed")
+        self.assertTrue(
+            False,
+            "Metrics not received before timeout, test failed",
+        )
 
     def run_server(self):
         self._test_server.timeout = self.METRIC_TIMEOUT

--- a/lte/gateway/python/integ_tests/gateway/rpc.py
+++ b/lte/gateway/python/integ_tests/gateway/rpc.py
@@ -10,24 +10,25 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
-from typing import Any, Dict, List
-
 import os
-from orc8r.protos.common_pb2 import Void
-from orc8r.protos.magmad_pb2_grpc import MagmadStub
-from orc8r.protos.mconfig import mconfigs_pb2
+from typing import Any, Dict, List
 
 from magma.common.service_registry import create_grpc_channel
 from magma.configuration.mconfigs import unpack_mconfig_any
+from orc8r.protos.common_pb2 import Void
+from orc8r.protos.magmad_pb2_grpc import MagmadStub
+from orc8r.protos.mconfig import mconfigs_pb2
 
 
 def get_rpc_channel(service):
     """
     Returns a RPC channel to the service in the gateway.
     """
-    return create_grpc_channel(os.environ.get('GATEWAY_IP', '192.168.60.142'),
-                               os.environ.get('GATEWAY_PORT', '8443'),
-                               '%s.local' % service)
+    return create_grpc_channel(
+        os.environ.get('GATEWAY_IP', '192.168.60.142'),
+        os.environ.get('GATEWAY_PORT', '8443'),
+        '%s.local' % service,
+    )
 
 
 def get_gateway_hw_id():

--- a/lte/gateway/python/integ_tests/gxgy_tests/policies.py
+++ b/lte/gateway/python/integ_tests/gxgy_tests/policies.py
@@ -11,15 +11,16 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 from lte.protos.policydb_pb2 import FlowDescription, FlowMatch, PolicyRule
-
 from magma.pipelined.tests.app.packet_builder import IPPacketBuilder
 
 MAC_DEST = "5e:cc:cc:b1:49:4b"
 
 
-def create_uplink_rule(id, rating_group, ip_dest, m_key=None,
-                       priority=10, tracking=PolicyRule.ONLY_OCS,
-                       action=FlowDescription.PERMIT):
+def create_uplink_rule(
+    id, rating_group, ip_dest, m_key=None,
+    priority=10, tracking=PolicyRule.ONLY_OCS,
+    action=FlowDescription.PERMIT,
+):
     """
     Create a rule with a single uplink IP flow, useful for testing
     Args:
@@ -37,10 +38,13 @@ def create_uplink_rule(id, rating_group, ip_dest, m_key=None,
     return PolicyRule(
         id=id,
         priority=priority,
-        flow_list=[FlowDescription(
-            match=FlowMatch(
-                ipv4_dst=ip_dest, direction=FlowMatch.UPLINK),
-            action=action)
+        flow_list=[
+            FlowDescription(
+                match=FlowMatch(
+                    ipv4_dst=ip_dest, direction=FlowMatch.UPLINK,
+                ),
+                action=action,
+            ),
         ],
         tracking_type=tracking,
         rating_group=rating_group,

--- a/lte/gateway/python/integ_tests/gxgy_tests/session_manager.py
+++ b/lte/gateway/python/integ_tests/gxgy_tests/session_manager.py
@@ -11,9 +11,14 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 from lte.protos import session_manager_pb2, session_manager_pb2_grpc
-from lte.protos.session_manager_pb2 import ChargingCredit, CreditUnit, \
-    CreditUpdateResponse, GrantedUnits, UsageMonitoringCredit, \
-    UsageMonitoringUpdateResponse
+from lte.protos.session_manager_pb2 import (
+    ChargingCredit,
+    CreditUnit,
+    CreditUpdateResponse,
+    GrantedUnits,
+    UsageMonitoringCredit,
+    UsageMonitoringUpdateResponse,
+)
 from ryu.lib import hub
 
 
@@ -53,10 +58,12 @@ def get_from_queue(q, retries=10, sleep_time=0.5):
     return None
 
 
-def get_standard_update_response(update_complete, monitor_complete, quota,
-                                 is_final=False,
-                                 success=True,
-                                 monitor_action=UsageMonitoringCredit.CONTINUE):
+def get_standard_update_response(
+    update_complete, monitor_complete, quota,
+    is_final=False,
+    success=True,
+    monitor_action=UsageMonitoringCredit.CONTINUE,
+):
     """
     Create a CreditUpdateResponse with some useful defaults
     Args:
@@ -72,15 +79,21 @@ def get_standard_update_response(update_complete, monitor_complete, quota,
         charging_responses = []
         monitor_responses = []
         for update in args[0].updates:
-            charging_responses.append(create_update_response(
+            charging_responses.append(
+                create_update_response(
                 update.sid, update.usage.charging_key, quota,
-                is_final=is_final, success=success))
+                is_final=is_final, success=success,
+                ),
+            )
             update_complete.put(update)
         for monitor in args[0].usage_monitors:
-            monitor_responses.append(create_monitor_response(
+            monitor_responses.append(
+                create_monitor_response(
                 monitor.sid, monitor.update.monitoring_key, quota,
                 monitor.update.level, action=monitor_action,
-                success=success))
+                success=success,
+                ),
+            )
             monitor_complete.put(monitor)
         return session_manager_pb2.UpdateSessionResponse(
             responses=charging_responses,
@@ -89,9 +102,11 @@ def get_standard_update_response(update_complete, monitor_complete, quota,
     return update_response
 
 
-def create_update_response(imsi, charging_key, total_quota,
-                           is_final=False,
-                           success=True):
+def create_update_response(
+    imsi, charging_key, total_quota,
+    is_final=False,
+    success=True,
+):
     """
     Create a CreditUpdateResponse with some useful defaults
     Args:
@@ -114,9 +129,11 @@ def create_update_response(imsi, charging_key, total_quota,
     )
 
 
-def create_monitor_response(imsi, m_key, total_quota, level,
-                            action=UsageMonitoringCredit.CONTINUE,
-                            success=True):
+def create_monitor_response(
+    imsi, m_key, total_quota, level,
+    action=UsageMonitoringCredit.CONTINUE,
+    success=True,
+):
     """
     Create a UsageMonitoringUpdateResponse with some useful defaults
     Args:
@@ -137,6 +154,6 @@ def create_monitor_response(imsi, m_key, total_quota, level,
                 total=CreditUnit(is_valid=True, volume=total_quota),
             ),
             level=level,
-            action=action
+            action=action,
         ),
     )

--- a/lte/gateway/python/integ_tests/gxgy_tests/test_credit_tracking.py
+++ b/lte/gateway/python/integ_tests/gxgy_tests/test_credit_tracking.py
@@ -20,8 +20,11 @@ from magma.pipelined.tests.app.subscriber import SubContextConfig
 from ryu.lib import hub
 
 from .policies import create_uplink_rule, get_packets_for_flows
-from .session_manager import create_update_response, get_from_queue, \
-    get_standard_update_response
+from .session_manager import (
+    create_update_response,
+    get_from_queue,
+    get_standard_update_response,
+)
 from .utils import GxGyTestUtil as TestUtil
 
 
@@ -51,9 +54,11 @@ class CreditTrackingTest(unittest.TestCase):
         self.test_util.controller.mock_create_session = Mock(
             return_value=session_manager_pb2.CreateSessionResponse(
                 credits=[create_update_response(sub1.imsi, 1, quota)],
-                static_rules=[session_manager_pb2.StaticRuleInstall(
-                    rule_id="simple_match"
-                )],
+                static_rules=[
+                    session_manager_pb2.StaticRuleInstall(
+                        rule_id="simple_match",
+                    ),
+                ],
                 dynamic_rules=[],
                 usage_monitors=[],
             ),
@@ -66,7 +71,8 @@ class CreditTrackingTest(unittest.TestCase):
         update_complete = hub.Queue()
         self.test_util.controller.mock_update_session = Mock(
             side_effect=get_standard_update_response(
-                update_complete, None, quota, is_final=False),
+                update_complete, None, quota, is_final=False,
+            ),
         )
 
         self.test_util.sessiond.CreateSession(
@@ -78,7 +84,8 @@ class CreditTrackingTest(unittest.TestCase):
         self.assertEqual(self.test_util.controller.mock_create_session.call_count, 1)
 
         packets = get_packets_for_flows(
-            sub1, self.test_util.static_rules["simple_match"].flow_list)
+            sub1, self.test_util.static_rules["simple_match"].flow_list,
+        )
         packet_count = int(quota / len(packets[0])) + 1
 
         self.test_util.thread.run_in_greenthread(
@@ -99,22 +106,26 @@ class CreditTrackingTest(unittest.TestCase):
         # return only rx (downlink) packets
         self.test_util.controller.mock_create_session = Mock(
             return_value=session_manager_pb2.CreateSessionResponse(
-                credits=[session_manager_pb2.CreditUpdateResponse(
-                    success=True,
-                    sid=sub1.imsi,
-                    charging_key=1,
-                    credit=session_manager_pb2.ChargingCredit(
-                        granted_units=session_manager_pb2.GrantedUnits(
-                            rx=session_manager_pb2.CreditUnit(
-                                is_valid=True,
-                                volume=quota,
+                credits=[
+                    session_manager_pb2.CreditUpdateResponse(
+                        success=True,
+                        sid=sub1.imsi,
+                        charging_key=1,
+                        credit=session_manager_pb2.ChargingCredit(
+                            granted_units=session_manager_pb2.GrantedUnits(
+                                rx=session_manager_pb2.CreditUnit(
+                                    is_valid=True,
+                                    volume=quota,
+                                ),
                             ),
                         ),
                     ),
-                )],
-                static_rules=[session_manager_pb2.StaticRuleInstall(
-                    rule_id="simple_match"
-                )],
+                ],
+                static_rules=[
+                    session_manager_pb2.StaticRuleInstall(
+                        rule_id="simple_match",
+                    ),
+                ],
             ),
         )
 
@@ -125,7 +136,8 @@ class CreditTrackingTest(unittest.TestCase):
         update_complete = hub.Queue()
         self.test_util.controller.mock_update_session = Mock(
             side_effect=get_standard_update_response(
-                update_complete, None, quota, is_final=False),
+                update_complete, None, quota, is_final=False,
+            ),
         )
 
         self.test_util.sessiond.CreateSession(
@@ -137,7 +149,8 @@ class CreditTrackingTest(unittest.TestCase):
         self.assertEqual(self.test_util.controller.mock_create_session.call_count, 1)
 
         packets = get_packets_for_flows(
-            sub1, self.test_util.static_rules["simple_match"].flow_list)
+            sub1, self.test_util.static_rules["simple_match"].flow_list,
+        )
         packet_count = int(quota / len(packets[0])) + 1
 
         self.test_util.thread.run_in_greenthread(
@@ -152,22 +165,26 @@ class CreditTrackingTest(unittest.TestCase):
         # now attach with tx (uplink packets)
         self.test_util.controller.mock_create_session = Mock(
             return_value=session_manager_pb2.CreateSessionResponse(
-                credits=[session_manager_pb2.CreditUpdateResponse(
-                    success=True,
-                    sid=sub1.imsi,
-                    charging_key=1,
-                    credit=session_manager_pb2.ChargingCredit(
-                        granted_units=session_manager_pb2.GrantedUnits(
-                            tx=session_manager_pb2.CreditUnit(
-                                is_valid=True,
-                                volume=quota,
+                credits=[
+                    session_manager_pb2.CreditUpdateResponse(
+                        success=True,
+                        sid=sub1.imsi,
+                        charging_key=1,
+                        credit=session_manager_pb2.ChargingCredit(
+                            granted_units=session_manager_pb2.GrantedUnits(
+                                tx=session_manager_pb2.CreditUnit(
+                                    is_valid=True,
+                                    volume=quota,
+                                ),
                             ),
                         ),
                     ),
-                )],
-                static_rules=[session_manager_pb2.StaticRuleInstall(
-                    rule_id="simple_match"
-                )],
+                ],
+                static_rules=[
+                    session_manager_pb2.StaticRuleInstall(
+                        rule_id="simple_match",
+                    ),
+                ],
             ),
         )
         self.test_util.sessiond.CreateSession(
@@ -195,22 +212,26 @@ class CreditTrackingTest(unittest.TestCase):
 
         self.test_util.controller.mock_create_session = Mock(
             return_value=session_manager_pb2.CreateSessionResponse(
-                credits=[session_manager_pb2.CreditUpdateResponse(
-                    success=True,
-                    sid=sub1.imsi,
-                    charging_key=1,
-                    credit=session_manager_pb2.ChargingCredit(
-                        granted_units=session_manager_pb2.GrantedUnits(
-                            total=session_manager_pb2.CreditUnit(
-                                is_valid=True,
-                                volume=quota,
+                credits=[
+                    session_manager_pb2.CreditUpdateResponse(
+                        success=True,
+                        sid=sub1.imsi,
+                        charging_key=1,
+                        credit=session_manager_pb2.ChargingCredit(
+                            granted_units=session_manager_pb2.GrantedUnits(
+                                total=session_manager_pb2.CreditUnit(
+                                    is_valid=True,
+                                    volume=quota,
+                                ),
                             ),
                         ),
                     ),
-                )],
-                static_rules=[session_manager_pb2.StaticRuleInstall(
-                    rule_id="simple_match"
-                )],
+                ],
+                static_rules=[
+                    session_manager_pb2.StaticRuleInstall(
+                        rule_id="simple_match",
+                    ),
+                ],
                 dynamic_rules=[],
                 usage_monitors=[],
             ),
@@ -223,7 +244,8 @@ class CreditTrackingTest(unittest.TestCase):
         update_complete = hub.Queue()
         self.test_util.controller.mock_update_session = Mock(
             side_effect=get_standard_update_response(
-                update_complete, None, quota, is_final=True),
+                update_complete, None, quota, is_final=True,
+            ),
         )
 
         self.test_util.sessiond.CreateSession(
@@ -235,10 +257,12 @@ class CreditTrackingTest(unittest.TestCase):
         self.assertEqual(self.test_util.controller.mock_create_session.call_count, 1)
 
         packets = get_packets_for_flows(
-            sub1, self.test_util.static_rules["simple_match"].flow_list)
+            sub1, self.test_util.static_rules["simple_match"].flow_list,
+        )
         packet_count = int(quota / len(packets[0])) + 1
         send_packets = self.test_util.get_packet_sender(
-            [sub1], packets, packet_count)
+            [sub1], packets, packet_count,
+        )
 
         self.test_util.thread.run_in_greenthread(send_packets)
         self.assertIsNotNone(get_from_queue(update_complete))
@@ -279,13 +303,16 @@ class CreditTrackingTest(unittest.TestCase):
                 'IMSI0010100000888{}'.format(i),
                 '192.168.128.{}'.format(i),
                 4,
-            ) for i in range(32)]
+            ) for i in range(32)
+        ]
         quota = 1024  # bytes
 
         # create some rules
         rule1 = create_uplink_rule("rule1", 2, '46.10.0.1')
-        rule2 = create_uplink_rule("rule2", 0, '47.10.0.1',
-                                   tracking=PolicyRule.NO_TRACKING)
+        rule2 = create_uplink_rule(
+            "rule2", 0, '47.10.0.1',
+            tracking=PolicyRule.NO_TRACKING,
+        )
         rule3 = create_uplink_rule("rule3", 3, '49.10.0.1')
         self.test_util.static_rules["rule1"] = rule1
         self.test_util.static_rules["rule2"] = rule2
@@ -300,16 +327,16 @@ class CreditTrackingTest(unittest.TestCase):
                 ],
                 static_rules=[
                     session_manager_pb2.StaticRuleInstall(
-                        rule_id="rule1"
+                        rule_id="rule1",
                     ),
                     session_manager_pb2.StaticRuleInstall(
-                        rule_id="rule2"
+                        rule_id="rule2",
                     ),
                 ],
                 dynamic_rules=[
                     session_manager_pb2.DynamicRuleInstall(
-                        policy_rule=rule3
-                    )
+                        policy_rule=rule3,
+                    ),
                 ],
             ),
         )
@@ -319,7 +346,8 @@ class CreditTrackingTest(unittest.TestCase):
         update_complete = hub.Queue()
         self.test_util.controller.mock_update_session = Mock(
             side_effect=get_standard_update_response(
-                update_complete, None, quota, is_final=True),
+                update_complete, None, quota, is_final=True,
+            ),
         )
 
         # initiate sessions
@@ -331,7 +359,8 @@ class CreditTrackingTest(unittest.TestCase):
                 ),
             )
         self.assertEqual(
-            self.test_util.controller.mock_create_session.call_count, len(subs))
+            self.test_util.controller.mock_create_session.call_count, len(subs),
+        )
 
         # send packets towards all 3 rules
         flows = [rule.flow_list[0] for rule in [rule1, rule2, rule3]]
@@ -355,7 +384,8 @@ class CreditTrackingTest(unittest.TestCase):
         for sub in subs:
             self.test_util.sessiond.EndSession(SubscriberID(id=sub.imsi))
         self.assertEqual(
-            self.test_util.controller.mock_terminate_session.call_count, len(subs))
+            self.test_util.controller.mock_terminate_session.call_count, len(subs),
+        )
 
 
 if __name__ == "__main__":

--- a/lte/gateway/python/integ_tests/gxgy_tests/test_failure_scenarios.py
+++ b/lte/gateway/python/integ_tests/gxgy_tests/test_failure_scenarios.py
@@ -15,12 +15,18 @@ from unittest.mock import Mock
 
 from lte.protos import session_manager_pb2
 from lte.protos.subscriberdb_pb2 import SubscriberID
-from magma.pipelined.tests.app.subscriber import SubContextConfig, default_ambr_config
+from magma.pipelined.tests.app.subscriber import (
+    SubContextConfig,
+    default_ambr_config,
+)
 from ryu.lib import hub
 
 from .policies import create_uplink_rule, get_packets_for_flows
-from .session_manager import create_update_response, get_from_queue, \
-    get_standard_update_response
+from .session_manager import (
+    create_update_response,
+    get_from_queue,
+    get_standard_update_response,
+)
 from .utils import GxGyTestUtil as TestUtil
 
 
@@ -47,9 +53,11 @@ class FailureScenarioTest(unittest.TestCase):
 
         self.test_util.controller.mock_create_session = Mock(
             return_value=session_manager_pb2.CreateSessionResponse(
-                static_rules=[session_manager_pb2.StaticRuleInstall(
-                    rule_id="simple_match"
-                )],  # no credit for RG 1
+                static_rules=[
+                    session_manager_pb2.StaticRuleInstall(
+                        rule_id="simple_match",
+                    ),
+                ],  # no credit for RG 1
             ),
         )
 
@@ -66,7 +74,8 @@ class FailureScenarioTest(unittest.TestCase):
         self.assertEqual(self.test_util.controller.mock_create_session.call_count, 1)
 
         packets = get_packets_for_flows(
-            sub1, self.test_util.static_rules["simple_match"].flow_list)
+            sub1, self.test_util.static_rules["simple_match"].flow_list,
+        )
 
         pkt_diff = self.test_util.thread.run_in_greenthread(
             self.test_util.get_packet_sender([sub1], packets, 1),
@@ -93,16 +102,18 @@ class FailureScenarioTest(unittest.TestCase):
                     # successful update, no credit
                     create_update_response(sub1.imsi, 1, 0, success=True),
                 ],
-                static_rules=[session_manager_pb2.StaticRuleInstall(
-                    rule_id="simple_match"
-                )],  # no credit for RG 1
+                static_rules=[
+                    session_manager_pb2.StaticRuleInstall(
+                        rule_id="simple_match",
+                    ),
+                ],  # no credit for RG 1
                 dynamic_rules=[
                     session_manager_pb2.DynamicRuleInstall(
-                        policy_rule=rule2
+                        policy_rule=rule2,
                     ),
                     session_manager_pb2.DynamicRuleInstall(
-                        policy_rule=rule3
-                    )
+                        policy_rule=rule3,
+                    ),
                 ],
             ),
         )
@@ -140,16 +151,19 @@ class FailureScenarioTest(unittest.TestCase):
         self.test_util.controller.mock_create_session = Mock(
             return_value=session_manager_pb2.CreateSessionResponse(
                 credits=[create_update_response(sub1.imsi, 1, quota)],
-                static_rules=[session_manager_pb2.StaticRuleInstall(
-                    rule_id="simple_match"
-                )],
+                static_rules=[
+                    session_manager_pb2.StaticRuleInstall(
+                        rule_id="simple_match",
+                    ),
+                ],
             ),
         )
 
         update_complete = hub.Queue()
         self.test_util.controller.mock_update_session = Mock(
             side_effect=get_standard_update_response(
-                update_complete, None, quota, success=False),
+                update_complete, None, quota, success=False,
+            ),
         )
 
         self.test_util.controller.mock_terminate_session = Mock(
@@ -165,7 +179,8 @@ class FailureScenarioTest(unittest.TestCase):
         self.assertEqual(self.test_util.controller.mock_create_session.call_count, 1)
 
         packets = get_packets_for_flows(
-            sub1, self.test_util.static_rules["simple_match"].flow_list)
+            sub1, self.test_util.static_rules["simple_match"].flow_list,
+        )
         packet_count = int(quota / len(packets[0])) + 1
         sender = self.test_util.get_packet_sender([sub1], packets, packet_count)
 
@@ -181,7 +196,8 @@ class FailureScenarioTest(unittest.TestCase):
 
         self.test_util.controller.mock_update_session = Mock(
             side_effect=get_standard_update_response(
-                update_complete, None, quota, success=True),
+                update_complete, None, quota, success=True,
+            ),
         )
         # wait for second update cycle to reactivate
         hub.sleep(4)

--- a/lte/gateway/python/integ_tests/gxgy_tests/test_gx_reauth.py
+++ b/lte/gateway/python/integ_tests/gxgy_tests/test_gx_reauth.py
@@ -14,15 +14,24 @@ import itertools
 import unittest
 from unittest.mock import Mock
 
-from integ_tests.gxgy_tests.policies import create_uplink_rule, \
-    get_packets_for_flows
+from integ_tests.gxgy_tests.policies import (
+    create_uplink_rule,
+    get_packets_for_flows,
+)
 from integ_tests.gxgy_tests.session_manager import create_update_response
 from lte.protos import session_manager_pb2
 from lte.protos.policydb_pb2 import PolicyRule
-from lte.protos.session_manager_pb2 import CreateSessionResponse, \
-    LocalCreateSessionRequest, PolicyReAuthRequest, SessionTerminateResponse
+from lte.protos.session_manager_pb2 import (
+    CreateSessionResponse,
+    LocalCreateSessionRequest,
+    PolicyReAuthRequest,
+    SessionTerminateResponse,
+)
 from lte.protos.subscriberdb_pb2 import SubscriberID
-from magma.pipelined.tests.app.subscriber import SubContextConfig, default_ambr_config
+from magma.pipelined.tests.app.subscriber import (
+    SubContextConfig,
+    default_ambr_config,
+)
 from ryu.lib import hub
 
 from .utils import GxGyTestUtil as TestUtil
@@ -36,11 +45,15 @@ class GxReauthTest(unittest.TestCase):
 
         # Static policies
         cls.test_util = TestUtil()
-        policy1 = create_uplink_rule('policy1', 1, '45.10.0.1',
-                                     tracking=PolicyRule.NO_TRACKING)
+        policy1 = create_uplink_rule(
+            'policy1', 1, '45.10.0.1',
+            tracking=PolicyRule.NO_TRACKING,
+        )
         cls.test_util.static_rules[policy1.id] = policy1
-        policy2 = create_uplink_rule('policy2', 1, '45.10.10.2',
-                                     tracking=PolicyRule.NO_TRACKING)
+        policy2 = create_uplink_rule(
+            'policy2', 1, '45.10.10.2',
+            tracking=PolicyRule.NO_TRACKING,
+        )
         cls.test_util.static_rules[policy2.id] = policy2
         hub.sleep(2)  # wait for static rule to sync
 
@@ -53,22 +66,30 @@ class GxReauthTest(unittest.TestCase):
         Send a Gx reauth request which installs one new static rule, one new
         dynamic rule, and removes one static and one dynamic rule.
         """
-        dynamic_rule1 = create_uplink_rule('dynamic1', 1, '46.10.10.1',
-                                           tracking=PolicyRule.NO_TRACKING)
-        dynamic_rule2 = create_uplink_rule('dynamic2', 1, '46.10.10.2',
-                                           tracking=PolicyRule.NO_TRACKING)
+        dynamic_rule1 = create_uplink_rule(
+            'dynamic1', 1, '46.10.10.1',
+            tracking=PolicyRule.NO_TRACKING,
+        )
+        dynamic_rule2 = create_uplink_rule(
+            'dynamic2', 1, '46.10.10.2',
+            tracking=PolicyRule.NO_TRACKING,
+        )
 
         # Initialize sub with 1 static and 1 dynamic rule
         sub = SubContextConfig('IMSI001010000088888', '192.168.128.74', default_ambr_config, 4)
         self.test_util.controller.mock_create_session = Mock(
             return_value=CreateSessionResponse(
                 credits=[create_update_response(sub.imsi, 1, 1024)],
-                static_rules=[session_manager_pb2.StaticRuleInstall(
-                    rule_id='policy1'
-                )],
-                dynamic_rules=[session_manager_pb2.DynamicRuleInstall(
-                    policy_rule=dynamic_rule1
-                )],
+                static_rules=[
+                    session_manager_pb2.StaticRuleInstall(
+                        rule_id='policy1',
+                    ),
+                ],
+                dynamic_rules=[
+                    session_manager_pb2.DynamicRuleInstall(
+                        policy_rule=dynamic_rule1,
+                    ),
+                ],
                 usage_monitors=[],
             ),
         )
@@ -79,7 +100,7 @@ class GxReauthTest(unittest.TestCase):
             LocalCreateSessionRequest(
                 sid=SubscriberID(id=sub.imsi),
                 ue_ipv4=sub.ip,
-            )
+            ),
         )
         self.assertEqual(
             self.test_util.controller.mock_create_session.call_count,
@@ -92,11 +113,11 @@ class GxReauthTest(unittest.TestCase):
             sub,
             [
                 session_manager_pb2.DynamicRuleInstall(
-                    policy_rule=self.test_util.static_rules['policy1']
+                    policy_rule=self.test_util.static_rules['policy1'],
                 ),
                 session_manager_pb2.DynamicRuleInstall(
-                    policy_rule=dynamic_rule1
-                )
+                    policy_rule=dynamic_rule1,
+                ),
             ],
         )
 
@@ -108,15 +129,15 @@ class GxReauthTest(unittest.TestCase):
                 rules_to_remove=['dynamic1', 'policy1'],
                 rules_to_install=[
                     session_manager_pb2.StaticRuleInstall(
-                        rule_id='policy2'
-                    )
+                        rule_id='policy2',
+                    ),
                 ],
                 dynamic_rules_to_install=[
                     session_manager_pb2.DynamicRuleInstall(
-                        policy_rule=dynamic_rule2
-                    )
+                        policy_rule=dynamic_rule2,
+                    ),
                 ],
-            )
+            ),
         )
         self.assertEqual(
             reauth_result.result,
@@ -127,10 +148,11 @@ class GxReauthTest(unittest.TestCase):
             sub,
             [
                 session_manager_pb2.DynamicRuleInstall(
-                    policy_rule=self.test_util.static_rules['policy2']),
+                    policy_rule=self.test_util.static_rules['policy2'],
+                ),
                 session_manager_pb2.DynamicRuleInstall(
-                    policy_rule=dynamic_rule2
-                )
+                    policy_rule=dynamic_rule2,
+                ),
             ],
         )
 
@@ -139,18 +161,18 @@ class GxReauthTest(unittest.TestCase):
             sub,
             [
                 session_manager_pb2.DynamicRuleInstall(
-                    policy_rule=self.test_util.static_rules['policy1']
+                    policy_rule=self.test_util.static_rules['policy1'],
                 ),
                 session_manager_pb2.DynamicRuleInstall(
-                    policy_rule=dynamic_rule1
-                )
+                    policy_rule=dynamic_rule1,
+                ),
             ],
             expected=0,
         )
 
     def _assert_rules(self, sub, rules, expected=-1):
         flows = list(
-            itertools.chain(*[rule.policy_rule.flow_list for rule in rules])
+            itertools.chain(*[rule.policy_rule.flow_list for rule in rules]),
         )
         packets = get_packets_for_flows(sub, flows)
         packet_sender = self.test_util.get_packet_sender([sub], packets, 1)

--- a/lte/gateway/python/integ_tests/gxgy_tests/test_usage_monitors.py
+++ b/lte/gateway/python/integ_tests/gxgy_tests/test_usage_monitors.py
@@ -16,12 +16,19 @@ from unittest.mock import Mock
 from lte.protos import session_manager_pb2
 from lte.protos.policydb_pb2 import PolicyRule
 from lte.protos.subscriberdb_pb2 import SubscriberID
-from magma.pipelined.tests.app.subscriber import SubContextConfig, default_ambr_config
+from magma.pipelined.tests.app.subscriber import (
+    SubContextConfig,
+    default_ambr_config,
+)
 from ryu.lib import hub
 
 from .policies import create_uplink_rule, get_packets_for_flows
-from .session_manager import create_monitor_response, create_update_response, \
-    get_from_queue, get_standard_update_response
+from .session_manager import (
+    create_monitor_response,
+    create_update_response,
+    get_from_queue,
+    get_standard_update_response,
+)
 from .utils import GxGyTestUtil as TestUtil
 
 
@@ -33,9 +40,11 @@ class UsageMonitorTest(unittest.TestCase):
 
         cls.test_util = TestUtil()
         # default rule
-        policy = create_uplink_rule("monitor_rule", 0, '45.10.0.1',
-                                             m_key="mkey1",
-                                             tracking=PolicyRule.ONLY_PCRF)
+        policy = create_uplink_rule(
+            "monitor_rule", 0, '45.10.0.1',
+            m_key="mkey1",
+            tracking=PolicyRule.ONLY_PCRF,
+        )
         cls.test_util.static_rules[policy.id] = policy
         hub.sleep(2)  # wait for static rule to sync
 
@@ -55,12 +64,17 @@ class UsageMonitorTest(unittest.TestCase):
         self.test_util.controller.mock_create_session = Mock(
             return_value=session_manager_pb2.CreateSessionResponse(
                 credits=[],
-                static_rules=[session_manager_pb2.StaticRuleInstall(
-                    rule_id="monitor_rule"
-                )],
+                static_rules=[
+                    session_manager_pb2.StaticRuleInstall(
+                        rule_id="monitor_rule",
+                    ),
+                ],
                 dynamic_rules=[],
-                usage_monitors=[create_monitor_response(
-                    sub1.imsi, "mkey1", quota, session_manager_pb2.PCC_RULE_LEVEL)],
+                usage_monitors=[
+                    create_monitor_response(
+                    sub1.imsi, "mkey1", quota, session_manager_pb2.PCC_RULE_LEVEL,
+                    ),
+                ],
             ),
         )
 
@@ -71,7 +85,8 @@ class UsageMonitorTest(unittest.TestCase):
         monitor_complete = hub.Queue()
         self.test_util.controller.mock_update_session = Mock(
             side_effect=get_standard_update_response(
-                None, monitor_complete, quota),
+                None, monitor_complete, quota,
+            ),
         )
 
         self.test_util.sessiond.CreateSession(
@@ -84,7 +99,8 @@ class UsageMonitorTest(unittest.TestCase):
         self.assertEqual(self.test_util.controller.mock_create_session.call_count, 1)
 
         packets = get_packets_for_flows(
-            sub1, self.test_util.static_rules["monitor_rule"].flow_list)
+            sub1, self.test_util.static_rules["monitor_rule"].flow_list,
+        )
         packet_count = int(quota / len(packets[0])) + 1
 
         self.test_util.thread.run_in_greenthread(
@@ -104,14 +120,20 @@ class UsageMonitorTest(unittest.TestCase):
         sub1 = SubContextConfig('IMSI001010000088888', '192.168.128.74', default_ambr_config, 4)
         quota = 1024  # bytes
 
-        pcrf_rule = create_uplink_rule("pcrf_rule", 0, '46.10.0.1',
-                                                m_key="key1",
-                                                tracking=PolicyRule.ONLY_PCRF)
-        ocs_rule = create_uplink_rule("ocs_rule", 1, '47.10.0.1',
-                                               tracking=PolicyRule.ONLY_OCS)
-        both_rule = create_uplink_rule("both_rule", 2, '48.10.0.1',
-                                                m_key="key2",
-                                                tracking=PolicyRule.OCS_AND_PCRF)
+        pcrf_rule = create_uplink_rule(
+            "pcrf_rule", 0, '46.10.0.1',
+            m_key="key1",
+            tracking=PolicyRule.ONLY_PCRF,
+        )
+        ocs_rule = create_uplink_rule(
+            "ocs_rule", 1, '47.10.0.1',
+            tracking=PolicyRule.ONLY_OCS,
+        )
+        both_rule = create_uplink_rule(
+            "both_rule", 2, '48.10.0.1',
+            m_key="key2",
+            tracking=PolicyRule.OCS_AND_PCRF,
+        )
 
         self.test_util.controller.mock_create_session = Mock(
             return_value=session_manager_pb2.CreateSessionResponse(
@@ -161,7 +183,8 @@ class UsageMonitorTest(unittest.TestCase):
         monitor_complete = hub.Queue()
         self.test_util.controller.mock_update_session = Mock(
             side_effect=get_standard_update_response(
-                charging_complete, monitor_complete, quota),
+                charging_complete, monitor_complete, quota,
+            ),
         )
 
         self.test_util.sessiond.CreateSession(

--- a/lte/gateway/python/integ_tests/gxgy_tests/utils.py
+++ b/lte/gateway/python/integ_tests/gxgy_tests/utils.py
@@ -18,15 +18,21 @@ from lte.protos import session_manager_pb2_grpc
 from magma.common.service_registry import ServiceRegistry
 from magma.configuration.service_configs import load_service_config
 from magma.pipelined.bridge_util import BridgeTools
-from magma.pipelined.tests.app.flow_query import RyuDirectFlowQuery \
-    as FlowQuery
+from magma.pipelined.tests.app.flow_query import RyuDirectFlowQuery as FlowQuery
 from magma.pipelined.tests.app.packet_injector import ScapyPacketInjector
-from magma.pipelined.tests.app.start_pipelined import PipelinedController, \
-    TestSetup
-from magma.pipelined.tests.app.table_isolation import RyuDirectTableIsolator, \
-    RyuForwardFlowArgsBuilder
-from magma.pipelined.tests.pipelined_test_util import start_ryu_app_thread, \
-    stop_ryu_app_thread, wait_after_send
+from magma.pipelined.tests.app.start_pipelined import (
+    PipelinedController,
+    TestSetup,
+)
+from magma.pipelined.tests.app.table_isolation import (
+    RyuDirectTableIsolator,
+    RyuForwardFlowArgsBuilder,
+)
+from magma.pipelined.tests.pipelined_test_util import (
+    start_ryu_app_thread,
+    stop_ryu_app_thread,
+    wait_after_send,
+)
 from magma.policydb.rule_store import PolicyRuleDict
 
 from .session_manager import MockSessionManager
@@ -54,7 +60,8 @@ class GxGyTestUtil(object):
         self.controller = MockSessionManager()
         self.server = grpc.server(ThreadPoolExecutor(max_workers=10))
         session_manager_pb2_grpc.add_CentralSessionControllerServicer_to_server(
-            self.controller, self.server)
+            self.controller, self.server,
+        )
         self.server.add_insecure_port('127.0.0.1:{}'.format(cloud_port))
         self.server.start()
 
@@ -66,7 +73,7 @@ class GxGyTestUtil(object):
         test_setup = TestSetup(
             apps=[PipelinedController.Testing],
             references={
-                PipelinedController.Testing: testing_controller_reference
+                PipelinedController.Testing: testing_controller_reference,
             },
             config={
                 'bridge_name': self.BRIDGE,
@@ -84,8 +91,10 @@ class GxGyTestUtil(object):
         # Stop ryu controller
         stop_ryu_app_thread(self.thread)
         # Remove bridge
-        BridgeTools.remove_controller_from_bridge(self.BRIDGE,
-                                                  self.CONTROLLER_PORT)
+        BridgeTools.remove_controller_from_bridge(
+            self.BRIDGE,
+            self.CONTROLLER_PORT,
+        )
         # Stop gRPC server
         self.server.stop(0)
 
@@ -103,11 +112,13 @@ class GxGyTestUtil(object):
         pkt_sender = ScapyPacketInjector(self.IFACE)
 
         def packet_sender():
-            isolators = [RyuDirectTableIsolator(
-                RyuForwardFlowArgsBuilder.from_subscriber(sub)
-                                         .build_requests(),
-                self.testing_controller,
-            ) for sub in subs]
+            isolators = [
+                RyuDirectTableIsolator(
+                    RyuForwardFlowArgsBuilder.from_subscriber(sub)
+                                             .build_requests(),
+                    self.testing_controller,
+                ) for sub in subs
+            ]
             flow_query = FlowQuery(20, self.testing_controller)
             pkt_start = sum(flow.packets for flow in flow_query.lookup())
             with ExitStack() as es:

--- a/lte/gateway/python/integ_tests/s1aptests/ovs/rest_api.py
+++ b/lte/gateway/python/integ_tests/s1aptests/ovs/rest_api.py
@@ -16,8 +16,7 @@ import logging
 import time
 
 import requests
-
-from integ_tests.s1aptests.ovs import DEV_VM_URL, OF_REST_PORT, MAX_RETRIES
+from integ_tests.s1aptests.ovs import DEV_VM_URL, MAX_RETRIES, OF_REST_PORT
 
 
 def get_flows(datapath, fields, ip=DEV_VM_URL):
@@ -60,8 +59,10 @@ def get_datapath(ip=DEV_VM_URL):
     return str(_ovs_api_request('GET', url)[0])
 
 
-def _ovs_api_request(method, url, data=None, max_retries=MAX_RETRIES,
-                     return_json=True):
+def _ovs_api_request(
+    method, url, data=None, max_retries=MAX_RETRIES,
+    return_json=True,
+):
     """
     Send generic OVS REST API request and retry if request fails. Returns json
     decoded message
@@ -76,5 +77,6 @@ def _ovs_api_request(method, url, data=None, max_retries=MAX_RETRIES,
         time.sleep(1)
     logging.error(
         "Could not send %s request to OVS REST API at %s with data %s",
-        method, url, data)
+        method, url, data,
+    )
     return {}

--- a/lte/gateway/python/integ_tests/s1aptests/s1ap_utils.py
+++ b/lte/gateway/python/integ_tests/s1aptests/s1ap_utils.py
@@ -13,9 +13,11 @@ limitations under the License.
 
 import ctypes
 import ipaddress
+import json
 import logging
 import os
 import shlex
+import subprocess
 import threading
 import time
 from enum import Enum
@@ -23,11 +25,14 @@ from queue import Queue
 from typing import Optional
 
 import grpc
-import subprocess
-import json
-
 import s1ap_types
 from integ_tests.gateway.rpc import get_rpc_channel
+from integ_tests.s1aptests.ovs.rest_api import get_datapath, get_flows
+from lte.protos.abort_session_pb2 import AbortSessionRequest, AbortSessionResult
+from lte.protos.abort_session_pb2_grpc import AbortSessionResponderStub
+from lte.protos.ha_service_pb2 import EnbOffloadType, StartAgwOffloadRequest
+from lte.protos.ha_service_pb2_grpc import HaServiceStub
+from lte.protos.mobilityd_pb2 import IPAddress
 from lte.protos.policydb_pb2 import (
     FlowDescription,
     FlowMatch,
@@ -35,7 +40,6 @@ from lte.protos.policydb_pb2 import (
     PolicyRule,
     QosArp,
 )
-from lte.protos.mobilityd_pb2 import IPAddress
 from lte.protos.session_manager_pb2 import (
     DynamicRuleInstall,
     PolicyReAuthRequest,
@@ -44,30 +48,16 @@ from lte.protos.session_manager_pb2 import (
     RulesPerSubscriber,
     SessionRules,
 )
-from lte.protos.abort_session_pb2 import (
-    AbortSessionRequest,
-    AbortSessionResult,
-)
-from lte.protos.spgw_service_pb2 import (
-    CreateBearerRequest,
-    DeleteBearerRequest,
-)
-from lte.protos.spgw_service_pb2_grpc import SpgwServiceStub
-from magma.subscriberdb.sid import SIDUtils
-from lte.protos.abort_session_pb2_grpc import AbortSessionResponderStub
 from lte.protos.session_manager_pb2_grpc import (
     LocalSessionManagerStub,
     SessionProxyResponderStub,
 )
+from lte.protos.spgw_service_pb2 import CreateBearerRequest, DeleteBearerRequest
+from lte.protos.spgw_service_pb2_grpc import SpgwServiceStub
+from magma.subscriberdb.sid import SIDUtils
+from orc8r.protos.common_pb2 import Void
 from orc8r.protos.directoryd_pb2 import GetDirectoryFieldRequest
 from orc8r.protos.directoryd_pb2_grpc import GatewayDirectoryServiceStub
-from integ_tests.s1aptests.ovs.rest_api import get_datapath, get_flows
-from lte.protos.ha_service_pb2_grpc import HaServiceStub
-from lte.protos.ha_service_pb2 import (
-    StartAgwOffloadRequest,
-    EnbOffloadType,
-)
-from orc8r.protos.common_pb2 import Void
 
 DEFAULT_GRPC_TIMEOUT = 10
 
@@ -128,7 +118,7 @@ class S1ApUtil(object):
         os.chdir(lib_path)
         self._test_lib = ctypes.cdll.LoadLibrary(lib)
         self._callback_type = ctypes.CFUNCTYPE(
-            None, ctypes.c_short, ctypes.c_void_p, ctypes.c_short
+            None, ctypes.c_short, ctypes.c_void_p, ctypes.c_short,
         )
         # Maintain a reference to the function object so GC doesn't release it.
         self._callback_fn = self._callback_type(S1ApUtil.s1ap_callback)
@@ -195,7 +185,7 @@ class S1ApUtil(object):
 
     def populate_pco(
             self, protCfgOpts_pr, pcscf_addr_type=None, dns_ipv6_addr=False,
-            ipcp=False
+            ipcp=False,
     ):
         """
         Populates the PCO values.
@@ -329,7 +319,7 @@ class S1ApUtil(object):
         # Populate PCO if pcscf_addr_type/dns_ipv6_addr/ipcp is set
         if pcscf_addr_type or dns_ipv6_addr or ipcp:
             self.populate_pco(
-                attach_req.protCfgOpts_pr, pcscf_addr_type, dns_ipv6_addr, ipcp
+                attach_req.protCfgOpts_pr, pcscf_addr_type, dns_ipv6_addr, ipcp,
             )
         assert self.issue_cmd(attach_type, attach_req) == 0
 
@@ -408,7 +398,6 @@ class S1ApUtil(object):
         with self._lock:
             del self._ue_ip_map[ue_id]
 
-
     def _verify_dl_flow(self, dl_flow_rules=None):
         # try at least 5 times before failing as gateway
         # might take some time to install the flows in ovs
@@ -422,7 +411,7 @@ class S1ApUtil(object):
             ue_ip_str = str(key)
             if key.version == 6:
                 ue_ip6_str = ipaddress.ip_network(
-                    (ue_ip_str + "/64"), strict=False
+                    (ue_ip_str + "/64"), strict=False,
                 ).with_netmask
             ue_ip_addr = ue_ip6_str if key.version == 6 else ue_ip_str
             dst_addr = "nw_dst" if key.version == 4 else "ipv6_dst"
@@ -490,7 +479,7 @@ class S1ApUtil(object):
                             if len(downlink_flows) >= num_dl_flows:
                                 break
                             time.sleep(
-                                5
+                                5,
                             )  # sleep for 5 seconds before retrying
                         assert (
                                 len(downlink_flows) >= num_dl_flows
@@ -523,7 +512,7 @@ class S1ApUtil(object):
                     "table_id": self.SPGW_TABLE,
                     "match": {
                         "in_port": GTP_PORT,
-                    }
+                    },
                 },
             )
             if len(uplink_flows) == num_ul_flows:
@@ -580,10 +569,11 @@ class S1ApUtil(object):
         print("Checking if all uplink/downlink flows were deleted")
         dpath = get_datapath()
         flows = get_flows(
-            dpath, {"table_id": self.SPGW_TABLE}
+            dpath, {"table_id": self.SPGW_TABLE},
         )
         assert(
-            len(flows) == 2), "There should only be 2 default table 0 flows"
+            len(flows) == 2
+        ), "There should only be 2 default table 0 flows"
 
     def generate_imsi(self, prefix=None):
         """
@@ -776,7 +766,7 @@ class MagmadUtil(object):
 
         ret_code = self.exec_command(
             magtivate_cmd + " && " + venvsudo_cmd + " python3 " +
-            config_stateless_script + " " + cmd.name.lower()
+            config_stateless_script + " " + cmd.name.lower(),
         )
 
         if ret_code == 0:
@@ -804,7 +794,7 @@ class MagmadUtil(object):
     def restart_all_services(self):
         """Restart all magma services on magma_dev VM"""
         self.exec_command(
-            "sudo service magma@* stop ; sudo service magma@magmad start"
+            "sudo service magma@* stop ; sudo service magma@magmad start",
         )
         print("Waiting for all services to restart. Sleeping for 60 seconds..")
         timeSlept = 0
@@ -865,7 +855,7 @@ class MagmadUtil(object):
 
         action = cmd.name.lower()
         ret_code = self.exec_command(
-            "sudo -E " + mme_config_update_script + " " + action
+            "sudo -E " + mme_config_update_script + " " + action,
         )
 
         if ret_code == 0:
@@ -915,7 +905,8 @@ class MagmadUtil(object):
             apn_correction_cmd = "sed -i \'s/enable_apn_correction: true/enable_apn_correction: false/g\' /etc/magma/mme.yml"
 
         ret_code = self.exec_command(
-            "sudo " + apn_correction_cmd)
+            "sudo " + apn_correction_cmd,
+        )
 
         if ret_code == 0:
             print("APN Correction configured")
@@ -931,15 +922,19 @@ class MagmadUtil(object):
         magma_health_service_name = "health"
         # Update health config to increment frequency of service failures
         if cmd.name == MagmadUtil.health_service_cmds.DISABLE.name:
-            health_config_cmd = ("sed -i 's/interval_check_mins: 1/interval_"
-                                 "check_mins: 3/g' /etc/magma/health.yml")
+            health_config_cmd = (
+                "sed -i 's/interval_check_mins: 1/interval_"
+                "check_mins: 3/g' /etc/magma/health.yml"
+            )
             self.exec_command("sudo %s" % health_config_cmd)
             if self.is_service_active(magma_health_service_name):
                 self.disable_service(magma_health_service_name)
             print("Health service is disabled")
         elif cmd.name == MagmadUtil.health_service_cmds.ENABLE.name:
-            health_config_cmd = ("sed -i 's/interval_check_mins: 3/interval_"
-                                 "check_mins: 1/g' /etc/magma/health.yml")
+            health_config_cmd = (
+                "sed -i 's/interval_check_mins: 3/interval_"
+                "check_mins: 1/g' /etc/magma/health.yml"
+            )
             self.exec_command("sudo %s" % health_config_cmd)
             if not self.is_service_active(magma_health_service_name):
                 self.enable_service("health")
@@ -1068,7 +1063,7 @@ class MagmadUtil(object):
         magtivate_cmd = "source /home/vagrant/build/python/bin/activate"
         imsi_state_cmd = "state_cli.py keys IMSI*"
         redis_imsi_keys = self.exec_command_output(
-            magtivate_cmd + " && " + imsi_state_cmd
+            magtivate_cmd + " && " + imsi_state_cmd,
         )
         keys_to_be_cleaned = []
         for key in redis_imsi_keys.split("\n"):
@@ -1079,7 +1074,7 @@ class MagmadUtil(object):
 
         mme_nas_state_cmd = "state_cli.py parse mme_nas_state"
         mme_nas_state = self.exec_command_output(
-            magtivate_cmd + " && " + mme_nas_state_cmd
+            magtivate_cmd + " && " + mme_nas_state_cmd,
         )
         num_htbl_entries = 0
         for state in mme_nas_state.split("\n"):
@@ -1210,7 +1205,7 @@ class SpgwUtil(object):
         # DL Flow description #1
         dlFlow1 = {
             "ipv4_src": "192.168.129.42",  # IPv4 source address
-            "tcp_src_port": 5001+port_idx,  # TCP source port
+            "tcp_src_port": 5001 + port_idx,  # TCP source port
             "ip_proto": FlowMatch.IPPROTO_TCP,  # Protocol Type
             "direction": FlowMatch.DOWNLINK,  # Direction
         }
@@ -1218,7 +1213,7 @@ class SpgwUtil(object):
         # DL Flow description #2
         dlFlow2 = {
             "ipv4_src": "",  # IPv4 source address
-            "tcp_src_port": 5002+port_idx,  # TCP source port
+            "tcp_src_port": 5002 + port_idx,  # TCP source port
             "ip_proto": FlowMatch.IPPROTO_TCP,  # Protocol Type
             "direction": FlowMatch.DOWNLINK,  # Direction
         }
@@ -1226,7 +1221,7 @@ class SpgwUtil(object):
         # DL Flow description #3
         dlFlow3 = {
             "ipv4_src": "192.168.129.64/26",  # IPv4 source address
-            "tcp_src_port": 5003+port_idx,  # TCP source port
+            "tcp_src_port": 5003 + port_idx,  # TCP source port
             "ip_proto": FlowMatch.IPPROTO_TCP,  # Protocol Type
             "direction": FlowMatch.DOWNLINK,  # Direction
         }
@@ -1234,7 +1229,7 @@ class SpgwUtil(object):
         # DL Flow description #4
         dlFlow4 = {
             "ipv4_src": "192.168.129.42/16",  # IPv4 source address
-            "tcp_src_port": 5004+port_idx,  # TCP source port
+            "tcp_src_port": 5004 + port_idx,  # TCP source port
             "ip_proto": FlowMatch.IPPROTO_TCP,  # Protocol Type
             "direction": FlowMatch.DOWNLINK,  # Direction
         }
@@ -1276,7 +1271,7 @@ class SpgwUtil(object):
         # DL Flow description #1
         dlFlow1 = {
             "ipv6_src": "baee:1205:486c:988c::99",  # IPv6 source address
-            "tcp_src_port": 5001+port_idx,  # TCP source port
+            "tcp_src_port": 5001 + port_idx,  # TCP source port
             "ip_proto": FlowMatch.IPPROTO_TCP,  # Protocol Type
             "direction": FlowMatch.DOWNLINK,  # Direction
         }
@@ -1284,7 +1279,7 @@ class SpgwUtil(object):
         # DL Flow description #2
         dlFlow2 = {
             "ipv6_src": "fdee:0005:006c:018c::8c99",  # IPv6 source address
-            "tcp_src_port": 5002+port_idx,  # TCP source port
+            "tcp_src_port": 5002 + port_idx,  # TCP source port
             "ip_proto": FlowMatch.IPPROTO_TCP,  # Protocol Type
             "direction": FlowMatch.DOWNLINK,  # Direction
         }
@@ -1322,7 +1317,7 @@ class SpgwUtil(object):
         # DL Flow description #1
         dlFlow1 = {
             "ipv4_src": "192.168.129.42",  # IPv4 source address
-            "tcp_src_port": 5001+port_idx,  # TCP source port
+            "tcp_src_port": 5001 + port_idx,  # TCP source port
             "ip_proto": FlowMatch.IPPROTO_TCP,  # Protocol Type
             "direction": FlowMatch.DOWNLINK,  # Direction
         }
@@ -1330,7 +1325,7 @@ class SpgwUtil(object):
         # DL Flow description #2
         dlFlow2 = {
             "ipv6_src": "fdee:0005:006c:018c::8c99",  # IPv6 source address
-            "tcp_src_port": 5002+port_idx,  # TCP source port
+            "tcp_src_port": 5002 + port_idx,  # TCP source port
             "ip_proto": FlowMatch.IPPROTO_TCP,  # Protocol Type
             "direction": FlowMatch.DOWNLINK,  # Direction
         }
@@ -1357,7 +1352,7 @@ class SpgwUtil(object):
             link_bearer_id=lbi,
             policy_rules=[
                 PolicyRule(
-                    id="rar_rule_"+rule_id,
+                    id="rar_rule_" + rule_id,
                     qos=FlowQos(
                         qci=qci_val,
                         gbr_ul=10000000,
@@ -1371,7 +1366,7 @@ class SpgwUtil(object):
                         ),
                     ),
                     flow_list=flow_match_list,
-                )
+                ),
             ],
         )
         self._stub.CreateBearer(req)
@@ -1382,7 +1377,7 @@ class SpgwUtil(object):
         """
         print("Sending DeleteBearer request to spgw service")
         req = DeleteBearerRequest(
-            sid=SIDUtils.to_pb(imsi), link_bearer_id=lbi, eps_bearer_ids=[ebi]
+            sid=SIDUtils.to_pb(imsi), link_bearer_id=lbi, eps_bearer_ids=[ebi],
         )
         self._stub.DeleteBearer(req)
 
@@ -1392,7 +1387,7 @@ class SpgwUtil(object):
         """
         print("Sending DeleteBearer request to spgw service")
         req = DeleteBearerRequest(
-            sid=SIDUtils.to_pb(imsi), link_bearer_id=lbi, eps_bearer_ids=ebi
+            sid=SIDUtils.to_pb(imsi), link_bearer_id=lbi, eps_bearer_ids=ebi,
         )
         self._stub.DeleteBearer(req)
 
@@ -1407,16 +1402,16 @@ class SessionManagerUtil(object):
         Initialize sessionManager util.
         """
         self._session_proxy_stub = SessionProxyResponderStub(
-            get_rpc_channel("sessiond")
+            get_rpc_channel("sessiond"),
         )
         self._abort_session_stub = AbortSessionResponderStub(
-            get_rpc_channel("abort_session_service")
+            get_rpc_channel("abort_session_service"),
         )
         self._directorydstub = GatewayDirectoryServiceStub(
-            get_rpc_channel("directoryd")
+            get_rpc_channel("directoryd"),
         )
         self._local_session_manager_stub = LocalSessionManagerStub(
-            get_rpc_channel("sessiond")
+            get_rpc_channel("sessiond"),
         )
 
     def get_flow_match(self, flow_list, flow_match_list):
@@ -1454,21 +1449,25 @@ class SessionManagerUtil(object):
             if flow.get("ipv4_src", None):
                 src_addr = IPAddress(
                     version=IPAddress.IPV4,
-                    address=flow.get("ipv4_src").encode('utf-8'))
+                    address=flow.get("ipv4_src").encode('utf-8'),
+                )
             elif flow.get("ipv6_src", None):
                 src_addr = IPAddress(
                     version=IPAddress.IPV6,
-                    address=flow.get("ipv6_src").encode('utf-8'))
+                    address=flow.get("ipv6_src").encode('utf-8'),
+                )
 
             dst_addr = None
             if flow.get("ipv4_dst", None):
                 dst_addr = IPAddress(
                     version=IPAddress.IPV4,
-                    address=flow.get("ipv4_dst").encode('utf-8'))
+                    address=flow.get("ipv4_dst").encode('utf-8'),
+                )
             elif flow.get("ipv6_dst", None):
                 dst_addr = IPAddress(
                     version=IPAddress.IPV6,
-                    address=flow.get("ipv6_dst").encode('utf-8'))
+                    address=flow.get("ipv6_dst").encode('utf-8'),
+                )
 
             flow_match_list.append(
                 FlowDescription(
@@ -1483,7 +1482,7 @@ class SessionManagerUtil(object):
                         direction=flow_direction,
                     ),
                     action=FlowDescription.PERMIT,
-                )
+                ),
             )
 
     def get_policy_rule(self, policy_id, qos=None, flow_match_list=None, he_urls=None):
@@ -1536,11 +1535,12 @@ class SessionManagerUtil(object):
         req = GetDirectoryFieldRequest(id=imsi, field_key="session_id")
         try:
             res = self._directorydstub.GetDirectoryField(
-                req, DEFAULT_GRPC_TIMEOUT
+                req, DEFAULT_GRPC_TIMEOUT,
             )
         except grpc.RpcError as err:
-            print("error: GetDirectoryFieldRequest error for id: "
-                  "%s! [%s] %s" % (imsi, err.code(),err.details())
+            print(
+                "error: GetDirectoryFieldRequest error for id: "
+                      "%s! [%s] %s" % (imsi, err.code(), err.details()),
             )
 
         if res == None:
@@ -1554,13 +1554,13 @@ class SessionManagerUtil(object):
                 rules_to_remove=[],
                 rules_to_install=[],
                 dynamic_rules_to_install=[
-                    DynamicRuleInstall(policy_rule=policy_rule)
+                    DynamicRuleInstall(policy_rule=policy_rule),
                 ],
                 event_triggers=[],
                 revalidation_time=None,
                 usage_monitoring_credits=[],
                 qos_info=qos,
-            )
+            ),
         )
 
     def create_AbortSessionRequest(self, imsi: str) -> AbortSessionResult:
@@ -1568,18 +1568,20 @@ class SessionManagerUtil(object):
         req = GetDirectoryFieldRequest(id=imsi, field_key="session_id")
         try:
             res = self._directorydstub.GetDirectoryField(
-                req, DEFAULT_GRPC_TIMEOUT
+                req, DEFAULT_GRPC_TIMEOUT,
             )
         except grpc.RpcError as err:
-            print("Error: GetDirectoryFieldRequest error for id: %s! [%s] %s" %
-                  (imsi, err.code(), err.details()))
+            print(
+                "Error: GetDirectoryFieldRequest error for id: %s! [%s] %s" %
+                (imsi, err.code(), err.details()),
+            )
             self._print_directoryd_content()
 
         return self._abort_session_stub.AbortSession(
             AbortSessionRequest(
                 session_id=res.value,
                 user_name=imsi,
-            )
+            ),
         )
 
     def _print_directoryd_content(self):
@@ -1616,27 +1618,28 @@ class SessionManagerUtil(object):
         default_flow_match_list = []
         self.get_flow_match(default_flow_rules, default_flow_match_list)
         default_policy_rule = self.get_policy_rule(
-            "allow_list_" + imsi, None, default_flow_match_list)
+            "allow_list_" + imsi, None, default_flow_match_list,
+        )
 
         rule_set = RuleSet(
-            apply_subscriber_wide = True,
-            apn = "",
-            static_rules = [],
-            dynamic_rules = [
+            apply_subscriber_wide=True,
+            apn="",
+            static_rules=[],
+            dynamic_rules=[
                 DynamicRuleInstall(policy_rule=policy_rule),
-                DynamicRuleInstall(policy_rule=default_policy_rule)
+                DynamicRuleInstall(policy_rule=default_policy_rule),
             ],
         )
 
         self._local_session_manager_stub.SetSessionRules(
             SessionRules(
-                rules_per_subscriber = [
+                rules_per_subscriber=[
                     RulesPerSubscriber(
-                        imsi = imsi,
-                        rule_set = [rule_set],
-                    )
-                ]
-            )
+                        imsi=imsi,
+                        rule_set=[rule_set],
+                    ),
+                ],
+            ),
         )
 
 
@@ -1644,7 +1647,7 @@ class GTPBridgeUtils:
     def __init__(self):
         self.magma_utils = MagmadUtil(None)
         ret = self.magma_utils.exec_command_output(
-            "sudo grep ovs_multi_tunnel  /etc/magma/spgw.yml"
+            "sudo grep ovs_multi_tunnel  /etc/magma/spgw.yml",
         )
         if "false" in ret:
             self.gtp_port_name = "gtp0"
@@ -1654,7 +1657,7 @@ class GTPBridgeUtils:
 
     def get_gtp_port_no(self) -> Optional[int]:
         output = self.magma_utils.exec_command_output(
-            "sudo ovsdb-client dump Interface name ofport"
+            "sudo ovsdb-client dump Interface name ofport",
         )
         for line in output.split("\n"):
             if self.gtp_port_name in line:
@@ -1663,7 +1666,7 @@ class GTPBridgeUtils:
 
     def get_proxy_port_no(self) -> Optional[int]:
         output = self.magma_utils.exec_command_output(
-            "sudo ovsdb-client dump Interface name ofport"
+            "sudo ovsdb-client dump Interface name ofport",
         )
         for line in output.split("\n"):
             if self.proxy_port in line:
@@ -1674,7 +1677,7 @@ class GTPBridgeUtils:
     # this adds similar API using `ovs-ofctl` cmd
     def get_flows(self, table_id) -> []:
         output = self.magma_utils.exec_command_output(
-            "sudo ovs-ofctl dump-flows gtp_br0 table={}".format(table_id)
+            "sudo ovs-ofctl dump-flows gtp_br0 table={}".format(table_id),
         )
         return output.split("\n")
 
@@ -1717,7 +1720,8 @@ class HeaderEnrichmentUtils:
         while retry < max:
             try:
                 output = self.magma_utils.exec_command_output(
-                    "sudo ip netns exec envoy_ns1 curl 127.0.0.1:9000/config_dump")
+                    "sudo ip netns exec envoy_ns1 curl 127.0.0.1:9000/config_dump",
+                )
                 self.dump = json.loads(output)
                 return self.dump
             except subprocess.CalledProcessError as e:

--- a/lte/gateway/python/integ_tests/s1aptests/s1ap_wrapper.py
+++ b/lte/gateway/python/integ_tests/s1aptests/s1ap_wrapper.py
@@ -11,19 +11,18 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
+import ctypes
 import os
 import time
-import ctypes
 
 import s1ap_types
 from integ_tests.common.magmad_client import MagmadServiceGrpc
-
 # from integ_tests.cloud.cloud_manager import CloudManager
 from integ_tests.common.mobility_service_client import MobilityServiceGrpc
 from integ_tests.common.service303_utils import GatewayServicesUtil
 from integ_tests.common.subscriber_db_client import (
-    SubscriberDbGrpc,
     SubscriberDbCassandra,
+    SubscriberDbGrpc,
 )
 from integ_tests.s1aptests.s1ap_utils import (
     MagmadUtil,
@@ -242,7 +241,7 @@ class TestWrapper(object):
             # APN configuration below can be overwritten in the test case
             # after configuring UE device.
             self.configAPN(
-                "IMSI" + "".join([str(j) for j in reqs[i].imsi]), None
+                "IMSI" + "".join([str(j) for j in reqs[i].imsi]), None,
             )
             self._configuredUes.append(reqs[i])
 
@@ -269,7 +268,7 @@ class TestWrapper(object):
             # APN configuration below can be overwritten in the test case
             # after configuring UE device.
             self.configAPN(
-                "IMSI" + "".join([str(j) for j in reqs[i].imsi]), None
+                "IMSI" + "".join([str(j) for j in reqs[i].imsi]), None,
             )
             self._configuredUes.append(reqs[i])
         for i in range(num_ues):
@@ -311,7 +310,7 @@ class TestWrapper(object):
             # APN configuration below can be overwritten in the test case
             # after configuring UE device.
             self.configAPN(
-                "IMSI" + "".join([str(j) for j in reqs[i].imsi]), None
+                "IMSI" + "".join([str(j) for j in reqs[i].imsi]), None,
             )
             self._configuredUes.append(reqs[i])
 
@@ -360,10 +359,10 @@ class TestWrapper(object):
             if not ip:
                 raise ValueError(
                     "Encountered invalid IP for UE ID %s."
-                    " Are you sure the UE is attached?" % ue
+                    " Are you sure the UE is attached?" % ue,
                 )
         return self._trf_util.generate_traffic_test(
-            ips, is_uplink=False, **kwargs
+            ips, is_uplink=False, **kwargs,
         )
 
     def configUplinkTest(self, *ues, **kwargs):
@@ -381,10 +380,10 @@ class TestWrapper(object):
             if not ip:
                 raise ValueError(
                     "Encountered invalid IP for UE ID %s."
-                    " Are you sure the UE is attached?" % ue
+                    " Are you sure the UE is attached?" % ue,
                 )
         return self._trf_util.generate_traffic_test(
-            ips, is_uplink=True, **kwargs
+            ips, is_uplink=True, **kwargs,
         )
 
     def get_gateway_services_util(self):
@@ -458,7 +457,7 @@ class TestWrapper(object):
         print("***************** Sending Multiple Enb Config Request\n")
         assert (
             self._s1_util.issue_cmd(
-                s1ap_types.tfwCmd.MULTIPLE_ENB_CONFIG_REQ, req
+                s1ap_types.tfwCmd.MULTIPLE_ENB_CONFIG_REQ, req,
             )
             == 0
         )
@@ -468,11 +467,11 @@ class TestWrapper(object):
         act_ded_bearer_acc.ue_Id = ue_id
         act_ded_bearer_acc.bearerId = bearerId
         self._s1_util.issue_cmd(
-            s1ap_types.tfwCmd.UE_ACT_DED_BER_ACC, act_ded_bearer_acc
+            s1ap_types.tfwCmd.UE_ACT_DED_BER_ACC, act_ded_bearer_acc,
         )
         print(
             "************** Sending activate dedicated EPS bearer "
-            "context accept\n"
+            "context accept\n",
         )
 
     def sendDeactDedicatedBearerAccept(self, ue_id, bearerId):
@@ -480,12 +479,12 @@ class TestWrapper(object):
         deact_ded_bearer_acc.ue_Id = ue_id
         deact_ded_bearer_acc.bearerId = bearerId
         self._s1_util.issue_cmd(
-            s1ap_types.tfwCmd.UE_DEACTIVATE_BER_ACC, deact_ded_bearer_acc
+            s1ap_types.tfwCmd.UE_DEACTIVATE_BER_ACC, deact_ded_bearer_acc,
         )
         print("************* Sending deactivate EPS bearer context accept\n")
 
     def sendPdnConnectivityReq(
-        self, ue_id, apn, pdn_type=1, pcscf_addr_type=None, dns_ipv6_addr=False
+        self, ue_id, apn, pdn_type=1, pcscf_addr_type=None, dns_ipv6_addr=False,
     ):
         req = s1ap_types.uepdnConReq_t()
         req.ue_Id = ue_id
@@ -497,13 +496,13 @@ class TestWrapper(object):
         req.pdnAPN_pr.pres = 1
         req.pdnAPN_pr.len = len(apn)
         req.pdnAPN_pr.pdn_apn = (ctypes.c_ubyte * 100)(
-            *[ctypes.c_ubyte(ord(c)) for c in apn[:100]]
+            *[ctypes.c_ubyte(ord(c)) for c in apn[:100]],
         )
         print("********* PDN type", pdn_type)
         # Populate PCO if pcscf_addr_type is set
         if pcscf_addr_type or dns_ipv6_addr:
             self._s1_util.populate_pco(
-                req.protCfgOpts_pr, pcscf_addr_type, dns_ipv6_addr
+                req.protCfgOpts_pr, pcscf_addr_type, dns_ipv6_addr,
             )
 
         self.s1_util.issue_cmd(s1ap_types.tfwCmd.UE_PDN_CONN_REQ, req)

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_act_dflt_ber_ctxt_rej.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_act_dflt_ber_ctxt_rej.py
@@ -12,11 +12,11 @@ limitations under the License.
 """
 
 
+import time
 import unittest
 
 import s1ap_types
 import s1ap_wrapper
-import time
 
 
 class TestAttachCompleteWithActvDfltBearCtxtRej(unittest.TestCase):
@@ -50,11 +50,11 @@ class TestAttachCompleteWithActvDfltBearCtxtRej(unittest.TestCase):
         print("********Triggering Attach Request ")
 
         self._s1ap_wrapper._s1_util.issue_cmd(
-            s1ap_types.tfwCmd.UE_ATTACH_REQUEST, attach_req
+            s1ap_types.tfwCmd.UE_ATTACH_REQUEST, attach_req,
         )
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_AUTH_REQ_IND.value
+            response.msg_type, s1ap_types.tfwCmd.UE_AUTH_REQ_IND.value,
         )
 
         # Trigger Authentication Response
@@ -64,28 +64,28 @@ class TestAttachCompleteWithActvDfltBearCtxtRej(unittest.TestCase):
         sqnRecvd.pres = 0
         auth_res.sqnRcvd = sqnRecvd
         self._s1ap_wrapper._s1_util.issue_cmd(
-            s1ap_types.tfwCmd.UE_AUTH_RESP, auth_res
+            s1ap_types.tfwCmd.UE_AUTH_RESP, auth_res,
         )
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_SEC_MOD_CMD_IND.value
+            response.msg_type, s1ap_types.tfwCmd.UE_SEC_MOD_CMD_IND.value,
         )
 
         # Trigger Security Mode Complete
         sec_mode_complete = s1ap_types.ueSecModeComplete_t()
         sec_mode_complete.ue_Id = req.ue_id
         self._s1ap_wrapper._s1_util.issue_cmd(
-            s1ap_types.tfwCmd.UE_SEC_MOD_COMPLETE, sec_mode_complete
+            s1ap_types.tfwCmd.UE_SEC_MOD_COMPLETE, sec_mode_complete,
         )
 
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.INT_CTX_SETUP_IND.value
+            response.msg_type, s1ap_types.tfwCmd.INT_CTX_SETUP_IND.value,
         )
 
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_ATTACH_ACCEPT_IND.value
+            response.msg_type, s1ap_types.tfwCmd.UE_ATTACH_ACCEPT_IND.value,
         )
         msg = response.cast(s1ap_types.ueAttachAccept_t)
         bid = msg.esmInfo.epsBearerId
@@ -102,17 +102,17 @@ class TestAttachCompleteWithActvDfltBearCtxtRej(unittest.TestCase):
         # Attach Complete message
         # Attach Complete + Activate Default EPS Bearer Context Reject
         self._s1ap_wrapper._s1_util.issue_cmd(
-            s1ap_types.tfwCmd.UE_ACTV_DEFAULT_EPS_BEARER_CNTXT_REJECT, act_rej
+            s1ap_types.tfwCmd.UE_ACTV_DEFAULT_EPS_BEARER_CNTXT_REJECT, act_rej,
         )
         # Attach Reject
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_ATTACH_REJECT_IND.value
+            response.msg_type, s1ap_types.tfwCmd.UE_ATTACH_REJECT_IND.value,
         )
 
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_CTX_REL_IND.value
+            response.msg_type, s1ap_types.tfwCmd.UE_CTX_REL_IND.value,
         )
         print("******** released UE contexts ********")
 

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_active_tau_with_combined_tala_update_reattach.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_active_tau_with_combined_tala_update_reattach.py
@@ -11,8 +11,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-import unittest
 import time
+import unittest
 
 import gpp_types
 import s1ap_types
@@ -69,14 +69,14 @@ class TestAttachActiveTauWithCombinedTalaUpdateReattach(unittest.TestCase):
         req.ue_Id = ue_id
         req.cause.causeVal = gpp_types.CauseRadioNetwork.USER_INACTIVITY.value
         self._s1ap_wrapper.s1_util.issue_cmd(
-            s1ap_types.tfwCmd.UE_CNTXT_REL_REQUEST, req
+            s1ap_types.tfwCmd.UE_CNTXT_REL_REQUEST, req,
         )
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_CTX_REL_IND.value
+            response.msg_type, s1ap_types.tfwCmd.UE_CTX_REL_IND.value,
         )
         print(
-            "************************* Received UE context release indication"
+            "************************* Received UE context release indication",
         )
 
         print(
@@ -95,19 +95,19 @@ class TestAttachActiveTauWithCombinedTalaUpdateReattach(unittest.TestCase):
         # Waiting for TAU Reject Indication -Combined TALA update not supported
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_TAU_REJECT_IND.value
+            response.msg_type, s1ap_types.tfwCmd.UE_TAU_REJECT_IND.value,
         )
         print(
             "************************* Received Tracking Area Update Reject "
-            "Indication"
+            "Indication",
         )
 
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_CTX_REL_IND.value
+            response.msg_type, s1ap_types.tfwCmd.UE_CTX_REL_IND.value,
         )
         print(
-            "************************* Received UE context release indication"
+            "************************* Received UE context release indication",
         )
 
         print(
@@ -131,7 +131,7 @@ class TestAttachActiveTauWithCombinedTalaUpdateReattach(unittest.TestCase):
         print("************************* Running UE detach for UE id", ue_id)
         # Now detach the UE
         self._s1ap_wrapper.s1_util.detach(
-            ue_id, s1ap_types.ueDetachType_t.UE_NORMAL_DETACH.value, True
+            ue_id, s1ap_types.ueDetachType_t.UE_NORMAL_DETACH.value, True,
         )
 
 

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_and_mme_restart_loop_detach_and_mme_restart_loop_multi_ue.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_and_mme_restart_loop_detach_and_mme_restart_loop_multi_ue.py
@@ -11,19 +11,19 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
+import random
 import time
 import unittest
 
 import s1ap_types
 import s1ap_wrapper
 from s1ap_utils import MagmadUtil
-import random
 
 
 class TestAttachAndMmeRestartLoopDetachAndMmeRestartLoopMultiUe(unittest.TestCase):
     def setUp(self):
         self._s1ap_wrapper = s1ap_wrapper.TestWrapper(
-            stateless_mode=MagmadUtil.stateless_cmds.ENABLE
+            stateless_mode=MagmadUtil.stateless_cmds.ENABLE,
         )
 
     def tearDown(self):

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_asr.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_asr.py
@@ -11,14 +11,13 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-import unittest
-import s1ap_types
 import time
+import unittest
 
+import s1ap_types
 from integ_tests.s1aptests import s1ap_wrapper
-from integ_tests.s1aptests.s1ap_utils import SpgwUtil
-from integ_tests.s1aptests.s1ap_utils import SessionManagerUtil
 from integ_tests.s1aptests.ovs.rest_api import get_datapath, get_flows
+from integ_tests.s1aptests.s1ap_utils import SessionManagerUtil, SpgwUtil
 
 
 class TestAttachASR(unittest.TestCase):
@@ -81,7 +80,7 @@ class TestAttachASR(unittest.TestCase):
         detach_accept = s1ap_types.ueTrigDetachAcceptInd_t()
         detach_accept.ue_Id = req.ue_id
         self._s1ap_wrapper._s1_util.issue_cmd(
-            s1ap_types.tfwCmd.UE_TRIGGERED_DETACH_ACCEPT, detach_accept
+            s1ap_types.tfwCmd.UE_TRIGGERED_DETACH_ACCEPT, detach_accept,
         )
 
         print("Sleeping for 5 seconds")
@@ -89,7 +88,6 @@ class TestAttachASR(unittest.TestCase):
 
         # Verify that all UL/DL flows are deleted
         self._s1ap_wrapper.s1_util.verify_flow_rules_deletion()
-
 
 
 if __name__ == "__main__":

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_auth_failure.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_auth_failure.py
@@ -14,7 +14,6 @@ limitations under the License.
 import unittest
 
 import s1ap_types
-
 from integ_tests.s1aptests import s1ap_wrapper
 
 
@@ -46,7 +45,7 @@ class TestAuthFailure(unittest.TestCase):
 
         print("Sending Attach Request for ue-id", attach_req.ue_Id)
         self._s1ap_wrapper._s1_util.issue_cmd(
-            s1ap_types.tfwCmd.UE_ATTACH_REQUEST, attach_req
+            s1ap_types.tfwCmd.UE_ATTACH_REQUEST, attach_req,
         )
 
         response = self._s1ap_wrapper.s1_util.get_response()
@@ -61,7 +60,7 @@ class TestAuthFailure(unittest.TestCase):
             auth_failure.auts[idx1] = 0
         print("Sending Authentication Failure for ue-id", auth_failure.ue_Id)
         self._s1ap_wrapper._s1_util.issue_cmd(
-            s1ap_types.tfwCmd.UE_AUTH_FAILURE, auth_failure
+            s1ap_types.tfwCmd.UE_AUTH_FAILURE, auth_failure,
         )
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertTrue(response, s1ap_types.tfwCmd.UE_AUTH_REJ_IND.value)

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_auth_mac_failure.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_auth_mac_failure.py
@@ -14,7 +14,6 @@ limitations under the License.
 import unittest
 
 import s1ap_types
-
 from integ_tests.s1aptests import s1ap_wrapper
 
 
@@ -46,7 +45,7 @@ class TestAuthMacFailure(unittest.TestCase):
 
         print("Sending Attach Request for ue-id", attach_req.ue_Id)
         self._s1ap_wrapper._s1_util.issue_cmd(
-            s1ap_types.tfwCmd.UE_ATTACH_REQUEST, attach_req
+            s1ap_types.tfwCmd.UE_ATTACH_REQUEST, attach_req,
         )
 
         response = self._s1ap_wrapper.s1_util.get_response()
@@ -61,7 +60,7 @@ class TestAuthMacFailure(unittest.TestCase):
             auth_failure.auts[idx1] = 0
         print("Sending Authentication Failure for ue-id", auth_failure.ue_Id)
         self._s1ap_wrapper._s1_util.issue_cmd(
-            s1ap_types.tfwCmd.UE_AUTH_FAILURE, auth_failure
+            s1ap_types.tfwCmd.UE_AUTH_FAILURE, auth_failure,
         )
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertTrue(response, s1ap_types.tfwCmd.UE_AUTH_REJ_IND.value)

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_combined_eps_imsi.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_combined_eps_imsi.py
@@ -30,23 +30,29 @@ class TestAttachCombinedEpsImsi(unittest.TestCase):
         self._s1ap_wrapper.configUEDevice(1)
         req = self._s1ap_wrapper.ue_req
         ue_id = req.ue_id
-        print("************************* Running End to End attach for UE id ",
-              ue_id)
+        print(
+            "************************* Running End to End attach for UE id ",
+            ue_id,
+        )
         # Now actually complete the attach
         self._s1ap_wrapper._s1_util.attach(
             ue_id, s1ap_types.tfwCmd.UE_END_TO_END_ATTACH_REQUEST,
             s1ap_types.tfwCmd.UE_ATTACH_ACCEPT_IND,
             s1ap_types.ueAttachAccept_t,
-            eps_type=s1ap_types.TFW_EPS_ATTACH_TYPE_COMB_EPS_IMSI_ATTACH)
+            eps_type=s1ap_types.TFW_EPS_ATTACH_TYPE_COMB_EPS_IMSI_ATTACH,
+        )
 
         # Wait on EMM Information from MME
         self._s1ap_wrapper._s1_util.receive_emm_info()
 
-        print("************************* Running UE detach for UE id ",
-              ue_id)
+        print(
+            "************************* Running UE detach for UE id ",
+            ue_id,
+        )
         # Now detach the UE
         self._s1ap_wrapper.s1_util.detach(
-            ue_id, s1ap_types.ueDetachType_t.UE_SWITCHOFF_DETACH.value, False)
+            ue_id, s1ap_types.ueDetachType_t.UE_SWITCHOFF_DETACH.value, False,
+        )
 
 
 if __name__ == "__main__":

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_detach.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_detach.py
@@ -12,8 +12,8 @@ limitations under the License.
 """
 
 import unittest
-import s1ap_types
 
+import s1ap_types
 from integ_tests.s1aptests import s1ap_wrapper
 
 
@@ -28,28 +28,36 @@ class TestAttachDetach(unittest.TestCase):
     def test_attach_detach(self):
         """ Basic attach/detach test with a single UE """
         num_ues = 2
-        detach_type = [s1ap_types.ueDetachType_t.UE_NORMAL_DETACH.value,
-                       s1ap_types.ueDetachType_t.UE_SWITCHOFF_DETACH.value]
+        detach_type = [
+            s1ap_types.ueDetachType_t.UE_NORMAL_DETACH.value,
+            s1ap_types.ueDetachType_t.UE_SWITCHOFF_DETACH.value,
+        ]
         wait_for_s1 = [True, False]
         self._s1ap_wrapper.configUEDevice(num_ues)
 
         for i in range(num_ues):
             req = self._s1ap_wrapper.ue_req
-            print("************************* Running End to End attach for ",
-                  "UE id ", req.ue_id)
+            print(
+                "************************* Running End to End attach for ",
+                "UE id ", req.ue_id,
+            )
             # Now actually complete the attach
             self._s1ap_wrapper._s1_util.attach(
                 req.ue_id, s1ap_types.tfwCmd.UE_END_TO_END_ATTACH_REQUEST,
                 s1ap_types.tfwCmd.UE_ATTACH_ACCEPT_IND,
-                s1ap_types.ueAttachAccept_t)
+                s1ap_types.ueAttachAccept_t,
+            )
 
             # Wait on EMM Information from MME
             self._s1ap_wrapper._s1_util.receive_emm_info()
-            print("************************* Running UE detach for UE id ",
-                  req.ue_id)
+            print(
+                "************************* Running UE detach for UE id ",
+                req.ue_id,
+            )
             # Now detach the UE
             self._s1ap_wrapper.s1_util.detach(
-                req.ue_id, detach_type[i], wait_for_s1[i])
+                req.ue_id, detach_type[i], wait_for_s1[i],
+            )
 
 
 if __name__ == "__main__":

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_ICS_Failure.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_ICS_Failure.py
@@ -48,11 +48,11 @@ class TestAttachICSFailure(unittest.TestCase):
         print("***Triggering Attach Request***")
 
         self._s1ap_wrapper._s1_util.issue_cmd(
-            s1ap_types.tfwCmd.UE_ATTACH_REQUEST, attach_req
+            s1ap_types.tfwCmd.UE_ATTACH_REQUEST, attach_req,
         )
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_AUTH_REQ_IND.value
+            response.msg_type, s1ap_types.tfwCmd.UE_AUTH_REQ_IND.value,
         )
 
         init_ctxt_setup_fail = s1ap_types.ueInitCtxtSetupFail()
@@ -69,27 +69,27 @@ class TestAttachICSFailure(unittest.TestCase):
         sqnRecvd.pres = 0
         auth_res.sqnRcvd = sqnRecvd
         self._s1ap_wrapper._s1_util.issue_cmd(
-            s1ap_types.tfwCmd.UE_AUTH_RESP, auth_res
+            s1ap_types.tfwCmd.UE_AUTH_RESP, auth_res,
         )
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_SEC_MOD_CMD_IND.value
+            response.msg_type, s1ap_types.tfwCmd.UE_SEC_MOD_CMD_IND.value,
         )
 
         self._s1ap_wrapper._s1_util.issue_cmd(
-            s1ap_types.tfwCmd.UE_SET_INIT_CTXT_SETUP_FAIL, init_ctxt_setup_fail
+            s1ap_types.tfwCmd.UE_SET_INIT_CTXT_SETUP_FAIL, init_ctxt_setup_fail,
         )
 
         # Trigger Security Mode Complete
         sec_mode_complete = s1ap_types.ueSecModeComplete_t()
         sec_mode_complete.ue_Id = req.ue_id
         self._s1ap_wrapper._s1_util.issue_cmd(
-            s1ap_types.tfwCmd.UE_SEC_MOD_COMPLETE, sec_mode_complete
+            s1ap_types.tfwCmd.UE_SEC_MOD_COMPLETE, sec_mode_complete,
         )
 
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.INT_CTX_SETUP_IND.value
+            response.msg_type, s1ap_types.tfwCmd.INT_CTX_SETUP_IND.value,
         )
 
         print("*** Received Initial Context Setup Failure ***")
@@ -98,7 +98,7 @@ class TestAttachICSFailure(unittest.TestCase):
         sctp_abort = s1ap_types.FwSctpAbortReq_t()
         sctp_abort.cause = 0
         self._s1ap_wrapper._s1_util.issue_cmd(
-            s1ap_types.tfwCmd.SCTP_ABORT_REQ, sctp_abort
+            s1ap_types.tfwCmd.SCTP_ABORT_REQ, sctp_abort,
         )
 
 

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_after_ue_context_release.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_after_ue_context_release.py
@@ -11,13 +11,12 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
+import time
 import unittest
-
 
 import gpp_types
 import s1ap_types
 import s1ap_wrapper
-import time
 
 
 class TestAttachDetachAfterUeContextRelease(unittest.TestCase):
@@ -34,13 +33,16 @@ class TestAttachDetachAfterUeContextRelease(unittest.TestCase):
         self._s1ap_wrapper.configUEDevice(1)
         req = self._s1ap_wrapper.ue_req
         ue_id = req.ue_id
-        print("************************* Running End to End attach for UE id ",
-              ue_id)
+        print(
+            "************************* Running End to End attach for UE id ",
+            ue_id,
+        )
         # Now actually complete the attach
         self._s1ap_wrapper.s1_util.attach(
             ue_id, s1ap_types.tfwCmd.UE_END_TO_END_ATTACH_REQUEST,
             s1ap_types.tfwCmd.UE_ATTACH_ACCEPT_IND,
-            s1ap_types.ueAttachAccept_t)
+            s1ap_types.ueAttachAccept_t,
+        )
 
         # Wait on EMM Information from MME
         self._s1ap_wrapper._s1_util.receive_emm_info()
@@ -49,23 +51,30 @@ class TestAttachDetachAfterUeContextRelease(unittest.TestCase):
         # context release
         time.sleep(0.5)
 
-        print("************************* Sending UE context release request ",
-              "for UE id ", ue_id)
+        print(
+            "************************* Sending UE context release request ",
+            "for UE id ", ue_id,
+        )
         # Send UE context release request to move UE to idle mode
         req = s1ap_types.ueCntxtRelReq_t()
         req.ue_Id = ue_id
         req.cause.causeVal = gpp_types.CauseRadioNetwork.USER_INACTIVITY.value
         self._s1ap_wrapper.s1_util.issue_cmd(
-            s1ap_types.tfwCmd.UE_CNTXT_REL_REQUEST, req)
+            s1ap_types.tfwCmd.UE_CNTXT_REL_REQUEST, req,
+        )
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_CTX_REL_IND.value)
+            response.msg_type, s1ap_types.tfwCmd.UE_CTX_REL_IND.value,
+        )
 
-        print("************************* Running UE detach (switch-off) for ",
-              "UE id ", ue_id)
+        print(
+            "************************* Running UE detach (switch-off) for ",
+            "UE id ", ue_id,
+        )
         # Now detach the UE
         self._s1ap_wrapper.s1_util.detach(
-            ue_id, s1ap_types.ueDetachType_t.UE_SWITCHOFF_DETACH.value, False)
+            ue_id, s1ap_types.ueDetachType_t.UE_SWITCHOFF_DETACH.value, False,
+        )
 
 
 if __name__ == "__main__":

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_attach_dl_tcp_data.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_attach_dl_tcp_data.py
@@ -29,44 +29,58 @@ class TestAttachDetachAttachDlTcpData(unittest.TestCase):
         """ Attach, detach, re-attach, send DL TCP data, and detach """
         self._s1ap_wrapper.configUEDevice(1)
         req = self._s1ap_wrapper.ue_req
-        print("************************* Running 1st End to End attach for ",
-              "UE id ", req.ue_id)
+        print(
+            "************************* Running 1st End to End attach for ",
+            "UE id ", req.ue_id,
+        )
         # Now actually complete the attach
         self._s1ap_wrapper._s1_util.attach(
             req.ue_id, s1ap_types.tfwCmd.UE_END_TO_END_ATTACH_REQUEST,
             s1ap_types.tfwCmd.UE_ATTACH_ACCEPT_IND,
-            s1ap_types.ueAttachAccept_t)
+            s1ap_types.ueAttachAccept_t,
+        )
         # Wait on EMM Information from MME
         self._s1ap_wrapper._s1_util.receive_emm_info()
 
-        print("************************* Running UE detach for UE id ",
-              req.ue_id)
+        print(
+            "************************* Running UE detach for UE id ",
+            req.ue_id,
+        )
         # Now detach the UE
         self._s1ap_wrapper.s1_util.detach(
             req.ue_id, s1ap_types.ueDetachType_t.UE_SWITCHOFF_DETACH.value,
-            True)
+            True,
+        )
 
-        print("************************* Running 2nd End to End attach for ",
-              "UE id ", req.ue_id)
+        print(
+            "************************* Running 2nd End to End attach for ",
+            "UE id ", req.ue_id,
+        )
         # Now actually complete the attach
         self._s1ap_wrapper._s1_util.attach(
             req.ue_id, s1ap_types.tfwCmd.UE_END_TO_END_ATTACH_REQUEST,
             s1ap_types.tfwCmd.UE_ATTACH_ACCEPT_IND,
-            s1ap_types.ueAttachAccept_t)
+            s1ap_types.ueAttachAccept_t,
+        )
         # Wait on EMM Information from MME
         self._s1ap_wrapper._s1_util.receive_emm_info()
 
-        print("************************* Running UE downlink (TCP) for UE id ",
-              req.ue_id)
+        print(
+            "************************* Running UE downlink (TCP) for UE id ",
+            req.ue_id,
+        )
         with self._s1ap_wrapper.configDownlinkTest(req, duration=1) as test:
             test.verify()
 
-        print("************************* Running UE detach for UE id ",
-              req.ue_id)
+        print(
+            "************************* Running UE detach for UE id ",
+            req.ue_id,
+        )
         # Now detach the UE
         self._s1ap_wrapper.s1_util.detach(
             req.ue_id, s1ap_types.ueDetachType_t.UE_SWITCHOFF_DETACH.value,
-            True)
+            True,
+        )
 
 
 if __name__ == "__main__":

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_attach_ul_tcp_data.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_attach_ul_tcp_data.py
@@ -29,44 +29,58 @@ class TestAttachDetachAttachUlTcpData(unittest.TestCase):
         """ Attach, detach, re-attach, send UL TCP data, and detach"""
         self._s1ap_wrapper.configUEDevice(1)
         req = self._s1ap_wrapper.ue_req
-        print("************************* Running 1st End to End attach for ",
-              "UE id ", req.ue_id)
+        print(
+            "************************* Running 1st End to End attach for ",
+            "UE id ", req.ue_id,
+        )
         # Now actually complete the attach
         self._s1ap_wrapper._s1_util.attach(
             req.ue_id, s1ap_types.tfwCmd.UE_END_TO_END_ATTACH_REQUEST,
             s1ap_types.tfwCmd.UE_ATTACH_ACCEPT_IND,
-            s1ap_types.ueAttachAccept_t)
+            s1ap_types.ueAttachAccept_t,
+        )
         # Wait on EMM Information from MME
         self._s1ap_wrapper._s1_util.receive_emm_info()
 
-        print("************************* Running UE detach for UE id ",
-              req.ue_id)
+        print(
+            "************************* Running UE detach for UE id ",
+            req.ue_id,
+        )
         # Now detach the UE
         self._s1ap_wrapper.s1_util.detach(
             req.ue_id, s1ap_types.ueDetachType_t.UE_SWITCHOFF_DETACH.value,
-            True)
+            True,
+        )
 
-        print("************************* Running 2nd End to End attach for ",
-              "UE id ", req.ue_id)
+        print(
+            "************************* Running 2nd End to End attach for ",
+            "UE id ", req.ue_id,
+        )
         # Now actually complete the attach
         self._s1ap_wrapper._s1_util.attach(
             req.ue_id, s1ap_types.tfwCmd.UE_END_TO_END_ATTACH_REQUEST,
             s1ap_types.tfwCmd.UE_ATTACH_ACCEPT_IND,
-            s1ap_types.ueAttachAccept_t)
+            s1ap_types.ueAttachAccept_t,
+        )
         # Wait on EMM Information from MME
         self._s1ap_wrapper._s1_util.receive_emm_info()
 
-        print("************************* Running UE uplink (TCP) for UE id ",
-              req.ue_id)
+        print(
+            "************************* Running UE uplink (TCP) for UE id ",
+            req.ue_id,
+        )
         with self._s1ap_wrapper.configUplinkTest(req, duration=1) as test:
             test.verify()
 
-        print("************************* Running UE detach for UE id ",
-              req.ue_id)
+        print(
+            "************************* Running UE detach for UE id ",
+            req.ue_id,
+        )
         # Now detach the UE
         self._s1ap_wrapper.s1_util.detach(
             req.ue_id, s1ap_types.ueDetachType_t.UE_SWITCHOFF_DETACH.value,
-            True)
+            True,
+        )
 
 
 if __name__ == "__main__":

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_disconnect_default_pdn.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_disconnect_default_pdn.py
@@ -11,8 +11,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-import unittest
 import time
+import unittest
 
 import s1ap_types
 import s1ap_wrapper
@@ -54,18 +54,18 @@ class TestDisconnectDefaultPdn(unittest.TestCase):
         pdn_disconnect_req.ue_Id = ue_id
         pdn_disconnect_req.epsBearerId = 5
         self._s1ap_wrapper._s1_util.issue_cmd(
-            s1ap_types.tfwCmd.UE_PDN_DISCONNECT_REQ, pdn_disconnect_req
+            s1ap_types.tfwCmd.UE_PDN_DISCONNECT_REQ, pdn_disconnect_req,
         )
 
         # Receive PDN Disconnect Reject
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_PDN_DISCONNECT_REJ.value
+            response.msg_type, s1ap_types.tfwCmd.UE_PDN_DISCONNECT_REJ.value,
         )
 
         # Now detach the UE
         self._s1ap_wrapper.s1_util.detach(
-            ue_id, s1ap_types.ueDetachType_t.UE_SWITCHOFF_DETACH.value, False
+            ue_id, s1ap_types.ueDetachType_t.UE_SWITCHOFF_DETACH.value, False,
         )
 
 

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_duplicate_nas_resp_messages.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_duplicate_nas_resp_messages.py
@@ -44,7 +44,7 @@ class TestAttachDetachDuplicateNASRespMessages(unittest.TestCase):
 
         print("*** Triggering Attach Request ***")
         self._s1ap_wrapper._s1_util.issue_cmd(
-            s1ap_types.tfwCmd.UE_ATTACH_REQUEST, attach_req
+            s1ap_types.tfwCmd.UE_ATTACH_REQUEST, attach_req,
         )
 
         # Waiting for Authentication Request
@@ -57,7 +57,7 @@ class TestAttachDetachDuplicateNASRespMessages(unittest.TestCase):
             )
             response = self._s1ap_wrapper.s1_util.get_response()
             self.assertEqual(
-                response.msg_type, s1ap_types.tfwCmd.UE_AUTH_REQ_IND.value
+                response.msg_type, s1ap_types.tfwCmd.UE_AUTH_REQ_IND.value,
             )
             print(
                 "*** Authentication Request Message Received (",
@@ -78,7 +78,7 @@ class TestAttachDetachDuplicateNASRespMessages(unittest.TestCase):
                 ") ***",
             )
             self._s1ap_wrapper._s1_util.issue_cmd(
-                s1ap_types.tfwCmd.UE_AUTH_RESP, auth_res
+                s1ap_types.tfwCmd.UE_AUTH_RESP, auth_res,
             )
 
         # Waiting for Security mode command
@@ -91,7 +91,7 @@ class TestAttachDetachDuplicateNASRespMessages(unittest.TestCase):
             )
             response = self._s1ap_wrapper.s1_util.get_response()
             self.assertEqual(
-                response.msg_type, s1ap_types.tfwCmd.UE_SEC_MOD_CMD_IND.value
+                response.msg_type, s1ap_types.tfwCmd.UE_SEC_MOD_CMD_IND.value,
             )
             print(
                 "*** Security Mode Command Message Received (",
@@ -109,7 +109,7 @@ class TestAttachDetachDuplicateNASRespMessages(unittest.TestCase):
                 ") ***",
             )
             self._s1ap_wrapper._s1_util.issue_cmd(
-                s1ap_types.tfwCmd.UE_SEC_MOD_COMPLETE, sec_mode_complete
+                s1ap_types.tfwCmd.UE_SEC_MOD_COMPLETE, sec_mode_complete,
             )
 
         # Waiting for Attach accept
@@ -129,7 +129,7 @@ class TestAttachDetachDuplicateNASRespMessages(unittest.TestCase):
 
             response = self._s1ap_wrapper.s1_util.get_response()
             self.assertEqual(
-                response.msg_type, s1ap_types.tfwCmd.UE_ATTACH_ACCEPT_IND.value
+                response.msg_type, s1ap_types.tfwCmd.UE_ATTACH_ACCEPT_IND.value,
             )
             print(
                 "*** Attach Accept Message Received (", str(i + 1), ") ***",
@@ -143,7 +143,7 @@ class TestAttachDetachDuplicateNASRespMessages(unittest.TestCase):
                 "*** Sending Attach Complete Message (", str(i + 1), ") ***",
             )
             self._s1ap_wrapper._s1_util.issue_cmd(
-                s1ap_types.tfwCmd.UE_ATTACH_COMPLETE, attach_complete
+                s1ap_types.tfwCmd.UE_ATTACH_COMPLETE, attach_complete,
             )
 
         print("*** Running UE detach ***")
@@ -152,7 +152,7 @@ class TestAttachDetachDuplicateNASRespMessages(unittest.TestCase):
         detach_req.ue_Id = req.ue_id
         detach_req.ueDetType = s1ap_types.ueDetachType_t.UE_NORMAL_DETACH.value
         self._s1ap_wrapper._s1_util.issue_cmd(
-            s1ap_types.tfwCmd.UE_DETACH_REQUEST, detach_req
+            s1ap_types.tfwCmd.UE_DETACH_REQUEST, detach_req,
         )
 
 

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_emm_status.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_emm_status.py
@@ -11,13 +11,12 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
+import time
 import unittest
-
 
 import gpp_types
 import s1ap_types
 import s1ap_wrapper
-import time
 
 
 class TestAttachDetachEmmStatusMsg(unittest.TestCase):
@@ -35,13 +34,16 @@ class TestAttachDetachEmmStatusMsg(unittest.TestCase):
         self._s1ap_wrapper.configUEDevice(1)
         req = self._s1ap_wrapper.ue_req
         ue_id = req.ue_id
-        print("************************* Running End to End attach for UE id ",
-              ue_id)
+        print(
+            "************************* Running End to End attach for UE id ",
+            ue_id,
+        )
         # Now actually complete the attach
         self._s1ap_wrapper.s1_util.attach(
             ue_id, s1ap_types.tfwCmd.UE_END_TO_END_ATTACH_REQUEST,
             s1ap_types.tfwCmd.UE_ATTACH_ACCEPT_IND,
-            s1ap_types.ueAttachAccept_t)
+            s1ap_types.ueAttachAccept_t,
+        )
 
         # Wait on EMM Information from MME
         self._s1ap_wrapper._s1_util.receive_emm_info()
@@ -51,29 +53,37 @@ class TestAttachDetachEmmStatusMsg(unittest.TestCase):
         emm_status.ue_Id = ue_id
         emm_status.cause = s1ap_types.TFW_EMM_CAUSE_INV_MSG_TYPE
         self._s1ap_wrapper.s1_util.issue_cmd(
-            s1ap_types.tfwCmd.UE_EMM_STATUS, emm_status)
+            s1ap_types.tfwCmd.UE_EMM_STATUS, emm_status,
+        )
         # Delay to ensure S1APTester sends attach complete before sending UE
         # context release
         time.sleep(0.5)
 
-        print("************************* Sending UE context release request ",
-              "for UE id ", ue_id)
+        print(
+            "************************* Sending UE context release request ",
+            "for UE id ", ue_id,
+        )
         # Send UE context release request to move UE to idle mode
         req = s1ap_types.ueCntxtRelReq_t()
         req.ue_Id = ue_id
         req.cause.causeVal = gpp_types.CauseRadioNetwork.USER_INACTIVITY.value
         self._s1ap_wrapper.s1_util.issue_cmd(
-            s1ap_types.tfwCmd.UE_CNTXT_REL_REQUEST, req)
+            s1ap_types.tfwCmd.UE_CNTXT_REL_REQUEST, req,
+        )
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_CTX_REL_IND.value)
+            response.msg_type, s1ap_types.tfwCmd.UE_CTX_REL_IND.value,
+        )
 
-        print("************************* Running UE detach (switch-off) for ",
-              "UE id ", ue_id)
+        print(
+            "************************* Running UE detach (switch-off) for ",
+            "UE id ", ue_id,
+        )
         time.sleep(10)
         # Now detach the UE
         self._s1ap_wrapper.s1_util.detach(
-            ue_id, s1ap_types.ueDetachType_t.UE_SWITCHOFF_DETACH.value, False)
+            ue_id, s1ap_types.ueDetachType_t.UE_SWITCHOFF_DETACH.value, False,
+        )
 
 
 if __name__ == "__main__":

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_enb_rlf_initial_ue_msg.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_enb_rlf_initial_ue_msg.py
@@ -12,12 +12,12 @@ limitations under the License.
 """
 
 
+import time
 import unittest
 
+import gpp_types
 import s1ap_types
 import s1ap_wrapper
-import time
-import gpp_types
 
 
 class TestAttachEnbRlf(unittest.TestCase):
@@ -28,7 +28,7 @@ class TestAttachEnbRlf(unittest.TestCase):
         self._s1ap_wrapper.cleanup()
         print(
             "Restart sctpd service to clear Redis state as test case doesn't"
-            " intend to initiate detach procedure"
+            " intend to initiate detach procedure",
         )
         self._s1ap_wrapper.magmad_util.restart_sctpd()
         self._s1ap_wrapper.magmad_util.print_redis_state()
@@ -56,11 +56,11 @@ class TestAttachEnbRlf(unittest.TestCase):
         print("***Triggering Attach Request ***")
 
         self._s1ap_wrapper._s1_util.issue_cmd(
-            s1ap_types.tfwCmd.UE_ATTACH_REQUEST, attach_req
+            s1ap_types.tfwCmd.UE_ATTACH_REQUEST, attach_req,
         )
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_AUTH_REQ_IND.value
+            response.msg_type, s1ap_types.tfwCmd.UE_AUTH_REQ_IND.value,
         )
 
         # Trigger Authentication Response
@@ -70,34 +70,34 @@ class TestAttachEnbRlf(unittest.TestCase):
         sqnRecvd.pres = 0
         auth_res.sqnRcvd = sqnRecvd
         self._s1ap_wrapper._s1_util.issue_cmd(
-            s1ap_types.tfwCmd.UE_AUTH_RESP, auth_res
+            s1ap_types.tfwCmd.UE_AUTH_RESP, auth_res,
         )
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_SEC_MOD_CMD_IND.value
+            response.msg_type, s1ap_types.tfwCmd.UE_SEC_MOD_CMD_IND.value,
         )
 
         # Trigger Security Mode Complete
         sec_mode_complete = s1ap_types.ueSecModeComplete_t()
         sec_mode_complete.ue_Id = 1
         self._s1ap_wrapper._s1_util.issue_cmd(
-            s1ap_types.tfwCmd.UE_SEC_MOD_COMPLETE, sec_mode_complete
+            s1ap_types.tfwCmd.UE_SEC_MOD_COMPLETE, sec_mode_complete,
         )
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.INT_CTX_SETUP_IND.value
+            response.msg_type, s1ap_types.tfwCmd.INT_CTX_SETUP_IND.value,
         )
 
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_ATTACH_ACCEPT_IND.value
+            response.msg_type, s1ap_types.tfwCmd.UE_ATTACH_ACCEPT_IND.value,
         )
 
         # Trigger Attach Complete
         attach_complete = s1ap_types.ueAttachComplete_t()
         attach_complete.ue_Id = 1
         self._s1ap_wrapper._s1_util.issue_cmd(
-            s1ap_types.tfwCmd.UE_ATTACH_COMPLETE, attach_complete
+            s1ap_types.tfwCmd.UE_ATTACH_COMPLETE, attach_complete,
         )
 
         print("***Triggering Re-Attach Request ***")
@@ -111,7 +111,7 @@ class TestAttachEnbRlf(unittest.TestCase):
         attach_req.epsAttachType = eps_type
         attach_req.useOldSecCtxt = sec_ctxt
         self._s1ap_wrapper._s1_util.issue_cmd(
-            s1ap_types.tfwCmd.UE_ATTACH_REQUEST, attach_req
+            s1ap_types.tfwCmd.UE_ATTACH_REQUEST, attach_req,
         )
 
         # Send UE context release request with cause Radio Link Failure
@@ -121,7 +121,7 @@ class TestAttachEnbRlf(unittest.TestCase):
             gpp_types.CauseRadioNetwork.RADIO_CONNECTION_WITH_UE_LOST.value
         )
         self._s1ap_wrapper.s1_util.issue_cmd(
-            s1ap_types.tfwCmd.UE_CNTXT_REL_REQUEST, ue_ctxt_rel_req
+            s1ap_types.tfwCmd.UE_CNTXT_REL_REQUEST, ue_ctxt_rel_req,
         )
         time.sleep(1)
 

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_looped.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_looped.py
@@ -30,27 +30,35 @@ class TestAttachDetachLooped(unittest.TestCase):
         Multiple-attach/detach test with a single UE attached at a given time
         """
         num_repeats = 10
-        detach_type = [s1ap_types.ueDetachType_t.UE_NORMAL_DETACH.value,
-                       s1ap_types.ueDetachType_t.UE_SWITCHOFF_DETACH.value]
+        detach_type = [
+            s1ap_types.ueDetachType_t.UE_NORMAL_DETACH.value,
+            s1ap_types.ueDetachType_t.UE_SWITCHOFF_DETACH.value,
+        ]
         self._s1ap_wrapper.configUEDevice(1)
         req = self._s1ap_wrapper.ue_req
         for iteration in range(num_repeats):
-            print("************************* Running End to End attach for ",
-                  "UE id ", req.ue_id)
+            print(
+                "************************* Running End to End attach for ",
+                "UE id ", req.ue_id,
+            )
             # Now actually complete the attach
             self._s1ap_wrapper._s1_util.attach(
                 req.ue_id, s1ap_types.tfwCmd.UE_END_TO_END_ATTACH_REQUEST,
                 s1ap_types.tfwCmd.UE_ATTACH_ACCEPT_IND,
-                s1ap_types.ueAttachAccept_t)
+                s1ap_types.ueAttachAccept_t,
+            )
             # Wait on EMM Information from MME
             self._s1ap_wrapper._s1_util.receive_emm_info()
 
-            print("************************* Running UE detach for UE id ",
-                  req.ue_id)
+            print(
+                "************************* Running UE detach for UE id ",
+                req.ue_id,
+            )
 
             # Now detach the UE
             self._s1ap_wrapper.s1_util.detach(
-                req.ue_id, detach_type[iteration % 2], True)
+                req.ue_id, detach_type[iteration % 2], True,
+            )
 
 
 if __name__ == "__main__":

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_multi_ue.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_multi_ue.py
@@ -13,7 +13,6 @@ limitations under the License.
 
 import unittest
 
-
 import s1ap_types
 import s1ap_wrapper
 
@@ -33,13 +32,16 @@ class TestAttachDetachMultiUe(unittest.TestCase):
         self._s1ap_wrapper.configUEDevice(num_ues)
         for _ in range(num_ues):
             req = self._s1ap_wrapper.ue_req
-            print("************************* Calling attach for UE id ",
-                  req.ue_id)
+            print(
+                "************************* Calling attach for UE id ",
+                req.ue_id,
+            )
             self._s1ap_wrapper.s1_util.attach(
                 req.ue_id,
                 s1ap_types.tfwCmd.UE_END_TO_END_ATTACH_REQUEST,
                 s1ap_types.tfwCmd.UE_ATTACH_ACCEPT_IND,
-                s1ap_types.ueAttachAccept_t)
+                s1ap_types.ueAttachAccept_t,
+            )
             # Wait on EMM Information from MME
             self._s1ap_wrapper._s1_util.receive_emm_info()
             ue_ids.append(req.ue_id)
@@ -48,7 +50,8 @@ class TestAttachDetachMultiUe(unittest.TestCase):
             print("************************* Calling detach for UE id ", ue)
             self._s1ap_wrapper.s1_util.detach(
                 ue,
-                s1ap_types.ueDetachType_t.UE_NORMAL_DETACH.value)
+                s1ap_types.ueDetachType_t.UE_NORMAL_DETACH.value,
+            )
 
 
 if __name__ == "__main__":

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_multi_ue_looped.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_multi_ue_looped.py
@@ -31,29 +31,37 @@ class TestAttachDetachMultiUeLooped(unittest.TestCase):
         """
         num_ues = 16
         num_repeats = 10
-        detach_type = [s1ap_types.ueDetachType_t.UE_NORMAL_DETACH.value,
-                       s1ap_types.ueDetachType_t.UE_SWITCHOFF_DETACH.value]
+        detach_type = [
+            s1ap_types.ueDetachType_t.UE_NORMAL_DETACH.value,
+            s1ap_types.ueDetachType_t.UE_SWITCHOFF_DETACH.value,
+        ]
         self._s1ap_wrapper.configUEDevice(num_ues)
         reqs = tuple(self._s1ap_wrapper.ue_req for _ in range(num_ues))
         for iteration in range(num_repeats):
             for req in reqs:
-                print("************************* Running End to End attach ",
-                      "for UE id ", req.ue_id)
+                print(
+                    "************************* Running End to End attach ",
+                    "for UE id ", req.ue_id,
+                )
                 # Now actually complete the attach
                 self._s1ap_wrapper._s1_util.attach(
                     req.ue_id, s1ap_types.tfwCmd.UE_END_TO_END_ATTACH_REQUEST,
                     s1ap_types.tfwCmd.UE_ATTACH_ACCEPT_IND,
-                    s1ap_types.ueAttachAccept_t)
+                    s1ap_types.ueAttachAccept_t,
+                )
 
                 # Wait on EMM Information from MME
                 self._s1ap_wrapper._s1_util.receive_emm_info()
 
             for req in reqs:
-                print("************************* Running UE detach for UE id ",
-                      req.ue_id)
+                print(
+                    "************************* Running UE detach for UE id ",
+                    req.ue_id,
+                )
                 # Now detach the UE
                 self._s1ap_wrapper.s1_util.detach(
-                    req.ue_id, detach_type[iteration % 2], True)
+                    req.ue_id, detach_type[iteration % 2], True,
+                )
 
 
 if __name__ == "__main__":

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_multiple_ip_blocks_mobilityd_restart.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_multiple_ip_blocks_mobilityd_restart.py
@@ -18,10 +18,12 @@ import s1ap_types
 import s1ap_wrapper
 from s1ap_utils import MagmadUtil
 
+
 class TestAttachDetachMultipleIpBlocksMobilitydRestart(unittest.TestCase):
     def setUp(self):
         self._s1ap_wrapper = s1ap_wrapper.TestWrapper(
-            stateless_mode=MagmadUtil.stateless_cmds.ENABLE)
+            stateless_mode=MagmadUtil.stateless_cmds.ENABLE,
+        )
         self._ip_block = '192.168.125.0/24'
 
     def tearDown(self):
@@ -35,7 +37,8 @@ class TestAttachDetachMultipleIpBlocksMobilitydRestart(unittest.TestCase):
         self._s1ap_wrapper.configUEDevice(1)
 
         self._s1ap_wrapper.mobility_util.add_ip_block(
-            self._ip_block)
+            self._ip_block,
+        )
 
         old_blocks = self._s1ap_wrapper.mobility_util.list_ip_blocks()
         assert len(old_blocks) == 2, "2 IP blocks should be allocated on " \
@@ -53,15 +56,18 @@ class TestAttachDetachMultipleIpBlocksMobilitydRestart(unittest.TestCase):
         self.assertListEqual(old_blocks, curr_blocks)
 
         req = self._s1ap_wrapper.ue_req
-        print("************************* Running End to End attach for ",
-              "UE id ", req.ue_id)
+        print(
+            "************************* Running End to End attach for ",
+            "UE id ", req.ue_id,
+        )
 
         # Now actually attempt the attach
         self._s1ap_wrapper.s1_util.attach(
             req.ue_id,
             s1ap_types.tfwCmd.UE_END_TO_END_ATTACH_REQUEST,
             s1ap_types.tfwCmd.UE_ATTACH_ACCEPT_IND,
-            s1ap_types.ueAttachAccept_t)
+            s1ap_types.ueAttachAccept_t,
+        )
 
         # Wait on EMM Information from MME
         self._s1ap_wrapper._s1_util.receive_emm_info()
@@ -69,7 +75,8 @@ class TestAttachDetachMultipleIpBlocksMobilitydRestart(unittest.TestCase):
         # Detach previously attached UE
         self._s1ap_wrapper.s1_util.detach(
             req.ue_id,
-            s1ap_types.ueDetachType_t.UE_NORMAL_DETACH.value)
+            s1ap_types.ueDetachType_t.UE_NORMAL_DETACH.value,
+        )
 
 
 if __name__ == "__main__":

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_multiple_rar_tcp_data.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_multiple_rar_tcp_data.py
@@ -11,14 +11,17 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-import unittest
-import s1ap_types
 import time
+import unittest
 
+import s1ap_types
 from integ_tests.s1aptests import s1ap_wrapper
-from integ_tests.s1aptests.s1ap_utils import SpgwUtil, GTPBridgeUtils
-from integ_tests.s1aptests.s1ap_utils import SessionManagerUtil
 from integ_tests.s1aptests.ovs.rest_api import get_datapath, get_flows
+from integ_tests.s1aptests.s1ap_utils import (
+    GTPBridgeUtils,
+    SessionManagerUtil,
+    SpgwUtil,
+)
 from lte.protos.policydb_pb2 import FlowMatch
 
 
@@ -190,17 +193,17 @@ class TestAttachDetachMultipleRarTcpData(unittest.TestCase):
             # Receive Activate dedicated bearer request
             response = self._s1ap_wrapper.s1_util.get_response()
             self.assertEqual(
-                response.msg_type, s1ap_types.tfwCmd.UE_ACT_DED_BER_REQ.value
+                response.msg_type, s1ap_types.tfwCmd.UE_ACT_DED_BER_REQ.value,
             )
             act_ded_ber_ctxt_req1 = response.cast(
-                s1ap_types.UeActDedBearCtxtReq_t
+                s1ap_types.UeActDedBearCtxtReq_t,
             )
 
             print("Sleeping for 5 seconds")
             time.sleep(5)
             # Send Activate dedicated bearer accept
             self._s1ap_wrapper.sendActDedicatedBearerAccept(
-                req.ue_id, act_ded_ber_ctxt_req1.bearerId
+                req.ue_id, act_ded_ber_ctxt_req1.bearerId,
             )
 
             print(
@@ -218,17 +221,17 @@ class TestAttachDetachMultipleRarTcpData(unittest.TestCase):
             # Receive Activate dedicated bearer request
             response = self._s1ap_wrapper.s1_util.get_response()
             self.assertEqual(
-                response.msg_type, s1ap_types.tfwCmd.UE_ACT_DED_BER_REQ.value
+                response.msg_type, s1ap_types.tfwCmd.UE_ACT_DED_BER_REQ.value,
             )
             act_ded_ber_ctxt_req2 = response.cast(
-                s1ap_types.UeActDedBearCtxtReq_t
+                s1ap_types.UeActDedBearCtxtReq_t,
             )
 
             print("Sleeping for 5 seconds")
             time.sleep(5)
             # Send Activate dedicated bearer accept
             self._s1ap_wrapper.sendActDedicatedBearerAccept(
-                req.ue_id, act_ded_ber_ctxt_req2.bearerId
+                req.ue_id, act_ded_ber_ctxt_req2.bearerId,
             )
 
             # Check if UL and DL OVS flows are created
@@ -292,7 +295,7 @@ class TestAttachDetachMultipleRarTcpData(unittest.TestCase):
                 and action["type"] == "SET_FIELD"
             )
             self.assertTrue(
-                has_tunnel_action, "Downlink flow missing set tunnel action"
+                has_tunnel_action, "Downlink flow missing set tunnel action",
             )
 
             with self._s1ap_wrapper.configUplinkTest(req, duration=1) as test:
@@ -321,7 +324,7 @@ class TestAttachDetachMultipleRarTcpData(unittest.TestCase):
 
             deactv_bearer_req = response.cast(s1ap_types.UeDeActvBearCtxtReq_t)
             self._s1ap_wrapper.sendDeactDedicatedBearerAccept(
-                req.ue_id, deactv_bearer_req.bearerId
+                req.ue_id, deactv_bearer_req.bearerId,
             )
 
             print("Sleeping for 5 seconds")
@@ -333,7 +336,7 @@ class TestAttachDetachMultipleRarTcpData(unittest.TestCase):
             )
             # Now detach the UE
             self._s1ap_wrapper.s1_util.detach(
-                req.ue_id, detach_type[i], wait_for_s1[i]
+                req.ue_id, detach_type[i], wait_for_s1[i],
             )
 
         # Verify that all UL/DL flows are deleted

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_multiple_secondary_pdn.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_multiple_secondary_pdn.py
@@ -11,8 +11,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-import unittest
 import time
+import unittest
 
 import s1ap_types
 import s1ap_wrapper
@@ -60,7 +60,7 @@ class TestMultipleSecondaryPdnConnReq(unittest.TestCase):
         apn_list = [ims, internet]
 
         self._s1ap_wrapper.configAPN(
-            "IMSI" + "".join([str(i) for i in req.imsi]), apn_list
+            "IMSI" + "".join([str(i) for i in req.imsi]), apn_list,
         )
         print(
             "*********************** Running End to End attach for UE id ",
@@ -86,7 +86,7 @@ class TestMultipleSecondaryPdnConnReq(unittest.TestCase):
             # Receive PDN CONN RSP/Activate default EPS bearer context request
             response = self._s1ap_wrapper.s1_util.get_response()
             self.assertEqual(
-                response.msg_type, s1ap_types.tfwCmd.UE_PDN_CONN_RSP_IND.value
+                response.msg_type, s1ap_types.tfwCmd.UE_PDN_CONN_RSP_IND.value,
             )
             act_def_bearer_req = response.cast(s1ap_types.uePdnConRsp_t)
 
@@ -113,7 +113,7 @@ class TestMultipleSecondaryPdnConnReq(unittest.TestCase):
                 pdn_disconnect_req.epsBearerId,
             )
             self._s1ap_wrapper._s1_util.issue_cmd(
-                s1ap_types.tfwCmd.UE_PDN_DISCONNECT_REQ, pdn_disconnect_req
+                s1ap_types.tfwCmd.UE_PDN_DISCONNECT_REQ, pdn_disconnect_req,
             )
 
             # Receive UE_DEACTIVATE_BER_REQ
@@ -125,11 +125,11 @@ class TestMultipleSecondaryPdnConnReq(unittest.TestCase):
 
             print(
                 "******************* Received deactivate eps bearer context"
-                " request"
+                " request",
             )
             # Send DeactDedicatedBearerAccept
             self._s1ap_wrapper.sendDeactDedicatedBearerAccept(
-                ue_id, bearer_ids[i]
+                ue_id, bearer_ids[i],
             )
 
         print(
@@ -139,7 +139,7 @@ class TestMultipleSecondaryPdnConnReq(unittest.TestCase):
         )
         # Now detach the UE
         self._s1ap_wrapper.s1_util.detach(
-            ue_id, s1ap_types.ueDetachType_t.UE_SWITCHOFF_DETACH.value, False
+            ue_id, s1ap_types.ueDetachType_t.UE_SWITCHOFF_DETACH.value, False,
         )
 
 

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_no_ueContext_release_comp.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_no_ueContext_release_comp.py
@@ -11,11 +11,11 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
+import time
 import unittest
 
 import s1ap_types
 import s1ap_wrapper
-import time
 
 
 class TestAttachDetachNoUeContextReleseComp(unittest.TestCase):
@@ -32,33 +32,42 @@ class TestAttachDetachNoUeContextReleseComp(unittest.TestCase):
         self._s1ap_wrapper.configUEDevice(1)
         req = self._s1ap_wrapper.ue_req
         ue_id = req.ue_id
-        print("************************ Running End to End attach for ",
-              "UE id ", ue_id)
+        print(
+            "************************ Running End to End attach for ",
+            "UE id ", ue_id,
+        )
         # Now actually complete the attach
         self._s1ap_wrapper._s1_util.attach(
                 ue_id, s1ap_types.tfwCmd.UE_END_TO_END_ATTACH_REQUEST,
                 s1ap_types.tfwCmd.UE_ATTACH_ACCEPT_IND,
-                s1ap_types.ueAttachAccept_t)
+                s1ap_types.ueAttachAccept_t,
+        )
 
         # Wait on EMM Information from MME
         self._s1ap_wrapper._s1_util.receive_emm_info()
-        print("************************* Running UE detach for ",
-              "UE id", ue_id)
+        print(
+            "************************* Running UE detach for ",
+            "UE id", ue_id,
+        )
         # Now detach the UE
         detach_req = s1ap_types.uedetachReq_t()
         detach_req.ue_Id = req.ue_id
         detach_req.ueDetType = s1ap_types.ueDetachType_t.UE_NORMAL_DETACH.value
         self._s1ap_wrapper._s1_util.issue_cmd(
-             s1ap_types.tfwCmd.UE_DETACH_REQUEST, detach_req)
+             s1ap_types.tfwCmd.UE_DETACH_REQUEST, detach_req,
+        )
         response = self._s1ap_wrapper._s1_util.get_response()
-        assert (s1ap_types.tfwCmd.UE_DETACH_ACCEPT_IND.value ==
-                response.msg_type)
+        assert (
+            s1ap_types.tfwCmd.UE_DETACH_ACCEPT_IND.value ==
+            response.msg_type
+        )
         time.sleep(0.1)
         # Send SCTP ABORT to MME
         sctp_abort = s1ap_types.FwSctpAbortReq_t()
         sctp_abort.cause = 0
         self._s1ap_wrapper.s1_util.issue_cmd(
-             s1ap_types.tfwCmd.SCTP_ABORT_REQ, sctp_abort)
+             s1ap_types.tfwCmd.SCTP_ABORT_REQ, sctp_abort,
+        )
 
 
 if __name__ == "__main__":

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_ps_service_not_available.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_ps_service_not_available.py
@@ -11,13 +11,12 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
+import time
 import unittest
-
 
 import gpp_types
 import s1ap_types
 import s1ap_wrapper
-import time
 
 
 class TestUeContextReleaseWithCausePsServiceNotAvailable(unittest.TestCase):
@@ -34,13 +33,16 @@ class TestUeContextReleaseWithCausePsServiceNotAvailable(unittest.TestCase):
         self._s1ap_wrapper.configUEDevice(1)
         req = self._s1ap_wrapper.ue_req
         ue_id = req.ue_id
-        print("************************* Running End to End attach for UE id ",
-              ue_id)
+        print(
+            "************************* Running End to End attach for UE id ",
+            ue_id,
+        )
         # Now actually complete the attach
         self._s1ap_wrapper.s1_util.attach(
             ue_id, s1ap_types.tfwCmd.UE_END_TO_END_ATTACH_REQUEST,
             s1ap_types.tfwCmd.UE_ATTACH_ACCEPT_IND,
-            s1ap_types.ueAttachAccept_t)
+            s1ap_types.ueAttachAccept_t,
+        )
 
         # Wait on EMM Information from MME
         self._s1ap_wrapper._s1_util.receive_emm_info()
@@ -49,27 +51,36 @@ class TestUeContextReleaseWithCausePsServiceNotAvailable(unittest.TestCase):
         # context release
         time.sleep(0.5)
 
-        print("************************* Sending UE context release request ",
-              "for UE id ", ue_id)
+        print(
+            "************************* Sending UE context release request ",
+            "for UE id ", ue_id,
+        )
         # Send UE context release request to move UE to
         # idle mode with Cause PS Service Not Available
         req = s1ap_types.ueCntxtRelReq_t()
         req.ue_Id = ue_id
-        req.cause.causeVal = (gpp_types.
-                              CauseRadioNetwork.
-                              UE_NOT_AVAILABLE_FOR_PS_SERVICE.value)
+        req.cause.causeVal = (
+            gpp_types.
+            CauseRadioNetwork.
+            UE_NOT_AVAILABLE_FOR_PS_SERVICE.value
+        )
         self._s1ap_wrapper.s1_util.issue_cmd(
-            s1ap_types.tfwCmd.UE_CNTXT_REL_REQUEST, req)
+            s1ap_types.tfwCmd.UE_CNTXT_REL_REQUEST, req,
+        )
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_CTX_REL_IND.value)
+            response.msg_type, s1ap_types.tfwCmd.UE_CTX_REL_IND.value,
+        )
 
-        print("************************* Running UE detach (switch-off) for ",
-              "UE id ", ue_id)
+        print(
+            "************************* Running UE detach (switch-off) for ",
+            "UE id ", ue_id,
+        )
         time.sleep(10)
         # Now detach the UE
         self._s1ap_wrapper.s1_util.detach(
-            ue_id, s1ap_types.ueDetachType_t.UE_SWITCHOFF_DETACH.value, False)
+            ue_id, s1ap_types.ueDetachType_t.UE_SWITCHOFF_DETACH.value, False,
+        )
 
 
 if __name__ == "__main__":

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_rar_activation_reject.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_rar_activation_reject.py
@@ -11,10 +11,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-import unittest
-import s1ap_types
 import time
+import unittest
 
+import s1ap_types
 from integ_tests.s1aptests import s1ap_wrapper
 from integ_tests.s1aptests.s1ap_utils import SessionManagerUtil
 from lte.protos.policydb_pb2 import FlowMatch
@@ -96,21 +96,21 @@ class TestAttachDetachRarActivationReject(unittest.TestCase):
 
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_ACT_DED_BER_REQ.value
+            response.msg_type, s1ap_types.tfwCmd.UE_ACT_DED_BER_REQ.value,
         )
         act_ded_ber_ctxt_req = response.cast(
-            s1ap_types.UeActDedBearCtxtReq_t
+            s1ap_types.UeActDedBearCtxtReq_t,
         )
         ded_bearer_rej = s1ap_types.UeActDedBearCtxtRej_t()
         ded_bearer_rej.ue_Id = req.ue_id
         ded_bearer_rej.bearerId = act_ded_ber_ctxt_req.bearerId
         time.sleep(15)
         print(
-            "********************** Sending activation Reject"
+            "********************** Sending activation Reject",
         )
         # Send Bearer Activation Reject
         self._s1ap_wrapper._s1_util.issue_cmd(
-            s1ap_types.tfwCmd.UE_ACT_DED_BER_REJ, ded_bearer_rej
+            s1ap_types.tfwCmd.UE_ACT_DED_BER_REJ, ded_bearer_rej,
         )
 
         time.sleep(15)
@@ -120,7 +120,7 @@ class TestAttachDetachRarActivationReject(unittest.TestCase):
         )
         # Now detach the UE
         self._s1ap_wrapper.s1_util.detach(
-            req.ue_id, s1ap_types.ueDetachType_t.UE_NORMAL_DETACH.value, True
+            req.ue_id, s1ap_types.ueDetachType_t.UE_NORMAL_DETACH.value, True,
         )
 
 

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_rar_tcp_data.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_rar_tcp_data.py
@@ -11,14 +11,17 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-import unittest
-import s1ap_types
 import time
+import unittest
 
+import s1ap_types
 from integ_tests.s1aptests import s1ap_wrapper
-from integ_tests.s1aptests.s1ap_utils import SpgwUtil
-from integ_tests.s1aptests.s1ap_utils import SessionManagerUtil, GTPBridgeUtils
 from integ_tests.s1aptests.ovs.rest_api import get_datapath, get_flows
+from integ_tests.s1aptests.s1ap_utils import (
+    GTPBridgeUtils,
+    SessionManagerUtil,
+    SpgwUtil,
+)
 from lte.protos.policydb_pb2 import FlowMatch
 
 
@@ -174,17 +177,17 @@ class TestAttachDetachRarTcpData(unittest.TestCase):
             # Receive Activate dedicated bearer request
             response = self._s1ap_wrapper.s1_util.get_response()
             self.assertEqual(
-                response.msg_type, s1ap_types.tfwCmd.UE_ACT_DED_BER_REQ.value
+                response.msg_type, s1ap_types.tfwCmd.UE_ACT_DED_BER_REQ.value,
             )
             act_ded_ber_ctxt_req = response.cast(
-                s1ap_types.UeActDedBearCtxtReq_t
+                s1ap_types.UeActDedBearCtxtReq_t,
             )
 
             print("Sleeping for 5 seconds")
             time.sleep(5)
             # Send Activate dedicated bearer accept
             self._s1ap_wrapper.sendActDedicatedBearerAccept(
-                req.ue_id, act_ded_ber_ctxt_req.bearerId
+                req.ue_id, act_ded_ber_ctxt_req.bearerId,
             )
             print("Sleeping again for flow to be installed")
             time.sleep(2)
@@ -250,7 +253,7 @@ class TestAttachDetachRarTcpData(unittest.TestCase):
                 and action["type"] == "SET_FIELD"
             )
             self.assertTrue(
-                has_tunnel_action, "Downlink flow missing set tunnel action"
+                has_tunnel_action, "Downlink flow missing set tunnel action",
             )
 
             print("Sleeping for 5 seconds")
@@ -263,7 +266,7 @@ class TestAttachDetachRarTcpData(unittest.TestCase):
                 "".join([str(i) for i in req.imsi]),
             )
             self._spgw_util.delete_bearer(
-                "IMSI" + "".join([str(i) for i in req.imsi]), 5, 6
+                "IMSI" + "".join([str(i) for i in req.imsi]), 5, 6,
             )
 
             response = self._s1ap_wrapper.s1_util.get_response()
@@ -276,7 +279,7 @@ class TestAttachDetachRarTcpData(unittest.TestCase):
 
             deactv_bearer_req = response.cast(s1ap_types.UeDeActvBearCtxtReq_t)
             self._s1ap_wrapper.sendDeactDedicatedBearerAccept(
-                req.ue_id, deactv_bearer_req.bearerId
+                req.ue_id, deactv_bearer_req.bearerId,
             )
 
             print("Sleeping for 5 seconds")
@@ -288,12 +291,11 @@ class TestAttachDetachRarTcpData(unittest.TestCase):
             )
             # Now detach the UE
             self._s1ap_wrapper.s1_util.detach(
-                req.ue_id, detach_type[i], wait_for_s1[i]
+                req.ue_id, detach_type[i], wait_for_s1[i],
             )
 
         # Verify that all UL/DL flows are deleted
         self._s1ap_wrapper.s1_util.verify_flow_rules_deletion()
-
 
 
 if __name__ == "__main__":

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_rar_tcp_he.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_rar_tcp_he.py
@@ -11,14 +11,18 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-import unittest
-import s1ap_types
 import time
+import unittest
 
+import s1ap_types
 from integ_tests.s1aptests import s1ap_wrapper
-from integ_tests.s1aptests.s1ap_utils import SpgwUtil, HeaderEnrichmentUtils
-from integ_tests.s1aptests.s1ap_utils import SessionManagerUtil, GTPBridgeUtils
 from integ_tests.s1aptests.ovs.rest_api import get_datapath, get_flows
+from integ_tests.s1aptests.s1ap_utils import (
+    GTPBridgeUtils,
+    HeaderEnrichmentUtils,
+    SessionManagerUtil,
+    SpgwUtil,
+)
 from lte.protos.policydb_pb2 import FlowMatch, HeaderEnrichment
 
 
@@ -53,7 +57,6 @@ class TestAttachDetachRarTcpDataWithHE(unittest.TestCase):
         gtp_br_util = GTPBridgeUtils()
         GTP_PORT = gtp_br_util.get_gtp_port_no()
         utils = HeaderEnrichmentUtils()
-
 
         for i in range(num_ues):
             req = self._s1ap_wrapper.ue_req
@@ -169,7 +172,8 @@ class TestAttachDetachRarTcpDataWithHE(unittest.TestCase):
             imsi = "IMSI" + "".join([str(i) for i in req.imsi])
 
             print(
-                "********************** Sending RAR for ", imsi)
+                "********************** Sending RAR for ", imsi,
+            )
             he_domain1 = "192.168.128.1"
             assert utils.he_count_record_of_imsi_to_domain(imsi, he_domain1) == 0
 
@@ -184,17 +188,17 @@ class TestAttachDetachRarTcpDataWithHE(unittest.TestCase):
             # Receive Activate dedicated bearer request
             response = self._s1ap_wrapper.s1_util.get_response()
             self.assertEqual(
-                response.msg_type, s1ap_types.tfwCmd.UE_ACT_DED_BER_REQ.value
+                response.msg_type, s1ap_types.tfwCmd.UE_ACT_DED_BER_REQ.value,
             )
             act_ded_ber_ctxt_req = response.cast(
-                s1ap_types.UeActDedBearCtxtReq_t
+                s1ap_types.UeActDedBearCtxtReq_t,
             )
 
             print("Sleeping for 5 seconds")
             time.sleep(5)
             # Send Activate dedicated bearer accept
             self._s1ap_wrapper.sendActDedicatedBearerAccept(
-                req.ue_id, act_ded_ber_ctxt_req.bearerId
+                req.ue_id, act_ded_ber_ctxt_req.bearerId,
             )
 
             # Check if UL and DL OVS flows are created
@@ -258,7 +262,7 @@ class TestAttachDetachRarTcpDataWithHE(unittest.TestCase):
                 and action["type"] == "SET_FIELD"
             )
             self.assertTrue(
-                has_tunnel_action, "Downlink flow missing set tunnel action"
+                has_tunnel_action, "Downlink flow missing set tunnel action",
             )
 
             print("Sleeping for 5 seconds")
@@ -272,7 +276,7 @@ class TestAttachDetachRarTcpDataWithHE(unittest.TestCase):
                 "".join([str(i) for i in req.imsi]),
             )
             self._spgw_util.delete_bearer(
-                "IMSI" + "".join([str(i) for i in req.imsi]), 5, 6
+                "IMSI" + "".join([str(i) for i in req.imsi]), 5, 6,
             )
 
             response = self._s1ap_wrapper.s1_util.get_response()
@@ -285,7 +289,7 @@ class TestAttachDetachRarTcpDataWithHE(unittest.TestCase):
 
             deactv_bearer_req = response.cast(s1ap_types.UeDeActvBearCtxtReq_t)
             self._s1ap_wrapper.sendDeactDedicatedBearerAccept(
-                req.ue_id, deactv_bearer_req.bearerId
+                req.ue_id, deactv_bearer_req.bearerId,
             )
 
             print("Sleeping for 5 seconds")
@@ -297,7 +301,7 @@ class TestAttachDetachRarTcpDataWithHE(unittest.TestCase):
             )
             # Now detach the UE
             self._s1ap_wrapper.s1_util.detach(
-                req.ue_id, detach_type[i], wait_for_s1[i]
+                req.ue_id, detach_type[i], wait_for_s1[i],
             )
 
             time.sleep(20)
@@ -305,6 +309,7 @@ class TestAttachDetachRarTcpDataWithHE(unittest.TestCase):
 
         # Verify that all UL/DL flows are deleted
         self._s1ap_wrapper.s1_util.verify_flow_rules_deletion()
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_security_algo_eea0_eia0.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_security_algo_eea0_eia0.py
@@ -14,7 +14,6 @@ limitations under the License.
 import unittest
 
 import s1ap_types
-
 from integ_tests.s1aptests import s1ap_wrapper
 
 
@@ -78,7 +77,7 @@ class TestAttachDetachSecurityAlgoEea0Eia0(unittest.TestCase):
             )
             # Now detach the UE
             self._s1ap_wrapper.s1_util.detach(
-                req.ue_id, detach_type[i], wait_for_s1[i]
+                req.ue_id, detach_type[i], wait_for_s1[i],
             )
 
 

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_security_algo_eea1_eia1.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_security_algo_eea1_eia1.py
@@ -14,7 +14,6 @@ limitations under the License.
 import unittest
 
 import s1ap_types
-
 from integ_tests.s1aptests import s1ap_wrapper
 
 
@@ -78,7 +77,7 @@ class TestAttachDetachSecurityAlgoEea1Eia1(unittest.TestCase):
             )
             # Now detach the UE
             self._s1ap_wrapper.s1_util.detach(
-                req.ue_id, detach_type[i], wait_for_s1[i]
+                req.ue_id, detach_type[i], wait_for_s1[i],
             )
 
 

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_security_algo_eea2_eia2.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_security_algo_eea2_eia2.py
@@ -14,7 +14,6 @@ limitations under the License.
 import unittest
 
 import s1ap_types
-
 from integ_tests.s1aptests import s1ap_wrapper
 
 
@@ -78,7 +77,7 @@ class TestAttachDetachSecurityAlgoEea2Eia2(unittest.TestCase):
             )
             # Now detach the UE
             self._s1ap_wrapper.s1_util.detach(
-                req.ue_id, detach_type[i], wait_for_s1[i]
+                req.ue_id, detach_type[i], wait_for_s1[i],
             )
 
 

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_service.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_service.py
@@ -32,25 +32,33 @@ class TestAttachDetachService(unittest.TestCase):
         self._s1ap_wrapper.configUEDevice(1)
         req = self._s1ap_wrapper.ue_req
         ue_id = req.ue_id
-        print("************************* Running End to End attach for UE id ",
-              ue_id)
+        print(
+            "************************* Running End to End attach for UE id ",
+            ue_id,
+        )
         # Now actually complete the attach
         self._s1ap_wrapper._s1_util.attach(
             ue_id, s1ap_types.tfwCmd.UE_END_TO_END_ATTACH_REQUEST,
             s1ap_types.tfwCmd.UE_ATTACH_ACCEPT_IND,
-            s1ap_types.ueAttachAccept_t)
+            s1ap_types.ueAttachAccept_t,
+        )
 
         # Wait on EMM Information from MME
         self._s1ap_wrapper._s1_util.receive_emm_info()
 
-        print("************************* Running UE detach for UE id ",
-              ue_id)
+        print(
+            "************************* Running UE detach for UE id ",
+            ue_id,
+        )
         # Now detach the UE
         self._s1ap_wrapper.s1_util.detach(
-            ue_id, s1ap_types.ueDetachType_t.UE_NORMAL_DETACH.value, True)
+            ue_id, s1ap_types.ueDetachType_t.UE_NORMAL_DETACH.value, True,
+        )
 
-        print("************************* Sending Service request for UE id ",
-              ue_id)
+        print(
+            "************************* Sending Service request for UE id ",
+            ue_id,
+        )
         # Send Service Request from the UE which is already detached in EPC
         req = s1ap_types.ueserviceReq_t()
         req.ue_Id = ue_id
@@ -58,16 +66,21 @@ class TestAttachDetachService(unittest.TestCase):
         req.ueMtmsi.pres = False
         req.rrcCause = s1ap_types.Rrc_Cause.TFW_MO_DATA.value
         self._s1ap_wrapper.s1_util.issue_cmd(
-            s1ap_types.tfwCmd.UE_SERVICE_REQUEST, req)
+            s1ap_types.tfwCmd.UE_SERVICE_REQUEST, req,
+        )
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_SERVICE_REJECT_IND.value)
-        print("************************* Received Service Reject for UE id ",
-              ue_id)
+            response.msg_type, s1ap_types.tfwCmd.UE_SERVICE_REJECT_IND.value,
+        )
+        print(
+            "************************* Received Service Reject for UE id ",
+            ue_id,
+        )
         # Wait for UE Context Release command
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_CTX_REL_IND.value)
+            response.msg_type, s1ap_types.tfwCmd.UE_CTX_REL_IND.value,
+        )
 
 
 if __name__ == "__main__":

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_setsessionrules_tcp_data.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_setsessionrules_tcp_data.py
@@ -11,15 +11,16 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-import unittest
-import s1ap_types
 import time
+import unittest
 
+import s1ap_types
 from integ_tests.s1aptests import s1ap_wrapper
-from integ_tests.s1aptests.s1ap_utils import SessionManagerUtil
 from integ_tests.s1aptests.ovs.rest_api import get_datapath, get_flows
+from integ_tests.s1aptests.s1ap_utils import SessionManagerUtil
 from lte.protos.policydb_pb2 import FlowMatch
 from s1ap_utils import GTPBridgeUtils
+
 
 class TestAttachDetachSetSessionRulesTcpData(unittest.TestCase):
     SPGW_TABLE = 0
@@ -55,10 +56,9 @@ class TestAttachDetachSetSessionRulesTcpData(unittest.TestCase):
         # APN list to be configured
         apn_list = [internet]
 
-
         req = self._s1ap_wrapper.ue_req
         self._s1ap_wrapper.configAPN(
-            "IMSI" + "".join([str(i) for i in req.imsi]), apn_list, default=False
+            "IMSI" + "".join([str(i) for i in req.imsi]), apn_list, default=False,
         )
         print(
             "********************** Running End to End attach for ",
@@ -79,14 +79,14 @@ class TestAttachDetachSetSessionRulesTcpData(unittest.TestCase):
         # UL Flow description #1
         ulFlow1 = {
             "ip_proto": FlowMatch.IPPROTO_TCP,  # Protocol Type
-            "tcp_dst_port": 5001, # TCP Server Port
+            "tcp_dst_port": 5001,  # TCP Server Port
             "direction": FlowMatch.UPLINK,  # Direction
         }
 
         # DL Flow description #1
         dlFlow1 = {
             "ip_proto": FlowMatch.IPPROTO_TCP,  # Protocol Type
-            "tcp_dst_port": 7001, # TCP UE Port
+            "tcp_dst_port": 7001,  # TCP UE Port
             "direction": FlowMatch.DOWNLINK,  # Direction
         }
 
@@ -142,15 +142,15 @@ class TestAttachDetachSetSessionRulesTcpData(unittest.TestCase):
         # Receive Activate dedicated bearer request
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_ACT_DED_BER_REQ.value
+            response.msg_type, s1ap_types.tfwCmd.UE_ACT_DED_BER_REQ.value,
         )
         act_ded_ber_ctxt_req = response.cast(
-            s1ap_types.UeActDedBearCtxtReq_t
+            s1ap_types.UeActDedBearCtxtReq_t,
         )
 
         # Send Activate dedicated bearer accept
         self._s1ap_wrapper.sendActDedicatedBearerAccept(
-            req.ue_id, act_ded_ber_ctxt_req.bearerId
+            req.ue_id, act_ded_ber_ctxt_req.bearerId,
         )
 
         policy_id = "tcp_udp_2"
@@ -171,29 +171,29 @@ class TestAttachDetachSetSessionRulesTcpData(unittest.TestCase):
         # Receive Deactivate dedicated bearer request
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_DEACTIVATE_BER_REQ.value
+            response.msg_type, s1ap_types.tfwCmd.UE_DEACTIVATE_BER_REQ.value,
         )
         deactivate_ber_ctxt_req = response.cast(
-            s1ap_types.UeDeActvBearCtxtReq_t
+            s1ap_types.UeDeActvBearCtxtReq_t,
         )
 
         # Send Deactivate dedicated bearer accept
         self._s1ap_wrapper.sendDeactDedicatedBearerAccept(
-            req.ue_id, deactivate_ber_ctxt_req.bearerId
+            req.ue_id, deactivate_ber_ctxt_req.bearerId,
         )
 
         # Receive Activate dedicated bearer request
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_ACT_DED_BER_REQ.value
+            response.msg_type, s1ap_types.tfwCmd.UE_ACT_DED_BER_REQ.value,
         )
         act_ded_ber_ctxt_req = response.cast(
-            s1ap_types.UeActDedBearCtxtReq_t
+            s1ap_types.UeActDedBearCtxtReq_t,
         )
 
         # Send Activate dedicated bearer accept
         self._s1ap_wrapper.sendActDedicatedBearerAccept(
-            req.ue_id, act_ded_ber_ctxt_req.bearerId
+            req.ue_id, act_ded_ber_ctxt_req.bearerId,
         )
 
         print("Sleeping for 2 seconds")
@@ -265,7 +265,7 @@ class TestAttachDetachSetSessionRulesTcpData(unittest.TestCase):
             and action["type"] == "SET_FIELD"
         )
         self.assertTrue(
-            has_tunnel_action, "Downlink flow missing set tunnel action"
+            has_tunnel_action, "Downlink flow missing set tunnel action",
         )
 
         # Get UL Flow Rule for TCP flows for verifying rate limits enforced
@@ -296,10 +296,10 @@ class TestAttachDetachSetSessionRulesTcpData(unittest.TestCase):
         print(uplink_flow_a)
         tcp_bytes = (uplink_flow_a[0]['byte_count'] - uplink_flow_b[0]['byte_count'])
         tcp_time = (uplink_flow_a[0]['duration_sec'] - uplink_flow_b[0]['duration_sec'])
-        tcp_rate = 8*tcp_bytes/tcp_time
+        tcp_rate = 8 * tcp_bytes / tcp_time
         print("TCP UL Rate from OVS: %.2fbps" % tcp_rate)
         # Allow for a 10% error margin
-        assert 0.9*tcp_rate < max_bw_ul, "UL Rate for TCP flow violates UL rate policy for UE"
+        assert 0.9 * tcp_rate < max_bw_ul, "UL Rate for TCP flow violates UL rate policy for UE"
 
         # Get DL Flow Rule for TCP flows for verifying rate limits enforced
         print("**********************Get downlink TCP flow for UE before DL traffic test:")
@@ -339,10 +339,10 @@ class TestAttachDetachSetSessionRulesTcpData(unittest.TestCase):
         print(downlink_flow_a)
         tcp_bytes = (downlink_flow_a[0]['byte_count'] - downlink_flow_b[0]['byte_count'])
         tcp_time = (downlink_flow_a[0]['duration_sec'] - downlink_flow_b[0]['duration_sec'])
-        tcp_rate = 8*tcp_bytes/tcp_time
+        tcp_rate = 8 * tcp_bytes / tcp_time
         print("TCP DL Rate from OVS: %.2fbps" % tcp_rate)
         # Allow for a 10% error margin
-        assert 0.9*tcp_rate < max_bw_dl, "DL Rate for TCP flow violates DL rate policy for UE"
+        assert 0.9 * tcp_rate < max_bw_dl, "DL Rate for TCP flow violates DL rate policy for UE"
         time.sleep(2)  # sleep for 2 seconds before detaching
 
         print(
@@ -351,12 +351,11 @@ class TestAttachDetachSetSessionRulesTcpData(unittest.TestCase):
         )
         # Now detach the UE
         self._s1ap_wrapper.s1_util.detach(
-            req.ue_id, s1ap_types.ueDetachType_t.UE_NORMAL_DETACH.value, True
+            req.ue_id, s1ap_types.ueDetachType_t.UE_NORMAL_DETACH.value, True,
         )
 
         # Verify that all UL/DL flows are deleted
         self._s1ap_wrapper.s1_util.verify_flow_rules_deletion()
-
 
 
 if __name__ == "__main__":

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_with_corrupt_stateless_mme.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_with_corrupt_stateless_mme.py
@@ -24,7 +24,8 @@ class TestAttachDetachWithCorruptStatelessMME(unittest.TestCase):
     def setUp(self):
         self._s1ap_wrapper = s1ap_wrapper.TestWrapper(
             stateless_mode=MagmadUtil.stateless_cmds.ENABLE,
-            health_service=MagmadUtil.stateless_cmds.ENABLE)
+            health_service=MagmadUtil.stateless_cmds.ENABLE,
+        )
 
     def tearDown(self):
         self._s1ap_wrapper.cleanup()
@@ -43,22 +44,26 @@ class TestAttachDetachWithCorruptStatelessMME(unittest.TestCase):
         }
 
         req = self._s1ap_wrapper.ue_req
-        print("************************* Running End to End attach for ",
-              "UE id ", req.ue_id)
+        print(
+            "************************* Running End to End attach for ",
+            "UE id ", req.ue_id,
+        )
 
         for s in services_state_dict:
             # Now actually complete the attach
             self._s1ap_wrapper._s1_util.attach(
                 req.ue_id, s1ap_types.tfwCmd.UE_END_TO_END_ATTACH_REQUEST,
                 s1ap_types.tfwCmd.UE_ATTACH_ACCEPT_IND,
-                s1ap_types.ueAttachAccept_t)
+                s1ap_types.ueAttachAccept_t,
+            )
 
             # Wait on EMM Information from MME
             self._s1ap_wrapper._s1_util.receive_emm_info()
 
             print("************************* Corrupting %s state" % s)
             self._s1ap_wrapper.magmad_util.corrupt_agw_state(
-                services_state_dict[s])
+                services_state_dict[s],
+            )
 
             print("************************* Restarting %s service" % s)
             self._s1ap_wrapper.magmad_util.restart_services([s])
@@ -93,7 +98,7 @@ class TestAttachDetachWithCorruptStatelessMME(unittest.TestCase):
                 req.ue_id,
             )
             self._s1ap_wrapper.s1_util.detach(
-                req.ue_id, detach_type, wait_for_s1
+                req.ue_id, detach_type, wait_for_s1,
             )
 
 

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_with_he_policy.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_with_he_policy.py
@@ -11,14 +11,18 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-import unittest
-import s1ap_types
 import time
+import unittest
 
+import s1ap_types
 from integ_tests.s1aptests import s1ap_wrapper
-from integ_tests.s1aptests.s1ap_utils import SpgwUtil, HeaderEnrichmentUtils
-from integ_tests.s1aptests.s1ap_utils import SessionManagerUtil, GTPBridgeUtils
 from integ_tests.s1aptests.ovs.rest_api import get_datapath, get_flows
+from integ_tests.s1aptests.s1ap_utils import (
+    GTPBridgeUtils,
+    HeaderEnrichmentUtils,
+    SessionManagerUtil,
+    SpgwUtil,
+)
 from lte.protos.policydb_pb2 import FlowMatch, HeaderEnrichment
 from ryu.lib.packet.in_proto import IPPROTO_TCP
 
@@ -110,7 +114,8 @@ class TestAttachDetachWithHE(unittest.TestCase):
             assert utils.he_count_record_of_imsi_to_domain(imsi, he_domain1) == 0
 
             print(
-                "********************** Sending RAR for ", imsi)
+                "********************** Sending RAR for ", imsi,
+            )
             self._sessionManager_util.send_ReAuthRequest(
                 "IMSI" + "".join([str(i) for i in req.imsi]),
                 policy_id,
@@ -122,17 +127,17 @@ class TestAttachDetachWithHE(unittest.TestCase):
             # Receive Activate dedicated bearer request
             response = self._s1ap_wrapper.s1_util.get_response()
             self.assertEqual(
-                response.msg_type, s1ap_types.tfwCmd.UE_ACT_DED_BER_REQ.value
+                response.msg_type, s1ap_types.tfwCmd.UE_ACT_DED_BER_REQ.value,
             )
             act_ded_ber_ctxt_req = response.cast(
-                s1ap_types.UeActDedBearCtxtReq_t
+                s1ap_types.UeActDedBearCtxtReq_t,
             )
 
             print("Sleeping for 5 seconds")
             time.sleep(5)
             # Send Activate dedicated bearer accept
             self._s1ap_wrapper.sendActDedicatedBearerAccept(
-                req.ue_id, act_ded_ber_ctxt_req.bearerId
+                req.ue_id, act_ded_ber_ctxt_req.bearerId,
             )
 
             # Check if UL and DL OVS flows are created
@@ -155,7 +160,7 @@ class TestAttachDetachWithHE(unittest.TestCase):
                 "".join([str(i) for i in req.imsi]),
             )
             self._spgw_util.delete_bearer(
-                "IMSI" + "".join([str(i) for i in req.imsi]), 5, 6
+                "IMSI" + "".join([str(i) for i in req.imsi]), 5, 6,
             )
 
             response = self._s1ap_wrapper.s1_util.get_response()
@@ -168,7 +173,7 @@ class TestAttachDetachWithHE(unittest.TestCase):
 
             deactv_bearer_req = response.cast(s1ap_types.UeDeActvBearCtxtReq_t)
             self._s1ap_wrapper.sendDeactDedicatedBearerAccept(
-                req.ue_id, deactv_bearer_req.bearerId
+                req.ue_id, deactv_bearer_req.bearerId,
             )
 
             print("Sleeping for 5 seconds")
@@ -180,7 +185,7 @@ class TestAttachDetachWithHE(unittest.TestCase):
             )
             # Now detach the UE
             self._s1ap_wrapper.s1_util.detach(
-                req.ue_id, detach_type[i], wait_for_s1[i]
+                req.ue_id, detach_type[i], wait_for_s1[i],
             )
 
             time.sleep(20)

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_with_ipv6_pcscf_and_dns_addr.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_with_ipv6_pcscf_and_dns_addr.py
@@ -6,12 +6,12 @@ LICENSE file in the root directory of this source tree. An additional grant
 of patent rights can be found in the PATENTS file in the same directory.
 """
 
-import unittest
+import ipaddress
 import time
+import unittest
 
 import s1ap_types
 import s1ap_wrapper
-import ipaddress
 
 
 class TestAttachDetachWithIpv6PcscfDnsAddr(unittest.TestCase):
@@ -46,7 +46,7 @@ class TestAttachDetachWithIpv6PcscfDnsAddr(unittest.TestCase):
         apn_list = [ims_apn]
 
         self._s1ap_wrapper.configAPN(
-            "IMSI" + "".join([str(i) for i in req.imsi]), apn_list
+            "IMSI" + "".join([str(i) for i in req.imsi]), apn_list,
         )
         print(
             "*********************** Running End to End attach for UE id ",
@@ -84,7 +84,7 @@ class TestAttachDetachWithIpv6PcscfDnsAddr(unittest.TestCase):
         # Receive PDN CONN RSP/Activate default EPS bearer context request
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_PDN_CONN_RSP_IND.value
+            response.msg_type, s1ap_types.tfwCmd.UE_PDN_CONN_RSP_IND.value,
         )
         act_def_bearer_req = response.cast(s1ap_types.uePdnConRsp_t)
 
@@ -96,21 +96,21 @@ class TestAttachDetachWithIpv6PcscfDnsAddr(unittest.TestCase):
         print(
             "*************** Added default bearer for apn-%s,"
             " bearer id-%d, pdn type-%d"
-            % (apn, act_def_bearer_req.m.pdnInfo.epsBearerId, pdn_type,)
+            % (apn, act_def_bearer_req.m.pdnInfo.epsBearerId, pdn_type),
         )
 
         # Receive Router Advertisement message
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_ROUTER_ADV_IND.value
+            response.msg_type, s1ap_types.tfwCmd.UE_ROUTER_ADV_IND.value,
         )
         routerAdv = response.cast(s1ap_types.ueRouterAdv_t)
         print(
             "************* Received Router Advertisement for APN-%s"
-            " bearer id-%d" % (apn, routerAdv.bearerId)
+            " bearer id-%d" % (apn, routerAdv.bearerId),
         )
         ipv6_addr = "".join([chr(i) for i in routerAdv.ipv6Addr]).rstrip(
-            "\x00"
+            "\x00",
         )
         print("********** UE IPv6 address: ", ipv6_addr)
         sec_ip_ipv6 = ipaddress.ip_address(ipv6_addr)
@@ -126,7 +126,7 @@ class TestAttachDetachWithIpv6PcscfDnsAddr(unittest.TestCase):
 
         # Verify if flow rules are created
         self._s1ap_wrapper.s1_util.verify_flow_rules(
-            num_ul_flows, dl_flow_rules
+            num_ul_flows, dl_flow_rules,
         )
 
         print("***** Sleeping for 5 seconds")
@@ -138,7 +138,7 @@ class TestAttachDetachWithIpv6PcscfDnsAddr(unittest.TestCase):
         )
         # Now detach the UE
         self._s1ap_wrapper.s1_util.detach(
-            ue_id, s1ap_types.ueDetachType_t.UE_SWITCHOFF_DETACH.value, False
+            ue_id, s1ap_types.ueDetachType_t.UE_SWITCHOFF_DETACH.value, False,
         )
 
 

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_with_mme_restart.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_with_mme_restart.py
@@ -23,7 +23,8 @@ class TestAttachDetachWithMmeRestart(unittest.TestCase):
 
     def setUp(self):
         self._s1ap_wrapper = s1ap_wrapper.TestWrapper(
-            stateless_mode=MagmadUtil.stateless_cmds.ENABLE)
+            stateless_mode=MagmadUtil.stateless_cmds.ENABLE,
+        )
 
     def tearDown(self):
         self._s1ap_wrapper.cleanup()
@@ -34,26 +35,33 @@ class TestAttachDetachWithMmeRestart(unittest.TestCase):
         where MME restarts between each attach and detach
         """
         num_ues = 2
-        detach_type = [s1ap_types.ueDetachType_t.UE_NORMAL_DETACH.value,
-                       s1ap_types.ueDetachType_t.UE_SWITCHOFF_DETACH.value]
+        detach_type = [
+            s1ap_types.ueDetachType_t.UE_NORMAL_DETACH.value,
+            s1ap_types.ueDetachType_t.UE_SWITCHOFF_DETACH.value,
+        ]
         wait_for_s1 = [True, False]
         self._s1ap_wrapper.configUEDevice(num_ues)
 
         for i in range(num_ues):
             req = self._s1ap_wrapper.ue_req
-            print("************************* Running End to End attach for ",
-                  "UE id ", req.ue_id)
+            print(
+                "************************* Running End to End attach for ",
+                "UE id ", req.ue_id,
+            )
             # Now actually complete the attach
             self._s1ap_wrapper._s1_util.attach(
                 req.ue_id, s1ap_types.tfwCmd.UE_END_TO_END_ATTACH_REQUEST,
                 s1ap_types.tfwCmd.UE_ATTACH_ACCEPT_IND,
-                s1ap_types.ueAttachAccept_t)
+                s1ap_types.ueAttachAccept_t,
+            )
 
             # Wait on EMM Information from MME
             self._s1ap_wrapper._s1_util.receive_emm_info()
 
-            print("************************* Restarting MME service on",
-                  "gateway")
+            print(
+                "************************* Restarting MME service on",
+                "gateway",
+            )
             self._s1ap_wrapper.magmad_util.restart_services(["mme"])
 
             for j in range(30):
@@ -61,10 +69,13 @@ class TestAttachDetachWithMmeRestart(unittest.TestCase):
                 time.sleep(1)
 
             # Now detach the UE
-            print("************************* Running UE detach for UE id ",
-                  req.ue_id)
+            print(
+                "************************* Running UE detach for UE id ",
+                req.ue_id,
+            )
             self._s1ap_wrapper.s1_util.detach(
-                req.ue_id, detach_type[i], wait_for_s1[i])
+                req.ue_id, detach_type[i], wait_for_s1[i],
+            )
 
             if i == 1:
                 break

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_with_mobilityd_restart.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_with_mobilityd_restart.py
@@ -22,7 +22,8 @@ class TestAttachDetachMobilitydRestart(unittest.TestCase):
 
     def setUp(self):
         self._s1ap_wrapper = s1ap_wrapper.TestWrapper(
-            stateless_mode=MagmadUtil.stateless_cmds.ENABLE)
+            stateless_mode=MagmadUtil.stateless_cmds.ENABLE,
+        )
 
     def tearDown(self):
         self._s1ap_wrapper.cleanup()
@@ -30,21 +31,26 @@ class TestAttachDetachMobilitydRestart(unittest.TestCase):
     def test_attach_detach_mobility_restart(self):
         """ Basic attach/detach test with a single UE and mobilityd restart """
         num_ues = 2
-        detach_type = [s1ap_types.ueDetachType_t.UE_NORMAL_DETACH.value,
-                       s1ap_types.ueDetachType_t.UE_SWITCHOFF_DETACH.value]
+        detach_type = [
+            s1ap_types.ueDetachType_t.UE_NORMAL_DETACH.value,
+            s1ap_types.ueDetachType_t.UE_SWITCHOFF_DETACH.value,
+        ]
         wait_for_s1 = [True, False]
         self._s1ap_wrapper.configUEDevice(num_ues)
 
         for i in range(num_ues):
             req = self._s1ap_wrapper.ue_req
-            print("************************* Running End to End attach for ",
-                  "UE id ", req.ue_id)
+            print(
+                "************************* Running End to End attach for ",
+                "UE id ", req.ue_id,
+            )
 
             # Now actually complete the attach
             self._s1ap_wrapper._s1_util.attach(
                 req.ue_id, s1ap_types.tfwCmd.UE_END_TO_END_ATTACH_REQUEST,
                 s1ap_types.tfwCmd.UE_ATTACH_ACCEPT_IND,
-                s1ap_types.ueAttachAccept_t)
+                s1ap_types.ueAttachAccept_t,
+            )
 
             # Wait on EMM Information from MME
             self._s1ap_wrapper._s1_util.receive_emm_info()
@@ -56,11 +62,14 @@ class TestAttachDetachMobilitydRestart(unittest.TestCase):
                 print("Waiting for", j, "seconds")
                 sleep(1)
 
-            print("************************* Running UE detach for UE id ",
-                  req.ue_id)
+            print(
+                "************************* Running UE detach for UE id ",
+                req.ue_id,
+            )
             # Now detach the UE
             self._s1ap_wrapper.s1_util.detach(
-                req.ue_id, detach_type[i], wait_for_s1[i])
+                req.ue_id, detach_type[i], wait_for_s1[i],
+            )
 
 
 if __name__ == "__main__":

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_with_ovs.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_with_ovs.py
@@ -16,9 +16,9 @@ import unittest
 
 import s1ap_types
 import s1ap_wrapper
-from s1ap_utils import GTPBridgeUtils
 from integ_tests.s1aptests.ovs.rest_api import get_datapath, get_flows
 from magma.pipelined.imsi import decode_imsi
+from s1ap_utils import GTPBridgeUtils
 
 
 class TestAttachDetachWithOVS(unittest.TestCase):
@@ -35,14 +35,20 @@ class TestAttachDetachWithOVS(unittest.TestCase):
     def check_imsi_metadata(self, flow, ue_req):
         """ Checks that IMSI set in the flow metadata matches the one sent """
         sent_imsi = 'IMSI' + ''.join([str(i) for i in ue_req.imsi])
-        imsi_action = next((a for a in flow["instructions"][0]["actions"]
-                            if a["field"] == "metadata"), None)
+        imsi_action = next(
+            (
+                a for a in flow["instructions"][0]["actions"]
+                if a["field"] == "metadata"
+            ), None,
+        )
         self.assertIsNotNone(imsi_action)
         imsi64 = imsi_action["value"]
         # Convert between compacted uint IMSI and string
         received_imsi = decode_imsi(imsi64)
-        self.assertEqual(sent_imsi, received_imsi,
-                         "IMSI set in metadata field does not match sent IMSI")
+        self.assertEqual(
+            sent_imsi, received_imsi,
+            "IMSI set in metadata field does not match sent IMSI",
+        )
 
     def test_attach_detach_with_ovs(self):
         """
@@ -54,8 +60,10 @@ class TestAttachDetachWithOVS(unittest.TestCase):
 
         print("Checking for default table 0 flows")
         flows = get_flows(datapath, {"table_id": self.SPGW_TABLE})
-        self.assertEqual(len(flows), 2,
-                         "There should only be 2 default table 0 flows")
+        self.assertEqual(
+            len(flows), 2,
+            "There should only be 2 default table 0 flows",
+        )
 
         self._s1ap_wrapper.configUEDevice(1)
         req = self._s1ap_wrapper.ue_req
@@ -64,7 +72,8 @@ class TestAttachDetachWithOVS(unittest.TestCase):
         self._s1ap_wrapper._s1_util.attach(
             req.ue_id, s1ap_types.tfwCmd.UE_END_TO_END_ATTACH_REQUEST,
             s1ap_types.tfwCmd.UE_ATTACH_ACCEPT_IND,
-            s1ap_types.ueAttachAccept_t)
+            s1ap_types.ueAttachAccept_t,
+        )
 
         self._s1ap_wrapper._s1_util.receive_emm_info()
 
@@ -76,16 +85,22 @@ class TestAttachDetachWithOVS(unittest.TestCase):
         # might take some time to install the flows in ovs
         for i in range(MAX_NUM_RETRIES):
             print("Get uplink flows: attempt ", i)
-            uplink_flows = get_flows(datapath,
-                                     {"table_id": self.SPGW_TABLE,
-                                      "match": {"in_port": gtp_port_no}})
+            uplink_flows = get_flows(
+                datapath,
+                {
+                    "table_id": self.SPGW_TABLE,
+                    "match": {"in_port": gtp_port_no},
+                },
+            )
             if len(uplink_flows) > 0:
                 break
             time.sleep(5)  # sleep for 5 seconds before retrying
 
         self.assertEqual(len(uplink_flows), 1, "Uplink flow missing for UE")
-        self.assertIsNotNone(uplink_flows[0]["match"]["tunnel_id"],
-                             "Uplink flow missing tunnel id match")
+        self.assertIsNotNone(
+            uplink_flows[0]["match"]["tunnel_id"],
+            "Uplink flow missing tunnel id match",
+        )
         self.check_imsi_metadata(uplink_flows[0], req)
 
         # DOWNLINK
@@ -96,37 +111,54 @@ class TestAttachDetachWithOVS(unittest.TestCase):
         # might take some time to install the flows in ovs
         for i in range(MAX_NUM_RETRIES):
             print("Get downlink flows: attempt ", i)
-            downlink_flows = get_flows(datapath,
-                                       {"table_id": self.SPGW_TABLE,
-                                        "match": {"nw_dst": ue_ip,
-                                                  "eth_type": 2048,
-                                                  "in_port": self.LOCAL_PORT}})
+            downlink_flows = get_flows(
+                datapath,
+                {
+                    "table_id": self.SPGW_TABLE,
+                    "match": {
+                        "nw_dst": ue_ip,
+                        "eth_type": 2048,
+                        "in_port": self.LOCAL_PORT,
+                    },
+                },
+            )
             if len(downlink_flows) > 0:
                 break
             time.sleep(5)  # sleep for 5 seconds before retrying
 
-        self.assertEqual(len(downlink_flows), 1,
-                         "Downlink flow missing for UE")
-        self.assertEqual(downlink_flows[0]["match"]["ipv4_dst"], ue_ip,
-                         "UE IP match missing from downlink flow")
+        self.assertEqual(
+            len(downlink_flows), 1,
+            "Downlink flow missing for UE",
+        )
+        self.assertEqual(
+            downlink_flows[0]["match"]["ipv4_dst"], ue_ip,
+            "UE IP match missing from downlink flow",
+        )
 
         actions = downlink_flows[0]["instructions"][0]["actions"]
-        has_tunnel_action = any(action for action in actions
-                                if action["field"] == "tunnel_id" and
-                                action["type"] == "SET_FIELD")
-        self.assertTrue(has_tunnel_action,
-                        "Downlink flow missing set tunnel action")
+        has_tunnel_action = any(
+            action for action in actions
+            if action["field"] == "tunnel_id" and
+            action["type"] == "SET_FIELD"
+        )
+        self.assertTrue(
+            has_tunnel_action,
+            "Downlink flow missing set tunnel action",
+        )
         self.check_imsi_metadata(downlink_flows[0], req)
 
         print("Running UE detach for UE id ", req.ue_id)
         # Now detach the UE
         self._s1ap_wrapper.s1_util.detach(
-            req.ue_id, s1ap_types.ueDetachType_t.UE_NORMAL_DETACH.value, True)
+            req.ue_id, s1ap_types.ueDetachType_t.UE_NORMAL_DETACH.value, True,
+        )
 
         print("Checking that uplink/downlink flows were deleted")
         flows = get_flows(datapath, {"table_id": self.SPGW_TABLE})
-        self.assertEqual(len(flows), 2,
-                         "There should only be 2 default table 0 flows")
+        self.assertEqual(
+            len(flows), 2,
+            "There should only be 2 default table 0 flows",
+        )
 
 
 if __name__ == "__main__":

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_with_pco_ipcp.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_with_pco_ipcp.py
@@ -14,7 +14,6 @@ limitations under the License.
 import unittest
 
 import s1ap_types
-
 from integ_tests.s1aptests import s1ap_wrapper
 
 

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_with_pcscf_address.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_with_pcscf_address.py
@@ -14,7 +14,6 @@ limitations under the License.
 import unittest
 
 import s1ap_types
-
 from integ_tests.s1aptests import s1ap_wrapper
 
 

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_with_sctpd_restart.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_with_sctpd_restart.py
@@ -22,7 +22,7 @@ from s1ap_utils import MagmadUtil
 class TestAttachDetachWithSctpdRestart(unittest.TestCase):
     def setUp(self):
         self._s1ap_wrapper = s1ap_wrapper.TestWrapper(
-            stateless_mode=MagmadUtil.stateless_cmds.ENABLE
+            stateless_mode=MagmadUtil.stateless_cmds.ENABLE,
         )
 
     def tearDown(self):
@@ -92,7 +92,7 @@ class TestAttachDetachWithSctpdRestart(unittest.TestCase):
                 req.ue_id,
             )
             self._s1ap_wrapper.s1_util.detach(
-                req.ue_id, detach_type[i], wait_for_s1[i]
+                req.ue_id, detach_type[i], wait_for_s1[i],
             )
 
             if i == 0:

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_dl_tcp_data.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_dl_tcp_data.py
@@ -29,28 +29,36 @@ class TestAttachDlTcpData(unittest.TestCase):
         """ Attach and send DL TCP data """
         self._s1ap_wrapper.configUEDevice(1)
         req = self._s1ap_wrapper.ue_req
-        print("************************* Running End to End attach for ",
-              "UE id ", req.ue_id)
+        print(
+            "************************* Running End to End attach for ",
+            "UE id ", req.ue_id,
+        )
         # Now actually complete the attach
         self._s1ap_wrapper._s1_util.attach(
             req.ue_id, s1ap_types.tfwCmd.UE_END_TO_END_ATTACH_REQUEST,
             s1ap_types.tfwCmd.UE_ATTACH_ACCEPT_IND,
-            s1ap_types.ueAttachAccept_t)
+            s1ap_types.ueAttachAccept_t,
+        )
 
         # Wait on EMM Information from MME
         self._s1ap_wrapper._s1_util.receive_emm_info()
 
-        print("************************* Running UE downlink (TCP) for UE id ",
-              req.ue_id)
+        print(
+            "************************* Running UE downlink (TCP) for UE id ",
+            req.ue_id,
+        )
         with self._s1ap_wrapper.configDownlinkTest(req, duration=1) as test:
             test.verify()
 
-        print("************************* Running UE detach for UE id ",
-              req.ue_id)
+        print(
+            "************************* Running UE detach for UE id ",
+            req.ue_id,
+        )
         # Now detach the UE
         self._s1ap_wrapper.s1_util.detach(
             req.ue_id, s1ap_types.ueDetachType_t.UE_SWITCHOFF_DETACH.value,
-            True)
+            True,
+        )
 
 
 if __name__ == "__main__":

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_dl_udp_data.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_dl_udp_data.py
@@ -29,29 +29,38 @@ class TestAttachDlUdpData(unittest.TestCase):
         """ Attach and send DL UDP data """
         self._s1ap_wrapper.configUEDevice(1)
         req = self._s1ap_wrapper.ue_req
-        print("************************* Running End to End attach for ",
-              "UE id ", req.ue_id)
+        print(
+            "************************* Running End to End attach for ",
+            "UE id ", req.ue_id,
+        )
         # Now actually complete the attach
         self._s1ap_wrapper._s1_util.attach(
             req.ue_id, s1ap_types.tfwCmd.UE_END_TO_END_ATTACH_REQUEST,
             s1ap_types.tfwCmd.UE_ATTACH_ACCEPT_IND,
-            s1ap_types.ueAttachAccept_t)
+            s1ap_types.ueAttachAccept_t,
+        )
 
         # Wait on EMM Information from MME
         self._s1ap_wrapper._s1_util.receive_emm_info()
 
-        print("************************* Running UE downlink (UDP) for UE id ",
-              req.ue_id)
+        print(
+            "************************* Running UE downlink (UDP) for UE id ",
+            req.ue_id,
+        )
         with self._s1ap_wrapper.configDownlinkTest(
-                req, duration=1, is_udp=True) as test:
+                req, duration=1, is_udp=True,
+        ) as test:
             test.verify()
 
-        print("************************* Running UE detach for UE id ",
-              req.ue_id)
+        print(
+            "************************* Running UE detach for UE id ",
+            req.ue_id,
+        )
         # Now detach the UE
         self._s1ap_wrapper.s1_util.detach(
             req.ue_id, s1ap_types.ueDetachType_t.UE_SWITCHOFF_DETACH.value,
-            True)
+            True,
+        )
 
 
 if __name__ == "__main__":

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_dl_udp_data_multi_ue.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_dl_udp_data_multi_ue.py
@@ -55,7 +55,7 @@ class TestAttachDlUdpDataMultiUe(unittest.TestCase):
             [req.ue_id for req in reqs],
         )
         with self._s1ap_wrapper.configDownlinkTest(
-            *reqs, duration=1, is_udp=True
+            *reqs, duration=1, is_udp=True,
         ) as test:
             test.verify()
 

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_emergency.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_emergency.py
@@ -27,20 +27,25 @@ class TestAttachEmergency(unittest.TestCase):
 
     def _test_attach_response_for_id_type(self, id_type, expected_ue_state):
         req = self._s1ap_wrapper.ue_req
-        print("************************* Running Emergency Attach for ",
-              "UE id ", req.ue_id)
+        print(
+            "************************* Running Emergency Attach for ",
+            "UE id ", req.ue_id,
+        )
 
         # Attach
         msg = self._s1ap_wrapper._s1_util.attach(
             req.ue_id, s1ap_types.tfwCmd.UE_END_TO_END_ATTACH_REQUEST,
             s1ap_types.tfwCmd.UE_ATTACH_REJECT_IND, s1ap_types.ueAttachFail_t,
             eps_type=s1ap_types.TFW_EPS_ATTACH_TYPE_EPS_EMRG_ATTACH,
-            id_type=id_type)
+            id_type=id_type,
+        )
 
         # Assert cause
         self.assertEqual(msg.ueState, expected_ue_state)
-        print("************************* Emergency attach rejection successful",
-              "UE id ", req.ue_id)
+        print(
+            "************************* Emergency attach rejection successful",
+            "UE id ", req.ue_id,
+        )
         # Context release, remove from queue
         self._s1ap_wrapper._s1_util.get_response()
 
@@ -52,13 +57,17 @@ class TestAttachEmergency(unittest.TestCase):
 
         # Test IMSI, should return cause not authorized
         expected_ue_state = 35  # EMM_CAUSE_NOT_AUTHORIZED_IN_PLMN
-        self._test_attach_response_for_id_type(s1ap_types.TFW_MID_TYPE_IMSI,
-                                               expected_ue_state)
+        self._test_attach_response_for_id_type(
+            s1ap_types.TFW_MID_TYPE_IMSI,
+            expected_ue_state,
+        )
 
         # Test IMEI, should return IMEI not accepted
         expected_ue_state = 5  # EMM_CAUSE_IMEI_NOT_ACCEPTED
-        self._test_attach_response_for_id_type(s1ap_types.TFW_MID_TYPE_IMEI,
-                                               expected_ue_state)
+        self._test_attach_response_for_id_type(
+            s1ap_types.TFW_MID_TYPE_IMEI,
+            expected_ue_state,
+        )
 
 
 if __name__ == "__main__":

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_esm_information.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_esm_information.py
@@ -11,13 +11,12 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
+import ctypes
+import time
 import unittest
 
 import s1ap_types
-import time
-
 from integ_tests.s1aptests import s1ap_wrapper
-import ctypes
 
 
 class TestEsmInformation(unittest.TestCase):
@@ -48,12 +47,12 @@ class TestEsmInformation(unittest.TestCase):
 
         print("Sending Attach Request ue-id", attach_req.ue_Id)
         self._s1ap_wrapper._s1_util.issue_cmd(
-            s1ap_types.tfwCmd.UE_ATTACH_REQUEST, attach_req
+            s1ap_types.tfwCmd.UE_ATTACH_REQUEST, attach_req,
         )
 
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_AUTH_REQ_IND.value
+            response.msg_type, s1ap_types.tfwCmd.UE_AUTH_REQ_IND.value,
         )
         print("Received auth req ind ")
 
@@ -64,12 +63,12 @@ class TestEsmInformation(unittest.TestCase):
         auth_res.sqnRcvd = sqn_recvd
         print("Sending Auth Response ue-id", auth_res.ue_Id)
         self._s1ap_wrapper._s1_util.issue_cmd(
-            s1ap_types.tfwCmd.UE_AUTH_RESP, auth_res
+            s1ap_types.tfwCmd.UE_AUTH_RESP, auth_res,
         )
 
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_SEC_MOD_CMD_IND.value
+            response.msg_type, s1ap_types.tfwCmd.UE_SEC_MOD_CMD_IND.value,
         )
         print("Received Security Mode Command ue-id", auth_res.ue_Id)
 
@@ -78,22 +77,22 @@ class TestEsmInformation(unittest.TestCase):
         sec_mode_complete = s1ap_types.ueSecModeComplete_t()
         sec_mode_complete.ue_Id = 1
         self._s1ap_wrapper._s1_util.issue_cmd(
-            s1ap_types.tfwCmd.UE_SEC_MOD_COMPLETE, sec_mode_complete
+            s1ap_types.tfwCmd.UE_SEC_MOD_COMPLETE, sec_mode_complete,
         )
 
         # Esm Information Request indication
         print(
-            "Received Esm Information Request ue-id", sec_mode_complete.ue_Id
+            "Received Esm Information Request ue-id", sec_mode_complete.ue_Id,
         )
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_ESM_INFORMATION_REQ.value
+            response.msg_type, s1ap_types.tfwCmd.UE_ESM_INFORMATION_REQ.value,
         )
         esm_info_req = response.cast(s1ap_types.ueEsmInformationReq_t)
 
         # Sending Esm Information Response
         print(
-            "Sending Esm Information Response ue-id", sec_mode_complete.ue_Id
+            "Sending Esm Information Response ue-id", sec_mode_complete.ue_Id,
         )
         esm_info_response = s1ap_types.ueEsmInformationRsp_t()
         esm_info_response.ue_Id = 1
@@ -102,26 +101,26 @@ class TestEsmInformation(unittest.TestCase):
         s = "magma.ipv4"
         esm_info_response.pdnAPN_pr.len = len(s)
         esm_info_response.pdnAPN_pr.pdn_apn = (ctypes.c_ubyte * 100)(
-            *[ctypes.c_ubyte(ord(c)) for c in s[:100]]
+            *[ctypes.c_ubyte(ord(c)) for c in s[:100]],
         )
         self._s1ap_wrapper._s1_util.issue_cmd(
-            s1ap_types.tfwCmd.UE_ESM_INFORMATION_RSP, esm_info_response
+            s1ap_types.tfwCmd.UE_ESM_INFORMATION_RSP, esm_info_response,
         )
 
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.INT_CTX_SETUP_IND.value
+            response.msg_type, s1ap_types.tfwCmd.INT_CTX_SETUP_IND.value,
         )
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_ATTACH_ACCEPT_IND.value
+            response.msg_type, s1ap_types.tfwCmd.UE_ATTACH_ACCEPT_IND.value,
         )
 
         # Trigger Attach Complete
         attach_complete = s1ap_types.ueAttachComplete_t()
         attach_complete.ue_Id = 1
         self._s1ap_wrapper._s1_util.issue_cmd(
-            s1ap_types.tfwCmd.UE_ATTACH_COMPLETE, attach_complete
+            s1ap_types.tfwCmd.UE_ATTACH_COMPLETE, attach_complete,
         )
         # Wait on EMM Information from MME
         self._s1ap_wrapper._s1_util.receive_emm_info()
@@ -134,12 +133,12 @@ class TestEsmInformation(unittest.TestCase):
             s1ap_types.ueDetachType_t.UE_SWITCHOFF_DETACH.value
         )
         self._s1ap_wrapper._s1_util.issue_cmd(
-            s1ap_types.tfwCmd.UE_DETACH_REQUEST, detach_req
+            s1ap_types.tfwCmd.UE_DETACH_REQUEST, detach_req,
         )
         # Wait for UE context release command
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_CTX_REL_IND.value
+            response.msg_type, s1ap_types.tfwCmd.UE_CTX_REL_IND.value,
         )
 
 

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_esm_information_apn_correction.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_esm_information_apn_correction.py
@@ -11,20 +11,20 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
+import ctypes
+import time
 import unittest
 
 import s1ap_types
-import time
-
 from integ_tests.s1aptests import s1ap_wrapper
 from s1ap_utils import MagmadUtil
-import ctypes
 
 
 class TestEsmInformationWithApnCorrection(unittest.TestCase):
     def setUp(self):
         self._s1ap_wrapper = s1ap_wrapper.TestWrapper(
-                apn_correction=MagmadUtil.apn_correction_cmds.ENABLE)
+                apn_correction=MagmadUtil.apn_correction_cmds.ENABLE,
+        )
 
     def tearDown(self):
         self._s1ap_wrapper.cleanup()
@@ -57,12 +57,12 @@ class TestEsmInformationWithApnCorrection(unittest.TestCase):
 
         print("Sending Attach Request ue-id", attach_req.ue_Id)
         self._s1ap_wrapper._s1_util.issue_cmd(
-            s1ap_types.tfwCmd.UE_ATTACH_REQUEST, attach_req
+            s1ap_types.tfwCmd.UE_ATTACH_REQUEST, attach_req,
         )
 
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_AUTH_REQ_IND.value
+            response.msg_type, s1ap_types.tfwCmd.UE_AUTH_REQ_IND.value,
         )
         print("Received auth req ind ")
 
@@ -73,12 +73,12 @@ class TestEsmInformationWithApnCorrection(unittest.TestCase):
         auth_res.sqnRcvd = sqn_recvd
         print("Sending Auth Response ue-id", auth_res.ue_Id)
         self._s1ap_wrapper._s1_util.issue_cmd(
-            s1ap_types.tfwCmd.UE_AUTH_RESP, auth_res
+            s1ap_types.tfwCmd.UE_AUTH_RESP, auth_res,
         )
 
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_SEC_MOD_CMD_IND.value
+            response.msg_type, s1ap_types.tfwCmd.UE_SEC_MOD_CMD_IND.value,
         )
         print("Received Security Mode Command ue-id", auth_res.ue_Id)
 
@@ -87,21 +87,21 @@ class TestEsmInformationWithApnCorrection(unittest.TestCase):
         sec_mode_complete = s1ap_types.ueSecModeComplete_t()
         sec_mode_complete.ue_Id = 1
         self._s1ap_wrapper._s1_util.issue_cmd(
-            s1ap_types.tfwCmd.UE_SEC_MOD_COMPLETE, sec_mode_complete
+            s1ap_types.tfwCmd.UE_SEC_MOD_COMPLETE, sec_mode_complete,
         )
 
         # Esm Information Request indication
         print(
-            "Received Esm Information Request ue-id", sec_mode_complete.ue_Id
+            "Received Esm Information Request ue-id", sec_mode_complete.ue_Id,
         )
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_ESM_INFORMATION_REQ.value
+            response.msg_type, s1ap_types.tfwCmd.UE_ESM_INFORMATION_REQ.value,
         )
         esm_info_req = response.cast(s1ap_types.ueEsmInformationReq_t)
         # Sending Esm Information Response
         print(
-            "Sending Esm Information Response ue-id", sec_mode_complete.ue_Id
+            "Sending Esm Information Response ue-id", sec_mode_complete.ue_Id,
         )
         esm_info_response = s1ap_types.ueEsmInformationRsp_t()
         esm_info_response.ue_Id = 1
@@ -110,27 +110,27 @@ class TestEsmInformationWithApnCorrection(unittest.TestCase):
         s = "oai"
         esm_info_response.pdnAPN_pr.len = len(s)
         esm_info_response.pdnAPN_pr.pdn_apn = (ctypes.c_ubyte * 100)(
-            *[ctypes.c_ubyte(ord(c)) for c in s[:100]]
+            *[ctypes.c_ubyte(ord(c)) for c in s[:100]],
         )
         print("Sending Esm Information with wrong APN ", s)
         self._s1ap_wrapper._s1_util.issue_cmd(
-            s1ap_types.tfwCmd.UE_ESM_INFORMATION_RSP, esm_info_response
+            s1ap_types.tfwCmd.UE_ESM_INFORMATION_RSP, esm_info_response,
         )
 
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.INT_CTX_SETUP_IND.value
+            response.msg_type, s1ap_types.tfwCmd.INT_CTX_SETUP_IND.value,
         )
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_ATTACH_ACCEPT_IND.value
+            response.msg_type, s1ap_types.tfwCmd.UE_ATTACH_ACCEPT_IND.value,
         )
 
         # Trigger Attach Complete
         attach_complete = s1ap_types.ueAttachComplete_t()
         attach_complete.ue_Id = 1
         self._s1ap_wrapper._s1_util.issue_cmd(
-            s1ap_types.tfwCmd.UE_ATTACH_COMPLETE, attach_complete
+            s1ap_types.tfwCmd.UE_ATTACH_COMPLETE, attach_complete,
         )
         # Wait on EMM Information from MME
         self._s1ap_wrapper._s1_util.receive_emm_info()
@@ -143,17 +143,18 @@ class TestEsmInformationWithApnCorrection(unittest.TestCase):
             s1ap_types.ueDetachType_t.UE_SWITCHOFF_DETACH.value
         )
         self._s1ap_wrapper._s1_util.issue_cmd(
-            s1ap_types.tfwCmd.UE_DETACH_REQUEST, detach_req
+            s1ap_types.tfwCmd.UE_DETACH_REQUEST, detach_req,
         )
         # Wait for UE context release command
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_CTX_REL_IND.value
+            response.msg_type, s1ap_types.tfwCmd.UE_CTX_REL_IND.value,
         )
 
         # Disable APN Correction
         self._s1ap_wrapper.magmad_util.config_apn_correction(
-                MagmadUtil.apn_correction_cmds.DISABLE)
+                MagmadUtil.apn_correction_cmds.DISABLE,
+        )
         self._s1ap_wrapper.magmad_util.restart_services(['mme'])
         for j in range(10):
             print("Waiting mme restart for", j, "seconds")

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_esm_information_timerexpiration.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_esm_information_timerexpiration.py
@@ -11,13 +11,12 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
+import ctypes
+import time
 import unittest
 
 import s1ap_types
-import time
-
 from integ_tests.s1aptests import s1ap_wrapper
-import ctypes
 
 
 class TestEsmInformation(unittest.TestCase):
@@ -49,12 +48,12 @@ class TestEsmInformation(unittest.TestCase):
 
         print("Sending Attach Request ue-id", attach_req.ue_Id)
         self._s1ap_wrapper._s1_util.issue_cmd(
-            s1ap_types.tfwCmd.UE_ATTACH_REQUEST, attach_req
+            s1ap_types.tfwCmd.UE_ATTACH_REQUEST, attach_req,
         )
 
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_AUTH_REQ_IND.value
+            response.msg_type, s1ap_types.tfwCmd.UE_AUTH_REQ_IND.value,
         )
         print("Received auth req ind ")
 
@@ -65,12 +64,12 @@ class TestEsmInformation(unittest.TestCase):
         auth_res.sqnRcvd = sqn_recvd
         print("Sending Auth Response ue-id", auth_res.ue_Id)
         self._s1ap_wrapper._s1_util.issue_cmd(
-            s1ap_types.tfwCmd.UE_AUTH_RESP, auth_res
+            s1ap_types.tfwCmd.UE_AUTH_RESP, auth_res,
         )
 
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_SEC_MOD_CMD_IND.value
+            response.msg_type, s1ap_types.tfwCmd.UE_SEC_MOD_CMD_IND.value,
         )
         print("Received Security Mode Command ue-id", auth_res.ue_Id)
 
@@ -79,23 +78,23 @@ class TestEsmInformation(unittest.TestCase):
         sec_mode_complete = s1ap_types.ueSecModeComplete_t()
         sec_mode_complete.ue_Id = 1
         self._s1ap_wrapper._s1_util.issue_cmd(
-            s1ap_types.tfwCmd.UE_SEC_MOD_COMPLETE, sec_mode_complete
+            s1ap_types.tfwCmd.UE_SEC_MOD_COMPLETE, sec_mode_complete,
         )
 
         for i in range(num_of_expires):
             # Esm Information Request indication
             print(
-                "Received Esm Information Request ue-id", sec_mode_complete.ue_Id
+                "Received Esm Information Request ue-id", sec_mode_complete.ue_Id,
             )
             response = self._s1ap_wrapper.s1_util.get_response()
             self.assertEqual(
-                response.msg_type, s1ap_types.tfwCmd.UE_ESM_INFORMATION_REQ.value
+                response.msg_type, s1ap_types.tfwCmd.UE_ESM_INFORMATION_REQ.value,
             )
             esm_info_req = response.cast(s1ap_types.ueEsmInformationReq_t)
 
         # Sending Esm Information Response
         print(
-            "Sending Esm Information Response ue-id", sec_mode_complete.ue_Id
+            "Sending Esm Information Response ue-id", sec_mode_complete.ue_Id,
         )
         esm_info_response = s1ap_types.ueEsmInformationRsp_t()
         esm_info_response.ue_Id = 1
@@ -104,26 +103,26 @@ class TestEsmInformation(unittest.TestCase):
         s = "magma.ipv4"
         esm_info_response.pdnAPN_pr.len = len(s)
         esm_info_response.pdnAPN_pr.pdn_apn = (ctypes.c_ubyte * 100)(
-            *[ctypes.c_ubyte(ord(c)) for c in s[:100]]
+            *[ctypes.c_ubyte(ord(c)) for c in s[:100]],
         )
         self._s1ap_wrapper._s1_util.issue_cmd(
-            s1ap_types.tfwCmd.UE_ESM_INFORMATION_RSP, esm_info_response
+            s1ap_types.tfwCmd.UE_ESM_INFORMATION_RSP, esm_info_response,
         )
 
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.INT_CTX_SETUP_IND.value
+            response.msg_type, s1ap_types.tfwCmd.INT_CTX_SETUP_IND.value,
         )
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_ATTACH_ACCEPT_IND.value
+            response.msg_type, s1ap_types.tfwCmd.UE_ATTACH_ACCEPT_IND.value,
         )
 
         # Trigger Attach Complete
         attach_complete = s1ap_types.ueAttachComplete_t()
         attach_complete.ue_Id = 1
         self._s1ap_wrapper._s1_util.issue_cmd(
-            s1ap_types.tfwCmd.UE_ATTACH_COMPLETE, attach_complete
+            s1ap_types.tfwCmd.UE_ATTACH_COMPLETE, attach_complete,
         )
         # Wait on EMM Information from MME
         self._s1ap_wrapper._s1_util.receive_emm_info()
@@ -136,12 +135,12 @@ class TestEsmInformation(unittest.TestCase):
             s1ap_types.ueDetachType_t.UE_SWITCHOFF_DETACH.value
         )
         self._s1ap_wrapper._s1_util.issue_cmd(
-            s1ap_types.tfwCmd.UE_DETACH_REQUEST, detach_req
+            s1ap_types.tfwCmd.UE_DETACH_REQUEST, detach_req,
         )
         # Wait for UE context release command
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_CTX_REL_IND.value
+            response.msg_type, s1ap_types.tfwCmd.UE_CTX_REL_IND.value,
         )
 
 

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_esm_information_wrong_apn.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_esm_information_wrong_apn.py
@@ -11,13 +11,12 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
+import ctypes
+import time
 import unittest
 
 import s1ap_types
-import time
-
 from integ_tests.s1aptests import s1ap_wrapper
-import ctypes
 
 
 class TestEsmInformationWrongApn(unittest.TestCase):
@@ -48,12 +47,12 @@ class TestEsmInformationWrongApn(unittest.TestCase):
 
         print("Sending Attach Request ue-id", attach_req.ue_Id)
         self._s1ap_wrapper._s1_util.issue_cmd(
-            s1ap_types.tfwCmd.UE_ATTACH_REQUEST, attach_req
+            s1ap_types.tfwCmd.UE_ATTACH_REQUEST, attach_req,
         )
 
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_AUTH_REQ_IND.value
+            response.msg_type, s1ap_types.tfwCmd.UE_AUTH_REQ_IND.value,
         )
         print("Received auth req ind ")
 
@@ -64,12 +63,12 @@ class TestEsmInformationWrongApn(unittest.TestCase):
         auth_res.sqnRcvd = sqn_recvd
         print("Sending Auth Response ue-id", auth_res.ue_Id)
         self._s1ap_wrapper._s1_util.issue_cmd(
-            s1ap_types.tfwCmd.UE_AUTH_RESP, auth_res
+            s1ap_types.tfwCmd.UE_AUTH_RESP, auth_res,
         )
 
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_SEC_MOD_CMD_IND.value
+            response.msg_type, s1ap_types.tfwCmd.UE_SEC_MOD_CMD_IND.value,
         )
         print("Received Security Mode Command ue-id", auth_res.ue_Id)
 
@@ -78,21 +77,21 @@ class TestEsmInformationWrongApn(unittest.TestCase):
         sec_mode_complete = s1ap_types.ueSecModeComplete_t()
         sec_mode_complete.ue_Id = 1
         self._s1ap_wrapper._s1_util.issue_cmd(
-            s1ap_types.tfwCmd.UE_SEC_MOD_COMPLETE, sec_mode_complete
+            s1ap_types.tfwCmd.UE_SEC_MOD_COMPLETE, sec_mode_complete,
         )
 
         # Esm Information Request indication
         print(
-            "Received Esm Information Request ue-id", sec_mode_complete.ue_Id
+            "Received Esm Information Request ue-id", sec_mode_complete.ue_Id,
         )
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_ESM_INFORMATION_REQ.value
+            response.msg_type, s1ap_types.tfwCmd.UE_ESM_INFORMATION_REQ.value,
         )
         esm_info_req = response.cast(s1ap_types.ueEsmInformationReq_t)
         # Sending Esm Information Response
         print(
-            "Sending Esm Information Response ue-id", sec_mode_complete.ue_Id
+            "Sending Esm Information Response ue-id", sec_mode_complete.ue_Id,
         )
         esm_info_response = s1ap_types.ueEsmInformationRsp_t()
         esm_info_response.ue_Id = 1
@@ -101,15 +100,15 @@ class TestEsmInformationWrongApn(unittest.TestCase):
         s = "oai"
         esm_info_response.pdnAPN_pr.len = len(s)
         esm_info_response.pdnAPN_pr.pdn_apn = (ctypes.c_ubyte * 100)(
-            *[ctypes.c_ubyte(ord(c)) for c in s[:100]]
+            *[ctypes.c_ubyte(ord(c)) for c in s[:100]],
         )
         self._s1ap_wrapper._s1_util.issue_cmd(
-            s1ap_types.tfwCmd.UE_ESM_INFORMATION_RSP, esm_info_response
+            s1ap_types.tfwCmd.UE_ESM_INFORMATION_RSP, esm_info_response,
         )
 
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_ATTACH_REJECT_IND.value
+            response.msg_type, s1ap_types.tfwCmd.UE_ATTACH_REJECT_IND.value,
         )
 
         print("*** Running UE detach ***")
@@ -120,12 +119,12 @@ class TestEsmInformationWrongApn(unittest.TestCase):
             s1ap_types.ueDetachType_t.UE_SWITCHOFF_DETACH.value
         )
         self._s1ap_wrapper._s1_util.issue_cmd(
-            s1ap_types.tfwCmd.UE_DETACH_REQUEST, detach_req
+            s1ap_types.tfwCmd.UE_DETACH_REQUEST, detach_req,
         )
         # Wait for UE context release command
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_CTX_REL_IND.value
+            response.msg_type, s1ap_types.tfwCmd.UE_CTX_REL_IND.value,
         )
 
 

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_ics_drop_with_mme_restart.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_ics_drop_with_mme_restart.py
@@ -23,7 +23,7 @@ from s1ap_utils import MagmadUtil
 class TestAttachIcsDropWithMmeRestart(unittest.TestCase):
     def setUp(self):
         self._s1ap_wrapper = s1ap_wrapper.TestWrapper(
-            stateless_mode=MagmadUtil.stateless_cmds.ENABLE
+            stateless_mode=MagmadUtil.stateless_cmds.ENABLE,
         )
 
     def tearDown(self):
@@ -59,11 +59,11 @@ class TestAttachIcsDropWithMmeRestart(unittest.TestCase):
 
         print("******************** Sending Attach Request")
         self._s1ap_wrapper._s1_util.issue_cmd(
-            s1ap_types.tfwCmd.UE_ATTACH_REQUEST, attach_req
+            s1ap_types.tfwCmd.UE_ATTACH_REQUEST, attach_req,
         )
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_AUTH_REQ_IND.value
+            response.msg_type, s1ap_types.tfwCmd.UE_AUTH_REQ_IND.value,
         )
         print("******************** Received Authentiction Request Indication")
 
@@ -75,17 +75,17 @@ class TestAttachIcsDropWithMmeRestart(unittest.TestCase):
         auth_res.sqnRcvd = sqnRecvd
         print("******************** Sending Authentiction Response")
         self._s1ap_wrapper._s1_util.issue_cmd(
-            s1ap_types.tfwCmd.UE_AUTH_RESP, auth_res
+            s1ap_types.tfwCmd.UE_AUTH_RESP, auth_res,
         )
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_SEC_MOD_CMD_IND.value
+            response.msg_type, s1ap_types.tfwCmd.UE_SEC_MOD_CMD_IND.value,
         )
         print("******************** Received Security Mode Command Indication")
 
         print(
             "******************** Setting flag to drop Initial Context Setup "
-            "Request"
+            "Request",
         )
         drop_init_ctxt_setup_req = s1ap_types.UeDropInitCtxtSetup()
         drop_init_ctxt_setup_req.ue_Id = req.ue_id
@@ -93,7 +93,7 @@ class TestAttachIcsDropWithMmeRestart(unittest.TestCase):
         # Timer to release UE context at s1ap tester
         drop_init_ctxt_setup_req.tmrVal = 2000
         self._s1ap_wrapper._s1_util.issue_cmd(
-            s1ap_types.tfwCmd.UE_SET_DROP_ICS, drop_init_ctxt_setup_req
+            s1ap_types.tfwCmd.UE_SET_DROP_ICS, drop_init_ctxt_setup_req,
         )
 
         print("******************** Sending Security Mode Complete")
@@ -101,18 +101,18 @@ class TestAttachIcsDropWithMmeRestart(unittest.TestCase):
         sec_mode_complete = s1ap_types.ueSecModeComplete_t()
         sec_mode_complete.ue_Id = req.ue_id
         self._s1ap_wrapper._s1_util.issue_cmd(
-            s1ap_types.tfwCmd.UE_SEC_MOD_COMPLETE, sec_mode_complete
+            s1ap_types.tfwCmd.UE_SEC_MOD_COMPLETE, sec_mode_complete,
         )
 
         # enbApp sends UE_ICS_DROPD_IND message to tfwApp after dropping
         # ICS request
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_ICS_DROPD_IND.value
+            response.msg_type, s1ap_types.tfwCmd.UE_ICS_DROPD_IND.value,
         )
         print(
             "******************** Received Initial Context Setup Dropped "
-            "Indication"
+            "Indication",
         )
 
         print("******************** Restarting MME service on gateway")
@@ -120,13 +120,13 @@ class TestAttachIcsDropWithMmeRestart(unittest.TestCase):
 
         print(
             "******************** Resetting flag to not drop next Initial "
-            "Context Setup Request messages"
+            "Context Setup Request messages",
         )
         drop_init_ctxt_setup_req = s1ap_types.UeDropInitCtxtSetup()
         drop_init_ctxt_setup_req.ue_Id = req.ue_id
         drop_init_ctxt_setup_req.flag = 0
         self._s1ap_wrapper._s1_util.issue_cmd(
-            s1ap_types.tfwCmd.UE_SET_DROP_ICS, drop_init_ctxt_setup_req
+            s1ap_types.tfwCmd.UE_SET_DROP_ICS, drop_init_ctxt_setup_req,
         )
 
         for j in range(30):
@@ -141,7 +141,7 @@ class TestAttachIcsDropWithMmeRestart(unittest.TestCase):
         # command to release the S1AP context
         print(
             "******************** Waiting for NW initiated Detach Request or "
-            "UE Context Release Indication"
+            "UE Context Release Indication",
         )
         resp_count = 0
         while True:
@@ -153,7 +153,7 @@ class TestAttachIcsDropWithMmeRestart(unittest.TestCase):
                 == s1ap_types.tfwCmd.UE_NW_INIT_DETACH_REQUEST.value
             ):
                 nw_init_detach_req = response.cast(
-                    s1ap_types.ueNwInitdetachReq_t
+                    s1ap_types.ueNwInitdetachReq_t,
                 )
                 print(
                     "******************** Received NW initiated Detach Request"
@@ -171,7 +171,7 @@ class TestAttachIcsDropWithMmeRestart(unittest.TestCase):
                     detach_accept.ue_Id = req.ue_id
                     print(
                         "******************** Sending UE triggered Detach "
-                        "Accept message"
+                        "Accept message",
                     )
                     self._s1ap_wrapper._s1_util.issue_cmd(
                         s1ap_types.tfwCmd.UE_TRIGGERED_DETACH_ACCEPT,
@@ -187,7 +187,7 @@ class TestAttachIcsDropWithMmeRestart(unittest.TestCase):
                 break
 
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_CTX_REL_IND.value
+            response.msg_type, s1ap_types.tfwCmd.UE_CTX_REL_IND.value,
         )
         print("******************** Received UE Context Release indication")
 

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_ics_failure_with_mme_restart.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_ics_failure_with_mme_restart.py
@@ -23,7 +23,7 @@ from s1ap_utils import MagmadUtil
 class TestAttachIcsFailureWithMmeRestart(unittest.TestCase):
     def setUp(self):
         self._s1ap_wrapper = s1ap_wrapper.TestWrapper(
-            stateless_mode=MagmadUtil.stateless_cmds.ENABLE
+            stateless_mode=MagmadUtil.stateless_cmds.ENABLE,
         )
 
     def tearDown(self):
@@ -59,11 +59,11 @@ class TestAttachIcsFailureWithMmeRestart(unittest.TestCase):
 
         print("******************** Sending Attach Request")
         self._s1ap_wrapper._s1_util.issue_cmd(
-            s1ap_types.tfwCmd.UE_ATTACH_REQUEST, attach_req
+            s1ap_types.tfwCmd.UE_ATTACH_REQUEST, attach_req,
         )
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_AUTH_REQ_IND.value
+            response.msg_type, s1ap_types.tfwCmd.UE_AUTH_REQ_IND.value,
         )
         print("******************** Received Authentiction Request Indication")
 
@@ -76,24 +76,24 @@ class TestAttachIcsFailureWithMmeRestart(unittest.TestCase):
 
         print("******************** Sending Authentiction Response")
         self._s1ap_wrapper._s1_util.issue_cmd(
-            s1ap_types.tfwCmd.UE_AUTH_RESP, auth_res
+            s1ap_types.tfwCmd.UE_AUTH_RESP, auth_res,
         )
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_SEC_MOD_CMD_IND.value
+            response.msg_type, s1ap_types.tfwCmd.UE_SEC_MOD_CMD_IND.value,
         )
         print("******************** Received Security Mode Command Indication")
 
         print(
             "******************** Setting flag to send Initial Context Setup "
-            "Failure"
+            "Failure",
         )
         init_ctxt_setup_fail = s1ap_types.ueInitCtxtSetupFail()
         init_ctxt_setup_fail.ue_Id = req.ue_id
         init_ctxt_setup_fail.flag = 1
         init_ctxt_setup_fail.causeType = 0
         self._s1ap_wrapper._s1_util.issue_cmd(
-            s1ap_types.tfwCmd.UE_SET_INIT_CTXT_SETUP_FAIL, init_ctxt_setup_fail
+            s1ap_types.tfwCmd.UE_SET_INIT_CTXT_SETUP_FAIL, init_ctxt_setup_fail,
         )
 
         print("******************** Sending Security Mode Complete")
@@ -101,12 +101,12 @@ class TestAttachIcsFailureWithMmeRestart(unittest.TestCase):
         sec_mode_complete = s1ap_types.ueSecModeComplete_t()
         sec_mode_complete.ue_Id = req.ue_id
         self._s1ap_wrapper._s1_util.issue_cmd(
-            s1ap_types.tfwCmd.UE_SEC_MOD_COMPLETE, sec_mode_complete
+            s1ap_types.tfwCmd.UE_SEC_MOD_COMPLETE, sec_mode_complete,
         )
 
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.INT_CTX_SETUP_IND.value
+            response.msg_type, s1ap_types.tfwCmd.INT_CTX_SETUP_IND.value,
         )
         print("******************** Received Initial Context Setup Indication")
 
@@ -119,10 +119,10 @@ class TestAttachIcsFailureWithMmeRestart(unittest.TestCase):
         init_ctxt_setup_fail.causeType = 0
         print(
             "******************** Resetting flag to not send Initial Context "
-            "Setup Failure"
+            "Setup Failure",
         )
         self._s1ap_wrapper._s1_util.issue_cmd(
-            s1ap_types.tfwCmd.UE_SET_INIT_CTXT_SETUP_FAIL, init_ctxt_setup_fail
+            s1ap_types.tfwCmd.UE_SET_INIT_CTXT_SETUP_FAIL, init_ctxt_setup_fail,
         )
 
         for j in range(30):
@@ -132,7 +132,7 @@ class TestAttachIcsFailureWithMmeRestart(unittest.TestCase):
         # Waiting for UE Context Release indication
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_CTX_REL_IND.value
+            response.msg_type, s1ap_types.tfwCmd.UE_CTX_REL_IND.value,
         )
         print("******************** Received UE Context Release indication")
 

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_implicit_detach_timer_expiry.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_implicit_detach_timer_expiry.py
@@ -11,8 +11,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-import unittest
 import time
+import unittest
 
 import gpp_types
 import s1ap_types
@@ -75,11 +75,11 @@ class TestAttachImplicitDetachTimerExpiry(unittest.TestCase):
         req.ue_Id = ue_id
         req.cause.causeVal = gpp_types.CauseRadioNetwork.USER_INACTIVITY.value
         self._s1ap_wrapper.s1_util.issue_cmd(
-            s1ap_types.tfwCmd.UE_CNTXT_REL_REQUEST, req
+            s1ap_types.tfwCmd.UE_CNTXT_REL_REQUEST, req,
         )
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_CTX_REL_IND.value
+            response.msg_type, s1ap_types.tfwCmd.UE_CTX_REL_IND.value,
         )
 
         # For implicit detach timer to expire, first ensure that
@@ -88,7 +88,7 @@ class TestAttachImplicitDetachTimerExpiry(unittest.TestCase):
         # DETACH TIMER VALUE = mobile reachability timer value + delta value
         print(
             "************************* Waiting for Implicit Detach Timer"
-            " to expire. Sleeping for 740 seconds.."
+            " to expire. Sleeping for 740 seconds..",
         )
         timeSlept = 0
         while timeSlept < 740:
@@ -107,15 +107,15 @@ class TestAttachImplicitDetachTimerExpiry(unittest.TestCase):
         req.ueMtmsi.pres = False
         req.rrcCause = s1ap_types.Rrc_Cause.TFW_MO_DATA.value
         self._s1ap_wrapper.s1_util.issue_cmd(
-            s1ap_types.tfwCmd.UE_SERVICE_REQUEST, req
+            s1ap_types.tfwCmd.UE_SERVICE_REQUEST, req,
         )
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_SERVICE_REJECT_IND.value
+            response.msg_type, s1ap_types.tfwCmd.UE_SERVICE_REJECT_IND.value,
         )
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_CTX_REL_IND.value
+            response.msg_type, s1ap_types.tfwCmd.UE_CTX_REL_IND.value,
         )
 
         time.sleep(0.5)

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_inactive_tau_with_combined_tala_update_reattach.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_inactive_tau_with_combined_tala_update_reattach.py
@@ -11,8 +11,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-import unittest
 import time
+import unittest
 
 import gpp_types
 import s1ap_types
@@ -69,14 +69,14 @@ class TestAttachInactiveTauWithCombinedTalaUpdateReattach(unittest.TestCase):
         req.ue_Id = ue_id
         req.cause.causeVal = gpp_types.CauseRadioNetwork.USER_INACTIVITY.value
         self._s1ap_wrapper.s1_util.issue_cmd(
-            s1ap_types.tfwCmd.UE_CNTXT_REL_REQUEST, req
+            s1ap_types.tfwCmd.UE_CNTXT_REL_REQUEST, req,
         )
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_CTX_REL_IND.value
+            response.msg_type, s1ap_types.tfwCmd.UE_CTX_REL_IND.value,
         )
         print(
-            "************************* Received UE context release indication"
+            "************************* Received UE context release indication",
         )
 
         print(
@@ -95,19 +95,19 @@ class TestAttachInactiveTauWithCombinedTalaUpdateReattach(unittest.TestCase):
         # Waiting for TAU Reject Indication -Combined TALA update not supported
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_TAU_REJECT_IND.value
+            response.msg_type, s1ap_types.tfwCmd.UE_TAU_REJECT_IND.value,
         )
         print(
             "************************* Received Tracking Area Update Reject "
-            "Indication"
+            "Indication",
         )
 
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_CTX_REL_IND.value
+            response.msg_type, s1ap_types.tfwCmd.UE_CTX_REL_IND.value,
         )
         print(
-            "************************* Received UE context release indication"
+            "************************* Received UE context release indication",
         )
 
         print(
@@ -135,7 +135,7 @@ class TestAttachInactiveTauWithCombinedTalaUpdateReattach(unittest.TestCase):
         )
         # Now detach the UE
         self._s1ap_wrapper.s1_util.detach(
-            ue_id, s1ap_types.ueDetachType_t.UE_SWITCHOFF_DETACH.value, True
+            ue_id, s1ap_types.ueDetachType_t.UE_SWITCHOFF_DETACH.value, True,
         )
 
 

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_ipv4v6_pdn_type.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_ipv4v6_pdn_type.py
@@ -12,9 +12,10 @@ limitations under the License.
 """
 
 
+import unittest
+
 import s1ap_types
 import s1ap_wrapper
-import unittest
 
 
 class TestAttachIpv4v6PdnType(unittest.TestCase):
@@ -29,15 +30,15 @@ class TestAttachIpv4v6PdnType(unittest.TestCase):
             capable """
         # Set PDN TYPE to IPv4V6 i.e. 3. IPV4 is equal to 1
         resp_ipv4_ipv6 = self._create_attach_ipv4v6_pdn_type_req(
-            pdn_type_value=3
+            pdn_type_value=3,
         )
         self.assertEqual(
-            resp_ipv4_ipv6.msg_type, s1ap_types.tfwCmd.UE_CTX_REL_IND.value
+            resp_ipv4_ipv6.msg_type, s1ap_types.tfwCmd.UE_CTX_REL_IND.value,
         )
         # IPv6 is equal to 2
         resp_ipv6 = self._create_attach_ipv4v6_pdn_type_req(pdn_type_value=2)
         self.assertEqual(
-            resp_ipv6.msg_type, s1ap_types.tfwCmd.UE_CTX_REL_IND.value
+            resp_ipv6.msg_type, s1ap_types.tfwCmd.UE_CTX_REL_IND.value,
         )
 
     def _create_attach_ipv4v6_pdn_type_req(self, pdn_type_value):
@@ -66,11 +67,11 @@ class TestAttachIpv4v6PdnType(unittest.TestCase):
             pdn_type_value,
         )
         self._s1ap_wrapper._s1_util.issue_cmd(
-            s1ap_types.tfwCmd.UE_ATTACH_REQUEST, attach_req
+            s1ap_types.tfwCmd.UE_ATTACH_REQUEST, attach_req,
         )
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_AUTH_REQ_IND.value
+            response.msg_type, s1ap_types.tfwCmd.UE_AUTH_REQ_IND.value,
         )
 
         # Trigger Authentication Response
@@ -80,41 +81,41 @@ class TestAttachIpv4v6PdnType(unittest.TestCase):
         sqnRecvd.pres = 0
         auth_res.sqnRcvd = sqnRecvd
         self._s1ap_wrapper._s1_util.issue_cmd(
-            s1ap_types.tfwCmd.UE_AUTH_RESP, auth_res
+            s1ap_types.tfwCmd.UE_AUTH_RESP, auth_res,
         )
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_SEC_MOD_CMD_IND.value
+            response.msg_type, s1ap_types.tfwCmd.UE_SEC_MOD_CMD_IND.value,
         )
 
         # Trigger Security Mode Complete
         sec_mode_complete = s1ap_types.ueSecModeComplete_t()
         sec_mode_complete.ue_Id = ue_req.ue_id
         self._s1ap_wrapper._s1_util.issue_cmd(
-            s1ap_types.tfwCmd.UE_SEC_MOD_COMPLETE, sec_mode_complete
+            s1ap_types.tfwCmd.UE_SEC_MOD_COMPLETE, sec_mode_complete,
         )
         # Attach Reject will be sent since IPv6 PDN Type is not configured
         if pdn_type_value == 2:
             response = self._s1ap_wrapper.s1_util.get_response()
             self.assertEqual(
-                response.msg_type, s1ap_types.tfwCmd.UE_ATTACH_REJECT_IND.value
+                response.msg_type, s1ap_types.tfwCmd.UE_ATTACH_REJECT_IND.value,
             )
             return self._s1ap_wrapper.s1_util.get_response()
 
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.INT_CTX_SETUP_IND.value
+            response.msg_type, s1ap_types.tfwCmd.INT_CTX_SETUP_IND.value,
         )
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_ATTACH_ACCEPT_IND.value
+            response.msg_type, s1ap_types.tfwCmd.UE_ATTACH_ACCEPT_IND.value,
         )
 
         # Trigger Attach Complete
         attach_complete = s1ap_types.ueAttachComplete_t()
         attach_complete.ue_Id = ue_req.ue_id
         self._s1ap_wrapper._s1_util.issue_cmd(
-            s1ap_types.tfwCmd.UE_ATTACH_COMPLETE, attach_complete
+            s1ap_types.tfwCmd.UE_ATTACH_COMPLETE, attach_complete,
         )
 
         # Wait on EMM Information from MME
@@ -127,7 +128,7 @@ class TestAttachIpv4v6PdnType(unittest.TestCase):
             s1ap_types.ueDetachType_t.UE_SWITCHOFF_DETACH.value
         )
         self._s1ap_wrapper._s1_util.issue_cmd(
-            s1ap_types.tfwCmd.UE_DETACH_REQUEST, detach_req
+            s1ap_types.tfwCmd.UE_DETACH_REQUEST, detach_req,
         )
 
         # Wait for UE context release command

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_missing_imsi.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_missing_imsi.py
@@ -31,18 +31,22 @@ class TestAttachMissingImsi(unittest.TestCase):
         self._s1ap_wrapper.configUEDevice(1)
         req = self._s1ap_wrapper.ue_req
         ue_id = req.ue_id
-        print("************************* Running End to End attach for ",
-              "UE id ", ue_id)
+        print(
+            "************************* Running End to End attach for ",
+            "UE id ", ue_id,
+        )
         self._s1ap_wrapper._sub_util.cleanup()
         # Now actually attempt the attach
         self._s1ap_wrapper._s1_util.attach(
             ue_id, s1ap_types.tfwCmd.UE_END_TO_END_ATTACH_REQUEST,
             s1ap_types.tfwCmd.UE_ATTACH_REJECT_IND,
-            s1ap_types.ueAttachRejInd_t)
+            s1ap_types.ueAttachRejInd_t,
+        )
 
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_CTX_REL_IND.value)
+            response.msg_type, s1ap_types.tfwCmd.UE_CTX_REL_IND.value,
+        )
 
         ue_id = 2
         print("************************* Adding IMSI entry for UE id ", ue_id)
@@ -51,13 +55,16 @@ class TestAttachMissingImsi(unittest.TestCase):
 
         time.sleep(5)
 
-        print("************************* Rerunning End to End attach for ",
-              "UE id ", ue_id)
+        print(
+            "************************* Rerunning End to End attach for ",
+            "UE id ", ue_id,
+        )
         # Now actually complete the attach
         self._s1ap_wrapper._s1_util.attach(
             ue_id, s1ap_types.tfwCmd.UE_END_TO_END_ATTACH_REQUEST,
             s1ap_types.tfwCmd.UE_ATTACH_ACCEPT_IND,
-            s1ap_types.ueAttachAccept_t)
+            s1ap_types.ueAttachAccept_t,
+        )
 
         # Wait on EMM Information from MME
         self._s1ap_wrapper._s1_util.receive_emm_info()
@@ -65,7 +72,8 @@ class TestAttachMissingImsi(unittest.TestCase):
         print("************************* Running UE detach for UE id ", ue_id)
         # Now detach the UE
         self._s1ap_wrapper.s1_util.detach(
-            ue_id, s1ap_types.ueDetachType_t.UE_SWITCHOFF_DETACH.value, False)
+            ue_id, s1ap_types.ueDetachType_t.UE_SWITCHOFF_DETACH.value, False,
+        )
 
 
 if __name__ == "__main__":

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_mme_restart_detach_multi_ue.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_mme_restart_detach_multi_ue.py
@@ -11,19 +11,19 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
+import random
 import time
 import unittest
 
 import s1ap_types
 import s1ap_wrapper
 from s1ap_utils import MagmadUtil
-import random
 
 
 class TestAttachMmeRestartDetachMultiUe(unittest.TestCase):
     def setUp(self):
         self._s1ap_wrapper = s1ap_wrapper.TestWrapper(
-            stateless_mode=MagmadUtil.stateless_cmds.ENABLE
+            stateless_mode=MagmadUtil.stateless_cmds.ENABLE,
         )
 
     def tearDown(self):

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_mobile_reachability_timer_expiry.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_mobile_reachability_timer_expiry.py
@@ -11,8 +11,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-import unittest
 import time
+import unittest
 
 import gpp_types
 import s1ap_types
@@ -74,18 +74,18 @@ class TestAttachMobileReachabilityTimerExpiry(unittest.TestCase):
         req.ue_Id = ue_id
         req.cause.causeVal = gpp_types.CauseRadioNetwork.USER_INACTIVITY.value
         self._s1ap_wrapper.s1_util.issue_cmd(
-            s1ap_types.tfwCmd.UE_CNTXT_REL_REQUEST, req
+            s1ap_types.tfwCmd.UE_CNTXT_REL_REQUEST, req,
         )
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_CTX_REL_IND.value
+            response.msg_type, s1ap_types.tfwCmd.UE_CTX_REL_IND.value,
         )
 
         # Delay by 6 minutes to ensure Mobile reachability timer expires.
         # MOBILE REACHABILITY TIMER VALUE = 1 minute (conf file) + delta value
         print(
             "************************* Waiting for Mobile Reachability Timer"
-            " to expire. Sleeping for 360 seconds.."
+            " to expire. Sleeping for 360 seconds..",
         )
         timeSlept = 0
         while timeSlept < 360:
@@ -104,17 +104,17 @@ class TestAttachMobileReachabilityTimerExpiry(unittest.TestCase):
         req.ueMtmsi.pres = False
         req.rrcCause = s1ap_types.Rrc_Cause.TFW_MO_DATA.value
         self._s1ap_wrapper.s1_util.issue_cmd(
-            s1ap_types.tfwCmd.UE_SERVICE_REQUEST, req
+            s1ap_types.tfwCmd.UE_SERVICE_REQUEST, req,
         )
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.INT_CTX_SETUP_IND.value
+            response.msg_type, s1ap_types.tfwCmd.INT_CTX_SETUP_IND.value,
         )
 
         print("************************* Running UE detach for UE id ", ue_id)
         # Now detach the UE
         self._s1ap_wrapper.s1_util.detach(
-            ue_id, s1ap_types.ueDetachType_t.UE_SWITCHOFF_DETACH.value, True
+            ue_id, s1ap_types.ueDetachType_t.UE_SWITCHOFF_DETACH.value, True,
         )
 
 

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_no_initial_context_resp.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_no_initial_context_resp.py
@@ -41,11 +41,11 @@ class TestAttachNoInitialContextSetupResp(unittest.TestCase):
         attach_req.useOldSecCtxt = sec_ctxt
 
         self._s1ap_wrapper._s1_util.issue_cmd(
-            s1ap_types.tfwCmd.UE_ATTACH_REQUEST, attach_req
+            s1ap_types.tfwCmd.UE_ATTACH_REQUEST, attach_req,
         )
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_AUTH_REQ_IND.value
+            response.msg_type, s1ap_types.tfwCmd.UE_AUTH_REQ_IND.value,
         )
         auth_res = s1ap_types.ueAuthResp_t()
         auth_res.ue_Id = req.ue_id
@@ -53,26 +53,26 @@ class TestAttachNoInitialContextSetupResp(unittest.TestCase):
         sqnrecvd.pres = 0
         auth_res.sqnRcvd = sqnrecvd
         self._s1ap_wrapper._s1_util.issue_cmd(
-            s1ap_types.tfwCmd.UE_AUTH_RESP, auth_res
+            s1ap_types.tfwCmd.UE_AUTH_RESP, auth_res,
         )
         response = self._s1ap_wrapper.s1_util.get_response()
 
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_SEC_MOD_CMD_IND.value
+            response.msg_type, s1ap_types.tfwCmd.UE_SEC_MOD_CMD_IND.value,
         )
 
         sec_mode_complete = s1ap_types.ueSecModeComplete_t()
         sec_mode_complete.ue_Id = req.ue_id
         self._s1ap_wrapper._s1_util.issue_cmd(
-            s1ap_types.tfwCmd.UE_SEC_MOD_COMPLETE, sec_mode_complete
+            s1ap_types.tfwCmd.UE_SEC_MOD_COMPLETE, sec_mode_complete,
         )
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.INT_CTX_SETUP_IND.value
+            response.msg_type, s1ap_types.tfwCmd.INT_CTX_SETUP_IND.value,
         )
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_ATTACH_ACCEPT_IND.value
+            response.msg_type, s1ap_types.tfwCmd.UE_ATTACH_ACCEPT_IND.value,
         )
 
         print(
@@ -84,7 +84,7 @@ class TestAttachNoInitialContextSetupResp(unittest.TestCase):
         sctp_abort = s1ap_types.FwSctpAbortReq_t()
         sctp_abort.cause = 0
         self._s1ap_wrapper._s1_util.issue_cmd(
-            s1ap_types.tfwCmd.SCTP_ABORT_REQ, sctp_abort
+            s1ap_types.tfwCmd.SCTP_ABORT_REQ, sctp_abort,
         )
         print(
             "************************* Send Initial context Setup response ",

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_nw_initiated_detach_with_mme_restart.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_nw_initiated_detach_with_mme_restart.py
@@ -11,19 +11,18 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-import unittest
-import s1ap_types
 import time
+import unittest
 
+import s1ap_types
 from integ_tests.s1aptests import s1ap_wrapper
-from integ_tests.s1aptests.s1ap_utils import SpgwUtil
-from integ_tests.s1aptests.s1ap_utils import MagmadUtil
+from integ_tests.s1aptests.s1ap_utils import MagmadUtil, SpgwUtil
 
 
 class TestAttachNwInitiatedDetachWithMmeRestart(unittest.TestCase):
     def setUp(self):
         self._s1ap_wrapper = s1ap_wrapper.TestWrapper(
-            stateless_mode=MagmadUtil.stateless_cmds.ENABLE
+            stateless_mode=MagmadUtil.stateless_cmds.ENABLE,
         )
         self._spgw_util = SpgwUtil()
 
@@ -104,7 +103,7 @@ class TestAttachNwInitiatedDetachWithMmeRestart(unittest.TestCase):
         detach_accept = s1ap_types.ueTrigDetachAcceptInd_t()
         detach_accept.ue_Id = req.ue_id
         self._s1ap_wrapper._s1_util.issue_cmd(
-            s1ap_types.tfwCmd.UE_TRIGGERED_DETACH_ACCEPT, detach_accept
+            s1ap_types.tfwCmd.UE_TRIGGERED_DETACH_ACCEPT, detach_accept,
         )
 
 

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_restricted_plmn.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_restricted_plmn.py
@@ -12,12 +12,12 @@ limitations under the License.
 """
 
 
+import ctypes
+import time
 import unittest
 
 import s1ap_types
 import s1ap_wrapper
-import ctypes
-import time
 
 
 class TestAttachRestrictedPlmn(unittest.TestCase):
@@ -74,19 +74,19 @@ class TestAttachRestrictedPlmn(unittest.TestCase):
             req.ue_id,
         )
         self._s1ap_wrapper._s1_util.issue_cmd(
-            s1ap_types.tfwCmd.UE_ATTACH_REQUEST, attach_req
+            s1ap_types.tfwCmd.UE_ATTACH_REQUEST, attach_req,
         )
 
         # Attach Reject
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_ATTACH_REJECT_IND.value
+            response.msg_type, s1ap_types.tfwCmd.UE_ATTACH_REJECT_IND.value,
         )
 
         attach_rej = response.cast(s1ap_types.ueAttachRejInd_t)
         print(
             "************************* Received attach reject for "
-            "UE id %d with cause %d" % (req.ue_id, attach_rej.cause)
+            "UE id %d with cause %d" % (req.ue_id, attach_rej.cause),
         )
 
         # Verify cause
@@ -95,7 +95,7 @@ class TestAttachRestrictedPlmn(unittest.TestCase):
         # Context release
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_CTX_REL_IND.value
+            response.msg_type, s1ap_types.tfwCmd.UE_CTX_REL_IND.value,
         )
         print(
             "************************* Received ue context release cmd for "
@@ -126,7 +126,7 @@ class TestAttachRestrictedPlmn(unittest.TestCase):
         print("********************** Running UE detach for UE id ", req.ue_id)
         # Now detach the UE
         self._s1ap_wrapper.s1_util.detach(
-            req.ue_id, s1ap_types.ueDetachType_t.UE_NORMAL_DETACH.value
+            req.ue_id, s1ap_types.ueDetachType_t.UE_NORMAL_DETACH.value,
         )
 
 

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_security_mode_reject.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_security_mode_reject.py
@@ -11,11 +11,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
+import time
 import unittest
 
 import s1ap_types
-import time
-
 from integ_tests.s1aptests import s1ap_wrapper
 
 
@@ -47,12 +46,12 @@ class TestSecurityModeReject(unittest.TestCase):
 
         print("Sending Attach Request ue-id", attach_req.ue_Id)
         self._s1ap_wrapper._s1_util.issue_cmd(
-            s1ap_types.tfwCmd.UE_ATTACH_REQUEST, attach_req
+            s1ap_types.tfwCmd.UE_ATTACH_REQUEST, attach_req,
         )
 
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_AUTH_REQ_IND.value
+            response.msg_type, s1ap_types.tfwCmd.UE_AUTH_REQ_IND.value,
         )
         print("Received auth req ind ")
 
@@ -63,12 +62,12 @@ class TestSecurityModeReject(unittest.TestCase):
         auth_res.sqnRcvd = sqn_recvd
         print("Sending Auth Response ue-id", auth_res.ue_Id)
         self._s1ap_wrapper._s1_util.issue_cmd(
-            s1ap_types.tfwCmd.UE_AUTH_RESP, auth_res
+            s1ap_types.tfwCmd.UE_AUTH_RESP, auth_res,
         )
 
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_SEC_MOD_CMD_IND.value
+            response.msg_type, s1ap_types.tfwCmd.UE_SEC_MOD_CMD_IND.value,
         )
         print("Received Security Mode Command ue-id", auth_res.ue_Id)
 
@@ -77,7 +76,7 @@ class TestSecurityModeReject(unittest.TestCase):
         sec_mode_reject.cause = s1ap_types.TFW_EMM_CAUSE_SEC_MOD_REJ_UNSP
         print("Sending Security Mode Reject ue-id", sec_mode_reject.ue_Id)
         self._s1ap_wrapper._s1_util.issue_cmd(
-            s1ap_types.tfwCmd.UE_SEC_MOD_REJECT, sec_mode_reject
+            s1ap_types.tfwCmd.UE_SEC_MOD_REJECT, sec_mode_reject,
         )
         time.sleep(2)
 

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_service.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_service.py
@@ -11,8 +11,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-import unittest
 import time
+import unittest
 
 import gpp_types
 import s1ap_types
@@ -34,13 +34,16 @@ class TestAttachService(unittest.TestCase):
         self._s1ap_wrapper.configUEDevice(1)
         req = self._s1ap_wrapper.ue_req
         ue_id = req.ue_id
-        print("************************* Running End to End attach for UE id ",
-              ue_id)
+        print(
+            "************************* Running End to End attach for UE id ",
+            ue_id,
+        )
         # Now actually complete the attach
         self._s1ap_wrapper._s1_util.attach(
             ue_id, s1ap_types.tfwCmd.UE_END_TO_END_ATTACH_REQUEST,
             s1ap_types.tfwCmd.UE_ATTACH_ACCEPT_IND,
-            s1ap_types.ueAttachAccept_t)
+            s1ap_types.ueAttachAccept_t,
+        )
 
         # Wait on EMM Information from MME
         self._s1ap_wrapper._s1_util.receive_emm_info()
@@ -49,20 +52,26 @@ class TestAttachService(unittest.TestCase):
         # context release
         time.sleep(0.5)
 
-        print("************************* Sending UE context release request ",
-              "for UE id ", ue_id)
+        print(
+            "************************* Sending UE context release request ",
+            "for UE id ", ue_id,
+        )
         # Send UE context release request to move UE to idle mode
         req = s1ap_types.ueCntxtRelReq_t()
         req.ue_Id = ue_id
         req.cause.causeVal = gpp_types.CauseRadioNetwork.USER_INACTIVITY.value
         self._s1ap_wrapper.s1_util.issue_cmd(
-            s1ap_types.tfwCmd.UE_CNTXT_REL_REQUEST, req)
+            s1ap_types.tfwCmd.UE_CNTXT_REL_REQUEST, req,
+        )
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_CTX_REL_IND.value)
+            response.msg_type, s1ap_types.tfwCmd.UE_CTX_REL_IND.value,
+        )
 
-        print("************************* Sending Service request for UE id ",
-              ue_id)
+        print(
+            "************************* Sending Service request for UE id ",
+            ue_id,
+        )
         # Send service request to reconnect UE
         req = s1ap_types.ueserviceReq_t()
         req.ue_Id = ue_id
@@ -70,16 +79,21 @@ class TestAttachService(unittest.TestCase):
         req.ueMtmsi.pres = False
         req.rrcCause = s1ap_types.Rrc_Cause.TFW_MO_DATA.value
         self._s1ap_wrapper.s1_util.issue_cmd(
-            s1ap_types.tfwCmd.UE_SERVICE_REQUEST, req)
+            s1ap_types.tfwCmd.UE_SERVICE_REQUEST, req,
+        )
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.INT_CTX_SETUP_IND.value)
+            response.msg_type, s1ap_types.tfwCmd.INT_CTX_SETUP_IND.value,
+        )
 
-        print("************************* Running UE detach for UE id ",
-              ue_id)
+        print(
+            "************************* Running UE detach for UE id ",
+            ue_id,
+        )
         # Now detach the UE
         self._s1ap_wrapper.s1_util.detach(
-            ue_id, s1ap_types.ueDetachType_t.UE_SWITCHOFF_DETACH.value, True)
+            ue_id, s1ap_types.ueDetachType_t.UE_SWITCHOFF_DETACH.value, True,
+        )
 
 
 if __name__ == "__main__":

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_service_multi_ue.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_service_multi_ue.py
@@ -11,8 +11,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-import unittest
 import time
+import unittest
 
 import gpp_types
 import s1ap_types
@@ -36,13 +36,16 @@ class TestAttachServiceMultiUe(unittest.TestCase):
         reqs = tuple(self._s1ap_wrapper.ue_req for _ in range(num_ues))
 
         for req in reqs:
-            print("************************* Running End to End attach for UE ",
-                  "id ", req.ue_id)
+            print(
+                "************************* Running End to End attach for UE ",
+                "id ", req.ue_id,
+            )
             # Now actually complete the attach
             self._s1ap_wrapper._s1_util.attach(
                 req.ue_id, s1ap_types.tfwCmd.UE_END_TO_END_ATTACH_REQUEST,
                 s1ap_types.tfwCmd.UE_ATTACH_ACCEPT_IND,
-                s1ap_types.ueAttachAccept_t)
+                s1ap_types.ueAttachAccept_t,
+            )
 
             # Wait on EMM Information from MME
             self._s1ap_wrapper._s1_util.receive_emm_info()
@@ -53,22 +56,28 @@ class TestAttachServiceMultiUe(unittest.TestCase):
 
         for req in reqs:
             ue_id = req.ue_id
-            print("************************* Sending UE context release "
-                  "request for UE id ", ue_id)
+            print(
+                "************************* Sending UE context release "
+                "request for UE id ", ue_id,
+            )
             # Send UE context release request to move UE to idle mode
             req = s1ap_types.ueCntxtRelReq_t()
             req.ue_Id = ue_id
             req.cause.causeVal = gpp_types.CauseRadioNetwork.USER_INACTIVITY.value
             self._s1ap_wrapper.s1_util.issue_cmd(
-                s1ap_types.tfwCmd.UE_CNTXT_REL_REQUEST, req)
+                s1ap_types.tfwCmd.UE_CNTXT_REL_REQUEST, req,
+            )
             response = self._s1ap_wrapper.s1_util.get_response()
             self.assertEqual(
-                response.msg_type, s1ap_types.tfwCmd.UE_CTX_REL_IND.value)
+                response.msg_type, s1ap_types.tfwCmd.UE_CTX_REL_IND.value,
+            )
 
         for req in reqs:
             ue_id = req.ue_id
-            print("************************* Sending Service request for UE "
-                  "id ", ue_id)
+            print(
+                "************************* Sending Service request for UE "
+                "id ", ue_id,
+            )
             # Send service request to reconnect UE
             req = s1ap_types.ueserviceReq_t()
             req.ue_Id = ue_id
@@ -76,18 +85,23 @@ class TestAttachServiceMultiUe(unittest.TestCase):
             req.ueMtmsi.pres = False
             req.rrcCause = s1ap_types.Rrc_Cause.TFW_MO_DATA.value
             self._s1ap_wrapper.s1_util.issue_cmd(
-                s1ap_types.tfwCmd.UE_SERVICE_REQUEST, req)
+                s1ap_types.tfwCmd.UE_SERVICE_REQUEST, req,
+            )
             response = self._s1ap_wrapper.s1_util.get_response()
             self.assertEqual(
-                response.msg_type, s1ap_types.tfwCmd.INT_CTX_SETUP_IND.value)
+                response.msg_type, s1ap_types.tfwCmd.INT_CTX_SETUP_IND.value,
+            )
 
         for req in reqs:
-            print("************************* Running UE detach for UE id ",
-                  req.ue_id)
+            print(
+                "************************* Running UE detach for UE id ",
+                req.ue_id,
+            )
             # Now detach the UE
             self._s1ap_wrapper.s1_util.detach(
                 req.ue_id, s1ap_types.ueDetachType_t.UE_SWITCHOFF_DETACH.value,
-                True)
+                True,
+            )
 
 
 if __name__ == "__main__":

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_service_ue_radio_capability.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_service_ue_radio_capability.py
@@ -11,8 +11,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-import unittest
 import time
+import unittest
 
 import gpp_types
 import s1ap_types
@@ -34,13 +34,16 @@ class TestAttachServiceUeRadioCapability(unittest.TestCase):
         self._s1ap_wrapper.configUEDevice(1)
         req = self._s1ap_wrapper.ue_req
         ue_id = req.ue_id
-        print("************************* Running End to End attach for UE id ",
-              ue_id)
+        print(
+            "************************* Running End to End attach for UE id ",
+            ue_id,
+        )
         # Now actually complete the attach
         self._s1ap_wrapper._s1_util.attach(
             ue_id, s1ap_types.tfwCmd.UE_END_TO_END_ATTACH_REQUEST,
             s1ap_types.tfwCmd.UE_ATTACH_ACCEPT_IND,
-            s1ap_types.ueAttachAccept_t)
+            s1ap_types.ueAttachAccept_t,
+        )
 
         # Wait on EMM Information from MME
         self._s1ap_wrapper._s1_util.receive_emm_info()
@@ -50,20 +53,26 @@ class TestAttachServiceUeRadioCapability(unittest.TestCase):
 
         time.sleep(0.5)
 
-        print("************************* Sending UE context release request ",
-              "for UE id ", ue_id)
+        print(
+            "************************* Sending UE context release request ",
+            "for UE id ", ue_id,
+        )
         # Send UE context release request to move UE to idle mode
         req = s1ap_types.ueCntxtRelReq_t()
         req.ue_Id = ue_id
         req.cause.causeVal = gpp_types.CauseRadioNetwork.USER_INACTIVITY.value
         self._s1ap_wrapper.s1_util.issue_cmd(
-            s1ap_types.tfwCmd.UE_CNTXT_REL_REQUEST, req)
+            s1ap_types.tfwCmd.UE_CNTXT_REL_REQUEST, req,
+        )
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_CTX_REL_IND.value)
+            response.msg_type, s1ap_types.tfwCmd.UE_CTX_REL_IND.value,
+        )
 
-        print("************************* Sending Service request for UE id ",
-              ue_id)
+        print(
+            "************************* Sending Service request for UE id ",
+            ue_id,
+        )
         # Send service request to reconnect UE
         req = s1ap_types.ueserviceReq_t()
         req.ue_Id = ue_id
@@ -71,16 +80,21 @@ class TestAttachServiceUeRadioCapability(unittest.TestCase):
         req.ueMtmsi.pres = False
         req.rrcCause = s1ap_types.Rrc_Cause.TFW_MO_DATA.value
         self._s1ap_wrapper.s1_util.issue_cmd(
-            s1ap_types.tfwCmd.UE_SERVICE_REQUEST, req)
+            s1ap_types.tfwCmd.UE_SERVICE_REQUEST, req,
+        )
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.INT_CTX_SETUP_IND.value)
+            response.msg_type, s1ap_types.tfwCmd.INT_CTX_SETUP_IND.value,
+        )
 
-        print("************************* Running UE detach for UE id ",
-              ue_id)
+        print(
+            "************************* Running UE detach for UE id ",
+            ue_id,
+        )
         # Now detach the UE
         self._s1ap_wrapper.s1_util.detach(
-            ue_id, s1ap_types.ueDetachType_t.UE_SWITCHOFF_DETACH.value, True)
+            ue_id, s1ap_types.ueDetachType_t.UE_SWITCHOFF_DETACH.value, True,
+        )
 
 
 if __name__ == "__main__":

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_service_with_multi_pdns_and_bearers.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_service_with_multi_pdns_and_bearers.py
@@ -11,9 +11,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-import unittest
-import time
 import ipaddress
+import time
+import unittest
+
 import gpp_types
 import s1ap_types
 import s1ap_wrapper
@@ -52,7 +53,7 @@ class TestAttachServiceWithMultiPdnsAndBearers(unittest.TestCase):
         apn_list = [ims]
 
         self._s1ap_wrapper.configAPN(
-            "IMSI" + "".join([str(i) for i in req.imsi]), apn_list
+            "IMSI" + "".join([str(i) for i in req.imsi]), apn_list,
         )
         print(
             "************************* Running End to End attach for UE id ",
@@ -186,7 +187,7 @@ class TestAttachServiceWithMultiPdnsAndBearers(unittest.TestCase):
         # Add dedicated bearer for default bearer 5
         print(
             "********************** Adding dedicated bearer to magma.ipv4"
-            " PDN"
+            " PDN",
         )
         print(
             "********************** Sending RAR for IMSI",
@@ -201,13 +202,13 @@ class TestAttachServiceWithMultiPdnsAndBearers(unittest.TestCase):
 
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_ACT_DED_BER_REQ.value
+            response.msg_type, s1ap_types.tfwCmd.UE_ACT_DED_BER_REQ.value,
         )
         act_ded_ber_req_oai_apn = response.cast(
-            s1ap_types.UeActDedBearCtxtReq_t
+            s1ap_types.UeActDedBearCtxtReq_t,
         )
         self._s1ap_wrapper.sendActDedicatedBearerAccept(
-            req.ue_id, act_ded_ber_req_oai_apn.bearerId
+            req.ue_id, act_ded_ber_req_oai_apn.bearerId,
         )
 
         print("Sleeping for 5 seconds")
@@ -218,7 +219,7 @@ class TestAttachServiceWithMultiPdnsAndBearers(unittest.TestCase):
         # Receive PDN CONN RSP/Activate default EPS bearer context request
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_PDN_CONN_RSP_IND.value
+            response.msg_type, s1ap_types.tfwCmd.UE_PDN_CONN_RSP_IND.value,
         )
         act_def_bearer_req = response.cast(s1ap_types.uePdnConRsp_t)
         addr = act_def_bearer_req.m.pdnInfo.pAddr.addrInfo
@@ -247,13 +248,13 @@ class TestAttachServiceWithMultiPdnsAndBearers(unittest.TestCase):
 
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_ACT_DED_BER_REQ.value
+            response.msg_type, s1ap_types.tfwCmd.UE_ACT_DED_BER_REQ.value,
         )
         act_ded_ber_req_ims_apn = response.cast(
-            s1ap_types.UeActDedBearCtxtReq_t
+            s1ap_types.UeActDedBearCtxtReq_t,
         )
         self._s1ap_wrapper.sendActDedicatedBearerAccept(
-            req.ue_id, act_ded_ber_req_ims_apn.bearerId
+            req.ue_id, act_ded_ber_req_ims_apn.bearerId,
         )
         print(
             "************* Added dedicated bearer",
@@ -271,7 +272,7 @@ class TestAttachServiceWithMultiPdnsAndBearers(unittest.TestCase):
         num_ul_flows = 4
         # Verify if flow rules are created
         self._s1ap_wrapper.s1_util.verify_flow_rules(
-            num_ul_flows, dl_flow_rules
+            num_ul_flows, dl_flow_rules,
         )
         print("*********** Moving UE to idle mode")
         print(
@@ -284,11 +285,11 @@ class TestAttachServiceWithMultiPdnsAndBearers(unittest.TestCase):
         req.ue_Id = ue_id
         req.cause.causeVal = gpp_types.CauseRadioNetwork.USER_INACTIVITY.value
         self._s1ap_wrapper.s1_util.issue_cmd(
-            s1ap_types.tfwCmd.UE_CNTXT_REL_REQUEST, req
+            s1ap_types.tfwCmd.UE_CNTXT_REL_REQUEST, req,
         )
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_CTX_REL_IND.value
+            response.msg_type, s1ap_types.tfwCmd.UE_CTX_REL_IND.value,
         )
 
         print("Sleeping for 5 seconds")
@@ -309,11 +310,11 @@ class TestAttachServiceWithMultiPdnsAndBearers(unittest.TestCase):
         req.ueMtmsi.pres = False
         req.rrcCause = s1ap_types.Rrc_Cause.TFW_MO_SIGNALLING.value
         self._s1ap_wrapper.s1_util.issue_cmd(
-            s1ap_types.tfwCmd.UE_SERVICE_REQUEST, req
+            s1ap_types.tfwCmd.UE_SERVICE_REQUEST, req,
         )
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.INT_CTX_SETUP_IND.value
+            response.msg_type, s1ap_types.tfwCmd.INT_CTX_SETUP_IND.value,
         )
 
         print("Sleeping for 5 seconds")
@@ -321,7 +322,7 @@ class TestAttachServiceWithMultiPdnsAndBearers(unittest.TestCase):
 
         # Verify if flow rules are created
         self._s1ap_wrapper.s1_util.verify_flow_rules(
-            num_ul_flows, dl_flow_rules
+            num_ul_flows, dl_flow_rules,
         )
 
         print("Sleeping for 5 seconds")
@@ -329,7 +330,7 @@ class TestAttachServiceWithMultiPdnsAndBearers(unittest.TestCase):
         print("************************* Running UE detach for UE id ", ue_id)
         # Now detach the UE
         self._s1ap_wrapper.s1_util.detach(
-            ue_id, s1ap_types.ueDetachType_t.UE_SWITCHOFF_DETACH.value, True
+            ue_id, s1ap_types.ueDetachType_t.UE_SWITCHOFF_DETACH.value, True,
         )
 
 

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_service_with_multi_pdns_and_bearers_failure.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_service_with_multi_pdns_and_bearers_failure.py
@@ -11,14 +11,14 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-import unittest
+import ipaddress
 import time
+import unittest
 
 import gpp_types
 import s1ap_types
 import s1ap_wrapper
 from integ_tests.s1aptests.s1ap_utils import SessionManagerUtil
-import ipaddress
 from lte.protos.policydb_pb2 import FlowMatch
 
 
@@ -53,7 +53,7 @@ class TestAttachServiceMultiPdnsBearersFailure(unittest.TestCase):
         apn_list = [ims]
 
         self._s1ap_wrapper.configAPN(
-            "IMSI" + "".join([str(i) for i in req.imsi]), apn_list
+            "IMSI" + "".join([str(i) for i in req.imsi]), apn_list,
         )
 
         # UL Flow description #1
@@ -186,7 +186,7 @@ class TestAttachServiceMultiPdnsBearersFailure(unittest.TestCase):
         # Add dedicated bearer for default bearer 5
         print(
             "********************** Adding dedicated bearer to magma.ipv4"
-            " PDN"
+            " PDN",
         )
         print(
             "********************** Sending RAR for IMSI",
@@ -201,13 +201,13 @@ class TestAttachServiceMultiPdnsBearersFailure(unittest.TestCase):
 
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_ACT_DED_BER_REQ.value
+            response.msg_type, s1ap_types.tfwCmd.UE_ACT_DED_BER_REQ.value,
         )
         act_ded_ber_req_oai_apn = response.cast(
-            s1ap_types.UeActDedBearCtxtReq_t
+            s1ap_types.UeActDedBearCtxtReq_t,
         )
         self._s1ap_wrapper.sendActDedicatedBearerAccept(
-            req.ue_id, act_ded_ber_req_oai_apn.bearerId
+            req.ue_id, act_ded_ber_req_oai_apn.bearerId,
         )
 
         print("************************* Sleeping for 5 seconds")
@@ -218,7 +218,7 @@ class TestAttachServiceMultiPdnsBearersFailure(unittest.TestCase):
         # Receive PDN CONN RSP/Activate default EPS bearer context request
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_PDN_CONN_RSP_IND.value
+            response.msg_type, s1ap_types.tfwCmd.UE_PDN_CONN_RSP_IND.value,
         )
         act_def_bearer_req = response.cast(s1ap_types.uePdnConRsp_t)
         addr = act_def_bearer_req.m.pdnInfo.pAddr.addrInfo
@@ -245,13 +245,13 @@ class TestAttachServiceMultiPdnsBearersFailure(unittest.TestCase):
 
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_ACT_DED_BER_REQ.value
+            response.msg_type, s1ap_types.tfwCmd.UE_ACT_DED_BER_REQ.value,
         )
         act_ded_ber_req_ims_apn = response.cast(
-            s1ap_types.UeActDedBearCtxtReq_t
+            s1ap_types.UeActDedBearCtxtReq_t,
         )
         self._s1ap_wrapper.sendActDedicatedBearerAccept(
-            req.ue_id, act_ded_ber_req_ims_apn.bearerId
+            req.ue_id, act_ded_ber_req_ims_apn.bearerId,
         )
         print(
             "************* Added dedicated bearer",
@@ -269,7 +269,7 @@ class TestAttachServiceMultiPdnsBearersFailure(unittest.TestCase):
         num_ul_flows = 4
         # Verify if flow rules are created
         self._s1ap_wrapper.s1_util.verify_flow_rules(
-            num_ul_flows, dl_flow_rules
+            num_ul_flows, dl_flow_rules,
         )
 
         print("************************* Sleeping for 5 seconds")
@@ -284,11 +284,11 @@ class TestAttachServiceMultiPdnsBearersFailure(unittest.TestCase):
         req.ue_Id = ue_id
         req.cause.causeVal = gpp_types.CauseRadioNetwork.USER_INACTIVITY.value
         self._s1ap_wrapper.s1_util.issue_cmd(
-            s1ap_types.tfwCmd.UE_CNTXT_REL_REQUEST, req
+            s1ap_types.tfwCmd.UE_CNTXT_REL_REQUEST, req,
         )
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_CTX_REL_IND.value
+            response.msg_type, s1ap_types.tfwCmd.UE_CTX_REL_IND.value,
         )
 
         # Send the bearers to be included in failed to setup list in ICS Rsp
@@ -323,11 +323,11 @@ class TestAttachServiceMultiPdnsBearersFailure(unittest.TestCase):
         req.ueMtmsi.pres = False
         req.rrcCause = s1ap_types.Rrc_Cause.TFW_MO_DATA.value
         self._s1ap_wrapper.s1_util.issue_cmd(
-            s1ap_types.tfwCmd.UE_SERVICE_REQUEST, req
+            s1ap_types.tfwCmd.UE_SERVICE_REQUEST, req,
         )
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.INT_CTX_SETUP_IND.value
+            response.msg_type, s1ap_types.tfwCmd.INT_CTX_SETUP_IND.value,
         )
 
         print("Sleeping for 5 seconds")
@@ -342,7 +342,7 @@ class TestAttachServiceMultiPdnsBearersFailure(unittest.TestCase):
         num_ul_flows = 2
         # Verify if flow rules are created
         self._s1ap_wrapper.s1_util.verify_flow_rules(
-            num_ul_flows, dl_flow_rules
+            num_ul_flows, dl_flow_rules,
         )
 
         print("************************* Sleeping for 5 seconds")
@@ -350,7 +350,7 @@ class TestAttachServiceMultiPdnsBearersFailure(unittest.TestCase):
         print("************************* Running UE detach for UE id ", ue_id)
         # Now detach the UE
         self._s1ap_wrapper.s1_util.detach(
-            ue_id, s1ap_types.ueDetachType_t.UE_SWITCHOFF_DETACH.value, True
+            ue_id, s1ap_types.ueDetachType_t.UE_SWITCHOFF_DETACH.value, True,
         )
 
 

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_service_with_multi_pdns_and_bearers_looped.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_service_with_multi_pdns_and_bearers_looped.py
@@ -11,14 +11,14 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-import unittest
+import ipaddress
 import time
+import unittest
 
 import gpp_types
 import s1ap_types
 import s1ap_wrapper
 from integ_tests.s1aptests.s1ap_utils import SessionManagerUtil
-import ipaddress
 from lte.protos.policydb_pb2 import FlowMatch
 
 
@@ -55,7 +55,7 @@ class TestAttachServiceWithMultiPdnsAndBearersLooped(unittest.TestCase):
         apn_list = [ims]
 
         self._s1ap_wrapper.configAPN(
-            "IMSI" + "".join([str(i) for i in req.imsi]), apn_list
+            "IMSI" + "".join([str(i) for i in req.imsi]), apn_list,
         )
         print(
             "************************* Running End to End attach for UE id ",
@@ -189,7 +189,7 @@ class TestAttachServiceWithMultiPdnsAndBearersLooped(unittest.TestCase):
         # Add dedicated bearer for default bearer 5
         print(
             "********************** Adding dedicated bearer to magma.ipv4"
-            " PDN"
+            " PDN",
         )
         print(
             "********************** Sending RAR for IMSI",
@@ -204,13 +204,13 @@ class TestAttachServiceWithMultiPdnsAndBearersLooped(unittest.TestCase):
 
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_ACT_DED_BER_REQ.value
+            response.msg_type, s1ap_types.tfwCmd.UE_ACT_DED_BER_REQ.value,
         )
         act_ded_ber_req_oai_apn = response.cast(
-            s1ap_types.UeActDedBearCtxtReq_t
+            s1ap_types.UeActDedBearCtxtReq_t,
         )
         self._s1ap_wrapper.sendActDedicatedBearerAccept(
-            req.ue_id, act_ded_ber_req_oai_apn.bearerId
+            req.ue_id, act_ded_ber_req_oai_apn.bearerId,
         )
 
         print("Sleeping for 5 seconds")
@@ -221,7 +221,7 @@ class TestAttachServiceWithMultiPdnsAndBearersLooped(unittest.TestCase):
         # Receive PDN CONN RSP/Activate default EPS bearer context request
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_PDN_CONN_RSP_IND.value
+            response.msg_type, s1ap_types.tfwCmd.UE_PDN_CONN_RSP_IND.value,
         )
         act_def_bearer_req = response.cast(s1ap_types.uePdnConRsp_t)
         addr = act_def_bearer_req.m.pdnInfo.pAddr.addrInfo
@@ -250,13 +250,13 @@ class TestAttachServiceWithMultiPdnsAndBearersLooped(unittest.TestCase):
 
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_ACT_DED_BER_REQ.value
+            response.msg_type, s1ap_types.tfwCmd.UE_ACT_DED_BER_REQ.value,
         )
         act_ded_ber_req_ims_apn = response.cast(
-            s1ap_types.UeActDedBearCtxtReq_t
+            s1ap_types.UeActDedBearCtxtReq_t,
         )
         self._s1ap_wrapper.sendActDedicatedBearerAccept(
-            req.ue_id, act_ded_ber_req_ims_apn.bearerId
+            req.ue_id, act_ded_ber_req_ims_apn.bearerId,
         )
         print(
             "************* Added dedicated bearer",
@@ -274,7 +274,7 @@ class TestAttachServiceWithMultiPdnsAndBearersLooped(unittest.TestCase):
         num_ul_flows = 4
         # Verify if flow rules are created
         self._s1ap_wrapper.s1_util.verify_flow_rules(
-            num_ul_flows, dl_flow_rules
+            num_ul_flows, dl_flow_rules,
         )
 
         print("*********** Moving UE to idle mode")
@@ -292,11 +292,11 @@ class TestAttachServiceWithMultiPdnsAndBearersLooped(unittest.TestCase):
                 gpp_types.CauseRadioNetwork.USER_INACTIVITY.value
             )
             self._s1ap_wrapper.s1_util.issue_cmd(
-                s1ap_types.tfwCmd.UE_CNTXT_REL_REQUEST, rel_req
+                s1ap_types.tfwCmd.UE_CNTXT_REL_REQUEST, rel_req,
             )
             response = self._s1ap_wrapper.s1_util.get_response()
             self.assertEqual(
-                response.msg_type, s1ap_types.tfwCmd.UE_CTX_REL_IND.value
+                response.msg_type, s1ap_types.tfwCmd.UE_CTX_REL_IND.value,
             )
 
             # Verify if paging flow rules are created
@@ -314,11 +314,11 @@ class TestAttachServiceWithMultiPdnsAndBearersLooped(unittest.TestCase):
             ser_req.ueMtmsi.pres = False
             ser_req.rrcCause = s1ap_types.Rrc_Cause.TFW_MO_SIGNALLING.value
             self._s1ap_wrapper.s1_util.issue_cmd(
-                s1ap_types.tfwCmd.UE_SERVICE_REQUEST, ser_req
+                s1ap_types.tfwCmd.UE_SERVICE_REQUEST, ser_req,
             )
             response = self._s1ap_wrapper.s1_util.get_response()
             self.assertEqual(
-                response.msg_type, s1ap_types.tfwCmd.INT_CTX_SETUP_IND.value
+                response.msg_type, s1ap_types.tfwCmd.INT_CTX_SETUP_IND.value,
             )
 
             print("Sleeping for 5 seconds")
@@ -326,7 +326,7 @@ class TestAttachServiceWithMultiPdnsAndBearersLooped(unittest.TestCase):
 
             # Verify if flow rules are created
             self._s1ap_wrapper.s1_util.verify_flow_rules(
-                num_ul_flows, dl_flow_rules
+                num_ul_flows, dl_flow_rules,
             )
 
         print("Sleeping for 5 seconds")
@@ -334,7 +334,7 @@ class TestAttachServiceWithMultiPdnsAndBearersLooped(unittest.TestCase):
         print("************************* Running UE detach for UE id ", ue_id)
         # Now detach the UE
         self._s1ap_wrapper.s1_util.detach(
-            ue_id, s1ap_types.ueDetachType_t.UE_SWITCHOFF_DETACH.value, True
+            ue_id, s1ap_types.ueDetachType_t.UE_SWITCHOFF_DETACH.value, True,
         )
 
 

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_service_with_multi_pdns_and_bearers_mt_data.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_service_with_multi_pdns_and_bearers_mt_data.py
@@ -11,14 +11,14 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-import unittest
+import ipaddress
 import time
+import unittest
 
 import gpp_types
 import s1ap_types
 import s1ap_wrapper
 from integ_tests.s1aptests.s1ap_utils import SessionManagerUtil
-import ipaddress
 from lte.protos.policydb_pb2 import FlowMatch
 
 
@@ -56,7 +56,7 @@ class TestAttachServiceWithMultiPdnsAndBearersMtData(unittest.TestCase):
         apn_list = [ims]
 
         self._s1ap_wrapper.configAPN(
-            "IMSI" + "".join([str(i) for i in req.imsi]), apn_list
+            "IMSI" + "".join([str(i) for i in req.imsi]), apn_list,
         )
 
         # UL Flow description #1
@@ -193,7 +193,7 @@ class TestAttachServiceWithMultiPdnsAndBearersMtData(unittest.TestCase):
         # Add dedicated bearer for default bearer 5
         print(
             "********************** Adding dedicated bearer to magma.ipv4"
-            " PDN"
+            " PDN",
         )
         print(
             "********************** Sending RAR for IMSI",
@@ -208,13 +208,13 @@ class TestAttachServiceWithMultiPdnsAndBearersMtData(unittest.TestCase):
 
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_ACT_DED_BER_REQ.value
+            response.msg_type, s1ap_types.tfwCmd.UE_ACT_DED_BER_REQ.value,
         )
         act_ded_ber_req_oai_apn = response.cast(
-            s1ap_types.UeActDedBearCtxtReq_t
+            s1ap_types.UeActDedBearCtxtReq_t,
         )
         self._s1ap_wrapper.sendActDedicatedBearerAccept(
-            req.ue_id, act_ded_ber_req_oai_apn.bearerId
+            req.ue_id, act_ded_ber_req_oai_apn.bearerId,
         )
 
         print("Sleeping for 5 seconds")
@@ -225,7 +225,7 @@ class TestAttachServiceWithMultiPdnsAndBearersMtData(unittest.TestCase):
         # Receive PDN CONN RSP/Activate default EPS bearer context request
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_PDN_CONN_RSP_IND.value
+            response.msg_type, s1ap_types.tfwCmd.UE_PDN_CONN_RSP_IND.value,
         )
         act_def_bearer_req = response.cast(s1ap_types.uePdnConRsp_t)
         addr = act_def_bearer_req.m.pdnInfo.pAddr.addrInfo
@@ -255,13 +255,13 @@ class TestAttachServiceWithMultiPdnsAndBearersMtData(unittest.TestCase):
 
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_ACT_DED_BER_REQ.value
+            response.msg_type, s1ap_types.tfwCmd.UE_ACT_DED_BER_REQ.value,
         )
         act_ded_ber_req_ims_apn = response.cast(
-            s1ap_types.UeActDedBearCtxtReq_t
+            s1ap_types.UeActDedBearCtxtReq_t,
         )
         self._s1ap_wrapper.sendActDedicatedBearerAccept(
-            req.ue_id, act_ded_ber_req_ims_apn.bearerId
+            req.ue_id, act_ded_ber_req_ims_apn.bearerId,
         )
         print(
             "************* Added dedicated bearer",
@@ -279,7 +279,7 @@ class TestAttachServiceWithMultiPdnsAndBearersMtData(unittest.TestCase):
         num_ul_flows = 4
         # Verify if flow rules are created
         self._s1ap_wrapper.s1_util.verify_flow_rules(
-            num_ul_flows, dl_flow_rules
+            num_ul_flows, dl_flow_rules,
         )
 
         print("*********** Moving UE to idle mode")
@@ -295,11 +295,11 @@ class TestAttachServiceWithMultiPdnsAndBearersMtData(unittest.TestCase):
             gpp_types.CauseRadioNetwork.USER_INACTIVITY.value
         )
         self._s1ap_wrapper.s1_util.issue_cmd(
-            s1ap_types.tfwCmd.UE_CNTXT_REL_REQUEST, rel_req
+            s1ap_types.tfwCmd.UE_CNTXT_REL_REQUEST, rel_req,
         )
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_CTX_REL_IND.value
+            response.msg_type, s1ap_types.tfwCmd.UE_CTX_REL_IND.value,
         )
 
         # Verify if paging flow rules are created
@@ -311,7 +311,7 @@ class TestAttachServiceWithMultiPdnsAndBearersMtData(unittest.TestCase):
             ue_id,
         )
         with self._s1ap_wrapper.configDownlinkTest(
-            req, duration=1, is_udp=True
+            req, duration=1, is_udp=True,
         ) as test:
             response = self._s1ap_wrapper.s1_util.get_response()
             self.assertTrue(response, s1ap_types.tfwCmd.UE_PAGING_IND.value)
@@ -326,7 +326,7 @@ class TestAttachServiceWithMultiPdnsAndBearersMtData(unittest.TestCase):
             ser_req.ueMtmsi.pres = False
             ser_req.rrcCause = s1ap_types.Rrc_Cause.TFW_MT_ACCESS.value
             self._s1ap_wrapper.s1_util.issue_cmd(
-                s1ap_types.tfwCmd.UE_SERVICE_REQUEST, ser_req
+                s1ap_types.tfwCmd.UE_SERVICE_REQUEST, ser_req,
             )
             # Wait for INT_CTX_SETUP_IND
             while response.msg_type == s1ap_types.tfwCmd.UE_PAGING_IND.value:
@@ -336,7 +336,7 @@ class TestAttachServiceWithMultiPdnsAndBearersMtData(unittest.TestCase):
                 response = self._s1ap_wrapper.s1_util.get_response()
 
             self.assertEqual(
-                response.msg_type, s1ap_types.tfwCmd.INT_CTX_SETUP_IND.value
+                response.msg_type, s1ap_types.tfwCmd.INT_CTX_SETUP_IND.value,
             )
             test.verify()
 
@@ -345,7 +345,7 @@ class TestAttachServiceWithMultiPdnsAndBearersMtData(unittest.TestCase):
 
         # Verify if flow rules are created
         self._s1ap_wrapper.s1_util.verify_flow_rules(
-            num_ul_flows, dl_flow_rules
+            num_ul_flows, dl_flow_rules,
         )
 
         pdn_disconnect_req = s1ap_types.uepdnDisconnectReq_t()
@@ -354,23 +354,23 @@ class TestAttachServiceWithMultiPdnsAndBearersMtData(unittest.TestCase):
             act_def_bearer_req.m.pdnInfo.epsBearerId
         )
         self._s1ap_wrapper._s1_util.issue_cmd(
-            s1ap_types.tfwCmd.UE_PDN_DISCONNECT_REQ, pdn_disconnect_req
+            s1ap_types.tfwCmd.UE_PDN_DISCONNECT_REQ, pdn_disconnect_req,
         )
 
         # Receive UE_DEACTIVATE_BER_REQ
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_DEACTIVATE_BER_REQ.value
+            response.msg_type, s1ap_types.tfwCmd.UE_DEACTIVATE_BER_REQ.value,
         )
 
         print(
             "******************* Received deactivate eps bearer context"
-            " request"
+            " request",
         )
         # Send DeactDedicatedBearerAccept
         deactv_bearer_req = response.cast(s1ap_types.UeDeActvBearCtxtReq_t)
         self._s1ap_wrapper.sendDeactDedicatedBearerAccept(
-            ue_id, deactv_bearer_req.bearerId
+            ue_id, deactv_bearer_req.bearerId,
         )
 
         print("Sleeping for 5 seconds")
@@ -378,7 +378,7 @@ class TestAttachServiceWithMultiPdnsAndBearersMtData(unittest.TestCase):
         print("************************* Running UE detach for UE id ", ue_id)
         # Now detach the UE
         self._s1ap_wrapper.s1_util.detach(
-            ue_id, s1ap_types.ueDetachType_t.UE_SWITCHOFF_DETACH.value, True
+            ue_id, s1ap_types.ueDetachType_t.UE_SWITCHOFF_DETACH.value, True,
         )
 
 

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_service_with_multi_pdns_and_bearers_multi_ue.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_service_with_multi_pdns_and_bearers_multi_ue.py
@@ -11,13 +11,13 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-import unittest
+import ipaddress
 import time
+import unittest
 
 import gpp_types
 import s1ap_types
 import s1ap_wrapper
-import ipaddress
 from integ_tests.s1aptests.s1ap_utils import SessionManagerUtil
 from lte.protos.policydb_pb2 import FlowMatch
 
@@ -165,7 +165,7 @@ class TestAttachServiceWithMultiPdnsAndBearersMultiUe(unittest.TestCase):
             apn_list = [ims]
 
             self._s1ap_wrapper.configAPN(
-                "IMSI" + "".join([str(i) for i in req.imsi]), apn_list
+                "IMSI" + "".join([str(i) for i in req.imsi]), apn_list,
             )
             print(
                 "********************** Running End to End attach for UE id ",
@@ -208,13 +208,13 @@ class TestAttachServiceWithMultiPdnsAndBearersMultiUe(unittest.TestCase):
 
             response = self._s1ap_wrapper.s1_util.get_response()
             self.assertEqual(
-                response.msg_type, s1ap_types.tfwCmd.UE_ACT_DED_BER_REQ.value
+                response.msg_type, s1ap_types.tfwCmd.UE_ACT_DED_BER_REQ.value,
             )
             act_ded_ber_req_oai_apn = response.cast(
-                s1ap_types.UeActDedBearCtxtReq_t
+                s1ap_types.UeActDedBearCtxtReq_t,
             )
             self._s1ap_wrapper.sendActDedicatedBearerAccept(
-                req.ue_id, act_ded_ber_req_oai_apn.bearerId
+                req.ue_id, act_ded_ber_req_oai_apn.bearerId,
             )
 
         # Add secondary PDN and dedicated bearers for all the UEs
@@ -232,7 +232,7 @@ class TestAttachServiceWithMultiPdnsAndBearersMultiUe(unittest.TestCase):
             # Receive PDN CONN RSP/Activate default EPS bearer context request
             response = self._s1ap_wrapper.s1_util.get_response()
             self.assertEqual(
-                response.msg_type, s1ap_types.tfwCmd.UE_PDN_CONN_RSP_IND.value
+                response.msg_type, s1ap_types.tfwCmd.UE_PDN_CONN_RSP_IND.value,
             )
             act_def_bearer_req = response.cast(s1ap_types.uePdnConRsp_t)
             addr = act_def_bearer_req.m.pdnInfo.pAddr.addrInfo
@@ -265,13 +265,13 @@ class TestAttachServiceWithMultiPdnsAndBearersMultiUe(unittest.TestCase):
 
             response = self._s1ap_wrapper.s1_util.get_response()
             self.assertEqual(
-                response.msg_type, s1ap_types.tfwCmd.UE_ACT_DED_BER_REQ.value
+                response.msg_type, s1ap_types.tfwCmd.UE_ACT_DED_BER_REQ.value,
             )
             act_ded_ber_req_ims_apn = response.cast(
-                s1ap_types.UeActDedBearCtxtReq_t
+                s1ap_types.UeActDedBearCtxtReq_t,
             )
             self._s1ap_wrapper.sendActDedicatedBearerAccept(
-                req.ue_id, act_ded_ber_req_ims_apn.bearerId
+                req.ue_id, act_ded_ber_req_ims_apn.bearerId,
             )
             print(
                 "************* Added dedicated bearer",
@@ -292,7 +292,7 @@ class TestAttachServiceWithMultiPdnsAndBearersMultiUe(unittest.TestCase):
             }
             # Verify if flow rules are created
             self._s1ap_wrapper.s1_util.verify_flow_rules(
-                num_ul_flows, dl_flow_rules
+                num_ul_flows, dl_flow_rules,
             )
 
         # Send UE context release request to move UEs to idle mode
@@ -315,11 +315,11 @@ class TestAttachServiceWithMultiPdnsAndBearersMultiUe(unittest.TestCase):
                 gpp_types.CauseRadioNetwork.USER_INACTIVITY.value
             )
             self._s1ap_wrapper.s1_util.issue_cmd(
-                s1ap_types.tfwCmd.UE_CNTXT_REL_REQUEST, rel_req
+                s1ap_types.tfwCmd.UE_CNTXT_REL_REQUEST, rel_req,
             )
             response = self._s1ap_wrapper.s1_util.get_response()
             self.assertEqual(
-                response.msg_type, s1ap_types.tfwCmd.UE_CTX_REL_IND.value
+                response.msg_type, s1ap_types.tfwCmd.UE_CTX_REL_IND.value,
             )
             # Verify if paging flow rules are created
             ip_list = [default_ips[i], sec_ips[i]]
@@ -343,11 +343,11 @@ class TestAttachServiceWithMultiPdnsAndBearersMultiUe(unittest.TestCase):
             ser_req.ueMtmsi.pres = False
             req.rrcCause = s1ap_types.Rrc_Cause.TFW_MO_SIGNALLING.value
             self._s1ap_wrapper.s1_util.issue_cmd(
-                s1ap_types.tfwCmd.UE_SERVICE_REQUEST, ser_req
+                s1ap_types.tfwCmd.UE_SERVICE_REQUEST, ser_req,
             )
             response = self._s1ap_wrapper.s1_util.get_response()
             self.assertEqual(
-                response.msg_type, s1ap_types.tfwCmd.INT_CTX_SETUP_IND.value
+                response.msg_type, s1ap_types.tfwCmd.INT_CTX_SETUP_IND.value,
             )
 
         # Delay of 10 seconds to make sure flows are added
@@ -360,7 +360,7 @@ class TestAttachServiceWithMultiPdnsAndBearersMultiUe(unittest.TestCase):
                 sec_ips[i]: [flow_list2],
             }
             self._s1ap_wrapper.s1_util.verify_flow_rules(
-                num_ul_flows, dl_flow_rules
+                num_ul_flows, dl_flow_rules,
             )
 
         print("Sleeping for 5 seconds")
@@ -370,7 +370,7 @@ class TestAttachServiceWithMultiPdnsAndBearersMultiUe(unittest.TestCase):
             print("************************* Running UE detach for UE id ", ue)
             # Now detach the UE
             self._s1ap_wrapper.s1_util.detach(
-                ue, s1ap_types.ueDetachType_t.UE_SWITCHOFF_DETACH.value, True
+                ue, s1ap_types.ueDetachType_t.UE_SWITCHOFF_DETACH.value, True,
             )
 
 

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_service_without_mac.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_service_without_mac.py
@@ -11,8 +11,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-import unittest
 import time
+import unittest
 
 import gpp_types
 import s1ap_types
@@ -63,11 +63,11 @@ class TestAttachServiceWithoutMac(unittest.TestCase):
         req.ue_Id = ue_id
         req.cause.causeVal = gpp_types.CauseRadioNetwork.USER_INACTIVITY.value
         self._s1ap_wrapper.s1_util.issue_cmd(
-            s1ap_types.tfwCmd.UE_CNTXT_REL_REQUEST, req
+            s1ap_types.tfwCmd.UE_CNTXT_REL_REQUEST, req,
         )
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_CTX_REL_IND.value
+            response.msg_type, s1ap_types.tfwCmd.UE_CTX_REL_IND.value,
         )
 
         print(
@@ -82,11 +82,11 @@ class TestAttachServiceWithoutMac(unittest.TestCase):
         req.rrcCause = s1ap_types.Rrc_Cause.TFW_MO_DATA.value
         req.noMac = True
         self._s1ap_wrapper.s1_util.issue_cmd(
-            s1ap_types.tfwCmd.UE_SERVICE_REQUEST, req
+            s1ap_types.tfwCmd.UE_SERVICE_REQUEST, req,
         )
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_SERVICE_REJECT_IND.value
+            response.msg_type, s1ap_types.tfwCmd.UE_SERVICE_REJECT_IND.value,
         )
         print(
             "************************* Received Service Reject for UE id ",
@@ -95,7 +95,7 @@ class TestAttachServiceWithoutMac(unittest.TestCase):
         print("************************* Running UE detach for UE id ", ue_id)
         # Now detach the UE
         self._s1ap_wrapper.s1_util.detach(
-            ue_id, s1ap_types.ueDetachType_t.UE_SWITCHOFF_DETACH.value, True
+            ue_id, s1ap_types.ueDetachType_t.UE_SWITCHOFF_DETACH.value, True,
         )
 
 

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_standalone_act_dflt_ber_ctxt_rej.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_standalone_act_dflt_ber_ctxt_rej.py
@@ -12,12 +12,12 @@ limitations under the License.
 """
 
 
+import ipaddress
+import time
 import unittest
 
 import s1ap_types
 import s1ap_wrapper
-import time
-import ipaddress
 
 
 class TestAttachStandaloneActvDfltBearCtxtRej(unittest.TestCase):
@@ -49,7 +49,7 @@ class TestAttachStandaloneActvDfltBearCtxtRej(unittest.TestCase):
         apn_list = [ims]
 
         self._s1ap_wrapper.configAPN(
-            "IMSI" + "".join([str(i) for i in req.imsi]), apn_list
+            "IMSI" + "".join([str(i) for i in req.imsi]), apn_list,
         )
         print(
             "************************* Running End to End attach for UE id ",
@@ -86,7 +86,7 @@ class TestAttachStandaloneActvDfltBearCtxtRej(unittest.TestCase):
         )
 
         print(
-            "Sent STANDALONE_ACTV_DEFAULT_EPS_BEARER_CNTXT_REJECT indication"
+            "Sent STANDALONE_ACTV_DEFAULT_EPS_BEARER_CNTXT_REJECT indication",
         )
         print("Sleeping for 5 seconds")
         time.sleep(5)
@@ -97,14 +97,14 @@ class TestAttachStandaloneActvDfltBearCtxtRej(unittest.TestCase):
         # Receive PDN CONN RSP/Activate default EPS bearer context request
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_PDN_CONN_RSP_IND.value
+            response.msg_type, s1ap_types.tfwCmd.UE_PDN_CONN_RSP_IND.value,
         )
         act_def_bearer_req = response.cast(s1ap_types.uePdnConRsp_t)
 
         print(
             "************************* Sending Activate default EPS bearer "
             "context reject for UE id %d and bearer %d"
-            % (req.ue_id, act_def_bearer_req.m.pdnInfo.epsBearerId)
+            % (req.ue_id, act_def_bearer_req.m.pdnInfo.epsBearerId),
         )
 
         print("Sleeping for 5 seconds")
@@ -121,7 +121,7 @@ class TestAttachStandaloneActvDfltBearCtxtRej(unittest.TestCase):
         }
 
         self._s1ap_wrapper.s1_util.verify_flow_rules(
-            num_ul_flows, dl_flow_rules
+            num_ul_flows, dl_flow_rules,
         )
 
         print("Sleeping for 5 seconds")

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_standalone_act_dflt_ber_ctxt_rej_ded_bearer_activation.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_standalone_act_dflt_ber_ctxt_rej_ded_bearer_activation.py
@@ -12,18 +12,18 @@ limitations under the License.
 """
 
 
+import ipaddress
+import time
 import unittest
 
 import s1ap_types
 import s1ap_wrapper
-import time
-import ipaddress
 from integ_tests.s1aptests.s1ap_utils import SessionManagerUtil
 from lte.protos.policydb_pb2 import FlowMatch
 
 
 class TestAttachStandaloneActvDfltBearCtxtRejDedBerActivation(
-    unittest.TestCase
+    unittest.TestCase,
 ):
     def setUp(self):
         self._s1ap_wrapper = s1ap_wrapper.TestWrapper()
@@ -146,7 +146,7 @@ class TestAttachStandaloneActvDfltBearCtxtRejDedBerActivation(
         apn_list = [ims]
 
         self._s1ap_wrapper.configAPN(
-            "IMSI" + "".join([str(i) for i in req.imsi]), apn_list
+            "IMSI" + "".join([str(i) for i in req.imsi]), apn_list,
         )
         print(
             "************************* Running End to End attach for UE id ",
@@ -175,7 +175,7 @@ class TestAttachStandaloneActvDfltBearCtxtRejDedBerActivation(
         # 1 UL flow for the default bearer
         num_ul_flows = 1
         self._s1ap_wrapper.s1_util.verify_flow_rules(
-            num_ul_flows, dl_flow_rules
+            num_ul_flows, dl_flow_rules,
         )
 
         print("Sleeping for 5 seconds")
@@ -194,7 +194,7 @@ class TestAttachStandaloneActvDfltBearCtxtRejDedBerActivation(
             def_ber_rej,
         )
         print(
-            "Sent STANDALONE_ACTV_DEFAULT_EPS_BEARER_CNTXT_REJECT indication"
+            "Sent STANDALONE_ACTV_DEFAULT_EPS_BEARER_CNTXT_REJECT indication",
         )
         print("Sleeping for 5 seconds")
         time.sleep(5)
@@ -204,14 +204,14 @@ class TestAttachStandaloneActvDfltBearCtxtRejDedBerActivation(
         # Receive PDN CONN RSP/Activate default EPS bearer context request
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_PDN_CONN_RSP_IND.value
+            response.msg_type, s1ap_types.tfwCmd.UE_PDN_CONN_RSP_IND.value,
         )
         act_def_bearer_req = response.cast(s1ap_types.uePdnConRsp_t)
 
         print(
             "************************* Sending Activate default EPS bearer "
             "context reject for UE id %d and bearer %d"
-            % (req.ue_id, act_def_bearer_req.m.pdnInfo.epsBearerId)
+            % (req.ue_id, act_def_bearer_req.m.pdnInfo.epsBearerId),
         )
 
         print("Sleeping for 5 seconds")
@@ -236,7 +236,7 @@ class TestAttachStandaloneActvDfltBearCtxtRejDedBerActivation(
         # dedicated bearer as UE rejected the establishment of secondary pdn
 
         self._s1ap_wrapper.s1_util.verify_flow_rules(
-            num_ul_flows, dl_flow_rules
+            num_ul_flows, dl_flow_rules,
         )
 
         print("Sleeping for 5 seconds")

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_ue_ctxt_release_cmp_delay.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_ue_ctxt_release_cmp_delay.py
@@ -12,12 +12,12 @@ limitations under the License.
 """
 
 
+import time
 import unittest
 
+import gpp_types
 import s1ap_types
 import s1ap_wrapper
-import time
-import gpp_types
 
 
 class TestAttachDelayUeContextRelComplete(unittest.TestCase):
@@ -46,11 +46,11 @@ class TestAttachDelayUeContextRelComplete(unittest.TestCase):
         print("********Triggering Attach Request ")
 
         self._s1ap_wrapper._s1_util.issue_cmd(
-            s1ap_types.tfwCmd.UE_ATTACH_REQUEST, attach_req
+            s1ap_types.tfwCmd.UE_ATTACH_REQUEST, attach_req,
         )
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_AUTH_REQ_IND.value
+            response.msg_type, s1ap_types.tfwCmd.UE_AUTH_REQ_IND.value,
         )
 
         # Trigger Authentication Response
@@ -60,28 +60,28 @@ class TestAttachDelayUeContextRelComplete(unittest.TestCase):
         sqnRecvd.pres = 0
         auth_res.sqnRcvd = sqnRecvd
         self._s1ap_wrapper._s1_util.issue_cmd(
-            s1ap_types.tfwCmd.UE_AUTH_RESP, auth_res
+            s1ap_types.tfwCmd.UE_AUTH_RESP, auth_res,
         )
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_SEC_MOD_CMD_IND.value
+            response.msg_type, s1ap_types.tfwCmd.UE_SEC_MOD_CMD_IND.value,
         )
 
         # Trigger Security Mode Complete
         sec_mode_complete = s1ap_types.ueSecModeComplete_t()
         sec_mode_complete.ue_Id = req.ue_id
         self._s1ap_wrapper._s1_util.issue_cmd(
-            s1ap_types.tfwCmd.UE_SEC_MOD_COMPLETE, sec_mode_complete
+            s1ap_types.tfwCmd.UE_SEC_MOD_COMPLETE, sec_mode_complete,
         )
 
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.INT_CTX_SETUP_IND.value
+            response.msg_type, s1ap_types.tfwCmd.INT_CTX_SETUP_IND.value,
         )
 
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_ATTACH_ACCEPT_IND.value
+            response.msg_type, s1ap_types.tfwCmd.UE_ATTACH_ACCEPT_IND.value,
         )
 
         delay_ue_ctxt_rel_cmp = s1ap_types.UeDelayUeCtxtRelCmp()
@@ -99,12 +99,12 @@ class TestAttachDelayUeContextRelComplete(unittest.TestCase):
         attach_complete = s1ap_types.ueAttachComplete_t()
         attach_complete.ue_Id = req.ue_id
         self._s1ap_wrapper._s1_util.issue_cmd(
-            s1ap_types.tfwCmd.UE_ATTACH_COMPLETE, attach_complete
+            s1ap_types.tfwCmd.UE_ATTACH_COMPLETE, attach_complete,
         )
         time.sleep(0.5)
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_EMM_INFORMATION.value
+            response.msg_type, s1ap_types.tfwCmd.UE_EMM_INFORMATION.value,
         )
 
         time.sleep(0.5)
@@ -113,11 +113,11 @@ class TestAttachDelayUeContextRelComplete(unittest.TestCase):
         detach_req.ue_Id = req.ue_id
         detach_req.ueDetType = s1ap_types.ueDetachType_t.UE_NORMAL_DETACH.value
         self._s1ap_wrapper._s1_util.issue_cmd(
-            s1ap_types.tfwCmd.UE_DETACH_REQUEST, detach_req
+            s1ap_types.tfwCmd.UE_DETACH_REQUEST, detach_req,
         )
         response = self._s1ap_wrapper._s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_DETACH_ACCEPT_IND.value
+            response.msg_type, s1ap_types.tfwCmd.UE_DETACH_ACCEPT_IND.value,
         )
 
         print(
@@ -135,11 +135,11 @@ class TestAttachDelayUeContextRelComplete(unittest.TestCase):
         )
 
         self._s1ap_wrapper.s1_util.issue_cmd(
-            s1ap_types.tfwCmd.UE_CNTXT_REL_REQUEST, uectxtrel_req
+            s1ap_types.tfwCmd.UE_CNTXT_REL_REQUEST, uectxtrel_req,
         )
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_CTX_REL_IND.value
+            response.msg_type, s1ap_types.tfwCmd.UE_CTX_REL_IND.value,
         )
 
         time.sleep(10)

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_ul_tcp_data.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_ul_tcp_data.py
@@ -29,28 +29,36 @@ class TestAttachUlTcpData(unittest.TestCase):
         """ Attach and send UL TCP data """
         self._s1ap_wrapper.configUEDevice(1)
         req = self._s1ap_wrapper.ue_req
-        print("************************* Running End to End attach for ",
-              "UE id ", req.ue_id)
+        print(
+            "************************* Running End to End attach for ",
+            "UE id ", req.ue_id,
+        )
         # Now actually complete the attach
         self._s1ap_wrapper._s1_util.attach(
             req.ue_id, s1ap_types.tfwCmd.UE_END_TO_END_ATTACH_REQUEST,
             s1ap_types.tfwCmd.UE_ATTACH_ACCEPT_IND,
-            s1ap_types.ueAttachAccept_t)
+            s1ap_types.ueAttachAccept_t,
+        )
 
         # Wait on EMM Information from MME
         self._s1ap_wrapper._s1_util.receive_emm_info()
 
-        print("************************* Running UE uplink (TCP) for UE id ",
-              req.ue_id)
+        print(
+            "************************* Running UE uplink (TCP) for UE id ",
+            req.ue_id,
+        )
         with self._s1ap_wrapper.configUplinkTest(req, duration=1) as test:
             test.verify()
 
-        print("************************* Running UE detach for UE id ",
-              req.ue_id)
+        print(
+            "************************* Running UE detach for UE id ",
+            req.ue_id,
+        )
         # Now detach the UE
         self._s1ap_wrapper.s1_util.detach(
             req.ue_id, s1ap_types.ueDetachType_t.UE_SWITCHOFF_DETACH.value,
-            True)
+            True,
+        )
 
 
 if __name__ == "__main__":

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_ul_udp_data.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_ul_udp_data.py
@@ -29,29 +29,38 @@ class TestAttachUlUdpData(unittest.TestCase):
         """ Attach and send UL UDP data """
         self._s1ap_wrapper.configUEDevice(1)
         req = self._s1ap_wrapper.ue_req
-        print("************************* Running End to End attach for ",
-              "UE id ", req.ue_id)
+        print(
+            "************************* Running End to End attach for ",
+            "UE id ", req.ue_id,
+        )
         # Now actually complete the attach
         self._s1ap_wrapper._s1_util.attach(
             req.ue_id, s1ap_types.tfwCmd.UE_END_TO_END_ATTACH_REQUEST,
             s1ap_types.tfwCmd.UE_ATTACH_ACCEPT_IND,
-            s1ap_types.ueAttachAccept_t)
+            s1ap_types.ueAttachAccept_t,
+        )
 
         # Wait on EMM Information from MME
         self._s1ap_wrapper._s1_util.receive_emm_info()
 
-        print("************************* Running UE uplink (UDP) for UE id ",
-              req.ue_id)
+        print(
+            "************************* Running UE uplink (UDP) for UE id ",
+            req.ue_id,
+        )
         with self._s1ap_wrapper.configUplinkTest(
-                req, duration=1, is_udp=True) as test:
+                req, duration=1, is_udp=True,
+        ) as test:
             test.verify()
 
-        print("************************* Running UE detach for UE id ",
-              req.ue_id)
+        print(
+            "************************* Running UE detach for UE id ",
+            req.ue_id,
+        )
         # Now detach the UE
         self._s1ap_wrapper.s1_util.detach(
             req.ue_id, s1ap_types.ueDetachType_t.UE_SWITCHOFF_DETACH.value,
-            True)
+            True,
+        )
 
 
 if __name__ == "__main__":

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_ul_udp_data_multi_ue.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_ul_udp_data_multi_ue.py
@@ -54,7 +54,7 @@ class TestAttachUlUdpDataMultiUe(unittest.TestCase):
             [req.ue_id for req in reqs],
         )
         with self._s1ap_wrapper.configUplinkTest(
-            *reqs, duration=1, is_udp=True
+            *reqs, duration=1, is_udp=True,
         ) as test:
             test.verify()
 

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_ul_udp_data_with_mme_restart.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_ul_udp_data_with_mme_restart.py
@@ -23,7 +23,8 @@ class TestAttachUlUdpDataWithMmeRestart(unittest.TestCase):
 
     def setUp(self):
         self._s1ap_wrapper = s1ap_wrapper.TestWrapper(
-            stateless_mode=MagmadUtil.stateless_cmds.ENABLE)
+            stateless_mode=MagmadUtil.stateless_cmds.ENABLE,
+        )
 
     def tearDown(self):
         self._s1ap_wrapper.cleanup()
@@ -32,21 +33,27 @@ class TestAttachUlUdpDataWithMmeRestart(unittest.TestCase):
         """ Attach, send UL UDP data, restart MME and send UL UDP data again"""
         self._s1ap_wrapper.configUEDevice(1)
         req = self._s1ap_wrapper.ue_req
-        print("************************* Running End to End attach for ",
-              "UE id ", req.ue_id)
+        print(
+            "************************* Running End to End attach for ",
+            "UE id ", req.ue_id,
+        )
         # Now actually complete the attach
         self._s1ap_wrapper._s1_util.attach(
             req.ue_id, s1ap_types.tfwCmd.UE_END_TO_END_ATTACH_REQUEST,
             s1ap_types.tfwCmd.UE_ATTACH_ACCEPT_IND,
-            s1ap_types.ueAttachAccept_t)
+            s1ap_types.ueAttachAccept_t,
+        )
 
         # Wait on EMM Information from MME
         self._s1ap_wrapper._s1_util.receive_emm_info()
 
-        print("************************* Running UE uplink (UDP) for UE id ",
-              req.ue_id)
+        print(
+            "************************* Running UE uplink (UDP) for UE id ",
+            req.ue_id,
+        )
         with self._s1ap_wrapper.configUplinkTest(
-                req, duration=1, is_udp=True) as test:
+                req, duration=1, is_udp=True,
+        ) as test:
             test.verify()
 
         print("************************* Restarting MME service on gateway")
@@ -56,18 +63,24 @@ class TestAttachUlUdpDataWithMmeRestart(unittest.TestCase):
             print("Waiting for", j, "seconds")
             time.sleep(1)
 
-        print("************************* Running UE uplink (UDP) for UE id ",
-              req.ue_id)
+        print(
+            "************************* Running UE uplink (UDP) for UE id ",
+            req.ue_id,
+        )
         with self._s1ap_wrapper.configUplinkTest(
-                req, duration=1, is_udp=True) as test:
+                req, duration=1, is_udp=True,
+        ) as test:
             test.verify()
 
-        print("************************* Running UE detach for UE id ",
-              req.ue_id)
+        print(
+            "************************* Running UE detach for UE id ",
+            req.ue_id,
+        )
         # Now detach the UE
         self._s1ap_wrapper.s1_util.detach(
             req.ue_id, s1ap_types.ueDetachType_t.UE_SWITCHOFF_DETACH.value,
-            True)
+            True,
+        )
 
 
 if __name__ == "__main__":

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_ul_udp_data_with_mobilityd_restart.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_ul_udp_data_with_mobilityd_restart.py
@@ -23,7 +23,8 @@ class TestAttachUlUdpDataWithMobilitydRestart(unittest.TestCase):
 
     def setUp(self):
         self._s1ap_wrapper = s1ap_wrapper.TestWrapper(
-            stateless_mode=MagmadUtil.stateless_cmds.ENABLE)
+            stateless_mode=MagmadUtil.stateless_cmds.ENABLE,
+        )
 
     def tearDown(self):
         self._s1ap_wrapper.cleanup()
@@ -35,43 +36,57 @@ class TestAttachUlUdpDataWithMobilitydRestart(unittest.TestCase):
         """
         self._s1ap_wrapper.configUEDevice(1)
         req = self._s1ap_wrapper.ue_req
-        print("************************* Running End to End attach for ",
-              "UE id ", req.ue_id)
+        print(
+            "************************* Running End to End attach for ",
+            "UE id ", req.ue_id,
+        )
         # Now actually complete the attach
         self._s1ap_wrapper._s1_util.attach(
             req.ue_id, s1ap_types.tfwCmd.UE_END_TO_END_ATTACH_REQUEST,
             s1ap_types.tfwCmd.UE_ATTACH_ACCEPT_IND,
-            s1ap_types.ueAttachAccept_t)
+            s1ap_types.ueAttachAccept_t,
+        )
 
         # Wait on EMM Information from MME
         self._s1ap_wrapper._s1_util.receive_emm_info()
 
-        print("************************* Running UE uplink (UDP) for UE id ",
-              req.ue_id)
+        print(
+            "************************* Running UE uplink (UDP) for UE id ",
+            req.ue_id,
+        )
         with self._s1ap_wrapper.configUplinkTest(
-                req, duration=1, is_udp=True) as test:
+                req, duration=1, is_udp=True,
+        ) as test:
             test.verify()
 
-        print("************************* Restarting Mobilityd service",
-              "on gateway")
+        print(
+            "************************* Restarting Mobilityd service",
+            "on gateway",
+        )
         self._s1ap_wrapper.magmad_util.restart_services(["mobilityd"])
 
         for j in range(30):
             print("Waiting for", j, "seconds")
             time.sleep(1)
 
-        print("************************* Running UE uplink (UDP) for UE id ",
-              req.ue_id)
+        print(
+            "************************* Running UE uplink (UDP) for UE id ",
+            req.ue_id,
+        )
         with self._s1ap_wrapper.configUplinkTest(
-                req, duration=1, is_udp=True) as test:
+                req, duration=1, is_udp=True,
+        ) as test:
             test.verify()
 
-        print("************************* Running UE detach for UE id ",
-              req.ue_id)
+        print(
+            "************************* Running UE detach for UE id ",
+            req.ue_id,
+        )
         # Now detach the UE
         self._s1ap_wrapper.s1_util.detach(
             req.ue_id, s1ap_types.ueDetachType_t.UE_SWITCHOFF_DETACH.value,
-            True)
+            True,
+        )
 
 
 if __name__ == "__main__":

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_ul_udp_data_with_multiple_service_restart.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_ul_udp_data_with_multiple_service_restart.py
@@ -18,11 +18,13 @@ import s1ap_types
 import s1ap_wrapper
 from s1ap_utils import MagmadUtil
 
+
 class TestAttachUlUdpDataWithMultipleServiceRestart(unittest.TestCase):
 
     def setUp(self):
         self._s1ap_wrapper = s1ap_wrapper.TestWrapper(
-            stateless_mode=MagmadUtil.stateless_cmds.ENABLE)
+            stateless_mode=MagmadUtil.stateless_cmds.ENABLE,
+        )
 
     def tearDown(self):
         self._s1ap_wrapper.cleanup()
@@ -34,44 +36,60 @@ class TestAttachUlUdpDataWithMultipleServiceRestart(unittest.TestCase):
         """
         self._s1ap_wrapper.configUEDevice(1)
         req = self._s1ap_wrapper.ue_req
-        print("************************* Running End to End attach for ",
-              "UE id ", req.ue_id)
+        print(
+            "************************* Running End to End attach for ",
+            "UE id ", req.ue_id,
+        )
         # Now actually complete the attach
         self._s1ap_wrapper._s1_util.attach(
             req.ue_id, s1ap_types.tfwCmd.UE_END_TO_END_ATTACH_REQUEST,
             s1ap_types.tfwCmd.UE_ATTACH_ACCEPT_IND,
-            s1ap_types.ueAttachAccept_t)
+            s1ap_types.ueAttachAccept_t,
+        )
 
         # Wait on EMM Information from MME
         self._s1ap_wrapper._s1_util.receive_emm_info()
 
-        print("************************* Running UE uplink (UDP) for UE id ",
-              req.ue_id)
+        print(
+            "************************* Running UE uplink (UDP) for UE id ",
+            req.ue_id,
+        )
         with self._s1ap_wrapper.configUplinkTest(
-                req, duration=1, is_udp=True) as test:
+                req, duration=1, is_udp=True,
+        ) as test:
             test.verify()
 
-        print("************************* Restarting Mobilityd, MME and",
-              "Pipelined services on gateway")
-        self._s1ap_wrapper.magmad_util.restart_services(["mobilityd", "mme",
-                                                         "pipelined"])
+        print(
+            "************************* Restarting Mobilityd, MME and",
+            "Pipelined services on gateway",
+        )
+        self._s1ap_wrapper.magmad_util.restart_services([
+            "mobilityd", "mme",
+            "pipelined",
+        ])
 
         for j in range(30):
             print("Waiting for", j, "seconds")
             time.sleep(1)
 
-        print("************************* Running UE uplink (UDP) for UE id ",
-              req.ue_id)
+        print(
+            "************************* Running UE uplink (UDP) for UE id ",
+            req.ue_id,
+        )
         with self._s1ap_wrapper.configUplinkTest(
-                req, duration=1, is_udp=True) as test:
+                req, duration=1, is_udp=True,
+        ) as test:
             test.verify()
 
-        print("************************* Running UE detach for UE id ",
-              req.ue_id)
+        print(
+            "************************* Running UE detach for UE id ",
+            req.ue_id,
+        )
         # Now detach the UE
         self._s1ap_wrapper.s1_util.detach(
             req.ue_id, s1ap_types.ueDetachType_t.UE_SWITCHOFF_DETACH.value,
-            True)
+            True,
+        )
 
 
 if __name__ == "__main__":

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_ul_udp_data_with_pipelined_restart.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_ul_udp_data_with_pipelined_restart.py
@@ -18,11 +18,13 @@ import s1ap_types
 import s1ap_wrapper
 from s1ap_utils import MagmadUtil
 
+
 class TestAttachUlUdpDataWithPipelinedRestart(unittest.TestCase):
 
     def setUp(self):
         self._s1ap_wrapper = s1ap_wrapper.TestWrapper(
-            stateless_mode=MagmadUtil.stateless_cmds.ENABLE)
+            stateless_mode=MagmadUtil.stateless_cmds.ENABLE,
+        )
 
     def tearDown(self):
         self._s1ap_wrapper.cleanup()
@@ -34,43 +36,57 @@ class TestAttachUlUdpDataWithPipelinedRestart(unittest.TestCase):
         """
         self._s1ap_wrapper.configUEDevice(1)
         req = self._s1ap_wrapper.ue_req
-        print("************************* Running End to End attach for ",
-              "UE id ", req.ue_id)
+        print(
+            "************************* Running End to End attach for ",
+            "UE id ", req.ue_id,
+        )
         # Now actually complete the attach
         self._s1ap_wrapper._s1_util.attach(
             req.ue_id, s1ap_types.tfwCmd.UE_END_TO_END_ATTACH_REQUEST,
             s1ap_types.tfwCmd.UE_ATTACH_ACCEPT_IND,
-            s1ap_types.ueAttachAccept_t)
+            s1ap_types.ueAttachAccept_t,
+        )
 
         # Wait on EMM Information from MME
         self._s1ap_wrapper._s1_util.receive_emm_info()
 
-        print("************************* Running UE uplink (UDP) for UE id ",
-              req.ue_id)
+        print(
+            "************************* Running UE uplink (UDP) for UE id ",
+            req.ue_id,
+        )
         with self._s1ap_wrapper.configUplinkTest(
-                req, duration=1, is_udp=True) as test:
+                req, duration=1, is_udp=True,
+        ) as test:
             test.verify()
 
-        print("************************* Restarting Pipelined service",
-              "on gateway")
+        print(
+            "************************* Restarting Pipelined service",
+            "on gateway",
+        )
         self._s1ap_wrapper.magmad_util.restart_services(["pipelined"])
 
         for j in range(30):
             print("Waiting for", j, "seconds")
             time.sleep(1)
 
-        print("************************* Running UE uplink (UDP) for UE id ",
-              req.ue_id)
+        print(
+            "************************* Running UE uplink (UDP) for UE id ",
+            req.ue_id,
+        )
         with self._s1ap_wrapper.configUplinkTest(
-                req, duration=1, is_udp=True) as test:
+                req, duration=1, is_udp=True,
+        ) as test:
             test.verify()
 
-        print("************************* Running UE detach for UE id ",
-              req.ue_id)
+        print(
+            "************************* Running UE detach for UE id ",
+            req.ue_id,
+        )
         # Now detach the UE
         self._s1ap_wrapper.s1_util.detach(
             req.ue_id, s1ap_types.ueDetachType_t.UE_SWITCHOFF_DETACH.value,
-            True)
+            True,
+        )
 
 
 if __name__ == "__main__":

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_ul_udp_data_with_sessiond_restart.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_ul_udp_data_with_sessiond_restart.py
@@ -18,11 +18,13 @@ import s1ap_types
 import s1ap_wrapper
 from s1ap_utils import MagmadUtil
 
+
 class TestAttachUlUdpDataWithSessiondRestart(unittest.TestCase):
 
     def setUp(self):
         self._s1ap_wrapper = s1ap_wrapper.TestWrapper(
-            stateless_mode=MagmadUtil.stateless_cmds.ENABLE)
+            stateless_mode=MagmadUtil.stateless_cmds.ENABLE,
+        )
 
     def tearDown(self):
         self._s1ap_wrapper.cleanup()
@@ -34,43 +36,57 @@ class TestAttachUlUdpDataWithSessiondRestart(unittest.TestCase):
         """
         self._s1ap_wrapper.configUEDevice(1)
         req = self._s1ap_wrapper.ue_req
-        print("************************* Running End to End attach for ",
-              "UE id ", req.ue_id)
+        print(
+            "************************* Running End to End attach for ",
+            "UE id ", req.ue_id,
+        )
         # Now actually complete the attach
         self._s1ap_wrapper._s1_util.attach(
             req.ue_id, s1ap_types.tfwCmd.UE_END_TO_END_ATTACH_REQUEST,
             s1ap_types.tfwCmd.UE_ATTACH_ACCEPT_IND,
-            s1ap_types.ueAttachAccept_t)
+            s1ap_types.ueAttachAccept_t,
+        )
 
         # Wait on EMM Information from MME
         self._s1ap_wrapper._s1_util.receive_emm_info()
 
-        print("************************* Running UE uplink (UDP) for UE id ",
-              req.ue_id)
+        print(
+            "************************* Running UE uplink (UDP) for UE id ",
+            req.ue_id,
+        )
         with self._s1ap_wrapper.configUplinkTest(
-                req, duration=1, is_udp=True) as test:
+                req, duration=1, is_udp=True,
+        ) as test:
             test.verify()
 
-        print("************************* Restarting Sessiond service",
-              "on gateway")
+        print(
+            "************************* Restarting Sessiond service",
+            "on gateway",
+        )
         self._s1ap_wrapper.magmad_util.restart_services(["sessiond"])
 
         for j in range(30):
             print("Waiting for", j, "seconds")
             time.sleep(1)
 
-        print("************************* Running UE uplink (UDP) for UE id ",
-              req.ue_id)
+        print(
+            "************************* Running UE uplink (UDP) for UE id ",
+            req.ue_id,
+        )
         with self._s1ap_wrapper.configUplinkTest(
-                req, duration=1, is_udp=True) as test:
+                req, duration=1, is_udp=True,
+        ) as test:
             test.verify()
 
-        print("************************* Running UE detach for UE id ",
-              req.ue_id)
+        print(
+            "************************* Running UE detach for UE id ",
+            req.ue_id,
+        )
         # Now detach the UE
         self._s1ap_wrapper.s1_util.detach(
             req.ue_id, s1ap_types.ueDetachType_t.UE_SWITCHOFF_DETACH.value,
-            True)
+            True,
+        )
 
 
 if __name__ == "__main__":

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_via_guti.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_via_guti.py
@@ -28,28 +28,36 @@ class TestAttachViaGuti(unittest.TestCase):
     def test_attach_via_guti(self):
         """ Basic attach test with a single UE using GUTI """
         num_ues = 2
-        detach_type = [s1ap_types.ueDetachType_t.UE_NORMAL_DETACH.value,
-                       s1ap_types.ueDetachType_t.UE_SWITCHOFF_DETACH.value]
+        detach_type = [
+            s1ap_types.ueDetachType_t.UE_NORMAL_DETACH.value,
+            s1ap_types.ueDetachType_t.UE_SWITCHOFF_DETACH.value,
+        ]
         wait_for_s1 = [True, False]
         self._s1ap_wrapper.configUEDevice(num_ues)
         for i in range(num_ues):
             req = self._s1ap_wrapper.ue_req
-            print("************************* Running End to End attach for "
-                  "UE id ", req.ue_id)
+            print(
+                "************************* Running End to End attach for "
+                "UE id ", req.ue_id,
+            )
             # Now actually complete the attach
             self._s1ap_wrapper.s1_util.attach(
                 req.ue_id, s1ap_types.tfwCmd.UE_END_TO_END_ATTACH_REQUEST,
                 s1ap_types.tfwCmd.UE_ATTACH_ACCEPT_IND,
                 s1ap_types.ueAttachAccept_t,
-                id_type=s1ap_types.TFW_MID_TYPE_GUTI)
+                id_type=s1ap_types.TFW_MID_TYPE_GUTI,
+            )
             # Wait on EMM Information from MME
             self._s1ap_wrapper._s1_util.receive_emm_info()
 
-            print("************************* Running UE detach for UE id ",
-                  req.ue_id)
+            print(
+                "************************* Running UE detach for UE id ",
+                req.ue_id,
+            )
             # Now detach the UE
             self._s1ap_wrapper.s1_util.detach(
-                req.ue_id, detach_type[i], wait_for_s1[i])
+                req.ue_id, detach_type[i], wait_for_s1[i],
+            )
 
 
 if __name__ == "__main__":

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_with_multiple_mme_restarts.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_with_multiple_mme_restarts.py
@@ -19,11 +19,13 @@ import s1ap_types
 import s1ap_wrapper
 from s1ap_utils import MagmadUtil
 
+
 class TestAttachWithMultipleMmeRestarts(unittest.TestCase):
 
     def setUp(self):
         self._s1ap_wrapper = s1ap_wrapper.TestWrapper(
-            stateless_mode=MagmadUtil.stateless_cmds.ENABLE)
+            stateless_mode=MagmadUtil.stateless_cmds.ENABLE,
+        )
 
     def tearDown(self):
         self._s1ap_wrapper.cleanup()
@@ -42,12 +44,12 @@ class TestAttachWithMultipleMmeRestarts(unittest.TestCase):
         attach_req.useOldSecCtxt = sec_ctxt
 
         self._s1ap_wrapper._s1_util.issue_cmd(
-            s1ap_types.tfwCmd.UE_ATTACH_REQUEST, attach_req
+            s1ap_types.tfwCmd.UE_ATTACH_REQUEST, attach_req,
         )
 
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_AUTH_REQ_IND.value
+            response.msg_type, s1ap_types.tfwCmd.UE_AUTH_REQ_IND.value,
         )
         print("************************* Received UE_AUTH_REQ_IND")
 
@@ -62,12 +64,12 @@ class TestAttachWithMultipleMmeRestarts(unittest.TestCase):
         auth_res.sqnRcvd = sqn_recvd
         print("************************* Sending Auth Response ue-id", auth_res.ue_Id)
         self._s1ap_wrapper._s1_util.issue_cmd(
-            s1ap_types.tfwCmd.UE_AUTH_RESP, auth_res
+            s1ap_types.tfwCmd.UE_AUTH_RESP, auth_res,
         )
 
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_SEC_MOD_CMD_IND.value
+            response.msg_type, s1ap_types.tfwCmd.UE_SEC_MOD_CMD_IND.value,
         )
         print("************************* Received UE_SEC_MOD_CMD_IND")
 
@@ -77,18 +79,18 @@ class TestAttachWithMultipleMmeRestarts(unittest.TestCase):
         sec_mode_complete = s1ap_types.ueSecModeComplete_t()
         sec_mode_complete.ue_Id = 1
         self._s1ap_wrapper._s1_util.issue_cmd(
-            s1ap_types.tfwCmd.UE_SEC_MOD_COMPLETE, sec_mode_complete
+            s1ap_types.tfwCmd.UE_SEC_MOD_COMPLETE, sec_mode_complete,
         )
 
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.INT_CTX_SETUP_IND.value
+            response.msg_type, s1ap_types.tfwCmd.INT_CTX_SETUP_IND.value,
         )
         print("************************* Received INT_CTX_SETUP_IND")
 
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_ATTACH_ACCEPT_IND.value
+            response.msg_type, s1ap_types.tfwCmd.UE_ATTACH_ACCEPT_IND.value,
         )
         print("************************* Received UE_ATTACH_ACCEPT_IND")
 
@@ -99,7 +101,7 @@ class TestAttachWithMultipleMmeRestarts(unittest.TestCase):
         attach_complete = s1ap_types.ueAttachComplete_t()
         attach_complete.ue_Id = 1
         self._s1ap_wrapper._s1_util.issue_cmd(
-            s1ap_types.tfwCmd.UE_ATTACH_COMPLETE, attach_complete
+            s1ap_types.tfwCmd.UE_ATTACH_COMPLETE, attach_complete,
         )
 
         # Wait on EMM Information from MME
@@ -112,7 +114,7 @@ class TestAttachWithMultipleMmeRestarts(unittest.TestCase):
             s1ap_types.ueDetachType_t.UE_SWITCHOFF_DETACH.value
         )
         self._s1ap_wrapper._s1_util.issue_cmd(
-            s1ap_types.tfwCmd.UE_DETACH_REQUEST, detach_req
+            s1ap_types.tfwCmd.UE_DETACH_REQUEST, detach_req,
         )
 
         # Wait for UE context release command

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_without_ips_available.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_without_ips_available.py
@@ -36,12 +36,15 @@ class TestAttachWithoutIpsAvailable(unittest.TestCase):
         self._s1ap_wrapper.mobility_util.cleanup()
 
         req = self._s1ap_wrapper.ue_req
-        print("************************* Running End to End attach for ",
-              "UE id ", req.ue_id)
+        print(
+            "************************* Running End to End attach for ",
+            "UE id ", req.ue_id,
+        )
         # Now actually attempt the attach
         self._s1ap_wrapper._s1_util.attach(
             req.ue_id, s1ap_types.tfwCmd.UE_END_TO_END_ATTACH_REQUEST,
-            s1ap_types.tfwCmd.UE_ATTACH_REJECT_IND, s1ap_types.ueAttachFail_t)
+            s1ap_types.tfwCmd.UE_ATTACH_REJECT_IND, s1ap_types.ueAttachFail_t,
+        )
 
 
 if __name__ == "__main__":

--- a/lte/gateway/python/integ_tests/s1aptests/test_continuous_random_attach.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_continuous_random_attach.py
@@ -11,13 +11,14 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-import unittest
-import threading
-import random
 import ipaddress
+import random
+import threading
+import unittest
 
 import s1ap_types
 import s1ap_wrapper
+
 
 class TestContinuousRandomAttach(unittest.TestCase):
 
@@ -38,7 +39,7 @@ class TestContinuousRandomAttach(unittest.TestCase):
                 sqn_recvd.pres = 0
                 auth_res.sqnRcvd = sqn_recvd
                 self._s1ap_wrapper._s1_util.issue_cmd(
-                    s1ap_types.tfwCmd.UE_AUTH_RESP, auth_res
+                    s1ap_types.tfwCmd.UE_AUTH_RESP, auth_res,
                 )
             elif msg.msg_type == s1ap_types.tfwCmd.UE_SEC_MOD_CMD_IND.value:
                 self.sec_mod_cmd_ind_count += 1
@@ -47,7 +48,7 @@ class TestContinuousRandomAttach(unittest.TestCase):
                 sec_mode_complete = s1ap_types.ueSecModeComplete_t()
                 sec_mode_complete.ue_Id = m.ue_Id
                 self._s1ap_wrapper._s1_util.issue_cmd(
-                    s1ap_types.tfwCmd.UE_SEC_MOD_COMPLETE, sec_mode_complete
+                    s1ap_types.tfwCmd.UE_SEC_MOD_COMPLETE, sec_mode_complete,
                 )
             elif msg.msg_type == s1ap_types.tfwCmd.UE_ATTACH_ACCEPT_IND.value:
                 self.attach_accept_ind_count += 1
@@ -63,7 +64,7 @@ class TestContinuousRandomAttach(unittest.TestCase):
                 attach_complete = s1ap_types.ueAttachComplete_t()
                 attach_complete.ue_Id = m.ue_Id
                 self._s1ap_wrapper._s1_util.issue_cmd(
-                    s1ap_types.tfwCmd.UE_ATTACH_COMPLETE, attach_complete
+                    s1ap_types.tfwCmd.UE_ATTACH_COMPLETE, attach_complete,
                 )
             elif msg.msg_type == s1ap_types.tfwCmd.UE_IDENTITY_REQ_IND.value:
                 self.identity_req_ind_count += 1
@@ -73,7 +74,7 @@ class TestContinuousRandomAttach(unittest.TestCase):
                 us_identity_resp.ue_Id = m.ue_Id
                 us_identity_resp.idType = m.idType
                 self._s1ap_wrapper._s1_util.issue_cmd(
-                    s1ap_types.tfwCmd.UE_IDENTITY_RESP, us_identity_resp
+                    s1ap_types.tfwCmd.UE_IDENTITY_RESP, us_identity_resp,
                 )
             elif msg.msg_type == s1ap_types.tfwCmd.INT_CTX_SETUP_IND.value:
                 self.int_ctx_setup_ind_count += 1
@@ -95,7 +96,7 @@ class TestContinuousRandomAttach(unittest.TestCase):
         attach_req.useOldSecCtxt = sec_ctxt
 
         self._s1ap_wrapper._s1_util.issue_cmd(
-            s1ap_types.tfwCmd.UE_ATTACH_REQUEST, attach_req
+            s1ap_types.tfwCmd.UE_ATTACH_REQUEST, attach_req,
         )
         self.attach_req_sent_count += 1
 
@@ -106,7 +107,7 @@ class TestContinuousRandomAttach(unittest.TestCase):
             s1ap_types.ueDetachType_t.UE_SWITCHOFF_DETACH.value
         )
         self._s1ap_wrapper._s1_util.issue_cmd(
-            s1ap_types.tfwCmd.UE_DETACH_REQUEST, detach_req
+            s1ap_types.tfwCmd.UE_DETACH_REQUEST, detach_req,
         )
         self.detach_req_sent_count += 1
 
@@ -115,17 +116,17 @@ class TestContinuousRandomAttach(unittest.TestCase):
         self.send_ue_detach(ue_state.ue_id)
         attachTime = random.uniform(self.attach_delay_t0, self.attach_delay_t1)
         ue_state.attachTimer = threading.Timer(
-            attachTime, self.handle_attach_timer, args=(ue_state,)
+            attachTime, self.handle_attach_timer, args=(ue_state,),
         )
         ue_state.attachTimer.start()
 
     def handle_attach_timer(self, ue_state):
         print("Attaching ue_id", ue_state.ue_id)
         attachDuration = random.uniform(
-            self.attach_duration_t0, self.attach_duration_t1
+            self.attach_duration_t0, self.attach_duration_t1,
         )
         ue_state.detachTimer = threading.Timer(
-            attachDuration, self.handle_detach_timer, args=(ue_state,)
+            attachDuration, self.handle_detach_timer, args=(ue_state,),
         )
         ue_state.detachTimer.start()
         self.send_attach_req(ue_state.ue_id)
@@ -133,7 +134,7 @@ class TestContinuousRandomAttach(unittest.TestCase):
     def start_ue(self, ue_state):
         attachTime = random.uniform(self.attach_delay_t0, self.attach_delay_t1)
         ue_state.attachTimer = threading.Timer(
-            attachTime, self.handle_attach_timer, args=(ue_state,)
+            attachTime, self.handle_attach_timer, args=(ue_state,),
         )
         ue_state.attachTimer.start()
 
@@ -204,6 +205,7 @@ class TestContinuousRandomAttach(unittest.TestCase):
         print("ue_emm_information_count: ", self.ue_emm_information_count)
         print("detach_req_sent_count: ", self.detach_req_sent_count)
         print("ue_ctx_rel_ind_count: ", self.ue_ctx_rel_ind_count)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/lte/gateway/python/integ_tests/s1aptests/test_data_flow_after_service_request.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_data_flow_after_service_request.py
@@ -11,12 +11,12 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
+import time
 import unittest
 
 import gpp_types
 import s1ap_types
 import s1ap_wrapper
-import time
 
 
 class TestDataFlowAfterServiceRequest(unittest.TestCase):
@@ -82,11 +82,11 @@ class TestDataFlowAfterServiceRequest(unittest.TestCase):
                 gpp_types.CauseRadioNetwork.USER_INACTIVITY.value
             )
             self._s1ap_wrapper.s1_util.issue_cmd(
-                s1ap_types.tfwCmd.UE_CNTXT_REL_REQUEST, req
+                s1ap_types.tfwCmd.UE_CNTXT_REL_REQUEST, req,
             )
             response = self._s1ap_wrapper.s1_util.get_response()
             self.assertEqual(
-                response.msg_type, s1ap_types.tfwCmd.UE_CTX_REL_IND.value
+                response.msg_type, s1ap_types.tfwCmd.UE_CTX_REL_IND.value,
             )
 
         for req in reqs:
@@ -102,11 +102,11 @@ class TestDataFlowAfterServiceRequest(unittest.TestCase):
             req.ueMtmsi.pres = False
             req.rrcCause = s1ap_types.Rrc_Cause.TFW_MO_DATA.value
             self._s1ap_wrapper.s1_util.issue_cmd(
-                s1ap_types.tfwCmd.UE_SERVICE_REQUEST, req
+                s1ap_types.tfwCmd.UE_SERVICE_REQUEST, req,
             )
             response = self._s1ap_wrapper.s1_util.get_response()
             self.assertEqual(
-                response.msg_type, s1ap_types.tfwCmd.INT_CTX_SETUP_IND.value
+                response.msg_type, s1ap_types.tfwCmd.INT_CTX_SETUP_IND.value,
             )
 
         with test:

--- a/lte/gateway/python/integ_tests/s1aptests/test_dedicated_bearer_activation_idle_mode.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_dedicated_bearer_activation_idle_mode.py
@@ -11,14 +11,14 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-import unittest
+import ipaddress
 import time
+import unittest
 
 import gpp_types
 import s1ap_types
 import s1ap_wrapper
 from integ_tests.s1aptests.s1ap_utils import SessionManagerUtil
-import ipaddress
 from lte.protos.policydb_pb2 import FlowMatch
 
 
@@ -178,11 +178,11 @@ class TestDedicatedBearerActivationIdleMode(unittest.TestCase):
             gpp_types.CauseRadioNetwork.USER_INACTIVITY.value
         )
         self._s1ap_wrapper.s1_util.issue_cmd(
-            s1ap_types.tfwCmd.UE_CNTXT_REL_REQUEST, rel_req
+            s1ap_types.tfwCmd.UE_CNTXT_REL_REQUEST, rel_req,
         )
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_CTX_REL_IND.value
+            response.msg_type, s1ap_types.tfwCmd.UE_CTX_REL_IND.value,
         )
 
         # Verify if paging flow rules are created
@@ -223,7 +223,7 @@ class TestDedicatedBearerActivationIdleMode(unittest.TestCase):
 
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_PAGING_IND.value
+            response.msg_type, s1ap_types.tfwCmd.UE_PAGING_IND.value,
         )
 
         print("*********** Received Paging for UE id ", ue_id)
@@ -235,20 +235,20 @@ class TestDedicatedBearerActivationIdleMode(unittest.TestCase):
         ser_req.ueMtmsi.pres = False
         ser_req.rrcCause = s1ap_types.Rrc_Cause.TFW_MO_SIGNALLING.value
         self._s1ap_wrapper.s1_util.issue_cmd(
-            s1ap_types.tfwCmd.UE_SERVICE_REQUEST, ser_req
+            s1ap_types.tfwCmd.UE_SERVICE_REQUEST, ser_req,
         )
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.INT_CTX_SETUP_IND.value
+            response.msg_type, s1ap_types.tfwCmd.INT_CTX_SETUP_IND.value,
         )
 
         print("*********** Received ICS Request for UE id ", ue_id)
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_ACT_DED_BER_REQ.value
+            response.msg_type, s1ap_types.tfwCmd.UE_ACT_DED_BER_REQ.value,
         )
         act_ded_ber_req_oai_apn1 = response.cast(
-            s1ap_types.UeActDedBearCtxtReq_t
+            s1ap_types.UeActDedBearCtxtReq_t,
         )
         print(
             "*********** Received Activate dedicated EPS bearer"
@@ -256,14 +256,14 @@ class TestDedicatedBearerActivationIdleMode(unittest.TestCase):
             act_ded_ber_req_oai_apn1.bearerId,
         )
         self._s1ap_wrapper.sendActDedicatedBearerAccept(
-            ue_id, act_ded_ber_req_oai_apn1.bearerId
+            ue_id, act_ded_ber_req_oai_apn1.bearerId,
         )
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_ACT_DED_BER_REQ.value
+            response.msg_type, s1ap_types.tfwCmd.UE_ACT_DED_BER_REQ.value,
         )
         act_ded_ber_req_oai_apn2 = response.cast(
-            s1ap_types.UeActDedBearCtxtReq_t
+            s1ap_types.UeActDedBearCtxtReq_t,
         )
         print(
             "*********** Received Activate dedicated EPS bearer"
@@ -272,7 +272,7 @@ class TestDedicatedBearerActivationIdleMode(unittest.TestCase):
         )
 
         self._s1ap_wrapper.sendActDedicatedBearerAccept(
-            ue_id, act_ded_ber_req_oai_apn2.bearerId
+            ue_id, act_ded_ber_req_oai_apn2.bearerId,
         )
 
         # Verify if flow rules are created
@@ -280,7 +280,7 @@ class TestDedicatedBearerActivationIdleMode(unittest.TestCase):
         # 1 UL flow is created per bearer
         num_ul_flows = 3
         self._s1ap_wrapper.s1_util.verify_flow_rules(
-            num_ul_flows, dl_flow_rules
+            num_ul_flows, dl_flow_rules,
         )
 
         print("*********** Sleeping for 5 seconds")
@@ -289,7 +289,7 @@ class TestDedicatedBearerActivationIdleMode(unittest.TestCase):
 
         # Now detach the UE
         self._s1ap_wrapper.s1_util.detach(
-            ue_id, s1ap_types.ueDetachType_t.UE_SWITCHOFF_DETACH.value, True
+            ue_id, s1ap_types.ueDetachType_t.UE_SWITCHOFF_DETACH.value, True,
         )
 
 

--- a/lte/gateway/python/integ_tests/s1aptests/test_dedicated_bearer_activation_idle_mode_multi_ue.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_dedicated_bearer_activation_idle_mode_multi_ue.py
@@ -11,13 +11,13 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-import unittest
+import ipaddress
 import time
+import unittest
 
 import gpp_types
 import s1ap_types
 import s1ap_wrapper
-import ipaddress
 from integ_tests.s1aptests.s1ap_utils import SessionManagerUtil
 from lte.protos.policydb_pb2 import FlowMatch
 
@@ -190,11 +190,11 @@ class TestDedicatedBearerActivationIdleModeMultiUe(unittest.TestCase):
                 gpp_types.CauseRadioNetwork.USER_INACTIVITY.value
             )
             self._s1ap_wrapper.s1_util.issue_cmd(
-                s1ap_types.tfwCmd.UE_CNTXT_REL_REQUEST, rel_req
+                s1ap_types.tfwCmd.UE_CNTXT_REL_REQUEST, rel_req,
             )
             response = self._s1ap_wrapper.s1_util.get_response()
             self.assertEqual(
-                response.msg_type, s1ap_types.tfwCmd.UE_CTX_REL_IND.value
+                response.msg_type, s1ap_types.tfwCmd.UE_CTX_REL_IND.value,
             )
             # Verify if paging flow rules are created
             ip_list = [default_ips[i]]
@@ -244,7 +244,7 @@ class TestDedicatedBearerActivationIdleModeMultiUe(unittest.TestCase):
 
             response = self._s1ap_wrapper.s1_util.get_response()
             self.assertEqual(
-                response.msg_type, s1ap_types.tfwCmd.UE_PAGING_IND.value
+                response.msg_type, s1ap_types.tfwCmd.UE_PAGING_IND.value,
             )
             print("*********** Received Paging for UE id ", ue_id)
 
@@ -260,20 +260,20 @@ class TestDedicatedBearerActivationIdleModeMultiUe(unittest.TestCase):
             req.ueMtmsi.pres = False
             req.rrcCause = s1ap_types.Rrc_Cause.TFW_MO_SIGNALLING.value
             self._s1ap_wrapper.s1_util.issue_cmd(
-                s1ap_types.tfwCmd.UE_SERVICE_REQUEST, req
+                s1ap_types.tfwCmd.UE_SERVICE_REQUEST, req,
             )
             response = self._s1ap_wrapper.s1_util.get_response()
             self.assertEqual(
-                response.msg_type, s1ap_types.tfwCmd.INT_CTX_SETUP_IND.value
+                response.msg_type, s1ap_types.tfwCmd.INT_CTX_SETUP_IND.value,
             )
 
             print("*********** Received ICS Request for UE id ", ue_id)
             response = self._s1ap_wrapper.s1_util.get_response()
             self.assertEqual(
-                response.msg_type, s1ap_types.tfwCmd.UE_ACT_DED_BER_REQ.value
+                response.msg_type, s1ap_types.tfwCmd.UE_ACT_DED_BER_REQ.value,
             )
             act_ded_ber_req_oai_apn1 = response.cast(
-                s1ap_types.UeActDedBearCtxtReq_t
+                s1ap_types.UeActDedBearCtxtReq_t,
             )
             print(
                 "*********** Received Activate dedicated EPS bearer"
@@ -281,14 +281,14 @@ class TestDedicatedBearerActivationIdleModeMultiUe(unittest.TestCase):
                 act_ded_ber_req_oai_apn1.bearerId,
             )
             self._s1ap_wrapper.sendActDedicatedBearerAccept(
-                ue_id, act_ded_ber_req_oai_apn1.bearerId
+                ue_id, act_ded_ber_req_oai_apn1.bearerId,
             )
             response = self._s1ap_wrapper.s1_util.get_response()
             self.assertEqual(
-                response.msg_type, s1ap_types.tfwCmd.UE_ACT_DED_BER_REQ.value
+                response.msg_type, s1ap_types.tfwCmd.UE_ACT_DED_BER_REQ.value,
             )
             act_ded_ber_req_oai_apn2 = response.cast(
-                s1ap_types.UeActDedBearCtxtReq_t
+                s1ap_types.UeActDedBearCtxtReq_t,
             )
             print(
                 "*********** Received Activate dedicated EPS bearer"
@@ -297,7 +297,7 @@ class TestDedicatedBearerActivationIdleModeMultiUe(unittest.TestCase):
             )
 
             self._s1ap_wrapper.sendActDedicatedBearerAccept(
-                ue_id, act_ded_ber_req_oai_apn2.bearerId
+                ue_id, act_ded_ber_req_oai_apn2.bearerId,
             )
 
         print("*********** Sleeping for 5 seconds")
@@ -309,7 +309,7 @@ class TestDedicatedBearerActivationIdleModeMultiUe(unittest.TestCase):
             dl_flow_rules = {default_ips[i]: [flow_list1, flow_list2]}
 
             self._s1ap_wrapper.s1_util.verify_flow_rules(
-                num_ul_flows, dl_flow_rules
+                num_ul_flows, dl_flow_rules,
             )
 
         print("*********** Sleeping for 5 seconds")
@@ -319,7 +319,7 @@ class TestDedicatedBearerActivationIdleModeMultiUe(unittest.TestCase):
 
             # Now detach the UE
             self._s1ap_wrapper.s1_util.detach(
-                ue, s1ap_types.ueDetachType_t.UE_SWITCHOFF_DETACH.value, True
+                ue, s1ap_types.ueDetachType_t.UE_SWITCHOFF_DETACH.value, True,
             )
 
 

--- a/lte/gateway/python/integ_tests/s1aptests/test_dedicated_bearer_activation_idle_mode_paging_timer_expiry.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_dedicated_bearer_activation_idle_mode_paging_timer_expiry.py
@@ -11,13 +11,13 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-import unittest
+import ipaddress
 import time
+import unittest
 
 import gpp_types
 import s1ap_types
 import s1ap_wrapper
-import ipaddress
 from integ_tests.s1aptests.s1ap_utils import SessionManagerUtil
 from lte.protos.policydb_pb2 import FlowMatch
 
@@ -160,11 +160,11 @@ class TestDedicatedBearerActivationIdleModePagingTmrExpiry(unittest.TestCase):
         req.ue_Id = ue_id
         req.cause.causeVal = gpp_types.CauseRadioNetwork.USER_INACTIVITY.value
         self._s1ap_wrapper.s1_util.issue_cmd(
-            s1ap_types.tfwCmd.UE_CNTXT_REL_REQUEST, req
+            s1ap_types.tfwCmd.UE_CNTXT_REL_REQUEST, req,
         )
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_CTX_REL_IND.value
+            response.msg_type, s1ap_types.tfwCmd.UE_CTX_REL_IND.value,
         )
 
         # Verify if paging flow rules are created
@@ -175,7 +175,7 @@ class TestDedicatedBearerActivationIdleModePagingTmrExpiry(unittest.TestCase):
         time.sleep(5)
         print(
             "************* Adding dedicated bearer to magma.ipv4"
-            " PDN in idle mode"
+            " PDN in idle mode",
         )
         print(
             "************* Sending RAR for IMSI",
@@ -190,14 +190,14 @@ class TestDedicatedBearerActivationIdleModePagingTmrExpiry(unittest.TestCase):
 
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_PAGING_IND.value
+            response.msg_type, s1ap_types.tfwCmd.UE_PAGING_IND.value,
         )
 
         print("*********** Received Paging for UE id ", ue_id)
 
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_PAGING_IND.value
+            response.msg_type, s1ap_types.tfwCmd.UE_PAGING_IND.value,
         )
 
         print("*********** Received second Paging for UE id ", ue_id)
@@ -213,7 +213,7 @@ class TestDedicatedBearerActivationIdleModePagingTmrExpiry(unittest.TestCase):
             s1ap_types.ueDetachType_t.UE_SWITCHOFF_DETACH.value
         )
         self._s1ap_wrapper._s1_util.issue_cmd(
-            s1ap_types.tfwCmd.UE_DETACH_REQUEST, detach_req
+            s1ap_types.tfwCmd.UE_DETACH_REQUEST, detach_req,
         )
 
 

--- a/lte/gateway/python/integ_tests/s1aptests/test_different_enb_s1ap_id_same_ue.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_different_enb_s1ap_id_same_ue.py
@@ -11,11 +11,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
+import time
 import unittest
 
 import s1ap_types
-import time
-
 from integ_tests.s1aptests import s1ap_wrapper
 
 
@@ -42,12 +41,12 @@ class TestDifferentEnbS1apIdSameUe(unittest.TestCase):
         attach_req.useOldSecCtxt = sec_ctxt
         print("Sending Attach Request ue-id", attach_req.ue_Id)
         self._s1ap_wrapper._s1_util.issue_cmd(
-            s1ap_types.tfwCmd.UE_ATTACH_REQUEST, attach_req
+            s1ap_types.tfwCmd.UE_ATTACH_REQUEST, attach_req,
         )
 
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_AUTH_REQ_IND.value
+            response.msg_type, s1ap_types.tfwCmd.UE_AUTH_REQ_IND.value,
         )
         print("Received auth req ind ")
 
@@ -58,12 +57,12 @@ class TestDifferentEnbS1apIdSameUe(unittest.TestCase):
         auth_res.sqnRcvd = sqn_recvd
         print("Sending Auth Response ue-id", auth_res.ue_Id)
         self._s1ap_wrapper._s1_util.issue_cmd(
-            s1ap_types.tfwCmd.UE_AUTH_RESP, auth_res
+            s1ap_types.tfwCmd.UE_AUTH_RESP, auth_res,
         )
 
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_SEC_MOD_CMD_IND.value
+            response.msg_type, s1ap_types.tfwCmd.UE_SEC_MOD_CMD_IND.value,
         )
         print("Received Security Mode Command ue-id", auth_res.ue_Id)
 
@@ -77,7 +76,7 @@ class TestDifferentEnbS1apIdSameUe(unittest.TestCase):
         attach_req.useOldSecCtxt = sec_ctxt
         print("Sending Attach Request ue-id", attach_req.ue_Id)
         self._s1ap_wrapper._s1_util.issue_cmd(
-            s1ap_types.tfwCmd.UE_ATTACH_REQUEST, attach_req
+            s1ap_types.tfwCmd.UE_ATTACH_REQUEST, attach_req,
         )
 
         time.sleep(1)
@@ -85,22 +84,22 @@ class TestDifferentEnbS1apIdSameUe(unittest.TestCase):
         sec_mode_complete = s1ap_types.ueSecModeComplete_t()
         sec_mode_complete.ue_Id = 1
         self._s1ap_wrapper._s1_util.issue_cmd(
-            s1ap_types.tfwCmd.UE_SEC_MOD_COMPLETE, sec_mode_complete
+            s1ap_types.tfwCmd.UE_SEC_MOD_COMPLETE, sec_mode_complete,
         )
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.INT_CTX_SETUP_IND.value
+            response.msg_type, s1ap_types.tfwCmd.INT_CTX_SETUP_IND.value,
         )
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_ATTACH_ACCEPT_IND.value
+            response.msg_type, s1ap_types.tfwCmd.UE_ATTACH_ACCEPT_IND.value,
         )
 
         # Trigger Attach Complete
         attach_complete = s1ap_types.ueAttachComplete_t()
         attach_complete.ue_Id = 1
         self._s1ap_wrapper._s1_util.issue_cmd(
-            s1ap_types.tfwCmd.UE_ATTACH_COMPLETE, attach_complete
+            s1ap_types.tfwCmd.UE_ATTACH_COMPLETE, attach_complete,
         )
         # Wait on EMM Information from MME
         self._s1ap_wrapper._s1_util.receive_emm_info()
@@ -115,12 +114,12 @@ class TestDifferentEnbS1apIdSameUe(unittest.TestCase):
             s1ap_types.ueDetachType_t.UE_SWITCHOFF_DETACH.value
         )
         self._s1ap_wrapper._s1_util.issue_cmd(
-            s1ap_types.tfwCmd.UE_DETACH_REQUEST, detach_req
+            s1ap_types.tfwCmd.UE_DETACH_REQUEST, detach_req,
         )
         # Wait for UE context release command
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_CTX_REL_IND.value
+            response.msg_type, s1ap_types.tfwCmd.UE_CTX_REL_IND.value,
         )
 
 

--- a/lte/gateway/python/integ_tests/s1aptests/test_duplicate_attach.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_duplicate_attach.py
@@ -46,25 +46,25 @@ class TestDuplicateAttach(unittest.TestCase):
         auth_res.sqnRcvd = sqnRecvd
 
         self._s1ap_wrapper._s1_util.issue_cmd(
-            s1ap_types.tfwCmd.UE_AUTH_RESP, auth_res
+            s1ap_types.tfwCmd.UE_AUTH_RESP, auth_res,
         )
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_SEC_MOD_CMD_IND.value
+            response.msg_type, s1ap_types.tfwCmd.UE_SEC_MOD_CMD_IND.value,
         )
 
         sec_mode_complete = s1ap_types.ueSecModeComplete_t()
         sec_mode_complete.ue_Id = req.ue_id
         self._s1ap_wrapper._s1_util.issue_cmd(
-            s1ap_types.tfwCmd.UE_SEC_MOD_COMPLETE, sec_mode_complete
+            s1ap_types.tfwCmd.UE_SEC_MOD_COMPLETE, sec_mode_complete,
         )
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.INT_CTX_SETUP_IND.value
+            response.msg_type, s1ap_types.tfwCmd.INT_CTX_SETUP_IND.value,
         )
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_ATTACH_ACCEPT_IND.value
+            response.msg_type, s1ap_types.tfwCmd.UE_ATTACH_ACCEPT_IND.value,
         )
 
         while True:
@@ -77,7 +77,7 @@ class TestDuplicateAttach(unittest.TestCase):
                 continue
 
             self.assertEqual(
-                response.msg_type, s1ap_types.tfwCmd.UE_CTX_REL_IND.value
+                response.msg_type, s1ap_types.tfwCmd.UE_CTX_REL_IND.value,
             )
             break
 
@@ -94,7 +94,7 @@ class TestDuplicateAttach(unittest.TestCase):
         print("************************* Running UE detach")
         # Now detach the UE
         self._s1ap_wrapper._s1_util.detach(
-            req.ue_id, s1ap_types.ueDetachType_t.UE_NORMAL_DETACH.value
+            req.ue_id, s1ap_types.ueDetachType_t.UE_NORMAL_DETACH.value,
         )
 
 

--- a/lte/gateway/python/integ_tests/s1aptests/test_enb_partial_reset.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_enb_partial_reset.py
@@ -11,8 +11,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-import unittest
 import time
+import unittest
 from builtins import range
 
 import s1ap_types
@@ -79,7 +79,7 @@ class TestEnbPartialReset(unittest.TestCase):
                 reset_req.r.partialRst.ueS1apIdPairList[indx].ueId,
             )
         self._s1ap_wrapper.s1_util.issue_cmd(
-            s1ap_types.tfwCmd.RESET_REQ, reset_req
+            s1ap_types.tfwCmd.RESET_REQ, reset_req,
         )
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(response.msg_type, s1ap_types.tfwCmd.RESET_ACK.value)
@@ -91,7 +91,7 @@ class TestEnbPartialReset(unittest.TestCase):
         for ue in ue_ids:
             print("************************* Calling detach for UE id ", ue)
             self._s1ap_wrapper.s1_util.detach(
-                ue, s1ap_types.ueDetachType_t.UE_NORMAL_DETACH.value, True
+                ue, s1ap_types.ueDetachType_t.UE_NORMAL_DETACH.value, True,
             )
 
 

--- a/lte/gateway/python/integ_tests/s1aptests/test_enb_partial_reset_con_dereg.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_enb_partial_reset_con_dereg.py
@@ -11,9 +11,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-import unittest
-import time
 import ctypes
+import time
+import unittest
 from builtins import range
 
 import s1ap_types
@@ -57,11 +57,11 @@ class TestEnbPartialReset(unittest.TestCase):
             print("********Triggering Attach Request with PND Type IPv4 test")
 
             self._s1ap_wrapper._s1_util.issue_cmd(
-                s1ap_types.tfwCmd.UE_ATTACH_REQUEST, attach_req
+                s1ap_types.tfwCmd.UE_ATTACH_REQUEST, attach_req,
             )
             response = self._s1ap_wrapper.s1_util.get_response()
             self.assertEqual(
-                response.msg_type, s1ap_types.tfwCmd.UE_AUTH_REQ_IND.value
+                response.msg_type, s1ap_types.tfwCmd.UE_AUTH_REQ_IND.value,
             )
 
             # Trigger Authentication Response
@@ -71,30 +71,30 @@ class TestEnbPartialReset(unittest.TestCase):
             sqnRecvd.pres = 0
             auth_res.sqnRcvd = sqnRecvd
             self._s1ap_wrapper._s1_util.issue_cmd(
-                s1ap_types.tfwCmd.UE_AUTH_RESP, auth_res
+                s1ap_types.tfwCmd.UE_AUTH_RESP, auth_res,
             )
             response = self._s1ap_wrapper.s1_util.get_response()
             self.assertEqual(
-                response.msg_type, s1ap_types.tfwCmd.UE_SEC_MOD_CMD_IND.value
+                response.msg_type, s1ap_types.tfwCmd.UE_SEC_MOD_CMD_IND.value,
             )
 
             # Trigger Security Mode Complete
             sec_mode_complete = s1ap_types.ueSecModeComplete_t()
             sec_mode_complete.ue_Id = req.ue_id
             self._s1ap_wrapper._s1_util.issue_cmd(
-                s1ap_types.tfwCmd.UE_SEC_MOD_COMPLETE, sec_mode_complete
+                s1ap_types.tfwCmd.UE_SEC_MOD_COMPLETE, sec_mode_complete,
             )
 
             response = self._s1ap_wrapper.s1_util.get_response()
             self.assertEqual(
-                response.msg_type, s1ap_types.tfwCmd.INT_CTX_SETUP_IND.value
+                response.msg_type, s1ap_types.tfwCmd.INT_CTX_SETUP_IND.value,
             )
 
             response = self._s1ap_wrapper.s1_util.get_response()
             print("response message type for ATTTACH ACC", response.msg_type)
             print("acc", s1ap_types.tfwCmd.UE_ATTACH_ACCEPT_IND.value)
             self.assertEqual(
-                response.msg_type, s1ap_types.tfwCmd.UE_ATTACH_ACCEPT_IND.value
+                response.msg_type, s1ap_types.tfwCmd.UE_ATTACH_ACCEPT_IND.value,
             )
             ue_ids.append(req.ue_id)
 
@@ -114,7 +114,7 @@ class TestEnbPartialReset(unittest.TestCase):
         reset_req.r = s1ap_types.R()
         reset_req.r.partialRst = s1ap_types.PartialReset()
         reset_req.r.partialRst.numOfConn = num_ues
-        reset_req.r.partialRst.ueS1apIdPairList  = (
+        reset_req.r.partialRst.ueS1apIdPairList = (
             (s1ap_types.UeS1apIdPair) * reset_req.r.partialRst.numOfConn
         )()
         for indx in range(reset_req.r.partialRst.numOfConn):
@@ -126,7 +126,7 @@ class TestEnbPartialReset(unittest.TestCase):
             )
         print("ue_ids", ue_ids)
         self._s1ap_wrapper.s1_util.issue_cmd(
-            s1ap_types.tfwCmd.RESET_REQ, reset_req
+            s1ap_types.tfwCmd.RESET_REQ, reset_req,
         )
         response1 = self._s1ap_wrapper.s1_util.get_response()
         print("response1 message type", response1.msg_type)

--- a/lte/gateway/python/integ_tests/s1aptests/test_enb_partial_reset_multi_ue.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_enb_partial_reset_multi_ue.py
@@ -11,10 +11,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-import unittest
-import time
-from builtins import range
 import random
+import time
+import unittest
+from builtins import range
 
 import s1ap_types
 import s1ap_wrapper
@@ -94,7 +94,7 @@ class TestEnbPartialResetMultiUe(unittest.TestCase):
 
         # Send eNB Partial Reset
         self._s1ap_wrapper.s1_util.issue_cmd(
-            s1ap_types.tfwCmd.RESET_REQ, reset_req
+            s1ap_types.tfwCmd.RESET_REQ, reset_req,
         )
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(response.msg_type, s1ap_types.tfwCmd.RESET_ACK.value)
@@ -106,7 +106,7 @@ class TestEnbPartialResetMultiUe(unittest.TestCase):
         for ue in ue_ids:
             print("************************* Calling detach for UE id ", ue)
             self._s1ap_wrapper.s1_util.detach(
-                ue, s1ap_types.ueDetachType_t.UE_NORMAL_DETACH.value, True
+                ue, s1ap_types.ueDetachType_t.UE_NORMAL_DETACH.value, True,
             )
 
 

--- a/lte/gateway/python/integ_tests/s1aptests/test_enb_partial_reset_multi_ue_with_mme_restart.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_enb_partial_reset_multi_ue_with_mme_restart.py
@@ -11,10 +11,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-import unittest
-import time
-from builtins import range
 import random
+import time
+import unittest
+from builtins import range
 
 import s1ap_types
 import s1ap_wrapper
@@ -24,7 +24,7 @@ from s1ap_utils import MagmadUtil
 class TestEnbPartialResetMultiUeWithMmeRestart(unittest.TestCase):
     def setUp(self):
         self._s1ap_wrapper = s1ap_wrapper.TestWrapper(
-            stateless_mode=MagmadUtil.stateless_cmds.ENABLE
+            stateless_mode=MagmadUtil.stateless_cmds.ENABLE,
         )
 
     def tearDown(self):
@@ -99,7 +99,7 @@ class TestEnbPartialResetMultiUeWithMmeRestart(unittest.TestCase):
 
         # Send eNB Partial Reset
         self._s1ap_wrapper.s1_util.issue_cmd(
-            s1ap_types.tfwCmd.RESET_REQ, reset_req
+            s1ap_types.tfwCmd.RESET_REQ, reset_req,
         )
 
         print("************************* Restarting MME service on gateway")
@@ -124,18 +124,18 @@ class TestEnbPartialResetMultiUeWithMmeRestart(unittest.TestCase):
             req.ueMtmsi.pres = False
             req.rrcCause = s1ap_types.Rrc_Cause.TFW_MO_DATA.value
             self._s1ap_wrapper.s1_util.issue_cmd(
-                s1ap_types.tfwCmd.UE_SERVICE_REQUEST, req
+                s1ap_types.tfwCmd.UE_SERVICE_REQUEST, req,
             )
             response = self._s1ap_wrapper.s1_util.get_response()
             self.assertEqual(
-                response.msg_type, s1ap_types.tfwCmd.INT_CTX_SETUP_IND.value
+                response.msg_type, s1ap_types.tfwCmd.INT_CTX_SETUP_IND.value,
             )
 
         # Trigger detach request
         for ue in ue_ids:
             print("************************* Calling detach for UE id ", ue)
             self._s1ap_wrapper.s1_util.detach(
-                ue, s1ap_types.ueDetachType_t.UE_NORMAL_DETACH.value, True
+                ue, s1ap_types.ueDetachType_t.UE_NORMAL_DETACH.value, True,
             )
 
 

--- a/lte/gateway/python/integ_tests/s1aptests/test_gateway_metrics_attach_detach.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_gateway_metrics_attach_detach.py
@@ -27,7 +27,8 @@ class TestGatewayMetricsAttachDetach(unittest.TestCase):
         self._gateway_service = self._s1ap_wrapper.get_gateway_services_util()
         v_mme_new_association = self._getMetricValueGivenLabel(
             str(metricsd.mme_new_association),
-            label_values)
+            label_values,
+        )
         assert(v_mme_new_association > 0)
 
     def tearDown(self):
@@ -38,13 +39,16 @@ class TestGatewayMetricsAttachDetach(unittest.TestCase):
         return service.get_metric_value(
             metric_name,
             label_values,
-            default=0)
+            default=0,
+        )
 
     def test_gateway_metrics_attach_detach(self):
         """ Basic gateway metrics with attach/detach for a single UE """
         num_ues = 2
-        detach_type = [s1ap_types.ueDetachType_t.UE_NORMAL_DETACH.value,
-                       s1ap_types.ueDetachType_t.UE_SWITCHOFF_DETACH.value]
+        detach_type = [
+            s1ap_types.ueDetachType_t.UE_NORMAL_DETACH.value,
+            s1ap_types.ueDetachType_t.UE_SWITCHOFF_DETACH.value,
+        ]
         wait_for_s1 = [True, False]
         self._s1ap_wrapper.configUEDevice(num_ues)
 
@@ -56,25 +60,32 @@ class TestGatewayMetricsAttachDetach(unittest.TestCase):
         for i in range(num_ues):
             v_ue_attach = self._getMetricValueGivenLabel(
                 str(metricsd.ue_attach),
-                label_values_ue_attach_result)
+                label_values_ue_attach_result,
+            )
             v_ue_detach = self._getMetricValueGivenLabel(
                 str(metricsd.ue_detach),
-                label_values_ue_detach_result)
+                label_values_ue_detach_result,
+            )
             v_spgw_create_session = self._getMetricValueGivenLabel(
                 str(metricsd.spgw_create_session),
-                label_values_session_result)
+                label_values_session_result,
+            )
             v_spgw_delete_session = self._getMetricValueGivenLabel(
                 str(metricsd.spgw_delete_session),
-                label_values_session_result)
+                label_values_session_result,
+            )
 
             req = self._s1ap_wrapper.ue_req
-            print("************************* Running End to End attach for ",
-                  "UE id ", req.ue_id)
+            print(
+                "************************* Running End to End attach for ",
+                "UE id ", req.ue_id,
+            )
             # Now actually complete the attach
             self._s1ap_wrapper._s1_util.attach(
                 req.ue_id, s1ap_types.tfwCmd.UE_END_TO_END_ATTACH_REQUEST,
                 s1ap_types.tfwCmd.UE_ATTACH_ACCEPT_IND,
-                s1ap_types.ueAttachAccept_t)
+                s1ap_types.ueAttachAccept_t,
+            )
 
             # Wait on EMM Information from MME
             self._s1ap_wrapper._s1_util.receive_emm_info()
@@ -83,40 +94,49 @@ class TestGatewayMetricsAttachDetach(unittest.TestCase):
             time.sleep(0.5)
             val = self._getMetricValueGivenLabel(
                 str(metricsd.ue_attach),
-                label_values_ue_attach_result)
+                label_values_ue_attach_result,
+            )
             assert(val == v_ue_attach + 1)
 
             val = self._getMetricValueGivenLabel(
                 str(metricsd.spgw_create_session),
-                label_values_session_result)
+                label_values_session_result,
+            )
             assert(val == v_spgw_create_session + 1)
 
             val = self._getMetricValueGivenLabel(
                 str(metricsd.ue_detach),
-                label_values_ue_detach_result)
+                label_values_ue_detach_result,
+            )
             assert (val == v_ue_detach)
 
             val = self._getMetricValueGivenLabel(
                 str(metricsd.spgw_delete_session),
-                label_values_session_result)
+                label_values_session_result,
+            )
             assert (val == v_spgw_delete_session)
 
-            print("************************* Running UE detach for UE id ",
-                  req.ue_id)
+            print(
+                "************************* Running UE detach for UE id ",
+                req.ue_id,
+            )
             # Now detach the UE
             self._s1ap_wrapper.s1_util.detach(
-                req.ue_id, detach_type[i], wait_for_s1[i])
+                req.ue_id, detach_type[i], wait_for_s1[i],
+            )
 
             # waits so that metrics have time to be updated
             time.sleep(0.5)
             val = self._getMetricValueGivenLabel(
                 str(metricsd.ue_detach),
-                label_values_ue_detach_result)
+                label_values_ue_detach_result,
+            )
             assert(val == v_ue_detach + 1)
 
             val = self._getMetricValueGivenLabel(
                 str(metricsd.spgw_delete_session),
-                label_values_session_result)
+                label_values_session_result,
+            )
             assert (val == v_spgw_delete_session + 1)
 
 

--- a/lte/gateway/python/integ_tests/s1aptests/test_ics_timer_expiry_ue_registered.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_ics_timer_expiry_ue_registered.py
@@ -11,8 +11,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-import unittest
 import time
+import unittest
 
 import gpp_types
 import s1ap_types
@@ -64,11 +64,11 @@ class TestIcsTimerExpiryUeRegistered(unittest.TestCase):
         req.ue_Id = ue_id
         req.cause.causeVal = gpp_types.CauseRadioNetwork.USER_INACTIVITY.value
         self._s1ap_wrapper.s1_util.issue_cmd(
-            s1ap_types.tfwCmd.UE_CNTXT_REL_REQUEST, req
+            s1ap_types.tfwCmd.UE_CNTXT_REL_REQUEST, req,
         )
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_CTX_REL_IND.value
+            response.msg_type, s1ap_types.tfwCmd.UE_CTX_REL_IND.value,
         )
 
         print("*** Sending indication to drop Initial Context Setup Req ***")
@@ -78,7 +78,7 @@ class TestIcsTimerExpiryUeRegistered(unittest.TestCase):
         # Timer to release UE context at s1ap tester
         drop_init_ctxt_setup_req.tmrVal = 2000
         self._s1ap_wrapper._s1_util.issue_cmd(
-            s1ap_types.tfwCmd.UE_SET_DROP_ICS, drop_init_ctxt_setup_req
+            s1ap_types.tfwCmd.UE_SET_DROP_ICS, drop_init_ctxt_setup_req,
         )
 
         print("**** Sleeping for 5 seconds *****")
@@ -94,19 +94,19 @@ class TestIcsTimerExpiryUeRegistered(unittest.TestCase):
         req.ueMtmsi.pres = False
         req.rrcCause = s1ap_types.Rrc_Cause.TFW_MO_DATA.value
         self._s1ap_wrapper.s1_util.issue_cmd(
-            s1ap_types.tfwCmd.UE_SERVICE_REQUEST, req
+            s1ap_types.tfwCmd.UE_SERVICE_REQUEST, req,
         )
 
         # enbApp sends UE_ICS_DROPD_IND message to tfwApp after dropping
         # ICS request
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_ICS_DROPD_IND.value
+            response.msg_type, s1ap_types.tfwCmd.UE_ICS_DROPD_IND.value,
         )
 
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_CTX_REL_IND.value
+            response.msg_type, s1ap_types.tfwCmd.UE_CTX_REL_IND.value,
         )
 
         print(
@@ -116,7 +116,7 @@ class TestIcsTimerExpiryUeRegistered(unittest.TestCase):
         print("************************* Running UE detach for UE id ", ue_id)
         # Now detach the UE
         self._s1ap_wrapper.s1_util.detach(
-            ue_id, s1ap_types.ueDetachType_t.UE_SWITCHOFF_DETACH.value, False
+            ue_id, s1ap_types.ueDetachType_t.UE_SWITCHOFF_DETACH.value, False,
         )
 
 

--- a/lte/gateway/python/integ_tests/s1aptests/test_ics_timer_expiry_ue_unregistered.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_ics_timer_expiry_ue_unregistered.py
@@ -49,11 +49,11 @@ class TestIcsTimerExpiryUeUnregistered(unittest.TestCase):
         attach_req.pdnType_pr = pdn_type
 
         self._s1ap_wrapper._s1_util.issue_cmd(
-            s1ap_types.tfwCmd.UE_ATTACH_REQUEST, attach_req
+            s1ap_types.tfwCmd.UE_ATTACH_REQUEST, attach_req,
         )
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_AUTH_REQ_IND.value
+            response.msg_type, s1ap_types.tfwCmd.UE_AUTH_REQ_IND.value,
         )
 
         print("*** Sending indication to drop Initial Context Setup Req ***")
@@ -63,7 +63,7 @@ class TestIcsTimerExpiryUeUnregistered(unittest.TestCase):
         # Timer to release UE context at s1ap tester
         drop_init_ctxt_setup_req.tmrVal = 2000
         self._s1ap_wrapper._s1_util.issue_cmd(
-            s1ap_types.tfwCmd.UE_SET_DROP_ICS, drop_init_ctxt_setup_req
+            s1ap_types.tfwCmd.UE_SET_DROP_ICS, drop_init_ctxt_setup_req,
         )
 
         # Trigger Authentication Response
@@ -73,30 +73,30 @@ class TestIcsTimerExpiryUeUnregistered(unittest.TestCase):
         sqnRecvd.pres = 0
         auth_res.sqnRcvd = sqnRecvd
         self._s1ap_wrapper._s1_util.issue_cmd(
-            s1ap_types.tfwCmd.UE_AUTH_RESP, auth_res
+            s1ap_types.tfwCmd.UE_AUTH_RESP, auth_res,
         )
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_SEC_MOD_CMD_IND.value
+            response.msg_type, s1ap_types.tfwCmd.UE_SEC_MOD_CMD_IND.value,
         )
 
         # Trigger Security Mode Complete
         sec_mode_complete = s1ap_types.ueSecModeComplete_t()
         sec_mode_complete.ue_Id = req.ue_id
         self._s1ap_wrapper._s1_util.issue_cmd(
-            s1ap_types.tfwCmd.UE_SEC_MOD_COMPLETE, sec_mode_complete
+            s1ap_types.tfwCmd.UE_SEC_MOD_COMPLETE, sec_mode_complete,
         )
 
         # enbApp sends UE_ICS_DROPD_IND message to tfwApp after dropping
         # ICS request
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_ICS_DROPD_IND.value
+            response.msg_type, s1ap_types.tfwCmd.UE_ICS_DROPD_IND.value,
         )
 
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_CTX_REL_IND.value
+            response.msg_type, s1ap_types.tfwCmd.UE_CTX_REL_IND.value,
         )
         print(
             "************************* Received UE_CTX_REL_IND for UE id ",

--- a/lte/gateway/python/integ_tests/s1aptests/test_ics_timer_expiry_with_mme_restart.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_ics_timer_expiry_with_mme_restart.py
@@ -11,8 +11,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-import unittest
 import time
+import unittest
 
 import gpp_types
 import s1ap_types
@@ -23,7 +23,7 @@ from s1ap_utils import MagmadUtil
 class TestIcsTimerExpiryWithMmeRestart(unittest.TestCase):
     def setUp(self):
         self._s1ap_wrapper = s1ap_wrapper.TestWrapper(
-            stateless_mode=MagmadUtil.stateless_cmds.ENABLE
+            stateless_mode=MagmadUtil.stateless_cmds.ENABLE,
         )
 
     def tearDown(self):
@@ -71,11 +71,11 @@ class TestIcsTimerExpiryWithMmeRestart(unittest.TestCase):
         req.ue_Id = ue_id
         req.cause.causeVal = gpp_types.CauseRadioNetwork.USER_INACTIVITY.value
         self._s1ap_wrapper.s1_util.issue_cmd(
-            s1ap_types.tfwCmd.UE_CNTXT_REL_REQUEST, req
+            s1ap_types.tfwCmd.UE_CNTXT_REL_REQUEST, req,
         )
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_CTX_REL_IND.value
+            response.msg_type, s1ap_types.tfwCmd.UE_CTX_REL_IND.value,
         )
 
         print("*** Sending indication to drop Initial Context Setup Req ***")
@@ -85,7 +85,7 @@ class TestIcsTimerExpiryWithMmeRestart(unittest.TestCase):
         # Timer to release UE context at s1ap tester
         drop_init_ctxt_setup_req.tmrVal = 2000
         self._s1ap_wrapper._s1_util.issue_cmd(
-            s1ap_types.tfwCmd.UE_SET_DROP_ICS, drop_init_ctxt_setup_req
+            s1ap_types.tfwCmd.UE_SET_DROP_ICS, drop_init_ctxt_setup_req,
         )
 
         print(
@@ -99,14 +99,14 @@ class TestIcsTimerExpiryWithMmeRestart(unittest.TestCase):
         req.ueMtmsi.pres = False
         req.rrcCause = s1ap_types.Rrc_Cause.TFW_MO_DATA.value
         self._s1ap_wrapper.s1_util.issue_cmd(
-            s1ap_types.tfwCmd.UE_SERVICE_REQUEST, req
+            s1ap_types.tfwCmd.UE_SERVICE_REQUEST, req,
         )
 
         # enbApp sends UE_ICS_DROPD_IND message to tfwApp after dropping
         # ICS request
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_ICS_DROPD_IND.value
+            response.msg_type, s1ap_types.tfwCmd.UE_ICS_DROPD_IND.value,
         )
         print("************************* Restarting MME service on gateway")
         self._s1ap_wrapper.magmad_util.restart_services(["mme"])
@@ -117,7 +117,7 @@ class TestIcsTimerExpiryWithMmeRestart(unittest.TestCase):
 
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_CTX_REL_IND.value
+            response.msg_type, s1ap_types.tfwCmd.UE_CTX_REL_IND.value,
         )
 
         print(
@@ -127,7 +127,7 @@ class TestIcsTimerExpiryWithMmeRestart(unittest.TestCase):
         print("************************* Running UE detach for UE id ", ue_id)
         # Now detach the UE
         self._s1ap_wrapper.s1_util.detach(
-            ue_id, s1ap_types.ueDetachType_t.UE_SWITCHOFF_DETACH.value, False
+            ue_id, s1ap_types.ueDetachType_t.UE_SWITCHOFF_DETACH.value, False,
         )
 
 

--- a/lte/gateway/python/integ_tests/s1aptests/test_idle_mode_with_mme_restart.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_idle_mode_with_mme_restart.py
@@ -11,8 +11,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-import unittest
 import time
+import unittest
 
 import gpp_types
 import s1ap_types
@@ -23,7 +23,7 @@ from s1ap_utils import MagmadUtil
 class TestIdleModeWithMmeRestart(unittest.TestCase):
     def setUp(self):
         self._s1ap_wrapper = s1ap_wrapper.TestWrapper(
-            stateless_mode=MagmadUtil.stateless_cmds.ENABLE
+            stateless_mode=MagmadUtil.stateless_cmds.ENABLE,
         )
 
     def tearDown(self):
@@ -72,11 +72,11 @@ class TestIdleModeWithMmeRestart(unittest.TestCase):
         req.ue_Id = ue_id
         req.cause.causeVal = gpp_types.CauseRadioNetwork.USER_INACTIVITY.value
         self._s1ap_wrapper.s1_util.issue_cmd(
-            s1ap_types.tfwCmd.UE_CNTXT_REL_REQUEST, req
+            s1ap_types.tfwCmd.UE_CNTXT_REL_REQUEST, req,
         )
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_CTX_REL_IND.value
+            response.msg_type, s1ap_types.tfwCmd.UE_CTX_REL_IND.value,
         )
 
         print("************************* Restarting MME service on gateway")
@@ -97,17 +97,17 @@ class TestIdleModeWithMmeRestart(unittest.TestCase):
         req.ueMtmsi.pres = False
         req.rrcCause = s1ap_types.Rrc_Cause.TFW_MO_DATA.value
         self._s1ap_wrapper.s1_util.issue_cmd(
-            s1ap_types.tfwCmd.UE_SERVICE_REQUEST, req
+            s1ap_types.tfwCmd.UE_SERVICE_REQUEST, req,
         )
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.INT_CTX_SETUP_IND.value
+            response.msg_type, s1ap_types.tfwCmd.INT_CTX_SETUP_IND.value,
         )
 
         print("************************* Running UE detach for UE id ", ue_id)
         # Now detach the UE
         self._s1ap_wrapper.s1_util.detach(
-            ue_id, s1ap_types.ueDetachType_t.UE_SWITCHOFF_DETACH.value, True
+            ue_id, s1ap_types.ueDetachType_t.UE_SWITCHOFF_DETACH.value, True,
         )
 
 

--- a/lte/gateway/python/integ_tests/s1aptests/test_imei_restriction_no_imeisv_in_smc.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_imei_restriction_no_imeisv_in_smc.py
@@ -12,12 +12,12 @@ limitations under the License.
 """
 
 
+import ctypes
+import time
 import unittest
 
 import s1ap_types
 import s1ap_wrapper
-import time
-import ctypes
 
 
 class TestImeiRestrictionNoImeisvInSmc(unittest.TestCase):
@@ -71,7 +71,7 @@ class TestImeiRestrictionNoImeisvInSmc(unittest.TestCase):
         attach_req.pdnType_pr = pdn_type
 
         self._s1ap_wrapper._s1_util.issue_cmd(
-            s1ap_types.tfwCmd.UE_ATTACH_REQUEST, attach_req
+            s1ap_types.tfwCmd.UE_ATTACH_REQUEST, attach_req,
         )
         print(
             "********************** Sent attach req for UE id ", ue_ids[0],
@@ -79,7 +79,7 @@ class TestImeiRestrictionNoImeisvInSmc(unittest.TestCase):
 
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_AUTH_REQ_IND.value
+            response.msg_type, s1ap_types.tfwCmd.UE_AUTH_REQ_IND.value,
         )
         auth_req = response.cast(s1ap_types.ueAuthReqInd_t)
         print(
@@ -94,13 +94,13 @@ class TestImeiRestrictionNoImeisvInSmc(unittest.TestCase):
         sqnRecvd.pres = 0
         auth_res.sqnRcvd = sqnRecvd
         self._s1ap_wrapper._s1_util.issue_cmd(
-            s1ap_types.tfwCmd.UE_AUTH_RESP, auth_res
+            s1ap_types.tfwCmd.UE_AUTH_RESP, auth_res,
         )
         print("********************** Sent auth rsp for UE id", ue_ids[0])
 
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_SEC_MOD_CMD_IND.value
+            response.msg_type, s1ap_types.tfwCmd.UE_SEC_MOD_CMD_IND.value,
         )
         sec_mod_cmd = response.cast(s1ap_types.ueSecModeCmdInd_t)
         print(
@@ -114,7 +114,7 @@ class TestImeiRestrictionNoImeisvInSmc(unittest.TestCase):
         # Do not include imeisv
         sec_mode_complete.noImeisv = True
         self._s1ap_wrapper._s1_util.issue_cmd(
-            s1ap_types.tfwCmd.UE_SEC_MOD_COMPLETE, sec_mode_complete
+            s1ap_types.tfwCmd.UE_SEC_MOD_COMPLETE, sec_mode_complete,
         )
         print(
             "********************** Sent security mode complete for UE id",
@@ -123,7 +123,7 @@ class TestImeiRestrictionNoImeisvInSmc(unittest.TestCase):
 
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_IDENTITY_REQ_IND.value
+            response.msg_type, s1ap_types.tfwCmd.UE_IDENTITY_REQ_IND.value,
         )
         id_req = response.cast(s1ap_types.ueIdentityReqInd_t)
         print(
@@ -143,30 +143,30 @@ class TestImeiRestrictionNoImeisvInSmc(unittest.TestCase):
         for i in range(0, len(imeisv)):
             identity_resp.idVal[i] = ctypes.c_ubyte(int(imeisv[i]))
         self._s1ap_wrapper._s1_util.issue_cmd(
-            s1ap_types.tfwCmd.UE_IDENTITY_RESP, identity_resp
+            s1ap_types.tfwCmd.UE_IDENTITY_RESP, identity_resp,
         )
         print("********************** Sent identity rsp for UE id", ue_ids[0])
 
         # Receive Attach Reject
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_ATTACH_REJECT_IND.value
+            response.msg_type, s1ap_types.tfwCmd.UE_ATTACH_REJECT_IND.value,
         )
         attach_rej = response.cast(s1ap_types.ueAttachRejInd_t)
         print(
             "********************** Received attach reject for UE id %d"
-            " with emm cause %d" % (ue_ids[0], attach_rej.cause)
+            " with emm cause %d" % (ue_ids[0], attach_rej.cause),
         )
 
         # Verify cause
         self.assertEqual(
-            attach_rej.cause, s1ap_types.TFW_EMM_CAUSE_IMEI_NOT_ACCEPTED
+            attach_rej.cause, s1ap_types.TFW_EMM_CAUSE_IMEI_NOT_ACCEPTED,
         )
 
         # UE Context release
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_CTX_REL_IND.value
+            response.msg_type, s1ap_types.tfwCmd.UE_CTX_REL_IND.value,
         )
         ue_context_rel = response.cast(s1ap_types.ueCntxtRelReq_t)
         print(
@@ -189,7 +189,7 @@ class TestImeiRestrictionNoImeisvInSmc(unittest.TestCase):
         attach_req.pdnType_pr = pdn_type
 
         self._s1ap_wrapper._s1_util.issue_cmd(
-            s1ap_types.tfwCmd.UE_ATTACH_REQUEST, attach_req
+            s1ap_types.tfwCmd.UE_ATTACH_REQUEST, attach_req,
         )
         print(
             "********************** Sent attach req for UE id ", ue_ids[1],
@@ -197,7 +197,7 @@ class TestImeiRestrictionNoImeisvInSmc(unittest.TestCase):
 
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_AUTH_REQ_IND.value
+            response.msg_type, s1ap_types.tfwCmd.UE_AUTH_REQ_IND.value,
         )
         auth_req = response.cast(s1ap_types.ueAuthReqInd_t)
         print(
@@ -211,13 +211,13 @@ class TestImeiRestrictionNoImeisvInSmc(unittest.TestCase):
         sqnRecvd.pres = 0
         auth_res.sqnRcvd = sqnRecvd
         self._s1ap_wrapper._s1_util.issue_cmd(
-            s1ap_types.tfwCmd.UE_AUTH_RESP, auth_res
+            s1ap_types.tfwCmd.UE_AUTH_RESP, auth_res,
         )
         print("********************** Sent auth rsp for UE id", ue_ids[1])
 
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_SEC_MOD_CMD_IND.value
+            response.msg_type, s1ap_types.tfwCmd.UE_SEC_MOD_CMD_IND.value,
         )
         sec_mod_cmd = response.cast(s1ap_types.ueSecModeCmdInd_t)
         print(
@@ -231,7 +231,7 @@ class TestImeiRestrictionNoImeisvInSmc(unittest.TestCase):
         # Do not include imeisv
         sec_mode_complete.noImeisv = True
         self._s1ap_wrapper._s1_util.issue_cmd(
-            s1ap_types.tfwCmd.UE_SEC_MOD_COMPLETE, sec_mode_complete
+            s1ap_types.tfwCmd.UE_SEC_MOD_COMPLETE, sec_mode_complete,
         )
         print(
             "********************** Sent security mode complete for UE id",
@@ -240,7 +240,7 @@ class TestImeiRestrictionNoImeisvInSmc(unittest.TestCase):
 
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_IDENTITY_REQ_IND.value
+            response.msg_type, s1ap_types.tfwCmd.UE_IDENTITY_REQ_IND.value,
         )
         id_req = response.cast(s1ap_types.ueIdentityReqInd_t)
         print(
@@ -253,18 +253,18 @@ class TestImeiRestrictionNoImeisvInSmc(unittest.TestCase):
         identity_resp.ue_Id = id_req.ue_Id
         identity_resp.idType = id_req.idType
         self._s1ap_wrapper._s1_util.issue_cmd(
-            s1ap_types.tfwCmd.UE_IDENTITY_RESP, identity_resp
+            s1ap_types.tfwCmd.UE_IDENTITY_RESP, identity_resp,
         )
         print("********************** Sent identity rsp for UE id", ue_ids[1])
 
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.INT_CTX_SETUP_IND.value
+            response.msg_type, s1ap_types.tfwCmd.INT_CTX_SETUP_IND.value,
         )
 
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_ATTACH_ACCEPT_IND.value
+            response.msg_type, s1ap_types.tfwCmd.UE_ATTACH_ACCEPT_IND.value,
         )
         attach_acc = response.cast(s1ap_types.ueAttachAccept_t)
         print(
@@ -275,14 +275,14 @@ class TestImeiRestrictionNoImeisvInSmc(unittest.TestCase):
         attach_complete = s1ap_types.ueAttachComplete_t()
         attach_complete.ue_Id = ue_ids[1]
         self._s1ap_wrapper._s1_util.issue_cmd(
-            s1ap_types.tfwCmd.UE_ATTACH_COMPLETE, attach_complete
+            s1ap_types.tfwCmd.UE_ATTACH_COMPLETE, attach_complete,
         )
         print(
             "********************** Sent attach complete for UE id", ue_ids[1],
         )
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_EMM_INFORMATION.value
+            response.msg_type, s1ap_types.tfwCmd.UE_EMM_INFORMATION.value,
         )
 
         print("********************** Sleeping for 0.5 seconds ")
@@ -295,12 +295,12 @@ class TestImeiRestrictionNoImeisvInSmc(unittest.TestCase):
             s1ap_types.ueDetachType_t.UE_SWITCHOFF_DETACH.value
         )
         self._s1ap_wrapper._s1_util.issue_cmd(
-            s1ap_types.tfwCmd.UE_DETACH_REQUEST, detach_req
+            s1ap_types.tfwCmd.UE_DETACH_REQUEST, detach_req,
         )
         # Wait for UE context release command
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_CTX_REL_IND.value
+            response.msg_type, s1ap_types.tfwCmd.UE_CTX_REL_IND.value,
         )
         ue_context_rel = response.cast(s1ap_types.ueCntxtRelReq_t)
         print(

--- a/lte/gateway/python/integ_tests/s1aptests/test_imei_restriction_smc.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_imei_restriction_smc.py
@@ -12,12 +12,12 @@ limitations under the License.
 """
 
 
+import ctypes
+import time
 import unittest
 
 import s1ap_types
 import s1ap_wrapper
-import time
-import ctypes
 
 
 class TestImeiRestrictionSmc(unittest.TestCase):
@@ -67,7 +67,7 @@ class TestImeiRestrictionSmc(unittest.TestCase):
         attach_req.pdnType_pr = pdn_type
 
         self._s1ap_wrapper._s1_util.issue_cmd(
-            s1ap_types.tfwCmd.UE_ATTACH_REQUEST, attach_req
+            s1ap_types.tfwCmd.UE_ATTACH_REQUEST, attach_req,
         )
         print(
             "********************** Sent attach req for UE id ", ue_ids[0],
@@ -75,7 +75,7 @@ class TestImeiRestrictionSmc(unittest.TestCase):
 
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_AUTH_REQ_IND.value
+            response.msg_type, s1ap_types.tfwCmd.UE_AUTH_REQ_IND.value,
         )
         auth_req = response.cast(s1ap_types.ueAuthReqInd_t)
         print(
@@ -90,13 +90,13 @@ class TestImeiRestrictionSmc(unittest.TestCase):
         sqnRecvd.pres = 0
         auth_res.sqnRcvd = sqnRecvd
         self._s1ap_wrapper._s1_util.issue_cmd(
-            s1ap_types.tfwCmd.UE_AUTH_RESP, auth_res
+            s1ap_types.tfwCmd.UE_AUTH_RESP, auth_res,
         )
         print("********************** Sent auth rsp for UE id", ue_ids[0])
 
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_SEC_MOD_CMD_IND.value
+            response.msg_type, s1ap_types.tfwCmd.UE_SEC_MOD_CMD_IND.value,
         )
         sec_mod_cmd = response.cast(s1ap_types.ueSecModeCmdInd_t)
         print(
@@ -114,7 +114,7 @@ class TestImeiRestrictionSmc(unittest.TestCase):
         for i in range(0, len(imeisv)):
             sec_mode_complete.imeisv[i] = ctypes.c_ubyte(int(imeisv[i]))
         self._s1ap_wrapper._s1_util.issue_cmd(
-            s1ap_types.tfwCmd.UE_SEC_MOD_COMPLETE, sec_mode_complete
+            s1ap_types.tfwCmd.UE_SEC_MOD_COMPLETE, sec_mode_complete,
         )
         print(
             "********************** Sent security mode complete for UE id",
@@ -124,23 +124,23 @@ class TestImeiRestrictionSmc(unittest.TestCase):
         # Receive Attach Reject
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_ATTACH_REJECT_IND.value
+            response.msg_type, s1ap_types.tfwCmd.UE_ATTACH_REJECT_IND.value,
         )
         attach_rej = response.cast(s1ap_types.ueAttachRejInd_t)
         print(
             "********************** Received attach reject for UE id %d"
-            " with emm cause %d" % (attach_rej.ue_Id, attach_rej.cause)
+            " with emm cause %d" % (attach_rej.ue_Id, attach_rej.cause),
         )
 
         # Verify cause
         self.assertEqual(
-            attach_rej.cause, s1ap_types.TFW_EMM_CAUSE_IMEI_NOT_ACCEPTED
+            attach_rej.cause, s1ap_types.TFW_EMM_CAUSE_IMEI_NOT_ACCEPTED,
         )
 
         # UE Context release
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_CTX_REL_IND.value
+            response.msg_type, s1ap_types.tfwCmd.UE_CTX_REL_IND.value,
         )
 
         ue_context_rel = response.cast(s1ap_types.ueCntxtRelReq_t)
@@ -169,7 +169,7 @@ class TestImeiRestrictionSmc(unittest.TestCase):
         print("********************** Running UE detach for UE id ", ue_ids[1])
         # Now detach the UE
         self._s1ap_wrapper.s1_util.detach(
-            ue_ids[1], s1ap_types.ueDetachType_t.UE_NORMAL_DETACH.value
+            ue_ids[1], s1ap_types.ueDetachType_t.UE_NORMAL_DETACH.value,
         )
 
 

--- a/lte/gateway/python/integ_tests/s1aptests/test_imei_restriction_wildcard_snr.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_imei_restriction_wildcard_snr.py
@@ -12,11 +12,11 @@ limitations under the License.
 """
 
 
+import ctypes
 import unittest
 
 import s1ap_types
 import s1ap_wrapper
-import ctypes
 
 
 class TestImeiRestrictionWildcardSnr(unittest.TestCase):
@@ -61,7 +61,7 @@ class TestImeiRestrictionWildcardSnr(unittest.TestCase):
         attach_req.pdnType_pr = pdn_type
 
         self._s1ap_wrapper._s1_util.issue_cmd(
-            s1ap_types.tfwCmd.UE_ATTACH_REQUEST, attach_req
+            s1ap_types.tfwCmd.UE_ATTACH_REQUEST, attach_req,
         )
         print(
             "********************** Sent attach req for UE id ", req.ue_id,
@@ -69,7 +69,7 @@ class TestImeiRestrictionWildcardSnr(unittest.TestCase):
 
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_AUTH_REQ_IND.value
+            response.msg_type, s1ap_types.tfwCmd.UE_AUTH_REQ_IND.value,
         )
         auth_req = response.cast(s1ap_types.ueAuthReqInd_t)
         print(
@@ -84,13 +84,13 @@ class TestImeiRestrictionWildcardSnr(unittest.TestCase):
         sqnRecvd.pres = 0
         auth_res.sqnRcvd = sqnRecvd
         self._s1ap_wrapper._s1_util.issue_cmd(
-            s1ap_types.tfwCmd.UE_AUTH_RESP, auth_res
+            s1ap_types.tfwCmd.UE_AUTH_RESP, auth_res,
         )
         print("********************** Sent auth rsp for UE id", req.ue_id)
 
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_SEC_MOD_CMD_IND.value
+            response.msg_type, s1ap_types.tfwCmd.UE_SEC_MOD_CMD_IND.value,
         )
         sec_mod_cmd = response.cast(s1ap_types.ueSecModeCmdInd_t)
         print(
@@ -108,7 +108,7 @@ class TestImeiRestrictionWildcardSnr(unittest.TestCase):
         for i in range(0, len(imeisv)):
             sec_mode_complete.imeisv[i] = ctypes.c_ubyte(int(imeisv[i]))
         self._s1ap_wrapper._s1_util.issue_cmd(
-            s1ap_types.tfwCmd.UE_SEC_MOD_COMPLETE, sec_mode_complete
+            s1ap_types.tfwCmd.UE_SEC_MOD_COMPLETE, sec_mode_complete,
         )
         print(
             "********************** Sent security mode complete for UE id",
@@ -118,23 +118,23 @@ class TestImeiRestrictionWildcardSnr(unittest.TestCase):
         # Receive Attach Reject
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_ATTACH_REJECT_IND.value
+            response.msg_type, s1ap_types.tfwCmd.UE_ATTACH_REJECT_IND.value,
         )
         attach_rej = response.cast(s1ap_types.ueAttachRejInd_t)
         print(
             "********************** Received attach reject for UE id %d"
-            " with emm cause %d" % (attach_rej.ue_Id, attach_rej.cause)
+            " with emm cause %d" % (attach_rej.ue_Id, attach_rej.cause),
         )
 
         # Verify cause
         self.assertEqual(
-            attach_rej.cause, s1ap_types.TFW_EMM_CAUSE_IMEI_NOT_ACCEPTED
+            attach_rej.cause, s1ap_types.TFW_EMM_CAUSE_IMEI_NOT_ACCEPTED,
         )
 
         # UE Context release
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_CTX_REL_IND.value
+            response.msg_type, s1ap_types.tfwCmd.UE_CTX_REL_IND.value,
         )
 
         ue_context_rel = response.cast(s1ap_types.ueCntxtRelReq_t)

--- a/lte/gateway/python/integ_tests/s1aptests/test_implicit_detach_timer_with_mme_restart.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_implicit_detach_timer_with_mme_restart.py
@@ -11,8 +11,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-import unittest
 import time
+import unittest
 
 import gpp_types
 import s1ap_types
@@ -23,7 +23,7 @@ from s1ap_utils import MagmadUtil
 class TestImplicitDetachTimerWithMmeRestart(unittest.TestCase):
     def setUp(self):
         self._s1ap_wrapper = s1ap_wrapper.TestWrapper(
-            stateless_mode=MagmadUtil.stateless_cmds.ENABLE
+            stateless_mode=MagmadUtil.stateless_cmds.ENABLE,
         )
 
     def tearDown(self):
@@ -80,11 +80,11 @@ class TestImplicitDetachTimerWithMmeRestart(unittest.TestCase):
         req.ue_Id = ue_id
         req.cause.causeVal = gpp_types.CauseRadioNetwork.USER_INACTIVITY.value
         self._s1ap_wrapper.s1_util.issue_cmd(
-            s1ap_types.tfwCmd.UE_CNTXT_REL_REQUEST, req
+            s1ap_types.tfwCmd.UE_CNTXT_REL_REQUEST, req,
         )
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_CTX_REL_IND.value
+            response.msg_type, s1ap_types.tfwCmd.UE_CTX_REL_IND.value,
         )
 
         # Delay by 6 minutes to ensure Mobile reachability timer expires.
@@ -92,7 +92,7 @@ class TestImplicitDetachTimerWithMmeRestart(unittest.TestCase):
         # at mme (4 minute)
         print(
             "************************* Waiting for Mobile Reachability Timer"
-            " to expire. Sleeping for 6 minutes"
+            " to expire. Sleeping for 6 minutes",
         )
         timeSlept = 0
         while timeSlept < 360:
@@ -113,7 +113,7 @@ class TestImplicitDetachTimerWithMmeRestart(unittest.TestCase):
         # Implicit detach timer = Mobile reachability timer
         print(
             "************************* Waiting for Implicit Detach Timer"
-            " to expire. Sleeping for 6 minutes.."
+            " to expire. Sleeping for 6 minutes..",
         )
         timeSlept = 0
         while timeSlept < 360:
@@ -132,11 +132,11 @@ class TestImplicitDetachTimerWithMmeRestart(unittest.TestCase):
         req.ueMtmsi.pres = False
         req.rrcCause = s1ap_types.Rrc_Cause.TFW_MO_DATA.value
         self._s1ap_wrapper.s1_util.issue_cmd(
-            s1ap_types.tfwCmd.UE_SERVICE_REQUEST, req
+            s1ap_types.tfwCmd.UE_SERVICE_REQUEST, req,
         )
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_SERVICE_REJECT_IND.value
+            response.msg_type, s1ap_types.tfwCmd.UE_SERVICE_REJECT_IND.value,
         )
 
         print(
@@ -147,7 +147,7 @@ class TestImplicitDetachTimerWithMmeRestart(unittest.TestCase):
         # Wait for UE Context Release command
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_CTX_REL_IND.value
+            response.msg_type, s1ap_types.tfwCmd.UE_CTX_REL_IND.value,
         )
 
 

--- a/lte/gateway/python/integ_tests/s1aptests/test_ipv4v6_secondary_pdn.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_ipv4v6_secondary_pdn.py
@@ -6,12 +6,12 @@ LICENSE file in the root directory of this source tree. An additional grant
 of patent rights can be found in the PATENTS file in the same directory.
 """
 
-import unittest
+import ipaddress
 import time
+import unittest
 
 import s1ap_types
 import s1ap_wrapper
-import ipaddress
 
 
 class TestIPv4v6SecondaryPdn(unittest.TestCase):
@@ -58,7 +58,7 @@ class TestIPv4v6SecondaryPdn(unittest.TestCase):
         apn_list = [ims_apn, internet_apn]
 
         self._s1ap_wrapper.configAPN(
-            "IMSI" + "".join([str(i) for i in req.imsi]), apn_list
+            "IMSI" + "".join([str(i) for i in req.imsi]), apn_list,
         )
         print(
             "*********************** Running End to End attach for UE id ",
@@ -90,12 +90,12 @@ class TestIPv4v6SecondaryPdn(unittest.TestCase):
         for i in range(num_pdns):
             # Send PDN Connectivity Request
             self._s1ap_wrapper.sendPdnConnectivityReq(
-                ue_id, apn[i], pdn_type=pdn_type[i]
+                ue_id, apn[i], pdn_type=pdn_type[i],
             )
             # Receive PDN CONN RSP/Activate default EPS bearer context request
             response = self._s1ap_wrapper.s1_util.get_response()
             self.assertEqual(
-                response.msg_type, s1ap_types.tfwCmd.UE_PDN_CONN_RSP_IND.value
+                response.msg_type, s1ap_types.tfwCmd.UE_PDN_CONN_RSP_IND.value,
             )
             act_def_bearer_req = response.cast(s1ap_types.uePdnConRsp_t)
 
@@ -117,21 +117,21 @@ class TestIPv4v6SecondaryPdn(unittest.TestCase):
                     apn[i],
                     act_def_bearer_req.m.pdnInfo.epsBearerId,
                     pdn_type[i],
-                )
+                ),
             )
 
             # Receive Router Advertisement message
             response = self._s1ap_wrapper.s1_util.get_response()
             self.assertEqual(
-                response.msg_type, s1ap_types.tfwCmd.UE_ROUTER_ADV_IND.value
+                response.msg_type, s1ap_types.tfwCmd.UE_ROUTER_ADV_IND.value,
             )
             routerAdv = response.cast(s1ap_types.ueRouterAdv_t)
             print(
                 "************* Received Router Advertisement for APN-%s"
-                " bearer id-%d" % (apn[i], routerAdv.bearerId)
+                " bearer id-%d" % (apn[i], routerAdv.bearerId),
             )
             ipv6_addr = "".join([chr(i) for i in routerAdv.ipv6Addr]).rstrip(
-                "\x00"
+                "\x00",
             )
             print("********** UE IPv6 address: ", ipv6_addr)
             sec_ip_ipv6 = ipaddress.ip_address(ipv6_addr)
@@ -158,7 +158,7 @@ class TestIPv4v6SecondaryPdn(unittest.TestCase):
 
             # Verify if flow rules are created
             self._s1ap_wrapper.s1_util.verify_flow_rules(
-                num_ul_flows, dl_flow_rules
+                num_ul_flows, dl_flow_rules,
             )
 
         print("***** Sleeping for 5 seconds")
@@ -170,7 +170,7 @@ class TestIPv4v6SecondaryPdn(unittest.TestCase):
         )
         # Now detach the UE
         self._s1ap_wrapper.s1_util.detach(
-            ue_id, s1ap_types.ueDetachType_t.UE_SWITCHOFF_DETACH.value, False
+            ue_id, s1ap_types.ueDetachType_t.UE_SWITCHOFF_DETACH.value, False,
         )
 
 

--- a/lte/gateway/python/integ_tests/s1aptests/test_ipv4v6_secondary_pdn_multi_ue.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_ipv4v6_secondary_pdn_multi_ue.py
@@ -6,12 +6,12 @@ LICENSE file in the root directory of this source tree. An additional grant
 of patent rights can be found in the PATENTS file in the same directory.
 """
 
-import unittest
+import ipaddress
 import time
+import unittest
 
 import s1ap_types
 import s1ap_wrapper
-import ipaddress
 
 
 class TestIPv4v6SecondaryPdnMultiUE(unittest.TestCase):
@@ -50,7 +50,7 @@ class TestIPv4v6SecondaryPdnMultiUE(unittest.TestCase):
             apn_list = [ims_apn]
 
             self._s1ap_wrapper.configAPN(
-                "IMSI" + "".join([str(i) for i in req.imsi]), apn_list
+                "IMSI" + "".join([str(i) for i in req.imsi]), apn_list,
             )
             print(
                 "*********************** Running End to End attach for UE id ",
@@ -85,12 +85,12 @@ class TestIPv4v6SecondaryPdnMultiUE(unittest.TestCase):
             pdn_type = 3
             # Send PDN Connectivity Request
             self._s1ap_wrapper.sendPdnConnectivityReq(
-                ue_id, apn, pdn_type=pdn_type
+                ue_id, apn, pdn_type=pdn_type,
             )
             # Receive PDN CONN RSP/Activate default EPS bearer context request
             response = self._s1ap_wrapper.s1_util.get_response()
             self.assertEqual(
-                response.msg_type, s1ap_types.tfwCmd.UE_PDN_CONN_RSP_IND.value
+                response.msg_type, s1ap_types.tfwCmd.UE_PDN_CONN_RSP_IND.value,
             )
             act_def_bearer_req = response.cast(s1ap_types.uePdnConRsp_t)
 
@@ -104,22 +104,22 @@ class TestIPv4v6SecondaryPdnMultiUE(unittest.TestCase):
             print(
                 "********************** Added default bearer for apn-%s,"
                 " bearer id-%d, pdn type-%d"
-                % (apn, act_def_bearer_req.m.pdnInfo.epsBearerId, pdn_type,)
+                % (apn, act_def_bearer_req.m.pdnInfo.epsBearerId, pdn_type),
             )
 
             # Receive Router Advertisement message
             response = self._s1ap_wrapper.s1_util.get_response()
             self.assertEqual(
-                response.msg_type, s1ap_types.tfwCmd.UE_ROUTER_ADV_IND.value
+                response.msg_type, s1ap_types.tfwCmd.UE_ROUTER_ADV_IND.value,
             )
             routerAdv = response.cast(s1ap_types.ueRouterAdv_t)
             print(
                 "******************* Received Router Advertisement for APN-%s"
-                " and, bearer id-%d" % (apn, routerAdv.bearerId)
+                " and, bearer id-%d" % (apn, routerAdv.bearerId),
             )
 
             ipv6_addr = "".join([chr(i) for i in routerAdv.ipv6Addr]).rstrip(
-                "\x00"
+                "\x00",
             )
             print("******* UE IPv6 address: ", ipv6_addr)
             sec_ip_ipv6.append(ipaddress.ip_address(ipv6_addr))
@@ -139,7 +139,7 @@ class TestIPv4v6SecondaryPdnMultiUE(unittest.TestCase):
             }
             # Verify if flow rules are created
             self._s1ap_wrapper.s1_util.verify_flow_rules(
-                num_ul_flows, dl_flow_rules
+                num_ul_flows, dl_flow_rules,
             )
 
         print("***** Sleeping for 5 seconds")
@@ -152,7 +152,7 @@ class TestIPv4v6SecondaryPdnMultiUE(unittest.TestCase):
             )
             # Now detach the UE
             self._s1ap_wrapper.s1_util.detach(
-                ue, s1ap_types.ueDetachType_t.UE_SWITCHOFF_DETACH.value, False
+                ue, s1ap_types.ueDetachType_t.UE_SWITCHOFF_DETACH.value, False,
             )
 
 

--- a/lte/gateway/python/integ_tests/s1aptests/test_ipv4v6_secondary_pdn_rs_retransmit.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_ipv4v6_secondary_pdn_rs_retransmit.py
@@ -6,12 +6,12 @@ LICENSE file in the root directory of this source tree. An additional grant
 of patent rights can be found in the PATENTS file in the same directory.
 """
 
-import unittest
+import ipaddress
 import time
+import unittest
 
 import s1ap_types
 import s1ap_wrapper
-import ipaddress
 
 
 class TestIPv4v6SecondaryPdnRSRetransmit(unittest.TestCase):
@@ -46,7 +46,7 @@ class TestIPv4v6SecondaryPdnRSRetransmit(unittest.TestCase):
         apn_list = [ims_apn]
 
         self._s1ap_wrapper.configAPN(
-            "IMSI" + "".join([str(i) for i in req.imsi]), apn_list
+            "IMSI" + "".join([str(i) for i in req.imsi]), apn_list,
         )
         print(
             "*********************** Running End to End attach for UE id ",
@@ -75,7 +75,7 @@ class TestIPv4v6SecondaryPdnRSRetransmit(unittest.TestCase):
         drop_ra.ue_Id = req.ue_id
         drop_ra.flag = 1
         self._s1ap_wrapper._s1_util.issue_cmd(
-            s1ap_types.tfwCmd.UE_SET_DROP_ROUTER_ADV, drop_ra
+            s1ap_types.tfwCmd.UE_SET_DROP_ROUTER_ADV, drop_ra,
         )
 
         print("***** Sleeping for 5 seconds")
@@ -85,12 +85,12 @@ class TestIPv4v6SecondaryPdnRSRetransmit(unittest.TestCase):
         pdn_type = 3
         # Send PDN Connectivity Request for ims apn
         self._s1ap_wrapper.sendPdnConnectivityReq(
-            ue_id, apn, pdn_type=pdn_type
+            ue_id, apn, pdn_type=pdn_type,
         )
         # Receive PDN CONN RSP/Activate default EPS bearer context request
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_PDN_CONN_RSP_IND.value
+            response.msg_type, s1ap_types.tfwCmd.UE_PDN_CONN_RSP_IND.value,
         )
         act_def_bearer_req = response.cast(s1ap_types.uePdnConRsp_t)
 
@@ -101,7 +101,7 @@ class TestIPv4v6SecondaryPdnRSRetransmit(unittest.TestCase):
         print(
             "********************** Added default bearer for apn-%s,"
             " bearer id-%d, pdn type-%d"
-            % (apn, act_def_bearer_req.m.pdnInfo.epsBearerId, pdn_type,)
+            % (apn, act_def_bearer_req.m.pdnInfo.epsBearerId, pdn_type),
         )
 
         # Wait for RS retransmissions
@@ -119,7 +119,7 @@ class TestIPv4v6SecondaryPdnRSRetransmit(unittest.TestCase):
 
         # Verify if flow rules are created
         self._s1ap_wrapper.s1_util.verify_flow_rules(
-            num_ul_flows, dl_flow_rules
+            num_ul_flows, dl_flow_rules,
         )
 
         print("***** Sleeping for 5 seconds")
@@ -131,7 +131,7 @@ class TestIPv4v6SecondaryPdnRSRetransmit(unittest.TestCase):
         )
         # Now detach the UE
         self._s1ap_wrapper.s1_util.detach(
-            ue_id, s1ap_types.ueDetachType_t.UE_SWITCHOFF_DETACH.value, False
+            ue_id, s1ap_types.ueDetachType_t.UE_SWITCHOFF_DETACH.value, False,
         )
 
 

--- a/lte/gateway/python/integ_tests/s1aptests/test_ipv4v6_secondary_pdn_with_ded_bearer.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_ipv4v6_secondary_pdn_with_ded_bearer.py
@@ -6,14 +6,14 @@ LICENSE file in the root directory of this source tree. An additional grant
 of patent rights can be found in the PATENTS file in the same directory.
 """
 
-import unittest
+import ipaddress
 import time
+import unittest
 
 import s1ap_types
 import s1ap_wrapper
-import ipaddress
-from lte.protos.policydb_pb2 import FlowMatch
 from integ_tests.s1aptests.s1ap_utils import SessionManagerUtil
+from lte.protos.policydb_pb2 import FlowMatch
 
 
 class TestIPv4v6SecondaryPdnWithDedBearer(unittest.TestCase):
@@ -120,7 +120,7 @@ class TestIPv4v6SecondaryPdnWithDedBearer(unittest.TestCase):
         apn_list = [ims_apn]
 
         self._s1ap_wrapper.configAPN(
-            "IMSI" + "".join([str(i) for i in req.imsi]), apn_list
+            "IMSI" + "".join([str(i) for i in req.imsi]), apn_list,
         )
         print(
             "*********************** Running End to End attach for UE id ",
@@ -149,12 +149,12 @@ class TestIPv4v6SecondaryPdnWithDedBearer(unittest.TestCase):
         pdn_type = 3
         # Send PDN Connectivity Request
         self._s1ap_wrapper.sendPdnConnectivityReq(
-            ue_id, apn, pdn_type=pdn_type
+            ue_id, apn, pdn_type=pdn_type,
         )
         # Receive PDN CONN RSP/Activate default EPS bearer context request
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_PDN_CONN_RSP_IND.value
+            response.msg_type, s1ap_types.tfwCmd.UE_PDN_CONN_RSP_IND.value,
         )
         act_def_bearer_req = response.cast(s1ap_types.uePdnConRsp_t)
 
@@ -177,22 +177,22 @@ class TestIPv4v6SecondaryPdnWithDedBearer(unittest.TestCase):
                 apn,
                 act_def_bearer_req.m.pdnInfo.epsBearerId,
                 pdn_type,
-            )
+            ),
         )
 
         # Receive Router Advertisement message
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_ROUTER_ADV_IND.value
+            response.msg_type, s1ap_types.tfwCmd.UE_ROUTER_ADV_IND.value,
         )
         routerAdv = response.cast(s1ap_types.ueRouterAdv_t)
         print(
             "******************* Received Router Advertisement for APN-%s"
-            " ,bearer id-%d" % (apn, routerAdv.bearerId)
+            " ,bearer id-%d" % (apn, routerAdv.bearerId),
         )
 
         ipv6_addr = "".join([chr(i) for i in routerAdv.ipv6Addr]).rstrip(
-            "\x00"
+            "\x00",
         )
         print("******* UE IPv6 address: ", ipv6_addr)
         sec_ip_ipv6 = ipaddress.ip_address(ipv6_addr)
@@ -214,13 +214,13 @@ class TestIPv4v6SecondaryPdnWithDedBearer(unittest.TestCase):
         )
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_ACT_DED_BER_REQ.value
+            response.msg_type, s1ap_types.tfwCmd.UE_ACT_DED_BER_REQ.value,
         )
         act_ded_ber_req_ims_apn = response.cast(
-            s1ap_types.UeActDedBearCtxtReq_t
+            s1ap_types.UeActDedBearCtxtReq_t,
         )
         self._s1ap_wrapper.sendActDedicatedBearerAccept(
-            req.ue_id, act_ded_ber_req_ims_apn.bearerId
+            req.ue_id, act_ded_ber_req_ims_apn.bearerId,
         )
         print(
             "************* Added dedicated bearer",
@@ -238,7 +238,7 @@ class TestIPv4v6SecondaryPdnWithDedBearer(unittest.TestCase):
         }
         # Verify if flow rules are created
         self._s1ap_wrapper.s1_util.verify_flow_rules(
-            num_ul_flows, dl_flow_rules
+            num_ul_flows, dl_flow_rules,
         )
 
         print("***** Sleeping for 5 seconds")
@@ -250,7 +250,7 @@ class TestIPv4v6SecondaryPdnWithDedBearer(unittest.TestCase):
         )
         # Now detach the UE
         self._s1ap_wrapper.s1_util.detach(
-            ue_id, s1ap_types.ueDetachType_t.UE_SWITCHOFF_DETACH.value, False
+            ue_id, s1ap_types.ueDetachType_t.UE_SWITCHOFF_DETACH.value, False,
         )
 
 

--- a/lte/gateway/python/integ_tests/s1aptests/test_ipv4v6_secondary_pdn_with_ded_bearer_multi_ue.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_ipv4v6_secondary_pdn_with_ded_bearer_multi_ue.py
@@ -6,14 +6,14 @@ LICENSE file in the root directory of this source tree. An additional grant
 of patent rights can be found in the PATENTS file in the same directory.
 """
 
-import unittest
+import ipaddress
 import time
+import unittest
 
 import s1ap_types
 import s1ap_wrapper
-import ipaddress
-from lte.protos.policydb_pb2 import FlowMatch
 from integ_tests.s1aptests.s1ap_utils import SessionManagerUtil
+from lte.protos.policydb_pb2 import FlowMatch
 
 
 class TestIPv4v6SecondaryPdnWithDedBearerMultiUe(unittest.TestCase):
@@ -125,7 +125,7 @@ class TestIPv4v6SecondaryPdnWithDedBearerMultiUe(unittest.TestCase):
 
             apn_list = [ims_apn]
             self._s1ap_wrapper.configAPN(
-                "IMSI" + "".join([str(i) for i in req.imsi]), apn_list
+                "IMSI" + "".join([str(i) for i in req.imsi]), apn_list,
             )
             print(
                 "*********************** Running End to End attach for UE id ",
@@ -160,12 +160,12 @@ class TestIPv4v6SecondaryPdnWithDedBearerMultiUe(unittest.TestCase):
             pdn_type = 3
             # Send PDN Connectivity Request
             self._s1ap_wrapper.sendPdnConnectivityReq(
-                ue_id, apn, pdn_type=pdn_type
+                ue_id, apn, pdn_type=pdn_type,
             )
             # Receive PDN CONN RSP/Activate default EPS bearer context request
             response = self._s1ap_wrapper.s1_util.get_response()
             self.assertEqual(
-                response.msg_type, s1ap_types.tfwCmd.UE_PDN_CONN_RSP_IND.value
+                response.msg_type, s1ap_types.tfwCmd.UE_PDN_CONN_RSP_IND.value,
             )
             act_def_bearer_req = response.cast(s1ap_types.uePdnConRsp_t)
 
@@ -183,22 +183,22 @@ class TestIPv4v6SecondaryPdnWithDedBearerMultiUe(unittest.TestCase):
                     apn,
                     act_def_bearer_req.m.pdnInfo.epsBearerId,
                     pdn_type,
-                )
+                ),
             )
 
             # Receive Router Advertisement message
             response = self._s1ap_wrapper.s1_util.get_response()
             self.assertEqual(
-                response.msg_type, s1ap_types.tfwCmd.UE_ROUTER_ADV_IND.value
+                response.msg_type, s1ap_types.tfwCmd.UE_ROUTER_ADV_IND.value,
             )
             routerAdv = response.cast(s1ap_types.ueRouterAdv_t)
             print(
                 "******************* Received Router Advertisement for APN-%s"
-                " ,bearer id-%d" % (apn, routerAdv.bearerId)
+                " ,bearer id-%d" % (apn, routerAdv.bearerId),
             )
 
             ipv6_addr = "".join([chr(i) for i in routerAdv.ipv6Addr]).rstrip(
-                "\x00"
+                "\x00",
             )
             print("******* UE IPv6 address: ", ipv6_addr)
             sec_ip_ipv6.append(ipaddress.ip_address(ipv6_addr))
@@ -220,13 +220,13 @@ class TestIPv4v6SecondaryPdnWithDedBearerMultiUe(unittest.TestCase):
             )
             response = self._s1ap_wrapper.s1_util.get_response()
             self.assertEqual(
-                response.msg_type, s1ap_types.tfwCmd.UE_ACT_DED_BER_REQ.value
+                response.msg_type, s1ap_types.tfwCmd.UE_ACT_DED_BER_REQ.value,
             )
             act_ded_ber_req_ims_apn = response.cast(
-                s1ap_types.UeActDedBearCtxtReq_t
+                s1ap_types.UeActDedBearCtxtReq_t,
             )
             self._s1ap_wrapper.sendActDedicatedBearerAccept(
-                req.ue_id, act_ded_ber_req_ims_apn.bearerId
+                req.ue_id, act_ded_ber_req_ims_apn.bearerId,
             )
             print(
                 "************* Added dedicated bearer",
@@ -246,7 +246,7 @@ class TestIPv4v6SecondaryPdnWithDedBearerMultiUe(unittest.TestCase):
             }
             # Verify if flow rules are created
             self._s1ap_wrapper.s1_util.verify_flow_rules(
-                num_ul_flows, dl_flow_rules
+                num_ul_flows, dl_flow_rules,
             )
 
         print("***** Sleeping for 5 seconds")
@@ -259,7 +259,7 @@ class TestIPv4v6SecondaryPdnWithDedBearerMultiUe(unittest.TestCase):
             )
             # Now detach the UE
             self._s1ap_wrapper.s1_util.detach(
-                ue, s1ap_types.ueDetachType_t.UE_SWITCHOFF_DETACH.value, False
+                ue, s1ap_types.ueDetachType_t.UE_SWITCHOFF_DETACH.value, False,
             )
 
 

--- a/lte/gateway/python/integ_tests/s1aptests/test_ipv6_secondary_pdn_rs_retransmit.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_ipv6_secondary_pdn_rs_retransmit.py
@@ -6,12 +6,12 @@ LICENSE file in the root directory of this source tree. An additional grant
 of patent rights can be found in the PATENTS file in the same directory.
 """
 
-import unittest
+import ipaddress
 import time
+import unittest
 
 import s1ap_types
 import s1ap_wrapper
-import ipaddress
 
 
 class TestIPv6SecondaryPdnRSRetransmit(unittest.TestCase):
@@ -47,7 +47,7 @@ class TestIPv6SecondaryPdnRSRetransmit(unittest.TestCase):
         apn_list = [ims_apn]
 
         self._s1ap_wrapper.configAPN(
-            "IMSI" + "".join([str(i) for i in req.imsi]), apn_list
+            "IMSI" + "".join([str(i) for i in req.imsi]), apn_list,
         )
         print(
             "*********************** Running End to End attach for UE id ",
@@ -82,19 +82,19 @@ class TestIPv6SecondaryPdnRSRetransmit(unittest.TestCase):
         drop_ra.ue_Id = req.ue_id
         drop_ra.flag = 1
         self._s1ap_wrapper._s1_util.issue_cmd(
-            s1ap_types.tfwCmd.UE_SET_DROP_ROUTER_ADV, drop_ra
+            s1ap_types.tfwCmd.UE_SET_DROP_ROUTER_ADV, drop_ra,
         )
 
         print("***** Sleeping for 5 seconds")
         time.sleep(5)
         # Send PDN Connectivity Request for ims apn
         self._s1ap_wrapper.sendPdnConnectivityReq(
-            ue_id, apn, pdn_type=pdn_type
+            ue_id, apn, pdn_type=pdn_type,
         )
         # Receive PDN CONN RSP/Activate default EPS bearer context request
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_PDN_CONN_RSP_IND.value
+            response.msg_type, s1ap_types.tfwCmd.UE_PDN_CONN_RSP_IND.value,
         )
         act_def_bearer_req = response.cast(s1ap_types.uePdnConRsp_t)
 
@@ -105,22 +105,22 @@ class TestIPv6SecondaryPdnRSRetransmit(unittest.TestCase):
         print(
             "********************** Added default bearer for apn-%s,"
             " bearer id-%d, pdn type-%d"
-            % (apn, act_def_bearer_req.m.pdnInfo.epsBearerId, pdn_type,)
+            % (apn, act_def_bearer_req.m.pdnInfo.epsBearerId, pdn_type),
         )
         # Receive UE_DEACTIVATE_BER_REQ
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_DEACTIVATE_BER_REQ.value
+            response.msg_type, s1ap_types.tfwCmd.UE_DEACTIVATE_BER_REQ.value,
         )
 
         print(
             "******************* Received deactivate eps bearer context"
-            " request"
+            " request",
         )
         # Send DeactDedicatedBearerAccept
         deactv_bearer_req = response.cast(s1ap_types.UeDeActvBearCtxtReq_t)
         self._s1ap_wrapper.sendDeactDedicatedBearerAccept(
-            req.ue_id, deactv_bearer_req.bearerId
+            req.ue_id, deactv_bearer_req.bearerId,
         )
 
         print("***** Sleeping for 5 seconds")
@@ -133,7 +133,7 @@ class TestIPv6SecondaryPdnRSRetransmit(unittest.TestCase):
 
         # Verify if flow rules are created
         self._s1ap_wrapper.s1_util.verify_flow_rules(
-            num_ul_flows, dl_flow_rules
+            num_ul_flows, dl_flow_rules,
         )
 
         print("***** Sleeping for 5 seconds")
@@ -145,7 +145,7 @@ class TestIPv6SecondaryPdnRSRetransmit(unittest.TestCase):
         )
         # Now detach the UE
         self._s1ap_wrapper.s1_util.detach(
-            ue_id, s1ap_types.ueDetachType_t.UE_SWITCHOFF_DETACH.value, False
+            ue_id, s1ap_types.ueDetachType_t.UE_SWITCHOFF_DETACH.value, False,
         )
 
 

--- a/lte/gateway/python/integ_tests/s1aptests/test_ipv6_secondary_pdn_with_ded_bearer.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_ipv6_secondary_pdn_with_ded_bearer.py
@@ -6,14 +6,14 @@ LICENSE file in the root directory of this source tree. An additional grant
 of patent rights can be found in the PATENTS file in the same directory.
 """
 
-import unittest
+import ipaddress
 import time
+import unittest
 
 import s1ap_types
 import s1ap_wrapper
-import ipaddress
-from lte.protos.policydb_pb2 import FlowMatch
 from integ_tests.s1aptests.s1ap_utils import SessionManagerUtil
+from lte.protos.policydb_pb2 import FlowMatch
 
 
 class TestIPv6SecondaryPdnWithDedBearer(unittest.TestCase):
@@ -104,7 +104,7 @@ class TestIPv6SecondaryPdnWithDedBearer(unittest.TestCase):
         apn_list = [ims_apn]
 
         self._s1ap_wrapper.configAPN(
-            "IMSI" + "".join([str(i) for i in req.imsi]), apn_list
+            "IMSI" + "".join([str(i) for i in req.imsi]), apn_list,
         )
         print(
             "*********************** Running End to End attach for UE id ",
@@ -133,12 +133,12 @@ class TestIPv6SecondaryPdnWithDedBearer(unittest.TestCase):
         pdn_type = 2
         # Send PDN Connectivity Request
         self._s1ap_wrapper.sendPdnConnectivityReq(
-            ue_id, apn, pdn_type=pdn_type
+            ue_id, apn, pdn_type=pdn_type,
         )
         # Receive PDN CONN RSP/Activate default EPS bearer context request
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_PDN_CONN_RSP_IND.value
+            response.msg_type, s1ap_types.tfwCmd.UE_PDN_CONN_RSP_IND.value,
         )
         act_def_bearer_req = response.cast(s1ap_types.uePdnConRsp_t)
 
@@ -153,22 +153,22 @@ class TestIPv6SecondaryPdnWithDedBearer(unittest.TestCase):
                 apn,
                 act_def_bearer_req.m.pdnInfo.epsBearerId,
                 pdn_type,
-            )
+            ),
         )
 
         # Receive Router Advertisement message
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_ROUTER_ADV_IND.value
+            response.msg_type, s1ap_types.tfwCmd.UE_ROUTER_ADV_IND.value,
         )
         routerAdv = response.cast(s1ap_types.ueRouterAdv_t)
         print(
             "******************* Received Router Advertisement for APN-%s"
-            " ,bearer id-%d" % (apn, routerAdv.bearerId)
+            " ,bearer id-%d" % (apn, routerAdv.bearerId),
         )
 
         ipv6_addr = "".join([chr(i) for i in routerAdv.ipv6Addr]).rstrip(
-            "\x00"
+            "\x00",
         )
         print("******* UE IPv6 address: ", ipv6_addr)
         sec_ip_ipv6 = ipaddress.ip_address(ipv6_addr)
@@ -190,13 +190,13 @@ class TestIPv6SecondaryPdnWithDedBearer(unittest.TestCase):
         )
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_ACT_DED_BER_REQ.value
+            response.msg_type, s1ap_types.tfwCmd.UE_ACT_DED_BER_REQ.value,
         )
         act_ded_ber_req_ims_apn = response.cast(
-            s1ap_types.UeActDedBearCtxtReq_t
+            s1ap_types.UeActDedBearCtxtReq_t,
         )
         self._s1ap_wrapper.sendActDedicatedBearerAccept(
-            req.ue_id, act_ded_ber_req_ims_apn.bearerId
+            req.ue_id, act_ded_ber_req_ims_apn.bearerId,
         )
         print(
             "************* Added dedicated bearer",
@@ -213,7 +213,7 @@ class TestIPv6SecondaryPdnWithDedBearer(unittest.TestCase):
         }
         # Verify if flow rules are created
         self._s1ap_wrapper.s1_util.verify_flow_rules(
-            num_ul_flows, dl_flow_rules
+            num_ul_flows, dl_flow_rules,
         )
 
         print("***** Sleeping for 5 seconds")
@@ -225,7 +225,7 @@ class TestIPv6SecondaryPdnWithDedBearer(unittest.TestCase):
         )
         # Now detach the UE
         self._s1ap_wrapper.s1_util.detach(
-            ue_id, s1ap_types.ueDetachType_t.UE_SWITCHOFF_DETACH.value, False
+            ue_id, s1ap_types.ueDetachType_t.UE_SWITCHOFF_DETACH.value, False,
         )
 
 

--- a/lte/gateway/python/integ_tests/s1aptests/test_mobile_reachability_timer_with_mme_restart.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_mobile_reachability_timer_with_mme_restart.py
@@ -11,8 +11,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-import unittest
 import time
+import unittest
 
 import gpp_types
 import s1ap_types
@@ -23,7 +23,7 @@ from s1ap_utils import MagmadUtil
 class TestMobileReachabilityTimerWithMmeRestart(unittest.TestCase):
     def setUp(self):
         self._s1ap_wrapper = s1ap_wrapper.TestWrapper(
-            stateless_mode=MagmadUtil.stateless_cmds.ENABLE
+            stateless_mode=MagmadUtil.stateless_cmds.ENABLE,
         )
 
     def tearDown(self):
@@ -80,11 +80,11 @@ class TestMobileReachabilityTimerWithMmeRestart(unittest.TestCase):
         req.ue_Id = ue_id
         req.cause.causeVal = gpp_types.CauseRadioNetwork.USER_INACTIVITY.value
         self._s1ap_wrapper.s1_util.issue_cmd(
-            s1ap_types.tfwCmd.UE_CNTXT_REL_REQUEST, req
+            s1ap_types.tfwCmd.UE_CNTXT_REL_REQUEST, req,
         )
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_CTX_REL_IND.value
+            response.msg_type, s1ap_types.tfwCmd.UE_CTX_REL_IND.value,
         )
 
         print("************************* Restarting MME service on gateway")
@@ -103,7 +103,7 @@ class TestMobileReachabilityTimerWithMmeRestart(unittest.TestCase):
         print(
             "************************* Waiting for Mobile Reachability Timer"
             " (5 Minutes) and Implicit Detach Timer (5 minutes) to expire."
-            " Together timer value is set to 660 seconds"
+            " Together timer value is set to 660 seconds",
         )
         # 5 Minutes + 5 minutes = 10 minutes (600 seconds)
         # 600 seconds + 60 seconds, delta(Randomly chosen)
@@ -124,11 +124,11 @@ class TestMobileReachabilityTimerWithMmeRestart(unittest.TestCase):
         req.ueMtmsi.pres = False
         req.rrcCause = s1ap_types.Rrc_Cause.TFW_MO_DATA.value
         self._s1ap_wrapper.s1_util.issue_cmd(
-            s1ap_types.tfwCmd.UE_SERVICE_REQUEST, req
+            s1ap_types.tfwCmd.UE_SERVICE_REQUEST, req,
         )
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_SERVICE_REJECT_IND.value
+            response.msg_type, s1ap_types.tfwCmd.UE_SERVICE_REJECT_IND.value,
         )
 
         print(
@@ -139,7 +139,7 @@ class TestMobileReachabilityTimerWithMmeRestart(unittest.TestCase):
         # Wait for UE Context Release command
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_CTX_REL_IND.value
+            response.msg_type, s1ap_types.tfwCmd.UE_CTX_REL_IND.value,
         )
 
 

--- a/lte/gateway/python/integ_tests/s1aptests/test_modify_mme_config_for_sanity.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_modify_mme_config_for_sanity.py
@@ -28,14 +28,15 @@ class TestModifyMMEConfigForSanity(unittest.TestCase):
         self._magmad_util = MagmadUtil(magmad_client)
 
         print(
-            "Modifying MME configuration for all sanity test cases to pass"
+            "Modifying MME configuration for all sanity test cases to pass",
         )
         self._magmad_util.update_mme_config_for_sanity(
-            MagmadUtil.config_update_cmds.MODIFY
+            MagmadUtil.config_update_cmds.MODIFY,
         )
 
         print("Restarting services to apply configuration change")
         self._magmad_util.restart_all_services()
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/lte/gateway/python/integ_tests/s1aptests/test_multi_enb_complete_reset.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_multi_enb_complete_reset.py
@@ -12,6 +12,7 @@ limitations under the License.
 """
 import time
 import unittest
+
 import s1ap_types
 import s1ap_wrapper
 
@@ -43,11 +44,13 @@ class TestMultipleEnbAttachDetachCompleteReset(unittest.TestCase):
 
         # column is an enb parameter, row is number of enbs
         """         Cell Id, Tac, EnbType, PLMN Id, PLMN length """
-        enb_list = [[1, 1, 1, "00101", 5],
-                    [2, 1, 1, "00101", 5],
-                    [3, 1, 1, "00101", 5],
-                    [4, 1, 1, "00101", 5],
-                    [5, 1, 1, "00101", 5]]
+        enb_list = [
+            [1, 1, 1, "00101", 5],
+            [2, 1, 1, "00101", 5],
+            [3, 1, 1, "00101", 5],
+            [4, 1, 1, "00101", 5],
+            [5, 1, 1, "00101", 5],
+        ]
 
         self._s1ap_wrapper.multiEnbConfig(len(enb_list), enb_list)
 
@@ -60,13 +63,16 @@ class TestMultipleEnbAttachDetachCompleteReset(unittest.TestCase):
         self._s1ap_wrapper.configUEDevice(num_ues)
         for _ in range(num_ues):
             req = self._s1ap_wrapper.ue_req
-            print("******************** Calling attach for UE id ",
-                  req.ue_id)
+            print(
+                "******************** Calling attach for UE id ",
+                req.ue_id,
+            )
             self._s1ap_wrapper.s1_util.attach(
                 req.ue_id,
                 s1ap_types.tfwCmd.UE_END_TO_END_ATTACH_REQUEST,
                 s1ap_types.tfwCmd.UE_ATTACH_ACCEPT_IND,
-                s1ap_types.ueAttachAccept_t)
+                s1ap_types.ueAttachAccept_t,
+            )
             # Wait on EMM Information from MME
             self._s1ap_wrapper._s1_util.receive_emm_info()
             ue_ids.append(req.ue_id)
@@ -88,17 +94,20 @@ class TestMultipleEnbAttachDetachCompleteReset(unittest.TestCase):
         reset_req.r.completeRst = s1ap_types.CompleteReset()
         reset_req.r.completeRst.enbId = 2
         self._s1ap_wrapper.s1_util.issue_cmd(
-            s1ap_types.tfwCmd.RESET_REQ, reset_req)
+            s1ap_types.tfwCmd.RESET_REQ, reset_req,
+        )
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.RESET_ACK.value)
+            response.msg_type, s1ap_types.tfwCmd.RESET_ACK.value,
+        )
 
         time.sleep(1)
         for ue in ue_ids:
             print("************************* Calling detach for UE id ", ue)
             self._s1ap_wrapper.s1_util.detach(
                 ue,
-                s1ap_types.ueDetachType_t.UE_NORMAL_DETACH.value)
+                s1ap_types.ueDetachType_t.UE_NORMAL_DETACH.value,
+            )
 
 
 if __name__ == "__main__":

--- a/lte/gateway/python/integ_tests/s1aptests/test_multi_enb_multi_ue.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_multi_enb_multi_ue.py
@@ -12,6 +12,7 @@ limitations under the License.
 """
 import time
 import unittest
+
 import s1ap_types
 import s1ap_wrapper
 
@@ -43,11 +44,13 @@ class TestMultiEnbMultiUEAttachDetach(unittest.TestCase):
 
         # column is an enb parameter, row is number of enbs
         """            Cell Id, Tac, EnbType, PLMN Id, PLMN length """
-        enb_list = [[1, 1, 1, "00101", 5],
-                    [2, 1, 1, "00101", 5],
-                    [3, 1, 1, "00101", 5],
-                    [4, 1, 1, "00101", 5],
-                    [5, 1, 1, "00101", 5]]
+        enb_list = [
+            [1, 1, 1, "00101", 5],
+            [2, 1, 1, "00101", 5],
+            [3, 1, 1, "00101", 5],
+            [4, 1, 1, "00101", 5],
+            [5, 1, 1, "00101", 5],
+        ]
 
         self._s1ap_wrapper.multiEnbConfig(len(enb_list), enb_list)
 
@@ -60,13 +63,16 @@ class TestMultiEnbMultiUEAttachDetach(unittest.TestCase):
         self._s1ap_wrapper.configUEDevice(num_ues)
         for _ in range(num_ues):
             req = self._s1ap_wrapper.ue_req
-            print("******************** Calling attach for UE id ",
-                  req.ue_id)
+            print(
+                "******************** Calling attach for UE id ",
+                req.ue_id,
+            )
             self._s1ap_wrapper.s1_util.attach(
                 req.ue_id,
                 s1ap_types.tfwCmd.UE_END_TO_END_ATTACH_REQUEST,
                 s1ap_types.tfwCmd.UE_ATTACH_ACCEPT_IND,
-                s1ap_types.ueAttachAccept_t)
+                s1ap_types.ueAttachAccept_t,
+            )
             # Wait on EMM Information from MME
             self._s1ap_wrapper._s1_util.receive_emm_info()
             ue_ids.append(req.ue_id)
@@ -75,7 +81,8 @@ class TestMultiEnbMultiUEAttachDetach(unittest.TestCase):
             print("************************* Calling detach for UE id ", ue)
             self._s1ap_wrapper.s1_util.detach(
                 ue,
-                s1ap_types.ueDetachType_t.UE_NORMAL_DETACH.value)
+                s1ap_types.ueDetachType_t.UE_NORMAL_DETACH.value,
+            )
 
 
 if __name__ == "__main__":

--- a/lte/gateway/python/integ_tests/s1aptests/test_multi_enb_multi_ue_diff_enbtype.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_multi_enb_multi_ue_diff_enbtype.py
@@ -12,6 +12,7 @@ limitations under the License.
 """
 import time
 import unittest
+
 import s1ap_types
 import s1ap_wrapper
 
@@ -44,8 +45,10 @@ class TestMultiEnbWithDifferentEnbType(unittest.TestCase):
         # column is an enb parameter, row is number of enbs
         # (EnbType=1 -> HomeENB-ID) (EnbType=0 -> MacroENB-ID)
         """ Cell Id, Tac, EnbType, PLMN Id, PLMN length """
-        enb_list = [[1, 1, 1, "00101", 5],
-                    [5, 1, 0, "00101", 5]]
+        enb_list = [
+            [1, 1, 1, "00101", 5],
+            [5, 1, 0, "00101", 5],
+        ]
 
         self._s1ap_wrapper.multiEnbConfig(len(enb_list), enb_list)
 
@@ -58,13 +61,16 @@ class TestMultiEnbWithDifferentEnbType(unittest.TestCase):
         self._s1ap_wrapper.configUEDevice(num_ues)
         for _ in range(num_ues):
             req = self._s1ap_wrapper.ue_req
-            print("******************** Calling attach for UE id ",
-                  req.ue_id)
+            print(
+                "******************** Calling attach for UE id ",
+                req.ue_id,
+            )
             self._s1ap_wrapper.s1_util.attach(
                 req.ue_id,
                 s1ap_types.tfwCmd.UE_END_TO_END_ATTACH_REQUEST,
                 s1ap_types.tfwCmd.UE_ATTACH_ACCEPT_IND,
-                s1ap_types.ueAttachAccept_t)
+                s1ap_types.ueAttachAccept_t,
+            )
             # Wait on EMM Information from MME
             self._s1ap_wrapper._s1_util.receive_emm_info()
             ue_ids.append(req.ue_id)
@@ -73,7 +79,8 @@ class TestMultiEnbWithDifferentEnbType(unittest.TestCase):
             print("************************* Calling detach for UE id ", ue)
             self._s1ap_wrapper.s1_util.detach(
                 ue,
-                s1ap_types.ueDetachType_t.UE_NORMAL_DETACH.value)
+                s1ap_types.ueDetachType_t.UE_NORMAL_DETACH.value,
+            )
 
 
 if __name__ == "__main__":

--- a/lte/gateway/python/integ_tests/s1aptests/test_multi_enb_multi_ue_diff_plmn.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_multi_enb_multi_ue_diff_plmn.py
@@ -12,6 +12,7 @@ limitations under the License.
 """
 import time
 import unittest
+
 import s1ap_types
 import s1ap_wrapper
 
@@ -85,7 +86,7 @@ class TestMultiEnbWithDifferentPlmn(unittest.TestCase):
         for ue in ue_ids:
             print("************************* Calling detach for UE id ", ue)
             self._s1ap_wrapper.s1_util.detach(
-                ue, s1ap_types.ueDetachType_t.UE_NORMAL_DETACH.value
+                ue, s1ap_types.ueDetachType_t.UE_NORMAL_DETACH.value,
             )
 
 

--- a/lte/gateway/python/integ_tests/s1aptests/test_multi_enb_multi_ue_diff_tac.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_multi_enb_multi_ue_diff_tac.py
@@ -12,6 +12,7 @@ limitations under the License.
 """
 import time
 import unittest
+
 import s1ap_types
 import s1ap_wrapper
 
@@ -85,7 +86,7 @@ class TestMultiEnbWithDifferentTac(unittest.TestCase):
         for ue in ue_ids:
             print("************************* Calling detach for UE id ", ue)
             self._s1ap_wrapper.s1_util.detach(
-                ue, s1ap_types.ueDetachType_t.UE_NORMAL_DETACH.value
+                ue, s1ap_types.ueDetachType_t.UE_NORMAL_DETACH.value,
             )
 
 

--- a/lte/gateway/python/integ_tests/s1aptests/test_multi_enb_paging_request.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_multi_enb_paging_request.py
@@ -11,13 +11,12 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
+import time
 import unittest
-
 
 import gpp_types
 import s1ap_types
 import s1ap_wrapper
-import time
 
 
 class TestMultiEnbPagingRequest(unittest.TestCase):
@@ -93,11 +92,11 @@ class TestMultiEnbPagingRequest(unittest.TestCase):
                 gpp_types.CauseRadioNetwork.USER_INACTIVITY.value
             )
             self._s1ap_wrapper.s1_util.issue_cmd(
-                s1ap_types.tfwCmd.UE_CNTXT_REL_REQUEST, ue_cntxt_rel_req
+                s1ap_types.tfwCmd.UE_CNTXT_REL_REQUEST, ue_cntxt_rel_req,
             )
             response = self._s1ap_wrapper.s1_util.get_response()
             self.assertEqual(
-                response.msg_type, s1ap_types.tfwCmd.UE_CTX_REL_IND.value
+                response.msg_type, s1ap_types.tfwCmd.UE_CTX_REL_IND.value,
             )
             time.sleep(0.5)
             print(
@@ -105,31 +104,31 @@ class TestMultiEnbPagingRequest(unittest.TestCase):
                 req.ue_id,
             )
             with self._s1ap_wrapper.configDownlinkTest(
-                req, duration=1, is_udp=True
+                req, duration=1, is_udp=True,
             ) as test:
                 response = self._s1ap_wrapper.s1_util.get_response()
                 self.assertTrue(
-                    response, s1ap_types.tfwCmd.UE_PAGING_IND.value
+                    response, s1ap_types.tfwCmd.UE_PAGING_IND.value,
                 )
 
                 response = self._s1ap_wrapper.s1_util.get_response()
                 self.assertTrue(
-                    response, s1ap_types.tfwCmd.UE_PAGING_IND.value
+                    response, s1ap_types.tfwCmd.UE_PAGING_IND.value,
                 )
 
                 response = self._s1ap_wrapper.s1_util.get_response()
                 self.assertTrue(
-                    response, s1ap_types.tfwCmd.UE_PAGING_IND.value
+                    response, s1ap_types.tfwCmd.UE_PAGING_IND.value,
                 )
 
                 response = self._s1ap_wrapper.s1_util.get_response()
                 self.assertTrue(
-                    response, s1ap_types.tfwCmd.UE_PAGING_IND.value
+                    response, s1ap_types.tfwCmd.UE_PAGING_IND.value,
                 )
 
                 response = self._s1ap_wrapper.s1_util.get_response()
                 self.assertTrue(
-                    response, s1ap_types.tfwCmd.UE_PAGING_IND.value
+                    response, s1ap_types.tfwCmd.UE_PAGING_IND.value,
                 )
                 # Send service request to reconnect UE
                 ser_req = s1ap_types.ueserviceReq_t()
@@ -138,7 +137,7 @@ class TestMultiEnbPagingRequest(unittest.TestCase):
                 ser_req.ueMtmsi.pres = False
                 ser_req.rrcCause = s1ap_types.Rrc_Cause.TFW_MT_ACCESS.value
                 self._s1ap_wrapper.s1_util.issue_cmd(
-                    s1ap_types.tfwCmd.UE_SERVICE_REQUEST, ser_req
+                    s1ap_types.tfwCmd.UE_SERVICE_REQUEST, ser_req,
                 )
                 response = self._s1ap_wrapper.s1_util.get_response()
                 self.assertEqual(
@@ -151,7 +150,7 @@ class TestMultiEnbPagingRequest(unittest.TestCase):
         for ue in ue_ids:
             print("************************* Calling detach for UE id ", ue)
             self._s1ap_wrapper.s1_util.detach(
-                ue, s1ap_types.ueDetachType_t.UE_NORMAL_DETACH.value, True
+                ue, s1ap_types.ueDetachType_t.UE_NORMAL_DETACH.value, True,
             )
 
         time.sleep(1)

--- a/lte/gateway/python/integ_tests/s1aptests/test_multi_enb_partial_reset.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_multi_enb_partial_reset.py
@@ -11,9 +11,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-import unittest
-import time
 import ctypes
+import time
+import unittest
 from builtins import range
 
 import s1ap_types
@@ -46,11 +46,13 @@ class TestMultipleEnbPartialReset(unittest.TestCase):
 
         # column is an enb parameter, row is number of enbs
         """         Cell Id, Tac, EnbType, PLMN Id, PLMN length """
-        enb_list = [[1, 1, 1, "00101", 5],
-                    [2, 1, 1, "00101", 5],
-                    [3, 1, 1, "00101", 5],
-                    [4, 1, 1, "00101", 5],
-                    [5, 1, 1, "00101", 5]]
+        enb_list = [
+            [1, 1, 1, "00101", 5],
+            [2, 1, 1, "00101", 5],
+            [3, 1, 1, "00101", 5],
+            [4, 1, 1, "00101", 5],
+            [5, 1, 1, "00101", 5],
+        ]
 
         self._s1ap_wrapper.multiEnbConfig(len(enb_list), enb_list)
 
@@ -61,8 +63,10 @@ class TestMultipleEnbPartialReset(unittest.TestCase):
         self._s1ap_wrapper.configUEDevice(num_ues)
         for _ in range(num_ues):
             req = self._s1ap_wrapper.ue_req
-            print("************************* Calling attach for UE id ",
-                  req.ue_id)
+            print(
+                "************************* Calling attach for UE id ",
+                req.ue_id,
+            )
             self._s1ap_wrapper.s1_util.attach(
                 req.ue_id,
                 s1ap_types.tfwCmd.UE_END_TO_END_ATTACH_REQUEST,
@@ -99,7 +103,8 @@ class TestMultipleEnbPartialReset(unittest.TestCase):
             )
         print("ue_ids", ue_ids)
         self._s1ap_wrapper.s1_util.issue_cmd(
-            s1ap_types.tfwCmd.RESET_REQ, reset_req)
+            s1ap_types.tfwCmd.RESET_REQ, reset_req,
+        )
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(response.msg_type, s1ap_types.tfwCmd.RESET_ACK.value)
         # Trigger detach request
@@ -108,7 +113,7 @@ class TestMultipleEnbPartialReset(unittest.TestCase):
             # self._s1ap_wrapper.s1_util.detach(
             #    ue, detach_type, wait_for_s1)
             self._s1ap_wrapper.s1_util.detach(
-                ue, s1ap_types.ueDetachType_t.UE_NORMAL_DETACH.value, True
+                ue, s1ap_types.ueDetachType_t.UE_NORMAL_DETACH.value, True,
             )
 
 

--- a/lte/gateway/python/integ_tests/s1aptests/test_multi_enb_sctp_shutdown.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_multi_enb_sctp_shutdown.py
@@ -12,6 +12,7 @@ limitations under the License.
 """
 import time
 import unittest
+
 import s1ap_types
 import s1ap_wrapper
 
@@ -43,11 +44,13 @@ class TestMultiEnbMultiUEAttachDetachSctpShutdown(unittest.TestCase):
 
         # column is an enb parameter, row is number of enbs
         """            Cell Id, Tac, EnbType, PLMN Id, PLMN length """
-        enb_list = [[1, 1, 1, "00101", 5],
-                    [2, 1, 1, "00101", 5],
-                    [3, 1, 1, "00101", 5],
-                    [4, 1, 1, "00101", 5],
-                    [5, 1, 1, "00101", 5]]
+        enb_list = [
+            [1, 1, 1, "00101", 5],
+            [2, 1, 1, "00101", 5],
+            [3, 1, 1, "00101", 5],
+            [4, 1, 1, "00101", 5],
+            [5, 1, 1, "00101", 5],
+        ]
 
         self._s1ap_wrapper.multiEnbConfig(len(enb_list), enb_list)
 
@@ -60,13 +63,16 @@ class TestMultiEnbMultiUEAttachDetachSctpShutdown(unittest.TestCase):
         self._s1ap_wrapper.configUEDevice(num_ues)
         for _ in range(num_ues):
             req = self._s1ap_wrapper.ue_req
-            print("******************** Calling attach for UE id ",
-                  req.ue_id)
+            print(
+                "******************** Calling attach for UE id ",
+                req.ue_id,
+            )
             self._s1ap_wrapper.s1_util.attach(
                 req.ue_id,
                 s1ap_types.tfwCmd.UE_END_TO_END_ATTACH_REQUEST,
                 s1ap_types.tfwCmd.UE_ATTACH_ACCEPT_IND,
-                s1ap_types.ueAttachAccept_t)
+                s1ap_types.ueAttachAccept_t,
+            )
             # Wait on EMM Information from MME
             self._s1ap_wrapper._s1_util.receive_emm_info()
             ue_ids.append(req.ue_id)
@@ -75,12 +81,14 @@ class TestMultiEnbMultiUEAttachDetachSctpShutdown(unittest.TestCase):
             print("************************* Calling detach for UE id ", ue)
             self._s1ap_wrapper.s1_util.detach(
                 ue,
-                s1ap_types.ueDetachType_t.UE_NORMAL_DETACH.value)
+                s1ap_types.ueDetachType_t.UE_NORMAL_DETACH.value,
+            )
 
         time.sleep(2)
         print("send SCTP SHUTDOWN")
         self._s1ap_wrapper._s1_util.issue_cmd(
-            s1ap_types.tfwCmd.SCTP_SHUTDOWN_REQ, None)
+            s1ap_types.tfwCmd.SCTP_SHUTDOWN_REQ, None,
+        )
 
 
 if __name__ == "__main__":

--- a/lte/gateway/python/integ_tests/s1aptests/test_nas_non_delivery_for_auth.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_nas_non_delivery_for_auth.py
@@ -14,7 +14,6 @@ limitations under the License.
 import unittest
 
 import s1ap_types
-
 from integ_tests.s1aptests import s1ap_wrapper
 
 
@@ -47,7 +46,7 @@ class TestNasNonDeliveryAuthReq(unittest.TestCase):
         attach_req.useOldSecCtxt = sec_ctxt
         print("Sending Attach Request for ue-id", req.ue_id)
         self._s1ap_wrapper._s1_util.issue_cmd(
-            s1ap_types.tfwCmd.UE_ATTACH_REQUEST, attach_req
+            s1ap_types.tfwCmd.UE_ATTACH_REQUEST, attach_req,
         )
 
         """ The purpose of UE_SET_NAS_NON_DELIVERY command is to prepare
@@ -63,13 +62,13 @@ class TestNasNonDeliveryAuthReq(unittest.TestCase):
         nas_non_del.causeVal = 3
         print("Sending Set Nas Non Del to enb for ue-id ", nas_non_del.ue_Id)
         self._s1ap_wrapper._s1_util.issue_cmd(
-            s1ap_types.tfwCmd.UE_SET_NAS_NON_DELIVERY, nas_non_del
+            s1ap_types.tfwCmd.UE_SET_NAS_NON_DELIVERY, nas_non_del,
         )
 
         """ Waiting for UE Context Release from MME """
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_CTX_REL_IND.value
+            response.msg_type, s1ap_types.tfwCmd.UE_CTX_REL_IND.value,
         )
         print("Received UE_CTX_REL_IND")
         # Reset the nas non delivery flag
@@ -82,7 +81,7 @@ class TestNasNonDeliveryAuthReq(unittest.TestCase):
         nas_non_del.causeVal = 3
         print("Sending Reset Nas Non Del ind to enbapp")
         self._s1ap_wrapper._s1_util.issue_cmd(
-            s1ap_types.tfwCmd.UE_SET_NAS_NON_DELIVERY, nas_non_del
+            s1ap_types.tfwCmd.UE_SET_NAS_NON_DELIVERY, nas_non_del,
         )
 
 

--- a/lte/gateway/python/integ_tests/s1aptests/test_nas_non_delivery_for_identity_req.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_nas_non_delivery_for_identity_req.py
@@ -14,7 +14,6 @@ limitations under the License.
 import unittest
 
 import s1ap_types
-
 from integ_tests.s1aptests import s1ap_wrapper
 
 
@@ -47,7 +46,7 @@ class TestNasNonDeliveryIdentityReq(unittest.TestCase):
         attach_req.useOldSecCtxt = sec_ctxt
         print("Sending Attach Request ue-id", req.ue_id)
         self._s1ap_wrapper._s1_util.issue_cmd(
-            s1ap_types.tfwCmd.UE_ATTACH_REQUEST, attach_req
+            s1ap_types.tfwCmd.UE_ATTACH_REQUEST, attach_req,
         )
 
         """ The purpose of UE_SET_NAS_NON_DELIVERY command is to prepare
@@ -63,13 +62,13 @@ class TestNasNonDeliveryIdentityReq(unittest.TestCase):
         nas_non_del.causeVal = 3
         print("Sending Set Nas Non Del to enb for ue-id ", nas_non_del.ue_Id)
         self._s1ap_wrapper._s1_util.issue_cmd(
-            s1ap_types.tfwCmd.UE_SET_NAS_NON_DELIVERY, nas_non_del
+            s1ap_types.tfwCmd.UE_SET_NAS_NON_DELIVERY, nas_non_del,
         )
 
         """ Waiting for UE Context Release command from MME """
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_CTX_REL_IND.value
+            response.msg_type, s1ap_types.tfwCmd.UE_CTX_REL_IND.value,
         )
         print("Received UE_CTX_REL_IND")
         # Reset the nas non delivery flag
@@ -82,7 +81,7 @@ class TestNasNonDeliveryIdentityReq(unittest.TestCase):
         nas_non_del.causeVal = 3
         print("Sending Reset Nas Non Del ind to enb")
         self._s1ap_wrapper._s1_util.issue_cmd(
-            s1ap_types.tfwCmd.UE_SET_NAS_NON_DELIVERY, nas_non_del
+            s1ap_types.tfwCmd.UE_SET_NAS_NON_DELIVERY, nas_non_del,
         )
 
 

--- a/lte/gateway/python/integ_tests/s1aptests/test_nas_non_delivery_for_smc.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_nas_non_delivery_for_smc.py
@@ -14,7 +14,6 @@ limitations under the License.
 import unittest
 
 import s1ap_types
-
 from integ_tests.s1aptests import s1ap_wrapper
 
 
@@ -47,12 +46,12 @@ class TestNasNonDeliverySmc(unittest.TestCase):
         attach_req.useOldSecCtxt = sec_ctxt
         print("Sending Attach Request ue-id", req.ue_id)
         self._s1ap_wrapper._s1_util.issue_cmd(
-            s1ap_types.tfwCmd.UE_ATTACH_REQUEST, attach_req
+            s1ap_types.tfwCmd.UE_ATTACH_REQUEST, attach_req,
         )
 
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_AUTH_REQ_IND.value
+            response.msg_type, s1ap_types.tfwCmd.UE_AUTH_REQ_IND.value,
         )
         print("Received auth req ind ue-Id", req.ue_id)
 
@@ -72,7 +71,7 @@ class TestNasNonDeliverySmc(unittest.TestCase):
         nas_non_del.causeVal = 3
         print("Sending Set Nas Non Del to enbApp for ue-id", nas_non_del.ue_Id)
         self._s1ap_wrapper._s1_util.issue_cmd(
-            s1ap_types.tfwCmd.UE_SET_NAS_NON_DELIVERY, nas_non_del
+            s1ap_types.tfwCmd.UE_SET_NAS_NON_DELIVERY, nas_non_del,
         )
 
         print("Send Auth Resp", req.ue_id)
@@ -83,12 +82,12 @@ class TestNasNonDeliverySmc(unittest.TestCase):
         auth_res.sqnRcvd = sqnRecvd
 
         self._s1ap_wrapper._s1_util.issue_cmd(
-            s1ap_types.tfwCmd.UE_AUTH_RESP, auth_res
+            s1ap_types.tfwCmd.UE_AUTH_RESP, auth_res,
         )
 
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_CTX_REL_IND.value
+            response.msg_type, s1ap_types.tfwCmd.UE_CTX_REL_IND.value,
         )
         print("Received UE_CTX_REL_IND")
 
@@ -102,7 +101,7 @@ class TestNasNonDeliverySmc(unittest.TestCase):
         nas_non_del.causeVal = 3
         print("Sending Reset Nas Non Del ind to enb")
         self._s1ap_wrapper._s1_util.issue_cmd(
-            s1ap_types.tfwCmd.UE_SET_NAS_NON_DELIVERY, nas_non_del
+            s1ap_types.tfwCmd.UE_SET_NAS_NON_DELIVERY, nas_non_del,
         )
 
 

--- a/lte/gateway/python/integ_tests/s1aptests/test_no_attach_complete.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_no_attach_complete.py
@@ -21,7 +21,6 @@ from python.integ_tests.common.service303_utils import (
     verify_gateway_metrics,
 )
 
-
 # This test case is to test EPC behaviour by not sending "attach complete"
 # in the response to multiple retries of  "attach accept" from EPC.
 # EPC is exepcetd to try sending attach accept 5 times when there is no
@@ -88,7 +87,7 @@ class NoAttachComplete(unittest.TestCase):
 
         req = self._s1ap_wrapper.ue_req
         print(
-            "************************* Running attach setup timer expiry test"
+            "************************* Running attach setup timer expiry test",
         )
 
         attach_req = s1ap_types.ueAttachRequest_t()
@@ -101,11 +100,11 @@ class NoAttachComplete(unittest.TestCase):
         attach_req.useOldSecCtxt = sec_ctxt
 
         self._s1ap_wrapper._s1_util.issue_cmd(
-            s1ap_types.tfwCmd.UE_ATTACH_REQUEST, attach_req
+            s1ap_types.tfwCmd.UE_ATTACH_REQUEST, attach_req,
         )
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_AUTH_REQ_IND.value
+            response.msg_type, s1ap_types.tfwCmd.UE_AUTH_REQ_IND.value,
         )
         auth_res = s1ap_types.ueAuthResp_t()
         auth_res.ue_Id = req.ue_id
@@ -114,26 +113,26 @@ class NoAttachComplete(unittest.TestCase):
         auth_res.sqnRcvd = sqnRecvd
 
         self._s1ap_wrapper._s1_util.issue_cmd(
-            s1ap_types.tfwCmd.UE_AUTH_RESP, auth_res
+            s1ap_types.tfwCmd.UE_AUTH_RESP, auth_res,
         )
         response = self._s1ap_wrapper.s1_util.get_response()
 
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_SEC_MOD_CMD_IND.value
+            response.msg_type, s1ap_types.tfwCmd.UE_SEC_MOD_CMD_IND.value,
         )
 
         sec_mode_complete = s1ap_types.ueSecModeComplete_t()
         sec_mode_complete.ue_Id = req.ue_id
         self._s1ap_wrapper._s1_util.issue_cmd(
-            s1ap_types.tfwCmd.UE_SEC_MOD_COMPLETE, sec_mode_complete
+            s1ap_types.tfwCmd.UE_SEC_MOD_COMPLETE, sec_mode_complete,
         )
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.INT_CTX_SETUP_IND.value
+            response.msg_type, s1ap_types.tfwCmd.INT_CTX_SETUP_IND.value,
         )
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_ATTACH_ACCEPT_IND.value
+            response.msg_type, s1ap_types.tfwCmd.UE_ATTACH_ACCEPT_IND.value,
         )
 
         # EPC would resend Attach accept 4 times and then would abort attach
@@ -141,14 +140,14 @@ class NoAttachComplete(unittest.TestCase):
         for i in range(4):
             response = self._s1ap_wrapper.s1_util.get_response()
             self.assertEqual(
-                response.msg_type, s1ap_types.tfwCmd.UE_ATTACH_ACCEPT_IND.value
+                response.msg_type, s1ap_types.tfwCmd.UE_ATTACH_ACCEPT_IND.value,
             )
             print("************************* Timeout", i + 1)
 
         print("***************** Attach Aborted and UE Context released")
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_CTX_REL_IND.value
+            response.msg_type, s1ap_types.tfwCmd.UE_CTX_REL_IND.value,
         )
 
 

--- a/lte/gateway/python/integ_tests/s1aptests/test_no_attach_complete_with_mme_restart.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_no_attach_complete_with_mme_restart.py
@@ -11,10 +11,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
+import time
 import unittest
 
 import s1ap_types
-import time
 import s1ap_wrapper
 from s1ap_utils import MagmadUtil
 
@@ -22,7 +22,7 @@ from s1ap_utils import MagmadUtil
 class TestNoAttachCompleteWithMmeRestart(unittest.TestCase):
     def setUp(self):
         self._s1ap_wrapper = s1ap_wrapper.TestWrapper(
-            stateless_mode=MagmadUtil.stateless_cmds.ENABLE
+            stateless_mode=MagmadUtil.stateless_cmds.ENABLE,
         )
         self.gateway_services = self._s1ap_wrapper.get_gateway_services_util()
 
@@ -46,7 +46,7 @@ class TestNoAttachCompleteWithMmeRestart(unittest.TestCase):
 
         req = self._s1ap_wrapper.ue_req
         print(
-            "************************* Running attach setup timer expiry test"
+            "************************* Running attach setup timer expiry test",
         )
 
         attach_req = s1ap_types.ueAttachRequest_t()
@@ -59,11 +59,11 @@ class TestNoAttachCompleteWithMmeRestart(unittest.TestCase):
         attach_req.useOldSecCtxt = sec_ctxt
 
         self._s1ap_wrapper._s1_util.issue_cmd(
-            s1ap_types.tfwCmd.UE_ATTACH_REQUEST, attach_req
+            s1ap_types.tfwCmd.UE_ATTACH_REQUEST, attach_req,
         )
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_AUTH_REQ_IND.value
+            response.msg_type, s1ap_types.tfwCmd.UE_AUTH_REQ_IND.value,
         )
         auth_res = s1ap_types.ueAuthResp_t()
         auth_res.ue_Id = req.ue_id
@@ -72,26 +72,26 @@ class TestNoAttachCompleteWithMmeRestart(unittest.TestCase):
         auth_res.sqnRcvd = sqnRecvd
 
         self._s1ap_wrapper._s1_util.issue_cmd(
-            s1ap_types.tfwCmd.UE_AUTH_RESP, auth_res
+            s1ap_types.tfwCmd.UE_AUTH_RESP, auth_res,
         )
         response = self._s1ap_wrapper.s1_util.get_response()
 
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_SEC_MOD_CMD_IND.value
+            response.msg_type, s1ap_types.tfwCmd.UE_SEC_MOD_CMD_IND.value,
         )
 
         sec_mode_complete = s1ap_types.ueSecModeComplete_t()
         sec_mode_complete.ue_Id = req.ue_id
         self._s1ap_wrapper._s1_util.issue_cmd(
-            s1ap_types.tfwCmd.UE_SEC_MOD_COMPLETE, sec_mode_complete
+            s1ap_types.tfwCmd.UE_SEC_MOD_COMPLETE, sec_mode_complete,
         )
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.INT_CTX_SETUP_IND.value
+            response.msg_type, s1ap_types.tfwCmd.INT_CTX_SETUP_IND.value,
         )
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_ATTACH_ACCEPT_IND.value
+            response.msg_type, s1ap_types.tfwCmd.UE_ATTACH_ACCEPT_IND.value,
         )
 
         print(
@@ -107,10 +107,10 @@ class TestNoAttachCompleteWithMmeRestart(unittest.TestCase):
         response = self._s1ap_wrapper.s1_util.get_response()
 
         while response.msg_type == s1ap_types.tfwCmd.UE_ATTACH_ACCEPT_IND:
-            print (
+            print(
                     "Received Attach Accept retransmission from before restart",
-                    "Ignoring..."
-                  )
+                    "Ignoring...",
+            )
             response = self._s1ap_wrapper.s1_util.get_response()
 
         self.assertEqual(
@@ -149,13 +149,13 @@ class TestNoAttachCompleteWithMmeRestart(unittest.TestCase):
         detach_accept = s1ap_types.ueTrigDetachAcceptInd_t()
         detach_accept.ue_Id = req.ue_id
         self._s1ap_wrapper._s1_util.issue_cmd(
-            s1ap_types.tfwCmd.UE_TRIGGERED_DETACH_ACCEPT, detach_accept
+            s1ap_types.tfwCmd.UE_TRIGGERED_DETACH_ACCEPT, detach_accept,
         )
 
         # Wait for UE context release command
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_CTX_REL_IND.value
+            response.msg_type, s1ap_types.tfwCmd.UE_CTX_REL_IND.value,
         )
         print("****** Received Ue context release command *********")
 

--- a/lte/gateway/python/integ_tests/s1aptests/test_no_auth_response.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_no_auth_response.py
@@ -76,7 +76,7 @@ class TestNoAuthResponse(unittest.TestCase):
         req = self._s1ap_wrapper.ue_req
         print(
             "************************* Running attach no auth response \
-            timer expiry test"
+            timer expiry test",
         )
 
         attach_req = s1ap_types.ueAttachRequest_t()
@@ -89,13 +89,13 @@ class TestNoAuthResponse(unittest.TestCase):
         attach_req.useOldSecCtxt = sec_ctxt
 
         self._s1ap_wrapper._s1_util.issue_cmd(
-            s1ap_types.tfwCmd.UE_ATTACH_REQUEST, attach_req
+            s1ap_types.tfwCmd.UE_ATTACH_REQUEST, attach_req,
         )
         # Wait for timer expiry 5 times, until context is released
         for i in range(5):
             response = self._s1ap_wrapper.s1_util.get_response()
             self.assertEqual(
-                response.msg_type, s1ap_types.tfwCmd.UE_AUTH_REQ_IND.value
+                response.msg_type, s1ap_types.tfwCmd.UE_AUTH_REQ_IND.value,
             )
             print("************************* Timeout", i + 1)
 
@@ -103,13 +103,13 @@ class TestNoAuthResponse(unittest.TestCase):
         # Attach Reject
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_ATTACH_REJECT_IND.value
+            response.msg_type, s1ap_types.tfwCmd.UE_ATTACH_REJECT_IND.value,
         )
 
         # Context release
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_CTX_REL_IND.value
+            response.msg_type, s1ap_types.tfwCmd.UE_CTX_REL_IND.value,
         )
         print("************************* Context released")
 

--- a/lte/gateway/python/integ_tests/s1aptests/test_no_auth_response_with_mme_restart.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_no_auth_response_with_mme_restart.py
@@ -11,13 +11,12 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-import unittest
 import time
+import unittest
 
 import s1ap_types
 import s1ap_wrapper
 from s1ap_utils import MagmadUtil
-
 
 # This test case is to test EPC behaviour by restarting mme
 # after authentication timer expires.
@@ -26,7 +25,7 @@ from s1ap_utils import MagmadUtil
 class TestNoAuthResponseWithMmeRestart(unittest.TestCase):
     def setUp(self):
         self._s1ap_wrapper = s1ap_wrapper.TestWrapper(
-            stateless_mode=MagmadUtil.stateless_cmds.ENABLE
+            stateless_mode=MagmadUtil.stateless_cmds.ENABLE,
         )
 
     def tearDown(self):
@@ -51,14 +50,14 @@ class TestNoAuthResponseWithMmeRestart(unittest.TestCase):
         attach_req.useOldSecCtxt = sec_ctxt
 
         self._s1ap_wrapper._s1_util.issue_cmd(
-            s1ap_types.tfwCmd.UE_ATTACH_REQUEST, attach_req
+            s1ap_types.tfwCmd.UE_ATTACH_REQUEST, attach_req,
         )
 
         # Wait for timer expiry 5 times, until context is released
         for i in range(5):
             response = self._s1ap_wrapper.s1_util.get_response()
             self.assertEqual(
-                response.msg_type, s1ap_types.tfwCmd.UE_AUTH_REQ_IND.value
+                response.msg_type, s1ap_types.tfwCmd.UE_AUTH_REQ_IND.value,
             )
             print("************************* Timeout", i + 1)
             print("********* Received Auth Req for ue", req.ue_id)
@@ -67,14 +66,14 @@ class TestNoAuthResponseWithMmeRestart(unittest.TestCase):
         # Attach Reject
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_ATTACH_REJECT_IND.value
+            response.msg_type, s1ap_types.tfwCmd.UE_ATTACH_REJECT_IND.value,
         )
         print("********* Received Attach Reject for ue", req.ue_id)
 
         # Context release
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_CTX_REL_IND.value
+            response.msg_type, s1ap_types.tfwCmd.UE_CTX_REL_IND.value,
         )
         print("********* Received UE_CTX_REL_IND for ue", req.ue_id)
 
@@ -97,7 +96,7 @@ class TestNoAuthResponseWithMmeRestart(unittest.TestCase):
         time.sleep(0.5)
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_EMM_INFORMATION.value
+            response.msg_type, s1ap_types.tfwCmd.UE_EMM_INFORMATION.value,
         )
 
         print(

--- a/lte/gateway/python/integ_tests/s1aptests/test_no_auth_response_with_mme_restart_reattach.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_no_auth_response_with_mme_restart_reattach.py
@@ -11,8 +11,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-import unittest
 import time
+import unittest
 
 import s1ap_types
 import s1ap_wrapper
@@ -22,7 +22,7 @@ from s1ap_utils import MagmadUtil
 class TestNoAuthResponseWithMmeRestartReattach(unittest.TestCase):
     def setUp(self):
         self._s1ap_wrapper = s1ap_wrapper.TestWrapper(
-            stateless_mode=MagmadUtil.stateless_cmds.ENABLE
+            stateless_mode=MagmadUtil.stateless_cmds.ENABLE,
         )
 
     def tearDown(self):
@@ -46,13 +46,13 @@ class TestNoAuthResponseWithMmeRestartReattach(unittest.TestCase):
         attach_req.useOldSecCtxt = sec_ctxt
 
         self._s1ap_wrapper._s1_util.issue_cmd(
-            s1ap_types.tfwCmd.UE_ATTACH_REQUEST, attach_req
+            s1ap_types.tfwCmd.UE_ATTACH_REQUEST, attach_req,
         )
         print("************ Sent Attach Request for ue", req.ue_id)
 
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_AUTH_REQ_IND.value
+            response.msg_type, s1ap_types.tfwCmd.UE_AUTH_REQ_IND.value,
         )
         print("************ Received Auth Req for ue", req.ue_id)
 
@@ -66,7 +66,7 @@ class TestNoAuthResponseWithMmeRestartReattach(unittest.TestCase):
         # Wait for UE context release command
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_CTX_REL_IND.value
+            response.msg_type, s1ap_types.tfwCmd.UE_CTX_REL_IND.value,
         )
         print("****** Received UE_CTX_REL_IND for ue", req.ue_id)
         print("****** Triggering end-end attach after mme restart *********")

--- a/lte/gateway/python/integ_tests/s1aptests/test_no_esm_information_rsp_with_mme_restart.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_no_esm_information_rsp_with_mme_restart.py
@@ -11,11 +11,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
+import time
 import unittest
 
 import s1ap_types
-import time
-
 from integ_tests.s1aptests import s1ap_wrapper
 from s1ap_utils import MagmadUtil
 
@@ -23,7 +22,7 @@ from s1ap_utils import MagmadUtil
 class TestNoEsmInformationRspWithMmeRestart(unittest.TestCase):
     def setUp(self):
         self._s1ap_wrapper = s1ap_wrapper.TestWrapper(
-            stateless_mode=MagmadUtil.stateless_cmds.ENABLE
+            stateless_mode=MagmadUtil.stateless_cmds.ENABLE,
         )
 
     def tearDown(self):
@@ -53,12 +52,12 @@ class TestNoEsmInformationRspWithMmeRestart(unittest.TestCase):
 
         print("Sending Attach Request ue-id", ue_id)
         self._s1ap_wrapper._s1_util.issue_cmd(
-            s1ap_types.tfwCmd.UE_ATTACH_REQUEST, attach_req
+            s1ap_types.tfwCmd.UE_ATTACH_REQUEST, attach_req,
         )
 
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_AUTH_REQ_IND.value
+            response.msg_type, s1ap_types.tfwCmd.UE_AUTH_REQ_IND.value,
         )
         print("Received Auth Req for ue-id", ue_id)
 
@@ -69,26 +68,26 @@ class TestNoEsmInformationRspWithMmeRestart(unittest.TestCase):
         auth_res.sqnRcvd = sqn_recvd
         print("Sending Auth Response for ue-id", ue_id)
         self._s1ap_wrapper._s1_util.issue_cmd(
-            s1ap_types.tfwCmd.UE_AUTH_RESP, auth_res
+            s1ap_types.tfwCmd.UE_AUTH_RESP, auth_res,
         )
 
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_SEC_MOD_CMD_IND.value
+            response.msg_type, s1ap_types.tfwCmd.UE_SEC_MOD_CMD_IND.value,
         )
         print("Received Security Mode Command for ue-id", ue_id)
 
         sec_mode_complete = s1ap_types.ueSecModeComplete_t()
         sec_mode_complete.ue_Id = ue_id
         self._s1ap_wrapper._s1_util.issue_cmd(
-            s1ap_types.tfwCmd.UE_SEC_MOD_COMPLETE, sec_mode_complete
+            s1ap_types.tfwCmd.UE_SEC_MOD_COMPLETE, sec_mode_complete,
         )
         print("Sent Security Mode Complete for ue-id", ue_id)
 
         # Esm Information Request indication
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_ESM_INFORMATION_REQ.value
+            response.msg_type, s1ap_types.tfwCmd.UE_ESM_INFORMATION_REQ.value,
         )
         print("Received Esm Information Request ue-id", ue_id)
 
@@ -112,7 +111,7 @@ class TestNoEsmInformationRspWithMmeRestart(unittest.TestCase):
             global response
             response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_CTX_REL_IND.value
+            response.msg_type, s1ap_types.tfwCmd.UE_CTX_REL_IND.value,
         )
 
         # Perform end-end attach
@@ -133,7 +132,7 @@ class TestNoEsmInformationRspWithMmeRestart(unittest.TestCase):
         )
         # Now detach the UE
         self._s1ap_wrapper.s1_util.detach(
-            ue_id, s1ap_types.ueDetachType_t.UE_SWITCHOFF_DETACH.value, False
+            ue_id, s1ap_types.ueDetachType_t.UE_SWITCHOFF_DETACH.value, False,
         )
 
 

--- a/lte/gateway/python/integ_tests/s1aptests/test_no_identity_rsp_with_mme_restart.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_no_identity_rsp_with_mme_restart.py
@@ -11,11 +11,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
+import time
 import unittest
 
 import s1ap_types
-import time
-
 from integ_tests.s1aptests import s1ap_wrapper
 from s1ap_utils import MagmadUtil
 
@@ -23,7 +22,7 @@ from s1ap_utils import MagmadUtil
 class TestNoIdentityRspWithMmeRestart(unittest.TestCase):
     def setUp(self):
         self._s1ap_wrapper = s1ap_wrapper.TestWrapper(
-            stateless_mode=MagmadUtil.stateless_cmds.ENABLE
+            stateless_mode=MagmadUtil.stateless_cmds.ENABLE,
         )
 
     def tearDown(self):
@@ -57,12 +56,12 @@ class TestNoIdentityRspWithMmeRestart(unittest.TestCase):
         attach_req.useOldSecCtxt = sec_ctxt
         print("Sending Attach Request for ue_id", req.ue_id)
         self._s1ap_wrapper._s1_util.issue_cmd(
-            s1ap_types.tfwCmd.UE_ATTACH_REQUEST, attach_req
+            s1ap_types.tfwCmd.UE_ATTACH_REQUEST, attach_req,
         )
 
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_IDENTITY_REQ_IND.value
+            response.msg_type, s1ap_types.tfwCmd.UE_IDENTITY_REQ_IND.value,
         )
         print(
             "Received Identity req ind ",
@@ -96,13 +95,13 @@ class TestNoIdentityRspWithMmeRestart(unittest.TestCase):
         attach_req.useOldSecCtxt = sec_ctxt
         print("Sending Attach Request for ue_id", req.ue_id)
         self._s1ap_wrapper._s1_util.issue_cmd(
-            s1ap_types.tfwCmd.UE_ATTACH_REQUEST, attach_req
+            s1ap_types.tfwCmd.UE_ATTACH_REQUEST, attach_req,
         )
 
         # Context release
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_CTX_REL_IND.value
+            response.msg_type, s1ap_types.tfwCmd.UE_CTX_REL_IND.value,
         )
         print("********** UE Context released **********")
 

--- a/lte/gateway/python/integ_tests/s1aptests/test_no_security_mode_complete.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_no_security_mode_complete.py
@@ -76,7 +76,7 @@ class TestNoSecurityModeComplete(unittest.TestCase):
         req = self._s1ap_wrapper.ue_req
         print(
             "************************* Running attach no security mode \
-            complete timer expiry test"
+            complete timer expiry test",
         )
 
         attach_req = s1ap_types.ueAttachRequest_t()
@@ -89,11 +89,11 @@ class TestNoSecurityModeComplete(unittest.TestCase):
         attach_req.useOldSecCtxt = sec_ctxt
 
         self._s1ap_wrapper._s1_util.issue_cmd(
-            s1ap_types.tfwCmd.UE_ATTACH_REQUEST, attach_req
+            s1ap_types.tfwCmd.UE_ATTACH_REQUEST, attach_req,
         )
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_AUTH_REQ_IND.value
+            response.msg_type, s1ap_types.tfwCmd.UE_AUTH_REQ_IND.value,
         )
         auth_res = s1ap_types.ueAuthResp_t()
         auth_res.ue_Id = req.ue_id
@@ -102,13 +102,13 @@ class TestNoSecurityModeComplete(unittest.TestCase):
         auth_res.sqnRcvd = sqnRecvd
 
         self._s1ap_wrapper._s1_util.issue_cmd(
-            s1ap_types.tfwCmd.UE_AUTH_RESP, auth_res
+            s1ap_types.tfwCmd.UE_AUTH_RESP, auth_res,
         )
         # Wait for timer expiry 5 times, until context is released
         for i in range(5):
             response = self._s1ap_wrapper.s1_util.get_response()
             self.assertEqual(
-                response.msg_type, s1ap_types.tfwCmd.UE_SEC_MOD_CMD_IND.value
+                response.msg_type, s1ap_types.tfwCmd.UE_SEC_MOD_CMD_IND.value,
             )
             print("************************* Timeout", i + 1)
 
@@ -116,7 +116,7 @@ class TestNoSecurityModeComplete(unittest.TestCase):
         # Context release
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_CTX_REL_IND.value
+            response.msg_type, s1ap_types.tfwCmd.UE_CTX_REL_IND.value,
         )
         print("************************* Context released")
 

--- a/lte/gateway/python/integ_tests/s1aptests/test_no_smc_with_mme_restart_reattach.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_no_smc_with_mme_restart_reattach.py
@@ -11,8 +11,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-import unittest
 import time
+import unittest
 
 import s1ap_types
 import s1ap_wrapper
@@ -22,7 +22,7 @@ from s1ap_utils import MagmadUtil
 class TestNoSmcWithMmeRestartReattach(unittest.TestCase):
     def setUp(self):
         self._s1ap_wrapper = s1ap_wrapper.TestWrapper(
-            stateless_mode=MagmadUtil.stateless_cmds.ENABLE
+            stateless_mode=MagmadUtil.stateless_cmds.ENABLE,
         )
 
     def tearDown(self):
@@ -47,11 +47,11 @@ class TestNoSmcWithMmeRestartReattach(unittest.TestCase):
 
         print("************* Send Attach Req for ue", req.ue_id)
         self._s1ap_wrapper._s1_util.issue_cmd(
-            s1ap_types.tfwCmd.UE_ATTACH_REQUEST, attach_req
+            s1ap_types.tfwCmd.UE_ATTACH_REQUEST, attach_req,
         )
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_AUTH_REQ_IND.value
+            response.msg_type, s1ap_types.tfwCmd.UE_AUTH_REQ_IND.value,
         )
         print("************* Received Auth Req for ue", req.ue_id)
         auth_res = s1ap_types.ueAuthResp_t()
@@ -62,12 +62,12 @@ class TestNoSmcWithMmeRestartReattach(unittest.TestCase):
 
         print("************* Send Auth Rsp for ue", req.ue_id)
         self._s1ap_wrapper._s1_util.issue_cmd(
-            s1ap_types.tfwCmd.UE_AUTH_RESP, auth_res
+            s1ap_types.tfwCmd.UE_AUTH_RESP, auth_res,
         )
 
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_SEC_MOD_CMD_IND.value
+            response.msg_type, s1ap_types.tfwCmd.UE_SEC_MOD_CMD_IND.value,
         )
 
         print("************* Received SMC for ue", req.ue_id)
@@ -86,7 +86,7 @@ class TestNoSmcWithMmeRestartReattach(unittest.TestCase):
             response = self._s1ap_wrapper.s1_util.get_response()
 
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_CTX_REL_IND.value
+            response.msg_type, s1ap_types.tfwCmd.UE_CTX_REL_IND.value,
         )
 
         print("****** Triggering end-end attach after mme restart *********")

--- a/lte/gateway/python/integ_tests/s1aptests/test_outoforder_attach_complete_ICSR.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_outoforder_attach_complete_ICSR.py
@@ -12,11 +12,11 @@ limitations under the License.
 """
 
 
+import time
 import unittest
 
 import s1ap_types
 import s1ap_wrapper
-import time
 
 
 class TestOutOfOrderAttachCompleteInitialCtxtSetupRsp(unittest.TestCase):
@@ -53,11 +53,11 @@ class TestOutOfOrderAttachCompleteInitialCtxtSetupRsp(unittest.TestCase):
         attach_req.pdnType_pr = pdn_type
 
         self._s1ap_wrapper._s1_util.issue_cmd(
-            s1ap_types.tfwCmd.UE_ATTACH_REQUEST, attach_req
+            s1ap_types.tfwCmd.UE_ATTACH_REQUEST, attach_req,
         )
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_AUTH_REQ_IND.value
+            response.msg_type, s1ap_types.tfwCmd.UE_AUTH_REQ_IND.value,
         )
 
         delay_init_ctxt_setup_resp = s1ap_types.UeDelayInitCtxtSetupRsp()
@@ -66,7 +66,7 @@ class TestOutOfOrderAttachCompleteInitialCtxtSetupRsp(unittest.TestCase):
         delay_init_ctxt_setup_resp.tmrVal = 2000
         print("*** Setting Initial Context Setup Resp Delay ***")
         self._s1ap_wrapper._s1_util.issue_cmd(
-            s1ap_types.tfwCmd.UE_SET_DELAY_ICS_RSP, delay_init_ctxt_setup_resp
+            s1ap_types.tfwCmd.UE_SET_DELAY_ICS_RSP, delay_init_ctxt_setup_resp,
         )
 
         # Trigger Authentication Response
@@ -76,41 +76,43 @@ class TestOutOfOrderAttachCompleteInitialCtxtSetupRsp(unittest.TestCase):
         sqnRecvd.pres = 0
         auth_res.sqnRcvd = sqnRecvd
         self._s1ap_wrapper._s1_util.issue_cmd(
-            s1ap_types.tfwCmd.UE_AUTH_RESP, auth_res
+            s1ap_types.tfwCmd.UE_AUTH_RESP, auth_res,
         )
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_SEC_MOD_CMD_IND.value
+            response.msg_type, s1ap_types.tfwCmd.UE_SEC_MOD_CMD_IND.value,
         )
 
         # Trigger Security Mode Complete
         sec_mode_complete = s1ap_types.ueSecModeComplete_t()
         sec_mode_complete.ue_Id = req.ue_id
         self._s1ap_wrapper._s1_util.issue_cmd(
-            s1ap_types.tfwCmd.UE_SEC_MOD_COMPLETE, sec_mode_complete
+            s1ap_types.tfwCmd.UE_SEC_MOD_COMPLETE, sec_mode_complete,
         )
 
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.INT_CTX_SETUP_IND.value
+            response.msg_type, s1ap_types.tfwCmd.INT_CTX_SETUP_IND.value,
         )
 
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_ATTACH_ACCEPT_IND.value
+            response.msg_type, s1ap_types.tfwCmd.UE_ATTACH_ACCEPT_IND.value,
         )
 
         # Trigger Attach Complete
         attach_complete = s1ap_types.ueAttachComplete_t()
         attach_complete.ue_Id = req.ue_id
         self._s1ap_wrapper._s1_util.issue_cmd(
-            s1ap_types.tfwCmd.UE_ATTACH_COMPLETE, attach_complete
+            s1ap_types.tfwCmd.UE_ATTACH_COMPLETE, attach_complete,
         )
 
         # Wait on EMM Information from MME
         self._s1ap_wrapper._s1_util.receive_emm_info()
-        print("************************* Running UE detach for UE id ",
-              req.ue_id)
+        print(
+            "************************* Running UE detach for UE id ",
+            req.ue_id,
+        )
         # Now detach the UE
         detach_req = s1ap_types.uedetachReq_t()
         detach_req.ue_Id = req.ue_id
@@ -118,12 +120,12 @@ class TestOutOfOrderAttachCompleteInitialCtxtSetupRsp(unittest.TestCase):
             s1ap_types.ueDetachType_t.UE_SWITCHOFF_DETACH.value
         )
         self._s1ap_wrapper._s1_util.issue_cmd(
-            s1ap_types.tfwCmd.UE_DETACH_REQUEST, detach_req
+            s1ap_types.tfwCmd.UE_DETACH_REQUEST, detach_req,
         )
         # Wait for UE context release command
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_CTX_REL_IND.value
+            response.msg_type, s1ap_types.tfwCmd.UE_CTX_REL_IND.value,
         )
 
         time.sleep(1)

--- a/lte/gateway/python/integ_tests/s1aptests/test_outoforder_erab_setup_rsp_dedicated_bearer.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_outoforder_erab_setup_rsp_dedicated_bearer.py
@@ -11,14 +11,14 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-import unittest
+import ipaddress
 import time
+import unittest
 
 import s1ap_types
 import s1ap_wrapper
-import ipaddress
-from lte.protos.policydb_pb2 import FlowMatch
 from integ_tests.s1aptests.s1ap_utils import SessionManagerUtil
+from lte.protos.policydb_pb2 import FlowMatch
 
 
 class TestOutOfOrderErabSetupRspDedicatedBearer(unittest.TestCase):
@@ -159,7 +159,7 @@ class TestOutOfOrderErabSetupRspDedicatedBearer(unittest.TestCase):
         )
         print(
             "Sent UE_SET_DELAY_ERAB_SETUP_RSP with delay value of %d secs"
-            % (delay_erab_setup_resp.tmrVal)
+            % (delay_erab_setup_resp.tmrVal),
         )
 
         print("Sleeping for 5 seconds")
@@ -178,7 +178,7 @@ class TestOutOfOrderErabSetupRspDedicatedBearer(unittest.TestCase):
         # Receive Activate dedicated bearer request
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_ACT_DED_BER_REQ.value
+            response.msg_type, s1ap_types.tfwCmd.UE_ACT_DED_BER_REQ.value,
         )
         act_ded_ber_ctxt_req = response.cast(s1ap_types.UeActDedBearCtxtReq_t)
 
@@ -186,7 +186,7 @@ class TestOutOfOrderErabSetupRspDedicatedBearer(unittest.TestCase):
         time.sleep(5)
         # Send Activate dedicated bearer accept
         self._s1ap_wrapper.sendActDedicatedBearerAccept(
-            ue_id, act_ded_ber_ctxt_req.bearerId
+            ue_id, act_ded_ber_ctxt_req.bearerId,
         )
         # Delay to ensure erab setup rsp is sent out of order
         print("Sleeping for 10 seconds")
@@ -199,7 +199,7 @@ class TestOutOfOrderErabSetupRspDedicatedBearer(unittest.TestCase):
         num_ul_flows = 2
         # Verify if flow rules are created
         self._s1ap_wrapper.s1_util.verify_flow_rules(
-            num_ul_flows, dl_flow_rules
+            num_ul_flows, dl_flow_rules,
         )
 
         print(
@@ -210,7 +210,7 @@ class TestOutOfOrderErabSetupRspDedicatedBearer(unittest.TestCase):
 
         # Now detach the UE
         self._s1ap_wrapper.s1_util.detach(
-            ue_id, s1ap_types.ueDetachType_t.UE_SWITCHOFF_DETACH.value, False
+            ue_id, s1ap_types.ueDetachType_t.UE_SWITCHOFF_DETACH.value, False,
         )
 
 

--- a/lte/gateway/python/integ_tests/s1aptests/test_outoforder_erab_setup_rsp_default_bearer.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_outoforder_erab_setup_rsp_default_bearer.py
@@ -11,12 +11,12 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-import unittest
+import ipaddress
 import time
+import unittest
 
 import s1ap_types
 import s1ap_wrapper
-import ipaddress
 
 
 class TestOutOfOrderErabSetupRspDefaultBearer(unittest.TestCase):
@@ -50,7 +50,7 @@ class TestOutOfOrderErabSetupRspDefaultBearer(unittest.TestCase):
         apn_list = [ims]
 
         self._s1ap_wrapper.configAPN(
-            "IMSI" + "".join([str(i) for i in req.imsi]), apn_list
+            "IMSI" + "".join([str(i) for i in req.imsi]), apn_list,
         )
         print(
             "************************* Running End to End attach for UE id ",
@@ -82,7 +82,7 @@ class TestOutOfOrderErabSetupRspDefaultBearer(unittest.TestCase):
         )
         print(
             "Sent UE_SET_DELAY_ERAB_SETUP_RSP with delay value of %d secs"
-            % (delay_erab_setup_resp.tmrVal)
+            % (delay_erab_setup_resp.tmrVal),
         )
 
         # Send PDN Connectivity Request
@@ -91,7 +91,7 @@ class TestOutOfOrderErabSetupRspDefaultBearer(unittest.TestCase):
         # Receive PDN CONN RSP/Activate default EPS bearer context request
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_PDN_CONN_RSP_IND.value
+            response.msg_type, s1ap_types.tfwCmd.UE_PDN_CONN_RSP_IND.value,
         )
         act_def_bearer_req = response.cast(s1ap_types.uePdnConRsp_t)
         addr = act_def_bearer_req.m.pdnInfo.pAddr.addrInfo
@@ -115,7 +115,7 @@ class TestOutOfOrderErabSetupRspDefaultBearer(unittest.TestCase):
         num_ul_flows = 2
         # Verify if flow rules are created
         self._s1ap_wrapper.s1_util.verify_flow_rules(
-            num_ul_flows, dl_flow_rules
+            num_ul_flows, dl_flow_rules,
         )
 
         # Send PDN Disconnect
@@ -125,23 +125,23 @@ class TestOutOfOrderErabSetupRspDefaultBearer(unittest.TestCase):
             act_def_bearer_req.m.pdnInfo.epsBearerId
         )
         self._s1ap_wrapper._s1_util.issue_cmd(
-            s1ap_types.tfwCmd.UE_PDN_DISCONNECT_REQ, pdn_disconnect_req
+            s1ap_types.tfwCmd.UE_PDN_DISCONNECT_REQ, pdn_disconnect_req,
         )
 
         # Receive UE_DEACTIVATE_BER_REQ
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_DEACTIVATE_BER_REQ.value
+            response.msg_type, s1ap_types.tfwCmd.UE_DEACTIVATE_BER_REQ.value,
         )
 
         print(
             "******************* Received deactivate eps bearer context"
-            " request"
+            " request",
         )
         # Send DeactDedicatedBearerAccept
         deactv_bearer_req = response.cast(s1ap_types.UeDeActvBearCtxtReq_t)
         self._s1ap_wrapper.sendDeactDedicatedBearerAccept(
-            ue_id, deactv_bearer_req.bearerId
+            ue_id, deactv_bearer_req.bearerId,
         )
 
         print(
@@ -151,7 +151,7 @@ class TestOutOfOrderErabSetupRspDefaultBearer(unittest.TestCase):
         )
         # Now detach the UE
         self._s1ap_wrapper.s1_util.detach(
-            ue_id, s1ap_types.ueDetachType_t.UE_SWITCHOFF_DETACH.value, False
+            ue_id, s1ap_types.ueDetachType_t.UE_SWITCHOFF_DETACH.value, False,
         )
 
 

--- a/lte/gateway/python/integ_tests/s1aptests/test_paging_request.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_paging_request.py
@@ -11,13 +11,12 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
+import time
 import unittest
-
 
 import gpp_types
 import s1ap_types
 import s1ap_wrapper
-import time
 
 
 class TestPagingRequest(unittest.TestCase):
@@ -73,11 +72,11 @@ class TestPagingRequest(unittest.TestCase):
             gpp_types.CauseRadioNetwork.USER_INACTIVITY.value
         )
         self._s1ap_wrapper.s1_util.issue_cmd(
-            s1ap_types.tfwCmd.UE_CNTXT_REL_REQUEST, ue_cntxt_rel_req
+            s1ap_types.tfwCmd.UE_CNTXT_REL_REQUEST, ue_cntxt_rel_req,
         )
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_CTX_REL_IND.value
+            response.msg_type, s1ap_types.tfwCmd.UE_CTX_REL_IND.value,
         )
 
         time.sleep(0.3)
@@ -86,7 +85,7 @@ class TestPagingRequest(unittest.TestCase):
             ue_id,
         )
         with self._s1ap_wrapper.configDownlinkTest(
-            req, duration=1, is_udp=True
+            req, duration=1, is_udp=True,
         ) as test:
             response = self._s1ap_wrapper.s1_util.get_response()
             self.assertTrue(response, s1ap_types.tfwCmd.UE_PAGING_IND.value)
@@ -97,18 +96,18 @@ class TestPagingRequest(unittest.TestCase):
             ser_req.ueMtmsi.pres = False
             ser_req.rrcCause = s1ap_types.Rrc_Cause.TFW_MO_DATA.value
             self._s1ap_wrapper.s1_util.issue_cmd(
-                s1ap_types.tfwCmd.UE_SERVICE_REQUEST, ser_req
+                s1ap_types.tfwCmd.UE_SERVICE_REQUEST, ser_req,
             )
             response = self._s1ap_wrapper.s1_util.get_response()
             self.assertEqual(
-                response.msg_type, s1ap_types.tfwCmd.INT_CTX_SETUP_IND.value
+                response.msg_type, s1ap_types.tfwCmd.INT_CTX_SETUP_IND.value,
             )
             test.verify()
 
         time.sleep(0.5)
         # Now detach the UE
         self._s1ap_wrapper.s1_util.detach(
-            ue_id, s1ap_types.ueDetachType_t.UE_NORMAL_DETACH.value, True
+            ue_id, s1ap_types.ueDetachType_t.UE_NORMAL_DETACH.value, True,
         )
         time.sleep(0.5)
 

--- a/lte/gateway/python/integ_tests/s1aptests/test_paging_with_mme_restart.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_paging_with_mme_restart.py
@@ -11,20 +11,20 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
+import time
 import unittest
-
 
 import gpp_types
 import s1ap_types
 import s1ap_wrapper
-import time
 from s1ap_utils import MagmadUtil
 
 
 class TestPagingWithMmeRestart(unittest.TestCase):
     def setUp(self):
         self._s1ap_wrapper = s1ap_wrapper.TestWrapper(
-            stateless_mode=MagmadUtil.stateless_cmds.ENABLE)
+            stateless_mode=MagmadUtil.stateless_cmds.ENABLE,
+        )
 
     def tearDown(self):
         self._s1ap_wrapper.cleanup()
@@ -79,11 +79,11 @@ class TestPagingWithMmeRestart(unittest.TestCase):
             gpp_types.CauseRadioNetwork.USER_INACTIVITY.value
         )
         self._s1ap_wrapper.s1_util.issue_cmd(
-            s1ap_types.tfwCmd.UE_CNTXT_REL_REQUEST, ue_cntxt_rel_req
+            s1ap_types.tfwCmd.UE_CNTXT_REL_REQUEST, ue_cntxt_rel_req,
         )
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_CTX_REL_IND.value
+            response.msg_type, s1ap_types.tfwCmd.UE_CTX_REL_IND.value,
         )
 
         time.sleep(0.3)
@@ -92,14 +92,16 @@ class TestPagingWithMmeRestart(unittest.TestCase):
             ue_id,
         )
         with self._s1ap_wrapper.configDownlinkTest(
-            req, duration=1, is_udp=True
+            req, duration=1, is_udp=True,
         ) as test:
             response = self._s1ap_wrapper.s1_util.get_response()
             self.assertTrue(response, s1ap_types.tfwCmd.UE_PAGING_IND.value)
             print("************************ Received Paging Indication")
 
-            print("************************* Restarting MME service on",
-                  "gateway")
+            print(
+                "************************* Restarting MME service on",
+                "gateway",
+            )
             self._s1ap_wrapper.magmad_util.restart_services(["mme"])
 
             for j in range(30):
@@ -128,18 +130,18 @@ class TestPagingWithMmeRestart(unittest.TestCase):
             ser_req.ueMtmsi.pres = False
             ser_req.rrcCause = s1ap_types.Rrc_Cause.TFW_MT_ACCESS.value
             self._s1ap_wrapper.s1_util.issue_cmd(
-                s1ap_types.tfwCmd.UE_SERVICE_REQUEST, ser_req
+                s1ap_types.tfwCmd.UE_SERVICE_REQUEST, ser_req,
             )
             response = self._s1ap_wrapper.s1_util.get_response()
             self.assertEqual(
-                response.msg_type, s1ap_types.tfwCmd.INT_CTX_SETUP_IND.value
+                response.msg_type, s1ap_types.tfwCmd.INT_CTX_SETUP_IND.value,
             )
             test.verify()
 
         time.sleep(0.5)
         # Now detach the UE
         self._s1ap_wrapper.s1_util.detach(
-            ue_id, s1ap_types.ueDetachType_t.UE_NORMAL_DETACH.value, True
+            ue_id, s1ap_types.ueDetachType_t.UE_NORMAL_DETACH.value, True,
         )
         time.sleep(0.5)
 

--- a/lte/gateway/python/integ_tests/s1aptests/test_restore_mme_config_after_sanity.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_restore_mme_config_after_sanity.py
@@ -32,11 +32,12 @@ class TestRestoreMMEConfigAfterSanity(unittest.TestCase):
         # test script s1aptests/test_modify_mme_config_for_sanity.py
         print(
             "Restoring MME configuration to default values using backup "
-            "configuration file"
+            "configuration file",
         )
         self._magmad_util.update_mme_config_for_sanity(
-            MagmadUtil.config_update_cmds.RESTORE
+            MagmadUtil.config_update_cmds.RESTORE,
         )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/lte/gateway/python/integ_tests/s1aptests/test_resync.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_resync.py
@@ -46,11 +46,11 @@ class TestSync(unittest.TestCase):
 
         # Trigger Attach
         self._s1ap_wrapper._s1_util.issue_cmd(
-            s1ap_types.tfwCmd.UE_ATTACH_REQUEST, attach_req
+            s1ap_types.tfwCmd.UE_ATTACH_REQUEST, attach_req,
         )
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_AUTH_REQ_IND.value
+            response.msg_type, s1ap_types.tfwCmd.UE_AUTH_REQ_IND.value,
         )
         auth_res = s1ap_types.ueAuthResp_t()
         auth_res.ue_Id = req.ue_id
@@ -65,47 +65,47 @@ class TestSync(unittest.TestCase):
         auth_res.sqnRcvd = sqnRecvd
         auth_res.maxSqnRcvd = maxSqnRecvd
         self._s1ap_wrapper._s1_util.issue_cmd(
-            s1ap_types.tfwCmd.UE_AUTH_RESP, auth_res
+            s1ap_types.tfwCmd.UE_AUTH_RESP, auth_res,
         )
         response = self._s1ap_wrapper.s1_util.get_response()
 
         # Verify that EPC re-sends Authentication Request
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_AUTH_REQ_IND.value
+            response.msg_type, s1ap_types.tfwCmd.UE_AUTH_REQ_IND.value,
         )
         print("************************* Retrying authentication")
         # Use SQN received from EPC as is
         sqnRecvd.pres = False
         auth_res.sqnRcvd = sqnRecvd
         self._s1ap_wrapper._s1_util.issue_cmd(
-            s1ap_types.tfwCmd.UE_AUTH_RESP, auth_res
+            s1ap_types.tfwCmd.UE_AUTH_RESP, auth_res,
         )
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_SEC_MOD_CMD_IND.value
+            response.msg_type, s1ap_types.tfwCmd.UE_SEC_MOD_CMD_IND.value,
         )
 
         # Trigger Security mode complete message
         sec_mode_complete = s1ap_types.ueSecModeComplete_t()
         sec_mode_complete.ue_Id = req.ue_id
         self._s1ap_wrapper._s1_util.issue_cmd(
-            s1ap_types.tfwCmd.UE_SEC_MOD_COMPLETE, sec_mode_complete
+            s1ap_types.tfwCmd.UE_SEC_MOD_COMPLETE, sec_mode_complete,
         )
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.INT_CTX_SETUP_IND.value
+            response.msg_type, s1ap_types.tfwCmd.INT_CTX_SETUP_IND.value,
         )
 
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_ATTACH_ACCEPT_IND.value
+            response.msg_type, s1ap_types.tfwCmd.UE_ATTACH_ACCEPT_IND.value,
         )
 
         # Trigger Attach complete message
         attach_complete = s1ap_types.ueAttachComplete_t()
         attach_complete.ue_Id = req.ue_id
         self._s1ap_wrapper._s1_util.issue_cmd(
-            s1ap_types.tfwCmd.UE_ATTACH_COMPLETE, attach_complete
+            s1ap_types.tfwCmd.UE_ATTACH_COMPLETE, attach_complete,
         )
         print("************************* UE Attach Complete")
 
@@ -120,11 +120,11 @@ class TestSync(unittest.TestCase):
             s1ap_types.ueDetachType_t.UE_SWITCHOFF_DETACH.value
         )
         self._s1ap_wrapper._s1_util.issue_cmd(
-            s1ap_types.tfwCmd.UE_DETACH_REQUEST, detach_req
+            s1ap_types.tfwCmd.UE_DETACH_REQUEST, detach_req,
         )
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_CTX_REL_IND.value
+            response.msg_type, s1ap_types.tfwCmd.UE_CTX_REL_IND.value,
         )
 
 

--- a/lte/gateway/python/integ_tests/s1aptests/test_s1setup_incorrect_plmn.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_s1setup_incorrect_plmn.py
@@ -11,8 +11,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-import unittest
 import ctypes
+import unittest
+
 import s1ap_types
 from integ_tests.s1aptests.s1ap_utils import S1ApUtil
 
@@ -37,7 +38,7 @@ class TestS1SetupFailureIncorrectPlmn(unittest.TestCase):
         # Convert PLMN to ASCII character array of MCC and MNC digits
         # For 5 digit PLMN add \0 in the end, e.g., "00101\0"
         req.plmnId_pr.plmn_id = (ctypes.c_ubyte * 6).from_buffer_copy(
-            bytearray(b"333333")
+            bytearray(b"333333"),
         )
 
         print("************************* Sending ENB configuration Request")

--- a/lte/gateway/python/integ_tests/s1aptests/test_s1setup_incorrect_tac.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_s1setup_incorrect_tac.py
@@ -12,6 +12,7 @@ limitations under the License.
 """
 
 import unittest
+
 import s1ap_types
 from integ_tests.s1aptests.s1ap_utils import S1ApUtil
 

--- a/lte/gateway/python/integ_tests/s1aptests/test_sctp_abort_after_auth_req.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_sctp_abort_after_auth_req.py
@@ -14,7 +14,6 @@ limitations under the License.
 import unittest
 
 import s1ap_types
-
 from integ_tests.s1aptests import s1ap_wrapper
 
 
@@ -46,22 +45,22 @@ class TestSctpAbortAfterAuthReq(unittest.TestCase):
         attach_req.useOldSecCtxt = sec_ctxt
         print("Sending Attach Request ue-id", req.ue_id)
         self._s1ap_wrapper._s1_util.issue_cmd(
-            s1ap_types.tfwCmd.UE_ATTACH_REQUEST, attach_req
+            s1ap_types.tfwCmd.UE_ATTACH_REQUEST, attach_req,
         )
 
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_AUTH_REQ_IND.value
+            response.msg_type, s1ap_types.tfwCmd.UE_AUTH_REQ_IND.value,
         )
         print(
-            "Received auth req ind ", s1ap_types.tfwCmd.UE_AUTH_REQ_IND.value
+            "Received auth req ind ", s1ap_types.tfwCmd.UE_AUTH_REQ_IND.value,
         )
 
         print("send SCTP ABORT")
         sctp_abort = s1ap_types.FwSctpAbortReq_t()
         sctp_abort.cause = 3
         self._s1ap_wrapper._s1_util.issue_cmd(
-            s1ap_types.tfwCmd.SCTP_ABORT_REQ, sctp_abort
+            s1ap_types.tfwCmd.SCTP_ABORT_REQ, sctp_abort,
         )
 
 

--- a/lte/gateway/python/integ_tests/s1aptests/test_sctp_abort_after_identity_req.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_sctp_abort_after_identity_req.py
@@ -14,7 +14,6 @@ limitations under the License.
 import unittest
 
 import s1ap_types
-
 from integ_tests.s1aptests import s1ap_wrapper
 
 
@@ -46,12 +45,12 @@ class TestSctpAbortAfterIdentityReq(unittest.TestCase):
         attach_req.useOldSecCtxt = sec_ctxt
         print("Sending Attach Request ue-id", req.ue_id)
         self._s1ap_wrapper._s1_util.issue_cmd(
-            s1ap_types.tfwCmd.UE_ATTACH_REQUEST, attach_req
+            s1ap_types.tfwCmd.UE_ATTACH_REQUEST, attach_req,
         )
 
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_IDENTITY_REQ_IND.value
+            response.msg_type, s1ap_types.tfwCmd.UE_IDENTITY_REQ_IND.value,
         )
         print(
             "Received Identity req ind ",
@@ -62,7 +61,7 @@ class TestSctpAbortAfterIdentityReq(unittest.TestCase):
         sctp_abort = s1ap_types.FwSctpAbortReq_t()
         sctp_abort.cause = 3
         self._s1ap_wrapper._s1_util.issue_cmd(
-            s1ap_types.tfwCmd.SCTP_ABORT_REQ, sctp_abort
+            s1ap_types.tfwCmd.SCTP_ABORT_REQ, sctp_abort,
         )
 
 

--- a/lte/gateway/python/integ_tests/s1aptests/test_sctp_abort_after_smc.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_sctp_abort_after_smc.py
@@ -14,7 +14,6 @@ limitations under the License.
 import unittest
 
 import s1ap_types
-
 from integ_tests.s1aptests import s1ap_wrapper
 
 
@@ -46,12 +45,12 @@ class TestSctpAbortAfterSmc(unittest.TestCase):
         attach_req.useOldSecCtxt = sec_ctxt
         print("Sending Attach Request ue-id", req.ue_id)
         self._s1ap_wrapper._s1_util.issue_cmd(
-            s1ap_types.tfwCmd.UE_ATTACH_REQUEST, attach_req
+            s1ap_types.tfwCmd.UE_ATTACH_REQUEST, attach_req,
         )
 
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_AUTH_REQ_IND.value
+            response.msg_type, s1ap_types.tfwCmd.UE_AUTH_REQ_IND.value,
         )
         print("Received auth req ind ue-id", req.ue_id)
 
@@ -62,12 +61,12 @@ class TestSctpAbortAfterSmc(unittest.TestCase):
         auth_res.sqnRcvd = sqn_recvd
         print("Sending Auth Response ue-id", req.ue_id)
         self._s1ap_wrapper._s1_util.issue_cmd(
-            s1ap_types.tfwCmd.UE_AUTH_RESP, auth_res
+            s1ap_types.tfwCmd.UE_AUTH_RESP, auth_res,
         )
 
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_SEC_MOD_CMD_IND.value
+            response.msg_type, s1ap_types.tfwCmd.UE_SEC_MOD_CMD_IND.value,
         )
         print("Received Security Mode Command ue-id", req.ue_id)
 
@@ -75,7 +74,7 @@ class TestSctpAbortAfterSmc(unittest.TestCase):
         sctp_abort = s1ap_types.FwSctpAbortReq_t()
         sctp_abort.cause = 3
         self._s1ap_wrapper._s1_util.issue_cmd(
-            s1ap_types.tfwCmd.SCTP_ABORT_REQ, sctp_abort
+            s1ap_types.tfwCmd.SCTP_ABORT_REQ, sctp_abort,
         )
 
 

--- a/lte/gateway/python/integ_tests/s1aptests/test_sctp_shutdown_after_auth_req.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_sctp_shutdown_after_auth_req.py
@@ -14,7 +14,6 @@ limitations under the License.
 import unittest
 
 import s1ap_types
-
 from integ_tests.s1aptests import s1ap_wrapper
 
 
@@ -46,18 +45,18 @@ class TestSctpShutdownAfterAuthReq(unittest.TestCase):
         attach_req.useOldSecCtxt = sec_ctxt
         print("Sending Attach Request ue-id", req.ue_id)
         self._s1ap_wrapper._s1_util.issue_cmd(
-            s1ap_types.tfwCmd.UE_ATTACH_REQUEST, attach_req
+            s1ap_types.tfwCmd.UE_ATTACH_REQUEST, attach_req,
         )
 
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_AUTH_REQ_IND.value
+            response.msg_type, s1ap_types.tfwCmd.UE_AUTH_REQ_IND.value,
         )
         print("Received auth req ind ue-id", req.ue_id)
 
         print("send SCTP SHUTDOWN")
         self._s1ap_wrapper._s1_util.issue_cmd(
-            s1ap_types.tfwCmd.SCTP_SHUTDOWN_REQ, None
+            s1ap_types.tfwCmd.SCTP_SHUTDOWN_REQ, None,
         )
 
 

--- a/lte/gateway/python/integ_tests/s1aptests/test_sctp_shutdown_after_identity_req.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_sctp_shutdown_after_identity_req.py
@@ -14,7 +14,6 @@ limitations under the License.
 import unittest
 
 import s1ap_types
-
 from integ_tests.s1aptests import s1ap_wrapper
 
 
@@ -46,12 +45,12 @@ class TestSctpShutdownAfterIdentityReq(unittest.TestCase):
         attach_req.useOldSecCtxt = sec_ctxt
         print("Sending Attach Request ue-id", req.ue_id)
         self._s1ap_wrapper._s1_util.issue_cmd(
-            s1ap_types.tfwCmd.UE_ATTACH_REQUEST, attach_req
+            s1ap_types.tfwCmd.UE_ATTACH_REQUEST, attach_req,
         )
 
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_IDENTITY_REQ_IND.value
+            response.msg_type, s1ap_types.tfwCmd.UE_IDENTITY_REQ_IND.value,
         )
         print(
             "Received Identity req ind ",
@@ -60,7 +59,7 @@ class TestSctpShutdownAfterIdentityReq(unittest.TestCase):
 
         print("send SCTP SHUTDOWN")
         self._s1ap_wrapper._s1_util.issue_cmd(
-            s1ap_types.tfwCmd.SCTP_SHUTDOWN_REQ, None
+            s1ap_types.tfwCmd.SCTP_SHUTDOWN_REQ, None,
         )
 
 

--- a/lte/gateway/python/integ_tests/s1aptests/test_sctp_shutdown_after_multi_ue_attach.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_sctp_shutdown_after_multi_ue_attach.py
@@ -12,6 +12,7 @@ limitations under the License.
 """
 
 import unittest
+
 import s1ap_types
 import s1ap_wrapper
 
@@ -24,7 +25,7 @@ class TestSctpShutdownAfterMultiUeAttach(unittest.TestCase):
         self._s1ap_wrapper.cleanup()
         print(
             "Restart sctpd service to clear Redis state as test case doesn't"
-            " intend to initiate detach procedure"
+            " intend to initiate detach procedure",
         )
         self._s1ap_wrapper.magmad_util.restart_sctpd()
         self._s1ap_wrapper.magmad_util.print_redis_state()

--- a/lte/gateway/python/integ_tests/s1aptests/test_sctp_shutdown_after_smc.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_sctp_shutdown_after_smc.py
@@ -14,7 +14,6 @@ limitations under the License.
 import unittest
 
 import s1ap_types
-
 from integ_tests.s1aptests import s1ap_wrapper
 
 
@@ -47,12 +46,12 @@ class TestSctpShutdownAfterSmc(unittest.TestCase):
         attach_req.useOldSecCtxt = sec_ctxt
         print("Sending Attach Request ue-id", req.ue_id)
         self._s1ap_wrapper._s1_util.issue_cmd(
-            s1ap_types.tfwCmd.UE_ATTACH_REQUEST, attach_req
+            s1ap_types.tfwCmd.UE_ATTACH_REQUEST, attach_req,
         )
 
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_AUTH_REQ_IND.value
+            response.msg_type, s1ap_types.tfwCmd.UE_AUTH_REQ_IND.value,
         )
         print("Received auth req ind ue-id", req.ue_id)
 
@@ -63,19 +62,19 @@ class TestSctpShutdownAfterSmc(unittest.TestCase):
         auth_res.sqnRcvd = sqn_recvd
         print("Sending Auth Response ue-id", req.ue_id)
         self._s1ap_wrapper._s1_util.issue_cmd(
-            s1ap_types.tfwCmd.UE_AUTH_RESP, auth_res
+            s1ap_types.tfwCmd.UE_AUTH_RESP, auth_res,
         )
 
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_SEC_MOD_CMD_IND.value
+            response.msg_type, s1ap_types.tfwCmd.UE_SEC_MOD_CMD_IND.value,
         )
         print("Received Security Mode Command ue-id", req.ue_id)
 
         print("send SCTP SHUTDOWN")
 
         self._s1ap_wrapper._s1_util.issue_cmd(
-            s1ap_types.tfwCmd.SCTP_SHUTDOWN_REQ, None
+            s1ap_types.tfwCmd.SCTP_SHUTDOWN_REQ, None,
         )
 
 

--- a/lte/gateway/python/integ_tests/s1aptests/test_sctp_shutdown_while_mme_is_stopped.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_sctp_shutdown_while_mme_is_stopped.py
@@ -15,7 +15,6 @@ import time
 import unittest
 
 import s1ap_types
-
 from integ_tests.s1aptests import s1ap_wrapper
 
 
@@ -57,12 +56,12 @@ class TestSctpShutdowniWhileStatelessMmeIsStopped(unittest.TestCase):
 
         print("Stopping MME service")
         self._s1ap_wrapper.magmad_util.exec_command(
-            "sudo service magma@mme stop"
+            "sudo service magma@mme stop",
         )
 
         print("send SCTP SHUTDOWN")
         self._s1ap_wrapper._s1_util.issue_cmd(
-            s1ap_types.tfwCmd.SCTP_SHUTDOWN_REQ, None
+            s1ap_types.tfwCmd.SCTP_SHUTDOWN_REQ, None,
         )
 
         print("Redis state after SCTP shutdown")
@@ -70,16 +69,16 @@ class TestSctpShutdowniWhileStatelessMmeIsStopped(unittest.TestCase):
 
         print("Starting MME service and waiting for 20 seconds")
         self._s1ap_wrapper.magmad_util.exec_command(
-            "sudo service magma@mobilityd start"
+            "sudo service magma@mobilityd start",
         )
         self._s1ap_wrapper.magmad_util.exec_command(
-            "sudo service magma@pipelined start"
+            "sudo service magma@pipelined start",
         )
         self._s1ap_wrapper.magmad_util.exec_command(
-            "sudo service magma@sessiond start"
+            "sudo service magma@sessiond start",
         )
         self._s1ap_wrapper.magmad_util.exec_command(
-            "sudo service magma@mme start"
+            "sudo service magma@mme start",
         )
         time.sleep(30)
 
@@ -93,7 +92,7 @@ class TestSctpShutdowniWhileStatelessMmeIsStopped(unittest.TestCase):
         )
 
         self._s1ap_wrapper.s1_util.detach(
-            req.ue_id, s1ap_types.ueDetachType_t.UE_NORMAL_DETACH.value, True
+            req.ue_id, s1ap_types.ueDetachType_t.UE_NORMAL_DETACH.value, True,
         )
 
 

--- a/lte/gateway/python/integ_tests/s1aptests/test_secondary_pdn_with_dedicated_bearer_multiple_services_restart.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_secondary_pdn_with_dedicated_bearer_multiple_services_restart.py
@@ -11,9 +11,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-import unittest
-import time
 import ipaddress
+import time
+import unittest
+
 import s1ap_types
 import s1ap_wrapper
 from integ_tests.s1aptests.s1ap_utils import SessionManagerUtil
@@ -22,11 +23,11 @@ from s1ap_utils import MagmadUtil
 
 
 class TestSecondaryPdnWithDedicatedBearerMultipleServicesRestart(
-    unittest.TestCase
+    unittest.TestCase,
 ):
     def setUp(self):
         self._s1ap_wrapper = s1ap_wrapper.TestWrapper(
-            stateless_mode=MagmadUtil.stateless_cmds.ENABLE
+            stateless_mode=MagmadUtil.stateless_cmds.ENABLE,
         )
 
         self._sessionManager_util = SessionManagerUtil()
@@ -59,7 +60,7 @@ class TestSecondaryPdnWithDedicatedBearerMultipleServicesRestart(
         apn_list = [ims]
 
         self._s1ap_wrapper.configAPN(
-            "IMSI" + "".join([str(i) for i in req.imsi]), apn_list
+            "IMSI" + "".join([str(i) for i in req.imsi]), apn_list,
         )
         print(
             "************************* Running End to End attach for UE id ",
@@ -193,7 +194,7 @@ class TestSecondaryPdnWithDedicatedBearerMultipleServicesRestart(
         # Add dedicated bearer for default bearer 5
         print(
             "********************** Adding dedicated bearer to magma.ipv4"
-            " PDN"
+            " PDN",
         )
         print(
             "********************** Sending RAR for IMSI",
@@ -208,13 +209,13 @@ class TestSecondaryPdnWithDedicatedBearerMultipleServicesRestart(
 
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_ACT_DED_BER_REQ.value
+            response.msg_type, s1ap_types.tfwCmd.UE_ACT_DED_BER_REQ.value,
         )
         act_ded_ber_req_oai_apn = response.cast(
-            s1ap_types.UeActDedBearCtxtReq_t
+            s1ap_types.UeActDedBearCtxtReq_t,
         )
         self._s1ap_wrapper.sendActDedicatedBearerAccept(
-            req.ue_id, act_ded_ber_req_oai_apn.bearerId
+            req.ue_id, act_ded_ber_req_oai_apn.bearerId,
         )
 
         print("Sleeping for 5 seconds")
@@ -225,7 +226,7 @@ class TestSecondaryPdnWithDedicatedBearerMultipleServicesRestart(
         # Receive PDN CONN RSP/Activate default EPS bearer context request
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_PDN_CONN_RSP_IND.value
+            response.msg_type, s1ap_types.tfwCmd.UE_PDN_CONN_RSP_IND.value,
         )
         act_def_bearer_req = response.cast(s1ap_types.uePdnConRsp_t)
         addr = act_def_bearer_req.m.pdnInfo.pAddr.addrInfo
@@ -254,13 +255,13 @@ class TestSecondaryPdnWithDedicatedBearerMultipleServicesRestart(
 
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_ACT_DED_BER_REQ.value
+            response.msg_type, s1ap_types.tfwCmd.UE_ACT_DED_BER_REQ.value,
         )
         act_ded_ber_req_ims_apn = response.cast(
-            s1ap_types.UeActDedBearCtxtReq_t
+            s1ap_types.UeActDedBearCtxtReq_t,
         )
         self._s1ap_wrapper.sendActDedicatedBearerAccept(
-            req.ue_id, act_ded_ber_req_ims_apn.bearerId
+            req.ue_id, act_ded_ber_req_ims_apn.bearerId,
         )
         print(
             "************* Added dedicated bearer",
@@ -278,7 +279,7 @@ class TestSecondaryPdnWithDedicatedBearerMultipleServicesRestart(
         num_ul_flows = 4
         # Verify if flow rules are created
         self._s1ap_wrapper.s1_util.verify_flow_rules(
-            num_ul_flows, dl_flow_rules
+            num_ul_flows, dl_flow_rules,
         )
 
         print(
@@ -286,7 +287,7 @@ class TestSecondaryPdnWithDedicatedBearerMultipleServicesRestart(
             "Pipelined services on gateway",
         )
         self._s1ap_wrapper.magmad_util.restart_services(
-            ["sessiond", "mme", "pipelined"]
+            ["sessiond", "mme", "pipelined"],
         )
 
         for j in range(30):
@@ -298,7 +299,7 @@ class TestSecondaryPdnWithDedicatedBearerMultipleServicesRestart(
 
         # Verify flow rules
         self._s1ap_wrapper.s1_util.verify_flow_rules(
-            num_ul_flows, dl_flow_rules
+            num_ul_flows, dl_flow_rules,
         )
 
         print("Sleeping for 5 seconds")
@@ -306,7 +307,7 @@ class TestSecondaryPdnWithDedicatedBearerMultipleServicesRestart(
         print("************************* Running UE detach for UE id ", ue_id)
         # Now detach the UE
         self._s1ap_wrapper.s1_util.detach(
-            ue_id, s1ap_types.ueDetachType_t.UE_SWITCHOFF_DETACH.value, True
+            ue_id, s1ap_types.ueDetachType_t.UE_SWITCHOFF_DETACH.value, True,
         )
 
 

--- a/lte/gateway/python/integ_tests/s1aptests/test_service_req_ul_udp_data_with_mme_restart.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_service_req_ul_udp_data_with_mme_restart.py
@@ -11,8 +11,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-import unittest
 import time
+import unittest
 
 import gpp_types
 import s1ap_types
@@ -23,7 +23,7 @@ from s1ap_utils import MagmadUtil
 class TestServiceReqUlUdpDataWithMmeRestart(unittest.TestCase):
     def setUp(self):
         self._s1ap_wrapper = s1ap_wrapper.TestWrapper(
-            stateless_mode=MagmadUtil.stateless_cmds.ENABLE
+            stateless_mode=MagmadUtil.stateless_cmds.ENABLE,
         )
 
     def tearDown(self):
@@ -64,7 +64,7 @@ class TestServiceReqUlUdpDataWithMmeRestart(unittest.TestCase):
         time.sleep(0.5)
 
         ul_test = self._s1ap_wrapper.configUplinkTest(
-            req, duration=1, is_udp=True
+            req, duration=1, is_udp=True,
         )
 
         print(
@@ -77,11 +77,11 @@ class TestServiceReqUlUdpDataWithMmeRestart(unittest.TestCase):
         req.ue_Id = ue_id
         req.cause.causeVal = gpp_types.CauseRadioNetwork.USER_INACTIVITY.value
         self._s1ap_wrapper.s1_util.issue_cmd(
-            s1ap_types.tfwCmd.UE_CNTXT_REL_REQUEST, req
+            s1ap_types.tfwCmd.UE_CNTXT_REL_REQUEST, req,
         )
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_CTX_REL_IND.value
+            response.msg_type, s1ap_types.tfwCmd.UE_CTX_REL_IND.value,
         )
 
         print("************************* Restarting MME service on gateway")
@@ -102,7 +102,7 @@ class TestServiceReqUlUdpDataWithMmeRestart(unittest.TestCase):
         req.ueMtmsi.pres = False
         req.rrcCause = s1ap_types.Rrc_Cause.TFW_MO_DATA.value
         self._s1ap_wrapper.s1_util.issue_cmd(
-            s1ap_types.tfwCmd.UE_SERVICE_REQUEST, req
+            s1ap_types.tfwCmd.UE_SERVICE_REQUEST, req,
         )
 
         # Ignore PAGING_IND and wait for INT_CTX_SETUP_IND
@@ -114,7 +114,7 @@ class TestServiceReqUlUdpDataWithMmeRestart(unittest.TestCase):
             response = self._s1ap_wrapper.s1_util.get_response()
 
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.INT_CTX_SETUP_IND.value
+            response.msg_type, s1ap_types.tfwCmd.INT_CTX_SETUP_IND.value,
         )
 
         print(
@@ -128,7 +128,7 @@ class TestServiceReqUlUdpDataWithMmeRestart(unittest.TestCase):
         print("************************* Running UE detach for UE id ", ue_id)
         # Now detach the UE
         self._s1ap_wrapper.s1_util.detach(
-            ue_id, s1ap_types.ueDetachType_t.UE_SWITCHOFF_DETACH.value, True
+            ue_id, s1ap_types.ueDetachType_t.UE_SWITCHOFF_DETACH.value, True,
         )
 
 

--- a/lte/gateway/python/integ_tests/s1aptests/test_standalone_pdn_conn_req.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_standalone_pdn_conn_req.py
@@ -11,14 +11,14 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
+import ctypes
 import threading
-import unittest
 import time
+import unittest
 
 import gpp_types
 import s1ap_types
 import s1ap_wrapper
-import ctypes
 
 
 class TestStandAlonePdnConnReq(unittest.TestCase):
@@ -36,19 +36,24 @@ class TestStandAlonePdnConnReq(unittest.TestCase):
         self._s1ap_wrapper.configUEDevice(1)
         req = self._s1ap_wrapper.ue_req
         ue_id = req.ue_id
-        print("************************* Running End to End attach for UE id ",
-              ue_id)
+        print(
+            "************************* Running End to End attach for UE id ",
+            ue_id,
+        )
         # Now actually complete the attach
         self._s1ap_wrapper.s1_util.attach(
             ue_id, s1ap_types.tfwCmd.UE_END_TO_END_ATTACH_REQUEST,
             s1ap_types.tfwCmd.UE_ATTACH_ACCEPT_IND,
-            s1ap_types.ueAttachAccept_t)
+            s1ap_types.ueAttachAccept_t,
+        )
 
         # Wait on EMM Information from MME
         self._s1ap_wrapper._s1_util.receive_emm_info()
 
-        print("************************* Sending PDN Connectivity Request ",
-              "for UE id ", ue_id)
+        print(
+            "************************* Sending PDN Connectivity Request ",
+            "for UE id ", ue_id,
+        )
         req = s1ap_types.uepdnConReq_t()
         req.ue_Id = ue_id
         # Request type = Initial Request
@@ -61,18 +66,23 @@ class TestStandAlonePdnConnReq(unittest.TestCase):
         req.pdnAPN_pr.len = len(s)
         req.pdnAPN_pr.pdn_apn = (ctypes.c_ubyte * 100)(*[ctypes.c_ubyte(ord(c)) for c in s[:100]])
         self._s1ap_wrapper.s1_util.issue_cmd(
-            s1ap_types.tfwCmd.UE_PDN_CONN_REQ, req)
+            s1ap_types.tfwCmd.UE_PDN_CONN_REQ, req,
+        )
         # Receive PDN Connectivity Reject
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_PDN_CONN_RSP_IND.value)
+            response.msg_type, s1ap_types.tfwCmd.UE_PDN_CONN_RSP_IND.value,
+        )
 
         print("Received PDN CONNECTIVITY REJECT")
-        print("************************* Running UE detach (switch-off) for ",
-              "UE id ", ue_id)
+        print(
+            "************************* Running UE detach (switch-off) for ",
+            "UE id ", ue_id,
+        )
         # Now detach the UE
         self._s1ap_wrapper.s1_util.detach(
-            ue_id, s1ap_types.ueDetachType_t.UE_SWITCHOFF_DETACH.value, False)
+            ue_id, s1ap_types.ueDetachType_t.UE_SWITCHOFF_DETACH.value, False,
+        )
 
 
 if __name__ == "__main__":

--- a/lte/gateway/python/integ_tests/s1aptests/test_standalone_pdn_conn_req_with_apn_correction.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_standalone_pdn_conn_req_with_apn_correction.py
@@ -11,22 +11,23 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
+import ctypes
 import threading
-import unittest
 import time
+import unittest
 
-from s1ap_utils import MagmadUtil
 import gpp_types
 import s1ap_types
 import s1ap_wrapper
-import ctypes
+from s1ap_utils import MagmadUtil
 
 
 class TestStandAlonePdnConnReqWithApnCorrection(unittest.TestCase):
 
     def setUp(self):
         self._s1ap_wrapper = s1ap_wrapper.TestWrapper(
-                apn_correction=MagmadUtil.apn_correction_cmds.ENABLE)
+                apn_correction=MagmadUtil.apn_correction_cmds.ENABLE,
+        )
 
     def tearDown(self):
         self._s1ap_wrapper.cleanup()
@@ -46,19 +47,24 @@ class TestStandAlonePdnConnReqWithApnCorrection(unittest.TestCase):
         self._s1ap_wrapper.configUEDevice(num_ues)
         req = self._s1ap_wrapper.ue_req
         ue_id = req.ue_id
-        print("************************* Running End to End attach for UE id ",
-              ue_id)
+        print(
+            "************************* Running End to End attach for UE id ",
+            ue_id,
+        )
         # Now actually complete the attach
         self._s1ap_wrapper.s1_util.attach(
             ue_id, s1ap_types.tfwCmd.UE_END_TO_END_ATTACH_REQUEST,
             s1ap_types.tfwCmd.UE_ATTACH_ACCEPT_IND,
-            s1ap_types.ueAttachAccept_t)
+            s1ap_types.ueAttachAccept_t,
+        )
 
         # Wait on EMM Information from MME
         self._s1ap_wrapper._s1_util.receive_emm_info()
 
-        print("************************* Sending PDN Connectivity Request ",
-              "for UE id ", ue_id)
+        print(
+            "************************* Sending PDN Connectivity Request ",
+            "for UE id ", ue_id,
+        )
         req = s1ap_types.uepdnConReq_t()
         req.ue_Id = ue_id
         # Request type = Initial Request
@@ -71,24 +77,30 @@ class TestStandAlonePdnConnReqWithApnCorrection(unittest.TestCase):
         req.pdnAPN_pr.len = len(s)
         req.pdnAPN_pr.pdn_apn = (ctypes.c_ubyte * 100)(*[ctypes.c_ubyte(ord(c)) for c in s[:100]])
         self._s1ap_wrapper.s1_util.issue_cmd(
-            s1ap_types.tfwCmd.UE_PDN_CONN_REQ, req)
+            s1ap_types.tfwCmd.UE_PDN_CONN_REQ, req,
+        )
         # Receive PDN Connectivity Reject
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_PDN_CONN_RSP_IND.value)
-        #self.assertEqual(
+            response.msg_type, s1ap_types.tfwCmd.UE_PDN_CONN_RSP_IND.value,
+        )
+        # self.assertEqual(
         #    response.msg_type, s1ap_types.tfwCmd.UE_ATTACH_FAIL_IND.value)
 
         print("Received PDN CONNECTIVITY REJECT")
-        print("************************* Running UE detach (switch-off) for ",
-              "UE id ", ue_id)
+        print(
+            "************************* Running UE detach (switch-off) for ",
+            "UE id ", ue_id,
+        )
         # Now detach the UE
         self._s1ap_wrapper.s1_util.detach(
-            ue_id, s1ap_types.ueDetachType_t.UE_SWITCHOFF_DETACH.value, False)
+            ue_id, s1ap_types.ueDetachType_t.UE_SWITCHOFF_DETACH.value, False,
+        )
 
         # Disable APN correction
         self._s1ap_wrapper.magmad_util.config_apn_correction(
-                MagmadUtil.apn_correction_cmds.DISABLE)
+                MagmadUtil.apn_correction_cmds.DISABLE,
+        )
         self._s1ap_wrapper.magmad_util.restart_services(['mme'])
         for j in range(10):
             print("Waiting mme restart for", j, "seconds")

--- a/lte/gateway/python/integ_tests/s1aptests/test_stateless_multi_ue_mixedstate_mme_restart.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_stateless_multi_ue_mixedstate_mme_restart.py
@@ -11,22 +11,22 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
+import ctypes
+import ipaddress
+import time
 import unittest
 
 import gpp_types
-import ipaddress
 import s1ap_types
-import time
-
 from integ_tests.s1aptests import s1ap_wrapper
 from s1ap_utils import MagmadUtil
-import ctypes
 
 
 class TestStatelessMultiUeMixedStateMmeRestart(unittest.TestCase):
     def setUp(self):
         self._s1ap_wrapper = s1ap_wrapper.TestWrapper(
-           stateless_mode=MagmadUtil.stateless_cmds.ENABLE)
+           stateless_mode=MagmadUtil.stateless_cmds.ENABLE,
+        )
         self.dl_flow_rules = {}
 
     def tearDown(self):
@@ -48,12 +48,12 @@ class TestStatelessMultiUeMixedStateMmeRestart(unittest.TestCase):
 
         print("Sending Attach Request ue-id", attach_req.ue_Id)
         self._s1ap_wrapper._s1_util.issue_cmd(
-            s1ap_types.tfwCmd.UE_ATTACH_REQUEST, attach_req
+            s1ap_types.tfwCmd.UE_ATTACH_REQUEST, attach_req,
         )
 
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_AUTH_REQ_IND.value
+            response.msg_type, s1ap_types.tfwCmd.UE_AUTH_REQ_IND.value,
         )
         print("Received auth req ind ue-id", attach_req.ue_Id)
 
@@ -65,12 +65,12 @@ class TestStatelessMultiUeMixedStateMmeRestart(unittest.TestCase):
         auth_res.sqnRcvd = sqn_recvd
         print("Sending Auth Response ue-id", auth_res.ue_Id)
         self._s1ap_wrapper._s1_util.issue_cmd(
-            s1ap_types.tfwCmd.UE_AUTH_RESP, auth_res
+            s1ap_types.tfwCmd.UE_AUTH_RESP, auth_res,
         )
 
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_SEC_MOD_CMD_IND.value
+            response.msg_type, s1ap_types.tfwCmd.UE_SEC_MOD_CMD_IND.value,
         )
         print("Received Security Mode Command ue-id", auth_res.ue_Id)
 
@@ -78,14 +78,14 @@ class TestStatelessMultiUeMixedStateMmeRestart(unittest.TestCase):
         sec_mode_complete = s1ap_types.ueSecModeComplete_t()
         sec_mode_complete.ue_Id = ue_id
         self._s1ap_wrapper._s1_util.issue_cmd(
-            s1ap_types.tfwCmd.UE_SEC_MOD_COMPLETE, sec_mode_complete
+            s1ap_types.tfwCmd.UE_SEC_MOD_COMPLETE, sec_mode_complete,
         )
         print(
-            "Received Esm Information Request ue-id", sec_mode_complete.ue_Id
+            "Received Esm Information Request ue-id", sec_mode_complete.ue_Id,
         )
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_ESM_INFORMATION_REQ.value
+            response.msg_type, s1ap_types.tfwCmd.UE_ESM_INFORMATION_REQ.value,
         )
         esm_info_req = response.cast(s1ap_types.ueEsmInformationReq_t)
         return esm_info_req.tId
@@ -93,28 +93,28 @@ class TestStatelessMultiUeMixedStateMmeRestart(unittest.TestCase):
     def exec_esm_inf_req_step(self, ue_id, tId):
         # Sending Esm Information Response
         print(
-            "Sending Esm Information Response ue-id", ue_id
+            "Sending Esm Information Response ue-id", ue_id,
         )
         esm_info_response = s1ap_types.ueEsmInformationRsp_t()
         esm_info_response.ue_Id = ue_id
-        esm_info_response.tId = tId # esm_info_req.tId
+        esm_info_response.tId = tId  # esm_info_req.tId
         esm_info_response.pdnAPN_pr.pres = 1
         s = "magma.ipv4"
         esm_info_response.pdnAPN_pr.len = len(s)
         esm_info_response.pdnAPN_pr.pdn_apn = (ctypes.c_ubyte * 100)(
-            *[ctypes.c_ubyte(ord(c)) for c in s[:100]]
+            *[ctypes.c_ubyte(ord(c)) for c in s[:100]],
         )
         self._s1ap_wrapper._s1_util.issue_cmd(
-            s1ap_types.tfwCmd.UE_ESM_INFORMATION_RSP, esm_info_response
+            s1ap_types.tfwCmd.UE_ESM_INFORMATION_RSP, esm_info_response,
         )
 
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.INT_CTX_SETUP_IND.value
+            response.msg_type, s1ap_types.tfwCmd.INT_CTX_SETUP_IND.value,
         )
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_ATTACH_ACCEPT_IND.value
+            response.msg_type, s1ap_types.tfwCmd.UE_ATTACH_ACCEPT_IND.value,
         )
         msg = response.cast(s1ap_types.ueAttachAccept_t)
         addr = msg.esmInfo.pAddr.addrInfo
@@ -130,17 +130,19 @@ class TestStatelessMultiUeMixedStateMmeRestart(unittest.TestCase):
         num_ues_active = 10
         num_attached_ues = num_ues_idle + num_ues_active
         # each list item can be a number in [1,3] and be repeated
-        stateof_ues_in_attachproc_before_restart = [1, 1, 1, 1, 1,
-                                                    2, 2, 2, 2, 2,
-                                                    3, 3, 3, 3, 3,
-                                                    ]
+        stateof_ues_in_attachproc_before_restart = [
+            1, 1, 1, 1, 1,
+            2, 2, 2, 2, 2,
+            3, 3, 3, 3, 3,
+        ]
         num_ues_attaching = len(stateof_ues_in_attachproc_before_restart)
 
-        attach_steps = [self.exec_attach_req_step,
-                        self.exec_auth_resp_step,
-                        self.exec_sec_mode_complete_step,
-                        self.exec_esm_inf_req_step,
-                        ]
+        attach_steps = [
+            self.exec_attach_req_step,
+            self.exec_auth_resp_step,
+            self.exec_sec_mode_complete_step,
+            self.exec_esm_inf_req_step,
+        ]
         num_of_steps = len(attach_steps)
 
         tot_num_ues = num_ues_idle + num_ues_active + num_ues_attaching
@@ -150,12 +152,14 @@ class TestStatelessMultiUeMixedStateMmeRestart(unittest.TestCase):
         # Prep attached UEs
         for i in range(num_ues_idle + num_ues_active):
             req = self._s1ap_wrapper.ue_req
-            print("************************* sending Attach Request for "
-                  "UE id ", req.ue_id)
+            print(
+                "************************* sending Attach Request for "
+                "UE id ", req.ue_id,
+            )
             attach = self._s1ap_wrapper._s1_util.attach(
                 req.ue_id, s1ap_types.tfwCmd.UE_END_TO_END_ATTACH_REQUEST,
                 s1ap_types.tfwCmd.UE_ATTACH_ACCEPT_IND,
-                s1ap_types.ueAttachAccept_t
+                s1ap_types.ueAttachAccept_t,
             )
 
             addr = attach.esmInfo.pAddr.addrInfo
@@ -173,7 +177,8 @@ class TestStatelessMultiUeMixedStateMmeRestart(unittest.TestCase):
         for i in range(num_ues_idle):
             print(
                 "************************* Sending UE context release request ",
-                "for UE id ", ue_ids[i])
+                "for UE id ", ue_ids[i],
+            )
             # Send UE context release request to move UE to idle mode
             ue_cntxt_rel_req = s1ap_types.ueCntxtRelReq_t()
             ue_cntxt_rel_req.ue_Id = ue_ids[i]
@@ -181,19 +186,21 @@ class TestStatelessMultiUeMixedStateMmeRestart(unittest.TestCase):
                 gpp_types.CauseRadioNetwork.USER_INACTIVITY.value
             )
             self._s1ap_wrapper.s1_util.issue_cmd(
-                s1ap_types.tfwCmd.UE_CNTXT_REL_REQUEST, ue_cntxt_rel_req
+                s1ap_types.tfwCmd.UE_CNTXT_REL_REQUEST, ue_cntxt_rel_req,
             )
             response = self._s1ap_wrapper.s1_util.get_response()
             self.assertEqual(
-                response.msg_type, s1ap_types.tfwCmd.UE_CTX_REL_IND.value
+                response.msg_type, s1ap_types.tfwCmd.UE_CTX_REL_IND.value,
             )
 
         tId = {}
         # start attach procedures for the remaining UEs
         for i in range(num_ues_attaching):
             req = self._s1ap_wrapper.ue_req
-            print("************************* Starting Attach procedure "
-                  "UE id ", req.ue_id)
+            print(
+                "************************* Starting Attach procedure "
+                "UE id ", req.ue_id,
+            )
             # bring each newly attaching UE to the desired point during
             # attach procedure before restarting mme service
             ue_ids.append(req.ue_id)
@@ -201,10 +208,9 @@ class TestStatelessMultiUeMixedStateMmeRestart(unittest.TestCase):
                 if attach_steps[step] == self.exec_sec_mode_complete_step:
                     tId[req.ue_id] = attach_steps[step](req.ue_id)
                 elif attach_steps[step] == self.exec_esm_inf_req_step:
-                    attach_steps[step](req.ue_id,tId[req.ue_id])
+                    attach_steps[step](req.ue_id, tId[req.ue_id])
                 else:
                     attach_steps[step](req.ue_id)
-
 
         # Restart mme
         self._s1ap_wrapper.magmad_util.restart_mme_and_wait()
@@ -212,15 +218,17 @@ class TestStatelessMultiUeMixedStateMmeRestart(unittest.TestCase):
         # Post restart, complete the attach procedures that were cut in between
         for i in range(num_ues_attaching):
             # resume attach for attaching UEs
-            print("************************* Resuming Attach procedure "
-                  "UE id ", ue_ids[i+num_attached_ues])
-            for step in range(stateof_ues_in_attachproc_before_restart[i],num_of_steps):
+            print(
+                "************************* Resuming Attach procedure "
+                "UE id ", ue_ids[i + num_attached_ues],
+            )
+            for step in range(stateof_ues_in_attachproc_before_restart[i], num_of_steps):
                 if attach_steps[step] == self.exec_sec_mode_complete_step:
-                    tId[ue_ids[i+num_attached_ues]] = attach_steps[step](ue_ids[i+num_attached_ues])
+                    tId[ue_ids[i + num_attached_ues]] = attach_steps[step](ue_ids[i + num_attached_ues])
                 elif attach_steps[step] == self.exec_esm_inf_req_step:
-                    attach_steps[step](ue_ids[i+num_attached_ues], tId[ue_ids[i+num_attached_ues]])
+                    attach_steps[step](ue_ids[i + num_attached_ues], tId[ue_ids[i + num_attached_ues]])
                 else:
-                    attach_steps[step](ue_ids[i+num_attached_ues])
+                    attach_steps[step](ue_ids[i + num_attached_ues])
 
         # Verify steady state flows in Table-0
         # Idle users will have paging rules installed
@@ -229,7 +237,7 @@ class TestStatelessMultiUeMixedStateMmeRestart(unittest.TestCase):
         num_ul_flows = num_ues_active + num_ues_attaching
         # Verify if flow rules are created
         self._s1ap_wrapper.s1_util.verify_flow_rules(
-            num_ul_flows, self.dl_flow_rules
+            num_ul_flows, self.dl_flow_rules,
         )
         # Verify paging flow rules for idle sessions
         self._s1ap_wrapper.s1_util.verify_paging_flow_rules(idle_session_ips)
@@ -238,7 +246,8 @@ class TestStatelessMultiUeMixedStateMmeRestart(unittest.TestCase):
         for i in range(num_ues_idle):
             print(
                 "************************* Sending Service Request ",
-                "for UE id ", ue_ids[i])
+                "for UE id ", ue_ids[i],
+            )
             # Send service request to reconnect UE
             ser_req = s1ap_types.ueserviceReq_t()
             ser_req.ue_Id = ue_ids[i]
@@ -246,24 +255,26 @@ class TestStatelessMultiUeMixedStateMmeRestart(unittest.TestCase):
             ser_req.ueMtmsi.pres = False
             ser_req.rrcCause = s1ap_types.Rrc_Cause.TFW_MO_DATA.value
             self._s1ap_wrapper.s1_util.issue_cmd(
-                s1ap_types.tfwCmd.UE_SERVICE_REQUEST, ser_req
+                s1ap_types.tfwCmd.UE_SERVICE_REQUEST, ser_req,
             )
             response = self._s1ap_wrapper.s1_util.get_response()
             self.assertEqual(
-                response.msg_type, s1ap_types.tfwCmd.INT_CTX_SETUP_IND.value
+                response.msg_type, s1ap_types.tfwCmd.INT_CTX_SETUP_IND.value,
             )
             self.dl_flow_rules[idle_session_ips[i]] = []
 
         # Verify default bearer rules
         self._s1ap_wrapper.s1_util.verify_flow_rules(
-            tot_num_ues, self.dl_flow_rules
+            tot_num_ues, self.dl_flow_rules,
         )
 
         # detach everyone
         print("*** Starting Detach Procedure for all UEs ***")
         for ue in ue_ids:
-            print("************************* Detaching "
-                  "UE id ", ue)
+            print(
+                "************************* Detaching "
+                "UE id ", ue,
+            )
             # Now detach the UE
             detach_req = s1ap_types.uedetachReq_t()
             detach_req.ue_Id = ue
@@ -271,14 +282,13 @@ class TestStatelessMultiUeMixedStateMmeRestart(unittest.TestCase):
                 s1ap_types.ueDetachType_t.UE_SWITCHOFF_DETACH.value
             )
             self._s1ap_wrapper._s1_util.issue_cmd(
-                s1ap_types.tfwCmd.UE_DETACH_REQUEST, detach_req
+                s1ap_types.tfwCmd.UE_DETACH_REQUEST, detach_req,
             )
 
             response = self._s1ap_wrapper.s1_util.get_response()
             self.assertEqual(
-                response.msg_type, s1ap_types.tfwCmd.UE_CTX_REL_IND.value
+                response.msg_type, s1ap_types.tfwCmd.UE_CTX_REL_IND.value,
             )
-
 
 
 if __name__ == "__main__":

--- a/lte/gateway/python/integ_tests/s1aptests/test_tau_periodic_active.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_tau_periodic_active.py
@@ -12,8 +12,8 @@ limitations under the License.
 """
 
 import threading
-import unittest
 import time
+import unittest
 
 import gpp_types
 import s1ap_types
@@ -36,14 +36,17 @@ class TestTauPeriodicActive(unittest.TestCase):
         self._s1ap_wrapper.configUEDevice(1)
         req = self._s1ap_wrapper.ue_req
         ue_id = req.ue_id
-        print("************************* Running End to End attach for UE id ",
-              ue_id)
+        print(
+            "************************* Running End to End attach for UE id ",
+            ue_id,
+        )
         # Now actually complete the attach
         self._s1ap_wrapper.s1_util.attach(
             ue_id, s1ap_types.tfwCmd.UE_END_TO_END_ATTACH_REQUEST,
             s1ap_types.tfwCmd.UE_ATTACH_ACCEPT_IND,
             s1ap_types.ueAttachAccept_t,
-            id_type=s1ap_types.TFW_MID_TYPE_GUTI)
+            id_type=s1ap_types.TFW_MID_TYPE_GUTI,
+        )
 
         # Wait on EMM Information from MME
         self._s1ap_wrapper._s1_util.receive_emm_info()
@@ -52,25 +55,31 @@ class TestTauPeriodicActive(unittest.TestCase):
         # UE context release request message.
         time.sleep(0.5)
 
-        print("************************* Sending UE context release request ",
-              "for UE id ", ue_id)
+        print(
+            "************************* Sending UE context release request ",
+            "for UE id ", ue_id,
+        )
         # Send UE context release request to move UE to idle mode
         req = s1ap_types.ueCntxtRelReq_t()
         req.ue_Id = ue_id
         req.cause.causeVal = gpp_types.CauseRadioNetwork.USER_INACTIVITY.value
         self._s1ap_wrapper.s1_util.issue_cmd(
-            s1ap_types.tfwCmd.UE_CNTXT_REL_REQUEST, req)
+            s1ap_types.tfwCmd.UE_CNTXT_REL_REQUEST, req,
+        )
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_CTX_REL_IND.value)
+            response.msg_type, s1ap_types.tfwCmd.UE_CTX_REL_IND.value,
+        )
 
         for _ in range(num_taus):
             timer = threading.Timer(tau_period, lambda: None)
             timer.start()
             timer.join()
 
-            print("************************* Sending Tracking Area Update ",
-                  "request for UE id ", ue_id)
+            print(
+                "************************* Sending Tracking Area Update ",
+                "request for UE id ", ue_id,
+            )
             # Send UE context release request to move UE to idle mode
             req = s1ap_types.ueTauReq_t()
             req.ue_Id = ue_id
@@ -78,35 +87,47 @@ class TestTauPeriodicActive(unittest.TestCase):
             req.Actv_flag = True
             req.ueMtmsi.pres = False
             self._s1ap_wrapper.s1_util.issue_cmd(
-                s1ap_types.tfwCmd.UE_TAU_REQ, req)
+                s1ap_types.tfwCmd.UE_TAU_REQ, req,
+            )
 
             response = self._s1ap_wrapper.s1_util.get_response()
             if s1ap_types.tfwCmd.INT_CTX_SETUP_IND.value == response.msg_type:
                 response = self._s1ap_wrapper.s1_util.get_response()
-                self.assertEquals(response.msg_type,
-                                  s1ap_types.tfwCmd.UE_TAU_ACCEPT_IND.value)
+                self.assertEquals(
+                    response.msg_type,
+                    s1ap_types.tfwCmd.UE_TAU_ACCEPT_IND.value,
+                )
 
-                print("************************* Sending UE context release ",
-                      "request for UE id ", ue_id)
+                print(
+                    "************************* Sending UE context release ",
+                    "request for UE id ", ue_id,
+                )
                 # Send UE context release request to move UE to idle mode
                 req = s1ap_types.ueCntxtRelReq_t()
                 req.ue_Id = ue_id
                 req.cause.causeVal = gpp_types.CauseRadioNetwork.USER_INACTIVITY.value
                 self._s1ap_wrapper.s1_util.issue_cmd(
-                    s1ap_types.tfwCmd.UE_CNTXT_REL_REQUEST, req)
+                    s1ap_types.tfwCmd.UE_CNTXT_REL_REQUEST, req,
+                )
                 response = self._s1ap_wrapper.s1_util.get_response()
                 self.assertEqual(
-                    response.msg_type, s1ap_types.tfwCmd.UE_CTX_REL_IND.value)
+                    response.msg_type, s1ap_types.tfwCmd.UE_CTX_REL_IND.value,
+                )
 
             else:
-                self.assertEquals(response.msg_type,
-                                  s1ap_types.tfwCmd.UE_TAU_REJECT_IND.value)
+                self.assertEquals(
+                    response.msg_type,
+                    s1ap_types.tfwCmd.UE_TAU_REJECT_IND.value,
+                )
 
-        print("************************* Running UE detach (switch-off) for ",
-              "UE id ", ue_id)
+        print(
+            "************************* Running UE detach (switch-off) for ",
+            "UE id ", ue_id,
+        )
         # Now detach the UE
         self._s1ap_wrapper.s1_util.detach(
-            ue_id, s1ap_types.ueDetachType_t.UE_SWITCHOFF_DETACH.value, False)
+            ue_id, s1ap_types.ueDetachType_t.UE_SWITCHOFF_DETACH.value, False,
+        )
 
 
 if __name__ == "__main__":

--- a/lte/gateway/python/integ_tests/s1aptests/test_tau_periodic_inactive.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_tau_periodic_inactive.py
@@ -12,8 +12,8 @@ limitations under the License.
 """
 
 import threading
-import unittest
 import time
+import unittest
 
 import gpp_types
 import s1ap_types
@@ -36,12 +36,15 @@ class TestTauPeriodicInactive(unittest.TestCase):
         self._s1ap_wrapper.configUEDevice(1)
         req = self._s1ap_wrapper.ue_req
         ue_id = req.ue_id
-        print("************************* Running End to End attach for UE id ",
-              ue_id)
+        print(
+            "************************* Running End to End attach for UE id ",
+            ue_id,
+        )
         # Now actually complete the attach
         self._s1ap_wrapper.s1_util.attach(
             ue_id, s1ap_types.tfwCmd.UE_END_TO_END_ATTACH_REQUEST,
-            s1ap_types.tfwCmd.UE_ATTACH_ACCEPT_IND, s1ap_types.ueAttachAccept_t)
+            s1ap_types.tfwCmd.UE_ATTACH_ACCEPT_IND, s1ap_types.ueAttachAccept_t,
+        )
         # Wait on EMM Information from MME
         self._s1ap_wrapper._s1_util.receive_emm_info()
 
@@ -50,25 +53,31 @@ class TestTauPeriodicInactive(unittest.TestCase):
 
         time.sleep(0.5)
 
-        print("************************* Sending UE context release request ",
-              "for UE id ", ue_id)
+        print(
+            "************************* Sending UE context release request ",
+            "for UE id ", ue_id,
+        )
         # Send UE context release request to move UE to idle mode
         req = s1ap_types.ueCntxtRelReq_t()
         req.ue_Id = ue_id
         req.cause.causeVal = gpp_types.CauseRadioNetwork.USER_INACTIVITY.value
         self._s1ap_wrapper.s1_util.issue_cmd(
-            s1ap_types.tfwCmd.UE_CNTXT_REL_REQUEST, req)
+            s1ap_types.tfwCmd.UE_CNTXT_REL_REQUEST, req,
+        )
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_CTX_REL_IND.value)
+            response.msg_type, s1ap_types.tfwCmd.UE_CTX_REL_IND.value,
+        )
 
         for _ in range(num_taus):
             timer = threading.Timer(tau_period, lambda: None)
             timer.start()
             timer.join()
 
-            print("************************* Sending Tracking Area Update ",
-                  "request for UE id ", ue_id)
+            print(
+                "************************* Sending Tracking Area Update ",
+                "request for UE id ", ue_id,
+            )
             # Send UE context release request to move UE to idle mode
             req = s1ap_types.ueTauReq_t()
             req.ue_Id = ue_id
@@ -76,21 +85,27 @@ class TestTauPeriodicInactive(unittest.TestCase):
             req.Actv_flag = False
             req.ueMtmsi.pres = False
             self._s1ap_wrapper.s1_util.issue_cmd(
-                s1ap_types.tfwCmd.UE_TAU_REQ, req)
+                s1ap_types.tfwCmd.UE_TAU_REQ, req,
+            )
 
             response = self._s1ap_wrapper.s1_util.get_response()
             self.assertEqual(
-                response.msg_type, s1ap_types.tfwCmd.UE_TAU_ACCEPT_IND.value)
+                response.msg_type, s1ap_types.tfwCmd.UE_TAU_ACCEPT_IND.value,
+            )
 
             response = self._s1ap_wrapper.s1_util.get_response()
             self.assertEqual(
-                response.msg_type, s1ap_types.tfwCmd.UE_CTX_REL_IND.value)
+                response.msg_type, s1ap_types.tfwCmd.UE_CTX_REL_IND.value,
+            )
 
-        print("************************* Running UE detach (switch-off) for ",
-              "UE id ", ue_id)
+        print(
+            "************************* Running UE detach (switch-off) for ",
+            "UE id ", ue_id,
+        )
         # Now detach the UE
         self._s1ap_wrapper.s1_util.detach(
-            ue_id, s1ap_types.ueDetachType_t.UE_SWITCHOFF_DETACH.value, False)
+            ue_id, s1ap_types.ueDetachType_t.UE_SWITCHOFF_DETACH.value, False,
+        )
 
 
 if __name__ == "__main__":

--- a/lte/gateway/python/integ_tests/s1aptests/test_x2_handover.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_x2_handover.py
@@ -11,11 +11,11 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
+import time
 import unittest
 
 import s1ap_types
 import s1ap_wrapper
-import time
 
 
 class TestX2HandOver(unittest.TestCase):
@@ -77,7 +77,7 @@ class TestX2HandOver(unittest.TestCase):
         time.sleep(3)
         print("************************* Sending ENB_CONFIGURATION_TRANSFER")
         self._s1ap_wrapper.s1_util.issue_cmd(
-            s1ap_types.tfwCmd.ENB_CONFIGURATION_TRANSFER, req
+            s1ap_types.tfwCmd.ENB_CONFIGURATION_TRANSFER, req,
         )
 
         response = self._s1ap_wrapper.s1_util.get_response()
@@ -98,18 +98,18 @@ class TestX2HandOver(unittest.TestCase):
         print("************************* Sending X2_HO_TRIGGER_REQ")
 
         self._s1ap_wrapper.s1_util.issue_cmd(
-            s1ap_types.tfwCmd.X2_HO_TRIGGER_REQ, req
+            s1ap_types.tfwCmd.X2_HO_TRIGGER_REQ, req,
         )
         # Receive Path Switch Request Ack
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.PATH_SW_REQ_ACK.value
+            response.msg_type, s1ap_types.tfwCmd.PATH_SW_REQ_ACK.value,
         )
 
         print("************************* Received Path Switch Request Ack")
 
         print(
-            "************************* Running UE detach for UE id ", req.ue_id
+            "************************* Running UE detach for UE id ", req.ue_id,
         )
         # Now detach the UE
         time.sleep(3)

--- a/lte/gateway/python/integ_tests/s1aptests/test_x2_handover_ping_pong.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_x2_handover_ping_pong.py
@@ -11,11 +11,11 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
+import time
 import unittest
 
 import s1ap_types
 import s1ap_wrapper
-import time
 
 
 class TestX2HandOverPingPong(unittest.TestCase):
@@ -78,7 +78,7 @@ class TestX2HandOverPingPong(unittest.TestCase):
         time.sleep(3)
         print("****************** Sending ENB_CONFIGURATION_TRANSFER")
         self._s1ap_wrapper.s1_util.issue_cmd(
-            s1ap_types.tfwCmd.ENB_CONFIGURATION_TRANSFER, req
+            s1ap_types.tfwCmd.ENB_CONFIGURATION_TRANSFER, req,
         )
 
         response = self._s1ap_wrapper.s1_util.get_response()
@@ -99,24 +99,24 @@ class TestX2HandOverPingPong(unittest.TestCase):
         print("****************** Sending X2_HO_TRIGGER_REQ")
 
         self._s1ap_wrapper.s1_util.issue_cmd(
-            s1ap_types.tfwCmd.X2_HO_TRIGGER_REQ, req
+            s1ap_types.tfwCmd.X2_HO_TRIGGER_REQ, req,
         )
         # Receive Path Switch Request Ack
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.PATH_SW_REQ_ACK.value
+            response.msg_type, s1ap_types.tfwCmd.PATH_SW_REQ_ACK.value,
         )
 
         print("****************** Received Path Switch Request Ack")
 
         print("****************** Second HO triggered")
         self._s1ap_wrapper.s1_util.issue_cmd(
-            s1ap_types.tfwCmd.X2_HO_TRIGGER_REQ, req
+            s1ap_types.tfwCmd.X2_HO_TRIGGER_REQ, req,
         )
         # Receive Path Switch Request Ack
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.PATH_SW_REQ_ACK.value
+            response.msg_type, s1ap_types.tfwCmd.PATH_SW_REQ_ACK.value,
         )
         print("****************** Received Path Switch Request Ack for 2nd HO")
         print("****************** Running UE detach for UE id ", req.ue_id)

--- a/lte/gateway/python/integ_tests/s1aptests/util/traffic_messages.py
+++ b/lte/gateway/python/integ_tests/s1aptests/util/traffic_messages.py
@@ -12,9 +12,9 @@ limitations under the License.
 """
 
 import enum
-import iperf3  # Used by recv to reconstruct iperf3.TestResult objects
 import pickle
 
+import iperf3  # Used by recv to reconstruct iperf3.TestResult objects
 
 '''
 TrafficServerInstance and TrafficTestInstance are payloads used to coordinate
@@ -53,6 +53,7 @@ TrafficTestDriver sends TrafficResponse (RESULTS) after tests have completed.
 class TrafficServerInstance(object):
     ''' Information about the server instance for a single uplink/downlink
     traffic channel '''
+
     def __init__(self, ip, port, mac):
         ''' Create a traffic server instance with the given values
 
@@ -71,12 +72,14 @@ class TrafficServerInstance(object):
             '%s:' % type(self).__name__,
             '%s:%d' % (self.ip.exploded, self.port),
             'on device',
-            self.mac))
+            self.mac,
+        ))
 
 
 class TrafficTestInstance(object):
     ''' Information about the test instance for a single uplink/downlink
     traffic channel '''
+
     def __init__(self, is_uplink, is_udp, duration, ip, port):
         ''' Create a traffic test instance with the given values
 
@@ -102,11 +105,13 @@ class TrafficTestInstance(object):
             'test,',
             '%d seconds' % self.duration,
             'for test device at',
-            '%s:%d' % (self.ip.exploded, self.port)))
+            '%s:%d' % (self.ip.exploded, self.port),
+        ))
 
 
 class TrafficMessage(object):
     ''' Message superclass between client and server '''
+
     def __init__(self, message, identifier, payload):
         ''' Create a TrafficMessage of the given type with the specified
         payload
@@ -127,7 +132,8 @@ class TrafficMessage(object):
         return ' '.join((
             '%s' % type(self).__name__,
             '(%s, id %s):' % (self.message.name, str(self.id)),
-            payload_str))
+            payload_str,
+        ))
 
     @staticmethod
     def recv(stream):
@@ -163,12 +169,16 @@ class TrafficMessage(object):
 
 
 # Enumerated type for TrafficRequest; module-level for pickling purposes
-TrafficRequestType = enum.unique(enum.Enum(
-    'TrafficRequestType', 'EXIT SHUTDOWN START TEST'))
+TrafficRequestType = enum.unique(
+    enum.Enum(
+    'TrafficRequestType', 'EXIT SHUTDOWN START TEST',
+    ),
+)
 
 
 class TrafficRequest(TrafficMessage):
     ''' Request object sent from client to server '''
+
     def __init__(self, message, identifier=None, payload=None):
         ''' Create a TrafficRequest of the given type with the specified
         payload
@@ -184,12 +194,16 @@ class TrafficRequest(TrafficMessage):
 
 
 # Enumerated type for TrafficResponse; module-level for pickling purposes
-TrafficResponseType = enum.unique(enum.Enum(
-    'TrafficResponseType', 'INFO RESULTS SERVER STARTED'))
+TrafficResponseType = enum.unique(
+    enum.Enum(
+    'TrafficResponseType', 'INFO RESULTS SERVER STARTED',
+    ),
+)
 
 
 class TrafficResponse(TrafficMessage):
     ''' Response object sent from server to client '''
+
     def __init__(self, message, identifier=None, payload=None):
         ''' Create a TrafficResponse of the given type with the specified
         payload

--- a/lte/gateway/python/integ_tests/s1aptests/workflow/attach_detach.py
+++ b/lte/gateway/python/integ_tests/s1aptests/workflow/attach_detach.py
@@ -15,19 +15,25 @@ import s1ap_types
 
 
 def attach_ue(ue, s1ap_wrapper):
-    print("************************* Running End to End attach for ",
-          "UE id ", ue.ue_id)
+    print(
+        "************************* Running End to End attach for ",
+        "UE id ", ue.ue_id,
+    )
     s1ap_wrapper.s1_util.attach(
         ue.ue_id, s1ap_types.tfwCmd.UE_END_TO_END_ATTACH_REQUEST,
         s1ap_types.tfwCmd.UE_ATTACH_ACCEPT_IND,
-        s1ap_types.ueAttachAccept_t)
+        s1ap_types.ueAttachAccept_t,
+    )
     # Wait on EMM Information from MME
     s1ap_wrapper.s1_util.receive_emm_info()
 
 
 def detach_ue(ue, s1ap_wrapper):
-    print("************************* Running UE detach for UE id ",
-          ue.ue_id)
+    print(
+        "************************* Running UE detach for UE id ",
+        ue.ue_id,
+    )
     s1ap_wrapper.s1_util.detach(
         ue.ue_id, s1ap_types.ueDetachType_t.UE_SWITCHOFF_DETACH.value,
-        True)
+        True,
+    )

--- a/lte/gateway/python/integ_tests/s1aptests/workflow/data.py
+++ b/lte/gateway/python/integ_tests/s1aptests/workflow/data.py
@@ -16,8 +16,10 @@ def run_tcp_downlink(ue, s1ap_wrapper, duration=1):
     """
     Given a configured UE, run a TCP downlink test for the specified duration.
     """
-    print("************************* Running UE downlink (TCP) for UE id ",
-          ue.ue_id)
+    print(
+        "************************* Running UE downlink (TCP) for UE id ",
+        ue.ue_id,
+    )
     with s1ap_wrapper.configDownlinkTest(ue, duration=duration) as test:
         test.verify()
 
@@ -26,8 +28,10 @@ def run_tcp_uplink(ue, s1ap_wrapper, duration=1):
     """
     Given a configured UE, run a TCP uplink test for the specified duration.
     """
-    print("************************* Running UE uplink (TCP) for UE id ",
-          ue.ue_id)
+    print(
+        "************************* Running UE uplink (TCP) for UE id ",
+        ue.ue_id,
+    )
     with s1ap_wrapper.configUplinkTest(ue, duration=duration) as test:
         test.verify()
 
@@ -36,10 +40,14 @@ def run_udp_downlink(ue, s1ap_wrapper, duration=1):
     """
     Given a configured UE, run a UDP downlink test for the specified duration.
     """
-    print("************************* Running UE downlink (UDP) for UE id ",
-          ue.ue_id)
-    with s1ap_wrapper.configDownlinkTest(ue, duration=duration,
-                                         is_udp=True) as test:
+    print(
+        "************************* Running UE downlink (UDP) for UE id ",
+        ue.ue_id,
+    )
+    with s1ap_wrapper.configDownlinkTest(
+        ue, duration=duration,
+        is_udp=True,
+    ) as test:
         test.verify()
 
 
@@ -47,8 +55,12 @@ def run_udp_uplink(ue, s1ap_wrapper, duration=1):
     """
     Given a configured UE, run a UDP uplink test for the specified duration.
     """
-    print("************************* Running UE uplink (UDP) for UE id ",
-          ue.ue_id)
-    with s1ap_wrapper.configUplinkTest(ue, duration=duration,
-                                       is_udp=True) as test:
+    print(
+        "************************* Running UE uplink (UDP) for UE id ",
+        ue.ue_id,
+    )
+    with s1ap_wrapper.configUplinkTest(
+        ue, duration=duration,
+        is_udp=True,
+    ) as test:
         test.verify()


### PR DESCRIPTION
Signed-off-by: Marie Bremner <marwhal@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary
Run formatting script to all integ tests file and enable python format GitHub action check for the directory.

The exact commands I ran: (which are the same as the ones run in CI)
```
for i in `find lte/gateway/python/integ_tests -name "*.py" -type f`; do
    echo $i;
    isort $i;
    autopep8 --select W291,W293,E2,E3 -r --in-place  $i;
    add-trailing-comma --py35-plus $i;
done
```
<!-- Enumerate changes you made and why you made them -->

## Test Plan
Run `make integ_test` locally -> passed
Run test on CircleCI -> passed: https://app.circleci.com/pipelines/github/magma/magma/24764/workflows/e3340038-5e42-4797-9209-969a2aad0945/jobs/263005
The formatter check now passes for integ_tests directory
<img width="876" alt="Screen Shot 2021-06-03 at 9 41 06 PM" src="https://user-images.githubusercontent.com/37634144/120737832-699d3580-c4b4-11eb-9780-90dcf732d8a4.png">
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->

