### PR TITLE
fix(ci): add back sentry-release job to v1.6 lte-agw-deploy-release job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -770,6 +770,7 @@ jobs:
           test: 'False'
           build: 'True'
           deploy: 'True'
+      - sentry-release
       - notify-magma:
           artifact_name: LTE AGW
           version_path: versions/magma_version


### PR DESCRIPTION
<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary
Fixing regression on CI from https://github.com/magma/magma/pull/7787

we need this in CI to have the executables be uploaded automatically
<!-- Enumerate changes you made and why you made them -->

## Test Plan
```
➜  magma git:(add-sentry-release-v1.6) ✗ circleci config validate -c .circleci/config.yml

Config file at .circleci/config.yml is valid.
```
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
