### PR TITLE
chore: [ci] Get rid of xwfm test as github action runner are too small

### DIFF
--- a/.github/workflows/cwag-workflow.yml
+++ b/.github/workflows/cwag-workflow.yml
@@ -74,71 +74,6 @@ jobs:
           max_attempts: 2
           timeout_minutes: 10
           # TODO bring up the containers and check for crashloops
-  xwfm-test:
-    runs-on: ubuntu-latest
-    env:
-      MAGMA_ROOT: "${{ github.workspace }}"
-      ACCESSTOKEN: "${{ secrets.XWF_ACCESSTOKEN }}"
-      AWS_ACCESS_KEY_ID: "${{ secrets.AWS_ACCESS_KEY_ID }}"
-      AWS_SECRET_ACCESS_KEY: "${{ secrets.AWS_SECRET_ACCESS_KEY }}"
-      AWS_DEFAULT_REGION: "${{ secrets.XWF_AWS_DEFAULT_REGION }}"
-      AWS_ACCOUNT_ID: "${{ secrets.XWF_AWS_ACCOUNT_ID }}"
-      PARTNERNAME: "${{ secrets.XWF_PARTNER_SHORT_NAME }}"
-      CPURL: "${{ secrets.XWF_CPURL }}"
-      VPCEndPointID: "${{ secrets.XWF_VPCEndPointID }}"
-    steps:
-      # Run dummy step to report this job as passed on pull_requests
-      # This will unblock xwfm-deploy-latest
-      - name: Run dummy step
-        run: |
-              echo "Unblocking xwfm-deploy-latest"
-      - uses: actions/checkout@v2
-        if: github.event_name != 'pull_request'
-      - name: Loading openvswitch kernel module
-        if: github.event_name != 'pull_request'
-        run: sudo modprobe openvswitch
-      - name: Run docker compose
-        if: github.event_name != 'pull_request'
-        # yamllint disable rule:line-length
-        run: |
-              env
-              docker login --username ${{ secrets.XWF_ARTIFACTORY_USER }} --password ${{ secrets.XWF_ARTIFACTORY_API_KEY }} ${{ secrets.XWF_ARTIFACTORY_LINK}}
-              cd ${MAGMA_ROOT}/xwf/docker/
-              docker-compose pull || true
-              docker-compose build --parallel && docker-compose up --detach && docker exec tests pytest --log-cli-level=info code/tests.py
-      - name: Extract commit title
-        if: github.ref == 'refs/heads/master'
-        env:
-          COMMIT_MESSAGE: ${{github.event.head_commit.message}}
-        run: |
-          echo COMMIT_TITLE="${COMMIT_MESSAGE%%$'\\n'*}"  >> $GITHUB_ENV
-      # Notify ci channel when failing
-      # Plugin info: https://github.com/marketplace/actions/slack-notify
-      # yamllint enable
-      - name: Notify failure to slack
-        if: failure() && github.ref == 'refs/heads/master' && github.event_name != 'pull_request'
-        uses: rtCamp/action-slack-notify@v2.2.0
-        env:
-          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_CI }}
-          SLACK_TITLE: "Github action xwfm-test failed"
-          SLACK_MESSAGE: "${{env.COMMIT_TITLE}}"
-          SLACK_USERNAME: "CWAG workflow"
-          SLACK_ICON_EMOJI: ":boom:"
-          SLACK_COLOR: "#FF0000"
-          SLACK_FOOTER: ''
-      # Notify ci channel when push succeeds
-      - name: Notify success to Slack
-        if: success() && github.ref == 'refs/heads/master' && github.event_name != 'pull_request'
-        uses: rtCamp/action-slack-notify@v2.2.0
-        env:
-          SLACK_CHANNEL: ${{ secrets.SLACK_CHANNEL_ARTIFACTS }}
-          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_OSS }}
-          SLACK_TITLE: "*xwfm-test test succeeded*"
-          SLACK_MESSAGE: "${{env.COMMIT_TITLE}}"
-          SLACK_USERNAME: "CWAG workflow"
-          SLACK_ICON_EMOJI: ":heavy_check_mark:"
-          SLACK_COLOR: "#00FF00"
-          SLACK_FOOTER: ''
   cwag-deploy:
     needs:
       - cwag-precommit
@@ -208,7 +143,6 @@ jobs:
   xwfm-deploy-latest:
     needs:
       - cwag-deploy
-      - xwfm-test
     runs-on: ubuntu-latest
     env:
       MAGMA_ROOT: "${{ github.workspace }}"
@@ -225,7 +159,7 @@ jobs:
         if: github.ref == 'refs/heads/master' && github.event_name != 'pull_request'
         # yamllint disable rule:line-length
         run: |
-            ./ci-scripts/tag-push-docker.sh --images 'goradius' --tag "${GITHUB_SHA:0:8}" --tag-latest true --project cwag
+            ./ci-scripts/tag-push-docker.sh --images 'goradius' --tag "${GITHUB_SHA:0:8}" --tag-latest true
       - name: Load openvswitch kernel module for xwf integ test
         # yamllint enable
         run: sudo modprobe openvswitch
@@ -237,7 +171,7 @@ jobs:
         if: github.ref == 'refs/heads/master' && github.event_name != 'pull_request'
         # yamllint disable rule:line-length
         run: |
-            ./ci-scripts/tag-push-docker.sh --images 'xwfm-integ-tests' --tag "${GITHUB_SHA:0:8}" --tag-latest true --project cwag
+            ./ci-scripts/tag-push-docker.sh --images 'xwfm-integ-tests' --tag "${GITHUB_SHA:0:8}" --tag-latest true
       - name: Extract commit title
         if: github.ref == 'refs/heads/master'
         env:


### PR DESCRIPTION


## Summary

GHA runners are too small and prevent the xwfm test to run.
Fixed wrong option in build job too

## Test Plan

NA

## Additional Information

Will need to migrate this job to the new jenkins
