### PR TITLE
docs: adding HIL sanity badges 

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
     <a href="https://github.com/magma/magma/commits/master"><img src="https://img.shields.io/github/commit-activity/y/magma/magma" alt="GitHub commit activity the past week"></a>
     <a href="https://circleci.com/gh/magma/magma"><img src="https://circleci.com/gh/magma/magma.svg?style=shield" alt="CircleCI"></a>
     <a href="https://codecov.io/gh/magma/magma"><img src="https://codecov.io/gh/magma/magma/branch/master/graph/badge.svg" alt="CodeCov"></a>
-    <a href="docs/readmes/lte/hil_tests"><img src="http://ens-spirent-test-summary.com.s3-us-west-1.amazonaws.com/sanity/hilsanityres.svg" alt="HIL Sanity Run"></a>
+    <a href="docs/readmes/lte/hil_tests.md"><img src="http://ens-spirent-test-summary.com.s3-us-west-1.amazonaws.com/sanity/hilsanityres.svg" alt="HIL Sanity Run"></a>
 </p>
 
 Magma is an open-source software platform that gives network operators an open, flexible and extendable mobile core network solution. Magma enables better connectivity by:

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
     <a href="https://github.com/magma/magma/commits/master"><img src="https://img.shields.io/github/commit-activity/y/magma/magma" alt="GitHub commit activity the past week"></a>
     <a href="https://circleci.com/gh/magma/magma"><img src="https://circleci.com/gh/magma/magma.svg?style=shield" alt="CircleCI"></a>
     <a href="https://codecov.io/gh/magma/magma"><img src="https://codecov.io/gh/magma/magma/branch/master/graph/badge.svg" alt="CodeCov"></a>
-    <a href="http://automation.fbmagma.ninja"><img src="http://ens-spirent-test-summary.com.s3-us-west-1.amazonaws.com/sanity/hilsanitypass.svg" alt="HIL Sanity Last Stable"></a>
+    <a href="http://automation.fbmagma.ninja"><img src="http://ens-spirent-test-summary.com.s3-us-west-1.amazonaws.com/sanity/hilsanitypass.svg" alt="HIL Sanity Last PASS"></a>
     <a href="http://automation.fbmagma.ninja"><img src="http://ens-spirent-test-summary.com.s3-us-west-1.amazonaws.com/sanity/hilsanityres.svg" alt="HIL Sanity Run"></a>
 </p>
 

--- a/README.md
+++ b/README.md
@@ -7,13 +7,13 @@
 <p align="center">
     <a href="https://github.com/magma/magma/blob/master/LICENSE"><img src="https://img.shields.io/badge/license-BSD3clause-blue.svg" alt="License"></a>
     <a href="https://github.com/magma/magma/releases"><img src="https://img.shields.io/github/release/magma/magma" alt="GitHub Release"></a>
+    <a href="https://docs.magmacore.org/docs/next/contributing/contribute_workflow"><img src="https://img.shields.io/badge/PRs-welcome-brightgreen.svg" alt="PR's Welcome"></a>
     <a href="https://github.com/magma/magma/graphs/contributors"><img src="https://img.shields.io/github/contributors/magma/magma" alt="GitHub contributors"></a>
     <a href="https://github.com/magma/magma/commits/master"><img src="https://img.shields.io/github/last-commit/magma/magma" alt="GitHub last commit"></a>
     <a href="https://github.com/magma/magma/commits/master"><img src="https://img.shields.io/github/commit-activity/y/magma/magma" alt="GitHub commit activity the past week"></a>
     <a href="https://circleci.com/gh/magma/magma"><img src="https://circleci.com/gh/magma/magma.svg?style=shield" alt="CircleCI"></a>
     <a href="https://codecov.io/gh/magma/magma"><img src="https://codecov.io/gh/magma/magma/branch/master/graph/badge.svg" alt="CodeCov"></a>
