### PR TITLE
AGW: add script to upgrade OVS kmod.

### DIFF
--- a/lte/gateway/deploy/roles/magma/files/ovs-kmod-upgrade.sh
+++ b/lte/gateway/deploy/roles/magma/files/ovs-kmod-upgrade.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+# Copyright 2021 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+echo "This upgrade would result in datapath level downtime for few minutes!"
+while true; do
+    read -p "Do you want to proceed with upgrade ?(y/n)" yn
+    case $yn in
+        [Yy]* ) break;;
+        [Nn]* ) exit;;
+        * ) echo "Please answer yes or no.";;
+    esac
+done
+
+apt update
+apt install -y  openvswitch-datapath-dkms libopenvswitch openvswitch-common openvswitch-switch python3-openvswitch
+
+service magma@* stop
+sleep 5
+ifdown gtp_br0
+ifdown uplink_br0
+sleep 5
+/etc/init.d/openvswitch-switch  force-reload-kmod
+sleep 5
+ifup uplink_br0
+ifup gtp_br0
+sleep 5
+service magma@magmad start
+
+kernel_ver=$(cat /sys/module/openvswitch/srcversion)
+mod_ver=$(modinfo /lib/modules/"$(uname -r)"/updates/dkms/openvswitch.ko |grep srcversion|awk '{print $2}')
+
+if [[ "$kernel_ver" == "$mod_ver" ]]; then
+        echo "update successful"
+else
+        echo "update failed"
+fi
+
+echo "To cleanup control plane state run: config_stateless_agw.py flushall_redis"

--- a/lte/gateway/release/build-magma.sh
+++ b/lte/gateway/release/build-magma.sh
@@ -419,6 +419,7 @@ ${ANSIBLE_FILES}/nx_actions_3.5.py=/usr/local/lib/python3.8/dist-packages/ryu/of
 ${MAGMA_ROOT}/lte/gateway/release/stretch_snapshot=/usr/local/share/magma/ \
 ${MAGMA_ROOT}/orc8r/tools/ansible/roles/fluent_bit/files/60-fluent-bit.conf=/etc/rsyslog.d/60-fluent-bit.conf \
 ${ANSIBLE_FILES}/set_irq_affinity=/usr/local/bin/ \
+${ANSIBLE_FILES}/ovs-kmod-upgrade.sh=/usr/local/bin/ \
 ${PY_PROTOS}=${PY_DEST} \
 $(glob_files "${PY_TMP_BUILD}/${PY_TMP_BUILD_SUFFIX}/${PKGNAME}*" ${PY_DEST}) \
 $(glob_files "${PY_TMP_BUILD}/${PY_TMP_BUILD_SUFFIX}/*.egg-info" ${PY_DEST}) \


### PR DESCRIPTION
This would allow operator to upgrade OVS kmod without restarting AGW.

Signed-off-by: Pravin B Shelar <pbshelar@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->

## Test Plan
validated on bare metal AGW.

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
