### PR TITLE
fix(datapath): bring up patch-up port on startup

### DIFF
--- a/lte/gateway/python/scripts/config_stateless_agw.py
+++ b/lte/gateway/python/scripts/config_stateless_agw.py
@@ -164,9 +164,11 @@ def ovs_reset_bridges():
         "ovs-vsctl --all destroy Flow_Sample_Collector_Set".split())
     subprocess.call("ifdown uplink_br0".split())
     subprocess.call("ifdown gtp_br0".split())
+    subprocess.call("ifdown patch-up".split())
     subprocess.call("service openvswitch-switch restart".split())
     subprocess.call("ifup uplink_br0".split())
     subprocess.call("ifup gtp_br0".split())
+    subprocess.call("ifup patch-up".split())
 
 
 def sctpd_pre_start():


### PR DESCRIPTION
In some cases we have seen patch-up port inconsistencies, it
results in crash loop due to bridge error. Following patch
fixes the issue by manually briging the port down when
bridge is down.

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->

## Test Plan
validated in lab setup.
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
