### PR TITLE
[lte][agw] dp_probe_cli add ingress, egress stats

### DIFF
--- a/docs/readmes/lte/debug_dp_probe.md
+++ b/docs/readmes/lte/debug_dp_probe.md
@@ -12,28 +12,32 @@ The datapath probe CLI helps an operator to probe the Datapath to the UE.
 
 On your GW host, run the following command
 
-```$ dp_probe_cli.py -i <IMSI> --direction <DL/UL> list_rules```
+```$ dp_probe_cli.py -i <IMSI> --direction <DL/UL> <list_rules/stats>```
 
 For example:
 ```sh
-$ dp_probe_cli.py -i 1010000051013 --direction DL
-IMSI: 1010000051013, IP: 192.168.128.13
-Running: sudo ovs-appctl ofproto/trace gtp_br0 tcp,in_port=local,ip_dst=192.168.128.13,ip_src=8.8.8.8,tcp_src=80,tcp_dst=3372
-Datapath Actions: set(tunnel(tun_id=0x1000008,dst=10.0.2.241,ttl=64,tp_dst=2152,flags(df|key))),pop_eth,2
-Downlink rules: allowlist_sid-IMSI1010000051013-magma.ipv4
+dp_probe_cli.py -i 001010000000004 --direction DL
+IMSI: 001010000000004, IP: 192.168.128.15
+LOCAL: n_packets=333, n_bytes=21998
+mtr0: n_packets=0, n_bytes=0
+Running: sudo ovs-appctl ofproto/trace gtp_br0 tcp,in_port=local,ip_dst=192.168.128.15,ip_src=8.8.8.8,tcp_src=80,tcp_dst=3372
+Datapath Actions: set(tunnel(tun_id=0xa000428,dst=192.168.60.141,ttl=64,tp_dst=2152,flags(df|key))),pop_eth,set(skb_mark(0x11)),2
+Downlink rules: allowlist_sid-IMSI001010000000004-magma.ipv4
 ```
 
 ```sh
-dp_probe_cli.py -i 1010000051013 --direction UL
-IMSI: 1010000051013, IP: 192.168.128.13
-Running: sudo ovs-appctl ofproto/trace gtp_br0 tcp,in_port=4,tun_id=0x2,ip_dst=8.8.8.8,ip_src=192.168.128.13,tcp_src=3372,tcp_dst=80
-Datapath Actions: set(eth(src=02:00:00:00:00:01,dst=92:9d:a2:1f:ea:44)),1
-Uplink rules: allowlist_sid-IMSI1010000051013-magma.ipv4
+dp_probe_cli.py -i 001010000000004 --direction UL
+IMSI: 001010000000004, IP: 192.168.128.15
+UL stats: n_packets=1512, n_bytes=942831
+Running: sudo ovs-appctl ofproto/trace gtp_br0 tcp,in_port=3,tun_id=0x5c6,ip_dst=8.8.8.8,ip_src=192.168.128.15,tcp_src=3372,tcp_dst=80
+Datapath Actions: set(eth(src=02:00:00:00:00:01,dst=da:de:f4:73:44:41)),set(skb_mark(0xf)),1
+Uplink rules: allowlist_sid-IMSI001010000000004-magma.ipv4
 ```
 
 You can also supply the followin options
 ```
 # list_rules
+# stats
 # -I <External IP Address>
 # -P <External Port>
 # -UP <UE Port>
@@ -41,17 +45,25 @@ You can also supply the followin options
 ```
 
 ```sh
-dp_probe_cli.py -i 1010000051013 --direction UL -p tcp -I 4.2.2.2 -P 8080 -UP 3172
-IMSI: 1010000051013, IP: 192.168.128.13
-Running: sudo ovs-appctl ofproto/trace gtp_br0 tcp,in_port=4,tun_id=0x2,ip_dst=4.2.2.2,ip_src=192.168.128.13,tcp_src=3172,tcp_dst=8080
-Datapath Actions: set(eth(src=02:00:00:00:00:01,dst=92:9d:a2:1f:ea:44)),1
-Uplink rules: allowlist_sid-IMSI1010000051013-magma.ipv4
+dp_probe_cli.py -i 001010000000004  --direction UL -p tcp -I 4.2.2.2 -P 8080 -UP 3172
+IMSI: 001010000000004, IP: 192.168.128.15
+UL stats: n_packets=312, n_bytes=189243
+Running: sudo ovs-appctl ofproto/trace gtp_br0 tcp,in_port=3,tun_id=0x5e6,ip_dst=4.2.2.2,ip_src=192.168.128.15,tcp_src=3172,tcp_dst=8080
+Datapath Actions: set(eth(src=02:00:00:00:00:01,dst=da:de:f4:73:44:41)),set(skb_mark(0xf)),1
+Uplink rules: allowlist_sid-IMSI001010000000004-magma.ipv4
 ```
 
 ```sh
 dp_probe_cli.py -i 1010000051013 --direction UL list_rules
 IMSI: 1010000051013, IP: 192.168.128.13
 Uplink rules: allowlist_sid-IMSI1010000051013-magma.ipv4
+```
+
+```sh
+dp_probe_cli.py -i 001010000000004 -d DL stats
+IMSI: 001010000000004, IP: 192.168.128.15
+LOCAL: n_packets=1100, n_bytes=72632
+mtr0: n_packets=0, n_bytes=0
 ```
 
 ## What is this command doing?
