### PR TITLE
fix(agw): fix perf regression with GTP echo

### DIFF
--- a/third_party/gtp_ovs/ovs-gtp-patches/2.14/0001-of-match-expand-NXM_NX_TUN_FLAGS-to-include-all-tunn.patch
+++ b/third_party/gtp_ovs/ovs-gtp-patches/2.14/0001-of-match-expand-NXM_NX_TUN_FLAGS-to-include-all-tunn.patch
@@ -1,7 +1,7 @@
-From c9d807443db2087baae9a36ad3cc58960818de43 Mon Sep 17 00:00:00 2001
+From 54273a31aaf4e9028265eab3ba35d744c76a7286 Mon Sep 17 00:00:00 2001
 From: Pravin B Shelar <pbshelar@fb.com>
 Date: Sun, 28 Jun 2020 21:49:40 +0000
-Subject: [PATCH 01/19] of-match: expand NXM_NX_TUN_FLAGS to include all tunnel
+Subject: [PATCH 01/20] of-match: expand NXM_NX_TUN_FLAGS to include all tunnel
  flags
 
 This allows OVS flows to match tunnel key and df flags. maching on

--- a/third_party/gtp_ovs/ovs-gtp-patches/2.14/0002-userspace-IPFIX-Add-tunnel-type-GTP.patch
+++ b/third_party/gtp_ovs/ovs-gtp-patches/2.14/0002-userspace-IPFIX-Add-tunnel-type-GTP.patch
@@ -1,7 +1,7 @@
-From 5c1e8256e36ccd942f077671f7c5bfb5b17bda46 Mon Sep 17 00:00:00 2001
+From 619ba66cdd60bdf651c8234d6722caa0214d4628 Mon Sep 17 00:00:00 2001
 From: Pravin B Shelar <pbshelar@fb.com>
 Date: Mon, 24 Feb 2020 04:29:56 +0000
-Subject: [PATCH 02/19] userspace: IPFIX: Add tunnel type GTP
+Subject: [PATCH 02/20] userspace: IPFIX: Add tunnel type GTP
 
 Add support for ingress/egress tunnel type GTP
 in IPFIX.

--- a/third_party/gtp_ovs/ovs-gtp-patches/2.14/0003-datapath-add-vport-gtp-for-GPRS-Tunneling-Protocol.patch
+++ b/third_party/gtp_ovs/ovs-gtp-patches/2.14/0003-datapath-add-vport-gtp-for-GPRS-Tunneling-Protocol.patch
@@ -1,7 +1,7 @@
-From 1d32fe6cc56137fd6b032940e6033a997d9545f5 Mon Sep 17 00:00:00 2001
+From 6a30c02a8cb201660ae6acafe63b468a7e88e78d Mon Sep 17 00:00:00 2001
 From: Pravin B Shelar <pbshelar@fb.com>
 Date: Sat, 28 Nov 2020 00:55:30 -0800
-Subject: [PATCH 03/19] datapath: add vport-gtp for GPRS Tunneling Protocol
+Subject: [PATCH 03/20] datapath: add vport-gtp for GPRS Tunneling Protocol
 
 Add vport-gtp which uses gtp_create_flow_based_dev exported by the Linux GTP
 module to create a flow based net_device

--- a/third_party/gtp_ovs/ovs-gtp-patches/2.14/0004-ovs-Add-support-to-set-GTP-header-fields.patch
+++ b/third_party/gtp_ovs/ovs-gtp-patches/2.14/0004-ovs-Add-support-to-set-GTP-header-fields.patch
@@ -1,7 +1,7 @@
-From a8c20610f041c87448d2d1d721ccf4c507a17099 Mon Sep 17 00:00:00 2001
+From c914c7fc3d6c77da28bfa8eaeb2dc7b2c5e40860 Mon Sep 17 00:00:00 2001
 From: Pravin B Shelar <pbshelar@fb.com>
 Date: Sat, 28 Nov 2020 00:58:18 -0800
-Subject: [PATCH 04/19] ovs: Add support to set GTP header fields.
+Subject: [PATCH 04/20] ovs: Add support to set GTP header fields.
 
 This allows OVS to match and set GTP header fields.
 This is useful when controller wants to send GTP
@@ -456,7 +456,7 @@ index 1c5a4930a..a59c0f9bf 100644
       * OXM: NXOXM_ET_GTPU_MSGTYPE(16) since v2.13.
       */
 diff --git a/lib/dpif-netlink.c b/lib/dpif-netlink.c
-index ef7ffe506..cd98a6980 100644
+index 10c522ef0..d68cc7e36 100644
 --- a/lib/dpif-netlink.c
 +++ b/lib/dpif-netlink.c
 @@ -2520,8 +2520,7 @@ parse_odp_packet(struct ofpbuf *buf, struct dpif_upcall *upcall,

--- a/third_party/gtp_ovs/ovs-gtp-patches/2.14/0005-OVS-gtp-echo-handling.patch
+++ b/third_party/gtp_ovs/ovs-gtp-patches/2.14/0005-OVS-gtp-echo-handling.patch
@@ -1,7 +1,7 @@
-From 5488098e2722da39fd48890598480050c0e1e9ec Mon Sep 17 00:00:00 2001
+From c1b11c6bd1284be65fd08048df34c5774d618c45 Mon Sep 17 00:00:00 2001
 From: Pravin B Shelar <pbshelar@fb.com>
 Date: Mon, 29 Jun 2020 02:45:36 +0000
-Subject: [PATCH 05/19] OVS: gtp echo handling
+Subject: [PATCH 05/20] OVS: gtp echo handling
 
 This uses OVS BFD module to send ech msgs.
 
@@ -10,10 +10,10 @@ testing done using ./tests/test-gtp 1.11.1.1 3201000a0000000000010000ff0003000a0
 Signed-off-by: Pravin B Shelar <pbshelar@fb.com>
 ---
  include/openvswitch/packets.h  |  16 ++
- lib/bfd.c                      |  81 ++++++++--
+ lib/bfd.c                      |  98 +++++++++--
  lib/bfd.h                      |   4 +-
  lib/netdev-provider.h          |   8 +
- lib/netdev-vport.c             | 179 ++++++++++++++++++++-
+ lib/netdev-vport.c             | 178 +++++++++++++++++++-
  lib/netdev.c                   |  38 +++++
  lib/netdev.h                   |  16 ++
  ofproto/ofproto-dpif-monitor.c |  13 +-
@@ -23,9 +23,9 @@ Signed-off-by: Pravin B Shelar <pbshelar@fb.com>
  ofproto/ofproto-dpif.h         |   2 +
  tests/automake.mk              |   3 +
  tests/system-common-macros.at  |  19 +++
- tests/system-layer3-tunnels.at | 285 +++++++++++++++++++++++++++------
- tests/test-gtp.c               | 111 +++++++++++++
- 16 files changed, 746 insertions(+), 83 deletions(-)
+ tests/system-layer3-tunnels.at | 297 +++++++++++++++++++++++++++------
+ tests/test-gtp.c               | 111 ++++++++++++
+ 16 files changed, 773 insertions(+), 84 deletions(-)
  create mode 100644 tests/test-gtp.c
 
 diff --git a/include/openvswitch/packets.h b/include/openvswitch/packets.h
@@ -56,7 +56,7 @@ index 236ae26cc..2f3fa3191 100644
  }
  #endif
 diff --git a/lib/bfd.c b/lib/bfd.c
