### PR TITLE
fix(mme):  Send UE ctx release cmd to the source eNB after S1 Handover

### DIFF
--- a/lte/gateway/c/core/oai/include/s1ap_types.h
+++ b/lte/gateway/c/core/oai/include/s1ap_types.h
@@ -84,10 +84,12 @@ typedef struct s1ap_handover_state_s {
   mme_ue_s1ap_id_t mme_ue_s1ap_id;
   uint32_t source_enb_id;
   uint32_t target_enb_id;
-  enb_ue_s1ap_id_t
-      target_enb_ue_s1ap_id : 24;  ///< Unique UE id over eNB (24 bits wide)
-  sctp_stream_id_t target_sctp_stream_recv;  ///< eNB -> MME stream
-  sctp_stream_id_t target_sctp_stream_send;  ///< MME -> eNB stream
+  enb_ue_s1ap_id_t source_enb_ue_s1ap_id : 24;
+  enb_ue_s1ap_id_t target_enb_ue_s1ap_id : 24;
+  sctp_stream_id_t source_sctp_stream_recv;  ///< source eNB -> MME stream
+  sctp_stream_id_t target_sctp_stream_recv;  ///< target eNB -> MME stream
+  sctp_stream_id_t source_sctp_stream_send;  ///< MME -> source eNB stream
+  sctp_stream_id_t target_sctp_stream_send;  ///< MME -> target eNB stream
   e_rab_admitted_list_t e_rab_admitted_list;
 } s1ap_handover_state_t;
 

