### PR TITLE
fix(agw): stop/start swap during provisioning to prevent error

### DIFF
--- a/lte/gateway/Vagrantfile
+++ b/lte/gateway/Vagrantfile
@@ -28,7 +28,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     config.vm.box = "magmacore/magma_dev"
     config.vm.box_version = "1.1.20210618"
      # Enable Dynamic Swap Space to prevent Out of Memory crashes
-    config.vm.provision :shell, inline: "fallocate -l 4G /swapfile && chmod 0600 /swapfile && mkswap /swapfile && swapon /swapfile && echo '/swapfile none swap sw 0 0' >> /etc/fstab"
+    config.vm.provision :shell, inline: "swapoff -a && fallocate -l 4G /swapfile && chmod 0600 /swapfile && mkswap /swapfile && swapon /swapfile && echo '/swapfile none swap sw 0 0' >> /etc/fstab && swapon -a"
     config.vm.provision :shell, inline: "echo vm.swappiness = 10 >> /etc/sysctl.conf && echo vm.vfs_cache_pressure = 50 >> /etc/sysctl.conf && sysctl -p"
     
     magma.vbguest.auto_update = false


### PR DESCRIPTION
Signed-off-by: Oriol Batalla <obatalla@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

When doing `vagrant provision magma` on an already provisioned magma VM, we were getting the error below.

It looks like activating the swap on the first provisioning works, but once it is activated we can not modify swap file anymore, so running provision again will fail

This PR adds swapoff and sappwon wrapping the command that enables swap. 

```
╰─ vagrant provision magma
==> magma: You assigned a static IP ending in ".1" to this machine.
==> magma: This is very often used by the router and can cause the
==> magma: network to not work properly. If the network doesn't work
==> magma: properly, try changing this IP.
==> magma: Running provisioner: shell...
    magma: Running: inline script
    magma: fallocate: fallocate failed: Text file busy
The SSH command responded with a non-zero exit status. Vagrant
assumes that this means the command failed. The output for this command
should be in the log above. Please read the output to determine what
went wrong.
```



## Test Plan

Checked if swap is still on after provisioning 
```
root@magma-dev-focal:/home/vagrant# swapon -s
Filename				Type		Size	Used	Priority
/swapfile                              	file    	4194300	0	-2
```
## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
