### PR TITLE
fix(sessiond): increase default_requested_units to 10Mb 

### DIFF
--- a/cwf/gateway/configs/sessiond.yml
+++ b/cwf/gateway/configs/sessiond.yml
@@ -51,8 +51,8 @@ support_stateless: false
 sessions_table: sessiond:sessions
 
 # Sets the amount of octets that will be requested on the CCR-I for credit if
-# credit is given. If unset, defaults to 200000
-default_requested_units: 200000
+# credit is given. If unset, defaults to 10Mb
+default_requested_units: 10000000
 
 # set to true if subscriber information export over IPFIX needs to be enabled
 # in order to enable ipfix, make sure to add ipfix as a static service in pipelined.yml

--- a/cwf/gateway/integ_tests/sessiond.yml
+++ b/cwf/gateway/integ_tests/sessiond.yml
@@ -42,7 +42,7 @@ support_stateless: true
 sessions_table: sessiond:sessions
 
 # Sets the amount of octets that will be requested on the CCR-I for credit if
-# credit is given. If unset, defaults to 200000
+# credit is given. If unset, defaults to 10Mb
 default_requested_units: 200000
 
 # set to true if subscriber information export over IPFIX needs to be enabled

--- a/lte/gateway/c/session_manager/SessionCredit.cpp
+++ b/lte/gateway/c/session_manager/SessionCredit.cpp
@@ -25,7 +25,7 @@ namespace magma {
 
 float SessionCredit::USAGE_REPORTING_THRESHOLD             = 0.8;
 bool SessionCredit::TERMINATE_SERVICE_WHEN_QUOTA_EXHAUSTED = true;
-uint64_t SessionCredit::DEFAULT_REQUESTED_UNITS            = 200000;
+uint64_t SessionCredit::DEFAULT_REQUESTED_UNITS            = 10000000;
 
 // by default, enable service & finite credit
 SessionCredit::SessionCredit() : SessionCredit(SERVICE_ENABLED, FINITE) {}

--- a/lte/gateway/configs/sessiond.yml
+++ b/lte/gateway/configs/sessiond.yml
@@ -55,8 +55,8 @@ sessions_table: sessiond:sessions
 converged_access: true
 
 # Sets the amount of octets that will be requested on the CCR-I for credit if
-# credit is given. If unset, defaults to 200000
-default_requested_units: 200000
+# credit is given. If unset, defaults to 10Mb
+default_requested_units: 10000000
 
 # [WARNING] only set this to false if you know what you're doing
 # If the config is missing, the value will default to true


### PR DESCRIPTION
Signed-off-by: Oriol Batalla <obatalla@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

Increased value of default_requested_units on sessiond from 200kb to 10mb. 

Having such a low value by default causes sessiond to spam FEG with bunch of update request when we have subscribers using data at a normal pace

Note we only change the default values. Values for cwag_integ_test are kept to 200kb in order to trigger those Update Request more often and reduce the execution time of the test.

## Test Plan
```
Test project /home/vagrant/build/c/session_manager
      Start  1: test_polling_pipelined
 1/17 Test  #1: test_polling_pipelined ...............   Passed    0.03 sec
      Start  2: test_session_credit
 2/17 Test  #2: test_session_credit ..................   Passed    1.02 sec
      Start  3: test_local_enforcer
 3/17 Test  #3: test_local_enforcer ..................   Passed    1.83 sec
      Start  4: test_cloud_reporter
 4/17 Test  #4: test_cloud_reporter ..................   Passed    0.06 sec
      Start  5: test_session_manager_handler
 5/17 Test  #5: test_session_manager_handler .........   Passed    0.05 sec
      Start  6: test_sessiond_integ
 6/17 Test  #6: test_sessiond_integ ..................   Passed    0.90 sec
      Start  7: test_session_state
 7/17 Test  #7: test_session_state ...................   Passed    0.02 sec
      Start  8: test_session_store
 8/17 Test  #8: test_session_store ...................   Passed    0.03 sec
      Start  9: test_store_client
 9/17 Test  #9: test_store_client ....................   Passed    0.02 sec
      Start 10: test_stored_state
10/17 Test #10: test_stored_state ....................   Passed    0.02 sec
      Start 11: test_proxy_responder_handler
11/17 Test #11: test_proxy_responder_handler .........   Passed    0.04 sec
      Start 12: test_metering_reporter
12/17 Test #12: test_metering_reporter ...............   Passed    0.02 sec
      Start 13: test_local_enforcer_wallet_exhaust
13/17 Test #13: test_local_enforcer_wallet_exhaust ...   Passed    0.04 sec
      Start 14: test_charging_grant
14/17 Test #14: test_charging_grant ..................   Passed    0.01 sec
      Start 15: test_usage_monitor
15/17 Test #15: test_usage_monitor ...................   Passed    0.02 sec
      Start 16: test_upf_node_state
16/17 Test #16: test_upf_node_state ..................   Passed    0.04 sec
      Start 17: test_set_session_manager_handler
17/17 Test #17: test_set_session_manager_handler .....   Passed    0.04 sec
```
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
