### PR TITLE
Remove proto dependencies from datastore

### DIFF
--- a/lte/gateway/c/session_manager/datastore/CMakeLists.txt
+++ b/lte/gateway/c/session_manager/datastore/CMakeLists.txt
@@ -22,8 +22,8 @@ list(APPEND PROTO_SRCS "")
 list(APPEND PROTO_HDRS "")
 
 set(ASYNC_ORC8R_CPP_PROTOS common redis)
-set(ASYNC_LTE_CPP_PROTOS session_manager policydb mobilityd apn subscriberdb)
-set(ASYNC_LTE_GRPC_PROTOS session_manager)
+set(ASYNC_LTE_CPP_PROTOS "")
+set(ASYNC_LTE_GRPC_PROTOS "")
 set(ASYNC_ORC8R_GRPC_PROTOS "")
 
 generate_all_protos("${ASYNC_LTE_CPP_PROTOS}" "${ASYNC_ORC8R_CPP_PROTOS}"


### PR DESCRIPTION
## Summary

Remove service proto dependencies from datastore and see if it fixes tests
These dependencies are not accurate anyway.

Signed-off-by: Amar Padmanabhan <amar@freedomfi.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->



<!-- Enumerate changes you made and why you made them -->

## Test Plan

make run
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
