### PR TITLE
[lte][agw] Fixing generation of congestion control enabled flag for mme.conf

### DIFF
--- a/lte/gateway/python/scripts/generate_oai_config.py
+++ b/lte/gateway/python/scripts/generate_oai_config.py
@@ -198,15 +198,15 @@ def _get_restricted_imeis(service_mconfig):
 
 def _get_service_area_maps(service_mconfig):
     if service_mconfig.service_area_maps:
-      service_area_map = [] 
+      service_area_map = []
       for sac in service_mconfig.service_area_maps:
         tac_list = []
         service_area_maps_dict = {}
         for idx in service_mconfig.service_area_maps[sac].tac :
-          tac_list.append(idx)  
+          tac_list.append(idx)
         service_area_maps_dict['sac'] = sac
         service_area_maps_dict['tac'] = tac_list
-        service_area_map.append(service_area_maps_dict) 
+        service_area_map.append(service_area_maps_dict)
       return service_area_map
     return {}
 
@@ -219,7 +219,7 @@ def _get_congestion_control_config(service_mconfig):
 
     Returns: congestion control flag
     """
-    if service_mconfig.congestion_control_enabled:
+    if service_mconfig.congestion_control_enabled is not None:
         return service_mconfig.congestion_control_enabled
 
     return True


### PR DESCRIPTION
Signed-off-by: Alex Rodriguez <ardzoht@gmail.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->
- Fixing `congestion_control_enabled` config value check on generate_oai_config.py

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->
- Changing value on `/etc/magma/gateway.mconfig` and check if it's reflected:
```
000206 Wed Jun 16 06:43:09 2021 7F4EE10D1CC0 INFO  CONFIG tasks/mme_app/mme_config.c      :1677    - Congestion control enabled ........................: false
000207 Wed Jun 16 06:43:09 2021 7F4EE10D1CC0 INFO  CONFIG tasks/mme_app/mme_config.c      :1682    - S1AP ZMQ Threshold ...........................:    2000000 (microseconds)
000208 Wed Jun 16 06:43:09 2021 7F4EE10D1CC0 INFO  CONFIG tasks/mme_app/mme_config.c      :1687    - MME APP ZMQ Congestion Threshold .............:     100000 (microseconds)
000209 Wed Jun 16 06:43:09 2021 7F4EE10D1CC0 INFO  CONFIG tasks/mme_app/mme_config.c      :1692    - MME APP ZMQ Auth Complete Threshold...........:     200000 (microseconds)
000210 Wed Jun 16 06:43:09 2021 7F4EE10D1CC0 INFO  CONFIG tasks/mme_app/mme_config.c      :1697    - MME APP ZMQ Identity Complete Threshold.......:     400000 (microseconds)
000211 Wed Jun 16 06:43:09 2021 7F4EE10D1CC0 INFO  CONFIG tasks/mme_app/mme_config.c      :1702    - MME APP ZMQ SMC Complete Threshold ...........:    1000000 (microseconds)
```

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
