### PR TITLE
fix(mme): Add residual T3422

### DIFF
--- a/lte/gateway/c/core/oai/tasks/nas/emm/Detach.c
+++ b/lte/gateway/c/core/oai/tasks/nas/emm/Detach.c
@@ -476,7 +476,7 @@ status_code_e emm_proc_detach_accept(mme_ue_s1ap_id_t ue_id) {
     OAILOG_DEBUG(
         LOG_NAS_EMM, "EMM-PROC  - Stop timer T3422 (%ld) for ue_id %d \n",
         emm_ctx->T3422.id, ue_id);
-    nas_stop_T3422(ue_id, &(emm_ctx->T3422));
+    nas_stop_T3422(emm_ctx->_imsi64, &(emm_ctx->T3422));
     if (emm_ctx->t3422_arg) {
       free_wrapper(&emm_ctx->t3422_arg);
       emm_ctx->t3422_arg = NULL;
@@ -566,7 +566,7 @@ status_code_e emm_proc_nw_initiated_detach_request(
       /*
        * Re-start T3422 timer
        */
-      nas_stop_T3422(ue_id, &(emm_ctx->T3422));
+      nas_stop_T3422(emm_ctx->_imsi64, &(emm_ctx->T3422));
       nas_start_T3422(
           ue_id, &(emm_ctx->T3422), mme_app_handle_detach_t3422_expiry);
     } else {

--- a/lte/gateway/c/core/oai/tasks/nas/emm/Detach.c
+++ b/lte/gateway/c/core/oai/tasks/nas/emm/Detach.c
@@ -473,9 +473,10 @@ status_code_e emm_proc_detach_accept(mme_ue_s1ap_id_t ue_id) {
 
   // Stop T3422
   if (emm_ctx->T3422.id != NAS_TIMER_INACTIVE_ID) {
-    OAILOG_DEBUG(
-        LOG_NAS_EMM, "EMM-PROC  - Stop timer T3422 (%ld) for ue_id %d \n",
-        emm_ctx->T3422.id, ue_id);
+    OAILOG_DEBUG_UE(
+        LOG_NAS_EMM, emm_ctx->_imsi64,
+        "EMM-PROC  - Stop timer T3422 (%ld) for ue_id %d \n", emm_ctx->T3422.id,
+        ue_id);
     nas_stop_T3422(emm_ctx->_imsi64, &(emm_ctx->T3422));
     if (emm_ctx->t3422_arg) {
       free_wrapper(&emm_ctx->t3422_arg);

--- a/lte/gateway/c/core/oai/tasks/nas/emm/emm_data.h
+++ b/lte/gateway/c/core/oai/tasks/nas/emm/emm_data.h
@@ -568,8 +568,7 @@ void nas_stop_T3460(
     const mme_ue_s1ap_id_t ue_id, struct nas_timer_s* const T3460);
 void nas_stop_T3470(
     const mme_ue_s1ap_id_t ue_id, struct nas_timer_s* const T3470);
-void nas_stop_T3422(
-    const mme_ue_s1ap_id_t ue_id, struct nas_timer_s* const T3422);
+void nas_stop_T3422(const imsi64_t imsi64, struct nas_timer_s* const T3422);
 void nas_start_Ts6a_auth_info(
     const mme_ue_s1ap_id_t ue_id, struct nas_timer_s* const Ts6a_auth_info,
     time_out_t time_out_cb);

--- a/lte/gateway/c/core/oai/tasks/nas/emm/emm_data_ctx.c
+++ b/lte/gateway/c/core/oai/tasks/nas/emm/emm_data_ctx.c
@@ -937,13 +937,11 @@ void nas_stop_T3470(
 }
 
 //------------------------------------------------------------------------------
-void nas_stop_T3422(
-    const mme_ue_s1ap_id_t ue_id, struct nas_timer_s* const T3422) {
+void nas_stop_T3422(const imsi64_t imsi64, struct nas_timer_s* const T3422) {
   if ((T3422) && (T3422->id != NAS_TIMER_INACTIVE_ID)) {
     mme_app_stop_timer(T3422->id);
     T3422->id = NAS_TIMER_INACTIVE_ID;
-    OAILOG_DEBUG(
-        LOG_NAS_EMM, "T3422 stopped UE " MME_UE_S1AP_ID_FMT "\n", ue_id);
+    OAILOG_DEBUG_UE(LOG_NAS_EMM, imsi64, "T3422 stopped ");
   }
 }
 

--- a/lte/gateway/c/core/oai/tasks/nas/nas_procedures.c
+++ b/lte/gateway/c/core/oai/tasks/nas/nas_procedures.c
@@ -471,10 +471,7 @@ void nas_delete_detach_procedure(struct emm_context_s* emm_context) {
 
     // Stop T3422 if running
     if (emm_context->T3422.id != NAS_TIMER_INACTIVE_ID) {
-      void* unused          = NULL;
-      void** timer_callback = &unused;
-      emm_context->T3422.id =
-          nas_timer_stop(emm_context->T3422.id, timer_callback);
+      nas_stop_T3422(emm_context->_imsi64, &(emm_context->T3422));
     }
     if (emm_context->t3422_arg) {
       free_wrapper(&emm_context->t3422_arg);


### PR DESCRIPTION
Signed-off-by: Ulas Kozat <kozat@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->
While migrating T3422, there was one place left during removal of detach procedure. For this particular timer, I also changed from ue_id to IMSI printing in the log message.

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->
S1AP integ tests.

mme.log example for network initiated detach:
```
002016 Thu Sep 02 07:54:37 2021 7F2FED5F2700 DEBUG NAS-EM tasks/nas/emm/Detach.c          :0476   [1010000000001]                     EMM-PROC  - Stop timer T3422 (8) for ue_id 4 
002017 Thu Sep 02 07:54:37 2021 7F2FED5F2700 DEBUG NAS-EM tasks/nas/emm/emm_data_ctx.c    :0944   [1010000000001]                     T3422 stopped 
```

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
