### PR TITLE
Add subscriberdb_cache service helm charts and values

### DIFF
--- a/feg/gateway/go.mod
+++ b/feg/gateway/go.mod
@@ -46,7 +46,6 @@ require (
 	google.golang.org/grpc v1.33.2
 	google.golang.org/protobuf v1.26.0
 	gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776 // indirect
-	gotest.tools/gotestsum v1.6.4 // indirect
 	layeh.com/radius v0.0.0-20200615152116-663b41c3bf86
 	magma/feg/cloud/go v0.0.0
 	magma/feg/cloud/go/protos v0.0.0

--- a/lte/cloud/helm/lte-orc8r/Chart.yaml
+++ b/lte/cloud/helm/lte-orc8r/Chart.yaml
@@ -13,7 +13,7 @@ apiVersion: v2
 appVersion: "1.0"
 description: A Helm chart for magma orchestrator's lte module
 name: lte-orc8r
-version: 0.2.4
+version: 0.2.5
 engine: gotpl
 sources:
   - https://github.com/magma/magma

--- a/lte/cloud/helm/lte-orc8r/templates/subscriberdb_cache.deployment.yaml
+++ b/lte/cloud/helm/lte-orc8r/templates/subscriberdb_cache.deployment.yaml
@@ -1,0 +1,52 @@
+{{/*
+# Copyright 2020 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+*/}}
+{{- include "orc8rlib.deployment" (list . "subscriberdb_cache.deployment") -}}
+{{- define "subscriberdb_cache.deployment" -}}
+metadata:
+  name: orc8r-subscriberdb-cache
+  labels:
+    app.kubernetes.io/component: subscriberdb-cache
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: subscriberdb-cache
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/component: subscriberdb-cache
+    spec:
+      containers:
+      -
+{{ include "orc8rlib.container" (list . "subscriberdb_cache.container")}}
+{{- end -}}
+{{- define "subscriberdb_cache.container" -}}
+name: subscriberdb-cache
+command: ["/usr/bin/envdir"]
+args: ["/var/opt/magma/envdir", "/var/opt/magma/bin/subscriberdb_cache", "-run_echo_server=true", "-logtostderr=true", "-v=0"]
+ports:
+  - name: grpc
+    containerPort: 9089
+  - name: http
+    containerPort: 10087
+livenessProbe:
+  tcpSocket:
+    port: 9089
+  initialDelaySeconds: 10
+  periodSeconds: 30
+readinessProbe:
+  tcpSocket:
+    port: 9089
+  initialDelaySeconds: 5
+  periodSeconds: 10
+{{- end -}}

--- a/lte/cloud/helm/lte-orc8r/templates/subscriberdb_cache.pdb.yaml
+++ b/lte/cloud/helm/lte-orc8r/templates/subscriberdb_cache.pdb.yaml
@@ -1,0 +1,25 @@
+{{/*
+Copyright 2020 The Magma Authors.
+
+This source code is licensed under the BSD-style license found in the
+LICENSE file in the root directory of this source tree.
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/}}
+{{- include "orc8rlib.pdb" (list . "subscriberdb_cache.pdb") -}}
+{{- define "subscriberdb_cache.pdb" -}}
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: orc8r-subscriberdb-cache
+  labels:
+    app.kubernetes.io/component: subscriberdb-cache
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: subscriberdb-cache
+{{- end }}

--- a/lte/cloud/helm/lte-orc8r/templates/subscriberdb_cache.service.yaml
+++ b/lte/cloud/helm/lte-orc8r/templates/subscriberdb_cache.service.yaml
@@ -1,0 +1,36 @@
+{{/*
+# Copyright 2020 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+*/}}
+
+{{- include "orc8rlib.service" (list . "subscriberdb_cache.service") -}}
+{{- define "subscriberdb_cache.service" -}}
+metadata:
+  name: orc8r-subscriberdb-cache
+  labels:
+    {{- with .Values.subscriberdb_cache.service.labels }}
+{{ toYaml . | indent 4}}
+    {{- end}}
+  {{- with .Values.subscriberdb_cache.service.annotations }}
+  annotations:
+{{ toYaml . | indent 4}}
+  {{- end }}
+spec:
+  selector:
+    app.kubernetes.io/component: subscriberdb-cache
+  ports:
+    - name: grpc
+      port: 9180
+      targetPort: 9089
+    - name: http
+      port: 8080
+      targetPort: 10087
+{{- end -}}

--- a/lte/cloud/helm/lte-orc8r/values.yaml
+++ b/lte/cloud/helm/lte-orc8r/values.yaml
@@ -137,3 +137,9 @@ smsd:
       orc8r.io/swagger_spec: "true"
     annotations:
       orc8r.io/obsidian_handlers_path_prefixes: "/magma/v1/lte/:network_id/sms"
+
+subscriberdb_cache:
+  service:
+    labels: {}
+    annotations: {}
+

--- a/lte/cloud/helm/lte-orc8r/values.yaml
+++ b/lte/cloud/helm/lte-orc8r/values.yaml
@@ -142,4 +142,3 @@ subscriberdb_cache:
   service:
     labels: {}
     annotations: {}
-

--- a/orc8r/cloud/deploy/orc8r_deployer/docker/root/data/vars.yml
+++ b/orc8r/cloud/deploy/orc8r_deployer/docker/root/data/vars.yml
@@ -294,7 +294,7 @@ platform:
     Type: string
     Required: false
     ConfigApps:
-      - tf     
+      - tf
   orc8r_db_identifier:
     Default: orc8rdb
     Description: Identifier for the RDS instance for Orchestrator.
@@ -305,7 +305,7 @@ platform:
   orc8r_db_instance_class:
     Default: "db.m4.large"
     Description: RDS instance Type for Orchestrator DB.
-    Type: string  
+    Type: string
     Required: false
     ConfigApps:
       - tf
@@ -411,7 +411,7 @@ service:
     Type: number
     Required: false
     ConfigApps:
-      - tf      
+      - tf
   existing_tiller_service_account_name:
     Description: Name of existing Tiller service account to use for Helm.
     Type: string
@@ -477,7 +477,7 @@ service:
     Required: false
     ConfigApps:
       - tf
-    Default: 0.2.4
+    Default: 0.2.5
   monitoring_kubernetes_namespace:
     Description: K8s namespace to install Orchestrator monitoring components into.
     Type: string


### PR DESCRIPTION
Signed-off-by: Yuanyuting Wang <yw3241@columbia.edu>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary

1. Add helm charts in preparation to deploy new orc8r service `subscriberdb_cache`.
<!-- Enumerate changes you made and why you made them -->

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->
1. Applied helm charts and spinned up `subscriberdb_cache` on minikube locally. Service produced reasonable logs.

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
