### PR TITLE
[AMF] Support for timers t3560, t3550 and t3570

### DIFF
--- a/lte/gateway/c/oai/tasks/amf/CMakeLists.txt
+++ b/lte/gateway/c/oai/tasks/amf/CMakeLists.txt
@@ -53,6 +53,7 @@ add_library(TASK_AMF_APP
     deregistration_request.cpp
     amf_app_pdu_resource_setup_req_rel.cpp
     nas5g_message.cpp
+    amf_app_timer_management.cpp
     ${PROTO_SRCS}
     ${PROTO_HDRS}
 )

--- a/lte/gateway/c/oai/tasks/amf/amf_Security_Mode.cpp
+++ b/lte/gateway/c/oai/tasks/amf/amf_Security_Mode.cpp
@@ -28,9 +28,9 @@ extern "C" {
 #include "amf_fsm.h"
 #include "amf_recv.h"
 #include "amf_sap.h"
+#include "amf_app_timer_management.h"
 
 namespace magma5g {
-extern task_zmq_ctx_s amf_app_task_zmq_ctx;
 
 /****************************************************************************
  **                                                                        **
@@ -64,12 +64,12 @@ int amf_handle_security_complete_response(
   }
   nas_amf_smc_proc_t* smc_proc = get_nas5g_common_procedure_smc(amf_ctx);
   if (smc_proc) {
-    /*
-     * TODO:Stop timer T3560 This to be taken care in upcoming PR
-     */
-
-    stop_timer(&amf_app_task_zmq_ctx, smc_proc->T3560.id);
-    OAILOG_DEBUG(LOG_AMF_APP, "Timer: After stopping SMC MODE timer \n");
+    amf_app_stop_timer(smc_proc->T3560.id);
+    OAILOG_DEBUG(
+        LOG_AMF_APP,
+        "Timer: After stopping timer T3560 for securiy mode command"
+        " with id: %d and ue_id: %d\n",
+        smc_proc->T3560.id, ue_id);
     smc_proc->T3560.id = NAS5G_TIMER_INACTIVE_ID;
 
     OAILOG_DEBUG(

--- a/lte/gateway/c/oai/tasks/amf/amf_app_handler.cpp
+++ b/lte/gateway/c/oai/tasks/amf/amf_app_handler.cpp
@@ -1170,7 +1170,4 @@ int amf_app_handle_notification_received(
       OAILOG_INFO(LOG_AMF_APP, "AMF_APP : default case nothing to do\n");
       break;
   }
-  OAILOG_FUNC_RETURN(LOG_NAS_AMF, rc);
-}
-
-}  // namespace magma5g
+  OAILOG_FUNC_RETURN(LOG_NAS_AMF

--- a/lte/gateway/c/oai/tasks/amf/amf_app_timer_management.cpp
+++ b/lte/gateway/c/oai/tasks/amf/amf_app_timer_management.cpp
@@ -1,0 +1,74 @@
+/*
+Copyright 2020 The Magma Authors.
+
+This source code is licensed under the BSD-style license found in the
+LICENSE file in the root directory of this source tree.
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+//--C includes -----------------------------------------------------------------
+extern "C" {
+#include "log.h"
+#include "conversions.h"
+#include "intertask_interface.h"
+#include "common_types.h"
+}
+#include "amf_app_timer_management.h"
+//--C++ includes ---------------------------------------------------------------
+#include <stdexcept>
+//--Other includes -------------------------------------------------------------
+
+namespace magma5g {
+
+extern task_zmq_ctx_t amf_app_task_zmq_ctx;
+typedef uint32_t timer_arg_t;
+
+//------------------------------------------------------------------------------
+int amf_app_start_timer(
+    size_t msec, timer_repeat_t repeat, zloop_timer_fn handler,
+    timer_arg_t id) {
+  return magma5g::AmfUeContext::Instance().StartTimer(
+      msec, repeat, handler, id);
+}
+
+//------------------------------------------------------------------------------
+void amf_app_stop_timer(int timer_id) {
+  magma5g::AmfUeContext::Instance().StopTimer(timer_id);
+}
+
+//------------------------------------------------------------------------------
+bool amf_app_get_timer_arg(int timer_id, timer_arg_t* arg) {
+  return magma5g::AmfUeContext::Instance().GetTimerArg(timer_id, arg);
+}
+
+//------------------------------------------------------------------------------
+int AmfUeContext::StartTimer(
+    size_t msec, timer_repeat_t repeat, zloop_timer_fn handler,
+    timer_arg_t arg) {
+  int timer_id = -1;
+  if ((timer_id = start_timer(
+           &amf_app_task_zmq_ctx, msec, repeat, handler, nullptr)) != -1) {
+    amf_app_timers.insert(std::pair<int, uint32_t>(timer_id, arg));
+  }
+  return timer_id;
+}
+//------------------------------------------------------------------------------
+void AmfUeContext::StopTimer(int timer_id) {
+  stop_timer(&amf_app_task_zmq_ctx, timer_id);
+  amf_app_timers.erase(timer_id);
+}
+//------------------------------------------------------------------------------
+bool AmfUeContext::GetTimerArg(const int timer_id, timer_arg_t* arg) const {
+  try {
+    *arg = amf_app_timers.at(timer_id);
+    return true;
+  } catch (std::out_of_range& e) {
+    return false;
+  }
+}
+
+}  // namespace magma5g

--- a/lte/gateway/c/oai/tasks/amf/amf_app_timer_management.h
+++ b/lte/gateway/c/oai/tasks/amf/amf_app_timer_management.h
@@ -1,0 +1,69 @@
+/*
+Copyright 2020 The Magma Authors.
+
+This source code is licensed under the BSD-style license found in the
+LICENSE file in the root directory of this source tree.
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#pragma once
+//--C includes -----------------------------------------------------------------
+extern "C" {
+#include "intertask_interface.h"
+}
+////--C++ includes
+///---------------------------------------------------------------
+////--Other includes
+///-------------------------------------------------------------
+#include <czmq.h>
+#include <map>
+#include <stddef.h>
+#include <stdint.h>
+
+namespace magma5g {
+
+typedef uint32_t timer_arg_t;
+
+#define AMF_APP_TIMER_INACTIVE_ID (-1)
+
+int amf_app_start_timer(
+    size_t msec, timer_repeat_t repeat, zloop_timer_fn handler, timer_arg_t id);
+
+void amf_app_stop_timer(int timer_id);
+
+/*void amf_app_resume_timer(
+    struct ue_mm_context_s* const ue_mm_context_pP, time_t start_time,
+    struct amf_app_timer_t* timer, zloop_timer_fn timer_expiry_handler,
+    char* timer_name);
+*/
+
+bool amf_app_get_timer_arg(int timer_id, timer_arg_t* arg);
+
+class AmfUeContext {
+ private:
+  std::map<int, timer_arg_t> amf_app_timers;
+  AmfUeContext() : amf_app_timers(){};
+
+ public:
+  static AmfUeContext& Instance() {
+    static AmfUeContext instance;
+    return instance;
+  }
+
+  AmfUeContext(AmfUeContext const&) = delete;
+  void operator=(AmfUeContext const&) = delete;
+
+  int StartTimer(
+      size_t msec, timer_repeat_t repeat, zloop_timer_fn handler,
+      timer_arg_t id);
+  void StopTimer(int timer_id);
+
+  bool GetTimerArg(const int timer_id, timer_arg_t* arg) const;
+};
+
+}  // namespace magma5g

--- a/lte/gateway/c/oai/tasks/amf/amf_app_ue_context_and_proc.h
+++ b/lte/gateway/c/oai/tasks/amf/amf_app_ue_context_and_proc.h
@@ -389,9 +389,6 @@ amf_ue_ngap_id_t amf_app_ctx_get_new_ue_id(
  * sctp assoc id + gnb_ue_ngap_id */
 void notify_ngap_new_ue_amf_ngap_id_association(
     const ue_m5gmm_context_s* ue_context_p);
-// void amf_remove_ue_context(
-//    amf_ue_context_t* const amf_ue_context,
-//    ue_m5gmm_context_s* const ue_context_p);
 
 ue_m5gmm_context_s* amf_create_new_ue_context(void);
 /*Multi PDU Session*/
@@ -775,8 +772,7 @@ int amf_send_registration_accept(amf_context_t* amf_context);
 int amf_proc_deregistration_request(
     amf_ue_ngap_id_t ue_id, amf_deregistration_request_ies_t* params);
 int amf_app_handle_deregistration_req(amf_ue_ngap_id_t ue_id);
-void amf_remove_ue_context(
-    amf_ue_context_t* amf_ue_context_p, ue_m5gmm_context_s* ue_context_p);
+void amf_remove_ue_context(ue_m5gmm_context_s* ue_context_p);
 void amf_smf_context_cleanup_pdu_session(ue_m5gmm_context_s* ue_context);
 
 // PDU session related communication to gNB

--- a/lte/gateway/c/oai/tasks/amf/amf_as.cpp
+++ b/lte/gateway/c/oai/tasks/amf/amf_as.cpp
@@ -1030,66 +1030,70 @@ static int amf_as_security_req(
         nas5g_auth_info_proc_t* auth_info_proc =
             get_nas5g_cn_procedure_auth_info(amf_ctx);
 
-        memcpy(
-            nas_msg.plain.amf.msg.authenticationrequestmsg.auth_rand.rand_val,
-            auth_info_proc->vector[0]->rand, RAND_LENGTH_OCTETS);
-        memcpy(
-            nas_msg.plain.amf.msg.authenticationrequestmsg.auth_autn.AUTN,
-            auth_info_proc->vector[0]->autn, AUTN_LENGTH_OCTETS);
+        // To check the validitiy of the vectors
+        if ((auth_info_proc) && (auth_info_proc->vector[0])) {
+          memcpy(
+              nas_msg.plain.amf.msg.authenticationrequestmsg.auth_rand.rand_val,
+              auth_info_proc->vector[0]->rand, RAND_LENGTH_OCTETS);
+          memcpy(
+              nas_msg.plain.amf.msg.authenticationrequestmsg.auth_autn.AUTN,
+              auth_info_proc->vector[0]->autn, AUTN_LENGTH_OCTETS);
 
-        if (ue_context->amf_context._security.eksi >= KSI_NO_KEY_AVAILABLE) {
-          ue_context->amf_context._security.eksi = 0;
+          if (ue_context->amf_context._security.eksi >= KSI_NO_KEY_AVAILABLE) {
+            ue_context->amf_context._security.eksi = 0;
+          }
+          OAILOG_INFO(
+              LOG_AMF_APP, "eksi:%x", ue_context->amf_context._security.eksi);
+          memcpy(
+              ue_context->amf_context
+                  ._vector
+                      [ue_context->amf_context._security.eksi %
+                       MAX_EPS_AUTH_VECTORS]
+                  .kasme,
+              auth_info_proc->vector[0]->kasme, KASME_LENGTH_OCTETS);
+          memcpy(
+              ue_context->amf_context
+                  ._vector
+                      [ue_context->amf_context._security.eksi %
+                       MAX_EPS_AUTH_VECTORS]
+                  .autn,
+              auth_info_proc->vector[0]->autn, AUTN_LENGTH_OCTETS);
+          memcpy(
+              ue_context->amf_context
+                  ._vector
+                      [ue_context->amf_context._security.eksi %
+                       MAX_EPS_AUTH_VECTORS]
+                  .rand,
+              auth_info_proc->vector[0]->rand, RAND_LENGTH_OCTETS);
+          memcpy(
+              ue_context->amf_context
+                  ._vector
+                      [ue_context->amf_context._security.eksi %
+                       MAX_EPS_AUTH_VECTORS]
+                  .ck,
+              auth_info_proc->vector[0]->ck, CK_LENGTH_OCTETS);
+          memcpy(
+              ue_context->amf_context
+                  ._vector
+                      [ue_context->amf_context._security.eksi %
+                       MAX_EPS_AUTH_VECTORS]
+                  .ik,
+              auth_info_proc->vector[0]->ik, IK_LENGTH_OCTETS);
+
+          memcpy(
+              ue_context->amf_context
+                  ._vector
+                      [ue_context->amf_context._security.eksi %
+                       MAX_EPS_AUTH_VECTORS]
+                  .xres,
+              auth_info_proc->vector[0]->xres.data,
+              auth_info_proc->vector[0]->xres.size);
+          ue_context->amf_context
+              ._vector
+                  [ue_context->amf_context._security.eksi %
+                   MAX_EPS_AUTH_VECTORS]
+              .xres_size = auth_info_proc->vector[0]->xres.size;
         }
-        OAILOG_INFO(
-            LOG_AMF_APP, "eksi:%x", ue_context->amf_context._security.eksi);
-        memcpy(
-            ue_context->amf_context
-                ._vector
-                    [ue_context->amf_context._security.eksi %
-                     MAX_EPS_AUTH_VECTORS]
-                .kasme,
-            auth_info_proc->vector[0]->kasme, KASME_LENGTH_OCTETS);
-        memcpy(
-            ue_context->amf_context
-                ._vector
-                    [ue_context->amf_context._security.eksi %
-                     MAX_EPS_AUTH_VECTORS]
-                .autn,
-            auth_info_proc->vector[0]->autn, AUTN_LENGTH_OCTETS);
-        memcpy(
-            ue_context->amf_context
-                ._vector
-                    [ue_context->amf_context._security.eksi %
-                     MAX_EPS_AUTH_VECTORS]
-                .rand,
-            auth_info_proc->vector[0]->rand, RAND_LENGTH_OCTETS);
-        memcpy(
-            ue_context->amf_context
-                ._vector
-                    [ue_context->amf_context._security.eksi %
-                     MAX_EPS_AUTH_VECTORS]
-                .ck,
-            auth_info_proc->vector[0]->ck, CK_LENGTH_OCTETS);
-        memcpy(
-            ue_context->amf_context
-                ._vector
-                    [ue_context->amf_context._security.eksi %
-                     MAX_EPS_AUTH_VECTORS]
-                .ik,
-            auth_info_proc->vector[0]->ik, IK_LENGTH_OCTETS);
-
-        memcpy(
-            ue_context->amf_context
-                ._vector
-                    [ue_context->amf_context._security.eksi %
-                     MAX_EPS_AUTH_VECTORS]
-                .xres,
-            auth_info_proc->vector[0]->xres.data,
-            auth_info_proc->vector[0]->xres.size);
-        ue_context->amf_context
-            ._vector
-                [ue_context->amf_context._security.eksi % MAX_EPS_AUTH_VECTORS]
-            .xres_size = auth_info_proc->vector[0]->xres.size;
 
         /* Building 32 bytes of string with serving network SN
          * SN value = 5G:mnc<mnc>.mcc<mcc>.3gppnetwork.org

--- a/lte/gateway/c/oai/tasks/amf/amf_as.cpp
+++ b/lte/gateway/c/oai/tasks/amf/amf_as.cpp
@@ -1030,70 +1030,66 @@ static int amf_as_security_req(
         nas5g_auth_info_proc_t* auth_info_proc =
             get_nas5g_cn_procedure_auth_info(amf_ctx);
 
-        // To check the validitiy of the vectors
-        if ((auth_info_proc) && (auth_info_proc->vector[0])) {
-          memcpy(
-              nas_msg.plain.amf.msg.authenticationrequestmsg.auth_rand.rand_val,
-              auth_info_proc->vector[0]->rand, RAND_LENGTH_OCTETS);
-          memcpy(
-              nas_msg.plain.amf.msg.authenticationrequestmsg.auth_autn.AUTN,
-              auth_info_proc->vector[0]->autn, AUTN_LENGTH_OCTETS);
+        memcpy(
+            nas_msg.plain.amf.msg.authenticationrequestmsg.auth_rand.rand_val,
+            auth_info_proc->vector[0]->rand, RAND_LENGTH_OCTETS);
+        memcpy(
+            nas_msg.plain.amf.msg.authenticationrequestmsg.auth_autn.AUTN,
+            auth_info_proc->vector[0]->autn, AUTN_LENGTH_OCTETS);
 
-          if (ue_context->amf_context._security.eksi >= KSI_NO_KEY_AVAILABLE) {
-            ue_context->amf_context._security.eksi = 0;
-          }
-          OAILOG_INFO(
-              LOG_AMF_APP, "eksi:%x", ue_context->amf_context._security.eksi);
-          memcpy(
-              ue_context->amf_context
-                  ._vector
-                      [ue_context->amf_context._security.eksi %
-                       MAX_EPS_AUTH_VECTORS]
-                  .kasme,
-              auth_info_proc->vector[0]->kasme, KASME_LENGTH_OCTETS);
-          memcpy(
-              ue_context->amf_context
-                  ._vector
-                      [ue_context->amf_context._security.eksi %
-                       MAX_EPS_AUTH_VECTORS]
-                  .autn,
-              auth_info_proc->vector[0]->autn, AUTN_LENGTH_OCTETS);
-          memcpy(
-              ue_context->amf_context
-                  ._vector
-                      [ue_context->amf_context._security.eksi %
-                       MAX_EPS_AUTH_VECTORS]
-                  .rand,
-              auth_info_proc->vector[0]->rand, RAND_LENGTH_OCTETS);
-          memcpy(
-              ue_context->amf_context
-                  ._vector
-                      [ue_context->amf_context._security.eksi %
-                       MAX_EPS_AUTH_VECTORS]
-                  .ck,
-              auth_info_proc->vector[0]->ck, CK_LENGTH_OCTETS);
-          memcpy(
-              ue_context->amf_context
-                  ._vector
-                      [ue_context->amf_context._security.eksi %
-                       MAX_EPS_AUTH_VECTORS]
-                  .ik,
-              auth_info_proc->vector[0]->ik, IK_LENGTH_OCTETS);
-
-          memcpy(
-              ue_context->amf_context
-                  ._vector
-                      [ue_context->amf_context._security.eksi %
-                       MAX_EPS_AUTH_VECTORS]
-                  .xres,
-              auth_info_proc->vector[0]->xres.data,
-              auth_info_proc->vector[0]->xres.size);
-          ue_context->amf_context
-              ._vector
-                  [ue_context->amf_context._security.eksi %
-                   MAX_EPS_AUTH_VECTORS]
-              .xres_size = auth_info_proc->vector[0]->xres.size;
+        if (ue_context->amf_context._security.eksi >= KSI_NO_KEY_AVAILABLE) {
+          ue_context->amf_context._security.eksi = 0;
         }
+        OAILOG_INFO(
+            LOG_AMF_APP, "eksi:%x", ue_context->amf_context._security.eksi);
+        memcpy(
+            ue_context->amf_context
+                ._vector
+                    [ue_context->amf_context._security.eksi %
+                     MAX_EPS_AUTH_VECTORS]
+                .kasme,
+            auth_info_proc->vector[0]->kasme, KASME_LENGTH_OCTETS);
+        memcpy(
+            ue_context->amf_context
+                ._vector
+                    [ue_context->amf_context._security.eksi %
+                     MAX_EPS_AUTH_VECTORS]
+                .autn,
+            auth_info_proc->vector[0]->autn, AUTN_LENGTH_OCTETS);
+        memcpy(
+            ue_context->amf_context
+                ._vector
+                    [ue_context->amf_context._security.eksi %
+                     MAX_EPS_AUTH_VECTORS]
+                .rand,
+            auth_info_proc->vector[0]->rand, RAND_LENGTH_OCTETS);
+        memcpy(
+            ue_context->amf_context
+                ._vector
+                    [ue_context->amf_context._security.eksi %
+                     MAX_EPS_AUTH_VECTORS]
+                .ck,
+            auth_info_proc->vector[0]->ck, CK_LENGTH_OCTETS);
+        memcpy(
+            ue_context->amf_context
+                ._vector
+                    [ue_context->amf_context._security.eksi %
+                     MAX_EPS_AUTH_VECTORS]
+                .ik,
+            auth_info_proc->vector[0]->ik, IK_LENGTH_OCTETS);
+
+        memcpy(
+            ue_context->amf_context
+                ._vector
+                    [ue_context->amf_context._security.eksi %
+                     MAX_EPS_AUTH_VECTORS]
+                .xres,
+            auth_info_proc->vector[0]->xres.data,
+            auth_info_proc->vector[0]->xres.size);
+        ue_context->amf_context
+            ._vector
+                [ue_context->amf_context._security.eksi % MAX_EPS_AUTH_VECTORS]
+            .xres_size = auth_info_proc->vector[0]->xres.size;
 
         /* Building 32 bytes of string with serving network SN
          * SN value = 5G:mnc<mnc>.mcc<mcc>.3gppnetwork.org

--- a/lte/gateway/c/oai/tasks/amf/amf_authentication.cpp
+++ b/lte/gateway/c/oai/tasks/amf/amf_authentication.cpp
@@ -975,4 +975,4 @@ static int authenthication_t3560_handler(
   }
 }
 
-}  // namespace magma5g
+}  // namespace magm

--- a/lte/gateway/c/oai/tasks/amf/amf_authentication.cpp
+++ b/lte/gateway/c/oai/tasks/amf/amf_authentication.cpp
@@ -875,12 +875,10 @@ int amf_send_authentication_request(
 
     if (rc != RETURNerror) {
       OAILOG_ERROR(LOG_NAS_EMM, "Timer:Start Authenthication Timer T3560\n");
-      amf_ue_ngap_id_t* ue_id =
-          (amf_ue_ngap_id_t*) malloc(sizeof(amf_ue_ngap_id_t));
-      *ue_id              = auth_proc->ue_id;
       auth_proc->T3560.id = start_timer(
           &amf_app_task_zmq_ctx, AUTHENTICATION_TIMER_EXPIRY_MSECS,
-          TIMER_REPEAT_ONCE, authenthication_t3560_handler, (void*) ue_id);
+          TIMER_REPEAT_ONCE, authenthication_t3560_handler,
+          (void*) auth_proc->ue_id);
       OAILOG_INFO(LOG_AMF_APP, "Timer: Authenthication timer T3560 started \n");
       OAILOG_INFO(
           LOG_AMF_APP, "Timer: Authenthication timer T3560 id is %d\n",
@@ -901,7 +899,6 @@ static int authenthication_t3560_handler(
   amf_context_t* amf_ctx = NULL;
   amf_ue_ngap_id_t ue_id = 0;
   ue_id                  = *((amf_ue_ngap_id_t*) (arg));
-  free((amf_ue_ngap_id_t*) (arg));
 
   OAILOG_INFO(
       LOG_AMF_APP, "Timer: ZMQ In _identification_t3560_handler - T3560\n");

--- a/lte/gateway/c/oai/tasks/amf/amf_authentication.h
+++ b/lte/gateway/c/oai/tasks/amf/amf_authentication.h
@@ -77,5 +77,4 @@ int amf_nas_proc_authentication_info_answer(itti_amf_subs_auth_info_ans_t* aia);
 nas5g_amf_auth_proc_t* get_nas5g_common_procedure_authentication(
     const amf_context_t* const ctxt);
 
-void amf_proc_stop_t3560_timer(nas5g_amf_auth_proc_t* auth_proc);
 }  // namespace magma5g

--- a/lte/gateway/c/oai/tasks/amf/amf_identity.cpp
+++ b/lte/gateway/c/oai/tasks/amf/amf_identity.cpp
@@ -29,11 +29,11 @@ extern "C" {
 #include "amf_identity.h"
 #include "amf_sap.h"
 #include "amf_recv.h"
+#include "amf_app_timer_management.h"
 
 extern amf_config_t amf_config;
 namespace magma5g {
 
-extern task_zmq_ctx_s amf_app_task_zmq_ctx;
 // Global map of supi to guti along with amf_ue_ngap_id
 std::unordered_map<imsi64_t, guti_and_amf_id_t> amf_supi_guti_map;
 
@@ -145,7 +145,7 @@ int amf_proc_identification_complete(
     OAILOG_INFO(
         LOG_AMF_APP, "Timer: Stopping Identity timer with ID %d\n",
         ident_proc->T3570.id);
-    stop_timer(&amf_app_task_zmq_ctx, ident_proc->T3570.id);
+    amf_app_stop_timer(ident_proc->T3570.id);
     OAILOG_INFO(LOG_AMF_APP, "Timer: After Stopping Identity timer \n");
     ident_proc->T3570.id = NAS5G_TIMER_INACTIVE_ID;
 

--- a/lte/gateway/c/oai/tasks/amf/deregistration_request.cpp
+++ b/lte/gateway/c/oai/tasks/amf/deregistration_request.cpp
@@ -211,7 +211,7 @@ int amf_app_handle_deregistration_req(amf_ue_ngap_id_t ue_id) {
   amf_smf_context_cleanup_pdu_session(ue_context);
 
   // Remove stored UE context from AMF core.
-  amf_remove_ue_context(&amf_app_desc_p->amf_ue_contexts, ue_context);
+  amf_remove_ue_context(ue_context);
 
   OAILOG_FUNC_RETURN(LOG_NAS_AMF, rc);
 }
@@ -259,8 +259,7 @@ void amf_smf_context_cleanup_pdu_session(ue_m5gmm_context_s* ue_context) {
 **                                                                        **
 **                                                                        **
 ***************************************************************************/
-void amf_remove_ue_context(
-    amf_ue_context_t* amf_ue_context_p, ue_m5gmm_context_s* ue_context_p) {
+void amf_remove_ue_context(ue_m5gmm_context_s* ue_context_p) {
   std::unordered_map<amf_ue_ngap_id_t, ue_m5gmm_context_s*>::iterator
       found_ue_id = ue_context_map.find(ue_context_p->amf_ue_ngap_id);
 

--- a/lte/gateway/c/oai/tasks/amf/nas_proc.cpp
+++ b/lte/gateway/c/oai/tasks/amf/nas_proc.cpp
@@ -29,10 +29,10 @@ extern "C" {
 #include "amf_app_ue_context_and_proc.h"
 #include "amf_authentication.h"
 #include "amf_sap.h"
+#include "amf_app_timer_management.h"
 
 extern amf_config_t amf_config;
 namespace magma5g {
-extern task_zmq_ctx_s amf_app_task_zmq_ctx;
 AmfMsg amf_msg_obj;
 static int identification_t3570_handler(zloop_t* loop, int timer_id, void* arg);
 int nas_proc_establish_ind(
@@ -260,12 +260,11 @@ static int amf_identification_request(nas_amf_ident_proc_t* const proc) {
     /*
      * Start Identification T3570 timer
      */
-    // TODO
     OAILOG_INFO(
         LOG_AMF_APP, "AMF_TEST: Timer: Starting Identity timer T3570 \n");
-    proc->T3570.id = start_timer(
-        &amf_app_task_zmq_ctx, IDENTITY_TIMER_EXPIRY_MSECS, TIMER_REPEAT_ONCE,
-        identification_t3570_handler, (void*) proc->ue_id);
+    proc->T3570.id = amf_app_start_timer(
+        IDENTITY_TIMER_EXPIRY_MSECS, TIMER_REPEAT_ONCE,
+        identification_t3570_handler, proc->ue_id);
     OAILOG_INFO(
         LOG_AMF_APP, "Timer: Started Identity timer T3570 with id %d\n",
         proc->T3570.id);
@@ -276,23 +275,27 @@ static int amf_identification_request(nas_amf_ident_proc_t* const proc) {
 /* Identification Timer T3570 Expiry Handler */
 static int identification_t3570_handler(
     zloop_t* loop, int timer_id, void* arg) {
-#if 0  /* TIMER_CHANGES_REVIEW */
-  amf_ue_ngap_id_t ue_id = NULL;
-  ue_id                  = *((amf_ue_ngap_id_t*) (arg));
+  amf_ue_ngap_id_t ue_id = 0;
   amf_context_t* amf_ctx = NULL;
   OAILOG_INFO(LOG_AMF_APP, "Timer: identification T3570 handler \n");
+
+  if (!amf_app_get_timer_arg(timer_id, &ue_id)) {
+    OAILOG_WARNING(
+        LOG_AMF_APP, "Invalid Timer Id expiration, Timer Id: %u\n", timer_id);
+    OAILOG_FUNC_RETURN(LOG_NAS_AMF, RETURNerror);
+  }
 
   ue_m5gmm_context_s* ue_context = amf_ue_context_exists_amf_ue_ngap_id(ue_id);
 
   if (ue_context == NULL) {
     OAILOG_INFO(LOG_AMF_APP, "AMF_TEST: ue_context is NULL\n");
-    return -1;
+    OAILOG_FUNC_RETURN(LOG_NAS_AMF, RETURNerror);
   }
 
   amf_ctx = &ue_context->amf_context;
   if (!(amf_ctx)) {
     OAILOG_ERROR(LOG_AMF_APP, "Timer: T3570 timer expired No AMF context\n");
-    return 1;
+    OAILOG_FUNC_RETURN(LOG_NAS_AMF, RETURNerror);
   }
 
   nas_amf_ident_proc_t* ident_proc =
@@ -303,38 +306,42 @@ static int identification_t3570_handler(
         LOG_AMF_APP, "T3570 timer   timer id %d ue id %d\n",
         ident_proc->T3570.id, ident_proc->ue_id);
     ident_proc->T3570.id = NAS5G_TIMER_INACTIVE_ID;
-  }
-  /*
-   * Increment the retransmission counter
-   */
-  ident_proc->retransmission_count += 1;
-  OAILOG_ERROR(
-      LOG_AMF_APP, "Timer: Incrementing retransmission_count to %d\n",
-      ident_proc->retransmission_count);
+    /*
+     * Increment the retransmission counter
+     */
+    ident_proc->retransmission_count += 1;
+    OAILOG_ERROR(
+        LOG_AMF_APP, "Timer: Incrementing retransmission_count to %d\n",
+        ident_proc->retransmission_count);
 
-  if (ident_proc->retransmission_count < IDENTIFICATION_COUNTER_MAX) {
-    /*
-     * Send identity request message to the UE
-     */
-    OAILOG_ERROR(
-        LOG_AMF_APP, "Timer: IDENTIFICATION_COUNTER_MAX =  %d\n",
-        IDENTIFICATION_COUNTER_MAX);
-    OAILOG_ERROR(
-        LOG_AMF_APP,
-        "Timer: timer has expired Sending Identification request again\n");
-    amf_identification_request(ident_proc);
-  } else {
-    /*
-     * Abort the identification procedure
-     */
-    OAILOG_ERROR(
-        LOG_AMF_APP,
-        "Timer: Maximum retires done hence Abort the identification "
-        "procedure\n");
-    return -1;
+    if (ident_proc->retransmission_count < IDENTIFICATION_COUNTER_MAX) {
+      /*
+       * Send identity request message to the UE
+       */
+      OAILOG_ERROR(
+          LOG_AMF_APP, "Timer: IDENTIFICATION_COUNTER_MAX =  %d\n",
+          IDENTIFICATION_COUNTER_MAX);
+      OAILOG_ERROR(
+          LOG_AMF_APP,
+          "Timer: timer has expired retransmitting Identification request "
+          "again\n");
+      amf_identification_request(ident_proc);
+      OAILOG_FUNC_RETURN(LOG_NAS_AMF, RETURNok);
+    } else {
+      /*
+       * Abort the identification procedure
+       */
+      OAILOG_ERROR(
+          LOG_AMF_APP,
+          "Timer: Maximum retires:%d, for T3570  done hence Abort the "
+          "identification "
+          "procedure\n",
+          ident_proc->retransmission_count);
+      amf_remove_ue_context(ue_context);
+      OAILOG_FUNC_RETURN(LOG_NAS_AMF, RETURNerror);
+    }
   }
-#endif /*  TIMER_CHANGES_REVIEW */
-  return 0;
+  OAILOG_FUNC_RETURN(LOG_NAS_AMF, RETURNerror);
 }
 
 //-------------------------------------------------------------------------------------


### PR DESCRIPTION
<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary

Fixes:
Implemented the timer wrapper APIs to maintain the thread arguments to be consistent in callbacks
Added the missing code functionality to support T3560 timer, t3550 and t3570


## Test Plan

Test cases:
1) Run with UERANSIM to miss the response for authentication request
2) Run with UERANSIM to send the authentication success and failure messages after initial failures
3) Run with UERANSIM to miss the response for registration request
4) Run with UERANSIM to send the registration success and failure messages after initial failures

Signed-off-by: Kaleemullah Mohammed <kaleemullah.mohammed@wavelabs.ai>

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
![authenticationrequest](https://user-images.githubusercontent.com/83354949/123457446-8c2cf500-d601-11eb-867a-0db43dd36444.jpg)
![securitymode](https://user-images.githubusercontent.com/83354949/123457451-8df6b880-d601-11eb-81e1-0e99327416f4.jpg)
![successfulcase](https://user-images.githubusercontent.com/83354949/123457638-bed6ed80-d601-11eb-909f-74d0651cadb1.jpg)
