### PR TITLE
fix(session_proxy): add missing code to parse service indicator from …

### DIFF
--- a/feg/gateway/services/session_proxy/credit_control/gx/model_conversion.go
+++ b/feg/gateway/services/session_proxy/credit_control/gx/model_conversion.go
@@ -65,17 +65,25 @@ func (qos *QosRequestInfo) FromProtos(pQos *protos.QosInformationRequest) *QosRe
 
 func (rd *RuleDefinition) ToProto() *protos.PolicyRule {
 	return &protos.PolicyRule{
-		Id:            rd.RuleName,
-		RatingGroup:   swag.Uint32Value(rd.RatingGroup),
-		MonitoringKey: rd.MonitoringKey,
-		Priority:      rd.Precedence,
-		Redirect:      rd.RedirectInformation.ToProto(),
-		FlowList:      rd.GetFlowList(),
-		Qos:           rd.Qos.ToProto(),
-		TrackingType:  rd.GetTrackingType(),
-		Offline:       Int32ToBoolean(rd.Offline),
-		Online:        Int32ToBoolean(rd.Online),
+		Id:                rd.RuleName,
+		RatingGroup:       swag.Uint32Value(rd.RatingGroup),
+		ServiceIdentifier: ServiceIdentifierToProto(rd.ServiceIdentifier),
+		MonitoringKey:     rd.MonitoringKey,
+		Priority:          rd.Precedence,
+		Redirect:          rd.RedirectInformation.ToProto(),
+		FlowList:          rd.GetFlowList(),
+		Qos:               rd.Qos.ToProto(),
+		TrackingType:      rd.GetTrackingType(),
+		Offline:           Int32ToBoolean(rd.Offline),
+		Online:            Int32ToBoolean(rd.Online),
 	}
+}
+
+func ServiceIdentifierToProto(si *uint32) *protos.ServiceIdentifier {
+	if si == nil {
+		return nil
+	}
+	return &protos.ServiceIdentifier{Value: *si}
 }
 
 func (q *QosInformation) ToProto() *protos.FlowQos {


### PR DESCRIPTION
…Gx CCA-I

Signed-off-by: Oriol Batalla <obatalla@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

Added missing Service Indicator parse code from to capture SI from the GX CCR-I response 

## Test Plan
New teravm test `gxgy02b`

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
