### PR TITLE
fix(mme): Increasing zmq verbose logging on v1.5 and fixed memory lea…

### DIFF
--- a/lte/gateway/c/oai/lib/itti/signals.c
+++ b/lte/gateway/c/oai/lib/itti/signals.c
@@ -156,7 +156,7 @@ int signal_handle(int* end, task_zmq_ctx_t* task_ctx) {
     perror("sigwait");
     return ret;
   }
-  // printf("Received signal %d\n", info.si_signo);
+  printf("Received signal %d\n", info.si_signo);
 
   /*
    * Real-time signals are non constant and are therefore not suitable for

--- a/lte/gateway/c/oai/tasks/mme_app/mme_app_bearer.c
+++ b/lte/gateway/c/oai/tasks/mme_app/mme_app_bearer.c
@@ -287,7 +287,7 @@ void mme_app_handle_conn_est_cnf(
   itti_mme_app_connection_establishment_cnf_t* establishment_cnf_p = NULL;
   int rc                                                           = RETURNok;
 
-  OAILOG_DEBUG(
+  OAILOG_INFO(
       LOG_MME_APP,
       "Handle MME_APP_CONNECTION_ESTABLISHMENT_CNF for "
       "ue-id " MME_UE_S1AP_ID_FMT "\n",
@@ -315,7 +315,7 @@ void mme_app_handle_conn_est_cnf(
      * send IMSI Detach towads UE to re-attach for non-eps services
      * otherwise send itti SGS Service request message to SGS
      */
