### PR TITLE
Fix ctests for OAI and SCTPD

### DIFF
--- a/lte/gateway/Makefile
+++ b/lte/gateway/Makefile
@@ -128,10 +128,10 @@ cp -r $(REPORT_DIR) $(MAGMA_ROOT)
 @echo "Reports in magma/reports/.../index.html"
 endef
 
-# run_ctest BUILD_DIRECTORY, FILE_DIRECTORY, FLAGS
+# run_ctest BUILD_DIRECTORY, TEST_BUILD_DIRECTORY, FILE_DIRECTORY, FLAGS
 define run_ctest
-$(call run_cmake, $(1), $(2), $(3) $(TEST_FLAG))
-cd $(1) && ctest --output-on-failure
+$(call run_cmake, $(1), $(3), $(4) $(TEST_FLAG))
+cd $(2) && ctest --output-on-failure
 endef
 
 format_common:
@@ -205,15 +205,18 @@ test_python: stop ## Run all Python-specific tests
 	make -C $(MAGMA_ROOT)/lte/gateway/python test_all
 
 test_oai: ## Run all OAI-specific tests
-	$(call run_ctest, $(C_BUILD)/core, $(GATEWAY_C_DIR)/core, $(OAI_FLAGS))
+	$(call run_ctest, $(C_BUILD)/core, $(C_BUILD)/core/oai, $(GATEWAY_C_DIR)/core, $(OAI_FLAGS))
+
+test_sctpd: ## Run all OAI-specific tests
+	$(call run_ctest, $(C_BUILD)/sctp, $(C_BUILD)/sctp/src, $(GATEWAY_C_DIR)/sctpd, )
 
 test_common: build_common ## Run all tests in magma_common
-	$(call run_ctest, $(C_BUILD)/magma_common, $(MAGMA_ROOT)/orc8r/gateway/c/common, )
+	$(call run_ctest, $(C_BUILD)/magma_common, $(C_BUILD)/magma_common, $(MAGMA_ROOT)/orc8r/gateway/c/common, )
 
 # Catch all for c service tests
 # This works with test_dpi and test_session_manager
 test_%: build_common
-	$(call run_ctest, $(C_BUILD)/$*, $(GATEWAY_C_DIR)/$*, )
+	$(call run_ctest, $(C_BUILD)/$*, $(C_BUILD)/$*, $(GATEWAY_C_DIR)/$*, )
 
 coverage_oai: test_oai
 	lcov --capture --directory $(C_BUILD) --output-file /tmp/coverage_oai.info.raw

--- a/lte/gateway/c/sctpd/CMakeLists.txt
+++ b/lte/gateway/c/sctpd/CMakeLists.txt
@@ -13,6 +13,18 @@ cmake_minimum_required(VERSION 3.0.2)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 set(CMAKE_VERBOSE_MAKEFILE ON)
 
+get_cmake_property(vars CACHE_VARIABLES)
+foreach (var ${vars})
+  get_property(currentHelpString CACHE "${var}" PROPERTY HELPSTRING)
+  # message("${var} = [${${var}}]  --  ${currentHelpString}")
+  if ("${currentHelpString}" MATCHES
+      "No help, variable specified on the command line." OR
+      "${currentHelpString}" STREQUAL "")
+    list(APPEND CL_ARGS "-D${var}=${${var}}")
+  endif ()
+endforeach ()
+
+
 project(MagmaSctpd)
 
 include(ExternalProject)
@@ -28,4 +40,5 @@ ExternalProject_Add(Sctpd
     BUILD_ALWAYS 1
     BINARY_DIR "${CMAKE_BINARY_DIR}/src"
     INSTALL_COMMAND ""
-    DEPENDS MagmaCommon)
+    DEPENDS MagmaCommon
+    CMAKE_ARGS ${CL_ARGS})


### PR DESCRIPTION
## Summary
Two issues:
The test directory is nested inside the super build base directory so
add a separate directory arg for the test directory
sctpd build was omitting flags passed to sub build fix it

Closes #7457


Signed-off-by: Amar Padmanabhan <amar@freedomfi.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->



<!-- Enumerate changes you made and why you made them -->

## Test Plan
Tests pass:

Test project /build/c/sctp/src
    Start 1: test_sctp_desc
1/2 Test #1: test_sctp_desc ...................   Passed    0.00 sec
    Start 2: test_event_handler
2/2 Test #2: test_event_handler ...............   Passed    0.05 sec

Test project /build/c/core/oai
    Start 1: test_mme_app_ue_context
1/8 Test #1: test_mme_app_ue_context ..........   Passed    0.03 sec
    Start 2: test_mme_app_emm_decode
2/8 Test #2: test_mme_app_emm_decode ..........   Passed    0.02 sec
    Start 3: test_openflow_controller
3/8 Test #3: test_openflow_controller .........   Passed    0.02 sec
    Start 4: test_imsi_encoder
4/8 Test #4: test_imsi_encoder ................   Passed    0.01 sec
    Start 5: test_gtp_app
5/8 Test #5: test_gtp_app .....................   Passed    0.03 sec
    Start 6: test_spgw_state_converter
6/8 Test #6: test_spgw_state_converter ........   Passed    0.02 sec
    Start 7: test_itti
7/8 Test #7: test_itti ........................   Passed    4.22 sec
    Start 8: test_pipelined_client
8/8 Test #8: test_pipelined_client ............   Passed    0.02 sec

100% tests passed, 0 tests failed out of 8

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
