### PR TITLE
refactor(nms): Changed subscriber detail KPIs to display data usage as MB/s and changed histogram to line chart

### DIFF
--- a/nms/app/packages/magmalte/app/views/subscriber/SubscriberChart.js
+++ b/nms/app/packages/magmalte/app/views/subscriber/SubscriberChart.js
@@ -21,7 +21,6 @@ import type {network_id, subscriber_id} from '@fbcnms/magma-api';
 import Card from '@material-ui/core/Card';
 import CardHeader from '@material-ui/core/CardHeader';
 import CardTitleRow from '../../components/layout/CardTitleRow';
-import CustomHistogram from '../../components/CustomMetrics';
 import Divider from '@material-ui/core/Divider';
 
 import DataGrid from '../../components/DataGrid';
@@ -34,9 +33,10 @@ import Text from '../../theme/design-system/Text';
 import moment from 'moment';
 import nullthrows from '@fbcnms/util/nullthrows';
 
+import {CustomLineChart} from '../../components/CustomMetrics';
 import {DateTimePicker} from '@material-ui/pickers';
 import {colors} from '../../theme/default';
-import {getLabelUnit, getPromValue} from './SubscriberUtils';
+import {convertBitToMbit, getPromValue} from './SubscriberUtils';
 import {getStep, getStepString} from '../../components/CustomMetrics';
 import {makeStyles} from '@material-ui/styles';
 import {useEffect, useState} from 'react';
