### PR TITLE
[orc8r][terraform]adds random provider back in

### DIFF
--- a/orc8r/cloud/deploy/terraform/orc8r-aws/providers.tf
+++ b/orc8r/cloud/deploy/terraform/orc8r-aws/providers.tf
@@ -15,6 +15,10 @@ provider "aws" {
   region  = var.region
 }
 
+provider "random" {
+  version = "~> 2.1"
+}
+
 data "aws_eks_cluster" "cluster" {
   name = module.eks.cluster_id
 }


### PR DESCRIPTION
Signed-off-by: Sudhi Kandi <sudhikan@fb.com>

## Summary

Adds `random` providers back in. Noticed in cloud upgrade 1.5 -> 1.6 that without this, `terraform refresh` and `terraform plan` fail. Undo's one of the changes from https://github.com/magma/magma/pull/7346

## Test Plan

Tested on the ENS orc8r upgrade. 

## Additional Information

- [ ] This change is backwards-breaking

