### PR TITLE
feat(nms): Gateway Config Page Editing Federation Gateway

### DIFF
--- a/nms/app/packages/magmalte/app/components/feg/FEGGatewayDialog.js
+++ b/nms/app/packages/magmalte/app/components/feg/FEGGatewayDialog.js
@@ -29,6 +29,7 @@ import Checkbox from '@material-ui/core/Checkbox';
 import Dialog from '@material-ui/core/Dialog';
 import DialogActions from '@material-ui/core/DialogActions';
 import DialogContent from '@material-ui/core/DialogContent';
+import FEGGatewayContext from '../context/FEGGatewayContext';
 import FormControl from '@material-ui/core/FormControl';
 import FormControlLabel from '@material-ui/core/FormControlLabel';
 import InputLabel from '@material-ui/core/InputLabel';
@@ -36,7 +37,7 @@ import KeyValueFields from '@fbcnms/magmalte/app/components/KeyValueFields';
 import LoadingFillerBackdrop from '@fbcnms/ui/components/LoadingFillerBackdrop';
 import MagmaV1API from '@fbcnms/magma-api/client/WebClient';
 import MenuItem from '@material-ui/core/MenuItem';
-import React, {useState} from 'react';
+import React, {useContext, useState} from 'react';
 import Select from '@material-ui/core/Select';
 import Tab from '@material-ui/core/Tab';
 import Tabs from '@material-ui/core/Tabs';
