### PR TITLE
fix(session_proxy): add service identifier to terminate request to

### DIFF
--- a/feg/gateway/services/session_proxy/credit_control/gy/model_conversion.go
+++ b/feg/gateway/services/session_proxy/credit_control/gy/model_conversion.go
@@ -34,6 +34,7 @@ func (credits *UsedCredits) FromCreditUsage(usage *protos.CreditUsage) *UsedCred
 	credits.OutputOctets = usage.BytesRx // receive == output
 	credits.TotalOctets = usage.BytesTx + usage.BytesRx
 	credits.Type = UsedCreditsType(usage.Type)
+	credits.ServiceIdentifier = fromServiceIdentifier(usage.ServiceIdentifier)
 	return credits
 }
 


### PR DESCRIPTION
session_proxy

Signed-off-by: Oriol Batalla <obatalla@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

Fixing possible issue reported here 

https://magmacore.slack.com/archives/G01N7ABCL6M/p1628207845010200

Service identifier was not included on terminate request

## Test Plan
./build.py -c
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
