### PR TITLE
[mme] Change various AssertFatal calls to Fatal

### DIFF
--- a/lte/gateway/c/core/oai/common/common_defs.h
+++ b/lte/gateway/c/core/oai/common/common_defs.h
@@ -168,14 +168,14 @@ typedef enum {
 #define IPV4_STR_ADDR_TO_INADDR(AdDr_StR, InAdDr, MeSsAgE)                     \
   do {                                                                         \
     if (inet_aton(AdDr_StR, &InAdDr) <= 0) {                                   \
-      AssertFatal(0, MeSsAgE);                                                 \
+      Fatal(MeSsAgE);                                                          \
     }                                                                          \
   } while (0)
 
 #define IPV6_STR_ADDR_TO_INADDR(AdDr_StR, InAdDr, MeSsAgE)                     \
   do {                                                                         \
     if (inet_pton(AF_INET6, AdDr_StR, &InAdDr) <= 0) {                         \
-      AssertFatal(0, MeSsAgE);                                                 \
+      Fatal(MeSsAgE);                                                          \
     }                                                                          \
   } while (0)
 

--- a/lte/gateway/c/core/oai/lib/3gpp/3gpp_24.008_common_ies.c
+++ b/lte/gateway/c/core/oai/lib/3gpp/3gpp_24.008_common_ies.c
@@ -885,7 +885,6 @@ int encode_mobile_station_classmark_2_ie(
 int decode_mobile_station_classmark_3_ie(
     mobile_station_classmark3_t* mobilestationclassmark3,
     const bool iei_present, uint8_t* buffer, const uint32_t len) {
-  // AssertFatal(false, "TODO");
   // Temporary fix so that we decode other IEs required for CSFB
   int decoded   = 0;
   uint8_t ielen = 0;
@@ -906,7 +905,6 @@ int decode_mobile_station_classmark_3_ie(
 int encode_mobile_station_classmark_3_ie(
     mobile_station_classmark3_t* mobilestationclassmark3,
     const bool iei_present, uint8_t* buffer, const uint32_t len) {
-  // AssertFatal(false, "TODO");
   return 0;
 }
 
@@ -1031,7 +1029,6 @@ int encode_ms_network_feature_support_ie(
 int decode_network_resource_identifier_container_ie(
     network_resource_identifier_container_t* networkresourceidentifiercontainer,
     const bool iei_present, uint8_t* buffer, const uint32_t len) {
-  // AssertFatal(false, "TODO");
   // Temporary fix so that we decode other IEs
   int decoded   = 0;
   uint8_t ielen = 0;
@@ -1052,6 +1049,5 @@ int decode_network_resource_identifier_container_ie(
 int encode_network_resource_identifier_container_ie(
     network_resource_identifier_container_t* networkresourceidentifiercontainer,
     const bool iei_present, uint8_t* buffer, const uint32_t len) {
-  // AssertFatal(false, "TODO");
   return 0;
 }

--- a/lte/gateway/c/core/oai/lib/3gpp/3gpp_24.008_gmm_ies.c
+++ b/lte/gateway/c/core/oai/lib/3gpp/3gpp_24.008_gmm_ies.c
@@ -190,7 +190,7 @@ int decode_identity_type_2_ie(
       buffer, IDENTITY_TYPE_2_IE_MAX_LENGTH, len);
 
   if (is_ie_present) {
-    AssertFatal(0, "No IEI for Identity type 2");
+    Fatal("No IEI for Identity type 2");
     CHECK_IEI_DECODER((*buffer & 0xf0), 0);
   }
 
@@ -212,7 +212,7 @@ int encode_identity_type_2_ie(
       buffer, IDENTITY_TYPE_2_IE_MAX_LENGTH, len);
   *(buffer + encoded) = 0x00;
   if (is_ie_present) {
-    AssertFatal(0, "No IEI for Identity type 2");
+    Fatal("No IEI for Identity type 2");
     *(buffer + encoded) |= (0 & 0xf0);
   }
   *(buffer + encoded) |= (*identitytype2 & 0x7);

--- a/lte/gateway/c/core/oai/lib/3gpp/3gpp_24.008_mm_ies.c
+++ b/lte/gateway/c/core/oai/lib/3gpp/3gpp_24.008_mm_ies.c
@@ -584,7 +584,7 @@ int decode_emergency_number_list_ie(
        i < EMERGENCY_NUMBER_MAX_DIGITS; i++) {
     e->number_digit[i] = 0xFF;
   }
-  AssertFatal(0, "TODO emergency_number_list_t->next");
+  Fatal("TODO emergency_number_list_t->next");
 
   return decoded;
 }
@@ -597,7 +597,7 @@ int encode_emergency_number_list_ie(
   uint32_t encoded           = 0;
   emergency_number_list_t* e = emergencynumberlist;
 
-  AssertFatal(0, "TODO");
+  Fatal("TODO Implement encode_emergency_number_list_ie");
   if (iei_present) {
     CHECK_PDU_POINTER_AND_LENGTH_ENCODER(
         buffer, EMERGENCY_NUMBER_LIST_IE_MIN_LENGTH, len);

--- a/lte/gateway/c/core/oai/lib/3gpp/3gpp_24.008_sm_ies.c
+++ b/lte/gateway/c/core/oai/lib/3gpp/3gpp_24.008_sm_ies.c
@@ -496,14 +496,14 @@ int encode_quality_of_service_ie(
 int encode_linked_ti_ie(
     linked_ti_t* linkedti, const bool iei_present, uint8_t* buffer,
     const uint32_t len) {
-  AssertFatal(0, "TODO");
+  Fatal("TODO Implement encode_linked_ti_ie");
   return 0;
 }
 
 int decode_linked_ti_ie(
     linked_ti_t* linkedti, const bool iei_present, uint8_t* buffer,
     const uint32_t len) {
-  AssertFatal(0, "TODO");
+  Fatal("TODO Implement decode_linked_ti_ie");
   return 0;
 }
 

--- a/lte/gateway/c/core/oai/lib/gtpv2-c/nwgtpv2c-0.11/include/NwGtpv2cPrivate.h
+++ b/lte/gateway/c/core/oai/lib/gtpv2-c/nwgtpv2c-0.11/include/NwGtpv2cPrivate.h
@@ -66,7 +66,7 @@ extern "C" {
                  ->memMgr.memAlloc(                                            \
                      ((nw_gtpv2c_stack_t*) (_stack))->memMgr.hMemMgr, _size,   \
                      __FILE__, __LINE__);                                      \
-      AssertFatal(0, "Do not use this Mem manager");                           \
+      Fatal("Do not use this Mem manager");                                    \
     } else {                                                                   \
       _mem = (_type) malloc(_size);                                            \
     }                                                                          \
@@ -80,7 +80,7 @@ extern "C" {
           ->memMgr.memFree(                                                    \
               ((nw_gtpv2c_stack_t*) (_stack))->memMgr.hMemMgr, _mem, __FILE__, \
               __LINE__);                                                       \
-      AssertFatal(0, "Do not use this Mem manager");                           \
+      Fatal("Do not use this Mem manager");                                    \
     } else {                                                                   \
       free((void*) _mem);                                                      \
     }                                                                          \

--- a/lte/gateway/c/core/oai/tasks/mme_app/mme_config.c
+++ b/lte/gateway/c/core/oai/tasks/mme_app/mme_config.c
@@ -342,13 +342,13 @@ int mme_config_parse_file(mme_config_t* config_pP) {
           bdata(config_pP->config_file), config_error_line(&cfg),
           config_error_text(&cfg));
       config_destroy(&cfg);
-      AssertFatal(
-          1 == 0, "Failed to parse MME configuration file %s!\n",
+      Fatal(
+          "Failed to parse MME configuration file %s!\n",
           bdata(config_pP->config_file));
     }
   } else {
     config_destroy(&cfg);
-    AssertFatal(0, "No MME configuration file provided!\n");
+    Fatal("No MME configuration file provided!\n");
   }
 
   setting_mme = config_lookup(&cfg, MME_CONFIG_STRING_MME_CONFIG);
@@ -636,8 +636,8 @@ int mme_config_parse_file(mme_config_t* config_pP) {
             config_pP->s6a_config.hss_host_name = bfromcstr(astring);
           }
         } else
-          AssertFatal(
-              1 == 0, "You have to provide a valid HSS hostname %s=...\n",
+          Fatal(
+              "You have to provide a valid HSS hostname %s=...\n",
               MME_CONFIG_STRING_S6A_HSS_HOSTNAME);
       }
       if ((config_setting_lookup_string(
@@ -650,8 +650,8 @@ int mme_config_parse_file(mme_config_t* config_pP) {
             config_pP->s6a_config.hss_realm = bfromcstr(astring);
           }
         } else
-          AssertFatal(
-              1 == 0, "You have to provide a valid HSS realm %s=...\n",
+          Fatal(
+              "You have to provide a valid HSS realm %s=...\n",
               MME_CONFIG_STRING_S6A_HSS_REALM);
       }
     }

--- a/lte/gateway/c/core/oai/tasks/nas/api/mme/mme_api.c
+++ b/lte/gateway/c/core/oai/tasks/nas/api/mme/mme_api.c
@@ -224,8 +224,8 @@ int mme_api_get_emm_config(
       break;
     }
     default:
-      AssertFatal(
-          0, "BAD TAI list configuration, unknown TAI list type %u",
+      Fatal(
+          "BAD TAI list configuration, unknown TAI list type %u",
           mme_config_p->served_tai.list_type);
   }
   // Read GUMMEI List
@@ -526,8 +526,8 @@ int mme_api_new_guti(
         }
         break;
       default:
-        AssertFatal(
-            0, "BAD TAI list configuration, unknown TAI list type %u",
+        Fatal(
+            "BAD TAI list configuration, unknown TAI list type %u",
             _emm_data.conf.tai_list.partial_tai_list[i].typeoflist);
     }
 

--- a/lte/gateway/c/core/oai/tasks/nas/emm/Attach.c
+++ b/lte/gateway/c/core/oai/tasks/nas/emm/Attach.c
@@ -1183,7 +1183,7 @@ static int emm_attach_run_procedure(emm_context_t* emm_context) {
           emm_attach_failure_identification_cb);
     } else if (attach_proc->ies->imei) {
       // emergency allowed if go here, but have to be implemented...
-      AssertFatal(0, "TODO emergency");
+      Fatal("TODO emergency");
     }
   }
   OAILOG_FUNC_RETURN(LOG_NAS_EMM, rc);
@@ -1232,7 +1232,7 @@ static int emm_attach_failure_identification_cb(emm_context_t* emm_context) {
       LOG_NAS_EMM, emm_context->_imsi64,
       "ATTACH - Identification procedure failed!\n");
 
-  AssertFatal(0, "Cannot happen...\n");
+  Fatal("Cannot happen...\n");
   OAILOG_FUNC_RETURN(LOG_NAS_EMM, rc);
 }
 

--- a/lte/gateway/c/core/oai/tasks/nas/emm/Identification.c
+++ b/lte/gateway/c/core/oai/tasks/nas/emm/Identification.c
@@ -294,8 +294,7 @@ int emm_proc_identification_complete(
         /*
          * Update the GUTI
          */
-        AssertFatal(
-            false,
+        Fatal(
             "TODO, should not happen because this type of identity is not "
             "requested by MME");
       }

--- a/lte/gateway/c/core/oai/tasks/nas/esm/PdnConnectivity.c
+++ b/lte/gateway/c/core/oai/tasks/nas/esm/PdnConnectivity.c
@@ -403,10 +403,10 @@ static int pdn_connectivity_create(
             break;
           // TODO Handle static IPv4v6 addr allocation
           case IPv4_AND_v6:
-            AssertFatal(0, "TODO\n");
+            Fatal("TODO Implement pdn_connectivity_create IPv4_AND_v6 \n");
             break;
           case IPv4_OR_v6:
-            AssertFatal(0, "TODO\n");
+            Fatal("TODO Implement pdn_connectivity_create IPv4_OR_v6 \n");
             break;
           default:;
         }
@@ -467,10 +467,10 @@ static int pdn_connectivity_create(
                 "BAD IPv6 ADDRESS FORMAT FOR PAA!\n");
             break;
           case IPv4_AND_v6:
-            AssertFatal(0, "TODO\n");
+            Fatal("TODO Implement pdn_connectivity_create IPv4_AND_v6 \n");
             break;
           case IPv4_OR_v6:
-            AssertFatal(0, "TODO\n");
+            Fatal("TODO Implement pdn_connectivity_create IPv4_OR_v6 \n");
             break;
           default:;
         }

--- a/lte/gateway/c/core/oai/tasks/nas/ies/TrafficFlowAggregateDescription.c
+++ b/lte/gateway/c/core/oai/tasks/nas/ies/TrafficFlowAggregateDescription.c
@@ -30,8 +30,7 @@
 int decode_traffic_flow_aggregate_description(
     traffic_flow_aggregate_description_t* trafficflowaggregatedescription,
     uint8_t iei, uint8_t* buffer, uint32_t len) {
-  AssertFatal(
-      0,
+  Fatal(
       "The Traffic flow aggregate description information element is decoded "
       "using the same format as the Traffic flow template (TFT) information "
       "element");
@@ -42,8 +41,7 @@ int decode_traffic_flow_aggregate_description(
 int encode_traffic_flow_aggregate_description(
     traffic_flow_aggregate_description_t* trafficflowaggregatedescription,
     uint8_t iei, uint8_t* buffer, uint32_t len) {
-  AssertFatal(
-      0,
+  Fatal(
       "The Traffic flow aggregate description information element is encoded "
       "using the same format as the Traffic flow template (TFT) information "
       "element");

--- a/lte/gateway/c/core/oai/tasks/nas/nas_procedures.c
+++ b/lte/gateway/c/core/oai/tasks/nas/nas_procedures.c
@@ -315,7 +315,7 @@ static void nas_delete_child_procedures(
 //-----------------------------------------------------------------------------
 static void nas_delete_con_mngt_procedure(nas_emm_con_mngt_proc_t** proc) {
   if (*proc) {
-    AssertFatal(0, "TODO");
+    Fatal("TODO Implement nas_delete_con_mngt_procedure");
     free_wrapper((void**) proc);
   }
 }

--- a/lte/gateway/c/core/oai/tasks/s1ap/s1ap_mme_handlers.c
+++ b/lte/gateway/c/core/oai/tasks/s1ap/s1ap_mme_handlers.c
@@ -4075,7 +4075,7 @@ int s1ap_mme_handle_erab_setup_response(
 int s1ap_mme_handle_erab_setup_failure(
     s1ap_state_t* state, const sctp_assoc_id_t assoc_id,
     const sctp_stream_id_t stream, S1ap_S1AP_PDU_t* message) {
-  AssertFatal(0, "TODO");
+  Fatal("TODO Implement s1ap_mme_handle_erab_setup_failure");
 }
 
 //------------------------------------------------------------------------------
@@ -4684,8 +4684,7 @@ int s1ap_mme_handle_erab_modification_indication(
                .s1_xNB_fteid.ipv6_address,
           transport_layer_address->data, blength(transport_layer_address));
     } else {
-      AssertFatal(
-          0, "TODO IP address %d bytes", blength(transport_layer_address));
+      Fatal("TODO IP address %d bytes", blength(transport_layer_address));
     }
     bdestroy_wrapper(&transport_layer_address);
 
@@ -4741,8 +4740,7 @@ int s1ap_mme_handle_erab_modification_indication(
                  .s1_xNB_fteid.ipv6_address,
             transport_layer_address->data, blength(transport_layer_address));
       } else {
-        AssertFatal(
-            0, "TODO IP address %d bytes", blength(transport_layer_address));
+        Fatal("TODO IP address %d bytes", blength(transport_layer_address));
       }
       bdestroy_wrapper(&transport_layer_address);
 

--- a/lte/gateway/c/core/oai/tasks/sgw/pgw_config.c
+++ b/lte/gateway/c/core/oai/tasks/sgw/pgw_config.c
@@ -244,14 +244,14 @@ int pgw_config_parse_file(pgw_config_t* config_pP) {
           LOG_SPGW_APP, "%s:%d - %s\n", bdata(config_pP->config_file),
           config_error_line(&cfg), config_error_text(&cfg));
       config_destroy(&cfg);
-      AssertFatal(
-          1 == 0, "Failed to parse SP-GW configuration file %s!\n",
+      Fatal(
+          "Failed to parse SP-GW configuration file %s!\n",
           bdata(config_pP->config_file));
     }
   } else {
     OAILOG_ERROR(LOG_SPGW_APP, "No SP-GW configuration file provided!\n");
     config_destroy(&cfg);
-    AssertFatal(0, "No SP-GW configuration file provided!\n");
+    Fatal("No SP-GW configuration file provided!\n");
   }
 
   OAILOG_INFO(

--- a/lte/gateway/c/core/oai/tasks/sgw/pgw_handlers.c
+++ b/lte/gateway/c/core/oai/tasks/sgw/pgw_handlers.c
@@ -145,8 +145,8 @@ void handle_s5_create_session_request(
       break;
 
     default:
-      AssertFatal(
-          0, "BAD paa.pdn_type %d",
+      Fatal(
+          "BAD paa.pdn_type %d",
           new_bearer_ctxt_info_p->sgw_eps_bearer_context_information
               .saved_message.pdn_type);
       break;

--- a/lte/gateway/c/core/oai/tasks/sgw/pgw_pcef_emulation.c
+++ b/lte/gateway/c/core/oai/tasks/sgw/pgw_pcef_emulation.c
@@ -468,7 +468,7 @@ bstring pgw_pcef_emulation_packet_filter_2_iptable_string(
   }
   if (TRAFFIC_FLOW_TEMPLATE_IPV6_REMOTE_ADDR_FLAG &
       packetfiltercontents->flags) {
-    AssertFatal(0, "TODO");  // we have time
+    Fatal("TODO Implement pgw_pcef_emulation_packet_filter_2_iptable_string");
   }
   if (TRAFFIC_FLOW_TEMPLATE_PROTOCOL_NEXT_HEADER_FLAG &
       packetfiltercontents->flags) {
@@ -491,7 +491,7 @@ bstring pgw_pcef_emulation_packet_filter_2_iptable_string(
   }
   if (TRAFFIC_FLOW_TEMPLATE_LOCAL_PORT_RANGE_FLAG &
       packetfiltercontents->flags) {
-    AssertFatal(0, "TODO LOCAL_PORT_RANGE");
+    Fatal("TODO LOCAL_PORT_RANGE");
   }
   if (TRAFFIC_FLOW_TEMPLATE_SINGLE_REMOTE_PORT_FLAG &
       packetfiltercontents->flags) {
@@ -508,7 +508,7 @@ bstring pgw_pcef_emulation_packet_filter_2_iptable_string(
   }
   if (TRAFFIC_FLOW_TEMPLATE_REMOTE_PORT_RANGE_FLAG &
       packetfiltercontents->flags) {
-    AssertFatal(0, "TODO REMOTE_PORT_RANGE");
+    Fatal("TODO REMOTE_PORT_RANGE");
   }
   if (TRAFFIC_FLOW_TEMPLATE_SECURITY_PARAMETER_INDEX_FLAG &
       packetfiltercontents->flags) {
@@ -524,7 +524,7 @@ bstring pgw_pcef_emulation_packet_filter_2_iptable_string(
         packetfiltercontents->typdeofservice_trafficclass.value);
   }
   if (TRAFFIC_FLOW_TEMPLATE_FLOW_LABEL_FLAG & packetfiltercontents->flags) {
-    AssertFatal(0, "TODO");  // we have time
+    Fatal("TODO Implement pgw_pcef_emulation_packet_filter_2_iptable_string");
   }
   return bstr;
 }

--- a/lte/gateway/c/core/oai/tasks/sgw/sgw_config.c
+++ b/lte/gateway/c/core/oai/tasks/sgw/sgw_config.c
@@ -95,14 +95,14 @@ int sgw_config_parse_file(sgw_config_t* config_pP)
           LOG_SPGW_APP, "%s:%d - %s\n", bdata(config_pP->config_file),
           config_error_line(&cfg), config_error_text(&cfg));
       config_destroy(&cfg);
-      AssertFatal(
-          1 == 0, "Failed to parse SP-GW configuration file %s!\n",
+      Fatal(
+          "Failed to parse SP-GW configuration file %s!\n",
           bdata(config_pP->config_file));
     }
   } else {
     OAILOG_ERROR(LOG_SPGW_APP, "No SP-GW configuration file provided!\n");
     config_destroy(&cfg);
-    AssertFatal(0, "No SP-GW configuration file provided!\n");
+    Fatal("No SP-GW configuration file provided!\n");
   }
 
   OAILOG_INFO(
@@ -302,7 +302,7 @@ int sgw_config_parse_file(sgw_config_t* config_pP)
     config_setting_t* ovs_settings =
         config_setting_get_member(setting_sgw, SGW_CONFIG_STRING_OVS_CONFIG);
     if (ovs_settings == NULL) {
-      AssertFatal(false, "Couldn't find OVS subsetting in spgw config\n");
+      Fatal("Couldn't find OVS subsetting in spgw config\n");
     }
     char* ovs_bridge_name                       = NULL;
     libconfig_int gtp_port_num                  = 0;
@@ -364,7 +364,7 @@ int sgw_config_parse_file(sgw_config_t* config_pP)
       }
       OAILOG_INFO(LOG_SPGW_APP, "Multi tunnel enable: %s\n", multi_tunnel);
     } else {
-      AssertFatal(false, "Couldn't find all ovs settings in spgw config\n");
+      Fatal("Couldn't find all ovs settings in spgw config\n");
     }
 #endif
   }

--- a/lte/gateway/c/core/oai/tasks/sgw/sgw_handlers.c
+++ b/lte/gateway/c/core/oai/tasks/sgw/sgw_handlers.c
@@ -829,7 +829,7 @@ int sgw_handle_sgi_endpoint_deleted(
           break;
 
         default:
-          AssertFatal(0, "Bad paa.pdn_type %d", resp_pP->paa.pdn_type);
+          Fatal("Bad paa.pdn_type %d", resp_pP->paa.pdn_type);
           break;
       }
       OAILOG_FUNC_RETURN(LOG_SPGW_APP, rv);

--- a/lte/gateway/c/core/oai/tasks/sgw/spgw_config.c
+++ b/lte/gateway/c/core/oai/tasks/sgw/spgw_config.c
@@ -83,14 +83,14 @@ int spgw_config_parse_file(spgw_config_t* config_pP) {
           LOG_SPGW_APP, "%s:%d - %s\n", bdata(config_pP->config_file),
           config_error_line(&cfg), config_error_text(&cfg));
       config_destroy(&cfg);
-      AssertFatal(
-          0, "Failed to parse SP-GW configuration file %s!\n",
+      Fatal(
+          "Failed to parse SP-GW configuration file %s!\n",
           bdata(config_pP->config_file));
     }
   } else {
     OAILOG_ERROR(LOG_SPGW_APP, "No SP-GW configuration file provided!\n");
     config_destroy(&cfg);
-    AssertFatal(0, "No SP-GW configuration file provided!\n");
+    Fatal("No SP-GW configuration file provided!\n");
   }
 
   OAILOG_INFO(


### PR DESCRIPTION
Signed-off-by: Andrei Lee <andreilee@fb.com>

## Summary

MME service has various usages of `AssertFatal(..)` that always trigger a crash. These have been replaced with usages of `Fatal(..)` to better reflect what's going on.

This PR is part of a series to rework `AssertFatal(..)` usage in Magma's MME service

## Test Plan

Only built MME service:

```
vagrant@magma-dev:~/magma/lte/gateway$ make build_oai
.
.
.
[1971/1971] Linking CXX executable oai_mme/mme
vagrant@magma-dev:~/magma/lte/gateway$ 
```

## Additional Information

- [ ] This change is backwards-breaking
