### PR TITLE
fix(mme): Backport PR 8455

### DIFF
--- a/lte/gateway/c/core/oai/tasks/grpc_service/grpc_service_task.c
+++ b/lte/gateway/c/core/oai/tasks/grpc_service/grpc_service_task.c
@@ -63,7 +63,8 @@ static void* grpc_service_thread(__attribute__((unused)) void* args) {
 
   start_grpc_service(grpc_service_config->server_address);
   zloop_start(grpc_service_task_zmq_ctx.event_loop);
-  grpc_service_exit();
+  AssertFatal(
+      0, "Asserting as grpc_service_thread should not be exiting on its own!");
   return NULL;
 }
 

--- a/lte/gateway/c/core/oai/tasks/mme_app/mme_app_main.c
+++ b/lte/gateway/c/core/oai/tasks/mme_app/mme_app_main.c
@@ -28,6 +28,7 @@
 #include <stdint.h>
 #include <pthread.h>
 
+#include "assertions.h"
 #include "bstrlib.h"
 #include "log.h"
 #include "intertask_interface.h"
@@ -525,7 +526,8 @@ static void* mme_app_thread(__attribute__((unused)) void* args) {
   start_stats_timer();
 
   zloop_start(mme_app_task_zmq_ctx.event_loop);
-  mme_app_exit();
+  AssertFatal(
+      0, "Asserting as mme_app_thread should not be exiting on its own!");
   return NULL;
 }
 

--- a/lte/gateway/c/core/oai/tasks/ngap/ngap_amf.c
+++ b/lte/gateway/c/core/oai/tasks/ngap/ngap_amf.c
@@ -198,7 +198,8 @@ static void* ngap_amf_thread(__attribute__((unused)) void* args) {
     OAILOG_INFO(LOG_NGAP, " sending SCTP_INIT_MSG to SCTP \n");
   }
   zloop_start(ngap_task_zmq_ctx.event_loop);
-  ngap_amf_exit();
+  AssertFatal(
+      0, "Asserting as ngap_amf_thread should not be exiting on its own!");
   return NULL;
 }
 

--- a/lte/gateway/c/core/oai/tasks/s11/s11_tasks.c
+++ b/lte/gateway/c/core/oai/tasks/s11/s11_tasks.c
@@ -377,7 +377,8 @@ static void* s11_mme_thread(void* args) {
   bdestroy_wrapper(&b);
 
   zloop_start(s11_task_zmq_ctx.event_loop);
-  s11_mme_exit();
+  AssertFatal(
+      0, "Asserting as s11_mme_thread should not be exiting on its own!");
   return NULL;
 }
 

--- a/lte/gateway/c/core/oai/tasks/s1ap/s1ap_mme.c
+++ b/lte/gateway/c/core/oai/tasks/s1ap/s1ap_mme.c
@@ -374,7 +374,8 @@ static void* s1ap_mme_thread(__attribute__((unused)) void* args) {
   start_stats_timer();
 
   zloop_start(s1ap_task_zmq_ctx.event_loop);
-  s1ap_mme_exit();
+  AssertFatal(
+      0, "Asserting as s1ap_mme_thread should not be exiting on its own!");
   return NULL;
 }
 

--- a/lte/gateway/c/core/oai/tasks/s6a/s6a_task.c
+++ b/lte/gateway/c/core/oai/tasks/s6a/s6a_task.c
@@ -142,7 +142,7 @@ static void* s6a_thread(void* args) {
   }
 
   zloop_start(s6a_task_zmq_ctx.event_loop);
-  s6a_exit();
+  AssertFatal(0, "Asserting as s6a_thread should not be exiting on its own!");
   return NULL;
 }
 

--- a/lte/gateway/c/core/oai/tasks/sctp/sctp_primitives_server.c
+++ b/lte/gateway/c/core/oai/tasks/sctp/sctp_primitives_server.c
@@ -136,7 +136,7 @@ static void* sctp_thread(__attribute__((unused)) void* args_p) {
       handle_message, &sctp_task_zmq_ctx);
 
   zloop_start(sctp_task_zmq_ctx.event_loop);
-  sctp_exit();
+  AssertFatal(0, "Asserting as sctp_thread should not be exiting on its own!");
   return NULL;
 }
 

--- a/lte/gateway/c/core/oai/tasks/service303/service303_task.c
+++ b/lte/gateway/c/core/oai/tasks/service303/service303_task.c
@@ -19,6 +19,7 @@
 
 #include <stdio.h>
 
+#include "assertions.h"
 #include "log.h"
 #include "intertask_interface.h"
 #include "common_defs.h"
