### PR TITLE
[LTE][AGW] S6A/Diameter Enable extended bitrates

### DIFF
--- a/lte/gateway/c/oai/patches/0002-opencoord.org.freeDiameter.patch
+++ b/lte/gateway/c/oai/patches/0002-opencoord.org.freeDiameter.patch
@@ -1,0 +1,124 @@
+diff --git a/extensions/dict_ts29272_avps/dict_ts29272_avps.c b/extensions/dict_ts29272_avps/dict_ts29272_avps.c
+index 5d74805..f6261ba 100644
+--- a/extensions/dict_ts29272_avps/dict_ts29272_avps.c
++++ b/extensions/dict_ts29272_avps/dict_ts29272_avps.c
+@@ -2891,8 +2891,10 @@ static int dict_ts29272_avps_load_rules(char * conffile)
+		CHECK_dict_search(DICT_AVP,  AVP_BY_NAME_AND_VENDOR, &avp_vendor_plus_name, &avp)
+		struct local_rules_definition rules[] =
+		{
+			{ { .avp_vendor = 10415, .avp_name = "Max-Requested-Bandwidth-UL"}, RULE_REQUIRED, -1, -1 },
+-			{ { .avp_vendor = 10415, .avp_name = "Max-Requested-Bandwidth-DL"}, RULE_REQUIRED, -1, -1 }
++			{ { .avp_vendor = 10415, .avp_name = "Max-Requested-Bandwidth-DL"}, RULE_REQUIRED, -1, -1 },
++			{ { .avp_vendor = 10415, .avp_name = "Extended-Max-Requested-BW-UL"}, RULE_OPTIONAL, -1, -1 },
++			{ { .avp_vendor = 10415, .avp_name = "Extended-Max-Requested-BW-DL"}, RULE_OPTIONAL, -1, -1 }
+		};
+		PARSE_loc_rules( rules, avp );
+	  }
+diff --git a/extensions/dict_ts29214_avps/dict_ts29214_avps.c b/extensions/dict_ts29214_avps/dict_ts29214_avps.c
+index 734a5c8..6fd4d7c 100644
+--- a/extensions/dict_ts29214_avps/dict_ts29214_avps.c
++++ b/extensions/dict_ts29214_avps/dict_ts29214_avps.c
+@@ -278,6 +278,102 @@ static int dict_ts29214_avps_load_defs(char * conffile)
+ 			};
+ 			CHECK_dict_new( DICT_AVP, &data, NULL, NULL);
+ 		};
++		/* Extended-Max-Requested-BW-DL */
++		{
++			struct dict_avp_data data = {
++				554,	/* Code */
++				10415,	/* Vendor */
++				"Extended-Max-Requested-BW-DL",	/* Name */
++				AVP_FLAG_VENDOR | AVP_FLAG_MANDATORY,	/* Fixed flags */
++				AVP_FLAG_VENDOR,	/* Fixed flag values */
++				AVP_TYPE_UNSIGNED32	/* base type of data */
++			};
++			CHECK_dict_new( DICT_AVP, &data, NULL, NULL);
++		};
++		/* Extended-Max-Requested-BW-UL */
++		{
++			struct dict_avp_data data = {
++				555,	/* Code */
++				10415,	/* Vendor */
++				"Extended-Max-Requested-BW-UL",	/* Name */
++				AVP_FLAG_VENDOR | AVP_FLAG_MANDATORY,	/* Fixed flags */
++				AVP_FLAG_VENDOR,	/* Fixed flag values */
++				AVP_TYPE_UNSIGNED32	/* base type of data */
++			};
++			CHECK_dict_new( DICT_AVP, &data, NULL, NULL);
++		};
++		/* Extended-Max-Supported-BW-DL */
++		{
++			struct dict_avp_data data = {
++				556,	/* Code */
++				10415,	/* Vendor */
++				"Extended-Max-Supported-BW-DL",	/* Name */
++				AVP_FLAG_VENDOR | AVP_FLAG_MANDATORY,	/* Fixed flags */
++				AVP_FLAG_VENDOR,	/* Fixed flag values */
++				AVP_TYPE_UNSIGNED32	/* base type of data */
++			};
++			CHECK_dict_new( DICT_AVP, &data, NULL, NULL);
++		};
++		/* Extended-Max-Supported-BW-UL */
++		{
++			struct dict_avp_data data = {
++				557,	/* Code */
++				10415,	/* Vendor */
++				"Extended-Max-Supported-BW-UL",	/* Name */
++				AVP_FLAG_VENDOR | AVP_FLAG_MANDATORY,	/* Fixed flags */
++				AVP_FLAG_VENDOR,	/* Fixed flag values */
++				AVP_TYPE_UNSIGNED32	/* base type of data */
++			};
++			CHECK_dict_new( DICT_AVP, &data, NULL, NULL);
++		};
++		/* Extended-Min-Desired-BW-DL */
++		{
++			struct dict_avp_data data = {
++				558,	/* Code */
++				10415,	/* Vendor */
++				"Extended-Min-Desired-BW-DL",	/* Name */
++				AVP_FLAG_VENDOR | AVP_FLAG_MANDATORY,	/* Fixed flags */
++				AVP_FLAG_VENDOR,	/* Fixed flag values */
++				AVP_TYPE_UNSIGNED32	/* base type of data */
++			};
++			CHECK_dict_new( DICT_AVP, &data, NULL, NULL);
++		};
++		/* Extended-Min-Desired-BW-UL */
++		{
++			struct dict_avp_data data = {
++				559,	/* Code */
++				10415,	/* Vendor */
++				"Extended-Min-Desired-BW-UL",	/* Name */
++				AVP_FLAG_VENDOR | AVP_FLAG_MANDATORY,	/* Fixed flags */
++				AVP_FLAG_VENDOR,	/* Fixed flag values */
++				AVP_TYPE_UNSIGNED32	/* base type of data */
++			};
++			CHECK_dict_new( DICT_AVP, &data, NULL, NULL);
++		};
++		/* Extended-Min-Requested-BW-DL */
++		{
++			struct dict_avp_data data = {
++				560,	/* Code */
++				10415,	/* Vendor */
++				"Extended-Min-Requested-BW-DL",	/* Name */
++				AVP_FLAG_VENDOR | AVP_FLAG_MANDATORY,	/* Fixed flags */
++				AVP_FLAG_VENDOR,	/* Fixed flag values */
++				AVP_TYPE_UNSIGNED32	/* base type of data */
++			};
++			CHECK_dict_new( DICT_AVP, &data, NULL, NULL);
++		};
++		/* Extended-Min-Requested-BW-UL */
++		{
++			struct dict_avp_data data = {
++				561,	/* Code */
++				10415,	/* Vendor */
++				"Extended-Min-Requested-BW-UL",	/* Name */
++				AVP_FLAG_VENDOR | AVP_FLAG_MANDATORY,	/* Fixed flags */
++				AVP_FLAG_VENDOR,	/* Fixed flag values */
++				AVP_TYPE_UNSIGNED32	/* base type of data */
++			};
++			CHECK_dict_new( DICT_AVP, &data, NULL, NULL);
++		};
+ 		/* Flow-Description */
+ 		{
+ 			struct dict_avp_data data = {
+ 

--- a/lte/gateway/c/oai/patches/0002-opencoord.org.freeDiameter.patch
+++ b/lte/gateway/c/oai/patches/0002-opencoord.org.freeDiameter.patch
@@ -29,7 +29,7 @@ index 734a5c8..6fd4d7c 100644
 +				10415,	/* Vendor */
 +				"Extended-Max-Requested-BW-DL",	/* Name */
 +				AVP_FLAG_VENDOR | AVP_FLAG_MANDATORY,	/* Fixed flags */
-+				AVP_FLAG_VENDOR,	/* Fixed flag values */
++				AVP_FLAG_VENDOR | AVP_FLAG_MANDATORY,	/* Fixed flag values */
 +				AVP_TYPE_UNSIGNED32	/* base type of data */
 +			};
 +			CHECK_dict_new( DICT_AVP, &data, NULL, NULL);
@@ -41,7 +41,7 @@ index 734a5c8..6fd4d7c 100644
 +				10415,	/* Vendor */
 +				"Extended-Max-Requested-BW-UL",	/* Name */
 +				AVP_FLAG_VENDOR | AVP_FLAG_MANDATORY,	/* Fixed flags */
-+				AVP_FLAG_VENDOR,	/* Fixed flag values */
++				AVP_FLAG_VENDOR | AVP_FLAG_MANDATORY,	/* Fixed flag values */
 +				AVP_TYPE_UNSIGNED32	/* base type of data */
 +			};
 +			CHECK_dict_new( DICT_AVP, &data, NULL, NULL);
