### PR TITLE
[orc8r] backport 7545 Include service indicator on policies

### DIFF
--- a/feg/gateway/services/session_proxy/credit_control/gy/gy_client_test.go
+++ b/feg/gateway/services/session_proxy/credit_control/gy/gy_client_test.go
@@ -66,7 +66,7 @@ func TestGyClient(t *testing.T) {
 		&serverConfig,
 		getReAuthHandler(), nil, gyGlobalConfig,
 	)
-
+	si11 := uint32(11)
 	// send init
 	ccrInit := &gy.CreditControlRequest{
 		SessionID:     "1",
@@ -85,6 +85,11 @@ func TestGyClient(t *testing.T) {
 				RatingGroup:    2,
 				RequestedUnits: defaultRSU,
 			},
+			{
+				RatingGroup:       3,
+				ServiceIdentifier: &si11,
+				RequestedUnits:    defaultRSU,
+			},
 		},
 	}
 	done := make(chan interface{}, 1000)
@@ -96,7 +101,7 @@ func TestGyClient(t *testing.T) {
 
 	assert.Equal(t, ccrInit.SessionID, answer.SessionID)
 	assert.Equal(t, ccrInit.RequestNumber, answer.RequestNumber)
-	assert.Equal(t, 2, len(answer.Credits))
+	assert.Equal(t, 3, len(answer.Credits))
 	assert.Equal(t, uint32(diam.Success), answer.ResultCode)
 	assertReceivedAPNonOCS(t, ocs, ccrInit.Apn)
 

--- a/feg/gateway/services/session_proxy/credit_control/gy/model_conversion.go
+++ b/feg/gateway/services/session_proxy/credit_control/gy/model_conversion.go
@@ -51,17 +51,25 @@ func (request *CreditControlRequest) FromCreditUsageUpdate(update *protos.Credit
 	request.UserLocation = update.UserLocation
 	request.ChargingCharacteristics = update.ChargingCharacteristics
 	request.Type = credit_control.CRTUpdate
-	request.Credits = []*UsedCredits{&UsedCredits{
-		RatingGroup:    update.Usage.ChargingKey,
-		InputOctets:    update.Usage.BytesTx, // transmit == input
-		OutputOctets:   update.Usage.BytesRx, // receive == output
-		TotalOctets:    update.Usage.BytesTx + update.Usage.BytesRx,
-		Type:           UsedCreditsType(update.Usage.Type),
-		RequestedUnits: update.Usage.GetRequestedUnits(),
+	request.Credits = []*UsedCredits{{
+		RatingGroup:       update.Usage.ChargingKey,
+		ServiceIdentifier: fromServiceIdentifier(update.Usage.ServiceIdentifier),
+		InputOctets:       update.Usage.BytesTx, // transmit == input
+		OutputOctets:      update.Usage.BytesRx, // receive == output
+		TotalOctets:       update.Usage.BytesTx + update.Usage.BytesRx,
+		Type:              UsedCreditsType(update.Usage.Type),
+		RequestedUnits:    update.Usage.GetRequestedUnits(),
 	}}
 	request.RatType = GetRATType(common.GetRatType())
 	request.TgppCtx = update.GetTgppCtx()
 	return request
+}
+
+func fromServiceIdentifier(si *protos.ServiceIdentifier) *uint32 {
+	if si == nil {
+		return nil
+	}
+	return &si.Value
 }
 
 func GetRATType(prt protos.RATType) string {

--- a/lte/cloud/go/services/policydb/obsidian/models/conversion.go
+++ b/lte/cloud/go/services/policydb/obsidian/models/conversion.go
@@ -178,6 +178,7 @@ func (m *PolicyRule) getConfig() *PolicyRuleConfig {
 		MonitoringKey:           m.MonitoringKey,
 		Priority:                m.Priority,
 		RatingGroup:             m.RatingGroup,
+		ServiceIdentifier:       m.ServiceIdentifier,
 		Redirect:                m.Redirect,
 		TrackingType:            m.TrackingType,
 		AppName:                 m.AppName,
@@ -200,6 +201,7 @@ func (m *PolicyRule) fillFromConfig(entConfig interface{}) *PolicyRule {
 	m.MonitoringKey = monKey
 	m.Priority = cfg.Priority
 	m.RatingGroup = cfg.RatingGroup
+	m.ServiceIdentifier = cfg.ServiceIdentifier
 	m.Redirect = cfg.Redirect
 	m.TrackingType = cfg.TrackingType
 	m.AppName = cfg.AppName
@@ -262,6 +264,7 @@ func (m *PolicyRuleConfig) ToProto(id string, qos *protos.FlowQos) *protos.Polic
 			protoMKey = []byte(m.MonitoringKey)
 		}
 	}
+
 	rule := &protos.PolicyRule{
 		Id:             id,
 		Priority:       swag.Uint32Value(m.Priority),
@@ -272,6 +275,9 @@ func (m *PolicyRuleConfig) ToProto(id string, qos *protos.FlowQos) *protos.Polic
 		AppServiceType: protos.PolicyRule_AppServiceType(protos.PolicyRule_AppServiceType_value[m.AppServiceType]),
 		HardTimeout:    0,
 		Qos:            qos,
+	}
+	if m.ServiceIdentifier != 0 {
+		rule.ServiceIdentifier = &protos.ServiceIdentifier{Value: m.ServiceIdentifier}
 	}
 	if m.Redirect != nil {
 		rule.Redirect = m.Redirect.ToProto()

--- a/lte/cloud/go/services/policydb/obsidian/models/policy_rule_config_swaggergen.go
+++ b/lte/cloud/go/services/policydb/obsidian/models/policy_rule_config_swaggergen.go
@@ -48,6 +48,9 @@ type PolicyRuleConfig struct {
 	// redirect
 	Redirect *RedirectInformation `json:"redirect,omitempty"`
 
+	// service identifier
+	ServiceIdentifier uint32 `json:"service_identifier,omitempty"`
+
 	// tracking type
 	// Enum: [ONLY_OCS ONLY_PCRF OCS_AND_PCRF NO_TRACKING]
 	TrackingType string `json:"tracking_type,omitempty"`

--- a/lte/cloud/go/services/policydb/obsidian/models/policy_rule_swaggergen.go
+++ b/lte/cloud/go/services/policydb/obsidian/models/policy_rule_swaggergen.go
@@ -58,6 +58,9 @@ type PolicyRule struct {
 	// redirect
 	Redirect *RedirectInformation `json:"redirect,omitempty"`
 
+	// service identifier
+	ServiceIdentifier uint32 `json:"service_identifier,omitempty"`
+
 	// tracking type
 	// Enum: [ONLY_OCS ONLY_PCRF OCS_AND_PCRF NO_TRACKING]
 	TrackingType string `json:"tracking_type,omitempty"`

--- a/lte/cloud/go/services/policydb/obsidian/models/swagger.v1.yml
+++ b/lte/cloud/go/services/policydb/obsidian/models/swagger.v1.yml
@@ -573,6 +573,9 @@ definitions:
         type: integer
         format: uint32
         default: 10
+      service_identifier:
+        type: integer
+        format: uint32
       rating_group:
         type: integer
         format: uint32
@@ -662,6 +665,9 @@ definitions:
         format: uint32
         default: 10
       rating_group:
+        type: integer
+        format: uint32
+      service_identifier:
         type: integer
         format: uint32
       monitoring_key:

--- a/orc8r/cloud/go/obsidian/swagger/v1/swagger.yml
+++ b/orc8r/cloud/go/obsidian/swagger/v1/swagger.yml
@@ -10601,6 +10601,9 @@ definitions:
         type: integer
       redirect:
         $ref: '#/definitions/redirect_information'
+      service_identifier:
+        format: uint32
+        type: integer
       tracking_type:
         enum:
         - ONLY_OCS
@@ -10670,6 +10673,9 @@ definitions:
         type: integer
       redirect:
         $ref: '#/definitions/redirect_information'
+      service_identifier:
+        format: uint32
+        type: integer
       tracking_type:
         enum:
         - ONLY_OCS


### PR DESCRIPTION
Signed-off-by: Oriol Batalla <obatalla@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary

backport https://github.com/magma/magma/pull/7545 and https://github.com/magma/magma/pull/7616 to provide support to service identifier on feg

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
