### PR TITLE
feat: Add initial changes to build protos/grpc with Bazel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -97,3 +97,9 @@ fb
 orc8r/cloud/coverage/
 feg/gateway/coverage/
 lte/gateway/c/oai/code_coverage/
+
+# Bazel
+bazel-bin
+bazel-magma
+bazel-out
+bazel-testlogs

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,0 +1,5 @@
+load("@com_github_bazelbuild_buildtools//buildifier:def.bzl", "buildifier")
+
+buildifier(
+    name = "buildifier",
+)

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,0 +1,114 @@
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
+
+### BUILDIFIER DEPENDENCIES
+# See https://github.com/bazelbuild/buildtools/blob/master/buildifier/README.md
+# buildifier is written in Go and hence needs rules_go to be built.
+# See https://github.com/bazelbuild/rules_go for the up to date setup instructions.
+http_archive(
+    name = "io_bazel_rules_go",
+    sha256 = "d1ffd055969c8f8d431e2d439813e42326961d0942bdf734d2c95dc30c369566",
+    urls = [
+        "https://mirror.bazel.build/github.com/bazelbuild/rules_go/releases/download/v0.24.5/rules_go-v0.24.5.tar.gz",
+        "https://github.com/bazelbuild/rules_go/releases/download/v0.24.5/rules_go-v0.24.5.tar.gz",
+    ],
+)
+
+load("@io_bazel_rules_go//go:deps.bzl", "go_register_toolchains", "go_rules_dependencies")
+
+go_rules_dependencies()
+
+go_register_toolchains()
+
+http_archive(
+    name = "bazel_gazelle",
+    sha256 = "b85f48fa105c4403326e9525ad2b2cc437babaa6e15a3fc0b1dbab0ab064bc7c",
+    urls = [
+        "https://mirror.bazel.build/github.com/bazelbuild/bazel-gazelle/releases/download/v0.22.2/bazel-gazelle-v0.22.2.tar.gz",
+        "https://github.com/bazelbuild/bazel-gazelle/releases/download/v0.22.2/bazel-gazelle-v0.22.2.tar.gz",
+    ],
+)
+
+load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies")
+
+# If you use WORKSPACE.bazel, use the following line instead of the bare gazelle_dependencies():
+# gazelle_dependencies(go_repository_default_config = "@//:WORKSPACE.bazel")
+gazelle_dependencies()
+
+# protobuf dependency covered below
+
+http_archive(
+    name = "com_github_bazelbuild_buildtools",
+    sha256 = "4698e467ed72b09227afcb7b8d289f8ec0eaead3494f7b80aefc6610e0ae855b",
+    strip_prefix = "buildtools-master",
+    url = "https://github.com/bazelbuild/buildtools/archive/master.zip",
+)
+### BUILDIFIER DEPENDENCIES
+
+http_archive(
+    name = "bazel_skylib",
+    sha256 = "1c531376ac7e5a180e0237938a2536de0c54d93f5c278634818e0efc952dd56c",
+    urls = [
+        "https://github.com/bazelbuild/bazel-skylib/releases/download/1.0.3/bazel-skylib-1.0.3.tar.gz",
+        "https://mirror.bazel.build/github.com/bazelbuild/bazel-skylib/releases/download/1.0.3/bazel-skylib-1.0.3.tar.gz",
+    ],
+)
+
+load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
+
+bazel_skylib_workspace()
+
+# rules_cc defines rules for generating C++ code from Protocol Buffers.
+http_archive(
+    name = "rules_cc",
+    sha256 = "56ac9633c13d74cb71e0546f103ce1c58810e4a76aa8325da593ca4277908d72",
+    strip_prefix = "rules_cc-40548a2974f1aea06215272d9c2b47a14a24e556",
+    urls = ["https://github.com/bazelbuild/rules_cc/archive/40548a2974f1aea06215272d9c2b47a14a24e556.zip"],
+)
+
+load("@rules_cc//cc:repositories.bzl", "rules_cc_dependencies")
+
+rules_cc_dependencies()
+
+### PROTO / GRPC DEPENDENCIES ###
+load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
+
+git_repository(
+    name = "com_google_protobuf",
+    commit = "0770434ff0ab33ce68a647c311bbe38be03a73c1",
+    remote = "https://github.com/protocolbuffers/protobuf",
+    shallow_since = "1624681439 -0700",
+)
+
+load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps")
+
+protobuf_deps()
+
+# see https://rules-proto-grpc.aliddell.com/en/latest/index.html
+http_archive(
+    name = "rules_proto_grpc",
+    sha256 = "7954abbb6898830cd10ac9714fbcacf092299fda00ed2baf781172f545120419",
+    strip_prefix = "rules_proto_grpc-3.1.1",
+    urls = ["https://github.com/rules-proto-grpc/rules_proto_grpc/archive/3.1.1.tar.gz"],
+)
+
+load("@rules_proto_grpc//:repositories.bzl", "rules_proto_grpc_repos", "rules_proto_grpc_toolchains")
+
+rules_proto_grpc_toolchains()
+
+rules_proto_grpc_repos()
+
+load("@rules_proto//proto:repositories.bzl", "rules_proto_dependencies", "rules_proto_toolchains")
+
+rules_proto_dependencies()
+
+rules_proto_toolchains()
+
+load("@rules_proto_grpc//cpp:repositories.bzl", rules_proto_grpc_cpp_repos = "cpp_repos")
+
+rules_proto_grpc_cpp_repos()
+
+load("@com_github_grpc_grpc//bazel:grpc_deps.bzl", "grpc_deps")
+
+grpc_deps()
+### PROTO / GRPC DEPENDENCIES ###

