### PR TITLE
[sessiond] add grpc print logging flag to sessiond.yml

### DIFF
--- a/cwf/gateway/configs/sessiond.yml
+++ b/cwf/gateway/configs/sessiond.yml
@@ -12,12 +12,14 @@
 # limitations under the License.
 
 log_level: INFO
+print_grpc_payload: false
+
 rule_update_inteval_sec: 1
 
 # Session manager will report the usage when the usage is greater than
 # usage_reporting_threshold * available quota since last update
 # In this way, session manager will report the usage before the subscriber
-# completely uses up the quota. 
+# completely uses up the quota.
 usage_reporting_threshold: 0.8
 
 # Set to true to terminate service when the quota of a session is exhausted.

--- a/cwf/gateway/helm/cwf-kubevirt/templates/bin/_sessiond.yml.tpl
+++ b/cwf/gateway/helm/cwf-kubevirt/templates/bin/_sessiond.yml.tpl
@@ -12,6 +12,8 @@
 # limitations under the License.
 
 log_level: INFO
+print_grpc_payload: false
+
 rule_update_inteval_sec: 1
 
 # Session manager will report the usage when the usage is greater than

--- a/cwf/gateway/helm/cwf-virtlet/templates/bin/_sessiond.yml.tpl
+++ b/cwf/gateway/helm/cwf-virtlet/templates/bin/_sessiond.yml.tpl
@@ -12,6 +12,8 @@
 # limitations under the License.
 
 log_level: INFO
+print_grpc_payload: false
+
 rule_update_inteval_sec: 1
 
 # Session manager will report the usage when the usage is greater than

--- a/cwf/gateway/integ_tests/sessiond.yml
+++ b/cwf/gateway/integ_tests/sessiond.yml
@@ -12,12 +12,14 @@
 # limitations under the License.
 
 log_level: DEBUG
+print_grpc_payload: false
+
 rule_update_inteval_sec: 1
 
 # Session manager will report the usage when the usage is greater than
 # usage_reporting_threshold * available quota since last update
 # In this way, session manager will report the usage before the subscriber
-# completely uses up the quota. 
+# completely uses up the quota.
 usage_reporting_threshold: 0.8
 
 # Set to true to terminate service when the quota of a session is exhausted.

--- a/docs/readmes/lte/dev_notes.md
+++ b/docs/readmes/lte/dev_notes.md
@@ -152,16 +152,11 @@ the section previous (`/var/log/syslog`). By default, it is disabled.
 Note GRPC printing is independent of the `log_level`. So you can enabled GRPC
 printing even that your level is set as `INFO`.
 
-To enable GRPC logging for `magmad`, `pipelined`, `mobilityd`, `directoryd` or
-`subscriberdb` you can modify this line on the `/etc/magma/<service_name>.yml`
-config file:
+To enable GRPC logging for `magmad`, `sessiond`, `pipelined`, `mobilityd`,
+`directoryd` or`subscriberdb` you can modify this line on the
+`/etc/magma/<service_name>.yml` config file:
 ```yaml
 print_grpc_payload: true
-```
-
-To enable this on sessiond you will have to create an environment variable
-```text
-MAGMA_PRINT_GRPC_PAYLOAD=1
 ```
 
 ### CLIs

--- a/lte/gateway/c/session_manager/GrpcMagmaUtils.cpp
+++ b/lte/gateway/c/session_manager/GrpcMagmaUtils.cpp
@@ -24,7 +24,21 @@
 
 #define MAGMA_PRINT_GRPC_PAYLOAD "MAGMA_PRINT_GRPC_PAYLOAD"
 
