### PR TITLE
fix: Add docker retry in cwag-deploy

### DIFF
--- a/.github/workflows/cwag-workflow.yml
+++ b/.github/workflows/cwag-workflow.yml
@@ -150,12 +150,32 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Run docker compose
+        id: cwag-docker-compose
+        continue-on-error: true
         # yamllint disable rule:line-length
         env:
           DOCKER_REGISTRY: cwf_
         run: |
           cd ${MAGMA_ROOT}/cwf/gateway/docker
           docker-compose --file docker-compose.yml --file docker-compose.override.yml build --parallel
+      - name: Retry docker compose on failure
+        id: retry-cwag-docker-compose
+        continue-on-error: true
+        if: steps.cwag-docker-compose.outcome=='failure'
+        env:
+          DOCKER_REGISTRY: cwf_
+        run: |
+          cd ${MAGMA_ROOT}/cwf/gateway/docker
+          docker-compose --file docker-compose.yml --file docker-compose.override.yml build --parallel
+      - name: Set the job status
+        if: always()
+        run: |
+          if ${{ steps.cwag-docker-compose.outcome=='success' || steps.retry-cwag-docker-compose.outcome=='success' }}; then
+             echo "Docker compose completed successfully"
+          else
+             echo "Docker compose failed"
+             exit 1
+          fi
       - name: Tag and push to Docker Registry
         if: github.ref == 'refs/heads/master' && github.event_name != 'pull_request'
         env:


### PR DESCRIPTION
Add a manual retry in case docker compose step
fails in cwag-deploy

Signed-off-by: Jessica Wagantall <jwagantall@linuxfoundation.org>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
