### PR TITLE
[lte][agw] Change the utility function location for service area verification

### DIFF
--- a/lte/gateway/c/core/oai/common/common_types.c
+++ b/lte/gateway/c/core/oai/common/common_types.c
@@ -203,22 +203,3 @@ void bstring_to_paa(const bstring bstr, paa_t* paa) {
     }
   }
 }
-
-int verify_service_area_restriction(
-    tac_t tac, const regional_subscription_t* reg_sub, uint8_t num_reg_sub) {
-  OAILOG_FUNC_IN(LOG_MME_APP);
-  tac_list_per_sac_t* tac_list = NULL;
-  for (uint8_t itr = 0; itr < num_reg_sub; itr++) {
-    hashtable_rc_t htbl = obj_hashtable_get(
-        mme_config.sac_to_tacs_map.sac_to_tacs_map_htbl, reg_sub[itr].zone_code,
-        ZONE_CODE_LEN, (void**) &tac_list);
-    if (htbl == HASH_TABLE_OK) {
-      for (uint8_t idx = 0; idx < tac_list->num_tac_entries; idx++) {
-        if (tac_list->tacs[idx] == tac) {
-          OAILOG_FUNC_RETURN(LOG_COMMON, RETURNok);
-        }
-      }
-    }
-  }
-  OAILOG_FUNC_RETURN(LOG_COMMON, RETURNerror);
-}

--- a/lte/gateway/c/core/oai/common/common_types.h
+++ b/lte/gateway/c/core/oai/common/common_types.h
@@ -293,8 +293,6 @@ void get_fteid_ip_address(
 bstring ip_address_to_bstring(const ip_address_t* ip_address);
 void bstring_to_ip_address(bstring const bstr, ip_address_t* const ip_address);
 void bstring_to_paa(bstring bstr, paa_t* paa);
-int verify_service_area_restriction(
-    tac_t tac, const regional_subscription_t* reg_sub, uint8_t num_reg_sub);
 
 //-----------------
 typedef enum {

--- a/lte/gateway/c/core/oai/common/common_utility_funs.cpp
+++ b/lte/gateway/c/core/oai/common/common_utility_funs.cpp
@@ -57,3 +57,23 @@ extern "C" int match_fed_mode_map(const char* imsi, log_proto_t module) {
   OAILOG_FUNC_RETURN(
       module, magma::mconfig::ModeMapItem_FederatedMode_SPGW_SUBSCRIBER);
 }
+
+// Verify that tac is included in registered subscription areas
+extern "C" int verify_service_area_restriction(
+    tac_t tac, const regional_subscription_t* reg_sub, uint8_t num_reg_sub) {
+  OAILOG_FUNC_IN(LOG_MME_APP);
+  tac_list_per_sac_t* tac_list = NULL;
+  for (uint8_t itr = 0; itr < num_reg_sub; itr++) {
+    hashtable_rc_t htbl = obj_hashtable_get(
+        mme_config.sac_to_tacs_map.sac_to_tacs_map_htbl, reg_sub[itr].zone_code,
+        ZONE_CODE_LEN, (void**) &tac_list);
+    if (htbl == HASH_TABLE_OK) {
+      for (uint8_t idx = 0; idx < tac_list->num_tac_entries; idx++) {
+        if (tac_list->tacs[idx] == tac) {
+          OAILOG_FUNC_RETURN(LOG_COMMON, RETURNok);
+        }
+      }
+    }
+  }
+  OAILOG_FUNC_RETURN(LOG_COMMON, RETURNerror);
+}

--- a/lte/gateway/c/core/oai/common/common_utility_funs.h
+++ b/lte/gateway/c/core/oai/common/common_utility_funs.h
@@ -10,6 +10,9 @@ extern "C" {
 #include "common_defs.h"
 
 int match_fed_mode_map(const char* imsi, log_proto_t module);
+int verify_service_area_restriction(
+    tac_t tac, const regional_subscription_t* reg_sub, uint8_t num_reg_sub);
+
 #ifdef __cplusplus
 }
 #endif

--- a/lte/gateway/c/core/oai/tasks/mme_app/mme_app_location.c
+++ b/lte/gateway/c/core/oai/tasks/mme_app/mme_app_location.c
@@ -35,6 +35,7 @@
 #include "conversions.h"
 #include "intertask_interface.h"
 #include "common_defs.h"
+#include "common_utility_funs.h"
 #include "mme_config.h"
 #include "mme_app_ue_context.h"
 #include "mme_app_defs.h"

--- a/lte/gateway/c/core/oai/tasks/nas/emm/TrackingAreaUpdate.c
+++ b/lte/gateway/c/core/oai/tasks/nas/emm/TrackingAreaUpdate.c
@@ -26,6 +26,7 @@
 #include "3gpp_requirements_24.301.h"
 #include "common_types.h"
 #include "common_defs.h"
+#include "common_utility_funs.h"
 #include "3gpp_24.008.h"
 #include "mme_app_ue_context.h"
 #include "emm_proc.h"


### PR DESCRIPTION
Signed-off-by: Ulas Kozat <kozat@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->
- The original choice of files to add helper function was breaking unit tests. I moved them to the utility function.
## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->
Run unit tests.
```
cd  /home/vagrant/build/c/core/oai && ctest --output-on-failure
Test project /home/vagrant/build/c/core/oai
    Start 1: test_mme_app_ue_context
1/8 Test #1: test_mme_app_ue_context ..........   Passed    0.17 sec
    Start 2: test_mme_app_emm_decode
2/8 Test #2: test_mme_app_emm_decode ..........   Passed    0.07 sec
    Start 3: test_openflow_controller
3/8 Test #3: test_openflow_controller .........   Passed    0.09 sec
    Start 4: test_imsi_encoder
4/8 Test #4: test_imsi_encoder ................   Passed    0.05 sec
    Start 5: test_gtp_app
5/8 Test #5: test_gtp_app .....................   Passed    0.13 sec
    Start 6: test_spgw_state_converter
6/8 Test #6: test_spgw_state_converter ........   Passed    0.07 sec
    Start 7: test_itti
7/8 Test #7: test_itti ........................   Passed    4.30 sec
    Start 8: test_pipelined_client
8/8 Test #8: test_pipelined_client ............   Passed    0.07 sec

100% tests passed, 0 tests failed out of 8
```

Build magma core.

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
