### PR TITLE
chore(nms): Trigger cwag gh actions on nms changes

### DIFF
--- a/.github/workflows/cwag-workflow.yml
+++ b/.github/workflows/cwag-workflow.yml
@@ -10,6 +10,7 @@ on:  # yamllint disable-line rule:truthy
       - 'lte/**'
       - 'feg/**'
       - 'cwf/**'
+      - 'nms/**'
   pull_request:
     branches:
       - master
@@ -18,6 +19,7 @@ on:  # yamllint disable-line rule:truthy
       - 'lte/**'
       - 'feg/**'
       - 'cwf/**'
+      - 'nms/**'
 jobs:
   cwag-precommit:
     runs-on: ubuntu-latest

--- a/lte/gateway/c/core/oai/tasks/amf/amf_app_handler.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_app_handler.cpp
@@ -614,7 +614,7 @@ void amf_app_handle_pdu_session_response(
     amf_sap.u.amf_as.u.establish.ue_id    = ue_id;
     amf_sap.u.amf_as.u.establish.nas_info = AMF_AS_NAS_INFO_SR;
 
-    amf_sap.u.amf_as.u.establish.pdu_sesion_status_ie =
+    amf_sap.u.amf_as.u.establish.pdu_session_status_ie =
         (AMF_AS_PDU_SESSION_STATUS | AMF_AS_PDU_SESSION_REACTIVATION_STATUS);
     amf_sap.u.amf_as.u.establish.pdu_session_status =
         (1 << smf_ctx->smf_proc_data.pdu_session_identity.pdu_session_id);

--- a/lte/gateway/c/core/oai/tasks/amf/amf_as.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_as.cpp
@@ -503,7 +503,7 @@ int amf_reg_acceptmsg(const guti_m5_t* guti, amf_nas_message_t* nas_msg) {
  **              Others:        None                                       **
  **                                                                        **
  ***************************************************************************/
-static int amf_service_acceptmsg(
+int amf_service_acceptmsg(
     const amf_as_establish_t* msg, amf_nas_message_t* nas_msg) {
   OAILOG_FUNC_IN(LOG_NAS_AMF);
   int size = SERVICE_ACCEPT_MINIMUM_LENGTH;
@@ -521,7 +521,7 @@ static int amf_service_acceptmsg(
   nas_msg->header.security_header_type =
       SECURITY_HEADER_TYPE_INTEGRITY_PROTECTED_CYPHERED;
 
-  if (msg->pdu_sesion_status_ie & AMF_AS_PDU_SESSION_STATUS) {
+  if (msg->pdu_session_status_ie & AMF_AS_PDU_SESSION_STATUS) {
     nas_msg->security_protected.plain.amf.msg.service_accept.pdu_session_status
         .iei = PDU_SESSION_STATUS;
     nas_msg->security_protected.plain.amf.msg.service_accept.pdu_session_status
@@ -530,7 +530,7 @@ static int amf_service_acceptmsg(
         .pduSessionStatus = msg->pdu_session_status;
   }
 
-  if (msg->pdu_sesion_status_ie & AMF_AS_PDU_SESSION_REACTIVATION_STATUS) {
+  if (msg->pdu_session_status_ie & AMF_AS_PDU_SESSION_REACTIVATION_STATUS) {
     nas_msg->security_protected.plain.amf.msg.service_accept
         .pdu_re_activation_status.iei = PDU_SESSION_REACTIVATION_RESULT;
     nas_msg->security_protected.plain.amf.msg.service_accept

--- a/lte/gateway/c/core/oai/tasks/amf/amf_asDefs.h
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_asDefs.h
@@ -24,6 +24,7 @@ extern "C" {
 #include "common_types.h"
 #include "amf_config.h"
 #include "amf_securityDef.h"
+#include "amf_app_ue_context_and_proc.h"
 
 #define AUTH_KNAS_INT_SIZE 16 /* NAS integrity key     */
 #define AUTH_KNAS_ENC_SIZE 16 /* NAS cyphering key     */
@@ -116,7 +117,7 @@ typedef struct amf_as_establish_s {
                          // type
 #define AMF_AS_PDU_SESSION_STATUS 0x01
 #define AMF_AS_PDU_SESSION_REACTIVATION_STATUS 0x02
-  uint8_t pdu_sesion_status_ie;
+  uint8_t pdu_session_status_ie;
   uint16_t pdu_session_status;
   uint16_t pdu_session_reactivation_status;
   uint8_t ue_context_req;
@@ -171,4 +172,6 @@ typedef struct amf_as_s {
   as_primitive_t u;
 } amf_as_t;
 
+int amf_service_acceptmsg(
+    const amf_as_establish_t* msg, amf_nas_message_t* nas_msg);
 }  // namespace magma5g

--- a/lte/gateway/c/core/oai/tasks/ngap/ngap_amf_handlers.c
+++ b/lte/gateway/c/core/oai/tasks/ngap/ngap_amf_handlers.c
@@ -637,9 +637,8 @@ amf_config_read_lock(&amf_config);
   Ngap_SliceSupportItem_t* SliceItem =
       (Ngap_SliceSupportItem_t*) calloc(1, sizeof(Ngap_SliceSupportItem_t));
 
-  char* from_buf = "0x11";
-
-  OCTET_STRING_fromBuf(&SliceItem->s_NSSAI.sST, from_buf, 1);
+  uint8_t sst = _SST_eMBB;  // enhanced mobile broadband eMBB
+  OCTET_STRING_fromBuf(&SliceItem->s_NSSAI.sST, (char*) &sst, 1);
 
   ASN_SEQUENCE_ADD(
       &plmnItem->sliceSupportList.list,

--- a/lte/gateway/c/core/oai/tasks/ngap/ngap_amf_ta.h
+++ b/lte/gateway/c/core/oai/tasks/ngap/ngap_amf_ta.h
@@ -33,6 +33,12 @@ enum {
   TA_LIST_COMPLETE_MATCH     = 0x3,
 };
 
+typedef enum s_nssai_sst_s {
+  _SST_eMBB  = 1,
+  _SST_URLLC = 2,
+  _SST_mMTC  = 3,
+} s_nssai_sst_t;
+
 int ngap_amf_compare_ta_lists(Ngap_SupportedTAList_t* ta_list);
 int ngap_paging_compare_ta_lists(
     m5g_supported_ta_list_t* enb_ta_list, const paging_tai_list_t* p_tai_list,

--- a/lte/gateway/c/core/oai/test/amf/CMakeLists.txt
+++ b/lte/gateway/c/core/oai/test/amf/CMakeLists.txt
@@ -15,14 +15,14 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 
 include_directories("${PROJECT_SOURCE_DIR}")
 include_directories("${PROJECT_SOURCE_DIR}/tasks/amf")
+include_directories("${PROJECT_SOURCE_DIR}/include/nas/")
+include_directories("${PROJECT_SOURCE_DIR}/lib/secu")
 
 pkg_search_module(OPENSSL openssl REQUIRED)
 include_directories(${OPENSSL_INCLUDE_DIRS})
 
 pkg_search_module(CRYPTO libcrypto REQUIRED)
 include_directories(${CRYPTO_INCLUDE_DIRS})
-
-include_directories("${PROJECT_SOURCE_DIR}/include/nas")
 
 add_library(AMF_TASK_TEST_LIB
     util_nas5g_pkt.h

--- a/lte/gateway/c/core/oai/test/amf/util_nas5g_pkt.h
+++ b/lte/gateway/c/core/oai/test/amf/util_nas5g_pkt.h
@@ -18,6 +18,8 @@
 #include "M5GDeRegistrationRequestUEInit.h"
 #include "M5GServiceRequest.h"
 #include "M5GServiceAccept.h"
+#include "amf_app_ue_context_and_proc.h"
+#include "amf_asDefs.h"
 
 namespace magma5g {
 

--- a/lte/gateway/python/scripts/generate_oai_config.py
+++ b/lte/gateway/python/scripts/generate_oai_config.py
@@ -206,7 +206,8 @@ def _get_service_area_maps(service_mconfig):
         return {}
     service_area_map = []
     for sac, sam in service_mconfig.service_area_maps.items():
-        service_area_map.append({'sac': sac, 'tac': sam.tac.copy()})
+        tac = list(sam.tac)
+        service_area_map.append({'sac': sac, 'tac': tac.copy()})
     return service_area_map
 
 


### PR DESCRIPTION
## Summary

Opening this PR more as a point of discussion - I noticed that neither `cwag-build` nor the `cwag-precommit` Github checks are ever reported on pull requests that only include NMS changes. See #8589 and #8666 for reference.

Not sure if this is the best way to fix this though.

## Test Plan

Absolutely none

## Additional Information

- [ ] This change is backwards-breaking
