### PR TITLE
DOCKER: fix after core inversion typo

### DIFF
--- a/lte/gateway/docker/mme/Dockerfile.rhel8
+++ b/lte/gateway/docker/mme/Dockerfile.rhel8
@@ -433,7 +433,7 @@ RUN cp $MAGMA_ROOT/lte/gateway/configs/redis.yml .
 RUN cp $MAGMA_ROOT/lte/gateway/configs/service_registry.yml .
 
 WORKDIR /magma-mme/scripts
-RUN cp $MAGMA_ROOT/lte/gateway/c/oai/core/test/check_mme_s6a_certificate . && \
+RUN cp $MAGMA_ROOT/lte/gateway/c/core/oai/test/check_mme_s6a_certificate . && \
     sed -i -e "s@^.*THIS_SCRIPT_PATH@#@" \
            -e "s@\$SUDO@@" \
            -e "s@echo_error@echo@" \


### PR DESCRIPTION
Signed-off-by: Raphael Defosseux <raphael.defosseux@openairinterface.org>


## Summary

After Amar's big PR, one little typo went through.

## Test Plan

## Additional Information

- [ ] This change is backwards-breaking

