### PR TITLE
feat(ci): Add golangci-lint GH Action for review annotations

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -1,0 +1,24 @@
+---
+name: lint-golangci
+on:  # yamllint disable-line rule:truthy
+  pull_request_target:
+    types:
+      - opened
+      - reopened
+      - synchronize
+    paths:
+      - .github/workflows/golangci-lint.yml
+      - src/go/**
+
+jobs:
+  golangci-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v2
+      - name: golangci-lint
+        uses: reviewdog/action-golangci-lint@v2
+        with:
+          golangci_lint_flags: '--config=../../.golangci.yml'
+          reporter: github-pr-review  # Comments on PR with review comments.
+          workdir: src/go/


### PR DESCRIPTION
We have used ReviewDog wrapped Linters for many of our existing linting at Magma - to great effect. They support GitHub review Annotations which are placed directly on the PR.

Closes #8971

## Test Plan

In test PR #8943, Cherry-picked this PR against @markjen's new Golang AGW pr #8928.

Signed-off-by: Scott Harrison Moeller <smoeller@fb.com>