### PR TITLE
Fix metrics collection chunks

### DIFF
--- a/orc8r/gateway/python/magma/magmad/main.py
+++ b/orc8r/gateway/python/magma/magmad/main.py
@@ -92,7 +92,9 @@ def main():
     grpc_msg_size = metrics_config.get('max_grpc_msg_size_mb', 4)
     metrics_post_processor_fn = metrics_config.get('post_processing_fn')
 
-    metric_scrape_targets = [ScrapeTarget(t['url'], t['name'], t['interval']) for t in metrics_config.get('metric_scrape_targets', [])]
+    metric_scrape_targets = [ScrapeTarget(t['url'], t['name'], t['interval'])
+                             for t in
+                             metrics_config.get('metric_scrape_targets', [])]
 
     # Create local metrics collector
     metrics_collector = MetricsCollector(
@@ -285,7 +287,7 @@ def _get_upgrader_impl(service):
         factory_clsname,
     )
     factory_impl = FactoryClass()
-    assert isinstance(factory_impl, UpgraderFactory),\
+    assert isinstance(factory_impl, UpgraderFactory), \
         'upgrader_factory must be a subclass of UpgraderFactory'
 
     return factory_impl.create_upgrader(service, service.loop)

--- a/orc8r/gateway/python/magma/magmad/main.py
+++ b/orc8r/gateway/python/magma/magmad/main.py
@@ -92,13 +92,7 @@ def main():
     grpc_msg_size = metrics_config.get('max_grpc_msg_size_mb', 4)
     metrics_post_processor_fn = metrics_config.get('post_processing_fn')
 
-    metric_scrape_targets = map(
-        lambda x: ScrapeTarget(
-            x['url'], x['name'],
-            x['interval'],
-        ),
-        metrics_config.get('metric_scrape_targets', []),
-    )
+    metric_scrape_targets = [ScrapeTarget(t['url'], t['name'], t['interval']) for t in metrics_config.get('metric_scrape_targets', [])]
 
     # Create local metrics collector
     metrics_collector = MetricsCollector(

--- a/orc8r/gateway/python/magma/magmad/main.py
+++ b/orc8r/gateway/python/magma/magmad/main.py
@@ -287,8 +287,9 @@ def _get_upgrader_impl(service):
         factory_clsname,
     )
     factory_impl = FactoryClass()
-    assert isinstance(factory_impl, UpgraderFactory), \
-        'upgrader_factory must be a subclass of UpgraderFactory'
+    assert isinstance(factory_impl, UpgraderFactory), ('upgrader_factory '
+                                                       'must be a subclass '
+                                                       'of UpgraderFactory')
 
     return factory_impl.create_upgrader(service, service.loop)
 

--- a/orc8r/gateway/python/magma/magmad/metrics_collector.py
+++ b/orc8r/gateway/python/magma/magmad/metrics_collector.py
@@ -13,9 +13,8 @@ limitations under the License.
 import asyncio
 import calendar
 import logging
-import math
 import time
-from typing import Callable, Dict, List, NamedTuple, Optional
+from typing import Callable, Dict, List, NamedTuple, Optional, Union
 
 import metrics_pb2
 import prometheus_client.core
@@ -50,7 +49,7 @@ class MetricsCollector(object):
         collect_interval: int,
         sync_interval: int,
         grpc_timeout: int,
-        grpc_max_msg_size_mb: int,
+        grpc_max_msg_size_mb: Union[int, float],
         loop: Optional[asyncio.AbstractEventLoop] = None,
         post_processing_fn: Optional[Callable] = None,
         scrape_targets: [ScrapeTarget] = None,

--- a/orc8r/gateway/python/magma/magmad/metrics_collector.py
+++ b/orc8r/gateway/python/magma/magmad/metrics_collector.py
@@ -217,18 +217,13 @@ class MetricsCollector(object):
         )
 
     def _chunk_samples(self, samples):
-        # Add 1kiB fpr gRPC overhead
-        sample_size_bytes = sum(s.ByteSize() for s in samples) + 1000
-
-        buckets = math.ceil(
-            sample_size_bytes / self.grpc_max_msg_size_bytes,
-        )
-        chunk_size_bytes = sample_size_bytes // buckets
+        # Add 1kiB for gRPC overhead
+        max_msg_bytes = self.grpc_max_msg_size_bytes - 1000
 
         chunked_samples = []
         chunked_samples_size = 0
         for s in samples:
-            if chunked_samples_size + s.ByteSize() <= chunk_size_bytes:
+            if chunked_samples_size + s.ByteSize() <= max_msg_bytes:
                 chunked_samples.append(s)
                 chunked_samples_size += s.ByteSize()
             else:


### PR DESCRIPTION
<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->
- The current collection of metrics samples is based on splitting chunks by an even number of buckets, however this can lead to a `message larger than gRPC max allowed size` since the splitting does not take into account the size of each chunk.
- This change updates the chunking of samples to do the splitting based on size of each bucket, this way we ensure there is not a sent message that is larger than the allowed maximum.

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->
- Used local script to generate metrics on the AGW so they can be scraped by prometheus, provided by @karthiksubraveti 
- Before (one chunk with size 417 bytes and the second with 8093664 bytes):
```
Jun 08 23:35:12 magma-dev-focal magmad[282473]: INFO:root:Preparing chunk 0
Jun 08 23:35:12 magma-dev-focal magmad[282473]: INFO:root:Metric container size: 417
Jun 08 23:35:12 magma-dev-focal magmad[282473]: INFO:root:Preparing chunk 1
Jun 08 23:35:12 magma-dev-focal magmad[282473]: INFO:root:Metric container size: 8093664
Jun 08 23:35:13 magma-dev-focal magmad[282473]: ERROR:root:Prometheus Target Metrics upload error! [StatusCode.RESOURCE_EXHAUSTED] Sent message larger than max (8093664 vs. 4194304)
```
- After:
```
Jun 08 23:24:26 magma-dev-focal magmad[279947]: INFO:root:Preparing chunk 0
Jun 08 23:24:26 magma-dev-focal magmad[279947]: INFO:root:Metric container size: 2698432
Jun 08 23:24:26 magma-dev-focal magmad[279947]: INFO:root:Submitting chunk num 1 with size 2697801 bytes
Jun 08 23:24:26 magma-dev-focal magmad[279947]: INFO:root:Preparing chunk 1
Jun 08 23:24:26 magma-dev-focal magmad[279947]: INFO:root:Metric container size: 2697844
Jun 08 23:24:27 magma-dev-focal magmad[279947]: INFO:root:Submitting chunk num 2 with size 2697800 bytes
Jun 08 23:24:27 magma-dev-focal magmad[279947]: INFO:root:Preparing chunk 2
Jun 08 23:24:27 magma-dev-focal magmad[279947]: INFO:root:Metric container size: 2697843
Jun 08 23:24:27 magma-dev-focal magmad[279947]: INFO:root:Submitting final chunk  with size 2697800 bytes
```

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
