### PR TITLE
modify stop command to also stop sctpd service

### DIFF
--- a/lte/gateway/Makefile
+++ b/lte/gateway/Makefile
@@ -90,6 +90,7 @@ start: ## Start all services
 
 stop: ## Stop all services
 	sudo service magma@* stop
+	sudo service sctpd stop
 
 restart: stop start ## Restart all services
 


### PR DESCRIPTION
Signed-off-by: Marie Bremner <marwhal@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary
`make stop` currently only stops `magma@*` but not the `sctpd` service. Adding sctpd to the make command.
<!-- Enumerate changes you made and why you made them -->

## Test Plan
ran `make stop`
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
