### PR TITLE
fix(agw): Change the location where metrics scraping callback is added

### DIFF
--- a/orc8r/gateway/python/magma/magmad/metrics_collector.py
+++ b/orc8r/gateway/python/magma/magmad/metrics_collector.py
@@ -282,6 +282,11 @@ class MetricsCollector(object):
                     self.scrape_done, future, target,
                 ),
             )
+        
+        self._loop.call_later(
+            target.interval,
+            self.scrape_prometheus_target, target,
+        )
 
     def scrape_done(self, collect_future, target):
         """
@@ -298,11 +303,6 @@ class MetricsCollector(object):
                 "Prometheus Target Metrics upload success: %s",
                 target.name,
             )
-
-        self._loop.call_later(
-            target.interval,
-            self.scrape_prometheus_target, target,
-        )
 
 
 def _parse_metrics_response(response_text: str) -> [metrics_pb2.MetricFamily]:


### PR DESCRIPTION
Signed-off-by: Karthik Subraveti <ksubraveti@fb.com>

## Summary

In the latest set of changes introduced by PR https://github.com/magma/magma/pull/7431, we added the ability to chunk grpc messages for the metrics collected from scrape targets. This however schedules same target to be scraped in the future done callback for each of the chunks. This is unnecessary and aggressive. This change moves the scrape target callback to be set in the original routine instead of scrape_done callback. 

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
