### PR TITLE
[LTE][AGW] NSA add UE Additional security capabilities in NAS SMC, ad…

### DIFF
--- a/lte/gateway/c/oai/include/mme_app_messages_types.h
+++ b/lte/gateway/c/oai/include/mme_app_messages_types.h
@@ -96,6 +96,7 @@ typedef struct itti_mme_app_connection_establishment_cnf_s {
   uint16_t ue_security_capabilities_integrity_algorithms;
 
   // NR UE Security Capabilities
+  bool nr_ue_security_capabilities_present;
   uint16_t nr_ue_security_capabilities_encryption_algorithms;
   uint16_t nr_ue_security_capabilities_integrity_algorithms;
 

--- a/lte/gateway/c/oai/lib/3gpp/3gpp_24.301.h
+++ b/lte/gateway/c/oai/lib/3gpp/3gpp_24.301.h
@@ -301,6 +301,14 @@ typedef struct ue_security_capability_s {
   uint8_t gea : 7;
 } ue_security_capability_t;
 
+// 9.9.3.53 UE additional security capability
+typedef struct ue_additional_security_capability_s {
+  /* NR encryption algorithms supported  */
+  uint16_t _5g_ea;
+  /* NR integrity algorithms supported */
+  uint16_t _5g_ia;
+} ue_additional_security_capability_t;
+
 // 9.2.1.127 NR UE security capability
 #define NR_UE_SECURITY_CAPABILITY_MINIMUM_LENGTH 4
 #define NR_UE_SECURITY_CAPABILITY_MAXIMUM_LENGTH 7

--- a/lte/gateway/c/oai/tasks/mme_app/mme_app_bearer.c
+++ b/lte/gateway/c/oai/tasks/mme_app/mme_app_bearer.c
@@ -478,12 +478,11 @@ void mme_app_handle_conn_est_cnf(
   }
 
   if (emm_context._ue_network_capability.dcnr) {
+    establishment_cnf_p->nr_ue_security_capabilities_present = true;
     establishment_cnf_p->nr_ue_security_capabilities_encryption_algorithms =
-        ((uint16_t) emm_context._nr_ue_security_capability.nea & ~(1 << 7))
-        << 1;
+        emm_context.ue_additional_security_capability._5g_ea << 1;
     establishment_cnf_p->nr_ue_security_capabilities_integrity_algorithms =
-        ((uint16_t) emm_context._nr_ue_security_capability.nia & ~(1 << 7))
-        << 1;
+        emm_context.ue_additional_security_capability._5g_ia << 1;
   }
 
   derive_keNB(

--- a/lte/gateway/c/oai/tasks/nas/emm/Attach.c
+++ b/lte/gateway/c/oai/tasks/nas/emm/Attach.c
@@ -1156,6 +1156,11 @@ static int emm_attach_run_procedure(emm_context_t* emm_context) {
     // temporary choice to clear security context if it exist
     emm_ctx_clear_security(emm_context);
 
+    if (attach_proc->ies->ueadditionalsecuritycapability) {
+      emm_ctx_set_ue_additional_security_capability(
+          emm_context, attach_proc->ies->ueadditionalsecuritycapability);
+    }
+
     if (attach_proc->ies->imsi) {
       if ((attach_proc->ies->decode_status.mac_matched) ||
           !(attach_proc->ies->decode_status.integrity_protected_message)) {
@@ -2420,6 +2425,43 @@ static bool emm_attach_ies_have_changed(
       OAILOG_FUNC_RETURN(LOG_NAS_EMM, true);
     }
   }
+  /*
+   * UE Additional Security Capability
+   */
+  if ((ies1->ueadditionalsecuritycapability) &&
+      (!ies2->ueadditionalsecuritycapability)) {
+    OAILOG_DEBUG(
+        LOG_NAS_EMM,
+        "UE " MME_UE_S1AP_ID_FMT
+        " Attach IEs changed: UE additional security capability\n",
+        ue_id);
+    OAILOG_FUNC_RETURN(LOG_NAS_EMM, true);
+  }
+
+  if ((!ies1->ueadditionalsecuritycapability) &&
+      (ies2->ueadditionalsecuritycapability)) {
+    OAILOG_DEBUG(
+        LOG_NAS_EMM,
+        "UE " MME_UE_S1AP_ID_FMT
+        " Attach IEs changed: UE additional security capability\n",
+        ue_id);
+    OAILOG_FUNC_RETURN(LOG_NAS_EMM, true);
+  }
+
+  if ((ies1->ueadditionalsecuritycapability) &&
+      (ies2->ueadditionalsecuritycapability)) {
+    if (memcmp(
+            ies1->ueadditionalsecuritycapability,
+            ies2->ueadditionalsecuritycapability,
+            sizeof(*ies2->ueadditionalsecuritycapability)) != 0) {
+      OAILOG_DEBUG(
+          LOG_NAS_EMM,
+          "UE " MME_UE_S1AP_ID_FMT
+          " Attach IEs changed: UE additional security capability\n",
+          ue_id);
+      OAILOG_FUNC_RETURN(LOG_NAS_EMM, true);
+    }
+  }
   // TODO ESM MSG ?
 
   OAILOG_FUNC_RETURN(LOG_NAS_EMM, false);
@@ -2459,6 +2501,9 @@ void free_emm_attach_request_ies(emm_attach_request_ies_t** const ies) {
   }
   if ((*ies)->voicedomainpreferenceandueusagesetting) {
     free_wrapper((void**) &(*ies)->voicedomainpreferenceandueusagesetting);
+  }
+  if ((*ies)->ueadditionalsecuritycapability) {
+    free_wrapper((void**) &(*ies)->ueadditionalsecuritycapability);
   }
   free_wrapper((void**) ies);
 }

--- a/lte/gateway/c/oai/tasks/nas/emm/SecurityModeControl.c
+++ b/lte/gateway/c/oai/tasks/nas/emm/SecurityModeControl.c
@@ -361,6 +361,12 @@ int emm_proc_security_mode_control(
     // smc_proc->imeisv_request = (IS_EMM_CTXT_PRESENT_IMEISV(emm_ctx)) ?
     // false:true;
 
+    if IS_EMM_CTXT_PRESENT_UE_ADDITIONAL_SECURITY_CAPABILITY (emm_ctx) {
+      smc_proc->replayed_ue_add_sec_cap_present = true;
+      smc_proc->_5g_ea = emm_ctx->ue_additional_security_capability._5g_ea;
+      smc_proc->_5g_ia = emm_ctx->ue_additional_security_capability._5g_ia;
+    }
+
     /*
      * Send security mode command message to the UE
      */
@@ -833,6 +839,10 @@ static int security_request(nas_emm_smc_proc_t* const smc_proc) {
     emm_sap.u.emm_as.u.security.selected_eea   = smc_proc->selected_eea;
     emm_sap.u.emm_as.u.security.selected_eia   = smc_proc->selected_eia;
     emm_sap.u.emm_as.u.security.imeisv_request = smc_proc->imeisv_request;
+    emm_sap.u.emm_as.u.security.replayed_ue_add_sec_cap_present =
+        smc_proc->replayed_ue_add_sec_cap_present;
+    emm_sap.u.emm_as.u.security._5g_ea = smc_proc->_5g_ea;
+    emm_sap.u.emm_as.u.security._5g_ia = smc_proc->_5g_ia;
 
     ue_mm_context = mme_ue_context_exists_mme_ue_s1ap_id(smc_proc->ue_id);
     if (ue_mm_context) {

--- a/lte/gateway/c/oai/tasks/nas/emm/emm_data.h
+++ b/lte/gateway/c/oai/tasks/nas/emm/emm_data.h
@@ -203,6 +203,7 @@ typedef struct emm_context_s {
 #define EMM_CTXT_MEMBER_PENDING_DRX_PARAMETER ((uint32_t) 1 << 13)
 #define EMM_CTXT_MEMBER_EPS_BEARER_CONTEXT_STATUS ((uint32_t) 1 << 14)
 #define EMM_CTXT_MEMBER_MOB_STATION_CLSMARK2 ((uint32_t) 1 << 15)
+#define EMM_CTXT_MEMBER_UE_ADDITIONAL_SECURITY_CAPABILITY ((uint32_t) 1 << 16)
 
 #define EMM_CTXT_MEMBER_AUTH_VECTOR0 ((uint32_t) 1 << 26)
   //#define           EMM_CTXT_MEMBER_AUTH_VECTOR1                 ((uint32_t)1
@@ -245,7 +246,7 @@ typedef struct emm_context_s {
   ksi_t ksi;            /*key set identifier  */
   ue_network_capability_t _ue_network_capability;
   ms_network_capability_t _ms_network_capability;
-  nr_ue_security_capability_t _nr_ue_security_capability;
+  ue_additional_security_capability_t ue_additional_security_capability;
   drx_parameter_t _drx_parameter;
 
   int remaining_vectors;                       // remaining unused vectors
@@ -323,6 +324,9 @@ typedef struct emm_context_s {
 #define IS_EMM_CTXT_PRESENT_MS_NETWORK_CAPABILITY(eMmCtXtPtR)                  \
   (!!((eMmCtXtPtR)->member_present_mask &                                      \
       EMM_CTXT_MEMBER_MS_NETWORK_CAPABILITY_IE))
+#define IS_EMM_CTXT_PRESENT_UE_ADDITIONAL_SECURITY_CAPABILITY(eMmCtXtPtR)      \
+  (!!((eMmCtXtPtR)->member_present_mask &                                      \
+      EMM_CTXT_MEMBER_UE_ADDITIONAL_SECURITY_CAPABILITY))
 
 #define IS_EMM_CTXT_PRESENT_AUTH_VECTOR(eMmCtXtPtR, KsI)                       \
   (!!((eMmCtXtPtR)->member_present_mask &                                      \
@@ -519,6 +523,12 @@ void emm_ctx_set_drx_parameter(emm_context_t* const ctxt, drx_parameter_t* drx)
     __attribute__((nonnull));
 void emm_ctx_set_valid_drx_parameter(
     emm_context_t* const ctxt, drx_parameter_t* drx) __attribute__((nonnull));
+
+void emm_ctx_clear_ue_additional_security_capability(emm_context_t* const ctxt)
+    __attribute__((nonnull));
+void emm_ctx_set_ue_additional_security_capability(
+    emm_context_t* const ctxt, ue_additional_security_capability_t* drx)
+    __attribute__((nonnull));
 
 void free_emm_ctx_memory(
     emm_context_t* const ctxt, const mme_ue_s1ap_id_t ue_id);

--- a/lte/gateway/c/oai/tasks/nas/emm/emm_data_ctx.c
+++ b/lte/gateway/c/oai/tasks/nas/emm/emm_data_ctx.c
@@ -550,6 +550,39 @@ inline void emm_ctx_set_valid_drx_parameter(
 }
 
 //------------------------------------------------------------------------------
+/* Clear UE additional security capability */
+inline void emm_ctx_clear_ue_additional_security_capability(
+    emm_context_t* const ctxt) {
+  memset(
+      &ctxt->ue_additional_security_capability, 0,
+      sizeof(ue_additional_security_capability_t));
+  emm_ctx_clear_attribute_present(
+      ctxt, EMM_CTXT_MEMBER_UE_ADDITIONAL_SECURITY_CAPABILITY);
+  OAILOG_DEBUG(
+      LOG_NAS_EMM,
+      "ue_id=" MME_UE_S1AP_ID_FMT
+      " cleared ue additional security capability\n",
+      (PARENT_STRUCT(ctxt, struct ue_mm_context_s, emm_context))
+          ->mme_ue_s1ap_id);
+}
+
+/* Set UE additional security capability */
+inline void emm_ctx_set_ue_additional_security_capability(
+    emm_context_t* const ctxt, ue_additional_security_capability_t* uasc) {
+  memcpy(
+      &ctxt->ue_additional_security_capability, uasc,
+      sizeof(ue_additional_security_capability_t));
+  emm_ctx_set_attribute_present(
+      ctxt, EMM_CTXT_MEMBER_UE_ADDITIONAL_SECURITY_CAPABILITY);
+  OAILOG_DEBUG(
+      LOG_NAS_EMM,
+      "ue_id=" MME_UE_S1AP_ID_FMT
+      " set ue additional security capability (present)\n",
+      (PARENT_STRUCT(ctxt, struct ue_mm_context_s, emm_context))
+          ->mme_ue_s1ap_id);
+}
+
+//------------------------------------------------------------------------------
 /* Clear EPS bearer context status   */
 inline void emm_ctx_clear_eps_bearer_context_status(emm_context_t* const ctxt) {
   memset(
@@ -917,6 +950,7 @@ void emm_init_context(
   emm_ctx_clear_ue_nw_cap(emm_ctx);
   emm_ctx_clear_drx_parameter(emm_ctx);
   emm_ctx_clear_mobile_station_clsMark2(emm_ctx);
+  emm_ctx_clear_ue_additional_security_capability(emm_ctx);
   emm_ctx->T3422.id        = NAS_TIMER_INACTIVE_ID;
   emm_ctx->T3422.sec       = T3422_DEFAULT_VALUE;
   emm_ctx->new_attach_info = NULL;

--- a/lte/gateway/c/oai/tasks/nas/emm/emm_proc.h
+++ b/lte/gateway/c/oai/tasks/nas/emm/emm_proc.h
@@ -115,6 +115,7 @@ typedef struct emm_attach_request_ies_s {
       mob_st_clsMark2; /* Mobile station classmark2 provided by the UE */
   voice_domain_preference_and_ue_usage_setting_t*
       voicedomainpreferenceandueusagesetting;
+  ue_additional_security_capability_t* ueadditionalsecuritycapability;
 } emm_attach_request_ies_t;
 
 typedef struct emm_detach_request_ies_s {

--- a/lte/gateway/c/oai/tasks/nas/emm/msg/AttachRequest.c
+++ b/lte/gateway/c/oai/tasks/nas/emm/msg/AttachRequest.c
@@ -279,7 +279,7 @@ int decode_attach_request(
          * Set corresponding mask to 1 in presencemask
          */
         attach_request->presencemask |=
-            ATTACH_REQUEST_UE_ADDITIONAL_SECURITY_CAPABILITY_IEI;
+            ATTACH_REQUEST_UE_ADDITIONAL_SECURITY_CAPABILITY_PRESENT;
         break;
 
       case ATTACH_REQUEST_VOICE_DOMAIN_PREFERENCE_AND_UE_USAGE_SETTING_IEI:

--- a/lte/gateway/c/oai/tasks/nas/emm/msg/TrackingAreaUpdateRequest.c
+++ b/lte/gateway/c/oai/tasks/nas/emm/msg/TrackingAreaUpdateRequest.c
@@ -387,7 +387,7 @@ int decode_tracking_area_update_request(
          * Set corresponding mask to 1 in presencemask
          */
         tracking_area_update_request->presencemask |=
-            TRACKING_AREA_UPDATE_REQUEST_UE_ADDITIONAL_SECURITY_CAPABILITY_IEI;
+            TRACKING_AREA_UPDATE_REQUEST_UE_ADDITIONAL_SECURITY_CAPABILITY_PRESENT;
         break;
 
       default:

--- a/lte/gateway/c/oai/tasks/nas/emm/sap/emm_asDef.h
+++ b/lte/gateway/c/oai/tasks/nas/emm/sap/emm_asDef.h
@@ -138,6 +138,10 @@ typedef struct emm_as_security_s {
   uint8_t selected_eea; /* Selected EPS encryption algorithms   */
   uint8_t selected_eia; /* Selected EPS integrity algorithms    */
 
+  bool replayed_ue_add_sec_cap_present;
+  uint16_t _5g_ea; /* Replayed 5GS encryption algorithms */
+  uint16_t _5g_ia; /* Replayed 5GS integrity algorithms */
+
 #define EMM_AS_MSG_TYPE_IDENT 0x01 /* Identification message   */
 #define EMM_AS_MSG_TYPE_AUTH 0x02  /* Authentication message   */
 #define EMM_AS_MSG_TYPE_SMC 0x03   /* Security Mode Command    */

--- a/lte/gateway/c/oai/tasks/nas/emm/sap/emm_recv.c
+++ b/lte/gateway/c/oai/tasks/nas/emm/sap/emm_recv.c
@@ -444,6 +444,16 @@ int emm_recv_attach_request(
         sizeof(voice_domain_preference_and_ue_usage_setting_t));
   }
 
+  if (msg->presencemask &
+      ATTACH_REQUEST_UE_ADDITIONAL_SECURITY_CAPABILITY_PRESENT) {
+    params->ueadditionalsecuritycapability =
+        calloc(1, sizeof(ue_additional_security_capability_t));
+    memcpy(
+        params->ueadditionalsecuritycapability,
+        &msg->ueadditionalsecuritycapability,
+        sizeof(ue_additional_security_capability_t));
+  }
+
   /*
    * Execute the requested UE attach procedure
    */

--- a/lte/gateway/c/oai/tasks/nas/emm/sap/emm_send.c
+++ b/lte/gateway/c/oai/tasks/nas/emm/sap/emm_send.c
@@ -1501,6 +1501,13 @@ int emm_send_security_mode_command(
   emm_msg->replayeduesecuritycapabilities.gea          = msg->gea;
   emm_msg->presencemask                                = 0;
 
+  if (msg->replayed_ue_add_sec_cap_present) {
+    emm_msg->presencemask |=
+        SECURITY_MODE_COMMAND_REPLAYED_UE_ADDITIONAL_SECU_CAPABILITY_PRESENT;
+    emm_msg->replayedueadditionalsecuritycapabilities._5g_ea = msg->_5g_ea;
+    emm_msg->replayedueadditionalsecuritycapabilities._5g_ia = msg->_5g_ia;
+  }
+
   /*
    *  Setting the IMEISV Request
    */

--- a/lte/gateway/c/oai/tasks/nas/ies/UeAdditionalSecurityCapability.h
+++ b/lte/gateway/c/oai/tasks/nas/ies/UeAdditionalSecurityCapability.h
@@ -21,10 +21,7 @@
 #define UE_ADDITIONAL_SECURITY_CAPABILITY_MINIMUM_LENGTH 6
 #define UE_ADDITIONAL_SECURITY_CAPABILITY_MAXIMUM_LENGTH 6
 
-typedef struct ue_additional_security_capability_s {
-  uint16_t _5g_ea;
-  uint16_t _5g_ia;
-} ue_additional_security_capability_t;
+#include "3gpp_24.301.h"
 
 int encode_ue_additional_security_capability(
     ue_additional_security_capability_t* uasc, uint8_t iei, uint8_t* buffer,

--- a/lte/gateway/c/oai/tasks/nas/nas_procedures.h
+++ b/lte/gateway/c/oai/tasks/nas/nas_procedures.h
@@ -245,6 +245,9 @@ typedef struct nas_emm_smc_proc_s {
                         * to the ongoing EMM procedure */
   bool is_new;         /* new security context for SMC header type */
   bool imeisv_request;
+  bool replayed_ue_add_sec_cap_present;
+  uint16_t _5g_ea; /* Replayed 5GS encryption algorithms */
+  uint16_t _5g_ia; /* Replayed 5GS integrity algorithms */
 } nas_emm_smc_proc_t;
 
 typedef struct nas_emm_info_proc_s {

--- a/lte/gateway/c/oai/tasks/nas/nas_state_converter.cpp
+++ b/lte/gateway/c/oai/tasks/nas/nas_state_converter.cpp
@@ -594,6 +594,28 @@ void NasStateConverter::proto_to_voice_preference(
   // TODO
 }
 
+void NasStateConverter::ue_additional_security_capability_to_proto(
+    const ue_additional_security_capability_t*
+        state_ue_additional_security_capability,
+    oai::UeAdditionalSecurityCapability*
+        ue_additional_security_capability_proto) {
+  ue_additional_security_capability_proto->set_ea(
+      state_ue_additional_security_capability->_5g_ea);
+  ue_additional_security_capability_proto->set_ia(
+      state_ue_additional_security_capability->_5g_ia);
+}
+
+void NasStateConverter::proto_to_ue_additional_security_capability(
+    const oai::UeAdditionalSecurityCapability&
+        ue_additional_security_capability_proto,
+    ue_additional_security_capability_t*
+        state_ue_additional_security_capability) {
+  state_ue_additional_security_capability->_5g_ea =
+      ue_additional_security_capability_proto.ea();
+  state_ue_additional_security_capability->_5g_ia =
+      ue_additional_security_capability_proto.ia();
+}
+
 void NasStateConverter::nas_message_decode_status_to_proto(
     const nas_message_decode_status_t* state_nas_message_decode_status,
     oai::NasMsgDecodeStatus* nas_msg_decode_status_proto) {
@@ -687,6 +709,11 @@ void NasStateConverter::emm_attach_request_ies_to_proto(
   voice_preference_to_proto(
       state_emm_attach_request_ies->voicedomainpreferenceandueusagesetting,
       attach_request_ies_proto->mutable_voice_preference());
+  if (state_emm_attach_request_ies->ueadditionalsecuritycapability) {
+    ue_additional_security_capability_to_proto(
+        state_emm_attach_request_ies->ueadditionalsecuritycapability,
+        attach_request_ies_proto->mutable_ue_additional_security_capability());
+  }
 }
 
 void NasStateConverter::proto_to_emm_attach_request_ies(
@@ -759,6 +786,14 @@ void NasStateConverter::proto_to_emm_attach_request_ies(
   proto_to_voice_preference(
       attach_request_ies_proto.voice_preference(),
       state_emm_attach_request_ies->voicedomainpreferenceandueusagesetting);
+  if (attach_request_ies_proto.has_ue_additional_security_capability()) {
+    state_emm_attach_request_ies->ueadditionalsecuritycapability =
+        (ue_additional_security_capability_t*) calloc(
+            1, sizeof(ue_additional_security_capability_t));
+    proto_to_ue_additional_security_capability(
+        attach_request_ies_proto.ue_additional_security_capability(),
+        state_emm_attach_request_ies->ueadditionalsecuritycapability);
+  }
 }
 
 void NasStateConverter::nas_attach_proc_to_proto(
@@ -1700,6 +1735,9 @@ void NasStateConverter::emm_context_to_proto(
   ue_network_capability_to_proto(
       &state_emm_context->_ue_network_capability,
       emm_context_proto->mutable_ue_network_capability());
+  ue_additional_security_capability_to_proto(
+      &state_emm_context->ue_additional_security_capability,
+      emm_context_proto->mutable_ue_additional_security_capability());
   if (state_emm_context->t3422_arg) {
     nw_detach_data_to_proto(
         (nw_detach_data_t*) state_emm_context->t3422_arg,
@@ -1785,6 +1823,9 @@ void NasStateConverter::proto_to_emm_context(
   proto_to_ue_network_capability(
       emm_context_proto.ue_network_capability(),
       &state_emm_context->_ue_network_capability);
+  proto_to_ue_additional_security_capability(
+      emm_context_proto.ue_additional_security_capability(),
+      &state_emm_context->ue_additional_security_capability);
 
   state_emm_context->T3422.id  = NAS_TIMER_INACTIVE_ID;
   state_emm_context->T3422.sec = T3422_DEFAULT_VALUE;

--- a/lte/gateway/c/oai/tasks/nas/nas_state_converter.h
+++ b/lte/gateway/c/oai/tasks/nas/nas_state_converter.h
@@ -162,6 +162,18 @@ class NasStateConverter : StateConverter {
       voice_domain_preference_and_ue_usage_setting_t*
           state_voice_domain_preference_and_ue_usage_setting);
 
+  static void ue_additional_security_capability_to_proto(
+      const ue_additional_security_capability_t*
+          state_ue_additional_security_capability,
+      oai::UeAdditionalSecurityCapability*
+          ue_additional_security_capability_proto);
+
+  static void proto_to_ue_additional_security_capability(
+      const oai::UeAdditionalSecurityCapability&
+          ue_additional_security_capability_proto,
+      ue_additional_security_capability_t*
+          state_ue_additional_security_capability);
+
   static void ambr_to_proto(const ambr_t& state_ambr, oai::Ambr* ambr_proto);
 
   static void proto_to_ambr(const oai::Ambr& ambr_proto, ambr_t* state_ambr);

--- a/lte/gateway/c/oai/tasks/s1ap/s1ap_mme_nas_procedures.c
+++ b/lte/gateway/c/oai/tasks/s1ap/s1ap_mme_nas_procedures.c
@@ -1043,48 +1043,6 @@ void s1ap_handle_conn_est_cnf(
         conn_est_cnf_pP->ue_security_capabilities_integrity_algorithms);
     ASN_SEQUENCE_ADD(&out->protocolIEs.list, ie);
   }
-  if (uenetworkcapability.dcnr == 1) {
-    OAILOG_DEBUG(
-        LOG_S1AP, " EN_DC dual connectivity indicator = %d \n",
-        uenetworkcapability.dcnr);
-    {
-      ie = (S1ap_InitialContextSetupRequestIEs_t*) calloc(
-          1, sizeof(S1ap_InitialContextSetupRequestIEs_t));
-      ie->id          = S1ap_ProtocolIE_ID_id_NRUESecurityCapabilities;
-      ie->criticality = S1ap_Criticality_reject;
-      ie->value.present =
-          S1ap_InitialContextSetupRequestIEs__value_PR_NRUESecurityCapabilities;
-
-      S1ap_NRUESecurityCapabilities_t* const nr_ue_security_capabilities =
-          &ie->value.choice.NRUESecurityCapabilities;
-
-      nr_ue_security_capabilities->nRencryptionAlgorithms.buf =
-          calloc(1, sizeof(uint16_t));
-      memcpy(
-          nr_ue_security_capabilities->nRencryptionAlgorithms.buf,
-          &conn_est_cnf_pP->nr_ue_security_capabilities_encryption_algorithms,
-          sizeof(uint16_t));
-      nr_ue_security_capabilities->nRencryptionAlgorithms.size        = 2;
-      nr_ue_security_capabilities->nRencryptionAlgorithms.bits_unused = 0;
-      OAILOG_DEBUG(
-          LOG_S1AP, "security_capabilities_encryption_algorithms 0x%04X\n",
-          conn_est_cnf_pP->nr_ue_security_capabilities_encryption_algorithms);
-
-      nr_ue_security_capabilities->nRintegrityProtectionAlgorithms.buf =
-          calloc(1, sizeof(uint16_t));
-      memcpy(
-          nr_ue_security_capabilities->nRintegrityProtectionAlgorithms.buf,
-          &conn_est_cnf_pP->nr_ue_security_capabilities_integrity_algorithms,
-          sizeof(uint16_t));
-      nr_ue_security_capabilities->nRintegrityProtectionAlgorithms.size = 2;
-      nr_ue_security_capabilities->nRintegrityProtectionAlgorithms.bits_unused =
-          0;
-      OAILOG_DEBUG(
-          LOG_S1AP, "security_capabilities_integrity_algorithms 0x%04X\n",
-          conn_est_cnf_pP->nr_ue_security_capabilities_integrity_algorithms);
-      ASN_SEQUENCE_ADD(&out->protocolIEs.list, ie);
-    }
-  }
   /* mandatory */
   ie = (S1ap_InitialContextSetupRequestIEs_t*) calloc(
       1, sizeof(S1ap_InitialContextSetupRequestIEs_t));
@@ -1123,6 +1081,50 @@ void s1ap_handle_conn_est_cnf(
         (const char*) conn_est_cnf_pP->ue_radio_capability->data,
         conn_est_cnf_pP->ue_radio_capability->slen);
     ASN_SEQUENCE_ADD(&out->protocolIEs.list, ie);
+  }
+
+  /* optional */
+  if (conn_est_cnf_pP->nr_ue_security_capabilities_present) {
+    {
+      ie = (S1ap_InitialContextSetupRequestIEs_t*) calloc(
+          1, sizeof(S1ap_InitialContextSetupRequestIEs_t));
+      ie->id          = S1ap_ProtocolIE_ID_id_NRUESecurityCapabilities;
+      ie->criticality = S1ap_Criticality_ignore;
+      ie->value.present =
+          S1ap_InitialContextSetupRequestIEs__value_PR_NRUESecurityCapabilities;
+
+      S1ap_NRUESecurityCapabilities_t* const nr_ue_security_capabilities =
+          &ie->value.choice.NRUESecurityCapabilities;
+
+      nr_ue_security_capabilities->nRencryptionAlgorithms.buf =
+          calloc(1, sizeof(uint16_t));
+      uint16_t ahtobe16 = htobe16(
+          conn_est_cnf_pP->nr_ue_security_capabilities_encryption_algorithms);
+      memcpy(
+          nr_ue_security_capabilities->nRencryptionAlgorithms.buf, &ahtobe16,
+          sizeof(uint16_t));
+      nr_ue_security_capabilities->nRencryptionAlgorithms.size        = 2;
+      nr_ue_security_capabilities->nRencryptionAlgorithms.bits_unused = 0;
+      OAILOG_DEBUG(
+          LOG_S1AP,
+          "NR ue security_capabilities_encryption_algorithms 0x%04X\n",
+          conn_est_cnf_pP->nr_ue_security_capabilities_encryption_algorithms);
+
+      nr_ue_security_capabilities->nRintegrityProtectionAlgorithms.buf =
+          calloc(1, sizeof(uint16_t));
+      ahtobe16 = htobe16(
+          conn_est_cnf_pP->nr_ue_security_capabilities_integrity_algorithms);
+      memcpy(
+          nr_ue_security_capabilities->nRintegrityProtectionAlgorithms.buf,
+          &ahtobe16, sizeof(uint16_t));
+      nr_ue_security_capabilities->nRintegrityProtectionAlgorithms.size = 2;
+      nr_ue_security_capabilities->nRintegrityProtectionAlgorithms.bits_unused =
+          0;
+      OAILOG_DEBUG(
+          LOG_S1AP, "NR ue security_capabilities_integrity_algorithms 0x%04X\n",
+          conn_est_cnf_pP->nr_ue_security_capabilities_integrity_algorithms);
+      ASN_SEQUENCE_ADD(&out->protocolIEs.list, ie);
+    }
   }
 
   if (s1ap_mme_encode_pdu(&pdu, &buffer_p, &length) < 0) {

--- a/lte/protos/oai/nas_state.proto
+++ b/lte/protos/oai/nas_state.proto
@@ -130,6 +130,7 @@ message AttachRequestIes {
   NasMsgDecodeStatus decode_status = 16;
   MobileStaClassmark2 classmark2 = 17;
   VoicePreference voice_preference = 18;
+  UeAdditionalSecurityCapability ue_additional_security_capability = 19;
 }
 
 // nas_emm_attach_proc_t
@@ -334,6 +335,12 @@ message UeNetworkCapability {
   uint32 length = 33;
 }
 
+// ue_additional_security_capability_t
+message UeAdditionalSecurityCapability {
+  uint32 ea = 1;
+  uint32 ia = 2;
+}
+
 // bearer_qos_t
 message BearerQos {
   uint32 pci = 1;
@@ -464,5 +471,6 @@ message EmmContext {
   UeNetworkCapability ue_network_capability = 65;
   NwDetachData nw_detach_data = 66;
   NewAttachInfo new_attach_info = 67;
+  UeAdditionalSecurityCapability ue_additional_security_capability = 68;
   // TODO: add remaining emm_context elements
   }


### PR DESCRIPTION
[LTE][AGW] NSA 
Add UE Additional security capabilities in NAS SECURITY_MODE_COMMAND.
Add NRUESecurityCapabilities in InitialContextSetupRequest.
Assuming MME always acknowledge NSA for incoming en-dc featured UEs

Signed-off-by: lionelgo <29477918+lionelgo@users.noreply.github.com>

## Summary

Changes made to be compliant with 3GPP specs

## Test Plan
Tested with ds-tester and OAI CUPS
See ds-tester scenario file and PCAP
[PR5811.zip](https://github.com/magma/magma/files/6600059/PR5811.zip)



## Additional Information



