### PR TITLE
[gateway][lib] Add build/commit information API & magmad commit info display

### DIFF
--- a/orc8r/gateway/go/Makefile
+++ b/orc8r/gateway/go/Makefile
@@ -19,6 +19,17 @@ endif
 GOOS ?= $(shell go env GOOS)
 GOARCH ?= $(shell go env GOARCH)
 
+MAGMA_BUILD_BRANCH ?= $(shell git rev-parse --abbrev-ref HEAD)
+MAGMA_BUILD_TAG ?= $(shell git describe --tags --abbrev=0)
+MAGMA_BUILD_COMMIT_HASH ?= $(shell git rev-parse HEAD)
+MAGMA_BUILD_COMMIT_DATE ?= $(shell git log -1 --format=%cd)
+
+LDFLAGS := -ldflags="-X 'magma/orc8r/lib/go/build_info.buildBranch=$(MAGMA_BUILD_BRANCH)' \
+	-X 'magma/orc8r/lib/go/build_info.buildCommitHash=$(MAGMA_BUILD_COMMIT_HASH)' \
+	-X 'magma/orc8r/lib/go/build_info.buildCommitDate=$(MAGMA_BUILD_COMMIT_DATE)' \
+	-X 'magma/orc8r/lib/go/build_info.buildTag=$(MAGMA_BUILD_TAG)' \
+	-X 'magma/orc8r/lib/go/build_info.buildDate=$(shell date)'"
+
 all: fmt test vet install
 
 build: install
@@ -28,7 +39,7 @@ download:
 
 install:
 	mkdir -p $(GOBIN)
-	GOARCH=$(GOARCH) GOOS=$(GOOS) go build -o $(BUILD_OUT) $(GOFLAGS) magma/gateway/services/magmad
+	GOARCH=$(GOARCH) GOOS=$(GOOS) go build -o $(BUILD_OUT) $(GOFLAGS) $(LDFLAGS) magma/gateway/services/magmad
 	$(MAKE) -C $(MAGMA_ROOT)/orc8r/cloud/go/tools GOARCH=$(GOARCH) GOOS=$(GOOS) GOFLAGS=$(GOFLAGS) BUILD_OUT=$(BUILD_OUT) gateway_tools
 
 test:

--- a/orc8r/gateway/go/services/magmad/main.go
+++ b/orc8r/gateway/go/services/magmad/main.go
@@ -30,6 +30,7 @@ import (
 	"magma/gateway/services/magmad/service_manager"
 	"magma/gateway/services/magmad/status"
 	sync_rpc "magma/gateway/services/sync_rpc/service"
+	"magma/orc8r/lib/go/build_info"
 	"magma/orc8r/lib/go/profile"
 )
 
@@ -44,7 +45,7 @@ Examples:
 
     $> %s
 
-    The command will run magmad service which will periodically 
+    The command will run magmad service which will periodically
     check and update the gateway certificats and cloud managed GW configs
 
   2. Show the gateway information needed for the gateway registration and exit:
@@ -80,6 +81,7 @@ func main() {
 			os.Exit(1)
 		}
 		fmt.Print(info)
+		fmt.Print(build_info.String())
 		os.Exit(0)
 	}
 

