### PR TITLE
fix(mme): PDUSessionResourceSetupRequest failure randomly

### DIFF
--- a/lte/gateway/c/core/oai/tasks/amf/Registration.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/Registration.cpp
@@ -249,9 +249,9 @@ int amf_proc_registration_reject(
   registration_proc->amf_cause = amf_cause;
   if (amf_ctx) {
     if (is_nas_specific_procedure_registration_running(amf_ctx)) {
-      rc = amf_registration_reject(amf_ctx, registration_proc);
-      amf_sap_t amf_sap;
-      amf_sap.primitive                   = AMFREG_REGISTRATION_REJ;
+      rc                = amf_registration_reject(amf_ctx, registration_proc);
+      amf_sap_t amf_sap = {};
+      amf_sap.primitive = AMFREG_REGISTRATION_REJ;
       amf_sap.u.amf_reg.ue_id             = ue_id;
       amf_sap.u.amf_reg.ctx               = amf_ctx;
       amf_sap.u.amf_reg.notify            = false;
@@ -276,8 +276,8 @@ int amf_proc_registration_reject(
 static int amf_registration_reject(
     amf_context_t* amf_context, nas_amf_registration_proc_t* nas_base_proc) {
   OAILOG_FUNC_IN(LOG_NAS_AMF);
-  int rc = RETURNerror;
-  amf_sap_t amf_sap;
+  int rc            = RETURNerror;
+  amf_sap_t amf_sap = {};
   nas_amf_registration_proc_t* registration_proc =
       (nas_amf_registration_proc_t*) nas_base_proc;
   OAILOG_WARNING(
@@ -455,8 +455,8 @@ static int amf_registration_failure_authentication_cb(
       get_nas_specific_procedure_registration(amf_context);
 
   if (registration_proc) {
-    registration_proc->amf_cause = amf_context->amf_cause;
-    amf_sap_t amf_sap;
+    registration_proc->amf_cause        = amf_context->amf_cause;
+    amf_sap_t amf_sap                   = {};
     amf_sap.primitive                   = AMFREG_REGISTRATION_REJ;
     amf_sap.u.amf_reg.ue_id             = registration_proc->ue_id;
     amf_sap.u.amf_reg.ctx               = amf_context;
@@ -590,7 +590,7 @@ int amf_send_registration_accept(amf_context_t* amf_context) {
   int rc = RETURNerror;
 
   if (amf_context) {
-    amf_sap_t amf_sap;
+    amf_sap_t amf_sap = {};
     nas_amf_registration_proc_t* registration_proc =
         get_nas_specific_procedure_registration(amf_context);
     ue_m5gmm_context_s* ue_m5gmm_context_p =
@@ -745,7 +745,7 @@ int amf_proc_registration_complete(amf_context_t* amf_ctx) {
   OAILOG_FUNC_IN(LOG_NAS_AMF);
   nas_amf_registration_proc_t* registration_proc = NULL;
   int rc                                         = RETURNerror;
-  amf_sap_t amf_sap;
+  amf_sap_t amf_sap                              = {};
   amf_ue_ngap_id_t ue_id =
       PARENT_STRUCT(amf_ctx, struct ue_m5gmm_context_s, amf_context)
           ->amf_ue_ngap_id;
@@ -862,8 +862,8 @@ int amf_handle_registration_complete_response(
  ***************************************************************************/
 
 int amf_proc_amf_information(ue_m5gmm_context_s* ue_amf_ctx) {
-  int rc = RETURNerror;
-  amf_sap_t amf_sap;
+  int rc                 = RETURNerror;
+  amf_sap_t amf_sap      = {};
   amf_as_data_t* amf_as  = &amf_sap.u.amf_as.u.data;
   amf_context_t* amf_ctx = &(ue_amf_ctx->amf_context);
   OAILOG_FUNC_IN(LOG_NAS_AMF);

--- a/lte/gateway/c/core/oai/tasks/amf/amf_Security_Mode.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_Security_Mode.cpp
@@ -80,7 +80,7 @@ int amf_handle_security_complete_response(
         /*
          * Notify AMF that the authentication procedure successfully completed
          */
-        amf_sap_t amf_sap;
+        amf_sap_t amf_sap                = {};
         amf_sap.primitive                = AMFCN_CS_RESPONSE;
         amf_sap.u.amf_reg.ue_id          = ue_id;
         amf_sap.u.amf_reg.ctx            = amf_ctx;

--- a/lte/gateway/c/core/oai/tasks/amf/amf_app_ue_context.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_app_ue_context.cpp
@@ -139,6 +139,7 @@ ue_m5gmm_context_s* amf_create_new_ue_context(void) {
     OAILOG_ERROR(LOG_AMF_APP, "Failed to allocate memory for UE context \n");
     return NULL;
   }
+  memset(new_p, 0, sizeof(ue_m5gmm_context_s));
 
   new_p->amf_ue_ngap_id  = INVALID_AMF_UE_NGAP_ID;
   new_p->gnb_ngap_id_key = INVALID_GNB_UE_NGAP_ID_KEY;
@@ -218,6 +219,7 @@ ue_m5gmm_context_s* amf_ue_context_exists_amf_ue_ngap_id(
 smf_context_t* amf_insert_smf_context(
     ue_m5gmm_context_s* ue_context, uint8_t pdu_session_id) {
   smf_context_t smf_context;
+  memset(&smf_context, 0, sizeof(smf_context));
   std::vector<smf_context_t>::iterator i;
   int j = 0;
 

--- a/lte/gateway/c/core/oai/tasks/amf/amf_app_ue_context.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_app_ue_context.cpp
@@ -139,7 +139,6 @@ ue_m5gmm_context_s* amf_create_new_ue_context(void) {
     OAILOG_ERROR(LOG_AMF_APP, "Failed to allocate memory for UE context \n");
     return NULL;
   }
-  memset(new_p, 0, sizeof(ue_m5gmm_context_s));
 
   new_p->amf_ue_ngap_id  = INVALID_AMF_UE_NGAP_ID;
   new_p->gnb_ngap_id_key = INVALID_GNB_UE_NGAP_ID_KEY;
@@ -218,8 +217,7 @@ ue_m5gmm_context_s* amf_ue_context_exists_amf_ue_ngap_id(
  ***************************************************************************/
 smf_context_t* amf_insert_smf_context(
     ue_m5gmm_context_s* ue_context, uint8_t pdu_session_id) {
-  smf_context_t smf_context;
-  memset(&smf_context, 0, sizeof(smf_context));
+  smf_context_t smf_context = {};
   std::vector<smf_context_t>::iterator i;
   int j = 0;
 

--- a/lte/gateway/c/core/oai/tasks/amf/amf_asDefs.h
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_asDefs.h
@@ -90,17 +90,12 @@ class amf_as_data_t {
       bool is_ciphered);
 };
 
-typedef struct amf_as_pdusession_identity_s {
-  const guti_m5_t* guti;  // The GUTI, if valid
-} amf_as_pdusession_identity_t;
-
 // Structure to handle UL/DL NAS message in AMF
 typedef struct amf_as_establish_s {
-  amf_ue_ngap_id_t ue_id;               // UE lower layer identifier
-  uint64_t puid;                        // linked to procedure UID
-  amf_as_pdusession_identity_t pds_id;  // UE's 5g cn mobile identity
-  amf_as_security_data_t sctx;          // 5g cn NAS security context
-  bool is_initial;                      // true if contained in initial message
+  amf_ue_ngap_id_t ue_id;       // UE lower layer identifier
+  uint64_t puid;                // linked to procedure UID
+  amf_as_security_data_t sctx;  // 5g cn NAS security context
+  bool is_initial;              // true if contained in initial message
   bool is_amf_ctx_new;
   uint8_t amf_cause;  // amf failure cause code
   tai_t tai;          // The first tracking area the UE is registered

--- a/lte/gateway/c/core/oai/tasks/amf/amf_authentication.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_authentication.cpp
@@ -445,7 +445,7 @@ int amf_proc_authentication_ksi(
     /*
      * Notify AMF that common procedure has been initiated
      */
-    amf_sap_t amf_sap;
+    amf_sap_t amf_sap       = {};
     amf_sap.primitive       = AMFREG_COMMON_PROC_REQ;
     amf_sap.u.amf_reg.ue_id = ue_id;
     amf_sap.u.amf_reg.ctx   = amf_context;
@@ -557,7 +557,7 @@ int amf_proc_authentication_complete(
         /*
          * Notify AMF that the authentication procedure failed
          */
-        amf_sap_t amf_sap;
+        amf_sap_t amf_sap                    = {};
         amf_sap.primitive                    = AMFAS_SECURITY_REJ;
         amf_sap.u.amf_as.u.security.ue_id    = ue_id;
         amf_sap.u.amf_as.u.security.msg_type = AMF_AS_MSG_TYPE_AUTH;
@@ -571,7 +571,7 @@ int amf_proc_authentication_complete(
     /*
      * Notify AMF that the authentication procedure successfully completed
      */
-    amf_sap_t amf_sap;
+    amf_sap_t amf_sap               = {};
     amf_sap.primitive               = AMFREG_COMMON_PROC_CNF;
     amf_sap.u.amf_reg.ue_id         = ue_id;
     amf_sap.u.amf_reg.ctx           = amf_ctx;
@@ -709,7 +709,7 @@ int amf_proc_authentication_failure(
         /*
          * Notify AMF that the authentication procedure successfully completed
          */
-        amf_sap_t amf_sap;
+        amf_sap_t amf_sap                    = {};
         amf_sap.primitive                    = AMFAS_SECURITY_REJ;
         amf_sap.u.amf_as.u.security.ue_id    = ue_id;
         amf_sap.u.amf_as.u.security.msg_type = AMF_AS_MSG_TYPE_AUTH;
@@ -770,7 +770,7 @@ int amf_send_authentication_request(
      * Notify AMF-AS SAP that Authentication Request message has to be sent
      * to the UE
      */
-    amf_sap_t amf_sap;
+    amf_sap_t amf_sap                = {};
     amf_sap.primitive                = AMFAS_SECURITY_REQ;
     amf_sap.u.amf_as.u.security.guti = {0};
     //    amf_sap.u.amf_as.u.security.ue_id    = auth_proc->ue_id;

--- a/lte/gateway/c/core/oai/tasks/amf/amf_identity.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_identity.cpp
@@ -117,8 +117,8 @@ int amf_proc_identification_complete(
     const amf_ue_ngap_id_t ue_id, imsi_t* const imsi, imei_t* const imei,
     imeisv_t* const imeisv, uint32_t* const tmsi, guti_m5_t* amf_ctx_guti) {
   OAILOG_FUNC_IN(LOG_NAS_AMF);
-  int rc = RETURNerror;
-  amf_sap_t amf_sap;
+  int rc                 = RETURNerror;
+  amf_sap_t amf_sap      = {};
   amf_context_t* amf_ctx = NULL;
 
   OAILOG_DEBUG(

--- a/lte/gateway/c/core/oai/tasks/amf/amf_security_mode_control.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_security_mode_control.cpp
@@ -124,9 +124,9 @@ static int amf_security_request(nas_amf_smc_proc_t* const smc_proc) {
   OAILOG_FUNC_IN(LOG_NAS_AMF);
   ue_m5gmm_context_s* ue_mm_context = NULL;
   amf_context_t* amf_ctx            = NULL;
-  amf_sap_t amf_sap;
-  int rc             = RETURNerror;
-  smc_proc->T3560.id = NAS5G_TIMER_INACTIVE_ID;
+  amf_sap_t amf_sap                 = {};
+  int rc                            = RETURNerror;
+  smc_proc->T3560.id                = NAS5G_TIMER_INACTIVE_ID;
 
   if (smc_proc) {
     /*

--- a/lte/gateway/c/core/oai/tasks/amf/deregistration_request.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/deregistration_request.cpp
@@ -131,7 +131,7 @@ int amf_proc_deregistration_request(
         ue_id, params->de_reg_type);
     OAILOG_FUNC_RETURN(LOG_NAS_AMF, RETURNerror);
   }
-  amf_sap_t amf_sap;
+  amf_sap_t amf_sap     = {};
   amf_as_data_t* amf_as = &amf_sap.u.amf_as.u.data;
 
   /* if switched off, directly release all resources and

--- a/lte/gateway/c/core/oai/tasks/amf/nas_proc.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/nas_proc.cpp
@@ -41,8 +41,8 @@ int nas_proc_establish_ind(
     const tai_t originating_tai, const ecgi_t ecgi,
     const m5g_rrc_establishment_cause_t as_cause, const s_tmsi_m5_t s_tmsi,
     bstring msg) {
-  amf_sap_t amf_sap;
-  uint32_t rc = RETURNerror;
+  amf_sap_t amf_sap = {};
+  uint32_t rc       = RETURNerror;
   if (msg) {
     /*
      * Notify the AMF procedure call manager that NAS signaling
@@ -234,9 +234,9 @@ nas_amf_ident_proc_t* nas5g_new_identification_procedure(
 ***************************************************************************/
 static int amf_identification_request(nas_amf_ident_proc_t* const proc) {
   OAILOG_FUNC_IN(LOG_NAS_EMM);
-  amf_sap_t amf_sap;  //             = {0};
-  int rc         = RETURNok;
-  proc->T3570.id = NAS5G_TIMER_INACTIVE_ID;
+  amf_sap_t amf_sap = {};
+  int rc            = RETURNok;
+  proc->T3570.id    = NAS5G_TIMER_INACTIVE_ID;
   OAILOG_DEBUG(LOG_AMF_APP, "Sending AS IDENTITY_REQUEST\n");
   /*
    * Notify AMF-AS SAP that Identity Request message has to be sent
@@ -374,7 +374,7 @@ int amf_proc_identification(
       /*
        * Notify 5G CN that common procedure has been initiated
        */
-      amf_sap_t amf_sap;
+      amf_sap_t amf_sap       = {};
       amf_sap.primitive       = AMFREG_COMMON_PROC_REQ;
       amf_sap.u.amf_reg.ue_id = ue_id;
       amf_sap.u.amf_reg.ctx   = amf_context;

--- a/lte/gateway/c/core/oai/test/amf/CMakeLists.txt
+++ b/lte/gateway/c/core/oai/test/amf/CMakeLists.txt
@@ -15,7 +15,18 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 
 include_directories("${PROJECT_SOURCE_DIR}")
 include_directories("${PROJECT_SOURCE_DIR}/tasks/amf")
+include_directories(${CMAKE_CURRENT_SOURCE_DIR}/../../tasks/amf)
 
+pkg_search_module(OPENSSL openssl REQUIRED)
+include_directories(${OPENSSL_INCLUDE_DIRS})
+
+pkg_search_module(CRYPTO libcrypto REQUIRED)
+include_directories(${CRYPTO_INCLUDE_DIRS})
+
+include_directories("${PROJECT_SOURCE_DIR}/include/nas")
+
+message("amf path: " ${PROJECT_SOURCE_DIR}) 
+message("amf lib:  " ${TASK_AMF_APP}) 
 add_library(AMF_TASK_TEST_LIB
     util_nas5g_pkt.h
     util_nas5g_registration_pkt.cpp
@@ -27,7 +38,9 @@ link_directories(${PROJECT_SOURCE_DIR}/tasks/amf)
 target_link_libraries(AMF_TASK_TEST_LIB
         ${CONFIG}
         COMMON
-	LIB_NAS5G gtest gtest_main pthread rt yaml-cpp
+	LIB_NAS5G TASK_AMF_APP gtest gtest_main pthread rt yaml-cpp
+        ${CRYPTO_LIBRARIES} ${OPENSSL_LIBRARIES}
+        ${NETTLE_LIBRARIES}
     )
 
 add_executable(amf_test test_amf.cpp)

--- a/lte/gateway/c/core/oai/test/amf/CMakeLists.txt
+++ b/lte/gateway/c/core/oai/test/amf/CMakeLists.txt
@@ -15,7 +15,6 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 
 include_directories("${PROJECT_SOURCE_DIR}")
 include_directories("${PROJECT_SOURCE_DIR}/tasks/amf")
-include_directories(${CMAKE_CURRENT_SOURCE_DIR}/../../tasks/amf)
 
 pkg_search_module(OPENSSL openssl REQUIRED)
 include_directories(${OPENSSL_INCLUDE_DIRS})
@@ -25,8 +24,6 @@ include_directories(${CRYPTO_INCLUDE_DIRS})
 
 include_directories("${PROJECT_SOURCE_DIR}/include/nas")
 
-message("amf path: " ${PROJECT_SOURCE_DIR}) 
-message("amf lib:  " ${TASK_AMF_APP}) 
 add_library(AMF_TASK_TEST_LIB
     util_nas5g_pkt.h
     util_nas5g_registration_pkt.cpp

--- a/lte/gateway/c/core/oai/test/amf/test_amf.cpp
+++ b/lte/gateway/c/core/oai/test/amf/test_amf.cpp
@@ -11,29 +11,13 @@
 
 #include "util_nas5g_pkt.h"
 #include <gtest/gtest.h>
+#include "intertask_interface.h"
 #include "../../tasks/amf/amf_app_ue_context_and_proc.h"
 
-extern "C" {
-#include "dynamic_memory_check.h"
-#define CHECK_PROTOTYPE_ONLY
-#include "intertask_interface_init.h"
-#undef CHECK_PROTOTYPE_ONLY
-#include "intertask_interface.h"
-#include "intertask_interface_types.h"
-#include "itti_free_defined_msg.h"
-}
-
-task_zmq_ctx_t grpc_service_task_zmq_ctx;
-
-const task_info_t tasks_info[] = {
-    {THREAD_NULL, "TASK_UNKNOWN", "ipc://IPC_TASK_UNKNOWN"},
-#define TASK_DEF(tHREADiD)                                                     \
-  {THREAD_##tHREADiD, #tHREADiD, "ipc://IPC_" #tHREADiD},
-#include <tasks_def.h>
-#undef TASK_DEF
-};
 
 using ::testing::Test;
+
+task_zmq_ctx_t grpc_service_task_zmq_ctx;
 
 namespace magma5g {
 


### PR DESCRIPTION
Signed-off-by: ganeshg87 <ganesh.gedela@wavelabs.ai>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary
  fix(mme): PDUSessionResourceSetupRequest failure randomly

## Test Plan

 below flows verified using UERANSIM
      1. registration setup
      2. pdu session
      3. deregistration


## Additional Information

1. pdu session resource setup request failed due to number active pdusession variable is uninitialized 
![bb87a45ae1c55486f51997eaa008cf6f46ae3f6f220e88b4b145572bc333e30f](https://user-images.githubusercontent.com/83060027/128134123-99dcb98c-48c6-4081-aaa6-6283e2fa0c14.png)
2. pdu session resource setup request failed due to pds_id.guti  variable is uninitilized 
![image](https://user-images.githubusercontent.com/83060027/128134453-469aac9a-5a08-4298-bce3-044d0567bab1.png)

