### PR TITLE
fix(agw): Fix bootstrap failure due to bad Python open args

### DIFF
--- a/orc8r/gateway/python/magma/common/service_registry.py
+++ b/orc8r/gateway/python/magma/common/service_registry.py
@@ -100,7 +100,7 @@ class ServiceRegistry:
         authority = proxy_config['bootstrap_address']
 
         try:
-            rootca = open(proxy_config['rootca_cert'], 'rb', encoding="utf-8").read()
+            rootca = open(proxy_config['rootca_cert'], 'rb').read()
         except FileNotFoundError as exp:
             raise ValueError("SSL cert not found: %s" % exp)
 
@@ -254,7 +254,7 @@ def get_ssl_creds():
     """
     proxy_config = ServiceRegistry.get_proxy_config()
     try:
-        with open(proxy_config['rootca_cert'], 'rb', encoding="utf-8") as rootca_f:
+        with open(proxy_config['rootca_cert'], 'rb') as rootca_f:
             with open(proxy_config['gateway_cert'], encoding="utf-8") as cert_f:
                 with open(proxy_config['gateway_key'], encoding="utf-8") as key_f:
                     rootca = rootca_f.read()


### PR DESCRIPTION
## Summary

Current master's AGW is failing to connect to the controller at all, including to sync subscribers. Root cause is service registry code is broken due to the light refactor introduced in #8720.

This fix reverts the subset of #8720's changes that introduced the bug.

## Test Plan

Before, the root cause log was

```
Aug 24 20:56:56 mpk-dogfooding magmad[3250809]: ERROR:root:Failed to get rpc channel: binary mode doesn't take an encoding argument
```

After, the fix, this log no longer appears, and gateway is able to successfully bootstrap and make its usual requests to the controller.

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->