### PR TITLE
feat(mme): use sentry_config sent down as mme config

### DIFF
--- a/lte/gateway/c/core/oai/common/sentry_wrapper.cpp
+++ b/lte/gateway/c/core/oai/common/sentry_wrapper.cpp
@@ -19,8 +19,6 @@
 
 #include <cstdlib>
 #include <fstream>
-#include <sstream>
-#include <string>
 
 #include "sentry.h"
 #include "includes/ServiceConfigLoader.h"
@@ -34,47 +32,47 @@
 #define SNOWFLAKE_PATH "/etc/snowflake"
 #define HWID "hwid"
 #define SERVICE_NAME "service_name"
+#define DEFAULT_SAMPLE_RATE 0.5f
 
 using std::experimental::optional;
 
 bool should_upload_mme_log(
-    const sentry_config_t* sentry_config, YAML::Node control_proxy_config) {
+    bool sentry_upload_mme_log, YAML::Node control_proxy_config) {
   if (control_proxy_config[SHOULD_UPLOAD_MME_LOG].IsDefined()) {
     return control_proxy_config[SHOULD_UPLOAD_MME_LOG].as<bool>();
   }
-  return sentry_config->upload_mme_log;
+  return sentry_upload_mme_log;
 }
 
 optional<std::string> get_sentry_url(
-    const sentry_config_t* sentry_config, YAML::Node control_proxy_config) {
+    bstring sentry_url_native, YAML::Node control_proxy_config) {
   if (control_proxy_config[SENTRY_NATIVE_URL].IsDefined()) {
     const std::string dns_override =
         control_proxy_config[SENTRY_NATIVE_URL].as<std::string>();
-    if (dns_override.size()) {
+    if (!dns_override.empty()) {
       return dns_override;
     }
   }
-  const std::string sentry_url(bdata(sentry_config->url_native));
-  if (sentry_url.size()) {
+  const std::string sentry_url(bdata(sentry_url_native));
+  if (!sentry_url.empty()) {
     return sentry_url;
   }
   return {};
 }
 
 float get_sentry_sample_rate(
-    const sentry_config_t* sentry_config, YAML::Node control_proxy_config) {
+    float sentry_sample_rate, YAML::Node control_proxy_config) {
   if (control_proxy_config[SENTRY_SAMPLE_RATE].IsDefined()) {
-    const float sample_rate_override =
+    const auto sample_rate_override =
         control_proxy_config[SENTRY_SAMPLE_RATE].as<float>();
-    if (sample_rate_override) {
+    if (sample_rate_override > 0) {
       return sample_rate_override;
     }
   }
-  const float sample_rate = sentry_config->sample_rate;
-  if (sample_rate) {
-    return sample_rate;
+  if (sentry_sample_rate > 0) {
+    return sentry_sample_rate;
   }
-  return 1.0f;
+  return DEFAULT_SAMPLE_RATE;
 }
 
 std::string get_snowflake() {
@@ -87,16 +85,19 @@ std::string get_snowflake() {
 void initialize_sentry(const sentry_config_t* sentry_config) {
   auto control_proxy_config = magma::ServiceConfigLoader{}.load_service_config(
       CONTROL_PROXY_SERVICE_NAME);
-  auto op_sentry_url = get_sentry_url(sentry_config, control_proxy_config);
+  auto op_sentry_url =
+      get_sentry_url(sentry_config->url_native, control_proxy_config);
   if (op_sentry_url) {
     sentry_options_t* options = sentry_options_new();
     sentry_options_set_dsn(options, op_sentry_url->c_str());
     sentry_options_set_sample_rate(
-        options, get_sentry_sample_rate(sentry_config, control_proxy_config));
+        options, get_sentry_sample_rate(
+                     sentry_config->sample_rate, control_proxy_config));
     if (const char* commit_hash_p = std::getenv(COMMIT_HASH_ENV)) {
       sentry_options_set_release(options, commit_hash_p);
     }
-    if (should_upload_mme_log(sentry_config, control_proxy_config)) {
+    if (should_upload_mme_log(
+            sentry_config->upload_mme_log, control_proxy_config)) {
       sentry_options_add_attachment(options, MME_LOG_PATH);
     }
 

--- a/lte/gateway/c/core/oai/common/sentry_wrapper.h
+++ b/lte/gateway/c/core/oai/common/sentry_wrapper.h
@@ -13,6 +13,8 @@
 
 #pragma once
 
+#include "mme_config.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -21,7 +23,7 @@ extern "C" {
  * @brief Initialize sentry if SENTRY_ENABLED flag is set and project slug is
  * configured in control_proxy.yml
  */
-void initialize_sentry(void);
+void initialize_sentry(const sentry_config_t* sentry_config);
 
 /**
  * @brief Shutdown sentry if SENTRY_ENABLED flag is set

--- a/lte/gateway/c/core/oai/include/mme_config.h
+++ b/lte/gateway/c/core/oai/include/mme_config.h
@@ -220,6 +220,12 @@
 #define MME_CONFIG_STRING_TAC_LIST_PER_SAC "TACS_PER_SAC"
 #define MME_CONFIG_STRING_SRVC_AREA_CODE_2_TACS_MAP "SRVC_AREA_CODE_2_TACS_MAP"
 
+// SENTRY CONFIGURATION
+#define MME_CONFIG_STRING_SENTRY_CONFIG "SENTRY_CONFIG"
+#define MME_CONFIG_STRING_SAMPLE_RATE "SAMPLE_RATE"
+#define MME_CONFIG_STRING_UPLOAD_MME_LOG "UPLOAD_MME_LOG"
+#define MME_CONFIG_STRING_URL_NATIVE "URL_NATIVE"
+
 typedef enum { RUN_MODE_TEST = 0, RUN_MODE_OTHER } run_mode_t;
 
 typedef struct eps_network_feature_config_s {
@@ -322,6 +328,12 @@ typedef struct e_dns_config_s {
   struct in_addr sgw_ip_addr[MME_CONFIG_MAX_SGW];
 } e_dns_config_t;
 
+typedef struct sentry_config {
+  float sample_rate;
+  bool upload_mme_log;
+  bstring url_native;
+} sentry_config_t;
+
 typedef struct gummei_config_s {
   int nb;
   gummei_t gummei[MAX_GUMMEI];
@@ -402,6 +414,7 @@ typedef struct mme_config_s {
   sgs_config_t sgs_config;
   log_config_t log_config;
   e_dns_config_t e_dns_emulation;
+  sentry_config_t sentry_config;
 
   ip_t ip;
 

--- a/lte/gateway/c/core/oai/include/mme_config.h
+++ b/lte/gateway/c/core/oai/include/mme_config.h
@@ -328,7 +328,7 @@ typedef struct e_dns_config_s {
   struct in_addr sgw_ip_addr[MME_CONFIG_MAX_SGW];
 } e_dns_config_t;
 
-typedef struct sentry_config {
+typedef struct sentry_config_s {
   float sample_rate;
   bool upload_mme_log;
   bstring url_native;

--- a/lte/gateway/c/core/oai/oai_mme/oai_mme.c
+++ b/lte/gateway/c/core/oai/oai_mme/oai_mme.c
@@ -77,9 +77,10 @@ static int main_init(void) {
   // broadcast messages or timer messages)
   init_task_context(
       TASK_MAIN,
-      (task_id_t[]){TASK_MME_APP, TASK_SERVICE303, TASK_SERVICE303_SERVER,
-                    TASK_S6A, TASK_S1AP, TASK_SCTP, TASK_SPGW_APP, TASK_SGW_S8,
-                    TASK_GRPC_SERVICE, TASK_LOG, TASK_SHARED_TS_LOG},
+      (task_id_t[]){
+          TASK_MME_APP, TASK_SERVICE303, TASK_SERVICE303_SERVER, TASK_S6A,
+          TASK_S1AP, TASK_SCTP, TASK_SPGW_APP, TASK_SGW_S8, TASK_GRPC_SERVICE,
+          TASK_LOG, TASK_SHARED_TS_LOG},
       11, NULL, &main_zmq_ctx);
 
   return RETURNok;
@@ -100,18 +101,6 @@ int main(int argc, char* argv[]) {
       TASK_MAX, THREAD_MAX, MESSAGES_ID_MAX, tasks_info, messages_info, NULL,
       NULL));
 
-  // Initialize Sentry error collection (Currently only supported on
-  // Ubuntu 20.04)
-  // We have to initialize here for now since itti_init asserts on there being
-  // only 1 thread
-  initialize_sentry();
-
-  CHECK_INIT_RETURN(timer_init());
-  // Could not be launched before ITTI initialization
-  shared_log_itti_connect();
-  OAILOG_ITTI_CONNECT();
-  CHECK_INIT_RETURN(main_init());
-
   /*
    * Parse the command line for options and set the mme_config accordingly.
    */
@@ -121,6 +110,18 @@ int main(int argc, char* argv[]) {
 #else
   CHECK_INIT_RETURN(mme_config_parse_opt_line(argc, argv, &mme_config));
 #endif
+
+  // Initialize Sentry error collection (Currently only supported on
+  // Ubuntu 20.04)
+  // We have to initialize here for now since itti_init asserts on there being
+  // only 1 thread
+  initialize_sentry(&mme_config.sentry_config);
+
+  CHECK_INIT_RETURN(timer_init());
+  // Could not be launched before ITTI initialization
+  shared_log_itti_connect();
+  OAILOG_ITTI_CONNECT();
+  CHECK_INIT_RETURN(main_init());
 
   pid_file_name = get_pid_file_name(mme_config.pid_dir);
 

--- a/lte/gateway/c/core/oai/tasks/mme_app/mme_config.c
+++ b/lte/gateway/c/core/oai/tasks/mme_app/mme_config.c
@@ -315,6 +315,7 @@ int mme_config_parse_file(mme_config_t* config_pP) {
   config_setting_t* sub2setting = NULL;
   config_setting_t* sub3setting = NULL;
   int aint                      = 0;
+  double adouble                = 0.0;
   int i = 0, n = 0, stop_index = 0, num = 0;
   const char* astring  = NULL;
   const char* tac      = NULL;
@@ -1529,6 +1530,29 @@ int mme_config_parse_file(mme_config_t* config_pP) {
       }
     }
 
+    // Parsing Sentry Config
+    setting =
+        config_setting_get_member(setting_mme, MME_CONFIG_STRING_SENTRY_CONFIG);
+    memset(&config_pP->sentry_config, 0, sizeof(sentry_config_t));
+    config_pP->sentry_config.url_native = bfromcstr("");
+    OAILOG_INFO(LOG_MME_APP, "MME_CONFIG_STRING_SENTRY_CONFIG \n");
+    if (setting != NULL) {
+      if ((config_setting_lookup_float(
+              setting, MME_CONFIG_STRING_SAMPLE_RATE, &adouble))) {
+        config_pP->sentry_config.sample_rate = (float) adouble;
+      }
+      if ((config_setting_lookup_string(
+              setting, MME_CONFIG_STRING_UPLOAD_MME_LOG,
+              (const char**) &astring))) {
+        config_pP->sentry_config.upload_mme_log = parse_bool(astring);
+      }
+      if ((config_setting_lookup_string(
+              setting, MME_CONFIG_STRING_URL_NATIVE,
+              (const char**) &astring))) {
+        bassigncstr(config_pP->sentry_config.url_native, astring);
+      }
+    }
+
     // SGS TIMERS
     setting =
         config_setting_get_member(setting_mme, MME_CONFIG_STRING_SGS_CONFIG);
@@ -1750,6 +1774,17 @@ void mme_config_display(mme_config_t* config_pP) {
         LOG_CONFIG, "  Address : Unknown address family %d\n",
         config_pP->e_dns_emulation.sgw_ip_addr[0].s_addr);
   }
+
+  OAILOG_INFO(LOG_CONFIG, "- Sentry:\n");
+  OAILOG_INFO(
+      LOG_CONFIG, "    sample rate ......: %f\n",
+      config_pP->sentry_config.sample_rate);
+  OAILOG_INFO(
+      LOG_CONFIG, "    upload MME log ...: %d\n",
+      config_pP->sentry_config.upload_mme_log);
+  OAILOG_INFO(
+      LOG_CONFIG, "    URL native .......: %s\n",
+      bdata(config_pP->sentry_config.url_native));
 
   OAILOG_INFO(LOG_CONFIG, "- ITTI:\n");
   OAILOG_INFO(

--- a/lte/gateway/configs/templates/mme.conf.template
+++ b/lte/gateway/configs/templates/mme.conf.template
@@ -322,4 +322,11 @@ MME :
      }{% if not loop.last %},{% endif %}
      {% endfor %}
    );
+
+   SENTRY_CONFIG = {
+       # Sentry.io configuration sent from the Orc8r
+       SAMPLE_RATE      = {{ sentry_config.sample_rate }};
+       UPLOAD_MME_LOG   = "{{ sentry_config.upload_mme_log }}";
+       URL_NATIVE       = "{{ sentry_config.url_native }}"
+   }
 };

--- a/lte/gateway/python/scripts/generate_oai_config.py
+++ b/lte/gateway/python/scripts/generate_oai_config.py
@@ -202,18 +202,12 @@ def _get_restricted_imeis(service_mconfig):
 
 
 def _get_service_area_maps(service_mconfig):
-    if service_mconfig.service_area_maps:
-      service_area_map = []
-      for sac in service_mconfig.service_area_maps:
-        tac_list = []
-        service_area_maps_dict = {}
-        for idx in service_mconfig.service_area_maps[sac].tac:
-          tac_list.append(idx)
-        service_area_maps_dict['sac'] = sac
-        service_area_maps_dict['tac'] = tac_list
-        service_area_map.append(service_area_maps_dict)
-      return service_area_map
-    return {}
+    if not service_mconfig.service_area_maps:
+        return {}
+    service_area_map = []
+    for sac, sam in service_mconfig.service_area_maps.items():
+        service_area_map.append({'sac': sac, 'tac': sam.tac.copy()})
+    return service_area_map
 
 
 def _get_congestion_control_config(service_mconfig):
@@ -282,6 +276,7 @@ def _get_context():
             mme_service_config,
         ),
         "service_area_map": _get_service_area_maps(mme_service_config),
+        "sentry_config": mme_service_config.sentry_config,
     }
 
     context["s1u_ip"] = mme_service_config.ipv4_sgw_s1u_addr or _get_iface_ip(


### PR DESCRIPTION
Signed-off-by: Waqar Aqeel <waqeel@fb.com>

## Summary

Working towards #7613.

This PR adds parsing in MME for Sentry configuration sent from the Orc8r and also initializes Sentry in MME using that configuration. 

## Test Plan

Ran `make test_oai`. Also verified that sentry config sent by the orc8r was correctly put in `mme.conf`, then read from `mme.conf`, and sentry was initialized with that config.

Also ran the [integration test](https://github.com/magma/magma/blob/master/docs/readmes/lte/s1ap_tests.md#run-tests) `s1aptests/test_attach_detach.py`.