### PR TITLE
[MME][LOG] Use unsigned decimal for all UE ID logging

### DIFF
--- a/lte/gateway/c/core/oai/common/common_types.h
+++ b/lte/gateway/c/core/oai/common/common_types.h
@@ -69,13 +69,10 @@ typedef uint64_t enb_s1ap_id_key_t;
 
 //------------------------------------------------------------------------------
 // UE S1AP IDs
-
 #define INVALID_ENB_UE_S1AP_ID_KEY 0xFFFFFFFFFFFFFFFF
 #define ENB_UE_S1AP_ID_MASK 0x00FFFFFF
-#define ENB_UE_S1AP_ID_FMT "0x%06" PRIX32
-
-#define MME_UE_S1AP_ID_FMT "0x%08" PRIX32
-
+#define ENB_UE_S1AP_ID_FMT "%u"
+#define MME_UE_S1AP_ID_FMT "%u"
 #define COMP_S1AP_ID_FMT "0x%016" PRIX64
 
 /* INVALID_MME_UE_S1AP_ID
@@ -88,12 +85,10 @@ typedef uint64_t enb_s1ap_id_key_t;
 
 // UE NGAP IDs
 #define INVALID_AMF_UE_NGAP_ID 0x0
-
 #define INVALID_GNB_UE_NGAP_ID_KEY 0xFFFFFFFFFFFFFFFF
 #define GNB_UE_NGAP_ID_MASK 0x00FFFFFF
-#define GNB_UE_NGAP_ID_FMT "0x%06" PRIX32
-
-#define AMF_UE_NGAP_ID_FMT "0x%08" PRIX32
+#define GNB_UE_NGAP_ID_FMT "%u"
+#define AMF_UE_NGAP_ID_FMT "%u"
 
 /* INVALID_AMF_UE_NGAP_ID
  * Any value between 0..2^32-1, is allowed/valid as per 3GPP spec 36.413.
@@ -111,7 +106,7 @@ typedef uint64_t enb_s1ap_id_key_t;
 //------------------------------------------------------------------------------
 // TEIDs
 typedef uint32_t teid_t;
-#define TEID_FMT "0x%" PRIX32
+#define TEID_FMT "%u"
 #define TEID_SCAN_FMT SCNx32
 typedef teid_t s11_teid_t;
 typedef teid_t s1u_teid_t;

--- a/lte/gateway/c/core/oai/tasks/mme_app/mme_app_bearer.c
+++ b/lte/gateway/c/core/oai/tasks/mme_app/mme_app_bearer.c
@@ -1659,7 +1659,7 @@ void mme_app_handle_release_access_bearers_resp(
 
   if (ue_context_p == NULL) {
     OAILOG_DEBUG(
-        LOG_MME_APP, "We didn't find this teid in list of UE: %" PRIX32 "\n",
+        LOG_MME_APP, "We didn't find this teid in list of UE: " TEID_FMT "\n",
         rel_access_bearers_rsp_pP->teid);
     OAILOG_FUNC_OUT(LOG_MME_APP);
   }
@@ -1694,7 +1694,7 @@ void mme_app_handle_s11_create_bearer_req(
 
   if (ue_context_p == NULL) {
     OAILOG_DEBUG(
-        LOG_MME_APP, "We didn't find this teid in list of UE: %" PRIX32 "\n",
+        LOG_MME_APP, "We didn't find this teid in list of UE: " TEID_FMT "\n",
         create_bearer_request_pP->teid);
     OAILOG_FUNC_OUT(LOG_MME_APP);
   }
@@ -2471,20 +2471,20 @@ void mme_app_handle_suspend_acknowledge(
 
   OAILOG_FUNC_IN(LOG_MME_APP);
   OAILOG_INFO(
-      LOG_MME_APP, "Rx Suspend Acknowledge with MME_S11_TEID :%d \n",
+      LOG_MME_APP, "Rx Suspend Acknowledge with MME_S11_TEID: " TEID_FMT "\n",
       suspend_acknowledge_pP->teid);
 
   ue_context_p = mme_ue_context_exists_s11_teid(
       &mme_app_desc_p->mme_ue_contexts, suspend_acknowledge_pP->teid);
   if (ue_context_p == NULL) {
     OAILOG_ERROR(
-        LOG_MME_APP, "We didn't find this teid in list of UE: %" PRIX32 "\n",
+        LOG_MME_APP, "We didn't find this teid in list of UE: " TEID_FMT "\n",
         suspend_acknowledge_pP->teid);
     OAILOG_FUNC_OUT(LOG_MME_APP);
   }
   OAILOG_DEBUG_UE(
       LOG_MME_APP, ue_context_p->emm_context._imsi64,
-      " Rx Suspend Acknowledge with MME_S11_TEID " TEID_FMT "\n",
+      " Rx Suspend Acknowledge with MME_S11_TEID: " TEID_FMT "\n",
       suspend_acknowledge_pP->teid);
   /*
    * Updating statistics
@@ -3599,7 +3599,7 @@ void mme_app_handle_path_switch_request(
     OAILOG_ERROR(
         LOG_MME_APP,
         "PATH_SWITCH_REQUEST RECEIVED, Failed to find UE context for "
-        "mme_ue_s1ap_id 0x%06" PRIX32 " \n",
+        "mme_ue_s1ap_id " MME_UE_S1AP_ID_FMT " \n",
         path_switch_req_p->mme_ue_s1ap_id);
     OAILOG_FUNC_OUT(LOG_MME_APP);
   }

--- a/lte/gateway/c/core/oai/tasks/mme_app/mme_app_context.c
+++ b/lte/gateway/c/core/oai/tasks/mme_app/mme_app_context.c
@@ -1669,7 +1669,7 @@ void mme_app_handle_s1ap_ue_context_modification_fail(
     OAILOG_ERROR(
         LOG_MME_APP,
         " UE CONTEXT MODIFICATION FAILURE RECEIVED, Failed to find UE context"
-        "for mme_ue_s1ap_id 0x%06" PRIX32 " \n",
+        "for mme_ue_s1ap_id " MME_UE_S1AP_ID_FMT "\n",
         s1ap_ue_context_mod_fail->mme_ue_s1ap_id);
     OAILOG_FUNC_OUT(LOG_MME_APP);
   }
@@ -1705,7 +1705,7 @@ void mme_app_handle_s1ap_ue_context_modification_resp(
     OAILOG_ERROR(
         LOG_MME_APP,
         " UE CONTEXT MODIFICATION RESPONSE RECEIVED, Failed to find UE context"
-        "for mme_ue_s1ap_id 0x%06" PRIX32 " \n",
+        "for mme_ue_s1ap_id " MME_UE_S1AP_ID_FMT " \n",
         s1ap_ue_context_mod_resp->mme_ue_s1ap_id);
     OAILOG_FUNC_OUT(LOG_MME_APP);
   }

--- a/lte/gateway/c/core/oai/tasks/mme_app/mme_app_itti_messaging.h
+++ b/lte/gateway/c/core/oai/tasks/mme_app/mme_app_itti_messaging.h
@@ -86,8 +86,8 @@ static inline void mme_app_itti_ue_context_mod_for_csfb(
   }
   OAILOG_INFO(
       LOG_MME_APP,
-      "Sent S1AP_UE_CONTEXT_MODIFICATION_REQUEST mme_ue_s1ap_id %06" PRIX32
-      " \n",
+      "Sent S1AP_UE_CONTEXT_MODIFICATION_REQUEST "
+      "mme_ue_s1ap_id " MME_UE_S1AP_ID_FMT "\n",
       S1AP_UE_CONTEXT_MODIFICATION_REQUEST(message_p).mme_ue_s1ap_id);
   send_msg_to_task(&mme_app_task_zmq_ctx, TASK_S1AP, message_p);
 


### PR DESCRIPTION
Signed-off-by: Tariq Al-Khasib <talkhasib@fb.com>

## Summary

We currently use a mix of decimal and hex logging for UE IDs. This is a bit confusing when parsing MME logs.
Unify logging to use unsigned decimal

## Test Plan

Built on local vagrant box and tested using s1ap integ test
