### PR TITLE
[lte][agw] Fix itti message construction with correct apn size

### DIFF
--- a/lte/gateway/c/core/oai/lib/s6a_proxy/proto_msg_to_itti_msg.cpp
+++ b/lte/gateway/c/core/oai/lib/s6a_proxy/proto_msg_to_itti_msg.cpp
@@ -161,7 +161,6 @@ void convert_proto_msg_to_itti_s6a_update_location_ans(
       SUBSCRIBER_PERIODIC_RAU_TAU_TIMER_VAL;
 
   // apn configuration
-  itti_msg->subscription_data.apn_config_profile.nb_apns = msg.apn_size();
   uint8_t idx                                            = 0;
   while (idx < msg.apn_size() && idx < MAX_APN_PER_UE) {
     auto apn                                 = msg.apn(idx);
@@ -203,6 +202,7 @@ void convert_proto_msg_to_itti_s6a_update_location_ans(
     itti_msg_apn->ambr.br_unit = (apn_ambr_bitrate_unit_t) apn.ambr().unit();
     ++idx;
   }
+  itti_msg->subscription_data.apn_config_profile.nb_apns = idx;
   return;
 }
 

--- a/lte/gateway/c/core/oai/lib/s6a_proxy/proto_msg_to_itti_msg.cpp
+++ b/lte/gateway/c/core/oai/lib/s6a_proxy/proto_msg_to_itti_msg.cpp
@@ -150,7 +150,7 @@ void convert_proto_msg_to_itti_s6a_update_location_ans(
           regional_subscription_zone_code.c_str(), ZONE_CODE_LEN);
       ++reg_sub_idx;
     } else {
-      std::cout << "[ERROR] Invalid zonecode length received, ignoring"
+      std::cout << "[WARNING] Invalid zonecode length received, ignoring"
                 << regional_subscription_zone_code.length() << std::endl;
     }
   }
@@ -161,8 +161,18 @@ void convert_proto_msg_to_itti_s6a_update_location_ans(
       SUBSCRIBER_PERIODIC_RAU_TAU_TIMER_VAL;
 
   // apn configuration
-  uint8_t idx                                            = 0;
-  while (idx < msg.apn_size() && idx < MAX_APN_PER_UE) {
+  uint8_t nb_apns = 0;
+  if (msg.apn_size() > MAX_APN_PER_UE) {
+    std::cout << "[WARNING] The number of APNs configured in subscriber data ("
+              << msg.apn_size() << ") is larger than MME limit of "
+              << MAX_APN_PER_UE << ". Truncating the list to this MME limit."
+              << std::endl;
+    nb_apns = MAX_APN_PER_UE;
+  } else {
+    nb_apns = msg.apn_size();
+  }
+  itti_msg->subscription_data.apn_config_profile.nb_apns = nb_apns;
+  for (uint8_t idx = 0; idx < nb_apns; ++idx) {
     auto apn                                 = msg.apn(idx);
     struct apn_configuration_s* itti_msg_apn = &(
         itti_msg->subscription_data.apn_config_profile.apn_configuration[idx]);
@@ -200,9 +210,8 @@ void convert_proto_msg_to_itti_s6a_update_location_ans(
     itti_msg_apn->ambr.br_ul   = apn.ambr().max_bandwidth_ul();
     itti_msg_apn->ambr.br_dl   = apn.ambr().max_bandwidth_dl();
     itti_msg_apn->ambr.br_unit = (apn_ambr_bitrate_unit_t) apn.ambr().unit();
-    ++idx;
   }
-  itti_msg->subscription_data.apn_config_profile.nb_apns = idx;
+
   return;
 }
 


### PR DESCRIPTION
Signed-off-by: Ulas Kozat <kozat@fb.com>

<!--
    Tag your PR title with the components that it touches along with type of
    change. Checkout 'contribute_commit_msg' doc for recommended git commit
    message style.
    E.g. "fix(orc8r): Changeset" or "feat(agw) ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->
GRPC response on apn configuration is not translated correctly onto itti message when the number of returned APN configurations is larger than the maximum allowed by the MME.

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->
Run full suite of integ tests locally.

Modified s1ap tests.

Output of `sudo journalctl -fu magma@mme` with APNs exceeding the limit:
```
Jul 02 01:41:46 magma-dev-focal mme[1864056]: Received SGW IP Address 0x629000757228
Jul 02 01:41:46 magma-dev-focal mme[1864056]: Received SGW IP Address 0x6290007a2228
Jul 02 01:41:46 magma-dev-focal mme[1864056]: Received SGW IP Address 0x6290007ac228
Jul 02 01:41:46 magma-dev-focal mme[1864056]: [INFO] Sending S6A-AUTHENTICATION_INFORMATION_REQUEST with IMSI: 001010000000001
Jul 02 01:41:46 magma-dev-focal mme[1864056]: [INFO] Received S6A-AUTHENTICATION_INFORMATION_ANSWER for IMSI: 001010000000001; Status: ; StatusCode: 2001
Jul 02 01:41:46 magma-dev-focal mme[1864056]: [DEBUG] Sending S6A-UPDATE_LOCATION_REQUEST with IMSI: 001010000000001
Jul 02 01:41:46 magma-dev-focal mme[1864056]: [INFO] Received S6A-LOCATION-UPDATE_ANSWER for IMSI: 001010000000001; Status: ; StatusCode: 2001
Jul 02 01:41:46 magma-dev-focal mme[1864056]: [WARNING] The number of APNs configured in subscriber data (11) is larger than MME limit of 10. Truncating the list to this MME limit.
Jul 02 01:41:46 magma-dev-focal mme[1864056]: [INFO] sent itti S6A-LOCATION-UPDATE_ANSWER for IMSI: 001010000000001
```

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
