### PR TITLE
[orc8r] remove usage of `$MAGMA_ROOT`

### DIFF
--- a/orc8r/cloud/go/tools/combine_swagger/combine/combine_test.go
+++ b/orc8r/cloud/go/tools/combine_swagger/combine/combine_test.go
@@ -34,7 +34,6 @@ var (
 	testdataDir    = "../testdata"
 	specsDir       = filepath.Join(testdataDir, "configs")
 	commonFilepath = filepath.Join(testdataDir, "common/common.yml")
-	outFilepath    = filepath.Join(testdataDir, "out.yml")
 	goldenFilepath = filepath.Join(testdataDir, "monolithic.yml.golden")
 )
 
@@ -45,9 +44,6 @@ var (
 //
 // go-swagger mixin: https://goswagger.io/usage/mixin.html
 func TestCombine(t *testing.T) {
-	cleanup()
-	defer cleanup()
-
 	nErrsFromCombine := 9
 
 	yamlCommon, yamlSpecs, err := combine.Load(commonFilepath, specsDir)
@@ -61,17 +57,16 @@ func TestCombine(t *testing.T) {
 	assert.True(t, ok)
 	assert.Len(t, merrs.Errors, nErrsFromCombine)
 
-	err = combine.Write(combined, outFilepath)
+	outFile, err := ioutil.TempFile(testdataDir, "out*.yml")
+	assert.NoError(t, err)
+	defer os.Remove(outFile.Name())
+
+	err = combine.Write(combined, outFile.Name())
 	assert.NoError(t, err)
 
 	expected := readFile(t, goldenFilepath)
-	actual := readFile(t, outFilepath)
+	actual := readFile(t, outFile.Name())
 	assert.Equal(t, expected, actual)
-}
-
-// cleanup cleans up created tmp files.
-func cleanup() {
-	_ = os.Remove(outFilepath)
 }
 
 // readFile returns the content of the passed filepath.

--- a/orc8r/cloud/go/tools/combine_swagger/combine/combine_test.go
+++ b/orc8r/cloud/go/tools/combine_swagger/combine/combine_test.go
@@ -57,6 +57,7 @@ func TestCombine(t *testing.T) {
 	assert.True(t, ok)
 	assert.Len(t, merrs.Errors, nErrsFromCombine)
 
+	// '*' is replaced by a random number to ensure uniqueness
 	outFile, err := ioutil.TempFile(testdataDir, "out*.yml")
 	assert.NoError(t, err)
 	defer os.Remove(outFile.Name())

--- a/orc8r/cloud/go/tools/combine_swagger/generate/generate.go
+++ b/orc8r/cloud/go/tools/combine_swagger/generate/generate.go
@@ -26,11 +26,11 @@ import (
 
 // GenerateStandaloneSpecs generates standalone specs for all Swagger specs in
 // a directory
-func GenerateStandaloneSpecs(specDir string) error {
+func GenerateStandaloneSpecs(specDir string, rootDir string) error {
 	outDir := filepath.Join(filepath.Dir(specDir), "standalone")
 	specPaths := getFilepaths(specDir)
 	for _, path := range specPaths {
-		specs, err := generate.ParseSwaggerDependencyTree(path, "../../")
+		specs, err := generate.ParseSwaggerDependencyTree(path, rootDir)
 		if err != nil {
 			return err
 		}

--- a/orc8r/cloud/go/tools/combine_swagger/generate/generate.go
+++ b/orc8r/cloud/go/tools/combine_swagger/generate/generate.go
@@ -28,6 +28,7 @@ import (
 // a directory
 func GenerateStandaloneSpecs(specDir string) error {
 	rootDir := os.Getenv("MAGMA_ROOT")
+	outDir := filepath.Join(filepath.Dir(specDir), "standalone")
 	specPaths := getFilepaths(specDir)
 	for _, path := range specPaths {
 		specs, err := generate.ParseSwaggerDependencyTree(path, rootDir)
@@ -35,8 +36,7 @@ func GenerateStandaloneSpecs(specDir string) error {
 			return err
 		}
 
-		specFile := filepath.Base(path)
-		outPath := filepath.Join(rootDir, "orc8r/cloud/swagger/specs/standalone", specFile)
+		outPath := filepath.Join(outDir, filepath.Base(path))
 		if err != nil {
 			return err
 		}

--- a/orc8r/cloud/go/tools/combine_swagger/generate/generate.go
+++ b/orc8r/cloud/go/tools/combine_swagger/generate/generate.go
@@ -27,11 +27,10 @@ import (
 // GenerateStandaloneSpecs generates standalone specs for all Swagger specs in
 // a directory
 func GenerateStandaloneSpecs(specDir string) error {
-	rootDir := os.Getenv("MAGMA_ROOT")
 	outDir := filepath.Join(filepath.Dir(specDir), "standalone")
 	specPaths := getFilepaths(specDir)
 	for _, path := range specPaths {
-		specs, err := generate.ParseSwaggerDependencyTree(path, rootDir)
+		specs, err := generate.ParseSwaggerDependencyTree(path, "../../")
 		if err != nil {
 			return err
 		}

--- a/orc8r/cloud/go/tools/combine_swagger/generate/generate_test.go
+++ b/orc8r/cloud/go/tools/combine_swagger/generate/generate_test.go
@@ -32,7 +32,7 @@ func Test_GenerateStandaloneSpec(t *testing.T) {
 	os.Remove(specTargetPath)
 	defer os.Remove(specTargetPath)
 
-	specs, err := swaggergen.ParseSwaggerDependencyTree(targetFilePath, "../../../../../../")
+	specs, err := swaggergen.ParseSwaggerDependencyTree(targetFilePath, "../testdata")
 	assert.NoError(t, err)
 
 	err = generate.GenerateSpec(targetFilePath, specs, specTargetPath)

--- a/orc8r/cloud/go/tools/combine_swagger/generate/generate_test.go
+++ b/orc8r/cloud/go/tools/combine_swagger/generate/generate_test.go
@@ -32,7 +32,7 @@ func Test_GenerateStandaloneSpec(t *testing.T) {
 	os.Remove(specTargetPath)
 	defer os.Remove(specTargetPath)
 
-	specs, err := swaggergen.ParseSwaggerDependencyTree(targetFilePath, os.Getenv("MAGMA_ROOT"))
+	specs, err := swaggergen.ParseSwaggerDependencyTree(targetFilePath, "../../../../../../")
 	assert.NoError(t, err)
 
 	err = generate.GenerateSpec(targetFilePath, specs, specTargetPath)

--- a/orc8r/cloud/go/tools/combine_swagger/main.go
+++ b/orc8r/cloud/go/tools/combine_swagger/main.go
@@ -27,6 +27,7 @@ package main
 import (
 	"flag"
 	"fmt"
+	"os"
 
 	"magma/orc8r/cloud/go/obsidian/swagger/spec"
 	"magma/orc8r/cloud/go/tools/combine_swagger/combine"
@@ -40,6 +41,7 @@ func main() {
 	commonFilepath := flag.String("common", "", "Common definitions filepath")
 	outFilepath := flag.String("out", "", "Output directory")
 	generateStandAloneSpec := flag.Bool("standalone", true, "Generate standalone specs")
+	rootDir := flag.String("root", os.Getenv("MAGMA_ROOT"), "Root path to resolve dependency and output directories based on")
 
 	flag.Parse()
 
@@ -67,7 +69,7 @@ func main() {
 	}
 
 	if *generateStandAloneSpec {
-		err := generate.GenerateStandaloneSpecs(*inDir)
+		err := generate.GenerateStandaloneSpecs(*inDir, *rootDir)
 		if err != nil {
 			glog.Fatalf("Error generating standalone Swagger specs %+v", err)
 		}

--- a/orc8r/cloud/go/tools/combine_swagger/main.go
+++ b/orc8r/cloud/go/tools/combine_swagger/main.go
@@ -41,7 +41,6 @@ func main() {
 	commonFilepath := flag.String("common", "", "Common definitions filepath")
 	outFilepath := flag.String("out", "", "Output directory")
 	generateStandAloneSpec := flag.Bool("standalone", true, "Generate standalone specs")
-	rootDir := flag.String("root", os.Getenv("MAGMA_ROOT"), "Root path to resolve dependency and output directories based on")
 
 	flag.Parse()
 
@@ -69,7 +68,7 @@ func main() {
 	}
 
 	if *generateStandAloneSpec {
-		err := generate.GenerateStandaloneSpecs(*inDir, *rootDir)
+		err := generate.GenerateStandaloneSpecs(*inDir, os.Getenv("MAGMA_ROOT"))
 		if err != nil {
 			glog.Fatalf("Error generating standalone Swagger specs %+v", err)
 		}

--- a/orc8r/cloud/go/tools/combine_swagger/testdata/configs/base.yml
+++ b/orc8r/cloud/go/tools/combine_swagger/testdata/configs/base.yml
@@ -2,10 +2,10 @@
 swagger: '2.0'
 
 magma-gen-meta:
-  go-package: magma/orc8r/cloud/go/tools/swaggergen/testdata/base/models
+  go-package: magma/orc8r/cloud/go/tools/combine_swagger/testdata/base/models
   dependencies: []
   temp-gen-filename: base-swagger.yml
-  output-dir: orc8r/cloud/go/tools/swaggergen/testdata/base
+  output-dir: base
   types:
     - go-struct-name: BarDef
       filename: bar_def_swaggergen.actual

--- a/orc8r/cloud/go/tools/combine_swagger/testdata/configs/cycle1.yml
+++ b/orc8r/cloud/go/tools/combine_swagger/testdata/configs/cycle1.yml
@@ -4,11 +4,11 @@
 swagger: '2.0'
 
 magma-gen-meta:
-  go-package: magma/orc8r/cloud/go/tools/swaggergen/testdata/cycle1/models
+  go-package: magma/orc8r/cloud/go/tools/combine_swagger/testdata/cycle1/models
   dependencies:
-    - 'orc8r/cloud/go/tools/swaggergen/testdata/cycle2.yml'
+    - 'cycle2.yml'
   temp-gen-filename: cycle1-swagger.yml
-  output-dir: orc8r/cloud/go/tools/swaggergen/testdata/cycle1
+  output-dir: cycle1
   types:
     - go-struct-name: Cycle1
       filename: cycle1_swaggergen.go

--- a/orc8r/cloud/go/tools/combine_swagger/testdata/configs/cycle2.yml
+++ b/orc8r/cloud/go/tools/combine_swagger/testdata/configs/cycle2.yml
@@ -6,9 +6,9 @@ swagger: '2.0'
 magma-gen-meta:
   go-package: magma/orc8r/cloud/go/tools/swaggergen/testdata/cycle2/models
   dependencies:
-    - 'orc8r/cloud/go/tools/swaggergen/testdata/cycle1.yml'
+    - 'cycle1.yml'
   temp-gen-filename: cycle2-swagger.yml
-  output-dir: orc8r/cloud/go/tools/swaggergen/testdata/cycle2
+  output-dir: cycle2
   types:
     - go-struct-name: Cycle2
       filename: cycle2_swaggergen.go

--- a/orc8r/cloud/go/tools/combine_swagger/testdata/configs/importer.yml
+++ b/orc8r/cloud/go/tools/combine_swagger/testdata/configs/importer.yml
@@ -6,7 +6,7 @@ magma-gen-meta:
   dependencies:
     - 'configs/base.yml'
   temp-gen-filename: importer-swagger.yml
-  output-dir: orc8r/cloud/go/tools/swaggergen/testdata/importer
+  output-dir: importer
   types:
     - go-struct-name: ImportingDef
       filename: importing_def_swaggergen.actual

--- a/orc8r/cloud/go/tools/combine_swagger/testdata/configs/importer.yml
+++ b/orc8r/cloud/go/tools/combine_swagger/testdata/configs/importer.yml
@@ -4,7 +4,7 @@ swagger: '2.0'
 magma-gen-meta:
   go-package: magma/orc8r/cloud/go/tools/swaggergen/testdata/importer/models
   dependencies:
-    - 'orc8r/cloud/go/tools/swaggergen/testdata/base.yml'
+    - 'configs/base.yml'
   temp-gen-filename: importer-swagger.yml
   output-dir: orc8r/cloud/go/tools/swaggergen/testdata/importer
   types:

--- a/orc8r/cloud/go/tools/combine_swagger/testdata/configs/importer2.yml
+++ b/orc8r/cloud/go/tools/combine_swagger/testdata/configs/importer2.yml
@@ -7,7 +7,7 @@ magma-gen-meta:
     - 'configs/base.yml'
     - 'configs/importer.yml'
   temp-gen-filename: importer2-swagger.yml
-  output-dir: orc8r/cloud/go/tools/swaggergen/testdata/importer2
+  output-dir: importer2
   types:
     - go-struct-name: ImportingChainDef
       filename: importing_chain_def_swaggergen.actual

--- a/orc8r/cloud/go/tools/combine_swagger/testdata/configs/importer2.yml
+++ b/orc8r/cloud/go/tools/combine_swagger/testdata/configs/importer2.yml
@@ -4,8 +4,8 @@ swagger: '2.0'
 magma-gen-meta:
   go-package: magma/orc8r/cloud/go/tools/swaggergen/testdata/importer2/models
   dependencies:
-    - 'orc8r/cloud/go/tools/swaggergen/testdata/base.yml'
-    - 'orc8r/cloud/go/tools/swaggergen/testdata/importer.yml'
+    - 'configs/base.yml'
+    - 'configs/importer.yml'
   temp-gen-filename: importer2-swagger.yml
   output-dir: orc8r/cloud/go/tools/swaggergen/testdata/importer2
   types:

--- a/orc8r/cloud/go/tools/swaggergen/generate/generate.go
+++ b/orc8r/cloud/go/tools/swaggergen/generate/generate.go
@@ -106,7 +106,7 @@ const tmpGenDir = "tmpgen"
 // copies the files that the target file depends on into the current working
 // directory, shells out to `swagger generate models`, then cleans up the
 // dependency files.
-func GenerateModels(targetFilepath string, configFilepath string, rootDir string, specs map[string]MagmaSwaggerSpec) error {
+func GenerateModels(targetFilepath string, configFilepath string, specs map[string]MagmaSwaggerSpec) error {
 	absTargetFilepath, err := filepath.Abs(targetFilepath)
 	if err != nil {
 		return errors.Wrapf(err, "target filepath %s is invalid", targetFilepath)

--- a/orc8r/cloud/go/tools/swaggergen/generate/generate.go
+++ b/orc8r/cloud/go/tools/swaggergen/generate/generate.go
@@ -110,7 +110,7 @@ func GenerateModels(targetFilepath string, configFilepath string, rootDir string
 		return errors.Wrapf(err, "target filepath %s is invalid", targetFilepath)
 	}
 
-	tmpGenDir, err := ioutil.TempDir("./", "tmpgen")
+	tmpGenDir, err := ioutil.TempDir(".", "tmpgen")
 	if err != nil {
 		return errors.Wrap(err, "could not create temporary gen directory")
 	}

--- a/orc8r/cloud/go/tools/swaggergen/generate/generate.go
+++ b/orc8r/cloud/go/tools/swaggergen/generate/generate.go
@@ -100,8 +100,6 @@ type MagmaGenType struct {
 	Filename     string
 }
 
-const tmpGenDir = "tmpgen"
-
 // GenerateModels parses the magma-gen-meta key of the given swagger YAML file,
 // copies the files that the target file depends on into the current working
 // directory, shells out to `swagger generate models`, then cleans up the
@@ -112,18 +110,15 @@ func GenerateModels(targetFilepath string, configFilepath string, rootDir string
 		return errors.Wrapf(err, "target filepath %s is invalid", targetFilepath)
 	}
 
-	defer func() {
-		// Always perform cleanup step
-		r := recover()
-		_ = os.RemoveAll(tmpGenDir)
-		if r != nil {
-			panic(r)
-		}
-	}()
+	tmpGenDir, err := ioutil.TempDir("./", "tmpgen")
+	if err != nil {
+		return errors.Wrap(err, "could not create temporary gen directory")
+	}
+	defer os.RemoveAll(tmpGenDir)
 
 	// For each dependency, strip the magma-gen-meta and write the result to
 	// the filename specified by `dependent-filename`
-	err = StripAndWriteSwaggerSpecs(specs)
+	err = StripAndWriteSwaggerSpecs(specs, tmpGenDir)
 	if err != nil {
 		return errors.WithStack(err)
 	}
@@ -136,19 +131,9 @@ func GenerateModels(targetFilepath string, configFilepath string, rootDir string
 		return err
 	}
 
-	cwd, err := os.Getwd()
-	if err != nil {
-		return err
-	}
-	err = os.Chdir(tmpGenDir)
-	if err != nil {
-		return err
-	}
-	defer os.Chdir(cwd)
-
 	cmd := exec.Command(
 		"swagger", "generate", "model",
-		"--spec", targetSpec.MagmaGenMeta.TempGenFilename,
+		"--spec", filepath.Join(tmpGenDir, targetSpec.MagmaGenMeta.TempGenFilename),
 		"--target", outputDir,
 		"--config-file", absConfigFilepath,
 	)
@@ -221,12 +206,7 @@ func ParseSwaggerDependencyTree(rootFilepath string, rootDir string) (map[string
 	return allSpecs, nil
 }
 
-func StripAndWriteSwaggerSpecs(specs map[string]MagmaSwaggerSpec) error {
-	err := os.Mkdir(tmpGenDir, 0777)
-	if err != nil {
-		return errors.Wrap(err, "could not create temporary gen directory")
-	}
-
+func StripAndWriteSwaggerSpecs(specs map[string]MagmaSwaggerSpec, outDir string) error {
 	for path, msc := range specs {
 		sanitized := msc.ToSwaggerSpec()
 		marshaledSanitized, err := yaml.Marshal(sanitized)
@@ -234,7 +214,7 @@ func StripAndWriteSwaggerSpecs(specs map[string]MagmaSwaggerSpec) error {
 			return errors.Wrapf(err, "could not re-marshal swagger spec %s", path)
 		}
 
-		err = ioutil.WriteFile(filepath.Join(tmpGenDir, msc.MagmaGenMeta.TempGenFilename), marshaledSanitized, 0666) // \m/
+		err = ioutil.WriteFile(filepath.Join(outDir, msc.MagmaGenMeta.TempGenFilename), marshaledSanitized, 0666) // \m/
 		if err != nil {
 			return errors.Wrapf(err, "could not write dependency swagger spec %s", msc.MagmaGenMeta.TempGenFilename)
 		}

--- a/orc8r/cloud/go/tools/swaggergen/generate/generate.go
+++ b/orc8r/cloud/go/tools/swaggergen/generate/generate.go
@@ -106,7 +106,7 @@ const tmpGenDir = "tmpgen"
 // copies the files that the target file depends on into the current working
 // directory, shells out to `swagger generate models`, then cleans up the
 // dependency files.
-func GenerateModels(targetFilepath string, configFilepath string, specs map[string]MagmaSwaggerSpec) error {
+func GenerateModels(targetFilepath string, configFilepath string, rootDir string, specs map[string]MagmaSwaggerSpec) error {
 	absTargetFilepath, err := filepath.Abs(targetFilepath)
 	if err != nil {
 		return errors.Wrapf(err, "target filepath %s is invalid", targetFilepath)
@@ -130,7 +130,7 @@ func GenerateModels(targetFilepath string, configFilepath string, specs map[stri
 
 	// Shell out to go-swagger
 	targetSpec := specs[absTargetFilepath]
-	outputDir := filepath.Join(os.Getenv("MAGMA_ROOT"), targetSpec.MagmaGenMeta.OutputDir)
+	outputDir := filepath.Join(rootDir, targetSpec.MagmaGenMeta.OutputDir)
 	absConfigFilepath, err := filepath.Abs(configFilepath)
 	if err != nil {
 		return err

--- a/orc8r/cloud/go/tools/swaggergen/generate/generate.go
+++ b/orc8r/cloud/go/tools/swaggergen/generate/generate.go
@@ -214,7 +214,7 @@ func StripAndWriteSwaggerSpecs(specs map[string]MagmaSwaggerSpec, outDir string)
 			return errors.Wrapf(err, "could not re-marshal swagger spec %s", path)
 		}
 
-		err = ioutil.WriteFile(filepath.Join(outDir, msc.MagmaGenMeta.TempGenFilename), marshaledSanitized, 0666) // \m/
+		err = ioutil.WriteFile(filepath.Join(outDir, msc.MagmaGenMeta.TempGenFilename), marshaledSanitized, 0666)
 		if err != nil {
 			return errors.Wrapf(err, "could not write dependency swagger spec %s", msc.MagmaGenMeta.TempGenFilename)
 		}

--- a/orc8r/cloud/go/tools/swaggergen/generate/generate_test.go
+++ b/orc8r/cloud/go/tools/swaggergen/generate/generate_test.go
@@ -28,7 +28,7 @@ import (
 )
 
 func TestParseSwaggerDependencyTree(t *testing.T) {
-	actual, err := generate.ParseSwaggerDependencyTree("../testdata/importer2.yml", "../../../../../../")
+	actual, err := generate.ParseSwaggerDependencyTree("../testdata/importer2.yml", "../testdata")
 	assert.NoError(t, err)
 
 	expectedFiles := []string{"../testdata/base.yml", "../testdata/importer.yml", "../testdata/importer2.yml"}
@@ -38,7 +38,7 @@ func TestParseSwaggerDependencyTree(t *testing.T) {
 }
 
 func TestParseSwaggerDependencyTree_Cycle(t *testing.T) {
-	actual, err := generate.ParseSwaggerDependencyTree("../testdata/cycle1.yml", "../../../../../../")
+	actual, err := generate.ParseSwaggerDependencyTree("../testdata/cycle1.yml", "../testdata")
 	assert.NoError(t, err)
 
 	expectedFiles := []string{"../testdata/cycle1.yml", "../testdata/cycle2.yml"}
@@ -57,10 +57,9 @@ func TestGenerateModels(t *testing.T) {
 func runTestGenerateCase(t *testing.T, ymlFile string, outputDir string) {
 	defer cleanupActualFiles(outputDir)
 
-	rootDir := "../../../../../../"
-	specs, err := generate.ParseSwaggerDependencyTree(ymlFile, rootDir)
+	specs, err := generate.ParseSwaggerDependencyTree(ymlFile, "../testdata")
 	assert.NoError(t, err)
-	err = generate.GenerateModels(ymlFile, "../testdata/config.yml", rootDir, specs)
+	err = generate.GenerateModels(ymlFile, "../testdata/config.yml", "../../testdata", specs)
 	assert.NoError(t, err)
 
 	// Verify that generated files are the same as the expected golden files

--- a/orc8r/cloud/go/tools/swaggergen/generate/generate_test.go
+++ b/orc8r/cloud/go/tools/swaggergen/generate/generate_test.go
@@ -59,7 +59,7 @@ func runTestGenerateCase(t *testing.T, ymlFile string, outputDir string) {
 
 	specs, err := generate.ParseSwaggerDependencyTree(ymlFile, "../testdata")
 	assert.NoError(t, err)
-	err = generate.GenerateModels(ymlFile, "../testdata/config.yml", "../../testdata", specs)
+	err = generate.GenerateModels(ymlFile, "../testdata/config.yml", "../testdata", specs)
 	assert.NoError(t, err)
 
 	// Verify that generated files are the same as the expected golden files

--- a/orc8r/cloud/go/tools/swaggergen/generate/generate_test.go
+++ b/orc8r/cloud/go/tools/swaggergen/generate/generate_test.go
@@ -60,7 +60,7 @@ func runTestGenerateCase(t *testing.T, ymlFile string, outputDir string) {
 	rootDir := os.Getenv("MAGMA_ROOT")
 	specs, err := generate.ParseSwaggerDependencyTree(ymlFile, rootDir)
 	assert.NoError(t, err)
-	err = generate.GenerateModels(ymlFile, "../testdata/config.yml", rootDir, specs)
+	err = generate.GenerateModels(ymlFile, "../testdata/config.yml", specs)
 	assert.NoError(t, err)
 
 	// Verify that generated files are the same as the expected golden files

--- a/orc8r/cloud/go/tools/swaggergen/generate/generate_test.go
+++ b/orc8r/cloud/go/tools/swaggergen/generate/generate_test.go
@@ -28,7 +28,7 @@ import (
 )
 
 func TestParseSwaggerDependencyTree(t *testing.T) {
-	actual, err := generate.ParseSwaggerDependencyTree("../testdata/importer2.yml", os.Getenv("MAGMA_ROOT"))
+	actual, err := generate.ParseSwaggerDependencyTree("../testdata/importer2.yml", "../../../../../../")
 	assert.NoError(t, err)
 
 	expectedFiles := []string{"../testdata/base.yml", "../testdata/importer.yml", "../testdata/importer2.yml"}
@@ -38,7 +38,7 @@ func TestParseSwaggerDependencyTree(t *testing.T) {
 }
 
 func TestParseSwaggerDependencyTree_Cycle(t *testing.T) {
-	actual, err := generate.ParseSwaggerDependencyTree("../testdata/cycle1.yml", os.Getenv("MAGMA_ROOT"))
+	actual, err := generate.ParseSwaggerDependencyTree("../testdata/cycle1.yml", "../../../../../../")
 	assert.NoError(t, err)
 
 	expectedFiles := []string{"../testdata/cycle1.yml", "../testdata/cycle2.yml"}
@@ -57,10 +57,10 @@ func TestGenerateModels(t *testing.T) {
 func runTestGenerateCase(t *testing.T, ymlFile string, outputDir string) {
 	defer cleanupActualFiles(outputDir)
 
-	rootDir := os.Getenv("MAGMA_ROOT")
+	rootDir := "../../../../../../"
 	specs, err := generate.ParseSwaggerDependencyTree(ymlFile, rootDir)
 	assert.NoError(t, err)
-	err = generate.GenerateModels(ymlFile, "../testdata/config.yml", specs)
+	err = generate.GenerateModels(ymlFile, "../testdata/config.yml", rootDir, specs)
 	assert.NoError(t, err)
 
 	// Verify that generated files are the same as the expected golden files

--- a/orc8r/cloud/go/tools/swaggergen/generate/generate_test.go
+++ b/orc8r/cloud/go/tools/swaggergen/generate/generate_test.go
@@ -104,17 +104,10 @@ func parseExpectedFiles(t *testing.T, files []string) map[string]generate.MagmaS
 }
 
 func cleanupActualFiles(outputDir string) {
-	_ = recover()
-
-	cleanupFiles := []string{}
 	_ = filepath.Walk(outputDir, func(path string, _ os.FileInfo, _ error) error {
-		if strings.HasSuffix(path, "actual") {
-			cleanupFiles = append(cleanupFiles, path)
+		if strings.HasSuffix(path, ".actual") {
+			_ = os.Remove(path)
 		}
 		return nil
 	})
-
-	for _, cleanupFile := range cleanupFiles {
-		_ = os.Remove(cleanupFile)
-	}
 }

--- a/orc8r/cloud/go/tools/swaggergen/generate/rewrite_test.go
+++ b/orc8r/cloud/go/tools/swaggergen/generate/rewrite_test.go
@@ -38,7 +38,7 @@ func runRewriteTestCase(t *testing.T, ymlFile string, outputDir string) {
 	specs, err := generate.ParseSwaggerDependencyTree(ymlFile, "../testdata")
 	assert.NoError(t, err)
 
-	err = generate.GenerateModels(ymlFile, "../testdata/config.yml", "../../testdata", specs)
+	err = generate.GenerateModels(ymlFile, "../testdata/config.yml", "../testdata", specs)
 	assert.NoError(t, err)
 
 	err = generate.RewriteGeneratedRefs(ymlFile, "../testdata", specs)

--- a/orc8r/cloud/go/tools/swaggergen/generate/rewrite_test.go
+++ b/orc8r/cloud/go/tools/swaggergen/generate/rewrite_test.go
@@ -35,11 +35,11 @@ func TestRewriteGeneratedRefs(t *testing.T) {
 func runRewriteTestCase(t *testing.T, ymlFile string, outputDir string) {
 	defer cleanupActualFiles(outputDir)
 
-	rootDir := os.Getenv("MAGMA_ROOT")
+	rootDir := "../../../../../../"
 	specs, err := generate.ParseSwaggerDependencyTree(ymlFile, rootDir)
 	assert.NoError(t, err)
 
-	err = generate.GenerateModels(ymlFile, "../testdata/config.yml", specs)
+	err = generate.GenerateModels(ymlFile, "../testdata/config.yml", rootDir, specs)
 	assert.NoError(t, err)
 
 	err = generate.RewriteGeneratedRefs(ymlFile, rootDir, specs)

--- a/orc8r/cloud/go/tools/swaggergen/generate/rewrite_test.go
+++ b/orc8r/cloud/go/tools/swaggergen/generate/rewrite_test.go
@@ -35,14 +35,13 @@ func TestRewriteGeneratedRefs(t *testing.T) {
 func runRewriteTestCase(t *testing.T, ymlFile string, outputDir string) {
 	defer cleanupActualFiles(outputDir)
 
-	rootDir := "../../../../../../"
-	specs, err := generate.ParseSwaggerDependencyTree(ymlFile, rootDir)
+	specs, err := generate.ParseSwaggerDependencyTree(ymlFile, "../testdata")
 	assert.NoError(t, err)
 
-	err = generate.GenerateModels(ymlFile, "../testdata/config.yml", rootDir, specs)
+	err = generate.GenerateModels(ymlFile, "../testdata/config.yml", "../../testdata", specs)
 	assert.NoError(t, err)
 
-	err = generate.RewriteGeneratedRefs(ymlFile, rootDir, specs)
+	err = generate.RewriteGeneratedRefs(ymlFile, "../testdata", specs)
 	assert.NoError(t, err)
 
 	goldenFiles, actualFiles := []string{}, []string{}

--- a/orc8r/cloud/go/tools/swaggergen/generate/rewrite_test.go
+++ b/orc8r/cloud/go/tools/swaggergen/generate/rewrite_test.go
@@ -39,7 +39,7 @@ func runRewriteTestCase(t *testing.T, ymlFile string, outputDir string) {
 	specs, err := generate.ParseSwaggerDependencyTree(ymlFile, rootDir)
 	assert.NoError(t, err)
 
-	err = generate.GenerateModels(ymlFile, "../testdata/config.yml", rootDir, specs)
+	err = generate.GenerateModels(ymlFile, "../testdata/config.yml", specs)
 	assert.NoError(t, err)
 
 	err = generate.RewriteGeneratedRefs(ymlFile, rootDir, specs)

--- a/orc8r/cloud/go/tools/swaggergen/main.go
+++ b/orc8r/cloud/go/tools/swaggergen/main.go
@@ -100,7 +100,7 @@ func main() {
 		glog.Fatalf("Error parsing swagger spec dependency tree: %v\n", err)
 	}
 
-	err = generate.GenerateModels(*targetFilepath, *configFilepath, *rootDir, specs)
+	err = generate.GenerateModels(*targetFilepath, *configFilepath, specs)
 	if err != nil {
 		glog.Fatalf("Error generating default swagger models: %v\n", err)
 	}

--- a/orc8r/cloud/go/tools/swaggergen/main.go
+++ b/orc8r/cloud/go/tools/swaggergen/main.go
@@ -79,7 +79,7 @@ import (
 func main() {
 	targetFilepath := flag.String("target", "", "Target swagger spec to generate code from")
 	configFilepath := flag.String("config", "", "Config file for go-swagger command")
-	rootDir := flag.String("root", "../../", "Root path to resolve dependency and output directories based on")
+	rootDir := flag.String("root", os.Getenv("MAGMA_ROOT"), "Root path to resolve dependency and output directories based on")
 	flag.Parse()
 
 	if *targetFilepath == "" {

--- a/orc8r/cloud/go/tools/swaggergen/main.go
+++ b/orc8r/cloud/go/tools/swaggergen/main.go
@@ -79,7 +79,7 @@ import (
 func main() {
 	targetFilepath := flag.String("target", "", "Target swagger spec to generate code from")
 	configFilepath := flag.String("config", "", "Config file for go-swagger command")
-	rootDir := flag.String("root", os.Getenv("MAGMA_ROOT"), "Root path to resolve dependency and output directories based on")
+	rootDir := flag.String("root", "../../", "Root path to resolve dependency and output directories based on")
 	flag.Parse()
 
 	if *targetFilepath == "" {
@@ -100,7 +100,7 @@ func main() {
 		glog.Fatalf("Error parsing swagger spec dependency tree: %v\n", err)
 	}
 
-	err = generate.GenerateModels(*targetFilepath, *configFilepath, specs)
+	err = generate.GenerateModels(*targetFilepath, *configFilepath, *rootDir, specs)
 	if err != nil {
 		glog.Fatalf("Error generating default swagger models: %v\n", err)
 	}

--- a/orc8r/cloud/go/tools/swaggergen/testdata/base.yml
+++ b/orc8r/cloud/go/tools/swaggergen/testdata/base.yml
@@ -5,7 +5,7 @@ magma-gen-meta:
   go-package: magma/orc8r/cloud/go/tools/swaggergen/testdata/base/models
   dependencies: []
   temp-gen-filename: base-swagger.yml
-  output-dir: orc8r/cloud/go/tools/swaggergen/testdata/base
+  output-dir: base
   types:
     - go-struct-name: BarDef
       filename: bar_def_swaggergen.actual

--- a/orc8r/cloud/go/tools/swaggergen/testdata/cycle1.yml
+++ b/orc8r/cloud/go/tools/swaggergen/testdata/cycle1.yml
@@ -6,9 +6,9 @@ swagger: '2.0'
 magma-gen-meta:
   go-package: magma/orc8r/cloud/go/tools/swaggergen/testdata/cycle1/models
   dependencies:
-    - 'orc8r/cloud/go/tools/swaggergen/testdata/cycle2.yml'
+    - 'cycle2.yml'
   temp-gen-filename: cycle1-swagger.yml
-  output-dir: orc8r/cloud/go/tools/swaggergen/testdata/cycle1
+  output-dir: cycle1
   types:
     - go-struct-name: Cycle1
       filename: cycle1_swaggergen.go

--- a/orc8r/cloud/go/tools/swaggergen/testdata/cycle2.yml
+++ b/orc8r/cloud/go/tools/swaggergen/testdata/cycle2.yml
@@ -6,9 +6,9 @@ swagger: '2.0'
 magma-gen-meta:
   go-package: magma/orc8r/cloud/go/tools/swaggergen/testdata/cycle2/models
   dependencies:
-    - 'orc8r/cloud/go/tools/swaggergen/testdata/cycle1.yml'
+    - 'cycle1.yml'
   temp-gen-filename: cycle2-swagger.yml
-  output-dir: orc8r/cloud/go/tools/swaggergen/testdata/cycle2
+  output-dir: cycle2
   types:
     - go-struct-name: Cycle2
       filename: cycle2_swaggergen.go

--- a/orc8r/cloud/go/tools/swaggergen/testdata/importer.yml
+++ b/orc8r/cloud/go/tools/swaggergen/testdata/importer.yml
@@ -4,9 +4,9 @@ swagger: '2.0'
 magma-gen-meta:
   go-package: magma/orc8r/cloud/go/tools/swaggergen/testdata/importer/models
   dependencies:
-    - 'orc8r/cloud/go/tools/swaggergen/testdata/base.yml'
+    - 'base.yml'
   temp-gen-filename: importer-swagger.yml
-  output-dir: orc8r/cloud/go/tools/swaggergen/testdata/importer
+  output-dir: importer
   types:
     - go-struct-name: ImportingDef
       filename: importing_def_swaggergen.actual

--- a/orc8r/cloud/go/tools/swaggergen/testdata/importer2.yml
+++ b/orc8r/cloud/go/tools/swaggergen/testdata/importer2.yml
@@ -4,10 +4,10 @@ swagger: '2.0'
 magma-gen-meta:
   go-package: magma/orc8r/cloud/go/tools/swaggergen/testdata/importer2/models
   dependencies:
-    - 'orc8r/cloud/go/tools/swaggergen/testdata/base.yml'
-    - 'orc8r/cloud/go/tools/swaggergen/testdata/importer.yml'
+    - 'base.yml'
+    - 'importer.yml'
   temp-gen-filename: importer2-swagger.yml
-  output-dir: orc8r/cloud/go/tools/swaggergen/testdata/importer2
+  output-dir: importer2
   types:
     - go-struct-name: ImportingChainDef
       filename: importing_chain_def_swaggergen.actual


### PR DESCRIPTION
Signed-off-by: Waqar Ahmed Aqeel <waqeel@fb.com>

## Summary

Addresses #7111 to:
1. remove reliance on `$MAGMA_ROOT` from `combine_swagger` and `swaggergen` tests.
2. put temporary files generated during tests in `ioutils.Temp*`

## Test Plan

1. Ran `make swagger` from `$MAGMA_ROOT/orc8r/cloud`
2. Ran `./build.py --generate` from `$MAGMA_ROOT/orc8r/cloud/docker`
3. Ran `make test` from `$MAGMA_ROOT/orc8r/cloud/go`

All tests passed.