### PR TITLE
fix(mme): Incorrect sST in PDUSessionResourceSetupRequest

### DIFF
--- a/lte/gateway/c/core/oai/tasks/ngap/ngap_amf_nas_procedures.c
+++ b/lte/gateway/c/core/oai/tasks/ngap/ngap_amf_nas_procedures.c
@@ -25,6 +25,7 @@
 #include "asn1_conversions.h"
 #include "ngap_amf_encoder.h"
 #include "ngap_amf.h"
+#include "ngap_amf_ta.h"
 #include "ngap_amf_nas_procedures.h"
 #include "ngap_amf_itti_messaging.h"
 #include "includes/MetricsHelpers.h"
@@ -1230,7 +1231,7 @@ int ngap_amf_nas_pdusession_resource_setup_stream(
     ngap_pdusession_setup_item_ies->s_NSSAI.sST.size = 1;
     ngap_pdusession_setup_item_ies->s_NSSAI.sST.buf =
         (uint8_t*) calloc(1, sizeof(uint8_t));
-    ngap_pdusession_setup_item_ies->s_NSSAI.sST.buf[0] = 0x11;
+    ngap_pdusession_setup_item_ies->s_NSSAI.sST.buf[0] = _SST_eMBB;
 
     // filling PDU TX Structure
     amf_pdu_ses_setup_transfer_req =


### PR DESCRIPTION
Signed-off-by: LKishor123 <laawanya.kishor@wavelabs.ai>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary
fix(mme): Incorrect sST in PDUSessionResourceSetupRequest
1. Changed Hardcoded value from 0x11.
2. Now the value is fetched from enum s_nssai_sst_s->_SST_eMBB.

<!-- Enumerate changes you made and why you made them -->

## Test Plan
Tested on TeraVM.
![TeraVM_sST_change](https://user-images.githubusercontent.com/52399057/130947149-74484765-f20d-4a4d-b37f-4799ea764cb4.png)

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
