### PR TITLE
[feg] Add NH support to FeG 2 GW relay (issue #7473)

### DIFF
--- a/feg/cloud/go/services/feg_relay/servicers/feg_to_gw_relay.go
+++ b/feg/cloud/go/services/feg_relay/servicers/feg_to_gw_relay.go
@@ -128,6 +128,8 @@ func getAllGWSGSServiceConnCtx(ctx context.Context) ([]*grpc.ClientConn, []conte
 	return connList, ctxList, nil
 }
 
+// getFegServedIds returns ServedNetworkIds of the given FeG networkId and appends to the list all ServedNetworkIds of
+// the network's Neutral Host Network if any
 func getFegServedIds(networkId string) ([]string, error) {
 	if len(networkId) == 0 {
 		return []string{}, fmt.Errorf("Empty networkID provided.")
@@ -140,7 +142,31 @@ func getFegServedIds(networkId string) ([]string, error) {
 	if !ok || networkFegConfigs == nil {
 		return []string{}, fmt.Errorf("invalid federation network config found for network: %s", networkId)
 	}
-	return networkFegConfigs.ServedNetworkIds, nil
+	// getFegServedIds will always return ServedNetworkIds of the given FeG networkId, but if the given FeG Network
+	// is also serving Neutral Host Network, getFegServedIds would append all ServedNetworkIds of this
+	// Neutral Host Network to the result
+	if len(networkFegConfigs.ServedNhIds) == 0 {
+		return networkFegConfigs.ServedNetworkIds, nil
+	}
+	// If this is a NH FeG Network, add served networks from ServedNhIds FeG networks
+	nids := networkFegConfigs.ServedNetworkIds // prepend 'local' ServedNhIds to the combined result
+	glog.V(2).Infof("getFegServedIds: nonempty Served NH Networks list for network: %s", networkId)
+	for _, nhNetworkId := range networkFegConfigs.ServedNhIds {
+		if len(nhNetworkId) > 0 {
+			nhFegCfg, err := configurator.LoadNetworkConfig(nhNetworkId, feg.FegNetworkType, serdes.Network)
+			if err != nil || nhFegCfg == nil {
+				glog.Errorf("unable to retrieve config for NH federation network '%s': %v", nhNetworkId, err)
+				continue
+			}
+			nhNetworkFegConfigs, ok := nhFegCfg.(*models.NetworkFederationConfigs)
+			if !ok || nhNetworkFegConfigs == nil {
+				glog.Errorf("invalid FeG network config found for NH network '%s': %T", nhNetworkId, nhFegCfg)
+				continue
+			}
+			nids = append(nids, nhNetworkFegConfigs.ServedNetworkIds...)
+		}
+	}
+	return nids, nil
 }
 
 func validateFegContext(ctx context.Context) error {


### PR DESCRIPTION
Signed-off-by: Evgeniy Makeev <evgeniym@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary

Currently Neutral Host functionality is only supported on GW->FeG relay (see issue 7473). 
For FeG to GW calls only 'local' served networks are considered. This PR adds support for served NH networks as well.


## Test Plan
Unit tests; test w staging/test orc8r
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
