### PR TITLE
feat: Domain proxy helm chart

### DIFF
--- a/.github/workflows/config/yamllint_config.yml
+++ b/.github/workflows/config/yamllint_config.yml
@@ -9,6 +9,7 @@ yaml-files:
 
 ignore: |
   **/templates/*.yaml
+  **/templates/**/*.yaml
 
 rules:
   braces: enable

--- a/dp/cloud/helm/dp/Chart.yaml
+++ b/dp/cloud/helm/dp/Chart.yaml
@@ -1,0 +1,67 @@
+---
+# Copyright 2020 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v2
+appVersion: "0.1.0"
+version: 0.1.0
+description: A Helm chart for magma orchestrator's domain-proxy module.
+name: domain-proxy
+engine: gotpl
+sources:
+  - https://github.com/magma/magma
+keywords:
+  - magma
+  - or8cr
+  - dp
+type: application
+
+long_description: |
+  This Chart will deploy the following:
+
+  - 1 x Configuration controller.
+  - 1 x protocol controller with 80/443 TCP port exposed with either ingress/contour ingress resource.
+  - 1 x radio controller with GRPC 50053/TCP port.
+  - All using Kubernetes Deployment
+  - 1 x job for Postgres database migration.
+
+  ## Installation.
+
+  ### Preprequsites.
+
+  Domain proxy requires an ingress controller to be present on targer kubernetes cluster.
+  Standard ingress resource is supported as well as countour httpproxy CRD.
+  (https://projectcontour.io/docs/v1.16.0/config/fundamentals/)
+
+  ### From Source.
+
+  ```bash
+  git clone
+  cd dp/cloud/helm/dp
+  helm dep update domain-proxy
+  helm install --name myname --namespace mynamespace domain-proxy
+  ```
+
+  ### Certificates.
+
+  In order to work properly Domain proxy requires set of certificates. To enable chart to consume them place them inside.
+  `certificates` directory and setup proper certificate paths in your `values.yaml` file.
+
+  ## Development.
+
+  ### Local Deployment using Minikube.
+  If you're running locally in Minikube, see the `examples/minikube_values.yml` file.
+
+  To run local development environment:
+
+  ```bash
+  make
+  ```

--- a/dp/cloud/helm/dp/README.md
+++ b/dp/cloud/helm/dp/README.md
@@ -1,0 +1,186 @@
+
+Domain-proxy
+===========
+
+A Helm chart for magma orchestrator's domain-proxy module.
+
+This Chart will deploy the following:
+
+- 1 x Configuration controller.
+- 1 x protocol controller with 80/443 TCP port exposed with either ingress/contour ingress resource.
+- 1 x radio controller with GRPC 50053/TCP port.
+- All using Kubernetes Deployment
+- 1 x job for Postgres database migration.
+
+## Installation.
+
+### Preprequsites.
+
+Domain proxy requires an ingress controller to be present on targer kubernetes cluster.
+Standard ingress resource is supported as well as countour httpproxy CRD.
+(https://projectcontour.io/docs/v1.16.0/config/fundamentals/)
+
+### From Source.
+
+```bash
+git clone
+cd dp/cloud/helm/dp
+helm dep update domain-proxy
+helm install --name myname --namespace mynamespace domain-proxy
+```
+
+### Certificates.
+
+In order to work properly Domain proxy requires set of certificates. To enable chart to consume them place them inside.
+`certificates` directory and setup proper certificate paths in your `values.yaml` file.
+
+## Development.
+
+### Local Deployment using Minikube.
+If you're running locally in Minikube, see the `examples/minikube_values.yml` file.
+
+To run local development environment:
+
+```bash
+make
+```
+
+## Configuration
+
+The following table lists the configurable parameters of the Domain-proxy chart and their default values.
+
+| Parameter                | Description             | Default        |
+| ------------------------ | ----------------------- | -------------- |
+| `nameOverride` | Replaces the name of the chart in the `Chart.yaml` file. | `""` |
+| `fullnameOverride` | Completely replaces the helm release generated name. | `""` |
+| `configuration_controller.sasEndpointUrl` | Endpoint where sas request should be send. | `"https://fake-sas-service/v1.2"` |
+| `configuration_controller.nameOverride` | Replaces service part of the dp component deployment name. | `""` |
+| `configuration_controller.fullnameOverride` | Completely replaces dp component deployment name. | `""` |
+| `configuration_controller.enabled` | Enables deployment of the given service. | `true` |
+| `configuration_controller.name` | Domain proxy component name. | `"configuration-controller"` |
+| `configuration_controller.image.repository` | Docker image repository. | `"configuration-controller"` |
+| `configuration_controller.image.pullPolicy` | Default the pull policy of all containers in that pod. | `"IfNotPresent"` |
+| `configuration_controller.image.tag` | Overrides the image tag whose default is the chart appVersion. | `""` |
+| `configuration_controller.replicaCount` | How many replicas of particular component should be created. | `1` |
+| `configuration_controller.imagePullSecrets` | Name of the secret that contains container image registry keys | `[]` |
+| `configuration_controller.serviceAccount.create` | Specifies whether a service account should be created | `false` |
+| `configuration_controller.serviceAccount.annotations` | Annotations to add to the service account | `{}` |
+| `configuration_controller.serviceAccount.name` | The name of the service account to use,If not set and create is true, a name is generated using the fullname template. | `""` |
+| `configuration_controller.podAnnotations` | Additional pod annotations | `{}` |
+| `configuration_controller.podSecurityContext` | Holds pod-level security attributes | `{}` |
+| `configuration_controller.securityContext` | Holds security configuration that will be applied to a container. | `{}` |
+| `configuration_controller.service.enable` | Whether to enable kubernetes service for dp component. | `true` |
+| `configuration_controller.service.type` | Type of enabled kubernetes service. | `"ClusterIP"` |
+| `configuration_controller.service.port` | Default port of enabled kubernetes service. | `8080` |
+| `configuration_controller.tlsConfig.paths.cert` | Client/Server TLS certificate path. | `""` |
+| `configuration_controller.tlsConfig.paths.key` | Client/Server TLS private key path. | `""` |
+| `configuration_controller.tlsConfig.paths.ca` | Certificate Authority certifcate chain path. | `""` |
+| `configuration_controller.ingress.enabled` | Enable kubernetes ingress resource. | `false` |
+| `configuration_controller.ingress.annotations` | Annotations to kubernetes ingress resource. | `{}` |
+| `configuration_controller.ingress.hosts` |  | `[{"host": "chart-example.local", "paths": [{"path": "/", "backend": {"serviceName": "chart-example.local", "servicePort": 80}}]}]` |
+| `configuration_controller.ingress.tls` | Kubernetes secret name for tls termination on ingress kubernetes resource. | `[]` |
+| `configuration_controller.resources` | Resource requests and limits of Pod. | `{}` |
+| `configuration_controller.readinessProbe` | Readines probe definition. | `{}` |
+| `configuration_controller.livenessProbe` | Livenes probe definition. | `{}` |
+| `configuration_controller.autoscaling.enabled` | Enables horizontal pod autscaler kubernetes resource. | `false` |
+| `configuration_controller.autoscaling.minReplicas` | Minimum number of dp component replicas. | `1` |
+| `configuration_controller.autoscaling.maxReplicas` | Maximum number of dp component replicas. | `100` |
+| `configuration_controller.autoscaling.targetCPUUtilizationPercentage` | Target CPU utilization threshold in perecents when new replica should be created | `80` |
+| `configuration_controller.podDisruptionBudget.enabled` | Creates kubernetes podDisruptionBudget resource. | `false` |
+| `configuration_controller.podDisruptionBudget.minAvailable` | Minimum available pods for dp component. | `1` |
+| `configuration_controller.podDisruptionBudget.maxUnavailable` | Maximum unavailable pods for dp component. | `""` |
+| `configuration_controller.nodeSelector` | Kubernetes node selection constraint. | `{}` |
+| `configuration_controller.tolerations` | Allow the pods to schedule onto nodes with matching taints. | `[]` |
+| `configuration_controller.affinity` | Constrain which nodes your pod is eligible to be scheduled on. | `{}` |
+| `protocol_controller.nameOverride` | Replaces service part of the dp component deployment name. | `""` |
+| `protocol_controller.fullnameOverride` | Completely replaces dp component deployment name. | `""` |
+| `protocol_controller.enabled` | Enables deployment of the given dp component. | `true` |
+| `protocol_controller.name` | Domain proxy component name. | `"protocol-controller"` |
+| `protocol_controller.image.repository` | Docker image repository. | `"protocol-controller"` |
+| `protocol_controller.image.tag` | Overrides the image tag whose default is the chart appVersion. | `""` |
+| `protocol_controller.image.pullPolicy` | Default the pull policy of all containers in that pod. | `"IfNotPresent"` |
+| `protocol_controller.replicaCount` | How many replicas of particular component should be created. | `1` |
+| `protocol_controller.imagePullSecrets` | Name of the secret that contains container image registry keys. | `[]` |
+| `protocol_controller.serviceAccount.create` | Specifies whether a service account should be created | `false` |
+| `protocol_controller.serviceAccount.annotations` | Annotations to add to the service account | `{}` |
+| `protocol_controller.serviceAccount.name` | The name of the service account to use,If not set and create is true, a name is generated using the fullname template. | `""` |
+| `protocol_controller.podAnnotations` | Additional pod annotations. | `{}` |
+| `protocol_controller.podSecurityContext` | Holds pod-level security attributes. | `{}` |
+| `protocol_controller.securityContext` | Holds security configuration that will be applied to a container. | `{}` |
+| `protocol_controller.service.enable` | Whether to enable kubernetes service for dp component. | `true` |
+| `protocol_controller.service.type` | Type of enabled kubernetes service. | `"ClusterIP"` |
+| `protocol_controller.service.port` | Default port of enabled kubernetes service. | `8080` |
+| `protocol_controller.tlsConfig.paths.cert` | Client/Server TLS certificate path. | `""` |
+| `protocol_controller.tlsConfig.paths.key` | Client/Server TLS private key path. | `""` |
+| `protocol_controller.tlsConfig.paths.ca` | Certificate Authority certifcate chain path. | `""` |
+| `protocol_controller.apiPrefix` | Protocol controller URL API prefix. | `"/sas/v1"` |
+| `protocol_controller.ingress.enabled` | Enable kubernetes ingress resource. | `false` |
+| `protocol_controller.ingress.annotations` | Annotations to kubernetes ingress resource. | `{}` |
+| `protocol_controller.ingress.hosts` |  | `[{"host": "chart-example.local", "paths": [{"path": "/", "backend": {"serviceName": "chart-example.local", "servicePort": 80}}]}]` |
+| `protocol_controller.ingress.tls` | Kubernetes secret name for tls termination on ingress kubernetes resource. | `[]` |
+| `protocol_controller.httpproxy.enabled` | Enables contour httpproxy CRD. | `false` |
+| `protocol_controller.httpproxy.annotations` | Aditional annotations. | `{}` |
+| `protocol_controller.httpproxy.virtualhost.fqdn` | Host header wildcards for kubernetes ingress resource. | `"chart-example.local"` |
+| `protocol_controller.httpproxy.virtualhost.path` | Path header wildcards for kubernetes ingress resource. | `"/example"` |
+| `protocol_controller.httpproxy.virtualhost.tls` | Kubernetes secret name for tls termination on ingress kubernetes resource. | `{}` |
+| `protocol_controller.resources` | Resource requests and limits of Pod. | `{}` |
+| `protocol_controller.readinessProbe` | Readines probe definition. | `{}` |
+| `protocol_controller.livenessProbe` | Livenes probe definition. | `{}` |
+| `protocol_controller.autoscaling.enabled` | Enables horizontal pod autscaler kubernetes resource. | `false` |
+| `protocol_controller.autoscaling.minReplicas` | Minimum number of dp component replicas. | `1` |
+| `protocol_controller.autoscaling.maxReplicas` | Maximum number of dp component replicas. | `100` |
+| `protocol_controller.autoscaling.targetCPUUtilizationPercentage` | Target CPU utilization threshold in perecents when new replica should be created. | `80` |
+| `protocol_controller.podDisruptionBudget.enabled` | Creates kubernetes podDisruptionBudget resource. | `false` |
+| `protocol_controller.podDisruptionBudget.minAvailable` | Minimum available pods for dp component. | `1` |
+| `protocol_controller.podDisruptionBudget.maxUnavailable` | Minimum available pods for dp component. | `""` |
+| `protocol_controller.nodeSelector` | Kubernetes node selection constraint. | `{}` |
+| `protocol_controller.tolerations` | Allow the pods to schedule onto nodes with matching taints. | `[]` |
+| `protocol_controller.affinity` | Constrain which nodes your pod is eligible to be scheduled on. | `{}` |
+| `radio_controller.nameOverride` | Replaces service part of the dp component deployment name. | `""` |
+| `radio_controller.fullnameOverride` | Completely replaces dp component deployment name. | `""` |
+| `radio_controller.enabled` | Enables deployment of the given dp component. | `true` |
+| `radio_controller.name` | Domain proxy component name. | `"radio-controller"` |
+| `radio_controller.image.repository` | Docker image repository. | `"radio-controller"` |
+| `radio_controller.image.tag` | Overrides the image tag whose default is the chart appVersion. | `""` |
+| `radio_controller.image.pullPolicy` | Default the pull policy of all containers in that pod. | `"IfNotPresent"` |
+| `radio_controller.replicaCount` | How many replicas of particular component should be created. | `1` |
+| `radio_controller.imagePullSecrets` | Name of the secret that contains container image registry keys. | `[]` |
+| `radio_controller.serviceAccount.create` | Specifies whether a service account should be created. | `false` |
+| `radio_controller.serviceAccount.annotations` | Annotations to add to the service account. | `{}` |
+| `radio_controller.serviceAccount.name` | The name of the service account to use,If not set and create is true, a name is generated using the fullname template. | `""` |
+| `radio_controller.podAnnotations` | Additional pod annotations. | `{}` |
+| `radio_controller.podSecurityContext` | Holds pod-level security attributes. | `{}` |
+| `radio_controller.securityContext` | Holds security configuration that will be applied to a container. | `{}` |
+| `radio_controller.service.enable` | Whether to enable kubernetes service for dp component. | `true` |
+| `radio_controller.service.type` | Type of enabled kubernetes service. | `"ClusterIP"` |
+| `radio_controller.service.port` | Default port of enabled kubernetes service. | `50053` |
+| `radio_controller.resources` | Resource requests and limits of Pod. | `{}` |
+| `radio_controller.readinessProbe` | Readines probe definition. | `{}` |
+| `radio_controller.livenessProbe` | Livenes probe definition. | `{}` |
+| `radio_controller.autoscaling.enabled` | Enables horizontal pod autscaler kubernetes resource. | `false` |
+| `radio_controller.autoscaling.minReplicas` | Minimum number of dp component replicas. | `1` |
+| `radio_controller.autoscaling.maxReplicas` | Maximum number of dp component replicas. | `100` |
+| `radio_controller.autoscaling.targetCPUUtilizationPercentage` | Target CPU utilization threshold in perecents when new replica should be created | `80` |
+| `radio_controller.podDisruptionBudget.enabled` | Creates kubernetes podDisruptionBudget resource. | `false` |
+| `radio_controller.podDisruptionBudget.minAvailable` | Minimum available pods for dp component. | `1` |
+| `radio_controller.podDisruptionBudget.maxUnavailable` | Maximum unavailable pods for dp component. | `""` |
+| `radio_controller.nodeSelector` | Kubernetes node selection constraint. | `{}` |
+| `radio_controller.tolerations` | Allow the pods to schedule onto nodes with matching taints. | `[]` |
+| `radio_controller.affinity` | Constrain which nodes your pod is eligible to be scheduled on. | `{}` |
+| `db_service.enabled` | Enables deployment of the given service. | `true` |
+| `db_service.nameOverride` | Replaces service part of the dp component deployment name. | `""` |
+| `db_service.fullnameOverride` | Completely replaces dp component deployment name. | `""` |
+| `db_service.name` | Domain proxy component name. | `"db-service"` |
+| `db_service.image.repository` | Docker image repository. | `"db-service"` |
+| `db_service.image.pullPolicy` | Default the pull policy of all containers in that pod. | `"IfNotPresent"` |
+| `db_service.image.tag` | Overrides the image tag whose default is the chart appVersion. | `""` |
+| `db_service.imagePullSecrets` | Name of the secret that contains container image registry keys | `[]` |
+| `db_service.serviceAccount.create` | Specifies whether a service account should be created. | `false` |
+| `db_service.serviceAccount.annotations` | Annotations to add to the service account. | `{}` |
+| `db_service.serviceAccount.name` | The name of the service account to use,If not set and create is true, a name is generated using the fullname template. | `""` |
+
+
+
+---
+_Documentation generated by [Frigate](https://frigate.readthedocs.io)._
+

--- a/dp/cloud/helm/dp/examples/aws_contour_values.yaml
+++ b/dp/cloud/helm/dp/examples/aws_contour_values.yaml
@@ -1,0 +1,246 @@
+---
+nameOverride: ""
+fullnameOverride: ""
+
+configuration_controller:
+
+  nameOverride: ""
+  fullnameOverride: ""
+  enabled: true
+  name: configuration-controller
+
+  sasEndpointUrl: "https://fake-sas-service/v1.2"
+
+  image:
+    repository: domainproxyfw1/configuration-controller
+    pullPolicy: IfNotPresent
+    tag: "latest"
+
+  replicaCount: 1
+
+  imagePullSecrets: []
+
+  serviceAccount:
+    create: false
+    annotations: {}
+    name: ""
+
+  podAnnotations: {}
+
+  podSecurityContext: {}
+
+  securityContext: {}
+
+  service:
+    enable: true
+    type: ClusterIP
+    port: 8080
+
+  tlsConfig:
+    paths:
+      cert: "certificates/configuration_controller/device_c.cert"
+      key: "certificates/configuration_controller/device_c.key"
+      ca: "certificates/configuration_controller/ca.cert"
+
+  ingress:
+    enabled: false
+    annotations: {}
+    hosts: []
+    tls: []
+
+  resources:
+    limits:
+      cpu: 100m
+      memory: 128Mi
+    requests:
+      cpu: 100m
+      memory: 128Mi
+
+  readinessProbe: {}
+
+  livenessProbe: {}
+
+  autoscaling:
+    enabled: false
+    minReplicas: 1
+    maxReplicas: 100
+    targetCPUUtilizationPercentage: 80
+
+  podDisruptionBudget:
+    enabled: false
+    minAvailable: 1
+    maxUnavailable: ""
+
+  nodeSelector: {}
+
+  tolerations: []
+
+  affinity: {}
+
+protocol_controller:
+
+  nameOverride: ""
+  fullnameOverride: ""
+  enabled: true
+  name: protocol-controller
+
+  image:
+    repository: domainproxyfw1/protocol-controller
+    tag: "latest"
+    pullPolicy: IfNotPresent
+
+  replicaCount: 1
+
+  imagePullSecrets: []
+
+  serviceAccount:
+    create: false
+    annotations: {}
+    name: ""
+
+  podAnnotations: {}
+
+  podSecurityContext: {}
+
+  securityContext: {}
+
+  service:
+    enable: true
+    type: ClusterIP
+    port: 8080
+
+  tlsConfig:
+    paths:
+      cert: "certificates/protocol_controller/domain_proxy_bundle.cert"
+      key: "certificates/protocol_controller/domain_proxy_server.key"
+      ca: "certificates/protocol_controller/ca.cert"
+
+  apiPrefix: "/sas/v1"
+
+  ingress:
+    enabled: false
+    annotations: {}
+    hosts: []
+    tls: []
+
+  httpproxy:
+    enabled: true
+    annotations: {}
+    virtualhost:
+      fqdn: domain-proxy
+      path: /sas
+      tls:
+        secretName: domain-proxy-pc
+        caSecret: domain-proxy-pc-ca
+
+  resources:
+    limits:
+      cpu: 100m
+      memory: 128Mi
+    requests:
+      cpu: 100m
+      memory: 128Mi
+
+  readinessProbe: {}
+
+  livenessProbe: {}
+
+  autoscaling:
+    enabled: false
+    minReplicas: 1
+    maxReplicas: 100
+    targetCPUUtilizationPercentage: 80
+
+  podDisruptionBudget:
+    enabled: false
+    minAvailable: 1
+    maxUnavailable: ""
+
+  nodeSelector: {}
+
+  tolerations: []
+
+  affinity: {}
+
+radio_controller:
+
+  nameOverride: ""
+  fullnameOverride: ""
+  enabled: true
+  name: radio-controller
+
+  image:
+    repository: domainproxyfw1/radio-controller
+    tag: "latest"
+    pullPolicy: IfNotPresent
+
+  replicaCount: 1
+
+  imagePullSecrets: []
+
+  serviceAccount:
+    create: false
+    annotations: {}
+    name: ""
+
+  podAnnotations: {}
+
+  podSecurityContext: {}
+
+  securityContext: {}
+
+  service:
+    enable: true
+    type: ClusterIP
+    port: 50053
+
+  resources:
+    limits:
+      cpu: 100m
+      memory: 128Mi
+    requests:
+      cpu: 100m
+      memory: 128Mi
+
+  readinessProbe: {}
+
+  livenessProbe: {}
+
+  autoscaling:
+    enabled: false
+    minReplicas: 1
+    maxReplicas: 100
+    targetCPUUtilizationPercentage: 80
+
+  podDisruptionBudget:
+    enabled: false
+    minAvailable: 1
+    maxUnavailable: ""
+  nodeSelector: {}
+
+  tolerations: []
+
+  affinity: {}
+
+db_service:
+
+  enabled: true
+  nameOverride: ""
+  fullnameOverride: ""
+  name: db-service
+
+  image:
+    repository: domainproxyfw1/db-service
+    pullPolicy: IfNotPresent
+    tag: "latest"
+
+  imagePullSecrets: []
+
+  serviceAccount:
+    # Specifies whether a service account should be created
+    create: false
+    # Annotations to add to the service account
+    annotations: {}
+    # The name of the service account to use.
+    # If not set and create is true, a name is generated using the fullname template
+    name: ""

--- a/dp/cloud/helm/dp/examples/aws_nginx_values.yaml
+++ b/dp/cloud/helm/dp/examples/aws_nginx_values.yaml
@@ -1,0 +1,259 @@
+---
+nameOverride: ""
+fullnameOverride: ""
+
+configuration_controller:
+
+  nameOverride: ""
+  fullnameOverride: ""
+  enabled: true
+  name: configuration-controller
+  sasEndpointUrl: "https://fake-sas-service/v1.3"
+
+  image:
+    repository: domainproxyfw1/configuration-controller
+    pullPolicy: IfNotPresent
+    tag: "latest"
+
+  replicaCount: 1
+
+  imagePullSecrets: []
+
+  serviceAccount:
+    create: false
+    annotations: {}
+    name: ""
+
+  podAnnotations: {}
+
+  podSecurityContext: {}
+
+  securityContext: {}
+
+  service:
+    enable: true
+    type: ClusterIP
+    port: 8080
+
+  tlsConfig:
+    paths:
+      cert: "certificates/configuration_controller/device_c.cert"
+      key: "certificates/configuration_controller/device_c.key"
+      ca: "certificates/configuration_controller/ca.cert"
+
+  ingress:
+    enabled: false
+    annotations: {}
+    hosts: []
+    tls: []
+
+  resources:
+    limits:
+      cpu: 100m
+      memory: 128Mi
+    requests:
+      cpu: 100m
+      memory: 128Mi
+
+  readinessProbe: {}
+
+  livenessProbe: {}
+
+  autoscaling:
+    enabled: false
+    minReplicas: 1
+    maxReplicas: 100
+    targetCPUUtilizationPercentage: 80
+
+  podDisruptionBudget:
+    enabled: false
+    minAvailable: 1
+    maxUnavailable: ""
+  nodeSelector: {}
+
+  tolerations: []
+
+  affinity: {}
+
+protocol_controller:
+
+  nameOverride: ""
+  fullnameOverride: ""
+  enabled: true
+  name: protocol-controller
+
+  imageConfig:
+    pullPolicy: IfNotPresent
+
+  image:
+    repository: domainproxyfw1/protocol-controller
+    tag: "latest"
+    pullPolicy: IfNotPresent
+
+  replicaCount: 1
+
+  imagePullSecrets: []
+
+  serviceAccount:
+    create: false
+    annotations: {}
+    name: ""
+
+  podAnnotations: {}
+
+  podSecurityContext: {}
+
+  securityContext: {}
+
+  service:
+    enable: true
+    type: ClusterIP
+    port: 8080
+
+  tlsConfig:
+    paths:
+      cert: "certificates/protocol_controller/domain_proxy_bundle.cert"
+      key: "certificates/protocol_controller/domain_proxy_server.key"
+      ca: "certificates/protocol_controller/ca.cert"
+
+  apiPrefix: "/sas/v1"
+
+  ingress:
+    enabled: true
+    annotations:
+      nginx.ingress.kubernetes.io/auth-tls-verify-client: "on"
+      nginx.ingress.kubernetes.io/auth-tls-secret: "default/domain-proxy-pc-ca"
+      nginx.ingress.kubernetes.io/default-backend: "domain-proxy-protocol-controller"
+      kubernetes.io/ingress.class: "nginx"
+
+    hosts:
+      - host: domain-proxy
+        paths:
+          - path: /sas
+            pathType: ImplementationSpecific
+    tls:
+      - secretName: domain-proxy-pc
+        hosts:
+          - domain-proxy
+
+  httpproxy:
+    enabled: false
+    annotations: {}
+    virtualhost: {}
+
+  resources:
+    limits:
+      cpu: 100m
+      memory: 128Mi
+    requests:
+      cpu: 100m
+      memory: 128Mi
+
+  readinessProbe: {}
+
+  livenessProbe: {}
+
+  autoscaling:
+    enabled: false
+    minReplicas: 1
+    maxReplicas: 100
+    targetCPUUtilizationPercentage: 80
+
+  podDisruptionBudget:
+    enabled: false
+    minAvailable: 1
+    maxUnavailable: ""
+  nodeSelector: {}
+
+  tolerations: []
+
+  affinity: {}
+
+radio_controller:
+
+  nameOverride: ""
+  fullnameOverride: ""
+  enabled: true
+  name: radio-controller
+
+  imageConfig:
+    pullPolicy: IfNotPresent
+
+  image:
+    repository: domainproxyfw1/radio-controller
+    tag: "latest"
+    pullPolicy: IfNotPresent
+
+  replicaCount: 1
+
+  imagePullSecrets: []
+
+  serviceAccount:
+    create: false
+    annotations: {}
+    name: ""
+
+  podAnnotations: {}
+
+  podSecurityContext: {}
+
+  securityContext: {}
+
+  service:
+    enable: true
+    type: ClusterIP
+    port: 50053
+
+  resources:
+    limits:
+      cpu: 100m
+      memory: 128Mi
+    requests:
+      cpu: 100m
+      memory: 128Mi
+
+  readinessProbe: {}
+
+  livenessProbe: {}
+
+  autoscaling:
+    enabled: false
+    minReplicas: 1
+    maxReplicas: 100
+    targetCPUUtilizationPercentage: 80
+
+  podDisruptionBudget:
+    enabled: false
+    minAvailable: 1
+    maxUnavailable: ""
+  nodeSelector: {}
+
+  tolerations: []
+
+  affinity: {}
+
+db_service:
+
+  enabled: true
+  nameOverride: ""
+  fullnameOverride: ""
+  name: db-service
+
+  imageConfig:
+    pullPolicy: IfNotPresent
+
+  image:
+    repository: domainproxyfw1/db-service
+    pullPolicy: IfNotPresent
+    tag: "latest"
+
+  imagePullSecrets: []
+
+  serviceAccount:
+    # Specifies whether a service account should be created
+    create: false
+    # Annotations to add to the service account
+    annotations: {}
+    # The name of the service account to use.
+    # If not set and create is true, a name is generated using the fullname template
+    name: ""

--- a/dp/cloud/helm/dp/examples/minikube_values.yaml
+++ b/dp/cloud/helm/dp/examples/minikube_values.yaml
@@ -1,0 +1,246 @@
+---
+nameOverride: ""
+fullnameOverride: ""
+
+configuration_controller:
+
+  nameOverride: ""
+  fullnameOverride: ""
+  enabled: true
+  name: configuration-controller
+  sasEndpointUrl: "https://fake-sas-service/v1.2"
+
+  image:
+    repository: configuration-controller
+    pullPolicy: IfNotPresent
+    tag: ""
+
+  replicaCount: 1
+
+  imagePullSecrets: []
+
+  serviceAccount:
+    create: false
+    annotations: {}
+    name: ""
+
+  podAnnotations: {}
+
+  podSecurityContext: {}
+
+  securityContext: {}
+
+  service:
+    enable: true
+    type: ClusterIP
+    port: 8080
+
+  tlsConfig:
+    paths:
+      cert: "certificates/configuration_controller/device_c.cert"
+      key: "certificates/configuration_controller/device_c.key"
+      ca: "certificates/configuration_controller/ca.cert"
+
+  ingress:
+    enabled: false
+    annotations: {}
+    hosts: []
+    tls: []
+
+  resources:
+    limits:
+      cpu: 100m
+      memory: 128Mi
+    requests:
+      cpu: 100m
+      memory: 128Mi
+
+  readinessProbe: {}
+
+  livenessProbe: {}
+
+  autoscaling:
+    enabled: true
+    minReplicas: 1
+    maxReplicas: 100
+    targetCPUUtilizationPercentage: 80
+    # targetMemoryUtilizationPercentage: 80
+
+  podDisruptionBudget:
+    enabled: false
+    minAvailable: 1
+    maxUnavailable: ""
+
+  nodeSelector: {}
+
+  tolerations: []
+
+  affinity: {}
+
+protocol_controller:
+
+  nameOverride: ""
+  fullnameOverride: ""
+  enabled: true
+  name: protocol-controller
+
+  image:
+    repository: protocol-controller
+    tag: ""
+    pullPolicy: IfNotPresent
+
+  replicaCount: 1
+
+  imagePullSecrets: []
+
+  serviceAccount:
+    create: false
+    annotations: {}
+    name: ""
+
+  podAnnotations: {}
+
+  podSecurityContext: {}
+
+  securityContext: {}
+
+  service:
+    enable: true
+    type: ClusterIP
+    port: 8080
+
+  tlsConfig:
+    paths:
+      cert: "certificates/protocol_controller/domain_proxy_bundle.cert"
+      key: "certificates/protocol_controller/domain_proxy_server.key"
+      ca: "certificates/protocol_controller/ca.cert"
+
+  apiPrefix: "/sas/v1"
+
+  ingress:
+    enabled: false
+    annotations: {}
+    hosts: []
+    tls: []
+
+  httpproxy:
+    enabled: true
+    annotations: {}
+    virtualhost:
+      fqdn: domain-proxy
+      path: "/sas/v1"
+
+  resources:
+    limits:
+      cpu: 100m
+      memory: 128Mi
+    requests:
+      cpu: 100m
+      memory: 128Mi
+
+  readinessProbe: {}
+
+  livenessProbe: {}
+
+  autoscaling:
+    enabled: true
+    minReplicas: 1
+    maxReplicas: 100
+    targetCPUUtilizationPercentage: 80
+    # targetMemoryUtilizationPercentage: 80
+
+  podDisruptionBudget:
+    enabled: false
+    minAvailable: 1
+    maxUnavailable: ""
+
+  nodeSelector: {}
+
+  tolerations: []
+
+  affinity: {}
+
+radio_controller:
+
+  nameOverride: ""
+  fullnameOverride: ""
+  enabled: true
+  name: radio-controller
+
+  image:
+    repository: radio-controller
+    tag: ""
+    pullPolicy: IfNotPresent
+
+  replicaCount: 1
+
+  imagePullSecrets: []
+
+  serviceAccount:
+    create: false
+    annotations: {}
+    name: ""
+
+  podAnnotations: {}
+
+  podSecurityContext: {}
+
+  securityContext: {}
+
+  service:
+    enable: true
+    type: ClusterIP
+    port: 50053
+
+  resources:
+    limits:
+      cpu: 100m
+      memory: 128Mi
+    requests:
+      cpu: 100m
+      memory: 128Mi
+
+  readinessProbe: {}
+
+  livenessProbe: {}
+
+  autoscaling:
+    enabled: true
+    minReplicas: 1
+    maxReplicas: 100
+    targetCPUUtilizationPercentage: 80
+    # targetMemoryUtilizationPercentage: 80
+
+  podDisruptionBudget:
+    enabled: false
+    minAvailable: 1
+    maxUnavailable: ""
+
+  nodeSelector: {}
+
+  tolerations: []
+
+  affinity: {}
+
+db_service:
+
+  enabled: true
+  nameOverride: ""
+  fullnameOverride: ""
+  name: db-service
+
+  image:
+    repository: db-service
+    pullPolicy: IfNotPresent
+    tag: ""
+
+  imagePullSecrets: []
+
+  serviceAccount:
+    # Specifies whether a service account should be created
+    create: false
+    # Annotations to add to the service account
+    annotations: {}
+    # The name of the service account to use.
+    # If not set and create is true, a name is generated using the fullname template
+    name: ""

--- a/dp/cloud/helm/dp/examples/minikube_values_nginx.yaml
+++ b/dp/cloud/helm/dp/examples/minikube_values_nginx.yaml
@@ -1,0 +1,248 @@
+---
+nameOverride: ""
+fullnameOverride: ""
+
+configuration_controller:
+
+  nameOverride: ""
+  fullnameOverride: ""
+  enabled: true
+  name: configuration-controller
+  sasEndpointUrl: "https://fake-sas-service/v1.2"
+
+  image:
+    repository: configuration-controller
+    pullPolicy: IfNotPresent
+    tag: ""
+
+  replicaCount: 1
+
+  imagePullSecrets: []
+
+  serviceAccount:
+    create: false
+    annotations: {}
+    name: ""
+
+  podAnnotations: {}
+
+  podSecurityContext: {}
+
+  securityContext: {}
+
+  service:
+    enable: true
+    type: ClusterIP
+    port: 8080
+
+  tlsConfig:
+    paths:
+      cert: "certificates/configuration_controller/device_c.cert"
+      key: "certificates/configuration_controller/device_c.key"
+      ca: "certificates/configuration_controller/ca.cert"
+
+  ingress:
+    enabled: false
+    annotations: {}
+    hosts: []
+    tls: []
+
+  resources:
+    limits:
+      cpu: 100m
+      memory: 128Mi
+    requests:
+      cpu: 100m
+      memory: 128Mi
+
+  readinessProbe: {}
+
+  livenessProbe: {}
+
+  autoscaling:
+    enabled: true
+    minReplicas: 1
+    maxReplicas: 100
+    targetCPUUtilizationPercentage: 80
+    # targetMemoryUtilizationPercentage: 80
+
+  podDisruptionBudget:
+    enabled: false
+    minAvailable: 1
+    maxUnavailable: ""
+
+  nodeSelector: {}
+
+  tolerations: []
+
+  affinity: {}
+
+protocol_controller:
+
+  nameOverride: ""
+  fullnameOverride: ""
+  enabled: true
+  name: protocol-controller
+
+  image:
+    repository: protocol-controller
+    tag: ""
+    pullPolicy: IfNotPresent
+
+  replicaCount: 1
+
+  imagePullSecrets: []
+
+  serviceAccount:
+    create: false
+    annotations: {}
+    name: ""
+
+  podAnnotations: {}
+
+  podSecurityContext: {}
+
+  securityContext: {}
+
+  service:
+    enable: true
+    type: ClusterIP
+    port: 8080
+
+  tlsConfig:
+    paths:
+      cert: "certificates/protocol_controller/domain_proxy_bundle.cert"
+      key: "certificates/protocol_controller/domain_proxy_server.key"
+      ca: "certificates/protocol_controller/ca.cert"
+
+  apiPrefix: "/sas/v1"
+
+  ingress:
+    enabled: true
+    annotations:
+      nginx.ingress.kubernetes.io/auth-tls-verify-client: "on"
+      nginx.ingress.kubernetes.io/default-backend: "domain-proxy-protocol-controller"
+      kubernetes.io/ingress.class: "nginx"
+    hosts:
+      - host: domain-proxy
+        paths:
+          - path: /sas/v1
+            pathType: ImplementationSpecific
+
+  httpproxy:
+    enabled: false
+    annotations: {}
+    virtualhost: {}
+
+  resources:
+    limits:
+      cpu: 100m
+      memory: 128Mi
+    requests:
+      cpu: 100m
+      memory: 128Mi
+
+  readinessProbe: {}
+
+  livenessProbe: {}
+
+  autoscaling:
+    enabled: true
+    minReplicas: 1
+    maxReplicas: 100
+    targetCPUUtilizationPercentage: 80
+    # targetMemoryUtilizationPercentage: 80
+
+  podDisruptionBudget:
+    enabled: false
+    minAvailable: 1
+    maxUnavailable: ""
+  nodeSelector: {}
+
+  tolerations: []
+
+  affinity: {}
+
+radio_controller:
+
+  nameOverride: ""
+  fullnameOverride: ""
+  enabled: true
+  name: radio-controller
+
+  image:
+    repository: radio-controller
+    tag: ""
+    pullPolicy: IfNotPresent
+
+  replicaCount: 1
+
+  imagePullSecrets: []
+
+  serviceAccount:
+    create: false
+    annotations: {}
+    name: ""
+
+  podAnnotations: {}
+
+  podSecurityContext: {}
+
+  securityContext: {}
+
+  service:
+    enable: true
+    type: ClusterIP
+    port: 50053
+
+  resources:
+    limits:
+      cpu: 100m
+      memory: 128Mi
+    requests:
+      cpu: 100m
+      memory: 128Mi
+
+  readinessProbe: {}
+
+  livenessProbe: {}
+
+  autoscaling:
+    enabled: true
+    minReplicas: 1
+    maxReplicas: 100
+    targetCPUUtilizationPercentage: 80
+    # targetMemoryUtilizationPercentage: 80
+
+  podDisruptionBudget:
+    enabled: false
+    minAvailable: 1
+    maxUnavailable: ""
+  nodeSelector: {}
+
+  tolerations: []
+
+  affinity: {}
+
+db_service:
+
+  enabled: true
+  nameOverride: ""
+  fullnameOverride: ""
+  name: db-service
+
+  image:
+    repository: db-service
+    pullPolicy: IfNotPresent
+    tag: ""
+
+  imagePullSecrets: []
+
+  serviceAccount:
+    # Specifies whether a service account should be created
+    create: false
+    # Annotations to add to the service account
+    annotations: {}
+    # The name of the service account to use.
+    # If not set and create is true, a name is generated using the fullname template
+    name: ""

--- a/dp/cloud/helm/dp/templates/NOTES.txt
+++ b/dp/cloud/helm/dp/templates/NOTES.txt
@@ -1,0 +1,9 @@
+Thank you for installing {{ .Chart.Name }}.
+
+Your release is named {{ .Release.Name }}.
+
+To learn more about the release, try:
+
+  $ helm status {{ .Release.Name }}
+  $ helm get all {{ .Release.Name }}
+

--- a/dp/cloud/helm/dp/templates/_helpers.tpl
+++ b/dp/cloud/helm/dp/templates/_helpers.tpl
@@ -1,0 +1,256 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "domain-proxy.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "domain-proxy.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Match labels
+*/}}
+{{- define "domain-proxy.common.matchLabels" -}}
+app.kubernetes.io/name: {{ include "domain-proxy.name" . }}
+app.kubernetes.io/release: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Meta labels
+*/}}
+{{- define "domain-proxy.common.metaLabels" -}}
+helm.sh/chart: {{ include "domain-proxy.chart" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Configuration controller match labels
+*/}}
+{{- define "domain-proxy.configuration_controller.matchLabels" -}}
+component: {{ .Values.configuration_controller.name | quote }}
+{{ include "domain-proxy.common.matchLabels" . }}
+{{- end -}}
+
+{{/*
+Configuration controller labels
+*/}}
+{{- define "domain-proxy.configuration_controller.labels" -}}
+{{ include "domain-proxy.configuration_controller.matchLabels" . }}
+{{ include "domain-proxy.common.metaLabels" . }}
+{{- end -}}
+
+{{/*
+Protocol controller match labels
+*/}}
+{{- define "domain-proxy.protocol_controller.matchLabels" -}}
+component: {{ .Values.protocol_controller.name | quote }}
+{{ include "domain-proxy.common.matchLabels" . }}
+{{- end -}}
+
+{{/*
+Protocol controller labels
+*/}}
+{{- define "domain-proxy.protocol_controller.labels" -}}
+{{ include "domain-proxy.protocol_controller.matchLabels" . }}
+{{ include "domain-proxy.common.metaLabels" . }}
+{{- end -}}
+
+{{/*
+Radio controller match labels
+*/}}
+{{- define "domain-proxy.radio_controller.matchLabels" -}}
+component: {{ .Values.radio_controller.name | quote }}
+{{ include "domain-proxy.common.matchLabels" . }}
+{{- end -}}
+
+{{/*
+Radio controller labels
+*/}}
+{{- define "domain-proxy.radio_controller.labels" -}}
+{{ include "domain-proxy.radio_controller.matchLabels" . }}
+{{ include "domain-proxy.common.metaLabels" . }}
+{{- end -}}
+
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "domain-proxy.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+
+{{/*
+Create a fully qualified configuration_controller name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+
+{{- define "domain-proxy.configuration_controller.fullname" -}}
+{{- if .Values.configuration_controller.fullnameOverride -}}
+{{- .Values.configuration_controller.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- printf "%s-%s" .Release.Name .Values.configuration_controller.name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s-%s" .Release.Name $name .Values.configuration_controller.name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create a fully qualified protocol_controller name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+
+{{- define "domain-proxy.protocol_controller.fullname" -}}
+{{- if .Values.protocol_controller.fullnameOverride -}}
+{{- .Values.protocol_controller.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- printf "%s-%s" .Release.Name .Values.protocol_controller.name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s-%s" .Release.Name $name .Values.protocol_controller.name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create a fully qualified radio_controller name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+
+{{- define "domain-proxy.radio_controller.fullname" -}}
+{{- if .Values.radio_controller.fullnameOverride -}}
+{{- .Values.radio_controller.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- printf "%s-%s" .Release.Name .Values.radio_controller.name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s-%s" .Release.Name $name .Values.radio_controller.name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create a fully qualified db_service name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+
+{{- define "domain-proxy.db_service.fullname" -}}
+{{- if .Values.db_service.fullnameOverride -}}
+{{- .Values.db_service.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- printf "%s-%s" .Release.Name .Values.db_service.name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s-%s" .Release.Name $name .Values.db_service.name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return the appropriate apiVersion for deployment.
+*/}}
+{{- define "domain-proxy.deployment.apiVersion" -}}
+{{- print "apps/v1" -}}
+{{- end -}}
+
+{{/*
+Return the appropriate apiVersion for ingress.
+*/}}
+{{- define "domain-proxy.ingress.apiVersion" -}}
+{{- print "networking.k8s.io/v1beta1" -}}
+{{- end -}}
+
+{{/*
+Return the appropriate apiVersion for job.
+*/}}
+{{- define "domain-proxy.job.apiVersion" -}}
+{{- print "batch/v1" -}}
+{{- end -}}
+
+{{/*
+Return the appropriate apiVersion for ingress.
+*/}}
+{{- define "ingress.apiVersion" -}}
+{{- print "networking.k8s.io/v1" -}}
+{{- end -}}
+
+{{/*
+Return the appropriate apiVersion for HTTPProxy.
+*/}}
+{{- define "httpproxy.apiVersion" -}}
+{{- print "projectcontour.io/v1" -}}
+{{- end -}}
+
+{{/*
+Create the name of the service account to use for configuration controller
+*/}}
+{{- define "domain-proxy.configuration_controller.serviceAccountName" -}}
+{{- if .Values.configuration_controller.serviceAccount.create }}
+{{- default (include "domain-proxy.fullname" .) .Values.configuration_controller.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.configuration_controller.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use for protocol controller
+*/}}
+{{- define "domain-proxy.protocol_controller.serviceAccountName" -}}
+{{- if .Values.protocol_controller.serviceAccount.create }}
+{{- default (include "domain-proxy.fullname" .) .Values.protocol_controller.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.protocol_controller.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use for radio controller
+*/}}
+{{- define "domain-proxy.radio_controller.serviceAccountName" -}}
+{{- if .Values.radio_controller.serviceAccount.create }}
+{{- default (include "domain-proxy.fullname" .) .Values.radio_controller.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.radio_controller.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use for db service
+*/}}
+{{- define "domain-proxy.db_service.serviceAccountName" -}}
+{{- if .Values.db_service.serviceAccount.create }}
+{{- default (include "domain-proxy.fullname" .) .Values.db_service.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.db_service.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{/*
+Define the domain-proxy.namespace template
+*/}}
+{{- define "domain-proxy.namespace" -}}
+{{ printf "namespace: %s" .Release.Namespace }}
+{{- end -}}

--- a/dp/cloud/helm/dp/templates/configuration_controller/ca.yaml
+++ b/dp/cloud/helm/dp/templates/configuration_controller/ca.yaml
@@ -1,0 +1,12 @@
+{{- $fullName := include "domain-proxy.fullname" . -}}
+{{- if (empty (lookup "v1" "Secret" .Release.Namespace "${fullName}-cc-ca")) -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ $fullName }}-cc-ca
+type: Opaque
+data:
+{{- $pathca := printf "%s" .Values.configuration_controller.tlsConfig.paths.ca }}
+  ca.crt: |
+{{ (.Files.Get $pathca) | b64enc | indent 4 }}
+{{- end -}}

--- a/dp/cloud/helm/dp/templates/configuration_controller/cm.yaml
+++ b/dp/cloud/helm/dp/templates/configuration_controller/cm.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.configuration_controller.enabled -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    {{-  include "domain-proxy.configuration_controller.labels" . | nindent 4 }}
+  name: {{ include "domain-proxy.configuration_controller.fullname" . }}
+{{ include "domain-proxy.namespace" . | indent 2 }}
+data:
+{{- if .Values.configuration_controller.sasEndpointUrl }}
+  SAS_URL: {{ .Values.configuration_controller.sasEndpointUrl }}
+{{- end }}
+{{- end }}

--- a/dp/cloud/helm/dp/templates/configuration_controller/deployment.yaml
+++ b/dp/cloud/helm/dp/templates/configuration_controller/deployment.yaml
@@ -1,0 +1,76 @@
+{{- if .Values.configuration_controller.enabled -}}
+apiVersion: {{ template "domain-proxy.deployment.apiVersion" . }}
+kind: Deployment
+metadata:
+  name: {{ include "domain-proxy.configuration_controller.fullname" . }}
+  labels:
+    {{- include "domain-proxy.configuration_controller.labels" . | nindent 4 }}
+spec:
+  {{- if not .Values.configuration_controller.autoscaling.enabled }}
+  replicas: {{ .Values.configuration_controller.replicaCount }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "domain-proxy.configuration_controller.matchLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.configuration_controller.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "domain-proxy.configuration_controller.labels" . | nindent 8 }}
+    spec:
+      {{- with .Values.configuration_controller.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "domain-proxy.configuration_controller.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.configuration_controller.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ .Values.configuration_controller.name }}
+          image: >-
+            {{ .Values.configuration_controller.image.repository -}}:
+            {{- .Values.configuration_controller.image.tag | 
+            default .Chart.AppVersion  }}
+          imagePullPolicy: {{ .Values.configuration_controller.image.pullPolicy }}
+          {{- if .Values.configuration_controller.livenessProbe }}
+          livenessProbe:
+            {{- toYaml .Values.configuration_controller.livenessProbe | nindent 12 }}
+          {{- end }}
+          {{- if .Values.configuration_controller.readinessProbe }}
+          readinessProbe:
+            {{- toYaml .Values.configuration_controller.readinessProbe | nindent 12 }}
+          {{- end }}
+          resources:
+            {{- toYaml .Values.configuration_controller.resources | nindent 12 }}
+          volumeMounts:
+            - name: tls
+              mountPath: /backend/configuration_controller/certs
+              readOnly: true
+          envFrom:
+          - configMapRef:
+              name: {{ include "domain-proxy.configuration_controller.fullname" . }}
+      volumes:
+        - name: tls
+          projected:
+            sources:
+            - secret:
+                name: {{ include "domain-proxy.fullname" . -}}-cc
+            - secret:
+                name: {{ include "domain-proxy.fullname" . -}}-cc-ca
+
+      {{- with .Values.configuration_controller.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.configuration_controller.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.configuration_controller.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/dp/cloud/helm/dp/templates/configuration_controller/hpa.yaml
+++ b/dp/cloud/helm/dp/templates/configuration_controller/hpa.yaml
@@ -1,0 +1,28 @@
+{{- if and .Values.configuration_controller.autoscaling.enabled  .Values.configuration_controller.enabled }}
+apiVersion: autoscaling/v2beta1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "domain-proxy.configuration_controller.fullname" . }}
+  labels:
+    {{- include "domain-proxy.configuration_controller.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "domain-proxy.configuration_controller.fullname" . }}
+  minReplicas: {{ .Values.configuration_controller.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.configuration_controller.autoscaling.maxReplicas }}
+  metrics:
+    {{- if .Values.configuration_controller.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        targetAverageUtilization: {{ .Values.configuration_controller.autoscaling.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if .Values.configuration_controller.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        targetAverageUtilization: {{ .Values.configuration_controller.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+{{- end }}

--- a/dp/cloud/helm/dp/templates/configuration_controller/ingress.yaml
+++ b/dp/cloud/helm/dp/templates/configuration_controller/ingress.yaml
@@ -1,0 +1,41 @@
+{{- if .Values.configuration_controller.ingress.enabled -}}
+{{- $fullName := include "domain-proxy.configuration_controller.fullname" . -}}
+{{- $svcPort := .Values.configuration_controller.service.port -}}
+{{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: apiVersion: {{ template "domain-proxy.ingress.apiVersion" . }}
+{{- else -}}
+apiVersion: extensions/v1beta1
+{{- end }}
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+    {{- include "domain-proxy.configuration_controller.labels" . | nindent 4 }}
+  {{- with .Values.configuration_controller.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.configuration_controller.ingress.tls }}
+  tls:
+    {{- range .Values.configuration_controller.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.configuration_controller.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            backend:
+              serviceName: {{ $fullName }}
+              servicePort: {{ $svcPort }}
+          {{- end }}
+    {{- end }}
+  {{- end }}

--- a/dp/cloud/helm/dp/templates/configuration_controller/pdb.yaml
+++ b/dp/cloud/helm/dp/templates/configuration_controller/pdb.yaml
@@ -1,0 +1,18 @@
+{{- if and .Values.configuration_controller.enabled .Values.configuration_controller.podDisruptionBudget.enabled -}}
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "domain-proxy.configuration_controller.fullname" . }}
+  labels:
+    {{- include "domain-proxy.configuration_controller.labels" . | nindent 4 }}
+spec:
+  {{- with .Values.configuration_controller.podDisruptionBudget.minAvailable }}
+  minAvailable: {{ . }}
+  {{- end }}
+  {{- with .Values.configuration_controller.podDisruptionBudget.maxUnavailable }}
+  maxUnavailable: {{ . }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "domain-proxy.configuration_controller.matchLabels" . | nindent 6 }}
+{{- end }}

--- a/dp/cloud/helm/dp/templates/configuration_controller/service.yaml
+++ b/dp/cloud/helm/dp/templates/configuration_controller/service.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.configuration_controller.service.enable -}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "domain-proxy.configuration_controller.fullname" . }}
+  labels:
+    {{- include "domain-proxy.configuration_controller.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.configuration_controller.service.type }}
+  ports:
+    - port: {{ .Values.configuration_controller.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "domain-proxy.configuration_controller.matchLabels" . | nindent 4 }}
+{{- end }}

--- a/dp/cloud/helm/dp/templates/configuration_controller/serviceaccount.yaml
+++ b/dp/cloud/helm/dp/templates/configuration_controller/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.configuration_controller.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "domain-proxy.serviceAccountName.configuration_controller" . }}
+  labels:
+    {{- include "domain-proxy.configuration_controller.labels" . | nindent 4 }}
+  {{- with .Values.configuration_controller.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/dp/cloud/helm/dp/templates/configuration_controller/tls.yaml
+++ b/dp/cloud/helm/dp/templates/configuration_controller/tls.yaml
@@ -1,0 +1,15 @@
+{{- $fullName := include "domain-proxy.fullname" . -}}
+{{- if (empty (lookup "v1" "Secret" .Release.Namespace "${fullName}-cc")) -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ $fullName }}-cc
+type: kubernetes.io/tls
+data:
+{{- $pathcrt := printf "%s" .Values.configuration_controller.tlsConfig.paths.cert }}
+{{- $pathkey := printf "%s" .Values.configuration_controller.tlsConfig.paths.key }}
+  tls.crt: |
+{{ (.Files.Get $pathcrt) | b64enc | indent 4 }}
+  tls.key: |
+{{ (.Files.Get $pathkey) | b64enc | indent 4 }}
+{{- end -}}

--- a/dp/cloud/helm/dp/templates/db_service/job.yaml
+++ b/dp/cloud/helm/dp/templates/db_service/job.yaml
@@ -1,0 +1,31 @@
+{{- if .Values.db_service.enabled -}}
+apiVersion: {{ template "domain-proxy.job.apiVersion" . }}
+kind: Job
+metadata:
+  name: {{ include "domain-proxy.db_service.fullname" . }}
+spec:
+  ttlSecondsAfterFinished: 100
+  template:
+    spec:
+      {{- with .Values.db_service.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "domain-proxy.db_service.serviceAccountName" . }}
+      containers:
+      - name: {{ .Values.db_service.name }}
+        image: >-
+          {{ .Values.db_service.image.repository -}}:
+          {{- .Values.db_service.image.tag |
+          default .Chart.AppVersion }}
+      restartPolicy: Never
+      initContainers:
+      - name: {{ .Values.db_service.name }}-init
+        image: >-
+          {{ .Values.db_service.image.repository -}}:
+          {{- .Values.db_service.image.tag |
+          default .Chart.AppVersion }}
+        command: ["alembic"]
+        args: ["upgrade","head"]
+  backoffLimit: 4
+{{- end }}

--- a/dp/cloud/helm/dp/templates/db_service/serviceaccount.yaml
+++ b/dp/cloud/helm/dp/templates/db_service/serviceaccount.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.db_service.enabled -}}
+{{- if .Values.db_service.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "domain-proxy.serviceAccountName.db_service" . }}
+  labels:
+    {{- include "domain-proxy.db_service.labels" . | nindent 4 }}
+  {{- with .Values.db_service.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}
+{{- end }}

--- a/dp/cloud/helm/dp/templates/protocol_controller/ca.yaml
+++ b/dp/cloud/helm/dp/templates/protocol_controller/ca.yaml
@@ -1,0 +1,14 @@
+{{- $fullName := include "domain-proxy.fullname" . -}}
+{{- if .Values.protocol_controller.tlsConfig.paths.ca -}}
+{{- if (empty (lookup "v1" "Secret" .Release.Namespace "${fullName}-pc-ca")) -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ $fullName }}-pc-ca
+type: Opaque
+data:
+{{- $pathca := printf "%s" .Values.protocol_controller.tlsConfig.paths.ca }}
+  ca.crt: |
+{{ (.Files.Get $pathca) | b64enc | indent 4 }}
+{{- end }}
+{{- end -}}

--- a/dp/cloud/helm/dp/templates/protocol_controller/cm.yaml
+++ b/dp/cloud/helm/dp/templates/protocol_controller/cm.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.protocol_controller.enabled -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    {{-  include "domain-proxy.protocol_controller.labels" . | nindent 4 }}
+  name: {{ include "domain-proxy.protocol_controller.fullname" . }}
+{{ include "domain-proxy.namespace" . | indent 2 }}
+data:
+{{- if .Values.protocol_controller.apiPrefix }}
+  API_PREFIX: {{ .Values.protocol_controller.apiPrefix }}
+{{- end }}
+  GRPC_SERVICE: {{ include "domain-proxy.radio_controller.fullname" . }}
+{{- end }}

--- a/dp/cloud/helm/dp/templates/protocol_controller/deployment.yaml
+++ b/dp/cloud/helm/dp/templates/protocol_controller/deployment.yaml
@@ -1,0 +1,65 @@
+{{- if .Values.protocol_controller.enabled -}}
+apiVersion: {{ template "domain-proxy.deployment.apiVersion" . }}
+kind: Deployment
+metadata:
+  name: {{ include "domain-proxy.protocol_controller.fullname" . }}
+  labels:
+    {{- include "domain-proxy.protocol_controller.labels" . | nindent 4 }}
+spec:
+  {{- if not .Values.protocol_controller.autoscaling.enabled }}
+  replicas: {{ .Values.protocol_controller.replicaCount }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "domain-proxy.protocol_controller.matchLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.protocol_controller.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "domain-proxy.protocol_controller.labels" . | nindent 8 }}
+    spec:
+      {{- with .Values.protocol_controller.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "domain-proxy.protocol_controller.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.protocol_controller.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ .Values.protocol_controller.name }}
+          securityContext:
+            {{- toYaml .Values.protocol_controller.securityContext | nindent 12 }}
+          image: >-
+            {{ .Values.protocol_controller.image.repository -}}:
+            {{- .Values.protocol_controller.image.tag | 
+            default .Chart.AppVersion }}
+          imagePullPolicy: {{ .Values.protocol_controller.image.pullPolicy }}
+          {{- if .Values.protocol_controller.livenessProbe }}
+          livenessProbe:
+            {{- toYaml .Values.protocol_controller.livenessProbe | nindent 12 }}
+          {{- end }}
+          {{- if .Values.protocol_controller.readinessProbe }}
+          readinessProbe:
+            {{- toYaml .Values.protocol_controller.readinessProbe | nindent 12 }}
+          {{- end }}
+          resources:
+            {{- toYaml .Values.protocol_controller.resources | nindent 12 }}
+          envFrom:
+          - configMapRef:
+              name: {{ include "domain-proxy.protocol_controller.fullname" . }}
+      {{- with .Values.protocol_controller.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.protocol_controller.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.protocol_controller.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/dp/cloud/helm/dp/templates/protocol_controller/hpa.yaml
+++ b/dp/cloud/helm/dp/templates/protocol_controller/hpa.yaml
@@ -1,0 +1,28 @@
+{{- if and .Values.protocol_controller.autoscaling.enabled .Values.protocol_controller.enabled }}
+apiVersion: autoscaling/v2beta1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "domain-proxy.protocol_controller.fullname" . }}
+  labels:
+    {{- include "domain-proxy.protocol_controller.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "domain-proxy.protocol_controller.fullname" . }}
+  minReplicas: {{ .Values.protocol_controller.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.protocol_controller.autoscaling.maxReplicas }}
+  metrics:
+    {{- if .Values.protocol_controller.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        targetAverageUtilization: {{ .Values.protocol_controller.autoscaling.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if .Values.protocol_controller.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        targetAverageUtilization: {{ .Values.protocol_controller.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+{{- end }}

--- a/dp/cloud/helm/dp/templates/protocol_controller/httpproxy.yaml
+++ b/dp/cloud/helm/dp/templates/protocol_controller/httpproxy.yaml
@@ -1,0 +1,33 @@
+{{- if .Values.protocol_controller.httpproxy.enabled -}}
+{{- $fullName := include "domain-proxy.protocol_controller.fullname" . -}}
+{{- $svcPort := .Values.protocol_controller.service.port -}}
+{{- $caSecret := printf "%s/%s-pc-ca" .Release.Namespace (include "domain-proxy.fullname" .) -}}
+{{- $tlsSecret := printf "%s-pc" (include "domain-proxy.fullname" .) -}}
+apiVersion: {{ template "httpproxy.apiVersion" . }}
+kind: HTTPProxy
+metadata:
+  name: {{ $fullName }}
+  labels:
+    {{- include "domain-proxy.protocol_controller.labels" . | nindent 4 }}
+  {{- with .Values.protocol_controller.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  virtualhost:
+    fqdn: {{ .Values.protocol_controller.httpproxy.virtualhost.fqdn | quote }}
+    tls:
+      secretName: {{ default $tlsSecret .Values.protocol_controller.httpproxy.virtualhost.tls.secretName }}
+      clientValidation:
+      {{- if .Values.protocol_controller.tlsConfig.paths.ca }}
+        caSecret: {{ $caSecret }}
+      {{ else }}
+        caSecret: {{ .Values.protocol_controller.httpproxy.virtualhost.tls.caSecret }}
+      {{- end }}
+  routes:
+    - conditions:
+        - prefix: {{ .Values.protocol_controller.httpproxy.virtualhost.path }}
+      services:
+        - name: {{ $fullName }}
+          port: {{ $svcPort }}
+{{- end }}

--- a/dp/cloud/helm/dp/templates/protocol_controller/ingress.yaml
+++ b/dp/cloud/helm/dp/templates/protocol_controller/ingress.yaml
@@ -1,0 +1,56 @@
+{{- if .Values.protocol_controller.ingress.enabled -}}
+{{- $fullName := include "domain-proxy.protocol_controller.fullname" . -}}
+{{- $svcPort := .Values.protocol_controller.service.port -}}
+{{- $caSecret := printf "%s/%s-pc-ca" .Release.Namespace (include "domain-proxy.fullname" .) -}}
+{{- $tlsSecret := printf "%s-pc" (include "domain-proxy.fullname" .) -}}
+{{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: {{ template "domain-proxy.ingress.apiVersion" . }}
+{{- else -}}
+apiVersion: extensions/v1beta1
+{{- end }}
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+    {{- include "domain-proxy.configuration_controller.labels" . | nindent 4 }}
+  annotations:
+  {{- if .Values.protocol_controller.tlsConfig.paths.ca }} 
+    nginx.ingress.kubernetes.io/auth-tls-secret: {{ $caSecret }}
+  {{- end }}
+  {{- with .Values.protocol_controller.ingress.annotations }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.protocol_controller.ingress.tls }}
+  tls:
+    {{- range .Values.protocol_controller.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ default $tlsSecret .secretName }}
+    {{- end }}
+  {{ else }}
+  tls:
+    - hosts:
+    {{- range .Values.protocol_controller.ingress.hosts }}
+        - {{ .host | quote }}
+    {{- end }}
+      secretName: {{ default $tlsSecret .secretName }}
+  {{- end }}
+  rules:
+    {{- range .Values.protocol_controller.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            {{- if and .pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
+            pathType: {{ .pathType }}
+            {{- end }}
+            backend:
+              serviceName: {{ $fullName }}
+              servicePort: {{ $svcPort }}
+          {{- end }}
+    {{- end }}
+  {{- end }}

--- a/dp/cloud/helm/dp/templates/protocol_controller/pdb.yaml
+++ b/dp/cloud/helm/dp/templates/protocol_controller/pdb.yaml
@@ -1,0 +1,18 @@
+{{- if and .Values.protocol_controller.enabled .Values.protocol_controller.podDisruptionBudget.enabled -}}
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "domain-proxy.protocol_controller.fullname" . }}
+  labels:
+    {{- include "domain-proxy.protocol_controller.labels" . | nindent 4 }}
+spec:
+  {{- with .Values.protocol_controller.podDisruptionBudget.minAvailable }}
+  minAvailable: {{ . }}
+  {{- end }}
+  {{- with .Values.protocol_controller.podDisruptionBudget.maxUnavailable }}
+  maxUnavailable: {{ . }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "domain-proxy.protocol_controller.matchLabels" . | nindent 6 }}
+{{- end }}

--- a/dp/cloud/helm/dp/templates/protocol_controller/service.yaml
+++ b/dp/cloud/helm/dp/templates/protocol_controller/service.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.protocol_controller.service.enable -}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "domain-proxy.protocol_controller.fullname" . }}
+  labels:
+    {{- include "domain-proxy.protocol_controller.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.protocol_controller.service.type }}
+  ports:
+    - port: {{ .Values.protocol_controller.service.port }}
+      targetPort: 8080
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "domain-proxy.protocol_controller.matchLabels" . | nindent 4 }}
+{{- end }}

--- a/dp/cloud/helm/dp/templates/protocol_controller/serviceaccount.yaml
+++ b/dp/cloud/helm/dp/templates/protocol_controller/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.protocol_controller.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "domain-proxy.serviceAccountName.protocol_controller" . }}
+  labels:
+    {{- include "domain-proxy.protocol_controller.labels" . | nindent 4 }}
+  {{- with .Values.protocol_controller.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/dp/cloud/helm/dp/templates/protocol_controller/tls.yaml
+++ b/dp/cloud/helm/dp/templates/protocol_controller/tls.yaml
@@ -1,0 +1,19 @@
+{{- $fullName := include "domain-proxy.fullname" . -}}
+{{- if .Values.protocol_controller.tlsConfig.paths.key -}}
+{{- if .Values.protocol_controller.tlsConfig.paths.cert -}}
+{{- if (empty (lookup "v1" "Secret" .Release.Namespace "${fullName}-pc")) -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ $fullName }}-pc
+type: kubernetes.io/tls
+data:
+{{- $pathcrt := printf "%s" .Values.protocol_controller.tlsConfig.paths.cert }}
+{{- $pathkey := printf "%s" .Values.protocol_controller.tlsConfig.paths.key }}
+  tls.crt: |
+{{ (.Files.Get $pathcrt) | b64enc | indent 4 }}
+  tls.key: |
+{{ (.Files.Get $pathkey) | b64enc | indent 4 }}
+{{- end }}
+{{- end }}
+{{- end -}}

--- a/dp/cloud/helm/dp/templates/radio_controller/deployment.yaml
+++ b/dp/cloud/helm/dp/templates/radio_controller/deployment.yaml
@@ -1,0 +1,75 @@
+{{/*
+# Copyright 2020 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+*/}}
+
+{{- if .Values.radio_controller.enabled -}}
+apiVersion: {{ template "domain-proxy.deployment.apiVersion" . }}
+kind: Deployment
+metadata:
+  name: {{ include "domain-proxy.radio_controller.fullname" . }}
+  labels:
+    {{- include "domain-proxy.radio_controller.labels" . | nindent 4 }}
+spec:
+  {{- if not .Values.radio_controller.autoscaling.enabled }}
+  replicas: {{ .Values.radio_controller.replicaCount }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "domain-proxy.radio_controller.matchLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.radio_controller.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "domain-proxy.radio_controller.labels" . | nindent 8 }}
+    spec:
+      {{- with .Values.radio_controller.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "domain-proxy.radio_controller.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.radio_controller.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ .Values.radio_controller.name }}
+          securityContext:
+            {{- toYaml .Values.radio_controller.securityContext | nindent 12 }}
+          image: >-
+            {{ .Values.radio_controller.image.repository -}}:
+            {{- .Values.radio_controller.image.tag | 
+            default .Chart.AppVersion }}
+          imagePullPolicy: {{ .Values.radio_controller.image.pullPolicy }}
+          {{- if .Values.radio_controller.livenessProbe }}
+          livenessProbe:
+            {{- toYaml .Values.radio_controller.livenessProbe | nindent 12 }}
+          {{- end }}
+          {{- if .Values.radio_controller.readinessProbe }}
+          readinessProbe:
+            {{- toYaml .Values.radio_controller.readinessProbe | nindent 12 }}
+          {{- end }}
+          resources:
+            {{- toYaml .Values.radio_controller.resources | nindent 12 }}
+      {{- with .Values.radio_controller.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.radio_controller.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.radio_controller.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/dp/cloud/helm/dp/templates/radio_controller/hpa.yaml
+++ b/dp/cloud/helm/dp/templates/radio_controller/hpa.yaml
@@ -1,0 +1,43 @@
+{{/*
+# Copyright 2020 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+*/}}
+
+{{- if .Values.radio_controller.enabled -}}
+{{- if .Values.radio_controller.autoscaling.enabled }}
+apiVersion: autoscaling/v2beta1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "domain-proxy.radio_controller.fullname" . }}
+  labels:
+    {{- include "domain-proxy.radio_controller.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "domain-proxy.radio_controller.fullname" . }}
+  minReplicas: {{ .Values.radio_controller.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.radio_controller.autoscaling.maxReplicas }}
+  metrics:
+    {{- if .Values.radio_controller.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        targetAverageUtilization: {{ .Values.radio_controller.autoscaling.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if .Values.radio_controller.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        targetAverageUtilization: {{ .Values.radio_controller.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+{{- end }}
+{{- end }}

--- a/dp/cloud/helm/dp/templates/radio_controller/pdb.yaml
+++ b/dp/cloud/helm/dp/templates/radio_controller/pdb.yaml
@@ -1,0 +1,18 @@
+{{- if and .Values.radio_controller.enabled .Values.radio_controller.podDisruptionBudget.enabled -}}
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "domain-proxy.radio_controller.fullname" . }}
+  labels:
+    {{- include "domain-proxy.radio_controller.labels" . | nindent 4 }}
+spec:
+  {{- with .Values.radio_controller.podDisruptionBudget.minAvailable }}
+  minAvailable: {{ . }}
+  {{- end }}
+  {{- with .Values.radio_controller.podDisruptionBudget.maxUnavailable }}
+  maxUnavailable: {{ . }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "domain-proxy.radio_controller.matchLabels" . | nindent 6 }}
+{{- end }}

--- a/dp/cloud/helm/dp/templates/radio_controller/service.yaml
+++ b/dp/cloud/helm/dp/templates/radio_controller/service.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.radio_controller.enabled -}}
+{{- if .Values.radio_controller.service.enable -}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "domain-proxy.radio_controller.fullname" . }}
+  labels:
+    {{- include "domain-proxy.radio_controller.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.radio_controller.service.type }}
+  ports:
+    - port: {{ .Values.radio_controller.service.port }}
+      targetPort: 50053
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "domain-proxy.radio_controller.matchLabels" . | nindent 4 }}
+{{- end }}
+{{- end }}

--- a/dp/cloud/helm/dp/templates/radio_controller/serviceaccount.yaml
+++ b/dp/cloud/helm/dp/templates/radio_controller/serviceaccount.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.radio_controller.enabled -}}
+{{- if .Values.radio_controller.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "domain-proxy.serviceAccountName.radio_controller" . }}
+  labels:
+    {{- include "domain-proxy.radio_controller.labels" . | nindent 4 }}
+  {{- with .Values.radio_controller.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}
+{{- end }}

--- a/dp/cloud/helm/dp/templates/tests/protocol_controller-test.yaml
+++ b/dp/cloud/helm/dp/templates/tests/protocol_controller-test.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.protocol_controller.enabled }}
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ .Release.Name }}-pc-test"
+  annotations:
+    "helm.sh/hook": test
+spec:
+  containers:
+    - name: {{ .Release.Name }}-pc-test
+      image: curlimages/curl
+      imagePullPolicy: "Always"
+      args:
+        - --silent
+        - http://{{ include "domain-proxy.protocol_controller.fullname" . }}:8080/sas/v1
+  restartPolicy: Never
+{{- end }}

--- a/dp/cloud/helm/dp/templates/tests/radio_controller-test.yaml
+++ b/dp/cloud/helm/dp/templates/tests/radio_controller-test.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.radio_controller.enabled }}
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ .Release.Name }}-rc-test"
+  annotations:
+    "helm.sh/hook": test
+spec:
+  containers:
+    - name: {{ .Release.Name }}-rc-test
+      image: subfuzion/netcat
+      imagePullPolicy: "Always"
+      args:
+        - "-zv"
+        - {{ include "domain-proxy.radio_controller.fullname" . }}
+        - "50053"
+  restartPolicy: Never
+{{- end }}

--- a/dp/cloud/helm/dp/values.yaml
+++ b/dp/cloud/helm/dp/values.yaml
@@ -1,0 +1,345 @@
+# Default values for domain-proxy.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+#
+---
+nameOverride: ""  # Replaces the name of the chart in the `Chart.yaml` file.
+fullnameOverride: ""  # Completely replaces the helm release generated name.
+
+configuration_controller:
+
+  sasEndpointUrl: "https://fake-sas-service/v1.2"  # Endpoint where sas request should be send.
+  nameOverride: ""  # Replaces service part of the dp component deployment name.
+  fullnameOverride: ""  # Completely replaces dp component deployment name.
+  enabled: true  # Enables deployment of the given service.
+  name: configuration-controller  # Domain proxy component name.
+
+  image:
+    repository: configuration-controller  # Docker image repository.
+    pullPolicy: IfNotPresent  # Default the pull policy of all containers in that pod.
+    tag: ""  # Overrides the image tag whose default is the chart appVersion.
+
+  replicaCount: 1  # How many replicas of particular component should be created.
+
+  imagePullSecrets: []  # Name of the secret that contains container image registry keys
+
+  serviceAccount:
+    create: false  # Specifies whether a service account should be created
+    annotations: {}  # Annotations to add to the service account
+    name: ""  # The name of the service account to use,If not set and create is true, a name is generated using the fullname template.
+
+  podAnnotations: {}  # Additional pod annotations
+
+  podSecurityContext: {}  # Holds pod-level security attributes
+  #  fsGroup: 2000
+
+  securityContext: {}  # Holds security configuration that will be applied to a container.
+  #  capabilities:
+  #    drop:
+  #      - ALL
+  #  readOnlyRootFilesystem: true
+  #  runAsNonRoot: true
+  #  runAsUser: 1000
+
+  service:
+    enable: true  # Whether to enable kubernetes service for dp component.
+    type: ClusterIP  # Type of enabled kubernetes service.
+    port: 8080  # Default port of enabled kubernetes service.
+
+  # If paths are set chart will generate kubernetes Secret resources for ingress. Mutually exclusive with ingress.tls.
+  tlsConfig:
+    paths:
+      cert: ""  # Client/Server TLS certificate path.
+      key: ""  # Client/Server TLS private key path.
+      ca: ""  # Certificate Authority certifcate chain path.
+
+  ingress:
+    enabled: false  # Enable kubernetes ingress resource.
+    annotations: {}  # Annotations to kubernetes ingress resource.
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+    hosts:
+      - host: chart-example.local  # Host header wildcards for kubernetes ingress resource.
+        paths:
+          - path: /  # Path header wildcards for kubernetes ingress resource.
+            backend:
+              serviceName: chart-example.local  # Kubernetes Service resource name where traffic should be passed.
+              servicePort: 80  # Kubernetes Service port where traffic should be passed.
+    tls: []  # Kubernetes secret name for tls termination on ingress kubernetes resource.
+    #  - secretName: chart-example-tls
+    #    hosts:
+    #      - chart-example.local
+
+  resources: {}  # Resource requests and limits of Pod.
+  #  We usually recommend not to specify default resources and to leave this as a conscious
+  #  choice for the user. This also increases chances charts run on environments with little
+  #  resources, such as Minikube. If you do want to specify resources, uncomment the following
+  #  lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  #  limits:
+  #    cpu: 100m
+  #    memory: 128Mi
+  #  requests:
+  #    cpu: 100m
+  #    memory: 128Mi
+
+  readinessProbe: {}  # Readines probe definition.
+  #  Example httpGet probe
+  #  httpGet:
+  #    path: /
+  #    port: http
+
+  livenessProbe: {}  # Livenes probe definition.
+  #  Example httpget probe
+  #  httpGet:
+  #    path: /
+  #    port: http
+
+  autoscaling:
+    enabled: false  # Enables horizontal pod autscaler kubernetes resource.
+    minReplicas: 1  # Minimum number of dp component replicas.
+    maxReplicas: 100  # Maximum number of dp component replicas.
+    targetCPUUtilizationPercentage: 80  # Target CPU utilization threshold in perecents when new replica should be created
+    # targetMemoryUtilizationPercentage: 80  # Target CPU utilization threshold in perecents when new replica should be created
+    # You can use one of these
+
+  # ref: https://kubernetes.io/docs/tasks/run-application/configure-pdb/#specifying-a-poddisruptionbudget
+  podDisruptionBudget:
+    enabled: false  # Creates kubernetes podDisruptionBudget resource.
+    minAvailable: 1  # Minimum available pods for dp component.
+    maxUnavailable: ""  # Maximum unavailable pods for dp component.
+    # You can use either one.
+
+  nodeSelector: {}  # Kubernetes node selection constraint.
+
+  tolerations: []  # Allow the pods to schedule onto nodes with matching taints.
+
+  affinity: {}  # Constrain which nodes your pod is eligible to be scheduled on.
+
+protocol_controller:
+
+  nameOverride: ""  # Replaces service part of the dp component deployment name.
+  fullnameOverride: ""  # Completely replaces dp component deployment name.
+  enabled: true  # Enables deployment of the given dp component.
+  name: protocol-controller  # Domain proxy component name.
+
+  image:
+    repository: protocol-controller  # Docker image repository.
+    tag: ""  # Overrides the image tag whose default is the chart appVersion.
+    pullPolicy: IfNotPresent  # Default the pull policy of all containers in that pod.
+
+
+  replicaCount: 1  # How many replicas of particular component should be created.
+
+  imagePullSecrets: []  # Name of the secret that contains container image registry keys.
+
+  serviceAccount:
+    create: false  # Specifies whether a service account should be created
+    annotations: {}  # Annotations to add to the service account
+    name: ""  # The name of the service account to use,If not set and create is true, a name is generated using the fullname template.
+
+  podAnnotations: {}  # Additional pod annotations.
+
+  podSecurityContext: {}  # Holds pod-level security attributes.
+  #  fsGroup: 2000
+
+  securityContext: {}  # Holds security configuration that will be applied to a container.
+  #  capabilities:
+  #    drop:
+  #      - ALL
+  #  readOnlyRootFilesystem: true
+  #  runAsNonRoot: true
+  #  runAsUser: 1000
+
+  service:
+    enable: true  # Whether to enable kubernetes service for dp component.
+    type: ClusterIP  # Type of enabled kubernetes service.
+    port: 8080  # Default port of enabled kubernetes service.
+
+
+  # If paths are set chart will generate kubernetes Secret resources for ingress. Mutually exclusive with ingress.tls.
+  tlsConfig:
+    paths:
+      cert: ""  # Client/Server TLS certificate path.
+      key: ""  # Client/Server TLS private key path.
+      ca: ""  # Certificate Authority certifcate chain path.
+
+  apiPrefix: "/sas/v1"  # Protocol controller URL API prefix.
+
+  # Currently you can choose between standard kubernetes resource and Contour httpproxy CRD.
+  # https://projectcontour.io/docs/v1.16.0/config/fundamentals/
+  ingress:
+    enabled: false  # Enable kubernetes ingress resource.
+    annotations: {}  # Annotations to kubernetes ingress resource.
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+    #
+    hosts:
+      - host: chart-example.local  # Host header wildcards for kubernetes ingress resource.
+        paths:
+          - path: /  # Path header wildcards for kubernetes ingress resource.
+            backend:
+              serviceName: chart-example.local  # Kubernetes Service resource name where traffic should be passed.
+              servicePort: 80  # Kubernetes Service port where traffic should be passed.
+    tls: []  # Kubernetes secret name for tls termination on ingress kubernetes resource.
+    #  - secretName: chart-example-tls
+    #    hosts:
+    #      - chart-example.local
+
+  # Pick either httpproxy orn ingress.
+  httpproxy:
+    enabled: false  # Enables contour httpproxy CRD.
+    annotations: {}  # Aditional annotations.
+    virtualhost:
+      fqdn: chart-example.local  # Host header wildcards for kubernetes ingress resource.
+      path: /example  # Path header wildcards for kubernetes ingress resource.
+      tls: {}  # Kubernetes secret name for tls termination on ingress kubernetes resource.
+      # secretName: chart-example-tls
+      # caSecret: chart-example-ca
+
+  resources: {}  # Resource requests and limits of Pod.
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #  cpu: 100m
+  #  memory: 128Mi
+  # requests:
+  #  cpu: 100m
+  #  memory: 128Mi
+
+  readinessProbe: {}  # Readines probe definition.
+  # Example httpGet probe
+  # httpGet:
+  #   path: /
+  #   port: http
+
+  livenessProbe: {}  # Livenes probe definition.
+  # Example httpget probe
+  # httpGet:
+  #   path: /
+  #   port: http
+
+  autoscaling:
+    enabled: false  # Enables horizontal pod autscaler kubernetes resource.
+    minReplicas: 1  # Minimum number of dp component replicas.
+    maxReplicas: 100  # Maximum number of dp component replicas.
+    targetCPUUtilizationPercentage: 80  # Target CPU utilization threshold in perecents when new replica should be created.
+    # targetMemoryUtilizationPercentage: 80 # Target CPU utilization threshold in perecents when new replica should be created.
+    # # You can use one of these.
+
+  # ref: https://kubernetes.io/docs/tasks/run-application/configure-pdb/#specifying-a-poddisruptionbudget
+  podDisruptionBudget:
+    enabled: false  # Creates kubernetes podDisruptionBudget resource.
+    minAvailable: 1  # Minimum available pods for dp component.
+    maxUnavailable: ""  # Minimum available pods for dp component.
+    # You can use either one.
+
+  nodeSelector: {}  # Kubernetes node selection constraint.
+
+  tolerations: []  # Allow the pods to schedule onto nodes with matching taints.
+
+  affinity: {}  # Constrain which nodes your pod is eligible to be scheduled on.
+
+radio_controller:
+
+  nameOverride: ""  # Replaces service part of the dp component deployment name.
+  fullnameOverride: ""  # Completely replaces dp component deployment name.
+  enabled: true  # Enables deployment of the given dp component.
+  name: radio-controller  # Domain proxy component name.
+
+  image:
+    repository: radio-controller  # Docker image repository.
+    tag: ""  # Overrides the image tag whose default is the chart appVersion.
+    pullPolicy: IfNotPresent  # Default the pull policy of all containers in that pod.
+
+  replicaCount: 1  # How many replicas of particular component should be created.
+
+  imagePullSecrets: []  # Name of the secret that contains container image registry keys.
+
+  serviceAccount:
+    create: false  # Specifies whether a service account should be created.
+    annotations: {}  # Annotations to add to the service account.
+    name: ""  # The name of the service account to use,If not set and create is true, a name is generated using the fullname template.
+
+  podAnnotations: {}  # Additional pod annotations.
+
+  podSecurityContext: {}  # Holds pod-level security attributes.
+  # fsGroup: 2000
+
+  securityContext: {}  # Holds security configuration that will be applied to a container.
+  # capabilities:
+  #   drop:
+  #   - ALL
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+  # runAsUser: 1000
+
+  service:
+    enable: true  # Whether to enable kubernetes service for dp component.
+    type: ClusterIP  # Type of enabled kubernetes service.
+    port: 50053  # Default port of enabled kubernetes service.
+
+  resources: {}  # Resource requests and limits of Pod.
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+  readinessProbe: {}  # Readines probe definition.
+  # Example httpGet probe
+  # httpGet:
+  #   path: /
+  #   port: http
+
+  livenessProbe: {}  # Livenes probe definition.
+  # Example httpget probe
+  # httpGet:
+  #   path: /
+  #   port: http
+
+  autoscaling:
+    enabled: false  # Enables horizontal pod autscaler kubernetes resource.
+    minReplicas: 1  # Minimum number of dp component replicas.
+    maxReplicas: 100  # Maximum number of dp component replicas.
+    targetCPUUtilizationPercentage: 80  # Target CPU utilization threshold in perecents when new replica should be created
+    # targetMemoryUtilizationPercentage: 80 # Target CPU utilization threshold in perecents when new replica should be created
+    # You can use one of these
+
+  # ref: https://kubernetes.io/docs/tasks/run-application/configure-pdb/#specifying-a-poddisruptionbudget
+  podDisruptionBudget:
+    enabled: false  # Creates kubernetes podDisruptionBudget resource.
+    minAvailable: 1  # Minimum available pods for dp component.
+    maxUnavailable: ""  # Maximum unavailable pods for dp component.
+    # You can use either one.
+
+  nodeSelector: {}  # Kubernetes node selection constraint.
+
+  tolerations: []  # Allow the pods to schedule onto nodes with matching taints.
+
+  affinity: {}  # Constrain which nodes your pod is eligible to be scheduled on.
+
+db_service:
+
+  enabled: true  # Enables deployment of the given service.
+  nameOverride: ""  # Replaces service part of the dp component deployment name.
+  fullnameOverride: ""  # Completely replaces dp component deployment name.
+  name: db-service  # Domain proxy component name.
+
+  image:
+    repository: db-service  # Docker image repository.
+    pullPolicy: IfNotPresent  # Default the pull policy of all containers in that pod.
+    tag: ""  # Overrides the image tag whose default is the chart appVersion.
+
+  imagePullSecrets: []  # Name of the secret that contains container image registry keys
+
+  serviceAccount:
+    create: false  # Specifies whether a service account should be created.
+    annotations: {}  # Annotations to add to the service account.
+    name: ""  # The name of the service account to use,If not set and create is true, a name is generated using the fullname template.


### PR DESCRIPTION
Signed-off-by: Marcin Trojanowski <marcin.trojanowski@freedomfi.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

- Create dp directory to host helm charts for domain-proxy component.
- Domain proxy chart requires ingress controller to be present on Cluster.

## Test Plan

 Install chart using one of provided example values.
 All tests should pass.

## Additional Information

- [ ] This change is backwards-breaking
