### PR TITLE
build(mme): fix perm error in AGW docker build appliance

### DIFF
--- a/lte/gateway/docker/mme/Dockerfile.ubuntu20.04
+++ b/lte/gateway/docker/mme/Dockerfile.ubuntu20.04
@@ -260,8 +260,8 @@ RUN git clone https://github.com/include-what-you-use/include-what-you-use && \
 
 #### libfluid is requird to build MME with OVS support
 COPY third_party /tmp/third_party/
-RUN /tmp/third_party/build/bin/libfluid_build.sh && \
-     find . -name magma-libfluid_0.1* -exec dpkg -i {} \; && \
+RUN /tmp/third_party/build/bin/libfluid_build.sh /tmp && \
+     find /tmp -name magma-libfluid_0.1* -exec dpkg -i {} \; && \
      rm -rf /tmp/*
 
 ##### FreeDiameter

--- a/lte/gateway/docker/mme/Dockerfile.ubuntu20.04
+++ b/lte/gateway/docker/mme/Dockerfile.ubuntu20.04
@@ -261,7 +261,7 @@ RUN git clone https://github.com/include-what-you-use/include-what-you-use && \
 #### libfluid is requird to build MME with OVS support
 COPY third_party /tmp/third_party/
 RUN /tmp/third_party/build/bin/libfluid_build.sh /tmp && \
-     find /tmp -name magma-libfluid_0.1* -exec dpkg -i {} \; && \
+     find /tmp -name 'magma-libfluid_0.1*' -exec dpkg -i {} \; && \
      rm -rf /tmp/*
 
 ##### FreeDiameter


### PR DESCRIPTION
## Summary

`find .` fails in some environments (e.g. linux 5.12.10-300.fc34.x86_64 w/
docker 20.10.7) because some paths in /proc/... have special permissions
(e.g. /proc/tty/driver is 500 and owned by nobody:nogroup). Also, there is no
reason to `find .` from `/`. This change instructs libfluid_build to output
to `/tmp` and looks for the resulting package there for install.

## Test Plan

docker build succeeds and `make oai_mme` in /lte/gateway within the resulting docker image succeeds.