--- a/experimental/bazel-base/Dockerfile
+++ b/experimental/bazel-base/Dockerfile
@@ -1,0 +1,32 @@
+################################################################
+# Builder Image (can also be used as developer's image)
+################################################################
+FROM ubuntu:focal as bazel_builder
+
+ENV TZ=America/New_York
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && \
+    apt-get upgrade -y && \
+    apt-get install -y --no-install-recommends \
+        apt-transport-https \
+        apt-utils \
+        build-essential \
+        ca-certificates \
+        curl \
+        gcc \
+        git \
+        gnupg2 \
+        g++ \
+        python-dev \
+        zip \
+        unzip \
+        vim \
+        wget
+
+WORKDIR /usr/sbin
+RUN wget --progress=dot:giga https://github.com/bazelbuild/bazelisk/releases/download/v1.6.1/bazelisk-linux-amd64 && \
+    chmod +x bazelisk-linux-amd64 && \
+    ln -s /usr/sbin/bazelisk-linux-amd64 /usr/sbin/bazel
+
+WORKDIR /magma

--- a/experimental/bazel-base/README.md
+++ b/experimental/bazel-base/README.md
@@ -1,0 +1,41 @@
+> :warning: **Bazel based builds are still experimental**
+
+# Bazel-Build Docker Image
+This Dockerfile is used to create a build space for all development with Bazel.
+
+## Build bazel-build Docker image
+
+To build bazel-build base image, run the following.
+
+```bash
+# MAGMA_ROOT should be set to repo root
+export PATH_TO_DOCKERFILE=$MAGMA_ROOT/experimental/bazel-base/Dockerfile
+docker build -t magma/bazel-build -f $PATH_TO_DOCKERFILE $MAGMA_ROOT
+```
+
+## Run bazel commands
+
+To run bazel commands, exec into a bazel-build container,
+
+```bash
+docker run -v $MAGMA_ROOT:/magma -v $MAGMA_ROOT/lte/gateway/configs:/etc/magma -i -t magma/bazel-build:latest /bin/bash
+```
+
+Once insider the container, bazel can be run like this,
+
+```bash
+# To build all targets
+bazel build ...
+# To build a specific target (Ex: session_manager.proto)
+bazel build lte/protos:session_manager_cpp_proto
+# To run all tests
+bazel test ...
+```
+
+## Format bazel files
+
+To format all bazel related files, exec into a bazel container and run the following
+
+```bash
+bazel run //:buildifier
+```

