### PR TITLE
docs: Add parameter docs for cwf/gateway/fabfile

### DIFF
--- a/cwf/gateway/fabfile.py
+++ b/cwf/gateway/fabfile.py
@@ -71,17 +71,36 @@ def integ_test(
 
     gateway_host: The ssh address string of the machine to run the gateway
         services on. Formatted as "host:port". If not specified, defaults to
-        the `cwag` vagrant box.
+        the `cwag` vagrant box
 
     test_host: The ssh address string of the machine to run the tests on
         on. Formatted as "host:port". If not specified, defaults to the
-        `cwag_test` vagrant box.
+        `cwag_test` vagrant box
 
     trf_host: The ssh address string of the machine to run the tests on
         on. Formatted as "host:port". If not specified, defaults to the
-        `magma_trfserver` vagrant box.
+        `magma_trfserver` vagrant box
 
-    no_build: When set to true, this script will NOT rebuild all docker images.
+    destroy_vm: When set to true, all VMs will be destroyed before running the tests
+
+    provision_vm: When set to true, all VMs will be provisioned before running the tests
+
+    no_build: When set to true, this script will not rebuild all docker images
+        in the CWAG VM
+
+    transfer_images: When set to true, the script will transfer all cwf_* docker 
+        images from the host machine to the CWAG VM to use in the test
+
+    skip_unit_tests: When set to true, only integration tests will be run
+
+    run_tests: When set to to false, no tests will be run
+
+    test_re: When set to a value, integrations tests that match the expression will be run. 
+        (Ex: test_re=TestAuth will run all tests that start with TestAuth)
+
+    count: When set to a number, the integrations tests will be run that many times
+
+    test_result_xml: When set to a path, a JUnit style test summary in XML will be produced at the path
     """
     try:
         tests_to_run = SubTests(tests_to_run)


### PR DESCRIPTION
Signed-off-by: Marie Bremner <marwhal@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary
I recently added a doc that recommends running `fab --display integ_test` for all available commands. Noticed that some parameters are missing descriptions so adding them here.

<!-- Enumerate changes you made and why you made them -->

## Test Plan
```
➜  gateway git:(add-cwf-integ-test-doc) ✗ fab --display integ_test
Displaying detailed information for task 'integ_test':

    Run the integration tests. This defaults to running on local vagrant
    machines, but can also be pointed to an arbitrary host (e.g. amazon) by
    passing "address:port" as arguments

    gateway_host: The ssh address string of the machine to run the gateway
        services on. Formatted as "host:port". If not specified, defaults to
        the `cwag` vagrant box

    test_host: The ssh address string of the machine to run the tests on
        on. Formatted as "host:port". If not specified, defaults to the
        `cwag_test` vagrant box

    trf_host: The ssh address string of the machine to run the tests on
        on. Formatted as "host:port". If not specified, defaults to the
        `magma_trfserver` vagrant box

    destroy_vm: When set to true, all VMs will be destroyed before running the tests

    provision_vm: When set to true, all VMs will be provisioned before running the tests

    no_build: When set to true, this script will not rebuild all docker images
        in the CWAG VM

    transfer_images: When set to true, the script will transfer all cwf_* docker
        images from the host machine to the CWAG VM to use in the test

    skip_unit_tests: When set to true, only integration tests will be run

    run_tests: When set to to false, no tests will be run

    test_re: When set to a value, integrations tests that match the expression will be run.
        (Ex: test_re=TestAuth will run all tests that start with TestAuth)

    count: When set to a number, the integrations tests will be run that many times

    test_result_xml: When set to a path, a JUnit style test summary in XML will be produced at the path

    Arguments: gateway_host=None, test_host=None, trf_host=None, gateway_vm='cwag', gateway_ansible_file='cwag_dev.yml', transfer_images=False, destroy_vm=False, no_build=False, tests_to_run='all', skip_unit_tests=False, test_re=None, test_result_xml=None, run_tests=True, count='1', provision_vm=True

```
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
