### PR TITLE
docs: update python conventions doc

### DIFF
--- a/docs/readmes/contributing/contribute_conventions.md
+++ b/docs/readmes/contributing/contribute_conventions.md
@@ -234,13 +234,11 @@ def foo(arg1: str) -> int:
 - For mandatory lint checks, we have a unit test that runs [Pylint](https://pypi.org/project/pylint/) on all gateway services
   - On CI, the check gets run as part of the `lte-test` job
 - Additionally, we have a [Reviewdog](https://github.com/reviewdog/reviewdog) linter using [wemake-python-styleguide](https://wemake-python-stylegui.de/en/latest/) enabled to aid the code review process
-  - To run the linter locally, use the [precommit script](https://github.com/magma/magma/blob/master/lte/gateway/python/precommit.py)
+  - Instructions on running the linter locally is provided [here](../lte/dev_unit_testing#format-agw)
 
 **Formatters**
 
-- We recommend [autopep8](https://pypi.org/project/autopep8/) as it conforms to [pep8](https://www.python.org/dev/peps/pep-0008/)
-  - The above-mentioned [precommit script](https://github.com/magma/magma/blob/master/lte/gateway/python/precommit.py) also has an option to format your changes with
-  [isort](https://pypi.org/project/isort/), [autopep8](https://pypi.org/project/autopep8/), and [add-trailing-comma](https://pypi.org/project/add-trailing-comma/)
+- Instructions on formatting Python locally is provided [here](../lte/dev_unit_testing#format-agw)
 - We do *not* recommend other formatters such as [black](https://black.readthedocs.io/en/stable/installation_and_usage.html), as it diverges from pep8 on basic things like line length, etc.
 
 


### PR DESCRIPTION


Signed-off-by: Marie Bremner <marwhal@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary
@waqaraqeel pointed out recently that the doc points to the script file, not the documentation we have on how to use the script. Modifying the contributing convention guide to point to the recently added doc in docusaurus. 
<!-- Enumerate changes you made and why you made them -->

## Test Plan
local testing
<img width="803" alt="Screen Shot 2021-07-27 at 1 52 25 PM" src="https://user-images.githubusercontent.com/37634144/127211274-56dc1a6b-6eb7-443c-ad76-f09ba5d15c7f.png">
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
