### PR TITLE
docs: Fix absolute asset links

### DIFF
--- a/docs/readmes/orc8r/architecture_modularity.md
+++ b/docs/readmes/orc8r/architecture_modularity.md
@@ -90,7 +90,7 @@ Magma modules encapsulate domain-specific functionality by defining reusable cod
 
 You can see the full list of modules in [Module Dependencies](./dev_dependencies.md). These modules span both Orc8r and the relevant gateways, allowing domain-specific code to be shared and injected across the stack. As an example, the AGW, FeG, and CWAG are gateways that collectively share the *orc8r*, *lte*, *feg*, and *cwf* modules
 
-![Orc8r modules example](../assets/orc8r/magma_modules.png)
+![Orc8r modules example](assets/orc8r/magma_modules.png)
 
 ## Extending Orchestrator
 

--- a/docs/readmes/orc8r/architecture_overview.md
+++ b/docs/readmes/orc8r/architecture_overview.md
@@ -16,7 +16,7 @@ Magma's Orchestrator is a centralized controller for a set of networks. Orchestr
 configuration and metrics for network devices
 - **A southbound interface** which applies device configuration and reports device status
 
-![Orc8r Overview](../assets/orc8r/orc8r_overview.png)
+![Orc8r Overview](assets/orc8r/orc8r_overview.png)
 
 At a lower level, Orchestrator supports the following functionality
 
@@ -35,20 +35,20 @@ Orchestrator follows a modular design. Core Orchestrator services (located at `o
 
 Every Orchestrator service is deployed with its own Kubernetes service and pod.
 
-![Orc8r Service Mesh Architecture](../assets/orc8r/orc8r_service_mesh.png)
+![Orc8r Service Mesh Architecture](assets/orc8r/orc8r_service_mesh.png)
 
 ### Configuration
 
 The following diagram displays an example call flow for LTE gateway
 configuration
 
-![Orc8r Configuration](../assets/orc8r/orc8r_configuration.png)
+![Orc8r Configuration](assets/orc8r/orc8r_configuration.png)
 
 ### Metrics
 
 The following diagram displays the call flow for the metrics pipeline
 
-![Orc8r Metrics](../assets/orc8r/orc8r_metrics.png)
+![Orc8r Metrics](assets/orc8r/orc8r_metrics.png)
 
 ### Services
 

--- a/docs/readmes/proposals/p008_inbound_roaming_with_subscriberdb.md
+++ b/docs/readmes/proposals/p008_inbound_roaming_with_subscriberdb.md
@@ -21,7 +21,7 @@ we consider the use case when a subscriber of a Roaming Partner Network (RPN)
 tries to access LTE services while visiting an area covered by Magma Partner
 Network (MPN).
 
-![Inbound Roaming 3gpp](../assets/feg/proposals/inbound_roaming_3gpp_description.jpeg)
+![Inbound Roaming 3gpp](assets/feg/proposals/inbound_roaming_3gpp_description.jpeg)
 
 ## Use cases
 
@@ -40,7 +40,7 @@ cases which include HSS for X operator (Magma operator).
 To support inbound roaming we will need to modify current flow on control plane
 on AGW and introduce a new service (s8_proxy) on FEG.
 
-![Inbound Roaming Magma Architecture](../assets/feg/proposals/inbound_roaming_magma_architecture.jpeg)
+![Inbound Roaming Magma Architecture](assets/feg/proposals/inbound_roaming_magma_architecture.jpeg)
 
 ## Design
 
@@ -118,7 +118,7 @@ Some partners have also offered their support to test in their own local
 environment using a remote HSS and PGW. That will allow testing Magma in a
 production environment that implements VPN between remote and local network.
 
-![Inbound Roaming proposed setup](../assets/feg/proposals/inbound_roaming_prod_setup.jpg)
+![Inbound Roaming proposed setup](assets/feg/proposals/inbound_roaming_prod_setup.jpg)
 
 ## Implementation Phases
 


### PR DESCRIPTION
<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

Links were broken, because Docusaurus makes you use relative (non-absolute) links: https://v1.docusaurus.io/docs/en/doc-markdown#linking-to-images-and-other-assets

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->