### PR TITLE
fix(ci): Fix propagation of docker credentials to build job of cwf

### DIFF
--- a/.github/workflows/cwf-operator.yml
+++ b/.github/workflows/cwf-operator.yml
@@ -63,6 +63,10 @@ jobs:
       - name: Tag and push to Docker Registry
         if: github.ref == 'refs/heads/master'
         # yamllint disable rule:line-length
+        env:
+          DOCKER_REGISTRY: "${{ secrets.DOCKER_REGISTRY }}"
+          DOCKER_USERNAME: "${{ secrets.DOCKER_USERNAME }}"
+          DOCKER_PASSWORD: "${{ secrets.DOCKER_PASSWORD }}"
         run: |
             ./ci-scripts/tag-push-docker.sh --images 'operator' --tag "${GITHUB_SHA:0:8}" --tag-latest true --project cwf
       - name: Tag and push to Jfrog Registry


### PR DESCRIPTION
Signed-off-by: Quentin, Derory <15911421+quentinDERORY@users.noreply.github.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

Fix cwf GHA build job.


## Test Plan

Test on master.
Circle ci cwf build job still running so no real impact.

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
