### PR TITLE
[mme] Remove additional unnecessary AssertFatal calls

### DIFF
--- a/lte/gateway/c/core/oai/common/async_system.c
+++ b/lte/gateway/c/core/oai/common/async_system.c
@@ -142,7 +142,6 @@ int async_system_command(
   }
   MessageDef* message_p = NULL;
   message_p = itti_alloc_new_message(sender_itti_task, ASYNC_SYSTEM_COMMAND);
-  AssertFatal(message_p, "itti_alloc_new_message Failed");
   ASYNC_SYSTEM_COMMAND(message_p).system_command    = bstr;
   ASYNC_SYSTEM_COMMAND(message_p).is_abort_on_error = is_abort_on_error;
   rv                                                = send_msg_to_task(

--- a/lte/gateway/c/core/oai/common/itti_free_defined_msg.c
+++ b/lte/gateway/c/core/oai/common/itti_free_defined_msg.c
@@ -93,9 +93,6 @@ void itti_free_msg_content(MessageDef* const message_p) {
 
     case MME_APP_UPLINK_DATA_IND:
       bdestroy_wrapper(&message_p->ittiMsg.mme_app_ul_data_ind.nas_msg);
-      AssertFatal(
-          NULL == message_p->ittiMsg.mme_app_ul_data_ind.nas_msg,
-          "TODO clean pointer");
       break;
 
     case MME_APP_HANDOVER_REQUEST:


### PR DESCRIPTION
## Summary

Removes two unnecessary `AssertFatal` calls in MME service.

- `itti_alloc_new_message` cannot return NULL, as it asserts in its function body for non-NULL return values.
- `bdestroy_wrapper` will always clean up the input, so the `AssertFatal` check after is unnecessary.

## Test Plan

Only built MME:

```
vagrant@magma-dev:~/magma/lte/gateway$ make build_oai
.
.
.
[1973/1973] Linking CXX executable oai_mme/mme
[16/16] Completed 'MagmaCore'
vagrant@magma-dev:~/magma/lte/gateway$
```

## Additional Information

- [ ] This change is backwards-breaking
