### PR TITLE
fix sentry release circle ci job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -435,17 +435,6 @@ commands:
             mkdir -p versions
             echo "${CIRCLE_SHA1:0:8}" > versions/<< parameters.file_prefix >>_version
 
-  tag-sentry-release:
-    parameters:
-      project_name:
-        type: string
-    steps:
-      - run: |
-          export SENTRY_RELEASE=${CIRCLE_SHA1:0:8}
-          sentry-cli releases new -p parameters.project_name $SENTRY_RELEASE
-          sentry-cli releases set-commits --auto $SENTRY_RELEASE
-          sentry-cli releases finalize $SENTRY_RELEASE
-
   notify-magma:
     description: Notify Slack when an artifact is published
     parameters:
@@ -510,15 +499,15 @@ jobs:
     docker:
       - image: circleci/node:4.8.2
     environment:
-      SENTRY_ORG: lf-9c
       SENTRY_ENVIRONMENT: staging
+      SENTRY_ORG: lf-9c
     steps:
       - checkout  # check out the code in the project directory
       - run: curl -sL https://sentry.io/get-cli/ | bash
-      - tag-sentry-release:
-          project_name: lab-agws-python
-      - tag-sentry-release:
-          project_name: lab-agws-native
+      - run: |
+          sentry-cli --log-level=info releases new -p lab-agws-python -p lab-agws-native ${CIRCLE_SHA1:0:8}
+          sentry-cli --log-level=info releases set-commits --auto --ignore-missing ${CIRCLE_SHA1:0:8}
+          sentry-cli --log-level=info releases finalize ${CIRCLE_SHA1:0:8}
 
   backport:
     machine:


### PR DESCRIPTION
Signed-off-by: Marie Bremner <marwhal@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary
Ran and tested locally
```
➜  magma git:(fix-sentry-release) ✗ circleci local execute --job "sentry-release" -e SENTRY_AUTH_TOKEN=**REDACTED**

Docker image digest: sha256:a705e4489616fccc12c07c209f48edb95c1749a69d29dfc7e87bb9fe25553a40
====>> Spin up environment
Build-agent version  ()
Docker Engine Version: 20.10.6
Kernel Version: Linux dbd19567f5d5 5.10.25-linuxkit #1 SMP Tue Mar 23 09:27:39 UTC 2021 x86_64 Linux
Starting container circleci/node:4.8.2
  image is cached as circleci/node:4.8.2, but refreshing...
4.8.2: Pulling from circleci/node
Digest: sha256:ddc83cb402457061b4d628d9045b6bc7ce16195f763001e50b80758348a0f9db
Status: Image is up to date for circleci/node:4.8.2
  pull stats: N/A
  time to create container: 38ms
  using image circleci/node@sha256:ddc83cb402457061b4d628d9045b6bc7ce16195f763001e50b80758348a0f9db
Time to upload agent and config: 1.2930331s
Time to start containers: 2.1082485s
====>> Preparing environment variables
Using build environment variables:
  BASH_ENV=/tmp/.bash_env-localbuild-1623341132
  CI=true
  CIRCLECI=true
  CIRCLE_BRANCH=fix-sentry-release
  CIRCLE_BUILD_NUM=
  CIRCLE_JOB=sentry-release
  CIRCLE_NODE_INDEX=0
  CIRCLE_NODE_TOTAL=1
  CIRCLE_REPOSITORY_URL=https://github.com/themarwhal/magma.git
  CIRCLE_SHA1=f1853f0bc7107b085d72fc006cfcd5ddbd18696f
  CIRCLE_SHELL_ENV=/tmp/.bash_env-localbuild-1623341132
  CIRCLE_WORKING_DIRECTORY=~/project

Using environment variables from project settings and/or contexts:
  SENTRY_AUTH_TOKEN=**REDACTED**

The redacted variables listed above will be masked in run step output.====>> Checkout code
Making checkout directory "/home/circleci/project"
Copying files from "/tmp/_circleci_local_build_repo" to "/home/circleci/project"
====>> curl -sL https://sentry.io/get-cli/ | bash
  #!/bin/bash -eo pipefail
curl -sL https://sentry.io/get-cli/ | bash
This script will automatically install sentry-cli 1.66.0 for you.
Installation path: /usr/local/bin/sentry-cli
######################################################################## 100.0%
Done!
====>> sentry-cli --log-level=info releases new -p lab-agws-python -p lab-agws-native ${CIRCLE_SHA1:0:8}
sentry-cli --log-level=info releases set-commits --auto --ignore-missing ${CIRCLE_SHA1:0:8}
sentry-cli --log-level=info releases finalize ${CIRCLE_SHA1:0:8}

  #!/bin/bash -eo pipefail
sentry-cli --log-level=info releases new -p lab-agws-python -p lab-agws-native ${CIRCLE_SHA1:0:8}
sentry-cli --log-level=info releases set-commits --auto --ignore-missing ${CIRCLE_SHA1:0:8}
sentry-cli --log-level=info releases finalize ${CIRCLE_SHA1:0:8}

  INFO    2021-06-10 16:06:15.900758400 +00:00 sentry-cli was invoked with the following command line: "sentry-cli" "--log-level=info" "releases" "new" "-p" "lab-agws-python" "-p" "lab-agws-native" "f1853f0b"
Created release f1853f0b.
  INFO    2021-06-10 16:06:16.312646300 +00:00 Running update nagger update check
  INFO    2021-06-10 16:06:16.512853900 +00:00 Looking for file named: sentry-cli-Linux-x86_64
  INFO    2021-06-10 16:06:16.512941300 +00:00 Found asset sentry-cli-Linux-x86_64
  INFO    2021-06-10 16:06:16.520855200 +00:00 sentry-cli was invoked with the following command line: "sentry-cli" "--log-level=info" "releases" "set-commits" "--auto" "--ignore-missing" "f1853f0b"
  INFO    2021-06-10 16:06:16.874938800 +00:00 Resolving HEAD (origin@HEAD)
Could not determine any commits to be associated with a repo-based integration. Proceeding to find commits from local git tree.
Could not find the SHA of the previous release in the git history. Skipping previous release and creating a new one with 20 commits.
Success! Set commits for release f1853f0b.
  INFO    2021-06-10 16:06:18.927076 +00:00 Skipping update nagger update check
  INFO    2021-06-10 16:06:18.935070 +00:00 sentry-cli was invoked with the following command line: "sentry-cli" "--log-level=info" "releases" "finalize" "f1853f0b"
Finalized release f1853f0b.
  INFO    2021-06-10 16:06:19.311675100 +00:00 Skipping update nagger update check
Success!
```
<img width="1014" alt="Screen Shot 2021-06-10 at 11 09 13 AM" src="https://user-images.githubusercontent.com/37634144/121559562-4e628680-c9dc-11eb-8406-b250a335aa88.png">
<!-- Enumerate changes you made and why you made them -->

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->

