### PR TITLE
fix(s6a_proxy): remove origin-state-id avp

### DIFF
--- a/feg/gateway/services/s6a_proxy/servicers/s6a_proxy.go
+++ b/feg/gateway/services/s6a_proxy/servicers/s6a_proxy.go
@@ -64,7 +64,6 @@ type s6aProxy struct {
 	connMan        *diameter.ConnectionManager
 	requestTracker *diameter.RequestTracker
 	healthTracker  *metrics.S6aHealthTracker
-	originStateID  uint32
 }
 
 func NewS6aProxy(
@@ -132,7 +131,6 @@ func NewS6aProxy(
 		connMan:        connMan,
 		requestTracker: diameter.NewRequestTracker(),
 		healthTracker:  metrics.NewS6aHealthTracker(),
-		originStateID:  originStateID,
 	}
 	mux.HandleIdx(
 		diam.CommandIndex{AppID: diam.TGPP_S6A_APP_ID, Code: diam.AuthenticationInformation, Request: false},

--- a/feg/gateway/services/s6a_proxy/servicers/util.go
+++ b/feg/gateway/services/s6a_proxy/servicers/util.go
@@ -24,7 +24,4 @@ import (
 func (s *s6aProxy) addDiamOriginAVPs(m *diam.Message) {
 	m.NewAVP(avp.OriginHost, avp.Mbit, 0, datatype.DiameterIdentity(s.config.ClientCfg.Host))
 	m.NewAVP(avp.OriginRealm, avp.Mbit, 0, datatype.DiameterIdentity(s.config.ClientCfg.Realm))
-	if s.originStateID != 0 {
-		m.NewAVP(avp.OriginStateID, avp.Mbit, 0, datatype.Unsigned32(s.originStateID))
-	}
 }


### PR DESCRIPTION
Signed-off-by: Oriol Batalla <obatalla@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary
Per 3gpp `origin-state-id` avp should not be included in any of the s6a messages
 
3GPP TS 129 272 V15.4.0
https://www.etsi.org/deliver/etsi_ts/129200_129299/129272/16.06.00_60/ts_129272v160600p.pdf



## Test Plan

./build.py -c

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
