### PR TITLE
feat(agw): Adapt subscriberdb agw client to make SyncSubscribers calls

### DIFF
--- a/lte/gateway/python/magma/subscriberdb/client.py
+++ b/lte/gateway/python/magma/subscriberdb/client.py
@@ -13,6 +13,7 @@ limitations under the License.
 import asyncio
 import datetime
 import logging
+from collections import namedtuple
 
 import grpc
 from lte.protos.s6a_service_pb2 import DeleteSubscriberRequest
@@ -23,6 +24,7 @@ from lte.protos.subscriberdb_pb2 import (
     ListSubscribersRequest,
     LTESubscription,
     SubscriberData,
+    SyncSubscribersRequest,
 )
 from magma.common.grpc_client_manager import GRPCClientManager
 from magma.common.rpc_utils import grpc_async_wrapper
@@ -34,6 +36,11 @@ from magma.subscriberdb.metrics import (
     SUBSCRIBER_SYNC_SUCCESS_TOTAL,
 )
 from magma.subscriberdb.store.sqlite import SqliteStore
+
+CloudSubscribersInfo = namedtuple(
+    'CloudSubscribersInfo',
+    ['subscribers', 'flat_digest', 'per_sub_digests'],
+)
 
 
 class SubscriberDBCloudClient(SDWatchdogTask):
@@ -83,13 +90,18 @@ class SubscriberDBCloudClient(SDWatchdogTask):
         if in_sync:
             return
 
-        subscribers, flat_digest = await self._get_all_subscribers()
-        if subscribers is None:
+        resync = await self._sync_subscribers()
+        if not resync:
+            return
+
+        subscribers_info = await self._get_all_subscribers()
+        if subscribers_info is None:
             return
         # Process subscriber data before digest data, in case there's a gateway
         # failure between the calls
-        self._process_subscribers(subscribers)
-        self._update_flat_digest(flat_digest)
+        self._process_subscribers(subscribers_info.subscribers)
+        self._update_flat_digest(subscribers_info.flat_digest)
+        self._update_per_sub_digests(subscribers_info.per_sub_digests)
 
     async def _check_subscribers_in_sync(self) -> bool:
         """
@@ -121,10 +133,50 @@ class SubscriberDBCloudClient(SDWatchdogTask):
             return False
         return res.in_sync
 
-    async def _get_all_subscribers(self) -> (SubscriberData, Digest):
+    async def _sync_subscribers(self) -> bool:
+        """
+        Sync local subscriber data and digests with the cloud if didn't receive
+        resync signal.
+
+        Returns:
+            boolean value for whether a resync with cloud is needed
+        """
+        subscriberdb_cloud_client = self._grpc_client_manager.get_client()
+        req = SyncSubscribersRequest(
+            per_sub_digests=self._store.get_current_per_sub_digests(),
+        )
+        try:
+            res = await grpc_async_wrapper(
+                subscriberdb_cloud_client.SyncSubscribers.future(
+                    req,
+                    self.SUBSCRIBERDB_REQUEST_TIMEOUT,
+                ),
+                self._loop,
+            )
+        except grpc.RpcError as err:
+            logging.error(
+                "Sync subscribers request error! [%s] %s", err.code(),
+                err.details(),
+            )
+            return True
+
+        if not res.resync:
+            self._update_flat_digest(res.flat_digest)
+            self._update_per_sub_digests(res.per_sub_digests)
+
+            for sid in res.to_renew:
+                subscriber_data = res.to_renew[sid]
+                self._store.upsert_subscriber(subscriber_data)
+            for sid in res.deleted:
+                self._store.delete_subscriber(sid)
+
+        return res.resync
+
+    async def _get_all_subscribers(self) -> CloudSubscribersInfo:
         subscriberdb_cloud_client = self._grpc_client_manager.get_client()
         subscribers = []
         flat_digest = None
+        per_sub_digests = None
         req_page_token = ""  # noqa: S105
         found_empty_token = False
         sync_start = datetime.datetime.now()
@@ -147,6 +199,7 @@ class SubscriberDBCloudClient(SDWatchdogTask):
                 # Cloud sends back digests during request for the first page
                 if req_page_token == "":
                     flat_digest = res.flat_digest
+                    per_sub_digests = res.per_sub_digests
 
                 req_page_token = res.next_page_token
                 found_empty_token = req_page_token == ""
@@ -161,7 +214,7 @@ class SubscriberDBCloudClient(SDWatchdogTask):
                     time_elapsed.total_seconds() * 1000,
                 )
                 SUBSCRIBER_SYNC_FAILURE_TOTAL.inc()
-                return None, None
+                return None
         logging.info(
             "Successfully fetched all subscriber "
             "pages from the cloud!",
@@ -172,12 +225,21 @@ class SubscriberDBCloudClient(SDWatchdogTask):
             time_elapsed.total_seconds() * 1000,
         )
 
-        return subscribers, flat_digest
+        return CloudSubscribersInfo(
+            subscribers=subscribers,
+            flat_digest=flat_digest,
+            per_sub_digests=per_sub_digests,
+        )
 
     def _update_flat_digest(self, flat_digest: Digest) -> None:
         if Digest is None:
             return
         self._store.update_digest(flat_digest.md5_base64_digest)
+
+    def _update_per_sub_digests(self, per_sub_digests: list) -> None:
+        if per_sub_digests is None:
+            return
+        self._store.update_per_sub_digests(per_sub_digests)
 
     def _process_subscribers(self, subscribers: SubscriberData) -> None:
         active_subscriber_ids = []

--- a/lte/gateway/python/magma/subscriberdb/store/base.py
+++ b/lte/gateway/python/magma/subscriberdb/store/base.py
@@ -109,6 +109,17 @@ class BaseStore(metaclass=abc.ABCMeta):
         raise NotImplementedError()
 
     @abc.abstractmethod
+    def upsert_subscriber(self, subscriber_data):
+        """
+        Check if the given subscriber exists in store. If so, update subscriber
+        data; otherwise, add subscriber.
+
+        Args:
+            subscriber_data: the data of the subscriber to be upserted.
+        """
+        raise NotImplementedError()
+
+    @abc.abstractmethod
     async def on_ready(self):
         """
         Awaitable interface to block until datastore is

