### PR TITLE
[AMF] Authentication Reject message related  changes

### DIFF
--- a/lte/gateway/c/oai/lib/3gpp/3gpp_24.501.h
+++ b/lte/gateway/c/oai/lib/3gpp/3gpp_24.501.h
@@ -96,6 +96,7 @@ Deregistration accept (UE terminated) */
 #define AMF_UE_SECURITY_CAPABILITIES_MISMATCH                                  \
   23  // UE security capabilities mismatch
 #define AMF_SECURITY_MODE_REJECT 24
+#define AMF_NON_5G_AUTHENTICATION_UNACCEPTABLE 26
 
 /* 5G Timer structure */
 typedef struct nas5g_timer_s {

--- a/lte/gateway/c/oai/tasks/amf/amf_authentication.h
+++ b/lte/gateway/c/oai/tasks/amf/amf_authentication.h
@@ -31,6 +31,8 @@ typedef struct nas5g_amf_auth_proc_s {
   uint8_t rand[AUTH_RAND_SIZE]; /* Random challenge number  */
   uint8_t autn[AUTH_AUTN_SIZE]; /* Authentication token     */
   int amf_cause;
+  int retry_sync_failure;
+#define MAX_SYNC_FAILURES 2
 } nas5g_amf_auth_proc_t;
 
 typedef struct nas5g_auth_info_proc_s {


### PR DESCRIPTION
<!--

-->
Changes: Authentication Reject support for the below causes
Cause #20 – MAC failure
Cause #21 – Synch failure
Cause #26 – Non-5G authentication unacceptable

Testing:
![AR-MAC-Failure](https://user-images.githubusercontent.com/83354949/127499760-0f547f35-239a-4803-b0cb-24704ab464fe.jpg)
![AR-Synch-Failure](https://user-images.githubusercontent.com/83354949/127499765-cda586ac-9596-459a-9c8d-27b528e51533.jpg)
![AR-NON_5G_A_U](https://user-images.githubusercontent.com/83354949/127499769-767001fc-fff1-423f-8245-fd35a431a51b.jpg)

UT testing done using UERANSIM

## Summary

<!-- Enumerate changes you made and why you made them -->

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
