### PR TITLE
AGW: OVS: add dmks install to upgrade script.

### DIFF
--- a/lte/gateway/deploy/roles/magma/files/ovs-kmod-upgrade.sh
+++ b/lte/gateway/deploy/roles/magma/files/ovs-kmod-upgrade.sh
@@ -23,6 +23,7 @@ done
 apt update
 apt install -y  openvswitch-datapath-dkms libopenvswitch openvswitch-common openvswitch-switch python3-openvswitch
 
+dkms autoinstall
 service magma@* stop
 sleep 5
 ifdown gtp_br0


### PR DESCRIPTION
Incase AGW reboots in newer kernel the dkms install can take care
of OVS module installation for the kernel.

Signed-off-by: Pravin B Shelar <pbshelar@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->

## Test Plan
validated it on lab setup.

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
