### PR TITLE
feat(nms): Gateway Config Page

### DIFF
--- a/nms/app/packages/magmalte/app/views/equipment/FEGGatewayDetailConfig.js
+++ b/nms/app/packages/magmalte/app/views/equipment/FEGGatewayDetailConfig.js
@@ -1,0 +1,251 @@
+/*
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @flow strict-local
+ * @format
+ */
+
+import type {DataRows} from '../../components/DataGrid';
+import type {
+  diameter_client_configs,
+  federation_gateway,
+  sctp_client_configs,
+} from '@fbcnms/magma-api';
+
+import CardTitleRow from '../../components/layout/CardTitleRow';
+import DataGrid from '../../components/DataGrid';
+import FEGGatewayContext from '../../components/context/FEGGatewayContext';
+import Grid from '@material-ui/core/Grid';
+import React from 'react';
+import nullthrows from '@fbcnms/util/nullthrows';
+
+import {makeStyles} from '@material-ui/styles';
+import {useContext} from 'react';
+import {useRouter} from '@fbcnms/ui/hooks';
+
+const useStyles = makeStyles(theme => ({
+  dashboardRoot: {
+    margin: theme.spacing(3),
+    flexGrow: 1,
+  },
+}));
+
+/**
+ * Returns the configuration page of the selected federation
+ * gateway. It provides information about the federation gateway
+ * and its servers such as gx, gy, and the like.
+ */
+export default function FEGGatewayConfig() {
+  const classes = useStyles();
+  const {match} = useRouter();
+  const gatewayId: string = nullthrows(match.params.gatewayId);
+  const ctx = useContext(FEGGatewayContext);
+  const gwInfo = ctx.state[gatewayId];
+
+  return (
+    <div className={classes.dashboardRoot}>
+      <Grid container spacing={4}>
+        <Grid item xs={12}>
+          <Grid container spacing={4}>
+            <Grid item xs={12} md={6} alignItems="center">
+              <Grid container spacing={4}>
+                <Grid item xs={12}>
+                  <CardTitleRow label="Gateway" />
+                  <GatewayInfoConfig gwInfo={gwInfo} />
+                </Grid>
+                <Grid item xs={12}>
+                  <CardTitleRow label="Gx" />
+                  <GatewayDiameterServerConfig
+                    serverConfig={gwInfo?.federation?.gx?.server || {}}
+                    testID={'Gx'}
+                  />
+                </Grid>
+                <Grid item xs={12}>
+                  <CardTitleRow label="CSFB" />
+                  <GatewaySctpServerConfig
+                    serverConfig={gwInfo?.federation?.csfb?.client || {}}
+                    testID={'CSFB'}
+                  />
+                </Grid>
+              </Grid>
+            </Grid>
+            <Grid item xs={12} md={6} alignItems="center">
+              <Grid container spacing={4}>
+                <Grid item xs={12}>
+                  <CardTitleRow label="Gy" />
+                  <GatewayDiameterServerConfig
+                    serverConfig={gwInfo?.federation?.gy?.server || {}}
+                    testID={'Gy'}
+                  />
+                </Grid>
+                <Grid item xs={12}>
+                  <CardTitleRow label="SWx" />
+                  <GatewayDiameterServerConfig
+                    serverConfig={gwInfo?.federation?.swx?.server || {}}
+                    testID={'SWx'}
+                  />
+                </Grid>
+                <Grid item xs={12}>
+                  <CardTitleRow label="S6a" />
+                  <GatewayDiameterServerConfig
+                    serverConfig={gwInfo?.federation?.s6a?.server || {}}
+                    testID={'S6a'}
+                  />
+                </Grid>
+              </Grid>
+            </Grid>
+          </Grid>
+        </Grid>
+      </Grid>
+    </div>
+  );
+}
+
+/**
+ * Returns useful information about the federation gateway. It returns
+ * its name, id, hardware uuid, version and description.
+ * @param {federation_gateway} gwInfo The federation gateway that is being looked at.
+ */
+function GatewayInfoConfig({gwInfo}: {gwInfo: federation_gateway}) {
+  const data: DataRows[] = [
+    [
+      {
+        category: 'Name',
+        value: gwInfo.name,
+      },
+    ],
+    [
+      {
+        category: 'Gateway ID',
+        value: gwInfo.id,
+      },
+    ],
+    [
+      {
+        category: 'Hardware UUID',
+        value: gwInfo.device.hardware_id,
+      },
+    ],
+    [
+      {
+        category: 'Version',
+        value: gwInfo.status?.platform_info?.packages?.[0]?.version ?? 'null',
+      },
+    ],
+    [
+      {
+        category: 'Description',
+        value: gwInfo.description,
+      },
+    ],
+  ];
+
+  return <DataGrid data={data} />;
+}
+
+/**
+ * Returns useful information about the federation gateway's diameter based
+ * server.
+ * @param {diameter_client_configs} serverConfig Configuration object of the diameter based server.
+ * @param {string} testId An id used to differentiate the various diameter servers.
+ */
+function GatewayDiameterServerConfig({
+  serverConfig,
+  testID,
+}: {
+  serverConfig: diameter_client_configs,
+  testID: string,
+}) {
+  const data: DataRows[] = [
+    [
+      {
+        category: 'Address',
+        value: serverConfig?.address || '-',
+      },
+    ],
+    [
+      {
+        category: 'Destination Host',
+        value: serverConfig?.dest_host || '-',
+      },
+    ],
+    [
+      {
+        category: 'Destination Realm',
+        value: serverConfig?.dest_realm || '-',
+      },
+    ],
+    [
+      {
+        category: 'Host',
+        value: serverConfig?.host || '-',
+      },
+    ],
+    [
+      {
+        category: 'Realm',
+        value: serverConfig?.realm || '-',
+      },
+    ],
+    [
+      {
+        category: 'Local Address',
+        value: serverConfig?.local_address || '-',
+      },
+    ],
+    [
+      {
+        category: 'Product Name',
+        value: serverConfig?.product_name || '-',
+      },
+    ],
+    [
+      {
+        category: 'Protocol',
+        value: serverConfig?.protocol || '-',
+      },
+    ],
+  ];
+
+  return <DataGrid data={data} testID={testID} />;
+}
+
+/**
+ * Returns useful information about the federation gateway's sctp based
+ * server.
+ * @param {sctp_client_configs} serverConfig Configuration object of the sctp based server.
+ * @param {string} testId An id used to differentiate the various servers.
+ */
+function GatewaySctpServerConfig({
+  serverConfig,
+  testID,
+}: {
+  serverConfig: sctp_client_configs,
+  testID: string,
+}) {
+  const data: DataRows[] = [
+    [
+      {
+        category: 'Local Address',
+        value: serverConfig?.local_address || '-',
+      },
+    ],
+    [
+      {
+        category: 'Server Address',
+        value: serverConfig?.server_address || '-',
+      },
+    ],
+  ];
+
+  return <DataGrid data={data} testID={testID} />;
+}

