### PR TITLE
[docker] links session_manager config files

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -295,3 +295,6 @@ RUN git clone https://github.com/OPENAIRINTERFACE/opencord.org.freeDiameter.git 
     make install && \
     cd / && \
     rm -rf freediameter
+
+#### Link configuration files needed for session_manager
+RUN ln -s lte/gateway/configs/ /etc/magma

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -295,6 +295,3 @@ RUN git clone https://github.com/OPENAIRINTERFACE/opencord.org.freeDiameter.git 
     make install && \
     cd / && \
     rm -rf freediameter
-
-#### Link configuration files needed for session_manager
-RUN ln -s lte/gateway/configs/ /etc/magma

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -53,6 +53,7 @@
 	"mounts": [
 		"source=/var/run/docker.sock,target=/var/run/docker-host.sock,type=bind"
 	],
+	"postCreateCommand": "sudo ln -s /workspaces/magma/lte/gateway/configs /etc/magma",
 	"runArgs": [
 		"--init"
 	],

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -53,7 +53,7 @@
 	"mounts": [
 		"source=/var/run/docker.sock,target=/var/run/docker-host.sock,type=bind"
 	],
-	"postCreateCommand": "sudo ln -s /workspaces/magma/lte/gateway/configs /etc/magma",
+	"postCreateCommand": "sudo ln -s ${containerWorkspaceFolder}/lte/gateway/configs /etc/magma",
 	"runArgs": [
 		"--init"
 	],


### PR DESCRIPTION
Signed-off-by: Waqar Aqeel <waqeel@fb.com>

## Summary

When `make test_session_manager` is run in the docker environment, tests that expect config files in `/etc/magma` fail because the docker env doesn't link the required files in the right place during setup. This PR adds a step in Dockerfile.

## Test Plan

Executed `Rebuild Container` in VSCode.