### PR TITLE
Update ci job ownership docs

### DIFF
--- a/docs/docusaurus/i18n/en.json
+++ b/docs/docusaurus/i18n/en.json
@@ -20,6 +20,9 @@
       "contributing/contribute_codeowners": {
         "title": "Codeowners Workflow"
       },
+      "contributing/contribute_commit_msg": {
+        "title": "Commit message style"
+      },
       "contributing/contribute_conventions": {
         "title": "Contributing Conventions"
       },

--- a/docs/readmes/contributing/contribute_ci_checks.md
+++ b/docs/readmes/contributing/contribute_ci_checks.md
@@ -18,24 +18,27 @@ When submitting PRs to the Magma repo, a suite of Continuous Integration tests a
 | GCC Warnings & Errors / gen_build_container | Passive Check generates container for GCC builds |  |
 | GCC Warnings & Errors / build_oai | Annotate Pull Requests with any GCC Warnings or Errors for MME target | electronjoe (GH), Scott Moeller (slack) |
 | GCC Warnings & Errors / build_session_manager | Annotate Pull Requests with any GCC Warnings or Errors for session_manager target | electronjoe (GH), Scott Moeller (slack) |
-| Jenkins | ? |  |
-| Jenkins CWAG Libvirt | CWAG Docker Compose based integration test? |  themarwhal (GH), Marie Bremner (slack) |
+| Jenkins | LTE integration test suite in Jenkins | mattymo (GH), Matthew Mosesohn |
+| Jenkins CWAG Libvirt | CWF integration test suite in Jenkins |  themarwhal (GH), Marie Bremner (slack) |
 | Jenkins LTE | A lighter weight and low flake subset of LTE tests including...? |  |
 | Code scanning results / CodeQL | How does this differ from the other CodeQL / Analyzer stages? |  |
 | Magma CI autolabel | ? |  |
 | Magma-OAI-Jenkins | OAI's MME integration test run on OAI Jenkins | rdefosse (GH), Raphael Defosseux (slack) |
 | ci/circleci: c-cpp-codecov | AGW c/c++ unit tests and push coverage to codecov.io | electronjoe (GH), Scott Moeller (slack) |
-| ci/circleci: cloud-test | ? |  |
+| ci/circleci: cloud-test | Orc8r unit tests | hcgatewood (GH), Hunter Gatewood (slack) |
 | ci/circleci: cloud_lint | ? |  |
-| ci/circleci: cwag-precommit | ? |  |
+| ci/circleci: cwag-precommit | CWF Unit Tests | themarwhal (GH), Marie Bremner (slack); uri200 (GH), Oriol Batalla (slack) |
+| ci/circleci: cwag-build | Validate that CWAG builds | themarwhal (GH), Marie Bremner (slack); uri200 (GH), Oriol Batalla (slack) |
+| ci/circleci: cwf-integ-test | Run CWF integration test suite in CircleCI | themarwhal (GH), Marie Bremner (slack); uri200 (GH), Oriol Batalla (slack) |
 | ci/circleci: cwf-operator-build | ? |  |
 | ci/circleci: cwf-operator-precommit | ? |  |
 | ci/circleci: eslint | ? |  |
-| ci/circleci: feg-build | Builds Docker images for FEG | themarwhal (GH), Marie Bremner (slack); mpgermano(GH), Michael Germano (slack); uri200 (GH), Oriol Batalla (slack); emakeev (GH), Evgeniy Makeev (slack) |
-| ci/circleci: feg-lint | FEG Go linter and code coverage | themarwhal (GH), Marie Bremner (slack); mpgermano(GH), Michael Germano (slack); uri200 (GH), Oriol Batalla (slack); emakeev (GH), Evgeniy Makeev (slack) |
-| ci/circleci: feg-precommit | Runs FEG unittest | themarwhal (GH), Marie Bremner (slack); mpgermano(GH), Michael Germano (slack); uri200 (GH), Oriol Batalla (slack); emakeev (GH), Evgeniy Makeev (slack) |
+| ci/circleci: feg-build | 	Validate that FeG builds | themarwhal (GH), Marie Bremner (slack); uri200 (GH), Oriol Batalla (slack); emakeev (GH), emak (slack) |
+| ci/circleci: feg-lint | FEG Go linter and code coverage | themarwhal (GH), Marie Bremner (slack);  uri200 (GH), Oriol Batalla (slack); emakeev (GH), emak (slack) |
+| ci/circleci: feg-precommit | Run FEG unit tests | themarwhal (GH), Marie Bremner (slack);  uri200 (GH), Oriol Batalla (slack); emakeev (GH), emak (slack) |
 | ci/circleci: insync-checkin | ? |  |
-| ci/circleci: lte-test | ? Is this dupe with Jenkins LTE?... |  |
+| ci/circleci: lte-test | Run AGW Python unit tests | pshelar (GH), Pravin Shelar (slack); ardzoht (GH), Alex Rodriguez (slack) |
+| ci/circleci: lte-integ-test | Run LTE integration test suite in CircleCI | ardzoht (GH), Alex Rodriguez (slack); ulaskozat (GH), Ulas Kozat (slack) |
 | ci/circleci: mme_test | Validate that MME related unit tests build and pass | themarwhal (GH), Marie Bremner (slack) |
 | ci/circleci: nms-build | Validate that the NMS builds | karthiksubravet (GH), karthik subraveti (slack); andreilee (GH), Andre Lee (slack) |
 | ci/circleci: nms-e2e-test | ? | karthiksubravet (GH), karthik subraveti (slack); andreilee (GH), Andre Lee (slack) |

--- a/feg/gateway/go.sum
+++ b/feg/gateway/go.sum
@@ -718,6 +718,7 @@ github.com/tidwall/pretty v1.0.0 h1:HsD+QiTn7sK6flMKIvNmpqz1qrpP3Ps6jOKIKMooyg4=
 github.com/tidwall/pretty v1.0.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=
 github.com/tklauser/go-sysconf v0.3.4 h1:HT8SVixZd3IzLdfs/xlpq0jeSfTX57g1v6wB1EuzV7M=
 github.com/tklauser/go-sysconf v0.3.4/go.mod h1:Cl2c8ZRWfHD5IrfHo9VN+FX9kCFjIOyVklgXycLB6ek=
+github.com/tklauser/numcpus v0.2.1 h1:ct88eFm+Q7m2ZfXJdan1xYoXKlmwsfP+k88q05KvlZc=
 github.com/tklauser/numcpus v0.2.1/go.mod h1:9aU+wOc6WjUIZEwWMP62PL/41d65P+iks1gBkr4QyP8=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=


### PR DESCRIPTION
Signed-off-by: Marie Bremner <marwhal@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary
Update the CI job ownership doc to include the lte / cwf integration test jobs
Also removed Michael from the doc as he is no longer a maintainer
<!-- Enumerate changes you made and why you made them -->

## Test Plan
docusaurus builds locally
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
