### PR TITLE
Fix conntrackd zone verification

### DIFF
--- a/lte/gateway/c/connection_tracker/EventTracker.h
+++ b/lte/gateway/c/connection_tracker/EventTracker.h
@@ -19,12 +19,12 @@ namespace lte {
 
 class EventTracker {
  public:
-  EventTracker(std::shared_ptr<PacketGenerator> pkt_gen);
+  EventTracker(std::shared_ptr<PacketGenerator> pkt_gen, int zone);
 
-  int init_conntrack_event_loop(void);
+  int init_conntrack_event_loop();
 
- private:
   std::shared_ptr<PacketGenerator> pkt_gen_;
+  int zone_;
 };
 
 }  // namespace lte

--- a/lte/gateway/c/connection_tracker/main.cpp
+++ b/lte/gateway/c/connection_tracker/main.cpp
@@ -80,6 +80,7 @@ int main(void) {
   std::string interface_name = config["interface_name"].as<std::string>();
   std::string pkt_dst_mac    = config["pkt_dst_mac"].as<std::string>();
   std::string pkt_src_mac    = config["pkt_src_mac"].as<std::string>();
+  int zone                   = config["zone"].as<int>();
 
   magma::service303::MagmaService server(
       CONNECTION_SERVICE, CONNECTIOND_VERSION);
@@ -89,7 +90,7 @@ int main(void) {
       interface_name, pkt_dst_mac, pkt_src_mac);
 
   auto event_tracker =
-      std::make_shared<magma::lte::EventTracker>(pkt_generator);
+      std::make_shared<magma::lte::EventTracker>(pkt_generator, zone);
 
   event_tracker->init_conntrack_event_loop();
 

--- a/lte/gateway/configs/connectiond.yml
+++ b/lte/gateway/configs/connectiond.yml
@@ -19,3 +19,6 @@ interface_name: ipfix0
 # Used for generated internal packets
 pkt_dst_mac: "33:aa:99:33:aa:00"
 pkt_src_mac: "55:11:44:ee:00:00"
+
+# IMPORTANT when modifying also modify the corresponding pipelined.yml entry
+zone: 897

--- a/lte/gateway/configs/pipelined.yml
+++ b/lte/gateway/configs/pipelined.yml
@@ -85,6 +85,7 @@ dpi:
 
 conntrackd:
   enabled: false
+  zone: 897
 
 # Interface to address L2 traffic to and answer ARP for UE subnet
 virtual_interface: gtp_br0

--- a/lte/gateway/configs/pipelined.yml_prod
+++ b/lte/gateway/configs/pipelined.yml_prod
@@ -76,6 +76,7 @@ dpi:
 
 conntrackd:
   enabled: false
+  zone: 897
 
 # Enable polling mobilityd to identify which subscriber sessions need to be
 # terminated. If disabling this, make sure to set a valid idle_timeout for

--- a/lte/gateway/python/magma/pipelined/tests/test_conntrack.py
+++ b/lte/gateway/python/magma/pipelined/tests/test_conntrack.py
@@ -93,7 +93,10 @@ class ConntrackTest(unittest.TestCase):
                 'access_control': {
                     'ip_blocklist': [
                     ]
-                }
+                },
+                'conntrackd': {
+                    'zone': 897,
+                },
             },
             mconfig=PipelineD(
                 allowed_gre_peers=[],


### PR DESCRIPTION
<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary
Instead of checking all conntrackd events only check those which match the zone set by ovs

## Test Plan

Checked logs when running conntrack pipelined test, works as expected

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
