### PR TITLE
chore: add a new 'release' tag to packaging fab command

### DIFF
--- a/circleci/fabfile.py
+++ b/circleci/fabfile.py
@@ -351,7 +351,7 @@ def _run_remote_lte_package(
                    f'cert_file={vagrant_cert},' \
                    f'proxy_config={vagrant_cp},' \
                    f'destroy_vm={destroy_vm}'
-        run(f'fab test package:{fab_args}')
+        run(f'fab release package:{fab_args}')
         # This will create /tmp/packages.tar.gz, /tmp/packages.txt on the
         # remote CI executor node (the current fab host)
         run('fab copy_packages')

--- a/docs/readmes/howtos/package.md
+++ b/docs/readmes/howtos/package.md
@@ -8,9 +8,8 @@ hide_title: true
 
 ## TL;DR
 
-1. Run `fab test package` on the host to create packages inside the
-gateway VM.
-2. Commit changes to build-magma.sh and magma.lockfile.ubuntu.
+1. Run `fab release package` on the host to create production packages inside the gateway VM
+2. Commit changes to build-magma.sh and magma.lockfile.ubuntu
 
 ## Creating a production release package
 
@@ -29,13 +28,11 @@ you can also increment the iteration number.
 
 ## Creating a development package
 
-To create an AGW package with debug compiler flags (`Debug`),
-run `fab dev package`
+To create an AGW package with debug compiler flags (`Debug`), run `fab dev package`
 
 ## Testing a release package before you push it
 
-You should always do this. In general, try your best not to release broken
-packages.
+You should always do this. In general, try your best not to release broken packages.
 
 1. Build the release like you normally would.
 2. Spin up a fresh prod VM or gateway machine and copy the `magma_<version>.deb`

--- a/docs/readmes/lte/build_install_magma_pkg_in_agw.md
+++ b/docs/readmes/lte/build_install_magma_pkg_in_agw.md
@@ -27,7 +27,7 @@ hide_title: true
     To create a package for production, run
 
     ```bash
-    fab test package:vcs=git
+    fab release package:vcs=git
     ```
 
     To create a package for development or testing, run

--- a/lte/gateway/fabfile.py
+++ b/lte/gateway/fabfile.py
@@ -66,7 +66,14 @@ def dev():
     env.debug_mode = True
 
 
+# TODO: Deprecate
 def test():
+    print("Caution! 'test' will be deprecated soon. Please migrate to using 'release'.")
+    env.debug_mode = False
+
+
+def release():
+    """Set debug_mode to False, should be used for producing a production AGW package"""
     env.debug_mode = False
 
 
@@ -87,7 +94,7 @@ def package(
     if not hasattr(env, 'debug_mode'):
         print(
             "Error: The Deploy target isn't specified. Specify one with\n\n"
-            "\tfab [dev|test] package",
+            "\tfab [dev|release] package",
         )
         exit(1)
 


### PR DESCRIPTION
Signed-off-by: Marie Bremner <marwhal@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary
Follow up from https://github.com/magma/magma/issues/8322

Adding a new 'release' tag so you can run `fab release pkg:vcs=git` instead of `fab test pkg:vcs=git` to get a release build. I'm still keeping around the `test` command so we can switch to the new command gently.


<!-- Enumerate changes you made and why you made them -->

## Test Plan
New warning message when running the old command:
```
➜  gateway git:(add-new-release-tag) ✗ fab test package:vcs=git
Caution! 'test' will be deprecated soon. Please migrate to using 'release'.
[localhost] local: pwd
[localhost] local: vagrant status magma
```

New command:
```
➜  gateway git:(add-new-release-tag) ✗ fab release  package:vcs=git
[localhost] local: pwd
[localhost] local: vagrant status magma
```
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

Doc precommit
```
➜  docs git:(add-new-release-tag) ✗ make precommit
make -C readmes precommit
docker build -t magma_readmes .
[+] Building 1.6s (8/8) FINISHED
 => [internal] load build definition from Dockerfile                                                                                                                                                                                                     0.0s
 => => transferring dockerfile: 36B                                                                                                                                                                                                                      0.0s
 => [internal] load .dockerignore                                                                                                                                                                                                                        0.0s
 => => transferring context: 2B                                                                                                                                                                                                                          0.0s
 => [internal] load metadata for docker.io/library/node:14                                                                                                                                                                                               1.5s
 => [1/4] FROM docker.io/library/node:14@sha256:cd98882c1093f758d09cf6821dc8f96b241073b38e8ed294ca1f9e484743858f                                                                                                                                         0.0s
 => CACHED [2/4] RUN mkdir -p /readmes                                                                                                                                                                                                                   0.0s
 => CACHED [3/4] WORKDIR /readmes                                                                                                                                                                                                                        0.0s
 => CACHED [4/4] RUN npm install --global markdownlint-cli                                                                                                                                                                                               0.0s
 => exporting to image                                                                                                                                                                                                                                   0.0s
 => => exporting layers                                                                                                                                                                                                                                  0.0s
 => => writing image sha256:4f88f810fb275a5ef12ddf38b3fd309cbcec3e7a81b94f9447b9f32de4bda40a                                                                                                                                                             0.0s
 => => naming to docker.io/library/magma_readmes                                                                                                                                                                                                         0.0s
docker-compose run readmes markdownlint --ignore proposals/p010_vendor_neutral_dp.md . && echo PASSED
Creating readmes_readmes_run ... done
PASSED
```
- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
