### PR TITLE
commit leftover formatting changes to v1.6

### DIFF
--- a/lte/gateway/c/core/oai/tasks/nas/emm/SecurityModeControl.c
+++ b/lte/gateway/c/core/oai/tasks/nas/emm/SecurityModeControl.c
@@ -362,11 +362,12 @@ int emm_proc_security_mode_control(
     // smc_proc->imeisv_request = (IS_EMM_CTXT_PRESENT_IMEISV(emm_ctx)) ?
     // false:true;
 
-    if IS_EMM_CTXT_PRESENT_UE_ADDITIONAL_SECURITY_CAPABILITY (emm_ctx) {
-      smc_proc->replayed_ue_add_sec_cap_present = true;
-      smc_proc->_5g_ea = emm_ctx->ue_additional_security_capability._5g_ea;
-      smc_proc->_5g_ia = emm_ctx->ue_additional_security_capability._5g_ia;
-    }
+    if
+      IS_EMM_CTXT_PRESENT_UE_ADDITIONAL_SECURITY_CAPABILITY(emm_ctx) {
+        smc_proc->replayed_ue_add_sec_cap_present = true;
+        smc_proc->_5g_ea = emm_ctx->ue_additional_security_capability._5g_ea;
+        smc_proc->_5g_ia = emm_ctx->ue_additional_security_capability._5g_ia;
+      }
 
     /*
      * Send security mode command message to the UE


### PR DESCRIPTION
Signed-off-by: Marie Bremner <marwhal@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary
Noticed that there were some formatting changes produced when running local tests on v1.6

## Test Plan
CI / should be a no op
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