-index 3c965699a..8433de86a 100644
+index 3c965699a..6e4ac8eb5 100644
 --- a/lib/bfd.c
 +++ b/lib/bfd.c
 @@ -15,6 +15,7 @@
@@ -67,7 +67,26 @@ index 3c965699a..8433de86a 100644
  #include <sys/types.h>
  #include <netinet/in.h>
  #include <arpa/inet.h>
-@@ -521,6 +522,7 @@ long long int
+@@ -358,7 +359,7 @@ bfd_configure(struct bfd *bfd, const char *name, const struct smap *cfg,
+     int decay_min_rx;
+     long long int min_tx, min_rx;
+     bool need_poll = false;
+-    bool cfg_min_rx_changed = false;
++    bool cfg_min_rx_changed = false, dummy1=false;
+     bool cpath_down, forwarding_if_rx;
+ 
+     if (!cfg || !smap_get_bool(cfg, "enable", false)) {
+@@ -477,6 +478,9 @@ bfd_configure(struct bfd *bfd, const char *name, const struct smap *cfg,
+         bfd_forwarding_if_rx_update(bfd);
+     }
+ 
++    if (netdev_should_send_keep_alive_pkt(bfd->netdev, &dummy1) != EOPNOTSUPP) {
++        need_poll = true;
++    }
+     if (need_poll) {
+         bfd_poll(bfd);
+     }
+@@ -521,6 +525,7 @@ long long int
  bfd_wake_time(const struct bfd *bfd) OVS_EXCLUDED(mutex)
  {
      long long int retval;
@@ -75,7 +94,7 @@ index 3c965699a..8433de86a 100644
  
      if (!bfd) {
          return LLONG_MAX;
-@@ -530,9 +532,14 @@ bfd_wake_time(const struct bfd *bfd) OVS_EXCLUDED(mutex)
+@@ -530,9 +535,14 @@ bfd_wake_time(const struct bfd *bfd) OVS_EXCLUDED(mutex)
      if (bfd->flags & FLAG_FINAL) {
          retval = 0;
      } else {
@@ -93,7 +112,27 @@ index 3c965699a..8433de86a 100644
          }
      }
      ovs_mutex_unlock(&mutex);
-@@ -574,20 +581,26 @@ bfd_should_send_packet(const struct bfd *bfd) OVS_EXCLUDED(mutex)
+@@ -546,6 +556,11 @@ bfd_run(struct bfd *bfd) OVS_EXCLUDED(mutex)
+     bool old_in_decay;
+ 
+     ovs_mutex_lock(&mutex);
++    bool ret;
++    if (netdev_should_send_keep_alive_pkt(bfd->netdev, &ret) != EOPNOTSUPP) {
++        goto unlock;
++    }
++ 
+     now = time_msec();
+     old_in_decay = bfd->in_decay;
+ 
+@@ -566,6 +581,7 @@ bfd_run(struct bfd *bfd) OVS_EXCLUDED(mutex)
+         || bfd->in_decay != old_in_decay) {
+         bfd_poll(bfd);
+     }
++unlock:
+     ovs_mutex_unlock(&mutex);
+ }
+ 
+@@ -574,20 +590,26 @@ bfd_should_send_packet(const struct bfd *bfd) OVS_EXCLUDED(mutex)
  {
      bool ret;
      ovs_mutex_lock(&mutex);
@@ -123,7 +162,7 @@ index 3c965699a..8433de86a 100644
  
      ovs_mutex_lock(&mutex);
      if (bfd->next_tx) {
-@@ -612,6 +625,25 @@ bfd_put_packet(struct bfd *bfd, struct dp_packet *p,
+@@ -612,6 +634,25 @@ bfd_put_packet(struct bfd *bfd, struct dp_packet *p,
          ? eth_addr_bfd : bfd->local_eth_dst;
      eth->eth_type = htons(ETH_TYPE_IP);
  
@@ -149,7 +188,7 @@ index 3c965699a..8433de86a 100644
      ip = dp_packet_put_zeros(p, sizeof *ip);
      ip->ip_ihl_ver = IP_IHL_VER(5, 4);
      ip->ip_tot_len = htons(sizeof *ip + sizeof *udp + sizeof *msg);
-@@ -650,13 +682,20 @@ bfd_put_packet(struct bfd *bfd, struct dp_packet *p,
+@@ -650,13 +691,20 @@ bfd_put_packet(struct bfd *bfd, struct dp_packet *p,
      msg->min_rx = htonl(min_rx * 1000);
  
      bfd->flags &= ~FLAG_FINAL;
@@ -172,7 +211,7 @@ index 3c965699a..8433de86a 100644
  }
  
  bool
-@@ -664,6 +703,14 @@ bfd_should_process_flow(const struct bfd *bfd_, const struct flow *flow,
+@@ -664,6 +712,14 @@ bfd_should_process_flow(const struct bfd *bfd_, const struct flow *flow,
                          struct flow_wildcards *wc)
  {
      struct bfd *bfd = CONST_CAST(struct bfd *, bfd_);
@@ -187,19 +226,19 @@ index 3c965699a..8433de86a 100644
  
      if (!eth_addr_is_zero(bfd->rmt_eth_dst)) {
          memset(&wc->masks.dl_dst, 0xff, sizeof wc->masks.dl_dst);
-@@ -708,15 +755,21 @@ bfd_process_packet(struct bfd *bfd, const struct flow *flow,
+@@ -708,15 +764,21 @@ bfd_process_packet(struct bfd *bfd, const struct flow *flow,
      enum flags flags;
      uint8_t version;
      struct msg *msg;
 -    const uint8_t *l7 = dp_packet_get_udp_payload(p);
 +    const uint8_t *l7;
-+
+ 
 +    ovs_mutex_lock(&mutex);
 +    if (netdev_process_keep_alive_pkt(bfd->netdev, flow, p) == 0) {
 +        VLOG_DBG_RL(&rl, "%s: Received GTP echo packet", bfd->name);
 +        goto unlock;
 +    }
- 
++
 +    l7 = dp_packet_get_udp_payload(p);
      if (!l7) {
 -        return; /* No UDP payload. */
@@ -212,7 +251,7 @@ index 3c965699a..8433de86a 100644
      /* Increments the decay rx counter. */
      bfd->decay_rx_ctl++;
  
-@@ -726,7 +779,6 @@ bfd_process_packet(struct bfd *bfd, const struct flow *flow,
+@@ -726,7 +788,6 @@ bfd_process_packet(struct bfd *bfd, const struct flow *flow,
          /* XXX Should drop in the kernel to prevent DOS. */
          goto out;
      }
@@ -220,7 +259,7 @@ index 3c965699a..8433de86a 100644
      msg = dp_packet_at(p, l7 - (uint8_t *)dp_packet_data(p), BFD_PACKET_LEN);
      if (!msg) {
          VLOG_INFO_RL(&rl, "%s: Received too-short BFD control message (only "
-@@ -888,6 +940,7 @@ bfd_process_packet(struct bfd *bfd, const struct flow *flow,
+@@ -888,6 +949,7 @@ bfd_process_packet(struct bfd *bfd, const struct flow *flow,
  
  out:
      bfd_forwarding__(bfd);
@@ -228,12 +267,18 @@ index 3c965699a..8433de86a 100644
      ovs_mutex_unlock(&mutex);
  }
  
-@@ -966,6 +1019,10 @@ bfd_in_poll(const struct bfd *bfd) OVS_REQUIRES(mutex)
+@@ -966,6 +1028,16 @@ bfd_in_poll(const struct bfd *bfd) OVS_REQUIRES(mutex)
  static void
  bfd_poll(struct bfd *bfd) OVS_REQUIRES(mutex)
  {
 +    bool ret;
 +    if (netdev_should_send_keep_alive_pkt(bfd->netdev, &ret) != EOPNOTSUPP) {
++        bfd_set_state(bfd, STATE_UP, DIAG_RMT_DOWN);
++        bfd->forwarding_override = 1;
++        bfd->rmt_state = STATE_UP;
++        bfd->poll_min_tx = bfd->cfg_min_tx;
++        bfd->min_tx = bfd->cfg_min_tx;
++        VLOG_DBG_RL(&rl, "%s: No Poll. Set State UP", bfd->name);
 +        return;
 +    }
      if (bfd->state > STATE_DOWN && !bfd_in_poll(bfd)
@@ -274,7 +319,7 @@ index 73dce2fca..d6adcedc8 100644
  
  int netdev_register_provider(const struct netdev_class *);
 diff --git a/lib/netdev-vport.c b/lib/netdev-vport.c
-index 0f3d587e0..6f5c30e9a 100644
+index 0f3d587e0..6d0fd8888 100644
 --- a/lib/netdev-vport.c
 +++ b/lib/netdev-vport.c
 @@ -29,6 +29,7 @@
@@ -303,7 +348,7 @@ index 0f3d587e0..6f5c30e9a 100644
      has_seq = strstr(type, "gre");
      memset(&tnl_cfg, 0, sizeof tnl_cfg);
  
-@@ -1129,6 +1132,172 @@ netdev_vport_get_pt_mode(const struct netdev *netdev)
+@@ -1129,6 +1132,171 @@ netdev_vport_get_pt_mode(const struct netdev *netdev)
  
  
  #ifdef __linux__
@@ -312,8 +357,7 @@ index 0f3d587e0..6f5c30e9a 100644
 +gtp_get_remote_info(struct netdev_vport *dev, struct ds *ds)
 +{
 +    struct netdev_tunnel_config *cfg = &dev->tnl_cfg;
-+
-+    if (cfg->gtp_timestamp) {
++    if (cfg && cfg->gtp_timestamp) {
 +        ds_put_format(ds, "\t%s: RX: %ld TX: %ld remote ip: "IP_FMT", seq %d, pending send %d\n",
 +                      xastrftime_msec("%H:%M:%S.###", cfg->gtp_timestamp, true), cfg->gtp_rx_cnt, cfg->gtp_tx_cnt,
 +                      IP_ARGS(in6_addr_get_mapped_ipv4(&cfg->ipv6_dst)), cfg->gtp_seq, (int)cfg->gtp_need_to_send);
@@ -334,21 +378,21 @@ index 0f3d587e0..6f5c30e9a 100644
 +{
 +    struct netdev_vport *dev = netdev_vport_cast(netdev);
 +
-+    if (wc) {
-+        memset(&wc->masks.tunnel.gtpu_msgtype, 0xff, sizeof wc->masks.tunnel.gtpu_msgtype);
-+        memset(&wc->masks.tunnel.ip_dst, 0xff, sizeof wc->masks.tunnel.ip_dst);
-+    }
-+    
-+    VLOG_DBG("gtp flags %x msg_type %d dev->tnl_cfg.dst_port %d == (%d, %d) flow "IP_FMT" cfg "IP_FMT,
++    VLOG_DBG("gtpu flags %x msg_type %d dev->tnl_cfg.dst_port %d == (%d, %d) flow "IP_FMT" cfg "IP_FMT,
 +            flow->tunnel.gtpu_flags, flow->tunnel.gtpu_msgtype, dev->tnl_cfg.dst_port,
 +            flow->tunnel.tp_src, flow->tunnel.tp_dst,
 +            IP_ARGS(flow->tunnel.ip_src), IP_ARGS(in6_addr_get_mapped_ipv4(&dev->tnl_cfg.ipv6_dst)));
 +
-+    *res = (flow->tunnel.gtpu_msgtype == 1) &&                  // echo request msg type
-+           (flow->tunnel.gtpu_flags == 0x32) &&              // needs seq in packet.
-+           (flow->tunnel.ip_src == in6_addr_get_mapped_ipv4(&dev->tnl_cfg.ipv6_dst)) &&
-+           (flow->tunnel.tp_src == dev->tnl_cfg.dst_port) &&
-+           (flow->tunnel.tp_dst == dev->tnl_cfg.dst_port);
++    if ((flow->tunnel.tp_dst == dev->tnl_cfg.dst_port) &&
++        (flow->tunnel.ip_src == in6_addr_get_mapped_ipv4(&dev->tnl_cfg.ipv6_dst))) {
++        *res = (flow->tunnel.gtpu_msgtype == 1) &&                  // echo request msg type
++               (flow->tunnel.gtpu_flags == 0x32);                   // needs seq in packet.
++
++        if (flow->tunnel.gtpu_msgtype && wc) {
++            memset(&wc->masks.tunnel.gtpu_msgtype, 0xff, sizeof wc->masks.tunnel.gtpu_msgtype);
++            memset(&wc->masks.tunnel.gtpu_flags, 0xff, sizeof wc->masks.tunnel.gtpu_flags);
++        }
++   }
 +    return 0;
 +}
 +
@@ -476,7 +520,7 @@ index 0f3d587e0..6f5c30e9a 100644
  static int
  netdev_vport_get_ifindex(const struct netdev *netdev_)
  {
-@@ -1254,6 +1423,11 @@ netdev_vport_tunnel_register(void)
+@@ -1254,6 +1422,11 @@ netdev_vport_tunnel_register(void)
                .build_header = netdev_gtpu_build_header,
                .push_header = netdev_gtpu_push_header,
                .pop_header = netdev_gtpu_pop_header,
@@ -488,7 +532,7 @@ index 0f3d587e0..6f5c30e9a 100644
            },
            {{NULL, NULL, 0, 0}}
          },
-@@ -1272,6 +1446,9 @@ netdev_vport_tunnel_register(void)
+@@ -1272,6 +1445,9 @@ netdev_vport_tunnel_register(void)
          unixctl_command_register("tnl/egress_port_range", "min max", 0, 2,
                                   netdev_tnl_egress_port_range, NULL);
  
@@ -689,10 +733,10 @@ index 3426a27b2..5d1bd84d5 100644
  void xlate_mac_learning_update(const struct ofproto_dpif *ofproto,
                                 ofp_port_t in_port, struct eth_addr dl_src,
 diff --git a/ofproto/ofproto-dpif.c b/ofproto/ofproto-dpif.c
-index 0f8ae8a73..a8a49adf0 100644
+index 34cb1793c..5b59c4f5e 100644
 --- a/ofproto/ofproto-dpif.c
 +++ b/ofproto/ofproto-dpif.c
-@@ -5265,6 +5265,23 @@ ofproto_dpif_send_packet(const struct ofport_dpif *ofport, bool oam,
+@@ -5284,6 +5284,23 @@ ofproto_dpif_send_packet(const struct ofport_dpif *ofport, bool oam,
      ovs_mutex_unlock(&ofproto->stats_mutex);
      return error;
  }
@@ -717,10 +761,10 @@ index 0f8ae8a73..a8a49adf0 100644
  /* Return the version string of the datapath that backs up
   * this 'ofproto'.
 diff --git a/ofproto/ofproto-dpif.h b/ofproto/ofproto-dpif.h
-index 1f5794f03..c57ec5a35 100644
+index 6e5cfe38d..4a8f49cf4 100644
 --- a/ofproto/ofproto-dpif.h
 +++ b/ofproto/ofproto-dpif.h
-@@ -370,6 +370,8 @@ void ofproto_dpif_send_async_msg(struct ofproto_dpif *,
+@@ -373,6 +373,8 @@ void ofproto_dpif_send_async_msg(struct ofproto_dpif *,
                                   struct ofproto_async_msg *);
  int ofproto_dpif_send_packet(const struct ofport_dpif *, bool oam,
                               struct dp_packet *);
@@ -774,7 +818,7 @@ index 490c59e04..bc94680f0 100644
  #                [tunnel-args])
  #
 diff --git a/tests/system-layer3-tunnels.at b/tests/system-layer3-tunnels.at
-index 141a7afb4..b50984e37 100644
+index 141a7afb4..83c9c4593 100644
 --- a/tests/system-layer3-tunnels.at
 +++ b/tests/system-layer3-tunnels.at
 @@ -49,58 +49,6 @@ NS_CHECK_EXEC([at_ns0], [ping -s 3200 -q -c 3 -i 0.3 -w 2 10.1.1.2 | FORMAT_PING
@@ -836,7 +880,7 @@ index 141a7afb4..b50984e37 100644
  AT_SETUP([layer3 - ping over GRE])
  OVS_TRAFFIC_VSWITCHD_START([set Bridge br0 other-config:hwaddr="00:12:34:56:78:bb"])
  OVS_CHECK_GRE_L3()
-@@ -205,3 +153,236 @@ AT_CHECK([tail -1 stdout], [0],
+@@ -205,3 +153,248 @@ AT_CHECK([tail -1 stdout], [0],
  
  OVS_VSWITCHD_STOP
  AT_CLEANUP
@@ -890,7 +934,18 @@ index 141a7afb4..b50984e37 100644
 +NS_CHECK_EXEC([at_ns0], [ping -s 3200 -q -c 3 -i 0.3 -w 2 10.1.1.2 | FORMAT_PING], [0], [dnl
 +3 packets transmitted, 3 received, 0% packet loss, time 0ms
 +])
++AT_CHECK([ovs-vsctl set interface at_gtp0 bfd:enable=true])
++AT_CHECK([ovs-vsctl set interface at_gtp0 bfd:min_tx=5000 bfd:min_rx=5000])
 +
++sleep 2
++NS_CHECK_EXEC([at_ns0], [ping -q -c 3 -i 0.3 -w 2 10.1.1.2 | FORMAT_PING], [0], [dnl
++3 packets transmitted, 3 received, 0% packet loss, time 0ms
++])
++NS_CHECK_EXEC([at_ns0], [ping -s 3200 -q -c 3 -i 0.3 -w 2 10.1.1.2 | FORMAT_PING], [0], [dnl
++3 packets transmitted, 3 received, 0% packet loss, time 0ms
++])
++
++dnl sleep 1000 
 +OVS_TRAFFIC_VSWITCHD_STOP
 +AT_CLEANUP
 +
@@ -956,7 +1011,7 @@ index 141a7afb4..b50984e37 100644
 +AT_CHECK([ip neigh add 10.1.1.1 lladdr 00:12:34:56:78:aa dev br0])
 +
 +NS_CHECK_EXEC([at_ns0], [ip link set dev p0 mtu 1480 up])
-+AT_CHECK([ovs-vsctl set interface at_gtp0 bfd:min_tx=500 bfd:min_rx=500])
++AT_CHECK([ovs-vsctl set interface at_gtp0 bfd:min_tx=5000 bfd:min_rx=5000])
 +AT_CHECK([ovs-vsctl set interface at_gtp0 bfd:enable=true])
 +
 +AT_CHECK([ovs-ofctl add-flow br-underlay "actions=normal"])
@@ -964,12 +1019,13 @@ index 141a7afb4..b50984e37 100644
 +AT_CHECK([ovs-appctl vlog/set dbg], [0], [ignore])
 +AT_CHECK([echo 'module openvswitch +p' > /sys/kernel/debug/dynamic_debug/control])
 +
++dnl sleep 1000
 +AT_CHECK([ovs-appctl tnl/gtp_echo_remote_end_points], [0], [dnl
 +Tunnel port: at_gtp0
 +])  
 +
 +NS_CHECK_EXEC([at_ns0], [test-gtp 172.31.1.100 3201000a0000000000010000ff0003000a01], [0], [ignore])
-+sleep 2
++sleep 1
 +AT_CHECK([ovs-appctl tnl/gtp_echo_remote_end_points | sed -e  's/^.*: RX/RX/'], [0], [dnl
 +Tunnel port: at_gtp0
 +RX: 1 TX: 1 remote ip: 172.31.1.1, seq 1, pending send 0
@@ -984,7 +1040,7 @@ index 141a7afb4..b50984e37 100644
 +Tunnel port: at_gtp0
 +RX: 2 TX: 2 remote ip: 172.31.1.1, seq 3, pending send 0
 +])
-+
++dnl sleep 1000
 +OVS_WAIT_UNTIL([cat p1.pcap | egrep "IP 172.31.1.100.2152 > 172.31.1.1.2152: UDP, length 12" 2>&1 1>/dev/null])
 +OVS_WAIT_UNTIL([cat p1.pcap | egrep "0x0000:.*0800 4500"                                     2>&1 1>/dev/null])
 +OVS_WAIT_UNTIL([cat p1.pcap | egrep "0x0010:.*ac1f 0164 ac1f"       2>&1 1>/dev/null])
@@ -1020,7 +1076,7 @@ index 141a7afb4..b50984e37 100644
 +NS_CHECK_EXEC([at_ns0], [ip link set dev p0 mtu 1480 up])
 +NS_CHECK_EXEC([at_ns1], [ip link set dev p1 mtu 1480 up])
 +
-+AT_CHECK([ovs-vsctl set interface at_gtp0 bfd:min_tx=500 bfd:min_rx=500])
++AT_CHECK([ovs-vsctl set interface at_gtp0 bfd:min_tx=5000 bfd:min_rx=5000])
 +AT_CHECK([ovs-vsctl set interface at_gtp0 bfd:enable=true])
 +AT_CHECK([ovs-vsctl set interface at_gtp1 bfd:enable=false])
 +
@@ -1050,7 +1106,7 @@ index 141a7afb4..b50984e37 100644
 +Tunnel port: at_gtp1
 +])  
 +
-+AT_CHECK([ovs-vsctl set interface at_gtp1 bfd:min_tx=500 bfd:min_rx=500])
++AT_CHECK([ovs-vsctl set interface at_gtp1 bfd:min_tx=5000 bfd:min_rx=5000])
 +AT_CHECK([ovs-vsctl set interface at_gtp1 bfd:enable=true])
 +
 +NS_CHECK_EXEC([at_ns1], [test-gtp 172.31.1.100 3201000a0000000000030000ff0003000a01], [0], [ignore])

--- a/third_party/gtp_ovs/ovs-gtp-patches/2.14/0006-ovs-test-add-gtp-marker-test.patch
+++ b/third_party/gtp_ovs/ovs-gtp-patches/2.14/0006-ovs-test-add-gtp-marker-test.patch
@@ -1,7 +1,7 @@
-From bdc8da7790e4736d32dda649df85793f399a3f12 Mon Sep 17 00:00:00 2001
+From 65a999b3224a2f2a26526ec4447e63b03af605bb Mon Sep 17 00:00:00 2001
 From: Pravin B Shelar <pbshelar@fb.com>
 Date: Mon, 29 Jun 2020 06:54:04 +0000
-Subject: [PATCH 06/19] ovs: test: add gtp marker test
+Subject: [PATCH 06/20] ovs: test: add gtp marker test
 
 Signed-off-by: Pravin B Shelar <pbshelar@fb.com>
 ---
@@ -9,10 +9,10 @@ Signed-off-by: Pravin B Shelar <pbshelar@fb.com>
  1 file changed, 60 insertions(+)
 
 diff --git a/tests/system-layer3-tunnels.at b/tests/system-layer3-tunnels.at
-index b50984e37..2abb817f7 100644
+index 83c9c4593..2b8a70c6d 100644
 --- a/tests/system-layer3-tunnels.at
 +++ b/tests/system-layer3-tunnels.at
-@@ -386,3 +386,63 @@ RX: 1 TX: 1 remote ip: 172.31.1.2, seq 3, pending send 0
+@@ -398,3 +398,63 @@ RX: 1 TX: 1 remote ip: 172.31.1.2, seq 3, pending send 0
  
  OVS_TRAFFIC_VSWITCHD_STOP
  AT_CLEANUP

--- a/third_party/gtp_ovs/ovs-gtp-patches/2.14/0007-datapath-Fixes-for-4.9-kernel.patch
+++ b/third_party/gtp_ovs/ovs-gtp-patches/2.14/0007-datapath-Fixes-for-4.9-kernel.patch
@@ -1,7 +1,7 @@
-From 4cbbdb641c49affd80aa38d6bfbe6a5e54e395aa Mon Sep 17 00:00:00 2001
+From 3b423e8d9b5936c6a7e3501dfc9a7d48b8ba705d Mon Sep 17 00:00:00 2001
 From: Pravin B Shelar <pbshelar@fb.com>
 Date: Tue, 7 Jul 2020 01:46:36 +0000
-Subject: [PATCH 07/19] datapath: Fixes for 4.9 kernel
+Subject: [PATCH 07/20] datapath: Fixes for 4.9 kernel
 
 Signed-off-by: Pravin B Shelar <pbshelar@fb.com>
 ---
@@ -25,7 +25,7 @@ index a0dcc2667..66bd252ea 100644
  
  #define skb_is_encapsulated ovs_skb_is_encapsulated
 diff --git a/tests/system-layer3-tunnels.at b/tests/system-layer3-tunnels.at
-index 2abb817f7..b8925d237 100644
+index 2b8a70c6d..d66b56ffa 100644
 --- a/tests/system-layer3-tunnels.at
 +++ b/tests/system-layer3-tunnels.at
 @@ -157,6 +157,7 @@ AT_CLEANUP
@@ -45,7 +45,7 @@ index 2abb817f7..b8925d237 100644
  NS_CHECK_EXEC([at_ns0], [gtp-tunnel add at_gtp1 v1 0 0 10.1.1.1 172.31.1.100], [0], [ignore], [ignore])
  NS_CHECK_EXEC([at_ns0], [ip addr add dev at_gtp1 10.1.1.1/24])
  NS_CHECK_EXEC([at_ns0], [ip link set dev at_gtp1 mtu 1450 up])
-@@ -390,7 +393,7 @@ AT_CLEANUP
+@@ -402,7 +405,7 @@ AT_CLEANUP
  AT_SETUP([layer3 - GTP end marker test])
  OVS_TRAFFIC_VSWITCHD_START([set Bridge br0 other-config:hwaddr="00:12:34:56:78:bb"])
  OVS_CHECK_GTP_L3()
@@ -54,7 +54,7 @@ index 2abb817f7..b8925d237 100644
  ADD_BR([br-underlay])
  
  ADD_NAMESPACES(at_ns0)
-@@ -407,6 +410,8 @@ dnl linux device inside the namespace.
+@@ -419,6 +422,8 @@ dnl linux device inside the namespace.
  ADD_OVS_TUNNEL([gtpu], [br0], [at_gtp0], [172.31.1.1], [10.1.1.2/24], [options:key=flow])
  AT_CHECK([ip neigh add 10.1.1.1 lladdr 00:12:34:56:78:aa dev br0])
  NS_CHECK_EXEC([at_ns0], [gtp-link add at_gtp1 --sgsn &], [0], [ignore])

--- a/third_party/gtp_ovs/ovs-gtp-patches/2.14/0008-ovs-datapath-enable-kernel-5.6.patch
+++ b/third_party/gtp_ovs/ovs-gtp-patches/2.14/0008-ovs-datapath-enable-kernel-5.6.patch
@@ -1,7 +1,7 @@
-From 29a2e5e00e3de94d3f1786c565781a69ff1e1ada Mon Sep 17 00:00:00 2001
+From 21963cdbbde9db2787f19cd7b476325da1000faa Mon Sep 17 00:00:00 2001
 From: Pravin B Shelar <pbshelar@fb.com>
 Date: Fri, 21 Aug 2020 05:35:16 +0000
-Subject: [PATCH 08/19] ovs: datapath enable kernel 5.6
+Subject: [PATCH 08/20] ovs: datapath enable kernel 5.6
 
 Signed-off-by: Pravin B Shelar <pbshelar@fb.com>
 ---

--- a/third_party/gtp_ovs/ovs-gtp-patches/2.14/0009-AGW-OVS-handle-gtp-tunnel-type.patch
+++ b/third_party/gtp_ovs/ovs-gtp-patches/2.14/0009-AGW-OVS-handle-gtp-tunnel-type.patch
@@ -1,7 +1,7 @@
-From 095bc30959ecf4236cf75f339047b3c44ae682a9 Mon Sep 17 00:00:00 2001
+From 18cccb04cb2989c39abd3398dc81c94fd96a3623 Mon Sep 17 00:00:00 2001
 From: Pravin B Shelar <pbshelar@fb.com>
 Date: Wed, 23 Sep 2020 04:01:59 +0000
-Subject: [PATCH 09/19] AGW: OVS: handle gtp tunnel type
+Subject: [PATCH 09/20] AGW: OVS: handle gtp tunnel type
 
 magma GTP implementation defines gtp as tunnel type for OVS tunnel.
 But upstream ovs it is defined as gtpu. This patch maps older name to

--- a/third_party/gtp_ovs/ovs-gtp-patches/2.14/0010-native-tnl-routing-tunnel-lookup-with-pkt-mark.patch
+++ b/third_party/gtp_ovs/ovs-gtp-patches/2.14/0010-native-tnl-routing-tunnel-lookup-with-pkt-mark.patch
@@ -1,7 +1,7 @@
-From 68b8f1d6c57fbe74bb6e7f8e2964b0da1c0a17b3 Mon Sep 17 00:00:00 2001
+From 379551dda80f2a25456228491673bed1b9f22e4a Mon Sep 17 00:00:00 2001
 From: Pravin B Shelar <pbshelar@fb.com>
 Date: Sun, 27 Sep 2020 19:46:24 +0000
-Subject: [PATCH 10/19] native-tnl: routing: tunnel lookup with pkt-mark
+Subject: [PATCH 10/20] native-tnl: routing: tunnel lookup with pkt-mark
 
 In case of zero packet mark ignore packet mark in lookup.
 

--- a/third_party/gtp_ovs/ovs-gtp-patches/2.14/0011-fixes-for-2.14.patch
+++ b/third_party/gtp_ovs/ovs-gtp-patches/2.14/0011-fixes-for-2.14.patch
@@ -1,7 +1,7 @@
-From b29518282262eaae3a0dd882c2ea4506e663da71 Mon Sep 17 00:00:00 2001
+From f2e3039cf4be98bca09026513b56aaa79e7ad053 Mon Sep 17 00:00:00 2001
 From: Pravin B Shelar <pbshelar@fb.com>
 Date: Sat, 28 Nov 2020 23:09:50 -0800
-Subject: [PATCH 11/19] fixes for 2.14
+Subject: [PATCH 11/20] fixes for 2.14
 
 ---
  datapath/flow_netlink.c                       |  2 ++

--- a/third_party/gtp_ovs/ovs-gtp-patches/2.14/0012-Add-custom-IPDR-fields-for-IPFIX-export.patch
+++ b/third_party/gtp_ovs/ovs-gtp-patches/2.14/0012-Add-custom-IPDR-fields-for-IPFIX-export.patch
@@ -1,7 +1,7 @@
-From 2b473f52a3c792d45a56a3c4be0f393492de9b48 Mon Sep 17 00:00:00 2001
+From bb0799c9ca6f8901a5a53eeb8b76178ef17fb082 Mon Sep 17 00:00:00 2001
 From: Nick Yurchenko <koolzz@fb.com>
 Date: Mon, 1 Feb 2021 21:25:00 -0500
-Subject: [PATCH 12/19] Add custom IPDR fields for IPFIX export
+Subject: [PATCH 12/20] Add custom IPDR fields for IPFIX export
 
 Signed-off-by: Nick Yurchenko <koolzz@fb.com>
 ---

--- a/third_party/gtp_ovs/ovs-gtp-patches/2.14/0013-ovs-Handle-spaces-in-ovs-arguments.patch
+++ b/third_party/gtp_ovs/ovs-gtp-patches/2.14/0013-ovs-Handle-spaces-in-ovs-arguments.patch
@@ -1,7 +1,7 @@
-From 04c745d107fcf9f8df0b1a4037c2ee700bbfbd4a Mon Sep 17 00:00:00 2001
+From e06cfab4d2493ffd18362bf318f4f0cecf52fd85 Mon Sep 17 00:00:00 2001
 From: Pravin B Shelar <pbshelar@fb.com>
 Date: Fri, 13 Mar 2020 19:18:40 +0000
-Subject: [PATCH 13/19] ovs: Handle spaces in ovs arguments
+Subject: [PATCH 13/20] ovs: Handle spaces in ovs arguments
 
 Signed-off-by: Pravin B Shelar <pbshelar@fb.com>
 ---

--- a/third_party/gtp_ovs/ovs-gtp-patches/2.14/0014-Add-pdp_start_epoch-custom-field-to-IPFIX-export.patch
+++ b/third_party/gtp_ovs/ovs-gtp-patches/2.14/0014-Add-pdp_start_epoch-custom-field-to-IPFIX-export.patch
@@ -1,7 +1,7 @@
-From e337bd8b1e2fdef4203b57faf725e6a0408ce7c4 Mon Sep 17 00:00:00 2001
+From 8b12eded5c5cb2ea72213b495d22e8dd3d669df2 Mon Sep 17 00:00:00 2001
 From: Nick Yurchenko <koolzz@fb.com>
 Date: Mon, 1 Feb 2021 21:46:32 -0500
-Subject: [PATCH 14/19] Add pdp_start_epoch custom field to IPFIX export
+Subject: [PATCH 14/20] Add pdp_start_epoch custom field to IPFIX export
 
 Signed-off-by: Nick Yurchenko <koolzz@fb.com>
 ---

--- a/third_party/gtp_ovs/ovs-gtp-patches/2.14/0015-GTP-Extension-header-support-in-ovs2.14.patch
+++ b/third_party/gtp_ovs/ovs-gtp-patches/2.14/0015-GTP-Extension-header-support-in-ovs2.14.patch
@@ -1,7 +1,7 @@
-From 07efec18b3ed0410c8b9a27f06e6f2b790e7253a Mon Sep 17 00:00:00 2001
+From 43cb5542a82b033012be876d52c1030e399daab7 Mon Sep 17 00:00:00 2001
 From: YOGESH PANDEY <yogesh@wavelabs.ai>
 Date: Thu, 25 Mar 2021 16:48:07 +0530
-Subject: [PATCH 15/19] GTP Extension header support in ovs2.14
+Subject: [PATCH 15/20] GTP Extension header support in ovs2.14
 
 Add GTP Extension header Processing. Following are the changes :
   1. When a GTPU packet comes from GNB the extension header is

--- a/third_party/gtp_ovs/ovs-gtp-patches/2.14/0016-ODP-action-Fix-L3-port-to-L3-port-traffic.patch
+++ b/third_party/gtp_ovs/ovs-gtp-patches/2.14/0016-ODP-action-Fix-L3-port-to-L3-port-traffic.patch
@@ -1,7 +1,7 @@
-From 6a35cc32b5b0f733126620dcc0044b1cb56e26a9 Mon Sep 17 00:00:00 2001
+From 621056b265a778673db99353980a025db4c4e8d0 Mon Sep 17 00:00:00 2001
 From: Pravin B Shelar <pbshelar@fb.com>
 Date: Sun, 18 Apr 2021 17:17:56 +0000
-Subject: [PATCH 16/19] ODP-action: Fix L3 port to L3 port traffic.
+Subject: [PATCH 16/20] ODP-action: Fix L3 port to L3 port traffic.
 
 Signed-off-by: Pravin B Shelar <pbshelar@fb.com>
 ---

--- a/third_party/gtp_ovs/ovs-gtp-patches/2.14/0017-datapath-GTP-cleanup.patch
+++ b/third_party/gtp_ovs/ovs-gtp-patches/2.14/0017-datapath-GTP-cleanup.patch
@@ -1,7 +1,7 @@
-From 75aa316f7494ea388a5e8f459a139c1b04afd85b Mon Sep 17 00:00:00 2001
+From cc72d7439824d655b972da70c77594a03fb6f0f8 Mon Sep 17 00:00:00 2001
 From: Pravin B Shelar <pbshelar@fb.com>
 Date: Sun, 9 May 2021 06:11:10 +0000
-Subject: [PATCH 17/19] datapath: GTP: cleanup
+Subject: [PATCH 17/20] datapath: GTP: cleanup
 
 Get rid of pdp based GTP dev interface.
 Signed-off-by: Pravin B Shelar <pbshelar@fb.com>

--- a/third_party/gtp_ovs/ovs-gtp-patches/2.14/0018-GTP-handle-seq-number-in-HDR.patch
+++ b/third_party/gtp_ovs/ovs-gtp-patches/2.14/0018-GTP-handle-seq-number-in-HDR.patch
@@ -1,7 +1,7 @@
-From c8dcb82eb388c0cb68c4a11344ed0906ec8756be Mon Sep 17 00:00:00 2001
+From 85349c9b2f502212b7cd90c0dbf9f14a5a23e06f Mon Sep 17 00:00:00 2001
 From: Pravin B Shelar <pbshelar@fb.com>
 Date: Fri, 28 May 2021 16:06:54 +0000
-Subject: [PATCH 18/19] GTP: handle seq number in HDR
+Subject: [PATCH 18/20] GTP: handle seq number in HDR
 
 ---
  datapath/linux/compat/gtp.c | 11 ++++++++---

--- a/third_party/gtp_ovs/ovs-gtp-patches/2.14/0019-datapath-gtp-add-segmentation-offloads.patch
+++ b/third_party/gtp_ovs/ovs-gtp-patches/2.14/0019-datapath-gtp-add-segmentation-offloads.patch
@@ -1,7 +1,7 @@
-From b20a404d7c4d065c70b49c9f6660f3313622c658 Mon Sep 17 00:00:00 2001
+From beb94dba13b9f6d99522bd37acf34743549622ae Mon Sep 17 00:00:00 2001
 From: Pravin B Shelar <pbshelar@fb.com>
 Date: Tue, 8 Jun 2021 01:44:33 +0000
-Subject: [PATCH 19/19] datapath: gtp: add segmentation offloads
+Subject: [PATCH 19/20] datapath: gtp: add segmentation offloads
 
 Signed-off-by: Pravin B Shelar <pbshelar@fb.com>
 ---
@@ -75,10 +75,10 @@ index 661dfb991..d817479b0 100644
     * New upstream version
  
 diff --git a/tests/system-layer3-tunnels.at b/tests/system-layer3-tunnels.at
-index b8925d237..c95f0aac7 100644
+index d66b56ffa..29bc77039 100644
 --- a/tests/system-layer3-tunnels.at
 +++ b/tests/system-layer3-tunnels.at
-@@ -304,7 +304,7 @@ RX: 2 TX: 2 remote ip: 172.31.1.1, seq 3, pending send 0
+@@ -316,7 +316,7 @@ dnl sleep 1000
  OVS_WAIT_UNTIL([cat p1.pcap | egrep "IP 172.31.1.100.2152 > 172.31.1.1.2152: UDP, length 12" 2>&1 1>/dev/null])
  OVS_WAIT_UNTIL([cat p1.pcap | egrep "0x0000:.*0800 4500"                                     2>&1 1>/dev/null])
  OVS_WAIT_UNTIL([cat p1.pcap | egrep "0x0010:.*ac1f 0164 ac1f"       2>&1 1>/dev/null])
@@ -87,7 +87,7 @@ index b8925d237..c95f0aac7 100644
  OVS_WAIT_UNTIL([cat p1.pcap | egrep "0x0030:  0000 0003 0e00"                                2>&1 1>/dev/null])
  
  OVS_TRAFFIC_VSWITCHD_STOP
-@@ -446,7 +446,7 @@ sleep 2
+@@ -458,7 +458,7 @@ sleep 2
  
  OVS_WAIT_UNTIL([cat p1.pcap | egrep "0x0000:.*0800 4500"                                2>&1 1>/dev/null])
  OVS_WAIT_UNTIL([cat p1.pcap | egrep "0x0010:.*ac1f 0164 ac1f"                           2>&1 1>/dev/null])

--- a/third_party/gtp_ovs/ovs-gtp-patches/2.14/0020-net-Fix-zero-copy-head-len-calculation.patch
+++ b/third_party/gtp_ovs/ovs-gtp-patches/2.14/0020-net-Fix-zero-copy-head-len-calculation.patch
@@ -1,4 +1,4 @@
-From 0a507d5e28861d60303560fc87c827491e3794d6 Mon Sep 17 00:00:00 2001
+From e9e17000c3238bba5e2558b1db27767101a4988b Mon Sep 17 00:00:00 2001
 From: Pravin B Shelar <pbshelar@fb.com>
 Date: Sun, 4 Jul 2021 19:31:58 +0000
 Subject: [PATCH 20/20] net: Fix zero-copy head len calculation.
@@ -103,12 +103,12 @@ index 4cdeedc58..9db943da1 100644
  /**
   *	skb_zerocopy - Zero copy skb to skb
 diff --git a/debian/changelog b/debian/changelog
-index d817479b0..ac0d3515a 100644
+index d817479b0..a2896d041 100644
 --- a/debian/changelog
 +++ b/debian/changelog
 @@ -1,4 +1,4 @@
 -openvswitch (2.14.3-8) unstable; urgency=low
-+openvswitch (2.14.3-10) unstable; urgency=low
++openvswitch (2.14.3-13) unstable; urgency=low
     [ Open vSwitch team ]
     * New upstream version
  


### PR DESCRIPTION
Following patch improves GTP performance by fixing the
flow mask and setting right interface state for BFD.

Signed-off-by: Pravin B Shelar <pbshelar@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->

## Test Plan
validated with OVS unit test and perf test on lab setup.

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
