### PR TITLE
Remove default in orc8r database storage

### DIFF
--- a/fbinternal/cloud/go/services/testcontroller/testcontroller/main.go
+++ b/fbinternal/cloud/go/services/testcontroller/testcontroller/main.go
@@ -41,7 +41,7 @@ func main() {
 		glog.Fatalf("Error creating service: %s", err)
 	}
 
-	db, err := sqorc.Open(storage2.SQLDriver, storage2.DatabaseSource)
+	db, err := sqorc.Open(storage2.GetSQLDriver(), storage2.GetDatabaseSource())
 	if err != nil {
 		glog.Fatalf("Failed to connect to database: %s", err)
 	}

--- a/feg/cloud/go/services/health/health/main.go
+++ b/feg/cloud/go/services/health/health/main.go
@@ -39,7 +39,7 @@ func main() {
 	if err != nil {
 		glog.Fatalf("Error creating service: %+v", err)
 	}
-	db, err := sqorc.Open(storage.SQLDriver, storage.DatabaseSource)
+	db, err := sqorc.Open(storage.GetDatabaseSource(), storage.GetDatabaseSource())
 	if err != nil {
 		glog.Fatalf("Failed to connect to database: %+v", err)
 	}

--- a/feg/cloud/go/services/health/health/main.go
+++ b/feg/cloud/go/services/health/health/main.go
@@ -39,7 +39,7 @@ func main() {
 	if err != nil {
 		glog.Fatalf("Error creating service: %+v", err)
 	}
-	db, err := sqorc.Open(storage.GetDatabaseSource(), storage.GetDatabaseSource())
+	db, err := sqorc.Open(storage.GetSQLDriver(), storage.GetDatabaseSource())
 	if err != nil {
 		glog.Fatalf("Failed to connect to database: %+v", err)
 	}

--- a/lte/cloud/go/services/lte/lte/main.go
+++ b/lte/cloud/go/services/lte/lte/main.go
@@ -53,7 +53,7 @@ func main() {
 	swagger_protos.RegisterSwaggerSpecServer(srv.GrpcServer, swagger.NewSpecServicerFromFile(lte_service.ServiceName))
 
 	// Init storage
-	db, err := sqorc.Open(storage.SQLDriver, storage.DatabaseSource)
+	db, err := sqorc.Open(storage.GetDatabaseSource(), storage.GetDatabaseSource())
 	if err != nil {
 		glog.Fatalf("Error opening db connection: %v", err)
 	}

--- a/lte/cloud/go/services/lte/lte/main.go
+++ b/lte/cloud/go/services/lte/lte/main.go
@@ -53,7 +53,7 @@ func main() {
 	swagger_protos.RegisterSwaggerSpecServer(srv.GrpcServer, swagger.NewSpecServicerFromFile(lte_service.ServiceName))
 
 	// Init storage
-	db, err := sqorc.Open(storage.GetDatabaseSource(), storage.GetDatabaseSource())
+	db, err := sqorc.Open(storage.GetSQLDriver(), storage.GetDatabaseSource())
 	if err != nil {
 		glog.Fatalf("Error opening db connection: %v", err)
 	}

--- a/lte/cloud/go/services/nprobe/nprobe/main.go
+++ b/lte/cloud/go/services/nprobe/nprobe/main.go
@@ -47,7 +47,7 @@ func main() {
 	}
 
 	// Init storage
-	db, err := sqorc.Open(storage.GetDatabaseSource(), storage.GetDatabaseSource())
+	db, err := sqorc.Open(storage.GetSQLDriver(), storage.GetDatabaseSource())
 	if err != nil {
 		glog.Fatalf("Error opening db connection: %+v", err)
 	}

--- a/lte/cloud/go/services/nprobe/nprobe/main.go
+++ b/lte/cloud/go/services/nprobe/nprobe/main.go
@@ -47,7 +47,7 @@ func main() {
 	}
 
 	// Init storage
-	db, err := sqorc.Open(storage.SQLDriver, storage.DatabaseSource)
+	db, err := sqorc.Open(storage.GetDatabaseSource(), storage.GetDatabaseSource())
 	if err != nil {
 		glog.Fatalf("Error opening db connection: %+v", err)
 	}

--- a/lte/cloud/go/services/smsd/smsd/main.go
+++ b/lte/cloud/go/services/smsd/smsd/main.go
@@ -37,7 +37,7 @@ func main() {
 	}
 
 	// Storage
-	db, err := sqorc.Open(storage.SQLDriver, storage.DatabaseSource)
+	db, err := sqorc.Open(storage.GetDatabaseSource(), storage.GetDatabaseSource())
 	if err != nil {
 		glog.Fatalf("error opening db conn: %v", err)
 	}

--- a/lte/cloud/go/services/smsd/smsd/main.go
+++ b/lte/cloud/go/services/smsd/smsd/main.go
@@ -37,7 +37,7 @@ func main() {
 	}
 
 	// Storage
-	db, err := sqorc.Open(storage.GetDatabaseSource(), storage.GetDatabaseSource())
+	db, err := sqorc.Open(storage.GetSQLDriver(), storage.GetDatabaseSource())
 	if err != nil {
 		glog.Fatalf("error opening db conn: %v", err)
 	}

--- a/lte/cloud/go/services/subscriberdb/subscriberdb/main.go
+++ b/lte/cloud/go/services/subscriberdb/subscriberdb/main.go
@@ -41,7 +41,7 @@ func main() {
 	}
 
 	// Init storage
-	db, err := sqorc.Open(storage.SQLDriver, storage.DatabaseSource)
+	db, err := sqorc.Open(storage.GetDatabaseSource(), storage.GetDatabaseSource())
 	if err != nil {
 		glog.Fatalf("Error opening db connection: %v", err)
 	}

--- a/lte/cloud/go/services/subscriberdb/subscriberdb/main.go
+++ b/lte/cloud/go/services/subscriberdb/subscriberdb/main.go
@@ -41,7 +41,7 @@ func main() {
 	}
 
 	// Init storage
-	db, err := sqorc.Open(storage.GetDatabaseSource(), storage.GetDatabaseSource())
+	db, err := sqorc.Open(storage.GetSQLDriver(), storage.GetDatabaseSource())
 	if err != nil {
 		glog.Fatalf("Error opening db connection: %v", err)
 	}

--- a/orc8r/cloud/go/services/accessd/accessd/main.go
+++ b/orc8r/cloud/go/services/accessd/accessd/main.go
@@ -37,7 +37,7 @@ func main() {
 	}
 
 	// Init storage
-	db, err := sqorc.Open(storage2.SQLDriver, storage2.DatabaseSource)
+	db, err := sqorc.Open(storage2.GetSQLDriver(), storage2.GetDatabaseSource())
 	if err != nil {
 		glog.Fatalf("Failed to connect to database: %s", err)
 	}

--- a/orc8r/cloud/go/services/certifier/certifier/main.go
+++ b/orc8r/cloud/go/services/certifier/certifier/main.go
@@ -56,7 +56,7 @@ func main() {
 	}
 
 	// Init storage
-	db, err := sqorc.Open(storage2.SQLDriver, storage2.DatabaseSource)
+	db, err := sqorc.Open(storage2.GetSQLDriver(), storage2.GetDatabaseSource())
 	if err != nil {
 		glog.Fatalf("Failed to connect to database: %s", err)
 	}

--- a/orc8r/cloud/go/services/configurator/configurator/main.go
+++ b/orc8r/cloud/go/services/configurator/configurator/main.go
@@ -41,7 +41,7 @@ func main() {
 	if err != nil {
 		glog.Fatalf("Error creating service: %s", err)
 	}
-	db, err := sqorc.Open(storage2.SQLDriver, storage2.DatabaseSource)
+	db, err := sqorc.Open(storage2.GetSQLDriver(), storage2.GetDatabaseSource())
 	if err != nil {
 		glog.Fatalf("Failed to connect to database: %s", err)
 	}

--- a/orc8r/cloud/go/services/ctraced/ctraced/main.go
+++ b/orc8r/cloud/go/services/ctraced/ctraced/main.go
@@ -39,7 +39,7 @@ func main() {
 	}
 
 	// Init storage
-	db, err := sqorc.Open(storage.SQLDriver, storage.DatabaseSource)
+	db, err := sqorc.Open(storage.GetDatabaseSource(), storage.GetDatabaseSource())
 	if err != nil {
 		glog.Fatalf("Error opening db connection: %+v", err)
 	}

--- a/orc8r/cloud/go/services/ctraced/ctraced/main.go
+++ b/orc8r/cloud/go/services/ctraced/ctraced/main.go
@@ -39,7 +39,7 @@ func main() {
 	}
 
 	// Init storage
-	db, err := sqorc.Open(storage.GetDatabaseSource(), storage.GetDatabaseSource())
+	db, err := sqorc.Open(storage.GetSQLDriver(), storage.GetDatabaseSource())
 	if err != nil {
 		glog.Fatalf("Error opening db connection: %+v", err)
 	}

--- a/orc8r/cloud/go/services/device/device/main.go
+++ b/orc8r/cloud/go/services/device/device/main.go
@@ -31,7 +31,7 @@ func main() {
 	if err != nil {
 		glog.Fatalf("Error creating device service %s", err)
 	}
-	db, err := sqorc.Open(storage2.SQLDriver, storage2.DatabaseSource)
+	db, err := sqorc.Open(storage2.GetSQLDriver(), storage2.GetDatabaseSource())
 	if err != nil {
 		glog.Fatalf("Failed to connect to database: %s", err)
 	}

--- a/orc8r/cloud/go/services/directoryd/directoryd/main.go
+++ b/orc8r/cloud/go/services/directoryd/directoryd/main.go
@@ -53,7 +53,7 @@ func main() {
 	}
 
 	// Init storage
-	db, err := sqorc.Open(storage.GetDatabaseSource(), storage.GetDatabaseSource())
+	db, err := sqorc.Open(storage.GetSQLDriver(), storage.GetDatabaseSource())
 	if err != nil {
 		glog.Fatalf("Error opening db connection: %s", err)
 	}

--- a/orc8r/cloud/go/services/directoryd/directoryd/main.go
+++ b/orc8r/cloud/go/services/directoryd/directoryd/main.go
@@ -53,7 +53,7 @@ func main() {
 	}
 
 	// Init storage
-	db, err := sqorc.Open(storage.SQLDriver, storage.DatabaseSource)
+	db, err := sqorc.Open(storage.GetDatabaseSource(), storage.GetDatabaseSource())
 	if err != nil {
 		glog.Fatalf("Error opening db connection: %s", err)
 	}

--- a/orc8r/cloud/go/services/state/state/main.go
+++ b/orc8r/cloud/go/services/state/state/main.go
@@ -59,7 +59,7 @@ func main() {
 	if err != nil {
 		glog.Fatalf("Error creating state service %v", err)
 	}
-	db, err := sqorc.Open(storage.SQLDriver, storage.DatabaseSource)
+	db, err := sqorc.Open(storage.GetDatabaseSource(), storage.GetDatabaseSource())
 	if err != nil {
 		glog.Fatalf("Error connecting to database: %v", err)
 	}
@@ -105,7 +105,7 @@ func newIndexerManagerServicer(cfg *config.ConfigMap, db *sql.DB, store blobstor
 	reindexer := reindex.NewReindexer(queue, reindex.NewStore(store))
 	servicer := servicers.NewIndexerManagerServicer(reindexer, autoReindex)
 
-	if autoReindex && storage.SQLDriver != sqorc.PostgresDriver {
+	if autoReindex && storage.GetDatabaseSource() != sqorc.PostgresDriver {
 		glog.Warning(nonPostgresDriverMessage)
 	}
 

--- a/orc8r/cloud/go/services/state/state/main.go
+++ b/orc8r/cloud/go/services/state/state/main.go
@@ -59,7 +59,7 @@ func main() {
 	if err != nil {
 		glog.Fatalf("Error creating state service %v", err)
 	}
-	db, err := sqorc.Open(storage.GetDatabaseSource(), storage.GetDatabaseSource())
+	db, err := sqorc.Open(storage.GetSQLDriver(), storage.GetDatabaseSource())
 	if err != nil {
 		glog.Fatalf("Error connecting to database: %v", err)
 	}
@@ -105,7 +105,7 @@ func newIndexerManagerServicer(cfg *config.ConfigMap, db *sql.DB, store blobstor
 	reindexer := reindex.NewReindexer(queue, reindex.NewStore(store))
 	servicer := servicers.NewIndexerManagerServicer(reindexer, autoReindex)
 
-	if autoReindex && storage.GetDatabaseSource() != sqorc.PostgresDriver {
+	if autoReindex && storage.GetSQLDriver() != sqorc.PostgresDriver {
 		glog.Warning(nonPostgresDriverMessage)
 	}
 

--- a/orc8r/cloud/go/services/tenants/tenants/main.go
+++ b/orc8r/cloud/go/services/tenants/tenants/main.go
@@ -36,7 +36,7 @@ func main() {
 	if err != nil {
 		glog.Fatalf("Error creating tenants service %s", err)
 	}
-	db, err := sqorc.Open(storage2.SQLDriver, storage2.DatabaseSource)
+	db, err := sqorc.Open(storage2.GetSQLDriver(), storage2.GetDatabaseSource())
 	if err != nil {
 		glog.Fatalf("Failed to connect to database: %s", err)
 	}

--- a/orc8r/cloud/go/storage/storage.go
+++ b/orc8r/cloud/go/storage/storage.go
@@ -25,11 +25,6 @@ import (
 	"github.com/thoas/go-funk"
 )
 
-var (
-	SQLDriver      = definitions.MustGetEnv("SQL_DRIVER")
-	DatabaseSource = definitions.MustGetEnv("DATABASE_SOURCE")
-)
-
 type IsolationLevel int
 
 // TxOptions specifies options for transactions
@@ -159,4 +154,12 @@ type UUIDGenerator struct{}
 
 func (*UUIDGenerator) New() string {
 	return uuid.New().String()
+}
+
+func GetSQLDriver() string {
+	return definitions.MustGetEnv("SQL_DRIVER")
+}
+
+func GetDatabaseSource() string {
+	return definitions.MustGetEnv("DATABASE_SOURCE")
 }

--- a/orc8r/cloud/go/storage/storage.go
+++ b/orc8r/cloud/go/storage/storage.go
@@ -26,8 +26,8 @@ import (
 )
 
 var (
-	SQLDriver      = definitions.GetEnvWithDefault("SQL_DRIVER", "sqlite3")
-	DatabaseSource = definitions.GetEnvWithDefault("DATABASE_SOURCE", ":memory:")
+	SQLDriver      = definitions.MustGetEnv("SQL_DRIVER")
+	DatabaseSource = definitions.MustGetEnv("DATABASE_SOURCE")
 )
 
 type IsolationLevel int

--- a/orc8r/cloud/go/test_utils/test_db.go
+++ b/orc8r/cloud/go/test_utils/test_db.go
@@ -21,7 +21,7 @@ import (
 
 	"magma/orc8r/cloud/go/blobstore"
 	"magma/orc8r/cloud/go/sqorc"
-	storage2 "magma/orc8r/cloud/go/storage"
+	"magma/orc8r/lib/go/definitions"
 
 	_ "github.com/mattn/go-sqlite3"
 	"github.com/pkg/errors"
@@ -36,7 +36,7 @@ var (
 // GetSharedMemoryDB returns a singleton in-memory database connection.
 func GetSharedMemoryDB() (*sql.DB, error) {
 	var err error
-	once.Do(func() { instance, err = sqorc.Open(storage2.SQLDriver, ":memory:") })
+	once.Do(func() { instance, err = sqorc.Open(definitions.SQLite3, ":memory:") })
 	return instance, err
 }
 

--- a/orc8r/cloud/go/test_utils/test_db.go
+++ b/orc8r/cloud/go/test_utils/test_db.go
@@ -21,7 +21,6 @@ import (
 
 	"magma/orc8r/cloud/go/blobstore"
 	"magma/orc8r/cloud/go/sqorc"
-	"magma/orc8r/lib/go/definitions"
 
 	_ "github.com/mattn/go-sqlite3"
 	"github.com/pkg/errors"
@@ -36,7 +35,7 @@ var (
 // GetSharedMemoryDB returns a singleton in-memory database connection.
 func GetSharedMemoryDB() (*sql.DB, error) {
 	var err error
-	once.Do(func() { instance, err = sqorc.Open(definitions.SQLiteDriver, ":memory:") })
+	once.Do(func() { instance, err = sqorc.Open(sqorc.SQLiteDriver, ":memory:") })
 	return instance, err
 }
 

--- a/orc8r/cloud/go/test_utils/test_db.go
+++ b/orc8r/cloud/go/test_utils/test_db.go
@@ -36,7 +36,7 @@ var (
 // GetSharedMemoryDB returns a singleton in-memory database connection.
 func GetSharedMemoryDB() (*sql.DB, error) {
 	var err error
-	once.Do(func() { instance, err = sqorc.Open(definitions.SQLite3, ":memory:") })
+	once.Do(func() { instance, err = sqorc.Open(definitions.SQLiteDriver, ":memory:") })
 	return instance, err
 }
 

--- a/orc8r/lib/go/definitions/const.go
+++ b/orc8r/lib/go/definitions/const.go
@@ -24,5 +24,5 @@ const (
 	StateServiceName        = "state"
 	StreamerServiceName     = "streamer"
 
-	SQLite3 = "sqlite3"
+	SQLiteDriver = "sqlite3"
 )

--- a/orc8r/lib/go/definitions/const.go
+++ b/orc8r/lib/go/definitions/const.go
@@ -23,6 +23,4 @@ const (
 	MetricsdServiceName     = "metricsd"
 	StateServiceName        = "state"
 	StreamerServiceName     = "streamer"
-
-	SQLiteDriver = "sqlite3"
 )

--- a/orc8r/lib/go/definitions/const.go
+++ b/orc8r/lib/go/definitions/const.go
@@ -23,4 +23,6 @@ const (
 	MetricsdServiceName     = "metricsd"
 	StateServiceName        = "state"
 	StreamerServiceName     = "streamer"
+
+	SQLite3 = "sqlite3"
 )

--- a/orc8r/lib/go/definitions/env.go
+++ b/orc8r/lib/go/definitions/env.go
@@ -13,7 +13,10 @@ limitations under the License.
 
 package definitions
 
-import "os"
+import (
+	"fmt"
+	"os"
+)
 
 // GetEnvWithDefault returns the string value of the environment variable,
 // defaulting to a specified value if it doesn't exist.
@@ -21,6 +24,16 @@ func GetEnvWithDefault(variable string, defaultValue string) string {
 	value := os.Getenv(variable)
 	if len(value) == 0 {
 		value = defaultValue
+	}
+	return value
+}
+
+// MustGetEnv returns the string value of the environment variable,
+// panics it doesn't exist
+func MustGetEnv(variable string) string {
+	value := os.Getenv(variable)
+	if len(value) == 0 {
+		panic(fmt.Errorf("%s env not found", variable))
 	}
 	return value
 }

--- a/orc8r/lib/go/definitions/env.go
+++ b/orc8r/lib/go/definitions/env.go
@@ -14,8 +14,9 @@ limitations under the License.
 package definitions
 
 import (
-	"fmt"
 	"os"
+
+	"github.com/pkg/errors"
 )
 
 // GetEnvWithDefault returns the string value of the environment variable,
@@ -33,7 +34,7 @@ func GetEnvWithDefault(variable string, defaultValue string) string {
 func MustGetEnv(variable string) string {
 	value := os.Getenv(variable)
 	if len(value) == 0 {
-		panic(fmt.Errorf("%s env not found", variable))
+		panic(errors.Errorf("%s env not found", variable))
 	}
 	return value
 }


### PR DESCRIPTION
Remove default in orc8r database storage

## Summary

Add a new MustGetEnv function in orc8r/lib/go/definitions/env.go
Set SQL driver and DB source in orc8r/cloud/go/storage/storage.go with MustGetEnv instead of the "with default" getter
Fix tests
## Test Plan
./build.py -t

## Additional Information

#4086