### PR TITLE
[agw] Fix pylint issues

### DIFF
--- a/lte/gateway/python/magma/enodebd/tr069/rpc_methods.py
+++ b/lte/gateway/python/magma/enodebd/tr069/rpc_methods.py
@@ -96,7 +96,7 @@ class AutoConfigServer(ServiceBase):
         else:
             logger.debug('Handling TR069 message.')
 
-        req = cls.__get_tr069_response_from_sm(ctx, message)
+        req = cls._get_tr069_response_from_sm(ctx, message)
 
         # Log outgoing msg
         if hasattr(req, 'as_dict'):
@@ -117,7 +117,7 @@ class AutoConfigServer(ServiceBase):
         return cls._generate_acs_to_cpe_request_copy(req)
 
     @classmethod
-    def __get_tr069_response_from_sm(
+    def _get_tr069_response_from_sm(
             cls,
             ctx: WsgiMethodContext,
             message: ComplexModelBase,

--- a/lte/gateway/python/magma/subscriberdb/main.py
+++ b/lte/gateway/python/magma/subscriberdb/main.py
@@ -39,8 +39,8 @@ def main():
 
     # Initialize a store to keep all subscriber data.
     store = SqliteStore(
-        service.config['db_path'], loop=service.loop,
-        sid_digits=service.config['sid_last_n'],
+        service.config.get('db_path'), loop=service.loop,
+        sid_digits=service.config.get('sid_last_n'),
     )
 
     # Initialize the processor
@@ -60,7 +60,7 @@ def main():
     subscriberdb_servicer.add_to_server(service.rpc_server)
 
     # Start a background thread to stream updates from the cloud
-    if service.config['enable_streaming']:
+    if service.config.get('enable_streaming'):
         grpc_client_manager = GRPCClientManager(
             service_name="subscriberdb",
             service_stub=SubscriberDBCloudStub,
@@ -92,7 +92,7 @@ def main():
             # Waiting for subscribers to be added to store
             await store.on_ready()
 
-        if service.config['s6a_over_grpc']:
+        if service.config.get('s6a_over_grpc'):
             logging.info('Running s6a over grpc')
             s6a_proxy_servicer = S6aProxyRpcServicer(
                 processor,
@@ -102,9 +102,9 @@ def main():
         else:
             logging.info('Running s6a over DIAMETER')
             base_manager = base.BaseApplication(
-                service.config['mme_realm'],
-                service.config['mme_host_name'],
-                service.config['mme_host_address'],
+                service.config.get('mme_realm'),
+                service.config.get('mme_host_name'),
+                service.config.get('mme_host_address'),
             )
             s6a_manager = _get_s6a_manager(service, processor)
             base_manager.register(s6a_manager)
@@ -114,11 +114,11 @@ def main():
                 lambda: S6aServer(
                     base_manager,
                     s6a_manager,
-                    service.config['mme_realm'],
-                    service.config['mme_host_name'],
+                    service.config.get('mme_realm'),
+                    service.config.get('mme_host_name'),
                     loop=service.loop,
                 ),
-                service.config['host_address'], service.config['mme_port'],
+                service.config.get('host_address'), service.config.get('mme_port'),
             )
             asyncio.ensure_future(s6a_server, loop=service.loop)
     asyncio.ensure_future(serve(), loop=service.loop)
@@ -133,9 +133,9 @@ def main():
 def _get_s6a_manager(service, processor):
     return s6a.S6AApplication(
         processor,
-        service.config['mme_realm'],
-        service.config['mme_host_name'],
-        service.config['mme_host_address'],
+        service.config.get('mme_realm'),
+        service.config.get('mme_host_name'),
+        service.config.get('mme_host_address'),
         service.loop,
     )
 

--- a/orc8r/gateway/python/magma/common/service.py
+++ b/orc8r/gateway/python/magma/common/service.py
@@ -19,7 +19,7 @@ import os
 import signal
 import time
 from concurrent import futures
-from typing import List, Optional
+from typing import List, Optional, Dict, Any
 
 import grpc
 import pkg_resources
@@ -175,7 +175,7 @@ class MagmaService(Service303Servicer):
         return self._state
 
     @property
-    def config(self):
+    def config(self) -> Dict[str, Any]:
         """Return the service config"""
         return self._config
 

--- a/orc8r/gateway/python/magma/magmad/main.py
+++ b/orc8r/gateway/python/magma/magmad/main.py
@@ -61,7 +61,7 @@ def main():
     logging.info('Starting magmad for UUID: %s', snowflake.make_snowflake())
 
     # Create service manager
-    services = service.config['magma_services']
+    services = service.config.get('magma_services')
     init_system = service.config.get('init_system', 'systemd')
     registered_dynamic_services = service.config.get(
         'registered_dynamic_services', [],
@@ -84,7 +84,7 @@ def main():
     )
 
     # Get metrics service config
-    metrics_config = service.config['metricsd']
+    metrics_config = service.config.get('metricsd')
     metrics_services = metrics_config['services']
     collect_interval = metrics_config['collect_interval']
     sync_interval = metrics_config['sync_interval']


### PR DESCRIPTION
Signed-off-by: Andrei Lee <andreilee@fb.com>

## Summary

Fix pylint issues to fix build.

Previous errors:

```
======================================================================
FAIL: test_pylint (tests.pylint_tests.MagmaPyLintTest)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/vagrant/magma/lte/gateway/python/magma/tests/pylint_tests.py", line 60, in test_pylint
    py_wrap.assertNoLintErrors(path)
  File "/home/vagrant/magma/lte/gateway/python/magma/tests/pylint_wrapper.py", line 97, in assertNoLintErrors
    raise AssertionError(msg)
AssertionError: PyLint found errors:
************* Module enodebd.tr069.rpc_methods
W0238: 120, 4: Unused private member `AutoConfigServer.__get_tr069_response_from_sm(cls, ctx: WsgiMethodContext, message: ComplexModelBase)` (unused-private-member)
```

```
======================================================================
FAIL: test_pylint (tests.pylint_tests.MagmaPyLintTest)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/vagrant/magma/lte/gateway/python/magma/tests/pylint_tests.py", line 60, in test_pylint
    py_wrap.assertNoLintErrors(path)
  File "/home/vagrant/magma/lte/gateway/python/magma/tests/pylint_wrapper.py", line 97, in assertNoLintErrors
    raise AssertionError(msg)
AssertionError: PyLint found errors:
************* Module subscriberdb.main
E1136: 63, 7: Value 'service.config' is unsubscriptable (unsubscriptable-object)
E1136: 95, 11: Value 'service.config' is unsubscriptable (unsubscriptable-object)
E1136: 105, 16: Value 'service.config' is unsubscriptable (unsubscriptable-object)
E1136: 106, 16: Value 'service.config' is unsubscriptable (unsubscriptable-object)
E1136: 107, 16: Value 'service.config' is unsubscriptable (unsubscriptable-object)
E1136: 117, 20: Value 'service.config' is unsubscriptable (unsubscriptable-object)
E1136: 118, 20: Value 'service.config' is unsubscriptable (unsubscriptable-object)
E1136: 121, 16: Value 'service.config' is unsubscriptable (unsubscriptable-object)
E1136: 121, 48: Value 'service.config' is unsubscriptable (unsubscriptable-object)
```

```
======================================================================
FAIL: test_pylint (tests.pylint_tests.MagmaPyLintTest)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/vagrant/magma/orc8r/gateway/python/magma/tests/pylint_tests.py", line 57, in test_pylint
    py_wrap.assertNoLintErrors(path)
  File "/home/vagrant/magma/lte/gateway/python/magma/tests/pylint_wrapper.py", line 97, in assertNoLintErrors
    raise AssertionError(msg)
AssertionError: PyLint found errors:
************* Module magmad.main
E1136: 87, 21: Value 'service.config' is unsubscriptable (unsubscriptable-object)
```

## Test Plan

```
Name                                                                    Stmts   Miss Branch BrPart  Cover
---------------------------------------------------------------------------------------------------------
.
.
.
magma/tests/__init__.py                                                     0      0      0      0   100%
magma/tests/pylint_tests.py                                                33     27      2      2    17%
magma/tests/pylint_wrapper.py                                              58     36      8      3    38%
---------------------------------------------------------------------------------------------------------
```

## Additional Information

- [ ] This change is backwards-breaking
