### PR TITLE
[Orc8r] Fix the certifier service to register the prometheus gauge

### DIFF
--- a/orc8r/cloud/configs/certifier.yml
+++ b/orc8r/cloud/configs/certifier.yml
@@ -31,5 +31,3 @@ analytics:
     cert_expires_in_hours:
       register: true
       export: false
-      labels:
-        class: reliability


### PR DESCRIPTION
Signed-off-by: Karthik Subraveti <ksubraveti@fb.com>

## Summary

Certifier service wasn't registering a prometheus gauge, hence the metric was not getting registered.

## Test Plan
- Verified the fix on staging
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
