### PR TITLE
[mme] Remove AssertFatal NULL checks after itti_alloc_new_message calls

### DIFF
--- a/lte/gateway/c/oai/lib/message_utils/service303_message_utils.c
+++ b/lte/gateway/c/oai/lib/message_utils/service303_message_utils.c
@@ -31,6 +31,5 @@ int send_app_health_to_service303(
   } else {
     message_p = itti_alloc_new_message(origin_id, APPLICATION_UNHEALTHY_MSG);
   }
-  AssertFatal(message_p != NULL, "itti_alloc_new_message Failed");
   return send_msg_to_task(task_zmq_ctx_p, TASK_SERVICE303, message_p);
 }

--- a/lte/gateway/c/oai/tasks/ngap/ngap_amf_handlers.c
+++ b/lte/gateway/c/oai/tasks/ngap/ngap_amf_handlers.c
@@ -750,7 +750,6 @@ int ngap_amf_handle_initial_context_setup_response(
   ue_ref_p->ng_ue_state = NGAP_UE_CONNECTED;
   message_p =
       itti_alloc_new_message(TASK_NGAP, AMF_APP_INITIAL_CONTEXT_SETUP_RSP);
-  AssertFatal(message_p != NULL, "itti_alloc_new_message Failed");
   AMF_APP_INITIAL_CONTEXT_SETUP_RSP(message_p).ue_id = ue_ref_p->amf_ue_ngap_id;
 
   if (ie) {
@@ -997,7 +996,6 @@ int ngap_amf_handle_ue_context_release_request(
 
       message_p =
           itti_alloc_new_message(TASK_NGAP, NGAP_UE_CONTEXT_RELEASE_REQ);
-      AssertFatal(message_p != NULL, "itti_alloc_new_message Failed");
 
       NGAP_UE_CONTEXT_RELEASE_REQ(message_p).amf_ue_ngap_id =
           ue_ref_p->amf_ue_ngap_id;
@@ -1335,7 +1333,6 @@ int ngap_amf_handle_initial_context_setup_failure(
   }
   message_p =
       itti_alloc_new_message(TASK_NGAP, AMF_APP_INITIAL_CONTEXT_SETUP_FAILURE);
-  AssertFatal(message_p != NULL, "itti_alloc_new_message Failed");
   memset(
       (void*) &message_p->ittiMsg.amf_app_initial_context_setup_failure, 0,
       sizeof(itti_amf_app_initial_context_setup_failure_t));
@@ -1540,7 +1537,6 @@ void ngap_amf_handle_ue_context_rel_comp_timer_expiry(
    */
   message_p =
       itti_alloc_new_message(TASK_NGAP, NGAP_UE_CONTEXT_RELEASE_COMPLETE);
-  AssertFatal(message_p != NULL, "itti_alloc_new_message Failed");
   memset(
       (void*) &message_p->ittiMsg.ngap_ue_context_release_complete, 0,
       sizeof(itti_ngap_ue_context_release_complete_t));
@@ -1577,7 +1573,6 @@ void ngap_amf_release_ue_context(
    */
   message_p =
       itti_alloc_new_message(TASK_NGAP, NGAP_UE_CONTEXT_RELEASE_COMPLETE);
-  AssertFatal(message_p != NULL, "itti_alloc_new_message Failed");
   memset(
       (void*) &message_p->ittiMsg.ngap_ue_context_release_complete, 0,
       sizeof(itti_ngap_ue_context_release_complete_t));
@@ -1772,7 +1767,6 @@ int ngap_amf_handle_pduSession_setup_response(
 
   message_p =
       itti_alloc_new_message(TASK_NGAP, NGAP_PDUSESSIONRESOURCE_SETUP_RSP);
-  AssertFatal(message_p != NULL, "itti_alloc_new_message Failed");
   NGAP_PDUSESSIONRESOURCE_SETUP_RSP(message_p).amf_ue_ngap_id =
       ue_ref_p->amf_ue_ngap_id;
   NGAP_PDUSESSIONRESOURCE_SETUP_RSP(message_p).gnb_ue_ngap_id =

--- a/lte/gateway/c/oai/tasks/s1ap/s1ap_mme_handlers.c
+++ b/lte/gateway/c/oai/tasks/s1ap/s1ap_mme_handlers.c
@@ -986,7 +986,6 @@ int s1ap_mme_handle_initial_context_setup_response(
   ue_ref_p->s1_ue_state = S1AP_UE_CONNECTED;
   message_p =
       itti_alloc_new_message(TASK_S1AP, MME_APP_INITIAL_CONTEXT_SETUP_RSP);
-  AssertFatal(message_p != NULL, "itti_alloc_new_message Failed");
   MME_APP_INITIAL_CONTEXT_SETUP_RSP(message_p).ue_id = ue_ref_p->mme_ue_s1ap_id;
   MME_APP_INITIAL_CONTEXT_SETUP_RSP(message_p).e_rab_setup_list.no_of_items =
       ie->value.choice.E_RABSetupListCtxtSURes.list.count;
@@ -1694,7 +1693,6 @@ int s1ap_mme_handle_initial_context_setup_failure(
   }
   message_p =
       itti_alloc_new_message(TASK_S1AP, MME_APP_INITIAL_CONTEXT_SETUP_FAILURE);
-  AssertFatal(message_p != NULL, "itti_alloc_new_message Failed");
   memset(
       (void*) &message_p->ittiMsg.mme_app_initial_context_setup_failure, 0,
       sizeof(itti_mme_app_initial_context_setup_failure_t));
@@ -1767,7 +1765,6 @@ int s1ap_mme_handle_ue_context_modification_response(
 
       message_p = itti_alloc_new_message(
           TASK_S1AP, S1AP_UE_CONTEXT_MODIFICATION_RESPONSE);
-      AssertFatal(message_p != NULL, "itti_alloc_new_message Failed");
       memset(
           (void*) &message_p->ittiMsg.s1ap_ue_context_mod_response, 0,
           sizeof(itti_s1ap_ue_context_mod_resp_t));
@@ -1917,7 +1914,6 @@ int s1ap_mme_handle_ue_context_modification_failure(
       }
       message_p = itti_alloc_new_message(
           TASK_S1AP, S1AP_UE_CONTEXT_MODIFICATION_FAILURE);
-      AssertFatal(message_p != NULL, "itti_alloc_new_message Failed");
       memset(
           (void*) &message_p->ittiMsg.s1ap_ue_context_mod_response, 0,
           sizeof(itti_s1ap_ue_context_mod_resp_fail_t));
@@ -3777,7 +3773,6 @@ void s1ap_mme_handle_ue_context_rel_comp_timer_expiry(
    */
   message_p =
       itti_alloc_new_message(TASK_S1AP, S1AP_UE_CONTEXT_RELEASE_COMPLETE);
-  AssertFatal(message_p != NULL, "itti_alloc_new_message Failed");
   memset(
       (void*) &message_p->ittiMsg.s1ap_ue_context_release_complete, 0,
       sizeof(itti_s1ap_ue_context_release_complete_t));
@@ -3817,7 +3812,6 @@ void s1ap_mme_release_ue_context(
    */
   message_p =
       itti_alloc_new_message(TASK_S1AP, S1AP_UE_CONTEXT_RELEASE_COMPLETE);
-  AssertFatal(message_p != NULL, "itti_alloc_new_message Failed");
   memset(
       (void*) &message_p->ittiMsg.s1ap_ue_context_release_complete, 0,
       sizeof(itti_s1ap_ue_context_release_complete_t));
@@ -4019,7 +4013,6 @@ int s1ap_mme_handle_erab_setup_response(
       (const hash_key_t) ue_ref_p->mme_ue_s1ap_id, &imsi64);
 
   message_p = itti_alloc_new_message(TASK_S1AP, S1AP_E_RAB_SETUP_RSP);
-  AssertFatal(message_p != NULL, "itti_alloc_new_message Failed");
   S1AP_E_RAB_SETUP_RSP(message_p).mme_ue_s1ap_id = ue_ref_p->mme_ue_s1ap_id;
   S1AP_E_RAB_SETUP_RSP(message_p).enb_ue_s1ap_id = ue_ref_p->enb_ue_s1ap_id;
   S1AP_E_RAB_SETUP_RSP(message_p).e_rab_setup_list.no_of_items           = 0;
@@ -4640,7 +4633,6 @@ int s1ap_mme_handle_erab_modification_indication(
   }
 
   message_p = itti_alloc_new_message(TASK_S1AP, S1AP_E_RAB_MODIFICATION_IND);
-  AssertFatal(message_p != NULL, "itti_alloc_new_message Failed");
   S1AP_E_RAB_MODIFICATION_IND(message_p).mme_ue_s1ap_id =
       ue_ref_p->mme_ue_s1ap_id;
   S1AP_E_RAB_MODIFICATION_IND(message_p).enb_ue_s1ap_id =

--- a/lte/gateway/c/oai/tasks/s6a/s6a_peer.c
+++ b/lte/gateway/c/oai/tasks/s6a/s6a_peer.c
@@ -175,10 +175,8 @@ int s6a_fd_new_peer(void) {
 void send_activate_messages(void) {
   MessageDef* message_p;
   message_p = itti_alloc_new_message(TASK_S6A, ACTIVATE_MESSAGE);
-  AssertFatal(message_p != NULL, "itti_alloc_new_message Failed");
   send_msg_to_task(&s6a_task_zmq_ctx, TASK_MME_APP, message_p);
 
   message_p = itti_alloc_new_message(TASK_S6A, ACTIVATE_MESSAGE);
-  AssertFatal(message_p != NULL, "itti_alloc_new_message Failed");
   send_msg_to_task(&s6a_task_zmq_ctx, TASK_S1AP, message_p);
 }


### PR DESCRIPTION
Signed-off-by: Andrei Lee <andreilee@fb.com>

## Summary

A number of times after calling `itti_alloc_new_message(..)`, the return value is checked via `AssertFatal(..)` if it is non-NULL. This is redundant since `itti_alloc_new_message already checks if its result of `malloc` is non-NULL.

This PR is part of a series to rework `AssertFatal(..)` usage in Magma's MME service

## Test Plan

Only built MME service:

```
vagrant@magma-dev:~/magma/lte/gateway$ make build_oai
.
.
.
[1971/1971] Linking CXX executable oai_mme/mme
vagrant@magma-dev:~/magma/lte/gateway$ 
```

## Additional Information

- [ ] This change is backwards-breaking
