### PR TITLE
temporarily disable test summary uploading from the magma VM to unblock master CI

### DIFF
--- a/lte/gateway/fabfile.py
+++ b/lte/gateway/fabfile.py
@@ -299,9 +299,11 @@ def get_test_summaries(
         test_host=None,
         dst_path="/tmp"):
     local('mkdir -p ' + dst_path)
-    _switch_to_vm_no_provision(gateway_host, "magma", "magma_dev.yml")
-    with settings(warn_only=True):
-        get(remote_path=TEST_SUMMARY_GLOB, local_path=dst_path)
+
+    # Currently broken on master: GH7688
+    # _switch_to_vm_no_provision(gateway_host, "magma", "magma_dev.yml")
+    # with settings(warn_only=True):
+    #     get(remote_path=TEST_SUMMARY_GLOB, local_path=dst_path)
     _switch_to_vm_no_provision(test_host, "magma_test", "magma_test.yml")
     with settings(warn_only=True):
         get(remote_path=TEST_SUMMARY_GLOB, local_path=dst_path)


### PR DESCRIPTION
Signed-off-by: Marie Bremner <marwhal@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary
issue tracked here: https://github.com/magma/magma/issues/7688
I wonder something about the new VM won't let the fabric `get` method go through.

This works no problem
```
    _switch_to_vm_no_provision(test_host, "magma_test", "magma_test.yml")
    with settings(warn_only=True):
        get(remote_path=TEST_SUMMARY_GLOB, local_path=dst_path)
```
but not this
```
    # _switch_to_vm_no_provision(gateway_host, "magma", "magma_dev.yml")
    # with settings(warn_only=True):
    #     get(remote_path=TEST_SUMMARY_GLOB, local_path=dst_path)
```
<!-- Enumerate changes you made and why you made them -->

## Test Plan
https://app.circleci.com/pipelines/github/magma/magma/26791/workflows/c8b48406-efe3-4f91-be2a-0c5d9d981232/jobs/287317
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
