### PR TITLE
AGW: add IRQ CPU affinity configuration

### DIFF
--- a/lte/gateway/configs/pipelined.yml
+++ b/lte/gateway/configs/pipelined.yml
@@ -190,3 +190,11 @@ ovs_internal_conntrack_fwd_tbl_number: 202
 5G_feature_set:
  enable: False
  node_identifier: 192.168.200.1
+
+dp_irq:
+ enable: True
+ S1_cpu: '1'
+ S1_queue_size: 256
+ SGi_cpu: '2'
+ SGi_queue_size: 256
+

--- a/lte/gateway/configs/pipelined.yml_prod
+++ b/lte/gateway/configs/pipelined.yml_prod
@@ -167,3 +167,10 @@ ovs_internal_conntrack_port_number: 15579
 
 # Table to forward packets from the internal conntrack
 ovs_internal_conntrack_fwd_tbl_number: 202
+
+dp_irq:
+ enable: True
+ S1_cpu: '2-3'
+ S1_queue_size: 1024
+ SGi_cpu: '2-3'
+ SGi_queue_size: 1024

--- a/lte/gateway/deploy/roles/magma/files/set_irq_affinity
+++ b/lte/gateway/deploy/roles/magma/files/set_irq_affinity
@@ -1,0 +1,265 @@
+#!/bin/bash
+#
+# Copyright (c) 2015, Intel Corporation
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+#     * Redistributions of source code must retain the above copyright notice,
+#       this list of conditions and the following disclaimer.
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in the
+#       documentation and/or other materials provided with the distribution.
+#     * Neither the name of Intel Corporation nor the names of its contributors
+#       may be used to endorse or promote products derived from this software
+#       without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+# Affinitize interrupts to cores
+#
+# typical usage is (as root):
+# set_irq_affinity -x local eth1 <eth2> <eth3>
+#
+# to get help:
+# set_irq_affinity
+
+usage()
+{
+	echo
+	echo "Usage: $0 [-x|-X] {all|local|remote|one|custom} [ethX] <[ethY]>"
+	echo "	options: -x		Configure XPS as well as smp_affinity"
+	echo "	options: -X		Disable XPS but set smp_affinity"
+	echo "	options: {remote|one} can be followed by a specific node number"
+	echo "	Ex: $0 local eth0"
+	echo "	Ex: $0 remote 1 eth0"
+	echo "	Ex: $0 custom eth0 eth1"
+	echo "	Ex: $0 0-7,16-23 eth0"
+	echo
+	exit 1
+}
+
+usageX()
+{
+	echo "options -x and -X cannot both be specified, pick one"
+	exit 1
+}
+
+if [ "$1" == "-x" ]; then
+	XPS_ENA=1
+	shift
+fi
+
+if [ "$1" == "-X" ]; then
+	if [ -n "$XPS_ENA" ]; then
+		usageX
+	fi
+	XPS_DIS=2
+	shift
+fi
+
+if [ "$1" == -x ]; then
+	usageX
+fi
+
+if [ -n "$XPS_ENA" ] && [ -n "$XPS_DIS" ]; then
+	usageX
+fi
+
+if [ -z "$XPS_ENA" ]; then
+	XPS_ENA=$XPS_DIS
+fi
+
+num='^[0-9]+$'
+# Vars
+AFF=$1
+shift
+
+case "$AFF" in
+    remote)	[[ $1 =~ $num ]] && rnode=$1 && shift ;;
+    one)	[[ $1 =~ $num ]] && cnt=$1 && shift ;;
+    all)	;;
+    local)	;;
+    custom)	;;
+    [0-9]*)	;;
+    -h|--help)	usage ;;
+    "")		usage ;;
+    *)		IFACES=$AFF && AFF=all ;;	# Backwards compat mode
+esac
+
+# append the interfaces listed to the string with spaces
+while [ "$#" -ne "0" ] ; do
+	IFACES+=" $1"
+	shift
+done
+
+# for now the user must specify interfaces
+if [ -z "$IFACES" ]; then
+	usage
+	exit 1
+fi
+
+# support functions
+
+set_affinity()
+{
+	VEC=$core
+	if [ $VEC -ge 32 ]
+	then
+		MASK_FILL=""
+		MASK_ZERO="00000000"
+		let "IDX = $VEC / 32"
+		for ((i=1; i<=$IDX;i++))
+		do
+			MASK_FILL="${MASK_FILL},${MASK_ZERO}"
+		done
+
+		let "VEC -= 32 * $IDX"
+		MASK_TMP=$((1<<$VEC))
+		MASK=$(printf "%X%s" $MASK_TMP $MASK_FILL)
+	else
+		MASK_TMP=$((1<<$VEC))
+		MASK=$(printf "%X" $MASK_TMP)
+	fi
+
+	printf "%s" $MASK > /proc/irq/$IRQ/smp_affinity
+	printf "%s %d %s -> /proc/irq/$IRQ/smp_affinity\n" $IFACE $core $MASK
+	case "$XPS_ENA" in
+	1)
+		printf "%s %d %s -> /sys/class/net/%s/queues/tx-%d/xps_cpus\n" $IFACE $core $MASK $IFACE $((n-1))
+		printf "%s" $MASK > /sys/class/net/$IFACE/queues/tx-$((n-1))/xps_cpus
+	;;
+	2)
+		MASK=0
+		printf "%s %d %s -> /sys/class/net/%s/queues/tx-%d/xps_cpus\n" $IFACE $core $MASK $IFACE $((n-1))
+		printf "%s" $MASK > /sys/class/net/$IFACE/queues/tx-$((n-1))/xps_cpus
+	;;
+	*)
+	esac
+}
+
+# Allow usage of , or -
+#
+parse_range () {
+        RANGE=${@//,/ }
+        RANGE=${RANGE//-/..}
+        LIST=""
+        for r in $RANGE; do
+		# eval lets us use vars in {#..#} range
+                [[ $r =~ '..' ]] && r="$(eval echo {$r})"
+		LIST+=" $r"
+        done
+	echo $LIST
+}
+
+# Affinitize interrupts
+#
+setaff()
+{
+	CORES=$(parse_range $CORES)
+	ncores=$(echo $CORES | wc -w)
+	n=1
+
+	# this script only supports interrupt vectors in pairs,
+	# modification would be required to support a single Tx or Rx queue
+	# per interrupt vector
+
+	queues="${IFACE}-.*TxRx"
+
+	irqs=$(grep "$queues" /proc/interrupts | cut -f1 -d:)
+	[ -z "$irqs" ] && irqs=$(grep $IFACE /proc/interrupts | cut -f1 -d:)
+	[ -z "$irqs" ] && irqs=$(for i in `ls -Ux /sys/class/net/$IFACE/device/msi_irqs` ;\
+	                         do grep "$i:.*TxRx" /proc/interrupts | grep -v fdir | cut -f 1 -d : ;\
+	                         done)
+	[ -z "$irqs" ] && echo "Error: Could not find interrupts for $IFACE"
+
+	echo "IFACE CORE MASK -> FILE"
+	echo "======================="
+	for IRQ in $irqs; do
+		[ "$n" -gt "$ncores" ] && n=1
+		j=1
+		# much faster than calling cut for each
+		for i in $CORES; do
+			[ $((j++)) -ge $n ] && break
+		done
+		core=$i
+		set_affinity
+		((n++))
+	done
+}
+
+# now the actual useful bits of code
+
+# these next 2 lines would allow script to auto-determine interfaces
+#[ -z "$IFACES" ] && IFACES=$(ls /sys/class/net)
+#[ -z "$IFACES" ] && echo "Error: No interfaces up" && exit 1
+
+# echo IFACES is $IFACES
+
+CORES=$(</sys/devices/system/cpu/online)
+[ "$CORES" ] || CORES=$(grep ^proc /proc/cpuinfo | cut -f2 -d:)
+
+# Core list for each node from sysfs
+node_dir=/sys/devices/system/node
+for i in $(ls -d $node_dir/node*); do
+	i=${i/*node/}
+	corelist[$i]=$(<$node_dir/node${i}/cpulist)
+done
+
+for IFACE in $IFACES; do
+	# echo $IFACE being modified
+
+	dev_dir=/sys/class/net/$IFACE/device
+	[ -e $dev_dir/numa_node ] && node=$(<$dev_dir/numa_node)
+	[ "$node" ] && [ "$node" -gt 0 ] || node=0
+
+	case "$AFF" in
+	local)
+		CORES=${corelist[$node]}
+	;;
+	remote)
+		[ "$rnode" ] || { [ $node -eq 0 ] && rnode=1 || rnode=0; }
+		CORES=${corelist[$rnode]}
+	;;
+	one)
+		[ -n "$cnt" ] || cnt=0
+		CORES=$cnt
+	;;
+	all)
+		CORES=$CORES
+	;;
+	custom)
+		echo -n "Input cores for $IFACE (ex. 0-7,15-23): "
+		read CORES
+	;;
+	[0-9]*)
+		CORES=$AFF
+	;;
+	*)
+		usage
+		exit 1
+	;;
+	esac
+
+	# call the worker function
+	setaff
+done
+
+# check for irqbalance running
+IRQBALANCE_ON=`ps ax | grep -v grep | grep -q irqbalance; echo $?`
+if [ "$IRQBALANCE_ON" == "0" ] ; then
+	echo " WARNING: irqbalance is running and will"
+	echo "          likely override this script's affinitization."
+	echo "          Please stop the irqbalance service and/or execute"
+	echo "          'killall irqbalance'"
+fi
+

--- a/lte/gateway/deploy/roles/magma/tasks/main.yml
+++ b/lte/gateway/deploy/roles/magma/tasks/main.yml
@@ -76,6 +76,10 @@
   copy: src=99-magma.conf dest=/etc/sysctl.d/99-magma.conf
   when: full_provision
 
+- name: Copy set_irq_affinity
+  copy: src=set_irq_affinity dest=/usr/local/bin/set_irq_affinity mode=751
+  when: full_provision
+
 - name: Add the sysctl config from the step before
   become: yes
   command: 'sysctl -p /etc/sysctl.d/99-magma.conf'
@@ -386,6 +390,7 @@
   when: ansible_distribution == "Ubuntu"
 
 - name: Bring up ovs bridge
+  ignore_errors: yes
   shell: ifup -i /etc/network/interfaces.d/gtp {{ item }}
   with_items:
     - gtp_br0

--- a/lte/gateway/python/magma/pipelined/datapath_setup.py
+++ b/lte/gateway/python/magma/pipelined/datapath_setup.py
@@ -1,0 +1,89 @@
+"""
+Copyright 2021 The Magma Authors.
+
+This source code is licensed under the BSD-style license found in the
+LICENSE file in the root directory of this source tree.
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+import subprocess
+import os
+import logging
+
+irq_utility = '/usr/local/bin/set_irq_affinity'
+ethtool_utility = '/usr/sbin/ethtool'
+
+'''
+Following function sets various tuning parameters related
+interface queue.
+1. queue size
+2. queue CPU assignment
+'''
+
+
+def tune_datapath(config_dict):
+    # TODO move this to mconfig
+    if 'dp_irq' not in config_dict:
+        logging.info("DP Tunning not enabled.")
+        return
+
+    if not os.path.isfile(irq_utility) or \
+            not os.access(irq_utility, os.X_OK):
+        logging.info("missing set_irq_affinity %s", os.path.isfile(irq_utility))
+        logging.info("missing set_irq_affinity %s", os.access(irq_utility, os.X_OK))
+
+        return
+
+    tune_dp_irqs = config_dict['dp_irq']
+    logging.info("set tuning params: %s", tune_dp_irqs)
+
+    # stop irq-balance
+    stop_irq_balance = ['service', 'irqbalance', 'stop']
+    logging.debug("cmd: %s", stop_irq_balance)
+    try:
+        subprocess.check_call(stop_irq_balance)
+    except subprocess.CalledProcessError as ex:
+        logging.debug('%s failed with: %s', stop_irq_balance, ex)
+
+    # set_irq_affinity -X 1-2 eth1
+    s1_interface = config_dict['enodeb_iface']
+    s1_cpu = tune_dp_irqs['S1_cpu']
+    set_s1_cpu_command = [irq_utility, '-X', s1_cpu, s1_interface]
+    logging.debug("cmd: %s", set_s1_cpu_command)
+    try:
+        subprocess.check_call(set_s1_cpu_command)
+    except subprocess.CalledProcessError as ex:
+        logging.debug('%s failed with: %s', set_s1_cpu_command, ex)
+
+    sgi_interface = config_dict['nat_iface']
+    sgi_cpu = tune_dp_irqs['SGi_cpu']
+    set_sgi_cpu_command = [irq_utility, '-X', sgi_cpu, sgi_interface]
+    logging.debug("cmd: %s", set_sgi_cpu_command)
+    try:
+        subprocess.check_call(set_sgi_cpu_command)
+    except subprocess.CalledProcessError as ex:
+        logging.debug('%s failed with: %s', set_sgi_cpu_command, ex)
+
+    # ethtool -G eth1 rx 1024 tx 1024
+    s1_queue_size = tune_dp_irqs['S1_queue_size']
+    set_s1_rx_sz = [ethtool_utility, '-G', s1_interface,
+                    'rx', str(s1_queue_size), 'tx', str(s1_queue_size)]
+    logging.debug("cmd: %s", set_s1_rx_sz)
+    try:
+        subprocess.check_call(set_s1_rx_sz)
+    except subprocess.CalledProcessError as ex:
+        logging.debug('%s failed with: %s', set_s1_rx_sz, ex)
+
+    sgi_queue_size = tune_dp_irqs['SGi_queue_size']
+    set_sgi_rx_sz = [ethtool_utility, '-G', s1_interface,
+                     'rx', str(sgi_queue_size), 'tx', str(sgi_queue_size)]
+    logging.debug("cmd: %s", set_sgi_rx_sz)
+    try:
+        subprocess.check_call(set_sgi_rx_sz)
+    except subprocess.CalledProcessError as ex:
+        logging.debug('%s failed with: %s', set_sgi_rx_sz, ex)
+

--- a/lte/gateway/python/magma/pipelined/main.py
+++ b/lte/gateway/python/magma/pipelined/main.py
@@ -41,6 +41,7 @@ from ryu import cfg
 from ryu.base.app_manager import AppManager
 from ryu.ofproto.ofproto_v1_4 import OFPP_LOCAL
 from scapy.arch import get_if_hwaddr
+from magma.pipelined.datapath_setup import tune_datapath
 
 
 def main():
@@ -120,6 +121,9 @@ def main():
         he_enabled_flag = service.mconfig.he_config.enable_header_enrichment
     he_enabled = service.config.get('he_enabled', he_enabled_flag)
     service.config['he_enabled'] = he_enabled
+
+    # tune datapath according to config
+    tune_datapath(service.config)
 
     # monitoring related configuration
     mtr_interface = service.config.get('mtr_interface', None)

--- a/lte/gateway/release/build-magma.sh
+++ b/lte/gateway/release/build-magma.sh
@@ -418,6 +418,7 @@ ${ANSIBLE_FILES}/nx_actions_3.5.py=/usr/local/lib/python3.5/dist-packages/ryu/of
 ${ANSIBLE_FILES}/nx_actions_3.5.py=/usr/local/lib/python3.8/dist-packages/ryu/ofproto/nx_actions.py \
 ${MAGMA_ROOT}/lte/gateway/release/stretch_snapshot=/usr/local/share/magma/ \
 ${MAGMA_ROOT}/orc8r/tools/ansible/roles/fluent_bit/files/60-fluent-bit.conf=/etc/rsyslog.d/60-fluent-bit.conf \
+${ANSIBLE_FILES}/set_irq_affinity=/usr/local/bin/ \
 ${PY_PROTOS}=${PY_DEST} \
 $(glob_files "${PY_TMP_BUILD}/${PY_TMP_BUILD_SUFFIX}/${PKGNAME}*" ${PY_DEST}) \
 $(glob_files "${PY_TMP_BUILD}/${PY_TMP_BUILD_SUFFIX}/*.egg-info" ${PY_DEST}) \


### PR DESCRIPTION
Add IRQ CPU affinity configuration for AGW.
This patch sets default configuration that restricts
datapath processing on two core. This would reduce max
packet per second performance of AGW but it improves
control plane responsiveness

Signed-off-by: Pravin B Shelar <pbshelar@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->

## Test Plan
Validate on lab AGW and vagrant VM.

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
