### PR TITLE
feat(mme): Adding periodic output of UE state hashtables for s1ap spgw mme_app tasks

### DIFF
--- a/lte/gateway/c/core/oai/tasks/s1ap/s1ap_mme.h
+++ b/lte/gateway/c/core/oai/tasks/s1ap/s1ap_mme.h
@@ -82,4 +82,12 @@ void s1ap_remove_ue(s1ap_state_t* state, ue_description_t* ue_ref);
  **/
 void s1ap_remove_enb(s1ap_state_t* state, enb_description_t* enb_ref);
 
+/**
+ * \brief Callback function to remove target ue if matches sctp assoc id
+ * @return false if UE not found, true otherwise
+ */
+bool s1ap_dump_ue_hash_cb(
+    const hash_key_t keyP, void* const ue_void, void* parameter,
+    void** unused_res);
+
 #endif /* FILE_S1AP_MME_SEEN */


### PR DESCRIPTION
Signed-off-by: Alex Rodriguez <ardzoht@gmail.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

- Adds periodic logging of internal state UE hashtable entries for SPGW S1AP and MME_APP tasks
- **TODO**: Add configurable flag to enable / disable logging

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
