### PR TITLE
[cwag] Make sure to push latest when building cwf and feg docker images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -739,6 +739,10 @@ jobs:
       - magma_slack_notify
 
   feg-build:
+    parameters:
+      tag-latest:
+        default: false
+        type: boolean
     machine:
       image: ubuntu-1604:201903-01
       docker_layer_caching: true
@@ -776,12 +780,14 @@ jobs:
           project: feg
           images: "gateway_go|gateway_python"
           registry: $DOCKER_FEG_REGISTRY
+          tag-latest: <<parameters.tag-latest>>
       - tag-push-docker:
           project: feg
           images: "gateway_go|gateway_python"
           registry: $JFROG_DOCKER_FEG_REGISTRY
           username: $JFROG_USERNAME
           password: $JFROG_PASSWORD
+          tag-latest: <<parameters.tag-latest>>
       - persist-githash-version:
           file_prefix: feg
       - notify-magma:
@@ -1613,6 +1619,7 @@ workflows:
       - feg-build:
           requires:
             - feg-precommit
+          tag-latest: true
 
   cwag:
     jobs:
@@ -1627,6 +1634,7 @@ workflows:
           requires:
             - cwag-precommit
             - cwf-integ-test
+          tag-latest: true
       - xwfm-deploy:
           <<: *only_master
           name: xwfm-deploy-latest


### PR DESCRIPTION
## Summary

Make sure to push latest for feg and cwf docker-test images

## Test Plan

Modified job feg-build running as expected with changes
https://app.circleci.com/pipelines/github/magma/magma/26231/workflows/d510d954-d5dd-46df-8f9d-6604dd762bab/jobs/279074


## Additional Information

Maybe would be better to run feg-build only on master.