### PR TITLE
fix(agw): Handle empty ctx descriptor for soap messages

### DIFF
--- a/lte/gateway/python/magma/enodebd/tr069/spyne_mods.py
+++ b/lte/gateway/python/magma/enodebd/tr069/spyne_mods.py
@@ -146,7 +146,7 @@ class Tr069Soap11(Soap11):
         # it still has a stale value.
         # Force repopulation of dictionary by deleting entry
         # TODO Remove this code once we have a better fix
-        if (ctx.descriptor.out_message in self._attrcache):
+        if (ctx.descriptor and ctx.descriptor.out_message in self._attrcache):
             del self._attrcache[ctx.descriptor.out_message]  # noqa: WPS529
 
         super(Tr069Soap11, self).serialize(ctx, message)


### PR DESCRIPTION
## Summary
In certain cases like empty HTTP ok messages the ctxt descriptor itself
might be None. Add a check for this case before dereferencing out_message

## Test Plan
Saw failures before fix.
make test_python

Signed-off-by: Amar Padmanabhan <amar@freedomfi.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->



<!-- Enumerate changes you made and why you made them -->



<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
