### PR TITLE
fix(mme): sentry_config was not set in OAI dockerfiles

### DIFF
--- a/ci-scripts/docker/Dockerfile.mme.ci.rhel8
+++ b/ci-scripts/docker/Dockerfile.mme.ci.rhel8
@@ -21,6 +21,35 @@ RUN export PKG_CONFIG_PATH=$PKG_CONFIG_PATH:/usr/local/lib/pkgconfig/ && \
     make build_oai && \
     make build_sctpd
 
+# Prepare config file
+RUN yum install -y python3-pip && \
+    pip3 install jinja2-cli && \
+    cd $MAGMA_ROOT/lte/gateway/docker/mme/configs/ && \
+    echo -e '{ \n' \
+    '"realm": "magma.com",	 \n'\
+    '"use_stateless": "", \n'\
+    '"conf_dir": "/magma-mme/etc", \n'\
+    '"hss_hostname": "hss", \n'\
+    '"mcc": "001", \n'\
+    '"mnc": "01", \n'\
+    '"mmeGid": "1", \n'\
+    '"mmeCode": "1", \n'\
+    '"tac": "1", \n'\
+    '"non_eps_service_control": "OFF", \n'\
+    '"csfb_mcc": "001", \n'\
+    '"csfb_mnc": "01", \n'\
+    '"lac": "1", \n'\
+    '"s1ap_iface_name": "eth0", \n'\
+    '"s1ap_ip": "192.168.61.133/24", \n'\
+    '"s11_iface_name": "eth0", \n'\
+    '"mme_s11_ip": "192.168.61.133/24", \n'\
+    '"oai_log_level": "INFO", \n'\
+    '"remote_sgw_ip": "192.168.61.130", \n'\
+    '"attachedEnodebTacs": [], \n'\
+    '"attached_enodeb_tacs": [1] }' \
+    > mme_vars.json && \
+    jinja2 ../../../configs/templates/mme.conf.template mme_vars.json --format=json  > mme.conf
+
 ################################################################
 # Target Image
 ################################################################

--- a/ci-scripts/docker/Dockerfile.mme.ci.rhel8
+++ b/ci-scripts/docker/Dockerfile.mme.ci.rhel8
@@ -22,9 +22,7 @@ RUN export PKG_CONFIG_PATH=$PKG_CONFIG_PATH:/usr/local/lib/pkgconfig/ && \
     make build_sctpd
 
 # Prepare config file
-RUN yum install -y python3-pip && \
-    pip3 install jinja2-cli && \
-    cd $MAGMA_ROOT/lte/gateway/docker/mme/configs/ && \
+RUN cd $MAGMA_ROOT/lte/gateway/docker/mme/configs/ && \
     echo -e '{ \n' \
     '"realm": "magma.com",	 \n'\
     '"use_stateless": "", \n'\

--- a/ci-scripts/docker/Dockerfile.mme.ci.ubuntu18
+++ b/ci-scripts/docker/Dockerfile.mme.ci.ubuntu18
@@ -21,9 +21,7 @@ RUN cd $MAGMA_ROOT/lte/gateway && \
     make build_sctpd
 
 # Prepare config file
-RUN apt-get install -y python3-pip && \
-    pip3 install jinja2-cli && \
-    cd $MAGMA_ROOT/lte/gateway/docker/mme/configs/ && \
+RUN cd $MAGMA_ROOT/lte/gateway/docker/mme/configs/ && \
     echo '{ \n' \
     '"realm": "magma.com",	 \n'\
     '"use_stateless": "", \n'\

--- a/ci-scripts/docker/Dockerfile.mme.ci.ubuntu18
+++ b/ci-scripts/docker/Dockerfile.mme.ci.ubuntu18
@@ -20,6 +20,35 @@ RUN cd $MAGMA_ROOT/lte/gateway && \
     make build_oai && \
     make build_sctpd
 
+# Prepare config file
+RUN apt-get install -y python3-pip && \
+    pip3 install jinja2-cli && \
+    cd $MAGMA_ROOT/lte/gateway/docker/mme/configs/ && \
+    echo '{ \n' \
+    '"realm": "magma.com",	 \n'\
+    '"use_stateless": "", \n'\
+    '"conf_dir": "/magma-mme/etc", \n'\
+    '"hss_hostname": "hss", \n'\
+    '"mcc": "001", \n'\
+    '"mnc": "01", \n'\
+    '"mmeGid": "1", \n'\
+    '"mmeCode": "1", \n'\
+    '"tac": "1", \n'\
+    '"non_eps_service_control": "OFF", \n'\
+    '"csfb_mcc": "001", \n'\
+    '"csfb_mnc": "01", \n'\
+    '"lac": "1", \n'\
+    '"s1ap_iface_name": "eth0", \n'\
+    '"s1ap_ip": "192.168.61.133/24", \n'\
+    '"s11_iface_name": "eth0", \n'\
+    '"mme_s11_ip": "192.168.61.133/24", \n'\
+    '"oai_log_level": "INFO", \n'\
+    '"remote_sgw_ip": "192.168.61.130", \n'\
+    '"attachedEnodebTacs": [], \n'\
+    '"attached_enodeb_tacs": [1] }' \
+    > mme_vars.json && \
+    jinja2 ../../../configs/templates/mme.conf.template mme_vars.json --format=json  > mme.conf
+
 ################################################################
 # Target Image
 ################################################################

--- a/lte/gateway/configs/templates/mme.conf.template
+++ b/lte/gateway/configs/templates/mme.conf.template
@@ -324,9 +324,11 @@ MME :
    );
 
    SENTRY_CONFIG = {
+     {% if sentry_config %}
        # Sentry.io configuration sent from the Orc8r
        SAMPLE_RATE      = {{ sentry_config.sample_rate }};
        UPLOAD_MME_LOG   = "{{ sentry_config.upload_mme_log }}";
        URL_NATIVE       = "{{ sentry_config.url_native }}"
+     {%- endif %}
    }
 };


### PR DESCRIPTION
Signed-off-by: Raphael Defosseux <raphael.defosseux@openairinterface.org>

## Summary

I was not using `jinja` template for CI-PR runs `dockerfiles`
But it is used in the full-from-scratch `dockerfiles` and this morning `master` branch checks failed because of this.

See [failed run today](https://jenkins-oai.eurecom.fr/job/MAGMA-MME-production/5117/).

What I've added:

- a check in template for existence of `sentry_config`
- jinja calls in CI-PR runs `dockerfiles` to avoid the same kind of error.

## Test Plan

I've tested manually with and without `sentry_config` the `jinja` command.
Normally the `OAI` CI pipeline will finalize the fix.

## Additional Information

- [ ] This change is backwards-breaking

