### PR TITLE
[feg_relay] fix wrong teid

### DIFF
--- a/feg/cloud/go/services/feg_relay/servicers/create_bearer_pgw.go
+++ b/feg/cloud/go/services/feg_relay/servicers/create_bearer_pgw.go
@@ -36,11 +36,11 @@ func (srv *FegToGwRelayServer) CreateBearer(
 	if err := validateFegContext(ctx); err != nil {
 		return nil, err
 	}
-	if req == nil || req.BearerContext == nil || req.BearerContext.UserPlaneFteid == nil {
-		glog.Errorf("unable to send CreateBearerPGWUnverified, Teid not found  %v", req)
+	if req == nil {
+		glog.Error("unable to send CreateBearerPGW, request is nil")
 		return &fegprotos.CreateBearerResponsePgw{Cause: 73}, nil
 	}
-	teid := fmt.Sprint(req.BearerContext.UserPlaneFteid.Teid)
+	teid := fmt.Sprint(req.CAgwTeid)
 	hwId, err := getHwIDFromTeid(ctx, teid)
 	if err != nil {
 		glog.Errorf("unable to get HwID from TEID %s. err: %v", teid, err)


### PR DESCRIPTION
Signed-off-by: Oriol Batalla <obatalla@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary

Feg relay was using the wrong teid to find the AGW. This should fix the issue

## Test Plan

teravm once landed

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
