### PR TITLE
feat(sctpd): flagged configuration of upstream / downstream sock

### DIFF
--- a/lte/gateway/c/core/oai/tasks/sctp/sctpd_uplink_server.cpp
+++ b/lte/gateway/c/core/oai/tasks/sctp/sctpd_uplink_server.cpp
@@ -136,18 +136,6 @@ using magma::mme::SctpdUplinkImpl;
 std::shared_ptr<SctpdUplinkImpl> service = nullptr;
 std::unique_ptr<Server> server           = nullptr;
 
-int start_sctpd_uplink_server(void) {
-  service = std::make_shared<SctpdUplinkImpl>();
-
-  ServerBuilder builder;
-  builder.AddListeningPort(UPSTREAM_SOCK, grpc::InsecureServerCredentials());
-  builder.RegisterService(service.get());
-
-  server = builder.BuildAndStart();
-
-  return 0;
-}
-
 void stop_sctpd_uplink_server(void) {
   if (server != nullptr) {
     server->Shutdown();

--- a/lte/gateway/c/sctpd/src/CMakeLists.txt
+++ b/lte/gateway/c/sctpd/src/CMakeLists.txt
@@ -51,7 +51,7 @@ add_library(SCTPD_LIB
 target_compile_definitions(SCTPD_LIB PUBLIC LOG_WITH_GLOG)
 
 target_link_libraries(SCTPD_LIB
-    sctp pthread grpc++ grpc protobuf glog MAGMA_LOGGING
+    sctp pthread grpc++ grpc protobuf glog gflags MAGMA_LOGGING
     )
 
 target_include_directories(SCTPD_LIB PUBLIC


### PR DESCRIPTION
## Summary

Added linking with gflags library, and added two flags to the sctpd binary:

```
  Flags from /magma/lte/gateway/c/sctpd/src/sctpd.cpp:
    -downstream_sock (Path to unix domain socket for SCTPD downstream traffic.)
      type: string default: "unix:///tmp/sctpd_downstream.sock"
    -upstream_sock (Path to unix domain socket for SCTPD upstream traffic.)
      type: string default: "unix:///tmp/sctpd_upstream.sock"
```

Closes #8828.

## Test Plan

- ran LTE integ_test to valdiate existing behavior
- verified command line flags help display

Signed-off-by: Scott Harrison Moeller <smoeller@fb.com>