### PR TITLE
feat(nms): Equipment Dashboard Federation Gateway KPIs

### DIFF
--- a/nms/app/packages/magmalte/app/components/GatewayUtils.js
+++ b/nms/app/packages/magmalte/app/components/GatewayUtils.js
@@ -14,12 +14,17 @@
  * @format
  */
 
+import type {EnqueueSnackbarOptions} from 'notistack';
 import type {
   gateway_he_config,
+  gateway_id,
   lte_gateway,
   mutable_cellular_gateway_pool,
   network_dns_config,
+  network_id,
 } from '@fbcnms/magma-api';
+
+import MagmaV1API from '@fbcnms/magma-api/client/WebClient';
 
 export const toString = (input: ?number | ?string): string => {
   return input !== null && input !== undefined ? input + '' : '';
@@ -175,11 +180,20 @@ type GatewayStatusPayload = {
   kernel_versions_installed?: Array<string>,
 };
 
+export type FederationGatewayHealthStatus = {
+  status: string,
+};
+
 const GATEWAY_KEEPALIVE_TIMEOUT_MS = 1000 * 5 * 60;
 
 export const HEALTHY_GATEWAY = 'Good';
 
 export const UNHEALTHY_GATEWAY = 'Bad';
+
+// health status used for federation gateways
+export const HEALTHY_STATUS = 'HEALTHY';
+
+export const UNHEALTHY_STATUS = 'UNHEALTHY';
 
 export default function isGatewayHealthy({status}: lte_gateway) {
   if (status != null) {
@@ -189,6 +203,42 @@ export default function isGatewayHealthy({status}: lte_gateway) {
     }
   }
   return false;
+}
+
+/**
+ * Returns health status of the federation gateway.
+ *
+ * @param {network_id} networkId: Id of the federation network.
+ * @param {gateway_id} gatewayId: Id of the gateway
+ * @param {(msg, cfg,) => ?(string | number),} enqueueSnackbar Snackbar to display error
+ * @returns the health status of the gateway or an empty string for an error.
+ */
+export async function getFederationGatewayHealthStatus(
+  networkId: network_id,
+  gatewayId: gateway_id,
+  enqueueSnackbar?: (
+    msg: string,
+    cfg: EnqueueSnackbarOptions,
+  ) => ?(string | number),
+): Promise<FederationGatewayHealthStatus> {
+  try {
+    const gwHealthStatus = await MagmaV1API.getFegByNetworkIdGatewaysByGatewayIdHealthStatus(
+      {
+        networkId,
+        gatewayId,
+      },
+    );
+    return {status: gwHealthStatus.status};
+  } catch (e) {
+    enqueueSnackbar?.(
+      'failed fetching health status information for federation gateway with id ' +
+        gatewayId,
+      {
+        variant: 'error',
+      },
+    );
+    return {status: ''};
+  }
 }
 
 export const DynamicServices = Object.freeze({

--- a/nms/app/packages/magmalte/app/components/context/FEGGatewayContext.js
+++ b/nms/app/packages/magmalte/app/components/context/FEGGatewayContext.js
@@ -1,0 +1,28 @@
+/**
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @flow strict-local
+ * @format
+ */
+
+import type {FederationGatewayHealthStatus} from '../../components/GatewayUtils';
+import type {federation_gateway, gateway_id} from '@fbcnms/magma-api';
+
+import React from 'react';
+
+export type FEGGatewayContextType = {
+  state: {[string]: federation_gateway},
+  health: {[gateway_id]: FederationGatewayHealthStatus},
+  activeFegGatewayId: gateway_id,
+};
+
+export default React.createContext<FEGGatewayContextType>({});

--- a/nms/app/packages/magmalte/app/components/feg/FEGContext.js
+++ b/nms/app/packages/magmalte/app/components/feg/FEGContext.js
@@ -15,15 +15,24 @@
  */
 
 import * as React from 'react';
+import FEGGatewayContext from '../context/FEGGatewayContext';
 import FEGNetworkContext from '../context/FEGNetworkContext';
 import LoadingFiller from '@fbcnms/ui/components/LoadingFiller';
 import MagmaV1API from '@fbcnms/magma-api/client/WebClient';
 import useMagmaAPI from '@fbcnms/ui/magma/useMagmaAPI';
 
-import type {feg_network, network_id, network_type} from '@fbcnms/magma-api';
+import type {FederationGatewayHealthStatus} from '../../components/GatewayUtils';
+import type {
+  federation_gateway,
+  feg_network,
+  gateway_id,
+  network_id,
+  network_type,
+} from '@fbcnms/magma-api';
 
+import {InitGatewayState} from '../../state/feg/EquipmentState';
 import {UpdateNetworkState as UpdateFegNetworkState} from '../../state/feg/NetworkState';
-import {useCallback, useState} from 'react';
+import {useCallback, useEffect, useState} from 'react';
 import {useEnqueueSnackbar} from '@fbcnms/ui/hooks/useSnackbar';
 
 type Props = {
@@ -31,6 +40,54 @@ type Props = {
   networkType: network_type,
   children: React.Node,
 };
+
+/**
+ * Fetches and returns the federation gateways, their health status and
+ * the active federation gateway id.
+ * @param {network_id} networkId Id of the network
+ * @param {network_type} networkType Type of the network
+ */
+export function FEGGatewayContextProvider(props: Props) {
+  const {networkId} = props;
+  const [fegGateways, setFegGateways] = useState<{
+    [gateway_id]: federation_gateway,
+  }>({});
+  const [fegGatewaysHealthStatus, setFegGatewaysHealthStatus] = useState<{
+    [gateway_id]: FederationGatewayHealthStatus,
+  }>({});
+  const [activeFegGatewayId, setActiveFegGatewayId] = useState<gateway_id>('');
+  const [isLoading, setIsLoading] = useState(true);
+  const enqueueSnackbar = useEnqueueSnackbar();
+
+  useEffect(() => {
+    const fetchState = async () => {
+      await InitGatewayState({
+        networkId,
+        setFegGateways,
+        setFegGatewaysHealthStatus,
+        setActiveFegGatewayId,
+        enqueueSnackbar,
+      });
+      setIsLoading(false);
+    };
+    fetchState();
+  }, [networkId, enqueueSnackbar]);
+
+  if (isLoading) {
+    return <LoadingFiller />;
+  }
+
+  return (
+    <FEGGatewayContext.Provider
+      value={{
+        state: fegGateways,
+        health: fegGatewaysHealthStatus,
+        activeFegGatewayId,
+      }}>
+      {props.children}
+    </FEGGatewayContext.Provider>
+  );
+}
 
 /**
  * Fetches and returns information about the federation network inside
@@ -88,7 +145,9 @@ export function FEGContextProvider(props: Props) {
 
   return (
     <FEGNetworkContextProvider {...{networkId, networkType}}>
-      {props.children}
+      <FEGGatewayContextProvider {...{networkId, networkType}}>
+        {props.children}
+      </FEGGatewayContextProvider>
     </FEGNetworkContextProvider>
   );
 }

--- a/nms/app/packages/magmalte/app/state/feg/EquipmentState.js
+++ b/nms/app/packages/magmalte/app/state/feg/EquipmentState.js
@@ -1,0 +1,138 @@
+/**
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @flow strict-local
+ * @format
+ */
+
+import type {EnqueueSnackbarOptions} from 'notistack';
+import type {FederationGatewayHealthStatus} from '../../components/GatewayUtils';
+import type {
+  federation_gateway,
+  gateway_id,
+  network_id,
+} from '@fbcnms/magma-api';
+
+import MagmaV1API from '@fbcnms/magma-api/client/WebClient';
+import {getFederationGatewayHealthStatus} from '../../components/GatewayUtils';
+
+type InitGatewayStateProps = {
+  networkId: network_id,
+  setFegGateways: ({[string]: federation_gateway}) => void,
+  setFegGatewaysHealthStatus: ({
+    [string]: FederationGatewayHealthStatus,
+  }) => void,
+  setActiveFegGatewayId: (gatewayId: gateway_id) => void,
+  enqueueSnackbar: (
+    msg: string,
+    cfg: EnqueueSnackbarOptions,
+  ) => ?(string | number),
+};
+
+/**
+ * Initializes the federation gateway state which is going to have a maximum of
+ * 2 federation gateways, their health status, and the gateway id of the active
+ * federation gateway.
+ * @param {network_id} networkId Id of the federation network
+ * @param {({[string]: federation_gateway}) => void} setFegGateways Sets federation gateways.
+ * @param {({[string]: FederationGatewayHealthStatus}) => void} setFegGatewaysHealthStatus Sets federation gateways health status.
+ * @param {(gatewayId:gateway_id) => void} setActiveFegGatewayId Sets the active gateway id.
+ * @param {(msg, cfg,) => ?(string | number),} enqueueSnackbar Snackbar to display error
+ */
+export async function InitGatewayState(props: InitGatewayStateProps) {
+  const {
+    networkId,
+    setFegGateways,
+    setFegGatewaysHealthStatus,
+    setActiveFegGatewayId,
+    enqueueSnackbar,
+  } = props;
+  try {
+    const fegGateways = await MagmaV1API.getFegByNetworkIdGateways({
+      networkId: networkId,
+    });
+    const [fegGatewaysHealthStatus, activeFegGatewayId] = await Promise.all([
+      getFegGatewaysHealthStatus(networkId, fegGateways, enqueueSnackbar),
+      getActiveFegGatewayId(networkId, fegGateways, enqueueSnackbar),
+    ]);
+    setFegGateways(fegGateways);
+    setFegGatewaysHealthStatus(fegGatewaysHealthStatus);
+    setActiveFegGatewayId(activeFegGatewayId);
+  } catch (e) {
+    enqueueSnackbar?.('failed fetching federation gateway information', {
+      variant: 'error',
+    });
+  }
+}
+
+/**
+ * Returns an object containing the IDs of the federation gateways mapped to
+ * a boolean value showing each gateway's health status. A boolean value of
+ * true shows that the gateway is healthy.
+ *
+ * @param {network_id} networkId: Id of the federation network.
+ * @param {{[gateway_id]: federation_gateway}} fegGateways Federation gateways of the network.
+ * @param {(msg, cfg,) => ?(string | number),} enqueueSnackbar Snackbar to display error
+ * @returns an object containing the IDs of the federation gateways mapped to their health status.
+ */
+async function getFegGatewaysHealthStatus(
+  networkId: network_id,
+  fegGateways: {[gateway_id]: federation_gateway},
+  enqueueSnackbar?: (
+    msg: string,
+    cfg: EnqueueSnackbarOptions,
+  ) => ?(string | number),
+): Promise<{[gateway_id]: FederationGatewayHealthStatus}> {
+  const fegGatewaysHealthStatus = {};
+  const fegGatewaysId = Object.keys(fegGateways);
+  for (const fegGatewayId of fegGatewaysId) {
+    const healthStatus = await getFederationGatewayHealthStatus(
+      networkId,
+      fegGatewayId,
+      enqueueSnackbar,
+    );
+    fegGatewaysHealthStatus[fegGatewayId] = healthStatus;
+  }
+  return fegGatewaysHealthStatus;
+}
+
+/**
+ * Fetches and returns the active federation gateway id. If it doesn't
+ * have one, then it returns an empty string.
+ *
+ * @param {network_id} networkId: Id of the federation network.
+ * @param {{[gateway_id]: federation_gateway}} fegGateways Federation gateways of the network.
+ * @param {(msg, cfg,) => ?(string | number),} enqueueSnackbar Snackbar to display error
+ * @returns returns the active federation gateway id or an empty string.
+ */
+async function getActiveFegGatewayId(
+  networkId: network_id,
+  fegGateways: {[gateway_id]: federation_gateway},
+  enqueueSnackbar?: (
+    msg: string,
+    cfg: EnqueueSnackbarOptions,
+  ) => ?(string | number),
+): Promise<string> {
+  try {
+    const response = await MagmaV1API.getFegByNetworkIdClusterStatus({
+      networkId,
+    });
+    const activeFegGatewayId = response?.active_gateway;
+    // make sure active gateway id is not a dummy id
+    return fegGateways[activeFegGatewayId] ? activeFegGatewayId : '';
+  } catch (e) {
+    enqueueSnackbar?.('failed fetching active federation gateway id', {
+      variant: 'error',
+    });
+    return '';
+  }
+}

--- a/nms/app/packages/magmalte/app/views/equipment/FEGEquipmentGateway.js
+++ b/nms/app/packages/magmalte/app/views/equipment/FEGEquipmentGateway.js
@@ -14,8 +14,10 @@
  * @format
  */
 
+import FEGEquipmentGatewayKPIs from './FEGEquipmentGatewayKPIs';
 import GatewayCheckinChart from './GatewayCheckinChart';
 import Grid from '@material-ui/core/Grid';
+import Paper from '@material-ui/core/Paper';
 import React from 'react';
 import {makeStyles} from '@material-ui/styles';
 
@@ -38,6 +40,11 @@ export default function FEGGateway() {
       <Grid container justify="space-between" spacing={3}>
         <Grid item xs={12}>
           <GatewayCheckinChart />
+        </Grid>
+        <Grid item xs={12}>
+          <Paper elevation={0}>
+            <FEGEquipmentGatewayKPIs />
+          </Paper>
         </Grid>
       </Grid>
     </div>

--- a/nms/app/packages/magmalte/app/views/equipment/__tests__/FEGEquipmentGatewayTest.js
+++ b/nms/app/packages/magmalte/app/views/equipment/__tests__/FEGEquipmentGatewayTest.js
@@ -1,0 +1,221 @@
+/**
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @flow strict-local
+ * @format
+ */
+
+import 'jest-dom/extend-expect';
+import FEGEquipmentGateway from '../FEGEquipmentGateway';
+import MagmaAPIBindings from '@fbcnms/magma-api';
+import MuiStylesThemeProvider from '@material-ui/styles/ThemeProvider';
+import React from 'react';
+import axiosMock from 'axios';
+import defaultTheme from '@fbcnms/ui/theme/default';
+import {FEGGatewayContextProvider} from '../../../components/feg/FEGContext';
+import {MemoryRouter, Route} from 'react-router-dom';
+import {MuiThemeProvider} from '@material-ui/core/styles';
+import {cleanup, render, wait} from '@testing-library/react';
+import type {
+  federation_gateway,
+  federation_gateway_health_status,
+  federation_network_cluster_status,
+  promql_return_object,
+} from '@fbcnms/magma-api';
+
+jest.mock('axios');
+jest.mock('@fbcnms/magma-api');
+jest.mock('@fbcnms/ui/hooks/useSnackbar');
+afterEach(cleanup);
+
+const mockGw0: federation_gateway = {
+  id: 'test_feg_gw0',
+  name: 'test_gateway',
+  description: 'hello I am a federated gateway',
+  tier: 'default',
+  device: {
+    key: {key: '', key_type: 'SOFTWARE_ECDSA_SHA256'},
+    hardware_id: '',
+  },
+  magmad: {
+    autoupgrade_enabled: true,
+    autoupgrade_poll_interval: 300,
+    checkin_interval: 60,
+    checkin_timeout: 100,
+    tier: 'tier2',
+  },
+  federation: {
+    aaa_server: {},
+    eap_aka: {
+      plmn_ids: [],
+    },
+    gx: {
+      server: {
+        protocol: 'tcp',
+      },
+      servers: [],
+      virtual_apn_rules: [],
+    },
+    gy: {
+      server: {
+        protocol: 'tcp',
+      },
+      servers: [],
+      virtual_apn_rules: [],
+    },
+    health: {
+      health_services: [],
+    },
+    hss: {},
+    s6a: {
+      plmn_ids: [],
+      server: {
+        protocol: 'tcp',
+      },
+    },
+    served_network_ids: [],
+    swx: {
+      hlr_plmn_ids: [],
+      server: {
+        protocol: 'tcp',
+      },
+      servers: [],
+    },
+  },
+  status: {
+    checkin_time: 0,
+    meta: {
+      gps_latitude: '0',
+      gps_longitude: '0',
+      gps_connected: '0',
+      enodeb_connected: '0',
+      mme_connected: '0',
+    },
+  },
+};
+
+const mockCheckinMetric: promql_return_object = {
+  status: 'success',
+  data: {
+    resultType: 'matrix',
+    result: [
+      {
+        metric: {},
+        values: [['1588898968.042', '6']],
+      },
+    ],
+  },
+};
+
+const mockKPIMetric: promql_return_object = {
+  status: 'success',
+  data: {
+    resultType: 'matrix',
+    result: [
+      {
+        metric: {},
+        value: ['1588898968.042', '6'],
+      },
+      {
+        metric: {},
+        value: ['1588898968.042', '8'],
+      },
+    ],
+  },
+};
+
+const mockGw1: federation_gateway = {
+  ...mockGw0,
+  id: 'test_gw1',
+  name: 'test_gateway1',
+};
+
+const fegGateways = {
+  [mockGw0.id]: mockGw0,
+  [mockGw1.id]: mockGw1,
+};
+
+const mockHealthyGatewayStatus: federation_gateway_health_status = {
+  description: '',
+  status: 'HEALTHY',
+};
+
+const mockUnhealthyGatewayStatus: federation_gateway_health_status = {
+  description: '',
+  status: 'UNHEALTHY',
+};
+
+const mockClusterStatus: federation_network_cluster_status = {
+  active_gateway: mockGw0.id,
+};
+
+describe('<FEGEquipmentGateway />', () => {
+  beforeEach(() => {
+    // gateway context gets list of federation gateways
+    MagmaAPIBindings.getFegByNetworkIdGateways.mockResolvedValue(fegGateways);
+    // gateway context gets health status of the gateways
+    MagmaAPIBindings.getFegByNetworkIdGatewaysByGatewayIdHealthStatus.mockImplementation(
+      req => {
+        if (req.gatewayId == mockGw0.id) {
+          // only gateway 0 is healthy
+          return mockHealthyGatewayStatus;
+        }
+        return mockUnhealthyGatewayStatus;
+      },
+    );
+    // gateway context gets the active gateway id
+    MagmaAPIBindings.getFegByNetworkIdClusterStatus.mockResolvedValue(
+      mockClusterStatus,
+    );
+    // called by gateway checkin chart
+    MagmaAPIBindings.getNetworksByNetworkIdPrometheusQueryRange.mockResolvedValue(
+      mockCheckinMetric,
+    );
+    // called when getting max, min and average latency
+    MagmaAPIBindings.getNetworksByNetworkIdPrometheusQuery.mockResolvedValue(
+      mockKPIMetric,
+    );
+  });
+
+  afterEach(() => {
+    axiosMock.get.mockClear();
+  });
+
+  const Wrapper = () => (
+    <MemoryRouter initialEntries={['/nms/mynetwork/gateway']} initialIndex={0}>
+      <MuiThemeProvider theme={defaultTheme}>
+        <MuiStylesThemeProvider theme={defaultTheme}>
+          <FEGGatewayContextProvider networkId="mynetwork" networkType="FEG">
+            <Route
+              path="/nms/:networkId/gateway/"
+              render={props => <FEGEquipmentGateway {...props} />}
+            />
+          </FEGGatewayContextProvider>
+        </MuiStylesThemeProvider>
+      </MuiThemeProvider>
+    </MemoryRouter>
+  );
+
+  it('renders federation gateway KPIs correctly', async () => {
+    const {getByTestId} = render(<Wrapper />);
+    await wait();
+    // verify KPI metrics
+    expect(getByTestId('Max Latency')).toHaveTextContent('8');
+    expect(getByTestId('Min Latency')).toHaveTextContent('6');
+    expect(getByTestId('Avg Latency')).toHaveTextContent('7');
+    expect(getByTestId('Federation Gateway Count')).toHaveTextContent('2');
+    expect(getByTestId('Healthy Federation Gateway Count')).toHaveTextContent(
+      '1',
+    );
+    expect(getByTestId('% Healthy Gateways')).toHaveTextContent('50');
+  });
+});


### PR DESCRIPTION
<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary
This is a draft PR because it is a stacked pr upon an existing open PR #7700 . Once, that PR is approved, this PR would get rebased and would be changed from draft to a normal PR. Context provider was added to share information about the federation gateways, their health and the active gateway id instead of fetching it in each page. Since federation gateways can be a maximum of 2, sharing this information doesn't consume memory. Using the Gateway information, KPIs were added to it to better understand the gateway status. 
<!-- Enumerate changes you made and why you made them -->

## Test Plan
A test was added in a file FEGEquipmentGatewayTest.js. It tests the KPIs information and how the context providers gets the data that is used in the calculation to get the KPI. Also, previous tests were ran and all worked without error.

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information
![Screen Shot 2021-06-24 at 10 08 38 AM](https://user-images.githubusercontent.com/34602743/123277590-3eff3500-d4d4-11eb-9eab-a243d6b38793.png)


<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