--- a/nms/app/packages/magmalte/app/views/equipment/FEGGatewayDetailMain.js
+++ b/nms/app/packages/magmalte/app/views/equipment/FEGGatewayDetailMain.js
@@ -21,6 +21,7 @@ import CellWifiIcon from '@material-ui/icons/CellWifi';
 import DashboardIcon from '@material-ui/icons/Dashboard';
 import EventsTable from '../../views/events/EventsTable';
 import FEGGatewayContext from '../../components/context/FEGGatewayContext';
+import FEGGatewayDetailConfig from './FEGGatewayDetailConfig';
 import FEGGatewayDetailStatus from './FEGGatewayDetailStatus';
 import FEGGatewaySummary from './FEGGatewaySummary';
 import GraphicEqIcon from '@material-ui/icons/GraphicEq';
@@ -91,6 +92,10 @@ export default function FEGGatewayDetail() {
         <Route
           path={relativePath('/overview')}
           component={FEGGatewayOverview}
+        />
+        <Route
+          path={relativePath('/config')}
+          component={FEGGatewayDetailConfig}
         />
         <Redirect to={relativeUrl('/overview')} />
       </Switch>

--- a/nms/app/packages/magmalte/app/views/equipment/__tests__/FEGGatewayDetailConfigTest.js
+++ b/nms/app/packages/magmalte/app/views/equipment/__tests__/FEGGatewayDetailConfigTest.js
@@ -1,0 +1,188 @@
+/**
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @flow strict-local
+ * @format
+ */
+
+import 'jest-dom/extend-expect';
+import FEGGatewayContext from '../../../components/context/FEGGatewayContext';
+import FEGGatewayDetailConfig from '../FEGGatewayDetailConfig';
+import MuiStylesThemeProvider from '@material-ui/styles/ThemeProvider';
+import React from 'react';
+import defaultTheme from '@fbcnms/ui/theme/default';
+import {MemoryRouter, Route} from 'react-router-dom';
+import {MuiThemeProvider} from '@material-ui/core/styles';
+import {cleanup, render, wait} from '@testing-library/react';
+import type {
+  csfb,
+  federation_gateway,
+  gx,
+  gy,
+  s6a,
+  swx,
+} from '@fbcnms/magma-api';
+
+jest.mock('axios');
+jest.mock('@fbcnms/magma-api');
+jest.mock('@fbcnms/ui/hooks/useSnackbar');
+afterEach(cleanup);
+
+const mockGx: gx = {
+  server: {
+    address: '174.16.1.14:3868',
+    dest_host: 'magma.magma.com',
+    dest_realm: 'magma.com',
+    product_name: 'magma',
+  },
+};
+
+const mockGy: gy = {
+  server: {
+    address: '174.18.1.0:3868',
+    host: 'localhost',
+    realm: 'test',
+  },
+};
+
+const mockSwx: swx = {
+  server: {
+    address: '174.18.1.0:3869',
+    local_address: ':3809',
+  },
+};
+
+const mockS6a: s6a = {
+  server: {
+    address: '174.18.1.0:2000',
+    protocol: 'tcp',
+  },
+};
+
+const mockCsfb: csfb = {
+  client: {
+    server_address: '174.18.1.0:2200',
+    local_address: ':3440',
+  },
+};
+
+const mockGw0: federation_gateway = {
+  id: 'test_feg_gw0',
+  name: 'test_gateway',
+  description: 'hello I am a federated gateway',
+  tier: 'default',
+  device: {
+    key: {key: '', key_type: 'SOFTWARE_ECDSA_SHA256'},
+    hardware_id: 'c9439d30-61ef-46c7-93f2-e01fc131255d',
+  },
+  magmad: {
+    autoupgrade_enabled: true,
+    autoupgrade_poll_interval: 300,
+    checkin_interval: 60,
+    checkin_timeout: 100,
+    tier: 'tier2',
+  },
+  federation: {
+    aaa_server: {},
+    eap_aka: {
+      plmn_ids: [],
+    },
+    gx: mockGx,
+    gy: mockGy,
+    health: {
+      health_services: [],
+    },
+    hss: {},
+    s6a: mockS6a,
+    served_network_ids: [],
+    swx: mockSwx,
+    csfb: mockCsfb,
+  },
+  status: {
+    checkin_time: 0,
+    meta: {
+      gps_latitude: '0',
+      gps_longitude: '0',
+      gps_connected: '0',
+      enodeb_connected: '0',
+      mme_connected: '0',
+    },
+  },
+};
+
+const fegGateways = {
+  [mockGw0.id]: mockGw0,
+};
+
+const fegGatewaysHealth = {
+  [mockGw0.id]: {status: 'HEALTHY'},
+};
+
+describe('<FEGGatewayDetailConfig />', () => {
+  const Wrapper = () => (
+    <MemoryRouter
+      initialEntries={[
+        '/nms/mynetwork/equipment/overview/gateway/test_feg_gw0/config',
+      ]}
+      initialIndex={0}>
+      <MuiThemeProvider theme={defaultTheme}>
+        <MuiStylesThemeProvider theme={defaultTheme}>
+          <FEGGatewayContext.Provider
+            value={{
+              state: fegGateways,
+              setState: async _ => {},
+              health: fegGatewaysHealth,
+              activeFegGatewayId: mockGw0.id,
+            }}>
+            <Route
+              path="/nms/:networkId/equipment/overview/gateway/:gatewayId/config"
+              render={props => <FEGGatewayDetailConfig {...props} />}
+            />
+          </FEGGatewayContext.Provider>
+        </MuiStylesThemeProvider>
+      </MuiThemeProvider>
+    </MemoryRouter>
+  );
+
+  it('renders federation gateway configs correctly', async () => {
+    const {getByTestId} = render(<Wrapper />);
+    await wait();
+    // verify gateway info
+    expect(getByTestId('Name')).toHaveTextContent('test_gateway');
+    expect(getByTestId('Gateway ID')).toHaveTextContent('test_feg_gw0');
+    expect(getByTestId('Hardware UUID')).toHaveTextContent(
+      'c9439d30-61ef-46c7-93f2-e01fc131255d',
+    );
+    expect(getByTestId('Version')).toHaveTextContent('null');
+    expect(getByTestId('Description')).toHaveTextContent(
+      'hello I am a federated gateway',
+    );
+    // verify gx configurations
+    expect(getByTestId('Gx')).toHaveTextContent('174.16.1.14:3868');
+    expect(getByTestId('Gx')).toHaveTextContent('magma.magma.com');
+    expect(getByTestId('Gx')).toHaveTextContent('magma.com');
+    expect(getByTestId('Gx')).toHaveTextContent('magma');
+    // verify gy configurations
+    expect(getByTestId('Gy')).toHaveTextContent('74.18.1.0:3868');
+    expect(getByTestId('Gy')).toHaveTextContent('localhost');
+    expect(getByTestId('Gy')).toHaveTextContent('test');
+    // verify swx configurations
+    expect(getByTestId('SWx')).toHaveTextContent('174.18.1.0:3869');
+    expect(getByTestId('SWx')).toHaveTextContent(':3809');
+    // verify s6a configurations
+    expect(getByTestId('S6a')).toHaveTextContent('174.18.1.0:2000');
+    expect(getByTestId('S6a')).toHaveTextContent('tcp');
+    // verify csfb configurations
+    expect(getByTestId('CSFB')).toHaveTextContent('174.18.1.0:2200');
+    expect(getByTestId('CSFB')).toHaveTextContent('3440');
+  });
+});


### PR DESCRIPTION
<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary
This is stacked PR upon the open PR #8015, and therefore is a Draft PR until the other PR gets merged. A Gateway Config Page was created which  displays information about the Federation Gateway and its gx, gy, swx, s6a, and csfb servers. 
<!-- Enumerate changes you made and why you made them -->

## Test Plan
A test file named FEGGatewayDetailConfigTest.js was added to check that the correct information about the federation gateway and its servers is displayed. Also, all previous test run without any error. 
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information
<img width="1770" alt="Screen Shot 2021-07-16 at 11 46 48 AM" src="https://user-images.githubusercontent.com/34602743/125974361-dcb5e094-8132-4bda-90bc-6ccc75aab565.png">

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
