### PR TITLE
remove msisdn label from usage metrics in sessiond

### DIFF
--- a/lte/gateway/c/core/oai/tasks/nas/emm/SecurityModeControl.c
+++ b/lte/gateway/c/core/oai/tasks/nas/emm/SecurityModeControl.c
@@ -362,11 +362,12 @@ int emm_proc_security_mode_control(
     // smc_proc->imeisv_request = (IS_EMM_CTXT_PRESENT_IMEISV(emm_ctx)) ?
     // false:true;
 
-    if IS_EMM_CTXT_PRESENT_UE_ADDITIONAL_SECURITY_CAPABILITY (emm_ctx) {
-      smc_proc->replayed_ue_add_sec_cap_present = true;
-      smc_proc->_5g_ea = emm_ctx->ue_additional_security_capability._5g_ea;
-      smc_proc->_5g_ia = emm_ctx->ue_additional_security_capability._5g_ia;
-    }
+    if
+      IS_EMM_CTXT_PRESENT_UE_ADDITIONAL_SECURITY_CAPABILITY(emm_ctx) {
+        smc_proc->replayed_ue_add_sec_cap_present = true;
+        smc_proc->_5g_ea = emm_ctx->ue_additional_security_capability._5g_ea;
+        smc_proc->_5g_ia = emm_ctx->ue_additional_security_capability._5g_ia;
+      }
 
     /*
      * Send security mode command message to the UE

--- a/lte/gateway/c/session_manager/SessionState.h
+++ b/lte/gateway/c/session_manager/SessionState.h
@@ -937,13 +937,22 @@ class SessionState {
       PolicyRule* rule_out);
 
   /**
-   * Increments data usage values for session
-   * @param usage_label either UE_DROPPED_LABEL / UE_USED_LABEL
+   * Set data usage values for session
+   * @param gauge_name
    * @param bytes_tx
    * @param bytes_rx
    */
-  void update_data_metrics(
-      const char* counter_name, uint64_t bytes_tx, uint64_t bytes_rx);
+  void set_data_metrics(
+      const char* gauge_name, uint64_t bytes_tx, uint64_t bytes_rx) const;
+
+  /**
+   * Increment data usage values for session
+   * @param counter_name
+   * @param delta_tx
+   * @param delta_rx
+   */
+  void increment_data_metrics(
+      const char* counter_name, uint64_t delta_tx, uint64_t delta_rx) const;
 
   /**
    * Computes delta from previous rule report

--- a/orc8r/gateway/c/common/service303/MetricsHelpers.cpp
+++ b/orc8r/gateway/c/common/service303/MetricsHelpers.cpp
@@ -33,6 +33,13 @@ void increment_counter(
   va_end(ap);
 }
 
+void remove_gauge(const char* name, size_t n_labels, ...) {
+  va_list ap;
+  va_start(ap, n_labels);
+  MetricsSingleton::Instance().RemoveGauge(name, n_labels, ap);
+  va_end(ap);
+}
+
 void increment_gauge(const char* name, double increment, size_t n_labels, ...) {
   va_list ap;
   va_start(ap, n_labels);

--- a/orc8r/gateway/c/common/service303/MetricsSingleton.cpp
+++ b/orc8r/gateway/c/common/service303/MetricsSingleton.cpp
@@ -69,6 +69,13 @@ void MetricsSingleton::IncrementCounter(
   counters_.Get(name, labels).Increment(increment);
 }
 
+void MetricsSingleton::RemoveGauge(
+    const char* name, size_t label_count, va_list& args) {
+  std::map<std::string, std::string> labels;
+  args_to_map(labels, label_count, args);
+  gauges_.Remove(name, labels);
+}
+
 void MetricsSingleton::IncrementGauge(
     const char* name, double increment, size_t label_count, va_list& args) {
   std::map<std::string, std::string> labels;

--- a/orc8r/gateway/c/common/service303/includes/MetricsHelpers.h
+++ b/orc8r/gateway/c/common/service303/includes/MetricsHelpers.h
@@ -37,6 +37,14 @@ void increment_counter(
     const char* name, double increment, size_t n_labels, ...);
 
 /**
+ * Remove the gauge metric that matches name+labels given
+ * @param name
+ * @param n_labels number of labels
+ * @param ... label args (name, value)
+ */
+void remove_gauge(const char* name, size_t n_labels, ...);
+
+/**
  * Increments value for Gauge metric
  * @param name
  * @param increment value to increment

--- a/orc8r/gateway/c/common/service303/includes/MetricsSingleton.h
+++ b/orc8r/gateway/c/common/service303/includes/MetricsSingleton.h
@@ -79,6 +79,7 @@ class MetricsSingleton {
   void RemoveCounter(const char* name, size_t label_count, va_list& args);
   void IncrementCounter(
       const char* name, double increment, size_t label_count, va_list& args);
+  void RemoveGauge(const char* name, size_t label_count, va_list& args);
   void IncrementGauge(
       const char* name, double increment, size_t label_count, va_list& args);
   void DecrementGauge(


### PR DESCRIPTION
Signed-off-by: Marie Bremner <marwhal@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary
3 things mostly

1. remove msisdn from counter=`ue_reported_usage` and gauge=`ue_dropped_usage`
2. address minor regression that changed `ue_reported_usage` to a gauge from this morning
3. add a remove gauge function to clear metrics on session termination

## Test Plan
make precommit_sm
manually verify stats are removed on session termination
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
