### PR TITLE
chore(magmad): pretty print gateway.mconfig file

### DIFF
--- a/orc8r/gateway/python/magma/configuration/mconfig_managers.py
+++ b/orc8r/gateway/python/magma/configuration/mconfig_managers.py
@@ -222,8 +222,9 @@ class MconfigManagerImpl(MconfigManager[GatewayConfigs]):
         magma_configuration_events.deleted_stored_mconfig()
 
     def update_stored_mconfig(self, updated_value: str) -> GatewayConfigs:
+        parsed = json.loads(updated_value)
         serialization_utils.write_to_file_atomically(
-            self.MCONFIG_PATH, updated_value,
+            self.MCONFIG_PATH, json.dumps(parsed, indent=4, sort_keys=True),
         )
         magma_configuration_events.updated_stored_mconfig()
 


### PR DESCRIPTION
Signed-off-by: Oriol Batalla <obatalla@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

gateway.mconfig is stored without pretty format on gateways.

This PR converts the single string into proper human readable format

from this
```
(python) vagrant@magma-dev-focal:~/magma/lte/gateway$ cat /var/opt/magma/configs/gateway.mconfig
{"configsByKey":{"control_proxy":{"@type":"type.googleapis.com/magma.mconfig.ControlProxy","logLevel":"INFO"},"eventd":{"@type":"type.googleapis.com/magma.mconfig.EventD","logLevel":"INFO","eventVerbosity":-1},"magmad":{"@type":"type.googleapis.com/magma.mconfig.MagmaD","logLevel":"INFO","checkinInterval":60,"checkinTimeout":30,"autoupgradeEnabled":true,"autoupgradePollInterval":60,"packageVersion":"0.0.0-0"},"metricsd":{"@type":"type.googleapis.com/magma.mconfig.MetricsD","logLevel":"INFO"},"ovpn":{"@type":"type.googleapis.com/magma.mconfig.OpenVPN"},"td-agent-bit":{"@type":"type.googleapis.com/magma.mconfig.FluentBit","extraTags":{"gateway_id":"gw2","network_id":"feg_lte_test"},"throttleRate":1000,"throttleWindow":5,"throttleInterval":"1m"}},"metadata":{"created_at":1629626708}}(python) vagrant@magma-dev-focal:~/magma/lte/gateway$ ls -la  /var/opt/magma/configs/gateway.mconfig
```


to this
```
(python) vagrant@magma-dev-focal:~/magma/lte/gateway$ cat /var/opt/magma/configs/gateway.mconfig
{
    "configsByKey": {
        "control_proxy": {
            "@type": "type.googleapis.com/magma.mconfig.ControlProxy",
            "logLevel": "INFO"
        },
        "eventd": {
            "@type": "type.googleapis.com/magma.mconfig.EventD",
            "eventVerbosity": -1,
            "logLevel": "INFO"
        },
        "magmad": {
            "@type": "type.googleapis.com/magma.mconfig.MagmaD",
            "autoupgradeEnabled": true,
            "autoupgradePollInterval": 60,
            "checkinInterval": 60,
            "checkinTimeout": 30,
            "logLevel": "INFO",
            "packageVersion": "0.0.0-0"
        },
        "metricsd": {
            "@type": "type.googleapis.com/magma.mconfig.MetricsD",
            "logLevel": "INFO"
        },

```

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
