### PR TITLE
refactor(sessiond): refactor local create session request handling logic

### DIFF
--- a/lte/gateway/c/session_manager/LocalEnforcer.cpp
+++ b/lte/gateway/c/session_manager/LocalEnforcer.cpp
@@ -2006,19 +2006,11 @@ void LocalEnforcer::propagate_bearer_updates_to_mme(
 }
 
 void LocalEnforcer::handle_cwf_roaming(
-    SessionMap& session_map, const std::string& imsi,
-    const SessionConfig& config, SessionUpdate& session_update) {
-  auto it = session_map.find(imsi);
-  if (it != session_map.end()) {
-    for (const auto& session : it->second) {
-      auto& uc = session_update[imsi][session->get_session_id()];
-      session->set_config(config);
-      uc.is_config_updated = true;
-      uc.updated_config    = session->get_config();
-      // TODO Check for event triggers and send updates to the core if needed
-      update_ipfix_flow(imsi, config, session->get_pdp_start_time());
-    }
-  }
+    std::unique_ptr<SessionState>& session, const SessionConfig& new_config,
+    SessionStateUpdateCriteria* session_uc) {
+  session->set_config(new_config, session_uc);
+  update_ipfix_flow(
+      new_config.get_imsi(), new_config, session->get_pdp_start_time());
 }
 
 bool LocalEnforcer::bind_policy_to_bearer(

--- a/lte/gateway/c/session_manager/LocalEnforcer.h
+++ b/lte/gateway/c/session_manager/LocalEnforcer.h
@@ -260,8 +260,8 @@ class LocalEnforcer {
    * IMSI
    */
   void handle_cwf_roaming(
-      SessionMap& session_map, const std::string& imsi,
-      const magma::SessionConfig& config, SessionUpdate& session_update);
+      std::unique_ptr<SessionState>& session, const SessionConfig& new_config,
+      SessionStateUpdateCriteria* session_uc);
 
   /**
    * Execute actions on subscriber's service, eg. terminate, redirect data, or

--- a/lte/gateway/c/session_manager/LocalSessionManagerHandler.cpp
+++ b/lte/gateway/c/session_manager/LocalSessionManagerHandler.cpp
@@ -215,60 +215,86 @@ static CreateSessionRequest make_create_session_request(
   return create_request;
 }
 
+grpc::Status LocalSessionManagerHandlerImpl::check_sessiond_is_ready() {
+  if (pipelined_state_ != READY) {
+    MLOG(MINFO) << "Rejecting requests since PipelineD is still setting up";
+    return Status(grpc::UNAVAILABLE, "PipelineD is not ready");
+  }
+  if (!session_store_.is_ready()) {
+    MLOG(MINFO)
+        << "Rejecting requests since SessionStore (Redis) is unavailable";
+    return Status(grpc::UNAVAILABLE, "Storage backend is not available");
+  }
+  return Status::OK;
+}
+
+grpc::Status LocalSessionManagerHandlerImpl::validate_create_session_request(
+    const SessionConfig cfg) {
+  const auto rat_type               = cfg.common_context.rat_type();
+  const CommonSessionContext common = cfg.common_context;
+  if (rat_type != TGPP_WLAN && rat_type != TGPP_LTE) {
+    // We don't support outside of WLAN / LTE
+    std::ostringstream failure_stream;
+    failure_stream << "Received an invalid RAT type " << rat_type;
+    std::string failure_msg = failure_stream.str();
+    MLOG(MERROR) << failure_msg;
+    events_reporter_->session_create_failure(cfg, failure_msg);
+    return Status(grpc::FAILED_PRECONDITION, failure_msg);
+  }
+  return check_sessiond_is_ready();
+}
+
 void LocalSessionManagerHandlerImpl::CreateSession(
     ServerContext* context, const LocalCreateSessionRequest* request,
     std::function<void(Status, LocalCreateSessionResponse)> response_callback) {
   set_sentry_transaction("CreateSession");
   auto& request_cpy = *request;
   PrintGrpcMessage(static_cast<const google::protobuf::Message&>(request_cpy));
-  enforcer_->get_event_base().runInEventBaseThread(
-      [this, context, response_callback, request_cpy]() {
-        SessionConfig cfg(request_cpy);
-        const std::string& imsi = cfg.get_imsi();
-        const auto& session_id  = id_gen_.gen_session_id(imsi);
-        log_create_session(cfg);
-        if (pipelined_state_ != READY) {
-          MLOG(MINFO) << "Rejecting LocalCreateSessionRequest for " << imsi
-                      << " apn=" << cfg.common_context.apn()
-                      << " since PipelineD is still setting up.";
-          send_local_create_session_response(
-              Status(grpc::UNAVAILABLE, "PipelineD is not ready"), session_id,
-              response_callback);
-          return;
-        }
-        if (!session_store_.is_ready()) {
-          MLOG(MINFO) << "Rejecting LocalCreateSessionRequest for " << imsi
-                      << " apn=" << cfg.common_context.apn()
-                      << " since SessionStore (Redis) is unavailable.";
-          send_local_create_session_response(
-              Status(grpc::UNAVAILABLE, "Storage backend is not available"),
-              session_id, response_callback);
-          return;
-        }
+  enforcer_->get_event_base().runInEventBaseThread([this, context,
+                                                    response_callback,
+                                                    request_cpy]() {
+    SessionConfig cfg(request_cpy);
+    const std::string& imsi           = cfg.get_imsi();
+    const CommonSessionContext common = cfg.common_context;
 
-        auto session_map     = session_store_.read_sessions({imsi});
-        const auto& rat_type = cfg.common_context.rat_type();
-        switch (rat_type) {
-          case TGPP_WLAN:
-            handle_create_session_cwf(
-                session_map, session_id, cfg, response_callback);
-            return;
-          case TGPP_LTE:
-            handle_create_session_lte(
-                session_map, session_id, cfg, response_callback);
-            return;
-          default:
-            std::ostringstream failure_stream;
-            failure_stream << "Received an invalid RAT type " << rat_type;
-            std::string failure_msg = failure_stream.str();
-            MLOG(MERROR) << failure_msg;
-            events_reporter_->session_create_failure(cfg, failure_msg);
-            send_local_create_session_response(
-                Status(grpc::FAILED_PRECONDITION, "Invalid RAT type"),
-                session_id, response_callback);
-            return;
-        }
-      });
+    log_create_session(cfg);
+    auto status = validate_create_session_request(cfg);
+    if (!status.ok()) {
+      send_local_create_session_response(status, "", response_callback);
+      return;
+    }
+
+    const auto& session_id = id_gen_.gen_session_id(imsi);
+    auto session_map       = session_store_.read_sessions({imsi});
+    SessionActionOrStatus action;
+    switch (common.rat_type()) {
+      case TGPP_WLAN:
+        action = handle_create_session_cwf(session_map, session_id, cfg);
+        break;
+      case TGPP_LTE:
+        action = handle_create_session_lte(session_map, session_id, cfg);
+        break;
+      default:
+        // this should be handled above
+        MLOG(MERROR) << "RAT type " << common.rat_type() << " is not supported";
+        return;
+    }
+    if (action.end_existing_session) {
+      // Assumption here is that sessions are unique by IMSI+APN
+      end_session(
+          session_map, common.sid(), common.apn(),
+          [&](grpc::Status status, LocalEndSessionResponse response) {});
+    }
+    if (action.create_new_session) {
+      send_create_session(
+          session_map, action.session_id_to_send_back, cfg, response_callback);
+    }
+    if (action.status_back_to_access) {
+      send_local_create_session_response(
+          *(action.status_back_to_access), action.session_id_to_send_back,
+          response_callback);
+    }
+  });
 }
 
 void LocalSessionManagerHandlerImpl::send_create_session(
@@ -320,27 +346,25 @@ void LocalSessionManagerHandlerImpl::send_create_session(
       });
 }
 
-void LocalSessionManagerHandlerImpl::handle_create_session_cwf(
-    SessionMap& session_map, const std::string& session_id, SessionConfig cfg,
-    std::function<void(Status, LocalCreateSessionResponse)> cb) {
-  auto imsi = cfg.get_imsi();
-
-  auto it = session_map.find(imsi);
+SessionActionOrStatus LocalSessionManagerHandlerImpl::handle_create_session_cwf(
+    SessionMap& session_map, const std::string& session_id,
+    const SessionConfig& cfg) const {
+  auto it = session_map.find(cfg.get_imsi());
   if (it != session_map.end()) {
-    for (const auto& session : it->second) {
+    for (auto& session : it->second) {
       if (session->is_active()) {
-        recycle_cwf_session(imsi, session_id, cfg, session_map, cb);
-        return;
+        return recycle_cwf_session(session, cfg, session_map);
       }
     }
   }
-  send_create_session(session_map, session_id, cfg, cb);
+  return SessionActionOrStatus::create_new_session_action(session_id);
 }
 
-void LocalSessionManagerHandlerImpl::recycle_cwf_session(
-    const std::string& imsi, const std::string& session_id,
-    const SessionConfig& cfg, SessionMap& session_map,
-    std::function<void(Status, LocalCreateSessionResponse)> cb) {
+SessionActionOrStatus LocalSessionManagerHandlerImpl::recycle_cwf_session(
+    std::unique_ptr<SessionState>& session, const SessionConfig& cfg,
+    SessionMap& session_map) const {
+  const std::string imsi       = cfg.get_imsi();
+  const std::string session_id = session->get_session_id();
   // To recycle the session, it has to be active (i.e., not in
   // transition for termination).
   MLOG(MINFO) << "Found an active CWF session with the same IMSI " << imsi
@@ -349,64 +373,61 @@ void LocalSessionManagerHandlerImpl::recycle_cwf_session(
   // update the config
   SessionUpdate session_update =
       SessionStore::get_default_session_update(session_map);
-  enforcer_->handle_cwf_roaming(session_map, imsi, cfg, session_update);
+  SessionStateUpdateCriteria* session_uc = &session_update[imsi][session_id];
+  enforcer_->handle_cwf_roaming(session, cfg, session_uc);
   bool success = session_store_.update_sessions(session_update);
   if (!success) {
     MLOG(MINFO) << "Failed to update session config for " << session_id
                 << " in SessionD due to failure writing to SessionStore."
                 << " An earlier update may have invalidated it.";
-    auto err_status = Status(grpc::ABORTED, "Failed to update SessionStore");
-    send_local_create_session_response(err_status, session_id, cb);
-    return;
+    return SessionActionOrStatus::status(
+        Status(grpc::ABORTED, "Failed to update SessionStore"));
   }
   MLOG(MINFO) << "Successfully recycled an existing CWF session " << session_id;
-  send_local_create_session_response(grpc::Status::OK, session_id, cb);
+  return SessionActionOrStatus::OK(session->get_session_id());
 }
 
-void LocalSessionManagerHandlerImpl::handle_create_session_lte(
-    SessionMap& session_map, const std::string& session_id, SessionConfig cfg,
-    std::function<void(Status, LocalCreateSessionResponse)> cb) {
-  auto imsi = cfg.get_imsi();
+SessionActionOrStatus LocalSessionManagerHandlerImpl::handle_create_session_lte(
+    SessionMap& session_map, const std::string& session_id,
+    const SessionConfig& cfg) {
+  SessionActionOrStatus action;
+  const std::string imsi   = cfg.get_imsi();
+  const std::string apn    = cfg.common_context.apn();
+  const std::string msisdn = cfg.common_context.msisdn();
 
-  // If there are no existing sessions for the IMSI, just create a new one
-  auto it = session_map.find(imsi);
-  if (it == session_map.end()) {
-    send_create_session(session_map, session_id, cfg, cb);
-    return;
+  // If there are no existing sessions for the IMSI+APN, just create a new one
+  SessionSearchCriteria criteria(imsi, IMSI_AND_APN, apn);
+  auto session_it = session_store_.find_session(session_map, criteria);
+  if (!session_it) {
+    return SessionActionOrStatus::create_new_session_action(session_id);
   }
+  auto& session                         = **session_it;
+  const std::string existing_session_id = session->get_session_id();
 
-  for (const auto& session : it->second) {
-    const std::string& existing_session_id = session->get_session_id();
-    if (cfg == session->get_config() && session->is_active()) {
-      // To recycle the session, it has to be active (i.e., not in
-      // transition for termination) AND it should have the exact same
-      // configuration.
-      MLOG(MINFO) << "Found an active completely duplicated session with IMSI "
-                  << imsi << " and APN " << cfg.common_context.apn()
-                  << ", and same configuration. Recycling the existing session "
-                  << existing_session_id;
-      send_local_create_session_response(
-          grpc::Status::OK, existing_session_id, cb);
-      return;  // Return early
-    }
-    auto apn = cfg.common_context.apn();
-    // At this point, we have session with same IMSI, but not identical config
-    if (session->get_config().common_context.apn() == apn &&
-        session->is_active()) {
-      // If we have found an active session with the same IMSI+APN, but NOT
-      // identical context, we should terminate the existing session.
-      MLOG(MINFO) << "Found an active session " << existing_session_id
-                  << " with same IMSI " << imsi << " and APN " << apn
-                  << ", but different configuration. Ending the existing "
-                  << "session, and requesting a new session";
-      end_session(
-          session_map, cfg.common_context.sid(), apn,
-          [&](grpc::Status status, LocalEndSessionResponse response) {});
-      // All sessions are unique by IMSI+APN
-      break;
-    }
+  if (cfg == session->get_config() && session->is_active()) {
+    // To recycle the session, it has to be active (i.e., not in
+    // transition for termination) AND it should have the exact same
+    // configuration.
+    MLOG(MINFO) << "Found an active completely duplicated session with IMSI "
+                << imsi << " and APN " << cfg.common_context.apn()
+                << ", and same configuration. Recycling the existing session "
+                << existing_session_id;
+    add_session_to_directory_record(imsi, existing_session_id, msisdn);
+    return SessionActionOrStatus::OK(existing_session_id);
   }
-  send_create_session(session_map, session_id, cfg, cb);
+  // At this point, we have session with same IMSI, but not identical config
+  if (session->get_config().common_context.apn() == apn &&
+      session->is_active()) {
+    // If we have found an active session with the same IMSI+APN, but NOT
+    // identical context, we should terminate the existing session.
+    MLOG(MINFO) << "Found an active session " << existing_session_id
+                << " with same IMSI " << imsi << " and APN " << apn
+                << ", but different configuration. Ending the existing "
+                << "session, and requesting a new session";
+    action.set_end_existing_session();
+  }
+  action.set_create_new_session(session_id);
+  return action;  // Return early
 }
 
 void LocalSessionManagerHandlerImpl::send_local_create_session_response(
@@ -434,6 +455,8 @@ void LocalSessionManagerHandlerImpl::add_session_to_directory_record(
   update_fields->insert({session_id_key, session_id});
   std::string msisdn_id_key = "msisdn";
   update_fields->insert({msisdn_id_key, msisdn});
+  MLOG(MINFO) << "Sending a request to DirectoryD to register sessiond ID: "
+              << session_id << " msisdn: " << msisdn;
   directoryd_client_->update_directoryd_record(
       request, [this, imsi](Status status, Void) {
         if (!status.ok()) {
@@ -466,6 +489,8 @@ void LocalSessionManagerHandlerImpl::EndSession(
   enforcer_->get_event_base().runInEventBaseThread(
       [this, sid, apn, response_callback]() {
         auto session_map = session_store_.read_sessions({sid.id()});
+        MLOG(MINFO) << "Received a termination request from Access for "
+                    << sid.id() << " apn " << apn;
         end_session(session_map, sid, apn, response_callback);
       });
 }
@@ -474,9 +499,7 @@ void LocalSessionManagerHandlerImpl::end_session(
     SessionMap& session_map, const SubscriberID& sid, const std::string& apn,
     std::function<void(Status, LocalEndSessionResponse)> response_callback) {
   auto update = SessionStore::get_default_session_update(session_map);
-  MLOG(MINFO) << "Received a termination request from Access for " << sid.id()
-              << " apn " << apn;
-  auto found = enforcer_->handle_termination_from_access(
+  auto found  = enforcer_->handle_termination_from_access(
       session_map, sid.id(), apn, update);
   if (!found) {
     MLOG(MERROR) << "Failed to find session to terminate for subscriber "
@@ -505,13 +528,13 @@ void LocalSessionManagerHandlerImpl::BindPolicy2Bearer(
   set_sentry_transaction("BindPolicy2Bearer");
   auto& request_cpy = *request;
   PrintGrpcMessage(static_cast<const google::protobuf::Message&>(request_cpy));
-  MLOG(INFO) << "Received a BindPolicy2Bearer request for "
-             << request->sid().id()
-             << " with default bearerID: " << request->linked_bearer_id()
-             << " policyID: " << request->policy_rule_id()
-             << " created dedicated bearerID: " << request->bearer_id()
-             << " agw TEID: " << request->teids().agw_teid()
-             << " eNB TEID: " << request->teids().enb_teid();
+  MLOG(MINFO) << "Received a BindPolicy2Bearer request for "
+              << request->sid().id()
+              << " with default bearerID: " << request->linked_bearer_id()
+              << " policyID: " << request->policy_rule_id()
+              << " created dedicated bearerID: " << request->bearer_id()
+              << " agw TEID: " << request->teids().agw_teid()
+              << " eNB TEID: " << request->teids().enb_teid();
   enforcer_->get_event_base().runInEventBaseThread([this, request_cpy]() {
     auto session_map = session_store_.read_sessions({request_cpy.sid().id()});
     SessionUpdate update =
@@ -541,10 +564,10 @@ void LocalSessionManagerHandlerImpl::UpdateTunnelIds(
   auto& request_cpy = *request;
   auto imsi         = request->sid().id();
   PrintGrpcMessage(static_cast<const google::protobuf::Message&>(request_cpy));
-  MLOG(MDEBUG) << "Received a UpdateTunnelIds request for " << imsi
-               << " with default bearer id: " << request->bearer_id()
-               << " enb_teid= " << request->enb_teid()
-               << " agw_teid= " << request->agw_teid();
+  MLOG(MINFO) << "Received a UpdateTunnelIds request for " << imsi
+              << " with default bearer id: " << request->bearer_id()
+              << " enb_teid= " << request->enb_teid()
+              << " agw_teid= " << request->agw_teid();
   enforcer_->get_event_base().runInEventBaseThread([this, request_cpy, imsi,
                                                     response_callback]() {
     auto session_map = session_store_.read_sessions({imsi});
@@ -598,7 +621,8 @@ void LocalSessionManagerHandlerImpl::SetSessionRules(
   response_callback(Status::OK, Void());
 }
 
-void LocalSessionManagerHandlerImpl::log_create_session(SessionConfig& cfg) {
+void LocalSessionManagerHandlerImpl::log_create_session(
+    const SessionConfig& cfg) {
   const std::string& imsi = cfg.get_imsi();
   const auto& apn         = cfg.common_context.apn();
   std::string create_message =

--- a/lte/gateway/c/session_manager/LocalSessionManagerHandler.h
+++ b/lte/gateway/c/session_manager/LocalSessionManagerHandler.h
@@ -30,6 +30,41 @@ using grpc::Status;
 
 namespace magma {
 using namespace orc8r;
+using std::experimental::optional;
+
+struct SessionActionOrStatus {
+  bool create_new_session;
+  bool end_existing_session;
+  std::string session_id_to_send_back;
+  // if this value is set, we should respond back to access immediately
+  optional<grpc::Status> status_back_to_access;
+  SessionActionOrStatus()
+      : create_new_session(false), end_existing_session(false) {}
+  static SessionActionOrStatus create_new_session_action(
+      const std::string session_id) {
+    SessionActionOrStatus action;
+    action.create_new_session      = true;
+    action.session_id_to_send_back = session_id;
+    return action;
+  }
+  static SessionActionOrStatus status(grpc::Status status) {
+    SessionActionOrStatus action;
+    action.status_back_to_access = status;
+    return action;
+  }
+  static SessionActionOrStatus OK(const std::string session_id) {
+    SessionActionOrStatus action;
+    action.status_back_to_access   = grpc::Status::OK;
+    action.session_id_to_send_back = session_id;
+    return action;
+  }
+  void set_create_new_session(const std::string session_id) {
+    create_new_session      = true;
+    session_id_to_send_back = session_id;
+  }
+  void set_end_existing_session() { create_new_session = true; }
+  void set_status(grpc::Status status) { status_back_to_access = status; }
+};
 
 class LocalSessionManagerHandler {
  public:
@@ -182,31 +217,36 @@ class LocalSessionManagerHandlerImpl : public LocalSessionManagerHandler {
 
   /**
    * handle_create_session_cwf handles a sequence of actions needed for the
-   * RATType=WLAN case. It is responsible for responding to the original
-   * LocalCreateSession request.
+   * RATType=WLAN case.
    * If there is an existing session for the IMSI that is ACTIVE, we will
    * simply update its SessionConfig with the new context. In this case, we will
    * NOT send a CreateSession request into FeG/PolicyDB.
    * Otherwise, we will go through the procedure of creating a new context.
    * @param session_map - SessionMap that contains all sessions with IMSI
-   * @param sid - newly created SessionID
+   * @param session_id - newly created SessionID
    * @param cfg - newly created SessionConfig from the LocalCreateSessionRequest
-   * @param cb - callback needed to respond to the original
-   * LocalCreateSessionRequest
+   * @returns if we should immediately respond to the access component without
+   * creating a new session in the policy component, it'll return a struct with
+   * grpc::Status set. otherwise, it'll return a struct with fields set to
+   * indicate what actions need to be taken.
    */
-  void handle_create_session_cwf(
-      SessionMap& session_map, const std::string& sid, SessionConfig cfg,
-      std::function<void(Status, LocalCreateSessionResponse)> cb);
+  SessionActionOrStatus handle_create_session_cwf(
+      SessionMap& session_map, const std::string& session_id,
+      const SessionConfig& cfg) const;
 
   /**
-   * Handle the logic to recycle an existing CWF session. This involves updating
-   * the existing SessionConfig with the new one. This function is responsible
-   * for responding to the original LocalCreateSession call with the cb.
+   * @brief Handle the logic to recycle an existing CWF session. This involves
+   * updating the existing SessionConfig with the new one. This function is
+   * responsible for responding to the original LocalCreateSession call with the
+   * cb.
+   *
+   * @param cfg
+   * @param session_map
+   * @return SessionActionOrStatus with grpc::Status set
    */
-  void recycle_cwf_session(
-      const std::string& imsi, const std::string& sid, const SessionConfig& cfg,
-      SessionMap& session_map,
-      std::function<void(Status, LocalCreateSessionResponse)> cb);
+  SessionActionOrStatus recycle_cwf_session(
+      std::unique_ptr<SessionState>& session, const SessionConfig& cfg,
+      SessionMap& session_map) const;
   /**
    * handle_create_session_lte handles a sequence of actions needed for the
    * RATType=LTE case. It is responsible for responding to the original
@@ -216,14 +256,16 @@ class LocalSessionManagerHandlerImpl : public LocalSessionManagerHandler {
    * a CreateSession request into FeG/PolicyDB.
    * Otherwise, we will go through the procedure of creating a new context.
    * @param session_map - SessionMap that contains all sessions with IMSI
-   * @param sid - newly created SessionID
+   * @param session_id - newly created SessionID
    * @param cfg - newly created SessionConfig from the LocalCreateSessionRequest
-   * @param cb - callback needed to respond to the original
-   * LocalCreateSessionRequest
+   * @returns if we should immediately respond to the access component without
+   * creating a new session in the policy component, it'll return a struct with
+   * grpc::Status set. otherwise, it'll return a struct with fields set to
+   * indicate what actions need to be taken.
    */
-  void handle_create_session_lte(
-      SessionMap& session_map, const std::string& sid, SessionConfig cfg,
-      std::function<void(Status, LocalCreateSessionResponse)> cb);
+  SessionActionOrStatus handle_create_session_lte(
+      SessionMap& session_map, const std::string& session_id,
+      const SessionConfig& cfg);
 
   /**
    * Send session creation request to the CentralSessionController.
@@ -231,7 +273,8 @@ class LocalSessionManagerHandlerImpl : public LocalSessionManagerHandler {
    * gRPC caller.
    */
   void send_create_session(
-      SessionMap& session_map, const std::string& sid, const SessionConfig& cfg,
+      SessionMap& session_map, const std::string& session_id,
+      const SessionConfig& cfg,
       std::function<void(grpc::Status, LocalCreateSessionResponse)> cb);
 
   void handle_setup_callback(
@@ -242,7 +285,23 @@ class LocalSessionManagerHandlerImpl : public LocalSessionManagerHandler {
       std::function<void(Status, LocalCreateSessionResponse)>
           response_callback);
 
-  void log_create_session(SessionConfig& cfg);
+  void log_create_session(const SessionConfig& cfg);
+
+  /**
+   * @param cfg
+   * @return status::OK if the request can be processed, otherwise the status
+   * that should be sent back
+   */
+  grpc::Status validate_create_session_request(const SessionConfig cfg);
+
+  /**
+   * @brief SessionD will not process any requests if
+   * 1. SessionStore is not ready
+   * 2. PipelineD is not ready
+   *
+   * @return status::OK if SessionD is ready to accept requests
+   */
+  grpc::Status check_sessiond_is_ready();
 };
 
 }  // namespace magma

