### PR TITLE
[Agw][MME][refactor] Replace some func return types with status_code_e

### DIFF
--- a/lte/gateway/c/core/oai/lib/gtpv2-c/gtpv2c_ie_formatter/shared/gtpv2c_ie_formatter.h
+++ b/lte/gateway/c/core/oai/lib/gtpv2-c/gtpv2c_ie_formatter/shared/gtpv2c_ie_formatter.h
@@ -27,6 +27,7 @@
 
 #include <stdbool.h>
 
+#include "common_defs.h"
 #include "NwTypes.h"
 #include "NwGtpv2c.h"
 #include "3gpp_23.003.h"
@@ -125,7 +126,7 @@ nw_rc_t gtpv2c_target_identification_ie_get(
     uint8_t ieType, uint16_t ieLength, uint8_t ieInstance, uint8_t* ieValue,
     void* arg);
 
-int gtpv2c_target_identification_ie_set(
+status_code_e gtpv2c_target_identification_ie_set(
     nw_gtpv2c_msg_handle_t* msg,
     const target_identification_t* target_identification);
 

--- a/lte/gateway/c/core/oai/lib/gtpv2-c/gtpv2c_ie_formatter/src/gtpv2c_ie_formatter.c
+++ b/lte/gateway/c/core/oai/lib/gtpv2-c/gtpv2c_ie_formatter/src/gtpv2c_ie_formatter.c
@@ -759,7 +759,7 @@ nw_rc_t gtpv2c_target_identification_ie_get(
 }
 
 //------------------------------------------------------------------------------
-int gtpv2c_target_identification_ie_set(
+status_code_e gtpv2c_target_identification_ie_set(
     nw_gtpv2c_msg_handle_t* msg,
     const target_identification_t* target_identification) {
   nw_rc_t rc;

--- a/lte/gateway/c/core/oai/lib/openflow/controller/OpenflowController.cpp
+++ b/lte/gateway/c/core/oai/lib/openflow/controller/OpenflowController.cpp
@@ -118,7 +118,8 @@ void OpenflowController::inject_external_event(
   latest_ofconn_->add_immediate_event(cb, ev);
 }
 
-bool OpenflowController::is_controller_connected_to_switch(int conn_timeout) {
+status_code_e OpenflowController::is_controller_connected_to_switch(
+    int conn_timeout) {
   /* c++ provided conditional variable is added to wait for
    * conn_timeout seconds to make sure connection is established
    * between Controller and switch before inserting the OVS rules

--- a/lte/gateway/c/core/oai/lib/openflow/controller/OpenflowController.h
+++ b/lte/gateway/c/core/oai/lib/openflow/controller/OpenflowController.h
@@ -25,6 +25,7 @@
 
 #include "ControllerEvents.h"
 #include "OpenflowMessenger.h"
+#include "common_defs.h"
 
 namespace openflow {
 
@@ -116,7 +117,7 @@ class OpenflowController : public fluid_base::OFServer {
    */
   void inject_external_event(
       std::shared_ptr<ExternalEvent> ev, void* (*cb)(std::shared_ptr<void>) );
-  bool is_controller_connected_to_switch(int conn_timeout);
+  status_code_e is_controller_connected_to_switch(int conn_timeout);
 
  private:
   std::shared_ptr<OpenflowMessenger> messenger_;

--- a/lte/gateway/c/core/oai/lib/pcef/pcef_handlers.cpp
+++ b/lte/gateway/c/core/oai/lib/pcef/pcef_handlers.cpp
@@ -98,7 +98,7 @@ static void pcef_fill_create_session_req(
  * Send an ITTI message from GRPC service task to SPGW task when the
  * PCEFClient receives the response for the aynchronous Create Sesssion RPC
  */
-int send_itti_pcef_create_session_response(
+status_code_e send_itti_pcef_create_session_response(
     const std::string& imsi, s5_create_session_request_t session_request,
     const grpc::Status& status) {
   MessageDef* message_p = nullptr;

--- a/lte/gateway/c/core/oai/tasks/grpc_service/amf_service_handler.c
+++ b/lte/gateway/c/core/oai/tasks/grpc_service/amf_service_handler.c
@@ -21,7 +21,7 @@
 
 extern task_zmq_ctx_t grpc_service_task_zmq_ctx;
 
-int send_n11_create_pdu_session_resp_itti(
+status_code_e send_n11_create_pdu_session_resp_itti(
     itti_n11_create_pdu_session_response_t* itti_msg) {
   OAILOG_DEBUG(
       LOG_UTIL, "Sending itti_n11_create_pdu_session_response to AMF \n");

--- a/lte/gateway/c/core/oai/tasks/grpc_service/grpc_service_task.c
+++ b/lte/gateway/c/core/oai/tasks/grpc_service/grpc_service_task.c
@@ -67,7 +67,7 @@ static void* grpc_service_thread(__attribute__((unused)) void* args) {
   return NULL;
 }
 
-int grpc_service_init(void) {
+status_code_e grpc_service_init(void) {
   OAILOG_DEBUG(LOG_UTIL, "Initializing grpc_service task interface\n");
   grpc_service_config                 = calloc(1, sizeof(grpc_service_data_t));
   grpc_service_config->server_address = bfromcstr(GRPCSERVICES_SERVER_ADDRESS);

--- a/lte/gateway/c/core/oai/tasks/gtpv1-u/gtp_tunnel_libgtpnl.c
+++ b/lte/gateway/c/core/oai/tasks/gtpv1-u/gtp_tunnel_libgtpnl.c
@@ -43,7 +43,7 @@ static struct {
 
 #define GTP_DEVNAME "gtp0"
 
-int libgtpnl_init(
+status_code_e libgtpnl_init(
     struct in_addr* ue_net, uint32_t mask, int mtu, int* fd0, int* fd1u,
     bool persist_state) {
   // we don't need GTP v0, but interface with kernel requires 2 file descriptors
@@ -135,20 +135,20 @@ int libgtpnl_init(
   return RETURNok;
 }
 
-int libgtpnl_uninit(void) {
+status_code_e libgtpnl_uninit(void) {
   if (!gtp_nl.is_enabled) return -1;
 
   return gtp_dev_destroy(GTP_DEVNAME);
 }
 
-int libgtpnl_reset(void) {
+status_code_e libgtpnl_reset(void) {
   int rv = 0;
   rv     = system("rmmod gtp");
   rv     = system("modprobe gtp");
   return rv;
 }
 
-int libgtpnl_add_tunnel(
+status_code_e libgtpnl_add_tunnel(
     struct in_addr ue, __attribute__((unused)) struct in6_addr* ue_ipv6,
     __attribute__((unused)) int vlan, struct in_addr enb, uint32_t i_tei,
     uint32_t o_tei, Imsi_t imsi, struct ip_flow_dl* flow_dl,
@@ -174,7 +174,7 @@ int libgtpnl_add_tunnel(
   return ret;
 }
 
-int libgtpnl_del_tunnel(
+status_code_e libgtpnl_del_tunnel(
     __attribute__((unused)) struct in_addr enb,
     __attribute__((unused)) struct in_addr ue,
     __attribute__((unused)) struct in6_addr* ue_ipv6, uint32_t i_tei,

--- a/lte/gateway/c/core/oai/tasks/ha/ha_defs.h
+++ b/lte/gateway/c/core/oai/tasks/ha/ha_defs.h
@@ -18,7 +18,7 @@ limitations under the License.
 
 extern task_zmq_ctx_t ha_task_zmq_ctx;
 
-int ha_init(const mme_config_t* mme_config);
+status_code_e ha_init(const mme_config_t* mme_config);
 
 /*
  * Syncs up with orc8r and fetches eNB connection state

--- a/lte/gateway/c/core/oai/tasks/ha/ha_task.c
+++ b/lte/gateway/c/core/oai/tasks/ha/ha_task.c
@@ -85,7 +85,7 @@ static void* ha_thread(__attribute__((unused)) void* args_p) {
 }
 
 //------------------------------------------------------------------------------
-int ha_init(const mme_config_t* mme_config_p) {
+status_code_e ha_init(const mme_config_t* mme_config_p) {
   OAILOG_DEBUG(LOG_UTIL, "Initializing HA task interface\n");
 
   if (itti_create_task(TASK_HA, &ha_thread, NULL) < 0) {

--- a/lte/gateway/c/core/oai/tasks/mme_app/mme_app_apn_selection.c
+++ b/lte/gateway/c/core/oai/tasks/mme_app/mme_app_apn_selection.c
@@ -33,7 +33,7 @@
 #include "conversions.h"
 
 //------------------------------------------------------------------------------
-int select_pdn_type(
+status_code_e select_pdn_type(
     struct apn_configuration_s* apn_config,
     esm_proc_pdn_type_t ue_selected_pdn_type, esm_cause_t* esm_cause) {
   /* Overwrite apn_config->pdn_type based on the PDN type sent by UE and the PDN

--- a/lte/gateway/c/core/oai/tasks/mme_app/mme_app_bearer.c
+++ b/lte/gateway/c/core/oai/tasks/mme_app/mme_app_bearer.c
@@ -92,7 +92,7 @@ static void send_s11_modify_bearer_request(
     ue_mm_context_t* ue_context_p, pdn_context_t* pdn_context_p,
     MessageDef* message_p);
 
-int send_modify_bearer_req(mme_ue_s1ap_id_t ue_id, ebi_t ebi) {
+status_code_e send_modify_bearer_req(mme_ue_s1ap_id_t ue_id, ebi_t ebi) {
   OAILOG_FUNC_IN(LOG_MME_APP);
 
   uint8_t item = 0;  // This function call is used for default bearer only
@@ -219,7 +219,7 @@ void print_bearer_ids_helper(const ebi_t* ebi, uint32_t no_of_bearers) {
 }
 
 //------------------------------------------------------------------------------
-int send_pcrf_bearer_actv_rsp(
+status_code_e send_pcrf_bearer_actv_rsp(
     struct ue_mm_context_s* ue_context_p, ebi_t ebi,
     gtpv2c_cause_value_t cause) {
   OAILOG_FUNC_IN(LOG_MME_APP);
@@ -1034,7 +1034,7 @@ void mme_app_handle_delete_session_rsp(
 }
 
 //------------------------------------------------------------------------------
-int mme_app_handle_create_sess_resp(
+status_code_e mme_app_handle_create_sess_resp(
     mme_app_desc_t* mme_app_desc_p,
     itti_s11_create_session_response_t* const create_sess_resp_pP) {
   OAILOG_FUNC_IN(LOG_MME_APP);
@@ -1532,7 +1532,7 @@ static void mme_app_build_modify_bearer_request_message(
 }
 
 //------------------------------------------------------------------------------
-static int mme_app_send_modify_bearer_request_for_active_pdns(
+static status_code_e mme_app_send_modify_bearer_request_for_active_pdns(
     struct ue_mm_context_s* ue_context_p,
     itti_mme_app_initial_context_setup_rsp_t* const initial_ctxt_setup_rsp_p) {
   OAILOG_FUNC_IN(LOG_MME_APP);
@@ -1854,7 +1854,7 @@ void mme_app_handle_e_rab_setup_rsp(
 }
 
 //------------------------------------------------------------------------------
-int mme_app_handle_mobile_reachability_timer_expiry(
+status_code_e mme_app_handle_mobile_reachability_timer_expiry(
     zloop_t* loop, int timer_id, void* args) {
   OAILOG_FUNC_IN(LOG_MME_APP);
 
@@ -1902,7 +1902,7 @@ int mme_app_handle_mobile_reachability_timer_expiry(
   OAILOG_FUNC_RETURN(LOG_MME_APP, RETURNok);
 }
 //------------------------------------------------------------------------------
-int mme_app_handle_implicit_detach_timer_expiry(
+status_code_e mme_app_handle_implicit_detach_timer_expiry(
     zloop_t* loop, int timer_id, void* args) {
   OAILOG_FUNC_IN(LOG_MME_APP);
   mme_ue_s1ap_id_t mme_ue_s1ap_id = 0;
@@ -1929,7 +1929,7 @@ int mme_app_handle_implicit_detach_timer_expiry(
 }
 
 //------------------------------------------------------------------------------
-int mme_app_handle_initial_context_setup_rsp_timer_expiry(
+status_code_e mme_app_handle_initial_context_setup_rsp_timer_expiry(
     zloop_t* loop, int timer_id, void* args) {
   OAILOG_FUNC_IN(LOG_MME_APP);
   mme_ue_s1ap_id_t mme_ue_s1ap_id = 0;
@@ -2095,7 +2095,7 @@ static void notify_s1ap_new_ue_mme_s1ap_id_association(
  * @param paging_id_stmsi- paging ID, either to page with IMSI or STMSI
  * @param domain_indicator- Informs paging initiated for CS/PS
  */
-int mme_app_paging_request_helper(
+status_code_e mme_app_paging_request_helper(
     ue_mm_context_t* ue_context_p, bool set_timer, uint8_t paging_id_stmsi,
     s1ap_cn_domain_t domain_indicator) {
   MessageDef* message_p = NULL;
@@ -2295,7 +2295,7 @@ void mme_app_send_actv_dedicated_bearer_rej_for_pending_bearers(
   OAILOG_FUNC_OUT(LOG_MME_APP);
 }
 
-int mme_app_handle_paging_timer_expiry(
+status_code_e mme_app_handle_paging_timer_expiry(
     zloop_t* loop, int timer_id, void* args) {
   OAILOG_FUNC_IN(LOG_MME_APP);
   mme_ue_s1ap_id_t mme_ue_s1ap_id = 0;
@@ -2371,7 +2371,8 @@ int mme_app_handle_paging_timer_expiry(
   OAILOG_FUNC_RETURN(LOG_MME_APP, RETURNok);
 }
 
-int mme_app_handle_ulr_timer_expiry(zloop_t* loop, int timer_id, void* args) {
+status_code_e mme_app_handle_ulr_timer_expiry(
+    zloop_t* loop, int timer_id, void* args) {
   OAILOG_FUNC_IN(LOG_MME_APP);
   mme_ue_s1ap_id_t mme_ue_s1ap_id = 0;
   if (!mme_app_get_timer_arg(timer_id, &mme_ue_s1ap_id)) {
@@ -2412,7 +2413,7 @@ int mme_app_handle_ulr_timer_expiry(zloop_t* loop, int timer_id, void* args) {
  * handover and discard the DL data received for this UE
  *
  * */
-int mme_app_send_s11_suspend_notification(
+status_code_e mme_app_send_s11_suspend_notification(
     struct ue_mm_context_s* const ue_context_pP, const pdn_cid_t pdn_index) {
   MessageDef* message_p                                   = NULL;
   itti_s11_suspend_notification_t* suspend_notification_p = NULL;
@@ -2502,7 +2503,7 @@ void mme_app_handle_suspend_acknowledge(
 }
 
 //------------------------------------------------------------------------------
-int mme_app_handle_nas_extended_service_req(
+status_code_e mme_app_handle_nas_extended_service_req(
     const mme_ue_s1ap_id_t ue_id, const uint8_t service_type,
     uint8_t csfb_response) {
   struct ue_mm_context_s* ue_context_p = NULL;
@@ -2683,7 +2684,7 @@ int mme_app_handle_nas_extended_service_req(
 }
 
 //------------------------------------------------------------------------------
-int mme_app_handle_ue_context_modification_timer_expiry(
+status_code_e mme_app_handle_ue_context_modification_timer_expiry(
     zloop_t* loop, int timer_id, void* args) {
   OAILOG_FUNC_IN(LOG_MME_APP);
   mme_ue_s1ap_id_t mme_ue_s1ap_id = 0;
@@ -2716,7 +2717,7 @@ int mme_app_handle_ue_context_modification_timer_expiry(
  * And Send Service Reject to UE
  * In case of of MO CS call, send Service Reject to UE
  */
-int handle_csfb_s1ap_procedure_failure(
+status_code_e handle_csfb_s1ap_procedure_failure(
     ue_mm_context_t* ue_context_p, char* failed_statement,
     uint8_t failed_procedure) {
   OAILOG_FUNC_IN(LOG_MME_APP);

--- a/lte/gateway/c/core/oai/tasks/mme_app/mme_app_capabilities.c
+++ b/lte/gateway/c/core/oai/tasks/mme_app/mme_app_capabilities.c
@@ -27,7 +27,7 @@
 #include "mme_app_desc.h"
 #include "s1ap_messages_types.h"
 
-int mme_app_handle_s1ap_ue_capabilities_ind(
+status_code_e mme_app_handle_s1ap_ue_capabilities_ind(
     const itti_s1ap_ue_cap_ind_t* const s1ap_ue_cap_ind_pP) {
   ue_mm_context_t* ue_context_p = NULL;
 

--- a/lte/gateway/c/core/oai/tasks/mme_app/mme_app_context.c
+++ b/lte/gateway/c/core/oai/tasks/mme_app/mme_app_context.c
@@ -595,7 +595,7 @@ void mme_ue_context_dump_coll_keys(const mme_ue_context_t* mme_ue_contexts_p) {
 }
 
 //------------------------------------------------------------------------------
-int mme_insert_ue_context(
+status_code_e mme_insert_ue_context(
     mme_ue_context_t* const mme_ue_context_p,
     const struct ue_mm_context_s* const ue_context_p) {
   hashtable_rc_t h_rc                 = HASH_TABLE_OK;

--- a/lte/gateway/c/core/oai/tasks/mme_app/mme_app_defs.h
+++ b/lte/gateway/c/core/oai/tasks/mme_app/mme_app_defs.h
@@ -233,8 +233,8 @@ int mme_app_handle_sgsap_reset_indication(
 
 int sgs_fsm_associated_reset_indication(const sgs_fsm_t* fsm_evt);
 
-bool mme_app_handle_reset_indication(
-    hash_key_t keyP, void* ue_context_pP, void* unused_param_pP,
+status_code_e mme_app_handle_reset_indication(
+    hash_key_t keyP, void* const ue_context_pP, void* unused_param_pP,
     void** unused_result_pP);
 
 int mme_app_handle_sgsap_alert_request(
@@ -312,7 +312,7 @@ void mme_app_handle_path_switch_req_failure(
 void mme_app_send_itti_sgsap_ue_activity_ind(
     const char* imsi, unsigned int imsi_len);
 
-int emm_send_cs_domain_attach_or_tau_accept(
+status_code_e emm_send_cs_domain_attach_or_tau_accept(
     struct ue_mm_context_s* ue_context_p);
 
 void mme_app_update_paging_tai_list(

--- a/lte/gateway/c/core/oai/tasks/mme_app/mme_app_detach.c
+++ b/lte/gateway/c/core/oai/tasks/mme_app/mme_app_detach.c
@@ -223,7 +223,7 @@ void mme_app_handle_detach_req(const mme_ue_s1ap_id_t ue_id) {
  **          Return:    RETURNok, RETURNerror                               **
  **                                                                         **
  ******************************************************************************/
-int mme_app_handle_nw_initiated_detach_request(
+status_code_e mme_app_handle_nw_initiated_detach_request(
     mme_ue_s1ap_id_t ue_id, uint8_t detach_type) {
   OAILOG_FUNC_IN(LOG_MME_APP);
   emm_cn_nw_initiated_detach_ue_t emm_cn_nw_initiated_detach = {0};

--- a/lte/gateway/c/core/oai/tasks/mme_app/mme_app_edns_emulation.c
+++ b/lte/gateway/c/core/oai/tasks/mme_app/mme_app_edns_emulation.c
@@ -46,7 +46,7 @@ struct in_addr* mme_app_edns_get_sgw_entry(bstring id) {
 }
 
 //------------------------------------------------------------------------------
-int mme_app_edns_add_sgw_entry(bstring id, struct in_addr in_addr) {
+status_code_e mme_app_edns_add_sgw_entry(bstring id, struct in_addr in_addr) {
   char* cid = calloc(1, blength(id) + 1);
   if (cid) {
     strncpy(cid, (const char*) id->data, blength(id));
@@ -68,7 +68,7 @@ int mme_app_edns_add_sgw_entry(bstring id, struct in_addr in_addr) {
 }
 
 //------------------------------------------------------------------------------
-int mme_app_edns_init(const mme_config_t* mme_config_p) {
+status_code_e mme_app_edns_init(const mme_config_t* mme_config_p) {
   int rc          = RETURNok;
   g_e_dns_entries = obj_hashtable_create(
       OAI_MIN(32, MME_CONFIG_MAX_SGW), NULL, free_wrapper, free_wrapper, NULL);

--- a/lte/gateway/c/core/oai/tasks/mme_app/mme_app_edns_emulation.h
+++ b/lte/gateway/c/core/oai/tasks/mme_app/mme_app_edns_emulation.h
@@ -18,6 +18,7 @@
 #ifndef FILE_MME_APP_EDNS_EMULATION_SEEN
 #define FILE_MME_APP_EDNS_EMULATION_SEEN
 
+#include "common_defs.h"
 #include "bstrlib.h"
 #include "mme_config.h"
 
@@ -30,8 +31,8 @@ struct in_addr;
 */
 
 struct in_addr* mme_app_edns_get_sgw_entry(bstring id);
-int mme_app_edns_add_sgw_entry(bstring id, struct in_addr in_addr);
-int mme_app_edns_init(const mme_config_t* mme_config_p);
+status_code_e mme_app_edns_add_sgw_entry(bstring id, struct in_addr in_addr);
+status_code_e mme_app_edns_init(const mme_config_t* mme_config_p);
 void mme_app_edns_exit(void);
 
 #endif

--- a/lte/gateway/c/core/oai/tasks/mme_app/mme_app_embedded_spgw.c
+++ b/lte/gateway/c/core/oai/tasks/mme_app/mme_app_embedded_spgw.c
@@ -49,7 +49,7 @@ static void usage(char* exe_path) {
       exe_path, PACKAGE_NAME);
 }
 
-int mme_config_embedded_spgw_parse_opt_line(
+status_code_e mme_config_embedded_spgw_parse_opt_line(
     int argc, char* argv[], mme_config_t* mme_config_p,
     spgw_config_t* spgw_config_p) {
   int c;

--- a/lte/gateway/c/core/oai/tasks/mme_app/mme_app_embedded_spgw.h
+++ b/lte/gateway/c/core/oai/tasks/mme_app/mme_app_embedded_spgw.h
@@ -20,7 +20,7 @@
 #include "sgw_config.h"
 #include "sgw_defs.h"
 
-int mme_config_embedded_spgw_parse_opt_line(
+status_code_e mme_config_embedded_spgw_parse_opt_line(
     int argc, char* argv[], mme_config_t*, spgw_config_t*);
 
 #endif /* ifndef FILE_MME_APP_SPGW_SEEN */

--- a/lte/gateway/c/core/oai/tasks/mme_app/mme_app_hss_reset.c
+++ b/lte/gateway/c/core/oai/tasks/mme_app/mme_app_hss_reset.c
@@ -37,7 +37,8 @@
 #include "mme_app_desc.h"
 #include "s6a_messages_types.h"
 
-int mme_app_handle_s6a_reset_req(const s6a_reset_req_t* const rsr_pP) {
+status_code_e mme_app_handle_s6a_reset_req(
+    const s6a_reset_req_t* const rsr_pP) {
   int rc                               = RETURNok;
   struct ue_mm_context_s* ue_context_p = NULL;
   hash_node_t* node                    = NULL;

--- a/lte/gateway/c/core/oai/tasks/mme_app/mme_app_itti_messaging.c
+++ b/lte/gateway/c/core/oai/tasks/mme_app/mme_app_itti_messaging.c
@@ -115,7 +115,7 @@ void mme_app_itti_ue_context_release(
  **      Return:    RETURNok, RETURNerror                                  **
  **                                                                        **
  ***************************************************************************/
-int mme_app_send_s11_release_access_bearers_req(
+status_code_e mme_app_send_s11_release_access_bearers_req(
     struct ue_mm_context_s* const ue_mm_context, const pdn_cid_t pdn_index) {
   OAILOG_FUNC_IN(LOG_MME_APP);
   /*
@@ -183,7 +183,7 @@ int mme_app_send_s11_release_access_bearers_req(
  **      Return:    RETURNok, RETURNerror                                  **
  **                                                                        **
  ***************************************************************************/
-int mme_app_send_s11_create_session_req(
+status_code_e mme_app_send_s11_create_session_req(
     mme_app_desc_t* mme_app_desc_p, struct ue_mm_context_s* const ue_mm_context,
     const pdn_cid_t pdn_cid) {
   OAILOG_FUNC_IN(LOG_MME_APP);

--- a/lte/gateway/c/core/oai/tasks/mme_app/mme_app_itti_messaging.h
+++ b/lte/gateway/c/core/oai/tasks/mme_app/mme_app_itti_messaging.h
@@ -45,9 +45,9 @@
 void mme_app_itti_ue_context_release(
     struct ue_mm_context_s* ue_context_p, enum s1cause cause);
 int mme_app_notify_s1ap_ue_context_released(const mme_ue_s1ap_id_t ue_idP);
-int mme_app_send_s11_release_access_bearers_req(
+status_code_e mme_app_send_s11_release_access_bearers_req(
     struct ue_mm_context_s* const ue_mm_context, const pdn_cid_t pdn_index);
-int mme_app_send_s11_create_session_req(
+status_code_e mme_app_send_s11_create_session_req(
     mme_app_desc_t* mme_app_desc_p, struct ue_mm_context_s* const ue_mm_context,
     const pdn_cid_t pdn_cid);
 

--- a/lte/gateway/c/core/oai/tasks/mme_app/mme_app_location.c
+++ b/lte/gateway/c/core/oai/tasks/mme_app/mme_app_location.c
@@ -58,7 +58,7 @@
 #include "dynamic_memory_check.h"
 
 //------------------------------------------------------------------------------
-int mme_app_send_s6a_update_location_req(
+status_code_e mme_app_send_s6a_update_location_req(
     struct ue_mm_context_s* const ue_context_p) {
   OAILOG_FUNC_IN(LOG_MME_APP);
   MessageDef* message_p                = NULL;
@@ -170,7 +170,7 @@ int mme_app_send_s6a_update_location_req(
   OAILOG_FUNC_RETURN(LOG_MME_APP, rc);
 }
 
-int handle_ula_failure(struct ue_mm_context_s* ue_context_p) {
+status_code_e handle_ula_failure(struct ue_mm_context_s* ue_context_p) {
   int rc = RETURNok;
 
   OAILOG_FUNC_IN(LOG_MME_APP);
@@ -195,7 +195,7 @@ int handle_ula_failure(struct ue_mm_context_s* ue_context_p) {
 }
 
 //------------------------------------------------------------------------------
-int mme_app_handle_s6a_update_location_ans(
+status_code_e mme_app_handle_s6a_update_location_ans(
     mme_app_desc_t* mme_app_desc_p,
     const s6a_update_location_ans_t* const ula_pP) {
   OAILOG_FUNC_IN(LOG_MME_APP);
@@ -396,7 +396,7 @@ int mme_app_handle_s6a_update_location_ans(
   OAILOG_FUNC_RETURN(LOG_MME_APP, rc);
 }
 
-int mme_app_handle_s6a_cancel_location_req(
+status_code_e mme_app_handle_s6a_cancel_location_req(
     mme_app_desc_t* mme_app_desc_p,
     const s6a_cancel_location_req_t* const clr_pP) {
   uint64_t imsi                        = 0;
@@ -491,7 +491,7 @@ int mme_app_handle_s6a_cancel_location_req(
   OAILOG_FUNC_RETURN(LOG_MME_APP, RETURNok);
 }
 
-int mme_app_send_s6a_cancel_location_ans(
+status_code_e mme_app_send_s6a_cancel_location_ans(
     int cla_result, const char* imsi, uint8_t imsi_length, void* msg_cla_p) {
   MessageDef* message_p                = NULL;
   s6a_cancel_location_ans_t* s6a_cla_p = NULL;

--- a/lte/gateway/c/core/oai/tasks/mme_app/mme_app_main.c
+++ b/lte/gateway/c/core/oai/tasks/mme_app/mme_app_main.c
@@ -538,7 +538,7 @@ static void mme_app_init_congestion_params(const mme_config_t* mme_config_p) {
 }
 
 //------------------------------------------------------------------------------
-int mme_app_init(const mme_config_t* mme_config_p) {
+status_code_e mme_app_init(const mme_config_t* mme_config_p) {
   OAILOG_FUNC_IN(LOG_MME_APP);
   if (mme_nas_state_init(mme_config_p)) {
     OAILOG_FUNC_RETURN(LOG_MME_APP, RETURNerror);

--- a/lte/gateway/c/core/oai/tasks/mme_app/mme_app_procedures.c
+++ b/lte/gateway/c/core/oai/tasks/mme_app/mme_app_procedures.c
@@ -116,7 +116,7 @@ static void mme_app_free_s11_procedure_create_bearer(
 }
 
 //------------------------------------------------------------------------------
-int mme_app_run_s1ap_procedure_modify_bearer_ind(
+status_code_e mme_app_run_s1ap_procedure_modify_bearer_ind(
     mme_app_s1ap_proc_modify_bearer_ind_t* proc,
     const itti_s1ap_e_rab_modification_ind_t* const e_rab_modification_ind) {
   OAILOG_FUNC_IN(LOG_MME_APP);

--- a/lte/gateway/c/core/oai/tasks/mme_app/mme_app_purge_ue.c
+++ b/lte/gateway/c/core/oai/tasks/mme_app/mme_app_purge_ue.c
@@ -39,7 +39,7 @@
 #include "mme_app_desc.h"
 #include "s6a_messages_types.h"
 
-int mme_app_send_s6a_purge_ue_req(
+status_code_e mme_app_send_s6a_purge_ue_req(
     mme_app_desc_t* mme_app_desc_p,
     struct ue_mm_context_s* const ue_context_pP) {
   struct ue_mm_context_s* ue_context_p = NULL;
@@ -82,7 +82,8 @@ int mme_app_send_s6a_purge_ue_req(
   OAILOG_FUNC_RETURN(LOG_MME_APP, rc);
 }
 
-int mme_app_handle_s6a_purge_ue_ans(const s6a_purge_ue_ans_t* const pua_pP) {
+status_code_e mme_app_handle_s6a_purge_ue_ans(
+    const s6a_purge_ue_ans_t* const pua_pP) {
   uint64_t imsi = 0;
 
   OAILOG_FUNC_IN(LOG_MME_APP);

--- a/lte/gateway/c/core/oai/tasks/mme_app/mme_app_sgs_alert.c
+++ b/lte/gateway/c/core/oai/tasks/mme_app/mme_app_sgs_alert.c
@@ -75,7 +75,7 @@ static int mme_app_send_sgsap_alert_ack(
  **      Return:    RETURNok, RETURNerror                                  **
  **                                                                        **
  ***************************************************************************/
-int mme_app_handle_sgsap_alert_request(
+status_code_e mme_app_handle_sgsap_alert_request(
     mme_app_desc_t* mme_app_desc_p,
     itti_sgsap_alert_request_t* const sgsap_alert_req_pP) {
   uint64_t imsi64                      = 0;
@@ -144,7 +144,7 @@ int mme_app_handle_sgsap_alert_request(
  **          Return:    RETURNok, RETURNerror **
  **
  ***********************************************************************************/
-static int mme_app_send_sgsap_alert_reject(
+static status_code_e mme_app_send_sgsap_alert_reject(
     itti_sgsap_alert_request_t* const sgsap_alert_req_pP, SgsCause_t sgs_cause,
     uint64_t imsi64) {
   OAILOG_FUNC_IN(LOG_MME_APP);
@@ -189,7 +189,7 @@ static int mme_app_send_sgsap_alert_reject(
  **          Return:    RETURNok, RETURNerror **
  **
  ***********************************************************************************/
-static int mme_app_send_sgsap_alert_ack(
+static status_code_e mme_app_send_sgsap_alert_ack(
     itti_sgsap_alert_request_t* const sgsap_alert_req_pP, uint64_t imsi64) {
   int rc                                     = RETURNerror;
   MessageDef* message_p                      = NULL;

--- a/lte/gateway/c/core/oai/tasks/mme_app/mme_app_sgs_associated.c
+++ b/lte/gateway/c/core/oai/tasks/mme_app/mme_app_sgs_associated.c
@@ -64,7 +64,7 @@
  **          Return:    RETURNok, RETURNerror                              **
  **                                                                        **
  ***************************************************************************/
-int sgs_associated_handler(const sgs_fsm_t* evt) {
+status_code_e sgs_associated_handler(const sgs_fsm_t* evt) {
   int rc = RETURNerror;
   OAILOG_FUNC_IN(LOG_MME_APP);
 

--- a/lte/gateway/c/core/oai/tasks/mme_app/mme_app_sgs_detach.c
+++ b/lte/gateway/c/core/oai/tasks/mme_app/mme_app_sgs_detach.c
@@ -146,7 +146,7 @@ static void mme_app_send_sgs_eps_detach_indication(
 }
 
 // handle the SGS EPS detach timer expiry
-int mme_app_handle_sgs_eps_detach_timer_expiry(
+status_code_e mme_app_handle_sgs_eps_detach_timer_expiry(
     zloop_t* loop, int timer_id, void* args) {
   OAILOG_FUNC_IN(LOG_MME_APP);
   mme_ue_s1ap_id_t mme_ue_s1ap_id = 0;
@@ -206,7 +206,7 @@ int mme_app_handle_sgs_eps_detach_timer_expiry(
 }
 
 // handle the SGS Implicit EPS detach timer expiry
-int mme_app_handle_sgs_implicit_eps_detach_timer_expiry(
+status_code_e mme_app_handle_sgs_implicit_eps_detach_timer_expiry(
     zloop_t* loop, int timer_id, void* args) {
   OAILOG_FUNC_IN(LOG_MME_APP);
   mme_ue_s1ap_id_t mme_ue_s1ap_id = 0;
@@ -347,7 +347,7 @@ void mme_app_send_sgs_imsi_detach_indication(
 }
 
 /* handle the SGS IMSI detach timer expiry. */
-int mme_app_handle_sgs_imsi_detach_timer_expiry(
+status_code_e mme_app_handle_sgs_imsi_detach_timer_expiry(
     zloop_t* loop, int timer_id, void* args) {
   OAILOG_FUNC_IN(LOG_MME_APP);
   mme_ue_s1ap_id_t mme_ue_s1ap_id = 0;
@@ -430,7 +430,7 @@ int mme_app_handle_sgs_imsi_detach_timer_expiry(
 }
 
 /* handle the SGS Implicit IMSI detach timer expiry. */
-int mme_app_handle_sgs_implicit_imsi_detach_timer_expiry(
+status_code_e mme_app_handle_sgs_implicit_imsi_detach_timer_expiry(
     zloop_t* loop, int timer_id, void* args) {
   OAILOG_FUNC_IN(LOG_MME_APP);
   mme_ue_s1ap_id_t mme_ue_s1ap_id = 0;
@@ -569,7 +569,7 @@ void mme_app_handle_sgs_detach_req(
   OAILOG_FUNC_OUT(LOG_MME_APP);
 }
 
-int mme_app_handle_sgs_eps_detach_ack(
+status_code_e mme_app_handle_sgs_eps_detach_ack(
     mme_app_desc_t* mme_app_desc_p,
     const itti_sgsap_eps_detach_ack_t* const eps_detach_ack_p) {
   imsi64_t imsi64                      = INVALID_IMSI64;
@@ -623,7 +623,7 @@ int mme_app_handle_sgs_eps_detach_ack(
   OAILOG_FUNC_RETURN(LOG_MME_APP, RETURNok);
 }
 
-int mme_app_handle_sgs_imsi_detach_ack(
+status_code_e mme_app_handle_sgs_imsi_detach_ack(
     mme_app_desc_t* mme_app_desc_p,
     const itti_sgsap_imsi_detach_ack_t* const imsi_detach_ack_p) {
   imsi64_t imsi64                      = INVALID_IMSI64;

--- a/lte/gateway/c/core/oai/tasks/mme_app/mme_app_sgs_fsm.c
+++ b/lte/gateway/c/core/oai/tasks/mme_app/mme_app_sgs_fsm.c
@@ -75,9 +75,9 @@ static const char* sgs_fsm_state_str[SGS_STATE_MAX] = {
 /* Type of the SGS state machine handler */
 typedef int (*sgs_fsm_handler_t)(const sgs_fsm_t*);
 
-int sgs_null_handler(const sgs_fsm_t*);
-int sgs_la_update_requested_handler(const sgs_fsm_t*);
-int sgs_associated_handler(const sgs_fsm_t*);
+status_code_e sgs_null_handler(const sgs_fsm_t*);
+status_code_e sgs_la_update_requested_handler(const sgs_fsm_t*);
+status_code_e sgs_associated_handler(const sgs_fsm_t*);
 
 /* SGS state machine handlers */
 static const sgs_fsm_handler_t sgs_fsm_handlers[SGS_STATE_MAX] = {
@@ -121,7 +121,7 @@ void sgs_fsm_initialize(void) {
  **      Return:    RETURNok, RETURNerror                                  **
  **                                                                        **
  ***************************************************************************/
-int sgs_fsm_process(const sgs_fsm_t* sgs_evt) {
+status_code_e sgs_fsm_process(const sgs_fsm_t* sgs_evt) {
   int rc = RETURNerror;
   sgs_fsm_state_t state;
   sgs_primitive_t primitive;
@@ -165,7 +165,7 @@ int sgs_fsm_process(const sgs_fsm_t* sgs_evt) {
  **      Others:    _sgs_fsm_state                            **
  **                                                                        **
  ***************************************************************************/
-int sgs_fsm_set_status(
+status_code_e sgs_fsm_set_status(
     mme_ue_s1ap_id_t ue_id, void* ctx, sgs_fsm_state_t state) {
   OAILOG_FUNC_IN(LOG_MME_APP);
   sgs_context_t* sgs_ctx = (sgs_context_t*) ctx;

--- a/lte/gateway/c/core/oai/tasks/mme_app/mme_app_sgs_fsm.h
+++ b/lte/gateway/c/core/oai/tasks/mme_app/mme_app_sgs_fsm.h
@@ -35,6 +35,7 @@ Description Defines the SGS State Machine handling
 #ifndef FILE_SGS_FSM_SEEN
 #define FILE_SGS_FSM_SEEN
 
+#include "common_defs.h"
 #include "common_types.h"
 #include "sgs_messages_types.h"
 #include "3gpp_36.401.h"
@@ -83,12 +84,11 @@ typedef struct {
 /******************  E X P O R T E D    F U N C T I O N S  ******************/
 /****************************************************************************/
 
-int sgs_fsm_process(const sgs_fsm_t* sgs_evt);
-int sgs_fsm_set_status(
+status_code_e sgs_fsm_process(const sgs_fsm_t* sgs_evt);
+status_code_e sgs_fsm_set_status(
     mme_ue_s1ap_id_t ue_id, void* ctx, sgs_fsm_state_t state);
 void sgs_fsm_initialize(void);
 sgs_fsm_state_t sgs_fsm_get_status(mme_ue_s1ap_id_t ueid, void* ctx);
-int sgs_fsm_process(const sgs_fsm_t* sgs_evt);
 
 int sgs_fsm_null_loc_updt_acc(const sgs_fsm_t* fsm_evt);
 int sgs_fsm_null_loc_updt_rej(const sgs_fsm_t* fsm_evt);

--- a/lte/gateway/c/core/oai/tasks/mme_app/mme_app_sgs_la_updated.c
+++ b/lte/gateway/c/core/oai/tasks/mme_app/mme_app_sgs_la_updated.c
@@ -64,7 +64,7 @@
  **          Return:    RETURNok, RETURNerror                              **
  **                                                                        **
  ***************************************************************************/
-int sgs_la_update_requested_handler(const sgs_fsm_t* evt) {
+status_code_e sgs_la_update_requested_handler(const sgs_fsm_t* evt) {
   OAILOG_FUNC_IN(LOG_MME_APP);
   int rc = RETURNerror;
 

--- a/lte/gateway/c/core/oai/tasks/mme_app/mme_app_sgs_null.c
+++ b/lte/gateway/c/core/oai/tasks/mme_app/mme_app_sgs_null.c
@@ -63,7 +63,7 @@
  **          Return:    RETURNok, RETURNerror                              **
  **                                                                        **
  ***************************************************************************/
-int sgs_null_handler(const sgs_fsm_t* evt) {
+status_code_e sgs_null_handler(const sgs_fsm_t* evt) {
   int rc = RETURNerror;
   OAILOG_FUNC_IN(LOG_MME_APP);
 

--- a/lte/gateway/c/core/oai/tasks/mme_app/mme_app_sgs_paging.c
+++ b/lte/gateway/c/core/oai/tasks/mme_app/mme_app_sgs_paging.c
@@ -84,7 +84,7 @@ static int sgs_handle_paging_request_for_mt_sms_in_idle(
  **          Return:    RETURNok, RETURNerror                               **
  **                                                                         **
  ******************************************************************************/
-int sgs_handle_associated_paging_request(const sgs_fsm_t* evt) {
+status_code_e sgs_handle_associated_paging_request(const sgs_fsm_t* evt) {
   int rc                                           = RETURNerror;
   itti_sgsap_paging_request_t* sgsap_paging_req_pP = NULL;
 
@@ -121,7 +121,8 @@ int sgs_handle_associated_paging_request(const sgs_fsm_t* evt) {
  **          Return:    RETURNok, RETURNerror                               **
  **                                                                         **
  ******************************************************************************/
-static int sgs_handle_paging_request_for_mt_sms(const sgs_fsm_t* evt) {
+static status_code_e sgs_handle_paging_request_for_mt_sms(
+    const sgs_fsm_t* evt) {
   int rc                                           = RETURNerror;
   ue_mm_context_t* ue_context_p                    = NULL;
   sgs_context_t* sgs_context                       = NULL;
@@ -187,7 +188,8 @@ static int sgs_handle_paging_request_for_mt_sms(const sgs_fsm_t* evt) {
  **          Return:    RETURNok, RETURNerror                                **
  **                                                                          **
  *******************************************************************************/
-static int sgs_handle_paging_request_for_mt_call(const sgs_fsm_t* evt) {
+static status_code_e sgs_handle_paging_request_for_mt_call(
+    const sgs_fsm_t* evt) {
   int rc                                           = RETURNerror;
   ue_mm_context_t* ue_context_p                    = NULL;
   sgs_context_t* sgs_context                       = NULL;
@@ -273,7 +275,7 @@ static int sgs_handle_paging_request_for_mt_call(const sgs_fsm_t* evt) {
  **                                                                         **
  ******************************************************************************/
 
-static int sgs_handle_paging_request_for_mt_call_in_connected(
+static status_code_e sgs_handle_paging_request_for_mt_call_in_connected(
     ue_mm_context_t* ue_context_p,
     itti_sgsap_paging_request_t* const sgsap_paging_req_pP) {
   int rc            = RETURNerror;
@@ -340,7 +342,7 @@ static int sgs_handle_paging_request_for_mt_call_in_connected(
  **          Return:    RETURNok, RETURNerror                               **
  **                                                                         **
  ******************************************************************************/
-static int sgs_handle_paging_request_for_mt_sms_in_connected(
+static status_code_e sgs_handle_paging_request_for_mt_sms_in_connected(
     ue_mm_context_t* ue_context_p,
     itti_sgsap_paging_request_t* const sgsap_paging_req_pP) {
   int rc = RETURNerror;
@@ -391,7 +393,7 @@ static int sgs_handle_paging_request_for_mt_sms_in_connected(
  ** **
  ***********************************************************************************/
 
-static int sgs_handle_paging_request_for_mt_call_in_idle(
+static status_code_e sgs_handle_paging_request_for_mt_call_in_idle(
     ue_mm_context_t* ue_context_p,
     itti_sgsap_paging_request_t* const sgsap_paging_req_pP)
 
@@ -476,7 +478,7 @@ static int sgs_handle_paging_request_for_mt_call_in_idle(
  ** **
  ***********************************************************************************/
 
-static int sgs_handle_paging_request_for_mt_sms_in_idle(
+static status_code_e sgs_handle_paging_request_for_mt_sms_in_idle(
     ue_mm_context_t* ue_context_p,
     itti_sgsap_paging_request_t* const sgsap_paging_req_pP)
 
@@ -562,7 +564,7 @@ static int sgs_handle_paging_request_for_mt_sms_in_idle(
  ** **
  ***********************************************************************************/
 
-int mme_app_send_sgsap_service_request(
+status_code_e mme_app_send_sgsap_service_request(
     uint8_t service_indicator, struct ue_mm_context_s* ue_context_p) {
   int rc                                             = RETURNerror;
   MessageDef* message_p                              = NULL;
@@ -629,7 +631,7 @@ int mme_app_send_sgsap_service_request(
  **          Return:    RETURNok, RETURNerror                               **
  **
  ******************************************************************************/
-int mme_app_send_sgsap_paging_reject(
+status_code_e mme_app_send_sgsap_paging_reject(
     struct ue_mm_context_s* ue_context_p, imsi64_t imsi, uint8_t imsi_len,
     SgsCause_t sgs_cause) {
   int rc                                             = RETURNerror;
@@ -683,7 +685,7 @@ int mme_app_send_sgsap_paging_reject(
  **
  ***********************************************************************************/
 
-int sgs_handle_null_paging_request(const sgs_fsm_t* evt) {
+status_code_e sgs_handle_null_paging_request(const sgs_fsm_t* evt) {
   int rc                                           = RETURNerror;
   struct ue_mm_context_s* ue_context_p             = NULL;
   itti_sgsap_paging_request_t* sgsap_paging_req_pP = NULL;
@@ -735,7 +737,7 @@ int sgs_handle_null_paging_request(const sgs_fsm_t* evt) {
  **
  ***********************************************************************************/
 
-static int mme_app_send_sgsap_ue_unreachable(
+static status_code_e mme_app_send_sgsap_ue_unreachable(
     struct ue_mm_context_s* ue_context_p, SgsCause_t sgs_cause) {
   int rc                                               = RETURNerror;
   MessageDef* message_p                                = NULL;
@@ -787,7 +789,7 @@ static int mme_app_send_sgsap_ue_unreachable(
  **          Return:    RETURNok, RETURNerror **
  **
  ***********************************************************************************/
-static int sgsap_handle_paging_request_without_lai(
+static status_code_e sgsap_handle_paging_request_without_lai(
     ue_mm_context_t* ue_context_p,
     itti_sgsap_paging_request_t* const sgsap_paging_req_pP) {
   int rc                     = RETURNok;
@@ -864,7 +866,7 @@ static int sgsap_handle_paging_request_without_lai(
  **      Return:    RETURNok, RETURNerror                                  **
  **                                                                        **
  ***************************************************************************/
-int mme_app_handle_sgsap_paging_request(
+status_code_e mme_app_handle_sgsap_paging_request(
     mme_app_desc_t* mme_app_desc_p,
     itti_sgsap_paging_request_t* const sgsap_paging_req_pP) {
   struct ue_mm_context_s* ue_context_p = NULL;

--- a/lte/gateway/c/core/oai/tasks/mme_app/mme_app_sgs_reset.c
+++ b/lte/gateway/c/core/oai/tasks/mme_app/mme_app_sgs_reset.c
@@ -61,7 +61,7 @@
  **          Return:    RETURNok, RETURNerror                              **
  **                                                                        **
  ***************************************************************************/
-int mme_app_handle_sgsap_reset_indication(
+status_code_e mme_app_handle_sgsap_reset_indication(
     itti_sgsap_vlr_reset_indication_t* const reset_indication_pP) {
   int rc = RETURNerror;
   OAILOG_FUNC_IN(LOG_MME_APP);
@@ -93,7 +93,7 @@ int mme_app_handle_sgsap_reset_indication(
  **          Return:    RETURNok, RETURNerror                              **
  **                                                                        **
  ***************************************************************************/
-bool mme_app_handle_reset_indication(
+status_code_e mme_app_handle_reset_indication(
     const hash_key_t keyP, void* const ue_context_pP, void* unused_param_pP,
     void** unused_result_pP) {
   int rc = RETURNerror;
@@ -147,7 +147,7 @@ bool mme_app_handle_reset_indication(
  **          Return:    RETURNok, RETURNerror                              **
  **                                                                        **
  ***************************************************************************/
-int sgs_fsm_associated_reset_indication(const sgs_fsm_t* fsm_evt) {
+status_code_e sgs_fsm_associated_reset_indication(const sgs_fsm_t* fsm_evt) {
   OAILOG_FUNC_IN(LOG_MME_APP);
   if (fsm_evt == NULL) {
     OAILOG_ERROR(LOG_MME_APP, "Invalid SGS FSM Event object received\n");

--- a/lte/gateway/c/core/oai/tasks/mme_app/mme_app_sgs_status.c
+++ b/lte/gateway/c/core/oai/tasks/mme_app/mme_app_sgs_status.c
@@ -61,7 +61,7 @@ static void mme_app_handle_sgs_status_for_loc_upd_req(
  **                                                                        **
  ***************************************************************************/
 
-int mme_app_handle_sgs_status_message(
+status_code_e mme_app_handle_sgs_status_message(
     mme_app_desc_t* mme_app_desc_p,
     itti_sgsap_status_t* const sgsap_status_pP) {
   struct ue_mm_context_s* ue_context_p = NULL;

--- a/lte/gateway/c/core/oai/tasks/mme_app/mme_app_sgsap.c
+++ b/lte/gateway/c/core/oai/tasks/mme_app/mme_app_sgsap.c
@@ -55,7 +55,7 @@
  **      Return:    RETURNok, RETURNerror                                  **
  **                                                                        **
  ***************************************************************************/
-int mme_app_handle_sgsap_paging_request(
+status_code_e mme_app_handle_sgsap_paging_request(
     mme_app_desc_t* mme_app_desc_p,
     itti_sgsap_paging_request_t* const sgsap_paging_req_pP) {
   struct ue_mm_context_s* ue_context_p = NULL;

--- a/lte/gateway/c/core/oai/tasks/mme_app/mme_app_sgsap_location_update.c
+++ b/lte/gateway/c/core/oai/tasks/mme_app/mme_app_sgsap_location_update.c
@@ -278,7 +278,7 @@ static int build_sgs_status(
  ** Outputs:                                                                   *
  **      Return:    RETURNok, RETURNerror                                      *
  *******************************************************************************/
-static int handle_cs_domain_loc_updt_acc(
+static status_code_e handle_cs_domain_loc_updt_acc(
     itti_sgsap_location_update_acc_t* const itti_sgsap_location_update_acc,
     struct ue_mm_context_s* ue_context_p) {
   OAILOG_FUNC_IN(LOG_MME_APP);
@@ -366,7 +366,7 @@ static int handle_cs_domain_loc_updt_acc(
  **                      Type of message:Attach Request or TAU Request      **
  **                                                                         **
  ******************************************************************************/
-int mme_app_handle_nas_cs_domain_location_update_req(
+status_code_e mme_app_handle_nas_cs_domain_location_update_req(
     ue_mm_context_t* ue_context_p, uint8_t msg_type) {
   OAILOG_FUNC_IN(LOG_MME_APP);
   OAILOG_INFO(
@@ -429,7 +429,8 @@ int mme_app_handle_nas_cs_domain_location_update_req(
  ** Inputs: **
  **
  ***********************************************************************************/
-int send_itti_sgsap_location_update_req(ue_mm_context_t* ue_context_p) {
+status_code_e send_itti_sgsap_location_update_req(
+    ue_mm_context_t* ue_context_p) {
   OAILOG_FUNC_IN(LOG_MME_APP);
 
   MessageDef* message_p = NULL;
@@ -559,7 +560,7 @@ int send_itti_sgsap_location_update_req(ue_mm_context_t* ue_context_p) {
  ** Inputs:              nas_sgs_location_update_acc                        **
  **
  ******************************************************************************/
-int mme_app_handle_sgsap_location_update_acc(
+status_code_e mme_app_handle_sgsap_location_update_acc(
     mme_app_desc_t* mme_app_desc_p,
     itti_sgsap_location_update_acc_t* const itti_sgsap_location_update_acc) {
   imsi64_t imsi64                      = INVALID_IMSI64;
@@ -610,7 +611,7 @@ int mme_app_handle_sgsap_location_update_acc(
  ** Inputs:              nas_sgs_location_update_rej                         **
  **
  *******************************************************************************/
-int mme_app_handle_sgsap_location_update_rej(
+status_code_e mme_app_handle_sgsap_location_update_rej(
     mme_app_desc_t* mme_app_desc_p,
     itti_sgsap_location_update_rej_t* const itti_sgsap_location_update_rej) {
   imsi64_t imsi64                      = INVALID_IMSI64;
@@ -664,7 +665,7 @@ int mme_app_handle_sgsap_location_update_rej(
  ** Inputs:              sgs_fsm_t                                           **
  **                                                                          **
  *******************************************************************************/
-int sgs_fsm_null_loc_updt_acc(const sgs_fsm_t* fsm_evt) {
+status_code_e sgs_fsm_null_loc_updt_acc(const sgs_fsm_t* fsm_evt) {
   int rc                                                             = RETURNok;
   itti_sgsap_location_update_acc_t* itti_sgsap_location_update_acc_p = NULL;
   MobileIdentity_t* mobileid                                         = NULL;
@@ -731,7 +732,7 @@ int sgs_fsm_null_loc_updt_acc(const sgs_fsm_t* fsm_evt) {
  ** Inputs:              sgs_fsm_t **
  ** **
  ***********************************************************************************/
-int sgs_fsm_associated_loc_updt_acc(const sgs_fsm_t* fsm_evt) {
+status_code_e sgs_fsm_associated_loc_updt_acc(const sgs_fsm_t* fsm_evt) {
   int rc = RETURNok;
 
   OAILOG_FUNC_IN(LOG_MME_APP);
@@ -769,7 +770,7 @@ int sgs_fsm_associated_loc_updt_acc(const sgs_fsm_t* fsm_evt) {
  ** Inputs:              sgs_fsm_t                                           **
  **                                                                          **
  *******************************************************************************/
-int sgs_fsm_la_updt_req_loc_updt_acc(const sgs_fsm_t* fsm_evt) {
+status_code_e sgs_fsm_la_updt_req_loc_updt_acc(const sgs_fsm_t* fsm_evt) {
   int rc                                                             = RETURNok;
   itti_sgsap_location_update_acc_t* itti_sgsap_location_update_acc_p = NULL;
   struct ue_mm_context_s* ue_context_p                               = NULL;
@@ -855,7 +856,7 @@ int sgs_fsm_la_updt_req_loc_updt_acc(const sgs_fsm_t* fsm_evt) {
  ** Inputs:              sgs_fsm_t **
  ** **
  ***********************************************************************************/
-int sgs_fsm_null_loc_updt_rej(const sgs_fsm_t* fsm_evt) {
+status_code_e sgs_fsm_null_loc_updt_rej(const sgs_fsm_t* fsm_evt) {
   int rc = RETURNok;
   OAILOG_FUNC_IN(LOG_MME_APP);
   OAILOG_ERROR(
@@ -875,7 +876,7 @@ int sgs_fsm_null_loc_updt_rej(const sgs_fsm_t* fsm_evt) {
  ** Inputs:              sgs_fsm_t **
  ** **
  *****************************************************************************************/
-int sgs_fsm_la_updt_req_loc_updt_rej(const sgs_fsm_t* fsm_evt) {
+status_code_e sgs_fsm_la_updt_req_loc_updt_rej(const sgs_fsm_t* fsm_evt) {
   int rc                                                             = RETURNok;
   struct ue_mm_context_s* ue_context_p                               = NULL;
   itti_sgsap_location_update_rej_t* itti_sgsap_location_update_rej_p = NULL;
@@ -928,7 +929,8 @@ int sgs_fsm_la_updt_req_loc_updt_rej(const sgs_fsm_t* fsm_evt) {
  ** Inputs:              ue_mm_context_s **
  ** **
  ***********************************************************************************/
-int mme_app_handle_ts6_1_timer_expiry(zloop_t* loop, int timer_id, void* args) {
+status_code_e mme_app_handle_ts6_1_timer_expiry(
+    zloop_t* loop, int timer_id, void* args) {
   OAILOG_FUNC_IN(LOG_MME_APP);
   mme_ue_s1ap_id_t mme_ue_s1ap_id = 0;
   if (!mme_app_get_timer_arg(timer_id, &mme_ue_s1ap_id)) {
@@ -973,7 +975,7 @@ int mme_app_handle_ts6_1_timer_expiry(zloop_t* loop, int timer_id, void* args) {
  ** Inputs:              sgs_fsm_t **
  ** **
  ***********************************************************************************/
-int sgs_fsm_associated_loc_updt_rej(const sgs_fsm_t* fsm_evt) {
+status_code_e sgs_fsm_associated_loc_updt_rej(const sgs_fsm_t* fsm_evt) {
   int rc                                                             = RETURNok;
   struct ue_mm_context_s* ue_context_p                               = NULL;
   itti_sgsap_location_update_rej_t* itti_sgsap_location_update_rej_p = NULL;
@@ -1011,7 +1013,7 @@ int sgs_fsm_associated_loc_updt_rej(const sgs_fsm_t* fsm_evt) {
  **                      RETURNerror: On failure                              **
  **                                                                           **
  ********************************************************************************/
-int mme_app_create_sgs_context(ue_mm_context_t* ue_context_p) {
+status_code_e mme_app_create_sgs_context(ue_mm_context_t* ue_context_p) {
   OAILOG_FUNC_IN(LOG_MME_APP);
   if (ue_context_p == NULL) {
     OAILOG_ERROR(LOG_MME_APP, "Invalid UE context \n");

--- a/lte/gateway/c/core/oai/tasks/mme_app/mme_app_sgsap_service_abort.c
+++ b/lte/gateway/c/core/oai/tasks/mme_app/mme_app_sgsap_service_abort.c
@@ -42,7 +42,7 @@
  **                      Abort Request message **
  ** Outputs:             Return:    RETURNok, RETURNerror **
  ***********************************************************************************/
-int mme_app_handle_sgsap_service_abort_request(
+status_code_e mme_app_handle_sgsap_service_abort_request(
     mme_app_desc_t* mme_app_desc_p,
     itti_sgsap_service_abort_req_t* const itti_sgsap_service_abort_req_p) {
   imsi64_t imsi64                      = INVALID_IMSI64;
@@ -105,7 +105,8 @@ int mme_app_handle_sgsap_service_abort_request(
  ** Inputs:              sgs_fsm_t **
  ** Outputs:             Return:    RETURNok, RETURNerror **
  ***********************************************************************************/
-int sgs_fsm_associated_service_abort_request(const sgs_fsm_t* fsm_evt) {
+status_code_e sgs_fsm_associated_service_abort_request(
+    const sgs_fsm_t* fsm_evt) {
   OAILOG_FUNC_IN(LOG_MME_APP);
   sgs_context_t* sgs_context = (sgs_context_t*) fsm_evt->ctx;
 
@@ -140,7 +141,7 @@ int sgs_fsm_associated_service_abort_request(const sgs_fsm_t* fsm_evt) {
  ** Inputs:              sgs_fsm_t **
  ** Outputs:             Return:    RETURNok, RETURNerror **
  ***********************************************************************************/
-int sgs_fsm_null_service_abort_request(const sgs_fsm_t* fsm_evt) {
+status_code_e sgs_fsm_null_service_abort_request(const sgs_fsm_t* fsm_evt) {
   OAILOG_FUNC_IN(LOG_MME_APP);
   OAILOG_ERROR(
       LOG_MME_APP,
@@ -159,7 +160,8 @@ int sgs_fsm_null_service_abort_request(const sgs_fsm_t* fsm_evt) {
  ** Inputs:              sgs_fsm_t **
  ** Outputs:             Return:    RETURNok, RETURNerror **
 ***********************************************************************************/
-int sgs_fsm_la_update_req_service_abort_request(const sgs_fsm_t* fsm_evt) {
+status_code_e sgs_fsm_la_update_req_service_abort_request(
+    const sgs_fsm_t* fsm_evt) {
   OAILOG_FUNC_IN(LOG_MME_APP);
   OAILOG_ERROR(
       LOG_MME_APP,

--- a/lte/gateway/c/core/oai/tasks/mme_app/mme_app_transport.c
+++ b/lte/gateway/c/core/oai/tasks/mme_app/mme_app_transport.c
@@ -42,7 +42,7 @@
 #include "sgs_messages_types.h"
 
 //------------------------------------------------------------------------------
-int mme_app_handle_nas_dl_req(
+status_code_e mme_app_handle_nas_dl_req(
     const mme_ue_s1ap_id_t ue_id, bstring nas_msg,
     nas_error_code_t transaction_status)
 //------------------------------------------------------------------------------

--- a/lte/gateway/c/core/oai/tasks/nas/MMEprocess.c
+++ b/lte/gateway/c/core/oai/tasks/nas/MMEprocess.c
@@ -69,7 +69,7 @@ static void _nas_clean(int net_fd);
 /****************************************************************************/
 
 /****************************************************************************/
-int main(int argc, const char* argv[]) {
+status_code_e main(int argc, const char* argv[]) {
   /*
    * Get the command line options
    */

--- a/lte/gateway/c/core/oai/tasks/nas/api/mme/mme_api.c
+++ b/lte/gateway/c/core/oai/tasks/nas/api/mme/mme_api.c
@@ -99,7 +99,7 @@ static int copy_plmn_from_config(
  **      Others:    None                                       **
  **                                                                        **
  ***************************************************************************/
-int mme_api_get_emm_config(
+status_code_e mme_api_get_emm_config(
     mme_api_emm_config_t* config, const struct mme_config_s* mme_config_p) {
   OAILOG_FUNC_IN(LOG_NAS);
   if (mme_config_p->served_tai.nb_tai < 1) {
@@ -306,7 +306,7 @@ int mme_api_get_emm_config(
  **      Others:    None                                       **
  **                                                                        **
  ***************************************************************************/
-int mme_api_get_esm_config(mme_api_esm_config_t* config) {
+status_code_e mme_api_get_esm_config(mme_api_esm_config_t* config) {
   OAILOG_FUNC_IN(LOG_NAS);
   if (strcmp((const char*) mme_config.non_eps_service_control->data, "SMS") ==
       0) {
@@ -338,7 +338,7 @@ int mme_api_get_esm_config(mme_api_esm_config_t* config) {
  *  Return:    RETURNok, RETURNerror
  *
  */
-int mme_api_notify_imsi(const mme_ue_s1ap_id_t id, imsi64_t imsi64) {
+status_code_e mme_api_notify_imsi(const mme_ue_s1ap_id_t id, imsi64_t imsi64) {
   mme_app_desc_t* mme_app_desc_p = get_mme_nas_state(false);
   ue_mm_context_t* ue_mm_context = NULL;
 
@@ -368,7 +368,8 @@ int mme_api_notify_imsi(const mme_ue_s1ap_id_t id, imsi64_t imsi64) {
  *  Return:    RETURNok, RETURNerror
  *
  */
-int mme_api_notify_new_guti(const mme_ue_s1ap_id_t id, guti_t* const guti) {
+status_code_e mme_api_notify_new_guti(
+    const mme_ue_s1ap_id_t id, guti_t* const guti) {
   ue_mm_context_t* ue_mm_context = NULL;
   mme_app_desc_t* mme_app_desc_p = get_mme_nas_state(false);
   OAILOG_FUNC_IN(LOG_NAS);
@@ -405,7 +406,7 @@ int mme_api_notify_new_guti(const mme_ue_s1ap_id_t id, guti_t* const guti) {
  **      Others:    None                                               **
  **                                                                    **
  ***********************************************************************/
-int mme_api_new_guti(
+status_code_e mme_api_new_guti(
     const imsi_t* const imsi, const guti_t* const old_guti, guti_t* const guti,
     const tai_t* const originating_tai, tai_list_t* const tai_list) {
   OAILOG_FUNC_IN(LOG_NAS);
@@ -592,7 +593,7 @@ int mme_api_new_guti(
  **                  Others:    None                                       **
  **                                                                        **
  ***************************************************************************/
-int mme_api_subscribe(
+status_code_e mme_api_subscribe(
     bstring* apn, mme_api_ip_version_t mme_pdn_index, bstring* pdn_addr,
     int is_emergency, mme_api_qos_t* qos) {
   int rc = RETURNok;
@@ -617,7 +618,7 @@ int mme_api_subscribe(
  **                  Others:    None                                       **
  **                                                                        **
  ***************************************************************************/
-int mme_api_unsubscribe(bstring apn) {
+status_code_e mme_api_unsubscribe(bstring apn) {
   OAILOG_FUNC_IN(LOG_NAS);
   int rc = RETURNok;
 

--- a/lte/gateway/c/core/oai/tasks/nas/api/mme/mme_api.h
+++ b/lte/gateway/c/core/oai/tasks/nas/api/mme/mme_api.h
@@ -41,6 +41,7 @@ Description Implements the API used by the NAS layer running in the MME
 #include "TrackingAreaIdentity.h"
 #include "TrackingAreaIdentityList.h"
 #include "3gpp_23.003.h"
+#include "common_defs.h"
 #include "common_types.h"
 #include "3gpp_36.401.h"
 #include "bstrlib.h"
@@ -137,7 +138,7 @@ typedef struct mme_api_qos_s {
 /****************************************************************************/
 struct mme_config_s;
 
-int mme_api_get_emm_config(
+status_code_e mme_api_get_emm_config(
     mme_api_emm_config_t* config, const struct mme_config_s* mme_config_p);
 
 #define REMOVE_OLD_CONTEXT true
@@ -146,20 +147,22 @@ void mme_api_duplicate_enb_ue_s1ap_id_detected(
     const enb_s1ap_id_key_t enb_ue_s1ap_id,
     const mme_ue_s1ap_id_t mme_ue_s1ap_id, const bool is_remove_old);
 
-int mme_api_get_esm_config(mme_api_esm_config_t* config);
+status_code_e mme_api_get_esm_config(mme_api_esm_config_t* config);
 
-int mme_api_notify_imsi(const mme_ue_s1ap_id_t id, const imsi64_t imsi64);
+status_code_e mme_api_notify_imsi(
+    const mme_ue_s1ap_id_t id, const imsi64_t imsi64);
 
-int mme_api_notify_new_guti(const mme_ue_s1ap_id_t ueid, guti_t* const guti);
+status_code_e mme_api_notify_new_guti(
+    const mme_ue_s1ap_id_t ueid, guti_t* const guti);
 
-int mme_api_new_guti(
+status_code_e mme_api_new_guti(
     const imsi_t* const imsi, const guti_t* const old_guti, guti_t* const guti,
     const tai_t* const originating_tai, tai_list_t* const tai_list);
 
-int mme_api_subscribe(
+status_code_e mme_api_subscribe(
     bstring* apn, mme_api_ip_version_t mme_pdn_index, bstring* pdn_addr,
     int is_emergency, mme_api_qos_t* qos);
-int mme_api_unsubscribe(bstring apn);
+status_code_e mme_api_unsubscribe(bstring apn);
 
 void mme_ue_context_update_ue_emm_state(
     mme_ue_s1ap_id_t mme_ue_s1ap_id, mm_state_t new_emm_state);

--- a/lte/gateway/c/core/oai/tasks/nas/api/network/as_message.c
+++ b/lte/gateway/c/core/oai/tasks/nas/api/network/as_message.c
@@ -77,7 +77,8 @@
  **    Others:  None                                       **
  **                                                                        **
  ***************************************************************************/
-int as_message_decode(const char* buffer, as_message_t* msg, size_t length) {
+status_code_e as_message_decode(
+    const char* buffer, as_message_t* msg, size_t length) {
   OAILOG_FUNC_IN(LOG_NAS);
   int bytes;
   uint8_t** data = NULL;

--- a/lte/gateway/c/core/oai/tasks/nas/api/network/nas_message.c
+++ b/lte/gateway/c/core/oai/tasks/nas/api/network/nas_message.c
@@ -109,7 +109,7 @@ static uint32_t nas_message_get_mac(
  * has been successfully encrypted; Negative error code otherwise. Others:  None
  *
  */
-int nas_message_encrypt(
+status_code_e nas_message_encrypt(
     const unsigned char* inbuf, unsigned char* outbuf,
     const nas_message_security_header_t* header, size_t length,
     void* security) {
@@ -233,7 +233,7 @@ int nas_message_encrypt(
  **    Others:  None                                       **
  **                                                                        **
  ***************************************************************************/
-int nas_message_decrypt(
+status_code_e nas_message_decrypt(
     const unsigned char* const inbuf, unsigned char* const outbuf,
     nas_message_security_header_t* header, size_t length, void* security,
     nas_message_decode_status_t* status) {
@@ -332,7 +332,7 @@ int nas_message_decrypt(
        Others:  Return the computed mac if security context is established
 
 */
-int nas_message_decode(
+status_code_e nas_message_decode(
     const unsigned char* const buffer, nas_message_t* msg, size_t length,
     void* security, nas_message_decode_status_t* status) {
   OAILOG_FUNC_IN(LOG_NAS);
@@ -529,7 +529,7 @@ int nas_message_decode(
  **    Others:  None                                       **
  **                                                                        **
  ***************************************************************************/
-int nas_message_encode(
+status_code_e nas_message_encode(
     unsigned char* buffer, const nas_message_t* const msg, size_t length,
     void* security) {
   OAILOG_FUNC_IN(LOG_NAS);
@@ -674,7 +674,7 @@ int nas_message_encode(
  **    Others:  None                                       **
  **                                                                        **
  ***************************************************************************/
-int nas_message_header_decode(
+status_code_e nas_message_header_decode(
     const unsigned char* const buffer,
     nas_message_security_header_t* const header, const size_t length,
     nas_message_decode_status_t* const status, bool* const is_sr) {

--- a/lte/gateway/c/core/oai/tasks/nas/api/network/nas_message.h
+++ b/lte/gateway/c/core/oai/tasks/nas/api/network/nas_message.h
@@ -107,25 +107,25 @@ typedef struct nas_message_decode_status_s {
 /****************************************************************************/
 /******************  E X P O R T E D    F U N C T I O N S  ******************/
 /****************************************************************************/
-int nas_message_header_decode(
+status_code_e nas_message_header_decode(
     const unsigned char* const buffer,
     nas_message_security_header_t* const header, const size_t length,
     nas_message_decode_status_t* const status, bool* const is_sr);
 
-int nas_message_encrypt(
+status_code_e nas_message_encrypt(
     const unsigned char* inbuf, unsigned char* outbuf,
     const nas_message_security_header_t* header, size_t length, void* security);
 
-int nas_message_decrypt(
+status_code_e nas_message_decrypt(
     const unsigned char* const inbuf, unsigned char* const outbuf,
     nas_message_security_header_t* header, size_t length, void* security,
     nas_message_decode_status_t* status);
 
-int nas_message_decode(
+status_code_e nas_message_decode(
     const unsigned char* const buffer, nas_message_t* msg, size_t length,
     void* security, nas_message_decode_status_t* status);
 
-int nas_message_encode(
+status_code_e nas_message_encode(
     unsigned char* buffer, const nas_message_t* const msg, size_t length,
     void* security);
 

--- a/lte/gateway/c/core/oai/tasks/nas/api/network/network_api.c
+++ b/lte/gateway/c/core/oai/tasks/nas/api/network/network_api.c
@@ -127,7 +127,7 @@ static as_message_t _as_data = {}; /* Access Stratum message     */
  **      Others:  _network_api_id                            **
  **                                                                        **
  ***************************************************************************/
-int network_api_initialize(const char* host, const char* port) {
+status_code_e network_api_initialize(const char* host, const char* port) {
   OAILOG_FUNC_IN(LOG_NAS);
   /*
    * Initialize network socket handlers
@@ -174,7 +174,7 @@ int network_api_initialize(const char* host, const char* port) {
  **      Others:  None                                       **
  **                                                                        **
  ***************************************************************************/
-int network_api_get_fd(void) {
+status_code_e network_api_get_fd(void) {
   OAILOG_FUNC_IN(LOG_NAS);
   OAILOG_FUNC_RETURN(LOG_NAS, NETWORK_API_GETFD());
 }
@@ -214,7 +214,7 @@ const void* network_api_get_data(void) {
  **      Others:  _network_api_recv_buffer, _network_api_id  **
  **                                                                        **
  ***************************************************************************/
-int network_api_read_data(int fd) {
+status_code_e network_api_read_data(int fd) {
   OAILOG_FUNC_IN(LOG_NAS);
   int rbytes;
 
@@ -273,7 +273,7 @@ int network_api_read_data(int fd) {
  **      Others:  None                                       **
  **                                                                        **
  ***************************************************************************/
-int network_api_send_data(int fd, size_t length) {
+status_code_e network_api_send_data(int fd, size_t length) {
   OAILOG_FUNC_IN(LOG_NAS);
   int sbytes;
 
@@ -368,7 +368,7 @@ void network_api_close(int fd) {
  **      Others:  _as_data                                   **
  **                                                                        **
  ***************************************************************************/
-int network_api_decode_data(size_t length) {
+status_code_e network_api_decode_data(size_t length) {
   OAILOG_FUNC_IN(LOG_NAS);
   /*
    * Decode the Access Stratum message received from the network
@@ -398,7 +398,7 @@ int network_api_decode_data(size_t length) {
  **      Others:  _network_api_send_buffer                   **
  **                                                                        **
  ***************************************************************************/
-int network_api_encode_data(void* data) {
+status_code_e network_api_encode_data(void* data) {
   OAILOG_FUNC_IN(LOG_NAS);
   /*
    * Encode the Access Stratum  message
@@ -430,7 +430,7 @@ int network_api_encode_data(void* data) {
  **      Others:  _network_api_send_buffer                   **
  **                                                                        **
  ***************************************************************************/
-int as_message_send(as_message_t* as_msg) {
+status_code_e as_message_send(as_message_t* as_msg) {
   int bytes;
 
   OAILOG_FUNC_IN(LOG_NAS);

--- a/lte/gateway/c/core/oai/tasks/nas/api/network/network_api.h
+++ b/lte/gateway/c/core/oai/tasks/nas/api/network/network_api.h
@@ -52,16 +52,16 @@ Description Implements the API used by the NAS layer to send/receive
 /******************  E X P O R T E D    F U N C T I O N S  ******************/
 /****************************************************************************/
 
-int network_api_initialize(const char* host, const char* port);
+status_code_e network_api_initialize(const char* host, const char* port);
 
-int network_api_get_fd(void);
+status_code_e network_api_get_fd(void);
 const void* network_api_get_data(void);
 
-int network_api_read_data(int fd);
-int network_api_send_data(int fd, size_t length);
+status_code_e network_api_read_data(int fd);
+status_code_e network_api_send_data(int fd, size_t length);
 void network_api_close(int fd);
 
-int network_api_decode_data(size_t length);
-int network_api_encode_data(void* data);
+status_code_e network_api_decode_data(size_t length);
+status_code_e network_api_encode_data(void* data);
 
 #endif /* FILE_NETWORK_API_SEEN*/

--- a/lte/gateway/c/core/oai/tasks/nas/emm/Attach.c
+++ b/lte/gateway/c/core/oai/tasks/nas/emm/Attach.c
@@ -200,7 +200,7 @@ static void create_new_attach_info(
  *
  */
 //------------------------------------------------------------------------------
-int emm_proc_attach_request(
+status_code_e emm_proc_attach_request(
     mme_ue_s1ap_id_t ue_id, const bool is_mm_ctx_new,
     emm_attach_request_ies_t* const ies) {
   OAILOG_FUNC_IN(LOG_NAS_EMM);
@@ -642,7 +642,8 @@ int emm_proc_attach_request(
  *
  */
 //------------------------------------------------------------------------------
-int emm_proc_attach_reject(mme_ue_s1ap_id_t ue_id, emm_cause_t emm_cause) {
+status_code_e emm_proc_attach_reject(
+    mme_ue_s1ap_id_t ue_id, emm_cause_t emm_cause) {
   OAILOG_FUNC_IN(LOG_NAS_EMM);
   int rc = RETURNerror;
 
@@ -699,7 +700,7 @@ int emm_proc_attach_reject(mme_ue_s1ap_id_t ue_id, emm_cause_t emm_cause) {
  *
  */
 //------------------------------------------------------------------------------
-int emm_proc_attach_complete(
+status_code_e emm_proc_attach_complete(
     mme_ue_s1ap_id_t ue_id, const_bstring esm_msg_pP, int emm_cause,
     const nas_message_decode_status_t status) {
   OAILOG_FUNC_IN(LOG_NAS_EMM);
@@ -1032,7 +1033,7 @@ static int emm_attach_release(emm_context_t* emm_context) {
  *      Others:    None
  *
  */
-int _emm_attach_reject(
+status_code_e _emm_attach_reject(
     emm_context_t* emm_context, struct nas_base_proc_s* nas_base_proc) {
   OAILOG_FUNC_IN(LOG_NAS_EMM);
   int rc = RETURNerror;
@@ -1506,7 +1507,7 @@ static int emm_attach_failure_security_cb(emm_context_t* emm_context) {
  *
  */
 //------------------------------------------------------------------------------
-int emm_attach_security(struct emm_context_s* emm_context) {
+status_code_e emm_attach_security(struct emm_context_s* emm_context) {
   return emm_attach_security_a(emm_context);
 }
 
@@ -1752,7 +1753,7 @@ static void encode_csfb_parameters_attach_accept(
 }
 
 //------------------------------------------------------------------------------
-int emm_cn_wrapper_attach_accept(emm_context_t* emm_context) {
+status_code_e emm_cn_wrapper_attach_accept(emm_context_t* emm_context) {
   return emm_send_attach_accept(emm_context);
 }
 

--- a/lte/gateway/c/core/oai/tasks/nas/emm/Authentication.c
+++ b/lte/gateway/c/core/oai/tasks/nas/emm/Authentication.c
@@ -150,7 +150,7 @@ static void s6a_auth_info_rsp_timer_expiry_handler(
  **      Others:    None                                       **
  **                                                                        **
  ***************************************************************************/
-int emm_proc_authentication_ksi(
+status_code_e emm_proc_authentication_ksi(
     struct emm_context_s* emm_context,
     nas_emm_specific_proc_t* const emm_specific_proc, ksi_t ksi,
     const uint8_t* const rand, const uint8_t* const autn, success_cb_t success,
@@ -246,7 +246,7 @@ int emm_proc_authentication_ksi(
 }
 
 //------------------------------------------------------------------------------
-int emm_proc_authentication(
+status_code_e emm_proc_authentication(
     struct emm_context_s* emm_context,
     nas_emm_specific_proc_t* const emm_specific_proc, success_cb_t success,
     failure_cb_t failure) {
@@ -600,7 +600,7 @@ static int auth_info_proc_failure_cb(struct emm_context_s* emm_ctx) {
 }
 
 //------------------------------------------------------------------------------
-int emm_proc_authentication_failure(
+status_code_e emm_proc_authentication_failure(
     mme_ue_s1ap_id_t ue_id, int emm_cause, const_bstring auts) {
   OAILOG_FUNC_IN(LOG_NAS_EMM);
   // Get the UE context
@@ -862,7 +862,7 @@ int emm_proc_authentication_failure(
  **      Others:    _emm_data, T3460                                       **
  **                                                                        **
  ***************************************************************************/
-int emm_proc_authentication_complete(
+status_code_e emm_proc_authentication_complete(
     mme_ue_s1ap_id_t ue_id, authentication_response_msg* msg, int emm_cause,
     const_bstring const res) {
   OAILOG_FUNC_IN(LOG_NAS_EMM);

--- a/lte/gateway/c/core/oai/tasks/nas/emm/Detach.c
+++ b/lte/gateway/c/core/oai/tasks/nas/emm/Detach.c
@@ -229,7 +229,8 @@ void _clear_emm_ctxt(emm_context_t* emm_context) {
  **      Others:    T3422                                      **
  **                                                                        **
  ***************************************************************************/
-int emm_proc_detach(mme_ue_s1ap_id_t ue_id, emm_proc_detach_type_t type) {
+status_code_e emm_proc_detach(
+    mme_ue_s1ap_id_t ue_id, emm_proc_detach_type_t type) {
   OAILOG_FUNC_IN(LOG_NAS_EMM);
   int rc = RETURNerror;
 
@@ -259,7 +260,7 @@ int emm_proc_detach(mme_ue_s1ap_id_t ue_id, emm_proc_detach_type_t type) {
  **      Others:    None                                                   **
  **                                                                        **
  ***************************************************************************/
-int emm_proc_sgs_detach_request(
+status_code_e emm_proc_sgs_detach_request(
     mme_ue_s1ap_id_t ue_id, emm_proc_sgs_detach_type_t sgs_detach_type) {
   OAILOG_FUNC_IN(LOG_NAS_EMM);
 
@@ -323,7 +324,7 @@ int emm_proc_sgs_detach_request(
  **      Others:    None                                       **
  **                                                                        **
  ***************************************************************************/
-int emm_proc_detach_request(
+status_code_e emm_proc_detach_request(
     mme_ue_s1ap_id_t ue_id, emm_detach_request_ies_t* params)
 
 {
@@ -425,7 +426,7 @@ int emm_proc_detach_request(
  **      and S1AP                                                          **
  **                                                                        **
  ***************************************************************************/
-int emm_proc_detach_accept(mme_ue_s1ap_id_t ue_id) {
+status_code_e emm_proc_detach_accept(mme_ue_s1ap_id_t ue_id) {
   OAILOG_FUNC_IN(LOG_NAS_EMM);
   emm_context_t* emm_ctx = NULL;
 
@@ -485,7 +486,7 @@ int emm_proc_detach_accept(mme_ue_s1ap_id_t ue_id) {
  **      DETACH REQUEST message to UE                                      **
  **                                                                        **
  ***************************************************************************/
-int emm_proc_nw_initiated_detach_request(
+status_code_e emm_proc_nw_initiated_detach_request(
     mme_ue_s1ap_id_t ue_id, uint8_t detach_type) {
   OAILOG_FUNC_IN(LOG_NAS_EMM);
   int rc;

--- a/lte/gateway/c/core/oai/tasks/nas/emm/EmmCommon.c
+++ b/lte/gateway/c/core/oai/tasks/nas/emm/EmmCommon.c
@@ -136,7 +136,7 @@ struct emm_common_data_s* emm_common_data_context_get(
  **      Others:    _emm_common_data                           **
  **                                                                        **
  ***************************************************************************/
-int emm_proc_common_initialize(
+status_code_e emm_proc_common_initialize(
     mme_ue_s1ap_id_t ue_id, emm_common_success_callback_t _success,
     emm_common_reject_callback_t _reject,
     emm_common_failure_callback_t _failure,
@@ -197,7 +197,7 @@ int emm_proc_common_initialize(
  **      Others:    None                                       **
  **                                                                        **
  ***************************************************************************/
-int emm_proc_common_success(emm_common_data_t* emm_common_data_ctx) {
+status_code_e emm_proc_common_success(emm_common_data_t* emm_common_data_ctx) {
   emm_common_success_callback_t emm_callback = {0};
   int rc                                     = RETURNerror;
 
@@ -233,7 +233,7 @@ int emm_proc_common_success(emm_common_data_t* emm_common_data_ctx) {
  **      Others:    None                                       **
  **                                                                        **
  ***************************************************************************/
-int emm_proc_common_reject(emm_common_data_t* emm_common_data_ctx) {
+status_code_e emm_proc_common_reject(emm_common_data_t* emm_common_data_ctx) {
   int rc = RETURNerror;
   emm_common_reject_callback_t emm_callback;
 
@@ -252,7 +252,7 @@ int emm_proc_common_reject(emm_common_data_t* emm_common_data_ctx) {
   OAILOG_FUNC_RETURN(LOG_NAS_EMM, rc);
 }
 
-int emm_proc_common_failure(emm_common_data_t* emm_common_data_ctx) {
+status_code_e emm_proc_common_failure(emm_common_data_t* emm_common_data_ctx) {
   int rc = RETURNerror;
   emm_common_reject_callback_t emm_callback;
 
@@ -289,7 +289,8 @@ int emm_proc_common_failure(emm_common_data_t* emm_common_data_ctx) {
  **      Others:    None                                       **
  **                                                                        **
  ***************************************************************************/
-int emm_proc_common_ll_failure(emm_common_data_t* emm_common_data_ctx) {
+status_code_e emm_proc_common_ll_failure(
+    emm_common_data_t* emm_common_data_ctx) {
   emm_common_ll_failure_callback_t emm_callback;
   int rc = RETURNerror;
 
@@ -328,7 +329,8 @@ int emm_proc_common_ll_failure(emm_common_data_t* emm_common_data_ctx) {
  **      Others:    None                                       **
  **                                                                        **
  ***************************************************************************/
-int emm_proc_common_non_delivered(emm_common_data_t* emm_common_data_ctx) {
+status_code_e emm_proc_common_non_delivered(
+    emm_common_data_t* emm_common_data_ctx) {
   emm_common_non_delivered_callback_t emm_callback;
   int rc = RETURNerror;
 
@@ -366,7 +368,7 @@ int emm_proc_common_non_delivered(emm_common_data_t* emm_common_data_ctx) {
  **      Others:    None                                       **
  **                                                                        **
  ***************************************************************************/
-int emm_proc_common_abort(emm_common_data_t* emm_common_data_ctx) {
+status_code_e emm_proc_common_abort(emm_common_data_t* emm_common_data_ctx) {
   emm_common_abort_callback_t emm_callback;
   int rc = RETURNerror;
 

--- a/lte/gateway/c/core/oai/tasks/nas/emm/EmmCommon.h
+++ b/lte/gateway/c/core/oai/tasks/nas/emm/EmmCommon.h
@@ -45,6 +45,7 @@ Description Defines callback functions executed within EMM common procedures
 #define FILE_EMM_COMMON_SEEN
 #include <pthread.h>
 
+#include "common_defs.h"
 #include "common_types.h"
 #include "tree.h"
 #include "3gpp_36.401.h"
@@ -106,19 +107,21 @@ extern emm_common_data_head_t emm_common_data_head;
 /******************  E X P O R T E D    F U N C T I O N S  ******************/
 /****************************************************************************/
 
-int emm_proc_common_initialize(
+status_code_e emm_proc_common_initialize(
     mme_ue_s1ap_id_t ue_id, emm_common_success_callback_t success,
     emm_common_reject_callback_t reject, emm_common_failure_callback_t failure,
     emm_common_ll_failure_callback_t ll_failure,
     emm_common_non_delivered_callback_t non_delivered,
     emm_common_abort_callback_t abort, void* args);
 
-int emm_proc_common_success(emm_common_data_t* emm_common_data_ctx);
-int emm_proc_common_reject(emm_common_data_t* emm_common_data_ctx);
-int emm_proc_common_failure(emm_common_data_t* emm_common_data_ctx);
-int emm_proc_common_ll_failure(emm_common_data_t* emm_common_data_ctx);
-int emm_proc_common_non_delivered(emm_common_data_t* emm_common_data_ctx);
-int emm_proc_common_abort(emm_common_data_t* emm_common_data_ctx);
+status_code_e emm_proc_common_success(emm_common_data_t* emm_common_data_ctx);
+status_code_e emm_proc_common_reject(emm_common_data_t* emm_common_data_ctx);
+status_code_e emm_proc_common_failure(emm_common_data_t* emm_common_data_ctx);
+status_code_e emm_proc_common_ll_failure(
+    emm_common_data_t* emm_common_data_ctx);
+status_code_e emm_proc_common_non_delivered(
+    emm_common_data_t* emm_common_data_ctx);
+status_code_e emm_proc_common_abort(emm_common_data_t* emm_common_data_ctx);
 
 void* emm_proc_common_get_args(mme_ue_s1ap_id_t ue_id);
 // Free args and set it to NULL

--- a/lte/gateway/c/core/oai/tasks/nas/emm/EmmInformation.c
+++ b/lte/gateway/c/core/oai/tasks/nas/emm/EmmInformation.c
@@ -68,7 +68,7 @@
 
 static void emm_information_pack_gsm_7Bit(bstring str, unsigned char* result);
 
-int emm_proc_emm_informtion(ue_mm_context_t* ue_emm_ctx) {
+status_code_e emm_proc_emm_informtion(ue_mm_context_t* ue_emm_ctx) {
   int rc                    = RETURNerror;
   unsigned char result[256] = {0};
   emm_sap_t emm_sap         = {0};

--- a/lte/gateway/c/core/oai/tasks/nas/emm/EmmStatusHdl.c
+++ b/lte/gateway/c/core/oai/tasks/nas/emm/EmmStatusHdl.c
@@ -61,7 +61,8 @@
  **      Others:    None                                       **
  **                                                                        **
  ***************************************************************************/
-int emm_proc_status_ind(mme_ue_s1ap_id_t ue_id, emm_cause_t emm_cause) {
+status_code_e emm_proc_status_ind(
+    mme_ue_s1ap_id_t ue_id, emm_cause_t emm_cause) {
   OAILOG_FUNC_IN(LOG_NAS_EMM);
   int rc = RETURNok;
 

--- a/lte/gateway/c/core/oai/tasks/nas/emm/Identification.c
+++ b/lte/gateway/c/core/oai/tasks/nas/emm/Identification.c
@@ -110,7 +110,7 @@ static int identification_request(nas_emm_ident_proc_t* const proc);
  **      Others:    _emm_data                                      **
  **                                                                **
  ********************************************************************/
-int emm_proc_identification(
+status_code_e emm_proc_identification(
     struct emm_context_s* const emm_context, nas_emm_proc_t* const emm_proc,
     const identity_type2_t type, success_cb_t success, failure_cb_t failure) {
   OAILOG_FUNC_IN(LOG_NAS_EMM);
@@ -199,7 +199,7 @@ int emm_proc_identification(
  **      Others:    _emm_data, T3470                                       **
  **                                                                        **
  ***************************************************************************/
-int emm_proc_identification_complete(
+status_code_e emm_proc_identification_complete(
     const mme_ue_s1ap_id_t ue_id, imsi_t* const imsi, imei_t* const imei,
     imeisv_t* const imeisv, uint32_t* const tmsi) {
   OAILOG_FUNC_IN(LOG_NAS_EMM);

--- a/lte/gateway/c/core/oai/tasks/nas/emm/LowerLayer.c
+++ b/lte/gateway/c/core/oai/tasks/nas/emm/LowerLayer.c
@@ -69,7 +69,7 @@
  **      Others:    None                                       **
  **                                                                        **
  ***************************************************************************/
-int lowerlayer_success(mme_ue_s1ap_id_t ue_id, bstring* nas_msg) {
+status_code_e lowerlayer_success(mme_ue_s1ap_id_t ue_id, bstring* nas_msg) {
   OAILOG_FUNC_IN(LOG_NAS_EMM);
   emm_sap_t emm_sap = {0};
   int rc            = RETURNok;
@@ -115,7 +115,8 @@ int lowerlayer_success(mme_ue_s1ap_id_t ue_id, bstring* nas_msg) {
  **      Others:    None                                       **
  **                                                                        **
  ***************************************************************************/
-int lowerlayer_failure(mme_ue_s1ap_id_t ue_id, STOLEN_REF bstring* nas_msg) {
+status_code_e lowerlayer_failure(
+    mme_ue_s1ap_id_t ue_id, STOLEN_REF bstring* nas_msg) {
   OAILOG_FUNC_IN(LOG_NAS_EMM);
   emm_sap_t emm_sap = {0};
   int rc            = RETURNok;
@@ -160,7 +161,7 @@ int lowerlayer_failure(mme_ue_s1ap_id_t ue_id, STOLEN_REF bstring* nas_msg) {
  **      Others:    None                                                   **
  **                                                                        **
  ***************************************************************************/
-int lowerlayer_non_delivery_indication(
+status_code_e lowerlayer_non_delivery_indication(
     mme_ue_s1ap_id_t ue_id, STOLEN_REF bstring* nas_msg) {
   OAILOG_FUNC_IN(LOG_NAS_EMM);
   emm_sap_t emm_sap = {0};
@@ -206,7 +207,7 @@ int lowerlayer_non_delivery_indication(
  **      Others:    None                                       **
  **                                                                        **
  ***************************************************************************/
-int lowerlayer_establish(void) {
+status_code_e lowerlayer_establish(void) {
   OAILOG_FUNC_IN(LOG_NAS_EMM);
   OAILOG_FUNC_RETURN(LOG_NAS_EMM, RETURNok);
 }
@@ -226,7 +227,7 @@ int lowerlayer_establish(void) {
  **      Others:    None                                       **
  **                                                                        **
  ***************************************************************************/
-int lowerlayer_release(mme_ue_s1ap_id_t ue_id, int cause) {
+status_code_e lowerlayer_release(mme_ue_s1ap_id_t ue_id, int cause) {
   OAILOG_FUNC_IN(LOG_NAS_EMM);
   emm_sap_t emm_sap = {0};
   int rc            = RETURNok;
@@ -260,7 +261,7 @@ int lowerlayer_release(mme_ue_s1ap_id_t ue_id, int cause) {
  **      Others:    None                                       **
  **                                                                        **
  ***************************************************************************/
-int lowerlayer_data_ind(mme_ue_s1ap_id_t ue_id, const_bstring data) {
+status_code_e lowerlayer_data_ind(mme_ue_s1ap_id_t ue_id, const_bstring data) {
   esm_sap_t esm_sap = {0};
   int rc            = RETURNok;
 
@@ -292,7 +293,7 @@ int lowerlayer_data_ind(mme_ue_s1ap_id_t ue_id, const_bstring data) {
  **      Others:    None                                       **
  **                                                                        **
  ***************************************************************************/
-int lowerlayer_data_req(mme_ue_s1ap_id_t ue_id, bstring data) {
+status_code_e lowerlayer_data_req(mme_ue_s1ap_id_t ue_id, bstring data) {
   OAILOG_FUNC_IN(LOG_NAS_EMM);
   int rc                         = RETURNok;
   emm_sap_t emm_sap              = {0};
@@ -319,7 +320,7 @@ int lowerlayer_data_req(mme_ue_s1ap_id_t ue_id, bstring data) {
 }
 
 //------------------------------------------------------------------------------
-int lowerlayer_activate_bearer_req(
+status_code_e lowerlayer_activate_bearer_req(
     const mme_ue_s1ap_id_t ue_id, const ebi_t ebi, const bitrate_t mbr_dl,
     const bitrate_t mbr_ul, const bitrate_t gbr_dl, const bitrate_t gbr_ul,
     bstring data) {
@@ -353,7 +354,7 @@ int lowerlayer_activate_bearer_req(
 }
 
 //------------------------------------------------------------------------------
-int lowerlayer_deactivate_bearer_req(
+status_code_e lowerlayer_deactivate_bearer_req(
     const mme_ue_s1ap_id_t ue_id, const ebi_t ebi, bstring data) {
   OAILOG_FUNC_IN(LOG_NAS_EMM);
   int rc                         = RETURNok;

--- a/lte/gateway/c/core/oai/tasks/nas/emm/LowerLayer.h
+++ b/lte/gateway/c/core/oai/tasks/nas/emm/LowerLayer.h
@@ -38,6 +38,7 @@ Description Defines EMM procedures executed by the Non-Access Stratum
 #ifndef __LOWERLAYER_H__
 #define __LOWERLAYER_H__
 
+#include "common_defs.h"
 #include "common_types.h"
 #include "bstrlib.h"
 #include "3gpp_24.007.h"
@@ -60,20 +61,21 @@ Description Defines EMM procedures executed by the Non-Access Stratum
 /******************  E X P O R T E D    F U N C T I O N S  ******************/
 /****************************************************************************/
 
-int lowerlayer_success(mme_ue_s1ap_id_t ue_id, bstring* nas_msg);
-int lowerlayer_failure(mme_ue_s1ap_id_t ueid, STOLEN_REF bstring* nas_msg);
-int lowerlayer_non_delivery_indication(
+status_code_e lowerlayer_success(mme_ue_s1ap_id_t ue_id, bstring* nas_msg);
+status_code_e lowerlayer_failure(
+    mme_ue_s1ap_id_t ueid, STOLEN_REF bstring* nas_msg);
+status_code_e lowerlayer_non_delivery_indication(
     mme_ue_s1ap_id_t ue_id, STOLEN_REF bstring* nas_msg);
-int lowerlayer_establish(void);
-int lowerlayer_release(mme_ue_s1ap_id_t ue_id, int cause);
+status_code_e lowerlayer_establish(void);
+status_code_e lowerlayer_release(mme_ue_s1ap_id_t ue_id, int cause);
 
-int lowerlayer_data_ind(mme_ue_s1ap_id_t ueid, const_bstring data);
-int lowerlayer_data_req(mme_ue_s1ap_id_t ueid, bstring data);
-int lowerlayer_activate_bearer_req(
+status_code_e lowerlayer_data_ind(mme_ue_s1ap_id_t ueid, const_bstring data);
+status_code_e lowerlayer_data_req(mme_ue_s1ap_id_t ueid, bstring data);
+status_code_e lowerlayer_activate_bearer_req(
     const mme_ue_s1ap_id_t ue_id, const ebi_t ebi, const bitrate_t mbr_dl,
     const bitrate_t mbr_ul, const bitrate_t gbr_dl, const bitrate_t gbr_ul,
     bstring data);
-int lowerlayer_deactivate_bearer_req(
+status_code_e lowerlayer_deactivate_bearer_req(
     const mme_ue_s1ap_id_t ue_id, const ebi_t ebi, bstring data);
 
 #endif /* __LOWERLAYER_H__*/

--- a/lte/gateway/c/core/oai/tasks/nas/emm/NasTransportHdl.c
+++ b/lte/gateway/c/core/oai/tasks/nas/emm/NasTransportHdl.c
@@ -97,7 +97,8 @@
  **      Others:    _emm_data                                  **
  **                                                                        **
  ***************************************************************************/
-int emm_proc_uplink_nas_transport(mme_ue_s1ap_id_t ue_id, bstring nas_msg_pP) {
+status_code_e emm_proc_uplink_nas_transport(
+    mme_ue_s1ap_id_t ue_id, bstring nas_msg_pP) {
   int rc                                     = RETURNok;
   emm_context_t* emm_ctxt_p                  = NULL;
   imeisv_t* p_imeisv                         = NULL;

--- a/lte/gateway/c/core/oai/tasks/nas/emm/SecurityModeControl.c
+++ b/lte/gateway/c/core/oai/tasks/nas/emm/SecurityModeControl.c
@@ -164,7 +164,7 @@ static int security_request(nas_emm_smc_proc_t* const smc_proc);
  **      Others:    None                                       **
  **                                                                        **
  ***************************************************************************/
-int emm_proc_security_mode_control(
+status_code_e emm_proc_security_mode_control(
     struct emm_context_s* emm_ctx,
     nas_emm_specific_proc_t* const emm_specific_proc, ksi_t ksi,
     success_cb_t success, failure_cb_t failure) {
@@ -407,7 +407,7 @@ int emm_proc_security_mode_control(
  **      Others:    None                                                   **
  **                                                                        **
  ***************************************************************************/
-int validate_imei(imeisv_t* imeisv) {
+status_code_e validate_imei(imeisv_t* imeisv) {
   OAILOG_FUNC_IN(LOG_NAS_EMM);
   /* First convert only TAC to uint64_t. If TAC is not found in the hashlist,
    * convert IMEI(TAC + SNR) into uint64_t and check if the key is found
@@ -462,7 +462,7 @@ int validate_imei(imeisv_t* imeisv) {
  **      Others:    None                                       **
  **                                                                        **
  ***************************************************************************/
-int emm_proc_security_mode_complete(
+status_code_e emm_proc_security_mode_complete(
     mme_ue_s1ap_id_t ue_id, const imeisv_mobile_identity_t* const imeisvmob) {
   OAILOG_FUNC_IN(LOG_NAS_EMM);
   ue_mm_context_t* ue_mm_context = NULL;
@@ -630,7 +630,7 @@ int emm_proc_security_mode_complete(
  **      Others:    None                                       **
  **                                                                        **
  ***************************************************************************/
-int emm_proc_security_mode_reject(mme_ue_s1ap_id_t ue_id) {
+status_code_e emm_proc_security_mode_reject(mme_ue_s1ap_id_t ue_id) {
   OAILOG_FUNC_IN(LOG_NAS_EMM);
   ue_mm_context_t* ue_mm_context = NULL;
   emm_context_t* emm_ctx         = NULL;

--- a/lte/gateway/c/core/oai/tasks/nas/emm/ServiceRequestHdl.c
+++ b/lte/gateway/c/core/oai/tasks/nas/emm/ServiceRequestHdl.c
@@ -68,7 +68,7 @@ static int check_paging_received_without_lai(mme_ue_s1ap_id_t ue_id);
 /****************************************************************************/
 /******************  E X P O R T E D    F U N C T I O N S  ******************/
 /****************************************************************************/
-int emm_proc_service_reject(
+status_code_e emm_proc_service_reject(
     const mme_ue_s1ap_id_t ue_id, const uint8_t emm_cause) {
   int rc = RETURNok;
   OAILOG_FUNC_IN(LOG_NAS_EMM);
@@ -139,7 +139,7 @@ static int emm_service_reject(mme_ue_s1ap_id_t ue_id, uint8_t emm_cause)
  **              and EPC supports CS or SMS                                **
  **              send the extended service req notification to mme_app     **
  ***************************************************************************/
-int emm_proc_extended_service_request(
+status_code_e emm_proc_extended_service_request(
     const mme_ue_s1ap_id_t ue_id, const extended_service_request_msg* msg) {
   OAILOG_FUNC_IN(LOG_NAS_EMM);
   int rc                 = RETURNok;
@@ -207,7 +207,7 @@ int emm_proc_extended_service_request(
  **              and EPC supports CS call or SMS                           **
  **              send the extended service req notification to mme_app     **
  ***************************************************************************/
-int emm_recv_initial_ext_service_request(
+status_code_e emm_recv_initial_ext_service_request(
     const mme_ue_s1ap_id_t ue_id, const extended_service_request_msg* msg,
     int* emm_cause, const nas_message_decode_status_t* decode_status) {
   OAILOG_FUNC_IN(LOG_NAS_EMM);
@@ -324,7 +324,7 @@ static int check_paging_received_without_lai(mme_ue_s1ap_id_t ue_id) {
   OAILOG_FUNC_RETURN(LOG_NAS_EMM, false);
 }
 
-int emm_send_service_reject_in_dl_nas(
+status_code_e emm_send_service_reject_in_dl_nas(
     const mme_ue_s1ap_id_t ue_id, const uint8_t emm_cause) {
   int rc                 = RETURNok;
   emm_sap_t emm_sap      = {0};

--- a/lte/gateway/c/core/oai/tasks/nas/emm/TrackingAreaUpdate.c
+++ b/lte/gateway/c/core/oai/tasks/nas/emm/TrackingAreaUpdate.c
@@ -89,7 +89,8 @@ static int send_tau_accept_and_check_for_neaf_flag(
 /******************  E X P O R T E D    F U N C T I O N S  ******************/
 /****************************************************************************/
 
-int emm_proc_tracking_area_update_accept(nas_emm_tau_proc_t* const tau_proc) {
+status_code_e emm_proc_tracking_area_update_accept(
+    nas_emm_tau_proc_t* const tau_proc) {
   int rc = RETURNerror;
   OAILOG_FUNC_IN(LOG_NAS_EMM);
   rc = emm_tracking_area_update_accept(tau_proc);
@@ -108,7 +109,7 @@ int emm_proc_tracking_area_update_accept(nas_emm_tau_proc_t* const tau_proc) {
  ** Outputs: Return:    RETURNok, RETURNerror                              **
  **                                                                        **
  ***************************************************************************/
-int csfb_handle_tracking_area_req(
+status_code_e csfb_handle_tracking_area_req(
     emm_context_t* emm_context_p, emm_tau_request_ies_t* ies) {
   OAILOG_FUNC_IN(LOG_NAS_EMM);
   ue_mm_context_t* ue_mm_context = NULL;
@@ -190,7 +191,7 @@ int csfb_handle_tracking_area_req(
   OAILOG_FUNC_RETURN(LOG_NAS_EMM, RETURNerror);
 }
 
-int emm_proc_tracking_area_update_request(
+status_code_e emm_proc_tracking_area_update_request(
     const mme_ue_s1ap_id_t ue_id, emm_tau_request_ies_t* ies, int* emm_cause,
     tac_t tac) {
   OAILOG_FUNC_IN(LOG_NAS_EMM);
@@ -423,7 +424,7 @@ int emm_proc_tracking_area_update_request(
  **                  Others:    _emm_data                                  **
  **                                                                        **
  ***************************************************************************/
-int emm_proc_tracking_area_update_reject(
+status_code_e emm_proc_tracking_area_update_reject(
     const mme_ue_s1ap_id_t ue_id, const int emm_cause) {
   int rc = RETURNerror;
   OAILOG_FUNC_IN(LOG_NAS_EMM);
@@ -963,7 +964,7 @@ void free_emm_tau_request_ies(emm_tau_request_ies_t** const ies) {
  **      Others:    _emm_data, T3450                                       **
  **                                                                        **
  ***************************************************************************/
-int emm_proc_tau_complete(mme_ue_s1ap_id_t ue_id) {
+status_code_e emm_proc_tau_complete(mme_ue_s1ap_id_t ue_id) {
   emm_context_t* emm_ctx               = NULL;
   struct ue_mm_context_s* ue_context_p = NULL;
 

--- a/lte/gateway/c/core/oai/tasks/nas/emm/emm_data.h
+++ b/lte/gateway/c/core/oai/tasks/nas/emm/emm_data.h
@@ -36,6 +36,7 @@ Description Defines internal private data handled by EPS Mobility
 #define FILE_EMM_DATA_SEEN
 
 #include <sys/types.h>
+#include "common_defs.h"
 #include "queue.h"
 #include "hashtable.h"
 #include "obj_hashtable.h"
@@ -540,8 +541,8 @@ struct emm_context_s* emm_context_get_by_imsi(
 struct emm_context_s* emm_context_get_by_guti(
     emm_data_t* emm_data, guti_t* guti);
 
-int emm_context_upsert_imsi(emm_data_t* emm_data, struct emm_context_s* elm)
-    __attribute__((nonnull));
+status_code_e emm_context_upsert_imsi(
+    emm_data_t* emm_data, struct emm_context_s* elm) __attribute__((nonnull));
 
 void nas_start_T3450(
     const mme_ue_s1ap_id_t ue_id, struct nas_timer_s* const T3450,

--- a/lte/gateway/c/core/oai/tasks/nas/emm/emm_data_ctx.c
+++ b/lte/gateway/c/core/oai/tasks/nas/emm/emm_data_ctx.c
@@ -750,7 +750,8 @@ void emm_data_context_remove_mobile_ids(
 }
 //------------------------------------------------------------------------------
 
-int emm_context_upsert_imsi(emm_data_t* emm_data, struct emm_context_s* elm) {
+status_code_e emm_context_upsert_imsi(
+    emm_data_t* emm_data, struct emm_context_s* elm) {
   hashtable_rc_t h_rc = HASH_TABLE_OK;
   mme_ue_s1ap_id_t ue_id =
       (PARENT_STRUCT(elm, struct ue_mm_context_s, emm_context))->mme_ue_s1ap_id;

--- a/lte/gateway/c/core/oai/tasks/nas/emm/emm_proc.h
+++ b/lte/gateway/c/core/oai/tasks/nas/emm/emm_proc.h
@@ -35,6 +35,8 @@ Description Defines the EPS Mobility Management procedures executed at
 #ifndef FILE_EMM_PROC_SEEN
 #define FILE_EMM_PROC_SEEN
 
+#include "common_defs.h"
+
 #include "nas/commonDef.h"
 #include "bstrlib.h"
 
@@ -170,7 +172,8 @@ typedef struct emm_tau_request_ies_s {
  *              EMM status procedure
  *---------------------------------------------------------------------------
  */
-int emm_proc_status_ind(mme_ue_s1ap_id_t ue_id, emm_cause_t emm_cause);
+status_code_e emm_proc_status_ind(
+    mme_ue_s1ap_id_t ue_id, emm_cause_t emm_cause);
 int emm_proc_status(mme_ue_s1ap_id_t ue_id, emm_cause_t emm_cause);
 
 /*
@@ -193,16 +196,17 @@ int emm_proc_status(mme_ue_s1ap_id_t ue_id, emm_cause_t emm_cause);
 
 void free_emm_attach_request_ies(emm_attach_request_ies_t** const params);
 
-int emm_proc_attach_request(
+status_code_e emm_proc_attach_request(
     mme_ue_s1ap_id_t ue_id, const bool ctx_is_new,
     emm_attach_request_ies_t* const params);
 
-int _emm_attach_reject(
+status_code_e _emm_attach_reject(
     emm_context_t* emm_context, struct nas_base_proc_s* nas_base_proc);
 
-int emm_proc_attach_reject(mme_ue_s1ap_id_t ue_id, emm_cause_t emm_cause);
+status_code_e emm_proc_attach_reject(
+    mme_ue_s1ap_id_t ue_id, emm_cause_t emm_cause);
 
-int emm_proc_attach_complete(
+status_code_e emm_proc_attach_complete(
     mme_ue_s1ap_id_t ue_id, const_bstring esm_msg_pP, int emm_cause,
     const nas_message_decode_status_t status);
 
@@ -210,17 +214,17 @@ void set_callbacks_for_attach_proc(nas_emm_attach_proc_t* attach_proc);
 
 void free_emm_tau_request_ies(emm_tau_request_ies_t** const ies);
 
-int emm_proc_tracking_area_update_request(
+status_code_e emm_proc_tracking_area_update_request(
     const mme_ue_s1ap_id_t ue_id, emm_tau_request_ies_t* ies, int* emm_cause,
     tac_t tac);
 
-int emm_proc_tracking_area_update_reject(
+status_code_e emm_proc_tracking_area_update_reject(
     const mme_ue_s1ap_id_t ue_id, const int emm_cause);
 
-int emm_proc_service_reject(
+status_code_e emm_proc_service_reject(
     const mme_ue_s1ap_id_t ue_id, const uint8_t emm_cause);
 
-int emm_proc_extended_service_request(
+status_code_e emm_proc_extended_service_request(
     const mme_ue_s1ap_id_t ue_id, const extended_service_request_msg* msg);
 
 /*
@@ -229,15 +233,16 @@ int emm_proc_extended_service_request(
  * --------------------------------------------------------------------------
  */
 
-int emm_proc_detach(mme_ue_s1ap_id_t ue_id, emm_proc_detach_type_t type);
-int emm_proc_sgs_detach_request(
+status_code_e emm_proc_detach(
+    mme_ue_s1ap_id_t ue_id, emm_proc_detach_type_t type);
+status_code_e emm_proc_sgs_detach_request(
     mme_ue_s1ap_id_t ue_id, emm_proc_sgs_detach_type_t type);
-int emm_proc_nw_initiated_detach_request(
+status_code_e emm_proc_nw_initiated_detach_request(
     mme_ue_s1ap_id_t ue_id, uint8_t detach_type);
 void free_emm_detach_request_ies(emm_detach_request_ies_t** const ies);
-int emm_proc_detach_request(
+status_code_e emm_proc_detach_request(
     mme_ue_s1ap_id_t ue_id, emm_detach_request_ies_t* params);
-int emm_proc_detach_accept(mme_ue_s1ap_id_t ue_id);
+status_code_e emm_proc_detach_accept(mme_ue_s1ap_id_t ue_id);
 /*
  * --------------------------------------------------------------------------
  *              Identification procedure
@@ -245,10 +250,10 @@ int emm_proc_detach_accept(mme_ue_s1ap_id_t ue_id);
  */
 struct emm_context_s;
 
-int emm_proc_identification(
+status_code_e emm_proc_identification(
     struct emm_context_s* const emm_context, nas_emm_proc_t* const emm_proc,
     const identity_type2_t type, success_cb_t success, failure_cb_t failure);
-int emm_proc_identification_complete(
+status_code_e emm_proc_identification_complete(
     const mme_ue_s1ap_id_t ue_id, imsi_t* const imsi, imei_t* const imei,
     imeisv_t* const imeisv, uint32_t* const tmsi);
 
@@ -258,25 +263,25 @@ int emm_proc_identification_complete(
  * --------------------------------------------------------------------------
  */
 
-int emm_proc_authentication_ksi(
+status_code_e emm_proc_authentication_ksi(
     struct emm_context_s* emm_context,
     nas_emm_specific_proc_t* const emm_specific_proc, ksi_t ksi,
     const uint8_t* const rand, const uint8_t* const autn, success_cb_t success,
     failure_cb_t failure);
 
-int emm_proc_authentication(
+status_code_e emm_proc_authentication(
     struct emm_context_s* emm_context,
     nas_emm_specific_proc_t* const emm_specific_proc, success_cb_t success,
     failure_cb_t failure);
 
-int emm_proc_authentication_failure(
+status_code_e emm_proc_authentication_failure(
     mme_ue_s1ap_id_t ue_id, int emm_cause, const_bstring auts);
 
-int emm_proc_authentication_complete(
+status_code_e emm_proc_authentication_complete(
     mme_ue_s1ap_id_t ue_id, authentication_response_msg* msg, int emm_cause,
     const_bstring const res);
 
-int emm_attach_security(struct emm_context_s* emm_context);
+status_code_e emm_attach_security(struct emm_context_s* emm_context);
 
 void set_notif_callbacks_for_auth_proc(nas_emm_auth_proc_t* auth_proc);
 void set_callbacks_for_auth_proc(nas_emm_auth_proc_t* auth_proc);
@@ -287,21 +292,22 @@ void set_callbacks_for_auth_info_proc(nas_auth_info_proc_t* auth_info_proc);
  * --------------------------------------------------------------------------
  */
 
-int emm_proc_security_mode_control(
+status_code_e emm_proc_security_mode_control(
     struct emm_context_s* emm_context,
     nas_emm_specific_proc_t* const emm_specific_proc, ksi_t ksi,
     success_cb_t success, failure_cb_t failure);
-int emm_proc_security_mode_complete(
+status_code_e emm_proc_security_mode_complete(
     mme_ue_s1ap_id_t ue_id, const imeisv_mobile_identity_t* const imeisv);
-int emm_proc_security_mode_reject(mme_ue_s1ap_id_t ue_id);
-int emm_proc_emm_informtion(ue_mm_context_t* emm_ctx);
+status_code_e emm_proc_security_mode_reject(mme_ue_s1ap_id_t ue_id);
+status_code_e emm_proc_emm_informtion(ue_mm_context_t* emm_ctx);
 
 void _clear_emm_ctxt(emm_context_t* emm_ctx);
 
-int emm_proc_tau_complete(mme_ue_s1ap_id_t ue_id);
-int emm_send_service_reject_in_dl_nas(
+status_code_e emm_proc_tau_complete(mme_ue_s1ap_id_t ue_id);
+status_code_e emm_send_service_reject_in_dl_nas(
     const mme_ue_s1ap_id_t ue_id, const uint8_t emm_cause);
-int emm_proc_uplink_nas_transport(mme_ue_s1ap_id_t ue_id, bstring nas_msg);
+status_code_e emm_proc_uplink_nas_transport(
+    mme_ue_s1ap_id_t ue_id, bstring nas_msg);
 
 void set_notif_callbacks_for_smc_proc(nas_emm_smc_proc_t* smc_proc);
 void set_callbacks_for_smc_proc(nas_emm_smc_proc_t* smc_proc);

--- a/lte/gateway/c/core/oai/tasks/nas/emm/sap/EmmCommonProcedureInitiated.c
+++ b/lte/gateway/c/core/oai/tasks/nas/emm/sap/EmmCommonProcedureInitiated.c
@@ -76,7 +76,7 @@
  **      Others:    emm_fsm_status                             **
  **                                                                        **
  ***************************************************************************/
-int EmmCommonProcedureInitiated(emm_reg_t* const evt) {
+status_code_e EmmCommonProcedureInitiated(emm_reg_t* const evt) {
   OAILOG_FUNC_IN(LOG_NAS_EMM);
   int rc                 = RETURNerror;
   emm_context_t* emm_ctx = evt->ctx;

--- a/lte/gateway/c/core/oai/tasks/nas/emm/sap/EmmDeregistered.c
+++ b/lte/gateway/c/core/oai/tasks/nas/emm/sap/EmmDeregistered.c
@@ -82,7 +82,7 @@
  **      Others:    emm_fsm_status                             **
  **                                                                        **
  ***************************************************************************/
-int EmmDeregistered(emm_reg_t* const evt) {
+status_code_e EmmDeregistered(emm_reg_t* const evt) {
   OAILOG_FUNC_IN(LOG_NAS_EMM);
   int rc                 = RETURNerror;
   emm_context_t* emm_ctx = evt->ctx;

--- a/lte/gateway/c/core/oai/tasks/nas/emm/sap/EmmDeregisteredInitiated.c
+++ b/lte/gateway/c/core/oai/tasks/nas/emm/sap/EmmDeregisteredInitiated.c
@@ -51,7 +51,7 @@
  **      Others:    emm_fsm_status                             **
  **                                                                        **
  ***************************************************************************/
-int EmmDeregisteredInitiated(const emm_reg_t* evt) {
+status_code_e EmmDeregisteredInitiated(const emm_reg_t* evt) {
   OAILOG_FUNC_IN(LOG_NAS_EMM);
   int rc                 = RETURNerror;
   emm_context_t* emm_ctx = evt->ctx;

--- a/lte/gateway/c/core/oai/tasks/nas/emm/sap/EmmRegistered.c
+++ b/lte/gateway/c/core/oai/tasks/nas/emm/sap/EmmRegistered.c
@@ -51,7 +51,7 @@
  **      Others:    emm_fsm_status                             **
  **                                                                        **
  ***************************************************************************/
-int EmmRegistered(const emm_reg_t* evt) {
+status_code_e EmmRegistered(const emm_reg_t* evt) {
   OAILOG_FUNC_IN(LOG_NAS_EMM);
   int rc                 = RETURNerror;
   emm_context_t* emm_ctx = evt->ctx;

--- a/lte/gateway/c/core/oai/tasks/nas/emm/sap/emm_as.c
+++ b/lte/gateway/c/core/oai/tasks/nas/emm/sap/emm_as.c
@@ -164,7 +164,7 @@ void emm_as_initialize(void) {
  **      Others:    None                                       **
  **                                                                        **
  ***************************************************************************/
-int emm_as_send(emm_as_t* msg) {
+status_code_e emm_as_send(emm_as_t* msg) {
   OAILOG_FUNC_IN(LOG_NAS_EMM);
   int rc                       = RETURNok;
   int emm_cause                = EMM_CAUSE_SUCCESS;

--- a/lte/gateway/c/core/oai/tasks/nas/emm/sap/emm_as.h
+++ b/lte/gateway/c/core/oai/tasks/nas/emm/sap/emm_as.h
@@ -36,6 +36,7 @@ Description Defines the EMMAS Service Access Point that provides
 #ifndef FILE_EMM_AS_SEEN
 #define FILE_EMM_AS_SEEN
 
+#include "common_defs.h"
 #include "emm_asDef.h"
 
 /****************************************************************************/
@@ -58,6 +59,6 @@ Description Defines the EMMAS Service Access Point that provides
 
 void emm_as_initialize(void);
 
-int emm_as_send(emm_as_t* msg);
+status_code_e emm_as_send(emm_as_t* msg);
 
 #endif /* FILE_EMM_AS_SEEN*/

--- a/lte/gateway/c/core/oai/tasks/nas/emm/sap/emm_cn.c
+++ b/lte/gateway/c/core/oai/tasks/nas/emm/sap/emm_cn.c
@@ -848,7 +848,7 @@ static int send_attach_accept(struct emm_context_s* emm_ctx_p) {
 }
 
 //------------------------------------------------------------------------------
-int emm_send_cs_domain_attach_or_tau_accept(
+status_code_e emm_send_cs_domain_attach_or_tau_accept(
     struct ue_mm_context_s* ue_context_p) {
   int rc                    = RETURNok;
   emm_fsm_state_t fsm_state = EMM_DEREGISTERED;
@@ -1150,7 +1150,7 @@ static int emm_cn_pdn_disconnect_rsp(emm_cn_pdn_disconnect_rsp_t* msg) {
 }
 
 //------------------------------------------------------------------------------
-int emm_cn_send(const emm_cn_t* msg) {
+status_code_e emm_cn_send(const emm_cn_t* msg) {
   int rc                       = RETURNerror;
   emm_cn_primitive_t primitive = msg->primitive;
 

--- a/lte/gateway/c/core/oai/tasks/nas/emm/sap/emm_cn.h
+++ b/lte/gateway/c/core/oai/tasks/nas/emm/sap/emm_cn.h
@@ -36,7 +36,8 @@ Description
 #ifndef FILE_EMM_CN_SEEN
 #define FILE_EMM_CN_SEEN
 
+#include "common_defs.h"
 #include "emm_cnDef.h"
-int emm_cn_send(const emm_cn_t* msg);
+status_code_e emm_cn_send(const emm_cn_t* msg);
 
 #endif /* FILE_EMM_CN_SEEN */

--- a/lte/gateway/c/core/oai/tasks/nas/emm/sap/emm_esm.c
+++ b/lte/gateway/c/core/oai/tasks/nas/emm/sap/emm_esm.c
@@ -77,7 +77,7 @@ void emm_esm_initialize(void) {
  **      Others:    None                                       **
  **                                                                        **
  ***************************************************************************/
-int emm_esm_send(const emm_esm_t* msg) {
+status_code_e emm_esm_send(const emm_esm_t* msg) {
   OAILOG_FUNC_IN(LOG_NAS_EMM);
   int rc                        = RETURNerror;
   emm_esm_primitive_t primitive = msg->primitive;

--- a/lte/gateway/c/core/oai/tasks/nas/emm/sap/emm_esm.h
+++ b/lte/gateway/c/core/oai/tasks/nas/emm/sap/emm_esm.h
@@ -37,6 +37,7 @@ Description Defines the EMMESM Service Access Point that provides
 #ifndef FILE_EMM_ESM_SEEN
 #define FILE_EMM_ESM_SEEN
 
+#include "common_defs.h"
 #include "emm_esmDef.h"
 
 /****************************************************************************/
@@ -57,6 +58,6 @@ Description Defines the EMMESM Service Access Point that provides
 
 void emm_esm_initialize(void);
 
-int emm_esm_send(const emm_esm_t* msg);
+status_code_e emm_esm_send(const emm_esm_t* msg);
 
 #endif /* FILE_EMM_ESM_SEEN*/

--- a/lte/gateway/c/core/oai/tasks/nas/emm/sap/emm_fsm.c
+++ b/lte/gateway/c/core/oai/tasks/nas/emm/sap/emm_fsm.c
@@ -83,10 +83,10 @@ static const char* const emm_fsm_status_str[EMM_STATE_MAX] = {
 /* Type of the EPS Mobility Management state machine handler */
 typedef int (*emm_fsm_handler_t)(emm_reg_t* const);
 
-int EmmDeregistered(emm_reg_t* const);
-int EmmRegistered(emm_reg_t* const);
-int EmmDeregisteredInitiated(emm_reg_t* const);
-int EmmCommonProcedureInitiated(emm_reg_t* const);
+status_code_e EmmDeregistered(emm_reg_t* const);
+status_code_e EmmRegistered(emm_reg_t* const);
+status_code_e EmmDeregisteredInitiated(emm_reg_t* const);
+status_code_e EmmCommonProcedureInitiated(emm_reg_t* const);
 
 /* EMM state machine handlers */
 static const emm_fsm_handler_t emm_fsm_handlers[EMM_STATE_MAX] = {
@@ -141,7 +141,7 @@ void emm_fsm_initialize(void) {
  **      Others:    _emm_fsm_status                            **
  **                                                                        **
  ***************************************************************************/
-int emm_fsm_set_state(
+status_code_e emm_fsm_set_state(
     const mme_ue_s1ap_id_t ue_id, struct emm_context_s* const emm_context,
     const emm_fsm_state_t state) {
   OAILOG_FUNC_IN(LOG_NAS_EMM);
@@ -224,7 +224,7 @@ const char* emm_fsm_get_state_str(
  **      Others:    None                                       **
  **                                                                        **
  ***************************************************************************/
-int emm_fsm_process(struct emm_reg_s* const evt) {
+status_code_e emm_fsm_process(struct emm_reg_s* const evt) {
   int rc = RETURNerror;
   emm_fsm_state_t state;
   emm_reg_primitive_t primitive;

--- a/lte/gateway/c/core/oai/tasks/nas/emm/sap/emm_fsm.h
+++ b/lte/gateway/c/core/oai/tasks/nas/emm/sap/emm_fsm.h
@@ -60,6 +60,7 @@ typedef enum {
   EMM_STATE_MAX
 } emm_fsm_state_t;
 
+#include "common_defs.h"
 #include "emm_regDef.h"
 #include "3gpp_36.401.h"
 
@@ -78,13 +79,13 @@ void emm_fsm_initialize(void);
 struct emm_context_s;
 struct emm_reg_s;
 
-int emm_fsm_set_state(
+status_code_e emm_fsm_set_state(
     const mme_ue_s1ap_id_t ueid, struct emm_context_s* const emm_context,
     const emm_fsm_state_t status);
 emm_fsm_state_t emm_fsm_get_state(
     const struct emm_context_s* const emm_context);
 const char* emm_fsm_get_state_str(
     const struct emm_context_s* const emm_context);
-int emm_fsm_process(struct emm_reg_s* const evt);
+status_code_e emm_fsm_process(struct emm_reg_s* const evt);
 
 #endif /* FILE_EMM_FSM_SEEN*/

--- a/lte/gateway/c/core/oai/tasks/nas/emm/sap/emm_recv.c
+++ b/lte/gateway/c/core/oai/tasks/nas/emm/sap/emm_recv.c
@@ -91,7 +91,7 @@ static int emm_initiate_default_bearer_re_establishment(emm_context_t* emm_ctx);
  **      Others:    None                                       **
  **                                                                        **
  ***************************************************************************/
-int emm_recv_status(
+status_code_e emm_recv_status(
     mme_ue_s1ap_id_t ue_id, emm_status_msg* msg, int* emm_cause,
     const nas_message_decode_status_t* status) {
   OAILOG_FUNC_IN(LOG_NAS_EMM);
@@ -133,7 +133,7 @@ int emm_recv_status(
  **      Others:    None                                                   **
  **                                                                        **
  ***************************************************************************/
-int check_plmn_restriction(imsi_t imsi) {
+status_code_e check_plmn_restriction(imsi_t imsi) {
   OAILOG_FUNC_IN(LOG_NAS_EMM);
   for (uint8_t itr = 0; itr < mme_config.restricted_plmn.num; itr++) {
     if ((imsi.u.num.digit1 ==
@@ -177,7 +177,7 @@ int check_plmn_restriction(imsi_t imsi) {
  **      Others:    None                                       **
  **                                                                        **
  ***************************************************************************/
-int emm_recv_attach_request(
+status_code_e emm_recv_attach_request(
     const mme_ue_s1ap_id_t ue_id, const tai_t* const originating_tai,
     const ecgi_t* const originating_ecgi, attach_request_msg* const msg,
     const bool is_initial, const bool is_mm_ctx_new, int* const emm_cause,
@@ -478,7 +478,7 @@ int emm_recv_attach_request(
  **      Others:    None                                       **
  **                                                                        **
  ***************************************************************************/
-int emm_recv_attach_complete(
+status_code_e emm_recv_attach_complete(
     mme_ue_s1ap_id_t ue_id, const attach_complete_msg* msg, int* emm_cause,
     const nas_message_decode_status_t* status) {
   OAILOG_FUNC_IN(LOG_NAS_EMM);
@@ -512,7 +512,7 @@ int emm_recv_attach_complete(
  **      Others:    None                                       **
  **                                                                        **
  ***************************************************************************/
-int emm_recv_detach_request(
+status_code_e emm_recv_detach_request(
     mme_ue_s1ap_id_t ue_id, const detach_request_msg* msg,
     const bool is_initial, int* emm_cause,
     const nas_message_decode_status_t* status) {
@@ -582,7 +582,7 @@ int emm_recv_detach_request(
  **              Others:        None                                       **
  **                                                                        **
  ***************************************************************************/
-int emm_recv_tracking_area_update_request(
+status_code_e emm_recv_tracking_area_update_request(
     const mme_ue_s1ap_id_t ue_id, tracking_area_update_request_msg* const msg,
     const bool is_initial, const tac_t const tac, int* const emm_cause,
     const nas_message_decode_status_t* const decode_status) {
@@ -733,7 +733,7 @@ int emm_recv_tracking_area_update_request(
  **              Others:        None                                       **
  **                                                                        **
  ***************************************************************************/
-int emm_recv_service_request(
+status_code_e emm_recv_service_request(
     mme_ue_s1ap_id_t ue_id, const service_request_msg* msg,
     const bool is_initial, int* emm_cause,
     const nas_message_decode_status_t* decode_status) {
@@ -829,7 +829,7 @@ int emm_recv_service_request(
  **              Others:        None                                       **
  **                                                                        **
  ***************************************************************************/
-int emm_recv_ext_service_request(
+status_code_e emm_recv_ext_service_request(
     mme_ue_s1ap_id_t ue_id, const extended_service_request_msg* msg,
     int* emm_cause, const nas_message_decode_status_t* decode_status) {
   int rc = RETURNok;
@@ -877,7 +877,7 @@ int emm_recv_ext_service_request(
  **      Others:    None                                       **
  **                                                                        **
  ***************************************************************************/
-int emm_recv_identity_response(
+status_code_e emm_recv_identity_response(
     mme_ue_s1ap_id_t ue_id, identity_response_msg* msg, int* emm_cause,
     const nas_message_decode_status_t* status) {
   OAILOG_FUNC_IN(LOG_NAS_EMM);
@@ -1000,7 +1000,7 @@ int emm_recv_identity_response(
  **      Others:    None                                       **
  **                                                                        **
  ***************************************************************************/
-int emm_recv_authentication_response(
+status_code_e emm_recv_authentication_response(
     mme_ue_s1ap_id_t ue_id, authentication_response_msg* msg, int* emm_cause,
     const nas_message_decode_status_t* status) {
   OAILOG_FUNC_IN(LOG_NAS_EMM);
@@ -1057,7 +1057,7 @@ int emm_recv_authentication_response(
  **      Others:    None                                       **
  **                                                                        **
  ***************************************************************************/
-int emm_recv_authentication_failure(
+status_code_e emm_recv_authentication_failure(
     mme_ue_s1ap_id_t ue_id, authentication_failure_msg* msg, int* emm_cause,
     const nas_message_decode_status_t* status) {
   OAILOG_FUNC_IN(LOG_NAS_EMM);
@@ -1121,7 +1121,7 @@ int emm_recv_authentication_failure(
  **      Others:    None                                       **
  **                                                                        **
  ***************************************************************************/
-int emm_recv_security_mode_complete(
+status_code_e emm_recv_security_mode_complete(
     mme_ue_s1ap_id_t ue_id, security_mode_complete_msg* msg, int* emm_cause,
     const nas_message_decode_status_t* status) {
   OAILOG_FUNC_IN(LOG_NAS_EMM);
@@ -1183,7 +1183,7 @@ int emm_recv_security_mode_complete(
  **      Others:    None                                                   **
  **                                                                        **
  ***************************************************************************/
-int emm_recv_security_mode_reject(
+status_code_e emm_recv_security_mode_reject(
     mme_ue_s1ap_id_t ue_id, security_mode_reject_msg* msg, int* emm_cause,
     const nas_message_decode_status_t* status) {
   OAILOG_FUNC_IN(LOG_NAS_EMM);
@@ -1242,7 +1242,7 @@ int emm_recv_security_mode_reject(
  **      Others:    None                                                   **
  **                                                                        **
  ***************************************************************************/
-int emm_recv_detach_accept(mme_ue_s1ap_id_t ue_id, int* emm_cause) {
+status_code_e emm_recv_detach_accept(mme_ue_s1ap_id_t ue_id, int* emm_cause) {
   OAILOG_FUNC_IN(LOG_NAS_EMM);
   int rc = RETURNok;
 
@@ -1297,7 +1297,7 @@ static int emm_initiate_default_bearer_re_establishment(
  **      Others:    None                                                   **
  **                                                                        **
  ***************************************************************************/
-int emm_recv_tau_complete(
+status_code_e emm_recv_tau_complete(
     mme_ue_s1ap_id_t ue_id, const tracking_area_update_complete_msg* msg) {
   OAILOG_FUNC_IN(LOG_NAS_EMM);
   int rc;
@@ -1324,7 +1324,7 @@ int emm_recv_tau_complete(
  **          Others:    None                                               **
  **                                                                        **
  ***************************************************************************/
-int emm_recv_uplink_nas_transport(
+status_code_e emm_recv_uplink_nas_transport(
     mme_ue_s1ap_id_t ue_id, uplink_nas_transport_msg* msg, int* emm_cause,
     const nas_message_decode_status_t* status) {
   int rc = RETURNok;

--- a/lte/gateway/c/core/oai/tasks/nas/emm/sap/emm_recv.h
+++ b/lte/gateway/c/core/oai/tasks/nas/emm/sap/emm_recv.h
@@ -55,6 +55,7 @@ Description Defines functions executed at the EMMAS Service Access
 #include "NASSecurityModeComplete.h"
 #include "SecurityModeReject.h"
 #include "UplinkNasTransport.h"
+#include "common_defs.h"
 #include "nas_message.h"
 #include "3gpp_23.003.h"
 #include "3gpp_36.401.h"
@@ -81,75 +82,75 @@ Description Defines functions executed at the EMMAS Service Access
  * Functions executed by the MME upon receiving EMM message from the UE
  * --------------------------------------------------------------------------
  */
-int emm_recv_status(
+status_code_e emm_recv_status(
     mme_ue_s1ap_id_t ueid, emm_status_msg* msg, int* emm_cause,
     const nas_message_decode_status_t* const status);
 
-int emm_recv_attach_request(
+status_code_e emm_recv_attach_request(
     const mme_ue_s1ap_id_t ue_id, const tai_t* const originating_tai,
     const ecgi_t* const originating_ecgi, attach_request_msg* const msg,
     const bool is_initial, const bool ctx_is_new, int* const emm_cause,
     const nas_message_decode_status_t* decode_status);
 
-int emm_recv_attach_complete(
+status_code_e emm_recv_attach_complete(
     const mme_ue_s1ap_id_t ueid, const attach_complete_msg* msg,
     int* const emm_cause,
     const nas_message_decode_status_t* const decode_status);
 
-int emm_recv_detach_request(
+status_code_e emm_recv_detach_request(
     mme_ue_s1ap_id_t ueid, const detach_request_msg* msg, const bool is_initial,
     int* const emm_cause,
     const nas_message_decode_status_t* const decode_status);
 
-int emm_recv_tracking_area_update_request(
+status_code_e emm_recv_tracking_area_update_request(
     const mme_ue_s1ap_id_t ueid, tracking_area_update_request_msg* const msg,
     const bool is_initial, tac_t tac, int* const emm_cause,
     const nas_message_decode_status_t* const decode_status);
 
-int emm_recv_service_request(
+status_code_e emm_recv_service_request(
     mme_ue_s1ap_id_t ueid, const service_request_msg* msg,
     const bool is_initial, int* const emm_cause,
     const nas_message_decode_status_t* const decode_status);
 
-int emm_recv_initial_ext_service_request(
+status_code_e emm_recv_initial_ext_service_request(
     mme_ue_s1ap_id_t ue_id, const extended_service_request_msg* msg,
     int* emm_cause, const nas_message_decode_status_t* decode_status);
 
-int emm_recv_ext_service_request(
+status_code_e emm_recv_ext_service_request(
     mme_ue_s1ap_id_t ue_id, const extended_service_request_msg* msg,
     int* emm_cause, const nas_message_decode_status_t* decode_status);
 
-int emm_recv_identity_response(
+status_code_e emm_recv_identity_response(
     const mme_ue_s1ap_id_t ueid, identity_response_msg* msg,
     int* const emm_cause,
     const nas_message_decode_status_t* const decode_status);
 
-int emm_recv_authentication_response(
+status_code_e emm_recv_authentication_response(
     const mme_ue_s1ap_id_t ueid, authentication_response_msg* msg,
     int* const emm_cause,
     const nas_message_decode_status_t* const decode_status);
 
-int emm_recv_authentication_failure(
+status_code_e emm_recv_authentication_failure(
     const mme_ue_s1ap_id_t ueid, authentication_failure_msg* msg,
     int* const emm_cause,
     const nas_message_decode_status_t* const decode_status);
 
-int emm_recv_security_mode_complete(
+status_code_e emm_recv_security_mode_complete(
     const mme_ue_s1ap_id_t ueid, security_mode_complete_msg* msg,
     int* const emm_cause,
     const nas_message_decode_status_t* const decode_status);
 
-int emm_recv_security_mode_reject(
+status_code_e emm_recv_security_mode_reject(
     const mme_ue_s1ap_id_t ueid, security_mode_reject_msg* msg,
     int* const emm_cause,
     const nas_message_decode_status_t* const decode_status);
 
-int emm_recv_detach_accept(mme_ue_s1ap_id_t ueid, int* emm_cause);
+status_code_e emm_recv_detach_accept(mme_ue_s1ap_id_t ueid, int* emm_cause);
 
-int emm_recv_tau_complete(
+status_code_e emm_recv_tau_complete(
     mme_ue_s1ap_id_t ue_id, const tracking_area_update_complete_msg* msg);
 
-int emm_recv_uplink_nas_transport(
+status_code_e emm_recv_uplink_nas_transport(
     mme_ue_s1ap_id_t ueid, uplink_nas_transport_msg* msg, int* emm_cause,
     const nas_message_decode_status_t* status);
 #endif /* FILE_EMM_RECV_SEEN*/

--- a/lte/gateway/c/core/oai/tasks/nas/emm/sap/emm_reg.c
+++ b/lte/gateway/c/core/oai/tasks/nas/emm/sap/emm_reg.c
@@ -71,7 +71,7 @@ void emm_reg_initialize(void) {
  **      Others:    None                                       **
  **                                                                        **
  ***************************************************************************/
-int emm_reg_send(emm_reg_t* const msg) {
+status_code_e emm_reg_send(emm_reg_t* const msg) {
   OAILOG_FUNC_IN(LOG_NAS_EMM);
   int rc = RETURNok;
 

--- a/lte/gateway/c/core/oai/tasks/nas/emm/sap/emm_reg.h
+++ b/lte/gateway/c/core/oai/tasks/nas/emm/sap/emm_reg.h
@@ -37,6 +37,7 @@ Description Defines the EMMREG Service Access Point that provides
 #ifndef FILE_EMM_REG_SEEN
 #define FILE_EMM_REG_SEEN
 
+#include "common_defs.h"
 #include "emm_regDef.h"
 
 /****************************************************************************/
@@ -57,6 +58,6 @@ Description Defines the EMMREG Service Access Point that provides
 
 void emm_reg_initialize(void);
 
-int emm_reg_send(emm_reg_t* const msg);
+status_code_e emm_reg_send(emm_reg_t* const msg);
 
 #endif /* FILE_EMM_REG_SEEN*/

--- a/lte/gateway/c/core/oai/tasks/nas/emm/sap/emm_sap.c
+++ b/lte/gateway/c/core/oai/tasks/nas/emm/sap/emm_sap.c
@@ -71,7 +71,7 @@ void emm_sap_initialize(void) {
  **      Others:    None                                       **
  **                                                                        **
  ***************************************************************************/
-int emm_sap_send(emm_sap_t* msg) {
+status_code_e emm_sap_send(emm_sap_t* msg) {
   int rc                    = RETURNerror;
   emm_primitive_t primitive = msg->primitive;
 

--- a/lte/gateway/c/core/oai/tasks/nas/emm/sap/emm_sap.h
+++ b/lte/gateway/c/core/oai/tasks/nas/emm/sap/emm_sap.h
@@ -38,6 +38,7 @@ Description Defines the EMM Service Access Points at which the EPS
 #ifndef FILE_EMM_SAP_SEEN
 #define FILE_EMM_SAP_SEEN
 
+#include "common_defs.h"
 #include "emm_data.h"
 #include "emm_regDef.h"
 #include "emm_esmDef.h"
@@ -166,6 +167,6 @@ typedef struct emm_sap_s {
 
 void emm_sap_initialize(void);
 
-int emm_sap_send(emm_sap_t* msg);
+status_code_e emm_sap_send(emm_sap_t* msg);
 
 #endif /* FILE_EMM_SAP_SEEN*/

--- a/lte/gateway/c/core/oai/tasks/nas/emm/sap/emm_send.c
+++ b/lte/gateway/c/core/oai/tasks/nas/emm/sap/emm_send.c
@@ -92,7 +92,8 @@
  **      Others:    None                                       **
  **                                                                        **
  ***************************************************************************/
-int emm_send_status(const emm_as_status_t* msg, emm_status_msg* emm_msg) {
+status_code_e emm_send_status(
+    const emm_as_status_t* msg, emm_status_msg* emm_msg) {
   OAILOG_FUNC_IN(LOG_NAS_EMM);
   int size = EMM_HEADER_MAXIMUM_LENGTH;
 
@@ -129,7 +130,7 @@ int emm_send_status(const emm_as_status_t* msg, emm_status_msg* emm_msg) {
  **      Others:    None                                       **
  **                                                                        **
  ***************************************************************************/
-int emm_send_detach_accept(
+status_code_e emm_send_detach_accept(
     const emm_as_data_t* msg, detach_accept_msg* emm_msg) {
   OAILOG_FUNC_IN(LOG_NAS_EMM);
   int size = EMM_HEADER_MAXIMUM_LENGTH;
@@ -158,7 +159,7 @@ int emm_send_detach_accept(
  **      Others:    None                                                   **
  **                                                                        **
  ***************************************************************************/
-int emm_send_nw_detach_request(
+status_code_e emm_send_nw_detach_request(
     const emm_as_data_t* msg, nw_detach_request_msg* emm_msg) {
   OAILOG_FUNC_IN(LOG_NAS_EMM);
   int size = EMM_HEADER_MAXIMUM_LENGTH;
@@ -205,7 +206,7 @@ int emm_send_nw_detach_request(
  **      Others:    None                                       **
  **                                                                        **
  ***************************************************************************/
-int emm_send_attach_accept(
+status_code_e emm_send_attach_accept(
     const emm_as_establish_t* msg, attach_accept_msg* emm_msg) {
   OAILOG_FUNC_IN(LOG_NAS_EMM);
   int size = EMM_HEADER_MAXIMUM_LENGTH;
@@ -518,7 +519,7 @@ int emm_send_attach_accept(
  **      Others:    None                                                   **
  **                                                                        **
  ***************************************************************************/
-int emm_send_attach_accept_dl_nas(
+status_code_e emm_send_attach_accept_dl_nas(
     const emm_as_data_t* msg, attach_accept_msg* emm_msg) {
   OAILOG_FUNC_IN(LOG_NAS_EMM);
   int size = EMM_HEADER_MAXIMUM_LENGTH;
@@ -772,7 +773,7 @@ int emm_send_attach_accept_dl_nas(
  **      Others:    None                                       **
  **                                                                        **
  ***************************************************************************/
-int emm_send_attach_reject(
+status_code_e emm_send_attach_reject(
     const emm_as_establish_t* msg, attach_reject_msg* emm_msg) {
   OAILOG_FUNC_IN(LOG_NAS_EMM);
   int size = EMM_HEADER_MAXIMUM_LENGTH;
@@ -825,7 +826,7 @@ int emm_send_attach_reject(
  **              Others:        None                                       **
  **                                                                        **
  ***************************************************************************/
-int emm_send_tracking_area_update_accept(
+status_code_e emm_send_tracking_area_update_accept(
     const emm_as_establish_t* msg, tracking_area_update_accept_msg* emm_msg) {
   OAILOG_FUNC_IN(LOG_NAS_EMM);
   int size = EMM_HEADER_MAXIMUM_LENGTH;
@@ -1098,7 +1099,7 @@ int emm_send_tracking_area_update_accept(
  **                                                                        **
  ***************************************************************************/
 
-int emm_send_tracking_area_update_accept_dl_nas(
+status_code_e emm_send_tracking_area_update_accept_dl_nas(
     const emm_as_data_t* msg, tracking_area_update_accept_msg* emm_msg) {
   OAILOG_FUNC_IN(LOG_NAS_EMM);
   int size = EMM_HEADER_MAXIMUM_LENGTH;
@@ -1208,7 +1209,7 @@ int emm_send_tracking_area_update_accept_dl_nas(
  **              Others:        None                                       **
  **                                                                        **
  ***************************************************************************/
-int emm_send_tracking_area_update_reject(
+status_code_e emm_send_tracking_area_update_reject(
     const emm_as_establish_t* msg, tracking_area_update_reject_msg* emm_msg) {
   OAILOG_FUNC_IN(LOG_NAS_EMM);
   int size = EMM_HEADER_MAXIMUM_LENGTH;
@@ -1247,7 +1248,7 @@ int emm_send_tracking_area_update_reject(
  **              Others:        None                                       **
  **                                                                        **
  ***************************************************************************/
-int emm_send_service_reject(
+status_code_e emm_send_service_reject(
     const uint8_t emm_cause, service_reject_msg* emm_msg) {
   OAILOG_FUNC_IN(LOG_NAS_EMM);
   int size = EMM_HEADER_MAXIMUM_LENGTH;
@@ -1285,7 +1286,7 @@ int emm_send_service_reject(
  **      Others:    None                                       **
  **                                                                        **
  ***************************************************************************/
-int emm_send_identity_request(
+status_code_e emm_send_identity_request(
     const emm_as_security_t* msg, identity_request_msg* emm_msg) {
   OAILOG_FUNC_IN(LOG_NAS_EMM);
   int size = EMM_HEADER_MAXIMUM_LENGTH;
@@ -1338,7 +1339,7 @@ int emm_send_identity_request(
  **      Others:    None                                       **
  **                                                                        **
  ***************************************************************************/
-int emm_send_authentication_request(
+status_code_e emm_send_authentication_request(
     const emm_as_security_t* msg, authentication_request_msg* emm_msg) {
   OAILOG_FUNC_IN(LOG_NAS_EMM);
   int size = EMM_HEADER_MAXIMUM_LENGTH;
@@ -1424,7 +1425,8 @@ void emm_free_send_authentication_request(authentication_request_msg* emm_msg) {
  **      Others:    None                                       **
  **                                                                        **
  ***************************************************************************/
-int emm_send_authentication_reject(authentication_reject_msg* emm_msg) {
+status_code_e emm_send_authentication_reject(
+    authentication_reject_msg* emm_msg) {
   OAILOG_FUNC_IN(LOG_NAS_EMM);
   int size = EMM_HEADER_MAXIMUM_LENGTH;
 
@@ -1453,7 +1455,7 @@ int emm_send_authentication_reject(authentication_reject_msg* emm_msg) {
  **      Others:    None                                       **
  **                                                                        **
  ***************************************************************************/
-int emm_send_security_mode_command(
+status_code_e emm_send_security_mode_command(
     const emm_as_security_t* msg, security_mode_command_msg* emm_msg) {
   OAILOG_FUNC_IN(LOG_NAS_EMM);
   int size = EMM_HEADER_MAXIMUM_LENGTH;
@@ -1546,7 +1548,7 @@ int emm_send_security_mode_command(
  **              Others:        None                                       **
  **                                                                        **
  ***************************************************************************/
-int emm_send_emm_information(
+status_code_e emm_send_emm_information(
     const emm_as_data_t* msg, emm_information_msg* emm_msg) {
   OAILOG_FUNC_IN(LOG_NAS_EMM);
   char string[MAX_MINUTE_DIGITS] = {0};
@@ -1692,7 +1694,7 @@ int emm_send_emm_information(
  **                                                                        **
  ***************************************************************************/
 
-int emm_send_dl_nas_transport(
+status_code_e emm_send_dl_nas_transport(
     const emm_as_data_t* msg, downlink_nas_transport_msg* emm_msg) {
   OAILOG_FUNC_IN(LOG_NAS_EMM);
   int size = EMM_HEADER_MAXIMUM_LENGTH;
@@ -1744,7 +1746,7 @@ void emm_free_send_emm_information(emm_information_msg* emm_msg) {
  ** Outputs:            Returns the Timezone numerical format              **
  **                                                                        **
  ***************************************************************************/
-int get_time_zone(void) {
+status_code_e get_time_zone(void) {
   char timestr[20]               = {0};
   char string[MAX_MINUTE_DIGITS] = {0};
   time_t t;

--- a/lte/gateway/c/core/oai/tasks/nas/emm/sap/emm_send.h
+++ b/lte/gateway/c/core/oai/tasks/nas/emm/sap/emm_send.h
@@ -55,6 +55,7 @@ Description Defines functions executed at the EMMAS Service Access
 #include "EmmInformation.h"
 #include "DownlinkNasTransport.h"
 #include "CsServiceNotification.h"
+#include "common_defs.h"
 #include "emm_asDef.h"
 
 /****************************************************************************/
@@ -78,39 +79,44 @@ Description Defines functions executed at the EMMAS Service Access
  * Functions executed by the MME to send EMM messages to the UE
  * --------------------------------------------------------------------------
  */
-int emm_send_status(const emm_as_status_t*, emm_status_msg*);
+status_code_e emm_send_status(const emm_as_status_t*, emm_status_msg*);
 
-int emm_send_detach_accept(const emm_as_data_t*, detach_accept_msg*);
+status_code_e emm_send_detach_accept(const emm_as_data_t*, detach_accept_msg*);
 
-int emm_send_attach_accept(const emm_as_establish_t*, attach_accept_msg*);
-int emm_send_attach_accept_dl_nas(const emm_as_data_t* msg, attach_accept_msg*);
-int emm_send_attach_reject(const emm_as_establish_t*, attach_reject_msg*);
+status_code_e emm_send_attach_accept(
+    const emm_as_establish_t*, attach_accept_msg*);
+status_code_e emm_send_attach_accept_dl_nas(
+    const emm_as_data_t* msg, attach_accept_msg*);
+status_code_e emm_send_attach_reject(
+    const emm_as_establish_t*, attach_reject_msg*);
 
-int emm_send_tracking_area_update_reject(
+status_code_e emm_send_tracking_area_update_reject(
     const emm_as_establish_t* msg, tracking_area_update_reject_msg* emm_msg);
-int emm_send_tracking_area_update_accept(
+status_code_e emm_send_tracking_area_update_accept(
     const emm_as_establish_t* msg, tracking_area_update_accept_msg* emm_msg);
 
-int emm_send_tracking_area_update_accept_dl_nas(
+status_code_e emm_send_tracking_area_update_accept_dl_nas(
     const emm_as_data_t* msg, tracking_area_update_accept_msg* emm_msg);
 
-int emm_send_service_reject(
+status_code_e emm_send_service_reject(
     const uint8_t emm_cause, service_reject_msg* emm_msg);
 
-int emm_send_identity_request(const emm_as_security_t*, identity_request_msg*);
-int emm_send_authentication_request(
+status_code_e emm_send_identity_request(
+    const emm_as_security_t*, identity_request_msg*);
+status_code_e emm_send_authentication_request(
     const emm_as_security_t*, authentication_request_msg*);
 void emm_free_send_authentication_request(authentication_request_msg*);
-int emm_send_authentication_reject(authentication_reject_msg*);
-int emm_send_security_mode_command(
+status_code_e emm_send_authentication_reject(authentication_reject_msg*);
+status_code_e emm_send_security_mode_command(
     const emm_as_security_t*, security_mode_command_msg*);
-int emm_send_emm_information(
+status_code_e emm_send_emm_information(
     const emm_as_data_t* msg, emm_information_msg* emm_msg);
 void emm_free_send_emm_information(emm_information_msg* emm_msg);
 
-int emm_send_nw_detach_request(const emm_as_data_t*, nw_detach_request_msg*);
+status_code_e emm_send_nw_detach_request(
+    const emm_as_data_t*, nw_detach_request_msg*);
 
-int emm_send_dl_nas_transport(
+status_code_e emm_send_dl_nas_transport(
     const emm_as_data_t*, downlink_nas_transport_msg*);
 void emm_free_send_dl_nas_transport(downlink_nas_transport_msg* emm_msg);
 

--- a/lte/gateway/c/core/oai/tasks/nas/esm/DedicatedEpsBearerContextActivation.c
+++ b/lte/gateway/c/core/oai/tasks/nas/esm/DedicatedEpsBearerContextActivation.c
@@ -98,7 +98,7 @@ static void erab_setup_rsp_tmr_exp_ded_bearer_handler(
  **      Others:    None                                                   **
  **                                                                        **
  ***************************************************************************/
-int esm_proc_dedicated_eps_bearer_context(
+status_code_e esm_proc_dedicated_eps_bearer_context(
     emm_context_t* emm_context, const proc_tid_t pti, pdn_cid_t pid, ebi_t* ebi,
     ebi_t* default_ebi, const qci_t qci, const bitrate_t gbr_dl,
     const bitrate_t gbr_ul, const bitrate_t mbr_dl, const bitrate_t mbr_ul,
@@ -179,7 +179,7 @@ int esm_proc_dedicated_eps_bearer_context(
  **      Others:    None                                                   **
  **                                                                        **
  ***************************************************************************/
-int esm_proc_dedicated_eps_bearer_context_request(
+status_code_e esm_proc_dedicated_eps_bearer_context_request(
     bool is_standalone, emm_context_t* emm_context, ebi_t ebi,
     STOLEN_REF bstring* msg, bool ue_triggered) {
   OAILOG_FUNC_IN(LOG_NAS_ESM);
@@ -243,7 +243,7 @@ int esm_proc_dedicated_eps_bearer_context_request(
  **      Others:    None                                                   **
  **                                                                        **
  ***************************************************************************/
-int esm_proc_dedicated_eps_bearer_context_accept(
+status_code_e esm_proc_dedicated_eps_bearer_context_accept(
     emm_context_t* emm_context, ebi_t ebi, esm_cause_t* esm_cause) {
   OAILOG_FUNC_IN(LOG_NAS_ESM);
   int rc                        = RETURNerror;
@@ -332,7 +332,7 @@ int esm_proc_dedicated_eps_bearer_context_accept(
  **      Others:    None                                                   **
  **                                                                        **
  ***************************************************************************/
-int esm_proc_dedicated_eps_bearer_context_reject(
+status_code_e esm_proc_dedicated_eps_bearer_context_reject(
     emm_context_t* emm_context, ebi_t ebi) {
   OAILOG_FUNC_IN(LOG_NAS_ESM);
   int rc;

--- a/lte/gateway/c/core/oai/tasks/nas/esm/DefaultEpsBearerContextActivation.c
+++ b/lte/gateway/c/core/oai/tasks/nas/esm/DefaultEpsBearerContextActivation.c
@@ -95,7 +95,7 @@ static int default_eps_bearer_activate_in_bearer_setup_req(
  **      Others:    None                                       **
  **                                                                        **
  ***************************************************************************/
-int esm_proc_default_eps_bearer_context(
+status_code_e esm_proc_default_eps_bearer_context(
     emm_context_t* emm_context, const proc_tid_t pti, pdn_cid_t pid, ebi_t* ebi,
     const qci_t qci, esm_cause_t* esm_cause) {
   OAILOG_FUNC_IN(LOG_NAS_ESM);
@@ -176,7 +176,7 @@ int esm_proc_default_eps_bearer_context(
  **      Others:    None                                       **
  **                                                                        **
  ***************************************************************************/
-int esm_proc_default_eps_bearer_context_request(
+status_code_e esm_proc_default_eps_bearer_context_request(
     bool is_standalone, emm_context_t* emm_context, ebi_t ebi,
     STOLEN_REF bstring* msg, bool ue_triggered) {
   OAILOG_FUNC_IN(LOG_NAS_ESM);
@@ -254,7 +254,7 @@ int esm_proc_default_eps_bearer_context_request(
  **      Others:    None                                       **
  **                                                                        **
  ***************************************************************************/
-int esm_proc_default_eps_bearer_context_accept(
+status_code_e esm_proc_default_eps_bearer_context_accept(
     emm_context_t* emm_context, ebi_t ebi, esm_cause_t* esm_cause) {
   OAILOG_FUNC_IN(LOG_NAS_ESM);
   int rc;
@@ -316,7 +316,7 @@ int esm_proc_default_eps_bearer_context_accept(
  **      Others:    None                                       **
  **                                                                        **
  ***************************************************************************/
-int esm_proc_default_eps_bearer_context_reject(
+status_code_e esm_proc_default_eps_bearer_context_reject(
     emm_context_t* emm_context, ebi_t ebi, esm_cause_t* esm_cause) {
   OAILOG_FUNC_IN(LOG_NAS_ESM);
   int rc;
@@ -399,7 +399,7 @@ int esm_proc_default_eps_bearer_context_reject(
  **      Others:    None                                       **
  **                                                                        **
  ***************************************************************************/
-int esm_proc_default_eps_bearer_context_failure(
+status_code_e esm_proc_default_eps_bearer_context_failure(
     emm_context_t* emm_context, pdn_cid_t* const pid) {
   OAILOG_FUNC_IN(LOG_NAS_ESM);
   int rc = RETURNerror;

--- a/lte/gateway/c/core/oai/tasks/nas/esm/EpsBearerContextDeactivation.c
+++ b/lte/gateway/c/core/oai/tasks/nas/esm/EpsBearerContextDeactivation.c
@@ -104,7 +104,7 @@ extern int pdn_connectivity_delete(emm_context_t* emm_context, pdn_cid_t pid);
  **      Others:    None                                       **
  **                                                                        **
  ***************************************************************************/
-int esm_proc_eps_bearer_context_deactivate(
+status_code_e esm_proc_eps_bearer_context_deactivate(
     emm_context_t* const emm_context_p, const bool is_local, const ebi_t ebi,
     pdn_cid_t* pid, int* const bidx, esm_cause_t* const esm_cause) {
   OAILOG_FUNC_IN(LOG_NAS_ESM);
@@ -207,7 +207,7 @@ int esm_proc_eps_bearer_context_deactivate(
  **      Others:    None                                       **
  **                                                                        **
  ***************************************************************************/
-int esm_proc_eps_bearer_context_deactivate_request(
+status_code_e esm_proc_eps_bearer_context_deactivate_request(
     const bool is_standalone, emm_context_t* const emm_context_p,
     const ebi_t ebi, STOLEN_REF bstring* msg, const bool ue_triggered) {
   OAILOG_FUNC_IN(LOG_NAS_ESM);
@@ -593,7 +593,7 @@ static int eps_bearer_deactivate(
  **      Others:    None                                       **
  **                                                                        **
  ***************************************************************************/
-int eps_bearer_release(
+status_code_e eps_bearer_release(
     emm_context_t* emm_context_p, ebi_t ebi, pdn_cid_t* pid, int* bidx) {
   OAILOG_FUNC_IN(LOG_NAS_ESM);
   int rc = RETURNerror;

--- a/lte/gateway/c/core/oai/tasks/nas/esm/EsmStatusHdl.c
+++ b/lte/gateway/c/core/oai/tasks/nas/esm/EsmStatusHdl.c
@@ -68,7 +68,7 @@
  **      Others:    None                                       **
  **                                                                        **
  ***************************************************************************/
-int esm_proc_status_ind(
+status_code_e esm_proc_status_ind(
     emm_context_t* emm_context, proc_tid_t pti, ebi_t ebi,
     esm_cause_t* esm_cause) {
   OAILOG_FUNC_IN(LOG_NAS_ESM);
@@ -147,7 +147,7 @@ int esm_proc_status_ind(
  **      Others:    None                                       **
  **                                                                        **
  ***************************************************************************/
-int esm_proc_status(
+status_code_e esm_proc_status(
     const bool is_standalone, emm_context_t* const emm_context, const ebi_t ebi,
     STOLEN_REF bstring* msg, const bool ue_triggered) {
   OAILOG_FUNC_IN(LOG_NAS_ESM);

--- a/lte/gateway/c/core/oai/tasks/nas/esm/PdnConnectivity.c
+++ b/lte/gateway/c/core/oai/tasks/nas/esm/PdnConnectivity.c
@@ -116,7 +116,7 @@ proc_tid_t pdn_connectivity_delete(
  **      Others:    _esm_data                                  **
  **                                                                        **
  ***************************************************************************/
-int esm_proc_pdn_connectivity_request(
+status_code_e esm_proc_pdn_connectivity_request(
     emm_context_t* emm_context, const proc_tid_t pti, const pdn_cid_t pdn_cid,
     const context_identifier_t context_identifier,
     const esm_proc_pdn_request_t request_type, const_bstring const apn,
@@ -204,7 +204,7 @@ int esm_proc_pdn_connectivity_request(
  **      Others:    None                                       **
  **                                                                        **
  ***************************************************************************/
-int esm_proc_pdn_connectivity_reject(
+status_code_e esm_proc_pdn_connectivity_reject(
     bool is_standalone, emm_context_t* emm_context, ebi_t ebi,
     STOLEN_REF bstring* msg, bool ue_triggered) {
   OAILOG_FUNC_IN(LOG_NAS_ESM);
@@ -262,7 +262,7 @@ int esm_proc_pdn_connectivity_reject(
  **                  Others:    None                                       **
  **                                                                        **
  ***************************************************************************/
-int esm_proc_pdn_connectivity_failure(
+status_code_e esm_proc_pdn_connectivity_failure(
     emm_context_t* emm_context, pdn_cid_t pdn_cid) {
   OAILOG_FUNC_IN(LOG_NAS_ESM);
   proc_tid_t pti = ESM_PT_UNASSIGNED;

--- a/lte/gateway/c/core/oai/tasks/nas/esm/PdnDisconnect.c
+++ b/lte/gateway/c/core/oai/tasks/nas/esm/PdnDisconnect.c
@@ -88,7 +88,7 @@ static int pdn_disconnect_get_pid(emm_context_t* emm_context, proc_tid_t pti);
  **      Others:    None                                       **
  **                                                                        **
  ***************************************************************************/
-int esm_proc_pdn_disconnect_request(
+status_code_e esm_proc_pdn_disconnect_request(
     emm_context_t* emm_context, proc_tid_t pti, esm_cause_t* esm_cause) {
   OAILOG_FUNC_IN(LOG_NAS_ESM);
   pdn_cid_t pid = RETURNerror;
@@ -154,7 +154,7 @@ int esm_proc_pdn_disconnect_request(
  **      Others:    None                                       **
  **                                                                        **
  ***************************************************************************/
-int esm_proc_pdn_disconnect_accept(
+status_code_e esm_proc_pdn_disconnect_accept(
     emm_context_t* emm_context, pdn_cid_t pid, esm_cause_t* esm_cause) {
   OAILOG_FUNC_IN(LOG_NAS_ESM);
   mme_ue_s1ap_id_t ue_id =
@@ -210,7 +210,7 @@ int esm_proc_pdn_disconnect_accept(
  **      Others:    None                                       **
  **                                                                        **
  ***************************************************************************/
-int esm_proc_pdn_disconnect_reject(
+status_code_e esm_proc_pdn_disconnect_reject(
     const bool is_standalone, emm_context_t* emm_context, ebi_t ebi,
     STOLEN_REF bstring* msg, const bool ue_triggered) {
   OAILOG_FUNC_IN(LOG_NAS_ESM);

--- a/lte/gateway/c/core/oai/tasks/nas/esm/esm_ebr.c
+++ b/lte/gateway/c/core/oai/tasks/nas/esm/esm_ebr.c
@@ -111,7 +111,7 @@ void esm_ebr_initialize(void) {
  **      Others:    _esm_ebr_data                                          **
  **                                                                        **
  ***************************************************************************/
-int esm_ebr_assign(emm_context_t* emm_context) {
+status_code_e esm_ebr_assign(emm_context_t* emm_context) {
   OAILOG_FUNC_IN(LOG_NAS_ESM);
   ue_mm_context_t* ue_context_p =
       PARENT_STRUCT(emm_context, struct ue_mm_context_s, emm_context);
@@ -147,7 +147,7 @@ int esm_ebr_assign(emm_context_t* emm_context) {
  **      Others:    _esm_ebr_data                              **
  **                                                                        **
  ***************************************************************************/
-int esm_ebr_release(emm_context_t* emm_context, ebi_t ebi) {
+status_code_e esm_ebr_release(emm_context_t* emm_context, ebi_t ebi) {
   OAILOG_FUNC_IN(LOG_NAS_ESM);
   esm_ebr_context_t* ebr_ctx       = NULL;
   bearer_context_t* bearer_context = NULL;
@@ -239,7 +239,7 @@ int esm_ebr_release(emm_context_t* emm_context, ebi_t ebi) {
  **      Others:    _esm_ebr_data                              **
  **                                                                        **
  ***************************************************************************/
-int esm_ebr_start_timer(
+status_code_e esm_ebr_start_timer(
     emm_context_t* emm_context, ebi_t ebi, CLONE_REF const_bstring msg,
     uint32_t sec, nas_timer_callback_t cb) {
   OAILOG_FUNC_IN(LOG_NAS_ESM);
@@ -352,7 +352,7 @@ int esm_ebr_start_timer(
  **      Others:    _esm_ebr_data                              **
  **                                                                        **
  ***************************************************************************/
-int esm_ebr_stop_timer(emm_context_t* emm_context, ebi_t ebi) {
+status_code_e esm_ebr_stop_timer(emm_context_t* emm_context, ebi_t ebi) {
   esm_ebr_context_t* ebr_ctx       = NULL;
   bearer_context_t* bearer_context = NULL;
 
@@ -474,7 +474,7 @@ ebi_t esm_ebr_get_pending_ebi(
  **      Others:    _esm_ebr_data                              **
  **                                                                        **
  ***************************************************************************/
-int esm_ebr_set_status(
+status_code_e esm_ebr_set_status(
     emm_context_t* emm_context, ebi_t ebi, esm_ebr_state status,
     bool ue_requested) {
   bearer_context_t* bearer_context = NULL;

--- a/lte/gateway/c/core/oai/tasks/nas/esm/esm_ebr.h
+++ b/lte/gateway/c/core/oai/tasks/nas/esm/esm_ebr.h
@@ -70,17 +70,17 @@ const char* esm_ebr_state2string(esm_ebr_state esm_ebr_state);
 bool esm_ebr_is_reserved(ebi_t ebi);
 
 void esm_ebr_initialize(void);
-int esm_ebr_assign(emm_context_t* emm_context);
-int esm_ebr_release(emm_context_t* emm_context, ebi_t ebi);
+status_code_e esm_ebr_assign(emm_context_t* emm_context);
+status_code_e esm_ebr_release(emm_context_t* emm_context, ebi_t ebi);
 
-int esm_ebr_start_timer(
+status_code_e esm_ebr_start_timer(
     emm_context_t* emm_context, ebi_t ebi, CLONE_REF const_bstring msg,
     uint32_t sec, nas_timer_callback_t cb);
-int esm_ebr_stop_timer(emm_context_t* emm_context, ebi_t ebi);
+status_code_e esm_ebr_stop_timer(emm_context_t* emm_context, ebi_t ebi);
 
 ebi_t esm_ebr_get_pending_ebi(emm_context_t* emm_context, esm_ebr_state status);
 
-int esm_ebr_set_status(
+status_code_e esm_ebr_set_status(
     emm_context_t* emm_context, ebi_t ebi, esm_ebr_state status,
     bool ue_requested);
 esm_ebr_state esm_ebr_get_status(emm_context_t* emm_context, ebi_t ebi);

--- a/lte/gateway/c/core/oai/tasks/nas/esm/esm_information.c
+++ b/lte/gateway/c/core/oai/tasks/nas/esm/esm_information.c
@@ -62,7 +62,7 @@ static int esm_information(
 /****************************************************************************/
 
 //------------------------------------------------------------------------------
-int esm_proc_esm_information_request(
+status_code_e esm_proc_esm_information_request(
     emm_context_t* const emm_context_p, const pti_t pti) {
   OAILOG_FUNC_IN(LOG_NAS_ESM);
   int rc;
@@ -106,7 +106,7 @@ int esm_proc_esm_information_request(
 }
 
 //------------------------------------------------------------------------------
-int esm_proc_esm_information_response(
+status_code_e esm_proc_esm_information_response(
     emm_context_t* emm_context_p, pti_t pti, const_bstring const apn,
     const protocol_configuration_options_t* const pco,
     esm_cause_t* const esm_cause) {

--- a/lte/gateway/c/core/oai/tasks/nas/esm/esm_proc.h
+++ b/lte/gateway/c/core/oai/tasks/nas/esm/esm_proc.h
@@ -98,10 +98,10 @@ typedef struct esm_proc_data_s {
  * --------------------------------------------------------------------------
  */
 
-int esm_proc_status_ind(
+status_code_e esm_proc_status_ind(
     emm_context_t* emm_context, const proc_tid_t pti, ebi_t ebi,
     esm_cause_t* esm_cause);
-int esm_proc_status(
+status_code_e esm_proc_status(
     const bool is_standalone, emm_context_t* const emm_context, const ebi_t ebi,
     bstring* msg, const bool sent_by_ue);
 
@@ -111,7 +111,7 @@ int esm_proc_status(
  * --------------------------------------------------------------------------
  */
 
-int esm_proc_pdn_connectivity_request(
+status_code_e esm_proc_pdn_connectivity_request(
     emm_context_t* emm_context, const proc_tid_t pti, const pdn_cid_t pdn_cid,
     const context_identifier_t context_identifier,
     const esm_proc_pdn_request_t request_type, const_bstring const apn,
@@ -119,10 +119,10 @@ int esm_proc_pdn_connectivity_request(
     bearer_qos_t* default_qos, protocol_configuration_options_t* const pco,
     esm_cause_t* esm_cause);
 
-int esm_proc_pdn_connectivity_reject(
+status_code_e esm_proc_pdn_connectivity_reject(
     bool is_standalone, emm_context_t* emm_context, ebi_t ebi, bstring* msg,
     bool ue_triggered);
-int esm_proc_pdn_connectivity_failure(
+status_code_e esm_proc_pdn_connectivity_failure(
     emm_context_t* emm_context, pdn_cid_t pid);
 
 /*
@@ -131,12 +131,12 @@ int esm_proc_pdn_connectivity_failure(
  * --------------------------------------------------------------------------
  */
 
-int esm_proc_pdn_disconnect_request(
+status_code_e esm_proc_pdn_disconnect_request(
     emm_context_t* emm_context, const proc_tid_t pti, esm_cause_t* esm_cause);
 
-int esm_proc_pdn_disconnect_accept(
+status_code_e esm_proc_pdn_disconnect_accept(
     emm_context_t* emm_context, pdn_cid_t pid, esm_cause_t* esm_cause);
-int esm_proc_pdn_disconnect_reject(
+status_code_e esm_proc_pdn_disconnect_reject(
     const bool is_standalone, emm_context_t* emm_context, ebi_t ebi,
     bstring* msg, const bool ue_triggered);
 
@@ -146,10 +146,10 @@ int esm_proc_pdn_disconnect_reject(
  * --------------------------------------------------------------------------
  */
 
-int esm_proc_esm_information_request(
+status_code_e esm_proc_esm_information_request(
     emm_context_t* const emm_context_p, const pti_t pti);
 
-int esm_proc_esm_information_response(
+status_code_e esm_proc_esm_information_response(
     emm_context_t* emm_context_p, pti_t pti, const_bstring const apn,
     const protocol_configuration_options_t* const pco,
     esm_cause_t* const esm_cause);
@@ -159,18 +159,18 @@ int esm_proc_esm_information_response(
  *      Default EPS bearer context activation procedure
  * --------------------------------------------------------------------------
  */
-int esm_proc_default_eps_bearer_context(
+status_code_e esm_proc_default_eps_bearer_context(
     emm_context_t* emm_context, const proc_tid_t pti, pdn_cid_t pid, ebi_t* ebi,
     const qci_t qci, esm_cause_t* esm_cause);
-int esm_proc_default_eps_bearer_context_request(
+status_code_e esm_proc_default_eps_bearer_context_request(
     bool is_standalone, emm_context_t* const emm_context, const ebi_t ebi,
     STOLEN_REF bstring* msg, const bool ue_triggered);
-int esm_proc_default_eps_bearer_context_failure(
+status_code_e esm_proc_default_eps_bearer_context_failure(
     emm_context_t* emm_context, pdn_cid_t* const pid);
 
-int esm_proc_default_eps_bearer_context_accept(
+status_code_e esm_proc_default_eps_bearer_context_accept(
     emm_context_t* emm_context, ebi_t ebi, esm_cause_t* esm_cause);
-int esm_proc_default_eps_bearer_context_reject(
+status_code_e esm_proc_default_eps_bearer_context_reject(
     emm_context_t* emm_context, ebi_t ebi, esm_cause_t* esm_cause);
 
 /*
@@ -178,20 +178,20 @@ int esm_proc_default_eps_bearer_context_reject(
  *      Dedicated EPS bearer context activation procedure
  * --------------------------------------------------------------------------
  */
-int esm_proc_dedicated_eps_bearer_context(
+status_code_e esm_proc_dedicated_eps_bearer_context(
     emm_context_t* emm_context, const proc_tid_t pti, pdn_cid_t pid, ebi_t* ebi,
     ebi_t* default_ebi, const qci_t qci, const bitrate_t gbr_dl,
     const bitrate_t gbr_ul, const bitrate_t mbr_dl, const bitrate_t mbr_ul,
     traffic_flow_template_t* tft, protocol_configuration_options_t* pco,
     fteid_t* sgw_fteid, esm_cause_t* esm_cause);
 
-int esm_proc_dedicated_eps_bearer_context_request(
+status_code_e esm_proc_dedicated_eps_bearer_context_request(
     const bool is_standalone, emm_context_t* const emm_context, const ebi_t ebi,
     STOLEN_REF bstring* msg, const bool ue_triggered);
 
-int esm_proc_dedicated_eps_bearer_context_accept(
+status_code_e esm_proc_dedicated_eps_bearer_context_accept(
     emm_context_t* emm_context, ebi_t ebi, esm_cause_t* esm_cause);
-int esm_proc_dedicated_eps_bearer_context_reject(
+status_code_e esm_proc_dedicated_eps_bearer_context_reject(
     emm_context_t* emm_context, ebi_t ebi);
 
 /*
@@ -199,10 +199,10 @@ int esm_proc_dedicated_eps_bearer_context_reject(
  *      EPS bearer context deactivation procedure
  * --------------------------------------------------------------------------
  */
-int esm_proc_eps_bearer_context_deactivate(
+status_code_e esm_proc_eps_bearer_context_deactivate(
     emm_context_t* const emm_context_p, const bool is_local, const ebi_t ebi,
     pdn_cid_t* pid, int* const bidx, esm_cause_t* const esm_cause);
-int esm_proc_eps_bearer_context_deactivate_request(
+status_code_e esm_proc_eps_bearer_context_deactivate_request(
     const bool is_standalone, emm_context_t* const emm_context, const ebi_t ebi,
     STOLEN_REF bstring* msg, const bool ue_triggered);
 pdn_cid_t esm_proc_eps_bearer_context_deactivate_accept(

--- a/lte/gateway/c/core/oai/tasks/nas/esm/sap/esm_sap.c
+++ b/lte/gateway/c/core/oai/tasks/nas/esm/sap/esm_sap.c
@@ -126,7 +126,7 @@ void esm_sap_initialize(void) {
  **      Others:    None                                       **
  **                                                                        **
  ***************************************************************************/
-int esm_sap_send(esm_sap_t* msg) {
+status_code_e esm_sap_send(esm_sap_t* msg) {
   OAILOG_FUNC_IN(LOG_NAS_ESM);
   int rc        = RETURNerror;
   pdn_cid_t pid = MAX_APN_PER_UE;

--- a/lte/gateway/c/core/oai/tasks/nas/esm/sap/esm_sap.h
+++ b/lte/gateway/c/core/oai/tasks/nas/esm/sap/esm_sap.h
@@ -36,6 +36,7 @@ Description Defines the ESM Service Access Points at which the EPS
 #ifndef __ESM_SAP_H__
 #define __ESM_SAP_H__
 
+#include "common_defs.h"
 #include "esm_sapDef.h"
 
 /****************************************************************************/
@@ -56,6 +57,6 @@ Description Defines the ESM Service Access Points at which the EPS
 
 void esm_sap_initialize(void);
 
-int esm_sap_send(esm_sap_t* msg);
+status_code_e esm_sap_send(esm_sap_t* msg);
 
 #endif /* __ESM_SAP_H__*/

--- a/lte/gateway/c/core/oai/tasks/nas/esm/sap/esm_send.c
+++ b/lte/gateway/c/core/oai/tasks/nas/esm/sap/esm_send.c
@@ -45,7 +45,7 @@
    Functions executed by the MME to send ESM messages
    --------------------------------------------------------------------------
 */
-int esm_send_esm_information_request(
+status_code_e esm_send_esm_information_request(
     pti_t pti, ebi_t ebi, esm_information_request_msg* msg) {
   OAILOG_FUNC_IN(LOG_NAS_ESM);
   /*
@@ -81,7 +81,8 @@ int esm_send_esm_information_request(
  **      Others:    None                                       **
  **                                                                        **
  ***************************************************************************/
-int esm_send_status(pti_t pti, ebi_t ebi, esm_status_msg* msg, int esm_cause) {
+status_code_e esm_send_status(
+    pti_t pti, ebi_t ebi, esm_status_msg* msg, int esm_cause) {
   OAILOG_FUNC_IN(LOG_NAS_ESM);
   /*
    * Mandatory - ESM message header
@@ -124,7 +125,7 @@ int esm_send_status(pti_t pti, ebi_t ebi, esm_status_msg* msg, int esm_cause) {
  **      Others:    None                                       **
  **                                                                        **
  ***************************************************************************/
-int esm_send_pdn_connectivity_reject(
+status_code_e esm_send_pdn_connectivity_reject(
     pti_t pti, pdn_connectivity_reject_msg* msg, int esm_cause) {
   OAILOG_FUNC_IN(LOG_NAS_ESM);
   /*
@@ -168,7 +169,7 @@ int esm_send_pdn_connectivity_reject(
  **      Others:    None                                       **
  **                                                                        **
  ***************************************************************************/
-int esm_send_pdn_disconnect_reject(
+status_code_e esm_send_pdn_disconnect_reject(
     pti_t pti, pdn_disconnect_reject_msg* msg, int esm_cause) {
   OAILOG_FUNC_IN(LOG_NAS_ESM);
   /*
@@ -218,7 +219,7 @@ int esm_send_pdn_disconnect_reject(
  **      Others:    None                                       **
  **                                                                        **
  ***************************************************************************/
-int esm_send_activate_default_eps_bearer_context_request(
+status_code_e esm_send_activate_default_eps_bearer_context_request(
     pti_t pti, ebi_t ebi, activate_default_eps_bearer_context_request_msg* msg,
     pdn_context_t* pdn_context_p, const protocol_configuration_options_t* pco,
     int pdn_type, bstring pdn_addr, const EpsQualityOfService* qos,
@@ -359,7 +360,7 @@ int esm_send_activate_default_eps_bearer_context_request(
  **      Others:    None                                       **
  **                                                                        **
  ***************************************************************************/
-int esm_send_activate_dedicated_eps_bearer_context_request(
+status_code_e esm_send_activate_dedicated_eps_bearer_context_request(
     pti_t pti, ebi_t ebi,
     activate_dedicated_eps_bearer_context_request_msg* msg, ebi_t linked_ebi,
     const EpsQualityOfService* qos, traffic_flow_template_t* tft,
@@ -423,7 +424,7 @@ int esm_send_activate_dedicated_eps_bearer_context_request(
  **      Others:    None                                       **
  **                                                                        **
  ***************************************************************************/
-int esm_send_deactivate_eps_bearer_context_request(
+status_code_e esm_send_deactivate_eps_bearer_context_request(
     pti_t pti, ebi_t ebi, deactivate_eps_bearer_context_request_msg* msg,
     int esm_cause) {
   OAILOG_FUNC_IN(LOG_NAS_ESM);

--- a/lte/gateway/c/core/oai/tasks/nas/esm/sap/esm_send.h
+++ b/lte/gateway/c/core/oai/tasks/nas/esm/sap/esm_send.h
@@ -74,38 +74,39 @@ Description Defines functions executed at the ESM Service Access
  * Functions executed by the MME to send ESM message to the UE
  * --------------------------------------------------------------------------
  */
-int esm_send_esm_information_request(
+status_code_e esm_send_esm_information_request(
     pti_t pti, ebi_t ebi, esm_information_request_msg* msg);
 
-int esm_send_status(pti_t pti, ebi_t ebi, esm_status_msg* msg, int esm_cause);
+status_code_e esm_send_status(
+    pti_t pti, ebi_t ebi, esm_status_msg* msg, int esm_cause);
 
 /*
  * Transaction related messages
  * ----------------------------
  */
-int esm_send_pdn_connectivity_reject(
+status_code_e esm_send_pdn_connectivity_reject(
     pti_t pti, pdn_connectivity_reject_msg* msg, int esm_cause);
 
-int esm_send_pdn_disconnect_reject(
+status_code_e esm_send_pdn_disconnect_reject(
     pti_t pti, pdn_disconnect_reject_msg* msg, int esm_cause);
 
 /*
  * Messages related to EPS bearer contexts
  * ---------------------------------------
  */
-int esm_send_activate_default_eps_bearer_context_request(
+status_code_e esm_send_activate_default_eps_bearer_context_request(
     pti_t pti, ebi_t ebi, activate_default_eps_bearer_context_request_msg* msg,
     pdn_context_t* pdn_context_p, const protocol_configuration_options_t* pco,
     int pdn_type, bstring pdn_addr, const EpsQualityOfService* qos,
     int esm_cause);
 
-int esm_send_activate_dedicated_eps_bearer_context_request(
+status_code_e esm_send_activate_dedicated_eps_bearer_context_request(
     pti_t pti, ebi_t ebi,
     activate_dedicated_eps_bearer_context_request_msg* msg, ebi_t linked_ebi,
     const EpsQualityOfService* qos, traffic_flow_template_t* tft,
     protocol_configuration_options_t* pco);
 
-int esm_send_deactivate_eps_bearer_context_request(
+status_code_e esm_send_deactivate_eps_bearer_context_request(
     pti_t pti, ebi_t ebi, deactivate_eps_bearer_context_request_msg* msg,
     int esm_cause);
 

--- a/lte/gateway/c/core/oai/tasks/nas/ies/EpsQualityOfService.c
+++ b/lte/gateway/c/core/oai/tasks/nas/ies/EpsQualityOfService.c
@@ -43,7 +43,7 @@ static int decode_eps_qos_bit_rates(
 }
 
 //------------------------------------------------------------------------------
-int decode_eps_quality_of_service(
+status_code_e decode_eps_quality_of_service(
     EpsQualityOfService* epsqualityofservice, uint8_t iei, uint8_t* buffer,
     uint32_t len) {
   int decoded   = 0;
@@ -108,7 +108,7 @@ static int encode_eps_qos_bit_rates(
 }
 
 //------------------------------------------------------------------------------
-int encode_eps_quality_of_service(
+status_code_e encode_eps_quality_of_service(
     EpsQualityOfService* epsqualityofservice, uint8_t iei, uint8_t* buffer,
     uint32_t len) {
   uint8_t* lenPtr;
@@ -146,7 +146,7 @@ int encode_eps_quality_of_service(
 
 #define EPS_QOS_BIT_RATE_MAX 262144  // 256 Mbps
 //------------------------------------------------------------------------------
-int eps_qos_bit_rate_value(uint8_t br) {
+status_code_e eps_qos_bit_rate_value(uint8_t br) {
   if (br < 0b00000001) {
     return (EPS_QOS_BIT_RATE_MAX);
   } else if ((br > 0b00000000) && (br < 0b01000000)) {
@@ -161,7 +161,7 @@ int eps_qos_bit_rate_value(uint8_t br) {
 }
 
 //------------------------------------------------------------------------------
-int eps_qos_bit_rate_ext_value(uint8_t br) {
+status_code_e eps_qos_bit_rate_ext_value(uint8_t br) {
   if ((br > 0b00000000) && (br < 0b01001011)) {
     return (8600 + br * 100);
   } else if ((br > 0b01001010) && (br < 0b10111011)) {
@@ -174,7 +174,7 @@ int eps_qos_bit_rate_ext_value(uint8_t br) {
 }
 
 //------------------------------------------------------------------------------
-int qos_params_to_eps_qos(
+status_code_e qos_params_to_eps_qos(
     const qci_t qci, const bitrate_t mbr_dl, const bitrate_t mbr_ul,
     const bitrate_t gbr_dl, const bitrate_t gbr_ul,
     EpsQualityOfService* const eps_qos, bool is_default_bearer) {

--- a/lte/gateway/c/core/oai/tasks/nas/nas_proc.c
+++ b/lte/gateway/c/core/oai/tasks/nas/nas_proc.c
@@ -154,7 +154,7 @@ void nas_proc_cleanup(void) {
  **      Others:    None                                       **
  **                                                                        **
  ***************************************************************************/
-int nas_proc_establish_ind(
+status_code_e nas_proc_establish_ind(
     const mme_ue_s1ap_id_t ue_id, const bool is_mm_ctx_new,
     const tai_t originating_tai, const ecgi_t ecgi, const as_cause_t as_cause,
     const s_tmsi_t s_tmsi, STOLEN_REF bstring* msg) {
@@ -204,7 +204,7 @@ int nas_proc_establish_ind(
  **      Others:    None                                       **
  **                                                                        **
  ***************************************************************************/
-int nas_proc_dl_transfer_cnf(
+status_code_e nas_proc_dl_transfer_cnf(
     const uint32_t ue_id, const nas_error_code_t status,
     bstring* STOLEN_REF nas_msg) {
   OAILOG_FUNC_IN(LOG_NAS_EMM);
@@ -248,7 +248,7 @@ int nas_proc_dl_transfer_cnf(
  **      Others:    None                                       **
  **                                                                        **
  ***************************************************************************/
-int nas_proc_dl_transfer_rej(
+status_code_e nas_proc_dl_transfer_rej(
     const uint32_t ue_id, const nas_error_code_t status,
     bstring* STOLEN_REF nas_msg) {
   OAILOG_FUNC_IN(LOG_NAS_EMM);
@@ -298,7 +298,7 @@ int nas_proc_dl_transfer_rej(
  **      Others:    None                                       **
  **                                                                        **
  ***************************************************************************/
-int nas_proc_ul_transfer_ind(
+status_code_e nas_proc_ul_transfer_ind(
     const mme_ue_s1ap_id_t ue_id, const tai_t originating_tai, const ecgi_t cgi,
     STOLEN_REF bstring* msg) {
   OAILOG_FUNC_IN(LOG_NAS_EMM);
@@ -336,7 +336,7 @@ int nas_proc_ul_transfer_ind(
 }
 
 //-----------------------------------------------------------------------------
-int nas_proc_authentication_info_answer(
+status_code_e nas_proc_authentication_info_answer(
     mme_app_desc_t* mme_app_desc_p, s6a_auth_info_ans_t* aia) {
   imsi64_t imsi64                  = INVALID_IMSI64;
   int rc                           = RETURNerror;
@@ -417,7 +417,7 @@ int nas_proc_authentication_info_answer(
 }
 
 //------------------------------------------------------------------------------
-int nas_proc_auth_param_res(
+status_code_e nas_proc_auth_param_res(
     mme_ue_s1ap_id_t ue_id, uint8_t nb_vectors, eutran_vector_t* vectors) {
   OAILOG_FUNC_IN(LOG_NAS_EMM);
   int rc                            = RETURNerror;
@@ -437,7 +437,8 @@ int nas_proc_auth_param_res(
 }
 
 //------------------------------------------------------------------------------
-int nas_proc_auth_param_fail(mme_ue_s1ap_id_t ue_id, nas_cause_t cause) {
+status_code_e nas_proc_auth_param_fail(
+    mme_ue_s1ap_id_t ue_id, nas_cause_t cause) {
   OAILOG_FUNC_IN(LOG_NAS_EMM);
   int rc                              = RETURNerror;
   emm_sap_t emm_sap                   = {0};
@@ -453,7 +454,7 @@ int nas_proc_auth_param_fail(mme_ue_s1ap_id_t ue_id, nas_cause_t cause) {
 }
 
 //------------------------------------------------------------------------------
-int nas_proc_ula_success(mme_ue_s1ap_id_t ue_id) {
+status_code_e nas_proc_ula_success(mme_ue_s1ap_id_t ue_id) {
   OAILOG_FUNC_IN(LOG_NAS_EMM);
   int rc                                  = RETURNerror;
   emm_sap_t emm_sap                       = {0};
@@ -471,7 +472,7 @@ int nas_proc_ula_success(mme_ue_s1ap_id_t ue_id) {
 }
 
 //------------------------------------------------------------------------------
-int nas_proc_cs_respose_success(
+status_code_e nas_proc_cs_respose_success(
     emm_cn_cs_response_success_t* cs_response_success) {
   OAILOG_FUNC_IN(LOG_NAS_EMM);
   int rc            = RETURNerror;
@@ -489,7 +490,8 @@ int nas_proc_cs_respose_success(
 }
 
 //------------------------------------------------------------------------------
-int nas_proc_ula_or_csrsp_fail(emm_cn_ula_or_csrsp_fail_t* ula_or_csrsp_fail) {
+status_code_e nas_proc_ula_or_csrsp_fail(
+    emm_cn_ula_or_csrsp_fail_t* ula_or_csrsp_fail) {
   OAILOG_FUNC_IN(LOG_NAS_EMM);
   int rc            = RETURNerror;
   emm_sap_t emm_sap = {0};
@@ -501,7 +503,7 @@ int nas_proc_ula_or_csrsp_fail(emm_cn_ula_or_csrsp_fail_t* ula_or_csrsp_fail) {
 }
 
 //------------------------------------------------------------------------------
-int nas_proc_create_dedicated_bearer(
+status_code_e nas_proc_create_dedicated_bearer(
     emm_cn_activate_dedicated_bearer_req_t* emm_cn_activate) {
   OAILOG_FUNC_IN(LOG_NAS_EMM);
   int rc            = RETURNerror;
@@ -513,7 +515,7 @@ int nas_proc_create_dedicated_bearer(
 }
 
 //------------------------------------------------------------------------------
-int nas_proc_delete_dedicated_bearer(
+status_code_e nas_proc_delete_dedicated_bearer(
     emm_cn_deactivate_dedicated_bearer_req_t* emm_cn_deactivate) {
   OAILOG_FUNC_IN(LOG_NAS_EMM);
   int rc            = RETURNerror;
@@ -525,7 +527,7 @@ int nas_proc_delete_dedicated_bearer(
 }
 
 //------------------------------------------------------------------------------
-int nas_proc_implicit_detach_ue_ind(mme_ue_s1ap_id_t ue_id) {
+status_code_e nas_proc_implicit_detach_ue_ind(mme_ue_s1ap_id_t ue_id) {
   int rc            = RETURNerror;
   emm_sap_t emm_sap = {0};
 
@@ -537,7 +539,7 @@ int nas_proc_implicit_detach_ue_ind(mme_ue_s1ap_id_t ue_id) {
 }
 
 //------------------------------------------------------------------------------
-int nas_proc_nw_initiated_detach_ue_request(
+status_code_e nas_proc_nw_initiated_detach_ue_request(
     emm_cn_nw_initiated_detach_ue_t* const nw_initiated_detach_p) {
   int rc            = RETURNerror;
   emm_sap_t emm_sap = {0};
@@ -560,7 +562,8 @@ int nas_proc_nw_initiated_detach_ue_request(
 }
 
 //------------------------------------------------------------------------------
-int nas_proc_downlink_unitdata(itti_sgsap_downlink_unitdata_t* dl_unitdata) {
+status_code_e nas_proc_downlink_unitdata(
+    itti_sgsap_downlink_unitdata_t* dl_unitdata) {
   imsi64_t imsi64       = INVALID_IMSI64;
   int rc                = RETURNerror;
   emm_context_t* ctxt   = NULL;
@@ -603,7 +606,7 @@ int nas_proc_downlink_unitdata(itti_sgsap_downlink_unitdata_t* dl_unitdata) {
   OAILOG_FUNC_RETURN(LOG_NAS_EMM, rc);
 }
 
-int encode_mobileid_imsi_tmsi(
+status_code_e encode_mobileid_imsi_tmsi(
     MobileIdentity* out, MobileIdentity in, uint8_t typeofidentity)
 
 {
@@ -650,7 +653,7 @@ int encode_mobileid_imsi_tmsi(
 }
 
 //------------------------------------------------------------------------------
-int nas_proc_cs_domain_location_updt_fail(
+status_code_e nas_proc_cs_domain_location_updt_fail(
     SgsRejectCause_t cause, lai_t* lai, mme_ue_s1ap_id_t mme_ue_s1ap_id) {
   int rc                                                      = RETURNerror;
   emm_sap_t emm_sap                                           = {0};
@@ -675,7 +678,8 @@ int nas_proc_cs_domain_location_updt_fail(
 }
 
 //------------------------------------------------------------------------------
-int nas_proc_sgs_release_req(itti_sgsap_release_req_t* sgs_release_req) {
+status_code_e nas_proc_sgs_release_req(
+    itti_sgsap_release_req_t* sgs_release_req) {
   imsi64_t imsi64     = INVALID_IMSI64;
   int rc              = RETURNerror;
   emm_context_t* ctxt = NULL;
@@ -737,7 +741,7 @@ int nas_proc_sgs_release_req(itti_sgsap_release_req_t* sgs_release_req) {
  **      Return:    RETURNok, RETURNerror                                  **
  **                                                                        **
  ***************************************************************************/
-int nas_proc_cs_service_notification(
+status_code_e nas_proc_cs_service_notification(
     mme_ue_s1ap_id_t ue_id, uint8_t paging_id, bstring cli) {
   int rc            = RETURNerror;
   emm_sap_t emm_sap = {0};
@@ -855,7 +859,7 @@ static nas_cause_t s6a_error_2_nas_cause(uint32_t s6a_error, int experimental) {
 
 // Handle CS domain MM-Information request from MSC/VLR
 
-int nas_proc_cs_domain_mm_information_request(
+status_code_e nas_proc_cs_domain_mm_information_request(
     itti_sgsap_mm_information_req_t* const mm_information_req_pP) {
   int rc            = RETURNerror;
   emm_sap_t emm_sap = {0};
@@ -880,7 +884,7 @@ int nas_proc_cs_domain_mm_information_request(
  **      Return:    RETURNok, RETURNerror                                  **
  **                                                                        **
  ***************************************************************************/
-int nas_proc_pdn_disconnect_rsp(
+status_code_e nas_proc_pdn_disconnect_rsp(
     emm_cn_pdn_disconnect_rsp_t* emm_cn_pdn_disconnect_rsp) {
   OAILOG_FUNC_IN(LOG_NAS_EMM);
   int rc            = RETURNerror;

--- a/lte/gateway/c/core/oai/tasks/nas/nas_proc.h
+++ b/lte/gateway/c/core/oai/tasks/nas/nas_proc.h
@@ -84,18 +84,18 @@ void nas_proc_cleanup(void);
  * --------------------------------------------------------------------------
  */
 
-int nas_proc_establish_ind(
+status_code_e nas_proc_establish_ind(
     const mme_ue_s1ap_id_t ue_id, const bool is_mm_ctx_new,
     const tai_t originating_tai, const ecgi_t ecgi, const as_cause_t as_cause,
     const s_tmsi_t s_tmsi, STOLEN_REF bstring* msg);
 
-int nas_proc_dl_transfer_cnf(
+status_code_e nas_proc_dl_transfer_cnf(
     const mme_ue_s1ap_id_t ueid, const nas_error_code_t status,
     STOLEN_REF bstring* nas_msg);
-int nas_proc_dl_transfer_rej(
+status_code_e nas_proc_dl_transfer_rej(
     const mme_ue_s1ap_id_t ueid, const nas_error_code_t status,
     STOLEN_REF bstring* nas_msg);
-int nas_proc_ul_transfer_ind(
+status_code_e nas_proc_ul_transfer_ind(
     const mme_ue_s1ap_id_t ueid, const tai_t originating_tai, const ecgi_t cgi,
     STOLEN_REF bstring* msg);
 
@@ -104,32 +104,35 @@ int nas_proc_ul_transfer_ind(
  *      NAS procedures triggered by the mme applicative layer
  * --------------------------------------------------------------------------
  */
-int nas_proc_authentication_info_answer(
+status_code_e nas_proc_authentication_info_answer(
     mme_app_desc_t* mme_app_desc_p, s6a_auth_info_ans_t* ans);
-int nas_proc_auth_param_res(
+status_code_e nas_proc_auth_param_res(
     mme_ue_s1ap_id_t ue_id, uint8_t nb_vectors, eutran_vector_t* vectors);
-int nas_proc_auth_param_fail(mme_ue_s1ap_id_t ue_id, nas_cause_t cause);
-int nas_proc_ula_success(mme_ue_s1ap_id_t ue_id);
-int nas_proc_cs_respose_success(
+status_code_e nas_proc_auth_param_fail(
+    mme_ue_s1ap_id_t ue_id, nas_cause_t cause);
+status_code_e nas_proc_ula_success(mme_ue_s1ap_id_t ue_id);
+status_code_e nas_proc_cs_respose_success(
     emm_cn_cs_response_success_t* nas_cs_response_success);
-int nas_proc_ula_or_csrsp_fail(emm_cn_ula_or_csrsp_fail_t* ula_or_csrsp_fail);
-int nas_proc_create_dedicated_bearer(
+status_code_e nas_proc_ula_or_csrsp_fail(
+    emm_cn_ula_or_csrsp_fail_t* ula_or_csrsp_fail);
+status_code_e nas_proc_create_dedicated_bearer(
     emm_cn_activate_dedicated_bearer_req_t* emm_cn_activate);
 int nas_proc_signalling_connection_rel_ind(mme_ue_s1ap_id_t ue_id);
-int nas_proc_implicit_detach_ue_ind(mme_ue_s1ap_id_t ue_id);
+status_code_e nas_proc_implicit_detach_ue_ind(mme_ue_s1ap_id_t ue_id);
 int nas_proc_smc_fail(emm_cn_smc_fail_t* emm_cn_smc_fail);
-int nas_proc_nw_initiated_detach_ue_request(
+status_code_e nas_proc_nw_initiated_detach_ue_request(
     emm_cn_nw_initiated_detach_ue_t* const nw_initiated_detach_p);
-int nas_proc_cs_domain_location_updt_fail(
+status_code_e nas_proc_cs_domain_location_updt_fail(
     SgsRejectCause_t cause, lai_t* lai, mme_ue_s1ap_id_t mme_ue_s1ap_id);
-int nas_proc_downlink_unitdata(itti_sgsap_downlink_unitdata_t* dl_unitdata);
-int nas_proc_sgs_release_req(itti_sgsap_release_req_t* sgs_rel);
-int nas_proc_cs_domain_mm_information_request(
+status_code_e nas_proc_downlink_unitdata(
+    itti_sgsap_downlink_unitdata_t* dl_unitdata);
+status_code_e nas_proc_sgs_release_req(itti_sgsap_release_req_t* sgs_rel);
+status_code_e nas_proc_cs_domain_mm_information_request(
     itti_sgsap_mm_information_req_t* const mm_information_req_pP);
-int nas_proc_cs_service_notification(
+status_code_e nas_proc_cs_service_notification(
     mme_ue_s1ap_id_t ue_id, uint8_t paging_id, bstring cli);
-int nas_proc_delete_dedicated_bearer(
+status_code_e nas_proc_delete_dedicated_bearer(
     emm_cn_deactivate_dedicated_bearer_req_t* emm_cn_deactivate);
-int nas_proc_pdn_disconnect_rsp(
+status_code_e nas_proc_pdn_disconnect_rsp(
     emm_cn_pdn_disconnect_rsp_t* emm_cn_pdn_disconnect_rsp);
 #endif /* FILE_NAS_PROC_SEEN*/

--- a/lte/gateway/c/core/oai/tasks/nas/nas_procedures.c
+++ b/lte/gateway/c/core/oai/tasks/nas/nas_procedures.c
@@ -261,7 +261,7 @@ inline bool is_nas_attach_complete_received(
 }
 
 //------------------------------------------------------------------------------
-int nas_unlink_procedures(
+status_code_e nas_unlink_procedures(
     nas_base_proc_t* const parent_proc, nas_base_proc_t* const child_proc) {
   if ((parent_proc) && (child_proc)) {
     if ((parent_proc->child == child_proc) &&

--- a/lte/gateway/c/core/oai/tasks/nas/nas_procedures.h
+++ b/lte/gateway/c/core/oai/tasks/nas/nas_procedures.h
@@ -33,6 +33,7 @@
 #include "3gpp_33.401.h"
 #include "3gpp_36.401.h"
 #include "bstrlib.h"
+#include "common_defs.h"
 #include "common_types.h"
 #include "emm_fsm.h"
 #include "nas_timer.h"
@@ -437,7 +438,7 @@ bool is_nas_attach_reject_sent(const nas_emm_attach_proc_t* const attach_proc);
 bool is_nas_attach_complete_received(
     const nas_emm_attach_proc_t* const attach_proc);
 
-int nas_unlink_procedures(
+status_code_e nas_unlink_procedures(
     nas_base_proc_t* const parent_proc, nas_base_proc_t* const child_proc);
 
 void nas_delete_all_emm_procedures(struct emm_context_s* const emm_context);

--- a/lte/gateway/c/core/oai/tasks/nas/util/nas_timer.c
+++ b/lte/gateway/c/core/oai/tasks/nas/util/nas_timer.c
@@ -44,7 +44,7 @@
 #include "log.h"
 
 //------------------------------------------------------------------------------
-int nas_timer_init(void) {
+status_code_e nas_timer_init(void) {
   return (RETURNok);
 }
 

--- a/lte/gateway/c/core/oai/tasks/nas/util/nas_timer.h
+++ b/lte/gateway/c/core/oai/tasks/nas/util/nas_timer.h
@@ -34,6 +34,7 @@ Description Timer utilities
 #ifndef FILE_NAS_TIMER_SEEN
 #define FILE_NAS_TIMER_SEEN
 
+#include "common_defs.h"
 #include "common_types.h"
 /****************************************************************************/
 /*********************  G L O B A L    C O N S T A N T S  *******************/
@@ -71,7 +72,7 @@ typedef struct nas_itti_timer_arg_s {
 /******************  E X P O R T E D    F U N C T I O N S  ******************/
 /****************************************************************************/
 
-int nas_timer_init(void);
+status_code_e nas_timer_init(void);
 void nas_timer_cleanup(void);
 long int nas_timer_start(
     uint32_t sec, uint32_t usec, nas_timer_callback_t nas_timer_callback,

--- a/lte/gateway/c/core/oai/tasks/nas/util/parser.c
+++ b/lte/gateway/c/core/oai/tasks/nas/util/parser.c
@@ -97,7 +97,7 @@ void parser_print_usage(const parser_command_line_t* command_line) {
  **      Others:  None                                       **
  **                                                                        **
  ***************************************************************************/
-int parser_get_options(
+status_code_e parser_get_options(
     int argc, const char** argv, parser_command_line_t* command_line) {
   int argument_not_found, option_not_found = 1;
   int option_length;

--- a/lte/gateway/c/core/oai/tasks/nas/util/parser.h
+++ b/lte/gateway/c/core/oai/tasks/nas/util/parser.h
@@ -34,6 +34,8 @@ Description Usefull command line parser
 #ifndef FILE_PARSER_SEEN
 #define FILE_PARSER_SEEN
 
+#include "common_defs.h"
+
 /****************************************************************************/
 /*********************  G L O B A L    C O N S T A N T S  *******************/
 /****************************************************************************/
@@ -79,7 +81,7 @@ typedef struct {
 /****************************************************************************/
 
 void parser_print_usage(const parser_command_line_t* commamd_line);
-int parser_get_options(
+status_code_e parser_get_options(
     int argc, const char** argv, parser_command_line_t* commamd_line);
 
 #endif /* FILE_PARSER_SEEN*/

--- a/lte/gateway/c/core/oai/tasks/nas/util/socket.c
+++ b/lte/gateway/c/core/oai/tasks/nas/util/socket.c
@@ -385,7 +385,7 @@ ssize_t socket_send(const void* id, const char* buffer, size_t length) {
  **      Others:  None                                       **
  **                                                                        **
  ***************************************************************************/
-int socket_get_fd(const void* id) {
+status_code_e socket_get_fd(const void* id) {
   if (id) {
     return ((socket_id_t*) id)->fd;
   }

--- a/lte/gateway/c/core/oai/tasks/nas/util/socket.h
+++ b/lte/gateway/c/core/oai/tasks/nas/util/socket.h
@@ -34,6 +34,7 @@ Description Implements TCP socket handlers
 #ifndef FILE_SOCKET_SEEN
 #define FILE_SOCKET_SEEN
 
+#include "common_defs.h"
 #include <sys/types.h>
 
 /****************************************************************************/
@@ -60,7 +61,7 @@ typedef struct socket_id_s socket_id_t;
 /****************************************************************************/
 
 void* socket_udp_open(int type, const char* host, const char* port);
-int socket_get_fd(const void* id);
+status_code_e socket_get_fd(const void* id);
 
 ssize_t socket_recv(void* id, char* buffer, size_t length);
 ssize_t socket_send(const void* id, const char* buffer, size_t length);

--- a/lte/gateway/c/core/oai/tasks/ngap/ngap_amf.c
+++ b/lte/gateway/c/core/oai/tasks/ngap/ngap_amf.c
@@ -203,7 +203,7 @@ static void* ngap_amf_thread(__attribute__((unused)) void* args) {
 }
 
 //------------------------------------------------------------------------------
-int ngap_amf_init(const amf_config_t* amf_config_p) {
+status_code_e ngap_amf_init(const amf_config_t* amf_config_p) {
   OAILOG_DEBUG(LOG_NGAP, "Initializing NGAP interface\n");
 
   if (itti_create_task(TASK_NGAP, &ngap_amf_thread, NULL) == RETURNerror) {

--- a/lte/gateway/c/core/oai/tasks/ngap/ngap_amf.h
+++ b/lte/gateway/c/core/oai/tasks/ngap/ngap_amf.h
@@ -13,6 +13,7 @@
 
 #pragma once
 
+#include "common_defs.h"
 #include "intertask_interface.h"
 #include "ngap_types.h"
 #include "amf_config.h"
@@ -22,7 +23,7 @@ extern bool hss_associated;
 /** \brief NGAP layer top init
  * @returns -1 in case of failure
  **/
-int ngap_amf_init(const amf_config_t* amf_config);
+status_code_e ngap_amf_init(const amf_config_t* amf_config);
 
 /** \brief NGAP layer top exit
  **/

--- a/lte/gateway/c/core/oai/tasks/ngap/ngap_amf_handlers.c
+++ b/lte/gateway/c/core/oai/tasks/ngap/ngap_amf_handlers.c
@@ -78,10 +78,10 @@
 
 struct Ngap_IE;
 
-int ngap_generate_ng_setup_response(
+status_code_e ngap_generate_ng_setup_response(
     ngap_state_t* state, gnb_description_t* gnb_association);
 
-int ngap_amf_generate_ue_context_release_command(
+status_code_e ngap_amf_generate_ue_context_release_command(
     ngap_state_t* state, m5g_ue_description_t* ue_ref_p, enum Ngcause,
     imsi64_t imsi64);
 
@@ -153,7 +153,7 @@ ngap_message_handler_t ngap_message_handlers[][3] = {
     {0, 0, 0}, /* UplinkNonUEAssociatedLPPaTransport */
 };
 
-int ngap_amf_handle_message(
+status_code_e ngap_amf_handle_message(
     ngap_state_t* state, const sctp_assoc_id_t assoc_id,
     const sctp_stream_id_t stream, Ngap_NGAP_PDU_t* pdu) {
   /*
@@ -187,7 +187,7 @@ int ngap_amf_handle_message(
 }
 
 //------------------------------------------------------------------------------
-int ngap_amf_set_cause(
+status_code_e ngap_amf_set_cause(
     Ngap_Cause_t* cause_p, const Ngap_Cause_PR cause_type,
     const long cause_value) {
   DevAssert(cause_p != NULL);
@@ -222,7 +222,7 @@ int ngap_amf_set_cause(
 }
 
 //------------------------------------------------------------------------------
-int ngap_amf_generate_ng_setup_failure(
+status_code_e ngap_amf_generate_ng_setup_failure(
     const sctp_assoc_id_t assoc_id, const Ngap_Cause_PR cause_type,
     const long cause_value, const long time_to_wait) {
   uint8_t* buffer_p = 0;
@@ -278,7 +278,7 @@ int ngap_amf_generate_ng_setup_failure(
 ////////////////////////////////////////////////////////////////////////////////
 
 //------------------------------------------------------------------------------
-int ngap_amf_handle_ng_setup_request(
+status_code_e ngap_amf_handle_ng_setup_request(
     ngap_state_t* state, const sctp_assoc_id_t assoc_id,
     const sctp_stream_id_t stream, Ngap_NGAP_PDU_t* pdu) {
   int rc = RETURNok;
@@ -495,7 +495,7 @@ int ngap_amf_handle_ng_setup_request(
 }
 
 //------------------------------------------------------------------------------
-int ngap_generate_ng_setup_response(
+status_code_e ngap_generate_ng_setup_response(
     ngap_state_t* state, gnb_description_t* gnb_association) {
   Ngap_NGAP_PDU_t pdu;
   Ngap_NGSetupResponse_t* out;
@@ -677,7 +677,7 @@ amf_config_read_lock(&amf_config);
 ////////////////////////////////////////////////////////////////////////////////
 
 //------------------------------------------------------------------------------
-int ngap_amf_handle_initial_context_setup_response(
+status_code_e ngap_amf_handle_initial_context_setup_response(
     ngap_state_t* state, __attribute__((unused)) const sctp_assoc_id_t assoc_id,
     __attribute__((unused)) const sctp_stream_id_t stream,
     Ngap_NGAP_PDU_t* pdu) {
@@ -784,7 +784,7 @@ int ngap_amf_handle_initial_context_setup_response(
 }
 
 //------------------------------------------------------------------------------
-int ngap_handle_new_association(
+status_code_e ngap_handle_new_association(
     ngap_state_t* state, sctp_new_peer_t* sctp_new_peer_p) {
   gnb_description_t* gnb_association = NULL;
 
@@ -853,7 +853,7 @@ int ngap_handle_new_association(
   OAILOG_FUNC_RETURN(LOG_NGAP, RETURNok);
 }
 
-int ngap_amf_handle_ue_context_release_request(
+status_code_e ngap_amf_handle_ue_context_release_request(
     __attribute__((unused)) ngap_state_t* state,
     __attribute__((unused)) const sctp_assoc_id_t assoc_id,
     __attribute__((unused)) const sctp_stream_id_t stream,
@@ -1021,7 +1021,7 @@ int ngap_amf_handle_ue_context_release_request(
 }
 
 //------------------------------------------------------------------------------
-int ngap_amf_generate_ue_context_release_command(
+status_code_e ngap_amf_generate_ue_context_release_command(
     ngap_state_t* state, m5g_ue_description_t* ue_ref_p, enum Ngcause cause,
     imsi64_t imsi64) {
   uint8_t* buffer = NULL;
@@ -1110,7 +1110,7 @@ int ngap_amf_generate_ue_context_release_command(
 }
 
 //------------------------------------------------------------------------------
-int ngap_handle_ue_context_release_command(
+status_code_e ngap_handle_ue_context_release_command(
     ngap_state_t* state,
     const itti_ngap_ue_context_release_command_t* const
         ue_context_release_command_pP,
@@ -1149,7 +1149,7 @@ int ngap_handle_ue_context_release_command(
 }
 
 //------------------------------------------------------------------------------
-int ngap_amf_handle_ue_context_release_complete(
+status_code_e ngap_amf_handle_ue_context_release_complete(
     ngap_state_t* state, __attribute__((unused)) const sctp_assoc_id_t assoc_id,
     __attribute__((unused)) const sctp_stream_id_t stream,
     Ngap_NGAP_PDU_t* pdu) {
@@ -1199,7 +1199,7 @@ int ngap_amf_handle_ue_context_release_complete(
 }
 
 //------------------------------------------------------------------------------
-int ngap_amf_handle_initial_context_setup_failure(
+status_code_e ngap_amf_handle_initial_context_setup_failure(
     ngap_state_t* state, __attribute__((unused)) const sctp_assoc_id_t assoc_id,
     __attribute__((unused)) const sctp_stream_id_t stream,
     Ngap_NGAP_PDU_t* pdu) {
@@ -1444,7 +1444,7 @@ typedef struct arg_ngap_construct_gnb_reset_req_s {
 } arg_ngap_construct_gnb_reset_req_t;
 
 //------------------------------------------------------------------------------
-int ngap_handle_sctp_disconnection(
+status_code_e ngap_handle_sctp_disconnection(
     ngap_state_t* state, const sctp_assoc_id_t assoc_id, bool reset) {
   arg_ngap_send_gnb_dereg_ind_t arg  = {0};
   int i                              = 0;
@@ -1591,7 +1591,7 @@ void ngap_amf_release_ue_context(
 }
 
 //------------------------------------------------------------------------------
-int ngap_amf_handle_error_ind_message(
+status_code_e ngap_amf_handle_error_ind_message(
     ngap_state_t* state, const sctp_assoc_id_t assoc_id,
     const sctp_stream_id_t stream, Ngap_NGAP_PDU_t* message) {
   OAILOG_FUNC_IN(LOG_NGAP);
@@ -1618,7 +1618,7 @@ const char* ngap_direction2str(uint8_t dir) {
 }
 
 //------------------------------------------------------------------------------
-int ngap_amf_handle_pduSession_release_response(
+status_code_e ngap_amf_handle_pduSession_release_response(
     ngap_state_t* state, const sctp_assoc_id_t assoc_id,
     const sctp_stream_id_t stream, Ngap_NGAP_PDU_t* pdu) {
   OAILOG_FUNC_IN(LOG_NGAP);
@@ -1711,7 +1711,7 @@ int ngap_amf_handle_pduSession_release_response(
   OAILOG_FUNC_RETURN(LOG_NGAP, rc);
 }
 
-int ngap_amf_handle_pduSession_setup_response(
+status_code_e ngap_amf_handle_pduSession_setup_response(
     ngap_state_t* state, const sctp_assoc_id_t assoc_id,
     const sctp_stream_id_t stream, Ngap_NGAP_PDU_t* pdu) {
   OAILOG_FUNC_IN(LOG_NGAP);
@@ -1871,7 +1871,7 @@ int ngap_amf_handle_pduSession_setup_response(
 }
 
 //-------------------------------------------------------------------------------
-int ngap_handle_paging_request(
+status_code_e ngap_handle_paging_request(
     ngap_state_t* state, const itti_ngap_paging_request_t* paging_request,
     imsi64_t imsi64) {
   OAILOG_FUNC_IN(LOG_NGAP);

--- a/lte/gateway/c/core/oai/tasks/ngap/ngap_amf_handlers.h
+++ b/lte/gateway/c/core/oai/tasks/ngap/ngap_amf_handlers.h
@@ -18,6 +18,7 @@
 #include "ngap_amf.h"
 #include "intertask_interface.h"
 #include "Ngap_Cause.h"
+#include "common_defs.h"
 #include "common_types.h"
 #include "ngap_messages_types.h"
 #include "sctp_messages_types.h"
@@ -33,7 +34,7 @@ const char* ngap_direction2str(uint8_t dir);
  * \param message_p The message decoded by the ASN1C decoder
  * @returns int
  **/
-int ngap_amf_handle_message(
+status_code_e ngap_amf_handle_message(
     ngap_state_t* state, const sctp_assoc_id_t assoc_id,
     const sctp_stream_id_t stream, Ngap_NGAP_PDU_t* message_p);
 
@@ -46,11 +47,11 @@ int ngap_amf_handle_message(
  * \param message_p The message decoded by the ASN1C decoder
  * @returns int
  **/
-int ngap_amf_handle_ng_setup_request(
+status_code_e ngap_amf_handle_ng_setup_request(
     ngap_state_t* state, const sctp_assoc_id_t assoc_id,
     const sctp_stream_id_t stream, Ngap_NGAP_PDU_t* message_p);
 
-int ngap_amf_generate_ng_setup_failure(
+status_code_e ngap_amf_generate_ng_setup_failure(
     const sctp_assoc_id_t assoc_id, const Ngap_Cause_PR cause_type,
     const long cause_value, const long time_to_wait);
 
@@ -61,7 +62,7 @@ int ngap_amf_generate_ng_setup_failure(
  * \param message_p message will be encoded by  ASN1C encoder
  * @returns int
  **/
-int ngap_amf_handle_initial_context_setup_failure(
+status_code_e ngap_amf_handle_initial_context_setup_failure(
     ngap_state_t* state, const sctp_assoc_id_t assoc_id,
     const sctp_stream_id_t stream, Ngap_NGAP_PDU_t* message_p);
 
@@ -72,7 +73,7 @@ int ngap_amf_handle_initial_context_setup_failure(
  * \param message_p message will be encoded by  ASN1C encoder
  * @returns int
  **/
-int ngap_amf_handle_initial_context_setup_response(
+status_code_e ngap_amf_handle_initial_context_setup_response(
     ngap_state_t* state, const sctp_assoc_id_t assoc_id,
     const sctp_stream_id_t stream, Ngap_NGAP_PDU_t* message_p);
 
@@ -82,7 +83,7 @@ int ngap_amf_handle_initial_context_setup_response(
  * \param reset Flag for reset
  * @returns int
  **/
-int ngap_handle_sctp_disconnection(
+status_code_e ngap_handle_sctp_disconnection(
     ngap_state_t* state, const sctp_assoc_id_t assoc_id, bool reset);
 
 /** \brief SCTP layer notifies NGAP of new association
@@ -90,7 +91,7 @@ int ngap_handle_sctp_disconnection(
  * \param sctp_new_peer_p new peer info
  * @returns int
  **/
-int ngap_handle_new_association(
+status_code_e ngap_handle_new_association(
     ngap_state_t* state, sctp_new_peer_t* sctp_new_peer_p);
 
 /** \brief sets the cause for NgSetup Failure
@@ -98,11 +99,11 @@ int ngap_handle_new_association(
  * \param cause_type cause type
  * @returns int
  **/
-int ngap_amf_set_cause(
+status_code_e ngap_amf_set_cause(
     Ngap_Cause_t* cause_p, const Ngap_Cause_PR cause_type,
     const long cause_value);
 
-int ngap_amf_handle_error_ind_message(
+status_code_e ngap_amf_handle_error_ind_message(
     ngap_state_t* state, const sctp_assoc_id_t assoc_id,
     const sctp_stream_id_t stream, Ngap_NGAP_PDU_t* message);
 
@@ -112,20 +113,20 @@ void amf_app_handle_gnb_deregister_ind(
 void ngap_amf_release_ue_context(
     ngap_state_t* state, m5g_ue_description_t* ue_ref_p, imsi64_t imsi64);
 
-int ngap_handle_paging_request(
+status_code_e ngap_handle_paging_request(
     ngap_state_t* state, const itti_ngap_paging_request_t* paging_request,
     imsi64_t imsi64);
 
-int ngap_amf_handle_ue_context_release_request(
+status_code_e ngap_amf_handle_ue_context_release_request(
     ngap_state_t* state, const sctp_assoc_id_t assoc_id,
     const sctp_stream_id_t stream, Ngap_NGAP_PDU_t* message_p);
 
-int ngap_handle_ue_context_release_command(
+status_code_e ngap_handle_ue_context_release_command(
     ngap_state_t* state,
     const itti_ngap_ue_context_release_command_t* const
         ue_context_release_command_pP,
     imsi64_t imsi64);
 
-int ngap_amf_handle_ue_context_release_complete(
+status_code_e ngap_amf_handle_ue_context_release_complete(
     ngap_state_t* state, const sctp_assoc_id_t assoc_id,
     const sctp_stream_id_t stream, Ngap_NGAP_PDU_t* message_p);

--- a/lte/gateway/c/core/oai/tasks/ngap/ngap_amf_itti_messaging.c
+++ b/lte/gateway/c/core/oai/tasks/ngap/ngap_amf_itti_messaging.c
@@ -30,7 +30,7 @@
 
 task_zmq_ctx_t ngap_task_zmq_ctx;
 //------------------------------------------------------------------------------
-int ngap_amf_itti_send_sctp_request(
+status_code_e ngap_amf_itti_send_sctp_request(
     STOLEN_REF bstring* payload, const sctp_assoc_id_t assoc_id,
     const sctp_stream_id_t stream, const amf_ue_ngap_id_t ue_id) {
   MessageDef* message_p = NULL;
@@ -52,7 +52,7 @@ int ngap_amf_itti_send_sctp_request(
   return send_msg_to_task(&ngap_task_zmq_ctx, TASK_SCTP, message_p);
 }
 
-int ngap_amf_itti_nas_uplink_ind(
+status_code_e ngap_amf_itti_nas_uplink_ind(
     const amf_ue_ngap_id_t ue_id, STOLEN_REF bstring* payload,
     const tai_t* const tai, const ecgi_t* const cgi) {
   MessageDef* message_p = NULL;

--- a/lte/gateway/c/core/oai/tasks/ngap/ngap_amf_itti_messaging.h
+++ b/lte/gateway/c/core/oai/tasks/ngap/ngap_amf_itti_messaging.h
@@ -39,7 +39,7 @@ task_zmq_ctx_t ngap_task_zmq_ctx;
  * \param amf_ue_ngap_id_t amf_ue_ngap_id
  * @returns int
  **/
-int ngap_amf_itti_send_sctp_request(
+status_code_e ngap_amf_itti_send_sctp_request(
     STOLEN_REF bstring* payload, const uint32_t sctp_assoc_id_t,
     const sctp_stream_id_t stream, const amf_ue_ngap_id_t ue_id);
 
@@ -50,7 +50,7 @@ int ngap_amf_itti_send_sctp_request(
  * \param cgi E-UTRAN Cell Global Identification
  * @returns int
  **/
-int ngap_amf_itti_nas_uplink_ind(
+status_code_e ngap_amf_itti_nas_uplink_ind(
     const amf_ue_ngap_id_t ue_id, STOLEN_REF bstring* payload,
     const tai_t* const tai, const ecgi_t* const cgi);
 

--- a/lte/gateway/c/core/oai/tasks/ngap/ngap_amf_nas_procedures.c
+++ b/lte/gateway/c/core/oai/tasks/ngap/ngap_amf_nas_procedures.c
@@ -59,7 +59,7 @@
 #include "ngap_common.h"
 
 //------------------------------------------------------------------------------
-int ngap_amf_handle_initial_ue_message(
+status_code_e ngap_amf_handle_initial_ue_message(
     ngap_state_t* state, const sctp_assoc_id_t assoc_id,
     const sctp_stream_id_t stream, Ngap_NGAP_PDU_t* pdu) {
   Ngap_InitialUEMessage_t* container;
@@ -231,7 +231,7 @@ int ngap_amf_handle_initial_ue_message(
 
 //------------------------------------------------------------------------------
 
-int ngap_amf_handle_uplink_nas_transport(
+status_code_e ngap_amf_handle_uplink_nas_transport(
     ngap_state_t* state, const sctp_assoc_id_t assoc_id,
     __attribute__((unused)) const sctp_stream_id_t stream,
     Ngap_NGAP_PDU_t* pdu) {
@@ -344,7 +344,7 @@ int ngap_amf_handle_uplink_nas_transport(
 }
 
 //------------------------------------------------------------------------------
-int ngap_amf_handle_nas_non_delivery(
+status_code_e ngap_amf_handle_nas_non_delivery(
     ngap_state_t* state, __attribute__((unused)) sctp_assoc_id_t assoc_id,
     sctp_stream_id_t stream, Ngap_NGAP_PDU_t* pdu) {
   Ngap_NASNonDeliveryIndication_t* container;
@@ -421,7 +421,7 @@ int ngap_amf_handle_nas_non_delivery(
 }
 
 //------------------------------------------------------------------------------
-int ngap_generate_downlink_nas_transport(
+status_code_e ngap_generate_downlink_nas_transport(
     ngap_state_t* state, const gnb_ue_ngap_id_t gnb_ue_ngap_id,
     const amf_ue_ngap_id_t ue_id, STOLEN_REF bstring* payload,
     const imsi64_t imsi64) {
@@ -593,7 +593,7 @@ void ngap_handle_amf_ue_id_notification(
 }
 
 //------------------------------------------------------------------------------
-int ngap_generate_ngap_pdusession_resource_setup_req(
+status_code_e ngap_generate_ngap_pdusession_resource_setup_req(
     ngap_state_t* state, itti_ngap_pdusession_resource_setup_req_t* const
                              pdusession_resource_setup_req) {
   OAILOG_FUNC_IN(LOG_NGAP);
@@ -870,7 +870,7 @@ int ngap_generate_ngap_pdusession_resource_setup_req(
 }
 
 //------------------------------------------------------------------------------
-int ngap_generate_ngap_pdusession_resource_rel_cmd(
+status_code_e ngap_generate_ngap_pdusession_resource_rel_cmd(
     ngap_state_t* state,
     itti_ngap_pdusessionresource_rel_req_t* const pdusessionresource_rel_cmd) {
   OAILOG_FUNC_IN(LOG_NGAP);

--- a/lte/gateway/c/core/oai/tasks/ngap/ngap_amf_nas_procedures.h
+++ b/lte/gateway/c/core/oai/tasks/ngap/ngap_amf_nas_procedures.h
@@ -28,7 +28,7 @@ struct ngap_message_s;
  * \param message The message as decoded by the ASN.1 codec
  * @returns -1 on failure, 0 otherwise
  **/
-int ngap_amf_handle_initial_ue_message(
+status_code_e ngap_amf_handle_initial_ue_message(
     ngap_state_t* state, const sctp_assoc_id_t assocId,
     const sctp_stream_id_t stream, Ngap_NGAP_PDU_t* message);
 
@@ -39,7 +39,7 @@ int ngap_amf_handle_initial_ue_message(
  * \param message The message as decoded by the ASN.1 codec
  * @returns -1 on failure, 0 otherwise
  **/
-int ngap_amf_handle_uplink_nas_transport(
+status_code_e ngap_amf_handle_uplink_nas_transport(
     ngap_state_t* state, const sctp_assoc_id_t assocId,
     const sctp_stream_id_t stream, Ngap_NGAP_PDU_t* message);
 
@@ -51,7 +51,7 @@ int ngap_amf_handle_uplink_nas_transport(
  * \param imsi64 IMSI value
  * @returns int
  **/
-int ngap_generate_downlink_nas_transport(
+status_code_e ngap_generate_downlink_nas_transport(
     ngap_state_t* state, const gnb_ue_ngap_id_t gnb_ue_ngap_id,
     const amf_ue_ngap_id_t ue_id, STOLEN_REF bstring* payload, imsi64_t imsi64);
 
@@ -61,7 +61,7 @@ int ngap_generate_downlink_nas_transport(
  * \param message The message as decoded by the ASN.1 codec
  * @returns -1 on failure, 0 otherwise
  **/
-int ngap_amf_handle_nas_non_delivery(
+status_code_e ngap_amf_handle_nas_non_delivery(
     ngap_state_t* state, const sctp_assoc_id_t assocId,
     const sctp_stream_id_t stream, Ngap_NGAP_PDU_t* message);
 
@@ -80,14 +80,14 @@ void ngap_handle_amf_ue_id_notification(
  * \param message The message as decoded by the ASN.1 codec
  * @returns -1 on failure, 0 otherwise
  **/
-int ngap_amf_handle_nas_non_delivery(
+status_code_e ngap_amf_handle_nas_non_delivery(
     ngap_state_t* state, const sctp_assoc_id_t assocId,
     const sctp_stream_id_t stream, Ngap_NGAP_PDU_t* message);
 
-int ngap_generate_ngap_pdusession_resource_setup_req(
+status_code_e ngap_generate_ngap_pdusession_resource_setup_req(
     ngap_state_t* state, itti_ngap_pdusession_resource_setup_req_t* const
                              pdusession_resource_setup_req);
 
-int ngap_generate_ngap_pdusession_resource_rel_cmd(
+status_code_e ngap_generate_ngap_pdusession_resource_rel_cmd(
     ngap_state_t* state,
     itti_ngap_pdusessionresource_rel_req_t* const pdusessionresource_rel_cmd);

--- a/lte/gateway/c/core/oai/tasks/s11/s11_ie_formatter.c
+++ b/lte/gateway/c/core/oai/tasks/s11/s11_ie_formatter.c
@@ -124,7 +124,7 @@ nw_rc_t gtpv2c_node_type_ie_get(
 }
 
 //------------------------------------------------------------------------------
-int gtpv2c_node_type_ie_set(
+status_code_e gtpv2c_node_type_ie_set(
     nw_gtpv2c_msg_handle_t* msg, const node_type_t* node_type) {
   nw_rc_t rc;
   uint8_t value;
@@ -176,7 +176,7 @@ nw_rc_t gtpv2c_pdn_type_ie_get(
 }
 
 //------------------------------------------------------------------------------
-int gtpv2c_pdn_type_ie_set(
+status_code_e gtpv2c_pdn_type_ie_set(
     nw_gtpv2c_msg_handle_t* msg, const pdn_type_t* pdn_type) {
   nw_rc_t rc;
   uint8_t value;
@@ -255,7 +255,7 @@ nw_rc_t gtpv2c_rat_type_ie_get(
 }
 
 //------------------------------------------------------------------------------
-int gtpv2c_rat_type_ie_set(
+status_code_e gtpv2c_rat_type_ie_set(
     nw_gtpv2c_msg_handle_t* msg, const rat_type_t* rat_type) {
   nw_rc_t rc;
   uint8_t value;
@@ -343,7 +343,7 @@ nw_rc_t gtpv2c_pti_ie_get(
 }
 
 //------------------------------------------------------------------------------
-int gtpv2c_bearer_context_to_create_ie_set(
+status_code_e gtpv2c_bearer_context_to_create_ie_set(
     nw_gtpv2c_msg_handle_t* msg, const bearer_to_create_t* bearer_to_create) {
   nw_rc_t rc;
 
@@ -467,7 +467,8 @@ nw_rc_t gtpv2c_bearer_context_to_be_created_within_create_bearer_request_ie_get(
 }
 
 //------------------------------------------------------------------------------
-int gtpv2c_bearer_context_to_be_created_within_create_bearer_request_ie_set(
+status_code_e
+gtpv2c_bearer_context_to_be_created_within_create_bearer_request_ie_set(
     nw_gtpv2c_msg_handle_t* msg,
     const bearer_context_to_be_created_t* bearer_context) {
   nw_rc_t rc;
@@ -509,7 +510,7 @@ int gtpv2c_bearer_context_to_be_created_within_create_bearer_request_ie_set(
 }
 
 //------------------------------------------------------------------------------
-int gtpv2c_bearer_context_within_create_bearer_response_ie_set(
+status_code_e gtpv2c_bearer_context_within_create_bearer_response_ie_set(
     nw_gtpv2c_msg_handle_t* msg,
     const bearer_context_within_create_bearer_response_t* bearer_context) {
   nw_rc_t rc;
@@ -754,7 +755,8 @@ nw_rc_t gtpv2c_bearer_context_to_be_updated_within_update_bearer_request_ie_get(
 }
 
 //------------------------------------------------------------------------------
-int gtpv2c_bearer_context_to_be_updated_within_update_bearer_request_ie_set(
+status_code_e
+gtpv2c_bearer_context_to_be_updated_within_update_bearer_request_ie_set(
     nw_gtpv2c_msg_handle_t* msg,
     const bearer_context_to_be_updated_t* bearer_context) {
   nw_rc_t rc;
@@ -783,7 +785,7 @@ int gtpv2c_bearer_context_to_be_updated_within_update_bearer_request_ie_set(
 }
 
 //------------------------------------------------------------------------------
-int gtpv2c_bearer_context_within_update_bearer_response_ie_set(
+status_code_e gtpv2c_bearer_context_within_update_bearer_response_ie_set(
     nw_gtpv2c_msg_handle_t* msg,
     const bearer_context_within_update_bearer_response_t* bearer_context) {
   nw_rc_t rc;
@@ -943,7 +945,7 @@ nw_rc_t gtpv2c_failed_bearer_contexts_within_delete_bearer_request_ie_get(
 }
 
 //------------------------------------------------------------------------------
-int gtpv2c_failed_bearer_context_within_delete_bearer_request_ie_set(
+status_code_e gtpv2c_failed_bearer_context_within_delete_bearer_request_ie_set(
     nw_gtpv2c_msg_handle_t* msg,
     const bearer_context_to_be_removed_t* bearer_context) {
   nw_rc_t rc;
@@ -966,7 +968,7 @@ int gtpv2c_failed_bearer_context_within_delete_bearer_request_ie_set(
   return RETURNok;
 }
 //------------------------------------------------------------------------------
-int gtpv2c_ebis_within_delete_bearer_request_ie_set(
+status_code_e gtpv2c_ebis_within_delete_bearer_request_ie_set(
     nw_gtpv2c_msg_handle_t* msg, const ebis_to_be_deleted_t* ebis_tbd) {
   int rc = RETURNok;
   DevAssert(ebis_tbd);
@@ -997,7 +999,7 @@ nw_rc_t gtpv2c_ebis_to_be_deleted_within_delete_bearer_request_ie_get(
 }
 
 //------------------------------------------------------------------------------
-int gtpv2c_bearer_context_within_delete_bearer_response_ie_set(
+status_code_e gtpv2c_bearer_context_within_delete_bearer_response_ie_set(
     nw_gtpv2c_msg_handle_t* msg,
     const bearer_context_within_delete_bearer_response_t* bearer_context) {
   nw_rc_t rc;
@@ -1081,7 +1083,7 @@ nw_rc_t gtpv2c_bearer_context_within_delete_bearer_response_ie_get(
 }
 
 //------------------------------------------------------------------------------
-int gtpv2c_bearer_context_ebi_only_ie_set(
+status_code_e gtpv2c_bearer_context_ebi_only_ie_set(
     nw_gtpv2c_msg_handle_t* const msg, const ebi_t ebi) {
   nw_rc_t rc;
 
@@ -1100,7 +1102,8 @@ int gtpv2c_bearer_context_ebi_only_ie_set(
 }
 
 //------------------------------------------------------------------------------
-int gtpv2c_bearer_context_to_be_modified_within_modify_bearer_request_ie_set(
+status_code_e
+gtpv2c_bearer_context_to_be_modified_within_modify_bearer_request_ie_set(
     nw_gtpv2c_msg_handle_t* msg,
     const bearer_context_to_be_modified_t* bearer_context) {
   nw_rc_t rc;
@@ -1174,7 +1177,8 @@ gtpv2c_bearer_context_to_be_modified_within_modify_bearer_request_ie_get(
 }
 
 //------------------------------------------------------------------------------
-int gtpv2c_bearer_context_to_be_removed_within_modify_bearer_request_ie_set(
+status_code_e
+gtpv2c_bearer_context_to_be_removed_within_modify_bearer_request_ie_set(
     nw_gtpv2c_msg_handle_t* msg,
     const bearer_context_to_be_removed_t* bearer_context) {
   nw_rc_t rc;
@@ -1350,7 +1354,7 @@ nw_rc_t gtpv2c_bearer_context_marked_for_removal_ie_get(
 }
 
 //------------------------------------------------------------------------------
-int gtpv2c_bearer_context_marked_for_removal_ie_set(
+status_code_e gtpv2c_bearer_context_marked_for_removal_ie_set(
     nw_gtpv2c_msg_handle_t* msg,
     const bearer_context_marked_for_removal_t* const bearer) {
   nw_rc_t rc;
@@ -1388,7 +1392,7 @@ nw_rc_t gtpv2c_apn_restriction_ie_get(
    by any already active bearer context. If there are no already active bearer
    contexts, this value is set to the least restrictive type.
 */
-int gtpv2c_apn_restriction_ie_set(
+status_code_e gtpv2c_apn_restriction_ie_set(
     nw_gtpv2c_msg_handle_t* msg, const uint8_t apn_restriction) {
   nw_rc_t rc;
 
@@ -1431,7 +1435,7 @@ nw_rc_t gtpv2c_serving_network_ie_get(
 }
 
 //------------------------------------------------------------------------------
-int gtpv2c_serving_network_ie_set(
+status_code_e gtpv2c_serving_network_ie_set(
     nw_gtpv2c_msg_handle_t* msg, const ServingNetwork_t* serving_network) {
   nw_rc_t rc;
   uint8_t value[3];
@@ -1477,7 +1481,7 @@ nw_rc_t gtpv2c_pco_ie_get(
 }
 
 //------------------------------------------------------------------------------
-int gtpv2c_pco_ie_set(
+status_code_e gtpv2c_pco_ie_set(
     nw_gtpv2c_msg_handle_t* msg, const protocol_configuration_options_t* pco) {
   uint8_t temp[PROTOCOL_CONFIGURATION_OPTIONS_IE_MAX_LENGTH];
   uint8_t offset = 0;
@@ -1531,7 +1535,7 @@ nw_rc_t gtpv2c_apn_ie_get(
 }
 
 //------------------------------------------------------------------------------
-int gtpv2c_apn_ie_set(nw_gtpv2c_msg_handle_t* msg, const char* apn) {
+status_code_e gtpv2c_apn_ie_set(nw_gtpv2c_msg_handle_t* msg, const char* apn) {
   nw_rc_t rc;
   uint8_t* value;
   uint8_t apn_length;
@@ -1566,7 +1570,7 @@ int gtpv2c_apn_ie_set(nw_gtpv2c_msg_handle_t* msg, const char* apn) {
   return RETURNok;
 }
 
-int gtpv2c_apn_plmn_ie_set(
+status_code_e gtpv2c_apn_plmn_ie_set(
     nw_gtpv2c_msg_handle_t* msg, const char* apn,
     const ServingNetwork_t* serving_network) {
   nw_rc_t rc;
@@ -1611,7 +1615,7 @@ int gtpv2c_apn_plmn_ie_set(
   return RETURNok;
 }
 
-int gtpv2c_uli_ie_set(nw_gtpv2c_msg_handle_t* msg, const Uli_t* uli) {
+status_code_e gtpv2c_uli_ie_set(nw_gtpv2c_msg_handle_t* msg, const Uli_t* uli) {
   nw_rc_t rc;
   uint8_t value[22];
   uint8_t* current = NULL;
@@ -1696,7 +1700,7 @@ nw_rc_t gtpv2c_ip_address_ie_get(
 }
 
 //------------------------------------------------------------------------------
-int gtpv2c_ip_address_ie_set(
+status_code_e gtpv2c_ip_address_ie_set(
     nw_gtpv2c_msg_handle_t* msg, const gtp_ip_address_t* ip_address) {
   return RETURNok;
 }
@@ -1719,7 +1723,7 @@ nw_rc_t gtpv2c_delay_value_ie_get(
 }
 
 //------------------------------------------------------------------------------
-int gtpv2c_delay_value_ie_set(
+status_code_e gtpv2c_delay_value_ie_set(
     nw_gtpv2c_msg_handle_t* msg, const DelayValue_t* delay_value) {
   uint8_t value;
   nw_rc_t rc;
@@ -1754,7 +1758,7 @@ nw_rc_t gtpv2c_ue_time_zone_ie_get(
 }
 
 //------------------------------------------------------------------------------
-int gtpv2c_ue_time_zone_ie_set(
+status_code_e gtpv2c_ue_time_zone_ie_set(
     nw_gtpv2c_msg_handle_t* msg, const UETimeZone_t* ue_time_zone) {
   uint8_t value[2];
   nw_rc_t rc;
@@ -1786,7 +1790,7 @@ nw_rc_t gtpv2c_bearer_flags_ie_get(
 }
 
 //------------------------------------------------------------------------------
-int gtpv2c_bearer_flags_ie_set(
+status_code_e gtpv2c_bearer_flags_ie_set(
     nw_gtpv2c_msg_handle_t* msg, const bearer_flags_t* bearer_flags) {
   nw_rc_t rc;
   uint8_t value;
@@ -1846,7 +1850,7 @@ nw_rc_t gtpv2c_indication_flags_ie_get(
 }
 
 //------------------------------------------------------------------------------
-int gtpv2c_indication_flags_ie_set(
+status_code_e gtpv2c_indication_flags_ie_set(
     nw_gtpv2c_msg_handle_t* msg, const indication_flags_t* indication_flags) {
   nw_rc_t rc;
   uint8_t value[3];

--- a/lte/gateway/c/core/oai/tasks/s11/s11_ie_formatter.h
+++ b/lte/gateway/c/core/oai/tasks/s11/s11_ie_formatter.h
@@ -22,6 +22,7 @@
   \email: lionel.gauthier@eurecom.fr
 */
 
+#include "common_defs.h"
 #include "sgw_ie_defs.h"
 
 #ifndef FILE_S11_IE_FORMATTER_SEEN
@@ -49,7 +50,7 @@ nw_rc_t gtpv2c_node_type_ie_get(
     uint8_t ieType, uint16_t ieLength, uint8_t ieInstance, uint8_t* ieValue,
     void* arg);
 
-int gtpv2c_node_type_ie_set(
+status_code_e gtpv2c_node_type_ie_set(
     nw_gtpv2c_msg_handle_t* msg, const node_type_t* node_type);
 
 /* PDN Type Information Element
@@ -63,7 +64,7 @@ nw_rc_t gtpv2c_pdn_type_ie_get(
     uint8_t ieType, uint16_t ieLength, uint8_t ieInstance, uint8_t* ieValue,
     void* arg);
 
-int gtpv2c_pdn_type_ie_set(
+status_code_e gtpv2c_pdn_type_ie_set(
     nw_gtpv2c_msg_handle_t* msg, const pdn_type_t* pdn_type);
 
 /* RAT type Information Element
@@ -74,47 +75,49 @@ nw_rc_t gtpv2c_rat_type_ie_get(
     uint8_t ieType, uint16_t ieLength, uint8_t ieInstance, uint8_t* ieValue,
     void* arg);
 
-int gtpv2c_rat_type_ie_set(
+status_code_e gtpv2c_rat_type_ie_set(
     nw_gtpv2c_msg_handle_t* msg, const rat_type_t* rat_type);
 
 nw_rc_t gtpv2c_bearer_context_to_be_created_within_create_bearer_request_ie_get(
     uint8_t ieType, uint16_t ieLength, uint8_t ieInstance, uint8_t* ieValue,
     void* arg);
-int gtpv2c_bearer_context_to_be_created_within_create_bearer_request_ie_set(
+status_code_e
+gtpv2c_bearer_context_to_be_created_within_create_bearer_request_ie_set(
     nw_gtpv2c_msg_handle_t* msg,
     const bearer_context_to_be_created_t* bearer_context);
 
 nw_rc_t gtpv2c_failed_bearer_contexts_within_delete_bearer_request_ie_get(
     uint8_t ieType, uint16_t ieLength, uint8_t ieInstance, uint8_t* ieValue,
     void* arg);
-int gtpv2c_failed_bearer_context_within_delete_bearer_request_ie_set(
+status_code_e gtpv2c_failed_bearer_context_within_delete_bearer_request_ie_set(
     nw_gtpv2c_msg_handle_t* msg,
     const bearer_context_to_be_removed_t* bearer_context);
 
-int gtpv2c_bearer_context_within_create_bearer_response_ie_set(
+status_code_e gtpv2c_bearer_context_within_create_bearer_response_ie_set(
     nw_gtpv2c_msg_handle_t* msg,
     const bearer_context_within_create_bearer_response_t* bearer_context);
 nw_rc_t gtpv2c_bearer_context_within_create_bearer_response_ie_get(
     uint8_t ieType, uint16_t ieLength, uint8_t ieInstance, uint8_t* ieValue,
     void* arg);
 
-int gtpv2c_ebis_within_delete_bearer_request_ie_set(
+status_code_e gtpv2c_ebis_within_delete_bearer_request_ie_set(
     nw_gtpv2c_msg_handle_t* msg, const ebis_to_be_deleted_t* ebis_tbd);
 nw_rc_t gtpv2c_ebis_to_be_deleted_within_delete_bearer_request_ie_get(
     uint8_t ieType, uint16_t ieLength, uint8_t ieInstance, uint8_t* ieValue,
     void* arg);
 
-int gtpv2c_bearer_context_within_delete_bearer_response_ie_set(
+status_code_e gtpv2c_bearer_context_within_delete_bearer_response_ie_set(
     nw_gtpv2c_msg_handle_t* msg,
     const bearer_context_within_delete_bearer_response_t* bearer_context);
 nw_rc_t gtpv2c_bearer_context_within_delete_bearer_response_ie_get(
     uint8_t ieType, uint16_t ieLength, uint8_t ieInstance, uint8_t* ieValue,
     void* arg);
 
-int gtpv2c_bearer_context_ebi_only_ie_set(
+status_code_e gtpv2c_bearer_context_ebi_only_ie_set(
     nw_gtpv2c_msg_handle_t* const msg, const ebi_t ebi);
 
-int gtpv2c_bearer_context_to_be_modified_within_modify_bearer_request_ie_set(
+status_code_e
+gtpv2c_bearer_context_to_be_modified_within_modify_bearer_request_ie_set(
     nw_gtpv2c_msg_handle_t* msg,
     const bearer_context_to_be_modified_t* bearer_context);
 nw_rc_t
@@ -122,7 +125,8 @@ gtpv2c_bearer_context_to_be_modified_within_modify_bearer_request_ie_get(
     uint8_t ieType, uint16_t ieLength, uint8_t ieInstance, uint8_t* ieValue,
     void* arg);
 
-int gtpv2c_bearer_context_to_be_removed_within_modify_bearer_request_ie_set(
+status_code_e
+gtpv2c_bearer_context_to_be_removed_within_modify_bearer_request_ie_set(
     nw_gtpv2c_msg_handle_t* msg,
     const bearer_context_to_be_removed_t* bearer_context);
 nw_rc_t gtpv2c_bearer_context_to_be_removed_within_modify_bearer_request_ie_get(
@@ -147,7 +151,7 @@ nw_rc_t gtpv2c_bearer_context_modified_ie_get(
 nw_rc_t gtpv2c_bearer_context_marked_for_removal_ie_get(
     uint8_t ieType, uint16_t ieLength, uint8_t ieInstance, uint8_t* ieValue,
     void* arg);
-int gtpv2c_bearer_context_marked_for_removal_ie_set(
+status_code_e gtpv2c_bearer_context_marked_for_removal_ie_set(
     nw_gtpv2c_msg_handle_t* msg,
     const bearer_context_marked_for_removal_t* const bearer);
 
@@ -157,14 +161,14 @@ int gtpv2c_bearer_context_marked_for_removal_ie_set(
 nw_rc_t gtpv2c_serving_network_ie_get(
     uint8_t ieType, uint16_t ieLength, uint8_t ieInstance, uint8_t* ieValue,
     void* arg);
-int gtpv2c_serving_network_ie_set(
+status_code_e gtpv2c_serving_network_ie_set(
     nw_gtpv2c_msg_handle_t* msg, const ServingNetwork_t* serving_network);
 
 /* Protocol Configuration Options Information Element */
 nw_rc_t gtpv2c_pco_ie_get(
     uint8_t ieType, uint16_t ieLength, uint8_t ieInstance, uint8_t* ieValue,
     void* arg);
-int gtpv2c_pco_ie_set(
+status_code_e gtpv2c_pco_ie_set(
     nw_gtpv2c_msg_handle_t* msg, const protocol_configuration_options_t* pco);
 
 /* Access Point Name Information Element
@@ -177,13 +181,13 @@ nw_rc_t gtpv2c_apn_ie_get(
     uint8_t ieType, uint16_t ieLength, uint8_t ieInstance, uint8_t* ieValue,
     void* arg);
 
-int gtpv2c_apn_ie_set(nw_gtpv2c_msg_handle_t* msg, const char* apn);
+status_code_e gtpv2c_apn_ie_set(nw_gtpv2c_msg_handle_t* msg, const char* apn);
 
-int gtpv2c_apn_plmn_ie_set(
+status_code_e gtpv2c_apn_plmn_ie_set(
     nw_gtpv2c_msg_handle_t* msg, const char* apn,
     const ServingNetwork_t* serving_network);
 
-int gtpv2c_uli_ie_set(nw_gtpv2c_msg_handle_t* msg, const Uli_t* uli);
+status_code_e gtpv2c_uli_ie_set(nw_gtpv2c_msg_handle_t* msg, const Uli_t* uli);
 
 nw_rc_t gtpv2c_mei_ie_get(
     uint8_t ieType, uint16_t ieLength, uint8_t ieInstance, uint8_t* ieValue,
@@ -199,7 +203,7 @@ nw_rc_t gtpv2c_uli_ie_get(
 nw_rc_t gtpv2c_apn_restriction_ie_get(
     uint8_t ieType, uint16_t ieLength, uint8_t ieInstance, uint8_t* ieValue,
     void* arg);
-int gtpv2c_apn_restriction_ie_set(
+status_code_e gtpv2c_apn_restriction_ie_set(
     nw_gtpv2c_msg_handle_t* msg, const uint8_t apn_restriction);
 
 /* IP address Information Element
@@ -208,7 +212,7 @@ int gtpv2c_apn_restriction_ie_set(
 nw_rc_t gtpv2c_ip_address_ie_get(
     uint8_t ieType, uint16_t ieLength, uint8_t ieInstance, uint8_t* ieValue,
     void* arg);
-int gtpv2c_ip_address_ie_set(
+status_code_e gtpv2c_ip_address_ie_set(
     nw_gtpv2c_msg_handle_t* msg, const gtp_ip_address_t* ip_address);
 
 /* Delay Value Information Element
@@ -217,7 +221,7 @@ int gtpv2c_ip_address_ie_set(
 nw_rc_t gtpv2c_delay_value_ie_get(
     uint8_t ieType, uint16_t ieLength, uint8_t ieInstance, uint8_t* ieValue,
     void* arg);
-int gtpv2c_delay_value_ie_set(
+status_code_e gtpv2c_delay_value_ie_set(
     nw_gtpv2c_msg_handle_t* msg, const DelayValue_t* delay_value);
 
 /* UE Time Zone Information Element
@@ -226,7 +230,7 @@ int gtpv2c_delay_value_ie_set(
 nw_rc_t gtpv2c_ue_time_zone_ie_get(
     uint8_t ieType, uint16_t ieLength, uint8_t ieInstance, uint8_t* ieValue,
     void* arg);
-int gtpv2c_ue_time_zone_ie_set(
+status_code_e gtpv2c_ue_time_zone_ie_set(
     nw_gtpv2c_msg_handle_t* msg, const UETimeZone_t* ue_time_zone);
 
 /* Bearer Flags Information Element
@@ -235,7 +239,7 @@ int gtpv2c_ue_time_zone_ie_set(
 nw_rc_t gtpv2c_bearer_flags_ie_get(
     uint8_t ieType, uint16_t ieLength, uint8_t ieInstance, uint8_t* ieValue,
     void* arg);
-int gtpv2c_bearer_flags_ie_set(
+status_code_e gtpv2c_bearer_flags_ie_set(
     nw_gtpv2c_msg_handle_t* msg, const bearer_flags_t* bearer_flags);
 
 /* Indication Element
@@ -244,7 +248,7 @@ int gtpv2c_bearer_flags_ie_set(
 nw_rc_t gtpv2c_indication_flags_ie_get(
     uint8_t ieType, uint16_t ieLength, uint8_t ieInstance, uint8_t* ieValue,
     void* arg);
-int gtpv2c_indication_flags_ie_set(
+status_code_e gtpv2c_indication_flags_ie_set(
     nw_gtpv2c_msg_handle_t* msg, const indication_flags_t* indication_flags);
 
 /* FQ-CSID Information Element

--- a/lte/gateway/c/core/oai/tasks/s11/s11_mme_bearer_manager.c
+++ b/lte/gateway/c/core/oai/tasks/s11/s11_mme_bearer_manager.c
@@ -49,7 +49,7 @@
 extern hash_table_ts_t* s11_mme_teid_2_gtv2c_teid_handle;
 
 //------------------------------------------------------------------------------
-int s11_mme_release_access_bearers_request(
+status_code_e s11_mme_release_access_bearers_request(
     nw_gtpv2c_stack_handle_t* stack_p,
     itti_s11_release_access_bearers_request_t* req_p) {
   nw_gtpv2c_ulp_api_t ulp_req;
@@ -94,7 +94,7 @@ int s11_mme_release_access_bearers_request(
 }
 
 //------------------------------------------------------------------------------
-int s11_mme_downlink_data_notification_acknowledge(
+status_code_e s11_mme_downlink_data_notification_acknowledge(
     nw_gtpv2c_stack_handle_t* stack_p,
     itti_s11_downlink_data_notification_acknowledge_t* ack_p) {
   nw_gtpv2c_ulp_api_t ulp_ack;
@@ -144,7 +144,7 @@ int s11_mme_downlink_data_notification_acknowledge(
 }
 
 //------------------------------------------------------------------------------
-int s11_mme_handle_release_access_bearer_response(
+status_code_e s11_mme_handle_release_access_bearer_response(
     nw_gtpv2c_stack_handle_t* stack_p, nw_gtpv2c_ulp_api_t* pUlpApi) {
   nw_rc_t rc = NW_OK;
   uint8_t offendingIeType, offendingIeInstance;
@@ -196,7 +196,7 @@ int s11_mme_handle_release_access_bearer_response(
 }
 
 //------------------------------------------------------------------------------
-int s11_mme_modify_bearer_request(
+status_code_e s11_mme_modify_bearer_request(
     nw_gtpv2c_stack_handle_t* stack_p,
     itti_s11_modify_bearer_request_t* req_p) {
   nw_gtpv2c_ulp_api_t ulp_req;
@@ -264,7 +264,7 @@ int s11_mme_modify_bearer_request(
 }
 
 //------------------------------------------------------------------------------
-int s11_mme_handle_modify_bearer_response(
+status_code_e s11_mme_handle_modify_bearer_response(
     nw_gtpv2c_stack_handle_t* stack_p, nw_gtpv2c_ulp_api_t* pUlpApi) {
   nw_rc_t rc = NW_OK;
   uint8_t offendingIeType, offendingIeInstance;
@@ -348,7 +348,7 @@ int s11_mme_handle_modify_bearer_response(
 }
 
 //------------------------------------------------------------------------------
-int s11_mme_delete_bearer_command(
+status_code_e s11_mme_delete_bearer_command(
     nw_gtpv2c_stack_handle_t* stack_p,
     itti_s11_delete_bearer_command_t* cmd_p) {
   nw_gtpv2c_ulp_api_t ulp_req;
@@ -395,7 +395,7 @@ int s11_mme_delete_bearer_command(
 }
 
 //------------------------------------------------------------------------------
-int s11_mme_handle_create_bearer_request(
+status_code_e s11_mme_handle_create_bearer_request(
     nw_gtpv2c_stack_handle_t* stack_p, nw_gtpv2c_ulp_api_t* pUlpApi) {
   nw_rc_t rc = NW_OK;
   uint8_t offendingIeType, offendingIeInstance;
@@ -472,7 +472,7 @@ int s11_mme_handle_create_bearer_request(
 }
 
 //------------------------------------------------------------------------------
-int s11_mme_create_bearer_response(
+status_code_e s11_mme_create_bearer_response(
     nw_gtpv2c_stack_handle_t* stack_p,
     itti_s11_create_bearer_response_t* response_p) {
   gtpv2c_cause_t cause;

--- a/lte/gateway/c/core/oai/tasks/s11/s11_mme_bearer_manager.h
+++ b/lte/gateway/c/core/oai/tasks/s11/s11_mme_bearer_manager.h
@@ -25,30 +25,32 @@
 #ifndef FILE_S11_MME_BEARER_MANAGER_SEEN
 #define FILE_S11_MME_BEARER_MANAGER_SEEN
 
+#include "common_defs.h"
+
 /* @brief Create a new Release Access Bearers Request and send it to provided
  * S-GW. */
-int s11_mme_release_access_bearers_request(
+status_code_e s11_mme_release_access_bearers_request(
     nw_gtpv2c_stack_handle_t* stack_p,
     itti_s11_release_access_bearers_request_t* release_access_bearers_p);
 
 /* @brief Handle a Release Access Bearer Response received from S-GW. */
-int s11_mme_handle_release_access_bearer_response(
+status_code_e s11_mme_handle_release_access_bearer_response(
     nw_gtpv2c_stack_handle_t* stack_p, nw_gtpv2c_ulp_api_t* pUlpApi);
 
 /* @brief Handle a Modify Bearer Response received from S-GW. */
-int s11_mme_handle_modify_bearer_response(
+status_code_e s11_mme_handle_modify_bearer_response(
     nw_gtpv2c_stack_handle_t* stack_p, nw_gtpv2c_ulp_api_t* pUlpApi);
 
 /* @brief Create a new Delete Bearer Command and send it to provided S-GW. */
-int s11_mme_delete_bearer_command(
+status_code_e s11_mme_delete_bearer_command(
     nw_gtpv2c_stack_handle_t* stack_p, itti_s11_delete_bearer_command_t* cmd_p);
 
 /* @brief Handle a Create Bearer Request received from S-GW. */
-int s11_mme_handle_create_bearer_request(
+status_code_e s11_mme_handle_create_bearer_request(
     nw_gtpv2c_stack_handle_t* stack_p, nw_gtpv2c_ulp_api_t* pUlpApi);
 
 /* @brief Create a new Create Bearer Response and send it to provided S-GW. */
-int s11_mme_create_bearer_response(
+status_code_e s11_mme_create_bearer_response(
     nw_gtpv2c_stack_handle_t* stack_p,
     itti_s11_create_bearer_response_t* rsp_p);
 
@@ -61,7 +63,7 @@ int s11_mme_handle_downlink_data_notification(
     nw_gtpv2c_stack_handle_t* stack_p, nw_gtpv2c_ulp_api_t* pUlpApi);
 
 /* @brief Handle a Downlink Data Notification acknowledge received from S-GW. */
-int s11_mme_downlink_data_notification_acknowledge(
+status_code_e s11_mme_downlink_data_notification_acknowledge(
     nw_gtpv2c_stack_handle_t* stack_p,
     itti_s11_downlink_data_notification_acknowledge_t* ack_p);
 

--- a/lte/gateway/c/core/oai/tasks/s11/s11_mme_session_manager.c
+++ b/lte/gateway/c/core/oai/tasks/s11/s11_mme_session_manager.c
@@ -56,7 +56,7 @@
 extern hash_table_ts_t* s11_mme_teid_2_gtv2c_teid_handle;
 
 //------------------------------------------------------------------------------
-int s11_mme_create_session_request(
+status_code_e s11_mme_create_session_request(
     nw_gtpv2c_stack_handle_t* stack_p,
     itti_s11_create_session_request_t* req_p) {
   nw_gtpv2c_ulp_api_t ulp_req = {0};
@@ -171,7 +171,7 @@ int s11_mme_create_session_request(
 }
 
 //------------------------------------------------------------------------------
-int s11_mme_handle_create_session_response(
+status_code_e s11_mme_handle_create_session_response(
     nw_gtpv2c_stack_handle_t* stack_p, nw_gtpv2c_ulp_api_t* pUlpApi) {
   nw_rc_t rc = NW_OK;
   uint8_t offendingIeType, offendingIeInstance;
@@ -291,7 +291,7 @@ int s11_mme_handle_create_session_response(
 }
 
 //------------------------------------------------------------------------------
-int s11_mme_delete_session_request(
+status_code_e s11_mme_delete_session_request(
     nw_gtpv2c_stack_handle_t* stack_p,
     itti_s11_delete_session_request_t* req_p) {
   nw_gtpv2c_ulp_api_t ulp_req;
@@ -349,7 +349,7 @@ int s11_mme_delete_session_request(
 }
 
 //------------------------------------------------------------------------------
-int s11_mme_handle_delete_session_response(
+status_code_e s11_mme_handle_delete_session_response(
     nw_gtpv2c_stack_handle_t* stack_p, nw_gtpv2c_ulp_api_t* pUlpApi) {
   nw_rc_t rc = NW_OK;
   uint8_t offendingIeType, offendingIeInstance;
@@ -436,7 +436,7 @@ int s11_mme_handle_delete_session_response(
 }
 
 //------------------------------------------------------------------------------
-int s11_mme_handle_ulp_error_indicatior(
+status_code_e s11_mme_handle_ulp_error_indicatior(
     nw_gtpv2c_stack_handle_t* stack_p, nw_gtpv2c_ulp_api_t* pUlpApi) {
   /** Get the failed transaction. */
   /** Check the message type. */

--- a/lte/gateway/c/core/oai/tasks/s11/s11_mme_session_manager.h
+++ b/lte/gateway/c/core/oai/tasks/s11/s11_mme_session_manager.h
@@ -25,29 +25,31 @@
 #ifndef FILE_S11_MME_SESSION_MANAGER_SEEN
 #define FILE_S11_MME_SESSION_MANAGER_SEEN
 
+#include "common_defs.h"
+
 /* @brief Create a new Create Session Request and send it to provided S-GW. */
-int s11_mme_create_session_request(
+status_code_e s11_mme_create_session_request(
     nw_gtpv2c_stack_handle_t* stack_p,
     itti_s11_create_session_request_t* create_session_p);
 
 /* @brief Handle a Create Session Response received from S-GW. */
-int s11_mme_handle_create_session_response(
+status_code_e s11_mme_handle_create_session_response(
     nw_gtpv2c_stack_handle_t* stack_p, nw_gtpv2c_ulp_api_t* pUlpApi);
 
 /* @brief Create a new Delete Session Request and send it to provided S-GW. */
-int s11_mme_delete_session_request(
+status_code_e s11_mme_delete_session_request(
     nw_gtpv2c_stack_handle_t* stack_p,
     itti_s11_delete_session_request_t* delete_session_p);
 
-int s11_mme_handle_delete_session_response(
+status_code_e s11_mme_handle_delete_session_response(
     nw_gtpv2c_stack_handle_t* stack_p, nw_gtpv2c_ulp_api_t* pUlpApi);
 
 /* @brief Create a new Modify Bearer Request and send it to provided S-GW. */
-int s11_mme_modify_bearer_request(
+status_code_e s11_mme_modify_bearer_request(
     nw_gtpv2c_stack_handle_t* stack_p,
     itti_s11_modify_bearer_request_t* modify_bearer_p);
 
-int s11_mme_handle_ulp_error_indicatior(
+status_code_e s11_mme_handle_ulp_error_indicatior(
     nw_gtpv2c_stack_handle_t* stack_p, nw_gtpv2c_ulp_api_t* pUlpApi);
 
 #endif /* FILE_S11_MME_SESSION_MANAGER_SEEN */

--- a/lte/gateway/c/core/oai/tasks/s11/s11_tasks.c
+++ b/lte/gateway/c/core/oai/tasks/s11/s11_tasks.c
@@ -382,7 +382,7 @@ static void* s11_mme_thread(void* args) {
 }
 
 //------------------------------------------------------------------------------
-int s11_mme_init(mme_config_t* mme_config_p) {
+status_code_e s11_mme_init(mme_config_t* mme_config_p) {
   int ret = 0;
 
   OAILOG_DEBUG(LOG_S11, "Initializing S11 interface\n");

--- a/lte/gateway/c/core/oai/tasks/s1ap/s1ap_mme.c
+++ b/lte/gateway/c/core/oai/tasks/s1ap/s1ap_mme.c
@@ -375,7 +375,7 @@ static void* s1ap_mme_thread(__attribute__((unused)) void* args) {
 }
 
 //------------------------------------------------------------------------------
-int s1ap_mme_init(const mme_config_t* mme_config_p) {
+status_code_e s1ap_mme_init(const mme_config_t* mme_config_p) {
   OAILOG_DEBUG(LOG_S1AP, "Initializing S1AP interface\n");
 
   if (get_asn1c_environment_version() < ASN1_MINIMUM_VERSION) {

--- a/lte/gateway/c/core/oai/tasks/s1ap/s1ap_mme.h
+++ b/lte/gateway/c/core/oai/tasks/s1ap/s1ap_mme.h
@@ -29,6 +29,7 @@
 #include "intertask_interface.h"
 #endif
 
+#include "common_defs.h"
 #include "s1ap_state.h"
 #include "s1ap_types.h"
 
@@ -40,7 +41,7 @@ extern bool hss_associated;
 /** \brief S1AP layer top init
  * @returns -1 in case of failure
  **/
-int s1ap_mme_init(const mme_config_t* mme_config);
+status_code_e s1ap_mme_init(const mme_config_t* mme_config);
 
 /** \brief S1AP layer top exit
  **/

--- a/lte/gateway/c/core/oai/tasks/s1ap/s1ap_mme_decoder.c
+++ b/lte/gateway/c/core/oai/tasks/s1ap/s1ap_mme_decoder.c
@@ -40,7 +40,8 @@
 #include "per_decoder.h"
 
 //-----------------------------------------------------------------------------
-int s1ap_mme_decode_pdu(S1ap_S1AP_PDU_t* pdu, const_bstring const raw) {
+status_code_e s1ap_mme_decode_pdu(
+    S1ap_S1AP_PDU_t* pdu, const_bstring const raw) {
   if ((pdu) && (raw)) {
     if (blength(raw) == 0) {
       OAILOG_DEBUG(LOG_S1AP, "Buffer length is Zero \n");

--- a/lte/gateway/c/core/oai/tasks/s1ap/s1ap_mme_decoder.h
+++ b/lte/gateway/c/core/oai/tasks/s1ap/s1ap_mme_decoder.h
@@ -18,8 +18,9 @@
 #ifndef FILE_S1AP_MME_DECODER_SEEN
 #define FILE_S1AP_MME_DECODER_SEEN
 #include "bstrlib.h"
+#include "common_defs.h"
 #include "s1ap_common.h"
 
-int s1ap_mme_decode_pdu(S1ap_S1AP_PDU_t* pdu, const_bstring const raw)
+status_code_e s1ap_mme_decode_pdu(S1ap_S1AP_PDU_t* pdu, const_bstring const raw)
     __attribute__((warn_unused_result));
 #endif /* FILE_S1AP_MME_DECODER_SEEN */

--- a/lte/gateway/c/core/oai/tasks/s1ap/s1ap_mme_encoder.c
+++ b/lte/gateway/c/core/oai/tasks/s1ap/s1ap_mme_encoder.c
@@ -31,7 +31,7 @@ static inline int s1ap_mme_encode_successfull_outcome(
 static inline int s1ap_mme_encode_unsuccessfull_outcome(
     S1ap_S1AP_PDU_t* pdu, uint8_t** buffer, uint32_t* len);
 //------------------------------------------------------------------------------
-int s1ap_mme_encode_pdu(
+status_code_e s1ap_mme_encode_pdu(
     S1ap_S1AP_PDU_t* pdu, uint8_t** buffer, uint32_t* length) {
   int ret = -1;
 

--- a/lte/gateway/c/core/oai/tasks/s1ap/s1ap_mme_encoder.h
+++ b/lte/gateway/c/core/oai/tasks/s1ap/s1ap_mme_encoder.h
@@ -19,9 +19,10 @@
 
 #ifndef FILE_S1AP_MME_ENCODER_SEEN
 #define FILE_S1AP_MME_ENCODER_SEEN
+#include "common_defs.h"
 #include "S1ap_S1AP-PDU.h"
 
-int s1ap_mme_encode_pdu(
+status_code_e s1ap_mme_encode_pdu(
     S1ap_S1AP_PDU_t* message, uint8_t** buffer, uint32_t* len)
     __attribute__((warn_unused_result));
 

--- a/lte/gateway/c/core/oai/tasks/s1ap/s1ap_mme_handlers.c
+++ b/lte/gateway/c/core/oai/tasks/s1ap/s1ap_mme_handlers.c
@@ -105,7 +105,7 @@ struct S1ap_E_RABSetupItemBearerSURes_s;
 struct S1ap_E_RABSetupItemCtxtSURes_s;
 struct S1ap_IE;
 
-int s1ap_generate_s1_setup_response(
+status_code_e s1ap_generate_s1_setup_response(
     s1ap_state_t* state, enb_description_t* enb_association);
 
 bool is_all_erabId_same(S1ap_PathSwitchRequest_t* container);
@@ -192,7 +192,7 @@ s1ap_message_handler_t message_handlers[][3] = {
     {0, 0, 0}, /* 62 SecondaryRATDataUsageReport */
 };
 
-int s1ap_mme_handle_message(
+status_code_e s1ap_mme_handle_message(
     s1ap_state_t* state, const sctp_assoc_id_t assoc_id,
     const sctp_stream_id_t stream, S1ap_S1AP_PDU_t* pdu) {
   /*
@@ -227,7 +227,7 @@ int s1ap_mme_handle_message(
 }
 
 //------------------------------------------------------------------------------
-int s1ap_mme_set_cause(
+status_code_e s1ap_mme_set_cause(
     S1ap_Cause_t* cause_p, const S1ap_Cause_PR cause_type,
     const long cause_value) {
   if (cause_p == NULL) {
@@ -306,7 +306,7 @@ long s1ap_mme_get_cause_value(S1ap_Cause_t* cause) {
 }
 
 //------------------------------------------------------------------------------
-int s1ap_mme_generate_s1_setup_failure(
+status_code_e s1ap_mme_generate_s1_setup_failure(
     const sctp_assoc_id_t assoc_id, const S1ap_Cause_PR cause_type,
     const long cause_value, const long time_to_wait) {
   uint8_t* buffer_p = 0;
@@ -421,7 +421,7 @@ void clean_stale_enb_state(
   OAILOG_DEBUG(LOG_S1AP, "Removed stale eNB and all associated UEs.");
 }
 
-int s1ap_mme_handle_s1_setup_request(
+status_code_e s1ap_mme_handle_s1_setup_request(
     s1ap_state_t* state, const sctp_assoc_id_t assoc_id,
     const sctp_stream_id_t stream, S1ap_S1AP_PDU_t* pdu) {
   int rc = RETURNok;
@@ -673,7 +673,7 @@ int s1ap_mme_handle_s1_setup_request(
 }
 
 //------------------------------------------------------------------------------
-int s1ap_generate_s1_setup_response(
+status_code_e s1ap_generate_s1_setup_response(
     s1ap_state_t* state, enb_description_t* enb_association) {
   S1ap_S1AP_PDU_t pdu;
   S1ap_S1SetupResponse_t* out;
@@ -790,7 +790,7 @@ int s1ap_generate_s1_setup_response(
 }
 
 //------------------------------------------------------------------------------
-int s1ap_mme_handle_ue_cap_indication(
+status_code_e s1ap_mme_handle_ue_cap_indication(
     s1ap_state_t* state, __attribute__((unused)) const sctp_assoc_id_t assoc_id,
     const sctp_stream_id_t stream, S1ap_S1AP_PDU_t* pdu) {
   ue_description_t* ue_ref_p = NULL;
@@ -911,7 +911,7 @@ int s1ap_mme_handle_ue_cap_indication(
 ////////////////////////////////////////////////////////////////////////////////
 
 //------------------------------------------------------------------------------
-int s1ap_mme_handle_initial_context_setup_response(
+status_code_e s1ap_mme_handle_initial_context_setup_response(
     s1ap_state_t* state, __attribute__((unused)) const sctp_assoc_id_t assoc_id,
     __attribute__((unused)) const sctp_stream_id_t stream,
     S1ap_S1AP_PDU_t* pdu) {
@@ -1077,7 +1077,7 @@ int s1ap_mme_handle_initial_context_setup_response(
 }
 
 //------------------------------------------------------------------------------
-int s1ap_mme_handle_ue_context_release_request(
+status_code_e s1ap_mme_handle_ue_context_release_request(
     s1ap_state_t* state, __attribute__((unused)) const sctp_assoc_id_t assoc_id,
     __attribute__((unused)) const sctp_stream_id_t stream,
     S1ap_S1AP_PDU_t* pdu) {
@@ -1244,7 +1244,7 @@ int s1ap_mme_handle_ue_context_release_request(
 }
 
 //------------------------------------------------------------------------------
-int s1ap_mme_generate_ue_context_release_command(
+status_code_e s1ap_mme_generate_ue_context_release_command(
     s1ap_state_t* state, ue_description_t* ue_ref_p, enum s1cause cause,
     imsi64_t imsi64, const sctp_assoc_id_t assoc_id,
     const sctp_stream_id_t stream, mme_ue_s1ap_id_t mme_ue_s1ap_id,
@@ -1350,7 +1350,7 @@ int s1ap_mme_generate_ue_context_release_command(
 //------------------------------------------------------------------------------
 
 //------------------------------------------------------------------------------
-int s1ap_mme_generate_ue_context_modification(
+status_code_e s1ap_mme_generate_ue_context_modification(
     ue_description_t* ue_ref_p,
     const itti_s1ap_ue_context_mod_req_t* const ue_context_mod_req_pP,
     imsi64_t imsi64) {
@@ -1440,7 +1440,7 @@ int s1ap_mme_generate_ue_context_modification(
 }
 
 //------------------------------------------------------------------------------
-int s1ap_handle_ue_context_release_command(
+status_code_e s1ap_handle_ue_context_release_command(
     s1ap_state_t* state,
     const itti_s1ap_ue_context_release_command_t* const
         ue_context_release_command_pP,
@@ -1481,7 +1481,7 @@ int s1ap_handle_ue_context_release_command(
 //------------------------------------------------------------------------------
 
 //------------------------------------------------------------------------------
-int s1ap_handle_ue_context_mod_req(
+status_code_e s1ap_handle_ue_context_mod_req(
     s1ap_state_t* state,
     const itti_s1ap_ue_context_mod_req_t* const ue_context_mod_req_pP,
     imsi64_t imsi64) {
@@ -1510,7 +1510,7 @@ int s1ap_handle_ue_context_mod_req(
 }
 
 //------------------------------------------------------------------------------
-int s1ap_mme_handle_ue_context_release_complete(
+status_code_e s1ap_mme_handle_ue_context_release_complete(
     s1ap_state_t* state, __attribute__((unused)) const sctp_assoc_id_t assoc_id,
     __attribute__((unused)) const sctp_stream_id_t stream,
     S1ap_S1AP_PDU_t* pdu) {
@@ -1560,7 +1560,7 @@ int s1ap_mme_handle_ue_context_release_complete(
 }
 
 //------------------------------------------------------------------------------
-int s1ap_mme_handle_initial_context_setup_failure(
+status_code_e s1ap_mme_handle_initial_context_setup_failure(
     s1ap_state_t* state, __attribute__((unused)) const sctp_assoc_id_t assoc_id,
     __attribute__((unused)) const sctp_stream_id_t stream,
     S1ap_S1AP_PDU_t* pdu) {
@@ -1704,7 +1704,7 @@ int s1ap_mme_handle_initial_context_setup_failure(
   OAILOG_FUNC_RETURN(LOG_S1AP, rc);
 }
 
-int s1ap_mme_handle_ue_context_modification_response(
+status_code_e s1ap_mme_handle_ue_context_modification_response(
     s1ap_state_t* state, __attribute__((unused)) const sctp_assoc_id_t assoc_id,
     __attribute__((unused)) const sctp_stream_id_t stream,
     S1ap_S1AP_PDU_t* pdu) {
@@ -1792,7 +1792,7 @@ int s1ap_mme_handle_ue_context_modification_response(
   OAILOG_FUNC_RETURN(LOG_S1AP, RETURNok);
 }
 
-int s1ap_mme_handle_ue_context_modification_failure(
+status_code_e s1ap_mme_handle_ue_context_modification_failure(
     s1ap_state_t* state, __attribute__((unused)) const sctp_assoc_id_t assoc_id,
     __attribute__((unused)) const sctp_stream_id_t stream,
     S1ap_S1AP_PDU_t* pdu) {
@@ -1947,7 +1947,7 @@ int s1ap_mme_handle_ue_context_modification_failure(
 
 //------------------------------------------------------------------------------
 
-int s1ap_mme_handle_handover_request_ack(
+status_code_e s1ap_mme_handle_handover_request_ack(
     s1ap_state_t* state, __attribute__((unused)) const sctp_assoc_id_t assoc_id,
     __attribute__((unused)) const sctp_stream_id_t stream,
     S1ap_S1AP_PDU_t* pdu) {
@@ -2096,7 +2096,7 @@ int s1ap_mme_handle_handover_request_ack(
   OAILOG_FUNC_RETURN(LOG_S1AP, RETURNok);
 }
 
-int s1ap_mme_handle_handover_failure(
+status_code_e s1ap_mme_handle_handover_failure(
     s1ap_state_t* state, const sctp_assoc_id_t assoc_id,
     const sctp_stream_id_t stream, S1ap_S1AP_PDU_t* pdu) {
   S1ap_HandoverFailure_t* container = NULL;
@@ -2235,7 +2235,7 @@ int s1ap_mme_handle_handover_failure(
   OAILOG_FUNC_RETURN(LOG_S1AP, RETURNok);
 }
 
-int s1ap_mme_handle_handover_cancel(
+status_code_e s1ap_mme_handle_handover_cancel(
     s1ap_state_t* state, const sctp_assoc_id_t assoc_id,
     const sctp_stream_id_t stream, S1ap_S1AP_PDU_t* pdu) {
   S1ap_HandoverCancel_t* container = NULL;
@@ -2376,7 +2376,7 @@ int s1ap_mme_handle_handover_cancel(
   OAILOG_FUNC_RETURN(LOG_S1AP, RETURNok);
 }
 
-int s1ap_mme_handle_handover_request(
+status_code_e s1ap_mme_handle_handover_request(
     s1ap_state_t* state, const itti_mme_app_handover_request_t* ho_request_p) {
   uint8_t* buffer_p   = NULL;
   uint8_t err         = 0;
@@ -2645,7 +2645,7 @@ int s1ap_mme_handle_handover_request(
   OAILOG_FUNC_RETURN(LOG_S1AP, RETURNok);
 }
 
-int s1ap_mme_handle_handover_required(
+status_code_e s1ap_mme_handle_handover_required(
     s1ap_state_t* state, __attribute__((unused)) const sctp_assoc_id_t assoc_id,
     __attribute__((unused)) const sctp_stream_id_t stream,
     S1ap_S1AP_PDU_t* pdu) {
@@ -2859,7 +2859,7 @@ int s1ap_mme_handle_handover_required(
   OAILOG_FUNC_RETURN(LOG_S1AP, RETURNok);
 }
 
-int s1ap_mme_handle_handover_command(
+status_code_e s1ap_mme_handle_handover_command(
     s1ap_state_t* state, const itti_mme_app_handover_command_t* ho_command_p) {
   uint8_t* buffer_p   = NULL;
   uint8_t err         = 0;
@@ -2962,7 +2962,7 @@ int s1ap_mme_handle_handover_command(
   OAILOG_FUNC_RETURN(LOG_S1AP, RETURNok);
 }
 
-int s1ap_mme_handle_handover_notify(
+status_code_e s1ap_mme_handle_handover_notify(
     s1ap_state_t* state, const sctp_assoc_id_t assoc_id,
     const sctp_stream_id_t stream, S1ap_S1AP_PDU_t* pdu) {
   S1ap_HandoverNotify_t* container    = NULL;
@@ -3128,7 +3128,7 @@ int s1ap_mme_handle_handover_notify(
   OAILOG_FUNC_RETURN(LOG_S1AP, RETURNok);
 }
 
-int s1ap_mme_handle_enb_status_transfer(
+status_code_e s1ap_mme_handle_enb_status_transfer(
     s1ap_state_t* state, const sctp_assoc_id_t assoc_id,
     const sctp_stream_id_t stream, S1ap_S1AP_PDU_t* pdu) {
   S1ap_ENBStatusTransfer_t* container       = NULL;
@@ -3233,7 +3233,7 @@ int s1ap_mme_handle_enb_status_transfer(
   OAILOG_FUNC_RETURN(LOG_S1AP, RETURNok);
 }
 
-int s1ap_mme_handle_path_switch_request(
+status_code_e s1ap_mme_handle_path_switch_request(
     s1ap_state_t* state, __attribute__((unused)) const sctp_assoc_id_t assoc_id,
     __attribute__((unused)) const sctp_stream_id_t stream,
     S1ap_S1AP_PDU_t* pdu) {
@@ -3574,7 +3574,7 @@ bool construct_s1ap_mme_full_reset_req(
 }
 
 //------------------------------------------------------------------------------
-int s1ap_handle_sctp_disconnection(
+status_code_e s1ap_handle_sctp_disconnection(
     s1ap_state_t* state, const sctp_assoc_id_t assoc_id, bool reset) {
   arg_s1ap_send_enb_dereg_ind_t arg  = {0};
   MessageDef* message_p              = NULL;
@@ -3663,7 +3663,7 @@ int s1ap_handle_sctp_disconnection(
 }
 
 //------------------------------------------------------------------------------
-int s1ap_handle_new_association(
+status_code_e s1ap_handle_new_association(
     s1ap_state_t* state, sctp_new_peer_t* sctp_new_peer_p) {
   enb_description_t* enb_association = NULL;
 
@@ -3833,7 +3833,7 @@ void s1ap_mme_release_ue_context(
 }
 
 //------------------------------------------------------------------------------
-int s1ap_mme_handle_error_ind_message(
+status_code_e s1ap_mme_handle_error_ind_message(
     s1ap_state_t* state, const sctp_assoc_id_t assoc_id,
     const sctp_stream_id_t stream, S1ap_S1AP_PDU_t* message) {
   OAILOG_FUNC_IN(LOG_S1AP);
@@ -3957,7 +3957,7 @@ int s1ap_mme_handle_error_ind_message(
 }
 
 //------------------------------------------------------------------------------
-int s1ap_mme_handle_erab_setup_response(
+status_code_e s1ap_mme_handle_erab_setup_response(
     s1ap_state_t* state, const sctp_assoc_id_t assoc_id,
     const sctp_stream_id_t stream, S1ap_S1AP_PDU_t* pdu) {
   OAILOG_FUNC_IN(LOG_S1AP);
@@ -4072,14 +4072,14 @@ int s1ap_mme_handle_erab_setup_response(
 }
 
 //------------------------------------------------------------------------------
-int s1ap_mme_handle_erab_setup_failure(
+status_code_e s1ap_mme_handle_erab_setup_failure(
     s1ap_state_t* state, const sctp_assoc_id_t assoc_id,
     const sctp_stream_id_t stream, S1ap_S1AP_PDU_t* message) {
   Fatal("TODO Implement s1ap_mme_handle_erab_setup_failure");
 }
 
 //------------------------------------------------------------------------------
-int s1ap_mme_handle_enb_reset(
+status_code_e s1ap_mme_handle_enb_reset(
     s1ap_state_t* state, const sctp_assoc_id_t assoc_id,
     const sctp_stream_id_t stream, S1ap_S1AP_PDU_t* pdu) {
   MessageDef* msg                                = NULL;
@@ -4334,7 +4334,7 @@ int s1ap_mme_handle_enb_reset(
   OAILOG_FUNC_RETURN(LOG_S1AP, rc);
 }
 //------------------------------------------------------------------------------
-int s1ap_handle_enb_initiated_reset_ack(
+status_code_e s1ap_handle_enb_initiated_reset_ack(
     const itti_s1ap_enb_initiated_reset_ack_t* const enb_reset_ack_p,
     imsi64_t imsi64) {
   uint8_t* buffer = NULL;
@@ -4417,7 +4417,7 @@ int s1ap_handle_enb_initiated_reset_ack(
 }
 
 //-------------------------------------------------------------------------------
-int s1ap_handle_paging_request(
+status_code_e s1ap_handle_paging_request(
     s1ap_state_t* state, const itti_s1ap_paging_request_t* paging_request,
     imsi64_t imsi64) {
   OAILOG_FUNC_IN(LOG_S1AP);
@@ -4587,7 +4587,7 @@ int s1ap_handle_paging_request(
 }
 
 //------------------------------------------------------------------------------
-int s1ap_mme_handle_erab_modification_indication(
+status_code_e s1ap_mme_handle_erab_modification_indication(
     s1ap_state_t* state, const sctp_assoc_id_t assoc_id,
     const sctp_stream_id_t stream, S1ap_S1AP_PDU_t* pdu) {
   OAILOG_FUNC_IN(LOG_S1AP);
@@ -4851,7 +4851,7 @@ void s1ap_mme_generate_erab_modification_confirm(
 }
 
 //----------------------------------------------------------------
-int s1ap_mme_handle_enb_configuration_transfer(
+status_code_e s1ap_mme_handle_enb_configuration_transfer(
     s1ap_state_t* state, const sctp_assoc_id_t assoc_id,
     const sctp_stream_id_t stream, S1ap_S1AP_PDU_t* pdu) {
   S1ap_ENBConfigurationTransfer_t* container = NULL;
@@ -5016,7 +5016,7 @@ bool is_all_erabId_same(S1ap_PathSwitchRequest_t* container) {
   OAILOG_FUNC_RETURN(LOG_S1AP, rc);
 }
 //------------------------------------------------------------------------------
-int s1ap_handle_path_switch_req_ack(
+status_code_e s1ap_handle_path_switch_req_ack(
     s1ap_state_t* state,
     const itti_s1ap_path_switch_request_ack_t* path_switch_req_ack_p,
     imsi64_t imsi64) {
@@ -5110,7 +5110,7 @@ int s1ap_handle_path_switch_req_ack(
   OAILOG_FUNC_RETURN(LOG_S1AP, rc);
 }
 //------------------------------------------------------------------------------
-int s1ap_handle_path_switch_req_failure(
+status_code_e s1ap_handle_path_switch_req_failure(
     s1ap_state_t* state,
     const itti_s1ap_path_switch_request_failure_t* path_switch_req_failure_p,
     imsi64_t imsi64) {
@@ -5199,7 +5199,7 @@ const char* s1ap_direction2str(uint8_t dir) {
 }
 
 //------------------------------------------------------------------------------
-int s1ap_mme_handle_erab_rel_response(
+status_code_e s1ap_mme_handle_erab_rel_response(
     s1ap_state_t* state, const sctp_assoc_id_t assoc_id,
     const sctp_stream_id_t stream, S1ap_S1AP_PDU_t* pdu) {
   OAILOG_FUNC_IN(LOG_S1AP);
@@ -5293,7 +5293,7 @@ int s1ap_mme_handle_erab_rel_response(
   OAILOG_FUNC_RETURN(LOG_S1AP, rc);
 }
 
-int s1ap_mme_remove_stale_ue_context(
+status_code_e s1ap_mme_remove_stale_ue_context(
     enb_ue_s1ap_id_t enb_ue_s1ap_id, uint32_t enb_id) {
   OAILOG_FUNC_IN(LOG_S1AP);
   MessageDef* message_p = NULL;
@@ -5315,7 +5315,7 @@ int s1ap_mme_remove_stale_ue_context(
   OAILOG_FUNC_RETURN(LOG_S1AP, RETURNok);
 }
 
-int s1ap_send_mme_ue_context_release(
+status_code_e s1ap_send_mme_ue_context_release(
     s1ap_state_t* state, ue_description_t* ue_ref_p,
     enum s1cause s1_release_cause, S1ap_Cause_t ie_cause, imsi64_t imsi64) {
   MessageDef* message_p = NULL;

--- a/lte/gateway/c/core/oai/tasks/s1ap/s1ap_mme_handlers.h
+++ b/lte/gateway/c/core/oai/tasks/s1ap/s1ap_mme_handlers.h
@@ -19,6 +19,7 @@
 #define FILE_S1AP_MME_HANDLERS_SEEN
 #include <stdbool.h>
 
+#include "common_defs.h"
 #include "s1ap_mme.h"
 #include "intertask_interface.h"
 #include "S1ap_Cause.h"
@@ -37,11 +38,11 @@ const char* s1ap_direction2str(uint8_t dir);
  * \param message_p The message decoded by the ASN1C decoder
  * @returns int
  **/
-int s1ap_mme_handle_message(
+status_code_e s1ap_mme_handle_message(
     s1ap_state_t* state, const sctp_assoc_id_t assoc_id,
     const sctp_stream_id_t stream, S1ap_S1AP_PDU_t* message_p);
 
-int s1ap_mme_handle_ue_cap_indication(
+status_code_e s1ap_mme_handle_ue_cap_indication(
     s1ap_state_t* state, const sctp_assoc_id_t assoc_id,
     const sctp_stream_id_t stream, S1ap_S1AP_PDU_t* message);
 
@@ -54,92 +55,92 @@ int s1ap_mme_handle_ue_cap_indication(
  * \param message_p The message decoded by the ASN1C decoder
  * @returns int
  **/
-int s1ap_mme_handle_s1_setup_request(
+status_code_e s1ap_mme_handle_s1_setup_request(
     s1ap_state_t* state, const sctp_assoc_id_t assoc_id,
     const sctp_stream_id_t stream, S1ap_S1AP_PDU_t* message_p);
 
-int s1ap_mme_handle_handover_required(
+status_code_e s1ap_mme_handle_handover_required(
     s1ap_state_t* state, const sctp_assoc_id_t assoc_id,
     const sctp_stream_id_t stream, S1ap_S1AP_PDU_t* message_p);
 
-int s1ap_mme_handle_handover_command(
+status_code_e s1ap_mme_handle_handover_command(
     s1ap_state_t* state, const itti_mme_app_handover_command_t* ho_command_p);
 
-int s1ap_mme_handle_handover_request(
+status_code_e s1ap_mme_handle_handover_request(
     s1ap_state_t* state, const itti_mme_app_handover_request_t* ho_request_p);
 
-int s1ap_mme_handle_handover_request_ack(
+status_code_e s1ap_mme_handle_handover_request_ack(
     s1ap_state_t* state, const sctp_assoc_id_t assoc_id,
     const sctp_stream_id_t stream, S1ap_S1AP_PDU_t* message_p);
 
-int s1ap_mme_handle_handover_cancel(
+status_code_e s1ap_mme_handle_handover_cancel(
     s1ap_state_t* state, const sctp_assoc_id_t assoc_id,
     const sctp_stream_id_t stream, S1ap_S1AP_PDU_t* message_p);
 
-int s1ap_mme_handle_handover_failure(
+status_code_e s1ap_mme_handle_handover_failure(
     s1ap_state_t* state, const sctp_assoc_id_t assoc_id,
     const sctp_stream_id_t stream, S1ap_S1AP_PDU_t* message_p);
 
-int s1ap_mme_handle_enb_status_transfer(
+status_code_e s1ap_mme_handle_enb_status_transfer(
     s1ap_state_t* state, const sctp_assoc_id_t assoc_id,
     const sctp_stream_id_t stream, S1ap_S1AP_PDU_t* pdu);
 
-int s1ap_mme_handle_handover_notify(
+status_code_e s1ap_mme_handle_handover_notify(
     s1ap_state_t* state, const sctp_assoc_id_t assoc_id,
     const sctp_stream_id_t stream, S1ap_S1AP_PDU_t* message_p);
 
-int s1ap_mme_handle_path_switch_request(
+status_code_e s1ap_mme_handle_path_switch_request(
     s1ap_state_t* state, const sctp_assoc_id_t assoc_id,
     const sctp_stream_id_t stream, S1ap_S1AP_PDU_t* message_p);
 
-int s1ap_mme_handle_ue_context_release_request(
+status_code_e s1ap_mme_handle_ue_context_release_request(
     s1ap_state_t* state, const sctp_assoc_id_t assoc_id,
     const sctp_stream_id_t stream, S1ap_S1AP_PDU_t* message_p);
 
-int s1ap_handle_ue_context_release_command(
+status_code_e s1ap_handle_ue_context_release_command(
     s1ap_state_t* state,
     const itti_s1ap_ue_context_release_command_t* const
         ue_context_release_command_pP,
     imsi64_t imsi64);
 
-int s1ap_mme_handle_ue_context_release_complete(
+status_code_e s1ap_mme_handle_ue_context_release_complete(
     s1ap_state_t* state, const sctp_assoc_id_t assoc_id,
     const sctp_stream_id_t stream, S1ap_S1AP_PDU_t* message_p);
 
-int s1ap_handle_ue_context_mod_req(
+status_code_e s1ap_handle_ue_context_mod_req(
     s1ap_state_t* state,
     const itti_s1ap_ue_context_mod_req_t* const ue_context_mod_req_pP,
     imsi64_t imsi64);
 
-int s1ap_mme_handle_initial_context_setup_failure(
+status_code_e s1ap_mme_handle_initial_context_setup_failure(
     s1ap_state_t* state, const sctp_assoc_id_t assoc_id,
     const sctp_stream_id_t stream, S1ap_S1AP_PDU_t* message_p);
 
-int s1ap_mme_handle_initial_context_setup_response(
+status_code_e s1ap_mme_handle_initial_context_setup_response(
     s1ap_state_t* state, const sctp_assoc_id_t assoc_id,
     const sctp_stream_id_t stream, S1ap_S1AP_PDU_t* message_p);
 
-int s1ap_handle_sctp_disconnection(
+status_code_e s1ap_handle_sctp_disconnection(
     s1ap_state_t* state, const sctp_assoc_id_t assoc_id, bool reset);
 
-int s1ap_handle_new_association(
+status_code_e s1ap_handle_new_association(
     s1ap_state_t* state, sctp_new_peer_t* sctp_new_peer_p);
 
-int s1ap_mme_set_cause(
+status_code_e s1ap_mme_set_cause(
     S1ap_Cause_t* cause_p, const S1ap_Cause_PR cause_type,
     const long cause_value);
 
 long s1ap_mme_get_cause_value(S1ap_Cause_t* cause);
 
-int s1ap_mme_generate_s1_setup_failure(
+status_code_e s1ap_mme_generate_s1_setup_failure(
     const sctp_assoc_id_t assoc_id, const S1ap_Cause_PR cause_type,
     const long cause_value, const long time_to_wait);
 
-int s1ap_mme_handle_erab_setup_response(
+status_code_e s1ap_mme_handle_erab_setup_response(
     s1ap_state_t* state, const sctp_assoc_id_t assoc_id,
     const sctp_stream_id_t stream, S1ap_S1AP_PDU_t* message);
 
-int s1ap_mme_handle_erab_setup_failure(
+status_code_e s1ap_mme_handle_erab_setup_failure(
     s1ap_state_t* state, const sctp_assoc_id_t assoc_id,
     const sctp_stream_id_t stream, S1ap_S1AP_PDU_t* message);
 
@@ -149,64 +150,64 @@ void s1ap_mme_handle_ue_context_rel_comp_timer_expiry(
 void s1ap_mme_release_ue_context(
     s1ap_state_t* state, ue_description_t* ue_ref_p, imsi64_t imsi64);
 
-int s1ap_mme_handle_error_ind_message(
+status_code_e s1ap_mme_handle_error_ind_message(
     s1ap_state_t* state, const sctp_assoc_id_t assoc_id,
     const sctp_stream_id_t stream, S1ap_S1AP_PDU_t* message);
 
-int s1ap_mme_handle_enb_reset(
+status_code_e s1ap_mme_handle_enb_reset(
     s1ap_state_t* state, const sctp_assoc_id_t assoc_id,
     const sctp_stream_id_t stream, S1ap_S1AP_PDU_t* message);
 
-int s1ap_handle_enb_initiated_reset_ack(
+status_code_e s1ap_handle_enb_initiated_reset_ack(
     const itti_s1ap_enb_initiated_reset_ack_t* const enb_reset_ack_p,
     imsi64_t imsi64);
 
-int s1ap_handle_paging_request(
+status_code_e s1ap_handle_paging_request(
     s1ap_state_t* state, const itti_s1ap_paging_request_t* paging_request,
     imsi64_t imsi64);
 
-int s1ap_mme_handle_ue_context_modification_response(
+status_code_e s1ap_mme_handle_ue_context_modification_response(
     s1ap_state_t* state, const sctp_assoc_id_t assoc_id,
     const sctp_stream_id_t stream, S1ap_S1AP_PDU_t* message_p);
 
-int s1ap_mme_handle_ue_context_modification_failure(
+status_code_e s1ap_mme_handle_ue_context_modification_failure(
     s1ap_state_t* state, const sctp_assoc_id_t assoc_id,
     const sctp_stream_id_t stream, S1ap_S1AP_PDU_t* message_p);
 
-int s1ap_mme_handle_erab_rel_response(
+status_code_e s1ap_mme_handle_erab_rel_response(
     s1ap_state_t* state, const sctp_assoc_id_t assoc_id,
     const sctp_stream_id_t stream, S1ap_S1AP_PDU_t* message);
 
-int s1ap_mme_handle_enb_configuration_transfer(
+status_code_e s1ap_mme_handle_enb_configuration_transfer(
     s1ap_state_t* state, const sctp_assoc_id_t assoc_id,
     const sctp_stream_id_t stream, S1ap_S1AP_PDU_t* message_p);
 
-int s1ap_handle_path_switch_req_ack(
+status_code_e s1ap_handle_path_switch_req_ack(
     s1ap_state_t* state,
     const itti_s1ap_path_switch_request_ack_t* path_switch_req_ack_p,
     imsi64_t imsi64);
 
-int s1ap_handle_path_switch_req_failure(
+status_code_e s1ap_handle_path_switch_req_failure(
     s1ap_state_t* state,
     const itti_s1ap_path_switch_request_failure_t* path_switch_req_failure_p,
     imsi64_t imsi64);
 
-int s1ap_mme_handle_erab_modification_indication(
+status_code_e s1ap_mme_handle_erab_modification_indication(
     s1ap_state_t* state, const sctp_assoc_id_t assoc_id,
     const sctp_stream_id_t stream, S1ap_S1AP_PDU_t* pdu);
 
 void s1ap_mme_generate_erab_modification_confirm(
     s1ap_state_t* state, const itti_s1ap_e_rab_modification_cnf_t* const conf);
 
-int s1ap_mme_generate_ue_context_release_command(
+status_code_e s1ap_mme_generate_ue_context_release_command(
     s1ap_state_t* state, ue_description_t* ue_ref_p, enum s1cause,
     imsi64_t imsi64, sctp_assoc_id_t assoc_id, sctp_stream_id_t stream,
     mme_ue_s1ap_id_t mme_ue_s1ap_id, enb_ue_s1ap_id_t enb_ue_s1ap_id);
 
-int s1ap_mme_remove_stale_ue_context(
+status_code_e s1ap_mme_remove_stale_ue_context(
     enb_ue_s1ap_id_t enb_ue_s1ap_id, uint32_t enb_id);
 
-int s1ap_send_mme_ue_context_release(
+status_code_e s1ap_send_mme_ue_context_release(
     s1ap_state_t* state, ue_description_t* ue_ref_p,
     enum s1cause s1_release_cause, S1ap_Cause_t ie_cause, imsi64_t imsi64);
 #endif /* FILE_S1AP_MME_HANDLERS_SEEN */

--- a/lte/gateway/c/core/oai/tasks/s1ap/s1ap_mme_itti_messaging.c
+++ b/lte/gateway/c/core/oai/tasks/s1ap/s1ap_mme_itti_messaging.c
@@ -41,7 +41,7 @@
 #include "sctp_messages_types.h"
 
 //------------------------------------------------------------------------------
-int s1ap_mme_itti_send_sctp_request(
+status_code_e s1ap_mme_itti_send_sctp_request(
     STOLEN_REF bstring* payload, const sctp_assoc_id_t assoc_id,
     const sctp_stream_id_t stream, const mme_ue_s1ap_id_t ue_id) {
   MessageDef* message_p = NULL;
@@ -64,7 +64,7 @@ int s1ap_mme_itti_send_sctp_request(
 }
 
 //------------------------------------------------------------------------------
-int s1ap_mme_itti_nas_uplink_ind(
+status_code_e s1ap_mme_itti_nas_uplink_ind(
     const mme_ue_s1ap_id_t ue_id, STOLEN_REF bstring* payload,
     const tai_t* const tai, const ecgi_t* const cgi) {
   MessageDef* message_p = NULL;
@@ -98,7 +98,7 @@ int s1ap_mme_itti_nas_uplink_ind(
 }
 
 //------------------------------------------------------------------------------
-int s1ap_mme_itti_nas_downlink_cnf(
+status_code_e s1ap_mme_itti_nas_downlink_cnf(
     const mme_ue_s1ap_id_t ue_id, const bool is_success) {
   MessageDef* message_p = NULL;
   imsi64_t imsi64       = INVALID_IMSI64;
@@ -276,7 +276,7 @@ void s1ap_mme_itti_nas_non_delivery_ind(
 }
 
 //------------------------------------------------------------------------------
-int s1ap_mme_itti_s1ap_path_switch_request(
+status_code_e s1ap_mme_itti_s1ap_path_switch_request(
     const sctp_assoc_id_t assoc_id, uint32_t enb_id,
     const enb_ue_s1ap_id_t enb_ue_s1ap_id,
     const e_rab_to_be_switched_in_downlink_list_t* const
@@ -314,7 +314,7 @@ int s1ap_mme_itti_s1ap_path_switch_request(
 }
 
 //------------------------------------------------------------------------------
-int s1ap_mme_itti_s1ap_handover_required(
+status_code_e s1ap_mme_itti_s1ap_handover_required(
     const sctp_assoc_id_t assoc_id, uint32_t enb_id, const S1ap_Cause_t cause,
     const S1ap_HandoverType_t handover_type,
     const mme_ue_s1ap_id_t mme_ue_s1ap_id, const bstring src_tgt_container,
@@ -342,7 +342,7 @@ int s1ap_mme_itti_s1ap_handover_required(
   OAILOG_FUNC_RETURN(LOG_S1AP, RETURNok);
 }
 
-int s1ap_mme_itti_s1ap_handover_request_ack(
+status_code_e s1ap_mme_itti_s1ap_handover_request_ack(
     const mme_ue_s1ap_id_t mme_ue_s1ap_id,
     const enb_ue_s1ap_id_t src_enb_ue_s1ap_id,
     const enb_ue_s1ap_id_t tgt_enb_ue_s1ap_id,
@@ -375,7 +375,7 @@ int s1ap_mme_itti_s1ap_handover_request_ack(
   OAILOG_FUNC_RETURN(LOG_S1AP, RETURNok);
 }
 
-int s1ap_mme_itti_s1ap_handover_notify(
+status_code_e s1ap_mme_itti_s1ap_handover_notify(
     const mme_ue_s1ap_id_t mme_ue_s1ap_id,
     const s1ap_handover_state_t handover_state,
     const enb_ue_s1ap_id_t target_enb_ue_s1ap_id,

--- a/lte/gateway/c/core/oai/tasks/s1ap/s1ap_mme_itti_messaging.h
+++ b/lte/gateway/c/core/oai/tasks/s1ap/s1ap_mme_itti_messaging.h
@@ -44,15 +44,15 @@
 extern task_zmq_ctx_t s1ap_task_zmq_ctx;
 extern long s1ap_last_msg_latency;
 
-int s1ap_mme_itti_send_sctp_request(
+status_code_e s1ap_mme_itti_send_sctp_request(
     STOLEN_REF bstring* payload, const uint32_t sctp_assoc_id_t,
     const sctp_stream_id_t stream, const mme_ue_s1ap_id_t ue_id);
 
-int s1ap_mme_itti_nas_uplink_ind(
+status_code_e s1ap_mme_itti_nas_uplink_ind(
     const mme_ue_s1ap_id_t ue_id, STOLEN_REF bstring* payload,
     const tai_t* const tai, const ecgi_t* const cgi);
 
-int s1ap_mme_itti_nas_downlink_cnf(
+status_code_e s1ap_mme_itti_nas_downlink_cnf(
     const mme_ue_s1ap_id_t ue_id, const bool is_success);
 
 void s1ap_mme_itti_s1ap_initial_ue_message(
@@ -71,7 +71,7 @@ void s1ap_mme_itti_nas_non_delivery_ind(
     const size_t nas_msg_length, const S1ap_Cause_t* const cause,
     imsi64_t imsi64);
 
-int s1ap_mme_itti_s1ap_path_switch_request(
+status_code_e s1ap_mme_itti_s1ap_path_switch_request(
     const sctp_assoc_id_t assoc_id, const uint32_t enb_id,
     const enb_ue_s1ap_id_t enb_ue_s1ap_id,
     const e_rab_to_be_switched_in_downlink_list_t* const
@@ -80,13 +80,13 @@ int s1ap_mme_itti_s1ap_path_switch_request(
     const tai_t* const tai, const uint16_t encryption_algorithm_capabilitie,
     uint16_t integrity_algorithm_capabilities, imsi64_t imsi64);
 
-int s1ap_mme_itti_s1ap_handover_required(
+status_code_e s1ap_mme_itti_s1ap_handover_required(
     const sctp_assoc_id_t assoc_id, uint32_t enb_id, const S1ap_Cause_t cause,
     const S1ap_HandoverType_t handover_type,
     const mme_ue_s1ap_id_t mme_ue_s1ap_id, const bstring src_tgt_container,
     imsi64_t imsi64);
 
-int s1ap_mme_itti_s1ap_handover_request_ack(
+status_code_e s1ap_mme_itti_s1ap_handover_request_ack(
     const mme_ue_s1ap_id_t mme_ue_s1ap_id,
     const enb_ue_s1ap_id_t src_enb_ue_s1ap_id,
     const enb_ue_s1ap_id_t tgt_enb_ue_s1ap_id,
@@ -95,7 +95,7 @@ int s1ap_mme_itti_s1ap_handover_request_ack(
     const uint32_t source_enb_id, const uint32_t target_enb_id,
     imsi64_t imsi64);
 
-int s1ap_mme_itti_s1ap_handover_notify(
+status_code_e s1ap_mme_itti_s1ap_handover_notify(
     const mme_ue_s1ap_id_t mme_ue_s1ap_id,
     const s1ap_handover_state_t handover_state,
     const enb_ue_s1ap_id_t target_ue_s1ap_id,

--- a/lte/gateway/c/core/oai/tasks/s1ap/s1ap_mme_nas_procedures.c
+++ b/lte/gateway/c/core/oai/tasks/s1ap/s1ap_mme_nas_procedures.c
@@ -82,7 +82,7 @@ extern long s1ap_last_msg_latency;
 extern long s1ap_zmq_th;
 
 //------------------------------------------------------------------------------
-int s1ap_mme_handle_initial_ue_message(
+status_code_e s1ap_mme_handle_initial_ue_message(
     s1ap_state_t* state, const sctp_assoc_id_t assoc_id,
     const sctp_stream_id_t stream, S1ap_S1AP_PDU_t* pdu) {
   S1ap_InitialUEMessage_t* container = NULL;
@@ -278,7 +278,7 @@ int s1ap_mme_handle_initial_ue_message(
 }
 
 //------------------------------------------------------------------------------
-int s1ap_mme_handle_uplink_nas_transport(
+status_code_e s1ap_mme_handle_uplink_nas_transport(
     s1ap_state_t* state, const sctp_assoc_id_t assoc_id,
     __attribute__((unused)) const sctp_stream_id_t stream,
     S1ap_S1AP_PDU_t* pdu) {
@@ -401,7 +401,7 @@ int s1ap_mme_handle_uplink_nas_transport(
 }
 
 //------------------------------------------------------------------------------
-int s1ap_mme_handle_nas_non_delivery(
+status_code_e s1ap_mme_handle_nas_non_delivery(
     s1ap_state_t* state, __attribute__((unused)) sctp_assoc_id_t assoc_id,
     sctp_stream_id_t stream, S1ap_S1AP_PDU_t* pdu) {
   S1ap_NASNonDeliveryIndication_t* container;
@@ -490,7 +490,7 @@ int s1ap_mme_handle_nas_non_delivery(
 }
 
 //------------------------------------------------------------------------------
-int s1ap_generate_downlink_nas_transport(
+status_code_e s1ap_generate_downlink_nas_transport(
     s1ap_state_t* state, const enb_ue_s1ap_id_t enb_ue_s1ap_id,
     const mme_ue_s1ap_id_t ue_id, STOLEN_REF bstring* payload,
     const imsi64_t imsi64, bool* is_state_same) {
@@ -624,7 +624,7 @@ int s1ap_generate_downlink_nas_transport(
 }
 
 //------------------------------------------------------------------------------
-int s1ap_generate_s1ap_e_rab_setup_req(
+status_code_e s1ap_generate_s1ap_e_rab_setup_req(
     s1ap_state_t* state, itti_s1ap_e_rab_setup_req_t* const e_rab_setup_req) {
   OAILOG_FUNC_IN(LOG_S1AP);
   ue_description_t* ue_ref              = NULL;
@@ -1203,7 +1203,7 @@ void s1ap_handle_mme_ue_id_notification(
 }
 
 //------------------------------------------------------------------------------
-int s1ap_generate_s1ap_e_rab_rel_cmd(
+status_code_e s1ap_generate_s1ap_e_rab_rel_cmd(
     s1ap_state_t* state, itti_s1ap_e_rab_rel_cmd_t* const e_rab_rel_cmd) {
   OAILOG_FUNC_IN(LOG_S1AP);
 

--- a/lte/gateway/c/core/oai/tasks/s1ap/s1ap_mme_nas_procedures.h
+++ b/lte/gateway/c/core/oai/tasks/s1ap/s1ap_mme_nas_procedures.h
@@ -39,7 +39,7 @@
  * \param message The message as decoded by the ASN.1 codec
  * @returns -1 on failure, 0 otherwise
  **/
-int s1ap_mme_handle_initial_ue_message(
+status_code_e s1ap_mme_handle_initial_ue_message(
     s1ap_state_t* state, const sctp_assoc_id_t assocId,
     const sctp_stream_id_t stream, S1ap_S1AP_PDU_t* message);
 
@@ -50,7 +50,7 @@ int s1ap_mme_handle_initial_ue_message(
  * \param message The message as decoded by the ASN.1 codec
  * @returns -1 on failure, 0 otherwise
  **/
-int s1ap_mme_handle_uplink_nas_transport(
+status_code_e s1ap_mme_handle_uplink_nas_transport(
     s1ap_state_t* state, const sctp_assoc_id_t assocId,
     const sctp_stream_id_t stream, S1ap_S1AP_PDU_t* message);
 
@@ -60,7 +60,7 @@ int s1ap_mme_handle_uplink_nas_transport(
  * \param message The message as decoded by the ASN.1 codec
  * @returns -1 on failure, 0 otherwise
  **/
-int s1ap_mme_handle_nas_non_delivery(
+status_code_e s1ap_mme_handle_nas_non_delivery(
     s1ap_state_t* state, const sctp_assoc_id_t assocId,
     const sctp_stream_id_t stream, S1ap_S1AP_PDU_t* message);
 
@@ -68,7 +68,7 @@ void s1ap_handle_conn_est_cnf(
     s1ap_state_t* state,
     const itti_mme_app_connection_establishment_cnf_t* const conn_est_cnf_p);
 
-int s1ap_generate_downlink_nas_transport(
+status_code_e s1ap_generate_downlink_nas_transport(
     s1ap_state_t* state, const enb_ue_s1ap_id_t enb_ue_s1ap_id,
     const mme_ue_s1ap_id_t ue_id, STOLEN_REF bstring* payload, imsi64_t imsi64,
     bool* is_state_same);
@@ -77,10 +77,10 @@ void s1ap_handle_mme_ue_id_notification(
     s1ap_state_t* state,
     const itti_mme_app_s1ap_mme_ue_id_notification_t* const notification_p);
 
-int s1ap_generate_s1ap_e_rab_setup_req(
+status_code_e s1ap_generate_s1ap_e_rab_setup_req(
     s1ap_state_t* state, itti_s1ap_e_rab_setup_req_t* const e_rab_setup_req);
 
-int s1ap_generate_s1ap_e_rab_rel_cmd(
+status_code_e s1ap_generate_s1ap_e_rab_rel_cmd(
     s1ap_state_t* state, itti_s1ap_e_rab_rel_cmd_t* const e_rab_rel_cmd);
 
 #endif /* FILE_S1AP_MME_NAS_PROCEDURES_SEEN */

--- a/lte/gateway/c/core/oai/tasks/s6a/s6a_auth_info.c
+++ b/lte/gateway/c/core/oai/tasks/s6a/s6a_auth_info.c
@@ -195,7 +195,7 @@ static inline int s6a_parse_authentication_info_avp(
   return RETURNok;
 }
 
-int s6a_aia_cb(
+status_code_e s6a_aia_cb(
     struct msg** msg, struct avp* paramavp, struct session* sess, void* opaque,
     enum disp_action* act) {
   struct msg* ans                          = NULL;
@@ -300,7 +300,7 @@ err:
   return RETURNok;
 }
 
-int s6a_generate_authentication_info_req(s6a_auth_info_req_t* air_p) {
+status_code_e s6a_generate_authentication_info_req(s6a_auth_info_req_t* air_p) {
   struct avp* avp;
   struct msg* msg;
   struct session* sess;

--- a/lte/gateway/c/core/oai/tasks/s6a/s6a_defs.h
+++ b/lte/gateway/c/core/oai/tasks/s6a/s6a_defs.h
@@ -30,6 +30,7 @@
 #include <freeDiameter/freeDiameter-host.h>
 #include <freeDiameter/libfdcore.h>
 
+#include "common_defs.h"
 #include "mme_config.h"
 #include "queue.h"
 #include "intertask_interface.h"
@@ -202,22 +203,22 @@ extern s6a_fd_cnf_t s6a_fd_cnf;
 #define AVP_CODE_PDN_TYPE (1456)
 #define AVP_CODE_SUBSCRIBED_PERIODIC_RAU_TAU_TIMER (1619)
 
-int s6a_init(const mme_config_t* mme_config);
+status_code_e s6a_init(const mme_config_t* mme_config);
 
-int s6a_fd_new_peer(void);
+status_code_e s6a_fd_new_peer(void);
 
 void s6a_peer_connected_cb(struct peer_info* info, void* arg);
 
-int s6a_fd_init_dict_objs(void);
+status_code_e s6a_fd_init_dict_objs(void);
 
-int s6a_parse_subscription_data(
+status_code_e s6a_parse_subscription_data(
     struct avp* avp_subscription_data, subscription_data_t* subscription_data);
 
 int s6a_parse_supported_features(
     struct avp* avp_supported_features,
     supported_features_t* subscription_data);
 
-int s6a_parse_experimental_result(
+status_code_e s6a_parse_experimental_result(
     struct avp* avp, s6a_experimental_result_t* ptr);
 char* experimental_retcode_2_string(uint32_t ret_code);
 char* retcode_2_string(uint32_t ret_code);

--- a/lte/gateway/c/core/oai/tasks/s6a/s6a_dict.c
+++ b/lte/gateway/c/core/oai/tasks/s6a/s6a_dict.c
@@ -41,7 +41,7 @@
    \version 0.1
 */
 
-int s6a_fd_init_dict_objs(void) {
+status_code_e s6a_fd_init_dict_objs(void) {
   struct disp_when when;
   vendor_id_t vendor_3gpp  = VENDOR_3GPP;
   application_id_t app_s6a = APP_S6A;

--- a/lte/gateway/c/core/oai/tasks/s6a/s6a_error.c
+++ b/lte/gateway/c/core/oai/tasks/s6a/s6a_error.c
@@ -34,7 +34,7 @@
 
 struct avp;
 
-int s6a_parse_experimental_result(
+status_code_e s6a_parse_experimental_result(
     struct avp* avp, s6a_experimental_result_t* ptr) {
   struct avp_hdr* hdr;
   struct avp* child_avp = NULL;

--- a/lte/gateway/c/core/oai/tasks/s6a/s6a_messages.h
+++ b/lte/gateway/c/core/oai/tasks/s6a/s6a_messages.h
@@ -24,20 +24,21 @@
 #ifndef S6A_MESSAGES_H_
 #define S6A_MESSAGES_H_
 
+#include "common_defs.h"
 #include "s6a_messages_types.h"
 
 #include <freeDiameter/freeDiameter-host.h>
 #include <freeDiameter/libfdproto.h>
 
-int s6a_generate_update_location(s6a_update_location_req_t* ulr_p);
-int s6a_generate_authentication_info_req(s6a_auth_info_req_t* uar_p);
+status_code_e s6a_generate_update_location(s6a_update_location_req_t* ulr_p);
+status_code_e s6a_generate_authentication_info_req(s6a_auth_info_req_t* uar_p);
 int s6a_send_cancel_location_ans(s6a_cancel_location_ans_t* cla_pP);
-int s6a_generate_purge_ue_req(const char* imsi);
+status_code_e s6a_generate_purge_ue_req(const char* imsi);
 
-int s6a_ula_cb(
+status_code_e s6a_ula_cb(
     struct msg** msg, struct avp* paramavp, struct session* sess, void* opaque,
     enum disp_action* act);
-int s6a_aia_cb(
+status_code_e s6a_aia_cb(
     struct msg** msg, struct avp* paramavp, struct session* sess, void* opaque,
     enum disp_action* act);
 
@@ -45,14 +46,14 @@ int s6a_clr_cb(
     struct msg** msg, struct avp* paramavp, struct session* sess, void* opaque,
     enum disp_action* act);
 
-int s6a_pua_cb(
+status_code_e s6a_pua_cb(
     struct msg** msg, struct avp* paramavp, struct session* sess, void* opaque,
     enum disp_action* act);
 int s6a_rsr_cb(
     struct msg** msg, struct avp* paramavp, struct session* sess, void* opaque,
     enum disp_action* act);
 
-int s6a_parse_subscription_data(
+status_code_e s6a_parse_subscription_data(
     struct avp* avp_subscription_data, subscription_data_t* subscription_data);
 
 #endif /* S6A_MESSAGES_H_ */

--- a/lte/gateway/c/core/oai/tasks/s6a/s6a_peer.c
+++ b/lte/gateway/c/core/oai/tasks/s6a/s6a_peer.c
@@ -79,7 +79,7 @@ void s6a_peer_connected_cb(struct peer_info* info, void* arg) {
 #endif
 }
 
-int s6a_fd_new_peer(void) {
+status_code_e s6a_fd_new_peer(void) {
   int ret = 0;
 #if FD_CONF_FILE_NO_CONNECT_PEERS_CONFIGURED
   struct peer_info info = {0};

--- a/lte/gateway/c/core/oai/tasks/s6a/s6a_purge_ue.c
+++ b/lte/gateway/c/core/oai/tasks/s6a/s6a_purge_ue.c
@@ -36,7 +36,7 @@ struct avp;
 struct msg;
 struct session;
 
-int s6a_pua_cb(
+status_code_e s6a_pua_cb(
     struct msg** msg_pP, struct avp* paramavp_pP, struct session* sess_pP,
     void* opaque_pP, enum disp_action* act_pP) {
   struct msg* ans_p                      = NULL;
@@ -165,7 +165,7 @@ err:
   return RETURNok;
 }
 
-int s6a_generate_purge_ue_req(const char* imsi) {
+status_code_e s6a_generate_purge_ue_req(const char* imsi) {
   struct avp* avp_p      = NULL;
   struct msg* msg_p      = NULL;
   struct session* sess_p = NULL;

--- a/lte/gateway/c/core/oai/tasks/s6a/s6a_subscription_data.c
+++ b/lte/gateway/c/core/oai/tasks/s6a/s6a_subscription_data.c
@@ -472,7 +472,7 @@ static inline int s6a_parse_apn_configuration_profile(
   return RETURNok;
 }
 
-int s6a_parse_subscription_data(
+status_code_e s6a_parse_subscription_data(
     struct avp* avp_subscription_data, subscription_data_t* subscription_data) {
   struct avp* avp = NULL;
   struct avp_hdr* hdr;

--- a/lte/gateway/c/core/oai/tasks/s6a/s6a_task.c
+++ b/lte/gateway/c/core/oai/tasks/s6a/s6a_task.c
@@ -147,7 +147,7 @@ static void* s6a_thread(void* args) {
 }
 
 //------------------------------------------------------------------------------
-int s6a_init(const mme_config_t* mme_config_p) {
+status_code_e s6a_init(const mme_config_t* mme_config_p) {
   OAILOG_DEBUG(LOG_S6A, "Initializing S6a interface\n");
 
   if (itti_create_task(

--- a/lte/gateway/c/core/oai/tasks/s6a/s6a_up_loc.c
+++ b/lte/gateway/c/core/oai/tasks/s6a/s6a_up_loc.c
@@ -46,7 +46,7 @@ struct avp;
 struct msg;
 struct session;
 
-int s6a_ula_cb(
+status_code_e s6a_ula_cb(
     struct msg** msg_pP, struct avp* paramavp_pP, struct session* sess_pP,
     void* opaque_pP, enum disp_action* act_pP) {
   struct msg* ans_p                                    = NULL;
@@ -187,7 +187,7 @@ err:
   return RETURNok;
 }
 
-int s6a_generate_update_location(s6a_update_location_req_t* ulr_pP) {
+status_code_e s6a_generate_update_location(s6a_update_location_req_t* ulr_pP) {
   struct avp* avp_p      = NULL;
   struct msg* msg_p      = NULL;
   struct session* sess_p = NULL;

--- a/lte/gateway/c/core/oai/tasks/sctp/sctp_itti_messaging.c
+++ b/lte/gateway/c/core/oai/tasks/sctp/sctp_itti_messaging.c
@@ -33,7 +33,7 @@
 #include "itti_free_defined_msg.h"
 
 //------------------------------------------------------------------------------
-int sctp_itti_send_lower_layer_conf(
+status_code_e sctp_itti_send_lower_layer_conf(
     task_id_t origin_task_id, sctp_ppid_t ppid, sctp_assoc_id_t assoc_id,
     sctp_stream_id_t stream, uint32_t xap_id, bool is_success) {
   MessageDef* msg = itti_alloc_new_message(TASK_SCTP, SCTP_DATA_CNF);
@@ -48,7 +48,7 @@ int sctp_itti_send_lower_layer_conf(
 }
 
 //------------------------------------------------------------------------------
-int sctp_itti_send_new_association(
+status_code_e sctp_itti_send_new_association(
     sctp_ppid_t ppid, sctp_assoc_id_t assoc_id, sctp_stream_id_t instreams,
     sctp_stream_id_t outstreams, STOLEN_REF bstring* ran_cp_ipaddr) {
   MessageDef* msg = itti_alloc_new_message(TASK_SCTP, SCTP_NEW_ASSOCIATION);
@@ -77,7 +77,7 @@ int sctp_itti_send_new_association(
 }
 
 //------------------------------------------------------------------------------
-int sctp_itti_send_new_message_ind(
+status_code_e sctp_itti_send_new_message_ind(
     STOLEN_REF bstring* payload, sctp_ppid_t ppid, sctp_assoc_id_t assoc_id,
     sctp_stream_id_t stream) {
   MessageDef* msg = itti_alloc_new_message(TASK_SCTP, SCTP_DATA_IND);
@@ -106,7 +106,7 @@ int sctp_itti_send_new_message_ind(
 }
 
 //------------------------------------------------------------------------------
-int sctp_itti_send_com_down_ind(
+status_code_e sctp_itti_send_com_down_ind(
     sctp_ppid_t ppid, sctp_assoc_id_t assoc_id, bool reset) {
   MessageDef* msg = itti_alloc_new_message(TASK_SCTP, SCTP_CLOSE_ASSOCIATION);
 

--- a/lte/gateway/c/core/oai/tasks/sctp/sctp_itti_messaging.h
+++ b/lte/gateway/c/core/oai/tasks/sctp/sctp_itti_messaging.h
@@ -38,19 +38,19 @@
 
 extern task_zmq_ctx_t sctp_task_zmq_ctx;
 
-int sctp_itti_send_lower_layer_conf(
+status_code_e sctp_itti_send_lower_layer_conf(
     task_id_t origin_task_id, sctp_ppid_t ppid, sctp_assoc_id_t assoc_id,
     sctp_stream_id_t stream, uint32_t agw_ue_xap_id, bool is_success);
 
-int sctp_itti_send_new_association(
+status_code_e sctp_itti_send_new_association(
     sctp_ppid_t ppid, sctp_assoc_id_t assoc_id, sctp_stream_id_t instreams,
     sctp_stream_id_t outstreams, STOLEN_REF bstring* ran_cp_ipaddr);
 
-int sctp_itti_send_new_message_ind(
+status_code_e sctp_itti_send_new_message_ind(
     STOLEN_REF bstring* payload, sctp_ppid_t ppid, sctp_assoc_id_t assoc_id,
     sctp_stream_id_t stream);
 
-int sctp_itti_send_com_down_ind(
+status_code_e sctp_itti_send_com_down_ind(
     sctp_ppid_t ppid, sctp_assoc_id_t assoc_id, bool reset);
 
 #endif /* FILE_SCTP_ITTI_MESSAGING_SEEN */

--- a/lte/gateway/c/core/oai/tasks/service303/service303_task.c
+++ b/lte/gateway/c/core/oai/tasks/service303/service303_task.c
@@ -135,7 +135,7 @@ static void* service303_thread(void* args) {
   return NULL;
 }
 
-int service303_init(service303_data_t* service303_data) {
+status_code_e service303_init(service303_data_t* service303_data) {
   OAILOG_DEBUG(LOG_UTIL, "Initializing Service303 task interface\n");
 
   if (itti_create_task(

--- a/lte/gateway/c/core/oai/tasks/sgs/sgs_defs.h
+++ b/lte/gateway/c/core/oai/tasks/sgs/sgs_defs.h
@@ -30,8 +30,9 @@
 #include "hashtable.h"
 #include "queue.h"
 #include "nas/commonDef.h"
+#include "common_defs.h"
 #include "common_types.h"
 
-int sgs_init(const mme_config_t* mme_config);
+status_code_e sgs_init(const mme_config_t* mme_config);
 
 #endif

--- a/lte/gateway/c/core/oai/tasks/sgs/sgs_service_handler.c
+++ b/lte/gateway/c/core/oai/tasks/sgs/sgs_service_handler.c
@@ -28,7 +28,7 @@
 
 static void sgs_send_sgsap_vlr_reset_ack(void);
 
-int handle_sgs_location_update_accept(
+status_code_e handle_sgs_location_update_accept(
     const itti_sgsap_location_update_acc_t* itti_sgsap_location_update_acc_p) {
   /* Received SGS Location Update Accept from FedGW
    *send it to MME App for further processing
@@ -54,7 +54,7 @@ int handle_sgs_location_update_accept(
 }
 
 //------------------------------------------------------------------------------------------------------------
-int handle_sgs_location_update_reject(
+status_code_e handle_sgs_location_update_reject(
     const itti_sgsap_location_update_rej_t* itti_sgsap_loc_updt_rej_p) {
   MessageDef* message_p = NULL;
   int rc                = RETURNok;
@@ -79,7 +79,7 @@ int handle_sgs_location_update_reject(
   OAILOG_FUNC_RETURN(LOG_SGS, rc);
 }
 
-int handle_sgs_eps_detach_ack(
+status_code_e handle_sgs_eps_detach_ack(
     const itti_sgsap_eps_detach_ack_t* sgsap_eps_detach_ack_p) {
   // send it to MME module for further processing
   int rc                                            = RETURNok;
@@ -99,7 +99,7 @@ int handle_sgs_eps_detach_ack(
   OAILOG_FUNC_RETURN(LOG_SGS, rc);
 }
 
-int handle_sgs_imsi_detach_ack(
+status_code_e handle_sgs_imsi_detach_ack(
     const itti_sgsap_imsi_detach_ack_t* sgsap_imsi_detach_ack_p) {
   // send it to MME module for further processing
   int rc                                              = RETURNok;
@@ -120,7 +120,7 @@ int handle_sgs_imsi_detach_ack(
   OAILOG_FUNC_RETURN(LOG_SGS, rc);
 }
 
-int handle_sgs_downlink_unitdata(
+status_code_e handle_sgs_downlink_unitdata(
     const itti_sgsap_downlink_unitdata_t* sgs_dl_unitdata_p) {
   int rc = RETURNok;
 
@@ -140,7 +140,8 @@ int handle_sgs_downlink_unitdata(
   OAILOG_FUNC_RETURN(LOG_NAS_EMM, rc);
 }
 
-int handle_sgs_release_req(const itti_sgsap_release_req_t* sgs_release_req_p) {
+status_code_e handle_sgs_release_req(
+    const itti_sgsap_release_req_t* sgs_release_req_p) {
   int rc = RETURNok;
 
   MessageDef* message_p                   = NULL;
@@ -160,7 +161,7 @@ int handle_sgs_release_req(const itti_sgsap_release_req_t* sgs_release_req_p) {
  * MSC/VLR
  */
 
-int handle_sgs_mm_information_request(
+status_code_e handle_sgs_mm_information_request(
     const itti_sgsap_mm_information_req_t* mm_information_req_pP) {
   /* Received SGS MM Information Request from FedGW
    *send it to NAS task for further processing
@@ -194,7 +195,7 @@ int handle_sgs_mm_information_request(
 }
 
 //------------------------------------------------------------------------------------------------------------
-int handle_sgs_service_abort_req(
+status_code_e handle_sgs_service_abort_req(
     const itti_sgsap_service_abort_req_t* itti_sgsap_service_abort_req_p) {
   /* Received SGS SERVICE ABORT Request from FedGW
    *send it to MME App for further processing
@@ -226,7 +227,7 @@ int handle_sgs_service_abort_req(
  * Is function invoked by FedGW on reception of Paging Request from MSC/VLR
  */
 
-int handle_sgs_paging_request(
+status_code_e handle_sgs_paging_request(
     const itti_sgsap_paging_request_t* const sgs_paging_req_pP) {
   MessageDef* message_p = NULL;
   int rc                = RETURNok;
@@ -265,7 +266,7 @@ int handle_sgs_paging_request(
  * Is Function invoked by FedGW on reception of Reset Indication from MSC/VLR
  */
 
-int handle_sgs_vlr_reset_indication(
+status_code_e handle_sgs_vlr_reset_indication(
     const itti_sgsap_vlr_reset_indication_t* const sgs_vlr_reset_ind_pP) {
   MessageDef* message_p = NULL;
   int rc                = RETURNok;
@@ -312,7 +313,8 @@ int handle_sgs_vlr_reset_indication(
  * Is function invoked by FedGW on reception of Sgs Status message from MSC/VLR
  */
 
-int handle_sgs_status_message(const itti_sgsap_status_t* sgs_status_pP) {
+status_code_e handle_sgs_status_message(
+    const itti_sgsap_status_t* sgs_status_pP) {
   MessageDef* message_p = NULL;
   int rc                = RETURNok;
   OAILOG_FUNC_IN(LOG_SGS);
@@ -367,7 +369,7 @@ static void sgs_send_sgsap_vlr_reset_ack(void) {
   OAILOG_FUNC_OUT(LOG_SGS);
 }
 
-int handle_sgsap_alert_request(
+status_code_e handle_sgsap_alert_request(
     const itti_sgsap_alert_request_t* const sgsap_alert_request) {
   MessageDef* message_p = NULL;
   int rc                = RETURNok;

--- a/lte/gateway/c/core/oai/tasks/sgs/sgs_task.c
+++ b/lte/gateway/c/core/oai/tasks/sgs/sgs_task.c
@@ -185,7 +185,7 @@ static void* sgs_thread(__attribute__((unused)) void* args_p) {
 }
 
 //------------------------------------------------------------------------------
-int sgs_init(const mme_config_t* mme_config_p) {
+status_code_e sgs_init(const mme_config_t* mme_config_p) {
   OAILOG_DEBUG(LOG_SGS, "Initializing SGS task interface\n");
 
   if (itti_create_task(TASK_SGS, &sgs_thread, NULL) < 0) {

--- a/lte/gateway/c/core/oai/tasks/sgw/pgw_config.c
+++ b/lte/gateway/c/core/oai/tasks/sgw/pgw_config.c
@@ -65,7 +65,7 @@ void pgw_config_init(pgw_config_t* config_pP) {
 }
 
 //------------------------------------------------------------------------------
-int pgw_config_process(pgw_config_t* config_pP) {
+status_code_e pgw_config_process(pgw_config_t* config_pP) {
 #if (!EMBEDDED_SGW)
   async_system_command(
       TASK_ASYNC_SYSTEM, PGW_ABORT_ON_ERROR, "iptables -t mangle -F OUTPUT");
@@ -206,7 +206,7 @@ int pgw_config_process(pgw_config_t* config_pP) {
 }
 
 //------------------------------------------------------------------------------
-int pgw_config_parse_file(pgw_config_t* config_pP) {
+status_code_e pgw_config_parse_file(pgw_config_t* config_pP) {
   config_t cfg                  = {0};
   config_setting_t* setting_pgw = NULL;
   config_setting_t* subsetting  = NULL;

--- a/lte/gateway/c/core/oai/tasks/sgw/pgw_handlers.c
+++ b/lte/gateway/c/core/oai/tasks/sgw/pgw_handlers.c
@@ -217,7 +217,7 @@ void spgw_handle_pcef_create_session_response(
 /*
  * Handle NW initiated Dedicated Bearer Activation from SPGW service
  */
-int spgw_handle_nw_initiated_bearer_actv_req(
+status_code_e spgw_handle_nw_initiated_bearer_actv_req(
     spgw_state_t* spgw_state,
     const itti_gx_nw_init_actv_bearer_request_t* const bearer_req_p,
     imsi64_t imsi64, gtpv2c_cause_value_t* failed_cause) {
@@ -476,7 +476,7 @@ static int32_t spgw_build_and_send_s11_deactivate_bearer_req(
 }
 
 //------------------------------------------------------------------------------
-int spgw_send_nw_init_activate_bearer_rsp(
+status_code_e spgw_send_nw_init_activate_bearer_rsp(
     gtpv2c_cause_value_t cause, imsi64_t imsi64,
     bearer_context_within_create_bearer_response_t* bearer_ctx,
     uint8_t default_bearer_id, char* policy_rule_name) {

--- a/lte/gateway/c/core/oai/tasks/sgw/pgw_handlers.h
+++ b/lte/gateway/c/core/oai/tasks/sgw/pgw_handlers.h
@@ -24,6 +24,7 @@
 
 #ifndef FILE_PGW_HANDLERS_SEEN
 #define FILE_PGW_HANDLERS_SEEN
+#include "common_defs.h"
 #include "gx_messages_types.h"
 #include "spgw_state.h"
 
@@ -40,7 +41,7 @@ void spgw_handle_pcef_create_session_response(
 uint32_t spgw_handle_nw_init_deactivate_bearer_rsp(
     gtpv2c_cause_t cause, ebi_t lbi);
 
-int spgw_handle_nw_initiated_bearer_actv_req(
+status_code_e spgw_handle_nw_initiated_bearer_actv_req(
     spgw_state_t* state,
     const itti_gx_nw_init_actv_bearer_request_t* const bearer_req_p,
     imsi64_t imsi64, gtpv2c_cause_value_t* failed_cause);
@@ -49,7 +50,7 @@ int32_t spgw_handle_nw_initiated_bearer_deactv_req(
     const itti_gx_nw_init_deactv_bearer_request_t* const bearer_req_p,
     imsi64_t imsi64);
 
-int spgw_send_nw_init_activate_bearer_rsp(
+status_code_e spgw_send_nw_init_activate_bearer_rsp(
     gtpv2c_cause_value_t cause, imsi64_t imsi64,
     bearer_context_within_create_bearer_response_t* bearer_ctx,
     uint8_t default_bearer_id, char* policy_rule_name);

--- a/lte/gateway/c/core/oai/tasks/sgw/pgw_pcef_emulation.c
+++ b/lte/gateway/c/core/oai/tasks/sgw/pgw_pcef_emulation.c
@@ -50,7 +50,7 @@
  * Function that adds predefined PCC rules to PGW struct,
  * it returns an error or success code after adding rules.
  */
-int pgw_pcef_emulation_init(
+status_code_e pgw_pcef_emulation_init(
     spgw_state_t* state_p, const pgw_config_t* const pgw_config_p) {
   int rc             = RETURNok;
   hashtable_rc_t hrc = HASH_TABLE_OK;
@@ -530,7 +530,7 @@ bstring pgw_pcef_emulation_packet_filter_2_iptable_string(
 }
 
 //------------------------------------------------------------------------------
-int pgw_pcef_get_sdf_parameters(
+status_code_e pgw_pcef_get_sdf_parameters(
     spgw_state_t* state_p, const sdf_id_t sdf_id,
     bearer_qos_t* const bearer_qos, packet_filter_t* const packet_filter,
     uint8_t* const num_pf) {

--- a/lte/gateway/c/core/oai/tasks/sgw/pgw_pcef_emulation.h
+++ b/lte/gateway/c/core/oai/tasks/sgw/pgw_pcef_emulation.h
@@ -28,13 +28,14 @@
 #include <stdbool.h>
 #include <stdint.h>
 
+#include "common_defs.h"
 #include "queue.h"
 #include "bstrlib.h"
 #include "pgw_config.h"
 #include "pgw_types.h"
 #include "spgw_state.h"
 
-int pgw_pcef_emulation_init(
+status_code_e pgw_pcef_emulation_init(
     spgw_state_t* state_p, const pgw_config_t* pgw_config_p);
 void pgw_pcef_emulation_apply_rule(
     spgw_state_t* state_p, sdf_id_t sdf_id, const pgw_config_t* pgw_config_p);
@@ -42,7 +43,7 @@ void pgw_pcef_emulation_apply_sdf_filter(
     sdf_filter_t* sdf_f, sdf_id_t sdf_id, const pgw_config_t* pgw_config_p);
 bstring pgw_pcef_emulation_packet_filter_2_iptable_string(
     packet_filter_contents_t* packetfiltercontents, uint8_t direction);
-int pgw_pcef_get_sdf_parameters(
+status_code_e pgw_pcef_get_sdf_parameters(
     spgw_state_t* state, sdf_id_t sdf_id, bearer_qos_t* bearer_qos,
     packet_filter_t* packet_filter, uint8_t* num_pf);
 

--- a/lte/gateway/c/core/oai/tasks/sgw/pgw_pco.c
+++ b/lte/gateway/c/core/oai/tasks/sgw/pgw_pco.c
@@ -37,7 +37,7 @@
 #include "pgw_config.h"
 
 //------------------------------------------------------------------------------
-int pgw_pco_push_protocol_or_container_id(
+status_code_e pgw_pco_push_protocol_or_container_id(
     protocol_configuration_options_t* const pco,
     pco_protocol_or_container_id_t* const
         poc_id /* STOLEN_REF poc_id->contents*/) {
@@ -60,7 +60,7 @@ int pgw_pco_push_protocol_or_container_id(
 }
 
 //------------------------------------------------------------------------------
-int pgw_process_pco_request_ipcp(
+status_code_e pgw_process_pco_request_ipcp(
     protocol_configuration_options_t* const pco_resp,
     const pco_protocol_or_container_id_t* const poc_id) {
   in_addr_t ipcp_dns_prim_ipv4_addr          = INADDR_NONE;
@@ -267,7 +267,7 @@ int pgw_process_pco_request_ipcp(
 }
 
 //------------------------------------------------------------------------------
-int pgw_process_pco_dns_server_request(
+status_code_e pgw_process_pco_dns_server_request(
     protocol_configuration_options_t* const pco_resp,
     const pco_protocol_or_container_id_t* const poc_id) {
   in_addr_t ipcp_out_dns_prim_ipv4_addr =
@@ -289,7 +289,7 @@ int pgw_process_pco_dns_server_request(
   return pgw_pco_push_protocol_or_container_id(pco_resp, &poc_id_resp);
 }
 //------------------------------------------------------------------------------
-int pgw_process_pco_link_mtu_request(
+status_code_e pgw_process_pco_link_mtu_request(
     protocol_configuration_options_t* const pco_resp,
     const pco_protocol_or_container_id_t* const poc_id) {
   pco_protocol_or_container_id_t poc_id_resp = {0};
@@ -307,7 +307,7 @@ int pgw_process_pco_link_mtu_request(
 }
 
 //------------------------------------------------------------------------------
-int pgw_process_pco_pcscf_ipv4_address_req(
+status_code_e pgw_process_pco_pcscf_ipv4_address_req(
     protocol_configuration_options_t* const pco_resp) {
   if (!spgw_config.pgw_config.pcscf.ipv4_addr.s_addr) {
     OAILOG_ERROR(
@@ -334,7 +334,7 @@ int pgw_process_pco_pcscf_ipv4_address_req(
 }
 
 //------------------------------------------------------------------------------
-int pgw_process_pco_pcscf_ipv6_address_req(
+status_code_e pgw_process_pco_pcscf_ipv6_address_req(
     protocol_configuration_options_t* const pco_resp) {
   if (!strlen((char*) spgw_config.pgw_config.pcscf.ipv6_addr.s6_addr)) {
     OAILOG_ERROR(
@@ -362,7 +362,7 @@ int pgw_process_pco_pcscf_ipv6_address_req(
 }
 
 //------------------------------------------------------------------------------
-int pgw_process_pco_dns_server_ipv6_address_req(
+status_code_e pgw_process_pco_dns_server_ipv6_address_req(
     protocol_configuration_options_t* const pco_resp) {
   struct in6_addr dns_ipv6_addr = spgw_config.pgw_config.ipv6.dns_ipv6_addr;
   pco_protocol_or_container_id_t poc_id_resp = {0};
@@ -380,7 +380,7 @@ int pgw_process_pco_dns_server_ipv6_address_req(
 
 //------------------------------------------------------------------------------
 
-int pgw_process_pco_request(
+status_code_e pgw_process_pco_request(
     const protocol_configuration_options_t* const pco_req,
     protocol_configuration_options_t* pco_resp,
     protocol_configuration_options_ids_t* const pco_ids) {

--- a/lte/gateway/c/core/oai/tasks/sgw/pgw_pco.h
+++ b/lte/gateway/c/core/oai/tasks/sgw/pgw_pco.h
@@ -26,6 +26,7 @@
 
 #include <stdint.h>
 
+#include "common_defs.h"
 #include "3gpp_24.008.h"
 
 /**
@@ -47,23 +48,23 @@ typedef struct protocol_configuration_options_ids_s {
   uint8_t ci_ipv4_link_mtu_request : 1;
 } protocol_configuration_options_ids_t;
 
-int pgw_pco_push_protocol_or_container_id(
+status_code_e pgw_pco_push_protocol_or_container_id(
     protocol_configuration_options_t* const pco,
     pco_protocol_or_container_id_t* const poc_id);
 
-int pgw_process_pco_request_ipcp(
+status_code_e pgw_process_pco_request_ipcp(
     protocol_configuration_options_t* const pco_resp,
     const pco_protocol_or_container_id_t* const poc_id);
 
-int pgw_process_pco_dns_server_request(
+status_code_e pgw_process_pco_dns_server_request(
     protocol_configuration_options_t* const pco_resp,
     const pco_protocol_or_container_id_t* const poc_id);
 
-int pgw_process_pco_link_mtu_request(
+status_code_e pgw_process_pco_link_mtu_request(
     protocol_configuration_options_t* const pco_resp,
     const pco_protocol_or_container_id_t* const poc_id);
 
-int pgw_process_pco_request(
+status_code_e pgw_process_pco_request(
     const protocol_configuration_options_t* const pco_req,
     protocol_configuration_options_t* pco_resp,
     protocol_configuration_options_ids_t* const pco_ids);

--- a/lte/gateway/c/core/oai/tasks/sgw/sgw_config.c
+++ b/lte/gateway/c/core/oai/tasks/sgw/sgw_config.c
@@ -56,13 +56,13 @@ void sgw_config_init(sgw_config_t* config_pP) {
   pthread_rwlock_init(&config_pP->rw_lock, NULL);
 }
 //------------------------------------------------------------------------------
-int sgw_config_process(sgw_config_t* config_pP) {
+status_code_e sgw_config_process(sgw_config_t* config_pP) {
   int ret = RETURNok;
   return ret;
 }
 
 //------------------------------------------------------------------------------
-int sgw_config_parse_file(sgw_config_t* config_pP)
+status_code_e sgw_config_parse_file(sgw_config_t* config_pP)
 
 {
   config_t cfg                             = {0};

--- a/lte/gateway/c/core/oai/tasks/sgw/sgw_context_manager.c
+++ b/lte/gateway/c/core/oai/tasks/sgw/sgw_context_manager.c
@@ -193,7 +193,8 @@ sgw_cm_create_bearer_context_information_in_collection(teid_t teid) {
 }
 
 //-----------------------------------------------------------------------------
-int sgw_cm_remove_bearer_context_information(teid_t teid, imsi64_t imsi64) {
+status_code_e sgw_cm_remove_bearer_context_information(
+    teid_t teid, imsi64_t imsi64) {
   int temp = 0;
 
   hash_table_ts_t* state_teid_ht = get_spgw_teid_state();
@@ -315,7 +316,7 @@ sgw_eps_bearer_ctxt_t* sgw_cm_get_eps_bearer_entry(
 }
 
 //-----------------------------------------------------------------------------
-int sgw_cm_remove_eps_bearer_entry(
+status_code_e sgw_cm_remove_eps_bearer_entry(
     sgw_pdn_connection_t* const sgw_pdn_connection, ebi_t ebi)
 //-----------------------------------------------------------------------------
 {
@@ -361,7 +362,7 @@ spgw_ue_context_t* spgw_create_or_get_ue_context(imsi64_t imsi64) {
   OAILOG_FUNC_RETURN(LOG_SPGW_APP, ue_context_p);
 }
 
-int spgw_update_teid_in_ue_context(imsi64_t imsi64, teid_t teid) {
+status_code_e spgw_update_teid_in_ue_context(imsi64_t imsi64, teid_t teid) {
   OAILOG_FUNC_IN(LOG_SPGW_APP);
   spgw_ue_context_t* ue_context_p = spgw_create_or_get_ue_context(imsi64);
   if (!ue_context_p) {

--- a/lte/gateway/c/core/oai/tasks/sgw/sgw_defs.h
+++ b/lte/gateway/c/core/oai/tasks/sgw/sgw_defs.h
@@ -25,11 +25,12 @@
 #ifndef FILE_SGW_DEFS_SEEN
 #define FILE_SGW_DEFS_SEEN
 
+#include "common_defs.h"
 #include "intertask_interface.h"
 #include "spgw_config.h"
 
 extern task_zmq_ctx_t spgw_app_task_zmq_ctx;
 
-int spgw_app_init(spgw_config_t* spgw_config_pP, bool persist_state);
+status_code_e spgw_app_init(spgw_config_t* spgw_config_pP, bool persist_state);
 
 #endif /* FILE_SGW_DEFS_SEEN */

--- a/lte/gateway/c/core/oai/tasks/sgw/sgw_handlers.c
+++ b/lte/gateway/c/core/oai/tasks/sgw/sgw_handlers.c
@@ -98,7 +98,7 @@ uint32_t spgw_get_new_s1u_teid(spgw_state_t* state) {
 }
 
 //------------------------------------------------------------------------------
-int sgw_handle_s11_create_session_request(
+status_code_e sgw_handle_s11_create_session_request(
     spgw_state_t* state,
     const itti_s11_create_session_request_t* const session_req_pP,
     imsi64_t imsi64) {
@@ -301,7 +301,7 @@ int sgw_handle_s11_create_session_request(
 }
 
 //------------------------------------------------------------------------------
-int sgw_handle_sgi_endpoint_created(
+status_code_e sgw_handle_sgi_endpoint_created(
     spgw_state_t* state, itti_sgi_create_end_point_response_t* const resp_pP,
     imsi64_t imsi64) {
   OAILOG_FUNC_IN(LOG_SPGW_APP);
@@ -698,7 +698,7 @@ void sgw_handle_sgi_endpoint_updated(
   OAILOG_FUNC_OUT(LOG_SPGW_APP);
 }
 //------------------------------------------------------------------------------
-int sgw_handle_sgi_endpoint_deleted(
+status_code_e sgw_handle_sgi_endpoint_deleted(
     const itti_sgi_delete_end_point_request_t* const resp_pP, imsi64_t imsi64) {
   sgw_eps_bearer_ctxt_t* eps_bearer_ctxt_p = NULL;
   int rv                                   = RETURNok;
@@ -880,7 +880,7 @@ void populate_sgi_end_point_update(
 
 //------------------------------------------------------------------------------
 // This function populates and sends MBR failure message to MME APP
-int send_mbr_failure(
+status_code_e send_mbr_failure(
     log_proto_t module,
     const itti_s11_modify_bearer_request_t* const modify_bearer_pP,
     imsi64_t imsi64) {
@@ -926,7 +926,7 @@ int send_mbr_failure(
 }
 
 //------------------------------------------------------------------------------
-int sgw_handle_modify_bearer_request(
+status_code_e sgw_handle_modify_bearer_request(
     const itti_s11_modify_bearer_request_t* const modify_bearer_pP,
     imsi64_t imsi64) {
   OAILOG_FUNC_IN(LOG_SPGW_APP);
@@ -1039,7 +1039,7 @@ int sgw_handle_modify_bearer_request(
 }
 
 //------------------------------------------------------------------------------
-int sgw_handle_delete_session_request(
+status_code_e sgw_handle_delete_session_request(
     const itti_s11_delete_session_request_t* const delete_session_req_pP,
     imsi64_t imsi64) {
   OAILOG_FUNC_IN(LOG_SPGW_APP);
@@ -1434,7 +1434,7 @@ void handle_s5_create_session_response(
  * TODO for multiple PDN support, suspend all bearers and disard the DL data for
  * the UE
  */
-int sgw_handle_suspend_notification(
+status_code_e sgw_handle_suspend_notification(
     const itti_s11_suspend_notification_t* const suspend_notification_pP,
     imsi64_t imsi64) {
   itti_s11_suspend_acknowledge_t* suspend_acknowledge_p = NULL;
@@ -1520,7 +1520,7 @@ int sgw_handle_suspend_notification(
  * Handle NW initiated Dedicated Bearer Activation Rsp from MME
  */
 
-int sgw_handle_nw_initiated_actv_bearer_rsp(
+status_code_e sgw_handle_nw_initiated_actv_bearer_rsp(
     const itti_s11_nw_init_actv_bearer_rsp_t* const s11_actv_bearer_rsp,
     imsi64_t imsi64) {
   OAILOG_FUNC_IN(LOG_SPGW_APP);
@@ -1657,7 +1657,7 @@ int sgw_handle_nw_initiated_actv_bearer_rsp(
  * Handle NW-initiated dedicated bearer dectivation rsp from MME
  */
 
-int sgw_handle_nw_initiated_deactv_bearer_rsp(
+status_code_e sgw_handle_nw_initiated_deactv_bearer_rsp(
     spgw_state_t* spgw_state,
     const itti_s11_nw_init_deactv_bearer_rsp_t* const
         s11_pcrf_ded_bearer_deactv_rsp,
@@ -1815,7 +1815,7 @@ int sgw_handle_nw_initiated_deactv_bearer_rsp(
   OAILOG_FUNC_RETURN(LOG_SPGW_APP, rc);
 }
 
-int sgw_handle_ip_allocation_rsp(
+status_code_e sgw_handle_ip_allocation_rsp(
     spgw_state_t* spgw_state,
     const itti_ip_allocation_response_t* ip_allocation_rsp, imsi64_t imsi64) {
   OAILOG_FUNC_IN(LOG_SPGW_APP);

--- a/lte/gateway/c/core/oai/tasks/sgw/sgw_handlers.h
+++ b/lte/gateway/c/core/oai/tasks/sgw/sgw_handlers.h
@@ -25,6 +25,7 @@
 #ifndef FILE_SGW_HANDLERS_SEEN
 #define FILE_SGW_HANDLERS_SEEN
 
+#include "common_defs.h"
 #include "common_types.h"
 #include "gtpv1_u_messages_types.h"
 #include "ip_forward_messages_types.h"
@@ -34,41 +35,41 @@
 
 extern task_zmq_ctx_t spgw_app_task_zmq_ctx;
 
-int sgw_handle_s11_create_session_request(
+status_code_e sgw_handle_s11_create_session_request(
     spgw_state_t* state,
     const itti_s11_create_session_request_t* const session_req_p,
     imsi64_t imsi64);
 void sgw_handle_sgi_endpoint_updated(
     const itti_sgi_update_end_point_response_t* const resp_p, imsi64_t imsi64);
-int sgw_handle_sgi_endpoint_deleted(
+status_code_e sgw_handle_sgi_endpoint_deleted(
     const itti_sgi_delete_end_point_request_t* const resp_pP, imsi64_t imsi64);
-int sgw_handle_modify_bearer_request(
+status_code_e sgw_handle_modify_bearer_request(
     const itti_s11_modify_bearer_request_t* const modify_bearer_p,
     imsi64_t imsi64);
-int sgw_handle_delete_session_request(
+status_code_e sgw_handle_delete_session_request(
     const itti_s11_delete_session_request_t* const delete_session_p,
     imsi64_t imsi64);
 void sgw_handle_release_access_bearers_request(
     const itti_s11_release_access_bearers_request_t* const
         release_access_bearers_req_pP,
     imsi64_t imsi64);
-int sgw_handle_suspend_notification(
+status_code_e sgw_handle_suspend_notification(
     const itti_s11_suspend_notification_t* const suspend_notification_pP,
     imsi64_t imsi64);
-int sgw_handle_nw_initiated_actv_bearer_rsp(
+status_code_e sgw_handle_nw_initiated_actv_bearer_rsp(
     const itti_s11_nw_init_actv_bearer_rsp_t* const s11_actv_bearer_rsp,
     imsi64_t imsi64);
-int sgw_handle_nw_initiated_deactv_bearer_rsp(
+status_code_e sgw_handle_nw_initiated_deactv_bearer_rsp(
     spgw_state_t* spgw_state,
     const itti_s11_nw_init_deactv_bearer_rsp_t* const
         s11_pcrf_ded_bearer_deactv_rsp,
     imsi64_t imsi64);
-int sgw_handle_ip_allocation_rsp(
+status_code_e sgw_handle_ip_allocation_rsp(
     spgw_state_t* spgw_state,
     const itti_ip_allocation_response_t* ip_allocation_rsp, imsi64_t imsi64);
 bool is_enb_ip_address_same(const fteid_t* fte_p, ip_address_t* ip_p);
 uint32_t spgw_get_new_s1u_teid(spgw_state_t* state);
-int send_mbr_failure(
+status_code_e send_mbr_failure(
     log_proto_t module,
     const itti_s11_modify_bearer_request_t* const modify_bearer_pP,
     imsi64_t imsi64);

--- a/lte/gateway/c/core/oai/tasks/sgw/sgw_task.c
+++ b/lte/gateway/c/core/oai/tasks/sgw/sgw_task.c
@@ -225,7 +225,7 @@ static void* spgw_app_thread(__attribute__((unused)) void* args) {
 }
 
 //------------------------------------------------------------------------------
-int spgw_app_init(spgw_config_t* spgw_config_pP, bool persist_state) {
+status_code_e spgw_app_init(spgw_config_t* spgw_config_pP, bool persist_state) {
   OAILOG_DEBUG(LOG_SPGW_APP, "Initializing SPGW-APP  task interface\n");
 
   if (spgw_state_init(persist_state, spgw_config_pP) < 0) {

--- a/lte/gateway/c/core/oai/tasks/sgw/spgw_config.c
+++ b/lte/gateway/c/core/oai/tasks/sgw/spgw_config.c
@@ -70,7 +70,7 @@ static int spgw_config_process(spgw_config_t* config_pP) {
 }
 
 //------------------------------------------------------------------------------
-int spgw_config_parse_file(spgw_config_t* config_pP) {
+status_code_e spgw_config_parse_file(spgw_config_t* config_pP) {
   config_t cfg = {0};
   config_init(&cfg);
 
@@ -139,7 +139,7 @@ static void usage(char* target) {
       LOG_CONFIG, "-V      Print %s version and return\n", PACKAGE_NAME);
 }
 //------------------------------------------------------------------------------
-int spgw_config_parse_opt_line(
+status_code_e spgw_config_parse_opt_line(
     int argc, char* argv[], spgw_config_t* spgw_config_p) {
   int c;
 

--- a/lte/gateway/c/core/oai/tasks/sgw_s8/sgw_s8_defs.h
+++ b/lte/gateway/c/core/oai/tasks/sgw_s8/sgw_s8_defs.h
@@ -13,9 +13,10 @@ limitations under the License.
 
 #pragma once
 
+#include "common_defs.h"
 #include "intertask_interface.h"
 #include "sgw_config.h"
 
 extern task_zmq_ctx_t sgw_s8_task_zmq_ctx;
 
-int sgw_s8_init(sgw_config_t* sgw_config_p);
+status_code_e sgw_s8_init(sgw_config_t* sgw_config_p);

--- a/lte/gateway/c/core/oai/tasks/sgw_s8/sgw_s8_handlers.c
+++ b/lte/gateway/c/core/oai/tasks/sgw_s8/sgw_s8_handlers.c
@@ -143,7 +143,7 @@ spgw_ue_context_t* sgw_create_or_get_ue_context(
   OAILOG_FUNC_RETURN(LOG_SGW_S8, ue_context_p);
 }
 
-int sgw_update_teid_in_ue_context(
+status_code_e sgw_update_teid_in_ue_context(
     sgw_state_t* sgw_state, imsi64_t imsi64, teid_t teid) {
   OAILOG_FUNC_IN(LOG_SGW_S8);
   spgw_ue_context_t* ue_context_p =

--- a/lte/gateway/c/core/oai/tasks/sgw_s8/sgw_s8_task.c
+++ b/lte/gateway/c/core/oai/tasks/sgw_s8/sgw_s8_task.c
@@ -38,7 +38,7 @@ static void* sgw_s8_thread(void* args) {
   return NULL;
 }
 
-int sgw_s8_init(sgw_config_t* sgw_config_p) {
+status_code_e sgw_s8_init(sgw_config_t* sgw_config_p) {
   OAILOG_DEBUG(LOG_SGW_S8, "Initializing SGW-S8 interface\n");
   if (sgw_state_init(false, sgw_config_p) < 0) {
     OAILOG_CRITICAL(LOG_SGW_S8, "Error while initializing SGW_S8 state\n");

--- a/lte/gateway/c/core/oai/tasks/sms_orc8r/sms_orc8r_defs.h
+++ b/lte/gateway/c/core/oai/tasks/sms_orc8r/sms_orc8r_defs.h
@@ -27,11 +27,12 @@
 #include <stdint.h>
 #include <netinet/in.h>
 #include "bstrlib.h"
+#include "common_defs.h"
 #include "hashtable.h"
 #include "queue.h"
 #include "nas/commonDef.h"
 #include "common_types.h"
 
-int sms_orc8r_init(const mme_config_t* mme_config);
+status_code_e sms_orc8r_init(const mme_config_t* mme_config);
 
 #endif

--- a/lte/gateway/c/core/oai/tasks/sms_orc8r/sms_orc8r_service_handler.c
+++ b/lte/gateway/c/core/oai/tasks/sms_orc8r/sms_orc8r_service_handler.c
@@ -26,7 +26,7 @@
 #include "sms_orc8r_messages.h"
 #include "sgs_messages_types.h"
 
-int handle_sms_orc8r_downlink_unitdata(
+status_code_e handle_sms_orc8r_downlink_unitdata(
     const itti_sgsap_downlink_unitdata_t* sgs_dl_unitdata_p) {
   int rc = RETURNok;
 

--- a/lte/gateway/c/core/oai/tasks/sms_orc8r/sms_orc8r_task.c
+++ b/lte/gateway/c/core/oai/tasks/sms_orc8r/sms_orc8r_task.c
@@ -85,7 +85,7 @@ static void* sms_orc8r_thread(__attribute__((unused)) void* args_p) {
 }
 
 //------------------------------------------------------------------------------
-int sms_orc8r_init(const mme_config_t* mme_config_p) {
+status_code_e sms_orc8r_init(const mme_config_t* mme_config_p) {
   OAILOG_DEBUG(LOG_SMS_ORC8R, "Initializing SMS_ORC8R task interface\n");
 
   if (itti_create_task(TASK_SMS_ORC8R, &sms_orc8r_thread, NULL) < 0) {


### PR DESCRIPTION
Signed-off-by: Andrei Lee <andreilee@fb.com>

## Summary

See: https://github.com/magma/magma/pull/7483

This PR is part of an effort to move all `Assert`s from lower level library-equivalent functions to higher level callers.

This PR refactors all the function signatures that return either `RETURNok` or `RETURNerror`, so that their specified return type is `status_code_e`

An additional later PR will modify functions that return either a value of `RETURNerror` or an integer (or other such variants).

## Test Plan

Only built MME

```
vagrant@magma-dev:~/magma/lte/gateway$ make build_oai
.
.
.
[7/7] Completed 'MagmaCore'
vagrant@magma-dev:~/magma/lte/gateway$
```

## Additional Information

- [ ] This change is backwards-breaking
