### PR TITLE
fix(s8_proxy): fix tft filter proto to include repeated field

### DIFF
--- a/feg/gateway/services/s8_proxy/servicers/mock_pgw/cb.go
+++ b/feg/gateway/services/s8_proxy/servicers/mock_pgw/cb.go
@@ -13,7 +13,6 @@ limitations under the License.
 
 package mock_pgw
 
-/*
 import (
 	"fmt"
 	"net"
@@ -125,28 +124,28 @@ func buildNewBearerTFTCreateNewTFT(req CreateBearerRequest) *ie.IE {
 		[]*ie.TFTPacketFilter{
 			ie.NewTFTPacketFilter(
 				ie.TFTPFBidirectional, 0, 0,
-				// component 0
+				// component 0.0
 				ie.NewTFTPFComponentSecurityParameterIndex(0xdeadbeef),
-				// component 1
+				// component 0.1
 				ie.NewTFTPFComponentIPv4RemoteAddress(net.IP{127, 0, 0, 1}, net.IPMask{255, 255, 255, 0}),
-				// component 2
+				// component 0.2
 				ie.NewTFTPFComponentProtocolIdentifierNextHeader(req.BiFilterProtocolId),
-				// component 3
+				// component 0.3
 				ie.NewTFTPFComponentTypeOfServiceTrafficClass(1, 2),
-				// component 4
+				// component 0.4
 				ie.NewTFTPFComponentSingleLocalPort(req.BiLocalFilterPort),
-				// component 5
+				// component 0.5
 				ie.NewTFTPFComponentSingleRemotePort(req.BiRemoteFilterPort),
 			),
 			ie.NewTFTPacketFilter(
 				ie.TFTPFDownlinkOnly, 1, 0,
-				// component 6
+				// component 1.0
 				ie.NewTFTPFComponentProtocolIdentifierNextHeader(1),
-				// component 7
+				// component 1.1
 				ie.NewTFTPFComponentSecurityParameterIndex(0xdeadbeef),
-				// component 8
+				// component 1.2
 				ie.NewTFTPFComponentLocalPortRange(req.BiLocalFilterPort, req.BiLocalFilterPort+10),
-				// component 9
+				// component 1.3
 				ie.NewTFTPFComponentRemotePortRange(req.BiRemoteFilterPort, req.BiRemoteFilterPort+10),
 			),
 		},
@@ -174,4 +173,3 @@ func (mPgw *MockPgw) getHandleCreateBearerRequest() gtpv2.HandlerFunc {
 		return nil
 	}
 }
-*/

--- a/feg/gateway/services/s8_proxy/servicers/mock_pgw/mock_pgw.go
+++ b/feg/gateway/services/s8_proxy/servicers/mock_pgw/mock_pgw.go
@@ -80,7 +80,7 @@ func (mPgw *MockPgw) Start(ctx context.Context, pgwAddrsStr string) error {
 		message.MsgTypeCreateSessionRequest:       mPgw.getHandleCreateSessionRequest(),
 		message.MsgTypeModifyAccessBearersRequest: mPgw.getHandleModifyBearerRequest(),
 		message.MsgTypeDeleteSessionRequest:       mPgw.getHandleDeleteSessionRequest(),
-		//message.MsgTypeCreateBearerResponse:       mPgw.getHandleCreateBearerRequest(),
+		message.MsgTypeCreateBearerResponse:       mPgw.getHandleCreateBearerRequest(),
 	})
 	return nil
 }

--- a/feg/gateway/services/s8_proxy/servicers/proto_conversions.go
+++ b/feg/gateway/services/s8_proxy/servicers/proto_conversions.go
@@ -352,14 +352,12 @@ func handleBearerCtx(brCtxIE *ie.IE) (*protos.BearerContext, *protos.GtpError, e
 			}
 			bearerCtx.Qos = qos
 
-			/*
-				case ie.BearerTFT:
-					bearerTFT, err := handleTFT(childIE)
-					if err != nil {
-						return nil, nil, err
-					}
-					bearerCtx.Tft = bearerTFT
-			*/
+		case ie.BearerTFT:
+			bearerTFT, err := handleTFT(childIE)
+			if err != nil {
+				return nil, nil, err
+			}
+			bearerCtx.Tft = bearerTFT
 		}
 	}
 	return bearerCtx, nil, nil

