### PR TITLE
fix(cloud): Upgrading Cloudstrapper for v1.6

### DIFF
--- a/experimental/cloudstrapper/playbooks/roles/build-platform/vars/main.yaml
+++ b/experimental/cloudstrapper/playbooks/roles/build-platform/vars/main.yaml
@@ -42,7 +42,7 @@ pipPackages:
 k8sPackages:
   - kubectl
   - helm
-  - terraform=0.14.5
+  - terraform
 
 # terraform downgraded to work with orc8r.
 


### PR DESCRIPTION
Signed-off-by: Arun Thulasi <arunt@fb.com>

## Summary

Upgrading terraform to 0.15 or above (default for Ubuntu 20.04) since orc8r now supports higher versions of terraform

## Test Plan

Deploy Cloudstrapper and check terraform version. It should be 0.15 or above. 

## Additional Information

- [x] This change is backwards-breaking

Older versions of Orc8r (1.5 or earlier) would not work with terraform 0.15
