### PR TITLE
[agw][cloudstrapper] Export AGW AMI to qcow2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1477,7 +1477,7 @@ jobs:
           name: Propagate names for AWS essential components
           command: |
             sed -i -e '/^secgroupDefault: /s/:.*$/: publish-amis-to-marketplace-secgroup/' $VARS_DIR/defaults.yaml
-            sed -i -e '/^bucketDefault: /s/:.*$/: publish-amis-to-marketplace-bucket/' $VARS_DIR/defaults.yaml
+            sed -i -e '/^bucketDefault: /s/:.*$/: publish-amis-to-marketplace-bucket2/' $VARS_DIR/defaults.yaml
             sed -i -e '/^stackEssentialsDefault: /s/:.*$/: publish-amis-to-marketplace-stack/' $VARS_DIR/defaults.yaml
             sed -i -e '/^keyBoot: /s/:.*$/: publish-amis-to-marketplace-keyboot/' $VARS_DIR/defaults.yaml
             sed -i -e '/^keyHost: /s/:.*$/: publish-amis-to-marketplace-keyhost/' $VARS_DIR/defaults.yaml
@@ -1496,6 +1496,7 @@ jobs:
             sed -i -e '/^buildUbuntuAmi: /s/:.*$/: ami-09e67e426f25ce0d7/' $VARS_DIR/build.yaml
       - run:
           name: Generate Cloudstrapper AMI
+          no_output_timeout: 30m
           command: |
             ansible-playbook $WORK_DIR/devops-provision.yaml -e "dirLocalInventory=$VARS_DIR"
             echo "Waiting one minute for the instance to boot up."
@@ -1513,12 +1514,20 @@ jobs:
             sed -i -e '/^awsAgwAmi: /s/:.*$/: ami-09e67e426f25ce0d7/' $VARS_DIR/cluster.yaml
       - run:
           name: Generate AGW AMI
+          no_output_timeout: 30m
           command: |
             ansible-playbook $WORK_DIR/agw-provision.yaml -e "idSite=DevOps" -e "idGw=publishAmisToMarketplaceAgw" -e "dirLocalInventory=$VARS_DIR" --tags infra,inventory  -e "agwDevops=1" --skip-tags createBridge,cleanupBridge,cleanupNet
             echo "Waiting one minute for the instance to boot up."
             sleep 60
             ansible-playbook $WORK_DIR/ami-configure.yaml -i "$VARS_DIR/common_instance_aws_ec2.yaml" -e "dirLocalInventory=$VARS_DIR" -e "aminode=tag_Name_publishAmisToMarketplaceAgw" -e "ansible_python_interpreter=/usr/bin/python3" -u ubuntu
             ansible-playbook $WORK_DIR/ami-init.yaml -e "dirLocalInventory=$VARS_DIR"
+      - run:
+          name: Export qcow2 image for fb aws account in s3
+          no_output_timeout: 30m
+          command: |
+            if [ "<<parameters.aws_account>>" = "FB" ]; then
+              ansible-playbook $WORK_DIR/devops-convert-to-qcow2.yaml -e "dirLocalInventory=$VARS_DIR" -e "agwAmiName=agw-ami-$VERSION"
+            fi
       - run:
           name: Clean AWS resources
           command: |

--- a/experimental/cloudstrapper/playbooks/devops-convert-to-qcow2.yaml
+++ b/experimental/cloudstrapper/playbooks/devops-convert-to-qcow2.yaml
@@ -1,0 +1,14 @@
+---
+
+- hosts: localhost
+  roles:
+    - convert-to-qcow2
+  environment:
+    AWS_ACCESS_KEY_ID: "{{ awsAccessKey }}"
+    AWS_SECRET_ACCESS_KEY: "{{ awsSecretKey }}"
+    AWS_DEFAULT_REGION: "{{ awsAgwRegion }}"
+  vars_files:
+    - roles/vars/defaults.yaml
+    - "{{ dirLocalInventory }}/secrets.yaml"
+    - roles/vars/cluster.yaml
+    - roles/vars/build.yaml

--- a/experimental/cloudstrapper/playbooks/roles/agw-infra/tasks/provision-instances.yaml
+++ b/experimental/cloudstrapper/playbooks/roles/agw-infra/tasks/provision-instances.yaml
@@ -64,6 +64,15 @@
       paramAgwInstanceType: "t2.medium"
   when: agwDevops is undefined
 
+- name: Get EBS encryption default
+  command: aws ec2 get-ebs-encryption-by-default --query 'EbsEncryptionByDefault' --output text
+  register: ebsEncryptiondefault
+  when: agwDevops is defined
+
+- name: Disable EBS encryption to permit export of ami
+  command: aws ec2 disable-ebs-encryption-by-default
+  when: agwDevops is defined and ebsEncryptiondefault.stdout == 'True'
+
 - name: provision agw with dual NICs for devops
   cloudformation:
     stack_name: "stack{{ siteName }}{{ idGw }}"
@@ -80,3 +89,7 @@
       paramAgwTagSite: "{{ siteName }}"
       paramAgwInstanceType: "t2.medium"
   when: agwDevops is defined
+
+- name: Enable EBS encryption to permit export of ami
+  command: aws ec2 enable-ebs-encryption-by-default
+  when: agwDevops is defined and ebsEncryptiondefault.stdout == 'True'

