### PR TITLE
remove unused proto dependencies from connection tracker and li agent

### DIFF
--- a/lte/gateway/c/connection_tracker/CMakeLists.txt
+++ b/lte/gateway/c/connection_tracker/CMakeLists.txt
@@ -17,25 +17,25 @@ add_compile_options(-std=c++14)
 
 include($ENV{MAGMA_ROOT}/orc8r/gateway/c/common/CMakeProtoMacros.txt)
 
-if (NOT BUILD_TESTS)
-  # Add AddressSanitizer (asan) support for debug builds of ConnectionD
-  set (CMAKE_CXX_FLAGS_DEBUG
-      "${CMAKE_CXX_FLAGS_DEBUG} -fno-omit-frame-pointer -fsanitize=address")
-  set (CMAKE_LINKER_FLAGS_DEBUG
-      "${CMAKE_LINKER_FLAGS_DEBUG} -fno-omit-frame-pointer -fsanitize=address")
-  # Add LeakSanitizer (lsan) support to the release build of SessionD so that
-  # we can find memory leaks in production.
-  set(CMAKE_C_FLAGS_RELWITHDEBINFO
-     "${CMAKE_C_FLAGS_RELWITHDEBINFO} -fsanitize=leak -fno-omit-frame-pointer")
-  set(CMAKE_EXE_LINKER_FLAGS_RELWITHDEBINFO
-     "${CMAKE_EXE_LINKER_FLAGS_RELWITHDEBINFO} -fsanitize=leak")
-else() # BUILD_TESTS
+if (BUILD_TESTS)
   message("Adding code coverage build and linker flags for BUILD_TESTS")
   set (CMAKE_CXX_FLAGS_DEBUG
       "${CMAKE_CXX_FLAGS_DEBUG} -g -O0 -fprofile-arcs -ftest-coverage")
   set(CMAKE_LINKER_FLAGS_DEBUG
       "${CMAKE_LINKER_FLAGS_DEBUG} -fprofile-arcs -ftest-coverage")
 endif ()
+
+# Add AddressSanitizer (asan) support for debug builds of ConnectionD
+set (CMAKE_CXX_FLAGS_DEBUG
+    "${CMAKE_CXX_FLAGS_DEBUG} -fno-omit-frame-pointer -fsanitize=address")
+set (CMAKE_LINKER_FLAGS_DEBUG
+    "${CMAKE_LINKER_FLAGS_DEBUG} -fno-omit-frame-pointer -fsanitize=address")
+# Add LeakSanitizer (lsan) support to the release build of SessionD so that
+# we can find memory leaks in production.
+set(CMAKE_C_FLAGS_RELWITHDEBINFO
+    "${CMAKE_C_FLAGS_RELWITHDEBINFO} -fsanitize=leak -fno-omit-frame-pointer")
+set(CMAKE_EXE_LINKER_FLAGS_RELWITHDEBINFO
+    "${CMAKE_EXE_LINKER_FLAGS_RELWITHDEBINFO} -fsanitize=leak")
 
 set(OUTPUT_DIR "${CMAKE_CURRENT_BINARY_DIR}")
 
@@ -58,35 +58,19 @@ include_directories(${MAGMA_LIB_DIR}/config)
 
 include($ENV{MAGMA_ROOT}/orc8r/gateway/c/common/CMakeProtoMacros.txt)
 
-# compile the needed macros
-create_proto_dir("lte" LTE_CPP_OUT_DIR)
-create_proto_dir("orc8r" ORC8R_CPP_OUT_DIR)
-create_proto_dir("feg/gateway/services/aaa" CWF_CPP_OUT_DIR)
-
-list(APPEND PROTO_SRCS "")
-list(APPEND PROTO_HDRS "")
-
-message("Proto_srcs are ${PROTO_SRCS}")
-
 find_library(SERVICE303_LIB SERVICE303_LIB HINTS ${MAGMA_LIB_DIR}/service303)
 
 # compile the needed macros
 create_proto_dir("lte" LTE_CPP_OUT_DIR)
 create_proto_dir("orc8r" ORC8R_CPP_OUT_DIR)
-create_proto_dir("feg/gateway/services/aaa" CWF_CPP_OUT_DIR)
 
 list(APPEND PROTO_SRCS "")
 list(APPEND PROTO_HDRS "")
+message("Proto_srcs are ${PROTO_SRCS}")
 
-
-set(SMGR_LTE_CPP_PROTOS session_manager subscriberdb
-  pipelined spgw_service mconfig/mconfigs)
-generate_cpp_protos("${SMGR_LTE_CPP_PROTOS}" "${PROTO_SRCS}"
+set(C_TRACKER_LTE_CPP_PROTOS mconfig/mconfigs)
+generate_cpp_protos("${C_TRACKER_LTE_CPP_PROTOS}" "${PROTO_SRCS}"
   "${PROTO_HDRS}" ${LTE_PROTO_DIR} ${LTE_CPP_OUT_DIR})
-
-set(SMGR_CWF_CPP_PROTOS accounting context)
-generate_cwf_cpp_protos("${SMGR_CWF_CPP_PROTOS}" "${PROTO_SRCS}"
-  "${PROTO_HDRS}" ${CWF_PROTO_DIR} ${CWF_CPP_OUT_DIR})
 
 # TODO: Temp workaround until packages are imported by these cmakefile
 # Will be removed in subsequent patch

--- a/lte/gateway/c/li_agent/CMakeLists.txt
+++ b/lte/gateway/c/li_agent/CMakeLists.txt
@@ -64,8 +64,8 @@ list(APPEND PROTO_HDRS "")
 
 message("Proto_srcs are ${PROTO_SRCS}")
 
-set(SMGR_LTE_CPP_PROTOS mconfig/mconfigs)
-generate_cpp_protos("${SMGR_LTE_CPP_PROTOS}" "${PROTO_SRCS}"
+set(LI_AGENT_LTE_CPP_PROTOS mconfig/mconfigs)
+generate_cpp_protos("${LI_AGENT_LTE_CPP_PROTOS}" "${PROTO_SRCS}"
   "${PROTO_HDRS}" ${LTE_PROTO_DIR} ${LTE_CPP_OUT_DIR})
 
 link_directories(


### PR DESCRIPTION


Signed-off-by: Marie Bremner <marwhal@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary
* connection tracker and li agent both don't need cwf related proto generation
<!-- Enumerate changes you made and why you made them -->

## Test Plan
CI + building locally
<img width="861" alt="Screen Shot 2021-06-10 at 2 34 01 PM" src="https://user-images.githubusercontent.com/37634144/121586125-e8d0c300-c9f8-11eb-867a-0dc422480cc5.png">
<img width="862" alt="Screen Shot 2021-06-10 at 2 34 20 PM" src="https://user-images.githubusercontent.com/37634144/121586164-f38b5800-c9f8-11eb-9ded-2d0177edd180.png">

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
