### PR TITLE
fix(mme): procps-ng is no more in latest RHEL UBI8 base image

### DIFF
--- a/ci-scripts/docker/Dockerfile.mme.ci.rhel8
+++ b/ci-scripts/docker/Dockerfile.mme.ci.rhel8
@@ -63,6 +63,7 @@ RUN yum update -y && \
       libasan \
       liblsan \
       psmisc \
+      procps-ng \
       tcpdump \
       openssl \
       net-tools \

--- a/lte/gateway/docker/mme/Dockerfile.rhel8
+++ b/lte/gateway/docker/mme/Dockerfile.rhel8
@@ -458,6 +458,7 @@ RUN yum update -y && \
       libasan \
       liblsan \
       psmisc \
+      procps-ng \
       tcpdump \
       openssl \
       net-tools \


### PR DESCRIPTION
Signed-off-by: Raphael Defosseux <raphael.defosseux@openairinterface.org>

## Summary

Just noticed that [RHEL8 magma deployment check](https://jenkins-oai.eurecom.fr/job/MAGMA-MME-RHEL8-Deploy-Check/497/artifact/test_results_magma_epc_rhel8.html) was in the red. Even if the test passed.

Friday I updated the `RHEL8` latest `UBI8` image and I guess `procps-ng` is no more there by default.

Added explicitly it to the target image.
 
## Test Plan

none required. The red box in CI shall be back in green.

## Additional Information

- [ ] This change is backwards-breaking
