### PR TITLE
[Non_Sanity_Testing] Updated the s1ap_tests document with non-sanity testing step

### DIFF
--- a/docs/readmes/lte/s1ap_tests.md
+++ b/docs/readmes/lte/s1ap_tests.md
@@ -46,7 +46,7 @@ run is `s1aptests/test_attach_detach.py`.
 * Individual test(s): `make integ_test TESTS=<test(s)_to_run>`
 * All Sanity tests: `make integ_test`
 * All Non-Sanity tests: `make nonsanity`
-* Minimum test to be executed before committing changes to magma repository: `make precommit`
+* Minimal set of tests to be executed before committing changes to magma repository: `make precommit`
 
 **Note**: The traffic tests will fail as traffic server is not running in this
 setup. Look at the section below on running traffic tests.

--- a/docs/readmes/lte/s1ap_tests.md
+++ b/docs/readmes/lte/s1ap_tests.md
@@ -44,7 +44,9 @@ either individual tests or the full suite of tests. A safe, non-flaky test to
 run is `s1aptests/test_attach_detach.py`.
 
 * Individual test(s): `make integ_test TESTS=<test(s)_to_run>`
-* All tests: `make integ_test`
+* All Sanity tests: `make integ_test`
+* All Non-Sanity tests: `make nonsanity`
+* Minimum test to be executed before committing changes to magma repository: `make precommit`
 
 **Note**: The traffic tests will fail as traffic server is not running in this
 setup. Look at the section below on running traffic tests.


### PR DESCRIPTION
## Title
[Non_Sanity_Testing] Updated the s1ap_tests document with non-sanity testing step

## Summary
Recently non-sanity testing has been introduced for executing the test cases which were not part of sanity suite as part of PR #5840. This is supposed to help executing all the newly added test cases which remain untracked until needed.

This PR adds the step in the s1ap_tests document to run the set of non-sanity tests. Additionally this PR also updates the missing step to run set of precommit tests.

Signed-off-by: VinashakAnkitAman <ankit.aman@radisys.com>