### PR TITLE
[feg] add commit information in feg images. Add build.py to feg

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -806,7 +806,7 @@ jobs:
           name: build docker
           command: |
             cd ${MAGMA_ROOT}/feg/gateway/docker
-            DOCKER_REGISTRY=feg_ docker-compose build --parallel
+            DOCKER_REGISTRY=feg_ ./build.py
       - run:
           name: run docker containers and check health
           command: |

--- a/feg/gateway/Makefile
+++ b/feg/gateway/Makefile
@@ -1,5 +1,7 @@
 .PHONY: all build download fmt test clean run install build_only gen precommit
 
+MAGMA_GIT_COMMIT := $(shell git rev-list -1 HEAD)
+
 ifndef MAGMA_ROOT
 MAGMA_ROOT = /home/$USER/magma
 endif
@@ -18,6 +20,7 @@ download:
 	go mod download
 
 install:
+	#go install -ldflags "-X main.MagmaGitCommit=$(MAGMA_GIT_COMMIT)"  ./... magma/gateway/services/magmad
 	go install ./... magma/gateway/services/magmad
 
 install_envoy_controller:

--- a/feg/gateway/docker/.env
+++ b/feg/gateway/docker/.env
@@ -26,4 +26,4 @@ CONFIGS_TEMPLATES_PATH=../../../orc8r/gateway/configs/templates
 CERTS_VOLUME=gwcerts
 CONFIGS_VOLUME=gwconfigs
 
-LOG_DRIVER=journald
+#LOG_DRIVER=journald

