### PR TITLE
[NMS] Full Network page: Including Servicing Access Gateway Table

### DIFF
--- a/nms/app/packages/magmalte/app/components/GatewayUtils.js
+++ b/nms/app/packages/magmalte/app/components/GatewayUtils.js
@@ -177,6 +177,10 @@ type GatewayStatusPayload = {
 
 const GATEWAY_KEEPALIVE_TIMEOUT_MS = 1000 * 5 * 60;
 
+export const HEALTHY_GATEWAY = 'Good';
+
+export const UNHEALTHY_GATEWAY = 'Bad';
+
 export default function isGatewayHealthy({status}: lte_gateway) {
   if (status != null) {
     const checkin = status.checkin_time;

--- a/nms/app/packages/magmalte/app/views/network/FEGNetworkDashboard.js
+++ b/nms/app/packages/magmalte/app/views/network/FEGNetworkDashboard.js
@@ -18,6 +18,7 @@ import Button from '@material-ui/core/Button';
 import CardTitleRow from '../../components/layout/CardTitleRow';
 import FEGNetworkContext from '../../components/context/FEGNetworkContext';
 import FEGNetworkInfo from './FEGNetworkInfo';
+import FEGServicingAccessGatewayTable from './FEGServicingAccessGatewayTable';
 import Grid from '@material-ui/core/Grid';
 import JsonEditor from '../../components/JsonEditor';
 import React from 'react';
@@ -147,6 +148,14 @@ export function NetworkDashboardInternal() {
           <Grid item xs={12}>
             <CardTitleRow label="Network" />
             <FEGNetworkInfo fegNetwork={ctx.state} />
+          </Grid>
+        </Grid>
+        <Grid item xs={12} md={6}>
+          <Grid container spacing={4}>
+            <Grid item xs={12}>
+              <CardTitleRow label="Servicing Access Gateways" />
+              <FEGServicingAccessGatewayTable />
+            </Grid>
           </Grid>
         </Grid>
       </Grid>

--- a/nms/app/packages/magmalte/app/views/network/FEGServicingAccessGatewayTable.js
+++ b/nms/app/packages/magmalte/app/views/network/FEGServicingAccessGatewayTable.js
@@ -1,0 +1,169 @@
+/*
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @flow strict-local
+ * @format
+ */
+
+import type {EnqueueSnackbarOptions} from 'notistack';
+import type {
+  feg_lte_network,
+  gateway_id,
+  gateway_name,
+  lte_gateway,
+  network_id,
+  network_name,
+} from '@fbcnms/magma-api';
+
+import ActionTable from '../../components/ActionTable';
+import Link from '@material-ui/core/Link';
+import LoadingFiller from '@fbcnms/ui/components/LoadingFiller';
+import React, {useEffect, useState} from 'react';
+import isGatewayHealthy from '../../components/GatewayUtils';
+import nullthrows from '@fbcnms/util/nullthrows';
+
+import {FetchGateways} from '../../state/lte/EquipmentState';
+import {
+  HEALTHY_GATEWAY,
+  UNHEALTHY_GATEWAY,
+} from '../../components/GatewayUtils';
+import {getServicedAccessNetworks} from '../../components/FEGServicingAccessGatewayKPIs';
+import {useEnqueueSnackbar} from '@fbcnms/ui/hooks/useSnackbar';
+import {useRouter} from '@fbcnms/ui/hooks';
+
+type ServicingAccessGatewayRowType = {
+  networkId: network_id,
+  networkName: network_name,
+  gatewayId: gateway_id,
+  gatewayName: gateway_name,
+  gatewayHealth: string,
+};
+
+/**
+ * Returns an array which holds information about each serviced
+ * access gateways servicied by this federation network.
+ * The information about the serviced gateways includes the gateway
+ * id, name, network name & network id under which the gateway exists.
+ *
+ * @param {Array<feg_lte_network>} servicedAccessNetworks List of federated LTE networks serviced by this federation network.
+ * @param {(msg, cfg) => ?(string | number),} enqueueSnackbar A snackbar to display errors.
+ * @returns An Array of the serviced access gateways with information about each.
+ */
+async function getServicedAccessGatewaysInfo(
+  servicedAccessNetworks: Array<feg_lte_network>,
+  enqueueSnackbar: (
+    msg: string,
+    cfg: EnqueueSnackbarOptions,
+  ) => ?(string | number),
+): Promise<Array<ServicingAccessGatewayRowType>> {
+  const newServicedAccessGatewaysInfo = [];
+  for (const servicedAccessNetwork of servicedAccessNetworks) {
+    const servicedAccessGateways: {
+      [string]: lte_gateway,
+    } = await FetchGateways({
+      networkId: servicedAccessNetwork.id,
+      undefined,
+      enqueueSnackbar,
+    });
+    //Add the gateways of the serviced network
+    Object.keys(servicedAccessGateways).map(servicedAccessGatewayId => {
+      const newServicedAccessGatewayInfo: ServicingAccessGatewayRowType = {
+        networkId: servicedAccessNetwork.id,
+        networkName: servicedAccessNetwork.name,
+        gatewayId: servicedAccessGatewayId,
+        gatewayName:
+          servicedAccessGateways[servicedAccessGatewayId]?.name || '',
+        gatewayHealth: isGatewayHealthy(
+          servicedAccessGateways[servicedAccessGatewayId] || {},
+        )
+          ? HEALTHY_GATEWAY
+          : UNHEALTHY_GATEWAY,
+      };
+      newServicedAccessGatewaysInfo.push(newServicedAccessGatewayInfo);
+    });
+  }
+  return newServicedAccessGatewaysInfo;
+}
+
+/**
+ * Returns a table consisting of the serviced access gateways alongside
+ * the serviced network in which they are under.
+ */
+export default function ServicingAccessGatewayInfo() {
+  const {match} = useRouter();
+  const enqueueSnackbar = useEnqueueSnackbar();
+  const networkId: string = nullthrows(match.params.networkId);
+  const [servicedAccessGatewaysInfo, setServicedAccessGatewaysInfo] = useState<
+    Array<ServicingAccessGatewayRowType>,
+  >([]);
+  const [isLoading, setIsLoading] = useState(true);
+
+  useEffect(() => {
+    const fetchServicedAccessGateways = async () => {
+      try {
+        const servicedAccessNetworks = await getServicedAccessNetworks(
+          networkId,
+          enqueueSnackbar,
+        );
+        const newServicedAccessGatewaysInfo = await getServicedAccessGatewaysInfo(
+          servicedAccessNetworks,
+          enqueueSnackbar,
+        );
+        setServicedAccessGatewaysInfo(newServicedAccessGatewaysInfo);
+        setIsLoading(false);
+      } catch (e) {
+        enqueueSnackbar?.(
+          'failed fetching servicing access gateway information',
+          {
+            variant: 'error',
+          },
+        );
+      }
+    };
+    fetchServicedAccessGateways();
+  }, [networkId, enqueueSnackbar]);
+  if (isLoading) {
+    return <LoadingFiller />;
+  }
+  return (
+    <div>
+      <ActionTable
+        data={servicedAccessGatewaysInfo}
+        columns={[
+          {title: 'Access Network', field: 'networkName'},
+          {title: 'Access Gateway Id', field: 'gatewayId'},
+          {
+            title: 'Access Gateway Name',
+            field: 'gatewayName',
+            render: currRow => (
+              <Link
+                variant="body2"
+                component="button"
+                onClick={() => {
+                  window.open(
+                    `${window.location.origin}/nms/${currRow.networkId}/equipment/overview/gateway/${currRow.gatewayId}`,
+                  );
+                }}>
+                {currRow.gatewayName}
+              </Link>
+            ),
+          },
+          {title: 'Access Gateway Health', field: 'gatewayHealth'},
+        ]}
+        options={{
+          actionsColumnIndex: -1,
+          pageSizeOptions: [5, 10],
+        }}
+      />
+    </div>
+  );
+}

--- a/nms/app/packages/magmalte/app/views/network/__tests__/FEGServicingAccessGatewayTableTest.js
+++ b/nms/app/packages/magmalte/app/views/network/__tests__/FEGServicingAccessGatewayTableTest.js
@@ -1,0 +1,238 @@
+/**
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @flow strict-local
+ * @format
+ */
+
+import 'jest-dom/extend-expect';
+import FEGNetworkContext from '../../../components/context/FEGNetworkContext';
+import FEGServicingAccessGatewaysTable from '../FEGServicingAccessGatewayTable';
+import MagmaAPIBindings from '@fbcnms/magma-api';
+import MuiStylesThemeProvider from '@material-ui/styles/ThemeProvider';
+import React from 'react';
+import axiosMock from 'axios';
+import defaultTheme from '@fbcnms/ui/theme/default';
+import {MemoryRouter, Route} from 'react-router-dom';
+import {MuiThemeProvider} from '@material-ui/core/styles';
+import {cleanup, render, wait} from '@testing-library/react';
+import type {
+  feg_lte_network,
+  feg_network,
+  lte_gateway,
+} from '@fbcnms/magma-api';
+
+afterEach(cleanup);
+
+const mockFegLteNetworks: Array<string> = [
+  'test_network1',
+  'test_network2',
+  'test_network3',
+];
+
+const mockFegLteNetwork: feg_lte_network = {
+  cellular: {
+    epc: {
+      gx_gy_relay_enabled: false,
+      hss_relay_enabled: false,
+      lte_auth_amf: '',
+      lte_auth_op: '',
+      mcc: '',
+      mnc: '',
+      tac: 1,
+    },
+    ran: {
+      bandwidth_mhz: 20,
+    },
+  },
+  description: 'I am a test federated lte network',
+  dns: {
+    enable_caching: false,
+    local_ttl: 0,
+  },
+  federation: {
+    feg_network_id: 'mynetwork',
+  },
+  id: 'test_network1',
+  name: 'test network1',
+};
+
+const mockGw1: lte_gateway = {
+  id: 'test_gw1',
+  name: 'test gateway1',
+  description: 'hello I am a gateway',
+  tier: 'default',
+  device: {
+    key: {key: '', key_type: 'SOFTWARE_ECDSA_SHA256'},
+    hardware_id: '',
+  },
+  magmad: {
+    autoupgrade_enabled: true,
+    autoupgrade_poll_interval: 300,
+    checkin_interval: 60,
+    checkin_timeout: 100,
+    tier: 'tier2',
+  },
+  connected_enodeb_serials: [],
+  cellular: {
+    epc: {
+      ip_block: '192.168.0.1/24',
+      nat_enabled: true,
+    },
+    ran: {
+      pci: 620,
+      transmit_enabled: true,
+    },
+  },
+  status: {
+    checkin_time: 0,
+    meta: {
+      gps_latitude: '0',
+      gps_longitude: '0',
+      gps_connected: '0',
+      enodeb_connected: '0',
+      mme_connected: '0',
+    },
+  },
+};
+
+jest.mock('axios');
+jest.mock('@fbcnms/magma-api');
+jest.mock('@fbcnms/ui/hooks/useSnackbar');
+
+describe('<ServicingAccessGatewaysInfo />', () => {
+  const testNetwork: feg_network = {
+    description: 'Test Network Description',
+    federation: {
+      aaa_server: {},
+      eap_aka: {},
+      gx: {},
+      gy: {},
+      health: {},
+      hss: {},
+      s6a: {},
+      served_network_ids: [],
+      swx: {},
+    },
+    id: 'mynetwork',
+    name: 'Test Network',
+    dns: {
+      enable_caching: false,
+      local_ttl: 0,
+      records: [],
+    },
+  };
+  const mockFegLteNetwork2 = {
+    ...mockFegLteNetwork,
+    federation: {feg_network_id: ''},
+    id: 'test_network2',
+    name: 'test network2',
+  };
+  const mockFegLteNetwork3 = {
+    ...mockFegLteNetwork,
+    id: 'test_network3',
+    name: 'test network3',
+  };
+  const mockGw2 = {...mockGw1, id: 'test_gw2', name: 'test gateway2'};
+  const mockGw3 = {
+    ...mockGw1,
+    id: 'test_gw3',
+    name: 'test gateway3',
+    status: {checkin_time: Date.now()},
+  };
+  beforeEach(() => {
+    MagmaAPIBindings.getFegLte.mockResolvedValue(mockFegLteNetworks);
+    MagmaAPIBindings.getFegLteByNetworkId
+      .mockReturnValueOnce(mockFegLteNetwork)
+      .mockReturnValueOnce(mockFegLteNetwork2)
+      .mockResolvedValue(mockFegLteNetwork3);
+    MagmaAPIBindings.getLteByNetworkIdGateways
+      .mockReturnValueOnce({
+        [mockGw1.id]: mockGw1,
+        [mockGw2.id]: mockGw2,
+      })
+      .mockResolvedValue({[mockGw3.id]: mockGw3});
+  });
+
+  afterEach(() => {
+    axiosMock.get.mockClear();
+  });
+
+  const Wrapper = () => {
+    const networkCtx = {
+      state: {
+        ...testNetwork,
+      },
+      updateNetworks: async _ => {},
+    };
+    return (
+      <MemoryRouter
+        initialEntries={['/nms/mynetwork/network']}
+        initialIndex={0}>
+        <MuiThemeProvider theme={defaultTheme}>
+          <MuiStylesThemeProvider theme={defaultTheme}>
+            <FEGNetworkContext.Provider value={networkCtx}>
+              <Route
+                path="/nms/:networkId/network/"
+                render={props => <FEGServicingAccessGatewaysTable {...props} />}
+              />
+            </FEGNetworkContext.Provider>
+          </MuiStylesThemeProvider>
+        </MuiThemeProvider>
+      </MemoryRouter>
+    );
+  };
+  it('renders serviced access gateway table correctly', async () => {
+    const {getAllByRole} = render(<Wrapper />);
+    await wait();
+    //first get list of feg_lte networks
+    expect(MagmaAPIBindings.getFegLte).toHaveBeenCalledTimes(1);
+    //get info about each feg_lte network
+    expect(MagmaAPIBindings.getFegLteByNetworkId).toHaveBeenCalledTimes(3);
+    expect(MagmaAPIBindings.getFegLteByNetworkId).toHaveBeenCalledWith({
+      networkId: mockFegLteNetwork.id,
+    });
+    expect(MagmaAPIBindings.getFegLteByNetworkId).toHaveBeenCalledWith({
+      networkId: mockFegLteNetwork2.id,
+    });
+    expect(MagmaAPIBindings.getFegLteByNetworkId).toHaveBeenCalledWith({
+      networkId: mockFegLteNetwork3.id,
+    });
+    //only 2 of the 3 feg_lte networks are serviced by current network
+    expect(MagmaAPIBindings.getLteByNetworkIdGateways).toHaveBeenCalledTimes(2);
+    expect(MagmaAPIBindings.getLteByNetworkIdGateways).toHaveBeenCalledWith({
+      networkId: mockFegLteNetwork.id,
+    });
+    expect(MagmaAPIBindings.getLteByNetworkIdGateways).toHaveBeenCalledWith({
+      networkId: mockFegLteNetwork3.id,
+    });
+    const rowItems = await getAllByRole('row');
+    // first row is the header
+    expect(rowItems[0]).toHaveTextContent('Access Network');
+    expect(rowItems[0]).toHaveTextContent('Access Gateway Id');
+    expect(rowItems[0]).toHaveTextContent('Access Gateway Name');
+    expect(rowItems[0]).toHaveTextContent('Access Gateway Health');
+    //only network 1(with 2 gateways) and network 3 (1 gateway) are serviced
+    expect(rowItems[1]).toHaveTextContent('test network1');
+    expect(rowItems[1]).toHaveTextContent('test_gw1');
+    expect(rowItems[1]).toHaveTextContent('test gateway1');
+    expect(rowItems[1]).toHaveTextContent('Bad');
+    expect(rowItems[2]).toHaveTextContent('test network1');
+    expect(rowItems[2]).toHaveTextContent('test_gw2');
+    expect(rowItems[2]).toHaveTextContent('test gateway2');
+    expect(rowItems[2]).toHaveTextContent('Bad');
+    expect(rowItems[3]).toHaveTextContent('test network3');
+    expect(rowItems[3]).toHaveTextContent('test_gw3');
+    expect(rowItems[3]).toHaveTextContent('test gateway3');
+    expect(rowItems[3]).toHaveTextContent('Good');
+  });
+});


### PR DESCRIPTION
<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary
This is a draft PR because it is a stacked pr upon an exisiting open PR #7641. Once, that PR is approved, this PR would get rebased and would be changed from draft to a normal PR. Servicing access gateway table was added to the network page. Since servicing access gateways had a potential to be a large number, the gateway names and the network they are under were fetched and displayed in a table.
<!-- Enumerate changes you made and why you made them -->

## Test Plan
A test file was created which verifies that all of the serviced access gateways are found under the table.  


<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information
![Screen Shot 2021-06-24 at 3 22 23 PM](https://user-images.githubusercontent.com/34602743/123320726-23aa1f00-d500-11eb-8bcc-14fc8f4ec02e.png)



<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
