### PR TITLE
Carry BUILD_TYPE flag to subprojects

### DIFF
--- a/lte/gateway/c/connection_tracker/CMakeLists.txt
+++ b/lte/gateway/c/connection_tracker/CMakeLists.txt
@@ -21,6 +21,7 @@ foreach (var ${vars})
     list(APPEND CL_ARGS "-D${var}=${${var}}")
   endif ()
 endforeach ()
+list(APPEND CL_ARGS "-DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}")
 
 project(MagmaConnectionTracker)
 
@@ -30,7 +31,8 @@ ExternalProject_Add(MagmaCommon
     SOURCE_DIR "$ENV{MAGMA_ROOT}/orc8r/gateway/c/common"
     BUILD_ALWAYS 1
     BINARY_DIR "${CMAKE_BINARY_DIR}/common"
-    INSTALL_COMMAND "")
+    INSTALL_COMMAND ""
+    CMAKE_ARGS ${CL_ARGS})
 
 ExternalProject_Add(ConnectionTracker
     SOURCE_DIR "${CMAKE_SOURCE_DIR}/src"

--- a/lte/gateway/c/core/CMakeLists.txt
+++ b/lte/gateway/c/core/CMakeLists.txt
@@ -23,6 +23,8 @@ foreach (var ${vars})
   endif ()
 endforeach ()
 
+list(APPEND CL_ARGS "-DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}")
+
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 set(CMAKE_VERBOSE_MAKEFILE ON)
 
@@ -34,7 +36,8 @@ ExternalProject_Add(MagmaCommon
     SOURCE_DIR "$ENV{MAGMA_ROOT}/orc8r/gateway/c/common"
     BUILD_ALWAYS 1
     BINARY_DIR "${CMAKE_BINARY_DIR}/common"
-    INSTALL_COMMAND "")
+    INSTALL_COMMAND ""
+    CMAKE_ARGS ${CL_ARGS})
 
 ExternalProject_Add(MagmaCore
     SOURCE_DIR "${CMAKE_SOURCE_DIR}/oai"

--- a/lte/gateway/c/li_agent/CMakeLists.txt
+++ b/lte/gateway/c/li_agent/CMakeLists.txt
@@ -23,7 +23,7 @@ foreach (var ${vars})
     list(APPEND CL_ARGS "-D${var}=${${var}}")
   endif ()
 endforeach ()
-
+list(APPEND CL_ARGS "-DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}")
 
 project(MagmaLiAgent)
 
@@ -33,7 +33,8 @@ ExternalProject_Add(MagmaCommon
     SOURCE_DIR "$ENV{MAGMA_ROOT}/orc8r/gateway/c/common"
     BUILD_ALWAYS 1
     BINARY_DIR "${CMAKE_BINARY_DIR}/common"
-    INSTALL_COMMAND "")
+    INSTALL_COMMAND ""
+    CMAKE_ARGS ${CL_ARGS})
 
 ExternalProject_Add(LiAgent
     SOURCE_DIR "${CMAKE_SOURCE_DIR}/src"

--- a/lte/gateway/c/sctpd/CMakeLists.txt
+++ b/lte/gateway/c/sctpd/CMakeLists.txt
@@ -23,7 +23,7 @@ foreach (var ${vars})
     list(APPEND CL_ARGS "-D${var}=${${var}}")
   endif ()
 endforeach ()
-
+list(APPEND CL_ARGS "-DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}")
 
 project(MagmaSctpd)
 
@@ -33,7 +33,8 @@ ExternalProject_Add(MagmaCommon
     SOURCE_DIR "$ENV{MAGMA_ROOT}/orc8r/gateway/c/common"
     BUILD_ALWAYS 1
     BINARY_DIR "${CMAKE_BINARY_DIR}/common"
-    INSTALL_COMMAND "")
+    INSTALL_COMMAND ""
+    CMAKE_ARGS ${CL_ARGS})
 
 ExternalProject_Add(Sctpd
     SOURCE_DIR "${CMAKE_SOURCE_DIR}/src"

--- a/orc8r/gateway/c/common/CMakeLists.txt
+++ b/orc8r/gateway/c/common/CMakeLists.txt
@@ -56,7 +56,7 @@ ExternalProject_Add(Eventd
         DEPENDS AsyncGrpc
         DEPENDS ServiceRegistry)
 
-if (BUILD_TESTS)
-  ENABLE_TESTING()
-  ADD_SUBDIRECTORY(test)
-endif (BUILD_TESTS)
+#if (BUILD_TESTS)
+#  ENABLE_TESTING()
+#  ADD_SUBDIRECTORY(test)
+#endif (BUILD_TESTS)


### PR DESCRIPTION
-DCMAKE_BUILD_TYPE flag wasn't passed on to subprojects this
resulted in builds always being RelWithDebug.
Pass the build flag explicitly to the sub builds

Testing Done:
1 - Verified Debug builds are getting created
2 - Make coverage is generating valid coverage reports

lcov -r /tmp/coverage_oai.info.raw "/*/test/*" -o /tmp/coverage_oai.info
Reading tracefile /tmp/coverage_oai.info.raw
Removing /magma/lte/gateway/c/core/oai/test/itti/test_itti.cpp
Removing /magma/lte/gateway/c/core/oai/test/mme_app_task/test_mme_app_emm_decode.cpp
Removing /magma/lte/gateway/c/core/oai/test/mme_app_task/test_mme_app_ue_context.c
Removing /magma/lte/gateway/c/core/oai/test/openflow/openflow_mocks.h
Removing /magma/lte/gateway/c/core/oai/test/openflow/test_gtp_app.cpp
Removing /magma/lte/gateway/c/core/oai/test/openflow/test_imsi_encoder.cpp
Removing /magma/lte/gateway/c/core/oai/test/openflow/test_openflow_controller.cpp
Removing /magma/lte/gateway/c/core/oai/test/pipelined_client/test_pipelined_client.cpp
Removing /magma/lte/gateway/c/core/oai/test/pipelined_client/utility_protobuf.h
Removing /magma/lte/gateway/c/core/oai/test/spgw_task/state_creators.cpp
Removing /magma/lte/gateway/c/core/oai/test/spgw_task/test_spgw_state_converter.cpp
Removing /magma/lte/gateway/c/session_manager/test/Matchers.h
Removing /magma/lte/gateway/c/session_manager/test/ProtobufCreators.cpp
Removing /magma/lte/gateway/c/session_manager/test/SessionStateTester.h
Removing /magma/lte/gateway/c/session_manager/test/SessiondMocks.h
Removing /magma/lte/gateway/c/session_manager/test/test_charging_grant.cpp
Removing /magma/lte/gateway/c/session_manager/test/test_local_enforcer.cpp
Removing /magma/lte/gateway/c/session_manager/test/test_local_enforcer_wallet_exhaust.cpp
Removing /magma/lte/gateway/c/session_manager/test/test_metering_reporter.cpp
Removing /magma/lte/gateway/c/session_manager/test/test_proxy_responder_handler.cpp
Removing /magma/lte/gateway/c/session_manager/test/test_session_credit.cpp
Removing /magma/lte/gateway/c/session_manager/test/test_session_manager_handler.cpp
Removing /magma/lte/gateway/c/session_manager/test/test_session_state.cpp
Removing /magma/lte/gateway/c/session_manager/test/test_session_store.cpp
Removing /magma/lte/gateway/c/session_manager/test/test_store_client.cpp
Removing /magma/lte/gateway/c/session_manager/test/test_stored_state.cpp
Removing /magma/lte/gateway/c/session_manager/test/test_upf_node_state.cpp
Removing /magma/lte/gateway/c/session_manager/test/test_usage_monitor.cpp
Deleted 28 files
Writing data to /tmp/coverage_oai.info
Summary coverage rate:
  lines......: 19.9% (22719 of 114224 lines)
  functions..: 38.6% (19114 of 49527 functions)
  branches...: no data found

Signed-off-by: Amar Padmanabhan <amar@freedomfi.com>