### PR TITLE
fix(mme): Free bstring field for ICS response

### DIFF
--- a/lte/gateway/c/core/oai/common/itti_free_defined_msg.c
+++ b/lte/gateway/c/core/oai/common/itti_free_defined_msg.c
@@ -27,6 +27,7 @@
 #include "dynamic_memory_check.h"
 #include "assertions.h"
 #include "3gpp_24.008.h"
+#include "3gpp_36.413.h"
 #include "intertask_interface.h"
 #include "itti_free_defined_msg.h"
 #include "async_system_messages_types.h"
@@ -84,8 +85,13 @@ void itti_free_msg_content(MessageDef* const message_p) {
       bdestroy_wrapper(&mme_app_est_cnf.ue_radio_capability);
     } break;
 
-    case MME_APP_INITIAL_CONTEXT_SETUP_RSP:
-      break;
+    case MME_APP_INITIAL_CONTEXT_SETUP_RSP: {
+      e_rab_setup_list_t* e_rab_setup_list =
+          &(MME_APP_INITIAL_CONTEXT_SETUP_RSP(message_p).e_rab_setup_list);
+      for (int i = 0; i < MAX_NO_OF_E_RABS; ++i) {
+        bdestroy_wrapper(&(e_rab_setup_list->item[i].transport_layer_address));
+      }
+    } break;
 
     case MME_APP_DELETE_SESSION_RSP:
       // DO nothing
@@ -95,10 +101,16 @@ void itti_free_msg_content(MessageDef* const message_p) {
       bdestroy_wrapper(&message_p->ittiMsg.mme_app_ul_data_ind.nas_msg);
       break;
 
-    case MME_APP_HANDOVER_REQUEST:
+    case MME_APP_HANDOVER_REQUEST: {
       bdestroy_wrapper(
           &message_p->ittiMsg.mme_app_handover_request.src_tgt_container);
-      break;
+      for (int i = 0; i < BEARERS_PER_UE; i++) {
+        bdestroy_wrapper(
+            &(message_p->ittiMsg.mme_app_handover_request.e_rab_list.item[i]
+                  .transport_layer_address));
+      }
+    } break;
+
     case MME_APP_HANDOVER_COMMAND:
       bdestroy_wrapper(
           &message_p->ittiMsg.mme_app_handover_command.tgt_src_container);

--- a/lte/gateway/c/core/oai/tasks/s1ap/s1ap_mme_handlers.c
+++ b/lte/gateway/c/core/oai/tasks/s1ap/s1ap_mme_handlers.c
@@ -1058,14 +1058,10 @@ status_code_e s1ap_mme_handle_initial_context_setup_response(
     for (int index = 0; index < s1ap_e_rab_list->list.count; index++) {
       S1ap_E_RABItem_t* erab_item =
           (S1ap_E_RABItem_t*) s1ap_e_rab_list->list.array[index];
-      initial_context_setup_rsp->e_rab_failed_to_setup_list
-          .item[initial_context_setup_rsp->e_rab_failed_to_setup_list
-                    .no_of_items]
+      initial_context_setup_rsp->e_rab_failed_to_setup_list.item[index]
           .e_rab_id = erab_item->e_RAB_ID;
-      initial_context_setup_rsp->e_rab_failed_to_setup_list
-          .item[initial_context_setup_rsp->e_rab_failed_to_setup_list
-                    .no_of_items]
-          .cause = erab_item->cause;
+      initial_context_setup_rsp->e_rab_failed_to_setup_list.item[index].cause =
+          erab_item->cause;
     }
     initial_context_setup_rsp->e_rab_failed_to_setup_list.no_of_items =
         s1ap_e_rab_list->list.count;

--- a/lte/gateway/c/core/oai/test/itti/test_itti.cpp
+++ b/lte/gateway/c/core/oai/test/itti/test_itti.cpp
@@ -61,7 +61,9 @@ static int handle_message(zloop_t* loop, zsock_t* reader, void* arg) {
       msg_latency = ITTI_MSG_LATENCY(received_message_p);
     } break;
 
-    default: { } break; }
+    default: {
+    } break;
+  }
   itti_free_msg_content(received_message_p);
   free(received_message_p);
   // Add sleep to introduce delay in pulling the next message
