### PR TITLE
Add a GetGauge helper function to read specific stats

### DIFF
--- a/orc8r/gateway/c/common/service303/MetricsSingleton.cpp
+++ b/orc8r/gateway/c/common/service303/MetricsSingleton.cpp
@@ -97,6 +97,13 @@ void MetricsSingleton::SetGauge(
   gauges_.Get(name, labels).Set(value);
 }
 
+double MetricsSingleton::GetGauge(
+    const char* name, size_t label_count, va_list& args) {
+  std::map<std::string, std::string> labels;
+  args_to_map(labels, label_count, args);
+  return gauges_.Get(name, labels).Value();
+}
+
 void MetricsSingleton::ObserveHistogram(
     const char* name, double observation, size_t label_count, va_list& args) {
   std::map<std::string, std::string> labels;

--- a/orc8r/gateway/c/common/service303/includes/MetricsSingleton.h
+++ b/orc8r/gateway/c/common/service303/includes/MetricsSingleton.h
@@ -88,6 +88,7 @@ class MetricsSingleton {
       const char* name, double value, size_t label_count, va_list& args);
   void ObserveHistogram(
       const char* name, double observation, size_t label_count, va_list& args);
+  double GetGauge(const char* name, size_t label_count, va_list& args);
 
  private:
   MetricsSingleton();                         // Prevent construction


### PR DESCRIPTION
## Summary

Add an accessor for reading specific stats

see https://github.com/magma/magma/pull/7847 for full changeset

Signed-off-by: Amar Padmanabhan <amar@freedomfi.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->



<!-- Enumerate changes you made and why you made them -->

## Test Plan

make integ_test

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
