### PR TITLE
feat: add IPv6 support to byte_count.bpf.c

### DIFF
--- a/lte/gateway/python/magma/kernsnoopd/ebpf/byte_count.bpf.c
+++ b/lte/gateway/python/magma/kernsnoopd/ebpf/byte_count.bpf.c
@@ -1,4 +1,3 @@
-
 /**
  * Copyright 2020 The Magma Authors.
  *
@@ -58,7 +57,7 @@ int kprobe__tcp_sendmsg(struct pt_regs *ctx, struct sock *sk, struct msghdr *msg
       }
     }
 
-    // read binary name, pid, and source port
+    // read binary name, pid, and IP version
     bpf_get_current_comm(key.comm, TASK_COMM_LEN);
     key.pid = bpf_get_current_pid_tgid() >> 32;
     key.family = family;

--- a/lte/gateway/python/magma/kernsnoopd/ebpf/common.bpf.h
+++ b/lte/gateway/python/magma/kernsnoopd/ebpf/common.bpf.h
@@ -27,8 +27,9 @@ struct key_t {
   // binary name (task->comm in the kernel)
   char comm[TASK_COMM_LEN];
   u32 pid;
-  // source port and destination IP address, port
-  u32 daddr;
-  u16 lport;
+  // destination IP address and port
+  unsigned __int128 daddr;
   u16 dport;
+  // IP version
+  u16 family;
 };

--- a/lte/gateway/python/magma/kernsnoopd/tests/byte_counter_tests.py
+++ b/lte/gateway/python/magma/kernsnoopd/tests/byte_counter_tests.py
@@ -11,7 +11,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 import unittest
-from socket import htons
+from socket import AF_INET, AF_INET6, htons
 from unittest.mock import MagicMock
 
 from magma.kernsnoopd.handlers import ByteCounter
@@ -88,8 +88,9 @@ class ByteCounterTests(unittest.TestCase):
 
         key = MagicMock()
         key.pid, key.comm = 0, b'subscriberdb'
+        key.family = AF_INET
         # 16777343 is "127.0.0.1" packed as a 4 byte int
-        key.daddr, key.dport = 16777343, htons(80)
+        key.daddr, key.dport = [16777343], htons(80)
 
         count = MagicMock()
         count.value = 100
@@ -111,8 +112,10 @@ class ByteCounterTests(unittest.TestCase):
 
         key = MagicMock()
         key.pid, key.comm = 0, b'sshd'
-        # 16777343 is "127.0.0.1" packed as a 4 byte int
-        key.daddr, key.dport = 16777343, htons(443)
+        key.family = AF_INET6
+        # localhost in IPv6 with embedded IPv4
+        # ::ffff:127.0.0.1 = 0x0100007FFFFF0000
+        key.daddr, key.dport = b'0100007FFFFF0000', htons(443)
 
         count = MagicMock()
         count.value = 100


### PR DESCRIPTION
Signed-off-by: Waqar Aqeel <waqeel@fb.com>

## Summary

This PR adds IPv6 support for byte counting IPv6 traffic. Traffic from local AGW services to the control proxy is IPv6 with embedded IPv4. This PR also handles this traffic to count bytes that local services send to the cloud through control proxy.

## Test Plan

Updated `byte_counter_tests.py` to reflect changes. All tests pass.
