### PR TITLE
fix(agw): Flaky test case for partial reset

### DIFF
--- a/lte/gateway/python/integ_tests/s1aptests/test_multi_enb_partial_reset.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_multi_enb_partial_reset.py
@@ -106,6 +106,7 @@ class TestMultipleEnbPartialReset(unittest.TestCase):
         )
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(response.msg_type, s1ap_types.tfwCmd.RESET_ACK.value)
+        time.sleep(0.5)
         # Trigger detach request
         for ue in ue_ids:
             print("************************* Calling detach for UE id ", ue)


### PR DESCRIPTION
Signed-off-by: Ulas Kozat <kozat@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->
Partial reset test case has been very flaky in recent tests. Since context release and acknowledging reset request are concurrent events, the timing assumptions of the test case was not always correct. Added half a second delay in the test case before sending detach request to be inline with expected sequence of events by the test scenario.

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->
Run the flaky test >200 times successively without any issues.

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
