### PR TITLE
chore: remove PipelineD from being excluded in the formatting check

### DIFF
--- a/.github/workflows/python-formatting-check.yml
+++ b/.github/workflows/python-formatting-check.yml
@@ -8,7 +8,6 @@ on:  # yamllint disable-line rule:truthy
       - synchronize
     paths:  # order matters here, always put includes then excludes
       - '**.py'
-      - '!lte/gateway/python/magma/pipelined/**.py'  # TODO add back
 
 jobs:
   run-formatters-and-check-for-errors:


### PR DESCRIPTION
Signed-off-by: Marie Bremner <marwhal@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary
After https://github.com/magma/magma/pull/8256 is merged, we should no longer exclude PipelineD from the check
<!-- Enumerate changes you made and why you made them -->

## Test Plan
N/A
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
