### PR TITLE
perf(pipelined): backport-v1.6: Avoid service reatart on bridge reconfigure (#7851)

### DIFF
--- a/lte/gateway/python/magma/pipelined/app/uplink_bridge.py
+++ b/lte/gateway/python/magma/pipelined/app/uplink_bridge.py
@@ -10,7 +10,6 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
-import os
 import subprocess
 from collections import namedtuple
 
@@ -22,7 +21,6 @@ from magma.pipelined.openflow import flows
 from ryu.lib import hub
 
 UPLINK_OVS_BRIDGE_NAME = 'uplink_br0'
-
 
 class UplinkBridgeController(MagmaController):
     """
@@ -248,9 +246,6 @@ class UplinkBridgeController(MagmaController):
             raise Exception('Error: %s failed with: %s' % (ovs_add_port, ex))
 
         self.logger.info("Add uplink port: %s", ovs_add_port)
-        # sometimes the mac address changes after port addition, so restart the service.
-        self.logger.info('OVS uplink bridge reconfigured, restarting to get new config')
-        os._exit(0) # pylint: disable=protected-access
 
     def _del_eth_port(self):
         if BridgeTools.port_is_in_bridge(self.config.uplink_bridge,

--- a/lte/gateway/python/magma/pipelined/main.py
+++ b/lte/gateway/python/magma/pipelined/main.py
@@ -27,7 +27,6 @@ from magma.common.service import MagmaService
 from magma.configuration import environment
 from magma.pipelined.app import of_rest_server
 from magma.pipelined.app.he import PROXY_PORT_NAME
-from magma.pipelined.app.uplink_bridge import UPLINK_OVS_BRIDGE_NAME
 from magma.pipelined.bridge_util import BridgeTools
 from magma.pipelined.check_quota_server import run_flask
 from magma.pipelined.gtp_stats_collector import (
@@ -97,10 +96,8 @@ def main():
     )
     if 'virtual_mac' not in service.config:
         if service.config['dp_router_enabled']:
-            up_bridge_name = service.config.get(
-                'uplink_bridge', UPLINK_OVS_BRIDGE_NAME,
-            )
-            mac_addr = get_if_hwaddr(up_bridge_name)
+            up_iface_name = service.config.get('nat_iface', None)
+            mac_addr = get_if_hwaddr(up_iface_name)
         else:
             mac_addr = get_if_hwaddr(service.config.get('bridge_name'))
 


### PR DESCRIPTION

Bridge reconfigure can result in mac address change. pipelineD can
use mac address of egress interface to avoid handling this change.
This improves restart time of pipelineD.

Signed-off-by: Pravin B Shelar <pbshelar@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
