### PR TITLE
updated path to install agw on debian

### DIFF
--- a/docs/docusaurus/versioned_docs/version-1.5.0/lte/deploy_install.md
+++ b/docs/docusaurus/versioned_docs/version-1.5.0/lte/deploy_install.md
@@ -53,7 +53,7 @@ installation process to get an IP using DHCP.
 
 ```bash
 su
-wget https://raw.githubusercontent.com/facebookincubator/magma/v1.4/lte/gateway/deploy/agw_install.sh
+wget https://raw.githubusercontent.com/magma/magma/master/lte/gateway/deploy/agw_install.sh
 bash agw_install.sh
 ```
 


### PR DESCRIPTION
<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary

Updated documentation to point debian installer to master

## Test Plan

wget https://raw.githubusercontent.com/magma/magma/master/lte/gateway/deploy/agw_install.sh
bash agw_install.sh

[Install logs > ](https://gist.github.com/shanku9/97c258d61cf9debe11896a5615b89e41)
## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
