### PR TITLE
docs: fix doc lint on master

### DIFF
--- a/docs/docusaurus/i18n/en.json
+++ b/docs/docusaurus/i18n/en.json
@@ -426,6 +426,9 @@
       "proposals/p018_control_network_metrics": {
         "title": "Export Control Path Network Metrics"
       },
+      "proposals/p019_enodeb_cbrs_support": {
+        "title": "Enodebd CBRS Support"
+      },
       "proposals/qos_enforcement": {
         "title": "proposals/qos_enforcement"
       },

--- a/docs/docusaurus/sidebars.json
+++ b/docs/docusaurus/sidebars.json
@@ -318,7 +318,8 @@
           "proposals/p007_header_enrichment",
           "proposals/p008_apn_correction",
           "proposals/p013_Ubuntu_upgrade",
-          "proposals/p018_control_network_metrics"
+          "proposals/p018_control_network_metrics",
+          "proposals/p019_enodeb_cbrs_support"
         ]
       },
       {

--- a/docs/readmes/proposals/p019_enodeb_cbrs_support.md
+++ b/docs/readmes/proposals/p019_enodeb_cbrs_support.md
@@ -1,12 +1,19 @@
-Proposal: [Enodebd CBRS Support]
+---
+id: p019_enodeb_cbrs_support
+title: Enodebd CBRS Support
+hide_title: true
+---
+
+# Proposal: [Enodebd CBRS Support]
 
 Author(s): [@amarpad]
 
 Last updated: [07/20/2021]
 
-Discussion at https://github.com/magma/magma/issues/8196.
+Discussion at <https://github.com/magma/magma/issues/8196>.
 
-Context & scope
+## Context & scope
+
 CBRS radios require specific radio parameters to be set based on grants that
 can be obtained from third party spectrum databases called SAS. In Magma this
 requires communication between the enodebd service that manages the radio
@@ -18,51 +25,57 @@ opposed to directly from the enodeb including security. Further, having the
 desired state of the network including the radio parameters managed in the
 orchestrator has been a primary goal of Magma.
 
-Goals
-- Allow enodebs to obtain spectrum leases from SAS on bring up
-- Allow enodebs to heartbeat to the SAS and if needed the SAS can revoke the
-  grant
-- Deregister a cbrs eNB from the SAS when it is deleted from magma.
-- Relinquish a grant if the eNB stops radiating.
+## Goal
 
-Non-goals/Simplifications
+- Allow enodebs to obtain spectrum leases from SAS on bring up  
+- Allow enodebs to heartbeat to the SAS and if needed the SAS can revoke the
+  grant  
+- Deregister a cbrs eNB from the SAS when it is deleted from magma  
+- Relinquish a grant if the eNB stops radiating  
+
+## Non-goals / simplifications
+
 - For simplicity we collapse the need for a SAS grant with the transmit enabled
   status of the radio. i.e. if a CBRS radio is transmitting we assume it needs
   a grant.
 
-Proposal
+## Proposal
 
 The top level goal of this proposal is to have the domain proxy on the
 orchestrator to serve as the truth and act as a desired state store for the
 enodeb and rely on a control channel between enodebd->domain proxy and
 enodeb->enodebd to keep the actual state in sync with the desired state.
 
-User facing:
+### User facing
+
 - NMS: NMS will explicitly support specific CBRS certified radios from vendors.
   The knowledge of these radios being CBRS certified is obtained out of band.
   i.e. for practical purposes the onboarding of these radios are going to be
   similar to what we have today.
 
-API changes:
+### API changes
+
 - Swagger: Swagger will introduce a new vendor name for CBRS certified radios
 
-**mconfig changes:**
+### Mconfig changes
+
 - mconfig will be extended to introduce a new boolean field indicating if the
   radio is a CBRS radio.
 
-**enodebd changes: (only applies to CBRS enodebs)**
+### Enodebd changes (only applies to CBRS enodebs)
 
 There are two subcases for enodeb bring up, eNB provisioned for first time/after
 factory reset. eNB reconnecting to enodebd after reboot/disconnect etc.
 
-**New enodebd provisioning:**
+#### New enodebd provisioning
 
 enodebd is in the new enodeb provisioning flow if there is no SAS related
 state for the eNB in Redis.
 
-Towards eNB:
+#### Towards eNB
 
 Precondition: SAS state in Redis and in-memory is none.
+
 - Parse Inform message as today, if serial number maps to enodeb with CBRS
   enabled and gps location absent, transition to enabling GPS state (new state),
   else complete session state (same complete session as today).
@@ -71,18 +84,21 @@ Precondition: SAS state in Redis and in-memory is none.
 - Read GPS location, serial number as part of next inform, complete session.
 - Radio status here is GPS is enabled, but radio is not transmitting
 
-Towards cloud:
+#### Towards cloud
 
 Precondition: GPS state, serial number available.
+
 - Make GRPC call to domain proxy for registration request with the following
   fields populated.
-  ```
-  “cbsdSerialNumber”: “abcd1234”,
-  “installationParam”: {
-    “latitude”: 37.425056,
-    “longitude”: -122.084113,
+
+  ```json
+  "cbsdSerialNumber": "abcd1234",
+  "installationParam": {
+    "latitude": 37.425056,
+    "longitude": -122.084113,
   }
   ```
+
 - The domain proxy will persist this state in the database and will interact
   with the SAS on behalf of the enodeb using these parameters.
 - On response from the SAS the domain proxy will persist the grant in the
@@ -90,16 +106,19 @@ Precondition: GPS state, serial number available.
 - Enodebd will periodically poll the domain proxy to retrive the desired
   state of the radio, once the SAS grant has been recvd the domain proxy
   will respond with a payload like
-  ```
+
+  ```json
   "Tx enabled": yes
   "Tx Power" : xxxx
   "Frequency" : yyyy
   ```
+
   this poll frequency is configurable.
 - Version 1: Restart enodebd, when enodebd comes back up it will be in the
   reboot/reconnect enodeb flow.
 
-**Reboot/Reconnect endoebd provisioning**:
+#### Reboot/Reconnect endoebd provisioning
+
 - Populate in-memory tx power, frequency and other SAS parameter states that
   specific vendors require on startup.
 - On Inform message if serial number maps to CBRS enabled enodeb, set cbrs
@@ -107,58 +126,63 @@ Precondition: GPS state, serial number available.
 - enodebd will continue to poll the domain proxy as above for the transmit
   payload.
 
-**Hearbeat and spectrum revocation**
+#### Hearbeat and spectrum revocation
 
 The domain proxy will heartbeat with the SAS on behalf of all enodebs
 provisioned at a frequency specified by the SAS.
+
 - On spectrum revocation the domain proxy will update the database state
   associated with the eNB to disable transmit.
 - enodebd's periodic poll request will return the following
-  ```
+
+  ```json
   "Tx enabled": false
   ```
+
 - enodebd will remove the sas redis state associated with the radio and restart.
 - enodebd will move into new enodebd provisioning flow.
 
-**Handling radio relocation**
+#### Handling radio relocation
+
 The poll request from the enodebd can contain the lat/long associated with the
 enodeb, if the location changes, the domain proxy can reset the Tx enabled flag
 which will cause the enodeb to stop transmitting and restart provisioning based
 on the new lat long. The Domain proxy inturn will need to explicitly
 relinquish the grant from the SAS using the "Relenquish" method.
 
-Alternatives considered
+## Alternatives considered
 
 - Leverage sync RPC or bi-directional GRPC for communication from the DP to
   the enodebd instead of a poll loop: We deprioritized this option to use
   poll for the following reasons:
-  - The domain proxy instance that receives the heartbeat revoking the
+    - The domain proxy instance that receives the heartbeat revoking the
     spectrum grant might still need to persist the state in case the enodebd
     is unreachable. Further modeling the event as state is more Magmaesque.
     Poll is a simple way of state synchronization using a set interface
-  - Sync RPC and GRPC based streaming are more complicated.
+    - Sync RPC and GRPC based streaming are more complicated.
 
 - Not restarting the enodebd service when SAS gets configured: This is just
   a phase-1 implementation, further as the interface towards the enodebd is
   idempotent restarting the enodebd service should have no effect on traffic.
 
-Cross-cutting concerns
+## Cross-cutting concerns
+
 - SAS interactions are message oriented, by persisting the desired enodeb
   state we model this more as a level trigger. This comes at the expense of
   responsiveness (capped by poll frequency), but this is an explicit tradeoff.
 
-Compatibility
+## Compatibility
 
 N/A
 
-Observability and Debug
+## Observability and Debug
 
 enodebd_cli should be enhanced to show SAS related information
 
-Security & privacy
+## Security & privacy
 
 Reuse existing communication channels
 
-Open issues (if applicable)
+## Open issues (if applicable)
 
 - Optimize away the need to restart enodebd on SAS param changes


### PR DESCRIPTION
Signed-off-by: Marie Bremner <marwhal@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary
* Saw that doc precommit fails on master
* Added proposal 19 to docusaurus 

<!-- Enumerate changes you made and why you made them -->

## Test Plan
Seen on master
```
Creating readmes_readmes_run ... done
proposals/p019_enodeb_cbrs_support.md:1 MD041/first-line-heading/first-line-h1 First line in a file should be a top-level heading [Context: "Proposal: [Enodebd CBRS Suppor..."]
proposals/p019_enodeb_cbrs_support.md:7:15 MD034/no-bare-urls Bare URL used [Context: "https://github.com/magma/magma..."]
proposals/p019_enodeb_cbrs_support.md:22 MD032/blanks-around-lists Lists should be surrounded by blank lines [Context: "- Allow enodebs to obtain spec..."]
proposals/p019_enodeb_cbrs_support.md:29 MD032/blanks-around-lists Lists should be surrounded by blank lines [Context: "- For simplicity we collapse t..."]
proposals/p019_enodeb_cbrs_support.md:41 MD032/blanks-around-lists Lists should be surrounded by blank lines [Context: "- NMS: NMS will explicitly sup..."]
proposals/p019_enodeb_cbrs_support.md:47 MD032/blanks-around-lists Lists should be surrounded by blank lines [Context: "- Swagger: Swagger will introd..."]
proposals/p019_enodeb_cbrs_support.md:50 MD032/blanks-around-lists Lists should be surrounded by blank lines [Context: "- mconfig will be extended to ..."]
proposals/p019_enodeb_cbrs_support.md:53 MD036/no-emphasis-as-heading/no-emphasis-as-header Emphasis used instead of a heading [Context: "enodebd changes: (only applies..."]
proposals/p019_enodeb_cbrs_support.md:66 MD032/blanks-around-lists Lists should be surrounded by blank lines [Context: "- Parse Inform message as toda..."]
proposals/p019_enodeb_cbrs_support.md:77 MD032/blanks-around-lists Lists should be surrounded by blank lines [Context: "- Make GRPC call to domain pro..."]
proposals/p019_enodeb_cbrs_support.md:79 MD031/blanks-around-fences Fenced code blocks should be surrounded by blank lines [Context: "```"]
proposals/p019_enodeb_cbrs_support.md:79 MD040/fenced-code-language Fenced code blocks should have a language specified [Context: "  ```"]
proposals/p019_enodeb_cbrs_support.md:85 MD031/blanks-around-fences Fenced code blocks should be surrounded by blank lines [Context: "```"]
proposals/p019_enodeb_cbrs_support.md:93 MD031/blanks-around-fences Fenced code blocks should be surrounded by blank lines [Context: "```"]
proposals/p019_enodeb_cbrs_support.md:93 MD040/fenced-code-language Fenced code blocks should have a language specified [Context: "  ```"]
proposals/p019_enodeb_cbrs_support.md:97 MD031/blanks-around-fences Fenced code blocks should be surrounded by blank lines [Context: "```"]
proposals/p019_enodeb_cbrs_support.md:103 MD032/blanks-around-lists Lists should be surrounded by blank lines [Context: "- Populate in-memory tx power,..."]
proposals/p019_enodeb_cbrs_support.md:110 MD036/no-emphasis-as-heading/no-emphasis-as-header Emphasis used instead of a heading [Context: "Hearbeat and spectrum revocati..."]
proposals/p019_enodeb_cbrs_support.md:114 MD032/blanks-around-lists Lists should be surrounded by blank lines [Context: "- On spectrum revocation the d..."]
proposals/p019_enodeb_cbrs_support.md:117 MD031/blanks-around-fences Fenced code blocks should be surrounded by blank lines [Context: "```"]
proposals/p019_enodeb_cbrs_support.md:117 MD040/fenced-code-language Fenced code blocks should have a language specified [Context: "  ```"]
proposals/p019_enodeb_cbrs_support.md:119 MD031/blanks-around-fences Fenced code blocks should be surrounded by blank lines [Context: "```"]
proposals/p019_enodeb_cbrs_support.md:135:1 MD007/ul-indent Unordered list indentation [Expected: 4; Actual: 2]
proposals/p019_enodeb_cbrs_support.md:139:1 MD007/ul-indent Unordered list indentation [Expected: 4; Actual: 2]
proposals/p019_enodeb_cbrs_support.md:146 MD032/blanks-around-lists Lists should be surrounded by blank lines [Context: "- SAS interactions are message..."]
ERROR: 1
make[1]: *** [precommit] Error 1
make: *** [precommit] Error 2
```

With these changes
```
➜  docs git:(address-md-lint) ✗ make precommit
make -C readmes precommit
docker build -t magma_readmes .
[+] Building 1.2s (8/8) FINISHED
 => [internal] load build definition from Dockerfile                                                                                                                                                                                                     0.0s
 => => transferring dockerfile: 138B                                                                                                                                                                                                                     0.0s
 => [internal] load .dockerignore                                                                                                                                                                                                                        0.0s
 => => transferring context: 2B                                                                                                                                                                                                                          0.0s
 => [internal] load metadata for docker.io/library/node:14                                                                                                                                                                                               1.1s
 => [1/4] FROM docker.io/library/node:14@sha256:cd98882c1093f758d09cf6821dc8f96b241073b38e8ed294ca1f9e484743858f                                                                                                                                         0.0s
 => CACHED [2/4] RUN mkdir -p /readmes                                                                                                                                                                                                                   0.0s
 => CACHED [3/4] WORKDIR /readmes                                                                                                                                                                                                                        0.0s
 => CACHED [4/4] RUN npm install --global markdownlint-cli                                                                                                                                                                                               0.0s
 => exporting to image                                                                                                                                                                                                                                   0.0s
 => => exporting layers                                                                                                                                                                                                                                  0.0s
 => => writing image sha256:4f88f810fb275a5ef12ddf38b3fd309cbcec3e7a81b94f9447b9f32de4bda40a                                                                                                                                                             0.0s
 => => naming to docker.io/library/magma_readmes                                                                                                                                                                                                         0.0s
docker-compose run readmes markdownlint --ignore proposals/p010_vendor_neutral_dp.md . && echo PASSED
Creating readmes_readmes_run ... done
PASSED
```
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
