### PR TITLE
feat(agw): ovs: Simplify GTP echo configuration.

### DIFF
--- a/third_party/gtp_ovs/ovs-gtp-patches/2.14/0001-of-match-expand-NXM_NX_TUN_FLAGS-to-include-all-tunn.patch
+++ b/third_party/gtp_ovs/ovs-gtp-patches/2.14/0001-of-match-expand-NXM_NX_TUN_FLAGS-to-include-all-tunn.patch
@@ -1,4 +1,4 @@
-From 87b8032282d178144bf6cfc78e2f2b96ef13c8c3 Mon Sep 17 00:00:00 2001
+From c9d807443db2087baae9a36ad3cc58960818de43 Mon Sep 17 00:00:00 2001
 From: Pravin B Shelar <pbshelar@fb.com>
 Date: Sun, 28 Jun 2020 21:49:40 +0000
 Subject: [PATCH 01/19] of-match: expand NXM_NX_TUN_FLAGS to include all tunnel

--- a/third_party/gtp_ovs/ovs-gtp-patches/2.14/0002-userspace-IPFIX-Add-tunnel-type-GTP.patch
+++ b/third_party/gtp_ovs/ovs-gtp-patches/2.14/0002-userspace-IPFIX-Add-tunnel-type-GTP.patch
@@ -1,4 +1,4 @@
-From a65af73631599aea3621a8e50c24adb0fcf29190 Mon Sep 17 00:00:00 2001
+From 5c1e8256e36ccd942f077671f7c5bfb5b17bda46 Mon Sep 17 00:00:00 2001
 From: Pravin B Shelar <pbshelar@fb.com>
 Date: Mon, 24 Feb 2020 04:29:56 +0000
 Subject: [PATCH 02/19] userspace: IPFIX: Add tunnel type GTP

--- a/third_party/gtp_ovs/ovs-gtp-patches/2.14/0003-datapath-add-vport-gtp-for-GPRS-Tunneling-Protocol.patch
+++ b/third_party/gtp_ovs/ovs-gtp-patches/2.14/0003-datapath-add-vport-gtp-for-GPRS-Tunneling-Protocol.patch
@@ -1,4 +1,4 @@
-From ee2a0eebb6085adc47f20ed94fd90ca08b8acef0 Mon Sep 17 00:00:00 2001
+From 1d32fe6cc56137fd6b032940e6033a997d9545f5 Mon Sep 17 00:00:00 2001
 From: Pravin B Shelar <pbshelar@fb.com>
 Date: Sat, 28 Nov 2020 00:55:30 -0800
 Subject: [PATCH 03/19] datapath: add vport-gtp for GPRS Tunneling Protocol

--- a/third_party/gtp_ovs/ovs-gtp-patches/2.14/0004-ovs-Add-support-to-set-GTP-header-fields.patch
+++ b/third_party/gtp_ovs/ovs-gtp-patches/2.14/0004-ovs-Add-support-to-set-GTP-header-fields.patch
@@ -1,4 +1,4 @@
-From 79b56fee795f7e0808bdc9b84beeb55def63da73 Mon Sep 17 00:00:00 2001
+From a8c20610f041c87448d2d1d721ccf4c507a17099 Mon Sep 17 00:00:00 2001
 From: Pravin B Shelar <pbshelar@fb.com>
 Date: Sat, 28 Nov 2020 00:58:18 -0800
 Subject: [PATCH 04/19] ovs: Add support to set GTP header fields.

--- a/third_party/gtp_ovs/ovs-gtp-patches/2.14/0005-OVS-gtp-echo-handling.patch
+++ b/third_party/gtp_ovs/ovs-gtp-patches/2.14/0005-OVS-gtp-echo-handling.patch
@@ -1,4 +1,4 @@
-From 523519e3a84add450a4121ba3973bf93c2917fa5 Mon Sep 17 00:00:00 2001
+From 5488098e2722da39fd48890598480050c0e1e9ec Mon Sep 17 00:00:00 2001
 From: Pravin B Shelar <pbshelar@fb.com>
 Date: Mon, 29 Jun 2020 02:45:36 +0000
 Subject: [PATCH 05/19] OVS: gtp echo handling
@@ -13,20 +13,19 @@ Signed-off-by: Pravin B Shelar <pbshelar@fb.com>
  lib/bfd.c                      |  81 ++++++++--
  lib/bfd.h                      |   4 +-
  lib/netdev-provider.h          |   8 +
- lib/netdev-vport-private.h     |   1 +
- lib/netdev-vport.c             | 267 +++++++++++++++++++++++++++++++-
+ lib/netdev-vport.c             | 179 ++++++++++++++++++++-
  lib/netdev.c                   |  38 +++++
- lib/netdev.h                   |  11 ++
+ lib/netdev.h                   |  16 ++
  ofproto/ofproto-dpif-monitor.c |  13 +-
- ofproto/ofproto-dpif-xlate.c   |  35 +++--
+ ofproto/ofproto-dpif-xlate.c   |  35 ++--
  ofproto/ofproto-dpif-xlate.h   |   2 +
  ofproto/ofproto-dpif.c         |  17 ++
  ofproto/ofproto-dpif.h         |   2 +
  tests/automake.mk              |   3 +
  tests/system-common-macros.at  |  19 +++
- tests/system-layer3-tunnels.at | 273 ++++++++++++++++++++++++++-------
- tests/test-gtp.c               | 111 ++++++++++++++
- 17 files changed, 818 insertions(+), 83 deletions(-)
+ tests/system-layer3-tunnels.at | 285 +++++++++++++++++++++++++++------
+ tests/test-gtp.c               | 111 +++++++++++++
+ 16 files changed, 746 insertions(+), 83 deletions(-)
  create mode 100644 tests/test-gtp.c
 
 diff --git a/include/openvswitch/packets.h b/include/openvswitch/packets.h
