### PR TITLE
chore(ci): Store SwaggerHub account info to sops

### DIFF
--- a/secrets/ci.yaml
+++ b/secrets/ci.yaml
@@ -1,19 +1,24 @@
 magma-bot:
-    gmail:
-        username: ENC[AES256_GCM,data:vVsbjRVfR422Y0ZrSsjcVMGf,iv:GwSUUAR1bcS7MQxJmrAjdZ+ZRO3EpCdBC3hi1950cSw=,tag:4cflzSkz3A2Ylw8PILSm2w==,type:str]
-        password: ENC[AES256_GCM,data:fCtfudvsxYgyqo1rsSm/m5VTcgmEIZdq3tG0EetnxH7ANvBip7imjw==,iv:i2PGcmO4+mooSBivGp+qmPHLyX0lo38GZRnSuf6hygQ=,tag:rkulxtsfVCwqIXCJmNX0tA==,type:str]
-    github:
-        username: ENC[AES256_GCM,data:5aEfakE74+36,iv:386NYGmhrIOO3TBnMXHChmjHty5wp5REMGUyR5KfTzs=,tag:m6JI7OrazaySc7wfDHzpEQ==,type:str]
-        password: ENC[AES256_GCM,data:qyOLEXpJOeuJwOdbrOLCOyrJ9QjRZVeMd9NlVbPQjYjYxQNBxkgKyw==,iv:LvZKY3RcW/+4Vdhw60OrVtzwKLhyU8rFjmAVhK8KDPE=,tag:DyZdMboeVoflRS4ET/cx7g==,type:str]
-        tokens:
-            magma-docusaurus-bot: ENC[AES256_GCM,data:y4qVGzDJeJi/EHvoAqDhNijLExivYqzhWT4Nqvqst/T4gptL9U7M1w==,iv:PCLaOEzLORyZ2KMmReEjT28UaJk7yEC/OVQLPmXNXTg=,tag:Urcc9TpaN2UuCRQqq8Vejg==,type:str]
+    about: ENC[AES256_GCM,data:vOZmDNgP8Tjcv5dowNMdM8VkHoq3VHUn75MEEigIFP71nn3SPHw8iA==,iv:0lxJj4jAvEsjKXlMyaF071K/hcqt0NhPSCseGzophk8=,tag:FSyvvpQou3KALWbhttgByw==,type:str]
+    email: ENC[AES256_GCM,data:jMjqYXE7m//9Y1064wLcyQj1,iv:yfm+bS3LWR/BQxcNoy36QwHppG5vhyFML9i+PRK8KkM=,tag:5D48W7HC6gj4X1hJX/F3wA==,type:str]
+    accounts:
+        gmail.com:
+            password: ENC[AES256_GCM,data:0MFDb66EfTfo2F7qdPdtR9NWOwse/WhbASiHuFa+b6ZuLpmzCGxKRA==,iv:+VutVQ70CpsWQtrt6rH0p0cbvx6rXdoubnTYSVaLa9Q=,tag:3jeAq3n/n+AnPZZ2QwDnSg==,type:str]
+        github.com:
+            username: ENC[AES256_GCM,data:S/zxMmCEmEEB,iv:YZzvJY0dEbd/jKbOT2e2z1xQc0XN1bxMld2noIOOnI4=,tag:bZN3BP6mv3+gNOuavfD+QQ==,type:str]
+            password: ENC[AES256_GCM,data:vBN+sbaH0g4H9zvlOgCZI8L1dNewHnzqMb79w3Wvg01XRQqQWmyX+A==,iv:6Z408C+KKCTmP0oCDiYA2p49hyArBKrBMTyBE+Bqp/s=,tag:fYerNn6nBOTQtuN1PqPANg==,type:str]
+            tokens:
+                magma-docusaurus-bot: ENC[AES256_GCM,data:G/KRaZ8YKbTzGetff0/3lXNAakj+yPX2cZfK1sSuuRfOfQSNBeTffA==,iv:nuTQsZthSK5ie+M1iuz6wP+ED91QuolK5Ib6+MZtsYk=,tag:T240VJNsJ1+Vc8Z11djhHQ==,type:str]
+        swaggerhub.com:
+            password: ENC[AES256_GCM,data:mlPtpYtFtdueu3aPU5ZnBQIuDOw=,iv:jPXUIzeWOKEt4P+sJUg+raW1XmusVgQh6MOgCefbgPk=,tag:ynD3ySJx9nbbJAe/qIQ7jw==,type:str]
+            api_key: ENC[AES256_GCM,data:9rObxLklCYP2/aJPh6oO8m+CJkHV/iwvI/Jw4qJzWScfc9b6,iv:2lvPbJLSsux3m75mOIsQsDkC0vC6OEuvJi8PT2uAn9g=,tag:6vpCIsQvYLxj508EkaxuwA==,type:str]
 sops:
     kms: []
     gcp_kms: []
     azure_kv: []
     hc_vault: []
-    lastmodified: '2021-04-29T00:22:23Z'
-    mac: ENC[AES256_GCM,data:biuduGRnOdTA9Nnx54La4e98/biPVMUJxAuV+zcD3h7NybSX9W6A1PAStyPp+DuVBkHNN+RB3buglGeEf6xqdKxqmPLHGjoCEXrC6LiSjcLT/R9lKkVWrjWtE7Rjzo6nVSTxl1RTs4aX/dAqj062Fp2xPAGjXu+l4ctZeFa4k2g=,iv:6em15XVBfVa1C5dFtHm+MwkiGYzuKXK5URm/s2cUSUU=,tag:3wOmRqfMax6K2M6lG6STfw==,type:str]
+    lastmodified: '2021-07-23T01:26:48Z'
+    mac: ENC[AES256_GCM,data:RnlzrPqArmf20Omb5dGsvmxEDqtaNoC7sX+rsKj9L3MhL9iSJjSNQHjhq3hlstpX0XSzV2H4VQ/RPWsk3CkfNRM31IMUVEL2/XqpsnV5Jt0uVxOw/VcJlso8t4ngL4QGm8JzYvrqbGAUYc2yy7CeSt+MAq0li++1W8eLnJqWE4U=,iv:R4m9Ar7EvYUE+1n3iR9UMtOObg2eSCsbrQ0YrWjBuWs=,tag:2jP00x4rpDxQZA/b2Kjtbg==,type:str]
     pgp:
     -   created_at: '2021-04-29T00:05:39Z'
         enc: |


### PR DESCRIPTION
<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

PGP key and passphrase is stored in lastpass. After injecting PGP key locally, can use sops as follows

```bash
sops secrets/ci.yaml  # edit

sops -d secrets/ci.yaml  # view
```

Stored in encrypted yaml, but unencrypted looks like this

```yaml
magma-bot:
  about: Bot account for automating Magma actions
  email: bots@magmacore.org
  accounts:
    gmail.com:
      password: XXX
    github.com:
      username: magma-bot
      password: XXX
      tokens:
        magma-docusaurus-bot: XXX
    swaggerhub.com:
      password: XXX
      api_key: XXX
```


## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->