### PR TITLE
fix: Fix slack color on success

### DIFF
--- a/.github/workflows/cloud-workflow.yml
+++ b/.github/workflows/cloud-workflow.yml
@@ -195,4 +195,4 @@ jobs:
           SLACK_TITLE: "*Orchestrator images have been published*"
           SLACK_USERNAME: "Cloud workflow"
           SLACK_ICON_EMOJI: ":heavy_check_mark:"
-          SLACK_COLOR: "#FF0000"
+          SLACK_COLOR: "#00FF00"

--- a/.github/workflows/feg-workflow.yml
+++ b/.github/workflows/feg-workflow.yml
@@ -171,4 +171,4 @@ jobs:
           SLACK_TITLE: "*FeG Artifact Has Been Published*"
           SLACK_USERNAME: "Feg workflow"
           SLACK_ICON_EMOJI: ":heavy_check_mark:"
-          SLACK_COLOR: "#FF0000"
+          SLACK_COLOR: "#00FF00"


### PR DESCRIPTION
Fix on-success slack color notifications for
cloud and feg workflows.

Signed-off-by: Jessica Wagantall <jwagantall@linuxfoundation.org>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
