### PR TITLE
Don't build protos in common

### DIFF
--- a/lte/gateway/c/session_manager/CMakeLists.txt
+++ b/lte/gateway/c/session_manager/CMakeLists.txt
@@ -84,7 +84,7 @@ generate_cpp_protos("${SMGR_ORC8R_CPP_PROTOS}" "${PROTO_SRCS}"
   "${PROTO_HDRS}" ${ORC8R_PROTO_DIR} ${ORC8R_CPP_OUT_DIR})
 
 set(SMGR_LTE_CPP_PROTOS session_manager
-  pipelined spgw_service mconfig/mconfigs)
+  pipelined spgw_service abort_session mconfig/mconfigs)
 generate_cpp_protos("${SMGR_LTE_CPP_PROTOS}" "${PROTO_SRCS}"
   "${PROTO_HDRS}" ${LTE_PROTO_DIR} ${LTE_CPP_OUT_DIR})
 
@@ -96,7 +96,7 @@ set(SMGR_ORC8R_GRPC_PROTOS directoryd)
 generate_grpc_protos("${SMGR_ORC8R_GRPC_PROTOS}" "${PROTO_SRCS}"
   "${PROTO_HDRS}" ${ORC8R_PROTO_DIR} ${ORC8R_CPP_OUT_DIR})
 
-set(SMGR_GRPC_PROTOS session_manager pipelined spgw_service)
+set(SMGR_GRPC_PROTOS abort_session session_manager pipelined spgw_service)
 generate_grpc_protos("${SMGR_GRPC_PROTOS}" "${PROTO_SRCS}"
   "${PROTO_HDRS}" ${LTE_PROTO_DIR} ${LTE_CPP_OUT_DIR})
 

--- a/orc8r/gateway/c/common/async_grpc/CMakeLists.txt
+++ b/orc8r/gateway/c/common/async_grpc/CMakeLists.txt
@@ -18,45 +18,14 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 
 find_package(MAGMA_LOGGING REQUIRED)
 
-include("${PROJECT_SOURCE_DIR}/../CMakeProtoMacros.txt")
-
-#compile the relevant protos
-
-list(APPEND PROTO_SRCS "")
-list(APPEND PROTO_HDRS "")
-
-set(ASYNC_ORC8R_CPP_PROTOS common redis eventd)
-set(ASYNC_LTE_CPP_PROTOS session_manager abort_session policydb apn subscriberdb
-    mobilityd pipelined)
-set(ASYNC_LTE_GRPC_PROTOS session_manager abort_session mobilityd pipelined)
-set(ASYNC_ORC8R_GRPC_PROTOS eventd)
-set(MAGMA_INCLUDE_DIR $ENV{C_BUILD}/common/includes)
-
-generate_all_protos("${ASYNC_LTE_CPP_PROTOS}" "${ASYNC_ORC8R_CPP_PROTOS}"
-    "${ASYNC_LTE_GRPC_PROTOS}"
-    "${ASYNC_ORC8R_GRPC_PROTOS}" "${PROTO_SRCS}" "${PROTO_HDRS}")
-
-message("Async Proto_srcs are ${PROTO_SRCS}")
-
 add_library(ASYNC_GRPC
     GRPCReceiver.cpp
-    ${PROTO_SRCS}
-    ${PROTO_HDRS}
     )
 
 target_link_libraries(ASYNC_GRPC PRIVATE MAGMA_LOGGING)
 
-# copy headers to build directory so they can be shared with OAI,
-# session_manager, etc.
-add_custom_command(TARGET ASYNC_GRPC POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E make_directory ${MAGMA_INCLUDE_DIR})
-add_custom_command(TARGET ASYNC_GRPC POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E copy
-    ${PROJECT_SOURCE_DIR}/includes/*.h ${MAGMA_INCLUDE_DIR})
-
 target_include_directories(ASYNC_GRPC PUBLIC
     "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>"
-    $<TARGET_FILE_DIR:ASYNC_GRPC>
     )
 
 install(TARGETS ASYNC_GRPC EXPORT ASYNC_GRPC_TARGETS
@@ -66,3 +35,12 @@ install(TARGETS ASYNC_GRPC EXPORT ASYNC_GRPC_TARGETS
 set(CMAKE_EXPORT_PACKAGE_REGISTRY ON)
 export(TARGETS ASYNC_GRPC FILE ASYNC_GRPCConfig.cmake)
 export(PACKAGE ASYNC_GRPC)
+
+# Copy headers to build directory so they can be shared with session_manager
+# Can be removed when session manager moves to a super build model.
+set(MAGMA_INCLUDE_DIR $ENV{C_BUILD}/common/includes)
+add_custom_command(TARGET ASYNC_GRPC POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E make_directory ${MAGMA_INCLUDE_DIR})
+add_custom_command(TARGET ASYNC_GRPC POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E copy
+    ${PROJECT_SOURCE_DIR}/includes/*.h ${MAGMA_INCLUDE_DIR})


### PR DESCRIPTION
## Summary

Don't build protos in common

This is not needed as the specific super builds will build protos
Also, its probably not common if we are building specific service protos

Signed-off-by: Amar Padmanabhan <amar@freedomfi.com>

## Test Plan

make run

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
