### PR TITLE
fix(agw): Add 10.0.2.3 in resolv conf for Virtualbox VMs

### DIFF
--- a/lte/gateway/deploy/roles/dev_common/files/magma_resolv.conf
+++ b/lte/gateway/deploy/roles/dev_common/files/magma_resolv.conf
@@ -10,9 +10,10 @@
 # Defaults can be restored by simply deleting this file.
 #
 # See resolved.conf(5) for details
+# 10.0.2.3 is needed for Virtualbox 
 
 [Resolve]
-DNS=8.8.8.8 208.67.222.222
+DNS=8.8.8.8 208.67.222.222 10.0.2.3
 #FallbackDNS=
 #Domains=
 #LLMNR=no

--- a/lte/gateway/deploy/roles/dev_common/tasks/main.yml
+++ b/lte/gateway/deploy/roles/dev_common/tasks/main.yml
@@ -432,4 +432,4 @@
   copy:
     src: magma_resolv.conf
     dest: /etc/systemd/resolved.conf
-  when: preburn and ansible_distribution == "Ubuntu"
+  when: ansible_distribution == "Ubuntu"


### PR DESCRIPTION
Signed-off-by: Timothée Dzik <timdzik@fb.com>

fix(agw) Add 10.0.2.3 in resolv conf for Virtualbox VMs

## Summary

fix(agw) Add 10.0.2.3 in resolv conf for Virtualbox VMs

## Test Plan
```
cd lte/gateway && vagrant destroy -f && vagrant up && vagrant ssh 
ping google.com
```

## Additional Information

None