### PR TITLE
chore(mme): Migrate bearer activation and deactivation timers to zmq

### DIFF
--- a/lte/gateway/c/core/oai/include/mme_app_ue_context.h
+++ b/lte/gateway/c/core/oai/include/mme_app_ue_context.h
@@ -48,6 +48,7 @@
 #include "emm_data.h"
 #include "esm_data.h"
 #include "emm_cnDef.h"
+#include "nas_timer.h"
 
 typedef enum {
   ECM_IDLE = 0,
@@ -102,11 +103,6 @@ mme_ue_s1ap_id_t mme_app_ctx_get_new_ue_id(
 #define MME_APP_UE_CONTEXT_MODIFICATION_TIMER_VALUE 2    // In seconds
 #define MME_APP_PAGING_RESPONSE_TIMER_VALUE 4            // In seconds
 #define MME_APP_ULR_RESPONSE_TIMER_VALUE 3               // In seconds
-/* Timer structure */
-struct mme_app_timer_t {
-  long id;      /* The timer identifier                 */
-  uint32_t sec; /* The timer interval value in seconds  */
-};
 
 /** @struct bearer_context_t
  *  @brief Parameters that should be kept for an eps bearer.
@@ -267,7 +263,7 @@ typedef struct sgs_context_s {
   /* Non EPS Alert Flag */
   bool neaf;
   /* SGS Location update timer */
-  struct mme_app_timer_t ts6_1_timer;
+  nas_timer_t ts6_1_timer;
 
 #define EPS_DETACH_RETRANSMISSION_COUNTER_MAX 2
 #define IMSI_DETACH_RETRANSMISSION_COUNTER_MAX 2
@@ -275,16 +271,16 @@ typedef struct sgs_context_s {
 #define IMPLICIT_EPS_DETACH_RETRANSMISSION_COUNTER_MAX 2
 
   /* SGS EPS Detach indication timer */
-  struct mme_app_timer_t ts8_timer;
+  nas_timer_t ts8_timer;
   unsigned int ts8_retransmission_count;
   /* SGS IMSI Detach indication timer */
-  struct mme_app_timer_t ts9_timer;
+  nas_timer_t ts9_timer;
   unsigned int ts9_retransmission_count;
   /* SGS IMPLICIT IMSI DETACH INDICATION timer */
-  struct mme_app_timer_t ts10_timer;
+  nas_timer_t ts10_timer;
   unsigned int ts10_retransmission_count;
   /* SGS IMPLICIT EPS DETACH INDICATION timer */
-  struct mme_app_timer_t ts13_timer;
+  nas_timer_t ts13_timer;
   unsigned int ts13_retransmission_count;
 
   /* message_p: To store S1AP NAS DL DATA REQ in case of UE initiated IMSI or
@@ -411,22 +407,22 @@ typedef struct ue_mm_context_s {
   /* mobile_reachability_timer: Start when UE moves to idle state.
    *             Stop when UE moves to connected state
    */
-  struct mme_app_timer_t mobile_reachability_timer;
+  nas_timer_t mobile_reachability_timer;
   time_t time_mobile_reachability_timer_started;
   /* implicit_detach_timer: Start at the expiry of Mobile Reachability timer.
    * Stop when UE moves to connected state
    */
-  struct mme_app_timer_t implicit_detach_timer;
+  nas_timer_t implicit_detach_timer;
   time_t time_implicit_detach_timer_started;
   /* Initial Context Setup Procedure Guard timer */
-  struct mme_app_timer_t initial_context_setup_rsp_timer;
+  nas_timer_t initial_context_setup_rsp_timer;
   time_t time_ics_rsp_timer_started;
   /* UE Context Modification Procedure Guard timer */
-  struct mme_app_timer_t ue_context_modification_timer;
+  nas_timer_t ue_context_modification_timer;
   /* Timer for retrying paging messages */
 #define MAX_PAGING_RETRY_COUNT 1
   uint8_t paging_retx_count;
-  struct mme_app_timer_t paging_response_timer;
+  nas_timer_t paging_response_timer;
   time_t time_paging_response_timer_started;
   /* send_ue_purge_request: If true MME shall send S6a- Purge Req to
    * delete contexts at HSS
@@ -436,7 +432,7 @@ typedef struct ue_mm_context_s {
   bool hss_initiated_detach;
   bool location_info_confirmed_in_hss;
   /* S6a- update location request guard timer */
-  struct mme_app_timer_t ulr_response_timer;
+  nas_timer_t ulr_response_timer;
   sgs_context_t* sgs_context;
   uint8_t attach_type;
   lai_t lai;

--- a/lte/gateway/c/core/oai/tasks/mme_app/mme_app_bearer.c
+++ b/lte/gateway/c/core/oai/tasks/mme_app/mme_app_bearer.c
@@ -1869,7 +1869,7 @@ status_code_e mme_app_handle_mobile_reachability_timer_expiry(
   OAILOG_FUNC_IN(LOG_MME_APP);
 
   mme_ue_s1ap_id_t mme_ue_s1ap_id = 0;
-  if (!mme_app_get_timer_arg(timer_id, &mme_ue_s1ap_id)) {
+  if (!mme_app_get_timer_arg_ue_id(timer_id, &mme_ue_s1ap_id)) {
     OAILOG_WARNING(
         LOG_MME_APP, "Invalid Timer Id expiration, Timer Id: %u\n", timer_id);
     OAILOG_FUNC_RETURN(LOG_MME_APP, RETURNok);
@@ -1916,7 +1916,7 @@ status_code_e mme_app_handle_implicit_detach_timer_expiry(
     zloop_t* loop, int timer_id, void* args) {
   OAILOG_FUNC_IN(LOG_MME_APP);
   mme_ue_s1ap_id_t mme_ue_s1ap_id = 0;
-  if (!mme_app_get_timer_arg(timer_id, &mme_ue_s1ap_id)) {
+  if (!mme_app_get_timer_arg_ue_id(timer_id, &mme_ue_s1ap_id)) {
     OAILOG_WARNING(
         LOG_MME_APP, "Invalid Timer Id expiration, Timer Id: %u\n", timer_id);
     OAILOG_FUNC_RETURN(LOG_MME_APP, RETURNok);
@@ -1943,7 +1943,7 @@ status_code_e mme_app_handle_initial_context_setup_rsp_timer_expiry(
     zloop_t* loop, int timer_id, void* args) {
   OAILOG_FUNC_IN(LOG_MME_APP);
   mme_ue_s1ap_id_t mme_ue_s1ap_id = 0;
-  if (!mme_app_get_timer_arg(timer_id, &mme_ue_s1ap_id)) {
+  if (!mme_app_get_timer_arg_ue_id(timer_id, &mme_ue_s1ap_id)) {
     OAILOG_ERROR(
         LOG_MME_APP, "Invalid Timer Id expiration, Timer Id: %u\n", timer_id);
     OAILOG_FUNC_RETURN(LOG_MME_APP, RETURNok);
@@ -2309,7 +2309,7 @@ status_code_e mme_app_handle_paging_timer_expiry(
     zloop_t* loop, int timer_id, void* args) {
   OAILOG_FUNC_IN(LOG_MME_APP);
   mme_ue_s1ap_id_t mme_ue_s1ap_id = 0;
-  if (!mme_app_get_timer_arg(timer_id, &mme_ue_s1ap_id)) {
+  if (!mme_app_get_timer_arg_ue_id(timer_id, &mme_ue_s1ap_id)) {
     OAILOG_WARNING(
         LOG_MME_APP, "Invalid Timer Id expiration, Timer Id: %u\n", timer_id);
     OAILOG_FUNC_RETURN(LOG_MME_APP, RETURNok);
@@ -2385,7 +2385,7 @@ status_code_e mme_app_handle_ulr_timer_expiry(
     zloop_t* loop, int timer_id, void* args) {
   OAILOG_FUNC_IN(LOG_MME_APP);
   mme_ue_s1ap_id_t mme_ue_s1ap_id = 0;
-  if (!mme_app_get_timer_arg(timer_id, &mme_ue_s1ap_id)) {
+  if (!mme_app_get_timer_arg_ue_id(timer_id, &mme_ue_s1ap_id)) {
     OAILOG_WARNING(
         LOG_MME_APP, "Invalid Timer Id expiration, Timer Id: %u\n", timer_id);
     OAILOG_FUNC_RETURN(LOG_MME_APP, RETURNok);
@@ -2698,7 +2698,7 @@ status_code_e mme_app_handle_ue_context_modification_timer_expiry(
     zloop_t* loop, int timer_id, void* args) {
   OAILOG_FUNC_IN(LOG_MME_APP);
   mme_ue_s1ap_id_t mme_ue_s1ap_id = 0;
-  if (!mme_app_get_timer_arg(timer_id, &mme_ue_s1ap_id)) {
+  if (!mme_app_get_timer_arg_ue_id(timer_id, &mme_ue_s1ap_id)) {
     OAILOG_WARNING(
         LOG_MME_APP, "Invalid Timer Id expiration, Timer Id: %u\n", timer_id);
     OAILOG_FUNC_RETURN(LOG_MME_APP, RETURNok);

--- a/lte/gateway/c/core/oai/tasks/mme_app/mme_app_context.c
+++ b/lte/gateway/c/core/oai/tasks/mme_app/mme_app_context.c
@@ -2241,6 +2241,9 @@ static void mme_app_resume_esm_ebr_timer(ue_mm_context_t* ue_context_p) {
   for (int idx = 0; idx < BEARERS_PER_UE; idx++) {
     bearer_context_t* bearer_context_p = ue_context_p->bearer_contexts[idx];
     if (bearer_context_p) {
+      timer_arg_t timer_args;
+      timer_args.ue_id                           = ue_context_p->mme_ue_s1ap_id;
+      timer_args.ebi                             = bearer_context_p->ebi;
       bearer_context_p->esm_ebr_context.timer.id = NAS_TIMER_INACTIVE_ID;
       pdn_cid_t pdn_cid                          = bearer_context_p->pdn_cx_id;
       // Below check is added to identify default and dedicated bearer
@@ -2248,40 +2251,32 @@ static void mme_app_resume_esm_ebr_timer(ue_mm_context_t* ue_context_p) {
           (ue_context_p->pdn_contexts[pdn_cid]->default_ebi ==
            bearer_context_p->ebi)) {
         // Invoke callback registered for default bearer's activation
-        if ((bearer_context_p->esm_ebr_context.args) &&
-            (bearer_context_p->esm_ebr_context.status ==
-             ESM_EBR_ACTIVE_PENDING)) {
+        if (bearer_context_p->esm_ebr_context.status ==
+            ESM_EBR_ACTIVE_PENDING) {
           bearer_context_p->esm_ebr_context.timer.sec = T3485_DEFAULT_VALUE;
           default_eps_bearer_activate_t3485_handler(
-              NULL, bearer_context_p->esm_ebr_context.timer.id,
-              bearer_context_p->esm_ebr_context.args);
+              NULL, NAS_TIMER_INACTIVE_ID, (void*) &timer_args);
         } else {  // Invoke callback registered for default bearer's
                   // deactivation procedure
-          if ((bearer_context_p->esm_ebr_context.args) &&
-              (bearer_context_p->esm_ebr_context.status ==
-               ESM_EBR_INACTIVE_PENDING)) {
+          if (bearer_context_p->esm_ebr_context.status ==
+              ESM_EBR_INACTIVE_PENDING) {
             eps_bearer_deactivate_t3495_handler(
-                NULL, bearer_context_p->esm_ebr_context.timer.id,
-                bearer_context_p->esm_ebr_context.args);
+                NULL, NAS_TIMER_INACTIVE_ID, (void*) &timer_args);
           }
         }
       } else {
         // Invoke callback registered for dedicated bearer's activation
-        if ((bearer_context_p->esm_ebr_context.args) &&
-            (bearer_context_p->esm_ebr_context.status ==
-             ESM_EBR_ACTIVE_PENDING)) {
+        if (bearer_context_p->esm_ebr_context.status ==
+            ESM_EBR_ACTIVE_PENDING) {
           bearer_context_p->esm_ebr_context.timer.sec = T3485_DEFAULT_VALUE;
           dedicated_eps_bearer_activate_t3485_handler(
-              NULL, bearer_context_p->esm_ebr_context.timer.id,
-              bearer_context_p->esm_ebr_context.args);
+              NULL, NAS_TIMER_INACTIVE_ID, (void*) &timer_args);
         } else {  // Invoke callback registered for dedicated bearer's
                   // deactivation procedure
-          if ((bearer_context_p->esm_ebr_context.args) &&
-              (bearer_context_p->esm_ebr_context.status ==
-               ESM_EBR_INACTIVE_PENDING)) {
+          if (bearer_context_p->esm_ebr_context.status ==
+              ESM_EBR_INACTIVE_PENDING) {
             eps_bearer_deactivate_t3495_handler(
-                NULL, bearer_context_p->esm_ebr_context.timer.id,
-                bearer_context_p->esm_ebr_context.args);
+                NULL, NAS_TIMER_INACTIVE_ID, (void*) &timer_args);
           }
         }
       }

--- a/lte/gateway/c/core/oai/tasks/mme_app/mme_app_context.c
+++ b/lte/gateway/c/core/oai/tasks/mme_app/mme_app_context.c
@@ -138,13 +138,13 @@ ue_mm_context_t* mme_create_new_ue_context(void) {
   new_p->mobile_reachability_timer.id = MME_APP_TIMER_INACTIVE_ID;
   new_p->implicit_detach_timer.id     = MME_APP_TIMER_INACTIVE_ID;
 
-  new_p->initial_context_setup_rsp_timer = (struct mme_app_timer_t){
+  new_p->initial_context_setup_rsp_timer = (nas_timer_t){
       MME_APP_TIMER_INACTIVE_ID, MME_APP_INITIAL_CONTEXT_SETUP_RSP_TIMER_VALUE};
-  new_p->paging_response_timer = (struct mme_app_timer_t){
+  new_p->paging_response_timer = (nas_timer_t){
       MME_APP_TIMER_INACTIVE_ID, MME_APP_PAGING_RESPONSE_TIMER_VALUE};
-  new_p->ulr_response_timer = (struct mme_app_timer_t){
-      MME_APP_TIMER_INACTIVE_ID, MME_APP_ULR_RESPONSE_TIMER_VALUE};
-  new_p->ue_context_modification_timer = (struct mme_app_timer_t){
+  new_p->ulr_response_timer = (nas_timer_t){MME_APP_TIMER_INACTIVE_ID,
+                                            MME_APP_ULR_RESPONSE_TIMER_VALUE};
+  new_p->ue_context_modification_timer = (nas_timer_t){
       MME_APP_TIMER_INACTIVE_ID, MME_APP_UE_CONTEXT_MODIFICATION_TIMER_VALUE};
 
   new_p->ue_context_rel_cause = S1AP_INVALID_CAUSE;
@@ -2253,16 +2253,16 @@ static void mme_app_resume_esm_ebr_timer(ue_mm_context_t* ue_context_p) {
              ESM_EBR_ACTIVE_PENDING)) {
           bearer_context_p->esm_ebr_context.timer.sec = T3485_DEFAULT_VALUE;
           default_eps_bearer_activate_t3485_handler(
-              bearer_context_p->esm_ebr_context.args,
-              &ue_context_p->emm_context._imsi64);
+              NULL, bearer_context_p->esm_ebr_context.timer.id,
+              bearer_context_p->esm_ebr_context.args);
         } else {  // Invoke callback registered for default bearer's
                   // deactivation procedure
-          if ((ue_context_p->bearer_contexts[idx]->esm_ebr_context.args) &&
-              (ue_context_p->bearer_contexts[idx]->esm_ebr_context.status ==
+          if ((bearer_context_p->esm_ebr_context.args) &&
+              (bearer_context_p->esm_ebr_context.status ==
                ESM_EBR_INACTIVE_PENDING)) {
             eps_bearer_deactivate_t3495_handler(
-                ue_context_p->bearer_contexts[idx]->esm_ebr_context.args,
-                &ue_context_p->emm_context._imsi64);
+                NULL, bearer_context_p->esm_ebr_context.timer.id,
+                bearer_context_p->esm_ebr_context.args);
           }
         }
       } else {
@@ -2272,16 +2272,16 @@ static void mme_app_resume_esm_ebr_timer(ue_mm_context_t* ue_context_p) {
              ESM_EBR_ACTIVE_PENDING)) {
           bearer_context_p->esm_ebr_context.timer.sec = T3485_DEFAULT_VALUE;
           dedicated_eps_bearer_activate_t3485_handler(
-              bearer_context_p->esm_ebr_context.args,
-              &ue_context_p->emm_context._imsi64);
+              NULL, bearer_context_p->esm_ebr_context.timer.id,
+              bearer_context_p->esm_ebr_context.args);
         } else {  // Invoke callback registered for dedicated bearer's
                   // deactivation procedure
-          if ((ue_context_p->bearer_contexts[idx]->esm_ebr_context.args) &&
-              (ue_context_p->bearer_contexts[idx]->esm_ebr_context.status ==
+          if ((bearer_context_p->esm_ebr_context.args) &&
+              (bearer_context_p->esm_ebr_context.status ==
                ESM_EBR_INACTIVE_PENDING)) {
             eps_bearer_deactivate_t3495_handler(
-                ue_context_p->bearer_contexts[idx]->esm_ebr_context.args,
-                &ue_context_p->emm_context._imsi64);
+                NULL, bearer_context_p->esm_ebr_context.timer.id,
+                bearer_context_p->esm_ebr_context.args);
           }
         }
       }

--- a/lte/gateway/c/core/oai/tasks/mme_app/mme_app_sgs_detach.c
+++ b/lte/gateway/c/core/oai/tasks/mme_app/mme_app_sgs_detach.c
@@ -150,7 +150,7 @@ status_code_e mme_app_handle_sgs_eps_detach_timer_expiry(
     zloop_t* loop, int timer_id, void* args) {
   OAILOG_FUNC_IN(LOG_MME_APP);
   mme_ue_s1ap_id_t mme_ue_s1ap_id = 0;
-  if (!mme_app_get_timer_arg(timer_id, &mme_ue_s1ap_id)) {
+  if (!mme_app_get_timer_arg_ue_id(timer_id, &mme_ue_s1ap_id)) {
     OAILOG_WARNING(
         LOG_MME_APP, "Invalid Timer Id expiration, Timer Id: %u\n", timer_id);
     OAILOG_FUNC_RETURN(LOG_MME_APP, RETURNerror);
@@ -210,7 +210,7 @@ status_code_e mme_app_handle_sgs_implicit_eps_detach_timer_expiry(
     zloop_t* loop, int timer_id, void* args) {
   OAILOG_FUNC_IN(LOG_MME_APP);
   mme_ue_s1ap_id_t mme_ue_s1ap_id = 0;
-  if (!mme_app_get_timer_arg(timer_id, &mme_ue_s1ap_id)) {
+  if (!mme_app_get_timer_arg_ue_id(timer_id, &mme_ue_s1ap_id)) {
     OAILOG_WARNING(
         LOG_MME_APP, "Invalid Timer Id expiration, Timer Id: %u\n", timer_id);
     OAILOG_FUNC_RETURN(LOG_MME_APP, RETURNerror);
@@ -351,7 +351,7 @@ status_code_e mme_app_handle_sgs_imsi_detach_timer_expiry(
     zloop_t* loop, int timer_id, void* args) {
   OAILOG_FUNC_IN(LOG_MME_APP);
   mme_ue_s1ap_id_t mme_ue_s1ap_id = 0;
-  if (!mme_app_get_timer_arg(timer_id, &mme_ue_s1ap_id)) {
+  if (!mme_app_get_timer_arg_ue_id(timer_id, &mme_ue_s1ap_id)) {
     OAILOG_WARNING(
         LOG_MME_APP, "Invalid Timer Id expiration, Timer Id: %u\n", timer_id);
     OAILOG_FUNC_RETURN(LOG_MME_APP, RETURNerror);
@@ -434,7 +434,7 @@ status_code_e mme_app_handle_sgs_implicit_imsi_detach_timer_expiry(
     zloop_t* loop, int timer_id, void* args) {
   OAILOG_FUNC_IN(LOG_MME_APP);
   mme_ue_s1ap_id_t mme_ue_s1ap_id = 0;
-  if (!mme_app_get_timer_arg(timer_id, &mme_ue_s1ap_id)) {
+  if (!mme_app_get_timer_arg_ue_id(timer_id, &mme_ue_s1ap_id)) {
     OAILOG_WARNING(
         LOG_MME_APP, "Invalid Timer Id expiration, Timer Id: %u\n", timer_id);
     OAILOG_FUNC_RETURN(LOG_MME_APP, RETURNerror);

--- a/lte/gateway/c/core/oai/tasks/mme_app/mme_app_sgsap_location_update.c
+++ b/lte/gateway/c/core/oai/tasks/mme_app/mme_app_sgsap_location_update.c
@@ -935,7 +935,7 @@ status_code_e mme_app_handle_ts6_1_timer_expiry(
     zloop_t* loop, int timer_id, void* args) {
   OAILOG_FUNC_IN(LOG_MME_APP);
   mme_ue_s1ap_id_t mme_ue_s1ap_id = 0;
-  if (!mme_app_get_timer_arg(timer_id, &mme_ue_s1ap_id)) {
+  if (!mme_app_get_timer_arg_ue_id(timer_id, &mme_ue_s1ap_id)) {
     OAILOG_WARNING(
         LOG_MME_APP, "Invalid Timer Id expiration, Timer Id: %u\n", timer_id);
     OAILOG_FUNC_RETURN(LOG_MME_APP, RETURNerror);

--- a/lte/gateway/c/core/oai/tasks/mme_app/mme_app_state_converter.cpp
+++ b/lte/gateway/c/core/oai/tasks/mme_app/mme_app_state_converter.cpp
@@ -334,8 +334,10 @@ void MmeNasStateConverter::bearer_context_list_to_proto(
         ue_context_proto->add_bearer_contexts();
     if (state_ue_context.bearer_contexts[i]) {
       OAILOG_DEBUG(
-          LOG_MME_APP, "writing bearer context at index %d with ebi %d", i,
-          state_ue_context.bearer_contexts[i]->ebi);
+          LOG_MME_APP,
+          "writing bearer context at index %d with ebi %d timer id %ld", i,
+          state_ue_context.bearer_contexts[i]->ebi,
+          state_ue_context.bearer_contexts[i]->esm_ebr_context.timer.id);
       bearer_ctxt_proto->set_validity(oai::BearerContext::VALID);
       bearer_context_to_proto(
           *state_ue_context.bearer_contexts[i], bearer_ctxt_proto);
@@ -350,7 +352,6 @@ void MmeNasStateConverter::proto_to_bearer_context_list(
   for (int i = 0; i < BEARERS_PER_UE; i++) {
     if (ue_context_proto.bearer_contexts(i).validity() ==
         oai::BearerContext::VALID) {
-      OAILOG_DEBUG(LOG_MME_APP, "reading bearer context at index %d", i);
       auto* eps_bearer_ctxt =
           (bearer_context_t*) calloc(1, sizeof(bearer_context_t));
       proto_to_bearer_context(
@@ -360,6 +361,12 @@ void MmeNasStateConverter::proto_to_bearer_context_list(
         state_ue_context->bearer_contexts[i]->esm_ebr_context.args->ctx =
             &state_ue_context->emm_context;
       }
+      OAILOG_DEBUG(
+          LOG_MME_APP,
+          "Reading bearer context at index %d with ebi %d timer id %ld", i,
+          state_ue_context->bearer_contexts[i]->ebi,
+          state_ue_context->bearer_contexts[i]->esm_ebr_context.timer.id);
+
     } else {
       state_ue_context->bearer_contexts[i] = nullptr;
     }

--- a/lte/gateway/c/core/oai/tasks/mme_app/mme_app_state_converter.cpp
+++ b/lte/gateway/c/core/oai/tasks/mme_app/mme_app_state_converter.cpp
@@ -201,13 +201,13 @@ void MmeNasStateConverter::proto_to_guti_table(
  **********************************************************/
 
 void MmeNasStateConverter::mme_app_timer_to_proto(
-    const mme_app_timer_t& state_mme_timer, oai::Timer* timer_proto) {
+    const nas_timer_t& state_mme_timer, oai::Timer* timer_proto) {
   timer_proto->set_id(state_mme_timer.id);
   timer_proto->set_sec(state_mme_timer.sec);
 }
 
 void MmeNasStateConverter::proto_to_mme_app_timer(
-    const oai::Timer& timer_proto, mme_app_timer_t* state_mme_app_timer) {
+    const oai::Timer& timer_proto, nas_timer_t* state_mme_app_timer) {
   state_mme_app_timer->id  = timer_proto.id();
   state_mme_app_timer->sec = timer_proto.sec();
 }

--- a/lte/gateway/c/core/oai/tasks/mme_app/mme_app_state_converter.h
+++ b/lte/gateway/c/core/oai/tasks/mme_app/mme_app_state_converter.h
@@ -104,10 +104,10 @@ class MmeNasStateConverter : public StateConverter {
    **********************************************************/
 
   static void mme_app_timer_to_proto(
-      const mme_app_timer_t& state_mme_timer, oai::Timer* timer_proto);
+      const nas_timer_t& state_mme_timer, oai::Timer* timer_proto);
 
   static void proto_to_mme_app_timer(
-      const oai::Timer& timer_proto, mme_app_timer_t* state_mme_app_timer);
+      const oai::Timer& timer_proto, nas_timer_t* state_mme_app_timer);
 
   static void sgs_context_to_proto(
       sgs_context_t* state_sgs_context, oai::SgsContext* sgs_context_proto);

--- a/lte/gateway/c/core/oai/tasks/mme_app/mme_app_timer.h
+++ b/lte/gateway/c/core/oai/tasks/mme_app/mme_app_timer.h
@@ -20,22 +20,28 @@ extern "C" {
 
 #include "intertask_interface.h"
 #include "mme_app_ue_context.h"
+#include "nas_timer.h"
 
 #define MME_APP_TIMER_INACTIVE_ID (-1)
 
-typedef uint32_t timer_arg_t;
+int mme_app_start_timer_arg(
+    size_t msec, timer_repeat_t repeat, zloop_timer_fn handler,
+    timer_arg_t* arg);
 
+// Most handlers only need mme_ue_s1ap_id, use this function for
+// such handlers.
 int mme_app_start_timer(
-    size_t msec, timer_repeat_t repeat, zloop_timer_fn handler, timer_arg_t id);
+    size_t msec, timer_repeat_t repeat, zloop_timer_fn handler,
+    mme_ue_s1ap_id_t ue_id);
 
 void mme_app_stop_timer(int timer_id);
 
 void mme_app_resume_timer(
     struct ue_mm_context_s* const ue_mm_context_pP, time_t start_time,
-    struct mme_app_timer_t* timer, zloop_timer_fn timer_expiry_handler,
-    char* timer_name);
+    nas_timer_t* timer, zloop_timer_fn timer_expiry_handler, char* timer_name);
 
 bool mme_app_get_timer_arg(int timer_id, timer_arg_t* arg);
+bool mme_app_get_timer_arg_ue_id(int timer_id, mme_ue_s1ap_id_t* ue_id);
 
 #ifdef __cplusplus
 }

--- a/lte/gateway/c/core/oai/tasks/mme_app/mme_app_timer_management.cpp
+++ b/lte/gateway/c/core/oai/tasks/mme_app/mme_app_timer_management.cpp
@@ -110,7 +110,7 @@ namespace lte {
 //------------------------------------------------------------------------------
 int MmeUeContext::StartTimer(
     size_t msec, timer_repeat_t repeat, zloop_timer_fn handler,
-    TimerArgType& arg) {
+    const TimerArgType& arg) {
   int timer_id = -1;
   if ((timer_id = start_timer(
            &mme_app_task_zmq_ctx, msec, repeat, handler, nullptr)) != -1) {

--- a/lte/gateway/c/core/oai/tasks/mme_app/mme_app_timer_management.cpp
+++ b/lte/gateway/c/core/oai/tasks/mme_app/mme_app_timer_management.cpp
@@ -26,11 +26,21 @@ extern "C" {
 extern task_zmq_ctx_t mme_app_task_zmq_ctx;
 
 //------------------------------------------------------------------------------
+int mme_app_start_timer_arg(
+    size_t msec, timer_repeat_t repeat, zloop_timer_fn handler,
+    timer_arg_t* arg) {
+  return magma::lte::MmeUeContext::Instance().StartTimer(
+      msec, repeat, handler, *arg);
+}
+
 int mme_app_start_timer(
     size_t msec, timer_repeat_t repeat, zloop_timer_fn handler,
-    timer_arg_t id) {
+    mme_ue_s1ap_id_t ue_id) {
+  timer_arg_t arg;
+  arg.ue_id = ue_id;
+  arg.ebi   = UINT8_MAX;  // fill in an invalid ebi as it is unused
   return magma::lte::MmeUeContext::Instance().StartTimer(
-      msec, repeat, handler, id);
+      msec, repeat, handler, arg);
 }
 
 //------------------------------------------------------------------------------
@@ -40,8 +50,7 @@ void mme_app_stop_timer(int timer_id) {
 //------------------------------------------------------------------------------
 void mme_app_resume_timer(
     struct ue_mm_context_s* const ue_mm_context_pP, time_t start_time,
-    struct mme_app_timer_t* timer, zloop_timer_fn timer_expiry_handler,
-    char* timer_name) {
+    nas_timer_t* timer, zloop_timer_fn timer_expiry_handler, char* timer_name) {
   OAILOG_FUNC_IN(LOG_MME_APP);
   time_t current_time = time(NULL);
   time_t lapsed_time  = current_time - start_time;
@@ -63,9 +72,12 @@ void mme_app_resume_timer(
       remaining_time_in_seconds);
 
   // Start timer only for remaining duration
+  timer_arg_t arg;
+  arg.ue_id = ue_mm_context_pP->mme_ue_s1ap_id;
+  arg.ebi   = UINT8_MAX;  // fill in an invalid ebi as it is unused
   if ((timer->id = magma::lte::MmeUeContext::Instance().StartTimer(
            remaining_time_in_seconds * 1000, TIMER_REPEAT_ONCE,
-           timer_expiry_handler, ue_mm_context_pP->mme_ue_s1ap_id)) == -1) {
+           timer_expiry_handler, arg)) == -1) {
     OAILOG_ERROR_UE(
         LOG_MME_APP, ue_mm_context_pP->emm_context._imsi64,
         "Failed to start %s timer for UE id "
@@ -85,16 +97,24 @@ bool mme_app_get_timer_arg(int timer_id, timer_arg_t* arg) {
   return magma::lte::MmeUeContext::Instance().GetTimerArg(timer_id, arg);
 }
 
+bool mme_app_get_timer_arg_ue_id(int timer_id, mme_ue_s1ap_id_t* ue_id) {
+  timer_arg_t arg;
+  bool result =
+      magma::lte::MmeUeContext::Instance().GetTimerArg(timer_id, &arg);
+  *ue_id = arg.ue_id;
+  return result;
+}
+
 namespace magma {
 namespace lte {
 //------------------------------------------------------------------------------
 int MmeUeContext::StartTimer(
     size_t msec, timer_repeat_t repeat, zloop_timer_fn handler,
-    TimerArgType arg) {
+    TimerArgType& arg) {
   int timer_id = -1;
   if ((timer_id = start_timer(
            &mme_app_task_zmq_ctx, msec, repeat, handler, nullptr)) != -1) {
-    mme_app_timers.insert(std::pair<int, uint32_t>(timer_id, arg));
+    mme_app_timers.insert(std::pair<int, TimerArgType>(timer_id, arg));
   }
   return timer_id;
 }

--- a/lte/gateway/c/core/oai/tasks/mme_app/mme_app_timer_management.h
+++ b/lte/gateway/c/core/oai/tasks/mme_app/mme_app_timer_management.h
@@ -12,21 +12,20 @@ limitations under the License.
 */
 #ifndef FILE_MME_UE_CONTEXT_H_SEEN
 #define FILE_MME_UE_CONTEXT_H_SEEN
-//--C includes -----------------------------------------------------------------
+// C includes --------------------------------------------------------------
 extern "C" {
 #include "intertask_interface.h"
 #include "esm_data.h"
 #include "mme_app_timer.h"
 }
-////--C++ includes
-///---------------------------------------------------------------
+// C++ includes ------------------------------------------------------------
 #include <czmq.h>
 #include <map>
+#include <utility>
 #include <stddef.h>
 #include <stdint.h>
-#include <utility>
-////--Other includes
-///-------------------------------------------------------------
+// Other includes ----------------------------------------------------------
+
 namespace magma {
 namespace lte {
 

--- a/lte/gateway/c/core/oai/tasks/mme_app/mme_app_timer_management.h
+++ b/lte/gateway/c/core/oai/tasks/mme_app/mme_app_timer_management.h
@@ -16,6 +16,7 @@ limitations under the License.
 extern "C" {
 #include "intertask_interface.h"
 #include "esm_data.h"
+#include "mme_app_timer.h"
 }
 ////--C++ includes
 ///---------------------------------------------------------------
@@ -29,7 +30,7 @@ extern "C" {
 namespace magma {
 namespace lte {
 
-typedef uint32_t TimerArgType;
+typedef timer_arg_t TimerArgType;
 
 class MmeUeContext {
  private:
@@ -47,7 +48,7 @@ class MmeUeContext {
 
   int StartTimer(
       size_t msec, timer_repeat_t repeat, zloop_timer_fn handler,
-      TimerArgType id);
+      TimerArgType& arg);
   void StopTimer(int timer_id);
 
   bool GetTimerArg(const int timer_id, TimerArgType* arg) const;

--- a/lte/gateway/c/core/oai/tasks/mme_app/mme_app_timer_management.h
+++ b/lte/gateway/c/core/oai/tasks/mme_app/mme_app_timer_management.h
@@ -20,13 +20,13 @@ extern "C" {
 }
 ////--C++ includes
 ///---------------------------------------------------------------
-////--Other includes
-///-------------------------------------------------------------
 #include <czmq.h>
 #include <map>
 #include <stddef.h>
 #include <stdint.h>
-
+#include <utility>
+////--Other includes
+///-------------------------------------------------------------
 namespace magma {
 namespace lte {
 
@@ -48,7 +48,7 @@ class MmeUeContext {
 
   int StartTimer(
       size_t msec, timer_repeat_t repeat, zloop_timer_fn handler,
-      TimerArgType& arg);
+      const TimerArgType& arg);
   void StopTimer(int timer_id);
 
   bool GetTimerArg(const int timer_id, TimerArgType* arg) const;

--- a/lte/gateway/c/core/oai/tasks/nas/emm/Attach.c
+++ b/lte/gateway/c/core/oai/tasks/nas/emm/Attach.c
@@ -960,7 +960,7 @@ status_code_e mme_app_handle_emm_attach_t3450_expiry(
   OAILOG_FUNC_IN(LOG_NAS_EMM);
 
   mme_ue_s1ap_id_t mme_ue_s1ap_id = 0;
-  if (!mme_app_get_timer_arg(timer_id, &mme_ue_s1ap_id)) {
+  if (!mme_app_get_timer_arg_ue_id(timer_id, &mme_ue_s1ap_id)) {
     OAILOG_WARNING(
         LOG_NAS_EMM, "Invalid Timer Id expiration, Timer Id: %u\n", timer_id);
     OAILOG_FUNC_RETURN(LOG_NAS_EMM, RETURNok);

--- a/lte/gateway/c/core/oai/tasks/nas/emm/Authentication.c
+++ b/lte/gateway/c/core/oai/tasks/nas/emm/Authentication.c
@@ -1061,7 +1061,7 @@ status_code_e mme_app_handle_auth_t3460_expiry(
   OAILOG_FUNC_IN(LOG_NAS_EMM);
 
   mme_ue_s1ap_id_t mme_ue_s1ap_id = 0;
-  if (!mme_app_get_timer_arg(timer_id, &mme_ue_s1ap_id)) {
+  if (!mme_app_get_timer_arg_ue_id(timer_id, &mme_ue_s1ap_id)) {
     OAILOG_WARNING(
         LOG_NAS_EMM, "Invalid Timer Id expiration, Timer Id: %u\n", timer_id);
     OAILOG_FUNC_RETURN(LOG_NAS_EMM, RETURNok);
@@ -1583,7 +1583,7 @@ status_code_e mme_app_handle_air_timer_expiry(
   OAILOG_FUNC_IN(LOG_NAS_EMM);
 
   mme_ue_s1ap_id_t mme_ue_s1ap_id = 0;
-  if (!mme_app_get_timer_arg(timer_id, &mme_ue_s1ap_id)) {
+  if (!mme_app_get_timer_arg_ue_id(timer_id, &mme_ue_s1ap_id)) {
     OAILOG_WARNING(
         LOG_NAS_EMM, "Invalid Timer Id expiration, Timer Id: %u\n", timer_id);
     OAILOG_FUNC_RETURN(LOG_NAS_EMM, RETURNok);

--- a/lte/gateway/c/core/oai/tasks/nas/emm/Detach.c
+++ b/lte/gateway/c/core/oai/tasks/nas/emm/Detach.c
@@ -101,7 +101,7 @@ status_code_e mme_app_handle_detach_t3422_expiry(
     mme_ue_s1ap_id = data->ue_id;
     emm_ctx        = emm_context_get(&_emm_data, mme_ue_s1ap_id);
   } else {
-    if (!mme_app_get_timer_arg(timer_id, &mme_ue_s1ap_id)) {
+    if (!mme_app_get_timer_arg_ue_id(timer_id, &mme_ue_s1ap_id)) {
       OAILOG_WARNING(
           LOG_NAS_EMM, "Invalid Timer Id expiration, Timer Id: %u\n", timer_id);
       OAILOG_FUNC_RETURN(LOG_NAS_EMM, RETURNok);

--- a/lte/gateway/c/core/oai/tasks/nas/emm/Identification.c
+++ b/lte/gateway/c/core/oai/tasks/nas/emm/Identification.c
@@ -44,6 +44,7 @@
 #include "nas_procedures.h"
 #include "nas_proc.h"
 #include "includes/MetricsHelpers.h"
+#include "mme_app_timer.h"
 
 /****************************************************************************/
 /****************  E X T E R N A L    D E F I N I T I O N S  ****************/

--- a/lte/gateway/c/core/oai/tasks/nas/emm/Identification.c
+++ b/lte/gateway/c/core/oai/tasks/nas/emm/Identification.c
@@ -385,7 +385,7 @@ status_code_e mme_app_handle_identification_t3470_expiry(
     zloop_t* loop, int timer_id, void* args) {
   OAILOG_FUNC_IN(LOG_NAS_EMM);
   mme_ue_s1ap_id_t mme_ue_s1ap_id = 0;
-  if (!mme_app_get_timer_arg(timer_id, &mme_ue_s1ap_id)) {
+  if (!mme_app_get_timer_arg_ue_id(timer_id, &mme_ue_s1ap_id)) {
     OAILOG_WARNING(
         LOG_NAS_EMM, "Invalid Timer Id expiration, Timer Id: %u\n", timer_id);
     OAILOG_FUNC_RETURN(LOG_NAS_EMM, RETURNok);

--- a/lte/gateway/c/core/oai/tasks/nas/emm/SecurityModeControl.c
+++ b/lte/gateway/c/core/oai/tasks/nas/emm/SecurityModeControl.c
@@ -745,7 +745,7 @@ status_code_e mme_app_handle_security_t3460_expiry(
   OAILOG_FUNC_IN(LOG_NAS_EMM);
 
   mme_ue_s1ap_id_t mme_ue_s1ap_id = 0;
-  if (!mme_app_get_timer_arg(timer_id, &mme_ue_s1ap_id)) {
+  if (!mme_app_get_timer_arg_ue_id(timer_id, &mme_ue_s1ap_id)) {
     OAILOG_WARNING(
         LOG_NAS_EMM, "Invalid Timer Id expiration, Timer Id: %u\n", timer_id);
     OAILOG_FUNC_RETURN(LOG_NAS_EMM, RETURNok);

--- a/lte/gateway/c/core/oai/tasks/nas/emm/TrackingAreaUpdate.c
+++ b/lte/gateway/c/core/oai/tasks/nas/emm/TrackingAreaUpdate.c
@@ -464,7 +464,7 @@ status_code_e mme_app_handle_tau_t3450_expiry(
     zloop_t* loop, int timer_id, void* args) {
   OAILOG_FUNC_IN(LOG_NAS_EMM);
   mme_ue_s1ap_id_t mme_ue_s1ap_id = 0;
-  if (!mme_app_get_timer_arg(timer_id, &mme_ue_s1ap_id)) {
+  if (!mme_app_get_timer_arg_ue_id(timer_id, &mme_ue_s1ap_id)) {
     OAILOG_WARNING(
         LOG_NAS_EMM, "Invalid Timer Id expiration, Timer Id: %u\n", timer_id);
     OAILOG_FUNC_RETURN(LOG_NAS_EMM, RETURNok);

--- a/lte/gateway/c/core/oai/tasks/nas/emm/TrackingAreaUpdate.c
+++ b/lte/gateway/c/core/oai/tasks/nas/emm/TrackingAreaUpdate.c
@@ -753,7 +753,6 @@ static int emm_tracking_area_update_accept(nas_emm_tau_proc_t* const tau_proc) {
           /*
            * Re-start T3450 timer
            */
-          void* timer_callback_arg = NULL;
           nas_stop_T3450(tau_proc->ue_id, &tau_proc->T3450);
           nas_start_T3450(
               tau_proc->ue_id, &tau_proc->T3450,

--- a/lte/gateway/c/core/oai/tasks/nas/esm/DedicatedEpsBearerContextActivation.c
+++ b/lte/gateway/c/core/oai/tasks/nas/esm/DedicatedEpsBearerContextActivation.c
@@ -415,7 +415,9 @@ status_code_e dedicated_eps_bearer_activate_t3485_handler(
   OAILOG_FUNC_IN(LOG_NAS_ESM);
 
   timer_arg_t timer_args;
-  if (!mme_app_get_timer_arg(timer_id, &timer_args)) {
+  if (args) {
+    timer_args = *((timer_arg_t*) args);
+  } else if (!mme_app_get_timer_arg(timer_id, &timer_args)) {
     OAILOG_WARNING(
         LOG_NAS_EMM, "Invalid Timer Id expiration, Timer Id: %u\n", timer_id);
     OAILOG_FUNC_RETURN(LOG_NAS_ESM, RETURNok);

--- a/lte/gateway/c/core/oai/tasks/nas/esm/DedicatedEpsBearerContextActivation.c
+++ b/lte/gateway/c/core/oai/tasks/nas/esm/DedicatedEpsBearerContextActivation.c
@@ -38,6 +38,7 @@
 #include "emm_esmDef.h"
 #include "esm_data.h"
 #include "mme_app_defs.h"
+#include "mme_app_timer.h"
 
 /****************************************************************************/
 /****************  E X T E R N A L    D E F I N I T I O N S  ****************/
@@ -63,8 +64,8 @@
 static int dedicated_eps_bearer_activate(
     emm_context_t* emm_context, ebi_t ebi, STOLEN_REF bstring* msg);
 
-static void erab_setup_rsp_tmr_exp_ded_bearer_handler(
-    void* args, imsi64_t* imsi64);
+static status_code_e erab_setup_rsp_tmr_exp_ded_bearer_handler(
+    zloop_t* loop, int timer_id, void* args);
 
 /****************************************************************************/
 /******************  E X P O R T E D    F U N C T I O N S  ******************/
@@ -409,19 +410,49 @@ status_code_e esm_proc_dedicated_eps_bearer_context_reject(
  **      Others:    None                                                   **
  **                                                                        **
  ***************************************************************************/
-void dedicated_eps_bearer_activate_t3485_handler(void* args, imsi64_t* imsi64) {
+status_code_e dedicated_eps_bearer_activate_t3485_handler(
+    zloop_t* loop, int timer_id, void* args) {
   OAILOG_FUNC_IN(LOG_NAS_ESM);
+
+  timer_arg_t timer_args;
+  if (!mme_app_get_timer_arg(timer_id, &timer_args)) {
+    OAILOG_WARNING(
+        LOG_NAS_EMM, "Invalid Timer Id expiration, Timer Id: %u\n", timer_id);
+    OAILOG_FUNC_RETURN(LOG_NAS_ESM, RETURNok);
+  }
+  mme_ue_s1ap_id_t ue_id = timer_args.ue_id;
+
+  ue_mm_context_t* ue_mm_context = mme_app_get_ue_context_for_timer(
+      ue_id, "EPS BEARER DEACTIVATE T3495 Timer");
+  if (ue_mm_context == NULL) {
+    OAILOG_ERROR(
+        LOG_MME_APP,
+        "Invalid UE context received, MME UE S1AP Id: " MME_UE_S1AP_ID_FMT "\n",
+        ue_id);
+    OAILOG_FUNC_RETURN(LOG_NAS_ESM, RETURNok);
+  }
+
+  ebi_t ebi = timer_args.ebi;
   int rc;
+  int bid = EBI_TO_INDEX(ebi);
 
-  /*
-   * Get retransmission timer parameters data
-   */
-  esm_ebr_timer_data_t* esm_ebr_timer_data = (esm_ebr_timer_data_t*) (args);
+  bearer_context_t* bearer_context = ue_mm_context->bearer_contexts[bid];
+  if (bearer_context == NULL) {
+    OAILOG_ERROR_UE(
+        LOG_NAS_ESM, ue_mm_context->emm_context._imsi64,
+        "Failed to find bearer context for bearer_id:%u and "
+        "ue_id " MME_UE_S1AP_ID_FMT "\n",
+        ebi, ue_id);
+    OAILOG_FUNC_RETURN(LOG_NAS_ESM, RETURNok);
+  }
 
-  if (esm_ebr_timer_data && esm_ebr_timer_data->ctx) {
-    /*
-     * Increment the retransmission counter
-     */
+  esm_ebr_context_t* ebr_ctx = &(bearer_context->esm_ebr_context);
+
+  if (ebr_ctx && ebr_ctx->args) {
+    // Get retransmission timer parameters data
+    esm_ebr_timer_data_t* esm_ebr_timer_data =
+        (esm_ebr_timer_data_t*) (ebr_ctx->args);
+    // Increment the retransmission counter
     esm_ebr_timer_data->count += 1;
     OAILOG_WARNING(
         LOG_NAS_ESM,
@@ -430,31 +461,7 @@ void dedicated_eps_bearer_activate_t3485_handler(void* args, imsi64_t* imsi64) {
         "retransmission counter = %d\n",
         esm_ebr_timer_data->ue_id, esm_ebr_timer_data->ebi,
         esm_ebr_timer_data->count);
-    *imsi64 = esm_ebr_timer_data->ctx->_imsi64;
 
-    // on timer expiry set the timer_id to inactive
-    ue_mm_context_t* ue_mm_context =
-        mme_ue_context_exists_mme_ue_s1ap_id(esm_ebr_timer_data->ue_id);
-    bearer_context_t* bearer_context = NULL;
-    esm_ebr_context_t* ebr_ctx       = NULL;
-    if (!ue_mm_context) {
-      OAILOG_ERROR_UE(
-          LOG_NAS_ESM, *imsi64,
-          "Failed to find ue context for ue_id " MME_UE_S1AP_ID_FMT "\n",
-          esm_ebr_timer_data->ue_id);
-      OAILOG_FUNC_OUT(LOG_NAS_ESM);
-    }
-    bearer_context =
-        ue_mm_context->bearer_contexts[EBI_TO_INDEX(esm_ebr_timer_data->ebi)];
-    if (bearer_context == NULL) {
-      OAILOG_ERROR_UE(
-          LOG_NAS_ESM, *imsi64,
-          "Failed to find bearer context for bearer_id:%u and "
-          "ue_id " MME_UE_S1AP_ID_FMT "\n",
-          esm_ebr_timer_data->ebi, esm_ebr_timer_data->ue_id);
-      OAILOG_FUNC_OUT(LOG_NAS_ESM);
-    }
-    ebr_ctx           = &bearer_context->esm_ebr_context;
     ebr_ctx->timer.id = NAS_TIMER_INACTIVE_ID;
 
     if (esm_ebr_timer_data->count < DEDICATED_EPS_BEARER_ACTIVATE_COUNTER_MAX) {
@@ -467,20 +474,14 @@ void dedicated_eps_bearer_activate_t3485_handler(void* args, imsi64_t* imsi64) {
           esm_ebr_timer_data->ctx, esm_ebr_timer_data->ebi, &b);
       bdestroy_wrapper(&b);
     } else {
-      /*
-       * The maximum number of activate dedicated EPS bearer context request
-       * message retransmission has exceed
-       */
+      // The maximum number of activate dedicated EPS bearer context request
+      // message retransmission has exceed
 
-      /* Store ebi and ue_id as esm_ebr_timer_data gets freed in
-       * esm_proc_eps_bearer_context_deactivate().
-       */
-      pdn_cid_t pid                 = MAX_APN_PER_UE;
-      int bid                       = BEARERS_PER_UE;
-      ebi_t ebi                     = esm_ebr_timer_data->ebi;
-      ue_mm_context_t* ue_context_p = PARENT_STRUCT(
-          esm_ebr_timer_data->ctx, struct ue_mm_context_s, emm_context);
+      // Store ebi and ue_id as esm_ebr_timer_data gets freed in
+      // esm_proc_eps_bearer_context_deactivate().
 
+      pdn_cid_t pid = MAX_APN_PER_UE;
+      bid           = BEARERS_PER_UE;
       /*
        * Release the dedicated EPS bearer context, enter state INACTIVE and
        * stop T3485 timer. Timer is stopped inside
@@ -491,13 +492,13 @@ void dedicated_eps_bearer_activate_t3485_handler(void* args, imsi64_t* imsi64) {
           NULL);
 
       // Send dedicated_eps_bearer_reject to MME APP
-      if ((rc != RETURNerror) && (ue_context_p)) {
-        mme_app_handle_create_dedicated_bearer_rej(ue_context_p, ebi);
+      if (rc != RETURNerror) {
+        mme_app_handle_create_dedicated_bearer_rej(ue_mm_context, ebi);
       }
     }
   }
 
-  OAILOG_FUNC_OUT(LOG_NAS_ESM);
+  OAILOG_FUNC_RETURN(LOG_NAS_ESM, RETURNok);
 }
 
 /*
@@ -581,7 +582,7 @@ static int dedicated_eps_bearer_activate(
 
 /****************************************************************************
  **                                                                        **
- ** Name:    _erab_setup_rsp_tmr_exp_ded_bearer_handler()                  **
+ ** Name:    erab_setup_rsp_tmr_exp_ded_bearer_handler()                  **
  **                                                                        **
  ** Description: Handles Erab setup rsp timer expiry                       **
  **                                                                        **
@@ -595,15 +596,48 @@ static int dedicated_eps_bearer_activate(
  **                                                                        **
  ***************************************************************************/
 
-static void erab_setup_rsp_tmr_exp_ded_bearer_handler(
-    void* args, imsi64_t* imsi64) {
+status_code_e erab_setup_rsp_tmr_exp_ded_bearer_handler(
+    zloop_t* loop, int timer_id, void* args) {
   OAILOG_FUNC_IN(LOG_NAS_ESM);
+
+  timer_arg_t timer_args;
+  if (!mme_app_get_timer_arg(timer_id, &timer_args)) {
+    OAILOG_WARNING(
+        LOG_NAS_EMM, "Invalid Timer Id expiration, Timer Id: %u\n", timer_id);
+    OAILOG_FUNC_RETURN(LOG_NAS_ESM, RETURNok);
+  }
+  mme_ue_s1ap_id_t ue_id = timer_args.ue_id;
+
+  ue_mm_context_t* ue_mm_context = mme_app_get_ue_context_for_timer(
+      ue_id, "EPS BEARER DEACTIVATE T3495 Timer");
+  if (ue_mm_context == NULL) {
+    OAILOG_ERROR(
+        LOG_MME_APP,
+        "Invalid UE context received, MME UE S1AP Id: " MME_UE_S1AP_ID_FMT "\n",
+        ue_id);
+    OAILOG_FUNC_RETURN(LOG_NAS_ESM, RETURNok);
+  }
+
+  ebi_t ebi = timer_args.ebi;
   int rc;
+  int bid = EBI_TO_INDEX(ebi);
 
-  // Get retransmission timer parameters data
-  esm_ebr_timer_data_t* esm_ebr_timer_data = (esm_ebr_timer_data_t*) (args);
+  bearer_context_t* bearer_context = ue_mm_context->bearer_contexts[bid];
+  if (bearer_context == NULL) {
+    OAILOG_ERROR_UE(
+        LOG_NAS_ESM, ue_mm_context->emm_context._imsi64,
+        "Failed to find bearer context for bearer_id:%u and "
+        "ue_id " MME_UE_S1AP_ID_FMT "\n",
+        ebi, ue_id);
+    OAILOG_FUNC_RETURN(LOG_NAS_ESM, RETURNok);
+  }
 
-  if (esm_ebr_timer_data) {
+  esm_ebr_context_t* ebr_ctx = &(bearer_context->esm_ebr_context);
+
+  if (ebr_ctx && ebr_ctx->args) {
+    // Get retransmission timer parameters data
+    esm_ebr_timer_data_t* esm_ebr_timer_data =
+        (esm_ebr_timer_data_t*) (ebr_ctx->args);
     // Increment the retransmission counter
     esm_ebr_timer_data->count += 1;
     OAILOG_WARNING(
@@ -614,20 +648,7 @@ static void erab_setup_rsp_tmr_exp_ded_bearer_handler(
         esm_ebr_timer_data->ue_id, esm_ebr_timer_data->ebi,
         esm_ebr_timer_data->count);
 
-    *imsi64 = esm_ebr_timer_data->ctx->_imsi64;
-    ue_mm_context_t* ue_mm_context =
-        mme_ue_context_exists_mme_ue_s1ap_id(esm_ebr_timer_data->ue_id);
-
-    bearer_context_t* bearer_ctx =
-        mme_app_get_bearer_context(ue_mm_context, esm_ebr_timer_data->ebi);
-    if (!bearer_ctx) {
-      OAILOG_ERROR(
-          LOG_NAS_ESM,
-          "Bearer context is NULL for (ebi=%u), ue id " MME_UE_S1AP_ID_FMT "\n",
-          esm_ebr_timer_data->ebi, esm_ebr_timer_data->ue_id);
-      OAILOG_FUNC_OUT(LOG_NAS_ESM);
-    }
-    if (!bearer_ctx->enb_fteid_s1u.teid) {
+    if (!bearer_context->enb_fteid_s1u.teid) {
       if (esm_ebr_timer_data->count < ERAB_SETUP_RSP_COUNTER_MAX) {
         // Restart the timer
         rc = esm_ebr_start_timer(
@@ -654,8 +675,8 @@ static void erab_setup_rsp_tmr_exp_ded_bearer_handler(
             " ebi (%u)"
             "\n",
             esm_ebr_timer_data->ue_id, esm_ebr_timer_data->ebi);
-        if (bearer_ctx->esm_ebr_context.timer.id != NAS_TIMER_INACTIVE_ID) {
-          bearer_ctx->esm_ebr_context.timer.id = NAS_TIMER_INACTIVE_ID;
+        if (bearer_context->esm_ebr_context.timer.id != NAS_TIMER_INACTIVE_ID) {
+          bearer_context->esm_ebr_context.timer.id = NAS_TIMER_INACTIVE_ID;
         }
         if (esm_ebr_timer_data) {
           if (esm_ebr_timer_data->msg) {
@@ -667,8 +688,8 @@ static void erab_setup_rsp_tmr_exp_ded_bearer_handler(
     } else {
       mme_app_handle_create_dedicated_bearer_rsp(
           ue_mm_context, esm_ebr_timer_data->ebi);
-      if (bearer_ctx->esm_ebr_context.timer.id != NAS_TIMER_INACTIVE_ID) {
-        bearer_ctx->esm_ebr_context.timer.id = NAS_TIMER_INACTIVE_ID;
+      if (bearer_context->esm_ebr_context.timer.id != NAS_TIMER_INACTIVE_ID) {
+        bearer_context->esm_ebr_context.timer.id = NAS_TIMER_INACTIVE_ID;
       }
       if (esm_ebr_timer_data) {
         if (esm_ebr_timer_data->msg) {
@@ -678,5 +699,5 @@ static void erab_setup_rsp_tmr_exp_ded_bearer_handler(
       }
     }
   }
-  OAILOG_FUNC_OUT(LOG_NAS_ESM);
+  OAILOG_FUNC_RETURN(LOG_NAS_ESM, RETURNok);
 }

--- a/lte/gateway/c/core/oai/tasks/nas/esm/DefaultEpsBearerContextActivation.c
+++ b/lte/gateway/c/core/oai/tasks/nas/esm/DefaultEpsBearerContextActivation.c
@@ -38,6 +38,7 @@
 #include "emm_esmDef.h"
 #include "esm_data.h"
 #include "mme_app_timer.h"
+#include "mme_app_defs.h"
 
 /****************************************************************************/
 /****************  E X T E R N A L    D E F I N I T I O N S  ****************/
@@ -482,7 +483,9 @@ status_code_e default_eps_bearer_activate_t3485_handler(
   OAILOG_FUNC_IN(LOG_NAS_ESM);
 
   timer_arg_t timer_args;
-  if (!mme_app_get_timer_arg(timer_id, &timer_args)) {
+  if (args) {
+    timer_args = *((timer_arg_t*) args);
+  } else if (!mme_app_get_timer_arg(timer_id, &timer_args)) {
     OAILOG_WARNING(
         LOG_NAS_EMM, "Invalid Timer Id expiration, Timer Id: %u\n", timer_id);
     OAILOG_FUNC_RETURN(LOG_NAS_ESM, RETURNok);
@@ -500,8 +503,7 @@ status_code_e default_eps_bearer_activate_t3485_handler(
   }
 
   ebi_t ebi = timer_args.ebi;
-  int rc;
-  int bid = EBI_TO_INDEX(ebi);
+  int bid   = EBI_TO_INDEX(ebi);
 
   bearer_context_t* bearer_context = ue_mm_context->bearer_contexts[bid];
   if (bearer_context == NULL) {

--- a/lte/gateway/c/core/oai/tasks/nas/esm/EpsBearerContextDeactivation.c
+++ b/lte/gateway/c/core/oai/tasks/nas/esm/EpsBearerContextDeactivation.c
@@ -42,6 +42,7 @@
 #include "esm_pt.h"
 #include "mme_app_state.h"
 #include "mme_app_timer.h"
+#include "mme_app_defs.h"
 
 /****************************************************************************/
 /****************  E X T E R N A L    D E F I N I T I O N S  ****************/
@@ -404,7 +405,9 @@ status_code_e eps_bearer_deactivate_t3495_handler(
   OAILOG_FUNC_IN(LOG_NAS_ESM);
 
   timer_arg_t timer_args;
-  if (!mme_app_get_timer_arg(timer_id, &timer_args)) {
+  if (args) {
+    timer_args = *((timer_arg_t*) args);
+  } else if (!mme_app_get_timer_arg(timer_id, &timer_args)) {
     OAILOG_WARNING(
         LOG_NAS_EMM, "Invalid Timer Id expiration, Timer Id: %u\n", timer_id);
     OAILOG_FUNC_RETURN(LOG_NAS_ESM, RETURNok);

--- a/lte/gateway/c/core/oai/tasks/nas/esm/EpsBearerContextDeactivation.c
+++ b/lte/gateway/c/core/oai/tasks/nas/esm/EpsBearerContextDeactivation.c
@@ -41,6 +41,7 @@
 #include "esm_sapDef.h"
 #include "esm_pt.h"
 #include "mme_app_state.h"
+#include "mme_app_timer.h"
 
 /****************************************************************************/
 /****************  E X T E R N A L    D E F I N I T I O N S  ****************/
@@ -398,23 +399,50 @@ pdn_cid_t esm_proc_eps_bearer_context_deactivate_accept(
  **      Others:    None                                       **
  **                                                                        **
  ***************************************************************************/
-void eps_bearer_deactivate_t3495_handler(void* args, imsi64_t* imsi64) {
+status_code_e eps_bearer_deactivate_t3495_handler(
+    zloop_t* loop, int timer_id, void* args) {
   OAILOG_FUNC_IN(LOG_NAS_ESM);
+
+  timer_arg_t timer_args;
+  if (!mme_app_get_timer_arg(timer_id, &timer_args)) {
+    OAILOG_WARNING(
+        LOG_NAS_EMM, "Invalid Timer Id expiration, Timer Id: %u\n", timer_id);
+    OAILOG_FUNC_RETURN(LOG_NAS_ESM, RETURNok);
+  }
+  mme_ue_s1ap_id_t ue_id = timer_args.ue_id;
+
+  ue_mm_context_t* ue_mm_context = mme_app_get_ue_context_for_timer(
+      ue_id, "EPS BEARER DEACTIVATE T3495 Timer");
+  if (ue_mm_context == NULL) {
+    OAILOG_ERROR(
+        LOG_MME_APP,
+        "Invalid UE context received, MME UE S1AP Id: " MME_UE_S1AP_ID_FMT "\n",
+        ue_id);
+    OAILOG_FUNC_RETURN(LOG_NAS_ESM, RETURNok);
+  }
+
+  ebi_t ebi = timer_args.ebi;
   int rc;
   bool delete_default_bearer = false;
-  ebi_t ebi                  = 0;
-  mme_ue_s1ap_id_t ue_id     = 0;
-  int bid                    = BEARERS_PER_UE;
+  int bid                    = EBI_TO_INDEX(ebi);
 
-  /*
-   * Get retransmission timer parameters data
-   */
-  esm_ebr_timer_data_t* esm_ebr_timer_data = (esm_ebr_timer_data_t*) (args);
+  bearer_context_t* bearer_context = ue_mm_context->bearer_contexts[bid];
+  if (bearer_context == NULL) {
+    OAILOG_ERROR_UE(
+        LOG_NAS_ESM, ue_mm_context->emm_context._imsi64,
+        "Failed to find bearer context for bearer_id:%u and "
+        "ue_id " MME_UE_S1AP_ID_FMT "\n",
+        ebi, ue_id);
+    OAILOG_FUNC_RETURN(LOG_NAS_ESM, RETURNok);
+  }
 
-  if (esm_ebr_timer_data && esm_ebr_timer_data->ctx) {
-    /*
-     * Increment the retransmission counter
-     */
+  esm_ebr_context_t* ebr_ctx = &(bearer_context->esm_ebr_context);
+
+  if (ebr_ctx && ebr_ctx->args) {
+    // Get retransmission timer parameters data
+    esm_ebr_timer_data_t* esm_ebr_timer_data =
+        (esm_ebr_timer_data_t*) (ebr_ctx->args);
+    // Increment the retransmission counter
     esm_ebr_timer_data->count += 1;
     OAILOG_WARNING(
         LOG_NAS_ESM,
@@ -423,31 +451,7 @@ void eps_bearer_deactivate_t3495_handler(void* args, imsi64_t* imsi64) {
         "retransmission counter = %d\n",
         esm_ebr_timer_data->ue_id, esm_ebr_timer_data->ebi,
         esm_ebr_timer_data->count);
-    *imsi64 = esm_ebr_timer_data->ctx->_imsi64;
 
-    // on timer expiry set the timer_id to inactive
-    ue_mm_context_t* ue_mm_context =
-        mme_ue_context_exists_mme_ue_s1ap_id(esm_ebr_timer_data->ue_id);
-    bearer_context_t* bearer_context = NULL;
-    esm_ebr_context_t* ebr_ctx       = NULL;
-    if (!ue_mm_context) {
-      OAILOG_ERROR_UE(
-          LOG_NAS_ESM, *imsi64,
-          "Failed to find ue context for ue_id " MME_UE_S1AP_ID_FMT "\n",
-          esm_ebr_timer_data->ue_id);
-      OAILOG_FUNC_OUT(LOG_NAS_ESM);
-    }
-    bearer_context =
-        ue_mm_context->bearer_contexts[EBI_TO_INDEX(esm_ebr_timer_data->ebi)];
-    if (bearer_context == NULL) {
-      OAILOG_ERROR_UE(
-          LOG_NAS_ESM, *imsi64,
-          "Failed to find bearer context for bearer_id:%u and "
-          "ue_id " MME_UE_S1AP_ID_FMT "\n",
-          esm_ebr_timer_data->ebi, esm_ebr_timer_data->ue_id);
-      OAILOG_FUNC_OUT(LOG_NAS_ESM);
-    }
-    ebr_ctx           = &bearer_context->esm_ebr_context;
     ebr_ctx->timer.id = NAS_TIMER_INACTIVE_ID;
     if (esm_ebr_timer_data->count < EPS_BEARER_DEACTIVATE_COUNTER_MAX) {
       /*
@@ -460,30 +464,9 @@ void eps_bearer_deactivate_t3495_handler(void* args, imsi64_t* imsi64) {
     } else {
       /*
        * The maximum number of deactivate EPS bearer context request
-       * message retransmission has exceed
+       * message retransmission has exceeded
        */
-      ue_mm_context_t* ue_mm_context =
-          mme_ue_context_exists_mme_ue_s1ap_id(esm_ebr_timer_data->ue_id);
 
-      ebi   = esm_ebr_timer_data->ebi;
-      ue_id = esm_ebr_timer_data->ue_id;
-      // Find the index in which the bearer id is stored
-      for (bid = 0; bid < BEARERS_PER_UE; bid++) {
-        if (ue_mm_context->bearer_contexts[bid]) {
-          if (ue_mm_context->bearer_contexts[bid]->ebi == ebi) {
-            break;
-          }
-        }
-      }
-
-      if (bid >= BEARERS_PER_UE) {
-        OAILOG_WARNING(
-            LOG_NAS_ESM,
-            "ESM-PROC  - Did not find bearer context for "
-            "(ue_id=" MME_UE_S1AP_ID_FMT ", ebi=%d), \n",
-            ue_id, ebi);
-        OAILOG_FUNC_OUT(LOG_NAS_ESM);
-      }
       // Fetch pdn id using bearer index
       pdn_cid_t pdn_id = ue_mm_context->bearer_contexts[bid]->pdn_cx_id;
 
@@ -495,7 +478,7 @@ void eps_bearer_deactivate_t3495_handler(void* args, imsi64_t* imsi64) {
             "\n"
             "pdn_id=%d\n",
             ue_id, pdn_id);
-        OAILOG_FUNC_OUT(LOG_NAS_ESM);
+        OAILOG_FUNC_RETURN(LOG_NAS_ESM, RETURNok);
       }
       // Send bearer_deactivation_reject to MME
       teid_t s_gw_teid_s11_s4 =
@@ -539,7 +522,7 @@ void eps_bearer_deactivate_t3495_handler(void* args, imsi64_t* imsi64) {
     }
   }
 
-  OAILOG_FUNC_OUT(LOG_NAS_ESM);
+  OAILOG_FUNC_RETURN(LOG_NAS_ESM, RETURNok);
 }
 /*
    --------------------------------------------------------------------------
@@ -549,7 +532,7 @@ void eps_bearer_deactivate_t3495_handler(void* args, imsi64_t* imsi64) {
 
 /****************************************************************************
  **                                                                        **
- ** Name:    _eps_bearer_deactivate()                                  **
+ ** Name:    eps_bearer_deactivate()                                  **
  **                                                                        **
  ** Description: Sends DEACTIVATE EPS BEREAR CONTEXT REQUEST message and   **
  **      starts timer T3495                                        **

--- a/lte/gateway/c/core/oai/tasks/nas/esm/esm_data_context.c
+++ b/lte/gateway/c/core/oai/tasks/nas/esm/esm_data_context.c
@@ -46,8 +46,7 @@ void free_esm_bearer_context(esm_ebr_context_t* esm_ebr_context) {
     }
     if (NAS_TIMER_INACTIVE_ID != esm_ebr_context->timer.id) {
       esm_ebr_timer_data_t* esm_ebr_timer_data = NULL;
-      esm_ebr_context->timer.id                = nas_timer_stop(
-          esm_ebr_context->timer.id, (void**) &esm_ebr_timer_data);
+      nas_timer_stop(&(esm_ebr_context->timer));
       /*
        * Release the retransmisison timer parameters
        */

--- a/lte/gateway/c/core/oai/tasks/nas/esm/esm_ebr.h
+++ b/lte/gateway/c/core/oai/tasks/nas/esm/esm_ebr.h
@@ -75,7 +75,7 @@ status_code_e esm_ebr_release(emm_context_t* emm_context, ebi_t ebi);
 
 status_code_e esm_ebr_start_timer(
     emm_context_t* emm_context, ebi_t ebi, CLONE_REF const_bstring msg,
-    uint32_t sec, nas_timer_callback_t cb);
+    uint32_t sec, time_out_t cb);
 status_code_e esm_ebr_stop_timer(emm_context_t* emm_context, ebi_t ebi);
 
 ebi_t esm_ebr_get_pending_ebi(emm_context_t* emm_context, esm_ebr_state status);

--- a/lte/gateway/c/core/oai/tasks/nas/esm/esm_ebr_context.h
+++ b/lte/gateway/c/core/oai/tasks/nas/esm/esm_ebr_context.h
@@ -42,6 +42,7 @@ Description Defines functions used to handle EPS bearer contexts.
 #include "common_types.h"
 #include "emm_data.h"
 #include "esm_data.h"
+#include <czmq.h>
 /****************************************************************************/
 /*********************  G L O B A L    C O N S T A N T S  *******************/
 /****************************************************************************/
@@ -74,9 +75,12 @@ ebi_t esm_ebr_context_release(
 
 void free_esm_ebr_context(esm_ebr_context_t* ctx);
 
-void default_eps_bearer_activate_t3485_handler(void* args, imsi64_t* imsi64);
+int default_eps_bearer_activate_t3485_handler(
+    zloop_t* loop, int timer_id, void* args);
 
-void dedicated_eps_bearer_activate_t3485_handler(void* args, imsi64_t* imsi64);
+int dedicated_eps_bearer_activate_t3485_handler(
+    zloop_t* loop, int timer_id, void* args);
 
-void eps_bearer_deactivate_t3495_handler(void*, imsi64_t* imsi64);
+int eps_bearer_deactivate_t3495_handler(
+    zloop_t* loop, int timer_id, void* args);
 #endif /* ESM_EBR_CONTEXT_SEEN */

--- a/lte/gateway/c/core/oai/tasks/nas/esm/esm_information.c
+++ b/lte/gateway/c/core/oai/tasks/nas/esm/esm_information.c
@@ -174,7 +174,7 @@ status_code_e mme_app_handle_esm_information_t3489_expiry(
   OAILOG_FUNC_IN(LOG_NAS_ESM);
 
   mme_ue_s1ap_id_t mme_ue_s1ap_id = 0;
-  if (!mme_app_get_timer_arg(timer_id, &mme_ue_s1ap_id)) {
+  if (!mme_app_get_timer_arg_ue_id(timer_id, &mme_ue_s1ap_id)) {
     OAILOG_WARNING(
         LOG_NAS_EMM, "Invalid Timer Id expiration, Timer Id: %u\n", timer_id);
     OAILOG_FUNC_RETURN(LOG_NAS_ESM, RETURNok);

--- a/lte/gateway/c/core/oai/tasks/nas/nas_procedures.c
+++ b/lte/gateway/c/core/oai/tasks/nas/nas_procedures.c
@@ -44,6 +44,7 @@
 #include "digest.h"
 #include "nas_procedures.h"
 #include "common_defs.h"
+#include "mme_app_timer.h"
 
 // TODO: Add unit tests for common procedure functions
 static nas_emm_common_proc_t* get_nas_common_procedure(

--- a/lte/gateway/c/core/oai/tasks/nas/nas_procedures.h
+++ b/lte/gateway/c/core/oai/tasks/nas/nas_procedures.h
@@ -40,7 +40,6 @@
 #include "queue.h"
 #include "nas/securityDef.h"
 #include "security_types.h"
-#include <czmq.h>
 
 struct emm_context_s;
 struct nas_base_proc_s;
@@ -60,7 +59,6 @@ typedef int (*pdu_in_resp_t)(
 typedef int (*pdu_in_rej_t)(struct emm_context_s*, void* arg);  // REJECT.
 typedef int (*pdu_out_rej_t)(
     struct emm_context_s*, struct nas_base_proc_s*);  // REJECT.
-typedef int (*time_out_t)(zloop_t* loop, int timer_id, void* args);
 
 typedef int (*sdu_out_delivered_t)(
     struct emm_context_s*, struct nas_emm_proc_s*);

--- a/lte/gateway/c/core/oai/tasks/nas/util/nas_timer.h
+++ b/lte/gateway/c/core/oai/tasks/nas/util/nas_timer.h
@@ -34,6 +34,10 @@ Description Timer utilities
 #ifndef FILE_NAS_TIMER_SEEN
 #define FILE_NAS_TIMER_SEEN
 
+#include <czmq.h>
+
+#include "3gpp_36.401.h"
+#include "3gpp_24.007.h"
 #include "common_defs.h"
 #include "common_types.h"
 /****************************************************************************/
@@ -45,6 +49,7 @@ Description Timer utilities
  * failed to be started)
  */
 #define NAS_TIMER_INACTIVE_ID (-1)
+typedef int (*time_out_t)(zloop_t* loop, int timer_id, void* args);
 
 /****************************************************************************/
 /************************  G L O B A L    T Y P E S  ************************/
@@ -55,6 +60,11 @@ typedef struct nas_timer_s {
   long int id;  /* The timer identifier                 */
   uint32_t sec; /* The timer interval value in seconds  */
 } nas_timer_t;
+
+typedef struct timer_arg_s {
+  mme_ue_s1ap_id_t ue_id;
+  ebi_t ebi;
+} timer_arg_t;
 
 /* Type of the callback executed when the timer expired */
 typedef void (*nas_timer_callback_t)(void*, imsi64_t* imsi64);
@@ -74,10 +84,10 @@ typedef struct nas_itti_timer_arg_s {
 
 status_code_e nas_timer_init(void);
 void nas_timer_cleanup(void);
-long int nas_timer_start(
-    uint32_t sec, uint32_t usec, nas_timer_callback_t nas_timer_callback,
-    void* nas_timer_callback_args);
-long int nas_timer_stop(long int timer_id, void** nas_timer_callback_arg);
+void nas_timer_start(
+    nas_timer_t* const timer, time_out_t time_out_cb,
+    timer_arg_t* time_out_cb_args);
+void nas_timer_stop(nas_timer_t* const timer);
 void mme_app_nas_timer_handle_signal_expiry(
     long timer_id, nas_itti_timer_arg_t* nas_itti_timer_arg, imsi64_t* imsi64);
 

--- a/lte/gateway/c/core/oai/tasks/s1ap/s1ap_state_converter.cpp
+++ b/lte/gateway/c/core/oai/tasks/s1ap/s1ap_state_converter.cpp
@@ -255,7 +255,7 @@ void S1apStateConverter::proto_to_supported_ta_list(
     const oai::SupportedTaList& supported_ta_list_proto) {
   supported_ta_list_state->list_count = supported_ta_list_proto.list_count();
   for (int idx = 0; idx < supported_ta_list_state->list_count; idx++) {
-    OAILOG_DEBUG(LOG_MME_APP, "reading bearer context at index %d", idx);
+    OAILOG_DEBUG(LOG_MME_APP, "reading supported ta list at index %d", idx);
     proto_to_supported_tai_items(
         &supported_ta_list_state->supported_tai_items[idx],
         supported_ta_list_proto.supported_tai_items(idx));

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_nw_triggered_delete_last_pdn.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_nw_triggered_delete_last_pdn.py
@@ -122,6 +122,7 @@ class TestAttachDetachNwTriggeredDeleteLastPdn(unittest.TestCase):
             )
 
             # Verify that all UL/DL flows are deleted
+            time.sleep(5)
             self._s1ap_wrapper._s1_util.verify_flow_rules_deletion()
 
 


### PR DESCRIPTION
<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->
As the final part of migrating to zmq for NAS timers, network initiated default and dedicated bearer activation/deactivation timers are completed. Since these timers need ebi in addition to the s1ap mme id, a new struct for holding timer argument and methods to retrieve it are also added. 

There were couple of clean ups as we no longer pass calloced arguments to the timers.

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->
S1AP integration tests that already covers these procedures with expired timers and service restarts.
Unit tests will be added in the next couple of sprints for all the procedures including timer expiration cases.

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
