### PR TITLE
fix(agw): handle missing error code on service failure

### DIFF
--- a/orc8r/gateway/python/scripts/service_util.py
+++ b/orc8r/gateway/python/scripts/service_util.py
@@ -28,7 +28,7 @@ def get_status() -> ServiceExitStatus:
     @returns a populated service exit status object
     """
     service_result = os.environ.get("SERVICE_RESULT")
-    exit_code = os.environ.get("EXIT_CODE")
+    exit_code = os.environ.get("EXIT_CODE", "EXITED")
     exit_status = os.environ.get("EXIT_STATUS")
 
     # Populate the service exit status string and exit code.
@@ -47,8 +47,8 @@ def get_status() -> ServiceExitStatus:
     ):
         try:
             status_obj.latest_rc = int(exit_status)
-        except ValueError:
-            logging.error("Error parsing service exit status", exit_status)
+        except (ValueError, TypeError):
+            logging.error("Error parsing service exit status: %s", exit_status)
             pass
     return status_obj
 


### PR DESCRIPTION
Fixes following exception:
```
magma-dev-focal pipelined[2619]: Traceback (most recent call last):
magma-dev-focal pipelined[2619]:   File "/usr/local/bin/service_util.py", line 80, in <module>
magma-dev-focal pipelined[2619]:     update_stats(service_name)
magma-dev-focal pipelined[2619]:   File "/usr/local/bin/service_util.py", line 69, in update_stats
magma-dev-focal pipelined[2619]:     status = get_status()
magma-dev-focal pipelined[2619]:   File "/usr/local/bin/service_util.py", line 42, in get_status
magma-dev-focal pipelined[2619]:     ServiceExitStatus.ExitCode.Value(exit_code.upper())
magma-dev-focal pipelined[2619]: AttributeError: 'NoneType' object has no attribute 'upper'
```

Signed-off-by: Pravin B Shelar <pbshelar@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
