### PR TITLE
refactor: [ci] Put all helm dependency checks into one check

### DIFF
--- a/.github/workflows/helm-chart-dependency-check.yml
+++ b/.github/workflows/helm-chart-dependency-check.yml
@@ -7,28 +7,59 @@ jobs:
     env:
       MAGMA_ROOT: "${{ github.workspace }}"
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        charts:
-          - ["orc8r", "$MAGMA_ROOT/orc8r/cloud/helm/orc8r/"]
-          - ["cwf-orc8r", "$MAGMA_ROOT/cwf/cloud/helm/cwf-orc8r/"]
-          - ["lte-orc8r", "$MAGMA_ROOT/lte/cloud/helm/lte-orc8r/"]
-          - ["feg-orc8r", "$MAGMA_ROOT/feg/cloud/helm/feg-orc8r/"]
-          - ["fbinternal-orc8r", "$MAGMA_ROOT/fbinternal/cloud/helm/fbinternal-orc8r/"]
-          - ["wifi-orc8r", "$MAGMA_ROOT/wifi/cloud/helm/wifi-orc8r/"]
     name: Check dependency of helm chart ${{ matrix.charts[0] }}
     steps:
       - uses: actions/checkout@v2
-      - name: Get chart.lock digest
+      - name: Check Orc8r
         run: |
-          echo "DIGEST=$(cat ${{ matrix.charts[1] }}Chart.lock | grep digest | cut -d ":" -f 2-3 | xargs)" >> $GITHUB_ENV
-      - name: Run dependency check against ${{ matrix.charts[0] }}
+          echo "DIGEST=$(cat $MAGMA_ROOT/orc8r/cloud/helm/orc8r/Chart.lock | grep digest | cut -d ":" -f 2-3 | xargs)" >> $GITHUB_ENV
+          helm dependency update "$MAGMA_ROOT/orc8r/cloud/helm/orc8r/"
+          echo "NEW_DIGEST=$(cat $MAGMA_ROOT/orc8r/cloud/helm/orc8r/Chart.lock | grep digest | cut -d ":" -f 2-3 | xargs)" >> $GITHUB_ENV
+          if [ "$NEW_DIGEST" != "$NEW_DIGEST" ]; then
+            exit 1
+          fi
+      - name: Check cwf-orc8r
+        if: always()
         run: |
-          helm dependency update "${{ matrix.charts[1] }}"
-      - name: Get new chart.lock digest
+          echo "DIGEST=$(cat $MAGMA_ROOT/cwf/cloud/helm/cwf-orc8r//Chart.lock | grep digest | cut -d ":" -f 2-3 | xargs)" >> $GITHUB_ENV
+          helm dependency update "$MAGMA_ROOT/cwf/cloud/helm/cwf-orc8r/"
+          echo "NEW_DIGEST=$(cat $MAGMA_ROOT/cwf/cloud/helm/cwf-orc8r//Chart.lock | grep digest | cut -d ":" -f 2-3 | xargs)" >> $GITHUB_ENV
+          if [ "$NEW_DIGEST" != "$NEW_DIGEST" ]; then
+            exit 1
+          fi
+      - name: Check lte-orc8r
+        if: always()
         run: |
-          echo "NEW_DIGEST=$(cat ${{ matrix.charts[1] }}Chart.lock | grep digest | cut -d ":" -f 2-3 | xargs)" >> $GITHUB_ENV
-      - name: Verify digest is the same
-        if: ${{ env.DIGEST != env.NEW_DIGEST }}
-        run: exit 1
+          echo "DIGEST=$(cat $MAGMA_ROOT/lte/cloud/helm/lte-orc8r/Chart.lock | grep digest | cut -d ":" -f 2-3 | xargs)" >> $GITHUB_ENV
+          helm dependency update "$MAGMA_ROOT/lte/cloud/helm/lte-orc8r/"
+          echo "NEW_DIGEST=$(cat $MAGMA_ROOT/lte/cloud/helm/lte-orc8r/Chart.lock | grep digest | cut -d ":" -f 2-3 | xargs)" >> $GITHUB_ENV
+          if [ "$NEW_DIGEST" != "$NEW_DIGEST" ]; then
+            exit 1
+          fi
+      - name: Check feg-orc8r
+        if: always()
+        run: |
+          echo "DIGEST=$(cat $MAGMA_ROOT/feg/cloud/helm/feg-orc8r/Chart.lock | grep digest | cut -d ":" -f 2-3 | xargs)" >> $GITHUB_ENV
+          helm dependency update "$MAGMA_ROOT/feg/cloud/helm/feg-orc8r/"
+          echo "NEW_DIGEST=$(cat $MAGMA_ROOT/feg/cloud/helm/feg-orc8r/Chart.lock | grep digest | cut -d ":" -f 2-3 | xargs)" >> $GITHUB_ENV
+          if [ "$NEW_DIGEST" != "$NEW_DIGEST" ]; then
+            exit 1
+          fi
+      - name: Check fbinternal-orc8r
+        if: always()
+        run: |
+          echo "DIGEST=$(cat $MAGMA_ROOT/fbinternal/cloud/helm/fbinternal-orc8r/Chart.lock | grep digest | cut -d ":" -f 2-3 | xargs)" >> $GITHUB_ENV
+          helm dependency update "$MAGMA_ROOT/fbinternal/cloud/helm/fbinternal-orc8r/"
+          echo "NEW_DIGEST=$(cat $MAGMA_ROOT/fbinternal/cloud/helm/fbinternal-orc8r/Chart.lock | grep digest | cut -d ":" -f 2-3 | xargs)" >> $GITHUB_ENV
+          if [ "$NEW_DIGEST" != "$NEW_DIGEST" ]; then
+            exit 1
+          fi
+      - name: Check wifi-orc8r
+        if: always()
+        run: |
+          echo "DIGEST=$(cat $MAGMA_ROOT/wifi/cloud/helm/wifi-orc8r/Chart.lock | grep digest | cut -d ":" -f 2-3 | xargs)" >> $GITHUB_ENV
+          helm dependency update "$MAGMA_ROOT/wifi/cloud/helm/wifi-orc8r/"
+          echo "NEW_DIGEST=$(cat $MAGMA_ROOT/wifi/cloud/helm/wifi-orc8r/Chart.lock | grep digest | cut -d ":" -f 2-3 | xargs)" >> $GITHUB_ENV
+          if [ "$NEW_DIGEST" != "$NEW_DIGEST" ]; then
+            exit 1
+          fi


### PR DESCRIPTION
Signed-off-by: Quentin, Derory <15911421+quentinDERORY@users.noreply.github.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary
Helm checks were too noisy in the PR checks tab.
So we're trimming it down to one github action job.
Still have same functionality

## Test Plan

Tested on PR itself

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
