### PR TITLE
fix(mme): a few compilation warnings

### DIFF
--- a/lte/gateway/c/core/oai/tasks/nas/ies/MessageType.c
+++ b/lte/gateway/c/core/oai/tasks/nas/ies/MessageType.c
@@ -17,6 +17,7 @@
 
 #include <stdint.h>
 
+#include "assertions.h"
 #include "MessageType.h"
 
 //------------------------------------------------------------------------------

--- a/lte/gateway/c/core/oai/tasks/nas/ies/SecurityHeaderType.c
+++ b/lte/gateway/c/core/oai/tasks/nas/ies/SecurityHeaderType.c
@@ -17,6 +17,7 @@
 
 #include <stdint.h>
 
+#include "assertions.h"
 #include "SecurityHeaderType.h"
 
 //------------------------------------------------------------------------------

--- a/lte/gateway/c/core/oai/tasks/udp/udp_primitives_server.c
+++ b/lte/gateway/c/core/oai/tasks/udp/udp_primitives_server.c
@@ -176,7 +176,7 @@ static void udp_server_receive_and_process(
   }
 }
 
-static void udp_socket_handler(zloop_t* loop, zmq_pollitem_t* item, void* arg) {
+static int udp_socket_handler(zloop_t* loop, zmq_pollitem_t* item, void* arg) {
   struct udp_socket_desc_s* udp_sock_p = NULL;
 
   pthread_mutex_lock(&udp_socket_list_mutex);
@@ -190,6 +190,8 @@ static void udp_socket_handler(zloop_t* loop, zmq_pollitem_t* item, void* arg) {
   }
 
   pthread_mutex_unlock(&udp_socket_list_mutex);
+
+  return 0;
 }
 
 //------------------------------------------------------------------------------


### PR DESCRIPTION
Signed-off-by: Raphael Defosseux <raphael.defosseux@openairinterface.org>

## Summary

Another round of code clean-up for compilation warnings inserted by [this PR](https://github.com/magma/magma/pull/8122)

2 could have been easily detected by contributor --> `cpplint` showed [them](https://github.com/magma/magma/pull/8122/checks?check_run_id=3090570827) 

```
Warning: lte/gateway/c/core/oai/tasks/nas/ies/SecurityHeaderType.c:26:3: warning: implicit declaration of function 'Fatal' [-Wimplicit-function-declaration]
```

the last one: `zloop_fn` has for prototype:

```c
// Callback function for reactor events (low-level)
typedef int (zloop_fn) (
    zloop_t *loop, zmq_pollitem_t *item, void *arg);
```

## Test Plan

Let the CI does its magic.

## Additional Information

- [ ] This change is backwards-breaking
