### PR TITLE
ci(agw): Filter lte/gateway/c code coverage

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,7 @@ aliases:
   - &lte_build_verify
     paths: "orc8r lte"
   - &c_cpp_build_verify
-    paths: "orc8r/gateway/c orc8r/protos lte/gateway/c lte/protos feg/protos orc8r/protos"
+    paths: "orc8r/gateway/c orc8r/protos lte/gateway/c lte/protos feg/protos orc8r/protos lte/gateway/Makefile"
   - &session_manager_build_verify
     paths: "orc8r/gateway/c orc8r/protos lte/gateway/c/session_manager lte/protos feg/protos orc8r/protos"
   - &mme_build_verify

--- a/lte/gateway/Makefile
+++ b/lte/gateway/Makefile
@@ -228,17 +228,17 @@ test_%: build_common
 
 coverage_oai: test_oai
 	lcov --capture --directory $(C_BUILD) --output-file /tmp/coverage_oai.info.raw
-	lcov -r /tmp/coverage_oai.info.raw "/*/test/*" -o /tmp/coverage_oai.info
+	lcov -r /tmp/coverage_oai.info.raw "/*/test/*" "/usr/*" "/build/*protos*" -o /tmp/coverage_oai.info
 	rm -f `find $(C_BUILD) -name *.gcda` # Clean up any prior coverage data
 
 coverage_sctpd: test_sctpd
 	lcov --capture --directory $(C_BUILD) --output-file /tmp/coverage_sctpd.info.raw
-	lcov -r /tmp/coverage_sctpd.info.raw "/*/test/*" -o /tmp/coverage_sctpd.info
+	lcov -r /tmp/coverage_sctpd.info.raw "/*/test/*" "/usr/*" "/build/*protos*" -o /tmp/coverage_sctpd.info
 	rm -f `find $(C_BUILD) -name *.gcda` # Clean up any prior coverage data
 
 coverage_session_manager: test_session_manager
 	lcov --capture --directory $(C_BUILD) --output-file /tmp/coverage_session_manager.info.raw
-	lcov -r /tmp/coverage_session_manager.info.raw "/*/test/*" -o /tmp/coverage_session_manager.info
+	lcov -r /tmp/coverage_session_manager.info.raw "/*/test/*" "/usr/*" "/build/*protos*" -o /tmp/coverage_session_manager.info
 	rm -f `find $(C_BUILD) -name *.gcda` # Clean up any prior coverage data
 
 # format and test c/session_manager
@@ -291,7 +291,8 @@ clang_tidy_oai_upload: clang_tidy_oai
 
 ## Generate complete code structural information prior to any test execution
 base_coverage: build_oai build_sctpd build_session_manager build_connection_tracker
-	lcov --initial --directory $(C_BUILD) -c --output-file /tmp/coverage_initialize.info
+	lcov --initial --directory $(C_BUILD) -c --output-file /tmp/coverage_initialize.info.raw
+	lcov -r /tmp/coverage_initialize.info.raw "/*/test/*" "/usr/*" "/build/*protos*" -o /tmp/coverage_initialize.info
 	rm -f `find $(C_BUILD) -name *.gcda` # Clean up any prior coverage data
 
 # Combine results of sub-coverages


### PR DESCRIPTION
Closes #6348

Remove coverage of generated code and included libraries.

Signed-off-by: Mark Jen <markjen@fb.com>

## Test Plan

Ran `make coverage` from /lte/gateway inside build docker instance and checked results using genhtml.

## Additional Information

Updated coverage report from my local build, showing reduced file set.

![after](https://user-images.githubusercontent.com/72896/123013131-3ea65300-d389-11eb-9b1e-98d0ecd1c1dc.png)
