### PR TITLE
Addresses deadStore warnings by using/removing stores

### DIFF
--- a/lte/gateway/c/core/oai/common/async_system.c
+++ b/lte/gateway/c/core/oai/common/async_system.c
@@ -61,7 +61,6 @@ static int handle_message(zloop_t* loop, zsock_t* reader, void* arg) {
 
   switch (ITTI_MSG_ID(received_message_p)) {
     case ASYNC_SYSTEM_COMMAND: {
-      rc = 0;
       OAILOG_DEBUG(
           LOG_ASYNC_SYSTEM, "C system() call: %s\n",
           bdata(ASYNC_SYSTEM_COMMAND(received_message_p).system_command));
@@ -137,7 +136,7 @@ int async_system_command(
   rv = bvcformata(bstr, 1024, format, args);  // big number, see bvcformata
   va_end(args);
 
-  if (NULL == bstr) {
+  if (NULL == bstr || BSTR_OK != rv) {
     OAILOG_ERROR(LOG_ASYNC_SYSTEM, "Error while formatting system command");
     return RETURNerror;
   }

--- a/lte/gateway/c/core/oai/common/itti_free_defined_msg.c
+++ b/lte/gateway/c/core/oai/common/itti_free_defined_msg.c
@@ -73,8 +73,8 @@ void itti_free_msg_content(MessageDef* const message_p) {
       break;
 
     case MME_APP_CONNECTION_ESTABLISHMENT_CNF: {
-      itti_mme_app_connection_establishment_cnf_t mme_app_est_cnf = {0};
-      mme_app_est_cnf = message_p->ittiMsg.mme_app_connection_establishment_cnf;
+      itti_mme_app_connection_establishment_cnf_t mme_app_est_cnf =
+          message_p->ittiMsg.mme_app_connection_establishment_cnf;
       for (uint8_t index = 0; index < BEARERS_PER_UE; index++) {
         bdestroy_wrapper(&mme_app_est_cnf.nas_pdu[index]);
       }

--- a/lte/gateway/c/core/oai/common/shared_ts_log.c
+++ b/lte/gateway/c/core/oai/common/shared_ts_log.c
@@ -291,11 +291,10 @@ void shared_log_start_use(void) {
 
 //------------------------------------------------------------------------------
 void shared_log_flush_messages(void) {
-  int rv                          = 0;
   shared_log_queue_item_t* item_p = NULL;
 
-  while ((rv = lfds710_queue_bmm_dequeue(
-              &g_shared_log.log_message_queue, NULL, (void**) &item_p)) == 1) {
+  while (lfds710_queue_bmm_dequeue(
+             &g_shared_log.log_message_queue, NULL, (void**) &item_p) == 1) {
     if ((item_p->app_id >= MIN_SH_TS_LOG_CLIENT) &&
         (item_p->app_id < MAX_SH_TS_LOG_CLIENT)) {
       (*g_shared_log.logger_callback[item_p->app_id])(item_p);


### PR DESCRIPTION
Signed-off-by: Waqar Aqeel <waqeel@fb.com>

## Summary

Working towards #5364. Addresses deadStore warnings from clang-tidy in 3 files.

## Test Plan

Ran `make test_oai`.
