### PR TITLE
perf(datapath): Increase NIC queue size of S1 interface.

### DIFF
--- a/lte/gateway/configs/pipelined.yml_prod
+++ b/lte/gateway/configs/pipelined.yml_prod
@@ -171,6 +171,6 @@ ovs_internal_conntrack_fwd_tbl_number: 202
 dp_irq:
  enable: True
  S1_cpu: '2-3'
- S1_queue_size: 1024
+ S1_queue_size: 2048
  SGi_cpu: '2-3'
  SGi_queue_size: 1024


### PR DESCRIPTION
This queus size shows better stability on UE sessions after the
attachment.

Signed-off-by: Pravin B Shelar <pbshelar@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->

## Test Plan
validated on baremetal AGW
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
