### PR TITLE
[lte][agw] Add detach timer to the clean up

### DIFF
--- a/lte/gateway/c/core/oai/tasks/nas/nas_procedures.c
+++ b/lte/gateway/c/core/oai/tasks/nas/nas_procedures.c
@@ -470,6 +470,18 @@ void nas_delete_detach_procedure(struct emm_context_s* emm_context) {
       free_emm_detach_request_ies(&proc->ies);
     }
 
+    // Stop T3422 if running
+    if (emm_context->T3422.id != NAS_TIMER_INACTIVE_ID) {
+      void* unused          = NULL;
+      void** timer_callback = &unused;
+      emm_context->T3422.id =
+          nas_timer_stop(emm_context->T3422.id, timer_callback);
+    }
+    if (emm_context->t3422_arg) {
+      free_wrapper(&emm_context->t3422_arg);
+      emm_context->t3422_arg = NULL;
+    }
+
     nas_delete_child_procedures(emm_context, (nas_base_proc_t*) proc);
 
     free_wrapper((void**) &emm_context->emm_procedures->emm_specific_proc);


### PR DESCRIPTION
Signed-off-by: Ulas Kozat <kozat@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->
- Detach timer was not being cleaned up when UE context was removed. This is a potential fix for #7566. 

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->
Integ tests.

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
