### PR TITLE
chore(magmad): bump psutil to 5.8

### DIFF
--- a/orc8r/gateway/python/setup.py
+++ b/orc8r/gateway/python/setup.py
@@ -79,7 +79,7 @@ setup(
         'prometheus_client==0.3.1',
         'sentry_sdk>=1.0.0',
         'snowflake>=0.0.3',
-        'psutil==5.6.6',
+        'psutil==5.8.0',
         'cryptography>=1.9',
         'itsdangerous>=0.24',
         'click>=5.1',


### PR DESCRIPTION
Signed-off-by: Oriol Batalla <obatalla@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

psutil is causing the warnings below when setting the log to debug.

This is caused because this issue already reported in psuitl 5.6 https://github.com/giampaolo/psutil/issues/1650

This PR bumps psutil to 5.8 to avoid that warning

```
Aug 12 03:15:36 ubuntuAGW magmad[926799]: INFO:root:[SyncRPC] Got heartBeat from cloud
Aug 12 03:15:57 ubuntuAGW magmad[926799]: /usr/local/lib/python3.8/dist-packages/psutil/_pslinux.py:1226: RuntimeWarning: ignoring FileNotFoundError(2, 'No such file or directory') for file '/sys/class/hwmon/hwmon0/temp1_input'
Aug 12 03:15:57 ubuntuAGW magmad[926799]:   warnings.warn("ignoring %r for file %r" % (err, path),
Aug 12 03:15:57 ubuntuAGW magmad[926799]: /usr/local/lib/python3.8/dist-packages/psutil/_pslinux.py:1226: RuntimeWarning: ignoring FileNotFoundError(2, 'No such file or directory') for file '/sys/class/hwmon/hwmon0/temp2_input'
```

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
