### PR TITLE
fix(pipelined): Fix Verbose ofctl logging

### DIFF
--- a/lte/gateway/deploy/roles/magma/files/patches/0001-Set-unknown-dpid-ofctl-log-to-debug.patch
+++ b/lte/gateway/deploy/roles/magma/files/patches/0001-Set-unknown-dpid-ofctl-log-to-debug.patch
@@ -1,0 +1,26 @@
+From 215a293ff0d8deaea80739a67c63cbbe47bfdf79 Mon Sep 17 00:00:00 2001
+From: Nick Yurchenko <urchennko@gmail.com>
+Date: Fri, 6 Aug 2021 14:44:13 +0000
+Subject: [PATCH] Set unknown dpid ofctl log to debug
+
+Signed-off-by: Nick Yurchenko <urchennko@gmail.com>
+---
+ ryu/app/ofctl/service.py | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/ryu/app/ofctl/service.py b/ryu/app/ofctl/service.py
+index eed51774..d70b2484 100644
+--- a/ryu/app/ofctl/service.py
++++ b/ryu/app/ofctl/service.py
+@@ -138,7 +138,7 @@ class OfctlService(app_manager.RyuApp):
+         try:
+             si = self._switches[datapath.id]
+         except KeyError:
+-            self.logger.error('unknown dpid %s' % (datapath.id,))
++            self.logger.debug('unknown dpid %s' % (datapath.id,))
+             rep = event.Reply(exception=exception.
+                               InvalidDatapath(result=datapath.id))
+             self.reply_to_request(req, rep)
+-- 
+2.25.1
+

--- a/orc8r/gateway/python/python.mk
+++ b/orc8r/gateway/python/python.mk
@@ -62,6 +62,10 @@ py_patches:
 	&&  (patch -N -s -f $(SITE_PACKAGES_DIR)/ryu/ofproto/nx_actions.py <$(PATCHES_DIR)/ryu_ipfix_args.patch && echo "ryu was patched" ) \
 	|| ( true && echo "skipping ryu patch since it was already applied")
 
+	patch --dry-run -N -s -f $(SITE_PACKAGES_DIR)/ryu/ofproto/nx_actions.py <$(PATCHES_DIR)/0001-Set-unknown-dpid-ofctl-log-to-debug.patch 2>/dev/null \
+	&&  (patch -N -s -f $(SITE_PACKAGES_DIR)/ryu/ofproto/nx_actions.py <$(PATCHES_DIR)/0001-Set-unknown-dpid-ofctl-log-to-debug.patch && echo "ryu was patched" ) \
+	|| ( true && echo "skipping ryu patch since it was already applied")
+
 	$(VIRT_ENV_PIP_INSTALL) --force-reinstall git+https://github.com/URenko/aioh2.git
 
 swagger:: swagger_prereqs $(SWAGGER_LIST)


### PR DESCRIPTION
Signed-off-by: Nick Yurchenko <koolzz@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary
The ofctl log is quite verbose because it complains about xids not belonging to itslef. log at debug to not be noisy

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
