### PR TITLE
feat(amf): Handling security mode reject 

### DIFF
--- a/lte/gateway/c/core/oai/tasks/amf/amf_app_ue_context_and_proc.h
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_app_ue_context_and_proc.h
@@ -764,6 +764,7 @@ void amf_app_state_free_ue_context(void** ue_context_node);
 int amf_proc_security_mode_control(
     amf_context_t* amf_ctx, nas_amf_specific_proc_t* amf_specific_proc,
     ksi_t ksi, success_cb_t success, failure_cb_t failure);
+int amf_proc_security_mode_reject(amf_ue_ngap_id_t ue_id);
 void amf_proc_create_procedure_registration_request(
     ue_m5gmm_context_s* ue_ctx, amf_registration_request_ies_t* ies);
 amf_procedures_t* nas_new_amf_procedures(amf_context_t* amf_context);

--- a/lte/gateway/c/core/oai/tasks/amf/amf_as.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_as.cpp
@@ -201,6 +201,11 @@ static int amf_as_establish_req(amf_as_establish_t* msg, int* amf_cause) {
     case SEC_MODE_COMPLETE:
       rc = amf_handle_security_complete_response(msg->ue_id, decode_status);
       break;
+    case SEC_MODE_REJECT:
+      rc = amf_handle_security_mode_reject(
+          msg->ue_id, &amf_msg->msg.securitymodereject, *amf_cause,
+          decode_status);
+      break;
     case REG_COMPLETE:
       rc = amf_handle_registration_complete_response(
           msg->ue_id, &amf_msg->msg.registrationcompletemsg, *amf_cause,

--- a/lte/gateway/c/core/oai/tasks/amf/amf_recv.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_recv.cpp
@@ -781,7 +781,7 @@ int amf_handle_security_mode_reject(
     OAILOG_FUNC_RETURN(LOG_NAS_AMF, RETURNerror);
   }
 
-  if (msg->m5gmm_cause.m5gmm_cause == AMF_CAUSE_UE_SECURITY_CAP_MISMATCH) {
+  if (msg->m5gmm_cause.m5gmm_cause == AMF_CAUSE_UE_SEC_CAP_MISSMATCH) {
     increment_counter(
         "security_mode_reject_received", 1, 1, "cause", "ue_sec_cap_mismatch");
   } else {

--- a/lte/gateway/c/core/oai/tasks/amf/amf_recv.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_recv.cpp
@@ -29,6 +29,7 @@ extern "C" {
 #include "amf_identity.h"
 #include "amf_sap.h"
 #include "amf_app_timer_management.h"
+#include "includes/MetricsHelpers.h"
 
 #define AMF_CAUSE_SUCCESS (1)
 #define AMF_CAUSE_UE_SEC_CAP_MISSMATCH (23)
@@ -737,6 +738,62 @@ ue_m5gmm_context_s* lookup_ue_ctxt_by_imsi(imsi64_t imsi64) {
     return amf_ue_context_exists_amf_ue_ngap_id(
         found_imsi->second.amf_ue_ngap_id);
   }
+}
+
+/****************************************************************************
+ **                                                                        **
+ ** Name:    amf_handle_security_mode_reject()                             **
+ **                                                                        **
+ ** Description: Processes Security Mode Reject message                    **
+ **                                                                        **
+ ** Inputs:  ue_id:      UE lower layer identifier                         **
+ **      msg:       The received AMF message                               **
+ **      Others:    None                                                   **
+ **                                                                        **
+ ** Outputs:     amf_cause: AMF cause code                                 **
+ **      Return:    RETURNok, RETURNerror                                  **
+ **      Others:    None                                                   **
+ **                                                                        **
+ ***************************************************************************/
+int amf_handle_security_mode_reject(
+    amf_ue_ngap_id_t ue_id, SecurityModeRejectMsg* msg, int amf_cause,
+    const amf_nas_message_decode_status_t status) {
+  OAILOG_FUNC_IN(LOG_NAS_AMF);
+  int rc = RETURNok;
+
+  OAILOG_WARNING(
+      LOG_NAS_AMF,
+      "AMFAS-SAP - Received Security Mode Reject message "
+      "(cause=%d)\n",
+      msg->m5gmm_cause.m5gmm_cause);
+
+  /*
+   * Message checking
+   */
+  if (msg->m5gmm_cause.m5gmm_cause == AMF_CAUSE_SUCCESS) {
+    amf_cause = AMF_CAUSE_INVALID_MANDATORY_INFO;
+  }
+
+  /*
+   * Handle message checking error
+   */
+  if (amf_cause != AMF_CAUSE_SUCCESS) {
+    OAILOG_FUNC_RETURN(LOG_NAS_AMF, RETURNerror);
+  }
+
+  if (msg->m5gmm_cause.m5gmm_cause == AMF_CAUSE_UE_SECURITY_CAP_MISMATCH) {
+    increment_counter(
+        "security_mode_reject_received", 1, 1, "cause", "ue_sec_cap_mismatch");
+  } else {
+    increment_counter(
+        "security_mode_reject_received", 1, 1, "cause", "unspecified");
+  }
+
+  /*
+   * Execute the NAS security mode command not accepted by the UE
+   */
+  rc = amf_proc_security_mode_reject(ue_id);
+  OAILOG_FUNC_RETURN(LOG_NAS_AMF, rc);
 }
 
 }  // namespace magma5g

--- a/lte/gateway/c/core/oai/tasks/amf/amf_recv.h
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_recv.h
@@ -39,6 +39,9 @@ int amf_handle_authentication_failure(
     amf_nas_message_decode_status_t status);
 int amf_handle_security_complete_response(
     amf_ue_ngap_id_t ue_id, amf_nas_message_decode_status_t decode_status);
+int amf_handle_security_mode_reject(
+    const amf_ue_ngap_id_t ueid, SecurityModeRejectMsg* msg,
+    int const amf_cause, const amf_nas_message_decode_status_t decode_status);
 int amf_handle_registration_complete_response(
     amf_ue_ngap_id_t ue_id, RegistrationCompleteMsg* msg, int amf_cause,
     amf_nas_message_decode_status_t decode_status);

--- a/lte/gateway/c/core/oai/tasks/amf/deregistration_request.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/deregistration_request.cpp
@@ -208,7 +208,12 @@ int amf_app_handle_deregistration_req(amf_ue_ngap_id_t ue_id) {
     OAILOG_FUNC_RETURN(LOG_NAS_AMF, rc);
   }
   // UE context release notification to NGAP
-  amf_app_ue_context_release(ue_context, ue_context->ue_context_rel_cause);
+  if (ue_context->ue_context_rel_cause.ngapCause_u.nas == NGAP_INVALID_CAUSE) {
+    ue_context->ue_context_rel_cause.ngapCause_u.nas = ngap_CauseNas_deregister;
+    amf_app_ue_context_release(ue_context, ue_context->ue_context_rel_cause);
+  } else {
+    amf_app_ue_context_release(ue_context, ue_context->ue_context_rel_cause);
+  }
 
   // Clean up all the sessions.
   amf_smf_context_cleanup_pdu_session(ue_context);

--- a/lte/gateway/c/core/oai/tasks/amf/deregistration_request.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/deregistration_request.cpp
@@ -208,12 +208,11 @@ int amf_app_handle_deregistration_req(amf_ue_ngap_id_t ue_id) {
     OAILOG_FUNC_RETURN(LOG_NAS_AMF, rc);
   }
   // UE context release notification to NGAP
-  if (ue_context->ue_context_rel_cause.ngapCause_u.nas == NGAP_INVALID_CAUSE) {
+  if (ue_context->ue_context_rel_cause.ngapCause_u.nas ==
+      ngap_CauseNas_normal_release) {
     ue_context->ue_context_rel_cause.ngapCause_u.nas = ngap_CauseNas_deregister;
-    amf_app_ue_context_release(ue_context, ue_context->ue_context_rel_cause);
-  } else {
-    amf_app_ue_context_release(ue_context, ue_context->ue_context_rel_cause);
   }
+  amf_app_ue_context_release(ue_context, ue_context->ue_context_rel_cause);
 
   // Clean up all the sessions.
   amf_smf_context_cleanup_pdu_session(ue_context);

--- a/lte/gateway/c/core/oai/test/amf/CMakeLists.txt
+++ b/lte/gateway/c/core/oai/test/amf/CMakeLists.txt
@@ -30,6 +30,7 @@ add_library(AMF_TASK_TEST_LIB
     util_nas5g_auth_fail_pkt.cpp
     util_nas5g_ul_nas_pdu_decode.cpp
     util_nas5g_service_request_pkt.cpp
+    util_nas5g_security_mode_reject_pkt.cpp
     )
 link_directories(${PROJECT_SOURCE_DIR}/tasks/amf)
 target_link_libraries(AMF_TASK_TEST_LIB

--- a/lte/gateway/c/core/oai/test/amf/test_amf.cpp
+++ b/lte/gateway/c/core/oai/test/amf/test_amf.cpp
@@ -93,6 +93,8 @@ uint8_t NAS5GPktSnapShot::service_request[37] = {
 
 uint8_t NAS5GPktSnapShot::registration_reject[4] = {0x00, 0x00, 0x00, 0x00};
 
+uint8_t NAS5GPktSnapShot::security_mode_reject[4] = {0x7e, 0x00, 0x5f, 0x24};
+
 TEST(test_amf_nas5g_pkt_process, test_amf_ue_register_req_msg) {
   NAS5GPktSnapShot nas5g_pkt_snap;
   RegistrationRequestMsg reg_request;
@@ -614,6 +616,28 @@ TEST(test_dlnastransport, test_dlnastransport) {
       static_cast<uint8_t>(M5GMmCause::MAX_PDU_SESSIONS_REACHED));
   bdestroy(buffer);
 }
+
+/* Test for security mode reject Data */
+TEST(test_amf_nas5g_pkt_process, test_amf_security_mode_reject_message_data) {
+  NAS5GPktSnapShot nas5g_pkt_snap;
+  SecurityModeRejectMsg sm_reject;
+  bool decode_res = 0;
+
+  uint32_t len = nas5g_pkt_snap.get_security_mode_reject_len();
+
+  memset(&sm_reject, 0, sizeof(SecurityModeRejectMsg));
+
+  decode_res = decode_security_mode_reject_msg(
+      &sm_reject, nas5g_pkt_snap.security_mode_reject, len);
+  EXPECT_EQ(decode_res, true);
+  EXPECT_EQ(
+      sm_reject.extended_protocol_discriminator.extended_proto_discriminator,
+      M5G_MOBILITY_MANAGEMENT_MESSAGES);
+  EXPECT_EQ(sm_reject.sec_header_type.sec_hdr, (uint8_t) 0x00);
+  EXPECT_EQ(sm_reject.message_type.msg_type, SEC_MODE_REJECT);
+  EXPECT_EQ(sm_reject.m5gmm_cause.m5gmm_cause, 0x24);
+}
+
 int main(int argc, char** argv) {
   ::testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();

--- a/lte/gateway/c/core/oai/test/amf/util_nas5g_pkt.h
+++ b/lte/gateway/c/core/oai/test/amf/util_nas5g_pkt.h
@@ -22,6 +22,7 @@
 #include "amf_app_ue_context_and_proc.h"
 #include "amf_asDefs.h"
 #include "3gpp_24.008.h"
+#include "M5GSecurityModeReject.h"
 
 namespace magma5g {
 
@@ -36,6 +37,7 @@ class NAS5GPktSnapShot {
   static uint8_t deregistrarion_request[17];
   static uint8_t service_request[37];
   static uint8_t registration_reject[4];
+  static uint8_t security_mode_reject[4];
 
   uint32_t get_reg_req_buffer_len() {
     return sizeof(reg_req_buffer) / sizeof(unsigned char);
@@ -69,6 +71,10 @@ class NAS5GPktSnapShot {
     return sizeof(deregistrarion_request) / sizeof(unsigned char);
   }
 
+  uint32_t get_security_mode_reject_len() {
+    return sizeof(security_mode_reject) / sizeof(unsigned char);
+  }
+
   NAS5GPktSnapShot() {}
 };
 
@@ -99,5 +105,8 @@ bool decode_service_request_msg(
 void gen_ipcp_pco_options(protocol_configuration_options_t* const pco_resp);
 
 int gen_dns_pco_options(protocol_configuration_options_t* const pco_resp);
+
+bool decode_security_mode_reject_msg(
+    SecurityModeRejectMsg* sm_reject, const uint8_t* buffer, uint32_t len);
 
 }  // namespace magma5g

--- a/lte/gateway/c/core/oai/test/amf/util_nas5g_security_mode_reject_pkt.cpp
+++ b/lte/gateway/c/core/oai/test/amf/util_nas5g_security_mode_reject_pkt.cpp
@@ -1,0 +1,34 @@
+/**
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <iostream>
+#include "./util_nas5g_pkt.h"
+
+namespace magma5g {
+
+//  API for testing decode security mode reject
+bool decode_security_mode_reject_msg(
+    SecurityModeRejectMsg* sm_reject, const uint8_t* buffer, uint32_t len) {
+  bool decode_success = true;
+  uint8_t* decode_security_mode_reject =
+      const_cast<uint8_t*>(reinterpret_cast<const uint8_t*>(buffer));
+
+  if (sm_reject->DecodeSecurityModeRejectMsg(
+          sm_reject, decode_security_mode_reject, len) < 0) {
+    decode_success = false;
+  }
+
+  return (decode_success);
+}
+
+}  // namespace magma5g


### PR DESCRIPTION
Signed-off-by: chandhu-wavelabs <chandhu.naga@wavelabs.ai>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

Support added for handling security mode reject message

## Test Plan

unit test case is added for security mode reject decoding.
Tested the handling of security mode reject on UERANSIM setup

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