@@ -53,7 +53,7 @@ index 734a5c8..6fd4d7c 100644
 +				10415,	/* Vendor */
 +				"Extended-Max-Supported-BW-DL",	/* Name */
 +				AVP_FLAG_VENDOR | AVP_FLAG_MANDATORY,	/* Fixed flags */
-+				AVP_FLAG_VENDOR,	/* Fixed flag values */
++				AVP_FLAG_VENDOR | AVP_FLAG_MANDATORY,	/* Fixed flag values */
 +				AVP_TYPE_UNSIGNED32	/* base type of data */
 +			};
 +			CHECK_dict_new( DICT_AVP, &data, NULL, NULL);
@@ -65,7 +65,7 @@ index 734a5c8..6fd4d7c 100644
 +				10415,	/* Vendor */
 +				"Extended-Max-Supported-BW-UL",	/* Name */
 +				AVP_FLAG_VENDOR | AVP_FLAG_MANDATORY,	/* Fixed flags */
-+				AVP_FLAG_VENDOR,	/* Fixed flag values */
++				AVP_FLAG_VENDOR | AVP_FLAG_MANDATORY,	/* Fixed flag values */
 +				AVP_TYPE_UNSIGNED32	/* base type of data */
 +			};
 +			CHECK_dict_new( DICT_AVP, &data, NULL, NULL);
