### PR TITLE
[component:agw] Mobilityd IP Release fix

### DIFF
--- a/lte/gateway/c/oai/include/amf_app_messages_types.h
+++ b/lte/gateway/c/oai/include/amf_app_messages_types.h
@@ -126,7 +126,7 @@ typedef struct itti_amf_ip_allocation_response_s {
   uint8_t gnb_gtp_teid_ip_addr[16];
 
   /* UE IP Address Allocated by MobilityD */
-  char ip_str[INET_ADDRSTRLEN];
+  paa_t paa;
 
   /* Result Type of IP Allocation */
   int result;

--- a/lte/gateway/c/oai/lib/n11/M5GMobilityServiceClient.h
+++ b/lte/gateway/c/oai/lib/n11/M5GMobilityServiceClient.h
@@ -21,20 +21,27 @@ namespace magma5g {
 class M5GMobilityServiceClient {
  public:
   virtual ~M5GMobilityServiceClient() {}
-  virtual bool allocate_ipv4_address(
+  virtual int allocate_ipv4_address(
       const char* subscriber_id, const char* apn, uint32_t pdu_session_id,
       uint8_t pti, uint32_t pdu_session_type, uint8_t* gnb_gtp_teid,
       uint8_t gnb_gtp_teid_len, uint8_t* gnb_gtp_teid_ip_addr,
       uint8_t gnb_gtp_teid_ip_addr_len) = 0;
+
+  virtual int release_ipv4_address(
+      const char* subscriber_id, const char* apn,
+      const struct in_addr* addr) = 0;
 };
 
 class AsyncM5GMobilityServiceClient : public M5GMobilityServiceClient {
  public:
-  bool allocate_ipv4_address(
+  int allocate_ipv4_address(
       const char* subscriber_id, const char* apn, uint32_t pdu_session_id,
       uint8_t pti, uint32_t pdu_session_type, uint8_t* gnb_gtp_teid,
       uint8_t gnb_gtp_teid_len, uint8_t* gnb_gtp_teid_ip_addr,
       uint8_t gnb_gtp_teid_ip_addr_len);
+
+  int release_ipv4_address(
+      const char* subscriber_id, const char* apn, const struct in_addr* addr);
 
   static AsyncM5GMobilityServiceClient& getInstance();
 

--- a/lte/gateway/c/oai/tasks/amf/amf_app_defs.h
+++ b/lte/gateway/c/oai/tasks/amf/amf_app_defs.h
@@ -42,4 +42,6 @@ int amf_app_handle_notification_received(
     itti_n11_received_notification_t* notification);
 int amf_app_handle_pdu_session_accept(
     itti_n11_create_pdu_session_response_t* pdu_session_resp, uint32_t ue_id);
+int amf_smf_handle_ip_address_response(
+    itti_amf_ip_allocation_response_t* response_p);
 }  // namespace magma5g

--- a/lte/gateway/c/oai/tasks/amf/amf_app_handler.cpp
+++ b/lte/gateway/c/oai/tasks/amf/amf_app_handler.cpp
@@ -1172,4 +1172,5 @@ int amf_app_handle_notification_received(
   }
   OAILOG_FUNC_RETURN(LOG_NAS_AMF, rc);
 }
+
 }  // namespace magma5g

--- a/lte/gateway/c/oai/tasks/amf/amf_app_main.cpp
+++ b/lte/gateway/c/oai/tasks/amf/amf_app_main.cpp
@@ -96,11 +96,8 @@ static int handle_message(zloop_t* loop, zsock_t* reader, void* arg) {
 
       response_p = &(received_message_p->ittiMsg.amf_ip_allocation_response);
 
-      amf_smf_create_ipv4_session_grpc_req(
-          response_p->imsi, response_p->apn, response_p->pdu_session_id,
-          response_p->pdu_session_type, response_p->gnb_gtp_teid,
-          response_p->pti, response_p->gnb_gtp_teid_ip_addr,
-          response_p->ip_str);
+      amf_smf_handle_ip_address_response(response_p);
+
       break;
 
     /* Handle PDU session resource setup response */

--- a/lte/gateway/c/oai/tasks/amf/amf_app_ue_context_and_proc.h
+++ b/lte/gateway/c/oai/tasks/amf/amf_app_ue_context_and_proc.h
@@ -259,6 +259,8 @@ typedef struct smf_context_s {
   uint16_t ul_session_ambr;
   QOSRule qos_rules[1];
   teid_upf_gnb_t gtp_tunnel_id;
+  paa_t pdu_address;
+  uint8_t apn[ACCESS_POINT_NAME_MAX_LENGTH + 1];
   smf_proc_data_t smf_proc_data;
 
   // Request to gnb on PDU establisment request

--- a/lte/gateway/c/oai/tasks/amf/deregistration_request.cpp
+++ b/lte/gateway/c/oai/tasks/amf/deregistration_request.cpp
@@ -34,6 +34,9 @@ extern "C" {
 #include "amf_sap.h"
 #include "amf_app_state_manager.h"
 #include "conversions.h"
+#include "M5GMobilityServiceClient.h"
+
+using magma5g::AsyncM5GMobilityServiceClient;
 
 namespace magma5g {
 amf_as_data_t amf_data_de_reg_sec;
@@ -239,6 +242,12 @@ void amf_smf_context_cleanup_pdu_session(ue_m5gmm_context_s* ue_context) {
     smf_message.pti = i->smf_proc_data.pti.pti;
 
     release_session_gprc_req(&smf_message, imsi);
+
+    if (i->pdu_address.pdn_type == IPv4) {
+      AsyncM5GMobilityServiceClient::getInstance().release_ipv4_address(
+          imsi, reinterpret_cast<const char*>(i->apn),
+          &(i->pdu_address.ipv4_address));
+    }
   }
 }
 


### PR DESCRIPTION
Issue:
  1. Once the session is released IP addresse
     needs to be freed in mobilityD

Fix:
  1. Enhanced the M5G mobility Service client to support
     IP address release message to MobolityD
  2. Done some changes in IP Address allocation part
     to store the information in SMF context.

Test:
  1. Tested on UERANSIM and verified logs of mobilityd

Log : Released IP 192.168.128.223 for sid IMSI901700000000001

Signed-off-by: Yogesh Pandey <yogesh@wavelabs.ai>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
