### PR TITLE
Add approvers-agw-c to connection_tracker directory

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -40,7 +40,7 @@ orc8r/gateway/c/ @magma/approvers-agw-c
 lte/gateway/c/session_manager @magma/approvers-agw-sessiond
 lte/gateway/c/oai @magma/approvers-agw-mme
 lte/gateway/c/sctpd @magma/approvers-agw-mme
-lte/gateway/c/connection_tracker @koolzz
+lte/gateway/c/connection_tracker @koolzz @magma/approvers-agw-c
 lte/gateway/python/magma/pipelined @magma/approvers-agw-pipelined
 lte/gateway/python/integ_tests @magma/approvers-agw-integtests
 


### PR DESCRIPTION
Signed-off-by: Marie Bremner <marwhal@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary
`lte/gateway/c/connection_tracker` only has one owner which is less than the minimum number of 2 we aim for. Since it is a c++ directory, also adding `approvers-c` (marie and alex) to increase the total number of owners to 3.
<!-- Enumerate changes you made and why you made them -->

## Test Plan
CI's codeowners syntax check
<img width="961" alt="Screen Shot 2021-06-07 at 10 12 31 AM" src="https://user-images.githubusercontent.com/37634144/121041996-e102eb80-c778-11eb-86ef-6647cf3efa0c.png">
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->