@@ -274,20 +273,8 @@ index 73dce2fca..d6adcedc8 100644
  };
  
  int netdev_register_provider(const struct netdev_class *);
-diff --git a/lib/netdev-vport-private.h b/lib/netdev-vport-private.h
-index d89a28c66..3c82d5837 100644
---- a/lib/netdev-vport-private.h
-+++ b/lib/netdev-vport-private.h
-@@ -40,6 +40,7 @@ struct netdev_vport {
- 
-     /* Patch Ports. */
-     char *peer;
-+    struct hmap keep_alives;
- };
- 
- int netdev_vport_construct(struct netdev *);
 diff --git a/lib/netdev-vport.c b/lib/netdev-vport.c
-index 0f3d587e0..1db1b7c0d 100644
+index 0f3d587e0..6f5c30e9a 100644
 --- a/lib/netdev-vport.c
 +++ b/lib/netdev-vport.c
 @@ -29,6 +29,7 @@
@@ -306,15 +293,7 @@ index 0f3d587e0..1db1b7c0d 100644
  #include "openvswitch/dynamic-string.h"
  #include "ovs-router.h"
  #include "packets.h"
-@@ -198,6 +200,7 @@ netdev_vport_construct(struct netdev *netdev_)
- 
-     ovs_mutex_init(&dev->mutex);
-     eth_addr_random(&dev->etheraddr);
-+    hmap_init(&dev->keep_alives);
- 
-     if (name && dpif_port && (strlen(name) > strlen(dpif_port) + 1) &&
-         (!strncmp(name, dpif_port, strlen(dpif_port)))) {
-@@ -573,7 +576,8 @@ set_tunnel_config(struct netdev *dev_, const struct smap *args, char **errp)
+@@ -573,7 +575,8 @@ set_tunnel_config(struct netdev *dev_, const struct smap *args, char **errp)
      int err;
  
      has_csum = strstr(type, "gre") || strstr(type, "geneve") ||
@@ -324,47 +303,20 @@ index 0f3d587e0..1db1b7c0d 100644
      has_seq = strstr(type, "gre");
      memset(&tnl_cfg, 0, sizeof tnl_cfg);
  
-@@ -1129,6 +1133,256 @@ netdev_vport_get_pt_mode(const struct netdev *netdev)
+@@ -1129,6 +1132,172 @@ netdev_vport_get_pt_mode(const struct netdev *netdev)
  
  
  #ifdef __linux__
 +
-+struct keep_alive_info {
-+    struct hmap_node hmap_node;
-+    ovs_be32 ip_src;
-+    __u8 flags;
-+    int seq;
-+    bool csum;
-+    long long int timestamp;
-+    bool need_to_send;
-+    long rx_cnt;
-+    long tx_cnt;
-+};
-+
-+int keep_alive_info_max = 1000;
-+
-+// TODO implement LRU cache to avoid manual purge
-+//
 +static void
 +gtp_get_remote_info(struct netdev_vport *dev, struct ds *ds)
 +{
-+    struct keep_alive_info *kai;
++    struct netdev_tunnel_config *cfg = &dev->tnl_cfg;
 +
-+    HMAP_FOR_EACH(kai, hmap_node, &dev->keep_alives) {
++    if (cfg->gtp_timestamp) {
 +        ds_put_format(ds, "\t%s: RX: %ld TX: %ld remote ip: "IP_FMT", seq %d, pending send %d\n",
-+                      xastrftime_msec("%H:%M:%S.###", kai->timestamp, true), kai->rx_cnt, kai->tx_cnt,
-+                      IP_ARGS(kai->ip_src), kai->seq, (int)kai->need_to_send );
-+    }
-+}
-+
-+static void
-+gtp_del_remote_end_points_info(struct netdev_vport *dev)
-+{
-+    struct keep_alive_info *kai, *next;
-+
-+    HMAP_FOR_EACH_SAFE(kai, next, hmap_node, &dev->keep_alives) {
-+        hmap_remove(&dev->keep_alives, &kai->hmap_node);
-+        free(kai);
++                      xastrftime_msec("%H:%M:%S.###", cfg->gtp_timestamp, true), cfg->gtp_rx_cnt, cfg->gtp_tx_cnt,
++                      IP_ARGS(in6_addr_get_mapped_ipv4(&cfg->ipv6_dst)), cfg->gtp_seq, (int)cfg->gtp_need_to_send);
 +    }
 +}
 +
@@ -390,31 +342,14 @@ index 0f3d587e0..1db1b7c0d 100644
 +    VLOG_DBG("gtp flags %x msg_type %d dev->tnl_cfg.dst_port %d == (%d, %d) flow "IP_FMT" cfg "IP_FMT,
 +            flow->tunnel.gtpu_flags, flow->tunnel.gtpu_msgtype, dev->tnl_cfg.dst_port,
 +            flow->tunnel.tp_src, flow->tunnel.tp_dst,
-+            IP_ARGS(flow->tunnel.ip_dst), IP_ARGS(in6_addr_get_mapped_ipv4(&dev->tnl_cfg.ipv6_src)));
++            IP_ARGS(flow->tunnel.ip_src), IP_ARGS(in6_addr_get_mapped_ipv4(&dev->tnl_cfg.ipv6_dst)));
 +
 +    *res = (flow->tunnel.gtpu_msgtype == 1) &&                  // echo request msg type
 +           (flow->tunnel.gtpu_flags == 0x32) &&              // needs seq in packet.