-    <a href="http://automation.fbmagma.ninja"><img src="http://ens-spirent-test-summary.com.s3-us-west-1.amazonaws.com/sanity/hilsanitypass.svg" alt="HIL Sanity Last PASS"></a>
-    <a href="http://automation.fbmagma.ninja"><img src="http://ens-spirent-test-summary.com.s3-us-west-1.amazonaws.com/sanity/hilsanityres.svg" alt="HIL Sanity Run"></a>
+    <a href="docs/readmes/lte/hil_tests"><img src="http://ens-spirent-test-summary.com.s3-us-west-1.amazonaws.com/sanity/hilsanityres.svg" alt="HIL Sanity Run"></a>
 </p>
 
 Magma is an open-source software platform that gives network operators an open, flexible and extendable mobile core network solution. Magma enables better connectivity by:

--- a/README.md
+++ b/README.md
@@ -7,12 +7,13 @@
 <p align="center">
     <a href="https://github.com/magma/magma/blob/master/LICENSE"><img src="https://img.shields.io/badge/license-BSD3clause-blue.svg" alt="License"></a>
     <a href="https://github.com/magma/magma/releases"><img src="https://img.shields.io/github/release/magma/magma" alt="GitHub Release"></a>
-    <a href="https://docs.magmacore.org/docs/next/contributing/contribute_workflow"><img src="https://img.shields.io/badge/PRs-welcome-brightgreen.svg" alt="PR's Welcome"></a>
     <a href="https://github.com/magma/magma/graphs/contributors"><img src="https://img.shields.io/github/contributors/magma/magma" alt="GitHub contributors"></a>
     <a href="https://github.com/magma/magma/commits/master"><img src="https://img.shields.io/github/last-commit/magma/magma" alt="GitHub last commit"></a>
     <a href="https://github.com/magma/magma/commits/master"><img src="https://img.shields.io/github/commit-activity/y/magma/magma" alt="GitHub commit activity the past week"></a>
     <a href="https://circleci.com/gh/magma/magma"><img src="https://circleci.com/gh/magma/magma.svg?style=shield" alt="CircleCI"></a>
     <a href="https://codecov.io/gh/magma/magma"><img src="https://codecov.io/gh/magma/magma/branch/master/graph/badge.svg" alt="CodeCov"></a>
+    <a href="http://automation.fbmagma.ninja"><img src="http://ens-spirent-test-summary.com.s3-us-west-1.amazonaws.com/sanity/hilsanitypass.svg" alt="HIL Sanity Last Stable"></a>
+    <a href="http://automation.fbmagma.ninja"><img src="http://ens-spirent-test-summary.com.s3-us-west-1.amazonaws.com/sanity/hilsanityres.svg" alt="HIL Sanity Run"></a>
 </p>
 
 Magma is an open-source software platform that gives network operators an open, flexible and extendable mobile core network solution. Magma enables better connectivity by:

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
     <a href="https://github.com/magma/magma/commits/master"><img src="https://img.shields.io/github/commit-activity/y/magma/magma" alt="GitHub commit activity the past week"></a>
     <a href="https://circleci.com/gh/magma/magma"><img src="https://circleci.com/gh/magma/magma.svg?style=shield" alt="CircleCI"></a>
     <a href="https://codecov.io/gh/magma/magma"><img src="https://codecov.io/gh/magma/magma/branch/master/graph/badge.svg" alt="CodeCov"></a>
-    <a href="docs/readmes/lte/hil_tests.md"><img src="http://ens-spirent-test-summary.com.s3-us-west-1.amazonaws.com/sanity/hilsanityres.svg" alt="HIL Sanity Run"></a>
+    <a href="docs/readmes/lte/hil_tests.md"><img src="http://ens-spirent-test-summary.com.s3-us-west-1.amazonaws.com/sanity/hilsanityres.svg" alt="HIL AGW tests"></a>
 </p>
 
 Magma is an open-source software platform that gives network operators an open, flexible and extendable mobile core network solution. Magma enables better connectivity by:

