### PR TITLE
[feg][nms] Fix new FeG creation on NMS to use ECDSA challenge

### DIFF
--- a/nms/app/packages/magmalte/app/components/feg/FEGGatewayDialog.js
+++ b/nms/app/packages/magmalte/app/components/feg/FEGGatewayDialog.js
@@ -222,7 +222,7 @@ export default function FEGGatewayDialog(props: Props) {
               hardware_id: generalFields.hardwareID,
               key: {
                 key: generalFields.challengeKey,
-                key_type: 'ECHO',
+                key_type: 'SOFTWARE_ECDSA_SHA256', // default key type should be ECDSA (do not use ECHO for prod)
               },
             },
             federation: getFederationConfigs(),


### PR DESCRIPTION
Signed-off-by: Evgeniy Makeev <evgeniym@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary

Fix new FeG creation on NMS to use ECDSA challenge

Currently FeG challenge key type is set to ECHO. ECHO is not a secure protocol, it's available only for testing/debugging 
& shouldn't be used in any actual deployments. Switching to SOFTWARE_ECDSA_SHA256 instead.

## Test Plan
staging test 

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
