### PR TITLE
fix: add `_total` suffix to metric names

### DIFF
--- a/nms/app/packages/magmalte/data/LteMetrics.json
+++ b/nms/app/packages/magmalte/data/LteMetrics.json
@@ -735,14 +735,14 @@
       "Service": "sessiond"
     },
     {
-      "MetricName": "magma_bytes_sent",
+      "MetricName": "magma_bytes_sent_total",
       "PromQL": "magma_bytes_sent",
       "Description": "Total bytes sent from Magma gateway services to Orc8r services",
       "Category": "AGW",
       "Service": "kernsnoopd"
     },
     {
-      "MetricName": "linux_bytes_sent",
+      "MetricName": "linux_bytes_sent_total",
       "PromQL": "linux_bytes_sent",
       "Description": "Total bytes sent from non-Magma-service binaries to any destination",
       "Category": "AGW",


### PR DESCRIPTION
Signed-off-by: Waqar Aqeel <waqeel@fb.com>

## Summary

There was a mismatch in Prometheus metric names and those in `LteMetrics.json`. This caused "Description unavailable" in the NMS explore UI. This PR fixes the descrepancy to provide proper description and category to NMS.

## Test Plan

Built NMS and observed display of description and category.

<img width="1472" alt="Screen Shot 2021-08-03 at 4 23 45 PM" src="https://user-images.githubusercontent.com/4567080/128081568-0c322b5b-b256-4a5e-a58f-41b15c9d55cc.png">
