### PR TITLE
fix(agw): swap python package json-pointer with jsonpointer

### DIFF
--- a/lte/gateway/python/setup.py
+++ b/lte/gateway/python/setup.py
@@ -133,7 +133,7 @@ if release_info.get('VERSION_CODENAME', '') == 'focal':
             'pycryptodome>=3.9.9',
             'pyroute2==0.5.14',
             'aiohttp==3.6.2',
-            'json-pointer>=0.1.2',
+            "jsonpointer>=1.14",
             'ovs>=2.13',
             'prometheus-client>=0.3.1',
             'aioeventlet==0.5.1',   # aioeventlet-build.sh

--- a/lte/gateway/release/magma.lockfile.ubuntu
+++ b/lte/gateway/release/magma.lockfile.ubuntu
@@ -630,9 +630,9 @@
         },
         "eventlet": {
           "root": true,
-          "source": "apt",
+          "source": "pypi",
           "sysdep": "python3-eventlet",
-          "version": "0.26.1"
+          "version": "0.30.2"
         },
         "fire": {
           "root": true,
@@ -736,6 +736,12 @@
           "sysdep": "python3-jsonpickle",
           "version": "1.2"
         },
+        "jsonpointer": {
+          "root": true,
+          "source": "pypi",
+          "sysdep": "python3-json-pointer",
+          "version": "2.0"
+        },
         "jsonref": {
           "root": false,
           "source": "apt",
@@ -756,9 +762,9 @@
         },
         "lxml": {
           "root": true,
-          "source": "apt",
+          "source": "pypi",
           "sysdep": "python3-lxml",
-          "version": "4.6.2"
+          "version": "4.6.3"
         },
         "mccabe": {
           "root": false,
@@ -770,7 +776,7 @@
           "root": false,
           "source": "apt",
           "sysdep": "python3-msgpack",
-          "version": "0.6.2"
+          "version": "1.0.0"
         },
         "multidict": {
           "root": false,
@@ -876,7 +882,7 @@
         },
         "pyyaml": {
           "root": true,
-          "source": "apt",
+          "source": "pypi",
           "sysdep": "python3-yaml",
           "version": "5.3.1"
         },
@@ -958,6 +964,12 @@
           "sysdep": "python3-swagger-spec-validator",
           "version": "2.7.3"
         },
+        "systemd-python": {
+          "root": true,
+          "source": "apt",
+          "sysdep": "python3-systemd-python",
+          "version": "234"
+        },
         "toml": {
           "root": false,
           "source": "apt",
@@ -1029,6 +1041,9 @@
         "cryptography": {
           "version": "2.8"
         },
+        "eventlet": {
+          "version": "0.30.2"
+        },
         "fire": {
           "version": "0.2.1"
         },
@@ -1050,8 +1065,14 @@
         "jsonpickle": {
           "version": "1.2"
         },
+        "jsonpointer": {
+          "version": "2.0"
+        },
         "jsonschema": {
           "version": "3.1.0"
+        },
+        "lxml": {
+          "version": "4.6.3"
         },
         "netifaces": {
           "version": "0.10.4"

--- a/lte/gateway/release/pydep
+++ b/lte/gateway/release/pydep
@@ -73,6 +73,7 @@ PYPI_TO_DEB = {
     'msgpack-python': 'msgpack',
     'scapy-python3': 'scapy',
     'python-apt': 'apt',
+    'jsonpointer': 'json-pointer'
 }
 
 # Some packages exist in the standard Debian repos with an epoch number

--- a/orc8r/gateway/python/setup.py
+++ b/orc8r/gateway/python/setup.py
@@ -193,7 +193,7 @@ setup(
         'jsonschema==3.1.0',
         "strict-rfc3339>=0.7",
         "rfc3987>=1.3.0",
-        "jsonpointer>=1.13",
+        "jsonpointer>=1.14",
         "webcolors>=1.11.1",
     ],
     extras_require={


### PR DESCRIPTION
## Summary

A fresh AGW VM coming up after `vagrant up magma`, `make run`, and `register_vm` is not able to checkin with the orc8r. `magtivate && checkin_cli.py` in the magma VM fails with the error:

```
pkg_resources.DistributionNotFound: The 'jsonpointer>1.13; extra == "format"' distribution was not found and is required by jsonschema
```
This is because the `jsonpointer` Python package has not been installed. Python dependencies are listed in `lte/gateway/python/setup.py` and the `install_requires` list has `json-pointer` instead of `jsonpointer`. The `json-pointer` package is different and is not one of our dependencies.

The `jsonpointer` package is indeed listed as one of our dependencies in `orc8r/gateway/python/setup.py`, but the version there is 1.13. The current `jsonschema` package we install requires `jsonpointer>=1.14`.

This PR fixes the typo/confusion in `lte/gateway/python/setup.py` and bumps the version for `jsonpointer`.

## Test Plan

Tested `checkin_cli.py` with `json-pointer` installed but `jsonpointer` uninstalled -> Failure
Tested `checkin_cli.py` with `jsonpointer` installed but `json-pointer` uninstalled -> Success!

Built and tested the `magma` package on a VM as instructed [here](https://docs.magmacore.org/docs/lte/build_install_magma_pkg_in_agw). 

Signed-off-by: Waqar Aqeel <waqeel@fb.com>