### PR TITLE
chore(orc8r): bump docker-compose to 1.29.1 on ansible role and other install scripts

### DIFF
--- a/cwf/gateway/helm/cwf-kubevirt/templates/bin/_install_gateway.sh.tpl
+++ b/cwf/gateway/helm/cwf-kubevirt/templates/bin/_install_gateway.sh.tpl
@@ -23,9 +23,7 @@ cd /opt/magma/
 
 # TODO: Update docker-compose to stable version
 
-# Using RC as opposed to stable (1.24.0) due to
-# SCTP port mapping support
-DOCKER_COMPOSE_VERSION=1.25.0-rc1
+DOCKER_COMPOSE_VERSION=1.29.1
 
 DIR="."
 echo "Setting working directory as: $DIR"

--- a/cwf/gateway/helm/cwf-virtlet/templates/bin/_install_gateway.sh.tpl
+++ b/cwf/gateway/helm/cwf-virtlet/templates/bin/_install_gateway.sh.tpl
@@ -23,9 +23,7 @@ cd /opt/magma/
 
 # TODO: Update docker-compose to stable version
 
-# Using RC as opposed to stable (1.24.0) due to
-# SCTP port mapping support
-DOCKER_COMPOSE_VERSION=1.25.0-rc1
+DOCKER_COMPOSE_VERSION=1.29.1
 
 DIR="."
 echo "Setting working directory as: $DIR"

--- a/feg/gateway/helm/feg-kubevirt/templates/bin/_install_gateway.sh.tpl
+++ b/feg/gateway/helm/feg-kubevirt/templates/bin/_install_gateway.sh.tpl
@@ -23,9 +23,7 @@ cd /opt/magma/
 
 # TODO: Update docker-compose to stable version
 
-# Using RC as opposed to stable (1.24.0) due to
-# SCTP port mapping support
-DOCKER_COMPOSE_VERSION=1.25.0-rc1
+DOCKER_COMPOSE_VERSION=1.29.1
 
 DIR="."
 echo "Setting working directory as: $DIR"

--- a/feg/gateway/helm/feg-virtlet/templates/bin/_install_gateway.sh.tpl
+++ b/feg/gateway/helm/feg-virtlet/templates/bin/_install_gateway.sh.tpl
@@ -23,9 +23,7 @@ cd /opt/magma/
 
 # TODO: Update docker-compose to stable version
 
-# Using RC as opposed to stable (1.24.0) due to
-# SCTP port mapping support
-DOCKER_COMPOSE_VERSION=1.25.0-rc1
+DOCKER_COMPOSE_VERSION=1.29.1
 
 DIR="."
 echo "Setting working directory as: $DIR"

--- a/orc8r/tools/ansible/roles/docker/defaults/main.yml
+++ b/orc8r/tools/ansible/roles/docker/defaults/main.yml
@@ -11,7 +11,7 @@
 # limitations under the License.
 
 ansible_python_interpreter: /usr/bin/python3
-docker_compose_version: 1.24.0
+docker_compose_version: 1.29.1
 
 working_dir: /var/opt/magma/docker
 

--- a/orc8r/tools/docker/install_gateway.sh
+++ b/orc8r/tools/docker/install_gateway.sh
@@ -25,8 +25,6 @@ INSTALL_DIR="/tmp/magmagw_install"
 
 # TODO: Update docker-compose to stable version
 
-# Using RC as opposed to stable (1.24.0) due to
-# SCTP port mapping support
 DOCKER_COMPOSE_VERSION=1.29.1
 
 DIR="."


### PR DESCRIPTION
Signed-off-by: Oriol Batalla <obatalla@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

Setting docker-compose to 1.29.1 system wise not to fall behind and to match the current version we use in the FEG 

## Test Plan

feg has been using this version for weeks

cwag works with this version
```
vagrant@cwag-dev:~/magma/cwf/gateway/docker$ docker-compose -v
docker-compose version 1.29.1, build c34c88b2

vagrant@cwag-dev:~/magma/cwf/gateway/docker$ docker-compose -f docker-compose.yml -f docker-compose.override.yml -f docker-compose.nginx.yml -f docker-compose.integ-test.yml up -d
WARNING: The ANALYTICS_GRAPHQL_TOKEN variable is not set. Defaulting to a blank string.
WARNING: The ANALYTICS_GRAPHQL_ENDPOINT variable is not set. Defaulting to a blank string.
Creating network "cwf_default" with the default driver
Creating pcrf2         ... done
Creating td-agent-bit  ... done
Creating pipelined     ... done
Creating ocs           ... done
Creating magmad        ... done
Creating control_proxy ... done
Creating radius        ... done
Creating ingress       ... done
Creating eap_aka       ... done
Creating health        ... done
Creating cwf_nginx_1   ... done
Creating redis         ... done
Creating ocs2          ... done
Creating uesim         ... done
Creating radiusd       ... done
Creating aaa_server    ... done
Creating eventd        ... done
Creating pcrf          ... done
Creating eap_sim       ... done
Creating monitord      ... done
Creating redirectd     ... done
Creating hss           ... done
Creating swx_proxy     ... done
Creating policydb      ... done
Creating state         ... done
Creating directoryd    ... done
Creating session_proxy ... done
Creating sessiond      ... done

## Additional Information
```
- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
