### PR TITLE
docs(agw): Fix AGW v1.5 install script location

### DIFF
--- a/docs/docusaurus/versioned_docs/version-1.5.0/lte/deploy_install_ubuntu.md
+++ b/docs/docusaurus/versioned_docs/version-1.5.0/lte/deploy_install_ubuntu.md
@@ -53,7 +53,7 @@ installation process to get an IP using DHCP.
 
 ```bash
 su
-wget https://raw.githubusercontent.com/magma/magma/master/lte/gateway/deploy/agw_install_ubuntu.sh
+wget https://raw.githubusercontent.com/magma/magma/v1.5/lte/gateway/deploy/agw_install_ubuntu.sh
 bash agw_post_install_ubuntu.sh
 ```
 


### PR DESCRIPTION
Signed-off-by: Vitalii Kostenko vitalii@freedomfi.com

## Summary

At the moment documentation suggests to deploy AGW with latest manifest from master which is not correct

