### PR TITLE
refactor(agw): move sync interval randomization from agw to orc8r

### DIFF
--- a/lte/cloud/go/services/lte/servicers/builder_servicer.go
+++ b/lte/cloud/go/services/lte/servicers/builder_servicer.go
@@ -16,6 +16,7 @@ package servicers
 import (
 	"context"
 	"fmt"
+	"hash/fnv"
 	"sort"
 
 	feg "magma/feg/cloud/go/feg"
@@ -196,7 +197,7 @@ func (s *builderServicer) Build(ctx context.Context, request *builder_protos.Bui
 			LteAuthAmf:      nwEpc.LteAuthAmf,
 			SubProfiles:     getSubProfiles(nwEpc),
 			HssRelayEnabled: swag.BoolValue(nwEpc.HssRelayEnabled),
-			SyncInterval:    s.getSyncInterval(nwEpc, gwEpc),
+			SyncInterval:    s.getRandomizedSyncInterval(cellGW.Key, nwEpc, gwEpc),
 		},
 		"policydb": &lte_mconfig.PolicyDB{
 			LogLevel: protos.LogLevel_INFO,
@@ -634,7 +635,7 @@ func getNetworkSentryConfig(network *configurator.Network) *lte_mconfig.SentryCo
 	}
 }
 
-// getSyncInterval takes network-wide subscriberdb sync interval and overrides it if also set for gateway.
+// getSyncInterval takes network-wide subscriberdb sync interval in seconds and overrides it if also set for gateway.
 // If sync interval is unset for both network and gateway, a default is read from lte/cloud/configs/lte.yml
 func (s *builderServicer) getSyncInterval(nwEpc *lte_models.NetworkEpcConfigs, gwEpc *lte_models.GatewayEpcConfigs) uint32 {
 	// minSyncInterval enforces a minimum sync interval to prevent too many
@@ -653,4 +654,21 @@ func (s *builderServicer) getSyncInterval(nwEpc *lte_models.NetworkEpcConfigs, g
 		return s.defaultSubscriberdbSyncInterval
 	}
 	return minSyncInterval
+}
+
+// getRandomizedSyncInterval returns the interval received from getSyncInterval as seconds and increases it by a random
+// delta in the range [0, getSyncInterval() / 5.0]. Increased sync interval ameliorates the thundering herd effect at
+// the orc8r. Delta is deterministic based on gwKey
+func (s *builderServicer) getRandomizedSyncInterval(gwKey string, nwEpc *lte_models.NetworkEpcConfigs, gwEpc *lte_models.GatewayEpcConfigs) uint32 {
+	syncInterval := s.getSyncInterval(nwEpc, gwEpc)
+
+	// FNV-1 is a non-cryptographic hash function that is fast and very simple to implement
+	h := fnv.New32a()
+	_, err := h.Write([]byte(gwKey))
+	if err != nil {
+		return syncInterval
+	}
+	multiplier := float32(h.Sum32()%100) / 100.0
+	delta := multiplier * (float32(syncInterval) / 5.0)
+	return syncInterval + uint32(delta)
 }

