### PR TITLE
[LTE][AGW] EMM data context _ms_network_capability attribute copy: wrong sizeof()

### DIFF
--- a/lte/gateway/c/oai/tasks/nas/emm/emm_data_ctx.c
+++ b/lte/gateway/c/oai/tasks/nas/emm/emm_data_ctx.c
@@ -477,7 +477,7 @@ inline void emm_ctx_set_valid_ue_nw_cap(
 /* Clear MS network capability IE   */
 inline void emm_ctx_clear_ms_nw_cap(emm_context_t* const ctxt) {
   memset(
-      &ctxt->_ms_network_capability, 0, sizeof(ctxt->_ue_network_capability));
+      &ctxt->_ms_network_capability, 0, sizeof(ctxt->_ms_network_capability));
   emm_ctx_clear_attribute_present(
       ctxt, EMM_CTXT_MEMBER_MS_NETWORK_CAPABILITY_IE);
   OAILOG_DEBUG(


### PR DESCRIPTION
Signed-off-by: lionelgo <29477918+lionelgo@users.noreply.github.com>

## Summary

I changed   
memset( &ctxt->_ms_network_capability, 0, sizeof(ctxt->_ue_network_capability));
to
memset( &ctxt->_ms_network_capability, 0, sizeof(ctxt->_ms_network_capability));

so that attribute declared right after _ms_network_capability won't be overwritten when clearing _ms_network_capability value through emm_ctx_clear_ms_nw_cap().

## Test Plan

This bug was certainly modifying emm_context_t/_drx_parameter, should not now.

## Additional Information


