### PR TITLE
build(nms): Running build.py -g will generate NMS generated files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,8 @@ orc8r/cloud/swagger/specs
 
 # Node
 node_modules/
+orc8r/cloud/package.json
+orc8r/cloud/yarn.lock
 
 # Docusaurus
 docs/docusaurus/build/

--- a/nms/packages/magmalte/scripts/generateAPIFromSwagger.sh
+++ b/nms/packages/magmalte/scripts/generateAPIFromSwagger.sh
@@ -1,9 +1,53 @@
-#! /bin/sh
+#!/bin/bash
+################################################################################
+# Copyright 2020 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
 
 set -e # exit on any error
 
+USAGE="generateAPIFromSwagger.sh — generates NMS API bindings for swagger spec
+
+  Usage:
+    generateAPIFromSwagger.sh <input> <output>
+
+  Options:
+    <input>   Input swagger.yml file to read.
+    <input>   Output file for js bindings.
+    -h        Show this message.
+"
+
+help() {
+  echo "$USAGE"
+}
+
+while getopts ':hs:' option; do
+  case "$option" in
+    h) echo "$USAGE"
+       exit
+       ;;
+   \?) printf "illegal option: -%s\n" "$OPTARG" >&2
+       echo "$USAGE" >&2
+       exit 1
+       ;;
+  esac
+done
+
+INPUT=${1:-swagger.yml}
+OUTPUT=${2:-generated/MagmaAPIBindings.js}
+echo "Input Swagger file: $INPUT";
+echo "Output file: $OUTPUT";
+
 TEMP_FILE=$(mktemp)
-yarn --silent swagger2js gen swagger.yml -t flow -c MagmaAPIBindings -b > "$TEMP_FILE"
+yarn --silent swagger2js gen "$INPUT" -t flow -c MagmaAPIBindings -b > "$TEMP_FILE"
 
 HEADER='/**
  * Copyright 2020 The Magma Authors.
@@ -23,8 +67,4 @@ HEADER='/**
  */
 '
 
-OUTPUT=generated/MagmaAPIBindings.js
-
-# adding this sed command to avoid having Phabricator think this file is
-# generated since it looks for the "generated" keyword
-(echo "$HEADER"; cat "$TEMP_FILE") | sed -e "s#REPLACE_WITH_GENERATED_TOKEN#generated#" >$OUTPUT
+(echo "$HEADER"; cat "$TEMP_FILE") > $OUTPUT

--- a/orc8r/cloud/Makefile
+++ b/orc8r/cloud/Makefile
@@ -37,6 +37,7 @@ SWAGGER_V1_SPECS_DIR := $(MAGMA_ROOT)/orc8r/cloud/swagger/specs
 SWAGGER_V1_PARTIAL_SPECS_DIR := $(SWAGGER_V1_SPECS_DIR)/partial
 SWAGGER_V1_COMMON_DIR := $(SWAGGER_V1_SPECS_DIR)/common
 SWAGGER_V1_STANDALONE_DIR := $(SWAGGER_V1_SPECS_DIR)/standalone
+SWAGGER_NMS_OUT := $(MAGMA_ROOT)/nms/packages/magmalte/generated/MagmaAPIBindings.js
 
 export SWAGGER_ROOT
 export SWAGGER_COMMON
@@ -109,7 +110,7 @@ fmt: $(FMT_LIST)
 $(FMT_LIST): %_fmt:
 	make -C $*/cloud/go fmt
 
-fullgen: clean_gen gen swagger tidy
+fullgen: clean_gen gen swagger nms_fullgen tidy
 
 gen: tools order_imports gen_protos $(GEN_LIST)
 $(GEN_LIST): %_gen:
@@ -156,6 +157,40 @@ swagger_directories:
 	rm -rf $(SWAGGER_V1_SPECS_DIR)
 	mkdir -p $(SWAGGER_V1_COMMON_DIR) $(SWAGGER_V1_PARTIAL_SPECS_DIR) $(SWAGGER_V1_STANDALONE_DIR)
 
