### PR TITLE
[AGW][PACKER] Buff up base image for Ubuntu 

### DIFF
--- a/orc8r/tools/packer/magma-focal-virtualbox.json
+++ b/orc8r/tools/packer/magma-focal-virtualbox.json
@@ -46,7 +46,7 @@
           "modifyvm",
           "{{.Name}}",
           "--memory",
-          "2048"
+          "8192"
         ],
         [
           "modifyvm",
@@ -71,7 +71,7 @@
           "modifyvm",
           "{{.Name}}",
           "--cpus",
-          "2"
+          "4"
         ]
       ],
       "virtualbox_version_file": ".vbox_version",


### PR DESCRIPTION
Signed-off-by: Timothée Dzik <timdzik@fb.com>

[AGW][PACKER] Buff up base image for Ubuntu 

## Summary

[AGW][PACKER] Buff up base image for Ubuntu 
from 2 CPU to 4 
from 2048 to 8192 mem

## Test Plan
cd orc8r/tools/packer && packer build -force magma-focal-virtualbox.json