### PR TITLE
[lte][agw] Fix segfault in issue 7128

### DIFF
--- a/lte/gateway/c/core/oai/tasks/mme_app/mme_app_ip_imsi.cpp
+++ b/lte/gateway/c/core/oai/tasks/mme_app/mme_app_ip_imsi.cpp
@@ -77,11 +77,11 @@ int mme_app_get_imsi_from_ipv4(uint32_t ipv4_addr, imsi64_t** imsi_list) {
   } else {
     uint8_t idx = 0;
     num_imsis   = itr->second.size();
-    *imsi_list  = (imsi64_t*) calloc(num_imsis, sizeof(imsi64_t));
+    (*imsi_list)  = (imsi64_t*) calloc(num_imsis, sizeof(imsi64_t));
 
     for (auto vect_itr = itr->second.begin(); vect_itr != itr->second.end();
          vect_itr++) {
-      *imsi_list[idx++] = *vect_itr;
+      (*imsi_list)[idx++] = *vect_itr;
       OAILOG_DEBUG_UE(
           LOG_MME_APP, *vect_itr, " Found imsi for ip:%x \n", ipv4_addr);
     }


### PR DESCRIPTION
Signed-off-by: Ulas Kozat <kozat@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->
Issue #7128 provides the context. (*imsi_list) is the dynamic array that will hold the list of imsi64's but the assignment on line 84 is not writing to this array but to an arbitrary location as `[]` has precedence over `*`.

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->
Sanity tests.

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
