### PR TITLE
[m5g][agw] Fix serving network name derivation

### DIFF
--- a/lte/gateway/c/oai/tasks/amf/amf_app_ue_context_and_proc.h
+++ b/lte/gateway/c/oai/tasks/amf/amf_app_ue_context_and_proc.h
@@ -319,6 +319,7 @@ typedef struct amf_context_s {
   std::string smf_msg; /* SMF message contained within the initial request*/
   bool is_imsi_only_detach;
   uint8_t reg_id_type;
+  tai_t originating_tai;
 } amf_context_t;
 
 typedef struct amf_ue_context_s {

--- a/lte/gateway/c/oai/tasks/amf/amf_as.cpp
+++ b/lte/gateway/c/oai/tasks/amf/amf_as.cpp
@@ -987,7 +987,6 @@ static int amf_as_security_req(
   uint8_t snni[32]  = {0};
   uint8_t xres[16]  = {0};
   uint8_t rand[16]  = {0};
-  amf_plmn_t plmn;
 
   memset(&nas_msg, 0, sizeof(amf_nas_message_t));
 
@@ -1092,31 +1091,24 @@ static int amf_as_security_req(
                 [ue_context->amf_context._security.eksi % MAX_EPS_AUTH_VECTORS]
             .xres_size = auth_info_proc->vector[0]->xres.size;
 
-        // NAS Integrity key is calculated as specified in TS 33501, Annex A
-        memcpy(&plmn, ue_context->amf_context.imsi.u.value, 3);
-
-        if ((ue_context->amf_context.imsi.u.value[1] & 0xf) != 0xf) {
-          plmn.mnc_digit1 = (amf_ctx->imsi.u.value[1] & 0xf);
-          plmn.mnc_digit2 = (amf_ctx->imsi.u.value[2] & 0xf0) >> 4;
-          plmn.mnc_digit3 = (amf_ctx->imsi.u.value[2] & 0xf);
-        }
-
-        format_plmn(&plmn);
-
         /* Building 32 bytes of string with serving network SN
-         * SN value 5G:mnc095.mcc208.3gppnetwork.org
-         * mcc and mnc retrive saved _imsi from amf_context
+         * SN value = 5G:mnc<mnc>.mcc<mcc>.3gppnetwork.org
+         * mcc and mnc are retrieved from serving network PLMN
          */
         uint32_t mcc              = 0;
         uint32_t mnc              = 0;
         uint32_t mnc_digit_length = 0;
-
-        PLMN_T_TO_MCC_MNC(plmn, mcc, mnc, mnc_digit_length);
+        PLMN_T_TO_MCC_MNC(
+            ue_context->amf_context.originating_tai.plmn, mcc, mnc,
+            mnc_digit_length);
         uint32_t snni_buf_len = sprintf(
             (char*) snni, "5G:mnc%03d.mcc%03d.3gppnetwork.org", mnc, mcc);
         if (snni_buf_len != 32) {
-          OAILOG_ERROR(LOG_NAS_AMF, "Failed to create SNNI String\n");
+          OAILOG_ERROR(
+              LOG_NAS_AMF, "Failed to create proper SNNI String: %s ", snni);
           OAILOG_FUNC_RETURN(LOG_NAS_AMF, RETURNerror);
+        } else {
+          OAILOG_DEBUG(LOG_NAS_AMF, "serving network name: %s", snni);
         }
 
         memcpy(

--- a/lte/gateway/c/oai/tasks/amf/amf_authentication.cpp
+++ b/lte/gateway/c/oai/tasks/amf/amf_authentication.cpp
@@ -606,7 +606,7 @@ int amf_proc_authentication_complete(
     for (idx = 0; idx < amf_ctx->_vector[auth_proc->ksi].xres_size; idx++) {
       if ((amf_ctx->_vector[auth_proc->ksi].xres[idx]) !=
           msg->autn_response_parameter.response_parameter[idx]) {
-        // is_xres_validation_failed = true;
+        is_xres_validation_failed = true;
         break;
       }
     }

--- a/lte/gateway/c/oai/tasks/amf/amf_recv.cpp
+++ b/lte/gateway/c/oai/tasks/amf/amf_recv.cpp
@@ -155,6 +155,9 @@ int amf_handle_registration_request(
   memcpy(
       &(ue_context->amf_context.ue_sec_capability), &(msg->ue_sec_capability),
       sizeof(UESecurityCapabilityMsg));
+  memcpy(
+      &(ue_context->amf_context.originating_tai), (const void*) originating_tai,
+      sizeof(tai_t));
 
   OAILOG_DEBUG(LOG_NAS_AMF, "Processing REGITRATION_REQUEST message\n");
   OAILOG_DEBUG(

--- a/lte/gateway/c/oai/tasks/amf/amf_security_mode_control.cpp
+++ b/lte/gateway/c/oai/tasks/amf/amf_security_mode_control.cpp
@@ -359,29 +359,24 @@ int amf_proc_security_mode_control(
       // NAS Integrity key is calculated as specified in TS 33501, Annex A
       char imsi[IMSI_BCD_DIGITS_MAX + 1];
       IMSI64_TO_STRING(amf_ctx->imsi64, imsi, 15);
-      memcpy(&plmn, amf_ctx->imsi.u.value, 3);
-
-      if ((amf_ctx->imsi.u.value[1] & 0xf) != 0xf) {
-        plmn.mnc_digit1 = (amf_ctx->imsi.u.value[1] & 0xf);
-        plmn.mnc_digit2 = (amf_ctx->imsi.u.value[2] & 0xf0) >> 4;
-        plmn.mnc_digit3 = (amf_ctx->imsi.u.value[2] & 0xf);
-      }
-      format_plmn(&plmn);
 
       /* Building 32 bytes of string with serving network SN
-       * SN value 5G:mnc095.mcc208.3gppnetwork.org
-       * mcc and mnc retrive saved _imsi from amf_context
+       * SN value = 5G:mnc<mnc>.mcc<mcc>.3gppnetwork.org
+       * mcc and mnc are retrieved from serving network PLMN
        */
       uint32_t mcc              = 0;
       uint32_t mnc              = 0;
       uint32_t mnc_digit_length = 0;
-
-      PLMN_T_TO_MCC_MNC(plmn, mcc, mnc, mnc_digit_length);
+      PLMN_T_TO_MCC_MNC(
+          amf_ctx->originating_tai.plmn, mcc, mnc, mnc_digit_length);
       uint32_t snni_buf_len =
           sprintf((char*) snni, "5G:mnc%03d.mcc%03d.3gppnetwork.org", mnc, mcc);
       if (snni_buf_len != 32) {
-        OAILOG_ERROR(LOG_NAS_AMF, "Failed to create SNNI String\n");
+        OAILOG_ERROR(
+            LOG_NAS_AMF, "Failed to create proper SNNI String: %s ", snni);
         OAILOG_FUNC_RETURN(LOG_NAS_AMF, RETURNerror);
+      } else {
+        OAILOG_DEBUG(LOG_NAS_AMF, "serving network name: %s", snni);
       }
 
       memcpy(
@@ -404,11 +399,20 @@ int amf_proc_security_mode_control(
       derive_5gkey_nas(
           NAS_INT_ALG, 2, amf_ctx->_security.kamf, amf_ctx->_security.knas_int);
 
-      derive_key_nas(
-          NAS_ENC_ALG, amf_ctx->_security.selected_algorithms.encryption,
-          amf_ctx->_vector[amf_ctx->_security.eksi % MAX_EPS_AUTH_VECTORS]
-              .kasme,
-          amf_ctx->_security.knas_enc);
+      derive_5gkey_nas(
+          NAS_ENC_ALG, 1, amf_ctx->_security.kamf, amf_ctx->_security.knas_enc);
+
+      OAILOG_STREAM_HEX(
+          OAILOG_LEVEL_TRACE, LOG_AMF_APP, "KAUSF: ", (const char*) &(kausf[0]),
+          AUTH_KASME_SIZE);
+      OAILOG_STREAM_HEX(
+          OAILOG_LEVEL_TRACE, LOG_AMF_APP, "KSEAF: ", (const char*) &(kseaf[0]),
+          AUTH_KASME_SIZE);
+      OAILOG_STREAM_HEX(
+          OAILOG_LEVEL_TRACE, LOG_AMF_APP,
+          "KAMF: ", (const char*) &(amf_ctx->_security.kamf[0]),
+          AUTH_KAMF_SIZE);
+
       /*
        * Set new security context indicator
        */

--- a/lte/gateway/c/oai/tasks/amf/nas_proc.cpp
+++ b/lte/gateway/c/oai/tasks/amf/nas_proc.cpp
@@ -55,6 +55,7 @@ int nas_proc_establish_ind(
     amf_sap.u.amf_as.u.establish.is_amf_ctx_new = is_mm_ctx_new;
     amf_sap.u.amf_as.u.establish.nas_msg        = msg;
     amf_sap.u.amf_as.u.establish.ecgi           = ecgi;
+    amf_sap.u.amf_as.u.establish.tai            = originating_tai;
     rc                                          = amf_sap_send(&amf_sap);
   }
   OAILOG_FUNC_RETURN(LOG_NAS_AMF, rc);

--- a/lte/gateway/c/oai/tasks/ngap/ngap_amf_itti_messaging.c
+++ b/lte/gateway/c/oai/tasks/ngap/ngap_amf_itti_messaging.c
@@ -143,7 +143,7 @@ void ngap_amf_itti_ngap_initial_ue_message(
   }
 #endif
   NGAP_INITIAL_UE_MESSAGE(message_p).gnb_ue_ngap_id = gnb_ue_ngap_id;
-
+  NGAP_INITIAL_UE_MESSAGE(message_p).tai            = *tai;
   send_msg_to_task(&ngap_task_zmq_ctx, TASK_AMF_APP, message_p);
   OAILOG_INFO(LOG_NGAP, "iniUEmsg sent to TASK_AMF_APP");
   OAILOG_FUNC_OUT(LOG_NGAP);

--- a/lte/gateway/c/oai/tasks/ngap/ngap_amf_nas_procedures.c
+++ b/lte/gateway/c/oai/tasks/ngap/ngap_amf_nas_procedures.c
@@ -164,6 +164,10 @@ int ngap_amf_handle_initial_ue_message(
     DevAssert(
         ie->value.choice.UserLocationInformation.choice
             .userLocationInformationNR.tAI.pLMNIdentity.size == 3);
+    TBCD_TO_PLMN_T(
+        &ie->value.choice.UserLocationInformation.choice
+             .userLocationInformationNR.tAI.pLMNIdentity,
+        &(tai.plmn));
     NGAP_FIND_PROTOCOLIE_BY_ID(
         Ngap_InitialUEMessage_IEs_t, ie, container,
         Ngap_ProtocolIE_ID_id_UserLocationInformation, true);


### PR DESCRIPTION
<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->
- Serving network name was falsely derived from IMSI. Made the necessary changes to percolate serving TAI information across the layers and store in UE AMF context.

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->
- Created log messages to check if SNN is correctly computed.
Before the change:
-  SNN = `5G:mnc045.mcc222.3gppnetwork.org`
- TeraVM log indicating integ failures:
[SA_01_02_03_04_Hyper_Suci_210618_213045-1_0.module.log](https://github.com/magma/magma/files/6680352/SA_01_02_03_04_Hyper_Suci_210618_213045-1_0.module.log)
- Mismatched keys

After the change:
-SNN = `5G:mnc456.mcc222.3gppnetwork.org`
- TeraVM log indicating no issues:
[SA_01_02_03_04_Hyper_Guti_210619_085652-1_0.module.log](https://github.com/magma/magma/files/6680355/SA_01_02_03_04_Hyper_Guti_210619_085652-1_0.module.log)
- Matched KSEAF, KAMF, KNASINT

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
