### PR TITLE
fix(mme): Make stats collection and display configurable

### DIFF
--- a/lte/gateway/c/core/oai/include/mme_config.h
+++ b/lte/gateway/c/core/oai/include/mme_config.h
@@ -76,6 +76,7 @@
 #define MME_CONFIG_STRING_MAXENB "MAXENB"
 #define MME_CONFIG_STRING_MAXUE "MAXUE"
 #define MME_CONFIG_STRING_RELATIVE_CAPACITY "RELATIVE_CAPACITY"
+#define MME_CONFIG_STRING_STATS_TIMER "STATS_REPORTING_TIMER"
 
 #define MME_CONFIG_STRING_USE_STATELESS "USE_STATELESS"
 #define MME_CONFIG_STRING_ENABLE_CONVERGED_CORE "ENABLE_CONVERGED_CORE"
@@ -373,6 +374,8 @@ typedef struct mme_config_s {
   uint32_t max_ues;
 
   uint8_t relative_capacity;
+
+  uint32_t stats_timer;
 
   bstring ip_capability;
   bstring non_eps_service_control;

--- a/lte/gateway/c/core/oai/include/mme_config.h
+++ b/lte/gateway/c/core/oai/include/mme_config.h
@@ -76,7 +76,7 @@
 #define MME_CONFIG_STRING_MAXENB "MAXENB"
 #define MME_CONFIG_STRING_MAXUE "MAXUE"
 #define MME_CONFIG_STRING_RELATIVE_CAPACITY "RELATIVE_CAPACITY"
-#define MME_CONFIG_STRING_STATS_TIMER "STATS_REPORTING_TIMER"
+#define MME_CONFIG_STRING_STATS_TIMER "STATS_TIMER_SEC"
 
 #define MME_CONFIG_STRING_USE_STATELESS "USE_STATELESS"
 #define MME_CONFIG_STRING_ENABLE_CONVERGED_CORE "ENABLE_CONVERGED_CORE"
@@ -375,7 +375,7 @@ typedef struct mme_config_s {
 
   uint8_t relative_capacity;
 
-  uint32_t stats_timer;
+  uint32_t stats_timer_sec;
 
   bstring ip_capability;
   bstring non_eps_service_control;

--- a/lte/gateway/c/core/oai/include/service303.h
+++ b/lte/gateway/c/core/oai/include/service303.h
@@ -27,8 +27,6 @@
 
 #define NO_BOUNDARIES 0
 #define NO_LABELS 0
-#define EPC_STATS_TIMER_MSEC 60000          // In milliseconds
-#define EPC_STATS_DISPLAY_TIMER_MSEC 60000  // In milliseconds
 
 void service303_mme_app_statistics_read(
     application_mme_app_stats_msg_t* stats_msg_p);
@@ -40,6 +38,7 @@ void service303_statistics_display(void);
 typedef struct {
   bstring name;
   bstring version;
+  uint32_t display_stats_period;
 } service303_data_t;
 
 typedef enum application_health_e {

--- a/lte/gateway/c/core/oai/include/service303.h
+++ b/lte/gateway/c/core/oai/include/service303.h
@@ -38,7 +38,7 @@ void service303_statistics_display(void);
 typedef struct {
   bstring name;
   bstring version;
-  uint32_t display_stats_period;
+  uint32_t stats_display_timer_sec;
 } service303_data_t;
 
 typedef enum application_health_e {

--- a/lte/gateway/c/core/oai/tasks/mme_app/mme_app_main.c
+++ b/lte/gateway/c/core/oai/tasks/mme_app/mme_app_main.c
@@ -64,6 +64,7 @@ bool mme_congestion_control_enabled = true;
 long mme_app_last_msg_latency;
 long pre_mme_task_msg_latency;
 static long epc_stats_timer_id;
+static size_t epc_stats_timer = 60;
 
 mme_congestion_params_t mme_congestion_params;
 
@@ -553,6 +554,9 @@ status_code_e mme_app_init(const mme_config_t* mme_config_p) {
   mme_congestion_control_enabled = mme_config_p->enable_congestion_control;
   mme_app_init_congestion_params(mme_config_p);
 
+  // Initialize global stats timer
+  epc_stats_timer = (size_t) mme_config_p->stats_timer;
+
   /*
    * Create the thread associated with MME applicative layer
    */
@@ -578,7 +582,7 @@ static int handle_stats_timer(zloop_t* loop, int id, void* arg) {
 
 static void start_stats_timer(void) {
   epc_stats_timer_id = start_timer(
-      &mme_app_task_zmq_ctx, EPC_STATS_TIMER_MSEC, TIMER_REPEAT_FOREVER,
+      &mme_app_task_zmq_ctx, 1000 * epc_stats_timer, TIMER_REPEAT_FOREVER,
       handle_stats_timer, NULL);
 }
 

--- a/lte/gateway/c/core/oai/tasks/mme_app/mme_app_main.c
+++ b/lte/gateway/c/core/oai/tasks/mme_app/mme_app_main.c
@@ -64,7 +64,7 @@ bool mme_congestion_control_enabled = true;
 long mme_app_last_msg_latency;
 long pre_mme_task_msg_latency;
 static long epc_stats_timer_id;
-static size_t epc_stats_timer = 60;
+static size_t epc_stats_timer_sec = 60;
 
 mme_congestion_params_t mme_congestion_params;
 
@@ -555,7 +555,7 @@ status_code_e mme_app_init(const mme_config_t* mme_config_p) {
   mme_app_init_congestion_params(mme_config_p);
 
   // Initialize global stats timer
-  epc_stats_timer = (size_t) mme_config_p->stats_timer;
+  epc_stats_timer_sec = (size_t) mme_config_p->stats_timer_sec;
 
   /*
    * Create the thread associated with MME applicative layer
@@ -582,7 +582,7 @@ static int handle_stats_timer(zloop_t* loop, int id, void* arg) {
 
 static void start_stats_timer(void) {
   epc_stats_timer_id = start_timer(
-      &mme_app_task_zmq_ctx, 1000 * epc_stats_timer, TIMER_REPEAT_FOREVER,
+      &mme_app_task_zmq_ctx, 1000 * epc_stats_timer_sec, TIMER_REPEAT_FOREVER,
       handle_stats_timer, NULL);
 }
 

--- a/lte/gateway/c/core/oai/tasks/mme_app/mme_config.c
+++ b/lte/gateway/c/core/oai/tasks/mme_app/mme_config.c
@@ -244,19 +244,19 @@ void mme_config_init(mme_config_t* config) {
 
   pthread_rwlock_init(&config->rw_lock, NULL);
 
-  config->config_file                            = NULL;
-  config->max_enbs                               = 2;
-  config->max_ues                                = 2;
-  config->unauthenticated_imsi_supported         = 0;
-  config->relative_capacity                      = RELATIVE_CAPACITY;
-  config->stats_timer                            = 60;
-  config->service303_config.display_stats_period = 60;
-  config->enable_congestion_control              = true;
-  config->s1ap_zmq_th                            = LONG_MAX;
-  config->mme_app_zmq_congest_th                 = LONG_MAX;
-  config->mme_app_zmq_auth_th                    = LONG_MAX;
-  config->mme_app_zmq_ident_th                   = LONG_MAX;
-  config->mme_app_zmq_smc_th                     = LONG_MAX;
+  config->config_file                               = NULL;
+  config->max_enbs                                  = 2;
+  config->max_ues                                   = 2;
+  config->unauthenticated_imsi_supported            = 0;
+  config->relative_capacity                         = RELATIVE_CAPACITY;
+  config->stats_timer_sec                           = 60;
+  config->service303_config.stats_display_timer_sec = 60;
+  config->enable_congestion_control                 = true;
+  config->s1ap_zmq_th                               = LONG_MAX;
+  config->mme_app_zmq_congest_th                    = LONG_MAX;
+  config->mme_app_zmq_auth_th                       = LONG_MAX;
+  config->mme_app_zmq_ident_th                      = LONG_MAX;
+  config->mme_app_zmq_smc_th                        = LONG_MAX;
 
   log_config_init(&config->log_config);
   eps_network_feature_config_init(&config->eps_network_feature_support);
@@ -525,8 +525,8 @@ int mme_config_parse_file(mme_config_t* config_pP) {
 
     if ((config_setting_lookup_int(
             setting_mme, MME_CONFIG_STRING_STATS_TIMER, &aint))) {
-      config_pP->stats_timer                            = (uint32_t) aint;
-      config_pP->service303_config.display_stats_period = (uint32_t) aint;
+      config_pP->stats_timer_sec                           = (uint32_t) aint;
+      config_pP->service303_config.stats_display_timer_sec = (uint32_t) aint;
     }
 
     if ((config_setting_lookup_string(
@@ -1672,7 +1672,7 @@ void mme_config_display(mme_config_t* config_pP) {
       config_pP->relative_capacity);
   OAILOG_INFO(
       LOG_CONFIG, "- Statistics timer .....................: %u (seconds)\n\n",
-      config_pP->stats_timer);
+      config_pP->stats_timer_sec);
   OAILOG_INFO(
       LOG_CONFIG, "- Congestion control enabled ........................: %s\n",
       config_pP->enable_congestion_control ? "true" : "false");

--- a/lte/gateway/c/core/oai/tasks/mme_app/mme_config.c
+++ b/lte/gateway/c/core/oai/tasks/mme_app/mme_config.c
@@ -244,17 +244,19 @@ void mme_config_init(mme_config_t* config) {
 
   pthread_rwlock_init(&config->rw_lock, NULL);
 
-  config->config_file                    = NULL;
-  config->max_enbs                       = 2;
-  config->max_ues                        = 2;
-  config->unauthenticated_imsi_supported = 0;
-  config->relative_capacity              = RELATIVE_CAPACITY;
-  config->enable_congestion_control      = true;
-  config->s1ap_zmq_th                    = LONG_MAX;
-  config->mme_app_zmq_congest_th         = LONG_MAX;
-  config->mme_app_zmq_auth_th            = LONG_MAX;
-  config->mme_app_zmq_ident_th           = LONG_MAX;
-  config->mme_app_zmq_smc_th             = LONG_MAX;
+  config->config_file                            = NULL;
+  config->max_enbs                               = 2;
+  config->max_ues                                = 2;
+  config->unauthenticated_imsi_supported         = 0;
+  config->relative_capacity                      = RELATIVE_CAPACITY;
+  config->stats_timer                            = 60;
+  config->service303_config.display_stats_period = 60;
+  config->enable_congestion_control              = true;
+  config->s1ap_zmq_th                            = LONG_MAX;
+  config->mme_app_zmq_congest_th                 = LONG_MAX;
+  config->mme_app_zmq_auth_th                    = LONG_MAX;
+  config->mme_app_zmq_ident_th                   = LONG_MAX;
+  config->mme_app_zmq_smc_th                     = LONG_MAX;
 
   log_config_init(&config->log_config);
   eps_network_feature_config_init(&config->eps_network_feature_support);
@@ -519,6 +521,12 @@ int mme_config_parse_file(mme_config_t* config_pP) {
     if ((config_setting_lookup_int(
             setting_mme, MME_CONFIG_STRING_RELATIVE_CAPACITY, &aint))) {
       config_pP->relative_capacity = (uint8_t) aint;
+    }
+
+    if ((config_setting_lookup_int(
+            setting_mme, MME_CONFIG_STRING_STATS_TIMER, &aint))) {
+      config_pP->stats_timer                            = (uint32_t) aint;
+      config_pP->service303_config.display_stats_period = (uint32_t) aint;
     }
 
     if ((config_setting_lookup_string(
@@ -1662,6 +1670,9 @@ void mme_config_display(mme_config_t* config_pP) {
   OAILOG_INFO(
       LOG_CONFIG, "- Relative capa ........................: %u\n",
       config_pP->relative_capacity);
+  OAILOG_INFO(
+      LOG_CONFIG, "- Statistics timer .....................: %u (seconds)\n\n",
+      config_pP->stats_timer);
   OAILOG_INFO(
       LOG_CONFIG, "- Congestion control enabled ........................: %s\n",
       config_pP->enable_congestion_control ? "true" : "false");

--- a/lte/gateway/c/core/oai/tasks/s1ap/s1ap_mme.c
+++ b/lte/gateway/c/core/oai/tasks/s1ap/s1ap_mme.c
@@ -77,6 +77,7 @@ bool s1ap_dump_ue_hash_cb(
 static void start_stats_timer(void);
 static int handle_stats_timer(zloop_t* loop, int id, void* arg);
 static long epc_stats_timer_id;
+static size_t epc_stats_timer = 60;
 
 bool hss_associated = false;
 static int indent   = 0;
@@ -394,6 +395,9 @@ status_code_e s1ap_mme_init(const mme_config_t* mme_config_p) {
   s1ap_congestion_control_enabled = mme_config_p->enable_congestion_control;
   s1ap_zmq_th                     = mme_config_p->s1ap_zmq_th;
 
+  // Initialize global stats timer
+  epc_stats_timer = (size_t) mme_config_p->stats_timer;
+
   if (s1ap_state_init(
           mme_config_p->max_ues, mme_config_p->max_enbs,
           mme_config_p->use_stateless) < 0) {
@@ -630,6 +634,6 @@ static int handle_stats_timer(zloop_t* loop, int id, void* arg) {
 
 static void start_stats_timer(void) {
   epc_stats_timer_id = start_timer(
-      &s1ap_task_zmq_ctx, EPC_STATS_TIMER_MSEC, TIMER_REPEAT_FOREVER,
+      &s1ap_task_zmq_ctx, 1000 * epc_stats_timer, TIMER_REPEAT_FOREVER,
       handle_stats_timer, NULL);
 }

--- a/lte/gateway/c/core/oai/tasks/s1ap/s1ap_mme.c
+++ b/lte/gateway/c/core/oai/tasks/s1ap/s1ap_mme.c
@@ -77,7 +77,7 @@ bool s1ap_dump_ue_hash_cb(
 static void start_stats_timer(void);
 static int handle_stats_timer(zloop_t* loop, int id, void* arg);
 static long epc_stats_timer_id;
-static size_t epc_stats_timer = 60;
+static size_t epc_stats_timer_sec = 60;
 
 bool hss_associated = false;
 static int indent   = 0;
@@ -396,7 +396,7 @@ status_code_e s1ap_mme_init(const mme_config_t* mme_config_p) {
   s1ap_zmq_th                     = mme_config_p->s1ap_zmq_th;
 
   // Initialize global stats timer
-  epc_stats_timer = (size_t) mme_config_p->stats_timer;
+  epc_stats_timer_sec = (size_t) mme_config_p->stats_timer_sec;
 
   if (s1ap_state_init(
           mme_config_p->max_ues, mme_config_p->max_enbs,
@@ -634,6 +634,6 @@ static int handle_stats_timer(zloop_t* loop, int id, void* arg) {
 
 static void start_stats_timer(void) {
   epc_stats_timer_id = start_timer(
-      &s1ap_task_zmq_ctx, 1000 * epc_stats_timer, TIMER_REPEAT_FOREVER,
+      &s1ap_task_zmq_ctx, 1000 * epc_stats_timer_sec, TIMER_REPEAT_FOREVER,
       handle_stats_timer, NULL);
 }

--- a/lte/gateway/c/core/oai/tasks/service303/service303_task.c
+++ b/lte/gateway/c/core/oai/tasks/service303/service303_task.c
@@ -113,7 +113,7 @@ static void* service303_thread(void* args) {
   init_task_context(
       TASK_SERVICE303, (task_id_t[]){}, 0, handle_service_message,
       &service303_message_task_zmq_ctx);
-  start_display_stats_timer((size_t) service303_data->display_stats_period);
+  start_display_stats_timer((size_t) service303_data->stats_display_timer_sec);
   zloop_start(service303_message_task_zmq_ctx.event_loop);
   service303_message_exit();
   return NULL;
@@ -160,8 +160,8 @@ static int handle_display_timer(zloop_t* loop, int id, void* arg) {
   return 0;
 }
 
-static void start_display_stats_timer(size_t display_stats_period) {
+static void start_display_stats_timer(size_t stats_display_timer_sec) {
   display_stats_timer_id = start_timer(
-      &service303_message_task_zmq_ctx, 1000 * display_stats_period,
+      &service303_message_task_zmq_ctx, 1000 * stats_display_timer_sec,
       TIMER_REPEAT_FOREVER, handle_display_timer, NULL);
 }

--- a/lte/gateway/c/core/oai/tasks/service303/service303_task.c
+++ b/lte/gateway/c/core/oai/tasks/service303/service303_task.c
@@ -35,7 +35,7 @@ task_zmq_ctx_t service303_server_task_zmq_ctx;
 task_zmq_ctx_t service303_message_task_zmq_ctx;
 static long display_stats_timer_id;
 static int handle_display_timer(zloop_t*, int, void*);
-static void start_display_stats_timer(void);
+static void start_display_stats_timer(size_t);
 
 static int handle_service303_server_message(
     zloop_t* loop, zsock_t* reader, void* arg) {
@@ -108,11 +108,12 @@ static int handle_service_message(zloop_t* loop, zsock_t* reader, void* arg) {
 }
 
 static void* service303_thread(void* args) {
+  service303_data_t* service303_data = (service303_data_t*) args;
   itti_mark_task_ready(TASK_SERVICE303);
   init_task_context(
       TASK_SERVICE303, (task_id_t[]){}, 0, handle_service_message,
       &service303_message_task_zmq_ctx);
-  start_display_stats_timer();
+  start_display_stats_timer((size_t) service303_data->display_stats_period);
   zloop_start(service303_message_task_zmq_ctx.event_loop);
   service303_message_exit();
   return NULL;
@@ -159,8 +160,8 @@ static int handle_display_timer(zloop_t* loop, int id, void* arg) {
   return 0;
 }
 
-static void start_display_stats_timer(void) {
+static void start_display_stats_timer(size_t display_stats_period) {
   display_stats_timer_id = start_timer(
-      &service303_message_task_zmq_ctx, EPC_STATS_DISPLAY_TIMER_MSEC,
+      &service303_message_task_zmq_ctx, 1000 * display_stats_period,
       TIMER_REPEAT_FOREVER, handle_display_timer, NULL);
 }

--- a/lte/gateway/configs/templates/mme.conf.template
+++ b/lte/gateway/configs/templates/mme.conf.template
@@ -31,7 +31,7 @@ MME :
     EPS_NETWORK_FEATURE_SUPPORT_EXTENDED_SERVICE_REQUEST             = "no";    # DO NOT CHANGE
 
     # Report/Display MME statistics (expressed in seconds)
-    STATS_REPORTING_TIMER                    = 60;
+    STATS_TIMER_SEC                    = 60;
 
     USE_STATELESS = "{{ use_stateless }}";
     USE_HA = "{{ use_ha }}";

--- a/lte/gateway/configs/templates/mme.conf.template
+++ b/lte/gateway/configs/templates/mme.conf.template
@@ -30,6 +30,9 @@ MME :
     EPS_NETWORK_FEATURE_SUPPORT_LOCATION_SERVICES_VIA_EPC            = "no";    # DO NOT CHANGE
     EPS_NETWORK_FEATURE_SUPPORT_EXTENDED_SERVICE_REQUEST             = "no";    # DO NOT CHANGE
 
+    # Report/Display MME statistics (expressed in seconds)
+    STATS_REPORTING_TIMER                    = 60;
+
     USE_STATELESS = "{{ use_stateless }}";
     USE_HA = "{{ use_ha }}";
     ENABLE_GTPU_PRIVATE_IP_CORRECTION = "{{ enable_gtpu_private_ip_correction }}";


### PR DESCRIPTION
Signed-off-by: Ulas Kozat <kozat@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->
As part of resolving race conditions, stats reporting was moved out of mme_app during which configurable stats reporting parameter was removed as well. When log display was introduced back to service303 task, the display timer was hardcoded. The current PR makes stats collection and display period configurable. 

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->
Changed STATS_REPORTING_TIMER to 10 seconds, change mme log level to DEBUG, restart AGW services and observe log messages.

```
003143 Wed Jul 14 00:06:28 2021 7FD3B55F5700 DEBUG SERVIC tasks/service303/service303_mme_:0040    ======================================= STATISTICS ============================================

003144 Wed Jul 14 00:06:28 2021 7FD3B55F5700 DEBUG SERVIC tasks/service303/service303_mme_:0044                   |   Current Status|
003145 Wed Jul 14 00:06:28 2021 7FD3B55F5700 DEBUG SERVIC tasks/service303/service303_mme_:0045    Attached UEs   |          0      |
003146 Wed Jul 14 00:06:28 2021 7FD3B55F5700 DEBUG SERVIC tasks/service303/service303_mme_:0048    Connected UEs  |          0      |
003147 Wed Jul 14 00:06:28 2021 7FD3B55F5700 DEBUG SERVIC tasks/service303/service303_mme_:0051    Connected eNBs |          0      |
003148 Wed Jul 14 00:06:28 2021 7FD3B55F5700 DEBUG SERVIC tasks/service303/service303_mme_:0054    Default Bearers|          0      |
003149 Wed Jul 14 00:06:28 2021 7FD3B55F5700 DEBUG SERVIC tasks/service303/service303_mme_:0057    S1-U Bearers   |          0      |

003150 Wed Jul 14 00:06:28 2021 7FD3B55F5700 DEBUG SERVIC tasks/service303/service303_mme_:0061    ======================================= STATISTICS ============================================

003151 Wed Jul 14 00:06:28 2021 7FD3B35F1700 DEBUG MME-AP tasks/mme_app/mme_app_state_mana:0090      Inside get_state with read_from_db 0
003152 Wed Jul 14 00:06:38 2021 7FD3B55F5700 DEBUG SERVIC tasks/service303/service303_mme_:0040    ======================================= STATISTICS ============================================

003153 Wed Jul 14 00:06:38 2021 7FD3B55F5700 DEBUG SERVIC tasks/service303/service303_mme_:0044                   |   Current Status|
003154 Wed Jul 14 00:06:38 2021 7FD3B55F5700 DEBUG SERVIC tasks/service303/service303_mme_:0045    Attached UEs   |          0      |
003155 Wed Jul 14 00:06:38 2021 7FD3B55F5700 DEBUG SERVIC tasks/service303/service303_mme_:0048    Connected UEs  |          0      |
003156 Wed Jul 14 00:06:38 2021 7FD3B55F5700 DEBUG SERVIC tasks/service303/service303_mme_:0051    Connected eNBs |          0      |
003157 Wed Jul 14 00:06:38 2021 7FD3B55F5700 DEBUG SERVIC tasks/service303/service303_mme_:0054    Default Bearers|          0      |
003158 Wed Jul 14 00:06:38 2021 7FD3B55F5700 DEBUG SERVIC tasks/service303/service303_mme_:0057    S1-U Bearers   |          0      |

003159 Wed Jul 14 00:06:38 2021 7FD3B55F5700 DEBUG SERVIC tasks/service303/service303_mme_:0061    ======================================= STATISTICS ============================================

003160 Wed Jul 14 00:06:38 2021 7FD3B35F1700 DEBUG MME-AP tasks/mme_app/mme_app_state_mana:0090      Inside get_state with read_from_db 0
003161 Wed Jul 14 00:06:48 2021 7FD3B55F5700 DEBUG SERVIC tasks/service303/service303_mme_:0040    ======================================= STATISTICS ============================================

003162 Wed Jul 14 00:06:48 2021 7FD3B55F5700 DEBUG SERVIC tasks/service303/service303_mme_:0044                   |   Current Status|
003163 Wed Jul 14 00:06:48 2021 7FD3B55F5700 DEBUG SERVIC tasks/service303/service303_mme_:0045    Attached UEs   |          0      |
003164 Wed Jul 14 00:06:48 2021 7FD3B55F5700 DEBUG SERVIC tasks/service303/service303_mme_:0048    Connected UEs  |          0      |
003165 Wed Jul 14 00:06:48 2021 7FD3B55F5700 DEBUG SERVIC tasks/service303/service303_mme_:0051    Connected eNBs |          0      |
003166 Wed Jul 14 00:06:48 2021 7FD3B55F5700 DEBUG SERVIC tasks/service303/service303_mme_:0054    Default Bearers|          0      |
003167 Wed Jul 14 00:06:48 2021 7FD3B55F5700 DEBUG SERVIC tasks/service303/service303_mme_:0057    S1-U Bearers   |          0      |

003168 Wed Jul 14 00:06:48 2021 7FD3B55F5700 DEBUG SERVIC tasks/service303/service303_mme_:0061    ======================================= STATISTICS ============================================
```

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
