### PR TITLE
Handler for expiry of timer T3560

### DIFF
--- a/lte/gateway/c/oai/tasks/amf/amf_as.cpp
+++ b/lte/gateway/c/oai/tasks/amf/amf_as.cpp
@@ -1030,66 +1030,70 @@ static int amf_as_security_req(
         nas5g_auth_info_proc_t* auth_info_proc =
             get_nas5g_cn_procedure_auth_info(amf_ctx);
 
-        memcpy(
-            nas_msg.plain.amf.msg.authenticationrequestmsg.auth_rand.rand_val,
-            auth_info_proc->vector[0]->rand, RAND_LENGTH_OCTETS);
-        memcpy(
-            nas_msg.plain.amf.msg.authenticationrequestmsg.auth_autn.AUTN,
-            auth_info_proc->vector[0]->autn, AUTN_LENGTH_OCTETS);
+        // To check the validitiy of the vectors
+        if ((auth_info_proc) && (auth_info_proc->vector[0])) {
+          memcpy(
+              nas_msg.plain.amf.msg.authenticationrequestmsg.auth_rand.rand_val,
+              auth_info_proc->vector[0]->rand, RAND_LENGTH_OCTETS);
+          memcpy(
+              nas_msg.plain.amf.msg.authenticationrequestmsg.auth_autn.AUTN,
+              auth_info_proc->vector[0]->autn, AUTN_LENGTH_OCTETS);
 
-        if (ue_context->amf_context._security.eksi >= KSI_NO_KEY_AVAILABLE) {
-          ue_context->amf_context._security.eksi = 0;
+          if (ue_context->amf_context._security.eksi >= KSI_NO_KEY_AVAILABLE) {
+            ue_context->amf_context._security.eksi = 0;
+          }
+          OAILOG_INFO(
+              LOG_AMF_APP, "eksi:%x", ue_context->amf_context._security.eksi);
+          memcpy(
+              ue_context->amf_context
+                  ._vector
+                      [ue_context->amf_context._security.eksi %
+                       MAX_EPS_AUTH_VECTORS]
+                  .kasme,
+              auth_info_proc->vector[0]->kasme, KASME_LENGTH_OCTETS);
+          memcpy(
+              ue_context->amf_context
+                  ._vector
+                      [ue_context->amf_context._security.eksi %
+                       MAX_EPS_AUTH_VECTORS]
+                  .autn,
+              auth_info_proc->vector[0]->autn, AUTN_LENGTH_OCTETS);
+          memcpy(
+              ue_context->amf_context
+                  ._vector
+                      [ue_context->amf_context._security.eksi %
+                       MAX_EPS_AUTH_VECTORS]
+                  .rand,
+              auth_info_proc->vector[0]->rand, RAND_LENGTH_OCTETS);
+          memcpy(
+              ue_context->amf_context
+                  ._vector
+                      [ue_context->amf_context._security.eksi %
+                       MAX_EPS_AUTH_VECTORS]
+                  .ck,
+              auth_info_proc->vector[0]->ck, CK_LENGTH_OCTETS);
+          memcpy(
+              ue_context->amf_context
+                  ._vector
+                      [ue_context->amf_context._security.eksi %
+                       MAX_EPS_AUTH_VECTORS]
+                  .ik,
+              auth_info_proc->vector[0]->ik, IK_LENGTH_OCTETS);
+
+          memcpy(
+              ue_context->amf_context
+                  ._vector
+                      [ue_context->amf_context._security.eksi %
+                       MAX_EPS_AUTH_VECTORS]
+                  .xres,
+              auth_info_proc->vector[0]->xres.data,
+              auth_info_proc->vector[0]->xres.size);
+          ue_context->amf_context
+              ._vector
+                  [ue_context->amf_context._security.eksi %
+                   MAX_EPS_AUTH_VECTORS]
+              .xres_size = auth_info_proc->vector[0]->xres.size;
         }
-        OAILOG_INFO(
-            LOG_AMF_APP, "eksi:%x", ue_context->amf_context._security.eksi);
-        memcpy(
-            ue_context->amf_context
-                ._vector
-                    [ue_context->amf_context._security.eksi %
-                     MAX_EPS_AUTH_VECTORS]
-                .kasme,
-            auth_info_proc->vector[0]->kasme, KASME_LENGTH_OCTETS);
-        memcpy(
-            ue_context->amf_context
-                ._vector
-                    [ue_context->amf_context._security.eksi %
-                     MAX_EPS_AUTH_VECTORS]
-                .autn,
-            auth_info_proc->vector[0]->autn, AUTN_LENGTH_OCTETS);
-        memcpy(
-            ue_context->amf_context
-                ._vector
-                    [ue_context->amf_context._security.eksi %
-                     MAX_EPS_AUTH_VECTORS]
-                .rand,
-            auth_info_proc->vector[0]->rand, RAND_LENGTH_OCTETS);
-        memcpy(
-            ue_context->amf_context
-                ._vector
-                    [ue_context->amf_context._security.eksi %
-                     MAX_EPS_AUTH_VECTORS]
-                .ck,
-            auth_info_proc->vector[0]->ck, CK_LENGTH_OCTETS);
-        memcpy(
-            ue_context->amf_context
-                ._vector
-                    [ue_context->amf_context._security.eksi %
-                     MAX_EPS_AUTH_VECTORS]
-                .ik,
-            auth_info_proc->vector[0]->ik, IK_LENGTH_OCTETS);
-
-        memcpy(
-            ue_context->amf_context
-                ._vector
-                    [ue_context->amf_context._security.eksi %
-                     MAX_EPS_AUTH_VECTORS]
-                .xres,
-            auth_info_proc->vector[0]->xres.data,
-            auth_info_proc->vector[0]->xres.size);
-        ue_context->amf_context
-            ._vector
-                [ue_context->amf_context._security.eksi % MAX_EPS_AUTH_VECTORS]
-            .xres_size = auth_info_proc->vector[0]->xres.size;
 
         /* Building 32 bytes of string with serving network SN
          * SN value = 5G:mnc<mnc>.mcc<mcc>.3gppnetwork.org

--- a/lte/gateway/c/oai/tasks/amf/amf_authentication.cpp
+++ b/lte/gateway/c/oai/tasks/amf/amf_authentication.cpp
@@ -875,10 +875,12 @@ int amf_send_authentication_request(
 
     if (rc != RETURNerror) {
       OAILOG_ERROR(LOG_NAS_EMM, "Timer:Start Authenthication Timer T3560\n");
+      amf_ue_ngap_id_t* ue_id =
+          (amf_ue_ngap_id_t*) malloc(sizeof(amf_ue_ngap_id_t));
+      *ue_id              = auth_proc->ue_id;
       auth_proc->T3560.id = start_timer(
           &amf_app_task_zmq_ctx, AUTHENTICATION_TIMER_EXPIRY_MSECS,
-          TIMER_REPEAT_ONCE, authenthication_t3560_handler,
-          (void*) auth_proc->ue_id);
+          TIMER_REPEAT_ONCE, authenthication_t3560_handler, (void*) ue_id);
       OAILOG_INFO(LOG_AMF_APP, "Timer: Authenthication timer T3560 started \n");
       OAILOG_INFO(
           LOG_AMF_APP, "Timer: Authenthication timer T3560 id is %d\n",
@@ -899,6 +901,7 @@ static int authenthication_t3560_handler(
   amf_context_t* amf_ctx = NULL;
   amf_ue_ngap_id_t ue_id = 0;
   ue_id                  = *((amf_ue_ngap_id_t*) (arg));
+  free((amf_ue_ngap_id_t*) (arg));
 
   OAILOG_INFO(
       LOG_AMF_APP, "Timer: ZMQ In _identification_t3560_handler - T3560\n");


### PR DESCRIPTION
    Fixes:
    1) Added the missing code functionality to support T3560 timer

    Test cases:
    1) Run with UERANSIM to miss the response for authenticatoin request
    2) Run with UERANSIM to send the authentication success and failure messages after initial failures

    Signed-off-by: Kaleemullah Mohammed <kaleemullah.mohammed@wavelabs.ai>

## Summary

<!-- Enumerate changes you made and why you made them -->

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
![FailureScenario](https://user-images.githubusercontent.com/83354949/123065810-1ec86b00-d42d-11eb-9472-d103c474faf7.jpg)
![SuccessScenario](https://user-images.githubusercontent.com/83354949/123065818-20922e80-d42d-11eb-8c77-510d4b536cb4.jpg)
