### PR TITLE
feat(nms): Equipmentdashboard - Federation Gateways Cluster Status

### DIFF
--- a/nms/app/packages/magmalte/app/views/equipment/FEGClusterStatus.js
+++ b/nms/app/packages/magmalte/app/views/equipment/FEGClusterStatus.js
@@ -1,0 +1,175 @@
+/**
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @flow strict-local
+ * @format
+ */
+
+import type {DataRows} from '../../components/DataGrid';
+
+import CardTitleRow from '../../components/layout/CardTitleRow';
+import DataGrid from '../../components/DataGrid';
+import FEGGatewayContext from '../../components/context/FEGGatewayContext';
+import GroupWorkIcon from '@material-ui/icons/GroupWork';
+import MagmaV1API from '@fbcnms/magma-api/client/WebClient';
+import Paper from '@material-ui/core/Paper';
+import React from 'react';
+import Typography from '@material-ui/core/Typography';
+import moment from 'moment';
+import nullthrows from '@fbcnms/util/nullthrows';
+import useMagmaAPI from '@fbcnms/ui/magma/useMagmaAPI';
+
+import {GatewayTypeEnum, HEALTHY_STATUS} from '../../components/GatewayUtils';
+import {makeStyles} from '@material-ui/styles';
+import {useContext} from 'react';
+import {useRouter} from '@fbcnms/ui/hooks';
+
+const useStyles = makeStyles(_ => ({
+  paperRoot: {
+    display: 'flex',
+    padding: '10px 20px',
+  },
+  paperRow: {
+    padding: '0px 20px',
+    fontWeight: 'light',
+  },
+}));
+
+/**
+ * Displays the last fallover time, health of primary gateway & secondary gateway,
+ * and the name of the primary/active gateway.
+ */
+export default function FEGClusterStatus() {
+  const classes = useStyles();
+  const {match} = useRouter();
+  const ctx = useContext(FEGGatewayContext);
+  const networkId: string = nullthrows(match.params.networkId);
+  const timeRange = '7d';
+  const {response: lastFalloverResponse} = useMagmaAPI(
+    MagmaV1API.getNetworksByNetworkIdPrometheusQuery,
+    {
+      networkId: networkId,
+      query: `max_over_time(timestamp(changes(active_gateway_changed_total[30s]) > 0)[${timeRange}:10s])`,
+    },
+  );
+  const getGatewayHealthStatus = (fegGatewaysHealthStatus, gatewayId) => {
+    const gatewayHealthStatus = fegGatewaysHealthStatus[gatewayId]?.status;
+    if (gatewayId && gatewayHealthStatus) {
+      // gateway exists and health status was fetched without error
+      return gatewayHealthStatus == HEALTHY_STATUS
+        ? GatewayTypeEnum.HEALTHY_GATEWAY
+        : GatewayTypeEnum.UNHEALTHY_GATEWAY;
+    }
+    return 'N/A';
+  };
+  const getLastFalloverStatus = lastFalloverResponse => {
+    let lastFalloverStatus = '-';
+    let lastFalloverTime = 0;
+    const lastFalloverResult = lastFalloverResponse?.data?.result || [];
+
+    lastFalloverResult.map(res => {
+      const curUpdate = parseFloat(res?.value?.[1]) || 0;
+      // save the latest update
+      lastFalloverTime = Math.max(lastFalloverTime, curUpdate);
+    });
+    lastFalloverTime &&
+      (lastFalloverStatus = moment.unix(lastFalloverTime).calendar());
+    return lastFalloverStatus;
+  };
+  const getSecondaryFegGatewayId = (fegGateways, activeFegGatewayId) => {
+    const fegGatewaysId = Object.keys(fegGateways);
+    if (fegGatewaysId.length > 1) {
+      // has secondary gateway
+      return fegGatewaysId[0] == activeFegGatewayId
+        ? fegGatewaysId[1]
+        : fegGatewaysId[0];
+    }
+    return '';
+  };
+  const isGatewayHealthStatusInactive = (
+    fegGatewayId,
+    fegGatewayHealthStatus,
+  ) => {
+    // is inactive if gateway doesn't exits or have no health status
+    return !(fegGatewayId && fegGatewayHealthStatus?.status);
+  };
+  const fegGateways = ctx.state || {};
+  const fegGatewaysHealthStatus = ctx.health || {};
+  const activeFegGatewayId = ctx.activeFegGatewayId || '';
+  const secondaryFegGatewayId = getSecondaryFegGatewayId(
+    fegGateways,
+    activeFegGatewayId,
+  );
+  const activeFegGatewayHealthStatus = getGatewayHealthStatus(
+    fegGatewaysHealthStatus,
+    activeFegGatewayId,
+  );
+  const secondaryFegGatewayHealthStatus = getGatewayHealthStatus(
+    fegGatewaysHealthStatus,
+    secondaryFegGatewayId,
+  );
+  const lastFalloverStatus = getLastFalloverStatus(lastFalloverResponse);
+
+  const kpiData: DataRows[] = [
+    [
+      {
+        category: 'Last Fallover Time',
+        value: lastFalloverStatus,
+        tooltip: 'The last time the active gateway of the network was changed',
+      },
+      {
+        category: 'Primary Health',
+        value: activeFegGatewayHealthStatus,
+        statusCircle: true,
+        // make kpi inactive if gateway doesn't exist or had no health status
+        statusInactive: isGatewayHealthStatusInactive(
+          activeFegGatewayId,
+          fegGatewaysHealthStatus[activeFegGatewayId],
+        ),
+        status: activeFegGatewayHealthStatus === HEALTHY_STATUS,
+        tooltip: 'Health of primary federation gateway',
+      },
+      {
+        category: 'Secondary Health',
+        value: secondaryFegGatewayHealthStatus,
+        statusCircle: true,
+        // make kpi inactive if secondary gateway doesn't exist or had no health status
+        statusInactive: isGatewayHealthStatusInactive(
+          secondaryFegGatewayId,
+          fegGatewaysHealthStatus[secondaryFegGatewayId],
+        ),
+        status: secondaryFegGatewayHealthStatus === HEALTHY_STATUS,
+        tooltip: 'Health of secondary federation gateway',
+      },
+    ],
+  ];
+
+  return (
+    <>
+      <CardTitleRow icon={GroupWorkIcon} label="Cluster Status" />
+      <DataGrid data={kpiData} />
+      <Paper className={classes.paperRoot}>
+        <Typography color="textSecondary" className={classes.paperRow}>
+          Primary
+        </Typography>
+        <Typography
+          color="textSecondary"
+          className={classes.paperRow}
+          data-testid="Primary Gateway Name">
+          {fegGateways[activeFegGatewayId]
+            ? fegGateways[activeFegGatewayId].name
+            : 'N/A'}
+        </Typography>
+      </Paper>
+    </>
+  );
+}