--- a/lte/gateway/python/magma/subscriberdb/store/onready.py
+++ b/lte/gateway/python/magma/subscriberdb/store/onready.py
@@ -20,7 +20,9 @@ class OnDataReady:
     when subscribers are added to the data store. Routines can wait on
     the _ready_ event to block until a condition is met:
         1. a subscriber is added
-        2. a datastore resync is triggered
+        2. a subscriber is deleted
+        3. a subscriber is upserted
+        4. a datastore resync is triggered
     """
 
     def __init__(self, loop=None):
@@ -30,7 +32,32 @@ class OnDataReady:
     def add_subscriber(self, _):
         self.loop.call_soon_threadsafe(self.trigger_ready)
 
+    def delete_subscriber(self, _):
+        self.loop.call_soon_threadsafe(self.trigger_ready)
+
+    def upsert_subscriber(self, _):
+        self.loop.call_soon_threadsafe(self.trigger_ready)
+
     def resync(self, _):
+        self.loop.call_soon_threadsafe(self.trigger_ready)
+
+    def trigger_ready(self):
+        if not self.event.is_set():
+            self.event.set()
+
+
+class OnDigestsReady:
+    """
+    A thread-safe Event mixin interface for triggering a ready event
+    when per-subscriber digests are resynced in the store. Routines can wait on
+    the _ready_ event to block until a per-subscriber datastore update is
+    triggered.
+    """
+    def __init__(self, loop=None):
+        self.loop = loop if loop else asyncio.new_event_loop()
+        self.event = asyncio.Event(loop=self.loop)
+
+    def update_per_sub_digests(self, _):
         self.loop.call_soon_threadsafe(self.trigger_ready)
 
     def trigger_ready(self):

--- a/lte/gateway/python/magma/subscriberdb/store/onready.py
+++ b/lte/gateway/python/magma/subscriberdb/store/onready.py
@@ -53,6 +53,7 @@ class OnDigestsReady:
     the _ready_ event to block until a per-subscriber datastore update is
     triggered.
     """
+
     def __init__(self, loop=None):
         self.loop = loop if loop else asyncio.new_event_loop()
         self.event = asyncio.Event(loop=self.loop)

--- a/lte/gateway/python/magma/subscriberdb/store/onready.py
+++ b/lte/gateway/python/magma/subscriberdb/store/onready.py
@@ -50,13 +50,16 @@ class OnDigestsReady:
     """
     A thread-safe Event mixin interface for triggering a ready event
     when per-subscriber digests are resynced in the store. Routines can wait on
-    the _ready_ event to block until a per-subscriber datastore update is
-    triggered.
+    the _ready_ event to block until a flat digest or a per-subscriber digests
+    datastore update is triggered.
     """
 
     def __init__(self, loop=None):
         self.loop = loop if loop else asyncio.new_event_loop()
         self.event = asyncio.Event(loop=self.loop)
+
+    def update_digest(self, _):
+        self.loop.call_soon_threadsafe(self.trigger_ready)
 
     def update_per_sub_digests(self, _):
         self.loop.call_soon_threadsafe(self.trigger_ready)

--- a/lte/gateway/python/magma/subscriberdb/store/sqlite.py
+++ b/lte/gateway/python/magma/subscriberdb/store/sqlite.py
@@ -28,10 +28,12 @@ from magma.subscriberdb.sid import SIDUtils
 from .base import BaseStore, DuplicateSubscriberError, SubscriberNotFoundError
 from .onready import OnDataReady, OnDigestsReady
 
-
-class DigestDBInfo(NamedTuple):
-    flat_digest_db_location: str
-    per_sub_digest_db_location: str
+DigestDBInfo = NamedTuple(
+    'DigestDBInfo', [
+        ('flat_digest_db_location', str),
+        ('per_sub_digest_db_location', str),
+    ],
+)
 
 
 class SqliteStore(BaseStore):

--- a/lte/gateway/python/magma/subscriberdb/store/sqlite.py
+++ b/lte/gateway/python/magma/subscriberdb/store/sqlite.py
@@ -378,6 +378,7 @@ class SqliteStore(BaseStore):
             conn.close()
 
         logging.info("update digest stored in gateway: %s", new_digest)
