### PR TITLE
fix(mme): reduce EPC_STATS_TIMER_MSEC back to 20s

### DIFF
--- a/lte/gateway/c/core/oai/include/service303.h
+++ b/lte/gateway/c/core/oai/include/service303.h
@@ -27,8 +27,8 @@
 
 #define NO_BOUNDARIES 0
 #define NO_LABELS 0
-#define EPC_STATS_TIMER_MSEC 60000          // In milliseconds
-#define EPC_STATS_DISPLAY_TIMER_MSEC 60000  // In milliseconds
+#define EPC_STATS_TIMER_MSEC 20000          // In milliseconds
+#define EPC_STATS_DISPLAY_TIMER_MSEC 20000  // In milliseconds
 
 void service303_mme_app_statistics_read(
     application_mme_app_stats_msg_t* stats_msg_p);


### PR DESCRIPTION
Signed-off-by: Oriol Batalla <obatalla@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

Stats on MME are used to debug issues. Reducing its frequency to 1 min defeats the purpose of this log.

Setting this back to 20s until we have a config parameter to change that value

## Test Plan

make test at agw
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
