### PR TITLE
fix(agw): Solve bug parsing result from ovsdb-client on GTPStatsCollector

### DIFF
--- a/lte/gateway/python/magma/pipelined/gtp_stats_collector.py
+++ b/lte/gateway/python/magma/pipelined/gtp_stats_collector.py
@@ -47,7 +47,7 @@ interface_group = r"(?P<Interface>\w+)"
 remote_ip_group = r"(?P<remote_ip>.*)"
 rx_bytes_group = r"(?P<rx_bytes>\d+)"
 tx_bytes_group = r"(?P<tx_bytes>\d+)"
-stats_re_str = r'"{}"(.*)(remote_ip="{}")(.*)?rx_bytes={}.+tx_bytes={}'
+stats_re_str = r'{}(.*)(remote_ip="{}")(.*)?rx_bytes={}.+tx_bytes={}'
 
 interface_tx_rx_stats_re = re.compile(
     stats_re_str.format(


### PR DESCRIPTION
…ctor

Solves #8926

Signed-off-by: Joary Paulo Wanzeler Fortuna <joarypl@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

Remove the first pair of double-quotes from the RegEx parsing ovsdb-client result on GTPStatsCollector

## Test Plan

![image](https://user-images.githubusercontent.com/1166157/131752796-f63a2678-254d-4107-b88f-47cd7e684125.png)


## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
