### PR TITLE
[Agw][MME] Remove caller null checks on return of itti_alloc_new_message

### DIFF
--- a/lte/gateway/c/core/oai/common/async_system.c
+++ b/lte/gateway/c/core/oai/common/async_system.c
@@ -142,7 +142,6 @@ int async_system_command(
   }
   MessageDef* message_p = NULL;
   message_p = itti_alloc_new_message(sender_itti_task, ASYNC_SYSTEM_COMMAND);
-  AssertFatal(message_p, "itti_alloc_new_message Failed");
   ASYNC_SYSTEM_COMMAND(message_p).system_command    = bstr;
   ASYNC_SYSTEM_COMMAND(message_p).is_abort_on_error = is_abort_on_error;
   rv                                                = send_msg_to_task(

--- a/lte/gateway/c/core/oai/lib/itti/intertask_interface.h
+++ b/lte/gateway/c/core/oai/lib/itti/intertask_interface.h
@@ -184,7 +184,8 @@ const char* itti_get_task_name(task_id_t task_id);
 /** \brief Alloc and memset(0) a new itti message.
  * \param origin_task_id Task ID of the sending task
  * \param message_id Message ID
- * @returns NULL in case of failure or newly allocated mesage ref
+ * @returns newly allocated mesage ref
+ * @note Asserts that newly allocated message ref is non-NULL
  **/
 MessageDef* itti_alloc_new_message(
     task_id_t origin_task_id, MessagesIds message_id);

--- a/lte/gateway/c/core/oai/tasks/grpc_service/amf_service_handler.c
+++ b/lte/gateway/c/core/oai/tasks/grpc_service/amf_service_handler.c
@@ -27,12 +27,6 @@ int send_n11_create_pdu_session_resp_itti(
       LOG_UTIL, "Sending itti_n11_create_pdu_session_response to AMF \n");
   MessageDef* message_p = itti_alloc_new_message(
       TASK_GRPC_SERVICE, N11_CREATE_PDU_SESSION_RESPONSE);
-  if (message_p == NULL) {
-    OAILOG_ERROR(
-        LOG_UTIL,
-        "Failed to allocate memory for N11_CREATE_PDU_SESSION_RESPONSE\n");
-    return RETURNerror;
-  }
   message_p->ittiMsg.n11_create_pdu_session_response = *itti_msg;
   return send_msg_to_task(&grpc_service_task_zmq_ctx, TASK_AMF_APP, message_p);
 }

