### PR TITLE
style: Apply formatting scripts to PipelineD

### DIFF
--- a/lte/gateway/python/magma/pipelined/app/classifier.py
+++ b/lte/gateway/python/magma/pipelined/app/classifier.py
@@ -234,7 +234,7 @@ class Classifier(MagmaController):
         )
         future.add_done_callback(
                               lambda future: self.loop.call_soon_threadsafe(
-                              self._paging_msg_sent_callback, future,
+                                  self._paging_msg_sent_callback, future,
                               ),
         )
 

--- a/lte/gateway/python/magma/pipelined/app/enforcement.py
+++ b/lte/gateway/python/magma/pipelined/app/enforcement.py
@@ -178,10 +178,10 @@ class EnforcementController(PolicyMixin, RestartMixin, MagmaController):
             try:
                 flow_adds.extend(
                     self._get_classify_rule_flow_msgs(
-                    imsi, msisdn, uplink_tunnel, ip_addr, apn_ambr, flow, rule_num, priority,
-                    rule.qos, rule.hard_timeout, rule.id, rule.app_name,
-                    rule.app_service_type, self.next_main_table,
-                    version, self._qos_mgr, self._enforcement_stats_tbl, shard_id,  rule.he.urls, local_f_teid_ng,
+                        imsi, msisdn, uplink_tunnel, ip_addr, apn_ambr, flow, rule_num, priority,
+                        rule.qos, rule.hard_timeout, rule.id, rule.app_name,
+                        rule.app_service_type, self.next_main_table,
+                        version, self._qos_mgr, self._enforcement_stats_tbl, shard_id, rule.he.urls, local_f_teid_ng,
                     ),
                 )
 

--- a/lte/gateway/python/magma/pipelined/app/gy.py
+++ b/lte/gateway/python/magma/pipelined/app/gy.py
@@ -44,11 +44,14 @@ class GYController(PolicyMixin, RestartMixin, MagmaController):
         self._config = kwargs['config']
         self.tbl_num = self._service_manager.get_table_num(self.APP_NAME)
         self.next_main_table = self._service_manager.get_next_table_num(
-            self.APP_NAME)
+            self.APP_NAME,
+        )
         self.next_service_table = self._service_manager.get_next_table_num(
-            EnforcementStatsController.APP_NAME)
+            EnforcementStatsController.APP_NAME,
+        )
         self._enforcement_stats_tbl = self._service_manager.get_table_num(
-            EnforcementStatsController.APP_NAME)
+            EnforcementStatsController.APP_NAME,
+        )
         self.loop = kwargs['loop']
         self._msg_hub = MessageHub(self.logger)
         self._internal_ip_allocator = kwargs['internal_ip_allocator']
@@ -68,7 +71,7 @@ class GYController(PolicyMixin, RestartMixin, MagmaController):
                 self._enforcement_stats_tbl,
                 self._service_manager.get_table_num(EGRESS),
                 self._redirect_scratch,
-                self._session_rule_version_mapper
+                self._session_rule_version_mapper,
             )
         if self._setup_type == 'CWF':
             self._redirect_manager.set_cwf_args(
@@ -76,7 +79,7 @@ class GYController(PolicyMixin, RestartMixin, MagmaController):
                 arp=kwargs['app_futures']['arpd'],
                 mac_rewrite=self._mac_rewr,
                 bridge_name=kwargs['config']['bridge_name'],
-                egress_table=self._service_manager.get_table_num(EGRESS)
+                egress_table=self._service_manager.get_table_num(EGRESS),
             )
 
     def initialize_on_connect(self, datapath):
@@ -130,8 +133,10 @@ class GYController(PolicyMixin, RestartMixin, MagmaController):
         """
         match = MagmaMatch(imsi=encode_imsi(imsi))
         flows.delete_flow(self._datapath, self.tbl_num, match)
-        self._redirect_manager.deactivate_flows_for_subscriber(self._datapath,
-                                                               imsi)
+        self._redirect_manager.deactivate_flows_for_subscriber(
+            self._datapath,
+            imsi,
+        )
         self._qos_mgr.remove_subscriber_qos(imsi)
         self._remove_he_flows(ip_addr, None)
 
@@ -150,15 +155,21 @@ class GYController(PolicyMixin, RestartMixin, MagmaController):
             return
         cookie, mask = (num, flows.OVS_COOKIE_MATCH_ALL)
         match = MagmaMatch(imsi=encode_imsi(imsi))
-        flows.delete_flow(self._datapath, self.tbl_num, match,
-                          cookie=cookie, cookie_mask=mask)
-        self._redirect_manager.deactivate_flow_for_rule(self._datapath, imsi,
-                                                        num)
+        flows.delete_flow(
+            self._datapath, self.tbl_num, match,
+            cookie=cookie, cookie_mask=mask,
+        )
+        self._redirect_manager.deactivate_flow_for_rule(
+            self._datapath, imsi,
+            num,
+        )
         self._qos_mgr.remove_subscriber_qos(imsi, num)
         self._remove_he_flows(ip_addr, rule_id)
 
-    def _install_flow_for_rule(self, imsi, msisdn:bytes, uplink_tunnel: int,
-                               ip_addr, apn_ambr, rule, version, shard_id, local_f_teid_ng: int):
+    def _install_flow_for_rule(
+        self, imsi, msisdn: bytes, uplink_tunnel: int,
+        ip_addr, apn_ambr, rule, version, shard_id, local_f_teid_ng: int,
+    ):
         """
         Install a flow to get stats for a particular rule. Flows will match on
         IMSI, cookie (the rule num), in/out direction
@@ -174,15 +185,19 @@ class GYController(PolicyMixin, RestartMixin, MagmaController):
             return RuleModResult.SUCCESS
 
         if not rule.flow_list:
-            self.logger.error('The flow list for imsi %s, rule.id - %s'
-                              'is empty, this shoudn\'t happen', imsi, rule.id)
+            self.logger.error(
+                'The flow list for imsi %s, rule.id - %s'
+                'is empty, this shoudn\'t happen', imsi, rule.id,
+            )
             return RuleModResult.FAILURE
 
         flow_adds = []
         try:
-            flow_adds = self._get_rule_match_flow_msgs(imsi, msisdn, uplink_tunnel,
-                                                       ip_addr, apn_ambr, rule,
-                                                       version, shard_id, local_f_teid_ng)
+            flow_adds = self._get_rule_match_flow_msgs(
+                imsi, msisdn, uplink_tunnel,
+                ip_addr, apn_ambr, rule,
+                version, shard_id, local_f_teid_ng,
+            )
         except FlowMatchError:
             return RuleModResult.FAILURE
 
@@ -213,7 +228,8 @@ class GYController(PolicyMixin, RestartMixin, MagmaController):
         flows.add_resubmit_next_service_flow(
             datapath, self.tbl_num, match, [],
             priority=flows.MINIMUM_PRIORITY,
-            resubmit_table=self.next_main_table)
+            resubmit_table=self.next_main_table,
+        )
 
     def _install_redirect_flow(self, imsi, ip_addr, rule, version):
         rule_num = self._rule_mapper.get_or_create_rule_num(rule.id)
@@ -231,19 +247,22 @@ class GYController(PolicyMixin, RestartMixin, MagmaController):
             rule=rule,
             rule_num=rule_num,
             rule_version=version,
-            priority=priority)
+            priority=priority,
+        )
         try:
             if self._setup_type == 'CWF':
                 self._redirect_manager.setup_cwf_redirect(
-                    self._datapath, self.loop, redirect_request)
+                    self._datapath, self.loop, redirect_request,
+                )
             else:
                 self._redirect_manager.setup_lte_redirect(
-                    self._datapath, self.loop, redirect_request)
+                    self._datapath, self.loop, redirect_request,
+                )
             return RuleModResult.SUCCESS
         except RedirectException as err:
             self.logger.error(
                 'Redirect Exception for imsi %s, rule.id - %s : %s',
-                imsi, rule.id, err
+                imsi, rule.id, err,
             )
             return RuleModResult.FAILURE
 
@@ -260,12 +279,15 @@ class GYController(PolicyMixin, RestartMixin, MagmaController):
         msg = flows.get_add_resubmit_next_service_flow_msg(
             datapath, self.tbl_num, match, [],
             priority=flows.MINIMUM_PRIORITY,
-            resubmit_table=self.next_main_table)
+            resubmit_table=self.next_main_table,
+        )
 
         return {self.tbl_num: [msg]}
 
