### PR TITLE
fix(mme): fix compilation warning

### DIFF
--- a/lte/gateway/c/core/oai/tasks/nas/emm/Attach.c
+++ b/lte/gateway/c/core/oai/tasks/nas/emm/Attach.c
@@ -94,6 +94,7 @@
 #include "nas_proc.h"
 
 #include "AdditionalUpdateType.h"
+#include "EmmCommon.h"
 #include "EmmCause.h"
 #include "EpsNetworkFeatureSupport.h"
 #include "TrackingAreaIdentity.h"


### PR DESCRIPTION
Signed-off-by: Raphael Defosseux <raphael.defosseux@openairinterface.org>

## Summary

Once again, merges are done without verifying simple compilation warnings message.

## Test Plan

None.

## Additional Information

- [ ] This change is backwards-breaking

