### PR TITLE
Revert "feat(pipelined): Use future for poll stats retrieval (#8205)"

### DIFF
--- a/lte/gateway/python/magma/pipelined/openflow/flows.py
+++ b/lte/gateway/python/magma/pipelined/openflow/flows.py
@@ -672,7 +672,7 @@ def send_stats_request(
     cookie_mask: hex = 0, retries: int = 3,
 ):
     """
-    Send a stats request msg
+    Send a stats request msg 
     Args:
         datapath (ryu.controller.controller.Datapath):
             Datapath to query from
@@ -691,6 +691,4 @@ def send_stats_request(
         cookie_mask=cookie_mask,
     )
     logger.debug('flowmod: %s (table %d)', req, tbl_num)
-    xid = datapath.set_xid(req)
     messages.send_msg(datapath, req, retries)
-    return xid

--- a/lte/gateway/python/magma/pipelined/tests/test_pull_stats.py
+++ b/lte/gateway/python/magma/pipelined/tests/test_pull_stats.py
@@ -90,7 +90,6 @@ class PullStatsTest(unittest.TestCase):
                 'enforcement': {
                     'poll_interval': 2,
                     'default_drop_flow_name': self.DEFAULT_DROP_FLOW_NAME,
-                    'periodic_stats_reporting': False,
                 },
                 'nat_iface': 'eth2',
                 'enodeb_iface': 'eth1',


### PR DESCRIPTION
This reverts commit 317974886169e1884655e4b5c46374c437da6852.

Signed-off-by: Nick Yurchenko <koolzz@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
