### PR TITLE
feat(sessiond): example of simple shard id (THIS IS A JUST A TEMPLATE, not to be merged)

### DIFF
--- a/lte/gateway/c/session_manager/LocalEnforcer.h
+++ b/lte/gateway/c/session_manager/LocalEnforcer.h
@@ -39,6 +39,8 @@
 namespace magma {
 using std::experimental::optional;
 
+using shards_ = std::vector<int>;
+
 using ImsiAndSessionID = std::pair<std::string, std::string>;
 
 struct RuleRecord_equal {

--- a/lte/gateway/c/session_manager/SessionState.h
+++ b/lte/gateway/c/session_manager/SessionState.h
@@ -267,6 +267,9 @@ class SessionState {
 
   std::string get_imsi() const { return config_.common_context.sid().id(); }
 
+  int get_shard_id() { return shard_id_; }
+  void set_shard_id(int shard_id) { shard_id_ = shard_id;}
+
   std::string get_session_id() const { return session_id_; }
 
   uint32_t get_pdu_id() const;
@@ -740,6 +743,7 @@ class SessionState {
   uint64_t pdp_end_time_;
   /*5G related message to handle session state context */
   uint32_t current_version_;  // To compare with incoming session version
+  int shard_id_;
   /**
    *  Counter to keep track of number of retries in case of SMF-UPF version
    *  mismatch

--- a/lte/gateway/c/session_manager/ShardTracker.cpp
+++ b/lte/gateway/c/session_manager/ShardTracker.cpp
@@ -20,18 +20,18 @@ namespace magma {
 
 int ShardTracker::add_ue() {
   /*
-  * If there are no shards, add an entry for the shard
-  * representing a single UE at the new shard
-  */
+   * If there are no shards, add an entry for the shard
+   * representing a single UE at the new shard
+   */
   if (ue_count_per_shard_.size() == 0) {
     ue_count_per_shard_.push_back(1);
     return 0;
   }
   /*
-  * Iterate through all existing shards, if all are full
-  * create a new shard with quantity 1, otherwise increment
-  * the quantity of UEs in the latest shard
-  */
+   * Iterate through all existing shards, if all are full
+   * create a new shard with quantity 1, otherwise increment
+   * the quantity of UEs in the latest shard
+   */
   for (size_t shard_id = 0; shard_id < ue_count_per_shard_.size(); shard_id++) {
     if (ue_count_per_shard_[shard_id] < max_shard_size_) {
       ue_count_per_shard_[shard_id]++;
@@ -44,10 +44,10 @@ int ShardTracker::add_ue() {
 
 bool ShardTracker::remove_ue(int shard_id) {
   /*
-  * Since we only keep global state of all UEs, we just
-  * need to decrement the number of UEs at a particular id
-  * if there are no UEs at the shard, removal should fail
-  */
+   * Since we only keep global state of all UEs, we just
+   * need to decrement the number of UEs at a particular id
+   * if there are no UEs at the shard, removal should fail
+   */
   if (ue_count_per_shard_.empty()) {
     return false;
   }

--- a/lte/gateway/c/session_manager/ShardTracker.h
+++ b/lte/gateway/c/session_manager/ShardTracker.h
@@ -37,15 +37,15 @@ class ShardTracker {
   bool remove_ue(int shard_id);
 
  private:
-  /* 
-  * a vector of quantities, where the indices represent
-  * the shard id and the values represent the number of
-  * UEs held in each shard
-  */
+  /*
+   * a vector of quantities, where the indices represent
+   * the shard id and the values represent the number of
+   * UEs held in each shard
+   */
   std::vector<uint16_t> ue_count_per_shard_;
   /*
-  * largest number of UEs that can fill a shard
-  */
+   * largest number of UEs that can fill a shard
+   */
   const uint16_t max_shard_size_ = 100;
 };
 


### PR DESCRIPTION
Signed-off-by: Oriol Batalla <obatalla@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary


This is just an example of adding and removing shards ids from UEs. 

The main idea is shards_ will be just a vector of integers. In other words, just a counter of how many UEs we have in each shard.

Each session will store the value of its shard

Every session for one specific UE will have the same shard (that can be easily change removing some conditions)

When UE is added we will either get the shard from a previous session for that UE or get a new one and ++ the counter for that shard

When UE leaves, we just check if the session is the last one for that UE. If so, we -- on that specific shard



Note code IT IS NOT PROPER 
- Location of shards_ is wrong
- shards_ is not initialized 
- access to shards_ is not good
- functions are not defined on headers


<!-- Enumerate changes you made and why you made them -->

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
