### PR TITLE
fix(enodebd): Fixing clear_stats function traversal of stats dictionary

### DIFF
--- a/lte/gateway/python/magma/enodebd/stats_manager.py
+++ b/lte/gateway/python/magma/enodebd/stats_manager.py
@@ -370,7 +370,7 @@ class StatsManager:
         """
         logger.info('Clearing performance counter statistics')
         # Set all metrics to 0 if eNodeB not connected
-        for pm_name, metric in self.PM_FILE_TO_METRIC_MAP:
+        for pm_name, metric in self.PM_FILE_TO_METRIC_MAP.items():
             # eNB data usage metrics will not be cleared
             if pm_name not in ('PDCP.UpOctUl', 'PDCP.UpOctDl'):
                 metric.set(0)

--- a/lte/gateway/python/magma/enodebd/tests/stats_manager_tests.py
+++ b/lte/gateway/python/magma/enodebd/tests/stats_manager_tests.py
@@ -102,3 +102,25 @@ class StatsManagerTest(TestCase):
         self.assertEqual(pdcp_user_plane_bytes_dl[0].samples[0][1], {'enodeb': '1234'})
         self.assertEqual(pdcp_user_plane_bytes_ul[0].samples[0][2], 1000)
         self.assertEqual(pdcp_user_plane_bytes_dl[0].samples[0][2], 500)
+
+    def test_clear_stats(self):
+        """
+        Check that stats of PMPM_FILE_TO_METRIC_MAP is cleared successfully
+        """
+        # Example performance metrics structure, sent by eNodeB
+        pm_file_example = pkg_resources.resource_string(
+            __name__,
+            'pm_file_example.xml',
+        )
+
+        root = ElementTree.fromstring(pm_file_example)
+        self.mgr._parse_pm_xml('1234', root)
+
+        # Check that metrics were correctly populated
+        rrc_estab_attempts = metrics.STAT_RRC_ESTAB_ATT.collect()
+        self.assertEqual(rrc_estab_attempts[0].samples[0][2], 123)
+
+        self.mgr._clear_stats()
+        rrc_estab_attempts = metrics.STAT_RRC_ESTAB_ATT.collect()
+        # After clearing stats collection of metric should report 0
+        self.assertEqual(rrc_estab_attempts[0].samples[0][2], 0)


### PR DESCRIPTION
Signed-off-by: Alex Rodriguez <ardzoht@gmail.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->
- testing on enodebd, there is an issue raised out on clearing of metrics due to missed traversal of dictionary items:
```
Jun 29 18:30:10 handset-test enodebd[1963471]: INFO:root:Clearing performance counter statistics
Jun 29 18:30:10 handset-test enodebd[1963471]: ERROR:asyncio:Exception in callback StatsManager._periodic_check_rf_tx()
Jun 29 18:30:10 handset-test enodebd[1963471]: handle: <TimerHandle when=527272.986716413 StatsManager._periodic_check_rf_tx()>
Jun 29 18:30:10 handset-test enodebd[1963471]: Traceback (most recent call last):
Jun 29 18:30:10 handset-test enodebd[1963471]:   File "/usr/lib/python3.8/asyncio/events.py", line 81, in _run
Jun 29 18:30:10 handset-test enodebd[1963471]:     self._context.run(self._callback, *self._args)
Jun 29 18:30:10 handset-test enodebd[1963471]:   File "/usr/local/lib/python3.8/dist-packages/magma/enodebd/stats_manager.py", line 94, in _periodic_check_rf_tx
Jun 29 18:30:10 handset-test enodebd[1963471]:     self._check_rf_tx()
Jun 29 18:30:10 handset-test enodebd[1963471]:   File "/usr/local/lib/python3.8/dist-packages/magma/enodebd/stats_manager.py", line 116, in _check_rf_tx
Jun 29 18:30:10 handset-test enodebd[1963471]:     self._check_rf_tx_for_handler(handler)
Jun 29 18:30:10 handset-test enodebd[1963471]:   File "/usr/local/lib/python3.8/dist-packages/magma/enodebd/stats_manager.py", line 121, in _check_rf_tx_for_handler
Jun 29 18:30:10 handset-test enodebd[1963471]:     self._clear_stats()
Jun 29 18:30:10 handset-test enodebd[1963471]:   File "/usr/local/lib/python3.8/dist-packages/magma/enodebd/stats_manager.py", line 366, in _clear_stats
Jun 29 18:30:10 handset-test enodebd[1963471]:     for pm_name, metric in self.PM_FILE_TO_METRIC_MAP:
Jun 29 18:30:10 handset-test enodebd[1963471]: ValueError: too many values to unpack (expected 2)
```


## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->
- added unit test to cover edge case
- make test on local VM

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
