### PR TITLE
[LTE][AGW] S6A/Diameter Enable extended bitrates

### DIFF
--- a/lte/gateway/c/core/oai/patches/0002-opencoord.org.freeDiameter.patch
+++ b/lte/gateway/c/core/oai/patches/0002-opencoord.org.freeDiameter.patch
@@ -1,0 +1,124 @@
+diff --git a/extensions/dict_ts29272_avps/dict_ts29272_avps.c b/extensions/dict_ts29272_avps/dict_ts29272_avps.c
+index 5d74805..f6261ba 100644
+--- a/extensions/dict_ts29272_avps/dict_ts29272_avps.c
++++ b/extensions/dict_ts29272_avps/dict_ts29272_avps.c
+@@ -2891,8 +2891,10 @@ static int dict_ts29272_avps_load_rules(char * conffile)
+		CHECK_dict_search(DICT_AVP,  AVP_BY_NAME_AND_VENDOR, &avp_vendor_plus_name, &avp)
+		struct local_rules_definition rules[] =
+		{
+			{ { .avp_vendor = 10415, .avp_name = "Max-Requested-Bandwidth-UL"}, RULE_REQUIRED, -1, -1 },
+-			{ { .avp_vendor = 10415, .avp_name = "Max-Requested-Bandwidth-DL"}, RULE_REQUIRED, -1, -1 }
++			{ { .avp_vendor = 10415, .avp_name = "Max-Requested-Bandwidth-DL"}, RULE_REQUIRED, -1, -1 },
++			{ { .avp_vendor = 10415, .avp_name = "Extended-Max-Requested-BW-UL"}, RULE_OPTIONAL, -1, -1 },
++			{ { .avp_vendor = 10415, .avp_name = "Extended-Max-Requested-BW-DL"}, RULE_OPTIONAL, -1, -1 }
+		};
+		PARSE_loc_rules( rules, avp );
+	  }
+diff --git a/extensions/dict_ts29214_avps/dict_ts29214_avps.c b/extensions/dict_ts29214_avps/dict_ts29214_avps.c
+index 734a5c8..6fd4d7c 100644
+--- a/extensions/dict_ts29214_avps/dict_ts29214_avps.c
++++ b/extensions/dict_ts29214_avps/dict_ts29214_avps.c
+@@ -278,6 +278,102 @@ static int dict_ts29214_avps_load_defs(char * conffile)
+ 			};
+ 			CHECK_dict_new( DICT_AVP, &data, NULL, NULL);
+ 		};
++		/* Extended-Max-Requested-BW-DL */
++		{
++			struct dict_avp_data data = {
++				554,	/* Code */
++				10415,	/* Vendor */
++				"Extended-Max-Requested-BW-DL",	/* Name */
++				AVP_FLAG_VENDOR | AVP_FLAG_MANDATORY,	/* Fixed flags */
++				AVP_FLAG_VENDOR | AVP_FLAG_MANDATORY,	/* Fixed flag values */
++				AVP_TYPE_UNSIGNED32	/* base type of data */
++			};
++			CHECK_dict_new( DICT_AVP, &data, NULL, NULL);
++		};
++		/* Extended-Max-Requested-BW-UL */
++		{
++			struct dict_avp_data data = {
++				555,	/* Code */
++				10415,	/* Vendor */
++				"Extended-Max-Requested-BW-UL",	/* Name */
++				AVP_FLAG_VENDOR | AVP_FLAG_MANDATORY,	/* Fixed flags */
++				AVP_FLAG_VENDOR | AVP_FLAG_MANDATORY,	/* Fixed flag values */
++				AVP_TYPE_UNSIGNED32	/* base type of data */
++			};
++			CHECK_dict_new( DICT_AVP, &data, NULL, NULL);
++		};
++		/* Extended-Max-Supported-BW-DL */
++		{
++			struct dict_avp_data data = {
++				556,	/* Code */
++				10415,	/* Vendor */
++				"Extended-Max-Supported-BW-DL",	/* Name */
++				AVP_FLAG_VENDOR | AVP_FLAG_MANDATORY,	/* Fixed flags */
++				AVP_FLAG_VENDOR | AVP_FLAG_MANDATORY,	/* Fixed flag values */
++				AVP_TYPE_UNSIGNED32	/* base type of data */
++			};
++			CHECK_dict_new( DICT_AVP, &data, NULL, NULL);
++		};
++		/* Extended-Max-Supported-BW-UL */
++		{
++			struct dict_avp_data data = {
++				557,	/* Code */
++				10415,	/* Vendor */
++				"Extended-Max-Supported-BW-UL",	/* Name */
++				AVP_FLAG_VENDOR | AVP_FLAG_MANDATORY,	/* Fixed flags */
++				AVP_FLAG_VENDOR | AVP_FLAG_MANDATORY,	/* Fixed flag values */
++				AVP_TYPE_UNSIGNED32	/* base type of data */
++			};
++			CHECK_dict_new( DICT_AVP, &data, NULL, NULL);
++		};
++		/* Extended-Min-Desired-BW-DL */
++		{
++			struct dict_avp_data data = {
++				558,	/* Code */
++				10415,	/* Vendor */
++				"Extended-Min-Desired-BW-DL",	/* Name */
++				AVP_FLAG_VENDOR | AVP_FLAG_MANDATORY,	/* Fixed flags */
++				AVP_FLAG_VENDOR | AVP_FLAG_MANDATORY,	/* Fixed flag values */
++				AVP_TYPE_UNSIGNED32	/* base type of data */
++			};
++			CHECK_dict_new( DICT_AVP, &data, NULL, NULL);
++		};
++		/* Extended-Min-Desired-BW-UL */
++		{
++			struct dict_avp_data data = {
++				559,	/* Code */
++				10415,	/* Vendor */
++				"Extended-Min-Desired-BW-UL",	/* Name */
++				AVP_FLAG_VENDOR | AVP_FLAG_MANDATORY,	/* Fixed flags */
++				AVP_FLAG_VENDOR | AVP_FLAG_MANDATORY,	/* Fixed flag values */
++				AVP_TYPE_UNSIGNED32	/* base type of data */
++			};
++			CHECK_dict_new( DICT_AVP, &data, NULL, NULL);
++		};
++		/* Extended-Min-Requested-BW-DL */
++		{
++			struct dict_avp_data data = {
++				560,	/* Code */
++				10415,	/* Vendor */
++				"Extended-Min-Requested-BW-DL",	/* Name */
++				AVP_FLAG_VENDOR | AVP_FLAG_MANDATORY,	/* Fixed flags */
++				AVP_FLAG_VENDOR | AVP_FLAG_MANDATORY,	/* Fixed flag values */
++				AVP_TYPE_UNSIGNED32	/* base type of data */
++			};
++			CHECK_dict_new( DICT_AVP, &data, NULL, NULL);
++		};
++		/* Extended-Min-Requested-BW-UL */
++		{
++			struct dict_avp_data data = {
++				561,	/* Code */
++				10415,	/* Vendor */
++				"Extended-Min-Requested-BW-UL",	/* Name */
++				AVP_FLAG_VENDOR | AVP_FLAG_MANDATORY,	/* Fixed flags */
++				AVP_FLAG_VENDOR | AVP_FLAG_MANDATORY,	/* Fixed flag values */
++				AVP_TYPE_UNSIGNED32	/* base type of data */
++			};
++			CHECK_dict_new( DICT_AVP, &data, NULL, NULL);
++		};
+ 		/* Flow-Description */
+ 		{
+ 			struct dict_avp_data data = {
+ 

--- a/lte/gateway/c/core/oai/tasks/s6a/CMakeLists.txt
+++ b/lte/gateway/c/core/oai/tasks/s6a/CMakeLists.txt
@@ -6,6 +6,7 @@ set(S6A_SRC
     s6a_error.c
     s6a_peer.c
     s6a_subscription_data.c
+    s6a_supported_features.c
     s6a_task.c
     s6a_up_loc.c
     s6a_cancel_loc.c

--- a/lte/gateway/c/core/oai/tasks/s6a/s6a_defs.h
+++ b/lte/gateway/c/core/oai/tasks/s6a/s6a_defs.h
@@ -117,6 +117,8 @@ typedef struct {
   struct dict_object* dataobj_s6a_cancellation_type;
   struct dict_object* dataobj_s6a_pua_flags;
   struct dict_object* dataobj_s6a_supported_features;
+  struct dict_object* dataobj_s6a_feature_list_id;
+  struct dict_object* dataobj_s6a_feature_list;
 
   /* Handlers */
   struct disp_hdl* aia_hdl; /* Authentication Information Answer Handle */
@@ -142,6 +144,9 @@ extern s6a_fd_cnf_t s6a_fd_cnf;
 #define PUA_FREEZE_M_TMSI (1U)
 #define PUA_FREEZE_P_TMSI (1U << 1)
 
+#define FLID_SMS_IN_MME (1U)
+#define FLID_NR_AS_SECONDARY_RAT (1U << 27)
+
 #define FLAG_IS_SET(x, flag) ((x) & (flag))
 
 #define FLAGS_SET(x, flags) ((x) |= (flags))
@@ -159,9 +164,13 @@ extern s6a_fd_cnf_t s6a_fd_cnf;
 #define AVP_CODE_MIP_HOME_AGENT_ADDRESS (334)
 #define AVP_CODE_MIP6_AGENT_INFO (486)
 #define AVP_CODE_SERVICE_SELECTION (493)
-#define AVP_CODE_BANDWIDTH_UL (516)
-#define AVP_CODE_BANDWIDTH_DL (515)
+#define AVP_CODE_MAX_REQUESTED_BANDWIDTH_UL (516)
+#define AVP_CODE_MAX_REQUESTED_BANDWIDTH_DL (515)
+#define AVP_CODE_EXTENDED_MAX_REQUESTED_BW_UL (555)
+#define AVP_CODE_EXTENDED_MAX_REQUESTED_BW_DL (554)
 #define AVP_CODE_SUPPORTED_FEATURES (628)
+#define AVP_CODE_FEATURE_LIST_ID (629)
+#define AVP_CODE_FEATURE_LIST (630)
 #define AVP_CODE_MSISDN (701)
 #define AVP_CODE_SERVED_PARTY_IP_ADDRESS (848)
 #define AVP_CODE_QCI (1028)
@@ -203,6 +212,10 @@ int s6a_fd_init_dict_objs(void);
 
 int s6a_parse_subscription_data(
     struct avp* avp_subscription_data, subscription_data_t* subscription_data);
+
+int s6a_parse_supported_features(
+    struct avp* avp_supported_features,
+    supported_features_t* subscription_data);
 
 int s6a_parse_experimental_result(
     struct avp* avp, s6a_experimental_result_t* ptr);

--- a/lte/gateway/c/core/oai/tasks/s6a/s6a_dict.c
+++ b/lte/gateway/c/core/oai/tasks/s6a/s6a_dict.c
@@ -173,6 +173,17 @@ int s6a_fd_init_dict_objs(void) {
   CHECK_FD_FCT(fd_dict_search(
       fd_g_config->cnf_dict, DICT_AVP, AVP_BY_NAME_ALL_VENDORS, "PUA-Flags",
       &s6a_fd_cnf.dataobj_s6a_pua_flags, ENOENT));
+  CHECK_FD_FCT(fd_dict_search(
+      fd_g_config->cnf_dict, DICT_AVP, AVP_BY_NAME_ALL_VENDORS,
+      "Supported-Features", &s6a_fd_cnf.dataobj_s6a_supported_features,
+      ENOENT));
+  CHECK_FD_FCT(fd_dict_search(
+      fd_g_config->cnf_dict, DICT_AVP, AVP_BY_NAME_ALL_VENDORS,
+      "Feature-List-ID", &s6a_fd_cnf.dataobj_s6a_feature_list_id, ENOENT));
+  CHECK_FD_FCT(fd_dict_search(
+      fd_g_config->cnf_dict, DICT_AVP, AVP_BY_NAME_ALL_VENDORS, "Feature-List",
+      &s6a_fd_cnf.dataobj_s6a_feature_list, ENOENT));
+
   /*
    * Register callbacks
    */

--- a/lte/gateway/c/core/oai/tasks/s6a/s6a_subscription_data.c
+++ b/lte/gateway/c/core/oai/tasks/s6a/s6a_subscription_data.c
@@ -91,38 +91,76 @@ static inline int s6a_parse_bitrate(
 static inline int s6a_parse_ambr(struct avp* avp_ambr, ambr_t* ambr) {
   struct avp* avp = NULL;
   struct avp_hdr* hdr;
+  bitrate_t ext_max_req_bw_ul = ULONG_MAX;
+  bitrate_t ext_max_req_bw_dl = ULONG_MAX;
 
   CHECK_FCT(fd_msg_browse(avp_ambr, MSG_BRW_FIRST_CHILD, &avp, NULL));
 
   if (!avp) {
     /*
-     * Child avps for ambr are mandatory
+     * First Child avps for ambr are mandatory
      */
     return RETURNerror;
   }
 
   while (avp) {
     CHECK_FCT(fd_msg_avp_hdr(avp, &hdr));
+    if (hdr) {
+      switch (hdr->avp_code) {
+        case AVP_CODE_MAX_REQUESTED_BANDWIDTH_UL:
+          CHECK_FCT(s6a_parse_bitrate(hdr, &ambr->br_ul));
+          break;
 
-    switch (hdr->avp_code) {
-      case AVP_CODE_BANDWIDTH_UL:
-        CHECK_FCT(s6a_parse_bitrate(hdr, &ambr->br_ul));
-        break;
+        case AVP_CODE_MAX_REQUESTED_BANDWIDTH_DL:
+          CHECK_FCT(s6a_parse_bitrate(hdr, &ambr->br_dl));
+          break;
 
-      case AVP_CODE_BANDWIDTH_DL:
-        CHECK_FCT(s6a_parse_bitrate(hdr, &ambr->br_dl));
-        break;
+        case AVP_CODE_EXTENDED_MAX_REQUESTED_BW_UL:
+          CHECK_FCT(s6a_parse_bitrate(hdr, &ext_max_req_bw_ul));
+          break;
 
-      default:
-        return RETURNerror;
+        case AVP_CODE_EXTENDED_MAX_REQUESTED_BW_DL:
+          CHECK_FCT(s6a_parse_bitrate(hdr, &ext_max_req_bw_dl));
+          break;
+
+        default:
+          OAILOG_DEBUG(
+              LOG_S6A, "AMBR child AVP %u is silently discarded\n",
+              hdr->avp_code);
+          return RETURNerror;
+      }
+    } else {
+      OAILOG_DEBUG(LOG_S6A, "AMBR child AVP header error\n");
     }
-
     /*
      * Go to next AVP in the grouped AVP
      */
     CHECK_FCT(fd_msg_browse(avp, MSG_BRW_NEXT, &avp, NULL));
   }
-
+  if ((ambr->br_ul != 4294967295) && (ext_max_req_bw_ul == ULONG_MAX)) {
+    ambr->br_unit = BPS;
+  } else if ((ambr->br_ul == 4294967295)) {
+    ambr->br_unit = KBPS;
+    ambr->br_ul   = ext_max_req_bw_ul;
+  } else {
+    OAILOG_DEBUG(LOG_S6A, "AMBR UL parsing error\n");
+    return RETURNerror;
+  }
+  if ((ambr->br_dl != 4294967295) && (ext_max_req_bw_dl == ULONG_MAX)) {
+    // harmonize
+    if (ambr->br_unit == KBPS) {
+      ambr->br_dl = ambr->br_dl / 1000;
+    }
+  } else if ((ambr->br_dl == 4294967295)) {
+    if (ambr->br_unit == BPS) {
+      ambr->br_unit = KBPS;
+      ambr->br_ul   = ambr->br_ul / 1000;
+    }
+    ambr->br_dl = ext_max_req_bw_dl;
+  } else {
+    OAILOG_DEBUG(LOG_S6A, "AMBR DL parsing error\n");
+    return RETURNerror;
+  }
   return RETURNok;
 }
 
@@ -443,66 +481,73 @@ int s6a_parse_subscription_data(
       fd_msg_browse(avp_subscription_data, MSG_BRW_FIRST_CHILD, &avp, NULL));
 
   while (avp) {
+    hdr = NULL;
     CHECK_FCT(fd_msg_avp_hdr(avp, &hdr));
 
-    switch (hdr->avp_code) {
-      case AVP_CODE_SUBSCRIBER_STATUS:
-        CHECK_FCT(s6a_parse_subscriber_status(
-            hdr, &subscription_data->subscriber_status));
-        break;
+    if (hdr) {
+      switch (hdr->avp_code) {
+        case AVP_CODE_SUBSCRIBER_STATUS:
+          CHECK_FCT(s6a_parse_subscriber_status(
+              hdr, &subscription_data->subscriber_status));
+          break;
 
-      case AVP_CODE_MSISDN:
-        CHECK_FCT(s6a_parse_msisdn(
-            hdr, subscription_data->msisdn, &subscription_data->msisdn_length));
-        break;
+        case AVP_CODE_MSISDN:
+          CHECK_FCT(s6a_parse_msisdn(
+              hdr, subscription_data->msisdn,
+              &subscription_data->msisdn_length));
+          break;
 
-      case AVP_CODE_NETWORK_ACCESS_MODE:
-        CHECK_FCT(s6a_parse_network_access_mode(
-            hdr, &subscription_data->access_mode));
-        break;
+        case AVP_CODE_NETWORK_ACCESS_MODE:
+          CHECK_FCT(s6a_parse_network_access_mode(
+              hdr, &subscription_data->access_mode));
+          break;
 
-      case AVP_CODE_ACCESS_RESTRICTION_DATA:
-        CHECK_FCT(s6a_parse_access_restriction_data(
-            hdr, &subscription_data->access_restriction));
-        break;
+        case AVP_CODE_ACCESS_RESTRICTION_DATA:
+          CHECK_FCT(s6a_parse_access_restriction_data(
+              hdr, &subscription_data->access_restriction));
+          break;
 
-      case AVP_CODE_AMBR:
-        CHECK_FCT(s6a_parse_ambr(avp, &subscription_data->subscribed_ambr));
-        break;
+        case AVP_CODE_AMBR:
+          CHECK_FCT(s6a_parse_ambr(avp, &subscription_data->subscribed_ambr));
+          break;
 
-      case AVP_CODE_APN_CONFIGURATION_PROFILE:
-        CHECK_FCT(s6a_parse_apn_configuration_profile(
-            avp, &subscription_data->apn_config_profile));
-        break;
+        case AVP_CODE_APN_CONFIGURATION_PROFILE:
+          CHECK_FCT(s6a_parse_apn_configuration_profile(
+              avp, &subscription_data->apn_config_profile));
+          break;
 
-      case AVP_CODE_SUBSCRIBED_PERIODIC_RAU_TAU_TIMER:
-        subscription_data->rau_tau_timer = hdr->avp_value->u32;
-        break;
+        case AVP_CODE_SUBSCRIBED_PERIODIC_RAU_TAU_TIMER:
+          subscription_data->rau_tau_timer = hdr->avp_value->u32;
+          break;
 
-      case AVP_CODE_APN_OI_REPLACEMENT:
-        OAILOG_DEBUG(
-            LOG_S6A, "AVP code %d APN-OI-Replacement not processed\n",
-            hdr->avp_code);
-        break;
+        case AVP_CODE_APN_OI_REPLACEMENT:
+          OAILOG_DEBUG(
+              LOG_S6A, "AVP code %d APN-OI-Replacement not processed\n",
+              hdr->avp_code);
+          break;
 
-      case AVP_CODE_3GPP_CHARGING_CHARACTERISTICS:
-        OAILOG_DEBUG(
-            LOG_S6A,
-            "AVP code %d 3GPP-Charging Characteristics not processed\n",
-            hdr->avp_code);
-        break;
+        case AVP_CODE_3GPP_CHARGING_CHARACTERISTICS:
+          OAILOG_DEBUG(
+              LOG_S6A,
+              "AVP code %d 3GPP-Charging Characteristics not processed\n",
+              hdr->avp_code);
+          break;
 
-      case AVP_CODE_REGIONAL_SUBSCRIPTION_ZONE_CODE:
-        OAILOG_DEBUG(
-            LOG_S6A,
-            "AVP code %d Regional-Subscription-Zone=Code not processed\n",
-            hdr->avp_code);
-        break;
+        case AVP_CODE_REGIONAL_SUBSCRIPTION_ZONE_CODE:
+          OAILOG_DEBUG(
+              LOG_S6A,
+              "AVP code %d Regional-Subscription-Zone=Code not processed\n",
+              hdr->avp_code);
+          break;
 
-      default:
-        OAILOG_DEBUG(
-            LOG_S6A, "Unknown AVP code %d not processed\n", hdr->avp_code);
-        return RETURNerror;
+        default:
+          OAILOG_DEBUG(
+              LOG_S6A, "Unknown AVP code %d not processed\n", hdr->avp_code);
+          return RETURNerror;
+      }
+    } else {
+      OAILOG_DEBUG(LOG_S6A, "Subscription Data parsing Error\n");
+      return RETURNerror;
     }
 
     /*
@@ -510,6 +555,5 @@ int s6a_parse_subscription_data(
      */
     CHECK_FCT(fd_msg_browse(avp, MSG_BRW_NEXT, &avp, NULL));
   }
-
   return RETURNok;
 }

--- a/lte/gateway/c/core/oai/tasks/s6a/s6a_supported_features.c
+++ b/lte/gateway/c/core/oai/tasks/s6a/s6a_supported_features.c
@@ -1,0 +1,97 @@
+/*
+ * Licensed to the OpenAirInterface (OAI) Software Alliance under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The OpenAirInterface Software Alliance licenses this file to You under
+ * the terms found in the LICENSE file in the root of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *-------------------------------------------------------------------------------
+ * For more information about the OpenAirInterface (OAI) Software Alliance:
+ *      contact@openairinterface.org
+ */
+
+/*! \file s6a_supported_features.c
+  \brief
+  \author Lionel Gauthier
+  \company Eurecom
+  \email: lionel.gauthier@eurecom.fr
+*/
+
+#include <stdint.h>
+#include <netinet/in.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "assertions.h"
+#include "3gpp_24.008.h"
+#include "common_defs.h"
+#include "common_types.h"
+#include "s6a_defs.h"
+
+struct avp;
+
+int s6a_parse_supported_features(
+    struct avp* avp_supported_features,
+    supported_features_t* subscription_data) {
+  struct avp* avp = NULL;
+  struct avp_hdr* hdr;
+  uint32_t feature_list_id = 0;
+  uint32_t feature_list    = 0;
+
+  CHECK_FCT(
+      fd_msg_browse(avp_supported_features, MSG_BRW_FIRST_CHILD, &avp, NULL));
+
+  while (avp) {
+    hdr = NULL;
+    CHECK_FCT(fd_msg_avp_hdr(avp, &hdr));
+
+    if (hdr) {
+      switch (hdr->avp_code) {
+        case AVP_CODE_VENDOR_ID:
+          // no check
+          break;
+
+        case AVP_CODE_FEATURE_LIST_ID:
+          if (hdr->avp_value) {
+            feature_list_id = hdr->avp_value->u32;
+          } else {
+            return RETURNerror;
+          }
+          break;
+
+        case AVP_CODE_FEATURE_LIST:
+          if (hdr->avp_value) {
+            feature_list = hdr->avp_value->u32;
+            if (feature_list_id == 2) {
+              subscription_data->external_identifier = true;
+              subscription_data->nr_as_secondary_rat =
+                  FLAG_IS_SET(feature_list, FLID_NR_AS_SECONDARY_RAT);
+            }
+          } else {
+            return RETURNerror;
+          }
+          break;
+
+        default:
+          OAILOG_DEBUG(
+              LOG_S6A, "Unknown AVP code %d not processed\n", hdr->avp_code);
+          return RETURNerror;
+      }
+    } else {
+      OAILOG_DEBUG(LOG_S6A, "Supported Features parsing Error\n");
+      return RETURNerror;
+    }
+
+    /*
+     * Go to next AVP in the grouped AVP
+     */
+    CHECK_FCT(fd_msg_browse(avp, MSG_BRW_NEXT, &avp, NULL));
+  }
+
+  return RETURNok;
+}

--- a/lte/gateway/c/core/oai/tasks/s6a/s6a_supported_features.c
+++ b/lte/gateway/c/core/oai/tasks/s6a/s6a_supported_features.c
@@ -1,26 +1,19 @@
-/*
- * Licensed to the OpenAirInterface (OAI) Software Alliance under one or more
- * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.
- * The OpenAirInterface Software Alliance licenses this file to You under
- * the terms found in the LICENSE file in the root of this source tree.
+/**
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *-------------------------------------------------------------------------------
- * For more information about the OpenAirInterface (OAI) Software Alliance:
- *      contact@openairinterface.org
  */
-
-/*! \file s6a_supported_features.c
-  \brief
-  \author Lionel Gauthier
-  \company Eurecom
-  \email: lionel.gauthier@eurecom.fr
-*/
+/****************************************************************************
+  Subsystem   MME
+  Description Handles the Supported Features Diameter AVP
+*****************************************************************************/
 
 #include <stdint.h>
 #include <netinet/in.h>

--- a/lte/gateway/c/core/oai/tasks/s6a/s6a_up_loc.c
+++ b/lte/gateway/c/core/oai/tasks/s6a/s6a_up_loc.c
@@ -302,6 +302,11 @@ int s6a_generate_update_location(s6a_update_location_req_t* ulr_pP) {
   if (ulr_pP->initial_attach) {
     FLAGS_SET(value.u32, ULR_INITIAL_ATTACH_IND);
   }
+
+  if (ulr_pP->dual_regis_5g_ind) {
+    FLAGS_SET(value.u32, ULR_DUAL_REGIS_5G_IND);
+  }
+
   CHECK_FCT(fd_msg_avp_setvalue(avp_p, &value));
   CHECK_FCT(fd_msg_avp_add(msg_p, MSG_BRW_LAST_CHILD, avp_p));
   CHECK_FCT(fd_msg_send(&msg_p, NULL, NULL));


### PR DESCRIPTION
## Summary

Enable Diameter extended bitrates
Handle ULA Supported-Features AVP for NSA
Send in ULR Dual-Registration-5G-Indicator
Test Plan

## Test Plan

Tested with dsTester NSA scenario:
Provision subscribers in OAI HSS with bitrate(s) greater than 4294967295 bits/s

## Additional Information
    This change is not backward breaking.
    This changes only S6a/Diameter interface, to enable NSA compatibility between Magma and OAI HSS network function.