### PR TITLE
[orc8r] Adding network level congestion control config flag

### DIFF
--- a/lte/cloud/go/services/lte/obsidian/models/defaults.go
+++ b/lte/cloud/go/services/lte/obsidian/models/defaults.go
@@ -37,6 +37,7 @@ func NewDefaultTDDNetworkConfig() *NetworkCellularConfigs {
 			HssRelayEnabled:          swag.Bool(false),
 			GxGyRelayEnabled:         swag.Bool(false),
 			CloudSubscriberdbEnabled: false,
+			CongestionControlEnabled: swag.Bool(true),
 			DefaultRuleID:            "",
 		},
 	}

--- a/lte/cloud/go/services/lte/obsidian/models/network_epc_configs_swaggergen.go
+++ b/lte/cloud/go/services/lte/obsidian/models/network_epc_configs_swaggergen.go
@@ -23,6 +23,9 @@ type NetworkEpcConfigs struct {
 	// cloud subscriberdb enabled
 	CloudSubscriberdbEnabled bool `json:"cloud_subscriberdb_enabled,omitempty"`
 
+	// Network configuration flag for congestion control on EPC
+	CongestionControlEnabled *bool `json:"congestion_control_enabled,omitempty"`
+
 	// default rule id
 	DefaultRuleID string `json:"default_rule_id,omitempty"`
 

--- a/lte/cloud/go/services/lte/obsidian/models/swagger.v1.yml
+++ b/lte/cloud/go/services/lte/obsidian/models/swagger.v1.yml
@@ -1752,6 +1752,11 @@ definitions:
       cloud_subscriberdb_enabled:
         type: boolean
         example: false
+      congestion_control_enabled:
+        description: Network configuration flag for congestion control on EPC
+        type: boolean
+        example: true
+        default: true
       network_services:
         description: Configuration for network services. Services will be instantiated in the listed order.
         type: array

--- a/lte/cloud/go/services/lte/servicers/builder_servicer.go
+++ b/lte/cloud/go/services/lte/servicers/builder_servicer.go
@@ -115,6 +115,11 @@ func (s *builderServicer) Build(ctx context.Context, request *builder_protos.Bui
 	if err != nil {
 		return nil, err
 	}
+	congestionControlEnabled := nwEpc.CongestionControlEnabled
+	if gwEpc.CongestionControlEnabled != nil {
+		congestionControlEnabled = gwEpc.CongestionControlEnabled
+	}
+
 
 	vals := map[string]proto.Message{
 		"enodebd": &lte_mconfig.EnodebD{
@@ -166,7 +171,7 @@ func (s *builderServicer) Build(ctx context.Context, request *builder_protos.Bui
 			RestrictedImeis:          getRestrictedImeis(nwEpc.RestrictedImeis),
 			ServiceAreaMaps:          getServiceAreaMaps(nwEpc.ServiceAreaMaps),
 			FederatedModeMap:         getFederatedModeMap(federatedNetworkConfigs),
-			CongestionControlEnabled: swag.BoolValue(gwEpc.CongestionControlEnabled),
+			CongestionControlEnabled: swag.BoolValue(congestionControlEnabled),
 			SentryConfig:             getNetworkSentryConfig(&network),
 		},
 		"pipelined": &lte_mconfig.PipelineD{

--- a/lte/cloud/go/services/lte/servicers/builder_servicer.go
+++ b/lte/cloud/go/services/lte/servicers/builder_servicer.go
@@ -120,7 +120,6 @@ func (s *builderServicer) Build(ctx context.Context, request *builder_protos.Bui
 		congestionControlEnabled = gwEpc.CongestionControlEnabled
 	}
 
-
 	vals := map[string]proto.Message{
 		"enodebd": &lte_mconfig.EnodebD{
 			LogLevel:            protos.LogLevel_INFO,

--- a/lte/cloud/go/services/lte/servicers/builder_servicer_test.go
+++ b/lte/cloud/go/services/lte/servicers/builder_servicer_test.go
@@ -134,6 +134,7 @@ func TestBuilder_Build(t *testing.T) {
 			EnableDnsCaching:         false,
 			AttachedEnodebTacs:       []int32{15000},
 			NatEnabled:               true,
+			CongestionControlEnabled: true,
 			SentryConfig: &lte_mconfig.SentryConfig{
 				SampleRate:   0.75,
 				UploadMmeLog: true,
@@ -352,6 +353,7 @@ func TestBuilder_Build_NonNat(t *testing.T) {
 			CloudSubscriberdbEnabled: false,
 			AttachedEnodebTacs:       nil,
 			NatEnabled:               false,
+			CongestionControlEnabled: true,
 		},
 		"pipelined": &lte_mconfig.PipelineD{
 			LogLevel:      protos.LogLevel_INFO,
@@ -622,6 +624,7 @@ func TestBuilder_Build_BaseCase(t *testing.T) {
 			CloudSubscriberdbEnabled: false,
 			AttachedEnodebTacs:       nil,
 			NatEnabled:               true,
+			CongestionControlEnabled: true,
 		},
 		"pipelined": &lte_mconfig.PipelineD{
 			LogLevel:      protos.LogLevel_INFO,
@@ -758,6 +761,7 @@ func TestBuilder_Build_FederatedBaseCase(t *testing.T) {
 			CloudSubscriberdbEnabled: false,
 			AttachedEnodebTacs:       nil,
 			NatEnabled:               true,
+			CongestionControlEnabled: true,
 			FederatedModeMap: &lte_mconfig.FederatedModeMap{
 				Enabled: true,
 				Mapping: []*lte_mconfig.ModeMapItem{
@@ -918,6 +922,7 @@ func TestBuilder_BuildInheritedProperties(t *testing.T) {
 			EnableDnsCaching:         false,
 			AttachedEnodebTacs:       []int32{1},
 			NatEnabled:               true,
+			CongestionControlEnabled: true,
 		},
 		"pipelined": &lte_mconfig.PipelineD{
 			LogLevel:      protos.LogLevel_INFO,
@@ -1043,6 +1048,141 @@ func TestBuilder_BuildUnmanagedEnbConfig(t *testing.T) {
 			HssRelayEnabled:          false,
 			CloudSubscriberdbEnabled: false,
 			EnableDnsCaching:         false,
+			AttachedEnodebTacs:       []int32{1},
+			NatEnabled:               true,
+			CongestionControlEnabled: true,
+		},
+		"pipelined": &lte_mconfig.PipelineD{
+			LogLevel:      protos.LogLevel_INFO,
+			UeIpBlock:     "192.168.128.0/24",
+			NatEnabled:    true,
+			DefaultRuleId: "",
+			Services: []lte_mconfig.PipelineD_NetworkServices{
+				lte_mconfig.PipelineD_ENFORCEMENT,
+			},
+			SgiManagementIfaceVlan: "",
+			HeConfig:               &lte_mconfig.PipelineD_HEConfig{},
+			LiUes:                  &lte_mconfig.PipelineD_LiUes{},
+		},
+		"subscriberdb": &lte_mconfig.SubscriberDB{
+			LogLevel:        protos.LogLevel_INFO,
+			LteAuthOp:       []byte("\x11\x11\x11\x11\x11\x11\x11\x11\x11\x11\x11\x11\x11\x11\x11\x11"),
+			LteAuthAmf:      []byte("\x80\x00"),
+			SubProfiles:     nil,
+			HssRelayEnabled: false,
+		},
+		"policydb": &lte_mconfig.PolicyDB{
+			LogLevel: protos.LogLevel_INFO,
+		},
+		"sessiond": &lte_mconfig.SessionD{
+			LogLevel:         protos.LogLevel_INFO,
+			GxGyRelayEnabled: false,
+			WalletExhaustDetection: &lte_mconfig.WalletExhaustDetection{
+				TerminateOnExhaust: false,
+			},
+		},
+		"dnsd": &lte_mconfig.DnsD{
+			LogLevel:          protos.LogLevel_INFO,
+			DhcpServerEnabled: true,
+		},
+		"liagentd": &lte_mconfig.LIAgentD{
+			LogLevel: protos.LogLevel_INFO,
+		},
+	}
+
+	actual, err := build_non_federated(&nw, &graph, "gw1")
+	assert.NoError(t, err)
+	assert.Equal(t, expected, actual)
+}
+
+func TestBuilder_BuildCongestionControlConfig(t *testing.T) {
+	lte_test_init.StartTestService(t)
+
+	nw := configurator.Network{
+		ID: "n1",
+		Configs: map[string]interface{}{
+			lte.CellularNetworkConfigType: lte_models.NewDefaultTDDNetworkConfig(),
+			orc8r.DnsdNetworkType: &models.NetworkDNSConfig{
+				EnableCaching: swag.Bool(true),
+			},
+		},
+	}
+	gw := configurator.NetworkEntity{
+		Type: orc8r.MagmadGatewayType, Key: "gw1",
+		Associations: []storage.TypeAndKey{
+			{Type: lte.CellularGatewayEntityType, Key: "gw1"},
+		},
+	}
+	lteGW := configurator.NetworkEntity{
+		Type: lte.CellularGatewayEntityType, Key: "gw1",
+		Config: newDefaultGatewayConfig(),
+		Associations: []storage.TypeAndKey{
+			{Type: lte.CellularEnodebEntityType, Key: "enb1"},
+		},
+		ParentAssociations: []storage.TypeAndKey{gw.GetTypeAndKey()},
+	}
+	enb := configurator.NetworkEntity{
+		Type: lte.CellularEnodebEntityType, Key: "enb1",
+		Config:             newDefaultUnmanagedEnodebConfig(),
+		ParentAssociations: []storage.TypeAndKey{lteGW.GetTypeAndKey()},
+	}
+	graph := configurator.EntityGraph{
+		Entities: []configurator.NetworkEntity{enb, lteGW, gw},
+		Edges: []configurator.GraphEdge{
+			{From: gw.GetTypeAndKey(), To: lteGW.GetTypeAndKey()},
+			{From: lteGW.GetTypeAndKey(), To: enb.GetTypeAndKey()},
+		},
+	}
+
+	// Gateway specific config overrides network level
+	gwConfig := lteGW.Config
+	cellularGwConfig := gwConfig.(*lte_models.GatewayCellularConfigs)
+	cellularGwConfig.Epc.CongestionControlEnabled = swag.Bool(false)
+
+	expected := map[string]proto.Message{
+		"enodebd": &lte_mconfig.EnodebD{
+			LogLevel: protos.LogLevel_INFO,
+			Pci:      260,
+			TddConfig: &lte_mconfig.EnodebD_TDDConfig{
+				Earfcndl:               44590,
+				SubframeAssignment:     2,
+				SpecialSubframePattern: 7,
+			},
+			BandwidthMhz:        20,
+			AllowEnodebTransmit: true,
+			Tac:                 1,
+			PlmnidList:          "00101",
+			CsfbRat:             lte_mconfig.EnodebD_CSFBRAT_2G,
+			Arfcn_2G:            nil,
+			EnbConfigsBySerial: map[string]*lte_mconfig.EnodebD_EnodebConfig{
+				"enb1": {
+					CellId:    138777000,
+					Tac:       1,
+					IpAddress: "192.168.0.124",
+				},
+			},
+		},
+		"mobilityd": &lte_mconfig.MobilityD{
+			LogLevel: protos.LogLevel_INFO,
+			IpBlock:  "192.168.128.0/24",
+		},
+		"mme": &lte_mconfig.MME{
+			LogLevel:                 protos.LogLevel_INFO,
+			Mcc:                      "001",
+			Mnc:                      "01",
+			Tac:                      1,
+			MmeCode:                  1,
+			MmeGid:                   1,
+			MmeRelativeCapacity:      10,
+			NonEpsServiceControl:     lte_mconfig.MME_NON_EPS_SERVICE_CONTROL_OFF,
+			CsfbMcc:                  "001",
+			CsfbMnc:                  "01",
+			Lac:                      1,
+			HssRelayEnabled:          false,
+			CloudSubscriberdbEnabled: false,
+			EnableDnsCaching:         false,
+			// Gateway congestion control enabled should be false
+			CongestionControlEnabled: false,
 			AttachedEnodebTacs:       []int32{1},
 			NatEnabled:               true,
 		},
@@ -1174,6 +1314,7 @@ func TestBuilder_Build_MMEPool(t *testing.T) {
 			CloudSubscriberdbEnabled: false,
 			AttachedEnodebTacs:       nil,
 			NatEnabled:               true,
+			CongestionControlEnabled: true,
 		},
 		"pipelined": &lte_mconfig.PipelineD{
 			LogLevel:      protos.LogLevel_INFO,
@@ -1265,6 +1406,7 @@ func newDefaultGatewayConfig() *lte_models.GatewayCellularConfigs {
 		Epc: &lte_models.GatewayEpcConfigs{
 			NatEnabled: swag.Bool(true),
 			IPBlock:    "192.168.128.0/24",
+			CongestionControlEnabled: swag.Bool(true),
 		},
 		NonEpsService: &lte_models.GatewayNonEpsConfigs{
 			CsfbMcc:              "001",

--- a/lte/cloud/go/services/lte/servicers/builder_servicer_test.go
+++ b/lte/cloud/go/services/lte/servicers/builder_servicer_test.go
@@ -1404,8 +1404,8 @@ func newDefaultGatewayConfig() *lte_models.GatewayCellularConfigs {
 			TransmitEnabled: swag.Bool(true),
 		},
 		Epc: &lte_models.GatewayEpcConfigs{
-			NatEnabled: swag.Bool(true),
-			IPBlock:    "192.168.128.0/24",
+			NatEnabled:               swag.Bool(true),
+			IPBlock:                  "192.168.128.0/24",
 			CongestionControlEnabled: swag.Bool(true),
 		},
 		NonEpsService: &lte_models.GatewayNonEpsConfigs{

--- a/orc8r/cloud/go/obsidian/swagger/v1/models/network_epc_configs.go
+++ b/orc8r/cloud/go/obsidian/swagger/v1/models/network_epc_configs.go
@@ -23,6 +23,9 @@ type NetworkEpcConfigs struct {
 	// cloud subscriberdb enabled
 	CloudSubscriberdbEnabled bool `json:"cloud_subscriberdb_enabled,omitempty"`
 
+	// Network configuration flag for congestion control on EPC
+	CongestionControlEnabled *bool `json:"congestion_control_enabled,omitempty"`
+
 	// default rule id
 	DefaultRuleID string `json:"default_rule_id,omitempty"`
 

--- a/orc8r/cloud/go/obsidian/swagger/v1/swagger.yml
+++ b/orc8r/cloud/go/obsidian/swagger/v1/swagger.yml
@@ -9919,6 +9919,11 @@ definitions:
       cloud_subscriberdb_enabled:
         example: false
         type: boolean
+      congestion_control_enabled:
+        default: true
+        description: Network configuration flag for congestion control on EPC
+        example: true
+        type: boolean
       default_rule_id:
         example: default_rule_1
         type: string


### PR DESCRIPTION
Signed-off-by: Alex Rodriguez <ardzoht@gmail.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->
- Adding congestion control configuration flag to network EPC config level
- This config is to control the activation of congestion control on MME service, currently it exists at gateway EPC config, adding one for network wide level

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->
- Testing on local orc8r with local VM connected, verifying it is streamed down to gateway.mconfig and is generated on mme.conf
- Added unit test on `builder_servicer_test`

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