--- a/experimental/cloudstrapper/playbooks/roles/clean-ami/tasks/main.yaml
+++ b/experimental/cloudstrapper/playbooks/roles/clean-ami/tasks/main.yaml
@@ -12,12 +12,6 @@
     state: absent
   become: true
 
-- name: Clean ssh host key
-  command: shred -u /etc/ssh/*_key /etc/ssh/*_key.pub ~/.*history
-  become: true
-  ignore_errors: true
-  tags: clearSSHKeys
-
 - name: Clean authorized keys for ubuntu
   file:
     name: /home/ubuntu/.ssh/authorized_keys

--- a/experimental/cloudstrapper/playbooks/roles/convert-to-qcow2/tasks/main.yaml
+++ b/experimental/cloudstrapper/playbooks/roles/convert-to-qcow2/tasks/main.yaml
@@ -3,6 +3,15 @@
 # AWS account pre-requisites: Make sure to create the vm import role used by export function
 # https://docs.aws.amazon.com/vm-import/latest/userguide/vmie_prereqs.html#vmimport-role
 
+- name: Check Export Bucket exist
+  command: aws s3 ls "s3://{{ exportBucket }}"
+
+- name: Create dummy file to test bucket rights
+  command: touch ~/dummy
+
+- name: Check Export Bucket permissions
+  command: aws s3 cp ~/dummy  "s3://{{ exportBucket }}" --dryrun
+
 - name: Get latest agw ami
   ec2_ami_info:
     filters:
@@ -48,7 +57,7 @@
     object: "/exports/{{exportTaskId.stdout}}.vmdk"
     mode: delobj
 
-- name: Clean vmdk file
+- name: Clean default generated file
   amazon.aws.aws_s3:
     bucket: "{{ bucketDefault }}"
     object: "/vmimportexport_write_verification"

--- a/experimental/cloudstrapper/playbooks/roles/convert-to-qcow2/tasks/main.yaml
+++ b/experimental/cloudstrapper/playbooks/roles/convert-to-qcow2/tasks/main.yaml
@@ -1,0 +1,55 @@
+---
+# convert-to-qcow2 export agw ami to qcow2 through magma s3 bucket
+# AWS account pre-requisites: Make sure to create the vm import role used by export function
+# https://docs.aws.amazon.com/vm-import/latest/userguide/vmie_prereqs.html#vmimport-role
+
+- name: Get latest agw ami
+  ec2_ami_info:
+    filters:
+      name: "{{ agwAmiName }}"
+  register: agwAMI
+
+- name: Export ami in vmdk format
+  command: aws ec2 export-image --image-id "{{agwAMI.images[0].image_id}}" --disk-image-format VMDK --s3-export-location S3Bucket="{{ bucketDefault }}",S3Prefix=exports/ --query 'ExportImageTaskId' --output text
+  register: exportTaskId
+
+- name: Wait for the export to complete
+  shell: |
+    status=$(aws ec2 describe-export-image-tasks --export-image-task-ids "{{exportTaskId.stdout}}" --query 'ExportImageTasks[0].Status' --output text)
+    while [ "$status" != "completed" ]; do sleep 30; status=$(aws ec2 describe-export-image-tasks --export-image-task-ids "{{exportTaskId.stdout}}" --query 'ExportImageTasks[0].Status' --output text); echo $status; done
+
+- name: Download exported AMI in vmdk format
+  amazon.aws.aws_s3:
+    bucket: "{{ bucketDefault }}"
+    object: "/exports/{{exportTaskId.stdout}}.vmdk"
+    dest: ~/agwami.vmdk
+    mode: get
+
+- name: Install qemu-utils package
+  apt:
+    name: qemu-utils
+    state: present
+    update_cache: true
+  become: true
+
+- name: Convert to qcow2
+  command: qemu-img convert -f raw -O qcow2 ~/agwami.vmdk "~/{{ agwAmiName }}.qcow2"
+
+- name: Upload to export bucket
+  amazon.aws.aws_s3:
+    bucket: "{{ exportBucket }}"
+    src: "~/{{ agwAmiName }}.qcow2"
+    object: "/agwqcow2/{{ agwAmiName }}.qcow2"
+    mode: put
+
+- name: Clean vmdk file
+  amazon.aws.aws_s3:
+    bucket: "{{ bucketDefault }}"
+    object: "/exports/{{exportTaskId.stdout}}.vmdk"
+    mode: delobj
+
+- name: Clean vmdk file
+  amazon.aws.aws_s3:
+    bucket: "{{ bucketDefault }}"
+    object: "/vmimportexport_write_verification"
+    mode: delobj

--- a/experimental/cloudstrapper/playbooks/roles/convert-to-qcow2/vars/main.yaml
+++ b/experimental/cloudstrapper/playbooks/roles/convert-to-qcow2/vars/main.yaml
@@ -1,0 +1,3 @@
+---
+# Bucket where qcow2 image will be exported
+exportBucket: qcow2images


### PR DESCRIPTION
<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary

Added the convertion to qcow2 to the agw ami pipeline.
The script will export it in qcow2 format in a pre-configured bucket: qcow2images

## Test Plan

Tested the pipeline in circle ci https://app.circleci.com/pipelines/github/magma/magma/26537/workflows/b623c96b-96cb-492a-bf6a-b0261626e4e0/jobs/283388

## Additional Information

Disabling default EBS encryption if enabled to permit export of ami.
Using the default bucket to store the intermediate vmdk file.
Got rid of failing cleaning commands.