### PR TITLE
fix(orc8r): Fix Orc8r bug causing subscriber sync to fail

### DIFF
--- a/lte/cloud/go/services/nprobe/storage/storage_blobstore.go
+++ b/lte/cloud/go/services/nprobe/storage/storage_blobstore.go
@@ -38,7 +38,7 @@ type nprobeBlobStore struct {
 
 // StoreNProbeData stores current state for a given networkID and taskID
 func (c *nprobeBlobStore) StoreNProbeData(networkID, taskID string, data models.NetworkProbeData) error {
-	store, err := c.factory.StartTransaction(&storage.TxOptions{ReadOnly: false})
+	store, err := c.factory.StartTransaction(nil)
 	if err != nil {
 		return errors.Wrap(err, "failed to start transaction")
 	}

--- a/lte/cloud/go/services/subscriberdb/storage/last_resync.go
+++ b/lte/cloud/go/services/subscriberdb/storage/last_resync.go
@@ -56,7 +56,7 @@ func (l *LastResyncTimeStore) Get(network string, gateway string) (uint32, error
 }
 
 func (l *LastResyncTimeStore) Set(network string, gateway string, unixTime uint32) error {
-	store, err := l.fact.StartTransaction(&storage.TxOptions{ReadOnly: true})
+	store, err := l.fact.StartTransaction(nil)
 	if err != nil {
 		return errors.Wrapf(err, "error starting transaction")
 	}

--- a/lte/cloud/go/services/subscriberdb/storage/per_sub_digest.go
+++ b/lte/cloud/go/services/subscriberdb/storage/per_sub_digest.go
@@ -70,7 +70,7 @@ func (l *PerSubDigestStore) GetDigest(network string) ([]*lte_protos.SubscriberD
 
 // SetDigest creates or updates the per-subscriber digests of a network.
 func (l *PerSubDigestStore) SetDigest(network string, digests []*lte_protos.SubscriberDigestWithID) error {
-	store, err := l.fact.StartTransaction(&storage.TxOptions{ReadOnly: true})
+	store, err := l.fact.StartTransaction(nil)
 	if err != nil {
 		return errors.Wrap(err, "error starting transaction")
 	}

--- a/orc8r/cloud/go/services/accessd/storage/storage_blobstore.go
+++ b/orc8r/cloud/go/services/accessd/storage/storage_blobstore.go
@@ -145,7 +145,7 @@ func (a *accessdBlobstore) PutACL(id *protos.Identity, acl *accessprotos.AccessC
 		return status.Error(codes.InvalidArgument, "nil AccessControl_List")
 	}
 
-	store, err := a.factory.StartTransaction(&storage.TxOptions{})
+	store, err := a.factory.StartTransaction(nil)
 	if err != nil {
 		return status.Errorf(codes.Unavailable, "failed to start transaction: %s", err)
 	}
@@ -177,7 +177,7 @@ func (a *accessdBlobstore) UpdateACLWithEntities(id *protos.Identity, entities [
 		return status.Error(codes.InvalidArgument, "nil AccessControl_Entity slice")
 	}
 
-	store, err := a.factory.StartTransaction(&storage.TxOptions{})
+	store, err := a.factory.StartTransaction(nil)
 	if err != nil {
 		return status.Errorf(codes.Unavailable, "failed to start transaction: %s", err)
 	}
@@ -223,7 +223,7 @@ func (a *accessdBlobstore) DeleteACL(id *protos.Identity) error {
 		return status.Error(codes.InvalidArgument, "nil Identity")
 	}
 
-	store, err := a.factory.StartTransaction(&storage.TxOptions{})
+	store, err := a.factory.StartTransaction(nil)
 	if err != nil {
 		return status.Errorf(codes.Unavailable, "failed to start transaction: %s", err)
 	}

--- a/orc8r/cloud/go/services/certifier/storage/storage_blobstore.go
+++ b/orc8r/cloud/go/services/certifier/storage/storage_blobstore.go
@@ -133,7 +133,7 @@ func (c *certifierBlobstore) GetAllCertInfo() (map[string]*protos.CertificateInf
 }
 
 func (c *certifierBlobstore) PutCertInfo(serialNumber string, certInfo *protos.CertificateInfo) error {
-	store, err := c.factory.StartTransaction(&storage.TxOptions{})
+	store, err := c.factory.StartTransaction(nil)
 	if err != nil {
 		return errors.Wrap(err, "failed to start transaction")
 	}
@@ -154,7 +154,7 @@ func (c *certifierBlobstore) PutCertInfo(serialNumber string, certInfo *protos.C
 }
 
 func (c *certifierBlobstore) DeleteCertInfo(serialNumber string) error {
-	store, err := c.factory.StartTransaction(&storage.TxOptions{})
+	store, err := c.factory.StartTransaction(nil)
 	if err != nil {
 		return errors.Wrap(err, "failed to start transaction")
 	}

--- a/orc8r/cloud/go/services/ctraced/storage/storage_blobstore.go
+++ b/orc8r/cloud/go/services/ctraced/storage/storage_blobstore.go
@@ -43,7 +43,7 @@ type ctracedBlobStore struct {
 
 // StoreCallTrace
 func (c *ctracedBlobStore) StoreCallTrace(networkID string, callTraceID string, data []byte) error {
-	store, err := c.factory.StartTransaction(&storage.TxOptions{ReadOnly: false})
+	store, err := c.factory.StartTransaction(nil)
 	if err != nil {
 		return errors.Wrap(err, "failed to start transaction")
 	}

--- a/orc8r/cloud/go/services/directoryd/storage/storage_blobstore.go
+++ b/orc8r/cloud/go/services/directoryd/storage/storage_blobstore.go
@@ -74,7 +74,7 @@ func (d *directorydBlobstore) GetHostnameForHWID(hwid string) (string, error) {
 }
 
 func (d *directorydBlobstore) MapHWIDsToHostnames(hwidToHostname map[string]string) error {
-	store, err := d.factory.StartTransaction(&storage.TxOptions{})
+	store, err := d.factory.StartTransaction(nil)
 	if err != nil {
 		return errors.Wrap(err, "failed to start transaction")
 	}
@@ -111,7 +111,7 @@ func (d *directorydBlobstore) GetIMSIForSessionID(networkID, sessionID string) (
 }
 
 func (d *directorydBlobstore) MapSessionIDsToIMSIs(networkID string, sessionIDToIMSI map[string]string) error {
-	store, err := d.factory.StartTransaction(&storage.TxOptions{})
+	store, err := d.factory.StartTransaction(nil)
 	if err != nil {
 		return errors.Wrap(err, "failed to start transaction")
 	}
@@ -148,7 +148,7 @@ func (d *directorydBlobstore) GetHWIDForSgwCTeid(networkID, teid string) (string
 }
 
 func (d *directorydBlobstore) MapSgwCTeidToHWID(networkID string, sgwCTeidToHwid map[string]string) error {
-	store, err := d.factory.StartTransaction(&storage.TxOptions{})
+	store, err := d.factory.StartTransaction(nil)
 	if err != nil {
 		return errors.Wrap(err, "failed to start transaction to Map sgwCTeidToHwid")
 	}

--- a/orc8r/cloud/go/syncstore/store_writer.go
+++ b/orc8r/cloud/go/syncstore/store_writer.go
@@ -292,7 +292,7 @@ func (l *syncStore) collectGarbageCacheWriter(tracked []string) error {
 // getInvalidCacheWriter returns a list of cache writer IDs from blobstore that
 // either belong to already deleted networks or have expired.
 func (l *syncStore) getInvalidCacheWriter(tracked []string, cacheWriterValidIntervalSecs int64) (map[string][]string, error) {
-	store, err := l.fact.StartTransaction(nil)
+	store, err := l.fact.StartTransaction(&storage.TxOptions{ReadOnly: true})
 	if err != nil {
 		return nil, errors.Wrap(err, "error starting transaction")
 	}


### PR DESCRIPTION
<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

Subscriber sync is failing due to "read only" being incorrectly assigned. Also cleaned up other usages.

Refs

- Error: https://gist.github.com/themarwhal/fa1a93fd0d6a03b584cfc130c4ba69c4
- Reported: https://magmacore.slack.com/archives/C01RENQQZB4/p1628623693054900

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->