### PR TITLE
[Agw][MME] Add itti_alloc_new_message_fatal to disambiguate expectation

### DIFF
--- a/lte/gateway/c/core/oai/common/async_system.c
+++ b/lte/gateway/c/core/oai/common/async_system.c
@@ -141,7 +141,8 @@ status_code_e async_system_command(
     return RETURNerror;
   }
   MessageDef* message_p = NULL;
-  message_p = itti_alloc_new_message(sender_itti_task, ASYNC_SYSTEM_COMMAND);
+  message_p             = DEPRECATEDitti_alloc_new_message_fatal(
+      sender_itti_task, ASYNC_SYSTEM_COMMAND);
   ASYNC_SYSTEM_COMMAND(message_p).system_command    = bstr;
   ASYNC_SYSTEM_COMMAND(message_p).is_abort_on_error = is_abort_on_error;
   status_code_e result                              = send_msg_to_task(

--- a/lte/gateway/c/core/oai/common/common_defs.h
+++ b/lte/gateway/c/core/oai/common/common_defs.h
@@ -105,8 +105,8 @@ typedef enum {
  * Inspired by Google's absl::Status
  */
 typedef enum {
-  RETURNerror   = -1,   // An internal invariant is broken
-  RETURNok      = 0,    // Ok
+  RETURNerror = -1,  // An internal invariant is broken
+  RETURNok    = 0,   // Ok
 } status_code_e;
 
 /* This enum should match with the ModeMapItem_FederatedMode enum

--- a/lte/gateway/c/core/oai/common/redis_utils/redis_client.cpp
+++ b/lte/gateway/c/core/oai/common/redis_utils/redis_client.cpp
@@ -55,7 +55,8 @@ void RedisClient::init_db_connection() {
   is_connected_ = true;
 }
 
-status_code_e RedisClient::write(const std::string& key, const std::string& value) {
+status_code_e RedisClient::write(
+    const std::string& key, const std::string& value) {
   if (!is_connected()) {
     return RETURNerror;
   }
@@ -103,7 +104,8 @@ status_code_e RedisClient::write_proto_str(
   return RETURNok;
 }
 
-status_code_e RedisClient::read_proto(const std::string& key, Message& proto_msg) {
+status_code_e RedisClient::read_proto(
+    const std::string& key, Message& proto_msg) {
   orc8r::RedisState wrapper_proto = orc8r::RedisState();
   if (read_redis_state(key, wrapper_proto) != RETURNok) {
     return RETURNerror;
@@ -126,7 +128,8 @@ int RedisClient::read_version(const std::string& key) {
   return wrapper_proto.version();
 }
 
-status_code_e RedisClient::clear_keys(const std::vector<std::string>& keys_to_clear) {
+status_code_e RedisClient::clear_keys(
+    const std::vector<std::string>& keys_to_clear) {
   auto db_write = db_client_->del(keys_to_clear);
   db_client_->sync_commit();
   auto reply = db_write.get();

--- a/lte/gateway/c/core/oai/common/redis_utils/redis_client.h
+++ b/lte/gateway/c/core/oai/common/redis_utils/redis_client.h
@@ -79,7 +79,8 @@ class RedisClient {
    * @param key
    * @return response code of operation
    */
-  status_code_e read_proto(const std::string& key, google::protobuf::Message& proto_msg);
+  status_code_e read_proto(
+      const std::string& key, google::protobuf::Message& proto_msg);
 
   int read_version(const std::string& key);
 
@@ -99,7 +100,8 @@ class RedisClient {
    * @param state_out
    * @return response code of operation
    */
-  status_code_e read_redis_state(const std::string& key, orc8r::RedisState& state_out);
+  status_code_e read_redis_state(
+      const std::string& key, orc8r::RedisState& state_out);
 
   /**
    * Takes a string and parses it to protobuf Message

--- a/lte/gateway/c/core/oai/lib/itti/intertask_interface.c
+++ b/lte/gateway/c/core/oai/lib/itti/intertask_interface.c
@@ -317,6 +317,14 @@ MessageDef* itti_alloc_new_message(
       origin_task_id, message_id, itti_desc.messages_info[message_id].size);
 }
 
+MessageDef* DEPRECATEDitti_alloc_new_message_fatal(
+    task_id_t origin_task_id, MessagesIds message_id) {
+  MessageDef* message_p = itti_alloc_new_message_sized(
+      origin_task_id, message_id, itti_desc.messages_info[message_id].size);
+  AssertFatal(message_p, "DEPRECATEDitti_alloc_new_message_fatal Failed");
+  return message_p;
+}
+
 status_code_e itti_create_task(
     task_id_t task_id, void* (*start_routine)(void*), void* args_p) {
   thread_id_t thread_id = TASK_GET_THREAD_ID(task_id);
@@ -491,11 +499,11 @@ void itti_wait_tasks_end(task_zmq_ctx_t* task_ctx) {
   }
 }
 
-void send_terminate_message(task_zmq_ctx_t* task_zmq_ctx) {
+void send_terminate_message_fatal(task_zmq_ctx_t* task_zmq_ctx) {
   MessageDef* terminate_message_p;
 
-  terminate_message_p =
-      itti_alloc_new_message(task_zmq_ctx->task_id, TERMINATE_MESSAGE);
+  terminate_message_p = DEPRECATEDitti_alloc_new_message_fatal(
+      task_zmq_ctx->task_id, TERMINATE_MESSAGE);
   send_broadcast_msg(task_zmq_ctx, terminate_message_p);
 }
 

--- a/lte/gateway/c/core/oai/lib/itti/intertask_interface.h
+++ b/lte/gateway/c/core/oai/lib/itti/intertask_interface.h
@@ -191,6 +191,16 @@ const char* itti_get_task_name(task_id_t task_id);
 MessageDef* itti_alloc_new_message(
     task_id_t origin_task_id, MessagesIds message_id);
 
+/** \brief Alloc and memset(0) a new itti message.
+ * @note DEPRECATED: Use itti_get_associated_imsi
+ * \param origin_task_id Task ID of the sending task
+ * \param message_id Message ID
+ * @returns newly allocated mesage ref
+ * @note Asserts that newly allocated message ref is non-NULL
+ **/
+MessageDef* DEPRECATEDitti_alloc_new_message_fatal(
+    task_id_t origin_task_id, MessagesIds message_id);
+
 /**
  * \brief Returns IMSI of ITTI task
  * @param msg MessageDef struct
@@ -206,8 +216,9 @@ void itti_wait_tasks_end(task_zmq_ctx_t* task_ctx);
 
 /** \brief Send a termination message to all tasks.
  * \param task_id task that is broadcasting the message.
+ * @note Asserts that newly allocated message ref is non-NULL
  **/
-void send_terminate_message(task_zmq_ctx_t* task_zmq_ctx);
+void send_terminate_message_fatal(task_zmq_ctx_t* task_zmq_ctx);
 
 /**
  * \brief Returns the latency of the message

--- a/lte/gateway/c/core/oai/lib/itti/signals.c
+++ b/lte/gateway/c/core/oai/lib/itti/signals.c
@@ -177,7 +177,7 @@ int signal_handle(int* end, task_zmq_ctx_t* task_ctx) {
       case SIGINT:
       case SIGTERM:
         printf("Received SIGINT or SIGTERM\n");
-        send_terminate_message(task_ctx);
+        send_terminate_message_fatal(task_ctx);
         *end = 1;
         break;
 

--- a/lte/gateway/c/core/oai/lib/itti/timer.c
+++ b/lte/gateway/c/core/oai/lib/itti/timer.c
@@ -89,9 +89,10 @@ int timer_handle_signal(siginfo_t* info, task_zmq_ctx_t* task_ctx) {
   timer_p = (struct timer_elm_s*) info->si_ptr;
   // LG: To many traces for msc timer:
   // TMR_DEBUG("Timer with id 0x%lx has expired", (long)timer_p->timer);
-  task_id         = timer_p->task_id;
-  message_p       = itti_alloc_new_message(TASK_MAIN, TIMER_HAS_EXPIRED);
-  timer_expired_p = &message_p->ittiMsg.timer_has_expired;
+  task_id = timer_p->task_id;
+  message_p =
+      DEPRECATEDitti_alloc_new_message_fatal(TASK_MAIN, TIMER_HAS_EXPIRED);
+  timer_expired_p           = &message_p->ittiMsg.timer_has_expired;
   timer_expired_p->timer_id = (long) timer_p->timer;
   timer_expired_p->arg      = timer_p->timer_arg;
 

--- a/lte/gateway/c/core/oai/lib/message_utils/service303_message_utils.c
+++ b/lte/gateway/c/core/oai/lib/message_utils/service303_message_utils.c
@@ -27,9 +27,11 @@ int send_app_health_to_service303(
     task_zmq_ctx_t* task_zmq_ctx_p, task_id_t origin_id, bool healthy) {
   MessageDef* message_p;
   if (healthy) {
-    message_p = itti_alloc_new_message(origin_id, APPLICATION_HEALTHY_MSG);
+    message_p = DEPRECATEDitti_alloc_new_message_fatal(
+        origin_id, APPLICATION_HEALTHY_MSG);
   } else {
-    message_p = itti_alloc_new_message(origin_id, APPLICATION_UNHEALTHY_MSG);
+    message_p = DEPRECATEDitti_alloc_new_message_fatal(
+        origin_id, APPLICATION_UNHEALTHY_MSG);
   }
   return send_msg_to_task(task_zmq_ctx_p, TASK_SERVICE303, message_p);
 }

--- a/lte/gateway/c/core/oai/oai_mme/oai_mme.c
+++ b/lte/gateway/c/core/oai/oai_mme/oai_mme.c
@@ -197,7 +197,8 @@ int main(int argc, char* argv[]) {
 static void send_timer_recovery_message(void) {
   MessageDef* recovery_message_p;
 
-  recovery_message_p = itti_alloc_new_message(TASK_UNKNOWN, RECOVERY_MESSAGE);
+  recovery_message_p =
+      DEPRECATEDitti_alloc_new_message_fatal(TASK_UNKNOWN, RECOVERY_MESSAGE);
   send_broadcast_msg(&main_zmq_ctx, recovery_message_p);
   return;
 }

--- a/lte/gateway/c/core/oai/tasks/grpc_service/spgw_service_handler.c
+++ b/lte/gateway/c/core/oai/tasks/grpc_service/spgw_service_handler.c
@@ -30,7 +30,7 @@ extern task_zmq_ctx_t grpc_service_task_zmq_ctx;
 int send_activate_bearer_request_itti(
     itti_gx_nw_init_actv_bearer_request_t* itti_msg) {
   OAILOG_DEBUG(LOG_SPGW_APP, "Sending nw_init_actv_bearer_request to SPGW \n");
-  MessageDef* message_p = itti_alloc_new_message(
+  MessageDef* message_p = DEPRECATEDitti_alloc_new_message_fatal(
       TASK_GRPC_SERVICE, GX_NW_INITIATED_ACTIVATE_BEARER_REQ);
   message_p->ittiMsg.gx_nw_init_actv_bearer_request = *itti_msg;
 
@@ -42,7 +42,7 @@ int send_activate_bearer_request_itti(
 int send_deactivate_bearer_request_itti(
     itti_gx_nw_init_deactv_bearer_request_t* itti_msg) {
   OAILOG_DEBUG(LOG_SPGW_APP, "Sending spgw_nw_init_deactv_bearer_request\n");
-  MessageDef* message_p = itti_alloc_new_message(
+  MessageDef* message_p = DEPRECATEDitti_alloc_new_message_fatal(
       TASK_GRPC_SERVICE, GX_NW_INITIATED_DEACTIVATE_BEARER_REQ);
   message_p->ittiMsg.gx_nw_init_deactv_bearer_request = *itti_msg;
 

--- a/lte/gateway/c/core/oai/tasks/mme_app/mme_app_bearer.c
+++ b/lte/gateway/c/core/oai/tasks/mme_app/mme_app_bearer.c
@@ -394,7 +394,7 @@ void mme_app_handle_conn_est_cnf(
       OAILOG_FUNC_OUT(LOG_MME_APP);
     }
   }
-  message_p = itti_alloc_new_message(
+  message_p = DEPRECATEDitti_alloc_new_message_fatal(
       TASK_MME_APP, MME_APP_CONNECTION_ESTABLISHMENT_CNF);
   establishment_cnf_p =
       &message_p->ittiMsg.mme_app_connection_establishment_cnf;
@@ -2069,8 +2069,8 @@ static void notify_s1ap_new_ue_mme_s1ap_id_association(
     OAILOG_ERROR(LOG_MME_APP, " NULL UE context pointer!\n");
     OAILOG_FUNC_OUT(LOG_MME_APP);
   }
-  message_p =
-      itti_alloc_new_message(TASK_MME_APP, MME_APP_S1AP_MME_UE_ID_NOTIFICATION);
+  message_p = DEPRECATEDitti_alloc_new_message_fatal(
+      TASK_MME_APP, MME_APP_S1AP_MME_UE_ID_NOTIFICATION);
   notification_p = &message_p->ittiMsg.mme_app_s1ap_mme_ue_id_notification;
   memset(notification_p, 0, sizeof(itti_mme_app_s1ap_mme_ue_id_notification_t));
   notification_p->enb_ue_s1ap_id = ue_context_p->enb_ue_s1ap_id;
@@ -3279,7 +3279,8 @@ void mme_app_handle_handover_required(
         handover_required_p->mme_ue_s1ap_id);
   }
 
-  message_p    = itti_alloc_new_message(TASK_MME_APP, MME_APP_HANDOVER_REQUEST);
+  message_p = DEPRECATEDitti_alloc_new_message_fatal(
+      TASK_MME_APP, MME_APP_HANDOVER_REQUEST);
   ho_request_p = &message_p->ittiMsg.mme_app_handover_request;
 
   // get the ue security capabilities

--- a/lte/gateway/c/core/oai/tasks/mme_app/mme_app_context.c
+++ b/lte/gateway/c/core/oai/tasks/mme_app/mme_app_context.c
@@ -1754,7 +1754,8 @@ void mme_app_handle_enb_reset_req(
   }
 
   // Send Reset Ack to S1AP module
-  msg = itti_alloc_new_message(TASK_MME_APP, S1AP_ENB_INITIATED_RESET_ACK);
+  msg = DEPRECATEDitti_alloc_new_message_fatal(
+      TASK_MME_APP, S1AP_ENB_INITIATED_RESET_ACK);
   reset_ack = &S1AP_ENB_INITIATED_RESET_ACK(msg);
 
   // ue_to_reset_list needs to be freed by S1AP module

--- a/lte/gateway/c/core/oai/tasks/mme_app/mme_app_itti_messaging.c
+++ b/lte/gateway/c/core/oai/tasks/mme_app/mme_app_itti_messaging.c
@@ -209,7 +209,8 @@ int mme_app_send_s11_create_session_req(
     OAILOG_FUNC_RETURN(LOG_MME_APP, RETURNerror);
   }
 
-  message_p = itti_alloc_new_message(TASK_MME_APP, S11_CREATE_SESSION_REQUEST);
+  message_p = DEPRECATEDitti_alloc_new_message_fatal(
+      TASK_MME_APP, S11_CREATE_SESSION_REQUEST);
   /*
    * WARNING:
    * Some parameters should be provided by NAS Layer:

--- a/lte/gateway/c/core/oai/tasks/mme_app/mme_app_sgsap_location_update.c
+++ b/lte/gateway/c/core/oai/tasks/mme_app/mme_app_sgsap_location_update.c
@@ -216,7 +216,8 @@ static int build_sgs_status(
   OAILOG_FUNC_IN(LOG_MME_APP);
 
   MessageDef* message_p = NULL;
-  message_p             = itti_alloc_new_message(TASK_MME_APP, SGSAP_STATUS);
+  message_p =
+      DEPRECATEDitti_alloc_new_message_fatal(TASK_MME_APP, SGSAP_STATUS);
   itti_sgsap_status_t* sgsap_status = &message_p->ittiMsg.sgsap_status;
   memset((void*) sgsap_status, 0, sizeof(itti_sgsap_status_t));
 
@@ -436,7 +437,8 @@ int send_itti_sgsap_location_update_req(ue_mm_context_t* ue_context_p) {
   int rc                = RETURNok;
   uint8_t tau_updt_type = -1;
 
-  message_p = itti_alloc_new_message(TASK_MME_APP, SGSAP_LOCATION_UPDATE_REQ);
+  message_p = DEPRECATEDitti_alloc_new_message_fatal(
+      TASK_MME_APP, SGSAP_LOCATION_UPDATE_REQ);
   itti_sgsap_location_update_req_t* sgsap_location_update_req =
       &message_p->ittiMsg.sgsap_location_update_req;
   memset(

--- a/lte/gateway/c/core/oai/tasks/mme_app/mme_app_transport.c
+++ b/lte/gateway/c/core/oai/tasks/mme_app/mme_app_transport.c
@@ -52,7 +52,8 @@ int mme_app_handle_nas_dl_req(
   int rc                          = RETURNok;
   enb_ue_s1ap_id_t enb_ue_s1ap_id = 0;
 
-  message_p = itti_alloc_new_message(TASK_MME_APP, S1AP_NAS_DL_DATA_REQ);
+  message_p = DEPRECATEDitti_alloc_new_message_fatal(
+      TASK_MME_APP, S1AP_NAS_DL_DATA_REQ);
 
   mme_app_desc_t* mme_app_desc_p = get_mme_nas_state(false);
   if (!mme_app_desc_p) {

--- a/lte/gateway/c/core/oai/tasks/nas/api/mme/mme_api.c
+++ b/lte/gateway/c/core/oai/tasks/nas/api/mme/mme_api.c
@@ -240,8 +240,7 @@ int mme_api_get_emm_config(
     }
     default:
       OAILOG_ERROR(
-          LOG_NAS,
-          "BAD TAI list configuration, unknown TAI list type %u\n",
+          LOG_NAS, "BAD TAI list configuration, unknown TAI list type %u\n",
           mme_config_p->served_tai.list_type);
       OAILOG_FUNC_RETURN(LOG_NAS, RETURNerror);
   }

--- a/lte/gateway/c/core/oai/tasks/nas/emm/emm_main.c
+++ b/lte/gateway/c/core/oai/tasks/nas/emm/emm_main.c
@@ -63,8 +63,9 @@ void emm_main_initialize(const mme_config_t* mme_config_p) {
    */
   memset(&_emm_data.conf, 0, sizeof(_emm_data.conf));
   if (mme_api_get_emm_config(&_emm_data.conf, mme_config_p) != RETURNok) {
-    Fatal("EMM-MAIN  - Failed to get all required MME config data, "
-          "check the error logs for missing configs");
+    Fatal(
+        "EMM-MAIN  - Failed to get all required MME config data, "
+        "check the error logs for missing configs");
   }
   OAILOG_FUNC_OUT(LOG_NAS_EMM);
 }

--- a/lte/gateway/c/core/oai/tasks/ngap/ngap_amf.c
+++ b/lte/gateway/c/core/oai/tasks/ngap/ngap_amf.c
@@ -57,7 +57,7 @@ static int ngap_send_init_sctp(void) {
   // Create and alloc new message
   MessageDef* message_p = NULL;
 
-  message_p = itti_alloc_new_message(TASK_NGAP, SCTP_INIT_MSG);
+  message_p = DEPRECATEDitti_alloc_new_message_fatal(TASK_NGAP, SCTP_INIT_MSG);
   message_p->ittiMsg.sctpInit.port         = NGAP_PORT_NUMBER;
   message_p->ittiMsg.sctpInit.ppid         = NGAP_SCTP_PPID;
   message_p->ittiMsg.sctpInit.ipv4         = 1;

--- a/lte/gateway/c/core/oai/tasks/ngap/ngap_amf_handlers.c
+++ b/lte/gateway/c/core/oai/tasks/ngap/ngap_amf_handlers.c
@@ -748,8 +748,8 @@ int ngap_amf_handle_initial_context_setup_response(
     }
   }
   ue_ref_p->ng_ue_state = NGAP_UE_CONNECTED;
-  message_p =
-      itti_alloc_new_message(TASK_NGAP, AMF_APP_INITIAL_CONTEXT_SETUP_RSP);
+  message_p             = DEPRECATEDitti_alloc_new_message_fatal(
+      TASK_NGAP, AMF_APP_INITIAL_CONTEXT_SETUP_RSP);
   AMF_APP_INITIAL_CONTEXT_SETUP_RSP(message_p).ue_id = ue_ref_p->amf_ue_ngap_id;
 
   if (ie) {
@@ -994,8 +994,8 @@ int ngap_amf_handle_ue_context_release_request(
           imsi_map->amf_ue_id_imsi_htbl, (const hash_key_t) amf_ue_ngap_id,
           &imsi64);
 
-      message_p =
-          itti_alloc_new_message(TASK_NGAP, NGAP_UE_CONTEXT_RELEASE_REQ);
+      message_p = DEPRECATEDitti_alloc_new_message_fatal(
+          TASK_NGAP, NGAP_UE_CONTEXT_RELEASE_REQ);
 
       NGAP_UE_CONTEXT_RELEASE_REQ(message_p).amf_ue_ngap_id =
           ue_ref_p->amf_ue_ngap_id;
@@ -1331,8 +1331,8 @@ int ngap_amf_handle_initial_context_setup_failure(
           cause_type);
       OAILOG_FUNC_RETURN(LOG_NGAP, RETURNerror);
   }
-  message_p =
-      itti_alloc_new_message(TASK_NGAP, AMF_APP_INITIAL_CONTEXT_SETUP_FAILURE);
+  message_p = DEPRECATEDitti_alloc_new_message_fatal(
+      TASK_NGAP, AMF_APP_INITIAL_CONTEXT_SETUP_FAILURE);
   memset(
       (void*) &message_p->ittiMsg.amf_app_initial_context_setup_failure, 0,
       sizeof(itti_amf_app_initial_context_setup_failure_t));
@@ -1382,8 +1382,8 @@ bool ngap_send_gnb_deregistered_ind(
   hashtable_ts_get(ngap_ue_state, (const hash_key_t) dataP, (void**) &ue_ref_p);
   if (ue_ref_p) {
     if (arg->current_ue_index == 0) {
-      arg->message_p =
-          itti_alloc_new_message(TASK_NGAP, NGAP_GNB_DEREGISTERED_IND);
+      arg->message_p = DEPRECATEDitti_alloc_new_message_fatal(
+          TASK_NGAP, NGAP_GNB_DEREGISTERED_IND);
     }
     if (ue_ref_p->amf_ue_ngap_id == INVALID_AMF_UE_NGAP_ID) {
       /*
@@ -1535,8 +1535,8 @@ void ngap_amf_handle_ue_context_rel_comp_timer_expiry(
   /*
    * Remove UE context and inform AMF_APP.
    */
-  message_p =
-      itti_alloc_new_message(TASK_NGAP, NGAP_UE_CONTEXT_RELEASE_COMPLETE);
+  message_p = DEPRECATEDitti_alloc_new_message_fatal(
+      TASK_NGAP, NGAP_UE_CONTEXT_RELEASE_COMPLETE);
   memset(
       (void*) &message_p->ittiMsg.ngap_ue_context_release_complete, 0,
       sizeof(itti_ngap_ue_context_release_complete_t));
@@ -1571,8 +1571,8 @@ void ngap_amf_release_ue_context(
   /*
    * Remove UE context and inform AMF_APP.
    */
-  message_p =
-      itti_alloc_new_message(TASK_NGAP, NGAP_UE_CONTEXT_RELEASE_COMPLETE);
+  message_p = DEPRECATEDitti_alloc_new_message_fatal(
+      TASK_NGAP, NGAP_UE_CONTEXT_RELEASE_COMPLETE);
   memset(
       (void*) &message_p->ittiMsg.ngap_ue_context_release_complete, 0,
       sizeof(itti_ngap_ue_context_release_complete_t));
@@ -1765,8 +1765,8 @@ int ngap_amf_handle_pduSession_setup_response(
       imsi_map->amf_ue_id_imsi_htbl,
       (const hash_key_t) ue_ref_p->amf_ue_ngap_id, &imsi64);
 
-  message_p =
-      itti_alloc_new_message(TASK_NGAP, NGAP_PDUSESSIONRESOURCE_SETUP_RSP);
+  message_p = DEPRECATEDitti_alloc_new_message_fatal(
+      TASK_NGAP, NGAP_PDUSESSIONRESOURCE_SETUP_RSP);
   NGAP_PDUSESSIONRESOURCE_SETUP_RSP(message_p).amf_ue_ngap_id =
       ue_ref_p->amf_ue_ngap_id;
   NGAP_PDUSESSIONRESOURCE_SETUP_RSP(message_p).gnb_ue_ngap_id =

--- a/lte/gateway/c/core/oai/tasks/s11/s11_mme_bearer_manager.c
+++ b/lte/gateway/c/core/oai/tasks/s11/s11_mme_bearer_manager.c
@@ -154,8 +154,8 @@ int s11_mme_handle_release_access_bearer_response(
   nw_gtpv2c_msg_parser_t* pMsgParser;
 
   DevAssert(stack_p);
-  message_p =
-      itti_alloc_new_message(TASK_S11, S11_RELEASE_ACCESS_BEARERS_RESPONSE);
+  message_p = DEPRECATEDitti_alloc_new_message_fatal(
+      TASK_S11, S11_RELEASE_ACCESS_BEARERS_RESPONSE);
   resp_p = &message_p->ittiMsg.s11_release_access_bearers_response;
 
   resp_p->teid = nwGtpv2cMsgGetTeid(pUlpApi->hMsg);
@@ -274,8 +274,9 @@ int s11_mme_handle_modify_bearer_response(
   nw_gtpv2c_msg_parser_t* pMsgParser;
 
   DevAssert(stack_p);
-  message_p = itti_alloc_new_message(TASK_S11, S11_MODIFY_BEARER_RESPONSE);
-  resp_p    = &message_p->ittiMsg.s11_modify_bearer_response;
+  message_p = DEPRECATEDitti_alloc_new_message_fatal(
+      TASK_S11, S11_MODIFY_BEARER_RESPONSE);
+  resp_p = &message_p->ittiMsg.s11_modify_bearer_response;
 
   resp_p->teid           = nwGtpv2cMsgGetTeid(pUlpApi->hMsg);
   resp_p->internal_flags = pUlpApi->u_api_info.triggeredRspIndInfo.trx_flags;
@@ -405,7 +406,8 @@ int s11_mme_handle_create_bearer_request(
   nw_gtpv2c_msg_parser_t* pMsgParser;
 
   DevAssert(stack_p);
-  message_p = itti_alloc_new_message(TASK_S11, S11_CREATE_BEARER_REQUEST);
+  message_p = DEPRECATEDitti_alloc_new_message_fatal(
+      TASK_S11, S11_CREATE_BEARER_REQUEST);
 
   if (message_p) {
     req_p = &message_p->ittiMsg.s11_create_bearer_request;
@@ -538,8 +540,9 @@ int s11_mme_handle_downlink_data_notification(
   MessageDef* message_p;
 
   DevAssert(stack_p);
-  message_p = itti_alloc_new_message(TASK_S10, S11_DOWNLINK_DATA_NOTIFICATION);
-  notif_p   = &message_p->ittiMsg.s11_downlink_data_notification;
+  message_p = DEPRECATEDitti_alloc_new_message_fatal(
+      TASK_S10, S11_DOWNLINK_DATA_NOTIFICATION);
+  notif_p = &message_p->ittiMsg.s11_downlink_data_notification;
   memset(notif_p, 0, sizeof(*notif_p));
   notif_p->teid = nwGtpv2cMsgGetTeid(
       pUlpApi->hMsg); /**< When the message is sent, this is the field,

--- a/lte/gateway/c/core/oai/tasks/s11/s11_mme_session_manager.c
+++ b/lte/gateway/c/core/oai/tasks/s11/s11_mme_session_manager.c
@@ -181,8 +181,9 @@ int s11_mme_handle_create_session_response(
   nw_gtpv2c_msg_parser_t* pMsgParser;
 
   DevAssert(stack_p);
-  message_p = itti_alloc_new_message(TASK_S11, S11_CREATE_SESSION_RESPONSE);
-  resp_p    = &message_p->ittiMsg.s11_create_session_response;
+  message_p = DEPRECATEDitti_alloc_new_message_fatal(
+      TASK_S11, S11_CREATE_SESSION_RESPONSE);
+  resp_p = &message_p->ittiMsg.s11_create_session_response;
 
   resp_p->teid = nwGtpv2cMsgGetTeid(pUlpApi->hMsg);
 
@@ -360,8 +361,9 @@ int s11_mme_handle_delete_session_response(
   hashtable_rc_t hash_rc                     = HASH_TABLE_OK;
 
   DevAssert(stack_p);
-  message_p = itti_alloc_new_message(TASK_S11, S11_DELETE_SESSION_RESPONSE);
-  resp_p    = &message_p->ittiMsg.s11_delete_session_response;
+  message_p = DEPRECATEDitti_alloc_new_message_fatal(
+      TASK_S11, S11_DELETE_SESSION_RESPONSE);
+  resp_p = &message_p->ittiMsg.s11_delete_session_response;
 
   resp_p->teid           = nwGtpv2cMsgGetTeid(pUlpApi->hMsg);
   resp_p->internal_flags = pUlpApi->u_api_info.triggeredRspIndInfo.trx_flags;
@@ -449,8 +451,9 @@ int s11_mme_handle_ulp_error_indicatior(
     {
       itti_s11_create_session_response_t* rsp_p;
       /** Respond with an S10 Context Reponse Failure. */
-      message_p = itti_alloc_new_message(TASK_S11, S11_CREATE_SESSION_RESPONSE);
-      rsp_p     = &message_p->ittiMsg.s11_create_session_response;
+      message_p = DEPRECATEDitti_alloc_new_message_fatal(
+          TASK_S11, S11_CREATE_SESSION_RESPONSE);
+      rsp_p = &message_p->ittiMsg.s11_create_session_response;
       memset(rsp_p, 0, sizeof(*rsp_p));
       /** Set the destination TEID (our TEID). */
       rsp_p->teid = pUlpApi->u_api_info.rspFailureInfo.teidLocal;
@@ -463,8 +466,9 @@ int s11_mme_handle_ulp_error_indicatior(
     } break;
     case NW_GTP_MODIFY_BEARER_REQ: {
       itti_s11_modify_bearer_response_t* rsp_p;
-      message_p = itti_alloc_new_message(TASK_S11, S11_MODIFY_BEARER_RESPONSE);
-      rsp_p     = &message_p->ittiMsg.s11_modify_bearer_response;
+      message_p = DEPRECATEDitti_alloc_new_message_fatal(
+          TASK_S11, S11_MODIFY_BEARER_RESPONSE);
+      rsp_p = &message_p->ittiMsg.s11_modify_bearer_response;
       memset(rsp_p, 0, sizeof(*rsp_p));
       /** Set the destination TEID (our TEID). */
       rsp_p->teid = pUlpApi->u_api_info.rspFailureInfo.teidLocal;
@@ -481,8 +485,9 @@ int s11_mme_handle_ulp_error_indicatior(
        * UE context should always be removed.
        */
       itti_s11_delete_session_response_t* rsp_p;
-      message_p = itti_alloc_new_message(TASK_S11, S11_DELETE_SESSION_RESPONSE);
-      rsp_p     = &message_p->ittiMsg.s11_delete_session_response;
+      message_p = DEPRECATEDitti_alloc_new_message_fatal(
+          TASK_S11, S11_DELETE_SESSION_RESPONSE);
+      rsp_p = &message_p->ittiMsg.s11_delete_session_response;
       memset(rsp_p, 0, sizeof(*rsp_p));
       /** Set the destination TEID (our TEID). */
       rsp_p->teid = pUlpApi->u_api_info.rspFailureInfo.teidLocal;
@@ -506,8 +511,8 @@ int s11_mme_handle_ulp_error_indicatior(
        * UE context should always be removed.
        */
       itti_s11_release_access_bearers_response_t* rsp_p;
-      message_p =
-          itti_alloc_new_message(TASK_S11, S11_RELEASE_ACCESS_BEARERS_RESPONSE);
+      message_p = DEPRECATEDitti_alloc_new_message_fatal(
+          TASK_S11, S11_RELEASE_ACCESS_BEARERS_RESPONSE);
       rsp_p = &message_p->ittiMsg.s11_release_access_bearers_response;
       memset(rsp_p, 0, sizeof(*rsp_p));
       /** Set the destination TEID (our TEID). */

--- a/lte/gateway/c/core/oai/tasks/s1ap/s1ap_mme.c
+++ b/lte/gateway/c/core/oai/tasks/s1ap/s1ap_mme.c
@@ -88,7 +88,7 @@ static int s1ap_send_init_sctp(void) {
   // Create and alloc new message
   MessageDef* message_p = NULL;
 
-  message_p = itti_alloc_new_message(TASK_S1AP, SCTP_INIT_MSG);
+  message_p = DEPRECATEDitti_alloc_new_message_fatal(TASK_S1AP, SCTP_INIT_MSG);
   message_p->ittiMsg.sctpInit.port         = S1AP_PORT_NUMBER;
   message_p->ittiMsg.sctpInit.ppid         = S1AP_SCTP_PPID;
   message_p->ittiMsg.sctpInit.ipv4         = 1;

--- a/lte/gateway/c/core/oai/tasks/s1ap/s1ap_mme_handlers.c
+++ b/lte/gateway/c/core/oai/tasks/s1ap/s1ap_mme_handlers.c
@@ -984,8 +984,8 @@ int s1ap_mme_handle_initial_context_setup_response(
     OAILOG_FUNC_RETURN(LOG_S1AP, RETURNerror);
   }
   ue_ref_p->s1_ue_state = S1AP_UE_CONNECTED;
-  message_p =
-      itti_alloc_new_message(TASK_S1AP, MME_APP_INITIAL_CONTEXT_SETUP_RSP);
+  message_p             = DEPRECATEDitti_alloc_new_message_fatal(
+      TASK_S1AP, MME_APP_INITIAL_CONTEXT_SETUP_RSP);
   MME_APP_INITIAL_CONTEXT_SETUP_RSP(message_p).ue_id = ue_ref_p->mme_ue_s1ap_id;
   MME_APP_INITIAL_CONTEXT_SETUP_RSP(message_p).e_rab_setup_list.no_of_items =
       ie->value.choice.E_RABSetupListCtxtSURes.list.count;
@@ -1691,8 +1691,8 @@ int s1ap_mme_handle_initial_context_setup_failure(
           cause_type);
       OAILOG_FUNC_RETURN(LOG_S1AP, RETURNerror);
   }
-  message_p =
-      itti_alloc_new_message(TASK_S1AP, MME_APP_INITIAL_CONTEXT_SETUP_FAILURE);
+  message_p = DEPRECATEDitti_alloc_new_message_fatal(
+      TASK_S1AP, MME_APP_INITIAL_CONTEXT_SETUP_FAILURE);
   memset(
       (void*) &message_p->ittiMsg.mme_app_initial_context_setup_failure, 0,
       sizeof(itti_mme_app_initial_context_setup_failure_t));
@@ -1763,7 +1763,7 @@ int s1ap_mme_handle_ue_context_modification_response(
           imsi_map->mme_ue_id_imsi_htbl,
           (const hash_key_t) ie->value.choice.MME_UE_S1AP_ID, &imsi64);
 
-      message_p = itti_alloc_new_message(
+      message_p = DEPRECATEDitti_alloc_new_message_fatal(
           TASK_S1AP, S1AP_UE_CONTEXT_MODIFICATION_RESPONSE);
       memset(
           (void*) &message_p->ittiMsg.s1ap_ue_context_mod_response, 0,
@@ -1912,7 +1912,7 @@ int s1ap_mme_handle_ue_context_modification_failure(
               cause_type);
           OAILOG_FUNC_RETURN(LOG_S1AP, RETURNerror);
       }
-      message_p = itti_alloc_new_message(
+      message_p = DEPRECATEDitti_alloc_new_message_fatal(
           TASK_S1AP, S1AP_UE_CONTEXT_MODIFICATION_FAILURE);
       memset(
           (void*) &message_p->ittiMsg.s1ap_ue_context_mod_response, 0,
@@ -3492,8 +3492,8 @@ bool s1ap_send_enb_deregistered_ind(
   hashtable_ts_get(s1ap_ue_state, (const hash_key_t) dataP, (void**) &ue_ref_p);
   if (ue_ref_p) {
     if (arg->current_ue_index == 0) {
-      arg->message_p =
-          itti_alloc_new_message(TASK_S1AP, S1AP_ENB_DEREGISTERED_IND);
+      arg->message_p = DEPRECATEDitti_alloc_new_message_fatal(
+          TASK_S1AP, S1AP_ENB_DEREGISTERED_IND);
       OAILOG_DEBUG(LOG_S1AP, "eNB Deregesteration");
     }
     if (ue_ref_p->mme_ue_s1ap_id == INVALID_MME_UE_S1AP_ID) {
@@ -3771,8 +3771,8 @@ void s1ap_mme_handle_ue_context_rel_comp_timer_expiry(
   /*
    * Remove UE context and inform MME_APP.
    */
-  message_p =
-      itti_alloc_new_message(TASK_S1AP, S1AP_UE_CONTEXT_RELEASE_COMPLETE);
+  message_p = DEPRECATEDitti_alloc_new_message_fatal(
+      TASK_S1AP, S1AP_UE_CONTEXT_RELEASE_COMPLETE);
   memset(
       (void*) &message_p->ittiMsg.s1ap_ue_context_release_complete, 0,
       sizeof(itti_s1ap_ue_context_release_complete_t));
@@ -3810,8 +3810,8 @@ void s1ap_mme_release_ue_context(
   /*
    * Remove UE context and inform MME_APP.
    */
-  message_p =
-      itti_alloc_new_message(TASK_S1AP, S1AP_UE_CONTEXT_RELEASE_COMPLETE);
+  message_p = DEPRECATEDitti_alloc_new_message_fatal(
+      TASK_S1AP, S1AP_UE_CONTEXT_RELEASE_COMPLETE);
   memset(
       (void*) &message_p->ittiMsg.s1ap_ue_context_release_complete, 0,
       sizeof(itti_s1ap_ue_context_release_complete_t));
@@ -4012,7 +4012,8 @@ int s1ap_mme_handle_erab_setup_response(
       imsi_map->mme_ue_id_imsi_htbl,
       (const hash_key_t) ue_ref_p->mme_ue_s1ap_id, &imsi64);
 
-  message_p = itti_alloc_new_message(TASK_S1AP, S1AP_E_RAB_SETUP_RSP);
+  message_p =
+      DEPRECATEDitti_alloc_new_message_fatal(TASK_S1AP, S1AP_E_RAB_SETUP_RSP);
   S1AP_E_RAB_SETUP_RSP(message_p).mme_ue_s1ap_id = ue_ref_p->mme_ue_s1ap_id;
   S1AP_E_RAB_SETUP_RSP(message_p).enb_ue_s1ap_id = ue_ref_p->enb_ue_s1ap_id;
   S1AP_E_RAB_SETUP_RSP(message_p).e_rab_setup_list.no_of_items           = 0;
@@ -4171,7 +4172,8 @@ int s1ap_mme_handle_enb_reset(
           reset_count, enb_association->nb_ue_associated);
     }
   }
-  msg       = itti_alloc_new_message(TASK_S1AP, S1AP_ENB_INITIATED_RESET_REQ);
+  msg = DEPRECATEDitti_alloc_new_message_fatal(
+      TASK_S1AP, S1AP_ENB_INITIATED_RESET_REQ);
   reset_req = &S1AP_ENB_INITIATED_RESET_REQ(msg);
 
   reset_req->s1ap_reset_type = s1ap_reset_type;
@@ -4632,7 +4634,8 @@ int s1ap_mme_handle_erab_modification_indication(
     OAILOG_FUNC_RETURN(LOG_S1AP, RETURNerror);
   }
 
-  message_p = itti_alloc_new_message(TASK_S1AP, S1AP_E_RAB_MODIFICATION_IND);
+  message_p = DEPRECATEDitti_alloc_new_message_fatal(
+      TASK_S1AP, S1AP_E_RAB_MODIFICATION_IND);
   S1AP_E_RAB_MODIFICATION_IND(message_p).mme_ue_s1ap_id =
       ue_ref_p->mme_ue_s1ap_id;
   S1AP_E_RAB_MODIFICATION_IND(message_p).enb_ue_s1ap_id =

--- a/lte/gateway/c/core/oai/tasks/s6a/s6a_auth_info.c
+++ b/lte/gateway/c/core/oai/tasks/s6a/s6a_auth_info.c
@@ -213,7 +213,8 @@ int s6a_aia_cb(
    */
   CHECK_FCT(fd_msg_answ_getq(ans, &qry));
   DevAssert(qry);
-  message_p           = itti_alloc_new_message(TASK_S6A, S6A_AUTH_INFO_ANS);
+  message_p =
+      DEPRECATEDitti_alloc_new_message_fatal(TASK_S6A, S6A_AUTH_INFO_ANS);
   s6a_auth_info_ans_p = &message_p->ittiMsg.s6a_auth_info_ans;
   OAILOG_DEBUG(
       LOG_S6A, "Received S6A Authentication Information Answer (AIA)\n");

--- a/lte/gateway/c/core/oai/tasks/s6a/s6a_cancel_loc.c
+++ b/lte/gateway/c/core/oai/tasks/s6a/s6a_cancel_loc.c
@@ -128,7 +128,8 @@ int s6a_clr_cb(
     CHECK_FCT(fd_msg_avp_hdr(avp_p, &hdr_p));
     if (hdr_p->avp_value->u32 == SUBSCRIPTION_WITHDRAWL) {
       // Send it to MME module for further processing
-      message_p = itti_alloc_new_message(TASK_S6A, S6A_CANCEL_LOCATION_REQ);
+      message_p = DEPRECATEDitti_alloc_new_message_fatal(
+          TASK_S6A, S6A_CANCEL_LOCATION_REQ);
       s6a_cancel_location_req_p = &message_p->ittiMsg.s6a_cancel_location_req;
       memcpy(s6a_cancel_location_req_p->imsi, imsi_str, imsi_len);
       s6a_cancel_location_req_p->imsi[imsi_len]    = '\0';

--- a/lte/gateway/c/core/oai/tasks/s6a/s6a_hss_reset.c
+++ b/lte/gateway/c/core/oai/tasks/s6a/s6a_hss_reset.c
@@ -90,7 +90,7 @@ int s6a_rsr_cb(
   CHECK_FCT(fd_msg_avp_hdr(origin_host_p, &origin_host_hdr));
   CHECK_FCT(fd_msg_avp_hdr(origin_realm_p, &origin_realm_hdr));
   // Send it to MME module for further processing
-  message_p = itti_alloc_new_message(TASK_S6A, S6A_RESET_REQ);
+  message_p = DEPRECATEDitti_alloc_new_message_fatal(TASK_S6A, S6A_RESET_REQ);
   // s6a_reset_req_p->msg_rsa_p = msg_p;
   send_msg_to_task(&s6a_task_zmq_ctx, TASK_MME_APP, message_p);
   OAILOG_DEBUG(LOG_S6A, "Sending S6A_RESET_REQ to task MME_APP\n");

--- a/lte/gateway/c/core/oai/tasks/s6a/s6a_peer.c
+++ b/lte/gateway/c/core/oai/tasks/s6a/s6a_peer.c
@@ -174,9 +174,11 @@ int s6a_fd_new_peer(void) {
  */
 void send_activate_messages(void) {
   MessageDef* message_p;
-  message_p = itti_alloc_new_message(TASK_S6A, ACTIVATE_MESSAGE);
+  message_p =
+      DEPRECATEDitti_alloc_new_message_fatal(TASK_S6A, ACTIVATE_MESSAGE);
   send_msg_to_task(&s6a_task_zmq_ctx, TASK_MME_APP, message_p);
 
-  message_p = itti_alloc_new_message(TASK_S6A, ACTIVATE_MESSAGE);
+  message_p =
+      DEPRECATEDitti_alloc_new_message_fatal(TASK_S6A, ACTIVATE_MESSAGE);
   send_msg_to_task(&s6a_task_zmq_ctx, TASK_S1AP, message_p);
 }

--- a/lte/gateway/c/core/oai/tasks/s6a/s6a_purge_ue.c
+++ b/lte/gateway/c/core/oai/tasks/s6a/s6a_purge_ue.c
@@ -53,7 +53,8 @@ int s6a_pua_cb(
    */
   CHECK_FCT(fd_msg_answ_getq(ans_p, &qry_p));
   DevAssert(qry_p);
-  message_p          = itti_alloc_new_message(TASK_S6A, S6A_PURGE_UE_ANS);
+  message_p =
+      DEPRECATEDitti_alloc_new_message_fatal(TASK_S6A, S6A_PURGE_UE_ANS);
   s6a_purge_ue_ans_p = &message_p->ittiMsg.s6a_purge_ue_ans;
 
   /*

--- a/lte/gateway/c/core/oai/tasks/s6a/s6a_service_handler.c
+++ b/lte/gateway/c/core/oai/tasks/s6a/s6a_service_handler.c
@@ -28,7 +28,8 @@ int delete_subscriber_request(const char* imsi, const uint imsi_len) {
   // send it to MME module for further processing
   MessageDef* message_p                                = NULL;
   s6a_cancel_location_req_t* s6a_cancel_location_req_p = NULL;
-  message_p = itti_alloc_new_message(TASK_S6A, S6A_CANCEL_LOCATION_REQ);
+  message_p =
+      DEPRECATEDitti_alloc_new_message_fatal(TASK_S6A, S6A_CANCEL_LOCATION_REQ);
   s6a_cancel_location_req_p = &message_p->ittiMsg.s6a_cancel_location_req;
   memcpy(s6a_cancel_location_req_p->imsi, imsi, imsi_len);
   s6a_cancel_location_req_p->imsi[imsi_len]    = '\0';
@@ -42,7 +43,7 @@ int delete_subscriber_request(const char* imsi, const uint imsi_len) {
 void handle_reset_request(void) {
   // send it to MME module for further processing
   MessageDef* message_p = NULL;
-  message_p             = itti_alloc_new_message(TASK_S6A, S6A_RESET_REQ);
+  message_p = DEPRECATEDitti_alloc_new_message_fatal(TASK_S6A, S6A_RESET_REQ);
   // TBD - To add support for partial reset
   send_msg_to_task(&s6a_task_zmq_ctx, TASK_MME_APP, message_p);
   return;

--- a/lte/gateway/c/core/oai/tasks/s6a/s6a_up_loc.c
+++ b/lte/gateway/c/core/oai/tasks/s6a/s6a_up_loc.c
@@ -63,7 +63,8 @@ int s6a_ula_cb(
    */
   CHECK_FCT(fd_msg_answ_getq(ans_p, &qry_p));
   DevAssert(qry_p);
-  message_p = itti_alloc_new_message(TASK_S6A, S6A_UPDATE_LOCATION_ANS);
+  message_p =
+      DEPRECATEDitti_alloc_new_message_fatal(TASK_S6A, S6A_UPDATE_LOCATION_ANS);
   s6a_update_location_ans_p = &message_p->ittiMsg.s6a_update_location_ans;
   CHECK_FCT(fd_msg_search_avp(qry_p, s6a_fd_cnf.dataobj_s6a_user_name, &avp_p));
 

--- a/lte/gateway/c/core/oai/tasks/sctp/sctp_itti_messaging.c
+++ b/lte/gateway/c/core/oai/tasks/sctp/sctp_itti_messaging.c
@@ -36,7 +36,8 @@
 int sctp_itti_send_lower_layer_conf(
     task_id_t origin_task_id, sctp_ppid_t ppid, sctp_assoc_id_t assoc_id,
     sctp_stream_id_t stream, uint32_t xap_id, bool is_success) {
-  MessageDef* msg = itti_alloc_new_message(TASK_SCTP, SCTP_DATA_CNF);
+  MessageDef* msg =
+      DEPRECATEDitti_alloc_new_message_fatal(TASK_SCTP, SCTP_DATA_CNF);
 
   SCTP_DATA_CNF(msg).ppid          = ppid;
   SCTP_DATA_CNF(msg).assoc_id      = assoc_id;
@@ -51,7 +52,8 @@ int sctp_itti_send_lower_layer_conf(
 int sctp_itti_send_new_association(
     sctp_ppid_t ppid, sctp_assoc_id_t assoc_id, sctp_stream_id_t instreams,
     sctp_stream_id_t outstreams, STOLEN_REF bstring* ran_cp_ipaddr) {
-  MessageDef* msg = itti_alloc_new_message(TASK_SCTP, SCTP_NEW_ASSOCIATION);
+  MessageDef* msg =
+      DEPRECATEDitti_alloc_new_message_fatal(TASK_SCTP, SCTP_NEW_ASSOCIATION);
 
   SCTP_NEW_ASSOCIATION(msg).assoc_id   = assoc_id;
   SCTP_NEW_ASSOCIATION(msg).instreams  = instreams;
@@ -80,7 +82,8 @@ int sctp_itti_send_new_association(
 int sctp_itti_send_new_message_ind(
     STOLEN_REF bstring* payload, sctp_ppid_t ppid, sctp_assoc_id_t assoc_id,
     sctp_stream_id_t stream) {
-  MessageDef* msg = itti_alloc_new_message(TASK_SCTP, SCTP_DATA_IND);
+  MessageDef* msg =
+      DEPRECATEDitti_alloc_new_message_fatal(TASK_SCTP, SCTP_DATA_IND);
 
   SCTP_DATA_IND(msg).payload  = *payload;
   SCTP_DATA_IND(msg).stream   = stream;
@@ -108,7 +111,8 @@ int sctp_itti_send_new_message_ind(
 //------------------------------------------------------------------------------
 int sctp_itti_send_com_down_ind(
     sctp_ppid_t ppid, sctp_assoc_id_t assoc_id, bool reset) {
-  MessageDef* msg = itti_alloc_new_message(TASK_SCTP, SCTP_CLOSE_ASSOCIATION);
+  MessageDef* msg =
+      DEPRECATEDitti_alloc_new_message_fatal(TASK_SCTP, SCTP_CLOSE_ASSOCIATION);
 
   SCTP_CLOSE_ASSOCIATION(msg).assoc_id = assoc_id;
   SCTP_CLOSE_ASSOCIATION(msg).reset    = reset;

--- a/lte/gateway/c/core/oai/tasks/sctp/sctp_primitives_server.c
+++ b/lte/gateway/c/core/oai/tasks/sctp/sctp_primitives_server.c
@@ -75,12 +75,14 @@ static int handle_message(zloop_t* loop, zsock_t* reader, void* arg) {
       MessageDef* msg;
 
       if (received_message_p->ittiMsg.sctpInit.ppid == S1AP) {
-        msg = itti_alloc_new_message(TASK_S1AP, SCTP_MME_SERVER_INITIALIZED);
+        msg = DEPRECATEDitti_alloc_new_message_fatal(
+            TASK_S1AP, SCTP_MME_SERVER_INITIALIZED);
         SCTP_MME_SERVER_INITIALIZED(msg).successful = true;
         send_msg_to_task(&sctp_task_zmq_ctx, TASK_MME_APP, msg);
 
       } else if (received_message_p->ittiMsg.sctpInit.ppid == NGAP) {
-        msg = itti_alloc_new_message(TASK_NGAP, SCTP_AMF_SERVER_INITIALIZED);
+        msg = DEPRECATEDitti_alloc_new_message_fatal(
+            TASK_NGAP, SCTP_AMF_SERVER_INITIALIZED);
         SCTP_AMF_SERVER_INITIALIZED(msg).successful = true;
         send_msg_to_task(&sctp_task_zmq_ctx, TASK_AMF_APP, msg);
       } else {

--- a/lte/gateway/c/core/oai/tasks/sgs/sgs_service_handler.c
+++ b/lte/gateway/c/core/oai/tasks/sgs/sgs_service_handler.c
@@ -35,8 +35,8 @@ int handle_sgs_location_update_accept(
    */
   MessageDef* message_p = NULL;
   int rc                = RETURNok;
-  message_p = itti_alloc_new_message(TASK_SGS, SGSAP_LOCATION_UPDATE_ACC);
-  AssertFatal(message_p, "itti_alloc_new_message Failed");
+  message_p             = DEPRECATEDitti_alloc_new_message_fatal(
+      TASK_SGS, SGSAP_LOCATION_UPDATE_ACC);
   memset(
       (void*) &message_p->ittiMsg.sgsap_location_update_acc, 0,
       sizeof(itti_sgsap_location_update_acc_t));
@@ -62,8 +62,8 @@ int handle_sgs_location_update_reject(
   /* Received SGS Location Update Reject from FedGW
    *send it to MME App for further processing
    */
-  message_p = itti_alloc_new_message(TASK_SGS, SGSAP_LOCATION_UPDATE_REJ);
-  AssertFatal(message_p, "itti_alloc_new_message Failed");
+  message_p = DEPRECATEDitti_alloc_new_message_fatal(
+      TASK_SGS, SGSAP_LOCATION_UPDATE_REJ);
   OAILOG_DEBUG(
       LOG_SGS,
       "Received SGS Location Update Reject message from FedGW with IMSI %s\n",
@@ -86,8 +86,8 @@ int handle_sgs_eps_detach_ack(
   MessageDef* message_p                             = NULL;
   itti_sgsap_eps_detach_ack_t* sgs_eps_detach_ack_p = NULL;
 
-  message_p = itti_alloc_new_message(TASK_S6A, SGSAP_EPS_DETACH_ACK);
-  AssertFatal(message_p, "itti_alloc_new_message Failed");
+  message_p =
+      DEPRECATEDitti_alloc_new_message_fatal(TASK_S6A, SGSAP_EPS_DETACH_ACK);
   sgs_eps_detach_ack_p = &message_p->ittiMsg.sgsap_eps_detach_ack;
   memset((void*) sgs_eps_detach_ack_p, 0, sizeof(itti_sgsap_eps_detach_ack_t));
   OAILOG_DEBUG(LOG_SGS, "Received SGS EPS Detach Ack message from FedGW\n");
@@ -106,8 +106,8 @@ int handle_sgs_imsi_detach_ack(
   MessageDef* message_p                               = NULL;
   itti_sgsap_imsi_detach_ack_t* sgs_imsi_detach_ack_p = NULL;
 
-  message_p = itti_alloc_new_message(TASK_S6A, SGSAP_IMSI_DETACH_ACK);
-  AssertFatal(message_p, "itti_alloc_new_message Failed");
+  message_p =
+      DEPRECATEDitti_alloc_new_message_fatal(TASK_S6A, SGSAP_IMSI_DETACH_ACK);
   sgs_imsi_detach_ack_p = &message_p->ittiMsg.sgsap_imsi_detach_ack;
   memset(
       (void*) sgs_imsi_detach_ack_p, 0, sizeof(itti_sgsap_imsi_detach_ack_t));
@@ -127,8 +127,8 @@ int handle_sgs_downlink_unitdata(
   MessageDef* message_p                              = NULL;
   itti_sgsap_downlink_unitdata_t* sgs_dl_unit_data_p = NULL;
 
-  message_p = itti_alloc_new_message(TASK_SGS, SGSAP_DOWNLINK_UNITDATA);
-  AssertFatal(message_p, "itti_alloc_new_message Failed");
+  message_p =
+      DEPRECATEDitti_alloc_new_message_fatal(TASK_SGS, SGSAP_DOWNLINK_UNITDATA);
   sgs_dl_unit_data_p = &message_p->ittiMsg.sgsap_downlink_unitdata;
   memset((void*) sgs_dl_unit_data_p, 0, sizeof(itti_sgsap_downlink_unitdata_t));
   OAILOG_DEBUG(LOG_SGS, "Received SGS Downlink UnitData message from FedGW\n");
@@ -146,8 +146,8 @@ int handle_sgs_release_req(const itti_sgsap_release_req_t* sgs_release_req_p) {
   MessageDef* message_p                   = NULL;
   itti_sgsap_release_req_t* sgs_rel_req_p = NULL;
 
-  message_p = itti_alloc_new_message(TASK_SGS, SGSAP_RELEASE_REQ);
-  AssertFatal(message_p, "itti_alloc_new_message Failed");
+  message_p =
+      DEPRECATEDitti_alloc_new_message_fatal(TASK_SGS, SGSAP_RELEASE_REQ);
   sgs_rel_req_p = &message_p->ittiMsg.sgsap_release_req;
   memset((void*) sgs_rel_req_p, 0, sizeof(itti_sgsap_release_req_t));
   OAILOG_DEBUG(LOG_SGS, "Received SGS Release Request message from FedGW\n");
@@ -169,12 +169,8 @@ int handle_sgs_mm_information_request(
   int rc                = RETURNok;
   OAILOG_FUNC_IN(LOG_SGS);
 
-  message_p = itti_alloc_new_message(TASK_SGS, SGSAP_MM_INFORMATION_REQ);
-  AssertFatal(
-      message_p,
-      "itti_alloc_new_message Failed while handling MM Information Request "
-      "from "
-      "MSC/VLR");
+  message_p = DEPRECATEDitti_alloc_new_message_fatal(
+      TASK_SGS, SGSAP_MM_INFORMATION_REQ);
   itti_sgsap_mm_information_req_t* mm_information_req_p =
       &message_p->ittiMsg.sgsap_mm_information_req;
   memset(
@@ -203,9 +199,8 @@ int handle_sgs_service_abort_req(
   int rc                = RETURNok;
 
   OAILOG_FUNC_IN(LOG_SGS);
-  message_p = itti_alloc_new_message(TASK_SGS, SGSAP_SERVICE_ABORT_REQ);
-  AssertFatal(
-      message_p, "itti_alloc_new_message Failed for SGS Service Abort\n");
+  message_p =
+      DEPRECATEDitti_alloc_new_message_fatal(TASK_SGS, SGSAP_SERVICE_ABORT_REQ);
   memset(
       (void*) &message_p->ittiMsg.sgsap_service_abort_req, 0,
       sizeof(itti_sgsap_service_abort_req_t));
@@ -235,11 +230,8 @@ int handle_sgs_paging_request(
   /* Received SGS Paging Request from FedGW
    *send it to MME App for further processing
    */
-  message_p = itti_alloc_new_message(TASK_SGS, SGSAP_PAGING_REQUEST);
-  AssertFatal(
-      message_p,
-      "itti_alloc_new_message Failed while handling Paging Request from "
-      "MSC/VLR");
+  message_p =
+      DEPRECATEDitti_alloc_new_message_fatal(TASK_SGS, SGSAP_PAGING_REQUEST);
 
   itti_sgsap_paging_request_t* sgs_paging_req_p =
       &message_p->ittiMsg.sgsap_paging_request;
@@ -274,11 +266,8 @@ int handle_sgs_vlr_reset_indication(
   /* Received SGS VLR Reset Indication from FedGW
    * send it to MME App for further processing
    */
-  message_p = itti_alloc_new_message(TASK_SGS, SGSAP_VLR_RESET_INDICATION);
-  AssertFatal(
-      message_p,
-      "itti_alloc_new_message Failed while handling Reset Indication from "
-      "MSC/VLR");
+  message_p = DEPRECATEDitti_alloc_new_message_fatal(
+      TASK_SGS, SGSAP_VLR_RESET_INDICATION);
 
   itti_sgsap_vlr_reset_indication_t* sgs_vlr_reset_ind_p =
       &message_p->ittiMsg.sgsap_vlr_reset_indication;
@@ -320,11 +309,7 @@ int handle_sgs_status_message(const itti_sgsap_status_t* sgs_status_pP) {
   /* Received SGS status message from FedGW
    * send it to MME App for further processing
    */
-  message_p = itti_alloc_new_message(TASK_SGS, SGSAP_STATUS);
-  AssertFatal(
-      message_p,
-      "itti_alloc_new_message Failed while handling "
-      "SGS Status message from MSC/VLR \n");
+  message_p = DEPRECATEDitti_alloc_new_message_fatal(TASK_SGS, SGSAP_STATUS);
 
   itti_sgsap_status_t* sgs_status_p = &message_p->ittiMsg.sgsap_status;
   memset((void*) sgs_status_p, 0, sizeof(itti_sgsap_status_t));
@@ -352,8 +337,8 @@ static void sgs_send_sgsap_vlr_reset_ack(void) {
   itti_sgsap_vlr_reset_ack_t* sgsap_reset_ack_pP = NULL;
 
   OAILOG_FUNC_IN(LOG_SGS);
-  message_p = itti_alloc_new_message(TASK_SGS, SGSAP_VLR_RESET_ACK);
-  AssertFatal(message_p, "itti_alloc_new_message Failed: SGSAP_VLR_RESET_ACK");
+  message_p =
+      DEPRECATEDitti_alloc_new_message_fatal(TASK_SGS, SGSAP_VLR_RESET_ACK);
   sgsap_reset_ack_pP = &message_p->ittiMsg.sgsap_vlr_reset_ack;
   memset((void*) sgsap_reset_ack_pP, 0, sizeof(itti_sgsap_vlr_reset_ack_t));
 
@@ -376,11 +361,8 @@ int handle_sgsap_alert_request(
   /* Received SGS Alert Req from FedGW
    *send it to MME App for further processing
    */
-  message_p = itti_alloc_new_message(TASK_SGS, SGSAP_ALERT_REQUEST);
-  AssertFatal(
-      message_p,
-      "itti_alloc_new_message Failed while handling Alert Request from "
-      "MSC/VLR");
+  message_p =
+      DEPRECATEDitti_alloc_new_message_fatal(TASK_SGS, SGSAP_ALERT_REQUEST);
 
   memset(
       (void*) &message_p->ittiMsg.sgsap_alert_request, 0,

--- a/lte/gateway/c/core/oai/tasks/sgw/sgw_paging.c
+++ b/lte/gateway/c/core/oai/tasks/sgw/sgw_paging.c
@@ -38,7 +38,8 @@ void sgw_send_paging_request(const struct in_addr* dest_ip) {
   MessageDef* message_p                       = NULL;
   itti_s11_paging_request_t* paging_request_p = NULL;
 
-  message_p        = itti_alloc_new_message(TASK_SPGW_APP, S11_PAGING_REQUEST);
+  message_p =
+      DEPRECATEDitti_alloc_new_message_fatal(TASK_SPGW_APP, S11_PAGING_REQUEST);
   paging_request_p = &message_p->ittiMsg.s11_paging_request;
   memset((void*) paging_request_p, 0, sizeof(itti_s11_paging_request_t));
   paging_request_p->ipv4_addr = *dest_ip;

--- a/lte/gateway/c/core/oai/tasks/sms_orc8r/sms_orc8r_service_handler.c
+++ b/lte/gateway/c/core/oai/tasks/sms_orc8r/sms_orc8r_service_handler.c
@@ -33,8 +33,8 @@ int handle_sms_orc8r_downlink_unitdata(
   MessageDef* message_p                              = NULL;
   itti_sgsap_downlink_unitdata_t* sgs_dl_unit_data_p = NULL;
 
-  message_p = itti_alloc_new_message(TASK_SMS_ORC8R, SGSAP_DOWNLINK_UNITDATA);
-  AssertFatal(message_p, "itti_alloc_new_message Failed");
+  message_p = DEPRECATEDitti_alloc_new_message_fatal(
+      TASK_SMS_ORC8R, SGSAP_DOWNLINK_UNITDATA);
   sgs_dl_unit_data_p = &message_p->ittiMsg.sgsap_downlink_unitdata;
   memset((void*) sgs_dl_unit_data_p, 0, sizeof(itti_sgsap_downlink_unitdata_t));
 

--- a/lte/gateway/c/core/oai/tasks/udp/udp_primitives_server.c
+++ b/lte/gateway/c/core/oai/tasks/udp/udp_primitives_server.c
@@ -146,8 +146,8 @@ static void udp_server_receive_and_process(
       udp_data_ind_t* udp_data_ind_p;
       AssertFatal(
           sizeof(udp_sock_pP->buffer) >= bytes_received, "UDP BUFFER OVERFLOW");
-      message_p = itti_alloc_new_message(TASK_UDP, UDP_DATA_IND);
-      DevAssert(message_p != NULL);
+      message_p =
+          DEPRECATEDitti_alloc_new_message_fatal(TASK_UDP, UDP_DATA_IND);
       udp_data_ind_p = &message_p->ittiMsg.udp_data_ind;
       memcpy(udp_data_ind_p->msgBuf, udp_sock_pP->buffer, bytes_received);
 

--- a/lte/gateway/c/core/oai/test/itti/test_itti.cpp
+++ b/lte/gateway/c/core/oai/test/itti/test_itti.cpp
@@ -112,7 +112,7 @@ class ITTIApiTest : public ::testing::Test {
   }
 
   virtual void TearDown() {
-    send_terminate_message(&task_zmq_ctx_main);
+    send_terminate_message_fatal(&task_zmq_ctx_main);
 
     // Sleep 100 msec to allow message to be received before
     // destroying zmq context
@@ -126,15 +126,15 @@ class ITTIApiTest : public ::testing::Test {
 
 TEST_F(ITTIApiTest, TestMessageLatency) {
   MessageDef* test_message_p;
-  test_message_p =
-      itti_alloc_new_message(task_zmq_ctx_test1.task_id, TEST_MESSAGE);
+  test_message_p = DEPRECATEDitti_alloc_new_message_fatal(
+      task_zmq_ctx_test1.task_id, TEST_MESSAGE);
   send_msg_to_task(&task_zmq_ctx_test1, TASK_TEST_2, test_message_p);
   // Sleep 100 msec to allow message to be received on time
   std::this_thread::sleep_for(std::chrono::milliseconds(100));
   ASSERT_LE(msg_latency, 1000);
 
-  test_message_p =
-      itti_alloc_new_message(task_zmq_ctx_test1.task_id, TEST_MESSAGE);
+  test_message_p = DEPRECATEDitti_alloc_new_message_fatal(
+      task_zmq_ctx_test1.task_id, TEST_MESSAGE);
   send_msg_to_task(&task_zmq_ctx_test1, TASK_TEST_2, test_message_p);
   // Sleep 2 seconds to allow message to be received and processed
   std::this_thread::sleep_for(std::chrono::seconds(2));


### PR DESCRIPTION
Signed-off-by: Andrei Lee <andreilee@fb.com>

## Summary

This PR is part of a process to make `Assert`s in MME more explicit. Library-equivalent functions will eventually never `Assert`, instead letting callers decide.

Modified `itti_alloc_new_message(..)` to actually return NULL values when out of memory. It used to Assert on NULL values. A new function `itti_alloc_new_message(..) has been provided.
## Test Plan

Only built MME

```
vagrant@magma-dev:~/magma/lte/gateway$ make build_oai
.
.
.
[7/7] Completed 'MagmaCore'
vagrant@magma-dev:~/magma/lte/gateway$
```

## Additional Information

- [ ] This change is backwards-breaking
