### PR TITLE
fix(orc8r): Update new protobuf link in codebase

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1157,7 +1157,7 @@ jobs:
       - run: pip3 install setuptools==49.6.0
       - run:
           command: |
-            sudo curl -Lfs https://github.com/google/protobuf/releases/download/v3.1.0/protoc-3.1.0-linux-x86_64.zip -o protoc3.zip
+            sudo curl -Lfs https://github.com/protocolbuffers/protobuf/releases/download/v3.1.0/protoc-3.1.0-linux-x86_64.zip -o protoc3.zip
             sudo unzip protoc3.zip -d protoc3
             sudo mv protoc3/bin/protoc /bin/protoc
             sudo chmod a+rx /bin/protoc

--- a/circleci/golang_before_install.sh
+++ b/circleci/golang_before_install.sh
@@ -16,7 +16,7 @@ sudo apt-get update -qq
 sudo apt-get install -y bzr parallel build-essential unzip default-jre
 
 # Install protobuf compiler
-sudo curl -Lfs https://github.com/google/protobuf/releases/download/v3.1.0/protoc-3.1.0-linux-x86_64.zip -o protoc3.zip
+sudo curl -Lfs https://github.com/protocolbuffers/protobuf/releases/download/v3.1.0/protoc-3.1.0-linux-x86_64.zip -o protoc3.zip
 sudo unzip protoc3.zip -d protoc3
 sudo mv protoc3/bin/protoc /bin/protoc
 sudo chmod a+rx /bin/protoc

