### PR TITLE
chore(mme): Migrate S6A AIR timer to zmq

### DIFF
--- a/lte/gateway/c/core/oai/tasks/mme_app/mme_app_defs.h
+++ b/lte/gateway/c/core/oai/tasks/mme_app/mme_app_defs.h
@@ -177,6 +177,7 @@ imsi64_t mme_app_handle_initial_paging_request(
     const itti_s11_paging_request_t* paging_req);
 
 int mme_app_handle_paging_timer_expiry(zloop_t* loop, int timer_id, void* args);
+int mme_app_handle_air_timer_expiry(zloop_t* loop, int timer_id, void* args);
 int mme_app_handle_ulr_timer_expiry(zloop_t* loop, int timer_id, void* args);
 
 int mme_app_handle_sgs_eps_detach_timer_expiry(

--- a/lte/gateway/c/core/oai/tasks/nas/emm/Authentication.c
+++ b/lte/gateway/c/core/oai/tasks/nas/emm/Authentication.c
@@ -52,6 +52,8 @@
 #include "security_types.h"
 #include "intertask_interface.h"
 #include "nas_proc.h"
+#include "mme_app_defs.h"
+#include "mme_app_timer.h"
 
 /****************************************************************************/
 /****************  E X T E R N A L    D E F I N I T I O N S  ****************/
@@ -105,9 +107,6 @@ static void nas_itti_auth_info_req(
     const bool is_initial_reqP, plmn_t* const visited_plmnP,
     const uint8_t num_vectorsP, const_bstring const auts_pP,
     const uint8_t dcnr);
-
-static void s6a_auth_info_rsp_timer_expiry_handler(
-    void* args, imsi64_t* imsi64);
 
 /****************************************************************************/
 /******************  E X P O R T E D    F U N C T I O N S  ******************/
@@ -353,12 +352,11 @@ static int start_authentication_information_procedure(
       &auth_proc->emm_com_proc.emm_proc.base_proc;
   auth_proc->emm_com_proc.emm_proc.base_proc.child =
       &auth_info_proc->cn_proc.base_proc;
-  auth_info_proc->success_notif = auth_info_proc_success_cb;
-  auth_info_proc->failure_notif = auth_info_proc_failure_cb;
-  auth_info_proc->cn_proc.base_proc.time_out =
-      s6a_auth_info_rsp_timer_expiry_handler;
-  auth_info_proc->ue_id  = ue_id;
-  auth_info_proc->resync = auth_info_proc->request_sent;
+  auth_info_proc->success_notif              = auth_info_proc_success_cb;
+  auth_info_proc->failure_notif              = auth_info_proc_failure_cb;
+  auth_info_proc->cn_proc.base_proc.time_out = mme_app_handle_air_timer_expiry;
+  auth_info_proc->ue_id                      = ue_id;
+  auth_info_proc->resync                     = auth_info_proc->request_sent;
 
   plmn_t visited_plmn = {0};
   COPY_PLMN(visited_plmn, emm_context->originating_tai.plmn);
@@ -367,7 +365,7 @@ static int start_authentication_information_procedure(
   auth_info_proc->request_sent = true;
   nas_start_Ts6a_auth_info(
       auth_info_proc->ue_id, &auth_info_proc->timer_s6a,
-      auth_info_proc->cn_proc.base_proc.time_out, emm_context);
+      auth_info_proc->cn_proc.base_proc.time_out);
 
   nas_itti_auth_info_req(
       ue_id, &emm_context->_imsi, is_initial_req, &visited_plmn,
@@ -1015,10 +1013,9 @@ status_code_e emm_proc_authentication_complete(
  */
 
 void set_callbacks_for_auth_info_proc(nas_auth_info_proc_t* auth_info_proc) {
-  auth_info_proc->success_notif = auth_info_proc_success_cb;
-  auth_info_proc->failure_notif = auth_info_proc_failure_cb;
-  auth_info_proc->cn_proc.base_proc.time_out =
-      s6a_auth_info_rsp_timer_expiry_handler;
+  auth_info_proc->success_notif              = auth_info_proc_success_cb;
+  auth_info_proc->failure_notif              = auth_info_proc_failure_cb;
+  auth_info_proc->cn_proc.base_proc.time_out = mme_app_handle_air_timer_expiry;
 }
 
 void set_callbacks_for_auth_proc(nas_emm_auth_proc_t* auth_proc) {
@@ -1562,7 +1559,7 @@ static void nas_itti_auth_info_req(
 
 /************************************************************************
  **                                                                    **
- ** Name:    _s6a_auth_info_rsp_timer_expiry_handler                    **
+ ** Name:    mme_app_handle_air_timer_expiry                    **
  **                                                                    **
  ** Description:                                                       **
  **      The timer is used for monitoring Auth Response from HSS       **
@@ -1572,33 +1569,46 @@ static void nas_itti_auth_info_req(
  ** Inputs:  args:      handler parameters                             **
  **                                                                    **
  ************************************************************************/
-static void s6a_auth_info_rsp_timer_expiry_handler(
-    void* args, imsi64_t* imsi64) {
+status_code_e mme_app_handle_air_timer_expiry(
+    zloop_t* loop, int timer_id, void* args) {
   OAILOG_FUNC_IN(LOG_NAS_EMM);
-  emm_context_t* emm_ctx = (emm_context_t*) (args);
+
+  mme_ue_s1ap_id_t mme_ue_s1ap_id = 0;
+  if (!mme_app_get_timer_arg(timer_id, &mme_ue_s1ap_id)) {
+    OAILOG_WARNING(
+        LOG_NAS_EMM, "Invalid Timer Id expiration, Timer Id: %u\n", timer_id);
+    OAILOG_FUNC_RETURN(LOG_NAS_EMM, RETURNok);
+  }
+  struct ue_mm_context_s* ue_context_p = mme_app_get_ue_context_for_timer(
+      mme_ue_s1ap_id, "Mobile reachability timer");
+  if (ue_context_p == NULL) {
+    OAILOG_ERROR(
+        LOG_MME_APP,
+        "Invalid UE context received, MME UE S1AP Id: " MME_UE_S1AP_ID_FMT "\n",
+        mme_ue_s1ap_id);
+    OAILOG_FUNC_RETURN(LOG_NAS_EMM, RETURNok);
+  }
+
+  emm_context_t* emm_ctx = &ue_context_p->emm_context;
 
   if (emm_ctx) {
     nas_auth_info_proc_t* auth_info_proc =
         get_nas_cn_procedure_auth_info(emm_ctx);
     if (!auth_info_proc) {
-      OAILOG_FUNC_OUT(LOG_NAS_EMM);
+      OAILOG_FUNC_RETURN(LOG_NAS_EMM, RETURNok);
     }
-    *imsi64                   = emm_ctx->_imsi64;
-    void* timer_callback_args = NULL;
-    nas_stop_Ts6a_auth_info(
-        auth_info_proc->ue_id, &auth_info_proc->timer_s6a, timer_callback_args);
 
     auth_info_proc->timer_s6a.id = NAS_TIMER_INACTIVE_ID;
     if (auth_info_proc->resync) {
       OAILOG_ERROR_UE(
-          LOG_NAS_EMM, *imsi64,
+          LOG_NAS_EMM, ue_context_p->emm_context._imsi64,
           "EMM-PROC  - Timer timer_s6_auth_info_rsp expired. Resync auth "
           "procedure was in progress. Aborting attach procedure. UE "
           "id " MME_UE_S1AP_ID_FMT "\n",
           auth_info_proc->ue_id);
     } else {
       OAILOG_ERROR_UE(
-          LOG_NAS_EMM, *imsi64,
+          LOG_NAS_EMM, ue_context_p->emm_context._imsi64,
           "EMM-PROC  - Timer timer_s6_auth_info_rsp expired. Initial auth "
           "procedure was in progress. Aborting attach procedure. UE "
           "id " MME_UE_S1AP_ID_FMT "\n",
@@ -1610,9 +1620,10 @@ static void s6a_auth_info_rsp_timer_expiry_handler(
   } else {
     OAILOG_ERROR(
         LOG_NAS_EMM,
-        "EMM-PROC  - Timer timer_s6_auth_info_rsp expired. Null EMM Context "
+        "EMM-PROC  - Timer Authentication Info Request expired. Null EMM "
+        "Context "
         "for "
         "UE \n");
   }
-  OAILOG_FUNC_OUT(LOG_NAS_EMM);
+  OAILOG_FUNC_RETURN(LOG_NAS_EMM, RETURNok);
 }

--- a/lte/gateway/c/core/oai/tasks/nas/emm/Authentication.c
+++ b/lte/gateway/c/core/oai/tasks/nas/emm/Authentication.c
@@ -1580,7 +1580,7 @@ status_code_e mme_app_handle_air_timer_expiry(
     OAILOG_FUNC_RETURN(LOG_NAS_EMM, RETURNok);
   }
   struct ue_mm_context_s* ue_context_p = mme_app_get_ue_context_for_timer(
-      mme_ue_s1ap_id, "Mobile reachability timer");
+      mme_ue_s1ap_id, "Authentication Info Request Timer");
   if (ue_context_p == NULL) {
     OAILOG_ERROR(
         LOG_MME_APP,

--- a/lte/gateway/c/core/oai/tasks/nas/emm/emm_data.h
+++ b/lte/gateway/c/core/oai/tasks/nas/emm/emm_data.h
@@ -570,10 +570,7 @@ void nas_stop_T3470(
     void* timer_callback_args);
 void nas_start_Ts6a_auth_info(
     const mme_ue_s1ap_id_t ue_id, struct nas_timer_s* const Ts6a_auth_info,
-    time_out_t time_out_cb, void* timer_callback_args);
-void nas_stop_Ts6a_auth_info(
-    const mme_ue_s1ap_id_t ue_id, struct nas_timer_s* const Ts6a_auth_info,
-    void* timer_callback_args);
+    time_out_t time_out_cb);
 void emm_init_context(
     struct emm_context_s* const emm_ctx, const bool init_esm_ctxt)
     __attribute__((nonnull));

--- a/lte/gateway/c/core/oai/tasks/nas/emm/emm_data_ctx.c
+++ b/lte/gateway/c/core/oai/tasks/nas/emm/emm_data_ctx.c
@@ -50,6 +50,7 @@
 #include "nas_procedures.h"
 #include "nas_timer.h"
 #include "nas/securityDef.h"
+#include "intertask_interface.h"
 
 //------------------------------------------------------------------------------
 mme_ue_s1ap_id_t emm_ctx_get_new_ue_id(const emm_context_t* const ctxt) {
@@ -1018,10 +1019,10 @@ void nas_start_T3470(
 //------------------------------------------------------------------------------
 void nas_start_Ts6a_auth_info(
     const mme_ue_s1ap_id_t ue_id, struct nas_timer_s* const Ts6a_auth_info,
-    time_out_t time_out_cb, void* timer_callback_args) {
+    time_out_t time_out_cb) {
   if ((Ts6a_auth_info) && (Ts6a_auth_info->id == NAS_TIMER_INACTIVE_ID)) {
-    Ts6a_auth_info->id = nas_timer_start(
-        Ts6a_auth_info->sec, 0, time_out_cb, timer_callback_args);
+    Ts6a_auth_info->id = mme_app_start_timer(
+        Ts6a_auth_info->sec * 1000, TIMER_REPEAT_ONCE, time_out_cb, ue_id);
     if (NAS_TIMER_INACTIVE_ID != Ts6a_auth_info->id) {
       OAILOG_DEBUG(
           LOG_NAS_EMM, "Ts6a_auth_info started UE " MME_UE_S1AP_ID_FMT "\n",
@@ -1063,19 +1064,6 @@ void nas_stop_T3470(
     T3470->id = nas_timer_stop(T3470->id, &timer_callback_args);
     OAILOG_DEBUG(
         LOG_NAS_EMM, "T3470 stopped UE " MME_UE_S1AP_ID_FMT "\n", ue_id);
-  }
-}
-
-//------------------------------------------------------------------------------
-void nas_stop_Ts6a_auth_info(
-    const mme_ue_s1ap_id_t ue_id, struct nas_timer_s* const Ts6a_auth_info,
-    void* timer_callback_args) {
-  if ((Ts6a_auth_info) && (Ts6a_auth_info->id != NAS_TIMER_INACTIVE_ID)) {
-    Ts6a_auth_info->id =
-        nas_timer_stop(Ts6a_auth_info->id, &timer_callback_args);
-    OAILOG_DEBUG(
-        LOG_NAS_EMM, "Ts6a_auth_info stopped UE " MME_UE_S1AP_ID_FMT "\n",
-        ue_id);
   }
 }
 

--- a/lte/gateway/c/core/oai/tasks/nas/nas_procedures.c
+++ b/lte/gateway/c/core/oai/tasks/nas/nas_procedures.c
@@ -494,11 +494,7 @@ static void nas_delete_auth_info_procedure(
     struct emm_context_s* emm_context, nas_auth_info_proc_t** auth_info_proc) {
   if (*auth_info_proc) {
     if ((*auth_info_proc)->timer_s6a.id != NAS_TIMER_INACTIVE_ID) {
-      void* timer_callback_args = NULL;
-      nas_stop_Ts6a_auth_info(
-          (*auth_info_proc)->ue_id, &(*auth_info_proc)->timer_s6a,
-          timer_callback_args);
-
+      mme_app_stop_timer((*auth_info_proc)->timer_s6a.id);
       (*auth_info_proc)->timer_s6a.id = NAS_TIMER_INACTIVE_ID;
     }
 

--- a/lte/gateway/c/core/oai/tasks/s1ap/s1ap_state_manager.cpp
+++ b/lte/gateway/c/core/oai/tasks/s1ap/s1ap_state_manager.cpp
@@ -94,8 +94,7 @@ void S1apStateManager::create_state() {
 
 void free_s1ap_state(s1ap_state_t* state_cache_p) {
   AssertFatal(
-      state_cache_p,
-      "s1ap_state_t passed to free_s1ap_state must not be null");
+      state_cache_p, "s1ap_state_t passed to free_s1ap_state must not be null");
 
   int i;
   hashtable_rc_t ht_rc;


### PR DESCRIPTION
Signed-off-by: Ulas Kozat <kozat@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->
We have moved many of the timers in mme code to ZMQ but few timers are remaining. The PR migrates Authentication Information Request (AIR) timer.

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->
Sanity tests.

Emulate timeouts from subscriberdb.
```
000346 Tue Aug 24 07:22:16 2021 7F8511DAB700 INFO  NAS-EM tasks/nas/emm/Authentication.c  :1495                                 Sending Authentication Information Request message to S6A for ue_id = 95
000347 Tue Aug 24 07:22:16 2021 7F850DCE3700 INFO  S6A    common/common_utility_funs.cpp  :0054   [1010000000001] PLMN is not configured. Selecting default mode: SPGW_SUBSCRIBER 
000348 Tue Aug 24 07:22:19 2021 7F8511DAB700 INFO  MME-AP tasks/mme_app/mme_app_bearer.c  :4095         Expired- Authentication Info Request Timer for ue_id 95
000349 Tue Aug 24 07:22:19 2021 7F8511DAB700 ERROR NAS-EM tasks/nas/emm/Authentication.c  :1610   [1010000000001]      EMM-PROC  - Timer timer_s6_auth_info_rsp expired. Initial auth procedure was in progress. Aborting attach procedure. UE id 95
000350 Tue Aug 24 07:22:19 2021 7F8511DAB700 INFO  NAS-EM tasks/nas/emm/sap/emm_cn.c      :1158                  EMMCN-SAP - Received primitive EMM_CN_AUTHENTICATION_PARAM_FAIL (402)
000351 Tue Aug 24 07:22:19 2021 7F8511DAB700 ERROR NAS-EM tasks/nas/emm/Attach.c          :1304   [1010000000001]                        ATTACH - Authentication procedure failed!
```

Additional unit test coverage will be addressed once the PR #8487 lands.

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
