### PR TITLE
chore(agw): remove CLion/CMake gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,8 +65,8 @@ aws_keys.tfvars
 # Helm
 orc8r/cloud/helm/**/.secrets/
 
-# CMake debug files
-lte/gateway/c/session_manager/cmake-build-debug/
+# Certs for accessing the cloud
+.certs
 
 # Log files
 *.log


### PR DESCRIPTION
## Summary

Remove gitignore entries for cmake-build-debug folders. CLion/CMake pollutes checkouts with cmake-build-* folders, but they can be ignored by developers via their own global gitignore settings or entries in $MAGMA_ROOT/.gitignore/info/excludes

## Test Plan

Worked in my dev environment

## Additional Information

- [ ] This change is backwards-breaking

