### PR TITLE
test(s8_proxy): temporary hide tft filters so we can change definition on MME

### DIFF
--- a/feg/gateway/services/s8_proxy/servicers/mock_pgw/cb.go
+++ b/feg/gateway/services/s8_proxy/servicers/mock_pgw/cb.go
@@ -13,6 +13,7 @@ limitations under the License.
 
 package mock_pgw
 
+/*
 import (
 	"fmt"
 	"net"
@@ -173,3 +174,4 @@ func (mPgw *MockPgw) getHandleCreateBearerRequest() gtpv2.HandlerFunc {
 		return nil
 	}
 }
+*/

--- a/feg/gateway/services/s8_proxy/servicers/mock_pgw/mock_pgw.go
+++ b/feg/gateway/services/s8_proxy/servicers/mock_pgw/mock_pgw.go
@@ -80,7 +80,7 @@ func (mPgw *MockPgw) Start(ctx context.Context, pgwAddrsStr string) error {
 		message.MsgTypeCreateSessionRequest:       mPgw.getHandleCreateSessionRequest(),
 		message.MsgTypeModifyAccessBearersRequest: mPgw.getHandleModifyBearerRequest(),
 		message.MsgTypeDeleteSessionRequest:       mPgw.getHandleDeleteSessionRequest(),
-		message.MsgTypeCreateBearerResponse:       mPgw.getHandleCreateBearerRequest(),
+		//message.MsgTypeCreateBearerResponse:       mPgw.getHandleCreateBearerRequest(),
 	})
 	return nil
 }

--- a/feg/gateway/services/s8_proxy/servicers/proto_conversions.go
+++ b/feg/gateway/services/s8_proxy/servicers/proto_conversions.go
@@ -352,12 +352,14 @@ func handleBearerCtx(brCtxIE *ie.IE) (*protos.BearerContext, *protos.GtpError, e
 			}
 			bearerCtx.Qos = qos
 
-		case ie.BearerTFT:
-			bearerTFT, err := handleTFT(childIE)
-			if err != nil {
-				return nil, nil, err
-			}
-			bearerCtx.Tft = bearerTFT
+			/*
+				case ie.BearerTFT:
+					bearerTFT, err := handleTFT(childIE)
+					if err != nil {
+						return nil, nil, err
+					}
+					bearerCtx.Tft = bearerTFT
+			*/
 		}
 	}
 	return bearerCtx, nil, nil

--- a/feg/gateway/services/s8_proxy/servicers/s8_proxy_test.go
+++ b/feg/gateway/services/s8_proxy/servicers/s8_proxy_test.go
@@ -15,7 +15,6 @@ import (
 	"context"
 	"fmt"
 	"net"
-	"os"
 	"strconv"
 	"strings"
 	"testing"
@@ -23,10 +22,7 @@ import (
 
 	"magma/feg/cloud/go/protos"
 	"magma/feg/gateway/gtp"
-	"magma/feg/gateway/registry"
-	"magma/feg/gateway/services/s8_proxy/servicers/mock_feg_relay"
 	"magma/feg/gateway/services/s8_proxy/servicers/mock_pgw"
-	"magma/orc8r/cloud/go/test_utils"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -636,6 +632,7 @@ func TestS8proxyCreateSessionNoProtocolConfigurationOptions(t *testing.T) {
 	assert.Nil(t, csRes.ProtocolConfigurationOptions)
 }
 
+/*
 func TestCreateBearerRequest(t *testing.T) {
 	// set up client ans server
 	s8p, mockPgw := startSgwAndPgw(t, GtpTimeoutForTest)
@@ -826,9 +823,9 @@ func TestCreateBearerRequest(t *testing.T) {
 		}
 	}
 }
-
+*/
 func TestS8proxyEcho(t *testing.T) {
-	s8p, mockPgw := startSgwAndPgw(t, 100*time.Second)
+	s8p, mockPgw := startSgwAndPgw(t, 3*time.Second)
 	defer mockPgw.Close()
 
 	//------------------------------------

--- a/feg/gateway/services/s8_proxy/servicers/tft_proto_conversion.go
+++ b/feg/gateway/services/s8_proxy/servicers/tft_proto_conversion.go
@@ -11,6 +11,7 @@ limitations under the License.
 
 package servicers
 
+/*
 import (
 	"fmt"
 	"net"
@@ -166,3 +167,4 @@ func handlePacketFilterComponent(packetComponentIE *ie.TFTPFComponent) (*oaiprot
 
 	return content, nil
 }
+*/


### PR DESCRIPTION
Signed-off-by: Oriol Batalla <obatalla@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

tft filter on oai protos is not properly (fix here https://github.com/magma/magma/pull/8580)

But since tft filters are used both in AGW and feg that fix can't land without having both sides fixed.

Since tft filters at feg are used by a feature yet to be completed, this PR disables all the changes at s8_proxy to allow #8580 to land and let us test AGW independently from the feg changes

## Test Plan
./build.py c
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
