### PR TITLE
perf(pipeilined): Remove rule map entry in rule Deactivate call

### DIFF
--- a/lte/gateway/python/magma/pipelined/rpc_servicer.py
+++ b/lte/gateway/python/magma/pipelined/rpc_servicer.py
@@ -252,7 +252,7 @@ class PipelinedRpcServicer(pipelined_pb2_grpc.PipelinedServicer):
                 .remove(imsi, ip_address, rule_id, version)
         if not request.policies:
             self._service_manager.session_rule_version_mapper\
-                .update_all_ue_versions(request.sid.id, ip_address)
+                .remove_all_ue_versions(request.sid.id, ip_address)
             return
 
         for policy in request.policies:

--- a/lte/gateway/python/magma/pipelined/tests/test_rule_mappers.py
+++ b/lte/gateway/python/magma/pipelined/tests/test_rule_mappers.py
@@ -56,17 +56,17 @@ class RuleMappersTest(unittest.TestCase):
             2)
 
         # Test updating version for all rules of a subscriber
-        self._session_rule_version_mapper.update_all_ue_versions(imsi,
+        self._session_rule_version_mapper.remove_all_ue_versions(imsi,
             convert_ipv4_str_to_ip_proto(ip_addr))
 
         self.assertEqual(
             self._session_rule_version_mapper.get_version(
                 imsi, convert_ipv4_str_to_ip_proto(ip_addr), rule_ids[0]),
-            3)
+            -1)
         self.assertEqual(
             self._session_rule_version_mapper.get_version(
                 imsi, convert_ipv4_str_to_ip_proto(ip_addr), rule_ids[1]),
-            2)
+            -1)
 
     def test_session_rule_version_mapper_cwf(self):
         rule_ids = ['rule1', 'rule2']
@@ -93,16 +93,16 @@ class RuleMappersTest(unittest.TestCase):
             2)
 
         # Test updating version for all rules of a subscriber
-        self._session_rule_version_mapper.update_all_ue_versions(imsi, None)
+        self._session_rule_version_mapper.remove_all_ue_versions(imsi, None)
 
         self.assertEqual(
             self._session_rule_version_mapper.get_version(
                 imsi, None, rule_ids[0]),
-            3)
+            -1)
         self.assertEqual(
             self._session_rule_version_mapper.get_version(
                 imsi, None, rule_ids[1]),
-            2)
+            -1)
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
pipelined updates version of the rule on Deactivate call. This could
result in lower performance is case of higher number of UEs.
Deleting the entry improves performance and has same result.

Signed-off-by: Pravin B Shelar <pbshelar@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->

## Test Plan
`make test`
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
