### PR TITLE
make the test results related operations warn only

### DIFF
--- a/circleci/fabfile.py
+++ b/circleci/fabfile.py
@@ -10,15 +10,15 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
+import os
 import re
 import sys
 from time import sleep
 from typing import List, Optional
 
-import dateutil.parser
 import requests
 from fabric.api import run
-from fabric.context_managers import cd, lcd, settings
+from fabric.context_managers import cd, settings
 from fabric.contrib.files import exists
 from fabric.exceptions import CommandTimeout
 from fabric.operations import get, local, put
@@ -42,6 +42,7 @@ CWF_IMAGES = [
 ]
 
 DEFAULT_DOCKER_REG = 'facebookconnectivity-magma-docker.jfrog.io'
+
 
 class FabricException(Exception):
     pass
@@ -208,16 +209,18 @@ def _checkout_code(repo: str, branch: str, sha1: str, tag: str, pr_num: str,
 def _run_remote_lte_integ_test(repo: str, magma_root: str):
     repo_name = _get_repo_name(repo)
     with cd(f'{repo_name}/{magma_root}/lte/gateway'):
-        test_result = run('fab integ_test', timeout=180*60, warn_only=True)
+        test_result = run('fab integ_test', timeout=180 * 60, warn_only=True)
 
         # Transfer test summaries into current directory
         run('fab get_test_summaries:dst_path="test-results"', warn_only=True)
         # Copy from node
         local('mkdir -p test-results')
-        get('test-results', 'test-results')
+        with settings(warn_only=True):
+            get('test-results', 'test-results')
         # Copy to the directory CircleCI expects
         local('sudo mkdir -p /tmp/test-results/')
-        local('sudo mv test-results/* /tmp/test-results/')
+        if len(os.listdir('test-results')):
+            local('sudo mv test-results/* /tmp/test-results/')
 
         # On failure, transfer logs from all 3 VMs and copy to the log
         # directory. This will get stored as an artifact in the CircleCI
@@ -256,7 +259,7 @@ def _run_remote_cwf_integ_test(repo: str, magma_root: str):
                              'destroy_vm=True,'
                              'transfer_images=True,'
                              'test_result_xml=' + test_xml,
-                             timeout=110*60, warn_only=True)
+                             timeout=110 * 60, warn_only=True)
             except Exception as e:
                 _transfer_all_artifacts()
                 print(f'Exception while running cwf integ_test\n {e}')


### PR DESCRIPTION
Signed-off-by: Marie Bremner <marwhal@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary
sometimes these operations fail because the VM is not found, https://app.circleci.com/pipelines/github/magma/magma/26608/workflows/7e9227ab-0871-4757-b00a-4ef8aca20d13/jobs/284942
I suspect they are getting shutdown somehow. 

Anyhow, if the integration tests pass, I don't want the job to fail for test summary related reasons, so putting a warn only flag.
<!-- Enumerate changes you made and why you made them -->

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
