### PR TITLE
fix(mme): Solve AttributeError when accessing copy function from RepeatedScalar…

### DIFF
--- a/lte/gateway/python/scripts/generate_oai_config.py
+++ b/lte/gateway/python/scripts/generate_oai_config.py
@@ -206,7 +206,8 @@ def _get_service_area_maps(service_mconfig):
         return {}
     service_area_map = []
     for sac, sam in service_mconfig.service_area_maps.items():
-        service_area_map.append({'sac': sac, 'tac': sam.tac.copy()})
+        tac = list(sam.tac)
+        service_area_map.append({'sac': sac, 'tac': tac.copy()})
     return service_area_map
 
 


### PR DESCRIPTION
…FieldContainer

code is trying to access protobuf container directly

This solves issue found in https://github.com/magma/magma/issues/8301

Signed-off-by: Joary Paulo Wanzeler Fortuna <joarypl@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

- Convert sam.tac from ProtobufContainer to list before using .copy function.

## Test Plan

1. With service area configuration enabled, observe that mme gets into crashloop because the AtributeError.
2. Applied the change and observed the AtributeError is solved and mme gets out of crashloop. 

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
