### PR TITLE
fix(mme): Frees esmmessagecontainer on attach reject proc

### DIFF
--- a/lte/gateway/c/oai/tasks/nas/emm/sap/emm_recv.c
+++ b/lte/gateway/c/oai/tasks/nas/emm/sap/emm_recv.c
@@ -196,6 +196,8 @@ int emm_recv_attach_request(
         ue_id, *emm_cause);
     rc         = emm_proc_attach_reject(ue_id, *emm_cause);
     *emm_cause = EMM_CAUSE_SUCCESS;
+    // Free the ESM container
+    bdestroy(msg->esmmessagecontainer);
     OAILOG_FUNC_RETURN(LOG_NAS_EMM, rc);
   }
 


### PR DESCRIPTION
Signed-off-by: Alex Rodriguez <ardzoht@gmail.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->
- Backporting changes of #8594 into `v1.5` branch

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->
- tested locally on s1ap tester based off v1.5 and verified memory leak does not happen

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
