### PR TITLE
build(mme): adding missing patch to MME dockerfiles

### DIFF
--- a/lte/gateway/docker/mme/Dockerfile.rhel8
+++ b/lte/gateway/docker/mme/Dockerfile.rhel8
@@ -129,6 +129,7 @@ RUN yum install -y \
 WORKDIR /patches
 COPY  lte/gateway/c/core/oai/patches/folly-gflagslib-fix.patch .
 COPY  lte/gateway/c/core/oai/patches/0001-opencoord.org.freeDiameter.patch .
+COPY  lte/gateway/c/core/oai/patches/0002-opencoord.org.freeDiameter.patch .
 COPY  lte/gateway/c/core/oai/patches/libzmq-strncpy.patch .
 COPY  lte/gateway/c/core/oai/patches/czmq-strncat.patch .
 
@@ -327,6 +328,7 @@ RUN cd freediameter && \
     git log -n1 && \
     echo "Patching dict_S6as6d" && \
     patch -p1 < /patches/0001-opencoord.org.freeDiameter.patch && \
+    patch -p1 < /patches/0002-opencoord.org.freeDiameter.patch && \
     mkdir build && \
     cd build && \
     cmake3 ../ && \

--- a/lte/gateway/docker/mme/Dockerfile.ubuntu18.04
+++ b/lte/gateway/docker/mme/Dockerfile.ubuntu18.04
@@ -203,6 +203,7 @@ COPY ./ $MAGMA_ROOT
 RUN git clone https://github.com/OPENAIRINTERFACE/opencord.org.freeDiameter.git freediameter && \
     cd freediameter && \
     patch -p1 < $MAGMA_ROOT/lte/gateway/c/core/oai/patches/0001-opencoord.org.freeDiameter.patch && \
+    patch -p1 < $MAGMA_ROOT/lte/gateway/c/core/oai/patches/0002-opencoord.org.freeDiameter.patch && \
     mkdir build && \
     cd build && \
     cmake ../ && \

--- a/lte/gateway/docker/mme/Dockerfile.ubuntu20.04
+++ b/lte/gateway/docker/mme/Dockerfile.ubuntu20.04
@@ -267,6 +267,7 @@ COPY lte/gateway/c/core/oai/patches/ /tmp/
 RUN git clone https://github.com/OPENAIRINTERFACE/opencord.org.freeDiameter.git freediameter && \
     cd freediameter && \
     patch -p1 < /tmp/0001-opencoord.org.freeDiameter.patch && \
+    patch -p1 < /tmp/0002-opencoord.org.freeDiameter.patch && \
     mkdir build && \
     cd build && \
     cmake -DDISABLE_SCTP:BOOL=ON ../ && \


### PR DESCRIPTION
Signed-off-by: Raphael Defosseux <raphael.defosseux@openairinterface.org>

## Summary

After Lionel's [S6A Enable extended bitrates PR](https://github.com/magma/magma/pull/7354), I noticed he added this new patch for the S6A dictionary but he did not added into the dockerfiles.

I asked when he came back from vacation and they are needed.

## Test Plan

None needed. The patch is already included in the base images the OAI CI pipeline uses.

## Additional Information

- [ ] This change is backwards-breaking
