### PR TITLE
fix: Avoid using retry module

### DIFF
--- a/.github/workflows/cwag-workflow.yml
+++ b/.github/workflows/cwag-workflow.yml
@@ -67,13 +67,34 @@ jobs:
       MAGMA_ROOT: "${{ github.workspace }}"
     steps:
       - uses: actions/checkout@v2
-      - name: Run docker-compose
-        uses: nick-invision/retry@v2
-        with:
-          command: cd ${MAGMA_ROOT}/cwf/gateway/docker && docker-compose build --parallel
-          max_attempts: 2
-          timeout_minutes: 10
-          # TODO bring up the containers and check for crashloops
+      - name: Run docker compose
+        id: cwag-build-docker-compose
+        continue-on-error: true
+        # yamllint disable rule:line-length
+        env:
+          DOCKER_REGISTRY: cwf_
+        run: |
+          cd ${MAGMA_ROOT}/cwf/gateway/docker
+          docker-compose build --parallel
+      - name: Retry docker compose on failure
+        id: retry-cwag-build-docker-compose
+        continue-on-error: true
+        if: steps.cwag-docker-compose.outcome=='failure'
+        env:
+          DOCKER_REGISTRY: cwf_
+        run: |
+          cd ${MAGMA_ROOT}/cwf/gateway/docker
+          docker-compose build --parallel
+      - name: Set the job status
+        if: always()
+        run: |
+          if ${{ steps.cwag-build-docker-compose.outcome=='success' || steps.retry-cwag-build-docker-compose.outcome=='success' }}; then
+             echo "Docker compose completed successfully"
+          else
+             echo "Docker compose failed"
+             exit 1
+          fi
+        # TODO bring up the containers and check for crashloops
   cwag-deploy:
     needs:
       - cwag-precommit


### PR DESCRIPTION
Signed-off-by: Quentin, Derory <15911421+quentinDERORY@users.noreply.github.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

Retry module is not executing the command properly as shown in this PR where GHA succeeds and circle ci don't
https://github.com/magma/magma/pull/8282/checks?check_run_id=3172144915

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
