### PR TITLE
AGW: gtp: add support for segmentation offload.

### DIFF
--- a/third_party/gtp_ovs/ovs-gtp-patches/2.14/0001-of-match-expand-NXM_NX_TUN_FLAGS-to-include-all-tunn.patch
+++ b/third_party/gtp_ovs/ovs-gtp-patches/2.14/0001-of-match-expand-NXM_NX_TUN_FLAGS-to-include-all-tunn.patch
@@ -1,7 +1,7 @@
-From 26867647007d94a8ebadda08b4a6f5f699ab1849 Mon Sep 17 00:00:00 2001
+From 87b8032282d178144bf6cfc78e2f2b96ef13c8c3 Mon Sep 17 00:00:00 2001
 From: Pravin B Shelar <pbshelar@fb.com>
 Date: Sun, 28 Jun 2020 21:49:40 +0000
-Subject: [PATCH 01/18] of-match: expand NXM_NX_TUN_FLAGS to include all tunnel
+Subject: [PATCH 01/19] of-match: expand NXM_NX_TUN_FLAGS to include all tunnel
  flags
 
 This allows OVS flows to match tunnel key and df flags. maching on

--- a/third_party/gtp_ovs/ovs-gtp-patches/2.14/0002-userspace-IPFIX-Add-tunnel-type-GTP.patch
+++ b/third_party/gtp_ovs/ovs-gtp-patches/2.14/0002-userspace-IPFIX-Add-tunnel-type-GTP.patch
@@ -1,7 +1,7 @@
-From 2da46c5e703da0d812d04832518a5cb71b7728a3 Mon Sep 17 00:00:00 2001
+From a65af73631599aea3621a8e50c24adb0fcf29190 Mon Sep 17 00:00:00 2001
 From: Pravin B Shelar <pbshelar@fb.com>
 Date: Mon, 24 Feb 2020 04:29:56 +0000
-Subject: [PATCH 02/18] userspace: IPFIX: Add tunnel type GTP
+Subject: [PATCH 02/19] userspace: IPFIX: Add tunnel type GTP
 
 Add support for ingress/egress tunnel type GTP
 in IPFIX.

--- a/third_party/gtp_ovs/ovs-gtp-patches/2.14/0003-datapath-add-vport-gtp-for-GPRS-Tunneling-Protocol.patch
+++ b/third_party/gtp_ovs/ovs-gtp-patches/2.14/0003-datapath-add-vport-gtp-for-GPRS-Tunneling-Protocol.patch
@@ -1,7 +1,7 @@
-From ec7b43321e145fc641c7054a280d47f93bf022e5 Mon Sep 17 00:00:00 2001
+From ee2a0eebb6085adc47f20ed94fd90ca08b8acef0 Mon Sep 17 00:00:00 2001
 From: Pravin B Shelar <pbshelar@fb.com>
 Date: Sat, 28 Nov 2020 00:55:30 -0800
-Subject: [PATCH 03/18] datapath: add vport-gtp for GPRS Tunneling Protocol
+Subject: [PATCH 03/19] datapath: add vport-gtp for GPRS Tunneling Protocol
 
 Add vport-gtp which uses gtp_create_flow_based_dev exported by the Linux GTP
 module to create a flow based net_device

--- a/third_party/gtp_ovs/ovs-gtp-patches/2.14/0004-ovs-Add-support-to-set-GTP-header-fields.patch
+++ b/third_party/gtp_ovs/ovs-gtp-patches/2.14/0004-ovs-Add-support-to-set-GTP-header-fields.patch
@@ -1,7 +1,7 @@
-From 838507bcc1753df3d26b12b6e841daec151b22c8 Mon Sep 17 00:00:00 2001
+From 79b56fee795f7e0808bdc9b84beeb55def63da73 Mon Sep 17 00:00:00 2001
 From: Pravin B Shelar <pbshelar@fb.com>
 Date: Sat, 28 Nov 2020 00:58:18 -0800
-Subject: [PATCH 04/18] ovs: Add support to set GTP header fields.
+Subject: [PATCH 04/19] ovs: Add support to set GTP header fields.
 
 This allows OVS to match and set GTP header fields.
 This is useful when controller wants to send GTP
@@ -456,7 +456,7 @@ index 1c5a4930a..a59c0f9bf 100644
       * OXM: NXOXM_ET_GTPU_MSGTYPE(16) since v2.13.
       */
 diff --git a/lib/dpif-netlink.c b/lib/dpif-netlink.c
