### PR TITLE
[lte][agw][doc] Clarification for s1ap tester precondition

### DIFF
--- a/docs/readmes/lte/s1ap_tests.md
+++ b/docs/readmes/lte/s1ap_tests.md
@@ -7,6 +7,13 @@ hide_title: true
 Current testing workflow for VM-only S1AP integration tests. We cover
 gateway-only tests and some general notes.
 
+CRITICAL NOTE: S1AP integration tests are supposed to be run in a headless mode,
+i.e., AGW should not be connected to Orc8r. This is quite critical as S1AP tester
+makes local configurations to Magma AGW in accordance with the testing scenario (e.g.,
+subscriber, APN, policy rules, etc.). If an Orc8r is connected, these configurations
+would be overwritten periodically and also lead to restart of services, both of which will
+interfere with the test scenario.
+
 TODO: Update this document once integration tests with cloud are also supported
 
 Our VM-only tests use 3 Vagrant-managed VMs hosted on the local device (laptop):


### PR DESCRIPTION
Signed-off-by: Ulas Kozat <kozat@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->
- Added a note for the s1ap integration testing to not connect orc8r to the AGW and run it in a headless manner when s1ap tests are executed.

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
