### PR TITLE
[NMS]Federation Network: Network page - Displaying Network information

### DIFF
--- a/nms/app/packages/magmalte/app/components/context/FEGNetworkContext.js
+++ b/nms/app/packages/magmalte/app/components/context/FEGNetworkContext.js
@@ -1,0 +1,27 @@
+/**
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @flow strict-local
+ * @format
+ */
+'use strict';
+import type {UpdateNetworkProps as FEGUpdateNetworkProps} from '../../state/feg/NetworkState';
+import type {feg_network} from '@fbcnms/magma-api';
+
+import React from 'react';
+
+export type FEGNetworkContextType = {
+  state: $Shape<feg_network>,
+  updateNetworks: (props: $Shape<FEGUpdateNetworkProps>) => Promise<void>,
+};
+
+export default React.createContext<FEGNetworkContextType>({});

--- a/nms/app/packages/magmalte/app/components/feg/FEGContext.js
+++ b/nms/app/packages/magmalte/app/components/feg/FEGContext.js
@@ -1,0 +1,94 @@
+/**
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @flow strict-local
+ * @format
+ */
+
+import * as React from 'react';
+import FEGNetworkContext from '../context/FEGNetworkContext';
+import LoadingFiller from '@fbcnms/ui/components/LoadingFiller';
+import MagmaV1API from '@fbcnms/magma-api/client/WebClient';
+import useMagmaAPI from '@fbcnms/ui/magma/useMagmaAPI';
+
+import type {feg_network, network_id, network_type} from '@fbcnms/magma-api';
+
+import {UpdateNetworkState as UpdateFegNetworkState} from '../../state/feg/NetworkState';
+import {useCallback, useState} from 'react';
+import {useEnqueueSnackbar} from '@fbcnms/ui/hooks/useSnackbar';
+
+type Props = {
+  networkId: network_id,
+  networkType: network_type,
+  children: React.Node,
+};
+
+/**
+ * Fetches and returns information about the federation network inside
+ * a context provider.
+ * @param {object} props: contains the network id and its type
+ */
+export function FEGNetworkContextProvider(props: Props) {
+  const {networkId} = props;
+  const [fegNetwork, setFegNetwork] = useState<$Shape<feg_network>>({});
+  const enqueueSnackbar = useEnqueueSnackbar();
+  const {error, isLoading} = useMagmaAPI(
+    MagmaV1API.getFegByNetworkId,
+    {networkId: networkId},
+    useCallback(response => setFegNetwork(response), []),
+  );
+
+  if (error) {
+    enqueueSnackbar?.('failed fetching network information', {
+      variant: 'error',
+    });
+  }
+
+  if (isLoading) {
+    return <LoadingFiller />;
+  }
+
+  return (
+    <FEGNetworkContext.Provider
+      value={{
+        state: fegNetwork,
+        updateNetworks: props => {
+          let refreshState = true;
+          if (networkId !== props.networkId) {
+            refreshState = false;
+          }
+          return UpdateFegNetworkState({
+            networkId,
+            setFegNetwork,
+            refreshState,
+            ...props,
+          });
+        },
+      }}>
+      {props.children}
+    </FEGNetworkContext.Provider>
+  );
+}
+/**
+ * A context provider for federation networks. It is used in sharing
+ * information like the network information or the gateways information.
+ * @param {object} props contains the network id and its type
+ */
+export function FEGContextProvider(props: Props) {
+  const {networkId, networkType} = props;
+
+  return (
+    <FEGNetworkContextProvider {...{networkId, networkType}}>
+      {props.children}
+    </FEGNetworkContextProvider>
+  );
+}

--- a/nms/app/packages/magmalte/app/components/feg/FEGSections.js
+++ b/nms/app/packages/magmalte/app/components/feg/FEGSections.js
@@ -23,6 +23,8 @@ import FEGConfigure from './FEGConfigure';
 import FEGDashboard from '../../views/dashboard/feg/FEGDashboard';
 import FEGGateways from './FEGGateways';
 import FEGMetrics from './FEGMetrics';
+import FEGNetworkDashboard from '../../views/network/FEGNetworkDashboard';
+import NetworkCheckIcon from '@material-ui/icons/NetworkCheck';
 import React from 'react';
 import SettingsCellIcon from '@material-ui/icons/SettingsCell';
 import ShowChartIcon from '@material-ui/icons/ShowChart';