@@ -151,8 +153,7 @@ TEST_F(ITTIApiTest, TestInitialContextSetupRsp) {
   uint16_t erab_no_of_items = 3;
   uint16_t failed_erabs     = 4;
   char ipv4string[16]       = "192.168.101.234";
-  MessageDef* message_p;
-  message_p = DEPRECATEDitti_alloc_new_message_fatal(
+  MessageDef* message_p     = DEPRECATEDitti_alloc_new_message_fatal(
       TASK_S1AP, MME_APP_INITIAL_CONTEXT_SETUP_RSP);
   MME_APP_INITIAL_CONTEXT_SETUP_RSP(message_p).ue_id = 10;
   MME_APP_INITIAL_CONTEXT_SETUP_RSP(message_p).e_rab_setup_list.no_of_items =
@@ -180,6 +181,56 @@ TEST_F(ITTIApiTest, TestInitialContextSetupRsp) {
   }
 
   // Now free the message
+  itti_free_msg_content(message_p);
+  free(message_p);
+}
+
+TEST_F(ITTIApiTest, TestHandoverRequest) {
+  char arbitrary_src_tgt_container[20] = "This is arbitrary";
+  MessageDef* message_p                = DEPRECATEDitti_alloc_new_message_fatal(
+      TASK_MME_APP, MME_APP_HANDOVER_REQUEST);
+  itti_mme_app_handover_request_t* ho_request_p =
+      &message_p->ittiMsg.mme_app_handover_request;
+
+  // fill in arbitrary values
+  ho_request_p->encryption_algorithm_capabilities = 1;
+  ho_request_p->integrity_algorithm_capabilities  = 2;
+  ho_request_p->mme_ue_s1ap_id                    = 10;
+  ho_request_p->target_sctp_assoc_id              = 1;
+  ho_request_p->target_enb_id                     = 2;
+  ho_request_p->cause.present                     = S1ap_Cause_PR_radioNetwork;
+  ho_request_p->cause.choice.radioNetwork =
+      S1ap_CauseRadioNetwork_handover_desirable_for_radio_reason;
+  ho_request_p->handover_type     = S1ap_HandoverType_intralte;
+  ho_request_p->src_tgt_container = blk2bstr(arbitrary_src_tgt_container, 10);
+  ho_request_p->ue_ambr.br_unit   = KBPS;
+  ho_request_p->ue_ambr.br_ul     = 1000;
+  ho_request_p->ue_ambr.br_dl     = 10000;
+  ho_request_p->e_rab_list.no_of_items = 2;
+  fteid_t s_gw_fteid_s1u               = {1};
+
+  for (int i = 0; i < ho_request_p->e_rab_list.no_of_items; ++i) {
+    ho_request_p->e_rab_list.item[i].e_rab_id = 1;
+    ho_request_p->e_rab_list.item[i].transport_layer_address =
+        fteid_ip_address_to_bstring(&s_gw_fteid_s1u);
+    ho_request_p->e_rab_list.item[i].gtp_teid                       = 1;
+    ho_request_p->e_rab_list.item[i].e_rab_level_qos_parameters.qci = 9;
+    ho_request_p->e_rab_list.item[i]
+        .e_rab_level_qos_parameters.allocation_and_retention_priority
+        .priority_level = 0;
+    ho_request_p->e_rab_list.item[i]
+        .e_rab_level_qos_parameters.allocation_and_retention_priority
+        .pre_emption_capability =
+        (pre_emption_capability_t) PRE_EMPTION_CAPABILITY_ENABLED;
+    ho_request_p->e_rab_list.item[i]
+        .e_rab_level_qos_parameters.allocation_and_retention_priority
+        .pre_emption_vulnerability =
+        (pre_emption_vulnerability_t) PRE_EMPTION_VULNERABILITY_DISABLED;
+  }
+  for (int i = 0; i < AUTH_NEXT_HOP_SIZE; ++i) {
+    ho_request_p->nh[i] = 0x11;
+  }
+  ho_request_p->ncc = 2;
   itti_free_msg_content(message_p);
   free(message_p);
 }

--- a/lte/gateway/c/core/oai/test/itti/test_itti.cpp
+++ b/lte/gateway/c/core/oai/test/itti/test_itti.cpp
@@ -61,9 +61,7 @@ static int handle_message(zloop_t* loop, zsock_t* reader, void* arg) {
       msg_latency = ITTI_MSG_LATENCY(received_message_p);
     } break;
 
-    default: {
-    } break;
-  }
+    default: { } break; }
   itti_free_msg_content(received_message_p);
   free(received_message_p);
   // Add sleep to introduce delay in pulling the next message

--- a/lte/gateway/c/core/oai/test/itti/test_itti.cpp
+++ b/lte/gateway/c/core/oai/test/itti/test_itti.cpp
@@ -81,7 +81,7 @@ void* task_thread(task_thread_args_t* args) {
   return NULL;
 }
 
