### PR TITLE
chore(nms): Trigger cwag Github actions on NMS changes

### DIFF
--- a/.github/workflows/cwag-workflow.yml
+++ b/.github/workflows/cwag-workflow.yml
@@ -10,6 +10,7 @@ on:  # yamllint disable-line rule:truthy
       - 'lte/**'
       - 'feg/**'
       - 'cwf/**'
+      - 'nms/**'
   pull_request:
     branches:
       - master
@@ -18,6 +19,7 @@ on:  # yamllint disable-line rule:truthy
       - 'lte/**'
       - 'feg/**'
       - 'cwf/**'
+      - 'nms/**'
 jobs:
   cwag-precommit:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Signed-off-by: Andrei Lee <andreilee@fb.com>

## Summary

Opening this PR more as a point of discussion - I noticed that neither `cwag-build` nor the `cwag-precommit` Github checks are ever reported on pull requests that only include NMS changes. See #8589 and #8666 for reference.

Not sure if this is the best way to fix this though.

## Test Plan

Absolutely none

## Additional Information

- [ ] This change is backwards-breaking
