### PR TITLE
feat(orc8r): Support Orc8r-directed full resync for AGWs

### DIFF
--- a/lte/cloud/configs/subscriberdb.yml
+++ b/lte/cloud/configs/subscriberdb.yml
@@ -18,3 +18,6 @@ changesetSizeThreshold: 500
 # maxProtosLoadSize specifies the max size of cached subscriber protos that
 # can be loaded for a page.
 maxProtosLoadSize: 15000
+# maxResyncIntervalSecs specifies the max time interval (secs) before a orc8r-
+# directed resync is required for an agw.
+maxResyncIntervalSecs: 86400

--- a/lte/cloud/configs/subscriberdb.yml
+++ b/lte/cloud/configs/subscriberdb.yml
@@ -18,6 +18,6 @@ changesetSizeThreshold: 500
 # maxProtosLoadSize specifies the max size of cached subscriber protos that
 # can be loaded for a page.
 maxProtosLoadSize: 15000
-# maxResyncIntervalSecs specifies the max time interval (secs) before a orc8r-
-# directed resync is required for an agw.
-maxResyncIntervalSecs: 86400
+# resyncIntervalSecs specifies the max time interval (secs) before an orc8r-
+# directed resync is required for an AGW.
+resyncIntervalSecs: 86400

--- a/lte/cloud/configs/subscriberdb.yml
+++ b/lte/cloud/configs/subscriberdb.yml
@@ -18,6 +18,6 @@ changesetSizeThreshold: 500
 # maxProtosLoadSize specifies the max size of cached subscriber protos that
 # can be loaded for a page.
 maxProtosLoadSize: 15000
-# resyncIntervalSecs specifies the max time interval (secs) before an orc8r-
-# directed resync is required for an AGW.
-resyncIntervalSecs: 86400
+# resyncIntervalSecs specifies the max number of seconds before an Orc8r-
+# directed resync is issued for an AGW.
+resyncIntervalSecs: 86400  # 1 day

