### PR TITLE
fix: Modify python formatting job to run on all PRs

### DIFF
--- a/.github/workflows/python-workflow.yml
+++ b/.github/workflows/python-workflow.yml
@@ -6,12 +6,24 @@ on:  # yamllint disable-line rule:truthy
       - opened
       - reopened
       - synchronize
-    paths:  # order matters here, always put includes then excludes
-      - '**.py'
 
 jobs:
+  pre_job:
+    runs-on: ubuntu-latest
+    # Map a step output to a job output
+    outputs:
+      should_skip: ${{ steps.skip_check.outputs.should_skip }}
+    steps:
+      - id: skip_check
+        uses: fkirc/skip-duplicate-actions@master
+        with:
+          # Only run the main job for changes including the following paths
+          paths: '["**/*.py"]'
+
   run-formatters-and-check-for-errors:
-    name: Run Python formatters and check for errors
+    needs: pre_job
+    if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
+    name: Python Format Check
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -23,14 +35,16 @@ jobs:
         run: |
           echo "::set-output name=py::$(git diff --name-only --diff-filter=ACMRT ${{ github.event.pull_request.base.sha }} ${{ github.sha }} | grep .py$ | xargs)"
       - if: ${{ steps.py-changes.outputs.py }}
-        name: Docker Build
+        name: Build the python-precommit Docker base image
         uses: docker/build-push-action@v2
         with:
           context: .
           file: ./lte/gateway/docker/python-precommit/Dockerfile
           push: false
           tags: magma/py-lint:latest
-      - uses: addnab/docker-run-action@v3
+      - if: ${{ steps.py-changes.outputs.py }}
+        name: Format and check for leftover changes
+        uses: addnab/docker-run-action@v3
         with:
           image: magma/py-lint:latest
           options: -u 0 -v ${{ github.workspace }}:/code


### PR DESCRIPTION
Signed-off-by: Marie Bremner <marwhal@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary
Unfortunately the GitHub action feature that selectively triggers the job is not compatible with Github's branch protection rules. GitHub is not smart enough to figure out that some jobs are not run due to the path selection.

In order to get around this, we'll run the job on all PRs, but have a check to determine inside the job to decide whether the actual test / formatting job needs to be done.
<!-- Enumerate changes you made and why you made them -->

## Test Plan
On PRs that don't have any python changes: 
<img width="1006" alt="Screen Shot 2021-09-01 at 9 40 59 AM" src="https://user-images.githubusercontent.com/37634144/131640522-1e74a432-b0ed-4461-a9e0-8d5ade50b317.png">

On a PR with a few python changes:
<img width="992" alt="Screen Shot 2021-09-01 at 9 47 54 AM" src="https://user-images.githubusercontent.com/37634144/131641495-3eb95e13-3e75-46e9-a81d-15b38e409d00.png">

<img width="1308" alt="Screen Shot 2021-09-01 at 9 46 19 AM" src="https://user-images.githubusercontent.com/37634144/131641277-fe98b74c-f828-4862-aeb2-f477eb0a54fe.png">



<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
