### PR TITLE
fix(ci): add sftp config in the sshd_config file we use to provision VMs

### DIFF
--- a/lte/gateway/deploy/roles/dev_common/files/sshd_config
+++ b/lte/gateway/deploy/roles/dev_common/files/sshd_config
@@ -86,3 +86,5 @@ UsePAM yes
 X11Forwarding yes
 ClientAliveInterval 60
 ClientAliveCountMax 50
+
+Subsystem    sftp    /usr/lib/openssh/sftp-server

--- a/lte/gateway/deploy/roles/focal_hacks/tasks/main.yml
+++ b/lte/gateway/deploy/roles/focal_hacks/tasks/main.yml
@@ -17,22 +17,3 @@
     path: /usr/include/json.hpp
     state: link
     src: /usr/include/nlohmann/json.hpp
-
-- name: Check if sftp is enabled
-  shell: grep -c "Subsystem    sftp    /usr/lib/openssh/sftp-server" /etc/ssh/sshd_config || true
-  register: sftp_enabled
-  become: yes
-
-- name: Add sftp config to sshd_config
-  lineinfile:
-    dest: /etc/ssh/sshd_config
-    line: Subsystem    sftp    /usr/lib/openssh/sftp-server
-  when: sftp_enabled.stdout == "0"
-  become: yes
-
-- name: Reload service ssh, in all cases
-  ansible.builtin.service:
-    name: ssh
-    state: reloaded
-  when: sftp_enabled.stdout == "0"
-  become: yes

--- a/lte/gateway/fabfile.py
+++ b/lte/gateway/fabfile.py
@@ -300,10 +300,10 @@ def get_test_summaries(
         dst_path="/tmp"):
     local('mkdir -p ' + dst_path)
 
-    # Currently broken on master: GH7688
-    # _switch_to_vm_no_provision(gateway_host, "magma", "magma_dev.yml")
-    # with settings(warn_only=True):
-    #     get(remote_path=TEST_SUMMARY_GLOB, local_path=dst_path)
+    # TODO we may want to zip up all these files
+    _switch_to_vm_no_provision(gateway_host, "magma", "magma_dev.yml")
+    with settings(warn_only=True):
+        get(remote_path=TEST_SUMMARY_GLOB, local_path=dst_path)
     _switch_to_vm_no_provision(test_host, "magma_test", "magma_test.yml")
     with settings(warn_only=True):
         get(remote_path=TEST_SUMMARY_GLOB, local_path=dst_path)


### PR DESCRIPTION
Signed-off-by: Marie Bremner <marwhal@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary
We had added some steps to add sftp in `focal_hack` task, but little did we know we already have a step to configure `/etc/magam/sshd_config`. Swapping the roles in this PR: https://github.com/magma/magma/pull/7742 made it so that we overwrite our changes.

This PR makes it so that the sftp change is included in the file we use to set `/etc/magam/sshd_config`.
<!-- Enumerate changes you made and why you made them -->

## Test Plan
testing locally...
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