-index ae2a29322..7ff4bc1ec 100644
+index ef7ffe506..cd98a6980 100644
 --- a/lib/dpif-netlink.c
 +++ b/lib/dpif-netlink.c
 @@ -2520,8 +2520,7 @@ parse_odp_packet(struct ofpbuf *buf, struct dpif_upcall *upcall,

--- a/third_party/gtp_ovs/ovs-gtp-patches/2.14/0005-OVS-gtp-echo-handling.patch
+++ b/third_party/gtp_ovs/ovs-gtp-patches/2.14/0005-OVS-gtp-echo-handling.patch
@@ -1,7 +1,7 @@
-From 6f02a088ddfed42206a52b614d5e37887ef89064 Mon Sep 17 00:00:00 2001
+From 523519e3a84add450a4121ba3973bf93c2917fa5 Mon Sep 17 00:00:00 2001
 From: Pravin B Shelar <pbshelar@fb.com>
 Date: Mon, 29 Jun 2020 02:45:36 +0000
-Subject: [PATCH 05/18] OVS: gtp echo handling
+Subject: [PATCH 05/19] OVS: gtp echo handling
 
 This uses OVS BFD module to send ech msgs.
 
@@ -785,7 +785,7 @@ index 3426a27b2..5d1bd84d5 100644
  void xlate_mac_learning_update(const struct ofproto_dpif *ofproto,
                                 ofp_port_t in_port, struct eth_addr dl_src,
 diff --git a/ofproto/ofproto-dpif.c b/ofproto/ofproto-dpif.c
-index 4f0638f23..7c6c1ea77 100644
+index 0f8ae8a73..a8a49adf0 100644
 --- a/ofproto/ofproto-dpif.c
 +++ b/ofproto/ofproto-dpif.c
 @@ -5265,6 +5265,23 @@ ofproto_dpif_send_packet(const struct ofport_dpif *ofport, bool oam,

--- a/third_party/gtp_ovs/ovs-gtp-patches/2.14/0006-ovs-test-add-gtp-marker-test.patch
+++ b/third_party/gtp_ovs/ovs-gtp-patches/2.14/0006-ovs-test-add-gtp-marker-test.patch
@@ -1,7 +1,7 @@
-From 48b06eccb7773be8f355a7de05895e79a7bbe471 Mon Sep 17 00:00:00 2001
+From b151adf9017dfc2c35f9f072bcaae8431686232a Mon Sep 17 00:00:00 2001
 From: Pravin B Shelar <pbshelar@fb.com>
 Date: Mon, 29 Jun 2020 06:54:04 +0000
-Subject: [PATCH 06/18] ovs: test: add gtp marker test
+Subject: [PATCH 06/19] ovs: test: add gtp marker test
 
 Signed-off-by: Pravin B Shelar <pbshelar@fb.com>
 ---

--- a/third_party/gtp_ovs/ovs-gtp-patches/2.14/0007-datapath-Fixes-for-4.9-kernel.patch
+++ b/third_party/gtp_ovs/ovs-gtp-patches/2.14/0007-datapath-Fixes-for-4.9-kernel.patch
@@ -1,7 +1,7 @@
-From 4e37f667d5ed99b2c18f371dda392754bfc16324 Mon Sep 17 00:00:00 2001
+From 7be0ef9941a9051c445ccdbcda11d3e069f72c12 Mon Sep 17 00:00:00 2001
 From: Pravin B Shelar <pbshelar@fb.com>
 Date: Tue, 7 Jul 2020 01:46:36 +0000
-Subject: [PATCH 07/18] datapath: Fixes for 4.9 kernel
+Subject: [PATCH 07/19] datapath: Fixes for 4.9 kernel
 
 Signed-off-by: Pravin B Shelar <pbshelar@fb.com>
 ---

--- a/third_party/gtp_ovs/ovs-gtp-patches/2.14/0008-ovs-datapath-enable-kernel-5.6.patch
+++ b/third_party/gtp_ovs/ovs-gtp-patches/2.14/0008-ovs-datapath-enable-kernel-5.6.patch
@@ -1,7 +1,7 @@
-From f797dfb0ea14ace9ea0460b65248bfd5f75ddb6a Mon Sep 17 00:00:00 2001
+From b0cf4049573df3cba343f36b86e82e6f859196ca Mon Sep 17 00:00:00 2001
 From: Pravin B Shelar <pbshelar@fb.com>
 Date: Fri, 21 Aug 2020 05:35:16 +0000
-Subject: [PATCH 08/18] ovs: datapath enable kernel 5.6
+Subject: [PATCH 08/19] ovs: datapath enable kernel 5.6
 
 Signed-off-by: Pravin B Shelar <pbshelar@fb.com>
 ---

--- a/third_party/gtp_ovs/ovs-gtp-patches/2.14/0009-AGW-OVS-handle-gtp-tunnel-type.patch
+++ b/third_party/gtp_ovs/ovs-gtp-patches/2.14/0009-AGW-OVS-handle-gtp-tunnel-type.patch
@@ -1,7 +1,7 @@
-From 37392b2146168d4bee7e0f3b9241967891d7613f Mon Sep 17 00:00:00 2001
+From 0ca214dc8e6360ba54189564ca3680269249ad89 Mon Sep 17 00:00:00 2001
 From: Pravin B Shelar <pbshelar@fb.com>
 Date: Wed, 23 Sep 2020 04:01:59 +0000
-Subject: [PATCH 09/18] AGW: OVS: handle gtp tunnel type
+Subject: [PATCH 09/19] AGW: OVS: handle gtp tunnel type
 
 magma GTP implementation defines gtp as tunnel type for OVS tunnel.
 But upstream ovs it is defined as gtpu. This patch maps older name to

--- a/third_party/gtp_ovs/ovs-gtp-patches/2.14/0010-native-tnl-routing-tunnel-lookup-with-pkt-mark.patch
+++ b/third_party/gtp_ovs/ovs-gtp-patches/2.14/0010-native-tnl-routing-tunnel-lookup-with-pkt-mark.patch
@@ -1,7 +1,7 @@
-From de965f4d0ec7a37bdcc7a71c30007ec036956f7e Mon Sep 17 00:00:00 2001
+From eb4587e70f33ab8dbb7e4e40661e8f527ad5b52c Mon Sep 17 00:00:00 2001
 From: Pravin B Shelar <pbshelar@fb.com>
 Date: Sun, 27 Sep 2020 19:46:24 +0000
-Subject: [PATCH 10/18] native-tnl: routing: tunnel lookup with pkt-mark
+Subject: [PATCH 10/19] native-tnl: routing: tunnel lookup with pkt-mark
 
 In case of zero packet mark ignore packet mark in lookup.
 

--- a/third_party/gtp_ovs/ovs-gtp-patches/2.14/0011-fixes-for-2.14.patch
+++ b/third_party/gtp_ovs/ovs-gtp-patches/2.14/0011-fixes-for-2.14.patch
@@ -1,7 +1,7 @@
-From b4ef3b4e48b5c7c8904a74750a2019c410640a13 Mon Sep 17 00:00:00 2001
+From 88711c9e6cde32e62c2e20052c22eebf687f98b7 Mon Sep 17 00:00:00 2001
 From: Pravin B Shelar <pbshelar@fb.com>
 Date: Sat, 28 Nov 2020 23:09:50 -0800
-Subject: [PATCH 11/18] fixes for 2.14
+Subject: [PATCH 11/19] fixes for 2.14
 
 ---
  datapath/flow_netlink.c                       |  2 ++

--- a/third_party/gtp_ovs/ovs-gtp-patches/2.14/0012-Add-custom-IPDR-fields-for-IPFIX-export.patch
+++ b/third_party/gtp_ovs/ovs-gtp-patches/2.14/0012-Add-custom-IPDR-fields-for-IPFIX-export.patch
@@ -1,7 +1,7 @@
-From 76984e225b495bffcaf3e85933520da3e8f7705d Mon Sep 17 00:00:00 2001
+From 8df219052ba373beb03a819b3ec8575879b665e0 Mon Sep 17 00:00:00 2001
 From: Nick Yurchenko <koolzz@fb.com>
 Date: Mon, 1 Feb 2021 21:25:00 -0500
-Subject: [PATCH 12/18] Add custom IPDR fields for IPFIX export
+Subject: [PATCH 12/19] Add custom IPDR fields for IPFIX export
 
 Signed-off-by: Nick Yurchenko <koolzz@fb.com>
 ---
@@ -53,10 +53,10 @@ index a1d0d0fba..9dbff67a4 100644
  int odp_put_userspace_action(uint32_t pid,
                               const void *userdata, size_t userdata_size,
 diff --git a/lib/ofp-actions.c b/lib/ofp-actions.c
-index aa38b884c..4e9a35db9 100644
+index 64e77249b..4db224df1 100644
 --- a/lib/ofp-actions.c
 +++ b/lib/ofp-actions.c
-@@ -6129,10 +6129,13 @@ struct nx_action_sample2 {
+@@ -6156,10 +6156,13 @@ struct nx_action_sample2 {
      ovs_be32 obs_domain_id;         /* ID of sampling observation domain. */
      ovs_be32 obs_point_id;          /* ID of sampling observation point. */
      ovs_be16 sampling_port;         /* Sampling port. */
@@ -71,7 +71,7 @@ index aa38b884c..4e9a35db9 100644
  
  static enum ofperr
  decode_NXAST_RAW_SAMPLE(const struct nx_action_sample *nas,
-@@ -6169,6 +6172,9 @@ decode_SAMPLE2(const struct nx_action_sample2 *nas,
+@@ -6196,6 +6199,9 @@ decode_SAMPLE2(const struct nx_action_sample2 *nas,
      sample->obs_domain_id = ntohl(nas->obs_domain_id);
      sample->obs_point_id = ntohl(nas->obs_point_id);
      sample->sampling_port = u16_to_ofp(ntohs(nas->sampling_port));
@@ -81,7 +81,7 @@ index aa38b884c..4e9a35db9 100644
      sample->direction = direction;
  
      if (sample->probability == 0) {
-@@ -6215,6 +6221,9 @@ encode_SAMPLE2(const struct ofpact_sample *sample,
+@@ -6242,6 +6248,9 @@ encode_SAMPLE2(const struct ofpact_sample *sample,
      nas->obs_point_id = htonl(sample->obs_point_id);
      nas->sampling_port = htons(ofp_to_u16(sample->sampling_port));
      nas->direction = sample->direction;
@@ -91,7 +91,7 @@ index aa38b884c..4e9a35db9 100644
  }
  
  static void
-@@ -6247,8 +6256,11 @@ parse_SAMPLE(char *arg, const struct ofpact_parse_params *pp)
+@@ -6274,8 +6283,11 @@ parse_SAMPLE(char *arg, const struct ofpact_parse_params *pp)
      struct ofpact_sample *os = ofpact_put_SAMPLE(pp->ofpacts);
      os->sampling_port = OFPP_NONE;
      os->direction = NX_ACTION_SAMPLE_DEFAULT;
@@ -103,7 +103,7 @@ index aa38b884c..4e9a35db9 100644
      while (ofputil_parse_key_value(&arg, &key, &value)) {
          char *error = NULL;
  
-@@ -6257,6 +6269,20 @@ parse_SAMPLE(char *arg, const struct ofpact_parse_params *pp)
+@@ -6284,6 +6296,20 @@ parse_SAMPLE(char *arg, const struct ofpact_parse_params *pp)
              if (!error && os->probability == 0) {
                  error = xasprintf("invalid probability value \"%s\"", value);
              }
@@ -124,7 +124,7 @@ index aa38b884c..4e9a35db9 100644
          } else if (!strcmp(key, "collector_set_id")) {
              error = str_to_u32(value, &os->collector_set_id);
          } else if (!strcmp(key, "obs_domain_id")) {
-@@ -6294,12 +6320,18 @@ format_SAMPLE(const struct ofpact_sample *a,
+@@ -6321,12 +6347,18 @@ format_SAMPLE(const struct ofpact_sample *a,
      ds_put_format(fp->s, "%ssample(%s%sprobability=%s%"PRIu16
                    ",%scollector_set_id=%s%"PRIu32
                    ",%sobs_domain_id=%s%"PRIu32

--- a/third_party/gtp_ovs/ovs-gtp-patches/2.14/0013-ovs-Handle-spaces-in-ovs-arguments.patch
+++ b/third_party/gtp_ovs/ovs-gtp-patches/2.14/0013-ovs-Handle-spaces-in-ovs-arguments.patch
@@ -1,7 +1,7 @@
-From 8805b4f31c3139ffb5ef02494abb97271d047338 Mon Sep 17 00:00:00 2001
+From 6a3cb779340b524dab45478ee2e5ed114e7c04e3 Mon Sep 17 00:00:00 2001
 From: Pravin B Shelar <pbshelar@fb.com>
 Date: Fri, 13 Mar 2020 19:18:40 +0000
-Subject: [PATCH 13/18] ovs: Handle spaces in ovs arguments
+Subject: [PATCH 13/19] ovs: Handle spaces in ovs arguments
 
 Signed-off-by: Pravin B Shelar <pbshelar@fb.com>
 ---
@@ -12,10 +12,10 @@ Signed-off-by: Pravin B Shelar <pbshelar@fb.com>
  4 files changed, 62 insertions(+), 12 deletions(-)
 
 diff --git a/lib/ofp-actions.c b/lib/ofp-actions.c
-index 4e9a35db9..db8ba92ff 100644
+index 4db224df1..bcd67bae9 100644
 --- a/lib/ofp-actions.c
 +++ b/lib/ofp-actions.c
-@@ -6270,8 +6270,11 @@ parse_SAMPLE(char *arg, const struct ofpact_parse_params *pp)
+@@ -6297,8 +6297,11 @@ parse_SAMPLE(char *arg, const struct ofpact_parse_params *pp)
                  error = xasprintf("invalid probability value \"%s\"", value);
              }
          } else if (!strcmp(key, "apn_name")) {
@@ -28,7 +28,7 @@ index 4e9a35db9..db8ba92ff 100644
                  if ((char)value[i] == '\0')
                      break;
              }
-@@ -6320,18 +6323,25 @@ format_SAMPLE(const struct ofpact_sample *a,
+@@ -6347,18 +6350,25 @@ format_SAMPLE(const struct ofpact_sample *a,
      ds_put_format(fp->s, "%ssample(%s%sprobability=%s%"PRIu16
                    ",%scollector_set_id=%s%"PRIu32
                    ",%sobs_domain_id=%s%"PRIu32

--- a/third_party/gtp_ovs/ovs-gtp-patches/2.14/0014-Add-pdp_start_epoch-custom-field-to-IPFIX-export.patch
+++ b/third_party/gtp_ovs/ovs-gtp-patches/2.14/0014-Add-pdp_start_epoch-custom-field-to-IPFIX-export.patch
@@ -1,7 +1,7 @@
-From 5c5e4f06d525d49cfa3baba68d26daf559ed77c4 Mon Sep 17 00:00:00 2001
+From c5b551e20854ef6673bcd429f17531c648dbaf6b Mon Sep 17 00:00:00 2001
 From: Nick Yurchenko <koolzz@fb.com>
 Date: Mon, 1 Feb 2021 21:46:32 -0500
-Subject: [PATCH 14/18] Add pdp_start_epoch custom field to IPFIX export
+Subject: [PATCH 14/19] Add pdp_start_epoch custom field to IPFIX export
 
 Signed-off-by: Nick Yurchenko <koolzz@fb.com>
 ---
@@ -47,10 +47,10 @@ index 9dbff67a4..a32ab220b 100644
  int odp_put_userspace_action(uint32_t pid,
                               const void *userdata, size_t userdata_size,
 diff --git a/lib/ofp-actions.c b/lib/ofp-actions.c
-index db8ba92ff..daf48711c 100644
+index bcd67bae9..713d45108 100644
 --- a/lib/ofp-actions.c
 +++ b/lib/ofp-actions.c
-@@ -6132,10 +6132,11 @@ struct nx_action_sample2 {
+@@ -6159,10 +6159,11 @@ struct nx_action_sample2 {
      uint8_t  msisdn[16];
      struct   eth_addr apn_mac_addr;
      uint8_t  apn_name[24];
@@ -63,7 +63,7 @@ index db8ba92ff..daf48711c 100644
  
  static enum ofperr
  decode_NXAST_RAW_SAMPLE(const struct nx_action_sample *nas,
-@@ -6173,6 +6174,7 @@ decode_SAMPLE2(const struct nx_action_sample2 *nas,
+@@ -6200,6 +6201,7 @@ decode_SAMPLE2(const struct nx_action_sample2 *nas,
      sample->obs_point_id = ntohl(nas->obs_point_id);
      sample->sampling_port = u16_to_ofp(ntohs(nas->sampling_port));
      sample->apn_mac_addr = nas->apn_mac_addr;
@@ -71,7 +71,7 @@ index db8ba92ff..daf48711c 100644
      memcpy(&sample->msisdn, &nas->msisdn, 16);
      memcpy(&sample->apn_name, &nas->apn_name, 24);
      sample->direction = direction;
-@@ -6224,6 +6226,7 @@ encode_SAMPLE2(const struct ofpact_sample *sample,
+@@ -6251,6 +6253,7 @@ encode_SAMPLE2(const struct ofpact_sample *sample,
      memcpy(&nas->msisdn, &sample->msisdn, 16);
      nas->apn_mac_addr = sample->apn_mac_addr;
      memcpy(&nas->apn_name, &sample->apn_name, 24);
@@ -79,7 +79,7 @@ index db8ba92ff..daf48711c 100644
  }
  
  static void
-@@ -6286,6 +6289,8 @@ parse_SAMPLE(char *arg, const struct ofpact_parse_params *pp)
+@@ -6313,6 +6316,8 @@ parse_SAMPLE(char *arg, const struct ofpact_parse_params *pp)
              }
          } else if (!strcmp(key, "apn_mac_addr")) {
              error = str_to_mac(value, &os->apn_mac_addr);
@@ -88,7 +88,7 @@ index db8ba92ff..daf48711c 100644
          } else if (!strcmp(key, "collector_set_id")) {
              error = str_to_u32(value, &os->collector_set_id);
          } else if (!strcmp(key, "obs_domain_id")) {
-@@ -6323,12 +6328,14 @@ format_SAMPLE(const struct ofpact_sample *a,
+@@ -6350,12 +6355,14 @@ format_SAMPLE(const struct ofpact_sample *a,
      ds_put_format(fp->s, "%ssample(%s%sprobability=%s%"PRIu16
                    ",%scollector_set_id=%s%"PRIu32
                    ",%sobs_domain_id=%s%"PRIu32

--- a/third_party/gtp_ovs/ovs-gtp-patches/2.14/0015-GTP-Extension-header-support-in-ovs2.14.patch
+++ b/third_party/gtp_ovs/ovs-gtp-patches/2.14/0015-GTP-Extension-header-support-in-ovs2.14.patch
@@ -1,7 +1,7 @@
-From 66adf1b83d359cce6d1a9caa23c95eaeea3a0e68 Mon Sep 17 00:00:00 2001
+From 900e2c33b6b0d8a739f9b5dec36af24a5681393b Mon Sep 17 00:00:00 2001
 From: YOGESH PANDEY <yogesh@wavelabs.ai>
 Date: Thu, 25 Mar 2021 16:48:07 +0530
-Subject: [PATCH 15/18] GTP Extension header support in ovs2.14
+Subject: [PATCH 15/19] GTP Extension header support in ovs2.14
 
 Add GTP Extension header Processing. Following are the changes :
   1. When a GTPU packet comes from GNB the extension header is

--- a/third_party/gtp_ovs/ovs-gtp-patches/2.14/0016-ODP-action-Fix-L3-port-to-L3-port-traffic.patch
+++ b/third_party/gtp_ovs/ovs-gtp-patches/2.14/0016-ODP-action-Fix-L3-port-to-L3-port-traffic.patch
@@ -1,7 +1,7 @@
-From 5a69d8769870f24968e549d8ad937a900e9c3d1e Mon Sep 17 00:00:00 2001
+From 8ce2f4b78741f17769251ded235a21b9f20dd91b Mon Sep 17 00:00:00 2001
 From: Pravin B Shelar <pbshelar@fb.com>
 Date: Sun, 18 Apr 2021 17:17:56 +0000
-Subject: [PATCH 16/18] ODP-action: Fix L3 port to L3 port traffic.
+Subject: [PATCH 16/19] ODP-action: Fix L3 port to L3 port traffic.
 
 Signed-off-by: Pravin B Shelar <pbshelar@fb.com>
 ---

--- a/third_party/gtp_ovs/ovs-gtp-patches/2.14/0017-datapath-GTP-cleanup.patch
+++ b/third_party/gtp_ovs/ovs-gtp-patches/2.14/0017-datapath-GTP-cleanup.patch
@@ -1,7 +1,7 @@
-From 18c7474159d91f05c0c3510885552242d68ed7ff Mon Sep 17 00:00:00 2001
+From 3563e8046fe2d5987dcdc0f21403daa6969d5885 Mon Sep 17 00:00:00 2001
 From: Pravin B Shelar <pbshelar@fb.com>
 Date: Sun, 9 May 2021 06:11:10 +0000
-Subject: [PATCH 17/18] datapath: GTP: cleanup
+Subject: [PATCH 17/19] datapath: GTP: cleanup
 
 Get rid of pdp based GTP dev interface.
 Signed-off-by: Pravin B Shelar <pbshelar@fb.com>

--- a/third_party/gtp_ovs/ovs-gtp-patches/2.14/0018-GTP-handle-seq-number-in-HDR.patch
+++ b/third_party/gtp_ovs/ovs-gtp-patches/2.14/0018-GTP-handle-seq-number-in-HDR.patch
@@ -1,7 +1,7 @@
-From f6701010896aeb5aec0ea6a06407abb1e0ea54b1 Mon Sep 17 00:00:00 2001
+From 2c11949caf89fb599678219678c13ded30d6704d Mon Sep 17 00:00:00 2001
 From: Pravin B Shelar <pbshelar@fb.com>
 Date: Fri, 28 May 2021 16:06:54 +0000
-Subject: [PATCH 18/18] GTP: handle seq number in HDR
+Subject: [PATCH 18/19] GTP: handle seq number in HDR
 
 ---
  datapath/linux/compat/gtp.c | 11 ++++++++---

--- a/third_party/gtp_ovs/ovs-gtp-patches/2.14/0019-datapath-gtp-add-segmentation-offloads.patch
+++ b/third_party/gtp_ovs/ovs-gtp-patches/2.14/0019-datapath-gtp-add-segmentation-offloads.patch
@@ -1,0 +1,101 @@
+From 7127120cdda00421998252ee07b9751219e03a41 Mon Sep 17 00:00:00 2001
+From: Pravin B Shelar <pbshelar@fb.com>
+Date: Tue, 8 Jun 2021 01:44:33 +0000
+Subject: [PATCH 19/19] datapath: gtp: add segmentation offloads
+
+Signed-off-by: Pravin B Shelar <pbshelar@fb.com>
+---
+ datapath/linux/compat/gtp.c    | 22 +++++++++++++++++++---
+ debian/changelog               |  2 +-
+ tests/system-layer3-tunnels.at |  4 ++--
+ 3 files changed, 22 insertions(+), 6 deletions(-)
+
+diff --git a/datapath/linux/compat/gtp.c b/datapath/linux/compat/gtp.c
+index 75c5c547c..5046bd63a 100644
+--- a/datapath/linux/compat/gtp.c
++++ b/datapath/linux/compat/gtp.c
+@@ -440,6 +440,7 @@ static netdev_tx_t gtp_dev_xmit_fb(struct sk_buff *skb, struct net_device *dev)
+         __u8 ttl;
+         __u8 set_qfi = 0;
+         __u8 csum;
++        int err;
+ 
+ 	/* Read the IP destination address and resolve the PDP context.
+ 	 * Prepend PDP header with TEI/TID from PDP ctx.
+@@ -458,6 +459,12 @@ static netdev_tx_t gtp_dev_xmit_fb(struct sk_buff *skb, struct net_device *dev)
+ 
+ 	skb_dst_drop(skb);
+         csum = !!(info->key.tun_flags & TUNNEL_CSUM);
++        err = udp_tunnel_handle_offloads(skb, csum);
++        if (err)
++                goto err_rt;
++        netdev_dbg(dev, "skb->protocol %d\n", skb->protocol);
++        ovs_skb_set_inner_protocol(skb, cpu_to_be16(ETH_P_IP));
++
+         ttl = info->key.ttl;
+         df = info->key.tun_flags & TUNNEL_DONT_FRAGMENT ? htons(IP_DF) : 0;
+         netdev_dbg(dev, "packet with opt len %d", info->options_len);
+@@ -484,7 +491,7 @@ static netdev_tx_t gtp_dev_xmit_fb(struct sk_buff *skb, struct net_device *dev)
+ 			    fl4.saddr, fl4.daddr, fl4.flowi4_tos, ttl, df,
+ 			    gtp->gtph_port, gtp->gtph_port,
+ 			    !net_eq(sock_net(gtp->sk1u), dev_net(dev)),
+-                            csum);
++                            !csum);
+ 
+ 	return NETDEV_TX_OK;
+ err_rt:
+@@ -624,8 +631,17 @@ static void gtp_link_setup(struct net_device *dev)
+ 	dev->type = ARPHRD_NONE;
+ 	dev->flags = IFF_POINTOPOINT | IFF_NOARP | IFF_MULTICAST;
+ 
+-	dev->priv_flags	|= IFF_NO_QUEUE;
+-	dev->features	|= NETIF_F_LLTX;
++	dev->priv_flags	 |= IFF_NO_QUEUE;
++
++	dev->features    |= NETIF_F_LLTX;
++	dev->features    |= NETIF_F_SG | NETIF_F_HW_CSUM;
++	dev->features    |= NETIF_F_RXCSUM;
++	dev->features    |= NETIF_F_GSO_SOFTWARE;
++
++	dev->hw_features |= NETIF_F_SG | NETIF_F_HW_CSUM | NETIF_F_RXCSUM;
++	dev->hw_features |= NETIF_F_GSO_SOFTWARE;
++
++
+ 	netif_keep_dst(dev);
+ 
+ 	/* Assume largest header, ie. GTPv0. */
+diff --git a/debian/changelog b/debian/changelog
+index 661dfb991..18edd863a 100644
+--- a/debian/changelog
++++ b/debian/changelog
+@@ -1,4 +1,4 @@
+-openvswitch (2.14.3-3) unstable; urgency=low
++openvswitch (2.14.3-7) unstable; urgency=low
+    [ Open vSwitch team ]
+    * New upstream version
+ 
+diff --git a/tests/system-layer3-tunnels.at b/tests/system-layer3-tunnels.at
+index 57f39e3ad..e772f55d2 100644
+--- a/tests/system-layer3-tunnels.at
++++ b/tests/system-layer3-tunnels.at
+@@ -304,7 +304,7 @@ RX: 2 TX: 2 remote ip: 172.31.1.1, seq 3, pending send 0
+ OVS_WAIT_UNTIL([cat p1.pcap | egrep "IP 172.31.1.100.2152 > 172.31.1.1.2152: UDP, length 12" 2>&1 1>/dev/null])
+ OVS_WAIT_UNTIL([cat p1.pcap | egrep "0x0000:.*0800 4500"                                     2>&1 1>/dev/null])
+ OVS_WAIT_UNTIL([cat p1.pcap | egrep "0x0010:.*ac1f 0164 ac1f"       2>&1 1>/dev/null])
+-OVS_WAIT_UNTIL([cat p1.pcap | egrep "0x0020:  0101 0868 0868 0014 5ac9 3202 0004 0000"       2>&1 1>/dev/null])
++OVS_WAIT_UNTIL([cat p1.pcap | egrep "0x0020:  0101 0868 0868 0014 0000 3202 0004 0000"       2>&1 1>/dev/null])
+ OVS_WAIT_UNTIL([cat p1.pcap | egrep "0x0030:  0000 0003 0e00"                                2>&1 1>/dev/null])
+ 
+ OVS_TRAFFIC_VSWITCHD_STOP
+@@ -434,7 +434,7 @@ sleep 2
+ 
+ OVS_WAIT_UNTIL([cat p1.pcap | egrep "0x0000:.*0800 4500"                                2>&1 1>/dev/null])
+ OVS_WAIT_UNTIL([cat p1.pcap | egrep "0x0010:.*ac1f 0164 ac1f"                           2>&1 1>/dev/null])
+-OVS_WAIT_UNTIL([cat p1.pcap | egrep "0x0020:  0101 0868 0868 0010 5ac5 30fe 0000 0000"  2>&1 1>/dev/null])
++OVS_WAIT_UNTIL([cat p1.pcap | egrep "0x0020:  0101 0868 0868 0010 0000 30fe 0000 0000"  2>&1 1>/dev/null])
+ OVS_WAIT_UNTIL([cat p1.pcap | egrep "0x0030:  0064"                                     2>&1 1>/dev/null])
+ 
+ OVS_TRAFFIC_VSWITCHD_STOP
+-- 
+2.17.1
+


### PR DESCRIPTION
This would allow GTP module to make use of linux
kernel tunnel offloading functionality.

Signed-off-by: Pravin B Shelar <pbshelar@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->

## Test Plan
OVS Unit tests
Lab scale tests
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
