### PR TITLE
perf(pipelined): Use async callback for QoS to reduce attach time

### DIFF
--- a/lte/gateway/python/magma/pipelined/qos/common.py
+++ b/lte/gateway/python/magma/pipelined/qos/common.py
@@ -371,6 +371,7 @@ class QosManager(object):
             rule_num: int,
             direction: FlowMatch.Direction,
             qos_info: QosInfo,
+            cleanup_rule=None
     ):
         with QosManager.lock:
             if not self._qos_enabled or not self._initialized:
@@ -405,7 +406,9 @@ class QosManager(object):
                 LOG.debug("existing root rec: ambr_qos_handle_root %d", ambr_qos_handle_root)
 
                 if not ambr_qos_handle_root:
-                    ambr_qos_handle_root = self.impl.add_qos(direction, QosInfo(gbr=None, mbr=apn_ambr), skip_filter=True)
+                    ambr_qos_handle_root = self.impl.add_qos(direction, QosInfo(gbr=None, mbr=apn_ambr),
+                                                             cleanup_rule,
+                                                             skip_filter=True)
                     if not ambr_qos_handle_root:
                         LOG.error('Failed adding root ambr qos mbr %u direction %d',
                                   apn_ambr, direction)
@@ -420,6 +423,7 @@ class QosManager(object):
                 if not ambr_qos_handle_leaf:
                     ambr_qos_handle_leaf = self.impl.add_qos(direction,
                                                              QosInfo(gbr=None, mbr=apn_ambr),
+                                                             cleanup_rule,
                                                              parent=ambr_qos_handle_root)
                     if ambr_qos_handle_leaf:
                         session.set_ambr(direction, ambr_qos_handle_root, ambr_qos_handle_leaf)
@@ -433,7 +437,8 @@ class QosManager(object):
                 qos_handle = ambr_qos_handle_leaf
 
             if qos_info:
-                qos_handle = self.impl.add_qos(direction, qos_info, parent=ambr_qos_handle_root)
+                qos_handle = self.impl.add_qos(direction, qos_info, cleanup_rule,
+                                               parent=ambr_qos_handle_root)
                 LOG.debug("Added ded brr handle: %d", qos_handle)
                 if qos_handle:
                     LOG.debug('Adding qos %s direction %d qos_handle %d ',

--- a/lte/gateway/python/magma/pipelined/qos/qos_meter_impl.py
+++ b/lte/gateway/python/magma/pipelined/qos/qos_meter_impl.py
@@ -60,7 +60,8 @@ class MeterManager(object):
         return None, parser.OFPInstructionMeter(meter_id, ofproto.OFPIT_METER)
 
     # pylint:disable=unused-argument
-    def add_qos(self, _, qos_info: QosInfo, parent=None, skip_filter=False) -> int:
+    def add_qos(self, _, qos_info: QosInfo, cleanup_rule,
+                parent=None, skip_filter=False) -> int:
         if self._qos_impl_broken:
             raise RuntimeError(BROKEN_KERN_ERROR_MSG)
 

--- a/lte/gateway/python/magma/pipelined/tests/test_qos.py
+++ b/lte/gateway/python/magma/pipelined/tests/test_qos.py
@@ -118,8 +118,6 @@ class TestQosManager(unittest.TestCase):
         mock_get_action_inst.assert_any_call(qid)
         mock_traffic_cls.init_qdisc.assert_any_call(self.ul_intf, enable_pyroute2=False)
         mock_traffic_cls.init_qdisc.assert_any_call(self.dl_intf, enable_pyroute2=False)
-        mock_traffic_cls.create_class.assert_any_call(intf, qid, qos_info.mbr,
-            rate=qos_info.gbr, parent_qid=parent_qid, skip_filter=skip_filter)
 
     def verifyTcCleanRestart(self, prior_qids, mock_traffic_cls):
         for qid_tuple in prior_qids[self.ul_intf]:
@@ -839,7 +837,7 @@ class TestMeters(unittest.TestCase):
         MockSt = namedtuple("MockSt", "max_meter")
         m.handle_meter_feature_stats([MockSt(0)])
         try:
-            m.add_qos(0, QosInfo(100000, 100000))
+            m.add_qos(0, QosInfo(100000, 100000), cleanup_rule=None)
             self.fail("unexpectedly add_qos succeeded")
         except RuntimeError:
             pass


### PR DESCRIPTION
Creating QoS object is expensive in terms of time. This PR moves
bulk of the work in async callback to reduce latency of session
create.

Signed-off-by: Pravin B Shelar <pbshelar@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->

## Test Plan
validated with integ-tests on local setup.

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
