### PR TITLE
[lte][agw] fix aiohttpd debian dependency

### DIFF
--- a/lte/gateway/release/magma.lockfile.debian
+++ b/lte/gateway/release/magma.lockfile.debian
@@ -20,9 +20,9 @@
     },
     "aiohttp": {
       "root": true,
-      "source": "apt",
+      "source": "pypi",
       "sysdep": "python3-aiohttp",
-      "version": "1.2.0"
+      "version": "3.6.3"
     },
     "argparse": {
       "root": false,


### PR DESCRIPTION
<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

magma has a python dep of aiohttp=3.6.3, but aiohttp is fetched 1.2.0 is fetched from stretch apt repo.
<!-- Enumerate changes you made and why you made them -->

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
