### PR TITLE
[cwag] add print CCR message to mock OCS and PCRF

### DIFF
--- a/feg/gateway/services/testcore/ocs/mock_ocs/ccr_handler.go
+++ b/feg/gateway/services/testcore/ocs/mock_ocs/ccr_handler.go
@@ -76,6 +76,7 @@ type RequestedServiceUnit struct {
 func getCCRHandler(srv *OCSDiamServer) diam.HandlerFunc {
 	return func(c diam.Conn, m *diam.Message) {
 		glog.V(2).Infof("Received CCR from %s\n", c.RemoteAddr())
+		glog.V(2).Infof("Received Gy CCR message\n%s\n", m)
 		srv.lastDiamMessageReceived = m
 		var ccr ccrMessage
 		if err := m.Unmarshal(&ccr); err != nil {
@@ -211,6 +212,7 @@ func sendAnswer(
 	// SessionID must be the first AVP
 	a.InsertAVP(diam.NewAVP(avp.SessionID, avp.Mbit, 0, ccr.SessionID))
 
+	glog.V(2).Infof("Sending Gy CCA message\n%s\n", a)
 	_, err := a.WriteTo(conn)
 	if err != nil {
 		glog.Errorf("Failed to write message to %s: %s\n%s\n",

--- a/feg/gateway/services/testcore/pcrf/mock_pcrf/ccr_handler.go
+++ b/feg/gateway/services/testcore/pcrf/mock_pcrf/ccr_handler.go
@@ -64,6 +64,7 @@ type usedServiceUnitAVP struct {
 func getCCRHandler(srv *PCRFServer) diam.HandlerFunc {
 	return func(c diam.Conn, m *diam.Message) {
 		glog.V(2).Infof("Received CCR from %s\n", c.RemoteAddr())
+		glog.V(2).Infof("Received Gx CCR message\n%s\n", m)
 		srv.lastDiamMessageReceived = m
 		var ccr ccrMessage
 		if err := m.Unmarshal(&ccr); err != nil {
@@ -146,6 +147,7 @@ func sendAnswer(
 	// SessionID must be the first AVP
 	a.InsertAVP(diam.NewAVP(avp.SessionID, avp.Mbit, 0, ccr.SessionID))
 
+	glog.V(2).Infof("Sending Gx CCA message\n%s\n", a)
 	_, err := a.WriteTo(conn)
 	if err != nil {
 		glog.V(2).Infof("Failed to write message to %s: %s\n%s\n",


### PR DESCRIPTION
Signed-off-by: Oriol Batalla <obatalla@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary

Added print of CCR message to mock PCRF and OCS to see the content of the AVP without the need to use tcpdump


```
pcrf             | I0616 07:14:33.706784       1 pcrf.go:165] New account 492335504603081 added
pcrf             | I0616 07:14:37.754319       1 mock_driver.go:42] MockDriver: Initializing a new set of Expectations: [expected_request:<imsi:"492335504603081" request_type:INITIAL > answer:<result_code:2001 usage_monitoring_infos:<monitoring_key:"mkey1" monitoring_level:RuleLevel octets:<total_octets:5242880 > > rule_installs:<rule_names:"static-block-all" > > ]
pcrf             | I0616 07:14:37.791700       1 ccr_handler.go:69] Received CCR from 127.0.0.1:50004
pcrf             | I0616 07:14:37.791729       1 ccr_handler.go:70] Received Gx CCR message
pcrf             | Credit-Control-Request (CCR)
pcrf             | {Code:272,Flags:0xc0,Version:0x1,Length:644,ApplicationId:16777238,HopByHopId:0x43138666,EndToEndId:0xf58695bb}
pcrf             | 	Session-Id {Code:263,Flags:0x40,Length:64,VendorId:0,Value:UTF8String{feg.magma.svc.cluster.local;22;198;IMSI492335504603081},Padding:2}
pcrf             | 	Auth-Application-Id {Code:258,Flags:0x40,Length:12,VendorId:0,Value:Unsigned32{16777238}}
pcrf             | 	CC-Request-Type {Code:416,Flags:0x40,Length:12,VendorId:0,Value:Enumerated{1}}
pcrf             | 	CC-Request-Number {Code:415,Flags:0x40,Length:12,VendorId:0,Value:Unsigned32{0}}
pcrf             | 	Subscription-Id {Code:443,Flags:0x40,Length:44,VendorId:0,Value:Grouped{
pcrf             | 		Subscription-Id-Type {Code:450,Flags:0x40,Length:12,VendorId:0,Value:Enumerated{1}},
pcrf             | 		Subscription-Id-Data {Code:444,Flags:0x40,Length:24,VendorId:0,Value:UTF8String{492335504603081},Padding:1},
pcrf             | 	}}
pcrf             | 	Subscription-Id {Code:443,Flags:0x40,Length:40,VendorId:0,Value:Grouped{
pcrf             | 		Subscription-Id-Type {Code:450,Flags:0x40,Length:12,VendorId:0,Value:Enumerated{0}},
pcrf             | 		Subscription-Id-Data {Code:444,Flags:0x40,Length:20,VendorId:0,Value:UTF8String{5100001234},Padding:2},
pcrf             | 	}}
pcrf             | 	IP-CAN-Type {Code:1027,Flags:0xc0,Length:16,VendorId:10415,Value:Enumerated{6}}
pcrf             | 	RAT-Type {Code:1032,Flags:0x80,Length:16,VendorId:10415,Value:Enumerated{0}}
pcrf             | 	Framed-IPv6-Prefix {Code:97,Flags:0x40,Length:28,VendorId:0,Value:OctetString{0x0080fdfaceb0ad78ac2accb1befffe9fe943},Padding:2}
pcrf             | 	Called-Station-Id {Code:30,Flags:0x40,Length:48,VendorId:0,Value:UTF8String{98-DE-D0-84-B5-47:CWF-TP-LINK_B547_5G},Padding:3}
pcrf             | 	Supported-Features {Code:628,Flags:0x80,Length:56,VendorId:10415,Value:Grouped{
pcrf             | 		Vendor-Id {Code:266,Flags:0x40,Length:12,VendorId:0,Value:Unsigned32{10415}},
pcrf             | 		Feature-List-ID {Code:629,Flags:0x80,Length:16,VendorId:10415,Value:Unsigned32{1}},
pcrf             | 		Feature-List {Code:630,Flags:0x80,Length:16,VendorId:10415,Value:Unsigned32{3}},
pcrf             | 	}}
pcrf             | 	Supported-Features {Code:628,Flags:0x80,Length:56,VendorId:10415,Value:Grouped{
pcrf             | 		Vendor-Id {Code:266,Flags:0x40,Length:12,VendorId:0,Value:Unsigned32{10415}},
pcrf             | 		Feature-List-ID {Code:629,Flags:0x80,Length:16,VendorId:10415,Value:Unsigned32{2}},
pcrf             | 		Feature-List {Code:630,Flags:0x80,Length:16,VendorId:10415,Value:Unsigned32{3}},
pcrf             | 	}}

```

## Test Plan

make precommit
cwag test

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