--- a/feg/gateway/docker/build.py
+++ b/feg/gateway/docker/build.py
@@ -1,0 +1,204 @@
+#!/usr/bin/env python3
+
+"""
+Copyright 2021 The Magma Authors.
+
+This source code is licensed under the BSD-style license found in the
+LICENSE file in the root directory of this source tree.
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import argparse
+import json
+import glob
+import os
+import shutil
+import subprocess
+from collections import namedtuple
+from typing import Iterable, List, Optional
+
+
+HOST_MAGMA_ROOT = '../../../.'
+
+def main() -> None:
+    args = _parse_args()
+
+    if args.mount:
+        _run(['up', '-d', 'test'])
+        _run(['exec', 'test', 'bash'])
+        _down(args)
+
+    elif args.lint:
+        _run(['up', '-d', 'test'])
+        _run(['exec', 'test', 'make', 'lint'])
+        _down(args)
+
+    elif args.precommit:
+        _run(['up', '-d', 'test'])
+        _run(['exec', 'test', 'make', 'precommit'])
+        _down(args)
+
+    elif args.coverage:
+        _run(['up', '-d', 'test'])
+        _run(['exec', 'test', 'make', 'cover'])
+        _down(args)
+
+    elif args.tests:
+        _run(['up', '-d', 'test'])
+        _run(['exec', 'test', 'make', 'test'])
+        _down(args)
+
+    elif args.health:
+        _run(['up', '-d'])
+        _run_health()
+        _down(args)
+
+    elif args.git:
+       print(json.dumps(_run_get_git_vars(), indent=4, sort_keys=True))
+
+    else:
+        _run(['build'] + _get_default_build_args(args))
+        _down(args)
+
+def _run(cmd: List[str]) -> None:
+    """ Run the required docker-compose command """
+    cmd = ['docker-compose'] + cmd
+    print("Running '%s'..." % ' '.join(cmd))
+    try:
+        subprocess.run(cmd, check=True)
+    except subprocess.CalledProcessError as err:
+        exit(err.returncode)
+
+def _down(args: argparse.Namespace) -> None:
+    if args.down:
+         _run(['down'])
+
+def _get_default_build_args(args: argparse.Namespace) -> List[str]:
+    ret = []
+    git_info = _run_get_git_vars()
+
+    for arg, val in git_info.items():
+        ret.append("--build-arg")
+        ret.append("{}={}".format(arg, val))
+
+    if args.parallel:
+        ret.append('--parallel')
+    if args.nocache:
+        ret.append('--no-cache')
+    return ret
+
+
+def _run_get_git_vars():
+    try:
+        cmd = "tools/get_version_info.sh"
+        cmd_res = subprocess.run(cmd, check=True, capture_output=True)
+    except subprocess.CalledProcessError as err:
+        print("Error _run_get_git_vars")
+        exit(err.returncode)
+    version_info_json = json.loads(cmd_res.stdout)
+    return version_info_json
+
+def _run_health():
+    try:
+        cmd = "tools/docker_ps_healthcheck.sh"
+        res = subprocess.run(cmd, check=True)
+    except subprocess.CalledProcessError as err:
+        print("Error _run_health")
+        exit(err.returncode)
+    return
+
+def _parse_args() -> argparse.Namespace:
+    """ Parse the command line args """
+
+    # There are multiple ways to invoke finer-grained control over which
+    # images are built.
+    #
+    # (1) How many images to build
+    #
+    # all: all images
+    # default: images required for minimum functionality
+    #   - excluding metrics images
+    #   - including postgres, proxy, etc
+    #
+    # (2) Of the core orc8r images, which modules to build
+    #
+    # Defaults to all modules, but can be further specified by targeting a
+    # deployment type.
+
+    parser = argparse.ArgumentParser(description='Orc8r build tool')
+
+    # Run something
+    parser.add_argument(
+        '--tests', '-t',
+        action='store_true',
+        help='Run unit tests',
+    )
+
+    parser.add_argument(
+        '--mount', '-m',
+        action='store_true',
+        help='Mount the source code and create a bash shell',
+    )
+
+    parser.add_argument(
+        '--precommit', '-c',
+        action='store_true',
+        help='Mount the source code and run pre-commit checks',
+    )
+
+    parser.add_argument(
+        '--coverage', '-o',
+        action='store_true',
+        help='Generate test coverage statistics',
+    )
+
+    parser.add_argument(
+        '--lint', '-l',
+        action='store_true',
+        help='Run lint test',
+    )
+
+    parser.add_argument(
+        '--health', '-e',
+        action='store_true',
+        help='Run health test',
+    )
+
+    # Run something
+    parser.add_argument(
+        '--git', '-g',
+        action='store_true',
+        help='Get git info',
+    )
+
+    # How to do it
+    parser.add_argument(
+        '--nocache', '-n',
+        action='store_true',
+        help='Build the images with no Docker layer caching',
+    )
+    parser.add_argument(
+        '--parallel', '-p',
+        action='store_true',
+        default=False,
+        help='Build containers in parallel',
+    )
+    parser.add_argument(
+        '--down', '-down',
+        action='store_true',
+        default=False,
+        help='Leave containers up after running tests',
+    )
+
+    args = parser.parse_args()
+    return args
+
+
+if __name__ == '__main__':
+    main()
+

--- a/feg/gateway/docker/go/Dockerfile
+++ b/feg/gateway/docker/go/Dockerfile
@@ -119,6 +119,10 @@ COPY --from=builder /root/.cache /root/.cache
 # Production image
 # -----------------------------------------------------------------------------
 FROM ubuntu:bionic AS gateway_go
+ARG MAGMA_BUILD_BRANCH=unknown
+ARG MAGMA_BUILD_TAG=unknown
+ARG MAGMA_BUILD_COMMIT_HASH=unknonw
+ARG MAGMA_BUILD_COMMIT_DATE=unknown
 
 # Install envdir.
 RUN apt-get -y update && apt-get -y install daemontools netcat gettext musl
@@ -137,3 +141,9 @@ COPY feg/gateway/configs /etc/magma
 RUN mkdir -p /var/opt/magma/envdir
 RUN mkdir -p /var/opt/magma/configs
 RUN mkdir -p /var/opt/magma/tmp
+
+# Add commit information
+ENV MAGMA_BUILD_BRANCH $MAGMA_BUILD_BRANCH
+ENV MAGMA_BUILD_TAG $MAGMA_BUILD_TAG
+ENV MAGMA_BUILD_COMMIT_HASH $MAGMA_BUILD_COMMIT_HASH
+ENV MAGMA_BUILD_COMMIT_DATE $MAGMA_BUILD_COMMIT_DATE

--- a/feg/gateway/docker/python/Dockerfile
+++ b/feg/gateway/docker/python/Dockerfile
@@ -64,6 +64,10 @@ RUN make -C $MAGMA_ROOT/orc8r/gateway/python swagger
 # Production image
 # -----------------------------------------------------------------------------
 FROM ubuntu:focal AS gateway_python
+ARG MAGMA_BUILD_BRANCH=unknown
+ARG MAGMA_BUILD_TAG=unknown
+ARG MAGMA_BUILD_COMMIT_HASH=unknonw
+ARG MAGMA_BUILD_COMMIT_DATE=unknown
 
 # Add the magma apt repo
 RUN apt-get update && \
@@ -129,3 +133,9 @@ COPY orc8r/gateway/configs/templates /etc/magma/templates
 
 RUN mkdir -p /var/opt/magma/configs
 RUN mkdir -p /var/opt/magma/fluent-bit
+
+# Add commit information
+ENV MAGMA_BUILD_BRANCH $MAGMA_BUILD_BRANCH
+ENV MAGMA_BUILD_TAG $MAGMA_BUILD_TAG
+ENV MAGMA_BUILD_COMMIT_HASH $MAGMA_BUILD_COMMIT_HASH
+ENV MAGMA_BUILD_COMMIT_DATE $MAGMA_BUILD_COMMIT_DATE

--- a/feg/gateway/go.mod
+++ b/feg/gateway/go.mod
@@ -46,6 +46,7 @@ require (
 	google.golang.org/grpc v1.33.2
 	google.golang.org/protobuf v1.26.0
 	gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776 // indirect
+	gotest.tools/gotestsum v1.6.4 // indirect
 	layeh.com/radius v0.0.0-20200615152116-663b41c3bf86
 	magma/feg/cloud/go v0.0.0
 	magma/feg/cloud/go/protos v0.0.0

--- a/feg/gateway/services/csfb/csfb/main.go
+++ b/feg/gateway/services/csfb/csfb/main.go
@@ -24,6 +24,7 @@ import (
 	"magma/feg/gateway/services/csfb/servicers"
 	"magma/feg/gateway/services/csfb/servicers/decode"
 	"magma/feg/gateway/services/csfb/servicers/decode/message"
+	"magma/feg/gateway/utils"
 	"magma/orc8r/lib/go/service"
 
 	"github.com/golang/glog"
@@ -36,6 +37,7 @@ func init() {
 }
 
 func main() {
+	glog.Info(utils.PrintBuildInfo())
 	// Create the service
 	srv, err := service.NewServiceWithOptions(registry.ModuleName, registry.CSFB)
 	if err != nil {

--- a/feg/gateway/services/eap/providers/aka/eap_aka/main.go
+++ b/feg/gateway/services/eap/providers/aka/eap_aka/main.go
@@ -17,6 +17,8 @@ package main
 import (
 	"flag"
 
+	"magma/feg/gateway/utils"
+
 	"github.com/golang/glog"
 
 	"magma/feg/cloud/go/protos/mconfig"
@@ -34,6 +36,7 @@ func init() {
 }
 
 func main() {
+	glog.Info(utils.PrintBuildInfo())
 	// Create the EAP AKA Provider service
 	srv, err := service.NewServiceWithOptions(registry.ModuleName, registry.EAP_AKA)
 	if err != nil {

--- a/feg/gateway/services/eap/providers/sim/eap_sim/main.go
+++ b/feg/gateway/services/eap/providers/sim/eap_sim/main.go
@@ -17,6 +17,8 @@ package main
 import (
 	"flag"
 
+	"magma/feg/gateway/utils"
+
 	"github.com/golang/glog"
 
 	"magma/feg/cloud/go/protos/mconfig"
@@ -34,6 +36,7 @@ func init() {
 }
 
 func main() {
+	glog.Info(utils.PrintBuildInfo())
 	// Create the EAP SIM Provider service
 	srv, err := service.NewServiceWithOptions(registry.ModuleName, registry.EAP_SIM)
 	if err != nil {

--- a/feg/gateway/services/feg_hello/main.go
+++ b/feg/gateway/services/feg_hello/main.go
@@ -19,6 +19,7 @@ import (
 	"magma/feg/cloud/go/protos"
 	"magma/feg/gateway/registry"
 	"magma/feg/gateway/services/feg_hello/servicers"
+	"magma/feg/gateway/utils"
 	"magma/orc8r/lib/go/service"
 
 	"github.com/golang/glog"
@@ -29,6 +30,7 @@ func init() {
 }
 
 func main() {
+	glog.Info(utils.PrintBuildInfo())
 	// Create the service
 	srv, err := service.NewServiceWithOptions(registry.ModuleName, registry.FEG_HELLO)
 	if err != nil {

--- a/feg/gateway/services/gateway_health/gateway_health/main.go
+++ b/feg/gateway/services/gateway_health/gateway_health/main.go
@@ -19,6 +19,7 @@ import (
 
 	"magma/feg/gateway/registry"
 	"magma/feg/gateway/services/gateway_health/health_manager"
+	"magma/feg/gateway/utils"
 	"magma/orc8r/lib/go/service"
 
 	"github.com/golang/glog"
@@ -29,6 +30,7 @@ func init() {
 }
 
 func main() {
+	glog.Info(utils.PrintBuildInfo())
 	// Create the service
 	srv, err := service.NewServiceWithOptions(registry.ModuleName, registry.HEALTH)
 	if err != nil {

--- a/feg/gateway/services/s6a_proxy/s6a_proxy/main.go
+++ b/feg/gateway/services/s6a_proxy/s6a_proxy/main.go
@@ -18,12 +18,16 @@ package main
 
 import (
 	"flag"
+	"fmt"
 	"log"
 
 	"magma/feg/cloud/go/protos"
 	"magma/feg/gateway/registry"
 	"magma/feg/gateway/services/s6a_proxy/servicers"
+	"magma/feg/gateway/utils"
 	"magma/orc8r/lib/go/service"
+
+	"github.com/golang/glog"
 )
 
 func init() {
@@ -31,6 +35,7 @@ func init() {
 }
 
 func main() {
+	glog.Info(fmt.Print(utils.PrintBuildInfo()))
 	// Create the service
 	srv, err := service.NewServiceWithOptions(registry.ModuleName, registry.S6A_PROXY)
 	if err != nil {

--- a/feg/gateway/services/s8_proxy/s8_proxy/main.go
+++ b/feg/gateway/services/s8_proxy/s8_proxy/main.go
@@ -19,6 +19,7 @@ import (
 	"magma/feg/cloud/go/protos"
 	"magma/feg/gateway/registry"
 	"magma/feg/gateway/services/s8_proxy/servicers"
+	"magma/feg/gateway/utils"
 	"magma/orc8r/lib/go/service"
 
 	"github.com/golang/glog"
@@ -29,6 +30,7 @@ func init() {
 }
 
 func main() {
+	glog.Info(utils.PrintBuildInfo())
 	// Create the service
 	srv, err := service.NewServiceWithOptions(registry.ModuleName, registry.S8_PROXY)
 	if err != nil {

--- a/feg/gateway/services/session_proxy/session_proxy/main.go
+++ b/feg/gateway/services/session_proxy/session_proxy/main.go
@@ -32,6 +32,7 @@ import (
 	"magma/feg/gateway/services/session_proxy/credit_control/gx"
 	"magma/feg/gateway/services/session_proxy/credit_control/gy"
 	"magma/feg/gateway/services/session_proxy/servicers"
+	"magma/feg/gateway/utils"
 	lteprotos "magma/lte/cloud/go/protos"
 	"magma/orc8r/lib/go/service"
 	"magma/orc8r/lib/go/util"
@@ -39,11 +40,15 @@ import (
 	"github.com/golang/glog"
 )
 
+//var MagmaGitCommit string
+
 func init() {
 	flag.Parse()
 }
 
 func main() {
+	glog.Info(utils.PrintBuildInfo())
+
 	serviceBaseName := filepath.Base(os.Args[0])
 	serviceBaseName = strings.TrimSuffix(serviceBaseName, filepath.Ext(serviceBaseName))
 	if credit_control.SessionProxyServiceName != serviceBaseName {
@@ -73,6 +78,8 @@ func main() {
 	}
 	lteprotos.RegisterCentralSessionControllerServer(srv.GrpcServer, sessionManagerAndHealthServer)
 	protos.RegisterServiceHealthServer(srv.GrpcServer, sessionManagerAndHealthServer)
+
+	glog.Fatal("DELME")
 
 	// Run the service
 	err = srv.Run()

--- a/feg/gateway/services/swx_proxy/swx_proxy/main.go
+++ b/feg/gateway/services/swx_proxy/swx_proxy/main.go
@@ -20,6 +20,7 @@ import (
 	"magma/feg/cloud/go/protos"
 	"magma/feg/gateway/registry"
 	"magma/feg/gateway/services/swx_proxy/servicers"
+	"magma/feg/gateway/utils"
 	"magma/orc8r/lib/go/service"
 
 	"github.com/golang/glog"
@@ -30,6 +31,7 @@ func init() {
 }
 
 func main() {
+	glog.Info(utils.PrintBuildInfo())
 	// Create the service
 	srv, err := service.NewServiceWithOptions(registry.ModuleName, registry.SWX_PROXY)
 	if err != nil {

--- a/feg/gateway/utils/configs.go
+++ b/feg/gateway/utils/configs.go
@@ -117,3 +117,20 @@ func getFlagValue(flagName string) string {
 	}
 	return res
 }
+
+func PrintBuildInfo() string {
+	delimiter := "********"
+	return fmt.Sprintf("%s\n"+
+		"Build Info\n"+
+		"\tCommit Branch: %s\n"+
+		"\tCommit Tag: %s\n"+
+		"\tCommit Hash: %s\n"+
+		"\tCommit Date: %s\n"+
+		"%s\n",
+		delimiter,
+		os.Getenv("MAGMA_BUILD_BRANCH"),
+		os.Getenv("MAGMA_BUILD_TAG"),
+		os.Getenv("MAGMA_BUILD_COMMIT_HASH"),
+		os.Getenv("MAGMA_BUILD_COMMIT_DATE"),
+		delimiter)
+}

--- a/orc8r/gateway/go/services/bootstrapper/gateway_info/get_info.go
+++ b/orc8r/gateway/go/services/bootstrapper/gateway_info/get_info.go
@@ -5,6 +5,7 @@ import (
 	"crypto/x509"
 	"encoding/base64"
 	"fmt"
+	"os"
 
 	"magma/gateway/config"
 	"magma/gateway/services/bootstrapper/service"
@@ -44,7 +45,22 @@ func GetFormatted() (string, error) {
 			config.GetMagmadConfigs().BootstrapConfig.ChallengeKey, err)
 		return res, err
 	}
-	res = fmt.Sprintf("%s\nChallenge Key:\n--------------\n%s\n",
-		res, base64.StdEncoding.EncodeToString(marshaledPubKey))
+	res = fmt.Sprintf("%s\nChallenge Key:\n--------------\n%s\n%s\n",
+		res, base64.StdEncoding.EncodeToString(marshaledPubKey), PrintBuildInfo())
+
 	return res, nil
+}
+
+// PrintBuildInfo will return info about the build, if env vars exist available
+func PrintBuildInfo() string {
+	return fmt.Sprintf(
+		"Build Info\n" +
+		"\tCommit Branch: %s\n" +
+		"\tCommit Tag: %s\n" +
+		"\tCommit Hash: %s\n" +
+		"\tCommit Date: %s\n",
+		os.Getenv("MAGMA_BUILD_BRANCH"),
+		os.Getenv("MAGMA_BUILD_TAG"),
+		os.Getenv("MAGMA_BUILD_COMMIT_HASH"),
+		os.Getenv("MAGMA_BUILD_COMMIT_DATE"))
 }

--- a/orc8r/gateway/python/scripts/show_gateway_info.py
+++ b/orc8r/gateway/python/scripts/show_gateway_info.py
@@ -15,10 +15,20 @@ limitations under the License.
 
 import argparse
 import textwrap
+import os
 
 import snowflake
 from magma.common.cert_utils import load_public_key_to_base64der
 
+
+def get_commit_info() -> str:
+   return "Commit Branch: {}\n" \
+          "Commit Tag: {}\n" \
+          "Commit Hash: {}\n" \
+          "Commit Date: {}".format(os.getenv("MAGMA_BUILD_BRANCH"),
+                                   os.getenv("MAGMA_BUILD_TAG"),
+                                   os.getenv("MAGMA_BUILD_COMMIT_HASH") or os.getenv("COMMIT_HASH"),
+                                   os.getenv("MAGMA_BUILD_COMMIT_DATE"))
 
 def main():
     parser = argparse.ArgumentParser(
@@ -42,14 +52,22 @@ def main():
         -------------
         {}
 
+        Build info
+        -------------
+        {}
+
         Notes
         -----
         - Hardware ID is this gateway's unique identifier
         - Challenge key is this gateway's long-term keypair used for
           bootstrapping a secure connection to the cloud
+        - Build info shows git commit information of this build
         """
     )
