### PR TITLE
[lte][agw] Revert "Modified code to remove GUTI state entries"

### DIFF
--- a/lte/gateway/c/core/oai/include/mme_app_ue_context.h
+++ b/lte/gateway/c/core/oai/include/mme_app_ue_context.h
@@ -617,9 +617,7 @@ int mme_app_send_s6a_update_location_req(
     struct ue_mm_context_s* const ue_context_pP);
 void mme_app_recover_timers_for_all_ues(void);
 
-void proc_new_attach_req(
-    mme_ue_context_t* const mme_ue_context,
-    struct ue_mm_context_s* ue_context_p);
+void proc_new_attach_req(struct ue_mm_context_s* ue_context_p);
 
 int eps_bearer_release(
     emm_context_t* emm_context_p, ebi_t ebi, pdn_cid_t* pid, int* bidx);

--- a/lte/gateway/c/core/oai/tasks/mme_app/mme_app_bearer.c
+++ b/lte/gateway/c/core/oai/tasks/mme_app/mme_app_bearer.c
@@ -920,7 +920,7 @@ void mme_app_handle_delete_session_rsp(
     if (ue_context_p->nb_active_pdn_contexts == 0) {
       nas_delete_all_emm_procedures(&ue_context_p->emm_context);
       free_esm_context_content(&ue_context_p->emm_context.esm_ctx);
-      proc_new_attach_req(&mme_app_desc_p->mme_ue_contexts, ue_context_p);
+      proc_new_attach_req(ue_context_p);
     }
     OAILOG_FUNC_OUT(LOG_MME_APP);
   }

