### PR TITLE
[Orc8r]  Multiple Orc8r deployment changes including changes to metrics helm chart, elastic search curator chart values and orcl

### DIFF
--- a/orc8r/cloud/deploy/orc8r_deployer/docker/Dockerfile
+++ b/orc8r/cloud/deploy/orc8r_deployer/docker/Dockerfile
@@ -1,5 +1,5 @@
 FROM python:3.9-slim-buster
-
+ARG ENV=prod
 ARG HELM_VERSION="3.5.1"
 ARG TERRAFORM_VERSION="0.15.5"
 ARG KUBECTL_VERSION="1.20.2"
@@ -36,21 +36,7 @@ RUN pip3 install --no-cache-dir \
                         dataclasses-json \
                         pytest
 
-
-WORKDIR /usr/local
-RUN curl https://facebookconnectivity.jfrog.io/artifactory/generic/go1.13.4.linux-amd64.tar.gz -O && \
-    tar xf go1.13.4.linux-amd64.tar.gz && \
-    cp -r go/bin/* /usr/local/bin/
-ENV GO111MODULE=on
-ENV GOPROXY=https://proxy.golang.org
-ENV ANSIBLE_CONFIG=/root/.ansible.cfg
-
 WORKDIR /root/download
-
-# Install avalanche
-RUN go get -v github.com/open-fresh/avalanche/cmd/... && \
-    mv /root/go/bin/cmd /usr/local/bin/avalanche && \
-    chmod +x /usr/local/bin/avalanche
 
 # Install aws cli
 RUN wget "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -O "/root/download/awscli2.zip" && \
@@ -73,6 +59,23 @@ RUN wget https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform
     wget https://storage.googleapis.com/kubernetes-release/release/v$KUBECTL_VERSION/bin/linux/amd64/kubectl -O /usr/local/bin/kubectl && \
     chmod +x /usr/local/bin/kubectl && \
     rm -rf /root/download/*
+
+
+# Install go if we are building testframework image
+WORKDIR /usr/local
+RUN if [ "$ENV" = "testframework" ] ; then curl https://facebookconnectivity.jfrog.io/artifactory/generic/go1.13.4.linux-amd64.tar.gz -O && \
+    tar xf go1.13.4.linux-amd64.tar.gz && \
+    cp -r go/bin/* /usr/local/bin/ ; fi
+
+ENV GO111MODULE=on
+ENV GOPROXY=https://proxy.golang.org
+ENV ANSIBLE_CONFIG=/root/.ansible.cfg
+
+# Uncomment to install avalanche
+# WORKDIR /root/download
+# RUN if [ "$ENV" = "testframework" ] ; then go get -v github.com/open-fresh/avalanche/cmd/... && \
+#     mv /root/go/bin/cmd /usr/local/bin/avalanche && \
+#     chmod +x /usr/local/bin/avalanche ; fi
 
 COPY root/ /root/
 

--- a/orc8r/cloud/deploy/orc8r_deployer/docker/root/data/default_template.json
+++ b/orc8r/cloud/deploy/orc8r_deployer/docker/root/data/default_template.json
@@ -19,7 +19,7 @@
   "gateway": {
       "prefix" : "agw",
       "count" : 1,
-      "ami" : "ami-06447b6fef489a898",
+      "ami" : "ami-044bc7506dfacf204",
       "cloudstrapper_ami": "ami-051d6db85d3a56804",
       "region": "us-west-2",
       "az" : "us-west-2a",

--- a/orc8r/cloud/deploy/orc8r_deployer/docker/root/data/vars.yml
+++ b/orc8r/cloud/deploy/orc8r_deployer/docker/root/data/vars.yml
@@ -294,7 +294,7 @@ platform:
     Type: string
     Required: false
     ConfigApps:
-      - tf
+      - tf     
   orc8r_db_identifier:
     Default: orc8rdb
     Description: Identifier for the RDS instance for Orchestrator.
@@ -303,8 +303,9 @@ platform:
     ConfigApps:
       - tf
   orc8r_db_instance_class:
+    Default: "db.m4.large"
     Description: RDS instance Type for Orchestrator DB.
-    Type: string
+    Type: string  
     Required: false
     ConfigApps:
       - tf
@@ -405,6 +406,12 @@ service:
     Required: false
     ConfigApps:
       - tf
+  elasticsearch_disk_threshold:
+    Description: Size threshold in GB.
+    Type: number
+    Required: false
+    ConfigApps:
+      - tf      
   existing_tiller_service_account_name:
     Description: Name of existing Tiller service account to use for Helm.
     Type: string
@@ -483,7 +490,7 @@ service:
     Required: false
     ConfigApps:
       - tf
-    Default: 1.5.22
+    Default: 1.5.23
   orc8r_controller_replicas:
     Description: Replica count for Orchestrator controller pods.
     Type: number

--- a/orc8r/cloud/deploy/orc8r_deployer/docker/root/scripts/cli/cleanup.py
+++ b/orc8r/cloud/deploy/orc8r_deployer/docker/root/scripts/cli/cleanup.py
@@ -52,7 +52,7 @@ def tf_backup_fn(tf_dir):
 
 
 def tf_destroy(constants: dict, warn: bool = True,
-               max_retries: int = 3) -> int:
+               max_retries: int = 2) -> int:
     """Run through terraform cleanup
 
     Args:
@@ -120,7 +120,7 @@ def raw_cleanup(
         constants: dict,
         override_dict: dict = None,
         dryrun: bool = False,
-        max_retries: int = 3):
+        max_retries: int = 2):
     """Perform raw cleanup of resources using internal commands
 
     Args:

--- a/orc8r/cloud/deploy/orc8r_deployer/docker/root/scripts/cli/configlib.py
+++ b/orc8r/cloud/deploy/orc8r_deployer/docker/root/scripts/cli/configlib.py
@@ -38,7 +38,8 @@ def input_to_type(input_str: str, input_type: str):
     ''' convert input string to its appropriate type '''
     if input_type == 'map':
         return json.loads(input_str)
-
+    elif input_type == 'bool':
+        return input_str.lower() in ["true", "True"]
     return input_str
 
 
@@ -81,10 +82,11 @@ class ConfigManager(object):
         click.echo(f"Setting key {key} value {value} "
                    f"for component {component}")
         config_vars = self.config_vars[component]
-        if not config_vars.get(key):
+        config_info = config_vars.get(key)
+        if not config_info:
             print_error_msg(f"{key} not a valid attribute in {component}")
             return
-        self.configs[component][key] = value
+        self.configs[component][key] = input_to_type(value, config_info.get('Type'))
 
     def commit(self, component):
         set_aws_configs(self.aws_vars, self.configs[component])
@@ -94,6 +96,9 @@ class ConfigManager(object):
     def configure(self, component: str):
         print_title(f"\nConfiguring {component} deployment variables")
         cfgs = self.configs[component]
+
+        self.initialize_defaults(component)
+
         # TODO: use a different yaml loader to ensure we load inorder
         # sort the variables to group the inputs together
         config_vars = self.config_vars[component].items()
@@ -196,8 +201,7 @@ class ConfigManager(object):
         except OSError:
             click.echo(f"Failed opening vars file {vars_fn}")
 
-        # read all configs to initialize defaults and to identify
-        # app specific configs(terraform, awscli etc)
+        # read configs
         for component in constants['components']:
             self.configs[component] = {}
             try:
@@ -206,7 +210,6 @@ class ConfigManager(object):
             except OSError:
                 pass
 
-            cfgs = self.configs[component]
             for config_key, config_info in self.config_vars[component].items():
                 if 'tf' in config_info["ConfigApps"]:
                     self.tf_vars.add(config_key)
@@ -214,8 +217,18 @@ class ConfigManager(object):
                 if 'awscli' in config_info["ConfigApps"]:
                     self.aws_vars.add(config_key)
 
-                # add defaults to configs inorder to run prechecks
-                default = config_info.get('Default')
-                typ = config_info.get('Type')
-                if default is not None:
-                    cfgs[config_key] = input_to_type(default, typ)
+    def initialize_defaults(self, component):
+        cfgs = self.configs[component]
+        for config_key, config_info in self.config_vars[component].items():
+            # add defaults to configs inorder to run prechecks
+            default = config_info.get('Default')
+            typ = config_info.get('Type')
+            if default is not None:
+                curr_val = cfgs.get(config_key)
+
+                # if defaults are overriden already, explicitly confirm
+                # to reset defaults
+                if (not curr_val or (curr_val and default != curr_val and
+                    click.confirm(f"Override {config_key} "
+                    f"current val {curr_val} with default {default}"))):
+                    cfgs[config_key] = default

--- a/orc8r/cloud/deploy/orc8r_deployer/docker/root/scripts/cli/configlib_test.py
+++ b/orc8r/cloud/deploy/orc8r_deployer/docker/root/scripts/cli/configlib_test.py
@@ -119,10 +119,6 @@ variable "{{k}}" {}{% endfor %}
 
         # verify if components tfvars json is created
         mgr = configlib.ConfigManager(self.constants)
-
-        # check whether defaults are set
-        self.assertIn('lte_orc8r_chart_version', mgr.configs['service'])
-
         mgr.configure('infra')
         mgr.commit('infra')
 
@@ -188,6 +184,7 @@ variable "{{k}}" {}{% endfor %}
 
         fn = "%s/service.tfvars.json" % self.constants['config_dir']
         cfg = get_json(fn)
+
         # verify that default value was set
         self.assertEqual(len(cfg.keys()), 1)
         self.assertEqual(cfg['lte_orc8r_chart_version'], "0.2.4")

--- a/orc8r/cloud/deploy/orc8r_deployer/docker/root/scripts/cli/install.py
+++ b/orc8r/cloud/deploy/orc8r_deployer/docker/root/scripts/cli/install.py
@@ -26,7 +26,7 @@ from utils.common import execute_command
 
 
 def tf_install(constants: dict, warn: bool = True,
-               max_retries: int = 3) -> int:
+               max_retries: int = 2) -> int:
     """Run through terraform installation
 
     Args:
@@ -96,7 +96,7 @@ def install(ctx):
         else:
             print_warning_msg(f"Skipping installation prechecks")
 
-    tf_install(ctx.obj)
+        tf_install(ctx.obj)
 
 
 def precheck_cmd(constants: dict) -> list:

--- a/orc8r/cloud/deploy/orc8r_deployer/docker/root/scripts/playbooks/roles/infra/aws/tasks/main.yml
+++ b/orc8r/cloud/deploy/orc8r_deployer/docker/root/scripts/playbooks/roles/infra/aws/tasks/main.yml
@@ -40,3 +40,6 @@
 
 - name: Route53 tasks
   import_tasks: route53.yml
+
+- name: User tasks
+  import_tasks: user.yml 

--- a/orc8r/cloud/deploy/orc8r_deployer/docker/root/scripts/playbooks/roles/infra/aws/tasks/secrets.yml
+++ b/orc8r/cloud/deploy/orc8r_deployer/docker/root/scripts/playbooks/roles/infra/aws/tasks/secrets.yml
@@ -1,5 +1,6 @@
 - name: Query secretsmanager
-  ansible.builtin.shell: aws secretsmanager list-secret-version-ids --secret-id {{ infra_configs.secretsmanager_orc8r_secret | quote }} || /bin/true
+  ansible.builtin.shell: aws secretsmanager list-secret-version-ids --secret-id {{ infra_configs.secretsmanager_orc8r_secret | quote }}
+  ignore_errors: true
   register: result
   tags: install_precheck
 

--- a/orc8r/cloud/deploy/orc8r_deployer/docker/root/scripts/playbooks/roles/platform/tasks/elastic.yml
+++ b/orc8r/cloud/deploy/orc8r_deployer/docker/root/scripts/playbooks/roles/platform/tasks/elastic.yml
@@ -1,21 +1,20 @@
 - name: Get AWS IAM roles information
-  ansible.builtin.shell: aws iam list-roles || /bin/true
+  ansible.builtin.shell: aws iam get-role --role-name AWSServiceRoleForAmazonElasticsearchService
+  ignore_errors: true
   register: result
-  when: platform_configs.deploy_elasticsearch
+  when: platform_configs.deploy_elasticsearch_service_linked_role    
   tags:
     - install_precheck
     - upgrade_precheck
 
 - name: Check if AWSServiceRoleForAmazonElasticsearchService is present already
   assert:
-    that:
-      - "{{ platform_configs.deploy_elasticsearch_service_linked_role not in (true, 'true') or item.RoleName != 'AWSServiceRoleForAmazonElasticsearchService' }}"
-    msg:
+    that: '"NoSuchEntity" in result.stderr'
+    fail_msg:    
       - "IAM role AWSServiceRoleForAmazonElasticsearchService already exists"
       - "Configure deploy_elasticsearch_service_linked_role to be false"
-      - "For e.g: orcl configure set -c platform -k deploy_elasticsearch_service_linked_role -v false"
-  when: platform_configs.deploy_elasticsearch
-  with_items: "{{(result.stdout | from_json).Roles}}"
+      - "For e.g: orcl configure set -c platform -k deploy_elasticsearch_service_linked_role -v false"    
+  when: platform_configs.deploy_elasticsearch_service_linked_role      
   tags:
     - install_precheck
     - upgrade_precheck

--- a/orc8r/cloud/deploy/orc8r_deployer/docker/root/scripts/playbooks/roles/platform/tasks/rds.yml
+++ b/orc8r/cloud/deploy/orc8r_deployer/docker/root/scripts/playbooks/roles/platform/tasks/rds.yml
@@ -1,34 +1,53 @@
+- name: Get orderable DB instance options in the region
+  ansible.builtin.shell: aws rds describe-orderable-db-instance-options --engine postgres --db-instance-class "{{platform_configs.orc8r_db_instance_class}}"
+  register: orderable_instances
+  tags: 
+    - install_precheck
+    - upgrade_precheck
+
+- name: Check if RDS instance class can be deployed in the region
+  assert:
+    that: "{{(orderable_instances.stdout| from_json).OrderableDBInstanceOptions | length > 0}}"
+    fail_msg:
+      - "Provided instance class {{platform_configs.orc8r_db_instance_class}} is not available in the configured region"
+  tags: 
+    - install_precheck
+    - upgrade_precheck    
+
 - name: Get RDS information
-  ansible.builtin.shell: aws rds describe-db-instances || /bin/true
-  register: result
+  ansible.builtin.shell: aws rds describe-db-instances --db-instance-identifier "{{platform_configs.orc8r_db_identifier}}"|| /bin/true
+  register: db_instance
   tags: upgrade_precheck
 
-- name: Check if deployed RDS db instance version is greater than version specified in values
+- name: Get engine version and compatible upgrade versions
+  ansible.builtin.shell: aws rds describe-db-engine-versions --engine-version "{{orc8r_db_instance.EngineVersion}}" 
+  vars: 
+    orc8r_db_instance: "{{(db_instance.stdout | from_json).DBInstances[0]}}"
+  register: engine_versions  
+  tags: upgrade_precheck 
+
+- name: Check if deployed RDS db instance version matches or is a valid upgrade target
   assert:
-    that: "{{ platform_configs.orc8r_db_engine_version is version(item.EngineVersion, '>=') }}"
-    msg:
-      - "deployed version higher than to be configured version"
-      - "Configure the db engine version to be >= {{item.EngineVersion}}"
-      - "For e.g: orcl configure set -c infra -k orc8r_db_engine_version -v {{item.EngineVersion}}"
-  when: item.DBInstanceIdentifier == platform_configs.orc8r_db_identifier
-  with_items: "{{(result.stdout | from_json).DBInstances}}"
+    that: "{{ platform_configs.orc8r_db_engine_version in compatible_versions }}"
+    fail_msg:
+      - "Provided db version is not a valid upgrade target "
+      - "Valid upgrade targets for {{curr_version}} is {{upgrade_targets}}"
+      - "For e.g: orcl configure set -c infra -k orc8r_db_engine_version -v <desired_target_version>"
+  vars:
+    curr_version : "{{lookup('items', engine_versions.stdout | from_json | json_query('DBEngineVersions[*].EngineVersion'))}}"
+    upgrade_targets : "{{lookup('items', engine_versions.stdout | from_json | json_query('DBEngineVersions[*].ValidUpgradeTarget[*].EngineVersion'))}}"
+    compatible_versions: "{{upgrade_targets + [curr_version]}}"
   tags: upgrade_precheck
 
 - name: Delete rds instances
-  command: aws rds delete-db-instance --db-instance-identifier "{{ item }}" --skip-final-snapshot
-  when: item
-  with_items:
-    - "{{ orc8r_db_id }}"
-    # - "{{ nms_db_id }}"
+  command: aws rds delete-db-instance --db-instance-identifier "{{ orc8r_db_id }}" --skip-final-snapshot
+  when: "{{ orc8r_db_id }}"
   ignore_errors: true
   tags: cleanup
 
 - name: Wait for database deletion before deleting subnet group
-  command: aws rds wait db-instance-deleted --db-instance-identifier "{{ item }}"
-  when: item
-  with_items:
-    - "{{ orc8r_db_id }}"
-    # - "{{ nms_db_id }}"
+  command: aws rds wait db-instance-deleted --db-instance-identifier "{{ orc8r_db_id }}"
+  when: "{{ orc8r_db_id }}"
   ignore_errors: true
   tags: cleanup
 

--- a/orc8r/cloud/deploy/orc8r_deployer/docker/root/scripts/playbooks/roles/services/tasks/helm.yml
+++ b/orc8r/cloud/deploy/orc8r_deployer/docker/root/scripts/playbooks/roles/services/tasks/helm.yml
@@ -6,6 +6,14 @@
     - install_precheck
     - upgrade_precheck
 
+
+- name: Remove Helm repo if already present
+  ansible.builtin.shell: helm repo remove test
+  ignore_errors: true
+  tags:
+    - install_precheck
+    - upgrade_precheck
+
 - name: Verify the Helm repo
   ansible.builtin.shell: "helm repo add test {{service_configs.helm_repo}} {% if service_configs.helm_user != '' %} --username {{service_configs.helm_user}} --password {{service_configs.helm_pass}}  {% endif %}"
   tags:

--- a/orc8r/cloud/deploy/orc8r_deployer/docker/root/tf/main.tf.j2
+++ b/orc8r/cloud/deploy/orc8r_deployer/docker/root/tf/main.tf.j2
@@ -52,6 +52,7 @@ module "orc8r-app" {
   efs_file_system_id = module.orc8r.efs_file_system_id
   efs_provisioner_role_arn = module.orc8r.efs_provisioner_role_arn
   elasticsearch_endpoint = module.orc8r.es_endpoint
+  elasticsearch_disk_threshold = tonumber(module.orc8r.es_volume_size * 75 / 100)
 }
 
 output "nameservers" {

--- a/orc8r/cloud/deploy/orc8r_deployer/docker/run_deployer.bash
+++ b/orc8r/cloud/deploy/orc8r_deployer/docker/run_deployer.bash
@@ -14,6 +14,7 @@ options:
 --deploy-dir  deployment dir containing configs and secrets (mandatory)
 --root-dir    magma root directory
 --build       build the deployer container
+--build-testframework build the deployer container with go library and other testframework utilities
 --test        'check_all' or any specific test function[run_unit_tests,check_helmcharts_insync, check_tfvars_insync ]
 example: ./run_deployer.bash --deploy-dir ~/orc8r_15_deployment"
 }
@@ -63,6 +64,7 @@ if (( $# < 2 )); then
 fi
 
 DOCKER_BUILD=false
+DOCKER_BUILD_TESTFRAMEWORK=false
 DEPLOY_WORKDIR=
 MAGMA_ROOT=
 TEST_TO_RUN=
@@ -80,6 +82,9 @@ while [ -n "${1-}" ]; do
     --build)
         DOCKER_BUILD=true
         ;;
+    --build-testframework)
+        DOCKER_BUILD_TESTFRAMEWORK=true
+        ;;        
     --test)
         TEST_TO_RUN="$2"
         shift
@@ -111,6 +116,10 @@ fi
 
 if $DOCKER_BUILD; then
     docker build -t orc8r_deployer:latest .
+fi
+
+if $DOCKER_BUILD_TESTFRAMEWORK; then
+    docker build  --build-arg ENV=testframework -t orc8r_deployer:latest .
 fi
 
 if declare -F "$TEST_TO_RUN"; then

--- a/orc8r/cloud/deploy/terraform/orc8r-aws/db.tf
+++ b/orc8r/cloud/deploy/terraform/orc8r-aws/db.tf
@@ -24,11 +24,12 @@ resource "aws_db_instance" "default" {
 
   vpc_security_group_ids = [aws_security_group.default.id]
 
-  db_subnet_group_name = module.vpc.database_subnet_group
+  db_subnet_group_name = module.vpc.database_subnet_group  
 
   backup_retention_period = var.orc8r_db_backup_retention
   backup_window           = var.orc8r_db_backup_window
 
+  allow_major_version_upgrade = true
   skip_final_snapshot = true
   # we only need this as a placeholder value for `terraform destroy` to work,
   # this won't actually create a final snapshot on destroy

--- a/orc8r/cloud/deploy/terraform/orc8r-aws/outputs.tf
+++ b/orc8r/cloud/deploy/terraform/orc8r-aws/outputs.tf
@@ -47,6 +47,11 @@ output "es_endpoint" {
   value       = join("", aws_elasticsearch_domain.es.*.endpoint)
 }
 
+output "es_volume_size" {
+  description = "Endpoint of the ES cluster if deployed."
+  value       = var.elasticsearch_ebs_volume_size
+}
+
 output "secretsmanager_secret_name" {
   description = "Name of the Secrets Manager secret for deployment secrets"
   value       = aws_secretsmanager_secret.orc8r_secrets.name

--- a/orc8r/cloud/deploy/terraform/orc8r-helm-aws/examples/basic/main.tf
+++ b/orc8r/cloud/deploy/terraform/orc8r-helm-aws/examples/basic/main.tf
@@ -78,9 +78,10 @@ module "orc8r-app" {
   efs_provisioner_role_arn = module.orc8r.efs_provisioner_role_arn
 
   elasticsearch_endpoint = module.orc8r.es_endpoint
+  elasticsearch_disk_threshold = tonumber(module.orc8r.es_volume_size * 75 / 100)
 
   orc8r_deployment_type = "fwa"
-  orc8r_tag             = "1.4.0"
+  orc8r_tag             = "1.5.0"
 }
 
 output "nameservers" {

--- a/orc8r/cloud/deploy/terraform/orc8r-helm-aws/logging.tf
+++ b/orc8r/cloud/deploy/terraform/orc8r-helm-aws/logging.tf
@@ -135,10 +135,19 @@ resource "helm_release" "elasticsearch_curator" {
   repository = local.stable_helm_repo
   chart      = "elasticsearch-curator"
   namespace  = kubernetes_namespace.monitoring.metadata[0].name
-  version    = "2.1.3"
+  version    = "2.2.3"
   keyring    = ""
 
   values = [<<EOT
+  cronjob:    
+    schedule: "0 0 * * *"
+    annotations: {}
+    labels: {}
+    concurrencyPolicy: ""
+    failedJobsHistoryLimit: ""
+    successfulJobsHistoryLimit: ""
+    jobRestartPolicy: Never  
+  
   configMaps:
     config_yml: |-
       ---
@@ -172,6 +181,22 @@ resource "helm_release" "elasticsearch_curator" {
             stats_result:
             epoch:
             exclude: False
+        2:
+          action: delete_indices
+          description: "Clean up ES by magma log indices if it consumes more than 75% of volume"
+          options:
+            timeout_override:
+            continue_if_exception: False
+            disable_action: False
+            ignore_empty_list: True
+          filters:
+          - filtertype: pattern
+            kind: prefix
+            value: magma-
+          - filtertype: space
+            disk_space: ${var.elasticsearch_disk_threshold}
+            use_age: True
+            source: creation_date            
   EOT
   ]
 }

--- a/orc8r/cloud/deploy/terraform/orc8r-helm-aws/variables.tf
+++ b/orc8r/cloud/deploy/terraform/orc8r-helm-aws/variables.tf
@@ -167,7 +167,7 @@ variable "orc8r_deployment_type" {
 variable "orc8r_chart_version" {
   description = "Version of the core orchestrator Helm chart to install."
   type        = string
-  default     = "1.5.22"
+  default     = "1.5.23"
 }
 
 variable "cwf_orc8r_chart_version" {
@@ -246,6 +246,12 @@ variable "elasticsearch_endpoint" {
   description = "Endpoint of the Elasticsearch datasink for aggregated logs and events."
   type        = string
   default     = null
+}
+
+variable "elasticsearch_disk_threshold" {
+  description = "Size threshold in GB."
+  type        = number
+  default     = 10
 }
 
 variable "elasticsearch_retention_days" {

--- a/orc8r/cloud/helm/orc8r/Chart.yaml
+++ b/orc8r/cloud/helm/orc8r/Chart.yaml
@@ -13,7 +13,7 @@ apiVersion: v2
 appVersion: "1.0"
 description: A Helm chart for magma orchestrator
 name: orc8r
-version: 1.5.22
+version: 1.5.23
 engine: gotpl
 sources:
   - https://github.com/magma/magma
@@ -27,7 +27,7 @@ dependencies:
     repository: ""
     condition: secrets.create
   - name: metrics
-    version: 1.4.23
+    version: 1.4.24
     repository: ""
     condition: metrics.enabled
   - name: nms

--- a/orc8r/cloud/helm/orc8r/charts/metrics/Chart.yaml
+++ b/orc8r/cloud/helm/orc8r/charts/metrics/Chart.yaml
@@ -13,7 +13,7 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for magma metrics
 name: metrics
-version: 1.4.23
+version: 1.4.24
 engine: gotpl
 sources:
   - https://github.com/magma/magma

--- a/orc8r/cloud/helm/orc8r/charts/metrics/templates/prometheus.deployment.yaml
+++ b/orc8r/cloud/helm/orc8r/charts/metrics/templates/prometheus.deployment.yaml
@@ -102,6 +102,7 @@ spec:
           args: ['--config.file=/prometheus/prometheus.yml',
                  '--storage.tsdb.path=/data',
                  '--web.enable-lifecycle',
+                 '--web.enable-admin-api',
                  "--storage.tsdb.no-lockfile",
                  {{ if .Values.thanos.enabled }}
                  '--storage.tsdb.min-block-duration=2h',


### PR DESCRIPTION
Signed-off-by: Karthik Subraveti <ksubraveti@fb.com>

## Summary

This PR contains following changes
### Helm chart changes
- Upgraded prometheus helm chart to enable web admin api. This is required for us to take snapshots and cleanup timeseries

### Terraform changes
- Added `es_disk_threshold` to set the size threshold to trigger elastic search curator to cleanup magma log indices
- Upgraded elastic search curator chart from 2.1.3 -> 2.2.3


### Orcl changes
- Orcl - Added RDS version precheck to prevent upgrade failure to an incompatible DB version
- Orcl - Added RDS precheck to ensure instance class is available in the region where orc8r is being deployed
- Cleaned up Orcl docker image(added go and testlib binaries only when built with appropriate switch)
- Minor bugfixes in configlib code

## Test Plan
- orcl checks ran fine
- elastic search curator ran fine and was able to identify the right indices to look for cleanup
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
