### PR TITLE
feat(agw): Bump Master to 1.8.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -337,7 +337,7 @@ commands:
       - run:
           name: Create a release in Sentry.io with the commit hash
           command: |
-            COMMIT_HASH_WITH_VERSION="1.7.0-${CIRCLE_SHA1:0:8}"
+            COMMIT_HASH_WITH_VERSION="1.8.0-${CIRCLE_SHA1:0:8}"
             sentry-cli --log-level=info releases new -p lab-agws-python -p lab-agws-native ${COMMIT_HASH_WITH_VERSION}
             sentry-cli --log-level=info releases set-commits --auto --ignore-missing ${COMMIT_HASH_WITH_VERSION}
             sentry-cli --log-level=info releases finalize ${COMMIT_HASH_WITH_VERSION}
@@ -1482,8 +1482,8 @@ jobs:
             elif  [ "<<parameters.aws_account>>" = "LF" ]; then
               sed -i -e "s@awsAccessKey:@& ${AWS_ACCESS_KEY_AMI_LF}@1"  $VARS_DIR/secrets.yaml
               sed -i -e "s@awsSecretKey:@& ${AWS_SECRET_ACCESS_KEY_AMI_LF}@1"  $VARS_DIR/secrets.yaml
-              echo export PACKAGE_VERSION="1.7.0" >> $BASH_ENV
-              echo export VERSION="1.7.0" >> $BASH_ENV
+              echo export PACKAGE_VERSION="1.8.0" >> $BASH_ENV
+              echo export VERSION="1.8.0" >> $BASH_ENV
             fi
             echo export PACKAGE_REPO_HOST="artifactory.magmacore.org\\\/artifactory\\\/debian" >> $BASH_ENV
             echo export GIT_REF="${CIRCLE_SHA1}" >> $BASH_ENV

--- a/lte/gateway/release/build-magma.sh
+++ b/lte/gateway/release/build-magma.sh
@@ -20,8 +20,8 @@ SCRIPT_DIR="$(dirname "$(realpath "$0")")"
 
 # Please update the version number accordingly for beta/stable builds
 # Test builds are versioned automatically by fabfile.py
-VERSION=1.7.0 # magma version number
-SCTPD_MIN_VERSION=1.7.0 # earliest version of sctpd with which this version is compatible
+VERSION=1.8.0 # magma version number
+SCTPD_MIN_VERSION=1.8.0 # earliest version of sctpd with which this version is compatible
 
 # RelWithDebInfo or Debug
 BUILD_TYPE=Debug


### PR DESCRIPTION
Signed-off-by: Timothée Dzik <timdzik@fb.com>

feat(agw): Bump Master to 1.8.0

## Summary

As now 1.7 has been cut out, master will push 1.8.0 packages

## Test Plan

Let CI go 