### PR TITLE
[helm][ci] Check helm dependencies github action job

### DIFF
--- a/.github/workflows/helm-chart-dependency-check.yml
+++ b/.github/workflows/helm-chart-dependency-check.yml
@@ -1,7 +1,7 @@
 ---
 name: "Check dependencies of helm charts"
 
-on: [pull_request]
+on: [pull_request]  # yamllint disable-line rule:truthy
 jobs:
   check_helm_chart_dependencies:
     env:
@@ -11,15 +11,24 @@ jobs:
       fail-fast: false
       matrix:
         charts:
-          - ["orc8r","$MAGMA_ROOT/orc8r/cloud/helm/orc8r/"]
+          - ["orc8r", "$MAGMA_ROOT/orc8r/cloud/helm/orc8r/"]
           - ["cwf-orc8r", "$MAGMA_ROOT/cwf/cloud/helm/cwf-orc8r/"]
           - ["lte-orc8r", "$MAGMA_ROOT/lte/cloud/helm/lte-orc8r/"]
           - ["feg-orc8r", "$MAGMA_ROOT/feg/cloud/helm/feg-orc8r/"]
           - ["fbinternal-orc8r", "$MAGMA_ROOT/fbinternal/cloud/helm/fbinternal-orc8r/"]
           - ["wifi-orc8r", "$MAGMA_ROOT/wifi/cloud/helm/wifi-orc8r/"]
-    name: ${{ matrix.charts[0] }}
+    name: Check dependency of helm chart ${{ matrix.charts[0] }}
     steps:
       - uses: actions/checkout@v2
-      - name: Run depedency check against ${{ matrix.charts[0] }}
+      - name: Get chart.lock digest
+        run: |
+          echo "DIGEST=$(cat ${{ matrix.charts[1] }}Chart.lock | grep digest | cut -d ":" -f 2-3 | xargs)" >> $GITHUB_ENV
+      - name: Run dependency check against ${{ matrix.charts[0] }}
         run: |
           helm dependency update "${{ matrix.charts[1] }}"
+      - name: Get new chart.lock digest
+        run: |
+          echo "NEW_DIGEST=$(cat ${{ matrix.charts[1] }}Chart.lock | grep digest | cut -d ":" -f 2-3 | xargs)" >> $GITHUB_ENV
+      - name: Verify digest is the same
+        if: ${{ env.DIGEST != env.NEW_DIGEST }}
+        run: exit 1

--- a/.github/workflows/helm-chart-dependency-check.yml
+++ b/.github/workflows/helm-chart-dependency-check.yml
@@ -1,0 +1,25 @@
+---
+name: "Check dependencies of helm charts"
+
+on: [pull_request]
+jobs:
+  check_helm_chart_dependencies:
+    env:
+      MAGMA_ROOT: "${{ github.workspace }}"
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        charts:
+          - ["orc8r","$MAGMA_ROOT/orc8r/cloud/helm/orc8r/"]
+          - ["cwf-orc8r", "$MAGMA_ROOT/cwf/cloud/helm/cwf-orc8r/"]
+          - ["lte-orc8r", "$MAGMA_ROOT/lte/cloud/helm/lte-orc8r/"]
+          - ["feg-orc8r", "$MAGMA_ROOT/feg/cloud/helm/feg-orc8r/"]
+          - ["fbinternal-orc8r", "$MAGMA_ROOT/fbinternal/cloud/helm/fbinternal-orc8r/"]
+          - ["wifi-orc8r", "$MAGMA_ROOT/wifi/cloud/helm/wifi-orc8r/"]
+    name: ${{ matrix.charts[0] }}
+    steps:
+      - uses: actions/checkout@v2
+      - name: Run depedency check against ${{ matrix.charts[0] }}
+        run: |
+          helm dependency update "${{ matrix.charts[1] }}"


### PR DESCRIPTION

## Summary

Check helm dependencies to avoid failure of helm chart publish job.
Each helm chart has his own subjob for easier troubleshooting.

## Test Plan

Ran Github actions job in my repo: https://github.com/quentinDERORY/magma/actions/runs/926832586

## Additional Information

Checks chart.lock digest too
