### PR TITLE
Fix Ingress Flow Direction logic for CWF

### DIFF
--- a/lte/gateway/python/magma/pipelined/app/inout.py
+++ b/lte/gateway/python/magma/pipelined/app/inout.py
@@ -365,26 +365,39 @@ class InOutController(RestartMixin, MagmaController):
                                                      resubmit_table=next_table)
             )
 
-        # set a direction bit for outgoing (pn -> inet) traffic for remaining traffic
-        # Passthrough is zero for packets from eNodeB GTP tunnels
-        ps_match_out = MagmaMatch(passthrough=REG_ZERO_VAL)
-        actions = [load_direction(parser, Direction.OUT)]
-        msgs.append(
-            flows.get_add_resubmit_next_service_flow_msg(dp, self._ingress_tbl_num, ps_match_out,
-                                                 actions=actions,
-                                                 priority=flows.MINIMUM_PRIORITY,
-                                                 resubmit_table=next_table)
-        )
-        # Passthrough is one for packets from remote PGW GTP tunnels, set direction
-        # flag to IN for such packets.
-        ps_match_in = MagmaMatch(passthrough=PASSTHROUGH_REG_VAL)
-        actions = [load_direction(parser, Direction.IN)]
-        msgs.append(
-            flows.get_add_resubmit_next_service_flow_msg(dp, self._ingress_tbl_num, ps_match_in,
-                                                 actions=actions,
-                                                 priority=flows.MINIMUM_PRIORITY,
-                                                 resubmit_table=next_table)
-        )
+
+        if self.config.setup_type == 'CWF':
+            # set a direction bit for outgoing (pn -> inet) traffic for remaining traffic
+            ps_match_out = MagmaMatch()
+            actions = [load_direction(parser, Direction.OUT)]
+            msgs.append(
+                flows.get_add_resubmit_next_service_flow_msg(dp, self._ingress_tbl_num, ps_match_out,
+                                                     actions=actions,
+                                                     priority=flows.MINIMUM_PRIORITY,
+                                                     resubmit_table=next_table)
+            )
+        else:
+            # set a direction bit for outgoing (pn -> inet) traffic for remaining traffic
+            # Passthrough is zero for packets from eNodeB GTP tunnels
+            ps_match_out = MagmaMatch(passthrough=REG_ZERO_VAL)
+            actions = [load_direction(parser, Direction.OUT)]
+            msgs.append(
+                flows.get_add_resubmit_next_service_flow_msg(dp, self._ingress_tbl_num, ps_match_out,
+                                                     actions=actions,
+                                                     priority=flows.MINIMUM_PRIORITY,
+                                                     resubmit_table=next_table)
+            )
+
+            # Passthrough is one for packets from remote PGW GTP tunnels, set direction
+            # flag to IN for such packets.
+            ps_match_in = MagmaMatch(passthrough=PASSTHROUGH_REG_VAL)
+            actions = [load_direction(parser, Direction.IN)]
+            msgs.append(
+                flows.get_add_resubmit_next_service_flow_msg(dp, self._ingress_tbl_num, ps_match_in,
+                                                     actions=actions,
+                                                     priority=flows.MINIMUM_PRIORITY,
+                                                     resubmit_table=next_table)
+            )
 
         return msgs
 

--- a/lte/gateway/python/magma/pipelined/tests/snapshots/test_li_mirror.LIMirrorTest.testFlowSnapshotMatch.snapshot
+++ b/lte/gateway/python/magma/pipelined/tests/snapshots/test_li_mirror.LIMirrorTest.testFlowSnapshotMatch.snapshot
@@ -1,7 +1,6 @@
  cookie=0x0, table=ingress(main_table), n_packets=0, n_bytes=0, priority=10,in_port=LOCAL actions=set_field:0x10->reg1,resubmit(,middle(main_table)),set_field:0->reg0,set_field:0->reg3
  cookie=0x0, table=ingress(main_table), n_packets=0, n_bytes=0, priority=10,in_port=1 actions=set_field:0x10->reg1,resubmit(,li_mirror(main_table)),set_field:0->reg0,set_field:0->reg3
- cookie=0x0, table=ingress(main_table), n_packets=0, n_bytes=0, priority=0,reg6=0 actions=set_field:0x1->reg1,resubmit(,middle(main_table)),set_field:0->reg0,set_field:0->reg3
- cookie=0x0, table=ingress(main_table), n_packets=0, n_bytes=0, priority=0,reg6=0x1 actions=set_field:0x10->reg1,resubmit(,middle(main_table)),set_field:0->reg0,set_field:0->reg3
+ cookie=0x0, table=ingress(main_table), n_packets=0, n_bytes=0, priority=0 actions=set_field:0x1->reg1,resubmit(,middle(main_table)),set_field:0->reg0,set_field:0->reg3
  cookie=0x0, table=middle(main_table), n_packets=0, n_bytes=0, priority=15,reg6=0x1 actions=resubmit(,egress(main_table)),set_field:0->reg0,set_field:0->reg3
  cookie=0x0, table=middle(main_table), n_packets=0, n_bytes=0, priority=10 actions=resubmit(,li_mirror(main_table)),set_field:0->reg0,set_field:0->reg3
  cookie=0x0, table=li_mirror(main_table), n_packets=0, n_bytes=0, priority=0,ip,reg1=0x10 actions=output:2,resubmit(,egress(main_table)),set_field:0->reg0,set_field:0->reg3

