### PR TITLE
Fix dependency on datastore and policydb

### DIFF
--- a/lte/gateway/c/session_manager/CMakeLists.txt
+++ b/lte/gateway/c/session_manager/CMakeLists.txt
@@ -59,8 +59,6 @@ include_directories(${MAGMA_LIB_DIR}/service303)
 include_directories(${MAGMA_LIB_DIR}/service_registry)
 include_directories(${MAGMA_LIB_DIR}/async_grpc)
 include_directories(${MAGMA_LIB_DIR}/config)
-include_directories(${MAGMA_LIB_DIR}/datastore)
-include_directories(${MAGMA_LIB_DIR}/policydb)
 include_directories(${MAGMA_LIB_DIR}/eventd)
 
 # TODO: Temp workaround until packages are imported by these cmakefile
@@ -112,8 +110,6 @@ link_directories(
   ${MAGMA_LIB_DIR}/async_grpc
   ${MAGMA_LIB_DIR}/config
   ${MAGMA_LIB_DIR}/service303
-  ${MAGMA_LIB_DIR}/datastore
-  ${MAGMA_LIB_DIR}/policydb
   ${MAGMA_LIB_DIR}/eventd
   ${MAGMA_LIB_DIR}/service_registry)
 


### PR DESCRIPTION
## Summary

Fix dependency on datastore and policydb

Possible fix for #7518

When moving the policydb and datastore directories under common
I missed updating the dependencies on the top level CMakeLists.txt
Change fixes this, possibly addressing the cyclic dependency error

Unable to repro the said issue locally, but this change is
correct in itself.

Signed-off-by: Amar Padmanabhan <amar@freedomfi.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->



<!-- Enumerate changes you made and why you made them -->

## Test Plan

make run