### PR TITLE
fix: stop trying to start kernsnoopd

### DIFF
--- a/lte/gateway/configs/magmad.yml
+++ b/lte/gateway/configs/magmad.yml
@@ -35,7 +35,7 @@ magma_services:
   - smsd
   - ctraced
   - health
-  - kernsnoopd
+#  - kernsnoopd
 # - liagentd
 
 # List of services that don't provide service303 interface
@@ -126,7 +126,7 @@ metricsd:
     - pipelined
     - state
     - sessiond
-    - kernsnoopd
+#    - kernsnoopd
 
 generic_command_config:
   module: magma.magmad.generic_command.shell_command_executor


### PR DESCRIPTION
Signed-off-by: Waqar Aqeel <waqeel@fb.com>

## Summary

_kernsnoopd_ requires the apt package `bpfcc-tools` to start. The preburned gateway vagrant image doesn't have this package installed. The pipeline to update the image is broken. So until we are able to replace the image, _magmad_ should stop trying to start _kernsnoopd_ because it fails and attempts restarts indefinitely.

## Test Plan

Checked logs to verify that _magmad_ isn't trying to start _kernsnoopd_.