-+           (flow->tunnel.ip_dst == in6_addr_get_mapped_ipv4(&dev->tnl_cfg.ipv6_src)) &&
++           (flow->tunnel.ip_src == in6_addr_get_mapped_ipv4(&dev->tnl_cfg.ipv6_dst)) &&
 +           (flow->tunnel.tp_src == dev->tnl_cfg.dst_port) &&
 +           (flow->tunnel.tp_dst == dev->tnl_cfg.dst_port);
 +    return 0;
-+}
-+
-+static struct keep_alive_info *
-+gtp_get_keep_alive_info(struct netdev *netdev, ovs_be32 ip_src)
-+{
-+    struct netdev_vport *dev = netdev_vport_cast(netdev);
-+    struct keep_alive_info *kai;
-+
-+    HMAP_FOR_EACH_WITH_HASH(kai, hmap_node, hash_2words(ip_src, 0), &dev->keep_alives) {
-+        if (kai->ip_src == ip_src) {
-+            return kai;
-+        }
-+    }
-+    kai = xzalloc(sizeof *kai);
-+    kai->ip_src = ip_src;
-+    hmap_insert(&dev->keep_alives, &kai->hmap_node, hash_2words(ip_src, 0));
-+    return kai;
 +}
 +
 +static int
@@ -422,7 +357,7 @@ index 0f3d587e0..1db1b7c0d 100644
 +                           const struct dp_packet *p)
 +{
 +    struct netdev_vport *dev = netdev_vport_cast(netdev);
-+    struct keep_alive_info *kai;
++    struct netdev_tunnel_config *cfg = &dev->tnl_cfg;
 +    bool is_keep_alive;
 +
 +    ovs_mutex_lock(&dev->mutex);
@@ -432,22 +367,18 @@ index 0f3d587e0..1db1b7c0d 100644
 +    if (is_keep_alive) {
 +        struct gtp1_cntr_echo_req_header *hdr;
 +
-+        kai = gtp_get_keep_alive_info(netdev, flow->tunnel.ip_src);
-+
 +        if (dp_packet_size(p) >= sizeof(struct gtp1_cntr_echo_req_header) &&
 +            dp_packet_data(p) != NULL &&
 +            flow->tunnel.gtpu_flags & GTP_FLAGS_SEQ) {
 +            hdr = dp_packet_data(p);
-+            kai->seq = ntohs(hdr->seq);
-+            VLOG_DBG("got seq %d", kai->seq);
++            cfg->gtp_seq = ntohs(hdr->seq);
++            VLOG_DBG("got seq %d", cfg->gtp_seq);
 +        } else {
-+            kai->seq++;
++            cfg->gtp_seq++;
 +        }
-+        kai->timestamp = time_wall_msec();
-+        kai->need_to_send = true;
-+        kai->flags = flow->tunnel.gtpu_flags;
-+        kai->csum = !!(flow->tunnel.flags & FLOW_TNL_F_CSUM);
-+        kai->rx_cnt++;
++        cfg->gtp_timestamp = time_wall_msec();
++        cfg->gtp_need_to_send = true;
++        cfg->gtp_rx_cnt++;
 +    }
 +    ovs_mutex_unlock(&dev->mutex);
 +
@@ -459,59 +390,50 @@ index 0f3d587e0..1db1b7c0d 100644
 +                         struct ofpbuf *ofpacts, bool *more_pkts)
 +{
 +    struct netdev_vport *dev = netdev_vport_cast(netdev);
-+    struct keep_alive_info *kai, *found = NULL;
++    struct netdev_tunnel_config *cfg;
 +    struct gtp1_cntr_echo_rsp_header *hdr;
-+    bool plus_one = false;
-+    ovs_be32 ip_src_flow;
++    ovs_be32 ip_src_flow, ip_dst_flow;
 +    __u8 ttl;
 +    __u8 tos;
 +    __u8 gtpu_msgtype;
 +    __u8 gtpu_flags;
 +
 +    ovs_mutex_lock(&dev->mutex);
-+    ip_src_flow = dev->tnl_cfg.ip_src_flow;
-+
-+    HMAP_FOR_EACH(kai, hmap_node, &dev->keep_alives) {
-+        if (kai->need_to_send) {
-+                if (found == NULL) {
-+                    kai->need_to_send = false;
-+                    found = kai;
-+                } if (plus_one == false) {
-+                    plus_one = true;
-+                    break;
-+                } else {
-+                    break;
-+                }
-+        }
-+    }
-+
-+    if (!found) {
++    cfg = &dev->tnl_cfg;
++    if (!cfg->gtp_need_to_send) {
 +        ovs_mutex_unlock(&dev->mutex);
 +        return ENOENT;
 +    }
-+    *more_pkts = plus_one;
++    *more_pkts = false;
++
++    ip_src_flow = in6_addr_get_mapped_ipv4(&cfg->ipv6_src);
++    ip_dst_flow = in6_addr_get_mapped_ipv4(&cfg->ipv6_dst);
++
 +
 +    ttl = MAXTTL;
 +    tos = IPTOS_PREC_INTERNETCONTROL;
 +    gtpu_msgtype = 2;
-+    gtpu_flags = found->flags;
++    gtpu_flags = 0x32;
 +
 +    ofpact_put_set_field(ofpacts, mf_from_id(MFF_TUN_SRC), &ip_src_flow, &ip_src_flow);
-+    ofpact_put_set_field(ofpacts, mf_from_id(MFF_TUN_DST), &found->ip_src, &found->ip_src);
++    ofpact_put_set_field(ofpacts, mf_from_id(MFF_TUN_DST), &ip_dst_flow, &ip_dst_flow);
 +    ofpact_put_set_field(ofpacts, mf_from_id(MFF_TUN_TOS), &tos, &tos);
 +    ofpact_put_set_field(ofpacts, mf_from_id(MFF_TUN_TTL), &ttl, &ttl);
 +    ofpact_put_set_field(ofpacts, mf_from_id(MFF_TUN_GTPU_FLAGS), &gtpu_flags, &gtpu_flags);
 +    ofpact_put_set_field(ofpacts, mf_from_id(MFF_TUN_GTPU_MSGTYPE), &gtpu_msgtype, &gtpu_msgtype);
 +
-+    if (found->csum || 1) {
-+        __be16 csum = htons(FLOW_TNL_F_CSUM);
-+        ofpact_put_set_field(ofpacts, mf_from_id(MFF_TUN_FLAGS), &csum, &csum);
-+    }
++    __be16 csum = htons(FLOW_TNL_F_CSUM);
++    ofpact_put_set_field(ofpacts, mf_from_id(MFF_TUN_FLAGS), &csum, &csum);
++   
 +    hdr = dp_packet_put_zeros(p, sizeof *hdr);
-+    hdr->seq = htons(found->seq);
++    hdr->seq = htons(cfg->gtp_seq);
 +    hdr->recovery.type = 14;  //htons(0x0E00); // this is added for backward compatibility only.
 +    hdr->recovery.value = 0;
-+    found->tx_cnt++;
++    cfg->gtp_tx_cnt++;
++    cfg->gtp_need_to_send = false;
++    VLOG_DBG("gtp-echo xmit flags %x msg_type %d dev->tnl_cfg.dst_port %d src "IP_FMT" dst "IP_FMT,
++            gtpu_flags, gtpu_msgtype, dev->tnl_cfg.dst_port, IP_ARGS(ip_src_flow), IP_ARGS(ip_dst_flow));
++
 +    ovs_mutex_unlock(&dev->mutex);
 +    return 0;
 +}
@@ -550,38 +472,11 @@ index 0f3d587e0..1db1b7c0d 100644
 +    ds_destroy(&ds);
 +}
 +
