### PR TITLE
fix(agw): fix warning message on ansible when provisioning magma due to `atom-box` format

### DIFF
--- a/lte/gateway/deploy/hosts
+++ b/lte/gateway/deploy/hosts
@@ -16,5 +16,5 @@ magma_test ansible_ssh_host=192.168.60.141 ansible_ssh_port=22 ansible_user=vagr
 [prod]
 magma_prod ansible_ssh_host=192.168.60.151 ansible_ssh_port=22 ansible_user=vagrant
 
-[atom-box]
+[atom_box]
 10.0.4.1 ansible_user=magma ansible_ssh_pass=magma ansible_become_pass=magma


### PR DESCRIPTION
Signed-off-by: Oriol Batalla <obatalla@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

When provisioning we vagrant provision magma we get a warning message from ansible called `TRANSFORM_INVALID_GROUP_CHARS`. Root cause can be found [here](https://andreas.scherbaum.la/blog/archives/998-Ansible-TRANSFORM_INVALID_GROUP_CHARS-deprecation-warning.html).

The issue is `-` on `atom-box` is not allowed on ansible on host file

This PR clears this message

Error message with `vvvv` enabled
```
Set default localhost to 127.0.0.1
Not replacing invalid character(s) "{'-'}" in group name (atom-box)
Not replacing invalid character(s) "{'-'}" in group name (atom-box)
[DEPRECATION WARNING]: The TRANSFORM_INVALID_GROUP_CHARS settings is set to
allow bad characters in group names by default, this will change, but still be
user configurable on deprecation. This feature will be removed in version 2.10.
 Deprecation warnings can be disabled by setting deprecation_warnings=False in
ansible.cfg.
[WARNING]: Invalid characters were found in group names but not replaced, use
-vvvv to see details


```


## Test Plan

Ran `vagrant provision magma` and warning is gone

```
    magma: vm.vfs_cache_pressure = 50
    magma: vm.swappiness = 10
    magma: vm.vfs_cache_pressure = 50
==> magma: Running provisioner: ansible...
    magma: Running ansible-playbook...
PYTHONUNBUFFERED=1 ANSIBLE_FORCE_COLOR=true ANSIBLE_HOST_KEY_CHECKING=false ANSIBLE_SSH_ARGS='-o UserKnownHostsFile=/dev/null -o IdentitiesOnly=yes -o IdentityFile=/Users/obatalla/.vagrant.d/insecure_private_key -o ForwardAgent=yes -o ControlMaster=auto -o ControlPersist=60s' ansible-playbook --connection=ssh --timeout=30 --extra-vars=ansible_user\=\'vagrant\' --limit="magma" --inventory-file=deploy/hosts -v --timeout=30 deploy/magma_dev_focal.yml
Using /Users/obatalla/magma/lte/gateway/ansible.cfg as config file

PLAY [Set up Magma dev build environment on a local machine] *******************

TASK [Gathering Facts] *********************************************************
Saturday 17 July 2021  22:15:53 -0700 (0:00:00.128)       0:00:00.128 *********
ok: [magma]
```

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
