### PR TITLE
[feg] feg add commit info on docker image envars

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -788,6 +788,7 @@ jobs:
     steps:
       - checkout
       - docker/install-dc
+      - python/set_version
       - build/determinator:
           <<: *federated_build_verify
       - run:
@@ -806,12 +807,12 @@ jobs:
           name: build docker
           command: |
             cd ${MAGMA_ROOT}/feg/gateway/docker
-            DOCKER_REGISTRY=feg_ docker-compose build --parallel
+            DOCKER_REGISTRY=feg_ python3 build.py
       - run:
           name: run docker containers and check health
           command: |
-            cd ${MAGMA_ROOT}/feg/gateway
-            DOCKER_REGISTRY=feg_ make -C ${MAGMA_ROOT}/feg/gateway docker_healthcheck
+            cd ${MAGMA_ROOT}/feg/gateway/docker
+            DOCKER_REGISTRY=feg_ python3 build.py -e
       - tag-push-docker:
           project: feg
           images: "gateway_go|gateway_python"

--- a/feg/gateway/docker/build.py
+++ b/feg/gateway/docker/build.py
@@ -1,0 +1,212 @@
+#!/usr/bin/env python3
+
+"""
+Copyright 2021 The Magma Authors.
+
+This source code is licensed under the BSD-style license found in the
+LICENSE file in the root directory of this source tree.
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import argparse
+import json
+import os
+import platform
+import subprocess
+from typing import List
+
+HOST_MAGMA_ROOT = '../../../.'
+
+
+def main() -> None:
+    """ Run main"""
+    args = _parse_args()
+
+    if args.mount:
+        _run(['up', '-d', 'test'])
+        _run(['exec', 'test', 'bash'])
+        _down(args)
+
+    elif args.lint:
+        _run(['up', '-d', 'test'])
+        _run(['exec', 'test', 'make', 'lint'])
+        _down(args)
+
+    elif args.precommit:
+        _run(['up', '-d', 'test'])
+        _run(['exec', 'test', 'make', 'precommit'])
+        _down(args)
+
+    elif args.coverage:
+        _run(['up', '-d', 'test'])
+        _run(['exec', 'test', 'make', 'cover'])
+        _down(args)
+
+    elif args.tests:
+        _run(['up', '-d', 'test'])
+        _run(['exec', 'test', 'make', 'test'])
+        _down(args)
+
+    elif args.health:
+        # _set_mac_env_vars is needed to override LOG_DRIVER for mac
+        _set_mac_env_vars()
+        _run(['up', '-d'])
+        _run_health()
+        _down(args)
+
+    elif args.git:
+        print(json.dumps(_run_get_git_vars(), indent=4, sort_keys=True))
+
+    else:
+        _run(['build'] + _get_default_build_args(args))
+        _down(args)
+
+
+def _run(cmd: List[str]) -> None:
+    """ Run the required docker-compose command """
+    cmd = ['docker-compose'] + cmd
+    print("Running '%s'..." % ' '.join(cmd))
+    try:
+        subprocess.run(cmd, check=True)  # noqa: S603
+    except subprocess.CalledProcessError as err:
+        exit(err.returncode)
+
+
+def _down(args: argparse.Namespace) -> None:
+    if args.down:
+        _run(['down'])
+
+
+def _get_default_build_args(args: argparse.Namespace) -> List[str]:
+    ret = []
+    git_info = _run_get_git_vars()
+
+    for arg, val in git_info.items():
+        ret.append("--build-arg")
+        ret.append("{0}={1}".format(arg, val))
+
+    if args.parallel:
+        ret.append('--parallel')
+    if args.nocache:
+        ret.append('--no-cache')
+    return ret
+
+
+def _run_get_git_vars():
+    try:
+        cmd = "tools/get_version_info.sh"
+        cmd_res = \
+            subprocess.run(cmd, check=True, capture_output=True)  # noqa: S603
+    except subprocess.CalledProcessError as err:
+        print("Error _run_get_git_vars")
+        exit(err.returncode)
+    return json.loads(cmd_res.stdout)
+
+
+def _run_health():
+    try:
+        cmd = "tools/docker_ps_healthcheck.sh"
+        subprocess.run(cmd, check=True)  # noqa: S603
+    except subprocess.CalledProcessError as err:
+        print("Error _run_health")
+        exit(err.returncode)
+
+
+def _set_mac_env_vars():
+    if (platform.system().lower() == "darwin"):
+        os.environ['LOG_DRIVER'] = "json-file"
+
+
+def _parse_args() -> argparse.Namespace:
+    """ Parse the command line args """
+
+    # There are multiple ways to invoke finer-grained control over which
+    # images are built.
+    #
+    # (1) How many images to build
+    #
+    # all: all images
+    # default: images required for minimum functionality
+    #   - excluding metrics images
+    #   - including postgres, proxy, etc
+    #
+    # (2) Of the core orc8r images, which modules to build
+    #
+    # Defaults to all modules, but can be further specified by targeting a
+    # deployment type.
+
+    parser = argparse.ArgumentParser(description='Orc8r build tool')
+
+    # Run something
+    parser.add_argument(
+        '--tests', '-t',
+        action='store_true',
+        help='Run unit tests',
+    )
+
+    parser.add_argument(
+        '--mount', '-m',
+        action='store_true',
+        help='Mount the source code and create a bash shell',
+    )
+
+    parser.add_argument(
+        '--precommit', '-c',
+        action='store_true',
+        help='Mount the source code and run pre-commit checks',
+    )
+
+    parser.add_argument(
+        '--coverage', '-o',
+        action='store_true',
+        help='Generate test coverage statistics',
+    )
+
+    parser.add_argument(
+        '--lint', '-l',
+        action='store_true',
+        help='Run lint test',
+    )
+
+    parser.add_argument(
+        '--health', '-e',
+        action='store_true',
+        help='Run health test',
+    )
+
+    # Run something
+    parser.add_argument(
+        '--git', '-g',
+        action='store_true',
+        help='Get git info',
+    )
+
+    # How to do it
+    parser.add_argument(
+        '--nocache', '-n',
+        action='store_true',
+        help='Build the images with no Docker layer caching',
+    )
+    parser.add_argument(
+        '--parallel', '-p',
+        action='store_true',
+        default=False,
+        help='Build containers in parallel',
+    )
+    parser.add_argument(
+        '--down', '-down',
+        action='store_true',
+        default=False,
+        help='Leave containers up after running tests',
+    )
+
+    return parser.parse_args()
+
+
+if __name__ == '__main__':
+    main()

--- a/feg/gateway/docker/go/Dockerfile
+++ b/feg/gateway/docker/go/Dockerfile
@@ -119,6 +119,10 @@ COPY --from=builder /root/.cache /root/.cache
 # Production image
 # -----------------------------------------------------------------------------
 FROM ubuntu:bionic AS gateway_go
+ARG MAGMA_BUILD_BRANCH=unknown
+ARG MAGMA_BUILD_TAG=unknown
+ARG MAGMA_BUILD_COMMIT_HASH=unknonw
+ARG MAGMA_BUILD_COMMIT_DATE=unknown
 
 # Install envdir.
 RUN apt-get -y update && apt-get -y install daemontools netcat gettext musl
@@ -137,3 +141,9 @@ COPY feg/gateway/configs /etc/magma
 RUN mkdir -p /var/opt/magma/envdir
 RUN mkdir -p /var/opt/magma/configs
 RUN mkdir -p /var/opt/magma/tmp
+
+# Add commit information
+ENV MAGMA_BUILD_BRANCH $MAGMA_BUILD_BRANCH
+ENV MAGMA_BUILD_TAG $MAGMA_BUILD_TAG
+ENV MAGMA_BUILD_COMMIT_HASH $MAGMA_BUILD_COMMIT_HASH
+ENV MAGMA_BUILD_COMMIT_DATE $MAGMA_BUILD_COMMIT_DATE

--- a/feg/gateway/docker/python/Dockerfile
+++ b/feg/gateway/docker/python/Dockerfile
@@ -64,6 +64,10 @@ RUN make -C $MAGMA_ROOT/orc8r/gateway/python swagger
 # Production image
 # -----------------------------------------------------------------------------
 FROM ubuntu:focal AS gateway_python
+ARG MAGMA_BUILD_BRANCH=unknown
+ARG MAGMA_BUILD_TAG=unknown
+ARG MAGMA_BUILD_COMMIT_HASH=unknonw
+ARG MAGMA_BUILD_COMMIT_DATE=unknown
 
 # Add the magma apt repo
 RUN apt-get update && \
@@ -129,3 +133,9 @@ COPY orc8r/gateway/configs/templates /etc/magma/templates
 
 RUN mkdir -p /var/opt/magma/configs
 RUN mkdir -p /var/opt/magma/fluent-bit
+
+# Add commit information
+ENV MAGMA_BUILD_BRANCH $MAGMA_BUILD_BRANCH
+ENV MAGMA_BUILD_TAG $MAGMA_BUILD_TAG
+ENV MAGMA_BUILD_COMMIT_HASH $MAGMA_BUILD_COMMIT_HASH
+ENV MAGMA_BUILD_COMMIT_DATE $MAGMA_BUILD_COMMIT_DATE

--- a/feg/gateway/docker/tools/get_version_info.sh
+++ b/feg/gateway/docker/tools/get_version_info.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+branch=$(git rev-parse --abbrev-ref HEAD)
+tag=$(git tag --points-at HEAD)
+chash=$(git rev-parse --short HEAD)
+commit_date=$(git show -s --format=%ci)
+
+printf '{\n "MAGMA_BUILD_BRANCH":"%s",\n"MAGMA_BUILD_TAG":"%s",\n"MAGMA_BUILD_COMMIT_HASH":"%s",\n "MAGMA_BUILD_COMMIT_DATE":"%s"\n}' "$branch" "$tag" "$chash" "$commit_date"

--- a/orc8r/gateway/python/scripts/show_gateway_info.py
+++ b/orc8r/gateway/python/scripts/show_gateway_info.py
@@ -14,13 +14,26 @@ limitations under the License.
 """
 
 import argparse
