### PR TITLE
chore(policydb): added SubscriberPolicySet to state_cli.py

### DIFF
--- a/lte/gateway/python/scripts/state_cli.py
+++ b/lte/gateway/python/scripts/state_cli.py
@@ -28,7 +28,7 @@ from lte.protos.oai.mme_nas_state_pb2 import (
 )
 from lte.protos.oai.s1ap_state_pb2 import S1apImsiMap, S1apState, UeDescription
 from lte.protos.oai.spgw_state_pb2 import SpgwState, SpgwUeContext
-from lte.protos.policydb_pb2 import InstalledPolicies, PolicyRule
+from lte.protos.policydb_pb2 import InstalledPolicies, PolicyRule, SubscriberPolicySet
 from magma.common.redis.client import get_default_client
 from magma.common.redis.serializers import (
     get_json_deserializer,
@@ -98,6 +98,7 @@ class StateCLI(object):
         'rule_ids': get_json_deserializer(),
         'rule_versions': get_json_deserializer(),
         'rules': get_proto_deserializer(PolicyRule),
+        'apn_installed': get_proto_deserializer(SubscriberPolicySet),
     }
 
     STATE_PROTOS = {
@@ -112,6 +113,7 @@ class StateCLI(object):
         'mobilityd_ipdesc_record': IPDesc,
         'rules': PolicyRule,
         'installed': InstalledPolicies,
+        'apn_installed': SubscriberPolicySet,
     }
 
     def __init__(self):


### PR DESCRIPTION
Signed-off-by: Oriol Batalla <obatalla@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

state_cli was not displaying the contents of `policydb:apn_installed` which includes apn and policy configuration per subscriber.

This PR Adds that support running `state_cli.py parse policydb:apn_installed`

## Test Plan

Tested in teravm

```
magma@ubuntuAGW:/var/opt/magma$ state_cli.py parse policydb:apn_installed
IMSI888881234632894
global_policies: "PCC100-QCI1-STATIC"
global_policies: "PCC101-QCI2-STATIC"
global_policies: "PCC102-QCI3-STATIC"

IMSI888881234632895
global_policies: "PCC100-QCI1-STATIC"
global_policies: "PCC101-QCI2-STATIC"
global_policies: "PCC102-QCI3-STATIC"

IMSI888881234632896
global_policies: "PCC100-QCI1-STATIC"
...
```

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
