### PR TITLE
fix(mme): Frees esmmessagecontainer on attach reject proc

### DIFF
--- a/lte/gateway/c/core/oai/tasks/nas/emm/sap/emm_recv.c
+++ b/lte/gateway/c/core/oai/tasks/nas/emm/sap/emm_recv.c
@@ -207,6 +207,8 @@ status_code_e emm_recv_attach_request(
         ue_id, *emm_cause);
     rc         = emm_proc_attach_reject(ue_id, *emm_cause);
     *emm_cause = EMM_CAUSE_SUCCESS;
+    // Free the ESM container
+    bdestroy(msg->esmmessagecontainer);
     OAILOG_FUNC_RETURN(LOG_NAS_EMM, rc);
   }
 


### PR DESCRIPTION
Signed-off-by: Alex Rodriguez <ardzoht@gmail.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->
- `esmmessagecontainer` struct is decoded and encoded as part of attach request, however, there was a leak of memory on the attach reject procedure handling
- fixes #8573 

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->
- running integ tests and spirent tests and restarting MME to confirm there's no leak

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