@@ -77,7 +77,7 @@ index 734a5c8..6fd4d7c 100644
 +				10415,	/* Vendor */
 +				"Extended-Min-Desired-BW-DL",	/* Name */
 +				AVP_FLAG_VENDOR | AVP_FLAG_MANDATORY,	/* Fixed flags */
-+				AVP_FLAG_VENDOR,	/* Fixed flag values */
++				AVP_FLAG_VENDOR | AVP_FLAG_MANDATORY,	/* Fixed flag values */
 +				AVP_TYPE_UNSIGNED32	/* base type of data */
 +			};
 +			CHECK_dict_new( DICT_AVP, &data, NULL, NULL);
@@ -89,7 +89,7 @@ index 734a5c8..6fd4d7c 100644
 +				10415,	/* Vendor */
 +				"Extended-Min-Desired-BW-UL",	/* Name */
 +				AVP_FLAG_VENDOR | AVP_FLAG_MANDATORY,	/* Fixed flags */
-+				AVP_FLAG_VENDOR,	/* Fixed flag values */
++				AVP_FLAG_VENDOR | AVP_FLAG_MANDATORY,	/* Fixed flag values */
 +				AVP_TYPE_UNSIGNED32	/* base type of data */
 +			};
 +			CHECK_dict_new( DICT_AVP, &data, NULL, NULL);
@@ -101,7 +101,7 @@ index 734a5c8..6fd4d7c 100644
 +				10415,	/* Vendor */
 +				"Extended-Min-Requested-BW-DL",	/* Name */
 +				AVP_FLAG_VENDOR | AVP_FLAG_MANDATORY,	/* Fixed flags */
-+				AVP_FLAG_VENDOR,	/* Fixed flag values */
++				AVP_FLAG_VENDOR | AVP_FLAG_MANDATORY,	/* Fixed flag values */
 +				AVP_TYPE_UNSIGNED32	/* base type of data */
 +			};
 +			CHECK_dict_new( DICT_AVP, &data, NULL, NULL);