-    def _get_rule_match_flow_msgs(self, imsi, msisdn: bytes, uplink_tunnel: int, ip_addr, apn_ambr, rule,
-                                  version, shard_id: int, local_f_teid_ng: int):
+    def _get_rule_match_flow_msgs(
+        self, imsi, msisdn: bytes, uplink_tunnel: int, ip_addr, apn_ambr, rule,
+        version, shard_id: int, local_f_teid_ng: int,
+    ):
         """
         Get flow msgs to get stats for a particular rule. Flows will match on
         IMSI, cookie (the rule num), in/out direction
@@ -283,16 +305,20 @@ class GYController(PolicyMixin, RestartMixin, MagmaController):
         flow_adds = []
         for flow in rule.flow_list:
             try:
-                flow_adds.extend(self._get_classify_rule_flow_msgs(
-                    imsi, msisdn, uplink_tunnel, ip_addr, apn_ambr, flow, rule_num, priority,
-                    rule.qos, rule.hard_timeout, rule.id, rule.app_name,
-                    rule.app_service_type, self.next_service_table,
-                    version, self._qos_mgr, self._enforcement_stats_tbl, shard_id, local_f_teid_ng))
+                flow_adds.extend(
+                    self._get_classify_rule_flow_msgs(
+                        imsi, msisdn, uplink_tunnel, ip_addr, apn_ambr, flow, rule_num, priority,
+                        rule.qos, rule.hard_timeout, rule.id, rule.app_name,
+                        rule.app_service_type, self.next_service_table,
+                        version, self._qos_mgr, self._enforcement_stats_tbl, shard_id, local_f_teid_ng,
+                    ),
+                )
 
             except FlowMatchError as err:  # invalid match
                 self.logger.error(
                     "Failed to get flow msg '%s' for subscriber %s: %s",
-                    rule.id, imsi, err)
+                    rule.id, imsi, err,
+                )
                 raise err
         return flow_adds
 

--- a/lte/gateway/python/magma/pipelined/app/ipfix.py
+++ b/lte/gateway/python/magma/pipelined/app/ipfix.py
@@ -214,15 +214,15 @@ class IPFIXController(MagmaController):
             pdp = 1
             actions = [
                 parser.NXActionSample2(
-                probability=self.ipfix_config.probability,
-                collector_set_id=self.ipfix_config.collector_set_id,
-                obs_domain_id=self.ipfix_config.obs_domain_id,
-                obs_point_id=self.ipfix_config.obs_point_id,
-                apn_mac_addr=[0, 0, 0, 0, 0, 0],
-                msisdn="defau".encode('ascii'),
-                apn_name="default".encode('ascii'),
-                pdp_start_epoch=pdp.to_bytes(8, byteorder='little'),
-                sampling_port=self.ipfix_config.sampling_port,
+                    probability=self.ipfix_config.probability,
+                    collector_set_id=self.ipfix_config.collector_set_id,
+                    obs_domain_id=self.ipfix_config.obs_domain_id,
+                    obs_point_id=self.ipfix_config.obs_point_id,
+                    apn_mac_addr=[0, 0, 0, 0, 0, 0],
+                    msisdn="defau".encode('ascii'),
+                    apn_name="default".encode('ascii'),
+                    pdp_start_epoch=pdp.to_bytes(8, byteorder='little'),
+                    sampling_port=self.ipfix_config.sampling_port,
                 ),
             ]
             flows.add_drop_flow(
@@ -265,15 +265,15 @@ class IPFIXController(MagmaController):
 
         actions = [
             parser.NXActionSample2(
-            probability=self.ipfix_config.probability,
-            collector_set_id=self.ipfix_config.collector_set_id,
-            obs_domain_id=self.ipfix_config.obs_domain_id,
-            obs_point_id=self.ipfix_config.obs_point_id,
-            apn_mac_addr=apn_mac_bytes,
-            msisdn=msisdn.encode('ascii'),
-            apn_name=apn_name.encode('ascii'),
-            pdp_start_epoch=pdp_start_time.to_bytes(8, byteorder='little'),
-            sampling_port=self.ipfix_config.sampling_port,
+                probability=self.ipfix_config.probability,
+                collector_set_id=self.ipfix_config.collector_set_id,
+                obs_domain_id=self.ipfix_config.obs_domain_id,
+                obs_point_id=self.ipfix_config.obs_point_id,
+                apn_mac_addr=apn_mac_bytes,
+                msisdn=msisdn.encode('ascii'),
+                apn_name=apn_name.encode('ascii'),
+                pdp_start_epoch=pdp_start_time.to_bytes(8, byteorder='little'),
+                sampling_port=self.ipfix_config.sampling_port,
             ),
         ]
 

--- a/lte/gateway/python/magma/pipelined/app/policy_mixin.py
+++ b/lte/gateway/python/magma/pipelined/app/policy_mixin.py
@@ -25,10 +25,10 @@ from magma.pipelined.imsi import encode_imsi
 from magma.pipelined.openflow import flows
 from magma.pipelined.openflow.messages import MsgChannel
 from magma.pipelined.openflow.registers import (
+    NG_SESSION_ID_REG,
     RULE_NUM_REG,
     RULE_VERSION_REG,
     SCRATCH_REGS,
-    NG_SESSION_ID_REG,
 )
 from magma.pipelined.policy_converters import (
     FlowMatchError,
@@ -61,7 +61,8 @@ class PolicyMixin(metaclass=ABCMeta):
         self._rule_mapper = kwargs['rule_id_mapper']
         self._setup_type = kwargs['config']['setup_type']
         self._session_rule_version_mapper = kwargs[
-            'session_rule_version_mapper']
+            'session_rule_version_mapper'
+        ]
         if 'proxy' in kwargs['app_futures']:
             self.proxy_controller_fut = kwargs['app_futures']['proxy']
         else:
@@ -83,37 +84,46 @@ class PolicyMixin(metaclass=ABCMeta):
         if self._datapath is None:
             self.logger.error('Datapath not initialized for adding flows')
             return ActivateFlowsResult(
-                policy_results=[RuleModResult(
-                    rule_id=policy.rule.id,
-                    version=policy.version,
-                    result=RuleModResult.FAILURE,
-                ) for policy in policies],
+                policy_results=[
+                    RuleModResult(
+                        rule_id=policy.rule.id,
+                        version=policy.version,
+                        result=RuleModResult.FAILURE,
+                    ) for policy in policies
+                ],
             )
         policy_results = []
         for policy in policies:
-            res = self._install_flow_for_rule(imsi, msisdn, uplink_tunnel,
-                                              ip_addr, apn_ambr, policy.rule,
-                                              policy.version, shard_id, local_f_teid_ng)
+            res = self._install_flow_for_rule(
+                imsi, msisdn, uplink_tunnel,
+                ip_addr, apn_ambr, policy.rule,
+                policy.version, shard_id, local_f_teid_ng,
+            )
             policy_results.append(RuleModResult(rule_id=policy.rule.id, version=policy.version, result=res))
 
         # Install a base flow for when no rule is matched.
         self._install_default_flow_for_subscriber(imsi, ip_addr, local_f_teid_ng)
-        
+
         return ActivateFlowsResult(
             policy_results=policy_results,
         )
 
-    def _remove_he_flows(self, ip_addr: IPAddress, rule_id: str = "",
-                         rule_num: int = -1):
+    def _remove_he_flows(
+        self, ip_addr: IPAddress, rule_id: str = "",
+        rule_num: int = -1,
+    ):
         if self.proxy_controller:
-            self.proxy_controller.remove_subscriber_he_flows(ip_addr, rule_id,
-                                                             rule_num)
+            self.proxy_controller.remove_subscriber_he_flows(
+                ip_addr, rule_id,
+                rule_num,
+            )
 
     def _wait_for_rule_responses(self, imsi, ip_addr, rule, chan):
         def fail(err):
             self.logger.error(
                 "Failed to install rule %s for subscriber %s: %s",
-                rule.id, imsi, err)
+                rule.id, imsi, err,
+            )
             self._deactivate_flow_for_rule(imsi, ip_addr, rule.id)
             return RuleModResult.FAILURE
 
@@ -139,10 +149,12 @@ class PolicyMixin(metaclass=ABCMeta):
             if not result.ok():
                 return fail(result.exception())
 
-    def _get_classify_rule_flow_msgs(self, imsi, msisdn: bytes, uplink_tunnel: int, ip_addr, apn_ambr, flow, rule_num,
-                                     priority, qos, hard_timeout, rule_id, app_name,
-                                     app_service_type, next_table, version, qos_mgr,
-                                     copy_table, _, urls: List[str] = None, local_f_teid_ng: int = 0):
+    def _get_classify_rule_flow_msgs(
+        self, imsi, msisdn: bytes, uplink_tunnel: int, ip_addr, apn_ambr, flow, rule_num,
+        priority, qos, hard_timeout, rule_id, app_name,
+        app_service_type, next_table, version, qos_mgr,
+        copy_table, _, urls: List[str] = None, local_f_teid_ng: int = 0,
+    ):
         """
         Install a flow from a rule. If the flow action is DENY, then the flow
         will drop the packet. Otherwise, the flow classifies the packet with
@@ -153,15 +165,20 @@ class PolicyMixin(metaclass=ABCMeta):
         flow_match.imsi = encode_imsi(imsi)
         flow_match_actions, instructions = self._get_action_for_rule(
             flow, rule_num, imsi, ip_addr, apn_ambr, qos, rule_id, version, qos_mgr,
-            local_f_teid_ng)
+            local_f_teid_ng,
+        )
         msgs = []
         if app_name:
             # We have to allow initial traffic to pass through, before it gets
             # classified by DPI, flow match set app_id to unclassified
             flow_match.app_id = UNCLASSIFIED_PROTO_ID
             passthrough_actions = flow_match_actions + \
