### PR TITLE
Support for security mode reject handling

### DIFF
--- a/lte/gateway/c/oai/tasks/amf/amf_app_ue_context_and_proc.h
+++ b/lte/gateway/c/oai/tasks/amf/amf_app_ue_context_and_proc.h
@@ -761,6 +761,7 @@ void amf_app_state_free_ue_context(void** ue_context_node);
 int amf_proc_security_mode_control(
     amf_context_t* amf_ctx, nas_amf_specific_proc_t* amf_specific_proc,
     ksi_t ksi, success_cb_t success, failure_cb_t failure);
+int amf_proc_security_mode_reject(amf_ue_ngap_id_t ue_id);
 void amf_proc_create_procedure_registration_request(
     ue_m5gmm_context_s* ue_ctx, amf_registration_request_ies_t* ies);
 amf_procedures_t* nas_new_amf_procedures(amf_context_t* amf_context);

--- a/lte/gateway/c/oai/tasks/amf/amf_as.cpp
+++ b/lte/gateway/c/oai/tasks/amf/amf_as.cpp
@@ -196,6 +196,11 @@ static int amf_as_establish_req(amf_as_establish_t* msg, int* amf_cause) {
     case SEC_MODE_COMPLETE:
       rc = amf_handle_security_complete_response(msg->ue_id, decode_status);
       break;
+    case SEC_MODE_REJECT:
+      rc = amf_handle_security_mode_reject(
+          msg->ue_id, &amf_msg->msg.securitymodereject, *amf_cause,
+          decode_status);
+      break;
     case REG_COMPLETE:
       rc = amf_handle_registration_complete_response(
           msg->ue_id, &amf_msg->msg.registrationcompletemsg, *amf_cause,

--- a/lte/gateway/c/oai/tasks/amf/amf_recv.h
+++ b/lte/gateway/c/oai/tasks/amf/amf_recv.h
@@ -39,6 +39,10 @@ int amf_handle_authentication_failure(
     amf_nas_message_decode_status_t status);
 int amf_handle_security_complete_response(
     amf_ue_ngap_id_t ue_id, amf_nas_message_decode_status_t decode_status);
+int amf_handle_security_mode_reject(
+    const amf_ue_ngap_id_t ueid, SecurityModeRejectMsg* msg,
+    int const amf_cause, const amf_nas_message_decode_status_t decode_status);
+
 int amf_handle_registration_complete_response(
     amf_ue_ngap_id_t ue_id, RegistrationCompleteMsg* msg, int amf_cause,
     amf_nas_message_decode_status_t decode_status);

--- a/lte/gateway/c/oai/tasks/amf/amf_security_mode_control.cpp
+++ b/lte/gateway/c/oai/tasks/amf/amf_security_mode_control.cpp
@@ -465,4 +465,84 @@ int amf_proc_security_mode_control(
   }
   OAILOG_FUNC_RETURN(LOG_NAS_AMF, rc);
 }
+/****************************************************************************
+ **                                                                        **
+ ** Name:    amf_proc_security_mode_reject()                               **
+ **                                                                        **
+ ** Description: Performs the security mode control not accepted by the UE **
+ **                                                                        **
+ **              3GPP TS 24.501, section 5.4.2.5                           **
+ **      Upon receiving the SECURITY MODE REJECT message, the AMF          **
+ **      shall stop timer T3560 and abort the ongoing procedure            **
+ **      that triggered the initiation of the NAS security mode            **
+ **      control procedure.                                                **
+ **      The AMF shall apply the 5G NAS security context in use befo-      **
+ **      re the initiation of the security mode control procedure,         **
+ **      if any, to protect any subsequent messages.                       **
+ **                                                                        **
+ **                                                                        **
+ ** Inputs:  ue_id:      UE lower layer identifier                         **
+ **      Others:    None                                                   **
+ **                                                                        **
+ ** Outputs:     None                                                      **
+ **      Return:    RETURNok, RETURNerror                                  **
+ **      Others:    None                                                   **
+ **                                                                        **
+ ***************************************************************************/
+int amf_proc_security_mode_reject(amf_ue_ngap_id_t ue_id) {
+  OAILOG_FUNC_IN(LOG_NAS_AMF);
+  ue_m5gmm_context_s* ue_mm_context = NULL;
+  amf_context_t* amf_ctx            = NULL;
+  int rc                            = RETURNerror;
+
+  OAILOG_WARNING(
+      LOG_NAS_AMF,
+      "AMF-PROC  - Security mode command not accepted by the UE"
+      "(ue_id=" AMF_UE_NGAP_ID_FMT ")\n",
+      ue_id);
+  /*
+   *     Get the UE context
+   */
+  ue_mm_context = amf_ue_context_exists_amf_ue_ngap_id(ue_id);
+  if (ue_mm_context) {
+    amf_ctx = &ue_mm_context->amf_context;
+  } else {
+    OAILOG_FUNC_RETURN(LOG_NAS_AMF, RETURNerror);
+  }
+
+  nas_amf_smc_proc_t* smc_proc = get_nas5g_common_procedure_smc(amf_ctx);
+
+  if (smc_proc) {
+    /*
+     * Stop timer T3560
+     */
+    amf_app_stop_timer(smc_proc->T3560.id);
+
+    // restore previous values
+    amf_ctx->_security.selected_algorithms.encryption =
+        smc_proc->saved_selected_eea;
+    amf_ctx->_security.selected_algorithms.integrity =
+        smc_proc->saved_selected_eia;
+    smc_ctrl.amf_ctx_set_security_eksi(amf_ctx, smc_proc->saved_eksi);
+    amf_ctx->_security.dl_count.overflow = smc_proc->saved_overflow;
+    amf_ctx->_security.dl_count.seq_num  = smc_proc->saved_seq_num;
+    smc_ctrl.amf_ctx_set_security_type(amf_ctx, smc_proc->saved_sc_type);
+
+    /*
+     * Notify AMF that the security mode procedure failed
+     */
+    amf_sap_t amf_sap;
+
+    amf_sap.primitive               = AMFREG_COMMON_PROC_REJ;
+    amf_sap.u.amf_reg.ue_id         = ue_id;
+    amf_sap.u.amf_reg.ctx           = amf_ctx;
+    amf_sap.u.amf_reg.notify        = true;
+    amf_sap.u.amf_reg.free_proc     = false;
+    amf_sap.u.amf_reg.u.common_proc = &smc_proc->amf_com_proc;
+    rc                              = amf_sap_send(&amf_sap);
+  }
+  amf_app_handle_deregistration_req(ue_id);
+  OAILOG_FUNC_RETURN(LOG_NAS_AMF, rc);
+}
+
 }  // namespace magma5g

