### PR TITLE
fix(mme): S11 over GTPV2C Delete session resp lbi

### DIFF
--- a/lte/gateway/c/core/oai/include/mme_app_ue_context.h
+++ b/lte/gateway/c/core/oai/include/mme_app_ue_context.h
@@ -604,7 +604,7 @@ void mme_app_free_bearer_context(bearer_context_t** bc);
 
 void mme_app_send_delete_session_request(
     struct ue_mm_context_s* const ue_context_p, const ebi_t ebi,
-    const pdn_cid_t cid);
+    const pdn_cid_t cid, const bool no_delete_tunnel);
 
 void mme_app_handle_s1ap_ue_context_modification_resp(
     const itti_s1ap_ue_context_mod_resp_t* s1ap_ue_context_mod_resp);

--- a/lte/gateway/c/core/oai/lib/gtpv2-c/nwgtpv2c-0.11/include/NwGtpv2c.h
+++ b/lte/gateway/c/core/oai/lib/gtpv2-c/nwgtpv2c-0.11/include/NwGtpv2c.h
@@ -382,6 +382,14 @@ typedef struct nw_gtpv2c_delete_local_tunnel_info_s {
 } nw_gtpv2c_delete_local_tunnel_info_t;
 
 /**
+ * API procedure context storage
+ */
+
+typedef struct proc_contex_s {
+  uint8_t ebi;  // saved GTPV2-C info element
+} proc_context_t;
+
+/**
  * API container structure between ULP and Stack.
  */
 