-                [parser.NXActionRegLoad2(dst=SCRATCH_REGS[1],
-                                         value=IGNORE_STATS)]
+                [
+                    parser.NXActionRegLoad2(
+                        dst=SCRATCH_REGS[1],
+                        value=IGNORE_STATS,
+                    ),
+                ]
             msgs.append(
                 flows.get_add_resubmit_current_service_flow_msg(
                     self._datapath,
@@ -172,7 +189,8 @@ class PolicyMixin(metaclass=ABCMeta):
                     priority=Utils.UNCLASSIFIED_ALLOW_PRIORITY,
                     cookie=rule_num,
                     copy_table=copy_table,
-                    resubmit_table=next_table)
+                    resubmit_table=next_table,
+                ),
             )
             flow_match.app_id = get_app_id(
                 PolicyRule.AppName.Name(app_name),
@@ -182,30 +200,38 @@ class PolicyMixin(metaclass=ABCMeta):
         # For DROP flow just send to stats table, it'll get dropped there
         if flow.action == flow.DENY:
             flow_match_actions = flow_match_actions + \
-                [parser.NXActionRegLoad2(dst=SCRATCH_REGS[1],
-                                         value=DROP_FLOW_STATS)]
-            msgs.append(flows.get_add_resubmit_current_service_flow_msg(
-                self._datapath,
-                self.tbl_num,
-                flow_match,
-                flow_match_actions,
-                hard_timeout=hard_timeout,
-                priority=priority,
-                cookie=rule_num,
-                resubmit_table=copy_table)
+                [
+                    parser.NXActionRegLoad2(
+                        dst=SCRATCH_REGS[1],
+                        value=DROP_FLOW_STATS,
+                    ),
+                ]
+            msgs.append(
+                flows.get_add_resubmit_current_service_flow_msg(
+                    self._datapath,
+                    self.tbl_num,
+                    flow_match,
+                    flow_match_actions,
+                    hard_timeout=hard_timeout,
+                    priority=priority,
+                    cookie=rule_num,
+                    resubmit_table=copy_table,
+                ),
             )
         else:
-            msgs.append(flows.get_add_resubmit_current_service_flow_msg(
-                self._datapath,
-                self.tbl_num,
-                flow_match,
-                flow_match_actions,
-                instructions=instructions,
-                hard_timeout=hard_timeout,
-                priority=priority,
-                cookie=rule_num,
-                copy_table=copy_table,
-                resubmit_table=next_table)
+            msgs.append(
+                flows.get_add_resubmit_current_service_flow_msg(
+                    self._datapath,
+                    self.tbl_num,
+                    flow_match,
+                    flow_match_actions,
+                    instructions=instructions,
+                    hard_timeout=hard_timeout,
+                    priority=priority,
+                    cookie=rule_num,
+                    copy_table=copy_table,
+                    resubmit_table=next_table,
+                ),
             )
 
         if self.proxy_controller:
@@ -215,12 +241,15 @@ class PolicyMixin(metaclass=ABCMeta):
 
             proxy_msgs = self.proxy_controller.get_subscriber_he_flows(
                 rule_id, direction, ue_ip, uplink_tunnel, ip_dst, rule_num,
-                urls, imsi, msisdn)
+                urls, imsi, msisdn,
+            )
             msgs.extend(proxy_msgs)
         return msgs
 
-    def _get_action_for_rule(self, flow, rule_num, imsi, ip_addr,
-                             apn_ambr, qos, rule_id, version, qos_mgr, local_f_teid_ng):
+    def _get_action_for_rule(
+        self, flow, rule_num, imsi, ip_addr,
+        apn_ambr, qos, rule_id, version, qos_mgr, local_f_teid_ng,
+    ):
         """
         Returns an action instructions list to be applied for a specific flow.
         If qos or apn_ambr are set, the appropriate action is returned based
@@ -253,11 +282,14 @@ class PolicyMixin(metaclass=ABCMeta):
                 qos_info = QosInfo(gbr=qos.gbr_dl, mbr=mbr_dl)
 
         if qos_info or ambr:
-            cleanup_rule_func = lambda: self._invalidate_rule_version(imsi,
-                                                                      ip_addr, rule_id)
+            cleanup_rule_func = lambda: self._invalidate_rule_version(
+                imsi,
+                ip_addr, rule_id,
+            )
             action, inst = qos_mgr.add_subscriber_qos(
                 imsi, ip_addr.address.decode('utf8'), ambr, rule_num, d,
-                qos_info, cleanup_rule_func)
+                qos_info, cleanup_rule_func,
+            )
 
             self.logger.debug("adding Actions %s instruction %s ", action, inst)
             if action:
@@ -267,17 +299,21 @@ class PolicyMixin(metaclass=ABCMeta):
                 instructions.append(inst)
 
         actions.extend(
-            [parser.NXActionRegLoad2(dst=RULE_NUM_REG, value=rule_num),
-             parser.NXActionRegLoad2(dst=RULE_VERSION_REG, value=version),
-             parser.NXActionRegLoad2(dst=NG_SESSION_ID_REG, value=local_f_teid_ng)
-             ])
+            [
+                parser.NXActionRegLoad2(dst=RULE_NUM_REG, value=rule_num),
+                parser.NXActionRegLoad2(dst=RULE_VERSION_REG, value=version),
+                parser.NXActionRegLoad2(dst=NG_SESSION_ID_REG, value=local_f_teid_ng),
+            ],
+        )
         return actions, instructions
 
     # this function is used to schedule the rule removal in rule cleanup.
     def _invalidate_rule_version(self, imsi, ip_addr, rule_id):
-        self.logger.debug("Invalidate rule: imsi: %s ip: %s rule_id %s", imsi,
-                          ip_addr.address.decode('utf8'),
-                          rule_id)
+        self.logger.debug(
+            "Invalidate rule: imsi: %s ip: %s rule_id %s", imsi,
+            ip_addr.address.decode('utf8'),
+            rule_id,
+        )
 
         self._session_rule_version_mapper.save_version(imsi, ip_addr, rule_id, -1)
 
@@ -310,12 +346,15 @@ class PolicyMixin(metaclass=ABCMeta):
 
         return {self.tbl_num: msg_list}
 
-    def _get_policy_flows(self, imsi, msisdn, uplink_tunnel, ip_addr, apn_ambr,
-                          policy, shard_id):
+    def _get_policy_flows(
+        self, imsi, msisdn, uplink_tunnel, ip_addr, apn_ambr,
+        policy, shard_id,
+    ):
         msg_list = []
         # As the versions are managed by sessiond, save state here
         self._service_manager.session_rule_version_mapper.save_version(
-            imsi, ip_addr, policy.rule.id, policy.version)
+            imsi, ip_addr, policy.rule.id, policy.version,
+        )
         try:
             if policy.rule.redirect.support == policy.rule.redirect.ENABLED:
                 return msg_list
@@ -344,12 +383,16 @@ class PolicyMixin(metaclass=ABCMeta):
         if self.proxy_controller_fut and self.proxy_controller_fut.done():
             if not self.proxy_controller:
                 self.proxy_controller = self.proxy_controller_fut.result()
-        self.logger.info("Initialized proxy_controller %s",
-                         self.proxy_controller)
+        self.logger.info(
+            "Initialized proxy_controller %s",
+            self.proxy_controller,
+        )
 
     @abstractmethod
-    def _install_flow_for_rule(self, imsi, msisdn: bytes, uplink_tunnel: int,
-                               ip_addr, apn_ambr, rule, version, shard_id: int, local_f_teid_ng):
+    def _install_flow_for_rule(
+        self, imsi, msisdn: bytes, uplink_tunnel: int,
+        ip_addr, apn_ambr, rule, version, shard_id: int, local_f_teid_ng,
+    ):
         """
         Install a flow given a rule. Subclass should implement this.
 

--- a/lte/gateway/python/magma/pipelined/app/restart_mixin.py
+++ b/lte/gateway/python/magma/pipelined/app/restart_mixin.py
@@ -126,8 +126,8 @@ class RestartMixin(metaclass=ABCMeta):
                 )
                 msg_list.append(
                     flows.get_delete_flow_msg(
-                    self._datapath, tbl, match, cookie=flow.cookie,
-                    cookie_mask=flows.OVS_COOKIE_MATCH_ALL,
+                        self._datapath, tbl, match, cookie=flow.cookie,
+                        cookie_mask=flows.OVS_COOKIE_MATCH_ALL,
                     ),
                 )
         if msg_list:

--- a/lte/gateway/python/magma/pipelined/bridge_util.py
+++ b/lte/gateway/python/magma/pipelined/bridge_util.py
@@ -327,7 +327,7 @@ class BridgeTools:
                     cls.TABLE_NUM_REGEX,
                     lambda match: 'table={}'.format(
                         annotated_table_num(
-                        match.group(1),
+                            match.group(1),
                         ),
                     ),
                 ),

--- a/lte/gateway/python/magma/pipelined/main.py
+++ b/lte/gateway/python/magma/pipelined/main.py
@@ -29,7 +29,7 @@ from magma.pipelined.app import of_rest_server
 from magma.pipelined.app.he import PROXY_PORT_NAME
 from magma.pipelined.bridge_util import BridgeTools
 from magma.pipelined.check_quota_server import run_flask