--- a/docs/readmes/lte/hil_tests.md
+++ b/docs/readmes/lte/hil_tests.md
@@ -11,6 +11,11 @@ hide_title: true
 Current testing workflow for HIL testing is using Spirent test center to emulate eNodeB, UE and Network host to run scale and performance tests. HIL is focusing on Magma AGW.
 HIL tests can be run with virtual or physical gateway. However, for now the automated runs are using physical [SUT-HW](https://protectli.com/vault-4-port) box.
 
+## Dashboard
+
+All test results are available to compare on [dashboard](http://automation.fbmagma.ninja/). Please use `username:magma` and `password:magma`.
+We can retrieve log and Grafana metrics for each run by clicking on test run result table.
+
 ## Lab Setup
 
 Spirent test emulation hardware is hosted in FB lab emulating eNODEB, UE and traffic host elements. Magma AGW is also hosted in same lab. All tests are
@@ -36,11 +41,6 @@ Current Test categories supported are:
 1. Verify 400 UEs across 12 eNodeBs with 500k data per UE
 1. Verify 600 UEs across 12 eNodeBs with 500k data per UE
 1. Verify 30 UEs across 12 eNodeBs with 500K data changing state from active-idle-active-idle
-
-### Dashboard
-
-All test results are available to compare on [dashboard](http://automation.fbmagma.ninja/). Please use `username:magma` and `password:magma`.
-We can retrieve log and Grafana metrics for each run by clicking on test run result table.
 
 ### Notification
 

--- a/docs/readmes/lte/hil_tests.md
+++ b/docs/readmes/lte/hil_tests.md
@@ -6,7 +6,9 @@ hide_title: true
 
 # Hardware In Loop Tests
 
-<a href="http://automation.fbmagma.ninja"><img src="http://ens-spirent-test-summary.com.s3-us-west-1.amazonaws.com/sanity/hilsanitypass.svg" alt="HIL AGW Last Stable"></a>
+<p align="center">
+    <a href="http://automation.fbmagma.ninja"><img src="http://ens-spirent-test-summary.com.s3-us-west-1.amazonaws.com/sanity/hilsanitypass.svg" alt="HIL AGW Last Stable"></a>
+</p>
 
 Current testing workflow for HIL testing is using Spirent test center to emulate eNodeB, UE and Network host to run scale and performance tests. HIL is focusing on Magma AGW.
 HIL tests can be run with virtual or physical gateway. However, for now the automated runs are using physical [SUT-HW](https://protectli.com/vault-4-port) box.

--- a/docs/readmes/lte/hil_tests.md
+++ b/docs/readmes/lte/hil_tests.md
@@ -9,7 +9,7 @@ hide_title: true
 Current testing workflow for HIL testing is using Spirent test center to emulate eNodeB, UE and Network host to run scale and performance tests. HIL is focusing on Magma AGW.
 HIL tests can be run with virtual or physical gateway. However, for now the automated runs are using physical [SUT-HW](https://protectli.com/vault-4-port) box.
 
-![HIL AGW Last Stable](http://ens-spirent-test-summary.com.s3-us-west-1.amazonaws.com/sanity/hilsanitypass.svg)
+![HIL AGW Last Pass](http://ens-spirent-test-summary.com.s3-us-west-1.amazonaws.com/sanity/hilsanitypass.svg)
 
 ## Dashboard
 

--- a/docs/readmes/lte/hil_tests.md
+++ b/docs/readmes/lte/hil_tests.md
@@ -37,6 +37,8 @@ Current Test categories supported are:
 1. Verify 400 UEs across 12 eNodeBs with 500k data per UE
 1. Verify 600 UEs across 12 eNodeBs with 500k data per UE
 1. Verify 30 UEs across 12 eNodeBs with 500K data changing state from active-idle-active-idle
+1. Verify APN 10 correction mapping with 50 UEs
+1. Verify PLMN Restriction for 50 valid UEs and 50 invalid UEs
 
 ### Dashboard
 

--- a/docs/readmes/lte/hil_tests.md
+++ b/docs/readmes/lte/hil_tests.md
@@ -4,7 +4,7 @@ title: Hardware In Loop Testing
 hide_title: true
 ---
 
-<a href="http://automation.fbmagma.ninja"><img src="http://ens-spirent-test-summary.com.s3-us-west-1.amazonaws.com/sanity/hilsanityres.svg" alt="HIL Sanity Run"></a>
+<a href="http://automation.fbmagma.ninja"><img src="http://ens-spirent-test-summary.com.s3-us-west-1.amazonaws.com/sanity/hilsanitypass.svg" alt="HIL Sanity Last Stable"></a>
 
 # Hardware In Loop Tests
 

--- a/docs/readmes/lte/hil_tests.md
+++ b/docs/readmes/lte/hil_tests.md
@@ -1,0 +1,37 @@
+---
+id: hil_tests
+title: Hardware In Loop Testing
+hide_title: true
+---
+# Hardware In Loop Tests
+
+Current testing workflow for HIL testing is using Spirent test center to emulate eNodeB, UE and Network host to run scale and performance tests. We cover
+gateway-only tests.
+
+HIL tests can be run with different gateway. However for now the automated runs are using physical Protectli box. (https://protectli.com/vault-4-port)
+
+### Lab Setup
+
+
+Spirent test emulation hardware is hosted in FB lab emulating eNODEB, UE and traffic host elements. gateway are also hosted in same lab. All tests are
+executed in worker node in FB lab. Reports and logs are pushed out to aws S3 for debug and analysis.
+
+### Run tests
+
+To setup HIL worker follow instruction on (https://github.com/fbcinternal/ens_magma/tree/master/spirent_automation)
+
+Current Test categories supported are:
+1. Sanity (nightly run time - 30 minutes) update badge with latest results on magma main README
+1. Performace (nightly run time - 12hrs)
+1. Feature tests at scale - (nightly run time - 6 hrs)
+1. Availability - Every day for 12hrs period
+
+### HIL SANITY TEST CASES
+1. Verify 12 eNodeBs can connect to a Magma Access Gateway
+1. Verify 200 UEs at 5 UE/sec can connect to a Magma Access Gateway
+1. Verify 400 UEs at 5 UE/sec can connect to a Magma Access Gateway
+1. Verify 600 UEs at 5 UE/sec can connect to a Magma Access Gateway
+1. Verify 200 UEs across 12 eNodeBs with 2M data per UE
+1. Verify 400 UEs across 12 eNodeBs with 500k data per UE
+1. Verify 600 UEs across 12 eNodeBs with 500k data per UE
+1. Verify 30 UEs across 12 eNodeBs with 500K data changing state from active-idle-active-idle

--- a/docs/readmes/lte/hil_tests.md
+++ b/docs/readmes/lte/hil_tests.md
@@ -4,9 +4,9 @@ title: Hardware In Loop Testing
 hide_title: true
 ---
 
-<a href="http://automation.fbmagma.ninja"><img src="http://ens-spirent-test-summary.com.s3-us-west-1.amazonaws.com/sanity/hilsanitypass.svg" alt="HIL AGW Last Stable"></a>
-
 # Hardware In Loop Tests
+
+<a href="http://automation.fbmagma.ninja"><img src="http://ens-spirent-test-summary.com.s3-us-west-1.amazonaws.com/sanity/hilsanitypass.svg" alt="HIL AGW Last Stable"></a>
 
 Current testing workflow for HIL testing is using Spirent test center to emulate eNodeB, UE and Network host to run scale and performance tests. HIL is focusing on Magma AGW.
 HIL tests can be run with virtual or physical gateway. However, for now the automated runs are using physical [SUT-HW](https://protectli.com/vault-4-port) box.

--- a/docs/readmes/lte/hil_tests.md
+++ b/docs/readmes/lte/hil_tests.md
@@ -12,7 +12,7 @@ Current testing workflow for HIL testing is using Spirent test center to emulate
 gateway-only tests.
 HIL tests can be run with different gateway. However for now the automated runs are using physical [Protectli](https://protectli.com/vault-4-port) box.
 
-### Lab Setup
+## Lab Setup
 
 Spirent test emulation hardware is hosted in FB lab emulating eNODEB, UE and traffic host elements. gateway are also hosted in same lab. All tests are
 executed in worker node in FB lab. Reports and logs are pushed out to aws S3 for debug and analysis.
@@ -47,4 +47,3 @@ We can retrieve log and grafana metrics for each run by clicking on test run res
 
 All test suite run send notification to slack channel which is used as alerting mechanism.
 please join slack [chennal](https://magmacore.slack.com/archives/C02164DSGPM) for regular update
-

--- a/docs/readmes/lte/hil_tests.md
+++ b/docs/readmes/lte/hil_tests.md
@@ -1,0 +1,38 @@
+---
+id: hil_tests
+title: Hardware In Loop Testing
+hide_title: true
+---
+# Hardware In Loop Tests
+
+Current testing workflow for HIL testing is using Spirent test center to emulate eNodeB, UE and Network host to run scale and performance tests. We cover
+gateway-only tests.
+
+HIL tests can be run with different gateway. However for now the automated runs are using physical Protectli box. (https://protectli.com/vault-4-port)
+
+### Lab Setup
+
+
+Spirent test emulation hardware is hosted in FB lab emulating eNODEB, UE and traffic host elements. gateway are also hosted in same lab. All tests are
+executed in worker node in FB lab. Reports and logs are pushed out to aws S3 for debug and analysis.
+
+### Run tests
+
+To setup HIL worker follow instruction on (https://github.com/fbcinternal/ens_magma/tree/master/spirent_automation)
+
+Current Test categories supported are:
+1. Sanity (nightly run time - 30 minutes) update badge with latest results on magma main README
+1. Performace (nightly run time - 12hrs)
+1. Feature tests at scale - (nightly run time - 6 hrs)
+1. Availability - Every day for 12hrs period
+
+### HIL SANITY TEST CASES
+1. Verify 12 eNodeBs can connect to a Magma Access Gateway
+1. Verify 200 UEs at 5 UE/sec can connect to a Magma Access Gateway
+1. Verify 400 UEs at 5 UE/sec can connect to a Magma Access Gateway
+1. Verify 600 UEs at 5 UE/sec can connect to a Magma Access Gateway
+1. Verify 200 UEs across 12 eNodeBs with 2M data per UE
+1. Verify 400 UEs across 12 eNodeBs with 500k data per UE
+1. Verify 600 UEs across 12 eNodeBs with 500k data per UE
+1. Verify 30 UEs across 12 eNodeBs with 500K data changing state from active-idle-active-idle
+

--- a/docs/readmes/lte/hil_tests.md
+++ b/docs/readmes/lte/hil_tests.md
@@ -4,19 +4,15 @@ title: Hardware In Loop Testing
 hide_title: true
 ---
 
-<p align="center">
-    <a href="http://automation.fbmagma.ninja"><img src="http://ens-spirent-test-summary.com.s3-us-west-1.amazonaws.com/sanity/hilsanityres.svg" alt="HIL Sanity Run"></a>
-</p>
+<a href="http://automation.fbmagma.ninja"><img src="http://ens-spirent-test-summary.com.s3-us-west-1.amazonaws.com/sanity/hilsanityres.svg" alt="HIL Sanity Run"></a>
 
 # Hardware In Loop Tests
 
 Current testing workflow for HIL testing is using Spirent test center to emulate eNodeB, UE and Network host to run scale and Performance tests. We cover
 gateway-only tests.
-
 HIL tests can be run with different gateway. However for now the automated runs are using physical [Protectli](https://protectli.com/vault-4-port) box.
 
 ### Lab Setup
-
 
 Spirent test emulation hardware is hosted in FB lab emulating eNODEB, UE and traffic host elements. gateway are also hosted in same lab. All tests are
 executed in worker node in FB lab. Reports and logs are pushed out to aws S3 for debug and analysis.
@@ -24,8 +20,8 @@ executed in worker node in FB lab. Reports and logs are pushed out to aws S3 for
 ### Run tests
 
 To setup HIL worker follow [instruction](https://github.com/fbcinternal/ens_magma/tree/master/spirent_automation)
-
 Current Test categories supported are:
+
 1. Sanity (nightly run time - 30 minutes) update badge with latest results on magma main README
 1. Performance (nightly run time - 12hrs)
 1. Feature tests at scale - (nightly run time - 6 hrs)
@@ -45,7 +41,6 @@ Current Test categories supported are:
 ### Dashboard
 
 All test suite results and daily runs are available to compare on [dashboard](http://automation.fbmagma.ninja/) admin/test1234
-
 We can retrieve log and grafana metrics for each run by clicking on test run result table.
 
 ### Notification

--- a/docs/readmes/lte/hil_tests.md
+++ b/docs/readmes/lte/hil_tests.md
@@ -13,7 +13,7 @@ hide_title: true
 Current testing workflow for HIL testing is using Spirent test center to emulate eNodeB, UE and Network host to run scale and Performance tests. We cover
 gateway-only tests.
 
-HIL tests can be run with different gateway. However for now the automated runs are using physical Protectli box. (https://protectli.com/vault-4-port)
+HIL tests can be run with different gateway. However for now the automated runs are using physical [Protectli](https://protectli.com/vault-4-port) box.
 
 ### Lab Setup
 
@@ -23,7 +23,7 @@ executed in worker node in FB lab. Reports and logs are pushed out to aws S3 for
 
 ### Run tests
 
-To setup HIL worker follow instruction on (https://github.com/fbcinternal/ens_magma/tree/master/spirent_automation)
+To setup HIL worker follow [instruction](https://github.com/fbcinternal/ens_magma/tree/master/spirent_automation)
 
 Current Test categories supported are:
 1. Sanity (nightly run time - 30 minutes) update badge with latest results on magma main README
@@ -42,12 +42,11 @@ Current Test categories supported are:
 1. Verify 30 UEs across 12 eNodeBs with 500K data changing state from active-idle-active-idle
 
 ### Dashboard
-All test suite results and daily runs are available to compare on dashboard
-(http://automation.fbmagma.ninja/) admin/test1234
+All test suite results and daily runs are available to compare on [dashboard](http://automation.fbmagma.ninja/) admin/test1234
 
 We can retrieve log and grafana metrics for each run by clicking on test run result table.
 
 ### Notification
 All test suite run send notification to slack channel which is used as alerting mechanism.
-please join slack chennal - (https://magmacore.slack.com/archives/C02164DSGPM) for regular update
+please join slack [chennal](https://magmacore.slack.com/archives/C02164DSGPM) for regular update
 

--- a/docs/readmes/lte/hil_tests.md
+++ b/docs/readmes/lte/hil_tests.md
@@ -32,6 +32,7 @@ Current Test categories supported are:
 1. Availability - Every day for 12hrs period
 
 ### HIL SANITY TEST CASES
+
 1. Verify 12 eNodeBs can connect to a Magma Access Gateway
 1. Verify 200 UEs at 5 UE/sec can connect to a Magma Access Gateway
 1. Verify 400 UEs at 5 UE/sec can connect to a Magma Access Gateway
@@ -42,11 +43,13 @@ Current Test categories supported are:
 1. Verify 30 UEs across 12 eNodeBs with 500K data changing state from active-idle-active-idle
 
 ### Dashboard
+
 All test suite results and daily runs are available to compare on [dashboard](http://automation.fbmagma.ninja/) admin/test1234
 
 We can retrieve log and grafana metrics for each run by clicking on test run result table.
 
 ### Notification
+
 All test suite run send notification to slack channel which is used as alerting mechanism.
 please join slack [chennal](https://magmacore.slack.com/archives/C02164DSGPM) for regular update
 

--- a/docs/readmes/lte/hil_tests.md
+++ b/docs/readmes/lte/hil_tests.md
@@ -1,31 +1,30 @@
 ---
-id: hil_tests
+id: HIL_AGW_tests
 title: Hardware In Loop Testing
 hide_title: true
 ---
 
-<a href="http://automation.fbmagma.ninja"><img src="http://ens-spirent-test-summary.com.s3-us-west-1.amazonaws.com/sanity/hilsanitypass.svg" alt="HIL Sanity Last Stable"></a>
+<a href="http://automation.fbmagma.ninja"><img src="http://ens-spirent-test-summary.com.s3-us-west-1.amazonaws.com/sanity/hilsanitypass.svg" alt="HIL AGW Last Stable"></a>
 
 # Hardware In Loop Tests
 
-Current testing workflow for HIL testing is using Spirent test center to emulate eNodeB, UE and Network host to run scale and Performance tests. We cover
-gateway-only tests.
-HIL tests can be run with different gateway. However for now the automated runs are using physical [Protectli](https://protectli.com/vault-4-port) box.
+Current testing workflow for HIL testing is using Spirent test center to emulate eNodeB, UE and Network host to run scale and performance tests. HIL is focusing on Magma AGW.
+HIL tests can be run with virtual or physical gateway. However, for now the automated runs are using physical [SUT-HW](https://protectli.com/vault-4-port) box.
 
 ## Lab Setup
 
-Spirent test emulation hardware is hosted in FB lab emulating eNODEB, UE and traffic host elements. gateway are also hosted in same lab. All tests are
-executed in worker node in FB lab. Reports and logs are pushed out to aws S3 for debug and analysis.
+Spirent test emulation hardware is hosted in FB lab emulating eNODEB, UE and traffic host elements. Magma AGW is also hosted in same lab. All tests are
+executed in worker node in FB lab. Reports and logs are pushed out to AWS S3 for debug and analysis.
 
 ### Run tests
 
 To setup HIL worker follow [instruction](https://github.com/fbcinternal/ens_magma/tree/master/spirent_automation)
 Current Test categories supported are:
 
-1. Sanity (nightly run time - 30 minutes) update badge with latest results on magma main README
-1. Performance (nightly run time - 12hrs)
-1. Feature tests at scale - (nightly run time - 6 hrs)
-1. Availability - Every day for 12hrs period
+1. Sanity (every new build, run time - 30 minutes) updates badge with latest result on magma main README
+1. Performance (nightly, run time - 12hrs)
+1. Feature tests at scale - (nightly, run time - 6hrs)
+1. Availability - Every day, for 12hrs
 
 ### HIL SANITY TEST CASES
 
@@ -37,15 +36,13 @@ Current Test categories supported are:
 1. Verify 400 UEs across 12 eNodeBs with 500k data per UE
 1. Verify 600 UEs across 12 eNodeBs with 500k data per UE
 1. Verify 30 UEs across 12 eNodeBs with 500K data changing state from active-idle-active-idle
-1. Verify APN 10 correction mapping with 50 UEs
-1. Verify PLMN Restriction for 50 valid UEs and 50 invalid UEs
 
 ### Dashboard
 
-All test suite results and daily runs are available to compare on [dashboard](http://automation.fbmagma.ninja/) admin/test1234
-We can retrieve log and grafana metrics for each run by clicking on test run result table.
+All test results are available to compare on [dashboard](http://automation.fbmagma.ninja/). Please use `username:magma` and `password:magma`.
+We can retrieve log and Grafana metrics for each run by clicking on test run result table.
 
 ### Notification
 
-All test suite run send notification to slack channel which is used as alerting mechanism.
-please join slack [chennal](https://magmacore.slack.com/archives/C02164DSGPM) for regular update
+All test suites run send notification to slack channel which is used as alerting mechanism.
+please join slack [channel](https://magmacore.slack.com/archives/C02164DSGPM) for regular update

--- a/docs/readmes/lte/hil_tests.md
+++ b/docs/readmes/lte/hil_tests.md
@@ -3,9 +3,14 @@ id: hil_tests
 title: Hardware In Loop Testing
 hide_title: true
 ---
+
+<p align="center">
+    <a href="http://automation.fbmagma.ninja"><img src="http://ens-spirent-test-summary.com.s3-us-west-1.amazonaws.com/sanity/hilsanityres.svg" alt="HIL Sanity Run"></a>
+</p>
+
 # Hardware In Loop Tests
 
-Current testing workflow for HIL testing is using Spirent test center to emulate eNodeB, UE and Network host to run scale and performance tests. We cover
+Current testing workflow for HIL testing is using Spirent test center to emulate eNodeB, UE and Network host to run scale and Performance tests. We cover
 gateway-only tests.
 
 HIL tests can be run with different gateway. However for now the automated runs are using physical Protectli box. (https://protectli.com/vault-4-port)
@@ -22,7 +27,7 @@ To setup HIL worker follow instruction on (https://github.com/fbcinternal/ens_ma
 
 Current Test categories supported are:
 1. Sanity (nightly run time - 30 minutes) update badge with latest results on magma main README
-1. Performace (nightly run time - 12hrs)
+1. Performance (nightly run time - 12hrs)
 1. Feature tests at scale - (nightly run time - 6 hrs)
 1. Availability - Every day for 12hrs period
 
@@ -35,4 +40,14 @@ Current Test categories supported are:
 1. Verify 400 UEs across 12 eNodeBs with 500k data per UE
 1. Verify 600 UEs across 12 eNodeBs with 500k data per UE
 1. Verify 30 UEs across 12 eNodeBs with 500K data changing state from active-idle-active-idle
+
+### Dashboard
+All test suite results and daily runs are available to compare on dashboard
+(http://automation.fbmagma.ninja/) admin/test1234
+
+We can retrieve log and grafana metrics for each run by clicking on test run result table.
+
+### Notification
+All test suite run send notification to slack channel which is used as alerting mechanism.
+please join slack chennal - (https://magmacore.slack.com/archives/C02164DSGPM) for regular update
 

--- a/docs/readmes/lte/hil_tests.md
+++ b/docs/readmes/lte/hil_tests.md
@@ -1,13 +1,6 @@
----
-id: HIL_AGW_tests
-title: Hardware In Loop Testing
-hide_title: true
----
-
 <p align="center">
     <a href="http://automation.fbmagma.ninja"><img src="http://ens-spirent-test-summary.com.s3-us-west-1.amazonaws.com/sanity/hilsanitypass.svg" alt="HIL AGW Last Stable"></a>
 </p>
-
 
 # Hardware In Loop Tests
 

--- a/docs/readmes/lte/hil_tests.md
+++ b/docs/readmes/lte/hil_tests.md
@@ -1,11 +1,15 @@
-<p align="center">
-    <a href="http://automation.fbmagma.ninja"><img src="http://ens-spirent-test-summary.com.s3-us-west-1.amazonaws.com/sanity/hilsanitypass.svg" alt="HIL AGW Last Stable"></a>
-</p>
+---
+id: HIL_AGW_tests
+title: Hardware In Loop Testing
+hide_title: true
+---
 
 # Hardware In Loop Tests
 
 Current testing workflow for HIL testing is using Spirent test center to emulate eNodeB, UE and Network host to run scale and performance tests. HIL is focusing on Magma AGW.
 HIL tests can be run with virtual or physical gateway. However, for now the automated runs are using physical [SUT-HW](https://protectli.com/vault-4-port) box.
+
+![HIL AGW Last Stable](http://ens-spirent-test-summary.com.s3-us-west-1.amazonaws.com/sanity/hilsanitypass.svg)
 
 ## Dashboard
 

--- a/docs/readmes/lte/hil_tests.md
+++ b/docs/readmes/lte/hil_tests.md
@@ -4,11 +4,12 @@ title: Hardware In Loop Testing
 hide_title: true
 ---
 
-# Hardware In Loop Tests
-
 <p align="center">
     <a href="http://automation.fbmagma.ninja"><img src="http://ens-spirent-test-summary.com.s3-us-west-1.amazonaws.com/sanity/hilsanitypass.svg" alt="HIL AGW Last Stable"></a>
 </p>
+
+
+# Hardware In Loop Tests
 
 Current testing workflow for HIL testing is using Spirent test center to emulate eNodeB, UE and Network host to run scale and performance tests. HIL is focusing on Magma AGW.
 HIL tests can be run with virtual or physical gateway. However, for now the automated runs are using physical [SUT-HW](https://protectli.com/vault-4-port) box.


### PR DESCRIPTION


<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

- one for last stable and one for current state 
- removing PR welcome badge as discussed with brian/tariq

We are running nightly HIL testing. so using these badge, we want to achive two things. 
Indicate last HIL sanity stable build, which can be used to create quick release branch.
Indicate latest hil testing status.

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