@@ -69,6 +70,7 @@ type Props = {|
   onClose: () => void,
   onSave: federation_gateway => void,
   editingGateway?: federation_gateway,
+  tabOption?: TabOption,
 |};
 
 type SCTPValues = {
@@ -100,6 +102,17 @@ type DiameterValues = {
   protocol: $PropertyType<diameter_client_configs, 'protocol'>,
   disable_dest_host: boolean,
 };
+
+export const TAB_OPTIONS = Object.freeze({
+  GENERAL: 'general',
+  GX: 'gx',
+  GY: 'gy',
+  SWX: 'swx',
+  S6A: 's6a',
+  CSFB: 'csfb',
+});
+
+export type TabOption = $Values<typeof TAB_OPTIONS>;
 
 function getDiameterConfigs(cfg: DiameterValues): gx {
   return {
@@ -146,8 +159,11 @@ export default function FEGGatewayDialog(props: Props) {
   const {match} = useRouter();
   const enqueueSnackbar = useEnqueueSnackbar();
 
-  const {editingGateway} = props;
-  const [tab, setTab] = useState(editingGateway ? 'gx' : 'general');
+  const ctx = useContext(FEGGatewayContext);
+  const {editingGateway, tabOption} = props;
+  const [tab, setTab] = useState(
+    editingGateway ? tabOption ?? TAB_OPTIONS.GX : TAB_OPTIONS.GENERAL,
+  );
   const [generalFields, setGeneralFields] = useState(EMPTY_GATEWAY_FIELDS);
   const [gx, setGx] = useState<DiameterValues>(
     getDiameterServerConfig(editingGateway?.federation?.gx?.server),
@@ -209,30 +225,28 @@ export default function FEGGatewayDialog(props: Props) {
   const onSave = async () => {
     try {
       if (editingGateway) {
-        await MagmaV1API.putFegByNetworkIdGatewaysByGatewayIdFederation({
-          networkId: networkID,
-          gatewayId: editingGateway.id,
-          config: getFederationConfigs(),
-        });
+        const editedGateway = {
+          ...editingGateway,
+          federation: getFederationConfigs(),
+        };
+        await ctx.setState(editingGateway.id, editedGateway);
       } else {
-        await MagmaV1API.postFegByNetworkIdGateways({
-          networkId: networkID,
-          gateway: {
-            device: {
-              hardware_id: generalFields.hardwareID,
-              key: {
-                key: generalFields.challengeKey,
-                key_type: 'SOFTWARE_ECDSA_SHA256', // default key type should be ECDSA (do not use ECHO for prod)
-              },
+        const newGateway = {
+          device: {
+            hardware_id: generalFields.hardwareID,
+            key: {
+              key: generalFields.challengeKey,
+              key_type: 'SOFTWARE_ECDSA_SHA256', // default key type should be ECDSA (do not use ECHO for prod)
             },
-            federation: getFederationConfigs(),
-            magmad: MAGMAD_DEFAULT_CONFIGS,
-            id: generalFields.gatewayID,
-            description: generalFields.description,
-            name: generalFields.name,
-            tier: generalFields.tier,
           },
-        });
+          federation: getFederationConfigs(),
+          magmad: MAGMAD_DEFAULT_CONFIGS,
+          id: generalFields.gatewayID,
+          description: generalFields.description,
+          name: generalFields.name,
+          tier: generalFields.tier,
+        };
+        await ctx.setState(newGateway.id, newGateway);
       }
 
       const gateway = await MagmaV1API.getFegByNetworkIdGatewaysByGatewayId({
@@ -250,7 +264,7 @@ export default function FEGGatewayDialog(props: Props) {
   let content;
   let contentOverwriteAPN;
   switch (tab) {
-    case 'general':
+    case TAB_OPTIONS.GENERAL:
       content = (
         <AddGatewayFields
           onChange={setGeneralFields}
@@ -259,7 +273,7 @@ export default function FEGGatewayDialog(props: Props) {
         />
       );
       break;
-    case 'gx':
+    case TAB_OPTIONS.GX:
       content = (
         <DiameterFields
           onChange={setGx}
@@ -280,7 +294,7 @@ export default function FEGGatewayDialog(props: Props) {
         />
       );
       break;
-    case 'gy':
+    case TAB_OPTIONS.GY:
       content = (
         <DiameterFields
           onChange={setGy}
@@ -301,7 +315,7 @@ export default function FEGGatewayDialog(props: Props) {
         />
       );
       break;
-    case 'swx':
+    case TAB_OPTIONS.SWX:
       content = (
         <DiameterFields
           onChange={setSWx}
@@ -310,7 +324,7 @@ export default function FEGGatewayDialog(props: Props) {
         />
       );
       break;
-    case 's6a':
+    case TAB_OPTIONS.S6A:
       content = (
         <DiameterFields
           onChange={setS6A}
@@ -319,7 +333,7 @@ export default function FEGGatewayDialog(props: Props) {
         />
       );
       break;
-    case 'csfb':
+    case TAB_OPTIONS.CSFB:
       content = <SCTPFields onChange={setCSFB} values={csfb} />;
       break;
   }
@@ -371,6 +385,7 @@ function SCTPFields(props: {values: SCTPValues, onChange: SCTPValues => void}) {
         value={values.server_address}
         onChange={onChange('server_address')}
         placeholder="example.magma.com:5555"
+        inputProps={{'data-testid': 'serverAddress'}}
       />
       <TextField
         label="Local Address"
@@ -378,6 +393,7 @@ function SCTPFields(props: {values: SCTPValues, onChange: SCTPValues => void}) {
         value={values.local_address}
         onChange={onChange('local_address')}
         placeholder="example.magma.com:5555"
+        inputProps={{'data-testid': 'localAddress'}}
       />
     </>
   );
@@ -404,6 +420,7 @@ function DiameterFields(props: {
         value={values.address}
         onChange={onChange('address')}
         placeholder="example.magma.com:5555"
+        inputProps={{'data-testid': 'address'}}
       />
       <TextField
         label="Destination Host"
@@ -411,6 +428,7 @@ function DiameterFields(props: {
         value={values.dest_host}
         onChange={onChange('dest_host')}
         placeholder="magma-fedgw.magma.com"
+        inputProps={{'data-testid': 'destinationHost'}}
       />
       <TextField
         label="Dest Realm"
@@ -418,6 +436,7 @@ function DiameterFields(props: {
         value={values.dest_realm}
         onChange={onChange('dest_realm')}
         placeholder="magma.com"
+        inputProps={{'data-testid': 'destRealm'}}
       />
       <TextField
         label="Host"
@@ -425,6 +444,7 @@ function DiameterFields(props: {
         value={values.host}
         onChange={onChange('host')}
         placeholder="magma.com"
+        inputProps={{'data-testid': 'host'}}
       />
       <TextField
         label="Realm"
@@ -432,6 +452,7 @@ function DiameterFields(props: {
         value={values.realm}
         onChange={onChange('realm')}
         placeholder="realm"
+        inputProps={{'data-testid': 'realm'}}
       />
       <TextField
         label="Local Address"
@@ -439,6 +460,7 @@ function DiameterFields(props: {
         value={values.local_address}
         onChange={onChange('local_address')}
         placeholder=":56789"
+        inputProps={{'data-testid': 'localAddress'}}
       />
       <TextField
         label="Product Name"
@@ -446,11 +468,12 @@ function DiameterFields(props: {
         value={values.product_name}
         onChange={onChange('product_name')}
         placeholder="Magma"
+        inputProps={{'data-testid': 'productName'}}
       />
       <FormControl className={classes.input}>
         <InputLabel htmlFor="protocol">Protocol</InputLabel>
         <Select
-          inputProps={{id: 'protocol'}}
+          inputProps={{id: 'protocol', 'data-testid': 'protocol'}}
           value={values.protocol}
           onChange={({target}) => {
             switch (target.value) {
@@ -478,6 +501,7 @@ function DiameterFields(props: {
               props.onChange({...values, disable_dest_host: target.checked})
             }
             color="primary"
+            inputProps={{'data-testid': 'disableDestinationHost'}}
           />
         }
         label="Disable Destination Host"

--- a/nms/app/packages/magmalte/app/views/equipment/FEGGatewayDetailConfig.js
+++ b/nms/app/packages/magmalte/app/views/equipment/FEGGatewayDetailConfig.js
@@ -15,6 +15,7 @@
  */
 
 import type {DataRows} from '../../components/DataGrid';
+import type {TabOption} from '../../components/feg/FEGGatewayDialog';
 import type {
   diameter_client_configs,
   federation_gateway,
@@ -23,11 +24,13 @@ import type {
 
 import CardTitleRow from '../../components/layout/CardTitleRow';
 import DataGrid from '../../components/DataGrid';
+import EditGatewayButton from './FEGGatewayDetailConfigEdit';
 import FEGGatewayContext from '../../components/context/FEGGatewayContext';
 import Grid from '@material-ui/core/Grid';
 import React from 'react';
 import nullthrows from '@fbcnms/util/nullthrows';
 
+import {TAB_OPTIONS} from '../../components/feg/FEGGatewayDialog';
 import {makeStyles} from '@material-ui/styles';
 import {useContext} from 'react';
 import {useRouter} from '@fbcnms/ui/hooks';
@@ -49,7 +52,17 @@ export default function FEGGatewayConfig() {
   const {match} = useRouter();
   const gatewayId: string = nullthrows(match.params.gatewayId);
   const ctx = useContext(FEGGatewayContext);
-  const gwInfo = ctx.state[gatewayId];
+  const gwInfo: federation_gateway = ctx.state[gatewayId];
+
+  function editFilter(tabOption: TabOption) {
+    return (
+      <EditGatewayButton
+        title={'Edit'}
+        tabOption={tabOption}
+        editingGateway={gwInfo}
+      />
+    );
+  }
 
   return (
     <div className={classes.dashboardRoot}>
@@ -63,14 +76,20 @@ export default function FEGGatewayConfig() {
                   <GatewayInfoConfig gwInfo={gwInfo} />
                 </Grid>
                 <Grid item xs={12}>
-                  <CardTitleRow label="Gx" />
+                  <CardTitleRow
+                    label="Gx"
+                    filter={() => editFilter(TAB_OPTIONS.GX)}
+                  />
                   <GatewayDiameterServerConfig
                     serverConfig={gwInfo?.federation?.gx?.server || {}}
                     testID={'Gx'}
                   />
                 </Grid>
                 <Grid item xs={12}>
-                  <CardTitleRow label="CSFB" />
+                  <CardTitleRow
+                    label="CSFB"
+                    filter={() => editFilter(TAB_OPTIONS.CSFB)}
+                  />
                   <GatewaySctpServerConfig
                     serverConfig={gwInfo?.federation?.csfb?.client || {}}
                     testID={'CSFB'}
@@ -81,21 +100,30 @@ export default function FEGGatewayConfig() {
             <Grid item xs={12} md={6} alignItems="center">
               <Grid container spacing={4}>
                 <Grid item xs={12}>
-                  <CardTitleRow label="Gy" />
+                  <CardTitleRow
+                    label="Gy"
+                    filter={() => editFilter(TAB_OPTIONS.GY)}
+                  />
                   <GatewayDiameterServerConfig
                     serverConfig={gwInfo?.federation?.gy?.server || {}}
                     testID={'Gy'}
                   />
                 </Grid>
                 <Grid item xs={12}>
-                  <CardTitleRow label="SWx" />
+                  <CardTitleRow
+                    label="SWx"
+                    filter={() => editFilter(TAB_OPTIONS.SWX)}
+                  />
                   <GatewayDiameterServerConfig
                     serverConfig={gwInfo?.federation?.swx?.server || {}}
                     testID={'SWx'}
                   />
                 </Grid>
                 <Grid item xs={12}>
-                  <CardTitleRow label="S6a" />
+                  <CardTitleRow
+                    label="S6a"
+                    filter={() => editFilter(TAB_OPTIONS.S6A)}
+                  />
                   <GatewayDiameterServerConfig
                     serverConfig={gwInfo?.federation?.s6a?.server || {}}
                     testID={'S6a'}

--- a/nms/app/packages/magmalte/app/views/equipment/FEGGatewayDetailConfigEdit.js
+++ b/nms/app/packages/magmalte/app/views/equipment/FEGGatewayDetailConfigEdit.js
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @flow strict-local
+ * @format
+ */
+
+import type {TabOption} from '../../components/feg/FEGGatewayDialog';
+import type {federation_gateway} from '@fbcnms/magma-api';
+
+import Button from '@material-ui/core/Button';
+import FEGGatewayDialog from '../../components/feg/FEGGatewayDialog';
+import React from 'react';
+
+import {useState} from 'react';
+
+type ButtonProps = {
+  editingGateway: federation_gateway,
+  tabOption?: TabOption,
+  title: string,
+};
+
+/**
+ * Return a button which allows a user to edit the federation
+ * gateway. It displays the FEGGatewayDialog component when it
+ * is clicked / open.
+ * @param {federation_gateway} editingGateway The federation gateway being edited.
+ * @param {TabOption} tabOption The Tab that is being looked at.
+ * @param {string} title Title of the button.
+ */
+export default function EditGatewayButton(props: ButtonProps) {
+  const [open, setOpen] = useState(false);
+
+  const handleClickOpen = () => {
+    setOpen(true);
+  };
+
+  const handleClose = () => {
+    setOpen(false);
+  };
+
+  return (
+    <>
+      {open && (
+        <FEGGatewayDialog
+          editingGateway={props.editingGateway}
+          tabOption={props.tabOption}
+          onClose={handleClose}
+          onSave={_ => handleClose()}
+        />
+      )}
+      <Button
+        data-testid={(props.tabOption ?? '') + 'EditButton'}
+        component="button"
+        variant="text"
+        onClick={handleClickOpen}>
+        {props.title}
+      </Button>
+    </>
+  );
+}

--- a/nms/app/packages/magmalte/app/views/equipment/__tests__/FEGGatewayDetailConfigTest.js
+++ b/nms/app/packages/magmalte/app/views/equipment/__tests__/FEGGatewayDetailConfigTest.js
@@ -17,12 +17,16 @@
 import 'jest-dom/extend-expect';
 import FEGGatewayContext from '../../../components/context/FEGGatewayContext';
 import FEGGatewayDetailConfig from '../FEGGatewayDetailConfig';
+import MagmaAPIBindings from '@fbcnms/magma-api';
 import MuiStylesThemeProvider from '@material-ui/styles/ThemeProvider';
 import React from 'react';
 import defaultTheme from '@fbcnms/ui/theme/default';
 import {MemoryRouter, Route} from 'react-router-dom';
 import {MuiThemeProvider} from '@material-ui/core/styles';
-import {cleanup, render, wait} from '@testing-library/react';
+import {SetGatewayState} from '../../../state/feg/EquipmentState';
+import {cleanup, fireEvent, render, wait} from '@testing-library/react';
+import {useEnqueueSnackbar} from '@fbcnms/ui/hooks/useSnackbar';
+import {useState} from 'react';
 import type {
   csfb,
   federation_gateway,
@@ -42,30 +46,59 @@ const mockGx: gx = {
     address: '174.16.1.14:3868',
     dest_host: 'magma.magma.com',
     dest_realm: 'magma.com',
+    host: '',
+    realm: '',
+    local_address: '',
     product_name: 'magma',
+    protocol: 'tcp',
+    disable_dest_host: false,
   },
+  virtual_apn_rules: [],
 };
 
 const mockGy: gy = {
   server: {
     address: '174.18.1.0:3868',
+    dest_host: '',
+    dest_realm: '',
     host: 'localhost',
     realm: 'test',
+    local_address: '',
+    product_name: '',
+    protocol: 'tcp',
+    disable_dest_host: false,
   },
+  init_method: 2,
+  virtual_apn_rules: [],
 };
 
 const mockSwx: swx = {
   server: {
     address: '174.18.1.0:3869',
+    dest_host: '',
+    dest_realm: '',
+    host: '',
+    realm: '',
     local_address: ':3809',
+    product_name: '',
+    protocol: 'tcp',
+    disable_dest_host: false,
   },
 };
 
 const mockS6a: s6a = {
   server: {
     address: '174.18.1.0:2000',
+    dest_host: '',
+    dest_realm: '',
+    host: '',
+    realm: '',
+    local_address: '',
+    product_name: '',
     protocol: 'tcp',
+    disable_dest_host: false,
   },
+  plmn_ids: [],
 };
 
 const mockCsfb: csfb = {
@@ -93,14 +126,10 @@ const mockGw0: federation_gateway = {
   },
   federation: {
     aaa_server: {},
-    eap_aka: {
-      plmn_ids: [],
-    },
+    eap_aka: {},
     gx: mockGx,
     gy: mockGy,
-    health: {
-      health_services: [],
-    },
+    health: {},
     hss: {},
     s6a: mockS6a,
     served_network_ids: [],
@@ -128,6 +157,13 @@ const fegGatewaysHealth = {
 };
 
 describe('<FEGGatewayDetailConfig />', () => {
+  beforeEach(() => {
+    // Mocking value because it is called by FEGGatewayDialogue / Edit Gateway Page
+    MagmaAPIBindings.getNetworksByNetworkIdTiers.mockResolvedValue([]);
+  });
+  afterEach(() => {
+    MagmaAPIBindings.putFegByNetworkIdGatewaysByGatewayId.mockClear();
+  });
   const Wrapper = () => (
     <MemoryRouter
       initialEntries={[
@@ -153,6 +189,51 @@ describe('<FEGGatewayDetailConfig />', () => {
     </MemoryRouter>
   );
 
+  const EditWrapper = () => {
+    const [fegGateways, setFegGateways] = useState({[mockGw0.id]: mockGw0});
+    const [fegGatewaysHealthStatus, setFegGatewaysHealthStatus] = useState(
+      fegGatewaysHealth,
+    );
+    const [activeFegGatewayId, setActiveFegGatewayId] = useState(mockGw0.id);
+    const enqueueSnackbar = useEnqueueSnackbar();
+    return (
+      <MemoryRouter
+        initialEntries={[
+          '/nms/mynetwork/equipment/overview/gateway/test_feg_gw0/config',
+        ]}
+        initialIndex={0}>
+        <MuiThemeProvider theme={defaultTheme}>
+          <MuiStylesThemeProvider theme={defaultTheme}>
+            <FEGGatewayContext.Provider
+              value={{
+                state: fegGateways,
+                setState: async (key, value?, newState?) => {
+                  return SetGatewayState({
+                    networkId: 'mynetwork',
+                    fegGateways,
+                    fegGatewaysHealthStatus,
+                    setFegGateways,
+                    setFegGatewaysHealthStatus,
+                    setActiveFegGatewayId,
+                    key,
+                    value,
+                    newState,
+                    enqueueSnackbar,
+                  });
+                },
+                health: fegGatewaysHealthStatus,
+                activeFegGatewayId: activeFegGatewayId,
+              }}>
+              <Route
+                path="/nms/:networkId/equipment/overview/gateway/:gatewayId/config"
+                render={props => <FEGGatewayDetailConfig {...props} />}
+              />
+            </FEGGatewayContext.Provider>
+          </MuiStylesThemeProvider>
+        </MuiThemeProvider>
+      </MemoryRouter>
+    );
+  };
   it('renders federation gateway configs correctly', async () => {
     const {getByTestId} = render(<Wrapper />);
     await wait();
@@ -184,5 +265,172 @@ describe('<FEGGatewayDetailConfig />', () => {
     // verify csfb configurations
     expect(getByTestId('CSFB')).toHaveTextContent('174.18.1.0:2200');
     expect(getByTestId('CSFB')).toHaveTextContent('3440');
+  });
+  it('verify gx edit is working', async () => {
+    const {getByTestId, getByText} = render(<EditWrapper />);
+    await wait();
+    fireEvent.click(getByTestId('gxEditButton'));
+    await wait();
+    const address = getByTestId('address');
+    const destHost = getByTestId('destinationHost');
+    const destRealm = getByTestId('destRealm');
+    fireEvent.change(address, {target: {value: '194.16.1.14:3868'}});
+    fireEvent.change(destHost, {target: {value: 'abc.xyz.com'}});
+    fireEvent.change(destRealm, {target: {value: 'xyz.com'}});
+    fireEvent.click(getByText('Save'));
+    await wait();
+    // verify that address, dest_host, and dest_realm were edited
+    expect(
+      MagmaAPIBindings.putFegByNetworkIdGatewaysByGatewayId,
+    ).toHaveBeenCalledWith({
+      networkId: 'mynetwork',
+      gatewayId: mockGw0.id,
+      gateway: {
+        ...mockGw0,
+        federation: {
+          ...mockGw0.federation,
+          gx: {
+            ...mockGw0.federation.gx,
+            server: {
+              ...mockGw0.federation.gx.server,
+              address: '194.16.1.14:3868',
+              dest_host: 'abc.xyz.com',
+              dest_realm: 'xyz.com',
+            },
+          },
+        },
+      },
+    });
+  });
+  it('verify gy edit is working', async () => {
+    const {getByTestId, getByText} = render(<EditWrapper />);
+    await wait();
+    fireEvent.click(getByTestId('gyEditButton'));
+    await wait();
+    const address = getByTestId('address');
+    const host = getByTestId('host');
+    const realm = getByTestId('realm');
+    fireEvent.change(address, {target: {value: '174.18.1.1:4868'}});
+    fireEvent.change(host, {target: {value: '222.222.222.222'}});
+    fireEvent.change(realm, {target: {value: 'test_realm'}});
+    fireEvent.click(getByText('Save'));
+    await wait();
+    // verify that address, host, and realm were edited
+    expect(
+      MagmaAPIBindings.putFegByNetworkIdGatewaysByGatewayId,
+    ).toHaveBeenCalledWith({
+      networkId: 'mynetwork',
+      gatewayId: mockGw0.id,
+      gateway: {
+        ...mockGw0,
+        federation: {
+          ...mockGw0.federation,
+          gy: {
+            ...mockGw0.federation.gy,
+            server: {
+              ...mockGw0.federation.gy.server,
+              address: '174.18.1.1:4868',
+              host: '222.222.222.222',
+              realm: 'test_realm',
+            },
+          },
+        },
+      },
+    });
+  });
+  it('verify swx edit is working', async () => {
+    const {getByTestId, getByText} = render(<EditWrapper />);
+    await wait();
+    fireEvent.click(getByTestId('swxEditButton'));
+    await wait();
+    const address = getByTestId('address');
+    const localAddress = getByTestId('localAddress');
+    fireEvent.change(address, {target: {value: '174.58.1.0:3869'}});
+    fireEvent.change(localAddress, {target: {value: ':4444'}});
+    fireEvent.click(getByText('Save'));
+    await wait();
+    // verify that address and local_address were edited
+    expect(
+      MagmaAPIBindings.putFegByNetworkIdGatewaysByGatewayId,
+    ).toHaveBeenCalledWith({
+      networkId: 'mynetwork',
+      gatewayId: mockGw0.id,
+      gateway: {
+        ...mockGw0,
+        federation: {
+          ...mockGw0.federation,
+          swx: {
+            ...mockGw0.federation.swx,
+            server: {
+              ...mockGw0.federation.swx.server,
+              address: '174.58.1.0:3869',
+              local_address: ':4444',
+            },
+          },
+        },
+      },
+    });
+  });
+  it('verify s6a edit is working', async () => {
+    const {getByTestId, getByText} = render(<EditWrapper />);
+    await wait();
+    fireEvent.click(getByTestId('s6aEditButton'));
+    await wait();
+    const protocol = getByTestId('protocol');
+    fireEvent.change(protocol, {target: {value: 'sctp'}});
+    fireEvent.click(getByText('Save'));
+    await wait();
+    // verify that protocol was edited
+    expect(
+      MagmaAPIBindings.putFegByNetworkIdGatewaysByGatewayId,
+    ).toHaveBeenCalledWith({
+      networkId: 'mynetwork',
+      gatewayId: mockGw0.id,
+      gateway: {
+        ...mockGw0,
+        federation: {
+          ...mockGw0.federation,
+          s6a: {
+            ...mockGw0.federation.s6a,
+            server: {
+              ...mockGw0.federation.s6a.server,
+              protocol: 'sctp',
+            },
+          },
+        },
+      },
+    });
+  });
+  it('verify csfb edit is working', async () => {
+    const {getByTestId, getByText} = render(<EditWrapper />);
+    await wait();
+    fireEvent.click(getByTestId('csfbEditButton'));
+    await wait();
+    const serverAddress = getByTestId('serverAddress');
+    const localAddress = getByTestId('localAddress');
+    fireEvent.change(serverAddress, {target: {value: '175.18.1.0:2200'}});
+    fireEvent.change(localAddress, {target: {value: ':4400'}});
+    fireEvent.click(getByText('Save'));
+    await wait();
+    // verify that server_address and local_address were edited
+    expect(
+      MagmaAPIBindings.putFegByNetworkIdGatewaysByGatewayId,
+    ).toHaveBeenCalledWith({
+      networkId: 'mynetwork',
+      gatewayId: mockGw0.id,
+      gateway: {
+        ...mockGw0,
+        federation: {
+          ...mockGw0.federation,
+          csfb: {
+            ...mockGw0.federation.csfb,
+            client: {
+              server_address: '175.18.1.0:2200',
+              local_address: ':4400',
+            },
+          },
+        },
+      },
+    });
   });
 });


### PR DESCRIPTION
<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary
 An existing federation gateway edit page was hooked to the config page which now enables a user to edit the gx, gy, and the other properties as shown in the image. 
<!-- Enumerate changes you made and why you made them -->

## Test Plan
A test was added under the FEGGatewayDetailConfigTest.js file to test that the edit functionality is working. 
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information
<img width="1788" alt="Screen Shot 2021-07-16 at 1 47 24 PM" src="https://user-images.githubusercontent.com/34602743/125988492-c24f9a36-fd06-4fff-8ebc-557d30e2b006.png">

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