+        self._on_digests_ready.update_digest(new_digest)
 
     def get_current_per_sub_digests(self) -> list:
         digests = []
@@ -385,8 +386,7 @@ class SqliteStore(BaseStore):
         try:
             with conn:
                 res = conn.execute(
-                    "SELECT sid, digest FROM per_subscriber_digest "
-                    "ORDER BY sid",
+                    "SELECT sid, digest FROM per_subscriber_digest ",
                 )
 
                 for row in res:

--- a/lte/gateway/python/magma/subscriberdb/store/sqlite.py
+++ b/lte/gateway/python/magma/subscriberdb/store/sqlite.py
@@ -17,8 +17,11 @@ from collections import defaultdict
 from contextlib import contextmanager
 from datetime import datetime
 
-from lte.protos.subscriberdb_pb2 import SubscriberData, \
-    SubscriberDigestByID, Digest
+from lte.protos.subscriberdb_pb2 import (
+    Digest,
+    SubscriberData,
+    SubscriberDigestWithID,
+)
 from magma.subscriberdb.sid import SIDUtils
 
 from .base import BaseStore, DuplicateSubscriberError, SubscriberNotFoundError
@@ -74,7 +77,7 @@ class SqliteStore(BaseStore):
                                      'per-subscriber-digest.db?cache=shared'
         logging.info(
             "per-sub digest db location: %s",
-            per_sub_digest_db_location
+            per_sub_digest_db_location,
         )
 
         return digest_db_location, per_sub_digest_db_location
@@ -383,11 +386,11 @@ class SqliteStore(BaseStore):
             with conn:
                 res = conn.execute(
                     "SELECT sid, digest FROM per_subscriber_digest "
-                    "ORDER BY sid"
+                    "ORDER BY sid",
                 )
 
                 for row in res:
-                    digest = SubscriberDigestByID(
+                    digest = SubscriberDigestWithID(
                         sid=SIDUtils.to_pb(row[0]),
                         digest=Digest(md5_base64_digest=row[1]),
                     )
@@ -402,7 +405,7 @@ class SqliteStore(BaseStore):
         try:
             with conn:
                 conn.execute(
-                    "DELETE FROM per_subscriber_digest"
+                    "DELETE FROM per_subscriber_digest",
                 )
                 for digest_by_id in new_digests:
                     sid = SIDUtils.to_str(digest_by_id.sid)

--- a/lte/gateway/python/magma/subscriberdb/store/sqlite.py
+++ b/lte/gateway/python/magma/subscriberdb/store/sqlite.py
@@ -17,11 +17,12 @@ from collections import defaultdict
 from contextlib import contextmanager
 from datetime import datetime
 
-from lte.protos.subscriberdb_pb2 import SubscriberData
+from lte.protos.subscriberdb_pb2 import SubscriberData, \
+    SubscriberDigestByID, Digest
 from magma.subscriberdb.sid import SIDUtils
 
 from .base import BaseStore, DuplicateSubscriberError, SubscriberNotFoundError
-from .onready import OnDataReady
+from .onready import OnDataReady, OnDigestsReady
 
 
 class SqliteStore(BaseStore):
@@ -35,13 +36,14 @@ class SqliteStore(BaseStore):
     def __init__(self, db_location, loop=None, sid_digits=2):
         self._sid_digits = sid_digits  # last digits to be included from subscriber id
         self._n_shards = 10**sid_digits
-        self._db_locations, self._digest_db_location = \
-            self._create_db_locations(db_location, self._n_shards)
+        self._db_locations = self._create_db_locations(db_location, self._n_shards)
+        self._digest_db_location, self._per_sub_digest_db_location = \
+            self._create_digest_db_locations(db_location)
         self._create_store()
         self._on_ready = OnDataReady(loop=loop)
+        self._on_digests_ready = OnDigestsReady(loop=loop)
 
-    def _create_db_locations(self, db_location: str, n_shards: int) \
-            -> [list, str]:
+    def _create_db_locations(self, db_location: str, n_shards: int) -> list:
         # in memory if db_location is not specified
         if not db_location:
             db_location = "/var/opt/magma/"
@@ -61,11 +63,21 @@ class SqliteStore(BaseStore):
             )
             logging.info("db location: %s", db_location_list[shard])
 
+        return db_location_list
+
+    def _create_digest_db_locations(self, db_location: str) -> [str, str]:
         digest_db_location = 'file:' + db_location + \
                              'subscriber-digest.db?cache=shared'
         logging.info("digest db location: %s", digest_db_location)
 
