### PR TITLE
fix(agw): Fixed memory leaks during execution of s1ap sanity test suite

### DIFF
--- a/lte/gateway/c/core/oai/tasks/nas/emm/TrackingAreaUpdate.c
+++ b/lte/gateway/c/core/oai/tasks/nas/emm/TrackingAreaUpdate.c
@@ -682,11 +682,8 @@ static int emm_tracking_area_update_accept(nas_emm_tau_proc_t* const tau_proc) {
       emm_sap.u.emm_as.u.establish.emergency_number_list = NULL;
 
       emm_sap.u.emm_as.u.establish.eps_network_feature_support =
-          calloc(1, sizeof(eps_network_feature_support_t));
-      emm_sap.u.emm_as.u.establish.eps_network_feature_support->b1 =
-          _emm_data.conf.eps_network_feature_support[0];
-      emm_sap.u.emm_as.u.establish.eps_network_feature_support->b2 =
-          _emm_data.conf.eps_network_feature_support[1];
+          (eps_network_feature_support_t*) &_emm_data.conf
+              .eps_network_feature_support;
       emm_sap.u.emm_as.u.establish.additional_update_result = NULL;
       emm_sap.u.emm_as.u.establish.t3412_extended           = NULL;
       emm_sap.u.emm_as.u.establish.nas_msg =
@@ -779,12 +776,9 @@ static int emm_tracking_area_update_accept(nas_emm_tau_proc_t* const tau_proc) {
             tau_proc->ies->eps_bearer_context_status;
       }
 
-      emm_sap.u.emm_as.u.establish.eps_network_feature_support =
-          calloc(1, sizeof(eps_network_feature_support_t));
-      emm_sap.u.emm_as.u.establish.eps_network_feature_support->b1 =
-          _emm_data.conf.eps_network_feature_support[0];
-      emm_sap.u.emm_as.u.establish.eps_network_feature_support->b2 =
-          _emm_data.conf.eps_network_feature_support[1];
+      emm_sap.u.emm_as.u.data.eps_network_feature_support =
+          (eps_network_feature_support_t*) &_emm_data.conf
+              .eps_network_feature_support;
 
       /*If CSFB is enabled,store LAI,Mobile Identity and
        * Additional Update type to be sent in TAU accept to S1AP

--- a/lte/gateway/c/core/oai/tasks/s1ap/s1ap_state_converter.cpp
+++ b/lte/gateway/c/core/oai/tasks/s1ap/s1ap_state_converter.cpp
@@ -61,7 +61,11 @@ void S1apStateConverter::state_to_proto(s1ap_state_t* state, S1apState* proto) {
   }
 
   keys                        = hashtable_ts_get_keys(&state->enbs);
-  uint32_t expected_enb_count = keys ? keys->num_keys : 0;
+  uint32_t expected_enb_count = 0;
+  if (keys) {
+    expected_enb_count = keys->num_keys;
+    FREE_HASHTABLE_KEY_ARRAY(keys);
+  }
   if (expected_enb_count != state->num_enbs) {
     OAILOG_ERROR(
         LOG_S1AP, "Updating num_eNBs from maintained to actual count %u->%u",
@@ -89,7 +93,11 @@ void S1apStateConverter::proto_to_state(
 
   state->num_enbs             = proto.num_enbs();
   hashtable_key_array_t* keys = hashtable_ts_get_keys(&state->enbs);
-  uint32_t expected_enb_count = keys ? keys->num_keys : 0;
+  uint32_t expected_enb_count = 0;
+  if (keys) {
+    expected_enb_count = keys->num_keys;
+    FREE_HASHTABLE_KEY_ARRAY(keys);
+  }
   if (expected_enb_count != state->num_enbs) {
     OAILOG_WARNING(
         LOG_S1AP, "Updating num_eNBs from maintained to actual count %u->%u",


### PR DESCRIPTION
fix(agw): Fixes the issue, Fixes the issue, https://github.com/magma/magma/issues/6210

## Summary
All the memory leaks reported in issue, https://github.com/magma/magma/issues/6210 are not observed on latest master codebase. And provided fixes for which memory leaks observed on latest master codebase.

## Test Plan
Executed s1ap sanity test suite

