### PR TITLE
feat(agw): Handling UE_SERVICE_REQUEST_ON_PAGING (Idle state to Active state) in SMF

### DIFF
--- a/lte/gateway/c/session_manager/LocalEnforcer.cpp
+++ b/lte/gateway/c/session_manager/LocalEnforcer.cpp
@@ -268,7 +268,8 @@ void LocalEnforcer::poll_stats_enforcer(int cookie, int cookie_mask) {
   // so we bind to the object and the two arguments the function needs
   // which are the status and RuleRecordTable response
   pipelined_client_->poll_stats(
-      cookie, cookie_mask, std::bind(&LocalEnforcer::handle_pipelined_response, this, _1, _2));
+      cookie, cookie_mask,
+      std::bind(&LocalEnforcer::handle_pipelined_response, this, _1, _2));
 }
 
 void LocalEnforcer::sync_sessions_on_restart(std::time_t current_time) {

--- a/lte/gateway/c/session_manager/SessionState.cpp
+++ b/lte/gateway/c/session_manager/SessionState.cpp
@@ -233,7 +233,7 @@ uint32_t SessionState::get_current_version() {
 }
 
 void SessionState::set_current_version(
-    int new_session_version, SessionStateUpdateCriteria* session_uc) {
+    uint32_t new_session_version, SessionStateUpdateCriteria* session_uc) {
   current_version_ = new_session_version;
   if (session_uc) {
     session_uc->is_current_version_updated = true;
@@ -244,7 +244,7 @@ void SessionState::set_current_version(
 
 /* Add PDR rule to this rules session list */
 void SessionState::insert_pdr(
-    SetGroupPDR* rule, bool crit_add, SessionStateUpdateCriteria* session_uc) {
+    SetGroupPDR* rule, SessionStateUpdateCriteria* session_uc) {
   // Check if it already exists
   int32_t Pdr_index;
   Pdr_index = get_pdr_index(rule->pdr_id());
@@ -256,7 +256,9 @@ void SessionState::insert_pdr(
     pdr_list_.push_back(*rule);
   }
   // update criteria to be updated
-  if (crit_add) session_uc->pdrs_to_install.push_back(*rule);
+  if (session_uc) {
+    session_uc->pdrs_to_install.push_back(*rule);
+  }
 }
 
 /* method to change the PDR state */
@@ -902,8 +904,7 @@ SessionTerminateRequest SessionState::make_termination_request(
   }
   // gy credits
   for (auto& credit_pair : credit_map_) {
-    SessionCreditUpdateCriteria* credit_uc =
-        get_credit_uc(credit_pair.first, session_uc);
+    auto credit_uc    = get_credit_uc(credit_pair.first, session_uc);
     auto credit_usage = credit_pair.second->get_credit_usage(
         CreditUsage::TERMINATED, credit_uc, true);
     credit_pair.first.set_credit_usage(&credit_usage);
@@ -1016,6 +1017,9 @@ bool SessionState::is_radius_cwf_session() const {
   return (config_.common_context.rat_type() == RATType::TGPP_WLAN);
 }
 
+bool SessionState::is_5g_session() const {
+  return (config_.common_context.rat_type() == RATType::TGPP_NR);
+}
 SessionState::SessionInfo SessionState::get_session_info() {
   SessionState::SessionInfo info;
   info.imsi      = get_imsi();
@@ -1565,11 +1569,16 @@ bool SessionState::is_active() {
 void SessionState::set_fsm_state(
     SessionFsmState new_state, SessionStateUpdateCriteria* session_uc) {
   // Only log and reflect change into update criteria if the state is new
+  uint32_t local_teid_ = get_upf_local_teid();
   if (curr_state_ != new_state) {
-    MLOG(MDEBUG) << "Session " << session_id_ << " Teid " << local_teid_
+    MLOG(MDEBUG) << "Session: " << session_id_ << " Teid: " << local_teid_
                  << " FSM state change from "
                  << session_fsm_state_to_str(curr_state_) << " to "
-                 << session_fsm_state_to_str(new_state);
+                 << session_fsm_state_to_str(new_state)
+                 << " of imsi: " << get_imsi();
+    if (is_5g_session()) {
+      MLOG(MDEBUG) << " 5G specific-PDU Id: " << get_pdu_id();
+    }
     curr_state_ = new_state;
     if (session_uc) {
       session_uc->is_fsm_updated    = true;

--- a/lte/gateway/c/session_manager/SessionState.h
+++ b/lte/gateway/c/session_manager/SessionState.h
@@ -154,11 +154,12 @@ class SessionState {
   /* methods of new messages of 5G and handle other message*/
   uint32_t get_current_version();
 
+  /* method to set update the session current version */
   void set_current_version(
-      int new_session_version, SessionStateUpdateCriteria* session_uc);
+      uint32_t new_session_version, SessionStateUpdateCriteria* session_uc);
 
-  void insert_pdr(
-      SetGroupPDR* rule, bool crit_add, SessionStateUpdateCriteria* session_uc);
+  /* method to add new PDR rules to session */
+  void insert_pdr(SetGroupPDR* rule, SessionStateUpdateCriteria* session_uc);
 
   /* method to change the PDR state */
   void set_all_pdrs(enum PdrState);

--- a/lte/gateway/c/session_manager/SessionStateEnforcer.h
+++ b/lte/gateway/c/session_manager/SessionStateEnforcer.h
@@ -85,6 +85,11 @@ class SessionStateEnforcer {
       const std::string& imsi, std::unique_ptr<SessionState>& session,
       SetSmNotificationContext notif, SessionStateUpdateCriteria* session_uc);
 
+  /* Move to active state */
+  void m5g_move_to_active_state(
+      std::unique_ptr<SessionState>& session, SetSmNotificationContext notif,
+      SessionStateUpdateCriteria* session_uc);
+
   /*Release request handle*/
   bool m5g_release_session(
       SessionMap& session_map, const std::string& imsi, const uint32_t& pdu_id,
@@ -140,23 +145,39 @@ class SessionStateEnforcer {
   bool add_default_rules(
       std::unique_ptr<SessionState>& session_state, const std::string& imsi);
 
-  /* Send session requst to upf */
-  void m5g_send_session_request_to_upf(
-      const std::string& imsi, const std::unique_ptr<SessionState>& session);
-
   /* Pdr State change routine */
   void m5g_pdr_rules_change_and_update_upf(
       const std::unique_ptr<SessionState>& session, enum PdrState pdrstate);
+
+  /*Start processing to terminate respective session requested from AMF*/
+  void m5g_start_session_termination(
+      SessionMap& session_map, const std::unique_ptr<SessionState>& session,
+      const uint32_t& pdu_id, SessionStateUpdateCriteria* session_uc);
 
   /* Set new fsm state and increment version*/
   void set_new_fsm_state_and_increment_version(
       std::unique_ptr<SessionState>& session, SessionFsmState target_state,
       SessionStateUpdateCriteria* session_uc);
 
-  /*Start processing to terminate respective session requested from AMF*/
-  void m5g_start_session_termination(
-      SessionMap& session_map, const std::unique_ptr<SessionState>& session,
-      const uint32_t& pdu_id, SessionStateUpdateCriteria* session_uc);
+  /* update the GNB endpoint details in a rule */
+  bool insert_pdr_from_core(
+      std::unique_ptr<SessionState>& session, SetGroupPDR& rule,
+      SessionStateUpdateCriteria* session_uc);
+
+  uint32_t insert_pdr_from_access(
+      std::unique_ptr<SessionState>& session, SetGroupPDR& rule,
+      SessionStateUpdateCriteria* session_uc);
+
+  /*
+   * Acquire and update session rules based on the IMSI
+   * @param session : reference to SessionState
+   * @param get_gnb_teid : true if existing session has gNB TEID, else false
+   * @param get_upf_teid : true if existing session has UPF TEID, else false
+   * @return upf_teid : returns updated UPF TEID from insert_pdr_from_access()
+   * */
+  uint32_t update_session_rules(
+      std::unique_ptr<SessionState>& session_state, bool get_gnb_teid,
+      bool get_upf_teid, SessionStateUpdateCriteria* session_uc);
 
   /*Function will clean up all resources related to requested session*/
   void m5g_complete_termination(
@@ -195,20 +216,6 @@ class SessionStateEnforcer {
    */
   void m5g_handle_termination_on_timeout(
       const std::string& imsi, const std::string& session_id);
-
-  /* update the GNB endpoint details in a rule */
-  bool insert_pdr_from_core(
-      const std::string& imsi, std::unique_ptr<SessionState>& session_state,
-      SetGroupPDR& rule, SessionStateUpdateCriteria* session_uc);
-
-  uint32_t insert_pdr_from_access(
-      std::unique_ptr<SessionState>& session_state, SetGroupPDR& rule,
-      SessionStateUpdateCriteria* session_uc);
-
-  uint32_t update_session_rules(
-      const std::string& imsi, std::unique_ptr<SessionState>& session_state,
-      bool gnb_teid_get, bool upf_teid_get,
-      SessionStateUpdateCriteria* session_uc);
 
   bool inc_rtx_counter(const std::unique_ptr<SessionState>& session);
 

--- a/lte/gateway/c/session_manager/SessionStore.cpp
+++ b/lte/gateway/c/session_manager/SessionStore.cpp
@@ -300,6 +300,7 @@ optional<SessionVector::iterator> SessionStore::find_session(
             break;
         }
         break;  // break IMSI_AND_TEID
+
       case IMSI_AND_PDUID:
         if ((*it)
                 ->get_config()

--- a/lte/gateway/c/session_manager/SetMessageManagerHandler.cpp
+++ b/lte/gateway/c/session_manager/SetMessageManagerHandler.cpp
@@ -166,6 +166,13 @@ void SetMessageManagerHandler::SetSmfNotification(
       case UE_IDLE_MODE_NOTIFY:
         idle_mode_change_sessions_handle(noti, response_callback);
         return;
+      case UE_PAGING_NOTIFY:
+        return;
+      case UE_PERIODIC_REG_ACTIVE_MODE_NOTIFY:
+        return;
+      case UE_SERVICE_REQUEST_ON_PAGING:
+        service_handle_request_on_paging(noti, response_callback);
+        return;
       default:
         return;
     }
@@ -397,4 +404,55 @@ void SetMessageManagerHandler::idle_mode_change_sessions_handle(
   return;
 }
 
+/* This function callled when specific IMSI service
+ * request is received from AMF.
+ */
+void SetMessageManagerHandler::service_handle_request_on_paging(
+    const SetSmNotificationContext& notif,
+    std::function<void(Status, SmContextVoid)> response_callback) {
+  // extract IMSI value from proto
+  auto imsi           = notif.common_context().sid().id();
+  auto session_map    = session_store_.read_sessions({imsi});
+  int count           = 0;
+  auto session_update = SessionStore::get_default_session_update(session_map);
+  for (auto& session : session_map[imsi]) {
+    if (session->get_state() == INACTIVE) {
+      auto session_id                        = session->get_session_id();
+      SessionStateUpdateCriteria& session_uc = session_update[imsi][session_id];
+      m5g_enforcer_->m5g_move_to_active_state(session, notif, &session_uc);
+      bool update_success = session_store_.update_sessions(session_update);
+      if (!update_success) {
+        MLOG(MINFO) << "Operation aborted in  middle"
+                    << " session id: " << session->get_session_id() << imsi
+                    << " of imsi";
+        continue;
+      }
+      MLOG(MDEBUG) << "Successfully updated SessionStore "
+                   << " session id: " << session->get_session_id() << imsi
+                   << " of imsi";
+      count++;
+    }
+  }
+  if (!count) {
+    MLOG(MINFO) << " No Valid session found for IMSI: " << imsi;
+    Status status(grpc::NOT_FOUND, "Sesion Not found");
+    response_callback(status, SmContextVoid());
+    return;
+  }
+  bool update_success = session_store_.update_sessions(session_update);
+  if (!update_success) {
+    Status status(grpc::ABORTED, "update operation aborted in  middle");
+    response_callback(status, SmContextVoid());
+    return;
+  }
+  // Send  Paging service request response back to AMF
+  auto session = session_map[imsi].begin();
+  m5g_enforcer_->handle_state_update_to_amf(
+      **session, magma::lte::M5GSMCause::OPERATION_SUCCESS,
+      UE_SERVICE_REQUEST_ON_PAGING);
+  MLOG(MDEBUG) << "Successfully updated SessionStore "
+               << "of subscriber :" << imsi;
+  response_callback(Status::OK, SmContextVoid());
+  return;
+}
 }  // end namespace magma

--- a/lte/gateway/c/session_manager/SetMessageManagerHandler.h
+++ b/lte/gateway/c/session_manager/SetMessageManagerHandler.h
@@ -83,6 +83,12 @@ class SetMessageManagerHandler : public SetMessageManager {
       const SetSmNotificationContext& notif,
       std::function<void(Status, SmContextVoid)> response_callback);
 
+  /* Handle service request received from AMF after paging request is sent
+   */
+  void service_handle_request_on_paging(
+      const SetSmNotificationContext& notif,
+      std::function<void(Status, SmContextVoid)> response_callback);
+
   /*
    * Send session creation related request to the CentralSessionController.
    * which is policy/QoS related. On successful, creates and populate,

--- a/lte/gateway/c/session_manager/test/test_set_session_manager_handler.cpp
+++ b/lte/gateway/c/session_manager/test/test_set_session_manager_handler.cpp
@@ -21,16 +21,20 @@
  * included in "SetMessageManagerHandler.h"
  */
 #include "SetMessageManagerHandler.h"
+#include "SessionStateEnforcer.h"
+#include "includes/MagmaService.h"
 #include "ProtobufCreators.h"
 #include "RuleStore.h"
 #include "SessionState.h"
 #include "SessionStore.h"
+#include "includes/ServiceRegistrySingleton.h"
 #include "SessiondMocks.h"
 #include "StoredState.h"
 #include "magma_logging.h"
 #include "PipelinedClient.h"
 #include "AmfServiceClient.h"
 #include "Consts.h"
+#include "EnumToString.h"
 
 using grpc::ServerContext;
 using grpc::Status;
@@ -172,6 +176,7 @@ class SessionManagerHandlerTest : public ::testing::Test {
   SessionIDGenerator id_gen_;
   folly::EventBase* evb;
   SessionMap session_map_;
+  std::unordered_multimap<std::string, uint32_t> pdr_map_;
 };  // End of class
 
 TEST_F(SessionManagerHandlerTest, test_SetAmfSessionContext) {
@@ -195,6 +200,42 @@ TEST_F(SessionManagerHandlerTest, test_SetAmfSessionContext) {
   auto& session_temp = session_map[IMSI1][0];
   EXPECT_EQ(session_temp->get_config().common_context.sid().id(), IMSI1);
 }
+
+TEST_F(SessionManagerHandlerTest, test_SetSmfNotification) {
+  magma::SetSMSessionContext session_ctx_req;
+  set_sm_session_context(&session_ctx_req);
+
+  magma::SetSmNotificationContext request;
+  set_sm_notif_context(&request, &session_ctx_req);
+
+  grpc::ServerContext server_context;
+
+  set_session_manager->SetSmfNotification(
+      &server_context, &request,
+      [this](grpc::Status status, SmContextVoid Void) {});
+
+  /* Validating the funcationality when specific IMSi and its associated
+   * sessions moved to idle mode
+   */
+  set_session_manager->idle_mode_change_sessions_handle(
+      request, [](grpc::Status status, SmContextVoid Void) {});
+
+  /* Validating the functionality when any specific  session moved to
+   * idle state
+   */
+  set_session_manager->pdu_session_inactive(
+      request, [](grpc::Status status, SmContextVoid Void) {});
+
+  /* Validating the functionality when specific IMSI service
+   * request is received from AMF.
+   */
+  set_session_manager->service_handle_request_on_paging(
+      request, [](grpc::Status status, SmContextVoid Void) {});
+
+  // Run session creation in the EventBase loop
+  evb->loopOnce();
+}
+
 TEST_F(SessionManagerHandlerTest, test_InitSessionContext) {
   magma::SetSMSessionContext request;
   set_sm_session_context(&request);
@@ -456,7 +497,109 @@ TEST_F(SessionManagerHandlerTest, test_SessionCompleteTerminationContext) {
       session_map, IMSI2, session_id, session_update);
 
   EXPECT_EQ(session_map[IMSI2].size(), 0);
+}
 
+TEST_F(SessionManagerHandlerTest, test_PDUStateChangeHandling) {
+  magma::SetSMSessionContext request;
+  set_sm_session_context(&request);
+  request.mutable_common_context()->mutable_sid()->set_id(
+      "IMSI000000000000002");
+
+  grpc::ServerContext server_context;
+
+  set_session_manager->SetAmfSessionContext(
+      &server_context, &request,
+      [this](grpc::Status status, SmContextVoid Void) {});
+
+  // Run session creation in the EventBase loop
+  evb->loopOnce();
+
+  auto session_map = session_store->read_sessions({IMSI2});
+  auto it          = session_map.find(IMSI2);
+  EXPECT_FALSE(it == session_map.end());
+  EXPECT_EQ(session_map[IMSI2].size(), 1);
+
+  SessionConfig cfg;
+  cfg.common_context       = request.common_context();
+  cfg.rat_specific_context = request.rat_specific_context();
+  cfg.rat_specific_context.mutable_m5gsm_session_context()->set_ssc_mode(
+      SSC_MODE_3);
+
+  SessionUpdate session_update =
+      SessionStore::get_default_session_update(session_map);
+  uint32_t pdu_id = 5;
+  SessionSearchCriteria id1_success_sid(IMSI2, IMSI_AND_PDUID, pdu_id);
+  auto session_it = session_store->find_session(session_map, id1_success_sid);
+  auto& session   = **session_it;
+  auto session_id = session->get_session_id();
+  SessionStateUpdateCriteria& session_uc = session_update[IMSI2][session_id];
+  SetSmNotificationContext notif;
+  std::string imsi;
+
+  /* pdu_session_inactive() and idle_mode_change_sessions_handle()
+   * call flows
+   */
+  session_enforcer->m5g_move_to_inactive_state(
+      imsi.assign(IMSI2), session, notif, &session_uc);
+
+  session_enforcer->set_new_fsm_state_and_increment_version(
+      session, INACTIVE, &session_uc);
+
+  session_enforcer->m5g_pdr_rules_change_and_update_upf(
+      session, magma::PdrState::IDLE);
+
+  session_enforcer->m5g_send_session_request_to_upf(session);
+
+  /* service_handle_request_on_paging() call flows */
+  session_enforcer->m5g_move_to_active_state(session, notif, &session_uc);
+  bool gnb_teid_get = false;
+  bool upf_teid_get = false;
+  session_enforcer->update_session_rules(
+      session, gnb_teid_get, upf_teid_get, &session_uc);
+
+  ConvergedRuleStore GlobalRuleList;
+  SetGroupPDR rule;
+  auto& session_state = session_map[imsi];
+
+  auto itp = pdr_map_.equal_range(imsi);
+  for (auto itr = itp.first; itr != itp.second; itr++) {
+    GlobalRuleList.get_rule(itr->second, &rule);
+    // Get the UE ip address
+    rule.mutable_pdi()->set_ue_ip_adr(
+        cfg.rat_specific_context.m5gsm_session_context()
+            .pdu_address()
+            .redirect_server_address());
+
+    auto src_iface = rule.pdi().src_interface();
+    EXPECT_EQ(src_iface, magma::SourceInterfaceType::ACCESS);
+    uint32_t upf_teid = session_enforcer->insert_pdr_from_access(
+        session_state[1], rule, &session_uc);
+    EXPECT_EQ(upf_teid, session_enforcer->get_next_teid());
+
+    EXPECT_EQ(src_iface, magma::SourceInterfaceType::CORE);
+    EXPECT_TRUE(session_enforcer->insert_pdr_from_core(
+        session_state[1], rule, &session_uc));
+  }
+  session_enforcer->m5g_pdr_rules_change_and_update_upf(
+      session, magma::PdrState::INSTALL);
+
+  session_enforcer->handle_state_update_to_amf(
+      *session, magma::lte::M5GSMCause::OPERATION_SUCCESS,
+      magma::NotifyUeEvents::UE_SERVICE_REQUEST_ON_PAGING);
+
+  EXPECT_FALSE(it == session_map.end());
+  EXPECT_EQ(session_map[IMSI2].size(), 1);
+  auto& session_temp = session_map[IMSI2][0];
+  EXPECT_EQ(session_temp->get_config().common_context.sid().id(), IMSI2);
+
+  session_enforcer->m5g_release_session(
+      session_map, imsi, pdu_id, session_update);
+
+  session_enforcer->m5g_start_session_termination(
+      session_map, session, pdu_id, &session_uc);
+
+  session_enforcer->m5g_pdr_rules_change_and_update_upf(
+      session, magma::PdrState::REMOVE);
 }
 
 int main(int argc, char** argv) {


### PR DESCRIPTION
[5G SA][LTE][AGW][SMF]: Handling UE_SERVICE_REQUEST_ON_PAGING (Idle state to Active state)

## Summary

1) Specific IMSI service request is received from AMF.
2) Read the SessionMap from global session_store.
3) Check pre-condition for session state, it should be INACTIVE
4) move the fms state to CREATED
5) Reattach or get rules to the session.
6) Send the message to UPF for INSTALL the PDR
7) Handle the response notification from upf w.r.t. UPF message.
8) Update the state change notification to AMF

## Test Plan
Added new test case to "test_set_session_manager_handler.cpp" file to check the functionality of service_handle_request_on_paging(), m5g_move_to_active_state(), update_session_rules(), m5g_pdr_rules_change_and_update_upf(),  handle_state_update_to_amf()


## Additional Information

Signed-off-by: GANESH-WAVELABS <ganesh.irrinki@wavelabs.ai>