### PR TITLE
fix(mme): Fix enable_converged_core flag for headless ops

### DIFF
--- a/lte/gateway/configs/mme.yml
+++ b/lte/gateway/configs/mme.yml
@@ -27,7 +27,6 @@ apn_correction_map_list:
         - imsi_prefix: "00101"
           apn_override: "magma.ipv4"
 
-congestion_control_enabled: true
 s1ap_zmq_th_us: 2000000  # delay threshold used for dropping initial UE message
 mme_app_zmq_congest_th_us: 100000  # delay threshold used for rejecting attach requests
 mme_app_zmq_auth_th_us: 200000  # delay threshold used for dropping Authentication Complete

--- a/lte/gateway/python/scripts/generate_oai_config.py
+++ b/lte/gateway/python/scripts/generate_oai_config.py
@@ -214,7 +214,7 @@ def _get_service_area_maps(service_mconfig):
 def _get_congestion_control_config(service_mconfig):
     """
     Retrieves congestion_control_enabled config value, it it does not exist
-    it defaults to True.
+    it defaults to True. It gives precedence to the local mme.yml file.
     Args:
         service_mconfig:
 
@@ -236,7 +236,7 @@ def _get_congestion_control_config(service_mconfig):
 def _get_converged_core_config(service_mconfig: object) -> bool:
     """
     Retrieves enable_converged_core config value,If it does not exist
-    it defaults to False. It gives precedence to the service_mconfig file.
+    it defaults to False. It gives precedence to the local mme.yml file.
     """
     enable_converged_core = get_service_config_value(
         'mme', 'enable_converged_core', None,

--- a/lte/gateway/python/scripts/generate_oai_config.py
+++ b/lte/gateway/python/scripts/generate_oai_config.py
@@ -238,6 +238,13 @@ def _get_converged_core_config(service_mconfig: object) -> bool:
     Retrieves enable_converged_core config value,If it does not exist
     it defaults to False. It gives precedence to the service_mconfig file.
     """
+    enable_converged_core = get_service_config_value(
+        'mme', 'enable_converged_core', None,
+    )
+
+    if enable_converged_core is not None:
+        return enable_converged_core
+        
     if service_mconfig.enable_converged_core is not None:
         return service_mconfig.enable_converged_core
 


### PR DESCRIPTION
Signed-off-by: Ulas Kozat <kozat@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->
- Local MME override configuration for `enable_converged_core` was not working when older builds of orc8r are used.
- Similarly the existing default flag for congestion control in mme.yml file has precedence negating the orc8r pushed configs if any. Removed it from mme.yml.

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->
Test on SIT with older orc8r with various local overrides.

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
