### PR TITLE
test(orc8r): [ci] Get rid of -t options as starting docker from entrypoint script

### DIFF
--- a/orc8r/cloud/deploy/orc8r_deployer/docker/run_deployer.bash
+++ b/orc8r/cloud/deploy/orc8r_deployer/docker/run_deployer.bash
@@ -22,7 +22,7 @@ example: ./run_deployer.bash --deploy-dir ~/orc8r_15_deployment"
 run_unit_tests()
 {
     echo "Running orcl container unit tests"
-    docker run -it \
+    docker run -i \
         --entrypoint /root/scripts/cli/configlib_test.py \
         -v "${DEPLOY_WORKDIR}":/root/project \
         -v "${MAGMA_ROOT}":/root/magma \
@@ -33,7 +33,7 @@ run_unit_tests()
 check_helmcharts_insync()
 {
     echo "Checking if helm charts are in sync"
-    docker run -it \
+    docker run -i \
         --entrypoint /root/scripts/test_helm_charts_sync.py \
         -v "${DEPLOY_WORKDIR}":/root/project \
         -v "${MAGMA_ROOT}":/root/magma \
@@ -44,7 +44,7 @@ check_helmcharts_insync()
 check_tfvars_insync()
 {
     echo "Checking tf vars are in sync"
-    docker run -it \
+    docker run -i \
         --entrypoint /root/scripts/test_vars_sync.py \
         -v "${DEPLOY_WORKDIR}":/root/project \
         -v "${MAGMA_ROOT}":/root/magma \


### PR DESCRIPTION
Signed-off-by: Quentin, Derory <15911421+quentinDERORY@users.noreply.github.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

Removing the allocation of a pseudo-TTY as starting container from entrypoint script.
This option is failing when using docker 20.10.6 with ubuntu 20.04.
We want to upgrade ubuntu on the ci machines. (Currently ubuntu 16.04 with docker 19.03.8)

## Test Plan

Successful circle ci job on PR

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
