### PR TITLE
[NMS] Equipment dashboard: Federation Gateway Check in chart 

### DIFF
--- a/nms/app/packages/magmalte/app/components/feg/FEGSections.js
+++ b/nms/app/packages/magmalte/app/components/feg/FEGSections.js
@@ -21,11 +21,13 @@ import CellWifiIcon from '@material-ui/icons/CellWifi';
 import DashboardIcon from '@material-ui/icons/Dashboard';
 import FEGConfigure from './FEGConfigure';
 import FEGDashboard from '../../views/dashboard/feg/FEGDashboard';
+import FEGEquipmentDashboard from '../../views/equipment/FEGEquipmentDashboard';
 import FEGGateways from './FEGGateways';
 import FEGMetrics from './FEGMetrics';
 import FEGNetworkDashboard from '../../views/network/FEGNetworkDashboard';
 import NetworkCheckIcon from '@material-ui/icons/NetworkCheck';
 import React from 'react';
+import RouterIcon from '@material-ui/icons/Router';
 import SettingsCellIcon from '@material-ui/icons/SettingsCell';
 import ShowChartIcon from '@material-ui/icons/ShowChart';
 
@@ -42,6 +44,12 @@ export function getFEGSections(dashboardV2Enabled: boolean): SectionsConfigs {
       label: 'Network',
       icon: <NetworkCheckIcon />,
       component: FEGNetworkDashboard,
+    },
+    {
+      path: 'equipment',
+      label: 'Equipment',
+      icon: <RouterIcon />,
+      component: FEGEquipmentDashboard,
     },
     {
       path: 'configure',

--- a/nms/app/packages/magmalte/app/components/layout/__tests__/useSections-test.js
+++ b/nms/app/packages/magmalte/app/components/layout/__tests__/useSections-test.js
@@ -86,7 +86,14 @@ const testCases: {[string]: TestCase} = {
   },
   feg: {
     default: 'gateways',
-    sections: ['gateways', 'network', 'configure', 'alerts', 'metrics'],
+    sections: [
+      'gateways',
+      'network',
+      'equipment',
+      'configure',
+      'alerts',
+      'metrics',
+    ],
   },
   carrier_wifi_network: {
     default: 'gateways',

--- a/nms/app/packages/magmalte/app/views/equipment/FEGEquipmentDashboard.js
+++ b/nms/app/packages/magmalte/app/views/equipment/FEGEquipmentDashboard.js
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @flow strict-local
+ * @format
+ */
+
+import CellWifiIcon from '@material-ui/icons/CellWifi';
+import FEGGateway from './FEGEquipmentGateway';
+import React from 'react';
+import TopBar from '../../components/TopBar';
+
+import {Redirect, Route, Switch} from 'react-router-dom';
+import {useRouter} from '@fbcnms/ui/hooks';
+
+/**
+ * Returns the full equipment dashboard of the federation network.
+ * It consists of an internal equipment dashboard component to display
+ * the useful information about the federation gateways.
+ */
+function FEGEquipmentDashboard() {
+  const {relativePath, relativeUrl} = useRouter();
+
+  return (
+    <>
+      <Switch>
+        <Route
+          path={relativePath('/overview')}
+          component={EquipmentDashboardInternal}
+        />
+        <Redirect to={relativeUrl('/overview')} />
+      </Switch>
+    </>
+  );
+}
+/**
+ * It consists of a top bar to navigate and a federation gateway component
+ * to provide information about the federation gateways.
+ */
+function EquipmentDashboardInternal() {
+  const {relativePath, relativeUrl} = useRouter();
+
+  return (
+    <>
+      <TopBar
+        header="Equipment"
+        tabs={[
+          {
+            label: 'Federation Gateways',
+            to: '/gateway',
+            icon: CellWifiIcon,
+          },
+        ]}
+      />
+      <Switch>
+        <Route path={relativePath('/gateway')} component={FEGGateway} />
+        <Redirect to={relativeUrl('/gateway')} />
+      </Switch>
+    </>
+  );
+}
+
+export default FEGEquipmentDashboard;

--- a/nms/app/packages/magmalte/app/views/equipment/FEGEquipmentGateway.js
+++ b/nms/app/packages/magmalte/app/views/equipment/FEGEquipmentGateway.js
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @flow strict-local
+ * @format
+ */
+
+import GatewayCheckinChart from './GatewayCheckinChart';
+import Grid from '@material-ui/core/Grid';
+import React from 'react';
+import {makeStyles} from '@material-ui/styles';
+
+const useStyles = makeStyles(theme => ({
+  dashboardRoot: {
+    margin: theme.spacing(3),
+    flexGrow: 1,
+  },
+}));
+
+/**
+ * Returns the federation gateways check in chart, the gateways KPI,
+ * cluster KPI, and a table of the federation gateways.
+ */
+export default function FEGGateway() {
+  const classes = useStyles();
+
+  return (
+    <div className={classes.dashboardRoot}>
+      <Grid container justify="space-between" spacing={3}>
+        <Grid item xs={12}>
+          <GatewayCheckinChart />
+        </Grid>
+      </Grid>
+    </div>
+  );
+}


### PR DESCRIPTION
<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary
This is a draft PR because it is a stacked pr upon an exisiting open PR #7642. Once, that PR is approved, this PR would get rebased and would be changed from draft to a normal PR. An equipment page was created and under it a federation gateway check in chart was added to display the check in status information in a graph.
<!-- Enumerate changes you made and why you made them -->

## Test Plan
An existing gateway check in component was used and nothing new was added. Because of that, no new tests were added. However, previous tests were run and all pass. 
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information
![Screen Shot 2021-06-22 at 9 59 20 AM](https://user-images.githubusercontent.com/34602743/122938935-2c082b80-d341-11eb-8f31-4b26a7446ab2.png)


<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