--- a/lte/cloud/go/services/lte/servicers/builder_servicer.go
+++ b/lte/cloud/go/services/lte/servicers/builder_servicer.go
@@ -28,6 +28,7 @@ import (
 	lte_models "magma/lte/cloud/go/services/lte/obsidian/models"
 	nprobe_models "magma/lte/cloud/go/services/nprobe/obsidian/models"
 	"magma/orc8r/cloud/go/orc8r"
+	"magma/orc8r/cloud/go/orc8r/math"
 	"magma/orc8r/cloud/go/services/configurator"
 	"magma/orc8r/cloud/go/services/configurator/mconfig"
 	builder_protos "magma/orc8r/cloud/go/services/configurator/mconfig/protos"
@@ -666,6 +667,6 @@ func (s *builderServicer) getSyncInterval(nwEpc *lte_models.NetworkEpcConfigs, g
 // herd effect at the Orc8r.
 func (s *builderServicer) getRandomizedSyncInterval(gwKey string, nwEpc *lte_models.NetworkEpcConfigs, gwEpc *lte_models.GatewayEpcConfigs) uint32 {
 	syncInterval := s.getSyncInterval(nwEpc, gwEpc)
-	jitter := orc8r.JitterUint32(syncInterval, gwKey, 0.2)
+	jitter := math.JitterUint32(syncInterval, gwKey, 0.2)
 	return syncInterval + jitter
 }

--- a/lte/cloud/go/services/subscriberdb/config.go
+++ b/lte/cloud/go/services/subscriberdb/config.go
@@ -22,4 +22,7 @@ type Config struct {
 	// MaxProtosLoadSize specifies the max size of cached subscriber protos that
 	// can be loaded for a page.
 	MaxProtosLoadSize uint64 `yaml:"maxProtosLoadSize"`
+	// MaxResyncIntervalSecs specifies the max time interval (secs) before a orc8r-
+	// directed resync is required for an agw.
+	MaxResyncIntervalSecs uint64 `yaml:"maxResyncIntervalSecs"`
 }

--- a/lte/cloud/go/services/subscriberdb/config.go
+++ b/lte/cloud/go/services/subscriberdb/config.go
@@ -22,7 +22,7 @@ type Config struct {
 	// MaxProtosLoadSize specifies the max size of cached subscriber protos that
 	// can be loaded for a page.
 	MaxProtosLoadSize uint64 `yaml:"maxProtosLoadSize"`
-	// MaxResyncIntervalSecs specifies the max time interval (secs) before a orc8r-
-	// directed resync is required for an agw.
-	MaxResyncIntervalSecs uint64 `yaml:"maxResyncIntervalSecs"`
+	// ResyncIntervalSecs specifies the max time interval (secs) before an orc8r-
+	// directed resync is required for an AGW.
+	ResyncIntervalSecs uint64 `yaml:"resyncIntervalSecs"`
 }

--- a/lte/cloud/go/services/subscriberdb/config.go
+++ b/lte/cloud/go/services/subscriberdb/config.go
@@ -22,7 +22,7 @@ type Config struct {
 	// MaxProtosLoadSize specifies the max size of cached subscriber protos that
 	// can be loaded for a page.
 	MaxProtosLoadSize uint64 `yaml:"maxProtosLoadSize"`
-	// ResyncIntervalSecs specifies the max time interval (secs) before an orc8r-
-	// directed resync is required for an AGW.
-	ResyncIntervalSecs uint64 `yaml:"resyncIntervalSecs"`
+	// ResyncIntervalSecs specifies the max number of seconds before an Orc8r-
+	// directed resync is issued for an AGW.
+	ResyncIntervalSecs uint32 `yaml:"resyncIntervalSecs"`
 }

--- a/lte/cloud/go/services/subscriberdb/const.go
+++ b/lte/cloud/go/services/subscriberdb/const.go
@@ -18,8 +18,9 @@ const (
 
 	EntityType = "subscriber"
 
-	LookupTableBlobstore       = "subscriber_lookup_blobstore"
-	PerSubDigestTableBlobstore = "per_sub_digest_blobstore"
+	LookupTableBlobstore         = "subscriber_lookup_blobstore"
+	PerSubDigestTableBlobstore   = "per_sub_digest_blobstore"
+	LastResyncTimeTableBlobstore = "last_resync_time_blobstore"
 
 	// MinimumSyncInterval is the the minimum interval in seconds between
 	// gateway requests to sync its subscriberdb with the cloud.

--- a/lte/cloud/go/services/subscriberdb/servicers/subscriberdb_servicer.go
+++ b/lte/cloud/go/services/subscriberdb/servicers/subscriberdb_servicer.go
@@ -38,11 +38,11 @@ type subscriberdbServicer struct {
 	digestsEnabled         bool
 	changesetSizeThreshold int
 	maxProtosLoadSize      uint64
-	resyncIntervalSecs uint64
+	resyncIntervalSecs     uint64
 	digestStore            storage.DigestStore
 	perSubDigestStore      *storage.PerSubDigestStore
 	subStore               *storage.SubStore
-	lastResyncTimeStore   *storage.LastResyncTimeStore
+	lastResyncTimeStore    *storage.LastResyncTimeStore
 }
 
 func NewSubscriberdbServicer(
@@ -56,11 +56,11 @@ func NewSubscriberdbServicer(
 		digestsEnabled:         config.DigestsEnabled,
 		changesetSizeThreshold: config.ChangesetSizeThreshold,
 		maxProtosLoadSize:      config.MaxProtosLoadSize,
-		resyncIntervalSecs: config.ResyncIntervalSecs,
+		resyncIntervalSecs:     config.ResyncIntervalSecs,
 		digestStore:            digestStore,
 		perSubDigestStore:      perSubDigestStore,
 		subStore:               subStore,
-		lastResyncTimeStore:   lastResyncTimeStore,
+		lastResyncTimeStore:    lastResyncTimeStore,
 	}
 	return servicer
 }

--- a/lte/cloud/go/services/subscriberdb/servicers/subscriberdb_servicer.go
+++ b/lte/cloud/go/services/subscriberdb/servicers/subscriberdb_servicer.go
@@ -18,7 +18,7 @@ import (
 	"time"
 
 	"magma/lte/cloud/go/services/subscriberdb"
-	"magma/orc8r/cloud/go/orc8r"
+	"magma/orc8r/cloud/go/orc8r/math"
 
 	"github.com/golang/glog"
 	"github.com/pkg/errors"
@@ -278,7 +278,7 @@ func (l *subscriberdbServicer) shouldResync(network string, gateway string) bool
 	}
 	// Add a deterministic jitter to AGW sync intervals in the range of
 	// [0, 0.5 * resyncIntervalSecs] to ameliorate the thundering herd effect
-	resyncIntervalJitter := orc8r.JitterUint32(l.resyncIntervalSecs, gateway, 0.5)
+	resyncIntervalJitter := math.JitterUint32(l.resyncIntervalSecs, gateway, 0.5)
 	shouldResync := uint32(time.Now().Unix())-lastResyncTime > l.resyncIntervalSecs+resyncIntervalJitter
 	return shouldResync
 }

--- a/lte/cloud/go/services/subscriberdb/servicers/subscriberdb_servicer_test.go
+++ b/lte/cloud/go/services/subscriberdb/servicers/subscriberdb_servicer_test.go
@@ -17,6 +17,7 @@ import (
 	"context"
 	"encoding/base64"
 	"testing"
+	"time"
 
 	"magma/lte/cloud/go/lte"
 	lte_protos "magma/lte/cloud/go/protos"
@@ -47,8 +48,9 @@ func TestListSubscribers(t *testing.T) {
 	digestStore := initializeDigestStore(t)
 	perSubDigestStore := initializePerSubDigestStore(t)
 	subStore := initializeSubStore(t)
+	lastResyncStore := initializeLastResyncTimeStore(t)
 
-	servicer := servicers.NewSubscriberdbServicer(subscriberdb.Config{DigestsEnabled: false}, digestStore, perSubDigestStore, subStore)
+	servicer := servicers.NewSubscriberdbServicer(subscriberdb.Config{DigestsEnabled: false}, digestStore, perSubDigestStore, subStore, lastResyncStore)
 	err := configurator.CreateNetwork(configurator.Network{ID: "n1"}, serdes.Network)
 	assert.NoError(t, err)
 	_, err = configurator.CreateEntity("n1", configurator.NetworkEntity{Type: orc8r.MagmadGatewayType, Key: "g1", PhysicalID: "hw1"}, serdes.Entity)
@@ -308,11 +310,13 @@ func TestListSubscribersDigestsEnabled(t *testing.T) {
 	digestStore := initializeDigestStore(t)
 	perSubDigestStore := initializePerSubDigestStore(t)
 	subStore := initializeSubStore(t)
+	lastResyncStore := initializeLastResyncTimeStore(t)
 
 	servicer := servicers.NewSubscriberdbServicer(subscriberdb.Config{
 		DigestsEnabled:    true,
 		MaxProtosLoadSize: 10,
-	}, digestStore, perSubDigestStore, subStore)
+		ResyncIntervalSecs: 1000,
+	}, digestStore, perSubDigestStore, subStore, lastResyncStore)
 	err := configurator.CreateNetwork(configurator.Network{ID: "n1"}, serdes.Network)
 	assert.NoError(t, err)
 	gw, err := configurator.CreateEntity("n1", configurator.NetworkEntity{Type: lte.CellularGatewayEntityType, Key: "g1"}, serdes.Entity)
@@ -481,14 +485,74 @@ func TestListSubscribersDigestsEnabled(t *testing.T) {
 	assert.Equal(t, expectedToken, res.NextPageToken)
 }
 
+func TestListSubscribersSetLastResyncTime(t *testing.T) {
+	lte_test_init.StartTestService(t)
+	configurator_test_init.StartTestService(t)
+	digestStore := initializeDigestStore(t)
+	perSubDigestStore := initializePerSubDigestStore(t)
+	subStore := initializeSubStore(t)
+	lastResyncStore := initializeLastResyncTimeStore(t)
+
+	servicer := servicers.NewSubscriberdbServicer(subscriberdb.Config{
+		DigestsEnabled:    true,
+		MaxProtosLoadSize: 10,
+	}, digestStore, perSubDigestStore, subStore, lastResyncStore)
+	err := configurator.CreateNetwork(configurator.Network{ID: "n1"}, serdes.Network)
+	assert.NoError(t, err)
+	_, err = configurator.CreateEntity("n1", configurator.NetworkEntity{Type: lte.CellularGatewayEntityType, Key: "g1"}, serdes.Entity)
+	assert.NoError(t, err)
+
+	id := protos.NewGatewayIdentity("hw1", "n1", "g1")
+	ctx := id.NewContextWithIdentity(context.Background())
+
+	expectedProtos := []*lte_protos.SubscriberData{
+		basicSubProtoFromSid("IMSI00001", ""),
+		basicSubProtoFromSid("IMSI00002", ""),
+		basicSubProtoFromSid("IMSI00003", ""),
+	}
+	err = subStore.InsertMany("n1", expectedProtos)
+	assert.NoError(t, err)
+	err = subStore.ApplyUpdate("n1")
+	assert.NoError(t, err)
+
+	// The last resync time for this AGW should be set on the request for the last page (when nextToken is empty)
+	expectedNextToken := serializeToken(t, &configurator_storage.EntityPageToken{
+		LastIncludedEntity: "IMSI00003",
+	})
+	req := &lte_protos.ListSubscribersRequest{
+		PageSize:  3,
+		PageToken: "",
+	}
+	res, err := servicer.ListSubscribers(ctx, req)
+	assert.NoError(t, err)
+	assert.Len(t, res.Subscribers, 3)
+	assert.Equal(t, expectedNextToken, res.NextPageToken)
+	lastResyncTime, err := lastResyncStore.Get("n1", "g1")
+	assert.NoError(t, err)
+	assert.Empty(t, lastResyncTime)
+
+	req = &lte_protos.ListSubscribersRequest{
+		PageSize:  3,
+		PageToken: expectedNextToken,
+	}
+	res, err = servicer.ListSubscribers(ctx, req)
+	assert.NoError(t, err)
+	assert.Len(t, res.Subscribers, 0)
+	assert.Empty(t, res.NextPageToken)
+	lastResyncTime, err = lastResyncStore.Get("n1", "g1")
+	assert.NoError(t, err)
+	assert.NotEmpty(t, lastResyncTime)
+}
+
 func TestCheckSubscribersInSync(t *testing.T) {
 	lte_test_init.StartTestService(t)
 	configurator_test_init.StartTestService(t)
 	digestStore := initializeDigestStore(t)
 	perSubDigestStore := initializePerSubDigestStore(t)
 	subStore := initializeSubStore(t)
+	lastResyncStore := initializeLastResyncTimeStore(t)
 
-	servicer := servicers.NewSubscriberdbServicer(subscriberdb.Config{DigestsEnabled: true}, digestStore, perSubDigestStore, subStore)
+	servicer := servicers.NewSubscriberdbServicer(subscriberdb.Config{DigestsEnabled: true, ResyncIntervalSecs: 1000}, digestStore, perSubDigestStore, subStore, lastResyncStore)
 	err := configurator.CreateNetwork(configurator.Network{ID: "n1"}, serdes.Network)
 	assert.NoError(t, err)
 	_, err = configurator.CreateEntity("n1", configurator.NetworkEntity{Type: lte.CellularGatewayEntityType, Key: "g1"}, serdes.Entity)
@@ -499,6 +563,8 @@ func TestCheckSubscribersInSync(t *testing.T) {
 	err = digestStore.SetDigest("n1", "digest_apple")
 	assert.NoError(t, err)
 
+	err = lastResyncStore.Set("n1", "g1", uint64(time.Now().Unix()))
+	assert.NoError(t, err)
 	// Requests with blank digests should get an update signal in return
 	req := &lte_protos.CheckSubscribersInSyncRequest{
 		FlatDigest: &lte_protos.Digest{Md5Base64Digest: ""},
@@ -524,6 +590,17 @@ func TestCheckSubscribersInSync(t *testing.T) {
 	res, err = servicer.CheckSubscribersInSync(ctx, req)
 	assert.NoError(t, err)
 	assert.False(t, res.InSync)
+
+	// Requests from gateways that haven't been resynced for more than the specified
+	// resync interval should get an update signal in return
+	err = lastResyncStore.Set("n1", "g1", uint64(time.Now().Unix())-5000)
+	assert.NoError(t, err)
+	req = &lte_protos.CheckSubscribersInSyncRequest{
+		FlatDigest: &lte_protos.Digest{Md5Base64Digest: "digest_apple2"},
+	}
+	res, err = servicer.CheckSubscribersInSync(ctx, req)
+	assert.NoError(t, err)
+	assert.False(t, res.InSync)
 }
 
 func TestSyncSubscribers(t *testing.T) {
@@ -532,10 +609,11 @@ func TestSyncSubscribers(t *testing.T) {
 	digestStore := initializeDigestStore(t)
 	perSubDigestStore := initializePerSubDigestStore(t)
 	subStore := initializeSubStore(t)
+	lastResyncStore := initializeLastResyncTimeStore(t)
 
 	// Create servicer with the subscriber digests feature flag turned on
 	configs := subscriberdb.Config{DigestsEnabled: true, ChangesetSizeThreshold: 100, MaxProtosLoadSize: 100}
-	servicer := servicers.NewSubscriberdbServicer(configs, digestStore, perSubDigestStore, subStore)
+	servicer := servicers.NewSubscriberdbServicer(configs, digestStore, perSubDigestStore, subStore, lastResyncStore)
 	err := configurator.CreateNetwork(configurator.Network{ID: "n1"}, serdes.Network)
 	assert.NoError(t, err)
 	_, err = configurator.CreateEntity("n1", configurator.NetworkEntity{Type: lte.CellularGatewayEntityType, Key: "g1"}, serdes.Entity)
@@ -545,11 +623,21 @@ func TestSyncSubscribers(t *testing.T) {
 	err = digestStore.SetDigest("n1", "flat_digest_apple")
 	assert.NoError(t, err)
 
-	// Initially no digests
+	// If the gateway has not received orc8r-oriented resync in a while, should get a resync signal
 	req := &lte_protos.SyncSubscribersRequest{
 		PerSubDigests: []*lte_protos.SubscriberDigestWithID{},
 	}
 	res, err := servicer.SyncSubscribers(ctx, req)
+	assert.NoError(t, err)
+	assert.True(t, res.Resync)
+
+	err = lastResyncStore.Set("n1", "g1", uint64(time.Now().Unix()))
+	assert.NoError(t, err)
+	// Initially no digests
+	req = &lte_protos.SyncSubscribersRequest{
+		PerSubDigests: []*lte_protos.SubscriberDigestWithID{},
+	}
+	res, err = servicer.SyncSubscribers(ctx, req)
 	assert.NoError(t, err)
 	assert.Equal(t, "flat_digest_apple", res.FlatDigest.GetMd5Base64Digest())
 	assert.Empty(t, res.PerSubDigests)
@@ -654,14 +742,16 @@ func TestSyncSubscribersResync(t *testing.T) {
 	digestStore := initializeDigestStore(t)
 	perSubDigestStore := initializePerSubDigestStore(t)
 	subStore := initializeSubStore(t)
+	lastResyncStore := initializeLastResyncTimeStore(t)
 
 	// Create servicer with a small ChangesetSizeThreshold
 	configs := subscriberdb.Config{
 		DigestsEnabled:         true,
 		ChangesetSizeThreshold: 2,
 		MaxProtosLoadSize:      100,
+		ResyncIntervalSecs:    1000,
 	}
-	servicer := servicers.NewSubscriberdbServicer(configs, digestStore, perSubDigestStore, subStore)
+	servicer := servicers.NewSubscriberdbServicer(configs, digestStore, perSubDigestStore, subStore, lastResyncStore)
 
 	err := configurator.CreateNetwork(configurator.Network{ID: "n1"}, serdes.Network)
 	assert.NoError(t, err)
@@ -670,6 +760,8 @@ func TestSyncSubscribersResync(t *testing.T) {
 	id := protos.NewGatewayIdentity("hw1", "n1", "g1")
 	ctx := id.NewContextWithIdentity(context.Background())
 
+	err = lastResyncStore.Set("n1", "g1", uint64(time.Now().Unix()))
+	assert.NoError(t, err)
 	// When changeset is no larger than ChangesetSizeThreshold, the servicer should return the full changeset
 	expectedToRenewData := []*lte_protos.SubscriberData{
 		{
@@ -781,6 +873,16 @@ func initializeSubStore(t *testing.T) *subscriberdb_storage.SubStore {
 	assert.NoError(t, store.Initialize())
 	return store
 }
+
+func initializeLastResyncTimeStore(t *testing.T) *subscriberdb_storage.LastResyncTimeStore {
+	db, err := sqorc.Open("sqlite3", ":memory:")
+	assert.NoError(t, err)
+	fact := blobstore.NewSQLBlobStorageFactory(subscriberdb.LastResyncTimeTableBlobstore, db, sqorc.GetSqlBuilder())
+	assert.NoError(t, fact.InitializeFactory())
+	store := subscriberdb_storage.NewLastResyncTimeStore(fact)
+	return store
+}
+
 func assertEqualPerSubDigests(t *testing.T, expected []*lte_protos.SubscriberDigestWithID, got []*lte_protos.SubscriberDigestWithID) {
 	assert.Equal(t, len(expected), len(got))
 	for ind := range expected {

--- a/lte/cloud/go/services/subscriberdb/servicers/subscriberdb_servicer_test.go
+++ b/lte/cloud/go/services/subscriberdb/servicers/subscriberdb_servicer_test.go
@@ -313,8 +313,8 @@ func TestListSubscribersDigestsEnabled(t *testing.T) {
 	lastResyncStore := initializeLastResyncTimeStore(t)
 
 	servicer := servicers.NewSubscriberdbServicer(subscriberdb.Config{
-		DigestsEnabled:    true,
-		MaxProtosLoadSize: 10,
+		DigestsEnabled:     true,
+		MaxProtosLoadSize:  10,
 		ResyncIntervalSecs: 1000,
 	}, digestStore, perSubDigestStore, subStore, lastResyncStore)
 	err := configurator.CreateNetwork(configurator.Network{ID: "n1"}, serdes.Network)
@@ -749,7 +749,7 @@ func TestSyncSubscribersResync(t *testing.T) {
 		DigestsEnabled:         true,
 		ChangesetSizeThreshold: 2,
 		MaxProtosLoadSize:      100,
-		ResyncIntervalSecs:    1000,
+		ResyncIntervalSecs:     1000,
 	}
 	servicer := servicers.NewSubscriberdbServicer(configs, digestStore, perSubDigestStore, subStore, lastResyncStore)
 

--- a/lte/cloud/go/services/subscriberdb/servicers/subscriberdb_servicer_test.go
+++ b/lte/cloud/go/services/subscriberdb/servicers/subscriberdb_servicer_test.go
@@ -563,7 +563,7 @@ func TestCheckSubscribersInSync(t *testing.T) {
 	err = digestStore.SetDigest("n1", "digest_apple")
 	assert.NoError(t, err)
 
-	err = lastResyncStore.Set("n1", "g1", uint64(time.Now().Unix()))
+	err = lastResyncStore.Set("n1", "g1", uint32(time.Now().Unix()))
 	assert.NoError(t, err)
 	// Requests with blank digests should get an update signal in return
 	req := &lte_protos.CheckSubscribersInSyncRequest{
@@ -593,7 +593,7 @@ func TestCheckSubscribersInSync(t *testing.T) {
 
 	// Requests from gateways that haven't been resynced for more than the specified
 	// resync interval should get an update signal in return
-	err = lastResyncStore.Set("n1", "g1", uint64(time.Now().Unix())-5000)
+	err = lastResyncStore.Set("n1", "g1", uint32(time.Now().Unix())-5000)
 	assert.NoError(t, err)
 	req = &lte_protos.CheckSubscribersInSyncRequest{
 		FlatDigest: &lte_protos.Digest{Md5Base64Digest: "digest_apple2"},
@@ -631,7 +631,7 @@ func TestSyncSubscribers(t *testing.T) {
 	assert.NoError(t, err)
 	assert.True(t, res.Resync)
 
-	err = lastResyncStore.Set("n1", "g1", uint64(time.Now().Unix()))
+	err = lastResyncStore.Set("n1", "g1", uint32(time.Now().Unix()))
 	assert.NoError(t, err)
 	// Initially no digests
 	req = &lte_protos.SyncSubscribersRequest{
@@ -760,7 +760,7 @@ func TestSyncSubscribersResync(t *testing.T) {
 	id := protos.NewGatewayIdentity("hw1", "n1", "g1")
 	ctx := id.NewContextWithIdentity(context.Background())
 
-	err = lastResyncStore.Set("n1", "g1", uint64(time.Now().Unix()))
+	err = lastResyncStore.Set("n1", "g1", uint32(time.Now().Unix()))
 	assert.NoError(t, err)
 	// When changeset is no larger than ChangesetSizeThreshold, the servicer should return the full changeset
 	expectedToRenewData := []*lte_protos.SubscriberData{

--- a/lte/cloud/go/services/subscriberdb/storage/last_resync.go
+++ b/lte/cloud/go/services/subscriberdb/storage/last_resync.go
@@ -1,0 +1,77 @@
+/*
+ Copyright 2020 The Magma Authors.
+
+ This source code is licensed under the BSD-style license found in the
+ LICENSE file in the root directory of this source tree.
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package storage
+
+import (
+	"encoding/binary"
+
+	"magma/orc8r/cloud/go/blobstore"
+	"magma/orc8r/cloud/go/storage"
+	merrors "magma/orc8r/lib/go/errors"
+
+	"github.com/pkg/errors"
+)
+
+const (
+	lastResyncTimeBlobstoreType = "gateway_last_resync_time"
+)
+
+type LastResyncTimeStore struct {
+	fact blobstore.BlobStorageFactory
+}
+
+func NewLastResyncTimeStore(fact blobstore.BlobStorageFactory) *LastResyncTimeStore {
+	return &LastResyncTimeStore{fact: fact}
+}
+
+func (l *LastResyncTimeStore) Get(network string, gateway string) (uint64, error) {
+	store, err := l.fact.StartTransaction(&storage.TxOptions{ReadOnly: true})
+	if err != nil {
+		return uint64(0), errors.Wrapf(err, "error starting transaction")
+	}
+	defer store.Rollback()
+
+	blob, err := store.Get(network, storage.TypeAndKey{Type: lastResyncTimeBlobstoreType, Key: gateway})
+	if err == merrors.ErrNotFound {
+		// If this store has never been resynced, return 0 to enforce first resync
+		return uint64(0), nil
+	}
+	if err != nil {
+		return uint64(0), errors.Wrapf(err, "get last resync time of network %+v, gateway %+v from blobstore", network, gateway)
+	}
+
+	lastResyncTime := binary.LittleEndian.Uint64(blob.Value)
+	return lastResyncTime, store.Commit()
+}
+
+func (l *LastResyncTimeStore) Set(network string, gateway string, unixTime uint64) error {
+	store, err := l.fact.StartTransaction(&storage.TxOptions{ReadOnly: true})
+	if err != nil {
+		return errors.Wrapf(err, "error starting transaction")
+	}
+	defer store.Rollback()
+
+	lastResyncTimeBytes := make([]byte, 8)
+	binary.LittleEndian.PutUint64(lastResyncTimeBytes, unixTime)
+	err = store.CreateOrUpdate(network, blobstore.Blobs{{
+		Type:  lastResyncTimeBlobstoreType,
+		Key:   gateway,
+		Value: lastResyncTimeBytes,
+	}})
+	if err != nil {
+		return errors.Wrapf(err, "set last resync time of network %+v, gateway %+v in blobstore", network, gateway)
+	}
+
+	return store.Commit()
+}

--- a/lte/cloud/go/services/subscriberdb/storage/last_resync_test.go
+++ b/lte/cloud/go/services/subscriberdb/storage/last_resync_test.go
@@ -1,0 +1,79 @@
+/*
+ Copyright 2020 The Magma Authors.
+
+ This source code is licensed under the BSD-style license found in the
+ LICENSE file in the root directory of this source tree.
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package storage_test
+
+import (
+	"testing"
+	"time"
+
+	"magma/lte/cloud/go/services/subscriberdb"
+	"magma/lte/cloud/go/services/subscriberdb/storage"
+	"magma/orc8r/cloud/go/test_utils"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestLastResyncTimeStore(t *testing.T) {
+	fact := test_utils.NewSQLBlobstore(t, subscriberdb.LastResyncTimeTableBlobstore)
+	assert.NoError(t, fact.InitializeFactory())
+	s := storage.NewLastResyncTimeStore(fact)
+
+	t.Run("initially empty", func(t *testing.T) {
+		lastResyncTime, err := s.Get("n0", "g0")
+		assert.NoError(t, err)
+		assert.Empty(t, lastResyncTime)
+	})
+
+	t.Run("set and get", func(t *testing.T) {
+		expectedLastResyncTime := uint64(time.Now().Unix())
+		err := s.Set("n0", "g0", expectedLastResyncTime)
+		assert.NoError(t, err)
+		lastResyncTime, err := s.Get("n0", "g0")
+		assert.NoError(t, err)
+		assert.Equal(t, expectedLastResyncTime, lastResyncTime)
+	})
+
+	t.Run("multiple set and get", func(t *testing.T) {
+		expectedLastResyncTime := uint64(time.Now().Unix())
+
+		err := s.Set("n0", "g0", expectedLastResyncTime+1)
+		assert.NoError(t, err)
+		err = s.Set("n0", "g1", expectedLastResyncTime+2)
+		assert.NoError(t, err)
+		err = s.Set("n1", "g0", expectedLastResyncTime+3)
+		assert.NoError(t, err)
+		err = s.Set("n1", "g1", expectedLastResyncTime+4)
+		assert.NoError(t, err)
+
+		lastResyncTime1, err := s.Get("n0", "g0")
+		assert.NoError(t, err)
+		assert.Equal(t, expectedLastResyncTime+1, lastResyncTime1)
+		lastResyncTime2, err := s.Get("n0", "g1")
+		assert.NoError(t, err)
+		assert.Equal(t, expectedLastResyncTime+2, lastResyncTime2)
+		lastResyncTime3, err := s.Get("n1", "g0")
+		assert.NoError(t, err)
+		assert.Equal(t, expectedLastResyncTime+3, lastResyncTime3)
+		lastResyncTime4, err := s.Get("n1", "g1")
+		assert.NoError(t, err)
+		assert.Equal(t, expectedLastResyncTime+4, lastResyncTime4)
+
+		// Test upserting value to the store
+		err = s.Set("n0", "g0", expectedLastResyncTime+5)
+		assert.NoError(t, err)
+		lastResyncTime5, err := s.Get("n0", "g0")
+		assert.NoError(t, err)
+		assert.Equal(t, expectedLastResyncTime+5, lastResyncTime5)
+	})
+}

--- a/lte/cloud/go/services/subscriberdb/storage/last_resync_test.go
+++ b/lte/cloud/go/services/subscriberdb/storage/last_resync_test.go
@@ -36,7 +36,7 @@ func TestLastResyncTimeStore(t *testing.T) {
 	})
 
 	t.Run("set and get", func(t *testing.T) {
-		expectedLastResyncTime := uint64(time.Now().Unix())
+		expectedLastResyncTime := uint32(time.Now().Unix())
 		err := s.Set("n0", "g0", expectedLastResyncTime)
 		assert.NoError(t, err)
 		lastResyncTime, err := s.Get("n0", "g0")
@@ -45,7 +45,7 @@ func TestLastResyncTimeStore(t *testing.T) {
 	})
 
 	t.Run("multiple set and get", func(t *testing.T) {
-		expectedLastResyncTime := uint64(time.Now().Unix())
+		expectedLastResyncTime := uint32(time.Now().Unix())
 
 		err := s.Set("n0", "g0", expectedLastResyncTime+1)
 		assert.NoError(t, err)

--- a/lte/cloud/go/services/subscriberdb/subscriberdb/main.go
+++ b/lte/cloud/go/services/subscriberdb/subscriberdb/main.go
@@ -71,6 +71,12 @@ func main() {
 		glog.Fatalf("Error initializing subscriber proto storage: %+v", err)
 	}
 
+	lastResyncTimeFact := blobstore.NewEntStorage(subscriberdb.LastResyncTimeTableBlobstore, db, sqorc.GetSqlBuilder())
+	if err := lastResyncTimeFact.InitializeFactory(); err != nil {
+		glog.Fatalf("Error initializing last resync time storage: %+v", err)
+	}
+	lastResyncTimeStore := subscriberdb_storage.NewLastResyncTimeStore(lastResyncTimeFact)
+
 	var serviceConfig subscriberdb.Config
 	config.MustGetStructuredServiceConfig(lte.ModuleName, subscriberdb.ServiceName, &serviceConfig)
 	glog.Infof("Subscriberdb service config %+v", serviceConfig)
@@ -79,7 +85,7 @@ func main() {
 	obsidian.AttachHandlers(srv.EchoServer, handlers.GetHandlers())
 	protos.RegisterSubscriberLookupServer(srv.GrpcServer, servicers.NewLookupServicer(fact, ipStore))
 	state_protos.RegisterIndexerServer(srv.GrpcServer, servicers.NewIndexerServicer())
-	lte_protos.RegisterSubscriberDBCloudServer(srv.GrpcServer, servicers.NewSubscriberdbServicer(serviceConfig, digestStore, perSubDigestStore, subStore))
+	lte_protos.RegisterSubscriberDBCloudServer(srv.GrpcServer, servicers.NewSubscriberdbServicer(serviceConfig, digestStore, perSubDigestStore, subStore, lastResyncTimeStore))
 
 	swagger_protos.RegisterSwaggerSpecServer(srv.GrpcServer, swagger.NewSpecServicerFromFile(subscriberdb.ServiceName))
 

--- a/lte/cloud/go/services/subscriberdb/test_init/test_service_init.go
+++ b/lte/cloud/go/services/subscriberdb/test_init/test_service_init.go
@@ -65,6 +65,9 @@ func StartTestService(t *testing.T) {
 	perSubDigestStore := storage.NewPerSubDigestStore(perSubDigestFact)
 	subStore := storage.NewSubStore(db, sqorc.GetSqlBuilder())
 	assert.NoError(t, subStore.Initialize())
+	lastResyncTimeFact := blobstore.NewSQLBlobStorageFactory(subscriberdb.LastResyncTimeTableBlobstore, db, sqorc.GetSqlBuilder())
+	assert.NoError(t, lastResyncTimeFact.InitializeFactory())
+	lastResyncTimeStore := storage.NewLastResyncTimeStore(perSubDigestFact)
 
 	// Load service configs
 	var serviceConfig subscriberdb.Config
@@ -75,7 +78,7 @@ func StartTestService(t *testing.T) {
 	// Add servicers
 	protos.RegisterSubscriberLookupServer(srv.GrpcServer, servicers.NewLookupServicer(fact, ipStore))
 	state_protos.RegisterIndexerServer(srv.GrpcServer, servicers.NewIndexerServicer())
-	lte_protos.RegisterSubscriberDBCloudServer(srv.GrpcServer, servicers.NewSubscriberdbServicer(serviceConfig, digestStore, perSubDigestStore, subStore))
+	lte_protos.RegisterSubscriberDBCloudServer(srv.GrpcServer, servicers.NewSubscriberdbServicer(serviceConfig, digestStore, perSubDigestStore, subStore, lastResyncTimeStore))
 
 	// Run service
 	go srv.RunTest(lis)

--- a/orc8r/cloud/go/orc8r/jitter.go
+++ b/orc8r/cloud/go/orc8r/jitter.go
@@ -1,0 +1,30 @@
+/*
+Copyright 2020 The Magma Authors.
+
+This source code is licensed under the BSD-style license found in the
+LICENSE file in the root directory of this source tree.
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package orc8r
+
+import "hash/fnv"
+
+// JitterUint32 returns a jitter of the given uint32 value that is deterministic
+// based on the given key.
+func JitterUint32(keyn uint32, key string, maxJitterMultiplier float32) uint32 {
+	// FNV-1 is a non-cryptographic hash function that is fast and very simple to implement
+	h := fnv.New32a()
+	_, err := h.Write([]byte(key))
+	if err != nil {
+		return 0
+	}
+	multiplier := float32(h.Sum32()%100) / 100.0
+	maxJitter := float32(keyn) * maxJitterMultiplier
+	return uint32(multiplier * maxJitter)
+}

--- a/orc8r/cloud/go/orc8r/math/math.go
+++ b/orc8r/cloud/go/orc8r/math/math.go
@@ -11,13 +11,13 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package orc8r
+package math
 
 import "hash/fnv"
 
 // JitterUint32 returns a jitter of the given uint32 value that is deterministic
 // based on the given key.
-func JitterUint32(keyn uint32, key string, maxJitterMultiplier float32) uint32 {
+func JitterUint32(n uint32, key string, maxMultiplier float32) uint32 {
 	// FNV-1 is a non-cryptographic hash function that is fast and very simple to implement
 	h := fnv.New32a()
 	_, err := h.Write([]byte(key))
@@ -25,6 +25,6 @@ func JitterUint32(keyn uint32, key string, maxJitterMultiplier float32) uint32 {
 		return 0
 	}
 	multiplier := float32(h.Sum32()%100) / 100.0
-	maxJitter := float32(keyn) * maxJitterMultiplier
+	maxJitter := float32(n) * maxMultiplier
 	return uint32(multiplier * maxJitter)
 }


### PR DESCRIPTION
Signed-off-by: Yuanyuting Wang <yw3241@columbia.edu><!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->
1. Add `subscriberdb_storage.LastResyncStore` that tracks the last resync times of AGWs in each network
2. Add logic to `subscriberdb_servicer` that enforces orc8r-directed resync for an AGW if its last resync time is more than a configurable interval ago

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->
1. Ran all existing tests; all passed
2. Added new tests for the added functionalities

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