--- a/lte/gateway/c/oai/tasks/amf/deregistration_request.cpp
+++ b/lte/gateway/c/oai/tasks/amf/deregistration_request.cpp
@@ -205,7 +205,12 @@ int amf_app_handle_deregistration_req(amf_ue_ngap_id_t ue_id) {
     OAILOG_FUNC_RETURN(LOG_NAS_AMF, rc);
   }
   // UE context release notification to NGAP
-  amf_app_ue_context_release(ue_context, ue_context->ue_context_rel_cause);
+  if (ue_context->ue_context_rel_cause.ngapCause_u.nas == NGAP_INVALID_CAUSE) {
+    ue_context->ue_context_rel_cause.ngapCause_u.nas = ngap_CauseNas_deregister;
+    amf_app_ue_context_release(ue_context, ue_context->ue_context_rel_cause);
+  } else {
+    amf_app_ue_context_release(ue_context, ue_context->ue_context_rel_cause);
+  }
 
   // Clean up all the sessions.
   amf_smf_context_cleanup_pdu_session(ue_context);


### PR DESCRIPTION
Signed-off-by: chandhu-wavelabs <chandhu.naga@wavelabs.ai>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

Support added for handling security mode reject message.

## Test Plan

Tested with UERANSIM by mismatching the UE SECURITY CAPABILITIES, now AMF able to handle the security mode reject message.

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
