### PR TITLE
chore: remove unused function from SessionD

### DIFF
--- a/lte/gateway/c/session_manager/SessionState.cpp
+++ b/lte/gateway/c/session_manager/SessionState.cpp
@@ -1641,28 +1641,6 @@ DynamicRuleInstall SessionState::get_dynamic_rule_install(
   return rule_install;
 }
 
-// Charging Credits
-static FinalActionInfo get_final_action_info(
-    const magma::lte::ChargingCredit& credit) {
-  FinalActionInfo final_action_info;
-  if (credit.is_final()) {
-    final_action_info.final_action = credit.final_action();
-    switch (final_action_info.final_action) {
-      case ChargingCredit_FinalAction_REDIRECT:
-        final_action_info.redirect_server = credit.redirect_server();
-        break;
-      case ChargingCredit_FinalAction_RESTRICT_ACCESS:
-        for (auto rule : credit.restrict_rules()) {
-          final_action_info.restrict_rules.push_back(rule);
-        }
-        break;
-      default:  // do nothing;
-        break;
-    }
-  }
-  return final_action_info;
-}
-
 std::vector<PolicyRule> SessionState::get_all_final_unit_rules() {
   std::vector<PolicyRule> rules;
   for (auto& credit_pair : credit_map_) {


### PR DESCRIPTION
Signed-off-by: Marie Bremner <marwhal@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary
Got tired of seeing a GCC warning about unused function :D 
```
INFO: From Compiling lte/gateway/c/session_manager/SessionState.cpp:
lte/gateway/c/session_manager/SessionState.cpp:1645:24: warning: 'magma::FinalActionInfo magma::get_final_action_info(const magma::lte::ChargingCredit&)' defined but not used [-Wunused-function]
 1645 | static FinalActionInfo get_final_action_info(
      |                        ^~~~~~~~~~~~~~~~~~~~~
```
<!-- Enumerate changes you made and why you made them -->

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
