### PR TITLE
[component:agw] UE Data clean up in Deregister

### DIFF
--- a/lte/gateway/c/oai/tasks/ngap/ngap_amf_handlers.c
+++ b/lte/gateway/c/oai/tasks/ngap/ngap_amf_handlers.c
@@ -1150,7 +1150,7 @@ int ngap_handle_ue_context_release_command(
         ue_context_release_command_pP->cause ==
             NGAP_INITIAL_CONTEXT_SETUP_TMR_EXPRD ||
         ue_context_release_command_pP->cause == NGAP_INVALID_GNB_ID) {
-      // ngap_remove_ue(state, ue_ref_p);
+      ngap_remove_ue(state, ue_ref_p);
     } else {
       rc = ngap_amf_generate_ue_context_release_command(
           state, ue_ref_p, ue_context_release_command_pP->cause, imsi64);
@@ -1564,7 +1564,7 @@ void ngap_amf_handle_ue_context_rel_comp_timer_expiry(
   OAILOG_DEBUG_UE(
       LOG_NGAP, imsi64, "Removed NGAP UE " AMF_UE_NGAP_ID_FMT "\n",
       (uint32_t) ue_ref_p->amf_ue_ngap_id);
-  // ngap_remove_ue(state, ue_ref_p);
+  ngap_remove_ue(state, ue_ref_p);
 
   hashtable_uint64_ts_remove(
       imsi_map->amf_ue_id_imsi_htbl,
@@ -1601,7 +1601,7 @@ void ngap_amf_release_ue_context(
       LOG_NGAP, imsi64, "Removed NGAP UE " AMF_UE_NGAP_ID_FMT "\n",
       (uint32_t) ue_ref_p->amf_ue_ngap_id);
 
-  // ngap_remove_ue(state, ue_ref_p);
+  ngap_remove_ue(state, ue_ref_p);
   OAILOG_FUNC_OUT(LOG_NGAP);
 }
 

--- a/lte/gateway/c/oai/tasks/ngap/ngap_amf_nas_procedures.c
+++ b/lte/gateway/c/oai/tasks/ngap/ngap_amf_nas_procedures.c
@@ -103,7 +103,7 @@ int ngap_amf_handle_initial_ue_message(
         .plmn         = {0},
         .amf_set_id   = 0,
         .amf_regionid = 0};  // initialized after
-                             //.plmn = {0}, .amf_code = 0, .amf_gid = 0};  //
+                             //{.plmn = {0}, .amf_code = 0, .amf_gid = 0};  //
                              // initialized after
     s_tmsi_m5_t s_tmsi = {.amf_set_id = 0, .m_tmsi = INVALID_M_TMSI};
     ecgi_t ecgi        = {.plmn = {0}, .cell_identity = {0}};

--- a/lte/gateway/python/magma/pipelined/app/enforcement_stats.py
+++ b/lte/gateway/python/magma/pipelined/app/enforcement_stats.py
@@ -509,8 +509,8 @@ class EnforcementStatsController(PolicyMixin, RestartMixin, MagmaController):
             return
         #Report only if their is no change in version
         if self.ng_config.ng_service_enabled == True and mark_flow_deleted == False:
-            self._prepare_session_config_report(stats_msgs)
-
+            #self._prepare_session_config_report(stats_msgs)
+            self.logger.debug(" No Reporting ")
 
     def deactivate_default_flow(self, imsi, ip_addr):
         if self._datapath is None:


### PR DESCRIPTION
Fix:
  1. Remove UE from the hash table during de-register
  2. Comment out the monitor thread in Pipelined.
     Reason being SMF needs the handler and some cleanup in UPF

Test:
  1. Tested in Simulator

Signed-off-by: Yogesh Pandey <yogesh@wavelabs.ai>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
