### PR TITLE
feat(nms): Gateway Detail Page Displaying Gateway Status

### DIFF
--- a/nms/app/packages/magmalte/app/views/equipment/FEGGatewayDetailMain.js
+++ b/nms/app/packages/magmalte/app/views/equipment/FEGGatewayDetailMain.js
@@ -15,12 +15,15 @@
  */
 
 import AccessAlarmIcon from '@material-ui/icons/AccessAlarm';
+import AutorefreshCheckbox from '../../components/AutorefreshCheckbox';
 import CardTitleRow from '../../components/layout/CardTitleRow';
 import CellWifiIcon from '@material-ui/icons/CellWifi';
 import DashboardIcon from '@material-ui/icons/Dashboard';
 import EventsTable from '../../views/events/EventsTable';
 import FEGGatewayContext from '../../components/context/FEGGatewayContext';
+import FEGGatewayDetailStatus from './FEGGatewayDetailStatus';
 import FEGGatewaySummary from './FEGGatewaySummary';
+import GraphicEqIcon from '@material-ui/icons/GraphicEq';
 import Grid from '@material-ui/core/Grid';
 import ListAltIcon from '@material-ui/icons/ListAlt';
 import MyLocationIcon from '@material-ui/icons/MyLocation';
@@ -32,7 +35,7 @@ import nullthrows from '@fbcnms/util/nullthrows';
 import {EVENT_STREAM} from '../../views/events/EventsTable';
 import {Redirect, Route, Switch} from 'react-router-dom';
 import {makeStyles} from '@material-ui/styles';
