### PR TITLE
Revert "fix(session_proxy): add missing code to parse service indicator from …"

### DIFF
--- a/feg/gateway/services/session_proxy/credit_control/gx/model_conversion.go
+++ b/feg/gateway/services/session_proxy/credit_control/gx/model_conversion.go
@@ -65,25 +65,17 @@ func (qos *QosRequestInfo) FromProtos(pQos *protos.QosInformationRequest) *QosRe
 
 func (rd *RuleDefinition) ToProto() *protos.PolicyRule {
 	return &protos.PolicyRule{
-		Id:                rd.RuleName,
-		RatingGroup:       swag.Uint32Value(rd.RatingGroup),
-		ServiceIdentifier: ServiceIdentifierToProto(rd.ServiceIdentifier),
-		MonitoringKey:     rd.MonitoringKey,
-		Priority:          rd.Precedence,
-		Redirect:          rd.RedirectInformation.ToProto(),
-		FlowList:          rd.GetFlowList(),
-		Qos:               rd.Qos.ToProto(),
-		TrackingType:      rd.GetTrackingType(),
-		Offline:           Int32ToBoolean(rd.Offline),
-		Online:            Int32ToBoolean(rd.Online),
+		Id:            rd.RuleName,
+		RatingGroup:   swag.Uint32Value(rd.RatingGroup),
+		MonitoringKey: rd.MonitoringKey,
+		Priority:      rd.Precedence,
+		Redirect:      rd.RedirectInformation.ToProto(),
+		FlowList:      rd.GetFlowList(),
+		Qos:           rd.Qos.ToProto(),
+		TrackingType:  rd.GetTrackingType(),
+		Offline:       Int32ToBoolean(rd.Offline),
+		Online:        Int32ToBoolean(rd.Online),
 	}
-}
-
-func ServiceIdentifierToProto(si *uint32) *protos.ServiceIdentifier {
-	if si == nil {
-		return nil
-	}
-	return &protos.ServiceIdentifier{Value: *si}
 }
 
 func (q *QosInformation) ToProto() *protos.FlowQos {


### PR DESCRIPTION
Reverts magma/magma#8659

Per 3gpp, this AVP may not be needed on GY (still under investigation since we found contradicting information)


https://www.etsi.org/deliver/etsi_ts/132200_132299/132299/15.07.00_60/ts_132299v150700p.pdf


![image](https://user-images.githubusercontent.com/16157139/129936106-61b86672-3101-4e81-ae07-d6b72ec8ee49.png)
