### PR TITLE
feat(nms): Gateway Detail Page Displaying Gateway Information & Events Table

### DIFF
--- a/nms/app/packages/magmalte/app/views/equipment/FEGEquipmentDashboard.js
+++ b/nms/app/packages/magmalte/app/views/equipment/FEGEquipmentDashboard.js
@@ -16,6 +16,7 @@
 
 import CellWifiIcon from '@material-ui/icons/CellWifi';
 import FEGGateway from './FEGEquipmentGateway';
+import FEGGatewayDetail from './FEGGatewayDetailMain';
 import React from 'react';
 import TopBar from '../../components/TopBar';
 
@@ -33,6 +34,10 @@ function FEGEquipmentDashboard() {
   return (
     <>
       <Switch>
+        <Route
+          path={relativePath('/overview/gateway/:gatewayId')}
+          component={FEGGatewayDetail}
+        />
         <Route
           path={relativePath('/overview')}
           component={EquipmentDashboardInternal}

--- a/nms/app/packages/magmalte/app/views/equipment/FEGGatewayDetailMain.js
+++ b/nms/app/packages/magmalte/app/views/equipment/FEGGatewayDetailMain.js
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @flow strict-local
+ * @format
+ */
+
+import AccessAlarmIcon from '@material-ui/icons/AccessAlarm';
+import CardTitleRow from '../../components/layout/CardTitleRow';
+import CellWifiIcon from '@material-ui/icons/CellWifi';
+import DashboardIcon from '@material-ui/icons/Dashboard';
+import EventsTable from '../../views/events/EventsTable';
+import FEGGatewayContext from '../../components/context/FEGGatewayContext';
+import FEGGatewaySummary from './FEGGatewaySummary';
+import Grid from '@material-ui/core/Grid';
+import ListAltIcon from '@material-ui/icons/ListAlt';
+import MyLocationIcon from '@material-ui/icons/MyLocation';
+import React from 'react';
+import SettingsIcon from '@material-ui/icons/Settings';
+import TopBar from '../../components/TopBar';
+import nullthrows from '@fbcnms/util/nullthrows';
+
+import {EVENT_STREAM} from '../../views/events/EventsTable';
+import {Redirect, Route, Switch} from 'react-router-dom';
+import {makeStyles} from '@material-ui/styles';
+import {useContext} from 'react';
+import {useRouter} from '@fbcnms/ui/hooks';
+
+const useStyles = makeStyles(theme => ({
+  dashboardRoot: {
+    margin: theme.spacing(5),
+  },
+}));
+
+/**
+ * Returns the gateway detail page of the federation network.
+ * It consists of a gateway overview component to display
+ * the useful informations about the federation gateway selected
+ * and a top bar to navigate through different pages.
+ */
+export default function FEGGatewayDetail() {
+  const {relativePath, relativeUrl, match} = useRouter();
+  const gatewayId: string = nullthrows(match.params.gatewayId);
+
+  return (
+    <>
+      <TopBar
+        header={`Equipment/${gatewayId}`}
+        tabs={[
+          {
+            label: 'Overview',
+            to: '/overview',
+            icon: DashboardIcon,
+          },
+          {
+            label: 'Event',
+            to: '/event',
+            icon: MyLocationIcon,
+          },
+          {
+            label: 'Logs',
+            to: '/logs',
+            icon: ListAltIcon,
+          },
+          {
+            label: 'Alerts',
+            to: '/alert',
+            icon: AccessAlarmIcon,
+          },
+          {
+            label: 'Config',
+            to: '/config',
+            icon: SettingsIcon,
+          },
+        ]}
+      />
+
+      <Switch>
+        <Route
+          path={relativePath('/overview')}
+          component={FEGGatewayOverview}
+        />
+        <Redirect to={relativeUrl('/overview')} />
+      </Switch>
+    </>
+  );
+}
+
+/**
+ * Returns the gateway information, table of events coming from
+ * the gateway, its status, the cluster status of the gateways
+ * in the network, and the connected subscribers.
+ */
+function FEGGatewayOverview() {
+  const classes = useStyles();
+  const {match} = useRouter();
+  const gatewayId: string = nullthrows(match.params.gatewayId);
+  const gwCtx = useContext(FEGGatewayContext);
+  const gwInfo = gwCtx.state[gatewayId];
+
+  return (
+    <div className={classes.dashboardRoot}>
+      <Grid container spacing={4}>
+        <Grid item xs={12} md={6}>
+          <Grid container spacing={4} direction="column">
+            <Grid item xs={12} alignItems="center">
+              <CardTitleRow icon={CellWifiIcon} label={gatewayId} />
+              <FEGGatewaySummary gwInfo={gwInfo} />
+            </Grid>
+            <Grid item xs={12} alignItems="center">
+              <CardTitleRow icon={MyLocationIcon} label="Events" />
+              <EventsTable
+                eventStream={EVENT_STREAM.GATEWAY}
+                hardwareId={gwInfo.device.hardware_id}
+                sz="sm"
+              />
+            </Grid>
+          </Grid>
+        </Grid>
+      </Grid>
+    </div>
+  );
+}

--- a/nms/app/packages/magmalte/app/views/equipment/FEGGatewaySummary.js
+++ b/nms/app/packages/magmalte/app/views/equipment/FEGGatewaySummary.js
@@ -1,0 +1,59 @@
+/**
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @flow strict-local
+ * @format
+ */
+
+import type {DataRows} from '../../components/DataGrid';
+import type {federation_gateway} from '@fbcnms/magma-api';
+
+import DataGrid from '../../components/DataGrid';
+import React from 'react';
+
+/**
+ * Returns the federation gateway description, id, hardware uuid, and it's
+ * version.
+ * @param {federation_gateway} gwInfo The federation gateway being looked at.
+ */
+export default function GatewaySummary({gwInfo}: {gwInfo: federation_gateway}) {
+  const version = gwInfo.status?.platform_info?.packages?.[0]?.version;
+
+  const data: DataRows[] = [
+    [
+      {
+        category: 'Name',
+        value: gwInfo.name,
+      },
+    ],
+    [
+      {
+        category: 'Gateway ID',
+        value: gwInfo.id,
+      },
+    ],
+    [
+      {
+        category: 'Hardware UUID',
+        value: gwInfo.device.hardware_id,
+      },
+    ],
+    [
+      {
+        category: 'Version',
+        value: version ?? 'Unknown',
+      },
+    ],
+  ];
+
+  return <DataGrid data={data} />;
+}

--- a/nms/app/packages/magmalte/app/views/equipment/__tests__/FEGGatewaySummaryTest.js
+++ b/nms/app/packages/magmalte/app/views/equipment/__tests__/FEGGatewaySummaryTest.js
@@ -1,0 +1,145 @@
+/**
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @flow strict-local
+ * @format
+ */
+
+import 'jest-dom/extend-expect';
+import FEGGatewayContext from '../../../components/context/FEGGatewayContext';
+import FEGGatewaySummary from '../FEGGatewaySummary';
+import MuiStylesThemeProvider from '@material-ui/styles/ThemeProvider';
+import React from 'react';
+import defaultTheme from '@fbcnms/ui/theme/default';
+import {MemoryRouter, Route} from 'react-router-dom';
+import {MuiThemeProvider} from '@material-ui/core/styles';
+import {cleanup, render, wait} from '@testing-library/react';
+import type {federation_gateway} from '@fbcnms/magma-api';
+
+jest.mock('axios');
+jest.mock('@fbcnms/magma-api');
+jest.mock('@fbcnms/ui/hooks/useSnackbar');
+afterEach(cleanup);
+
+const mockHardwareId = 'c9439d30-61ef-46c7-93f2-e01fc131244d';
+
+const mockKeyType = 'SOFTWARE_ECDSA_SHA256';
+
+const mockGw0: federation_gateway = {
+  id: 'test_feg_gw0',
+  name: 'test_gateway',
+  description: 'hello I am a federated gateway',
+  tier: 'default',
+  device: {
+    key: {key: '', key_type: mockKeyType},
+    hardware_id: mockHardwareId,
+  },
+  magmad: {
+    autoupgrade_enabled: true,
+    autoupgrade_poll_interval: 300,
+    checkin_interval: 60,
+    checkin_timeout: 100,
+    tier: 'tier2',
+  },
+  federation: {
+    aaa_server: {},
+    eap_aka: {
+      plmn_ids: [],
+    },
+    gx: {},
+    gy: {},
+    health: {
+      health_services: [],
+    },
+    hss: {},
+    s6a: {},
+    served_network_ids: [],
+    swx: {
+      hlr_plmn_ids: [],
+      server: {
+        protocol: 'tcp',
+      },
+      servers: [],
+    },
+    csfb: {},
+  },
+  status: {
+    checkin_time: 0,
+    meta: {
+      gps_latitude: '0',
+      gps_longitude: '0',
+      gps_connected: '0',
+      enodeb_connected: '0',
+      mme_connected: '0',
+    },
+    platform_info: {
+      packages: [{version: '1.2'}],
+    },
+  },
+};
+
+const mockGw1: federation_gateway = {
+  ...mockGw0,
+  id: 'test_gw1',
+  name: 'test_gateway1',
+};
+
+const fegGateways = {
+  [mockGw0.id]: mockGw0,
+  [mockGw1.id]: mockGw1,
+};
+
+const fegGatewaysHealth = {
+  [mockGw0.id]: 'HEALTHY',
+  [mockGw1.id]: 'UNHEALTHY',
+};
+
+describe('<FEGEquipmentGateway />', () => {
+  const Wrapper = () => (
+    <MemoryRouter
+      initialEntries={[
+        '/nms/mynetwork/equipment/overview/gateway/test_feg_gw0/overview',
+      ]}
+      initialIndex={0}>
+      <MuiThemeProvider theme={defaultTheme}>
+        <MuiStylesThemeProvider theme={defaultTheme}>
+          <FEGGatewayContext.Provider
+            value={{
+              state: fegGateways,
+              setState: async _ => {},
+              health: fegGatewaysHealth,
+              activeFegGatewayId: mockGw0.id,
+            }}>
+            <Route
+              path="/nms/:networkId/equipment/overview/gateway/:gatewayId/overview"
+              render={props => (
+                <FEGGatewaySummary {...props} gwInfo={mockGw0} />
+              )}
+            />
+          </FEGGatewayContext.Provider>
+        </MuiStylesThemeProvider>
+      </MuiThemeProvider>
+    </MemoryRouter>
+  );
+
+  it('renders federation gateway summary correctly', async () => {
+    const {getByTestId} = render(<Wrapper />);
+    await wait();
+    // verify gateway information
+    expect(getByTestId('Name')).toHaveTextContent('test_gateway');
+    expect(getByTestId('Gateway ID')).toHaveTextContent('test_feg_gw0');
+    expect(getByTestId('Hardware UUID')).toHaveTextContent(
+      'c9439d30-61ef-46c7-93f2-e01fc131244d',
+    );
+    expect(getByTestId('Version')).toHaveTextContent('1.2');
+  });
+});


### PR DESCRIPTION
<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary
This is stacked PR(only the last commit holds changes relevant to this PR) upon the open PR #7882, and therefore is a Draft PR until the other PR gets merged. A Gateway Detail Page was created which currently displays information about the Gateway. Also, an events table was added to display any events of the gateway. <!-- Enumerate changes you made and why you made them -->

## Test Plan
A new Test file was created, named FEGGatewaySummaryTest.js, to test that the Gateway Information displayed is correct. No, new test was added for the events table because this was an existing component and no changes were made there. All Previous tests run without errors.  
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information
<img width="1774" alt="Screen Shot 2021-07-13 at 11 13 01 AM" src="https://user-images.githubusercontent.com/34602743/125477540-31f39daf-2b96-4e5f-86a6-43a12d2e6120.png">

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