@@ -63,6 +75,8 @@ This command is a wrapper around *ovs-appctl ofproto/trace* which simulates the 
 Based on the *IMSI* supplied to this command
 - If the UE is connected it prints:
     - The *IP Address* of the UE and the Datapath Actions based on the ovs-appctl ofproto/trace
+    - Ingress or egress stats obtained from ```ovs-ofctl dump-flows gtp_br0 table=0```
     - The enforced uplink or downlink rules in pipelined obtained from the script ```pipelined_cli.py enforcement display_flows```
     - If the parameter `list_rules` was set, only the enforced rules in pipelined will be shown
+    - If the parameter `stats` was set, only the downlink or uplink stats will be shown
 - If the UE is not connected, the command will output ***UE is not connected***

--- a/lte/gateway/python/scripts/dp_probe_cli.py
+++ b/lte/gateway/python/scripts/dp_probe_cli.py
@@ -20,262 +20,336 @@ import subprocess
 from lte.protos.mconfig import mconfigs_pb2
 from magma.common.service import MagmaService
 
+class DpProbe:
+    """Class for dp_probe cli"""
 
-def create_parser():
-    """
-    Creates the argparse parser with all the arguments.
-    """
-    parser = argparse.ArgumentParser(
-        description="CLI wrapper around ovs-appctl ofproto/trace.\n"
-        "To display the Datapath actions of the supplied IMSI",
-        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
-    )
-    subparsers = parser.add_subparsers(dest="subcmd")
-    parser.add_argument(
-        "-i", "--imsi", required=True,
-        help="IMSI of the subscriber",
-    )
-    parser.add_argument(
-        "-d",
-        "--direction",
-        required=True,
-        choices=["DL", "UL"],
-        help="Direction - DL/UL",
-    )
-    parser.add_argument(
-        "-I",
-        "--ip",
-        nargs="?",
-        const="8.8.8.8",
-        default="8.8.8.8",
-        help="External IP",
-    )
-    parser.add_argument(
-        "-P",
-        "--port",
-        nargs="?",
-        const="80",
-        default="80",
-        help="External Port",
-    )
-    parser.add_argument(
-        "-UP",
-        "--ue_port",
-        nargs="?",
-        const="3372",
-        default="3372",
-        help="UE Port",
-    )
-    parser.add_argument(
-        "-p",
-        "--protocol",
-        choices=["tcp", "udp", "icmp"],
-        nargs="?",
-        const="tcp",
-        default="tcp",
-        help="Portocol (i.e. tcp, udp, icmp)",
-    )
-    parser_list_rules = subparsers.add_parser(
-        'list_rules', help="List uplink or downlink enforced rules",
-    )
-    parser_list_rules.set_defaults(func=get_enforced_rules)
+    def __init__(self) -> None:
+        """Initialize common ue network parameters and ovs commands"""
 
