### PR TITLE
[MME][ZMQ] protect against using a destroyed zmq context

### DIFF
--- a/lte/gateway/c/core/oai/lib/itti/intertask_interface.h
+++ b/lte/gateway/c/core/oai/lib/itti/intertask_interface.h
@@ -72,6 +72,7 @@ typedef struct task_zmq_ctx_s {
   zsock_t* pull_sock;
   zsock_t* push_socks[TASK_MAX];
   pthread_mutex_t send_mutex;
+  bool ready;
 } task_zmq_ctx_t;
 
 typedef struct message_info_s {


### PR DESCRIPTION
Signed-off-by: Tariq Al-Khasib <talkhasib@fb.com>

## Summary

When a zmq context is destroyed during shutdown of MME, the context might be used by a pending GRPC service. This causes a benign assert that might mask other issues.

The assert that we have been observing due to this issue was
"Sending to task without push socket. id: %s to %s!"
And is only observed during an MME shutdown

This change adds a "ready" flag that gets cleared when the context is destroyed.

## Test Plan

Built and tested on local focal VM with s1aptester
