### PR TITLE
[feg] s8_proxy fix wrong mnc on ULI

### DIFF
--- a/feg/gateway/services/s8_proxy/servicers/ie_conversions.go
+++ b/feg/gateway/services/s8_proxy/servicers/ie_conversions.go
@@ -69,7 +69,7 @@ func buildCreateSessionRequestMsg(cPgwUDPAddr *net.UDPAddr, apnSuffix string, re
 		ie.NewIMSI(req.GetImsi()),
 		bearer,
 		cFegFTeid,
-		getUserLocationIndication(req.ServingNetwork.Mcc, req.ServingNetwork.Mcc, req.Uli),
+		getUserLocationIndication(req.ServingNetwork, req.Uli),
 		getPdnType(req.PdnType),
 		getPDNAddressAllocation(req),
 		getRatType(req.RatType),
@@ -103,7 +103,7 @@ func buildDeleteSessionRequestMsg(cPgwUDPAddr *net.UDPAddr, req *protos.DeleteSe
 	ies := []*ie.IE{
 		ie.NewEPSBearerID(uint8(req.BearerId)),
 		cFegFTeid,
-		getUserLocationIndication(req.ServingNetwork.Mcc, req.ServingNetwork.Mcc, req.Uli),
+		getUserLocationIndication(req.ServingNetwork, req.Uli),
 	}
 	return message.NewDeleteSessionRequest(req.CPgwTeid, 0, ies...), nil
 }
@@ -128,7 +128,7 @@ func buildCreateBearerResMsg(seq uint32, res *protos.CreateBearerResponsePgw) (m
 		res.CPgwTeid, seq,
 		ie.NewCause(gtpv2.CauseRequestAccepted, 0, 0, 0, nil),
 		bearer,
-		getUserLocationIndication(res.ServingNetwork.Mcc, res.ServingNetwork.Mcc, res.Uli),
+		getUserLocationIndication(res.ServingNetwork, res.Uli),
 		getProtocolConfigurationOptions(res.ProtocolConfigurationOptions),
 		ie.NewUETimeZone(offset, daylightSavingTime),
 	), nil
@@ -192,7 +192,7 @@ func getPdnType(pdnType protos.PDNType) *ie.IE {
 	return ie.NewPDNType(res)
 }
 
-func getUserLocationIndication(mcc, mnc string, uli *protos.UserLocationInformation) *ie.IE {
+func getUserLocationIndication(servingNetwork *protos.ServingNetwork, uli *protos.UserLocationInformation) *ie.IE {
 	var (
 		cgi    *ie.CGI    = nil
 		sai    *ie.SAI    = nil
@@ -203,6 +203,9 @@ func getUserLocationIndication(mcc, mnc string, uli *protos.UserLocationInformat
 		menbi  *ie.MENBI  = nil
 		emenbi *ie.EMENBI = nil
 	)
+
+	mcc := servingNetwork.Mcc
+	mnc := servingNetwork.Mnc
 
 	if uli.Lac != 0 && uli.Ci != 0 {
 		cgi = ie.NewCGI(mcc, mnc, uint16(uli.Lac), uint16(uli.Ci))

--- a/feg/gateway/services/s8_proxy/servicers/mock_pgw/cs.go
+++ b/feg/gateway/services/s8_proxy/servicers/mock_pgw/cs.go
@@ -60,6 +60,14 @@ func (mPgw *MockPgw) getHandleCreateSessionRequest() gtpv2.HandlerFunc {
 			fmt.Println("Missing IE (IMSI) on Create Session Request that PGW received")
 			return &gtpv2.RequiredIEMissingError{Type: ie.IMSI}
 		}
+		if uliIE := csReqFromSGW.ULI; uliIE != nil {
+			mPgw.LastULI, err = uliIE.UserLocationInformation()
+			if err != nil {
+				return err
+			}
+		} else {
+			return &gtpv2.RequiredIEMissingError{Type: ie.UserLocationInformation}
+		}
 		if msisdnIE := csReqFromSGW.MSISDN; msisdnIE != nil {
 			session.MSISDN, err = msisdnIE.MSISDN()
 			if err != nil {

--- a/feg/gateway/services/s8_proxy/servicers/mock_pgw/mock_pgw.go
+++ b/feg/gateway/services/s8_proxy/servicers/mock_pgw/mock_pgw.go
@@ -44,6 +44,7 @@ type LastValues struct {
 	LastTEIDu uint32
 	LastTEIDc uint32
 	LastQos   *protos.QosInformation
+	LastULI   *ie.UserLocationInformationFields
 }
 
 // CreateSessionOptions to control Create Session Response values to produce errors

--- a/feg/gateway/services/s8_proxy/servicers/s8_proxy_test.go
+++ b/feg/gateway/services/s8_proxy/servicers/s8_proxy_test.go
@@ -119,6 +119,20 @@ func TestS8proxyCreateAndDeleteSession(t *testing.T) {
 	expectedAPN := fmt.Sprintf("%s%s", "internet", s8p.config.ApnOperatorSuffix)
 	assert.Equal(t, expectedAPN, bearer.APN)
 
+	// check ULI received
+	require.NotNil(t, mockPgw.LastULI)
+	assert.Equal(t, csReq.Uli.Ci, uint32(mockPgw.LastULI.CGI.CI))
+	assert.Equal(t, csReq.ServingNetwork.Mcc, mockPgw.LastULI.CGI.MCC)
+	assert.Equal(t, csReq.ServingNetwork.Mnc, mockPgw.LastULI.CGI.MNC)
+
+	assert.Equal(t, csReq.Uli.Lac, uint32(mockPgw.LastULI.LAI.LAC))
+	assert.Equal(t, csReq.ServingNetwork.Mcc, mockPgw.LastULI.LAI.MCC)
+	assert.Equal(t, csReq.ServingNetwork.Mnc, mockPgw.LastULI.LAI.MNC)
+
+	assert.Equal(t, csReq.Uli.Eci, mockPgw.LastULI.ECGI.ECI)
+	assert.Equal(t, csReq.ServingNetwork.Mcc, mockPgw.LastULI.ECGI.MCC)
+	assert.Equal(t, csReq.ServingNetwork.Mnc, mockPgw.LastULI.ECGI.MNC)
+
 	// ------------------------
 	// ---- Delete Session ----
 	cdReq := getDeleteSessionRequest(mockPgw.LocalAddr().String(), csRes.CPgwFteid.Teid)
@@ -639,7 +653,7 @@ func TestCreateBearerRequest(t *testing.T) {
 	csRes, err := s8p.CreateSession(context.Background(), csReq)
 	assert.NoError(t, err)
 	assert.NotEmpty(t, csRes)
-	assert.Empty(t, csRes.GtpError)
+	require.Nil(t, csRes.GtpError)
 	_, err = mockPgw.GetSessionByIMSI(IMSI1)
 	assert.NoError(t, err)
 
@@ -658,7 +672,7 @@ func TestCreateBearerRequest(t *testing.T) {
 	fegRelayTestSrv.DefaultCreateBearerRes =
 		&protos.CreateBearerResponsePgw{
 			CPgwTeid:                     uint32(111),
-			ServingNetwork:               &protos.ServingNetwork{Mcc: "10", Mnc: "101"},
+			ServingNetwork:               &protos.ServingNetwork{Mcc: "011", Mnc: "99"},
 			Cause:                        uint32(gtpv2.CauseRequestAccepted),
 			BearerContext:                csReq.BearerContext,
 			ProtocolConfigurationOptions: csReq.ProtocolConfigurationOptions,

--- a/feg/gateway/tools/s8_cli/main.go
+++ b/feg/gateway/tools/s8_cli/main.go
@@ -311,19 +311,13 @@ func createSession(cmd *commands.Command, args []string) int {
 
 				fmt.Println("\n *** Delete Session Test ***")
 				dsReq := &protos.DeleteSessionRequestPgw{
-					PgwAddrs: pgwServerAddr,
-					Imsi:     currentImsi,
-					BearerId: bearerId,
-					CAgwTeid: currentCAgwTeid,
-					CPgwTeid: csRes.CPgwFteid.Teid,
-					ServingNetwork: &protos.ServingNetwork{
-						Mcc: "310",
-						Mnc: "14",
-					},
-					Uli: &protos.UserLocationInformation{
-						Tac: 5,
-						Eci: 6,
-					},
+					PgwAddrs:       pgwServerAddr,
+					Imsi:           imsi,
+					BearerId:       bearerId,
+					CAgwTeid:       uint32(AGWTeidC),
+					CPgwTeid:       csRes.CPgwFteid.Teid,
+					ServingNetwork: csReq.ServingNetwork,
+					Uli:            csReq.Uli,
 				}
 				printGRPCMessage("Sending GRPC message: ", dsReq)
 				dsRes, errCli := cli.DeleteSession(dsReq)


### PR DESCRIPTION
Signed-off-by: Oriol Batalla <obatalla@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary

Update Location Information on create session request at s8 was sending wrong MCC (in fact it was sending MNC two times).

This PR fixes that and adds some unit test to prevents future issues like this

## Test Plan

make precommit at feg

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
