### PR TITLE
fix(agw): Fixed memory leaks on branch v1.6

### DIFF
--- a/lte/gateway/c/core/oai/tasks/nas/emm/TrackingAreaUpdate.c
+++ b/lte/gateway/c/core/oai/tasks/nas/emm/TrackingAreaUpdate.c
@@ -681,11 +681,8 @@ static int emm_tracking_area_update_accept(nas_emm_tau_proc_t* const tau_proc) {
       emm_sap.u.emm_as.u.establish.emergency_number_list = NULL;
 
       emm_sap.u.emm_as.u.establish.eps_network_feature_support =
-          calloc(1, sizeof(eps_network_feature_support_t));
-      emm_sap.u.emm_as.u.establish.eps_network_feature_support->b1 =
-          _emm_data.conf.eps_network_feature_support[0];
-      emm_sap.u.emm_as.u.establish.eps_network_feature_support->b2 =
-          _emm_data.conf.eps_network_feature_support[1];
+          (eps_network_feature_support_t*) &_emm_data.conf
+              .eps_network_feature_support;
       emm_sap.u.emm_as.u.establish.additional_update_result = NULL;
       emm_sap.u.emm_as.u.establish.t3412_extended           = NULL;
       emm_sap.u.emm_as.u.establish.nas_msg =
@@ -778,12 +775,9 @@ static int emm_tracking_area_update_accept(nas_emm_tau_proc_t* const tau_proc) {
             tau_proc->ies->eps_bearer_context_status;
       }
 
-      emm_sap.u.emm_as.u.establish.eps_network_feature_support =
-          calloc(1, sizeof(eps_network_feature_support_t));
-      emm_sap.u.emm_as.u.establish.eps_network_feature_support->b1 =
-          _emm_data.conf.eps_network_feature_support[0];
-      emm_sap.u.emm_as.u.establish.eps_network_feature_support->b2 =
-          _emm_data.conf.eps_network_feature_support[1];
+      emm_sap.u.emm_as.u.data.eps_network_feature_support =
+          (eps_network_feature_support_t*) &_emm_data.conf
+              .eps_network_feature_support;
 
       /*If CSFB is enabled,store LAI,Mobile Identity and
        * Additional Update type to be sent in TAU accept to S1AP

--- a/lte/gateway/c/core/oai/tasks/nas/esm/DedicatedEpsBearerContextActivation.c
+++ b/lte/gateway/c/core/oai/tasks/nas/esm/DedicatedEpsBearerContextActivation.c
@@ -418,7 +418,7 @@ void dedicated_eps_bearer_activate_t3485_handler(void* args, imsi64_t* imsi64) {
    */
   esm_ebr_timer_data_t* esm_ebr_timer_data = (esm_ebr_timer_data_t*) (args);
 
-  if (esm_ebr_timer_data) {
+  if (esm_ebr_timer_data && esm_ebr_timer_data->ctx) {
     /*
      * Increment the retransmission counter
      */
@@ -431,6 +431,32 @@ void dedicated_eps_bearer_activate_t3485_handler(void* args, imsi64_t* imsi64) {
         esm_ebr_timer_data->ue_id, esm_ebr_timer_data->ebi,
         esm_ebr_timer_data->count);
     *imsi64 = esm_ebr_timer_data->ctx->_imsi64;
+
+    // on timer expiry set the timer_id to inactive
+    ue_mm_context_t* ue_mm_context =
+        mme_ue_context_exists_mme_ue_s1ap_id(esm_ebr_timer_data->ue_id);
+    bearer_context_t* bearer_context = NULL;
+    esm_ebr_context_t* ebr_ctx       = NULL;
+    if (!ue_mm_context) {
+      OAILOG_ERROR_UE(
+          LOG_NAS_ESM, *imsi64,
+          "Failed to find ue context for ue_id " MME_UE_S1AP_ID_FMT "\n",
+          esm_ebr_timer_data->ue_id);
+      OAILOG_FUNC_OUT(LOG_NAS_ESM);
+    }
+    bearer_context =
+        ue_mm_context->bearer_contexts[EBI_TO_INDEX(esm_ebr_timer_data->ebi)];
+    if (bearer_context == NULL) {
+      OAILOG_ERROR_UE(
+          LOG_NAS_ESM, *imsi64,
+          "Failed to find bearer context for bearer_id:%u and "
+          "ue_id " MME_UE_S1AP_ID_FMT "\n",
+          esm_ebr_timer_data->ebi, esm_ebr_timer_data->ue_id);
+      OAILOG_FUNC_OUT(LOG_NAS_ESM);
+    }
+    ebr_ctx           = &bearer_context->esm_ebr_context;
+    ebr_ctx->timer.id = NAS_TIMER_INACTIVE_ID;
+
     if (esm_ebr_timer_data->count < DEDICATED_EPS_BEARER_ACTIVATE_COUNTER_MAX) {
       /*
        * Re-send activate dedicated EPS bearer context request message
@@ -632,6 +658,9 @@ static void erab_setup_rsp_tmr_exp_ded_bearer_handler(
           bearer_ctx->esm_ebr_context.timer.id = NAS_TIMER_INACTIVE_ID;
         }
         if (esm_ebr_timer_data) {
+          if (esm_ebr_timer_data->msg) {
+            bdestroy_wrapper(&esm_ebr_timer_data->msg);
+          }
           free_wrapper((void**) &esm_ebr_timer_data);
         }
       }
@@ -642,6 +671,9 @@ static void erab_setup_rsp_tmr_exp_ded_bearer_handler(
         bearer_ctx->esm_ebr_context.timer.id = NAS_TIMER_INACTIVE_ID;
       }
       if (esm_ebr_timer_data) {
+        if (esm_ebr_timer_data->msg) {
+          bdestroy_wrapper(&esm_ebr_timer_data->msg);
+        }
         free_wrapper((void**) &esm_ebr_timer_data);
       }
     }

--- a/lte/gateway/c/core/oai/tasks/nas/esm/EpsBearerContextDeactivation.c
+++ b/lte/gateway/c/core/oai/tasks/nas/esm/EpsBearerContextDeactivation.c
@@ -411,7 +411,7 @@ void eps_bearer_deactivate_t3495_handler(void* args, imsi64_t* imsi64) {
    */
   esm_ebr_timer_data_t* esm_ebr_timer_data = (esm_ebr_timer_data_t*) (args);
 
-  if (esm_ebr_timer_data) {
+  if (esm_ebr_timer_data && esm_ebr_timer_data->ctx) {
     /*
      * Increment the retransmission counter
      */
@@ -423,8 +423,32 @@ void eps_bearer_deactivate_t3495_handler(void* args, imsi64_t* imsi64) {
         "retransmission counter = %d\n",
         esm_ebr_timer_data->ue_id, esm_ebr_timer_data->ebi,
         esm_ebr_timer_data->count);
-
     *imsi64 = esm_ebr_timer_data->ctx->_imsi64;
+
+    // on timer expiry set the timer_id to inactive
+    ue_mm_context_t* ue_mm_context =
+        mme_ue_context_exists_mme_ue_s1ap_id(esm_ebr_timer_data->ue_id);
+    bearer_context_t* bearer_context = NULL;
+    esm_ebr_context_t* ebr_ctx       = NULL;
+    if (!ue_mm_context) {
+      OAILOG_ERROR_UE(
+          LOG_NAS_ESM, *imsi64,
+          "Failed to find ue context for ue_id " MME_UE_S1AP_ID_FMT "\n",
+          esm_ebr_timer_data->ue_id);
+      OAILOG_FUNC_OUT(LOG_NAS_ESM);
+    }
+    bearer_context =
+        ue_mm_context->bearer_contexts[EBI_TO_INDEX(esm_ebr_timer_data->ebi)];
+    if (bearer_context == NULL) {
+      OAILOG_ERROR_UE(
+          LOG_NAS_ESM, *imsi64,
+          "Failed to find bearer context for bearer_id:%u and "
+          "ue_id " MME_UE_S1AP_ID_FMT "\n",
+          esm_ebr_timer_data->ebi, esm_ebr_timer_data->ue_id);
+      OAILOG_FUNC_OUT(LOG_NAS_ESM);
+    }
+    ebr_ctx           = &bearer_context->esm_ebr_context;
+    ebr_ctx->timer.id = NAS_TIMER_INACTIVE_ID;
     if (esm_ebr_timer_data->count < EPS_BEARER_DEACTIVATE_COUNTER_MAX) {
       /*
        * Re-send deactivate EPS bearer context request message to the UE

--- a/lte/gateway/c/core/oai/tasks/nas/esm/esm_ebr.c
+++ b/lte/gateway/c/core/oai/tasks/nas/esm/esm_ebr.c
@@ -185,15 +185,20 @@ int esm_ebr_release(emm_context_t* emm_context, ebi_t ebi) {
   /*
    * Stop the retransmission timer if still running
    */
-  if (ebr_ctx->timer.id != NAS_TIMER_INACTIVE_ID) {
+  if (ebr_ctx->timer.id != NAS_TIMER_INACTIVE_ID || ebr_ctx->args) {
     OAILOG_INFO(
         LOG_NAS_ESM,
         "ESM-FSM   - Stop retransmission timer %ld for ue "
         "id " MME_UE_S1AP_ID_FMT "\n",
         ebr_ctx->timer.id, ue_mm_context->mme_ue_s1ap_id);
     esm_ebr_timer_data_t* esm_ebr_timer_data = NULL;
-    ebr_ctx->timer.id =
-        nas_timer_stop(ebr_ctx->timer.id, (void**) &esm_ebr_timer_data);
+    // stop the timer if it's running
+    if (ebr_ctx->timer.id != NAS_TIMER_INACTIVE_ID) {
+      ebr_ctx->timer.id =
+          nas_timer_stop(ebr_ctx->timer.id, (void**) &esm_ebr_timer_data);
+    } else {  // Timer has expired, release the args
+      esm_ebr_timer_data = ebr_ctx->args;
+    }
     /*
      * Release the retransmisison timer parameters
      */
@@ -203,6 +208,7 @@ int esm_ebr_release(emm_context_t* emm_context, ebi_t ebi) {
       }
       free_wrapper((void**) &esm_ebr_timer_data);
     }
+    ebr_ctx->args = NULL;
   }
 
   /*


### PR DESCRIPTION

fix(agw): Fixed memory leaks on branch v1.6
## Summary
Inconsistently memory leak was observed during execution of test_attach_detach_dedicated_deactivation_timer_expiry.py
Cause for leak is, on first timer timer expiry, mme shall start the timer with some arguments, for which memory would be allocated.  So part of start, if timer has valid timer id then first timer is stopped and started again. As part of stop, it returns the memory allocated for timer arguments. 
Since timer has expired, timer id will not be found in the timer queue, so timer argument returned from stop was corrupted/incorrect. When start the timer again; it was not starting. Since it was not started, it was resulting into memory leak.
Memory allocated to timer argument would be freed, either on final timer expiry or while stopping using api, esm_ebr_stop_timer()
## Test Plan
Executed s1ap sanity test suite
Executed test_attach_detach_dedicated_deactivation_timer_expiry.py test case and stopped all services to check memory leaks.  This is repeated multiple times. 

Signed-off-by: Rashmi <rashmi.sarwad@radisys.com>