-std::string grpcLoginLevel = get_env_var(MAGMA_PRINT_GRPC_PAYLOAD);
+bool grpcLoggingEnabled = false;
+
+// set_grpc_logging_level will only change the level in case
+// MAGMA_PRINT_GRPC_PAYLOAD envar is not set
+void set_grpc_logging_level(bool enable) {
+  std::string val = get_env_var(MAGMA_PRINT_GRPC_PAYLOAD);
+  if (val == "") {
+    grpcLoggingEnabled = enable;
+  } else if (val == "1") {
+    grpcLoggingEnabled = true;
+  } else {
+    grpcLoggingEnabled = false;
+  }
+  MLOG(MINFO) << "print_grpc_payload set at: " << grpcLoggingEnabled;
+}
 
 std::string get_env_var(std::string const& key) {
   MLOG(MINFO) << "Checking env var " << key;
@@ -38,7 +52,7 @@ std::string get_env_var(std::string const& key) {
 }
 
 void PrintGrpcMessage(const google::protobuf::Message& msg) {
-  if (grpcLoginLevel == "1") {
+  if (grpcLoggingEnabled) {
     // Lazy log strategy
     const google::protobuf::Descriptor* desc = msg.GetDescriptor();
     MLOG(MINFO) << "\n"

--- a/lte/gateway/c/session_manager/GrpcMagmaUtils.h
+++ b/lte/gateway/c/session_manager/GrpcMagmaUtils.h
@@ -20,6 +20,8 @@ class Message;
 }
 }  // namespace google
 
+void set_grpc_logging_level(bool enable);
+
 std::string get_env_var(std::string const& key);
 
 void PrintGrpcMessage(const google::protobuf::Message& message);

--- a/lte/gateway/c/session_manager/sessiond_main.cpp
+++ b/lte/gateway/c/session_manager/sessiond_main.cpp
@@ -201,6 +201,10 @@ int main(int argc, char* argv[]) {
       magma::ServiceConfigLoader{}.load_service_config(SESSIOND_SERVICE);
   magma::set_verbosity(get_log_verbosity(config, mconfig));
 
+  if ((config["print_grpc_payload"].IsDefined())) {
+    set_grpc_logging_level(config["print_grpc_payload"].as<bool>());
+  }
+
   initialize_sentry();
 
   bool converged_access = false;

--- a/lte/gateway/configs/sessiond.yml
+++ b/lte/gateway/configs/sessiond.yml
@@ -12,6 +12,8 @@
 # limitations under the License.
 
 log_level: INFO
+print_grpc_payload: false
+
 rule_update_inteval_sec: 1
 
 # Session manager will report the usage when the usage is greater than

--- a/lte/gateway/configs/sessiond.yml_prod
+++ b/lte/gateway/configs/sessiond.yml_prod
@@ -12,6 +12,8 @@
 # limitations under the License.
 
 log_level: INFO
+print_grpc_payload: false
+
 rule_update_inteval_sec: 15
 
 # Session manager will report the usage when the usage is greater than


### PR DESCRIPTION
Signed-off-by: Oriol Batalla <obatalla@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary

Add `print_grpc_payload` flag to sessiond.yml to make it easier to enable/disable it

MAGMA_PRINT_GRPC_PAYLOAD envvar will still work and will take precedence in case of both being configured.


## Test Plan

make precommit_sm
tested in terravm 

```
Jun 15 19:30:09 agw systemd[1]: Started Magma session manager service.
Jun 15 19:30:09 agw sessiond[31538]: I0615 19:30:09.672209 31538 magma_logging_init.h:26] Setting verbosity to 4
Jun 15 19:30:09 agw sessiond[31538]: I0615 19:30:09.672948 31538 GrpcMagmaUtils.cpp:43] Checking env var MAGMA_PRINT_GRPC_PAYLOAD
Jun 15 19:30:09 agw sessiond[31538]: I0615 19:30:09.673358 31538 GrpcMagmaUtils.cpp:39] print_grpc_payload set at: 1
Jun 15 19:30:09 agw sessiond[31538]: I0615 19:30:09.673840 31538 sessiond_main.cpp:216] Starting Session Manager
Jun 15 19:30:09 agw sessiond[31538]: [/home/vagrant/magma/orc8r/gateway/c/common/config/ServiceConfigLoader.cpp:35] Over
```

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
