### PR TITLE
Move access of MME_APP stats into the MME_APP thread

### DIFF
--- a/lte/gateway/c/core/oai/include/service303.h
+++ b/lte/gateway/c/core/oai/include/service303.h
@@ -17,6 +17,8 @@
 
 #pragma once
 
+#include "service303_messages_types.h"
+
 #include "bstrlib.h"
 #define SERVICE303_MME_PACKAGE_NAME "mme"
 #define SERVICE303_MME_PACKAGE_VERSION "1.0"
@@ -27,7 +29,7 @@
 #define NO_LABELS 0
 #define EPC_STATS_TIMER_MSEC 60000  // In milliseconds
 
-void service303_statistics_read(void);
+void service303_mme_statistics_read(application_mme_stats_msg_t* stats_msg_p);
 
 // service303 conf type added to be able to use same task interface for MME and
 // SPGW while passing configs from mme_config and spgw_config types

--- a/lte/gateway/c/core/oai/include/service303_messages_def.h
+++ b/lte/gateway/c/core/oai/include/service303_messages_def.h
@@ -22,3 +22,6 @@ MESSAGE_DEF(
 MESSAGE_DEF(
     APPLICATION_UNHEALTHY_MSG, application_unhealthy_msg_t,
     application_unhealthy_msg)
+MESSAGE_DEF(
+    APPLICATION_STATS_MSG, application_mme_stats_msg_t,
+    application_mme_stats_msg)

--- a/lte/gateway/c/core/oai/include/service303_messages_types.h
+++ b/lte/gateway/c/core/oai/include/service303_messages_types.h
@@ -33,4 +33,11 @@ typedef struct application_unhealthy_msg {
   uint8_t unused;
 } application_unhealthy_msg_t;
 
+// Message capturing stats as communicated by the mme_app
+typedef struct application_mme_stats_msg {
+  uint32_t nb_enb_connected;
+  uint32_t nb_ue_attached;
+  uint32_t nb_ue_connected;
+} application_mme_stats_msg_t;
+
 #endif /* FILE_SERVICE303_MESSAGES_TYPES_SEEN */

--- a/lte/gateway/c/core/oai/lib/message_utils/service303_message_utils.c
+++ b/lte/gateway/c/core/oai/lib/message_utils/service303_message_utils.c
@@ -33,3 +33,22 @@ int send_app_health_to_service303(
   }
   return send_msg_to_task(task_zmq_ctx_p, TASK_SERVICE303, message_p);
 }
+
+int send_stats_to_service303(
+    task_zmq_ctx_t* task_zmq_ctx_p, task_id_t origin_id,
+    uint32_t nb_enb_connected, uint32_t nb_ue_attached,
+    uint32_t nb_ue_connected) {
+  MessageDef* message_p =
+      itti_alloc_new_message(origin_id, APPLICATION_STATS_MSG);
+  if (message_p == NULL) {
+    OAILOG_ERROR(LOG_MME_APP, "Unable to allocate memory");
+    OAILOG_FUNC_RETURN(LOG_MME_APP, RETURNerror);
+  }
+  message_p->ittiMsg.application_mme_stats_msg.nb_enb_connected =
+      nb_enb_connected;
+  message_p->ittiMsg.application_mme_stats_msg.nb_ue_attached   =
+      nb_ue_attached;
+  message_p->ittiMsg.application_mme_stats_msg.nb_ue_connected  =
+      nb_ue_connected;
+  return send_msg_to_task(task_zmq_ctx_p, TASK_SERVICE303, message_p);
+}

--- a/lte/gateway/c/core/oai/lib/message_utils/service303_message_utils.h
+++ b/lte/gateway/c/core/oai/lib/message_utils/service303_message_utils.h
@@ -26,4 +26,9 @@
 int send_app_health_to_service303(
     task_zmq_ctx_t* task_zmq_ctx_p, task_id_t origin_id, bool healthy);
 
+int send_stats_to_service303(
+    task_zmq_ctx_t* task_zmq_ctx_p, task_id_t origin_id,
+    uint32_t nb_enb_connected, uint32_t nb_ue_attached,
+    uint32_t nb_ue_connected);
+
 #endif /* FILE_SERVICE303_MESSAGE_UTILS */

--- a/lte/gateway/c/core/oai/tasks/mme_app/mme_app_main.c
+++ b/lte/gateway/c/core/oai/tasks/mme_app/mme_app_main.c
@@ -55,6 +55,7 @@
 static void check_mme_healthy_and_notify_service(void);
 static bool is_mme_app_healthy(void);
 static void mme_app_exit(void);
+static void start_stats_timer(void);
 
 bool mme_hss_associated = false;
 bool mme_sctp_bounded   = false;
@@ -62,6 +63,7 @@ task_zmq_ctx_t mme_app_task_zmq_ctx;
 bool mme_congestion_control_enabled = true;
 long mme_app_last_msg_latency;
 long pre_mme_task_msg_latency;
+static long epc_stats_timer_id;
 
 mme_congestion_params_t mme_congestion_params;
 
@@ -561,9 +563,23 @@ int mme_app_init(const mme_config_t* mme_config_p) {
     OAILOG_ERROR(LOG_MME_APP, "MME APP create task failed\n");
     OAILOG_FUNC_RETURN(LOG_MME_APP, RETURNerror);
   }
+  start_stats_timer();
 
   OAILOG_DEBUG(LOG_MME_APP, "Initializing MME applicative layer: DONE\n");
   OAILOG_FUNC_RETURN(LOG_MME_APP, RETURNok);
