### PR TITLE
[NMS] Federation Network Dashboard

### DIFF
--- a/nms/app/packages/magmalte/app/components/FEGDashboardKPIs.js
+++ b/nms/app/packages/magmalte/app/components/FEGDashboardKPIs.js
@@ -1,0 +1,39 @@
+/**
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @flow strict-local
+ * @format
+ */
+
+import CardTitleRow from './layout/CardTitleRow';
+import FEGGatewayKPIs from './FEGGatewayKPIs';
+import ServAccessGatewayKPIs from './ServAccessGatewayKPIs';
+import Grid from '@material-ui/core/Grid';
+import React from 'react';
+
+import {GpsFixed} from '@material-ui/icons';
+
+export default function () {
+  return (
+    <>
+      <CardTitleRow icon={GpsFixed} label="Events" />
+      <Grid container item zeroMinWidth alignItems="center" spacing={4}>
+        <Grid item xs={12} lg={6}>
+          <FEGGatewayKPIs />
+        </Grid>
+        <Grid item xs={12} lg={6}>
+          <ServAccessGatewayKPIs />
+        </Grid>
+      </Grid>
+    </>
+  );
+}

--- a/nms/app/packages/magmalte/app/components/FEGGatewayKPIs.js
+++ b/nms/app/packages/magmalte/app/components/FEGGatewayKPIs.js
@@ -1,0 +1,69 @@
+/**
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @flow strict-local
+ * @format
+ */
+
+import type {DataRows} from './DataGrid';
+import type {federation_gateway} from '@fbcnms/magma-api';
+
+import CellWifiIcon from '@material-ui/icons/CellWifi';
+import DataGrid from './DataGrid';
+import FEGGatewayContext from './context/FEGGatewayContext';
+import React from 'react';
+import isGatewayHealthy from './GatewayUtils';
+
+import {useContext} from 'react';
+
+function gatewayStatus(gatewaySt: {[string]: federation_gateway}): [number, number] {
+  let upCount = 0;
+  let downCount = 0;
+  Object.keys(gatewaySt)
+    .map((k: string) => gatewaySt[k])
+    .filter((g: lte_gateway) => g.federation && g.id)
+    .map(function (gateway: federation_gateway) {
+      isGatewayHealthy(gateway) ? upCount++ : downCount++;
+    });
+  return [upCount, downCount];
+}
+
+export default function FEGGatewayKPIs() {
+  const gwCtx = useContext(FEGGatewayContext);
+  const [upCount, downCount] = gatewayStatus(gwCtx.state);
+
+  const data: DataRows[] = [
+    [
+      {
+        icon: CellWifiIcon,
+        value: 'Federation Gateway',
+      },
+      {
+        category: 'Severe Events',
+        value: 0,
+        tooltip: 'Severe Events reported by the gateway',
+      },
+      {
+        category: 'Connected',
+        value: upCount || 0,
+        tooltip: 'Number of gateways checked in within last 5 minutes',
+      },
+      {
+        category: 'Disconnected',
+        value: downCount || 0,
+        tooltip: 'Number of gateways not checked in within last 5 minutes',
+      },
+    ],
+  ];
+
+  return <DataGrid data={data} />;
+}

