### PR TITLE
fix(agw): Update WaitEmptyMessageState logic

### DIFF
--- a/lte/gateway/python/magma/enodebd/state_machines/enb_acs_states.py
+++ b/lte/gateway/python/magma/enodebd/state_machines/enb_acs_states.py
@@ -266,18 +266,24 @@ class WaitEmptyMessageState(EnodebAcsState):
         """
         if not isinstance(message, models.DummyInput):
             logger.debug("Ignoring message %s", str(type(message)))
-            return AcsReadMsgResult(False, None)
-        if (self.unknown_param_transition):
-            if (get_optional_param_to_check((self.acs.data_model))):
-                return AcsReadMsgResult(True, self.unknown_param_transition)
-        return AcsReadMsgResult(True, self.done_transition)
+            return AcsReadMsgResult(msg_handled=False, next_state=None)
+        if self.unknown_param_transition:
+            if get_optional_param_to_check(self.acs.data_model):
+                return AcsReadMsgResult(
+                    msg_handled=True,
+                    next_state=self.unknown_param_transition,
+                )
+        return AcsReadMsgResult(
+            msg_handled=True,
+            next_state=self.done_transition,
+        )
 
     def get_msg(self, message: Any) -> AcsReadMsgResult:
         """
         Return a dummy message waiting for the empty message from CPE
         """
         request = models.DummyInput()
-        return AcsMsgAndTransition(request, None)
+        return AcsMsgAndTransition(msg=request, next_state=None)
 
     def state_description(self) -> str:
         return 'Waiting for empty message from eNodeB'

--- a/lte/gateway/python/magma/enodebd/state_machines/enb_acs_states.py
+++ b/lte/gateway/python/magma/enodebd/state_machines/enb_acs_states.py
@@ -265,10 +265,19 @@ class WaitEmptyMessageState(EnodebAcsState):
         rest of the provisioning process
         """
         if not isinstance(message, models.DummyInput):
+            logger.debug("Ignoring message %s", str(type(message)))
             return AcsReadMsgResult(False, None)
-        if get_optional_param_to_check(self.acs.data_model) is None:
-            return AcsReadMsgResult(True, self.done_transition)
-        return AcsReadMsgResult(True, self.unknown_param_transition)
+        if (self.unknown_param_transition):
+            if (get_optional_param_to_check((self.acs.data_model))):
+                return AcsReadMsgResult(True, self.unknown_param_transition)
+        return AcsReadMsgResult(True, self.done_transition)
+
+    def get_msg(self, message: Any) -> AcsReadMsgResult:
+        """
+        Return a dummy message waiting for the empty message from CPE
+        """
+        request = models.DummyInput()
+        return AcsMsgAndTransition(request, None)
 
     def state_description(self) -> str:
         return 'Waiting for empty message from eNodeB'


### PR DESCRIPTION
<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary
Add a get_message implementation to WaitEmptyMessageState that returns
and empty Dummy message. This allows for the ACS state to transition to
it even in response to any initial message like bootstrap.

Also fix the if logic in the read_message to return unknow_param_transition
only if the method is set.

Signed-off-by: Amar Padmanabhan <amar@freedomfi.com>

<!-- Enumerate changes you made and why you made them -->

## Test Plan

- unit test
- Sercomm radio configuration
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