-        return db_location_list, digest_db_location
+        per_sub_digest_db_location = 'file:' + db_location + \
+                                     'per-subscriber-digest.db?cache=shared'
+        logging.info(
+            "per-sub digest db location: %s",
+            per_sub_digest_db_location
+        )
+
+        return digest_db_location, per_sub_digest_db_location
 
     def _create_store(self) -> None:
         """
@@ -89,6 +101,16 @@ class SqliteStore(BaseStore):
                 conn.execute(
                     "CREATE TABLE IF NOT EXISTS subscriber_digest"
                     "(digest string PRIMARY KEY, updated_at timestamp)",
+                )
+        finally:
+            conn.close()
+
+        conn = sqlite3.connect(self._per_sub_digest_db_location, uri=True)
+        try:
+            with conn:
+                conn.execute(
+                    "CREATE TABLE IF NOT EXISTS per_subscriber_digest"
+                    "(sid string PRIMARY KEY, digest string)",
                 )
         finally:
             conn.close()
@@ -146,7 +168,37 @@ class SqliteStore(BaseStore):
         finally:
             conn.close()
 
-    def delete_subscriber(self, subscriber_id):
+    def upsert_subscriber(self, subscriber_data: SubscriberData) -> None:
+        """
+        Check if the given subscriber exists in store. If so, update subscriber
+        data; otherwise, add subscriber.
+        """
+        sid = SIDUtils.to_str(subscriber_data.sid)
+        data_str = subscriber_data.SerializeToString()
+        db_location = self._db_locations[self._sid2bucket(sid)]
+        conn = sqlite3.connect(db_location, uri=True)
+        try:
+            with conn:
+                res = conn.execute(
+                    "SELECT subscriber_id FROM subscriberdb WHERE "
+                    "subscriber_id = ?", (sid,),
+                )
+                row = res.fetchone()
+                if row is None:
+                    conn.execute(
+                        "INSERT INTO subscriberdb(subscriber_id, data) "
+                        "VALUES (?, ?)", (sid, data_str),
+                    )
+                else:
+                    conn.execute(
+                        "UPDATE subscriberdb SET data = ? "
+                        "WHERE subscriber_id = ?", (data_str, sid),
+                    )
+        finally:
+            conn.close()
+        self._on_ready.upsert_subscriber(subscriber_data)
+
+    def delete_subscriber(self, subscriber_id) -> None:
         """
         Delete a subscriber, if present.
         """
@@ -160,6 +212,7 @@ class SqliteStore(BaseStore):
                 )
         finally:
             conn.close()
+        self._on_ready.delete_subscriber(subscriber_id)
 
     def delete_all_subscribers(self):
         """
@@ -292,7 +345,8 @@ class SqliteStore(BaseStore):
         try:
             with conn:
                 res = conn.execute(
-                    "SELECT digest, updated_at FROM subscriber_digest",
+                    "SELECT digest, updated_at FROM subscriber_digest "
+                    "ORDER BY updated_at DESC",
                 )
                 row = res.fetchone()
                 if not row:
@@ -322,8 +376,50 @@ class SqliteStore(BaseStore):
 
         logging.info("update digest stored in gateway: %s", new_digest)
 
+    def get_current_per_sub_digests(self) -> list:
+        digests = []
+        conn = sqlite3.connect(self._per_sub_digest_db_location, uri=True)
+        try:
+            with conn:
+                res = conn.execute(
+                    "SELECT sid, digest FROM per_subscriber_digest "
+                    "ORDER BY sid"
+                )
+
+                for row in res:
+                    digest = SubscriberDigestByID(
+                        sid=SIDUtils.to_pb(row[0]),
+                        digest=Digest(md5_base64_digest=row[1]),
+                    )
+                    digests.append(digest)
+        finally:
+            conn.close()
+
+        return digests
+
+    def update_per_sub_digests(self, new_digests: list) -> None:
+        conn = sqlite3.connect(self._per_sub_digest_db_location, uri=True)
+        try:
+            with conn:
+                conn.execute(
+                    "DELETE FROM per_subscriber_digest"
+                )
+                for digest_by_id in new_digests:
+                    sid = SIDUtils.to_str(digest_by_id.sid)
+                    digest = digest_by_id.digest.md5_base64_digest
+                    conn.execute(
+                        "INSERT INTO per_subscriber_digest(sid, digest)"
+                        "VALUES (?, ?)", (sid, digest),
+                    )
+        finally:
+            conn.close()
+        self._on_digests_ready.update_per_sub_digests(new_digests)
+
     async def on_ready(self):
         return await self._on_ready.event.wait()