--- a/lte/gateway/c/core/oai/tasks/mme_app/mme_app_bearer.c
+++ b/lte/gateway/c/core/oai/tasks/mme_app/mme_app_bearer.c
@@ -130,14 +130,6 @@ int send_modify_bearer_req(mme_ue_s1ap_id_t ue_id, ebi_t ebi) {
 
   MessageDef* message_p =
       itti_alloc_new_message(TASK_MME_APP, S11_MODIFY_BEARER_REQUEST);
-  if (message_p == NULL) {
-    OAILOG_ERROR_UE(
-        LOG_MME_APP, ue_context_p->emm_context._imsi64,
-        "Cannot allocate memory to S11_MODIFY_BEARER_REQUEST for ue "
-        "id " MME_UE_S1AP_ID_FMT "\n",
-        ue_id);
-    OAILOG_FUNC_RETURN(LOG_MME_APP, RETURNerror);
-  }
 
   itti_s11_modify_bearer_request_t* s11_modify_bearer_request =
       &message_p->ittiMsg.s11_modify_bearer_request;
@@ -225,12 +217,6 @@ int send_pcrf_bearer_actv_rsp(
   OAILOG_FUNC_IN(LOG_MME_APP);
   MessageDef* message_p = itti_alloc_new_message(
       TASK_MME_APP, S11_NW_INITIATED_ACTIVATE_BEARER_RESP);
-  if (message_p == NULL) {
-    OAILOG_ERROR(
-        LOG_MME_APP,
-        "Cannot allocte memory to S11_NW_INITIATED_BEARER_ACTV_RSP\n");
-    OAILOG_FUNC_RETURN(LOG_MME_APP, RETURNerror);
-  }
   itti_s11_nw_init_actv_bearer_rsp_t* s11_nw_init_actv_bearer_rsp =
       &message_p->ittiMsg.s11_nw_init_actv_bearer_rsp;
 
@@ -788,13 +774,6 @@ void mme_app_handle_erab_setup_req(
   if (bearer_context) {
     MessageDef* message_p =
         itti_alloc_new_message(TASK_MME_APP, S1AP_E_RAB_SETUP_REQ);
-    if (message_p == NULL) {
-      OAILOG_WARNING_UE(
-          LOG_MME_APP, ue_context_p->emm_context._imsi64,
-          "Failed to allocate the memory for s1ap erab set request message\n");
-      bdestroy_wrapper(&nas_msg);
-      OAILOG_FUNC_OUT(LOG_MME_APP);
-    }
 
     itti_s1ap_e_rab_setup_req_t* s1ap_e_rab_setup_req =
         &message_p->ittiMsg.s1ap_e_rab_setup_req;
@@ -1545,17 +1524,6 @@ static int mme_app_send_modify_bearer_request_for_active_pdns(
     }
     MessageDef* message_p =
         itti_alloc_new_message(TASK_MME_APP, S11_MODIFY_BEARER_REQUEST);
-    if (message_p == NULL) {
-      OAILOG_ERROR_UE(
-          LOG_MME_APP, ue_context_p->emm_context._imsi64,
-          "Failed to allocate new ITTI message for S11 Modify Bearer Request "
-          "for MME UE S1AP Id: " MME_UE_S1AP_ID_FMT
-          " LBI %u"
-          "\n",
-          ue_context_p->mme_ue_s1ap_id,
-          ue_context_p->pdn_contexts[pid]->default_ebi);
-      OAILOG_FUNC_RETURN(LOG_MME_APP, RETURNerror);
-    }
     itti_s11_modify_bearer_request_t* s11_modify_bearer_request =
         &message_p->ittiMsg.s11_modify_bearer_request;
     s11_modify_bearer_request->local_teid = ue_context_p->mme_teid_s11;
@@ -2113,12 +2081,6 @@ int mme_app_paging_request_helper(
     OAILOG_FUNC_RETURN(LOG_MME_APP, RETURNerror);
   }
   message_p = itti_alloc_new_message(TASK_MME_APP, S1AP_PAGING_REQUEST);
-  if (message_p == NULL) {
-    OAILOG_ERROR(
-        LOG_MME_APP,
-        "Failed to allocate the memory for paging request message\n");
-    OAILOG_FUNC_RETURN(LOG_MME_APP, RETURNerror);
-  }
   itti_s1ap_paging_request_t* paging_request =
       &message_p->ittiMsg.s1ap_paging_request;
   memset(paging_request, 0, sizeof(itti_s1ap_paging_request_t));
@@ -2250,12 +2212,6 @@ void mme_app_send_actv_dedicated_bearer_rej_for_pending_bearers(
   OAILOG_FUNC_IN(LOG_MME_APP);
   MessageDef* message_p = itti_alloc_new_message(
       TASK_MME_APP, S11_NW_INITIATED_ACTIVATE_BEARER_RESP);
-  if (message_p == NULL) {
-    OAILOG_ERROR(
-        LOG_MME_APP,
-        "Cannot allocate memory to S11_NW_INITIATED_BEARER_ACTV_RSP\n");
-    OAILOG_FUNC_OUT(LOG_MME_APP);
-  }
   itti_s11_nw_init_actv_bearer_rsp_t* s11_nw_init_actv_bearer_rsp =
       &message_p->ittiMsg.s11_nw_init_actv_bearer_rsp;
   memset(
@@ -2429,12 +2385,6 @@ int mme_app_send_s11_suspend_notification(
       "Preparing to send Suspend Notification\n");
 
   message_p = itti_alloc_new_message(TASK_MME_APP, S11_SUSPEND_NOTIFICATION);
-  if (message_p == NULL) {
-    OAILOG_ERROR_UE(
-        LOG_MME_APP, ue_context_pP->emm_context._imsi64,
-        "Failed to allocate new ITTI message for S11 Suspend Notification\n");
-    OAILOG_FUNC_RETURN(LOG_MME_APP, RETURNerror);
-  }
 
   suspend_notification_p = &message_p->ittiMsg.s11_suspend_notification;
   memset(suspend_notification_p, 0, sizeof(itti_s11_suspend_notification_t));
@@ -2941,15 +2891,6 @@ void mme_app_handle_modify_ue_ambr_request(
   } else {
     message_p = itti_alloc_new_message(
         TASK_MME_APP, S1AP_UE_CONTEXT_MODIFICATION_REQUEST);
-    if (message_p == NULL) {
-      OAILOG_ERROR_UE(
-          LOG_MME_APP, ue_context_p->emm_context._imsi64,
-          "Failed to allocate new ITTI message for S1AP UE Context "
-          "Modification "
-          "Request for MME UE S1AP Id: " MME_UE_S1AP_ID_FMT "\n",
-          ue_context_p->mme_ue_s1ap_id);
-      OAILOG_FUNC_OUT(LOG_MME_APP);
-    }
     memset(
         (void*) &message_p->ittiMsg.s1ap_ue_context_mod_request, 0,
         sizeof(itti_s1ap_ue_context_mod_req_t));
@@ -3100,13 +3041,6 @@ void send_delete_dedicated_bearer_rsp(
       TASK_MME_APP, S11_NW_INITIATED_DEACTIVATE_BEARER_RESP);
   s11_deact_ded_bearer_rsp = &message_p->ittiMsg.s11_nw_init_deactv_bearer_rsp;
 
-  if (message_p == NULL) {
-    OAILOG_ERROR(
-        LOG_MME_APP,
-        "itti_alloc_new_message failed for"
-        "S11_NW_INITIATED_DEACTIVATE_BEARER_RESP\n");
-    OAILOG_FUNC_OUT(LOG_MME_APP);
-  }
   memset(
       s11_deact_ded_bearer_rsp, 0,
       sizeof(itti_s11_nw_init_deactv_bearer_rsp_t));
@@ -3396,12 +3330,6 @@ void mme_app_handle_handover_request_ack(
 
   message_p = itti_alloc_new_message(TASK_MME_APP, MME_APP_HANDOVER_COMMAND);
 
-  if (!message_p) {
-    OAILOG_ERROR(LOG_MME_APP, "Unable to allocate new ITTI message, failing\n");
-
-    OAILOG_FUNC_OUT(LOG_MME_APP);
-  }
-
   ho_command_p = &message_p->ittiMsg.mme_app_handover_command;
 
   ho_command_p->source_assoc_id    = handover_request_ack_p->source_assoc_id;
@@ -3478,14 +3406,6 @@ void mme_app_handle_handover_notify(
 
   // generate the Modify Bearer Request
   message_p = itti_alloc_new_message(TASK_MME_APP, S11_MODIFY_BEARER_REQUEST);
-  if (message_p == NULL) {
-    OAILOG_ERROR_UE(
-        LOG_MME_APP, ue_context_p->emm_context._imsi64,
-        "Failed to allocate new ITTI message for S11 Modify Bearer Request "
-        "for MME UE S1AP Id: " MME_UE_S1AP_ID_FMT "\n",
-        handover_notify_p->mme_ue_s1ap_id);
-    OAILOG_FUNC_OUT(LOG_MME_APP);
-  }
   itti_s11_modify_bearer_request_t* s11_modify_bearer_request =
       &message_p->ittiMsg.s11_modify_bearer_request;
   s11_modify_bearer_request->local_teid = ue_context_p->mme_teid_s11;
@@ -3657,14 +3577,6 @@ void mme_app_handle_path_switch_request(
   }
   // Build and send Modify Bearer Request
   message_p = itti_alloc_new_message(TASK_MME_APP, S11_MODIFY_BEARER_REQUEST);
-  if (message_p == NULL) {
-    OAILOG_ERROR_UE(
-        LOG_MME_APP, ue_context_p->emm_context._imsi64,
-        "Failed to allocate new ITTI message for S11 Modify Bearer Request "
-        "for MME UE S1AP Id: " MME_UE_S1AP_ID_FMT "\n",
-        path_switch_req_p->mme_ue_s1ap_id);
-    OAILOG_FUNC_OUT(LOG_MME_APP);
-  }
   itti_s11_modify_bearer_request_t* s11_modify_bearer_request =
       &message_p->ittiMsg.s11_modify_bearer_request;
   s11_modify_bearer_request->local_teid = ue_context_p->mme_teid_s11;
@@ -3840,11 +3752,6 @@ void mme_app_handle_erab_rel_cmd(
   }
 
   message_p = itti_alloc_new_message(TASK_MME_APP, S1AP_E_RAB_REL_CMD);
-  if (message_p == NULL) {
-    OAILOG_ERROR(LOG_MME_APP, "Cannot allocte memory to S1AP_E_RAB_REL_CMD \n");
-    bdestroy_wrapper(&nas_msg);
-    OAILOG_FUNC_OUT(LOG_MME_APP);
-  }
   itti_s1ap_e_rab_rel_cmd_t* s1ap_e_rab_rel_cmd =
       &message_p->ittiMsg.s1ap_e_rab_rel_cmd;
 
@@ -3957,14 +3864,6 @@ void mme_app_handle_path_switch_req_ack(
       ue_context_p->mme_ue_s1ap_id);
   message_p =
       itti_alloc_new_message(TASK_MME_APP, S1AP_PATH_SWITCH_REQUEST_ACK);
-  if (message_p == NULL) {
-    OAILOG_ERROR_UE(
-        LOG_MME_APP, ue_context_p->emm_context._imsi64,
-        "Failed to allocate new ITTI message for S1AP Path Switch Request Ack "
-        "for MME UE S1AP Id: " MME_UE_S1AP_ID_FMT "\n",
-        ue_context_p->mme_ue_s1ap_id);
-    OAILOG_FUNC_OUT(LOG_MME_APP);
-  }
   itti_s1ap_path_switch_request_ack_t* s1ap_path_switch_req_ack =
       &message_p->ittiMsg.s1ap_path_switch_request_ack;
 
@@ -4008,14 +3907,6 @@ void mme_app_handle_path_switch_req_failure(ue_mm_context_t* ue_context_p) {
       ue_context_p->mme_ue_s1ap_id);
   message_p =
       itti_alloc_new_message(TASK_MME_APP, S1AP_PATH_SWITCH_REQUEST_FAILURE);
-  if (message_p == NULL) {
-    OAILOG_ERROR_UE(
-        LOG_MME_APP, ue_context_p->emm_context._imsi64,
-        "Failed to allocate new ITTI message for S1AP Path Switch Request "
-        "Failure for MME UE S1AP Id: " MME_UE_S1AP_ID_FMT "\n",
-        ue_context_p->mme_ue_s1ap_id);
-    OAILOG_FUNC_OUT(LOG_MME_APP);
-  }
   itti_s1ap_path_switch_request_failure_t* s1ap_path_switch_req_failure =
       &message_p->ittiMsg.s1ap_path_switch_request_failure;
 
@@ -4211,14 +4102,6 @@ void mme_app_handle_e_rab_modification_ind(
 
   // Build and send Modify Bearer Request
   message_p = itti_alloc_new_message(TASK_MME_APP, S11_MODIFY_BEARER_REQUEST);
-  if (message_p == NULL) {
-    OAILOG_ERROR_UE(
-        LOG_MME_APP, ue_context_p->emm_context._imsi64,
-        "Failed to allocate new ITTI message for S11 Modify Bearer Request "
-        "for MME UE S1AP Id: " MME_UE_S1AP_ID_FMT "\n",
-        e_rab_modification_ind->mme_ue_s1ap_id);
-    OAILOG_FUNC_OUT(LOG_MME_APP);
-  }
   itti_s11_modify_bearer_request_t* s11_modify_bearer_request =
       &message_p->ittiMsg.s11_modify_bearer_request;
   s11_modify_bearer_request->local_teid = ue_context_p->mme_teid_s11;
@@ -4333,14 +4216,6 @@ void mme_app_handle_modify_bearer_rsp_erab_mod_ind(
       ue_context_p->mme_ue_s1ap_id);
 
   message_p = itti_alloc_new_message(TASK_MME_APP, S1AP_E_RAB_MODIFICATION_CNF);
-  if (message_p == NULL) {
-    OAILOG_ERROR_UE(
-        LOG_MME_APP, ue_context_p->emm_context._imsi64,
-        "Failed to allocate new ITTI message for E-RAB Modification Confirm "
-        "for MME UE S1AP Id: " MME_UE_S1AP_ID_FMT "\n",
-        ue_context_p->mme_ue_s1ap_id);
-    OAILOG_FUNC_OUT(LOG_MME_APP);
-  }
 
   itti_s1ap_e_rab_modification_cnf_t* s1ap_e_rab_modification_cnf_p =
       &message_p->ittiMsg.s1ap_e_rab_modification_cnf;

--- a/lte/gateway/c/core/oai/tasks/mme_app/mme_app_detach.c
+++ b/lte/gateway/c/core/oai/tasks/mme_app/mme_app_detach.c
@@ -69,14 +69,6 @@ void mme_app_send_delete_session_request(
       "Handle Delete session request for mme_s11_teid :%d\n",
       ue_context_p->mme_teid_s11);
   message_p = itti_alloc_new_message(TASK_MME_APP, S11_DELETE_SESSION_REQUEST);
-  if (message_p == NULL) {
-    OAILOG_ERROR(
-        LOG_MME_APP,
-        "Failed to allocate new ITTI message for S11 Delete Session Request "
-        "for MME UE S1AP Id: " MME_UE_S1AP_ID_FMT " and LBI: %u\n",
-        ue_context_p->mme_ue_s1ap_id, ebi);
-    OAILOG_FUNC_OUT(LOG_MME_APP);
-  }
 
   ue_context_p->pdn_contexts[cid]
       ->s_gw_address_s11_s4.address.ipv4_address.s_addr =

--- a/lte/gateway/c/core/oai/tasks/mme_app/mme_app_itti_messaging.c
+++ b/lte/gateway/c/core/oai/tasks/mme_app/mme_app_itti_messaging.c
@@ -76,12 +76,6 @@ void mme_app_itti_ue_context_release(
   OAILOG_FUNC_IN(LOG_MME_APP);
   message_p =
       itti_alloc_new_message(TASK_MME_APP, S1AP_UE_CONTEXT_RELEASE_COMMAND);
-  if (message_p == NULL) {
-    OAILOG_ERROR_UE(
-        LOG_MME_APP, ue_context_p->emm_context._imsi64,
-        "Failed to allocate memory for S1AP_UE_CONTEXT_RELEASE_COMMAND \n");
-    OAILOG_FUNC_OUT(LOG_MME_APP);
-  }
 
   OAILOG_INFO_UE(
       LOG_MME_APP, ue_context_p->emm_context._imsi64,
@@ -131,14 +125,6 @@ int mme_app_send_s11_release_access_bearers_req(
   }
   message_p =
       itti_alloc_new_message(TASK_MME_APP, S11_RELEASE_ACCESS_BEARERS_REQUEST);
-  if (message_p == NULL) {
-    OAILOG_ERROR_UE(
-        LOG_MME_APP, ue_mm_context->emm_context._imsi64,
-        "Failed to allocate memory for S11_RELEASE_ACCESS_BEARERS_REQUEST  for "
-        "ue id " MME_UE_S1AP_ID_FMT "\n",
-        ue_mm_context->mme_ue_s1ap_id);
-    OAILOG_FUNC_RETURN(LOG_MME_APP, RETURNerror);
-  }
   release_access_bearers_request_p =
       &message_p->ittiMsg.s11_release_access_bearers_request;
   release_access_bearers_request_p->local_teid = ue_mm_context->mme_teid_s11;
@@ -422,9 +408,6 @@ void mme_app_send_s1ap_e_rab_modification_confirm(
   /** Send a S1AP E-RAB MODIFICATION CONFIRM TO THE ENB. */
   MessageDef* message_p =
       itti_alloc_new_message(TASK_MME_APP, S1AP_E_RAB_MODIFICATION_CNF);
-  if (message_p == NULL) {
-    OAILOG_ERROR(LOG_MME_APP, "itti_alloc_new_message Failed\n");
-  }
 
   itti_s1ap_e_rab_modification_cnf_t* s1ap_e_rab_modification_cnf_p =
       &message_p->ittiMsg.s1ap_e_rab_modification_cnf;
@@ -479,11 +462,6 @@ void nas_itti_sgsap_uplink_unitdata(
   int uetimezone        = 0;
 
   message_p = itti_alloc_new_message(TASK_MME_APP, SGSAP_UPLINK_UNITDATA);
-  if (message_p == NULL) {
-    OAILOG_ERROR(
-        LOG_MME_APP, "Failed to allocate memory for SGSAP_UPLINK_UNITDATA \n");
-    OAILOG_FUNC_OUT(LOG_MME_APP);
-  }
   memset(
       &message_p->ittiMsg.sgsap_uplink_unitdata, 0,
       sizeof(itti_sgsap_uplink_unitdata_t));
@@ -589,12 +567,6 @@ void mme_app_itti_sgsap_tmsi_reallocation_comp(
   MessageDef* message_p = NULL;
 
   message_p = itti_alloc_new_message(TASK_MME_APP, SGSAP_TMSI_REALLOC_COMP);
-  if (message_p == NULL) {
-    OAILOG_ERROR(
-        LOG_MME_APP,
-        "Failed to allocate memory for SGSAP_TMSI_REALLOC_COMP \n");
-    OAILOG_FUNC_OUT(LOG_MME_APP);
-  }
   memset(
       &message_p->ittiMsg.sgsap_tmsi_realloc_comp, 0,
       sizeof(itti_sgsap_tmsi_reallocation_comp_t));
@@ -633,11 +605,6 @@ void mme_app_itti_sgsap_ue_activity_ind(
   MessageDef* message_p = NULL;
 
   message_p = itti_alloc_new_message(TASK_MME_APP, SGSAP_UE_ACTIVITY_IND);
-  if (message_p == NULL) {
-    OAILOG_ERROR(
-        LOG_MME_APP, "Failed to allocate memory for SGSAP_UE_ACTIVITY_IND \n");
-    OAILOG_FUNC_OUT(LOG_MME_APP);
-  }
   memset(
       &message_p->ittiMsg.sgsap_ue_activity_ind, 0,
       sizeof(itti_sgsap_ue_activity_ind_t));

--- a/lte/gateway/c/core/oai/tasks/mme_app/mme_app_location.c
+++ b/lte/gateway/c/core/oai/tasks/mme_app/mme_app_location.c
@@ -70,9 +70,6 @@ int mme_app_send_s6a_update_location_req(
       " \n",
       ue_context_p->mme_ue_s1ap_id);
   message_p = itti_alloc_new_message(TASK_MME_APP, S6A_UPDATE_LOCATION_REQ);
-  if (message_p == NULL) {
-    OAILOG_FUNC_RETURN(LOG_MME_APP, RETURNerror);
-  }
 
   s6a_ulr_p = &message_p->ittiMsg.s6a_update_location_req;
   memset((void*) s6a_ulr_p, 0, sizeof(s6a_update_location_req_t));
@@ -459,10 +456,6 @@ int mme_app_send_s6a_cancel_location_ans(
   OAILOG_FUNC_IN(LOG_MME_APP);
 
   message_p = itti_alloc_new_message(TASK_MME_APP, S6A_CANCEL_LOCATION_ANS);
-
-  if (message_p == NULL) {
-    OAILOG_FUNC_RETURN(LOG_MME_APP, RETURNerror);
-  }
 
   s6a_cla_p = &message_p->ittiMsg.s6a_cancel_location_ans;
   memset((void*) s6a_cla_p, 0, sizeof(s6a_cancel_location_ans_t));

--- a/lte/gateway/c/core/oai/tasks/mme_app/mme_app_procedures.c
+++ b/lte/gateway/c/core/oai/tasks/mme_app/mme_app_procedures.c
@@ -180,14 +180,6 @@ void mme_app_s11_procedure_create_bearer_send_response(
     mme_app_s11_proc_create_bearer_t* s11_proc_create) {
   MessageDef* message_p =
       itti_alloc_new_message(TASK_MME_APP, S11_CREATE_BEARER_RESPONSE);
-  if (message_p == NULL) {
-    OAILOG_ERROR(
-        LOG_MME_APP,
-        "Failed to allocate new ITTI message for S11 Create Bearer "
-        "Response for MME UE S1AP Id: " MME_UE_S1AP_ID_FMT "\n",
-        ue_context_p->mme_ue_s1ap_id);
-    OAILOG_FUNC_OUT(LOG_MME_APP);
-  }
 
   message_p->ittiMsgHeader.imsi = ue_context_p->emm_context._imsi64;
 

--- a/lte/gateway/c/core/oai/tasks/mme_app/mme_app_purge_ue.c
+++ b/lte/gateway/c/core/oai/tasks/mme_app/mme_app_purge_ue.c
@@ -60,14 +60,6 @@ int mme_app_send_s6a_purge_ue_req(
   }
 
   message_p = itti_alloc_new_message(TASK_MME_APP, S6A_PURGE_UE_REQ);
-  if (message_p == NULL) {
-    OAILOG_WARNING(
-        LOG_MME_APP,
-        "Failed to allocate memory for S6A_PURGE_UE_REQ, IMSI:" IMSI_64_FMT
-        "\n",
-        imsi);
-    OAILOG_FUNC_RETURN(LOG_MME_APP, RETURNerror);
-  }
 
   s6a_pur_p = &message_p->ittiMsg.s6a_purge_ue_req;
   memset((void*) s6a_pur_p, 0, sizeof(s6a_purge_ue_req_t));

--- a/lte/gateway/c/core/oai/tasks/mme_app/mme_app_sgs_alert.c
+++ b/lte/gateway/c/core/oai/tasks/mme_app/mme_app_sgs_alert.c
@@ -153,14 +153,6 @@ static int mme_app_send_sgsap_alert_reject(
   itti_sgsap_alert_reject_t* sgsap_alert_reject_pP = NULL;
 
   message_p = itti_alloc_new_message(TASK_MME_APP, SGSAP_ALERT_REJECT);
-  if (!message_p) {
-    OAILOG_ERROR(
-        LOG_MME_APP,
-        "Failed to allocate memory: SGSAP_ALERT_REJECT, IMSI: " IMSI_64_FMT
-        "\n",
-        imsi64);
-    OAILOG_FUNC_RETURN(LOG_MME_APP, rc);
-  }
   sgsap_alert_reject_pP = &message_p->ittiMsg.sgsap_alert_reject;
   memset((void*) sgsap_alert_reject_pP, 0, sizeof(itti_sgsap_alert_reject_t));
 
@@ -197,14 +189,6 @@ static int mme_app_send_sgsap_alert_ack(
   OAILOG_FUNC_IN(LOG_MME_APP);
 
   message_p = itti_alloc_new_message(TASK_MME_APP, SGSAP_ALERT_ACK);
-  if (!message_p) {
-    OAILOG_ERROR(
-        LOG_MME_APP,
-        "Failed to allocate memory for SGSAP_ALERT_ACK, IMSI: " IMSI_64_FMT
-        "\n",
-        imsi64);
-    OAILOG_FUNC_RETURN(LOG_MME_APP, rc);
-  }
   sgsap_alert_ack_pP = &message_p->ittiMsg.sgsap_alert_ack;
   memset((void*) sgsap_alert_ack_pP, 0, sizeof(itti_sgsap_alert_ack_t));
 

--- a/lte/gateway/c/core/oai/tasks/mme_app/mme_app_sgs_detach.c
+++ b/lte/gateway/c/core/oai/tasks/mme_app/mme_app_sgs_detach.c
@@ -70,14 +70,6 @@ static void mme_app_send_sgs_eps_detach_indication(
       "ue_id: " MME_UE_S1AP_ID_FMT "\n",
       detach_type, ue_context_p->mme_ue_s1ap_id);
   message_p = itti_alloc_new_message(TASK_MME_APP, SGSAP_EPS_DETACH_IND);
-  if (!message_p) {
-    OAILOG_ERROR(
-        LOG_MME_APP,
-        "Failed to allocate memory for SGSAP_EPS_DETACH_IND for "
-        "ue_id: " MME_UE_S1AP_ID_FMT "\n",
-        ue_context_p->mme_ue_s1ap_id);
-    OAILOG_FUNC_OUT(LOG_MME_APP);
-  }
   memset(
       (void*) &message_p->ittiMsg.sgsap_eps_detach_ind, 0,
       sizeof(itti_sgsap_eps_detach_ind_t));
@@ -275,14 +267,6 @@ void mme_app_send_sgs_imsi_detach_indication(
       "ue_id " MME_UE_S1AP_ID_FMT "\n",
       detach_type, ue_context_p->mme_ue_s1ap_id);
   message_p = itti_alloc_new_message(TASK_MME_APP, SGSAP_IMSI_DETACH_IND);
-  if (!message_p) {
-    OAILOG_ERROR(
-        LOG_MME_APP,
-        "Failed to allocate memory for SGSAP_IMSI_DETACH_IND for "
-        "ue_id: " MME_UE_S1AP_ID_FMT "\n",
-        ue_context_p->mme_ue_s1ap_id);
-    OAILOG_FUNC_OUT(LOG_MME_APP);
-  }
   memset(
       (void*) &message_p->ittiMsg.sgsap_imsi_detach_ind, 0,
       sizeof(itti_sgsap_imsi_detach_ind_t));

--- a/lte/gateway/c/core/oai/tasks/mme_app/mme_app_sgs_paging.c
+++ b/lte/gateway/c/core/oai/tasks/mme_app/mme_app_sgs_paging.c
@@ -576,14 +576,6 @@ int mme_app_send_sgsap_service_request(
   }
 
   message_p = itti_alloc_new_message(TASK_MME_APP, SGSAP_SERVICE_REQUEST);
-  if (message_p == NULL) {
-    OAILOG_ERROR(
-        LOG_MME_APP,
-        "Failed to allocate new ITTI message for SGSAP Service Request for "
-        "IMSI: " IMSI_64_FMT "\n",
-        ue_context_p->emm_context._imsi64);
-    OAILOG_FUNC_RETURN(LOG_MME_APP, rc);
-  }
   sgsap_service_req_pP = &message_p->ittiMsg.sgsap_service_request;
   memset((void*) sgsap_service_req_pP, 0, sizeof(itti_sgsap_service_request_t));
 
@@ -643,14 +635,6 @@ int mme_app_send_sgsap_paging_reject(
   }
 
   message_p = itti_alloc_new_message(TASK_MME_APP, SGSAP_PAGING_REJECT);
-  if (message_p == NULL) {
-    OAILOG_ERROR(
-        LOG_MME_APP,
-        "Failed to allocate new ITTI message for SGSAP Paging Reject for "
-        "IMSI: " IMSI_64_FMT "\n",
-        imsi);
-    OAILOG_FUNC_RETURN(LOG_MME_APP, rc);
-  }
   sgsap_paging_reject_pP = &message_p->ittiMsg.sgsap_paging_reject;
   memset((void*) sgsap_paging_reject_pP, 0, sizeof(itti_sgsap_paging_reject_t));
 
@@ -748,14 +732,6 @@ static int mme_app_send_sgsap_ue_unreachable(
   }
 
   message_p = itti_alloc_new_message(TASK_MME_APP, SGSAP_UE_UNREACHABLE);
-  if (message_p == NULL) {
-    OAILOG_ERROR(
-        LOG_MME_APP,
-        "Failed to allocate new ITTI message for SGSAP UE Unreachable for "
-        "IMSI: " IMSI_64_FMT "\n",
-        ue_context_p->emm_context._imsi64);
-    OAILOG_FUNC_RETURN(LOG_MME_APP, rc);
-  }
   sgsap_ue_unreachable_pP = &message_p->ittiMsg.sgsap_ue_unreachable;
   memset(
       (void*) sgsap_ue_unreachable_pP, 0, sizeof(itti_sgsap_ue_unreachable_t));

--- a/lte/gateway/c/core/oai/tasks/mme_app/mme_app_sgsap_location_update.c
+++ b/lte/gateway/c/core/oai/tasks/mme_app/mme_app_sgsap_location_update.c
@@ -143,14 +143,6 @@ void mme_app_send_itti_sgsap_ue_activity_ind(
   MessageDef* message_p = NULL;
 
   message_p = itti_alloc_new_message(TASK_MME_APP, SGSAP_UE_ACTIVITY_IND);
-  if (!message_p) {
-    OAILOG_ERROR(
-        LOG_MME_APP,
-        "Failed to allocate memory for SGSAP UE ACTIVITY IND for Imsi: "
-        "%s %d \n",
-        imsi, imsi_len);
-    OAILOG_FUNC_OUT(LOG_MME_APP);
-  }
   memset(
       &message_p->ittiMsg.sgsap_ue_activity_ind, 0,
       sizeof(itti_sgsap_ue_activity_ind_t));

--- a/lte/gateway/c/core/oai/tasks/nas/emm/Authentication.c
+++ b/lte/gateway/c/core/oai/tasks/nas/emm/Authentication.c
@@ -1499,15 +1499,6 @@ static void nas_itti_auth_info_req(
       ue_id);
 
   message_p = itti_alloc_new_message(TASK_MME_APP, S6A_AUTH_INFO_REQ);
-  if (!message_p) {
-    OAILOG_CRITICAL(
-        LOG_NAS_EMM,
-        "itti_alloc_new_message failed for Authentication"
-        " Information Request message to S6A for"
-        " ue-id = " MME_UE_S1AP_ID_FMT "\n",
-        ue_id);
-    OAILOG_FUNC_OUT(LOG_NAS);
-  }
   auth_info_req = &message_p->ittiMsg.s6a_auth_info_req;
   memset(auth_info_req, 0, sizeof(s6a_auth_info_req_t));
 

--- a/lte/gateway/c/core/oai/tasks/nas/emm/sap/emm_fsm.c
+++ b/lte/gateway/c/core/oai/tasks/nas/emm/sap/emm_fsm.c
@@ -172,6 +172,20 @@ int emm_fsm_set_state(
 
 /****************************************************************************
  **                                                                        **
+ ** Name:    sgs_la_update_requested_handler() **
+ **                                                                        **
+ ** Description: Handles the behaviour of the UE in MME while the          **
+ **              SGS is in SGS-LA_UPDATE_REQUEST state.                    **
+ **                                                                        **
+ ** Inputs:  sgs_evt:   The received SGS event                             **
+ **                                                                        **
+ ** Outputs:                                                               **
+ **          Return:    RETURNok, RETURNerror                              **
+ **                                                                        **
+ ***************************************************************************/
+
+/****************************************************************************
+ **                                                                        **
  ** Name:    emm_fsm_get_state()                                      **
  **                                                                        **
  ** Description: Get the current value of the EPS Mobility Management      **

--- a/lte/gateway/c/core/oai/tasks/ngap/ngap_amf_handlers.c
+++ b/lte/gateway/c/core/oai/tasks/ngap/ngap_amf_handlers.c
@@ -1671,10 +1671,6 @@ int ngap_amf_handle_pduSession_release_response(
 
   message_p =
       itti_alloc_new_message(TASK_NGAP, NGAP_PDUSESSIONRESOURCE_REL_RSP);
-  if (message_p == NULL) {
-    OAILOG_ERROR(LOG_NGAP, "itti_alloc_new_message Failed\n");
-    OAILOG_FUNC_RETURN(LOG_NGAP, RETURNerror);
-  }
   NGAP_PDUSESSIONRESOURCE_REL_RSP(message_p).amf_ue_ngap_id =
       ue_ref_p->amf_ue_ngap_id;
   NGAP_PDUSESSIONRESOURCE_REL_RSP(message_p).gnb_ue_ngap_id =

--- a/lte/gateway/c/core/oai/tasks/ngap/ngap_amf_itti_messaging.c
+++ b/lte/gateway/c/core/oai/tasks/ngap/ngap_amf_itti_messaging.c
@@ -36,13 +36,6 @@ int ngap_amf_itti_send_sctp_request(
   MessageDef* message_p = NULL;
 
   message_p = itti_alloc_new_message(TASK_NGAP, SCTP_DATA_REQ);
-  if (message_p == NULL) {
-    OAILOG_ERROR(
-        LOG_NGAP,
-        "itti_alloc_new_message Failed for"
-        " SCTP_DATA_REQ \n");
-    OAILOG_FUNC_RETURN(LOG_NGAP, RETURNerror);
-  }
   SCTP_DATA_REQ(message_p).payload       = *payload;
   *payload                               = NULL;
   SCTP_DATA_REQ(message_p).assoc_id      = assoc_id;
@@ -69,13 +62,6 @@ TODO: laterthis maps to state
       "Sending NAS Uplink indication to NAS_AMF_APP, amf_ue_ngap_id = (%u) \n",
       ue_id);
   message_p = itti_alloc_new_message(TASK_NGAP, AMF_APP_UPLINK_DATA_IND);
-  if (message_p == NULL) {
-    OAILOG_ERROR_UE(
-        LOG_NGAP, imsi64,
-        "itti_alloc_new_message Failed for"
-        " AMF_APP_UPLINK_DATA_IND \n");
-    OAILOG_FUNC_RETURN(LOG_NGAP, RETURNerror);
-  }
   AMF_APP_UL_DATA_IND(message_p).ue_id   = ue_id;
   AMF_APP_UL_DATA_IND(message_p).nas_msg = *payload;
   *payload                               = NULL;
@@ -103,14 +89,6 @@ void ngap_amf_itti_ngap_initial_ue_message(
   OAILOG_FUNC_IN(LOG_NGAP);
 
   message_p = itti_alloc_new_message(TASK_NGAP, NGAP_INITIAL_UE_MESSAGE);
-
-  if (message_p == NULL) {
-    OAILOG_ERROR(
-        LOG_NGAP,
-        "itti_alloc_new_message Failed for"
-        " NGAP_INITIAL_UE_MESSAGE \n");
-    OAILOG_FUNC_OUT(LOG_NGAP);
-  }
 
   OAILOG_INFO(
       LOG_NGAP,
@@ -186,13 +164,6 @@ void ngap_amf_itti_nas_non_delivery_ind(
   // TODO translate, insert, cause in message
   OAILOG_FUNC_IN(LOG_NGAP);
   message_p = itti_alloc_new_message(TASK_NGAP, AMF_APP_DOWNLINK_DATA_REJ);
-  if (message_p == NULL) {
-    OAILOG_ERROR_UE(
-        LOG_NGAP, imsi64,
-        "itti_alloc_new_message Failed for"
-        " AMF_APP_DOWNLINK_DATA_REJ \n");
-    OAILOG_FUNC_OUT(LOG_NGAP);
-  }
 
   AMF_APP_DL_DATA_REJ(message_p).ue_id = ue_id;
   /* Mapping between asn1 definition and NAS definition */

--- a/lte/gateway/c/core/oai/tasks/s11/s11_mme_bearer_manager.c
+++ b/lte/gateway/c/core/oai/tasks/s11/s11_mme_bearer_manager.c
@@ -407,68 +407,65 @@ int s11_mme_handle_create_bearer_request(
   DevAssert(stack_p);
   message_p = itti_alloc_new_message(TASK_S11, S11_CREATE_BEARER_REQUEST);
 
-  if (message_p) {
-    req_p = &message_p->ittiMsg.s11_create_bearer_request;
+  req_p = &message_p->ittiMsg.s11_create_bearer_request;
 
-    req_p->teid = nwGtpv2cMsgGetTeid(pUlpApi->hMsg);
-    req_p->trxn = (void*) pUlpApi->u_api_info.initialReqIndInfo.hTrxn;
+  req_p->teid = nwGtpv2cMsgGetTeid(pUlpApi->hMsg);
+  req_p->trxn = (void*) pUlpApi->u_api_info.initialReqIndInfo.hTrxn;
 
-    // Create a new message parser
-    rc = nwGtpv2cMsgParserNew(
-        *stack_p, NW_GTP_CREATE_BEARER_REQ, s11_ie_indication_generic, NULL,
-        &pMsgParser);
-    DevAssert(NW_OK == rc);
+  // Create a new message parser
+  rc = nwGtpv2cMsgParserNew(
+      *stack_p, NW_GTP_CREATE_BEARER_REQ, s11_ie_indication_generic, NULL,
+      &pMsgParser);
+  DevAssert(NW_OK == rc);
 
-    rc = nwGtpv2cMsgParserAddIe(
-        pMsgParser, NW_GTPV2C_IE_EBI, NW_GTPV2C_IE_INSTANCE_ZERO,
-        NW_GTPV2C_IE_PRESENCE_MANDATORY, gtpv2c_ebi_ie_get,
-        &req_p->linked_eps_bearer_id);
-    DevAssert(NW_OK == rc);
+  rc = nwGtpv2cMsgParserAddIe(
+      pMsgParser, NW_GTPV2C_IE_EBI, NW_GTPV2C_IE_INSTANCE_ZERO,
+      NW_GTPV2C_IE_PRESENCE_MANDATORY, gtpv2c_ebi_ie_get,
+      &req_p->linked_eps_bearer_id);
+  DevAssert(NW_OK == rc);
 
-    rc = nwGtpv2cMsgParserAddIe(
-        pMsgParser, NW_GTPV2C_IE_PCO, NW_GTPV2C_IE_INSTANCE_ZERO,
-        NW_GTPV2C_IE_PRESENCE_OPTIONAL, gtpv2c_pco_ie_get, &req_p->pco);
-    DevAssert(NW_OK == rc);
+  rc = nwGtpv2cMsgParserAddIe(
+      pMsgParser, NW_GTPV2C_IE_PCO, NW_GTPV2C_IE_INSTANCE_ZERO,
+      NW_GTPV2C_IE_PRESENCE_OPTIONAL, gtpv2c_pco_ie_get, &req_p->pco);
+  DevAssert(NW_OK == rc);
 
-    DevAssert(!&req_p->bearer_contexts);
+  DevAssert(!&req_p->bearer_contexts);
 
-    rc = nwGtpv2cMsgParserAddIe(
-        pMsgParser, NW_GTPV2C_IE_BEARER_CONTEXT, NW_GTPV2C_IE_INSTANCE_ZERO,
-        NW_GTPV2C_IE_PRESENCE_MANDATORY,
-        gtpv2c_bearer_context_to_be_created_within_create_bearer_request_ie_get,
-        &req_p->bearer_contexts);
-    DevAssert(NW_OK == rc);
+  rc = nwGtpv2cMsgParserAddIe(
+      pMsgParser, NW_GTPV2C_IE_BEARER_CONTEXT, NW_GTPV2C_IE_INSTANCE_ZERO,
+      NW_GTPV2C_IE_PRESENCE_MANDATORY,
+      gtpv2c_bearer_context_to_be_created_within_create_bearer_request_ie_get,
+      &req_p->bearer_contexts);
+  DevAssert(NW_OK == rc);
 
-    /** Add the PTI to inform to UEs. */
-    rc = nwGtpv2cMsgParserAddIe(
-        pMsgParser, NW_GTPV2C_IE_PROCEDURE_TRANSACTION_ID,
-        NW_GTPV2C_IE_INSTANCE_ZERO, NW_GTPV2C_IE_PRESENCE_CONDITIONAL,
-        gtpv2c_pti_ie_get, &req_p->pti);
-    DevAssert(NW_OK == rc);
+  /** Add the PTI to inform to UEs. */
+  rc = nwGtpv2cMsgParserAddIe(
+      pMsgParser, NW_GTPV2C_IE_PROCEDURE_TRANSACTION_ID,
+      NW_GTPV2C_IE_INSTANCE_ZERO, NW_GTPV2C_IE_PRESENCE_CONDITIONAL,
+      gtpv2c_pti_ie_get, &req_p->pti);
+  DevAssert(NW_OK == rc);
 
     // Run the parser
-    rc = nwGtpv2cMsgParserRun(
-        pMsgParser, (pUlpApi->hMsg), &offendingIeType, &offendingIeInstance,
-        &offendingIeLength);
+  rc = nwGtpv2cMsgParserRun(
+      pMsgParser, (pUlpApi->hMsg), &offendingIeType, &offendingIeInstance,
+      &offendingIeLength);
 
-    if (rc != NW_OK) {
-      // TODO: handle this case
-      free(message_p);
-      message_p = NULL;
-      rc        = nwGtpv2cMsgParserDelete(*stack_p, pMsgParser);
-      DevAssert(NW_OK == rc);
-      rc = nwGtpv2cMsgDelete(*stack_p, (pUlpApi->hMsg));
-      DevAssert(NW_OK == rc);
-      return RETURNerror;
-    }
-
-    rc = nwGtpv2cMsgParserDelete(*stack_p, pMsgParser);
+  if (rc != NW_OK) {
+    // TODO: handle this case
+    free(message_p);
+    message_p = NULL;
+    rc        = nwGtpv2cMsgParserDelete(*stack_p, pMsgParser);
     DevAssert(NW_OK == rc);
     rc = nwGtpv2cMsgDelete(*stack_p, (pUlpApi->hMsg));
     DevAssert(NW_OK == rc);
-    return send_msg_to_task(&s11_task_zmq_ctx, TASK_MME_APP, message_p);
+    return RETURNerror;
   }
-  return RETURNerror;
+
+  rc = nwGtpv2cMsgParserDelete(*stack_p, pMsgParser);
+  DevAssert(NW_OK == rc);
+  rc = nwGtpv2cMsgDelete(*stack_p, (pUlpApi->hMsg));
+  DevAssert(NW_OK == rc);
+  return send_msg_to_task(&s11_task_zmq_ctx, TASK_MME_APP, message_p);
 }
 
 //------------------------------------------------------------------------------

--- a/lte/gateway/c/core/oai/tasks/s11/s11_tasks.c
+++ b/lte/gateway/c/core/oai/tasks/s11/s11_tasks.c
@@ -149,7 +149,6 @@ static nw_rc_t s11_mme_send_udp_msg(
   int ret = 0;
 
   message_p = itti_alloc_new_message(TASK_S11, UDP_DATA_REQ);
-  if (message_p == NULL) return (NW_FAILURE);
   udp_data_req_p                = &message_p->ittiMsg.udp_data_req;
   udp_data_req_p->local_port    = localPort;
   udp_data_req_p->peer_address  = peerIpAddr;
@@ -298,9 +297,6 @@ static int handle_message(zloop_t* loop, zsock_t* reader, void* arg) {
 static int s11_send_init_udp(
     struct in_addr* address, struct in6_addr* address6, uint16_t port_number) {
   MessageDef* message_p = itti_alloc_new_message(TASK_S11, UDP_INIT);
-  if (message_p == NULL) {
-    return RETURNerror;
-  }
   message_p->ittiMsg.udp_init.port = port_number;
   if (address && address->s_addr) {
     message_p->ittiMsg.udp_init.in_addr = address;

--- a/lte/gateway/c/core/oai/tasks/s1ap/s1ap_mme_handlers.c
+++ b/lte/gateway/c/core/oai/tasks/s1ap/s1ap_mme_handlers.c
@@ -880,10 +880,6 @@ int s1ap_mme_handle_ue_cap_indication(
 
     message_p = itti_alloc_new_message(TASK_S1AP, S1AP_UE_CAPABILITIES_IND);
 
-    if (message_p == NULL) {
-      OAILOG_ERROR(LOG_S1AP, "message_p is NULL\n");
-      return RETURNerror;
-    }
     ue_cap_ind_p                 = &message_p->ittiMsg.s1ap_ue_cap_ind;
     ue_cap_ind_p->enb_ue_s1ap_id = ue_ref_p->enb_ue_s1ap_id;
     ue_cap_ind_p->mme_ue_s1ap_id = ue_ref_p->mme_ue_s1ap_id;
@@ -5252,10 +5248,6 @@ int s1ap_mme_handle_erab_rel_response(
       (const hash_key_t) ie->value.choice.MME_UE_S1AP_ID, &imsi64);
 
   message_p = itti_alloc_new_message(TASK_S1AP, S1AP_E_RAB_REL_RSP);
-  if (message_p == NULL) {
-    OAILOG_ERROR(LOG_S1AP, "itti_alloc_new_message Failed\n");
-    OAILOG_FUNC_RETURN(LOG_S1AP, RETURNerror);
-  }
   S1AP_E_RAB_REL_RSP(message_p).mme_ue_s1ap_id = ue_ref_p->mme_ue_s1ap_id;
   S1AP_E_RAB_REL_RSP(message_p).enb_ue_s1ap_id = ue_ref_p->enb_ue_s1ap_id;
   S1AP_E_RAB_REL_RSP(message_p).e_rab_rel_list.no_of_items           = 1;
@@ -5300,12 +5292,6 @@ int s1ap_mme_remove_stale_ue_context(
   OAILOG_FUNC_IN(LOG_S1AP);
   MessageDef* message_p = NULL;
   message_p = itti_alloc_new_message(TASK_S1AP, S1AP_REMOVE_STALE_UE_CONTEXT);
-  if (!message_p) {
-    OAILOG_ERROR(
-        LOG_S1AP,
-        "Failed to allocate memory for S1AP_REMOVE_STALE_UE_CONTEXT \n");
-    OAILOG_FUNC_RETURN(LOG_S1AP, RETURNerror);
-  }
   S1AP_REMOVE_STALE_UE_CONTEXT(message_p).enb_ue_s1ap_id = enb_ue_s1ap_id;
   S1AP_REMOVE_STALE_UE_CONTEXT(message_p).enb_id         = enb_id;
   OAILOG_INFO(
@@ -5322,12 +5308,6 @@ int s1ap_send_mme_ue_context_release(
     enum s1cause s1_release_cause, S1ap_Cause_t ie_cause, imsi64_t imsi64) {
   MessageDef* message_p = NULL;
   message_p = itti_alloc_new_message(TASK_S1AP, S1AP_UE_CONTEXT_RELEASE_REQ);
-  if (!message_p) {
-    OAILOG_ERROR(
-        LOG_S1AP,
-        "Failed to allocate memory for S1AP_REMOVE_STALE_UE_CONTEXT \n");
-    OAILOG_FUNC_RETURN(LOG_S1AP, RETURNerror);
-  }
 
   enb_description_t* enb_ref_p =
       s1ap_state_get_enb(state, ue_ref_p->sctp_assoc_id);

--- a/lte/gateway/c/core/oai/tasks/s1ap/s1ap_mme_itti_messaging.c
+++ b/lte/gateway/c/core/oai/tasks/s1ap/s1ap_mme_itti_messaging.c
@@ -47,13 +47,6 @@ int s1ap_mme_itti_send_sctp_request(
   MessageDef* message_p = NULL;
 
   message_p = itti_alloc_new_message(TASK_S1AP, SCTP_DATA_REQ);
-  if (message_p == NULL) {
-    OAILOG_ERROR(
-        LOG_S1AP,
-        "itti_alloc_new_message Failed for"
-        " SCTP_DATA_REQ \n");
-    OAILOG_FUNC_RETURN(LOG_S1AP, RETURNerror);
-  }
   SCTP_DATA_REQ(message_p).payload       = *payload;
   *payload                               = NULL;
   SCTP_DATA_REQ(message_p).assoc_id      = assoc_id;
@@ -79,13 +72,6 @@ int s1ap_mme_itti_nas_uplink_ind(
       "Sending NAS Uplink indication to NAS_MME_APP, mme_ue_s1ap_id = (%u) \n",
       ue_id);
   message_p = itti_alloc_new_message(TASK_S1AP, MME_APP_UPLINK_DATA_IND);
-  if (message_p == NULL) {
-    OAILOG_ERROR_UE(
-        LOG_S1AP, imsi64,
-        "itti_alloc_new_message Failed for"
-        " MME_APP_UPLINK_DATA_IND \n");
-    OAILOG_FUNC_RETURN(LOG_S1AP, RETURNerror);
-  }
   ITTI_MSG_LASTHOP_LATENCY(message_p)    = s1ap_last_msg_latency;
   MME_APP_UL_DATA_IND(message_p).ue_id   = ue_id;
   MME_APP_UL_DATA_IND(message_p).nas_msg = *payload;
@@ -120,13 +106,6 @@ int s1ap_mme_itti_nas_downlink_cnf(
   hashtable_uint64_ts_get(
       imsi_map->mme_ue_id_imsi_htbl, (const hash_key_t) ue_id, &imsi64);
   message_p = itti_alloc_new_message(TASK_S1AP, MME_APP_DOWNLINK_DATA_CNF);
-  if (message_p == NULL) {
-    OAILOG_ERROR_UE(
-        LOG_S1AP, imsi64,
-        "itti_alloc_new_message Failed for"
-        " MME_APP_DOWNLINK_DATA_CNF \n");
-    OAILOG_FUNC_RETURN(LOG_S1AP, RETURNerror);
-  }
   MME_APP_DL_DATA_CNF(message_p).ue_id = ue_id;
   if (is_success) {
     MME_APP_DL_DATA_CNF(message_p).err_code = AS_SUCCESS;
@@ -161,13 +140,6 @@ void s1ap_mme_itti_s1ap_initial_ue_message(
       (nas_msg_length < 1000), "Bad length for NAS message %lu",
       nas_msg_length);
   message_p = itti_alloc_new_message(TASK_S1AP, S1AP_INITIAL_UE_MESSAGE);
-  if (message_p == NULL) {
-    OAILOG_ERROR(
-        LOG_S1AP,
-        "itti_alloc_new_message Failed for"
-        " S1AP_INITIAL_UE_MESSAGE \n");
-    OAILOG_FUNC_OUT(LOG_S1AP);
-  }
 
   OAILOG_INFO(
       LOG_S1AP,
@@ -253,13 +225,6 @@ void s1ap_mme_itti_nas_non_delivery_ind(
   // TODO translate, insert, cause in message
   OAILOG_FUNC_IN(LOG_S1AP);
   message_p = itti_alloc_new_message(TASK_S1AP, MME_APP_DOWNLINK_DATA_REJ);
-  if (message_p == NULL) {
-    OAILOG_ERROR_UE(
-        LOG_S1AP, imsi64,
-        "itti_alloc_new_message Failed for"
-        " MME_APP_DOWNLINK_DATA_REJ \n");
-    OAILOG_FUNC_OUT(LOG_S1AP);
-  }
 
   MME_APP_DL_DATA_REJ(message_p).ue_id = ue_id;
   /* Mapping between asn1 definition and NAS definition */
@@ -286,10 +251,6 @@ int s1ap_mme_itti_s1ap_path_switch_request(
     uint16_t integrity_algorithm_capabilities, imsi64_t imsi64) {
   MessageDef* message_p = NULL;
   message_p = itti_alloc_new_message(TASK_S1AP, S1AP_PATH_SWITCH_REQUEST);
-  if (message_p == NULL) {
-    OAILOG_ERROR_UE(LOG_S1AP, imsi64, "itti_alloc_new_message Failed");
-    OAILOG_FUNC_RETURN(LOG_S1AP, RETURNerror);
-  }
   S1AP_PATH_SWITCH_REQUEST(message_p).sctp_assoc_id  = assoc_id;
   S1AP_PATH_SWITCH_REQUEST(message_p).enb_id         = enb_id;
   S1AP_PATH_SWITCH_REQUEST(message_p).enb_ue_s1ap_id = enb_ue_s1ap_id;
@@ -321,10 +282,6 @@ int s1ap_mme_itti_s1ap_handover_required(
     imsi64_t imsi64) {
   MessageDef* message_p = NULL;
   message_p = itti_alloc_new_message(TASK_S1AP, S1AP_HANDOVER_REQUIRED);
-  if (message_p == NULL) {
-    OAILOG_ERROR_UE(LOG_S1AP, imsi64, "itti_alloc_new_message Failed");
-    OAILOG_FUNC_RETURN(LOG_S1AP, RETURNerror);
-  }
   S1AP_HANDOVER_REQUIRED(message_p).sctp_assoc_id     = assoc_id;
   S1AP_HANDOVER_REQUIRED(message_p).enb_id            = enb_id;
   S1AP_HANDOVER_REQUIRED(message_p).cause             = cause;
@@ -352,10 +309,6 @@ int s1ap_mme_itti_s1ap_handover_request_ack(
     imsi64_t imsi64) {
   MessageDef* message_p = NULL;
   message_p = itti_alloc_new_message(TASK_S1AP, S1AP_HANDOVER_REQUEST_ACK);
-  if (message_p == NULL) {
-    OAILOG_ERROR_UE(LOG_S1AP, imsi64, "itti_alloc_new_message Failed");
-    OAILOG_FUNC_RETURN(LOG_S1AP, RETURNerror);
-  }
   S1AP_HANDOVER_REQUEST_ACK(message_p).mme_ue_s1ap_id     = mme_ue_s1ap_id;
   S1AP_HANDOVER_REQUEST_ACK(message_p).src_enb_ue_s1ap_id = src_enb_ue_s1ap_id;
   S1AP_HANDOVER_REQUEST_ACK(message_p).tgt_enb_ue_s1ap_id = tgt_enb_ue_s1ap_id;
@@ -383,10 +336,6 @@ int s1ap_mme_itti_s1ap_handover_notify(
     imsi64_t imsi64) {
   MessageDef* message_p = NULL;
   message_p = itti_alloc_new_message(TASK_S1AP, S1AP_HANDOVER_NOTIFY);
-  if (message_p == NULL) {
-    OAILOG_ERROR_UE(LOG_S1AP, imsi64, "itti_alloc_new_message Failed");
-    OAILOG_FUNC_RETURN(LOG_S1AP, RETURNerror);
-  }
 
   S1AP_HANDOVER_NOTIFY(message_p).mme_ue_s1ap_id = mme_ue_s1ap_id;
   S1AP_HANDOVER_NOTIFY(message_p).target_enb_id  = handover_state.target_enb_id;

--- a/lte/gateway/c/core/oai/tasks/sgs/sgs_service_handler.c
+++ b/lte/gateway/c/core/oai/tasks/sgs/sgs_service_handler.c
@@ -36,7 +36,6 @@ int handle_sgs_location_update_accept(
   MessageDef* message_p = NULL;
   int rc                = RETURNok;
   message_p = itti_alloc_new_message(TASK_SGS, SGSAP_LOCATION_UPDATE_ACC);
-  AssertFatal(message_p, "itti_alloc_new_message Failed");
   memset(
       (void*) &message_p->ittiMsg.sgsap_location_update_acc, 0,
       sizeof(itti_sgsap_location_update_acc_t));
@@ -63,7 +62,6 @@ int handle_sgs_location_update_reject(
    *send it to MME App for further processing
    */
   message_p = itti_alloc_new_message(TASK_SGS, SGSAP_LOCATION_UPDATE_REJ);
-  AssertFatal(message_p, "itti_alloc_new_message Failed");
   OAILOG_DEBUG(
       LOG_SGS,
       "Received SGS Location Update Reject message from FedGW with IMSI %s\n",
@@ -87,7 +85,6 @@ int handle_sgs_eps_detach_ack(
   itti_sgsap_eps_detach_ack_t* sgs_eps_detach_ack_p = NULL;
 
   message_p = itti_alloc_new_message(TASK_S6A, SGSAP_EPS_DETACH_ACK);
-  AssertFatal(message_p, "itti_alloc_new_message Failed");
   sgs_eps_detach_ack_p = &message_p->ittiMsg.sgsap_eps_detach_ack;
   memset((void*) sgs_eps_detach_ack_p, 0, sizeof(itti_sgsap_eps_detach_ack_t));
   OAILOG_DEBUG(LOG_SGS, "Received SGS EPS Detach Ack message from FedGW\n");
@@ -107,7 +104,6 @@ int handle_sgs_imsi_detach_ack(
   itti_sgsap_imsi_detach_ack_t* sgs_imsi_detach_ack_p = NULL;
 
   message_p = itti_alloc_new_message(TASK_S6A, SGSAP_IMSI_DETACH_ACK);
-  AssertFatal(message_p, "itti_alloc_new_message Failed");
   sgs_imsi_detach_ack_p = &message_p->ittiMsg.sgsap_imsi_detach_ack;
   memset(
       (void*) sgs_imsi_detach_ack_p, 0, sizeof(itti_sgsap_imsi_detach_ack_t));
@@ -128,7 +124,6 @@ int handle_sgs_downlink_unitdata(
   itti_sgsap_downlink_unitdata_t* sgs_dl_unit_data_p = NULL;
 
   message_p = itti_alloc_new_message(TASK_SGS, SGSAP_DOWNLINK_UNITDATA);
-  AssertFatal(message_p, "itti_alloc_new_message Failed");
   sgs_dl_unit_data_p = &message_p->ittiMsg.sgsap_downlink_unitdata;
   memset((void*) sgs_dl_unit_data_p, 0, sizeof(itti_sgsap_downlink_unitdata_t));
   OAILOG_DEBUG(LOG_SGS, "Received SGS Downlink UnitData message from FedGW\n");
@@ -147,7 +142,6 @@ int handle_sgs_release_req(const itti_sgsap_release_req_t* sgs_release_req_p) {
   itti_sgsap_release_req_t* sgs_rel_req_p = NULL;
 
   message_p = itti_alloc_new_message(TASK_SGS, SGSAP_RELEASE_REQ);
-  AssertFatal(message_p, "itti_alloc_new_message Failed");
   sgs_rel_req_p = &message_p->ittiMsg.sgsap_release_req;
   memset((void*) sgs_rel_req_p, 0, sizeof(itti_sgsap_release_req_t));
   OAILOG_DEBUG(LOG_SGS, "Received SGS Release Request message from FedGW\n");
@@ -170,11 +164,6 @@ int handle_sgs_mm_information_request(
   OAILOG_FUNC_IN(LOG_SGS);
 
   message_p = itti_alloc_new_message(TASK_SGS, SGSAP_MM_INFORMATION_REQ);
-  AssertFatal(
-      message_p,
-      "itti_alloc_new_message Failed while handling MM Information Request "
-      "from "
-      "MSC/VLR");
   itti_sgsap_mm_information_req_t* mm_information_req_p =
       &message_p->ittiMsg.sgsap_mm_information_req;
   memset(
@@ -204,8 +193,6 @@ int handle_sgs_service_abort_req(
 
   OAILOG_FUNC_IN(LOG_SGS);
   message_p = itti_alloc_new_message(TASK_SGS, SGSAP_SERVICE_ABORT_REQ);
-  AssertFatal(
-      message_p, "itti_alloc_new_message Failed for SGS Service Abort\n");
   memset(
       (void*) &message_p->ittiMsg.sgsap_service_abort_req, 0,
       sizeof(itti_sgsap_service_abort_req_t));
@@ -236,10 +223,6 @@ int handle_sgs_paging_request(
    *send it to MME App for further processing
    */
   message_p = itti_alloc_new_message(TASK_SGS, SGSAP_PAGING_REQUEST);
-  AssertFatal(
-      message_p,
-      "itti_alloc_new_message Failed while handling Paging Request from "
-      "MSC/VLR");
 
   itti_sgsap_paging_request_t* sgs_paging_req_p =
       &message_p->ittiMsg.sgsap_paging_request;
@@ -275,10 +258,6 @@ int handle_sgs_vlr_reset_indication(
    * send it to MME App for further processing
    */
   message_p = itti_alloc_new_message(TASK_SGS, SGSAP_VLR_RESET_INDICATION);
-  AssertFatal(
-      message_p,
-      "itti_alloc_new_message Failed while handling Reset Indication from "
-      "MSC/VLR");
 
   itti_sgsap_vlr_reset_indication_t* sgs_vlr_reset_ind_p =
       &message_p->ittiMsg.sgsap_vlr_reset_indication;
@@ -321,10 +300,6 @@ int handle_sgs_status_message(const itti_sgsap_status_t* sgs_status_pP) {
    * send it to MME App for further processing
    */
   message_p = itti_alloc_new_message(TASK_SGS, SGSAP_STATUS);
-  AssertFatal(
-      message_p,
-      "itti_alloc_new_message Failed while handling "
-      "SGS Status message from MSC/VLR \n");
 
   itti_sgsap_status_t* sgs_status_p = &message_p->ittiMsg.sgsap_status;
   memset((void*) sgs_status_p, 0, sizeof(itti_sgsap_status_t));
@@ -353,7 +328,6 @@ static void sgs_send_sgsap_vlr_reset_ack(void) {
 
   OAILOG_FUNC_IN(LOG_SGS);
   message_p = itti_alloc_new_message(TASK_SGS, SGSAP_VLR_RESET_ACK);
-  AssertFatal(message_p, "itti_alloc_new_message Failed: SGSAP_VLR_RESET_ACK");
   sgsap_reset_ack_pP = &message_p->ittiMsg.sgsap_vlr_reset_ack;
   memset((void*) sgsap_reset_ack_pP, 0, sizeof(itti_sgsap_vlr_reset_ack_t));
 
@@ -377,10 +351,6 @@ int handle_sgsap_alert_request(
    *send it to MME App for further processing
    */
   message_p = itti_alloc_new_message(TASK_SGS, SGSAP_ALERT_REQUEST);
-  AssertFatal(
-      message_p,
-      "itti_alloc_new_message Failed while handling Alert Request from "
-      "MSC/VLR");
 
   memset(
       (void*) &message_p->ittiMsg.sgsap_alert_request, 0,

--- a/lte/gateway/c/core/oai/tasks/sgw/pgw_handlers.c
+++ b/lte/gateway/c/core/oai/tasks/sgw/pgw_handlers.c
@@ -439,12 +439,6 @@ static int32_t spgw_build_and_send_s11_deactivate_bearer_req(
   OAILOG_FUNC_IN(LOG_SPGW_APP);
   MessageDef* message_p = itti_alloc_new_message(
       TASK_SPGW_APP, S11_NW_INITIATED_DEACTIVATE_BEARER_REQUEST);
-  if (message_p == NULL) {
-    OAILOG_ERROR_UE(
-        LOG_SPGW_APP, imsi64,
-        "itti_alloc_new_message failed for nw_initiated_deactv_bearer_req\n");
-    OAILOG_FUNC_RETURN(LOG_SPGW_APP, RETURNerror);
-  }
   itti_s11_nw_init_deactv_bearer_request_t* s11_bearer_deactv_request =
       &message_p->ittiMsg.s11_nw_init_deactv_bearer_request;
   memset(
@@ -535,13 +529,6 @@ static int spgw_build_and_send_s11_create_bearer_request(
 
   message_p = itti_alloc_new_message(
       TASK_SPGW_APP, S11_NW_INITIATED_ACTIVATE_BEARER_REQUEST);
-  if (!message_p) {
-    OAILOG_ERROR_UE(
-        LOG_SPGW_APP, spgw_ctxt_p->sgw_eps_bearer_context_information.imsi64,
-        "Failed to allocate message_p for"
-        "S11_NW_INITIATED_BEARER_ACTV_REQUEST\n");
-    OAILOG_FUNC_RETURN(LOG_SPGW_APP, rc);
-  }
 
   itti_s11_nw_init_actv_bearer_request_t* s11_actv_bearer_request =
       &message_p->ittiMsg.s11_nw_init_actv_bearer_request;

--- a/lte/gateway/c/core/oai/tasks/sgw/sgw_handlers.c
+++ b/lte/gateway/c/core/oai/tasks/sgw/sgw_handlers.c
@@ -318,10 +318,6 @@ int sgw_handle_sgi_endpoint_created(
   message_p =
       itti_alloc_new_message(TASK_SPGW_APP, S11_CREATE_SESSION_RESPONSE);
 
-  if (message_p == NULL) {
-    OAILOG_FUNC_RETURN(LOG_SPGW_APP, RETURNerror);
-  }
-
   create_session_response_p = &message_p->ittiMsg.s11_create_session_response;
   memset(
       create_session_response_p, 0, sizeof(itti_s11_create_session_response_t));
@@ -666,13 +662,6 @@ void sgw_handle_sgi_endpoint_updated(
       resp_pP->context_teid);
   message_p = itti_alloc_new_message(TASK_SPGW_APP, S11_MODIFY_BEARER_RESPONSE);
 
-  if (!message_p) {
-    OAILOG_ERROR_UE(
-        LOG_SPGW_APP, imsi64,
-        "Failed to allocate memory for S11_MODIFY_BEARER_RESPONSE\n");
-    OAILOG_FUNC_OUT(LOG_SPGW_APP);
-  }
-
   modify_response_p = &message_p->ittiMsg.s11_modify_bearer_response;
 
   s_plus_p_gw_eps_bearer_context_information_t* new_bearer_ctxt_info_p =
@@ -889,13 +878,6 @@ int send_mbr_failure(
   MessageDef* message_p =
       itti_alloc_new_message(TASK_SPGW_APP, S11_MODIFY_BEARER_RESPONSE);
 
-  if (!message_p) {
-    OAILOG_ERROR_UE(
-        module, imsi64,
-        "S11_MODIFY_BEARER_RESPONSE memory allocation failed\n");
-    OAILOG_FUNC_RETURN(module, RETURNerror);
-  }
-
   itti_s11_modify_bearer_response_t* modify_response_p =
       &message_p->ittiMsg.s11_modify_bearer_response;
 
@@ -1052,9 +1034,6 @@ int sgw_handle_delete_session_request(
   message_p =
       itti_alloc_new_message(TASK_SPGW_APP, S11_DELETE_SESSION_RESPONSE);
 
-  if (!message_p) {
-    OAILOG_FUNC_RETURN(LOG_SPGW_APP, RETURNerror);
-  }
   delete_session_resp_p = &message_p->ittiMsg.s11_delete_session_response;
   OAILOG_INFO_UE(
       LOG_SPGW_APP, imsi64,
@@ -1375,13 +1354,6 @@ void handle_s5_create_session_response(
   // Send Create Session Response with Nack
   message_p =
       itti_alloc_new_message(TASK_SPGW_APP, S11_CREATE_SESSION_RESPONSE);
-  if (!message_p) {
-    OAILOG_ERROR_UE(
-        LOG_SPGW_APP,
-        new_bearer_ctxt_info_p->sgw_eps_bearer_context_information.imsi64,
-        "Message Create Session Response allocation failed\n");
-    OAILOG_FUNC_OUT(LOG_SPGW_APP);
-  }
   create_session_response_p = &message_p->ittiMsg.s11_create_session_response;
   memset(
       create_session_response_p, 0, sizeof(itti_s11_create_session_response_t));
@@ -1449,12 +1421,6 @@ int sgw_handle_suspend_notification(
 
   message_p = itti_alloc_new_message(TASK_SPGW_APP, S11_SUSPEND_ACKNOWLEDGE);
 
-  if (!message_p) {
-    OAILOG_ERROR_UE(
-        LOG_SPGW_APP, imsi64,
-        "Unable to allocate itti message: S11_SUSPEND_ACKNOWLEDGE \n");
-    OAILOG_FUNC_RETURN(LOG_SPGW_APP, RETURNerror);
-  }
   suspend_acknowledge_p = &message_p->ittiMsg.s11_suspend_acknowledge;
   memset(
       (void*) suspend_acknowledge_p, 0, sizeof(itti_s11_suspend_acknowledge_t));
@@ -2194,12 +2160,6 @@ void sgw_send_release_access_bearer_response(
       NULL;
   MessageDef* message_p =
       itti_alloc_new_message(module, S11_RELEASE_ACCESS_BEARERS_RESPONSE);
-  if (message_p == NULL) {
-    OAILOG_ERROR_UE(
-        module, imsi64,
-        "Failed to allocate memory for Release Access Bearer Response \n");
-    OAILOG_FUNC_OUT(module);
-  }
   message_p->ittiMsgHeader.imsi = imsi64;
   release_access_bearers_resp_p =
       &message_p->ittiMsg.s11_release_access_bearers_response;

--- a/lte/gateway/c/core/oai/tasks/sgw_s8/sgw_s8_handlers.c
+++ b/lte/gateway/c/core/oai/tasks/sgw_s8/sgw_s8_handlers.c
@@ -370,12 +370,6 @@ static int sgw_s8_send_create_session_response(
   itti_s11_create_session_response_t* create_session_response_p = NULL;
 
   message_p = itti_alloc_new_message(TASK_SGW_S8, S11_CREATE_SESSION_RESPONSE);
-  if (message_p == NULL) {
-    OAILOG_CRITICAL_UE(
-        LOG_SGW_S8, sgw_context_p->imsi64,
-        "Failed to allocate memory for S11_create_session_response \n");
-    OAILOG_FUNC_RETURN(LOG_SGW_S8, RETURNerror);
-  }
   if (!sgw_context_p) {
     OAILOG_ERROR_UE(
         LOG_SGW_S8, sgw_context_p->imsi64, "sgw_context_p is NULL \n");
@@ -675,13 +669,6 @@ static void sgw_send_modify_bearer_response(
       resp_pP->context_teid);
   message_p = itti_alloc_new_message(TASK_SGW_S8, S11_MODIFY_BEARER_RESPONSE);
 
-  if (!message_p) {
-    OAILOG_ERROR_UE(
-        LOG_SGW_S8, imsi64,
-        "Failed to allocate memory for S11_MODIFY_BEARER_RESPONSE\n");
-    OAILOG_FUNC_OUT(LOG_SGW_S8);
-  }
-
   modify_response_p = &message_p->ittiMsg.s11_modify_bearer_response;
 
   if (sgw_context_p) {
@@ -976,14 +963,6 @@ void sgw_s8_handle_delete_session_response(
     OAILOG_FUNC_OUT(LOG_SGW_S8);
   }
   message_p = itti_alloc_new_message(TASK_SGW_S8, S11_DELETE_SESSION_RESPONSE);
-  if (message_p == NULL) {
-    OAILOG_CRITICAL_UE(
-        LOG_SGW_S8, sgw_context_p->imsi64,
-        "Failed to allocate memory for S11_delete_session_response for "
-        "context_teid " TEID_FMT "\n",
-        session_rsp_p->context_teid);
-    OAILOG_FUNC_OUT(LOG_SGW_S8);
-  }
 
   delete_session_response_p = &message_p->ittiMsg.s11_delete_session_response;
   message_p->ittiMsgHeader.imsi = imsi64;
@@ -1026,12 +1005,6 @@ static void sgw_s8_send_failed_delete_session_response(
   teid_t teid                                                   = 0;
 
   message_p = itti_alloc_new_message(TASK_SGW_S8, S11_DELETE_SESSION_RESPONSE);
-  if (message_p == NULL) {
-    OAILOG_CRITICAL_UE(
-        LOG_SGW_S8, sgw_context_p->imsi64,
-        "Failed to allocate memory for S11_delete_session_response \n");
-    OAILOG_FUNC_OUT(LOG_SGW_S8);
-  }
 
   delete_session_response_p = &message_p->ittiMsg.s11_delete_session_response;
   message_p->ittiMsgHeader.imsi = imsi64;

--- a/lte/gateway/c/core/oai/tasks/sms_orc8r/sms_orc8r_service_handler.c
+++ b/lte/gateway/c/core/oai/tasks/sms_orc8r/sms_orc8r_service_handler.c
@@ -34,7 +34,6 @@ int handle_sms_orc8r_downlink_unitdata(
   itti_sgsap_downlink_unitdata_t* sgs_dl_unit_data_p = NULL;
 
   message_p = itti_alloc_new_message(TASK_SMS_ORC8R, SGSAP_DOWNLINK_UNITDATA);
-  AssertFatal(message_p, "itti_alloc_new_message Failed");
   sgs_dl_unit_data_p = &message_p->ittiMsg.sgsap_downlink_unitdata;
   memset((void*) sgs_dl_unit_data_p, 0, sizeof(itti_sgsap_downlink_unitdata_t));
 

--- a/lte/gateway/c/core/oai/tasks/udp/udp_primitives_server.c
+++ b/lte/gateway/c/core/oai/tasks/udp/udp_primitives_server.c
@@ -147,7 +147,6 @@ static void udp_server_receive_and_process(
       AssertFatal(
           sizeof(udp_sock_pP->buffer) >= bytes_received, "UDP BUFFER OVERFLOW");
       message_p = itti_alloc_new_message(TASK_UDP, UDP_DATA_IND);
-      DevAssert(message_p != NULL);
       udp_data_ind_p = &message_p->ittiMsg.udp_data_ind;
       memcpy(udp_data_ind_p->msgBuf, udp_sock_pP->buffer, bytes_received);
 


### PR DESCRIPTION
Signed-off-by: Andrei Lee <andreilee@fb.com>

## Summary

Function `itti_alloc_new_message(..)` is documented to return NULL values when out of memory. This is untrue as there's an `AssertFatal` call inside which will cause MME to exit when out of memory. Modified the documentation block for this function, and also all callers of the function to no longer do any NULL checks on the return value

## Test Plan

Only build MME

```
vagrant@magma-dev:~/magma/lte/gateway$ make build_oai
.
.
.
[7/7] Completed 'MagmaCore'
vagrant@magma-dev:~/magma/lte/gateway$
```

## Additional Information

- [ ] This change is backwards-breaking
