### PR TITLE
[docker] change patches path after core superbuild

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -284,7 +284,7 @@ RUN /tmp/third_party/build/bin/libfluid_build.sh && \
      rm -rf /tmp/*
 
 ##### FreeDiameter
-COPY lte/gateway/c/oai/patches/ /tmp/
+COPY lte/gateway/c/core/oai/patches/ /tmp/
 RUN git clone https://github.com/OPENAIRINTERFACE/opencord.org.freeDiameter.git freediameter && \
     cd freediameter && \
     patch -p1 < /tmp/0001-opencoord.org.freeDiameter.patch && \


### PR DESCRIPTION
Signed-off-by: Waqar Ahmed Aqeel <waqeel@fb.com>

## Summary

Pull #7193 moves the `patches` directory from `lte/gateway/c/oai` to `lte/gateway/c/core/oai`. This updates the `.devcontainer/Dockerfile` to reflect the change.

## Test Plan

Rebuilt container.