### PR TITLE
feat(agw): back-port-v1.5: enable GTP-U echo response. (#7885)

### DIFF
--- a/lte/gateway/c/oai/include/sgw_config.h
+++ b/lte/gateway/c/oai/include/sgw_config.h
@@ -59,6 +59,7 @@
 #define SGW_CONFIG_STRING_OVS_UPLINK_PORT_NUM "UPLINK_PORT_NUM"
 #define SGW_CONFIG_STRING_OVS_UPLINK_MAC "UPLINK_MAC"
 #define SGW_CONFIG_STRING_OVS_MULTI_TUNNEL "MULTI_TUNNEL"
+#define SGW_CONFIG_STRING_OVS_GTP_ECHO "GTP_ECHO"
 
 #define SPGW_ABORT_ON_ERROR true
 #define SPGW_WARN_ON_ERROR false
@@ -72,6 +73,7 @@ typedef struct ovs_config_s {
   int uplink_port_num;
   bstring uplink_mac;
   bool multi_tunnel;
+  bool gtp_echo;
 } ovs_config_t;
 
 typedef struct sgw_config_s {

--- a/lte/gateway/c/oai/tasks/gtpv1-u/gtp_tunnel_openflow.c
+++ b/lte/gateway/c/oai/tasks/gtpv1-u/gtp_tunnel_openflow.c
@@ -154,13 +154,22 @@ static uint32_t get_gtp_port_no(char port_name[]) {
  */
 static uint32_t create_gtp_port(struct in_addr enb_addr, char port_name[]) {
   char gtp_port_create[512];
+  char* gtp_echo;
   int rc;
+
+  if (spgw_config.sgw_config.ovs_config.gtp_echo) {
+    gtp_echo = "true";
+  } else {
+    gtp_echo = "false";
+  }
   rc = snprintf(
       gtp_port_create, sizeof(gtp_port_create),
       "sudo ovs-vsctl --may-exist add-port gtp_br0 %s -- set Interface %s "
       "type=%s "
-      "options:remote_ip=%s options:key=flow",
-      port_name, port_name, ovs_gtp_type, inet_ntoa(enb_addr));
+      "options:remote_ip=%s options:key=flow "
+      "bfd:enable=%s "
+      "bfd:min_tx=5000 bfd:min_rx=5000",
+      port_name, port_name, ovs_gtp_type, inet_ntoa(enb_addr), gtp_echo);
   if (rc < 0) {
     OAILOG_ERROR(LOG_GTPV1U, "gtp-port create: format error %d", rc);
     return rc;

--- a/lte/gateway/c/oai/tasks/sgw/sgw_config.c
+++ b/lte/gateway/c/oai/tasks/sgw/sgw_config.c
@@ -311,6 +311,7 @@ int sgw_config_parse_file(sgw_config_t* config_pP)
     libconfig_int internal_sampling_fwd_tbl_num = 0;
     libconfig_int uplink_port_num               = 0;
     char* multi_tunnel                          = NULL;
+    char* gtp_echo                              = NULL;
     char* uplink_mac                            = NULL;
     if (config_setting_lookup_string(
             ovs_settings, SGW_CONFIG_STRING_OVS_BRIDGE_NAME,
@@ -333,7 +334,10 @@ int sgw_config_parse_file(sgw_config_t* config_pP)
             &internal_sampling_fwd_tbl_num) &&
         config_setting_lookup_string(
             ovs_settings, SGW_CONFIG_STRING_OVS_MULTI_TUNNEL,
-            (const char**) &multi_tunnel)) {
+            (const char**) &multi_tunnel) &&
+        config_setting_lookup_string(
+            ovs_settings, SGW_CONFIG_STRING_OVS_GTP_ECHO,
+            (const char**) &gtp_echo)) {
       config_pP->ovs_config.bridge_name  = bfromcstr(ovs_bridge_name);
       config_pP->ovs_config.gtp_port_num = gtp_port_num;
       config_pP->ovs_config.mtr_port_num = mtr_port_num;
@@ -349,6 +353,12 @@ int sgw_config_parse_file(sgw_config_t* config_pP)
         config_pP->ovs_config.multi_tunnel = true;
       }
       OAILOG_INFO(LOG_SPGW_APP, "Multi tunnel enable: %s\n", multi_tunnel);
+      if (strcasecmp(gtp_echo, "true") == 0) {
+        config_pP->ovs_config.gtp_echo = true;
+      } else {
+        config_pP->ovs_config.gtp_echo = false;
+      }
+      OAILOG_INFO(LOG_SPGW_APP, "GTP-U echo response enable: %s\n", gtp_echo);
     } else {
       AssertFatal(false, "Couldn't find all ovs settings in spgw config\n");
     }

--- a/lte/gateway/configs/spgw.yml
+++ b/lte/gateway/configs/spgw.yml
@@ -42,3 +42,6 @@ ovs_multi_tunnel: true
 
 # Non-NAT specific config
 ovs_uplink_port_number: 2
+
+# To enable GTP-U echo response on all GTP tunnels.
+ovs_gtpu_echo_resp: true

--- a/lte/gateway/configs/templates/spgw.conf.template
+++ b/lte/gateway/configs/templates/spgw.conf.template
@@ -46,6 +46,7 @@ S-GW :
       UPLINK_PORT_NUM                      = {{ ovs_uplink_port_number }};
       UPLINK_MAC                           = "{{ ovs_uplink_mac }}";
       MULTI_TUNNEL                         = "{{ ovs_multi_tunnel }}";
+      GTP_ECHO                             = "{{ ovs_gtpu_echo_resp }}";
     };
 };
 

--- a/lte/gateway/release/build-magma.sh
+++ b/lte/gateway/release/build-magma.sh
@@ -181,10 +181,10 @@ if [[ "$OS" == "debian" ]]; then
 else
     OVS_DEPS=(
         "magma-libfluid >= 0.1.0.6"
-        "libopenvswitch >= 2.14"
-        "openvswitch-switch >= 2.14"
-        "openvswitch-common >= 2.14"
-        "openvswitch-datapath-dkms >= 2.14"
+        "libopenvswitch >= 2.14.3-13"
+        "openvswitch-switch >= 2.14.3-13"
+        "openvswitch-common >= 2.14.3-13"
+        "openvswitch-datapath-dkms >= 2.14.3-13"
         )
 fi
 


### PR DESCRIPTION
AGW can make use of OVS echo response if available.

Signed-off-by: Pravin B Shelar <pbshelar@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