-class ITTIApiTest : public ::testing::Test {
+class ITTIMessagePassingTest : public ::testing::Test {
   virtual void SetUp() {
     itti_init(
         TASK_MAX, THREAD_MAX, MESSAGES_ID_MAX, tasks_info, messages_info, NULL,
@@ -124,7 +124,7 @@ class ITTIApiTest : public ::testing::Test {
   }
 };
 
-TEST_F(ITTIApiTest, TestMessageLatency) {
+TEST_F(ITTIMessagePassingTest, TestMessageLatency) {
   MessageDef* test_message_p;
   test_message_p = DEPRECATEDitti_alloc_new_message_fatal(
       task_zmq_ctx_test1.task_id, TEST_MESSAGE);
@@ -139,6 +139,49 @@ TEST_F(ITTIApiTest, TestMessageLatency) {
   // Sleep 2 seconds to allow message to be received and processed
   std::this_thread::sleep_for(std::chrono::seconds(2));
   ASSERT_GE(msg_latency, 1000000);
+}
+
+class ITTIApiTest : public ::testing::Test {
+  virtual void SetUp() {}
+
+  virtual void TearDown() {}
+};
+
+TEST_F(ITTIApiTest, TestInitialContextSetupRsp) {
+  uint16_t erab_no_of_items = 3;
+  uint16_t failed_erabs     = 4;
+  char ipv4string[16]       = "192.168.101.234";
+  MessageDef* message_p;
+  message_p = DEPRECATEDitti_alloc_new_message_fatal(
+      TASK_S1AP, MME_APP_INITIAL_CONTEXT_SETUP_RSP);
+  MME_APP_INITIAL_CONTEXT_SETUP_RSP(message_p).ue_id = 10;
+  MME_APP_INITIAL_CONTEXT_SETUP_RSP(message_p).e_rab_setup_list.no_of_items =
+      erab_no_of_items;
+  for (int item = 0; item < erab_no_of_items; item++) {
+    MME_APP_INITIAL_CONTEXT_SETUP_RSP(message_p)
+        .e_rab_setup_list.item[item]
+        .e_rab_id = (uint8_t) item;  // Arbitrary RAB ids
+    MME_APP_INITIAL_CONTEXT_SETUP_RSP(message_p)
+        .e_rab_setup_list.item[item]
+        .gtp_teid = (uint32_t) item;
+    MME_APP_INITIAL_CONTEXT_SETUP_RSP(message_p)
+        .e_rab_setup_list.item[item]
+        .transport_layer_address = blk2bstr(ipv4string, 15);
+  }
+  itti_mme_app_initial_context_setup_rsp_t* ics_rsp =
+      &(MME_APP_INITIAL_CONTEXT_SETUP_RSP(message_p));
+  for (int index = 0; index < failed_erabs; index++) {
+    ics_rsp->e_rab_failed_to_setup_list.item[index].e_rab_id =
+        (uint8_t) index;  // Arbitrary RAB ids
+    ics_rsp->e_rab_failed_to_setup_list.item[index].cause.present =
+        S1ap_Cause_PR_radioNetwork;
+    ics_rsp->e_rab_failed_to_setup_list.item[index].cause.choice.radioNetwork =
+        S1ap_CauseRadioNetwork_radio_resources_not_available;
+  }
+
+  // Now free the message
+  itti_free_msg_content(message_p);
+  free(message_p);
 }
 
 int main(int argc, char** argv) {


### PR DESCRIPTION
Signed-off-by: Ulas Kozat <kozat@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->
- Fixes the following memory leak observed on spirent:
```
Aug  3 14:20:12 phy-u13 mme[21761]: Direct leak of 11264 byte(s) in 704 object(s) allocated from:
Aug  3 14:20:12 phy-u13 mme[21761]:     #0 0x7f67db8059c1 in __interceptor_malloc ../../../../src/libsanitizer/lsan/lsan_interceptors.cpp:54
Aug  3 14:20:12 phy-u13 mme[21761]:     #1 0x561e951100fd in blk2bstr /home/vagrant/magma/lte/gateway/c/oai/lib/bstr/bstrlib.c:314
Aug  3 14:20:12 phy-u13 mme[21761]:     #2 0x561e95162a8f in s1ap_mme_handle_initial_context_setup_response /home/vagrant/magma/lte/gateway/c/oai/tasks/s1ap/s1ap_mme_handlers.c:1042
Aug  3 14:20:12 phy-u13 mme[21761]:     #3 0x561e95170f53 in s1ap_mme_handle_message /home/vagrant/magma/lte/gateway/c/oai/tasks/s1ap/s1ap_mme_handlers.c:225
Aug  3 14:20:12 phy-u13 mme[21761]:     #4 0x561e9511a087 in handle_message /home/vagrant/magma/lte/gateway/c/oai/tasks/s1ap/s1ap_mme.c:141
Aug  3 14:20:12 phy-u13 mme[21761]:     #5 0x7f67daa785c6 in zloop_start (/lib/x86_64-linux-gnu/libczmq.so.4+0x295c6)
```
- Fixes the bug in copying the failed radio access bearer info in the ICS Response
- Refactor itti unit test and new unit test for freeing ICS Response message.

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

- Integ tests.
- Added unit test.

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
