### PR TITLE
fix(s8_proxy): fix tft components and add sequence number to create b…

### DIFF
--- a/feg/gateway/services/s8_proxy/servicers/mock_pgw/cb.go
+++ b/feg/gateway/services/s8_proxy/servicers/mock_pgw/cb.go
@@ -124,18 +124,28 @@ func buildNewBearerTFTCreateNewTFT(req CreateBearerRequest) *ie.IE {
 		[]*ie.TFTPacketFilter{
 			ie.NewTFTPacketFilter(
 				ie.TFTPFBidirectional, 0, 0,
+				// component 0
 				ie.NewTFTPFComponentSecurityParameterIndex(0xdeadbeef),
+				// component 1
 				ie.NewTFTPFComponentIPv4RemoteAddress(net.IP{127, 0, 0, 1}, net.IPMask{255, 255, 255, 0}),
+				// component 2
 				ie.NewTFTPFComponentProtocolIdentifierNextHeader(req.BiFilterProtocolId),
+				// component 3
 				ie.NewTFTPFComponentTypeOfServiceTrafficClass(1, 2),
+				// component 4
 				ie.NewTFTPFComponentSingleLocalPort(req.BiLocalFilterPort),
+				// component 5
 				ie.NewTFTPFComponentSingleRemotePort(req.BiRemoteFilterPort),
 			),
 			ie.NewTFTPacketFilter(
 				ie.TFTPFDownlinkOnly, 1, 0,
+				// component 6
 				ie.NewTFTPFComponentProtocolIdentifierNextHeader(1),
+				// component 7
 				ie.NewTFTPFComponentSecurityParameterIndex(0xdeadbeef),
+				// component 8
 				ie.NewTFTPFComponentLocalPortRange(req.BiLocalFilterPort, req.BiLocalFilterPort+10),
+				// component 9
 				ie.NewTFTPFComponentRemotePortRange(req.BiRemoteFilterPort, req.BiRemoteFilterPort+10),
 			),
 		},

--- a/feg/gateway/services/s8_proxy/servicers/proto_conversions.go
+++ b/feg/gateway/services/s8_proxy/servicers/proto_conversions.go
@@ -134,6 +134,7 @@ func parseCreateBearerRequest(msg message.Message, senderAddr net.Addr) (*protos
 	glog.V(2).Infof("Received Create Bearer Request (gtp):\n%s", cbReqGtp.String())
 	cbReq := &protos.CreateBearerRequestPgw{}
 	cbReq.PgwAddrs = senderAddr.String()
+	cbReq.SequenceNumber = cbReqGtp.SequenceNumber
 
 	// cgw control plane teid
 	if !cbReqGtp.HasTEID() {


### PR DESCRIPTION
…earer request

Signed-off-by: Oriol Batalla <obatalla@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

This PR adds sequence number to the Create Bearer Request

It also fixes the way we were parsing TFT filter components. Our TFT Filter component GRPC definition doesn't match the GTP structure so this PR separates each component into a slice of components per the GRPC definition. That causes some repetition of fields (for example `direction` or `identifier`) but this is how MME defined this field so we wanted to keep it consistent on feg.

## Test Plan

./build -c at feg
terravm test 

filters now show separated per component
```
s8_proxy         |              "charging_id": 16,                                                                                                                                                                                                                    [175/4109]
s8_proxy         |              "tft": {
s8_proxy         |                      "packet_filter_list": {
s8_proxy         |                              "create_new_tft": [
s8_proxy         |                                      {
s8_proxy         |                                              "spare": 0,
s8_proxy         |                                              "direction": 3,
s8_proxy         |                                              "identifier": 1,
s8_proxy         |                                              "eval_precedence": 254,
s8_proxy         |                                              "length": 14,
s8_proxy         |                                              "packet_filter_contents": {
s8_proxy         |                                                      "flags": 16,
s8_proxy         |                                                      "ipv4_remote_addresses": [
s8_proxy         |                                                              {
s8_proxy         |                                                                      "addr": 2886734959,
s8_proxy         |                                                                      "mask": 4294967295
s8_proxy         |                                                              }
s8_proxy         |                                                      ],
s8_proxy         |                                                      "ipv6_remote_addresses": [
s8_proxy         |                                                      ],
s8_proxy         |                                                      "protocol_identifier_nextheader": 0,
s8_proxy         |                                                      "single_local_port": 0,
s8_proxy         |                                                      "local_port_range": null,
s8_proxy         |                                                      "single_remote_port": 0,
s8_proxy         |                                                      "remote_port_range": null,
s8_proxy         |                                                      "security_parameter_index": 0,
s8_proxy         |                                                      "type_of_service_traffic_class": null,
s8_proxy         |                                                      "flow_label": 0
s8_proxy         |                                              }
s8_proxy         |                                      },
s8_proxy         |                                      {
s8_proxy         |                                              "spare": 0,
s8_proxy         |                                              "direction": 3,
s8_proxy         |                                              "identifier": 1,
s8_proxy         |                                              "eval_precedence": 254,
s8_proxy         |                                              "length": 14,
s8_proxy         |                                              "packet_filter_contents": {
s8_proxy         |                                                      "flags": 48,
s8_proxy         |                                                      "ipv4_remote_addresses": [
s8_proxy         |                                                      ],
s8_proxy         |                                                      "ipv6_remote_addresses": [
s8_proxy         |                                                      ],
s8_proxy         |                                                      "protocol_identifier_nextheader": 17,
s8_proxy         |                                                      "single_local_port": 0,
s8_proxy         |                                                      "local_port_range": null,
s8_proxy         |                                                      "single_remote_port": 0,
s8_proxy         |                                                      "remote_port_range": null,
s8_proxy         |                                                      "security_parameter_index": 0,
s8_proxy         |                                                      "type_of_service_traffic_class": null,
s8_proxy         |                                                      "flow_label": 0
s8_proxy         |                                              }
s8_proxy         |                                      },
s8_proxy         |                                      {
s8_proxy         |                                              "spare": 0,
s8_proxy         |                                              "direction": 3,
s8_proxy         |                                              "identifier": 1,
s8_proxy         |                                              "eval_precedence": 254,
```

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
