### PR TITLE
ci: Turn off codecov comment

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,3 +1,4 @@
+comment: false
 coverage:
   status:
     project:
@@ -13,7 +14,7 @@ coverage:
         target: auto
         threshold: 0%
         flags:
-          - feg-lint 
+          - feg-lint
       lte-test:
         target: auto
         threshold: 0%


### PR DESCRIPTION
## Summary

Comment is useless noise due to MME codecov pipeline. Turning off to remove the noisy comments.

## Test Plan

test_in_prod

## Additional Information

- [ ] This change is backwards-breaking