### PR TITLE
fix(agw): backport-v1.6: enable GTP echo (#8328)

### DIFF
--- a/lte/gateway/c/core/oai/tasks/gtpv1-u/gtp_tunnel_openflow.c
+++ b/lte/gateway/c/core/oai/tasks/gtpv1-u/gtp_tunnel_openflow.c
@@ -167,7 +167,8 @@ static uint32_t create_gtp_port(struct in_addr enb_addr, char port_name[]) {
       "sudo ovs-vsctl --may-exist add-port gtp_br0 %s -- set Interface %s "
       "type=%s "
       "options:remote_ip=%s options:key=flow "
-      "bfd:enable=%s",
+      "bfd:enable=%s "
+      "bfd:min_tx=5000 bfd:min_rx=5000",
       port_name, port_name, ovs_gtp_type, inet_ntoa(enb_addr), gtp_echo);
   if (rc < 0) {
     OAILOG_ERROR(LOG_GTPV1U, "gtp-port create: format error %d", rc);

--- a/lte/gateway/configs/spgw.yml
+++ b/lte/gateway/configs/spgw.yml
@@ -47,4 +47,4 @@ ovs_uplink_port_number: 2
 pipelined_managed_tbl0: false
 
 # To enable GTP-U echo response on all GTP tunnels.
-ovs_gtpu_echo_resp: false
+ovs_gtpu_echo_resp: true

--- a/lte/gateway/release/build-magma.sh
+++ b/lte/gateway/release/build-magma.sh
@@ -183,10 +183,10 @@ if [[ "$OS" == "debian" ]]; then
 else
     OVS_DEPS=(
         "magma-libfluid >= 0.1.0.6"
-        "libopenvswitch >= 2.14.3-7"
-        "openvswitch-switch >= 2.14.3-7"
-        "openvswitch-common >= 2.14.3-7"
-        "openvswitch-datapath-dkms >= 2.14.3-7"
+        "libopenvswitch >= 2.14.3-13"
+        "openvswitch-switch >= 2.14.3-13"
+        "openvswitch-common >= 2.14.3-13"
+        "openvswitch-datapath-dkms >= 2.14.3-13"
         )
 fi
 


### PR DESCRIPTION
The GTP echo functionality regression is fixed. Following
commit enables the GTP echo on the AGW.

Signed-off-by: Pravin B Shelar <pravin.ovn@gmail.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