+
+    async def on_digests_ready(self):
+        return await self._on_digests_ready.event.wait()
 
     def _update_apn(self, apn_config, apn_data):
         """

--- a/lte/gateway/python/magma/subscriberdb/tests/client_tests.py
+++ b/lte/gateway/python/magma/subscriberdb/tests/client_tests.py
@@ -25,7 +25,9 @@ from lte.protos.subscriberdb_pb2 import (
     Digest,
     ListSubscribersResponse,
     SubscriberData,
+    SubscriberDigestByID,
     SubscriberID,
+    SyncSubscribersResponse,
 )
 from lte.protos.subscriberdb_pb2_grpc import (
     SubscriberDBCloudServicer,
@@ -35,6 +37,7 @@ from lte.protos.subscriberdb_pb2_grpc import (
 from magma.common.grpc_client_manager import GRPCClientManager
 from magma.common.service_registry import ServiceRegistry
 from magma.subscriberdb.client import SubscriberDBCloudClient
+from magma.subscriberdb.sid import SIDUtils
 from magma.subscriberdb.store.sqlite import SqliteStore
 
 
@@ -70,6 +73,55 @@ class MockSubscriberDBServer(SubscriberDBCloudServicer):
         in_sync = request.flat_digest.md5_base64_digest == "digest_pear"
         return CheckSubscribersInSyncResponse(in_sync=in_sync)
 
+    def SyncSubscribers(self, request, context):
+        """
+        Mock to trigger SyncSubscribers-related test cases
+
+        Args:
+            request: SyncSubscribersRequest
+            context: request context
+
+        Returns:
+            SyncSubscribersResponse
+        """
+        per_sub_digests = [
+            SubscriberDigestByID(
+                sid=SIDUtils.to_pb('IMSI11111'),
+                digest=Digest(md5_base64_digest="digest_banana"),
+            ),
+            SubscriberDigestByID(
+                sid=SIDUtils.to_pb('IMSI22222'),
+                digest=Digest(md5_base64_digest="digest_orange"),
+            ),
+            SubscriberDigestByID(
+                sid=SIDUtils.to_pb('IMSI33333'),
+                digest=Digest(md5_base64_digest="digest_tree"),
+            ),
+        ]
+
+        client_per_sub_digest_ids = [
+            SIDUtils.to_str(digest.sid) for digest in request.per_sub_digests
+        ]
+        to_renew = {}
+        deleted = []
+        if 'IMSI11111' not in client_per_sub_digest_ids:
+            to_renew['IMSI11111'] = subscriber_data_by_id('IMSI11111')
+        if 'IMSI22222' not in client_per_sub_digest_ids:
+            to_renew['IMSI22222'] = subscriber_data_by_id('IMSI22222')
+        if 'IMSI33333' not in client_per_sub_digest_ids:
+            to_renew['IMSI33333'] = subscriber_data_by_id('IMSI33333')
+        if 'IMSI00000' in client_per_sub_digest_ids:
+            deleted.append('IMSI00000')
+        resync = len(to_renew) >= 3
+
+        return SyncSubscribersResponse(
+            resync=resync,
+            flat_digest=Digest(md5_base64_digest="digest_cherry"),
+            per_sub_digests=per_sub_digests,
+            to_renew=to_renew,
+            deleted=deleted,
+        )
+
     def ListSubscribers(self, request, context):  # noqa: N802
         """
         List subscribers is a mock to trigger various test cases
@@ -86,6 +138,7 @@ class MockSubscriberDBServer(SubscriberDBCloudServicer):
         """
         # Add in logic to allow error handling testing
         flat_digest = Digest(md5_base64_digest="")
+        per_sub_digests = []
         if request.page_size == 1:
             raise grpc.RpcError("Test Exception")
         if request.page_token == "":
@@ -95,6 +148,12 @@ class MockSubscriberDBServer(SubscriberDBCloudServicer):
                 SubscriberData(sid=SubscriberID(id="IMSI222")),
             ]
             flat_digest = Digest(md5_base64_digest="digest_pear")
+            per_sub_digests = [
+                SubscriberDigestByID(
+                    sid=SIDUtils.to_pb("IMSI11111"),
+                    digest=Digest(md5_base64_digest="digest_birch"),
+                ),
+            ]
         elif request.page_token == "aaa":
             next_page_token = "bbb"  # noqa: S105
             subscribers = [
@@ -111,6 +170,7 @@ class MockSubscriberDBServer(SubscriberDBCloudServicer):
             subscribers=subscribers,
             next_page_token=next_page_token,
             flat_digest=flat_digest,
+            per_sub_digests=per_sub_digests,
         )
 
 
@@ -230,8 +290,17 @@ class SubscriberDBCloudClientTests(unittest.TestCase):
                 await self.subscriberdb_cloud_client._get_all_subscribers()
             )
             self.assertTrue(ret is not None)
-            self.assertEqual(self.get_all_subscribers(), ret[0])
-            self.assertEqual("digest_pear", ret[1].md5_base64_digest)
+            self.assertEqual(self.get_all_subscribers(), ret.subscribers)
+            self.assertEqual("digest_pear", ret.flat_digest.md5_base64_digest)
+            self.assertTrue(len(ret.per_sub_digests) == 1)
+            self.assertEqual(
+                ret.per_sub_digests[0].digest.md5_base64_digest,
+                "digest_birch",
+            )
+            self.assertEqual(
+                SIDUtils.to_str(ret.per_sub_digests[0].sid),
+                "IMSI11111",
+            )
 
         # Cancel the client's loop so there are no other activities
         self.subscriberdb_cloud_client._periodic_task.cancel()
@@ -255,7 +324,7 @@ class SubscriberDBCloudClientTests(unittest.TestCase):
             ret = (
                 await self.subscriberdb_cloud_client._get_all_subscribers()
             )
-            self.assertEqual((None, None), ret)
+            self.assertTrue(ret is None)
 
         # Cancel the client's loop so there are no other activities
         self.subscriberdb_cloud_client._periodic_task.cancel()
@@ -301,7 +370,7 @@ class SubscriberDBCloudClientTests(unittest.TestCase):
     )
     def test_check_subscribers_in_sync(self, get_grpc_mock):
         """
-        Test QueryFlatDigest RPC success
+        Test CheckSubscribersInSync RPC success
 
         Args:
             get_grpc_mock: mock for service registry
