### PR TITLE
[orc8r][helm] Fix dependency conflict for orc8r metric chart

### DIFF
--- a/orc8r/cloud/helm/orc8r/Chart.lock
+++ b/orc8r/cloud/helm/orc8r/Chart.lock
@@ -4,7 +4,7 @@ dependencies:
   version: 0.1.10
 - name: metrics
   repository: ""
-  version: 1.4.22
+  version: 1.4.23
 - name: nms
   repository: ""
   version: 0.1.11
@@ -14,5 +14,5 @@ dependencies:
 - name: orc8rlib
   repository: file://../orc8rlib
   version: 0.1.2
-digest: sha256:73383945a6f49b14bad2d42ffc0223286cd1d3f106319efc3739dc494547f08c
-generated: "2021-04-06T16:10:45.754709-07:00"
+digest: sha256:2b5a47a7b02c15ee9bd2a740f542f54c6068da49711e6d4fed063f5423b07d2e
+generated: "2021-06-10T08:49:34.426804-07:00"

--- a/orc8r/cloud/helm/orc8r/Chart.yaml
+++ b/orc8r/cloud/helm/orc8r/Chart.yaml
@@ -27,7 +27,7 @@ dependencies:
     repository: ""
     condition: secrets.create
   - name: metrics
-    version: 1.4.22
+    version: 1.4.23
     repository: ""
     condition: metrics.enabled
   - name: nms


### PR DESCRIPTION

## Summary

A new version of the metric helm chart raised an issue in the chart generation

## Test Plan

run the dependency update against the new set of versions and it is working

## Additional Information

Maybe it would be good to run the dependency check when filing a PR