--- a/lte/gateway/python/magma/pipelined/tests/snapshots/test_ue_passthrough.UEMacAddressTest.test_passthrough_rules.snapshot
+++ b/lte/gateway/python/magma/pipelined/tests/snapshots/test_ue_passthrough.UEMacAddressTest.test_passthrough_rules.snapshot
@@ -2,8 +2,7 @@
  cookie=0x0, table=ue_mac(main_table), n_packets=4, n_bytes=384, priority=12,dl_dst=5e:cc:cc:b1:49:4b actions=set_field:0x48c2739fd9c3->metadata,resubmit(,ue_mac(scratch_table_0)),set_field:0->reg0,set_field:0->reg3
  cookie=0x0, table=ue_mac(main_table), n_packets=0, n_bytes=0, priority=10,arp actions=resubmit(,ingress(main_table)),set_field:0->reg0,set_field:0->reg3
  cookie=0x0, table=ingress(main_table), n_packets=4, n_bytes=384, priority=10,in_port=LOCAL actions=set_field:0x10->reg1,resubmit(,arpd(main_table)),set_field:0->reg0,set_field:0->reg3
- cookie=0x0, table=ingress(main_table), n_packets=0, n_bytes=0, priority=0,reg6=0 actions=set_field:0x1->reg1,resubmit(,arpd(main_table)),set_field:0->reg0,set_field:0->reg3
- cookie=0x0, table=ingress(main_table), n_packets=0, n_bytes=0, priority=0,reg6=0x1 actions=set_field:0x10->reg1,resubmit(,arpd(main_table)),set_field:0->reg0,set_field:0->reg3
+ cookie=0x0, table=ingress(main_table), n_packets=0, n_bytes=0, priority=0 actions=set_field:0x1->reg1,resubmit(,arpd(main_table)),set_field:0->reg0,set_field:0->reg3
  cookie=0x0, table=arpd(main_table), n_packets=0, n_bytes=0, priority=12,arp,reg1=0x10,arp_tpa=1.2.3.4,arp_op=2 actions=set_field:0x1->reg6,resubmit(,middle(main_table)),set_field:0->reg0,set_field:0->reg3
  cookie=0x0, table=arpd(main_table), n_packets=0, n_bytes=0, priority=12,arp,reg1=0x10,arp_tpa=1.2.3.4,arp_op=1 actions=move:NXM_OF_ETH_SRC[]->NXM_OF_ETH_DST[],mod_dl_src:00:aa:bb:cc:dd:ee,load:0x2->NXM_OF_ARP_OP[],move:NXM_NX_ARP_SHA[]->NXM_NX_ARP_THA[],load:0xaabbccddee->NXM_NX_ARP_SHA[],move:NXM_OF_ARP_TPA[]->NXM_NX_REG0[],move:NXM_OF_ARP_SPA[]->NXM_OF_ARP_TPA[],move:NXM_NX_REG0[]->NXM_OF_ARP_SPA[],IN_PORT
  cookie=0x0, table=arpd(main_table), n_packets=0, n_bytes=0, priority=12,arp,reg1=0x10,arp_tpa=1.1.1.1,arp_op=2 actions=set_field:0x1->reg6,resubmit(,middle(main_table)),set_field:0->reg0,set_field:0->reg3

--- a/lte/gateway/python/magma/pipelined/tests/test_ue_passthrough.py
+++ b/lte/gateway/python/magma/pipelined/tests/test_ue_passthrough.py
@@ -190,7 +190,7 @@ class UEMacAddressTest(unittest.TestCase):
                 FlowTest(FlowQuery(self._tbl_num,
                                    self.testing_controller), 4, 3),
                 FlowTest(FlowQuery(self._ingress_tbl_num,
-                                   self.testing_controller), 4, 3),
+                                   self.testing_controller), 4, 2),
                 FlowTest(FlowQuery(self._egress_tbl_num,
                                    self.testing_controller), 3, 2),
                 FlowTest(flow_queries[0], 4, 1),


### PR DESCRIPTION
Signed-off-by: Nick Yurchenko <koolzz@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary

In CWF we saw that the traffic wasn't egressed properly thats due to the passthrough logic for lte. Changing the default flow to be CWF specific

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