@@ -322,3 +391,80 @@ class SubscriberDBCloudClientTests(unittest.TestCase):
         # Cancel the client's loop so there are no other activities
         self.subscriberdb_cloud_client._periodic_task.cancel()
         self.loop.run_until_complete(test())
+
+    @ unittest.mock.patch(
+        'magma.common.service_registry.ServiceRegistry.get_rpc_channel',
+    )
+    def test_sync_subscribers(self, get_grpc_mock):
+        """
+        Test SyncSubscribers RPC success
+
+        Args:
+            get_grpc_mock: mock for service registry
+        """
+        async def test():  # noqa: WPS430
+            get_grpc_mock.return_value = self.channel
+            # resync is True if the changeset is too big
+            resync = (
+                await self.subscriberdb_cloud_client._sync_subscribers()
+            )
+            self.assertEqual(True, resync)
+
+            self.subscriberdb_cloud_client._store.update_per_sub_digests([
+                SubscriberDigestByID(
+                    sid=SIDUtils.to_pb('IMSI11111'),
+                    digest=Digest(md5_base64_digest="digest_banana"),
+                ),
+                SubscriberDigestByID(
+                    sid=SIDUtils.to_pb('IMSI00000'),
+                    digest=Digest(md5_base64_digest="digest_peach"),
+                ),
+            ])
+            self.subscriberdb_cloud_client._store.add_subscriber(
+                subscriber_data_by_id('IMSI00000'),
+            )
+            self.subscriberdb_cloud_client._store.add_subscriber(
+                subscriber_data_by_id('IMSI11111'),
+            )
+
+            # the client subscriber db and per-subscriber digest db are updated
+            # when resync is False
+            resync = (
+                await self.subscriberdb_cloud_client._sync_subscribers()
+            )
+            self.assertEqual(False, resync)
+            self.assertEqual(
+                "digest_cherry",
+                self.subscriberdb_cloud_client._store.get_current_digest(),
+            )
+            self.assertEqual(
+                ['IMSI11111', 'IMSI22222', 'IMSI33333'],
+                self.subscriberdb_cloud_client._store.list_subscribers(),
+            )
+            self.assertEqual(
+                [
+                    SubscriberDigestByID(
+                        sid=SIDUtils.to_pb('IMSI11111'),
+                        digest=Digest(md5_base64_digest="digest_banana"),
+                    ),
+                    SubscriberDigestByID(
+                        sid=SIDUtils.to_pb('IMSI22222'),
+                        digest=Digest(md5_base64_digest="digest_orange"),
+                    ),
+                    SubscriberDigestByID(
+                        sid=SIDUtils.to_pb('IMSI33333'),
+                        digest=Digest(md5_base64_digest="digest_tree"),
+                    ),
+                ],
+                self.subscriberdb_cloud_client._store.get_current_per_sub_digests(),
+            )
+
+        # Cancel the client's loop so there are no other activities
+        self.subscriberdb_cloud_client._periodic_task.cancel()
+        self.loop.run_until_complete(test())
+
+
+def subscriber_data_by_id(sid_str):
+    sid = SIDUtils.to_pb(sid_str)
+    data = SubscriberData(sid=sid)
+    return data

--- a/lte/gateway/python/magma/subscriberdb/tests/client_tests.py
+++ b/lte/gateway/python/magma/subscriberdb/tests/client_tests.py
@@ -25,7 +25,7 @@ from lte.protos.subscriberdb_pb2 import (
     Digest,
     ListSubscribersResponse,
     SubscriberData,
-    SubscriberDigestByID,
+    SubscriberDigestWithID,
     SubscriberID,
     SyncSubscribersResponse,
 )