-from magma.pipelined.datapath_setup import tune_datapath, setup_masquerade_rule
+from magma.pipelined.datapath_setup import setup_masquerade_rule, tune_datapath
 from magma.pipelined.gtp_stats_collector import (
     MIN_OVSDB_DUMP_POLLING_INTERVAL,
     GTPStatsCollector,
@@ -132,7 +132,6 @@ def main():
     # Load the ryu apps
     service_manager = ServiceManager(service)
     service_manager.load()
-
 
     service.loop.create_task(
         monitor_ifaces(

--- a/lte/gateway/python/magma/pipelined/ng_set_session_msg.py
+++ b/lte/gateway/python/magma/pipelined/ng_set_session_msg.py
@@ -78,8 +78,8 @@ class CreateSessionUtil:
             flow_list = [
                 FlowDescription(
                     match=FlowMatch(
-                    ip_dst=ip_dst,
-                    direction=qos_enforce_rule.direction,
+                        ip_dst=ip_dst,
+                        direction=qos_enforce_rule.direction,
                     ),
                     action=allow,
                 ),
@@ -88,8 +88,8 @@ class CreateSessionUtil:
             flow_list = [
                 FlowDescription(
                     match=FlowMatch(
-                    ip_src=ip_src,
-                    direction=qos_enforce_rule.direction,
+                        ip_src=ip_src,
+                        direction=qos_enforce_rule.direction,
                     ),
                     action=allow,
                 ),
@@ -98,14 +98,18 @@ class CreateSessionUtil:
         qos_enforce_rule = ActivateFlowsRequest(
                                   sid=SIDUtils.to_pb(qos_enforce_rule.imsi),
                                   ip_addr=ue_ip_addr,
-                                  policies=[VersionedPolicy(rule = PolicyRule(
-                                  id=qos_enforce_rule.rule_id,
-                                  priority=qos_enforce_rule.priority,
-                                  hard_timeout=qos_enforce_rule.hard_timeout,
-                                  flow_list=flow_list), version=1,
-                                ),],
-                                request_origin=RequestOriginType(type=RequestOriginType.N4))
-        return  qos_enforce_rule
+                                  policies=[
+                                      VersionedPolicy(
+                                          rule=PolicyRule(
+                                            id=qos_enforce_rule.rule_id,
+                                            priority=qos_enforce_rule.priority,
+                                            hard_timeout=qos_enforce_rule.hard_timeout,
+                                            flow_list=flow_list,
+                                          ), version=1,
+                                      ), ],
+                                request_origin=RequestOriginType(type=RequestOriginType.N4),
+        )
+        return qos_enforce_rule
 
     @staticmethod
     def CreateDelQERinPDR(
@@ -116,8 +120,9 @@ class CreateSessionUtil:
         qos_enforce_rule = DeactivateFlowsRequest(
                                   sid=SIDUtils.to_pb(qos_enforce_rule.imsi),
                                   ip_addr=ue_ip_addr,
-                                  policies=[VersionedPolicyID(rule_id=qos_enforce_rule.rule_id),],
-                                  request_origin=RequestOriginType(type=RequestOriginType.N4))
+                                  policies=[VersionedPolicyID(rule_id=qos_enforce_rule.rule_id)],
+                                  request_origin=RequestOriginType(type=RequestOriginType.N4),
+        )
 
         return qos_enforce_rule
 

--- a/lte/gateway/python/magma/pipelined/openflow/flows.py
+++ b/lte/gateway/python/magma/pipelined/openflow/flows.py
@@ -633,7 +633,7 @@ def __get_instructions_for_actions(
     if actions:
         instructions.append(
             ofproto_parser.OFPInstructionActions(
-            ofproto.OFPIT_APPLY_ACTIONS, actions,
+                ofproto.OFPIT_APPLY_ACTIONS, actions,
             ),
         )
     return instructions

--- a/lte/gateway/python/magma/pipelined/openflow/magma_match.py
+++ b/lte/gateway/python/magma/pipelined/openflow/magma_match.py
@@ -16,15 +16,16 @@ from magma.pipelined.openflow.registers import (
     DIRECTION_REG,
     DPI_REG,
     IMSI_REG,
+    NG_SESSION_ID_REG,
     PASSTHROUGH_REG,
     PROXY_TAG_REG,
     RULE_NUM_REG,
     RULE_VERSION_REG,
     VLAN_TAG_REG,
-    NG_SESSION_ID_REG,
     Direction,
     is_valid_direction,
 )
+
 
 class MagmaMatch(object):
     """
@@ -33,11 +34,13 @@ class MagmaMatch(object):
     direction.
     """
 
-    def __init__(self, imsi: int = None, direction: Optional[Direction] = None,
-                 rule_num: int = None, rule_version: int = None,
-                 passthrough: int = None, vlan_tag: int = None,
-                 app_id: int = None, proxy_tag: int = None,
-                 local_f_teid_ng: int = None, **kwargs):
+    def __init__(
+        self, imsi: int = None, direction: Optional[Direction] = None,
+        rule_num: int = None, rule_version: int = None,
+        passthrough: int = None, vlan_tag: int = None,
+        app_id: int = None, proxy_tag: int = None,
+        local_f_teid_ng: int = None, **kwargs
+    ):
         self.imsi = imsi
         self.direction = direction
         self.rule_num = rule_num

--- a/lte/gateway/python/magma/pipelined/policy_converters.py
+++ b/lte/gateway/python/magma/pipelined/policy_converters.py
@@ -22,13 +22,15 @@ from magma.pipelined.openflow.registers import (
 )
 from ryu.lib.packet import ether_types
 
-MATCH_ATTRIBUTES = ['metadata', 'reg0', 'reg1', 'reg2', 'reg3', 'reg4', 'reg5',
-                    'reg6', 'reg8', 'reg9', 'reg10',
-                    'in_port', 'dl_vlan', 'vlan_tci',
-                    'eth_type', 'dl_dst', 'dl_src',
-                    'arp_tpa', 'arp_spa', 'arp_op',
-                    'ipv4_dst', 'ipv4_src', 'ipv6_src', 'ipv6_dst',
-                    'ip_proto', 'tcp_src', 'tcp_dst', 'udp_src', 'udp_dst']
+MATCH_ATTRIBUTES = [
+    'metadata', 'reg0', 'reg1', 'reg2', 'reg3', 'reg4', 'reg5',
+    'reg6', 'reg8', 'reg9', 'reg10',
+    'in_port', 'dl_vlan', 'vlan_tci',
+    'eth_type', 'dl_dst', 'dl_src',
+    'arp_tpa', 'arp_spa', 'arp_op',
+    'ipv4_dst', 'ipv4_src', 'ipv6_src', 'ipv6_dst',
+    'ip_proto', 'tcp_src', 'tcp_dst', 'udp_src', 'udp_dst',
+]
 
 
 class FlowMatchError(Exception):
@@ -42,11 +44,15 @@ def _check_pkt_protocol(match):
     Args:
         match: FlowMatch
     '''
-    if (match.tcp_dst or match.tcp_src) and (match.ip_proto !=
-                                             match.IPPROTO_TCP):
+    if (match.tcp_dst or match.tcp_src) and (
+        match.ip_proto !=
+        match.IPPROTO_TCP
+    ):
         raise FlowMatchError("To use tcp rules set ip_proto to IPPROTO_TCP")
-    if (match.udp_dst or match.udp_src) and (match.ip_proto !=
-                                             match.IPPROTO_UDP):
+    if (match.udp_dst or match.udp_src) and (
+        match.ip_proto !=
+        match.IPPROTO_UDP
+    ):
         raise FlowMatchError("To use udp rules set ip_proto to IPPROTO_UDP")
     return True
 
@@ -60,9 +66,11 @@ def flow_match_to_magma_match(match, ip_addr=None):
     '''
     _check_pkt_protocol(match)
     match_kwargs = {'eth_type': ether_types.ETH_TYPE_IP}
-    attributes = ['ip_dst', 'ip_src',
-                  'ip_proto', 'tcp_src', 'tcp_dst',
-                  'udp_src', 'udp_dst', 'app_name']
+    attributes = [
+        'ip_dst', 'ip_src',
+        'ip_proto', 'tcp_src', 'tcp_dst',
+        'udp_src', 'udp_dst', 'app_name',
+    ]
     for attrib in attributes:
         value = getattr(match, attrib, None)
         if not value:
@@ -107,8 +115,10 @@ def flow_match_to_magma_match(match, ip_addr=None):
             else:
                 match_kwargs[ip_dst_reg] = ip_addr.address.decode('utf-8')
 
-    return MagmaMatch(direction=get_direction_for_match(match),
-                      **match_kwargs)
+    return MagmaMatch(
+        direction=get_direction_for_match(match),
+        **match_kwargs,
+    )
 
 
 def flow_match_to_actions(datapath, match):
@@ -130,12 +140,12 @@ def flow_match_to_actions(datapath, match):
     if match.ip_proto == FlowMatch.IPPROTO_TCP:
         actions.extend([
             parser.OFPActionSetField(tcp_src=getattr(match, 'tcp_src', 0)),
-            parser.OFPActionSetField(tcp_dst=getattr(match, 'tcp_dst', 0))
+            parser.OFPActionSetField(tcp_dst=getattr(match, 'tcp_dst', 0)),
         ])
     elif match.ip_proto == FlowMatch.IPPROTO_UDP:
         actions.extend([
             parser.OFPActionSetField(udp_src=getattr(match, 'udp_src', 0)),
-            parser.OFPActionSetField(udp_dst=getattr(match, 'udp_dst', 0))
+            parser.OFPActionSetField(udp_dst=getattr(match, 'udp_dst', 0)),
         ])
     return actions
 
@@ -161,7 +171,7 @@ def flip_flow_match(match):
         udp_dst=getattr(match, 'udp_src', None),
         ip_proto=getattr(match, 'ip_proto', None),
         direction=direction,
-        app_name=getattr(match, 'app_name', None)
+        app_name=getattr(match, 'app_name', None),
     )
 
 
@@ -240,18 +250,24 @@ def get_direction_for_match(flow_match):
 
 
 def convert_ipv4_str_to_ip_proto(ipv4_str):
-    return IPAddress(version=IPAddress.IPV4,
-                     address=ipv4_str.encode('utf-8'))
+    return IPAddress(
+        version=IPAddress.IPV4,
+        address=ipv4_str.encode('utf-8'),
+    )
 
 
 def convert_ipv6_str_to_ip_proto(ipv6_str):
-    return IPAddress(version=IPAddress.IPV6,
-                     address=ipv6_str.encode('utf-8'))
+    return IPAddress(
+        version=IPAddress.IPV6,
+        address=ipv6_str.encode('utf-8'),
+    )
 
 
 def convert_ipv6_bytes_to_ip_proto(ipv6_bytes):
-    return IPAddress(version=IPAddress.IPV6,
-                     address=ipv6_bytes)
+    return IPAddress(
+        version=IPAddress.IPV6,
+        address=ipv6_bytes,
+    )
 
 
 def convert_ip_str_to_ip_proto(ip_str: str):

--- a/lte/gateway/python/magma/pipelined/redirect.py
+++ b/lte/gateway/python/magma/pipelined/redirect.py
@@ -603,7 +603,7 @@ class RedirectionManager:
             except aiodns.error.DNSError as err:
                 self.logger.error(
                     "Error: ip lookup for {}: {}".format(
-                    redirect_addr_host, err,
+                        redirect_addr_host, err,
                     ),
                 )
                 return

--- a/lte/gateway/python/magma/pipelined/rpc_servicer.py
+++ b/lte/gateway/python/magma/pipelined/rpc_servicer.py
@@ -853,11 +853,11 @@ class PipelinedRpcServicer(pipelined_pb2_grpc.PipelinedServicer):
         table_assignments = self._service_manager.get_all_table_assignments()
         return AllTableAssignments(
             table_assignments=[
-            TableAssignment(
-                app_name=app_name, main_table=tables.main_table,
-                scratch_tables=tables.scratch_tables,
-            ) for
-            app_name, tables in table_assignments.items()
+                TableAssignment(
+                    app_name=app_name, main_table=tables.main_table,
+                    scratch_tables=tables.scratch_tables,
+                ) for
+                app_name, tables in table_assignments.items()
             ],
         )
 

--- a/lte/gateway/python/magma/pipelined/rule_mappers.py
+++ b/lte/gateway/python/magma/pipelined/rule_mappers.py
@@ -13,6 +13,7 @@ limitations under the License.
 import json
 import threading
 from collections import namedtuple
+
 from lte.protos.mobilityd_pb2 import IPAddress
 from magma.common.redis.client import get_default_client
 from magma.common.redis.containers import RedisFlatDict, RedisHashDict
@@ -84,11 +85,13 @@ class SessionRuleToVersionMapper:
     """
 
     def __init__(self):
-        self._version_by_imsi_and_rule = {} 
+        self._version_by_imsi_and_rule = {}
         self._lock = threading.Lock()  # write lock
 
-    def _save_version_unsafe(self, imsi: str, ip_addr: str, rule_id: str,
-                             version):
+    def _save_version_unsafe(
+        self, imsi: str, ip_addr: str, rule_id: str,
+        version,
+    ):
         key = self._get_json_key(encode_imsi(imsi), ip_addr, rule_id)
         self._version_by_imsi_and_rule[key] = version
 
@@ -107,14 +110,18 @@ class SessionRuleToVersionMapper:
         with self._lock:
             for k in self._version_by_imsi_and_rule.keys():
                 _, cur_imsi, cur_ip_addr_str, _ = SubscriberRuleKey(*json.loads(k))
-                if cur_imsi == encoded_imsi and (ip_addr_str == "" or
-                                                 ip_addr_str == cur_ip_addr_str):
+                if cur_imsi == encoded_imsi and (
+                    ip_addr_str == "" or
+                    ip_addr_str == cur_ip_addr_str
+                ):
                     del_list.append(k)
             for k in del_list:
                 del self._version_by_imsi_and_rule[k]
 
-    def save_version(self, imsi: str, ip_addr: IPAddress,
-                     rule_id: [str], version: int):
+    def save_version(
+        self, imsi: str, ip_addr: IPAddress,
+        rule_id: [str], version: int,
+    ):
         """
         Increment the version number for a given subscriber and rule. If the
         rule id is not specified, then all rules for the subscriber will be
@@ -160,8 +167,12 @@ class SessionRuleToVersionMapper:
                 del self._version_by_imsi_and_rule[key]
 
     def _get_json_key(self, imsi: str, ip_addr: str, rule_id: str):
-        return json.dumps(SubscriberRuleKey('imsi_rule', imsi, ip_addr,
-                                            rule_id))
+        return json.dumps(
+            SubscriberRuleKey(
+                'imsi_rule', imsi, ip_addr,
+                rule_id,
+            ),
+        )
 
 
 class RuleIDDict(RedisFlatDict):
@@ -174,8 +185,10 @@ class RuleIDDict(RedisFlatDict):
 
     def __init__(self):
         client = get_default_client()
-        serde = RedisSerde(self._DICT_HASH, get_json_serializer(),
-                           get_json_deserializer())
+        serde = RedisSerde(
+            self._DICT_HASH, get_json_serializer(),
+            get_json_deserializer(),
+        )
         super().__init__(client, serde, writethrough=True)
 
     def __missing__(self, key):
@@ -196,7 +209,8 @@ class RuleNameDict(RedisHashDict):
         super().__init__(
             client,
             self._DICT_HASH,
-            get_json_serializer(), get_json_deserializer())
+            get_json_serializer(), get_json_deserializer(),
+        )
 
     def __missing__(self, key):
         """Instead of throwing a key error, return None when key not found"""
@@ -213,13 +227,16 @@ class RuleVersionDict(RedisFlatDict):
 
     def __init__(self):
         client = get_default_client()
-        serde = RedisSerde(self._DICT_HASH, get_json_serializer(),
-                           get_json_deserializer())
+        serde = RedisSerde(
+            self._DICT_HASH, get_json_serializer(),
+            get_json_deserializer(),
+        )
         super().__init__(client, serde, writethrough=True)
 
     def __missing__(self, key):
         """Instead of throwing a key error, return None when key not found"""
         return None
+
 
 class RestartInfoStore(RedisHashDict):
     """
@@ -228,10 +245,13 @@ class RestartInfoStore(RedisHashDict):
     Setting and deleting items in the dictionary syncs with Redis automatically
     """
     _DICT_HASH = "pipelined:enforcement_stats_info"
+
     def __init__(self):
         client = get_default_client()
-        super().__init__(client, self._DICT_HASH,
-                         get_json_serializer(), get_json_deserializer())
+        super().__init__(
+            client, self._DICT_HASH,
+            get_json_serializer(), get_json_deserializer(),
+        )
 
     def __missing__(self, key):
         """Instead of throwing a key error, return 0 when key not found"""

--- a/lte/gateway/python/magma/pipelined/service_manager.py
+++ b/lte/gateway/python/magma/pipelined/service_manager.py
@@ -80,8 +80,8 @@ from magma.pipelined.app.xwf_passthru import XWFPassthruController
 from magma.pipelined.internal_ip_allocator import InternalIPAllocator
 from magma.pipelined.ipv6_prefix_store import InterfaceIDToPrefixMapper
 from magma.pipelined.rule_mappers import (
-    RuleIDToNumMapper,
     RestartInfoStore,
+    RuleIDToNumMapper,
     SessionRuleToVersionMapper,
 )
 from magma.pipelined.tunnel_id_store import TunnelToTunnelMapper

--- a/lte/gateway/python/magma/pipelined/tests/app/subscriber.py
+++ b/lte/gateway/python/magma/pipelined/tests/app/subscriber.py
@@ -25,8 +25,12 @@ from magma.pipelined.policy_converters import convert_ip_str_to_ip_proto
 from magma.subscriberdb.sid import SIDUtils
 from ryu.lib import hub
 
-SubContextConfig = namedtuple('ContextConfig', ['imsi', 'ip', 'ambr',
-                                                'table_id'])
+SubContextConfig = namedtuple(
+    'ContextConfig', [
+        'imsi', 'ip', 'ambr',
+        'table_id',
+    ],
+)
 default_ambr_config = None
 
 
@@ -42,8 +46,10 @@ def try_grpc_call_with_retries(grpc_call, retry_count=5, retry_interval=1):
                 logging.warning("Pipelined unavailable, retrying...")
                 time.sleep(retry_interval * (2 ** i))
                 continue
-            logging.error("Pipelined grpc call failed with error : %s",
-                          error)
+            logging.error(
+                "Pipelined grpc call failed with error : %s",
+                error,
+            )
             raise
 
 
@@ -116,14 +122,18 @@ class RyuRPCSubscriberContext(SubscriberContext):
     def _activate_subscriber_rules(self):
         try_grpc_call_with_retries(
             lambda: self._pipelined_stub.ActivateFlows(
-                ActivateFlowsRequest(sid=SIDUtils.to_pb(self.cfg.imsi),
-                                     policies=self._policies))
+                ActivateFlowsRequest(
+                    sid=SIDUtils.to_pb(self.cfg.imsi),
+                    policies=self._policies,
+                ),
+            ),
         )
 
     def _deactivate_subscriber_rules(self):
         try_grpc_call_with_retries(
             lambda: self._pipelined_stub.DeactivateFlows(
-                DeactivateFlowsRequest(sid=SIDUtils.to_pb(self.cfg.imsi)))
+                DeactivateFlowsRequest(sid=SIDUtils.to_pb(self.cfg.imsi)),
+            ),
         )
 
 
@@ -133,8 +143,10 @@ class RyuDirectSubscriberContext(SubscriberContext):
     directly manage subscriber flows
     """
 
-    def __init__(self, imsi, ip, enforcement_controller, table_id=5,
-                 enforcement_stats_controller=None, nuke_flows_on_exit=True):
+    def __init__(
+        self, imsi, ip, enforcement_controller, table_id=5,
+        enforcement_stats_controller=None, nuke_flows_on_exit=True,
+    ):
         self.cfg = SubContextConfig(imsi, ip, default_ambr_config, table_id)
         self._policies = []
         self._ec = enforcement_controller
@@ -156,7 +168,8 @@ class RyuDirectSubscriberContext(SubscriberContext):
                 apn_ambr=default_ambr_config,
                 policies=self._policies,
                 shard_id=0,
-                local_f_teid_ng=0)
+                local_f_teid_ng=0,
+            )
             if self._esc:
                 self._esc.activate_rules(
                     imsi=self.cfg.imsi,
@@ -166,7 +179,8 @@ class RyuDirectSubscriberContext(SubscriberContext):
                     apn_ambr=default_ambr_config,
                     policies=self._policies,
                     shard_id=0,
-                    local_f_teid_ng=0)
+                    local_f_teid_ng=0,
+                )
         hub.joinall([hub.spawn(activate_flows)])
 
     def _deactivate_subscriber_rules(self):
@@ -176,5 +190,6 @@ class RyuDirectSubscriberContext(SubscriberContext):
                 self._ec.deactivate_rules(
                     imsi=self.cfg.imsi,
                     ip_addr=ip_addr,
-                    rule_ids=None)
+                    rule_ids=None,
+                )
             hub.joinall([hub.spawn(deactivate_flows)])

--- a/lte/gateway/python/magma/pipelined/tests/app/table_isolation.py
+++ b/lte/gateway/python/magma/pipelined/tests/app/table_isolation.py
@@ -106,7 +106,7 @@ class RyuForwardFlowArgsBuilder():
             Self
         """
         self._reg_sets.append(
-            {"type": "SET_FIELD", "field": reg_name, "value": value}
+            {"type": "SET_FIELD", "field": reg_name, "value": value},
         )
         return self
 
@@ -143,11 +143,15 @@ class RyuForwardFlowArgsBuilder():
             Self
         """
         self._ip = ip
-        self._ulink_action = {"type": "SET_FIELD", "field": DIRECTION_REG,
-                              "value": Direction.OUT}
+        self._ulink_action = {
+            "type": "SET_FIELD", "field": DIRECTION_REG,
+            "value": Direction.OUT,
+        }
 
-        self._dlink_action = {"type": "SET_FIELD", "field": DIRECTION_REG,
-                              "value": Direction.IN}
+        self._dlink_action = {
+            "type": "SET_FIELD", "field": DIRECTION_REG,
+            "value": Direction.IN,
+        }
         return self
 
     def set_eth_match(self, eth_src, eth_dst):
@@ -170,24 +174,28 @@ class RyuForwardFlowArgsBuilder():
 
         uplink["instructions"].append({
             "type": "APPLY_ACTIONS",
-            "actions": self._reg_sets + [self._ulink_action]
+            "actions": self._reg_sets + [self._ulink_action],
         })
         downlink["instructions"].append({
             "type": "APPLY_ACTIONS",
-            "actions": self._reg_sets + [self._dlink_action]
+            "actions": self._reg_sets + [self._dlink_action],
         })
 
         ip_addr = convert_ip_str_to_ip_proto(self._ip)
         if ip_addr.version == IPAddress.IPV4:
             uplink["match"].update(
-                {"ipv4_src": self._ip})
+                {"ipv4_src": self._ip},
+            )
             downlink["match"].update(
-                {"ipv4_dst": self._ip})
+                {"ipv4_dst": self._ip},
+            )
         else:
             uplink["match"].update(
-                {"ipv6_src": self._ip})
+                {"ipv6_src": self._ip},
+            )
             downlink["match"].update(
-                {"ipv6_dst": self._ip})
+                {"ipv6_dst": self._ip},
+            )
         return [uplink, downlink]
 
     def set_eth_type_arp(self):
@@ -215,7 +223,7 @@ class RyuForwardFlowArgsBuilder():
         else:
             if self._reg_sets:
                 self._request["instructions"].append(
-                    {"type": "APPLY_ACTIONS", "actions": self._reg_sets}
+                    {"type": "APPLY_ACTIONS", "actions": self._reg_sets},
                 )
             return [self._request]
 

--- a/lte/gateway/python/magma/pipelined/tests/pipelined_test_util.py
+++ b/lte/gateway/python/magma/pipelined/tests/pipelined_test_util.py
@@ -152,8 +152,10 @@ class FlowVerifier:
             logging.error("Test didn't finish, can't access final pkt stats")
             return None
 
-        return [(f.pkts - i.pkts, f.flow_count - i.flow_count)
-                for f, i in zip(self._final, self._initial)]
+        return [
+            (f.pkts - i.pkts, f.flow_count - i.flow_count)
+            for f, i in zip(self._final, self._initial)
+        ]
 
 
 def start_ryu_app_thread(test_setup):
@@ -229,12 +231,14 @@ def wait_after_send(test_controller, wait_time=1, max_sleep_time=20):
         if (sleep_time >= max_sleep_time):
             raise WaitTimeExceeded(
                 "Waiting on pkts exceeded the max({}) sleep time".
-                    format(max_sleep_time)
+                    format(max_sleep_time),
             )
 
 
-def setup_controller(controller, setup_req, sleep_time: float = 1,
-                     retries: int = 5):
+def setup_controller(
+    controller, setup_req, sleep_time: float = 1,
+    retries: int = 5,
+):
     for _ in range(0, retries):
         ret = controller.check_setup_request_epoch(setup_req.epoch)
         if ret == SetupFlowsResult.SUCCESS:
@@ -248,17 +252,22 @@ def setup_controller(controller, setup_req, sleep_time: float = 1,
 
 
 def fake_inout_setup(inout_controller):
-    TestCase().assertEqual(setup_controller(
-        inout_controller, SetupPolicyRequest(requests=[], epoch=global_epoch)),
-        SetupFlowsResult.SUCCESS)
+    TestCase().assertEqual(
+        setup_controller(
+            inout_controller, SetupPolicyRequest(requests=[], epoch=global_epoch),
+        ),
+        SetupFlowsResult.SUCCESS,
+    )
 
 
-def fake_controller_setup(enf_controller=None,
-                          enf_stats_controller=None,
-                          startup_flow_controller=None,
-                          check_quota_controller=None,
-                          setup_flows_request=None,
-                          check_quota_request=None):
+def fake_controller_setup(
+    enf_controller=None,
+    enf_stats_controller=None,
+    startup_flow_controller=None,
+    check_quota_controller=None,
+    setup_flows_request=None,
+    check_quota_request=None,
+):
     """
     Immitate contoller restart. This is done by manually setting contoller init
     fields back to False, and restarting the startup stats controller(optional)
@@ -279,24 +288,33 @@ def fake_controller_setup(enf_controller=None,
         if enf_stats_controller:
             TestCase().assertEqual(enf_stats_controller._clean_restart, True)
     enf_controller.init_finished = False
-    TestCase().assertEqual(setup_controller(
-        enf_controller, setup_flows_request),
-        SetupFlowsResult.SUCCESS)
+    TestCase().assertEqual(
+        setup_controller(
+            enf_controller, setup_flows_request,
+        ),
+        SetupFlowsResult.SUCCESS,
+    )
     if enf_stats_controller:
         enf_stats_controller.init_finished = False
         enf_stats_controller.cleanup_state()
-        TestCase().assertEqual(setup_controller(
-            enf_stats_controller, setup_flows_request),
-            SetupFlowsResult.SUCCESS)
+        TestCase().assertEqual(
+            setup_controller(
+                enf_stats_controller, setup_flows_request,
+            ),
+            SetupFlowsResult.SUCCESS,
+        )
     if check_quota_controller:
         check_quota_controller.init_finished = False
         if check_quota_request is None:
             check_quota_request = UpdateSubscriberQuotaStateRequest(
                 requests=[], epoch=global_epoch,
             )
-        TestCase().assertEqual(setup_controller(
-            check_quota_controller, check_quota_request),
-            SetupFlowsResult.SUCCESS)
+        TestCase().assertEqual(
+            setup_controller(
+                check_quota_controller, check_quota_request,
+            ),
+            SetupFlowsResult.SUCCESS,
+        )
 
 
 def fake_cwf_setup(ue_mac_controller, setup_ue_mac_request=None):
@@ -305,13 +323,18 @@ def fake_cwf_setup(ue_mac_controller, setup_ue_mac_request=None):
             requests=[], epoch=global_epoch,
         )
     ue_mac_controller.init_finished = False
-    TestCase().assertEqual(setup_controller(
-        ue_mac_controller, setup_ue_mac_request),
-        SetupFlowsResult.SUCCESS)
+    TestCase().assertEqual(
+        setup_controller(
+            ue_mac_controller, setup_ue_mac_request,
+        ),
+        SetupFlowsResult.SUCCESS,
+    )
 
 
-def wait_for_enforcement_stats(controller, rule_list, wait_time=1,
-                               max_sleep_time=25):
+def wait_for_enforcement_stats(
+    controller, rule_list, wait_time=1,
+    max_sleep_time=25,
+):
     """
     Wait until all rules from rule_list appear in reports from
     enforcement_controller to sessiond. This is done by checking the mocked
@@ -348,7 +371,7 @@ def wait_for_enforcement_stats(controller, rule_list, wait_time=1,
         if (sleep_time >= max_sleep_time):
             raise WaitTimeExceeded(
                 "Waiting on enforcement stats exceeded the max({}) sleep time".
-                    format(max_sleep_time)
+                    format(max_sleep_time),
             )
 
 
@@ -373,8 +396,10 @@ def get_enforcement_stats(enforcement_stats):
     return stats
 
 
-def create_service_manager(services: List[int],
-                           static_services: List[str] = None):
+def create_service_manager(
+    services: List[int],
+    static_services: List[str] = None,
+):
     """
     Creates a service manager from the given list of services.
     Args:
@@ -389,13 +414,14 @@ def create_service_manager(services: List[int],
         static_services = []
     magma_service.config = {
         'static_services': static_services,
-        '5G_feature_set': {'enable': False}
+        '5G_feature_set': {'enable': False},
     }
     # mock the get_default_client function used to return a fakeredis object
     func_mock = MagicMock(return_value=fakeredis.FakeStrictRedis())
     with mock.patch(
             'magma.pipelined.rule_mappers.get_default_client',
-            func_mock):
+            func_mock,
+    ):
         service_manager = ServiceManager(magma_service)
 
     # Workaround as we don't use redis in unit tests
@@ -418,49 +444,64 @@ def _parse_flow(flow):
     return flow
 
 
-def _get_current_bridge_snapshot(bridge_name, service_manager,
-                                 include_stats=True) -> List[str]:
+def _get_current_bridge_snapshot(
+    bridge_name, service_manager,
+    include_stats=True,
+) -> List[str]:
     table_assignments = service_manager.get_all_table_assignments()
     # Currently, the unit test setup library does not set up the ryu api app.
     # For now, snapshots are created from the flow dump output using ovs and
     # parsed using regex. Once the ryu api works for unit tests, we can
     # directly parse the api response and avoid the regex.
-    flows = BridgeTools.get_annotated_flows_for_bridge(bridge_name,
-                                                       table_assignments,
-                                                       include_stats=include_stats)
+    flows = BridgeTools.get_annotated_flows_for_bridge(
+        bridge_name,
+        table_assignments,
+        include_stats=include_stats,
+    )
     return [_parse_flow(flow) for flow in flows]
 
 
-def fail(test_case: TestCase, err_msg: str, _bridge_name: str,
-         snapshot_file, current_snapshot):
+def fail(
+    test_case: TestCase, err_msg: str, _bridge_name: str,
+    snapshot_file, current_snapshot,
+):
     ofctl_cmd = "sudo ovs-ofctl dump-flows %s" % _bridge_name
-    p = subprocess.Popen([ofctl_cmd],
-                         stdout=subprocess.PIPE,
-                         shell=True)
+    p = subprocess.Popen(
+        [ofctl_cmd],
+        stdout=subprocess.PIPE,
+        shell=True,
+    )
     ofctl_dump = p.stdout.read().decode("utf-8", 'ignore').strip()
     logging.error("cmd ofctl_dump: %s", ofctl_dump)
 
     msg = 'Snapshot mismatch with error:\n' \
           '{}\n' \
           'To fix the error, update "{}" to the current snapshot:\n' \
-          '{}'.format(err_msg, snapshot_file,
-                      '\n'.join(current_snapshot))
+          '{}'.format(
+              err_msg, snapshot_file,
+              '\n'.join(current_snapshot),
+          )
     return test_case.fail(msg)
 
 
-def expected_snapshot(test_case: TestCase,
-                      bridge_name: str,
-                      current_snapshot,
-                      snapshot_name: Optional[str] = None) -> bool:
+def expected_snapshot(
+    test_case: TestCase,
+    bridge_name: str,
+    current_snapshot,
+    snapshot_name: Optional[str] = None,
+) -> bool:
     if snapshot_name is not None:
-        combined_name = '{}.{}{}'.format(test_case.id(), snapshot_name,
-                                         SNAPSHOT_EXTENSION)
+        combined_name = '{}.{}{}'.format(
+            test_case.id(), snapshot_name,
+            SNAPSHOT_EXTENSION,
+        )
     else:
         combined_name = '{}{}'.format(test_case.id(), SNAPSHOT_EXTENSION)
     snapshot_file = os.path.join(
         os.path.dirname(os.path.realpath(__file__)),
         SNAPSHOT_DIR,
-        combined_name)
+        combined_name,
+    )
 
     try:
         with open(snapshot_file, 'r') as file:
