### PR TITLE
fix(sessiond): save new session state in redis while waiting for a response from PolicyDB/FeG

### DIFF
--- a/lte/gateway/c/session_manager/LocalEnforcer.cpp
+++ b/lte/gateway/c/session_manager/LocalEnforcer.cpp
@@ -1033,6 +1033,21 @@ void LocalEnforcer::handle_session_activate_rule_updates(
   }
 }
 
+std::unique_ptr<SessionState> LocalEnforcer::create_initializing_session(
+    const std::string& session_id, const SessionConfig& cfg) {
+  return std::make_unique<SessionState>(
+      session_id, cfg, *rule_store_, magma::get_time_in_sec_since_epoch());
+}
+
+void LocalEnforcer::init_session_with_policy_response(
+    std::unique_ptr<SessionState>& session,
+    const CreateSessionResponse& response,
+    SessionStateUpdateCriteria* session_uc) {
+  session->set_tgpp_context(response.tgpp_ctx(), session_uc);
+  session->set_create_session_response(response, session_uc);
+  session->set_fsm_state(SESSION_ACTIVE, session_uc);
+}
+
 void LocalEnforcer::init_session(
     SessionMap& session_map, const std::string& imsi,
     const std::string& session_id, const SessionConfig& cfg,

--- a/lte/gateway/c/session_manager/LocalEnforcer.cpp
+++ b/lte/gateway/c/session_manager/LocalEnforcer.cpp
@@ -1048,17 +1048,6 @@ void LocalEnforcer::init_session_with_policy_response(
   session->set_fsm_state(SESSION_ACTIVE, session_uc);
 }
 
-void LocalEnforcer::init_session(
-    SessionMap& session_map, const std::string& imsi,
-    const std::string& session_id, const SessionConfig& cfg,
-    const CreateSessionResponse& response) {
-  const auto time_since_epoch = magma::get_time_in_sec_since_epoch();
-  auto session                = std::make_unique<SessionState>(
-      imsi, session_id, cfg, *rule_store_, response.tgpp_ctx(),
-      time_since_epoch, response);
-  session_map[imsi].push_back(std::move(session));
-}
-
 void LocalEnforcer::add_ue_to_shard(
     const std::string imsi, SessionMap& session_map, SessionState& session) {
   auto sm_it     = session_map.find(imsi);

--- a/lte/gateway/c/session_manager/LocalEnforcer.cpp
+++ b/lte/gateway/c/session_manager/LocalEnforcer.cpp
@@ -1039,7 +1039,7 @@ std::unique_ptr<SessionState> LocalEnforcer::create_initializing_session(
       session_id, cfg, *rule_store_, magma::get_time_in_sec_since_epoch());
 }
 
-void LocalEnforcer::init_session_with_policy_response(
+void LocalEnforcer::update_session_with_policy_response(
     std::unique_ptr<SessionState>& session,
     const CreateSessionResponse& response,
     SessionStateUpdateCriteria* session_uc) {

--- a/lte/gateway/c/session_manager/LocalEnforcer.h
+++ b/lte/gateway/c/session_manager/LocalEnforcer.h
@@ -191,13 +191,14 @@ class LocalEnforcer {
       std::unordered_set<uint32_t>& charging_credits_received);
 
   /**
-   * @brief
-   *
+   * @brief Update the session with CreateSessionResponse
+   * This function should be called after we receive a CreateSessionResponse
+   * from PolicyDB / SessionProxy
    * @param session
    * @param response
    * @param session_uc
    */
-  void init_session_with_policy_response(
+  void update_session_with_policy_response(
       std::unique_ptr<SessionState>& session,
       const CreateSessionResponse& response,
       SessionStateUpdateCriteria* session_uc);

--- a/lte/gateway/c/session_manager/LocalEnforcer.h
+++ b/lte/gateway/c/session_manager/LocalEnforcer.h
@@ -191,16 +191,6 @@ class LocalEnforcer {
       std::unordered_set<uint32_t>& charging_credits_received);
 
   /**
-   * Initialize session on session map. Adds some information comming from
-   * the core (cloud). Rules will be installed by init_session_credit
-   * @param credit_response - message from cloud containing initial credits
-   */
-  void init_session(
-      SessionMap& session_map, const std::string& imsi,
-      const std::string& session_id, const SessionConfig& cfg,
-      const CreateSessionResponse& response);
-
-  /**
    * @brief
    *
    * @param session

--- a/lte/gateway/c/session_manager/LocalEnforcer.h
+++ b/lte/gateway/c/session_manager/LocalEnforcer.h
@@ -201,6 +201,27 @@ class LocalEnforcer {
       const CreateSessionResponse& response);
 
   /**
+   * @brief
+   *
+   * @param session
+   * @param response
+   * @param session_uc
+   */
+  void init_session_with_policy_response(
+      std::unique_ptr<SessionState>& session,
+      const CreateSessionResponse& response,
+      SessionStateUpdateCriteria* session_uc);
+
+  /**
+   * @brief Create a initializing session object
+   *
+   * @param session_id
+   * @param cfg
+   */
+  std::unique_ptr<SessionState> create_initializing_session(
+      const std::string& session_id, const SessionConfig& cfg);
+
+  /**
    * Process the update response from the reporter and update the
    * monitoring/charging credits and attached rules.
    * @param credit_response - message from cloud containing new credits

--- a/lte/gateway/c/session_manager/LocalSessionManagerHandler.cpp
+++ b/lte/gateway/c/session_manager/LocalSessionManagerHandler.cpp
@@ -318,10 +318,9 @@ void LocalSessionManagerHandlerImpl::CreateSession(
 bool LocalSessionManagerHandlerImpl::initialize_session(
     SessionMap& session_map, const std::string& session_id,
     const SessionConfig& cfg) {
-  MLOG(MINFO)
-      << "Initializing the new session in SessionStore before sending a "
-         "CreateSessionRequest for "
-      << session_id;
+  MLOG(MINFO) << "Initializing " << session_id
+              << " in SessionStore before sending a "
+                 "CreateSessionRequest";
   const std::string& imsi = cfg.get_imsi();
 
   session_map[imsi].push_back(
@@ -380,8 +379,8 @@ void LocalSessionManagerHandlerImpl::send_create_session(
 
         bool write_success = session_store_.update_sessions(update);
         if (write_success) {
-          MLOG(MINFO) << "Successfully initialized new session " << session_id
-                      << " in SessionD for subscriber " << imsi;
+          MLOG(MINFO) << "Successfully initialized " << session_id
+                      << " in SessionD after talking to PolicyDB/SessionProxy";
           add_session_to_directory_record(
               imsi, session_id, cfg.common_context.msisdn());
         } else {

--- a/lte/gateway/c/session_manager/LocalSessionManagerHandler.cpp
+++ b/lte/gateway/c/session_manager/LocalSessionManagerHandler.cpp
@@ -364,7 +364,7 @@ void LocalSessionManagerHandlerImpl::send_create_session(
         SessionStateUpdateCriteria* session_uc = &update[imsi][session_id];
 
         if (status.ok()) {
-          enforcer_->init_session_with_policy_response(
+          enforcer_->update_session_with_policy_response(
               session, response, session_uc);
         } else {
           std::ostringstream failure_stream;

--- a/lte/gateway/c/session_manager/LocalSessionManagerHandler.cpp
+++ b/lte/gateway/c/session_manager/LocalSessionManagerHandler.cpp
@@ -259,97 +259,138 @@ void LocalSessionManagerHandlerImpl::CreateSession(
   set_sentry_transaction("CreateSession");
   auto& request_cpy = *request;
   PrintGrpcMessage(static_cast<const google::protobuf::Message&>(request_cpy));
-  enforcer_->get_event_base().runInEventBaseThread([this, context,
-                                                    response_callback,
-                                                    request_cpy]() {
-    SessionConfig cfg(request_cpy);
-    const std::string& imsi           = cfg.get_imsi();
-    const CommonSessionContext common = cfg.common_context;
+  enforcer_->get_event_base().runInEventBaseThread(
+      [this, context, response_callback, request_cpy]() {
+        SessionConfig cfg(request_cpy);
+        const std::string& imsi           = cfg.get_imsi();
+        const CommonSessionContext common = cfg.common_context;
 
-    log_create_session(cfg);
-    auto status = validate_create_session_request(cfg);
-    if (!status.ok()) {
-      send_local_create_session_response(status, "", response_callback);
-      return;
-    }
+        log_create_session(cfg);
+        auto status = validate_create_session_request(cfg);
+        if (!status.ok()) {
+          send_local_create_session_response(status, "", response_callback);
+          return;
+        }
 
-    const auto& session_id = id_gen_.gen_session_id(imsi);
-    auto session_map       = session_store_.read_sessions({imsi});
-    SessionActionOrStatus action;
-    switch (common.rat_type()) {
-      case TGPP_WLAN:
-        action = handle_create_session_cwf(session_map, session_id, cfg);
-        break;
-      case TGPP_LTE:
-        action = handle_create_session_lte(session_map, session_id, cfg);
-        break;
-      default:
-        // this should be handled above
-        MLOG(MERROR) << "RAT type " << common.rat_type() << " is not supported";
-        return;
-    }
-    if (action.end_existing_session) {
-      // Assumption here is that sessions are unique by IMSI+APN
-      end_session(
-          session_map, common.sid(), common.apn(),
-          [&](grpc::Status status, LocalEndSessionResponse response) {});
-    }
-    if (action.create_new_session) {
-      send_create_session(
-          session_map, action.session_id_to_send_back, cfg, response_callback);
-    }
-    if (action.status_back_to_access) {
-      send_local_create_session_response(
-          *(action.status_back_to_access), action.session_id_to_send_back,
-          response_callback);
-    }
-  });
+        const auto& session_id = id_gen_.gen_session_id(imsi);
+        auto session_map       = session_store_.read_sessions({imsi});
+        SessionActionOrStatus action;
+        switch (common.rat_type()) {
+          case TGPP_WLAN:
+            action = handle_create_session_cwf(session_map, session_id, cfg);
+            break;
+          case TGPP_LTE:
+            action = handle_create_session_lte(session_map, session_id, cfg);
+            break;
+          default:
+            // this should be handled above
+            MLOG(MERROR) << "RAT type " << common.rat_type()
+                         << " is not supported";
+            return;
+        }
+        if (action.end_existing_session) {
+          // Assumption here is that sessions are unique by IMSI+APN
+          end_session(
+              session_map, common.sid(), common.apn(),
+              [&](grpc::Status status, LocalEndSessionResponse response) {});
+        }
+        if (action.create_new_session) {
+          bool success = initialize_session(
+              session_map, action.session_id_to_send_back, cfg);
+          if (success) {
+            send_create_session(
+                session_map, action.session_id_to_send_back, cfg,
+                response_callback);
+          } else {
+            // abort and send back a failure response to access
+            action.set_status(
+                Status(grpc::ABORTED, "Failed to update SessionStore"));
+          }
+        }
+        if (action.status_back_to_access) {
+          send_local_create_session_response(
+              *(action.status_back_to_access), action.session_id_to_send_back,
+              response_callback);
+        }
+      });
 }
 
+bool LocalSessionManagerHandlerImpl::initialize_session(
+    SessionMap& session_map, const std::string& session_id,
+    const SessionConfig& cfg) {
+  MLOG(MINFO)
+      << "Initializing the new session in SessionStore before sending a "
+         "CreateSessionRequest for "
+      << session_id;
+  const std::string& imsi = cfg.get_imsi();
+
+  session_map[imsi].push_back(
+      std::move(enforcer_->create_initializing_session(session_id, cfg)));
+  return session_store_.create_sessions(imsi, std::move(session_map[imsi]));
+}
+
+// This function must be called in the event base thread
 void LocalSessionManagerHandlerImpl::send_create_session(
     SessionMap& session_map, const std::string& session_id,
     const SessionConfig& cfg,
     std::function<void(grpc::Status, LocalCreateSessionResponse)> cb) {
-  const auto& imsi = cfg.get_imsi();
-  auto create_req  = make_create_session_request(
+  auto create_req = make_create_session_request(
       cfg, session_id, enforcer_->get_access_timezone());
+
   MLOG(MINFO) << "Sending a CreateSessionRequest to fetch policies for "
               << session_id;
   reporter_->report_create_session(
       create_req,
-      [this, imsi, session_id, cfg, cb,
+      [this, session_id, cfg, cb,
        session_map_ptr = std::make_shared<SessionMap>(std::move(session_map))](
           Status status, CreateSessionResponse response) mutable {
         PrintGrpcMessage(
             static_cast<const google::protobuf::Message&>(response));
+        const std::string& imsi = cfg.get_imsi();
+        MLOG(MINFO) << "Processing CreateSessionResponse for " << session_id;
+
+        auto session_map = session_store_.read_sessions({imsi});
+        SessionUpdate update =
+            SessionStore::get_default_session_update(session_map);
+        SessionSearchCriteria criteria(imsi, IMSI_AND_SESSION_ID, session_id);
+        auto session_it = session_store_.find_session(session_map, criteria);
+        if (!session_it) {
+          MLOG(MWARNING) << "Could not find session " << session_id;
+          status = Status(grpc::ABORTED, "Session not found");
+          send_local_create_session_response(status, session_id, cb);
+          return;
+        }
+
+        auto& session                          = **session_it;
+        SessionStateUpdateCriteria* session_uc = &update[imsi][session_id];
+
         if (status.ok()) {
-          MLOG(MINFO) << "Processing a CreateSessionResponse for "
-                      << session_id;
-          enforcer_->init_session(
-              *session_map_ptr, imsi, session_id, cfg, response);
-          bool write_success = session_store_.create_sessions(
-              imsi, std::move((*session_map_ptr)[imsi]));
-          if (write_success) {
-            MLOG(MINFO) << "Successfully initialized new session " << session_id
-                        << " in SessionD for subscriber " << imsi;
-            add_session_to_directory_record(
-                imsi, session_id, cfg.common_context.msisdn());
-          } else {
-            MLOG(MINFO) << "Failed to initialize new session " << session_id
-                        << " in SessionD for subscriber " << imsi
-                        << " due to failure writing to SessionStore."
-                        << " An earlier update may have invalidated it.";
-            status = Status(
-                grpc::ABORTED, "Failed to write session to SessionD storage.");
-          }
+          enforcer_->init_session_with_policy_response(
+              session, response, session_uc);
         } else {
           std::ostringstream failure_stream;
-          failure_stream << "Failed to initialize session in SessionProxy for "
-                         << imsi << " APN " << cfg.common_context.apn() << ": "
-                         << status.error_message();
-          std::string failure_msg = failure_stream.str();
-          MLOG(MERROR) << failure_msg;
-          events_reporter_->session_create_failure(cfg, failure_msg);
+          MLOG(MERROR)
+              << "Failed to initialize session in SessionProxy/PolicyDB for "
+              << imsi << " APN " << cfg.common_context.apn() << ": "
+              << status.error_message();
+          events_reporter_->session_create_failure(
+              cfg, "Failed to initialize session in SessionProxy/PolicyDB");
+          session_uc->is_session_ended = true;
+        }
+
+        bool write_success = session_store_.update_sessions(update);
+        if (write_success) {
+          MLOG(MINFO) << "Successfully initialized new session " << session_id
+                      << " in SessionD for subscriber " << imsi;
+          add_session_to_directory_record(
+              imsi, session_id, cfg.common_context.msisdn());
+        } else {
+          MLOG(MINFO) << "Failed to initialize new session " << session_id
+                      << " in SessionD for subscriber " << imsi
+                      << " due to failure writing to SessionStore."
+                      << " An earlier update may have invalidated it.";
+          status = Status(
+              grpc::ABORTED, "Failed to write session to SessionD storage");
         }
         send_local_create_session_response(status, session_id, cb);
       });

--- a/lte/gateway/c/session_manager/LocalSessionManagerHandler.h
+++ b/lte/gateway/c/session_manager/LocalSessionManagerHandler.h
@@ -66,7 +66,7 @@ struct SessionActionOrStatus {
   }
   void set_end_existing_session() { create_new_session = true; }
   void set_status(grpc::Status status) { status_back_to_access = status; }
-};  // namespace magma
+};
 
 class LocalSessionManagerHandler {
  public:

--- a/lte/gateway/c/session_manager/LocalSessionManagerHandler.h
+++ b/lte/gateway/c/session_manager/LocalSessionManagerHandler.h
@@ -39,7 +39,9 @@ struct SessionActionOrStatus {
   // if this value is set, we should respond back to access immediately
   optional<grpc::Status> status_back_to_access;
   SessionActionOrStatus()
-      : create_new_session(false), end_existing_session(false) {}
+      : create_new_session(false),
+        end_existing_session(false),
+        status_back_to_access({}) {}
   static SessionActionOrStatus create_new_session_action(
       const std::string session_id) {
     SessionActionOrStatus action;
@@ -64,7 +66,7 @@ struct SessionActionOrStatus {
   }
   void set_end_existing_session() { create_new_session = true; }
   void set_status(grpc::Status status) { status_back_to_access = status; }
-};
+};  // namespace magma
 
 class LocalSessionManagerHandler {
  public:
@@ -303,6 +305,10 @@ class LocalSessionManagerHandlerImpl : public LocalSessionManagerHandler {
    * @return status::OK if SessionD is ready to accept requests
    */
   grpc::Status check_sessiond_is_ready();
+
+  bool initialize_session(
+      SessionMap& session_map, const std::string& session_id,
+      const SessionConfig& cfg);
 };
 
 }  // namespace magma

--- a/lte/gateway/c/session_manager/LocalSessionManagerHandler.h
+++ b/lte/gateway/c/session_manager/LocalSessionManagerHandler.h
@@ -32,11 +32,16 @@ namespace magma {
 using namespace orc8r;
 using std::experimental::optional;
 
+// Utility struct to capture all actions that could result from handling a
+// LocalCreateSessionRequest
 struct SessionActionOrStatus {
   bool create_new_session;
+  // If true, end the existing session registered (in SessionD and policy
+  // component) for the IMSI and APN in the request
   bool end_existing_session;
+  // SessionID that needs to be sent back with LocalCreateSessionResponse
   std::string session_id_to_send_back;
-  // if this value is set, we should respond back to access immediately
+  // If this value is set, we should respond back to access immediately
   optional<grpc::Status> status_back_to_access;
   SessionActionOrStatus()
       : create_new_session(false),

--- a/lte/gateway/c/session_manager/SessionState.cpp
+++ b/lte/gateway/c/session_manager/SessionState.cpp
@@ -187,28 +187,22 @@ SessionState::SessionState(
 }
 
 SessionState::SessionState(
-    const std::string& imsi, const std::string& session_id,
-    const SessionConfig& cfg, StaticRuleStore& rule_store,
-    const magma::lte::TgppContext& tgpp_context, uint64_t pdp_start_time,
-    const CreateSessionResponse& csr)
-    : imsi_(imsi),
+    const std::string& session_id, const SessionConfig& cfg,
+    StaticRuleStore& rule_store, uint64_t pdp_start_time)
+    : imsi_(cfg.get_imsi()),
       session_id_(session_id),
       // Request number set to 1, because request 0 is INIT call
       request_number_(1),
-      curr_state_(SESSION_ACTIVE),
+      curr_state_(CREATING),
       config_(cfg),
       pdp_start_time_(pdp_start_time),
       pdp_end_time_(0),
+      current_version_(0),
       rtx_counter_(0),
-      tgpp_context_(tgpp_context),
-      create_session_response_(csr),
+      subscriber_quota_state_(SubscriberQuotaUpdate_Type_VALID_QUOTA),
       static_rules_(rule_store),
-      credit_map_(4, &ccHash, &ccEqual) {
-  // other default initializations
-  current_version_        = 0;
-  session_level_key_      = "";
-  subscriber_quota_state_ = SubscriberQuotaUpdate_Type_VALID_QUOTA;
-}
+      credit_map_(4, &ccHash, &ccEqual),
+      session_level_key_("") {}
 
 /*For 5G which doesn't have response context*/
 SessionState::SessionState(
@@ -228,26 +222,6 @@ SessionState::SessionState(
 /* get-set methods of new messages  for 5G*/
 uint32_t SessionState::get_current_version() {
   return current_version_;
-}
-
-SessionState::SessionState(
-    const std::string& session_id, const SessionConfig& cfg,
-    StaticRuleStore& rule_store, uint64_t pdp_start_time)
-    : imsi_(cfg.get_imsi()),
-      session_id_(session_id),
-      // Request number set to 1, because request 0 is INIT call
-      request_number_(1),
-      curr_state_(CREATING),
-      config_(cfg),
-      pdp_start_time_(pdp_start_time),
-      pdp_end_time_(0),
-      rtx_counter_(0),
-      static_rules_(rule_store),
-      credit_map_(4, &ccHash, &ccEqual) {
-  // other default initializations
-  current_version_        = 0;
-  session_level_key_      = "";
-  subscriber_quota_state_ = SubscriberQuotaUpdate_Type_VALID_QUOTA;
 }
 
 void SessionState::set_current_version(

--- a/lte/gateway/c/session_manager/SessionState.h
+++ b/lte/gateway/c/session_manager/SessionState.h
@@ -133,12 +133,6 @@ class SessionState {
 
  public:
   SessionState(
-      const std::string& imsi, const std::string& session_id,
-      const SessionConfig& cfg, StaticRuleStore& rule_store,
-      const magma::lte::TgppContext& tgpp_context, uint64_t pdp_start_time,
-      const CreateSessionResponse& csr);
-
-  SessionState(
       const std::string& session_id, const SessionConfig& cfg,
       StaticRuleStore& rule_store, uint64_t pdp_start_time);
 

--- a/lte/gateway/c/session_manager/SessionState.h
+++ b/lte/gateway/c/session_manager/SessionState.h
@@ -139,6 +139,10 @@ class SessionState {
       const CreateSessionResponse& csr);
 
   SessionState(
+      const std::string& session_id, const SessionConfig& cfg,
+      StaticRuleStore& rule_store, uint64_t pdp_start_time);
+
+  SessionState(
       const StoredSessionState& marshaled, StaticRuleStore& rule_store);
 
   static std::unique_ptr<SessionState> unmarshal(
@@ -321,6 +325,10 @@ class SessionState {
   void increment_request_number(uint32_t incr);
 
   SessionTerminateRequest make_termination_request(
+      SessionStateUpdateCriteria* session_uc);
+
+  void set_create_session_response(
+      const CreateSessionResponse response,
       SessionStateUpdateCriteria* session_uc);
 
   CreateSessionResponse get_create_session_response();

--- a/lte/gateway/c/session_manager/StoredState.cpp
+++ b/lte/gateway/c/session_manager/StoredState.cpp
@@ -84,6 +84,7 @@ SessionStateUpdateCriteria get_default_update_criteria() {
   uc.is_session_level_key_updated = false;
   uc.is_bearer_mapping_updated    = false;
   uc.policy_version_and_stats     = {};
+  uc.create_session_response      = {};
   return uc;
 }
 

--- a/lte/gateway/c/session_manager/StoredState.h
+++ b/lte/gateway/c/session_manager/StoredState.h
@@ -164,6 +164,8 @@ struct SessionStateUpdateCriteria {
   std::unordered_map<std::string, SessionCreditUpdateCriteria>
       monitor_credit_map;
   TgppContext updated_tgpp_context;
+  // The value should be set only when there is an update
+  optional<CreateSessionResponse> create_session_response;
   magma::lte::SubscriberQuotaUpdate_Type updated_subscriber_quota_state;
 
   bool is_bearer_mapping_updated;

--- a/lte/gateway/c/session_manager/test/SessionStateTester.h
+++ b/lte/gateway/c/session_manager/test/SessionStateTester.h
@@ -31,13 +31,19 @@ namespace magma {
 class SessionStateTest : public ::testing::Test {
  protected:
   virtual void SetUp() {
+    Teids teids;
+    cfg.common_context =
+        build_common_context(IMSI1, IP1, IPv6_1, teids, APN1, MSISDN, TGPP_LTE);
     auto tgpp_ctx       = TgppContext();
     auto pdp_start_time = 12345;
     create_tgpp_context("gx.dest.com", "gy.dest.com", &tgpp_ctx);
     rule_store    = std::make_shared<StaticRuleStore>();
     session_state = std::make_shared<SessionState>(
-        IMSI1, SESSION_ID_1, cfg, *rule_store, tgpp_ctx, pdp_start_time,
-        CreateSessionResponse{});
+        SESSION_ID_1, cfg, *rule_store, pdp_start_time);
+    session_state->set_tgpp_context(tgpp_ctx, nullptr);
+    session_state->set_fsm_state(SESSION_ACTIVE, nullptr);
+    session_state->set_create_session_response(
+        CreateSessionResponse(), nullptr);
     update_criteria = get_default_update_criteria();
   }
 
@@ -155,7 +161,7 @@ class SessionStateTest : public ::testing::Test {
   void receive_credit_from_ocs(uint32_t rating_group, uint64_t volume) {
     CreditUpdateResponse charge_resp;
     create_credit_update_response(
-        "IMSI1", "1234", rating_group, volume, &charge_resp);
+        IMSI1, SESSION_ID_1, rating_group, volume, &charge_resp);
     session_state->receive_charging_credit(charge_resp, &update_criteria);
   }
 
@@ -164,7 +170,7 @@ class SessionStateTest : public ::testing::Test {
       uint64_t rx_volume, bool is_final) {
     CreditUpdateResponse charge_resp;
     create_credit_update_response(
-        "IMSI1", "1234", rating_group, total_volume, tx_volume, rx_volume,
+        IMSI1, SESSION_ID_1, rating_group, total_volume, tx_volume, rx_volume,
         is_final, &charge_resp);
     session_state->receive_charging_credit(charge_resp, &update_criteria);
   }
@@ -180,7 +186,7 @@ class SessionStateTest : public ::testing::Test {
       uint64_t rx_volume, MonitoringLevel level) {
     UsageMonitoringUpdateResponse monitor_resp;
     create_monitor_update_response(
-        "IMSI1", "1234", mkey, level, total_volume, tx_volume, rx_volume,
+        IMSI1, SESSION_ID_1, mkey, level, total_volume, tx_volume, rx_volume,
         &monitor_resp);
     session_state->receive_monitor(monitor_resp, &update_criteria);
   }

--- a/lte/gateway/c/session_manager/test/test_local_enforcer.cpp
+++ b/lte/gateway/c/session_manager/test/test_local_enforcer.cpp
@@ -176,6 +176,16 @@ class LocalEnforcerTest : public ::testing::Test {
     return to_process;
   }
 
+  void initialize_session(
+      SessionMap& session_map, const std::string& session_id,
+      const SessionConfig& cfg, const CreateSessionResponse& response) {
+    const std::string imsi = cfg.get_imsi();
+    auto session = local_enforcer->create_initializing_session(session_id, cfg);
+    local_enforcer->init_session_with_policy_response(
+        session, response, nullptr);
+    session_map[imsi].push_back(std::move(session));
+  }
+
  protected:
   std::shared_ptr<MockSessionReporter> reporter;
   std::shared_ptr<StaticRuleStore> rule_store;
@@ -218,8 +228,7 @@ TEST_F(LocalEnforcerTest, test_init_cwf_session_credit) {
                              testing::_, testing::_))
       .Times(1);
 
-  local_enforcer->init_session(
-      session_map, IMSI1, SESSION_ID_1, test_cwf_cfg, response);
+  initialize_session(session_map, SESSION_ID_1, test_cwf_cfg, response);
 
   local_enforcer->update_tunnel_ids(
       session_map,
@@ -250,8 +259,8 @@ TEST_F(LocalEnforcerTest, test_init_infinite_metered_credit) {
                              test_cfg_.common_context.msisdn(), testing::_,
                              CheckRuleCount(1), testing::_))
       .Times(1);
-  local_enforcer->init_session(
-      session_map, IMSI1, SESSION_ID_1, test_cfg_, response);
+
+  initialize_session(session_map, SESSION_ID_1, test_cfg_, response);
 
   local_enforcer->update_tunnel_ids(
       session_map,
@@ -283,9 +292,8 @@ TEST_F(LocalEnforcerTest, test_init_no_credit) {
           test_cfg_.common_context.msisdn(), testing::_, CheckRuleCount(1),
           testing::_))
       .Times(1);
-  local_enforcer->init_session(
-      session_map, IMSI1, SESSION_ID_1, test_cfg_, response);
 
+  initialize_session(session_map, SESSION_ID_1, test_cfg_, response);
   local_enforcer->update_tunnel_ids(
       session_map,
       create_update_tunnel_ids_request(IMSI1, BEARER_ID_1, teids1));
@@ -306,12 +314,10 @@ TEST_F(LocalEnforcerTest, test_init_session_credit) {
       *pipelined_client,
       activate_flows_for_rules(
           testing::_, testing::_, testing::_, CheckTeids(teids1),
-          test_cfg_.common_context.msisdn(), testing::_, testing::_,
+          default_cfg_1.common_context.msisdn(), testing::_, testing::_,
           testing::_))
       .Times(1);
-  ;
-  local_enforcer->init_session(
-      session_map, IMSI1, SESSION_ID_1, test_cfg_, response);
+  initialize_session(session_map, SESSION_ID_1, default_cfg_1, response);
 
   local_enforcer->update_tunnel_ids(
       session_map,
@@ -326,8 +332,7 @@ TEST_F(LocalEnforcerTest, test_single_record) {
   CreateSessionResponse response;
   create_credit_update_response(
       IMSI1, SESSION_ID_1, 1, 1024, response.mutable_credits()->Add());
-  local_enforcer->init_session(
-      session_map, IMSI1, SESSION_ID_1, test_cfg_, response);
+  initialize_session(session_map, SESSION_ID_1, default_cfg_1, response);
   local_enforcer->update_tunnel_ids(
       session_map,
       create_update_tunnel_ids_request(IMSI1, BEARER_ID_1, teids1));
@@ -336,7 +341,7 @@ TEST_F(LocalEnforcerTest, test_single_record) {
   RuleRecordTable table;
   auto record_list = table.mutable_records();
   create_rule_record(
-      IMSI1, test_cfg_.common_context.ue_ipv4(), "rule1", 16, 32,
+      IMSI1, default_cfg_1.common_context.ue_ipv4(), "rule1", 16, 32,
       record_list->Add());
 
   auto update = SessionStore::get_default_session_update(session_map);
@@ -365,8 +370,7 @@ TEST_F(LocalEnforcerTest, test_aggregate_records_mixed_ips) {
       IMSI1, SESSION_ID_1, 1, 1024, response.mutable_credits()->Add());
   create_credit_update_response(
       IMSI1, SESSION_ID_1, 2, 1024, response.mutable_credits()->Add());
-  local_enforcer->init_session(
-      session_map, IMSI1, SESSION_ID_1, test_cfg_, response);
+  initialize_session(session_map, SESSION_ID_1, default_cfg_1, response);
   local_enforcer->update_tunnel_ids(
       session_map,
       create_update_tunnel_ids_request(IMSI1, BEARER_ID_1, teids1));
@@ -378,14 +382,14 @@ TEST_F(LocalEnforcerTest, test_aggregate_records_mixed_ips) {
   auto record_list = table.mutable_records();
   // ipv4 usage
   create_rule_record(
-      IMSI1, test_cfg_.common_context.ue_ipv4(), "rule1", 10, 20,
+      IMSI1, default_cfg_1.common_context.ue_ipv4(), "rule1", 10, 20,
       record_list->Add());
   // ipv6 usage for the same charging key and subscriber
   create_rule_record(
-      IMSI1, test_cfg_.common_context.ue_ipv6(), "rule2", 5, 15,
+      IMSI1, default_cfg_1.common_context.ue_ipv6(), "rule2", 5, 15,
       record_list->Add());
   create_rule_record(
-      IMSI1, test_cfg_.common_context.ue_ipv4(), "rule3", 100, 150,
+      IMSI1, default_cfg_1.common_context.ue_ipv4(), "rule3", 100, 150,
       record_list->Add());
 
   auto update = SessionStore::get_default_session_update(session_map);
@@ -422,8 +426,7 @@ TEST_F(LocalEnforcerTest, test_multi_version_reporting) {
       IMSI1, SESSION_ID_1, 1, 1024, response.mutable_credits()->Add());
   create_credit_update_response(
       IMSI1, SESSION_ID_1, 2, 1024, response.mutable_credits()->Add());
-  local_enforcer->init_session(
-      session_map, IMSI1, SESSION_ID_1, test_cfg_, response);
+  initialize_session(session_map, SESSION_ID_1, default_cfg_1, response);
   local_enforcer->update_tunnel_ids(
       session_map,
       create_update_tunnel_ids_request(IMSI1, BEARER_ID_1, teids1));
@@ -432,13 +435,13 @@ TEST_F(LocalEnforcerTest, test_multi_version_reporting) {
   RuleRecordTable table;
   auto record_list = table.mutable_records();
   create_rule_record(
-      IMSI1, test_cfg_.common_context.ue_ipv4(), "rule1", 1, 10, 20, 0, 0,
+      IMSI1, default_cfg_1.common_context.ue_ipv4(), "rule1", 1, 10, 20, 0, 0,
       record_list->Add());
   create_rule_record(
-      IMSI1, test_cfg_.common_context.ue_ipv4(), "rule1", 1, 25, 35, 0, 0,
+      IMSI1, default_cfg_1.common_context.ue_ipv4(), "rule1", 1, 25, 35, 0, 0,
       record_list->Add());
   create_rule_record(
-      IMSI1, test_cfg_.common_context.ue_ipv4(), "rule1", 2, 5, 105, 0, 0,
+      IMSI1, default_cfg_1.common_context.ue_ipv4(), "rule1", 2, 5, 105, 0, 0,
       record_list->Add());
 
   auto update = SessionStore::get_default_session_update(session_map);
@@ -463,8 +466,7 @@ TEST_F(LocalEnforcerTest, test_old_version_reporting) {
       IMSI1, SESSION_ID_1, 1, 1024, response.mutable_credits()->Add());
   create_credit_update_response(
       IMSI1, SESSION_ID_1, 2, 1024, response.mutable_credits()->Add());
-  local_enforcer->init_session(
-      session_map, IMSI1, SESSION_ID_1, test_cfg_, response);
+  initialize_session(session_map, SESSION_ID_1, default_cfg_1, response);
   local_enforcer->update_tunnel_ids(
       session_map,
       create_update_tunnel_ids_request(IMSI1, BEARER_ID_1, teids1));
@@ -472,26 +474,21 @@ TEST_F(LocalEnforcerTest, test_old_version_reporting) {
   RuleRecordTable table;
   auto record_list = table.mutable_records();
   // create three rule records version 1, version 2, version 3
+  auto ipv4 = default_cfg_1.common_context.ue_ipv4();
   create_rule_record(
-      IMSI1, test_cfg_.common_context.ue_ipv4(), "rule1", 1, 15, 30, 10, 15,
-      record_list->Add());
+      IMSI1, ipv4, "rule1", 1, 15, 30, 10, 15, record_list->Add());
   create_rule_record(
-      IMSI1, test_cfg_.common_context.ue_ipv4(), "rule1", 1, 20, 45, 13, 20,
-      record_list->Add());
+      IMSI1, ipv4, "rule1", 1, 20, 45, 13, 20, record_list->Add());
   create_rule_record(
-      IMSI1, test_cfg_.common_context.ue_ipv4(), "rule1", 2, 10, 80, 12, 20,
-      record_list->Add());
+      IMSI1, ipv4, "rule1", 2, 10, 80, 12, 20, record_list->Add());
   create_rule_record(
-      IMSI1, test_cfg_.common_context.ue_ipv4(), "rule1", 3, 40, 100, 6, 19,
-      record_list->Add());
+      IMSI1, ipv4, "rule1", 3, 40, 100, 6, 19, record_list->Add());
   // creating extra rules for old versions should be disregarded in stats
   // reporting
   create_rule_record(
-      IMSI1, test_cfg_.common_context.ue_ipv4(), "rule1", 1, 31, 51, 14, 3,
-      record_list->Add());
+      IMSI1, ipv4, "rule1", 1, 31, 51, 14, 3, record_list->Add());
   create_rule_record(
-      IMSI1, test_cfg_.common_context.ue_ipv4(), "rule1", 2, 15, 95, 10, 1,
-      record_list->Add());
+      IMSI1, ipv4, "rule1", 2, 15, 95, 10, 1, record_list->Add());
   auto update = SessionStore::get_default_session_update(session_map);
   auto uc     = get_default_update_criteria();
   // update to version 3 and check rx and tx values for older versions
@@ -533,8 +530,7 @@ TEST_F(LocalEnforcerTest, test_update_version_reporting) {
       IMSI1, SESSION_ID_1, 1, 1024, response.mutable_credits()->Add());
   create_credit_update_response(
       IMSI1, SESSION_ID_1, 2, 1024, response.mutable_credits()->Add());
-  local_enforcer->init_session(
-      session_map, IMSI1, SESSION_ID_1, test_cfg_, response);
+  initialize_session(session_map, SESSION_ID_1, default_cfg_1, response);
   local_enforcer->update_tunnel_ids(
       session_map,
       create_update_tunnel_ids_request(IMSI1, BEARER_ID_1, teids1));
@@ -543,18 +539,12 @@ TEST_F(LocalEnforcerTest, test_update_version_reporting) {
   RuleRecordTable table;
   auto record_list = table.mutable_records();
   // create rule records for 3 different versions
+  auto ipv4 = default_cfg_1.common_context.ue_ipv4();
+  create_rule_record(IMSI1, ipv4, "rule1", 1, 15, 30, 0, 0, record_list->Add());
+  create_rule_record(IMSI1, ipv4, "rule1", 1, 20, 45, 0, 0, record_list->Add());
+  create_rule_record(IMSI1, ipv4, "rule1", 2, 10, 80, 0, 0, record_list->Add());
   create_rule_record(
-      IMSI1, test_cfg_.common_context.ue_ipv4(), "rule1", 1, 15, 30, 0, 0,
-      record_list->Add());
-  create_rule_record(
-      IMSI1, test_cfg_.common_context.ue_ipv4(), "rule1", 1, 20, 45, 0, 0,
-      record_list->Add());
-  create_rule_record(
-      IMSI1, test_cfg_.common_context.ue_ipv4(), "rule1", 2, 10, 80, 0, 0,
-      record_list->Add());
-  create_rule_record(
-      IMSI1, test_cfg_.common_context.ue_ipv4(), "rule1", 3, 40, 100, 0, 0,
-      record_list->Add());
+      IMSI1, ipv4, "rule1", 3, 40, 100, 0, 0, record_list->Add());
   auto update = SessionStore::get_default_session_update(session_map);
   auto uc     = get_default_update_criteria();
   // check each version stats
@@ -594,8 +584,7 @@ TEST_F(LocalEnforcerTest, test_erroneous_data) {
       IMSI1, SESSION_ID_1, 1, 1024, response.mutable_credits()->Add());
   create_credit_update_response(
       IMSI1, SESSION_ID_1, 2, 1024, response.mutable_credits()->Add());
-  local_enforcer->init_session(
-      session_map, IMSI1, SESSION_ID_1, test_cfg_, response);
+  initialize_session(session_map, SESSION_ID_1, default_cfg_1, response);
   local_enforcer->update_tunnel_ids(
       session_map,
       create_update_tunnel_ids_request(IMSI1, BEARER_ID_1, teids1));
@@ -604,24 +593,15 @@ TEST_F(LocalEnforcerTest, test_erroneous_data) {
   RuleRecordTable table;
   auto record_list = table.mutable_records();
   // create 2 rule records each for 3 versions
+  auto ipv4 = default_cfg_1.common_context.ue_ipv4();
+  auto ipv6 = default_cfg_1.common_context.ue_ipv6();
+  create_rule_record(IMSI1, ipv4, "rule1", 1, 15, 30, 0, 0, record_list->Add());
+  create_rule_record(IMSI1, ipv6, "rule1", 1, 10, 20, 0, 0, record_list->Add());
+  create_rule_record(IMSI1, ipv6, "rule1", 2, 40, 90, 0, 0, record_list->Add());
+  create_rule_record(IMSI1, ipv6, "rule1", 2, 16, 24, 0, 0, record_list->Add());
   create_rule_record(
-      IMSI1, test_cfg_.common_context.ue_ipv4(), "rule1", 1, 15, 30, 0, 0,
-      record_list->Add());
-  create_rule_record(
-      IMSI1, test_cfg_.common_context.ue_ipv6(), "rule1", 1, 10, 20, 0, 0,
-      record_list->Add());
-  create_rule_record(
-      IMSI1, test_cfg_.common_context.ue_ipv6(), "rule1", 2, 40, 90, 0, 0,
-      record_list->Add());
-  create_rule_record(
-      IMSI1, test_cfg_.common_context.ue_ipv6(), "rule1", 2, 16, 24, 0, 0,
-      record_list->Add());
-  create_rule_record(
-      IMSI1, test_cfg_.common_context.ue_ipv6(), "rule1", 3, 50, 100, 0, 0,
-      record_list->Add());
-  create_rule_record(
-      IMSI1, test_cfg_.common_context.ue_ipv6(), "rule1", 3, 25, 60, 0, 0,
-      record_list->Add());
+      IMSI1, ipv6, "rule1", 3, 50, 100, 0, 0, record_list->Add());
+  create_rule_record(IMSI1, ipv6, "rule1", 3, 25, 60, 0, 0, record_list->Add());
 
   auto update = SessionStore::get_default_session_update(session_map);
   auto uc     = get_default_update_criteria();
@@ -657,8 +637,7 @@ TEST_F(LocalEnforcerTest, test_aggregate_records_for_termination) {
       IMSI1, SESSION_ID_1, 1, 1024, response.mutable_credits()->Add());
   create_credit_update_response(
       IMSI1, SESSION_ID_1, 2, 1024, response.mutable_credits()->Add());
-  local_enforcer->init_session(
-      session_map, IMSI1, SESSION_ID_1, get_default_config(IMSI1), response);
+  initialize_session(session_map, SESSION_ID_1, default_cfg_1, response);
   local_enforcer->update_tunnel_ids(
       session_map,
       create_update_tunnel_ids_request(IMSI1, BEARER_ID_1, teids1));
@@ -697,8 +676,7 @@ TEST_F(LocalEnforcerTest, test_collect_updates) {
   create_credit_update_response(
       IMSI1, SESSION_ID_1, 1, 3072, response.mutable_credits()->Add());
   response.mutable_static_rules()->Add()->mutable_rule_id()->assign("rule1");
-  local_enforcer->init_session(
-      session_map, IMSI1, SESSION_ID_1, test_cfg_, response);
+  initialize_session(session_map, SESSION_ID_1, default_cfg_1, response);
   local_enforcer->update_tunnel_ids(
       session_map,
       create_update_tunnel_ids_request(IMSI1, BEARER_ID_1, teids1));
@@ -713,7 +691,7 @@ TEST_F(LocalEnforcerTest, test_collect_updates) {
   RuleRecordTable table;
   auto record_list = table.mutable_records();
   create_rule_record(
-      IMSI1, test_cfg_.common_context.ue_ipv4(), "rule1", 1024, 2048,
+      IMSI1, default_cfg_1.common_context.ue_ipv4(), "rule1", 1024, 2048,
       record_list->Add());
 
   auto uc = get_default_update_criteria();
@@ -752,8 +730,7 @@ TEST_F(LocalEnforcerTest, test_collect_updates_with_online_avp_to_0) {
   response.set_online(false);
 
   // create session and install rules
-  local_enforcer->init_session(
-      session_map, IMSI1, SESSION_ID_1, test_cfg_, response);
+  initialize_session(session_map, SESSION_ID_1, default_cfg_1, response);
   local_enforcer->update_tunnel_ids(
       session_map,
       create_update_tunnel_ids_request(IMSI1, BEARER_ID_1, teids1));
@@ -768,7 +745,7 @@ TEST_F(LocalEnforcerTest, test_collect_updates_with_online_avp_to_0) {
   RuleRecordTable table;
   auto record_list = table.mutable_records();
   create_rule_record(
-      IMSI1, test_cfg_.common_context.ue_ipv4(), "rule1", 1024, 2048,
+      IMSI1, default_cfg_1.common_context.ue_ipv4(), "rule1", 1024, 2048,
       record_list->Add());
 
   auto update = SessionStore::get_default_session_update(session_map);
@@ -798,8 +775,7 @@ TEST_F(LocalEnforcerTest, test_update_session_credits_and_rules) {
   CreateSessionResponse response;
   auto credits = response.mutable_credits();
   create_credit_update_response(IMSI1, SESSION_ID_1, 1, 2048, credits->Add());
-  local_enforcer->init_session(
-      session_map, IMSI1, SESSION_ID_1, test_cfg_, response);
+  initialize_session(session_map, SESSION_ID_1, default_cfg_1, response);
   local_enforcer->update_tunnel_ids(
       session_map,
       create_update_tunnel_ids_request(IMSI1, BEARER_ID_1, teids1));
@@ -863,8 +839,7 @@ TEST_F(LocalEnforcerTest, test_update_session_credits_and_rules_with_failure) {
   create_monitor_update_response(
       IMSI1, SESSION_ID_1, "1", MonitoringLevel::PCC_RULE_LEVEL, 1024,
       monitor_updates->Add());
-  local_enforcer->init_session(
-      session_map, IMSI1, SESSION_ID_1, default_cfg_1, response);
+  initialize_session(session_map, SESSION_ID_1, default_cfg_1, response);
   local_enforcer->update_tunnel_ids(
       session_map,
       create_update_tunnel_ids_request(IMSI1, BEARER_ID_1, teids1));
@@ -877,7 +852,7 @@ TEST_F(LocalEnforcerTest, test_update_session_credits_and_rules_with_failure) {
   RuleRecordTable table;
   auto record_list = table.mutable_records();
   create_rule_record(
-      IMSI1, test_cfg_.common_context.ue_ipv4(), "rule1", 10, 20,
+      IMSI1, default_cfg_1.common_context.ue_ipv4(), "rule1", 10, 20,
       record_list->Add());
   auto update = SessionStore::get_default_session_update(session_map);
   auto uc     = get_default_update_criteria();
@@ -923,16 +898,14 @@ TEST_F(LocalEnforcerTest, test_terminate_credit) {
       IMSI2, SESSION_ID_2, 1, 4096, response2.mutable_credits()->Add());
 
   session_map = session_store->read_sessions(SessionRead{IMSI1});
-  local_enforcer->init_session(
-      session_map, IMSI1, SESSION_ID_1, get_default_config(IMSI1), response);
+  initialize_session(session_map, SESSION_ID_1, default_cfg_1, response);
   local_enforcer->update_tunnel_ids(
       session_map,
       create_update_tunnel_ids_request(IMSI1, BEARER_ID_1, teids1));
   session_store->create_sessions(IMSI1, std::move(session_map[IMSI1]));
 
   session_map = session_store->read_sessions(SessionRead{IMSI2});
-  local_enforcer->init_session(
-      session_map, IMSI2, SESSION_ID_2, get_default_config(IMSI2), response2);
+  initialize_session(session_map, SESSION_ID_1, default_cfg_2, response);
   local_enforcer->update_tunnel_ids(
       session_map,
       create_update_tunnel_ids_request(IMSI2, BEARER_ID_2, teids2));
@@ -972,8 +945,7 @@ TEST_F(LocalEnforcerTest, test_terminate_credit_during_reporting) {
   create_monitor_update_response(
       IMSI1, SESSION_ID_1, "m1", MonitoringLevel::PCC_RULE_LEVEL, 1024,
       response.mutable_usage_monitors()->Add());
-  local_enforcer->init_session(
-      session_map, IMSI1, SESSION_ID_1, default_cfg_1, response);
+  initialize_session(session_map, SESSION_ID_1, default_cfg_1, response);
   local_enforcer->update_tunnel_ids(
       session_map,
       create_update_tunnel_ids_request(IMSI1, BEARER_ID_1, teids1));
@@ -1048,8 +1020,7 @@ TEST_F(LocalEnforcerTest, test_sync_sessions_on_restart) {
   CreateSessionResponse response;
   create_credit_update_response(
       IMSI1, SESSION_ID_1, 1, 1024, true, response.mutable_credits()->Add());
-  local_enforcer->init_session(
-      session_map, IMSI1, SESSION_ID_1, test_cfg_, response);
+  initialize_session(session_map, SESSION_ID_1, default_cfg_1, response);
   local_enforcer->update_tunnel_ids(
       session_map,
       create_update_tunnel_ids_request(IMSI1, BEARER_ID_1, teids1));
@@ -1184,8 +1155,7 @@ TEST_F(LocalEnforcerTest, test_final_unit_handling) {
   CreateSessionResponse response;
   create_credit_update_response(
       IMSI1, SESSION_ID_1, 1, 1024, true, response.mutable_credits()->Add());
-  local_enforcer->init_session(
-      session_map, IMSI1, SESSION_ID_1, default_cfg_1, response);
+  initialize_session(session_map, SESSION_ID_1, default_cfg_1, response);
   local_enforcer->update_tunnel_ids(
       session_map,
       create_update_tunnel_ids_request(IMSI1, BEARER_ID_1, teids1));
@@ -1196,10 +1166,10 @@ TEST_F(LocalEnforcerTest, test_final_unit_handling) {
   RuleRecordTable table;
   auto record_list = table.mutable_records();
   create_rule_record(
-      IMSI1, test_cfg_.common_context.ue_ipv4(), "rule1", 1024, 2048,
+      IMSI1, default_cfg_1.common_context.ue_ipv4(), "rule1", 1024, 2048,
       record_list->Add());
   create_rule_record(
-      IMSI1, test_cfg_.common_context.ue_ipv4(), "rule2", 1024, 2048,
+      IMSI1, default_cfg_1.common_context.ue_ipv4(), "rule2", 1024, 2048,
       record_list->Add());
   auto update = SessionStore::get_default_session_update(session_map);
 
@@ -1248,8 +1218,7 @@ TEST_F(LocalEnforcerTest, test_cwf_final_unit_handling) {
   test_cwf_cfg.common_context.set_rat_type(TGPP_WLAN);
   test_cwf_cfg.rat_specific_context.mutable_wlan_context()->CopyFrom(wlan);
 
-  local_enforcer->init_session(
-      session_map, IMSI1, SESSION_ID_1, test_cwf_cfg, response);
+  initialize_session(session_map, SESSION_ID_1, test_cwf_cfg, response);
   local_enforcer->update_tunnel_ids(
       session_map,
       create_update_tunnel_ids_request(IMSI1, BEARER_ID_1, teids1));
@@ -1299,8 +1268,7 @@ TEST_F(LocalEnforcerTest, test_all) {
   CreateSessionResponse response;
   create_credit_update_response(
       IMSI1, SESSION_ID_1, 1, 1024, response.mutable_credits()->Add());
-  local_enforcer->init_session(
-      session_map, IMSI1, SESSION_ID_1, cfg1, response);
+  initialize_session(session_map, SESSION_ID_1, cfg1, response);
   local_enforcer->update_tunnel_ids(
       session_map,
       create_update_tunnel_ids_request(IMSI1, BEARER_ID_1, teids1));
@@ -1308,8 +1276,7 @@ TEST_F(LocalEnforcerTest, test_all) {
   CreateSessionResponse response2;
   create_credit_update_response(
       IMSI2, SESSION_ID_2, 2, 2048, response2.mutable_credits()->Add());
-  local_enforcer->init_session(
-      session_map, IMSI2, SESSION_ID_2, cfg2, response2);
+  initialize_session(session_map, SESSION_ID_2, cfg2, response2);
   local_enforcer->update_tunnel_ids(
       session_map,
       create_update_tunnel_ids_request(IMSI2, BEARER_ID_2, teids2));
@@ -1440,8 +1407,7 @@ TEST_F(LocalEnforcerTest, test_credit_init_with_transient_error_redirect) {
                              testing::_, testing::_, testing::_, testing::_,
                              CheckRuleCount(1), testing::_))
       .Times(1);
-  local_enforcer->init_session(
-      session_map, IMSI1, SESSION_ID_1, default_cfg_1, response);
+  initialize_session(session_map, SESSION_ID_1, default_cfg_1, response);
   local_enforcer->update_tunnel_ids(
       session_map,
       create_update_tunnel_ids_request(IMSI1, BEARER_ID_1, teids1));
@@ -1524,8 +1490,7 @@ TEST_F(LocalEnforcerTest, test_update_with_transient_error) {
   response.mutable_static_rules()->Add()->set_rule_id("rule2");
   response.mutable_static_rules()->Add()->set_rule_id("rule3");
 
-  local_enforcer->init_session(
-      session_map, IMSI1, SESSION_ID_1, test_cfg_, response);
+  initialize_session(session_map, SESSION_ID_1, default_cfg_1, response);
   local_enforcer->update_tunnel_ids(
       session_map,
       create_update_tunnel_ids_request(IMSI1, BEARER_ID_1, teids1));
@@ -1569,12 +1534,10 @@ TEST_F(LocalEnforcerTest, test_reauth_with_redirected_suspended_credit) {
   CreateSessionResponse response;
   response.mutable_static_rules()->Add()->set_rule_id("rule1");
   auto credits = response.mutable_credits();
-  test_cfg_.common_context.mutable_sid()->set_id(IMSI1);
   create_credit_update_response_with_error(
       IMSI1, SESSION_ID_1, 1, false, DIAMETER_CREDIT_LIMIT_REACHED,
       ChargingCredit_FinalAction_REDIRECT, "12.7.7.4", "", credits->Add());
-  local_enforcer->init_session(
-      session_map, IMSI1, SESSION_ID_1, test_cfg_, response);
+  initialize_session(session_map, SESSION_ID_1, default_cfg_1, response);
   local_enforcer->update_tunnel_ids(
       session_map,
       create_update_tunnel_ids_request(IMSI1, BEARER_ID_1, teids1));
@@ -1622,7 +1585,7 @@ TEST_F(LocalEnforcerTest, test_reauth_with_redirected_suspended_credit) {
   EXPECT_CALL(
       *pipelined_client, activate_flows_for_rules(
                              testing::_, testing::_, testing::_, testing::_,
-                             test_cfg_.common_context.msisdn(), testing::_,
+                             default_cfg_1.common_context.msisdn(), testing::_,
                              CheckRuleNames(pending_activation), testing::_))
       .Times(1);
   local_enforcer->update_session_credits_and_rules(
@@ -1633,8 +1596,7 @@ TEST_F(LocalEnforcerTest, test_reauth_with_redirected_suspended_credit) {
 TEST_F(LocalEnforcerTest, test_re_auth) {
   insert_static_rule(1, "", "rule1");
   CreateSessionResponse response;
-  local_enforcer->init_session(
-      session_map, IMSI1, SESSION_ID_1, get_default_config(IMSI1), response);
+  initialize_session(session_map, SESSION_ID_1, default_cfg_1, response);
   local_enforcer->update_tunnel_ids(
       session_map,
       create_update_tunnel_ids_request(IMSI1, BEARER_ID_1, teids1));
@@ -1669,7 +1631,7 @@ TEST_F(LocalEnforcerTest, test_re_auth) {
   EXPECT_CALL(
       *pipelined_client, activate_flows_for_rules(
                              testing::_, testing::_, testing::_, testing::_,
-                             test_cfg_.common_context.msisdn(), testing::_,
+                             default_cfg_1.common_context.msisdn(), testing::_,
                              testing::_, testing::_))
       .Times(1);
   actions.clear();
@@ -1686,8 +1648,7 @@ TEST_F(LocalEnforcerTest, test_dynamic_rules) {
   policy_rule->set_id("rule1");
   policy_rule->set_rating_group(1);
   policy_rule->set_tracking_type(PolicyRule::ONLY_OCS);
-  local_enforcer->init_session(
-      session_map, IMSI1, SESSION_ID_1, test_cfg_, response);
+  initialize_session(session_map, SESSION_ID_1, default_cfg_1, response);
   local_enforcer->update_tunnel_ids(
       session_map,
       create_update_tunnel_ids_request(IMSI1, BEARER_ID_1, teids1));
@@ -1696,10 +1657,10 @@ TEST_F(LocalEnforcerTest, test_dynamic_rules) {
   RuleRecordTable table;
   auto record_list = table.mutable_records();
   create_rule_record(
-      IMSI1, test_cfg_.common_context.ue_ipv4(), "rule1", 16, 32,
+      IMSI1, default_cfg_1.common_context.ue_ipv4(), "rule1", 16, 32,
       record_list->Add());
   create_rule_record(
-      IMSI1, test_cfg_.common_context.ue_ipv4(), "rule2", 8, 8,
+      IMSI1, default_cfg_1.common_context.ue_ipv4(), "rule2", 8, 8,
       record_list->Add());
 
   auto update = SessionStore::get_default_session_update(session_map);
@@ -1746,8 +1707,7 @@ TEST_F(LocalEnforcerTest, test_dynamic_rule_actions) {
                              CheckRuleCount(3), testing::_))
       .Times(1);
 
-  local_enforcer->init_session(
-      session_map, IMSI1, SESSION_ID_1, default_cfg_1, response);
+  initialize_session(session_map, SESSION_ID_1, default_cfg_1, response);
   local_enforcer->update_tunnel_ids(
       session_map,
       create_update_tunnel_ids_request(IMSI1, BEARER_ID_1, teids1));
@@ -1842,8 +1802,7 @@ TEST_F(LocalEnforcerTest, test_installing_rules_with_activation_time) {
   // We do not expect rule5 and rule2 to be activated since they are scheduled a
   // day away
 
-  local_enforcer->init_session(
-      session_map, IMSI1, SESSION_ID_1, test_cfg_, response);
+  initialize_session(session_map, SESSION_ID_1, test_cfg_, response);
   local_enforcer->update_tunnel_ids(
       session_map,
       create_update_tunnel_ids_request(IMSI1, BEARER_ID_1, teids1));
@@ -1879,10 +1838,8 @@ TEST_F(LocalEnforcerTest, test_usage_monitors) {
   response.mutable_static_rules()->Add()->set_rule_id("ocs_rule");
   response.mutable_static_rules()->Add()->set_rule_id("pcrf_only");
   response.mutable_static_rules()->Add()->set_rule_id("pcrf_split");
-  test_cfg_.common_context.mutable_sid()->set_id(IMSI1);
 
-  local_enforcer->init_session(
-      session_map, IMSI1, SESSION_ID_1, test_cfg_, response);
+  initialize_session(session_map, SESSION_ID_1, default_cfg_1, response);
   local_enforcer->update_tunnel_ids(
       session_map,
       create_update_tunnel_ids_request(IMSI1, BEARER_ID_1, teids1));
@@ -1895,7 +1852,7 @@ TEST_F(LocalEnforcerTest, test_usage_monitors) {
   // receive usages from pipelined
   RuleRecordTable table;
   auto record_list = table.mutable_records();
-  auto& ip         = test_cfg_.common_context.ue_ipv4();
+  auto& ip         = default_cfg_1.common_context.ue_ipv4();
   create_rule_record(IMSI1, ip, "both_rule", 10, 20, record_list->Add());
   create_rule_record(IMSI1, ip, "ocs_rule", 5, 15, record_list->Add());
   create_rule_record(IMSI1, ip, "pcrf_only", 1024, 1024, record_list->Add());
@@ -2009,7 +1966,7 @@ TEST_F(LocalEnforcerTest, test_usage_monitors) {
   EXPECT_CALL(
       *pipelined_client, activate_flows_for_rules(
                              IMSI1, testing::_, testing::_, testing::_,
-                             test_cfg_.common_context.msisdn(), testing::_,
+                             default_cfg_1.common_context.msisdn(), testing::_,
                              CheckRuleCount(1), testing::_))
       .Times(1);
   local_enforcer->update_session_credits_and_rules(
@@ -2039,8 +1996,7 @@ TEST_F(LocalEnforcerTest, test_usage_monitor_disable) {
   create_monitor_update_response(
       IMSI1, SESSION_ID_1, "3", MonitoringLevel::PCC_RULE_LEVEL, 1024,
       response_1.mutable_usage_monitors()->Add());
-  local_enforcer->init_session(
-      session_map, IMSI1, SESSION_ID_1, test_cfg_, response_1);
+  initialize_session(session_map, SESSION_ID_1, default_cfg_1, response_1);
   local_enforcer->update_tunnel_ids(
       session_map,
       create_update_tunnel_ids_request(IMSI1, BEARER_ID_1, teids1));
@@ -2060,7 +2016,7 @@ TEST_F(LocalEnforcerTest, test_usage_monitor_disable) {
   // reports for all monitors receive usages from pipelined
   RuleRecordTable table_1;
   auto record_list_1 = table_1.mutable_records();
-  auto ip            = test_cfg_.common_context.ue_ipv4();
+  auto ip            = default_cfg_1.common_context.ue_ipv4();
   create_rule_record(
       IMSI1, ip, "pcrf_only_active", 2000, 0, record_list_1->Add());
   create_rule_record(
@@ -2173,15 +2129,14 @@ TEST_F(LocalEnforcerTest, test_rar_create_dedicated_bearer) {
 
   SessionConfig test_volte_cfg;
   test_volte_cfg.common_context =
-      build_common_context("", IP1, IPv6_1, teids1, "", APN1, TGPP_LTE);
+      build_common_context(IMSI1, IP1, IPv6_1, teids1, "", APN1, TGPP_LTE);
   const auto& lte_context =
       build_lte_context("", "", "", "", "", 1, &test_qos_info);
   test_volte_cfg.rat_specific_context.mutable_lte_context()->CopyFrom(
       lte_context);
 
   CreateSessionResponse response;
-  local_enforcer->init_session(
-      session_map, IMSI1, SESSION_ID_1, test_volte_cfg, response);
+  initialize_session(session_map, SESSION_ID_1, test_volte_cfg, response);
   local_enforcer->update_tunnel_ids(
       session_map,
       create_update_tunnel_ids_request(IMSI1, BEARER_ID_1, teids1));
@@ -2226,8 +2181,7 @@ TEST_F(LocalEnforcerTest, test_dedicated_bearer_creation_on_session_init) {
   lte_context->set_bearer_id(default_bearer_id);  // linked_bearer_id
 
   response1.mutable_static_rules()->Add()->set_rule_id("qos-rule1");
-  local_enforcer->init_session(
-      session_map, IMSI1, SESSION_ID_1, test_cfg_, response1);
+  initialize_session(session_map, SESSION_ID_1, test_cfg_, response1);
   EXPECT_CALL(*spgw_client, create_dedicated_bearer(testing::_)).Times(1);
   local_enforcer->update_tunnel_ids(
       session_map,
@@ -2297,8 +2251,7 @@ TEST_F(LocalEnforcerTest, test_dedicated_bearer_lifecycle) {
       .Times(1)
       .WillOnce(testing::Return(true));
   // For testing change the delay to 0 ms.
-  local_enforcer->init_session(
-      session_map, IMSI1, SESSION_ID_1, test_cfg_, response);
+  initialize_session(session_map, SESSION_ID_1, test_cfg_, response);
   local_enforcer->update_tunnel_ids(
       session_map,
       create_update_tunnel_ids_request(IMSI1, default_bearer_id, teids1));
@@ -2462,13 +2415,11 @@ TEST_F(LocalEnforcerTest, test_set_session_rules) {
   response.mutable_dynamic_rules()->Add()->mutable_policy_rule()->CopyFrom(
       dynamic_1);
 
-  local_enforcer->init_session(
-      session_map, IMSI1, SESSION_ID_1, config1, response);
+  initialize_session(session_map, SESSION_ID_1, config1, response);
   local_enforcer->update_tunnel_ids(
       session_map,
       create_update_tunnel_ids_request(IMSI1, BEARER_ID_1, teids1));
-  local_enforcer->init_session(
-      session_map, IMSI1, SESSION_ID_2, config2, response);
+  initialize_session(session_map, SESSION_ID_2, config2, response);
   local_enforcer->update_tunnel_ids(
       session_map,
       create_update_tunnel_ids_request(IMSI1, BEARER_ID_2, teids2));
@@ -2555,8 +2506,7 @@ TEST_F(LocalEnforcerTest, test_rar_session_not_found) {
   // verify session validity passing in a valid IMSI (IMSI1)
   // and an invalid session-id (session1)
   CreateSessionResponse response;
-  local_enforcer->init_session(
-      session_map, IMSI1, "session0", test_cfg_, response);
+  initialize_session(session_map, "session0", test_cfg_, response);
   local_enforcer->update_tunnel_ids(
       session_map,
       create_update_tunnel_ids_request(IMSI1, BEARER_ID_1, teids1));
@@ -2584,8 +2534,7 @@ TEST_F(LocalEnforcerTest, test_revalidation_timer_on_init) {
   static_rule_install.set_rule_id("rule1");
   response.mutable_static_rules()->Add()->CopyFrom(static_rule_install);
 
-  local_enforcer->init_session(
-      session_map, IMSI1, SESSION_ID_1, default_cfg_1, response);
+  initialize_session(session_map, SESSION_ID_1, default_cfg_1, response);
   local_enforcer->update_tunnel_ids(
       session_map,
       create_update_tunnel_ids_request(IMSI1, BEARER_ID_1, teids1));
@@ -2618,8 +2567,7 @@ TEST_F(LocalEnforcerTest, test_revalidation_timer_on_rar) {
   create_session_create_response(
       IMSI1, SESSION_ID_1, mkey, rules_to_install, &response);
 
-  local_enforcer->init_session(
-      session_map, IMSI1, SESSION_ID_1, default_cfg_1, response);
+  initialize_session(session_map, SESSION_ID_1, default_cfg_1, response);
   local_enforcer->update_tunnel_ids(
       session_map,
       create_update_tunnel_ids_request(IMSI1, BEARER_ID_1, teids1));
@@ -2666,8 +2614,7 @@ TEST_F(LocalEnforcerTest, test_revalidation_timer_on_update) {
   // Create a CreateSessionResponse with one Gx monitor, PCC rule
   create_session_create_response(
       IMSI1, SESSION_ID_1, mkey1, rules_to_install, &create_response);
-  local_enforcer->init_session(
-      session_map, IMSI1, SESSION_ID_1, default_cfg_1, create_response);
+  initialize_session(session_map, SESSION_ID_1, default_cfg_1, create_response);
   local_enforcer->update_tunnel_ids(
       session_map,
       create_update_tunnel_ids_request(IMSI1, BEARER_ID_1, teids1));
@@ -2677,10 +2624,10 @@ TEST_F(LocalEnforcerTest, test_revalidation_timer_on_update) {
       IMSI2, SESSION_ID_2, mkey1, rules_to_install, &create_response);
   auto test_cfg_2 = test_cfg_;
   test_cfg_2.common_context.mutable_teids()->CopyFrom(teids2);
+  test_cfg_2.common_context.mutable_sid()->set_id(IMSI2);
   test_cfg_2.rat_specific_context.mutable_lte_context()->set_bearer_id(
       BEARER_ID_2);
-  local_enforcer->init_session(
-      session_map, IMSI2, SESSION_ID_2, test_cfg_2, create_response);
+  initialize_session(session_map, SESSION_ID_2, test_cfg_2, create_response);
   local_enforcer->update_tunnel_ids(
       session_map,
       create_update_tunnel_ids_request(IMSI2, BEARER_ID_2, teids2));
@@ -2744,8 +2691,7 @@ TEST_F(LocalEnforcerTest, test_revalidation_timer_on_update_no_monitor) {
   res->set_sid(IMSI1);
   res->set_session_id(SESSION_ID_1);
   create_response.mutable_static_rules()->Add()->CopyFrom(rule_install);
-  local_enforcer->init_session(
-      session_map, IMSI1, SESSION_ID_1, default_cfg_1, create_response);
+  initialize_session(session_map, SESSION_ID_1, default_cfg_1, create_response);
   local_enforcer->update_tunnel_ids(
       session_map,
       create_update_tunnel_ids_request(IMSI1, BEARER_ID_1, teids1));
@@ -2805,8 +2751,7 @@ TEST_F(LocalEnforcerTest, test_pipelined_cwf_setup) {
       TGPP_WLAN);
   const auto& wlan = build_wlan_context("11:22:00:00:22:11", "5555");
   test_cwf_cfg1.rat_specific_context.mutable_wlan_context()->CopyFrom(wlan);
-  local_enforcer->init_session(
-      session_map, IMSI1, SESSION_ID_1, test_cwf_cfg1, response);
+  initialize_session(session_map, SESSION_ID_1, test_cwf_cfg1, response);
   local_enforcer->update_tunnel_ids(
       session_map, create_update_tunnel_ids_request(IMSI1, 0, teids0));
 
@@ -2823,8 +2768,7 @@ TEST_F(LocalEnforcerTest, test_pipelined_cwf_setup) {
       IMSI2, IP1, "", teids0, "03-21-00-02-00-20:Magma", "msisdn2", TGPP_WLAN);
   const auto& wlan2 = build_wlan_context("00:00:00:00:00:02", "5555");
   test_cwf_cfg2.rat_specific_context.mutable_wlan_context()->CopyFrom(wlan2);
-  local_enforcer->init_session(
-      session_map, IMSI2, SESSION_ID_2, test_cwf_cfg2, response2);
+  initialize_session(session_map, SESSION_ID_2, test_cwf_cfg2, response2);
   local_enforcer->update_tunnel_ids(
       session_map, create_update_tunnel_ids_request(IMSI2, 0, teids0));
 
@@ -2871,8 +2815,7 @@ TEST_F(LocalEnforcerTest, test_pipelined_lte_setup) {
   static_rule->set_rule_id("rule2");
 
   default_cfg_1.common_context.set_ue_ipv6(IPv6_1);
-  local_enforcer->init_session(
-      session_map, IMSI1, SESSION_ID_1, default_cfg_1, response);
+  initialize_session(session_map, SESSION_ID_1, default_cfg_1, response);
   local_enforcer->update_tunnel_ids(
       session_map,
       create_update_tunnel_ids_request(IMSI1, BEARER_ID_1, teids1));
@@ -2889,8 +2832,7 @@ TEST_F(LocalEnforcerTest, test_pipelined_lte_setup) {
   default_cfg_2.common_context.mutable_teids()->CopyFrom(teids2);
   default_cfg_2.rat_specific_context.mutable_lte_context()->set_bearer_id(
       BEARER_ID_2);
-  local_enforcer->init_session(
-      session_map, IMSI2, SESSION_ID_2, default_cfg_2, response2);
+  initialize_session(session_map, SESSION_ID_2, default_cfg_2, response2);
   local_enforcer->update_tunnel_ids(
       session_map,
       create_update_tunnel_ids_request(IMSI2, BEARER_ID_2, teids2));
@@ -2938,8 +2880,7 @@ TEST_F(LocalEnforcerTest, test_valid_apn_parsing) {
   test_cwf_cfg.common_context.set_rat_type(TGPP_WLAN);
   test_cwf_cfg.rat_specific_context.mutable_wlan_context()->CopyFrom(wlan);
 
-  local_enforcer->init_session(
-      session_map, IMSI1, SESSION_ID_1, test_cwf_cfg, response);
+  initialize_session(session_map, SESSION_ID_1, test_cwf_cfg, response);
   local_enforcer->update_tunnel_ids(
       session_map, create_update_tunnel_ids_request(IMSI1, 0, teids0));
 
@@ -2977,8 +2918,7 @@ TEST_F(LocalEnforcerTest, test_invalid_apn_parsing) {
   test_cwf_cfg.common_context.set_rat_type(TGPP_WLAN);
   test_cwf_cfg.rat_specific_context.mutable_wlan_context()->CopyFrom(wlan);
 
-  local_enforcer->init_session(
-      session_map, IMSI1, SESSION_ID_1, test_cwf_cfg, response);
+  initialize_session(session_map, SESSION_ID_1, test_cwf_cfg, response);
   local_enforcer->update_tunnel_ids(
       session_map,
       create_update_tunnel_ids_request(IMSI1, BEARER_ID_1, teids1));
@@ -3021,8 +2961,7 @@ TEST_F(LocalEnforcerTest, test_final_unit_redirect_activation_and_termination) {
                              test_cfg_.common_context.msisdn(), testing::_,
                              CheckRuleCount(1), testing::_))
       .Times(1);
-  local_enforcer->init_session(
-      session_map, IMSI1, SESSION_ID_1, test_cfg_, response);
+  initialize_session(session_map, SESSION_ID_1, test_cfg_, response);
   local_enforcer->update_tunnel_ids(
       session_map,
       create_update_tunnel_ids_request(IMSI1, BEARER_ID_1, teids1));
@@ -3098,8 +3037,7 @@ TEST_F(LocalEnforcerTest, test_final_unit_activation_and_canceling) {
                              msisdn, testing::_, CheckRuleCount(3), testing::_))
       .Times(1);
 
-  local_enforcer->init_session(
-      session_map, IMSI1, SESSION_ID_1, default_cfg_1, response);
+  initialize_session(session_map, SESSION_ID_1, default_cfg_1, response);
   local_enforcer->update_tunnel_ids(
       session_map,
       create_update_tunnel_ids_request(IMSI1, BEARER_ID_1, teids1));
@@ -3204,8 +3142,7 @@ TEST_F(LocalEnforcerTest, test_final_unit_action_no_update) {
                              msisdn, testing::_, CheckRuleCount(1), testing::_))
       .Times(1);
 
-  local_enforcer->init_session(
-      session_map, IMSI1, SESSION_ID_1, test_cfg_, response);
+  initialize_session(session_map, SESSION_ID_1, test_cfg_, response);
   local_enforcer->update_tunnel_ids(
       session_map,
       create_update_tunnel_ids_request(IMSI1, BEARER_ID_1, teids1));
@@ -3279,8 +3216,7 @@ TEST_F(LocalEnforcerTest, test_rar_dynamic_rule_modification) {
                              CheckRuleCount(1), testing::_))
       .Times(1);
 
-  local_enforcer->init_session(
-      session_map, IMSI1, SESSION_ID_1, test_cfg_, response);
+  initialize_session(session_map, SESSION_ID_1, test_cfg_, response);
   local_enforcer->update_tunnel_ids(
       session_map,
       create_update_tunnel_ids_request(IMSI1, BEARER_ID_1, teids1));
@@ -3363,8 +3299,7 @@ TEST_F(
   create_credit_update_response_with_error(
       IMSI1, SESSION_ID_1, 1, false, DIAMETER_CREDIT_LIMIT_REACHED,
       ChargingCredit_FinalAction_REDIRECT, "12.7.7.4", "", credits->Add());
-  local_enforcer->init_session(
-      session_map, IMSI1, SESSION_ID_1, test_cfg_, response);
+  initialize_session(session_map, SESSION_ID_1, test_cfg_, response);
   local_enforcer->update_tunnel_ids(
       session_map,
       create_update_tunnel_ids_request(IMSI1, BEARER_ID_1, teids1));
@@ -3439,8 +3374,7 @@ TEST_F(
   create_credit_update_response_with_error(
       IMSI1, SESSION_ID_1, 1, false, DIAMETER_CREDIT_LIMIT_REACHED,
       ChargingCredit_FinalAction_REDIRECT, "12.7.7.4", "", credits->Add());
-  local_enforcer->init_session(
-      session_map, IMSI1, SESSION_ID_1, test_cfg_, response);
+  initialize_session(session_map, SESSION_ID_1, test_cfg_, response);
   local_enforcer->update_tunnel_ids(
       session_map,
       create_update_tunnel_ids_request(IMSI1, BEARER_ID_1, teids1));
@@ -3516,8 +3450,7 @@ TEST_F(LocalEnforcerTest, test_receiving_stats_for_subset_of_rules) {
       IMSI1, SESSION_ID_1, 1, false, DIAMETER_CREDIT_LIMIT_REACHED,
       ChargingCredit_FinalAction_REDIRECT, "12.7.7.4", "",
       response.mutable_credits()->Add());
-  local_enforcer->init_session(
-      session_map, IMSI1, SESSION_ID_1, test_cfg_, response);
+  initialize_session(session_map, SESSION_ID_1, default_cfg_1, response);
   local_enforcer->update_tunnel_ids(
       session_map,
       create_update_tunnel_ids_request(IMSI1, BEARER_ID_1, teids1));

--- a/lte/gateway/c/session_manager/test/test_local_enforcer.cpp
+++ b/lte/gateway/c/session_manager/test/test_local_enforcer.cpp
@@ -181,7 +181,7 @@ class LocalEnforcerTest : public ::testing::Test {
       const SessionConfig& cfg, const CreateSessionResponse& response) {
     const std::string imsi = cfg.get_imsi();
     auto session = local_enforcer->create_initializing_session(session_id, cfg);
-    local_enforcer->init_session_with_policy_response(
+    local_enforcer->update_session_with_policy_response(
         session, response, nullptr);
     session_map[imsi].push_back(std::move(session));
   }
@@ -1117,8 +1117,10 @@ TEST_F(LocalEnforcerTest, test_sync_sessions_on_restart_revalidation_timer) {
   create_credit_update_response(
       IMSI1, SESSION_ID_1, 1, 1024, true, response.mutable_credits()->Add());
   auto session_state = std::make_unique<SessionState>(
-      IMSI1, SESSION_ID_1, default_cfg_1, *rule_store, tgpp_ctx, pdp_start_time,
-      response);
+      SESSION_ID_1, default_cfg_1, *rule_store, pdp_start_time);
+  session_state->set_tgpp_context(tgpp_ctx, nullptr);
+  session_state->set_fsm_state(SESSION_ACTIVE, nullptr);
+  session_state->set_create_session_response(CreateSessionResponse(), nullptr);
 
   // manually place revalidation timer
   SessionStateUpdateCriteria uc;

--- a/lte/gateway/c/session_manager/test/test_local_enforcer.cpp
+++ b/lte/gateway/c/session_manager/test/test_local_enforcer.cpp
@@ -3494,7 +3494,7 @@ TEST_F(LocalEnforcerTest, test_receiving_stats_for_subset_of_rules) {
   EXPECT_EQ(1, session_map[IMSI1][0]->get_current_rule_version("rule1"));
   EXPECT_EQ(1, session_map[IMSI1][0]->get_current_rule_version("rule2"));
 }
-
+/**
 TEST_F(LocalEnforcerTest, test_sharding_of_sessions) {
   // create 501 UEs and check whether they are sharded in to
   // six, add random amounts of sessions between 1 and 4
@@ -3517,7 +3517,7 @@ TEST_F(LocalEnforcerTest, test_sharding_of_sessions) {
       sessionStream << imsi_id << "-" << std::to_string(i + 1);
       std::string session_id = sessionStream.str();
       sessionStream.clear();
-      local_enforcer->init_session(
+      local_enforcer->init_session_with_policy_response(
           session_map, imsi_id, session_id, test_cfg_, response);
       std::cout << "Updating tunnel id" << std::endl;
       local_enforcer->update_tunnel_ids(
@@ -3545,7 +3545,7 @@ TEST_F(LocalEnforcerTest, test_sharding_of_sessions) {
     }
   }
 }
-
+**/
 int main(int argc, char** argv) {
   ::testing::InitGoogleTest(&argc, argv);
   FLAGS_logtostderr = 1;

--- a/lte/gateway/c/session_manager/test/test_local_enforcer.cpp
+++ b/lte/gateway/c/session_manager/test/test_local_enforcer.cpp
@@ -3496,7 +3496,7 @@ TEST_F(LocalEnforcerTest, test_receiving_stats_for_subset_of_rules) {
   EXPECT_EQ(1, session_map[IMSI1][0]->get_current_rule_version("rule1"));
   EXPECT_EQ(1, session_map[IMSI1][0]->get_current_rule_version("rule2"));
 }
-/**
+
 TEST_F(LocalEnforcerTest, test_sharding_of_sessions) {
   // create 501 UEs and check whether they are sharded in to
   // six, add random amounts of sessions between 1 and 4
@@ -3519,8 +3519,8 @@ TEST_F(LocalEnforcerTest, test_sharding_of_sessions) {
       sessionStream << imsi_id << "-" << std::to_string(i + 1);
       std::string session_id = sessionStream.str();
       sessionStream.clear();
-      local_enforcer->init_session_with_policy_response(
-          session_map, imsi_id, session_id, test_cfg_, response);
+      auto cfg = get_default_config(imsi_id);
+      initialize_session(session_map, session_id, cfg, response);
       std::cout << "Updating tunnel id" << std::endl;
       local_enforcer->update_tunnel_ids(
           session_map, create_update_tunnel_ids_request(imsi_id, 0, teids0));
@@ -3547,7 +3547,7 @@ TEST_F(LocalEnforcerTest, test_sharding_of_sessions) {
     }
   }
 }
-**/
+
 int main(int argc, char** argv) {
   ::testing::InitGoogleTest(&argc, argv);
   FLAGS_logtostderr = 1;

--- a/lte/gateway/c/session_manager/test/test_local_enforcer_wallet_exhaust.cpp
+++ b/lte/gateway/c/session_manager/test/test_local_enforcer_wallet_exhaust.cpp
@@ -90,6 +90,16 @@ class LocalEnforcerTest : public ::testing::Test {
     rule_store->insert_rule(create_policy_rule(rule_id, m_key, rating_group));
   }
 
+  void initialize_session(
+      SessionMap& session_map, const std::string& session_id,
+      const SessionConfig& cfg, const CreateSessionResponse& response) {
+    const std::string imsi = cfg.get_imsi();
+    auto session = local_enforcer->create_initializing_session(session_id, cfg);
+    local_enforcer->init_session_with_policy_response(
+        session, response, nullptr);
+    session_map[imsi].push_back(std::move(session));
+  }
+
  protected:
   std::shared_ptr<MockSessionReporter> reporter;
   std::shared_ptr<StaticRuleStore> rule_store;
@@ -122,8 +132,7 @@ TEST_F(LocalEnforcerTest, test_termination_scheduling_on_sync_sessions) {
       *pipelined_client,
       update_subscriber_quota_state(
           CheckSubscriberQuotaUpdate(SubscriberQuotaUpdate_Type_VALID_QUOTA)));
-  local_enforcer->init_session(
-      session_map, IMSI1, SESSION_ID_1, cwf_session_config, response);
+  initialize_session(session_map, SESSION_ID_1, cwf_session_config, response);
   local_enforcer->update_tunnel_ids(
       session_map, create_update_tunnel_ids_request(IMSI1, 0, teids0));
 
@@ -189,8 +198,7 @@ TEST_F(LocalEnforcerTest, test_cwf_quota_exhaustion_on_init_has_quota) {
       update_subscriber_quota_state(
           CheckSubscriberQuotaUpdate(SubscriberQuotaUpdate_Type_VALID_QUOTA)))
       .Times(1);
-  local_enforcer->init_session(
-      session_map, IMSI1, SESSION_ID_1, cwf_session_config, response);
+  initialize_session(session_map, SESSION_ID_1, cwf_session_config, response);
   local_enforcer->update_tunnel_ids(
       session_map, create_update_tunnel_ids_request(IMSI1, 0, teids0));
 }
@@ -211,8 +219,7 @@ TEST_F(LocalEnforcerTest, test_cwf_quota_exhaustion_on_init_no_quota) {
       update_subscriber_quota_state(
           CheckSubscriberQuotaUpdate(SubscriberQuotaUpdate_Type_NO_QUOTA)))
       .Times(1);
-  local_enforcer->init_session(
-      session_map, IMSI1, SESSION_ID_1, cwf_session_config, response);
+  initialize_session(session_map, SESSION_ID_1, cwf_session_config, response);
   local_enforcer->update_tunnel_ids(
       session_map, create_update_tunnel_ids_request(IMSI1, 0, teids0));
 }
@@ -226,8 +233,7 @@ TEST_F(LocalEnforcerTest, test_cwf_quota_exhaustion_on_rar) {
   CreateSessionResponse response;
   create_session_create_response(
       IMSI1, SESSION_ID_1, "m1", static_rules, &response);
-  local_enforcer->init_session(
-      session_map, IMSI1, SESSION_ID_1, cwf_session_config, response);
+  initialize_session(session_map, SESSION_ID_1, cwf_session_config, response);
   local_enforcer->update_tunnel_ids(
       session_map, create_update_tunnel_ids_request(IMSI1, 0, teids0));
 
@@ -261,8 +267,7 @@ TEST_F(LocalEnforcerTest, test_cwf_quota_exhaustion_on_update) {
   CreateSessionResponse response;
   create_session_create_response(
       IMSI1, SESSION_ID_1, "m1", static_rules, &response);
-  local_enforcer->init_session(
-      session_map, IMSI1, SESSION_ID_1, cwf_session_config, response);
+  initialize_session(session_map, SESSION_ID_1, cwf_session_config, response);
   local_enforcer->update_tunnel_ids(
       session_map, create_update_tunnel_ids_request(IMSI1, 0, teids0));
 

--- a/lte/gateway/c/session_manager/test/test_local_enforcer_wallet_exhaust.cpp
+++ b/lte/gateway/c/session_manager/test/test_local_enforcer_wallet_exhaust.cpp
@@ -95,7 +95,7 @@ class LocalEnforcerTest : public ::testing::Test {
       const SessionConfig& cfg, const CreateSessionResponse& response) {
     const std::string imsi = cfg.get_imsi();
     auto session = local_enforcer->create_initializing_session(session_id, cfg);
-    local_enforcer->init_session_with_policy_response(
+    local_enforcer->update_session_with_policy_response(
         session, response, nullptr);
     session_map[imsi].push_back(std::move(session));
   }

--- a/lte/gateway/c/session_manager/test/test_polling_pipelined.cpp
+++ b/lte/gateway/c/session_manager/test/test_polling_pipelined.cpp
@@ -78,6 +78,16 @@ class LocalEnforcerStatsPollerTest : public ::testing::Test {
     rule_store->insert_rule(create_policy_rule(rule_id, m_key, rating_group));
   }
 
+  void initialize_session(
+      SessionMap& session_map, const std::string& session_id,
+      const SessionConfig& cfg, const CreateSessionResponse& response) {
+    const std::string imsi = cfg.get_imsi();
+    auto session = local_enforcer->create_initializing_session(session_id, cfg);
+    local_enforcer->update_session_with_policy_response(
+        session, response, nullptr);
+    session_map[imsi].push_back(std::move(session));
+  }
+
  protected:
   std::shared_ptr<MockSessionReporter> reporter;
   std::shared_ptr<StaticRuleStore> rule_store;
@@ -91,7 +101,7 @@ class LocalEnforcerStatsPollerTest : public ::testing::Test {
   SessionMap session_map;
   SessionConfig test_cfg_;
 };
-/**
+
 TEST_F(LocalEnforcerStatsPollerTest, test_poll_stats) {
   // insert some rules to retrieve
   insert_static_rule(1, "", "rule1");
@@ -100,8 +110,8 @@ TEST_F(LocalEnforcerStatsPollerTest, test_poll_stats) {
   insert_static_rule(1, "", "rule4");
 
   CreateSessionResponse response;
-  local_enforcer->init_session_with_policy_response(
-      session_map, IMSI1, SESSION_ID_1, get_default_config(IMSI1), response);
+  initialize_session(
+      session_map, SESSION_ID_1, get_default_config(IMSI1), response);
   local_enforcer->update_tunnel_ids(
       session_map,
       create_update_tunnel_ids_request(IMSI1, BEARER_ID_1, teids1));
@@ -136,7 +146,7 @@ TEST_F(LocalEnforcerStatsPollerTest, test_poll_stats) {
       .Times(1);
   local_enforcer->poll_stats_enforcer(cookie, cookie_mask);
 }
-**/
+
 int main(int argc, char** argv) {
   ::testing::InitGoogleTest(&argc, argv);
   FLAGS_logtostderr = 1;

--- a/lte/gateway/c/session_manager/test/test_polling_pipelined.cpp
+++ b/lte/gateway/c/session_manager/test/test_polling_pipelined.cpp
@@ -91,7 +91,7 @@ class LocalEnforcerStatsPollerTest : public ::testing::Test {
   SessionMap session_map;
   SessionConfig test_cfg_;
 };
-
+/**
 TEST_F(LocalEnforcerStatsPollerTest, test_poll_stats) {
   // insert some rules to retrieve
   insert_static_rule(1, "", "rule1");
@@ -100,7 +100,7 @@ TEST_F(LocalEnforcerStatsPollerTest, test_poll_stats) {
   insert_static_rule(1, "", "rule4");
 
   CreateSessionResponse response;
-  local_enforcer->init_session(
+  local_enforcer->init_session_with_policy_response(
       session_map, IMSI1, SESSION_ID_1, get_default_config(IMSI1), response);
   local_enforcer->update_tunnel_ids(
       session_map,
@@ -136,7 +136,7 @@ TEST_F(LocalEnforcerStatsPollerTest, test_poll_stats) {
       .Times(1);
   local_enforcer->poll_stats_enforcer(cookie, cookie_mask);
 }
-
+**/
 int main(int argc, char** argv) {
   ::testing::InitGoogleTest(&argc, argv);
   FLAGS_logtostderr = 1;

--- a/lte/gateway/c/session_manager/test/test_proxy_responder_handler.cpp
+++ b/lte/gateway/c/session_manager/test/test_proxy_responder_handler.cpp
@@ -85,9 +85,12 @@ class SessionProxyResponderHandlerTest : public ::testing::Test {
     cfg.rat_specific_context.mutable_wlan_context()->CopyFrom(wlan);
     auto tgpp_context   = TgppContext{};
     auto pdp_start_time = 12345;
-    return std::make_unique<SessionState>(
-        IMSI1, SESSION_ID_1, cfg, *rule_store, tgpp_context, pdp_start_time,
-        CreateSessionResponse{});
+    auto session        = std::make_unique<SessionState>(
+        SESSION_ID_1, cfg, *rule_store, pdp_start_time);
+    session->set_tgpp_context(tgpp_context, nullptr);
+    session->set_fsm_state(SESSION_ACTIVE, nullptr);
+    session->set_create_session_response(CreateSessionResponse(), nullptr);
+    return session;
   }
 
   UsageMonitoringUpdateResponse get_monitoring_update() {

--- a/lte/gateway/c/session_manager/test/test_session_manager_handler.cpp
+++ b/lte/gateway/c/session_manager/test/test_session_manager_handler.cpp
@@ -129,7 +129,7 @@ class SessionManagerHandlerTest : public ::testing::Test {
       const SessionConfig& cfg, const CreateSessionResponse& response) {
     const std::string imsi = cfg.get_imsi();
     auto session = local_enforcer->create_initializing_session(session_id, cfg);
-    local_enforcer->init_session_with_policy_response(
+    local_enforcer->update_session_with_policy_response(
         session, response, nullptr);
     session_map[imsi].push_back(std::move(session));
   }
@@ -341,9 +341,9 @@ TEST_F(SessionManagerHandlerTest, test_create_session) {
   create_response.mutable_static_rules()->Add()->mutable_rule_id()->assign(
       "rule3");
   create_credit_update_response(
-      IMSI1, "1234", 1, 1536, create_response.mutable_credits()->Add());
+      IMSI1, SESSION_ID_1, 1, 1536, create_response.mutable_credits()->Add());
   create_credit_update_response(
-      IMSI1, "1234", 2, 1024, create_response.mutable_credits()->Add());
+      IMSI1, SESSION_ID_1, 2, 1024, create_response.mutable_credits()->Add());
 
   // create expected request for report_create_session call
   RequestedUnits expected_requestedUnits;

--- a/lte/gateway/c/session_manager/test/test_session_manager_handler.cpp
+++ b/lte/gateway/c/session_manager/test/test_session_manager_handler.cpp
@@ -124,6 +124,16 @@ class SessionManagerHandlerTest : public ::testing::Test {
     evb->loopOnce();
   }
 
+  void initialize_session(
+      SessionMap& session_map, const std::string& session_id,
+      const SessionConfig& cfg, const CreateSessionResponse& response) {
+    const std::string imsi = cfg.get_imsi();
+    auto session = local_enforcer->create_initializing_session(session_id, cfg);
+    local_enforcer->init_session_with_policy_response(
+        session, response, nullptr);
+    session_map[imsi].push_back(std::move(session));
+  }
+
  protected:
   std::string monitoring_key;
 
@@ -166,7 +176,7 @@ TEST_F(SessionManagerHandlerTest, test_create_session_cfg) {
       IMSI1, SESSION_ID_1, 1, 1536, response.mutable_credits()->Add());
 
   auto session_map = session_store->read_sessions({IMSI1});
-  local_enforcer->init_session(session_map, IMSI1, SESSION_ID_1, cfg, response);
+  initialize_session(session_map, SESSION_ID_1, cfg, response);
   local_enforcer->update_tunnel_ids(
       session_map,
       create_update_tunnel_ids_request(IMSI1, BEARER_ID_1, teids0));
@@ -237,7 +247,7 @@ TEST_F(SessionManagerHandlerTest, test_session_recycling_lte) {
 
   auto session_map = session_store->read_sessions({IMSI1});
 
-  local_enforcer->init_session(session_map, IMSI1, sid, cfg, response);
+  initialize_session(session_map, SESSION_ID_1, cfg, response);
   local_enforcer->update_tunnel_ids(
       session_map,
       create_update_tunnel_ids_request(IMSI1, BEARER_ID_1, teids1));
@@ -412,7 +422,7 @@ TEST_F(SessionManagerHandlerTest, test_report_rule_stats) {
       session_created(IMSI1, SESSION_ID_1, testing::_, testing::_))
       .Times(1);
 
-  local_enforcer->init_session(session_map, IMSI1, SESSION_ID_1, cfg, response);
+  initialize_session(session_map, SESSION_ID_1, cfg, response);
   local_enforcer->update_tunnel_ids(
       session_map,
       create_update_tunnel_ids_request(IMSI1, BEARER_ID_1, teids0));
@@ -463,7 +473,7 @@ TEST_F(SessionManagerHandlerTest, test_end_session) {
 
   auto session_map = session_store->read_sessions({IMSI1});
 
-  local_enforcer->init_session(session_map, IMSI1, SESSION_ID_1, cfg, response);
+  initialize_session(session_map, SESSION_ID_1, cfg, response);
   local_enforcer->update_tunnel_ids(
       session_map, create_update_tunnel_ids_request(IMSI1, 0, teids0));
 

--- a/lte/gateway/c/session_manager/test/test_session_store.cpp
+++ b/lte/gateway/c/session_manager/test/test_session_store.cpp
@@ -81,9 +81,12 @@ class SessionStoreTest : public ::testing::Test {
     cfg.rat_specific_context.mutable_wlan_context()->CopyFrom(wlan_context);
     auto tgpp_context   = TgppContext{};
     auto pdp_start_time = 12345;
-    return std::make_unique<SessionState>(
-        imsi, session_id, cfg, *rule_store, tgpp_context, pdp_start_time,
-        response1);
+    auto session        = std::make_unique<SessionState>(
+        session_id, cfg, *rule_store, pdp_start_time);
+    session->set_tgpp_context(tgpp_context, nullptr);
+    session->set_fsm_state(SESSION_ACTIVE, nullptr);
+    session->set_create_session_response(response1, nullptr);
+    return session;
   }
 
   std::unique_ptr<SessionState> get_lte_session(
@@ -108,9 +111,12 @@ class SessionStoreTest : public ::testing::Test {
     cfg.rat_specific_context.mutable_lte_context()->CopyFrom(lte_context);
     auto tgpp_context   = TgppContext{};
     auto pdp_start_time = 12345;
-    return std::make_unique<SessionState>(
-        imsi, session_id, cfg, *rule_store, tgpp_context, pdp_start_time,
-        response1);
+    auto session        = std::make_unique<SessionState>(
+        session_id, cfg, *rule_store, pdp_start_time);
+    session->set_tgpp_context(tgpp_context, nullptr);
+    session->set_fsm_state(SESSION_ACTIVE, nullptr);
+    session->set_create_session_response(response1, nullptr);
+    return session;
   }
   UsageMonitoringUpdateResponse get_monitoring_update() {
     UsageMonitoringUpdateResponse response;

--- a/lte/gateway/c/session_manager/test/test_store_client.cpp
+++ b/lte/gateway/c/session_manager/test/test_store_client.cpp
@@ -44,73 +44,77 @@ class StoreClientTest : public ::testing::Test {
  */
 TEST_F(StoreClientTest, test_read_and_write) {
   std::string hardware_addr_bytes = {0x0f, 0x10, 0x2e, 0x12, 0x3a, 0x55};
-  std::string imsi                = "IMSI1";
-  std::string imsi2               = "IMSI2";
-  std::string imsi3               = "IMSI3";
-  std::string msisdn              = "5100001234";
-  std::string radius_session_id =
-      "AA-AA-AA-AA-AA-AA:TESTAP__"
-      "0F-10-2E-12-3A-55";
-  auto sid  = id_gen_.gen_session_id(imsi);
-  auto sid2 = id_gen_.gen_session_id(imsi2);
-  auto sid3 = id_gen_.gen_session_id(imsi3);
+  SessionConfig cfg1, cfg2, cfg3;
   Teids teids;
   teids.set_agw_teid(1);
   teids.set_enb_teid(2);
-  SessionConfig cfg;
-  cfg.common_context = build_common_context(
-      "", "128.0.0.1", "2001:0db8:0a0b:12f0:0000:0000:0000:0001", teids, "APN",
-      msisdn, TGPP_WLAN);
-  const auto& wlan = build_wlan_context("0f:10:2e:12:3a:55", radius_session_id);
-  cfg.rat_specific_context.mutable_wlan_context()->CopyFrom(wlan);
+  cfg1.common_context =
+      build_common_context(IMSI1, IP1, IPv6_1, teids, APN1, MSISDN, TGPP_WLAN);
+  cfg2.common_context =
+      build_common_context(IMSI2, IP1, IPv6_1, teids, APN1, MSISDN, TGPP_WLAN);
+  cfg3.common_context =
+      build_common_context(IMSI3, IP1, IPv6_1, teids, APN1, MSISDN, TGPP_WLAN);
+  const auto& wlan = build_wlan_context("0f:10:2e:12:3a:55", RADIUS_SESSION_ID);
+  cfg1.rat_specific_context.mutable_wlan_context()->CopyFrom(wlan);
+  cfg2.rat_specific_context.mutable_wlan_context()->CopyFrom(wlan);
+  cfg3.rat_specific_context.mutable_wlan_context()->CopyFrom(wlan);
+
+  CreateSessionResponse response1, response2, response3;
+  create_credit_update_response(
+      IMSI1, SESSION_ID_1, 1, 1000, response1.mutable_credits()->Add());
+  create_credit_update_response(
+      IMSI2, SESSION_ID_2, 2, 2000, response2.mutable_credits()->Add());
+  create_credit_update_response(
+      IMSI3, SESSION_ID_3, 3, 3000, response3.mutable_credits()->Add());
+
+  // Emulate CreateSession, which needs to create a new session for a
+  // subscriber
+  std::set<std::string> requested_ids{IMSI1, IMSI2};
   auto rule_store     = std::make_shared<StaticRuleStore>();
   auto tgpp_context   = TgppContext{};
   auto pdp_start_time = 12345;
 
   auto store_client = MemoryStoreClient(rule_store);
-
-  // Emulate CreateSession, which needs to create a new session for a subscriber
-  std::set<std::string> requested_ids{imsi, imsi2};
-  auto session_map = store_client.read_sessions(requested_ids);
+  auto session_map  = store_client.read_sessions(requested_ids);
 
   auto uc = get_default_update_criteria();
 
-  CreateSessionResponse response1;
-  auto credits = response1.mutable_credits();
-  create_credit_update_response(imsi, sid, 1, 1000, credits->Add());
-  auto session = std::make_unique<SessionState>(
-      imsi, sid, cfg, *rule_store, tgpp_context, pdp_start_time, response1);
+  auto session1 = std::make_unique<SessionState>(
+      SESSION_ID_1, cfg1, *rule_store, pdp_start_time);
+  session1->set_tgpp_context(tgpp_context, nullptr);
+  session1->set_fsm_state(SESSION_ACTIVE, nullptr);
+  session1->set_create_session_response(response1, nullptr);
 
-  CreateSessionResponse response2;
-  credits = response2.mutable_credits();
-  create_credit_update_response(imsi2, sid2, 2, 2000, credits->Add());
   auto session2 = std::make_unique<SessionState>(
-      imsi2, sid2, cfg, *rule_store, tgpp_context, pdp_start_time, response2);
+      SESSION_ID_2, cfg2, *rule_store, pdp_start_time);
+  session2->set_tgpp_context(tgpp_context, nullptr);
+  session2->set_fsm_state(SESSION_ACTIVE, nullptr);
+  session2->set_create_session_response(response2, nullptr);
 
-  CreateSessionResponse response3;
-  credits = response3.mutable_credits();
-  create_credit_update_response(imsi3, sid3, 3, 3000, credits->Add());
   auto session3 = std::make_unique<SessionState>(
-      imsi3, sid3, cfg, *rule_store, tgpp_context, pdp_start_time, response3);
+      SESSION_ID_3, cfg3, *rule_store, pdp_start_time);
+  session3->set_tgpp_context(tgpp_context, nullptr);
+  session3->set_fsm_state(SESSION_ACTIVE, nullptr);
+  session3->set_create_session_response(response3, nullptr);
 
-  EXPECT_EQ(session->get_session_id(), sid);
-  EXPECT_EQ(session2->get_session_id(), sid2);
+  EXPECT_EQ(session1->get_session_id(), SESSION_ID_1);
+  EXPECT_EQ(session2->get_session_id(), SESSION_ID_2);
 
   RuleLifetime lifetime{};
-  session->activate_static_rule("rule1", lifetime, &uc);
-  EXPECT_EQ(session->is_static_rule_installed("rule1"), true);
+  session1->activate_static_rule("rule1", lifetime, &uc);
+  EXPECT_EQ(session1->is_static_rule_installed("rule1"), true);
 
   EXPECT_EQ(session_map.size(), 2);
-  EXPECT_EQ(session_map[imsi].size(), 0);
-  session_map[imsi].push_back(std::move(session));
-  EXPECT_EQ(session_map[imsi].size(), 1);
+  EXPECT_EQ(session_map[IMSI1].size(), 0);
+  session_map[IMSI1].push_back(std::move(session1));
+  EXPECT_EQ(session_map[IMSI1].size(), 1);
 
   // Since the grant was not given with R/W permission for subscriber IMSI2,
   // The session for IMSI2 should not be saved into the store
-  session_map[imsi2] = SessionVector();
-  session_map[imsi2].push_back(std::move(session2));
+  session_map[IMSI2] = SessionVector();
+  session_map[IMSI2].push_back(std::move(session2));
   EXPECT_EQ(session_map.size(), 2);
-  EXPECT_EQ(session_map[imsi2].size(), 1);
+  EXPECT_EQ(session_map[IMSI2].size(), 1);
 
   // And now commit back to storage (memory actually, but later persistent)
   store_client.write_sessions(std::move(session_map));
@@ -118,32 +122,32 @@ TEST_F(StoreClientTest, test_read_and_write) {
   // Try to do a read to make sure that things are the same
   auto session_map_2 = store_client.read_sessions(requested_ids);
   EXPECT_EQ(session_map_2.size(), 2);
-  EXPECT_EQ(session_map_2[imsi].size(), 1);
-  EXPECT_EQ(session_map_2[imsi].front()->get_session_id(), sid);
+  EXPECT_EQ(session_map_2[IMSI1].size(), 1);
+  EXPECT_EQ(session_map_2[IMSI1].front()->get_session_id(), SESSION_ID_1);
   EXPECT_EQ(
-      session_map_2[imsi].front()->is_static_rule_installed("rule1"), true);
-  EXPECT_EQ(session_map_2[imsi].front()->get_config(), cfg);
+      session_map_2[IMSI1].front()->is_static_rule_installed("rule1"), true);
+  EXPECT_EQ(session_map_2[IMSI1].front()->get_config(), cfg1);
   EXPECT_EQ(
-      session_map_2[imsi].front()->get_create_session_response().DebugString(),
+      session_map_2[IMSI1].front()->get_create_session_response().DebugString(),
       response1.DebugString());
 
   // Now create a third session
-  std::set<std::string> requested_imsi3{imsi3};
+  std::set<std::string> requested_imsi3{IMSI3};
   auto session_map_3 = store_client.read_sessions(requested_imsi3);
   EXPECT_EQ(session_map_3.size(), 1);
-  session_map_3[imsi3].push_back(std::move(session3));
-  EXPECT_EQ(session_map_3[imsi3].size(), 1);
+  session_map_3[IMSI3].push_back(std::move(session3));
+  EXPECT_EQ(session_map_3[IMSI3].size(), 1);
   store_client.write_sessions(std::move(session_map_3));
 
   // Get all sessions
   auto all_sessions = store_client.read_all_sessions();
   EXPECT_EQ(all_sessions.size(), 3);
-  EXPECT_EQ(all_sessions[imsi].size(), 1);
-  EXPECT_EQ(all_sessions[imsi].front()->get_session_id(), sid);
-  EXPECT_EQ(all_sessions[imsi3].size(), 1);
-  EXPECT_EQ(all_sessions[imsi3].front()->get_session_id(), sid3);
+  EXPECT_EQ(all_sessions[IMSI1].size(), 1);
+  EXPECT_EQ(all_sessions[IMSI1].front()->get_session_id(), SESSION_ID_1);
+  EXPECT_EQ(all_sessions[IMSI3].size(), 1);
+  EXPECT_EQ(all_sessions[IMSI3].front()->get_session_id(), SESSION_ID_3);
   EXPECT_EQ(
-      all_sessions[imsi3].front()->get_create_session_response().DebugString(),
+      all_sessions[IMSI3].front()->get_create_session_response().DebugString(),
       response3.DebugString());
 }
 


### PR DESCRIPTION
<!--
    Tag your PR title with the components that it touches along with type of
    change. Checkout 'contribute_commit_msg' doc for recommended git commit
    message style.
    E.g. "fix(orc8r): Changeset" or "feat(agw) ..."
-->

## Summary
We currently have a bug where SessionD cannot handle concurrent attaches for multiple APNs of a same IMSI. (See attached issue for more info) 
This is due to SessionD holding on to the SessionMap between the time we send a CreateSessionRequest into PolicyDB / FeG and get back a response. This logic makes an assumption that the SessionMap entry for the IMSI does not change during this time. With the multi APN case, this is not a safe assumption to make. 

The solution here is to save the newly created Session BEFORE we send a CreateSessionRequest to PolicyDB / FeG. When we receive back a CreateSessionResponse, one of two things can happen:
1. Success, update the existing session (which we read from SessionStore) with the response and tgpp information.
2. Failure, remove the existing session by using the `is_session_ended` flag in SessionStateUpdateCriteria structure. This will ensure the session will be removed when the map is written back into SessionStore.

## Main Changes
1. When the Session is created (while we wait for the CreateSessionResponse), it will be in a `CREATING` state. When we receive back the response and it is successful, we transition into the `ACTIVE` state. The state here is mostly used for logging, so not much should change here.
2. Logic changes in LocalSessionManagerHandler to reflect the logic above^
3. create session response value in SessionState will now have to be updated via an update criteria. So added some logic to make that happen. (See StoredState.cpp/h and SessionState.cpp)
4. Lots of unit test changes to adapt to the new interfaces
<!-- Enumerate changes you made and why you made them -->

## Test Plan
Ran s1ap tests
Ran CWF integration tests
CI precommit checks

Ran the following on teravm
```
ng40test gxgy05_capacity_oriol.ntl
ng40test gxgy05.ntl
ng40test gxgy04.ntl
ng40test gxgy03.ntl
```
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
Signed-off-by: Marie Bremner <marwhal@fb.com>