--- a/lte/protos/BUILD.bazel
+++ b/lte/protos/BUILD.bazel
@@ -1,0 +1,199 @@
+load("@rules_cc//cc:defs.bzl", "cc_library")
+load("@rules_proto//proto:defs.bzl", "proto_library")
+load("@rules_proto_grpc//cpp:defs.bzl", "cpp_grpc_library")
+load("@rules_proto_grpc//cpp:defs.bzl", "cpp_proto_library")
+
+package(default_visibility = ["//visibility:public"])
+
+cpp_proto_library(
+    name = "abort_session_cpp_proto",
+    protos = [":abort_session_proto"],
+)
+
+proto_library(
+    name = "abort_session_proto",
+    srcs = ["abort_session.proto"],
+    deps = [],
+)
+
+cpp_proto_library(
+    name = "apn_cpp_proto",
+    protos = [":apn_proto"],
+)
+
+cpp_grpc_library(
+    name = "apn_cpp_grpc",
+    protos = [":apn_proto"],
+)
+
+proto_library(
+    name = "apn_proto",
+    srcs = ["apn.proto"],
+    deps = [],
+)
+
+cpp_proto_library(
+    name = "subscriberdb_cpp_proto",
+    protos = [":subscriberdb_proto"],
+    deps = [
+        ":apn_cpp_proto",
+        "//orc8r/protos:common_cpp_proto",
+    ],
+)
+
+cpp_grpc_library(
+    name = "subscriberdb_cpp_grpc",
+    protos = [":subscriberdb_proto"],
+    deps = [
+        ":apn_cpp_grpc",
+        "//orc8r/protos:common_cpp_grpc",
+    ],
+)
+
+proto_library(
+    name = "subscriberdb_proto",
+    srcs = ["subscriberdb.proto"],
+    deps = [
+        ":apn_proto",
+        "//orc8r/protos:common_proto",
+        "@com_google_protobuf//:field_mask_proto",
+    ],
+)
+
+cpp_proto_library(
+    name = "mobilityd_cpp_proto",
+    protos = [":mobilityd_proto"],
+    deps = [
+        ":subscriberdb_cpp_proto",
+    ],
+)
+
+cpp_grpc_library(
+    name = "mobilityd_cpp_grpc",
+    protos = [":mobilityd_proto"],
+    deps = [
+        ":subscriberdb_cpp_grpc",
+        "//orc8r/protos:common_cpp_grpc",
+    ],
+)
+
+proto_library(
+    name = "mobilityd_proto",
+    srcs = ["mobilityd.proto"],
+    deps = [
+        ":subscriberdb_proto",
+        "//orc8r/protos:common_proto",
+    ],
+)
+
+cpp_proto_library(
+    name = "policydb_cpp_proto",
+    protos = [":policydb_proto"],
+    deps = [
+        ":mobilityd_cpp_proto",
+        "//orc8r/protos:common_cpp_proto",
+    ],
+)
+
+cpp_grpc_library(
+    name = "policydb_cpp_grpc",
+    protos = [":policydb_proto"],
+    deps = [
+        ":mobilityd_cpp_grpc",
+        "//orc8r/protos:common_cpp_grpc",
+    ],
+)
+
+proto_library(
+    name = "policydb_proto",
+    srcs = ["policydb.proto"],
+    deps = [
+        ":mobilityd_proto",
+        "//orc8r/protos:common_proto",
+    ],
+)
+
+cpp_proto_library(
+    name = "session_manager_cpp_proto",
+    protos = [":session_manager_proto"],
+    deps = [
+        ":apn_cpp_proto",
+        ":policydb_cpp_proto",
+        "//orc8r/protos:common_cpp_proto",
+    ],
+)
+
+cpp_grpc_library(
+    name = "session_manager_cpp_grpc",
+    protos = [":session_manager_proto"],
+    deps = [
+        ":apn_cpp_grpc",
+        ":policydb_cpp_grpc",
+        "//orc8r/protos:common_cpp_grpc",
+    ],
+)
+
+proto_library(
+    name = "session_manager_proto",
+    srcs = ["session_manager.proto"],
+    deps = [
+        ":apn_proto",
+        ":policydb_proto",
+        ":subscriberdb_proto",
+        "//orc8r/protos:common_proto",
+        "@com_google_protobuf//:timestamp_proto",
+    ],
+)
+
+cpp_proto_library(
+    name = "pipelined_cpp_proto",
+    protos = [":pipelined_proto"],
+    deps = [
+        "apn_cpp_proto",
+        "policydb_cpp_proto",
+        ":session_manager_cpp_proto",
+        "//orc8r/protos:common_cpp_proto",
+    ],
+)
+
+cpp_grpc_library(
+    name = "pipelined_cpp_grpc",
+    protos = [":pipelined_proto"],
+    deps = [
+        "apn_cpp_grpc",
+        "policydb_cpp_grpc",
+        ":session_manager_cpp_grpc",
+        "//orc8r/protos:common_cpp_grpc",
+    ],
+)
+
+proto_library(
+    name = "pipelined_proto",
+    srcs = ["pipelined.proto"],
+    deps = [
+        ":apn_proto",
+        ":mobilityd_proto",
+        ":policydb_proto",
+        ":session_manager_proto",
+        ":subscriberdb_proto",
+        "//orc8r/protos:common_proto",
+    ],
+)
+
+cpp_proto_library(
+    name = "spgw_service_cpp_proto",
+    protos = [":spgw_service_proto"],
+    deps = [
+        ":policydb_cpp_proto",
+        ":subscriberdb_cpp_proto",
+    ],
+)
+
+proto_library(
+    name = "spgw_service_proto",
+    srcs = ["spgw_service.proto"],
+    deps = [
+        ":policydb_proto",
+        ":subscriberdb_proto",
+    ],
+)

