### PR TITLE
feat(orc8r): Context propagation for all network-related functions in configurator client API

### DIFF
--- a/cwf/cloud/go/services/cwf/obsidian/handlers/handlers.go
+++ b/cwf/cloud/go/services/cwf/obsidian/handlers/handlers.go
@@ -236,7 +236,7 @@ func getSubscriberDirectoryHandler(c echo.Context) error {
 	}
 
 	reqCtx := c.Request().Context()
-	configuratorNetwork, err := configurator.LoadNetwork(networkID, false, false, serdes.Network)
+	configuratorNetwork, err := configurator.LoadNetwork(reqCtx, networkID, false, false, serdes.Network)
 	if err != nil {
 		return obsidian.HttpError(err, http.StatusNotFound)
 	}
@@ -285,7 +285,7 @@ func getHAPairStatusHandler(c echo.Context) error {
 	}
 
 	reqCtx := c.Request().Context()
-	network, err := configurator.LoadNetwork(nid, true, true, serdes.Network)
+	network, err := configurator.LoadNetwork(reqCtx, nid, true, true, serdes.Network)
 	if err == merrors.ErrNotFound {
 		return c.NoContent(http.StatusNotFound)
 	}
@@ -356,7 +356,7 @@ func createHAPairHandler(c echo.Context) error {
 	if err := c.Bind(haPair); err != nil {
 		return obsidian.HttpError(err, http.StatusBadRequest)
 	}
-	if err := haPair.ValidateModel(); err != nil {
+	if err := haPair.ValidateModel(context.Background()); err != nil {
 		return obsidian.HttpError(err, http.StatusBadRequest)
 	}
 	_, err := configurator.CreateEntity(networkID, haPair.ToEntity(), serdes.Entity)
@@ -402,7 +402,7 @@ func updateHAPairHandler(c echo.Context) error {
 	if err := c.Bind(mutableHaPair); err != nil {
 		return obsidian.HttpError(err, http.StatusBadRequest)
 	}
-	if err := mutableHaPair.ValidateModel(); err != nil {
+	if err := mutableHaPair.ValidateModel(context.Background()); err != nil {
 		return obsidian.HttpError(err, http.StatusBadRequest)
 	}
 	if mutableHaPair.HaPairID != haPairID {

--- a/cwf/cloud/go/services/cwf/obsidian/handlers/handlers_test.go
+++ b/cwf/cloud/go/services/cwf/obsidian/handlers/handlers_test.go
@@ -14,6 +14,7 @@
 package handlers_test
 
 import (
+	context2 "context"
 	"testing"
 	"time"
 
@@ -181,7 +182,7 @@ func TestCwfNetworks(t *testing.T) {
 	}
 	tests.RunUnitTest(t, e, tc)
 
-	actualN1, err := configurator.LoadNetwork("n1", true, true, serdes.Network)
+	actualN1, err := configurator.LoadNetwork(context2.Background(), "n1", true, true, serdes.Network)
 	assert.NoError(t, err)
 	expected := configurator.Network{
 		ID:          "n1",
@@ -828,56 +829,50 @@ func TestCwfHaPairs(t *testing.T) {
 // n1, n3 are cwf networks, n2, n5 are not
 func seedCwfNetworks(t *testing.T) {
 	fegNetworkID := "n5"
-	_, err := configurator.CreateNetworks(
-		[]configurator.Network{
-			{
-				ID:          fegNetworkID,
-				Type:        feg.FederationNetworkType,
-				Name:        "foobar",
-				Description: "Foo Bar",
-				Configs: map[string]interface{}{
-					feg.FegNetworkType:          models3.NewDefaultNetworkFederationConfigs(),
-					orc8r.NetworkFeaturesConfig: models.NewDefaultFeaturesConfig(),
-					orc8r.DnsdNetworkType:       models.NewDefaultDNSConfig(),
-				},
+	_, err := configurator.CreateNetworks(context2.Background(), []configurator.Network{
+		{
+			ID:          fegNetworkID,
+			Type:        feg.FederationNetworkType,
+			Name:        "foobar",
+			Description: "Foo Bar",
+			Configs: map[string]interface{}{
+				feg.FegNetworkType:          models3.NewDefaultNetworkFederationConfigs(),
+				orc8r.NetworkFeaturesConfig: models.NewDefaultFeaturesConfig(),
+				orc8r.DnsdNetworkType:       models.NewDefaultDNSConfig(),
 			},
 		},
-		serdes.Network,
-	)
+	}, serdes.Network)
 	assert.NoError(t, err)
-	_, err = configurator.CreateNetworks(
-		[]configurator.Network{
-			{
-				ID:          "n1",
-				Type:        cwf.CwfNetworkType,
-				Name:        "foobar",
-				Description: "Foo Bar",
-				Configs: map[string]interface{}{
-					cwf.CwfNetworkType: models2.NewDefaultNetworkCarrierWifiConfigs(),
-					feg.FederatedNetworkType: &models3.FederatedNetworkConfigs{
-						FegNetworkID: &fegNetworkID,
-					},
-					orc8r.NetworkFeaturesConfig: models.NewDefaultFeaturesConfig(),
-					orc8r.DnsdNetworkType:       models.NewDefaultDNSConfig(),
+	_, err = configurator.CreateNetworks(context2.Background(), []configurator.Network{
+		{
+			ID:          "n1",
+			Type:        cwf.CwfNetworkType,
+			Name:        "foobar",
+			Description: "Foo Bar",
+			Configs: map[string]interface{}{
+				cwf.CwfNetworkType: models2.NewDefaultNetworkCarrierWifiConfigs(),
+				feg.FederatedNetworkType: &models3.FederatedNetworkConfigs{
+					FegNetworkID: &fegNetworkID,
 				},
-			},
-			{
-				ID:          "n2",
-				Type:        "blah",
-				Name:        "foobar",
-				Description: "Foo Bar",
-				Configs:     map[string]interface{}{},
-			},
-			{
-				ID:          "n3",
-				Type:        cwf.CwfNetworkType,
-				Name:        "barfoo",
-				Description: "Bar Foo",
-				Configs:     map[string]interface{}{},
+				orc8r.NetworkFeaturesConfig: models.NewDefaultFeaturesConfig(),
+				orc8r.DnsdNetworkType:       models.NewDefaultDNSConfig(),
 			},
 		},
-		serdes.Network,
-	)
+		{
+			ID:          "n2",
+			Type:        "blah",
+			Name:        "foobar",
+			Description: "Foo Bar",
+			Configs:     map[string]interface{}{},
+		},
+		{
+			ID:          "n3",
+			Type:        cwf.CwfNetworkType,
+			Name:        "barfoo",
+			Description: "Bar Foo",
+			Configs:     map[string]interface{}{},
+		},
+	}, serdes.Network)
 	assert.NoError(t, err)
 }
 

--- a/cwf/cloud/go/services/cwf/obsidian/models/conversion.go
+++ b/cwf/cloud/go/services/cwf/obsidian/models/conversion.go
@@ -14,6 +14,7 @@
 package models
 
 import (
+	"context"
 	"fmt"
 
 	"magma/cwf/cloud/go/cwf"
@@ -96,7 +97,7 @@ func (m *CwfNetwork) FromConfiguratorNetwork(n configurator.Network) interface{}
 	return m
 }
 
-func (m *CwfGateway) ValidateModel() error {
+func (m *CwfGateway) ValidateModel(context.Context) error {
 	return m.Validate(strfmt.Default)
 }
 
@@ -115,7 +116,7 @@ func (m *CwfGateway) FromBackendModels(
 	return m
 }
 
-func (m *MutableCwfGateway) ValidateModel() error {
+func (m *MutableCwfGateway) ValidateModel(context.Context) error {
 	return m.Validate(strfmt.Default)
 }
 
@@ -227,7 +228,7 @@ func (m *LiUes) GetFromNetwork(network configurator.Network) interface{} {
 	return networkConfig.(*NetworkCarrierWifiConfigs).LiUes
 }
 
-func (m *LiUes) ValidateModel() error {
+func (m *LiUes) ValidateModel(context.Context) error {
 	return m.Validate(strfmt.Default)
 }
 

--- a/cwf/cloud/go/services/cwf/obsidian/models/validate.go
+++ b/cwf/cloud/go/services/cwf/obsidian/models/validate.go
@@ -14,6 +14,7 @@
 package models
 
 import (
+	"context"
 	"fmt"
 	"net"
 
@@ -22,21 +23,21 @@ import (
 	"github.com/pkg/errors"
 )
 
-func (m *CwfNetwork) ValidateModel() error {
+func (m *CwfNetwork) ValidateModel(context.Context) error {
 	if err := m.Validate(strfmt.Default); err != nil {
 		return err
 	}
 	return nil
 }
 
-func (m *NetworkCarrierWifiConfigs) ValidateModel() error {
+func (m *NetworkCarrierWifiConfigs) ValidateModel(context.Context) error {
 	if err := m.Validate(strfmt.Default); err != nil {
 		return err
 	}
 	return nil
 }
 
-func (m *GatewayCwfConfigs) ValidateModel() error {
+func (m *GatewayCwfConfigs) ValidateModel(context.Context) error {
 	if err := m.Validate(strfmt.Default); err != nil {
 		return err
 	}
@@ -52,48 +53,48 @@ func (m *GatewayCwfConfigs) ValidateModel() error {
 	return nil
 }
 
-func (m *CwfSubscriberDirectoryRecord) ValidateModel() error {
+func (m *CwfSubscriberDirectoryRecord) ValidateModel(context.Context) error {
 	if err := m.Validate(strfmt.Default); err != nil {
 		return err
 	}
 	return nil
 }
 
-func (m *CarrierWifiHaPairStatus) ValidateModel() error {
+func (m *CarrierWifiHaPairStatus) ValidateModel(context.Context) error {
 	if err := m.Validate(strfmt.Default); err != nil {
 		return err
 	}
 	return nil
 }
 
-func (m *CarrierWifiGatewayHealthStatus) ValidateModel() error {
+func (m *CarrierWifiGatewayHealthStatus) ValidateModel(context.Context) error {
 	if err := m.Validate(strfmt.Default); err != nil {
 		return err
 	}
 	return nil
 }
 
-func (m *CwfHaPair) ValidateModel() error {
+func (m *CwfHaPair) ValidateModel(context.Context) error {
 	if err := m.Validate(strfmt.Default); err != nil {
 		return err
 	}
 	if m.GatewayID1 == m.GatewayID2 {
 		return fmt.Errorf("GatewayID1 and GatewayID2 cannot be the same")
 	}
-	return m.Config.ValidateModel()
+	return m.Config.ValidateModel(context.Background())
 }
 
-func (m *MutableCwfHaPair) ValidateModel() error {
+func (m *MutableCwfHaPair) ValidateModel(context.Context) error {
 	if err := m.Validate(strfmt.Default); err != nil {
 		return err
 	}
 	if m.GatewayID1 == m.GatewayID2 {
 		return fmt.Errorf("GatewayID1 and GatewayID2 cannot be the same")
 	}
-	return m.Config.ValidateModel()
+	return m.Config.ValidateModel(context.Background())
 }
 
-func (m *CwfHaPairConfigs) ValidateModel() error {
+func (m *CwfHaPairConfigs) ValidateModel(context.Context) error {
 	if err := m.Validate(strfmt.Default); err != nil {
 		return err
 	}

--- a/fbinternal/cloud/go/services/testcontroller/statemachines/enodebd_test.go
+++ b/fbinternal/cloud/go/services/testcontroller/statemachines/enodebd_test.go
@@ -803,7 +803,7 @@ func SetupTests(t *testing.T, dbName string) {
 
 func RegisterAGW(t *testing.T) {
 	// Register an AGW
-	err := configurator.CreateNetwork(configurator.Network{ID: "n1"}, serdes.Network)
+	err := configurator.CreateNetwork(context.Background(), configurator.Network{ID: "n1"}, serdes.Network)
 	assert.NoError(t, err)
 	_, err = configurator.CreateEntity(
 		"n1",

--- a/feg/cloud/go/services/basic_acct/tests/setup.go
+++ b/feg/cloud/go/services/basic_acct/tests/setup.go
@@ -106,7 +106,7 @@ func SetupNetworks(t *testing.T) {
 		servingFegNetworkCfg,
 		federatedLteNetCfg,
 	}
-	_, err := configurator.CreateNetworks(networkConfigs, serdes.Network)
+	_, err := configurator.CreateNetworks(context.Background(), networkConfigs, serdes.Network)
 	assert.NoError(t, err)
 
 	_, err = configurator.CreateEntities(
@@ -181,11 +181,11 @@ func SetupNetworks(t *testing.T) {
 	err = device.RegisterDevice(context.Background(), ServingFegNetworkID, orc8r.AccessGatewayRecordType, FegHwId, &models.GatewayDevice{HardwareID: FegHwId, Key: &models.ChallengeKey{KeyType: "ECHO"}}, serdes.Device)
 	assert.NoError(t, err)
 
-	actualNHNet, err := configurator.LoadNetwork(NhNetworkID, true, true, serdes.Network)
+	actualNHNet, err := configurator.LoadNetwork(context.Background(), NhNetworkID, true, true, serdes.Network)
 	assert.NoError(t, err)
 	assert.Equal(t, nhNetworkConfig, actualNHNet)
 
-	actualFeGNet, err := configurator.LoadNetwork(ServingFegNetworkID, true, true, serdes.Network)
+	actualFeGNet, err := configurator.LoadNetwork(context.Background(), ServingFegNetworkID, true, true, serdes.Network)
 	assert.NoError(t, err)
 	assert.Equal(t, servingFegNetworkCfg, actualFeGNet)
 

--- a/feg/cloud/go/services/feg/obsidian/handlers/handlers.go
+++ b/feg/cloud/go/services/feg/obsidian/handlers/handlers.go
@@ -211,7 +211,7 @@ func getClusterStatusHandler(c echo.Context) error {
 	}
 
 	reqCtx := c.Request().Context()
-	network, err := configurator.LoadNetwork(nid, true, true, serdes.Network)
+	network, err := configurator.LoadNetwork(reqCtx, nid, true, true, serdes.Network)
 	if err == merrors.ErrNotFound {
 		return c.NoContent(http.StatusNotFound)
 	}

--- a/feg/cloud/go/services/feg/obsidian/handlers/handlers_test.go
+++ b/feg/cloud/go/services/feg/obsidian/handlers/handlers_test.go
@@ -169,7 +169,7 @@ func TestFederationNetworks(t *testing.T) {
 	}
 	tests.RunUnitTest(t, e, tc)
 
-	actualN1, err := configurator.LoadNetwork("n1", true, true, serdes.Network)
+	actualN1, err := configurator.LoadNetwork(context.Background(), "n1", true, true, serdes.Network)
 	assert.NoError(t, err)
 	expected := configurator.Network{
 		ID:          "n1",
@@ -598,7 +598,7 @@ func TestFederatedLteNetworks(t *testing.T) {
 	}
 	tests.RunUnitTest(t, e, tc)
 
-	actualN1, err := configurator.LoadNetwork("n1", true, true, serdes.Network)
+	actualN1, err := configurator.LoadNetwork(context.Background(), "n1", true, true, serdes.Network)
 	assert.NoError(t, err)
 	expected := configurator.Network{
 		ID:          "n1",
@@ -713,72 +713,66 @@ func Test_GetNetworkSubscriberConfigHandlers(t *testing.T) {
 
 // n1, n3 are feg networks, n2 is not
 func seedFederationNetworks(t *testing.T) {
-	_, err := configurator.CreateNetworks(
-		[]configurator.Network{
-			{
-				ID:          "n1",
-				Type:        feg.FederationNetworkType,
-				Name:        "foobar",
-				Description: "Foo Bar",
-				Configs: map[string]interface{}{
-					feg.FegNetworkType:          models2.NewDefaultNetworkFederationConfigs(),
-					orc8r.NetworkFeaturesConfig: models.NewDefaultFeaturesConfig(),
-					orc8r.DnsdNetworkType:       models.NewDefaultDNSConfig(),
-				},
-			},
-			{
-				ID:          "n2",
-				Type:        "blah",
-				Name:        "foobar",
-				Description: "Foo Bar",
-				Configs:     map[string]interface{}{},
-			},
-			{
-				ID:          "n3",
-				Type:        feg.FederationNetworkType,
-				Name:        "barfoo",
-				Description: "Bar Foo",
-				Configs:     map[string]interface{}{},
+	_, err := configurator.CreateNetworks(context.Background(), []configurator.Network{
+		{
+			ID:          "n1",
+			Type:        feg.FederationNetworkType,
+			Name:        "foobar",
+			Description: "Foo Bar",
+			Configs: map[string]interface{}{
+				feg.FegNetworkType:          models2.NewDefaultNetworkFederationConfigs(),
+				orc8r.NetworkFeaturesConfig: models.NewDefaultFeaturesConfig(),
+				orc8r.DnsdNetworkType:       models.NewDefaultDNSConfig(),
 			},
 		},
-		serdes.Network,
-	)
+		{
+			ID:          "n2",
+			Type:        "blah",
+			Name:        "foobar",
+			Description: "Foo Bar",
+			Configs:     map[string]interface{}{},
+		},
+		{
+			ID:          "n3",
+			Type:        feg.FederationNetworkType,
+			Name:        "barfoo",
+			Description: "Bar Foo",
+			Configs:     map[string]interface{}{},
+		},
+	}, serdes.Network)
 	assert.NoError(t, err)
 }
 
 // n1, n3 are feg networks, n2 is not
 func seedFederatedLteNetworks(t *testing.T) {
-	_, err := configurator.CreateNetworks(
-		[]configurator.Network{
-			{
-				ID:          "n1",
-				Type:        feg.FederatedLteNetworkType,
-				Name:        "foobar",
-				Description: "Foo Bar",
-				Configs: map[string]interface{}{
-					feg.FederatedNetworkType:      models2.NewDefaultFederatedNetworkConfigs(),
-					lte.CellularNetworkConfigType: models3.NewDefaultTDDNetworkConfig(),
-					orc8r.NetworkFeaturesConfig:   models.NewDefaultFeaturesConfig(),
-					orc8r.DnsdNetworkType:         models.NewDefaultDNSConfig(),
-				},
-			},
-			{
-				ID:          "n2",
-				Type:        "blah",
-				Name:        "foobar",
-				Description: "Foo Bar",
-				Configs:     map[string]interface{}{},
-			},
-			{
-				ID:          "n3",
-				Type:        feg.FederatedLteNetworkType,
-				Name:        "barfoo",
-				Description: "Bar Foo",
-				Configs:     map[string]interface{}{},
+	_, err := configurator.CreateNetworks(context.Background(), []configurator.Network{
+		{
+			ID:          "n1",
+			Type:        feg.FederatedLteNetworkType,
+			Name:        "foobar",
+			Description: "Foo Bar",
+			Configs: map[string]interface{}{
+				feg.FederatedNetworkType:      models2.NewDefaultFederatedNetworkConfigs(),
+				lte.CellularNetworkConfigType: models3.NewDefaultTDDNetworkConfig(),
+				orc8r.NetworkFeaturesConfig:   models.NewDefaultFeaturesConfig(),
+				orc8r.DnsdNetworkType:         models.NewDefaultDNSConfig(),
 			},
 		},
-		serdes.Network,
-	)
+		{
+			ID:          "n2",
+			Type:        "blah",
+			Name:        "foobar",
+			Description: "Foo Bar",
+			Configs:     map[string]interface{}{},
+		},
+		{
+			ID:          "n3",
+			Type:        feg.FederatedLteNetworkType,
+			Name:        "barfoo",
+			Description: "Bar Foo",
+			Configs:     map[string]interface{}{},
+		},
+	}, serdes.Network)
 	assert.NoError(t, err)
 }
 

--- a/feg/cloud/go/services/feg/obsidian/models/conversion.go
+++ b/feg/cloud/go/services/feg/obsidian/models/conversion.go
@@ -14,6 +14,8 @@
 package models
 
 import (
+	"context"
+
 	"magma/feg/cloud/go/feg"
 	feg_protos "magma/feg/cloud/go/protos"
 	"magma/feg/cloud/go/protos/mconfig"
@@ -34,7 +36,7 @@ import (
 	"github.com/go-openapi/swag"
 )
 
-func (m *FegNetwork) ValidateModel() error {
+func (m *FegNetwork) ValidateModel(context.Context) error {
 	return m.Validate(strfmt.Default)
 }
 
@@ -96,7 +98,7 @@ func (m *FegNetwork) FromConfiguratorNetwork(n configurator.Network) interface{}
 	return m
 }
 
-func (m *FegLteNetwork) ValidateModel() error {
+func (m *FegLteNetwork) ValidateModel(context.Context) error {
 	return m.Validate(strfmt.Default)
 }
 
@@ -160,7 +162,7 @@ func (m *NetworkFederationConfigs) ToUpdateCriteria(network configurator.Network
 	return orc8rModels.GetNetworkConfigUpdateCriteria(network.ID, feg.FegNetworkType, m), nil
 }
 
-func (m *FederationGateway) ValidateModel() error {
+func (m *FederationGateway) ValidateModel(context.Context) error {
 	return m.Validate(strfmt.Default)
 }
 
@@ -177,7 +179,7 @@ func (m *FederationGateway) FromBackendModels(
 	return m
 }
 
-func (m *MutableFederationGateway) ValidateModel() error {
+func (m *MutableFederationGateway) ValidateModel(context.Context) error {
 	return m.Validate(strfmt.Default)
 }
 

--- a/feg/cloud/go/services/feg/obsidian/models/validate.go
+++ b/feg/cloud/go/services/feg/obsidian/models/validate.go
@@ -14,6 +14,7 @@
 package models
 
 import (
+	"context"
 	"fmt"
 	"regexp"
 
@@ -24,12 +25,12 @@ import (
 	"github.com/pkg/errors"
 )
 
-func (m FegNetworkID) ValidateModel() error {
+func (m FegNetworkID) ValidateModel(ctx context.Context) error {
 	if err := m.Validate(strfmt.Default); err != nil {
 		return err
 	}
 	if !swag.IsZero(m) {
-		exists, err := configurator.DoesNetworkExist(string(m))
+		exists, err := configurator.DoesNetworkExist(ctx, string(m))
 		if err != nil {
 			return errors.Wrap(err, fmt.Sprintf("Failed to search for network %s", string(m)))
 		}
@@ -40,13 +41,13 @@ func (m FegNetworkID) ValidateModel() error {
 	return nil
 }
 
-func (m *FederatedNetworkConfigs) ValidateModel() error {
+func (m *FederatedNetworkConfigs) ValidateModel(ctx context.Context) error {
 	if err := m.Validate(strfmt.Default); err != nil {
 		return err
 	}
 	nid := *m.FegNetworkID
 	if !swag.IsZero(nid) {
-		exists, err := configurator.DoesNetworkExist(nid)
+		exists, err := configurator.DoesNetworkExist(ctx, nid)
 		if err != nil {
 			return errors.Wrap(err, fmt.Sprintf("Failed to search for network %s", nid))
 		}
@@ -57,28 +58,28 @@ func (m *FederatedNetworkConfigs) ValidateModel() error {
 	return nil
 }
 
-func (m *DiameterClientConfigs) ValidateModel() error {
+func (m *DiameterClientConfigs) ValidateModel(context.Context) error {
 	if err := m.Validate(strfmt.Default); err != nil {
 		return err
 	}
 	return nil
 }
 
-func (m *DiameterServerConfigs) ValidateModel() error {
+func (m *DiameterServerConfigs) ValidateModel(context.Context) error {
 	if err := m.Validate(strfmt.Default); err != nil {
 		return err
 	}
 	return nil
 }
 
-func (m *EapAkaTimeouts) ValidateModel() error {
+func (m *EapAkaTimeouts) ValidateModel(context.Context) error {
 	if err := m.Validate(strfmt.Default); err != nil {
 		return err
 	}
 	return nil
 }
 
-func (m *GatewayFederationConfigs) ValidateModel() error {
+func (m *GatewayFederationConfigs) ValidateModel(context.Context) error {
 	if err := m.Validate(strfmt.Default); err != nil {
 		return err
 	}
@@ -87,7 +88,7 @@ func (m *GatewayFederationConfigs) ValidateModel() error {
 
 var nhRouteRegex = regexp.MustCompile(`^(\d{5,6})$`)
 
-func (m *NetworkFederationConfigs) ValidateModel() error {
+func (m *NetworkFederationConfigs) ValidateModel(context.Context) error {
 	if err := m.Validate(strfmt.Default); err != nil {
 		return err
 	}
@@ -101,7 +102,7 @@ func (m *NetworkFederationConfigs) ValidateModel() error {
 	return nil
 }
 
-func (m *SubscriptionProfile) ValidateModel() error {
+func (m *SubscriptionProfile) ValidateModel(context.Context) error {
 	if err := m.Validate(strfmt.Default); err != nil {
 		return err
 	}

--- a/feg/cloud/go/services/feg_relay/gw_to_feg_relay/feg_discovery.go
+++ b/feg/cloud/go/services/feg_relay/gw_to_feg_relay/feg_discovery.go
@@ -54,7 +54,7 @@ func RetrieveGatewayIdentity(inCtx context.Context) (*protos.Identity_Gateway, e
 //    FeG ID of the serving FeG Network
 // Returns serving Federation Gateway ID or error
 func FindServingFeGHwId(ctx context.Context, agNwID, imsi string) (string, error) {
-	cfg, err := configurator.LoadNetworkConfig(agNwID, feg.FederatedNetworkType, serdes.Network)
+	cfg, err := configurator.LoadNetworkConfig(ctx, agNwID, feg.FederatedNetworkType, serdes.Network)
 	if err != nil {
 		return "", status.Errorf(
 			codes.NotFound, "could not load federated network configs for access network %s: %s", agNwID, err)
@@ -66,7 +66,7 @@ func FindServingFeGHwId(ctx context.Context, agNwID, imsi string) (string, error
 	if federatedConfig.FegNetworkID == nil || *federatedConfig.FegNetworkID == "" {
 		return "", status.Errorf(codes.Internal, "FegNetworkID is empty in network config of network: %s", agNwID)
 	}
-	fegCfg, err := configurator.LoadNetworkConfig(*federatedConfig.FegNetworkID, feg.FegNetworkType, serdes.Network)
+	fegCfg, err := configurator.LoadNetworkConfig(ctx, *federatedConfig.FegNetworkID, feg.FegNetworkType, serdes.Network)
 	if err != nil || fegCfg == nil {
 		return "", status.Errorf(
 			codes.Internal, "unable to retrieve config for federation network: %s", *federatedConfig.FegNetworkID)
@@ -134,7 +134,7 @@ func findServingNHFeg(ctx context.Context, routes models.NhRoutes, nhNetworkId, 
 		}
 	}
 	// verify that serving FeG network has the NH network in it's configuration
-	fegCfg, err := configurator.LoadNetworkConfig(servingFegNetworkId, feg.FegNetworkType, serdes.Network)
+	fegCfg, err := configurator.LoadNetworkConfig(ctx, servingFegNetworkId, feg.FegNetworkType, serdes.Network)
 	if err != nil || fegCfg == nil {
 		glog.Errorf("unable to retrieve config for NH federation network: %s", servingFegNetworkId)
 		return ""

--- a/feg/cloud/go/services/feg_relay/gw_to_feg_relay/gw_to_feg_relay.go
+++ b/feg/cloud/go/services/feg_relay/gw_to_feg_relay/gw_to_feg_relay.go
@@ -152,7 +152,7 @@ func createNewRequest(req *http.Request, addr, hwId string) (*http.Request, *htt
 }
 
 func getFeGHwIdForNetwork(ctx context.Context, agNwID string) (string, error) {
-	cfg, err := configurator.LoadNetworkConfig(agNwID, feg.FederatedNetworkType, serdes.Network)
+	cfg, err := configurator.LoadNetworkConfig(ctx, agNwID, feg.FederatedNetworkType, serdes.Network)
 	if err != nil {
 		return "", fmt.Errorf("could not load federated network configs for access network %s: %s", agNwID, err)
 	}
@@ -163,7 +163,7 @@ func getFeGHwIdForNetwork(ctx context.Context, agNwID string) (string, error) {
 	if federatedConfig.FegNetworkID == nil || *federatedConfig.FegNetworkID == "" {
 		return "", fmt.Errorf("FegNetworkID is empty in network config of network: %s", agNwID)
 	}
-	fegCfg, err := configurator.LoadNetworkConfig(*federatedConfig.FegNetworkID, feg.FegNetworkType, serdes.Network)
+	fegCfg, err := configurator.LoadNetworkConfig(ctx, *federatedConfig.FegNetworkID, feg.FegNetworkType, serdes.Network)
 	if err != nil || fegCfg == nil {
 		return "", fmt.Errorf("unable to retrieve config for federation network: %s", *federatedConfig.FegNetworkID)
 	}

--- a/feg/cloud/go/services/feg_relay/gw_to_feg_relay/tests/relay_test.go
+++ b/feg/cloud/go/services/feg_relay/gw_to_feg_relay/tests/relay_test.go
@@ -258,7 +258,7 @@ func TestNHRouting(t *testing.T) {
 
 	// test #5: Remove Neutral Host settings (making NH FeG network a legacy FeG Network) and verify that
 	//			legacy (non NH) relay logic works as expected (GW requests with NH IMSI are routed to NH FeG)
-	nhNet, err := configurator.LoadNetwork(nhNetworkID, true, true, serdes.Network)
+	nhNet, err := configurator.LoadNetwork(context.Background(), nhNetworkID, true, true, serdes.Network)
 	assert.NoError(t, err)
 	assert.NotNil(t, nhNet)
 	cfg, ok := nhNet.Configs[feg.FegNetworkType]
@@ -268,7 +268,7 @@ func TestNHRouting(t *testing.T) {
 	assert.True(t, ok)
 	assert.NotNil(t, fegCfg)
 	fegCfg.NhRoutes = nil // delete NH configuration, now FeG Network is just a regular FeG Network
-	err = configurator.UpdateNetworkConfig(nhNetworkID, feg.FegNetworkType, fegCfg, serdes.Network)
+	err = configurator.UpdateNetworkConfig(context.Background(), nhNetworkID, feg.FegNetworkType, fegCfg, serdes.Network)
 	assert.NoError(t, err)
 
 	// Verify, relay now finds the NH local FeG for any IMSI

--- a/feg/cloud/go/services/feg_relay/gw_to_feg_relay/tests/test_setup.go
+++ b/feg/cloud/go/services/feg_relay/gw_to_feg_relay/tests/test_setup.go
@@ -117,7 +117,7 @@ func setupNeutralHostNetworks(t *testing.T) *health_servicers.TestHealthServer {
 		servingFegNetworkCfg,
 		federatedLteNetCfg,
 	}
-	_, err = configurator.CreateNetworks(networkConfigs, serdes.Network)
+	_, err = configurator.CreateNetworks(context.Background(), networkConfigs, serdes.Network)
 	assert.NoError(t, err)
 
 	_, err = configurator.CreateEntities(
@@ -192,11 +192,11 @@ func setupNeutralHostNetworks(t *testing.T) *health_servicers.TestHealthServer {
 	err = device.RegisterDevice(context.Background(), servingFegNetworkID, orc8r.AccessGatewayRecordType, fegHwId, &models.GatewayDevice{HardwareID: fegHwId, Key: &models.ChallengeKey{KeyType: "ECHO"}}, serdes.Device)
 	assert.NoError(t, err)
 
-	actualNHNet, err := configurator.LoadNetwork(nhNetworkID, true, true, serdes.Network)
+	actualNHNet, err := configurator.LoadNetwork(context.Background(), nhNetworkID, true, true, serdes.Network)
 	assert.NoError(t, err)
 	assert.Equal(t, nhNetworkConfig, actualNHNet)
 
-	actualFeGNet, err := configurator.LoadNetwork(servingFegNetworkID, true, true, serdes.Network)
+	actualFeGNet, err := configurator.LoadNetwork(context.Background(), servingFegNetworkID, true, true, serdes.Network)
 	assert.NoError(t, err)
 	assert.Equal(t, servingFegNetworkCfg, actualFeGNet)
 

--- a/feg/cloud/go/services/feg_relay/servicers/feg_to_gw_relay.go
+++ b/feg/cloud/go/services/feg_relay/servicers/feg_to_gw_relay.go
@@ -48,7 +48,7 @@ func getHwIDFromIMSI(ctx context.Context, imsi string) (string, error) {
 	if !strings.HasPrefix(imsi, "IMSI") {
 		imsi = fmt.Sprintf("IMSI%s", imsi)
 	}
-	servedIds, err := getFegServedIds(gw.GetNetworkId())
+	servedIds, err := getFegServedIds(ctx, gw.GetNetworkId())
 	if err != nil {
 		return "", err
 	}
@@ -64,7 +64,7 @@ func getHwIDFromIMSI(ctx context.Context, imsi string) (string, error) {
 
 func getHwIDFromTeid(ctx context.Context, teid string) (string, error) {
 	gw := protos.GetClientGateway(ctx)
-	servedIds, err := getFegServedIds(gw.GetNetworkId())
+	servedIds, err := getFegServedIds(ctx, gw.GetNetworkId())
 	if err != nil {
 		return "", err
 	}
@@ -130,11 +130,11 @@ func getAllGWSGSServiceConnCtx(ctx context.Context) ([]*grpc.ClientConn, []conte
 
 // getFegServedIds returns ServedNetworkIds of the given FeG networkId and appends to the list all ServedNetworkIds of
 // the network's Neutral Host Network if any
-func getFegServedIds(networkId string) ([]string, error) {
+func getFegServedIds(ctx context.Context, networkId string) ([]string, error) {
 	if len(networkId) == 0 {
 		return []string{}, fmt.Errorf("Empty networkID provided.")
 	}
-	fegCfg, err := configurator.LoadNetworkConfig(networkId, feg.FegNetworkType, serdes.Network)
+	fegCfg, err := configurator.LoadNetworkConfig(ctx, networkId, feg.FegNetworkType, serdes.Network)
 	if err != nil || fegCfg == nil {
 		return []string{}, fmt.Errorf("unable to retrieve config for federation network: %s", networkId)
 	}
@@ -153,7 +153,7 @@ func getFegServedIds(networkId string) ([]string, error) {
 	glog.V(2).Infof("getFegServedIds: nonempty Served NH Networks list for network: %s", networkId)
 	for _, nhNetworkId := range networkFegConfigs.ServedNhIds {
 		if len(nhNetworkId) > 0 {
-			nhFegCfg, err := configurator.LoadNetworkConfig(nhNetworkId, feg.FegNetworkType, serdes.Network)
+			nhFegCfg, err := configurator.LoadNetworkConfig(ctx, nhNetworkId, feg.FegNetworkType, serdes.Network)
 			if err != nil || nhFegCfg == nil {
 				glog.Errorf("unable to retrieve config for NH federation network '%s': %v", nhNetworkId, err)
 				continue

--- a/feg/cloud/go/services/feg_relay/utils/get_all_gateways.go
+++ b/feg/cloud/go/services/feg_relay/utils/get_all_gateways.go
@@ -50,7 +50,7 @@ func GetAllGatewayIDs(ctx context.Context) ([]string, error) {
 	if len(networkID) == 0 || len(logicalID) == 0 {
 		return res, fmt.Errorf("Unregistered Federated Gateway: %s", fegId.String())
 	}
-	cfg, err := getFegCfg(networkID, logicalID)
+	cfg, err := getFegCfg(ctx, networkID, logicalID)
 	if err != nil {
 		return res, fmt.Errorf("Error getting Federated Gateway %s:%s configs: %v", networkID, logicalID, err)
 	}
@@ -84,7 +84,7 @@ func GetAllGatewayIDs(ctx context.Context) ([]string, error) {
 	return res, nil
 }
 
-func getFegCfg(networkID, gatewayID string) (*models.GatewayFederationConfigs, error) {
+func getFegCfg(ctx context.Context, networkID, gatewayID string) (*models.GatewayFederationConfigs, error) {
 	fegGateway, err := configurator.LoadEntity(
 		networkID, feg.FegGatewayType, gatewayID,
 		configurator.EntityLoadCriteria{LoadConfig: true},
@@ -97,7 +97,7 @@ func getFegCfg(networkID, gatewayID string) (*models.GatewayFederationConfigs, e
 		return fegGateway.Config.(*models.GatewayFederationConfigs), nil
 	}
 
-	iNetworkConfig, err := configurator.LoadNetworkConfig(networkID, feg.FegNetworkType, serdes.Network)
+	iNetworkConfig, err := configurator.LoadNetworkConfig(ctx, networkID, feg.FegNetworkType, serdes.Network)
 	if err != nil {
 		return nil, merrors.ErrNotFound
 	}

--- a/feg/cloud/go/services/health/reporter/network_health_reporter.go
+++ b/feg/cloud/go/services/health/reporter/network_health_reporter.go
@@ -44,12 +44,12 @@ func (reporter *NetworkHealthStatusReporter) ReportHealthStatus(dur time.Duratio
 
 func (reporter *NetworkHealthStatusReporter) reportHealthStatus() error {
 	ctx := context.Background()
-	networks, err := configurator.ListNetworkIDs()
+	networks, err := configurator.ListNetworkIDs(ctx)
 	if err != nil {
 		return err
 	}
 	for _, networkID := range networks {
-		config, err := configurator.LoadNetworkConfig(networkID, feg.FegNetworkType, serdes.Network)
+		config, err := configurator.LoadNetworkConfig(ctx, networkID, feg.FegNetworkType, serdes.Network)
 		// Consider a FeG network to be only those that have FeG Network configs defined
 		if err != nil || config == nil {
 			continue
@@ -70,7 +70,7 @@ func (reporter *NetworkHealthStatusReporter) reportHealthStatus() error {
 				glog.V(2).Infof("error getting health for network %s, gateway %s: %v\n", networkID, gw.Key, err)
 				continue
 			}
-			status, _, err := servicers.AnalyzeHealthStats(healthStatus, networkID)
+			status, _, err := servicers.AnalyzeHealthStats(ctx, healthStatus, networkID)
 			if err != nil {
 				glog.V(2).Infof("error analyzing health stats for network %s, gateway %s: %v", networkID, gw.Key, err)
 			}

--- a/feg/cloud/go/services/health/servicers/config.go
+++ b/feg/cloud/go/services/health/servicers/config.go
@@ -14,6 +14,8 @@ limitations under the License.
 package servicers
 
 import (
+	"context"
+
 	"magma/feg/cloud/go/feg"
 	"magma/feg/cloud/go/serdes"
 	"magma/feg/cloud/go/services/feg/obsidian/models"
@@ -30,14 +32,14 @@ const (
 
 var defaultServices = []string{"SWX_PROXY", "SESSION_PROXY"}
 
-func GetHealthConfigForNetwork(networkID string) *healthConfig {
+func GetHealthConfigForNetwork(ctx context.Context, networkID string) *healthConfig {
 	defaultConfig := &healthConfig{
 		services:              defaultServices,
 		cpuUtilThreshold:      defaultCpuUtilThreshold,
 		memAvailableThreshold: defaultMemAvailableThreshold,
 		staleUpdateThreshold:  defaultStaleUpdateThreshold,
 	}
-	config, err := configurator.LoadNetworkConfig(networkID, feg.FegNetworkType, serdes.Network)
+	config, err := configurator.LoadNetworkConfig(ctx, networkID, feg.FegNetworkType, serdes.Network)
 	if err != nil {
 		glog.V(2).Infof("Using default health configuration for network %s; %s", networkID, err)
 		return defaultConfig

--- a/feg/cloud/go/services/health/test_utils/test_utils.go
+++ b/feg/cloud/go/services/health/test_utils/test_utils.go
@@ -16,6 +16,7 @@ limitations under the License.
 package test_utils
 
 import (
+	context2 "context"
 	"testing"
 	"time"
 
@@ -101,13 +102,10 @@ func GetUnhealthyRequest() *protos.HealthRequest {
 }
 
 func RegisterNetwork(t *testing.T, networkID string) {
-	err := configurator.CreateNetwork(
-		configurator.Network{
-			ID:   TestFegNetwork,
-			Type: feg.FegNetworkType,
-		},
-		serdes.Network,
-	)
+	err := configurator.CreateNetwork(context2.Background(), configurator.Network{
+		ID:   TestFegNetwork,
+		Type: feg.FegNetworkType,
+	}, serdes.Network)
 	assert.NoError(t, err)
 }
 

--- a/feg/gateway/go.mod
+++ b/feg/gateway/go.mod
@@ -44,7 +44,6 @@ require (
 	golang.org/x/crypto v0.0.0-20210421170649-83a5a9bb288b // indirect
 	google.golang.org/grpc v1.33.2
 	google.golang.org/protobuf v1.26.0
-	gotest.tools/gotestsum v1.7.0 // indirect
 	layeh.com/radius v0.0.0-20201203135236-838e26d0c9be
 	magma/feg/cloud/go v0.0.0
 	magma/feg/cloud/go/protos v0.0.0

--- a/feg/gateway/go.sum
+++ b/feg/gateway/go.sum
@@ -955,6 +955,7 @@ gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C
 gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776 h1:tQIYjPdBoyREyB9XMu+nnTclpTYkz2zFM+lzLJFO4gQ=
 gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gotest.tools v2.2.0+incompatible h1:VsBPFP1AI068pPrMxtb/S8Zkgf9xEmTLJjfM+P5UIEo=
+gotest.tools/gotestsum v1.6.4/go.mod h1:fTR9ZhxC/TLAAx2/WMk/m3TkMB9eEI89gdEzhiRVJT8=
 gotest.tools/gotestsum v1.7.0 h1:RwpqwwFKBAa2h+F6pMEGpE707Edld0etUD3GhqqhDNc=
 gotest.tools/gotestsum v1.7.0/go.mod h1:V1m4Jw3eBerhI/A6qCxUE07RnCg7ACkKj9BYcAm09V8=
 gotest.tools/v3 v3.0.3/go.mod h1:Z7Lb0S5l+klDB31fvDQX8ss/FlKDxtlFlw3Oa8Ymbl8=

--- a/lte/cloud/go/services/ha/servicers/servicer_test.go
+++ b/lte/cloud/go/services/ha/servicers/servicer_test.go
@@ -58,7 +58,7 @@ func TestHAServicer_GetEnodebOffloadState(t *testing.T) {
 	testGwId2 := "g2"
 	testGwPool := "pool1"
 	enbSn := "enb1"
-	err := configurator.CreateNetwork(configurator.Network{ID: testNetworkId}, serdes.Network)
+	err := configurator.CreateNetwork(context.Background(), configurator.Network{ID: testNetworkId}, serdes.Network)
 	assert.NoError(t, err)
 
 	// Initialize HA network topology

--- a/lte/cloud/go/services/lte/analytics/calculations/state.go
+++ b/lte/cloud/go/services/lte/analytics/calculations/state.go
@@ -48,7 +48,7 @@ func (x *UserMetricsCalculation) Calculate(prometheusClient query_api.Prometheus
 	glog.V(1).Info("Calculate User Metrics")
 
 	var results []*protos.CalculationResult
-	networks, err := configurator.ListNetworkIDs()
+	networks, err := configurator.ListNetworkIDs(context.Background())
 	if err != nil || networks == nil {
 		return results, err
 	}
@@ -125,7 +125,7 @@ type SiteMetricsCalculation struct {
 func (x *SiteMetricsCalculation) Calculate(prometheusClient query_api.PrometheusAPI) ([]*protos.CalculationResult, error) {
 	glog.V(1).Info("Calculate Site Metrics")
 	var results []*protos.CalculationResult
-	networks, err := configurator.ListNetworkIDs()
+	networks, err := configurator.ListNetworkIDs(context.Background())
 	if err != nil || networks == nil {
 		return results, err
 	}

--- a/lte/cloud/go/services/lte/analytics/calculations/state_test.go
+++ b/lte/cloud/go/services/lte/analytics/calculations/state_test.go
@@ -1,6 +1,7 @@
 package calculations_test
 
 import (
+	context2 "context"
 	"testing"
 
 	"magma/lte/cloud/go/lte"
@@ -23,7 +24,7 @@ import (
 func TestUserCalculations(t *testing.T) {
 	configurator_test_init.StartTestService(t)
 	state_test_init.StartTestService(t)
-	err := configurator.CreateNetwork(configurator.Network{ID: "n0"}, serdes.Network)
+	err := configurator.CreateNetwork(context2.Background(), configurator.Network{ID: "n0"}, serdes.Network)
 	assert.NoError(t, err)
 	_, err = configurator.CreateEntity(
 		"n0",
@@ -91,7 +92,7 @@ func TestUserCalculations(t *testing.T) {
 func TestSiteCalculations(t *testing.T) {
 	configurator_test_init.StartTestService(t)
 	state_test_init.StartTestService(t)
-	err := configurator.CreateNetwork(configurator.Network{ID: "n0"}, serdes.Network)
+	err := configurator.CreateNetwork(context2.Background(), configurator.Network{ID: "n0"}, serdes.Network)
 	assert.NoError(t, err)
 
 	_, err = configurator.CreateEntity(

--- a/lte/cloud/go/services/lte/obsidian/handlers/handlers_test.go
+++ b/lte/cloud/go/services/lte/obsidian/handlers/handlers_test.go
@@ -132,7 +132,7 @@ func TestCreateNetwork(t *testing.T) {
 	}
 	tests.RunUnitTest(t, e, tc)
 
-	actual, err := configurator.LoadNetwork("n1", true, true, serdes.Network)
+	actual, err := configurator.LoadNetwork(context.Background(), "n1", true, true, serdes.Network)
 	assert.NoError(t, err)
 	expected := configurator.Network{
 		ID:          "n1",
@@ -308,7 +308,7 @@ func TestUpdateNetwork(t *testing.T) {
 	}
 	tests.RunUnitTest(t, e, tc)
 
-	actualN1, err := configurator.LoadNetwork("n1", true, true, serdes.Network)
+	actualN1, err := configurator.LoadNetwork(context.Background(), "n1", true, true, serdes.Network)
 	assert.NoError(t, err)
 	expected := configurator.Network{
 		ID:          "n1",
@@ -377,7 +377,7 @@ func TestDeleteNetwork(t *testing.T) {
 	}
 	tests.RunUnitTest(t, e, tc)
 
-	actual, err := configurator.ListNetworkIDs()
+	actual, err := configurator.ListNetworkIDs(context.Background())
 	assert.NoError(t, err)
 	assert.Equal(t, []string{"n2", "n3"}, actual)
 }
@@ -478,16 +478,14 @@ func TestCellularPartialGet(t *testing.T) {
 	// add 'n2' as FegNetworkID to n1
 	cellularConfig := lteModels.NewDefaultTDDNetworkConfig()
 	cellularConfig.FegNetworkID = "n2"
-	err := configurator.UpdateNetworks([]configurator.NetworkUpdateCriteria{
+	err := configurator.UpdateNetworks(context.Background(), []configurator.NetworkUpdateCriteria{
 		{
 			ID: "n1",
 			ConfigsToAddOrUpdate: map[string]interface{}{
 				lte.CellularNetworkConfigType: cellularConfig,
 			},
 		},
-	},
-		serdes.Network,
-	)
+	}, serdes.Network)
 	assert.NoError(t, err)
 
 	// happy case FegNetworkID from cellular config
@@ -533,7 +531,7 @@ func TestCellularPartialUpdate(t *testing.T) {
 	}
 	tests.RunUnitTest(t, e, tc)
 
-	actualN2, err := configurator.LoadNetwork("n2", true, true, serdes.Network)
+	actualN2, err := configurator.LoadNetwork(context.Background(), "n2", true, true, serdes.Network)
 	assert.NoError(t, err)
 	expected := configurator.Network{
 		ID:          "n2",
@@ -594,7 +592,7 @@ func TestCellularPartialUpdate(t *testing.T) {
 	}
 	tests.RunUnitTest(t, e, tc)
 
-	actualN2, err = configurator.LoadNetwork("n2", true, true, serdes.Network)
+	actualN2, err = configurator.LoadNetwork(context.Background(), "n2", true, true, serdes.Network)
 	assert.NoError(t, err)
 	expected.Configs[lte.CellularNetworkConfigType].(*lteModels.NetworkCellularConfigs).Epc = epcConfig
 	expected.Version = 2
@@ -640,7 +638,7 @@ func TestCellularPartialUpdate(t *testing.T) {
 		ExpectedStatus: 204,
 	}
 	tests.RunUnitTest(t, e, tc)
-	actualN2, err = configurator.LoadNetwork("n2", true, true, serdes.Network)
+	actualN2, err = configurator.LoadNetwork(context.Background(), "n2", true, true, serdes.Network)
 	assert.NoError(t, err)
 	expected.Configs[lte.CellularNetworkConfigType].(*lteModels.NetworkCellularConfigs).Ran = ranConfig
 	expected.Version = 3
@@ -694,7 +692,7 @@ func TestCellularDelete(t *testing.T) {
 	}
 	tests.RunUnitTest(t, e, tc)
 
-	_, err := configurator.LoadNetworkConfig("n1", lte.CellularNetworkConfigType, serdes.Network)
+	_, err := configurator.LoadNetworkConfig(context.Background(), "n1", lte.CellularNetworkConfigType, serdes.Network)
 	assert.EqualError(t, err, "Not found")
 }
 
@@ -727,7 +725,7 @@ func Test_GetNetworkSubscriberConfigHandlers(t *testing.T) {
 		NetworkWideBaseNames: []policyModels.BaseName{"base1"},
 		NetworkWideRuleNames: []string{"rule1"},
 	}
-	assert.NoError(t, configurator.UpdateNetworkConfig("n1", lte.NetworkSubscriberConfigType, subscriberConfig, serdes.Network))
+	assert.NoError(t, configurator.UpdateNetworkConfig(context.Background(), "n1", lte.NetworkSubscriberConfigType, subscriberConfig, serdes.Network))
 
 	// happy case
 	tc = tests.Test{
@@ -837,7 +835,7 @@ func Test_ModifyNetworkSubscriberConfigHandlers(t *testing.T) {
 		ExpectedStatus: 204,
 	}
 	tests.RunUnitTest(t, e, tc)
-	iSubscriberConfig, err := configurator.LoadNetworkConfig("n1", lte.NetworkSubscriberConfigType, serdes.Network)
+	iSubscriberConfig, err := configurator.LoadNetworkConfig(context.Background(), "n1", lte.NetworkSubscriberConfigType, serdes.Network)
 	assert.NoError(t, err)
 	assert.Equal(t, subscriberConfig, iSubscriberConfig.(*policyModels.NetworkSubscriberConfig))
 
@@ -869,7 +867,7 @@ func Test_ModifyNetworkSubscriberConfigHandlers(t *testing.T) {
 	}
 	tests.RunUnitTest(t, e, tc)
 
-	iSubscriberConfig, err = configurator.LoadNetworkConfig("n1", lte.NetworkSubscriberConfigType, serdes.Network)
+	iSubscriberConfig, err = configurator.LoadNetworkConfig(context.Background(), "n1", lte.NetworkSubscriberConfigType, serdes.Network)
 	assert.NoError(t, err)
 	actualSubscriberConfig := iSubscriberConfig.(*policyModels.NetworkSubscriberConfig)
 
@@ -893,7 +891,7 @@ func Test_ModifyNetworkSubscriberConfigHandlers(t *testing.T) {
 	}
 	tests.RunUnitTest(t, e, tc)
 
-	iSubscriberConfig, err = configurator.LoadNetworkConfig("n1", lte.NetworkSubscriberConfigType, serdes.Network)
+	iSubscriberConfig, err = configurator.LoadNetworkConfig(context.Background(), "n1", lte.NetworkSubscriberConfigType, serdes.Network)
 	assert.NoError(t, err)
 	actualSubscriberConfig = iSubscriberConfig.(*policyModels.NetworkSubscriberConfig)
 
@@ -951,7 +949,7 @@ func Test_ModifyNetworkSubscriberConfigHandlers(t *testing.T) {
 		NetworkWideBaseNames: []policyModels.BaseName{"base3", "base4"},
 		NetworkWideRuleNames: []string{"rule3", "rule4"},
 	}
-	iSubscriberConfig, err = configurator.LoadNetworkConfig("n1", lte.NetworkSubscriberConfigType, serdes.Network)
+	iSubscriberConfig, err = configurator.LoadNetworkConfig(context.Background(), "n1", lte.NetworkSubscriberConfigType, serdes.Network)
 	assert.NoError(t, err)
 	actualSubscriberConfig = iSubscriberConfig.(*policyModels.NetworkSubscriberConfig)
 	assert.Equal(t, newSubscriberConfig, actualSubscriberConfig)
@@ -984,7 +982,7 @@ func Test_ModifyNetworkSubscriberConfigHandlers(t *testing.T) {
 		NetworkWideBaseNames: []policyModels.BaseName{"base3"},
 		NetworkWideRuleNames: []string{"rule3"},
 	}
-	iSubscriberConfig, err = configurator.LoadNetworkConfig("n1", lte.NetworkSubscriberConfigType, serdes.Network)
+	iSubscriberConfig, err = configurator.LoadNetworkConfig(context.Background(), "n1", lte.NetworkSubscriberConfigType, serdes.Network)
 	assert.NoError(t, err)
 	actualSubscriberConfig = iSubscriberConfig.(*policyModels.NetworkSubscriberConfig)
 	assert.Equal(t, newSubscriberConfig, actualSubscriberConfig)
@@ -996,7 +994,7 @@ func TestCreateGateway(t *testing.T) {
 	deviceTestInit.StartTestService(t)
 
 	// setup fixtures in backend
-	err := configurator.CreateNetwork(configurator.Network{ID: "n1"}, serdes.Network)
+	err := configurator.CreateNetwork(context.Background(), configurator.Network{ID: "n1"}, serdes.Network)
 	assert.NoError(t, err)
 	_, err = configurator.CreateEntities(
 		"n1",
@@ -1192,7 +1190,7 @@ func TestListAndGetGateways(t *testing.T) {
 	configuratorTestInit.StartTestService(t)
 	stateTestInit.StartTestService(t)
 	deviceTestInit.StartTestService(t)
-	err := configurator.CreateNetwork(configurator.Network{ID: "n1"}, serdes.Network)
+	err := configurator.CreateNetwork(context.Background(), configurator.Network{ID: "n1"}, serdes.Network)
 	assert.NoError(t, err)
 
 	e := echo.New()
@@ -1390,7 +1388,7 @@ func TestUpdateGateway(t *testing.T) {
 
 	configuratorTestInit.StartTestService(t)
 	deviceTestInit.StartTestService(t)
-	err := configurator.CreateNetwork(configurator.Network{ID: "n1"}, serdes.Network)
+	err := configurator.CreateNetwork(context.Background(), configurator.Network{ID: "n1"}, serdes.Network)
 	assert.NoError(t, err)
 
 	e := echo.New()
@@ -1535,7 +1533,7 @@ func TestDeleteGateway(t *testing.T) {
 
 	configuratorTestInit.StartTestService(t)
 	deviceTestInit.StartTestService(t)
-	err := configurator.CreateNetwork(configurator.Network{ID: "n1"}, serdes.Network)
+	err := configurator.CreateNetwork(context.Background(), configurator.Network{ID: "n1"}, serdes.Network)
 	assert.NoError(t, err)
 
 	e := echo.New()
@@ -1618,7 +1616,7 @@ func TestDeleteGateway(t *testing.T) {
 func TestGetCellularGatewayConfig(t *testing.T) {
 	configuratorTestInit.StartTestService(t)
 	deviceTestInit.StartTestService(t)
-	err := configurator.CreateNetwork(configurator.Network{ID: "n1"}, serdes.Network)
+	err := configurator.CreateNetwork(context.Background(), configurator.Network{ID: "n1"}, serdes.Network)
 	assert.NoError(t, err)
 
 	e := echo.New()
@@ -1726,7 +1724,7 @@ func TestGetCellularGatewayConfig(t *testing.T) {
 func TestUpdateCellularGatewayConfig(t *testing.T) {
 	configuratorTestInit.StartTestService(t)
 	deviceTestInit.StartTestService(t)
-	err := configurator.CreateNetwork(configurator.Network{ID: "n1"}, serdes.Network)
+	err := configurator.CreateNetwork(context.Background(), configurator.Network{ID: "n1"}, serdes.Network)
 	assert.NoError(t, err)
 
 	e := echo.New()
@@ -2081,7 +2079,7 @@ func TestUpdateCellularGatewayConfig(t *testing.T) {
 func TestListAndGetEnodebs(t *testing.T) {
 	configuratorTestInit.StartTestService(t)
 	deviceTestInit.StartTestService(t)
-	err := configurator.CreateNetwork(configurator.Network{ID: "n1"}, serdes.Network)
+	err := configurator.CreateNetwork(context.Background(), configurator.Network{ID: "n1"}, serdes.Network)
 	assert.NoError(t, err)
 
 	e := echo.New()
@@ -2256,7 +2254,7 @@ func TestListAndGetEnodebs(t *testing.T) {
 func TestCreateEnodeb(t *testing.T) {
 	configuratorTestInit.StartTestService(t)
 	deviceTestInit.StartTestService(t)
-	err := configurator.CreateNetwork(configurator.Network{ID: "n1"}, serdes.Network)
+	err := configurator.CreateNetwork(context.Background(), configurator.Network{ID: "n1"}, serdes.Network)
 	assert.NoError(t, err)
 
 	e := echo.New()
@@ -2413,7 +2411,7 @@ func TestCreateEnodeb(t *testing.T) {
 func TestUpdateEnodeb(t *testing.T) {
 	configuratorTestInit.StartTestService(t)
 	deviceTestInit.StartTestService(t)
-	err := configurator.CreateNetwork(configurator.Network{ID: "n1"}, serdes.Network)
+	err := configurator.CreateNetwork(context.Background(), configurator.Network{ID: "n1"}, serdes.Network)
 	assert.NoError(t, err)
 
 	e := echo.New()
@@ -2598,7 +2596,7 @@ func TestUpdateEnodeb(t *testing.T) {
 func TestDeleteEnodeb(t *testing.T) {
 	configuratorTestInit.StartTestService(t)
 	deviceTestInit.StartTestService(t)
-	err := configurator.CreateNetwork(configurator.Network{ID: "n1"}, serdes.Network)
+	err := configurator.CreateNetwork(context.Background(), configurator.Network{ID: "n1"}, serdes.Network)
 	assert.NoError(t, err)
 
 	e := echo.New()
@@ -2653,7 +2651,7 @@ func TestGetEnodebState(t *testing.T) {
 	configuratorTestInit.StartTestService(t)
 	stateTestInit.StartTestService(t)
 	deviceTestInit.StartTestService(t)
-	err := configurator.CreateNetwork(configurator.Network{ID: "n1"}, serdes.Network)
+	err := configurator.CreateNetwork(context.Background(), configurator.Network{ID: "n1"}, serdes.Network)
 	assert.NoError(t, err)
 
 	e := echo.New()
@@ -2716,7 +2714,7 @@ func TestGetEnodebState(t *testing.T) {
 
 func TestCreateApn(t *testing.T) {
 	configuratorTestInit.StartTestService(t)
-	err := configurator.CreateNetwork(configurator.Network{ID: "n1"}, serdes.Network)
+	err := configurator.CreateNetwork(context.Background(), configurator.Network{ID: "n1"}, serdes.Network)
 	assert.NoError(t, err)
 
 	e := echo.New()
@@ -2751,7 +2749,7 @@ func TestCreateApn(t *testing.T) {
 
 func TestListApns(t *testing.T) {
 	configuratorTestInit.StartTestService(t)
-	err := configurator.CreateNetwork(configurator.Network{ID: "n1"}, serdes.Network)
+	err := configurator.CreateNetwork(context.Background(), configurator.Network{ID: "n1"}, serdes.Network)
 	assert.NoError(t, err)
 
 	e := echo.New()
@@ -2853,7 +2851,7 @@ func TestListApns(t *testing.T) {
 
 func TestGetApn(t *testing.T) {
 	configuratorTestInit.StartTestService(t)
-	err := configurator.CreateNetwork(configurator.Network{ID: "n1"}, serdes.Network)
+	err := configurator.CreateNetwork(context.Background(), configurator.Network{ID: "n1"}, serdes.Network)
 	assert.NoError(t, err)
 
 	e := echo.New()
@@ -2921,7 +2919,7 @@ func TestGetApn(t *testing.T) {
 
 func TestUpdateApn(t *testing.T) {
 	configuratorTestInit.StartTestService(t)
-	err := configurator.CreateNetwork(configurator.Network{ID: "n1"}, serdes.Network)
+	err := configurator.CreateNetwork(context.Background(), configurator.Network{ID: "n1"}, serdes.Network)
 	assert.NoError(t, err)
 
 	e := echo.New()
@@ -3006,7 +3004,7 @@ func TestUpdateApn(t *testing.T) {
 
 func TestDeleteApn(t *testing.T) {
 	configuratorTestInit.StartTestService(t)
-	err := configurator.CreateNetwork(configurator.Network{ID: "n1"}, serdes.Network)
+	err := configurator.CreateNetwork(context.Background(), configurator.Network{ID: "n1"}, serdes.Network)
 	assert.NoError(t, err)
 
 	e := echo.New()
@@ -3091,7 +3089,7 @@ func TestAPNResource(t *testing.T) {
 	configuratorTestInit.StartTestService(t)
 	stateTestInit.StartTestService(t)
 	deviceTestInit.StartTestService(t)
-	err := configurator.CreateNetwork(configurator.Network{ID: "n0"}, serdes.Network)
+	err := configurator.CreateNetwork(context.Background(), configurator.Network{ID: "n0"}, serdes.Network)
 	assert.NoError(t, err)
 	_, err = configurator.CreateEntity("n0", configurator.NetworkEntity{Type: orc8r.UpgradeTierEntityType, Key: "t0"}, serdes.Entity)
 	assert.NoError(t, err)
@@ -3416,7 +3414,7 @@ func TestAPNResource_Regression_3088(t *testing.T) {
 	configuratorTestInit.StartTestService(t)
 	stateTestInit.StartTestService(t)
 	deviceTestInit.StartTestService(t)
-	err := configurator.CreateNetwork(configurator.Network{ID: "n0"}, serdes.Network)
+	err := configurator.CreateNetwork(context.Background(), configurator.Network{ID: "n0"}, serdes.Network)
 	assert.NoError(t, err)
 	_, err = configurator.CreateEntity("n0", configurator.NetworkEntity{Type: orc8r.UpgradeTierEntityType, Key: "t0"}, serdes.Entity)
 	assert.NoError(t, err)
@@ -3539,7 +3537,7 @@ func TestAPNResource_Regression_3149(t *testing.T) {
 	configuratorTestInit.StartTestService(t)
 	stateTestInit.StartTestService(t)
 	deviceTestInit.StartTestService(t)
-	err := configurator.CreateNetwork(configurator.Network{ID: "n0"}, serdes.Network)
+	err := configurator.CreateNetwork(context.Background(), configurator.Network{ID: "n0"}, serdes.Network)
 	assert.NoError(t, err)
 	_, err = configurator.CreateEntity("n0", configurator.NetworkEntity{Type: orc8r.UpgradeTierEntityType, Key: "t0"}, serdes.Entity)
 	assert.NoError(t, err)
@@ -4065,36 +4063,33 @@ func reportEnodebState(t *testing.T, ctx context.Context, enodebSerial string, r
 
 // n1, n3 are lte networks, n2 is not
 func seedNetworks(t *testing.T) {
-	_, err := configurator.CreateNetworks(
-		[]configurator.Network{
-			{
-				ID:          "n1",
-				Type:        lte.NetworkType,
-				Name:        "foobar",
-				Description: "Foo Bar",
-				Configs: map[string]interface{}{
-					lte.CellularNetworkConfigType: lteModels.NewDefaultTDDNetworkConfig(),
-					orc8r.NetworkFeaturesConfig:   models.NewDefaultFeaturesConfig(),
-					orc8r.DnsdNetworkType:         models.NewDefaultDNSConfig(),
-				},
-			},
-			{
-				ID:          "n2",
-				Type:        "blah",
-				Name:        "foobar",
-				Description: "Foo Bar",
-				Configs:     map[string]interface{}{},
-			},
-			{
-				ID:          "n3",
-				Type:        lte.NetworkType,
-				Name:        "barfoo",
-				Description: "Bar Foo",
-				Configs:     map[string]interface{}{},
+	_, err := configurator.CreateNetworks(context.Background(), []configurator.Network{
+		{
+			ID:          "n1",
+			Type:        lte.NetworkType,
+			Name:        "foobar",
+			Description: "Foo Bar",
+			Configs: map[string]interface{}{
+				lte.CellularNetworkConfigType: lteModels.NewDefaultTDDNetworkConfig(),
+				orc8r.NetworkFeaturesConfig:   models.NewDefaultFeaturesConfig(),
+				orc8r.DnsdNetworkType:         models.NewDefaultDNSConfig(),
 			},
 		},
-		serdes.Network,
-	)
+		{
+			ID:          "n2",
+			Type:        "blah",
+			Name:        "foobar",
+			Description: "Foo Bar",
+			Configs:     map[string]interface{}{},
+		},
+		{
+			ID:          "n3",
+			Type:        lte.NetworkType,
+			Name:        "barfoo",
+			Description: "Bar Foo",
+			Configs:     map[string]interface{}{},
+		},
+	}, serdes.Network)
 	assert.NoError(t, err)
 }
 

--- a/lte/cloud/go/services/lte/obsidian/models/validate.go
+++ b/lte/cloud/go/services/lte/obsidian/models/validate.go
@@ -14,6 +14,7 @@
 package models
 
 import (
+	"context"
 	"fmt"
 	"net"
 
@@ -27,23 +28,23 @@ import (
 	"github.com/pkg/errors"
 )
 
-func (m *LteNetwork) ValidateModel() error {
+func (m *LteNetwork) ValidateModel(context.Context) error {
 	if err := m.Validate(strfmt.Default); err != nil {
 		return err
 	}
 
 	var res []error
-	if err := m.Cellular.ValidateModel(); err != nil {
+	if err := m.Cellular.ValidateModel(context.Background()); err != nil {
 		res = append(res, err)
 	}
-	if err := m.DNS.ValidateModel(); err != nil {
+	if err := m.DNS.ValidateModel(context.Background()); err != nil {
 		res = append(res, err)
 	}
-	if err := m.Features.ValidateModel(); err != nil {
+	if err := m.Features.ValidateModel(context.Background()); err != nil {
 		res = append(res, err)
 	}
 	if m.SubscriberConfig != nil {
-		if err := m.SubscriberConfig.ValidateModel(); err != nil {
+		if err := m.SubscriberConfig.ValidateModel(context.Background()); err != nil {
 			res = append(res, err)
 		}
 	}
@@ -54,28 +55,28 @@ func (m *LteNetwork) ValidateModel() error {
 	return nil
 }
 
-func (m *NetworkCellularConfigs) ValidateModel() error {
+func (m *NetworkCellularConfigs) ValidateModel(ctx context.Context) error {
 	if err := m.Validate(strfmt.Default); err != nil {
 		return err
 	}
-	if err := m.FegNetworkID.ValidateModel(); err != nil {
+	if err := m.FegNetworkID.ValidateModel(ctx); err != nil {
 		return err
 	}
-	if err := m.Epc.ValidateModel(); err != nil {
+	if err := m.Epc.ValidateModel(ctx); err != nil {
 		return err
 	}
-	if err := m.Ran.ValidateModel(); err != nil {
+	if err := m.Ran.ValidateModel(ctx); err != nil {
 		return err
 	}
 	return nil
 }
 
-func (m FegNetworkID) ValidateModel() error {
+func (m FegNetworkID) ValidateModel(ctx context.Context) error {
 	if err := m.Validate(strfmt.Default); err != nil {
 		return err
 	}
 	if !swag.IsZero(m) {
-		exists, err := configurator.DoesNetworkExist(string(m))
+		exists, err := configurator.DoesNetworkExist(ctx, string(m))
 		if err != nil {
 			return errors.Wrap(err, fmt.Sprintf("Failed to search for network %s", string(m)))
 		}
@@ -86,7 +87,7 @@ func (m FegNetworkID) ValidateModel() error {
 	return nil
 }
 
-func (m *NetworkEpcConfigs) ValidateModel() error {
+func (m *NetworkEpcConfigs) ValidateModel(context.Context) error {
 	if err := m.Validate(strfmt.Default); err != nil {
 		return err
 	}
@@ -105,7 +106,7 @@ func (m *NetworkEpcConfigs) ValidateModel() error {
 	return nil
 }
 
-func (m *NetworkRanConfigs) ValidateModel() error {
+func (m *NetworkRanConfigs) ValidateModel(context.Context) error {
 	if err := m.Validate(strfmt.Default); err != nil {
 		return err
 	}
@@ -196,21 +197,21 @@ func validateIPBlocks(ipBlocks []string) error {
 	return nil
 }
 
-func (m *LteGateway) ValidateModel() error {
+func (m *LteGateway) ValidateModel(context.Context) error {
 	return m.Validate(strfmt.Default)
 }
 
-func (m *MutableLteGateway) ValidateModel() error {
+func (m *MutableLteGateway) ValidateModel(context.Context) error {
 	if err := m.Validate(strfmt.Default); err != nil {
 		return err
 	}
 
 	// Custom validation only for cellular and device
 	var res []error
-	if err := m.Cellular.ValidateModel(); err != nil {
+	if err := m.Cellular.ValidateModel(context.Background()); err != nil {
 		res = append(res, err)
 	}
-	if err := m.Device.ValidateModel(); err != nil {
+	if err := m.Device.ValidateModel(context.Background()); err != nil {
 		res = append(res, err)
 	}
 
@@ -231,7 +232,7 @@ func (m *MutableLteGateway) ValidateModel() error {
 	return nil
 }
 
-func (m *GatewayCellularConfigs) ValidateModel() error {
+func (m *GatewayCellularConfigs) ValidateModel(ctx context.Context) error {
 	if err := m.Validate(strfmt.Default); err != nil {
 		return err
 	}
@@ -241,17 +242,17 @@ func (m *GatewayCellularConfigs) ValidateModel() error {
 	if m.NonEpsService == nil {
 		return nil
 	}
-	if err := m.NonEpsService.ValidateModel(); err != nil {
+	if err := m.NonEpsService.ValidateModel(ctx); err != nil {
 		return err
 	}
 	return nil
 }
 
-func (m *GatewayRanConfigs) ValidateModel() error {
+func (m *GatewayRanConfigs) ValidateModel(context.Context) error {
 	return m.Validate(strfmt.Default)
 }
 
-func (m *GatewayEpcConfigs) ValidateModel() error {
+func (m *GatewayEpcConfigs) ValidateModel(context.Context) error {
 	if err := m.Validate(strfmt.Default); err != nil {
 		return err
 	}
@@ -283,7 +284,7 @@ func (m *GatewayEpcConfigs) ValidateModel() error {
 	return nil
 }
 
-func (m *GatewayNonEpsConfigs) ValidateModel() error {
+func (m *GatewayNonEpsConfigs) ValidateModel(context.Context) error {
 	// Don't validate sub-fields if Non-EPS control is off
 	if swag.Uint32Value(m.NonEpsServiceControl) == 0 {
 		return nil
@@ -319,23 +320,23 @@ func (m *GatewayNonEpsConfigs) ValidateModel() error {
 	return nil
 }
 
-func (m *GatewayDNSConfigs) ValidateModel() error {
+func (m *GatewayDNSConfigs) ValidateModel(context.Context) error {
 	return m.Validate(strfmt.Default)
 }
 
-func (m *GatewayDNSRecords) ValidateModel() error {
+func (m *GatewayDNSRecords) ValidateModel(context.Context) error {
 	return m.Validate(strfmt.Default)
 }
 
-func (m *EnodebSerials) ValidateModel() error {
+func (m *EnodebSerials) ValidateModel(context.Context) error {
 	return m.Validate(strfmt.Default)
 }
 
-func (m *GatewayHeConfig) ValidateModel() error {
+func (m *GatewayHeConfig) ValidateModel(context.Context) error {
 	return m.Validate(strfmt.Default)
 }
 
-func (m *Enodeb) ValidateModel() error {
+func (m *Enodeb) ValidateModel(context.Context) error {
 	if err := m.Validate(strfmt.Default); err != nil {
 		return err
 	}
@@ -349,11 +350,11 @@ func (m *Enodeb) ValidateModel() error {
 	return nil
 }
 
-func (m *EnodebConfiguration) ValidateModel() error {
+func (m *EnodebConfiguration) ValidateModel(context.Context) error {
 	return m.Validate(strfmt.Default)
 }
 
-func (m *UnmanagedEnodebConfiguration) ValidateModel() error {
+func (m *UnmanagedEnodebConfiguration) ValidateModel(context.Context) error {
 	return m.Validate(strfmt.Default)
 }
 
@@ -380,35 +381,35 @@ func (m *EnodebConfig) validateEnodebConfig() error {
 	return nil
 }
 
-func (m *EnodebState) ValidateModel() error {
+func (m *EnodebState) ValidateModel(context.Context) error {
 	return m.Validate(strfmt.Default)
 }
 
-func (m *Apn) ValidateModel() error {
+func (m *Apn) ValidateModel(context.Context) error {
 	return m.Validate(strfmt.Default)
 }
 
-func (m *CellularGatewayPool) ValidateModel() error {
+func (m *CellularGatewayPool) ValidateModel(context.Context) error {
 	err := m.Validate(strfmt.Default)
 	if err != nil {
 		return err
 	}
-	return m.Config.ValidateModel()
+	return m.Config.ValidateModel(context.Background())
 }
 
-func (m *CellularGatewayPoolConfigs) ValidateModel() error {
+func (m *CellularGatewayPoolConfigs) ValidateModel(context.Context) error {
 	return m.Validate(strfmt.Default)
 }
 
-func (m *MutableCellularGatewayPool) ValidateModel() error {
+func (m *MutableCellularGatewayPool) ValidateModel(context.Context) error {
 	err := m.Validate(strfmt.Default)
 	if err != nil {
 		return err
 	}
-	return m.Config.ValidateModel()
+	return m.Config.ValidateModel(context.Background())
 }
 
-func (m *CellularGatewayPoolRecords) ValidateModel() error {
+func (m *CellularGatewayPoolRecords) ValidateModel(context.Context) error {
 	err := m.Validate(strfmt.Default)
 	if err != nil {
 		return err

--- a/lte/cloud/go/services/lte/obsidian/models/validate_test.go
+++ b/lte/cloud/go/services/lte/obsidian/models/validate_test.go
@@ -14,6 +14,7 @@
 package models
 
 import (
+	"context"
 	"testing"
 
 	"github.com/go-openapi/swag"
@@ -61,7 +62,7 @@ func TestGatewayNonEpsConfigs_ValidateModel(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		err := tc.cfg.ValidateModel()
+		err := tc.cfg.ValidateModel(context.Background())
 		if err == nil {
 			assert.Equal(t, "", tc.expectedError)
 		} else {

--- a/lte/cloud/go/services/lte/servicers/indexer_servicer_test.go
+++ b/lte/cloud/go/services/lte/servicers/indexer_servicer_test.go
@@ -106,7 +106,7 @@ func TestIndexerEnodebState(t *testing.T) {
 }
 
 func seedNetwork(t *testing.T, networkID string) {
-	err := configurator.CreateNetwork(configurator.Network{ID: networkID}, serdes.Network)
+	err := configurator.CreateNetwork(context2.Background(), configurator.Network{ID: networkID}, serdes.Network)
 	assert.NoError(t, err)
 }
 

--- a/lte/cloud/go/services/lte/servicers/provider_servicer_test.go
+++ b/lte/cloud/go/services/lte/servicers/provider_servicer_test.go
@@ -69,7 +69,7 @@ func TestLTEStreamProviderServicer_GetUpdates(t *testing.T) {
 }
 
 func initSubscriber(t *testing.T, hwID string) {
-	err := configurator.CreateNetwork(configurator.Network{ID: "n1"}, serdes.Network)
+	err := configurator.CreateNetwork(context.Background(), configurator.Network{ID: "n1"}, serdes.Network)
 	assert.NoError(t, err)
 
 	_, err = configurator.CreateEntity("n1", configurator.NetworkEntity{Type: orc8r.MagmadGatewayType, Key: "g1", PhysicalID: hwID}, serdes.Entity)

--- a/lte/cloud/go/services/nprobe/nprobe_manager/nprobe_manager.go
+++ b/lte/cloud/go/services/nprobe/nprobe_manager/nprobe_manager.go
@@ -195,7 +195,7 @@ func (np *NProbeManager) processNProbeTask(networkID string, task *models.Networ
 // For each task, it collects latest events, creates the corresponding IRI record then
 // export them to a remote destination.
 func (np *NProbeManager) ProcessNProbeTasks() error {
-	networks, err := configurator.ListNetworksOfType(LteNetwork)
+	networks, err := configurator.ListNetworksOfType(context.Background(), LteNetwork)
 	if err != nil {
 		glog.Errorf("Failed to retrieve lte network list: %s", err)
 		return err

--- a/lte/cloud/go/services/nprobe/obsidian/handlers/handlers.go
+++ b/lte/cloud/go/services/nprobe/obsidian/handlers/handlers.go
@@ -14,6 +14,7 @@
 package handlers
 
 import (
+	"context"
 	"math/rand"
 	"net/http"
 	"time"
@@ -96,7 +97,7 @@ func getCreateNetworkProbeTaskHandlerFunc(storage storage.NProbeStorage) echo.Ha
 		if err := c.Bind(payload); err != nil {
 			return obsidian.HttpError(err, http.StatusBadRequest)
 		}
-		if err := payload.ValidateModel(); err != nil {
+		if err := payload.ValidateModel(context.Background()); err != nil {
 			return obsidian.HttpError(err, http.StatusBadRequest)
 		}
 
@@ -167,7 +168,7 @@ func updateNetworkProbeTask(c echo.Context) error {
 	if err := c.Bind(payload); err != nil {
 		return obsidian.HttpError(err, http.StatusBadRequest)
 	}
-	if err := payload.ValidateModel(); err != nil {
+	if err := payload.ValidateModel(context.Background()); err != nil {
 		return obsidian.HttpError(err, http.StatusBadRequest)
 	}
 
@@ -228,7 +229,7 @@ func createNetworkProbeDestination(c echo.Context) error {
 	if err := c.Bind(payload); err != nil {
 		return obsidian.HttpError(err, http.StatusBadRequest)
 	}
-	if err := payload.ValidateModel(); err != nil {
+	if err := payload.ValidateModel(context.Background()); err != nil {
 		return obsidian.HttpError(err, http.StatusBadRequest)
 	}
 
@@ -281,7 +282,7 @@ func updateNetworkProbeDestination(c echo.Context) error {
 	if err := c.Bind(payload); err != nil {
 		return obsidian.HttpError(err, http.StatusBadRequest)
 	}
-	if err := payload.ValidateModel(); err != nil {
+	if err := payload.ValidateModel(context.Background()); err != nil {
 		return obsidian.HttpError(err, http.StatusBadRequest)
 	}
 

--- a/lte/cloud/go/services/nprobe/obsidian/handlers/handlers_test.go
+++ b/lte/cloud/go/services/nprobe/obsidian/handlers/handlers_test.go
@@ -14,6 +14,7 @@
 package handlers_test
 
 import (
+	context2 "context"
 	"testing"
 	"time"
 
@@ -48,7 +49,7 @@ func getNProbeBlobstore(t *testing.T) storage.NProbeStorage {
 
 func TestCreateNetworkProbeTask(t *testing.T) {
 	configuratorTestInit.StartTestService(t)
-	err := configurator.CreateNetwork(configurator.Network{ID: "n1"}, serdes.Network)
+	err := configurator.CreateNetwork(context2.Background(), configurator.Network{ID: "n1"}, serdes.Network)
 	assert.NoError(t, err)
 
 	e := echo.New()
@@ -99,7 +100,7 @@ func TestCreateNetworkProbeTask(t *testing.T) {
 
 func TestListNetworkProbeTasks(t *testing.T) {
 	configuratorTestInit.StartTestService(t)
-	err := configurator.CreateNetwork(configurator.Network{ID: "n1"}, serdes.Network)
+	err := configurator.CreateNetwork(context2.Background(), configurator.Network{ID: "n1"}, serdes.Network)
 	assert.NoError(t, err)
 
 	e := echo.New()
@@ -179,7 +180,7 @@ func TestListNetworkProbeTasks(t *testing.T) {
 
 func TestGetNetworkProbeTask(t *testing.T) {
 	configuratorTestInit.StartTestService(t)
-	err := configurator.CreateNetwork(configurator.Network{ID: "n1"}, serdes.Network)
+	err := configurator.CreateNetwork(context2.Background(), configurator.Network{ID: "n1"}, serdes.Network)
 	assert.NoError(t, err)
 
 	e := echo.New()
@@ -236,7 +237,7 @@ func TestGetNetworkProbeTask(t *testing.T) {
 
 func TestUpdateNetworkProbeTask(t *testing.T) {
 	configuratorTestInit.StartTestService(t)
-	err := configurator.CreateNetwork(configurator.Network{ID: "n1"}, serdes.Network)
+	err := configurator.CreateNetwork(context2.Background(), configurator.Network{ID: "n1"}, serdes.Network)
 	assert.NoError(t, err)
 
 	e := echo.New()
@@ -310,7 +311,7 @@ func TestUpdateNetworkProbeTask(t *testing.T) {
 
 func TestDeleteNetworkProbeTask(t *testing.T) {
 	configuratorTestInit.StartTestService(t)
-	err := configurator.CreateNetwork(configurator.Network{ID: "n1"}, serdes.Network)
+	err := configurator.CreateNetwork(context2.Background(), configurator.Network{ID: "n1"}, serdes.Network)
 	assert.NoError(t, err)
 
 	e := echo.New()
@@ -377,7 +378,7 @@ func TestDeleteNetworkProbeTask(t *testing.T) {
 
 func TestCreateNetworkProbeDestination(t *testing.T) {
 	configuratorTestInit.StartTestService(t)
-	err := configurator.CreateNetwork(configurator.Network{ID: "n1"}, serdes.Network)
+	err := configurator.CreateNetwork(context2.Background(), configurator.Network{ID: "n1"}, serdes.Network)
 	assert.NoError(t, err)
 
 	e := echo.New()
@@ -421,7 +422,7 @@ func TestCreateNetworkProbeDestination(t *testing.T) {
 
 func TestListNetworkProbeDestinations(t *testing.T) {
 	configuratorTestInit.StartTestService(t)
-	err := configurator.CreateNetwork(configurator.Network{ID: "n1"}, serdes.Network)
+	err := configurator.CreateNetwork(context2.Background(), configurator.Network{ID: "n1"}, serdes.Network)
 	assert.NoError(t, err)
 
 	e := echo.New()
@@ -493,7 +494,7 @@ func TestListNetworkProbeDestinations(t *testing.T) {
 
 func TestGetNetworkProbeDestination(t *testing.T) {
 	configuratorTestInit.StartTestService(t)
-	err := configurator.CreateNetwork(configurator.Network{ID: "n1"}, serdes.Network)
+	err := configurator.CreateNetwork(context2.Background(), configurator.Network{ID: "n1"}, serdes.Network)
 	assert.NoError(t, err)
 
 	e := echo.New()
@@ -546,7 +547,7 @@ func TestGetNetworkProbeDestination(t *testing.T) {
 
 func TestUpdateNetworkProbeDestination(t *testing.T) {
 	configuratorTestInit.StartTestService(t)
-	err := configurator.CreateNetwork(configurator.Network{ID: "n1"}, serdes.Network)
+	err := configurator.CreateNetwork(context2.Background(), configurator.Network{ID: "n1"}, serdes.Network)
 	assert.NoError(t, err)
 
 	e := echo.New()
@@ -619,7 +620,7 @@ func TestUpdateNetworkProbeDestination(t *testing.T) {
 
 func TestDeleteNetworkProbeDestination(t *testing.T) {
 	configuratorTestInit.StartTestService(t)
-	err := configurator.CreateNetwork(configurator.Network{ID: "n1"}, serdes.Network)
+	err := configurator.CreateNetwork(context2.Background(), configurator.Network{ID: "n1"}, serdes.Network)
 	assert.NoError(t, err)
 
 	e := echo.New()

--- a/lte/cloud/go/services/nprobe/obsidian/models/validate.go
+++ b/lte/cloud/go/services/nprobe/obsidian/models/validate.go
@@ -14,13 +14,15 @@
 package models
 
 import (
+	"context"
+
 	strfmt "github.com/go-openapi/strfmt"
 )
 
-func (m *NetworkProbeTask) ValidateModel() error {
+func (m *NetworkProbeTask) ValidateModel(context.Context) error {
 	return m.Validate(strfmt.Default)
 }
 
-func (m *NetworkProbeDestination) ValidateModel() error {
+func (m *NetworkProbeDestination) ValidateModel(context.Context) error {
 	return m.Validate(strfmt.Default)
 }

--- a/lte/cloud/go/services/policydb/obsidian/handlers/policy_handlers.go
+++ b/lte/cloud/go/services/policydb/obsidian/handlers/policy_handlers.go
@@ -14,6 +14,7 @@
 package handlers
 
 import (
+	"context"
 	"net/http"
 	"sort"
 	"strings"
@@ -44,6 +45,7 @@ func ListBaseNames(c echo.Context) error {
 		return nerr
 	}
 
+	reqCtx := c.Request().Context()
 	view := c.QueryParam("view")
 	if strings.ToLower(view) == "full" {
 		baseNames, _, err := configurator.LoadAllEntitiesOfType(
@@ -61,7 +63,7 @@ func ListBaseNames(c echo.Context) error {
 		}
 		return c.JSON(http.StatusOK, ret)
 	} else {
-		names, err := configurator.ListEntityKeys(networkID, lte.BaseNameEntityType)
+		names, err := configurator.ListEntityKeys(reqCtx, networkID, lte.BaseNameEntityType)
 		if err != nil {
 			return obsidian.HttpError(err, http.StatusInternalServerError)
 		}
@@ -220,6 +222,7 @@ func ListRules(c echo.Context) error {
 	}
 
 	view := c.QueryParam("view")
+	reqCtx := c.Request().Context()
 	if strings.ToLower(view) == "full" {
 		rules, _, err := configurator.LoadAllEntitiesOfType(
 			networkID, lte.PolicyRuleEntityType,
@@ -236,7 +239,7 @@ func ListRules(c echo.Context) error {
 		}
 		return c.JSON(http.StatusOK, ret)
 	} else {
-		ruleIDs, err := configurator.ListEntityKeys(networkID, lte.PolicyRuleEntityType)
+		ruleIDs, err := configurator.ListEntityKeys(reqCtx, networkID, lte.PolicyRuleEntityType)
 		if err != nil {
 			return obsidian.HttpError(err, http.StatusInternalServerError)
 		}
@@ -255,7 +258,7 @@ func CreateRule(c echo.Context) error {
 	if err := c.Bind(rule); err != nil {
 		return obsidian.HttpError(err, http.StatusBadRequest)
 	}
-	if err := rule.ValidateModel(); err != nil {
+	if err := rule.ValidateModel(context.Background()); err != nil {
 		return obsidian.HttpError(err, http.StatusBadRequest)
 	}
 
@@ -323,7 +326,7 @@ func UpdateRule(c echo.Context) error {
 	if err := c.Bind(rule); err != nil {
 		return obsidian.HttpError(err, http.StatusBadRequest)
 	}
-	if err := rule.ValidateModel(); err != nil {
+	if err := rule.ValidateModel(context.Background()); err != nil {
 		return obsidian.HttpError(err, http.StatusBadRequest)
 	}
 	if ruleID != string(rule.ID) {
@@ -435,7 +438,7 @@ func createQoSProfile(c echo.Context) error {
 	if err := c.Bind(profile); err != nil {
 		return obsidian.HttpError(err, http.StatusBadRequest)
 	}
-	if err := profile.ValidateModel(); err != nil {
+	if err := profile.ValidateModel(context.Background()); err != nil {
 		return obsidian.HttpError(err, http.StatusBadRequest)
 	}
 

--- a/lte/cloud/go/services/policydb/obsidian/handlers/policy_handlers_test.go
+++ b/lte/cloud/go/services/policydb/obsidian/handlers/policy_handlers_test.go
@@ -14,6 +14,7 @@
 package handlers_test
 
 import (
+	context2 "context"
 	"fmt"
 	"testing"
 
@@ -38,7 +39,7 @@ func TestPolicyDBHandlersBasic(t *testing.T) {
 	e := echo.New()
 
 	obsidianHandlers := handlers.GetHandlers()
-	err := configurator.CreateNetwork(configurator.Network{ID: "n1", Type: lte.NetworkType}, serdes.Network)
+	err := configurator.CreateNetwork(context2.Background(), configurator.Network{ID: "n1", Type: lte.NetworkType}, serdes.Network)
 	assert.NoError(t, err)
 
 	listPolicies := tests.GetHandlerByPathAndMethod(t, obsidianHandlers, "/magma/v1/networks/:network_id/policies/rules", obsidian.GET).HandlerFunc
@@ -650,7 +651,7 @@ func TestPolicyHandlersAssociations(t *testing.T) {
 	e := echo.New()
 
 	obsidianHandlers := handlers.GetHandlers()
-	err := configurator.CreateNetwork(configurator.Network{ID: "n1", Type: lte.NetworkType}, serdes.Network)
+	err := configurator.CreateNetwork(context2.Background(), configurator.Network{ID: "n1", Type: lte.NetworkType}, serdes.Network)
 	assert.NoError(t, err)
 
 	createPolicy := tests.GetHandlerByPathAndMethod(t, obsidianHandlers, "/magma/v1/networks/:network_id/policies/rules", obsidian.POST).HandlerFunc
@@ -873,7 +874,7 @@ func TestQoSProfile(t *testing.T) {
 	e := echo.New()
 
 	policydbHandlers := handlers.GetHandlers()
-	err := configurator.CreateNetwork(configurator.Network{ID: "n1", Type: lte.NetworkType}, serdes.Network)
+	err := configurator.CreateNetwork(context2.Background(), configurator.Network{ID: "n1", Type: lte.NetworkType}, serdes.Network)
 	assert.NoError(t, err)
 
 	getAllProfiles := tests.GetHandlerByPathAndMethod(t, policydbHandlers, "/magma/v1/lte/:network_id/policy_qos_profiles", obsidian.GET).HandlerFunc
@@ -1093,7 +1094,7 @@ func TestPolicyWithQoSProfile(t *testing.T) {
 	e := echo.New()
 
 	policydbHandlers := handlers.GetHandlers()
-	err := configurator.CreateNetwork(configurator.Network{ID: "n1", Type: lte.NetworkType}, serdes.Network)
+	err := configurator.CreateNetwork(context2.Background(), configurator.Network{ID: "n1", Type: lte.NetworkType}, serdes.Network)
 	assert.NoError(t, err)
 
 	postProfile := tests.GetHandlerByPathAndMethod(t, policydbHandlers, "/magma/v1/lte/:network_id/policy_qos_profiles", obsidian.POST).HandlerFunc

--- a/lte/cloud/go/services/policydb/obsidian/handlers/rating_groups_handlers.go
+++ b/lte/cloud/go/services/policydb/obsidian/handlers/rating_groups_handlers.go
@@ -14,6 +14,7 @@
 package handlers
 
 import (
+	"context"
 	"net/http"
 
 	"magma/lte/cloud/go/lte"
@@ -65,7 +66,7 @@ func CreateRatingGroup(c echo.Context) error {
 	if err := c.Bind(group); err != nil {
 		return obsidian.HttpError(err, http.StatusBadRequest)
 	}
-	if err := group.ValidateModel(); err != nil {
+	if err := group.ValidateModel(context.Background()); err != nil {
 		return obsidian.HttpError(err, http.StatusBadRequest)
 	}
 
@@ -107,7 +108,7 @@ func UpdateRatingGroup(c echo.Context) error {
 	if err := c.Bind(ratingGroup); err != nil {
 		return obsidian.HttpError(err, http.StatusBadRequest)
 	}
-	if err := ratingGroup.ValidateModel(); err != nil {
+	if err := ratingGroup.ValidateModel(context.Background()); err != nil {
 		return obsidian.HttpError(err, http.StatusBadRequest)
 	}
 	groupID, err := swag.ConvertUint32(ratingGroupID)

--- a/lte/cloud/go/services/policydb/obsidian/handlers/rating_groups_handlers_test.go
+++ b/lte/cloud/go/services/policydb/obsidian/handlers/rating_groups_handlers_test.go
@@ -14,6 +14,7 @@
 package handlers_test
 
 import (
+	context2 "context"
 	"testing"
 
 	"magma/lte/cloud/go/lte"
@@ -36,7 +37,7 @@ func TestRatingGroupHandlersBasic(t *testing.T) {
 	e := echo.New()
 
 	obsidianHandlers := handlers.GetHandlers()
-	err := configurator.CreateNetwork(configurator.Network{ID: "n1", Type: lte.NetworkType}, serdes.Network)
+	err := configurator.CreateNetwork(context2.Background(), configurator.Network{ID: "n1", Type: lte.NetworkType}, serdes.Network)
 	assert.NoError(t, err)
 
 	listRatingGroups := tests.GetHandlerByPathAndMethod(t, obsidianHandlers, "/magma/v1/networks/:network_id/rating_groups", obsidian.GET).HandlerFunc

--- a/lte/cloud/go/services/policydb/obsidian/models/validate.go
+++ b/lte/cloud/go/services/policydb/obsidian/models/validate.go
@@ -14,22 +14,24 @@
 package models
 
 import (
+	"context"
+
 	"github.com/go-openapi/strfmt"
 	"github.com/pkg/errors"
 )
 
-func (m BaseNames) ValidateModel() error {
+func (m BaseNames) ValidateModel(context.Context) error {
 	return m.Validate(strfmt.Default)
 }
 
-func (m RuleNames) ValidateModel() error {
+func (m RuleNames) ValidateModel(context.Context) error {
 	return m.Validate(strfmt.Default)
 }
 
-func (m *PolicyRule) ValidateModel() error {
+func (m *PolicyRule) ValidateModel(context.Context) error {
 	for _, flow := range m.FlowList {
 		if flow.Match != nil {
-			errMatch := flow.Match.ValidateModel()
+			errMatch := flow.Match.ValidateModel(context.Background())
 			if errMatch != nil {
 				return errMatch
 			}
@@ -38,25 +40,25 @@ func (m *PolicyRule) ValidateModel() error {
 	return m.Validate(strfmt.Default)
 }
 
-func (m *FlowMatch) ValidateModel() error {
+func (m *FlowMatch) ValidateModel(context.Context) error {
 	if (m.IPV4Dst != "" || m.IPV4Src != "") && (m.IPSrc != nil || m.IPDst != nil) {
 		return errors.New("Invalid Argument: Can't mix old ipv4_src/ipv4_dst type with the new ip_src/ip_dst")
 	}
 	return m.Validate(strfmt.Default)
 }
 
-func (m *RatingGroup) ValidateModel() error {
+func (m *RatingGroup) ValidateModel(context.Context) error {
 	return m.Validate(strfmt.Default)
 }
 
-func (m *MutableRatingGroup) ValidateModel() error {
+func (m *MutableRatingGroup) ValidateModel(context.Context) error {
 	return m.Validate(strfmt.Default)
 }
 
-func (m *NetworkSubscriberConfig) ValidateModel() error {
+func (m *NetworkSubscriberConfig) ValidateModel(context.Context) error {
 	return m.Validate(strfmt.Default)
 }
 
-func (m *PolicyQosProfile) ValidateModel() error {
+func (m *PolicyQosProfile) ValidateModel(context.Context) error {
 	return m.Validate(strfmt.Default)
 }

--- a/lte/cloud/go/services/policydb/servicers/assignments_test.go
+++ b/lte/cloud/go/services/policydb/servicers/assignments_test.go
@@ -14,6 +14,7 @@ limitations under the License.
 package servicers_test
 
 import (
+	context2 "context"
 	"testing"
 
 	"magma/lte/cloud/go/lte"
@@ -46,7 +47,7 @@ func TestAssignmentsServicer(t *testing.T) {
 	testBaseName := "b1"
 
 	// Initialize network
-	err := configurator.CreateNetwork(configurator.Network{ID: testNetworkId}, serdes.Network)
+	err := configurator.CreateNetwork(context2.Background(), configurator.Network{ID: testNetworkId}, serdes.Network)
 	assert.NoError(t, err)
 
 	// Initialize gateway -> subscriber, and create a policy rule

--- a/lte/cloud/go/services/policydb/streamer/providers.go
+++ b/lte/cloud/go/services/policydb/streamer/providers.go
@@ -323,7 +323,7 @@ func (p *NetworkWideRulesProvider) GetUpdates(ctx context.Context, gatewayId str
 	if err != nil {
 		return nil, err
 	}
-	iNetworkSubscriberConfig, err := configurator.LoadNetworkConfig(gwEnt.NetworkID, lte.NetworkSubscriberConfigType, serdes.Network)
+	iNetworkSubscriberConfig, err := configurator.LoadNetworkConfig(ctx, gwEnt.NetworkID, lte.NetworkSubscriberConfigType, serdes.Network)
 	if err == merrors.ErrNotFound {
 		return []*protos.DataUpdate{}, nil
 	}

--- a/lte/cloud/go/services/policydb/streamer/providers_test.go
+++ b/lte/cloud/go/services/policydb/streamer/providers_test.go
@@ -44,7 +44,7 @@ func TestRatingGroupStreamers(t *testing.T) {
 	provider, err := providers.GetStreamProvider(lte.RatingGroupStreamName)
 	assert.NoError(t, err)
 
-	err = configurator.CreateNetwork(configurator.Network{ID: "n1"}, serdes.Network)
+	err = configurator.CreateNetwork(context.Background(), configurator.Network{ID: "n1"}, serdes.Network)
 	assert.NoError(t, err)
 	_, err = configurator.CreateEntity(
 		"n1",
@@ -120,7 +120,7 @@ func TestPolicyStreamers(t *testing.T) {
 	provider, err := providers.GetStreamProvider(lte.PolicyStreamName)
 	assert.NoError(t, err)
 
-	err = configurator.CreateNetwork(configurator.Network{ID: "n1"}, serdes.Network)
+	err = configurator.CreateNetwork(context.Background(), configurator.Network{ID: "n1"}, serdes.Network)
 	assert.NoError(t, err)
 	_, err = configurator.CreateEntity(
 		"n1",
@@ -332,7 +332,7 @@ func TestApnRuleMappingsProvider(t *testing.T) {
 	provider, err := providers.GetStreamProvider(lte.ApnRuleMappingsStreamName)
 	assert.NoError(t, err)
 
-	err = configurator.CreateNetwork(configurator.Network{ID: "n1"}, serdes.Network)
+	err = configurator.CreateNetwork(context.Background(), configurator.Network{ID: "n1"}, serdes.Network)
 	assert.NoError(t, err)
 	_, err = configurator.CreateEntity(
 		"n1",
@@ -479,7 +479,7 @@ func TestNetworkWideRulesProvider(t *testing.T) {
 	provider, err := providers.GetStreamProvider(lte.NetworkWideRulesStreamName)
 	assert.NoError(t, err)
 
-	err = configurator.CreateNetwork(configurator.Network{ID: "n1"}, serdes.Network)
+	err = configurator.CreateNetwork(context.Background(), configurator.Network{ID: "n1"}, serdes.Network)
 	assert.NoError(t, err)
 	_, err = configurator.CreateEntity(
 		"n1",
@@ -506,7 +506,7 @@ func TestNetworkWideRulesProvider(t *testing.T) {
 		NetworkWideBaseNames: []models.BaseName{"b1", "b2"},
 		NetworkWideRuleNames: []string{"r1", "r2"},
 	}
-	assert.NoError(t, configurator.UpdateNetworkConfig("n1", lte.NetworkSubscriberConfigType, config, serdes.Network))
+	assert.NoError(t, configurator.UpdateNetworkConfig(context.Background(), "n1", lte.NetworkSubscriberConfigType, config, serdes.Network))
 
 	expectedProtos := []*lte_protos.AssignedPolicies{
 		{

--- a/lte/cloud/go/services/smsd/obsidian/models/conversion.go
+++ b/lte/cloud/go/services/smsd/obsidian/models/conversion.go
@@ -1,6 +1,8 @@
 package models
 
 import (
+	"context"
+
 	"magma/lte/cloud/go/services/policydb/obsidian/models"
 	"magma/lte/cloud/go/services/smsd/storage"
 
@@ -36,7 +38,7 @@ func (m *SmsMessage) FromProto(from *storage.SMS) *SmsMessage {
 	return m
 }
 
-func (m *MutableSmsMessage) ValidateModel() error {
+func (m *MutableSmsMessage) ValidateModel(context.Context) error {
 	return m.Validate(strfmt.Default)
 }
 

--- a/lte/cloud/go/services/smsd/servicers/smsd_rest.go
+++ b/lte/cloud/go/services/smsd/servicers/smsd_rest.go
@@ -1,6 +1,7 @@
 package servicers
 
 import (
+	"context"
 	"net/http"
 
 	lteHandlers "magma/lte/cloud/go/services/lte/obsidian/handlers"
@@ -79,7 +80,7 @@ func (s *SMSDRestServicer) createMessage(c echo.Context) error {
 	if err := c.Bind(payload); err != nil {
 		return obsidian.HttpError(err, http.StatusBadRequest)
 	}
-	if err := payload.ValidateModel(); err != nil {
+	if err := payload.ValidateModel(context.Background()); err != nil {
 		return obsidian.HttpError(err, http.StatusBadRequest)
 	}
 

--- a/lte/cloud/go/services/subscriberdb/digest_test.go
+++ b/lte/cloud/go/services/subscriberdb/digest_test.go
@@ -14,6 +14,7 @@ limitations under the License.
 package subscriberdb_test
 
 import (
+	context2 "context"
 	"fmt"
 	"testing"
 
@@ -36,7 +37,7 @@ func TestGetDigestDeterministic(t *testing.T) {
 	lte_test_init.StartTestService(t)
 	configurator_test_init.StartTestService(t)
 
-	err := configurator.CreateNetwork(configurator.Network{ID: "n1"}, serdes.Network)
+	err := configurator.CreateNetwork(context2.Background(), configurator.Network{ID: "n1"}, serdes.Network)
 	assert.NoError(t, err)
 	_, err = configurator.CreateEntity("n1", configurator.NetworkEntity{Type: orc8r.MagmadGatewayType, Key: "g1", PhysicalID: "hw1"}, serdes.Entity)
 	assert.NoError(t, err)
@@ -124,7 +125,7 @@ func TestGetDigestApnResourceAssocs(t *testing.T) {
 	lte_test_init.StartTestService(t)
 	configurator_test_init.StartTestService(t)
 
-	err := configurator.CreateNetwork(configurator.Network{ID: "n1"}, serdes.Network)
+	err := configurator.CreateNetwork(context2.Background(), configurator.Network{ID: "n1"}, serdes.Network)
 	assert.NoError(t, err)
 	gw1, err := configurator.CreateEntity("n1", configurator.NetworkEntity{Type: lte.CellularGatewayEntityType, Key: "g1"}, serdes.Entity)
 	assert.NoError(t, err)
@@ -259,7 +260,7 @@ func TestGetPerSubscriberDigests(t *testing.T) {
 	lte_test_init.StartTestService(t)
 	configurator_test_init.StartTestService(t)
 
-	err := configurator.CreateNetwork(configurator.Network{ID: "n1"}, serdes.Network)
+	err := configurator.CreateNetwork(context2.Background(), configurator.Network{ID: "n1"}, serdes.Network)
 	assert.NoError(t, err)
 	gw, err := configurator.CreateEntity("n1", configurator.NetworkEntity{Type: lte.CellularGatewayEntityType, Key: "g1"}, serdes.Entity)
 	assert.NoError(t, err)

--- a/lte/cloud/go/services/subscriberdb/obsidian/handlers/handlers_test.go
+++ b/lte/cloud/go/services/subscriberdb/obsidian/handlers/handlers_test.go
@@ -51,7 +51,7 @@ import (
 func TestCreateSubscriber(t *testing.T) {
 	configuratorTestInit.StartTestService(t)
 	deviceTestInit.StartTestService(t)
-	err := configurator.CreateNetwork(configurator.Network{ID: "n1"}, serdes.Network)
+	err := configurator.CreateNetwork(context.Background(), configurator.Network{ID: "n1"}, serdes.Network)
 	assert.NoError(t, err)
 
 	e := echo.New()
@@ -150,20 +150,16 @@ func TestCreateSubscriber(t *testing.T) {
 	assert.EqualError(t, err, "Not found")
 
 	// nonexistent sub profile should be 400
-	err = configurator.UpdateNetworkConfig(
-		"n1", lte.CellularNetworkConfigType,
-		&lteModels.NetworkCellularConfigs{
-			Epc: &lteModels.NetworkEpcConfigs{
-				SubProfiles: map[string]lteModels.NetworkEpcConfigsSubProfilesAnon{
-					"blah": {
-						MaxDlBitRate: 100,
-						MaxUlBitRate: 100,
-					},
+	err = configurator.UpdateNetworkConfig(context.Background(), "n1", lte.CellularNetworkConfigType, &lteModels.NetworkCellularConfigs{
+		Epc: &lteModels.NetworkEpcConfigs{
+			SubProfiles: map[string]lteModels.NetworkEpcConfigsSubProfilesAnon{
+				"blah": {
+					MaxDlBitRate: 100,
+					MaxUlBitRate: 100,
 				},
 			},
 		},
-		serdes.Network,
-	)
+	}, serdes.Network)
 	assert.NoError(t, err)
 	payload = &subscriberModels.MutableSubscriber{
 		ID: "IMSI0987654321",
@@ -247,7 +243,7 @@ func TestCreateSubscribers(t *testing.T) {
 			Epc: &lteModels.NetworkEpcConfigs{SubProfiles: map[string]lteModels.NetworkEpcConfigsSubProfilesAnon{"present-profile": {}}},
 		},
 	}
-	err := configurator.CreateNetwork(configurator.Network{ID: "n1", Configs: networkConfigs}, serdes.Network)
+	err := configurator.CreateNetwork(context.Background(), configurator.Network{ID: "n1", Configs: networkConfigs}, serdes.Network)
 	assert.NoError(t, err)
 
 	e := echo.New()
@@ -368,7 +364,7 @@ func TestListSubscribers(t *testing.T) {
 	configuratorTestInit.StartTestService(t)
 	deviceTestInit.StartTestService(t)
 	stateTestInit.StartTestService(t)
-	err := configurator.CreateNetwork(configurator.Network{ID: "n1"}, serdes.Network)
+	err := configurator.CreateNetwork(context.Background(), configurator.Network{ID: "n1"}, serdes.Network)
 	assert.NoError(t, err)
 
 	e := echo.New()
@@ -606,7 +602,7 @@ func TestListSubscribersV2(t *testing.T) {
 	configuratorTestInit.StartTestService(t)
 	deviceTestInit.StartTestService(t)
 	stateTestInit.StartTestService(t)
-	err := configurator.CreateNetwork(configurator.Network{ID: "n1"}, serdes.Network)
+	err := configurator.CreateNetwork(context.Background(), configurator.Network{ID: "n1"}, serdes.Network)
 	assert.NoError(t, err)
 
 	e := echo.New()
@@ -868,7 +864,7 @@ func TestGetSubscriber(t *testing.T) {
 	configuratorTestInit.StartTestService(t)
 	deviceTestInit.StartTestService(t)
 	stateTestInit.StartTestService(t)
-	err := configurator.CreateNetwork(configurator.Network{ID: "n1"}, serdes.Network)
+	err := configurator.CreateNetwork(context.Background(), configurator.Network{ID: "n1"}, serdes.Network)
 	assert.NoError(t, err)
 
 	e := echo.New()
@@ -1052,7 +1048,7 @@ func TestGetSubscriberByExactIMSI(t *testing.T) {
 	configuratorTestInit.StartTestService(t)
 	deviceTestInit.StartTestService(t)
 	stateTestInit.StartTestService(t)
-	err := configurator.CreateNetwork(configurator.Network{ID: "n1"}, serdes.Network)
+	err := configurator.CreateNetwork(context.Background(), configurator.Network{ID: "n1"}, serdes.Network)
 	assert.NoError(t, err)
 
 	e := echo.New()
@@ -1135,7 +1131,7 @@ func TestListSubscriberStates(t *testing.T) {
 	configuratorTestInit.StartTestService(t)
 	deviceTestInit.StartTestService(t)
 	stateTestInit.StartTestService(t)
-	err := configurator.CreateNetwork(configurator.Network{ID: "n0"}, serdes.Network)
+	err := configurator.CreateNetwork(context.Background(), configurator.Network{ID: "n0"}, serdes.Network)
 	assert.NoError(t, err)
 
 	e := echo.New()
@@ -1252,7 +1248,7 @@ func TestGetSubscriberState(t *testing.T) {
 	configuratorTestInit.StartTestService(t)
 	deviceTestInit.StartTestService(t)
 	stateTestInit.StartTestService(t)
-	err := configurator.CreateNetwork(configurator.Network{ID: "n0"}, serdes.Network)
+	err := configurator.CreateNetwork(context.Background(), configurator.Network{ID: "n0"}, serdes.Network)
 	assert.NoError(t, err)
 
 	e := echo.New()
@@ -1352,7 +1348,7 @@ func TestGetSubscriberByMSISDN(t *testing.T) {
 	deviceTestInit.StartTestService(t)
 	stateTestInit.StartTestService(t)
 	subscriberdbTestInit.StartTestService(t)
-	err := configurator.CreateNetwork(configurator.Network{ID: "n0"}, serdes.Network)
+	err := configurator.CreateNetwork(context.Background(), configurator.Network{ID: "n0"}, serdes.Network)
 	assert.NoError(t, err)
 
 	e := echo.New()
@@ -1510,7 +1506,7 @@ func TestGetSubscriberByIP(t *testing.T) {
 	deviceTestInit.StartTestService(t)
 	stateTestInit.StartTestService(t)
 	subscriberdbTestInit.StartTestService(t)
-	err := configurator.CreateNetwork(configurator.Network{ID: "n0"}, serdes.Network)
+	err := configurator.CreateNetwork(context.Background(), configurator.Network{ID: "n0"}, serdes.Network)
 	assert.NoError(t, err)
 
 	e := echo.New()
@@ -1649,7 +1645,7 @@ func TestGetSubscriberByIP(t *testing.T) {
 func TestUpdateSubscriber(t *testing.T) {
 	configuratorTestInit.StartTestService(t)
 	deviceTestInit.StartTestService(t)
-	err := configurator.CreateNetwork(configurator.Network{ID: "n1"}, serdes.Network)
+	err := configurator.CreateNetwork(context.Background(), configurator.Network{ID: "n1"}, serdes.Network)
 	assert.NoError(t, err)
 
 	e := echo.New()
@@ -1694,20 +1690,16 @@ func TestUpdateSubscriber(t *testing.T) {
 	tests.RunUnitTest(t, e, tc)
 
 	// Happy path
-	err = configurator.UpdateNetworkConfig(
-		"n1", lte.CellularNetworkConfigType,
-		&lteModels.NetworkCellularConfigs{
-			Epc: &lteModels.NetworkEpcConfigs{
-				SubProfiles: map[string]lteModels.NetworkEpcConfigsSubProfilesAnon{
-					"foo": {
-						MaxUlBitRate: 100,
-						MaxDlBitRate: 100,
-					},
+	err = configurator.UpdateNetworkConfig(context.Background(), "n1", lte.CellularNetworkConfigType, &lteModels.NetworkCellularConfigs{
+		Epc: &lteModels.NetworkEpcConfigs{
+			SubProfiles: map[string]lteModels.NetworkEpcConfigsSubProfilesAnon{
+				"foo": {
+					MaxUlBitRate: 100,
+					MaxDlBitRate: 100,
 				},
 			},
 		},
-		serdes.Network,
-	)
+	}, serdes.Network)
 	assert.NoError(t, err)
 	_, err = configurator.CreateEntity(
 		"n1",
@@ -1787,7 +1779,7 @@ func TestUpdateSubscriber(t *testing.T) {
 func TestDeleteSubscriber(t *testing.T) {
 	configuratorTestInit.StartTestService(t)
 	deviceTestInit.StartTestService(t)
-	err := configurator.CreateNetwork(configurator.Network{ID: "n1"}, serdes.Network)
+	err := configurator.CreateNetwork(context.Background(), configurator.Network{ID: "n1"}, serdes.Network)
 	assert.NoError(t, err)
 
 	e := echo.New()
@@ -1846,7 +1838,7 @@ func TestDeleteSubscriber(t *testing.T) {
 func TestActivateDeactivateSubscriber(t *testing.T) {
 	configuratorTestInit.StartTestService(t)
 	deviceTestInit.StartTestService(t)
-	err := configurator.CreateNetwork(configurator.Network{ID: "n1"}, serdes.Network)
+	err := configurator.CreateNetwork(context.Background(), configurator.Network{ID: "n1"}, serdes.Network)
 	assert.NoError(t, err)
 
 	e := echo.New()
@@ -1950,22 +1942,18 @@ func TestUpdateSubscriberProfile(t *testing.T) {
 	configuratorTestInit.StartTestService(t)
 	deviceTestInit.StartTestService(t)
 
-	err := configurator.CreateNetwork(configurator.Network{ID: "n1"}, serdes.Network)
+	err := configurator.CreateNetwork(context.Background(), configurator.Network{ID: "n1"}, serdes.Network)
 	assert.NoError(t, err)
-	err = configurator.UpdateNetworkConfig(
-		"n1", lte.CellularNetworkConfigType,
-		&lteModels.NetworkCellularConfigs{
-			Epc: &lteModels.NetworkEpcConfigs{
-				SubProfiles: map[string]lteModels.NetworkEpcConfigsSubProfilesAnon{
-					"foo": {
-						MaxUlBitRate: 100,
-						MaxDlBitRate: 100,
-					},
+	err = configurator.UpdateNetworkConfig(context.Background(), "n1", lte.CellularNetworkConfigType, &lteModels.NetworkCellularConfigs{
+		Epc: &lteModels.NetworkEpcConfigs{
+			SubProfiles: map[string]lteModels.NetworkEpcConfigsSubProfilesAnon{
+				"foo": {
+					MaxUlBitRate: 100,
+					MaxDlBitRate: 100,
 				},
 			},
 		},
-		serdes.Network,
-	)
+	}, serdes.Network)
 	assert.NoError(t, err)
 
 	//preseed 2 apns
@@ -2105,7 +2093,7 @@ func TestUpdateSubscriberProfile(t *testing.T) {
 func TestSubscriberBasename(t *testing.T) {
 	configuratorTestInit.StartTestService(t)
 	stateTestInit.StartTestService(t)
-	err := configurator.CreateNetwork(configurator.Network{ID: "n0"}, serdes.Network)
+	err := configurator.CreateNetwork(context.Background(), configurator.Network{ID: "n0"}, serdes.Network)
 	assert.NoError(t, err)
 	_, err = configurator.CreateEntities(
 		"n0",
@@ -2212,7 +2200,7 @@ func TestSubscriberBasename(t *testing.T) {
 func TestSubscriberPolicy(t *testing.T) {
 	configuratorTestInit.StartTestService(t)
 	stateTestInit.StartTestService(t)
-	err := configurator.CreateNetwork(configurator.Network{ID: "n0"}, serdes.Network)
+	err := configurator.CreateNetwork(context.Background(), configurator.Network{ID: "n0"}, serdes.Network)
 	assert.NoError(t, err)
 	_, err = configurator.CreateEntities(
 		"n0",
@@ -2320,7 +2308,7 @@ func TestSubscriberPolicy(t *testing.T) {
 func TestAPNPolicyProfile(t *testing.T) {
 	configuratorTestInit.StartTestService(t)
 	stateTestInit.StartTestService(t)
-	err := configurator.CreateNetwork(configurator.Network{ID: "n0"}, serdes.Network)
+	err := configurator.CreateNetwork(context.Background(), configurator.Network{ID: "n0"}, serdes.Network)
 	assert.NoError(t, err)
 	_, err = configurator.CreateEntities(
 		"n0",
@@ -2385,7 +2373,7 @@ func TestAPNPolicyProfile(t *testing.T) {
 		tests.RunUnitTest(t, e, tc)
 
 		// Configurator confirms apn_policy_profile exists
-		profiles, err := configurator.ListEntityKeys("n0", lte.APNPolicyProfileEntityType)
+		profiles, err := configurator.ListEntityKeys(context.Background(), "n0", lte.APNPolicyProfileEntityType)
 		assert.NoError(t, err)
 		assert.Len(t, profiles, 1)
 
@@ -2406,7 +2394,7 @@ func TestAPNPolicyProfile(t *testing.T) {
 		tests.RunUnitTest(t, e, tc)
 
 		// Configurator confirms apn_policy_profile still exists
-		profiles, err = configurator.ListEntityKeys("n0", lte.APNPolicyProfileEntityType)
+		profiles, err = configurator.ListEntityKeys(context.Background(), "n0", lte.APNPolicyProfileEntityType)
 		assert.NoError(t, err)
 		assert.Len(t, profiles, 1)
 
@@ -2422,12 +2410,12 @@ func TestAPNPolicyProfile(t *testing.T) {
 		tests.RunUnitTest(t, e, tc)
 
 		// Configurator confirms subscriber no longer exists
-		profiles, err = configurator.ListEntityKeys("n0", lte.SubscriberEntityType)
+		profiles, err = configurator.ListEntityKeys(context.Background(), "n0", lte.SubscriberEntityType)
 		assert.NoError(t, err)
 		assert.Len(t, profiles, 0)
 
 		// Configurator confirms apn_policy_profile no longer exists
-		profiles, err = configurator.ListEntityKeys("n0", lte.APNPolicyProfileEntityType)
+		profiles, err = configurator.ListEntityKeys(context.Background(), "n0", lte.APNPolicyProfileEntityType)
 		assert.NoError(t, err)
 		assert.Len(t, profiles, 0)
 
@@ -2500,7 +2488,7 @@ func TestAPNPolicyProfile(t *testing.T) {
 	tests.RunUnitTest(t, e, tc)
 
 	// Configurator confirms policy profile exists
-	profiles, err := configurator.ListEntityKeys("n0", lte.APNPolicyProfileEntityType)
+	profiles, err := configurator.ListEntityKeys(context.Background(), "n0", lte.APNPolicyProfileEntityType)
 	assert.NoError(t, err)
 	assert.Len(t, profiles, 1)
 
@@ -2561,7 +2549,7 @@ func TestAPNPolicyProfile(t *testing.T) {
 	tests.RunUnitTest(t, e, tc)
 
 	// Configurator confirms policy profiles exist
-	profiles, err = configurator.ListEntityKeys("n0", lte.APNPolicyProfileEntityType)
+	profiles, err = configurator.ListEntityKeys(context.Background(), "n0", lte.APNPolicyProfileEntityType)
 	assert.NoError(t, err)
 	assert.Len(t, profiles, 2)
 
@@ -2612,7 +2600,7 @@ func TestAPNPolicyProfile(t *testing.T) {
 	tests.RunUnitTest(t, e, tc)
 
 	// Configurator confirms deletion
-	profiles, err = configurator.ListEntityKeys("n0", lte.APNPolicyProfileEntityType)
+	profiles, err = configurator.ListEntityKeys(context.Background(), "n0", lte.APNPolicyProfileEntityType)
 	assert.NoError(t, err)
 	assert.Len(t, profiles, 0)
 
@@ -2704,7 +2692,7 @@ func TestAPNPolicyProfile(t *testing.T) {
 	tests.RunUnitTest(t, e, tc)
 
 	// Configurator confirms deletion
-	profiles, err = configurator.ListEntityKeys("n0", lte.APNPolicyProfileEntityType)
+	profiles, err = configurator.ListEntityKeys(context.Background(), "n0", lte.APNPolicyProfileEntityType)
 	assert.NoError(t, err)
 	assert.Len(t, profiles, 1)
 
@@ -2724,7 +2712,7 @@ func TestAPNPolicyProfile(t *testing.T) {
 	tests.RunUnitTest(t, e, tc)
 
 	// Configurator non-shared apn_policy_profile
-	profiles, err = configurator.ListEntityKeys("n0", lte.APNPolicyProfileEntityType)
+	profiles, err = configurator.ListEntityKeys(context.Background(), "n0", lte.APNPolicyProfileEntityType)
 	assert.NoError(t, err)
 	assert.Len(t, profiles, 2)
 }

--- a/lte/cloud/go/services/subscriberdb/obsidian/models/conversion.go
+++ b/lte/cloud/go/services/subscriberdb/obsidian/models/conversion.go
@@ -14,6 +14,7 @@
 package models
 
 import (
+	"context"
 	"fmt"
 	"sort"
 	"strings"
@@ -183,7 +184,7 @@ func (m *MutableSubscriber) GetAssocs() []storage.TypeAndKey {
 	return assocs
 }
 
-func (m *SubProfile) ValidateModel() error {
+func (m *SubProfile) ValidateModel(context.Context) error {
 	return m.Validate(strfmt.Default)
 }
 

--- a/lte/cloud/go/services/subscriberdb/obsidian/models/validate.go
+++ b/lte/cloud/go/services/subscriberdb/obsidian/models/validate.go
@@ -14,6 +14,8 @@
 package models
 
 import (
+	"context"
+
 	"github.com/hashicorp/go-multierror"
 
 	"magma/orc8r/cloud/go/obsidian/models"
@@ -28,7 +30,7 @@ const (
 	lteAuthOpcLength = 16
 )
 
-func (m *LteSubscription) ValidateModel() error {
+func (m *LteSubscription) ValidateModel(context.Context) error {
 	if err := m.Validate(strfmt.Default); err != nil {
 		return err
 	}
@@ -47,11 +49,11 @@ func (m *LteSubscription) ValidateModel() error {
 	return nil
 }
 
-func (m *MutableSubscriber) ValidateModel() error {
+func (m *MutableSubscriber) ValidateModel(context.Context) error {
 	if err := m.Validate(strfmt.Default); err != nil {
 		return err
 	}
-	if err := m.Lte.ValidateModel(); err != nil {
+	if err := m.Lte.ValidateModel(context.Background()); err != nil {
 		return err
 	}
 
@@ -66,23 +68,23 @@ func (m *MutableSubscriber) ValidateModel() error {
 	return nil
 }
 
-func (m MutableSubscribers) ValidateModel() error {
+func (m MutableSubscribers) ValidateModel(context.Context) error {
 	errs := &multierror.Error{}
 	for _, s := range m {
-		if err := s.ValidateModel(); err != nil {
+		if err := s.ValidateModel(context.Background()); err != nil {
 			errs = multierror.Append(errs, err)
 		}
 	}
 	return errs.ErrorOrNil()
 }
 
-func (m *IcmpStatus) ValidateModel() error {
+func (m *IcmpStatus) ValidateModel(context.Context) error {
 	if err := m.Validate(strfmt.Default); err != nil {
 		return err
 	}
 	return nil
 }
 
-func (m *MsisdnAssignment) ValidateModel() error {
+func (m *MsisdnAssignment) ValidateModel(context.Context) error {
 	return m.Validate(strfmt.Default)
 }

--- a/lte/cloud/go/services/subscriberdb/servicers/subscriberdb_servicer_test.go
+++ b/lte/cloud/go/services/subscriberdb/servicers/subscriberdb_servicer_test.go
@@ -50,7 +50,7 @@ func TestListSubscribers(t *testing.T) {
 	storeReader, _ := initializeStore(t)
 
 	servicer := servicers.NewSubscriberdbServicer(subscriberdb.Config{DigestsEnabled: false}, storeReader)
-	err := configurator.CreateNetwork(configurator.Network{ID: "n1"}, serdes.Network)
+	err := configurator.CreateNetwork(context.Background(), configurator.Network{ID: "n1"}, serdes.Network)
 	assert.NoError(t, err)
 	_, err = configurator.CreateEntity("n1", configurator.NetworkEntity{Type: orc8r.MagmadGatewayType, Key: "g1", PhysicalID: "hw1"}, serdes.Entity)
 	assert.NoError(t, err)
@@ -314,7 +314,7 @@ func TestListSubscribersDigestsEnabled(t *testing.T) {
 		MaxProtosLoadSize:  10,
 		ResyncIntervalSecs: 1000,
 	}, storeReader)
-	err := configurator.CreateNetwork(configurator.Network{ID: "n1"}, serdes.Network)
+	err := configurator.CreateNetwork(context.Background(), configurator.Network{ID: "n1"}, serdes.Network)
 	assert.NoError(t, err)
 	gw, err := configurator.CreateEntity("n1", configurator.NetworkEntity{Type: lte.CellularGatewayEntityType, Key: "g1"}, serdes.Entity)
 	assert.NoError(t, err)
@@ -489,7 +489,7 @@ func TestListSubscribersSetLastResyncTime(t *testing.T) {
 		DigestsEnabled:    true,
 		MaxProtosLoadSize: 10,
 	}, storeReader)
-	err := configurator.CreateNetwork(configurator.Network{ID: "n1"}, serdes.Network)
+	err := configurator.CreateNetwork(context.Background(), configurator.Network{ID: "n1"}, serdes.Network)
 	assert.NoError(t, err)
 	_, err = configurator.CreateEntity("n1", configurator.NetworkEntity{Type: lte.CellularGatewayEntityType, Key: "g1"}, serdes.Entity)
 	assert.NoError(t, err)
@@ -546,7 +546,7 @@ func TestCheckSubscribersInSync(t *testing.T) {
 	storeReader, store := initializeStore(t)
 
 	servicer := servicers.NewSubscriberdbServicer(subscriberdb.Config{DigestsEnabled: true, ResyncIntervalSecs: 1000}, storeReader)
-	err := configurator.CreateNetwork(configurator.Network{ID: "n1"}, serdes.Network)
+	err := configurator.CreateNetwork(context.Background(), configurator.Network{ID: "n1"}, serdes.Network)
 	assert.NoError(t, err)
 	_, err = configurator.CreateEntity("n1", configurator.NetworkEntity{Type: lte.CellularGatewayEntityType, Key: "g1"}, serdes.Entity)
 	assert.NoError(t, err)
@@ -604,7 +604,7 @@ func TestSyncSubscribers(t *testing.T) {
 	// Create servicer with the subscriber digests feature flag turned on
 	configs := subscriberdb.Config{DigestsEnabled: true, ChangesetSizeThreshold: 100, MaxProtosLoadSize: 100}
 	servicer := servicers.NewSubscriberdbServicer(configs, storeReader)
-	err := configurator.CreateNetwork(configurator.Network{ID: "n1"}, serdes.Network)
+	err := configurator.CreateNetwork(context.Background(), configurator.Network{ID: "n1"}, serdes.Network)
 	assert.NoError(t, err)
 	_, err = configurator.CreateEntity("n1", configurator.NetworkEntity{Type: lte.CellularGatewayEntityType, Key: "g1"}, serdes.Entity)
 	assert.NoError(t, err)
@@ -754,7 +754,7 @@ func TestSyncSubscribersResync(t *testing.T) {
 	}
 	servicer := servicers.NewSubscriberdbServicer(configs, storeReader)
 
-	err := configurator.CreateNetwork(configurator.Network{ID: "n1"}, serdes.Network)
+	err := configurator.CreateNetwork(context.Background(), configurator.Network{ID: "n1"}, serdes.Network)
 	assert.NoError(t, err)
 	_, err = configurator.CreateEntity("n1", configurator.NetworkEntity{Type: lte.CellularGatewayEntityType, Key: "g1"}, serdes.Entity)
 	assert.NoError(t, err)

--- a/lte/cloud/go/services/subscriberdb/streamer/providers_test.go
+++ b/lte/cloud/go/services/subscriberdb/streamer/providers_test.go
@@ -43,7 +43,7 @@ func TestSubscriberdbStreamer(t *testing.T) {
 	provider, err := providers.GetStreamProvider(lte.SubscriberStreamName)
 	assert.NoError(t, err)
 
-	err = configurator.CreateNetwork(configurator.Network{ID: "n1"}, serdes.Network)
+	err = configurator.CreateNetwork(context.Background(), configurator.Network{ID: "n1"}, serdes.Network)
 	assert.NoError(t, err)
 	_, err = configurator.CreateEntity("n1", configurator.NetworkEntity{Type: orc8r.MagmadGatewayType, Key: "g1", PhysicalID: "hw1"}, serdes.Entity)
 	assert.NoError(t, err)

--- a/lte/cloud/go/services/subscriberdb_cache/worker.go
+++ b/lte/cloud/go/services/subscriberdb_cache/worker.go
@@ -14,6 +14,7 @@ limitations under the License.
 package subscriberdb_cache
 
 import (
+	"context"
 	"time"
 
 	lte_models "magma/lte/cloud/go/services/lte/obsidian/models"
@@ -51,7 +52,7 @@ func MonitorDigests(config Config, store syncstore.SyncStore) {
 // Note: RenewDigests renews digests only a single time. Prefer MonitorDigests
 // for continuously updating the digests.
 func RenewDigests(config Config, store syncstore.SyncStore) (map[string]string, map[string][]*protos.LeafDigest, error) {
-	tracked, err := configurator.ListNetworkIDs()
+	tracked, err := configurator.ListNetworkIDs(context.Background())
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "Load current networks for subscriberdb cache")
 	}

--- a/lte/cloud/go/services/subscriberdb_cache/worker_test.go
+++ b/lte/cloud/go/services/subscriberdb_cache/worker_test.go
@@ -14,6 +14,7 @@ limitations under the License.
 package subscriberdb_cache_test
 
 import (
+	context2 "context"
 	"strings"
 	"testing"
 	"time"
@@ -40,6 +41,7 @@ import (
 
 	"github.com/golang/protobuf/proto"
 	"github.com/stretchr/testify/assert"
+	"golang.org/x/net/context"
 )
 
 func TestSubscriberdbCacheWorker(t *testing.T) {
@@ -63,7 +65,7 @@ func TestSubscriberdbCacheWorker(t *testing.T) {
 	assert.Empty(t, subProtos)
 	assert.Empty(t, nextToken)
 
-	err = configurator.CreateNetwork(configurator.Network{ID: "n1"}, serdes.Network)
+	err = configurator.CreateNetwork(context2.Background(), configurator.Network{ID: "n1"}, serdes.Network)
 	assert.NoError(t, err)
 
 	_, _, err = subscriberdb_cache.RenewDigests(serviceConfig, store)
@@ -152,9 +154,9 @@ func TestSubscriberdbCacheWorker(t *testing.T) {
 	assert.Equal(t, expectedNextToken, nextToken)
 
 	// Detect newly added and removed networks
-	err = configurator.CreateNetwork(configurator.Network{ID: "n2"}, serdes.Network)
+	err = configurator.CreateNetwork(context.Background(), configurator.Network{ID: "n2"}, serdes.Network)
 	assert.NoError(t, err)
-	configurator.DeleteNetwork("n1")
+	configurator.DeleteNetwork(context.Background(), "n1")
 
 	clock.SetAndFreezeClock(t, clock.Now().Add(20*time.Minute))
 	_, _, err = subscriberdb_cache.RenewDigests(serviceConfig, store)
@@ -195,7 +197,7 @@ func TestUpdateSubProtosByNetworkNoChange(t *testing.T) {
 	lte_test_init.StartTestService(t)
 	configurator_test_init.StartTestService(t)
 
-	err := configurator.CreateNetwork(configurator.Network{ID: "n1"}, serdes.Network)
+	err := configurator.CreateNetwork(context.Background(), configurator.Network{ID: "n1"}, serdes.Network)
 	assert.NoError(t, err)
 	_, err = configurator.CreateEntities(
 		"n1",

--- a/lte/cloud/go/tools/migrations/m010_default_apns/main.go
+++ b/lte/cloud/go/tools/migrations/m010_default_apns/main.go
@@ -55,6 +55,7 @@
 package main
 
 import (
+	"context"
 	"database/sql"
 	"flag"
 	"fmt"
@@ -409,7 +410,7 @@ func verifyMigration(db *sql.DB, builder sqorc.StatementBuilder) error {
 		configurator.NewNetworkEntityConfigSerde(apnEntType, &types.ApnConfiguration{}),
 	)
 
-	nids, err := configurator.ListNetworkIDs()
+	nids, err := configurator.ListNetworkIDs(context.Background())
 	if err != nil {
 		return err
 	}

--- a/orc8r/cloud/go/models/validate.go
+++ b/orc8r/cloud/go/models/validate.go
@@ -14,25 +14,27 @@
 package models
 
 import (
+	"context"
+
 	"github.com/go-openapi/strfmt"
 )
 
-func (m *NetworkName) ValidateModel() error {
+func (m *NetworkName) ValidateModel(context.Context) error {
 	return m.Validate(strfmt.Default)
 }
 
-func (m *NetworkType) ValidateModel() error {
+func (m *NetworkType) ValidateModel(context.Context) error {
 	return m.Validate(strfmt.Default)
 }
 
-func (m *NetworkDescription) ValidateModel() error {
+func (m *NetworkDescription) ValidateModel(context.Context) error {
 	return m.Validate(strfmt.Default)
 }
 
-func (m *GatewayName) ValidateModel() error {
+func (m *GatewayName) ValidateModel(context.Context) error {
 	return m.Validate(strfmt.Default)
 }
 
-func (m *GatewayDescription) ValidateModel() error {
+func (m *GatewayDescription) ValidateModel(context.Context) error {
 	return m.Validate(strfmt.Default)
 }

--- a/orc8r/cloud/go/serde/serde.go
+++ b/orc8r/cloud/go/serde/serde.go
@@ -14,6 +14,7 @@
 package serde
 
 import (
+	"context"
 	"encoding"
 	"reflect"
 
@@ -43,7 +44,7 @@ type Serde interface {
 // ValidatableModel implements a ValidateModel() function that returns whether
 // the instance is valid.
 type ValidatableModel interface {
-	ValidateModel() error
+	ValidateModel(ctx context.Context) error
 }
 
 // ValidateableBinaryConvertible wraps both BinaryConvertible, for generic

--- a/orc8r/cloud/go/services/bootstrapper/servicers/bootstrapper_test.go
+++ b/orc8r/cloud/go/services/bootstrapper/servicers/bootstrapper_test.go
@@ -396,9 +396,9 @@ func TestBootstrapperServer(t *testing.T) {
 	device_test_init.StartTestService(t)
 
 	testNetworkID := "bootstrapper_test_network"
-	err := configurator.CreateNetwork(configurator.Network{ID: testNetworkID, Name: "Test Network Name"}, serdes.Network)
+	err := configurator.CreateNetwork(context.Background(), configurator.Network{ID: testNetworkID, Name: "Test Network Name"}, serdes.Network)
 	assert.NoError(t, err)
-	exists, err := configurator.DoesNetworkExist(testNetworkID)
+	exists, err := configurator.DoesNetworkExist(context.Background(), testNetworkID)
 	assert.NoError(t, err)
 	assert.True(t, exists)
 

--- a/orc8r/cloud/go/services/certifier/analytics/calculations/lifespan.go
+++ b/orc8r/cloud/go/services/certifier/analytics/calculations/lifespan.go
@@ -14,6 +14,7 @@
 package calculations
 
 import (
+	"context"
 	"crypto/x509"
 	"encoding/pem"
 	"fmt"
@@ -49,7 +50,7 @@ func (x *CertLifespanCalculation) Calculate(prometheusClient query_api.Prometheu
 		return results, nil
 	}
 
-	networks, err := configurator.ListNetworkIDs()
+	networks, err := configurator.ListNetworkIDs(context.Background())
 	if err != nil {
 		glog.Errorf("Unable to retrieve any networks: %+v", err)
 		return results, nil

--- a/orc8r/cloud/go/services/configurator/client_api_test.go
+++ b/orc8r/cloud/go/services/configurator/client_api_test.go
@@ -13,6 +13,7 @@ limitations under the License.
 package configurator_test
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
@@ -53,10 +54,10 @@ func TestConfiguratorService(t *testing.T) {
 		Description: "description",
 		Configs:     config,
 	}
-	_, err := configurator.CreateNetworks([]configurator.Network{network1}, networkSerdes)
+	_, err := configurator.CreateNetworks(context.Background(), []configurator.Network{network1}, networkSerdes)
 	assert.NoError(t, err)
 
-	networks, notFound, err := configurator.LoadNetworks([]string{networkID1}, true, true, networkSerdes)
+	networks, notFound, err := configurator.LoadNetworks(context.Background(), []string{networkID1}, true, true, networkSerdes)
 	assert.NoError(t, err)
 	assert.Equal(t, 0, len(notFound))
 	assert.Equal(t, 1, len(networks))
@@ -73,9 +74,9 @@ func TestConfiguratorService(t *testing.T) {
 		ConfigsToDelete:      toDelete,
 	}
 
-	err = configurator.UpdateNetworks([]configurator.NetworkUpdateCriteria{updateCriteria1}, networkSerdes)
+	err = configurator.UpdateNetworks(context.Background(), []configurator.NetworkUpdateCriteria{updateCriteria1}, networkSerdes)
 	assert.NoError(t, err)
-	networks, notFound, err = configurator.LoadNetworks([]string{networkID1}, true, true, networkSerdes)
+	networks, notFound, err = configurator.LoadNetworks(context.Background(), []string{networkID1}, true, true, networkSerdes)
 	assert.NoError(t, err)
 	assert.Equal(t, 0, len(notFound))
 	assert.Equal(t, 1, len(networks))
@@ -90,45 +91,42 @@ func TestConfiguratorService(t *testing.T) {
 		Name:        "test_network2",
 		Description: "description2",
 	}
-	_, err = configurator.CreateNetworks([]configurator.Network{network2}, networkSerdes)
+	_, err = configurator.CreateNetworks(context.Background(), []configurator.Network{network2}, networkSerdes)
 	assert.NoError(t, err)
 
-	networkIDs, err := configurator.ListNetworkIDs()
+	networkIDs, err := configurator.ListNetworkIDs(context.Background())
 	assert.NoError(t, err)
 	assert.Equal(t, 2, len(networkIDs))
 	assert.Equal(t, networkID2, networkIDs[1])
 
 	// Delete, Load
-	err = configurator.DeleteNetworks([]string{network2.ID})
+	err = configurator.DeleteNetworks(context.Background(), []string{network2.ID})
 	assert.NoError(t, err)
 
-	networks, notFound, err = configurator.LoadNetworks([]string{networkID2}, true, true, networkSerdes)
+	networks, notFound, err = configurator.LoadNetworks(context.Background(), []string{networkID2}, true, true, networkSerdes)
 	assert.NoError(t, err)
 	assert.Equal(t, 0, len(networks))
 	assert.Equal(t, 1, len(notFound))
 
 	// Create Networks With Type
-	createdTypedLteNetworks, err := configurator.CreateNetworks(
-		[]configurator.Network{
-			{
-				Name: "lte network 1",
-				Type: "lte",
-				ID:   "test_network3",
-			},
-			{
-				Name: "lte network 2",
-				Type: "lte",
-				ID:   "test_network4",
-			},
+	createdTypedLteNetworks, err := configurator.CreateNetworks(context.Background(), []configurator.Network{
+		{
+			Name: "lte network 1",
+			Type: "lte",
+			ID:   "test_network3",
 		},
-		networkSerdes,
-	)
+		{
+			Name: "lte network 2",
+			Type: "lte",
+			ID:   "test_network4",
+		},
+	}, networkSerdes)
 	assert.NoError(t, err)
 
 	createdTypedLteNetworks[0].Name = ""
 	createdTypedLteNetworks[1].Name = ""
 
-	networks, err = configurator.LoadNetworksOfType("lte", false, false, networkSerdes)
+	networks, err = configurator.LoadNetworksOfType(context.Background(), "lte", false, false, networkSerdes)
 	assert.NoError(t, err)
 	assert.Equal(t, createdTypedLteNetworks, networks)
 

--- a/orc8r/cloud/go/services/configurator/test_utils/utils.go
+++ b/orc8r/cloud/go/services/configurator/test_utils/utils.go
@@ -27,7 +27,7 @@ import (
 )
 
 func RegisterNetwork(t *testing.T, networkID string, networkName string) {
-	err := configurator.CreateNetwork(configurator.Network{ID: networkID, Name: networkName}, nil)
+	err := configurator.CreateNetwork(context.Background(), configurator.Network{ID: networkID, Name: networkName}, nil)
 	assert.NoError(t, err)
 }
 

--- a/orc8r/cloud/go/services/ctraced/obsidian/handlers/handlers.go
+++ b/orc8r/cloud/go/services/ctraced/obsidian/handlers/handlers.go
@@ -14,6 +14,7 @@
 package handlers
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 
@@ -102,7 +103,7 @@ func getCreateCallTraceHandlerFunc(client GwCtracedClient) echo.HandlerFunc {
 		if err != nil {
 			return obsidian.HttpError(err, http.StatusInternalServerError)
 		}
-		if err := ctr.ValidateModel(); err != nil {
+		if err := ctr.ValidateModel(context.Background()); err != nil {
 			return obsidian.HttpError(err, http.StatusBadRequest)
 		}
 
@@ -146,7 +147,7 @@ func getUpdateCallTraceHandlerFunc(client GwCtracedClient, storage storage.Ctrac
 		if err := c.Bind(mutableCallTrace); err != nil {
 			return obsidian.HttpError(err, http.StatusBadRequest)
 		}
-		if err := mutableCallTrace.ValidateModel(); err != nil {
+		if err := mutableCallTrace.ValidateModel(context.Background()); err != nil {
 			return obsidian.HttpError(err, http.StatusBadRequest)
 		}
 

--- a/orc8r/cloud/go/services/ctraced/obsidian/handlers/handlers_test.go
+++ b/orc8r/cloud/go/services/ctraced/obsidian/handlers/handlers_test.go
@@ -14,6 +14,7 @@
 package handlers_test
 
 import (
+	context2 "context"
 	"magma/orc8r/cloud/go/obsidian"
 	"magma/orc8r/cloud/go/obsidian/tests"
 	"magma/orc8r/cloud/go/serdes"
@@ -57,7 +58,7 @@ func TestCtracedHandlersBasic(t *testing.T) {
 	fact := test_utils.NewSQLBlobstore(t, "ctraced_handlers_test_blobstore")
 	blobstore := storage.NewCtracedBlobstore(fact)
 	obsidianHandlers := handlers.GetObsidianHandlers(mockGWClient, blobstore)
-	err := configurator.CreateNetwork(configurator.Network{ID: "n1"}, serdes.Network)
+	err := configurator.CreateNetwork(context2.Background(), configurator.Network{ID: "n1"}, serdes.Network)
 	assert.NoError(t, err)
 
 	listTraces := tests.GetHandlerByPathAndMethod(t, obsidianHandlers, "/magma/v1/networks/:network_id/tracing", obsidian.GET).HandlerFunc

--- a/orc8r/cloud/go/services/ctraced/obsidian/models/validate.go
+++ b/orc8r/cloud/go/services/ctraced/obsidian/models/validate.go
@@ -14,17 +14,19 @@
 package models
 
 import (
+	"context"
+
 	"github.com/go-openapi/strfmt"
 )
 
-func (m *CallTrace) ValidateModel() error {
+func (m *CallTrace) ValidateModel(context.Context) error {
 	if err := m.Validate(strfmt.Default); err != nil {
 		return err
 	}
 	return nil
 }
 
-func (m *MutableCallTrace) ValidateModel() error {
+func (m *MutableCallTrace) ValidateModel(context.Context) error {
 	if err := m.Validate(strfmt.Default); err != nil {
 		return err
 	}

--- a/orc8r/cloud/go/services/ctraced/servicers/trace_servicer_test.go
+++ b/orc8r/cloud/go/services/ctraced/servicers/trace_servicer_test.go
@@ -14,6 +14,7 @@ limitations under the License.
 package servicers_test
 
 import (
+	context2 "context"
 	"testing"
 
 	"magma/orc8r/cloud/go/orc8r"
@@ -40,7 +41,7 @@ func TestCallTraceServicer(t *testing.T) {
 	testGwLogicalId := "g1"
 
 	// Initialize network
-	err := configurator.CreateNetwork(configurator.Network{ID: testNetworkId}, serdes.Network)
+	err := configurator.CreateNetwork(context2.Background(), configurator.Network{ID: testNetworkId}, serdes.Network)
 	assert.NoError(t, err)
 
 	// Create a call trace

--- a/orc8r/cloud/go/services/directoryd/types/types.go
+++ b/orc8r/cloud/go/services/directoryd/types/types.go
@@ -14,6 +14,7 @@
 package types
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"strings"
@@ -33,7 +34,7 @@ type DirectoryRecord struct {
 }
 
 // ValidateModel is a wrapper to validate this directory record
-func (m *DirectoryRecord) ValidateModel() error {
+func (m *DirectoryRecord) ValidateModel(context.Context) error {
 	return m.Validate(strfmt.Default)
 }
 

--- a/orc8r/cloud/go/services/orchestrator/analytics/calculations/state.go
+++ b/orc8r/cloud/go/services/orchestrator/analytics/calculations/state.go
@@ -40,7 +40,7 @@ func (x *NetworkMetricsCalculation) Calculate(prometheusClient query_api.Prometh
 	glog.V(1).Info("Calculate Network Metrics")
 
 	var results []*protos.CalculationResult
-	networks, err := configurator.ListNetworkIDs()
+	networks, err := configurator.ListNetworkIDs(context.Background())
 	if err != nil || networks == nil {
 		return results, err
 	}
@@ -52,7 +52,7 @@ func (x *NetworkMetricsCalculation) Calculate(prometheusClient query_api.Prometh
 	}
 
 	for _, networkID := range networks {
-		network, err := configurator.LoadNetwork(networkID, true, true, serdes.Network)
+		network, err := configurator.LoadNetwork(context.TODO(), networkID, true, true, serdes.Network)
 		if err == merrors.ErrNotFound {
 			glog.Errorf("Network %s not found", networkID)
 			continue
@@ -85,7 +85,7 @@ func (x *SiteMetricsCalculation) Calculate(prometheusClient query_api.Prometheus
 	var results []*protos.CalculationResult
 
 	gatewayVersionCfg, gatewayVersionCfgOk := x.AnalyticsConfig.Metrics[metrics.GatewayMagmaVersionMetric]
-	networks, err := configurator.ListNetworkIDs()
+	networks, err := configurator.ListNetworkIDs(context.Background())
 	if err != nil || networks == nil || !gatewayVersionCfgOk {
 		return results, err
 	}

--- a/orc8r/cloud/go/services/orchestrator/analytics/calculations/state_test.go
+++ b/orc8r/cloud/go/services/orchestrator/analytics/calculations/state_test.go
@@ -1,6 +1,7 @@
 package calculations_test
 
 import (
+	context2 "context"
 	"testing"
 
 	"magma/orc8r/cloud/go/orc8r"
@@ -20,7 +21,7 @@ import (
 func TestSiteCalculations(t *testing.T) {
 	configurator_test_init.StartTestService(t)
 	state_test_init.StartTestService(t)
-	err := configurator.CreateNetwork(configurator.Network{ID: "n0"}, serdes.Network)
+	err := configurator.CreateNetwork(context2.Background(), configurator.Network{ID: "n0"}, serdes.Network)
 	assert.NoError(t, err)
 
 	_, err = configurator.CreateEntity(
@@ -64,10 +65,10 @@ func TestSiteCalculations(t *testing.T) {
 func TestNetworkCalculations(t *testing.T) {
 	configurator_test_init.StartTestService(t)
 	state_test_init.StartTestService(t)
-	configurator.CreateNetwork(configurator.Network{ID: "n0_1", Type: "LTE"}, serdes.Network)
-	configurator.CreateNetwork(configurator.Network{ID: "n1", Type: "FEG_LTE"}, serdes.Network)
-	configurator.CreateNetwork(configurator.Network{ID: "n2_0", Type: "FEG"}, serdes.Network)
-	configurator.CreateNetwork(configurator.Network{ID: "n2_2", Type: "FEG"}, serdes.Network)
+	configurator.CreateNetwork(context2.Background(), configurator.Network{ID: "n0_1", Type: "LTE"}, serdes.Network)
+	configurator.CreateNetwork(context2.Background(), configurator.Network{ID: "n1", Type: "FEG_LTE"}, serdes.Network)
+	configurator.CreateNetwork(context2.Background(), configurator.Network{ID: "n2_0", Type: "FEG"}, serdes.Network)
+	configurator.CreateNetwork(context2.Background(), configurator.Network{ID: "n2_2", Type: "FEG"}, serdes.Network)
 	analyticsConfig := &calculations.AnalyticsConfig{
 		Metrics: map[string]calculations.MetricConfig{
 			metrics.NetworkTypeMetric: {

--- a/orc8r/cloud/go/services/orchestrator/obsidian/handlers/common.go
+++ b/orc8r/cloud/go/services/orchestrator/obsidian/handlers/common.go
@@ -36,7 +36,7 @@ func GetAndValidatePayload(c echo.Context, model interface{}) (serde.Validatable
 		return nil, obsidian.HttpError(err, http.StatusBadRequest)
 	}
 	// Run validations specified by the swagger spec
-	if err := iModel.ValidateModel(); err != nil {
+	if err := iModel.ValidateModel(c.Request().Context()); err != nil {
 		return nil, obsidian.HttpError(err, http.StatusBadRequest)
 	}
 	return iModel, nil

--- a/orc8r/cloud/go/services/orchestrator/obsidian/handlers/gateway_handler_factory.go
+++ b/orc8r/cloud/go/services/orchestrator/obsidian/handlers/gateway_handler_factory.go
@@ -216,7 +216,7 @@ func GetListGatewaysHandler(path string, gateway MagmadEncompassingGateway, make
 			}
 
 			reqCtx := c.Request().Context()
-			ids, err := configurator.ListEntityKeys(nid, gateway.GetGatewayType())
+			ids, err := configurator.ListEntityKeys(reqCtx, nid, gateway.GetGatewayType())
 			if err != nil {
 				return obsidian.HttpError(err, http.StatusInternalServerError)
 			}

--- a/orc8r/cloud/go/services/orchestrator/obsidian/handlers/gateway_handler_factory_test.go
+++ b/orc8r/cloud/go/services/orchestrator/obsidian/handlers/gateway_handler_factory_test.go
@@ -14,6 +14,7 @@
 package handlers_test
 
 import (
+	context2 "context"
 	"fmt"
 	"testing"
 
@@ -61,7 +62,7 @@ func Test_GetPartialReadGatewayHandler(t *testing.T) {
 	}
 	tests.RunUnitTest(t, e, tc)
 
-	assert.NoError(t, configurator.CreateNetwork(network, serdes.Network))
+	assert.NoError(t, configurator.CreateNetwork(context2.Background(), network, serdes.Network))
 	gateway := configurator.NetworkEntity{
 		Key:  "gw1",
 		Type: orc8r.MagmadGatewayType,
@@ -112,7 +113,7 @@ func Test_GetPartialUpdateGatewayHandler(t *testing.T) {
 	}
 	tests.RunUnitTest(t, e, tc)
 
-	assert.NoError(t, configurator.CreateNetwork(network, serdes.Network))
+	assert.NoError(t, configurator.CreateNetwork(context2.Background(), network, serdes.Network))
 	Gateway := configurator.NetworkEntity{
 		Key:  "test_gateway_1",
 		Type: orc8r.MagmadGatewayType,
@@ -197,7 +198,7 @@ type testName struct {
 	Name string
 }
 
-func (m *testName) ValidateModel() error {
+func (m *testName) ValidateModel(context2.Context) error {
 	if m == nil {
 		return fmt.Errorf("Cannot be nil")
 	}

--- a/orc8r/cloud/go/services/orchestrator/obsidian/handlers/gateway_handlers_test.go
+++ b/orc8r/cloud/go/services/orchestrator/obsidian/handlers/gateway_handlers_test.go
@@ -45,7 +45,7 @@ func TestListGateways(t *testing.T) {
 	test_init.StartTestService(t)
 	deviceTestInit.StartTestService(t)
 	stateTestInit.StartTestService(t)
-	err := configurator.CreateNetwork(configurator.Network{ID: "n1"}, serdes.Network)
+	err := configurator.CreateNetwork(context.Background(), configurator.Network{ID: "n1"}, serdes.Network)
 	assert.NoError(t, err)
 
 	e := echo.New()
@@ -106,7 +106,7 @@ func TestListGateways(t *testing.T) {
 func TestCreateGateway(t *testing.T) {
 	test_init.StartTestService(t)
 	deviceTestInit.StartTestService(t)
-	err := configurator.CreateNetwork(configurator.Network{ID: "n1"}, serdes.Network)
+	err := configurator.CreateNetwork(context.Background(), configurator.Network{ID: "n1"}, serdes.Network)
 	assert.NoError(t, err)
 
 	// create 2 tiers
@@ -319,7 +319,7 @@ func TestGetGateway(t *testing.T) {
 	deviceTestInit.StartTestService(t)
 	stateTestInit.StartTestService(t)
 
-	err := configurator.CreateNetwork(configurator.Network{ID: "n1"}, serdes.Network)
+	err := configurator.CreateNetwork(context.Background(), configurator.Network{ID: "n1"}, serdes.Network)
 	assert.NoError(t, err)
 
 	_, err = configurator.CreateEntities(
@@ -439,7 +439,7 @@ func TestUpdateGateway(t *testing.T) {
 	stateTestInit.StartTestService(t)
 	test_init.StartTestService(t)
 	deviceTestInit.StartTestService(t)
-	err := configurator.CreateNetwork(configurator.Network{ID: "n1"}, serdes.Network)
+	err := configurator.CreateNetwork(context.Background(), configurator.Network{ID: "n1"}, serdes.Network)
 	assert.NoError(t, err)
 
 	_, err = configurator.CreateEntities(
@@ -577,7 +577,7 @@ func TestUpdateGateway(t *testing.T) {
 func TestDeleteGateway(t *testing.T) {
 	test_init.StartTestService(t)
 	deviceTestInit.StartTestService(t)
-	err := configurator.CreateNetwork(configurator.Network{ID: "n1"}, serdes.Network)
+	err := configurator.CreateNetwork(context.Background(), configurator.Network{ID: "n1"}, serdes.Network)
 	assert.NoError(t, err)
 
 	_, err = configurator.CreateEntities(
@@ -649,7 +649,7 @@ func TestGetPartialReadHandlers(t *testing.T) {
 	deviceTestInit.StartTestService(t)
 	stateTestInit.StartTestService(t)
 
-	err := configurator.CreateNetwork(configurator.Network{ID: "n1"}, serdes.Network)
+	err := configurator.CreateNetwork(context.Background(), configurator.Network{ID: "n1"}, serdes.Network)
 	assert.NoError(t, err)
 
 	gwConfig := &models.MagmadGatewayConfigs{
@@ -801,7 +801,7 @@ func TestGetGatewayTierHandler(t *testing.T) {
 	obsidianHandlers := handlers.GetObsidianHandlers()
 	getGatewayTier := tests.GetHandlerByPathAndMethod(t, obsidianHandlers, "/magma/v1/networks/:network_id/gateways/:gateway_id/tier", obsidian.GET).HandlerFunc
 
-	err := configurator.CreateNetwork(configurator.Network{ID: "n1"}, serdes.Network)
+	err := configurator.CreateNetwork(context.Background(), configurator.Network{ID: "n1"}, serdes.Network)
 	assert.NoError(t, err)
 
 	_, err = configurator.CreateEntities(
@@ -868,7 +868,7 @@ func TestUpdateGatewayTierHandler(t *testing.T) {
 	obsidianHandlers := handlers.GetObsidianHandlers()
 	updateGatewayTier := tests.GetHandlerByPathAndMethod(t, obsidianHandlers, "/magma/v1/networks/:network_id/gateways/:gateway_id/tier", obsidian.PUT).HandlerFunc
 
-	err := configurator.CreateNetwork(configurator.Network{ID: "n1"}, serdes.Network)
+	err := configurator.CreateNetwork(context.Background(), configurator.Network{ID: "n1"}, serdes.Network)
 	assert.NoError(t, err)
 
 	_, err = configurator.CreateEntities(
@@ -1009,7 +1009,7 @@ func TestGetPartialUpdateHandlers(t *testing.T) {
 	test_init.StartTestService(t)
 	deviceTestInit.StartTestService(t)
 
-	err := configurator.CreateNetwork(configurator.Network{ID: "n1"}, serdes.Network)
+	err := configurator.CreateNetwork(context.Background(), configurator.Network{ID: "n1"}, serdes.Network)
 	assert.NoError(t, err)
 
 	gwConfig := &models.MagmadGatewayConfigs{

--- a/orc8r/cloud/go/services/orchestrator/obsidian/handlers/network_handler_factory_test.go
+++ b/orc8r/cloud/go/services/orchestrator/obsidian/handlers/network_handler_factory_test.go
@@ -14,6 +14,7 @@
 package handlers_test
 
 import (
+	context2 "context"
 	"encoding/json"
 	"fmt"
 	"testing"
@@ -53,7 +54,7 @@ func Test_GetPartialReadNetworkHandler(t *testing.T) {
 		Name:        "Test Network 1",
 		Description: "Test Network 1",
 	}
-	assert.NoError(t, configurator.CreateNetwork(network, networkSerdes))
+	assert.NoError(t, configurator.CreateNetwork(context2.Background(), network, networkSerdes))
 
 	networkURL := fmt.Sprintf("%s/%s", testURLRoot, networkID)
 
@@ -91,7 +92,7 @@ func Test_GetPartialReadNetworkHandler(t *testing.T) {
 			"test": &TestFeature1{ID: &ID{Name: "hello!"}, Desc: "goodbye!"},
 		},
 	}
-	assert.NoError(t, configurator.UpdateNetworks([]configurator.NetworkUpdateCriteria{update}, networkSerdes))
+	assert.NoError(t, configurator.UpdateNetworks(context2.Background(), []configurator.NetworkUpdateCriteria{update}, networkSerdes))
 
 	// happy full case
 	getFullConfig = handlers.GetPartialReadNetworkHandler(networkURL, &TestFeature1{}, networkSerdes)
@@ -137,7 +138,7 @@ func TestGetUpdateNetworkConfigHandler(t *testing.T) {
 		Description: "Test Network 1",
 		Configs:     map[string]interface{}{"test": &TestFeature1{ID: &ID{Name: "hello!"}, Desc: "goodbye!"}},
 	}
-	assert.NoError(t, configurator.CreateNetwork(network, networkSerdes))
+	assert.NoError(t, configurator.CreateNetwork(context2.Background(), network, networkSerdes))
 
 	networkURL := fmt.Sprintf("%s/%s", testURLRoot, networkID)
 
@@ -184,7 +185,7 @@ func TestGetUpdateNetworkConfigHandler(t *testing.T) {
 	}
 	tests.RunUnitTest(t, e, updateFullConfig)
 
-	config, err := configurator.LoadNetworkConfig(networkID, "test", networkSerdes)
+	config, err := configurator.LoadNetworkConfig(context2.Background(), networkID, "test", networkSerdes)
 	assert.NoError(t, err)
 	assert.Equal(t, expectedConfig, config)
 
@@ -201,7 +202,7 @@ func TestGetUpdateNetworkConfigHandler(t *testing.T) {
 	}
 	tests.RunUnitTest(t, e, updateFullConfig)
 
-	config, err = configurator.LoadNetworkConfig(networkID, "test", networkSerdes)
+	config, err = configurator.LoadNetworkConfig(context2.Background(), networkID, "test", networkSerdes)
 	assert.NoError(t, err)
 	assert.Equal(t, expectedConfig, config)
 }
@@ -221,7 +222,7 @@ func TestGetDeleteNetworkConfigHandler(t *testing.T) {
 		Description: "Test Network 1",
 		Configs:     map[string]interface{}{"test": &TestFeature1{ID: &ID{Name: "hello!"}, Desc: "goodbye!"}},
 	}
-	assert.NoError(t, configurator.CreateNetwork(network, networkSerdes))
+	assert.NoError(t, configurator.CreateNetwork(context2.Background(), network, networkSerdes))
 
 	networkURL := fmt.Sprintf("%s/%s", testURLRoot, networkID)
 
@@ -236,7 +237,7 @@ func TestGetDeleteNetworkConfigHandler(t *testing.T) {
 	}
 	tests.RunUnitTest(t, e, deleteTestConfig)
 
-	_, err := configurator.LoadNetworkConfig(networkID, "test", networkSerdes)
+	_, err := configurator.LoadNetworkConfig(context2.Background(), networkID, "test", networkSerdes)
 	assert.EqualError(t, err, errors.ErrNotFound.Error())
 }
 
@@ -250,7 +251,7 @@ func (m *ID) Validate(_ strfmt.Registry) error {
 	return fmt.Errorf("Name cannot be nil")
 }
 
-func (m *ID) ValidateModel() error {
+func (m *ID) ValidateModel(context2.Context) error {
 	return m.Validate(strfmt.Default)
 }
 
@@ -278,7 +279,7 @@ func (m *TestFeature1) Validate(str strfmt.Registry) error {
 	return nil
 }
 
-func (m *TestFeature1) ValidateModel() error {
+func (m *TestFeature1) ValidateModel(context2.Context) error {
 	return m.Validate(strfmt.Default)
 }
 

--- a/orc8r/cloud/go/services/orchestrator/obsidian/handlers/network_handlers_test.go
+++ b/orc8r/cloud/go/services/orchestrator/obsidian/handlers/network_handlers_test.go
@@ -14,6 +14,7 @@
 package handlers_test
 
 import (
+	context2 "context"
 	"fmt"
 	"testing"
 
@@ -73,7 +74,7 @@ func Test_GetNetworkHandlers(t *testing.T) {
 		ID:   "n1",
 		Name: networkName1,
 	}
-	err := configurator.CreateNetwork(network1, serdes.Network)
+	err := configurator.CreateNetwork(context2.Background(), network1, serdes.Network)
 	assert.NoError(t, err)
 
 	tc = tests.Test{
@@ -111,7 +112,7 @@ func Test_GetNetworkHandlers(t *testing.T) {
 		ID:                   "n1",
 		ConfigsToAddOrUpdate: map[string]interface{}{orc8r.NetworkFeaturesConfig: networkFeatures1},
 	}
-	err = configurator.UpdateNetworks([]configurator.NetworkUpdateCriteria{update1}, serdes.Network)
+	err = configurator.UpdateNetworks(context2.Background(), []configurator.NetworkUpdateCriteria{update1}, serdes.Network)
 	assert.NoError(t, err)
 
 	expectedNetwork1 = models.Network{
@@ -139,7 +140,7 @@ func Test_GetNetworkHandlers(t *testing.T) {
 		ID:                   "n1",
 		ConfigsToAddOrUpdate: map[string]interface{}{orc8r.NetworkSentryConfig: sentryConfig},
 	}
-	err = configurator.UpdateNetworks([]configurator.NetworkUpdateCriteria{update1}, serdes.Network)
+	err = configurator.UpdateNetworks(context2.Background(), []configurator.NetworkUpdateCriteria{update1}, serdes.Network)
 	assert.NoError(t, err)
 
 	expectedNetwork1 = models.Network{
@@ -170,7 +171,7 @@ func Test_GetNetworkHandlers(t *testing.T) {
 		NewDescription:       &description1,
 		ConfigsToAddOrUpdate: map[string]interface{}{orc8r.DnsdNetworkType: dnsdConfig},
 	}
-	err = configurator.UpdateNetworks([]configurator.NetworkUpdateCriteria{update1}, serdes.Network)
+	err = configurator.UpdateNetworks(context2.Background(), []configurator.NetworkUpdateCriteria{update1}, serdes.Network)
 	assert.NoError(t, err)
 
 	expectedNetwork1 = models.Network{
@@ -202,7 +203,7 @@ func Test_GetNetworkHandlers(t *testing.T) {
 		ID:   networkID2,
 		Name: networkName2,
 	}
-	err = configurator.CreateNetwork(network2, serdes.Network)
+	err = configurator.CreateNetwork(context2.Background(), network2, serdes.Network)
 	assert.NoError(t, err)
 
 	tc = tests.Test{
@@ -327,7 +328,7 @@ func Test_PostNetworkHandlers(t *testing.T) {
 	}
 	tests.RunUnitTest(t, e, tc)
 
-	actualNetwork1, err := configurator.LoadNetwork("n1", true, true, serdes.Network)
+	actualNetwork1, err := configurator.LoadNetwork(context2.Background(), "n1", true, true, serdes.Network)
 	assert.NoError(t, err)
 	expectedNetwork1 := configurator.Network{
 		ID:          string(network1.ID),
@@ -645,7 +646,7 @@ func Test_PutNetworkMetadataHandlers(t *testing.T) {
 	}
 	tests.RunUnitTest(t, e, tc)
 
-	actualNetwork, err := configurator.LoadNetwork("n1", true, false, serdes.Network)
+	actualNetwork, err := configurator.LoadNetwork(context2.Background(), "n1", true, false, serdes.Network)
 	assert.NoError(t, err)
 	expectedNetwork1.Version = 1
 	expectedNetwork1.Name = "new_name"
@@ -662,7 +663,7 @@ func Test_PutNetworkMetadataHandlers(t *testing.T) {
 		ExpectedStatus: 204,
 	}
 	tests.RunUnitTest(t, e, tc)
-	actualNetwork, err = configurator.LoadNetwork("n1", true, false, serdes.Network)
+	actualNetwork, err = configurator.LoadNetwork(context2.Background(), "n1", true, false, serdes.Network)
 	assert.NoError(t, err)
 	expectedNetwork1.Type = "new_type"
 	expectedNetwork1.Version = 2
@@ -680,7 +681,7 @@ func Test_PutNetworkMetadataHandlers(t *testing.T) {
 	}
 	tests.RunUnitTest(t, e, putNetworkDesc)
 
-	actualNetwork, err = configurator.LoadNetwork("n1", true, false, serdes.Network)
+	actualNetwork, err = configurator.LoadNetwork(context2.Background(), "n1", true, false, serdes.Network)
 	assert.NoError(t, err)
 	expectedNetwork1.Description = "new_name"
 	expectedNetwork1.Version = 3
@@ -739,7 +740,7 @@ func Test_PutNetworkFeaturesHandlers(t *testing.T) {
 		ExpectedStatus: 204,
 	}
 	tests.RunUnitTest(t, e, tc)
-	config, err := configurator.LoadNetworkConfig("n1", orc8r.NetworkFeaturesConfig, serdes.Network)
+	config, err := configurator.LoadNetworkConfig(context2.Background(), "n1", orc8r.NetworkFeaturesConfig, serdes.Network)
 	assert.NoError(t, err)
 	assert.Equal(t, newFeatures, config)
 }
@@ -869,7 +870,7 @@ func Test_PutNetworkDNSHandlers(t *testing.T) {
 	}
 	tests.RunUnitTest(t, e, tc)
 
-	config, err := configurator.LoadNetworkConfig("n1", orc8r.DnsdNetworkType, serdes.Network)
+	config, err := configurator.LoadNetworkConfig(context2.Background(), "n1", orc8r.DnsdNetworkType, serdes.Network)
 	assert.NoError(t, err)
 	assert.Equal(t, newDNS, config)
 
@@ -892,7 +893,7 @@ func Test_PutNetworkDNSHandlers(t *testing.T) {
 		ExpectedStatus: 204,
 	}
 	tests.RunUnitTest(t, e, tc)
-	config, err = configurator.LoadNetworkConfig("n1", orc8r.DnsdNetworkType, serdes.Network)
+	config, err = configurator.LoadNetworkConfig(context2.Background(), "n1", orc8r.DnsdNetworkType, serdes.Network)
 	assert.NoError(t, err)
 	assert.Equal(t, models.NetworkDNSRecords(records), config.(*models.NetworkDNSConfig).Records)
 
@@ -932,7 +933,7 @@ func Test_PutNetworkDNSHandlers(t *testing.T) {
 		ExpectedStatus: 204,
 	}
 	tests.RunUnitTest(t, e, tc)
-	config, err = configurator.LoadNetworkConfig("n1", orc8r.DnsdNetworkType, serdes.Network)
+	config, err = configurator.LoadNetworkConfig(context2.Background(), "n1", orc8r.DnsdNetworkType, serdes.Network)
 	assert.NoError(t, err)
 	assert.Equal(t, record, config.(*models.NetworkDNSConfig).Records[0])
 
@@ -948,7 +949,7 @@ func Test_PutNetworkDNSHandlers(t *testing.T) {
 		ExpectedStatus: 204,
 	}
 	tests.RunUnitTest(t, e, tc)
-	config, err = configurator.LoadNetworkConfig("n1", orc8r.DnsdNetworkType, serdes.Network)
+	config, err = configurator.LoadNetworkConfig(context2.Background(), "n1", orc8r.DnsdNetworkType, serdes.Network)
 	assert.NoError(t, err)
 	assert.Empty(t, config.(*models.NetworkDNSConfig).Records)
 }
@@ -1038,7 +1039,7 @@ func Test_DeleteNetworkDNSHandlers(t *testing.T) {
 	}
 	tests.RunUnitTest(t, e, tc)
 
-	config, err := configurator.LoadNetworkConfig("n1", orc8r.DnsdNetworkType, serdes.Network)
+	config, err := configurator.LoadNetworkConfig(context2.Background(), "n1", orc8r.DnsdNetworkType, serdes.Network)
 	assert.NoError(t, err)
 	dnsConfig := config.(*models.NetworkDNSConfig)
 	assert.Empty(t, dnsConfig.Records)
@@ -1053,34 +1054,31 @@ func Test_DeleteNetworkDNSHandlers(t *testing.T) {
 	}
 	tests.RunUnitTest(t, e, tc)
 
-	_, err = configurator.LoadNetworkConfig("n1", orc8r.DnsdNetworkType, serdes.Network)
+	_, err = configurator.LoadNetworkConfig(context2.Background(), "n1", orc8r.DnsdNetworkType, serdes.Network)
 	assert.EqualError(t, err, "Not found")
 
 }
 
 func seedNetworks(t *testing.T) {
-	_, err := configurator.CreateNetworks(
-		[]configurator.Network{
-			{
-				ID:          "n1",
-				Type:        "type1",
-				Name:        "network1",
-				Description: "network 1",
-				Configs: map[string]interface{}{
-					orc8r.NetworkFeaturesConfig: models.NewDefaultFeaturesConfig(),
-					orc8r.NetworkSentryConfig:   models.NewDefaultSentryConfig(),
-					orc8r.DnsdNetworkType:       models.NewDefaultDNSConfig(),
-				},
-			},
-			{
-				ID:          "n2",
-				Type:        "blah",
-				Name:        "foobar",
-				Description: "Foo Bar",
-				Configs:     map[string]interface{}{},
+	_, err := configurator.CreateNetworks(context2.Background(), []configurator.Network{
+		{
+			ID:          "n1",
+			Type:        "type1",
+			Name:        "network1",
+			Description: "network 1",
+			Configs: map[string]interface{}{
+				orc8r.NetworkFeaturesConfig: models.NewDefaultFeaturesConfig(),
+				orc8r.NetworkSentryConfig:   models.NewDefaultSentryConfig(),
+				orc8r.DnsdNetworkType:       models.NewDefaultDNSConfig(),
 			},
 		},
-		serdes.Network,
-	)
+		{
+			ID:          "n2",
+			Type:        "blah",
+			Name:        "foobar",
+			Description: "Foo Bar",
+			Configs:     map[string]interface{}{},
+		},
+	}, serdes.Network)
 	assert.NoError(t, err)
 }

--- a/orc8r/cloud/go/services/orchestrator/obsidian/handlers/upgrade_handlers.go
+++ b/orc8r/cloud/go/services/orchestrator/obsidian/handlers/upgrade_handlers.go
@@ -31,7 +31,7 @@ import (
 )
 
 func listChannelsHandler(c echo.Context) error {
-	channelNames, err := configurator.ListInternalEntityKeys(orc8r.UpgradeReleaseChannelEntityType)
+	channelNames, err := configurator.ListInternalEntityKeys(c.Request().Context(), orc8r.UpgradeReleaseChannelEntityType)
 	if err != nil {
 		return obsidian.HttpError(err, http.StatusInternalServerError)
 	}
@@ -120,7 +120,7 @@ func listTiersHandler(c echo.Context) error {
 	if nerr != nil {
 		return nerr
 	}
-	tiers, err := configurator.ListEntityKeys(networkID, orc8r.UpgradeTierEntityType)
+	tiers, err := configurator.ListEntityKeys(c.Request().Context(), networkID, orc8r.UpgradeTierEntityType)
 	if err != nil {
 		return obsidian.HttpError(err, http.StatusInternalServerError)
 	}

--- a/orc8r/cloud/go/services/orchestrator/obsidian/handlers/upgrade_handlers_test.go
+++ b/orc8r/cloud/go/services/orchestrator/obsidian/handlers/upgrade_handlers_test.go
@@ -14,6 +14,7 @@
 package handlers_test
 
 import (
+	context2 "context"
 	"testing"
 
 	models1 "magma/orc8r/cloud/go/models"
@@ -229,7 +230,7 @@ func Test_Tiers(t *testing.T) {
 	readTier := tests.GetHandlerByPathAndMethod(t, obsidianHandlers, manageTiers, obsidian.GET).HandlerFunc
 	deleteTier := tests.GetHandlerByPathAndMethod(t, obsidianHandlers, manageTiers, obsidian.DELETE).HandlerFunc
 
-	assert.NoError(t, configurator.CreateNetwork(configurator.Network{ID: "n1"}, serdes.Network))
+	assert.NoError(t, configurator.CreateNetwork(context2.Background(), configurator.Network{ID: "n1"}, serdes.Network))
 
 	// happy case list
 	tc := tests.Test{

--- a/orc8r/cloud/go/services/orchestrator/obsidian/models/validate.go
+++ b/orc8r/cloud/go/services/orchestrator/obsidian/models/validate.go
@@ -14,6 +14,7 @@
 package models
 
 import (
+	"context"
 	"crypto/x509"
 	"errors"
 	"fmt"
@@ -24,42 +25,42 @@ import (
 const echoKeyType = "ECHO"
 const ecdsaKeyType = "SOFTWARE_ECDSA_SHA256"
 
-func (m *Network) ValidateModel() error {
+func (m *Network) ValidateModel(context.Context) error {
 	return m.Validate(strfmt.Default)
 }
 
-func (m *NetworkDNSConfig) ValidateModel() error {
+func (m *NetworkDNSConfig) ValidateModel(context.Context) error {
 	return m.Validate(strfmt.Default)
 }
 
-func (m *NetworkFeatures) ValidateModel() error {
+func (m *NetworkFeatures) ValidateModel(context.Context) error {
 	return m.Validate(strfmt.Default)
 }
 
-func (m *NetworkSentryConfig) ValidateModel() error {
+func (m *NetworkSentryConfig) ValidateModel(context.Context) error {
 	return m.Validate(strfmt.Default)
 }
 
-func (m NetworkDNSRecords) ValidateModel() error {
+func (m NetworkDNSRecords) ValidateModel(context.Context) error {
 	return m.Validate(strfmt.Default)
 }
 
-func (m DNSConfigRecord) ValidateModel() error {
+func (m DNSConfigRecord) ValidateModel(context.Context) error {
 	return m.Validate(strfmt.Default)
 }
 
-func (m *MagmadGateway) ValidateModel() error {
+func (m *MagmadGateway) ValidateModel(context.Context) error {
 	return m.Validate(strfmt.Default)
 }
 
-func (m *GatewayDevice) ValidateModel() error {
-	if err := m.Key.ValidateModel(); err != nil {
+func (m *GatewayDevice) ValidateModel(context.Context) error {
+	if err := m.Key.ValidateModel(context.Background()); err != nil {
 		return err
 	}
 	return m.Validate(strfmt.Default)
 }
 
-func (m *ChallengeKey) ValidateModel() error {
+func (m *ChallengeKey) ValidateModel(context.Context) error {
 	switch m.KeyType {
 	case echoKeyType:
 		if m.Key != nil {
@@ -80,49 +81,49 @@ func (m *ChallengeKey) ValidateModel() error {
 	}
 }
 
-func (m *MagmadGatewayConfigs) ValidateModel() error {
+func (m *MagmadGatewayConfigs) ValidateModel(context.Context) error {
 	if err := m.Validate(strfmt.Default); err != nil {
 		return err
 	}
 	return nil
 }
 
-func (m TierID) ValidateModel() error {
+func (m TierID) ValidateModel(context.Context) error {
 	return m.Validate(strfmt.Default)
 }
 
-func (m *ReleaseChannel) ValidateModel() error {
+func (m *ReleaseChannel) ValidateModel(context.Context) error {
 	return m.Validate(strfmt.Default)
 }
 
-func (m *Tier) ValidateModel() error {
+func (m *Tier) ValidateModel(context.Context) error {
 	return m.Validate(strfmt.Default)
 }
 
-func (m *TierName) ValidateModel() error {
+func (m *TierName) ValidateModel(context.Context) error {
 	return m.Validate(strfmt.Default)
 }
 
-func (m *TierVersion) ValidateModel() error {
+func (m *TierVersion) ValidateModel(context.Context) error {
 	return m.Validate(strfmt.Default)
 }
 
-func (m *TierGateways) ValidateModel() error {
+func (m *TierGateways) ValidateModel(context.Context) error {
 	return m.Validate(strfmt.Default)
 }
 
-func (m *TierImages) ValidateModel() error {
+func (m *TierImages) ValidateModel(context.Context) error {
 	return m.Validate(strfmt.Default)
 }
 
-func (m *TierImage) ValidateModel() error {
+func (m *TierImage) ValidateModel(context.Context) error {
 	return m.Validate(strfmt.Default)
 }
 
-func (m *GatewayStatus) ValidateModel() error {
+func (m *GatewayStatus) ValidateModel(context.Context) error {
 	return m.Validate(strfmt.Default)
 }
 
-func (m *GatewayVpnConfigs) ValidateModel() error {
+func (m *GatewayVpnConfigs) ValidateModel(context.Context) error {
 	return m.Validate(strfmt.Default)
 }

--- a/orc8r/cloud/go/services/state/client_api_test.go
+++ b/orc8r/cloud/go/services/state/client_api_test.go
@@ -187,7 +187,7 @@ func (m *Name) UnmarshalBinary(message []byte) error {
 	return err
 }
 
-func (m *Name) ValidateModel() error {
+func (m *Name) ValidateModel(context.Context) error {
 	if m.Name == "BADNAME" {
 		return fmt.Errorf("this name: %s is not allowed", m.Name)
 	}

--- a/orc8r/cloud/go/services/state/metrics/gateway_status_reporter.go
+++ b/orc8r/cloud/go/services/state/metrics/gateway_status_reporter.go
@@ -37,7 +37,7 @@ func PeriodicallyReportGatewayStatus(dur time.Duration) {
 }
 
 func reportGatewayStatus() error {
-	networks, err := configurator.ListNetworkIDs()
+	networks, err := configurator.ListNetworkIDs(context.Background())
 	if err != nil {
 		return err
 	}

--- a/orc8r/cloud/go/services/state/serde.go
+++ b/orc8r/cloud/go/services/state/serde.go
@@ -14,6 +14,7 @@
 package state
 
 import (
+	"context"
 	"encoding/json"
 
 	"magma/orc8r/cloud/go/serde"
@@ -36,7 +37,7 @@ func (m *StringToStringMap) UnmarshalBinary(data []byte) error {
 	return json.Unmarshal(data, m)
 }
 
-func (m *StringToStringMap) ValidateModel() error {
+func (m *StringToStringMap) ValidateModel(context.Context) error {
 	return nil
 }
 
@@ -55,6 +56,6 @@ func (j *ArbitraryJSON) UnmarshalBinary(data []byte) error {
 	return json.Unmarshal(data, j)
 }
 
-func (j *ArbitraryJSON) ValidateModel() error {
+func (j *ArbitraryJSON) ValidateModel(context.Context) error {
 	return nil
 }

--- a/orc8r/cloud/go/services/state/types/types.go
+++ b/orc8r/cloud/go/services/state/types/types.go
@@ -24,6 +24,7 @@ limitations under the License.
 package types
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 
@@ -263,7 +264,11 @@ func MakeState(p *protos.State, serdes serde.Registry) (State, *protos.IDAndErro
 		sErr := &protos.IDAndError{Type: p.Type, DeviceID: p.DeviceID, Error: err.Error()}
 		return State{}, sErr, nil
 	}
-	if err := model.ValidateModel(); err != nil {
+
+	// TODO: it's worth re-evaluating if ValidateModel should be allowed to
+	//  have side effects. For now, using context.Background() because
+	//  MakeState should not take in a context.
+	if err := model.ValidateModel(context.Background()); err != nil {
 		sErr := &protos.IDAndError{Type: p.Type, DeviceID: p.DeviceID, Error: err.Error()}
 		return State{}, sErr, nil
 	}

--- a/orc8r/cloud/go/services/streamer/providers/providers_test.go
+++ b/orc8r/cloud/go/services/streamer/providers/providers_test.go
@@ -14,6 +14,7 @@ limitations under the License.
 package providers_test
 
 import (
+	context2 "context"
 	"testing"
 
 	"magma/orc8r/cloud/go/orc8r"
@@ -53,7 +54,7 @@ func TestMconfigStreamer_Configurator(t *testing.T) {
 	mockBuilder.On("Build", mock.Anything, mock.Anything, "gw1").Return(marshaledConfigs, nil)
 	configurator_test_init.StartNewTestBuilder(t, mockBuilder)
 
-	err = configurator.CreateNetwork(configurator.Network{ID: "n1"}, serdes.Network)
+	err = configurator.CreateNetwork(context2.Background(), configurator.Network{ID: "n1"}, serdes.Network)
 	assert.NoError(t, err)
 	_, err = configurator.CreateEntity("n1", configurator.NetworkEntity{Type: orc8r.MagmadGatewayType, Key: "gw1", PhysicalID: "hw1"}, serdes.Entity)
 	assert.NoError(t, err)

--- a/orc8r/cloud/test/go.sum
+++ b/orc8r/cloud/test/go.sum
@@ -754,6 +754,7 @@ gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776 h1:tQIYjPdBoyREyB9XMu+nnTclpTYkz2zFM+lzLJFO4gQ=
 gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+gotest.tools/gotestsum v1.6.4/go.mod h1:fTR9ZhxC/TLAAx2/WMk/m3TkMB9eEI89gdEzhiRVJT8=
 gotest.tools/gotestsum v1.7.0/go.mod h1:V1m4Jw3eBerhI/A6qCxUE07RnCg7ACkKj9BYcAm09V8=
 gotest.tools/v3 v3.0.3/go.mod h1:Z7Lb0S5l+klDB31fvDQX8ss/FlKDxtlFlw3Oa8Ymbl8=
 honnef.co/go/tools v0.0.0-20180728063816-88497007e858/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=

--- a/wifi/cloud/go/services/wifi/obsidian/handlers/handlers.go
+++ b/wifi/cloud/go/services/wifi/obsidian/handlers/handlers.go
@@ -14,6 +14,7 @@
 package handlers
 
 import (
+	"context"
 	"net/http"
 	"reflect"
 	"sort"
@@ -224,7 +225,7 @@ func listMeshes(c echo.Context) error {
 		return nerr
 	}
 
-	ids, err := configurator.ListEntityKeys(nid, wifi.MeshEntityType)
+	ids, err := configurator.ListEntityKeys(c.Request().Context(), nid, wifi.MeshEntityType)
 	if err != nil {
 		if err == merrors.ErrNotFound {
 			return obsidian.HttpError(err, http.StatusNotFound)
@@ -245,7 +246,7 @@ func createMesh(c echo.Context) error {
 	if err := c.Bind(payload); err != nil {
 		return obsidian.HttpError(err, http.StatusBadRequest)
 	}
-	if err := payload.ValidateModel(); err != nil {
+	if err := payload.ValidateModel(context.Background()); err != nil {
 		return obsidian.HttpError(err, http.StatusBadRequest)
 	}
 
@@ -301,7 +302,7 @@ func updateMesh(c echo.Context) error {
 	if err := c.Bind(payload); err != nil {
 		return obsidian.HttpError(err, http.StatusBadRequest)
 	}
-	if err := payload.ValidateModel(); err != nil {
+	if err := payload.ValidateModel(context.Background()); err != nil {
 		return obsidian.HttpError(err, http.StatusBadRequest)
 	}
 	if string(payload.ID) != mid {

--- a/wifi/cloud/go/services/wifi/obsidian/handlers/handlers_test.go
+++ b/wifi/cloud/go/services/wifi/obsidian/handlers/handlers_test.go
@@ -116,7 +116,7 @@ func TestCreateNetwork(t *testing.T) {
 			wifi.WifiNetworkType:        models2.NewDefaultWifiNetworkConfig(),
 		},
 	}
-	actual, err := configurator.LoadNetwork("n1", true, true, serdes.Network)
+	actual, err := configurator.LoadNetwork(context.Background(), "n1", true, true, serdes.Network)
 	assert.NoError(t, err)
 	assert.Equal(t, expected, actual)
 }
@@ -232,7 +232,7 @@ func TestUpdateNetwork(t *testing.T) {
 	tc.ExpectedStatus = 204
 	tests.RunUnitTest(t, e, tc)
 
-	actualN1, err := configurator.LoadNetwork("n1", true, true, serdes.Network)
+	actualN1, err := configurator.LoadNetwork(context.Background(), "n1", true, true, serdes.Network)
 	assert.NoError(t, err)
 	expected := configurator.Network{
 		ID:          "n1",
@@ -305,7 +305,7 @@ func TestDeleteNetwork(t *testing.T) {
 	}
 	tests.RunUnitTest(t, e, tc)
 
-	actual, err := configurator.ListNetworkIDs()
+	actual, err := configurator.ListNetworkIDs(context.Background())
 	assert.NoError(t, err)
 	assert.Equal(t, []string{"n2"}, actual)
 }
@@ -386,7 +386,7 @@ func TestPartialUpdateAndGetNetwork(t *testing.T) {
 		ExpectedStatus: 204,
 	}
 	tests.RunUnitTest(t, e, tc)
-	actual, err := configurator.LoadNetwork("n1", true, true, serdes.Network)
+	actual, err := configurator.LoadNetwork(context.Background(), "n1", true, true, serdes.Network)
 	assert.NoError(t, err)
 	assert.Equal(t, updatedName, actual.Name)
 	tc = tests.Test{
@@ -412,7 +412,7 @@ func TestPartialUpdateAndGetNetwork(t *testing.T) {
 		ExpectedStatus: 204,
 	}
 	tests.RunUnitTest(t, e, tc)
-	actual, err = configurator.LoadNetwork("n1", true, true, serdes.Network)
+	actual, err = configurator.LoadNetwork(context.Background(), "n1", true, true, serdes.Network)
 	assert.NoError(t, err)
 	assert.Equal(t, updatedDescription, actual.Description)
 	tc = tests.Test{
@@ -438,7 +438,7 @@ func TestPartialUpdateAndGetNetwork(t *testing.T) {
 		ExpectedStatus: 204,
 	}
 	tests.RunUnitTest(t, e, tc)
-	actual, err = configurator.LoadNetwork("n1", true, true, serdes.Network)
+	actual, err = configurator.LoadNetwork(context.Background(), "n1", true, true, serdes.Network)
 	assert.NoError(t, err)
 	assert.Equal(t, updatedFeatures, actual.Configs[orc8r.NetworkFeaturesConfig].(*models.NetworkFeatures))
 	tc = tests.Test{
@@ -464,7 +464,7 @@ func TestPartialUpdateAndGetNetwork(t *testing.T) {
 		ExpectedStatus: 204,
 	}
 	tests.RunUnitTest(t, e, tc)
-	actual, err = configurator.LoadNetwork("n1", true, true, serdes.Network)
+	actual, err = configurator.LoadNetwork(context.Background(), "n1", true, true, serdes.Network)
 	assert.NoError(t, err)
 	assert.Equal(t, updatedWifi, actual.Configs[wifi.WifiNetworkType].(*models2.NetworkWifiConfigs))
 	tc = tests.Test{
@@ -2229,19 +2229,16 @@ func seedNetworks(t *testing.T) {
 	err := device.RegisterDevice(context.Background(), "n1", orc8r.AccessGatewayRecordType, "hw1", gatewayRecord, serdes.Device)
 	assert.NoError(t, err)
 
-	_, err = configurator.CreateNetworks(
-		[]configurator.Network{
-			models2.NewDefaultWifiNetwork().ToConfiguratorNetwork(),
-			{
-				ID:          "n2",
-				Type:        "blah",
-				Name:        "network_2",
-				Description: "Network 2",
-				Configs:     map[string]interface{}{},
-			},
+	_, err = configurator.CreateNetworks(context.Background(), []configurator.Network{
+		models2.NewDefaultWifiNetwork().ToConfiguratorNetwork(),
+		{
+			ID:          "n2",
+			Type:        "blah",
+			Name:        "network_2",
+			Description: "Network 2",
+			Configs:     map[string]interface{}{},
 		},
-		serdes.Network,
-	)
+	}, serdes.Network)
 	assert.NoError(t, err)
 }
 

--- a/wifi/cloud/go/services/wifi/obsidian/models/validate.go
+++ b/wifi/cloud/go/services/wifi/obsidian/models/validate.go
@@ -14,33 +14,35 @@
 package models
 
 import (
+	"context"
+
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/strfmt"
 )
 
-func (m *WifiNetwork) ValidateModel() error {
+func (m *WifiNetwork) ValidateModel(context.Context) error {
 	return m.Validate(strfmt.Default)
 }
 
-func (m *NetworkWifiConfigs) ValidateModel() error {
+func (m *NetworkWifiConfigs) ValidateModel(context.Context) error {
 	return m.Validate(strfmt.Default)
 }
 
-func (m *WifiGateway) ValidateModel() error {
+func (m *WifiGateway) ValidateModel(context.Context) error {
 	return m.Validate(strfmt.Default)
 }
 
-func (m *MutableWifiGateway) ValidateModel() error {
+func (m *MutableWifiGateway) ValidateModel(context.Context) error {
 	if err := m.Validate(strfmt.Default); err != nil {
 		return err
 	}
 
 	// Custom validation only for wifi and device
 	var res []error
-	if err := m.Wifi.ValidateModel(); err != nil {
+	if err := m.Wifi.ValidateModel(context.Background()); err != nil {
 		res = append(res, err)
 	}
-	if err := m.Device.ValidateModel(); err != nil {
+	if err := m.Device.ValidateModel(context.Background()); err != nil {
 		res = append(res, err)
 	}
 
@@ -50,18 +52,18 @@ func (m *MutableWifiGateway) ValidateModel() error {
 	return nil
 }
 
-func (m *GatewayWifiConfigs) ValidateModel() error {
+func (m *GatewayWifiConfigs) ValidateModel(context.Context) error {
 	return m.Validate(strfmt.Default)
 }
 
-func (m *WifiMesh) ValidateModel() error {
+func (m *WifiMesh) ValidateModel(context.Context) error {
 	return m.Validate(strfmt.Default)
 }
 
-func (m *MeshName) ValidateModel() error {
+func (m *MeshName) ValidateModel(context.Context) error {
 	return m.Validate(strfmt.Default)
 }
 
-func (m *MeshWifiConfigs) ValidateModel() error {
+func (m *MeshWifiConfigs) ValidateModel(context.Context) error {
 	return m.Validate(strfmt.Default)
 }


### PR DESCRIPTION
## Summary

- Propagate contexts in all network functions in configurator client_api.go

## Test Plan

- make test

## Additional Information

- [ ] This change is backwards-breaking

Signed-off-by: Jacky Tian <jacky@xjtian.com>
