### PR TITLE
refactor(nms): changed subscriber event table to display events from other streams like mme

### DIFF
--- a/nms/app/packages/magmalte/app/views/events/EventsTable.js
+++ b/nms/app/packages/magmalte/app/views/events/EventsTable.js
@@ -70,12 +70,14 @@ function getEventDescription(event) {
       return 'Subscriber session was created';
     case 'session_terminated':
       return 'Subscriber session was terminated';
+    case 'attach_success':
+      return 'UE attaches successfully';
+    case 'detach_success':
+      return 'UE detaches successfully';
     default:
       return event.event_type;
   }
 }
-
-const streamNameSessiond = 'sessiond';
 
 export type magmaEventStream = 'NETWORK' | 'GATEWAY' | 'SUBSCRIBER';
 type EventRowType = {
@@ -218,13 +220,23 @@ type EventTableProps = {
 };
 
 export default function EventsTable(props: EventTableProps) {
-  const {hardwareId, eventStream, tags, sz} = props;
+  const {hardwareId, eventStream, sz} = props;
   const classes = useStyles();
   const [eventCount, setEventCount] = useState(0);
   const tableRef = useRef(null);
   const {match} = useRouter();
   const networkId = nullthrows(match.params.networkId);
-  const streams = eventStream === 'SUBSCRIBER' ? streamNameSessiond : '';
+  const streams = '';
+  const buildTags = (tags: string) => {
+    let allTags = tags;
+    const tagsDelimter = ',';
+    if (eventStream == EVENT_STREAM.SUBSCRIBER) {
+      // sessionD requires tag to include the prefix IMSI together with n digits but mme doesn't require the prefix IMSI
+      allTags = [tags, tags.replace(/IMSI/, '')].join(tagsDelimter);
+    }
+    return allTags;
+  };
+  const tags = buildTags(props.tags ?? '');
 
   const [isAutoRefreshing, setIsAutoRefreshing] = useState(
     props.isAutoRefreshing ?? false,

--- a/nms/app/packages/magmalte/app/views/events/__tests__/EventsTableTest.js
+++ b/nms/app/packages/magmalte/app/views/events/__tests__/EventsTableTest.js
@@ -1,0 +1,216 @@
+/**
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @flow strict-local
+ * @format
+ */
+
+import 'jest-dom/extend-expect';
+import EventsTable from '../EventsTable';
+import MagmaAPIBindings from '@fbcnms/magma-api';
+import MuiStylesThemeProvider from '@material-ui/styles/ThemeProvider';
+import NetworkContext from '../../../components/context/NetworkContext';
+import React from 'react';
+import defaultTheme from '../../../theme/default.js';
+
+import {MemoryRouter, Route} from 'react-router-dom';
+import {MuiThemeProvider} from '@material-ui/core/styles';
+import {cleanup, render, wait} from '@testing-library/react';
+
+jest.mock('axios');
+jest.mock('@fbcnms/magma-api');
+jest.mock('@fbcnms/ui/hooks/useSnackbar');
+afterEach(cleanup);
+const enqueueSnackbarMock = jest.fn();
+jest
+  .spyOn(require('@fbcnms/ui/hooks/useSnackbar'), 'useEnqueueSnackbar')
+  .mockReturnValue(enqueueSnackbarMock);
+
+const mockEvents = [
+  {
+    event_type: 'attach_success',
+    hardware_id: 'fd9cb997-25b1-4d0a-b7d8-fea605558311',
+    stream_name: 'mme',
+    tag: '001011234560000',
+    timestamp: '2021-07-24T12:01:36.863752622+00:00',
+    value: {
+      imsi: '001011234560000',
+    },
+  },
+  {
+    event_type: 'session_created',
+    hardware_id: 'fd9cb997-25b1-4d0a-b7d8-fea605558311',
+    stream_name: 'sessiond',
+    tag: 'IMSI001011234560000',
+    timestamp: '2021-07-24T12:05:36.978641891+00:00',
+    value: {
+      apn: 'oai.ipv4',
+      charging_characteristics: '',
+      imei:
+        '\u0001\u0001\u0001\u0001\u0001\u0001\u0001\u0001\u0001\u0001\u0001\u0001\u0001\u0001\u0000\u0000',
+      imsi: 'IMSI001011234560000',
+      ip_addr: '192.168.130.10',
+      ipv6_addr: '',
+      mac_addr: '',
+      msisdn: '',
+      pdp_start_time: 1627128336,
+      session_id: 'IMSI001011234560000-522417',
+      spgw_ip: '10.22.10.92',
+      user_location: ' 92 01 f1 10 00 01 00 f1 10 00 00 00 01',
+    },
+  },
+  {
+    event_type: 'session_terminated',
+    hardware_id: 'fd9cb997-25b1-4d0a-b7d8-fea605558311',
+    stream_name: 'sessiond',
+    tag: 'IMSI001011234560000',
+    timestamp: '2021-07-27T01:59:40.343828806+00:00',
+    value: {
+      apn: 'oai.ipv4',
+      cause_for_rec_closing: 0,
+      charging_characteristics: '',
+      charging_rx: 0,
+      charging_tx: 0,
+      duration: 23353,
+      imei:
+        '\u0001\u0001\u0001\u0001\u0001\u0001\u0001\u0001\u0001\u0001\u0001\u0001\u0001\u0001\u0000\u0000',
+      imsi: 'IMSI001011234560000',
+      ip_addr: '192.168.156.10',
+      ipv6_addr: '',
+      list_of_service_data: [],
+      mac_addr: '',
+      monitoring_rx: 0,
+      monitoring_tx: 0,
+      msisdn: '',
+      pdp_end_time: 1627351175,
+      pdp_start_time: 1627327822,
+      record_sequence_number: 1,
+      session_id: 'IMSI001011234560000-522417',
+      spgw_ip: '10.22.10.92',
+      total_rx: 0,
+      total_tx: 0,
+      user_location: ' 92 01 f1 10 00 01 00 f1 10 00 00 00 01',
+    },
+  },
+  {
+    event_type: 'detach_success',
+    hardware_id: 'fd9cb997-25b1-4d0a-b7d8-fea605558311',
+    stream_name: 'mme',
+    tag: '001011234560000',
+    timestamp: '2021-07-27T08:34:02.531951334+00:00',
+    value: {
+      action: 'detach_accept_sent',
+      imsi: '001011234560000',
+    },
+  },
+];
+
+describe('<EventsTable />', () => {
+  beforeEach(() => {
+    MagmaAPIBindings.getEventsByNetworkIdAboutCount.mockResolvedValue(
+      mockEvents.length,
+    );
+    MagmaAPIBindings.getEventsByNetworkId.mockResolvedValue(mockEvents);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  const Wrapper = () => {
+    return (
+      <MemoryRouter
+        initialEntries={[
+          '/nms/test/subscribers/overview/config/IMSI0000000000/overview',
+        ]}
+        initialIndex={0}>
+        <MuiThemeProvider theme={defaultTheme}>
+          <MuiStylesThemeProvider theme={defaultTheme}>
+            <NetworkContext.Provider
+              value={{
+                networkId: 'test',
+              }}>
+              <Route
+                path="/nms/:networkId/subscribers/overview/config/:subscriberId/overview"
+                render={() => (
+                  <EventsTable
+                    eventStream={'SUBSCRIBER'}
+                    tags={'IMSI001011234560000'}
+                    sz={'md'}
+                  />
+                )}
+              />
+            </NetworkContext.Provider>
+          </MuiStylesThemeProvider>
+        </MuiThemeProvider>
+      </MemoryRouter>
+    );
+  };
+
+  it('Verify Subscriber Events Table', async () => {
+    const {getAllByRole} = render(<Wrapper />);
+    await wait();
+    const mockQuery = {
+      networkId: 'test',
+      tags: 'IMSI001011234560000,001011234560000',
+      streams: '',
+      hwIds: undefined,
+    };
+    // verify that API is called with the correct tag
+    expect(
+      MagmaAPIBindings.getEventsByNetworkIdAboutCount,
+    ).toHaveBeenCalledWith(expect.objectContaining(mockQuery));
+    expect(MagmaAPIBindings.getEventsByNetworkId).toHaveBeenCalledWith(
+      expect.objectContaining(mockQuery),
+    );
+    const rowItems = await getAllByRole('row');
+    // first row is the header
+    expect(rowItems[0]).toHaveTextContent('Timestamp');
+    expect(rowItems[0]).toHaveTextContent('Stream Name');
+    expect(rowItems[0]).toHaveTextContent('Event Type');
+    expect(rowItems[0]).toHaveTextContent('Tag');
+    expect(rowItems[0]).toHaveTextContent('Event Description');
+
+    // skipping second row because that is used for filtering events
+    expect(rowItems[2]).toHaveTextContent(
+      new Date(mockEvents[0].timestamp).toLocaleString(),
+    );
+    expect(rowItems[2]).toHaveTextContent('mme');
+    expect(rowItems[2]).toHaveTextContent('attach_success');
+    expect(rowItems[2]).toHaveTextContent('001011234560000');
+    expect(rowItems[2]).toHaveTextContent('UE attaches successfully');
+
+    expect(rowItems[3]).toHaveTextContent(
+      new Date(mockEvents[1].timestamp).toLocaleString(),
+    );
+    expect(rowItems[3]).toHaveTextContent('sessiond');
+    expect(rowItems[3]).toHaveTextContent('session_created');
+    expect(rowItems[3]).toHaveTextContent('IMSI001011234560000');
+    expect(rowItems[3]).toHaveTextContent('Subscriber session was created');
+
+    expect(rowItems[4]).toHaveTextContent(
+      new Date(mockEvents[2].timestamp).toLocaleString(),
+    );
+    expect(rowItems[4]).toHaveTextContent('sessiond');
+    expect(rowItems[4]).toHaveTextContent('session_terminated');
+    expect(rowItems[4]).toHaveTextContent('IMSI001011234560000');
+    expect(rowItems[4]).toHaveTextContent('Subscriber session was terminated');
+
+    expect(rowItems[5]).toHaveTextContent(
+      new Date(mockEvents[3].timestamp).toLocaleString(),
+    );
+    expect(rowItems[5]).toHaveTextContent('mme');
+    expect(rowItems[5]).toHaveTextContent('detach_success');
+    expect(rowItems[5]).toHaveTextContent('001011234560000');
+    expect(rowItems[5]).toHaveTextContent('UE detaches successfully');
+  });
+});


### PR DESCRIPTION

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary
Currently on the subscribers events table, we only show events from the sessionD. However, we also want to show events like when subscriber/UE attaches and detaches which comes from the stream mme.
<!-- Enumerate changes you made and why you made them -->

## Test Plan
A test named `SubscriberEventTest.js` file was added to ensure that the correct API endpoint with the correct parameters was called. Also, it tests that the response is correctly rendered. 
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information
<img width="1117" alt="Screen Shot 2021-08-10 at 3 19 25 PM" src="https://user-images.githubusercontent.com/34602743/129036301-b17cd009-8bb9-4f14-b5dd-58626f18a8c2.png">

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
