### PR TITLE
fix: [devops-migration] No unit tests for the cwf workflow

### DIFF
--- a/.github/workflows/unit-test-workflow.yml
+++ b/.github/workflows/unit-test-workflow.yml
@@ -5,7 +5,6 @@ on:  # yamllint disable-line rule:truthy
     workflows:
       - cloud-workflow
       - feg-workflow
-      - cwf-operator
     types:
       - completed
 


### PR DESCRIPTION
Signed-off-by: Quentin, Derory <15911421+quentinDERORY@users.noreply.github.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

No unit test to upload for the cwf operator

## Test Plan

NA (removing one trigger)

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
