### PR TITLE
fix(mme): Incorrect S-NSSAI sST value set,

### DIFF
--- a/lte/gateway/c/core/oai/tasks/ngap/ngap_amf_handlers.c
+++ b/lte/gateway/c/core/oai/tasks/ngap/ngap_amf_handlers.c
@@ -637,9 +637,8 @@ amf_config_read_lock(&amf_config);
   Ngap_SliceSupportItem_t* SliceItem =
       (Ngap_SliceSupportItem_t*) calloc(1, sizeof(Ngap_SliceSupportItem_t));
 
-  char* from_buf = "0x11";
-
-  OCTET_STRING_fromBuf(&SliceItem->s_NSSAI.sST, from_buf, 1);
+  uint8_t sst = _SST_eMBB;  // enhanced mobile broadband eMBB
+  OCTET_STRING_fromBuf(&SliceItem->s_NSSAI.sST, (char*) &sst, 1);
 
   ASN_SEQUENCE_ADD(
       &plmnItem->sliceSupportList.list,

--- a/lte/gateway/c/core/oai/tasks/ngap/ngap_amf_ta.h
+++ b/lte/gateway/c/core/oai/tasks/ngap/ngap_amf_ta.h
@@ -33,6 +33,12 @@ enum {
   TA_LIST_COMPLETE_MATCH     = 0x3,
 };
 
+typedef enum s_nssai_sst_s {
+  _SST_eMBB  = 1,
+  _SST_URLLC = 2,
+  _SST_mMTC  = 3,
+} s_nssai_sst_t;
+
 int ngap_amf_compare_ta_lists(Ngap_SupportedTAList_t* ta_list);
 int ngap_paging_compare_ta_lists(
     m5g_supported_ta_list_t* enb_ta_list, const paging_tai_list_t* p_tai_list,


### PR DESCRIPTION


Signed-off-by: LKishor123 <laawanya.kishor@wavelabs.ai>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary
Incorrect S-NSSAI sST value set, causing Slice not support error
1. Changed the hard  coded value of s-nssai.
2. Defined enum for s-nssai sST
3. Set the slice mode as eMBB in NG Setup Response, 
<!-- Enumerate changes you made and why you made them -->

## Test Plan
Used UERANSIM to test the NG Setup Response.
![slice_error](https://user-images.githubusercontent.com/52399057/129933480-50652316-b929-4ae4-9952-bd1c64734a0c.png)

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
