### PR TITLE
fix(agw): Process subscriber data before digest data

### DIFF
--- a/lte/gateway/python/magma/subscriberdb/client.py
+++ b/lte/gateway/python/magma/subscriberdb/client.py
@@ -86,8 +86,10 @@ class SubscriberDBCloudClient(SDWatchdogTask):
         subscribers, flat_digest = await self._get_all_subscribers()
         if subscribers is None:
             return
-        self._update_flat_digest(flat_digest)
+        # Process subscriber data before digest data, in case there's a gateway
+        # failure between the calls
         self._process_subscribers(subscribers)
+        self._update_flat_digest(flat_digest)
 
     async def _check_subscribers_in_sync(self) -> bool:
         """


### PR DESCRIPTION
<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->
1. Switched ordering of processing subscriber data (now first) and digest data (now second) in case there's a gw failure between the two calls

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->
1. Ran all existing tests; all passed

## Additional Information

- This fix is meant to be back-ported to v1.6

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
