### PR TITLE
feat(amf): Support for Invalid/unsupported ue security capabilities

### DIFF
--- a/lte/gateway/c/core/oai/tasks/amf/Registration.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/Registration.cpp
@@ -307,7 +307,7 @@ static int amf_registration_reject(
     amf_data_sec.amf_as_set_security_data(
         &amf_sap.u.amf_as.u.establish.sctx, NULL, false, false);
   }
-  OAILOG_DEBUG(LOG_NAS_AMF, "Processing REGITRATION_REJECT message\n");
+  OAILOG_DEBUG(LOG_NAS_AMF, "Processing REGISTRATION_REJECT message\n");
   rc = amf_sap_send(&amf_sap);
   increment_counter(
       "ue_Registration", 1, 1, "action", "Registration_reject_sent");

--- a/lte/gateway/c/core/oai/tasks/amf/amf_as.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_as.cpp
@@ -1503,7 +1503,7 @@ static int amf_as_establish_rej(
         amf_as_encode(&as_msg->nas_msg, &nas_msg, size, amf_security_context);
     if (bytes > 0) {
       // This is to indicate AMF-APP to release the NGAP UE context after
-      //       // sending the message.
+      // sending the message.
       as_msg->err_code = M5G_AS_TERMINATED_NAS;
       OAILOG_FUNC_RETURN(LOG_NAS_AMF, AS_NAS_ESTABLISH_RSP_);
     }

--- a/lte/gateway/c/core/oai/tasks/amf/amf_recv.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_recv.cpp
@@ -222,7 +222,7 @@ int amf_handle_registration_request(
       sizeof(tai_t));
 
   if (msg->m5gs_reg_type.type_val == AMF_REGISTRATION_TYPE_INITIAL) {
-    OAILOG_INFO(LOG_NAS_AMF, "New REGITRATION_REQUEST processing\n");
+    OAILOG_DEBUG(LOG_NAS_AMF, "New REGISTRATION_REQUEST processing\n");
     // Check integrity and ciphering algorithm bits
     // If all bits are zero it means integrity and ciphering algorithms are not
     // valid, AMF should reject the initial registration. Note : amf_cause is
@@ -230,11 +230,12 @@ int amf_handle_registration_request(
     // CONDITIONAL_IE_ERROR as amf cause.
     if (ue_context->amf_context.ue_sec_capability.ia == 0 ||
         ue_context->amf_context.ue_sec_capability.ea == 0) {
-      OAILOG_ERROR(LOG_NAS_AMF, "UE is not supporting any algorithms");
       amf_cause = AMF_CAUSE_UE_SEC_CAP_MISSMATCH;
       OAILOG_ERROR(
-          LOG_NAS_AMF, "AMF rejecting the initial registration with cause %d",
-          amf_cause);
+          LOG_NAS_AMF,
+          "UE is not supporting any algorithms, AMF rejecting the initial "
+          "registration with cause : %d for UE ID : %d",
+          amf_cause, ue_id);
       rc = amf_proc_registration_reject(ue_id, amf_cause);
       OAILOG_FUNC_RETURN(LOG_NAS_AMF, rc);
     } else {
@@ -249,13 +250,13 @@ int amf_handle_registration_request(
                              ue_context->amf_context.ue_sec_capability.ea2;
 
       if (supported_ia == 0 || supported_ea == 0) {
-        OAILOG_ERROR(
-            LOG_NAS_AMF,
-            "UE is not supporting the algorithms IA0 to IA2 and EA0 to EA2");
         amf_cause = AMF_CAUSE_UE_SEC_CAP_MISSMATCH;
         OAILOG_ERROR(
-            LOG_NAS_AMF, "AMF rejecting the initial registration with cause %d",
-            amf_cause);
+            LOG_NAS_AMF,
+            "UE is not supporting the algorithms IA0,IA1,IA2 and EA0,EA1,EA2, "
+            "AMF rejecting the initial registration with cause : %d for UE ID "
+            ": %d",
+            amf_cause, ue_id);
         rc = amf_proc_registration_reject(ue_id, amf_cause);
         OAILOG_FUNC_RETURN(LOG_NAS_AMF, rc);
       }

--- a/lte/gateway/c/core/oai/tasks/nas5g/include/ies/M5GUESecurityCapability.h
+++ b/lte/gateway/c/core/oai/tasks/nas5g/include/ies/M5GUESecurityCapability.h
@@ -20,6 +20,7 @@ class UESecurityCapabilityMsg {
 #define UE_SECURITY_CAPABILITY_MIN_LENGTH 1
   uint8_t length;
   uint8_t iei;
+  uint8_t ea;
   uint8_t ea0 : 1;
   uint8_t ea1 : 1;
   uint8_t ea2 : 1;
@@ -28,6 +29,7 @@ class UESecurityCapabilityMsg {
   uint8_t ea5 : 1;
   uint8_t ea6 : 1;
   uint8_t ea7 : 1;
+  uint8_t ia;
   uint8_t ia0 : 1;
   uint8_t ia1 : 1;
   uint8_t ia2 : 1;

--- a/lte/gateway/c/core/oai/tasks/nas5g/src/ies/M5GUESecurityCapability.cpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/src/ies/M5GUESecurityCapability.cpp
@@ -46,26 +46,26 @@ int UESecurityCapabilityMsg::DecodeUESecurityCapabilityMsg(
 
   // 5GS encryption algorithms
   ea                     = *(buffer + decoded);
-  ue_sec_capability->ea0 = (*(buffer + decoded) >> 7) & 0x1;
-  ue_sec_capability->ea1 = (*(buffer + decoded) >> 6) & 0x1;
-  ue_sec_capability->ea2 = (*(buffer + decoded) >> 5) & 0x1;
-  ue_sec_capability->ea3 = (*(buffer + decoded) >> 4) & 0x1;
-  ue_sec_capability->ea4 = (*(buffer + decoded) >> 3) & 0x1;
-  ue_sec_capability->ea5 = (*(buffer + decoded) >> 2) & 0x1;
-  ue_sec_capability->ea6 = (*(buffer + decoded) >> 1) & 0x1;
-  ue_sec_capability->ea7 = *(buffer + decoded) & 0x1;
+  ue_sec_capability->ea0 = (ea >> 7) & 0x1;
+  ue_sec_capability->ea1 = (ea >> 6) & 0x1;
+  ue_sec_capability->ea2 = (ea >> 5) & 0x1;
+  ue_sec_capability->ea3 = (ea >> 4) & 0x1;
+  ue_sec_capability->ea4 = (ea >> 3) & 0x1;
+  ue_sec_capability->ea5 = (ea >> 2) & 0x1;
+  ue_sec_capability->ea6 = (ea >> 1) & 0x1;
+  ue_sec_capability->ea7 = ea & 0x1;
   decoded++;
 
   // 5GS integrity algorithm
   ia                     = *(buffer + decoded);
-  ue_sec_capability->ia0 = (*(buffer + decoded) >> 7) & 0x1;
-  ue_sec_capability->ia1 = (*(buffer + decoded) >> 6) & 0x1;
-  ue_sec_capability->ia2 = (*(buffer + decoded) >> 5) & 0x1;
-  ue_sec_capability->ia3 = (*(buffer + decoded) >> 4) & 0x1;
-  ue_sec_capability->ia4 = (*(buffer + decoded) >> 3) & 0x1;
-  ue_sec_capability->ia5 = (*(buffer + decoded) >> 2) & 0x1;
-  ue_sec_capability->ia6 = (*(buffer + decoded) >> 1) & 0x1;
-  ue_sec_capability->ia7 = *(buffer + decoded) & 0x1;
+  ue_sec_capability->ia0 = (ia >> 7) & 0x1;
+  ue_sec_capability->ia1 = (ia >> 6) & 0x1;
+  ue_sec_capability->ia2 = (ia >> 5) & 0x1;
+  ue_sec_capability->ia3 = (ia >> 4) & 0x1;
+  ue_sec_capability->ia4 = (ia >> 3) & 0x1;
+  ue_sec_capability->ia5 = (ia >> 2) & 0x1;
+  ue_sec_capability->ia6 = (ia >> 1) & 0x1;
+  ue_sec_capability->ia7 = ia & 0x1;
   decoded++;
 
   // If any optional buffers are present skip it.

--- a/lte/gateway/c/core/oai/tasks/nas5g/src/ies/M5GUESecurityCapability.cpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/src/ies/M5GUESecurityCapability.cpp
@@ -45,6 +45,7 @@ int UESecurityCapabilityMsg::DecodeUESecurityCapabilityMsg(
   MLOG(MDEBUG) << " length = " << hex << int(ue_sec_capability->length) << endl;
 
   // 5GS encryption algorithms
+  ea                     = *(buffer + decoded);
   ue_sec_capability->ea0 = (*(buffer + decoded) >> 7) & 0x1;
   ue_sec_capability->ea1 = (*(buffer + decoded) >> 6) & 0x1;
   ue_sec_capability->ea2 = (*(buffer + decoded) >> 5) & 0x1;
@@ -56,6 +57,7 @@ int UESecurityCapabilityMsg::DecodeUESecurityCapabilityMsg(
   decoded++;
 
   // 5GS integrity algorithm
+  ia                     = *(buffer + decoded);
   ue_sec_capability->ia0 = (*(buffer + decoded) >> 7) & 0x1;
   ue_sec_capability->ia1 = (*(buffer + decoded) >> 6) & 0x1;
   ue_sec_capability->ia2 = (*(buffer + decoded) >> 5) & 0x1;


### PR DESCRIPTION
## Summary

Added support to handle invalid/unsupported ue security capabilities received from UE in Initial registration request

## Test Plan

Tested in UERANSIM setup and TVM setup
scenario_1 : With out ue security capabilities IE in initial registration request
scenario_2 : With ue security capabilities IE, but all bits are Zero, means ue don't support any algorithm
scenario_3 : UE don't support the mandatory algorithms, mandatory algorithms are {IA0, IA1, IA2} and {EA0, EA1, EA2}

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