-import {useContext} from 'react';
+import {useContext, useState} from 'react';
 import {useRouter} from '@fbcnms/ui/hooks';
 
 const useStyles = makeStyles(theme => ({
@@ -106,6 +109,16 @@ function FEGGatewayOverview() {
   const gatewayId: string = nullthrows(match.params.gatewayId);
   const gwCtx = useContext(FEGGatewayContext);
   const gwInfo = gwCtx.state[gatewayId];
+  const [refresh, setRefresh] = useState(true);
+
+  const filter = (refresh: boolean, setRefresh) => {
+    return (
+      <AutorefreshCheckbox
+        autorefreshEnabled={refresh}
+        onToggle={() => setRefresh(current => !current)}
+      />
+    );
+  };
 
   return (
     <div className={classes.dashboardRoot}>
@@ -123,6 +136,18 @@ function FEGGatewayOverview() {
                 hardwareId={gwInfo.device.hardware_id}
                 sz="sm"
               />
+            </Grid>
+          </Grid>
+        </Grid>
+        <Grid item xs={12} md={6}>
+          <Grid container spacing={4} direction="column">
+            <Grid item>
+              <CardTitleRow
+                icon={GraphicEqIcon}
+                label="Status"
+                filter={() => filter(refresh, setRefresh)}
+              />
+              <FEGGatewayDetailStatus refresh={refresh} />
             </Grid>
           </Grid>
         </Grid>

--- a/nms/app/packages/magmalte/app/views/equipment/FEGGatewayDetailStatus.js
+++ b/nms/app/packages/magmalte/app/views/equipment/FEGGatewayDetailStatus.js
@@ -1,0 +1,145 @@
+/*
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @flow strict-local
+ * @format
+ */
+import type {DataRows} from '../../components/DataGrid';
+
+import DataGrid from '../../components/DataGrid';
+import FEGGatewayContext from '../../components/context/FEGGatewayContext';
+import LoadingFiller from '@fbcnms/ui/components/LoadingFiller';
+import MagmaV1API from '@fbcnms/magma-api/client/WebClient';
+import React from 'react';
+import nullthrows from '@fbcnms/util/nullthrows';
+import useMagmaAPI from '@fbcnms/ui/magma/useMagmaAPI';
+
+import {
+  DynamicServices,
+  GatewayTypeEnum,
+  HEALTHY_STATUS,
+} from '../../components/GatewayUtils';
+import {
+  REFRESH_INTERVAL,
+  RefreshTypeEnum,
+  useRefreshingContext,
+} from '../../components/context/RefreshContext';
+import {useRouter} from '@fbcnms/ui/hooks';
+
+export default function GatewayDetailStatus({refresh}: {refresh: boolean}) {
+  const {match} = useRouter();
+  const networkId: string = nullthrows(match.params.networkId);
+  const gatewayId: string = nullthrows(match.params.gatewayId);
+  // Auto refresh gateways every 30 seconds
+  const refreshCtx = useRefreshingContext({
+    context: FEGGatewayContext,
+    networkId: networkId,
+    type: RefreshTypeEnum.FEG_GATEWAY,
+    interval: REFRESH_INTERVAL,
+    id: gatewayId,
+    refresh: refresh,
+  });
+  const fegGateways = refreshCtx.fegGateways || {};
+  const health = refreshCtx.health || {};
+  const gwInfo = fegGateways[gatewayId] || {};
+  let checkInTime;
+
+  if (
+    gwInfo.status &&
+    gwInfo.status.checkin_time !== undefined &&
+    gwInfo.status.checkin_time !== null
+  ) {
+    checkInTime = new Date(gwInfo.status.checkin_time);
+  }
+
+  const startTime = Math.floor(Date.now() / 1000);
+  const {response: cpuPercent, isLoading: isCpuPercentLoading} = useMagmaAPI(
+    MagmaV1API.getNetworksByNetworkIdPrometheusQueryRange,
+    {
+      networkId: networkId,
+      query: `cpu_percent{gatewayID="${gwInfo.id}", service="magmad"}`,
+      start: startTime.toString(),
+    },
+  );
+
+  const logAggregationEnabled =
+    !!gwInfo.magmad.dynamic_services &&
+    gwInfo.magmad.dynamic_services.includes(DynamicServices.TD_AGENT_BIT);
+
+  const eventAggregationEnabled =
+    !!gwInfo.magmad.dynamic_services &&
+    gwInfo.magmad.dynamic_services.includes(DynamicServices.EVENTD);
+
+  const cpeMonitoringEnabled =
+    !!gwInfo.magmad.dynamic_services &&
+    gwInfo.magmad.dynamic_services.includes(DynamicServices.MONITORD);
+
+  const gwHealth = health[gwInfo?.id].status
+    ? health[gwInfo?.id].status === HEALTHY_STATUS
+      ? GatewayTypeEnum.HEALTHY_GATEWAY
+      : GatewayTypeEnum.UNHEALTHY_GATEWAY
+    : 'N/A';
+
+  if (isCpuPercentLoading) {
+    return <LoadingFiller />;
+  }
+
+  const data: DataRows[] = [
+    [
+      {
+        category: 'Health',
+        value: gwHealth,
+        statusCircle: true,
+        // make kpi inactive if health status had error (health service not enabled)
+        statusInactive: health[gwInfo?.id]?.status ? false : true,
+        status: gwHealth === GatewayTypeEnum.HEALTHY_GATEWAY,
+        tooltip:
+          "Federation gateway's health as reported by the health service",
+      },
+      {
+        category: 'Last Check in',
+        value: checkInTime?.toLocaleString() ?? '-',
+        statusCircle: false,
+        tooltip: 'The last Time the gateway checked in',
+      },
+      {
+        category: 'CPU Usage',
+        value: cpuPercent?.data?.result?.[0]?.values?.[0]?.[1] ?? 'Unknown',
+        unit:
+          cpuPercent?.data?.result?.[0]?.values?.[0]?.[1] ?? false ? '%' : '',
+        statusCircle: false,
+        tooltip: 'Current Gateway CPU %',
+      },
+    ],
+    [
+      {
+        category: 'Event Aggregation',
+        value: eventAggregationEnabled ? 'Enabled' : 'Disabled',
+        statusCircle: true,
+        status: eventAggregationEnabled,
+      },
+      {
+        category: 'Log Aggregation',
+        value: logAggregationEnabled ? 'Enabled' : 'Disabled',
+        statusCircle: true,
+        status: logAggregationEnabled,
+      },
+      {
+        category: 'CPE Monitoring',
+        value: cpeMonitoringEnabled ? 'Enabled' : 'Disabled',
+        statusCircle: true,
+        status: cpeMonitoringEnabled,
+      },
+    ],
+  ];
+  return <DataGrid data={data} />;
+}

--- a/nms/app/packages/magmalte/app/views/equipment/__tests__/FEGGatewayDetailStatusTest.js
+++ b/nms/app/packages/magmalte/app/views/equipment/__tests__/FEGGatewayDetailStatusTest.js
@@ -1,0 +1,182 @@
+/**
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @flow strict-local
+ * @format
+ */
+
+import 'jest-dom/extend-expect';
+import * as hooks from '../../../components/context/RefreshContext';
+import FEGGatewayContext from '../../../components/context/FEGGatewayContext';
+import FEGGatewayDetailStatus from '../FEGGatewayDetailStatus';
+import MagmaAPIBindings from '@fbcnms/magma-api';
+import MuiStylesThemeProvider from '@material-ui/styles/ThemeProvider';
+import React from 'react';
+import axiosMock from 'axios';
+import defaultTheme from '@fbcnms/ui/theme/default';
+import {MemoryRouter, Route} from 'react-router-dom';
+import {MuiThemeProvider} from '@material-ui/core/styles';
+import {cleanup, render, wait} from '@testing-library/react';
+import type {federation_gateway, promql_return_object} from '@fbcnms/magma-api';
+
+jest.mock('axios');
+jest.mock('@fbcnms/magma-api');
+jest.mock('@fbcnms/ui/hooks/useSnackbar');
+afterEach(cleanup);
+
+const mockCheckinTime = new Date();
+
+const mockGw0: federation_gateway = {
+  id: 'test_feg_gw0',
+  name: 'test_gateway',
+  description: 'hello I am a federated gateway',
+  tier: 'default',
+  device: {
+    key: {key: '', key_type: 'SOFTWARE_ECDSA_SHA256'},
+    hardware_id: 'c9439d30-61ef-46c7-93f2-e01fc131244d',
+  },
+  magmad: {
+    autoupgrade_enabled: true,
+    autoupgrade_poll_interval: 300,
+    checkin_interval: 60,
+    checkin_timeout: 100,
+    dynamic_services: ['monitord', 'eventd'],
+    tier: 'tier2',
+  },
+  federation: {
+    aaa_server: {},
+    eap_aka: {
+      plmn_ids: [],
+    },
+    gx: {},
+    gy: {},
+    health: {
+      health_services: [],
+    },
+    hss: {},
+    s6a: {},
+    served_network_ids: [],
+    swx: {
+      hlr_plmn_ids: [],
+      server: {
+        protocol: 'tcp',
+      },
+      servers: [],
+    },
+    csfb: {},
+  },
+  status: {
+    checkin_time: mockCheckinTime.getTime(),
+    meta: {
+      gps_latitude: '0',
+      gps_longitude: '0',
+      gps_connected: '0',
+      enodeb_connected: '0',
+      mme_connected: '0',
+    },
+    platform_info: {
+      packages: [{version: '1.2'}],
+    },
+  },
+};
+
+const mockGw1: federation_gateway = {
+  ...mockGw0,
+  id: 'test_gw1',
+  name: 'test_gateway1',
+};
+
+const fegGateways = {
+  [mockGw0.id]: mockGw0,
+  [mockGw1.id]: mockGw1,
+};
+
+const fegGatewaysHealth = {
+  [mockGw0.id]: {status: 'HEALTHY'},
+  [mockGw1.id]: {status: 'UNHEALTHY'},
+};
+
+const mockCPUUsage: promql_return_object = {
+  status: 'success',
+  data: {
+    resultType: 'matrix',
+    result: [
+      {
+        metric: {},
+        values: [
+          ['1625239404', '3'],
+          ['1625239419', '0'],
+        ],
+      },
+    ],
+  },
+};
+
+describe('<FEGGatewayDetailStatus />', () => {
+  jest.spyOn(hooks, 'useRefreshingContext').mockImplementation(() => ({
+    fegGateways: fegGateways,
+    health: fegGatewaysHealth,
+    activeFegGatewayId: mockGw0.id,
+  }));
+
+  beforeEach(() => {
+    // called when getting the CPU Usage
+    MagmaAPIBindings.getNetworksByNetworkIdPrometheusQueryRange.mockResolvedValue(
+      mockCPUUsage,
+    );
+  });
+
+  afterEach(() => {
+    axiosMock.get.mockClear();
+  });
+
+  const Wrapper = () => (
+    <MemoryRouter
+      initialEntries={[
+        '/nms/mynetwork/equipment/overview/gateway/test_feg_gw0/overview',
+      ]}
+      initialIndex={0}>
+      <MuiThemeProvider theme={defaultTheme}>
+        <MuiStylesThemeProvider theme={defaultTheme}>
+          <FEGGatewayContext.Provider
+            value={{
+              state: fegGateways,
+              setState: async _ => {},
+              health: fegGatewaysHealth,
+              activeFegGatewayId: mockGw0.id,
+            }}>
+            <Route
+              path="/nms/:networkId/equipment/overview/gateway/:gatewayId/overview"
+              render={props => (
+                <FEGGatewayDetailStatus {...props} refresh={true} />
+              )}
+            />
+          </FEGGatewayContext.Provider>
+        </MuiStylesThemeProvider>
+      </MuiThemeProvider>
+    </MemoryRouter>
+  );
+
+  it('renders federation gateway status correctly', async () => {
+    const {getByTestId} = render(<Wrapper />);
+    await wait();
+    // verify gateway status
+    expect(getByTestId('Health')).toHaveTextContent('Good');
+    expect(getByTestId('Last Check in')).toHaveTextContent(
+      mockCheckinTime.toLocaleString(),
+    );
+    expect(getByTestId('CPU Usage')).toHaveTextContent('3');
+    expect(getByTestId('Event Aggregation')).toHaveTextContent('Enabled');
+    expect(getByTestId('Log Aggregation')).toHaveTextContent('Disabled');
+    expect(getByTestId('CPE Monitoring')).toHaveTextContent('Enabled');
+  });
+});


### PR DESCRIPTION
<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary
This is stacked PR upon the open PR #8015, and therefore is a Draft PR until the other PR gets merged(Only last commit represents changes).  Gateway Detail Status component was added to display different information about the status of the gateway like its health, last checkin time and the like. 
<!-- Enumerate changes you made and why you made them -->

## Test Plan
A test file named GatewayDetailStatusTest was added to test that the gateway status is displayed correctly. Also previous tests were run and all run without errors. 
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
<img width="1778" alt="Screen Shot 2021-07-13 at 11 29 18 AM" src="https://user-images.githubusercontent.com/34602743/125480402-c1fd166b-f9e3-4914-84f4-59436a26962d.png">
