### PR TITLE
test(mme): unit test for s1ap_handle_new_association

### DIFF
--- a/lte/gateway/c/core/oai/tasks/mme_app/CMakeLists.txt
+++ b/lte/gateway/c/core/oai/tasks/mme_app/CMakeLists.txt
@@ -70,8 +70,8 @@ target_link_libraries(TASK_MME_APP
     ${CONFIG_LIBRARIES}
     COMMON
     LIB_BSTR LIB_HASHTABLE LIB_DIRECTORYD LIB_SECU LIB_EVENT_CLIENT
-    TASK_NAS TASK_S1AP TASK_SERVICE303 TASK_SCTP_SERVER
-    TASK_S6A TASK_SGS protobuf cpp_redis yaml-cpp redis_utils
+    TASK_NAS TASK_S1AP TASK_SERVICE303 TASK_SCTP_SERVER TASK_S6A TASK_SGS
+    protobuf cpp_redis yaml-cpp redis_utils folly
     )
 
 if (EMBEDDED_SGW)

--- a/lte/gateway/c/core/oai/tasks/s1ap/s1ap_state_manager.cpp
+++ b/lte/gateway/c/core/oai/tasks/s1ap/s1ap_state_manager.cpp
@@ -61,34 +61,38 @@ void S1apStateManager::init(
   is_initialized = true;
 }
 
-void S1apStateManager::create_state() {
+s1ap_state_t* create_s1ap_state(uint32_t max_enbs, uint32_t max_ues) {
   bstring ht_name;
 
-  state_cache_p = (s1ap_state_t*) calloc(1, sizeof(s1ap_state_t));
+  s1ap_state_t* state_cache_p =
+      static_cast<s1ap_state_t*>(calloc(1, sizeof(s1ap_state_t)));
 
   ht_name = bfromcstr(S1AP_ENB_COLL);
   hashtable_ts_init(
-      &state_cache_p->enbs, max_enbs_, nullptr, free_wrapper, ht_name);
-
-  state_ue_ht = hashtable_ts_create(max_ues_, nullptr, free_wrapper, ht_name);
+      &state_cache_p->enbs, max_enbs, nullptr, free_wrapper, ht_name);
   bdestroy(ht_name);
 
   ht_name = bfromcstr(S1AP_MME_ID2ASSOC_ID_COLL);
   hashtable_ts_init(
-      &state_cache_p->mmeid2associd, max_ues_, nullptr, hash_free_int_func,
+      &state_cache_p->mmeid2associd, max_ues, nullptr, hash_free_int_func,
       ht_name);
   bdestroy(ht_name);
 
   state_cache_p->num_enbs = 0;
+  return state_cache_p;
+}
+
+void S1apStateManager::create_state() {
+  state_cache_p = create_s1ap_state(max_enbs_, max_ues_);
+
+  bstring ht_name = bfromcstr(S1AP_ENB_COLL);
+  state_ue_ht = hashtable_ts_create(max_ues_, nullptr, free_wrapper, ht_name);
+  bdestroy(ht_name);
 
   create_s1ap_imsi_map();
 }
 
