### PR TITLE
refactor: (mme)Add status_or struct for return types

### DIFF
--- a/lte/gateway/c/core/oai/common/common_defs.h
+++ b/lte/gateway/c/core/oai/common/common_defs.h
@@ -109,6 +109,27 @@ typedef enum {
   RETURNok    = 0,   // Ok
 } status_code_e;
 
+/* status_or structs should be returned by functions that have error handling.
+ * If the function returns a value without issue, the status should be RETURNok
+ * If the function has an error, then status should not be RETURNok,
+ * and the value should be ignored.
+ */
+#define TYPEDEF_STATUS_OR(nAME, tYPE)                                          \
+  typedef struct {                                                             \
+    status_code_e status;                                                      \
+    tYPE value;                                                                \
+  } nAME;
+
+#define IS_STATUS_OK(sTATUS_OR) (sTATUS_OR.status == RETURNok)
+
+#define RETURN_ERROR(sTATUS_OR) return (sTATUS_OR){RETURNerror, 0};
+
+TYPEDEF_STATUS_OR(status_or_int_t, int);
+TYPEDEF_STATUS_OR(status_or_uint32_t, uint32_t);
+
+#define RETURN_INT_ERROR return (status_or_int_t){RETURNerror, 0};
+#define RETURN_UINT_ERROR return (status_or_uint32_t){RETURNerror, 0};
+
 /* This enum should match with the ModeMapItem_FederatedMode enum
  * defined in mconfigs.proto
  */