--- a/nms/app/packages/magmalte/app/components/ServAccessGatewayKPIs.js
+++ b/nms/app/packages/magmalte/app/components/ServAccessGatewayKPIs.js
@@ -1,0 +1,114 @@
+/**
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @flow strict-local
+ * @format
+ */
+
+import type {DataRows} from './DataGrid';
+import type {EnqueueSnackbarOptions,federation_gateway,feg_lte_network, network_id} from '@fbcnms/magma-api';
+
+import CellWifiIcon from '@material-ui/icons/CellWifi';
+import DataGrid from './DataGrid';
+import LoadingFiller from '@fbcnms/ui/components/LoadingFiller';
+import MagmaV1API from '@fbcnms/magma-api/client/WebClient';
+import React from 'react';
+import isGatewayHealthy from './GatewayUtils';
+import nullthrows from '@fbcnms/util/nullthrows';
+
+import {useContext, useEffect, useState} from 'react';
+import {useRouter} from '@fbcnms/ui/hooks';
+import {useEnqueueSnackbar} from '@fbcnms/ui/hooks/useSnackbar';
+
+export async function getServAccessGateways(networkId:network_id, enqueueSnackbar?: (msg: string, cfg: EnqueueSnackbarOptions,) => ?(string | number),): Promise<Array<feg_lte_network>> {
+    const servedAccessGateways = [];
+    //console.log("First")
+    const fegLteNetworkIdList =  await MagmaV1API.getFegLte();
+    //console.log("Reached here: " + fegLteNetworkIdList);
+    const requests = fegLteNetworkIdList.map(fegLteNetworkId => {
+        try {
+          return MagmaV1API.getFegLteByNetworkId({
+            fegLteNetworkId,
+          });
+        } catch (e) {
+            console.log("error: " + e);
+          enqueueSnackbar?.('failed fetching tier information for ' + fegLteNetworkId, {
+            variant: 'error',
+          });
+          return;
+        }
+      });
+
+    const fegLteNetworks = await Promise.all(requests);
+    fegLteNetworks.filter(Boolean).forEach(fegLteNetwork => {
+        if (fegLteNetwork?.federation?.feg_network_id == networkId) {
+            servedAccessGateways.push(fegLteNetwork);
+        }
+    });
+    return servedAccessGateways;
+}
+
+export default function ServAccessGatewayKPIs() {
+    const {match} = useRouter();
+    const networkId = nullthrows(match.params.networkId);
+    const [isLoading, setIsLoading] = useState(true);
+    const [servedAccessGateways, setServedAccessGateways] = useState([]);
+    const enqueueSnackbar = useEnqueueSnackbar();
+    useEffect(() => {
+        const fetchServicedAccessGateways = async () => {
+            try {
+                const servedAccessGateways = await getServAccessGateways(networkId);
+                setServedAccessGateways(servedAccessGateways);
+                console.log("Served access gateways: ");
+                servedAccessGateways.map(s => {
+                    console.log(s);
+                });
+                setIsLoading(false);
+            }
+            catch (e) {
+                console.log("Error: " + e);
+                enqueueSnackbar?.('failed fetching servicing access gateway information', {
+                variant: 'error',
+                });
+            }
+        }
+        fetchServicedAccessGateways();
+    }, [networkId]);
+    const data: DataRows[] = [
+        [
+          {
+            icon: CellWifiIcon,
+            value: 'Federation Gateway',
+          },
+          {
+            category: 'Severe Events',
+            value: 0,
+            tooltip: 'Severe Events reported by the gateway',
+          },
+          {
+            category: 'Connected',
+            value: servedAccessGateways.length || 0,
+            tooltip: 'Number of gateways checked in within last 5 minutes',
+          },
+          {
+            category: 'Disconnected',
+            value: 0,
+            tooltip: 'Number of gateways not checked in within last 5 minutes',
+          },
+        ],
+      ];
+    if (isLoading) {
+        return <LoadingFiller />
+    }
+    return <DataGrid data={data} />;
+
+}

--- a/nms/app/packages/magmalte/app/components/context/FEGGatewayContext.js
+++ b/nms/app/packages/magmalte/app/components/context/FEGGatewayContext.js
@@ -1,0 +1,33 @@
+/**
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @flow strict-local
+ * @format
+ */
+import type {
+    gateway_id,
+    federation_gateway,
+    mutable_federation_gateway,
+  } from '@fbcnms/magma-api';
+
+import React from 'react';
+
+export type GatewayContextType = {
+    state: {[string]: federation_gateway},
+    setState: (
+      key: gateway_id,
+      val?: mutable_federation_gateway,
+      newState?: {[string]: federation_gateway},
+    ) => Promise<void>,
+};
+
+export default React.createContext<GatewayContextType>({});

