### PR TITLE
feat(nms): Gateway Detail Page Displaying Managed Subscribers

### DIFF
--- a/nms/app/packages/magmalte/app/components/FEGServicingAccessGatewayKPIs.js
+++ b/nms/app/packages/magmalte/app/components/FEGServicingAccessGatewayKPIs.js
@@ -37,7 +37,7 @@ import {useRouter} from '@fbcnms/ui/hooks';
  */
 export async function getServicedAccessNetworks(
   federationNetworkId: network_id,
-  enqueueSnackbar: (
+  enqueueSnackbar?: (
     msg: string,
     cfg: EnqueueSnackbarOptions,
   ) => ?(string | number),

--- a/nms/app/packages/magmalte/app/components/context/FEGSubscriberContext.js
+++ b/nms/app/packages/magmalte/app/components/context/FEGSubscriberContext.js
@@ -1,0 +1,34 @@
+/**
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @flow strict-local
+ * @format
+ */
+
+import type {
+  network_id,
+  subscriber_id,
+  subscriber_state,
+} from '@fbcnms/magma-api';
+
+import React from 'react';
+
+export type FEGSubscriberContextType = {
+  sessionState: {
+    [networkId: network_id]: {[subscriberId: subscriber_id]: subscriber_state},
+  },
+  setSessionState: (newSessionState: {
+    [string]: {[string]: subscriber_state},
+  }) => void,
+};
+
+export default React.createContext<FEGSubscriberContextType>({});

--- a/nms/app/packages/magmalte/app/components/feg/FEGContext.js
+++ b/nms/app/packages/magmalte/app/components/feg/FEGContext.js
@@ -17,6 +17,7 @@
 import * as React from 'react';
 import FEGGatewayContext from '../context/FEGGatewayContext';
 import FEGNetworkContext from '../context/FEGNetworkContext';
+import FEGSubscriberContext from '../context/FEGSubscriberContext';
 import LoadingFiller from '@fbcnms/ui/components/LoadingFiller';
 import MagmaV1API from '@fbcnms/magma-api/client/WebClient';
 import useMagmaAPI from '@fbcnms/ui/magma/useMagmaAPI';
@@ -28,8 +29,10 @@ import type {
   gateway_id,
   network_id,
   network_type,
+  subscriber_state,
 } from '@fbcnms/magma-api';
 
+import {FetchFegSubscriberState} from '../../state/feg/SubscriberState';
 import {
   InitGatewayState,
   SetGatewayState,
@@ -43,6 +46,53 @@ type Props = {
   networkType: network_type,
   children: React.Node,
 };
+
+/**
+ * Fetches and saves the subscriber session states of networks
+ * serviced by this federation network and whose subscriber
+ * information is not managed by the HSS.
+ *
+ * @param {network_id} networkId Id of the network
+ * @param {network_type} networkType Type of the network
+ */
+export function FEGSubscriberContextProvider(props: Props) {
+  const {networkId} = props;
+  const [sessionState, setSessionState] = useState<{
+    [networkId: network_id]: {[string]: subscriber_state},
+  }>({});
+  const [isLoading, setIsLoading] = useState(false);
+  const enqueueSnackbar = useEnqueueSnackbar();
+  useEffect(() => {
+    const fetchFegState = async () => {
+      if (networkId == null) {
+        return;
+      }
+      const sessionState = await FetchFegSubscriberState({
+        networkId,
+        enqueueSnackbar,
+      });
+      setSessionState(sessionState);
+      setIsLoading(false);
+    };
+    fetchFegState();
+  }, [networkId, enqueueSnackbar]);
+
+  if (isLoading) {
+    return <LoadingFiller />;
+  }
+
+  return (
+    <FEGSubscriberContext.Provider
+      value={{
+        sessionState: sessionState,
+        setSessionState: newSessionState => {
+          return setSessionState(newSessionState);
+        },
+      }}>
+      {props.children}
+    </FEGSubscriberContext.Provider>
+  );
+}
 
 /**
  * Fetches and returns the federation gateways, their health status and
@@ -162,9 +212,11 @@ export function FEGContextProvider(props: Props) {
 
   return (
     <FEGNetworkContextProvider {...{networkId, networkType}}>
-      <FEGGatewayContextProvider {...{networkId, networkType}}>
-        {props.children}
-      </FEGGatewayContextProvider>
+      <FEGSubscriberContextProvider {...{networkId, networkType}}>
+        <FEGGatewayContextProvider {...{networkId, networkType}}>
+          {props.children}
+        </FEGGatewayContextProvider>
+      </FEGSubscriberContextProvider>
     </FEGNetworkContextProvider>
   );
 }

--- a/nms/app/packages/magmalte/app/state/feg/SubscriberState.js
+++ b/nms/app/packages/magmalte/app/state/feg/SubscriberState.js
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @flow strict-local
+ * @format
+ */
+
+import type {EnqueueSnackbarOptions} from 'notistack';
+import type {network_id} from '@fbcnms/magma-api';
+
+import {FetchSubscriberState} from '../lte/SubscriberState';
+import {getServicedAccessNetworks} from '../../components/FEGServicingAccessGatewayKPIs';
+
+/**
+ * Props passed when fetching subscriber state.
+ *
+ * @param {network_id} networkId Id of the federation network.
+ * @param {(msg, cfg,) => ?(string | number),} enqueueSnackbar Snackbar to display error.
+ */
+type FetchProps = {
+  networkId: network_id,
+  enqueueSnackbar?: (
+    msg: string,
+    cfg: EnqueueSnackbarOptions,
+  ) => ?(string | number),
+};
+
+/**
+ * Fetches and returns the subscriber session state of all the serviced
+ * federated lte networks under by this federation network.
+ *
+ * @param {FetchProps} props an object containing the network id and snackbar to display error.
+ * @returns {{[string]:{[string]: subscriber_state}}} returns an object containing the serviced
+ *   network ids mapped to the each of their subscriber state. It returns an empty object and
+ *   displays any error encountered on the snackbar when it fails to fetch the session state.
+ */
+export async function FetchFegSubscriberState(props: FetchProps): {} {
+  const {networkId, enqueueSnackbar} = props;
+  const servicedAccessNetworks = await getServicedAccessNetworks(
+    networkId,
+    enqueueSnackbar,
+  );
+  const sessionState = {};
+  for (const servicedAccessNetwork of servicedAccessNetworks) {
+    const servicedAccessNetworkId = servicedAccessNetwork.id;
+    const state = await FetchSubscriberState({
+      networkId: servicedAccessNetworkId,
+      enqueueSnackbar,
+    });
+    // group session states under their network id
+    sessionState[servicedAccessNetworkId] = state;
+  }
+  return sessionState;
+}

--- a/nms/app/packages/magmalte/app/views/equipment/FEGGatewayDetailMain.js
+++ b/nms/app/packages/magmalte/app/views/equipment/FEGGatewayDetailMain.js
@@ -22,13 +22,16 @@ import DashboardIcon from '@material-ui/icons/Dashboard';
 import EventsTable from '../../views/events/EventsTable';
 import FEGGatewayContext from '../../components/context/FEGGatewayContext';
 import FEGGatewayDetailStatus from './FEGGatewayDetailStatus';
+import FEGGatewayDetailSubscribers from './FEGGatewayDetailSubscribers';
 import FEGGatewaySummary from './FEGGatewaySummary';
 import GraphicEqIcon from '@material-ui/icons/GraphicEq';
 import Grid from '@material-ui/core/Grid';
 import ListAltIcon from '@material-ui/icons/ListAlt';
 import MyLocationIcon from '@material-ui/icons/MyLocation';
+import PeopleIcon from '@material-ui/icons/People';
 import React from 'react';
 import SettingsIcon from '@material-ui/icons/Settings';
+import Tooltip from '@material-ui/core/Tooltip';
 import TopBar from '../../components/TopBar';
 import nullthrows from '@fbcnms/util/nullthrows';
 
@@ -110,6 +113,7 @@ function FEGGatewayOverview() {
   const gwCtx = useContext(FEGGatewayContext);
   const gwInfo = gwCtx.state[gatewayId];
   const [refresh, setRefresh] = useState(true);
+  const [refreshSubscribers, setRefreshSubscribers] = useState(false);
 
   const filter = (refresh: boolean, setRefresh) => {
     return (
@@ -148,6 +152,25 @@ function FEGGatewayOverview() {
                 filter={() => filter(refresh, setRefresh)}
               />
               <FEGGatewayDetailStatus refresh={refresh} />
+            </Grid>
+            <Grid item>
+              <Tooltip
+                title="List of subscriber sessions under the networks serviced by
+              this federation network">
+                <Grid>
+                  <CardTitleRow
+                    icon={PeopleIcon}
+                    label="Managed Subscribers"
+                    filter={() =>
+                      filter(refreshSubscribers, setRefreshSubscribers)
+                    }
+                  />
+                </Grid>
+              </Tooltip>
+              <FEGGatewayDetailSubscribers
+                gwInfo={gwInfo}
+                refresh={refreshSubscribers}
+              />
             </Grid>
           </Grid>
         </Grid>

--- a/nms/app/packages/magmalte/app/views/equipment/FEGGatewayDetailSubscribers.js
+++ b/nms/app/packages/magmalte/app/views/equipment/FEGGatewayDetailSubscribers.js
@@ -1,0 +1,151 @@
+/**
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @flow strict-local
+ * @format
+ */
+
+import type {federation_gateway, subscriber} from '@fbcnms/magma-api';
+
+import ActionTable from '../../components/ActionTable';
+import FEGSubscriberContext from '../../components/context/FEGSubscriberContext';
+import Link from '@material-ui/core/Link';
+import LoadingFiller from '@fbcnms/ui/components/LoadingFiller';
+import React from 'react';
+import nullthrows from '@fbcnms/util/nullthrows';
+
+import {FetchSubscribers} from '../../state/lte/SubscriberState';
+import {
+  REFRESH_INTERVAL,
+  RefreshTypeEnum,
+  useRefreshingContext,
+} from '../../components/context/RefreshContext';
+import {useEffect, useState} from 'react';
+import {useRouter} from '@fbcnms/ui/hooks';
+
+/**
+ * @property {federation_gateway} gwInfo The Federation gateway being looked at
+ * @property {boolean} refresh Boolean telling to autorefresh or not
+ */
+type FEGGatewayDetailType = {
+  gwInfo: federation_gateway,
+  refresh: boolean,
+};
+
+/**
+ * @property {string} name Subscriber name
+ * @property {string} id Subscriber id
+ * @property {string} service Subscriber service status
+ */
+type SubscriberRowType = {
+  name: string,
+  id: string,
+  service: string,
+};
+
+/**
+ * Returns a table of subscribers serviced by the federation gateway.
+ *
+ * @param {FEGGatewayDetailType} props
+ */
+export default function GatewayDetailSubscribers(props: FEGGatewayDetailType) {
+  const {history, match} = useRouter();
+  const networkId: string = nullthrows(match.params.networkId);
+  const [subscriberRows, setSubscriberRows] = useState<
+    Array<SubscriberRowType>,
+  >([]);
+  const [isLoading, setIsLoading] = useState(true);
+  // Auto refresh every REFRESH_INTERVAL seconds
+  const ctx = useRefreshingContext({
+    context: FEGSubscriberContext,
+    networkId: networkId,
+    type: RefreshTypeEnum.FEG_SUBSCRIBER,
+    interval: REFRESH_INTERVAL,
+    refresh: props.refresh,
+  });
+  const sessionState = ctx?.sessionState || {};
+  const subscriberToNetworkIdMap = {};
+
+  Object.keys(sessionState).map(servicedNetworkId => {
+    // $FlowIgnore[prop-missing] because refresh context returns other things too like state, enbInfo and each have their own property
+    const servicedNetworkSessionState = sessionState[servicedNetworkId] ?? {};
+    Object?.keys(servicedNetworkSessionState).map(subscriberImsi => {
+      subscriberToNetworkIdMap[subscriberImsi] = servicedNetworkId;
+    });
+  });
+  // get all the subscribers IMSI number serviced by the federation network
+  const subscribersImsi = JSON.stringify(Object.keys(subscriberToNetworkIdMap));
+
+  useEffect(() => {
+    const fetchSubscribersInfo = async () => {
+      const newSubscriberRows = [];
+      //TODO: - @andreilee bulk fetch from a paginated api endpoint
+      await Promise.all(
+        Object.keys(subscriberToNetworkIdMap).map(async subscriberImsi => {
+          // $FlowIgnore[incompatible-call] because it can be called with different values when getting paginated subscribers
+          const subscriberInfo: subscriber = await FetchSubscribers({
+            networkId: subscriberToNetworkIdMap[subscriberImsi],
+            id: subscriberImsi,
+          });
+          newSubscriberRows.push({
+            name: subscriberInfo?.name || subscriberImsi,
+            id: subscriberImsi,
+            service: subscriberInfo?.lte?.state || '-',
+          });
+        }),
+      );
+      setSubscriberRows(newSubscriberRows);
+      setIsLoading(false);
+    };
+    fetchSubscribersInfo();
+    // rerun only when a new subscriber session has been added
+  }, [subscribersImsi]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  if (isLoading) {
+    return <LoadingFiller />;
+  }
+
+  return (
+    <ActionTable
+      title=""
+      data={subscriberRows}
+      columns={[
+        {title: 'Name', field: 'name'},
+        {
+          title: 'Subscriber ID',
+          field: 'id',
+          render: currRow => (
+            <Link
+              variant="body2"
+              component="button"
+              onClick={() => {
+                history.push(
+                  match.url.replace(
+                    `equipment/overview/gateway/${props.gwInfo.id}`,
+                    `subscribers/overview/${currRow.id}`,
+                  ),
+                );
+              }}>
+              {currRow.id}
+            </Link>
+          ),
+        },
+        {title: 'Service', field: 'service'},
+      ]}
+      options={{
+        actionsColumnIndex: -1,
+        pageSizeOptions: [10],
+        toolbar: false,
+      }}
+    />
+  );
+}

--- a/nms/app/packages/magmalte/app/views/equipment/__tests__/FEGGatewayDetailSubscribersTest.js
+++ b/nms/app/packages/magmalte/app/views/equipment/__tests__/FEGGatewayDetailSubscribersTest.js
@@ -1,0 +1,205 @@
+/**
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @flow strict-local
+ * @format
+ */
+
+import type {
+  federation_gateway,
+  subscriber_id,
+  subscriber_state,
+} from '@fbcnms/magma-api';
+
+import 'jest-dom/extend-expect';
+import FEGGatewayDetailSubscribers from '../FEGGatewayDetailSubscribers';
+import FEGSubscriberContext from '../../../components/context/FEGSubscriberContext';
+import MagmaAPIBindings from '@fbcnms/magma-api';
+import MuiStylesThemeProvider from '@material-ui/styles/ThemeProvider';
+import React from 'react';
+import axiosMock from 'axios';
+import defaultTheme from '@fbcnms/ui/theme/default';
+
+import {MemoryRouter, Route} from 'react-router-dom';
+import {MuiThemeProvider} from '@material-ui/core/styles';
+import {cleanup, render, wait} from '@testing-library/react';
+
+jest.mock('axios');
+jest.mock('@fbcnms/magma-api');
+jest.mock('@fbcnms/ui/hooks/useSnackbar');
+afterEach(cleanup);
+
+const mockSubscriberIds: Array<subscriber_id> = [
+  'IMSI001011234565000',
+  'IMSI001011234565001',
+];
+const mockSubscribers = [
+  {
+    name: 'subscriber0',
+    active_apns: ['oai.ipv4'],
+    id: mockSubscriberIds[0],
+    lte: {
+      auth_algo: 'MILENAGE',
+      auth_key: 'i69HPy+P0JSHzMvXCXxoYg==',
+      auth_opc: 'jie2rw5pLnUPMmZ6OxRgXQ==',
+      state: 'ACTIVE',
+      sub_profile: 'default',
+    },
+    config: {
+      lte: {
+        auth_algo: 'MILENAGE',
+        auth_key: 'i69HPy+P0JSHzMvXCXxoYg==',
+        auth_opc: 'jie2rw5pLnUPMmZ6OxRgXQ==',
+        state: 'ACTIVE',
+        sub_profile: 'default',
+      },
+    },
+  },
+  {
+    name: 'subscriber1',
+    active_apns: ['oai.ipv4'],
+    id: mockSubscriberIds[1],
+    lte: {
+      auth_algo: 'MILENAGE',
+      auth_key: 'i69HPy+P0JSHzMvXCXxoYg==',
+      auth_opc: 'jie2rw5pLnUPMmZ6OxRgXQ==',
+      state: 'INACTIVE',
+      sub_profile: 'default',
+    },
+    config: {
+      lte: {
+        auth_algo: 'MILENAGE',
+        auth_key: 'i69HPy+P0JSHzMvXCXxoYg==',
+        auth_opc: 'jie2rw5pLnUPMmZ6OxRgXQ==',
+        state: 'INACTIVE',
+        sub_profile: 'default',
+      },
+    },
+  },
+];
+const mockSubscriberSessionState0: {[subscriber_id]: subscriber_state} = {
+  [mockSubscriberIds[0]]: {
+    directory: {},
+  },
+};
+const mockSubscriberSessionState1: {[subscriber_id]: subscriber_state} = {
+  [mockSubscriberIds[1]]: {
+    mme: {
+      accessRestrictionData: 32,
+    },
+  },
+};
+
+const mockGw0: federation_gateway = {
+  id: 'test_feg_gw0',
+  name: 'test_gateway',
+  description: 'hello I am a federated gateway',
+  tier: 'default',
+  device: {
+    key: {key: '', key_type: 'SOFTWARE_ECDSA_SHA256'},
+    hardware_id: '',
+  },
+  magmad: {
+    autoupgrade_enabled: true,
+    autoupgrade_poll_interval: 300,
+    checkin_interval: 60,
+    checkin_timeout: 100,
+    tier: 'tier2',
+  },
+  federation: {
+    aaa_server: {},
+    eap_aka: {
+      plmn_ids: [],
+    },
+    gx: {},
+    gy: {},
+    health: {
+      health_services: [],
+    },
+    hss: {},
+    s6a: {},
+    served_network_ids: [],
+    swx: {
+      hlr_plmn_ids: [],
+      server: {
+        protocol: 'tcp',
+      },
+      servers: [],
+    },
+    csfb: {},
+  },
+};
+
+describe('<FEGGatewayDetailSubscribers />', () => {
+  beforeEach(() => {
+    // called when getting subscriber name and service status
+    MagmaAPIBindings.getLteByNetworkIdSubscribersBySubscriberId
+      .mockReturnValueOnce(mockSubscribers[0])
+      .mockResolvedValue(mockSubscribers[1]);
+  });
+
+  afterEach(() => {
+    axiosMock.get.mockClear();
+  });
+
+  const Wrapper = () => (
+    <MemoryRouter
+      initialEntries={[
+        '/nms/mynetwork/equipment/overview/gateway/test_feg_gw0/overview',
+      ]}
+      initialIndex={0}>
+      <MuiThemeProvider theme={defaultTheme}>
+        <MuiStylesThemeProvider theme={defaultTheme}>
+          <FEGSubscriberContext.Provider
+            value={{
+              sessionState: {
+                feg_lte_network1: mockSubscriberSessionState0,
+                feg_lte_network2: mockSubscriberSessionState1,
+              },
+              setSessionState: _ => {},
+            }}>
+            <Route
+              path="/nms/:networkId/equipment/overview/gateway/:gatewayId/overview"
+              render={props => (
+                <FEGGatewayDetailSubscribers
+                  {...props}
+                  refresh={false}
+                  gwInfo={mockGw0}
+                />
+              )}
+            />
+          </FEGSubscriberContext.Provider>
+        </MuiStylesThemeProvider>
+      </MuiThemeProvider>
+    </MemoryRouter>
+  );
+
+  it('renders gateway detail subscribers table correctly', async () => {
+    const {getAllByRole} = render(<Wrapper />);
+    await wait();
+    // two subscribers in the network
+    expect(
+      MagmaAPIBindings.getLteByNetworkIdSubscribersBySubscriberId,
+    ).toHaveBeenCalledTimes(2);
+    const rowItems = await getAllByRole('row');
+    // first row is the header
+    expect(rowItems[0]).toHaveTextContent('Name');
+    expect(rowItems[0]).toHaveTextContent('Subscriber ID');
+    expect(rowItems[0]).toHaveTextContent('Service');
+    expect(rowItems[1]).toHaveTextContent('subscriber0');
+    expect(rowItems[1]).toHaveTextContent('IMSI001011234565000');
+    expect(rowItems[1]).toHaveTextContent('ACTIVE');
+    expect(rowItems[2]).toHaveTextContent('subscriber1');
+    expect(rowItems[2]).toHaveTextContent('IMSI001011234565001');
+    expect(rowItems[2]).toHaveTextContent('INACTIVE');
+  });
+});


### PR DESCRIPTION
<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary
This is stacked PR upon the open PR #8016. The managed subscriber table was added to the gateway detail page which shows the subscribers managed by the federation network. The subscribers come from the subscribers of the federated_lte networks serviced by the federation network.<!-- Enumerate changes you made and why you made them -->

## Test Plan
A test file named FEGGatewayDetailSubscribers.js to test the subscribers table. Also, all previous tests run without error. 
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking
<img width="1665" alt="Screen Shot 2021-07-13 at 1 33 14 PM" src="https://user-images.githubusercontent.com/34602743/125498964-66194b0b-de00-45be-875b-6cea76fb7e42.png">

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
![Screen Shot 2021-07-28 at 3 09 13 PM (2)](https://user-images.githubusercontent.com/34602743/127387408-30d3069a-2ad6-47b4-a163-21697050c308.jpg)