--- a/cwf/gateway/docker/go/Dockerfile
+++ b/cwf/gateway/docker/go/Dockerfile
@@ -43,7 +43,7 @@ RUN curl https://facebookconnectivity.jfrog.io/artifactory/generic/go1.13.4.linu
     cp -r go/bin/* /usr/local/bin/
 
 # Install protobuf compiler.
-RUN curl -Lfs https://github.com/google/protobuf/releases/download/v3.1.0/protoc-3.1.0-linux-x86_64.zip -o protoc3.zip && \
+RUN curl -Lfs https://github.com/protocolbuffers/protobuf/releases/download/v3.1.0/protoc-3.1.0-linux-x86_64.zip -o protoc3.zip && \
     unzip protoc3.zip -d protoc3 && \
     mv protoc3/bin/protoc /bin/protoc && \
     chmod a+rx /bin/protoc && \

--- a/cwf/gateway/docker/python/Dockerfile
+++ b/cwf/gateway/docker/python/Dockerfile
@@ -11,7 +11,7 @@ RUN apt-get -y update && apt-get -y install curl make virtualenv zip \
   apt-utils software-properties-common apt-transport-https
 
 # Install protobuf compiler.
-RUN curl -Lfs https://github.com/google/protobuf/releases/download/v3.1.0/protoc-3.1.0-linux-x86_64.zip -o protoc3.zip && \
+RUN curl -Lfs https://github.com/protocolbuffers/protobuf/releases/download/v3.1.0/protoc-3.1.0-linux-x86_64.zip -o protoc3.zip && \
   unzip protoc3.zip -d protoc3 && \
   mv protoc3/bin/protoc /usr/bin/protoc && \
   chmod a+rx /usr/bin/protoc && \

--- a/feg/gateway/docker/go/Dockerfile
+++ b/feg/gateway/docker/go/Dockerfile
@@ -46,7 +46,7 @@ RUN curl https://facebookconnectivity.jfrog.io/artifactory/generic/go1.13.4.linu
     cp -r go/bin/* /usr/local/bin/
 
 # Install protobuf compiler.
-RUN curl -Lfs https://github.com/google/protobuf/releases/download/v3.1.0/protoc-3.1.0-linux-x86_64.zip -o protoc3.zip && \
+RUN curl -Lfs https://github.com/protocolbuffers/protobuf/releases/download/v3.1.0/protoc-3.1.0-linux-x86_64.zip -o protoc3.zip && \
     unzip protoc3.zip -d protoc3 && \
     mv protoc3/bin/protoc /bin/protoc && \
     chmod a+rx /bin/protoc && \

--- a/feg/gateway/docker/python/Dockerfile
+++ b/feg/gateway/docker/python/Dockerfile
@@ -11,7 +11,7 @@ RUN apt-get -y update && apt-get -y install curl make virtualenv zip \
  apt-utils software-properties-common apt-transport-https git openjdk-8-jdk ant
 
 # Install protobuf compiler.
-RUN curl -Lfs https://github.com/google/protobuf/releases/download/v3.1.0/protoc-3.1.0-linux-x86_64.zip -o protoc3.zip && \
+RUN curl -Lfs https://github.com/protocolbuffers/protobuf/releases/download/v3.1.0/protoc-3.1.0-linux-x86_64.zip -o protoc3.zip && \
   unzip protoc3.zip -d protoc3 && \
   mv protoc3/bin/protoc /usr/bin/protoc && \
   chmod a+rx /usr/bin/protoc && \

--- a/orc8r/cloud/docker/controller/Dockerfile
+++ b/orc8r/cloud/docker/controller/Dockerfile
@@ -30,7 +30,7 @@ RUN curl https://facebookconnectivity.jfrog.io/artifactory/generic/go1.13.4.linu
 # Protobuf compiler
 # Apt has 2.x but we need 3.x
 # See: https://grpc.io/docs/protoc-installation/
-RUN curl -Lfs https://github.com/google/protobuf/releases/download/v3.1.0/protoc-3.1.0-linux-x86_64.zip -o protoc3.zip && \
+RUN curl -Lfs https://github.com/protocolbuffers/protobuf/releases/download/v3.1.0/protoc-3.1.0-linux-x86_64.zip -o protoc3.zip && \
     unzip protoc3.zip -d protoc3 && \
     mv protoc3/bin/protoc /bin/protoc && \
     chmod a+rx /bin/protoc && \

--- a/orc8r/gateway/docker/Dockerfile
+++ b/orc8r/gateway/docker/Dockerfile
@@ -7,7 +7,7 @@ RUN apt-get -y update && apt-get -y install curl make virtualenv zip \
   apt-utils software-properties-common apt-transport-https
 
 # Install protobuf compiler.
-RUN curl -Lfs https://github.com/google/protobuf/releases/download/v3.1.0/protoc-3.1.0-linux-x86_64.zip -o protoc3.zip && \
+RUN curl -Lfs https://github.com/protocolbuffers/protobuf/releases/download/v3.1.0/protoc-3.1.0-linux-x86_64.zip -o protoc3.zip && \
   unzip protoc3.zip -d protoc3 && \
   mv protoc3/bin/protoc /usr/bin/protoc && \
   chmod a+rx /usr/bin/protoc && \

--- a/orc8r/tools/ansible/roles/gateway_dev/tasks/main.yml
+++ b/orc8r/tools/ansible/roles/gateway_dev/tasks/main.yml
@@ -67,7 +67,7 @@
 - name: Install protobuf compiler
   command: "{{ item }}"
   with_items:
-    - curl -Lfs https://github.com/google/protobuf/releases/download/v3.1.0/protoc-3.1.0-linux-x86_64.zip -o protoc3.zip
+    - curl -Lfs https://github.com/protocolbuffers/protobuf/releases/download/v3.1.0/protoc-3.1.0-linux-x86_64.zip -o protoc3.zip
     - unzip protoc3.zip -d protoc3
     - mv protoc3/bin/protoc /usr/bin/protoc
     - chmod a+rx /usr/bin/protoc


### PR DESCRIPTION
Signed-off-by: Timothée Dzik <timdzik@fb.com>

fix(all): Update new protobuf link in codebase

## Summary
Protobuf link moved from https://github.com/google/protobuf/releases/download to https://github.com/protocolbuffers/protobuf/releases/download/

## Test Plan

Make CI green 

## Additional Information

- [ ] This change is backwards-breaking