-void S1apStateManager::free_state() {
-  AssertFatal(
-      is_initialized,
-      "S1apStateManager init() function should be called to initialize state.");
-
+void free_s1ap_state(s1ap_state_t* state_cache_p) {
   if (state_cache_p == nullptr) {
     return;
   }
@@ -119,11 +123,17 @@ void S1apStateManager::free_state() {
   if (hashtable_ts_destroy(&state_cache_p->mmeid2associd) != HASH_TABLE_OK) {
     OAI_FPRINTF_ERR("An error occurred while destroying assoc_id hash table");
   }
+  free_wrapper(reinterpret_cast<void**>(&state_cache_p));
+}
+
+void S1apStateManager::free_state() {
+  AssertFatal(
+      is_initialized,
+      "S1apStateManager init() function should be called to initialize state.");
+  free_s1ap_state(state_cache_p);
   if (hashtable_ts_destroy(state_ue_ht) != HASH_TABLE_OK) {
     OAI_FPRINTF_ERR("An error occurred while destroying assoc_id hash table");
   }
-  free_wrapper((void**) &state_cache_p);
-
   clear_s1ap_imsi_map();
 }
 

--- a/lte/gateway/c/core/oai/tasks/s1ap/s1ap_state_manager.h
+++ b/lte/gateway/c/core/oai/tasks/s1ap/s1ap_state_manager.h
@@ -42,6 +42,16 @@ namespace magma {
 namespace lte {
 
 /**
+ * create_s1ap_state allocates a new s1ap_state_t struct and initializes
+ * its properties.
+ */
+s1ap_state_t* create_s1ap_state(uint32_t max_enbs, uint32_t max_ues);
+/**
+ * free_s1ap_state deallocates a s1ap_state_t struct and its properties.
+ */
+void free_s1ap_state(s1ap_state_t* state_cache_p);
+
+/**
  * S1apStateManager is a thread safe singleton class that contains functions
  * to maintain S1AP task state, allocating and freeing related state structs.
  */

--- a/lte/gateway/c/core/oai/test/s1ap_task/CMakeLists.txt
+++ b/lte/gateway/c/core/oai/test/s1ap_task/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2020 The Magma Authors.
+# Copyright 2021 The Magma Authors.
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 # Unless required by applicable law or agreed to in writing, software
@@ -7,17 +7,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-cmake_minimum_required(VERSION 3.7.2)
+add_executable(s1ap_test test_s1ap_handle_new_association.cpp)
 
-set(CMAKE_CXX_STANDARD 14)
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
-set(CMAKE_CXX_EXTENSIONS OFF)
+target_link_libraries(s1ap_test
+        TASK_S1AP
+        gtest gtest_main
+        )
 
-add_subdirectory(mme_app_task)
-add_subdirectory(mobility_client)
-add_subdirectory(openflow)
-add_subdirectory(spgw_task)
-add_subdirectory(itti)
-add_subdirectory(pipelined_client)
-add_subdirectory(n11)
-add_subdirectory(s1ap_task)
+add_test(test_s1ap s1ap_test)

--- a/lte/gateway/c/core/oai/test/s1ap_task/test_s1ap_handle_new_association.cpp
+++ b/lte/gateway/c/core/oai/test/s1ap_task/test_s1ap_handle_new_association.cpp
@@ -1,0 +1,153 @@
+/**
+ * Copyright 2021 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <gtest/gtest.h>
+#include <glog/logging.h>
+
+extern "C" {
+#include "log.h"
+#include "S1ap_S1AP-PDU.h"
+#include "s1ap_mme_handlers.h"
+}
+
+#include "s1ap_state_manager.h"
+
+using ::testing::Test;
+
+namespace magma {
+namespace lte {
+
+TEST(test_s1ap_handle_new_association, empty_initial_state) {
+  s1ap_state_t* s = create_s1ap_state(2, 2);
+  // 192.168.60.141 as network bytes
+  bstring ran_cp_ipaddr = bfromcstr("\xc0\xa8\x3c\x8d");
+  sctp_new_peer_t p     = {
+      .instreams     = 1,
+      .outstreams    = 2,
+      .assoc_id      = 3,
+      .ran_cp_ipaddr = ran_cp_ipaddr,
+  };
+  EXPECT_EQ(s1ap_handle_new_association(s, &p), RETURNok);
+
+  EXPECT_EQ(s->enbs.num_elements, 1);
+
+  enb_description_t* enbd = nullptr;
+  EXPECT_EQ(
+      hashtable_ts_get(
+          &s->enbs, (const hash_key_t) p.assoc_id,
+          reinterpret_cast<void**>(&enbd)),
+      HASH_TABLE_OK);
+  EXPECT_EQ(enbd->sctp_assoc_id, 3);
+  EXPECT_EQ(enbd->instreams, 1);
+  EXPECT_EQ(enbd->outstreams, 2);
+  EXPECT_EQ(enbd->enb_id, 0xFFFFFFFF);
+  EXPECT_EQ(enbd->s1_state, S1AP_INIT);
+  EXPECT_EQ(enbd->next_sctp_stream, 1);
+  EXPECT_STREQ(enbd->ran_cp_ipaddr, "\300\250<\215\0\0\0\0\0\0\0\0\0\0\0\0");
+  EXPECT_EQ(enbd->ran_cp_ipaddr_sz, 4);
+
+  // association is created, but S1Setup has not yet occurred
+  EXPECT_EQ(s->num_enbs, 0);
+
+  bdestroy(ran_cp_ipaddr);
+  free_s1ap_state(s);
+}
+
+TEST(test_s1ap_handle_new_association, shutdown) {
+  s1ap_state_t* s   = create_s1ap_state(2, 2);
+  sctp_new_peer_t p = {.assoc_id = 1};
+  EXPECT_EQ(s1ap_handle_new_association(s, &p), RETURNok);
+
+  // set enb to shutdown state
+  enb_description_t* enbd = nullptr;
+  EXPECT_EQ(
+      hashtable_ts_get(
+          &s->enbs, (const hash_key_t) p.assoc_id,
+          reinterpret_cast<void**>(&enbd)),
+      HASH_TABLE_OK);
+  enbd->s1_state = S1AP_SHUTDOWN;
+
+  // expect error
+  EXPECT_EQ(s1ap_handle_new_association(s, &p), RETURNerror);
+
+  free_s1ap_state(s);
+}
+
+TEST(test_s1ap_handle_new_association, resetting) {
+  s1ap_state_t* s   = create_s1ap_state(2, 2);
+  sctp_new_peer_t p = {.assoc_id = 1};
+  EXPECT_EQ(s1ap_handle_new_association(s, &p), RETURNok);
+
+  // set enb to shutdown state
+  enb_description_t* enbd = nullptr;
+  EXPECT_EQ(
+      hashtable_ts_get(
+          &s->enbs, (const hash_key_t) p.assoc_id,
+          reinterpret_cast<void**>(&enbd)),
+      HASH_TABLE_OK);
+  enbd->s1_state = S1AP_RESETING;
+
+  // expect error
+  EXPECT_EQ(s1ap_handle_new_association(s, &p), RETURNerror);
+
+  free_s1ap_state(s);
+}
+
+TEST(test_s1ap_handle_new_association, reassociate) {
+  s1ap_state_t* s   = create_s1ap_state(2, 2);
+  sctp_new_peer_t p = {.assoc_id = 1};
+  EXPECT_EQ(s1ap_handle_new_association(s, &p), RETURNok);
+
+  // make sure first association worked
+  enb_description_t* enbd = nullptr;
+  EXPECT_EQ(
+      hashtable_ts_get(
+          &s->enbs, (const hash_key_t) p.assoc_id,
+          reinterpret_cast<void**>(&enbd)),
+      HASH_TABLE_OK);
+  EXPECT_EQ(enbd->sctp_assoc_id, 1);
+  EXPECT_EQ(enbd->instreams, 0);
+  EXPECT_EQ(enbd->outstreams, 0);
+  EXPECT_STREQ(enbd->ran_cp_ipaddr, "\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0");
+  EXPECT_EQ(enbd->ran_cp_ipaddr_sz, 0);
+  // should be OK if enb status is READY
+  enbd->s1_state = S1AP_READY;
+
+  // new assoc with same id should overwrite
+  bstring ran_cp_ipaddr = bfromcstr("\xc0\xa8\x3c\x8d");
+  sctp_new_peer_t p2    = {
+      .instreams     = 10,
+      .outstreams    = 20,
+      .assoc_id      = 1,
+      .ran_cp_ipaddr = ran_cp_ipaddr,
+  };
+  EXPECT_EQ(s1ap_handle_new_association(s, &p2), RETURNok);
+
+  EXPECT_EQ(enbd->sctp_assoc_id, 1);
+  EXPECT_EQ(enbd->instreams, 10);
+  EXPECT_EQ(enbd->outstreams, 20);
+  EXPECT_STREQ(enbd->ran_cp_ipaddr, "\300\250<\215\0\0\0\0\0\0\0\0\0\0\0\0");
+  EXPECT_EQ(enbd->ran_cp_ipaddr_sz, 4);
+  EXPECT_EQ(enbd->s1_state, S1AP_INIT);
+
+  bdestroy(ran_cp_ipaddr);
+  free_s1ap_state(s);
+}
+
+}  // namespace lte
+}  // namespace magma
+
+int main(int argc, char** argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  OAILOG_INIT("MME", OAILOG_LEVEL_DEBUG, MAX_LOG_PROTOS);
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
Signed-off-by: Mark Jen <markjen@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

* Add new unit test for S1AP task: s1ap_handle_new_association handler
* Refactor s1ap_state_manager funcs for testability

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

* `make test_oai` works in my dev
* expect ci to pass and code coverage to increase

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
