### PR TITLE
fix(agw): Add support for ParameterKey

### DIFF
--- a/lte/gateway/python/magma/enodebd/state_machines/enb_acs.py
+++ b/lte/gateway/python/magma/enodebd/state_machines/enb_acs.py
@@ -12,6 +12,7 @@ limitations under the License.
 """
 from abc import ABC, abstractmethod
 from asyncio import BaseEventLoop
+from time import time
 from typing import Any, Type
 
 from magma.common.service import MagmaService
@@ -40,12 +41,15 @@ class EnodebAcsStateMachine(ABC):
     This ABC is more of an interface definition.
     """
 
-    def __init__(self) -> None:
+    def __init__(self, use_param_key: bool = False) -> None:
         self._service = None
         self._desired_cfg = None
         self._device_cfg = None
         self._data_model = None
         self._are_invasive_changes_applied = True
+        # Flag to preseve backwards compatibility
+        self._use_param_key = use_param_key
+        self._param_version_key = None
 
     def has_parameter(self, param: ParameterName) -> bool:
         """
@@ -143,6 +147,8 @@ class EnodebAcsStateMachine(ABC):
 
     @desired_cfg.setter
     def desired_cfg(self, val: EnodebConfiguration) -> None:
+        if self.has_version_key:
+            self.parameter_version_inc()
         self._desired_cfg = val
 
     @property
@@ -156,6 +162,20 @@ class EnodebAcsStateMachine(ABC):
     @property
     def data_model(self) -> DataModel:
         return self._data_model
+
+    @property
+    def has_version_key(self) -> bool:
+        """ Return if the ACS supports param version key """
+        return self._use_param_key
+
+    @property
+    def parameter_version_key(self) -> int:
+        """ Return the param version key """
+        return self._param_version_key
+
+    def parameter_version_inc(self):
+        """ Set the internal version key to the timestamp """
+        self._param_version_key = time()
 
     @data_model.setter
     def data_model(self, data_model) -> None:

--- a/lte/gateway/python/magma/enodebd/state_machines/enb_acs_states.py
+++ b/lte/gateway/python/magma/enodebd/state_machines/enb_acs_states.py
@@ -820,12 +820,20 @@ class SetParameterValuesState(EnodebAcsState):
             self.acs.data_model,
         )
         request.ParameterList.arrayType = 'cwmp:ParameterValueStruct[%d]' \
-                                          % len(param_values)
+                                           % len(param_values)
         request.ParameterList.ParameterValueStruct = []
         logger.debug(
             'Sending TR069 request to set CPE parameter values: %s',
             str(param_values),
         )
+        # TODO: Match key response when we support having multiple outstanding
+        # calls.
+        if self.acs.has_version_key:
+            request.ParameterKey = models.ParameterKeyType()
+            request.ParameterKey.Data =\
+                "SetParameter-{:10.0f}".format(self.acs.parameter_version_key)
+            request.ParameterKey.type = 'xsd:string'
+
         for name, value in param_values.items():
             param_info = self.acs.data_model.get_parameter(name)
             type_ = param_info.type

--- a/lte/gateway/python/magma/enodebd/tr069/models.py
+++ b/lte/gateway/python/magma/enodebd/tr069/models.py
@@ -152,7 +152,7 @@ class ParameterNames(Tr069ComplexModel):
     _type_info["arrayType"] = XmlAttribute(String, ns=SOAP_ENC)
 
 
-class ParameterKeyType(String.customize(max_length=32)):
+class ParameterKeyType(anySimpleType):
     pass
 
 


### PR DESCRIPTION
## Summary

ParameterKey is a field that can be used to communicate the generation of
config that is being set on the enodeb. This is useful for debugging and
some models of eNB (e.g. Sercomm) require this to be set. It looks like
the field was only partially implemented (only in model).
Also fix the type of ParameterKey to be correct in the model definition
(per standard) and updates tr-69 tests to validate Key and NS.
Since there is no way to validate that ParamKey is supported by other
eNBs add the field through an opt in flag.

Signed-off-by: Amar Padmanabhan <amar@freedomfi.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->



<!-- Enumerate changes you made and why you made them -->

## Test Plan

test_python

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