@@ -85,15 +85,15 @@ class MockSubscriberDBServer(SubscriberDBCloudServicer):
             SyncSubscribersResponse
         """
         per_sub_digests = [
-            SubscriberDigestByID(
+            SubscriberDigestWithID(
                 sid=SIDUtils.to_pb('IMSI11111'),
                 digest=Digest(md5_base64_digest="digest_banana"),
             ),
-            SubscriberDigestByID(
+            SubscriberDigestWithID(
                 sid=SIDUtils.to_pb('IMSI22222'),
                 digest=Digest(md5_base64_digest="digest_orange"),
             ),
-            SubscriberDigestByID(
+            SubscriberDigestWithID(
                 sid=SIDUtils.to_pb('IMSI33333'),
                 digest=Digest(md5_base64_digest="digest_tree"),
             ),
@@ -149,7 +149,7 @@ class MockSubscriberDBServer(SubscriberDBCloudServicer):
             ]
             flat_digest = Digest(md5_base64_digest="digest_pear")
             per_sub_digests = [
-                SubscriberDigestByID(
+                SubscriberDigestWithID(
                     sid=SIDUtils.to_pb("IMSI11111"),
                     digest=Digest(md5_base64_digest="digest_birch"),
                 ),
@@ -411,11 +411,11 @@ class SubscriberDBCloudClientTests(unittest.TestCase):
             self.assertEqual(True, resync)
 
             self.subscriberdb_cloud_client._store.update_per_sub_digests([
-                SubscriberDigestByID(
+                SubscriberDigestWithID(
                     sid=SIDUtils.to_pb('IMSI11111'),
                     digest=Digest(md5_base64_digest="digest_banana"),
                 ),
-                SubscriberDigestByID(
+                SubscriberDigestWithID(
                     sid=SIDUtils.to_pb('IMSI00000'),
                     digest=Digest(md5_base64_digest="digest_peach"),
                 ),
@@ -443,15 +443,15 @@ class SubscriberDBCloudClientTests(unittest.TestCase):
             )
             self.assertEqual(
                 [
-                    SubscriberDigestByID(
+                    SubscriberDigestWithID(
                         sid=SIDUtils.to_pb('IMSI11111'),
                         digest=Digest(md5_base64_digest="digest_banana"),
                     ),
-                    SubscriberDigestByID(
+                    SubscriberDigestWithID(
                         sid=SIDUtils.to_pb('IMSI22222'),
                         digest=Digest(md5_base64_digest="digest_orange"),
                     ),
-                    SubscriberDigestByID(
+                    SubscriberDigestWithID(
                         sid=SIDUtils.to_pb('IMSI33333'),
                         digest=Digest(md5_base64_digest="digest_tree"),
                     ),

--- a/lte/gateway/python/magma/subscriberdb/tests/store/onready_test.py
+++ b/lte/gateway/python/magma/subscriberdb/tests/store/onready_test.py
@@ -18,9 +18,9 @@ import tempfile
 import unittest
 
 from lte.protos.subscriberdb_pb2 import (
-    SubscriberData,
-    SubscriberDigestByID,
     Digest,
+    SubscriberData,
+    SubscriberDigestWithID,
 )
 from magma.subscriberdb.sid import SIDUtils
 from magma.subscriberdb.store.cached_store import CachedStore
@@ -113,7 +113,7 @@ class OnReadyMixinTests(unittest.TestCase):
             self._store._persistent_store._on_ready.event.is_set(), False,
         )
         self._store.upsert_subscriber(
-            SubscriberData(sid=SIDUtils.to_pb('IMSI1111'))
+            SubscriberData(sid=SIDUtils.to_pb('IMSI1111')),
         )
 
         async def defer():
@@ -124,6 +124,7 @@ class OnReadyMixinTests(unittest.TestCase):
         self.assertEqual(
             self._store._persistent_store._on_ready.event.is_set(), True,
         )
+
 
 class OnDigestsReadyMixinTests(unittest.TestCase):
     """
