### PR TITLE
Package executables so they can be used in CircleCI nodes

### DIFF
--- a/lte/gateway/fabfile.py
+++ b/lte/gateway/fabfile.py
@@ -430,11 +430,13 @@ def _copy_out_c_execs_in_magma_vm():
     with settings(warn_only=True):
         exec_paths = ['/usr/local/bin/sessiond', '/usr/local/bin/mme',
                       '/usr/local/sbin/sctpd', '/usr/local/bin/connectiond']
+        dest_path = '~/magma-packages/executables'
+        run('mkdir -p ' + dest_path)
         for exec_path in exec_paths:
             if not exists(exec_path):
                 print(exec_path + " does not exist")
                 continue
-            run('cp ' + exec_path + ' ~/magma-packages')
+            run('cp ' + exec_path + ' ' + dest_path)
 
 
 

--- a/orc8r/tools/fab/pkg.py
+++ b/orc8r/tools/fab/pkg.py
@@ -162,9 +162,12 @@ def copy_packages():
             run('echo "%s %s %s" >> /tmp/packages.txt'
                 % (pkg_name, version, f))
 
-    # Tar up the packages
+    run('mkdir -p /tmp/packages/executables')
+    run('cp ~/magma-packages/executables/* /tmp/packages/executables')
+
+    # Tar up the packages and executables
     with cd('/tmp/packages'):
-        run('tar czf /tmp/packages.tar.gz *.deb')
+        run('tar czf /tmp/packages.tar.gz ./*.deb ./executables')
 
     # Pull the artifacts onto the local machine
     get('/tmp/packages.tar.gz', '/tmp/packages.tar.gz')


### PR DESCRIPTION
Signed-off-by: Marie Bremner <marwhal@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary
the current agw deploy job places all executables in `~/magma-packages`, but they don't get copied out to CircleCI. (Only `.deb` files are at the moment). This change makes it so that the executables are instead placed in `~/magma-packages/executables` so that everything in the directory can be copied out as well.
<!-- Enumerate changes you made and why you made them -->

## Test Plan
Run the following and check the executables made it inside
```
fab test package:vcs=git
fab copy_packages
tar xvf packages.tgz

logs..
...
x ./python3-wrapt_1.12.1_amd64.deb
x ./python3-wsgiserver_1.3_all.deb
x ./python3-zipp_1.2.0_all.deb
x ./td-agent-bit_1.7.8_amd64.deb
x ./executables/
x ./executables/sessiond
x ./executables/connectiond
x ./executables/mme
x ./executables/sctpd
```
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
