### PR TITLE
fix(mme): Fixed memory leaks observed during network initiated dedicated bearer deactivation procedure

### DIFF
--- a/lte/gateway/c/core/oai/tasks/nas/esm/DedicatedEpsBearerContextActivation.c
+++ b/lte/gateway/c/core/oai/tasks/nas/esm/DedicatedEpsBearerContextActivation.c
@@ -418,7 +418,7 @@ void dedicated_eps_bearer_activate_t3485_handler(void* args, imsi64_t* imsi64) {
    */
   esm_ebr_timer_data_t* esm_ebr_timer_data = (esm_ebr_timer_data_t*) (args);
 
-  if (esm_ebr_timer_data) {
+  if (esm_ebr_timer_data && esm_ebr_timer_data->ctx) {
     /*
      * Increment the retransmission counter
      */
@@ -431,6 +431,32 @@ void dedicated_eps_bearer_activate_t3485_handler(void* args, imsi64_t* imsi64) {
         esm_ebr_timer_data->ue_id, esm_ebr_timer_data->ebi,
         esm_ebr_timer_data->count);
     *imsi64 = esm_ebr_timer_data->ctx->_imsi64;
+
+    // on timer expiry set the timer_id to inactive
+    ue_mm_context_t* ue_mm_context =
+        mme_ue_context_exists_mme_ue_s1ap_id(esm_ebr_timer_data->ue_id);
+    bearer_context_t* bearer_context = NULL;
+    esm_ebr_context_t* ebr_ctx       = NULL;
+    if (!ue_mm_context) {
+      OAILOG_ERROR_UE(
+          LOG_NAS_ESM, *imsi64,
+          "Failed to find ue context for ue_id " MME_UE_S1AP_ID_FMT "\n",
+          esm_ebr_timer_data->ue_id);
+      OAILOG_FUNC_OUT(LOG_NAS_ESM);
+    }
+    bearer_context =
+        ue_mm_context->bearer_contexts[EBI_TO_INDEX(esm_ebr_timer_data->ebi)];
+    if (bearer_context == NULL) {
+      OAILOG_ERROR_UE(
+          LOG_NAS_ESM, *imsi64,
+          "Failed to find bearer context for bearer_id:%u and "
+          "ue_id " MME_UE_S1AP_ID_FMT "\n",
+          esm_ebr_timer_data->ebi, esm_ebr_timer_data->ue_id);
+      OAILOG_FUNC_OUT(LOG_NAS_ESM);
+    }
+    ebr_ctx           = &bearer_context->esm_ebr_context;
+    ebr_ctx->timer.id = NAS_TIMER_INACTIVE_ID;
+
     if (esm_ebr_timer_data->count < DEDICATED_EPS_BEARER_ACTIVATE_COUNTER_MAX) {
       /*
        * Re-send activate dedicated EPS bearer context request message
@@ -632,6 +658,9 @@ static void erab_setup_rsp_tmr_exp_ded_bearer_handler(
           bearer_ctx->esm_ebr_context.timer.id = NAS_TIMER_INACTIVE_ID;
         }
         if (esm_ebr_timer_data) {
+          if (esm_ebr_timer_data->msg) {
+            bdestroy_wrapper(&esm_ebr_timer_data->msg);
+          }
           free_wrapper((void**) &esm_ebr_timer_data);
         }
       }
@@ -642,6 +671,9 @@ static void erab_setup_rsp_tmr_exp_ded_bearer_handler(
         bearer_ctx->esm_ebr_context.timer.id = NAS_TIMER_INACTIVE_ID;
       }
       if (esm_ebr_timer_data) {
+        if (esm_ebr_timer_data->msg) {
+          bdestroy_wrapper(&esm_ebr_timer_data->msg);
+        }
         free_wrapper((void**) &esm_ebr_timer_data);
       }
     }

--- a/lte/gateway/c/core/oai/tasks/nas/esm/EpsBearerContextDeactivation.c
+++ b/lte/gateway/c/core/oai/tasks/nas/esm/EpsBearerContextDeactivation.c
@@ -411,7 +411,7 @@ void eps_bearer_deactivate_t3495_handler(void* args, imsi64_t* imsi64) {
    */
   esm_ebr_timer_data_t* esm_ebr_timer_data = (esm_ebr_timer_data_t*) (args);
 
-  if (esm_ebr_timer_data) {
+  if (esm_ebr_timer_data && esm_ebr_timer_data->ctx) {
     /*
      * Increment the retransmission counter
      */
@@ -423,8 +423,32 @@ void eps_bearer_deactivate_t3495_handler(void* args, imsi64_t* imsi64) {
         "retransmission counter = %d\n",
         esm_ebr_timer_data->ue_id, esm_ebr_timer_data->ebi,
         esm_ebr_timer_data->count);
-
     *imsi64 = esm_ebr_timer_data->ctx->_imsi64;
+
+    // on timer expiry set the timer_id to inactive
+    ue_mm_context_t* ue_mm_context =
+        mme_ue_context_exists_mme_ue_s1ap_id(esm_ebr_timer_data->ue_id);
+    bearer_context_t* bearer_context = NULL;
+    esm_ebr_context_t* ebr_ctx       = NULL;
+    if (!ue_mm_context) {
+      OAILOG_ERROR_UE(
+          LOG_NAS_ESM, *imsi64,
+          "Failed to find ue context for ue_id " MME_UE_S1AP_ID_FMT "\n",
+          esm_ebr_timer_data->ue_id);
+      OAILOG_FUNC_OUT(LOG_NAS_ESM);
+    }
+    bearer_context =
+        ue_mm_context->bearer_contexts[EBI_TO_INDEX(esm_ebr_timer_data->ebi)];
+    if (bearer_context == NULL) {
+      OAILOG_ERROR_UE(
+          LOG_NAS_ESM, *imsi64,
+          "Failed to find bearer context for bearer_id:%u and "
+          "ue_id " MME_UE_S1AP_ID_FMT "\n",
+          esm_ebr_timer_data->ebi, esm_ebr_timer_data->ue_id);
+      OAILOG_FUNC_OUT(LOG_NAS_ESM);
+    }
+    ebr_ctx           = &bearer_context->esm_ebr_context;
+    ebr_ctx->timer.id = NAS_TIMER_INACTIVE_ID;
     if (esm_ebr_timer_data->count < EPS_BEARER_DEACTIVATE_COUNTER_MAX) {
       /*
        * Re-send deactivate EPS bearer context request message to the UE

--- a/lte/gateway/c/core/oai/tasks/nas/esm/esm_ebr.c
+++ b/lte/gateway/c/core/oai/tasks/nas/esm/esm_ebr.c
@@ -185,15 +185,20 @@ status_code_e esm_ebr_release(emm_context_t* emm_context, ebi_t ebi) {
   /*
    * Stop the retransmission timer if still running
    */
-  if (ebr_ctx->timer.id != NAS_TIMER_INACTIVE_ID) {
+  if (ebr_ctx->timer.id != NAS_TIMER_INACTIVE_ID || ebr_ctx->args) {
     OAILOG_INFO(
         LOG_NAS_ESM,
         "ESM-FSM   - Stop retransmission timer %ld for ue "
         "id " MME_UE_S1AP_ID_FMT "\n",
         ebr_ctx->timer.id, ue_mm_context->mme_ue_s1ap_id);
     esm_ebr_timer_data_t* esm_ebr_timer_data = NULL;
-    ebr_ctx->timer.id =
-        nas_timer_stop(ebr_ctx->timer.id, (void**) &esm_ebr_timer_data);
+    // stop the timer if it's running
+    if (ebr_ctx->timer.id != NAS_TIMER_INACTIVE_ID) {
+      ebr_ctx->timer.id =
+          nas_timer_stop(ebr_ctx->timer.id, (void**) &esm_ebr_timer_data);
+    } else {  // Timer has expired, release the args
+      esm_ebr_timer_data = ebr_ctx->args;
+    }
     /*
      * Release the retransmisison timer parameters
      */
@@ -203,6 +208,7 @@ status_code_e esm_ebr_release(emm_context_t* emm_context, ebi_t ebi) {
       }
       free_wrapper((void**) &esm_ebr_timer_data);
     }
+    ebr_ctx->args = NULL;
   }
 
   /*


### PR DESCRIPTION
fix(agw): Fixed memory leaks observed during network initiated dedicated bearer deactivation procedure

## Summary
Inconsistently memory leak was observed during execution of test_attach_detach_dedicated_deactivation_timer_expiry.py
Cause for leak is, on first timer timer expiry, mme shall start the timer with some arguments, for which memory would be allocated. So part of start, if timer has valid timer id then first timer is stopped and started again. As part of stop, it returns the memory allocated for timer arguments.
Since timer has expired, timer id will not be found in the timer queue, so timer argument returned from stop was corrupted/incorrect. When start the timer again; it was not starting. Since it was not started, it was resulting into memory leak.
Memory allocated to timer argument would be freed, either on final timer expiry or while stopping using api, esm_ebr_stop_timer()

Below is the back trace where memory leak was observed,
```
Jul 27 13:25:32 magma-dev-focal mme[384880]: Direct leak of 32 byte(s) in 1 object(s) allocated from:
Jul 27 13:25:32 magma-dev-focal mme[384880]:     #0 0x7ff2bad9e712 in __interceptor_calloc ../../../../src/libsanitizer/lsan/lsan_interceptors.cpp:76
Jul 27 13:25:32 magma-dev-focal mme[384880]:     #1 0x55f463698ee7 in esm_ebr_start_timer /home/vagrant/magma/lte/gateway/c/core/oai/tasks/nas/esm/esm_ebr.c:297
Jul 27 13:25:32 magma-dev-focal mme[384880]:     #2 0x55f463697b6f in eps_bearer_deactivate /home/vagrant/magma/lte/gateway/c/core/oai/tasks/nas/esm/EpsBearerContextDeactivation.c:569
Jul 27 13:25:32 magma-dev-focal mme[384880]:     #3 0x55f463697be0 in esm_proc_eps_bearer_context_deactivate_request /home/vagrant/magma/lte/gateway/c/core/oai/tasks/nas/esm/EpsBearerContextDeactivation.c:229
Jul 27 13:25:32 magma-dev-focal mme[384880]:     #4 0x55f46369b522 in esm_sap_send_a /home/vagrant/magma/lte/gateway/c/core/oai/tasks/nas/esm/sap/esm_sap.c:926
Jul 27 13:25:32 magma-dev-focal mme[384880]:     #5 0x55f46369c22e in esm_sap_send /home/vagrant/magma/lte/gateway/c/core/oai/tasks/nas/esm/sap/esm_sap.c:248
Jul 27 13:25:32 magma-dev-focal mme[384880]:     #6 0x55f463690dab in emm_cn_deactivate_dedicated_bearer_req /home/vagrant/magma/lte/gateway/c/core/oai/tasks/nas/emm/sap/emm_cn.c:802
Jul 27 13:25:32 magma-dev-focal mme[384880]:     #7 0x55f463690dab in emm_cn_send /home/vagrant/magma/lte/gateway/c/core/oai/tasks/nas/emm/sap/emm_cn.c:1212
Jul 27 13:25:32 magma-dev-focal mme[384880]:     #8 0x55f46369392e in emm_sap_send /home/vagrant/magma/lte/gateway/c/core/oai/tasks/nas/emm/sap/emm_sap.c:113
Jul 27 13:25:32 magma-dev-focal mme[384880]:     #9 0x55f46367201f in nas_proc_delete_dedicated_bearer /home/vagrant/magma/lte/gateway/c/core/oai/tasks/nas/nas_proc.c:523
Jul 27 13:25:32 magma-dev-focal mme[384880]:     #10 0x55f463343aa9 in mme_app_handle_nw_init_bearer_deactv_req /home/vagrant/magma/lte/gateway/c/core/oai/tasks/mme_app/mme_app_bearer.c:3217
Jul 27 13:25:32 magma-dev-focal mme[384880]:     #11 0x55f46333b0ba in handle_message /home/vagrant/magma/lte/gateway/c/core/oai/tasks/mme_app/mme_app_main.c:405
Jul 27 13:25:32 magma-dev-focal mme[384880]:     #12 0x7ff2b9f755c6 in zloop_start (/lib/x86_64-linux-gnu/libczmq.so.4+0x295c6)
Jul 27 13:25:32 magma-dev-focal mme[384880]: Indirect leak of 16 byte(s) in 1 object(s) allocated from:
Jul 27 13:25:32 magma-dev-focal mme[384880]:     #0 0x7ff2bad9e9c1 in __interceptor_malloc ../../../../src/libsanitizer/lsan/lsan_interceptors.cpp:54
Jul 27 13:25:32 magma-dev-focal mme[384880]:     #1 0x55f463272440 in bstrcpy /home/vagrant/magma/lte/gateway/c/core/oai/lib/bstr/bstrlib.c:486
Jul 27 13:25:32 magma-dev-focal mme[384880]:     #2 0x55f463698f14 in esm_ebr_start_timer /home/vagrant/magma/lte/gateway/c/core/oai/tasks/nas/esm/esm_ebr.c:308
Jul 27 13:25:32 magma-dev-focal mme[384880]:     #3 0x55f463697b6f in eps_bearer_deactivate /home/vagrant/magma/lte/gateway/c/core/oai/tasks/nas/esm/EpsBearerContextDeactivation.c:569
Jul 27 13:25:32 magma-dev-focal mme[384880]:     #4 0x55f463697be0 in esm_proc_eps_bearer_context_deactivate_request /home/vagrant/magma/lte/gateway/c/core/oai/tasks/nas/esm/EpsBearerContextDeactivation.c:229
Jul 27 13:25:32 magma-dev-focal mme[384880]:     #5 0x55f46369b522 in esm_sap_send_a /home/vagrant/magma/lte/gateway/c/core/oai/tasks/nas/esm/sap/esm_sap.c:926
Jul 27 13:25:32 magma-dev-focal mme[384880]:     #6 0x55f46369c22e in esm_sap_send /home/vagrant/magma/lte/gateway/c/core/oai/tasks/nas/esm/sap/esm_sap.c:248
Jul 27 13:25:32 magma-dev-focal mme[384880]:     #7 0x55f463690dab in emm_cn_deactivate_dedicated_bearer_req /home/vagrant/magma/lte/gateway/c/core/oai/tasks/nas/emm/sap/emm_cn.c:802
Jul 27 13:25:32 magma-dev-focal mme[384880]:     #8 0x55f463690dab in emm_cn_send /home/vagrant/magma/lte/gateway/c/core/oai/tasks/nas/emm/sap/emm_cn.c:1212
Jul 27 13:25:32 magma-dev-focal mme[384880]:     #9 0x55f46369392e in emm_sap_send /home/vagrant/magma/lte/gateway/c/core/oai/tasks/nas/emm/sap/emm_sap.c:113
Jul 27 13:25:32 magma-dev-focal mme[384880]:     #10 0x55f46367201f in nas_proc_delete_dedicated_bearer /home/vagrant/magma/lte/gateway/c/core/oai/tasks/nas/nas_proc.c:523
Jul 27 13:25:32 magma-dev-focal mme[384880]:     #11 0x55f463343aa9 in mme_app_handle_nw_init_bearer_deactv_req /home/vagrant/magma/lte/gateway/c/core/oai/tasks/mme_app/mme_app_bearer.c:3217
Jul 27 13:25:32 magma-dev-focal mme[384880]:     #12 0x55f46333b0ba in handle_message /home/vagrant/magma/lte/gateway/c/core/oai/tasks/mme_app/mme_app_main.c:405
Jul 27 13:25:32 magma-dev-focal mme[384880]:     #13 0x7ff2b9f755c6 in zloop_start (/lib/x86_64-linux-gnu/libczmq.so.4+0x295c6)
Jul 27 13:25:32 magma-dev-focal mme[384880]: Indirect leak of 8 byte(s) in 1 object(s) allocated from:
Jul 27 13:25:32 magma-dev-focal mme[384880]:     #0 0x7ff2bad9e9c1 in __interceptor_malloc ../../../../src/libsanitizer/lsan/lsan_interceptors.cpp:54
Jul 27 13:25:32 magma-dev-focal mme[384880]:     #1 0x55f463272460 in bstrcpy /home/vagrant/magma/lte/gateway/c/core/oai/lib/bstr/bstrlib.c:495
Jul 27 13:25:32 magma-dev-focal mme[384880]:     #2 0x55f463698f14 in esm_ebr_start_timer /home/vagrant/magma/lte/gateway/c/core/oai/tasks/nas/esm/esm_ebr.c:308
Jul 27 13:25:32 magma-dev-focal mme[384880]:     #3 0x55f463697b6f in eps_bearer_deactivate /home/vagrant/magma/lte/gateway/c/core/oai/tasks/nas/esm/EpsBearerContextDeactivation.c:569
Jul 27 13:25:32 magma-dev-focal mme[384880]:     #4 0x55f463697be0 in esm_proc_eps_bearer_context_deactivate_request /home/vagrant/magma/lte/gateway/c/core/oai/tasks/nas/esm/EpsBearerContextDeactivation.c:229
Jul 27 13:25:32 magma-dev-focal mme[384880]:     #5 0x55f46369b522 in esm_sap_send_a /home/vagrant/magma/lte/gateway/c/core/oai/tasks/nas/esm/sap/esm_sap.c:926
Jul 27 13:25:32 magma-dev-focal mme[384880]:     #6 0x55f46369c22e in esm_sap_send /home/vagrant/magma/lte/gateway/c/core/oai/tasks/nas/esm/sap/esm_sap.c:248
Jul 27 13:25:32 magma-dev-focal mme[384880]:     #7 0x55f463690dab in emm_cn_deactivate_dedicated_bearer_req /home/vagrant/magma/lte/gateway/c/core/oai/tasks/nas/emm/sap/emm_cn.c:802
Jul 27 13:25:32 magma-dev-focal mme[384880]:     #8 0x55f463690dab in emm_cn_send /home/vagrant/magma/lte/gateway/c/core/oai/tasks/nas/emm/sap/emm_cn.c:1212
Jul 27 13:25:32 magma-dev-focal mme[384880]:     #9 0x55f46369392e in emm_sap_send /home/vagrant/magma/lte/gateway/c/core/oai/tasks/nas/emm/sap/emm_sap.c:113
Jul 27 13:25:32 magma-dev-focal mme[384880]:     #10 0x55f46367201f in nas_proc_delete_dedicated_bearer /home/vagrant/magma/lte/gateway/c/core/oai/tasks/nas/nas_proc.c:523
Jul 27 13:25:32 magma-dev-focal mme[384880]:     #11 0x55f463343aa9 in mme_app_handle_nw_init_bearer_deactv_req /home/vagrant/magma/lte/gateway/c/core/oai/tasks/mme_app/mme_app_bearer.c:3217
Jul 27 13:25:32 magma-dev-focal mme[384880]:     #12 0x55f46333b0ba in handle_message /home/vagrant/magma/lte/gateway/c/core/oai/tasks/mme_app/mme_app_main.c:405
Jul 27 13:25:32 magma-dev-focal mme[384880]:     #13 0x7ff2b9f755c6 in zloop_start (/lib/x86_64-linux-gnu/libczmq.so.4+0x295c6)
Jul 27 13:25:32 magma-dev-focal mme[384880]: SUMMARY: LeakSanitizer: 216 byte(s) leaked in 5 allocation(s).
Jul 27 13:25:32 magma-dev-focal systemd[1]: magma@mme.service: Main process exited, code=exited, status=23/n/a
Jul 27 13:25:32 magma-dev-focal systemd[1]: magma@mme.service: Failed with result 'exit-code'.
Jul 27 13:25:32 magma-dev-focal systemd[1]: Stopped Magma OAI MME service.
```

## Test Plan
Executed s1ap sanity test suite
Executed test_attach_detach_dedicated_deactivation_timer_expiry.py test case and stopped all services to check memory leaks. This is repeated multiple times.

Signed-off-by: Rashmi <rashmi.sarwad@radisys.com>