### PR TITLE
chore: [ci] Complete migration of cloud tests to github actions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -581,99 +581,6 @@ jobs:
           command: |
             cd ${MAGMA_ROOT}/circleci/release
             fab find_release_commits
-  ### CLOUD
-  cloud-test:
-    machine:
-      image: ubuntu-1604:201903-01
-      docker_layer_caching: true
-    environment:
-      MAGMA_ROOT: /home/circleci/project
-    steps:
-      - checkout
-      - build/determinator:
-          <<: *all_gateways_build_verify
-      - docker/install-dc
-      - python/set_version
-      - run:
-          command: |
-            cd ${MAGMA_ROOT}/orc8r/cloud/docker
-            python3 build.py --tests --up
-          no_output_timeout: 15m
-      - store_test_results:
-          path: /home/circleci/project/orc8r/cloud/test-results
-      - magma_slack_notify
-
-  # Fail if code doesn't pass formatting requirements.
-  # Upload test coverage statistics.
-  cloud_lint:
-    machine:
-      image: ubuntu-1604:201903-01
-      docker_layer_caching: true
-    environment:
-      MAGMA_ROOT: /home/circleci/project
-    steps:
-      - checkout
-      - build/determinator:
-          <<: *all_gateways_build_verify
-      - docker/install-dc
-      - python/set_version
-      - run:
-          name: Lint cloud Go code
-          command: |
-            cd ${MAGMA_ROOT}/orc8r/cloud/docker
-            python3 build.py --lint
-      - run:
-          name: Generate test coverage
-          command: |
-            cd ${MAGMA_ROOT}/orc8r/cloud/docker
-            python3 build.py --coverage
-      - codecov/upload:
-          file: /home/circleci/project/orc8r/cloud/coverage/all.gocov
-          flags: cloud_lint
-      - magma_slack_notify
-
-  # Fail if checked-in generated code doesn't match output from
-  # generation command.
-  insync-checkin:
-    machine:
-      image: ubuntu-1604:201903-01
-      #docker_layer_caching: true
-    environment:
-      MAGMA_ROOT: /home/circleci/project
-    steps:
-      - checkout
-      - build/determinator:
-          <<: *all_gateways_build_verify
-      - docker/install-dc
-      - python/set_version
-      - run:
-          command: |
-            cd ${MAGMA_ROOT}/orc8r/cloud/docker
-            python3 build.py --generate
-      - run: sudo chown -R circleci $MAGMA_ROOT/*
-      - run: git add .
-      - run: git status
-      - run: git diff-index --quiet HEAD
-      - magma_slack_notify
-
-  # Fail if terraform variables, helm charts and orcl is out of sync
-  deploy-sync-checkin:
-    machine:
-      image: ubuntu-1604:201903-01
-      # docker_layer_caching: true
-    environment:
-      MAGMA_ROOT: /home/circleci/project
-    steps:
-      - checkout
-      - build/determinator:
-          <<: *all_gateways_build_verify
-      - docker/install-dc
-      - python/set_version
-      - run:
-          command: |
-            cd ${MAGMA_ROOT}/orc8r/cloud/deploy/orc8r_deployer/docker
-            ./run_deployer.bash --deploy-dir /tmp/deploy_dir --build --test check_all
-      - magma_slack_notify
 
   orc8r-build:
     machine:
@@ -1426,19 +1333,6 @@ jobs:
       - magma_slack_notify
 workflows:
   version: 2
-
-  cloud:
-    jobs:
-      - insync-checkin
-      - deploy-sync-checkin
-      - cloud_lint
-      - cloud-test
-      - orc8r-build:
-          requires:
-            - insync-checkin
-            - deploy-sync-checkin
-            - cloud_lint
-            - cloud-test
 
   lib_gateway:
     jobs:


### PR DESCRIPTION

## Summary

Delete circle ci cloud tests
Github action job merged as part of https://github.com/magma/magma/pull/6372


## Test Plan

Github actions running fine in master: https://github.com/magma/magma/actions/runs/1031013669

## Additional Information


