### PR TITLE
feat(session_proxy): add a flag to disable Service Requested Unit AVP

### DIFF
--- a/feg/gateway/docker/docker-compose.yml
+++ b/feg/gateway/docker/docker-compose.yml
@@ -102,6 +102,7 @@ services:
       USE_GY_FOR_AUTH_ONLY: ${USE_GY_FOR_AUTH_ONLY}
       GY_SUPPORTED_VENDOR_IDS: ${GY_SUPPORTED_VENDOR_IDS}
       GY_SERVICE_CONTEXT_ID: ${GY_SERVICE_CONTEXT_ID}
+      DISABLE_REQUESTED_SERVICE_UNIT_AVP: ${DISABLE_REQUESTED_SERVICE_UNIT_AVP}
     container_name: session_proxy
     command: envdir /var/opt/magma/envdir /var/opt/magma/bin/session_proxy -logtostderr=true -v=0
 

--- a/feg/gateway/services/session_proxy/credit_control/gy/config.go
+++ b/feg/gateway/services/session_proxy/credit_control/gy/config.go
@@ -23,37 +23,42 @@ import (
 	"magma/feg/gateway/diameter"
 	"magma/feg/gateway/services/session_proxy/credit_control"
 	managed_configs "magma/gateway/mconfig"
+	"magma/orc8r/lib/go/util"
+
 )
 
 // OCS Environment Variables
 const (
-	OCSAddrEnv              = "OCS_ADDR"
-	GyNetworkEnv            = "GY_NETWORK"
-	GyDiamHostEnv           = "GY_DIAM_HOST"
-	GyDiamRealmEnv          = "GY_DIAM_REALM"
-	GyDiamProductEnv        = "GY_DIAM_PRODUCT"
-	GyInitMethodEnv         = "GY_INIT_METHOD"
-	GyLocalAddr             = "GY_LOCAL_ADDR"
-	OCSHostEnv              = "OCS_HOST"
-	OCSRealmEnv             = "OCS_REALM"
-	OCSApnOverwriteEnv      = "OCS_APN_OVERWRITE"
-	OCSServiceIdentifierEnv = "OCS_SERVICE_IDENTIFIER_OVERWRITE"
-	DisableDestHostEnv      = "DISABLE_DEST_HOST"
-	OverwriteDestHostEnv    = "GY_OVERWRITE_DEST_HOST"
-	UseGyForAuthOnlyEnv     = "USE_GY_FOR_AUTH_ONLY"
-	GySupportedVendorIDsEnv = "GY_SUPPORTED_VENDOR_IDS"
-	GyServiceContextIdEnv   = "GY_SERVICE_CONTEXT_ID"
+	OCSAddrEnv                         = "OCS_ADDR"
+	GyNetworkEnv                       = "GY_NETWORK"
+	GyDiamHostEnv                      = "GY_DIAM_HOST"
+	GyDiamRealmEnv                     = "GY_DIAM_REALM"
+	GyDiamProductEnv                   = "GY_DIAM_PRODUCT"
+	GyInitMethodEnv                    = "GY_INIT_METHOD"
+	GyLocalAddr                        = "GY_LOCAL_ADDR"
+	OCSHostEnv                         = "OCS_HOST"
+	OCSRealmEnv                        = "OCS_REALM"
+	OCSApnOverwriteEnv                 = "OCS_APN_OVERWRITE"
+	OCSServiceIdentifierEnv            = "OCS_SERVICE_IDENTIFIER_OVERWRITE"
+	DisableDestHostEnv                 = "DISABLE_DEST_HOST"
+	OverwriteDestHostEnv               = "GY_OVERWRITE_DEST_HOST"
+	UseGyForAuthOnlyEnv                = "USE_GY_FOR_AUTH_ONLY"
+	GySupportedVendorIDsEnv            = "GY_SUPPORTED_VENDOR_IDS"
+	GyServiceContextIdEnv              = "GY_SERVICE_CONTEXT_ID"
+	DisableRequestedGrantedUnitsAVPEnv = "DISABLE_REQUESTED_SERVICE_UNIT_AVP"
 
-	GyInitMethodFlag         = "gy_init_method"
-	OCSApnOverwriteFlag      = "ocs_apn_overwrite"
-	OCSServiceIdentifierFlag = "ocs_service_identifier_overwrite"
+	GyInitMethodFlag                    = "gy_init_method"
+	OCSApnOverwriteFlag                 = "ocs_apn_overwrite"
+	OCSServiceIdentifierFlag            = "ocs_service_identifier_overwrite"
+	DisableRequestedGrantedUnitsAVPFlag = "disable_requested_service_unit_AVP"
 )
 
 var (
 	_ = flag.String(GyInitMethodFlag, "", "Gy init method (per_key|per_session)")
 	_ = flag.String(OCSApnOverwriteFlag, "", "OCS APN to use instead of request's APN")
 	_ = flag.String(OCSServiceIdentifierFlag, "", "OCS ServiceIdentifier to use in Gy requests")
-)
+	avp437Flag = flag.Bool(DisableRequestedGrantedUnitsAVPFlag, false, "Disable Requested-Service-Unit AVP (437)")
+	)
 
 // InitMethod describes the type of ways sessions can be initialized through the
 // Gy interface