--- a/lte/cloud/go/services/lte/servicers/builder_servicer_test.go
+++ b/lte/cloud/go/services/lte/servicers/builder_servicer_test.go
@@ -39,6 +39,16 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+const (
+	// randomizedInterval300 and similar constants are calculated by adding delta * (300/5) to 300 where delta is a
+	// random fraction between 0 and 1 based on the FNV-1 hash of the string "gw1". These constants emulate return
+	// values of builder_servicer.getRandomizedSyncInterval("gw1", 300) etc.
+	randomizedInterval300 = 344
+	randomizedInterval120 = 137
+	randomizedInterval90  = 103
+	randomizedInterval60  = 68
+)
+
 func TestBuilder_Build(t *testing.T) {
 	lte_test_init.StartTestService(t)
 
@@ -160,7 +170,7 @@ func TestBuilder_Build(t *testing.T) {
 			LteAuthAmf:      []byte("\x80\x00"),
 			SubProfiles:     nil,
 			HssRelayEnabled: false,
-			SyncInterval:    300,
+			SyncInterval:    randomizedInterval300,
 		},
 		"policydb": &lte_mconfig.PolicyDB{
 			LogLevel: protos.LogLevel_INFO,
@@ -374,7 +384,7 @@ func TestBuilder_Build_NonNat(t *testing.T) {
 			LteAuthAmf:      []byte("\x80\x00"),
 			SubProfiles:     nil,
 			HssRelayEnabled: false,
-			SyncInterval:    300,
+			SyncInterval:    randomizedInterval300,
 		},
 		"policydb": &lte_mconfig.PolicyDB{
 			LogLevel: protos.LogLevel_INFO,
@@ -653,7 +663,7 @@ func TestBuilder_Build_BaseCase(t *testing.T) {
 			LteAuthAmf:      []byte("\x80\x00"),
 			SubProfiles:     nil,
 			HssRelayEnabled: false,
-			SyncInterval:    300,
+			SyncInterval:    randomizedInterval300,
 		},
 		"policydb": &lte_mconfig.PolicyDB{
 			LogLevel: protos.LogLevel_INFO,
@@ -721,7 +731,7 @@ func TestBuilder_Build_ConfigOverride(t *testing.T) {
 			LteAuthAmf:      []byte("\x80\x00"),
 			SubProfiles:     nil,
 			HssRelayEnabled: false,
-			SyncInterval:    120,
+			SyncInterval:    randomizedInterval120,
 		},
 	}
 
@@ -731,7 +741,7 @@ func TestBuilder_Build_ConfigOverride(t *testing.T) {
 
 	gatewayConfig.Epc.SubscriberdbSyncInterval = lte_models.SubscriberdbSyncInterval(90)
 	// override. gw-specific 90 expected
-	expected["subscriberdb"].(*lte_mconfig.SubscriberDB).SyncInterval = 90
+	expected["subscriberdb"].(*lte_mconfig.SubscriberDB).SyncInterval = randomizedInterval90
 
 	actual, err = buildNonFederated(&nw, &graph, "gw1")
 	assert.NoError(t, err)
@@ -741,7 +751,7 @@ func TestBuilder_Build_ConfigOverride(t *testing.T) {
 	gatewayConfig.Epc.SubscriberdbSyncInterval = 0
 
 	// nw-wide and gw-specific not set. Service-level default expected
-	expected["subscriberdb"].(*lte_mconfig.SubscriberDB).SyncInterval = 300
+	expected["subscriberdb"].(*lte_mconfig.SubscriberDB).SyncInterval = randomizedInterval300
 
 	actual, err = buildNonFederated(&nw, &graph, "gw1")
 	assert.NoError(t, err)
@@ -750,7 +760,7 @@ func TestBuilder_Build_ConfigOverride(t *testing.T) {
 	lte_test_init.StartTestServiceWithConfig(t, lte_service.Config{DefaultSubscriberdbSyncInterval: 30})
 
 	// nw-wide and gw-specific not set. Service-level default (30) too low. Enforced minimum (60) expected
-	expected["subscriberdb"].(*lte_mconfig.SubscriberDB).SyncInterval = 60
+	expected["subscriberdb"].(*lte_mconfig.SubscriberDB).SyncInterval = randomizedInterval60
 
 	actual, err = buildNonFederated(&nw, &graph, "gw1")
 	assert.NoError(t, err)
@@ -880,7 +890,7 @@ func TestBuilder_Build_FederatedBaseCase(t *testing.T) {
 			LteAuthAmf:      []byte("\x80\x00"),
 			SubProfiles:     nil,
 			HssRelayEnabled: false,
-			SyncInterval:    300,
+			SyncInterval:    randomizedInterval300,
 		},
 		"policydb": &lte_mconfig.PolicyDB{
 			LogLevel: protos.LogLevel_INFO,
@@ -1024,7 +1034,7 @@ func TestBuilder_BuildInheritedProperties(t *testing.T) {
 			LteAuthAmf:      []byte("\x80\x00"),
 			SubProfiles:     nil,
 			HssRelayEnabled: false,
-			SyncInterval:    300,
+			SyncInterval:    randomizedInterval300,
 		},
 		"policydb": &lte_mconfig.PolicyDB{
 			LogLevel: protos.LogLevel_INFO,
@@ -1153,7 +1163,7 @@ func TestBuilder_BuildUnmanagedEnbConfig(t *testing.T) {
 			LteAuthAmf:      []byte("\x80\x00"),
 			SubProfiles:     nil,
 			HssRelayEnabled: false,
-			SyncInterval:    300,
+			SyncInterval:    randomizedInterval300,
 		},
 		"policydb": &lte_mconfig.PolicyDB{
 			LogLevel: protos.LogLevel_INFO,
@@ -1288,7 +1298,7 @@ func TestBuilder_BuildCongestionControlConfig(t *testing.T) {
 			LteAuthAmf:      []byte("\x80\x00"),
 			SubProfiles:     nil,
 			HssRelayEnabled: false,
-			SyncInterval:    300,
+			SyncInterval:    randomizedInterval300,
 		},
 		"policydb": &lte_mconfig.PolicyDB{
 			LogLevel: protos.LogLevel_INFO,
@@ -1418,7 +1428,7 @@ func TestBuilder_Build_MMEPool(t *testing.T) {
 			LteAuthAmf:      []byte("\x80\x00"),
 			SubProfiles:     nil,
 			HssRelayEnabled: false,
-			SyncInterval:    300,
+			SyncInterval:    randomizedInterval300,
 		},
 		"policydb": &lte_mconfig.PolicyDB{
 			LogLevel: protos.LogLevel_INFO,

--- a/lte/gateway/configs/gateway.mconfig
+++ b/lte/gateway/configs/gateway.mconfig
@@ -80,7 +80,8 @@
       "@type": "type.googleapis.com/magma.mconfig.SubscriberDB",
       "logLevel": "INFO",
       "lteAuthOp": "EREREREREREREREREREREQ==",
-      "lteAuthAmf": "gAA="
+      "lteAuthAmf": "gAA=",
+      "sync_interval": 300
     },
     "dnsd": {
       "@type": "type.googleapis.com/magma.mconfig.DnsD",

--- a/lte/gateway/configs/subscriberdb.yml
+++ b/lte/gateway/configs/subscriberdb.yml
@@ -19,9 +19,6 @@ print_grpc_payload: False
 # Size of subscriber pages returned from cloud
 subscriber_page_size: 5000
 
-# Interval in seconds between gateway and cloud sync
-subscriberdb_sync_interval: 300  # 5m
-
 # Host address of the Diameter/S6A MME server
 host_address: 0.0.0.0 # Bind to all interfaces
 


### PR DESCRIPTION
Signed-off-by: Waqar Aqeel <waqeel@fb.com>

## Summary
Working towards #7643.

This PR moves the subscriberdb sync interval randomization (added in #7513) from the gateway to the orc8r. The intent is to keep the gateway dumb. The gateway will use the randomized subscriberdb sync interval as received from the orc8r (change made in #7664).

## Test Plan

Modified tests in `builder_servicer_tests` to accept randomized values from the `builder_servicer`. Ran those tests and others from `./build.py -t`. Ran `make test_python` from `lte/gateway` in the magma VM.