### PR TITLE
fix: handle int128 as couple of int64 and make hashable

### DIFF
--- a/lte/gateway/python/magma/kernsnoopd/metrics.py
+++ b/lte/gateway/python/magma/kernsnoopd/metrics.py
@@ -13,22 +13,10 @@ limitations under the License.
 
 from prometheus_client import Counter
 
-MAGMA_PACKETS_SENT_TOTAL = Counter(
-    'magma_packets_sent_total',
-    'Total packets sent from Magma gateway services to Orc8r services',
-    ['service_name', 'dest_service'],
-)
-
 MAGMA_BYTES_SENT_TOTAL = Counter(
     'magma_bytes_sent_total',
     'Total bytes sent from Magma gateway services to Orc8r services',
     ['service_name', 'dest_service'],
-)
-
-LINUX_PACKETS_SENT_TOTAL = Counter(
-    'linux_packets_sent_total',
-    'Total packets sent from non-Magma-service binaries to any destination',
-    ['binary_name'],
 )
 
 LINUX_BYTES_SENT_TOTAL = Counter(

--- a/lte/gateway/python/magma/kernsnoopd/tests/byte_counter_tests.py
+++ b/lte/gateway/python/magma/kernsnoopd/tests/byte_counter_tests.py
@@ -90,7 +90,8 @@ class ByteCounterTests(unittest.TestCase):
         key.pid, key.comm = 0, b'subscriberdb'
         key.family = AF_INET
         # 16777343 is "127.0.0.1" packed as a 4 byte int
-        key.daddr, key.dport = [16777343], htons(80)
+        key.daddr = self.byte_counter.Addr(16777343, 0)
+        key.dport = htons(80)
 
         count = MagicMock()
         count.value = 100
@@ -115,7 +116,8 @@ class ByteCounterTests(unittest.TestCase):
         key.family = AF_INET6
         # localhost in IPv6 with embedded IPv4
         # ::ffff:127.0.0.1 = 0x0100007FFFFF0000
-        key.daddr, key.dport = b'0100007FFFFF0000', htons(443)
+        key.daddr = self.byte_counter.Addr(0, 0x0100007FFFFF0000)
+        key.dport = htons(443)
 
         count = MagicMock()
         count.value = 100


### PR DESCRIPTION
Signed-off-by: Waqar Aqeel <waqeel@fb.com>

## Summary

IPv6 support in `ByteCounter` had a bug where a `c_ulong_Array_2` was being cast to tuple and then bytes in `_ip_addr_to_str`. That is incorrect as `inet_ntop` expects a `c_ulong_Array_2` object in case of `AF_INET6`. This PR fixes the bug by replace cast to bytes with cast to `c_ulong_Array_2`. The conversion to tuple is necessary for caching as it requires a hashable type.

Alternative would be to define `__hash__` and `__eq__` for the fixed-size array type. I think that is more clumsy.

## Test Plan

Unit tests did not catch the original bug as `key.daddr` was being mocked as `int` and `bytes` for IPv4 and IPv6 respectively. Modified the unit test to use the `c_ulong_Array_2` type. Tests pass.