--- a/orc8r/lib/go/build_info/build_info.go
+++ b/orc8r/lib/go/build_info/build_info.go
@@ -1,0 +1,72 @@
+/*
+Copyright 2021 The Magma Authors.
+
+This source code is licensed under the BSD-style license found in the
+LICENSE file in the root directory of this source tree.
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// package build_info provides API to get information on the binary build/commit version
+package build_info
+
+import (
+	"fmt"
+)
+
+const unknown = "UNDEFINED"
+
+// the following variables (buildBranch, buildTag, buildCommitHash, buildCommitDate & buildDate)
+// should be set by an external Makefile/build script/etc. via Go ldflags. For example:
+//     export MAGMA_BUILD_COMMIT_HASH=$(git rev-parse HEAD)
+//     export LD_FLAGS="-ldflags=-X 'magma/orc8r/lib/go/build_info.buildCommitHash=$MAGMA_BUILD_COMMIT_HASH'"
+//     go build -o ./magmad "$LD_FLAGS" magma/gateway/services/magmad
+//
+var (
+	buildBranch     = unknown
+	buildTag        = unknown
+	buildCommitHash = unknown
+	buildCommitDate = unknown
+	buildDate       = unknown
+)
+
+// Branch returns git branch of the current build
+func Branch() string {
+	return buildBranch
+}
+
+// Tag returns git tag of the current build
+func Tag() string {
+	return buildTag
+}
+
+// Commit returns git commit hash of the current build
+func Commit() string {
+	return buildCommitHash
+}
+
+// CommitDate returns git commit date of the current build
+func CommitDate() string {
+	return buildCommitDate
+}
+
+// BuildDate returns date & time of the current build
+func BuildDate() string {
+	return buildDate
+}
+
+// String returns formatted string of the current build's build & git commit information
+func String() string {
+	return fmt.Sprintf(
+		"\nBuild Info:\n-----------\n"+
+			"\tCommit Branch: %s\n"+
+			"\tCommit Tag:    %s\n"+
+			"\tCommit Hash:   %s\n"+
+			"\tCommit Date:   %s\n"+
+			"\tBuild  Date:   %s\n",
+		buildBranch, buildTag, buildCommitHash, buildCommitDate, buildDate)
+}

--- a/orc8r/lib/go/build_info/build_info_test.go
+++ b/orc8r/lib/go/build_info/build_info_test.go
@@ -1,0 +1,39 @@
+/*
+Copyright 2021 The Magma Authors.
+
+This source code is licensed under the BSD-style license found in the
+LICENSE file in the root directory of this source tree.
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// package build_info_test
+package build_info_test
+
+import (
+	"os/exec"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+var (
+	ldflags = "-ldflags=-X 'magma/orc8r/lib/go/build_info.buildBranch=test_branch'" +
+		" -X 'magma/orc8r/lib/go/build_info.buildCommitHash=abcdef123456'" +
+		" -X 'magma/orc8r/lib/go/build_info.buildCommitDate=Tue Jun 29 13:26:43 2021 -0700'" +
+		" -X 'magma/orc8r/lib/go/build_info.buildTag=test_tag'"
+	expected = "\nBuild Info:\n-----------\n\tCommit Branch: test_branch\n\tCommit Tag:    test_tag\n\t" +
+		"Commit Hash:   abcdef123456\n\tCommit Date:   Tue Jun 29 13:26:43 2021 -0700\n\tBuild  Date:   UNDEFINED\n"
+)
+
+func TestBuildInfoAPI(t *testing.T) {
+	cmd := exec.Command("go", "run", ldflags, "magma/orc8r/lib/go/build_info/test_build_info")
+	t.Log(cmd.String())
+	out, err := cmd.Output()
+	assert.NoError(t, err)
+	assert.Equal(t, expected, string(out))
+}

--- a/orc8r/lib/go/build_info/test_build_info/test_build_info.go
+++ b/orc8r/lib/go/build_info/test_build_info/test_build_info.go
@@ -1,0 +1,25 @@
+/*
+Copyright 2021 The Magma Authors.
+
+This source code is licensed under the BSD-style license found in the
+LICENSE file in the root directory of this source tree.
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// package main provides test app to verify build/commit info API
+package main
+
+import (
+	"fmt"
+
+	"magma/orc8r/lib/go/build_info"
+)
+
+func main() {
+	fmt.Print(build_info.String())
+}


### PR DESCRIPTION


Signed-off-by: Evgeniy Makeev <evgeniym@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary

Add build/commit information API & magmad commit info display.

Go 'magmad -s' use of this API as well as Makefile changes are provided as an example to use with other magma modules.

## Test Plan

~/magma/orc8r/gateway/go$ make install

mkdir -p <bin path>/bin

GOARCH=amd64 GOOS=darwin go build -o <bin path>/bin  -ldflags="-X 'magma/orc8r/lib/go/build_info.buildBranch=commit_info_on_builds' -X 'magma/orc8r/lib/go/build_info.buildCommitHash=9bbd97a703079c53545e2c3d2d7815adeaf6105c' -X 'magma/orc8r/lib/go/build_info.buildCommitDate=Tue Jun 29 13:26:43 2021 -0700' -X 'magma/orc8r/lib/go/build_info.buildTag=v1.0.0-rc1' -X 'magma/orc8r/lib/go/build_info.buildDate=Tue Jun 29 13:27:56 PDT 2021'" magma/gateway/services/magmad

make -C .../magma/orc8r/cloud/go/tools GOARCH=amd64 GOOS=darwin GOFLAGS= BUILD_OUT=<bin path>/bin gateway_tools

make[1]: Entering directory '.../magma/orc8r/cloud/go/tools'
mkdir -p <bin path>/bin
GOARCH=amd64 GOOS=darwin go build -o <bin path>/bin ./gateway_cli ./service303_cli
make[1]: Leaving directory '.../magma/orc8r/cloud/go/tools'

~/magma/orc8r/gateway/go$ <bin path>/bin/magmad -s

Hardware ID:
------------
4e7...0d-6fca-4f93-6eaf-8f8...731a0

Challenge Key:
--------------
MHYwEAYHKoZIzj0CAQYFK4EEACIDYgAE2LGJ1YO......SNc0YYLfWV0jzfa3G80sgPo

Build Info:
-----------
	Commit Branch: commit_info_on_builds
	Commit Tag:    v1.0.0-rc1
	Commit Hash:   9bbd97a703079c53545e2c3d2d7815adeaf6105c
	Commit Date:   Tue Jun 29 13:26:43 2021 -0700
	Build  Date:   Tue Jun 29 13:27:56 PDT 2021


## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
