### PR TITLE
Add W391 to the formatting script to strip empty space at the end of …

### DIFF
--- a/lte/gateway/python/precommit.py
+++ b/lte/gateway/python/precommit.py
@@ -67,7 +67,7 @@ def _format_diff(paths: List[str]):
         # make sure to change the corresponding github action
         _run_docker_cmd(['isort', path])
         _run_add_trailing_comma(path)
-        autopep8_checks = 'W291,W293,E2,E3'
+        autopep8_checks = 'W291,W293,W391,E2,E3'
         _run_docker_cmd(['autopep8', '--select', autopep8_checks, '-r', '--in-place', path])
 
 


### PR DESCRIPTION
…file

Signed-off-by: Marie Bremner <marwhal@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary
Noticed this warning on a PR I was looking at:

<img width="829" alt="Screen Shot 2021-06-04 at 4 00 38 PM" src="https://user-images.githubusercontent.com/37634144/120862730-0b716080-c54f-11eb-8829-e0989d063a76.png">

This can be addressed with the formatter so adding it to the list.

<!-- Enumerate changes you made and why you made them -->

## Test Plan
ran command -> stripped the space
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