--- a/orc8r/protos/BUILD.bazel
+++ b/orc8r/protos/BUILD.bazel
@@ -1,0 +1,117 @@
+load("@rules_proto//proto:defs.bzl", "proto_library")
+load("@rules_proto_grpc//cpp:defs.bzl", "cpp_grpc_library")
+load("@rules_proto_grpc//cpp:defs.bzl", "cpp_proto_library")
+
+package(default_visibility = ["//visibility:public"])
+
+cpp_proto_library(
+    name = "common_cpp_proto",
+    protos = [":common_proto"],
+)
+
+cpp_grpc_library(
+    name = "common_cpp_grpc",
+    protos = [":common_proto"],
+)
+
+proto_library(
+    name = "common_proto",
+    srcs = ["common.proto"],
+)
+
+cpp_grpc_library(
+    name = "eventd_cpp_grpc",
+    protos = [":eventd_proto"],
+    deps = [
+        ":common_cpp_grpc",
+    ],
+)
+
+proto_library(
+    name = "eventd_proto",
+    srcs = ["eventd.proto"],
+    deps = [
+        ":common_proto",
+    ],
+)
+
+cpp_proto_library(
+    name = "redis_cpp_proto",
+    protos = [":redis_proto"],
+)
+
+cpp_grpc_library(
+    name = "redis_cpp_grpc",
+    protos = [":redis_proto"],
+)
+
+proto_library(
+    name = "redis_proto",
+    srcs = ["redis.proto"],
+)
+
+proto_library(
+    name = "mconfigs_proto",
+    srcs = ["mconfig/mconfigs.proto"],
+    strip_import_prefix = "mconfig/",
+    deps = [
+        ":common_proto",
+    ],
+)
+
+cpp_proto_library(
+    name = "metrics_cpp_proto",
+    protos = [":metrics_proto"],
+)
+
+proto_library(
+    name = "metrics_proto",
+    srcs = ["prometheus/metrics.proto"],
+    strip_import_prefix = "prometheus/",
+)
+
+cpp_proto_library(
+    name = "metricsd_cpp_proto",
+    protos = [":metricsd_proto"],
+    deps = [
+        ":common_cpp_proto",
+        ":metrics_cpp_proto",
+    ],
+)
+
+proto_library(
+    name = "metricsd_proto",
+    srcs = ["metricsd.proto"],
+    deps = [
+        ":common_proto",
+        ":metrics_proto",
+    ],
+)
+
+cpp_grpc_library(
+    name = "service303_cpp_grpc",
+    protos = [":service303_proto"],
+    deps = [
+        ":common_cpp_proto",
+        ":metricsd_cpp_proto",
+    ],
+)
+
+cpp_proto_library(
+    name = "service303_cpp_proto",
+    protos = [":service303_proto"],
+    deps = [
+        ":common_cpp_proto",
+        ":metricsd_cpp_proto",
+    ],
+)
+
+proto_library(
+    name = "service303_proto",
+    srcs = ["service303.proto"],
+    deps = [
+        ":common_proto",
+        ":metricsd_proto",
+        "@com_google_protobuf//:wrappers_proto",
+    ],
+)


### PR DESCRIPTION
Signed-off-by: Marie Bremner <marwhal@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary
This commit does not affect any existing build infrastructure

First commit to get some bazel build working for proto / grpc, the goal is to eventually build SessionD (Tracked @ https://github.com/magma/magma/issues/8049)

This PR includes
1. Dockerfile so that I can do all my bazel build in a reproducible env easily
2. README.md to include any build instructions useful to have in the repo
2. WORKSPACE file to initialize any dependencies (currently only includes deps for protos and bazel formatter - buildifier)
3. BUILD.bazel files in both lte/protos and orc8r/protos to provide build targets
<!-- Enumerate changes you made and why you made them -->

## Test Plan
inside the bazel container...
```bash
bazel run //:buildifier
bazel build ...
```

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
