### PR TITLE
fix(feg): Flip radius accounting Octets-In/Out to reflect UE centric usage representation

### DIFF
--- a/feg/gateway/services/aaa/servicers/accounting.go
+++ b/feg/gateway/services/aaa/servicers/accounting.go
@@ -113,9 +113,12 @@ func (srv *accountingService) InterimUpdate(_ context.Context, ur *protos.Update
 
 	if srv.config.GetAcctReportingEnabled() {
 		_, err = base_acct.Update(&fegpb.AcctUpdateReq{
-			Session:     baseAcctSessionFromCtx(s.GetCtx()),
-			OctetsIn:    uint64(octetsIn),
-			OctetsOut:   uint64(octetsOut),
+			Session: baseAcctSessionFromCtx(s.GetCtx()),
+			// Acct-Input/Output-Octets indicates how many octets have been received from/sent to
+			// the user over the course of this service (https://datatracker.ietf.org/doc/html/rfc2866#section-5.3)
+			// the counters represent AP point of view & need to be reversed for our accounting
+			OctetsIn:    uint64(octetsOut),
+			OctetsOut:   uint64(octetsIn),
 			SessionTime: uint32(uint64(time.Now().UnixNano()/NanoInMilli) - s.GetCtx().GetCreatedTimeMs()),
 		})
 	}
@@ -179,9 +182,12 @@ func (srv *accountingService) Stop(_ context.Context, req *protos.StopRequest) (
 
 	if baseAcctEnabled {
 		_, err = base_acct.Stop(&fegpb.AcctUpdateReq{
-			Session:     acctSession,
-			OctetsIn:    uint64(req.GetOctetsIn()),
-			OctetsOut:   uint64(req.GetOctetsOut()),
+			Session: acctSession,
+			// Acct-Input/Output-Octets indicates how many octets have been received from/sent to
+			// the user over the course of this service (https://datatracker.ietf.org/doc/html/rfc2866#section-5.3)
+			// the counters represent AP point of view & need to be reversed for our accounting
+			OctetsIn:    uint64(req.GetOctetsOut()),
+			OctetsOut:   uint64(req.GetOctetsIn()),
 			SessionTime: uint32(uint64(time.Now().UnixNano()/NanoInMilli) - createdTimeMs),
 		})
 	}


### PR DESCRIPTION

## Summary

Flip radius accounting Octets-In/Out to reflect UE centric usage representation.
While radius accounting RFC is not 100% clear on In/Out definition: https://datatracker.ietf.org/doc/html/rfc2866#section-5.3,
vendor references (https://infocenter.nokia.com/public/7750SR150R5A/topic/com.sr.radius/html/sros_radius_attrib.html?cp=14_0) as well as known implementations take AP centric point of view. We need to flip In & Out for UE centric accounting.


## Test Plan

unit tests, verify on test APs

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