-
 $(SWAGGER_LIST): %_swagger:
 	make -C $*/cloud/go swagger_tools copy_swagger_files
+
+#############
+## NMS gen ##
+#############
+
+nms_fullgen: nms_prereqs nms_gen
+
+nms_prereqs:
+	$(MAKE) nms_prereqs_ubuntu || $(MAKE) nms_prereqs_osx
+
+nms_prereqs_ubuntu: nms_node_ubuntu
+	NODE="$(shell which nodejs)"; ln -s $$NODE /usr/local/bin/node
+	# update nodejs to latest
+	curl -sL https://deb.nodesource.com/setup_lts.x | bash -
+	apt-get install -y nodejs
+	# get codegen dependency
+	npm install --global yarn
+	yarn add swagger-js-codegen
+
+nms_node_ubuntu:
+	# install pre-reqs
+	apt update
+	apt install -y nodejs npm
+	# symlink nodejs executable
+	mkdir -p /usr/local/bin
+
+nms_prereqs_osx:
+	node --version || brew install node
+	npm --version || brew install npm
+	yarn --version || npm install --global yarn
+	yarn add swagger-js-codegen
+
+nms_gen:
+	# generate Swagger API bindings for NMS
+	$(MAGMA_ROOT)/nms/packages/magmalte/scripts/generateAPIFromSwagger.sh $(SWAGGER_V1_YML) $(SWAGGER_NMS_OUT)

--- a/orc8r/cloud/docker/build.py
+++ b/orc8r/cloud/docker/build.py
@@ -231,7 +231,10 @@ def _copy_module(module: MagmaModule) -> None:
             os.path.join(build_ctx, d),
         )
 
-    copy_to_ctx('cloud')
+    if module.name == 'nms':
+        copy_to_ctx('packages/magmalte/scripts')
+    else:
+        copy_to_ctx('cloud')
 
     # Orc8r module also has lib/ and gateway/
     if module.name == 'orc8r':

--- a/orc8r/cloud/docker/docker-compose.override.yml
+++ b/orc8r/cloud/docker/docker-compose.override.yml
@@ -18,6 +18,8 @@ services:
       context: /tmp/magma_orc8r_build
       dockerfile: $PWD/controller/Dockerfile
       target: src
+    volumes:
+      - $PWD/../../../nms/packages/magmalte:/src/magma/nms/packages/magmalte
     depends_on:
       - postgres_test
     working_dir: /src/magma/orc8r/cloud


### PR DESCRIPTION
Signed-off-by: Andrei Lee <andreilee@fb.com>

## Summary

This PR ensures that whenever running `./build.py -g` from `magma/orc8r/cloud`, NMS file `MagmaAPIBindings.js` will always be re-generated. This puts NMS in line with having all its generated files checked with `insync-checkin`.

With testing, this added ~50s of runtime to `make fullgen`

This change moves us towards a state where no breaking changes to NMS can be introduced without it being caught by CI.

## Test Plan

Ran `./build.py -g`:
```
➜  docker git:(1-8-make-gen-nms-6) ✗ ./build.py -g
...
# generate Swagger API bindings for NMS
cd /src/magma/nms/packages/magmalte; ./scripts/generateAPIFromSwagger.sh /src/magma/orc8r/cloud/go/obsidian/swagger/v1/swagger.yml /src/magma/nms/packages/magmalte/generated/MagmaAPIBindings.js
Input Swagger file: /src/magma/orc8r/cloud/go/obsidian/swagger/v1/swagger.yml
Output file: /src/magma/nms/packages/magmalte/generated/MagmaAPIBindings.js
...
```

Also ran `make nms_fullgen` on my Macbook.

The included change to `MagmaAPIBindings.js` in this pull request is from running `build.py`

## Additional Information

- [ ] This change is backwards-breaking
