### PR TITLE
fix(feg): Add Gigawords support to builtin radius update RPC payload

### DIFF
--- a/feg/gateway/services/aaa/radius/acct.go
+++ b/feg/gateway/services/aaa/radius/acct.go
@@ -164,11 +164,13 @@ func (s *AcctServer) ServeRADIUS(w radius.ResponseWriter, r *radius.Request) {
 
 func makeUpdateReq(aaaCtx *protos.Context, p *radius.Packet) *protos.UpdateRequest {
 	u := &protos.UpdateRequest{
-		OctetsIn:   uint32(rfc2866.AcctInputOctets_Get(p)),
-		OctetsOut:  uint32(rfc2866.AcctOutputOctets_Get(p)),
-		PacketsIn:  uint32(rfc2866.AcctInputPackets_Get(p)),
-		PacketsOut: uint32(rfc2866.AcctOutputPackets_Get(p)),
-		Ctx:        aaaCtx,
+		OctetsIn:     uint32(rfc2866.AcctInputOctets_Get(p)),
+		OctetsOut:    uint32(rfc2866.AcctOutputOctets_Get(p)),
+		PacketsIn:    uint32(rfc2866.AcctInputPackets_Get(p)),
+		PacketsOut:   uint32(rfc2866.AcctOutputPackets_Get(p)),
+		Ctx:          aaaCtx,
+		GigawordsIn:  uint32(rfc2869.AcctInputGigawords_Get(p)),
+		GigawordsOut: uint32(rfc2869.AcctOutputGigawords_Get(p)),
 	}
 	glog.V(2).Infof("Interim Update: %v", u)
 	return u


### PR DESCRIPTION
Signed-off-by: Evgeniy Makeev <evgeniym@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

Add Gigawords support to builtin radius update RPC payload

## Test Plan

unit tests; test by deploying on an AP.

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