-+static void
-+netdev_gtp_echo_remote_end_points_purge(struct unixctl_conn *conn, int argc OVS_UNUSED,
-+                             const char *argv[] OVS_UNUSED, void *aux OVS_UNUSED)
-+{
-+    struct ds ds = DS_EMPTY_INITIALIZER;
-+    struct netdev **vports;
-+    size_t i, n_vports;
-+
-+    int rec = 0;
-+
-+    vports = netdev_get_vports(&n_vports);
-+    for (i = 0; i < n_vports; i++) {
-+        struct netdev *netdev_ = vports[i];
-+        struct netdev_vport *netdev = netdev_vport_cast(netdev_);
-+
-+        ovs_mutex_lock(&netdev->mutex);
-+        gtp_del_remote_end_points_info(netdev);
-+        ovs_mutex_unlock(&netdev->mutex);
-+
-+        netdev_close(netdev_);
-+        rec++;
-+    }
-+    free(vports);
-+    unixctl_command_reply(conn, "Done");
-+    ds_destroy(&ds);
-+}
-+
 +
  static int
  netdev_vport_get_ifindex(const struct netdev *netdev_)
  {
-@@ -1254,6 +1508,11 @@ netdev_vport_tunnel_register(void)
+@@ -1254,6 +1423,11 @@ netdev_vport_tunnel_register(void)
                .build_header = netdev_gtpu_build_header,
                .push_header = netdev_gtpu_push_header,
                .pop_header = netdev_gtpu_pop_header,
@@ -593,15 +488,12 @@ index 0f3d587e0..1db1b7c0d 100644
            },
            {{NULL, NULL, 0, 0}}
          },
-@@ -1272,6 +1531,12 @@ netdev_vport_tunnel_register(void)
+@@ -1272,6 +1446,9 @@ netdev_vport_tunnel_register(void)
          unixctl_command_register("tnl/egress_port_range", "min max", 0, 2,
                                   netdev_tnl_egress_port_range, NULL);
  
 +        unixctl_command_register("tnl/gtp_echo_remote_end_points", "", 0, 0,
 +                                 netdev_gtp_echo_remote_end_points, NULL);
-+
-+        unixctl_command_register("tnl/gtp_echo_remote_end_points_purge", "", 0, 0,
-+                                 netdev_gtp_echo_remote_end_points_purge, NULL);
 +
          ovsthread_once_done(&once);
      }
@@ -653,10 +545,22 @@ index 91e91955c..1bc5abfc8 100644
 +    return EOPNOTSUPP;
 +}
 diff --git a/lib/netdev.h b/lib/netdev.h
-index 4877df5ff..de532a9dc 100644
+index 4877df5ff..633ac88f1 100644
 --- a/lib/netdev.h
 +++ b/lib/netdev.h
