### PR TITLE
chore: Set default build type of magma-build.sh to be RelWithDebInfo

### DIFF
--- a/lte/gateway/release/build-magma.sh
+++ b/lte/gateway/release/build-magma.sh
@@ -24,7 +24,7 @@ VERSION=1.7.0 # magma version number
 SCTPD_MIN_VERSION=1.7.0 # earliest version of sctpd with which this version is compatible
 
 # RelWithDebInfo or Debug
-BUILD_TYPE=Debug
+BUILD_TYPE=RelWithDebInfo
 
 # Cmdline options that overwrite the version configs above
 COMMIT_HASH=""  # hash of top magma commit (hg log $MAGMA_PATH)
@@ -90,7 +90,7 @@ case $OS in
     ;;
     *)
     echo "Error: unknown OS option:" $OS
-    echo "Usage: [--os debian|ubuntu]"
+    echo "Usage: [--os ubuntu]"
     exit 1
     ;;
 esac


### PR DESCRIPTION
Signed-off-by: Marie Bremner <marwhal@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary
Debug type has (which has ASAN enabled) has performance issues. It would make more sense for RelWithDebInfo to be the default as most people using this script wants a full AGW package that is functional. 

Also clean up debian mentions.
<!-- Enumerate changes you made and why you made them -->

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
