### PR TITLE
fix(agw):Fixed memory leaks on v1.5.2 branch

### DIFF
--- a/lte/gateway/c/oai/tasks/nas/emm/TrackingAreaUpdate.c
+++ b/lte/gateway/c/oai/tasks/nas/emm/TrackingAreaUpdate.c
@@ -652,7 +652,8 @@ static int emm_tracking_area_update_accept(nas_emm_tau_proc_t* const tau_proc) {
       emm_sap.u.emm_as.u.establish.emergency_number_list = NULL;
 
       emm_sap.u.emm_as.u.establish.eps_network_feature_support =
-          calloc(1, sizeof(eps_network_feature_support_t));
+          (eps_network_feature_support_t*) &_emm_data.conf
+              .eps_network_feature_support;
       emm_sap.u.emm_as.u.establish.eps_network_feature_support->b1 =
           _emm_data.conf.eps_network_feature_support[0];
       emm_sap.u.emm_as.u.establish.eps_network_feature_support->b2 =
@@ -750,7 +751,8 @@ static int emm_tracking_area_update_accept(nas_emm_tau_proc_t* const tau_proc) {
       }
 
       emm_sap.u.emm_as.u.establish.eps_network_feature_support =
-          calloc(1, sizeof(eps_network_feature_support_t));
+          (eps_network_feature_support_t*) &_emm_data.conf
+              .eps_network_feature_support;
       emm_sap.u.emm_as.u.establish.eps_network_feature_support->b1 =
           _emm_data.conf.eps_network_feature_support[0];
       emm_sap.u.emm_as.u.establish.eps_network_feature_support->b2 =


### PR DESCRIPTION
fix(agw):Fixed memory leaks on v1.5.2 branch

## Summary

Fixed memory leaks found on v1.5.2 release during the execution of the following TCs. These TCs are part of sanity :
test_tau_periodic_inactive.py
test_tau_periodic_active.py
test_attach_detach_enb_rlf_initial_ue_msg.py

Fixed the following leaks:
magma-dev-focal mme[7465]: Direct leak of 16 byte(s) in 1 object(s) allocated from:
magma-dev-focal mme[7465]:     #0 0x7f743723fdc6 in calloc (/lib/x86_64-linux-gnu/libasan.so.5+0x10ddc6)
magma-dev-focal mme[7465]:     #1 0x55ae123eae91 in create_new_attach_info /home/vagrant/magma/lte/gateway/c/oai/tasks/nas/emm/Attach.c:2550
magma-dev-focal mme[7465]:     #2 0x55ae123bfaec in emm_proc_attach_request /home/vagrant/magma/lte/gateway/c/oai/tasks/nas/emm/Attach.c:399
magma-dev-focal mme[7465]:     #3 0x55ae1248715c in emm_recv_attach_request /home/vagrant/magma/lte/gateway/c/oai/tasks/nas/emm/sap/emm_recv.c:422
magma-dev-focal mme[7465]:     #4 0x55ae1250e7d6 in emm_as_recv /home/vagrant/magma/lte/gateway/c/oai/tasks/nas/emm/sap/emm_as.c:377
magma-dev-focal mme[7465]:     #5 0x55ae12513414 in emm_as_data_ind /home/vagrant/magma/lte/gateway/c/oai/tasks/nas/emm/sap/emm_as.c:678
magma-dev-focal mme[7465]:     #6 0x55ae1250ce36 in emm_as_send /home/vagrant/magma/lte/gateway/c/oai/tasks/nas/emm/sap/emm_as.c:180
magma-dev-focal mme[7465]:     #7 0x55ae12495926 in emm_sap_send /home/vagrant/magma/lte/gateway/c/oai/tasks/nas/emm/sap/emm_sap.c:105
magma-dev-focal mme[7465]:     #8 0x55ae12390b27 in nas_proc_ul_transfer_ind /home/vagrant/magma/lte/gateway/c/oai/tasks/nas/nas_proc.c:326
magma-dev-focal mme[7465]:     #9 0x55ae11cdd0a8 in handle_message /home/vagrant/magma/lte/gateway/c/oai/tasks/mme_app/mme_app_main.c:95
magma-dev-focal mme[7465]:     #10 0x7f74363b65c6 in zloop_start (/lib/x86_64-linux-gnu/libczmq.so.4+0x295c6)

magma-dev-focal mme[233466]: Direct leak of 8 byte(s) in 4 object(s) allocated from:
magma-dev-focal mme[233466]: #0 0x7fb4700c7dc6 in calloc (/lib/x86_64-linux-gnu/libasan.so.5+0x10ddc6)
magma-dev-focal mme[233466]: #1 0x56217726d5d4 in emm_tracking_area_update_accept /home/vagrant/magma/lte/gateway/c/oai/tasks/nas/emm/TrackingAreaUpdate.c:753
magma-dev-focal mme[233466]: #2 0x562177268ea2 in emm_proc_tracking_area_update_request /home/vagrant/magma/lte/gateway/c/oai/tasks/nas/emm/TrackingAreaUpdate.c:352
magma-dev-focal mme[233466]: #3 0x5621772a3c53 in emm_recv_tracking_area_update_request /home/vagrant/magma/lte/gateway/c/oai/tasks/nas/emm/sap/emm_recv.c:668
magma-dev-focal mme[233466]: #4 0x56217732e19c in emm_as_establish_req /home/vagrant/magma/lte/gateway/c/oai/tasks/nas/emm/sap/emm_as.c:871
magma-dev-focal mme[233466]: #5 0x562177324f41 in emm_as_send /home/vagrant/magma/lte/gateway/c/oai/tasks/nas/emm/sap/emm_as.c:185
magma-dev-focal mme[233466]: #6 0x5621772ad8b6 in emm_sap_send /home/vagrant/magma/lte/gateway/c/oai/tasks/nas/emm/sap/emm_sap.c:105
magma-dev-focal mme[233466]: #7 0x5621771a7ab7 in nas_proc_establish_ind /home/vagrant/magma/lte/gateway/c/oai/tasks/nas/nas_proc.c:185
magma-dev-focal mme[233466]: #8 0x562176b085f7 in mme_app_handle_initial_ue_message /home/vagrant/magma/lte/gateway/c/oai/tasks/mme_app/mme_app_bearer.c:717
magma-dev-focal mme[233466]:  #9 0x562176af6443 in handle_message /home/vagrant/magma/lte/gateway/c/oai/tasks/mme_app/mme_app_main.c:202
magma-dev-focal mme[233466]:  #10 0x7fb46f23e5c6 in zloop_start (/lib/x86_64-linux-gnu/libczmq.so.4+0x295c6)


## Test Plan

Verified that the above mentioned leaks are not seen after the execution of sanity

## Additional Information

On 1.5.2 OVS flow verification is failing. So commented out that part in the TCs and executed sanity