### PR TITLE
[lte][agw] Update timer id for expired NAS procedure timers

### DIFF
--- a/lte/gateway/c/core/oai/tasks/nas/emm/Authentication.c
+++ b/lte/gateway/c/core/oai/tasks/nas/emm/Authentication.c
@@ -1084,6 +1084,8 @@ static void authentication_t3460_handler(void* args, imsi64_t* imsi64) {
     // TODO the network shall abort any ongoing EMM specific procedure.
 
     auth_proc->retransmission_count += 1;
+    auth_proc->T3460.id = NAS_TIMER_INACTIVE_ID;
+
     OAILOG_WARNING_UE(
         LOG_NAS_EMM, *imsi64,
         "EMM-PROC  - T3460 timer expired, retransmission "
@@ -1277,6 +1279,9 @@ static int authentication_request(
         /*
          * Start T3460 timer
          */
+        OAILOG_DEBUG(
+            LOG_NAS_EMM, "Timeout period for T3460 is: %u",
+            auth_proc->T3460.sec);
         nas_start_T3460(
             auth_proc->ue_id, &auth_proc->T3460,
             auth_proc->emm_com_proc.emm_proc.base_proc.time_out,

--- a/lte/gateway/c/core/oai/tasks/nas/emm/Authentication.c
+++ b/lte/gateway/c/core/oai/tasks/nas/emm/Authentication.c
@@ -1085,7 +1085,6 @@ static void authentication_t3460_handler(void* args, imsi64_t* imsi64) {
 
     auth_proc->retransmission_count += 1;
     auth_proc->T3460.id = NAS_TIMER_INACTIVE_ID;
-
     OAILOG_WARNING_UE(
         LOG_NAS_EMM, *imsi64,
         "EMM-PROC  - T3460 timer expired, retransmission "

--- a/lte/gateway/c/core/oai/tasks/nas/emm/Authentication.c
+++ b/lte/gateway/c/core/oai/tasks/nas/emm/Authentication.c
@@ -1279,9 +1279,6 @@ static int authentication_request(
         /*
          * Start T3460 timer
          */
-        OAILOG_DEBUG(
-            LOG_NAS_EMM, "Timeout period for T3460 is: %u",
-            auth_proc->T3460.sec);
         nas_start_T3460(
             auth_proc->ue_id, &auth_proc->T3460,
             auth_proc->emm_com_proc.emm_proc.base_proc.time_out,

--- a/lte/gateway/c/core/oai/tasks/nas/emm/SecurityModeControl.c
+++ b/lte/gateway/c/core/oai/tasks/nas/emm/SecurityModeControl.c
@@ -749,6 +749,7 @@ static void security_t3460_handler(void* args, imsi64_t* imsi64) {
      * Increment the retransmission counter
      */
     smc_proc->retransmission_count += 1;
+    smc_proc->T3460.id = NAS_TIMER_INACTIVE_ID;
     OAILOG_WARNING_UE(
         LOG_NAS_EMM, *imsi64,
         "EMM-PROC  - T3460 timer expired, retransmission "

--- a/lte/gateway/c/core/oai/tasks/nas/emm/TrackingAreaUpdate.c
+++ b/lte/gateway/c/core/oai/tasks/nas/emm/TrackingAreaUpdate.c
@@ -471,6 +471,7 @@ static void emm_tracking_area_update_t3450_handler(
      * Increment the retransmission counter
      */
     tau_proc->retransmission_count += 1;
+    tau_proc->T3450.id = NAS_TIMER_INACTIVE_ID;
     OAILOG_WARNING_UE(
         LOG_NAS_EMM, *imsi64,
         "EMM-PROC  - T3450 timer expired, retransmission counter = %d for ue "


### PR DESCRIPTION
Signed-off-by: Ulas Kozat <kozat@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->
- After moving the image to Ubuntu, `test_attach_detach_duplicate_nas_resp_messages.py` started failing. The PR updates the timer IDs in the handler functions for expired timers of NAS procedures. This prevents unnecessary stoppage of already expired one-off timers. 
- We still need to root cause why (presumed to be) idempotent "stop_timer" call is causing an issue for already expired timers.

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->
Run the failing integ tests and the full test suite.

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
