### PR TITLE
fix(agw): Fixing monitord "Too many opened files" OSError

### DIFF
--- a/lte/gateway/python/magma/monitord/cpe_monitoring.py
+++ b/lte/gateway/python/magma/monitord/cpe_monitoring.py
@@ -52,7 +52,6 @@ def _get_addr_from_subscribers(sub_ip) -> str:
 
 class CpeMonitoringModule:
     def __init__(self):
-        # TODO: Save to redis
         self._subscriber_state = defaultdict(ICMPMonitoringResponse)
         self.ping_addresses = []
         self.ping_targets = {}
@@ -73,6 +72,8 @@ class CpeMonitoringModule:
         Returns: List of [Subscriber ID => IP address, APN] entries
         """
 
+        ping_addresses = self.ping_addresses.copy()
+        ping_targets = self.ping_targets.copy()
         try:
             mobilityd_chan = ServiceRegistry.get_rpc_channel(
                 'mobilityd',
@@ -87,13 +88,13 @@ class CpeMonitoringModule:
             )
             for sub in response.entries:
                 ip = _get_addr_from_subscribers(sub.ip)
-                self.ping_addresses.append(ip)
-                self.ping_targets[sub.sid.id] = ip
+                ping_addresses.append(ip)
+                ping_targets[sub.sid.id] = ip
         except grpc.RpcError as err:
             logging.error(
                 "GetSubscribers Error for %s! %s", err.code(), err.details(),
             )
-        return PingedTargets(self.ping_targets, self.ping_addresses)
+        return PingedTargets(ping_targets, ping_addresses)
 
     def save_ping_response(
         self, sid: str, ip_addr: str,

--- a/lte/gateway/python/magma/monitord/main.py
+++ b/lte/gateway/python/magma/monitord/main.py
@@ -19,7 +19,7 @@ from magma.common.sentry import sentry_init
 from magma.common.service import MagmaService
 from magma.configuration import load_service_config
 from magma.monitord.cpe_monitoring import CpeMonitoringModule
-from magma.monitord.icmp_monitoring import ICMPMonitoring
+from magma.monitord.icmp_job import ICMPJob
 from magma.monitord.icmp_state import serialize_subscriber_states
 
 
@@ -58,7 +58,7 @@ def main():
     cpe_monitor = CpeMonitoringModule()
     cpe_monitor.set_manually_configured_targets(manual_ping_targets)
 
-    icmp_monitor = ICMPMonitoring(
+    icmp_monitor = ICMPJob(
         cpe_monitor,
         service.mconfig.polling_interval,
         service.loop, mtr_interface,

--- a/lte/gateway/python/magma/monitord/tests/test_icmp_monitor.py
+++ b/lte/gateway/python/magma/monitord/tests/test_icmp_monitor.py
@@ -17,7 +17,7 @@ import unittest
 
 from lte.protos.mobilityd_pb2 import IPAddress, SubscriberIPTable
 from magma.monitord.cpe_monitoring import CpeMonitoringModule
-from magma.monitord.icmp_monitoring import ICMPMonitoring
+from magma.monitord.icmp_job import ICMPJob
 
 LOCALHOST = '127.0.0.1'
 
@@ -44,7 +44,7 @@ class ICMPMonitoringTests(unittest.TestCase):
         self.loop = asyncio.get_event_loop()
         self.subscribers = {}
         self.obj = CpeMonitoringModule()
-        self._monitor = ICMPMonitoring(
+        self._monitor = ICMPJob(
             self.obj, polling_interval=5,
             service_loop=self.loop,
             mtr_interface=LOCALHOST,


### PR DESCRIPTION
Signed-off-by: Alex Rodriguez <ardzoht@gmail.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->
- Current implementation of asynchronous ICMP pinging job of the service is too aggressive, it opens a bunch of subprocess calls (bounded by the total number of subscribers attached) and sends them all at once, defeating the purpose of the asynchronous job.
- It also contains a bug introduced on #3649 refactor which holds inactive subscribers IPs and sends ICMP pings without ever releasing them.
- This PR introduces chunking of ping targets with sleep interval to allow the service to not overload opened subprocess tasks, and also releases inactive subscribers as targets to ping.
- Running `attach/detach` test running with 600 UEs quickly reproduces the issue:
```
Aug 26 17:38:28 phy-u6 monitord[1303578]: Traceback (most recent call last):
Aug 26 17:38:28 phy-u6 monitord[1303578]:   File "/usr/local/lib/python3.8/dist-packages/magma/common/job.py", line 121, in _periodic
Aug 26 17:38:28 phy-u6 monitord[1303578]:     await self._run()
Aug 26 17:38:28 phy-u6 monitord[1303578]:   File "/usr/local/lib/python3.8/dist-packages/magma/monitord/icmp_monitoring.py", line 96, in _run
Aug 26 17:38:28 phy-u6 monitord[1303578]:     await self._ping_targets(addresses, targets)
Aug 26 17:38:28 phy-u6 monitord[1303578]:   File "/usr/local/lib/python3.8/dist-packages/magma/monitord/icmp_monitoring.py", line 69, in _ping_targets
Aug 26 17:38:28 phy-u6 monitord[1303578]:     ping_results = await ping_interface_async(ping_params, self._loop)
Aug 26 17:38:28 phy-u6 monitord[1303578]:   File "/usr/lib/python3.8/asyncio/coroutines.py", line 127, in coro
Aug 26 17:38:28 phy-u6 monitord[1303578]:     res = yield from res
Aug 26 17:38:28 phy-u6 monitord[1303578]:   File "/usr/local/lib/python3.8/dist-packages/magma/magmad/check/subprocess_workflow.py", line 81, in exec_and_parse_subprocesses_async
Aug 26 17:38:28 phy-u6 monitord[1303578]:     subprocs = yield from asyncio.gather(*futures)
Aug 26 17:38:28 phy-u6 monitord[1303578]:   File "/usr/lib/python3.8/asyncio/subprocess.py", line 236, in create_subprocess_exec
Aug 26 17:38:28 phy-u6 monitord[1303578]:     transport, protocol = await loop.subprocess_exec(
Aug 26 17:38:28 phy-u6 monitord[1303578]:   File "/usr/lib/python3.8/asyncio/base_events.py", line 1630, in subprocess_exec
Aug 26 17:38:28 phy-u6 monitord[1303578]:     transport = await self._make_subprocess_transport(
Aug 26 17:38:28 phy-u6 monitord[1303578]:   File "/usr/lib/python3.8/asyncio/unix_events.py", line 197, in _make_subprocess_transport
Aug 26 17:38:28 phy-u6 monitord[1303578]:     transp = _UnixSubprocessTransport(self, protocol, args, shell,
Aug 26 17:38:28 phy-u6 monitord[1303578]:   File "/usr/lib/python3.8/asyncio/base_subprocess.py", line 36, in __init__
Aug 26 17:38:28 phy-u6 monitord[1303578]:     self._start(args=args, shell=shell, stdin=stdin, stdout=stdout,
Aug 26 17:38:28 phy-u6 monitord[1303578]:   File "/usr/lib/python3.8/asyncio/unix_events.py", line 789, in _start
Aug 26 17:38:28 phy-u6 monitord[1303578]:     self._proc = subprocess.Popen(
Aug 26 17:38:28 phy-u6 monitord[1303578]:   File "/usr/lib/python3.8/subprocess.py", line 858, in __init__
Aug 26 17:38:28 phy-u6 monitord[1303578]:     self._execute_child(args, executable, preexec_fn, close_fds,
Aug 26 17:38:28 phy-u6 monitord[1303578]:   File "/usr/lib/python3.8/subprocess.py", line 1605, in _execute_child
Aug 26 17:38:28 phy-u6 monitord[1303578]:     errpipe_read, errpipe_write = os.pipe()
Aug 26 17:38:28 phy-u6 monitord[1303578]: OSError: [Errno 24] Too many open files
```

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->
- Running same `active/detach` test on spirent issue does not appear:
```
magma@phy-u6:~$ sudo systemctl status magma@monitord
● magma@monitord.service - Magma monitord service
     Loaded: loaded (/etc/systemd/system/magma@.service; disabled; vendor preset: enabled)
     Active: active (running) since Thu 2021-08-26 21:39:32 UTC; 56min ago
   Main PID: 1557830 (python3)
      Tasks: 6 (limit: 9339)
     Memory: 47.7M (limit: 300.0M)
     CGroup: /system.slice/system-magma.slice/magma@monitord.service
             └─1557830 python3 -m magma.monitord.main

Aug 26 22:36:13 phy-u6 monitord[1557830]: INFO:root:Pinging 400:500 hosts
Aug 26 22:36:14 phy-u6 monitord[1557830]: INFO:root:001011234560000:192.168.135.166 => 1.237ms
Aug 26 22:36:14 phy-u6 monitord[1557830]: INFO:root:001011234560001:192.168.134.25 => 2.581ms
Aug 26 22:36:14 phy-u6 monitord[1557830]: INFO:root:001011234560002:192.168.129.118 => 1.157ms
Aug 26 22:36:14 phy-u6 monitord[1557830]: INFO:root:001011234560003:192.168.133.31 => 0.938ms
Aug 26 22:36:14 phy-u6 monitord[1557830]: INFO:root:001011234560004:192.168.134.67 => 0.926ms
Aug 26 22:36:14 phy-u6 monitord[1557830]: INFO:root:001011234560005:192.168.134.175 => 1.089ms
Aug 26 22:36:14 phy-u6 monitord[1557830]: INFO:root:001011234560006:192.168.133.59 => 0.864ms
Aug 26 22:36:14 phy-u6 monitord[1557830]: INFO:root:001011234560007:192.168.128.104 => 1.312ms
Aug 26 22:36:14 phy-u6 monitord[1557830]: INFO:root:001011234560008:192.168.134.8 => 1.545ms
```

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
