### PR TITLE
Update the build directory for clang_tidy_oai target

### DIFF
--- a/lte/gateway/Makefile
+++ b/lte/gateway/Makefile
@@ -240,12 +240,12 @@ precommit_oai: format_oai test_oai
 # TODO: CMake config issue - compile_commands.json is only generated if you first make_oai, then test_oai (or do either twice).
 #       Additionally compile_commands.json is **not capturing all build artifacts this way**
 clang_tidy_oai:
-	mkdir $(GATEWAY_C_DIR)/core/oai/build
-	cd $(GATEWAY_C_DIR)/core/oai/build;cmake ..
-	sed -i 's/CMAKE_EXPORT_COMPILE_COMMANDS:BOOL=OFF/CMAKE_EXPORT_COMPILE_COMMANDS:BOOL=ON/g' $(GATEWAY_C_DIR)/core/oai/build/CMakeCache.txt
-	cmake --build $(GATEWAY_C_DIR)/core/oai/build/
-	wget https://raw.githubusercontent.com/llvm-mirror/clang-tools-extra/master/clang-tidy/tool/run-clang-tidy.py
-	python run-clang-tidy.py -p $(GATEWAY_C_DIR)/core/oai/build/ -j 2 -checks='-*,clang-analyzer-security*,android-*,cert-*,clang-analyzer-*,concurrency,misc-*,-misc-unused-parameters,bugprone-*' 2>&1 | tee /tmp/clang-tidy-oai.findings
+	mkdir -p $(C_BUILD)/core/oai/build
+	cd $(C_BUILD)/core/oai/build;cmake $(GATEWAY_C_DIR)/core
+	sed -i 's/CMAKE_EXPORT_COMPILE_COMMANDS:BOOL=OFF/CMAKE_EXPORT_COMPILE_COMMANDS:BOOL=ON/g' $(C_BUILD)/core/oai/build/CMakeCache.txt
+	cmake --build $(C_BUILD)/core/oai/build/
+	cd $(C_BUILD)/core/oai/build;wget https://raw.githubusercontent.com/llvm-mirror/clang-tools-extra/master/clang-tidy/tool/run-clang-tidy.py;\
+	python run-clang-tidy.py -p $(C_BUILD)/core/oai/build/oai -j 2 -checks='-*,clang-analyzer-security*,android-*,cert-*,clang-analyzer-*,concurrency,misc-*,-misc-unused-parameters,bugprone-*' 2>&1 | tee /tmp/clang-tidy-oai.findings
 
 # Pushes per-finding counts to:
 #   https://docs.google.com/forms/d/1-45BZTHh4uBBOCqYM4LAD4zFT91B47sEEntHLkQuXWA/edit#responses


### PR DESCRIPTION
## Summary
The current target points at the source directory, this variable wasn't
set in the past making it default to /build. Fixes the build directory


<!-- Enumerate changes you made and why you made them -->

## Test Plan

Resolving raw.githubusercontent.com (raw.githubusercontent.com)... 185.199.108.133, 185.199.109.133, 185.199.110.133, ...
Connecting to raw.githubusercontent.com (raw.githubusercontent.com)|185.199.108.133|:443... connected.
HTTP request sent, awaiting response... 200 OK
Length: 11489 (11K) [text/plain]
Saving to: ‘run-clang-tidy.py’

run-clang-tidy.py                                           100%[========================================================================================================================================>]  11.22K  --.-KB/s    in 0.002s

2021-06-07 17:56:20 (5.60 MB/s) - ‘run-clang-tidy.py’ saved [11489/11489]

Validated on both docker and vagrant

Also ran the build validated git status after.

Signed-off-by: Amar Padmanabhan <amar@freedomfi.com>

## Additional Information

- [ ] This change is backwards-breaking


