### PR TITLE
add version prefix to commit hash so it's easier to filter releases o…

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -315,10 +315,13 @@ commands:
           executable_name: sessiond
       - sentry-upload:
           executable_name: mme
-      - run: |
-          sentry-cli --log-level=info releases new -p lab-agws-python -p lab-agws-native ${CIRCLE_SHA1:0:8}
-          sentry-cli --log-level=info releases set-commits --auto --ignore-missing ${CIRCLE_SHA1:0:8}
-          sentry-cli --log-level=info releases finalize ${CIRCLE_SHA1:0:8}
+      - run:
+          name: Create a release in Sentry.io with the commit hash
+          command: |
+            COMMIT_HASH_WITH_VERSION="v1.6-${CIRCLE_SHA1:0:8}"
+            sentry-cli --log-level=info releases new -p lab-agws-python -p lab-agws-native ${COMMIT_HASH_WITH_VERSION}
+            sentry-cli --log-level=info releases set-commits --auto --ignore-missing ${COMMIT_HASH_WITH_VERSION}
+            sentry-cli --log-level=info releases finalize ${COMMIT_HASH_WITH_VERSION}
 
 
   magma_integ_test:

--- a/lte/gateway/release/build-magma.sh
+++ b/lte/gateway/release/build-magma.sh
@@ -290,6 +290,7 @@ if [ -d ${PY_TMP_BUILD} ]; then
 fi
 
 FULL_VERSION=${VERSION}-$(date +%s)-${COMMIT_HASH}
+COMMIT_HASH_WITH_VERSION=${VERSION}-${COMMIT_HASH}
 
 # first do python protos and then build the python packages.
 # library will be dropped in $PY_TMP_BUILD/usr/lib/python3/dist-packages
@@ -342,7 +343,7 @@ trap "rm -f '${SCTPD_VERSION_FILE}' '${SCTPD_MIN_VERSION_FILE}' '${COMMIT_HASH_F
 
 echo "${FULL_VERSION}" > "${SCTPD_VERSION_FILE}"
 echo "${SCTPD_MIN_VERSION}" > "${SCTPD_MIN_VERSION_FILE}"
-echo "COMMIT_HASH=\"${COMMIT_HASH}\"" > "${COMMIT_HASH_FILE}"
+echo "COMMIT_HASH=\"${COMMIT_HASH_WITH_VERSION}\"" > "${COMMIT_HASH_FILE}"
 
 BUILDCMD="fpm \
 -s dir \


### PR DESCRIPTION
…n sentry

Signed-off-by: Marie Bremner <marwhal@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary
The release version just being the commit hash is terrible for sorting by release :) (like all releases associated with v1.6 vs v1.5, etc.)

Adding a v1.6 prefix to the related values so we can sort by `v1.6*`
<!-- Enumerate changes you made and why you made them -->

## Test Plan
test agw build locally
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
