### PR TITLE
feat(mme): amf client servicer layer

### DIFF
--- a/lte/gateway/c/core/oai/lib/n11/CMakeLists.txt
+++ b/lte/gateway/c/core/oai/lib/n11/CMakeLists.txt
@@ -10,8 +10,6 @@ list(APPEND PROTO_HDRS "")
 generate_all_protos("${N11_LTE_CPP_PROTOS}" "${N11_ORC8R_GRPC_PROTOS}"
     "${N11_LTE_GRPC_PROTOS}" "" "${PROTO_SRCS}" "${PROTO_HDRS}")
 
-
-
 add_library(LIB_N11
     SmfServiceClient.cpp
     amf_client_proto_msg_to_itti_msg.cpp
@@ -20,7 +18,6 @@ add_library(LIB_N11
     ${PROTO_SRCS}
     ${PROTO_HDRS}
     )
-
 
 target_link_libraries(LIB_N11
     COMMON

--- a/lte/gateway/c/core/oai/lib/n11/M5GAuthenticationServiceClient.cpp
+++ b/lte/gateway/c/core/oai/lib/n11/M5GAuthenticationServiceClient.cpp
@@ -152,10 +152,4 @@ AsyncM5GAuthenticationServiceClient::AsyncM5GAuthenticationServiceClient() {
   resp_loop_thread.detach();
 }
 
-AsyncM5GAuthenticationServiceClient&
-AsyncM5GAuthenticationServiceClient::getInstance() {
-  static AsyncM5GAuthenticationServiceClient instance;
-  return instance;
-}
-
 }  // namespace magma5g

--- a/lte/gateway/c/core/oai/lib/n11/M5GAuthenticationServiceClient.cpp
+++ b/lte/gateway/c/core/oai/lib/n11/M5GAuthenticationServiceClient.cpp
@@ -134,7 +134,7 @@ bool AsyncM5GAuthenticationServiceClient::get_subs_auth_info_resync(
 }
 
 void AsyncM5GAuthenticationServiceClient::GetSubscriberAuthInfoRPC(
-    M5GAuthenticationInformationRequest& request,
+    const M5GAuthenticationInformationRequest& request,
     const std::function<void(Status, M5GAuthenticationInformationAnswer)>&
         callback) {
   auto localResp = new AsyncLocalResponse<M5GAuthenticationInformationAnswer>(

--- a/lte/gateway/c/core/oai/lib/n11/M5GAuthenticationServiceClient.h
+++ b/lte/gateway/c/core/oai/lib/n11/M5GAuthenticationServiceClient.h
@@ -35,7 +35,7 @@ M5GAuthenticationInformationRequest create_subs_auth_request(
 
 class M5GAuthenticationServiceClient {
  public:
-  virtual ~M5GAuthenticationServiceClient() {}
+  virtual ~M5GAuthenticationServiceClient() = default;
   virtual bool get_subs_auth_info(
       const std::string& imsi, uint8_t imsi_length, const char* snni,
       amf_ue_ngap_id_t ue_id) = 0;
@@ -44,6 +44,12 @@ class M5GAuthenticationServiceClient {
       const std::string& imsi, uint8_t imsi_length, const char* snni,
       const void* resync_info, uint8_t resync_info_len,
       amf_ue_ngap_id_t ue_id) = 0;
+
+ private:
+  virtual void GetSubscriberAuthInfoRPC(
+      M5GAuthenticationInformationRequest& request,
+      const std::function<void(
+          grpc::Status, M5GAuthenticationInformationAnswer)>& callback) = 0;
 };
 
 /**
@@ -54,6 +60,7 @@ class AsyncM5GAuthenticationServiceClient
     : public GRPCReceiver,
       public M5GAuthenticationServiceClient {
  public:
+  AsyncM5GAuthenticationServiceClient();
   bool get_subs_auth_info(
       const std::string& imsi, uint8_t imsi_length, const char* snni,
       amf_ue_ngap_id_t ue_id);
@@ -69,7 +76,6 @@ class AsyncM5GAuthenticationServiceClient
   void operator=(AsyncM5GAuthenticationServiceClient const&) = delete;
 
  private:
-  AsyncM5GAuthenticationServiceClient();
   static const uint32_t RESPONSE_TIMEOUT = 10;  // seconds
   std::unique_ptr<M5GSubscriberAuthentication::Stub> stub_{};
 

--- a/lte/gateway/c/core/oai/lib/n11/M5GAuthenticationServiceClient.h
+++ b/lte/gateway/c/core/oai/lib/n11/M5GAuthenticationServiceClient.h
@@ -69,8 +69,6 @@ class AsyncM5GAuthenticationServiceClient
       const std::string& imsi, uint8_t imsi_length, const char* snni,
       const void* resync_info, uint8_t resync_info_len, amf_ue_ngap_id_t ue_id);
 
-  static AsyncM5GAuthenticationServiceClient& getInstance();
-
   AsyncM5GAuthenticationServiceClient(
       AsyncM5GAuthenticationServiceClient const&) = delete;
   void operator=(AsyncM5GAuthenticationServiceClient const&) = delete;

--- a/lte/gateway/c/core/oai/lib/n11/M5GAuthenticationServiceClient.h
+++ b/lte/gateway/c/core/oai/lib/n11/M5GAuthenticationServiceClient.h
@@ -47,7 +47,7 @@ class M5GAuthenticationServiceClient {
 
  private:
   virtual void GetSubscriberAuthInfoRPC(
-      M5GAuthenticationInformationRequest& request,
+      const M5GAuthenticationInformationRequest& request,
       const std::function<void(
           grpc::Status, M5GAuthenticationInformationAnswer)>& callback) = 0;
 };
@@ -78,7 +78,7 @@ class AsyncM5GAuthenticationServiceClient
   std::unique_ptr<M5GSubscriberAuthentication::Stub> stub_{};
 
   void GetSubscriberAuthInfoRPC(
-      M5GAuthenticationInformationRequest& request,
+      const M5GAuthenticationInformationRequest& request,
       const std::function<
           void(grpc::Status, M5GAuthenticationInformationAnswer)>& callback);
 };

--- a/lte/gateway/c/core/oai/tasks/amf/CMakeLists.txt
+++ b/lte/gateway/c/core/oai/tasks/amf/CMakeLists.txt
@@ -1,16 +1,7 @@
 set(NAS5G_C_DIR ${PROJECT_SOURCE_DIR}/tasks/nas5g)
-list(APPEND PROTO_SRCS "")
-list(APPEND PROTO_HDRS "")
+set(AMF_C_DIR ${PROJECT_SOURCE_DIR}/tasks/amf)
 
-create_proto_dir("feg" FEG_OUT_DIR)
-
-# S6a
-set(S6ASRV_FEG_CPP_PROTOS s6a_proxy)
-set(S6ASRV_FEG_GRPC_PROTOS s6a_proxy)
-generate_cpp_protos("${S6ASRV_FEG_CPP_PROTOS}" "${PROTO_SRCS}"
-  "${PROTO_HDRS}" ${FEG_PROTO_DIR} ${FEG_OUT_DIR})
-generate_grpc_protos("${S6ASRV_FEG_GRPC_PROTOS}" "${PROTO_SRCS}"
-  "${PROTO_HDRS}" ${FEG_PROTO_DIR} ${FEG_OUT_DIR})
+add_compile_options(-std=c++14)
 
 include_directories(${CMAKE_CURRENT_BINARY_DIR})
 include_directories("${NAS5G_C_DIR}")
@@ -40,6 +31,7 @@ add_library(TASK_AMF_APP
     amf_authentication.cpp
     amf_data.cpp
     amf_cn.cpp
+    amf_client_servicer.cpp
     amf_sap.cpp
     nas_proc.cpp
     Registration.cpp

--- a/lte/gateway/c/core/oai/tasks/amf/CMakeLists.txt
+++ b/lte/gateway/c/core/oai/tasks/amf/CMakeLists.txt
@@ -20,6 +20,7 @@ link_directories(
 
 add_library(TASK_AMF_APP
     amf_fsm.cpp
+    amf_metadata_util.cpp
     amf_app_main.cpp
     amf_config.c
     amf_app_handler.cpp

--- a/lte/gateway/c/core/oai/tasks/amf/amf_app_main.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_app_main.cpp
@@ -32,6 +32,7 @@ extern "C" {
 #include "amf_data.h"
 #include "amf_app_defs.h"
 #include "amf_authentication.h"
+#include "include/amf_client_servicer.h"
 #include "ngap_messages_types.h"
 #include "amf_app_state_manager.h"
 #include "amf_smfDefs.h"
@@ -182,6 +183,10 @@ extern "C" int amf_app_init(const amf_config_t* amf_config_p) {
   }
   /*Initialize UE state matrix */
   create_state_matrix();
+
+  // Initialize the client layer
+  amf_client_servicer_init();
+
   if (itti_create_task(TASK_AMF_APP, &amf_app_thread, NULL) < 0) {
     OAILOG_CRITICAL(LOG_AMF_APP, "Amf app create task failed\n");
     OAILOG_FUNC_RETURN(LOG_AMF_APP, RETURNerror);

--- a/lte/gateway/c/core/oai/tasks/amf/amf_app_main.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_app_main.cpp
@@ -157,7 +157,7 @@ static int handle_message(zloop_t* loop, zsock_t* reader, void* arg) {
 void* amf_app_thread(void* args) {
   itti_mark_task_ready(TASK_AMF_APP);
   const task_id_t tasks[]      = {TASK_NGAP, TASK_SERVICE303};
-  amf_metadata_t* amf_metadata = (amf_metadata_t*) args;
+  amf_metadata_t* amf_metadata = reinterpret_cast<amf_metadata_t*>(args);
 
   init_task_context(
       TASK_AMF_APP, tasks, 2, handle_message, &amf_app_task_zmq_ctx);
@@ -186,7 +186,7 @@ extern "C" int amf_app_init(const amf_config_t* amf_config_p) {
   /*Initialize UE state matrix */
   create_state_matrix();
 
-  // Initialze the metadata and client service entries
+  // initialize the metadata and client service entries
   amf_metadata_intialize(&(amf_metadata));
 
   if (itti_create_task(TASK_AMF_APP, &amf_app_thread, &(amf_metadata)) < 0) {

--- a/lte/gateway/c/core/oai/tasks/amf/amf_as.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_as.cpp
@@ -36,11 +36,8 @@ extern "C" {
 #include "S6aClient.h"
 #include "proto_msg_to_itti_msg.h"
 #include "ngap_messages_types.h"
-#include "M5GAuthenticationServiceClient.h"
 #include "M5GMMCause.h"
 #include "3gpp_38.401.h"
-
-using magma5g::AsyncM5GAuthenticationServiceClient;
 
 using namespace magma;
 #define QUADLET 4

--- a/lte/gateway/c/core/oai/tasks/amf/amf_authentication.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_authentication.cpp
@@ -31,7 +31,7 @@ extern "C" {
 #include "amf_recv.h"
 #include "amf_identity.h"
 #include "amf_sap.h"
-#include "include/amf_client_servicer.h"
+#include "include/amf_metadata_util.h"
 #include "amf_app_timer_management.h"
 
 #define AMF_CAUSE_SUCCESS (1)
@@ -130,21 +130,21 @@ static int start_authentication_information_procedure(
     OAILOG_FUNC_RETURN(LOG_NAS_AMF, rc);
   }
 
-  auto amf_client_servicer = get_amf_client_server_ref();
+  auto amf_client_servicer = amf_metadata.get_client_servicer_ref();
 
   if (is_initial_req) {
     OAILOG_INFO(
         LOG_AMF_APP,
         "Sending msg(grpc) to :[subscriberdb] for ue: [%s] auth-info\n",
         imsi_str);
-    amf_client_servicer.get_subscriber_authentication_info(
+    amf_client_servicer->get_subscriber_authentication_info(
         imsi_str, IMSI_LENGTH, reinterpret_cast<const char*>(snni), ue_id);
   } else if (auts->data) {
     OAILOG_INFO(
         LOG_AMF_APP,
         "Sending msg(grpc) to :[subscriberdb] for ue: [%s] auth-info-resync\n",
         imsi_str);
-    amf_client_servicer.get_subscriber_authentication_info_resync(
+    amf_client_servicer->get_subscriber_authentication_info_resync(
         imsi_str, IMSI_LENGTH, reinterpret_cast<const char*>(snni), auts->data,
         RAND_LENGTH_OCTETS + AUTS_LENGTH, ue_id);
   }

--- a/lte/gateway/c/core/oai/tasks/amf/amf_authentication.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_authentication.cpp
@@ -31,13 +31,11 @@ extern "C" {
 #include "amf_recv.h"
 #include "amf_identity.h"
 #include "amf_sap.h"
-#include "M5GAuthenticationServiceClient.h"
+#include "include/amf_client_servicer.h"
 #include "amf_app_timer_management.h"
 
 #define AMF_CAUSE_SUCCESS (1)
 #define MAX_5G_AUTH_VECTORS 1
-
-using magma5g::AsyncM5GAuthenticationServiceClient;
 
 namespace magma5g {
 extern task_zmq_ctx_t amf_app_task_zmq_ctx;
@@ -132,22 +130,23 @@ static int start_authentication_information_procedure(
     OAILOG_FUNC_RETURN(LOG_NAS_AMF, rc);
   }
 
+  auto amf_client_servicer = get_amf_client_server_ref();
+
   if (is_initial_req) {
     OAILOG_INFO(
         LOG_AMF_APP,
         "Sending msg(grpc) to :[subscriberdb] for ue: [%s] auth-info\n",
         imsi_str);
-    AsyncM5GAuthenticationServiceClient::getInstance().get_subs_auth_info(
+    amf_client_servicer.get_subscriber_authentication_info(
         imsi_str, IMSI_LENGTH, reinterpret_cast<const char*>(snni), ue_id);
   } else if (auts->data) {
     OAILOG_INFO(
         LOG_AMF_APP,
         "Sending msg(grpc) to :[subscriberdb] for ue: [%s] auth-info-resync\n",
         imsi_str);
-    AsyncM5GAuthenticationServiceClient::getInstance()
-        .get_subs_auth_info_resync(
-            imsi_str, IMSI_LENGTH, reinterpret_cast<const char*>(snni),
-            auts->data, RAND_LENGTH_OCTETS + AUTS_LENGTH, ue_id);
+    amf_client_servicer.get_subscriber_authentication_info_resync(
+        imsi_str, IMSI_LENGTH, reinterpret_cast<const char*>(snni), auts->data,
+        RAND_LENGTH_OCTETS + AUTS_LENGTH, ue_id);
   }
 
   OAILOG_FUNC_RETURN(LOG_NAS_AMF, RETURNok);

--- a/lte/gateway/c/core/oai/tasks/amf/amf_authentication.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_authentication.cpp
@@ -130,7 +130,7 @@ static int start_authentication_information_procedure(
     OAILOG_FUNC_RETURN(LOG_NAS_AMF, rc);
   }
 
-  auto amf_client_servicer = amf_metadata.get_client_servicer_ref();
+  auto amf_client_servicer = amf_get_client_servicer_ref();
 
   if (is_initial_req) {
     OAILOG_INFO(

--- a/lte/gateway/c/core/oai/tasks/amf/amf_client_servicer.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_client_servicer.cpp
@@ -16,21 +16,6 @@
 
 namespace magma5g {
 
-AmfClientServicer amf_client_servicer_g;
-
-// Fetch the amf client servicer reference
-AmfClientServicer& get_amf_client_server_ref() {
-  return amf_client_servicer_g;
-}
-
-// Initialize the client servicer layer
-void amf_client_servicer_init() {
-  auto authentication_client =
-      std::make_shared<AsyncM5GAuthenticationServiceClient>();
-
-  amf_client_servicer_g = AmfClientServicer(authentication_client);
-}
-
 // For authentication to subscriberdb
 bool AmfClientServicer::get_subscriber_authentication_info(
     const std::string& imsi, uint8_t imsi_length, const char* snni,

--- a/lte/gateway/c/core/oai/tasks/amf/amf_client_servicer.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_client_servicer.cpp
@@ -1,0 +1,57 @@
+/**
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "include/amf_client_servicer.h"
+#include <memory>
+
+namespace magma5g {
+
+AmfClientServicer amf_client_servicer_g;
+
+// Fetch the amf client servicer reference
+AmfClientServicer& get_amf_client_server_ref() {
+  return amf_client_servicer_g;
+}
+
+// Initialize the client servicer layer
+void amf_client_servicer_init() {
+  auto authentication_client =
+      std::make_shared<AsyncM5GAuthenticationServiceClient>();
+
+  amf_client_servicer_g = AmfClientServicer(authentication_client);
+}
+
+// For authentication to subscriberdb
+bool AmfClientServicer::get_subscriber_authentication_info(
+    const std::string& imsi, uint8_t imsi_length, const char* snni,
+    amf_ue_ngap_id_t ue_id) {
+  bool result = false;
+
+  result = m5g_auth_client_->get_subs_auth_info(imsi, imsi_length, snni, ue_id);
+
+  return (result);
+}
+
+// For authentication to subscriberdb after resync
+bool AmfClientServicer::get_subscriber_authentication_info_resync(
+    const std::string& imsi, uint8_t imsi_length, const char* snni,
+    const void* resync_info, uint8_t resync_info_len, amf_ue_ngap_id_t ue_id) {
+  bool result = false;
+
+  result = m5g_auth_client_->get_subs_auth_info_resync(
+      imsi, imsi_length, snni, resync_info, resync_info_len, ue_id);
+
+  return (result);
+}
+
+}  // namespace magma5g

--- a/lte/gateway/c/core/oai/tasks/amf/amf_config.c
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_config.c
@@ -24,7 +24,6 @@
 static bool parse_bool(const char* str);
 
 struct amf_config_s amf_config = {.rw_lock = PTHREAD_RWLOCK_INITIALIZER, 0};
-
 /***************************************************************************
 **                                                                        **
 ** Name:    log_amf_config_init()                                         **

--- a/lte/gateway/c/core/oai/tasks/amf/amf_metadata_util.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_metadata_util.cpp
@@ -15,9 +15,16 @@
 #include "include/amf_client_servicer.h"
 #include <memory>
 
-struct amf_metadata_s amf_metadata = {};
+std::shared_ptr<amf_metadata_t> metadata_info_ptr{};
 
 /* Function to initialize amf metadata information */
-void amf_metadata_intialize(amf_metadata_t* metadata_p) {
-  metadata_p->amf_client_servicer_init();
+void amf_metadata_initialize(
+    const std::shared_ptr<amf_metadata_t>& metadata_p) {
+  metadata_info_ptr = std::move(metadata_p);
+
+  metadata_info_ptr->amf_client_servicer_init();
+}
+
+std::shared_ptr<magma5g::AmfClientServicer> amf_get_client_servicer_ref() {
+  return metadata_info_ptr->amf_client_servicer;
 }

--- a/lte/gateway/c/core/oai/tasks/amf/amf_metadata_util.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_metadata_util.cpp
@@ -1,0 +1,23 @@
+/**
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "include/amf_metadata_util.h"
+#include "include/amf_client_servicer.h"
+#include <memory>
+
+struct amf_metadata_s amf_metadata = {};
+
+/* Function to initialize amf metadata information */
+void amf_metadata_intialize(amf_metadata_t* metadata_p) {
+  metadata_p->amf_client_servicer_init();
+}

--- a/lte/gateway/c/core/oai/tasks/amf/amf_smfDefs.h
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_smfDefs.h
@@ -26,7 +26,7 @@ namespace magma5g {
 #define OFFSET_OF(TyPe, MeMBeR) ((size_t) & ((TyPe*) 0)->MeMBeR)
 #define PARENT_STRUCT(cOnTaiNeD, TyPe, MeMBeR)                                 \
   ({                                                                           \
-    const typeof(((TyPe*) 0)->MeMBeR)* __MemBeR_ptr = (cOnTaiNeD);             \
+    const decltype(((TyPe*) 0)->MeMBeR)* __MemBeR_ptr = (cOnTaiNeD);           \
     (TyPe*) ((char*) __MemBeR_ptr - OFFSET_OF(TyPe, MeMBeR));                  \
   })
 //------------------------------------------------------------------------------

--- a/lte/gateway/c/core/oai/tasks/amf/include/amf_client_servicer.h
+++ b/lte/gateway/c/core/oai/tasks/amf/include/amf_client_servicer.h
@@ -1,0 +1,57 @@
+/**
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "M5GAuthenticationServiceClient.h"
+
+#include <iomanip>
+#include <memory>
+#include <string>
+
+namespace magma5g {
+
+/**
+ * This class is single place holder for all client related services.
+ * For instance : subscriberdb, sessiond, mobilityd
+ */
+class AmfClientServicer {
+ public:
+  AmfClientServicer(){};
+
+  AmfClientServicer(
+      std::shared_ptr<M5GAuthenticationServiceClient> m5g_auth_client)
+      : m5g_auth_client_(m5g_auth_client) {}
+
+  void update_auth_servicer(
+      std::shared_ptr<M5GAuthenticationServiceClient> m5g_auth_client);
+
+ private:
+  std::shared_ptr<M5GAuthenticationServiceClient> m5g_auth_client_;
+
+ public:
+  bool get_subscriber_authentication_info(
+      const std::string& imsi, uint8_t imsi_length, const char* snni,
+      amf_ue_ngap_id_t ue_id);
+
+  bool get_subscriber_authentication_info_resync(
+      const std::string& imsi, uint8_t imsi_length, const char* snni,
+      const void* resync_info, uint8_t resync_info_len, amf_ue_ngap_id_t ue_id);
+};
+
+// Initialize the client servicer layer
+void amf_client_servicer_init();
+
+// Fetch the Client Servicer object
+AmfClientServicer& get_amf_client_server_ref();
+
+}  // namespace magma5g

--- a/lte/gateway/c/core/oai/tasks/amf/include/amf_client_servicer.h
+++ b/lte/gateway/c/core/oai/tasks/amf/include/amf_client_servicer.h
@@ -26,7 +26,7 @@ namespace magma5g {
  */
 class AmfClientServicer {
  public:
-  AmfClientServicer(){};
+  AmfClientServicer() {}
 
   AmfClientServicer(
       std::shared_ptr<M5GAuthenticationServiceClient> m5g_auth_client)

--- a/lte/gateway/c/core/oai/tasks/amf/include/amf_client_servicer.h
+++ b/lte/gateway/c/core/oai/tasks/amf/include/amf_client_servicer.h
@@ -48,10 +48,4 @@ class AmfClientServicer {
       const void* resync_info, uint8_t resync_info_len, amf_ue_ngap_id_t ue_id);
 };
 
-// Initialize the client servicer layer
-void amf_client_servicer_init();
-
-// Fetch the Client Servicer object
-AmfClientServicer& get_amf_client_server_ref();
-
 }  // namespace magma5g

--- a/lte/gateway/c/core/oai/tasks/amf/include/amf_metadata_util.h
+++ b/lte/gateway/c/core/oai/tasks/amf/include/amf_metadata_util.h
@@ -18,27 +18,18 @@
 
 typedef struct amf_metadata_s {
   /* Amf Client Servicer Object */
-  std::shared_ptr<magma5g::AmfClientServicer> amf_client_servicer_;
+  std::shared_ptr<magma5g::AmfClientServicer> amf_client_servicer;
 
   /* Initialize the client servicer layer */
   void amf_client_servicer_init() {
     auto authentication_client =
         std::make_shared<magma5g::AsyncM5GAuthenticationServiceClient>();
 
-    amf_client_servicer_ =
+    amf_client_servicer =
         std::make_shared<magma5g::AmfClientServicer>(authentication_client);
   }
-
-  std::shared_ptr<magma5g::AmfClientServicer>& get_client_servicer_ref() {
-    return amf_client_servicer_;
-  }
-
 } amf_metadata_t;
 
-void amf_metadata_intialize(amf_metadata_t* metadata_p);
+void amf_metadata_initialize(const std::shared_ptr<amf_metadata_t>& metadata_p);
 
-/*
- * This strucuture is used in itti_create_task
- * Container of amf structure/class at the task level.
- */
-extern amf_metadata_t amf_metadata;
+std::shared_ptr<magma5g::AmfClientServicer> amf_get_client_servicer_ref();

--- a/lte/gateway/c/core/oai/tasks/amf/include/amf_metadata_util.h
+++ b/lte/gateway/c/core/oai/tasks/amf/include/amf_metadata_util.h
@@ -1,0 +1,44 @@
+/**
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "include/amf_client_servicer.h"
+#include <memory>
+#include <string>
+
+typedef struct amf_metadata_s {
+  /* Amf Client Servicer Object */
+  std::shared_ptr<magma5g::AmfClientServicer> amf_client_servicer_;
+
+  /* Initialize the client servicer layer */
+  void amf_client_servicer_init() {
+    auto authentication_client =
+        std::make_shared<magma5g::AsyncM5GAuthenticationServiceClient>();
+
+    amf_client_servicer_ =
+        std::make_shared<magma5g::AmfClientServicer>(authentication_client);
+  }
+
+  std::shared_ptr<magma5g::AmfClientServicer>& get_client_servicer_ref() {
+    return amf_client_servicer_;
+  }
+
+} amf_metadata_t;
+
+void amf_metadata_intialize(amf_metadata_t* metadata_p);
+
+/*
+ * This strucuture is used in itti_create_task
+ * Container of amf structure/class at the task level.
+ */
+extern amf_metadata_t amf_metadata;

--- a/lte/gateway/c/core/oai/test/n11/CMakeLists.txt
+++ b/lte/gateway/c/core/oai/test/n11/CMakeLists.txt
@@ -1,15 +1,23 @@
 include_directories("${PROJECT_BINARY_DIR}")
 include_directories("${PROJECT_SOURCE_DIR}/n11")
+include_directories("/usr/src/googletest/googlemock/include/")
 
-add_executable(smf_service_client test_smf_service_client.cpp)
-add_executable(auth_service_client test_auth_service_client.cpp)
-
-target_link_libraries(smf_service_client
-	LIB_N11 gtest gtest_main pthread protobuf rt yaml-cpp
+add_library(AMF_TEST_LIB
+    Consts.h
+    M5GAmfMock.h
+    test_smf_service_client.cpp
+    test_auth_service_client.cpp
+    test_amf_client_servicer.cpp
     )
-target_link_libraries(auth_service_client
-	LIB_N11 gtest gtest_main pthread protobuf grpc++ dl m rt yaml-cpp
+
+link_directories(/usr/src/googletest/googlemock/lib/)
+target_link_libraries(AMF_TEST_LIB
+	TASK_AMF_APP LIB_N11 gtest gtest_main gmock_main gmock pthread protobuf grpc++ dl m rt yaml-cpp
     )
 
-add_test(test_smf_service_client smf_service_client)
-add_test(test_auth_service_client auth_service_client)
+foreach (amf_client_test smf_service_client auth_service_client
+         amf_client_servicer)
+  add_executable(${amf_client_test}_test test_${amf_client_test}.cpp)
+  target_link_libraries(${amf_client_test}_test AMF_TEST_LIB)
+  add_test(test_${amf_client_test} ${amf_client_test}_test)
+endforeach (amf_client_test)

--- a/lte/gateway/c/core/oai/test/n11/Consts.h
+++ b/lte/gateway/c/core/oai/test/n11/Consts.h
@@ -1,0 +1,19 @@
+/**
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#define IMSI1 "IMSI000000000000001"
+#define IMSI_LENGTH 15
+#define SNNI_STR "3gppNetworks.111.222.org"
+#define UE_IDENTITY 100
+#define RESYNC_INFO_LEN 16

--- a/lte/gateway/c/core/oai/test/n11/M5GAmfMock.h
+++ b/lte/gateway/c/core/oai/test/n11/M5GAmfMock.h
@@ -50,7 +50,7 @@ class MockM5GAuthenticationServiceClient
   MOCK_METHOD2(
       GetSubscriberAuthInfoRPC,
       void(
-          M5GAuthenticationInformationRequest& request,
+          const M5GAuthenticationInformationRequest& request,
           const std::function<void(
               grpc::Status, M5GAuthenticationInformationAnswer)>& callback));
 };

--- a/lte/gateway/c/core/oai/test/n11/M5GAmfMock.h
+++ b/lte/gateway/c/core/oai/test/n11/M5GAmfMock.h
@@ -1,0 +1,57 @@
+/**
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "M5GAuthenticationServiceClient.h"
+
+#include <gmock/gmock.h>
+#include <grpc++/grpc++.h>
+#include <gtest/gtest.h>
+
+#include <memory>
+#include <string>
+#include <vector>
+
+using grpc::Status;
+using ::testing::_;
+using ::testing::Return;
+
+namespace magma5g {
+
+class MockM5GAuthenticationServiceClient
+    : public M5GAuthenticationServiceClient {
+ public:
+  MockM5GAuthenticationServiceClient() {
+    ON_CALL(*this, GetSubscriberAuthInfoRPC(_, _)).WillByDefault(Return());
+  }
+  MOCK_METHOD4(
+      get_subs_auth_info, bool(
+                              const std::string& imsi, uint8_t imsi_length,
+                              const char* snni, amf_ue_ngap_id_t ue_id));
+
+  MOCK_METHOD6(
+      get_subs_auth_info_resync,
+      bool(
+          const std::string& imsi, uint8_t imsi_length, const char* snni,
+          const void* resync_info, uint8_t resync_info_len,
+          amf_ue_ngap_id_t ue_id));
+
+ private:
+  MOCK_METHOD2(
+      GetSubscriberAuthInfoRPC,
+      void(
+          M5GAuthenticationInformationRequest& request,
+          const std::function<void(
+              grpc::Status, M5GAuthenticationInformationAnswer)>& callback));
+};
+}  // namespace magma5g

--- a/lte/gateway/c/core/oai/test/n11/test_amf_client_servicer.cpp
+++ b/lte/gateway/c/core/oai/test/n11/test_amf_client_servicer.cpp
@@ -1,0 +1,79 @@
+/**
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "M5GAmfMock.h"
+#include "amf_app_messages_types.h"
+#include "M5GAuthenticationServiceClient.h"
+#include "Consts.h"
+#include "include/amf_client_servicer.h"
+
+#include <gtest/gtest.h>
+#include <glog/logging.h>
+
+#include <grpcpp/impl/codegen/status.h>
+
+using ::testing::Test;
+
+namespace magma5g {
+
+class AMFClientServerTest : public ::testing::Test {
+ protected:
+  virtual void SetUp() {
+    subscriberdb_client =
+        std::make_shared<MockM5GAuthenticationServiceClient>();
+    amf_client = std::make_unique<AmfClientServicer>(subscriberdb_client);
+  }
+  virtual void TearDown() {}
+
+ protected:
+  std::unique_ptr<AmfClientServicer> amf_client;
+  std::shared_ptr<MockM5GAuthenticationServiceClient> subscriberdb_client;
+};
+
+TEST_F(AMFClientServerTest, test_get_subs_auth_info) {
+  EXPECT_CALL(
+      *subscriberdb_client,
+      get_subs_auth_info(testing::_, testing::_, testing::_, testing::_))
+      .Times(1)
+      .WillOnce(testing::Return(true));
+
+  auto succeeded = amf_client->get_subscriber_authentication_info(
+      IMSI1, IMSI_LENGTH, SNNI_STR, UE_IDENTITY);
+
+  EXPECT_TRUE(succeeded);
+}
+
+TEST_F(AMFClientServerTest, test_get_subs_auth_info_resync) {
+  unsigned char* data =
+      (unsigned char*) malloc(sizeof(unsigned char) * RESYNC_INFO_LEN);
+
+  EXPECT_CALL(
+      *subscriberdb_client, get_subs_auth_info_resync(
+                                testing::_, testing::_, testing::_, testing::_,
+                                testing::_, testing::_))
+      .Times(1)
+      .WillOnce(testing::Return(true));
+
+  auto succeeded = amf_client->get_subscriber_authentication_info_resync(
+      IMSI1, IMSI_LENGTH, SNNI_STR, data, RESYNC_INFO_LEN, UE_IDENTITY);
+
+  EXPECT_TRUE(succeeded);
+  free(data);
+}
+
+int main(int argc, char** argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}
+
+}  // namespace magma5g

--- a/lte/gateway/c/core/oai/test/n11/test_amf_client_servicer.cpp
+++ b/lte/gateway/c/core/oai/test/n11/test_amf_client_servicer.cpp
@@ -11,16 +11,14 @@
  * limitations under the License.
  */
 
+#include <gtest/gtest.h>
+#include <glog/logging.h>
+#include <grpcpp/impl/codegen/status.h>
 #include "M5GAmfMock.h"
 #include "amf_app_messages_types.h"
 #include "M5GAuthenticationServiceClient.h"
 #include "Consts.h"
 #include "include/amf_client_servicer.h"
-
-#include <gtest/gtest.h>
-#include <glog/logging.h>
-
-#include <grpcpp/impl/codegen/status.h>
 
 using ::testing::Test;
 

--- a/lte/gateway/c/core/oai/test/n11/test_auth_service_client.cpp
+++ b/lte/gateway/c/core/oai/test/n11/test_auth_service_client.cpp
@@ -25,9 +25,6 @@ using ::testing::Test;
 
 task_zmq_ctx_t grpc_service_task_zmq_ctx;
 
-namespace magma {
-namespace lte {
-
 TEST(
     test_convert_proto_msg_to_itti_m5g_auth_info_ans,
     convert_proto_msg_to_itti_m5g_auth_info_ans) {
@@ -103,5 +100,3 @@ int main(int argc, char** argv) {
   ::testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();
 }
-}  // namespace lte
-}  // namespace magma


### PR DESCRIPTION
Fixes:
  1. Removed the proto from AMF cmake as thats handled in oai/lib
  2. Introduced amf client servicer which will abstratct amf's client
     interaction like subscriberdb
  3. Introduced the Mock layer in amf unit test for the client testing
  4. Fixed the CMake for unit testing of amf

Testing:
  1. Basis unit testing
  2. Basic snaity with UERANSIM

Signed-off-by: Yogesh Pandey <yogesh@wavelabs.ai>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
