### PR TITLE
Fix SessionManager ninja cyclic dependency

### DIFF
--- a/lte/gateway/c/session_manager/CMakeLists.txt
+++ b/lte/gateway/c/session_manager/CMakeLists.txt
@@ -79,11 +79,11 @@ create_proto_dir("feg/gateway/services/aaa" CWF_CPP_OUT_DIR)
 list(APPEND PROTO_SRCS "")
 list(APPEND PROTO_HDRS "")
 
-set(SMGR_ORC8R_CPP_PROTOS common directoryd)
+set(SMGR_ORC8R_CPP_PROTOS directoryd)
 generate_cpp_protos("${SMGR_ORC8R_CPP_PROTOS}" "${PROTO_SRCS}"
   "${PROTO_HDRS}" ${ORC8R_PROTO_DIR} ${ORC8R_CPP_OUT_DIR})
 
-set(SMGR_LTE_CPP_PROTOS session_manager apn subscriberdb policydb
+set(SMGR_LTE_CPP_PROTOS session_manager
   pipelined spgw_service mconfig/mconfigs)
 generate_cpp_protos("${SMGR_LTE_CPP_PROTOS}" "${PROTO_SRCS}"
   "${PROTO_HDRS}" ${LTE_PROTO_DIR} ${LTE_CPP_OUT_DIR})
@@ -104,7 +104,7 @@ set(SMGR_CWF_GRPC_PROTOS accounting)
 generate_grpc_protos("${SMGR_CWF_GRPC_PROTOS}" "${PROTO_SRCS}"
   "${PROTO_HDRS}" ${CWF_PROTO_DIR} ${CWF_CPP_OUT_DIR})
 
-message("Proto_srcs are ${PROTO_SRCS}")
+message("SessionManager proto_srcs are ${PROTO_SRCS}")
 
 link_directories(
   ${MAGMA_LIB_DIR}/async_grpc

--- a/lte/gateway/c/session_manager/datastore/CMakeLists.txt
+++ b/lte/gateway/c/session_manager/datastore/CMakeLists.txt
@@ -21,16 +21,16 @@ include($ENV{MAGMA_ROOT}/orc8r/gateway/c/common/CMakeProtoMacros.txt)
 list(APPEND PROTO_SRCS "")
 list(APPEND PROTO_HDRS "")
 
-set(ASYNC_ORC8R_CPP_PROTOS common redis)
-set(ASYNC_LTE_CPP_PROTOS "")
-set(ASYNC_LTE_GRPC_PROTOS "")
-set(ASYNC_ORC8R_GRPC_PROTOS "")
+set(DS_ORC8R_CPP_PROTOS common redis)
+set(DS_LTE_CPP_PROTOS "")
+set(DS_LTE_GRPC_PROTOS "")
+set(DS_ORC8R_GRPC_PROTOS "")
 
-generate_all_protos("${ASYNC_LTE_CPP_PROTOS}" "${ASYNC_ORC8R_CPP_PROTOS}"
-    "${ASYNC_LTE_GRPC_PROTOS}"
-    "${ASYNC_ORC8R_GRPC_PROTOS}" "${PROTO_SRCS}" "${PROTO_HDRS}")
+generate_all_protos("${DS_LTE_CPP_PROTOS}" "${DS_ORC8R_CPP_PROTOS}"
+    "${DS_LTE_GRPC_PROTOS}"
+    "${DS_ORC8R_GRPC_PROTOS}" "${PROTO_SRCS}" "${PROTO_HDRS}")
 
-message("Async Proto_srcs are ${PROTO_SRCS}")
+message("Datastore Proto_srcs are ${PROTO_SRCS}")
 
 add_library(DATASTORE
     ObjectMap.h

--- a/lte/gateway/c/session_manager/policydb/CMakeLists.txt
+++ b/lte/gateway/c/session_manager/policydb/CMakeLists.txt
@@ -28,11 +28,11 @@ set(POLICYDB_ORC8R_CPP_PROTOS common)
 generate_cpp_protos("${POLICYDB_ORC8R_CPP_PROTOS}" "${PROTO_SRCS}"
     "${PROTO_HDRS}" ${ORC8R_PROTO_DIR} ${ORC8R_CPP_OUT_DIR})
 
-set(POLICYDB_LTE_CPP_PROTOS policydb)
+set(POLICYDB_LTE_CPP_PROTOS policydb apn mobilityd subscriberdb)
 generate_cpp_protos("${POLICYDB_LTE_CPP_PROTOS}" "${PROTO_SRCS}"
     "${PROTO_HDRS}" ${LTE_PROTO_DIR} ${LTE_CPP_OUT_DIR})
 
-message("Proto_srcs are ${PROTO_SRCS}")
+message("Policydb proto_srcs are ${PROTO_SRCS}")
 
 add_library(POLICYDB
     PolicyLoader.cpp


### PR DESCRIPTION
Ninja builds generate a dependency graph and when the build is rerun
as part of make coverage it fails due to a cyclic dependency on common.pb

lib datastore->depends->common.pb due to redis_client
session_manager->depends->lib-datastore and thus common.pb
session_manager compiles common.pb due to service303 and friends.

Fix this by removing the protobuf dependency at session_manger level
and instead relying on datastore to pull in the dependency.
Same logic applies for policydb as well.
A cleaner fix would be through a super build where common deps are
imported as a package.

Signed-off-by: Amar Padmanabhan <amar@freedomfi.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->

## Test Plan

fab lte_integ_test in progress

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