+import os
 import textwrap
 
 import snowflake
 from magma.common.cert_utils import load_public_key_to_base64der
 
 
+def get_commit_info() -> str:
+    """Get commit info if available"""
+    return " Commit Branch: {0}\n Commit Tag: {1}\n Commit Hash: {2}\n Commit Date: {3}".format(
+        os.getenv("MAGMA_BUILD_BRANCH", "unknown"),
+        os.getenv("MAGMA_BUILD_TAG", "unknown"),
+        os.getenv("MAGMA_BUILD_COMMIT_HASH", "unknown") or os.getenv(
+            "COMMIT_HASH", "unknown"),
+        os.getenv("MAGMA_BUILD_COMMIT_DATE", "unknown"),
+    )
+
+
 def main():
+    """Display information of a gateway"""
     parser = argparse.ArgumentParser(
         description='Show the UUID and base64 encoded DER public key',
     )
@@ -42,14 +55,25 @@ def main():
         -------------
         {}
 
+        Build info
+        -------------
+        {}
+
         Notes
         -----
         - Hardware ID is this gateway's unique identifier
         - Challenge key is this gateway's long-term keypair used for
           bootstrapping a secure connection to the cloud
-        """
+        - Build info shows git commit information of this build
+        """,
     )
-    print(msg.format(snowflake.snowflake(), public_key.decode('utf-8')))
+    print(
+        msg.format(
+            snowflake.snowflake(),
+            public_key.decode('utf-8'),
+            get_commit_info(),
+        ),
+    )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Signed-off-by: Oriol Batalla <obatalla@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary

