### PR TITLE
chore: remove unused imports

### DIFF
--- a/lte/gateway/python/integ_tests/s1aptests/s1ap_utils.py
+++ b/lte/gateway/python/integ_tests/s1aptests/s1ap_utils.py
@@ -30,7 +30,7 @@ from integ_tests.gateway.rpc import get_rpc_channel
 from integ_tests.s1aptests.ovs.rest_api import get_datapath, get_flows
 from lte.protos.abort_session_pb2 import AbortSessionRequest, AbortSessionResult
 from lte.protos.abort_session_pb2_grpc import AbortSessionResponderStub
-from lte.protos.ha_service_pb2 import EnbOffloadType, StartAgwOffloadRequest
+from lte.protos.ha_service_pb2 import StartAgwOffloadRequest
 from lte.protos.ha_service_pb2_grpc import HaServiceStub
 from lte.protos.mobilityd_pb2 import IPAddress
 from lte.protos.policydb_pb2 import (

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_asr.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_asr.py
@@ -16,7 +16,7 @@ import unittest
 
 import s1ap_types
 from integ_tests.s1aptests import s1ap_wrapper
-from integ_tests.s1aptests.ovs.rest_api import get_datapath, get_flows
+from integ_tests.s1aptests.ovs.rest_api import get_datapath
 from integ_tests.s1aptests.s1ap_utils import SessionManagerUtil, SpgwUtil
 
 

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_with_he_policy.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_with_he_policy.py
@@ -16,7 +16,7 @@ import unittest
 
 import s1ap_types
 from integ_tests.s1aptests import s1ap_wrapper
-from integ_tests.s1aptests.ovs.rest_api import get_datapath, get_flows
+from integ_tests.s1aptests.ovs.rest_api import get_datapath
 from integ_tests.s1aptests.s1ap_utils import (
     GTPBridgeUtils,
     HeaderEnrichmentUtils,
@@ -24,7 +24,6 @@ from integ_tests.s1aptests.s1ap_utils import (
     SpgwUtil,
 )
 from lte.protos.policydb_pb2 import FlowMatch, HeaderEnrichment
-from ryu.lib.packet.in_proto import IPPROTO_TCP
 
 
 class TestAttachDetachWithHE(unittest.TestCase):

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_with_multiple_mme_restarts.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_with_multiple_mme_restarts.py
@@ -11,10 +11,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-import time
 import unittest
 
-import orc8r.protos.metricsd_pb2 as metricsd
 import s1ap_types
 import s1ap_wrapper
 from s1ap_utils import MagmadUtil

--- a/lte/gateway/python/integ_tests/s1aptests/test_enb_partial_reset_con_dereg.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_enb_partial_reset_con_dereg.py
@@ -11,7 +11,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-import ctypes
 import time
 import unittest
 from builtins import range

--- a/lte/gateway/python/integ_tests/s1aptests/test_multi_enb_partial_reset.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_multi_enb_partial_reset.py
@@ -11,7 +11,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-import ctypes
 import time
 import unittest
 from builtins import range

--- a/lte/gateway/python/integ_tests/s1aptests/test_no_esm_information_rsp_with_mme_restart.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_no_esm_information_rsp_with_mme_restart.py
@@ -55,6 +55,7 @@ class TestNoEsmInformationRspWithMmeRestart(unittest.TestCase):
             s1ap_types.tfwCmd.UE_ATTACH_REQUEST, attach_req,
         )
 
+        global response
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
             response.msg_type, s1ap_types.tfwCmd.UE_AUTH_REQ_IND.value,
@@ -108,7 +109,6 @@ class TestNoEsmInformationRspWithMmeRestart(unittest.TestCase):
                 ue_id,
             )
             # Wait for UE_CTX_REL_IND
-            global response
             response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
             response.msg_type, s1ap_types.tfwCmd.UE_CTX_REL_IND.value,

--- a/lte/gateway/python/integ_tests/s1aptests/test_standalone_pdn_conn_req.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_standalone_pdn_conn_req.py
@@ -12,11 +12,8 @@ limitations under the License.
 """
 
 import ctypes
-import threading
-import time
 import unittest
 
-import gpp_types
 import s1ap_types
 import s1ap_wrapper
 

--- a/lte/gateway/python/integ_tests/s1aptests/test_standalone_pdn_conn_req_with_apn_correction.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_standalone_pdn_conn_req_with_apn_correction.py
@@ -12,11 +12,9 @@ limitations under the License.
 """
 
 import ctypes
-import threading
 import time
 import unittest
 
-import gpp_types
 import s1ap_types
 import s1ap_wrapper
 from s1ap_utils import MagmadUtil

--- a/lte/gateway/python/integ_tests/s1aptests/test_stateless_multi_ue_mixedstate_mme_restart.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_stateless_multi_ue_mixedstate_mme_restart.py
@@ -13,7 +13,6 @@ limitations under the License.
 
 import ctypes
 import ipaddress
-import time
 import unittest
 
 import gpp_types

--- a/lte/gateway/python/integ_tests/s1aptests/util/traffic_messages.py
+++ b/lte/gateway/python/integ_tests/s1aptests/util/traffic_messages.py
@@ -14,8 +14,6 @@ limitations under the License.
 import enum
 import pickle
 
-import iperf3  # Used by recv to reconstruct iperf3.TestResult objects
-
 '''
 TrafficServerInstance and TrafficTestInstance are payloads used to coordinate
 trfgen testing configurations, e.g. IPs and ports.


### PR DESCRIPTION
<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

Resolves #6057. 

In addition, it was found that the tests were throwing the following error on master:
```shell
Traceback (most recent call last):
  File "/usr/local/lib/python3.8/site-packages/pydocstyle/parser.py", line 415, in parse
    compile(src, filename, 'exec')
  File "lte/gateway/python/integ_tests/s1aptests/test_no_esm_information_rsp_with_mme_restart.py", line 111
    global response
    ^
SyntaxError: name 'response' is used prior to global declaration
```

326e17c was added to fix this error.

<!-- Enumerate changes you made and why you made them -->

## Test Plan
### Lint Grep
```shell
 % ./precommit.py --lint -p lte/gateway/python/integ_tests/s1aptests | grep -i "imported but unused"
 % 
```

### Format
```shell
 % ./precommit.py --format -p lte/gateway/python/integ_tests/s1aptests                              

Magma root is /Users/evanau/magma
Running 'docker run -it -u 0 -v /Users/evanau/magma:/code magma/py-lint:latest isort lte/gateway/python/integ_tests/s1aptests'...
Running 'docker run -it -u 0 -v /Users/evanau/magma:/code magma/py-lint:latest autopep8 --select W191,W291,W292,W293,W391,E2,E3 -r --in-place lte/gateway/python/integ_tests/s1aptests'...
 %
```

### CircleCI
`lte-integ-test` passes ([link](https://app.circleci.com/pipelines/github/magma/magma/30605/workflows/cc7f7506-c1de-4bb6-8f28-826052cc89bc/jobs/351908)).

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
