### PR TITLE
[orc8r] Default value for SNS emails

### DIFF
--- a/orc8r/cloud/deploy/terraform/orc8r-aws/variables.tf
+++ b/orc8r/cloud/deploy/terraform/orc8r-aws/variables.tf
@@ -385,4 +385,5 @@ variable "orc8r_sns_name" {
 variable "orc8r_sns_email" {
   description = "SNS email endpoint to send notifications"
   type        = string
+  default     = ""
 }


### PR DESCRIPTION
Signed-off-by: Arun Thulasi <arunt@fb.com>

## Summary

Setting default value for orc8r_sns_email

## Test Plan

Deploy orc8r without specifying a value for orc8r_sns_email

## Additional Information

