### PR TITLE
feat(orc8r): orc8r cost reduction

### DIFF
--- a/experimental/cloudstrapper/playbooks/roles/control/templates/main.tf.j2.poc
+++ b/experimental/cloudstrapper/playbooks/roles/control/templates/main.tf.j2.poc
@@ -13,10 +13,11 @@
 
 # instances price $0.2564/hour
 # 55 % cheaper than production
+# eks instance costs: $0.1664/hour 33 % cheaper than 3 t3.large
+# db instance cost: $0.018/hour 89 % cheaper than m4/m5 large
+# elastic search cost: $0.072/hour  51 % cheaper
 module "orc8r" {
 
-  # 33 % cheaper than 3 t3.large
-  # cost $0.1664/hour
   eks_worker_groups =[ {
         name                 = "wg-1"
         instance_type        = "t3.small"
@@ -33,8 +34,6 @@ module "orc8r" {
 
   region = "{{ awsOrc8rRegion }}"
 
-  # $0.018/hour
-  # 89 % cheaper than m4/m5 large
   orc8r_db_password           = "{{ orc8rDbPassword }}" # must be at least 8 characters
   orc8r_db_instance_class     = "db.t3.micro"
 
@@ -47,8 +46,6 @@ module "orc8r" {
   cluster_name = "{{ orc8rTfCluster }}"
   cluster_version = "1.17"
 
-  # 51 % cheaper
-  # $0.072/hour
   deploy_elasticsearch          = true
   elasticsearch_domain_name     = "{{ orc8rTfEs }}"
   elasticsearch_version         = "7.7"

--- a/experimental/cloudstrapper/playbooks/roles/control/templates/main.tf.j2.poc
+++ b/experimental/cloudstrapper/playbooks/roles/control/templates/main.tf.j2.poc
@@ -1,0 +1,111 @@
+################################################################################
+# Copyright 2020 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+# instances price $0.2564/hour
+# 55 % cheaper than production
+module "orc8r" {
+
+  # 33 % cheaper than 3 t3.large
+  # cost $0.1664/hour
+
+  eks_worker_groups =[ {
+        name                 = "wg-1"
+        instance_type        = "t3.small"
+        asg_desired_capacity = 8
+        asg_min_size         = 1
+        asg_max_size         = 8
+        autoscaling_enabled  = false
+        kubelet_extra_args = "" // object types must be identical (see thanos_worker_groups)
+  }]
+  # Specify arm based ami as t4g instance types are arm based
+  # eks_worker_ami = "amazon-eks-arm64-node-1.17-v20210722"
+  # Change this to pull from github with a specified ref
+  source = "{{ orc8rSource }}"
+
+  region = "{{ awsOrc8rRegion }}"
+
+  # 89 % cheaper than m4/m5 large
+  # $0.018
+  orc8r_db_password           = "{{ orc8rDbPassword }}" # must be at least 8 characters
+  secretsmanager_orc8r_secret = "{{ orc8rTfSecrets }}"
+  orc8r_domain_name           = "{{ orc8rDomainName }}"
+  orc8r_db_instance_class     = "db.t3.micro"
+
+
+  vpc_name     = "{{ orc8rTfVpc }}"
+  cluster_name = "{{ orc8rTfCluster }}"
+  cluster_version = "1.17"
+
+  # 51 % cheaper
+  # 0.072
+  deploy_elasticsearch          = true
+  elasticsearch_domain_name     = "{{ orc8rTfEs }}"
+  elasticsearch_version         = "7.7"
+  elasticsearch_instance_type   = "t3.small.elasticsearch"
+  elasticsearch_instance_count  = 2
+  elasticsearch_az_count        = 2
+  elasticsearch_ebs_enabled     = true
+  elasticsearch_ebs_volume_size = 32
+  elasticsearch_ebs_volume_type = "gp2"
+
+  deploy_elasticsearch_service_linked_role = "{{ varFirstInstall }}"
+
+}
+
+module "orc8r-app" {
+  source = "{{ orc8rAppSource }}"
+
+  region = "{{ awsOrc8rRegion }}"
+
+  orc8r_domain_name     = module.orc8r.orc8r_domain_name
+  orc8r_route53_zone_id = module.orc8r.route53_zone_id
+  external_dns_role_arn = module.orc8r.external_dns_role_arn
+
+  secretsmanager_orc8r_name = module.orc8r.secretsmanager_secret_name
+  seed_certs_dir            = "{{ dirSecretsLocal }}"
+
+  orc8r_db_host    = module.orc8r.orc8r_db_host
+  orc8r_db_port    = module.orc8r.orc8r_db_port
+  orc8r_db_dialect = module.orc8r.orc8r_db_dialect
+  orc8r_db_name    = module.orc8r.orc8r_db_name
+  orc8r_db_user    = module.orc8r.orc8r_db_user
+  orc8r_db_pass    = module.orc8r.orc8r_db_pass
+
+  # Note that this can be any container registry provider -- the example below
+  # provides the URL format for Docker Hub, where the user and pass are your
+  # Docker Hub username and access token, respectively
+  docker_registry = "docker.artifactory.magmacore.org"
+  docker_user = ""
+  docker_pass = ""
+
+  # Note that this can be any Helm chart repo provider -- the example below
+  # provides the URL format for using a raw GitHub repo, where the user and
+  # pass are your GitHub username and access token, respectively
+  helm_repo = "https://artifactory.magmacore.org/artifactory/helm/"
+  helm_user = ""
+  helm_pass = ""
+
+  eks_cluster_id = module.orc8r.eks_cluster_id
+
+  efs_file_system_id       = module.orc8r.efs_file_system_id
+  efs_provisioner_role_arn = module.orc8r.efs_provisioner_role_arn
+
+  elasticsearch_endpoint = module.orc8r.es_endpoint
+
+  orc8r_deployment_type = "fwa"
+  orc8r_tag           = "{{ orc8rLabel }}"
+}
+
+output "nameservers" {
+  value = module.orc8r.route53_nameservers
+}

--- a/experimental/cloudstrapper/playbooks/roles/control/templates/main.tf.j2.production
+++ b/experimental/cloudstrapper/playbooks/roles/control/templates/main.tf.j2.production
@@ -1,0 +1,104 @@
+################################################################################
+# Copyright 2020 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+# instances prices sum at $0.5736/hour
+module "orc8r" {
+
+  # $0.2496/hour
+  eks_worker_groups = [{
+        name                 = "wg-1"
+        instance_type        = "t3.large"
+        asg_desired_capacity = 3
+        asg_min_size         = 1
+        asg_max_size         = 3
+        autoscaling_enabled  = false
+        kubelet_extra_args = "" // object types must be identical (see thanos_worker_groups)
+  }]
+  # Specify arm based ami as t4g instance types are arm based
+  # eks_worker_ami = "amazon-eks-arm64-node-1.17-v20210722"
+  # Change this to pull from github with a specified ref
+  source = "{{ orc8rSource }}"
+
+  region = "{{ awsOrc8rRegion }}"
+
+  # $0.178/hour
+  orc8r_db_password           = "{{ orc8rDbPassword }}" # must be at least 8 characters
+  secretsmanager_orc8r_secret = "{{ orc8rTfSecrets }}"
+  orc8r_domain_name           = "{{ orc8rDomainName }}"
+  orc8r_db_instance_class     = "db.m5.large"
+
+  vpc_name     = "{{ orc8rTfVpc }}"
+  cluster_name = "{{ orc8rTfCluster }}"
+  cluster_version = "1.17"
+
+  # $0.146/hour
+  deploy_elasticsearch          = true
+  elasticsearch_domain_name     = "{{ orc8rTfEs }}"
+  elasticsearch_version         = "7.7"
+  elasticsearch_instance_type   = "t2.medium.elasticsearch"
+  elasticsearch_instance_count  = 2
+  elasticsearch_az_count        = 2
+  elasticsearch_ebs_enabled     = true
+  elasticsearch_ebs_volume_size = 32
+  elasticsearch_ebs_volume_type = "gp2"
+
+  deploy_elasticsearch_service_linked_role = "{{ varFirstInstall }}"
+
+}
+
+module "orc8r-app" {
+  source = "{{ orc8rAppSource }}"
+
+  region = "{{ awsOrc8rRegion }}"
+
+  orc8r_domain_name     = module.orc8r.orc8r_domain_name
+  orc8r_route53_zone_id = module.orc8r.route53_zone_id
+  external_dns_role_arn = module.orc8r.external_dns_role_arn
+
+  secretsmanager_orc8r_name = module.orc8r.secretsmanager_secret_name
+  seed_certs_dir            = "{{ dirSecretsLocal }}"
+
+  orc8r_db_host    = module.orc8r.orc8r_db_host
+  orc8r_db_port    = module.orc8r.orc8r_db_port
+  orc8r_db_dialect = module.orc8r.orc8r_db_dialect
+  orc8r_db_name    = module.orc8r.orc8r_db_name
+  orc8r_db_user    = module.orc8r.orc8r_db_user
+  orc8r_db_pass    = module.orc8r.orc8r_db_pass
+
+  # Note that this can be any container registry provider -- the example below
+  # provides the URL format for Docker Hub, where the user and pass are your
+  # Docker Hub username and access token, respectively
+  docker_registry = "docker.artifactory.magmacore.org"
+  docker_user = ""
+  docker_pass = ""
+
+  # Note that this can be any Helm chart repo provider -- the example below
+  # provides the URL format for using a raw GitHub repo, where the user and
+  # pass are your GitHub username and access token, respectively
+  helm_repo = "https://artifactory.magmacore.org/artifactory/helm/"
+  helm_user = ""
+  helm_pass = ""
+
+  eks_cluster_id = module.orc8r.eks_cluster_id
+
+  efs_file_system_id       = module.orc8r.efs_file_system_id
+  efs_provisioner_role_arn = module.orc8r.efs_provisioner_role_arn
+
+  elasticsearch_endpoint = module.orc8r.es_endpoint
+
+  orc8r_deployment_type = "fwa"
+  orc8r_tag           = "{{ orc8rLabel }}"
+}
+
+output "nameservers" {
+  value = module.orc8r.route53_nameservers
+}

--- a/experimental/cloudstrapper/playbooks/roles/control/templates/main.tf.j2.production
+++ b/experimental/cloudstrapper/playbooks/roles/control/templates/main.tf.j2.production
@@ -11,9 +11,11 @@
 # limitations under the License.
 ################################################################################
 # instances prices sum at $0.5736/hour
+# eks instance costs: $0.2496/hour
+# db instance cost: $0.178/hour
+# elastic search cost: $0.146/hour
 module "orc8r" {
 
-  # $0.2496/hour
   eks_worker_groups = [{
         name                 = "wg-1"
         instance_type        = "t3.large"
@@ -23,14 +25,12 @@ module "orc8r" {
         autoscaling_enabled  = false
         kubelet_extra_args = "" // object types must be identical (see thanos_worker_groups)
   }]
-  # Specify arm based ami as t4g instance types are arm based
-  # eks_worker_ami = "amazon-eks-arm64-node-1.17-v20210722"
+
   # Change this to pull from github with a specified ref
   source = "{{ orc8rSource }}"
 
   region = "{{ awsOrc8rRegion }}"
 
-  # $0.178/hour
   orc8r_db_password           = "{{ orc8rDbPassword }}" # must be at least 8 characters
   secretsmanager_orc8r_secret = "{{ orc8rTfSecrets }}"
   orc8r_domain_name           = "{{ orc8rDomainName }}"
@@ -40,7 +40,6 @@ module "orc8r" {
   cluster_name = "{{ orc8rTfCluster }}"
   cluster_version = "1.17"
 
-  # $0.146/hour
   deploy_elasticsearch          = true
   elasticsearch_domain_name     = "{{ orc8rTfEs }}"
   elasticsearch_version         = "7.7"

--- a/orc8r/cloud/deploy/terraform/orc8r-helm-aws/examples/poc/main.tf
+++ b/orc8r/cloud/deploy/terraform/orc8r-helm-aws/examples/poc/main.tf
@@ -11,6 +11,11 @@
 # limitations under the License.
 ################################################################################
 
+# instances price $0.2564/hour
+# 55 % cheaper than basic
+# eks instance costs: $0.1664/hour 33 % cheaper than 3 t3.large
+# db instance cost: $0.018/hour 89 % cheaper than m4/m5 large
+# elastic search cost: $0.072/hour  51 % cheaper
 module "orc8r" {
   # Change this to pull from GitHub with a specified ref, e.g.
   # source = "github.com/magma/magma//orc8r/cloud/deploy/terraform/orc8r-aws?ref=v1.6"
@@ -18,8 +23,6 @@ module "orc8r" {
 
   region = "us-west-2"
 
-  # cost $0.1664/hour
-  # 33 % cheaper than 3 t3.large
   eks_worker_groups =[ {
     name                 = "wg-1"
     instance_type        = "t3.small"
@@ -32,8 +35,6 @@ module "orc8r" {
 
   # If you performing a fresh Orc8r install, choose a recent Postgres version
   # orc8r_db_engine_version     = "12.6"
-  # $0.018/hour
-  # 89 % cheaper than m4/m5 large
   orc8r_db_password = "mypassword" # must be at least 8 characters
   orc8r_db_instance_class     = "db.t3.micro"
 
@@ -47,8 +48,6 @@ module "orc8r" {
   cluster_name    = "orc8r"
   cluster_version = "1.17"
 
-  # $0.072/hour
-  # 51 % cheaper than 2 t2.medium
   deploy_elasticsearch          = true
   elasticsearch_domain_name     = "orc8r-es"
   elasticsearch_version         = "7.7"


### PR DESCRIPTION
<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

Create two new sizes of orc8r deployment:
 - poc size ~50 % cheaper (instance price per hour) to deploy
 - production size, same as regular but updated rds instance size to m5.large 

## Test Plan

Successfuly deployed orc8r in aws

## Additional Information

Could not choose smaller eks instance size as there is a limit of pods per instance size here: https://github.com/awslabs/amazon-eks-ami/blob/master/files/eni-max-pods.txt
The ratio of pod/price was more interesting on t3.small than on t3.micro.

t4g instances types are not an option right now as they are arm based and most of helm charts does not behave well on this type of architecture

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