@@ -389,6 +397,7 @@ typedef struct nw_gtpv2c_ulp_api_s {
   nw_gtpv2c_ulp_api_type_t
       apiType; /**< First bytes of this field is used as flag holder   */
   nw_gtpv2c_msg_handle_t hMsg; /**< Handle associated with this API */
+  proc_context_t proc_context;
   union {
     nw_gtpv2c_initial_req_info_t initialReqInfo;
     nw_gtpv2c_triggered_rsp_info_t triggeredRspInfo;

--- a/lte/gateway/c/core/oai/lib/gtpv2-c/nwgtpv2c-0.11/include/NwGtpv2cPrivate.h
+++ b/lte/gateway/c/core/oai/lib/gtpv2-c/nwgtpv2c-0.11/include/NwGtpv2cPrivate.h
@@ -190,6 +190,7 @@ typedef struct nw_gtpv2c_trxn_s {
   nw_gtpv2c_msg_t* pMsg;
   bool pt_trx; /**< Make the transaction passthrough, such that the message is
                   forwarded, if no msg is appended to the trx. */
+  proc_context_t proc_context;
 
   nw_gtpv2c_stack_t* pStack;
   nw_gtpv2c_timer_handle_t hRspTmr;  /**< Handle to reponse timer            */

--- a/lte/gateway/c/core/oai/lib/gtpv2-c/nwgtpv2c-0.11/src/NwGtpv2c.c
+++ b/lte/gateway/c/core/oai/lib/gtpv2-c/nwgtpv2c-0.11/src/NwGtpv2c.c
@@ -767,7 +767,7 @@ static nw_rc_t nwGtpv2cHandleUlpInitialReq(
     }
 
     memcpy(
-        &pTrxn->proc_context, &pUlpReq->proc_context.ebi,
+        &pTrxn->proc_context, &pUlpReq->proc_context,
         sizeof(pTrxn->proc_context));
 
     char peer_ip[INET_ADDRSTRLEN];
@@ -1199,9 +1199,9 @@ static nw_rc_t nwGtpv2cSendTriggeredRspIndToUlp(
   ulpApi.u_api_info.triggeredRspIndInfo.error      = *pError;
   ulpApi.u_api_info.triggeredRspIndInfo.trx_flags  = *trxFlags_p;
   ulpApi.u_api_info.triggeredRspIndInfo.noDelete   = noDelete;
+  memcpy(&ulpApi.proc_context, proc_context, sizeof(ulpApi.proc_context));
   rc          = thiz->ulp.ulpReqCallback(thiz->ulp.hUlp, &ulpApi);
   *trxFlags_p = ulpApi.u_api_info.triggeredRspIndInfo.trx_flags;
-  memcpy(&ulpApi.proc_context, proc_context, sizeof(ulpApi.proc_context));
   OAILOG_FUNC_RETURN(LOG_GTPV2C, rc);
 }
 

--- a/lte/gateway/c/core/oai/lib/gtpv2-c/nwgtpv2c-0.11/src/NwGtpv2c.c
+++ b/lte/gateway/c/core/oai/lib/gtpv2-c/nwgtpv2c-0.11/src/NwGtpv2c.c
@@ -766,6 +766,10 @@ static nw_rc_t nwGtpv2cHandleUlpInitialReq(
       pTrxn->seqNum |= 0x00800000UL;
     }
 
+    memcpy(
+        &pTrxn->proc_context, &pUlpReq->proc_context.ebi,
+        sizeof(pTrxn->proc_context));
+
     char peer_ip[INET_ADDRSTRLEN];
     inet_ntop(
         AF_INET, (void*) &pTrxn->peer_ip.addrv4.sin_addr, peer_ip,
@@ -1179,7 +1183,7 @@ static nw_rc_t nwGtpv2cSendTriggeredRspIndToUlp(
     NW_IN uint16_t localPort, NW_IN uint16_t peerPort,
     NW_IN struct sockaddr* peerIp, NW_IN uint32_t hUlpTunnel,
     NW_IN uint32_t msgType, NW_IN bool noDelete,
-    NW_IN nw_gtpv2c_msg_handle_t hMsg) {
+    NW_IN nw_gtpv2c_msg_handle_t hMsg, NW_IN proc_context_t* proc_context) {
   nw_rc_t rc = NW_FAILURE;
   nw_gtpv2c_ulp_api_t ulpApi;
 
@@ -1197,6 +1201,7 @@ static nw_rc_t nwGtpv2cSendTriggeredRspIndToUlp(
   ulpApi.u_api_info.triggeredRspIndInfo.noDelete   = noDelete;
   rc          = thiz->ulp.ulpReqCallback(thiz->ulp.hUlp, &ulpApi);
   *trxFlags_p = ulpApi.u_api_info.triggeredRspIndInfo.trx_flags;
+  memcpy(&ulpApi.proc_context, proc_context, sizeof(ulpApi.proc_context));
   OAILOG_FUNC_RETURN(LOG_GTPV2C, rc);
 }
 
@@ -1559,7 +1564,7 @@ static nw_rc_t nwGtpv2cHandleTriggeredRsp(
     }
     rc = nwGtpv2cSendTriggeredRspIndToUlp(
         thiz, &error, keyTrxn.seqNum, &trx_flags, localPort, peerPort, peerIp,
-        hUlpTunnel, msgType, noDelete, hMsg);
+        hUlpTunnel, msgType, noDelete, hMsg, &pTrxn->proc_context);
     if (remove && !(trx_flags & INTERNAL_LATE_RESPONS_IND)) {
       OAILOG_WARNING(
           LOG_GTPV2C,

--- a/lte/gateway/c/core/oai/tasks/mme_app/mme_app_bearer.c
+++ b/lte/gateway/c/core/oai/tasks/mme_app/mme_app_bearer.c
@@ -878,8 +878,9 @@ void mme_app_handle_delete_session_rsp(
   OAILOG_INFO_UE(
       LOG_MME_APP, ue_context_p->emm_context._imsi64,
       "Received S11_DELETE_SESSION_RESPONSE from S+P-GW with teid " TEID_FMT
-      ", for ue id " MME_UE_S1AP_ID_FMT "\n ",
-      delete_sess_resp_pP->teid, ue_context_p->mme_ue_s1ap_id);
+      ", for ue id " MME_UE_S1AP_ID_FMT " lbi %u\n ",
+      delete_sess_resp_pP->teid, ue_context_p->mme_ue_s1ap_id,
+      delete_sess_resp_pP->lbi);
 
   if (delete_sess_resp_pP->cause.cause_value != REQUEST_ACCEPTED) {
     OAILOG_WARNING_UE(

--- a/lte/gateway/c/core/oai/tasks/mme_app/mme_app_context.c
+++ b/lte/gateway/c/core/oai/tasks/mme_app/mme_app_context.c
@@ -1839,12 +1839,21 @@ void mme_app_handle_s1ap_ue_context_release_complete(
       update_mme_app_stats_connected_ue_sub();
       OAILOG_FUNC_OUT(LOG_MME_APP);
     } else {
+      // delete gtpv2c tunnel on last PDN
+      bool no_delete = false;
+      pdn_cid_t cid_delete = 0;
+      for (pdn_cid_t i = 0; i < MAX_APN_PER_UE; i++) {
+        if (ue_context_p->pdn_contexts[i]) {
+          cid_delete = i;
+        }
+      }
       // Send a DELETE_SESSION_REQUEST message to the SGW
       for (pdn_cid_t i = 0; i < MAX_APN_PER_UE; i++) {
         if (ue_context_p->pdn_contexts[i]) {
           // Send a DELETE_SESSION_REQUEST message to the SGW
           mme_app_send_delete_session_request(
-              ue_context_p, ue_context_p->pdn_contexts[i]->default_ebi, i);
+              ue_context_p, ue_context_p->pdn_contexts[i]->default_ebi, i,
+              (cid_delete != i));
         }
       }
       // Move the UE to Idle state

--- a/lte/gateway/c/core/oai/tasks/mme_app/mme_app_detach.c
+++ b/lte/gateway/c/core/oai/tasks/mme_app/mme_app_detach.c
@@ -61,7 +61,7 @@
 //------------------------------------------------------------------------------
 void mme_app_send_delete_session_request(
     struct ue_mm_context_s* const ue_context_p, const ebi_t ebi,
-    const pdn_cid_t cid) {
+    const pdn_cid_t cid, const bool no_delete_tunnel) {
   MessageDef* message_p = NULL;
   OAILOG_FUNC_IN(LOG_MME_APP);
   OAILOG_INFO_UE(
@@ -84,6 +84,7 @@ void mme_app_send_delete_session_request(
   S11_DELETE_SESSION_REQUEST(message_p).local_teid = ue_context_p->mme_teid_s11;
   S11_DELETE_SESSION_REQUEST(message_p).teid =
       ue_context_p->pdn_contexts[cid]->s_gw_teid_s11_s4;
+  S11_DELETE_SESSION_REQUEST(message_p).noDelete = no_delete_tunnel;
   S11_DELETE_SESSION_REQUEST(message_p).lbi = ebi;  // default bearer
   S11_DELETE_SESSION_REQUEST(message_p).edns_peer_ip.addr_v4.sin_addr =
       ue_context_p->pdn_contexts[cid]->s_gw_address_s11_s4.address.ipv4_address;
@@ -201,11 +202,20 @@ void mme_app_handle_detach_req(const mme_ue_s1ap_id_t ue_id) {
       }
     }
   } else {
+    // delete gtpv2c tunnel on last PDN
+    bool no_delete = false;
+    pdn_cid_t cid_delete = 0;
+    for (pdn_cid_t i = 0; i < MAX_APN_PER_UE; i++) {
+      if (ue_context_p->pdn_contexts[i]) {
+        cid_delete = i;
+      }
+    }
     for (pdn_cid_t i = 0; i < MAX_APN_PER_UE; i++) {
       if (ue_context_p->pdn_contexts[i]) {
         // Send a DELETE_SESSION_REQUEST message to the SGW
         mme_app_send_delete_session_request(
-            ue_context_p, ue_context_p->pdn_contexts[i]->default_ebi, i);
+            ue_context_p, ue_context_p->pdn_contexts[i]->default_ebi, i,
+            (cid_delete != i));
       }
     }
   }

--- a/lte/gateway/c/core/oai/tasks/nas/esm/sap/esm_recv.c
+++ b/lte/gateway/c/core/oai/tasks/nas/esm/sap/esm_recv.c
@@ -523,13 +523,15 @@ esm_cause_t esm_recv_pdn_disconnect_request(
     OAILOG_FUNC_RETURN(LOG_NAS_ESM, ESM_CAUSE_INVALID_EPS_BEARER_IDENTITY);
   }
 
+  bool no_delete_tunnel = (ue_mm_context_p->nb_active_pdn_contexts > 1);
   OAILOG_INFO(
       LOG_NAS_ESM,
       "ESM-SAP   - Sending Delete session req message "
       "(ue_id=" MME_UE_S1AP_ID_FMT ", pid=%d, ebi=%d)\n",
       ue_mm_context_p->mme_ue_s1ap_id, pid, msg->linkedepsbeareridentity);
   mme_app_send_delete_session_request(
-      ue_mm_context_p, msg->linkedepsbeareridentity, pid);
+      ue_mm_context_p, msg->linkedepsbeareridentity, pid,
+      no_delete_tunnel);
 
   /*
    * Return the ESM cause value

--- a/lte/gateway/c/core/oai/tasks/s11/s11_mme_session_manager.c
+++ b/lte/gateway/c/core/oai/tasks/s11/s11_mme_session_manager.c
@@ -340,6 +340,8 @@ status_code_e s11_mme_delete_session_request(
   gtpv2c_ebi_ie_set(
       &(ulp_req.hMsg), (unsigned) req_p->lbi, NW_GTPV2C_IE_INSTANCE_ZERO);
 
+  ulp_req.proc_context.ebi = req_p->lbi;
+
   if ((req_p->indication_flags.oi) || (req_p->indication_flags.si)) {
     gtpv2c_indication_flags_ie_set(&(ulp_req.hMsg), &req_p->indication_flags);
   }
@@ -364,6 +366,9 @@ status_code_e s11_mme_handle_delete_session_response(
   message_p = DEPRECATEDitti_alloc_new_message_fatal(
       TASK_S11, S11_DELETE_SESSION_RESPONSE);
   resp_p = &message_p->ittiMsg.s11_delete_session_response;
+
+  // procedure data
+  resp_p->lbi = pUlpApi->proc_context.ebi;
 
   resp_p->teid           = nwGtpv2cMsgGetTeid(pUlpApi->hMsg);
   resp_p->internal_flags = pUlpApi->u_api_info.triggeredRspIndInfo.trx_flags;


### PR DESCRIPTION
## Summary

Harmonize S11-Delete-Session-Resp lbi IE for ITTI S11.

## Test Plan

The modified code is only impacting S11 over GTPV2c.  
Tested with DS-tester

## Additional Information
The LBI IE in ITTI S11-Delete-Session-Resp, not in 3GPP GTPV2C DSResp, it is a local key. 
This IE is stored in the GTPV2C Delete Session procedure.
