### PR TITLE
feat(agw): SMF is to handle PDU Session Release request from AMF#7216

### DIFF
--- a/lte/gateway/c/session_manager/SessionStateEnforcer.h
+++ b/lte/gateway/c/session_manager/SessionStateEnforcer.h
@@ -149,15 +149,21 @@ class SessionStateEnforcer {
       const std::string& imsi, const std::unique_ptr<SessionState>& session,
       enum PdrState pdrstate);
 
-  /*Start processing to terminate respective session requested from AMF*/
-  void m5g_start_session_termination(
-      SessionMap& session_map, const std::unique_ptr<SessionState>& session,
-      const uint32_t& pdu_id, SessionStateUpdateCriteria* uc);
-
   /* Set new fsm state and increment version*/
   void set_new_fsm_state_and_increment_version(
       std::unique_ptr<SessionState>& session, SessionFsmState target_state,
       SessionStateUpdateCriteria* session_uc);
+
+  /*Start processing to terminate respective session requested from AMF*/
+  void m5g_start_session_termination(
+      SessionMap& session_map, const std::string& imsi,
+      const std::unique_ptr<SessionState>& session, const uint32_t& pdu_id,
+      SessionStateUpdateCriteria* session_uc);
+
+  /*Function will clean up all resources related to requested session*/
+  void m5g_complete_termination(
+      SessionMap& session_map, const std::string& imsi,
+      const std::string& session_id, SessionUpdate& session_update);
 
  private:
   ConvergedRuleStore GlobalRuleList;