-    OAILOG_DEBUG_UE(
+    OAILOG_INFO_UE(
         LOG_MME_APP, emm_context_p->_imsi64,
         "CSFB Service Type = (%d) for (ue_id = " MME_UE_S1AP_ID_FMT ")\n",
         ue_context_p->sgs_context->csfb_service_type,
@@ -334,7 +334,7 @@ void mme_app_handle_conn_est_cnf(
         ue_context_p->sgs_context->csfb_service_type ==
         CSFB_SERVICE_MT_CALL_OR_SMS_WITHOUT_LAI) {
       // Inform NAS module to send network initiated IMSI detach request to UE
-      OAILOG_DEBUG_UE(
+      OAILOG_INFO_UE(
           LOG_MME_APP, emm_context_p->_imsi64,
           "Send SGS intiated Detach request to NAS module for ue_id "
           "= " MME_UE_S1AP_ID_FMT
@@ -408,7 +408,7 @@ void mme_app_handle_conn_est_cnf(
       LOG_MME_APP, emm_context_p->_imsi64, "CSFB Fallback indicator = (%d)\n",
       establishment_cnf_p->cs_fallback_indicator);
   // Copy UE radio capabilities into message if it exists
-  OAILOG_DEBUG_UE(
+  OAILOG_INFO_UE(
       LOG_MME_APP, emm_context_p->_imsi64,
       "UE radio context already cached: %s\n",
       ue_context_p->ue_radio_capability ? "yes" : "no");
@@ -489,11 +489,11 @@ void mme_app_handle_conn_est_cnf(
       establishment_cnf_p->kenb, emm_context_p->_security.next_hop,
       &emm_context_p->_security.next_hop_chaining_count);
 
-  OAILOG_DEBUG_UE(
+  OAILOG_INFO_UE(
       LOG_MME_APP, emm_context_p->_imsi64,
       "security_capabilities_encryption_algorithms 0x%04X\n",
       establishment_cnf_p->ue_security_capabilities_encryption_algorithms);
-  OAILOG_DEBUG_UE(
+  OAILOG_INFO_UE(
       LOG_MME_APP, emm_context_p->_imsi64,
       "security_capabilities_integrity_algorithms  0x%04X\n",
       establishment_cnf_p->ue_security_capabilities_integrity_algorithms);

--- a/lte/gateway/c/oai/tasks/mme_app/mme_app_main.c
+++ b/lte/gateway/c/oai/tasks/mme_app/mme_app_main.c
@@ -27,6 +27,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <pthread.h>
+#include <czmq.h>
 
 #include "assertions.h"
 #include "bstrlib.h"
@@ -466,6 +467,8 @@ static int handle_message(zloop_t* loop, zsock_t* reader, void* arg) {
   put_mme_nas_state();
   put_mme_ue_state(mme_app_desc_p, imsi64);
 
+  OAILOG_INFO(LOG_MME_APP, "zsys_interrupted: %d", zsys_interrupted);
+
   itti_free_msg_content(received_message_p);
   free(received_message_p);
   return 0;
@@ -484,7 +487,11 @@ static void* mme_app_thread(__attribute__((unused)) void* args) {
   send_app_health_to_service303(&mme_app_task_zmq_ctx, TASK_MME_APP, false);
   start_stats_timer();
 
-  zloop_start(mme_app_task_zmq_ctx.event_loop);
+  zloop_set_verbose(mme_app_task_zmq_ctx.event_loop, true);
+  int zloop_mme_task_res = zloop_start(mme_app_task_zmq_ctx.event_loop);
+  OAILOG_INFO(
+      LOG_MME_APP, "mme_app_thread zloop exit result: %d", zloop_mme_task_res);
+  OAILOG_INFO(LOG_MME_APP, "zsys_interrupted: %d", zsys_interrupted);
   AssertFatal(
       0, "Asserting as mme_app_thread should not be exiting on its own!");
   return NULL;

--- a/lte/gateway/c/oai/tasks/mme_app/mme_app_timer_management.cpp
+++ b/lte/gateway/c/oai/tasks/mme_app/mme_app_timer_management.cpp
@@ -45,7 +45,7 @@ void mme_app_resume_timer(
   OAILOG_FUNC_IN(LOG_MME_APP);
   time_t current_time = time(NULL);
   time_t lapsed_time  = current_time - start_time;
-  OAILOG_DEBUG(LOG_MME_APP, "Handling :%s timer \n", timer_name);
+  OAILOG_INFO(LOG_MME_APP, "Handling :%s timer \n", timer_name);
 
   /* Below condition validates whether timer has expired before MME recovers
    * from restart, so MME shall handle as timer expiry
@@ -55,7 +55,7 @@ void mme_app_resume_timer(
     OAILOG_FUNC_OUT(LOG_MME_APP);
   }
   uint32_t remaining_time_in_seconds = timer->sec - lapsed_time;
-  OAILOG_DEBUG(
+  OAILOG_INFO(
       LOG_MME_APP,
       "Current_time :%ld %s timer start time :%ld "
       "lapsed time:%ld remaining time:%d \n",
@@ -73,7 +73,7 @@ void mme_app_resume_timer(
         timer_name, ue_mm_context_pP->mme_ue_s1ap_id);
     timer->id = MME_APP_TIMER_INACTIVE_ID;
   } else {
-    OAILOG_DEBUG_UE(
+    OAILOG_INFO_UE(
         LOG_MME_APP, ue_mm_context_pP->emm_context._imsi64,
         "Started %s timer for UE id " MME_UE_S1AP_ID_FMT "\n", timer_name,
         ue_mm_context_pP->mme_ue_s1ap_id);
@@ -96,6 +96,7 @@ int MmeUeContext::StartTimer(
            &mme_app_task_zmq_ctx, msec, repeat, handler, nullptr)) != -1) {
     mme_app_timers.insert(std::pair<int, uint32_t>(timer_id, arg));
   }
+  OAILOG_INFO(LOG_MME_APP, "Started timer with id: %d", timer_id);
   return timer_id;
 }
 //------------------------------------------------------------------------------

--- a/lte/gateway/c/oai/tasks/nas/emm/sap/emm_recv.c
+++ b/lte/gateway/c/oai/tasks/nas/emm/sap/emm_recv.c
@@ -196,6 +196,8 @@ int emm_recv_attach_request(
         ue_id, *emm_cause);
     rc         = emm_proc_attach_reject(ue_id, *emm_cause);
     *emm_cause = EMM_CAUSE_SUCCESS;
+    // Free the ESM container
+    bdestroy(msg->esmmessagecontainer);
     OAILOG_FUNC_RETURN(LOG_NAS_EMM, rc);
   }
 

--- a/lte/gateway/c/oai/tasks/s1ap/s1ap_mme.c
+++ b/lte/gateway/c/oai/tasks/s1ap/s1ap_mme.c
@@ -34,6 +34,7 @@
 #include <stdint.h>
 #include <pthread.h>
 #include <netinet/in.h>
+#include <czmq.h>
 
 #include "bstrlib.h"
 #include "hashtable.h"
@@ -328,6 +329,7 @@ static int handle_message(zloop_t* loop, zsock_t* reader, void* arg) {
     put_s1ap_imsi_map();
     put_s1ap_ue_state(imsi64);
   }
+  OAILOG_INFO(LOG_MME_APP, "zsys_interrupted: %d", zsys_interrupted);
   itti_free_msg_content(received_message_p);
   free(received_message_p);
   return 0;
@@ -345,7 +347,12 @@ static void* s1ap_mme_thread(__attribute__((unused)) void* args) {
   }
   start_stats_timer();
 
-  zloop_start(s1ap_task_zmq_ctx.event_loop);
+  zloop_set_verbose(s1ap_task_zmq_ctx.event_loop, true);
+  int zloop_s1ap_task_res = zloop_start(s1ap_task_zmq_ctx.event_loop);
+  OAILOG_INFO(
+      LOG_S1AP, "spgw_app_thread zloop exit result: %d",
+      zloop_s1ap_task_res);
+  OAILOG_INFO(LOG_S1AP, "zsys_interrupted: %d", zsys_interrupted);
   AssertFatal(
       0, "Asserting as s1ap_mme_thread should not be exiting on its own!");
   return NULL;

--- a/lte/gateway/c/oai/tasks/s1ap/s1ap_mme_handlers.c
+++ b/lte/gateway/c/oai/tasks/s1ap/s1ap_mme_handlers.c
@@ -1224,10 +1224,6 @@ int s1ap_mme_handle_ue_context_release_request(
         (uint32_t) mme_ue_s1ap_id, (uint32_t) enb_ue_s1ap_id);
     OAILOG_FUNC_RETURN(LOG_S1AP, RETURNerror);
   } else {
-    s1ap_imsi_map_t* imsi_map = get_s1ap_imsi_map();
-    hashtable_uint64_ts_get(
-        imsi_map->mme_ue_id_imsi_htbl, (const hash_key_t) mme_ue_s1ap_id,
-        &imsi64);
     if (ue_ref_p->sctp_assoc_id == assoc_id &&
         ue_ref_p->enb_ue_s1ap_id == enb_ue_s1ap_id) {
       /*
@@ -1235,6 +1231,10 @@ int s1ap_mme_handle_ue_context_release_request(
        * Send a UE context Release Command to eNB after releasing S1-U bearer
        * tunnel mapping for all the bearers.
        */
+      s1ap_imsi_map_t* imsi_map = get_s1ap_imsi_map();
+      hashtable_uint64_ts_get(
+          imsi_map->mme_ue_id_imsi_htbl, (const hash_key_t) mme_ue_s1ap_id,
+          &imsi64);
       rc = s1ap_send_mme_ue_context_release(
           state, ue_ref_p, s1_release_cause, ie->value.choice.Cause, imsi64);
 
@@ -1253,7 +1253,7 @@ int s1ap_mme_handle_ue_context_release_request(
       OAILOG_FUNC_RETURN(LOG_S1AP, rc);
     } else {
       // abnormal case. No need to do anything. Ignore the message
-      OAILOG_DEBUG_UE(
+      OAILOG_INFO_UE(
           LOG_S1AP, imsi64,
           "UE_CONTEXT_RELEASE_REQUEST ignored, cause mismatch enb_ue_s1ap_id: "
           "ctxt " ENB_UE_S1AP_ID_FMT " != request " ENB_UE_S1AP_ID_FMT " ",


### PR DESCRIPTION
<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->
- This is a draft PR purposed to being tested on AGW deployment which is suffering from MME app thread exits
- Increases logging on the handling of initial context setup expiration timer for UE
- Increases verbose logging on zmq event loop 

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->
- to be tested on spirent physical ubuntu AGWs

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