@@ -207,20 +212,23 @@ func GetGyGlobalConfig() *GyGlobalConfig {
 	configsPtr := &mconfig.SessionProxyConfig{}
 	err := managed_configs.GetServiceConfigs(credit_control.SessionProxyServiceName, configsPtr)
 	siStr := diameter.GetValueOrEnv(OCSServiceIdentifierFlag, OCSServiceIdentifierEnv, "")
+	avp437 := *avp437Flag || util.IsTruthyEnv(DisableRequestedGrantedUnitsAVPEnv)
 	if err != nil || !validGyConfig(configsPtr) {
 		log.Printf("%s Managed Gy Server Configs Load Error: %v", credit_control.SessionProxyServiceName, err)
 		return &GyGlobalConfig{
-			OCSOverwriteApn:      diameter.GetValueOrEnv(OCSApnOverwriteFlag, OCSApnOverwriteEnv, ""),
-			OCSServiceIdentifier: siStr,
-			DisableGy:            false,
+			OCSOverwriteApn:               diameter.GetValueOrEnv(OCSApnOverwriteFlag, OCSApnOverwriteEnv, ""),
+			OCSServiceIdentifier:          siStr,
+			DisableGy:                     false,
+			DisableServiceGrantedUnitsAVP: avp437,
 		}
 	}
 
 	return &GyGlobalConfig{
-		OCSOverwriteApn:      diameter.GetValueOrEnv(OCSApnOverwriteFlag, OCSApnOverwriteEnv, configsPtr.GetGy().GetOverwriteApn()),
-		OCSServiceIdentifier: siStr,
-		DisableGy:            configsPtr.GetGy().GetDisableGy(),
-		VirtualApnRules:      credit_control.GenerateVirtualApnRules(configsPtr.GetGy().GetVirtualApnRules()),
+		OCSOverwriteApn:               diameter.GetValueOrEnv(OCSApnOverwriteFlag, OCSApnOverwriteEnv, configsPtr.GetGy().GetOverwriteApn()),
+		OCSServiceIdentifier:          siStr,
+		DisableGy:                     configsPtr.GetGy().GetDisableGy(),
+		VirtualApnRules:               credit_control.GenerateVirtualApnRules(configsPtr.GetGy().GetVirtualApnRules()),
+		DisableServiceGrantedUnitsAVP: avp437,
 	}
 }
 


### PR DESCRIPTION
Signed-off-by: Oriol Batalla <obatalla@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

To support some specific vendors we need to set Service Requested Unit AVP as empty. This PR adds a flag to session_proxy service to disable that AVP. 

To disable that, go to `.env` file and crate 
```
DISABLE_REQUESTED_SERVICE_UNIT_AVP=1
```


## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
