### PR TITLE
fix: Update CODEOWNERS to include a backslash prefix to indicate path…

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,66 +1,66 @@
 # approvers-ci
-.circleci/ @magma/approvers-ci
-circleci/ @magma/approvers-ci
-ci-scripts/ @magma/approvers-ci
-.github/workflows/ @magma/approvers-ci
-third_party/build/ @magma/approvers-ci
-orc8r/tools/packer/ @magma/approvers-ci
-orc8r/cloud/deploy/bare-metal/ @magma/approvers-ci
-orc8r/cloud/deploy/bare-metal-ansible/ @magma/approvers-ci
-lte/gateway/docker @magma/approvers-ci
-lte/gateway/release @magma/approvers-ci
-lte/gateway/Vagrantfile @magma/approvers-ci
-cwf/gateway/Vagrantfile @magma/approvers-ci
+/.circleci/ @magma/approvers-ci
+/circleci/ @magma/approvers-ci
+/ci-scripts/ @magma/approvers-ci
+/.github/workflows/ @magma/approvers-ci
+/third_party/build/ @magma/approvers-ci
+/orc8r/tools/packer/ @magma/approvers-ci
+/orc8r/cloud/deploy/bare-metal/ @magma/approvers-ci
+/orc8r/cloud/deploy/bare-metal-ansible/ @magma/approvers-ci
+/lte/gateway/docker @magma/approvers-ci
+/lte/gateway/release @magma/approvers-ci
+/lte/gateway/Vagrantfile @magma/approvers-ci
+/cwf/gateway/Vagrantfile @magma/approvers-ci
 
 # approvers-orc8r
 */cloud/ @magma/approvers-orc8r
-.golangci.yml @magma/approvers-orc8r
-orc8r/ @magma/approvers-orc8r
+/.golangci.yml @magma/approvers-orc8r
+/orc8r/ @magma/approvers-orc8r
 
 # approvers-nms
-nms/ @magma/approvers-nms
+/nms/ @magma/approvers-nms
 
 # approvers-feg
-feg/ @magma/approvers-feg
+/feg/ @magma/approvers-feg
 
 # approvers-cwf
-cwf/ @magma/approvers-cwf
+/cwf/ @magma/approvers-cwf
 
 # approvers-openwrt
-openwrt/ @magma/approvers-openwrt
+/openwrt/ @magma/approvers-openwrt
 
 # approvers-agw / approvers-agw-python / approvers-agw-c
-lte/gateway @magma/approvers-agw
-lte/protos @magma/approvers-agw
-lte/gateway/python @magma/approvers-agw-python
-lte/gateway/c @magma/approvers-agw-c
-orc8r/gateway/c/ @magma/approvers-agw-c
+/lte/gateway @magma/approvers-agw
+/lte/protos @magma/approvers-agw
+/lte/gateway/python @magma/approvers-agw-python
+/lte/gateway/c @magma/approvers-agw-c
+/orc8r/gateway/c/ @magma/approvers-agw-c
 
 # approvers-agw-<subsection>
-lte/gateway/c/session_manager @magma/approvers-agw-sessiond
-lte/gateway/c/core/oai @magma/approvers-agw-mme
-lte/gateway/c/sctpd @magma/approvers-agw-mme
-lte/gateway/c/connection_tracker @koolzz @magma/approvers-agw-c
-lte/gateway/python/magma/pipelined @magma/approvers-agw-pipelined
-lte/gateway/python/integ_tests @magma/approvers-agw-integtests
+/lte/gateway/c/session_manager @magma/approvers-agw-sessiond
+/lte/gateway/c/core/oai @magma/approvers-agw-mme
+/lte/gateway/c/sctpd @magma/approvers-agw-mme
+/lte/gateway/c/connection_tracker @koolzz @magma/approvers-agw-c
+/lte/gateway/python/magma/pipelined @magma/approvers-agw-pipelined
+/lte/gateway/python/integ_tests @magma/approvers-agw-integtests
 
 # XWF Magma integrations
-xwf/ @magma/approvers-xwf
-feg/radius @magma/approvers-xwf @magma/approvers-cwf
+/xwf/ @magma/approvers-xwf
+/feg/radius @magma/approvers-xwf @magma/approvers-cwf
 
 # approvers-showtech
-show-tech/ @magma/approvers-showtech
+/show-tech/ @magma/approvers-showtech
 
-docs/ @magma/approvers-docs
-docs/readmes/proposals @electronjoe
+/docs/ @magma/approvers-docs
+/docs/readmes/proposals @electronjoe
 
-CODEOWNERS @amarpad @electronjoe @hcgatewood
+/CODEOWNERS @amarpad @electronjoe @hcgatewood
 
 # Paths excluded from code ownership
 **/go.mod @ghost
 **/go.sum @ghost
 **/*.pb.go @ghost
 **/*_swaggergen.go @ghost
-orc8r/cloud/go/obsidian/swagger/v1/swagger.yml @ghost
-orc8r/cloud/go/obsidian/swagger/v1/client/ @ghost
-orc8r/cloud/go/obsidian/swagger/v1/models/ @ghost
+/orc8r/cloud/go/obsidian/swagger/v1/swagger.yml @ghost
+/orc8r/cloud/go/obsidian/swagger/v1/client/ @ghost
+/orc8r/cloud/go/obsidian/swagger/v1/models/ @ghost


### PR DESCRIPTION
… from root

Signed-off-by: Marie Bremner <marwhal@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary
I kept getting PR review request for NMS PRs like this one https://github.com/magma/magma/pull/7882

According to [the GitHub doc for codeowner syntax](https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/creating-a-repository-on-github/about-code-owners#codeowners-syntax), lines like `feg/` indicate coverage for any path that includes `feg/` not any paths under `$MAGMA_ROOT/feg`.
Noticing this pattern for many of the paths we have, so fixing it up in this PR. 

CODEOWNER coverage before this change: https://www.diffchecker.com/qRjiWCwb

With this change we lose CODEOWNER coverage on these two files:
* cn/deploy/docs/MVC1_5G_Orc8r_deployment_script_README.docx	
* cn/deploy/docs/MVC2_5G_Orc8r_deployment_script_README.docx

This was previously covered by the `docs/` line. I'm not too worried about losing coverage for those two files. We just need to find an appropriate owner for CN and potentially move CN docs into the docs/ directory 


<!-- Enumerate changes you made and why you made them -->

## Test Plan
```
➜  magma git:(fix-codeowners) docker run --rm -v $(pwd):/repo -w /repo \
  -e REPOSITORY_PATH="." \
  -e GITHUB_ACCESS_TOKEN="$GH_TOKEN" \
  -e OWNER_CHECKER_REPOSITORY="magma/magma" \
  mszostok/codeowners-validator:v0.6.0
==> Executing Duplicated Pattern Checker (191.171µs)
    Check OK
==> Executing Valid Syntax Checker (111.081µs)
    Check OK
==> Executing Valid Owner Checker (4.05506078s)
    Check OK
==> Executing File Exist Checker (18.197673986s)
    Check OK

4 check(s) executed, no failure(s)
```
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
