### PR TITLE
fix(mme): Fix NAS common procedure check segfaults (#8808)

### DIFF
--- a/lte/gateway/c/oai/tasks/nas/nas_procedures.c
+++ b/lte/gateway/c/oai/tasks/nas/nas_procedures.c
@@ -45,6 +45,7 @@
 #include "nas_procedures.h"
 #include "common_defs.h"
 
+// TODO: Add unit tests for common procedure functions
 static nas_emm_common_proc_t* get_nas_common_procedure(
     const struct emm_context_s* const ctxt, emm_common_proc_type_t proc_type);
 static nas_cn_proc_t* get_nas_cn_procedure(
@@ -74,7 +75,7 @@ static nas_emm_common_proc_t* get_nas_common_procedure(
       nas_emm_common_procedure_t* p2 = NULL;
       while (p1) {
         p2 = LIST_NEXT(p1, entries);
-        if (p1->proc->type == proc_type) {
+        if (p1->proc && (p1->proc->type == proc_type)) {
           return p1->proc;
         }
         p1 = p2;
@@ -92,7 +93,7 @@ static nas_cn_proc_t* get_nas_cn_procedure(
       nas_cn_procedure_t* p2 = NULL;
       while (p1) {
         p2 = LIST_NEXT(p1, entries);
-        if (p1->proc->type == proc_type) {
+        if (p1->proc && (p1->proc->type == proc_type)) {
           return p1->proc;
         }
         p1 = p2;


### PR DESCRIPTION
* fix(mme): Fix SIGSEGV faults on proc checks on nas_procedures.c

Signed-off-by: Alex Rodriguez <ardzoht@gmail.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->
- backporting changes of #8808 into v1.5 branch

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->
- make integ_test 

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
