### PR TITLE
feat(amf): Registration Reject with cause: UEIllegal

### DIFF
--- a/lte/gateway/c/core/oai/lib/3gpp/3gpp_24.501.h
+++ b/lte/gateway/c/core/oai/lib/3gpp/3gpp_24.501.h
@@ -96,6 +96,8 @@ Deregistration accept (UE terminated) */
 #define AMF_UE_SECURITY_CAPABILITIES_MISMATCH                                  \
   23  // UE security capabilities mismatch
 #define AMF_SECURITY_MODE_REJECT 24
+#define AMF_CAUSE_LENGTH 1
+#define AMF_UE_ILLEGAL 3
 
 /* 5G Timer structure */
 typedef struct nas5g_timer_s {

--- a/lte/gateway/c/core/oai/tasks/amf/amf_authentication.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_authentication.cpp
@@ -510,6 +510,8 @@ int amf_proc_authentication_complete(
         LOG_NAS_AMF,
         "AMF-PROC - Failed to authenticate the UE due to NULL"
         "ue_mm_context\n");
+    amf_cause = AMF_UE_ILLEGAL;
+    rc        = amf_proc_registration_reject(ue_id, amf_cause);
     OAILOG_FUNC_RETURN(LOG_NAS_AMF, rc);
   }
 

--- a/lte/gateway/c/core/oai/tasks/amf/nas_proc.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/nas_proc.cpp
@@ -30,6 +30,7 @@ extern "C" {
 #include "amf_authentication.h"
 #include "amf_sap.h"
 #include "amf_app_timer_management.h"
+#include "amf_recv.h"
 
 extern amf_config_t amf_config;
 namespace magma5g {
@@ -409,6 +410,7 @@ int amf_nas_proc_authentication_info_answer(
   int rc                                = RETURNerror;
   amf_context_t* amf_ctxt_p             = NULL;
   ue_m5gmm_context_s* ue_5gmm_context_p = NULL;
+  int amf_cause                         = -1;
   OAILOG_FUNC_IN(LOG_AMF_APP);
 
   IMSI_STRING_TO_IMSI64((char*) aia->imsi, &imsi64);
@@ -454,7 +456,11 @@ int amf_nas_proc_authentication_info_answer(
         amf_ue_ngap_id, aia->auth_info.nb_of_vectors,
         aia->auth_info.m5gauth_vector);
   } else {
-    // TODO ... Handle the failure case
+    OAILOG_ERROR(
+        LOG_NAS_AMF, "nb_of_vectors received is zero from subscriberdb");
+    amf_cause = AMF_UE_ILLEGAL;
+    rc        = amf_proc_registration_reject(amf_ue_ngap_id, amf_cause);
+    OAILOG_FUNC_RETURN(LOG_NAS_AMF, rc);
   }
 
   OAILOG_FUNC_RETURN(LOG_NAS_AMF, rc);


### PR DESCRIPTION
Signed-off-by: Kaleemullah Mohammed <kaleemullah.mohammed@wavelabs.ai>

Tested with:
1) Registration Reject message with cause Cause 3 – Illegal UE for authentication vector failure from subscriber db with no/wrong IMSI configuration 
2) For sync failure response from subscriber db

## Summary

<!-- Enumerate changes you made and why you made them -->

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
![ueillegal](https://user-images.githubusercontent.com/83354949/130588041-fa21ca37-3a13-4825-a241-91e2651e5b4c.jpg)

