### PR TITLE
fix(mme) removed a few compilation warnings

### DIFF
--- a/lte/gateway/c/core/oai/tasks/mme_app/mme_app_bearer.c
+++ b/lte/gateway/c/core/oai/tasks/mme_app/mme_app_bearer.c
@@ -2203,7 +2203,7 @@ void mme_app_send_paging_request(
 
 imsi64_t mme_app_handle_initial_paging_request(
     mme_app_desc_t* mme_app_desc_p,
-    const itti_s11_paging_request_t const* paging_req) {
+    const itti_s11_paging_request_t* paging_req) {
   OAILOG_FUNC_IN(LOG_MME_APP);
   imsi64_t imsi64 = INVALID_IMSI64;
 

--- a/lte/gateway/c/core/oai/tasks/mme_app/mme_app_defs.h
+++ b/lte/gateway/c/core/oai/tasks/mme_app/mme_app_defs.h
@@ -233,8 +233,8 @@ int mme_app_handle_sgsap_reset_indication(
 
 int sgs_fsm_associated_reset_indication(const sgs_fsm_t* fsm_evt);
 
-status_code_e mme_app_handle_reset_indication(
-    hash_key_t keyP, void* const ue_context_pP, void* unused_param_pP,
+bool mme_app_handle_reset_indication(
+    const hash_key_t keyP, void* const ue_context_pP, void* unused_param_pP,
     void** unused_result_pP);
 
 int mme_app_handle_sgsap_alert_request(

--- a/lte/gateway/c/core/oai/tasks/mme_app/mme_app_sgs_reset.c
+++ b/lte/gateway/c/core/oai/tasks/mme_app/mme_app_sgs_reset.c
@@ -90,7 +90,7 @@ status_code_e mme_app_handle_sgsap_reset_indication(
  **          unused_param_pP: Unused param list                            **
  **          unused_result_pP: Unused result                               **
  ** Outputs:                                                               **
- **          Return:    RETURNok, RETURNerror                              **
+ **          Return:    true, false                                        **
  **                                                                        **
  ***************************************************************************/
 bool mme_app_handle_reset_indication(

--- a/lte/gateway/c/core/oai/tasks/mme_app/mme_app_sgs_reset.c
+++ b/lte/gateway/c/core/oai/tasks/mme_app/mme_app_sgs_reset.c
@@ -93,7 +93,7 @@ status_code_e mme_app_handle_sgsap_reset_indication(
  **          Return:    RETURNok, RETURNerror                              **
  **                                                                        **
  ***************************************************************************/
-status_code_e mme_app_handle_reset_indication(
+bool mme_app_handle_reset_indication(
     const hash_key_t keyP, void* const ue_context_pP, void* unused_param_pP,
     void** unused_result_pP) {
   int rc = RETURNerror;
@@ -104,20 +104,20 @@ status_code_e mme_app_handle_reset_indication(
       (struct ue_mm_context_s*) ue_context_pP;
   if (ue_context_p == NULL) {
     OAILOG_WARNING(LOG_MME_APP, "UE context not found \n");
-    OAILOG_FUNC_RETURN(LOG_MME_APP, rc);
+    OAILOG_FUNC_RETURN(LOG_MME_APP, false);
   }
   if (ue_context_p->mm_state == UE_UNREGISTERED) {
     OAILOG_ERROR(
         LOG_MME_APP, "UE is not registered for ue_id:" MME_UE_S1AP_ID_FMT "\n",
         ue_context_p->mme_ue_s1ap_id);
-    OAILOG_FUNC_RETURN(LOG_MME_APP, rc);
+    OAILOG_FUNC_RETURN(LOG_MME_APP, false);
   }
   if (ue_context_p->sgs_context == NULL) {
     OAILOG_ERROR(
         LOG_MME_APP,
         "SGS context not created for ue_id:" MME_UE_S1AP_ID_FMT "\n",
         ue_context_p->mme_ue_s1ap_id);
-    OAILOG_FUNC_RETURN(LOG_MME_APP, rc);
+    OAILOG_FUNC_RETURN(LOG_MME_APP, false);
   }
 
   ue_context_p->sgs_context->sgsap_msg = NULL; /* sgs message */
@@ -131,7 +131,7 @@ status_code_e mme_app_handle_reset_indication(
         LOG_MME_APP, "Failed  to execute SGS State machine for ue_id :%u \n",
         ue_context_p->mme_ue_s1ap_id);
   }
-  OAILOG_FUNC_RETURN(LOG_MME_APP, rc);
+  OAILOG_FUNC_RETURN(LOG_MME_APP, true);
 }
 
 /****************************************************************************

--- a/lte/gateway/c/core/oai/tasks/mme_app/mme_app_state_converter.cpp
+++ b/lte/gateway/c/core/oai/tasks/mme_app/mme_app_state_converter.cpp
@@ -519,7 +519,7 @@ void MmeNasStateConverter::regional_subscription_to_proto(
 
 void MmeNasStateConverter::proto_to_regional_subscription(
     const oai::UeContext& ue_context_proto, ue_mm_context_t* state_ue_context) {
-  for (int itr = 0; itr < ue_context_proto.num_reg_sub(); itr++) {
+  for (unsigned int itr = 0; itr < ue_context_proto.num_reg_sub(); itr++) {
     memcpy(
         state_ue_context->reg_sub[itr].zone_code,
         ue_context_proto.reg_sub(itr).zone_code().c_str(),

--- a/lte/gateway/c/core/oai/tasks/mme_app/mme_config.c
+++ b/lte/gateway/c/core/oai/tasks/mme_app/mme_config.c
@@ -1170,8 +1170,7 @@ int mme_config_parse_file(mme_config_t* config_pP) {
         setting_mme, MME_CONFIG_STRING_SRVC_AREA_CODE_2_TACS_MAP);
     OAILOG_INFO(LOG_MME_APP, "MME_CONFIG_STRING_SRVC_AREA_CODE_2_TACS_MAP \n");
     if (setting != NULL) {
-      const char* sac_str = NULL;
-      num                 = config_setting_length(setting);
+      num = config_setting_length(setting);
       OAILOG_INFO(
           LOG_MME_APP, "Number of SRVC_AREA_CODE_2_TACS configured =%d\n", num);
       if (num > 0) {

--- a/lte/gateway/c/core/oai/tasks/nas/emm/TrackingAreaUpdate.c
+++ b/lte/gateway/c/core/oai/tasks/nas/emm/TrackingAreaUpdate.c
@@ -985,8 +985,7 @@ status_code_e emm_proc_tau_complete(mme_ue_s1ap_id_t ue_id) {
     if (tau_proc) {
       OAILOG_INFO(
           LOG_NAS_EMM,
-          "EMM-PROC  - Stop timer T3450 (%ld) for ue id " MME_UE_S1AP_ID_FMT
-          "\n",
+          "EMM-PROC  - Stop timer T3450 for ue id " MME_UE_S1AP_ID_FMT "\n",
           ue_id);
       if (emm_ctx->csfbparams.newTmsiAllocated) {
         nas_delete_tau_procedure(emm_ctx);

--- a/lte/gateway/c/core/oai/tasks/nas/emm/sap/emm_recv.c
+++ b/lte/gateway/c/core/oai/tasks/nas/emm/sap/emm_recv.c
@@ -584,8 +584,8 @@ status_code_e emm_recv_detach_request(
  ***************************************************************************/
 status_code_e emm_recv_tracking_area_update_request(
     const mme_ue_s1ap_id_t ue_id, tracking_area_update_request_msg* const msg,
-    const bool is_initial, const tac_t const tac, int* const emm_cause,
-    const nas_message_decode_status_t* const decode_status) {
+    const bool is_initial, const tac_t tac, int* const emm_cause,
+    const nas_message_decode_status_t* decode_status) {
   int rc = RETURNok;
 
   OAILOG_FUNC_IN(LOG_NAS_EMM);

--- a/lte/gateway/c/core/oai/tasks/s1ap/s1ap_mme_nas_procedures.c
+++ b/lte/gateway/c/core/oai/tasks/s1ap/s1ap_mme_nas_procedures.c
@@ -870,11 +870,10 @@ void s1ap_handle_conn_est_cnf(
    * At least one bearer has been established. We can now send s1ap initial
    * context setup request message to eNB.
    */
-  uint8_t* buffer_p                           = NULL;
-  uint8_t err                                 = 0;
-  uint32_t length                             = 0;
-  ue_network_capability_t uenetworkcapability = {0};
-  ue_description_t* ue_ref                    = NULL;
+  uint8_t* buffer_p        = NULL;
+  uint8_t err              = 0;
+  uint32_t length          = 0;
+  ue_description_t* ue_ref = NULL;
   S1ap_InitialContextSetupRequest_t* out;
   S1ap_InitialContextSetupRequestIEs_t* ie = NULL;
   S1ap_S1AP_PDU_t pdu                      = {0};  // yes, alloc on stack


### PR DESCRIPTION
Signed-off-by: Raphael Defosseux <raphael.defosseux@openairinterface.org>

## Summary

After the latest `master` branch merges, I saw a bunch of compilation warnings.

## Test Plan

Build and Ran on the OAI - MME build variant.
Tested w/ DsTester

## Additional Information

- [ ] This change is backwards-breaking

