### PR TITLE
orc8r: Fix hanging Swagger UI

### DIFF
--- a/orc8r/cloud/go/obsidian/swagger/poll.go
+++ b/orc8r/cloud/go/obsidian/swagger/poll.go
@@ -29,6 +29,7 @@ func GetCombinedSpec(yamlCommon string) (string, error) {
 	}
 
 	var yamlSpecs []string
+	// TODO(hcgatewood): parallelize this via goroutines to avoid broken services breaking GetCombinedSpec
 	for _, s := range servicers {
 		yamlSpec, err := s.GetPartialSpec()
 		if err != nil {

--- a/orc8r/cloud/go/obsidian/swagger/remote_spec.go
+++ b/orc8r/cloud/go/obsidian/swagger/remote_spec.go
@@ -16,6 +16,7 @@ package swagger
 import (
 	"context"
 	"strings"
+	"time"
 
 	"magma/orc8r/cloud/go/obsidian/swagger/protos"
 	merrors "magma/orc8r/lib/go/errors"
@@ -73,8 +74,12 @@ func (s *RemoteSpec) GetService() string {
 	return s.service
 }
 
+// Shorten timeout so that the caller doesn't time out (60s) if individual
+// services time out.
+const specClientDefaultTimeout = 5 * time.Second
+
 func (s *RemoteSpec) getClient() (protos.SwaggerSpecClient, error) {
-	conn, err := registry.GetConnection(s.service)
+	conn, err := registry.GetConnectionWithTimeout(s.service, specClientDefaultTimeout)
 	if err != nil {
 		initErr := merrors.NewInitError(err, s.service)
 		glog.Error(initErr)

--- a/orc8r/lib/go/registry/global_registry.go
+++ b/orc8r/lib/go/registry/global_registry.go
@@ -15,6 +15,8 @@ limitations under the License.
 package registry
 
 import (
+	"time"
+
 	"github.com/golang/glog"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
@@ -137,6 +139,12 @@ func GetAnnotationList(service, annotationName string) ([]string, error) {
 // GetConnection provides a gRPC connection to a service in the registry.
 func GetConnection(service string) (*grpc.ClientConn, error) {
 	return globalRegistry.GetConnection(service)
+}
+
+// GetConnectionWithTimeout is same as GetConnection, but caller can provide
+// their own timeout.
+func GetConnectionWithTimeout(service string, timeout time.Duration) (*grpc.ClientConn, error) {
+	return globalRegistry.GetConnectionWithTimeout(service, timeout)
 }
 
 func GetConnectionImpl(ctx context.Context, service string, opts ...grpc.DialOption) (*grpc.ClientConn, error) {

--- a/orc8r/lib/go/registry/registry.go
+++ b/orc8r/lib/go/registry/registry.go
@@ -367,8 +367,15 @@ func (r *ServiceRegistry) GetAnnotationList(service, annotationName string) ([]s
 // GetConnection provides a gRPC connection to a service in the registry.
 // The service needs to be added to the registry before this.
 func (r *ServiceRegistry) GetConnection(service string) (*grpc.ClientConn, error) {
+	return r.GetConnectionWithTimeout(service, GrpcMaxTimeoutSec*time.Second)
+}
+
+// GetConnectionWithTimeout is same as GetConnection, but caller can provide
+// their own timeout.
+// The service needs to be added to the registry before this.
+func (r *ServiceRegistry) GetConnectionWithTimeout(service string, timeout time.Duration) (*grpc.ClientConn, error) {
 	service = strings.ToLower(service)
-	ctx, cancel := context.WithTimeout(context.Background(), GrpcMaxTimeoutSec*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 	return r.GetConnectionImpl(ctx, service, r.getGRPCDialOptions()...)
 }


### PR DESCRIPTION
## Summary

nprobe service is crashing, causing Swagger UI to time out. Fix: change the swagger spec timeout to be short (5s), so it will skip the failing service and still return in time.

Resolves #7374.

## Test Plan

- [x] Manual

## Additional Information

- [ ] This change is backwards-breaking