### PR TITLE
chore(mme): Adding service303 log level config

### DIFF
--- a/lte/gateway/c/core/oai/common/log.c
+++ b/lte/gateway/c/core/oai/common/log.c
@@ -504,6 +504,9 @@ void log_configure(const log_config_t* const config) {
   if ((MAX_LOG_LEVEL > config->async_system_log_level) &&
       (MIN_LOG_LEVEL <= config->async_system_log_level))
     g_oai_log.log_level[LOG_ASYNC_SYSTEM] = config->async_system_log_level;
+  if ((MAX_LOG_LEVEL > config->service303_log_level) &&
+      (MIN_LOG_LEVEL <= config->service303_log_level))
+    g_oai_log.log_level[LOG_SERVICE303] = config->service303_log_level;
   g_oai_log.is_async      = config->is_output_thread_safe;
   g_oai_log.is_ansi_codes = config->color;
   log_init_handler(g_oai_log.is_async);

--- a/lte/gateway/c/core/oai/common/log.h
+++ b/lte/gateway/c/core/oai/common/log.h
@@ -125,6 +125,7 @@ extern int fd_g_debug_lvl;
 #define LOG_CONFIG_STRING_OUTPUT_THREAD_SAFE "THREAD_SAFE"
 #define LOG_CONFIG_STRING_UDP_LOG_LEVEL "UDP_LOG_LEVEL"
 #define LOG_CONFIG_STRING_UTIL_LOG_LEVEL "UTIL_LOG_LEVEL"
+#define LOG_CONFIG_STRING_SERVICE303_LOG_LEVEL "SERVICE303_LOG_LEVEL"
 #define LOG_CONFIG_STRING_SGS_LOG_LEVEL "SGS_LOG_LEVEL"
 #define LOG_CONFIG_STRING_NGAP_LOG_LEVEL "NGAP_LOG_LEVEL"
 #define LOG_CONFIG_STRING_AMF_APP_LOG_LEVEL "AMF_APP_LOG_LEVEL"
@@ -269,6 +270,9 @@ typedef struct log_config_s {
   log_level_t
       itti_log_level; /*!< \brief ITTI layer log level starting from
                          OAILOG_LEVEL_EMERGENCY up to MAX_LOG_LEVEL (no log) */
+  log_level_t
+      service303_log_level; /*!< \brief Service303 log level starting from
+                  OAILOG_LEVEL_EMERGENCY up to MAX_LOG_LEVEL (no log) */
   log_level_t
       sgs_log_level;            /*!< \brief SGS layer log level starting from
                                    OAILOG_LEVEL_EMERGENCY up to MAX_LOG_LEVEL (no log) */

--- a/lte/gateway/c/core/oai/tasks/mme_app/mme_config.c
+++ b/lte/gateway/c/core/oai/tasks/mme_app/mme_config.c
@@ -134,6 +134,7 @@ void log_config_init(log_config_t* log_conf) {
   log_conf->util_log_level       = MAX_LOG_LEVEL;
   log_conf->itti_log_level       = MAX_LOG_LEVEL;
   log_conf->spgw_app_log_level   = MAX_LOG_LEVEL;
+  log_conf->service303_log_level = MAX_LOG_LEVEL;
   log_conf->asn1_verbosity_level = 0;
 }
 
@@ -442,6 +443,12 @@ int mme_config_parse_file(mme_config_t* config_pP) {
               setting, LOG_CONFIG_STRING_ITTI_LOG_LEVEL,
               (const char**) &astring))
         config_pP->log_config.itti_log_level = OAILOG_LEVEL_STR2INT(astring);
+
+      if (config_setting_lookup_string(
+              setting, LOG_CONFIG_STRING_SERVICE303_LOG_LEVEL,
+              (const char**) &astring))
+        config_pP->log_config.service303_log_level =
+            OAILOG_LEVEL_STR2INT(astring);
 #if EMBEDDED_SGW
       if (config_setting_lookup_string(
               setting, LOG_CONFIG_STRING_GTPV1U_LOG_LEVEL,

--- a/lte/gateway/c/core/oai/tasks/s1ap/s1ap_state_manager.cpp
+++ b/lte/gateway/c/core/oai/tasks/s1ap/s1ap_state_manager.cpp
@@ -94,8 +94,7 @@ void S1apStateManager::create_state() {
 
 void free_s1ap_state(s1ap_state_t* state_cache_p) {
   AssertFatal(
-      state_cache_p,
-      "s1ap_state_t passed to free_s1ap_state must not be null");
+      state_cache_p, "s1ap_state_t passed to free_s1ap_state must not be null");
 
   int i;
   hashtable_rc_t ht_rc;

--- a/lte/gateway/configs/templates/mme.conf.template
+++ b/lte/gateway/configs/templates/mme.conf.template
@@ -280,6 +280,7 @@ MME :
         S11_LOG_LEVEL      = "{{ oai_log_level }}";
         S6A_LOG_LEVEL      = "{{ oai_log_level }}";
         UTIL_LOG_LEVEL     = "{{ oai_log_level }}";
+        SERVICE303_LOG_LEVEL     = "{{ oai_log_level }}";
         MSC_LOG_LEVEL      = "ERROR";
         ITTI_LOG_LEVEL     = "ERROR";
         MME_SCENARIO_PLAYER_LOG_LEVEL = "ERROR";


### PR DESCRIPTION
Signed-off-by: Alex Rodriguez <ardzoht@gmail.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->
- Adds log level configuration for service303 task on `mme.conf`
- Currently it is default to DEBUG level, and it is not controlled by config, all service303 task logging is ignoring the log level configuration for mme  service

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->
- Running make run on magma vm
- Ensuring service303 DEBUG is not being logged when mme config log level is set to INFO

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
