### PR TITLE
[component:agw] SUCI/IMSI based Registration fails when IMSI's MNC is…

### DIFF
--- a/lte/gateway/c/oai/tasks/amf/amf_as.cpp
+++ b/lte/gateway/c/oai/tasks/amf/amf_as.cpp
@@ -1094,6 +1094,13 @@ static int amf_as_security_req(
 
         // NAS Integrity key is calculated as specified in TS 33501, Annex A
         memcpy(&plmn, ue_context->amf_context.imsi.u.value, 3);
+
+        if ((ue_context->amf_context.imsi.u.value[1] & 0xf) != 0xf) {
+          plmn.mnc_digit1 = (amf_ctx->imsi.u.value[1] & 0xf);
+          plmn.mnc_digit2 = (amf_ctx->imsi.u.value[2] & 0xf0) >> 4;
+          plmn.mnc_digit3 = (amf_ctx->imsi.u.value[2] & 0xf);
+        }
+
         format_plmn(&plmn);
 
         /* Building 32 bytes of string with serving network SN

--- a/lte/gateway/c/oai/tasks/amf/amf_recv.cpp
+++ b/lte/gateway/c/oai/tasks/amf/amf_recv.cpp
@@ -174,7 +174,7 @@ int amf_handle_registration_request(
         /*
          * Extract the SUPI or IMSI from SUCI as scheme output is not encrypted
          */
-        params->imsi = new (imsi_t);
+        params->imsi = new imsi_t();
         /* Copying PLMN to local supi which is imsi*/
         supi_imsi.plmn.mcc_digit1 =
             msg->m5gs_mobile_identity.mobile_identity.imsi.mcc_digit1;
@@ -195,9 +195,18 @@ int amf_handle_registration_request(
             MSIN_MAX_LENGTH);
         // Copy entire supi_imsi to param->imsi->u.value
         memcpy(&params->imsi->u.value, &supi_imsi, IMSI_BCD8_SIZE);
-        OAILOG_DEBUG(
+
+        if (supi_imsi.plmn.mnc_digit3 != 0xf) {
+          params->imsi->u.value[0] = ((supi_imsi.plmn.mcc_digit1 << 4) & 0xf0) |
+                                     (supi_imsi.plmn.mcc_digit2 & 0xf);
+          params->imsi->u.value[1] = ((supi_imsi.plmn.mcc_digit3 << 4) & 0xf0) |
+                                     (supi_imsi.plmn.mnc_digit1 & 0xf);
+          params->imsi->u.value[2] = ((supi_imsi.plmn.mnc_digit2 << 4) & 0xf0) |
+                                     (supi_imsi.plmn.mnc_digit3 & 0xf);
+        }
+        OAILOG_INFO(
             LOG_AMF_APP, "Value of SUPI/IMSI from params->imsi->u.value\n");
-        OAILOG_DEBUG(
+        OAILOG_INFO(
             LOG_AMF_APP,
             "SUPI as IMSI derived : %02x%02x%02x%02x%02x%02x%02x%02x \n",
             params->imsi->u.value[0], params->imsi->u.value[1],
@@ -226,6 +235,7 @@ int amf_handle_registration_request(
         imsi64_t imsi64                = amf_imsi_to_imsi64(params->imsi);
         guti_and_amf_id.amf_guti       = amf_guti;
         guti_and_amf_id.amf_ue_ngap_id = ue_id;
+        OAILOG_DEBUG(LOG_AMF_APP, "imsi64 : " IMSI_64_FMT "\n", imsi64);
         if (amf_supi_guti_map.size() == 0) {
           // first entry.
           amf_supi_guti_map.insert(
@@ -338,7 +348,7 @@ int amf_handle_registration_request(
   }
   OAILOG_DEBUG(LOG_NAS_AMF, "Processing REGITRATION_REQUEST message\n");
   return rc;
-}
+}  // namespace magma5g
 
 /****************************************************************************
  **                                                                        **

--- a/lte/gateway/c/oai/tasks/amf/amf_security_mode_control.cpp
+++ b/lte/gateway/c/oai/tasks/amf/amf_security_mode_control.cpp
@@ -360,6 +360,12 @@ int amf_proc_security_mode_control(
       char imsi[IMSI_BCD_DIGITS_MAX + 1];
       IMSI64_TO_STRING(amf_ctx->imsi64, imsi, 15);
       memcpy(&plmn, amf_ctx->imsi.u.value, 3);
+
+      if ((amf_ctx->imsi.u.value[1] & 0xf) != 0xf) {
+        plmn.mnc_digit1 = (amf_ctx->imsi.u.value[1] & 0xf);
+        plmn.mnc_digit2 = (amf_ctx->imsi.u.value[2] & 0xf0) >> 4;
+        plmn.mnc_digit3 = (amf_ctx->imsi.u.value[2] & 0xf);
+      }
       format_plmn(&plmn);
 
       /* Building 32 bytes of string with serving network SN


### PR DESCRIPTION
… sent as 3 DIGIT #7619

    Fix:
       1. Resolved plmn, imsi64 while accessing 3digit mnc value from imsi in amf_context

    Testcases:
       1. Registration with 2 digit MNC successfull with UERANSIM
       1. Registration with 3 digit MNC successfull with UERANSIM

Signed-off-by: ganeshg87 <ganesh.gedela@wavelabs.ai>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