--- a/lte/gateway/c/session_manager/SentryWrappers.cpp
+++ b/lte/gateway/c/session_manager/SentryWrappers.cpp
@@ -59,7 +59,8 @@ float get_sentry_sample_rate(
     const magma::mconfig::SentryConfig& sentry_config,
     YAML::Node control_proxy_config) {
   if (control_proxy_config[SENTRY_SAMPLE_RATE].IsDefined()) {
-    const float sample_rate_override = control_proxy_config[SENTRY_SAMPLE_RATE].as<float>();
+    const float sample_rate_override =
+        control_proxy_config[SENTRY_SAMPLE_RATE].as<float>();
     if (sample_rate_override) {
       return sample_rate_override;
     }

--- a/lte/gateway/c/session_manager/SessionState.cpp
+++ b/lte/gateway/c/session_manager/SessionState.cpp
@@ -1003,8 +1003,13 @@ void SessionState::set_upf_teid_endpoint(
   return;
 }
 
-void SessionState::set_config(const SessionConfig& config) {
+void SessionState::set_config(
+    const SessionConfig& config, SessionStateUpdateCriteria* session_uc) {
   config_ = config;
+  if (session_uc) {
+    session_uc->is_config_updated = true;
+    session_uc->updated_config    = config;
+  }
 }
 
 bool SessionState::is_radius_cwf_session() const {

--- a/lte/gateway/c/session_manager/SessionState.h
+++ b/lte/gateway/c/session_manager/SessionState.h
@@ -292,7 +292,8 @@ class SessionState {
       const magma::lte::TgppContext& tgpp_context,
       SessionStateUpdateCriteria* session_uc);
 
-  void set_config(const SessionConfig& config);
+  void set_config(
+      const SessionConfig& config, SessionStateUpdateCriteria* session_uc);
 
   SessionConfig get_config() const { return config_; }
 

--- a/lte/gateway/c/session_manager/SetMessageManagerHandler.cpp
+++ b/lte/gateway/c/session_manager/SetMessageManagerHandler.cpp
@@ -204,7 +204,7 @@ void SetMessageManagerHandler::send_create_session(
                          .teid());
       MLOG(MDEBUG) << "2nd Request of session from UE with IMSI: " << imsi
                    << " PDU id " << pdu_id;
-      session->set_config(cfg);
+      session->set_config(cfg, nullptr);
       SessionUpdate update =
           SessionStore::get_default_session_update(session_map);
       bool success = m5g_enforcer_->m5g_update_session_context(

--- a/lte/gateway/c/session_manager/sessiond_main.cpp
+++ b/lte/gateway/c/session_manager/sessiond_main.cpp
@@ -340,21 +340,17 @@ int main(int argc, char* argv[]) {
 
   // Start off a thread to periodically poll stats from Pipelined
   // every fixed interval of time
-
-  if (config["enable_pull_stats"].IsDefined() &&
-      config["enable_pull_stats"].as<bool>()) {
-    auto periodic_stats_requester = std::make_shared<magma::StatsPoller>();
-    std::thread periodic_stats_requester_thread([&]() {
-      // random value assigned for interval period, the value will be loaded
-      // from a config field later
-      uint32_t interval = DEFAULT_POLL_INTERVAL_TIME;
-      if (config["poll_stats_interval"].IsDefined()) {
-        interval = config["poll_stats_interval"].as<uint32_t>();
-      }
-      periodic_stats_requester->start_loop(local_enforcer, interval);
-      periodic_stats_requester->stop();
-    });
-  }
+  auto periodic_stats_requester = std::make_shared<magma::StatsPoller>();
+  std::thread periodic_stats_requester_thread([&]() {
+    // random value assigned for interval period, the value will be loaded
+    // from a config field later
+    uint32_t interval = DEFAULT_POLL_INTERVAL_TIME;
+    if (config["poll_stats_interval"].IsDefined()) {
+      interval = config["poll_stats_interval"].as<uint32_t>();
+    }
+    periodic_stats_requester->start_loop(local_enforcer, interval);
+    periodic_stats_requester->stop();
+  });
 
   // Setup threads to serve as GRPC servers for the LocalSessionManagerHandler
   // and the SessionProxyHandler (RARs)

--- a/lte/gateway/c/session_manager/test/SessionStateTester.h
+++ b/lte/gateway/c/session_manager/test/SessionStateTester.h
@@ -109,7 +109,7 @@ class SessionStateTest : public ::testing::Test {
     const auto& lte_context =
         build_lte_context(IP2, "", "", "", "", BEARER_ID_1, &qos_info);
     cfg.rat_specific_context.mutable_lte_context()->CopyFrom(lte_context);
-    session_state->set_config(cfg);
+    session_state->set_config(cfg, nullptr);
   }
 
   // TODO: make session_manager.proto and policydb.proto to use common field

--- a/lte/gateway/c/session_manager/test/test_set_session_manager_handler.cpp
+++ b/lte/gateway/c/session_manager/test/test_set_session_manager_handler.cpp
@@ -244,7 +244,7 @@ TEST_F(SessionManagerHandlerTest, test_UpdateSessionContext) {
   SessionSearchCriteria id1_success_sid(IMSI1, IMSI_AND_PDUID, pdu_id);
   auto session_it = session_store->find_session(session_map, id1_success_sid);
   auto& session   = **session_it;
-  session->set_config(cfg);
+  session->set_config(cfg, nullptr);
   session_enforcer->add_default_rules(session, IMSI1);
   session_enforcer->m5g_update_session_context(
       session_map, IMSI1, session, update);


### PR DESCRIPTION
Signed-off-by: Marie Bremner <marwhal@fb.com>

<!--
    Tag your PR title with the components that it touches along with type of
    change. Checkout 'contribute_commit_msg' doc for recommended git commit
    message style.
    E.g. "fix(orc8r): Changeset" or "feat(agw) ..."
-->

## Summary
A few things while trying to resolve https://github.com/magma/magma/issues/7867

1. never pass in IMSI as arg to functions if SessionConfig is already an arg (repetitive)
2. refactor `handle_create_session_cwf` and `handle_create_session_lte` so that they return a strcture that indicates whether to make a call into PolicyDB, instead of making those calls directly. Just cleaning up so that all calls into policydb / mme are made at the top level.

New structure introduced to use as a return type
```
struct SessionActionOrStatus {
  bool create_new_session;
  bool end_existing_session;
  // if this value is set, we should respond back to access immediately
  optional<grpc::Status> status_back_to_access;
};
```
<!-- Enumerate changes you made and why you made them -->

## Test Plan
make precommit_sm

ran s1ap tests locally

CWF integ test
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