--- a/lte/gateway/c/core/oai/tasks/s1ap/s1ap_mme_handlers.c
+++ b/lte/gateway/c/core/oai/tasks/s1ap/s1ap_mme_handlers.c
@@ -1083,6 +1083,7 @@ status_code_e s1ap_mme_handle_ue_context_release_request(
   S1ap_UEContextReleaseRequest_t* container;
   S1ap_UEContextReleaseRequest_IEs_t* ie = NULL;
   ue_description_t* ue_ref_p             = NULL;
+  enb_description_t* enb_ref_p           = NULL;
   S1ap_Cause_PR cause_type;
   long cause_value;
   enum s1cause s1_release_cause   = S1AP_RADIO_EUTRAN_GENERATED_REASON;
@@ -1092,6 +1093,13 @@ status_code_e s1ap_mme_handle_ue_context_release_request(
   imsi64_t imsi64                 = INVALID_IMSI64;
 
   OAILOG_FUNC_IN(LOG_S1AP);
+  if ((enb_ref_p = s1ap_state_get_enb(state, assoc_id)) == NULL) {
+    OAILOG_ERROR(
+        LOG_S1AP, "Ignoring context release request from unknown assoc %u",
+        assoc_id);
+    OAILOG_FUNC_RETURN(LOG_S1AP, RETURNerror);
+  }
+
   container =
       &pdu->choice.initiatingMessage.value.choice.UEContextReleaseRequest;
   // Log the Cause Type and Cause value
@@ -1215,19 +1223,32 @@ status_code_e s1ap_mme_handle_ue_context_release_request(
         (uint32_t) mme_ue_s1ap_id, (uint32_t) enb_ue_s1ap_id);
     OAILOG_FUNC_RETURN(LOG_S1AP, RETURNerror);
   } else {
-    if (ue_ref_p->enb_ue_s1ap_id == enb_ue_s1ap_id) {
+    s1ap_imsi_map_t* imsi_map = get_s1ap_imsi_map();
+    hashtable_uint64_ts_get(
+        imsi_map->mme_ue_id_imsi_htbl, (const hash_key_t) mme_ue_s1ap_id,
+        &imsi64);
+    if (ue_ref_p->sctp_assoc_id == assoc_id &&
+        ue_ref_p->enb_ue_s1ap_id == enb_ue_s1ap_id) {
       /*
        * Both eNB UE S1AP ID and MME UE S1AP ID match.
        * Send a UE context Release Command to eNB after releasing S1-U bearer
        * tunnel mapping for all the bearers.
        */
-      s1ap_imsi_map_t* imsi_map = get_s1ap_imsi_map();
-      hashtable_uint64_ts_get(
-          imsi_map->mme_ue_id_imsi_htbl, (const hash_key_t) mme_ue_s1ap_id,
-          &imsi64);
       rc = s1ap_send_mme_ue_context_release(
           state, ue_ref_p, s1_release_cause, ie->value.choice.Cause, imsi64);
 
+      OAILOG_FUNC_RETURN(LOG_S1AP, rc);
+    } else if (
+        enb_ref_p->enb_id == ue_ref_p->s1ap_handover_state.source_enb_id &&
+        ue_ref_p->s1ap_handover_state.source_enb_ue_s1ap_id == enb_ue_s1ap_id) {
+      /*
+       * We just handed over from this eNB.
+       * Send a UE context Release Command to eNB. S1-U bearer already released
+       */
+      rc = s1ap_mme_generate_ue_context_release_command(
+          state, ue_ref_p, S1AP_RADIO_EUTRAN_GENERATED_REASON, imsi64, assoc_id,
+          ue_ref_p->s1ap_handover_state.source_sctp_stream_send, mme_ue_s1ap_id,
+          enb_ue_s1ap_id);
       OAILOG_FUNC_RETURN(LOG_S1AP, rc);
     } else {
       // abnormal case. No need to do anything. Ignore the message
@@ -1338,7 +1359,7 @@ status_code_e s1ap_mme_generate_ue_context_release_command(
   bstring b = blk2bstr(buffer, length);
   free(buffer);
   rc = s1ap_mme_itti_send_sctp_request(&b, assoc_id, stream, mme_ue_s1ap_id);
-  if (ue_ref_p != NULL) {
+  if (ue_ref_p != NULL && ue_ref_p->sctp_assoc_id == assoc_id) {
     ue_ref_p->s1_ue_state = S1AP_UE_WAITING_CRR;
     // We can safely remove UE context now, no need for timer
     s1ap_mme_release_ue_context(state, ue_ref_p, imsi64);
@@ -1545,16 +1566,28 @@ status_code_e s1ap_mme_handle_ue_context_release_complete(
         (uint32_t) mme_ue_s1ap_id);
     OAILOG_FUNC_RETURN(LOG_S1AP, RETURNok);
   } else {
-    /* This is an error scenario, the S1 UE context should have been deleted
-     * when UE context release command was sent
-     */
-    OAILOG_ERROR(
-        LOG_S1AP,
-        " UE Context Release commplete: S1 context should have been cleared "
-        "for "
-        "ueid " MME_UE_S1AP_ID_FMT "\n",
-        (uint32_t) mme_ue_s1ap_id);
-    OAILOG_FUNC_RETURN(LOG_S1AP, RETURNerror);
+    if (ue_ref_p->sctp_assoc_id == assoc_id) {
+      /* This is an error scenario, the S1 UE context should have been deleted
+       * when UE context release command was sent
+       */
+      OAILOG_ERROR(
+          LOG_S1AP,
+          " UE Context Release commplete: S1 context should have been cleared "
+          "for ueid " MME_UE_S1AP_ID_FMT "\n",
+          (uint32_t) mme_ue_s1ap_id);
+      OAILOG_FUNC_RETURN(LOG_S1AP, RETURNerror);
+    } else {
+      /*
+       * UE Context Release commplete received from a different eNB. This could
+       * be coming from the source eNB after a successful handover
+       */
+      OAILOG_DEBUG(
+          LOG_S1AP,
+          " UE Context Release commplete received from a different eNB."
+          " Ignore message for ueid " MME_UE_S1AP_ID_FMT "\n",
+          (uint32_t) mme_ue_s1ap_id);
+      OAILOG_FUNC_RETURN(LOG_S1AP, RETURNok);
+    }
   }
 }
 
@@ -2417,12 +2450,16 @@ status_code_e s1ap_mme_handle_handover_request(
   // set the recv and send streams for UE on the target.
   stream = target_enb->next_sctp_stream;
   ue_ref_p->s1ap_handover_state.target_sctp_stream_recv = stream;
+  ue_ref_p->s1ap_handover_state.source_sctp_stream_recv =
+      ue_ref_p->sctp_stream_recv;
   target_enb->next_sctp_stream += 1;
   if (target_enb->next_sctp_stream >= target_enb->instreams) {
     target_enb->next_sctp_stream = 1;
   }
   ue_ref_p->s1ap_handover_state.target_sctp_stream_send =
       target_enb->next_sctp_stream;
+  ue_ref_p->s1ap_handover_state.source_sctp_stream_send =
+      ue_ref_p->sctp_stream_send;
 
   // Build and send PDU
   pdu.present = S1ap_S1AP_PDU_PR_initiatingMessage;
@@ -2895,6 +2932,8 @@ status_code_e s1ap_mme_handle_handover_command(
   ue_ref_p->s1ap_handover_state.target_enb_id  = ho_command_p->target_enb_id;
   ue_ref_p->s1ap_handover_state.target_enb_ue_s1ap_id =
       ho_command_p->tgt_enb_ue_s1ap_id;
+  ue_ref_p->s1ap_handover_state.source_enb_ue_s1ap_id =
+      ue_ref_p->enb_ue_s1ap_id;
 
   OAILOG_INFO(LOG_S1AP, "Handover Command received");
   pdu.present = S1ap_S1AP_PDU_PR_successfulOutcome;
@@ -3096,6 +3135,7 @@ status_code_e s1ap_mme_handle_handover_notify(
         src_ue_ref_p->s1ap_handover_state.target_sctp_stream_recv;
     new_ue_ref_p->sctp_stream_send =
         src_ue_ref_p->s1ap_handover_state.target_sctp_stream_send;
+    new_ue_ref_p->s1ap_handover_state = src_ue_ref_p->s1ap_handover_state;
 
     // generate a message to update bearers
     s1ap_mme_itti_s1ap_handover_notify(


### PR DESCRIPTION
Signed-off-by: Tariq Al-Khasib <talkhasib@fb.com>

## Summary

As per https://github.com/magma/magma/pull/7985, context release command was getting sent to the wrong eNB.
This PR keeps track of the source eNB after a successful HO and appropriately handels the UE context release on the source eNB.

Next:
MME needs to start Handover_Release_Timer once a HO notify is received. If source eNB does not request a UE context release, MME should send a release command on expiry

## Test Plan

Tested using physical setup with 2 Baicells eNBs and a pixel3 phone
pcap and MME logs attached
[S1HO_fix_release.pcap.zip](https://github.com/magma/magma/files/6820705/S1HO_fix_release.pcap.zip)
[mme.log](https://github.com/magma/magma/files/6820707/mme.log)

integ_tests pass

