### PR TITLE
feat(session_proxy): Backport to 1.6 of add a flag to disable Service Requested Unit AVP

### DIFF
--- a/feg/gateway/services/session_proxy/credit_control/gy/config.go
+++ b/feg/gateway/services/session_proxy/credit_control/gy/config.go
@@ -24,7 +24,6 @@ import (
 	"magma/feg/gateway/services/session_proxy/credit_control"
 	managed_configs "magma/gateway/mconfig"
 	"magma/orc8r/lib/go/util"
-
 )
 
 // OCS Environment Variables
@@ -54,11 +53,11 @@ const (
 )
 
 var (
-	_ = flag.String(GyInitMethodFlag, "", "Gy init method (per_key|per_session)")
-	_ = flag.String(OCSApnOverwriteFlag, "", "OCS APN to use instead of request's APN")
-	_ = flag.String(OCSServiceIdentifierFlag, "", "OCS ServiceIdentifier to use in Gy requests")
+	_          = flag.String(GyInitMethodFlag, "", "Gy init method (per_key|per_session)")
+	_          = flag.String(OCSApnOverwriteFlag, "", "OCS APN to use instead of request's APN")
+	_          = flag.String(OCSServiceIdentifierFlag, "", "OCS ServiceIdentifier to use in Gy requests")
 	avp437Flag = flag.Bool(DisableRequestedGrantedUnitsAVPFlag, false, "Disable Requested-Service-Unit AVP (437)")
-	)
+)
 
 // InitMethod describes the type of ways sessions can be initialized through the
 // Gy interface


### PR DESCRIPTION
<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

backport https://github.com/magma/magma/pull/8697

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
