### PR TITLE
[nms] Upgrade @fbcnms/sequelize-models to ^0.1.10

### DIFF
--- a/nms/app/packages/magmalte/package.json
+++ b/nms/app/packages/magmalte/package.json
@@ -33,7 +33,7 @@
     "@fbcnms/magma-api": "^0.1.0",
     "@fbcnms/platform-server": "^0.1.29",
     "@fbcnms/projects": "^0.1.0",
-    "@fbcnms/sequelize-models": "^0.1.9",
+    "@fbcnms/sequelize-models": "^0.1.10",
     "@fbcnms/strings": "^0.1.0",
     "@fbcnms/types": "^0.1.11",
     "@fbcnms/ui": "^0.1.11",

--- a/nms/app/yarn.lock
+++ b/nms/app/yarn.lock
@@ -1533,6 +1533,18 @@
   resolved "https://registry.yarnpkg.com/@fbcnms/projects/-/projects-0.1.0.tgz#7e1d6641e6dbe0f8137560f25c6d89b1d5cd9354"
   integrity sha512-vdP5+Y4XWkdVR3H97NCbZiuMpi2xSelyUFg5AR7vZXWzXLFKVziSQEvvqG442U3PQbuLV15LShfYJhEHDc13fA==
 
+"@fbcnms/sequelize-models@^0.1.10":
+  version "0.1.10"
+  resolved "https://registry.yarnpkg.com/@fbcnms/sequelize-models/-/sequelize-models-0.1.10.tgz#f2207602361aeb0edd1e61872a116d1e82e0fcc4"
+  integrity sha512-msnqzWmcZ0FzmcxX+6MQiaO0XIMMHTRWZEJLHqPeT/A9LThrx3y4IcZSGfL+7Io250lfY/m00rmN/AaSAP6X6A==
+  dependencies:
+    "@fbcnms/babel-register" "^0.1.0"
+    inquirer "^8.0.0"
+    mariadb "^2.4.2"
+    minimist "^1.2.5"
+    pg "^8.6.0"
+    sequelize "^5.8.5"
+
 "@fbcnms/sequelize-models@^0.1.9":
   version "0.1.9"
   resolved "https://registry.yarnpkg.com/@fbcnms/sequelize-models/-/sequelize-models-0.1.9.tgz#f6913ded822aa1c7d0f05c1f6a2572ff73a91411"


### PR DESCRIPTION
Signed-off-by: Andrei Lee <andreilee@fb.com>

## Summary

Dependency `@fbcnms/sequelize-models` is not able to handle the idiosyncrasies of Postgres as compared to MariaDB which has been used with Magma NMS previously. A newer version of the package has been made to fix these bugs.

## Test Plan

See https://github.com/facebookincubator/fbc-js-core/pull/110

## Additional Information

- [ ] This change is backwards-breaking
