### PR TITLE
docs: Clarify underspecified path to proposal acceptance

### DIFF
--- a/docs/readmes/contributing/contribute_proposals.md
+++ b/docs/readmes/contributing/contribute_proposals.md
@@ -10,12 +10,15 @@ This document describes the process by which interested parties may propose chan
 
 To start, consider skimming the existing [Magma project proposals](https://github.com/magma/magma/issues?q=is%3Aissue+label%3A%22type%3A+proposal%22+).
 
-## Tracking proposals
+## Overview
 
-Proposals are tracked as GitHub Issues, using the following labels
+### Acceptance
 
-- [`type: proposal`](https://github.com/magma/magma/issues?q=is%3Aissue+label%3A%22type%3A+proposal%22+) for all proposals
-- [`tsc`](https://github.com/magma/magma/issues?q=is%3Aissue+label%3A%22type%3A+proposal%22+label%3Atsc) for proposals desiring TSC consideration
+To be accepted, proposals must receive a majority vote from the TSC.
+
+### Tracking
+
+Proposals are tracked as GitHub Issues, using the [`type: proposal`](https://github.com/magma/magma/issues?q=is%3Aissue+label%3A%22type%3A+proposal%22+) label.
 
 The `#proposals` Slack channel receives notifications when new proposals are created.
 
@@ -23,13 +26,13 @@ The `#proposals` Slack channel receives notifications when new proposals are cre
 
 ### Submit an Issue
 
-[Submit a GitHub Issue](https://github.com/magma/magma/issues/new/choose) following the "Proposal" template.
+[Submit a GitHub Issue](https://github.com/magma/magma/issues/new/choose) following the "Proposal" template. The proposal contents should be clear and concise. Aim for a "one-pager" style.
 
-The proposal contents should be clear and concise. Aim for a "one-pager" style.
+In many cases, the TSC will delegate their decision to one of the [approvers teams](https://github.com/orgs/magma/teams?query=approvers-). To expedite this process, you can [label your proposal with the applicable component](https://github.com/magma/magma/labels?q=component%3A), which will help the TSC identify domain experts.
 
 ### Receive feedback
 
-The project maintainers (or the TSC, if you applied the `tsc` label) will discuss the proposal and make comments on the Issue. One of four outcomes will be communicated via labels
+The TSC, and relevant project maintainers, will discuss the proposal and make comments on the Issue. One of four outcomes will be communicated via labels
 
 - [`status: accepted`](https://github.com/magma/magma/labels/status%3A%20accepted) proposal was accepted
 - [`status: rejected`](https://github.com/magma/magma/labels/status%3A%20rejected) proposal was rejected
@@ -48,3 +51,14 @@ When writing your design doc, consider following this [standardized design doc t
 
 - Example design doc: [Scaling Orc8r Subscribers Codepath](https://magma.github.io/magma/docs/next/proposals/p010_subscriber_scaling)
 - Example design doc PR: [APN Refactoring](https://github.com/magma/magma/pull/7191)
+
+### Resolution
+
+A proposal Issue will be closed when no further discussion is needed. This occurs after one of the following
+
+- Acceptance, rejection, or withdrawal of the Issue
+- Acceptance of a requested design doc
+
+## Conclusion
+
+Please direct process-related questions to the `#governance-tsc-ama` Slack channel.


### PR DESCRIPTION
<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

Process was unspecified for proposals that didn't require TSC approval, leading to multiple proposals sitting in purgatory.

With this change, proposals require TSC approval, which will help make the process more explicit -- TSC is the point of serialization, but can defer to `approvers-*` teams or the like. This should drastically improve the explicitness of the process by, in a public way, bringing the proposer+reviewer together to walk domain non-experts (the TSC) through the rationale for acceptance

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->