### PR TITLE
[nms][fuji] Fix NMS users & organizations not being created

### DIFF
--- a/nms/app/packages/magmalte/package.json
+++ b/nms/app/packages/magmalte/package.json
@@ -33,7 +33,7 @@
     "@fbcnms/magma-api": "^0.1.0",
     "@fbcnms/platform-server": "^0.1.27",
     "@fbcnms/projects": "^0.1.0",
-    "@fbcnms/sequelize-models": "^0.1.8",
+    "@fbcnms/sequelize-models": "^0.1.9",
     "@fbcnms/strings": "^0.1.0",
     "@fbcnms/types": "^0.1.11",
     "@fbcnms/ui": "^0.1.11",

--- a/nms/app/packages/magmalte/scripts/fuji-upgrade/runs-on-nms.sh
+++ b/nms/app/packages/magmalte/scripts/fuji-upgrade/runs-on-nms.sh
@@ -44,11 +44,11 @@ done
 
 cat << EOF
 --------------------------------------------------------------------------------
-              Upgrading @fbcnms/sequelize-models to ^0.1.7
+              Upgrading @fbcnms/sequelize-models to ^0.1.9
 --------------------------------------------------------------------------------
 EOF
 pushd /usr/src/packages/magmalte
-yarn upgrade @fbcnms/sequelize-models@^0.1.7
+yarn upgrade @fbcnms/sequelize-models@^0.1.9
 yarn
 popd
 cat << EOF


### PR DESCRIPTION
Signed-off-by: Andrei Lee <andreilee@fb.com>

## Summary

Added a fix for #6851 

To apply this fix for v1.5.0 and v1.5.1, run the provided script (after this merges):

`wget https://raw.githubusercontent.com/magma/magma/master/nms/app/packages/magmalte/scripts/fuji-fix/post-upgrade-fix.sh && chmod +x post-upgrade-fix.sh && ./post-upgrade-fix.sh.sh`

## Test Plan

N/A (dependency on `@fbcnms/sequelize-models` v0.1.9

## Additional Information

- [ ] This change is backwards-breaking
