### PR TITLE
docs(nms): Add contributing conventions for JavaScript

### DIFF
--- a/docs/docusaurus/i18n/en.json
+++ b/docs/docusaurus/i18n/en.json
@@ -439,6 +439,9 @@
       "proposals/p017_apn_refactoring": {
         "title": "APN Refactoring Proposal"
       },
+      "proposals/p018_control_network_metrics": {
+        "title": "Export Control Path Network Metrics"
+      },
       "proposals/qos_enforcement": {
         "title": "proposals/qos_enforcement"
       },
@@ -447,6 +450,9 @@
       },
       "proposals/proposal_template": {
         "title": "Title of Design Doc"
+      },
+      "resources/ref_magma_metrics": {
+        "title": "Life of a Magma Metric"
       },
       "resources/ref_pcap": {
         "title": "PCAP Collection"

--- a/docs/readmes/contributing/contribute_conventions.md
+++ b/docs/readmes/contributing/contribute_conventions.md
@@ -25,6 +25,7 @@ Follow these conventions when making changes to the Magma codebase.
 - Unit tests should default to being placed in the same directory as the files they're testing, except for the following
     - Python: directly-adjacent `tests` directory
     - C/C++: directly-adjacent `tests` directory
+    - JavaScript: directly-adjacent `__tests__` directory
 - Integration tests should be placed as close to the code-under-test as possible
 - If you're not sure how to test a change, reach out on the community Slack workspace for input
 
@@ -224,13 +225,13 @@ def foo(arg1: str) -> int:
 ```
 
 **Logging**
-- Use the [logging](https://docs.python.org/3/library/logging.html) module for all logging 
+- Use the [logging](https://docs.python.org/3/library/logging.html) module for all logging
 - Refer to the Go logging section for deciding between log levels
 
 
 **Linter**
 
-- For mandatory lint checks, we have a unit test that runs [Pylint](https://pypi.org/project/pylint/) on all gateway services 
+- For mandatory lint checks, we have a unit test that runs [Pylint](https://pypi.org/project/pylint/) on all gateway services
   - On CI, the check gets run as part of the `lte-test` job
 - Additionally, we have a [Reviewdog](https://github.com/reviewdog/reviewdog) linter using [wemake-python-styleguide](https://wemake-python-stylegui.de/en/latest/) enabled to aid the code review process
   - To run the linter locally, use the [precommit script](https://github.com/magma/magma/blob/master/lte/gateway/python/precommit.py)
@@ -238,9 +239,9 @@ def foo(arg1: str) -> int:
 **Formatters**
 
 - We recommend [autopep8](https://pypi.org/project/autopep8/) as it conforms to [pep8](https://www.python.org/dev/peps/pep-0008/)
-  - The above-mentioned [precommit script](https://github.com/magma/magma/blob/master/lte/gateway/python/precommit.py) also has an option to format your changes with 
+  - The above-mentioned [precommit script](https://github.com/magma/magma/blob/master/lte/gateway/python/precommit.py) also has an option to format your changes with
   [isort](https://pypi.org/project/isort/), [autopep8](https://pypi.org/project/autopep8/), and [add-trailing-comma](https://pypi.org/project/add-trailing-comma/)
-- We do *not* recommend other formatters such as [black](https://black.readthedocs.io/en/stable/installation_and_usage.html), as it diverges from pep8 on basic things like line length, etc.   
+- We do *not* recommend other formatters such as [black](https://black.readthedocs.io/en/stable/installation_and_usage.html), as it diverges from pep8 on basic things like line length, etc.
 
 
 ### C++
@@ -255,7 +256,7 @@ The [Google C++ Style Guide](https://google.github.io/styleguide/cppguide.html) 
 **Types**
 - Be mindful when choosing input / output types when writing new functions
   - Opt for return values over output parameters
-  - Non-optional input parameters should be values or const references 
+  - Non-optional input parameters should be values or const references
   - Use non-const pointers to represent optional outputs and optional input/output parameters
 
 **Headers**
@@ -280,6 +281,31 @@ The [Google C++ Style Guide](https://google.github.io/styleguide/cppguide.html) 
     - `.bash` for bash
     - Default to `.bash` except with specific reason
 - When a shell script passes around 100 lines, it's time to re-write it in Python or Go
+
+### Javascript
+
+**General**
+- Import order should be: types, default components, and named components with each separated by a newline
+- Use `TitleCase` for component file names
+- Favor `map` and `forEach` functions in place of regular `for` loops
+- Refrain from using literal strings/numbers without defining them
+- Use strict equality(`===`) when comparing values
+
+**Type annotations**
+- All new code should be fully type anotatated
+- We have a mandatory unit test that runs the [Flow](https://docs.magmacore.org/docs/next/nms/dev_testing#pre-commit-tests#flow) type checker on the NMS codebase
+    - On CI, the check gets run as part of the `nms-flow-test` job
+
+**Documentation**
+- Document all the components and functions you create
+- Keep the docs up to date when you make changes
+- Use [JSDoc](https://jsdoc.app/index.html) tags to document your code
+- Use `//` to comment line of code, if it is not clear in what it is doing
+
+**Linter**
+- Run [ESLint](https://docs.magmacore.org/docs/next/nms/dev_testing#pre-commit-tests#eslint) to lint your changes locally
+- For mandatory lint checks, we have a unit test that runs `eslint` on JS code
+    - On CI, the check gets run as part of the `eslint` job
 
 ## Tools
 
@@ -318,4 +344,3 @@ The [Google Protocol Buffer style guide](https://developers.google.com/protocol-
 ### CLIs
 
 - Consolidate related functionality into a single CLI
-


### PR DESCRIPTION
Signed-off-by: Dani Menewuyelet <dmenewuy@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary
A contributing convention was added for Javascript developers. It currently only consists of 4 parts: General, Type Annotations, Documentation, and Linter. Also, a note was added on where to place js test files. 
<!-- Enumerate changes you made and why you made them -->

## Test Plan
Run docusaurus locally also attached screenshots
![Screen Shot 2021-07-20 at 10 48 13 AM](https://user-images.githubusercontent.com/34602743/126345134-5b3feabd-c370-49c9-a1a3-dc1a13c0aa0e.png)
![Screen Shot 2021-07-20 at 10 48 38 AM](https://user-images.githubusercontent.com/34602743/126345135-b9de4cab-214f-4849-a382-5140e1911854.png)
. 

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
