### PR TITLE
feat(nms): Gateway Detail Page Displaying Connection Status and Cluster Status

### DIFF
--- a/nms/app/packages/fbcnms-magma-api/__generated__/MagmaAPIBindings.js
+++ b/nms/app/packages/fbcnms-magma-api/__generated__/MagmaAPIBindings.js
@@ -428,6 +428,9 @@ export type federation_gateway = {
 };
 export type federation_gateway_health_status = {
     description: string,
+    service_status ? : {
+        [string]: service_status_health,
+    },
     status: "HEALTHY" | "UNHEALTHY",
 };
 export type federation_network_cluster_status = {
@@ -499,6 +502,7 @@ export type gateway_dns_configs = {
 export type gateway_dns_records = Array < dns_config_record >
 ;
 export type gateway_epc_configs = {
+    congestion_control_enabled ? : boolean,
     dns_primary ? : string,
     dns_secondary ? : string,
     ip_block: string,
@@ -909,6 +913,7 @@ export type network = {
     features ? : network_features,
     id: network_id,
     name: network_name,
+    sentry_config ? : network_sentry_config,
     type ? : network_type,
 };
 export type network_carrier_wifi_configs = {
@@ -937,6 +942,7 @@ export type network_dns_records = Array < dns_config_record >
 ;
 export type network_epc_configs = {
     cloud_subscriberdb_enabled ? : boolean,
+    congestion_control_enabled ? : boolean,
     default_rule_id ? : string,
     gx_gy_relay_enabled: boolean,
     hss_relay_enabled: boolean,
@@ -1031,6 +1037,7 @@ export type network_probe_task = {
 export type network_probe_task_details = {
     correlation_id ? : number,
     delivery_type: "all" | "events_only",
+    domain_id ? : string,
     duration ? : number,
     target_id: string,
     target_type: "imsi" | "imei" | "msisdn",
@@ -1048,6 +1055,12 @@ export type network_ran_configs = {
         special_subframe_pattern: number,
         subframe_assignment: number,
     },
+};
+export type network_sentry_config = {
+    sample_rate ? : number,
+    upload_mme_log ? : boolean,
+    url_native ? : string,
+    url_python ? : string,
 };
 export type network_subscriber_config = {
     network_wide_base_names ? : base_names,
@@ -1158,6 +1171,7 @@ export type policy_rule = {
     qos_profile ? : string,
     rating_group ? : number,
     redirect ? : redirect_information,
+    service_identifier ? : number,
     tracking_type ? : "ONLY_OCS" | "ONLY_PCRF" | "OCS_AND_PCRF" | "NO_TRACKING",
 };
 export type policy_rule_config = {
@@ -1171,6 +1185,7 @@ export type policy_rule_config = {
     priority: number,
     rating_group ? : number,
     redirect ? : redirect_information,
+    service_identifier ? : number,
     tracking_type ? : "ONLY_OCS" | "ONLY_PCRF" | "OCS_AND_PCRF" | "NO_TRACKING",
 };
 export type prom_alert_config = {
@@ -1287,6 +1302,7 @@ export type s6a = {
     server ? : diameter_client_configs,
 };
 export type s8 = {
+    apn_operator_suffix ? : string,
     local_address ? : string,
     pgw_address ? : string,
 };
@@ -1298,6 +1314,10 @@ export type served_network_ids = Array < string >
 ;
 export type served_nh_ids = Array < string >
 ;
+export type service_status_health = {
+    health_status ? : "HEALTHY" | "UNHEALTHY",
+    service_state ? : "AVAILABLE" | "UNAVAILABLE",
+};
 export type slack_action = {
     confirm ? : slack_confirm_field,
     name ? : string,
@@ -9097,6 +9117,48 @@ export default class MagmaAPIBindings {
 
         if (parameters['ratingGroup'] !== undefined) {
             body = parameters['ratingGroup'];
+        }
+
+        return await this.request(path, 'PUT', query, body);
+    }
+    static async getNetworksByNetworkIdSentry(
+            parameters: {
+                'networkId': string,
+            }
+        ): Promise < network_sentry_config >
+        {
+            let path = '/networks/{network_id}/sentry';
+            let body;
+            let query = {};
+            if (parameters['networkId'] === undefined) {
+                throw new Error('Missing required  parameter: networkId');
+            }
+
+            path = path.replace('{network_id}', `${parameters['networkId']}`);
+
+            return await this.request(path, 'GET', query, body);
+        }
+    static async putNetworksByNetworkIdSentry(
+        parameters: {
+            'networkId': string,
+            'networkSentryConfig': network_sentry_config,
+        }
+    ): Promise < "Success" > {
+        let path = '/networks/{network_id}/sentry';
+        let body;
+        let query = {};
+        if (parameters['networkId'] === undefined) {
+            throw new Error('Missing required  parameter: networkId');
+        }
+
+        path = path.replace('{network_id}', `${parameters['networkId']}`);
+
+        if (parameters['networkSentryConfig'] === undefined) {
+            throw new Error('Missing required  parameter: networkSentryConfig');
+        }
+
+        if (parameters['networkSentryConfig'] !== undefined) {
+            body = parameters['networkSentryConfig'];
         }
 
         return await this.request(path, 'PUT', query, body);

--- a/nms/app/packages/magmalte/app/views/equipment/FEGGatewayConnectionStatus.js
+++ b/nms/app/packages/magmalte/app/views/equipment/FEGGatewayConnectionStatus.js
@@ -1,0 +1,97 @@
+/**
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @flow strict-local
+ * @format
+ */
+
+import type {DataRows} from '../../components/DataGrid';
+
+import DataGrid from '../../components/DataGrid';
+import FEGGatewayContext from '../../components/context/FEGGatewayContext';
+import React from 'react';
+import nullthrows from '@fbcnms/util/nullthrows';
+
+import {
+  AVAILABLE_STATUS,
+  HEALTHY_STATUS,
+  ServiceTypeEnum,
+} from '../../components/GatewayUtils';
+import {useContext} from 'react';
+import {useRouter} from '@fbcnms/ui/hooks';
+
+/**
+ * Displays the Connection status of the Gx/Gy servers, S6a server
+ * and SWx server.
+ */
+export default function FEGGatewayConnectionStatus() {
+  const {match} = useRouter();
+  const ctx = useContext(FEGGatewayContext);
+  const gatewayId: string = nullthrows(match.params.gatewayId);
+  const gwHealthStatus = ctx.health[gatewayId] || {};
+  const getServiceHealthStatus = serviceStatus => {
+    if (serviceStatus) {
+      if (!(serviceStatus.service_state === AVAILABLE_STATUS)) {
+        return ServiceTypeEnum.UNAVAILABLE_SERVICE;
+      }
+      return serviceStatus?.health_status === HEALTHY_STATUS
+        ? ServiceTypeEnum.HEALTHY_SERVICE
+        : ServiceTypeEnum.UNHEALTHY_SERVICE;
+    }
+    return ServiceTypeEnum.UNENABLED_SERVICE;
+  };
+  const isServiceStatusInactive = serviceStatus =>
+    serviceStatus === ServiceTypeEnum.UNAVAILABLE_SERVICE ||
+    serviceStatus === ServiceTypeEnum.UNENABLED_SERVICE;
+  const isServiceStatusActive = serviceStatus =>
+    serviceStatus === ServiceTypeEnum.HEALTHY_SERVICE;
+  const gxGyConnectionStatus = getServiceHealthStatus(
+    gwHealthStatus?.service_status?.SESSION_PROXY,
+  );
+  const swxConnectionStatus = getServiceHealthStatus(
+    gwHealthStatus?.service_status?.SWX_PROXY,
+  );
+  const s6aConnectionStatus = getServiceHealthStatus(
+    gwHealthStatus?.service_status?.S6A_PROXY,
+  );
+
+  const kpiData: DataRows[] = [
+    [
+      {
+        category: 'Gx/Gy Watchdog',
+        value: gxGyConnectionStatus,
+        statusCircle: true,
+        statusInactive: isServiceStatusInactive(gxGyConnectionStatus),
+        status: isServiceStatusActive(gxGyConnectionStatus),
+        tooltip: 'Connection status of Gx & Gy servers',
+      },
+      {
+        category: 'SWx Watchdog',
+        value: swxConnectionStatus,
+        statusCircle: true,
+        statusInactive: isServiceStatusInactive(swxConnectionStatus),
+        status: isServiceStatusActive(swxConnectionStatus),
+        tooltip: 'Connection status of SWx server',
+      },
+      {
+        category: 'S6a Watchdog',
+        value: s6aConnectionStatus,
+        statusCircle: true,
+        statusInactive: isServiceStatusInactive(s6aConnectionStatus),
+        status: isServiceStatusActive(s6aConnectionStatus),
+        tooltip: 'Connection status of S6a server',
+      },
+    ],
+  ];
+
+  return <DataGrid data={kpiData} />;
+}

--- a/nms/app/packages/magmalte/app/views/equipment/FEGGatewayDetailMain.js
+++ b/nms/app/packages/magmalte/app/views/equipment/FEGGatewayDetailMain.js
@@ -20,6 +20,8 @@ import CardTitleRow from '../../components/layout/CardTitleRow';
 import CellWifiIcon from '@material-ui/icons/CellWifi';
 import DashboardIcon from '@material-ui/icons/Dashboard';
 import EventsTable from '../../views/events/EventsTable';
+import FEGClusterStatus from '../equipment/FEGClusterStatus';
+import FEGGatewayConnectionStatus from './FEGGatewayConnectionStatus';
 import FEGGatewayContext from '../../components/context/FEGGatewayContext';
 import FEGGatewayDetailConfig from './FEGGatewayDetailConfig';
 import FEGGatewayDetailStatus from './FEGGatewayDetailStatus';
@@ -157,6 +159,13 @@ function FEGGatewayOverview() {
                 filter={() => filter(refresh, setRefresh)}
               />
               <FEGGatewayDetailStatus refresh={refresh} />
+            </Grid>
+            <Grid item>
+              <CardTitleRow icon={GraphicEqIcon} label="Connection Status" />
+              <FEGGatewayConnectionStatus />
+            </Grid>
+            <Grid item>
+              <FEGClusterStatus />
             </Grid>
             <Grid item>
               <Tooltip

--- a/nms/app/packages/magmalte/app/views/equipment/__tests__/FEGGatewayConnectionStatusTest.js
+++ b/nms/app/packages/magmalte/app/views/equipment/__tests__/FEGGatewayConnectionStatusTest.js
@@ -1,0 +1,122 @@
+/**
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @flow strict-local
+ * @format
+ */
+
+import 'jest-dom/extend-expect';
+import FEGGatewayConnectionStatus from '../FEGGatewayConnectionStatus';
+import FEGGatewayContext from '../../../components/context/FEGGatewayContext';
+import MuiStylesThemeProvider from '@material-ui/styles/ThemeProvider';
+import React from 'react';
+import defaultTheme from '@fbcnms/ui/theme/default';
+import {MemoryRouter, Route} from 'react-router-dom';
+import {MuiThemeProvider} from '@material-ui/core/styles';
+import {cleanup, render, wait} from '@testing-library/react';
+import type {federation_gateway} from '@fbcnms/magma-api';
+
+jest.mock('axios');
+jest.mock('@fbcnms/magma-api');
+jest.mock('@fbcnms/ui/hooks/useSnackbar');
+afterEach(cleanup);
+
+const mockGw0: federation_gateway = {
+  id: 'test_feg_gw0',
+  name: 'test_gateway',
+  description: 'hello I am a federated gateway',
+  tier: 'default',
+  device: {
+    key: {key: '', key_type: 'SOFTWARE_ECDSA_SHA256'},
+    hardware_id: 'c9439d30-61ef-46c7-93f2-e01fc131244d',
+  },
+  magmad: {
+    autoupgrade_enabled: true,
+    autoupgrade_poll_interval: 300,
+    checkin_interval: 60,
+    checkin_timeout: 100,
+    dynamic_services: ['monitord', 'eventd'],
+    tier: 'tier2',
+  },
+  federation: {
+    aaa_server: {},
+    eap_aka: {
+      plmn_ids: [],
+    },
+    gx: {},
+    gy: {},
+    health: {
+      health_services: [],
+    },
+    hss: {},
+    s6a: {},
+    served_network_ids: [],
+    swx: {
+      hlr_plmn_ids: [],
+      server: {
+        protocol: 'tcp',
+      },
+      servers: [],
+    },
+    csfb: {},
+  },
+};
+
+const fegGateways = {
+  [mockGw0.id]: mockGw0,
+};
+
+const fegGatewaysHealth = {
+  [mockGw0.id]: {
+    status: 'HEALTHY',
+    service_status: {
+      SESSION_PROXY: {health_status: 'UNHEALTHY', service_state: 'UNAVAILABLE'},
+      SWX_PROXY: {health_status: 'UNHEALTHY', service_state: 'AVAILABLE'},
+    },
+  },
+};
+
+describe('<FEGGatewayConnectionStatus />', () => {
+  const Wrapper = () => (
+    <MemoryRouter
+      initialEntries={[
+        '/nms/mynetwork/equipment/overview/gateway/test_feg_gw0/overview',
+      ]}
+      initialIndex={0}>
+      <MuiThemeProvider theme={defaultTheme}>
+        <MuiStylesThemeProvider theme={defaultTheme}>
+          <FEGGatewayContext.Provider
+            value={{
+              state: fegGateways,
+              setState: async _ => {},
+              health: fegGatewaysHealth,
+              activeFegGatewayId: mockGw0.id,
+            }}>
+            <Route
+              path="/nms/:networkId/equipment/overview/gateway/:gatewayId/overview"
+              render={props => <FEGGatewayConnectionStatus {...props} />}
+            />
+          </FEGGatewayContext.Provider>
+        </MuiStylesThemeProvider>
+      </MuiThemeProvider>
+    </MemoryRouter>
+  );
+
+  it('renders federation gateway connection status correctly', async () => {
+    const {getByTestId} = render(<Wrapper />);
+    await wait();
+    // verify gateway connection status
+    expect(getByTestId('Gx/Gy Watchdog')).toHaveTextContent('N/A');
+    expect(getByTestId('SWx Watchdog')).toHaveTextContent('Down');
+    expect(getByTestId('S6a Watchdog')).toHaveTextContent('Not Enabled');
+  });
+});


### PR DESCRIPTION
<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary
This is stacked PR upon the open PR #8018, and therefore is a Draft PR until the other PR gets merged. A component was created to display the connection status of the gateway. It displays the status of the gx/gy, swx and s6a servers of the federation gateway. Also, the cluster component displaying the federation network's cluster status was redisplayed here in the gateway details page too.
<!-- Enumerate changes you made and why you made them -->

## Test Plan
A test file named FEGGatewayConnectionStatusTest.js was created to test that the correct connection status was displayed. No, new test was added for the cluster status because it is an already existing component that has been tested and was just imported here. Also, previous tests run without error.
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information
<img width="821" alt="Screen Shot 2021-07-16 at 11 11 43 AM" src="https://user-images.githubusercontent.com/34602743/125969794-d3b9fc3b-6fbc-481b-9e6e-f7fc606a761f.png">

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