@@ -76,12 +76,12 @@ async function getDatasets(props: DatasetFetchProps) {
 
   const queries = [
     {
-      q: `sum(sum_over_time(ue_reported_usage{IMSI="${subscriberId}",direction="down"}[${step}]))`,
+      q: `avg(rate(ue_reported_usage{IMSI="${subscriberId}",direction="down"}[${step}]))`,
       color: colors.secondary.dodgerBlue,
       label: 'download',
     },
     {
-      q: `sum(sum_over_time(ue_reported_usage{IMSI="${subscriberId}",direction="up"}[${step}]))`,
+      q: `avg(rate(ue_reported_usage{IMSI="${subscriberId}",direction="up"}[${step}]))`,
       color: colors.data.flamePea,
       label: 'upload',
     },
@@ -102,7 +102,7 @@ async function getDatasets(props: DatasetFetchProps) {
         it['values']?.map(i => {
           data.push({
             t: parseInt(i[0]) * 1000,
-            y: parseFloat(i[1]),
+            y: parseFloat(convertBitToMbit(parseFloat(i[1]))),
           });
         }),
       );
@@ -110,16 +110,15 @@ async function getDatasets(props: DatasetFetchProps) {
       allDatasets.push({
         datasetKeyProvider: index.toString(),
         label: query.label,
-        fill: false,
-        barPercentage: 0.7,
+        fill: true,
 
-        borderWidth: 2,
+        borderWidth: 1,
         backgroundColor: query.color,
         borderColor: query.color,
         hoverBackgroundColor: query.color,
         hoverBorderColor: 'black',
         data: data,
-        unit: 'bytes',
+        unit: 'MB/s',
       });
     } catch (error) {
       requestError = error;
@@ -148,26 +147,39 @@ function SubscriberDataKPI() {
     // fetch queries
     const fetchAllData = async () => {
       const stepCategoryMap = {
-        '1h': 'Last 1 Hour',
-        '24h': 'Last 1 Day',
-        '7d': 'Last 1 Week',
-        '30d': 'Last 1 Month',
+        '1h': {
+          category: 'Hourly Usage MB/s',
+          tooltip: 'Average Data Usage in MB/s over the past 1 hour',
+        },
+        '24h': {
+          category: 'Daily Avg MB/s',
+          tooltip: 'Average Data Usage in MB/s over the past 1 day',
+        },
+        '30d': {
+          category: 'Monthly Avg Mb/s',
+          tooltip: 'Average Data Usage in MB/s over the past 1 month',
+        },
+        '1y': {
+          category: 'Yearly Avg Mb/s',
+          tooltip: 'Average Data Usage in MB/s over the past 1 year',
+        },
       };
 
       const queries = Object.keys(stepCategoryMap).map(async step => {
-        const category = stepCategoryMap[step];
+        const category = stepCategoryMap[step].category;
+        const tooltip = stepCategoryMap[step].tooltip;
         try {
           const result = await MagmaV1API.getNetworksByNetworkIdPrometheusQuery(
             {
               networkId,
-              query: `sum(increase(ue_reported_usage{IMSI="${subscriberId}",direction="down"}[${step}]))`,
+              query: `avg(rate(ue_reported_usage{IMSI="${subscriberId}",direction="down"}[${step}]))`,
             },
           );
-          const [value, unit] = getLabelUnit(getPromValue(result));
-          return {value, unit, category};
+          const value = convertBitToMbit(getPromValue(result));
+          return {value, category, tooltip};
         } catch (e) {
           enqueueSnackbar('Error getting subscriber KPIs', {variant: 'error'});
-          return {value: '-', unit: '', category};
+          return {value: '-', category, tooltip};
         }
       });
 
@@ -197,6 +209,7 @@ export default function SubscriberChart() {
   const [start, setStart] = useState(moment().subtract(3, 'hours'));
   const [end, setEnd] = useState(moment());
   const [isLoading, setIsLoading] = useState(true);
+  const yLabelUnit = 'MB/s';
 
   function Filter() {
     return (
@@ -247,8 +260,8 @@ export default function SubscriberChart() {
       });
       setDatasets(allDatasets);
       setToolTipHint(toolTipHint);
-      setIsLoading(false);
       setUnit(unit);
+      setIsLoading(false);
     };
 
     fetchAllData();
@@ -263,17 +276,17 @@ export default function SubscriberChart() {
       <CardTitleRow icon={DataUsageIcon} label={'Data Usage'} filter={Filter} />
       <Card elevation={0}>
         <CardHeader
-          title={<Text variant="body2">Data Usage Pattern</Text>}
+          title={<Text variant="body2">Data Usage {yLabelUnit}</Text>}
           subheader={
-            <CustomHistogram
+            <CustomLineChart
               dataset={datasets}
               unit={unit}
-              yLabel={'Bytes'}
+              yLabel={yLabelUnit}
               tooltipHandler={(tooltipItem, data) => {
-                const [val, units] = getLabelUnit(tooltipItem.yLabel);
+                const val = tooltipItem.yLabel;
                 return (
                   data.datasets[tooltipItem.datasetIndex].label +
-                  ` ${val}${units} in last ${toolTipHint}s`
+                  ` ${val} ${yLabelUnit} in last ${toolTipHint}s`
                 );
               }}
             />

--- a/nms/app/packages/magmalte/app/views/subscriber/SubscriberUtils.js
+++ b/nms/app/packages/magmalte/app/views/subscriber/SubscriberUtils.js
@@ -27,6 +27,15 @@ export function getLabelUnit(val: number) {
   return [val.toFixed(2), 'bytes'];
 }
 
+/**
+ * Converts bits to megabits
+ * @param {number} val The value in bits to be converted
+ * @returns {string} Megabits value of the number passed in
+ */
+export function convertBitToMbit(val: number) {
+  return (val / mBIT).toFixed(2);
+}
+
 export function getPromValue(resp: promql_return_object) {
   const respArr = resp?.data?.result
     ?.map(item => {

--- a/nms/app/packages/magmalte/app/views/subscriber/__tests__/SubscriberChartTest.js
+++ b/nms/app/packages/magmalte/app/views/subscriber/__tests__/SubscriberChartTest.js
@@ -1,0 +1,143 @@
+/**
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @flow strict-local
+ * @format
+ */
+
+import 'jest-dom/extend-expect';
+import MagmaAPIBindings from '@fbcnms/magma-api';
+import MomentUtils from '@date-io/moment';
+import MuiStylesThemeProvider from '@material-ui/styles/ThemeProvider';
+import NetworkContext from '../../../components/context/NetworkContext';
+import React from 'react';
+import SubscriberChart from '../SubscriberChart';
+import defaultTheme from '../../../theme/default.js';
+
+import {MemoryRouter, Route} from 'react-router-dom';
+import {MuiPickersUtilsProvider} from '@material-ui/pickers';
+import {MuiThemeProvider} from '@material-ui/core/styles';
+import {cleanup, render, wait} from '@testing-library/react';
+
+jest.mock('axios');
+jest.mock('@fbcnms/magma-api');
+jest.mock('@fbcnms/ui/hooks/useSnackbar');
+afterEach(cleanup);
+const enqueueSnackbarMock = jest.fn();
+jest
+  .spyOn(require('@fbcnms/ui/hooks/useSnackbar'), 'useEnqueueSnackbar')
+  .mockReturnValue(enqueueSnackbarMock);
+
+const mockAvgCurDataUsage = {
+  status: 'success',
+  data: {
+    resultType: 'vector',
+    result: [
+      {
+        metric: {},
+        value: [1627325883.103, '12108000.691521779536'],
+      },
+    ],
+  },
+};
+
+const mockAvgDailyDataUsage = {
+  status: 'success',
+  data: {
+    resultType: 'vector',
+    result: [
+      {
+        metric: {},
+        value: [1627325883.103, '2210400.691521779536'],
+      },
+    ],
+  },
+};
+
+const mockAvgMonthlyDataUsage = {
+  status: 'success',
+  data: {
+    resultType: 'vector',
+    result: [
+      {
+        metric: {},
+        value: [1627325883.103, '52108.691521779536'],
+      },
+    ],
+  },
+};
+
+const mockEmptyDataset = {
+  status: 'success',
+  data: {
+    metric: {},
+    resultType: 'vector',
+    result: [],
+  },
+};
+
+describe('<SubscriberChart />', () => {
+  beforeEach(() => {
+    // Called by the chart component
+    MagmaAPIBindings.getNetworksByNetworkIdPrometheusQueryRange.mockResolvedValue(
+      mockEmptyDataset,
+    );
+    // avg data usage in the past 1 hour
+    MagmaAPIBindings.getNetworksByNetworkIdPrometheusQuery
+      .mockReturnValueOnce(mockAvgCurDataUsage)
+      // avg data usage in the past 1 day
+      .mockReturnValueOnce(mockAvgDailyDataUsage)
+      // avg data usage in the past 1 month
+      .mockReturnValueOnce(mockAvgMonthlyDataUsage)
+      // avg data usage in the past 1 year
+      .mockReturnValueOnce(mockEmptyDataset);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  const Wrapper = () => {
+    return (
+      <MemoryRouter
+        initialEntries={[
+          '/nms/test/subscribers/overview/config/IMSI001011234560000/overview',
+        ]}
+        initialIndex={0}>
+        <MuiPickersUtilsProvider utils={MomentUtils}>
+          <MuiThemeProvider theme={defaultTheme}>
+            <MuiStylesThemeProvider theme={defaultTheme}>
+              <NetworkContext.Provider
+                value={{
+                  networkId: 'test',
+                }}>
+                <Route
+                  path="/nms/:networkId/subscribers/overview/config/:subscriberId/overview"
+                  component={SubscriberChart}
+                />
+              </NetworkContext.Provider>
+            </MuiStylesThemeProvider>
+          </MuiThemeProvider>
+        </MuiPickersUtilsProvider>
+      </MemoryRouter>
+    );
+  };
+
+  it('Verify Subscribers Data KPI', async () => {
+    const {getByTestId} = render(<Wrapper />);
+    await wait();
+    expect(getByTestId('Hourly Usage MB/s')).toHaveTextContent('12.11');
+    expect(getByTestId('Daily Avg MB/s')).toHaveTextContent('2.21');
+    expect(getByTestId('Monthly Avg Mb/s')).toHaveTextContent('0.05');
+    expect(getByTestId('Yearly Avg Mb/s')).toHaveTextContent('0.00');
+  });
+});


### PR DESCRIPTION

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary
The data usage KPI of the subscribers were changed from showing the total bytes to avg data usage in Mb/s. Also, the histogram showing the data usage was changed to a line chart.
<!-- Enumerate changes you made and why you made them -->

## Test Plan
A new testfile named, SubscriberChartTest.js, file was created to test that the correct KPIs are rendered.
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->
<img width="1676" alt="Screen Shot 2021-08-02 at 12 39 35 PM" src="https://user-images.githubusercontent.com/34602743/127895778-b9729f08-d7f6-4b5d-b629-acdb80d3e26b.png">

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
