### PR TITLE
fix(orc8r): [tracing] Context propagation for all modules

### DIFF
--- a/fbinternal/cloud/go/services/testcontroller/e2e_client_api.go
+++ b/fbinternal/cloud/go/services/testcontroller/e2e_client_api.go
@@ -82,12 +82,12 @@ func strPtr(s string) *string {
 	return &s
 }
 
-func GetTestCases(pks []int64, serdes serde.Registry) (map[int64]*UnmarshalledTestCase, error) {
+func GetTestCases(ctx context.Context, pks []int64, serdes serde.Registry) (map[int64]*UnmarshalledTestCase, error) {
 	client, err := getE2EClient()
 	if err != nil {
 		return nil, err
 	}
-	res, err := client.GetTestCases(context.Background(), &protos.GetTestCasesRequest{Pks: pks})
+	res, err := client.GetTestCases(ctx, &protos.GetTestCasesRequest{Pks: pks})
 	if err != nil {
 		return nil, err
 	}
@@ -106,7 +106,7 @@ func GetTestCases(pks []int64, serdes serde.Registry) (map[int64]*UnmarshalledTe
 	return ret, nil
 }
 
-func CreateOrUpdateTestCase(pk int64, testCaseType string, testCaseConfig interface{}, serdes serde.Registry) error {
+func CreateOrUpdateTestCase(ctx context.Context, pk int64, testCaseType string, testCaseConfig interface{}, serdes serde.Registry) error {
 	marshaledConfig, err := serde.Serialize(testCaseConfig, testCaseType, serdes)
 	if err != nil {
 		return errors.Wrap(err, "failed to serialize config")
@@ -117,7 +117,7 @@ func CreateOrUpdateTestCase(pk int64, testCaseType string, testCaseConfig interf
 		return err
 	}
 	_, err = client.CreateOrUpdateTestCase(
-		context.Background(),
+		ctx,
 		&protos.CreateTestCaseRequest{
 			Test: &storage.MutableTestCase{
 				Pk:           pk,

--- a/fbinternal/cloud/go/services/testcontroller/node_client_api.go
+++ b/fbinternal/cloud/go/services/testcontroller/node_client_api.go
@@ -35,66 +35,66 @@ func getNodeClient() (protos.NodeLeasorClient, error) {
 	return protos.NewNodeLeasorClient(conn), nil
 }
 
-func GetNodes(ids []string, tag *string) (map[string]*storage.CINode, error) {
+func GetNodes(ctx context.Context, ids []string, tag *string) (map[string]*storage.CINode, error) {
 	client, err := getNodeClient()
 	if err != nil {
 		return nil, err
 	}
-	res, err := client.GetNodes(context.Background(), &protos.GetNodesRequest{Ids: ids, Tag: asStringValue(tag)})
+	res, err := client.GetNodes(ctx, &protos.GetNodesRequest{Ids: ids, Tag: asStringValue(tag)})
 	if err != nil {
 		return nil, err
 	}
 	return res.Nodes, nil
 }
 
-func CreateOrUpdateNode(node *storage.MutableCINode) error {
+func CreateOrUpdateNode(ctx context.Context, node *storage.MutableCINode) error {
 	client, err := getNodeClient()
 	if err != nil {
 		return err
 	}
-	_, err = client.CreateOrUpdateNode(context.Background(), &protos.CreateOrUpdateNodeRequest{Node: node})
+	_, err = client.CreateOrUpdateNode(ctx, &protos.CreateOrUpdateNodeRequest{Node: node})
 	return err
 }
 
-func DeleteNode(id string) error {
+func DeleteNode(ctx context.Context, id string) error {
 	client, err := getNodeClient()
 	if err != nil {
 		return err
 	}
-	_, err = client.DeleteNode(context.Background(), &protos.DeleteNodeRequest{Id: id})
+	_, err = client.DeleteNode(ctx, &protos.DeleteNodeRequest{Id: id})
 	return err
 }
 
-func ReserveNode(id string) (*storage.NodeLease, error) {
+func ReserveNode(ctx context.Context, id string) (*storage.NodeLease, error) {
 	client, err := getNodeClient()
 	if err != nil {
 		return nil, err
 	}
-	res, err := client.ReserveNode(context.Background(), &protos.ReserveNodeRequest{Id: id})
+	res, err := client.ReserveNode(ctx, &protos.ReserveNodeRequest{Id: id})
 	if err != nil {
 		return nil, err
 	}
 	return res.Lease, nil
 }
 
-func LeaseNode(tag string) (*storage.NodeLease, error) {
+func LeaseNode(ctx context.Context, tag string) (*storage.NodeLease, error) {
 	client, err := getNodeClient()
 	if err != nil {
 		return nil, err
 	}
-	res, err := client.LeaseNode(context.Background(), &protos.LeaseNodeRequest{Tag: tag})
+	res, err := client.LeaseNode(ctx, &protos.LeaseNodeRequest{Tag: tag})
 	if err != nil {
 		return nil, err
 	}
 	return res.Lease, nil
 }
 
-func ReleaseNode(id string, leaseID string) error {
+func ReleaseNode(ctx context.Context, id string, leaseID string) error {
 	client, err := getNodeClient()
 	if err != nil {
 		return err
 	}
-	_, err = client.ReleaseNode(context.Background(), &protos.ReleaseNodeRequest{NodeID: id, LeaseID: leaseID})
+	_, err = client.ReleaseNode(ctx, &protos.ReleaseNodeRequest{NodeID: id, LeaseID: leaseID})
 	return err
 }
 

--- a/fbinternal/cloud/go/services/testcontroller/obsidian/handlers/node_handlers.go
+++ b/fbinternal/cloud/go/services/testcontroller/obsidian/handlers/node_handlers.go
@@ -64,7 +64,7 @@ func listCINodes(c echo.Context) error {
 		tag = strPtr("")
 	}
 
-	nodes, err := testcontroller.GetNodes(nil, tag)
+	nodes, err := testcontroller.GetNodes(c.Request().Context(), nil, tag)
 	if err != nil {
 		return obsidian.HttpError(err, http.StatusInternalServerError)
 	}
@@ -83,7 +83,7 @@ func getCINode(c echo.Context) error {
 		return nerr
 	}
 
-	nodes, err := testcontroller.GetNodes(idParam, nil)
+	nodes, err := testcontroller.GetNodes(c.Request().Context(), idParam, nil)
 	if err != nil {
 		return obsidian.HttpError(err, http.StatusInternalServerError)
 	}
@@ -103,7 +103,7 @@ func createCINode(c echo.Context) error {
 		return obsidian.HttpError(err, http.StatusBadRequest)
 	}
 
-	err := testcontroller.CreateOrUpdateNode(&storage.MutableCINode{Id: *node.ID, Tag: node.Tag, VpnIP: string(*node.VpnIP)})
+	err := testcontroller.CreateOrUpdateNode(c.Request().Context(), &storage.MutableCINode{Id: *node.ID, Tag: node.Tag, VpnIP: string(*node.VpnIP)})
 	if err != nil {
 		return obsidian.HttpError(err, http.StatusInternalServerError)
 	}
@@ -127,7 +127,7 @@ func updateCINode(c echo.Context) error {
 	if *node.ID != idParam[0] {
 		return obsidian.HttpError(errors.New("payload ID does not match path param"), http.StatusBadRequest)
 	}
-	err := testcontroller.CreateOrUpdateNode(&storage.MutableCINode{Id: *node.ID, Tag: node.Tag, VpnIP: string(*node.VpnIP)})
+	err := testcontroller.CreateOrUpdateNode(c.Request().Context(), &storage.MutableCINode{Id: *node.ID, Tag: node.Tag, VpnIP: string(*node.VpnIP)})
 	if err != nil {
 		return obsidian.HttpError(err, http.StatusInternalServerError)
 	}
@@ -140,7 +140,7 @@ func deleteCINode(c echo.Context) error {
 		return nerr
 	}
 
-	err := testcontroller.DeleteNode(idParam[0])
+	err := testcontroller.DeleteNode(c.Request().Context(), idParam[0])
 	if err != nil {
 		return obsidian.HttpError(err, http.StatusInternalServerError)
 	}
@@ -148,7 +148,7 @@ func deleteCINode(c echo.Context) error {
 }
 
 func leaseCINode(c echo.Context) error {
-	lease, err := testcontroller.LeaseNode(c.QueryParam(tagParamName))
+	lease, err := testcontroller.LeaseNode(c.Request().Context(), c.QueryParam(tagParamName))
 	if err != nil {
 		return obsidian.HttpError(err, http.StatusInternalServerError)
 	}
@@ -168,7 +168,7 @@ func reserveCINode(c echo.Context) error {
 		return nerr
 	}
 
-	lease, err := testcontroller.ReserveNode(idParam[0])
+	lease, err := testcontroller.ReserveNode(c.Request().Context(), idParam[0])
 	if err != nil {
 		return obsidian.HttpError(err, http.StatusInternalServerError)
 	}
@@ -189,7 +189,7 @@ func returnManuallyReservedCINode(c echo.Context) error {
 	}
 
 	// TODO: maybe expose this constant from the storage package?
-	err := testcontroller.ReleaseNode(idParam[0], "manual")
+	err := testcontroller.ReleaseNode(c.Request().Context(), idParam[0], "manual")
 	if err != nil {
 		return obsidian.HttpError(err, http.StatusInternalServerError)
 	}
@@ -202,7 +202,7 @@ func releaseCINode(c echo.Context) error {
 		return nerr
 	}
 	nodeID, leaseID := params[0], params[1]
-	err := testcontroller.ReleaseNode(nodeID, leaseID)
+	err := testcontroller.ReleaseNode(c.Request().Context(), nodeID, leaseID)
 	if err == nil {
 		return c.NoContent(http.StatusNoContent)
 	}

--- a/fbinternal/cloud/go/services/testcontroller/obsidian/handlers/node_handlers_test.go
+++ b/fbinternal/cloud/go/services/testcontroller/obsidian/handlers/node_handlers_test.go
@@ -14,6 +14,7 @@
 package handlers_test
 
 import (
+	context2 "context"
 	"testing"
 	"time"
 
@@ -54,9 +55,9 @@ func Test_ListCINodes(t *testing.T) {
 	tests.RunUnitTest(t, e, tc)
 
 	// Happy path
-	err := testcontroller.CreateOrUpdateNode(&storage.MutableCINode{Id: "node1", Tag: "foo", VpnIP: "192.168.100.1"})
+	err := testcontroller.CreateOrUpdateNode(context2.Background(), &storage.MutableCINode{Id: "node1", Tag: "foo", VpnIP: "192.168.100.1"})
 	assert.NoError(t, err)
-	err = testcontroller.CreateOrUpdateNode(&storage.MutableCINode{Id: "node2", VpnIP: "10.0.2.1"})
+	err = testcontroller.CreateOrUpdateNode(context2.Background(), &storage.MutableCINode{Id: "node2", VpnIP: "10.0.2.1"})
 	assert.NoError(t, err)
 	tc.ExpectedResult = tests.JSONMarshaler([]*models.CiNode{
 		{
@@ -123,7 +124,7 @@ func Test_GetCINode(t *testing.T) {
 	tests.RunUnitTest(t, e, tc)
 
 	// Happy path
-	err := testcontroller.CreateOrUpdateNode(&storage.MutableCINode{Id: "node1", VpnIP: "192.168.100.1"})
+	err := testcontroller.CreateOrUpdateNode(context2.Background(), &storage.MutableCINode{Id: "node1", VpnIP: "192.168.100.1"})
 	assert.NoError(t, err)
 	tc = tests.Test{
 		Method:         "GET",
@@ -178,7 +179,7 @@ func Test_CreateCINode(t *testing.T) {
 	}
 	tests.RunUnitTest(t, e, tc)
 
-	actual, err := testcontroller.GetNodes(nil, nil)
+	actual, err := testcontroller.GetNodes(context2.Background(), nil, nil)
 	assert.NoError(t, err)
 	expected := map[string]*storage.CINode{
 		"node1": {
@@ -222,7 +223,7 @@ func Test_UpdateCINode(t *testing.T) {
 	}
 	tests.RunUnitTest(t, e, tc)
 
-	actual, err := testcontroller.GetNodes(nil, nil)
+	actual, err := testcontroller.GetNodes(context2.Background(), nil, nil)
 	assert.NoError(t, err)
 	expected := map[string]*storage.CINode{
 		"node1": {
@@ -240,7 +241,7 @@ func Test_UpdateCINode(t *testing.T) {
 		VpnIP: ipv4("192.168.100.1"),
 	}
 	tests.RunUnitTest(t, e, tc)
-	actual, err = testcontroller.GetNodes(nil, nil)
+	actual, err = testcontroller.GetNodes(context2.Background(), nil, nil)
 	assert.NoError(t, err)
 	expected["node1"].VpnIp = "192.168.100.1"
 	assert.Equal(t, expected, actual)
@@ -253,7 +254,7 @@ func Test_UpdateCINode(t *testing.T) {
 	tc.ExpectedStatus = 400
 	tc.ExpectedError = "payload ID does not match path param"
 	tests.RunUnitTest(t, e, tc)
-	actual, err = testcontroller.GetNodes(nil, nil)
+	actual, err = testcontroller.GetNodes(context2.Background(), nil, nil)
 	assert.NoError(t, err)
 	assert.Equal(t, expected, actual)
 }
@@ -279,10 +280,10 @@ func Test_DeleteCINode(t *testing.T) {
 	tests.RunUnitTest(t, e, tc)
 
 	// Happy path
-	err := testcontroller.CreateOrUpdateNode(&storage.MutableCINode{Id: "node1", VpnIP: "10.0.2.1"})
+	err := testcontroller.CreateOrUpdateNode(context2.Background(), &storage.MutableCINode{Id: "node1", VpnIP: "10.0.2.1"})
 	assert.NoError(t, err)
 	tests.RunUnitTest(t, e, tc)
-	actual, err := testcontroller.GetNodes(nil, nil)
+	actual, err := testcontroller.GetNodes(context2.Background(), nil, nil)
 	assert.NoError(t, err)
 	assert.Empty(t, actual)
 }
@@ -311,9 +312,9 @@ func Test_ReserveCINode(t *testing.T) {
 	tests.RunUnitTest(t, e, tc)
 
 	// Happy path
-	err := testcontroller.CreateOrUpdateNode(&storage.MutableCINode{Id: "node1", VpnIP: "192.168.100.1"})
+	err := testcontroller.CreateOrUpdateNode(context2.Background(), &storage.MutableCINode{Id: "node1", VpnIP: "192.168.100.1"})
 	assert.NoError(t, err)
-	err = testcontroller.CreateOrUpdateNode(&storage.MutableCINode{Id: "node2", Tag: "foo", VpnIP: "10.0.0.2"})
+	err = testcontroller.CreateOrUpdateNode(context2.Background(), &storage.MutableCINode{Id: "node2", Tag: "foo", VpnIP: "10.0.0.2"})
 	assert.NoError(t, err)
 	tc = tests.Test{
 		Method:         "POST",
@@ -327,7 +328,7 @@ func Test_ReserveCINode(t *testing.T) {
 		},
 	}
 	tests.RunUnitTest(t, e, tc)
-	actual, err := testcontroller.GetNodes(nil, strPtr(""))
+	actual, err := testcontroller.GetNodes(context2.Background(), nil, strPtr(""))
 	assert.NoError(t, err)
 	expected := map[string]*storage.CINode{
 		"node1": {
@@ -364,7 +365,7 @@ func Test_ReserveCINode(t *testing.T) {
 		},
 	}
 	tests.RunUnitTest(t, e, tc)
-	actual, err = testcontroller.GetNodes(nil, strPtr(""))
+	actual, err = testcontroller.GetNodes(context2.Background(), nil, strPtr(""))
 	assert.NoError(t, err)
 	expected = map[string]*storage.CINode{
 		"node1": {
@@ -389,7 +390,7 @@ func Test_ReserveCINode(t *testing.T) {
 		},
 	}
 	tests.RunUnitTest(t, e, tc)
-	actual, err = testcontroller.GetNodes(nil, nil)
+	actual, err = testcontroller.GetNodes(context2.Background(), nil, nil)
 	assert.NoError(t, err)
 	expected = map[string]*storage.CINode{
 		"node1": {
@@ -435,7 +436,7 @@ func Test_ReserveSpecificCINode(t *testing.T) {
 	tests.RunUnitTest(t, e, tc)
 
 	// Happy path
-	err := testcontroller.CreateOrUpdateNode(&storage.MutableCINode{Id: "node1", VpnIP: "192.168.100.1"})
+	err := testcontroller.CreateOrUpdateNode(context2.Background(), &storage.MutableCINode{Id: "node1", VpnIP: "192.168.100.1"})
 	assert.NoError(t, err)
 	tc = tests.Test{
 		Method:         "POST",
@@ -451,7 +452,7 @@ func Test_ReserveSpecificCINode(t *testing.T) {
 		},
 	}
 	tests.RunUnitTest(t, e, tc)
-	actual, err := testcontroller.GetNodes(nil, nil)
+	actual, err := testcontroller.GetNodes(context2.Background(), nil, nil)
 	assert.NoError(t, err)
 	expected := map[string]*storage.CINode{
 		"node1": {
@@ -506,9 +507,9 @@ func Test_ReleaseCINode(t *testing.T) {
 	tests.RunUnitTest(t, e, tc)
 
 	// Happy path
-	err := testcontroller.CreateOrUpdateNode(&storage.MutableCINode{Id: "node1", VpnIP: "192.168.100.1"})
+	err := testcontroller.CreateOrUpdateNode(context2.Background(), &storage.MutableCINode{Id: "node1", VpnIP: "192.168.100.1"})
 	assert.NoError(t, err)
-	actualLease, err := testcontroller.LeaseNode("")
+	actualLease, err := testcontroller.LeaseNode(context2.Background(), "")
 	assert.NoError(t, err)
 	expectedLease := &storage.NodeLease{Id: "node1", VpnIP: "192.168.100.1", LeaseID: "1"}
 	assert.Equal(t, expectedLease, actualLease)
@@ -522,7 +523,7 @@ func Test_ReleaseCINode(t *testing.T) {
 	}
 	tests.RunUnitTest(t, e, tc)
 
-	actual, err := testcontroller.GetNodes(nil, nil)
+	actual, err := testcontroller.GetNodes(context2.Background(), nil, nil)
 	assert.NoError(t, err)
 	expected := map[string]*storage.CINode{
 		"node1": {

--- a/fbinternal/cloud/go/services/testcontroller/obsidian/handlers/testcontroller_handlers_test.go
+++ b/fbinternal/cloud/go/services/testcontroller/obsidian/handlers/testcontroller_handlers_test.go
@@ -14,6 +14,7 @@
 package handlers_test
 
 import (
+	context2 "context"
 	"testing"
 
 	"magma/fbinternal/cloud/go/serdes"
@@ -52,11 +53,11 @@ func Test_ListTestCases(t *testing.T) {
 	tests.RunUnitTest(t, e, tc)
 
 	// Happy path
-	err := testcontroller.CreateOrUpdateTestCase(1, testcontroller.EnodedTestCaseType, defaultEnodebdTestConfig(), serdes.TestController)
+	err := testcontroller.CreateOrUpdateTestCase(context2.Background(), 1, testcontroller.EnodedTestCaseType, defaultEnodebdTestConfig(), serdes.TestController)
 	assert.NoError(t, err)
-	err = testcontroller.CreateOrUpdateTestCase(2, testcontroller.EnodedTestCaseType, defaultEnodebdTestConfig(), serdes.TestController)
+	err = testcontroller.CreateOrUpdateTestCase(context2.Background(), 2, testcontroller.EnodedTestCaseType, defaultEnodebdTestConfig(), serdes.TestController)
 	assert.NoError(t, err)
-	err = testcontroller.CreateOrUpdateTestCase(3, testcontroller.EnodedTestExcludeTraffic, enodebdNoTrafficTestConfig(), serdes.TestController)
+	err = testcontroller.CreateOrUpdateTestCase(context2.Background(), 3, testcontroller.EnodedTestExcludeTraffic, enodebdNoTrafficTestConfig(), serdes.TestController)
 	assert.NoError(t, err)
 
 	tc.ExpectedResult = tests.JSONMarshaler([]*models.E2eTestCase{
@@ -117,9 +118,9 @@ func Test_ListEnodebdTestCases(t *testing.T) {
 	tests.RunUnitTest(t, e, tc)
 
 	// Happy path
-	err := testcontroller.CreateOrUpdateTestCase(1, testcontroller.EnodedTestCaseType, defaultEnodebdTestConfig(), serdes.TestController)
+	err := testcontroller.CreateOrUpdateTestCase(context2.Background(), 1, testcontroller.EnodedTestCaseType, defaultEnodebdTestConfig(), serdes.TestController)
 	assert.NoError(t, err)
-	err = testcontroller.CreateOrUpdateTestCase(2, testcontroller.EnodedTestCaseType, defaultEnodebdTestConfig(), serdes.TestController)
+	err = testcontroller.CreateOrUpdateTestCase(context2.Background(), 2, testcontroller.EnodedTestCaseType, defaultEnodebdTestConfig(), serdes.TestController)
 	assert.NoError(t, err)
 	tc.ExpectedResult = tests.JSONMarshaler([]*models.EnodebdE2eTest{
 		{
@@ -167,7 +168,7 @@ func Test_CreateEnodebdTestCase(t *testing.T) {
 	}
 	tests.RunUnitTest(t, e, tc)
 
-	actual, err := testcontroller.GetTestCases(nil, serdes.TestController)
+	actual, err := testcontroller.GetTestCases(context2.Background(), nil, serdes.TestController)
 	assert.NoError(t, err)
 	expected := map[int64]*testcontroller.UnmarshalledTestCase{
 		1: {
@@ -220,7 +221,7 @@ func Test_GetEnodebdTestCase(t *testing.T) {
 	tests.RunUnitTest(t, e, tc)
 
 	// Happy path
-	err := testcontroller.CreateOrUpdateTestCase(1, testcontroller.EnodedTestCaseType, defaultEnodebdTestConfig(), serdes.TestController)
+	err := testcontroller.CreateOrUpdateTestCase(context2.Background(), 1, testcontroller.EnodedTestCaseType, defaultEnodebdTestConfig(), serdes.TestController)
 	assert.NoError(t, err)
 	tc = tests.Test{
 		Method:         "GET",
@@ -252,7 +253,7 @@ func Test_UpdateEnodebdTestCase(t *testing.T) {
 	oHands := handlers.GetObsidianHandlers()
 	updateTest := tests.GetHandlerByPathAndMethod(t, oHands, testURLRoot+"/:test_pk", obsidian.PUT).HandlerFunc
 
-	err := testcontroller.CreateOrUpdateTestCase(1, testcontroller.EnodedTestCaseType, defaultEnodebdTestConfig(), serdes.TestController)
+	err := testcontroller.CreateOrUpdateTestCase(context2.Background(), 1, testcontroller.EnodedTestCaseType, defaultEnodebdTestConfig(), serdes.TestController)
 	assert.NoError(t, err)
 
 	newCfg := defaultEnodebdTestConfig()
@@ -269,7 +270,7 @@ func Test_UpdateEnodebdTestCase(t *testing.T) {
 	}
 	tests.RunUnitTest(t, e, tc)
 
-	actual, err := testcontroller.GetTestCases(nil, serdes.TestController)
+	actual, err := testcontroller.GetTestCases(context2.Background(), nil, serdes.TestController)
 	assert.NoError(t, err)
 	expected := map[int64]*testcontroller.UnmarshalledTestCase{
 		1: {
@@ -297,7 +298,7 @@ func Test_DeleteEnodebdTestCase(t *testing.T) {
 	oHands := handlers.GetObsidianHandlers()
 	deleteTest := tests.GetHandlerByPathAndMethod(t, oHands, testURLRoot+"/:test_pk", obsidian.DELETE).HandlerFunc
 
-	err := testcontroller.CreateOrUpdateTestCase(1, testcontroller.EnodedTestCaseType, defaultEnodebdTestConfig(), serdes.TestController)
+	err := testcontroller.CreateOrUpdateTestCase(context2.Background(), 1, testcontroller.EnodedTestCaseType, defaultEnodebdTestConfig(), serdes.TestController)
 	assert.NoError(t, err)
 
 	tc := tests.Test{
@@ -309,7 +310,7 @@ func Test_DeleteEnodebdTestCase(t *testing.T) {
 		ExpectedStatus: 204,
 	}
 	tests.RunUnitTest(t, e, tc)
-	actual, err := testcontroller.GetTestCases(nil, serdes.TestController)
+	actual, err := testcontroller.GetTestCases(context2.Background(), nil, serdes.TestController)
 	assert.NoError(t, err)
 	assert.Empty(t, actual)
 }

--- a/fbinternal/cloud/go/services/vpnservice/client_api.go
+++ b/fbinternal/cloud/go/services/vpnservice/client_api.go
@@ -25,13 +25,13 @@ func getVPNServiceClient() (fbprotos.VPNServiceClient, error) {
 }
 
 // Get the VPN CA certificate
-func GetVPNCA() (cert []byte, err error) {
+func GetVPNCA(ctx context.Context) (cert []byte, err error) {
 	client, err := getVPNServiceClient()
 	if err != nil {
 		return nil, err
 	}
 
-	caMsg, err := client.GetCA(context.Background(), &protos.Void{})
+	caMsg, err := client.GetCA(ctx, &protos.Void{})
 	if err != nil {
 		glog.Errorf("Failed to get VPN CA: %s", err)
 		return nil, err
@@ -42,14 +42,14 @@ func GetVPNCA() (cert []byte, err error) {
 
 // Return a certificate signed by the VPN CA, with serial number.
 // CSR is in ASN.1 DER encoding.
-func RequestSignedCert(csr []byte) (sn string, cert []byte, err error) {
+func RequestSignedCert(ctx context.Context, csr []byte) (sn string, cert []byte, err error) {
 	client, err := getVPNServiceClient()
 	if err != nil {
 		return "", nil, err
 	}
 
 	req := &fbprotos.VPNCertRequest{Request: csr}
-	certMsg, err := client.RequestCert(context.Background(), req)
+	certMsg, err := client.RequestCert(ctx, req)
 	if err != nil {
 		glog.Errorf("Failed to retrieve signed VPN cert: %s", err)
 		return "", nil, err

--- a/feg/cloud/go/services/feg/obsidian/handlers/handlers.go
+++ b/feg/cloud/go/services/feg/obsidian/handlers/handlers.go
@@ -209,6 +209,8 @@ func getClusterStatusHandler(c echo.Context) error {
 	if nerr != nil {
 		return nerr
 	}
+
+	reqCtx := c.Request().Context()
 	network, err := configurator.LoadNetwork(nid, true, true, serdes.Network)
 	if err == merrors.ErrNotFound {
 		return c.NoContent(http.StatusNotFound)
@@ -219,7 +221,7 @@ func getClusterStatusHandler(c echo.Context) error {
 	if network.Type != feg.FederationNetworkType {
 		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("network %s is not a <%s> network", nid, feg.FederationNetworkType))
 	}
-	activeGw, err := health.GetActiveGateway(nid)
+	activeGw, err := health.GetActiveGateway(reqCtx, nid)
 	if err != nil {
 		return obsidian.HttpError(err, http.StatusInternalServerError)
 	}
@@ -234,6 +236,8 @@ func getHealthStatusHandler(c echo.Context) error {
 	if nerr != nil {
 		return nerr
 	}
+
+	reqCtx := c.Request().Context()
 	pid, err := configurator.GetPhysicalIDOfEntity(nid, orc8r.MagmadGatewayType, gid)
 	if err == merrors.ErrNotFound || len(pid) == 0 {
 		return c.NoContent(http.StatusNotFound)
@@ -241,7 +245,7 @@ func getHealthStatusHandler(c echo.Context) error {
 	if err != nil {
 		return obsidian.HttpError(err, http.StatusInternalServerError)
 	}
-	res, err := health.GetHealth(nid, gid)
+	res, err := health.GetHealth(reqCtx, nid, gid)
 	if err != nil {
 		return obsidian.HttpError(err, http.StatusInternalServerError)
 	}

--- a/feg/cloud/go/services/feg_relay/gw_to_feg_relay/feg_connection.go
+++ b/feg/cloud/go/services/feg_relay/gw_to_feg_relay/feg_connection.go
@@ -37,12 +37,11 @@ func (rtr *Router) GetFegServiceConnection(
 	imsi string,
 	service gateway_registry.GwServiceType,
 ) (conn *grpc.ClientConn, ctx context.Context, cancel context.CancelFunc, err error) {
-
 	gwId, err := RetrieveGatewayIdentity(inCtx)
 	if err != nil {
 		return
 	}
-	fegHwId, err := FindServingFeGHwId(gwId.GetNetworkId(), imsi)
+	fegHwId, err := FindServingFeGHwId(inCtx, gwId.GetNetworkId(), imsi)
 	if err != nil {
 		return
 	}

--- a/feg/cloud/go/services/feg_relay/gw_to_feg_relay/gw_to_feg_relay.go
+++ b/feg/cloud/go/services/feg_relay/gw_to_feg_relay/gw_to_feg_relay.go
@@ -91,7 +91,7 @@ func (server *GatewayToFeGServer) useDispatcherHandler(responseWriter http.Respo
 	}
 	http2.LogRequestWithVerbosity(req, 4)
 	// get destination feg hwId
-	fegHwId, err := getFeGHwIdForNetwork(gw.NetworkId)
+	fegHwId, err := getFeGHwIdForNetwork(req.Context(), gw.NetworkId)
 	if err != nil {
 		glog.Errorf(err.Error())
 		http2.WriteErrResponse(responseWriter,
@@ -151,7 +151,7 @@ func createNewRequest(req *http.Request, addr, hwId string) (*http.Request, *htt
 	return newReq, nil
 }
 
-func getFeGHwIdForNetwork(agNwID string) (string, error) {
+func getFeGHwIdForNetwork(ctx context.Context, agNwID string) (string, error) {
 	cfg, err := configurator.LoadNetworkConfig(agNwID, feg.FederatedNetworkType, serdes.Network)
 	if err != nil {
 		return "", fmt.Errorf("could not load federated network configs for access network %s: %s", agNwID, err)
@@ -174,14 +174,14 @@ func getFeGHwIdForNetwork(agNwID string) (string, error) {
 	servedNetworkIDs := networkFegConfigs.ServedNetworkIds
 	for _, network := range servedNetworkIDs {
 		if agNwID == network {
-			return getActiveFeGForNetwork(*federatedConfig.FegNetworkID)
+			return getActiveFeGForNetwork(ctx, *federatedConfig.FegNetworkID)
 		}
 	}
 	return "", fmt.Errorf("federation network %s is not configured to serve network: %s", *federatedConfig.FegNetworkID, agNwID)
 }
 
-func getActiveFeGForNetwork(fegNetworkID string) (string, error) {
-	activeGW, err := health.GetActiveGateway(fegNetworkID)
+func getActiveFeGForNetwork(ctx context.Context, fegNetworkID string) (string, error) {
+	activeGW, err := health.GetActiveGateway(ctx, fegNetworkID)
 	if err != nil {
 		return "", fmt.Errorf("Unable to retrieve active FeG for network: %s; %s", fegNetworkID, err)
 	}

--- a/feg/cloud/go/services/feg_relay/gw_to_feg_relay/tests/relay_test.go
+++ b/feg/cloud/go/services/feg_relay/gw_to_feg_relay/tests/relay_test.go
@@ -93,7 +93,7 @@ func TestNHRouting(t *testing.T) {
 	testHealthServiser := setupNeutralHostNetworks(t)
 
 	// test # 1: Verify, relay finds the right serving FeG for IMSI's PLMN ID
-	foundFegHwId, err := gw_to_feg_relay.FindServingFeGHwId(federatedLteNetworkID, nhImsi)
+	foundFegHwId, err := gw_to_feg_relay.FindServingFeGHwId(context.Background(), federatedLteNetworkID, nhImsi)
 	assert.NoError(t, err)
 	assert.Equal(t, fegHwId, foundFegHwId)
 
@@ -224,11 +224,11 @@ func TestNHRouting(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Verify that NH FeG will be used as "catch all" for all but nhPlmnId
-	foundFegHwId, err = gw_to_feg_relay.FindServingFeGHwId(federatedLteNetworkID, "") // no IMSI
+	foundFegHwId, err = gw_to_feg_relay.FindServingFeGHwId(context.Background(), federatedLteNetworkID, "") // no IMSI
 	assert.NoError(t, err)
 	assert.Equal(t, nhFegHwId, foundFegHwId)
 
-	foundFegHwId, err = gw_to_feg_relay.FindServingFeGHwId(federatedLteNetworkID, nhImsi) // NH IMSI
+	foundFegHwId, err = gw_to_feg_relay.FindServingFeGHwId(context.Background(), federatedLteNetworkID, nhImsi) // NH IMSI
 	assert.NoError(t, err)
 	assert.Equal(t, fegHwId, foundFegHwId)
 
@@ -272,13 +272,13 @@ func TestNHRouting(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Verify, relay now finds the NH local FeG for any IMSI
-	foundFegHwId, err = gw_to_feg_relay.FindServingFeGHwId(federatedLteNetworkID, nhImsi)
+	foundFegHwId, err = gw_to_feg_relay.FindServingFeGHwId(context.Background(), federatedLteNetworkID, nhImsi)
 	assert.NoError(t, err)
 	assert.Equal(t, nhFegHwId, foundFegHwId)
-	foundFegHwId, err = gw_to_feg_relay.FindServingFeGHwId(federatedLteNetworkID, nonNhImsi)
+	foundFegHwId, err = gw_to_feg_relay.FindServingFeGHwId(context.Background(), federatedLteNetworkID, nonNhImsi)
 	assert.NoError(t, err)
 	assert.Equal(t, nhFegHwId, foundFegHwId)
-	foundFegHwId, err = gw_to_feg_relay.FindServingFeGHwId(federatedLteNetworkID, "") // no IMSI
+	foundFegHwId, err = gw_to_feg_relay.FindServingFeGHwId(context.Background(), federatedLteNetworkID, "") // no IMSI
 	assert.NoError(t, err)
 	assert.Equal(t, nhFegHwId, foundFegHwId)
 

--- a/feg/cloud/go/services/health/client_api.go
+++ b/feg/cloud/go/services/health/client_api.go
@@ -40,14 +40,14 @@ func getHealthClient() (protos.HealthClient, error) {
 }
 
 // GetActiveGateway returns the active federated gateway in the network specified by networkID
-func GetActiveGateway(networkID string) (string, error) {
+func GetActiveGateway(ctx context.Context, networkID string) (string, error) {
 	client, err := getHealthClient()
 	if err != nil {
 		return "", err
 	}
 
 	// Currently, we use networkID as clusterID as we only support one cluster per network
-	clusterState, err := client.GetClusterState(context.Background(), &protos.ClusterStateRequest{
+	clusterState, err := client.GetClusterState(ctx, &protos.ClusterStateRequest{
 		NetworkId: networkID,
 		ClusterId: networkID,
 	})
@@ -59,7 +59,7 @@ func GetActiveGateway(networkID string) (string, error) {
 
 // GetHealth fetches the health stats for a given gateway
 // represented by a (networkID, logicalId)
-func GetHealth(networkID string, logicalID string) (*protos.HealthStats, error) {
+func GetHealth(ctx context.Context, networkID string, logicalID string) (*protos.HealthStats, error) {
 	if len(networkID) == 0 {
 		return nil, fmt.Errorf("Empty networkId provided")
 	}
@@ -75,5 +75,5 @@ func GetHealth(networkID string, logicalID string) (*protos.HealthStats, error) 
 		NetworkId: networkID,
 		LogicalId: logicalID,
 	}
-	return client.GetHealth(context.Background(), gatewayHealthReq)
+	return client.GetHealth(ctx, gatewayHealthReq)
 }

--- a/feg/cloud/go/services/health/client_api_test.go
+++ b/feg/cloud/go/services/health/client_api_test.go
@@ -49,7 +49,7 @@ func TestHealthAPI_SingleFeg(t *testing.T) {
 		test_utils.TestFegHwId1,
 		test_utils.TestFegLogicalId1,
 	)
-	active, err := health.GetActiveGateway(test_utils.TestFegNetwork)
+	active, err := health.GetActiveGateway(context.Background(), test_utils.TestFegNetwork)
 	assert.NoError(t, err)
 	assert.Equal(t, test_utils.TestFegNetwork, active)
 
@@ -62,7 +62,7 @@ func TestHealthAPI_SingleFeg(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, protos.HealthResponse_SYSTEM_UP, res.Action)
 
-	activeID, err := health.GetActiveGateway(test_utils.TestFegNetwork)
+	activeID, err := health.GetActiveGateway(context.Background(), test_utils.TestFegNetwork)
 	assert.NoError(t, err)
 	assert.Equal(t, test_utils.TestFegLogicalId1, activeID)
 	checkHealthData(t, test_utils.TestFegNetwork, test_utils.TestFegLogicalId1, healthyRequest.HealthStats)
@@ -73,7 +73,7 @@ func TestHealthAPI_SingleFeg(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, protos.HealthResponse_SYSTEM_UP, res.Action)
 
-	activeID, err = health.GetActiveGateway(test_utils.TestFegNetwork)
+	activeID, err = health.GetActiveGateway(context.Background(), test_utils.TestFegNetwork)
 	assert.NoError(t, err)
 	assert.Equal(t, test_utils.TestFegLogicalId1, activeID)
 	checkHealthData(t, test_utils.TestFegNetwork, test_utils.TestFegLogicalId1, unhealthyRequest.HealthStats)
@@ -106,7 +106,7 @@ func TestHealthAPI_DualFeg(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, protos.HealthResponse_SYSTEM_UP, res.Action)
 
-	activeID, err := health.GetActiveGateway(test_utils.TestFegNetwork)
+	activeID, err := health.GetActiveGateway(context.Background(), test_utils.TestFegNetwork)
 	assert.NoError(t, err)
 	assert.Equal(t, test_utils.TestFegLogicalId1, activeID)
 	checkHealthData(t, test_utils.TestFegNetwork, test_utils.TestFegLogicalId1, healthyRequest.HealthStats)
@@ -127,7 +127,7 @@ func TestHealthAPI_DualFeg(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, protos.HealthResponse_SYSTEM_DOWN, res.Action)
 
-	activeID, err = health.GetActiveGateway(test_utils.TestFegNetwork)
+	activeID, err = health.GetActiveGateway(context.Background(), test_utils.TestFegNetwork)
 	assert.NoError(t, err)
 	assert.Equal(t, test_utils.TestFegLogicalId1, activeID)
 	checkHealthData(t, test_utils.TestFegNetwork, test_utils.TestFegLogicalId2, healthyRequest.HealthStats)
@@ -140,7 +140,7 @@ func TestHealthAPI_DualFeg(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, protos.HealthResponse_SYSTEM_DOWN, res.Action)
 
-	activeID, err = health.GetActiveGateway(test_utils.TestFegNetwork)
+	activeID, err = health.GetActiveGateway(context.Background(), test_utils.TestFegNetwork)
 	assert.NoError(t, err)
 	assert.Equal(t, test_utils.TestFegLogicalId2, activeID)
 	checkHealthData(t, test_utils.TestFegNetwork, test_utils.TestFegLogicalId1, unhealthyRequest.HealthStats)
@@ -152,7 +152,7 @@ func TestHealthAPI_DualFeg(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, protos.HealthResponse_SYSTEM_UP, res.Action)
 
-	activeID, err = health.GetActiveGateway(test_utils.TestFegNetwork)
+	activeID, err = health.GetActiveGateway(context.Background(), test_utils.TestFegNetwork)
 	assert.NoError(t, err)
 	assert.Equal(t, test_utils.TestFegLogicalId2, activeID)
 	checkHealthData(t, test_utils.TestFegNetwork, test_utils.TestFegLogicalId2, healthyRequest.HealthStats)
@@ -162,7 +162,7 @@ func TestHealthAPI_DualFeg(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, protos.HealthResponse_SYSTEM_UP, res.Action)
 
-	activeID, err = health.GetActiveGateway(test_utils.TestFegNetwork)
+	activeID, err = health.GetActiveGateway(context.Background(), test_utils.TestFegNetwork)
 	assert.NoError(t, err)
 	assert.Equal(t, test_utils.TestFegLogicalId2, activeID)
 	checkHealthData(t, test_utils.TestFegNetwork, test_utils.TestFegLogicalId2, unhealthyRequest.HealthStats)
@@ -174,7 +174,7 @@ func TestHealthAPI_DualFeg(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, protos.HealthResponse_SYSTEM_UP, res.Action)
 
-	activeID, err = health.GetActiveGateway(test_utils.TestFegNetwork)
+	activeID, err = health.GetActiveGateway(context.Background(), test_utils.TestFegNetwork)
 	assert.NoError(t, err)
 	assert.Equal(t, test_utils.TestFegLogicalId1, activeID)
 	checkHealthData(t, test_utils.TestFegNetwork, test_utils.TestFegLogicalId1, healthyRequest.HealthStats)
@@ -186,7 +186,7 @@ func TestHealthAPI_DualFeg(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, protos.HealthResponse_SYSTEM_DOWN, res.Action)
 
-	activeID, err = health.GetActiveGateway(test_utils.TestFegNetwork)
+	activeID, err = health.GetActiveGateway(context.Background(), test_utils.TestFegNetwork)
 	assert.NoError(t, err)
 	assert.Equal(t, test_utils.TestFegLogicalId1, activeID)
 	checkHealthData(t, test_utils.TestFegNetwork, test_utils.TestFegLogicalId2, unhealthyRequest.HealthStats)
@@ -204,7 +204,7 @@ func updateHealth(t *testing.T, req *protos.HealthRequest) (*protos.HealthRespon
 }
 
 func checkHealthData(t *testing.T, networkID, gatewayID string, expected *protos.HealthStats) {
-	actual, err := health.GetHealth(networkID, gatewayID)
+	actual, err := health.GetHealth(context.Background(), networkID, gatewayID)
 	assert.NoError(t, err)
 	// Let's just set time to 0 for comparison - we should inject a time
 	// provider dependency into the servicer

--- a/feg/cloud/go/services/health/reporter/network_health_reporter.go
+++ b/feg/cloud/go/services/health/reporter/network_health_reporter.go
@@ -14,6 +14,7 @@ limitations under the License.
 package reporter
 
 import (
+	"context"
 	"time"
 
 	"magma/feg/cloud/go/feg"
@@ -42,6 +43,7 @@ func (reporter *NetworkHealthStatusReporter) ReportHealthStatus(dur time.Duratio
 }
 
 func (reporter *NetworkHealthStatusReporter) reportHealthStatus() error {
+	ctx := context.Background()
 	networks, err := configurator.ListNetworkIDs()
 	if err != nil {
 		return err
@@ -63,7 +65,7 @@ func (reporter *NetworkHealthStatusReporter) reportHealthStatus() error {
 		}
 		healthyGateways := 0
 		for _, gw := range gateways {
-			healthStatus, err := health.GetHealth(networkID, gw.Key)
+			healthStatus, err := health.GetHealth(ctx, networkID, gw.Key)
 			if err != nil {
 				glog.V(2).Infof("error getting health for network %s, gateway %s: %v\n", networkID, gw.Key, err)
 				continue

--- a/feg/cloud/go/tools/health_cli/main.go
+++ b/feg/cloud/go/tools/health_cli/main.go
@@ -14,6 +14,7 @@ limitations under the License.
 package main
 
 import (
+	context2 "context"
 	"flag"
 	"fmt"
 	"os"
@@ -77,7 +78,7 @@ func handleCommands(cmd string) error {
 }
 
 func getHealth(networkID string, gatewayID string) error {
-	healthStats, err := health.GetHealth(networkID, gatewayID)
+	healthStats, err := health.GetHealth(context2.Background(), networkID, gatewayID)
 	if err != nil {
 		return err
 	}
@@ -103,7 +104,7 @@ func getHealth(networkID string, gatewayID string) error {
 }
 
 func getActiveGateway(networkID string) error {
-	activeID, err := health.GetActiveGateway(networkID)
+	activeID, err := health.GetActiveGateway(context2.Background(), networkID)
 	if err != nil {
 		return err
 	}

--- a/lte/cloud/go/services/ha/servicers/servicer.go
+++ b/lte/cloud/go/services/ha/servicers/servicer.go
@@ -102,7 +102,7 @@ func (s *HAServicer) GetEnodebOffloadState(ctx context.Context, req *lte_protos.
 			continue
 		}
 		for _, enb := range enbs {
-			offloadState, err := s.getOffloadStateForEnb(secondaryGw.NetworkId, primaryGwID, enb)
+			offloadState, err := s.getOffloadStateForEnb(ctx, secondaryGw.NetworkId, primaryGwID, enb)
 			// Since a secondary gateway can offload multiple ENBs, if we are
 			// unable to fetch offload state for an ENB, we should continue
 			// gathering offload state for other ENBs, rather than returning
@@ -172,8 +172,8 @@ func (s *HAServicer) isGatewayCheckinValid(ctx context.Context, networkID string
 	return timeSinceCheckin < validSecsSinceStateReported, nil
 }
 
-func (s *HAServicer) getOffloadStateForEnb(networkID string, primaryGwID string, enbSN string) (lte_protos.GetEnodebOffloadStateResponse_EnodebOffloadState, error) {
-	enodebState, err := lte_service.GetEnodebState(networkID, primaryGwID, enbSN)
+func (s *HAServicer) getOffloadStateForEnb(ctx context.Context, networkID string, primaryGwID string, enbSN string) (lte_protos.GetEnodebOffloadStateResponse_EnodebOffloadState, error) {
+	enodebState, err := lte_service.GetEnodebState(ctx, networkID, primaryGwID, enbSN)
 	if err != nil {
 		return lte_protos.GetEnodebOffloadStateResponse_NO_OP, err
 	}

--- a/lte/cloud/go/services/ha/servicers/servicer_test.go
+++ b/lte/cloud/go/services/ha/servicers/servicer_test.go
@@ -226,7 +226,7 @@ func reportEnodebState(t *testing.T, networkID string, gatewayID string, enodebS
 	req.TimeReported = uint64(clock.Now().UnixNano()) / uint64(time.Millisecond)
 	serializedEnodebState, err := serde.Serialize(req, lte.EnodebStateType, serdes.State)
 	assert.NoError(t, err)
-	err = lte_service.SetEnodebState(networkID, gatewayID, enodebSerial, serializedEnodebState)
+	err = lte_service.SetEnodebState(context.Background(), networkID, gatewayID, enodebSerial, serializedEnodebState)
 	assert.NoError(t, err)
 }
 

--- a/lte/cloud/go/services/lte/client_api.go
+++ b/lte/cloud/go/services/lte/client_api.go
@@ -28,13 +28,13 @@ import (
 	"github.com/golang/glog"
 )
 
-func GetEnodebState(networkID string, gatewayID string, enodebSN string) (*lte_models.EnodebState, error) {
+func GetEnodebState(ctx context.Context, networkID string, gatewayID string, enodebSN string) (*lte_models.EnodebState, error) {
 	client, err := getClient()
 	if err != nil {
 		return nil, err
 	}
 	res, err := client.GetEnodebState(
-		context.Background(),
+		ctx,
 		&protos.GetEnodebStateRequest{
 			NetworkId: networkID,
 			GatewayId: gatewayID,
@@ -55,13 +55,13 @@ func GetEnodebState(networkID string, gatewayID string, enodebSN string) (*lte_m
 	return enodebState, nil
 }
 
-func SetEnodebState(networkID string, gatewayID string, enodebSN string, serializedState []byte) error {
+func SetEnodebState(ctx context.Context, networkID string, gatewayID string, enodebSN string, serializedState []byte) error {
 	client, err := getClient()
 	if err != nil {
 		return err
 	}
 	_, err = client.SetEnodebState(
-		context.Background(),
+		ctx,
 		&protos.SetEnodebStateRequest{
 			NetworkId:       networkID,
 			GatewayId:       gatewayID,

--- a/lte/cloud/go/services/lte/servicers/indexer_servicer.go
+++ b/lte/cloud/go/services/lte/servicers/indexer_servicer.go
@@ -58,7 +58,7 @@ func (i *indexerServicer) Index(ctx context.Context, req *protos.IndexRequest) (
 	if err != nil {
 		return nil, err
 	}
-	stErrs, err := indexImpl(req.NetworkId, states)
+	stErrs, err := indexImpl(ctx, req.NetworkId, states)
 	if err != nil {
 		return nil, err
 	}
@@ -77,12 +77,12 @@ func (i *indexerServicer) CompleteReindex(ctx context.Context, req *protos.Compl
 	return nil, status.Errorf(codes.InvalidArgument, "unsupported from/to for CompleteReindex: %v to %v", req.FromVersion, req.ToVersion)
 }
 
-func indexImpl(networkID string, states state_types.StatesByID) (state_types.StateErrors, error) {
-	return setEnodebState(networkID, states)
+func indexImpl(ctx context.Context, networkID string, states state_types.StatesByID) (state_types.StateErrors, error) {
+	return setEnodebState(ctx, networkID, states)
 }
 
 // setEnodebState stores EnodebState with reporterID as an additional PK
-func setEnodebState(networkID string, states state_types.StatesByID) (state_types.StateErrors, error) {
+func setEnodebState(ctx context.Context, networkID string, states state_types.StatesByID) (state_types.StateErrors, error) {
 	stateErrors := state_types.StateErrors{}
 	for id, st := range states {
 		// Set time reported before storing
@@ -102,7 +102,7 @@ func setEnodebState(networkID string, states state_types.StatesByID) (state_type
 			stateErrors[id] = errors.Wrap(err, "error loading gatewayID")
 			continue
 		}
-		err = lte_api.SetEnodebState(networkID, gwEnt.Key, id.DeviceID, serializedState)
+		err = lte_api.SetEnodebState(ctx, networkID, gwEnt.Key, id.DeviceID, serializedState)
 		if err != nil {
 			stateErrors[id] = errors.Wrap(err, "error setting enodeb state")
 			continue

--- a/lte/cloud/go/services/lte/servicers/indexer_servicer_test.go
+++ b/lte/cloud/go/services/lte/servicers/indexer_servicer_test.go
@@ -14,6 +14,7 @@ limitations under the License.
 package servicers_test
 
 import (
+	context2 "context"
 	"testing"
 	"time"
 
@@ -84,10 +85,10 @@ func TestIndexerEnodebState(t *testing.T) {
 	errs, err = idx.Index(networkID, stateGw2)
 	assert.NoError(t, err)
 	assert.Empty(t, errs)
-	gotA, err := lte_service.GetEnodebState(networkID, gatewayID1, enbSN)
+	gotA, err := lte_service.GetEnodebState(context2.Background(), networkID, gatewayID1, enbSN)
 	assert.NoError(t, err)
 	assert.Equal(t, enbState1, gotA)
-	gotB, err := lte_service.GetEnodebState(networkID, gatewayID2, enbSN)
+	gotB, err := lte_service.GetEnodebState(context2.Background(), networkID, gatewayID2, enbSN)
 	assert.NoError(t, err)
 	assert.Equal(t, enbState2, gotB)
 
@@ -99,7 +100,7 @@ func TestIndexerEnodebState(t *testing.T) {
 	errs, err = idx.Index(networkID, states)
 	assert.NoError(t, err)
 	assert.Error(t, errs[id3])
-	gotC, err := lte_service.GetEnodebState(networkID, gatewayID1, enbSN)
+	gotC, err := lte_service.GetEnodebState(context2.Background(), networkID, gatewayID1, enbSN)
 	assert.NoError(t, err)
 	assert.Equal(t, enbState2, gotC)
 }

--- a/lte/cloud/go/services/subscriberdb/client_api.go
+++ b/lte/cloud/go/services/subscriberdb/client_api.go
@@ -26,7 +26,7 @@ import (
 )
 
 // ListMSISDNs returns the tracked MSISDNs, keyed by their associated IMSI.
-func ListMSISDNs(networkID string) (map[string]string, error) {
+func ListMSISDNs(ctx context.Context, networkID string) (map[string]string, error) {
 	msisdns := map[string]string{}
 
 	client, err := getClient()
@@ -35,7 +35,7 @@ func ListMSISDNs(networkID string) (map[string]string, error) {
 	}
 
 	res, err := client.GetMSISDNs(
-		context.Background(),
+		ctx,
 		&protos.GetMSISDNsRequest{
 			NetworkId: networkID,
 			Msisdns:   nil, // list all
@@ -50,14 +50,14 @@ func ListMSISDNs(networkID string) (map[string]string, error) {
 
 // GetIMSIForMSISDN returns the IMSI associated with the passed MSISDN.
 // If not found, returns ErrNotFound from magma/orc8r/lib/go/errors.
-func GetIMSIForMSISDN(networkID, msisdn string) (string, error) {
+func GetIMSIForMSISDN(ctx context.Context, networkID, msisdn string) (string, error) {
 	client, err := getClient()
 	if err != nil {
 		return "", err
 	}
 
 	res, err := client.GetMSISDNs(
-		context.Background(),
+		ctx,
 		&protos.GetMSISDNsRequest{
 			NetworkId: networkID,
 			Msisdns:   []string{msisdn},
@@ -76,14 +76,14 @@ func GetIMSIForMSISDN(networkID, msisdn string) (string, error) {
 }
 
 // SetIMSIForMSISDN maps a MSISDN to an IMSI.
-func SetIMSIForMSISDN(networkID, msisdn, imsi string) error {
+func SetIMSIForMSISDN(ctx context.Context, networkID, msisdn, imsi string) error {
 	client, err := getClient()
 	if err != nil {
 		return err
 	}
 
 	_, err = client.SetMSISDN(
-		context.Background(),
+		ctx,
 		&protos.SetMSISDNRequest{
 			NetworkId: networkID,
 			Msisdn:    msisdn,
@@ -98,14 +98,14 @@ func SetIMSIForMSISDN(networkID, msisdn, imsi string) error {
 }
 
 // DeleteMSISDN deletes a MSISDN to IMSI mapping.
-func DeleteMSISDN(networkID, msisdn string) error {
+func DeleteMSISDN(ctx context.Context, networkID, msisdn string) error {
 	client, err := getClient()
 	if err != nil {
 		return err
 	}
 
 	_, err = client.DeleteMSISDN(
-		context.Background(),
+		ctx,
 		&protos.DeleteMSISDNRequest{
 			NetworkId: networkID,
 			Msisdn:    msisdn,
@@ -119,14 +119,14 @@ func DeleteMSISDN(networkID, msisdn string) error {
 }
 
 // GetIMSIsForIP returns the IMSIs associated with the passed IP.
-func GetIMSIsForIP(networkID, ip string) ([]string, error) {
+func GetIMSIsForIP(ctx context.Context, networkID, ip string) ([]string, error) {
 	client, err := getClient()
 	if err != nil {
 		return nil, err
 	}
 
 	res, err := client.GetIPs(
-		context.Background(),
+		ctx,
 		&protos.GetIPsRequest{
 			NetworkId: networkID,
 			Ips:       []string{ip},
@@ -147,14 +147,14 @@ func GetIMSIsForIP(networkID, ip string) ([]string, error) {
 }
 
 // SetIMSIsForIPs creates a set of IP to IMSI mappings.
-func SetIMSIsForIPs(networkID string, mappings []*protos.IPMapping) error {
+func SetIMSIsForIPs(ctx context.Context, networkID string, mappings []*protos.IPMapping) error {
 	client, err := getClient()
 	if err != nil {
 		return err
 	}
 
 	_, err = client.SetIPs(
-		context.Background(),
+		ctx,
 		&protos.SetIPsRequest{
 			NetworkId:  networkID,
 			IpMappings: mappings,

--- a/lte/cloud/go/services/subscriberdb/obsidian/handlers/handlers.go
+++ b/lte/cloud/go/services/subscriberdb/obsidian/handlers/handlers.go
@@ -155,7 +155,7 @@ func listSubscribersHandler(c echo.Context) error {
 	// First check for query params to filter by
 	reqCtx := c.Request().Context()
 	if msisdn := c.QueryParam(ParamMSISDN); msisdn != "" {
-		queryIMSI, err := subscriberdb.GetIMSIForMSISDN(networkID, msisdn)
+		queryIMSI, err := subscriberdb.GetIMSIForMSISDN(reqCtx, networkID, msisdn)
 		if err != nil {
 			return makeErr(err)
 		}
@@ -166,7 +166,7 @@ func listSubscribersHandler(c echo.Context) error {
 		return c.JSON(http.StatusOK, subs)
 	}
 	if ip := c.QueryParam(ParamIP); ip != "" {
-		queryIMSIs, err := subscriberdb.GetIMSIsForIP(networkID, ip)
+		queryIMSIs, err := subscriberdb.GetIMSIsForIP(reqCtx, networkID, ip)
 		if err != nil {
 			return makeErr(err)
 		}
@@ -230,7 +230,7 @@ func listSubscribersV2Handler(c echo.Context) error {
 
 	// First check for query params to filter by
 	if msisdn := c.QueryParam(ParamMSISDN); msisdn != "" {
-		queryIMSI, err := subscriberdb.GetIMSIForMSISDN(networkID, msisdn)
+		queryIMSI, err := subscriberdb.GetIMSIForMSISDN(reqCtx, networkID, msisdn)
 		if err != nil {
 			return makeErr(err)
 		}
@@ -241,7 +241,7 @@ func listSubscribersV2Handler(c echo.Context) error {
 		return c.JSON(http.StatusOK, subs)
 	}
 	if ip := c.QueryParam(ParamIP); ip != "" {
-		queryIMSIs, err := subscriberdb.GetIMSIsForIP(networkID, ip)
+		queryIMSIs, err := subscriberdb.GetIMSIsForIP(reqCtx, networkID, ip)
 		if err != nil {
 			return makeErr(err)
 		}
@@ -425,7 +425,7 @@ func listMSISDNsHandler(c echo.Context) error {
 		return nerr
 	}
 
-	msisdns, err := subscriberdb.ListMSISDNs(networkID)
+	msisdns, err := subscriberdb.ListMSISDNs(c.Request().Context(), networkID)
 	if err != nil {
 		return makeErr(err)
 	}
@@ -451,7 +451,7 @@ func createMSISDNsHandler(c echo.Context) error {
 		return obsidian.HttpError(err, http.StatusBadRequest)
 	}
 
-	err := subscriberdb.SetIMSIForMSISDN(networkID, string(payload.Msisdn), string(payload.ID))
+	err := subscriberdb.SetIMSIForMSISDN(c.Request().Context(), networkID, string(payload.Msisdn), string(payload.ID))
 	if err != nil {
 		return obsidian.HttpError(err, http.StatusInternalServerError)
 	}
@@ -464,7 +464,7 @@ func getMSISDNHandler(c echo.Context) error {
 	if nerr != nil {
 		return nerr
 	}
-	imsi, err := subscriberdb.GetIMSIForMSISDN(networkID, msisdn)
+	imsi, err := subscriberdb.GetIMSIForMSISDN(c.Request().Context(), networkID, msisdn)
 	if err != nil {
 		return makeErr(err)
 	}
@@ -477,7 +477,7 @@ func deleteMSISDNHandler(c echo.Context) error {
 		return nerr
 	}
 
-	err := subscriberdb.DeleteMSISDN(networkID, msisdn)
+	err := subscriberdb.DeleteMSISDN(c.Request().Context(), networkID, msisdn)
 	if err != nil {
 		return obsidian.HttpError(err, http.StatusInternalServerError)
 	}

--- a/lte/cloud/go/services/subscriberdb/servicers/indexer_servicer.go
+++ b/lte/cloud/go/services/subscriberdb/servicers/indexer_servicer.go
@@ -68,7 +68,7 @@ func (i *indexerServicer) Index(ctx context.Context, req *protos.IndexRequest) (
 	if err != nil {
 		return nil, err
 	}
-	stErrs, err := indexImpl(req.NetworkId, states)
+	stErrs, err := indexImpl(ctx, req.NetworkId, states)
 	if err != nil {
 		return nil, err
 	}
@@ -87,12 +87,12 @@ func (i *indexerServicer) CompleteReindex(ctx context.Context, req *protos.Compl
 	return nil, status.Errorf(codes.InvalidArgument, "unsupported from/to for CompleteReindex: %v to %v", req.FromVersion, req.ToVersion)
 }
 
-func indexImpl(networkID string, states state_types.StatesByID) (state_types.StateErrors, error) {
-	return setIPMappings(networkID, states)
+func indexImpl(ctx context.Context, networkID string, states state_types.StatesByID) (state_types.StateErrors, error) {
+	return setIPMappings(ctx, networkID, states)
 }
 
 // setIPMappings maps {IP -> IMSI}.
-func setIPMappings(networkID string, states state_types.StatesByID) (state_types.StateErrors, error) {
+func setIPMappings(ctx context.Context, networkID string, states state_types.StatesByID) (state_types.StateErrors, error) {
 	var ipMappings []*subscriberdb_protos.IPMapping
 	stateErrors := state_types.StateErrors{}
 	for id, st := range states {
@@ -118,7 +118,7 @@ func setIPMappings(networkID string, states state_types.StatesByID) (state_types
 		return stateErrors, nil
 	}
 
-	err := subscriberdb.SetIMSIsForIPs(networkID, ipMappings)
+	err := subscriberdb.SetIMSIsForIPs(ctx, networkID, ipMappings)
 	if err != nil {
 		return stateErrors, errors.Wrapf(err, "update directoryd mapping of session IDs to IMSIs %+v", ipMappings)
 	}

--- a/lte/cloud/go/services/subscriberdb/servicers/indexer_servicer_test.go
+++ b/lte/cloud/go/services/subscriberdb/servicers/indexer_servicer_test.go
@@ -14,6 +14,7 @@ limitations under the License.
 package servicers_test
 
 import (
+	context2 "context"
 	"encoding/base64"
 	"net"
 	"testing"
@@ -65,10 +66,10 @@ func TestIndexerIP(t *testing.T) {
 	errs, err := idx.Index("nid0", states)
 	assert.NoError(t, err)
 	assert.Empty(t, errs)
-	gotA, err := subscriberdb.GetIMSIsForIP("nid0", "127.0.0.1")
+	gotA, err := subscriberdb.GetIMSIsForIP(context2.Background(), "nid0", "127.0.0.1")
 	assert.NoError(t, err)
 	assert.Equal(t, []string{"IMSI0", "IMSI1"}, gotA)
-	gotB, err := subscriberdb.GetIMSIsForIP("nid0", "127.0.0.2")
+	gotB, err := subscriberdb.GetIMSIsForIP(context2.Background(), "nid0", "127.0.0.2")
 	assert.NoError(t, err)
 	assert.Equal(t, []string{"IMSI1"}, gotB)
 
@@ -80,7 +81,7 @@ func TestIndexerIP(t *testing.T) {
 	errs, err = idx.Index("nid0", states)
 	assert.NoError(t, err)
 	assert.Error(t, errs[id2])
-	gotC, err := subscriberdb.GetIMSIsForIP("nid0", "127.0.0.3")
+	gotC, err := subscriberdb.GetIMSIsForIP(context2.Background(), "nid0", "127.0.0.3")
 	assert.NoError(t, err)
 	assert.Equal(t, []string{"IMSI0"}, gotC)
 }


### PR DESCRIPTION
## Summary

- Propagate contexts in all non-orc8r service client APIs. orc8r services (except configurator) were refactored in https://github.com/magma/magma/pull/7385

## Test Plan

`make test`

## Additional Information

- [ ] This change is backwards-breaking
