### PR TITLE
[bare-metal-ansible] Add 1.5 support and other enhancements

### DIFF
--- a/orc8r/cloud/deploy/bare-metal-ansible/ansible_vars.yaml
+++ b/orc8r/cloud/deploy/bare-metal-ansible/ansible_vars.yaml
@@ -1,8 +1,9 @@
+---
 ansible_user: ubuntu
 
 helm_enabled: true
 kube_network_plugin: calico
-kube_network_plugin_multus: true
+kube_network_plugin_multus: false
 
 kube_apiserver_port: 6443
 kube_pods_subnet: 10.233.64.0/18
@@ -53,19 +54,20 @@ kubelet_cgroup_driver: systemd
 # orc8r_nms_admin_email:
 
 # Component versions (orc8r 1.3.x or 1.4.x supported)
-# orc8r_chart_version: 1.4.x
-# orc8r_image_tag: 1.3.x
-# orc8r_nms_image_tag: 1.3.x
-# orc8r_nginx_image_tag: 1.3.x
+# orc8r_chart_version: 1.5.x
+# orc8r_image_tag: 1.5.x
+# orc8r_nms_image_tag: 1.5.x
+# orc8r_nginx_image_tag: 1.5.x
 
 # Component passwords are randomly generated (and stored in credentials dir).
 # Uncomment the following lines to explicitly set passwords
+# db_root_user:
 # db_root_password:
 # orc8r_db_pass:
 # orc8r_nms_db_pass:
 # orc8r_nms_admin_pass:
 
-# LoadBalancer settings for Magma services publicly exposed
+# (REQUIRED): LoadBalancer settings for Magma services publicly exposed
 # metallb_addresses: 192.168.10.200-192.168.10.230
 
 # Advanced options for enabling/disabling Helm charts
@@ -75,5 +77,4 @@ deploy_metallb: True
 deploy_mariadb: True
 deploy_elasticsearch: True
 deploy_fluentd: True
-deploy_kibana: False
-
+magma_namespace: magma

--- a/orc8r/cloud/deploy/bare-metal-ansible/deploy-magma-infra.yml
+++ b/orc8r/cloud/deploy/bare-metal-ansible/deploy-magma-infra.yml
@@ -2,7 +2,10 @@
   become: yes
   become_user: root
   roles:
-    - magma/nfs-server-provisioner
-    - magma/kubevirt
-    - magma/metallb
+    - role: magma/nfs-server-provisioner
+      when: deploy_nfs_server_provisioner | default(true)
+    - role: magma/kubevirt
+      when: kubevirt_enabled | default(false)
+    - role: magma/metallb
+      when: deploy_metallb | default(true)
 

--- a/orc8r/cloud/deploy/bare-metal-ansible/deploy-magma.yml
+++ b/orc8r/cloud/deploy/bare-metal-ansible/deploy-magma.yml
@@ -2,8 +2,11 @@
   become: yes
   become_user: root
   roles:
-    - magma/mariadb
-    - magma/elasticsearch
+    - role: magma/mariadb
+      when: deploy_mariadb | default(true)
+    - role: magma/elasticsearch
+      when: deploy_elasticsearch | default(true)
     - magma/fluentd
-    - magma/kibana
+    - role: magma/kibana
+      when: deploy_kibana | default(true)
     - magma/orc8r

--- a/orc8r/cloud/deploy/bare-metal-ansible/deploy.sh
+++ b/orc8r/cloud/deploy/bare-metal-ansible/deploy.sh
@@ -37,9 +37,9 @@ ansible-galaxy install git+https://github.com/uoi-io/ansible-haproxy,fe397a380ad
 
 
 # Update Ansible inventory file with inventory builder
-HOST_PREFIX=compute KUBE_MASTERS_MASTERS=3 CONFIG_FILE=inventory/$CLUSTER_NAME/hosts.yml python3 kubespray/contrib/inventory_builder/inventory.py ${IPS[@]}
+HOST_PREFIX="${HOST_PREFIX:-compute}" KUBE_MASTERS_MASTERS=3 CONFIG_FILE=inventory/$CLUSTER_NAME/hosts.yml python3 kubespray/contrib/inventory_builder/inventory.py ${IPS[@]}
 
-ansible-playbook -b -i inventory/$CLUSTER_NAME/hosts.yml  $playbook -e @ansible_vars.yaml
+ansible-playbook -b -i inventory/$CLUSTER_NAME/hosts.yml  $playbook -e @ansible_vars.yaml -v
 
 echo "If you did not specify passwords, you can find generated passwords here:"
 find inventory/$CLUSTER_NAME/credentials