@@ -113,7 +113,7 @@ index 734a5c8..6fd4d7c 100644
 +				10415,	/* Vendor */
 +				"Extended-Min-Requested-BW-UL",	/* Name */
 +				AVP_FLAG_VENDOR | AVP_FLAG_MANDATORY,	/* Fixed flags */
-+				AVP_FLAG_VENDOR,	/* Fixed flag values */
++				AVP_FLAG_VENDOR | AVP_FLAG_MANDATORY,	/* Fixed flag values */
 +				AVP_TYPE_UNSIGNED32	/* base type of data */
 +			};
 +			CHECK_dict_new( DICT_AVP, &data, NULL, NULL);

--- a/lte/gateway/c/oai/tasks/s6a/CMakeLists.txt
+++ b/lte/gateway/c/oai/tasks/s6a/CMakeLists.txt
@@ -6,6 +6,7 @@ set (S6A_SRC
     s6a_error.c
     s6a_peer.c
     s6a_subscription_data.c
+    s6a_supported_features.c
     s6a_task.c
     s6a_up_loc.c
     s6a_cancel_loc.c

--- a/lte/gateway/c/oai/tasks/s6a/s6a_defs.h
+++ b/lte/gateway/c/oai/tasks/s6a/s6a_defs.h
@@ -117,6 +117,8 @@ typedef struct {
   struct dict_object* dataobj_s6a_cancellation_type;
   struct dict_object* dataobj_s6a_pua_flags;
   struct dict_object* dataobj_s6a_supported_features;
+  struct dict_object* dataobj_s6a_feature_list_id;
+  struct dict_object* dataobj_s6a_feature_list;
 
   /* Handlers */
   struct disp_hdl* aia_hdl; /* Authentication Information Answer Handle */
@@ -142,6 +144,9 @@ extern s6a_fd_cnf_t s6a_fd_cnf;
 #define PUA_FREEZE_M_TMSI (1U)
 #define PUA_FREEZE_P_TMSI (1U << 1)
 
+#define FLID_SMS_IN_MME (1U)
+#define FLID_NR_AS_SECONDARY_RAT (1U << 27)
+
 #define FLAG_IS_SET(x, flag) ((x) & (flag))
 
 #define FLAGS_SET(x, flags) ((x) |= (flags))
@@ -159,9 +164,13 @@ extern s6a_fd_cnf_t s6a_fd_cnf;
 #define AVP_CODE_MIP_HOME_AGENT_ADDRESS (334)
 #define AVP_CODE_MIP6_AGENT_INFO (486)
 #define AVP_CODE_SERVICE_SELECTION (493)
-#define AVP_CODE_BANDWIDTH_UL (516)
-#define AVP_CODE_BANDWIDTH_DL (515)
+#define AVP_CODE_MAX_REQUESTED_BANDWIDTH_UL (516)
+#define AVP_CODE_MAX_REQUESTED_BANDWIDTH_DL (515)
+#define AVP_CODE_EXTENDED_MAX_REQUESTED_BW_UL (555)
+#define AVP_CODE_EXTENDED_MAX_REQUESTED_BW_DL (554)
 #define AVP_CODE_SUPPORTED_FEATURES (628)
+#define AVP_CODE_FEATURE_LIST_ID (629)
+#define AVP_CODE_FEATURE_LIST (630)
 #define AVP_CODE_MSISDN (701)
 #define AVP_CODE_SERVED_PARTY_IP_ADDRESS (848)
 #define AVP_CODE_QCI (1028)
@@ -203,6 +212,10 @@ int s6a_fd_init_dict_objs(void);
 
 int s6a_parse_subscription_data(
     struct avp* avp_subscription_data, subscription_data_t* subscription_data);
+
+int s6a_parse_supported_features(
+    struct avp* avp_supported_features,
+    supported_features_t* subscription_data);
 
 int s6a_parse_experimental_result(
     struct avp* avp, s6a_experimental_result_t* ptr);

--- a/lte/gateway/c/oai/tasks/s6a/s6a_dict.c
+++ b/lte/gateway/c/oai/tasks/s6a/s6a_dict.c
@@ -173,6 +173,17 @@ int s6a_fd_init_dict_objs(void) {
   CHECK_FD_FCT(fd_dict_search(
       fd_g_config->cnf_dict, DICT_AVP, AVP_BY_NAME_ALL_VENDORS, "PUA-Flags",
       &s6a_fd_cnf.dataobj_s6a_pua_flags, ENOENT));
+  CHECK_FD_FCT(fd_dict_search(
+      fd_g_config->cnf_dict, DICT_AVP, AVP_BY_NAME_ALL_VENDORS,
+      "Supported-Features", &s6a_fd_cnf.dataobj_s6a_supported_features,
+      ENOENT));
+  CHECK_FD_FCT(fd_dict_search(
+      fd_g_config->cnf_dict, DICT_AVP, AVP_BY_NAME_ALL_VENDORS,
+      "Feature-List-ID", &s6a_fd_cnf.dataobj_s6a_feature_list_id, ENOENT));
+  CHECK_FD_FCT(fd_dict_search(
+      fd_g_config->cnf_dict, DICT_AVP, AVP_BY_NAME_ALL_VENDORS, "Feature-List",
+      &s6a_fd_cnf.dataobj_s6a_feature_list, ENOENT));
+
   /*
    * Register callbacks
    */

--- a/lte/gateway/c/oai/tasks/s6a/s6a_supported_features.c
+++ b/lte/gateway/c/oai/tasks/s6a/s6a_supported_features.c
@@ -1,0 +1,97 @@
+/*
+ * Licensed to the OpenAirInterface (OAI) Software Alliance under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The OpenAirInterface Software Alliance licenses this file to You under
+ * the terms found in the LICENSE file in the root of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *-------------------------------------------------------------------------------
+ * For more information about the OpenAirInterface (OAI) Software Alliance:
+ *      contact@openairinterface.org
+ */
+
+/*! \file s6a_supported_features.c
+  \brief
+  \author Lionel Gauthier
+  \company Eurecom
+  \email: lionel.gauthier@eurecom.fr
+*/
+
+#include <stdint.h>
+#include <netinet/in.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "assertions.h"
+#include "3gpp_24.008.h"
+#include "common_defs.h"
+#include "common_types.h"
+#include "s6a_defs.h"
+
+struct avp;
+
+int s6a_parse_supported_features(
+    struct avp* avp_supported_features,
+    supported_features_t* subscription_data) {
+  struct avp* avp = NULL;
+  struct avp_hdr* hdr;
+  uint32_t feature_list_id = 0;
+  uint32_t feature_list    = 0;
+
+  CHECK_FCT(
+      fd_msg_browse(avp_supported_features, MSG_BRW_FIRST_CHILD, &avp, NULL));
+
+  while (avp) {
+    hdr = NULL;
+    CHECK_FCT(fd_msg_avp_hdr(avp, &hdr));
+
+    if (hdr) {
+      switch (hdr->avp_code) {
+        case AVP_CODE_VENDOR_ID:
+          // no check
+          break;
+
+        case AVP_CODE_FEATURE_LIST_ID:
+          if (hdr->avp_value) {
+            feature_list_id = hdr->avp_value->u32;
+          } else {
+            return RETURNerror;
+          }
+          break;
+
+        case AVP_CODE_FEATURE_LIST:
+          if (hdr->avp_value) {
+            feature_list = hdr->avp_value->u32;
+            if (feature_list_id == 2) {
+              subscription_data->external_identifier = true;
+              subscription_data->nr_as_secondary_rat =
+                  FLAG_IS_SET(feature_list, FLID_NR_AS_SECONDARY_RAT);
+            }
+          } else {
+            return RETURNerror;
+          }
+          break;
+
+        default:
+          OAILOG_DEBUG(
+              LOG_S6A, "Unknown AVP code %d not processed\n", hdr->avp_code);
+          return RETURNerror;
+      }
+    } else {
+      OAILOG_DEBUG(LOG_S6A, "Supported Features parsing Error\n");
+      return RETURNerror;
+    }
+
+    /*
+     * Go to next AVP in the grouped AVP
+     */
+    CHECK_FCT(fd_msg_browse(avp, MSG_BRW_NEXT, &avp, NULL));
+  }
+
+  return RETURNok;
+}

--- a/lte/gateway/c/oai/tasks/s6a/s6a_up_loc.c
+++ b/lte/gateway/c/oai/tasks/s6a/s6a_up_loc.c
@@ -302,6 +302,11 @@ int s6a_generate_update_location(s6a_update_location_req_t* ulr_pP) {
   if (ulr_pP->initial_attach) {
     FLAGS_SET(value.u32, ULR_INITIAL_ATTACH_IND);
   }
+
+  if (ulr_pP->dual_regis_5g_ind) {
+    FLAGS_SET(value.u32, ULR_DUAL_REGIS_5G_IND);
+  }
+
   CHECK_FCT(fd_msg_avp_setvalue(avp_p, &value));
   CHECK_FCT(fd_msg_avp_add(msg_p, MSG_BRW_LAST_CHILD, avp_p));
   CHECK_FCT(fd_msg_send(&msg_p, NULL, NULL));

--- a/lte/gateway/docker/mme/Dockerfile.rhel8
+++ b/lte/gateway/docker/mme/Dockerfile.rhel8
@@ -129,6 +129,7 @@ RUN yum install -y \
 WORKDIR /patches
 COPY  lte/gateway/c/oai/patches/folly-gflagslib-fix.patch .
 COPY  lte/gateway/c/oai/patches/0001-opencoord.org.freeDiameter.patch .
+COPY  lte/gateway/c/oai/patches/0002-opencoord.org.freeDiameter.patch .
 COPY  lte/gateway/c/oai/patches/libzmq-strncpy.patch .
 COPY  lte/gateway/c/oai/patches/czmq-strncat.patch .
 
@@ -327,6 +328,7 @@ RUN cd freediameter && \
     git log -n1 && \
     echo "Patching dict_S6as6d" && \
     patch -p1 < /patches/0001-opencoord.org.freeDiameter.patch && \
+    patch -p1 < /patches/0002-opencoord.org.freeDiameter.patch && \
     mkdir build && \
     cd build && \
     cmake3 ../ && \

--- a/lte/gateway/docker/mme/Dockerfile.ubuntu18.04
+++ b/lte/gateway/docker/mme/Dockerfile.ubuntu18.04
@@ -203,6 +203,7 @@ COPY ./ $MAGMA_ROOT
 RUN git clone https://github.com/OPENAIRINTERFACE/opencord.org.freeDiameter.git freediameter && \
     cd freediameter && \
     patch -p1 < $MAGMA_ROOT/lte/gateway/c/oai/patches/0001-opencoord.org.freeDiameter.patch && \
+    patch -p1 < $MAGMA_ROOT/lte/gateway/c/oai/patches/0002-opencoord.org.freeDiameter.patch && \
     mkdir build && \
     cd build && \
     cmake ../ && \

--- a/lte/gateway/docker/mme/Dockerfile.ubuntu20.04
+++ b/lte/gateway/docker/mme/Dockerfile.ubuntu20.04
@@ -269,6 +269,7 @@ COPY lte/gateway/c/oai/patches/ /tmp/
 RUN git clone https://github.com/OPENAIRINTERFACE/opencord.org.freeDiameter.git freediameter && \
     cd freediameter && \
     patch -p1 < /tmp/0001-opencoord.org.freeDiameter.patch && \
+    patch -p1 < /tmp/0002-opencoord.org.freeDiameter.patch && \
     mkdir build && \
     cd build && \
     cmake -DDISABLE_SCTP:BOOL=ON ../ && \


### PR DESCRIPTION

## Summary
Enable Diameter extended bitrates
Handle ULA Supported-Features AVP for NSA
Send in ULR Dual-Registration-5G-Indicator

## Test Plan

Tested with dsTester NSA scenario: 
Provision subscribers in OAI HSS with bitrate(s) greater than 4294967295 bits/s

## Additional Information

- This changes only S6a/Diameter interface, to enable NSA compatibility between Magma and OAI HSS network function.