-    return parser
+        # Dump flow table zero
+        self.output_flow_table_zero = self.get_ovs_dump_flow_table_zero()
+
+        # Parse the args
+        parser = self.create_parser()
+        self.args = parser.parse_args()
+
+        # Get ue network parameters
+        self.mtr_port = self.get_mtr0_port()
+        self.ue_ip = self.find_ue_ip(self.args.imsi)
+
+        service = MagmaService("pipelined", mconfigs_pb2.PipelineD())
+        if service.mconfig.nat_enabled:
+            self.ingress_in_port = "local"
+        else:
+            self.ingress_in_port = "patch-up"
+
+        if self.args.direction == "UL":
+            self.ingress_tun_id = self.get_ingress_tunid(self.ue_ip, self.ingress_in_port)
+
+            if not self.ingress_tun_id:
+                print("Ingress Tunnel not Found")
+                exit(1)
+
+            data = self.get_egress_tunid_and_port(self.ue_ip, self.ingress_tun_id)
+            if  data:
+                self.egress_tun_id = data["tun_id"]
+                self.egress_in_port = data["in_port"]
+            else:
+                print("Egress Tunnel not Found")
+                exit(1)
+
+    def create_parser(self):
+        """
+        Creates the argparse parser with all the arguments.
+        """
+        parser = argparse.ArgumentParser(
+            description="CLI wrapper around ovs-appctl ofproto/trace.\n"
+            "To display the Datapath actions of the supplied IMSI",
+            formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+        )
+        subparsers = parser.add_subparsers(dest="subcmd")
+        parser.add_argument(
+            "-i", "--imsi", required=True,
+            help="IMSI of the subscriber",
+        )
+        parser.add_argument(
+            "-d",
+            "--direction",
+            required=True,
+            choices=["DL", "UL"],
+            help="Direction - DL/UL",
+        )
+        parser.add_argument(
+            "-I",
+            "--ip",
+            nargs="?",
+            const="8.8.8.8",
+            default="8.8.8.8",
+            help="External IP",
+        )
+        parser.add_argument(
+            "-P",
+            "--port",
+            nargs="?",
+            const="80",
+            default="80",
+            help="External Port",
+        )
+        parser.add_argument(
+            "-UP",
+            "--ue_port",
+            nargs="?",
+            const="3372",
+            default="3372",
+            help="UE Port",
+        )
+        parser.add_argument(
+            "-p",
+            "--protocol",
+            choices=["tcp", "udp", "icmp"],
+            nargs="?",
+            const="tcp",
+            default="tcp",
+            help="Portocol (i.e. tcp, udp, icmp)",
+        )
+        parser_list_rules = subparsers.add_parser(
+            'list_rules', help="List uplink or downlink enforced rules",
+        )
+        parser_list_rules.set_defaults(func=self.get_enforced_rules)
+        parser_get_stats = subparsers.add_parser(
+            'stats', help="Output uplink or downlink stats",
+        )
+        parser_get_stats.set_defaults(func=self.get_stats)
+        return parser
 
 
-def find_ue_ip(imsi: str):
-    """Find the UE IP address corresponding to the imsi"""
-    cmd = ["mobility_cli.py", "get_subscriber_table"]
-    output = subprocess.check_output(cmd)
-    output_str = str(output, "utf-8").strip()
-    pattern = "IMSI.*?" + imsi + \
-        ".*?([0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3})"
-    match = re.search(pattern, output_str)
-    if match:
-        return match.group(1)
-    return
+    def find_ue_ip(self,imsi: str):
+        """Find the UE IP address corresponding to the imsi"""
+        cmd = ["mobility_cli.py", "get_subscriber_table"]
+        output = subprocess.check_output(cmd)
+        output_str = str(output, "utf-8").strip()
+        pattern = "IMSI.*?" + imsi + \
+            ".*?([0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3})"
+        match = re.search(pattern, output_str)
+        if match:
+            return match.group(1)
+        return
 
 
-def output_datapath_actions(
-    imsi: str,
-    direction: str,
-    ue_ip: str,
-    external_ip: str,
-    external_port: str,
-    ue_port: str,
-    protocol: str,
-):
-    """
-    Returns the Output of Datapath Actions based as per the supplied UE IP
-    """
-    service = MagmaService("pipelined", mconfigs_pb2.PipelineD())
-    cmd = ["sudo", "ovs-appctl", "ofproto/trace", "gtp_br0"]
-    if service.mconfig.nat_enabled:
-        in_port = "local"
-    else:
-        in_port = "patch-up"
+    def output_datapath_actions(
+        self,
+        imsi: str,
+        direction: str,
+        ue_ip: str,
+        external_ip: str,
+        external_port: str,
+        ue_port: str,
+        protocol: str,
+    ):
+        """
+        Returns the Output of Datapath Actions based as per the supplied UE IP
+        """
 
