### PR TITLE
[orc8r] add service indicator to PolicyRules on swagger

### DIFF
--- a/feg/gateway/go.mod
+++ b/feg/gateway/go.mod
@@ -46,7 +46,6 @@ require (
 	google.golang.org/grpc v1.33.2
 	google.golang.org/protobuf v1.26.0
 	gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776 // indirect
-	gotest.tools/gotestsum v1.6.4 // indirect
 	layeh.com/radius v0.0.0-20200615152116-663b41c3bf86
 	magma/feg/cloud/go v0.0.0
 	magma/feg/cloud/go/protos v0.0.0

--- a/lte/cloud/go/services/policydb/obsidian/models/conversion.go
+++ b/lte/cloud/go/services/policydb/obsidian/models/conversion.go
@@ -178,6 +178,7 @@ func (m *PolicyRule) getConfig() *PolicyRuleConfig {
 		MonitoringKey:           m.MonitoringKey,
 		Priority:                m.Priority,
 		RatingGroup:             m.RatingGroup,
+		ServiceIdentifier:       m.ServiceIdentifier,
 		Redirect:                m.Redirect,
 		TrackingType:            m.TrackingType,
 		AppName:                 m.AppName,
@@ -200,6 +201,7 @@ func (m *PolicyRule) fillFromConfig(entConfig interface{}) *PolicyRule {
 	m.MonitoringKey = monKey
 	m.Priority = cfg.Priority
 	m.RatingGroup = cfg.RatingGroup
+	m.ServiceIdentifier = cfg.ServiceIdentifier
 	m.Redirect = cfg.Redirect
 	m.TrackingType = cfg.TrackingType
 	m.AppName = cfg.AppName
@@ -262,6 +264,7 @@ func (m *PolicyRuleConfig) ToProto(id string, qos *protos.FlowQos) *protos.Polic
 			protoMKey = []byte(m.MonitoringKey)
 		}
 	}
+
 	rule := &protos.PolicyRule{
 		Id:             id,
 		Priority:       swag.Uint32Value(m.Priority),
@@ -272,6 +275,9 @@ func (m *PolicyRuleConfig) ToProto(id string, qos *protos.FlowQos) *protos.Polic
 		AppServiceType: protos.PolicyRule_AppServiceType(protos.PolicyRule_AppServiceType_value[m.AppServiceType]),
 		HardTimeout:    0,
 		Qos:            qos,
+	}
+	if m.ServiceIdentifier != 0 {
+		rule.ServiceIdentifier = &protos.ServiceIdentifier{Value: m.ServiceIdentifier}
 	}
 	if m.Redirect != nil {
 		rule.Redirect = m.Redirect.ToProto()

--- a/lte/cloud/go/services/policydb/obsidian/models/policy_rule_config_swaggergen.go
+++ b/lte/cloud/go/services/policydb/obsidian/models/policy_rule_config_swaggergen.go
@@ -48,6 +48,9 @@ type PolicyRuleConfig struct {
 	// redirect
 	Redirect *RedirectInformation `json:"redirect,omitempty"`
 
+	// service identifier
+	ServiceIdentifier uint32 `json:"service_identifier,omitempty"`
+
 	// tracking type
 	// Enum: [ONLY_OCS ONLY_PCRF OCS_AND_PCRF NO_TRACKING]
 	TrackingType string `json:"tracking_type,omitempty"`

--- a/lte/cloud/go/services/policydb/obsidian/models/policy_rule_swaggergen.go
+++ b/lte/cloud/go/services/policydb/obsidian/models/policy_rule_swaggergen.go
@@ -58,6 +58,9 @@ type PolicyRule struct {
 	// redirect
 	Redirect *RedirectInformation `json:"redirect,omitempty"`
 
+	// service identifier
+	ServiceIdentifier uint32 `json:"service_identifier,omitempty"`
+
 	// tracking type
 	// Enum: [ONLY_OCS ONLY_PCRF OCS_AND_PCRF NO_TRACKING]
 	TrackingType string `json:"tracking_type,omitempty"`

--- a/lte/cloud/go/services/policydb/obsidian/models/swagger.v1.yml
+++ b/lte/cloud/go/services/policydb/obsidian/models/swagger.v1.yml
@@ -573,6 +573,9 @@ definitions:
         type: integer
         format: uint32
         default: 10
+      service_identifier:
+        type: integer
+        format: uint32
       rating_group:
         type: integer
         format: uint32
@@ -662,6 +665,9 @@ definitions:
         format: uint32
         default: 10
       rating_group:
+        type: integer
+        format: uint32
+      service_identifier:
         type: integer
         format: uint32
       monitoring_key:

--- a/orc8r/cloud/go/obsidian/swagger/v1/models/policy_rule.go
+++ b/orc8r/cloud/go/obsidian/swagger/v1/models/policy_rule.go
@@ -58,6 +58,9 @@ type PolicyRule struct {
 	// redirect
 	Redirect *RedirectInformation `json:"redirect,omitempty"`
 
+	// service identifier
+	ServiceIdentifier uint32 `json:"service_identifier,omitempty"`
+
 	// tracking type
 	// Enum: [ONLY_OCS ONLY_PCRF OCS_AND_PCRF NO_TRACKING]
 	TrackingType string `json:"tracking_type,omitempty"`

--- a/orc8r/cloud/go/obsidian/swagger/v1/models/policy_rule_config.go
+++ b/orc8r/cloud/go/obsidian/swagger/v1/models/policy_rule_config.go
@@ -48,6 +48,9 @@ type PolicyRuleConfig struct {
 	// redirect
 	Redirect *RedirectInformation `json:"redirect,omitempty"`
 
+	// service identifier
+	ServiceIdentifier uint32 `json:"service_identifier,omitempty"`
+
 	// tracking type
 	// Enum: [ONLY_OCS ONLY_PCRF OCS_AND_PCRF NO_TRACKING]
 	TrackingType string `json:"tracking_type,omitempty"`

--- a/orc8r/cloud/go/obsidian/swagger/v1/swagger.yml
+++ b/orc8r/cloud/go/obsidian/swagger/v1/swagger.yml
@@ -10657,6 +10657,9 @@ definitions:
         type: integer
       redirect:
         $ref: '#/definitions/redirect_information'
+      service_identifier:
+        format: uint32
+        type: integer
       tracking_type:
         enum:
         - ONLY_OCS
@@ -10726,6 +10729,9 @@ definitions:
         type: integer
       redirect:
         $ref: '#/definitions/redirect_information'
+      service_identifier:
+        format: uint32
+        type: integer
       tracking_type:
         enum:
         - ONLY_OCS


### PR DESCRIPTION
Signed-off-by: Oriol Batalla <obatalla@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary

Added `service_indication` to policies stored on policydb

## Test Plan

./build.py g
make precommit at or8cr
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
