### PR TITLE
chore: remove stale symlinks

### DIFF
--- a/feg/README.md
+++ b/feg/README.md
@@ -1,1 +1,0 @@
-../docs/readmes/feg/legacy/README.md

--- a/lte/gateway/python/magma/enodebd/README.md
+++ b/lte/gateway/python/magma/enodebd/README.md
@@ -1,1 +1,0 @@
-../../../../../docs/readmes/lte/enodebd.md

--- a/lte/gateway/release/README_package.md
+++ b/lte/gateway/release/README_package.md
@@ -1,1 +1,0 @@
-../../../docs/readmes/howtos/README_package.md


### PR DESCRIPTION
Signed-off-by: Marie Bremner <marwhal@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary
Found three symlinks that no longer points to existing docs. I'm guessing the original documents were just moved within the doc directory. 
```
vagrant@magma-dev-focal:~/magma$ find . -type l -exec test ! -e {} \; -print
./lte/gateway/python/magma/enodebd/README.md
./lte/gateway/release/README_package.md
./feg/README.md
```
<!-- Enumerate changes you made and why you made them -->

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
