### PR TITLE
Pull Stats Model Config

### DIFF
--- a/cwf/gateway/configs/sessiond.yml
+++ b/cwf/gateway/configs/sessiond.yml
@@ -61,3 +61,6 @@ enable_ipfix: true
 # set to a certain interval measured in seconds for which sessiond should poll pipelined
 # for relevant stats
 poll_stats_interval: 5
+
+#set to true to enable pull model for stats(polling pipelined from sessiond)
+enable_pull_stats: false

--- a/cwf/gateway/configs/sessiond.yml
+++ b/cwf/gateway/configs/sessiond.yml
@@ -62,5 +62,5 @@ enable_ipfix: true
 # for relevant stats
 poll_stats_interval: 5
 
-#set to true to enable pull model for stats(polling pipelined from sessiond)
+# set to true to enable pull model for stats(polling pipelined from sessiond)
 enable_pull_stats: false

--- a/cwf/gateway/integ_tests/sessiond.yml
+++ b/cwf/gateway/integ_tests/sessiond.yml
@@ -52,3 +52,6 @@ enable_ipfix: true
 # set to a certain interval measured in seconds for which sessiond should poll pipelined
 # for relevant stats
 poll_stats_interval: 5
+
+#set to true to enable pull model for stats(polling pipelined from sessiond)
+enable_pull_stats: false

--- a/cwf/gateway/integ_tests/sessiond.yml
+++ b/cwf/gateway/integ_tests/sessiond.yml
@@ -53,5 +53,5 @@ enable_ipfix: true
 # for relevant stats
 poll_stats_interval: 5
 
-#set to true to enable pull model for stats(polling pipelined from sessiond)
+# set to true to enable pull model for stats(polling pipelined from sessiond)
 enable_pull_stats: false

--- a/lte/gateway/c/session_manager/sessiond_main.cpp
+++ b/lte/gateway/c/session_manager/sessiond_main.cpp
@@ -334,18 +334,21 @@ int main(int argc, char* argv[]) {
 
   // Start off a thread to periodically poll stats from Pipelined
   // every fixed interval of time
-  auto periodic_stats_requester = std::make_shared<magma::StatsPoller>();
-  std::thread periodic_stats_requester_thread([&]() {
-    // random value assigned for interval period, the value will be loaded
-    // from a config field later
-    uint32_t interval = DEFAULT_POLL_INTERVAL_TIME;
-    if (config["poll_stats_interval"].IsDefined()) {
-      interval = config["poll_stats_interval"].as<uint32_t>();
-    }
-    periodic_stats_requester->start_loop(
-          local_enforcer, interval);
-    periodic_stats_requester->stop();
-  });
+
+  if (config["enable_pull_stats"].IsDefined() &&
+      config["enable_pull_stats"].as<bool>()) {
+    auto periodic_stats_requester = std::make_shared<magma::StatsPoller>();
+    std::thread periodic_stats_requester_thread([&]() {
+      // random value assigned for interval period, the value will be loaded
+      // from a config field later
+      uint32_t interval = DEFAULT_POLL_INTERVAL_TIME;
+      if (config["poll_stats_interval"].IsDefined()) {
+        interval = config["poll_stats_interval"].as<uint32_t>();
+      }
+      periodic_stats_requester->start_loop(local_enforcer, interval);
+      periodic_stats_requester->stop();
+    });
+  }
 
   // Setup threads to serve as GRPC servers for the LocalSessionManagerHandler
   // and the SessionProxyHandler (RARs)

--- a/lte/gateway/configs/sessiond.yml
+++ b/lte/gateway/configs/sessiond.yml
@@ -76,3 +76,6 @@ session_rtx_count: 3
 # set to a certain interval measured in seconds for which sessiond should poll pipelined
 # for relevant stats
 poll_stats_interval: 5
+
+#set to true to enable pull model for stats(polling pipelined from sessiond)
+enable_pull_stats: false

--- a/lte/gateway/configs/sessiond.yml
+++ b/lte/gateway/configs/sessiond.yml
@@ -77,5 +77,5 @@ session_rtx_count: 3
 # for relevant stats
 poll_stats_interval: 5
 
-#set to true to enable pull model for stats(polling pipelined from sessiond)
+# set to true to enable pull model for stats(polling pipelined from sessiond)
 enable_pull_stats: false

--- a/lte/gateway/configs/sessiond.yml_prod
+++ b/lte/gateway/configs/sessiond.yml_prod
@@ -53,5 +53,5 @@ enable_ipfix: false
 # for relevant stats
 poll_stats_interval: 5
 
-#set to true to enable pull model for stats(polling pipelined from sessiond)
+# set to true to enable pull model for stats(polling pipelined from sessiond)
 enable_pull_stats: false

--- a/lte/gateway/configs/sessiond.yml_prod
+++ b/lte/gateway/configs/sessiond.yml_prod
@@ -52,3 +52,6 @@ enable_ipfix: false
 # set to a certain interval measured in seconds for which sessiond should poll pipelined
 # for relevant stats
 poll_stats_interval: 5
+
+#set to true to enable pull model for stats(polling pipelined from sessiond)
+enable_pull_stats: false


### PR DESCRIPTION
Signed-off-by: veshkemburu <veshkemburu@fb.com>

<!--
    Tag your PR title with the components that it touches along with type of
    change. Checkout 'contribute_commit_msg' doc for recommended git commit
    message style.
    E.g. "fix(orc8r): Changeset" or "feat(agw) ..."
-->

## Summary

Easily enable/disable the pull stats model using a flag. This flag connects directly to sessiond_main which creates the threads that poll pipelined. Disabling the flag would revert to the default push model.

## Test Plan

Added config flag to sessiond.yml files
Debugged output for both models(pull and push)

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