Added some commit information to docker images in build time

Note this could have been done easier if DOCKERFILE would have some kind of conditional copy. Then in case .git folder did not exist, we could skip the creation of those envars. But this is not supported. That is why the need to create a pre build script

We took advantage of the need of that pre build script and created a `build.py` similar to orc8r to build the images and run tests and precommit 

This PR also includes `build.py`

```
build.py 		<- builds feg (and stamps commit info on docker images)
build.py -c  	<- runs precommit
build.py -e		<- starts feg and runs health check
build.py -m		<- loads bash console on test container
build.py -g		<- shows git information
```



Commit information will show  doing `docker-compose exec magmad show_gateway_info.py`
```
root@docker-desktop:/# show_gateway_info.py

Hardware ID
-----------
f184da62-e944-4cf5-9805-6b18bae3f3d6

Challenge key
-------------
MHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEgls6FFUecrbtQTljawxCrR/JzDAwDmN4KwZbWSAk21pibCkEnNYSE1KlVkImoD02ULsPhZcw/9nwI7Z5UEOLfO2ueeQHT4gajSGDCfZ6O1F6HnAotd+p/s97+wEIRlDh

Version Info
-------------
Commit Branch: master
Commit Hash: 2cdcaa442
Commit Date: 2021-06-25 23:21:07 +0300

Notes
```



<!-- Enumerate changes you made and why you made them -->

## Test Plan

make precommit
## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
