### PR TITLE
orc8r: Improve AGW subscriber sync scalability

### DIFF
--- a/lte/gateway/configs/subscriberdb.yml
+++ b/lte/gateway/configs/subscriberdb.yml
@@ -17,10 +17,10 @@
 print_grpc_payload: False
 
 # Size of subscriber pages returned from cloud
-subscriber_page_size: 3000
+subscriber_page_size: 5000
 
 # Interval in seconds between gateway and cloud sync
-subscriberdb_sync_interval: 180
+subscriberdb_sync_interval: 300  # 5m
 
 # Host address of the Diameter/S6A MME server
 host_address: 0.0.0.0 # Bind to all interfaces

--- a/lte/gateway/python/magma/subscriberdb/main.py
+++ b/lte/gateway/python/magma/subscriberdb/main.py
@@ -11,8 +11,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 import asyncio
+import hashlib
 import logging
 
+import snowflake
 from lte.protos.mconfig import mconfigs_pb2
 from lte.protos.subscriberdb_pb2_grpc import SubscriberDBCloudStub
 from magma.common.grpc_client_manager import GRPCClientManager
@@ -64,7 +66,9 @@ def main():
             service_stub=SubscriberDBCloudStub,
             max_client_reuse=60,
         )
-        sync_interval = service.config.get('subscriberdb_sync_interval')
+        sync_interval = _randomize_sync_interval(
+            service.config.get('subscriberdb_sync_interval'),
+        )
         subscriber_page_size = service.config.get('subscriber_page_size')
         subscriberdb_cloud_client = SubscriberDBCloudClient(
             service.loop,
@@ -134,6 +138,19 @@ def _get_s6a_manager(service, processor):
         service.config['mme_host_address'],
         service.loop,
     )
+
+
+def _randomize_sync_interval(interval: int) -> int:
+    """_randomize_sync_interval increases sync interval by random amount.
+
+    Increased sync interval ameliorates the thundering herd effect at Orc8r.
+    "Random" increase is deterministic based on the gateway's HWID.
+    """
+    h = hashlib.md5()
+    h.update(bytes(snowflake.snowflake(), 'utf8'))  # digest of hwid
+    multiplier = (hash(h.hexdigest()) % 100) / 100  # to interval [0, 1]
+    delta = multiplier * (interval / 5)  # up to 1/5 of target interval
+    return int(interval + delta)
 
 
 if __name__ == "__main__":

--- a/lte/gateway/python/magma/subscriberdb/metrics.py
+++ b/lte/gateway/python/magma/subscriberdb/metrics.py
@@ -48,7 +48,7 @@ SUBSCRIBER_SYNC_LATENCY = Histogram(
     'subscriber_sync_latency_ms',
     'Latency syncing subscribers from cloud'
     'in milliseconds',
-    buckets=[50, 100, 200, 500, 1000, 2000, 10000],
+    buckets=[50, 100, 200, 500, 1000, 5000, 10000, 30000, 60000],
 )
 
 SUBSCRIBER_SYNC_SUCCESS_TOTAL = Counter(


### PR DESCRIPTION
## Summary

Currently, 20k subscribers and 50 gateways are *just barely* manageable. This change resolves some immediate issues experienced, in preparation for testing 100/200 gateways.

Additional items we will tweak to try to reach 200 gateways as-is:

- 10m sync interval for all gateways
- Better DB: beefier instance, upgrade to latest Postgres version

If we can hit 200 gateways as-is, I have confidence the subscriber digest work will land us near 500 gateways

## Test Plan

## Additional Information

- [ ] This change is backwards-breaking