### PR TITLE
clean up sentry related actions in lte-agw-deploy

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -277,32 +277,33 @@ commands:
           done
 
   sentry-upload:
-    description: Upload debug artifacts for an executable to Sentry.io
     parameters:
       executable_name:
         description: Name of executable that should be pushed to sentry
         type: string
     steps:
-      - run: |
-          # The assumption here is that packages.tar.gz was tarred in
-          # $MAGMA_ROOT/circleci in the magma_integ_test step
-          cd circleci/executables
+      - run:
+          name: Upload debug artifacts for an executable to Sentry.io
+          command: |
+            # The assumption here is that packages.tar.gz was tarred in
+            # $MAGMA_ROOT/circleci in the magma_integ_test step
+            cd circleci/executables
 
-          SENTRY_ORG="lf-9c"
-          NATIVE_PROJECT="lab-agws-native"
-          EXEC="<< parameters.executable_name >>"
-          objcopy --only-keep-debug "$EXEC" "$EXEC".debug
-          objcopy --strip-debug --strip-unneeded "$EXEC"
-          objcopy --add-gnu-debuglink="$EXEC".debug "$EXEC"
+            SENTRY_ORG="lf-9c"
+            NATIVE_PROJECT="lab-agws-native"
+            EXEC="<< parameters.executable_name >>"
+            objcopy --only-keep-debug "$EXEC" "$EXEC".debug
+            objcopy --strip-debug --strip-unneeded "$EXEC"
+            objcopy --add-gnu-debuglink="$EXEC".debug "$EXEC"
 
-          # [Optional] Log included debug information
-          sentry-cli difutil check "$EXEC"
-          sentry-cli difutil check "$EXEC".debug
+            # [Optional] Log included debug information
+            sentry-cli difutil check "$EXEC"
+            sentry-cli difutil check "$EXEC".debug
 
-          # Upload the debug artifact with `symtab`, `debug`, and `sources`
-          sentry-cli upload-dif --log-level=info --org="$SENTRY_ORG" --project="$NATIVE_PROJECT" --include-sources  "$EXEC".debug
-          # Upload the stripped executable with `unwind`
-          sentry-cli upload-dif --log-level=info --org="$SENTRY_ORG" --project="$NATIVE_PROJECT" "$EXEC"
+            # Upload the debug artifact with `symtab`, `debug`, and `sources`
+            sentry-cli upload-dif --log-level=info --org="$SENTRY_ORG" --project="$NATIVE_PROJECT" --include-sources  "$EXEC".debug
+            # Upload the stripped executable with `unwind`
+            sentry-cli upload-dif --log-level=info --org="$SENTRY_ORG" --project="$NATIVE_PROJECT" "$EXEC"
 
   sentry-release:
     steps:
@@ -312,17 +313,16 @@ commands:
           command: |
             echo export SENTRY_ENVIRONMENT="staging" >> $BASH_ENV
             echo export SENTRY_ORG="lf-9c" >> $BASH_ENV
-      - run: |
-          cd circleci/executables
-          ls
       - sentry-upload:
           executable_name: sessiond
       - sentry-upload:
           executable_name: mme
-      - run: |
-          sentry-cli --log-level=info releases new -p lab-agws-python -p lab-agws-native ${CIRCLE_SHA1:0:8}
-          sentry-cli --log-level=info releases set-commits --auto --ignore-missing ${CIRCLE_SHA1:0:8}
-          sentry-cli --log-level=info releases finalize ${CIRCLE_SHA1:0:8}
+      - run:
+          name: Create a release in Sentry.io with the commit hash
+          command: |
+            sentry-cli --log-level=info releases new -p lab-agws-python -p lab-agws-native ${CIRCLE_SHA1:0:8}
+            sentry-cli --log-level=info releases set-commits --auto --ignore-missing ${CIRCLE_SHA1:0:8}
+            sentry-cli --log-level=info releases finalize ${CIRCLE_SHA1:0:8}
 
 
   magma_integ_test:


### PR DESCRIPTION
Signed-off-by: Marie Bremner <marwhal@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary
The job is working on master right now, but noticed some very verbose titles. Wanted to clean that up here.

It currently looks like this:
I wanted to get rid of the two very long descriptions, and get rid of the ls step altogether, because I didn't mean to commit that step.
<img width="1370" alt="Screen Shot 2021-06-23 at 9 42 00 AM" src="https://user-images.githubusercontent.com/37634144/123117326-4573ab00-d407-11eb-9347-de43aa6f0c8f.png">


<!-- Enumerate changes you made and why you made them -->

## Test Plan
basic syntax check
```
➜  magma git:(cleanup-sentry-circleci) ✗ circleci config validate -c .circleci/config.yml

Config file at .circleci/config.yml is valid.
```
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
