### PR TITLE
[orc8r][docs] Added orcl/scaled deployment docs and minor test cluster cleanups

### DIFF
--- a/docs/readmes/orc8r/deploy_orcl.md
+++ b/docs/readmes/orc8r/deploy_orcl.md
@@ -16,11 +16,88 @@ Orcl is the Orchestrator CLI. It is used for managing an Orc8r deployment. It pr
 - Cleanup
 - Debug (perhaps in the future)
 
+## Steps to install Orc8r 1.6 through Orcl
+
+### 1. Build the orc8r_deployer image
+
+```
+git checkout v1.6
+cd magma/orc8r/cloud/deploy/orc8r_deployer/docker
+
+./run_deployer.bash --deploy-dir <deploy_dir> --build
+
+For e.g:
+./run_deployer.bash --deploy-dir ~/workspace/orc8r_16_deploy_dir --build
+```
+
+### 2. Run Orcl configure and add infra, platform and service level configs
+
+```
+root@ff1b8da0308c:~/project# orcl configure
+Configuring infra deployment variables
+aws_access_key_id(AWS access key id): <aws_access_key_id>
+aws_secret_access_key(AWS access secret): <aws_secret_access_key>
+orc8r_domain_name(Base domain name for AWS Route 53 hosted zone): <orc8r_domain> 
+region(AWS region to deploy Orchestrator components into. The chosen region must provide EKS): us-west-2
+secretsmanager_orc8r_secret(AWS Secret Manager secret to store Orchestrator secrets): <secrets_name>
+
+Configuring platform deployment variables
+orc8r_db_password(Password for the Orchestrator DB):<db_password>
+
+Configuring service deployment variables
+orc8r_deployment_type(Deployment Type of Orchestrator (fwa, federated fwa(ffwa), all)): fwa
+orc8r_tag(Image tag for Orchestrator components) [1.5.0]: 1.6.0
+```
+
+### 3. Add application certs and self signed certs if necessary
+
+```
+root@ff1b8da0308c:~/project# orcl certs add --self-signed
+```
+
+### 4. Install Orc8r with prechecks 
+
+```
+root@ff1b8da0308c:~/project# orcl install
+Do you want to run installation prechecks? [y/N]: y
+
+...
+Apply complete! Resources: 23 added, 1 changed, 0 destroyed.
+
+Outputs:
+
+nameservers = tolist([
+  "ns-1121.awsdns-12.org",
+  "ns-1606.awsdns-08.co.uk",
+  "ns-218.awsdns-27.com",
+  "ns-822.awsdns-38.net",
+])
+```
+
+Follow steps in deploy_install#dns-resolution
+
+
+### 5. Check sanity of Orc8r installation
+
+```
+root@efcb65fb4d48:~/project# orcl verify sanity
+....
+
+TASK [services/orc8r : Get all configured networks from NMS pod] ****************************************************************************************************************************************************************************
+changed: [localhost] => (item=magma/v1/networks)
+changed: [localhost] => (item=magma/v1/lte)
+
+PLAY RECAP **********************************************************************************************************************************************************************************************************************************
+localhost                  : ok=12   changed=7    unreachable=0    failed=0    skipped=2    rescued=0    ignored=0
+
+Post deployment verification ran successfully
+```
+
+
+## Usage
 ![Orcl Big Picture](assets/orc8r/orcl.png)
 
 Orcl is packaged within orc8r_deployer. Orc8r deployer is a docker image which contains all the necessary prerequisites to deploy orc8r. The only requirements for running orc8r_deployer is that the the host machine must have [docker engine installed](https://docs.docker.com/get-docker/).
-
-## Usage
 
 ```
 ./run_deployer runs the orc8r deployer container

--- a/experimental/cloudstrapper/playbooks/cluster-configure.yaml
+++ b/experimental/cloudstrapper/playbooks/cluster-configure.yaml
@@ -1,5 +1,6 @@
 ---
 - hosts: "{{ agws }}"
+  serial: 1
   roles:
     - {role: exporter, tags: exporter, become: yes}
     - {role: test-framework}

--- a/experimental/cloudstrapper/playbooks/roles/test-framework/tasks/configure-test-instances.yaml
+++ b/experimental/cloudstrapper/playbooks/roles/test-framework/tasks/configure-test-instances.yaml
@@ -5,6 +5,11 @@
 - name: Force new snowflake ID
   shell: snowflake -m --force-new-key
   become: true
+  tags: reset_hardware_id
+
+- name: Dump hardware id
+  shell: cat /etc/snowflake
+  register: hardware_id
 
 - name: Create cert and config directories
   file:
@@ -28,93 +33,6 @@
     src: roles/agw-platform/files/control_proxy.j2
     dest: "{{ agwConfigPath }}/control_proxy.yml"
 
-- name: Read magmad yaml file
-  command: cat /etc/magma/magmad.yml
-  register: magmad_raw_config
-
-- name: Check if avalanche exists on gateway
-  stat:
-    path: /usr/bin/avalanche
-  register: avalanche_gw_binary
-
-# Install avalanche for metric scaling
-- name: Check if avalanche exists
-  when: not avalanche_gw_binary.stat.exists
-  delegate_to: localhost
-  stat:
-    path: /usr/local/bin/avalanche
-  register: avalanche_binary
-
-- name: Check if avalanche exists
-  when: not avalanche_gw_binary.stat.exists
-  delegate_to: localhost
-  assert:
-    that: avalanche_binary.stat.exists
-
-- name: Copy avalanche to gateways
-  become: true
-  when: not avalanche_gw_binary.stat.exists
-  ansible.builtin.copy:
-    src: /usr/local/bin/avalanche
-    dest: /usr/bin/avalanche
-    owner: root
-    group: root
-    mode: 0744
-
-- name: create systemd service unit
-  become: true
-  template:
-    src: avalanche.j2
-    dest: /etc/systemd/system/avalanche.service
-    owner: "root"
-    group: "root"
-    mode: 0644
-
-- name: reenable avalanche service
-  become: true
-  command: systemctl reenable avalanche.service
-
-- name: restart avalanche
-  become: true
-  service:
-    name: avalanche
-    state: restarted
-
-- name: ensure avalanche service is enabled and started
-  service:
-    name: avalanche
-    state: started
-    enabled: yes
-
-- name: Add avalanche and node exporter as metric scrape targets
-  set_fact:
-      magmad_new_config: "{{ magmad_config | combine ({'metricsd': metrics_config})}}"
-  vars:
-    magmad_config: "{{ magmad_raw_config.stdout | from_yaml }}"
-    metrics_config: "{{ magmad_config['metricsd'] | combine({'metric_scrape_targets': metric_scrape_targets})}}"
-    metric_scrape_targets: [
-      {
-        'url' : "http://{{ node_exporter_listen_address }}/metrics",
-        'name': 'node_exporter',
-        'interval': 60
-      },
-      {
-        'url' : "http://0.0.0.0:{{ avalanche_port }}/metrics",
-        'name': 'avalanche',
-        'interval': 60
-      }
-    ]
-
-- name: Debug magmad config
-  debug:
-    var: magmad_new_config
-
-- name: Rewriting magmad config with metric scrape configs
-  become: true
-  copy:
-    dest: "/etc/magma/magmad.yml"
-    content: "{{magmad_new_config | to_yaml}}"
-
 - name: Restart magma services
   become: true
   systemd:
@@ -123,3 +41,21 @@
     no_block: true
   with_items:
     - "{{ servicesMagma }}"
+
+- name: load var from file
+  delegate_to: localhost
+  ignore_errors: true
+  include_vars:
+    file: "{{dirLocalInventory}}/gw_hwid.json"
+    name: gw_hwid_map
+
+- name: append more key/values
+  delegate_to: localhost
+  set_fact:
+    gw_hwid_map: "{{ gw_hwid_map | default([]) | combine({ansible_default_ipv4.address: hardware_id.stdout }) }}"
+
+- name: write var to file
+  delegate_to: localhost
+  copy: 
+    content: "{{ gw_hwid_map | to_nice_json }}" 
+    dest: "{{dirLocalInventory}}/gw_hwid.json"    

--- a/orc8r/cloud/deploy/orc8r_deployer/docker/root/data/default_template.json
+++ b/orc8r/cloud/deploy/orc8r_deployer/docker/root/data/default_template.json
@@ -11,7 +11,7 @@
      },
      "service": {
         "orc8r_deployment_type": "fwa",
-        "orc8r_tag": "1.5.0",
+        "orc8r_tag": "1.6.0",
         "orc8r_kubernetes_namespace": "orc8r",
         "cloudwatch_exporter_enabled": true
      }

--- a/orc8r/cloud/deploy/orc8r_deployer/docker/root/data/scale_template.json
+++ b/orc8r/cloud/deploy/orc8r_deployer/docker/root/data/scale_template.json
@@ -11,7 +11,7 @@
       },
       "service": {
          "orc8r_deployment_type": "fwa",
-         "orc8r_tag": "1.5.0",
+         "orc8r_tag": "1.6.0",
          "orc8r_kubernetes_namespace": "orc8r",
          "cloudwatch_exporter_enabled": true
       }

--- a/orc8r/cloud/deploy/orc8r_deployer/docker/root/scripts/playbooks/roles/services/tasks/helm.yml
+++ b/orc8r/cloud/deploy/orc8r_deployer/docker/root/scripts/playbooks/roles/services/tasks/helm.yml
@@ -21,7 +21,7 @@
     - upgrade_precheck
 
 - name: Get all charts present in the Helm repo
-  ansible.builtin.shell: helm search repo test -o json
+  ansible.builtin.shell: helm search repo test -o json -l
   register: helm_chart_info
   tags:
     - install_precheck
@@ -29,7 +29,7 @@
 
 - name: Get chart name and version from Helm list
   set_fact:
-    chart_version_map: "{{ chart_version_map | default({})  | combine({item.name.split('/')[1]: item.version}) }}"
+    chart_version_map: "{{ chart_version_map | default({})  | combine({item.name.split('/')[1]: chart_version_map[item.name.split('/')[1]] | default([]) + [item.version]}) }}"
   with_items: "{{ helm_chart_info.stdout }}"
   tags:
     - install_precheck
@@ -71,7 +71,7 @@
 
 - name: Validate if chart versions present match the expected version
   assert:
-    that: chart_version_map[item] == exp_chart_version_map[item]
+    that: exp_chart_version_map[item] in chart_version_map[item]
     fail_msg: "{{item}} chart version mismatch expected version {{exp_chart_version_map[item]}} found version {{chart_version_map[item]}}"
   with_items: "{{deployment_module_map[service_configs.orc8r_deployment_type]}}"
   tags:


### PR DESCRIPTION
Signed-off-by: Karthik Subraveti <ksubraveti@fb.com>

## Summary
Docs
- Added docs to install 1.6 through orcl
- Added docs to specify recommended configuration for supporting large scale deployments

Test cluster
- Removed node exporter install on gateways
- Serialized execution to avoid aws rate limiting errors
- Added hardwareIDs to cluster.json

Orcl
- Fixed helm related precheck where the ansible script expected only one version of chart to be present

## Test Plan

- Installed Orc8r through orcl and test-cluster commands and they came up fine.

<img width="1680" alt="Screen Shot 2021-07-08 at 1 24 39 AM" src="https://user-images.githubusercontent.com/8224854/124889898-5f2afb80-df8c-11eb-9295-b4cd73315f21.png">
<img width="1680" alt="Screen Shot 2021-07-08 at 1 24 48 AM" src="https://user-images.githubusercontent.com/8224854/124889909-60f4bf00-df8c-11eb-8f9c-7632e7b81fed.png">

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
