### PR TITLE
Add debug logging to the service303 thread

### DIFF
--- a/lte/gateway/c/core/oai/common/log.c
+++ b/lte/gateway/c/core/oai/common/log.c
@@ -683,6 +683,9 @@ int log_init(
       &g_oai_log.log_proto2str[LOG_ASYNC_SYSTEM][0], LOG_MAX_PROTO_NAME_LENGTH,
       "CMD");
   snprintf(
+      &g_oai_log.log_proto2str[LOG_SERVICE303][0], LOG_MAX_PROTO_NAME_LENGTH,
+      "SERVICE303");
+  snprintf(
       &g_oai_log.log_proto2str[LOG_ASSERT][0], LOG_MAX_PROTO_NAME_LENGTH,
       "ASSERT");
 

--- a/lte/gateway/c/core/oai/common/log.h
+++ b/lte/gateway/c/core/oai/common/log.h
@@ -175,6 +175,7 @@ typedef enum {
   LOG_SGW_S8,
   LOG_AMF_APP,
   LOG_NAS_AMF,
+  LOG_SERVICE303,
   MAX_LOG_PROTOS,
 } log_proto_t;
 

--- a/lte/gateway/c/core/oai/include/service303.h
+++ b/lte/gateway/c/core/oai/include/service303.h
@@ -28,10 +28,12 @@
 #define NO_BOUNDARIES 0
 #define NO_LABELS 0
 #define EPC_STATS_TIMER_MSEC 60000  // In milliseconds
+#define EPC_STATS_DISPLAY_TIMER_MSEC 60000 // In milliseconds
 
 void service303_mme_app_statistics_read(
     application_mme_app_stats_msg_t* stats_msg_p);
 void service303_s1ap_statistics_read(application_s1ap_stats_msg_t* stats_msg_p);
+void service303_statistics_display(void);
 
 // service303 conf type added to be able to use same task interface for MME and
 // SPGW while passing configs from mme_config and spgw_config types
@@ -122,6 +124,7 @@ void decrement_gauge(const char* name, double decrement, size_t n_labels, ...);
  * @param value1: the value of the first label
  */
 void set_gauge(const char* name, double value, size_t n_labels, ...);
