### PR TITLE
fix(mme): amf is not accepting if RAN-UE-NGAP-ID is big values

### DIFF
--- a/lte/gateway/c/core/oai/tasks/ngap/ngap_amf_handlers.c
+++ b/lte/gateway/c/core/oai/tasks/ngap/ngap_amf_handlers.c
@@ -726,8 +726,7 @@ status_code_e ngap_amf_handle_initial_context_setup_response(
       Ngap_InitialContextSetupResponseIEs_t, ie, container,
       Ngap_ProtocolIE_ID_id_RAN_UE_NGAP_ID, true);
   if (ie) {
-    gnb_ue_ngap_id = (gnb_ue_ngap_id_t)(
-        ie->value.choice.RAN_UE_NGAP_ID & GNB_UE_NGAP_ID_MASK);
+    gnb_ue_ngap_id = (gnb_ue_ngap_id_t)(ie->value.choice.RAN_UE_NGAP_ID);
   } else {
     OAILOG_FUNC_RETURN(LOG_NGAP, RETURNerror);
   }
@@ -928,8 +927,7 @@ int ngap_amf_handle_ue_context_release_request(
       Ngap_UEContextReleaseRequest_IEs_t, ie, container,
       Ngap_ProtocolIE_ID_id_RAN_UE_NGAP_ID, true);
   if (ie) {
-    gnb_ue_ngap_id = (gnb_ue_ngap_id_t)(
-        ie->value.choice.AMF_UE_NGAP_ID & GNB_UE_NGAP_ID_MASK);
+    gnb_ue_ngap_id = (gnb_ue_ngap_id_t)(ie->value.choice.RAN_UE_NGAP_ID);
   } else {
     OAILOG_FUNC_RETURN(LOG_NGAP, RETURNerror);
   }
@@ -1282,8 +1280,7 @@ status_code_e ngap_amf_handle_initial_context_setup_failure(
       Ngap_InitialContextSetupFailureIEs_t, ie, container,
       Ngap_ProtocolIE_ID_id_RAN_UE_NGAP_ID, true);
   if (ie) {
-    gnb_ue_ngap_id = (gnb_ue_ngap_id_t)(
-        ie->value.choice.RAN_UE_NGAP_ID & GNB_UE_NGAP_ID_MASK);
+    gnb_ue_ngap_id = (gnb_ue_ngap_id_t)(ie->value.choice.RAN_UE_NGAP_ID);
   } else {
     OAILOG_FUNC_RETURN(LOG_NGAP, RETURNok);
   }
@@ -1706,8 +1703,7 @@ status_code_e ngap_amf_handle_pduSession_release_response(
       Ngap_PDUSessionResourceReleaseResponseIEs_t, ie, container,
       Ngap_ProtocolIE_ID_id_RAN_UE_NGAP_ID, true);
   // gNB UE NGAP ID is limited to 24 bits
-  gnb_ue_ngap_id =
-      (gnb_ue_ngap_id_t)(ie->value.choice.RAN_UE_NGAP_ID & GNB_UE_NGAP_ID_MASK);
+  gnb_ue_ngap_id = (gnb_ue_ngap_id_t)(ie->value.choice.RAN_UE_NGAP_ID);
 
   if ((ie) && ue_ref_p->gnb_ue_ngap_id != gnb_ue_ngap_id) {
     OAILOG_ERROR(
@@ -1793,8 +1789,7 @@ status_code_e ngap_amf_handle_pduSession_setup_response(
       Ngap_ProtocolIE_ID_id_RAN_UE_NGAP_ID, true);
   if (ie) {
     // gNB UE NGAP ID is limited to 24 bits
-    gnb_ue_ngap_id = (gnb_ue_ngap_id_t)(
-        ie->value.choice.RAN_UE_NGAP_ID & GNB_UE_NGAP_ID_MASK);
+    gnb_ue_ngap_id = (gnb_ue_ngap_id_t)(ie->value.choice.RAN_UE_NGAP_ID);
   } else {
     OAILOG_FUNC_RETURN(LOG_NGAP, RETURNerror);
   }

--- a/lte/gateway/c/core/oai/tasks/ngap/ngap_amf_nas_procedures.c
+++ b/lte/gateway/c/core/oai/tasks/ngap/ngap_amf_nas_procedures.c
@@ -89,8 +89,7 @@ status_code_e ngap_amf_handle_initial_ue_message(
   }
 
   // gNB UE NGAP ID is limited to 24 bits
-  gnb_ue_ngap_id =
-      (gnb_ue_ngap_id_t)(ie->value.choice.RAN_UE_NGAP_ID & GNB_UE_NGAP_ID_MASK);
+  gnb_ue_ngap_id = (gnb_ue_ngap_id_t)(ie->value.choice.RAN_UE_NGAP_ID);
   OAILOG_DEBUG(
       LOG_NGAP,
       "New Initial UE message received with gNB UE NGAP ID: " GNB_UE_NGAP_ID_FMT

--- a/lte/gateway/c/core/oai/tasks/ngap/ngap_types.h
+++ b/lte/gateway/c/core/oai/tasks/ngap/ngap_types.h
@@ -83,8 +83,7 @@ struct ngap_timer_t {
 typedef struct m5g_ue_description_s {
   enum ng_ue_state_s ng_ue_state;  ///< NGAP UE state
 
-  gnb_ue_ngap_id_t
-      gnb_ue_ngap_id : 24;          ///< Unique UE id over gNB (24 bits wide)
+  gnb_ue_ngap_id_t gnb_ue_ngap_id;  ///< Unique UE id over gNB (24 bits wide)
   amf_ue_ngap_id_t amf_ue_ngap_id;  ///< Unique UE id over AMF (32 bits wide)
   sctp_assoc_id_t sctp_assoc_id;  ///< Assoc id of gNB which this UE is attached
   uint64_t comp_ngap_id;          ///< Unique composite UE id (sctp_assoc_id &

--- a/lte/gateway/c/core/oai/test/ngap/util_ngap_initiate_ue.cpp
+++ b/lte/gateway/c/core/oai/test/ngap/util_ngap_initiate_ue.cpp
@@ -261,8 +261,7 @@ bool validate_handle_initial_ue_message(
       Ngap_ProtocolIE_ID_id_RAN_UE_NGAP_ID);
 
   // gNB UE NGAP ID is limited to 24 bits
-  gnb_ue_ngap_id =
-      (gnb_ue_ngap_id_t)(ie->value.choice.RAN_UE_NGAP_ID & GNB_UE_NGAP_ID_MASK);
+  gnb_ue_ngap_id = (gnb_ue_ngap_id_t)(ie->value.choice.RAN_UE_NGAP_ID);
 
   ue_ref->ng_ue_state = NGAP_UE_WAITING_CSR;
 


### PR DESCRIPTION
Test cases:
    verified registration with bigger RAN-UE-NGAP-ID values.

Signed-off-by: ganeshg87 <ganesh.gedela@wavelabs.ai>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

amf is not allowing bigger RAN-UE-NGAP-ID values

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
