### PR TITLE
[nprobe] disable liagentd and fix x3 timestamp

### DIFF
--- a/lte/gateway/c/li_agent/src/PDUGenerator.cpp
+++ b/lte/gateway/c/li_agent/src/PDUGenerator.cpp
@@ -173,7 +173,9 @@ void* PDUGenerator::generate_record(
   pdu->correlation_id    = htobe64(state.correlation_id);
   pdu->payload_direction = htons(direction);
 
-  SET_INT64_TLV(&pdu->attrs.timestamp, TIMESTAMP_ATTRID, phdr->ts.tv_sec);
+  uint64_t tm = (uint64_t) phdr->ts.tv_sec << 32 | phdr->ts.tv_usec;
+  SET_INT64_TLV(&pdu->attrs.timestamp, TIMESTAMP_ATTRID, tm);
+
   SET_INT64_TLV(
       &pdu->attrs.sequence_number, SEQNBR_ATTRID, state.sequence_number);
 

--- a/lte/gateway/configs/magmad.yml
+++ b/lte/gateway/configs/magmad.yml
@@ -35,7 +35,7 @@ magma_services:
   - smsd
   - ctraced
   - health
-  - liagentd
+# - liagentd
 
 # List of services that don't provide service303 interface
 non_service303_services:


### PR DESCRIPTION
Signed-off-by: YOUSSEF EL MASMOUDI <ymasmoudi@fb.com>

## Summary

- Remove liagentd from magma services as it is disabled by default
- Fix timestamp encoding for x1 header

## Test Plan

New Record
```
$ cat output/x3_record_1624356405436441000.pdu | hexdump 
0000000 00 02 00 02 00 00 00 40 00 00 00 34 00 05 00 02
0000010 29 f2 8e 1c f2 30 48 6a a8 60 f5 a7 84 ab 91 78
0000020 08 66 cb 39 79 08 45 70 00 09 00 08 60 d1 b6 31
0000030 00 0f 03 3a 00 08 00 08 00 00 00 00 00 00 00 58
0000040 45 00 00 34 48 a1 40 00 3f 06 70 9b c0 a8 81 2a
0000050 c0 a8 80 0c 13 89 e9 45 57 0b d4 42 93 d2 c9 2c
0000060 80 11 03 ab 1c 9a 00 00 01 01 08 0a 00 26 9d 80
0000070 00 26 b1 06                               
```
Where timestamp  is 60 d1 b6 31 00 0f 03 3a => 1624356401983866 => Tuesday, 22 June 2021 18:06:41.983 GMT+08:00

```
[8/8] Completed 'LiAgent'
cd  /home/vagrant/build/c/li_agent/src && ctest --output-on-failure
Test project /home/vagrant/build/c/li_agent/src
    Start 1: test_pdu_generator
1/1 Test #1: test_pdu_generator ...............   Passed    0.03 sec

100% tests passed, 0 tests failed out of 1
```
