### PR TITLE
fix: Remove as_dict override for spyne

### DIFF
--- a/lte/gateway/python/magma/enodebd/tr069/models.py
+++ b/lte/gateway/python/magma/enodebd/tr069/models.py
@@ -35,18 +35,6 @@ class Tr069ComplexModel(ComplexModel):
         in CWMP XSD file. """
     __namespace__ = CWMP_NS
 
-    def as_dict(self):
-        """
-        Overriding default implementation to fix memory leak. Can remove if
-        or after https://github.com/arskom/spyne/pull/579 lands.
-        """
-        flat_type_info = self.get_flat_type_info(self.__class__)
-        return dict((
-            (k, getattr(self, k)) for k in flat_type_info
-            if getattr(self, k) is not None
-        ))
-
-
 class anySimpleType(Tr069ComplexModel):
     """ Type used to transfer simple data of various types. Data type is
         defined in 'type' XML attribute. Data is handled as a string. """


### PR DESCRIPTION
## Summary
The underlying memory leak has been fixed in spyne so remove
override in the subclass

Signed-off-by: Amar Padmanabhan <amar@freedomfi.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->



<!-- Enumerate changes you made and why you made them -->

## Test Plan

make python_test
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
