### PR TITLE
fix(pipelined): restart pipelineD service after uplink br reconfig.

### DIFF
--- a/lte/gateway/python/magma/pipelined/app/uplink_bridge.py
+++ b/lte/gateway/python/magma/pipelined/app/uplink_bridge.py
@@ -10,6 +10,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
+import os
 import subprocess
 from collections import namedtuple
 
@@ -247,6 +248,9 @@ class UplinkBridgeController(MagmaController):
             raise Exception('Error: %s failed with: %s' % (ovs_add_port, ex))
 
         self.logger.info("Add uplink port: %s", ovs_add_port)
+        # sometimes the mac address changes after port addition, so restart the service.
+        self.logger.info('OVS uplink bridge reconfigured, restarting to get new config')
+        os._exit(0) # pylint: disable=protected-access
 
     def _del_eth_port(self):
         if BridgeTools.port_is_in_bridge(self.config.uplink_bridge,


### PR DESCRIPTION
OVS can change mac address of the bridge after SGi interface addition.
to handle this change restart the service.

Signed-off-by: Pravin B Shelar <pbshelar@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->

## Test Plan
validated on lab setup.
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
