### PR TITLE
[ci] Migrate entirely docusaurus job to gitub action

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1357,35 +1357,6 @@ jobs:
       - run: sudo ${MAGMA_ROOT}/circleci/fossa-analyze-go.sh
       - magma_slack_notify
 
-  ### DOCUSAURUS
-
-  docusaurus_build_and_deploy:
-    docker:
-      - image: circleci/node:8.11.1
-    environment:
-      DOCUSAURUS_URL: https://magma.github.io
-      DOCUSAURUS_BASE_URL: /magma/
-    steps:
-      - checkout
-      - build/determinator:
-          <<: *docs_only
-      - run:
-          name: Setup docusaurus expected directory structure
-          command: |
-            mv docs/docusaurus website/
-            mv docs/readmes readmes/
-            rm -rf docs/
-            mv readmes/ docs/
-      - run:
-          name: Deploying to GitHub Pages
-          command: |
-            git config --global user.email "bots@magmacore.org"
-            git config --global user.name "magma-docusaurus-bot"
-            echo "machine github.com login magma-docusaurus-bot password $GITHUB_TOKEN" > ~/.netrc
-            cd website && yarn install
-            CUSTOM_COMMIT_MESSAGE="[skip ci] Deploy website" GIT_USER=magma-docusaurus-bot yarn run publish-gh-pages
-      - magma_slack_notify
-
   ### XWF
 
   xwfm-test:
@@ -1726,11 +1697,6 @@ workflows:
             - eslint
             - nms-yarn-test
             - nms-e2e-test
-
-  docusaurus:
-   jobs:
-    - docusaurus_build_and_deploy:
-        <<: *only_master
 
   fossa:
     jobs:

--- a/.github/workflows/docusaurus-workflow.yml
+++ b/.github/workflows/docusaurus-workflow.yml
@@ -29,4 +29,14 @@ jobs:
             cd website && yarn install
             CUSTOM_COMMIT_MESSAGE="[skip ci] Deploy website" GIT_USER=magma-docusaurus-bot yarn run publish-gh-pages
             # yamllint enable
-      # - magma_slack_notify
+      # Notify ci channel when failing
+      # Plugin info: https://github.com/marketplace/actions/slack-notify
+      - name: Notify failure to slack
+        if: failure() && github.ref == 'refs/heads/master'
+        uses: rtCamp/action-slack-notify@v2.0.2
+        env:
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_CI }}
+          SLACK_TITLE: "Github action Docusaurus update failed"
+          SLACK_USERNAME: "Docusaurus update "
+          SLACK_ICON_EMOJI: ":boom:"
+          SLACK_COLOR: "#FF0000"


### PR DESCRIPTION
Signed-off-by: Quentin, Derory <15911421+quentinDERORY@users.noreply.github.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary

Remove circle ci job and add the slack notification

## Test Plan

Docusaurus job already running in master: https://github.com/magma/magma/runs/2908949052?check_suite_focus=true 

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
