### PR TITLE
chore(mme): Migrate NAS timers to ZMQ

### DIFF
--- a/lte/gateway/c/core/oai/tasks/mme_app/mme_app_bearer.c
+++ b/lte/gateway/c/core/oai/tasks/mme_app/mme_app_bearer.c
@@ -1962,7 +1962,7 @@ status_code_e mme_app_handle_initial_context_setup_rsp_timer_expiry(
         get_nas_specific_procedure_attach(&ue_context_p->emm_context);
     // Stop T3450 timer if its still runinng
     if (attach_proc) {
-      nas_stop_T3450(attach_proc->ue_id, &attach_proc->T3450, NULL);
+      nas_stop_T3450(attach_proc->ue_id, &attach_proc->T3450);
     }
   }
 

--- a/lte/gateway/c/core/oai/tasks/mme_app/mme_app_defs.h
+++ b/lte/gateway/c/core/oai/tasks/mme_app/mme_app_defs.h
@@ -185,6 +185,8 @@ int mme_app_handle_security_t3460_expiry(
 int mme_app_handle_identification_t3470_expiry(
     zloop_t* loop, int timer_id, void* args);
 int mme_app_handle_tau_t3450_expiry(zloop_t* loop, int timer_id, void* args);
+int mme_app_handle_emm_attach_t3450_expiry(
+    zloop_t* loop, int timer_id, void* args);
 
 int mme_app_handle_sgs_eps_detach_timer_expiry(
     zloop_t* loop, int timer_id, void* args);

--- a/lte/gateway/c/core/oai/tasks/mme_app/mme_app_defs.h
+++ b/lte/gateway/c/core/oai/tasks/mme_app/mme_app_defs.h
@@ -179,6 +179,12 @@ imsi64_t mme_app_handle_initial_paging_request(
 int mme_app_handle_paging_timer_expiry(zloop_t* loop, int timer_id, void* args);
 int mme_app_handle_air_timer_expiry(zloop_t* loop, int timer_id, void* args);
 int mme_app_handle_ulr_timer_expiry(zloop_t* loop, int timer_id, void* args);
+int mme_app_handle_auth_t3460_expiry(zloop_t* loop, int timer_id, void* args);
+int mme_app_handle_security_t3460_expiry(
+    zloop_t* loop, int timer_id, void* args);
+int mme_app_handle_identification_t3470_expiry(
+    zloop_t* loop, int timer_id, void* args);
+int mme_app_handle_tau_t3450_expiry(zloop_t* loop, int timer_id, void* args);
 
 int mme_app_handle_sgs_eps_detach_timer_expiry(
     zloop_t* loop, int timer_id, void* args);

--- a/lte/gateway/c/core/oai/tasks/nas/emm/Attach.c
+++ b/lte/gateway/c/core/oai/tasks/nas/emm/Attach.c
@@ -967,7 +967,7 @@ status_code_e mme_app_handle_emm_attach_t3450_expiry(
   }
 
   struct ue_mm_context_s* ue_context_p = mme_app_get_ue_context_for_timer(
-      mme_ue_s1ap_id, "Authentication T3460 Timer");
+      mme_ue_s1ap_id, "Attach Procedure T3450 Timer");
   if (ue_context_p == NULL) {
     OAILOG_ERROR(
         LOG_MME_APP,

--- a/lte/gateway/c/core/oai/tasks/nas/emm/Attach.c
+++ b/lte/gateway/c/core/oai/tasks/nas/emm/Attach.c
@@ -1951,11 +1951,10 @@ static int emm_send_attach_accept(emm_context_t* emm_context) {
       /*
        * Start T3450 timer
        */
-      nas_stop_T3450(attach_proc->ue_id, &attach_proc->T3450, NULL);
+      nas_stop_T3450(attach_proc->ue_id, &attach_proc->T3450);
       nas_start_T3450(
           attach_proc->ue_id, &attach_proc->T3450,
-          attach_proc->emm_spec_proc.emm_proc.base_proc.time_out,
-          (void*) emm_context);
+          attach_proc->emm_spec_proc.emm_proc.base_proc.time_out);
       attach_proc->attach_accept_sent++;
     }
   } else {
@@ -2106,11 +2105,10 @@ static int emm_attach_accept_retx(emm_context_t* emm_context) {
       /*
        * Re-start T3450 timer
        */
-      nas_stop_T3450(ue_id, &attach_proc->T3450, NULL);
+      nas_stop_T3450(ue_id, &attach_proc->T3450);
       nas_start_T3450(
           ue_id, &attach_proc->T3450,
-          attach_proc->emm_spec_proc.emm_proc.base_proc.time_out,
-          (void*) emm_context);
+          attach_proc->emm_spec_proc.emm_proc.base_proc.time_out);
       OAILOG_INFO(
           LOG_NAS_EMM,
           "ue_id=" MME_UE_S1AP_ID_FMT

--- a/lte/gateway/c/core/oai/tasks/nas/emm/Attach.c
+++ b/lte/gateway/c/core/oai/tasks/nas/emm/Attach.c
@@ -99,6 +99,8 @@
 #include "EpsNetworkFeatureSupport.h"
 #include "TrackingAreaIdentity.h"
 #include "TrackingAreaIdentityList.h"
+#include "mme_app_defs.h"
+#include "mme_app_timer.h"
 
 /****************************************************************************/
 /****************  E X T E R N A L    D E F I N I T I O N S  ****************/
@@ -117,10 +119,6 @@ static const char* emm_attach_type_str[] = {"EPS", "IMSI", "EMERGENCY",
         Internal data handled by the attach procedure in the MME
    --------------------------------------------------------------------------
 */
-/*
-   Timer handlers
-*/
-static void emm_attach_t3450_handler(void*, imsi64_t* imsi64);
 
 /*
    Functions that may initiate EMM common procedures
@@ -889,9 +887,10 @@ status_code_e emm_proc_attach_complete(
  */
 
 void set_callbacks_for_attach_proc(nas_emm_attach_proc_t* attach_proc) {
-  ((nas_base_proc_t*) attach_proc)->abort    = emm_attach_abort;
-  ((nas_base_proc_t*) attach_proc)->fail_in  = NULL;
-  ((nas_base_proc_t*) attach_proc)->time_out = emm_attach_t3450_handler;
+  ((nas_base_proc_t*) attach_proc)->abort   = emm_attach_abort;
+  ((nas_base_proc_t*) attach_proc)->fail_in = NULL;
+  ((nas_base_proc_t*) attach_proc)->time_out =
+      mme_app_handle_emm_attach_t3450_expiry;
   ((nas_base_proc_t*) attach_proc)->fail_out = _emm_attach_reject;
 }
 
@@ -919,11 +918,12 @@ static void emm_proc_create_procedure_attach_request(
       nas_new_attach_procedure(&ue_mm_context->emm_context);
   AssertFatal(attach_proc, "TODO Handle this");
   if ((attach_proc)) {
-    attach_proc->ies                           = ies;
-    attach_proc->ue_id                         = ue_mm_context->mme_ue_s1ap_id;
-    ((nas_base_proc_t*) attach_proc)->abort    = emm_attach_abort;
-    ((nas_base_proc_t*) attach_proc)->fail_in  = NULL;  // No parent procedure
-    ((nas_base_proc_t*) attach_proc)->time_out = emm_attach_t3450_handler;
+    attach_proc->ies                          = ies;
+    attach_proc->ue_id                        = ue_mm_context->mme_ue_s1ap_id;
+    ((nas_base_proc_t*) attach_proc)->abort   = emm_attach_abort;
+    ((nas_base_proc_t*) attach_proc)->fail_in = NULL;  // No parent procedure
+    ((nas_base_proc_t*) attach_proc)->time_out =
+        mme_app_handle_emm_attach_t3450_expiry;
     ((nas_base_proc_t*) attach_proc)->fail_out = _emm_attach_reject;
   }
 }
@@ -935,7 +935,7 @@ static void emm_proc_create_procedure_attach_request(
 
 /*
  *
- * Name:    _emm_attach_t3450_handler()
+ * Name:    mme_app_handle_emm_attach_t3450_expiry
  *
  * Description: T3450 timeout handler
  *
@@ -955,13 +955,29 @@ static void emm_proc_create_procedure_attach_request(
  *      Others:    None
  *
  */
-static void emm_attach_t3450_handler(void* args, imsi64_t* imsi64) {
+status_code_e mme_app_handle_emm_attach_t3450_expiry(
+    zloop_t* loop, int timer_id, void* args) {
   OAILOG_FUNC_IN(LOG_NAS_EMM);
-  emm_context_t* emm_context = (emm_context_t*) (args);
 
-  if (emm_context) {
-    *imsi64 = emm_context->_imsi64;
+  mme_ue_s1ap_id_t mme_ue_s1ap_id = 0;
+  if (!mme_app_get_timer_arg(timer_id, &mme_ue_s1ap_id)) {
+    OAILOG_WARNING(
+        LOG_NAS_EMM, "Invalid Timer Id expiration, Timer Id: %u\n", timer_id);
+    OAILOG_FUNC_RETURN(LOG_NAS_EMM, RETURNok);
   }
+
+  struct ue_mm_context_s* ue_context_p = mme_app_get_ue_context_for_timer(
+      mme_ue_s1ap_id, "Authentication T3460 Timer");
+  if (ue_context_p == NULL) {
+    OAILOG_ERROR(
+        LOG_MME_APP,
+        "Invalid UE context received, MME UE S1AP Id: " MME_UE_S1AP_ID_FMT "\n",
+        mme_ue_s1ap_id);
+    OAILOG_FUNC_RETURN(LOG_NAS_EMM, RETURNok);
+  }
+
+  emm_context_t* emm_context = &ue_context_p->emm_context;
+
   if (is_nas_specific_procedure_attach_running(emm_context)) {
     nas_emm_attach_proc_t* attach_proc =
         get_nas_specific_procedure_attach(emm_context);
@@ -1001,7 +1017,7 @@ static void emm_attach_t3450_handler(void* args, imsi64_t* imsi64) {
     }
     // TODO REQUIREMENT_3GPP_24_301(R10_5_5_1_2_7_c__3) not coded
   }
-  OAILOG_FUNC_OUT(LOG_NAS_EMM);
+  OAILOG_FUNC_RETURN(LOG_NAS_EMM, RETURNok);
 }
 
 //------------------------------------------------------------------------------

--- a/lte/gateway/c/core/oai/tasks/nas/emm/Authentication.c
+++ b/lte/gateway/c/core/oai/tasks/nas/emm/Authentication.c
@@ -79,7 +79,6 @@ extern mme_congestion_params_t mme_congestion_params;
    --------------------------------------------------------------------------
 */
 // callbacks for authentication procedure
-static void authentication_t3460_handler(void* args, imsi64_t* imsi64);
 static int authentication_ll_failure(
     struct emm_context_s* emm_context, struct nas_emm_proc_s* emm_proc);
 static int authentication_non_delivered_ho(
@@ -221,7 +220,7 @@ status_code_e emm_proc_authentication_ksi(
       auth_proc->emm_com_proc.emm_proc.base_proc.fail_out =
           authentication_reject;
       auth_proc->emm_com_proc.emm_proc.base_proc.time_out =
-          authentication_t3460_handler;
+          mme_app_handle_auth_t3460_expiry;
     }
 
     /*
@@ -627,9 +626,7 @@ status_code_e emm_proc_authentication_failure(
   if (auth_proc) {
     // Stop timer T3460
     REQUIREMENT_3GPP_24_301(R10_5_4_2_4__3);
-    void* callback_args = NULL;
-    nas_stop_T3460(
-        ue_mm_context->mme_ue_s1ap_id, &auth_proc->T3460, callback_args);
+    nas_stop_T3460(ue_mm_context->mme_ue_s1ap_id, &auth_proc->T3460);
 
     switch (emm_cause) {
       case EMM_CAUSE_SYNCH_FAILURE:
@@ -920,8 +917,7 @@ status_code_e emm_proc_authentication_complete(
 
     // Stop timer T3460
     REQUIREMENT_3GPP_24_301(R10_5_4_2_4__1);
-    void* callback_arg = NULL;
-    nas_stop_T3460(ue_id, &auth_proc->T3460, callback_arg);
+    nas_stop_T3460(ue_id, &auth_proc->T3460);
     REQUIREMENT_3GPP_24_301(R10_5_4_2_4__2);
     emm_ctx_set_security_eksi(emm_ctx, auth_proc->ksi);
 
@@ -1026,7 +1022,7 @@ void set_callbacks_for_auth_proc(nas_emm_auth_proc_t* auth_proc) {
   auth_proc->emm_com_proc.emm_proc.base_proc.fail_in  = NULL;
   auth_proc->emm_com_proc.emm_proc.base_proc.fail_out = authentication_reject;
   auth_proc->emm_com_proc.emm_proc.base_proc.time_out =
-      authentication_t3460_handler;
+      mme_app_handle_auth_t3460_expiry;
 }
 
 /****************************************************************************/
@@ -1041,7 +1037,7 @@ void set_callbacks_for_auth_proc(nas_emm_auth_proc_t* auth_proc) {
 
 /****************************************************************************
  **                                                                        **
- ** Name:    _authentication_t3460_handler()                           **
+ ** Name:    authentication_t3460_handler()                           **
  **                                                                        **
  ** Description: T3460 timeout handler                                     **
  **      Upon T3460 timer expiration, the authentication request   **
@@ -1060,20 +1056,38 @@ void set_callbacks_for_auth_proc(nas_emm_auth_proc_t* auth_proc) {
  **      Others:    None                                       **
  **                                                                        **
  ***************************************************************************/
-static void authentication_t3460_handler(void* args, imsi64_t* imsi64) {
+status_code_e mme_app_handle_auth_t3460_expiry(
+    zloop_t* loop, int timer_id, void* args) {
   OAILOG_FUNC_IN(LOG_NAS_EMM);
-  emm_context_t* emm_ctx = (emm_context_t*) (args);
+
+  mme_ue_s1ap_id_t mme_ue_s1ap_id = 0;
+  if (!mme_app_get_timer_arg(timer_id, &mme_ue_s1ap_id)) {
+    OAILOG_WARNING(
+        LOG_NAS_EMM, "Invalid Timer Id expiration, Timer Id: %u\n", timer_id);
+    OAILOG_FUNC_RETURN(LOG_NAS_EMM, RETURNok);
+  }
+
+  struct ue_mm_context_s* ue_context_p = mme_app_get_ue_context_for_timer(
+      mme_ue_s1ap_id, "Authentication T3460 Timer");
+  if (ue_context_p == NULL) {
+    OAILOG_ERROR(
+        LOG_MME_APP,
+        "Invalid UE context received, MME UE S1AP Id: " MME_UE_S1AP_ID_FMT "\n",
+        mme_ue_s1ap_id);
+    OAILOG_FUNC_RETURN(LOG_NAS_EMM, RETURNok);
+  }
+
+  emm_context_t* emm_ctx = &ue_context_p->emm_context;
 
   if (!(emm_ctx)) {
     OAILOG_ERROR(LOG_NAS_EMM, "T3460 timer expired No EMM context\n");
-    OAILOG_FUNC_OUT(LOG_NAS_EMM);
+    OAILOG_FUNC_RETURN(LOG_NAS_EMM, RETURNok);
   }
   nas_emm_auth_proc_t* auth_proc =
       get_nas_common_procedure_authentication(emm_ctx);
   mme_ue_s1ap_id_t ue_id;
 
   if (auth_proc) {
-    *imsi64 = emm_ctx->_imsi64;
     /*
      * Increment the retransmission counter
      */
@@ -1083,7 +1097,7 @@ static void authentication_t3460_handler(void* args, imsi64_t* imsi64) {
     auth_proc->retransmission_count += 1;
     auth_proc->T3460.id = NAS_TIMER_INACTIVE_ID;
     OAILOG_WARNING_UE(
-        LOG_NAS_EMM, *imsi64,
+        LOG_NAS_EMM, emm_ctx->_imsi64,
         "EMM-PROC  - T3460 timer expired, retransmission "
         "counter = %d for ue id " MME_UE_S1AP_ID_FMT "\n",
         auth_proc->retransmission_count, auth_proc->ue_id);
@@ -1127,7 +1141,7 @@ static void authentication_t3460_handler(void* args, imsi64_t* imsi64) {
       increment_counter("ue_attach", 1, 1, "action", "attach_abort");
     }
   }
-  OAILOG_FUNC_OUT(LOG_NAS_EMM);
+  OAILOG_FUNC_RETURN(LOG_NAS_EMM, RETURNok);
 }
 
 /*
@@ -1268,17 +1282,14 @@ static int authentication_request(
     if (rc != RETURNerror) {
       if (emm_ctx) {
         if (auth_proc->T3460.id != NAS_TIMER_INACTIVE_ID) {
-          void* timer_callback_args = NULL;
-          nas_stop_T3460(
-              auth_proc->ue_id, &auth_proc->T3460, timer_callback_args);
+          nas_stop_T3460(auth_proc->ue_id, &auth_proc->T3460);
         }
         /*
          * Start T3460 timer
          */
         nas_start_T3460(
             auth_proc->ue_id, &auth_proc->T3460,
-            auth_proc->emm_com_proc.emm_proc.base_proc.time_out,
-            (void*) emm_ctx);
+            auth_proc->emm_com_proc.emm_proc.base_proc.time_out);
       }
     }
   }
@@ -1405,7 +1416,7 @@ static int authentication_non_delivered_ho(
           "EMM-PROC  - Stop timer T3460 (%ld) for (ue_id=" MME_UE_S1AP_ID_FMT
           ")\n",
           auth_proc->T3460.id, ue_mm_context->mme_ue_s1ap_id);
-      nas_stop_T3460(ue_mm_context->mme_ue_s1ap_id, &auth_proc->T3460, NULL);
+      nas_stop_T3460(ue_mm_context->mme_ue_s1ap_id, &auth_proc->T3460);
     }
     /*
      * Abort authentication and attach procedure
@@ -1455,9 +1466,7 @@ static int authentication_abort(
     /*
      * Stop timer T3460
      */
-    void* timer_callback_args = NULL;
-    nas_stop_T3460(
-        ue_mm_context->mme_ue_s1ap_id, &auth_proc->T3460, timer_callback_args);
+    nas_stop_T3460(ue_mm_context->mme_ue_s1ap_id, &auth_proc->T3460);
     rc = RETURNok;
   }
 

--- a/lte/gateway/c/core/oai/tasks/nas/emm/Authentication.c
+++ b/lte/gateway/c/core/oai/tasks/nas/emm/Authentication.c
@@ -118,34 +118,34 @@ static void nas_itti_auth_info_req(
 */
 /****************************************************************************
  **                                                                        **
- ** Name:    emm_proc_authentication()                                 **
+ ** Name:    emm_proc_authentication()                                     **
  **                                                                        **
  ** Description: Initiates authentication procedure to establish partial   **
- **      native EPS security context in the UE and the MME.        **
+ **      native EPS security context in the UE and the MME.                **
  **                                                                        **
  **              3GPP TS 24.301, section 5.4.2.2                           **
- **      The network initiates the authentication procedure by     **
- **      sending an AUTHENTICATION REQUEST message to the UE and   **
- **      starting the timer T3460. The AUTHENTICATION REQUEST mes- **
- **      sage contains the parameters necessary to calculate the   **
- **      authentication response.                                  **
+ **      The network initiates the authentication procedure by             **
+ **      sending an AUTHENTICATION REQUEST message to the UE and           **
+ **      starting the timer T3460. The AUTHENTICATION REQUEST mes-         **
+ **      sage contains the parameters necessary to calculate the           **
+ **      authentication response.                                          **
  **                                                                        **
- ** Inputs:  ue_id:      UE lower layer identifier                  **
- **      ksi:       NAS key set identifier                     **
- **      rand:      Random challenge number                    **
- **      autn:      Authentication token                       **
- **      success:   Callback function executed when the authen-**
- **             tication procedure successfully completes  **
- **      reject:    Callback function executed when the authen-**
- **             tication procedure fails or is rejected    **
- **      failure:   Callback function executed whener a lower  **
- **             layer failure occured before the authenti- **
- **             cation procedure comnpletes                **
- **      Others:    None                                       **
+ ** Inputs:  ue_id:      UE lower layer identifier                         **
+ **      ksi:       NAS key set identifier                                 **
+ **      rand:      Random challenge number                                **
+ **      autn:      Authentication token                                   **
+ **      success:   Callback function executed when the authen-            **
+ **             tication procedure successfully completes                  **
+ **      reject:    Callback function executed when the authen-            **
+ **             tication procedure fails or is rejected                    **
+ **      failure:   Callback function executed whener a lower              **
+ **             layer failure occured before the authenti-                 **
+ **             cation procedure comnpletes                                **
+ **      Others:    None                                                   **
  **                                                                        **
  ** Outputs:     None                                                      **
- **      Return:    RETURNok, RETURNerror                      **
- **      Others:    None                                       **
+ **      Return:    RETURNok, RETURNerror                                  **
+ **      Others:    None                                                   **
  **                                                                        **
  ***************************************************************************/
 status_code_e emm_proc_authentication_ksi(
@@ -584,8 +584,8 @@ static int auth_info_proc_failure_cb(struct emm_context_s* emm_ctx) {
         // TODO seems bad design here, tricky.
         if (auth_proc->emm_com_proc.emm_proc.base_proc.failure_notif) {
           emm_ctx->emm_cause = emm_cause;
-          rc = (*auth_proc->emm_com_proc.emm_proc.base_proc.failure_notif)(
-              emm_ctx);
+          rc                 = (*auth_proc->emm_com_proc.emm_proc.base_proc
+                     .failure_notif) (emm_ctx);
         } else {
           nas_delete_common_procedure(
               emm_ctx, (nas_emm_common_proc_t**) &auth_proc);
@@ -846,7 +846,7 @@ status_code_e emm_proc_authentication_failure(
  **      MME shall stop timer T3460 and check the correctness of           **
  **      the RES parameter.                                                **
  **                                                                        **
- ** Inputs:  ue_id:      UE lower layer identifier                          **
+ ** Inputs:  ue_id:      UE lower layer identifier                         **
  **      emm_cause: Authentication failure EMM cause code                  **
  **      res:       Authentication response parameter. or auts             **
  **                 in case of sync failure                                **
@@ -1037,23 +1037,23 @@ void set_callbacks_for_auth_proc(nas_emm_auth_proc_t* auth_proc) {
 
 /****************************************************************************
  **                                                                        **
- ** Name:    authentication_t3460_handler()                           **
+ ** Name:    mme_app_handle_auth_t3460_expiry()                            **
  **                                                                        **
  ** Description: T3460 timeout handler                                     **
- **      Upon T3460 timer expiration, the authentication request   **
- **      message is retransmitted and the timer restarted. When    **
- **      retransmission counter is exceed, the MME shall abort the **
- **      authentication procedure and any ongoing EMM specific     **
- **      procedure and release the NAS signalling connection.      **
+ **      Upon T3460 timer expiration, the authentication request           **
+ **      message is retransmitted and the timer restarted. When            **
+ **      retransmission counter is exceed, the MME shall abort the         **
+ **      authentication procedure and any ongoing EMM specific             **
+ **      procedure and release the NAS signalling connection.              **
  **                                                                        **
  **              3GPP TS 24.301, section 5.4.2.7, case b                   **
  **                                                                        **
- ** Inputs:  args:      handler parameters                         **
- **      Others:    None                                       **
+ ** Inputs:  args:      handler parameters                                 **
+ **      Others:    None                                                   **
  **                                                                        **
  ** Outputs:     None                                                      **
- **      Return:    None                                       **
- **      Others:    None                                       **
+ **      Return:    None                                                   **
+ **      Others:    None                                                   **
  **                                                                        **
  ***************************************************************************/
 status_code_e mme_app_handle_auth_t3460_expiry(
@@ -1398,7 +1398,7 @@ static int authentication_non_delivered_ho(
     nas_emm_auth_proc_t* auth_proc = (nas_emm_auth_proc_t*) emm_proc;
     REQUIREMENT_3GPP_24_301(R10_5_4_2_7_j);
     mme_ue_s1ap_id_t ue_id = auth_proc->ue_id;
-    /************************README***********************************************
+    /************************README********************************************
   ** NAS Non Delivery indication during HO handling will be added when HO is
   ** supported.
   ** In non hand-over case if MME receives NAS Non Delivery indication message
@@ -1444,9 +1444,9 @@ static int authentication_non_delivered_ho(
  ** Inputs:  args:      Authentication data to be released                 **
  **      Others:    None                                                   **
  **                                                                        **
- ** Outputs:     None
- **     Return: None
- **     Others: None
+ ** Outputs:     None                                                      **
+ **     Return: None                                                       **
+ **     Others: None                                                       **
  **                                                                        **
  ***************************************************************************/
 static int authentication_abort(
@@ -1568,7 +1568,7 @@ static void nas_itti_auth_info_req(
 
 /************************************************************************
  **                                                                    **
- ** Name:    mme_app_handle_air_timer_expiry                    **
+ ** Name:    mme_app_handle_air_timer_expiry                           **
  **                                                                    **
  ** Description:                                                       **
  **      The timer is used for monitoring Auth Response from HSS       **
@@ -1577,7 +1577,7 @@ static void nas_itti_auth_info_req(
  **                                                                    **
  ** Inputs:  args:      handler parameters                             **
  **                                                                    **
- ************************************************************************/
+ ***********************************************************************/
 status_code_e mme_app_handle_air_timer_expiry(
     zloop_t* loop, int timer_id, void* args) {
   OAILOG_FUNC_IN(LOG_NAS_EMM);

--- a/lte/gateway/c/core/oai/tasks/nas/emm/Authentication.c
+++ b/lte/gateway/c/core/oai/tasks/nas/emm/Authentication.c
@@ -584,8 +584,8 @@ static int auth_info_proc_failure_cb(struct emm_context_s* emm_ctx) {
         // TODO seems bad design here, tricky.
         if (auth_proc->emm_com_proc.emm_proc.base_proc.failure_notif) {
           emm_ctx->emm_cause = emm_cause;
-          rc                 = (*auth_proc->emm_com_proc.emm_proc.base_proc
-                     .failure_notif) (emm_ctx);
+          rc = (*auth_proc->emm_com_proc.emm_proc.base_proc.failure_notif)(
+              emm_ctx);
         } else {
           nas_delete_common_procedure(
               emm_ctx, (nas_emm_common_proc_t**) &auth_proc);

--- a/lte/gateway/c/core/oai/tasks/nas/emm/SecurityModeControl.c
+++ b/lte/gateway/c/core/oai/tasks/nas/emm/SecurityModeControl.c
@@ -722,22 +722,22 @@ void set_callbacks_for_smc_proc(nas_emm_smc_proc_t* smc_proc) {
 
 /****************************************************************************
  **                                                                        **
- ** Name:    mme_app_handle_security_t3460_expiry() **
+ ** Name:    mme_app_handle_security_t3460_expiry()                        **
  **                                                                        **
  ** Description: T3460 timeout handler                                     **
- **      Upon T3460 timer expiration, the security mode command    **
- **      message is retransmitted and the timer restarted. When    **
- **      retransmission counter is exceed, the MME shall abort the **
- **      security mode control procedure.                          **
+ **      Upon T3460 timer expiration, the security mode command            **
+ **      message is retransmitted and the timer restarted. When            **
+ **      retransmission counter is exceed, the MME shall abort the         **
+ **      security mode control procedure.                                  **
  **                                                                        **
  **              3GPP TS 24.301, section 5.4.3.7, case b                   **
  **                                                                        **
- ** Inputs:  args:      handler parameters                         **
- **      Others:    None                                       **
+ ** Inputs:  args:      handler parameters                                 **
+ **      Others:    None                                                   **
  **                                                                        **
  ** Outputs:     None                                                      **
- **      Return:    None                                       **
- **      Others:    None                                       **
+ **      Return:    None                                                   **
+ **      Others:    None                                                   **
  **                                                                        **
  ***************************************************************************/
 status_code_e mme_app_handle_security_t3460_expiry(

--- a/lte/gateway/c/core/oai/tasks/nas/emm/SecurityModeControl.c
+++ b/lte/gateway/c/core/oai/tasks/nas/emm/SecurityModeControl.c
@@ -75,6 +75,7 @@
 #include "security_types.h"
 #include "mme_app_defs.h"
 #include "conversions.h"
+#include "mme_app_timer.h"
 
 /****************************************************************************/
 /****************  E X T E R N A L    D E F I N I T I O N S  ****************/
@@ -102,7 +103,6 @@ extern mme_congestion_params_t mme_congestion_params;
 /*
    Timer handlers
 */
-static void security_t3460_handler(void*, imsi64_t* imsi64);
 static int security_ll_failure(
     emm_context_t* emm_context, struct nas_emm_proc_s* nas_emm_proc);
 static int security_non_delivered_ho(
@@ -292,7 +292,8 @@ status_code_e emm_proc_security_mode_control(
     smc_proc->emm_com_proc.emm_proc.base_proc.abort         = security_abort;
     smc_proc->emm_com_proc.emm_proc.base_proc.fail_in  = NULL;  // only response
     smc_proc->emm_com_proc.emm_proc.base_proc.fail_out = NULL;
-    smc_proc->emm_com_proc.emm_proc.base_proc.time_out = security_t3460_handler;
+    smc_proc->emm_com_proc.emm_proc.base_proc.time_out =
+        mme_app_handle_security_t3460_expiry;
 
     /*
      * Set the UE identifier
@@ -526,8 +527,7 @@ status_code_e emm_proc_security_mode_complete(
      */
     REQUIREMENT_3GPP_24_301(R10_5_4_3_4__1);
 
-    void* timer_callback_arg = NULL;
-    nas_stop_T3460(ue_id, &smc_proc->T3460, timer_callback_arg);
+    nas_stop_T3460(ue_id, &smc_proc->T3460);
 
     /* If MME requested for imeisv in security mode cmd
      * and UE did not include the same in security mode complete,
@@ -659,8 +659,7 @@ status_code_e emm_proc_security_mode_reject(mme_ue_s1ap_id_t ue_id) {
      * Stop timer T3460
      */
     REQUIREMENT_3GPP_24_301(R10_5_4_3_5__2);
-    void* timer_callback_arg = NULL;
-    nas_stop_T3460(ue_id, &smc_proc->T3460, timer_callback_arg);
+    nas_stop_T3460(ue_id, &smc_proc->T3460);
 
     // restore previous values
     REQUIREMENT_3GPP_24_301(R10_5_4_3_5__3);
@@ -707,7 +706,8 @@ void set_callbacks_for_smc_proc(nas_emm_smc_proc_t* smc_proc) {
   smc_proc->emm_com_proc.emm_proc.base_proc.abort   = security_abort;
   smc_proc->emm_com_proc.emm_proc.base_proc.fail_in = NULL;
   smc_proc->emm_com_proc.emm_proc.base_proc.fail_out = NULL;
-  smc_proc->emm_com_proc.emm_proc.base_proc.time_out = security_t3460_handler;
+  smc_proc->emm_com_proc.emm_proc.base_proc.time_out =
+      mme_app_handle_security_t3460_expiry;
 }
 
 /****************************************************************************/
@@ -722,7 +722,7 @@ void set_callbacks_for_smc_proc(nas_emm_smc_proc_t* smc_proc) {
 
 /****************************************************************************
  **                                                                        **
- ** Name:    _security_t3460_handler()                                 **
+ ** Name:    mme_app_handle_security_t3460_expiry() **
  **                                                                        **
  ** Description: T3460 timeout handler                                     **
  **      Upon T3460 timer expiration, the security mode command    **
@@ -740,25 +740,43 @@ void set_callbacks_for_smc_proc(nas_emm_smc_proc_t* smc_proc) {
  **      Others:    None                                       **
  **                                                                        **
  ***************************************************************************/
-static void security_t3460_handler(void* args, imsi64_t* imsi64) {
+status_code_e mme_app_handle_security_t3460_expiry(
+    zloop_t* loop, int timer_id, void* args) {
   OAILOG_FUNC_IN(LOG_NAS_EMM);
-  emm_context_t* emm_ctx = (emm_context_t*) (args);
+
+  mme_ue_s1ap_id_t mme_ue_s1ap_id = 0;
+  if (!mme_app_get_timer_arg(timer_id, &mme_ue_s1ap_id)) {
+    OAILOG_WARNING(
+        LOG_NAS_EMM, "Invalid Timer Id expiration, Timer Id: %u\n", timer_id);
+    OAILOG_FUNC_RETURN(LOG_NAS_EMM, RETURNok);
+  }
+
+  struct ue_mm_context_s* ue_context_p =
+      mme_app_get_ue_context_for_timer(mme_ue_s1ap_id, "Security T3460 Timer");
+  if (ue_context_p == NULL) {
+    OAILOG_ERROR(
+        LOG_MME_APP,
+        "Invalid UE context received, MME UE S1AP Id: " MME_UE_S1AP_ID_FMT "\n",
+        mme_ue_s1ap_id);
+    OAILOG_FUNC_RETURN(LOG_NAS_EMM, RETURNok);
+  }
+
+  emm_context_t* emm_ctx = &ue_context_p->emm_context;
 
   if (!(emm_ctx)) {
     OAILOG_ERROR(LOG_NAS_EMM, "T3460 timer expired No EMM context\n");
-    OAILOG_FUNC_OUT(LOG_NAS_EMM);
+    OAILOG_FUNC_RETURN(LOG_NAS_EMM, RETURNok);
   }
   nas_emm_smc_proc_t* smc_proc = get_nas_common_procedure_smc(emm_ctx);
 
   if (smc_proc) {
-    *imsi64 = emm_ctx->_imsi64;
     /*
      * Increment the retransmission counter
      */
     smc_proc->retransmission_count += 1;
     smc_proc->T3460.id = NAS_TIMER_INACTIVE_ID;
     OAILOG_WARNING_UE(
-        LOG_NAS_EMM, *imsi64,
+        LOG_NAS_EMM, emm_ctx->_imsi64,
         "EMM-PROC  - T3460 timer expired, retransmission "
         "counter = %d\n",
         smc_proc->retransmission_count);
@@ -787,7 +805,7 @@ static void security_t3460_handler(void* args, imsi64_t* imsi64) {
       increment_counter("ue_attach", 1, 1, "action", "attach_abort");
     }
   }
-  OAILOG_FUNC_OUT(LOG_NAS_EMM);
+  OAILOG_FUNC_RETURN(LOG_NAS_EMM, RETURNok);
 }
 
 /*
@@ -874,14 +892,13 @@ static int security_request(nas_emm_smc_proc_t* const smc_proc) {
 
     if (rc != RETURNerror) {
       REQUIREMENT_3GPP_24_301(R10_5_4_3_2__1);
-      void* timer_callback_args = NULL;
-      nas_stop_T3460(smc_proc->ue_id, &smc_proc->T3460, timer_callback_args);
+      nas_stop_T3460(smc_proc->ue_id, &smc_proc->T3460);
       /*
        * Start T3460 timer
        */
       nas_start_T3460(
           smc_proc->ue_id, &smc_proc->T3460,
-          smc_proc->emm_com_proc.emm_proc.base_proc.time_out, emm_ctx);
+          smc_proc->emm_com_proc.emm_proc.base_proc.time_out);
     }
   }
   OAILOG_FUNC_RETURN(LOG_NAS_EMM, rc);
@@ -984,7 +1001,7 @@ static int security_abort(
           "EMM-PROC  - Stop timer T3460 (%ld) for ue id " MME_UE_S1AP_ID_FMT
           "\n",
           smc_proc->T3460.id, ue_id);
-      nas_stop_T3460(ue_id, &smc_proc->T3460, NULL);
+      nas_stop_T3460(ue_id, &smc_proc->T3460);
     }
     /*
      * Release retransmission timer parameters

--- a/lte/gateway/c/core/oai/tasks/nas/emm/emm_data.h
+++ b/lte/gateway/c/core/oai/tasks/nas/emm/emm_data.h
@@ -552,22 +552,19 @@ status_code_e emm_context_upsert_imsi(
 
 void nas_start_T3450(
     const mme_ue_s1ap_id_t ue_id, struct nas_timer_s* const T3450,
-    time_out_t time_out_cb, void* timer_callback_args);
+    time_out_t time_out_cb);
 void nas_start_T3460(
     const mme_ue_s1ap_id_t ue_id, struct nas_timer_s* const T3460,
-    time_out_t time_out_cb, void* timer_callback_args);
+    time_out_t time_out_cb);
 void nas_start_T3470(
     const mme_ue_s1ap_id_t ue_id, struct nas_timer_s* const T3470,
-    time_out_t time_out_cb, void* timer_callback_args);
+    time_out_t time_out_cb);
 void nas_stop_T3450(
-    const mme_ue_s1ap_id_t ue_id, struct nas_timer_s* const T3450,
-    void* timer_callback_args);
+    const mme_ue_s1ap_id_t ue_id, struct nas_timer_s* const T3450);
 void nas_stop_T3460(
-    const mme_ue_s1ap_id_t ue_id, struct nas_timer_s* const T3460,
-    void* timer_callback_args);
+    const mme_ue_s1ap_id_t ue_id, struct nas_timer_s* const T3460);
 void nas_stop_T3470(
-    const mme_ue_s1ap_id_t ue_id, struct nas_timer_s* const T3470,
-    void* timer_callback_args);
+    const mme_ue_s1ap_id_t ue_id, struct nas_timer_s* const T3470);
 void nas_start_Ts6a_auth_info(
     const mme_ue_s1ap_id_t ue_id, struct nas_timer_s* const Ts6a_auth_info,
     time_out_t time_out_cb);

--- a/lte/gateway/c/core/oai/tasks/nas/emm/emm_data_ctx.c
+++ b/lte/gateway/c/core/oai/tasks/nas/emm/emm_data_ctx.c
@@ -51,6 +51,7 @@
 #include "nas_timer.h"
 #include "nas/securityDef.h"
 #include "intertask_interface.h"
+#include "mme_app_timer.h"
 
 //------------------------------------------------------------------------------
 mme_ue_s1ap_id_t emm_ctx_get_new_ue_id(const emm_context_t* const ctxt) {
@@ -968,10 +969,10 @@ void emm_init_context(
 //------------------------------------------------------------------------------
 void nas_start_T3450(
     const mme_ue_s1ap_id_t ue_id, struct nas_timer_s* const T3450,
-    time_out_t time_out_cb, void* timer_callback_args) {
+    time_out_t time_out_cb) {
   if ((T3450) && (T3450->id == NAS_TIMER_INACTIVE_ID)) {
-    T3450->id =
-        nas_timer_start(T3450->sec, 0, time_out_cb, timer_callback_args);
+    T3450->id = mme_app_start_timer(
+        T3450->sec * 1000, TIMER_REPEAT_ONCE, time_out_cb, ue_id);
     if (NAS_TIMER_INACTIVE_ID != T3450->id) {
       OAILOG_DEBUG(
           LOG_NAS_EMM, "T3450 started UE " MME_UE_S1AP_ID_FMT "\n", ue_id);
@@ -985,10 +986,10 @@ void nas_start_T3450(
 //------------------------------------------------------------------------------
 void nas_start_T3460(
     const mme_ue_s1ap_id_t ue_id, struct nas_timer_s* const T3460,
-    time_out_t time_out_cb, void* timer_callback_args) {
+    time_out_t time_out_cb) {
   if ((T3460) && (T3460->id == NAS_TIMER_INACTIVE_ID)) {
-    T3460->id =
-        nas_timer_start(T3460->sec, 0, time_out_cb, timer_callback_args);
+    T3460->id = mme_app_start_timer(
+        T3460->sec * 1000, TIMER_REPEAT_ONCE, time_out_cb, ue_id);
     if (NAS_TIMER_INACTIVE_ID != T3460->id) {
       OAILOG_DEBUG(
           LOG_NAS_EMM, "T3460 started UE " MME_UE_S1AP_ID_FMT "\n", ue_id);
@@ -1002,10 +1003,10 @@ void nas_start_T3460(
 //------------------------------------------------------------------------------
 void nas_start_T3470(
     const mme_ue_s1ap_id_t ue_id, struct nas_timer_s* const T3470,
-    time_out_t time_out_cb, void* timer_callback_args) {
+    time_out_t time_out_cb) {
   if ((T3470) && (T3470->id == NAS_TIMER_INACTIVE_ID)) {
-    T3470->id =
-        nas_timer_start(T3470->sec, 0, time_out_cb, timer_callback_args);
+    T3470->id = mme_app_start_timer(
+        T3470->sec * 1000, TIMER_REPEAT_ONCE, time_out_cb, ue_id);
     if (NAS_TIMER_INACTIVE_ID != T3470->id) {
       OAILOG_DEBUG(
           LOG_NAS_EMM, "T3470 started UE " MME_UE_S1AP_ID_FMT "\n", ue_id);
@@ -1036,10 +1037,10 @@ void nas_start_Ts6a_auth_info(
 }
 //------------------------------------------------------------------------------
 void nas_stop_T3450(
-    const mme_ue_s1ap_id_t ue_id, struct nas_timer_s* const T3450,
-    void* timer_callback_args) {
+    const mme_ue_s1ap_id_t ue_id, struct nas_timer_s* const T3450) {
   if ((T3450) && (T3450->id != NAS_TIMER_INACTIVE_ID)) {
-    T3450->id = nas_timer_stop(T3450->id, &timer_callback_args);
+    mme_app_stop_timer(T3450->id);
+    T3450->id = NAS_TIMER_INACTIVE_ID;
     OAILOG_DEBUG(
         LOG_NAS_EMM, "T3450 stopped UE " MME_UE_S1AP_ID_FMT "\n", ue_id);
   }
@@ -1047,10 +1048,10 @@ void nas_stop_T3450(
 
 //------------------------------------------------------------------------------
 void nas_stop_T3460(
-    const mme_ue_s1ap_id_t ue_id, struct nas_timer_s* const T3460,
-    void* timer_callback_args) {
+    const mme_ue_s1ap_id_t ue_id, struct nas_timer_s* const T3460) {
   if ((T3460) && (T3460->id != NAS_TIMER_INACTIVE_ID)) {
-    T3460->id = nas_timer_stop(T3460->id, &timer_callback_args);
+    mme_app_stop_timer(T3460->id);
+    T3460->id = NAS_TIMER_INACTIVE_ID;
     OAILOG_DEBUG(
         LOG_NAS_EMM, "T3460 stopped UE " MME_UE_S1AP_ID_FMT "\n", ue_id);
   }
@@ -1058,10 +1059,10 @@ void nas_stop_T3460(
 
 //------------------------------------------------------------------------------
 void nas_stop_T3470(
-    const mme_ue_s1ap_id_t ue_id, struct nas_timer_s* const T3470,
-    void* timer_callback_args) {
+    const mme_ue_s1ap_id_t ue_id, struct nas_timer_s* const T3470) {
   if ((T3470) && (T3470->id != NAS_TIMER_INACTIVE_ID)) {
-    T3470->id = nas_timer_stop(T3470->id, &timer_callback_args);
+    mme_app_stop_timer(T3470->id);
+    T3470->id = NAS_TIMER_INACTIVE_ID;
     OAILOG_DEBUG(
         LOG_NAS_EMM, "T3470 stopped UE " MME_UE_S1AP_ID_FMT "\n", ue_id);
   }

--- a/lte/gateway/c/core/oai/tasks/nas/nas_procedures.c
+++ b/lte/gateway/c/core/oai/tasks/nas/nas_procedures.c
@@ -387,18 +387,18 @@ static void nas_delete_common_procedures(struct emm_context_s* emm_context) {
           break;
         case EMM_COMM_PROC_AUTH: {
           nas_emm_auth_proc_t* auth_info_proc = (nas_emm_auth_proc_t*) p1->proc;
-          nas_stop_T3460(auth_info_proc->ue_id, &auth_info_proc->T3460, NULL);
+          nas_stop_T3460(auth_info_proc->ue_id, &auth_info_proc->T3460);
           if (auth_info_proc->unchecked_imsi) {
             free_wrapper((void**) &auth_info_proc->unchecked_imsi);
           }
         } break;
         case EMM_COMM_PROC_SMC: {
           nas_emm_smc_proc_t* smc_proc = (nas_emm_smc_proc_t*) (p1->proc);
-          nas_stop_T3460(smc_proc->ue_id, &smc_proc->T3460, NULL);
+          nas_stop_T3460(smc_proc->ue_id, &smc_proc->T3460);
         } break;
         case EMM_COMM_PROC_IDENT: {
           nas_emm_ident_proc_t* ident_proc = (nas_emm_ident_proc_t*) (p1->proc);
-          nas_stop_T3470(ident_proc->ue_id, &ident_proc->T3470, NULL);
+          nas_stop_T3470(ident_proc->ue_id, &ident_proc->T3470);
         } break;
         case EMM_COMM_PROC_INFO:
           break;
@@ -423,8 +423,7 @@ void nas_delete_attach_procedure(struct emm_context_s* emm_context) {
     mme_ue_s1ap_id_t ue_id =
         PARENT_STRUCT(emm_context, struct ue_mm_context_s, emm_context)
             ->mme_ue_s1ap_id;
-    void* unused = NULL;
-    nas_stop_T3450(ue_id, &proc->T3450, unused);
+    nas_stop_T3450(ue_id, &proc->T3450);
     if (proc->ies) {
       free_emm_attach_request_ies(&proc->ies);
     }
@@ -446,8 +445,7 @@ void nas_delete_tau_procedure(struct emm_context_s* emm_context) {
     mme_ue_s1ap_id_t ue_id =
         PARENT_STRUCT(emm_context, struct ue_mm_context_s, emm_context)
             ->mme_ue_s1ap_id;
-    void* unused = NULL;
-    nas_stop_T3450(ue_id, &proc->T3450, unused);
+    nas_stop_T3450(ue_id, &proc->T3450);
     if (proc->ies) {
       free_emm_tau_request_ies(&proc->ies);
     }

--- a/lte/gateway/c/core/oai/tasks/nas/nas_procedures.h
+++ b/lte/gateway/c/core/oai/tasks/nas/nas_procedures.h
@@ -40,6 +40,7 @@
 #include "queue.h"
 #include "nas/securityDef.h"
 #include "security_types.h"
+#include <czmq.h>
 
 struct emm_context_s;
 struct nas_base_proc_s;
@@ -59,7 +60,7 @@ typedef int (*pdu_in_resp_t)(
 typedef int (*pdu_in_rej_t)(struct emm_context_s*, void* arg);  // REJECT.
 typedef int (*pdu_out_rej_t)(
     struct emm_context_s*, struct nas_base_proc_s*);  // REJECT.
-typedef void (*time_out_t)(void* arg, imsi64_t* imsi64);
+typedef int (*time_out_t)(zloop_t* loop, int timer_id, void* args);
 
 typedef int (*sdu_out_delivered_t)(
     struct emm_context_s*, struct nas_emm_proc_s*);


### PR DESCRIPTION
Signed-off-by: Ulas Kozat <kozat@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->
Migrated the following NAS timers to ZMQ:
- T3450
- T3460
- T3470

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->
Integ test suit which has coverage over the timer expirations facing UE and RAN.

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
