### PR TITLE
refactor: remove snake case naming from test methods

### DIFF
--- a/lte/cloud/go/services/lte/servicers/builder_servicer_test.go
+++ b/lte/cloud/go/services/lte/servicers/builder_servicer_test.go
@@ -187,13 +187,13 @@ func TestBuilder_Build(t *testing.T) {
 	}
 
 	// Happy path
-	actual, err := build_non_federated(&nw, &graph, "gw1")
+	actual, err := buildNonFederated(&nw, &graph, "gw1")
 	assert.NoError(t, err)
 	assert.Equal(t, expected, actual)
 
 	// Break with non-allowed network service
 	setEPCNetworkServices([]string{"0xdeadbeef"}, &nw)
-	_, err = build_non_federated(&nw, &graph, "gw1")
+	_, err = buildNonFederated(&nw, &graph, "gw1")
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "unknown network service name 0xdeadbeef")
 
@@ -210,7 +210,7 @@ func TestBuilder_Build(t *testing.T) {
 		HeConfig: &lte_mconfig.PipelineD_HEConfig{},
 		LiUes:    &lte_mconfig.PipelineD_LiUes{},
 	}
-	actual, err = build_non_federated(&nw, &graph, "gw1")
+	actual, err = buildNonFederated(&nw, &graph, "gw1")
 	assert.NoError(t, err)
 	assert.Equal(t, expected, actual)
 
@@ -237,7 +237,7 @@ func TestBuilder_Build(t *testing.T) {
 		},
 	}
 
-	actual, err = build_lte_federated(&nw, &graph, "gw1")
+	actual, err = buildLTEFederated(&nw, &graph, "gw1")
 	assert.NoError(t, err)
 	assert.Equal(t, expected, actual)
 
@@ -263,7 +263,7 @@ func TestBuilder_Build(t *testing.T) {
 		},
 	}
 
-	actual, err = build_lte_federated(&nw, &graph, "gw1")
+	actual, err = buildLTEFederated(&nw, &graph, "gw1")
 	assert.NoError(t, err)
 	assert.Equal(t, expected, actual)
 
@@ -280,7 +280,7 @@ func TestBuilder_Build(t *testing.T) {
 			Tac: []uint32{211, 122},
 		},
 	}
-	actual, err = build_lte_federated(&nw, &graph, "gw1")
+	actual, err = buildLTEFederated(&nw, &graph, "gw1")
 	assert.NoError(t, err)
 	assert.Equal(t, expected, actual)
 }
@@ -392,7 +392,7 @@ func TestBuilder_Build_NonNat(t *testing.T) {
 			LogLevel: protos.LogLevel_INFO,
 		},
 	}
-	actual, err := build_non_federated(&nw, &graph, "gw1")
+	actual, err := buildNonFederated(&nw, &graph, "gw1")
 	assert.NoError(t, err)
 	assert.Equal(t, expected, actual)
 
@@ -403,7 +403,7 @@ func TestBuilder_Build_NonNat(t *testing.T) {
 		IpAllocatorType: lte_mconfig.MobilityD_DHCP,
 		StaticIpEnabled: false,
 	}
-	actual, err = build_non_federated(&nw, &graph, "gw1")
+	actual, err = buildNonFederated(&nw, &graph, "gw1")
 	assert.NoError(t, err)
 	assert.Equal(t, expected, actual)
 
@@ -414,7 +414,7 @@ func TestBuilder_Build_NonNat(t *testing.T) {
 		IpAllocatorType: lte_mconfig.MobilityD_IP_POOL,
 		StaticIpEnabled: false,
 	}
-	actual, err = build_non_federated(&nw, &graph, "gw1")
+	actual, err = buildNonFederated(&nw, &graph, "gw1")
 	assert.NoError(t, err)
 	assert.Equal(t, expected, actual)
 
@@ -425,7 +425,7 @@ func TestBuilder_Build_NonNat(t *testing.T) {
 		IpAllocatorType: lte_mconfig.MobilityD_IP_POOL,
 		StaticIpEnabled: true,
 	}
-	actual, err = build_non_federated(&nw, &graph, "gw1")
+	actual, err = buildNonFederated(&nw, &graph, "gw1")
 	assert.NoError(t, err)
 	assert.Equal(t, expected, actual)
 
@@ -436,7 +436,7 @@ func TestBuilder_Build_NonNat(t *testing.T) {
 		IpAllocatorType: lte_mconfig.MobilityD_DHCP,
 		StaticIpEnabled: true,
 	}
-	actual, err = build_non_federated(&nw, &graph, "gw1")
+	actual, err = buildNonFederated(&nw, &graph, "gw1")
 	assert.NoError(t, err)
 	assert.Equal(t, expected, actual)
 
@@ -449,7 +449,7 @@ func TestBuilder_Build_NonNat(t *testing.T) {
 		StaticIpEnabled: true,
 		MultiApnIpAlloc: true,
 	}
-	actual, err = build_non_federated(&nw, &graph, "gw1")
+	actual, err = buildNonFederated(&nw, &graph, "gw1")
 	assert.NoError(t, err)
 	assert.Equal(t, expected, actual)
 
@@ -478,7 +478,7 @@ func TestBuilder_Build_NonNat(t *testing.T) {
 		LiUes:                  &lte_mconfig.PipelineD_LiUes{},
 	}
 
