### PR TITLE
(lte)add verbosity option to subscribers list

### DIFF
--- a/lte/cloud/go/services/subscriberdb/obsidian/handlers/handlers.go
+++ b/lte/cloud/go/services/subscriberdb/obsidian/handlers/handlers.go
@@ -19,6 +19,7 @@ import (
 	"net/http"
 	"regexp"
 	"strconv"
+	"strings"
 
 	"magma/orc8r/cloud/go/serde"
 
@@ -226,6 +227,7 @@ func listSubscribersV2Handler(c echo.Context) error {
 		}
 	}
 	pageToken := c.QueryParam(ParamPageToken)
+	verbose := c.QueryParam("verbose")
 	reqCtx := c.Request().Context()
 
 	// First check for query params to filter by
@@ -238,6 +240,13 @@ func listSubscribersV2Handler(c echo.Context) error {
 		if err != nil {
 			return makeErr(err)
 		}
+		if strings.ToLower(verbose) == "false" {
+			subs_keys := make([]string, 0, len(subs))
+			for k := range subs {
+				subs_keys = append(subs_keys, k)
+			}
+			return c.JSON(http.StatusOK, subs_keys)
+		}
 		return c.JSON(http.StatusOK, subs)
 	}
 	if ip := c.QueryParam(ParamIP); ip != "" {
@@ -249,6 +258,13 @@ func listSubscribersV2Handler(c echo.Context) error {
 		subs, err := loadSubscribers(reqCtx, networkID, filter, queryIMSIs...)
 		if err != nil {
 			return makeErr(err)
+		}
+		if strings.ToLower(verbose) == "false" {
+			subs_keys := make([]string, 0, len(subs))
+			for k := range subs {
+				subs_keys = append(subs_keys, k)
+			}
+			return c.JSON(http.StatusOK, subs_keys)
 		}
 		return c.JSON(http.StatusOK, subs)
 	}
@@ -274,6 +290,13 @@ func listSubscribersV2Handler(c echo.Context) error {
 		TotalCount:    int64(count),
 		NextPageToken: subscribermodels.PageToken(nextPageToken),
 		Subscribers:   subs,
+	}
+	if strings.ToLower(verbose) == "false" {
+		subs_keys := make([]string, 0, len(subs))
+		for k := range subs {
+			subs_keys = append(subs_keys, k)
+		}
+		return c.JSON(http.StatusOK, subs_keys)
 	}
 	return c.JSON(http.StatusOK, paginatedSubs)
 }

--- a/lte/cloud/go/services/subscriberdb/obsidian/models/swagger.v1.yml
+++ b/lte/cloud/go/services/subscriberdb/obsidian/models/swagger.v1.yml
@@ -128,6 +128,25 @@ paths:
         default:
           $ref: './orc8r-swagger-common.yml#/responses/UnexpectedError'
 
+  /lte/{network_id}/subscribers_v2?verbose=foorbar:
+    get:
+      summary: List names of subscribers in the network
+      tags:
+        - Subscribers
+      parameters:
+        - $ref: './orc8r-swagger-common.yml#/parameters/network_id'
+        - $ref: './orc8r-swagger-common.yml#/parameters/page_size'
+        - $ref: './orc8r-swagger-common.yml#/parameters/page_token'
+      responses:
+        '200':
+          description: List of names of subscribers in the network
+          schema:
+            type: array
+            items:
+              $ref: './lte-policydb-swagger.yml#/parameters/subscriber_id'
+        default:
+          $ref: './orc8r-swagger-common.yml#/responses/UnexpectedError'
+
   /lte/{network_id}/subscribers/{subscriber_id}:
     get:
       summary: Retrieve the subscriber info


### PR DESCRIPTION
@andreilee @hcgatewood 

## Summary

Updated the `lte/cloud/go/services/subscriberdb/obsidian/handlers/handlers.go` - the `listSubscribersV2Handler` function now returns a list of subscriber names when the flag `verbose` is false

Updated the `lte/cloud/go/services/subscriberdb/obsidian/models/swagger.v1.yml` with an additonal entry in swaggerUI with the option `/lte/{network_id}/subscribers_v2?verbose=false:`

Currently threre is some error breaking the code generation process. This PR is made to allow repro and debug the error.

## Test Plan

Still to be completed. 

Command: `./build.py --generate`

Error trace:
```
stderr:
2021/09/01 00:32:07 trying to read config from /src/magma/orc8r/cloud/docker/controller/goswagger-config.yml
2021/09/01 00:32:07 validating spec /src/magma/lte/cloud/go/services/subscriberdb/obsidian/models/tmpgen303182631/lte-subscriberdb-swagger.yml
The swagger spec at "/src/magma/lte/cloud/go/services/subscriberdb/obsidian/models/tmpgen303182631/lte-subscriberdb-swagger.yml" is invalid against swagger specification 2.0. see errors :
- some references could not be resolved in spec. First found: json: cannot unmarshal bool into Go struct field .required of type []string

: exit status 1
goroutine 1 [running]:
github.com/golang/glog.stacks(0xc000145b00, 0xc000106000, 0x2d3, 0x328)
        /go/pkg/mod/github.com/golang/glog@v0.0.0-20160126235308-23def4e6c14b/glog.go:769 +0xb8
github.com/golang/glog.(*loggingT).output(0x7157c0, 0xc000000003, 0xc0000a4000, 0x6f7d5f, 0x7, 0x69, 0x0)
        /go/pkg/mod/github.com/golang/glog@v0.0.0-20160126235308-23def4e6c14b/glog.go:720 +0x372
github.com/golang/glog.(*loggingT).printf(0x7157c0, 0x3, 0x5d4208, 0x2c, 0xc0000d7ed0, 0x1, 0x1)
        /go/pkg/mod/github.com/golang/glog@v0.0.0-20160126235308-23def4e6c14b/glog.go:655 +0x14b
github.com/golang/glog.Fatalf(...)
        /go/pkg/mod/github.com/golang/glog@v0.0.0-20160126235308-23def4e6c14b/glog.go:1148
main.main()
        /src/magma/orc8r/cloud/go/tools/swaggergen/main.go:105 +0x434
services/subscriberdb/obsidian/models/gen.go:14: running "swaggergen": exit status 255
/src/magma/orc8r/cloud/go/module.mk:33: recipe for target 'gen' failed
make[1]: *** [gen] Error 1
make[1]: Leaving directory '/src/magma/lte/cloud/go'
Makefile:115: recipe for target '/src/magma/lte_gen' failed
make: *** [/src/magma/lte_gen] Error 2
```

## Additional Information

- [ ] This needs additional work before full functionality is achieved
- [ ] Please dont accept as-is this change is breaking currently!

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