@@ -473,10 +514,12 @@ def expected_snapshot(test_case: TestCase,
     return snapshot_file, prev_snapshot
 
 
-def assert_bridge_snapshot_match(test_case: TestCase, bridge_name: str,
-                                 service_manager: ServiceManager,
-                                 snapshot_name: Optional[str] = None,
-                                 include_stats: bool = True):
+def assert_bridge_snapshot_match(
+    test_case: TestCase, bridge_name: str,
+    service_manager: ServiceManager,
+    snapshot_name: Optional[str] = None,
+    include_stats: bool = True,
+):
     """
     Verifies the current bridge snapshot matches the snapshot saved in file for
     the given test case. Fails the test case if the snapshots differ.
@@ -490,31 +533,45 @@ def assert_bridge_snapshot_match(test_case: TestCase, bridge_name: str,
             this is used to distinguish the snapshots
     """
 
-    current_snapshot = _get_current_bridge_snapshot(bridge_name,
-                                                    service_manager,
-                                                    include_stats)
+    current_snapshot = _get_current_bridge_snapshot(
+        bridge_name,
+        service_manager,
+        include_stats,
+    )
 
-    snapshot_file, expected = expected_snapshot(test_case,
-                                                bridge_name,
-                                                current_snapshot,
-                                                snapshot_name)
+    snapshot_file, expected = expected_snapshot(
+        test_case,
+        bridge_name,
+        current_snapshot,
+        snapshot_name,
+    )
     if set(current_snapshot) != set(expected):
-        fail(test_case,
-             '\n'.join(list(unified_diff(expected, current_snapshot,
-                                         fromfile='previous snapshot',
-                                         tofile='current snapshot'))),
-             bridge_name,
-             snapshot_file,
-             current_snapshot)
+        fail(
+            test_case,
+            '\n'.join(
+                list(
+                    unified_diff(
+                        expected, current_snapshot,
+                        fromfile='previous snapshot',
+                        tofile='current snapshot',
+                    ),
+                ),
+            ),
+            bridge_name,
+            snapshot_file,
+            current_snapshot,
+        )
 
 
-def wait_for_snapshots(test_case: TestCase,
-                       bridge_name: str,
-                       service_manager: ServiceManager,
-                       snapshot_name: Optional[str] = None,
-                       wait_time: int = 1, max_sleep_time: int = 20,
-                       datapath=None,
-                       try_snapshot=False, include_stats=True):
+def wait_for_snapshots(
+    test_case: TestCase,
+    bridge_name: str,
+    service_manager: ServiceManager,
+    snapshot_name: Optional[str] = None,
+    wait_time: int = 1, max_sleep_time: int = 20,
+    datapath=None,
+    try_snapshot=False, include_stats=True,
+):
     """
     Wait after checking ovs snapshot as new changes might still come in,
 
@@ -527,19 +584,25 @@ def wait_for_snapshots(test_case: TestCase,
     Throws a WaitTimeExceeded Exception if max_sleep_time exceeded
     """
     sleep_time = 0
-    old_snapshot = _get_current_bridge_snapshot(bridge_name, service_manager,
-        include_stats=include_stats)
+    old_snapshot = _get_current_bridge_snapshot(
+        bridge_name, service_manager,
+        include_stats=include_stats,
+    )
     while True:
         if datapath:
             flows.set_barrier(datapath)
         hub.sleep(wait_time)
 
-        new_snapshot = _get_current_bridge_snapshot(bridge_name, service_manager,
-            include_stats=include_stats)
+        new_snapshot = _get_current_bridge_snapshot(
+            bridge_name, service_manager,
+            include_stats=include_stats,
+        )
         if try_snapshot:
-            snapshot_file, expected_ = expected_snapshot(test_case,
-                                                         bridge_name,
-                                                         snapshot_name)
+            snapshot_file, expected_ = expected_snapshot(
+                test_case,
+                bridge_name,
+                snapshot_name,
+            )
             if new_snapshot == expected_:
                 return
         else:
@@ -552,7 +615,7 @@ def wait_for_snapshots(test_case: TestCase,
         if sleep_time >= max_sleep_time:
             raise WaitTimeExceeded(
                 "Waiting on pkts exceeded the max({}) sleep time".
-                    format(max_sleep_time)
+                    format(max_sleep_time),
             )
 
 
@@ -561,13 +624,15 @@ class SnapshotVerifier:
     SnapshotVerifier is a context wrapper for verifying bridge snapshots.
     """
 
-    def __init__(self, test_case: TestCase, bridge_name: str,
-                 service_manager: ServiceManager,
-                 snapshot_name: Optional[str] = None,
-                 include_stats: bool = True,
-                 max_sleep_time: int = 20,
-                 datapath=None,
-                 try_snapshot=False):
+    def __init__(
+        self, test_case: TestCase, bridge_name: str,
+        service_manager: ServiceManager,
+        snapshot_name: Optional[str] = None,
+        include_stats: bool = True,
+        max_sleep_time: int = 20,
+        datapath=None,
+        try_snapshot=False,
+    ):
         """
         These arguments are used to call assert_bridge_snapshot_match on exit.
 
@@ -596,31 +661,39 @@ class SnapshotVerifier:
         Runs after finishing 'with' (Verify snapshot)
         """
         try:
-            wait_for_snapshots(self._test_case,
-                               self._bridge_name,
-                               self._service_manager,
-                               self._snapshot_name,
-                               max_sleep_time=self._max_sleep_time,
-                               datapath=self._datapath,
-                               try_snapshot=self._try_snapshot,
-                               include_stats=self._include_stats)
+            wait_for_snapshots(
+                self._test_case,
+                self._bridge_name,
+                self._service_manager,
+                self._snapshot_name,
+                max_sleep_time=self._max_sleep_time,
+                datapath=self._datapath,
+                try_snapshot=self._try_snapshot,
+                include_stats=self._include_stats,
+            )
         except WaitTimeExceeded as e:
             ofctl_cmd = "sudo ovs-ofctl dump-flows %s".format(self._bridge_name)
-            p = subprocess.Popen([ofctl_cmd],
-                                 stdout=subprocess.PIPE,
-                                 shell=True)
+            p = subprocess.Popen(
+                [ofctl_cmd],
+                stdout=subprocess.PIPE,
+                shell=True,
+            )
             ofctl_dump = p.stdout.read().decode("utf-8").strip()
             logging.error("ofctl_dump: [%s]", ofctl_dump)
             TestCase().fail(e)
 
-        assert_bridge_snapshot_match(self._test_case, self._bridge_name,
-                                     self._service_manager,
-                                     self._snapshot_name, self._include_stats)
+        assert_bridge_snapshot_match(
+            self._test_case, self._bridge_name,
+            self._service_manager,
+            self._snapshot_name, self._include_stats,
+        )
 
 
 def get_ovsdb_port_tag(port_name: str) -> str:
-    dump1 = subprocess.Popen(["ovsdb-client", "dump", "Port", "name", "tag"],
-                             stdout=subprocess.PIPE)
+    dump1 = subprocess.Popen(
+        ["ovsdb-client", "dump", "Port", "name", "tag"],
+        stdout=subprocess.PIPE,
+    )
     for port in dump1.stdout.readlines():
         if port_name not in str(port):
             continue

--- a/lte/gateway/python/magma/pipelined/tests/test_enforcement_5g.py
+++ b/lte/gateway/python/magma/pipelined/tests/test_enforcement_5g.py
@@ -133,14 +133,14 @@ class EnforcementTableTest(unittest.TestCase):
         flow_list1 = [
             FlowDescription(
                 match=FlowMatch(
-                direction=FlowMatch.UPLINK,
+                    direction=FlowMatch.UPLINK,
                 ),
                 action=FlowDescription.PERMIT,
             ),
             FlowDescription(
                 match=FlowMatch(
-                ip_dst=convert_ipv4_str_to_ip_proto("192.168.0.0/24"),
-                direction=FlowMatch.DOWNLINK,
+                    ip_dst=convert_ipv4_str_to_ip_proto("192.168.0.0/24"),
+                    direction=FlowMatch.DOWNLINK,
                 ),
                 action=FlowDescription.PERMIT,
             ),
@@ -152,8 +152,8 @@ class EnforcementTableTest(unittest.TestCase):
             imsi, None, 0, convert_ipv4_str_to_ip_proto(sub_ip),
             None, policies=[
                 VersionedPolicy(
-                rule=PolicyRule(id='rule1', priority=65530, flow_list=flow_list1),
-                version=1,
+                    rule=PolicyRule(id='rule1', priority=65530, flow_list=flow_list1),
+                    version=1,
                 ),
             ], shard_id=0, local_f_teid_ng=100,
         )
@@ -176,14 +176,14 @@ class EnforcementTableTest(unittest.TestCase):
         flow_list = [
             FlowDescription(
                 match=FlowMatch(
-                direction=FlowMatch.UPLINK,
+                    direction=FlowMatch.UPLINK,
                 ),
                 action=FlowDescription.PERMIT,
             ),
             FlowDescription(
                 match=FlowMatch(
-                ip_dst=convert_ipv4_str_to_ip_proto("192.168.0.0/24"),
-                direction=FlowMatch.DOWNLINK,
+                    ip_dst=convert_ipv4_str_to_ip_proto("192.168.0.0/24"),
+                    direction=FlowMatch.DOWNLINK,
                 ),
                 action=FlowDescription.PERMIT,
             ),
@@ -197,8 +197,8 @@ class EnforcementTableTest(unittest.TestCase):
             imsi, None, 0, convert_ipv4_str_to_ip_proto(sub_ip),
             None, policies=[
                 VersionedPolicy(
-                rule=PolicyRule(id='rule1', priority=65530, flow_list=flow_list),
-                version=2,
+                    rule=PolicyRule(id='rule1', priority=65530, flow_list=flow_list),
+                    version=2,
                 ),
             ], shard_id=0, local_f_teid_ng=555,
         )
@@ -207,14 +207,14 @@ class EnforcementTableTest(unittest.TestCase):
         flow_list = [
             FlowDescription(
                 match=FlowMatch(
-                direction=FlowMatch.UPLINK,
+                    direction=FlowMatch.UPLINK,
                 ),
                 action=FlowDescription.PERMIT,
             ),
             FlowDescription(
                 match=FlowMatch(
-                ip_dst=convert_ipv4_str_to_ip_proto("192.168.0.0/24"),
-                direction=FlowMatch.DOWNLINK,
+                    ip_dst=convert_ipv4_str_to_ip_proto("192.168.0.0/24"),
+                    direction=FlowMatch.DOWNLINK,
                 ),
                 action=FlowDescription.PERMIT,
             ),
@@ -228,8 +228,8 @@ class EnforcementTableTest(unittest.TestCase):
             imsi, None, 0, convert_ipv4_str_to_ip_proto(sub_ip),
             None, policies=[
                 VersionedPolicy(
-                rule=PolicyRule(id='rule2', priority=65536, flow_list=flow_list),
-                version=3,
+                    rule=PolicyRule(id='rule2', priority=65536, flow_list=flow_list),
+                    version=3,
                 ),
             ], shard_id=0, local_f_teid_ng=5000,
         )

--- a/lte/gateway/python/magma/pipelined/tests/test_qos.py
+++ b/lte/gateway/python/magma/pipelined/tests/test_qos.py
@@ -946,7 +946,7 @@ class TestTrafficClass(unittest.TestCase):
         assert(
             not [
                 info for info in class_list if 'class htb 1:{qid}'.format(
-                qid=qid,
+                    qid=qid,
                 ) in info
             ]
         )
@@ -960,7 +960,7 @@ class TestTrafficClass(unittest.TestCase):
         assert(
             not [
                 info for info in class_list if 'class htb 1:{qid}'.format(
-                qid=parent_qid,
+                    qid=parent_qid,
                 ) in info
             ]
         )

--- a/lte/gateway/python/magma/pipelined/tests/test_restart_resilience.py
+++ b/lte/gateway/python/magma/pipelined/tests/test_restart_resilience.py
@@ -477,7 +477,7 @@ class RestartResilienceTest(unittest.TestCase):
             FlowDescription(
                 match=FlowMatch(
                     ip_dst=convert_ipv4_str_to_ip_proto('45.10.0.0/25'),
-            direction=FlowMatch.UPLINK,
+                    direction=FlowMatch.UPLINK,
                 ),
                 action=FlowDescription.PERMIT,
             ),
@@ -486,7 +486,7 @@ class RestartResilienceTest(unittest.TestCase):
             FlowDescription(
                 match=FlowMatch(
                     ip_src=convert_ipv4_str_to_ip_proto('45.10.0.0/24'),
-            direction=FlowMatch.DOWNLINK,
+                    direction=FlowMatch.DOWNLINK,
                 ),
                 action=FlowDescription.PERMIT,
             ),

--- a/lte/gateway/python/magma/pipelined/tests/test_service_manager.py
+++ b/lte/gateway/python/magma/pipelined/tests/test_service_manager.py
@@ -141,17 +141,17 @@ class ServiceManagerTest(unittest.TestCase):
     def test_is_app_enabled(self):
         self.assertTrue(
             self.service_manager.is_app_enabled(
-            EnforcementController.APP_NAME,
+                EnforcementController.APP_NAME,
             ),
         )
         self.assertTrue(
             self.service_manager.is_app_enabled(
-            DPIController.APP_NAME,
+                DPIController.APP_NAME,
             ),
         )
         self.assertTrue(
             self.service_manager.is_app_enabled(
-            EnforcementStatsController.APP_NAME,
+                EnforcementStatsController.APP_NAME,
             ),
         )
 
@@ -162,12 +162,12 @@ class ServiceManagerTest(unittest.TestCase):
     def test_allocate_scratch_tables(self):
         self.assertEqual(
             self.service_manager.allocate_scratch_tables(
-            EnforcementController.APP_NAME, 1,
+                EnforcementController.APP_NAME, 1,
             ), [21],
         )
         self.assertEqual(
             self.service_manager.allocate_scratch_tables(
-            EnforcementController.APP_NAME, 2,
+                EnforcementController.APP_NAME, 2,
             ), [22, 23],
         )
 
@@ -189,7 +189,7 @@ class ServiceManagerTest(unittest.TestCase):
 
         self.assertEqual(
             self.service_manager.get_scratch_table_nums(
-            EnforcementController.APP_NAME,
+                EnforcementController.APP_NAME,
             ), enforcement_scratch,
         )
 


### PR DESCRIPTION
Signed-off-by: Marie Bremner <marwhal@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary
I initially punted off the formatting change for PipelineD to avoid unnecessary merge conflicts for https://github.com/magma/magma/pull/5625 (discussed with @koolzz). I recently checked the PR and it looks to have so much merge conflict already that it might be OK to go with the change. 

This is the last requirement needed to make the Python Format Check mandatory.

Ran 
```bash
isort lte/gateway/python/magma/pipelined
autopep8 --select W191,W291,W292,W293,W391,E2,E3 -r --in-place lte/gateway/python/magma/pipelined
for i in `find lte/gateway/python/magma/pipelined/ -name "*.py" -type f`; do
    echo $i;
    add-trailing-comma --py35-plus $i;
done
```

<!-- Enumerate changes you made and why you made them -->

## Test Plan
CI passes
both integration tests ran locally
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