@@ -34,6 +36,12 @@ export function getFEGSections(dashboardV2Enabled: boolean): SectionsConfigs {
       label: 'Gateways',
       icon: <CellWifiIcon />,
       component: FEGGateways,
+    },
+    {
+      path: 'network',
+      label: 'Network',
+      icon: <NetworkCheckIcon />,
+      component: FEGNetworkDashboard,
     },
     {
       path: 'configure',

--- a/nms/app/packages/magmalte/app/components/layout/__tests__/useSections-test.js
+++ b/nms/app/packages/magmalte/app/components/layout/__tests__/useSections-test.js
@@ -86,7 +86,7 @@ const testCases: {[string]: TestCase} = {
   },
   feg: {
     default: 'gateways',
-    sections: ['gateways', 'configure', 'alerts', 'metrics'],
+    sections: ['gateways', 'network', 'configure', 'alerts', 'metrics'],
   },
   carrier_wifi_network: {
     default: 'gateways',

--- a/nms/app/packages/magmalte/app/components/main/Index.js
+++ b/nms/app/packages/magmalte/app/components/main/Index.js
@@ -16,10 +16,13 @@
 
 import MagmaV1API from '@fbcnms/magma-api/client/WebClient';
 
+import {FEG} from '@fbcnms/types/network';
+import {FEGContextProvider} from '../feg/FEGContext';
 import {LteContextProvider} from '../lte/LteContext';
 import {coalesceNetworkType} from '@fbcnms/types/network';
 import type {NetworkType} from '@fbcnms/types/network';
 import type {Theme} from '@material-ui/core';
+import type {network_id, network_type} from '@fbcnms/magma-api';
 
 import * as React from 'react';
 import AppContent from '../layout/AppContent';
@@ -54,6 +57,12 @@ const useStyles = makeStyles((theme: Theme) => ({
   },
 }));
 
+type Props = {
+  networkId: network_id,
+  networkType: network_type,
+  children: React.Node,
+};
+
 export default function Index() {
   const classes = useStyles();
   const {match} = useRouter();
@@ -81,24 +90,47 @@ export default function Index() {
   }
 
   return (
+    <NetworkContextProvider {...{networkId, networkType}}>
+      <div className={classes.root}>
+        <AppSideBar
+          mainItems={[<SectionLinks key={1} />, <VersionTooltip key={2} />]}
+          secondaryItems={[<NetworkSelector key={1} />]}
+          projects={getProjectLinks(tabs, user)}
+          showSettings={shouldShowSettings({
+            isSuperUser: user.isSuperUser,
+            ssoEnabled,
+          })}
+          user={user}
+        />
+        <AppContent>
+          <SectionRoutes />
+        </AppContent>
+      </div>
+    </NetworkContextProvider>
+  );
+}
+
+/**
+ * Returns a Federation context provider if it is a federation network. It
+ * otherwise returns a LTE context provider for a LTE or Federated LTE network.
+ *
+ * @param {network_id} network_id Id of the network
+ * @param {network_type} network_type Type of the network
+ */
+function NetworkContextProvider(props: Props) {
+  const {networkId, networkType} = props;
+
+  return (
     <NetworkContext.Provider value={{networkId, networkType}}>
-      <LteContextProvider networkId={networkId} networkType={networkType}>
-        <div className={classes.root}>
-          <AppSideBar
-            mainItems={[<SectionLinks key={1} />, <VersionTooltip key={2} />]}
-            secondaryItems={[<NetworkSelector key={1} />]}
-            projects={getProjectLinks(tabs, user)}
-            showSettings={shouldShowSettings({
-              isSuperUser: user.isSuperUser,
-              ssoEnabled,
-            })}
-            user={user}
-          />
-          <AppContent>
-            <SectionRoutes />
-          </AppContent>
-        </div>
-      </LteContextProvider>
+      {networkType === FEG ? (
+        <FEGContextProvider networkId={networkId} networkType={networkType}>
+          {props.children}
+        </FEGContextProvider>
+      ) : (
+        <LteContextProvider networkId={networkId} networkType={networkType}>
+          {props.children}
+        </LteContextProvider>
+      )}
     </NetworkContext.Provider>
   );
 }

--- a/nms/app/packages/magmalte/app/state/feg/NetworkState.js
+++ b/nms/app/packages/magmalte/app/state/feg/NetworkState.js
@@ -24,6 +24,7 @@ import MagmaV1API from '@fbcnms/magma-api/client/WebClient';
 
 export type UpdateNetworkProps = {
   networkId: network_id,
+  fegNetwork?: feg_network,
   subscriberConfig?: network_subscriber_config,
   setFegNetwork: feg_network => void,
   refreshState: boolean,
@@ -32,6 +33,16 @@ export type UpdateNetworkProps = {
 export async function UpdateNetworkState(props: UpdateNetworkProps) {
   const {networkId, setFegNetwork} = props;
   const requests = [];
+  if (props.fegNetwork) {
+    requests.push(
+      await MagmaV1API.putFegByNetworkId({
+        networkId: networkId,
+        fegNetwork: {
+          ...props.fegNetwork,
+        },
+      }),
+    );
+  }
   if (props.subscriberConfig) {
     requests.push(
       await MagmaV1API.putFegByNetworkIdSubscriberConfig({

--- a/nms/app/packages/magmalte/app/views/network/FEGNetworkDashboard.js
+++ b/nms/app/packages/magmalte/app/views/network/FEGNetworkDashboard.js
@@ -1,0 +1,155 @@
+/*
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @flow strict-local
+ * @format
+ */
+
+import Button from '@material-ui/core/Button';
+import CardTitleRow from '../../components/layout/CardTitleRow';
+import FEGNetworkContext from '../../components/context/FEGNetworkContext';
+import FEGNetworkInfo from './FEGNetworkInfo';
+import Grid from '@material-ui/core/Grid';
+import JsonEditor from '../../components/JsonEditor';
+import React from 'react';
+import TopBar from '../../components/TopBar';
+import nullthrows from '@fbcnms/util/nullthrows';
+
+import {NetworkCheck} from '@material-ui/icons';
+import {Redirect, Route, Switch} from 'react-router-dom';
+import {colors, typography} from '../../theme/default';
+import {makeStyles} from '@material-ui/styles';
+import {useContext, useState} from 'react';
+import {useEnqueueSnackbar} from '@fbcnms/ui/hooks/useSnackbar';
+import {useRouter} from '@fbcnms/ui/hooks';
+
+const useStyles = makeStyles(theme => ({
+  dashboardRoot: {
+    margin: theme.spacing(5),
+  },
+  appBarBtn: {
+    color: colors.primary.white,
+    background: colors.primary.comet,
+    fontFamily: typography.button.fontFamily,
+    fontWeight: typography.button.fontWeight,
+    fontSize: typography.button.fontSize,
+    lineHeight: typography.button.lineHeight,
+    letterSpacing: typography.button.letterSpacing,
+
+    '&:hover': {
+      background: colors.primary.mirage,
+    },
+  },
+}));
+
+/**
+ * Returns the network page of a federation network. It consists of top
+ * bar, which has a button to navigate to the json configuration and a
+ * network information section.
+ */
+export default function NetworkDashboard() {
+  const classes = useStyles();
+  const {history, relativePath, relativeUrl} = useRouter();
+  const ctx = useContext(FEGNetworkContext);
+
+  return (
+    <>
+      <TopBar
+        header="Network"
+        tabs={[
+          {
+            label: ctx?.state?.id || 'Network',
+            to: '/network',
+            icon: NetworkCheck,
+            filters: (
+              <Grid
+                container
+                justify="flex-end"
+                alignItems="center"
+                spacing={2}>
+                <Grid item>
+                  <Button
+                    className={classes.appBarBtn}
+                    onClick={() => {
+                      history.push(relativeUrl('/json'));
+                    }}>
+                    Edit JSON
+                  </Button>
+                </Grid>
+              </Grid>
+            ),
+          },
+        ]}
+      />
+      <Switch>
+        <Route path={relativePath('/json')} component={NetworkJsonConfig} />
+        <Route
+          path={relativePath('/network')}
+          component={NetworkDashboardInternal}
+        />
+        <Redirect to={relativeUrl('/network')} />
+      </Switch>
+    </>
+  );
+}
+
+/**
+ * Returns a json config page which allows a user to edit the network
+ * information.
+ */
+export function NetworkJsonConfig() {
+  const {match} = useRouter();
+  const [error, setError] = useState('');
+  const networkId: string = nullthrows(match.params.networkId);
+  const enqueueSnackbar = useEnqueueSnackbar();
+  const ctx = useContext(FEGNetworkContext);
+
+  return (
+    <JsonEditor
+      content={ctx.state}
+      error={error}
+      onSave={async fegNetwork => {
+        try {
+          ctx.updateNetworks({networkId, fegNetwork});
+          enqueueSnackbar('Network saved successfully', {
+            variant: 'success',
+          });
+          setError('');
+        } catch (e) {
+          setError(e.response?.data?.message ?? e.message);
+        }
+      }}
+    />
+  );
+}
+
+/**
+ * Returns information about the federation network and a table of the servicing
+ * access gateways alongside the serviced networks they are under.
+ */
+export function NetworkDashboardInternal() {
+  const classes = useStyles();
+  const ctx = useContext(FEGNetworkContext);
+
+  return (
+    <div className={classes.dashboardRoot}>
+      <Grid container spacing={4}>
+        <Grid item xs={12} md={6}>
+          <Grid item xs={12}>
+            <CardTitleRow label="Network" />
+            <FEGNetworkInfo fegNetwork={ctx.state} />
+          </Grid>
+        </Grid>
+      </Grid>
+    </div>
+  );
+}

--- a/nms/app/packages/magmalte/app/views/network/FEGNetworkInfo.js
+++ b/nms/app/packages/magmalte/app/views/network/FEGNetworkInfo.js
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @flow strict-local
+ * @format
+ */
+
+import type {DataRows} from '../../components/DataGrid';
+import type {feg_network} from '@fbcnms/magma-api';
+
+import DataGrid from '../../components/DataGrid';
+import React from 'react';
+
+type Props = {
+  fegNetwork: $Shape<feg_network>,
+};
+
+/**
+ * Returns information about the federation network.
+ * @param {object} props: has a property called fegNetwork that has
+ * information about the federation network.
+ */
+export default function NetworkInfo(props: Props) {
+  const kpiData: DataRows[] = [
+    [
+      {
+        category: 'ID',
+        value: props.fegNetwork.id,
+      },
+    ],
+    [
+      {
+        category: 'Name',
+        value: props.fegNetwork.name,
+      },
+    ],
+    [
+      {
+        category: 'Description',
+        value: props.fegNetwork.description || '-',
+      },
+    ],
+    [
+      {
+        category: 'Served Federated LTE Network IDs',
+        value: props.fegNetwork?.federation?.served_network_ids?.join() || '-',
+        tooltip:
+          'List of Federated LTE Network IDs serviced under this federation network',
+      },
+    ],
+    [
+      {
+        category: 'Served Virtual Federation Network IDs',
+        value: props.fegNetwork?.federation?.served_nh_ids?.join() || '-',
+        tooltip:
+          'List of Neutral Host (or Virtual) Federation Networks IDs serviced under this federation network',
+      },
+    ],
+  ];
+  return <DataGrid data={kpiData} testID="feg_info" />;
+}


### PR DESCRIPTION
<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary
This is a draft PR because it is a stacked pr upon an exisiting open PR #7502. Once, that PR is approved, this PR would get rebased and would be changed from draft to a normal PR. A network page was created for the federation network. The network page was hooked up to an existing JSON Edit component for editing the network. A new Network info component was created which simply displays the id, description, name and federation of the network. Also, a context provider was created for sharing the network information between different pages instead of fetching the data.
<!-- Enumerate changes you made and why you made them -->

## Test Plan
A test was added under NetworkTest.js file to test that the new network info component displays correct information about the network. 
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information
![Screen Shot 2021-06-17 at 4 00 16 PM](https://user-images.githubusercontent.com/34602743/122465673-5f843800-cf86-11eb-8ae4-b5c28889b107.png)
![Screen Shot 2021-06-17 at 4 00 38 PM](https://user-images.githubusercontent.com/34602743/122465684-6317bf00-cf86-11eb-8f57-aba6c3b2b090.png)


<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
