### PR TITLE
refactor(ci): Rotate versions in helm test repo

### DIFF
--- a/.github/workflows/publish-helmcharts-to-artifactory.yml
+++ b/.github/workflows/publish-helmcharts-to-artifactory.yml
@@ -21,12 +21,14 @@ jobs:
         run: |
           if [ "${GITHUB_REF##*/}" = "master" ] ;then
             echo "VERSION=${GITHUB_RUN_NUMBER}" >> $GITHUB_ENV
-          else
-            echo "VERSION=${GITHUB_REF##*/}" >> $GITHUB_ENV
           fi
       - name: Launch build and publish script
         run: |
-          orc8r/tools/helm/package.sh --deployment-type all --version $VERSION
+          if [ "${GITHUB_REF##*/}" = "master" ] ;then
+            orc8r/tools/helm/package.sh --deployment-type all --version $VERSION
+          else
+            orc8r/tools/helm/package.sh --deployment-type all
+          fi
       # Notify ci channel when failing
       # Plugin info: https://github.com/marketplace/actions/slack-notify
       - name: Notify failure to slack

--- a/.github/workflows/publish-helmcharts-to-artifactory.yml
+++ b/.github/workflows/publish-helmcharts-to-artifactory.yml
@@ -3,7 +3,7 @@ name: "Push Helm Charts to Artifactory"
 
 on:  # yamllint disable-line rule:truthy
   push:
-    branches: [master, v1.*]  # Running on v1.* to tag official release with branch name
+    branches: [master, v1.*]  # Running on v1.* to tag official release
 jobs:
   build_publish_helm_charts:
     env:
@@ -32,7 +32,7 @@ jobs:
       # Notify ci channel when failing
       # Plugin info: https://github.com/marketplace/actions/slack-notify
       - name: Notify failure to slack
-        if: failure() && github.ref == 'refs/heads/master'
+        if: failure()
         uses: rtCamp/action-slack-notify@v2.0.2
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_CI }}
@@ -40,3 +40,7 @@ jobs:
           SLACK_USERNAME: "Helm charts push to Artifactory "
           SLACK_ICON_EMOJI: ":boom:"
           SLACK_COLOR: "#FF0000"
+      - name: Only keep the last 20 uploaded versions
+        run: |
+          pip install artifactory
+          python ci-scripts/helm_repo_rotation.py

--- a/ci-scripts/helm_repo_rotation.py
+++ b/ci-scripts/helm_repo_rotation.py
@@ -20,6 +20,7 @@ from artifactory import ArtifactoryPath
 
 # The number of versions kept in the helm repo
 NUMBER_OF_CHARTS = 20
+CHART_NAMES = ('cwf-orc8r', 'feg-orc8r', 'fbinternal-orc8r', 'lte-orc8r', 'orc8r', 'wifi-orc8r')
 
 
 def exit_environment_not_set(variable_name):
@@ -81,9 +82,5 @@ clean_artifacts_and_charts = list(
     map(lambda x: ['-'.join(x[0].split('-')[:-1]), x[1], x[0]], clean_artifact_map))
 
 # Make sure to only keep 20 artifacts per chart
-delete_old_artifacts(clean_artifacts_and_charts, 'cwf-orc8r')
-delete_old_artifacts(clean_artifacts_and_charts, 'feg-orc8r')
-delete_old_artifacts(clean_artifacts_and_charts, 'fbinternal-orc8r')
-delete_old_artifacts(clean_artifacts_and_charts, 'lte-orc8r')
-delete_old_artifacts(clean_artifacts_and_charts, 'orc8r')
-delete_old_artifacts(clean_artifacts_and_charts, 'wifi-orc8r')
+for chart_name in CHART_NAMES:
+    delete_old_artifacts(clean_artifacts_and_charts, chart_name)

