### PR TITLE
feat(subscriberdb): adding support for QoS

### DIFF
--- a/lte/protos/subscriberauth.proto
+++ b/lte/protos/subscriberauth.proto
@@ -80,8 +80,38 @@ message M5GAuthenticationInformationAnswer {
     repeated M5GAuthenticationVector m5gauth_vectors = 2;
 }
 
+message M5GSubscriptionInformationRequest {
+    // Subscriber identifier
+    string user_name = 1;
+}
+
+message M5GSubscriptionInformationAnswer {
+    // EPC error code on failure
+    M5GErrorCode error_code = 1;
+
+    // Subscriber authorized aggregate bitrate
+    AggregatedMaximumBitrate total_ambr = 3;
+
+    message AggregatedMaximumBitrate {
+        // Maximum uplink bitrate
+        uint32 max_bandwidth_ul = 1;
+        // Maximum downlink bitrate
+        uint32 max_bandwidth_dl = 2;
+        // Unit (either bps or Kbps)
+        BitrateUnitsAMBR unit = 3;
+
+        enum BitrateUnitsAMBR {
+         BPS = 0;
+         KBPS = 1;
+        }
+    }
+}
+
+
 service M5GSubscriberAuthentication {
     // Authentication-Information (Code 318)
     rpc M5GAuthenticationInformation (M5GAuthenticationInformationRequest) returns (M5GAuthenticationInformationAnswer) {}
+
+    rpc M5GSubcriptionInformation (M5GSubscriptionInformationRequest) returns (M5GSubscriptionInformationAnswer) {}
 }
 


### PR DESCRIPTION
Signed-off-by: Kaleemullah Mohammed <kaleemullah.mohammed@wavelabs.ai>

Changes: Added GRPC call to provide the default QoS configuration to AMF

## Summary

<!-- Enumerate changes you made and why you made them -->

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
