### PR TITLE
fix(mme): Closing latest OF connection on OpenFlowController

### DIFF
--- a/lte/gateway/c/core/oai/lib/openflow/controller/OpenflowController.cpp
+++ b/lte/gateway/c/core/oai/lib/openflow/controller/OpenflowController.cpp
@@ -44,6 +44,7 @@ OpenflowController::OpenflowController(
               .use_hello_elements(true)          // bitmask version negotiation
               .keep_data_ownership(false)),
       running_(true),
+      latest_ofconn_(nullptr),
       messenger_(messenger) {}
 
 OpenflowController::OpenflowController(
@@ -58,6 +59,9 @@ void OpenflowController::register_for_event(
 }
 
 void OpenflowController::stop() {
+  if (latest_ofconn_ != nullptr) {
+    latest_ofconn_->close();
+  }
   running_ = false;
   OFServer::stop();
 }
@@ -141,6 +145,10 @@ status_code_e OpenflowController::is_controller_connected_to_switch(
     OAILOG_FUNC_RETURN(LOG_GTPV1U, RETURNerror);
   };
   OAILOG_FUNC_RETURN(LOG_GTPV1U, RETURNok);
+}
+
+fluid_base::OFConnection* OpenflowController::get_latest_of_connection() {
+  return latest_ofconn_;
 }
 
 }  // namespace openflow

--- a/lte/gateway/c/core/oai/lib/openflow/controller/OpenflowController.h
+++ b/lte/gateway/c/core/oai/lib/openflow/controller/OpenflowController.h
@@ -119,6 +119,11 @@ class OpenflowController : public fluid_base::OFServer {
       std::shared_ptr<ExternalEvent> ev, void* (*cb)(std::shared_ptr<void>) );
   status_code_e is_controller_connected_to_switch(int conn_timeout);
 
+  /**
+   * @return latest saved connection of external event
+   */
+  fluid_base::OFConnection* get_latest_of_connection();
+
  private:
   std::shared_ptr<OpenflowMessenger> messenger_;
   std::unordered_map<uint32_t, std::vector<Application*>> event_listeners;

--- a/lte/gateway/c/core/oai/tasks/s1ap/s1ap_state_manager.cpp
+++ b/lte/gateway/c/core/oai/tasks/s1ap/s1ap_state_manager.cpp
@@ -111,17 +111,21 @@ void free_s1ap_state(s1ap_state_t* state_cache_p) {
       assoc_id = (sctp_assoc_id_t) keys->keys[i];
       ht_rc    = hashtable_ts_get(
           &state_cache_p->enbs, (hash_key_t) assoc_id, (void**) &enb);
-      AssertFatal(ht_rc == HASH_TABLE_OK, "eNB UE id not in assoc_id");
-      hashtable_uint64_ts_destroy(&enb->ue_id_coll);
+      if (ht_rc != HASH_TABLE_OK) {
+        OAILOG_ERROR(LOG_S1AP, "eNB entry not found in eNB S1AP state");
+      } else {
+        hashtable_uint64_ts_destroy(&enb->ue_id_coll);
+      }
     }
     FREE_HASHTABLE_KEY_ARRAY(keys);
   }
-
   if (hashtable_ts_destroy(&state_cache_p->enbs) != HASH_TABLE_OK) {
-    OAI_FPRINTF_ERR("An error occurred while destroying s1 eNB hash table");
+    OAILOG_ERROR(
+        LOG_S1AP, "An error occurred while destroying s1 eNB hash table");
   }
   if (hashtable_ts_destroy(&state_cache_p->mmeid2associd) != HASH_TABLE_OK) {
-    OAI_FPRINTF_ERR("An error occurred while destroying assoc_id hash table");
+    OAILOG_ERROR(
+        LOG_S1AP, "An error occurred while destroying assoc_id hash table");
   }
   free_wrapper(reinterpret_cast<void**>(&state_cache_p));
 }
@@ -132,7 +136,8 @@ void S1apStateManager::free_state() {
       "S1apStateManager init() function should be called to initialize state.");
   free_s1ap_state(state_cache_p);
   if (hashtable_ts_destroy(state_ue_ht) != HASH_TABLE_OK) {
-    OAI_FPRINTF_ERR("An error occurred while destroying assoc_id hash table");
+    OAILOG_ERROR(
+        LOG_S1AP, "An error occurred while destroying assoc_id hash table");
   }
   clear_s1ap_imsi_map();
 }

--- a/lte/gateway/c/core/oai/test/openflow/test_openflow_controller.cpp
+++ b/lte/gateway/c/core/oai/test/openflow/test_openflow_controller.cpp
@@ -86,6 +86,12 @@ TEST_F(ControllerTest, TestRunningAssertion) {
       std::runtime_error);
 }
 
+// Ensure controller closes lastest OF connection
+TEST_F(ControllerTest, TestClosedOFConnection) {
+  controller->stop();
+  EXPECT_EQ(controller->get_latest_of_connection(), nullptr);
+}
+
 // Test that with multiple apps registered, the correct apps receive the
 // correct events in order.
 TEST_F(ControllerTest, TestMultipleApplications) {


### PR DESCRIPTION
Signed-off-by: Alex Rodriguez <ardzoht@gmail.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->
- Fixes a memory leak of `OFBaseConnection` object held on `OpenFlowController` class, seen on https://github.com/magma/magma/issues/5086
```
Feb 22 16:08:55 agw1 mme[26668]:     #0 0x7f56e2ff1cdf in operator new[](unsigned long) (/usr/lib/x86_64-linux-gnu/liblsan.so.0+0xdcdf)
Feb 22 16:08:55 agw1 mme[26668]:     #1 0x7f56e01b4783 in fluid_base::BaseOFConnection::OFReadBuffer::read_notify(unsigned short) fluid/base/BaseOFConnection.cc:84
Feb 22 16:08:55 agw1 mme[26668]:     #2 0x7f56e01b4783 in fluid_base::BaseOFConnection::LibEventBaseOFConnection::read_cb(bufferevent*, void*) fluid/base/BaseOFConnection.cc:353
```
-  Removing assertFatal on s1ap_state_manager if eNB is not found in hashtable

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->
- running integ tests and restarting MME
- running spirent tests `active_idle` and `attach_detach` iterations 
- unit tests on `TestOpenFlowController`

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