-    if direction == "DL":
+        cmd = ["sudo", "ovs-appctl", "ofproto/trace", "gtp_br0"]
 
-        cmd_append = (
-            protocol
-            + ",in_port="
+        if direction == "DL":
+
+            cmd_append = (
+                protocol
+                + ",in_port="
+                + self.ingress_in_port
+                + ",ip_dst="
+                + ue_ip
+                + ",ip_src="
+                + external_ip
+            )
+
+            if protocol != "icmp":
+                cmd_append += (
+                    ","
+                    + protocol
+                    + "_src="
+                    + external_port
+                    + ","
+                    + protocol
+                    + "_dst="
+                    + ue_port
+                )
+
+            cmd.append(cmd_append)
+            self.get_ingress_stats(ue_ip)
+
+
+        elif direction == "UL":
+
+            cmd_append = (
+                protocol
+                + ",in_port="
+                + self.egress_in_port
+                + ",tun_id="
+                + self.egress_tun_id
+                + ",ip_dst="
+                + external_ip
+                + ",ip_src="
+                + ue_ip
+            )
+
+            if protocol != "icmp":
+                cmd_append += (
+                    ","
+                    + protocol
+                    + "_src="
+                    + ue_port
+                    + ","
+                    + protocol
+                    + "_dst="
+                    + external_port
+                )
+
+            cmd.append(cmd_append)
+            self.get_egress_stats(self.egress_tun_id)
+        else:
+            return
+
+        print("Running: " + " ".join(cmd))
+        output = subprocess.check_output(cmd)
+        output_str = str(output, "utf-8").strip()
+        pattern = "Datapath\sactions:(.*)"
+        match = re.search(pattern, output_str)
+        if match:
+            return match.group(1).strip()
+        else:
+            return
+
+
+    def get_ingress_tunid(self, ue_ip: str, in_port: str):
+        pattern = (
+            ".*?in_port="
             + in_port
-            + ",ip_dst="
+            + ",nw_dst="
             + ue_ip
-            + ",ip_src="
-            + external_ip
+            + ".*?load:(0x(?:[a-z]|[0-9]){1,})->OXM_OF_METADATA.*?"
         )
-
-        if protocol != "icmp":
-            cmd_append += (
-                ","
-                + protocol
-                + "_src="
-                + external_port
-                + ","
-                + protocol
-                + "_dst="
-                + ue_port
-            )
-
-        cmd.append(cmd_append)
-
-    elif direction == "UL":
-        ingress_tun_id = get_ingress_tunid(ue_ip, in_port)
-        if not ingress_tun_id:
-            print("Ingress Tunnel not Found")
-            exit(1)
-
-        data = get_egress_tunid_and_port(ue_ip, ingress_tun_id)
-        if not data:
-            print("Egress Tunnel not Found")
-            exit(1)
-
-        cmd_append = (
-            protocol
-            + ",in_port="
-            + data["in_port"]
-            + ",tun_id="
-            + data["tun_id"]
-            + ",ip_dst="
-            + external_ip
-            + ",ip_src="
-            + ue_ip
-        )
-
-        if protocol != "icmp":
-            cmd_append += (
-                ","
-                + protocol
-                + "_src="
-                + ue_port
-                + ","
-                + protocol
-                + "_dst="
-                + external_port
-            )
-
-        cmd.append(cmd_append)
-    else:
-        return
-
-    print("Running: " + " ".join(cmd))
-    output = subprocess.check_output(cmd)
-    output_str = str(output, "utf-8").strip()
-    pattern = "Datapath\sactions:(.*)"
-    match = re.search(pattern, output_str)
-    if match:
-        return match.group(1).strip()
-    else:
+        match = re.findall(pattern, self.output_flow_table_zero, re.IGNORECASE)
+        if match:
+            return match[0]
         return
 
 
-def get_ingress_tunid(ue_ip: str, in_port: str):
-    cmd = ["sudo", "ovs-ofctl", "dump-flows", "gtp_br0", "table=0"]
-    output = subprocess.check_output(cmd)
-    output = str(output, "utf-8").strip()
-    pattern = (
-        ".*?in_port="
-        + in_port
-        + ",nw_dst="
-        + ue_ip
-        + ".*?load:(0x(?:[a-z]|[0-9]){1,})->OXM_OF_METADATA.*?"
-    )
-    match = re.findall(pattern, output, re.IGNORECASE)
-    if match:
-        return match[0]
-    return
+    def get_egress_tunid_and_port(self, ue_ip: str, ingress_tun: str):
+        pattern = pattern = (
+            "tun_id=(0x(?:[a-z]|[0-9]){1,}),in_port=([a-z]|[0-9]).*?load:"
+            + ingress_tun
+            + "->OXM_OF_METADATA.*?\n"
+        )
+        match = re.findall(pattern, self.output_flow_table_zero)
+        if match:
+            return {"tun_id": match[0][0], "in_port": match[0][1]}
+        return
 
 
-def get_egress_tunid_and_port(ue_ip: str, ingress_tun: str):
-    cmd = ["sudo", "ovs-ofctl", "dump-flows", "gtp_br0", "table=0"]
-    output = subprocess.check_output(cmd)
-    output = str(output, "utf-8").strip()
-    pattern = pattern = (
-        "tun_id=(0x(?:[a-z]|[0-9]){1,}),in_port=([a-z]|[0-9]).*?load:"
-        + ingress_tun
-        + "->OXM_OF_METADATA.*?\n"
-    )
-    match = re.findall(pattern, output)
-    if match:
-        return {"tun_id": match[0][0], "in_port": match[0][1]}
-    return
+    def get_enforced_rules(self, args):
+        """Output enforced rules in pipelined using ue_ip obtained from args"""
+        cmd = ["sudo", "pipelined_cli.py", "enforcement", "display_flows"]
+        output = subprocess.check_output(cmd, stderr=subprocess.DEVNULL)
+        output = str(output, "utf-8").strip()
+
+        if args.direction == "DL":
+            pattern = ".*table=enforcement\(main_table\).*nw_dst=" + \
+                self.ue_ip + " actions=note:b\'(.*)\',load.*"
+            rules_dl = re.findall(pattern, output)
+            if len(rules_dl) > 0:
+                print("Downlink rules: " + '\n'.join(map(str, rules_dl)))
+            else:
+                print("No downlink rules found for UE")
+        elif args.direction == "UL":
+            pattern = ".*table=enforcement\(main_table\).*nw_src=" + \
+                self.ue_ip + " actions=note:b\'(.*)\',load.*"
+            rules_ul = re.findall(pattern, output)
+            if len(rules_ul) > 0:
+                print("Uplink rules: " + '\n'.join(map(str, rules_ul)))
+            else:
+                print("No uplink rules found for UE")
 
 
-def get_enforced_rules(args):
-    """Output enforced rules in pipelined using ue_ip obtained from args"""
-    cmd = ["sudo", "pipelined_cli.py", "enforcement", "display_flows"]
-    output = subprocess.check_output(cmd, stderr=subprocess.DEVNULL)
-    output = str(output, "utf-8").strip()
+    def get_stats(self, args):
+        """Output dowlink or uplink stats"""
 
-    if args.direction == "DL":
-        pattern = ".*table=enforcement\(main_table\).*nw_dst=" + \
-            args.ue_ip + " actions=note:b\'(.*)\',load.*"
-        rules_dl = re.findall(pattern, output)
-        if len(rules_dl) > 0:
-            print("Downlink rules: " + '\n'.join(map(str, rules_dl)))
-        else:
-            print("No downlink rules found for UE")
-    elif args.direction == "UL":
-        pattern = ".*table=enforcement\(main_table\).*nw_src=" + \
-            args.ue_ip + " actions=note:b\'(.*)\',load.*"
-        rules_ul = re.findall(pattern, output)
-        if len(rules_ul) > 0:
-            print("Uplink rules: " + '\n'.join(map(str, rules_ul)))
-        else:
-            print("No uplink rules found for UE")
+        if args.direction == "DL":
+            return self.get_ingress_stats(self.ue_ip)
+        elif args.direction == "UL":
+            return self.get_egress_stats(self.egress_tun_id)
+
+
+    def get_ingress_stats(self, ue_ip: str):
+        """Output ingress Downlink stats using ue_ip obtained from args"""
+
+        pattern_local = "(n_packets=[0-9]{1,}.*n_bytes=[0-9]{1,}).*in_port=LOCAL,nw_dst=" + ue_ip  +  ".*actions.*"
+        match_local = re.findall(pattern_local, self.output_flow_table_zero)
+
+        pattern_mtr0 =  "(n_packets=[0-9]{1,}.*n_bytes=[0-9]{1,}).*in_port="+self.mtr_port+",nw_dst=" + ue_ip  +  ".*actions.*"
+        match_mtr0 = re.findall(pattern_mtr0, self.output_flow_table_zero)
+
+        if match_local:
+            print("LOCAL: " + match_local[0])
+
+        if match_mtr0:
+            print("mtr0: " + match_mtr0[0])
+
+
+    def get_egress_stats(self, tun_id: str):
+        """Output egress Uplink stats using ue_ip obtained from args"""
+
+        pattern = "(n_packets=[0-9]{1,}.*n_bytes=[0-9]{1,}).*tun_id="+ tun_id +",in_port.*"
+        match = re.findall(pattern, self.output_flow_table_zero)
+        print("UL stats: " + match[0])
+
+
+    def get_mtr0_port(self):
+        """Output mtr0 port number"""
+        cmd = ["ovs-ofctl", "show", "gtp_br0"]
+        output = subprocess.check_output(cmd)
+        output = str(output, "utf-8").strip()
+        pattern = "([0-9]{1,})\(mtr0\)"
+        match_mtr0 = re.findall(pattern, output)
+        if match_mtr0:
+            return match_mtr0[0]
+
+
+    def get_ovs_dump_flow_table_zero(self):
+        """Output ovs dump flow table zero"""
+        cmd = ["sudo", "ovs-ofctl", "dump-flows", "gtp_br0", "table=0"]
+        output = subprocess.check_output(cmd)
+        output_str = str(output, "utf-8").strip()
+        return output_str
 
 
 def main():
-    parser = create_parser()
-    # Parse the args
-    args = parser.parse_args()
-    args.ue_ip = find_ue_ip(args.imsi)
-    if not args.ue_ip:
+    dp_probe = DpProbe()
+    if not dp_probe.ue_ip:
         print("UE is not connected")
         exit(1)
-    print("IMSI: " + args.imsi + ", IP: " + args.ue_ip)
+    print("IMSI: " + dp_probe.args.imsi + ", IP: " + dp_probe.ue_ip)
 
     # If there are subcomands, execute subcommands only
-    if args.subcmd:
-        args.func(args)
+    if dp_probe.args.subcmd:
+        dp_probe.args.func(dp_probe.args)
         exit(1)
 
-    dp_actions = output_datapath_actions(
-        args.imsi,
-        args.direction,
-        args.ue_ip,
-        args.ip,
-        args.port,
-        args.ue_port,
-        args.protocol,
+    dp_actions = dp_probe.output_datapath_actions(
+        dp_probe.args.imsi,
+        dp_probe.args.direction,
+        dp_probe.ue_ip,
+        dp_probe.args.ip,
+        dp_probe.args.port,
+        dp_probe.args.ue_port,
+        dp_probe.args.protocol,
     )
     if not dp_actions:
         print("Cannot find Datapath Actions for the UE")
 
     print("Datapath Actions: " + dp_actions)
-    get_enforced_rules(args)
+    dp_probe.get_enforced_rules(dp_probe.args)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Signed-off-by: Wally Rodriguez B <wallyrb@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary

- Create the class Dp_probe to initialize some attributes that are used several times in the code
- Create function get_ingress_stats that provide DL stats
- Create function get_egress_stats that provides UL stats
- Create function get_mtr0_port to get the mtr0 port use for CPE monitoring
- Create function get_ovs_dump_flow_table_zero that dumps the flow table zero, this is used several times in the code
- Update documentation for master


## Test Plan

- Tested with s1 ap integration tests

```
(python) vagrant@magma-dev:~/magma/lte/gateway$ dp_probe_cli.py -i 001010000000004 -d DL
IMSI: 001010000000004, IP: 192.168.128.15
LOCAL: n_packets=3, n_bytes=207
mtr0: n_packets=0, n_bytes=0
Running: sudo ovs-appctl ofproto/trace gtp_br0 tcp,in_port=local,ip_dst=192.168.128.15,ip_src=8.8.8.8,tcp_src=80,tcp_dst=3372
Datapath Actions: set(tunnel(tun_id=0xa000428,dst=192.168.60.141,ttl=64,tp_dst=2152,flags(df|key))),pop_eth,set(skb_mark(0x11)),2
Downlink rules: allowlist_sid-IMSI001010000000004-magma.ipv4
```

```
(python) vagrant@magma-dev:~/magma/lte/gateway$ dp_probe_cli.py -i 001010000000004 -d UL
IMSI: 001010000000004, IP: 192.168.128.15
UL stats: n_packets=1512, n_bytes=942831
Running: sudo ovs-appctl ofproto/trace gtp_br0 tcp,in_port=3,tun_id=0x5c6,ip_dst=8.8.8.8,ip_src=192.168.128.15,tcp_src=3372,tcp_dst=80
Datapath Actions: set(eth(src=02:00:00:00:00:01,dst=da:de:f4:73:44:41)),set(skb_mark(0xf)),1
Uplink rules: allowlist_sid-IMSI001010000000004-magma.ipv4
```

```
dp_probe_cli.py -i 001010000000004 -d DL stats
IMSI: 001010000000004, IP: 192.168.128.15
LOCAL: n_packets=1100, n_bytes=72632
mtr0: n_packets=0, n_bytes=0
```

![image](https://user-images.githubusercontent.com/37117037/122166016-e07bec00-ce2d-11eb-8d5a-35768d6d4985.png)