+}
+
+static int handle_stats_timer(zloop_t* loop, int id, void* arg) {
+  mme_app_desc_t* mme_app_desc_p = get_mme_nas_state(false);
+  return send_stats_to_service303(
+      &mme_app_task_zmq_ctx, TASK_MME_APP, mme_app_desc_p->nb_enb_connected,
+      mme_app_desc_p->nb_ue_attached, mme_app_desc_p->nb_ue_connected);
+}
+
+static void start_stats_timer(void) {
+  epc_stats_timer_id = start_timer(
+      &mme_app_task_zmq_ctx, EPC_STATS_TIMER_MSEC, TIMER_REPEAT_FOREVER,
+      handle_stats_timer, NULL);
 }
 
 static void check_mme_healthy_and_notify_service(void) {
@@ -578,6 +594,7 @@ static bool is_mme_app_healthy(void) {
 
 //------------------------------------------------------------------------------
 static void mme_app_exit(void) {
+  stop_timer(&mme_app_task_zmq_ctx, epc_stats_timer_id);
   mme_app_edns_exit();
   clear_mme_nas_state();
   // Clean-up NAS module

--- a/lte/gateway/c/core/oai/tasks/service303/service303_mme_stats.c
+++ b/lte/gateway/c/core/oai/tasks/service303/service303_mme_stats.c
@@ -21,16 +21,10 @@
 #include "mme_app_state.h"
 #include "service303.h"
 
-static void service303_mme_statistics_read(void) {
-  size_t label                   = 0;
-  mme_app_desc_t* mme_app_desc_p = get_mme_nas_state(false);
-  set_gauge("enb_connected", mme_app_desc_p->nb_enb_connected, label);
-  set_gauge("ue_registered", mme_app_desc_p->nb_ue_attached, label);
-  set_gauge("ue_connected", mme_app_desc_p->nb_ue_connected, label);
-  return;
-}
-
-void service303_statistics_read(void) {
-  service303_mme_statistics_read();
+void service303_mme_statistics_read(application_mme_stats_msg_t* stats_msg_p) {
+  size_t label = 0;
+  set_gauge("enb_connected", stats_msg_p->nb_enb_connected, label);
+  set_gauge("ue_registered", stats_msg_p->nb_ue_attached, label);
+  set_gauge("ue_connected", stats_msg_p->nb_ue_connected, label);
   return;
 }

--- a/lte/gateway/c/core/oai/tasks/service303/service303_task.c
+++ b/lte/gateway/c/core/oai/tasks/service303/service303_task.c
@@ -72,11 +72,6 @@ static void* service303_server_thread(__attribute__((unused)) void* args) {
   return NULL;
 }
 
-static int handle_timer(zloop_t* loop, int id, void* arg) {
-  service303_statistics_read();
-  return 0;
-}
-
 static int handle_service_message(zloop_t* loop, zsock_t* reader, void* arg) {
   MessageDef* received_message_p = receive_msg(reader);
 
@@ -87,6 +82,10 @@ static int handle_service_message(zloop_t* loop, zsock_t* reader, void* arg) {
     case APPLICATION_UNHEALTHY_MSG: {
       service303_set_application_health(APP_UNHEALTHY);
     } break;
+    case APPLICATION_STATS_MSG: {
+      service303_mme_statistics_read(
+          &received_message_p->ittiMsg.application_mme_stats_msg);
+    }
     case TERMINATE_MESSAGE:
       free(received_message_p);
       service303_message_exit();
@@ -103,32 +102,10 @@ static int handle_service_message(zloop_t* loop, zsock_t* reader, void* arg) {
 }
 
 static void* service303_thread(void* args) {
-  bstring pkg_name                   = bfromcstr(SERVICE303_MME_PACKAGE_NAME);
-  service303_data_t* service303_data = (service303_data_t*) args;
-
   itti_mark_task_ready(TASK_SERVICE303);
   init_task_context(
       TASK_SERVICE303, (task_id_t[]){}, 0, handle_service_message,
       &service303_message_task_zmq_ctx);
-
-  if (bstricmp(service303_data->name, pkg_name) == 0) {
-    /* NOTE : Above check for MME package is added since SPGW does not support
-     * stats at present
-     * TODO : Whenever SPGW implements stats,remove the above "if" check so that
-     * timer is started in SPGW also and SPGW stats can also be read as part of
-     * timer expiry handling
-     */
-
-    /*
-     * Start a periodic timer to trigger reading the mme stats so that it can be
-     * sent to server for display
-     */
-    service303_epc_stats_timer_id = start_timer(
-        &service303_message_task_zmq_ctx, EPC_STATS_TIMER_MSEC,
-        TIMER_REPEAT_FOREVER, handle_timer, NULL);
-  }
-
-  bdestroy(pkg_name);
 
   zloop_start(service303_message_task_zmq_ctx.event_loop);
   service303_message_exit();


### PR DESCRIPTION
## Summary
Currently service303 reaches across service boundaries to read
mme_app state. Fix this by pushing the stats over an ITTI message
Also remove the check for MME service as the timer is not started
in the SPGW context (as it is only run in the MME_APP)

Also may close #7421 where the nas datastructure is null as there is probably
races with clearing out the state_p.

Signed-off-by: Amar Padmanabhan <amar@freedomfi.com>


## Test Plan

- Ran test_attach_detach.py
- Added logs to verify the timer was getting fired and the service303_mme_statistics_read

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