--- a/orc8r/cloud/deploy/bare-metal-ansible/roles/magma/nfs-server-provisioner/defaults/main.yml
+++ b/orc8r/cloud/deploy/bare-metal-ansible/roles/magma/nfs-server-provisioner/defaults/main.yml
@@ -4,3 +4,5 @@ storage_class: nfs
 nfs_host: "{{ kube_override_hostname | default(inventory_hostname) }}"
 
 nfs_pv_path: /mnt/persistentvols/nfs
+setup_pv: true
+nfs_provisioner_storage_class: nfs-provisioner

--- a/orc8r/cloud/deploy/bare-metal-ansible/roles/magma/nfs-server-provisioner/tasks/main.yml
+++ b/orc8r/cloud/deploy/bare-metal-ansible/roles/magma/nfs-server-provisioner/tasks/main.yml
@@ -19,14 +19,17 @@
     path: "{{ nfs_pv_path }}"
     state: directory
     recurse: yes
+  when: setup_pv
 
 - name: nfs-server-provisioner | Template out PV 
   template:
     src: nfs-pv.yaml.j2
     dest: "{{ charts_dir }}/nfs-pv.yaml"
+  when: setup_pv
 
 - name: nfs-server-provisioner | Apply NFS PV
   command: kubectl apply -f {{ charts_dir}}/nfs-pv.yaml
+  when: setup_pv
 
 - name: nfs-server-provisioner | Template out helm chart values
   template:

--- a/orc8r/cloud/deploy/bare-metal-ansible/roles/magma/nfs-server-provisioner/templates/nfs-server-provisioner-values.yaml.j2
+++ b/orc8r/cloud/deploy/bare-metal-ansible/roles/magma/nfs-server-provisioner/templates/nfs-server-provisioner-values.yaml.j2
@@ -9,7 +9,7 @@ nodeSelector:
 persistence:
   enabled: true
   size: 200Gi
-  storageClass: nfs-provisioner
+  storageClass: {{ nfs_provisioner_storage_class }}
 replicaCount: 1
 resources:
   requests:

--- a/orc8r/cloud/deploy/bare-metal-ansible/roles/magma/orc8r/defaults/main.yml
+++ b/orc8r/cloud/deploy/bare-metal-ansible/roles/magma/orc8r/defaults/main.yml
@@ -9,22 +9,28 @@ credentials_dir: "{{ inventory_dir }}/credentials"
 magma_namespace: magma
 orc8r_domain: magma.local
 dns_domain: cluster.local
+kube_dns_resolver: coredns.kube-system.svc.{{ dns_domain }}
 
+orc8r_db_driver: mysql
+orc8r_db_sql_dialect: maria
 orc8r_image_tag: latest # Unsafe!! Use specific version
 orc8r_db_user: orc8r
+orc8r_db_port: 3306
 orc8r_db_host: mariadb.{{ mariadb_namespace | default("mariadb") }}
-orc8r_db_pass: "{{ lookup('password', credentials_dir + '/orc8r_db_pass.creds length=24 chars=hexdigits') | lower }}"
+orc8r_db_pass: "{{ lookup('password', credentials_dir + '/orc8r_db_pass.creds length=24 chars=asci_lowercase,digits') }}"
 orc8r_db_name: orc8r
 
 # NMS settings
 orc8r_nms_image_tag: latest # Unsafe!! Use specific version
+orc8r_nms_db_sql_dialect: mariadb
+orc8r_nms_db_port: 3306
 orc8r_nms_db_user: nms
 orc8r_nms_db_host: mariadb.{{ mariadb_namespace | default("mariadb") }}
-orc8r_nms_db_pass: "{{ lookup('password', credentials_dir + '/orc8r_nms_db_pass.creds length=24 chars=hexdigits') | lower }}"
+orc8r_nms_db_pass: "{{ lookup('password', credentials_dir + '/orc8r_nms_db_pass.creds length=24 chars=ascii_lowercase,digits') }}"
 orc8r_nms_db_name: nms
 
 orc8r_nms_admin_email: "admin@{{ orc8r_domain }}"
-orc8r_nms_admin_pass: "{{ lookup('password', credentials_dir + '/orc8r_nms_admin_pass.creds length=24 chars=hexdigits') | lower }}"
+orc8r_nms_admin_pass: "{{ lookup('password', credentials_dir + '/orc8r_nms_admin_pass.creds length=24 chars=ascii_lowercase,digits')}}"
 
 
 # Monitoring component settings

