### PR TITLE
fix(mme): Stop double free of state_cache_p in S1apStateManager

### DIFF
--- a/lte/gateway/c/core/oai/tasks/s1ap/s1ap_state_manager.cpp
+++ b/lte/gateway/c/core/oai/tasks/s1ap/s1ap_state_manager.cpp
@@ -93,9 +93,9 @@ void S1apStateManager::create_state() {
 }
 
 void free_s1ap_state(s1ap_state_t* state_cache_p) {
-  if (state_cache_p == nullptr) {
-    return;
-  }
+  AssertFatal(
+      state_cache_p,
+      "s1ap_state_t passed to free_s1ap_state must not be null");
 
   int i;
   hashtable_rc_t ht_rc;
@@ -127,14 +127,20 @@ void free_s1ap_state(s1ap_state_t* state_cache_p) {
     OAILOG_ERROR(
         LOG_S1AP, "An error occurred while destroying assoc_id hash table");
   }
-  free_wrapper(reinterpret_cast<void**>(&state_cache_p));
+  free(state_cache_p);
 }
 
 void S1apStateManager::free_state() {
   AssertFatal(
       is_initialized,
       "S1apStateManager init() function should be called to initialize state.");
+
+  if (state_cache_p == nullptr) {
+    return;
+  }
   free_s1ap_state(state_cache_p);
+  state_cache_p = nullptr;
+
   if (hashtable_ts_destroy(state_ue_ht) != HASH_TABLE_OK) {
     OAILOG_ERROR(
         LOG_S1AP, "An error occurred while destroying assoc_id hash table");

--- a/lte/gateway/c/core/oai/test/s1ap_task/CMakeLists.txt
+++ b/lte/gateway/c/core/oai/test/s1ap_task/CMakeLists.txt
@@ -7,7 +7,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-add_executable(s1ap_test test_s1ap_handle_new_association.cpp)
+add_executable(s1ap_test
+        s1ap_test.cpp
+        test_s1ap_handle_new_association.cpp
+        test_s1ap_state_manager.cpp)
 
 target_link_libraries(s1ap_test
         TASK_S1AP

--- a/lte/gateway/c/core/oai/test/s1ap_task/s1ap_test.cpp
+++ b/lte/gateway/c/core/oai/test/s1ap_task/s1ap_test.cpp
@@ -1,0 +1,24 @@
+/**
+ * Copyright 2021 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+
+extern "C" {
+#include "log.h"
+}
+
+int main(int argc, char** argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  OAILOG_INIT("MME", OAILOG_LEVEL_DEBUG, MAX_LOG_PROTOS);
+  return RUN_ALL_TESTS();
+}

--- a/lte/gateway/c/core/oai/test/s1ap_task/test_s1ap_handle_new_association.cpp
+++ b/lte/gateway/c/core/oai/test/s1ap_task/test_s1ap_handle_new_association.cpp
@@ -11,7 +11,6 @@
  * limitations under the License.
  */
 #include <gtest/gtest.h>
-#include <glog/logging.h>
 
 extern "C" {
 #include "log.h"
@@ -145,9 +144,3 @@ TEST(test_s1ap_handle_new_association, reassociate) {
 
 }  // namespace lte
 }  // namespace magma
-
-int main(int argc, char** argv) {
-  ::testing::InitGoogleTest(&argc, argv);
-  OAILOG_INIT("MME", OAILOG_LEVEL_DEBUG, MAX_LOG_PROTOS);
-  return RUN_ALL_TESTS();
-}

--- a/lte/gateway/c/core/oai/test/s1ap_task/test_s1ap_state_manager.cpp
+++ b/lte/gateway/c/core/oai/test/s1ap_task/test_s1ap_state_manager.cpp
@@ -1,0 +1,35 @@
+/**
+ * Copyright 2021 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <gtest/gtest.h>
+
+extern "C" {
+#include "log.h"
+}
+
+#include "s1ap_state_manager.h"
+
+namespace magma {
+namespace lte {
+
+/**
+ * Makes sure S1apStateManager::free_state is idempotent.
+ * Regression test for issue #8581.
+ */
+TEST(test_s1ap_state_manager, free_state_idempotent) {
+  S1apStateManager::getInstance().init(2, 2, false);
+  S1apStateManager::getInstance().free_state();
+  S1apStateManager::getInstance().free_state();
+}
+
+}  // namespace lte
+}  // namespace magma


### PR DESCRIPTION
Signed-off-by: Mark Jen <markjen@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

Fixed #8581 by guarding against state_cache_p being freed twice. 

This bug was introduced in #8209 when refactoring S1apStateManager for testability.

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

Added unit test.

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
