### PR TITLE
Variable Poll Stats Interval

### DIFF
--- a/cwf/gateway/configs/sessiond.yml
+++ b/cwf/gateway/configs/sessiond.yml
@@ -57,3 +57,7 @@ default_requested_units: 200000
 # set to true if subscriber information export over IPFIX needs to be enabled
 # in order to enable ipfix, make sure to add ipfix as a static service in pipelined.yml
 enable_ipfix: true
+
+# set to a certain interval measured in seconds for which sessiond should poll pipelined
+# for relevant stats
+poll_stats_interval: 5

--- a/cwf/gateway/integ_tests/sessiond.yml
+++ b/cwf/gateway/integ_tests/sessiond.yml
@@ -48,3 +48,7 @@ default_requested_units: 200000
 # set to true if subscriber information export over IPFIX needs to be enabled
 # in order to enable ipfix, make sure to add ipfix as a static service in pipelined.yml
 enable_ipfix: true
+
+# set to a certain interval measured in seconds for which sessiond should poll pipelined
+# for relevant stats
+poll_stats_interval: 5

--- a/lte/gateway/c/session_manager/sessiond_main.cpp
+++ b/lte/gateway/c/session_manager/sessiond_main.cpp
@@ -338,13 +338,12 @@ int main(int argc, char* argv[]) {
   std::thread periodic_stats_requester_thread([&]() {
     // random value assigned for interval period, the value will be loaded
     // from a config field later
+    uint32_t interval = DEFAULT_POLL_INTERVAL_TIME;
     if (config["poll_stats_interval"].IsDefined()) {
-      periodic_stats_requester->start_loop(
-          local_enforcer, config["poll_stats_interval"].as<uint32_t>());
-    } else {
-      periodic_stats_requester->start_loop(
-          local_enforcer, DEFAULT_POLL_INTERVAL_TIME);
+      interval = config["poll_stats_interval"].as<uint32_t>();
     }
+    periodic_stats_requester->start_loop(
+          local_enforcer, config["poll_stats_interval"].as<uint32_t>());
     periodic_stats_requester->stop();
   });
 

--- a/lte/gateway/c/session_manager/sessiond_main.cpp
+++ b/lte/gateway/c/session_manager/sessiond_main.cpp
@@ -335,9 +335,10 @@ int main(int argc, char* argv[]) {
   // every fixed interval of time
   auto periodic_stats_requester = std::make_shared<magma::StatsPoller>();
   std::thread periodic_stats_requester_thread([&]() {
-    //random value assigned for interval period, the value will be loaded
-    //from a config field later
-    periodic_stats_requester->start_loop(local_enforcer, 5);
+    // random value assigned for interval period, the value will be loaded
+    // from a config field later
+    periodic_stats_requester->start_loop(
+        local_enforcer, config["poll_stats_interval"].as<uint32_t>());
     periodic_stats_requester->stop();
   });
 

--- a/lte/gateway/c/session_manager/sessiond_main.cpp
+++ b/lte/gateway/c/session_manager/sessiond_main.cpp
@@ -343,7 +343,7 @@ int main(int argc, char* argv[]) {
       interval = config["poll_stats_interval"].as<uint32_t>();
     }
     periodic_stats_requester->start_loop(
-          local_enforcer, config["poll_stats_interval"].as<uint32_t>());
+          local_enforcer, interval);
     periodic_stats_requester->stop();
   });
 

--- a/lte/gateway/c/session_manager/sessiond_main.cpp
+++ b/lte/gateway/c/session_manager/sessiond_main.cpp
@@ -43,6 +43,7 @@
 #define DEFAULT_USAGE_REPORTING_THRESHOLD 0.8
 #define DEFAULT_QUOTA_EXHAUSTION_TERMINATION_MS 30000  // 30sec
 #define DEFAULT_SESSION_MAX_RTX_COUNT 3
+#define DEFAULT_POLL_INTERVAL_TIME 5
 
 #ifdef DEBUG
 extern "C" void __gcov_flush(void);
@@ -337,8 +338,13 @@ int main(int argc, char* argv[]) {
   std::thread periodic_stats_requester_thread([&]() {
     // random value assigned for interval period, the value will be loaded
     // from a config field later
-    periodic_stats_requester->start_loop(
-        local_enforcer, config["poll_stats_interval"].as<uint32_t>());
+    if (config["poll_stats_interval"].IsDefined()) {
+      periodic_stats_requester->start_loop(
+          local_enforcer, config["poll_stats_interval"].as<uint32_t>());
+    } else {
+      periodic_stats_requester->start_loop(
+          local_enforcer, DEFAULT_POLL_INTERVAL_TIME);
+    }
     periodic_stats_requester->stop();
   });
 

--- a/lte/gateway/configs/sessiond.yml
+++ b/lte/gateway/configs/sessiond.yml
@@ -72,3 +72,7 @@ enable_ipfix: false
 # Session manager max resending throttle count when the UPF session info version is
 # not matching with UPF received version no.
 session_rtx_count: 3
+
+# set to a certain interval measured in seconds for which sessiond should poll pipelined
+# for relevant stats
+poll_stats_interval: 5

--- a/lte/gateway/configs/sessiond.yml_prod
+++ b/lte/gateway/configs/sessiond.yml_prod
@@ -48,3 +48,7 @@ default_requested_units: 200000
 # set to true if subscriber information export over IPFIX needs to be enabled
 # in order to enable ipfix, make sure to add ipfix as a static service in pipelined.yml
 enable_ipfix: false
+
+# set to a certain interval measured in seconds for which sessiond should poll pipelined
+# for relevant stats
+poll_stats_interval: 5


### PR DESCRIPTION
Signed-off-by: veshkemburu <veshkemburu@fb.com>

<!--
    Tag your PR title with the components that it touches along with type of
    change. Checkout 'contribute_commit_msg' doc for recommended git commit
    message style.
    E.g. "fix(orc8r): Changeset" or "feat(agw) ..."
-->

## Summary

Add config value for polling stats every variable amount of seconds.

## Test Plan

Added config flag to multiple yaml files.
Ran sessiond manager unit tests on Magma VM
Removed flag and altered interval values and used journalctf to check polling times

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
