### PR TITLE
feat(agw): Pass mconfig and service config to post_processing

### DIFF
--- a/lte/gateway/python/magma/enodebd/device_config/configuration_init.py
+++ b/lte/gateway/python/magma/enodebd/device_config/configuration_init.py
@@ -125,7 +125,7 @@ def build_desired_config(
         enb_config.allow_enodeb_transmit,
     )
 
-    post_processor.postprocess(cfg_desired)
+    post_processor.postprocess(mconfig, service_config, cfg_desired)
     return cfg_desired
 
 

--- a/lte/gateway/python/magma/enodebd/device_config/enodeb_config_postprocessor.py
+++ b/lte/gateway/python/magma/enodebd/device_config/enodeb_config_postprocessor.py
@@ -11,6 +11,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 from abc import ABC, abstractmethod
+from typing import Any
 
 from magma.enodebd.device_config.enodeb_configuration import EnodebConfiguration
 
@@ -22,7 +23,7 @@ class EnodebConfigurationPostProcessor(ABC):
     """
 
     @abstractmethod
-    def postprocess(self, desired_cfg: EnodebConfiguration) -> None:
+    def postprocess(self, mconfig: Any, service_cfg: Any, desired_cfg: EnodebConfiguration) -> None:
         """
         Implementation of function which overrides the desired configuration
         for the eNodeB

--- a/lte/gateway/python/magma/enodebd/devices/baicells.py
+++ b/lte/gateway/python/magma/enodebd/devices/baicells.py
@@ -309,5 +309,5 @@ class BaicellsTrDataModel(DataModel):
 
 
 class BaicellsTrConfigurationInitializer(EnodebConfigurationPostProcessor):
-    def postprocess(self, desired_cfg: EnodebConfiguration) -> None:
+    def postprocess(self, mconfig: Any, service_cfg: Any, desired_cfg: EnodebConfiguration) -> None:
         desired_cfg.set_parameter(ParameterName.CELL_BARRED, False)

--- a/lte/gateway/python/magma/enodebd/devices/baicells_old.py
+++ b/lte/gateway/python/magma/enodebd/devices/baicells_old.py
@@ -325,5 +325,5 @@ class BaicellsTrOldDataModel(DataModel):
 
 
 class BaicellsTrOldConfigurationInitializer(EnodebConfigurationPostProcessor):
-    def postprocess(self, desired_cfg: EnodebConfiguration) -> None:
+    def postprocess(self, mconfig: Any, service_cfg: Any, desired_cfg: EnodebConfiguration) -> None:
         desired_cfg.set_parameter(ParameterName.CELL_BARRED, False)

--- a/lte/gateway/python/magma/enodebd/devices/baicells_qafa.py
+++ b/lte/gateway/python/magma/enodebd/devices/baicells_qafa.py
@@ -266,6 +266,6 @@ class BaicellsQAFATrDataModel(DataModel):
 
 
 class BaicellsQAFATrConfigurationInitializer(EnodebConfigurationPostProcessor):
-    def postprocess(self, desired_cfg: EnodebConfiguration) -> None:
+    def postprocess(self, mconfig: Any, service_cfg: Any, desired_cfg: EnodebConfiguration) -> None:
 
         desired_cfg.delete_parameter(ParameterName.ADMIN_STATE)

--- a/lte/gateway/python/magma/enodebd/devices/baicells_qafb.py
+++ b/lte/gateway/python/magma/enodebd/devices/baicells_qafb.py
@@ -506,7 +506,7 @@ class BaicellsQAFBTrDataModel(DataModel):
 
 
 class BaicellsQAFBTrConfigurationInitializer(EnodebConfigurationPostProcessor):
-    def postprocess(self, desired_cfg: EnodebConfiguration) -> None:
+    def postprocess(self, mconfig: Any, service_cfg: Any, desired_cfg: EnodebConfiguration) -> None:
         # We don't set this parameter for this device, it should be
         # auto-configured by the device.
         desired_cfg.delete_parameter(ParameterName.ADMIN_STATE)

--- a/lte/gateway/python/magma/enodebd/devices/baicells_rts.py
+++ b/lte/gateway/python/magma/enodebd/devices/baicells_rts.py
@@ -305,5 +305,5 @@ class BaicellsRTSTrDataModel(DataModel):
 
 
 class BaicellsRTSTrConfigurationInitializer(EnodebConfigurationPostProcessor):
-    def postprocess(self, desired_cfg: EnodebConfiguration) -> None:
+    def postprocess(self, mconfig: Any, service_cfg: Any, desired_cfg: EnodebConfiguration) -> None:
         desired_cfg.set_parameter(ParameterName.CELL_BARRED, False)

--- a/lte/gateway/python/magma/enodebd/devices/experimental/cavium.py
+++ b/lte/gateway/python/magma/enodebd/devices/experimental/cavium.py
@@ -486,6 +486,6 @@ class CaviumTrDataModel(DataModel):
 
 
 class CaviumTrConfigurationInitializer(EnodebConfigurationPostProcessor):
-    def postprocess(self, desired_cfg: EnodebConfiguration) -> None:
+    def postprocess(self, mconfig: Any, service_cfg: Any, desired_cfg: EnodebConfiguration) -> None:
         desired_cfg.set_parameter(ParameterName.CELL_BARRED, True)
         desired_cfg.set_parameter(ParameterName.ADMIN_STATE, True)


### PR DESCRIPTION
## Summary
The PostProcessor class is the class where model specific customization
happens. The current interface to this class is too simple and assumes the
post processing is always the same. Extend it to include configs passed into
the eNB. This allows other eNB models (like Sercomm/FreedomFiOne) to
customize the eNB settings based on the config.

Signed-off-by: Amar Padmanabhan <amar@freedomfi.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Test Plan
make test_python

<!-- Enumerate changes you made and why you made them -->



<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
