### PR TITLE
[Agw][MME][refactor] New enum explicitly for RETURNok and RETURNerror

### DIFF
--- a/lte/gateway/c/core/oai/common/async_system.c
+++ b/lte/gateway/c/core/oai/common/async_system.c
@@ -112,7 +112,7 @@ static void* async_system_thread(__attribute__((unused)) void* args_p) {
 }
 
 //------------------------------------------------------------------------------
-int async_system_init(void) {
+status_code_e async_system_init(void) {
   OAI_FPRINTF_INFO("Initializing ASYNC_SYSTEM\n");
   if (itti_create_task(TASK_ASYNC_SYSTEM, &async_system_thread, NULL) < 0) {
     perror("pthread_create");
@@ -125,7 +125,7 @@ int async_system_init(void) {
 }
 
 //------------------------------------------------------------------------------
-int async_system_command(
+status_code_e async_system_command(
     int sender_itti_task, bool is_abort_on_error, char* format, ...) {
   va_list args;
   int rv       = 0;
@@ -144,9 +144,9 @@ int async_system_command(
   message_p = itti_alloc_new_message(sender_itti_task, ASYNC_SYSTEM_COMMAND);
   ASYNC_SYSTEM_COMMAND(message_p).system_command    = bstr;
   ASYNC_SYSTEM_COMMAND(message_p).is_abort_on_error = is_abort_on_error;
-  rv                                                = send_msg_to_task(
+  status_code_e result                              = send_msg_to_task(
       &async_system_task_zmq_ctx, TASK_ASYNC_SYSTEM, message_p);
-  return rv;
+  return result;
 }
 
 //------------------------------------------------------------------------------

--- a/lte/gateway/c/core/oai/common/async_system.h
+++ b/lte/gateway/c/core/oai/common/async_system.h
@@ -41,9 +41,10 @@
 #define FILE_ASYNC_SYSTEM_SEEN
 
 #include <stdbool.h>
+#include "common_defs.h"
 
-int async_system_init(void);
-int async_system_command(
+status_code_e async_system_init(void);
+status_code_e async_system_command(
     int sender_itti_task, bool is_abort_on_error, char* format, ...);
 
 #endif /* FILE_SHARED_TS_LOG_SEEN */

--- a/lte/gateway/c/core/oai/common/common_defs.h
+++ b/lte/gateway/c/core/oai/common/common_defs.h
@@ -91,15 +91,23 @@ typedef enum {
   TLV_MANDATORY_FIELD_NOT_PRESENT = -3,
   TLV_UNEXPECTED_IEI              = -2,
 
-  RETURNerror = -1,
-  RETURNok    = 0,
-
-  TLV_ERROR_OK = RETURNok,
+  TLV_ERROR_OK = 0,
   /* Defines error code limit below which received message should be discarded
    * because it cannot be further processed */
   TLV_FATAL_ERROR = TLV_VALUE_DOESNT_MATCH
 
-} error_code_e;
+} tlv_error_code_e;
+
+/* Intended to be the primary mechanism to gracefully handle errors across
+ * API boundaries.
+ * Most functions which can produce a recoverable error should be designed to
+ * return this.
+ * Inspired by Google's absl::Status
+ */
+typedef enum {
+  RETURNerror   = -1,   // An internal invariant is broken
+  RETURNok      = 0,    // Ok
+} status_code_e;
 
 /* This enum should match with the ModeMapItem_FederatedMode enum
  * defined in mconfigs.proto

--- a/lte/gateway/c/core/oai/common/digest.c
+++ b/lte/gateway/c/core/oai/common/digest.c
@@ -45,7 +45,7 @@
 
 //------------------------------------------------------------------------------
 // evp_x can be EVP_sha256, ...
-int digest_buffer(
+status_code_e digest_buffer(
     const EVP_MD* (*evp_x)(void), const unsigned char* buffer,
     size_t buffer_len, unsigned char** digest, unsigned int* digest_len) {
   EVP_MD_CTX* mdctx = NULL;

--- a/lte/gateway/c/core/oai/common/digest.h
+++ b/lte/gateway/c/core/oai/common/digest.h
@@ -40,8 +40,9 @@
 #include <openssl/evp.h>
 #include <openssl/ossl_typ.h>
 #include <stddef.h>
+#include "common_defs.h"
 
-int digest_buffer(
+status_code_e digest_buffer(
     const EVP_MD* (*evp_x)(void), const unsigned char* buffer,
     size_t buffer_len, unsigned char** digest, unsigned int* digest_len);
 

--- a/lte/gateway/c/core/oai/common/redis_utils/redis_client.cpp
+++ b/lte/gateway/c/core/oai/common/redis_utils/redis_client.cpp
@@ -55,7 +55,7 @@ void RedisClient::init_db_connection() {
   is_connected_ = true;
 }
 
-int RedisClient::write(const std::string& key, const std::string& value) {
+status_code_e RedisClient::write(const std::string& key, const std::string& value) {
   if (!is_connected()) {
     return RETURNerror;
   }
@@ -87,7 +87,7 @@ std::string RedisClient::read(const std::string& key) {
   return db_read_reply.as_string();
 }
 
-int RedisClient::write_proto_str(
+status_code_e RedisClient::write_proto_str(
     const std::string& key, const std::string& proto_msg, uint64_t version) {
   orc8r::RedisState wrapper_proto = orc8r::RedisState();
   wrapper_proto.set_serialized_msg(proto_msg);
@@ -103,7 +103,7 @@ int RedisClient::write_proto_str(
   return RETURNok;
 }
 
-int RedisClient::read_proto(const std::string& key, Message& proto_msg) {
+status_code_e RedisClient::read_proto(const std::string& key, Message& proto_msg) {
   orc8r::RedisState wrapper_proto = orc8r::RedisState();
   if (read_redis_state(key, wrapper_proto) != RETURNok) {
     return RETURNerror;
@@ -126,7 +126,7 @@ int RedisClient::read_version(const std::string& key) {
   return wrapper_proto.version();
 }
 
-int RedisClient::clear_keys(const std::vector<std::string>& keys_to_clear) {
+status_code_e RedisClient::clear_keys(const std::vector<std::string>& keys_to_clear) {
   auto db_write = db_client_->del(keys_to_clear);
   db_client_->sync_commit();
   auto reply = db_write.get();
@@ -168,7 +168,7 @@ std::vector<std::string> RedisClient::get_keys(const std::string& pattern) {
   return replies;
 }
 
-int RedisClient::read_redis_state(
+status_code_e RedisClient::read_redis_state(
     const std::string& key, orc8r::RedisState& state_out) {
   try {
     std::string str_value = read(key);
@@ -181,7 +181,7 @@ int RedisClient::read_redis_state(
   }
 }
 
-int RedisClient::serialize(
+status_code_e RedisClient::serialize(
     const Message& proto_msg, std::string& str_to_serialize) {
   if (!proto_msg.SerializeToString(&str_to_serialize)) {
     return RETURNerror;
@@ -189,7 +189,7 @@ int RedisClient::serialize(
   return RETURNok;
 }
 
-int RedisClient::deserialize(
+status_code_e RedisClient::deserialize(
     Message& proto_msg, const std::string& str_to_deserialize) {
   if (!proto_msg.ParseFromString(str_to_deserialize)) {
     return RETURNerror;

--- a/lte/gateway/c/core/oai/common/redis_utils/redis_client.h
+++ b/lte/gateway/c/core/oai/common/redis_utils/redis_client.h
@@ -22,6 +22,7 @@
 #include <cpp_redis/cpp_redis>
 #include <google/protobuf/message.h>
 
+#include <common_defs.h>
 #include "orc8r/protos/redis.pb.h"
 
 namespace magma {
@@ -51,7 +52,7 @@ class RedisClient {
    * @param value
    * @return response code of operation
    */
-  int write(const std::string& key, const std::string& value);
+  status_code_e write(const std::string& key, const std::string& value);
 
   /**
    * Writes a protobuf object to redis
@@ -60,15 +61,16 @@ class RedisClient {
    * @param version
    * @return response code of operation
    */
-  int write_proto_str(
+  status_code_e write_proto_str(
       const std::string& key, const std::string& proto_msg, uint64_t version);
 
   /**
    * Converts protobuf Message and parses it to string
    * @param proto_msg
    * @param str_to_serialize
+   * @return response code of operation
    */
-  static int serialize(
+  static status_code_e serialize(
       const google::protobuf::Message& proto_msg,
       std::string& str_to_serialize);
 
@@ -77,11 +79,11 @@ class RedisClient {
    * @param key
    * @return response code of operation
    */
-  int read_proto(const std::string& key, google::protobuf::Message& proto_msg);
+  status_code_e read_proto(const std::string& key, google::protobuf::Message& proto_msg);
 
   int read_version(const std::string& key);
 
-  int clear_keys(const std::vector<std::string>& keys_to_clear);
+  status_code_e clear_keys(const std::vector<std::string>& keys_to_clear);
 
   std::vector<std::string> get_keys(const std::string& pattern);
 
@@ -95,16 +97,17 @@ class RedisClient {
    * Read the wrapper RedisState value from Redis for a key
    * @param key
    * @param state_out
-   * @return
+   * @return response code of operation
    */
-  int read_redis_state(const std::string& key, orc8r::RedisState& state_out);
+  status_code_e read_redis_state(const std::string& key, orc8r::RedisState& state_out);
 
   /**
    * Takes a string and parses it to protobuf Message
    * @param proto_msg
    * @param str_to_deserialize
+   * @return response code of operation
    */
-  static int deserialize(
+  static status_code_e deserialize(
       google::protobuf::Message& proto_msg,
       const std::string& str_to_deserialize);
 };

--- a/lte/gateway/c/core/oai/include/state_manager.h
+++ b/lte/gateway/c/core/oai/include/state_manager.h
@@ -83,7 +83,7 @@ class StateManager {
    * Reads and parses task state from db if persist_state is enabled
    * @return response code of operation
    */
-  virtual int read_state_from_db() {
+  virtual status_code_e read_state_from_db() {
     if (persist_state_enabled) {
       ProtoType state_proto = ProtoType();
       if (redis_client->read_proto(table_key, state_proto) != RETURNok) {
@@ -99,7 +99,7 @@ class StateManager {
     return RETURNok;
   }
 
-  virtual int read_ue_state_from_db() {
+  virtual status_code_e read_ue_state_from_db() {
     if (!persist_state_enabled) {
       return RETURNok;
     }

--- a/lte/gateway/c/core/oai/lib/itti/intertask_interface.c
+++ b/lte/gateway/c/core/oai/lib/itti/intertask_interface.c
@@ -118,7 +118,7 @@ typedef struct itti_desc_s {
 
 static itti_desc_t itti_desc;
 
-int send_msg_to_task(
+status_code_e send_msg_to_task(
     task_zmq_ctx_t* task_zmq_ctx_p, task_id_t destination_task_id,
     MessageDef* message) {
   if (likely(task_zmq_ctx_p->ready)) {
@@ -147,7 +147,7 @@ int send_msg_to_task(
   }
 
   free(message);
-  return 0;
+  return RETURNok;
 }
 
 MessageDef* receive_msg(zsock_t* reader) {
@@ -317,10 +317,9 @@ MessageDef* itti_alloc_new_message(
       origin_task_id, message_id, itti_desc.messages_info[message_id].size);
 }
 
-int itti_create_task(
+status_code_e itti_create_task(
     task_id_t task_id, void* (*start_routine)(void*), void* args_p) {
   thread_id_t thread_id = TASK_GET_THREAD_ID(task_id);
-  int result            = 0;
 
   AssertFatal(start_routine != NULL, "Start routine is NULL!\n");
   AssertFatal(
@@ -338,7 +337,7 @@ int itti_create_task(
       ITTI_DEBUG_INIT, " Creating thread for task %s ...\n",
       itti_get_task_name(task_id));
 
-  result = pthread_create(
+  int result = pthread_create(
       &itti_desc.threads[thread_id].task_thread, NULL, start_routine, args_p);
 
   AssertFatal(
@@ -354,7 +353,7 @@ int itti_create_task(
   while (itti_desc.threads[thread_id].task_state != TASK_STATE_READY)
     usleep(1000);
 
-  return 0;
+  return RETURNok;
 }
 
 void itti_mark_task_ready(task_id_t task_id) {

--- a/lte/gateway/c/core/oai/lib/itti/intertask_interface.h
+++ b/lte/gateway/c/core/oai/lib/itti/intertask_interface.h
@@ -46,6 +46,7 @@
 #include "intertask_interface_conf.h"
 #include "intertask_interface_types.h"
 #include "itti_types.h"
+#include "common_defs.h"
 
 #define ITTI_MSG_ID(mSGpTR) ((mSGpTR)->ittiMsgHeader.messageId)
 #define ITTI_MSG_ORIGIN_ID(mSGpTR) ((mSGpTR)->ittiMsgHeader.originTaskId)
@@ -100,9 +101,9 @@ typedef enum timer_repeat_s {
  \param task_zmq_ctx_p Pointer to task ZMQ context
  \param destination_task_id Destination task ID
  \param message Pointer to the message to send
- @returns -1 on failure, 0 otherwise
+ @returns status_code_e
  **/
-int send_msg_to_task(
+status_code_e send_msg_to_task(
     task_zmq_ctx_t* task_zmq_ctx_p, task_id_t destination_task_id,
     MessageDef* message);
 
@@ -157,9 +158,10 @@ void send_broadcast_msg(task_zmq_ctx_t* task_zmq_ctx_p, MessageDef* message);
  * \param task_id task to start
  * \param start_routine entry point for the task
  * \param args_p Optional argument to pass to the start routine
- * @returns -1 on failure, 0 otherwise
+ * @returns status_code_e
+ * @note Asserts that task is created
  **/
-int itti_create_task(
+status_code_e itti_create_task(
     task_id_t task_id, void* (*start_routine)(void*), void* args_p);
 
 /** \brief Mark the task as in ready state
@@ -206,8 +208,6 @@ void itti_wait_tasks_end(task_zmq_ctx_t* task_ctx);
  * \param task_id task that is broadcasting the message.
  **/
 void send_terminate_message(task_zmq_ctx_t* task_zmq_ctx);
-
-int itti_send_broadcast_message(MessageDef* message_p);
 
 /**
  * \brief Returns the latency of the message

--- a/lte/gateway/c/core/oai/tasks/mme_app/mme_app_state_manager.cpp
+++ b/lte/gateway/c/core/oai/tasks/mme_app/mme_app_state_manager.cpp
@@ -227,7 +227,7 @@ void MmeNasStateManager::free_state() {
   state_cache_p = nullptr;
 }
 
-int MmeNasStateManager::read_ue_state_from_db() {
+status_code_e MmeNasStateManager::read_ue_state_from_db() {
   if (persist_state_enabled) {
     auto keys = redis_client->get_keys("IMSI*" + task_name + "*");
     for (const auto& key : keys) {

--- a/lte/gateway/c/core/oai/tasks/mme_app/mme_app_state_manager.h
+++ b/lte/gateway/c/core/oai/tasks/mme_app/mme_app_state_manager.h
@@ -61,7 +61,7 @@ class MmeNasStateManager
 
   void free_state() override;
 
-  int read_ue_state_from_db() override;
+  status_code_e read_ue_state_from_db() override;
 
   /**
    * Copy constructor and assignment operator are marked as deleted functions.

--- a/lte/gateway/c/core/oai/tasks/ngap/ngap_state_manager.cpp
+++ b/lte/gateway/c/core/oai/tasks/ngap/ngap_state_manager.cpp
@@ -22,6 +22,7 @@
 #include "ngap_state_manager.h"
 #include "bstrlib.h"
 #include "log.h"
+#include "common_defs.h"
 typedef unsigned int uint32_t;
 namespace {
 constexpr char NGAP_GNB_COLL[]             = "ngap_gNB_coll";
@@ -126,7 +127,7 @@ void NgapStateManager::free_state() {
   clear_ngap_imsi_map();
 }
 
-int NgapStateManager::read_ue_state_from_db() {
+status_code_e NgapStateManager::read_ue_state_from_db() {
   if (!persist_state_enabled) {
     return RETURNok;
   }

--- a/lte/gateway/c/core/oai/tasks/ngap/ngap_state_manager.h
+++ b/lte/gateway/c/core/oai/tasks/ngap/ngap_state_manager.h
@@ -32,6 +32,7 @@ extern "C" {
 }
 #endif
 
+#include "common_defs.h"
 #include "state_manager.h"
 #include "ngap_state_converter.h"
 using namespace magma::lte;
@@ -79,7 +80,7 @@ class NgapStateManager
    * Reads NGAP context state for all UEs in db
    * @return operation response code
    */
-  int read_ue_state_from_db() override;
+  status_code_e read_ue_state_from_db() override;
 
   /**
    * Serializes ngap_imsi_map to proto and saves it into data store

--- a/lte/gateway/c/core/oai/tasks/s1ap/s1ap_state_manager.cpp
+++ b/lte/gateway/c/core/oai/tasks/s1ap/s1ap_state_manager.cpp
@@ -16,6 +16,7 @@
  */
 
 #include "s1ap_state_manager.h"
+#include "common_defs.h"
 
 namespace {
 constexpr char S1AP_ENB_COLL[]             = "s1ap_eNB_coll";
@@ -126,7 +127,7 @@ void S1apStateManager::free_state() {
   clear_s1ap_imsi_map();
 }
 
-int S1apStateManager::read_ue_state_from_db() {
+status_code_e S1apStateManager::read_ue_state_from_db() {
   if (!persist_state_enabled) {
     return RETURNok;
   }

--- a/lte/gateway/c/core/oai/tasks/s1ap/s1ap_state_manager.h
+++ b/lte/gateway/c/core/oai/tasks/s1ap/s1ap_state_manager.h
@@ -29,6 +29,7 @@ extern "C" {
 }
 #endif
 
+#include "common_defs.h"
 #include "state_manager.h"
 #include "s1ap_state_converter.h"
 
@@ -77,7 +78,7 @@ class S1apStateManager
    * Reads S1AP context state for all UEs in db
    * @return operation response code
    */
-  int read_ue_state_from_db() override;
+  status_code_e read_ue_state_from_db() override;
 
   /**
    * Serializes s1ap_imsi_map to proto and saves it into data store

--- a/lte/gateway/c/core/oai/tasks/sgw/spgw_state_manager.cpp
+++ b/lte/gateway/c/core/oai/tasks/sgw/spgw_state_manager.cpp
@@ -19,6 +19,7 @@
 
 extern "C" {
 #include <dynamic_memory_check.h>
+#include "common_defs.h"
 }
 
 namespace magma {
@@ -107,7 +108,7 @@ void SpgwStateManager::free_state() {
   free_wrapper((void**) &state_cache_p);
 }
 
-int SpgwStateManager::read_ue_state_from_db() {
+status_code_e SpgwStateManager::read_ue_state_from_db() {
   if (!persist_state_enabled) {
     return RETURNok;
   }

--- a/lte/gateway/c/core/oai/tasks/sgw/spgw_state_manager.h
+++ b/lte/gateway/c/core/oai/tasks/sgw/spgw_state_manager.h
@@ -20,6 +20,7 @@
 #include "state_manager.h"
 #include "spgw_state.h"
 #include "spgw_state_converter.h"
+#include "common_defs.h"
 
 namespace {
 constexpr int SGW_STATE_CONTEXT_HT_MAX_SIZE    = 512;
@@ -68,7 +69,7 @@ class SpgwStateManager : public StateManager<
    */
   void free_state() override;
 
-  int read_ue_state_from_db() override;
+  status_code_e read_ue_state_from_db() override;
 
   hash_table_ts_t* get_state_teid_ht();
 

--- a/lte/gateway/c/core/oai/tasks/sgw_s8/sgw_s8_state_manager.cpp
+++ b/lte/gateway/c/core/oai/tasks/sgw_s8/sgw_s8_state_manager.cpp
@@ -18,6 +18,7 @@ extern "C" {
 
 #include "sgw_context_manager.h"
 #include "sgw_s8_state_manager.h"
+#include "common_defs.h"
 
 namespace magma {
 namespace lte {
@@ -107,7 +108,7 @@ void SgwStateManager::free_state() {
   free_wrapper((void**) &state_cache_p);
 }
 
-int SgwStateManager::read_ue_state_from_db() {
+status_code_e SgwStateManager::read_ue_state_from_db() {
   /* TODO handle stateless for SGW_S8 task */
   return RETURNok;
 }

--- a/lte/gateway/c/core/oai/tasks/sgw_s8/sgw_s8_state_manager.h
+++ b/lte/gateway/c/core/oai/tasks/sgw_s8/sgw_s8_state_manager.h
@@ -17,6 +17,7 @@ limitations under the License.
 #include "sgw_s8_state.h"
 #include "lte/protos/oai/sgw_state.pb.h"
 #include "sgw_s8_state_converter.h"
+#include "common_defs.h"
 
 namespace {
 constexpr int SGW_STATE_CONTEXT_HT_MAX_SIZE    = 512;
@@ -65,7 +66,7 @@ class SgwStateManager : public StateManager<
    */
   void free_state() override;
 
-  int read_ue_state_from_db() override;
+  status_code_e read_ue_state_from_db() override;
 
  private:
   SgwStateManager();


### PR DESCRIPTION
Signed-off-by: Andrei Lee <andreilee@fb.com>

## Summary

This PR is part of an effort to move all `Assert`s from lower level library-equivalent functions to higher level callers.

Various functions return either `RETURNok` or `RETURNerror`. Created a new enum `status_code_e`, to denote that certain functions return this status code. Some additional refactoring done to function signatures.

A later PR will finish refactoring all the function signatures that return either `RETURNok` or `RETURNerror`: https://github.com/magma/magma/pull/7486

An additional later PR will modify functions that return either a value of `RETURNerror`.

## Test Plan

Only built MME

```
vagrant@magma-dev:~/magma/lte/gateway$ make build_oai
.
.
.
[7/7] Completed 'MagmaCore'
vagrant@magma-dev:~/magma/lte/gateway$
```

## Additional Information

- [ ] This change is backwards-breaking