--- a/ci-scripts/helm_repo_rotation.py
+++ b/ci-scripts/helm_repo_rotation.py
@@ -1,0 +1,89 @@
+"""
+Copyright 2021 The Magma Authors.
+
+This source code is licensed under the BSD-style license found in the
+LICENSE file in the root directory of this source tree.
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import os
+import re
+import time
+
+import requests
+from artifactory import ArtifactoryPath
+
+# The number of versions kept in the helm repo
+NUMBER_OF_CHARTS = 20
+
+
+def exit_environment_not_set(variable_name):
+    """Exit due to environment variable not set"""
+    print(variable_name + " is not set.")
+    exit(1)
+
+
+def delete_old_artifacts(list_of_artifacts, chart_name):
+    """Extract list of artifacts for this chart and only keep the last NUMBER_OF_CHARTS versions uploaded"""
+    artifacts = list(filter(lambda x: chart_name == x[0], list_of_artifacts))
+    if len(artifacts) < NUMBER_OF_CHARTS:
+        return
+    artifacts.sort(key=lambda date: time.strptime(date[1], '%d-%b-%Y %H:%M'))
+    for artifact in artifacts[:-(NUMBER_OF_CHARTS + 1)]:
+        artifact_path = ArtifactoryPath(
+            full_artifactory_url + artifact[2],
+            auth=credentials)
+        if artifact_path.exists():
+            print("Deleting artifact " + artifact[2])
+            artifact_path.unlink()
+
+
+# Verify existence of environment variables
+username = os.getenv('HELM_CHART_MUSEUM_USERNAME')
+if not username:
+    exit_environment_not_set('HELM_CHART_MUSEUM_USERNAME')
+password = os.getenv('HELM_CHART_MUSEUM_TOKEN')
+if not password:
+    exit_environment_not_set('HELM_CHART_MUSEUM_TOKEN')
+artifactory_url = os.getenv('HELM_CHART_ARTIFACTORY_URL')
+if not artifactory_url:
+    exit_environment_not_set('HELM_CHART_ARTIFACTORY_URL')
+helm_repo = os.getenv('HELM_CHART_MUSEUM_REPO')
+if not helm_repo:
+    exit_environment_not_set('HELM_CHART_MUSEUM_REPO')
+
+# Login to artifactory
+credentials = (username, password)
+
+full_artifactory_url = artifactory_url + helm_repo + '/'
+artifactory_path = ArtifactoryPath(
+    full_artifactory_url,
+    auth=credentials)
+artifactory_path.touch()
+
+# List from html website as GET API does not provide creation timestamp
+r = requests.get(full_artifactory_url)
+
+# Split response body per artifact
+artifact_list = re.search("<a href(.*)</pre>", str(r.content)).group(0).split('<a href')
+artifact_list_trimmed = list(filter(lambda x: x != "", artifact_list))
+
+# Extract artifact name and date
+clean_artifact_map = map(lambda p: re.search(">(.*)</a>[ ]+(.*)  ", str(p)).group(1, 2),
+                         artifact_list_trimmed)
+# Extract chart name for sorting
+clean_artifacts_and_charts = list(
+    map(lambda x: ['-'.join(x[0].split('-')[:-1]), x[1], x[0]], clean_artifact_map))
+
+# Make sure to only keep 20 artifacts per chart
+delete_old_artifacts(clean_artifacts_and_charts, 'cwf-orc8r')
+delete_old_artifacts(clean_artifacts_and_charts, 'feg-orc8r')
+delete_old_artifacts(clean_artifacts_and_charts, 'fbinternal-orc8r')
+delete_old_artifacts(clean_artifacts_and_charts, 'lte-orc8r')
+delete_old_artifacts(clean_artifacts_and_charts, 'orc8r')
+delete_old_artifacts(clean_artifacts_and_charts, 'wifi-orc8r')


### PR DESCRIPTION
## Summary

Only keep the last 20 uploaded versions per chart.
When releasing, use versioning specified in the chart themselves.

## Test Plan

Tested python script, tested launch of python script in PR.
Will test fully on master due to secrets not being available on PR event.

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