--- a/orc8r/cloud/deploy/bare-metal-ansible/roles/magma/orc8r/tasks/main.yml
+++ b/orc8r/cloud/deploy/bare-metal-ansible/roles/magma/orc8r/tasks/main.yml
@@ -40,6 +40,7 @@
     src: db_setup.sql.j2
     dest: "{{ orc8r_config_dir }}/db_setup.sql"
     mode: 600
+  when: orc8r_db_sql_dialect == "maria"
 
 - name: orc8r | copy orc8r settings secrets
   copy:
@@ -60,12 +61,13 @@
   shell: kubectl -n mariadb exec -i mariadb-0 -- mysql -u root "--password={{ db_root_password }}" mysql < db_setup.sql
   args:
     chdir: "{{ orc8r_config_dir }}"
+  when: orc8r_db_sql_dialect == "maria"
 
 - name: orc8r | precreate persistentvolumeclaims for components
   script: make_magma_pvcs.sh {{ magma_namespace }} {{ storage_class }} ReadWriteMany {{ item.key }} {{ item.value }}
   with_items: "{{ magma_pvcs | dict2items }}"
 
-- name: orc8r | Install/upgrade helm charts
+- name: orc8r | Install/upgrade orc8r helm charts
   command: >-
     helm upgrade --install
     -n {{ magma_namespace }}
@@ -76,6 +78,18 @@
     --wait
   with_items:
     - orc8r
+
+- name: orc8r | Install/upgrade lte-orc8r helm charts
+  command: >-
+    helm upgrade --install
+    -n {{ magma_namespace }}
+    {{ item }}
+    orc8r/{{ item }}
+    {% if lte_orc8r_chart_version is defined %} --version {{ lte_orc8r_chart_version }}{% endif %}
+    -f {{ charts_dir }}/orc8r-values.yaml
+    --wait
+  with_items:
+    - lte-orc8r
 
 - name: orc8r | Get orc8r certifier pod
   command: kubectl -n {{ magma_namespace }} get pod -l app.kubernetes.io/component=certifier  -o jsonpath='{.items[0].metadata.name}'

--- a/orc8r/cloud/deploy/bare-metal-ansible/roles/magma/orc8r/templates/orc8r-values-1.4.yaml.j2
+++ b/orc8r/cloud/deploy/bare-metal-ansible/roles/magma/orc8r/templates/orc8r-values-1.4.yaml.j2
@@ -7,12 +7,14 @@ controller:
   replicas: 2
   spec:
     database:
-      driver: mysql
-      sql_dialect: maria
-      db: {{ orc8r_db_user }}
+      driver: {{ orc8r_db_driver }}
+{% if orc8r_db_sql_dialect != "postgres" %}
+      sql_dialect: {{ orc8r_db_sql_dialect }}
+{% endif %}
+      db: {{ orc8r_db_name }}
       host: {{ orc8r_db_host }}
       pass: {{ orc8r_db_pass }}
-      port: 3306
+      port: {{ orc8r_db_port }}
       user: {{ orc8r_db_user }}
 imagePullSecrets:
 - name: artifactory
@@ -98,7 +100,7 @@ nginx:
     type: LoadBalancer
   spec:
     hostname: controller.{{ orc8r_domain }}
-    resolver: coredns.kube-system.svc.{{ dns_domain }} valid=10s
+    resolver: {{ kube_dns_resolver }} valid=10s
 nms:
   enabled: true
   imagePullSecrets:
@@ -110,9 +112,9 @@ nms:
       mysql_db: {{ orc8r_nms_db_name }}
       mysql_host: {{ orc8r_nms_db_host }}
       mysql_pass: {{ orc8r_nms_db_pass }}
-      mysql_port: 3306
+      mysql_port: {{ orc8r_nms_db_port }}
       mysql_user: {{ orc8r_nms_db_user }}
-      mysql_dialect: mariadb
+      mysql_dialect: {{ orc8r_nms_db_sql_dialect }}
     image:
       pullPolicy: IfNotPresent
       repository: {{ orc8r_image_repo | mandatory }}/magmalte


### PR DESCRIPTION


## Summary

* 1.5 reuses 1.4 template because it has minimal changes
* install orc8r-lte helm chart
* Allow postgres for nms backend
* Allow to disable deploying mariadb (in case externally provisioned postgres is used)

## Test Plan

Tested manually

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
