### PR TITLE
update `session_terminated` event definition to have all recently updated fields

### DIFF
--- a/lte/swagger/session_manager_events.v1.yml
+++ b/lte/swagger/session_manager_events.v1.yml
@@ -76,37 +76,83 @@ definitions:
         type: string
       apn:
         type: string
-      mac_addr:
-        type: string
       ip_addr:
+        type: string
+      ipv6_addr:
         type: string
       msisdn:
         type: string
+      session_id:
+        type: string
+      # The following fields are for WiFi sessions only
+      mac_addr:
+        type: string
+      # The following fields are for LTE sessions only
       imei:
         type: string
       spgw_ip:
         type: string
-      session_id:
+      user_location:
         type: string
+      charging_characteristics:
+        type: string
+      # Session summary
+      pdp_start_time:
+        type: integer
+        description: Time at which the session started
+      pdp_end_time:
+        type: integer
+        description: Time at which the session ended
+      duration:
+        type: integer
+      cause_for_rec_closing:
+        type: integer
+        description: As defined in 3GPP TS 32.298 v8.4.0 - 5.1.2.2.5
+      record_sequence_number:
+        type: integer
+      # Data usage
       total_tx:
         type: integer
         minimum: 0
+        description: Total Tx of all data usage tracked by any monitoring key or rating group
       total_rx:
         type: integer
         minimum: 0
+        description: Total Rx of all data usage tracked by any monitoring key or rating group
       charging_tx:
         type: integer
         minimum: 0
+        description: Total Tx of all data usage tracked by any rating group
       charging_rx:
         type: integer
         minimum: 0
+        description: Total Tx of all data usage tracked by any rating group
       monitoring_tx:
         type: integer
         minimum: 0
       monitoring_rx:
         type: integer
         minimum: 0
-      pdp_start_time:
-        type: integer
-      pdp_end_time:
-        type: integer
+      # Service Data
+      list_of_service_data:
+        type: array
+        description: Summaries of rating group tracked credits based on 3GPP TS 32.298 v8.4.0 - 5.1.2.2.22A
+        items:
+          type: object
+          properties:
+            rating_group:
+              type: integer
+            service_identifier:
+              type: integer
+            data_volume_downlink:
+              type: integer
+              minimum: 0
+            data_volume_uplink:
+              type: integer
+              minimum: 0
+            time_of_first_usage:
+              type: integer
+            time_of_last_usage:
+              type: integer
+            service_condition_change:
+              type: integer


### PR DESCRIPTION
Signed-off-by: Marie Bremner <marwhal@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary
Update the session_terminated swagger definition to include new fields added in the past few months.
<!-- Enumerate changes you made and why you made them -->

## Test Plan
run s1ap tests
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