--- a/nms/app/packages/magmalte/app/views/equipment/FEGEquipmentGateway.js
+++ b/nms/app/packages/magmalte/app/views/equipment/FEGEquipmentGateway.js
@@ -14,6 +14,7 @@
  * @format
  */
 
+import FEGClusterStatus from './FEGClusterStatus';
 import FEGEquipmentGatewayKPIs from './FEGEquipmentGatewayKPIs';
 import FEGGatewayTable from './FEGGatewayTable';
 import GatewayCheckinChart from './GatewayCheckinChart';
@@ -38,7 +39,7 @@ export default function FEGGateway() {
 
   return (
     <div className={classes.dashboardRoot}>
-      <Grid container justify="space-between" spacing={3}>
+      <Grid container justify="space-between" spacing={4}>
         <Grid item xs={12}>
           <GatewayCheckinChart />
         </Grid>
@@ -46,6 +47,9 @@ export default function FEGGateway() {
           <Paper elevation={0}>
             <FEGEquipmentGatewayKPIs />
           </Paper>
+        </Grid>
+        <Grid item xs={12}>
+          <FEGClusterStatus />
         </Grid>
         <Grid item xs={12}>
           <FEGGatewayTable />


### PR DESCRIPTION
<!--
    Tag your PR title with the components that it touches along with type of
    change. Checkout 'contribute_commit_msg' doc for recommended git commit
    message style.
    E.g. "fix(orc8r): Changeset" or "feat(agw) ..."
-->

## Summary
This is a draft PR because it is a stacked pr(only the last commit holds the changes relevant to this PR) upon an existing open PR #7804 . Once, that PR is approved, this PR would be changed from draft to a normal PR. A cluster status was added which show the health of both the primary and secondary gateways. It also displays the last fallover time, alongside with the name of the active/primary gateway just like in the design mockups. 
<!-- Enumerate changes you made and why you made them -->

## Test Plan
A test was added under FEGEquipmentGatewayTest.js file which tests the new feature. All previous tests run without any error.
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking
<img width="1780" alt="Screen Shot 2021-07-01 at 10 03 56 AM" src="https://user-images.githubusercontent.com/34602743/124154027-11c9fe00-da63-11eb-9879-ccbb60075a6e.png">

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