--- a/nms/app/packages/magmalte/app/components/feg/FEGContext.js
+++ b/nms/app/packages/magmalte/app/components/feg/FEGContext.js
@@ -1,0 +1,93 @@
+/**
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @flow strict-local
+ * @format
+ */
+import * as React from 'react';
+import FEGGatewayContext from '../context/FEGGatewayContext';
+import LoadingFiller from '@fbcnms/ui/components/LoadingFiller';
+import MagmaV1API from '@fbcnms/magma-api/client/WebClient';
+
+import type {federation_gateway, network_id, network_type} from '@fbcnms/magma-api';
+
+import {SetGatewayState} from '../../state/feg/EquipmentState';
+
+import {useContext, useEffect, useState} from 'react';
+import {useEnqueueSnackbar} from '@fbcnms/ui/hooks/useSnackbar';
+
+type Props = {
+    networkId: network_id,
+    networkType: network_type,
+    children: React.Node,
+};
+import {FEG} from '@fbcnms/types/network';
+export function FEGGatewayContextProvider(props: Props) {
+    const {networkId} = props;
+    const [fegGateways, setFegGateways] = useState<{[string]: federation_gateway}>({});
+    const [isLoading, setIsLoading] = useState(true);
+    const enqueueSnackbar = useEnqueueSnackbar();
+
+    useEffect(() => {
+        const fetchState = async () => {
+        try {
+            const fegGateways = await MagmaV1API.getFegByNetworkIdGateways({
+            networkId,
+            });
+            setFegGateways(fegGateways);
+        } catch (e) {
+            enqueueSnackbar?.('failed fetching gateway information', {
+            variant: 'error',
+            });
+        }
+        setIsLoading(false);
+        };
+        fetchState();
+    }, [networkId, enqueueSnackbar]);
+
+    if (isLoading) {
+        return <LoadingFiller />;
+    }
+
+    return (
+        <FEGGatewayContext.Provider
+        value={{
+            state: fegGateways,
+            setState: (key, value?, newState?) => {
+                return SetGatewayState({
+                    fegGateways,
+                    setFegGateways,
+                    networkId,
+                    key,
+                    value,
+                    newState,
+                });
+            },
+        }}>
+        {props.children}
+        </FEGGatewayContext.Provider>
+    );
+}
+
+export function FEGContextProvider(props: Props) {
+    const {networkId, networkType} = props;
+    const fegNetwork = networkType === FEG;
+    if (!fegNetwork) {
+      return props.children;
+    }
+
+    return (
+        <FEGGatewayContextProvider {...{networkId, networkType}}>
+            {props.children}
+        </FEGGatewayContextProvider>
+    );
+}

