### PR TITLE
count rule records with 0 usage in sessions_with_reporting_flows

### DIFF
--- a/lte/gateway/c/session_manager/LocalEnforcer.cpp
+++ b/lte/gateway/c/session_manager/LocalEnforcer.cpp
@@ -248,8 +248,8 @@ void LocalEnforcer::aggregate_records(
 
     auto& session                 = **session_it;
     const std::string& session_id = session->get_session_id();
+    sessions_with_reporting_flows.insert(ImsiAndSessionID(imsi, session_id));
     if (record.bytes_tx() > 0 || record.bytes_rx() > 0) {
-      sessions_with_reporting_flows.insert(ImsiAndSessionID(imsi, session_id));
       MLOG(MDEBUG) << session_id << " used " << record.bytes_tx()
                    << " tx bytes and " << record.bytes_rx()
                    << " rx bytes for rule " << record.rule_id();

--- a/lte/gateway/c/session_manager/test/test_local_enforcer.cpp
+++ b/lte/gateway/c/session_manager/test/test_local_enforcer.cpp
@@ -896,17 +896,11 @@ TEST_F(LocalEnforcerTest, test_terminate_credit) {
   local_enforcer->handle_termination_from_access(
       session_map, IMSI1, test_cfg_.common_context.apn(), update);
 
-  // pipelined still reports default drop flow rule when all flows are removed
-  RuleRecordTable only_drop_rule_table;
-  auto record_list = only_drop_rule_table.mutable_records();
-  create_rule_record(
-      IMSI1, test_cfg_.common_context.ue_ipv4(),
-      "internal_default_drop_flow_rule", 0, 0, record_list->Add());
-
+  RuleRecordTable empty_table;
   auto uc = get_default_update_criteria();
   session_map[IMSI1][0]->increment_rule_stats(
       "internal_default_drop_flow_rule", &uc);
-  local_enforcer->aggregate_records(session_map, only_drop_rule_table, update);
+  local_enforcer->aggregate_records(session_map, empty_table, update);
   run_evb();
   run_evb();
   bool success = session_store->update_sessions(update);


### PR DESCRIPTION
Signed-off-by: Marie Bremner <marwhal@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary
we currently only count records with non-zero usage as `sessions_with_reporting_flows`. This leads to weird logs when printing 
```
   MLOG(MINFO) << "Received stats for " << sessions_with_reporting_flows.size()
                << " active sessions and " << dead_sessions_to_cleanup.size()
                << " stale sessions";
```

This variable is used to determine any terminating sessions that no longer has stats in pipelined. We should not treat a record with 0 values as an indication of pipelined clearing state for the rule. Pipelined will stop sending any record once it cleans up state. 
<!-- Enumerate changes you made and why you made them -->

## Test Plan
Had to modify a test since it was making an assumption that we don't remove the drop rule on termination. -> we do.

terravm test 2+5+5capacity
<img width="1634" alt="Screen Shot 2021-06-14 at 10 14 18 AM" src="https://user-images.githubusercontent.com/37634144/121915925-4adf4000-ccf9-11eb-866b-5a0847d846af.png">

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->