@@ -144,10 +145,10 @@ class OnDigestsReadyMixinTests(unittest.TestCase):
         """
         self.assertEqual(self._store._on_digests_ready.event.is_set(), False)
         self._store.update_per_sub_digests([
-            SubscriberDigestByID(
+            SubscriberDigestWithID(
                 sid=SIDUtils.to_pb('IMSI11111'),
-                digest=Digest(md5_base64_digest='digest_cherry')
-            )
+                digest=Digest(md5_base64_digest='digest_cherry'),
+            ),
         ])
 
         async def defer():

--- a/lte/gateway/python/magma/subscriberdb/tests/store/onready_test.py
+++ b/lte/gateway/python/magma/subscriberdb/tests/store/onready_test.py
@@ -17,7 +17,11 @@ import asyncio
 import tempfile
 import unittest
 
-from lte.protos.subscriberdb_pb2 import SubscriberData
+from lte.protos.subscriberdb_pb2 import (
+    SubscriberData,
+    SubscriberDigestByID,
+    Digest,
+)
 from magma.subscriberdb.sid import SIDUtils
 from magma.subscriberdb.store.cached_store import CachedStore
 from magma.subscriberdb.store.sqlite import SqliteStore
@@ -80,3 +84,74 @@ class OnReadyMixinTests(unittest.TestCase):
         self.assertEqual(
             self._store._persistent_store._on_ready.event.is_set(), True,
         )
+
+    def test_delete_subscriber(self):
+        """
+        Test if subscriber deletion triggers ready
+        """
+        self.assertEqual(self._store._on_ready.event.is_set(), False)
+        self.assertEqual(
+            self._store._persistent_store._on_ready.event.is_set(), False,
+        )
+        self._store.delete_subscriber('IMSI11111')
+
+        async def defer():
+            await self._store.on_ready()
+        self.loop.run_until_complete(defer())
+
+        self.assertEqual(self._store._on_ready.event.is_set(), True)
+        self.assertEqual(
+            self._store._persistent_store._on_ready.event.is_set(), True,
+        )
+
+    def test_upsert_subscriber(self):
+        """
+        Test if subscriber upsertion triggers ready
+        """
+        self.assertEqual(self._store._on_ready.event.is_set(), False)
+        self.assertEqual(
+            self._store._persistent_store._on_ready.event.is_set(), False,
+        )
+        self._store.upsert_subscriber(
+            SubscriberData(sid=SIDUtils.to_pb('IMSI1111'))
+        )
+
+        async def defer():
+            await self._store.on_ready()
+        self.loop.run_until_complete(defer())
+
+        self.assertEqual(self._store._on_ready.event.is_set(), True)
+        self.assertEqual(
+            self._store._persistent_store._on_ready.event.is_set(), True,
+        )
+
+class OnDigestsReadyMixinTests(unittest.TestCase):
+    """
+    Test class for the OnDigestsReady subscriber digests storage mixin
+    """
+
+    def setUp(self):
+        self.loop = asyncio.new_event_loop()
+        self._tmpfile = tempfile.TemporaryDirectory()
+        self._store = SqliteStore(self._tmpfile.name + '/', loop=self.loop)
+
+    def tearDown(self):
+        self._tmpfile.cleanup()
+
+    def test_per_sub_digests_update(self):
+        """
+        Test if per-subscriber digests update triggers ready
+        """
+        self.assertEqual(self._store._on_digests_ready.event.is_set(), False)
+        self._store.update_per_sub_digests([
+            SubscriberDigestByID(
+                sid=SIDUtils.to_pb('IMSI11111'),
+                digest=Digest(md5_base64_digest='digest_cherry')
+            )
+        ])
+
+        async def defer():
+            await self._store.on_digests_ready()
+        self.loop.run_until_complete(defer())
+
+        self.assertEqual(self._store._on_digests_ready.event.is_set(), True)

--- a/lte/gateway/python/magma/subscriberdb/tests/store/onready_test.py
+++ b/lte/gateway/python/magma/subscriberdb/tests/store/onready_test.py
@@ -156,3 +156,16 @@ class OnDigestsReadyMixinTests(unittest.TestCase):
         self.loop.run_until_complete(defer())
 
         self.assertEqual(self._store._on_digests_ready.event.is_set(), True)
+
+    def test_digest_update(self):
+        """
+        Test if flat digest update triggers ready
+        """
+        self.assertEqual(self._store._on_digests_ready.event.is_set(), False)
+        self._store.update_digest("digest_apple")
+
+        async def defer():
+            await self._store.on_digests_ready()
+        self.loop.run_until_complete(defer())
+
+        self.assertEqual(self._store._on_digests_ready.event.is_set(), True)

--- a/lte/gateway/python/magma/subscriberdb/tests/store/store_tests.py
+++ b/lte/gateway/python/magma/subscriberdb/tests/store/store_tests.py
@@ -15,9 +15,9 @@ import tempfile
 import unittest
 
 from lte.protos.subscriberdb_pb2 import (
-    SubscriberData,
-    SubscriberDigestByID,
     Digest,
+    SubscriberData,
+    SubscriberDigestWithID,
 )
 from magma.subscriberdb.sid import SIDUtils
 from magma.subscriberdb.store.base import (
@@ -162,30 +162,30 @@ class StoreTests(unittest.TestCase):
         """
         self.assertEqual(self._store.get_current_per_sub_digests(), [])
         digests1 = [
-            SubscriberDigestByID(
+            SubscriberDigestWithID(
                 sid=SIDUtils.to_pb('IMSI11111'),
-                digest=Digest(md5_base64_digest='digest_apple')
+                digest=Digest(md5_base64_digest='digest_apple'),
             ),
-            SubscriberDigestByID(
+            SubscriberDigestWithID(
                 sid=SIDUtils.to_pb('IMSI22222'),
-                digest=Digest(md5_base64_digest='digest_cherry')
+                digest=Digest(md5_base64_digest='digest_cherry'),
             ),
         ]
         self._store.update_per_sub_digests(digests1)
         self.assertEqual(self._store.get_current_per_sub_digests(), digests1)
 
         digests2 = [
-            SubscriberDigestByID(
+            SubscriberDigestWithID(
                 sid=SIDUtils.to_pb('IMSI11111'),
-                digest=Digest(md5_base64_digest='digest_apple')
+                digest=Digest(md5_base64_digest='digest_apple'),
             ),
-            SubscriberDigestByID(
+            SubscriberDigestWithID(
                 sid=SIDUtils.to_pb('IMSI33333'),
-                digest=Digest(md5_base64_digest='digest_banana')
+                digest=Digest(md5_base64_digest='digest_banana'),
             ),
-            SubscriberDigestByID(
+            SubscriberDigestWithID(
                 sid=SIDUtils.to_pb('IMSI44444'),
-                digest=Digest(md5_base64_digest='digest_orange')
+                digest=Digest(md5_base64_digest='digest_orange'),
             ),
         ]
         self._store.update_per_sub_digests(digests2)


### PR DESCRIPTION
<!--
    Tag your PR title with the components that it touches along with type of
    change. Checkout 'contribute_commit_msg' doc for recommended git commit
    message style.
    E.g. "fix(orc8r): Changeset" or "feat(agw) ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->
1. Add functions in `SqliteStore` that stores and manages gateway-local per-subscriber digests
2. Add functions to ensure thread-safety of servicer-response-triggered `per-sub digests` store and `subscribers` store operations
3. Adapt the `subscriberdb` agw client to incorporate `SyncSubscribers` calls to cloud as part of its callpath

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->
1. Ran all existing tests; all passed
2. Added unit tests for the new `SqliteStore` functions, the modified`subscriberdb` client callpath, as well as the `OnDataReady` and `OnDigestsReady` mixin interfaces 

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
Signed-off-by: Yuanyuting Wang <yw3241@columbia.edu>