### PR TITLE
Remove unused CertExpirationTime from serialized state

### DIFF
--- a/cwf/cloud/go/services/cwf/obsidian/handlers/handlers_test.go
+++ b/cwf/cloud/go/services/cwf/obsidian/handlers/handlers_test.go
@@ -410,7 +410,6 @@ func TestCwfGateways(t *testing.T) {
 		},
 	}
 	expected["g1"].Status.CheckinTime = uint64(time.Unix(1000000, 0).UnixNano() / (int64(time.Millisecond) / int64(time.Nanosecond)))
-	expected["g1"].Status.CertExpirationTime = time.Unix(1000000, 0).Add(time.Hour * 4).Unix()
 	tc = tests.Test{
 		Method:         "GET",
 		URL:            "/magma/v1/cwf/n1/gateways",
@@ -451,7 +450,6 @@ func TestCwfGateways(t *testing.T) {
 		Status: models.NewDefaultGatewayStatus("hw1"),
 	}
 	expectedGet.Status.CheckinTime = uint64(time.Unix(1000000, 0).UnixNano() / (int64(time.Millisecond) / int64(time.Nanosecond)))
-	expectedGet.Status.CertExpirationTime = time.Unix(1000000, 0).Add(time.Hour * 4).Unix()
 	tc = tests.Test{
 		Method:         "GET",
 		URL:            "/magma/v1/cwf/n1/gateways/g1",

--- a/feg/cloud/go/services/feg/obsidian/handlers/handlers_test.go
+++ b/feg/cloud/go/services/feg/obsidian/handlers/handlers_test.go
@@ -339,7 +339,6 @@ func TestFederationGateways(t *testing.T) {
 		},
 	}
 	expected["g1"].Status.CheckinTime = uint64(time.Unix(1000000, 0).UnixNano() / (int64(time.Millisecond) / int64(time.Nanosecond)))
-	expected["g1"].Status.CertExpirationTime = time.Unix(1000000, 0).Add(time.Hour * 4).Unix()
 	tc = tests.Test{
 		Method:         "GET",
 		URL:            "/magma/v1/feg/n1/gateways",
@@ -370,7 +369,6 @@ func TestFederationGateways(t *testing.T) {
 		Status:     models.NewDefaultGatewayStatus("hw1"),
 	}
 	expectedGet.Status.CheckinTime = uint64(time.Unix(1000000, 0).UnixNano() / (int64(time.Millisecond) / int64(time.Nanosecond)))
-	expectedGet.Status.CertExpirationTime = time.Unix(1000000, 0).Add(time.Hour * 4).Unix()
 	tc = tests.Test{
 		Method:         "GET",
 		URL:            "/magma/v1/feg/n1/gateways/g1",

--- a/lte/cloud/go/services/lte/obsidian/handlers/handlers_test.go
+++ b/lte/cloud/go/services/lte/obsidian/handlers/handlers_test.go
@@ -1311,7 +1311,6 @@ func TestListAndGetGateways(t *testing.T) {
 		},
 	}
 	expected["g1"].Status.CheckinTime = uint64(time.Unix(1000000, 0).UnixNano() / (int64(time.Millisecond) / int64(time.Nanosecond)))
-	expected["g1"].Status.CertExpirationTime = time.Unix(1000000, 0).Add(time.Hour * 4).Unix()
 
 	tc := tests.Test{
 		Method:         "GET",
@@ -1347,7 +1346,6 @@ func TestListAndGetGateways(t *testing.T) {
 		ApnResources:           lteModels.ApnResources{},
 	}
 	expectedGet.Status.CheckinTime = uint64(time.Unix(1000000, 0).UnixNano() / (int64(time.Millisecond) / int64(time.Nanosecond)))
-	expectedGet.Status.CertExpirationTime = time.Unix(1000000, 0).Add(time.Hour * 4).Unix()
 	tc = tests.Test{
 		Method:         "GET",
 		URL:            testURLRoot,

--- a/orc8r/cloud/go/services/orchestrator/obsidian/handlers/gateway_handlers_test.go
+++ b/orc8r/cloud/go/services/orchestrator/obsidian/handlers/gateway_handlers_test.go
@@ -93,7 +93,6 @@ func TestListGateways(t *testing.T) {
 
 	expectedState := models.NewDefaultGatewayStatus("hw1")
 	expectedState.CheckinTime = uint64(time.Unix(1000000, 0).UnixNano() / (int64(time.Millisecond) / int64(time.Nanosecond)))
-	expectedState.CertExpirationTime = time.Unix(1000000, 0).Add(time.Hour * 4).Unix()
 
 	expectedResult = map[string]models.MagmadGateway{
 		"g1": {ID: "g1", Magmad: &models.MagmadGatewayConfigs{}, Device: gatewayRecord, Status: expectedState},
@@ -395,7 +394,6 @@ func TestGetGateway(t *testing.T) {
 		Status: models.NewDefaultGatewayStatus("hw1"),
 	}
 	expected.Status.CheckinTime = uint64(time.Unix(1000000, 0).UnixNano() / (int64(time.Millisecond) / int64(time.Nanosecond)))
-	expected.Status.CertExpirationTime = time.Unix(1000000, 0).Add(time.Hour * 4).Unix()
 
 	tc := tests.Test{
 		Method:         "GET",
@@ -738,7 +736,6 @@ func TestGetPartialReadHandlers(t *testing.T) {
 
 	expectedState := models.NewDefaultGatewayStatus("hw1")
 	expectedState.CheckinTime = uint64(time.Unix(1000000, 0).UnixNano() / (int64(time.Millisecond) / int64(time.Nanosecond)))
-	expectedState.CertExpirationTime = time.Unix(1000000, 0).Add(time.Hour * 4).Unix()
 
 	// happy path state
 	tc = tests.Test{

--- a/orc8r/cloud/go/services/orchestrator/servicers/indexer_servicer_test.go
+++ b/orc8r/cloud/go/services/orchestrator/servicers/indexer_servicer_test.go
@@ -188,10 +188,9 @@ func TestIndexerSessionID(t *testing.T) {
 
 func serialize(t *testing.T, st state_types.State, typ string) state_types.SerializedState {
 	s := state_types.SerializedState{
-		Version:            st.Version,
-		ReporterID:         st.ReporterID,
-		TimeMs:             st.TimeMs,
-		CertExpirationTime: st.CertExpirationTime,
+		Version:    st.Version,
+		ReporterID: st.ReporterID,
+		TimeMs:     st.TimeMs,
 	}
 	rep, err := serde.Serialize(st.ReportedState, typ, serdes.State)
 	assert.NoError(t, err)

--- a/orc8r/cloud/go/services/state/indexer/index/index_test.go
+++ b/orc8r/cloud/go/services/state/indexer/index/index_test.go
@@ -108,10 +108,9 @@ func serialize(t *testing.T, states state_types.StatesByID) state_types.Serializ
 	serialized := state_types.SerializedStatesByID{}
 	for id, st := range states {
 		s := state_types.SerializedState{
-			Version:            st.Version,
-			ReporterID:         st.ReporterID,
-			TimeMs:             st.TimeMs,
-			CertExpirationTime: st.CertExpirationTime,
+			Version:    st.Version,
+			ReporterID: st.ReporterID,
+			TimeMs:     st.TimeMs,
 		}
 		rep, err := serde.Serialize(st.ReportedState, id.Type, serdes.State)
 		assert.NoError(t, err)

--- a/orc8r/cloud/go/services/state/servicers/servicer.go
+++ b/orc8r/cloud/go/services/state/servicers/servicer.go
@@ -258,7 +258,6 @@ func wrapStateWithAdditionalInfo(st *protos.State, hwID string, time uint64, cer
 	wrap := state_types.SerializedState{
 		ReporterID:              hwID,
 		TimeMs:                  time,
-		CertExpirationTime:      certExpiry,
 		SerializedReportedState: st.Value,
 	}
 	ret, err := json.Marshal(wrap)

--- a/orc8r/cloud/go/services/state/types/types.go
+++ b/orc8r/cloud/go/services/state/types/types.go
@@ -79,8 +79,6 @@ type SerializedState struct {
 	ReporterID string
 	// TimeMs is the time the state was received in milliseconds.
 	TimeMs uint64
-	// CertExpirationTime is the expiration time in milliseconds.
-	CertExpirationTime int64
 }
 
 // SerializedStatesByID maps state IDs to state.
@@ -242,10 +240,9 @@ func MakeState(p *protos.State, serdes serde.Registry) (State, *protos.IDAndErro
 	}
 
 	st := State{
-		ReporterID:         serialized.ReporterID,
-		TimeMs:             serialized.TimeMs,
-		CertExpirationTime: serialized.CertExpirationTime,
-		Version:            p.Version,
+		ReporterID: serialized.ReporterID,
+		TimeMs:     serialized.TimeMs,
+		Version:    p.Version,
 	}
 
 	// Recover reported state within state struct


### PR DESCRIPTION
Remove cert expiration time from state metadata #5377

## Summary

Removed the cert expiration time from the metadata and updated all tests

## Test Plan

Ran unit tests

## Additional Information

replacement for https://github.com/magma/magma/pull/7454 - changed target to master
