### PR TITLE
fix(mme): Stop timer in right service303 thread

### DIFF
--- a/lte/gateway/c/core/oai/tasks/service303/service303_task.c
+++ b/lte/gateway/c/core/oai/tasks/service303/service303_task.c
@@ -142,13 +142,13 @@ status_code_e service303_init(service303_data_t* service303_data) {
 }
 
 static void service303_server_exit(void) {
-  stop_timer(&service303_message_task_zmq_ctx, display_stats_timer_id);
   destroy_task_context(&service303_server_task_zmq_ctx);
   OAI_FPRINTF_INFO("TASK_SERVICE303_SERVER terminated\n");
   pthread_exit(NULL);
 }
 
 static void service303_message_exit(void) {
+  stop_timer(&service303_message_task_zmq_ctx, display_stats_timer_id);
   destroy_task_context(&service303_message_task_zmq_ctx);
   OAI_FPRINTF_INFO("TASK_SERVICE303 terminated\n");
   pthread_exit(NULL);


### PR DESCRIPTION
## Summary

Service303 has two zmq threads the timer was being stopped in the
wrong threads exit path, this resulted in occasional timer stop
asserts

fixes #7919 

Signed-off-by: Amar Padmanabhan <amar@freedomfi.com>

## Test Plan

Without fix, restarted MME in a loop 10 times saw two crashes
With fix, didn't see the crash
make integ_test

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