-	actual, err = build_non_federated(&nw, &graph, "gw1")
+	actual, err = buildNonFederated(&nw, &graph, "gw1")
 	assert.NoError(t, err)
 	assert.Equal(t, expected, actual)
 
@@ -509,7 +509,7 @@ func TestBuilder_Build_NonNat(t *testing.T) {
 		LiUes:                    &lte_mconfig.PipelineD_LiUes{},
 	}
 
-	actual, err = build_non_federated(&nw, &graph, "gw1")
+	actual, err = buildNonFederated(&nw, &graph, "gw1")
 	assert.NoError(t, err)
 	assert.Equal(t, expected, actual)
 
@@ -541,7 +541,7 @@ func TestBuilder_Build_NonNat(t *testing.T) {
 		LiUes:                    &lte_mconfig.PipelineD_LiUes{},
 	}
 
-	actual, err = build_non_federated(&nw, &graph, "gw1")
+	actual, err = buildNonFederated(&nw, &graph, "gw1")
 	assert.NoError(t, err)
 	assert.Equal(t, expected, actual)
 
@@ -671,7 +671,7 @@ func TestBuilder_Build_BaseCase(t *testing.T) {
 		},
 	}
 
-	actual, err := build_non_federated(&nw, &graph, "gw1")
+	actual, err := buildNonFederated(&nw, &graph, "gw1")
 	assert.NoError(t, err)
 	assert.Equal(t, expected, actual)
 }
@@ -820,7 +820,7 @@ func TestBuilder_Build_FederatedBaseCase(t *testing.T) {
 	}
 
 	// Use LTE FEG NETWORK parser for this case
-	actual, err := build_lte_federated(&nw, &graph, "gw1")
+	actual, err := buildLTEFederated(&nw, &graph, "gw1")
 	assert.NoError(t, err)
 	assert.Equal(t, expected, actual)
 }
@@ -962,7 +962,7 @@ func TestBuilder_BuildInheritedProperties(t *testing.T) {
 		},
 	}
 
-	actual, err := build_non_federated(&nw, &graph, "gw1")
+	actual, err := buildNonFederated(&nw, &graph, "gw1")
 	assert.NoError(t, err)
 	assert.Equal(t, expected, actual)
 }
@@ -1090,7 +1090,7 @@ func TestBuilder_BuildUnmanagedEnbConfig(t *testing.T) {
 		},
 	}
 
-	actual, err := build_non_federated(&nw, &graph, "gw1")
+	actual, err := buildNonFederated(&nw, &graph, "gw1")
 	assert.NoError(t, err)
 	assert.Equal(t, expected, actual)
 }
@@ -1224,7 +1224,7 @@ func TestBuilder_BuildCongestionControlConfig(t *testing.T) {
 		},
 	}
 
-	actual, err := build_non_federated(&nw, &graph, "gw1")
+	actual, err := buildNonFederated(&nw, &graph, "gw1")
 	assert.NoError(t, err)
 	assert.Equal(t, expected, actual)
 }
@@ -1353,32 +1353,32 @@ func TestBuilder_Build_MMEPool(t *testing.T) {
 		},
 	}
 
-	actual, err := build_non_federated(&nw, &graph, "gw1")
+	actual, err := buildNonFederated(&nw, &graph, "gw1")
 	assert.NoError(t, err)
 	assert.Equal(t, expected, actual)
 }
 
-// build_lte_federated builds a Federated_LTE network that comes from swagger feg_lte_network model
-func build_lte_federated(network *configurator.Network, graph *configurator.EntityGraph, gatewayID string) (map[string]proto.Message, error) {
+// buildLTEFederated builds a Federated_LTE network that comes from swagger feg_lte_network model
+func buildLTEFederated(network *configurator.Network, graph *configurator.EntityGraph, gatewayID string) (map[string]proto.Message, error) {
 	// use federated serded (this is still an LTE network)
 	networkProto, err := network.ToProto(feg_serdes.Network)
 	if err != nil {
 		return nil, err
 	}
-	return build_impl(networkProto, graph, gatewayID)
+	return buildImpl(networkProto, graph, gatewayID)
 }
 
-// build_lte_federated builds an non federated LTE network that comes from swagger lte_networl
-func build_non_federated(network *configurator.Network, graph *configurator.EntityGraph, gatewayID string) (map[string]proto.Message, error) {
+// buildNonFederated builds an non federated LTE network that comes from swagger lte_networl
+func buildNonFederated(network *configurator.Network, graph *configurator.EntityGraph, gatewayID string) (map[string]proto.Message, error) {
 	// use NON federated serded
 	networkProto, err := network.ToProto(serdes.Network)
 	if err != nil {
 		return nil, err
 	}
-	return build_impl(networkProto, graph, gatewayID)
+	return buildImpl(networkProto, graph, gatewayID)
 }
 
-func build_impl(networkProto *storage_configurator.Network, graph *configurator.EntityGraph, gatewayID string) (map[string]proto.Message, error) {
+func buildImpl(networkProto *storage_configurator.Network, graph *configurator.EntityGraph, gatewayID string) (map[string]proto.Message, error) {
 	graphProto, err := graph.ToProto(serdes.Entity)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Signed-off-by: Waqar Aqeel <waqeel@fb.com>

## Summary

This PR just renames internal test functions to use camelCase. snake_case should not be used in Golang.

## Test Plan

Ran `./build.py -t`. All passed.