### PR TITLE
docs: add slack/github id mappings for all magma maintainers

### DIFF
--- a/docs/docusaurus/i18n/en.json
+++ b/docs/docusaurus/i18n/en.json
@@ -26,6 +26,9 @@
       "contributing/contribute_conventions": {
         "title": "Contributing Conventions"
       },
+      "contributing/contribute_id_mappings": {
+        "title": "Codeowners GitHub to Slack IDs"
+      },
       "contributing/contribute_onboarding": {
         "title": "Developer Onboarding"
       },

--- a/docs/docusaurus/sidebars.json
+++ b/docs/docusaurus/sidebars.json
@@ -189,7 +189,8 @@
       "contributing/contribute_workflow",
       "contributing/contribute_conventions",
       "contributing/contribute_ci_checks",
-      "contributing/contribute_codeowners"
+      "contributing/contribute_codeowners",
+      "contributing/contribute_id_mappings"
     ],
     "Technical Reference": [
       {

--- a/docs/readmes/contributing/contribute_id_mappings.md
+++ b/docs/readmes/contributing/contribute_id_mappings.md
@@ -1,0 +1,34 @@
+---
+id: contribute_id_mappings
+title: Codeowners GitHub to Slack IDs
+hide_title: true
+---
+
+Here are the Github to Slack ID mappings for all [Magma maintainers](https://github.com/orgs/magma/teams/repo-magma-maintain).
+
+Instructions on joining our Slack workspace is provided in the [Magma community page](https://www.magmacore.org/community/).
+
+| GitHub           | Slack (email)                          | Slack (displayname)     |
+| ---------------- | -------------------------------------- | ----------------------- |
+| 119Vik           | vitalii@freedomfi.com                  | VitaliiKostenko         |
+| aharonnovo       |                                        |
+| amarpad          | amarpad@gmail.com                      | AmarPadmanabhan         |
+| andreilee        | andreilee@fb.com                       | AndreiLee               |
+| ardzoht          | alexrod@fb.com                         | AlexRodriguez           |
+| arunuke          | arunt@fb.com                           | ArunThulasi             |
+| electronjoe      | smoeller@fb.com                        | ScottMoeller            |
+| emakeev          | evgeniym@fb.com                        | emak                    |
+| HannaFar         | hfarag@fb.com                          | HannaFarag              |
+| hcgatewood       | hcgatewood@fb.com                      | HunterGatewood(FB)      |
+| karthiksubraveti | ksubraveti@fb.com                      | karthiksubraveti        |
+| koolzz           | koolzz@fb.com                          | NickYurchenko           |
+| lionelgo         | lionel.gauthier@eurecom.fr             | LionelGauthier(Eurecom) |
+| mattymo          | matt@freedomfi.com                     | MatthewMosesohn         |
+| pshelar          | pbshelar@fb.com                        | pravin                  |
+| quentinDERORY    | derory.quentin@gmail.com               | QuentinDerory           |
+| rdefosse         | raphael.defosseux@openairinterface.org | RaphaelDefosseux(OSA)   |
+| ssanadhya        | ssanadhya@fb.com                       | Shruti                  |
+| themarwhal       | marwhal@fb.com                         | MarieBremner            |
+| tmdzk            | timdzik@fb.com                         | Tim                     |
+| ulaskozat        | kozat@fb.com                           | UlasKozat               |
+| uri200           | obatalla@fb.com                        | OriolBatalla            |


### PR DESCRIPTION


Signed-off-by: Marie Bremner <marwhal@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary
add a source of truth for all slack <-> github id mappings
added it under the contribute section in docusaurus, but please suggest alternate locations if it doesn't fit here.

TODO:
1. add a reference to this doc in the PR bot
2. remove slack / github ID mappings from the [CI job document](http://localhost:3000/docs/next/contributing/contribute_ci_checks) and just point to this doc
3. Add a note in magma-repo-maintain that this doc should be updated whenever a member is added / removed
<!-- Enumerate changes you made and why you made them -->

## Test Plan
create docusaurus locally
<img width="1164" alt="Screen Shot 2021-07-01 at 10 00 01 AM" src="https://user-images.githubusercontent.com/37634144/124146155-1dadc400-da53-11eb-8365-2234701809c4.png">

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