@@ -191,11 +197,6 @@ class SessionStateEnforcer {
    */
   void m5g_handle_termination_on_timeout(
       const std::string& imsi, const std::string& session_id);
-
-  /*Function will clean up all resources related to requested session*/
-  void m5g_complete_termination(
-      SessionMap& session_map, const std::string& imsi,
-      const std::string& session_id, SessionUpdate& session_update);
 
   /* update the GNB endpoint details in a rule */
   bool insert_pdr_from_core(

--- a/lte/gateway/c/session_manager/SessionStateEnforcer.h
+++ b/lte/gateway/c/session_manager/SessionStateEnforcer.h
@@ -146,8 +146,7 @@ class SessionStateEnforcer {
 
   /* Pdr State change routine */
   void m5g_pdr_rules_change_and_update_upf(
-      const std::string& imsi, const std::unique_ptr<SessionState>& session,
-      enum PdrState pdrstate);
+      const std::unique_ptr<SessionState>& session, enum PdrState pdrstate);
 
   /* Set new fsm state and increment version*/
   void set_new_fsm_state_and_increment_version(
@@ -156,9 +155,8 @@ class SessionStateEnforcer {
 
   /*Start processing to terminate respective session requested from AMF*/
   void m5g_start_session_termination(
-      SessionMap& session_map, const std::string& imsi,
-      const std::unique_ptr<SessionState>& session, const uint32_t& pdu_id,
-      SessionStateUpdateCriteria* session_uc);
+      SessionMap& session_map, const std::unique_ptr<SessionState>& session,
+      const uint32_t& pdu_id, SessionStateUpdateCriteria* session_uc);
 
   /*Function will clean up all resources related to requested session*/
   void m5g_complete_termination(

--- a/lte/gateway/c/session_manager/SetMessageManagerHandler.cpp
+++ b/lte/gateway/c/session_manager/SetMessageManagerHandler.cpp
@@ -99,8 +99,8 @@ void SetMessageManagerHandler::SetAmfSessionContext(
     // Requested message from AMF to release the session
     if (cfg.common_context.sm_session_state() == RELEASED_4) {
       if (cfg.common_context.sm_session_version() == 0) {
-        MLOG(MERROR) << "Wrong version received from AMF for " << imsi
-                     << " of PDU id:" << pdu_id;
+        MLOG(MERROR) << "Wrong version received from AMF for IMSI " << imsi
+                     << " but continuing release request";
         Status status(grpc::OUT_OF_RANGE, "Version number Out of Range");
         response_callback(status, SmContextVoid());
         return;

--- a/lte/gateway/c/session_manager/test/test_set_session_manager_handler.cpp
+++ b/lte/gateway/c/session_manager/test/test_set_session_manager_handler.cpp
@@ -250,26 +250,212 @@ TEST_F(SessionManagerHandlerTest, test_UpdateSessionContext) {
       session_map, IMSI1, session, update);
 }
 
-TEST_F(SessionManagerHandlerTest, test_SetSmfNotification) {
-  magma::SetSMSessionContext session_ctx_req;
-  set_sm_session_context(&session_ctx_req);
+TEST_F(SessionManagerHandlerTest, test_SetPduSessionReleaseContext) {
+  magma::SetSMSessionContext request;
+  auto* req =
+      request.mutable_rat_specific_context()->mutable_m5gsm_session_context();
+  auto* reqcmn = request.mutable_common_context();
+  req->set_pdu_session_id({0x5});
+  req->set_rquest_type(magma::RequestType::INITIAL_REQUEST);
+  req->mutable_pdu_address()->set_redirect_address_type(
+      magma::RedirectServer::IPV4);
+  req->mutable_pdu_address()->set_redirect_server_address("10.20.30.40");
+  req->set_priority_access(magma::priorityaccess::High);
+  req->set_imei("123456789012345");
+  req->set_gpsi("9876543210");
+  req->set_pcf_id("1357924680123456");
 
-  magma::SetSmNotificationContext request;
-  set_sm_notif_context(&request, &session_ctx_req);
+  reqcmn->mutable_sid()->set_id("IMSI000000000000001");
+  reqcmn->set_sm_session_state(magma::SMSessionFSMState::CREATING_0);
 
   grpc::ServerContext server_context;
 
-  set_session_manager->SetSmfNotification(
+  set_session_manager->SetAmfSessionContext(
       &server_context, &request,
       [this](grpc::Status status, SmContextVoid Void) {});
-  set_session_manager->idle_mode_change_sessions_handle(
-      request, [](grpc::Status status, SmContextVoid Void) {});
-
-  set_session_manager->pdu_session_inactive(
-      request, [](grpc::Status status, SmContextVoid Void) {});
 
   // Run session creation in the EventBase loop
   evb->loopOnce();
+  evb->loopOnce();
+
+  auto session_map = session_store->read_sessions({IMSI1});
+  auto it          = session_map.find(IMSI1);
+  EXPECT_FALSE(it == session_map.end());
+  EXPECT_EQ(session_map[IMSI1].size(), 1);
+
+  auto& session_temp = session_map[IMSI1][0];
+  EXPECT_EQ(session_temp->get_config().common_context.sid().id(), IMSI1);
+
+  req->set_rquest_type(magma::RequestType::EXISTING_PDU_SESSION);
+  reqcmn->set_sm_session_state(magma::SMSessionFSMState::RELEASED_4);
+  reqcmn->set_sm_session_version(2);
+
+  set_session_manager->SetAmfSessionContext(
+      &server_context, &request,
+      [this](grpc::Status status, SmContextVoid Void) {});
+
+  // Run session creation in the EventBase loop
+  evb->loopOnce();
+}
+
+TEST_F(SessionManagerHandlerTest, test_LocalReleaseSessionContext) {
+  magma::SetSMSessionContext request;
+  auto* req =
+      request.mutable_rat_specific_context()->mutable_m5gsm_session_context();
+  auto* reqcmn = request.mutable_common_context();
+  req->set_pdu_session_id({0x5});
+  req->set_rquest_type(magma::RequestType::INITIAL_REQUEST);
+  req->mutable_pdu_address()->set_redirect_address_type(
+      magma::RedirectServer::IPV4);
+  req->mutable_pdu_address()->set_redirect_server_address("10.20.30.40");
+  req->set_priority_access(magma::priorityaccess::High);
+  req->set_imei("123456789012345");
+  req->set_gpsi("9876543210");
+  req->set_pcf_id("1357924680123456");
+
+  reqcmn->mutable_sid()->set_id("IMSI000000000000001");
+  reqcmn->set_sm_session_state(magma::SMSessionFSMState::CREATING_0);
+
+  grpc::ServerContext server_context;
+
+  set_session_manager->SetAmfSessionContext(
+      &server_context, &request,
+      [this](grpc::Status status, SmContextVoid Void) {});
+
+  // Run session creation in the EventBase loop
+  evb->loopOnce();
+  evb->loopOnce();
+
+  auto session_map = session_store->read_sessions({IMSI1});
+  auto it          = session_map.find(IMSI1);
+  EXPECT_FALSE(it == session_map.end());
+  EXPECT_EQ(session_map[IMSI1].size(), 1);
+
+  SessionConfig cfg;
+  cfg.common_context       = request.common_context();
+  cfg.rat_specific_context = request.rat_specific_context();
+  cfg.rat_specific_context.mutable_m5gsm_session_context()->set_ssc_mode(
+      SSC_MODE_3);
+
+  SessionUpdate session_update =
+      SessionStore::get_default_session_update(session_map);
+  uint32_t pdu_id = 5;
+
+  session_enforcer->m5g_release_session(
+      session_map, IMSI1, pdu_id, session_update);
+  EXPECT_FALSE(it == session_map.end());
+  EXPECT_EQ(session_map[IMSI1].size(), 1);
+  auto& session_temp = session_map[IMSI1][0];
+  EXPECT_EQ(session_temp->get_config().common_context.sid().id(), IMSI1);
+}
+
+TEST_F(SessionManagerHandlerTest, test_LocalSessionTerminationContext) {
+  magma::SetSMSessionContext request;
+  auto* req =
+      request.mutable_rat_specific_context()->mutable_m5gsm_session_context();
+  auto* reqcmn = request.mutable_common_context();
+  req->set_pdu_session_id({0x5});
+  req->set_rquest_type(magma::RequestType::INITIAL_REQUEST);
+  req->mutable_pdu_address()->set_redirect_address_type(
+      magma::RedirectServer::IPV4);
+  req->mutable_pdu_address()->set_redirect_server_address("10.20.30.40");
+  req->set_priority_access(magma::priorityaccess::High);
+  req->set_imei("123456789012345");
+  req->set_gpsi("9876543210");
+  req->set_pcf_id("1357924680123456");
+
+  reqcmn->mutable_sid()->set_id("IMSI000000000000002");
+  reqcmn->set_sm_session_state(magma::SMSessionFSMState::CREATING_0);
+
+  grpc::ServerContext server_context;
+
+  set_session_manager->SetAmfSessionContext(
+      &server_context, &request,
+      [this](grpc::Status status, SmContextVoid Void) {});
+
+  // Run session creation in the EventBase loop
+  evb->loopOnce();
+  evb->loopOnce();
+
+  auto session_map = session_store->read_sessions({IMSI2});
+  auto it          = session_map.find(IMSI2);
+  EXPECT_FALSE(it == session_map.end());
+  EXPECT_EQ(session_map[IMSI2].size(), 1);
+
+  SessionConfig cfg;
+  cfg.common_context       = request.common_context();
+  cfg.rat_specific_context = request.rat_specific_context();
+  cfg.rat_specific_context.mutable_m5gsm_session_context()->set_ssc_mode(
+      SSC_MODE_3);
+
+  SessionUpdate session_update =
+      SessionStore::get_default_session_update(session_map);
+  uint32_t pdu_id = 5;
+  SessionSearchCriteria id1_success_sid(IMSI2, IMSI_AND_PDUID, pdu_id);
+  auto session_it = session_store->find_session(session_map, id1_success_sid);
+  auto& session   = **session_it;
+  auto session_id = session->get_session_id();
+  SessionStateUpdateCriteria& session_uc = session_update[IMSI2][session_id];
+
+  session_enforcer->m5g_start_session_termination(
+      session_map, IMSI2, session, pdu_id, &session_uc);
+
+  EXPECT_FALSE(it == session_map.end());
+  EXPECT_EQ(session_map[IMSI2].size(), 1);
+  auto& session_temp = session_map[IMSI2][0];
+  EXPECT_EQ(session_temp->get_config().common_context.sid().id(), IMSI2);
+}
+
+TEST_F(SessionManagerHandlerTest, test_SessionCompleteTerminationContext) {
+  magma::SetSMSessionContext request;
+  auto* req =
+      request.mutable_rat_specific_context()->mutable_m5gsm_session_context();
+  auto* reqcmn = request.mutable_common_context();
+  req->set_pdu_session_id({0x5});
+  req->set_rquest_type(magma::RequestType::INITIAL_REQUEST);
+  req->mutable_pdu_address()->set_redirect_address_type(
+      magma::RedirectServer::IPV4);
+  req->mutable_pdu_address()->set_redirect_server_address("10.20.30.40");
+  req->set_priority_access(magma::priorityaccess::High);
+  req->set_imei("123456789012345");
+  req->set_gpsi("9876543210");
+  req->set_pcf_id("1357924680123456");
+
+  reqcmn->mutable_sid()->set_id("IMSI000000000000002");
+  reqcmn->set_sm_session_state(magma::SMSessionFSMState::CREATING_0);
+
+  grpc::ServerContext server_context;
+  set_session_manager->SetAmfSessionContext(
+      &server_context, &request,
+      [this](grpc::Status status, SmContextVoid Void) {});
+
+  // Run session creation in the EventBase loop
+  evb->loopOnce();
+  evb->loopOnce();
+
+  auto session_map = session_store->read_sessions({IMSI2});
+  auto it          = session_map.find(IMSI2);
+  EXPECT_FALSE(it == session_map.end());
+  EXPECT_EQ(session_map[IMSI2].size(), 1);
+
+  SessionConfig cfg;
+  cfg.common_context       = request.common_context();
+  cfg.rat_specific_context = request.rat_specific_context();
+  cfg.rat_specific_context.mutable_m5gsm_session_context()->set_ssc_mode(
+      SSC_MODE_3);
+
+  SessionUpdate session_update =
+      SessionStore::get_default_session_update(session_map);
+  uint32_t pdu_id = 5;
+  SessionSearchCriteria id1_success_sid(IMSI2, IMSI_AND_PDUID, pdu_id);
+  auto session_it = session_store->find_session(session_map, id1_success_sid);
+  auto& session   = **session_it;
+  auto session_id = session->get_session_id();
+
+  session_enforcer->m5g_complete_termination(
+      session_map, IMSI2, session_id, session_update);
+
+  EXPECT_EQ(session_map[IMSI2].size(), 0);
 }
 
 int main(int argc, char** argv) {

--- a/lte/gateway/c/session_manager/test/test_set_session_manager_handler.cpp
+++ b/lte/gateway/c/session_manager/test/test_set_session_manager_handler.cpp
@@ -456,11 +456,11 @@ TEST_F(SessionManagerHandlerTest, test_SessionCompleteTerminationContext) {
       session_map, IMSI2, session_id, session_update);
 
   EXPECT_EQ(session_map[IMSI2].size(), 0);
+
 }
 
 int main(int argc, char** argv) {
   ::testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();
 }
-
 }  // namespace magma

--- a/lte/gateway/c/session_manager/test/test_set_session_manager_handler.cpp
+++ b/lte/gateway/c/session_manager/test/test_set_session_manager_handler.cpp
@@ -256,7 +256,7 @@ TEST_F(SessionManagerHandlerTest, test_SetPduSessionReleaseContext) {
       request.mutable_rat_specific_context()->mutable_m5gsm_session_context();
   auto* reqcmn = request.mutable_common_context();
   req->set_pdu_session_id({0x5});
-  req->set_rquest_type(magma::RequestType::INITIAL_REQUEST);
+  req->set_request_type(magma::RequestType::INITIAL_REQUEST);
   req->mutable_pdu_address()->set_redirect_address_type(
       magma::RedirectServer::IPV4);
   req->mutable_pdu_address()->set_redirect_server_address("10.20.30.40");
@@ -286,7 +286,7 @@ TEST_F(SessionManagerHandlerTest, test_SetPduSessionReleaseContext) {
   auto& session_temp = session_map[IMSI1][0];
   EXPECT_EQ(session_temp->get_config().common_context.sid().id(), IMSI1);
 
-  req->set_rquest_type(magma::RequestType::EXISTING_PDU_SESSION);
+  req->set_request_type(magma::RequestType::EXISTING_PDU_SESSION);
   reqcmn->set_sm_session_state(magma::SMSessionFSMState::RELEASED_4);
   reqcmn->set_sm_session_version(2);
 
@@ -304,7 +304,7 @@ TEST_F(SessionManagerHandlerTest, test_LocalReleaseSessionContext) {
       request.mutable_rat_specific_context()->mutable_m5gsm_session_context();
   auto* reqcmn = request.mutable_common_context();
   req->set_pdu_session_id({0x5});
-  req->set_rquest_type(magma::RequestType::INITIAL_REQUEST);
+  req->set_request_type(magma::RequestType::INITIAL_REQUEST);
   req->mutable_pdu_address()->set_redirect_address_type(
       magma::RedirectServer::IPV4);
   req->mutable_pdu_address()->set_redirect_server_address("10.20.30.40");
@@ -355,7 +355,7 @@ TEST_F(SessionManagerHandlerTest, test_LocalSessionTerminationContext) {
       request.mutable_rat_specific_context()->mutable_m5gsm_session_context();
   auto* reqcmn = request.mutable_common_context();
   req->set_pdu_session_id({0x5});
-  req->set_rquest_type(magma::RequestType::INITIAL_REQUEST);
+  req->set_request_type(magma::RequestType::INITIAL_REQUEST);
   req->mutable_pdu_address()->set_redirect_address_type(
       magma::RedirectServer::IPV4);
   req->mutable_pdu_address()->set_redirect_server_address("10.20.30.40");
@@ -398,7 +398,7 @@ TEST_F(SessionManagerHandlerTest, test_LocalSessionTerminationContext) {
   SessionStateUpdateCriteria& session_uc = session_update[IMSI2][session_id];
 
   session_enforcer->m5g_start_session_termination(
-      session_map, IMSI2, session, pdu_id, &session_uc);
+      session_map, session, pdu_id, &session_uc);
 
   EXPECT_FALSE(it == session_map.end());
   EXPECT_EQ(session_map[IMSI2].size(), 1);
@@ -412,7 +412,7 @@ TEST_F(SessionManagerHandlerTest, test_SessionCompleteTerminationContext) {
       request.mutable_rat_specific_context()->mutable_m5gsm_session_context();
   auto* reqcmn = request.mutable_common_context();
   req->set_pdu_session_id({0x5});
-  req->set_rquest_type(magma::RequestType::INITIAL_REQUEST);
+  req->set_request_type(magma::RequestType::INITIAL_REQUEST);
   req->mutable_pdu_address()->set_redirect_address_type(
       magma::RedirectServer::IPV4);
   req->mutable_pdu_address()->set_redirect_server_address("10.20.30.40");


### PR DESCRIPTION
Signed-off-by: prabina pattnaik <prabinak@wavelabs.ai>

## Summary

PDU session release support for 5G in master branch.
Below functionalities are supported as part of PDU session Release:
a) Read the SessionMap from global session_store.
b) Initiate release of the session in enforcer requested by AMF
c) Update respective session's state and session version.
d) Send Session Release message to UPF.
e) Handle the response notification from upf w.r.t. UPF message.
f) Clean up all resources related to requested session.
g) Handle the timeout termination session.

## Test Plan
UT Cases are written:
lte/gateway/c/session_manager/test/test_set_session_manager_handler.cpp

Functional Test:
Python stub written for Testing purpose:
lte/gateway/python/scripts/smf-upf_intergartion_TC_Stub.py
Output:
(python) vagrant@magma-dev:~/magma/lte/gateway/python/scripts$ python smf-upf_intergartion_TC_Stub.py amf_context set_amf_session_tc2
=========TEST CASE-2 PDU SESSION RELEASE============
common_context {
  sid {
    id: "IMSI12345"
  }
  apn: "BLR"
  rat_type: TGPP_NR
  sm_session_state: RELEASED_4
  sm_session_version: 2
}
rat_specific_context {
  m5gsm_session_context {
    pdu_session_id: 1
    rquest_type: EXISTING_PDU_SESSION
    pdu_address {
      redirect_server_address: "192.168.128.11"
    }
  }
}
Jun  4 15:48:47 magma-dev sessiond[23000]: I0604 15:48:47.394532 23000 SetMessageManagerHandler.cpp:101] Release request for session from IMSI: IMSI12345 pdu_id1

Below files are common code for #7254 and this PR:
lte/gateway/c/oai/tasks/grpc_service/AmfServiceImpl.cpp
lte/gateway/c/session_manager/SessionState.cpp
lte/gateway/c/session_manager/SessionState.h
lte/gateway/c/session_manager/SessionStateEnforcer.h
lte/gateway/c/session_manager/SessionStore.cpp
lte/gateway/c/session_manager/SessionStore.h        
lte/gateway/c/session_manager/StoredState.cpp
lte/gateway/c/session_manager/StoredState.h
lte/gateway/c/session_manager/sessiond_main.cpp
lte/gateway/c/session_manager/test/CMakeLists.txt
lte/gateway/c/session_manager/test/SessiondMocks.h
lte/gateway/c/session_manager/test/test_upf_node_state.cpp
lte/gateway/configs/sessiond.yml
lte/protos/pipelined.proto
lte/protos/session_manager.proto
lte/gateway/python/scripts/smf-upf_intergartion_TC_Stub.py

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
