### PR TITLE
refactor: add caching to expensive functions in ByteCount front-end

### DIFF
--- a/lte/gateway/python/magma/kernsnoopd/tests/byte_counter_tests.py
+++ b/lte/gateway/python/magma/kernsnoopd/tests/byte_counter_tests.py
@@ -91,7 +91,9 @@ class ByteCounterTests(unittest.TestCase):
         # 16777343 is "127.0.0.1" packed as a 4 byte int
         key.daddr, key.dport = 16777343, htons(80)
 
-        bpf = {'dest_counters': {key: 100}}
+        count = MagicMock()
+        count.value = 100
+        bpf = {'dest_counters': {key: count}}
 
         self.byte_counter.handle(bpf)
 
@@ -112,7 +114,9 @@ class ByteCounterTests(unittest.TestCase):
         # 16777343 is "127.0.0.1" packed as a 4 byte int
         key.daddr, key.dport = 16777343, htons(443)
 
-        bpf = {'dest_counters': {key: 100}}
+        count = MagicMock()
+        count.value = 100
+        bpf = {'dest_counters': {key: count}}
 
         self.byte_counter.handle(bpf)
 


### PR DESCRIPTION
## Summary

Some function calls when processing byte counters from the kernel can be expensive. `psutil.Process(cmdline).cmdline()` is one such example. This PR adds simple LRU caching to two such functions as suggested in [comments](https://github.com/magma/magma/pull/8251#discussion_r679609960) on #8251.

## Test Plan

Ran unit tests in `byte_counter_tests`. All pass.
