### PR TITLE
fix(agw): on AGW reboot bring up SGi interface.

### DIFF
--- a/lte/gateway/python/scripts/config_stateless_agw.py
+++ b/lte/gateway/python/scripts/config_stateless_agw.py
@@ -160,6 +160,12 @@ def disable_stateless_agw():
 
 
 def ovs_reset_bridges():
+    service_config = load_service_config('pipelined')
+    sgi_interface = service_config['nat_iface']
+    if_up_cmd = "ip link set dev %s up" % sgi_interface
+    subprocess.call(if_up_cmd.split())
+    print("ip up cmd %s", if_up_cmd)
+
     subprocess.call(
         "ovs-vsctl --all destroy Flow_Sample_Collector_Set".split(),
     )


### PR DESCRIPTION
In case of missing interface file for SGi interface, the
interface does not come up automatically. That can impact
SGi connectivity.

Following patch handles the case.

Signed-off-by: Pravin B Shelar <pbshelar@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->

## Test Plan
validated on AGW:
```
root@phy-u3:~# ifconfig eth0 down
root@phy-u3:~# config_stateless_agw.py flushall_redis; ifconfig eth0
Flushing all content in Redis
OK
Restarting sctpd
Job for sctpd.service failed because the control process exited with error code.
See "systemctl status sctpd.service" and "journalctl -xe" for details.
eth0: flags=4163<UP,BROADCAST,RUNNING,MULTICAST>  mtu 1500
        inet 10.22.70.93  netmask 255.255.255.0  broadcast 10.22.70.255
        inet6 fe80::2e0:67ff:fe1a:4f58  prefixlen 64  scopeid 0x20<link>
        ether 00:e0:67:1a:4f:58  txqueuelen 1000  (Ethernet)
        RX packets 370877  bytes 212022310 (212.0 MB)
        RX errors 0  dropped 186  overruns 0  frame 0
        TX packets 311680  bytes 165872062 (165.8 MB)
        TX errors 0  dropped 0 overruns 0  carrier 0  collisions 0
        device memory 0xb1500000-b151ffff
```
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
