### PR TITLE
[feg] Diameter failed connection recovery (possible fix for issue #7496)

### DIFF
--- a/feg/gateway/go.mod
+++ b/feg/gateway/go.mod
@@ -46,6 +46,7 @@ require (
 	google.golang.org/grpc v1.33.2
 	google.golang.org/protobuf v1.26.0
 	gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776 // indirect
+	gotest.tools/gotestsum v1.6.4 // indirect
 	layeh.com/radius v0.0.0-20200615152116-663b41c3bf86
 	magma/feg/cloud/go v0.0.0
 	magma/feg/cloud/go/protos v0.0.0


### PR DESCRIPTION
Signed-off-by: Evgeniy Makeev <evgeniym@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary

Diameter failed connection recovery (possible fix for issue #7496)

## Test Plan
 unit tests; try to reproduce issue #7496
 
 From the latest PR build logs:
 ```
 session_proxy    | I0618 21:53:56.243525       1 impl.go:51] Mconfig refresh succeeded from: /var/opt/magma/configs/gateway.mconfig
session_proxy    | E0618 21:53:57.407516       1 diameter_client.go:164] diameter connection 172.16.1.13:3907->172.16.1.6:3868 error: diameter error on 172.16.1.6:3868: read tcp 172.16.1.13:3907->172.16.1.6:3868: use of closed network connection
session_proxy    | I0618 21:53:57.408293       1 connection.go:180] destroyed 172.16.1.13:3907->172.16.1.6:3868 connection
session_proxy    | I0618 21:53:57.409293       1 diameter_client.go:179] diameter connection 172.16.1.13:3907->172.16.1.6:3868 is successfully recovered
session_proxy    | I0618 21:54:00.374577       1 connection_manager.go:115] ConnectionManager: enabling connections
```
We were able to reproduce the issue in the lab & the introduced recovery logic seemed to fix the connection (reconnect) in less than 3 seconds.

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
