### PR TITLE
[agw][cloudstrapper] clean ami root ssh keys

### DIFF
--- a/experimental/cloudstrapper/playbooks/roles/clean-ami/tasks/main.yaml
+++ b/experimental/cloudstrapper/playbooks/roles/clean-ami/tasks/main.yaml
@@ -18,9 +18,16 @@
   ignore_errors: true
   tags: clearSSHKeys
 
-- name: Clean authorized keys
+- name: Clean authorized keys for ubuntu
   file:
     name: /home/ubuntu/.ssh/authorized_keys
+    state: absent
+  become: true
+  tags: clearSSHKeys
+
+- name: Clean authorized keys for root
+  file:
+    name: /root/.ssh/authorized_keys
     state: absent
   become: true
   tags: clearSSHKeys


### PR DESCRIPTION
## Summary

Clean root ssh authorized key.
Created by default by AWS when creating the instance.

## Test Plan

Testing pipeline in circleci
https://app.circleci.com/pipelines/github/magma/magma/25279/workflows/35046732-f16c-4f3c-a514-68cf8dbf0158/jobs/268044


