### PR TITLE
feat(orc8r): Monitor NMS cert lifespan with alerts

### DIFF
--- a/orc8r/cloud/configs/certifier.yml
+++ b/orc8r/cloud/configs/certifier.yml
@@ -18,6 +18,7 @@ certsDirectory: "/var/opt/magma/certs/"
 orchestratorCerts:
   - "rootCA.pem"
   - "admin_operator.pem"
+  - "nms_operator.pem"
   - "controller.crt"
   - "certifier.pem"
   - "fluentd.pem"


### PR DESCRIPTION
Signed-off-by: Andrei Lee <andreilee@fb.com>

## Summary

Added `nms_operator.pem` certificate to `certifier.yml` to be monitored for certificate lifespan. This is so that alerts can fire when NMS operator certificates are going to expire soon.

## Test Plan

Stood up a local test development environment using Docker. Then checked that the metric for cert lifespan of the `nms_operator.pem` cert would be propagated to Prometheus. The screenshot below shows the metric.

![Screen Shot 2021-08-11 at 12 51 15 PM](https://user-images.githubusercontent.com/804385/129098039-3470f04c-4151-4133-8c34-cce1b40c006b.png)

The alert functionality was not tested, as it has not changed.


## Additional Information

- [ ] This change is backwards-breaking