--- a/lte/gateway/c/core/oai/include/mme_config.h
+++ b/lte/gateway/c/core/oai/include/mme_config.h
@@ -438,13 +438,13 @@ typedef struct mme_config_s {
 
 extern mme_config_t mme_config;
 
-int mme_config_find_mnc_length(
+status_or_int_t mme_config_find_mnc_length(
     const char mcc_digit1P, const char mcc_digit2P, const char mcc_digit3P,
     const char mnc_digit1P, const char mnc_digit2P, const char mnc_digit3P);
 
 void mme_config_init(mme_config_t*);
 int mme_config_parse_opt_line(int argc, char* argv[], mme_config_t* mme_config);
-int mme_config_parse_file(mme_config_t*);
+status_code_e mme_config_parse_file(mme_config_t*);
 void mme_config_display(mme_config_t*);
 
 void mme_config_exit(void);

--- a/lte/gateway/c/core/oai/tasks/gtpv1-u/gtp_tunnel_libgtpnl.c
+++ b/lte/gateway/c/core/oai/tasks/gtpv1-u/gtp_tunnel_libgtpnl.c
@@ -136,7 +136,7 @@ status_code_e libgtpnl_init(
 }
 
 status_code_e libgtpnl_uninit(void) {
-  if (!gtp_nl.is_enabled) return -1;
+  if (!gtp_nl.is_enabled) return RETURNerror;
 
   return gtp_dev_destroy(GTP_DEVNAME);
 }

--- a/lte/gateway/c/core/oai/tasks/ngap/ngap_amf_decoder.c
+++ b/lte/gateway/c/core/oai/tasks/ngap/ngap_amf_decoder.c
@@ -32,7 +32,8 @@
 #include "constr_TYPE.h"
 #include "per_decoder.h"
 
-int ngap_amf_decode_pdu(Ngap_NGAP_PDU_t* pdu, const_bstring const raw) {
+status_code_e ngap_amf_decode_pdu(
+    Ngap_NGAP_PDU_t* pdu, const_bstring const raw) {
   asn_dec_rval_t dec_ret;
   DevAssert(pdu != NULL);
   DevAssert(blength(raw) != 0);
@@ -42,7 +43,7 @@ int ngap_amf_decode_pdu(Ngap_NGAP_PDU_t* pdu, const_bstring const raw) {
 
   if (dec_ret.code != RC_OK) {
     OAILOG_ERROR(LOG_NGAP, "Failed to decode PDU\n");
-    return -1;
+    return RETURNerror;
   }
-  return 0;
+  return RETURNok;
 }

--- a/lte/gateway/c/core/oai/tasks/ngap/ngap_amf_encoder.c
+++ b/lte/gateway/c/core/oai/tasks/ngap/ngap_amf_encoder.c
@@ -76,7 +76,7 @@ int ngap_amf_encode_pdu(
 }
 
 //------------------------------------------------------------------------------
-static inline int ngap_amf_encode_initiating(
+static inline status_code_e ngap_amf_encode_initiating(
     Ngap_NGAP_PDU_t* pdu, uint8_t** buffer, uint32_t* length) {
   asn_encode_to_new_buffer_result_t res = {NULL, {0, NULL, NULL}};
   DevAssert(pdu != NULL);
@@ -96,7 +96,7 @@ static inline int ngap_amf_encode_initiating(
           (int) pdu->choice.initiatingMessage.procedureCode);
       *buffer = NULL;
       *length = 0;
-      return -1;
+      return RETURNerror;
   }
 
   memset(&res, 0, sizeof(res));
@@ -104,11 +104,11 @@ static inline int ngap_amf_encode_initiating(
       NULL, ATS_ALIGNED_CANONICAL_PER, &asn_DEF_Ngap_NGAP_PDU, pdu);
   *buffer = (uint8_t*) res.buffer;
   *length = res.result.encoded;
-  return 0;
+  return RETURNok;
 }
 
 //------------------------------------------------------------------------------
-static inline int ngap_amf_encode_successful_outcome(
+static inline status_code_e ngap_amf_encode_successful_outcome(
     Ngap_NGAP_PDU_t* pdu, uint8_t** buffer, uint32_t* length) {
   asn_encode_to_new_buffer_result_t res = {NULL, {0, NULL, NULL}};
   DevAssert(pdu != NULL);
@@ -124,7 +124,7 @@ static inline int ngap_amf_encode_successful_outcome(
           (int) pdu->choice.successfulOutcome.procedureCode);
       *buffer = NULL;
       *length = 0;
-      return -1;
+      return RETURNerror;
   }
 
   memset(&res, 0, sizeof(res));
@@ -133,11 +133,11 @@ static inline int ngap_amf_encode_successful_outcome(
 
   *buffer = res.buffer;
   *length = res.result.encoded;
-  return 0;
+  return RETURNok;
 }
 
 //------------------------------------------------------------------------------
-static inline int ngap_amf_encode_unsuccessful_outcome(
+static inline status_code_e ngap_amf_encode_unsuccessful_outcome(
     Ngap_NGAP_PDU_t* pdu, uint8_t** buffer, uint32_t* length) {
   asn_encode_to_new_buffer_result_t res = {NULL, {0, NULL, NULL}};
   DevAssert(pdu != NULL);
@@ -153,7 +153,7 @@ static inline int ngap_amf_encode_unsuccessful_outcome(
           (int) pdu->choice.unsuccessfulOutcome.procedureCode);
       *buffer = NULL;
       *length = 0;
-      return -1;
+      return RETURNerror;
   }
 
   memset(&res, 0, sizeof(res));
@@ -162,5 +162,5 @@ static inline int ngap_amf_encode_unsuccessful_outcome(
 
   *buffer = res.buffer;
   *length = res.result.encoded;
-  return 0;
+  return RETURNok;
 }

--- a/lte/gateway/c/core/oai/tasks/ngap/ngap_amf_handlers.c
+++ b/lte/gateway/c/core/oai/tasks/ngap/ngap_amf_handlers.c
@@ -169,7 +169,7 @@ status_code_e ngap_amf_handle_message(
         "[SCTP %d] Either procedureCode %d or direction %d exceed expected\n",
         assoc_id, (int) pdu->choice.initiatingMessage.procedureCode,
         (int) pdu->present);
-    return -1;
+    return RETURNerror;
   }
 
   ngap_message_handler_t handler =
@@ -182,7 +182,7 @@ status_code_e ngap_amf_handle_message(
         LOG_NGAP, "[SCTP %d] No handler for procedureCode %d in %s\n", assoc_id,
         (int) pdu->choice.initiatingMessage.procedureCode,
         ngap_direction2str(pdu->present));
-    return -2;
+    return RETURNerror;
   }
 
   return handler(state, assoc_id, stream, pdu);
@@ -218,10 +218,10 @@ status_code_e ngap_amf_set_cause(
 
     default:
       OAILOG_DEBUG(LOG_NGAP, "Unknown cause for context release");
-      return -1;
+      return RETURNerror;
   }
 
-  return 0;
+  return RETURNok;
 }
 
 //------------------------------------------------------------------------------
@@ -546,7 +546,7 @@ status_code_e ngap_generate_ng_setup_response(
   // memset for gcc 4.8.4 instead of {0}, servedGUAMFI.servedPLMNs
   servedGUAMFI = calloc(1, sizeof *servedGUAMFI);
 
-#if 0  
+#if 0
 amf_config_read_lock(&amf_config);
   /*
    * Use the guamfi parameters provided by configuration

--- a/lte/gateway/c/core/oai/tasks/ngap/ngap_amf_nas_procedures.c
+++ b/lte/gateway/c/core/oai/tasks/ngap/ngap_amf_nas_procedures.c
@@ -116,7 +116,7 @@ status_code_e ngap_amf_handle_initial_ue_message(
      * * * * Forward message to NAS.
      */
     if ((ue_ref = ngap_new_ue(state, assoc_id, gnb_ue_ngap_id)) == NULL) {
-      // If we failed to allocate a new UE return -1
+      // If we failed to allocate a new UE return RETURNerror
       OAILOG_ERROR(
           LOG_NGAP,
           "Initial UE Message- Failed to allocate NGAP UE Context, "

--- a/lte/gateway/c/core/oai/tasks/s1ap/s1ap_mme_handlers.c
+++ b/lte/gateway/c/core/oai/tasks/s1ap/s1ap_mme_handlers.c
@@ -1403,19 +1403,20 @@ status_code_e s1ap_mme_generate_ue_context_modification(
   if ((ue_context_mod_req_pP->presencemask & S1AP_UE_CONTEXT_MOD_LAI_PRESENT) ==
       S1AP_UE_CONTEXT_MOD_LAI_PRESENT) {
 #define PLMN_SIZE 3
-    S1ap_LAI_t* lai_item        = &ie->value.choice.LAI;
-    lai_item->pLMNidentity.size = PLMN_SIZE;
-    lai_item->pLMNidentity.buf  = calloc(PLMN_SIZE, sizeof(uint8_t));
-    uint8_t mnc_length          = mme_config_find_mnc_length(
+    S1ap_LAI_t* lai_item           = &ie->value.choice.LAI;
+    lai_item->pLMNidentity.size    = PLMN_SIZE;
+    lai_item->pLMNidentity.buf     = calloc(PLMN_SIZE, sizeof(uint8_t));
+    status_or_int_t mnc_length_res = mme_config_find_mnc_length(
         ue_context_mod_req_pP->lai.mccdigit1,
         ue_context_mod_req_pP->lai.mccdigit2,
         ue_context_mod_req_pP->lai.mccdigit3,
         ue_context_mod_req_pP->lai.mncdigit1,
         ue_context_mod_req_pP->lai.mncdigit2,
         ue_context_mod_req_pP->lai.mncdigit3);
-    if (mnc_length != 2 && mnc_length != 3) {
+    if (!IS_STATUS_OK(mnc_length_res)) {
       OAILOG_FUNC_RETURN(LOG_S1AP, RETURNerror);
     }
+    uint8_t mnc_length = mnc_length_res.value;
     LAI_T_TO_TBCD(
         ue_context_mod_req_pP->lai, lai_item->pLMNidentity.buf, mnc_length);
 
@@ -3114,7 +3115,7 @@ status_code_e s1ap_mme_handle_handover_notify(
     }
     if ((new_ue_ref_p = s1ap_new_ue(state, assoc_id, tgt_enb_ue_s1ap_id)) ==
         NULL) {
-      // If we failed to allocate a new UE return -1
+      // If we failed to allocate a new UE return RETURNerror
       OAILOG_ERROR_UE(
           LOG_S1AP, imsi64,
           "S1AP:Handover Notify- Failed to allocate S1AP UE Context, "
@@ -3379,7 +3380,7 @@ status_code_e s1ap_mme_handle_path_switch_request(
      * from source eNB.
      */
     if ((new_ue_ref_p = s1ap_new_ue(state, assoc_id, enb_ue_s1ap_id)) == NULL) {
-      // If we failed to allocate a new UE return -1
+      // If we failed to allocate a new UE return RETURNerror
       OAILOG_ERROR_UE(
           LOG_S1AP, imsi64,
           "S1AP:Path Switch Request- Failed to allocate S1AP UE Context, "

--- a/lte/gateway/c/core/oai/tasks/s1ap/s1ap_mme_nas_procedures.c
+++ b/lte/gateway/c/core/oai/tasks/s1ap/s1ap_mme_nas_procedures.c
@@ -146,7 +146,7 @@ status_code_e s1ap_mme_handle_initial_ue_message(
      * * * * Forward message to NAS.
      */
     if ((ue_ref = s1ap_new_ue(state, assoc_id, enb_ue_s1ap_id)) == NULL) {
-      // If we failed to allocate a new UE return -1
+      // If we failed to allocate a new UE return RETURNerror
       OAILOG_ERROR(
           LOG_S1AP,
           "Initial UE Message- Failed to allocate S1AP UE Context, "

--- a/lte/gateway/c/core/oai/tasks/s6a/s6a_auth_info.c
+++ b/lte/gateway/c/core/oai/tasks/s6a/s6a_auth_info.c
@@ -378,13 +378,14 @@ status_code_e s6a_generate_authentication_info_req(s6a_auth_info_req_t* air_p) {
     uint8_t plmn[3] = {0x00, 0x00, 0x00};  //{ 0x02, 0xF8, 0x29 };
     CHECK_FCT(fd_msg_avp_new(s6a_fd_cnf.dataobj_s6a_visited_plmn_id, 0, &avp));
 
-    uint8_t mnc_length = mme_config_find_mnc_length(
+    status_or_int_t mnc_length_res = mme_config_find_mnc_length(
         air_p->visited_plmn.mcc_digit1, air_p->visited_plmn.mcc_digit2,
         air_p->visited_plmn.mcc_digit3, air_p->visited_plmn.mnc_digit1,
         air_p->visited_plmn.mnc_digit2, air_p->visited_plmn.mnc_digit3);
-    if (mnc_length != 2 && mnc_length != 3) {
+    if (!IS_STATUS_OK(mnc_length_res)) {
       OAILOG_FUNC_RETURN(LOG_S6A, RETURNerror);
     }
+    uint8_t mnc_length = mnc_length_res.value;
     PLMN_T_TO_TBCD(air_p->visited_plmn, plmn, mnc_length);
     value.os.data = plmn;
     value.os.len  = 3;

--- a/lte/gateway/c/core/oai/tasks/s6a/s6a_cancel_loc.c
+++ b/lte/gateway/c/core/oai/tasks/s6a/s6a_cancel_loc.c
@@ -210,7 +210,7 @@ int s6a_add_result_code(
   return 0;
 }
 
-int s6a_send_cancel_location_ans(s6a_cancel_location_ans_t* cla_pP) {
+status_code_e s6a_send_cancel_location_ans(s6a_cancel_location_ans_t* cla_pP) {
   struct msg** msg_p       = NULL;
   struct msg* ans_p        = NULL;
   struct avp* failed_avp_p = NULL;
@@ -225,7 +225,7 @@ int s6a_send_cancel_location_ans(s6a_cancel_location_ans_t* cla_pP) {
 
   msg_p = (struct msg**) cla_pP->msg_cla_p;
   if (msg_p == NULL) {
-    return -1;
+    return RETURNerror;
   }
   ans_p = *msg_p; /* Get the received CLA */
   /*
@@ -234,5 +234,5 @@ int s6a_send_cancel_location_ans(s6a_cancel_location_ans_t* cla_pP) {
   CHECK_FCT(
       s6a_add_result_code(ans_p, failed_avp_p, result_code, experimental));
   CHECK_FCT(fd_msg_send(msg_p, NULL, NULL));
-  return 0;
+  return RETURNok;
 }

--- a/lte/gateway/c/core/oai/tasks/s6a/s6a_up_loc.c
+++ b/lte/gateway/c/core/oai/tasks/s6a/s6a_up_loc.c
@@ -269,13 +269,14 @@ status_code_e s6a_generate_update_location(s6a_update_location_req_t* ulr_pP) {
     CHECK_FCT(
         fd_msg_avp_new(s6a_fd_cnf.dataobj_s6a_visited_plmn_id, 0, &avp_p));
 
-    uint8_t mnc_length = mme_config_find_mnc_length(
+    status_or_int_t mnc_length_res = mme_config_find_mnc_length(
         ulr_pP->visited_plmn.mcc_digit1, ulr_pP->visited_plmn.mcc_digit2,
         ulr_pP->visited_plmn.mcc_digit3, ulr_pP->visited_plmn.mnc_digit1,
         ulr_pP->visited_plmn.mnc_digit2, ulr_pP->visited_plmn.mnc_digit3);
-    if (mnc_length != 2 && mnc_length != 3) {
+    if (!IS_STATUS_OK(mnc_length_res)) {
       OAILOG_FUNC_RETURN(LOG_S6A, RETURNerror);
     }
+    uint8_t mnc_length = mnc_length_res.value;
     PLMN_T_TO_TBCD(ulr_pP->visited_plmn, plmn, mnc_length);
     value.os.data = plmn;
     value.os.len  = 3;

--- a/lte/gateway/c/core/oai/tasks/sctp/sctp_primitives_server.c
+++ b/lte/gateway/c/core/oai/tasks/sctp/sctp_primitives_server.c
@@ -142,7 +142,7 @@ static void* sctp_thread(__attribute__((unused)) void* args_p) {
   return NULL;
 }
 
-int sctp_init(const mme_config_t* mme_config_p) {
+status_code_e sctp_init(const mme_config_t* mme_config_p) {
   OAILOG_DEBUG(LOG_SCTP, "Initializing SCTP task interface\n");
 
   if (init_sctpd_downlink_client(!mme_config.use_stateless) < 0) {
@@ -152,11 +152,11 @@ int sctp_init(const mme_config_t* mme_config_p) {
   if (itti_create_task(TASK_SCTP, &sctp_thread, NULL) < 0) {
     OAILOG_ERROR(LOG_SCTP, "create task failed\n");
     OAILOG_DEBUG(LOG_SCTP, "Initializing SCTP task interface: FAILED\n");
-    return -1;
+    return RETURNerror;
   }
 
   OAILOG_DEBUG(LOG_SCTP, "Initializing SCTP task interface: DONE\n");
-  return 0;
+  return RETURNok;
 }
 
 static void sctp_exit(void) {

--- a/lte/gateway/c/core/oai/tasks/sctp/sctpd_downlink_client.h
+++ b/lte/gateway/c/core/oai/tasks/sctp/sctpd_downlink_client.h
@@ -26,8 +26,8 @@
 int init_sctpd_downlink_client(bool force_restart);
 
 // init
-int sctpd_init(sctp_init_t* init);
+status_code_e sctpd_init(sctp_init_t* init);
 
 // sendDl
-int sctpd_send_dl(
+status_code_e sctpd_send_dl(
     uint32_t ppid, uint32_t assoc_id, uint16_t stream, bstring payload);

--- a/lte/gateway/c/core/oai/tasks/sgw/mobilityd_ue_ip_address_alloc.c
+++ b/lte/gateway/c/core/oai/tasks/sgw/mobilityd_ue_ip_address_alloc.c
@@ -42,14 +42,14 @@ void release_ue_ipv6_address(
   release_ipv6_address(imsi, apn, addr);
 }
 
-int get_ip_block(struct in_addr* netaddr, uint32_t* netmask) {
+status_or_int_t get_ip_block(struct in_addr* netaddr, uint32_t* netmask) {
   int rv;
 
   rv = get_assigned_ipv4_block(0, netaddr, netmask);
   if (rv != 0) {
     OAILOG_CRITICAL(
         LOG_GTPV1U, "ERROR in getting assigned IP block from mobilityd\n");
-    return -1;
+    RETURN_INT_ERROR;
   }
-  return rv;
+  return (status_or_int_t){RETURNok, rv};
 }

--- a/lte/gateway/c/core/oai/tasks/sgw/pgw_config.c
+++ b/lte/gateway/c/core/oai/tasks/sgw/pgw_config.c
@@ -154,7 +154,7 @@ status_code_e pgw_config_process(pgw_config_t* config_pP) {
           OAILOG_CRITICAL(
               LOG_SPGW_APP,
               "ERROR in getting assigned IP block from mobilityd\n");
-          return -1;
+          return RETURNerror;
         } else {
           OAILOG_DEBUG(
               LOG_SPGW_APP, "mobilityD IP block read: retry attempt: %d",
@@ -202,7 +202,7 @@ status_code_e pgw_config_process(pgw_config_t* config_pP) {
 
   // TODO: Fix me: Add tc support
 
-  return 0;
+  return RETURNok;
 }
 
 //------------------------------------------------------------------------------

--- a/lte/gateway/c/core/oai/tasks/sgw/pgw_ue_ip_address_alloc.h
+++ b/lte/gateway/c/core/oai/tasks/sgw/pgw_ue_ip_address_alloc.h
@@ -34,7 +34,7 @@
 void release_ue_ipv4_address(
     const char* imsi, const char* apn, struct in_addr* addr);
 
-int get_ip_block(struct in_addr* netaddr, uint32_t* netmask);
+status_or_int_t get_ip_block(struct in_addr* netaddr, uint32_t* netmask);
 
 void release_ue_ipv6_address(
     const char* imsi, const char* apn, struct in6_addr* addr);

--- a/lte/gateway/c/core/oai/tasks/udp/udp_primitives_server.c
+++ b/lte/gateway/c/core/oai/tasks/udp/udp_primitives_server.c
@@ -39,6 +39,7 @@
 
 #include "assertions.h"
 #include "conversions.h"
+#include "common_defs.h"
 #include "dynamic_memory_check.h"
 #include "intertask_interface.h"
 #include "itti_free_defined_msg.h"
@@ -195,7 +196,7 @@ static int udp_socket_handler(zloop_t* loop, zmq_pollitem_t* item, void* arg) {
 }
 
 //------------------------------------------------------------------------------
-static int udp_server_create_socket_v4(
+static status_or_int_t udp_server_create_socket_v4(
     uint16_t port, struct in_addr* address, task_id_t task_id) {
   struct sockaddr_in addr;
   int sd;
@@ -211,7 +212,7 @@ static int udp_server_create_socket_v4(
      */
     OAILOG_ERROR(
         LOG_UDP, "IPv4 socket creation failed (%s)\n", strerror(errno));
-    return sd;
+    RETURN_INT_ERROR
   }
 
   memset(&addr, 0, sizeof(struct sockaddr_in));
@@ -235,7 +236,7 @@ static int udp_server_create_socket_v4(
         "Socket bind failed (%s) for IPv4 address %s and port %" PRIu16 "\n",
         strerror(errno), ipv4, port);
     close(sd);
-    return -1;
+    RETURN_INT_ERROR
   }
   struct sockaddr_in addr_check;
   socklen_t len = sizeof(addr_check);
@@ -255,7 +256,7 @@ static int udp_server_create_socket_v4(
         LOG_UDP, "fcntl F_SETFL O_NONBLOCK failed for IPv4: %s\n",
         strerror(errno));
     close(sd);
-    return -1;
+    RETURN_INT_ERROR
   }
 
   socket_desc_p = calloc(1, sizeof(struct udp_socket_desc_s));
@@ -275,11 +276,11 @@ static int udp_server_create_socket_v4(
   zmq_pollitem_t item = {0, sd, ZMQ_POLLIN, 0};
   zloop_poller(udp_task_zmq_ctx.event_loop, &item, udp_socket_handler, NULL);
 
-  return sd;
+  return (status_or_int_t){RETURNok, sd};  // NOLINT: semicolon required
 }
 
 //------------------------------------------------------------------------------
-static int udp_server_create_socket_v6(
+static status_or_int_t udp_server_create_socket_v6(
     uint16_t port, struct in6_addr* address, task_id_t task_id) {
   struct sockaddr_in6 addr;
   int sd;
@@ -294,7 +295,7 @@ static int udp_server_create_socket_v6(
      */
     OAILOG_ERROR(
         LOG_UDP, "IPv6 socket creation failed (%s)\n", strerror(errno));
-    return sd;
+    RETURN_INT_ERROR;
   }
 
   memset(&addr, 0, sizeof(struct sockaddr_in6));
@@ -316,7 +317,7 @@ static int udp_server_create_socket_v6(
     //    OAILOG_ERROR (LOG_UDP, "Socket bind failed (%s) for address %s and
     //    port %" PRIu16 "\n", strerror (errno), ipv4, port);
     close(sd);
-    return -1;
+    RETURN_INT_ERROR
   }
   struct sockaddr_in addr_check;
   socklen_t len = sizeof(addr_check);
@@ -335,7 +336,7 @@ static int udp_server_create_socket_v6(
     OAILOG_ERROR(
         LOG_UDP, "fcntl F_SETFL O_NONBLOCK failed: %s\n", strerror(errno));
     close(sd);
-    return -1;
+    RETURN_INT_ERROR
   }
 
   socket_desc_p = calloc(1, sizeof(struct udp_socket_desc_s));
@@ -357,7 +358,7 @@ static int udp_server_create_socket_v6(
   zmq_pollitem_t item = {0, sd, ZMQ_POLLIN, 0};
   zloop_poller(udp_task_zmq_ctx.event_loop, &item, udp_socket_handler, NULL);
 
-  return sd;
+  return (status_or_int_t){RETURNok, sd};  // NOLINT: semicolon required
 }
 
 static int handle_message(zloop_t* loop, zsock_t* reader, void* arg) {
@@ -514,17 +515,17 @@ static void* udp_thread(void* args) {
 }
 
 //------------------------------------------------------------------------------
-int udp_init(void) {
+status_code_e udp_init(void) {
   OAILOG_DEBUG(LOG_UDP, "Initializing UDP task interface\n");
   STAILQ_INIT(&udp_socket_list);
 
   if (itti_create_task(TASK_UDP, &udp_thread, NULL) < 0) {
     OAILOG_ERROR(LOG_UDP, "udp pthread_create (%s)\n", strerror(errno));
-    return -1;
+    return RETURNerror;
   }
 
   OAILOG_DEBUG(LOG_UDP, "Initializing UDP task interface: DONE\n");
-  return 0;
+  return RETURNok;
 }
 
 //------------------------------------------------------------------------------


### PR DESCRIPTION

## Summary

Refactoring change to add
- `status_or_int_t`
- `status_or_uint32_t`

## Test Plan

Built MME
```
vagrant@magma-dev-focal:~/magma/lte/gateway$ make build_oai
.
.
.
/usr/bin/ld: warning: libnettle.so.7, needed by /lib/x86_64-linux-gnu/librtmp.so.1, may conflict with libnettle.so.4
[8/8] Completed 'MagmaCore'
vagrant@magma-dev-focal:~/magma/lte/gateway$
```


Also ran attach and detach for sanity test:
```
vagrant@magma-test:~/magma/lte/gateway/python/integ_tests$ make integ_test TESTS=s1aptests/test_attach_detach.py
. /home/vagrant/build/python/bin/activate
echo "Running test: s1aptests/test_attach_detach.py"
Running test: s1aptests/test_attach_detach.py
timeout --foreground -k 930s 900s sudo -E PATH=/usr/lib/ccache:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/go/bin PYTHONPATH=:/home/vagrant/s1ap-tester/bin /home/vagrant/build/python/bin/nosetests --with-xunit --xunit-file=/var/tmp/test_results/test_attach_detach.xml -x -s s1aptests/test_attach_detach.py || exit 1
Start time 06:14:43
tag: AUTH_TYPE tagVal: MILENAGE
************************* Enb tester config

**********************TPT open server******** 0

 Server Socket FD =[13]
************* Testing *Time elapsed(in usec): for timer expiry               :3602 usec
AGW is stateless
APN Correction configured
Health service is disabled
Using subscriber IMSI IMSI001010000000001
Using IMEI 3805468432113171
Using subscriber IMSI IMSI001010000000002
Using IMEI 3805468432113172
************************* UE device config for ue_id  1
************************* UE device config for ue_id  2
************************* Configuring IP block
************************* Waiting for IP changes to propagate
************************* S1 setup
************************* UE App config
************************* Running End to End attach for  UE id  1
ue id 1 found
PDN_TYPE: 1
IPv4 PDN_ADDRESS:192 168 128 12

*************NbUiNbuHdlUeRadioCapMsg: Send UE cap msg SUCCESS*********
************************* Running UE detach for UE id  1
Deleting Ue Context from Traffic Handler
************************* Running End to End attach for  UE id  2
ue id 2 found

*************NbUiNbuHdlUeRadioCapMsg: Send UE cap msg SUCCESS*********
PDN_TYPE: 1
IPv4 PDN_ADDRESS:192 168 128 13
************************* Running UE detach for UE id  2
Deleting Ue Context from Traffic Handler
************************* send SCTP SHUTDOWN
Keys left in Redis (list should be empty)[

]
Entries in s1ap_imsi_map (should be zero): 0
Entries left in hashtables (should be zero): 0
.
----------------------------------------------------------------------
Ran 1 test in 6.556s

OK
sleep 1
```
## Additional Information

- [ ] This change is backwards-breaking
