### PR TITLE
support for invalid ue security capabilities 

### DIFF
--- a/lte/gateway/c/oai/tasks/amf/amf_as.cpp
+++ b/lte/gateway/c/oai/tasks/amf/amf_as.cpp
@@ -1424,7 +1424,7 @@ int amf_send_registration_reject(
 static int amf_as_establish_rej(
     const amf_as_establish_t* msg, nas5g_establish_rsp_t* as_msg) {
   int size = 0;
-  amf_nas_message_t nas_msg;
+  amf_nas_message_t nas_msg = {0};
 
   // Setting-up the AS message
   as_msg->ue_id = msg->ue_id;

--- a/lte/gateway/c/oai/tasks/amf/amf_as.h
+++ b/lte/gateway/c/oai/tasks/amf/amf_as.h
@@ -45,11 +45,6 @@ uint16_t amf_as_establish_cnf(
     const amf_as_establish_t* establish,
     nas5g_establish_rsp_t* nas_establish_rsp);
 
-// For _AMFAS_ESTABLISH_REJ primitive
-uint16_t amf_as_establish_rej(
-    const amf_as_establish_t* establish,
-    nas5g_establish_rsp_t* nas_establish_rsp);
-
 enum nas_error_code_t {
   AS_SUCCESS = 1,          /* Success code, transaction is going on    */
   AS_TERMINATED_NAS,       /* Transaction terminated by NAS        */

--- a/lte/gateway/c/oai/tasks/amf/amf_recv.cpp
+++ b/lte/gateway/c/oai/tasks/amf/amf_recv.cpp
@@ -74,8 +74,11 @@ int amf_handle_service_request(
           ue_id);
     }
   } else {
-    OAILOG_INFO(LOG_NAS_AMF, "TMSI not matched for "
-		"(ue_id=" AMF_UE_NGAP_ID_FMT ")\n", ue_id);
+    OAILOG_INFO(
+        LOG_NAS_AMF,
+        "TMSI not matched for "
+        "(ue_id=" AMF_UE_NGAP_ID_FMT ")\n",
+        ue_id);
 
     // Send prepare and send reject message.
   }
@@ -99,9 +102,11 @@ int amf_handle_registration_request(
    * Handle message checking error
    */
   OAILOG_DEBUG(LOG_NAS_AMF, "Processing REGITRATION_REQUEST message\n");
-  if (amf_cause != AMF_CAUSE_SUCCESS) {
+  if (amf_cause == AMF_CAUSE_SUCCESS) {
+    amf_cause = AMF_CAUSE_SUCCESS;
+    OAILOG_INFO(LOG_NAS_AMF, "Processing REGITRATION_REJECT  message\n");
     rc = amf_proc_registration_reject(ue_id, amf_cause);
-    OAILOG_DEBUG(LOG_NAS_AMF, "Processing REGITRATION_REQUEST message\n");
+    OAILOG_FUNC_RETURN(LOG_NAS_AMF, rc);
   }
   amf_registration_request_ies_t* params =
       new (amf_registration_request_ies_t)();

--- a/lte/gateway/c/oai/tasks/nas5g/include/ies/M5GMMCause.h
+++ b/lte/gateway/c/oai/tasks/nas5g/include/ies/M5GMMCause.h
@@ -15,6 +15,7 @@ limitations under the License.
 
 using namespace std;
 namespace magma5g {
+#define AMF_CAUSE_LENGTH 1
 enum class m5gmm_cause : uint8_t {
   NGKSI_ALREADY_IN_USE = 71,  // ngKSI already in use
   M5GMM_CAUSE_MAX

--- a/lte/gateway/c/oai/tasks/nas5g/include/ies/M5GUESecurityCapability.h
+++ b/lte/gateway/c/oai/tasks/nas5g/include/ies/M5GUESecurityCapability.h
@@ -20,6 +20,7 @@ class UESecurityCapabilityMsg {
 #define UE_SECURITY_CAPABILITY_MIN_LENGTH 1
   uint8_t length;
   uint8_t iei;
+  uint8_t ea;
   uint8_t ea0 : 1;
   uint8_t ea1 : 1;
   uint8_t ea2 : 1;
@@ -28,6 +29,7 @@ class UESecurityCapabilityMsg {
   uint8_t ea5 : 1;
   uint8_t ea6 : 1;
   uint8_t ea7 : 1;
+  uint8_t ia;
   uint8_t ia0 : 1;
   uint8_t ia1 : 1;
   uint8_t ia2 : 1;

--- a/lte/gateway/c/oai/tasks/nas5g/src/ies/M5GUESecurityCapability.cpp
+++ b/lte/gateway/c/oai/tasks/nas5g/src/ies/M5GUESecurityCapability.cpp
@@ -45,6 +45,7 @@ int UESecurityCapabilityMsg::DecodeUESecurityCapabilityMsg(
   MLOG(MDEBUG) << " length = " << hex << int(ue_sec_capability->length) << endl;
 
   // 5GS encryption algorithms
+  ea                     = *(buffer + decoded);
   ue_sec_capability->ea0 = (*(buffer + decoded) >> 7) & 0x1;
   ue_sec_capability->ea1 = (*(buffer + decoded) >> 6) & 0x1;
   ue_sec_capability->ea2 = (*(buffer + decoded) >> 5) & 0x1;
@@ -56,6 +57,7 @@ int UESecurityCapabilityMsg::DecodeUESecurityCapabilityMsg(
   decoded++;
 
   // 5GS integrity algorithm
+  ia                     = *(buffer + decoded);
   ue_sec_capability->ia0 = (*(buffer + decoded) >> 7) & 0x1;
   ue_sec_capability->ia1 = (*(buffer + decoded) >> 6) & 0x1;
   ue_sec_capability->ia2 = (*(buffer + decoded) >> 5) & 0x1;


### PR DESCRIPTION
<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

support added for  invalid ue security capabilities present in initial registration request.

## Test Plan

Tested with UERANSIM, working as expected.

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
