### PR TITLE
ci: Remove commit msg info with broken link

### DIFF
--- a/.github/workflows/pr_bot.yml
+++ b/.github/workflows/pr_bot.yml
@@ -27,7 +27,6 @@ jobs:
 
             Please take a moment to read through the Magma project's
             - [Contributing Conventions](https://docs.magmacore.org/docs/next/contributing/contribute_conventions) for norms around contributed code
-            - [Commit msg style](https://docs.magmacore.org/docs/next/contributing/contribute_commit_msg) recommended style for writing commit msg
 
             If this is your first Magma PR, also consider reading
             - [Developer Onboarding](https://docs.magmacore.org/docs/next/contributing/contribute_onboarding) for onboarding as a new Magma developer


### PR DESCRIPTION
<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary

Link is broken. Also, wrong place for this info, especially since it's not a required check yet

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->