### PR TITLE
Fixed Subscriber add dialog to show saved errors

### DIFF
--- a/nms/app/packages/magmalte/app/views/subscriber/SubscriberAddDialog.js
+++ b/nms/app/packages/magmalte/app/views/subscriber/SubscriberAddDialog.js
@@ -590,6 +590,14 @@ function AddSubscriberDetails(props: DialogProps) {
         const errMsg = e.response?.data?.message ?? e.message ?? e;
         subscriberErrors +=
           'error saving ' + subscriber.imsi + ' : ' + errMsg + '\n';
+        //report saved errors if we reach end of loop without calling bulkadd.
+        if (i == subscribers.length - 1) {
+          setError(subscriberErrors);
+          enqueueSnackbar('Saving subscribers to the api failed: ', {
+            variant: 'error',
+          });
+          return;
+        }
       }
     }
     enqueueSnackbar(


### PR DESCRIPTION
Signed-off-by: Dani Menewuyelet <dmenewuy@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary
The add dialogue bulkily adds 1000 subscribers at a time. If it gets any error in the middle of reading the 1000 subscribers, it saves them and finally shows them when it reaches the 1000th subscriber or if it reaches the end of the subscribers list(if we were adding less than 1000 subscriber). However, the previous implementation missed the condition where the last subscriber to be added resulted in an error. For that case, it would append the error but since there are no more subscribers to loop at, it returns without showing the saved errors. So, the changes in this PR makes sure that if the last subscriber resulted in an error, all the saved errors should be shown since we wouldn't get another chance to report those errors. 
<!-- Enumerate changes you made and why you made them -->

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