+double get_gauge(const char* name, size_t n_labels, ...);
 
 /**
  * Record an observation in the histogram defined by the name and label set.

--- a/lte/gateway/c/core/oai/include/service303_messages_types.h
+++ b/lte/gateway/c/core/oai/include/service303_messages_types.h
@@ -37,6 +37,8 @@ typedef struct application_unhealthy_msg {
 typedef struct application_mme_app_stats_msg {
   uint32_t nb_ue_attached;
   uint32_t nb_ue_connected;
+  uint32_t nb_default_eps_bearers;
+  uint32_t nb_s1u_bearers;
 } application_mme_app_stats_msg_t;
 
 typedef struct application_s1ap_stats_msg {

--- a/lte/gateway/c/core/oai/lib/message_utils/service303_message_utils.c
+++ b/lte/gateway/c/core/oai/lib/message_utils/service303_message_utils.c
@@ -49,6 +49,10 @@ int send_mme_app_stats_to_service303(
       stats_msg->nb_ue_attached;
   message_p->ittiMsg.application_mme_app_stats_msg.nb_ue_connected =
       stats_msg->nb_ue_connected;
+  message_p->ittiMsg.application_mme_app_stats_msg.nb_default_eps_bearers =
+      stats_msg->nb_default_eps_bearers;
+  message_p->ittiMsg.application_mme_app_stats_msg.nb_s1u_bearers =
+      stats_msg->nb_s1u_bearers;
   return send_msg_to_task(task_zmq_ctx_p, TASK_SERVICE303, message_p);
 }
 

--- a/lte/gateway/c/core/oai/tasks/mme_app/mme_app_main.c
+++ b/lte/gateway/c/core/oai/tasks/mme_app/mme_app_main.c
@@ -568,8 +568,10 @@ status_code_e mme_app_init(const mme_config_t* mme_config_p) {
 static int handle_stats_timer(zloop_t* loop, int id, void* arg) {
   mme_app_desc_t* mme_app_desc_p = get_mme_nas_state(false);
   application_mme_app_stats_msg_t stats_msg;
-  stats_msg.nb_ue_attached  = mme_app_desc_p->nb_ue_attached;
-  stats_msg.nb_ue_connected = mme_app_desc_p->nb_ue_connected;
+  stats_msg.nb_ue_attached         = mme_app_desc_p->nb_ue_attached;
+  stats_msg.nb_ue_connected        = mme_app_desc_p->nb_ue_connected;
+  stats_msg.nb_default_eps_bearers = mme_app_desc_p->nb_default_eps_bearers;
+  stats_msg.nb_s1u_bearers         = mme_app_desc_p->nb_s1u_bearers;
   return send_mme_app_stats_to_service303(
       &mme_app_task_zmq_ctx, TASK_MME_APP, &stats_msg);
 }

--- a/lte/gateway/c/core/oai/tasks/service303/service303.cpp
+++ b/lte/gateway/c/core/oai/tasks/service303/service303.cpp
@@ -70,6 +70,13 @@ void set_gauge(const char* name, double value, size_t n_labels, ...) {
   va_end(ap);
 }
 
+double get_gauge(const char* name, size_t n_labels, ...) {
+  va_list ap;
+  va_start(ap, n_labels);
+  return MetricsSingleton::Instance().GetGauge(name, n_labels, ap);
+  va_end(ap);
+}
+
 void observe_histogram(
     const char* name, double observation, size_t n_labels, ...) {
   va_list ap;

--- a/lte/gateway/c/core/oai/tasks/service303/service303_mme_stats.c
+++ b/lte/gateway/c/core/oai/tasks/service303/service303_mme_stats.c
@@ -17,8 +17,7 @@
 #define SERVICE303
 
 #include <stddef.h>
-
-#include "mme_app_state.h"
+#include "log.h"
 #include "service303.h"
 
 void service303_mme_app_statistics_read(
@@ -26,12 +25,41 @@ void service303_mme_app_statistics_read(
   size_t label = 0;
   set_gauge("ue_registered", stats_msg_p->nb_ue_attached, label);
   set_gauge("ue_connected", stats_msg_p->nb_ue_connected, label);
-  return;
+  set_gauge("default_eps_bearers", stats_msg_p->nb_default_eps_bearers, label);
+  set_gauge("s1u_bearers", stats_msg_p->nb_s1u_bearers, label);
 }
 
 void service303_s1ap_statistics_read(
     application_s1ap_stats_msg_t* stats_msg_p) {
   size_t label = 0;
   set_gauge("enb_connected", stats_msg_p->nb_enb_connected, label);
-  return;
+}
+
+void service303_statistics_display(void) {
+  size_t label = 0;
+  OAILOG_DEBUG(
+      LOG_SERVICE303,
+      "======================================= STATISTICS "
+      "============================================\n\n");
+  OAILOG_DEBUG(LOG_SERVICE303, "               |   Current Status|\n");
+  OAILOG_DEBUG(
+      LOG_SERVICE303, "Attached UEs   | %10u      |\n",
+      (uint32_t) get_gauge("ue_registered", label));
+  OAILOG_DEBUG(
+      LOG_SERVICE303, "Connected UEs  | %10u      |\n",
+      (uint32_t) get_gauge("ue_connected", label));
+  OAILOG_DEBUG(
+      LOG_SERVICE303, "Connected eNBs | %10u      |\n",
+      (uint32_t) get_gauge("enb_connected", label));
+  OAILOG_DEBUG(
+      LOG_SERVICE303, "Default Bearers| %10u      |\n",
+      (uint32_t) get_gauge("default_eps_bearers", label));
+  OAILOG_DEBUG(
+      LOG_SERVICE303, "S1-U Bearers   | %10u      |\n\n",
+      (uint32_t) get_gauge("s1u_bearers", label));
+
+  OAILOG_DEBUG(
+      LOG_SERVICE303,
+      "======================================= STATISTICS "
+      "============================================\n\n");
 }

--- a/lte/gateway/c/core/oai/tasks/service303/service303_task.c
+++ b/lte/gateway/c/core/oai/tasks/service303/service303_task.c
@@ -33,6 +33,9 @@ static void service303_message_exit(void);
 
 task_zmq_ctx_t service303_server_task_zmq_ctx;
 task_zmq_ctx_t service303_message_task_zmq_ctx;
+static long display_stats_timer_id;
+static int handle_display_timer(zloop_t*, int, void*);
+static void start_display_stats_timer(void);
 
 static int handle_service303_server_message(
     zloop_t* loop, zsock_t* reader, void* arg) {
@@ -109,7 +112,7 @@ static void* service303_thread(void* args) {
   init_task_context(
       TASK_SERVICE303, (task_id_t[]){}, 0, handle_service_message,
       &service303_message_task_zmq_ctx);
-
+  start_display_stats_timer();
   zloop_start(service303_message_task_zmq_ctx.event_loop);
   service303_message_exit();
   return NULL;
@@ -139,6 +142,7 @@ status_code_e service303_init(service303_data_t* service303_data) {
 }
 
 static void service303_server_exit(void) {
+  stop_timer(&service303_message_task_zmq_ctx, display_stats_timer_id);
   destroy_task_context(&service303_server_task_zmq_ctx);
   OAI_FPRINTF_INFO("TASK_SERVICE303_SERVER terminated\n");
   pthread_exit(NULL);
@@ -148,4 +152,15 @@ static void service303_message_exit(void) {
   destroy_task_context(&service303_message_task_zmq_ctx);
   OAI_FPRINTF_INFO("TASK_SERVICE303 terminated\n");
   pthread_exit(NULL);
+}
+
+static int handle_display_timer(zloop_t* loop, int id, void* arg) {
+  service303_statistics_display();
+  return 0;
+}
+
+static void start_display_stats_timer(void) {
+  display_stats_timer_id = start_timer(
+      &service303_message_task_zmq_ctx, EPC_STATS_DISPLAY_TIMER_MSEC,
+      TIMER_REPEAT_FOREVER, handle_display_timer, NULL);
 }


### PR DESCRIPTION
## Summary

Move logging to the service303 thread

Signed-off-by: Amar Padmanabhan <amar@freedomfi.com>

## Test Plan

make integ_test
validated output after running test
002005 Wed Jun 30 00:59:22 2021 7FECB9095700 DEBUG SERVIC tasks/service303/service303_mme_:0045    ======================================= STATISTICS ============================================
002006 Wed Jun 30 00:59:22 2021 7FECB9095700 DEBUG SERVIC tasks/service303/service303_mme_:0046                   |   Current Status|
002007 Wed Jun 30 00:59:22 2021 7FECB9095700 DEBUG SERVIC tasks/service303/service303_mme_:0049    Attached UEs   |          1      |
002008 Wed Jun 30 00:59:22 2021 7FECB9095700 DEBUG SERVIC tasks/service303/service303_mme_:0052    Connected UEs  |          1      |
002009 Wed Jun 30 00:59:22 2021 7FECB9095700 DEBUG SERVIC tasks/service303/service303_mme_:0055    Connected eNBs |          1      |
002010 Wed Jun 30 00:59:22 2021 7FECB9095700 DEBUG SERVIC tasks/service303/service303_mme_:0058    Default Bearers|          1      |
002011 Wed Jun 30 00:59:22 2021 7FECB9095700 DEBUG SERVIC tasks/service303/service303_mme_:0061    S1-U Bearers   |          1      |
002012 Wed Jun 30 00:59:22 2021 7FECB9095700 DEBUG SERVIC tasks/service303/service303_mme_:0066    ======================================= STATISTICS ============================================

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