-@@ -329,6 +329,17 @@ bool netdev_queue_dump_next(struct netdev_queue_dump *,
+@@ -142,6 +142,11 @@ struct netdev_tunnel_config {
+     bool erspan_hwid_flow;
+ 
+     bool gtp_random_src_port;
++    int gtp_seq;
++    long long int gtp_timestamp;
++    bool gtp_need_to_send;
++    long gtp_rx_cnt;
++    long gtp_tx_cnt;
+ };
+ 
+ void netdev_run(void);
+@@ -329,6 +334,17 @@ bool netdev_queue_dump_next(struct netdev_queue_dump *,
                              unsigned int *queue_id, struct smap *details);
  int netdev_queue_dump_done(struct netdev_queue_dump *);
  
@@ -870,7 +774,7 @@ index 490c59e04..bc94680f0 100644
  #                [tunnel-args])
  #
 diff --git a/tests/system-layer3-tunnels.at b/tests/system-layer3-tunnels.at
-index 141a7afb4..4bbb2198e 100644
+index 141a7afb4..b50984e37 100644
 --- a/tests/system-layer3-tunnels.at
 +++ b/tests/system-layer3-tunnels.at
 @@ -49,58 +49,6 @@ NS_CHECK_EXEC([at_ns0], [ping -s 3200 -q -c 3 -i 0.3 -w 2 10.1.1.2 | FORMAT_PING
@@ -932,7 +836,7 @@ index 141a7afb4..4bbb2198e 100644
  AT_SETUP([layer3 - ping over GRE])
  OVS_TRAFFIC_VSWITCHD_START([set Bridge br0 other-config:hwaddr="00:12:34:56:78:bb"])
  OVS_CHECK_GRE_L3()
-@@ -205,3 +153,224 @@ AT_CHECK([tail -1 stdout], [0],
+@@ -205,3 +153,236 @@ AT_CHECK([tail -1 stdout], [0],
  
  OVS_VSWITCHD_STOP
  AT_CLEANUP
@@ -1108,7 +1012,9 @@ index 141a7afb4..4bbb2198e 100644
 +dnl Set up tunnel endpoints on OVS outside the namespace and with a native
 +dnl linux device inside the namespace.
 +
-+ADD_OVS_TUNNEL_NO_REMOTE([gtpu], [br0], [at_gtp0], [10.1.1.2/24], [options:local_ip=172.31.1.100])
++ADD_OVS_TUNNEL([gtpu], [br0], [at_gtp0], [172.31.1.1], [10.1.1.2/24])
++ADD_OVS_TUNNEL([gtpu], [br0], [at_gtp1], [172.31.1.2], [10.1.2.2/24])
++
 +AT_CHECK([ip neigh add 10.1.1.1 lladdr 00:12:34:56:78:aa dev br0])
 +
 +NS_CHECK_EXEC([at_ns0], [ip link set dev p0 mtu 1480 up])
@@ -1116,6 +1022,7 @@ index 141a7afb4..4bbb2198e 100644
 +
 +AT_CHECK([ovs-vsctl set interface at_gtp0 bfd:min_tx=500 bfd:min_rx=500])
 +AT_CHECK([ovs-vsctl set interface at_gtp0 bfd:enable=true])
++AT_CHECK([ovs-vsctl set interface at_gtp1 bfd:enable=false])
 +
 +AT_CHECK([ovs-ofctl add-flow br-underlay "actions=normal"])
 +
@@ -1124,6 +1031,7 @@ index 141a7afb4..4bbb2198e 100644
 +
 +AT_CHECK([ovs-appctl tnl/gtp_echo_remote_end_points], [0], [dnl
 +Tunnel port: at_gtp0
++Tunnel port: at_gtp1
 +])  
 +
 +NS_CHECK_EXEC([at_ns0], [test-gtp 172.31.1.100 3201000a0000000000010000ff0003000a01], [0], [ignore])
@@ -1131,6 +1039,7 @@ index 141a7afb4..4bbb2198e 100644
 +AT_CHECK([ovs-appctl tnl/gtp_echo_remote_end_points | sed -e  's/^.*: RX/RX/'], [0], [dnl
 +Tunnel port: at_gtp0
 +RX: 1 TX: 1 remote ip: 172.31.1.1, seq 1, pending send 0
++Tunnel port: at_gtp1
 +])  
 +
 +NS_CHECK_EXEC([at_ns1], [test-gtp 172.31.1.100 3201000a0000000000030000ff0003000a01], [0], [ignore])
@@ -1138,22 +1047,29 @@ index 141a7afb4..4bbb2198e 100644
 +AT_CHECK([ovs-appctl tnl/gtp_echo_remote_end_points | sed -e  's/^.*: RX/RX/'], [0], [dnl
 +Tunnel port: at_gtp0
 +RX: 1 TX: 1 remote ip: 172.31.1.1, seq 1, pending send 0
++Tunnel port: at_gtp1
++])  
++
++AT_CHECK([ovs-vsctl set interface at_gtp1 bfd:min_tx=500 bfd:min_rx=500])
++AT_CHECK([ovs-vsctl set interface at_gtp1 bfd:enable=true])
++
++NS_CHECK_EXEC([at_ns1], [test-gtp 172.31.1.100 3201000a0000000000030000ff0003000a01], [0], [ignore])
++sleep 2
++AT_CHECK([ovs-appctl tnl/gtp_echo_remote_end_points | sed -e  's/^.*: RX/RX/'], [0], [dnl
++Tunnel port: at_gtp0
++Tunnel port: at_gtp1
 +RX: 1 TX: 1 remote ip: 172.31.1.2, seq 3, pending send 0
 +])  
 +
-+AT_CHECK([ovs-appctl tnl/gtp_echo_remote_end_points_purge], [0], [dnl
-+Done
-+])
-+AT_CHECK([ovs-appctl tnl/gtp_echo_remote_end_points | sed -e  's/^.*: RX/RX/'], [0], [dnl
-+Tunnel port: at_gtp0
-+])  
 +
 +NS_CHECK_EXEC([at_ns0], [test-gtp 172.31.1.100 3201000a0000000000040000ff0003000a01], [0], [ignore])
 +sleep 2
 +AT_CHECK([ovs-appctl tnl/gtp_echo_remote_end_points | sed -e  's/^.*: RX/RX/'], [0], [dnl
 +Tunnel port: at_gtp0
 +RX: 1 TX: 1 remote ip: 172.31.1.1, seq 4, pending send 0
-+])
++Tunnel port: at_gtp1
++RX: 1 TX: 1 remote ip: 172.31.1.2, seq 3, pending send 0
++])  
 +
 +OVS_TRAFFIC_VSWITCHD_STOP
 +AT_CLEANUP

--- a/third_party/gtp_ovs/ovs-gtp-patches/2.14/0006-ovs-test-add-gtp-marker-test.patch
+++ b/third_party/gtp_ovs/ovs-gtp-patches/2.14/0006-ovs-test-add-gtp-marker-test.patch
@@ -1,4 +1,4 @@
-From b151adf9017dfc2c35f9f072bcaae8431686232a Mon Sep 17 00:00:00 2001
+From bdc8da7790e4736d32dda649df85793f399a3f12 Mon Sep 17 00:00:00 2001
 From: Pravin B Shelar <pbshelar@fb.com>
 Date: Mon, 29 Jun 2020 06:54:04 +0000
 Subject: [PATCH 06/19] ovs: test: add gtp marker test
@@ -9,10 +9,10 @@ Signed-off-by: Pravin B Shelar <pbshelar@fb.com>
  1 file changed, 60 insertions(+)
 
 diff --git a/tests/system-layer3-tunnels.at b/tests/system-layer3-tunnels.at
-index 4bbb2198e..5587d6cde 100644
+index b50984e37..2abb817f7 100644
 --- a/tests/system-layer3-tunnels.at
 +++ b/tests/system-layer3-tunnels.at
-@@ -374,3 +374,63 @@ RX: 1 TX: 1 remote ip: 172.31.1.1, seq 4, pending send 0
+@@ -386,3 +386,63 @@ RX: 1 TX: 1 remote ip: 172.31.1.2, seq 3, pending send 0
  
  OVS_TRAFFIC_VSWITCHD_STOP
  AT_CLEANUP

--- a/third_party/gtp_ovs/ovs-gtp-patches/2.14/0007-datapath-Fixes-for-4.9-kernel.patch
+++ b/third_party/gtp_ovs/ovs-gtp-patches/2.14/0007-datapath-Fixes-for-4.9-kernel.patch
@@ -1,4 +1,4 @@
-From 7be0ef9941a9051c445ccdbcda11d3e069f72c12 Mon Sep 17 00:00:00 2001
+From 4cbbdb641c49affd80aa38d6bfbe6a5e54e395aa Mon Sep 17 00:00:00 2001
 From: Pravin B Shelar <pbshelar@fb.com>
 Date: Tue, 7 Jul 2020 01:46:36 +0000
 Subject: [PATCH 07/19] datapath: Fixes for 4.9 kernel
@@ -25,7 +25,7 @@ index a0dcc2667..66bd252ea 100644
  
  #define skb_is_encapsulated ovs_skb_is_encapsulated
 diff --git a/tests/system-layer3-tunnels.at b/tests/system-layer3-tunnels.at
-index 5587d6cde..57f39e3ad 100644
+index 2abb817f7..b8925d237 100644
 --- a/tests/system-layer3-tunnels.at
 +++ b/tests/system-layer3-tunnels.at
 @@ -157,6 +157,7 @@ AT_CLEANUP
@@ -45,7 +45,7 @@ index 5587d6cde..57f39e3ad 100644
  NS_CHECK_EXEC([at_ns0], [gtp-tunnel add at_gtp1 v1 0 0 10.1.1.1 172.31.1.100], [0], [ignore], [ignore])
  NS_CHECK_EXEC([at_ns0], [ip addr add dev at_gtp1 10.1.1.1/24])
  NS_CHECK_EXEC([at_ns0], [ip link set dev at_gtp1 mtu 1450 up])
-@@ -378,7 +381,7 @@ AT_CLEANUP
+@@ -390,7 +393,7 @@ AT_CLEANUP
  AT_SETUP([layer3 - GTP end marker test])
  OVS_TRAFFIC_VSWITCHD_START([set Bridge br0 other-config:hwaddr="00:12:34:56:78:bb"])
  OVS_CHECK_GTP_L3()
@@ -54,7 +54,7 @@ index 5587d6cde..57f39e3ad 100644
  ADD_BR([br-underlay])
  
  ADD_NAMESPACES(at_ns0)
-@@ -395,6 +398,8 @@ dnl linux device inside the namespace.
+@@ -407,6 +410,8 @@ dnl linux device inside the namespace.
  ADD_OVS_TUNNEL([gtpu], [br0], [at_gtp0], [172.31.1.1], [10.1.1.2/24], [options:key=flow])
  AT_CHECK([ip neigh add 10.1.1.1 lladdr 00:12:34:56:78:aa dev br0])
  NS_CHECK_EXEC([at_ns0], [gtp-link add at_gtp1 --sgsn &], [0], [ignore])

--- a/third_party/gtp_ovs/ovs-gtp-patches/2.14/0008-ovs-datapath-enable-kernel-5.6.patch
+++ b/third_party/gtp_ovs/ovs-gtp-patches/2.14/0008-ovs-datapath-enable-kernel-5.6.patch
@@ -1,4 +1,4 @@
-From b0cf4049573df3cba343f36b86e82e6f859196ca Mon Sep 17 00:00:00 2001
+From 29a2e5e00e3de94d3f1786c565781a69ff1e1ada Mon Sep 17 00:00:00 2001
 From: Pravin B Shelar <pbshelar@fb.com>
 Date: Fri, 21 Aug 2020 05:35:16 +0000
 Subject: [PATCH 08/19] ovs: datapath enable kernel 5.6

--- a/third_party/gtp_ovs/ovs-gtp-patches/2.14/0009-AGW-OVS-handle-gtp-tunnel-type.patch
+++ b/third_party/gtp_ovs/ovs-gtp-patches/2.14/0009-AGW-OVS-handle-gtp-tunnel-type.patch
@@ -1,4 +1,4 @@
-From 0ca214dc8e6360ba54189564ca3680269249ad89 Mon Sep 17 00:00:00 2001
+From 095bc30959ecf4236cf75f339047b3c44ae682a9 Mon Sep 17 00:00:00 2001
 From: Pravin B Shelar <pbshelar@fb.com>
 Date: Wed, 23 Sep 2020 04:01:59 +0000
 Subject: [PATCH 09/19] AGW: OVS: handle gtp tunnel type

--- a/third_party/gtp_ovs/ovs-gtp-patches/2.14/0010-native-tnl-routing-tunnel-lookup-with-pkt-mark.patch
+++ b/third_party/gtp_ovs/ovs-gtp-patches/2.14/0010-native-tnl-routing-tunnel-lookup-with-pkt-mark.patch
@@ -1,4 +1,4 @@
-From eb4587e70f33ab8dbb7e4e40661e8f527ad5b52c Mon Sep 17 00:00:00 2001
+From 68b8f1d6c57fbe74bb6e7f8e2964b0da1c0a17b3 Mon Sep 17 00:00:00 2001
 From: Pravin B Shelar <pbshelar@fb.com>
 Date: Sun, 27 Sep 2020 19:46:24 +0000
 Subject: [PATCH 10/19] native-tnl: routing: tunnel lookup with pkt-mark

--- a/third_party/gtp_ovs/ovs-gtp-patches/2.14/0011-fixes-for-2.14.patch
+++ b/third_party/gtp_ovs/ovs-gtp-patches/2.14/0011-fixes-for-2.14.patch
@@ -1,4 +1,4 @@
-From 88711c9e6cde32e62c2e20052c22eebf687f98b7 Mon Sep 17 00:00:00 2001
+From b29518282262eaae3a0dd882c2ea4506e663da71 Mon Sep 17 00:00:00 2001
 From: Pravin B Shelar <pbshelar@fb.com>
 Date: Sat, 28 Nov 2020 23:09:50 -0800
 Subject: [PATCH 11/19] fixes for 2.14

--- a/third_party/gtp_ovs/ovs-gtp-patches/2.14/0012-Add-custom-IPDR-fields-for-IPFIX-export.patch
+++ b/third_party/gtp_ovs/ovs-gtp-patches/2.14/0012-Add-custom-IPDR-fields-for-IPFIX-export.patch
@@ -1,4 +1,4 @@
-From 8df219052ba373beb03a819b3ec8575879b665e0 Mon Sep 17 00:00:00 2001
+From 2b473f52a3c792d45a56a3c4be0f393492de9b48 Mon Sep 17 00:00:00 2001
 From: Nick Yurchenko <koolzz@fb.com>
 Date: Mon, 1 Feb 2021 21:25:00 -0500
 Subject: [PATCH 12/19] Add custom IPDR fields for IPFIX export

--- a/third_party/gtp_ovs/ovs-gtp-patches/2.14/0013-ovs-Handle-spaces-in-ovs-arguments.patch
+++ b/third_party/gtp_ovs/ovs-gtp-patches/2.14/0013-ovs-Handle-spaces-in-ovs-arguments.patch
@@ -1,4 +1,4 @@
-From 6a3cb779340b524dab45478ee2e5ed114e7c04e3 Mon Sep 17 00:00:00 2001
+From 04c745d107fcf9f8df0b1a4037c2ee700bbfbd4a Mon Sep 17 00:00:00 2001
 From: Pravin B Shelar <pbshelar@fb.com>
 Date: Fri, 13 Mar 2020 19:18:40 +0000
 Subject: [PATCH 13/19] ovs: Handle spaces in ovs arguments

--- a/third_party/gtp_ovs/ovs-gtp-patches/2.14/0014-Add-pdp_start_epoch-custom-field-to-IPFIX-export.patch
+++ b/third_party/gtp_ovs/ovs-gtp-patches/2.14/0014-Add-pdp_start_epoch-custom-field-to-IPFIX-export.patch
@@ -1,4 +1,4 @@
-From c5b551e20854ef6673bcd429f17531c648dbaf6b Mon Sep 17 00:00:00 2001
+From e337bd8b1e2fdef4203b57faf725e6a0408ce7c4 Mon Sep 17 00:00:00 2001
 From: Nick Yurchenko <koolzz@fb.com>
 Date: Mon, 1 Feb 2021 21:46:32 -0500
 Subject: [PATCH 14/19] Add pdp_start_epoch custom field to IPFIX export

--- a/third_party/gtp_ovs/ovs-gtp-patches/2.14/0015-GTP-Extension-header-support-in-ovs2.14.patch
+++ b/third_party/gtp_ovs/ovs-gtp-patches/2.14/0015-GTP-Extension-header-support-in-ovs2.14.patch
@@ -1,4 +1,4 @@
-From 900e2c33b6b0d8a739f9b5dec36af24a5681393b Mon Sep 17 00:00:00 2001
+From 07efec18b3ed0410c8b9a27f06e6f2b790e7253a Mon Sep 17 00:00:00 2001
 From: YOGESH PANDEY <yogesh@wavelabs.ai>
 Date: Thu, 25 Mar 2021 16:48:07 +0530
 Subject: [PATCH 15/19] GTP Extension header support in ovs2.14

--- a/third_party/gtp_ovs/ovs-gtp-patches/2.14/0016-ODP-action-Fix-L3-port-to-L3-port-traffic.patch
+++ b/third_party/gtp_ovs/ovs-gtp-patches/2.14/0016-ODP-action-Fix-L3-port-to-L3-port-traffic.patch
@@ -1,4 +1,4 @@
-From 8ce2f4b78741f17769251ded235a21b9f20dd91b Mon Sep 17 00:00:00 2001
+From 6a35cc32b5b0f733126620dcc0044b1cb56e26a9 Mon Sep 17 00:00:00 2001
 From: Pravin B Shelar <pbshelar@fb.com>
 Date: Sun, 18 Apr 2021 17:17:56 +0000
 Subject: [PATCH 16/19] ODP-action: Fix L3 port to L3 port traffic.

--- a/third_party/gtp_ovs/ovs-gtp-patches/2.14/0017-datapath-GTP-cleanup.patch
+++ b/third_party/gtp_ovs/ovs-gtp-patches/2.14/0017-datapath-GTP-cleanup.patch
@@ -1,4 +1,4 @@
-From 3563e8046fe2d5987dcdc0f21403daa6969d5885 Mon Sep 17 00:00:00 2001
+From 75aa316f7494ea388a5e8f459a139c1b04afd85b Mon Sep 17 00:00:00 2001
 From: Pravin B Shelar <pbshelar@fb.com>
 Date: Sun, 9 May 2021 06:11:10 +0000
 Subject: [PATCH 17/19] datapath: GTP: cleanup

--- a/third_party/gtp_ovs/ovs-gtp-patches/2.14/0018-GTP-handle-seq-number-in-HDR.patch
+++ b/third_party/gtp_ovs/ovs-gtp-patches/2.14/0018-GTP-handle-seq-number-in-HDR.patch
@@ -1,4 +1,4 @@
-From 2c11949caf89fb599678219678c13ded30d6704d Mon Sep 17 00:00:00 2001
+From c8dcb82eb388c0cb68c4a11344ed0906ec8756be Mon Sep 17 00:00:00 2001
 From: Pravin B Shelar <pbshelar@fb.com>
 Date: Fri, 28 May 2021 16:06:54 +0000
 Subject: [PATCH 18/19] GTP: handle seq number in HDR

--- a/third_party/gtp_ovs/ovs-gtp-patches/2.14/0019-datapath-gtp-add-segmentation-offloads.patch
+++ b/third_party/gtp_ovs/ovs-gtp-patches/2.14/0019-datapath-gtp-add-segmentation-offloads.patch
@@ -1,4 +1,4 @@
-From 7127120cdda00421998252ee07b9751219e03a41 Mon Sep 17 00:00:00 2001
+From b20a404d7c4d065c70b49c9f6660f3313622c658 Mon Sep 17 00:00:00 2001
 From: Pravin B Shelar <pbshelar@fb.com>
 Date: Tue, 8 Jun 2021 01:44:33 +0000
 Subject: [PATCH 19/19] datapath: gtp: add segmentation offloads
@@ -65,17 +65,17 @@ index 75c5c547c..5046bd63a 100644
  
  	/* Assume largest header, ie. GTPv0. */
 diff --git a/debian/changelog b/debian/changelog
-index 661dfb991..18edd863a 100644
+index 661dfb991..d817479b0 100644
 --- a/debian/changelog
 +++ b/debian/changelog
 @@ -1,4 +1,4 @@
 -openvswitch (2.14.3-3) unstable; urgency=low
-+openvswitch (2.14.3-7) unstable; urgency=low
++openvswitch (2.14.3-8) unstable; urgency=low
     [ Open vSwitch team ]
     * New upstream version
  
 diff --git a/tests/system-layer3-tunnels.at b/tests/system-layer3-tunnels.at
-index 57f39e3ad..e772f55d2 100644
+index b8925d237..c95f0aac7 100644
 --- a/tests/system-layer3-tunnels.at
 +++ b/tests/system-layer3-tunnels.at
 @@ -304,7 +304,7 @@ RX: 2 TX: 2 remote ip: 172.31.1.1, seq 3, pending send 0
@@ -87,7 +87,7 @@ index 57f39e3ad..e772f55d2 100644
  OVS_WAIT_UNTIL([cat p1.pcap | egrep "0x0030:  0000 0003 0e00"                                2>&1 1>/dev/null])
  
  OVS_TRAFFIC_VSWITCHD_STOP
-@@ -434,7 +434,7 @@ sleep 2
+@@ -446,7 +446,7 @@ sleep 2
  
  OVS_WAIT_UNTIL([cat p1.pcap | egrep "0x0000:.*0800 4500"                                2>&1 1>/dev/null])
  OVS_WAIT_UNTIL([cat p1.pcap | egrep "0x0010:.*ac1f 0164 ac1f"                           2>&1 1>/dev/null])


### PR DESCRIPTION
When GTP echo was initially implemented AGW used dynamic GTP
tunnels, based on tunnel flows. Now AGW create static tunnels.
This allows OVS echo handler make use of GTP tunnel static config.
This also simplifies configuration as well as the  dynamic state management 
of GTP echo for each port. It no longer needs local-ip for enabling GTP echo.

Signed-off-by: Pravin B Shelar <pbshelar@fb.com>

<!--
    Tag your PR title with the components that it touches along with type of
    change. Checkout 'contribute_commit_msg' doc for recommended git commit
    message style.
    E.g. "fix(orc8r): Changeset" or "feat(agw) ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->

## Test Plan
OVS unit tests
lab validation.
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
