### PR TITLE
fix(mme): Fix memory leak in TAU procedure

### DIFF
--- a/lte/gateway/c/oai/tasks/nas/emm/TrackingAreaUpdate.c
+++ b/lte/gateway/c/oai/tasks/nas/emm/TrackingAreaUpdate.c
@@ -645,11 +645,8 @@ static int emm_tracking_area_update_accept(nas_emm_tau_proc_t* const tau_proc) {
       emm_sap.u.emm_as.u.establish.emergency_number_list = NULL;
 
       emm_sap.u.emm_as.u.establish.eps_network_feature_support =
-          calloc(1, sizeof(eps_network_feature_support_t));
-      emm_sap.u.emm_as.u.establish.eps_network_feature_support->b1 =
-          _emm_data.conf.eps_network_feature_support[0];
-      emm_sap.u.emm_as.u.establish.eps_network_feature_support->b2 =
-          _emm_data.conf.eps_network_feature_support[1];
+          (eps_network_feature_support_t*) &_emm_data.conf
+              .eps_network_feature_support;
       emm_sap.u.emm_as.u.establish.additional_update_result = NULL;
       emm_sap.u.emm_as.u.establish.t3412_extended           = NULL;
       emm_sap.u.emm_as.u.establish.nas_msg =
@@ -743,11 +740,8 @@ static int emm_tracking_area_update_accept(nas_emm_tau_proc_t* const tau_proc) {
       }
 
       emm_sap.u.emm_as.u.establish.eps_network_feature_support =
-          calloc(1, sizeof(eps_network_feature_support_t));
-      emm_sap.u.emm_as.u.establish.eps_network_feature_support->b1 =
-          _emm_data.conf.eps_network_feature_support[0];
-      emm_sap.u.emm_as.u.establish.eps_network_feature_support->b2 =
-          _emm_data.conf.eps_network_feature_support[1];
+          (eps_network_feature_support_t*) &_emm_data.conf
+              .eps_network_feature_support;
 
       /*If CSFB is enabled,store LAI,Mobile Identity and
        * Additional Update type to be sent in TAU accept to S1AP


### PR DESCRIPTION
<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->
Backports only the TAU part of the memory leak fix in #8029.  The other part was introduced and fixed on the same release cycle, hence it does have no effect on v1.5.
 
## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->
Integ tests. Spirent tests.

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
