### PR TITLE
Add edge case to Get Stats Function in EnforcementStats

### DIFF
--- a/lte/gateway/python/magma/pipelined/app/enforcement_stats.py
+++ b/lte/gateway/python/magma/pipelined/app/enforcement_stats.py
@@ -578,6 +578,7 @@ class EnforcementStatsController(PolicyMixin, RestartMixin, MagmaController):
         convert to a Rule Record Table
         """
         if not self._datapath:
+            self.logger.error("Could not initialize datapath for stats retrieval")
             return RuleRecordTable()
         parser = self._datapath.ofproto_parser
         message = parser.OFPFlowStatsRequest(datapath=self._datapath, cookie = cookie, cookie_mask = cookie_mask)

--- a/lte/gateway/python/magma/pipelined/app/enforcement_stats.py
+++ b/lte/gateway/python/magma/pipelined/app/enforcement_stats.py
@@ -577,6 +577,8 @@ class EnforcementStatsController(PolicyMixin, RestartMixin, MagmaController):
         Use Ryu API to send a stats request containing cookie and cookie mask, retrieve a response and 
         convert to a Rule Record Table
         """
+        if not self._datapath:
+            return RuleRecordTable()
         parser = self._datapath.ofproto_parser
         message = parser.OFPFlowStatsRequest(datapath=self._datapath, cookie = cookie, cookie_mask = cookie_mask)
         try:


### PR DESCRIPTION
Signed-off-by: veshkemburu <veshkemburu@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary

Sometimes the GetStats API is called before the datapath is populated. In this case we just send an empty RuleRecordsTable. 

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