--- a/feg/gateway/services/s8_proxy/servicers/s8_proxy_test.go
+++ b/feg/gateway/services/s8_proxy/servicers/s8_proxy_test.go
@@ -15,6 +15,7 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"os"
 	"strconv"
 	"strings"
 	"testing"
@@ -22,7 +23,10 @@ import (
 
 	"magma/feg/cloud/go/protos"
 	"magma/feg/gateway/gtp"
+	"magma/feg/gateway/registry"
+	"magma/feg/gateway/services/s8_proxy/servicers/mock_feg_relay"
 	"magma/feg/gateway/services/s8_proxy/servicers/mock_pgw"
+	"magma/orc8r/cloud/go/test_utils"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -632,7 +636,6 @@ func TestS8proxyCreateSessionNoProtocolConfigurationOptions(t *testing.T) {
 	assert.Nil(t, csRes.ProtocolConfigurationOptions)
 }
 
-/*
 func TestCreateBearerRequest(t *testing.T) {
 	// set up client ans server
 	s8p, mockPgw := startSgwAndPgw(t, GtpTimeoutForTest)
@@ -702,67 +705,56 @@ func TestCreateBearerRequest(t *testing.T) {
 	assert.Equal(t, uint32(DEDICATEDBEARER), cbReqReceived.BearerContext.Id)
 	assert.Equal(t, uint32(pgwCreateBearerRequest.QosQCI), cbReqReceived.BearerContext.Qos.Qci)
 	packetFilterComponents := cbReqReceived.BearerContext.Tft.PacketFilterList.CreateNewTft
-	assert.Equal(t, 10, len(packetFilterComponents))
+	assert.Equal(t, 2, len(packetFilterComponents))
 
 	// check filter components
-	// component 0
-	tft := packetFilterComponents[0]
-	assert.Equal(t, uint32(ie.TFTPFBidirectional), tft.Direction)
-	assert.Equal(t, uint32(0), tft.Identifier)
-	assert.Equal(t, ie.PFCompSecurityParameterIndex, uint8(tft.PacketFilterContents.Flags))
-	assert.Equal(t, uint32(0xdeadbeef), tft.PacketFilterContents.SecurityParameterIndex)
+	assert.Equal(t, 6, len(packetFilterComponents[0].PacketFilterContents))
+	assert.Equal(t, uint32(ie.TFTPFBidirectional), packetFilterComponents[0].Direction)
+	assert.Equal(t, uint32(0), packetFilterComponents[0].Identifier)
+	assert.Equal(t, 4, len(packetFilterComponents[1].PacketFilterContents))
+	assert.Equal(t, uint32(ie.TFTPFDownlinkOnly), packetFilterComponents[1].Direction)
+	assert.Equal(t, uint32(1), packetFilterComponents[1].Identifier)
 
-	// component 1
-	tft = packetFilterComponents[1]
-	assert.Equal(t, uint32(ie.TFTPFBidirectional), tft.Direction)
-	assert.Equal(t, uint32(0), tft.Identifier)
-	assert.Equal(t, ie.PFCompIPv4RemoteAddress, uint8(tft.PacketFilterContents.Flags))
-	assert.Equal(t, ip2Long("127.0.0.1"), tft.PacketFilterContents.Ipv4RemoteAddresses[0].Addr)
+	// component 0.0
+	tft := packetFilterComponents[0].PacketFilterContents[0]
+	assert.Equal(t, ie.PFCompSecurityParameterIndex, uint8(tft.Flags))
+	assert.Equal(t, uint32(0xdeadbeef), tft.SecurityParameterIndex)
 
-	// component 2
-	tft = packetFilterComponents[2]
-	assert.Equal(t, uint32(ie.TFTPFBidirectional), tft.Direction)
-	assert.Equal(t, uint32(0), tft.Identifier)
-	assert.Equal(t, ie.PFCompProtocolIdentifierNextHeader, uint8(tft.PacketFilterContents.Flags))
-	assert.Equal(t, pgwCreateBearerRequest.BiFilterProtocolId, uint8(tft.PacketFilterContents.ProtocolIdentifierNextheader))
+	// component 0.1
+	tft = packetFilterComponents[0].PacketFilterContents[1]
+	assert.Equal(t, ie.PFCompIPv4RemoteAddress, uint8(tft.Flags))
+	assert.Equal(t, ip2Long("127.0.0.1"), tft.Ipv4RemoteAddresses[0].Addr)
 
-	// component 3
-	tft = packetFilterComponents[3]
-	assert.Equal(t, uint32(ie.TFTPFBidirectional), tft.Direction)
-	assert.Equal(t, uint32(0), tft.Identifier)
-	assert.Equal(t, ie.PFCompTypeOfServiceTrafficClass, uint8(tft.PacketFilterContents.Flags))
-	assert.Equal(t, uint32(1), tft.PacketFilterContents.TypeOfServiceTrafficClass.Value)
-	assert.Equal(t, uint32(2), tft.PacketFilterContents.TypeOfServiceTrafficClass.Mask)
+	// component 0.2
+	tft = packetFilterComponents[0].PacketFilterContents[2]
+	assert.Equal(t, ie.PFCompProtocolIdentifierNextHeader, uint8(tft.Flags))
+	assert.Equal(t, pgwCreateBearerRequest.BiFilterProtocolId, uint8(tft.ProtocolIdentifierNextheader))
 
-	// component 4
-	tft = packetFilterComponents[4]
-	assert.Equal(t, uint32(ie.TFTPFBidirectional), tft.Direction)
-	assert.Equal(t, uint32(0), tft.Identifier)
-	assert.Equal(t, ie.PFCompSingleLocalPort, uint8(tft.PacketFilterContents.Flags))
-	assert.Equal(t, pgwCreateBearerRequest.BiLocalFilterPort, uint16(tft.PacketFilterContents.SingleLocalPort))
+	// component 0.3
+	tft = packetFilterComponents[0].PacketFilterContents[3]
+	assert.Equal(t, ie.PFCompTypeOfServiceTrafficClass, uint8(tft.Flags))
+	assert.Equal(t, uint32(1), tft.TypeOfServiceTrafficClass.Value)
+	assert.Equal(t, uint32(2), tft.TypeOfServiceTrafficClass.Mask)
 
-	// component 5
-	tft = packetFilterComponents[5]
-	assert.Equal(t, uint32(ie.TFTPFBidirectional), tft.Direction)
-	assert.Equal(t, uint32(0), tft.Identifier)
-	assert.Equal(t, ie.PFCompSingleRemotePort, uint8(tft.PacketFilterContents.Flags))
-	assert.Equal(t, pgwCreateBearerRequest.BiRemoteFilterPort, uint16(tft.PacketFilterContents.SingleRemotePort))
+	// component 0.4
+	tft = packetFilterComponents[0].PacketFilterContents[4]
+	assert.Equal(t, ie.PFCompSingleLocalPort, uint8(tft.Flags))
+	assert.Equal(t, pgwCreateBearerRequest.BiLocalFilterPort, uint16(tft.SingleLocalPort))
 
-	// component 8
-	tft = packetFilterComponents[8]
-	assert.Equal(t, uint32(ie.TFTPFDownlinkOnly), tft.Direction)
-	assert.Equal(t, uint32(1), tft.Identifier)
-	assert.Equal(t, ie.PFCompLocalPortRange, uint8(tft.PacketFilterContents.Flags))
-	assert.Equal(t, pgwCreateBearerRequest.BiLocalFilterPort, uint16(tft.PacketFilterContents.LocalPortRange.LowLimit))
-	assert.Equal(t, pgwCreateBearerRequest.BiLocalFilterPort+10, uint16(tft.PacketFilterContents.LocalPortRange.HighLimit))
+	// component 0.5
+	tft = packetFilterComponents[0].PacketFilterContents[5]
+	assert.Equal(t, ie.PFCompSingleRemotePort, uint8(tft.Flags))
+	assert.Equal(t, pgwCreateBearerRequest.BiRemoteFilterPort, uint16(tft.SingleRemotePort))
 
-	// component 9
-	tft = packetFilterComponents[9]
-	assert.Equal(t, uint32(ie.TFTPFDownlinkOnly), tft.Direction)
-	assert.Equal(t, uint32(1), tft.Identifier)
-	assert.Equal(t, ie.PFCompRemotePortRange, uint8(tft.PacketFilterContents.Flags))
-	assert.Equal(t, pgwCreateBearerRequest.BiRemoteFilterPort, uint16(tft.PacketFilterContents.RemotePortRange.LowLimit))
-	assert.Equal(t, pgwCreateBearerRequest.BiRemoteFilterPort+10, uint16(tft.PacketFilterContents.RemotePortRange.HighLimit))
+	// component 1.2
+	tft = packetFilterComponents[1].PacketFilterContents[2]
+	assert.Equal(t, pgwCreateBearerRequest.BiLocalFilterPort, uint16(tft.LocalPortRange.LowLimit))
+	assert.Equal(t, pgwCreateBearerRequest.BiLocalFilterPort+10, uint16(tft.LocalPortRange.HighLimit))
+
+	// component 1.3
+	tft = packetFilterComponents[1].PacketFilterContents[3]
+	assert.Equal(t, pgwCreateBearerRequest.BiRemoteFilterPort, uint16(tft.RemotePortRange.LowLimit))
+	assert.Equal(t, pgwCreateBearerRequest.BiRemoteFilterPort+10, uint16(tft.RemotePortRange.HighLimit))
 
 	// send the response from agw to feg
 	cbResGrpc := &protos.CreateBearerResponsePgw{
@@ -823,7 +815,7 @@ func TestCreateBearerRequest(t *testing.T) {
 		}
 	}
 }
-*/
+
 func TestS8proxyEcho(t *testing.T) {
 	s8p, mockPgw := startSgwAndPgw(t, 3*time.Second)
 	defer mockPgw.Close()

--- a/feg/gateway/services/s8_proxy/servicers/tft_proto_conversion.go
+++ b/feg/gateway/services/s8_proxy/servicers/tft_proto_conversion.go
@@ -11,7 +11,6 @@ limitations under the License.
 
 package servicers
 
-/*
 import (
 	"fmt"
 	"net"
@@ -60,23 +59,24 @@ func handleTFT(tftIE *ie.IE) (*oaiprotos.TrafficFlowTemplate, error) {
 func handlePacketFilters(tftFieldsIE *ie.TrafficFlowTemplate) ([]*oaiprotos.PacketFilter, error) {
 	packetFilters := []*oaiprotos.PacketFilter{}
 	for _, tftPacketFilterIE := range tftFieldsIE.PacketFilters {
+		contents := []*oaiprotos.PacketFilterContents{}
 		for _, packetComponentIE := range tftPacketFilterIE.Components {
 			component, err := handlePacketFilterComponent(packetComponentIE)
 			if err != nil {
 				glog.Infof("Couldn't parse Packet Filter Component: %s ", err)
 				continue
 			}
-			packetFilter := &oaiprotos.PacketFilter{
-				Spare:                0,
-				Direction:            uint32(tftPacketFilterIE.Direction),
-				Identifier:           uint32(tftPacketFilterIE.Identifier),
-				EvalPrecedence:       uint32(tftPacketFilterIE.EvaluationPrecedence),
-				Length:               uint32(tftPacketFilterIE.Length),
-				PacketFilterContents: component,
-			}
-
-			packetFilters = append(packetFilters, packetFilter)
+			contents = append(contents, component)
 		}
+		packetFilter := &oaiprotos.PacketFilter{
+			Spare:                0,
+			Direction:            uint32(tftPacketFilterIE.Direction),
+			Identifier:           uint32(tftPacketFilterIE.Identifier),
+			EvalPrecedence:       uint32(tftPacketFilterIE.EvaluationPrecedence),
+			Length:               uint32(tftPacketFilterIE.Length),
+			PacketFilterContents: contents,
+		}
+		packetFilters = append(packetFilters, packetFilter)
 	}
 	return packetFilters, nil
 }
@@ -167,4 +167,3 @@ func handlePacketFilterComponent(packetComponentIE *ie.TFTPFComponent) (*oaiprot
 
 	return content, nil
 }
-*/


### PR DESCRIPTION
Signed-off-by: Oriol Batalla <obatalla@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

After landing https://github.com/magma/magma/pull/8580 and https://github.com/magma/magma/pull/8592 now we revert the changes we did on tft filter and modify the proto to include the changes added on 8580

This PR also modifies the createBearereRequest test to include the changes on the filter proto definition

## Test Plan

./build.py -c at feg

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