@@ -70,7 +71,10 @@ static void* service303_server_thread(__attribute__((unused)) void* args) {
       handle_service303_server_message, &service303_server_task_zmq_ctx);
 
   zloop_start(service303_server_task_zmq_ctx.event_loop);
-  service303_server_exit();
+  AssertFatal(
+      0,
+      "Asserting as service303_server_thread should not be exiting on its "
+      "own!");
   return NULL;
 }
 
@@ -114,7 +118,8 @@ static void* service303_thread(void* args) {
       &service303_message_task_zmq_ctx);
   start_display_stats_timer();
   zloop_start(service303_message_task_zmq_ctx.event_loop);
-  service303_message_exit();
+  AssertFatal(
+      0, "Asserting as service303_thread should not be exiting on its own!");
   return NULL;
 }
 

--- a/lte/gateway/c/core/oai/tasks/sgs/sgs_task.c
+++ b/lte/gateway/c/core/oai/tasks/sgs/sgs_task.c
@@ -26,6 +26,7 @@
 
 #include <stdio.h>
 
+#include "assertions.h"
 #include "log.h"
 #include "intertask_interface.h"
 #include "mme_config.h"
@@ -180,7 +181,7 @@ static void* sgs_thread(__attribute__((unused)) void* args_p) {
       TASK_SGS, (task_id_t[]){TASK_MME_APP}, 1, handle_message, task_zmq_ctx_p);
 
   zloop_start(task_zmq_ctx_p->event_loop);
-  sgs_exit();
+  AssertFatal(0, "Asserting as sgs_thread should not be exiting on its own!");
   return NULL;
 }
 

--- a/lte/gateway/c/core/oai/tasks/sgw/sgw_task.c
+++ b/lte/gateway/c/core/oai/tasks/sgw/sgw_task.c
@@ -28,6 +28,7 @@
 #include <netinet/in.h>
 #include <sys/types.h>
 
+#include "assertions.h"
 #include "bstrlib.h"
 #include "dynamic_memory_check.h"
 #include "hashtable.h"
@@ -220,7 +221,8 @@ static void* spgw_app_thread(__attribute__((unused)) void* args) {
       &spgw_app_task_zmq_ctx);
 
   zloop_start(spgw_app_task_zmq_ctx.event_loop);
-  spgw_app_exit();
+  AssertFatal(
+      0, "Asserting as spgw_app_thread should not be exiting on its own!");
   return NULL;
 }
 

--- a/lte/gateway/c/core/oai/tasks/sgw_s8/sgw_s8_task.c
+++ b/lte/gateway/c/core/oai/tasks/sgw_s8/sgw_s8_task.c
@@ -34,7 +34,8 @@ static void* sgw_s8_thread(void* args) {
       &sgw_s8_task_zmq_ctx);
 
   zloop_start(sgw_s8_task_zmq_ctx.event_loop);
-  sgw_s8_exit();
+  AssertFatal(
+      0, "Asserting as sgw_s8_thread should not be exiting on its own!");
   return NULL;
 }
 

--- a/lte/gateway/c/core/oai/tasks/sms_orc8r/sms_orc8r_task.c
+++ b/lte/gateway/c/core/oai/tasks/sms_orc8r/sms_orc8r_task.c
@@ -26,6 +26,7 @@
 
 #include <stdio.h>
 
+#include "assertions.h"
 #include "log.h"
 #include "intertask_interface.h"
 #include "mme_config.h"
@@ -80,7 +81,8 @@ static void* sms_orc8r_thread(__attribute__((unused)) void* args_p) {
       task_zmq_ctx_p);
 
   zloop_start(task_zmq_ctx_p->event_loop);
-  sms_orc8r_exit();
+  AssertFatal(
+      0, "Asserting as sms_orc8r_thread should not be exiting on its own!");
   return NULL;
 }
 

--- a/lte/gateway/c/core/oai/tasks/udp/udp_primitives_server.c
+++ b/lte/gateway/c/core/oai/tasks/udp/udp_primitives_server.c
@@ -509,7 +509,7 @@ static void* udp_thread(void* args) {
       &udp_task_zmq_ctx);
 
   zloop_start(udp_task_zmq_ctx.event_loop);
-  udp_exit();
+  AssertFatal(0, "Asserting as udp_thread should not be exiting on its own!");
   return NULL;
 }
 


### PR DESCRIPTION
<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->
Backporting PR #8455 to guard against single thread exits.
 
## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->
S1AP integ tests.
Partner confirmed validation on the field.

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