--- a/lte/gateway/c/core/oai/tasks/mme_app/mme_app_context.c
+++ b/lte/gateway/c/core/oai/tasks/mme_app/mme_app_context.c
@@ -703,7 +703,7 @@ int mme_insert_ue_context(
     // filled guti
     if ((0 != ue_context_p->emm_context._guti.gummei.mme_code) ||
         (0 != ue_context_p->emm_context._guti.gummei.mme_gid) ||
-        (INVALID_TMSI != ue_context_p->emm_context._guti.m_tmsi) ||
+        (0 != ue_context_p->emm_context._guti.m_tmsi) ||
         (0 != ue_context_p->emm_context._guti.gummei.plmn
                   .mcc_digit1) ||  // MCC 000 does not exist in ITU table
         (0 != ue_context_p->emm_context._guti.gummei.plmn.mcc_digit2) ||

--- a/lte/gateway/c/core/oai/tasks/mme_app/mme_app_detach.c
+++ b/lte/gateway/c/core/oai/tasks/mme_app/mme_app_detach.c
@@ -154,7 +154,8 @@ void mme_app_handle_detach_req(const mme_ue_s1ap_id_t ue_id) {
       "Handle Detach Req at MME app for ue-id: " MME_UE_S1AP_ID_FMT
       " with mme_s11_teid " TEID_FMT "\n",
       ue_id, ue_context_p->mme_teid_s11);
-  if (!ue_context_p->nb_active_pdn_contexts) {
+  if ((!ue_context_p->mme_teid_s11) &&
+      (!ue_context_p->nb_active_pdn_contexts)) {
     /* No Session.
      * If UE is already in idle state, skip asking eNB to release UE context and
      * just clean up locally.
@@ -168,7 +169,7 @@ void mme_app_handle_detach_req(const mme_ue_s1ap_id_t ue_id) {
     if (ue_context_p->emm_context.new_attach_info) {
       nas_delete_all_emm_procedures(&ue_context_p->emm_context);
       free_esm_context_content(&ue_context_p->emm_context.esm_ctx);
-      proc_new_attach_req(&mme_app_desc_p->mme_ue_contexts, ue_context_p);
+      proc_new_attach_req(ue_context_p);
       OAILOG_FUNC_OUT(LOG_MME_APP);
     }
     if (ECM_IDLE == ue_context_p->ecm_state) {

--- a/lte/gateway/c/core/oai/tasks/nas/emm/Attach.c
+++ b/lte/gateway/c/core/oai/tasks/nas/emm/Attach.c
@@ -2549,95 +2549,62 @@ static int emm_attach_update(
   OAILOG_FUNC_RETURN(LOG_NAS_EMM, RETURNok);
 }
 
-void proc_new_attach_req(
-    mme_ue_context_t* const mme_ue_context_p,
-    struct ue_mm_context_s* ue_context_p) {
+void proc_new_attach_req(struct ue_mm_context_s* ue_context_p) {
   OAILOG_FUNC_IN(LOG_NAS_EMM);
 
-  hashtable_rc_t hash_rc = HASH_TABLE_OK;
   OAILOG_INFO(
       LOG_NAS_EMM,
       "Process new Attach Request for ue_id " MME_UE_S1AP_ID_FMT "\n",
       ue_context_p->mme_ue_s1ap_id);
-  new_attach_info_t attach_info = {0};
-  memcpy(
-      &attach_info, ue_context_p->emm_context.new_attach_info,
-      sizeof(new_attach_info_t));
-  free_wrapper((void**) &ue_context_p->emm_context.new_attach_info);
+  new_attach_info_t* attach_info = ue_context_p->emm_context.new_attach_info;
+  if (!attach_info) {
+    OAILOG_ERROR_UE(
+        LOG_NAS_EMM, ue_context_p->emm_context._imsi64,
+        "New attach request within EMM context is null \n");
+    OAILOG_FUNC_OUT(LOG_NAS_EMM);
+  }
+
   /* The new Attach Request is received in s1ap initial ue message,
-   * So release previous Attach Request's contexts
-   */
-  if (attach_info.is_mm_ctx_new) {
-    if (ue_context_p->ecm_state == ECM_IDLE) {
-      mme_remove_ue_context(mme_ue_context_p, ue_context_p);
-    } else {
-      ue_context_p->ue_context_rel_cause = S1AP_NAS_DETACH;
-      /* In case of Ue initiated explicit IMSI Detach or Combined EPS/IMSI
-       *  detach Do not send UE Context Release Command to eNB before receiving
-       *  SGs IMSI Detach Ack from MSC/VLR
-       */
-      if (ue_context_p->sgs_context != NULL) {
-        if ((ue_context_p->sgs_detach_type ==
-             SGS_EXPLICIT_UE_INITIATED_IMSI_DETACH_FROM_NONEPS) ||
-            (ue_context_p->sgs_detach_type ==
-             SGS_COMBINED_UE_INITIATED_IMSI_DETACH_FROM_EPS_N_NONEPS)) {
-          OAILOG_FUNC_OUT(LOG_NAS_EMM);
-        } else if (
-            ue_context_p->sgs_context->ts9_timer.id ==
-            MME_APP_TIMER_INACTIVE_ID) {
-          /* Notify S1AP to send UE Context Release Command to eNB or free
-           * s1 context locally.
-           */
-          mme_app_itti_ue_context_release(
-              ue_context_p, ue_context_p->ue_context_rel_cause);
-        }
-      } else {
-        // Notify S1AP to send UE Context Release Command to eNB or free s1
-        // context locally.
+   * So release previous Attach Request's contexts */
+  if (attach_info->is_mm_ctx_new) {
+    ue_context_p->ue_context_rel_cause = S1AP_NAS_DETACH;
+    /* In case of Ue initiated explicit IMSI Detach or Combined EPS/IMSI detach
+       Do not send UE Context Release Command to eNB before receiving SGs IMSI
+       Detach Ack from MSC/VLR */
+    if (ue_context_p->sgs_context != NULL) {
+      if ((ue_context_p->sgs_detach_type ==
+           SGS_EXPLICIT_UE_INITIATED_IMSI_DETACH_FROM_NONEPS) ||
+          (ue_context_p->sgs_detach_type ==
+           SGS_COMBINED_UE_INITIATED_IMSI_DETACH_FROM_EPS_N_NONEPS)) {
+        OAILOG_FUNC_OUT(LOG_NAS_EMM);
+      } else if (
+          ue_context_p->sgs_context->ts9_timer.id ==
+          MME_APP_TIMER_INACTIVE_ID) {
+        /* Notify S1AP to send UE Context Release Command to eNB or free
+         * s1 context locally.
+         */
         mme_app_itti_ue_context_release(
             ue_context_p, ue_context_p->ue_context_rel_cause);
       }
-      ue_context_p->ue_context_rel_cause = S1AP_INVALID_CAUSE;
+    } else {
+      // Notify S1AP to send UE Context Release Command to eNB or free s1
+      // context locally.
+      mme_app_itti_ue_context_release(
+          ue_context_p, ue_context_p->ue_context_rel_cause);
     }
-  } else {
-    uint64_t mme_ue_s1ap_id64 = 0;
-
-    hash_rc = obj_hashtable_uint64_ts_get(
-        mme_ue_context_p->guti_ue_context_htbl,
-        (const void*) &ue_context_p->emm_context._guti, sizeof(guti_t),
-        &mme_ue_s1ap_id64);
-
-    if (HASH_TABLE_OK == hash_rc) {
-      // While processing new attach req, remove GUTI from hashtable
-      if ((ue_context_p->emm_context._guti.gummei.mme_code) ||
-          (ue_context_p->emm_context._guti.gummei.mme_gid) ||
-          (ue_context_p->emm_context._guti.m_tmsi) ||
-          (ue_context_p->emm_context._guti.gummei.plmn.mcc_digit1) ||
-          (ue_context_p->emm_context._guti.gummei.plmn.mcc_digit2) ||
-          (ue_context_p->emm_context._guti.gummei.plmn.mcc_digit3)) {
-        hash_rc = obj_hashtable_uint64_ts_remove(
-            mme_ue_context_p->guti_ue_context_htbl,
-            (const void* const) & ue_context_p->emm_context._guti,
-            sizeof(ue_context_p->emm_context._guti));
-        if (HASH_TABLE_OK != hash_rc)
-          OAILOG_ERROR_UE(
-              LOG_MME_APP, ue_context_p->emm_context._imsi64,
-              "UE Context not found for GUTI " GUTI_FMT " \n",
-              GUTI_ARG(&(ue_context_p->emm_context._guti)));
-      }
-    }
+    ue_context_p->ue_context_rel_cause = S1AP_INVALID_CAUSE;
   }
-
   /* Proceed with new attach request */
   ue_mm_context_t* ue_mm_context =
-      mme_ue_context_exists_mme_ue_s1ap_id(attach_info.mme_ue_s1ap_id);
+      mme_ue_context_exists_mme_ue_s1ap_id(attach_info->mme_ue_s1ap_id);
   emm_context_t* new_emm_ctx = &ue_mm_context->emm_context;
   bdestroy(new_emm_ctx->esm_msg);
   emm_init_context(new_emm_ctx, true);
 
   new_emm_ctx->num_attach_request++;
-  new_emm_ctx->attach_type            = attach_info.ies->type;
-  new_emm_ctx->additional_update_type = attach_info.ies->additional_update_type;
+  new_emm_ctx->attach_type = attach_info->ies->type;
+  new_emm_ctx->additional_update_type =
+      attach_info->ies->additional_update_type;
   OAILOG_NOTICE(
       LOG_NAS_EMM,
       "EMM-PROC  - Create EMM context ue_id = " MME_UE_S1AP_ID_FMT "\n",
@@ -2645,18 +2612,19 @@ void proc_new_attach_req(
   new_emm_ctx->is_dynamic = true;
   new_emm_ctx->emm_cause  = EMM_CAUSE_SUCCESS;
   // Store Voice Domain pref IE to be sent to MME APP
-  if (attach_info.ies->voicedomainpreferenceandueusagesetting) {
+  if (attach_info->ies->voicedomainpreferenceandueusagesetting) {
     memcpy(
         &new_emm_ctx->volte_params.voice_domain_preference_and_ue_usage_setting,
-        attach_info.ies->voicedomainpreferenceandueusagesetting,
+        attach_info->ies->voicedomainpreferenceandueusagesetting,
         sizeof(voice_domain_preference_and_ue_usage_setting_t));
     new_emm_ctx->volte_params.presencemask |=
         VOICE_DOMAIN_PREF_UE_USAGE_SETTING;
   }
   if (!is_nas_specific_procedure_attach_running(&ue_mm_context->emm_context)) {
-    emm_proc_create_procedure_attach_request(ue_mm_context, attach_info.ies);
+    emm_proc_create_procedure_attach_request(ue_mm_context, attach_info->ies);
   }
   emm_attach_run_procedure(&ue_mm_context->emm_context);
+  free_wrapper((void**) &ue_context_p->emm_context.new_attach_info);
   OAILOG_FUNC_OUT(LOG_NAS_EMM);
 }
 

--- a/lte/gateway/c/core/oai/tasks/nas/emm/ServiceRequestHdl.c
+++ b/lte/gateway/c/core/oai/tasks/nas/emm/ServiceRequestHdl.c
@@ -120,6 +120,12 @@ static int emm_service_reject(mme_ue_s1ap_id_t ue_id, uint8_t emm_cause)
   }
   rc = emm_sap_send(&emm_sap);
 
+  // Release EMM context
+  if (emm_ctx) {
+    if (emm_ctx->is_dynamic) {
+      _clear_emm_ctxt(emm_ctx);
+    }
+  }
   OAILOG_FUNC_RETURN(LOG_NAS_EMM, rc);
 }
 

--- a/lte/gateway/c/core/oai/tasks/nas/emm/TrackingAreaUpdate.c
+++ b/lte/gateway/c/core/oai/tasks/nas/emm/TrackingAreaUpdate.c
@@ -546,6 +546,13 @@ static int emm_tracking_area_update_reject(
   rc = emm_sap_send(&emm_sap);
   increment_counter("tracking_area_update", 1, 1, "action", "tau_reject_sent");
 
+  // Release EMM context
+  if (emm_context) {
+    if (emm_context->is_dynamic) {
+      _clear_emm_ctxt(emm_context);
+    }
+  }
+
   OAILOG_FUNC_RETURN(LOG_NAS_EMM, rc);
 }
 


### PR DESCRIPTION
Reverts magma/magma#7322

noticed that running:
`make integ_test TESTS=s1aptests/test_attach_standalone_act_dflt_ber_ctxt_rej.py`

leaves dirty ovs state:
```
vagrant@magma-dev-focal:~/magma/lte/gateway$ sudo ovs-ofctl dump-flows gtp_br0 | grep "table=0"
 cookie=0x0, duration=140.486s, table=0, n_packets=8, n_bytes=560, idle_age=730, priority=10,in_port=15578 actions=resubmit(,201)
 cookie=0x0, duration=30.606s, table=0, n_packets=0, n_bytes=0, idle_age=30, priority=10,tun_id=0xd,in_port=3 actions=mod_dl_src:02:00:00:00:00:01,mod_dl_dst:ff:ff:ff:ff:ff:ff,load:0xd->NXM_NX_REG9[],load:0x7594587a00d->OXM_OF_METADATA[],resubmit(,1)
 cookie=0x0, duration=30.606s, table=0, n_packets=0, n_bytes=0, idle_age=30, priority=10,ip,in_port=LOCAL,nw_dst=192.168.128.12 actions=load:0xa000128->NXM_NX_TUN_ID[],load:0xc0a83c8d->NXM_NX_TUN_IPV4_DST[],load:0x3->NXM_NX_REG8[],load:0xd->NXM_NX_REG9[],mod_dl_dst:ff:ff:ff:ff:ff:ff,load:0x7594587a00d->OXM_OF_METADATA[],resubmit(,1)
 cookie=0x0, duration=30.606s, table=0, n_packets=0, n_bytes=0, idle_age=30, priority=10,ip,in_port=15577,nw_dst=192.168.128.12 actions=load:0xa000128->NXM_NX_TUN_ID[],load:0xc0a83c8d->NXM_NX_TUN_IPV4_DST[],load:0x3->NXM_NX_REG8[],load:0xd->NXM_NX_REG9[],mod_dl_dst:ff:ff:ff:ff:ff:ff,load:0x7594587a00d->OXM_OF_METADATA[],resubmit(,1)
 cookie=0x0, duration=30.606s, table=0, n_packets=0, n_bytes=0, idle_age=30, priority=10,arp,in_port=LOCAL,arp_tpa=192.168.128.12 actions=load:0x7594587a00d->OXM_OF_METADATA[],resubmit(,1)
 cookie=0x0, duration=30.606s, table=0, n_packets=0, n_bytes=0, idle_age=30, priority=10,arp,in_port=15577,arp_tpa=192.168.128.12 actions=load:0x7594587a00d->OXM_OF_METADATA[],resubmit(,1)
 cookie=0x0, duration=140.486s, table=0, n_packets=1142, n_bytes=14852, idle_age=9, priority=0 actions=resubmit(,1)
```

and on mme.log:
```
000495 Tue Jun 08 20:59:31 2021 7F10923ED700 INFO  SPGW-A tasks/sgw/sgw_handlers.c        :1059   [1010000000001] Handle delete session request for sgw_s11_teid 0x62C6BCF3
000496 Tue Jun 08 20:59:31 2021 7F10923ED700 WARNI GTPv1- tasks/gtpv1-u/gtp_tunnel_openflo:0190    zero enb IP address not supported
000497 Tue Jun 08 20:59:31 2021 7F1092BEE700 INFO  GTPv1- lib/openflow/controller/PagingAp:0148    Deleted paging flow rule for UE IP 192.168.128.13
```