### PR TITLE
fix(enodebd): Add workaround logic for stale msg name in dictionary

### DIFF
--- a/lte/gateway/python/magma/enodebd/data_models/transform_for_magma.py
+++ b/lte/gateway/python/magma/enodebd/data_models/transform_for_magma.py
@@ -54,7 +54,7 @@ def gps_tr181(value: str) -> str:
     """
     try:
         return str(float(value) / 1e6)
-    except ValueError:
+    except Exception:  # pylint: disable=broad-except
         return value
 
 

--- a/lte/gateway/python/magma/enodebd/tr069/spyne_mods.py
+++ b/lte/gateway/python/magma/enodebd/tr069/spyne_mods.py
@@ -140,6 +140,15 @@ class Tr069Soap11(Soap11):
         return super(Tr069Soap11, self).get_call_handles(ctx)
 
     def serialize(self, ctx, message):
+        # Workaround for issue https://github.com/magma/magma/issues/7869
+        # Updates to ctx.descriptor.out_message.Attributes.sub_name are taking
+        # effect on the descriptor. But when puled from _attrcache dictionary,
+        # it still has a stale value.
+        # Force repopulation of dictionary by deleting entry
+        # TODO Remove this code once we have a better fix
+        if (ctx.descriptor.out_message in self._attrcache):
+            del self._attrcache[ctx.descriptor.out_message]  # noqa: WPS529
+
         super(Tr069Soap11, self).serialize(ctx, message)
 
         # Keep XSD namespace


### PR DESCRIPTION
Signed-off-by: Tariq Al-Khasib <talkhasib@fb.com>
## Summary
https://github.com/magma/magma/issues/7869

"SetParameterValues" is going out as "GetParameterValues" message type. Although, the message body is correctly sent.
This causes the eNB to reject the message and send back a fault.

Issue traced down to the following
We set message name "tx.descriptor.out_message.Attributes.sub_name" to the correct message name. But, when the parent "serialize" function is called, it pulls a stale value from the dictionary "_attrcache"

Workaround is to clear the element in the dictionary to force "_attrcache" to repopulate using the provided descriptor.

## Test Plan

Tested on local home setup with BaiCells eNB