### PR TITLE
[orc8r] Upgrade prometheus version and add an option to not lockfile.

### DIFF
--- a/orc8r/cloud/deploy/orc8r_deployer/docker/root/data/vars.yml
+++ b/orc8r/cloud/deploy/orc8r_deployer/docker/root/data/vars.yml
@@ -483,7 +483,7 @@ service:
     Required: false
     ConfigApps:
       - tf
-    Default: 1.5.21
+    Default: 1.5.22
   orc8r_controller_replicas:
     Description: Replica count for Orchestrator controller pods.
     Type: number

--- a/orc8r/cloud/deploy/terraform/orc8r-helm-aws/variables.tf
+++ b/orc8r/cloud/deploy/terraform/orc8r-helm-aws/variables.tf
@@ -167,7 +167,7 @@ variable "orc8r_deployment_type" {
 variable "orc8r_chart_version" {
   description = "Version of the core orchestrator Helm chart to install."
   type        = string
-  default     = "1.5.21"
+  default     = "1.5.22"
 }
 
 variable "cwf_orc8r_chart_version" {

--- a/orc8r/cloud/helm/orc8r/Chart.yaml
+++ b/orc8r/cloud/helm/orc8r/Chart.yaml
@@ -13,7 +13,7 @@ apiVersion: v2
 appVersion: "1.0"
 description: A Helm chart for magma orchestrator
 name: orc8r
-version: 1.5.21
+version: 1.5.22
 engine: gotpl
 sources:
   - https://github.com/magma/magma

--- a/orc8r/cloud/helm/orc8r/charts/metrics/Chart.yaml
+++ b/orc8r/cloud/helm/orc8r/charts/metrics/Chart.yaml
@@ -13,7 +13,7 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for magma metrics
 name: metrics
-version: 1.4.22
+version: 1.4.23
 engine: gotpl
 sources:
   - https://github.com/magma/magma

--- a/orc8r/cloud/helm/orc8r/charts/metrics/templates/prometheus.deployment.yaml
+++ b/orc8r/cloud/helm/orc8r/charts/metrics/templates/prometheus.deployment.yaml
@@ -102,6 +102,7 @@ spec:
           args: ['--config.file=/prometheus/prometheus.yml',
                  '--storage.tsdb.path=/data',
                  '--web.enable-lifecycle',
+                 "--storage.tsdb.no-lockfile",
                  {{ if .Values.thanos.enabled }}
                  '--storage.tsdb.min-block-duration=2h',
                  '--storage.tsdb.max-block-duration=2h',

--- a/orc8r/cloud/helm/orc8r/charts/metrics/values.yaml
+++ b/orc8r/cloud/helm/orc8r/charts/metrics/values.yaml
@@ -109,7 +109,7 @@ prometheus:
 
   image:
     repository: docker.io/prom/prometheus
-    tag: v2.20.1
+    tag: v2.27.1
     pullPolicy: IfNotPresent
 
   resources: {}


### PR DESCRIPTION


Signed-off-by: Karthik Subraveti <ksubraveti@fb.com>


## Summary
Upgrade prometheus to latest version and also add a config option to not lock tsdb. 
This will help with upgrades and address https://github.com/magma/magma/issues/4580

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