-    print(msg.format(snowflake.snowflake(), public_key.decode('utf-8')))
+    print(msg.format(
+        snowflake.snowflake(),
+        public_key.decode('utf-8'),
+        get_commit_info()))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Signed-off-by: Oriol Batalla <obatalla@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary

Added some commit information to docker images in build time

A

Note this could have been done easier if DOCKERFILE would have some kind of conditonal copy. Thewn in case .git folder didnt exist, we could skip the creation of those envars. But this is not supported. That is why the need to create a pre build script

We took advantage of the need of that prebuild script and created a `build.py` similar to orc8r to build the images and run tests and precommit 


Commit information will show  doing `docker-compose exec magmad show_gateway_info.py`
```
root@docker-desktop:/# show_gateway_info.py

Hardware ID
-----------
f184da62-e944-4cf5-9805-6b18bae3f3d6

Challenge key
-------------
MHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEgls6FFUecrbtQTljawxCrR/JzDAwDmN4KwZbWSAk21pibCkEnNYSE1KlVkImoD02ULsPhZcw/9nwI7Z5UEOLfO2ueeQHT4gajSGDCfZ6O1F6HnAotd+p/s97+wEIRlDh

Version Info
-------------
Commit Branch: master
Commit Hash: 2cdcaa442
Commit Date: 2021-06-25 23:21:07 +0300

Notes
```

This will also show at start on all feg services
```
session_proxy    | ********
session_proxy    | Build Info
session_proxy    |  Commit Branch: master
session_proxy    |   Commit Tag:
session_proxy    |   Commit Hash: 2cdcaa442
session_proxy    |   Commit Date: 2021-06-25 23:21:07 +0300
session_proxy    | ********
```





<!-- Enumerate changes you made and why you made them -->

## Test Plan

make precommit
## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
