### PR TITLE
[lte][agw] Adding local service config for congestion control flag

### DIFF
--- a/lte/gateway/configs/mme.yml
+++ b/lte/gateway/configs/mme.yml
@@ -28,6 +28,7 @@ apn_correction_map_list:
         - imsi_prefix: "00101"
           apn_override: "magma.ipv4"
 
+congestion_control_enabled: true
 s1ap_zmq_th_us: 2000000  # delay threshold used for dropping initial UE message
 mme_app_zmq_congest_th_us: 100000  # delay threshold used for rejecting attach requests
 mme_app_zmq_auth_th_us: 200000  # delay threshold used for dropping Authentication Complete

--- a/lte/gateway/python/scripts/generate_oai_config.py
+++ b/lte/gateway/python/scripts/generate_oai_config.py
@@ -196,6 +196,7 @@ def _get_restricted_imeis(service_mconfig):
         return service_mconfig.restricted_imeis
     return {}
 
+
 def _get_service_area_maps(service_mconfig):
     if service_mconfig.service_area_maps:
       service_area_map = []
@@ -210,6 +211,7 @@ def _get_service_area_maps(service_mconfig):
       return service_area_map
     return {}
 
+
 def _get_congestion_control_config(service_mconfig):
     """
     Retrieves congestion_control_enabled config value, it it does not exist
@@ -219,6 +221,12 @@ def _get_congestion_control_config(service_mconfig):
 
     Returns: congestion control flag
     """
+    congestion_control_enabled = get_service_config_value(
+        'mme', 'congestion_control_enabled', None)
+
+    if congestion_control_enabled is not None:
+        return congestion_control_enabled
+
     if service_mconfig.congestion_control_enabled is not None:
         return service_mconfig.congestion_control_enabled
 


### PR DESCRIPTION
Signed-off-by: Alex Rodriguez <ardzoht@gmail.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->
- Adding local mme.yml config value for congestion_control flag 
- Updating `generate_oai_config` script to read value from service config

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->
- Tested locally on magma VM changing value on `/etc/magma/mme.yml`

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