--- a/nms/app/packages/magmalte/app/components/feg/FEGSections.js
+++ b/nms/app/packages/magmalte/app/components/feg/FEGSections.js
@@ -30,12 +30,6 @@ import ShowChartIcon from '@material-ui/icons/ShowChart';
 export function getFEGSections(dashboardV2Enabled: boolean): SectionsConfigs {
   const sections = [
     {
-      path: 'dashboard',
-      label: 'Dashboard',
-      icon: <DashboardIcon />,
-      component: FEGDashboard,
-    },
-    {
       path: 'gateways',
       label: 'Gateways',
       icon: <CellWifiIcon />,
@@ -63,10 +57,20 @@ export function getFEGSections(dashboardV2Enabled: boolean): SectionsConfigs {
 
   if (dashboardV2Enabled) {
     // TODO add equipment, policy and subscriber section
+    sections.splice(0, 0, {
+      path: 'dashboard',
+      label: 'Dashboard',
+      icon: <DashboardIcon />,
+      component: FEGDashboard,
+    });
+    return [
+      'dashboard', //landing path
+      sections,
+    ]
   }
 
   return [
-    'dashboard', // landing path
+    'gateways', // landing path
     sections,
   ];
 }

--- a/nms/app/packages/magmalte/app/components/feg/FEGSections.js
+++ b/nms/app/packages/magmalte/app/components/feg/FEGSections.js
@@ -18,7 +18,9 @@ import type {SectionsConfigs} from '@fbcnms/magmalte/app/components/layout/Secti
 import AlarmIcon from '@material-ui/icons/Alarm';
 import AlarmsDashboard from '../../views/alarms/AlarmsDashboard';
 import CellWifiIcon from '@material-ui/icons/CellWifi';
+import DashboardIcon from '@material-ui/icons/Dashboard';
 import FEGConfigure from './FEGConfigure';
+import FEGDashboard from '../../views/dashboard/feg/FEGDashboard';
 import FEGGateways from './FEGGateways';
 import FEGMetrics from './FEGMetrics';
 import React from 'react';
@@ -27,6 +29,12 @@ import ShowChartIcon from '@material-ui/icons/ShowChart';
 
 export function getFEGSections(dashboardV2Enabled: boolean): SectionsConfigs {
   const sections = [
+    {
+      path: 'dashboard',
+      label: 'Dashboard',
+      icon: <DashboardIcon />,
+      component: FEGDashboard,
+    },
     {
       path: 'gateways',
       label: 'Gateways',
@@ -58,7 +66,7 @@ export function getFEGSections(dashboardV2Enabled: boolean): SectionsConfigs {
   }
 
   return [
-    'gateways', // landing path
+    'dashboard', // landing path
     sections,
   ];
 }

--- a/nms/app/packages/magmalte/app/components/main/Index.js
+++ b/nms/app/packages/magmalte/app/components/main/Index.js
@@ -16,6 +16,7 @@
 
 import MagmaV1API from '@fbcnms/magma-api/client/WebClient';
 
+import {FEGContextProvider} from '../feg/FEGContext';
 import {LteContextProvider} from '../lte/LteContext';
 import {coalesceNetworkType} from '@fbcnms/types/network';
 import type {NetworkType} from '@fbcnms/types/network';
@@ -83,6 +84,7 @@ export default function Index() {
   return (
     <NetworkContext.Provider value={{networkId, networkType}}>
       <LteContextProvider networkId={networkId} networkType={networkType}>
+        <FEGContextProvider networkId={networkId} networkType={networkType}>
         <div className={classes.root}>
           <AppSideBar
             mainItems={[<SectionLinks key={1} />, <VersionTooltip key={2} />]}
@@ -98,6 +100,7 @@ export default function Index() {
             <SectionRoutes />
           </AppContent>
         </div>
+        </FEGContextProvider>
       </LteContextProvider>
     </NetworkContext.Provider>
   );

--- a/nms/app/packages/magmalte/app/state/feg/EquipmentState.js
+++ b/nms/app/packages/magmalte/app/state/feg/EquipmentState.js
@@ -1,0 +1,64 @@
+/**
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @flow strict-local
+ * @format
+ */
+import type {
+    gateway_id,
+    federation_gateway,
+    mutable_federation_gateway,
+    network_id,
+  } from '@fbcnms/magma-api';
+
+import MagmaV1API from '@fbcnms/magma-api/client/WebClient';
+/**************************** Gateway State **********************************/
+type GatewayStateProps = {
+    networkId: network_id,
+    fegGateways: {[string]: federation_gateway},
+    setFegGateways: ({[string]: federation_gateway}) => void,
+    key: gateway_id,
+    value?: mutable_federation_gateway,
+    newState?: {[string]: federation_gateway},
+};
+
+export async function SetGatewayState(props: GatewayStateProps) {
+    const {networkId, fegGateways, setFegGateways, key, value, newState} = props;
+    if (newState) {
+        setFegGateways(newState);
+        return;
+    }
+    if (value != null) {
+        if (!(key in fegGateways)) {
+        await MagmaV1API.postFegByNetworkIdGateways({
+            networkId: networkId,
+            gateway: value,
+        });
+        setFegGateways({...fegGateways, [key]: value});
+        } else {
+        await MagmaV1API.putFegByNetworkIdGatewaysByGatewayId({
+            networkId: networkId,
+            gatewayId: key,
+            gateway: value,
+        });
+        setFegGateways({...fegGateways, [key]: value});
+        }
+    } else {
+        await MagmaV1API.deleteFegByNetworkIdGatewaysByGatewayId({
+        networkId: networkId,
+        gatewayId: key,
+        });
+        const newFegGateways = {...fegGateways};
+        delete newFegGateways[key];
+        setFegGateways(newFegGateways);
+    }
+}

--- a/nms/app/packages/magmalte/app/views/dashboard/feg/FEGDashboard.js
+++ b/nms/app/packages/magmalte/app/views/dashboard/feg/FEGDashboard.js
@@ -1,7 +1,20 @@
-// @flow
-/*[object Object]*/
+/*
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @flow strict-local
+ * @format
+ */
 import DashboardAlertTable from '../../../components/DashboardAlertTable';
-import DashboardKPIs from '../../../components/DashboardKPIs';
+import FEGDashboardKPIs from '../../../components/FEGDashboardKPIs';
 import EventAlertChart from '../../../components/EventAlertChart';
 import EventsTable from '../../events/EventsTable';
 import Grid from '@material-ui/core/Grid';
@@ -87,7 +100,7 @@ function FEGDashboard() {
         <Route
           path={relativePath('/network')}
           render={props => (
-            <LteNetworkDashboard {...props} startEnd={[startDate, endDate]} />
+            <FEGNetworkDashboard {...props} startEnd={[startDate, endDate]} />
           )}
         />
         <Redirect to={relativeUrl('/network')} />
@@ -95,7 +108,7 @@ function FEGDashboard() {
     </>
   );
 }
-function LteNetworkDashboard({startEnd}: {startEnd: [moment, moment]}) {
+function FEGNetworkDashboard({startEnd}: {startEnd: [moment, moment]}) {
   const classes = useStyles();
 
   return (
@@ -107,6 +120,9 @@ function LteNetworkDashboard({startEnd}: {startEnd: [moment, moment]}) {
 
         <Grid item xs={12}>
           <DashboardAlertTable />
+        </Grid>
+        <Grid item xs={12}>
+          <FEGDashboardKPIs />
         </Grid>
       </Grid>
     </div>

--- a/nms/app/packages/magmalte/app/views/dashboard/feg/FEGDashboard.js
+++ b/nms/app/packages/magmalte/app/views/dashboard/feg/FEGDashboard.js
@@ -1,0 +1,113 @@
+// @flow
+/*[object Object]*/
+import DashboardAlertTable from '../../../components/DashboardAlertTable';
+import DashboardKPIs from '../../../components/DashboardKPIs';
+import EventAlertChart from '../../../components/EventAlertChart';
+import EventsTable from '../../events/EventsTable';
+import Grid from '@material-ui/core/Grid';
+import React, {useState} from 'react';
+import Text from '../../../theme/design-system/Text';
+import TopBar from '../../../components/TopBar';
+import moment from 'moment';
+
+import {DateTimePicker} from '@material-ui/pickers';
+import {NetworkCheck} from '@material-ui/icons';
+import {Redirect, Route, Switch} from 'react-router-dom';
+import {colors} from '../../../theme/default';
+import {makeStyles} from '@material-ui/styles';
+import {useRouter} from '@fbcnms/ui/hooks';
+
+const useStyles = makeStyles(theme => ({
+  dashboardRoot: {
+    margin: theme.spacing(5),
+  },
+  dateTimeText: {
+    color: colors.primary.selago,
+  },
+}));
+
+function FEGDashboard() {
+  const classes = useStyles();
+  const {relativePath, relativeUrl} = useRouter();
+
+  // datetime picker
+  const [startDate, setStartDate] = useState(moment().subtract(3, 'days'));
+  const [endDate, setEndDate] = useState(moment());
+
+  return (
+    <>
+      <TopBar
+        key="dashboard"
+        header="Federated Network Dashboard"
+        tabs={[
+          {
+            label: 'Network',
+            to: '/network',
+            icon: NetworkCheck,
+            filters: (
+              <Grid
+                container
+                justify="flex-end"
+                alignItems="center"
+                spacing={2}>
+                <Grid item>
+                  <Text variant="body3" className={classes.dateTimeText}>
+                    Filter By Date
+                  </Text>
+                </Grid>
+                <DateTimePicker
+                  autoOk
+                  variant="inline"
+                  inputVariant="outlined"
+                  maxDate={endDate}
+                  disableFuture
+                  value={startDate}
+                  onChange={setStartDate}
+                />
+                <Grid item>
+                  <Text variant="body3" className={classes.dateTimeText}>
+                    to
+                  </Text>
+                </Grid>
+                <DateTimePicker
+                  autoOk
+                  variant="inline"
+                  inputVariant="outlined"
+                  disableFuture
+                  value={endDate}
+                  onChange={setEndDate}
+                />
+              </Grid>
+            ),
+          },
+        ]}
+      />
+
+      <Switch>
+        <Route
+          path={relativePath('/network')}
+          render={props => (
+            <LteNetworkDashboard {...props} startEnd={[startDate, endDate]} />
+          )}
+        />
+        <Redirect to={relativeUrl('/network')} />
+      </Switch>
+    </>
+  );
+}
+function LteNetworkDashboard({startEnd}: {startEnd: [moment, moment]}) {
+  const classes = useStyles();
+
+  return (
+    <div className={classes.dashboardRoot}>
+      <Grid container spacing={4}>
+        <Grid item xs={12}>
+          <EventAlertChart startEnd={startEnd} />
+        </Grid>
+
+
+      </Grid>
+    </div>
+  );
+}
+export default FEGDashboard;

--- a/nms/app/packages/magmalte/app/views/dashboard/feg/FEGDashboard.js
+++ b/nms/app/packages/magmalte/app/views/dashboard/feg/FEGDashboard.js
@@ -105,7 +105,9 @@ function LteNetworkDashboard({startEnd}: {startEnd: [moment, moment]}) {
           <EventAlertChart startEnd={startEnd} />
         </Grid>
 
-
+        <Grid item xs={12}>
+          <DashboardAlertTable />
+        </Grid>
       </Grid>
     </div>
   );


### PR DESCRIPTION
<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary

The federation network dashboard currently supports Alert & Events Chart, Alert Table, and Dashboard KPI. The Alert & Events Chart and Alert table have nothing new and the previous components used to support the LTE Dashboard page was used directly. However, the Dashboard KPI uses new context provider which was specifically created for the federation network and hence would be tested. This draft pull request is made for helping to understand why one of the api endpoint is working.
## Test Plan
Since this is a draft pull request, no new test was added. However, new tests would be added to test the new Dashboard KPIs when the pull request is ready.


