### PR TITLE
feat(agw): Add commands and logs in show-tech playbook

### DIFF
--- a/docs/docusaurus/versioned_docs/version-1.4.0/debugging_tools/show_tech.md
+++ b/docs/docusaurus/versioned_docs/version-1.4.0/debugging_tools/show_tech.md
@@ -17,7 +17,7 @@ This feature enables an operator to capture the essential state of the gateway (
 # On your GW host, run the following command as user root:
 # If you have git repo checked out already
 $ cd ${MAGMA_ROOT}/show-tech
-$ ansible-playbook show-tech.yml
+$ sudo ansible-playbook show-tech.yml
 
 # In case you want to download and process latest version of this playbook from Magma's master:
 $ ansible-pull -U https://github.com/magma/magma.git show-tech/show-tech.yml -d /tmp/show-tech --purge
@@ -151,7 +151,7 @@ PLAY [install pre-requisites for show-tech] ************************************
 Run the show-tech playbook:
 
 ```
-$ ansible-playbook show-tech.yml
+$ sudo ansible-playbook show-tech.yml
 ```
 
 Validate the content of the package.

--- a/docs/docusaurus/versioned_docs/version-1.5.0/lte/debug_show_tech.md
+++ b/docs/docusaurus/versioned_docs/version-1.5.0/lte/debug_show_tech.md
@@ -18,7 +18,7 @@ This feature enables an operator to capture the essential state of the gateway (
 # On your GW host, run the following command as user root:
 # If you have git repo checked out already
 $ cd ${MAGMA_ROOT}/show-tech
-$ ansible-playbook show-tech.yml
+$ sudo ansible-playbook show-tech.yml
 
 # In case you want to download and process latest version of this playbook from Magma's master:
 $ ansible-pull -U https://github.com/magma/magma.git show-tech/show-tech.yml -d /tmp/show-tech --purge
@@ -152,7 +152,7 @@ PLAY [install pre-requisites for show-tech] ************************************
 Run the show-tech playbook:
 
 ```
-$ ansible-playbook show-tech.yml
+$ sudo ansible-playbook show-tech.yml
 ```
 
 Validate the content of the package.

--- a/docs/readmes/lte/debug_show_tech.md
+++ b/docs/readmes/lte/debug_show_tech.md
@@ -17,7 +17,7 @@ This feature enables an operator to capture the essential state of the gateway (
 # On your GW host, run the following command as user root:
 # If you have git repo checked out already
 $ cd ${MAGMA_ROOT}/show-tech
-$ ansible-playbook show-tech.yml
+$ sudo ansible-playbook show-tech.yml
 
 # In case you want to download and process latest version of this playbook from Magma's master:
 $ ansible-pull -U https://github.com/magma/magma.git show-tech/show-tech.yml -d /tmp/show-tech --purge
@@ -151,7 +151,7 @@ PLAY [install pre-requisites for show-tech] ************************************
 Run the show-tech playbook:
 
 ```
-$ ansible-playbook show-tech.yml
+$ sudo ansible-playbook show-tech.yml
 ```
 
 Validate the content of the package.

--- a/show-tech/constants.yml
+++ b/show-tech/constants.yml
@@ -12,10 +12,15 @@ general_commands:
   - "top -b -n 1"
   - "df -kh"
 debian_commands:
-  - "dpkg -l | grep magma"
+  - "dpkg -l magma*"
+  - "dpkg -l *openvswitch*"
   - "ovs-vsctl show"
+  - "ovs-ofctl show gtp_br0"
+  - "ovs-ofctl dump-flows gtp_br0"
   - "apt show magma"
   - "service magma@* status"
+  - "service sctpd status"
+  - "service openvswitch-switch status"
   - "show_gateway_info.py"
   - "checkin_cli.py"
   - "mobility_cli.py get_subscriber_table"
@@ -23,7 +28,6 @@ debian_commands:
   - "enodebd_cli.py get_all_status"
   - "ip addr"
   - "ping google.com -I eth0 -c 5"
-  - "journalctl -u magma@*"
   - "timeout 60 sudo tcpdump -i any sctp -w {{report_dir_output.stdout}}/sctp.pcap"
   - "timeout 60 sudo tcpdump -i any port 48080 -w {{report_dir_output.stdout}}/any-48080.pcap"
 
@@ -34,10 +38,9 @@ paths_to_collect:
   - "/etc/magma/configs/*"
   - "/etc/systemd/system/*"
   - "/usr/local/bin/mme"
-  - "/var/log/syslog"
   - "/var/core/*"
-  - "/var/log/MME.*"
-  - "/var/log/enode.*"
+  - "/var/log/*"
+  - "/var/log/openvswitch/*"
 
 # core file paths for gdb execution, requires core file location and binary
 core_file_age_in_days: 3


### PR DESCRIPTION
Signed-off-by: Wally Rodriguez B <wallyrb@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary

- "command" in ansible doesn't take pipes. Changing to "dpkg -l magma*" in order to get sctpd and other magma package related versions
- Add "sudo" in the documentation
- Add ovs commands to be collected
- Check service status from ovs and scptd
- Collect all /var/log folder from AGW
- Since we are collecting syslogs, remove the journalctl -u magma@* command


## Test Plan

Tested in 1.5 Ubuntu AGW