### PR TITLE
fix(mme): Fixed mme crash occurring while updating stats

### DIFF
--- a/lte/gateway/c/core/oai/tasks/sgw_s8/sgw_s8_handlers.c
+++ b/lte/gateway/c/core/oai/tasks/sgw_s8/sgw_s8_handlers.c
@@ -27,6 +27,7 @@ limitations under the License.
 #include "sgw_handlers.h"
 #include "directoryd.h"
 #include "conversions.h"
+#include "includes/MetricsHelpers.h"
 
 extern task_zmq_ctx_t sgw_s8_task_zmq_ctx;
 extern struct gtp_tunnel_ops* gtp_tunnel_ops;


### PR DESCRIPTION
fix(mme): Fixed mme crash occurring while updating stats
## Summary
Issue description: While executing roaming attach, s8 task was crashing while updating stats.
Fix: increment_counter() is defined now only in file, MetricsHelpers.cpp, earlier it was defined in service303.cpp also.
so inclusion of file MetricsHelpers.h resolved the crash.
## Test Plan
Executed s1ap sanity test suite
Signed-off-by: Rashmi <rashmi.sarwad@radisys.com>
