### PR TITLE
fix(mme): gTEID changed from octet string to uint32 in AMF and NGAP

### DIFF
--- a/lte/gateway/c/core/oai/common/common_defs.h
+++ b/lte/gateway/c/core/oai/common/common_defs.h
@@ -40,6 +40,8 @@
 
 #include <string.h>  // memcpy
 #include <arpa/inet.h>
+
+#define GNB_GTP_TEID_FMT "%08x"
 //------------------------------------------------------------------------------
 #define STOLEN_REF
 #define CLONE_REF

--- a/lte/gateway/c/core/oai/include/amf_app_messages_types.h
+++ b/lte/gateway/c/core/oai/include/amf_app_messages_types.h
@@ -123,7 +123,7 @@ typedef struct itti_amf_ip_allocation_response_s {
   uint32_t pdu_session_type;
 
   /* GNB GTP Tunnel Identifier */
-  uint8_t gnb_gtp_teid[5];
+  uint32_t gnb_gtp_teid;
 
   /* GNB End Point IP address */
   uint8_t gnb_gtp_teid_ip_addr[16];

--- a/lte/gateway/c/core/oai/lib/n11/M5GMobilityServiceClient.cpp
+++ b/lte/gateway/c/core/oai/lib/n11/M5GMobilityServiceClient.cpp
@@ -41,7 +41,7 @@ extern task_zmq_ctx_t grpc_service_task_zmq_ctx;
 static void handle_allocate_ipv4_address_status(
     const grpc::Status& status, struct in_addr in_ip4_addr, int vlan,
     const char* imsi, const char* apn, uint32_t pdu_session_id, uint8_t pti,
-    uint32_t pdu_session_type, uint8_t* gnb_gtp_teid, uint8_t gnb_gtp_teid_len,
+    uint32_t pdu_session_type, uint32_t gnb_gtp_teid,
     uint8_t* gnb_gtp_teid_ip_addr, uint8_t gnb_gtp_teid_ip_addr_len) {
   MessageDef* message_p;
   message_p =
@@ -62,7 +62,8 @@ static void handle_allocate_ipv4_address_status(
   amf_ip_allocation_response_p->paa.pdn_type     = IPv4;
   amf_ip_allocation_response_p->paa.vlan         = vlan;
 
-  memcpy(amf_ip_allocation_response_p->gnb_gtp_teid, gnb_gtp_teid, 4);
+  amf_ip_allocation_response_p->gnb_gtp_teid = gnb_gtp_teid;
+
   memcpy(
       amf_ip_allocation_response_p->gnb_gtp_teid_ip_addr, gnb_gtp_teid_ip_addr,
       4);
@@ -82,16 +83,14 @@ namespace magma5g {
 
 int AsyncM5GMobilityServiceClient::allocate_ipv4_address(
     const char* subscriber_id, const char* apn, uint32_t pdu_session_id,
-    uint8_t pti, uint32_t pdu_session_type, uint8_t* gnb_gtp_teid,
-    uint8_t gnb_gtp_teid_len, uint8_t* gnb_gtp_teid_ip_addr,
-    uint8_t gnb_gtp_teid_ip_addr_len) {
+    uint8_t pti, uint32_t pdu_session_type, uint32_t gnb_gtp_teid,
+    uint8_t* gnb_gtp_teid_ip_addr, uint8_t gnb_gtp_teid_ip_addr_len) {
   auto subscriber_id_str = std::string(subscriber_id);
   auto apn_str           = std::string(apn);
   MobilityServiceClient::getInstance().AllocateIPv4AddressAsync(
       subscriber_id_str, apn,
       [subscriber_id_str, apn, pdu_session_id, pti, pdu_session_type,
-       gnb_gtp_teid, gnb_gtp_teid_len, gnb_gtp_teid_ip_addr,
-       gnb_gtp_teid_ip_addr_len](
+       gnb_gtp_teid, gnb_gtp_teid_ip_addr, gnb_gtp_teid_ip_addr_len](
           const Status& status, const AllocateIPAddressResponse& ip_msg) {
         struct in_addr addr;
         std::string ipv4_addr_str;
@@ -104,8 +103,8 @@ int AsyncM5GMobilityServiceClient::allocate_ipv4_address(
 
         handle_allocate_ipv4_address_status(
             status, addr, vlan, subscriber_id_str.c_str(), apn, pdu_session_id,
-            pti, pdu_session_type, gnb_gtp_teid, gnb_gtp_teid_len,
-            gnb_gtp_teid_ip_addr, gnb_gtp_teid_ip_addr_len);
+            pti, pdu_session_type, gnb_gtp_teid, gnb_gtp_teid_ip_addr,
+            gnb_gtp_teid_ip_addr_len);
       });
   return RETURNok;
 }

--- a/lte/gateway/c/core/oai/lib/n11/M5GMobilityServiceClient.h
+++ b/lte/gateway/c/core/oai/lib/n11/M5GMobilityServiceClient.h
@@ -23,9 +23,8 @@ class M5GMobilityServiceClient {
   virtual ~M5GMobilityServiceClient() {}
   virtual int allocate_ipv4_address(
       const char* subscriber_id, const char* apn, uint32_t pdu_session_id,
-      uint8_t pti, uint32_t pdu_session_type, uint8_t* gnb_gtp_teid,
-      uint8_t gnb_gtp_teid_len, uint8_t* gnb_gtp_teid_ip_addr,
-      uint8_t gnb_gtp_teid_ip_addr_len) = 0;
+      uint8_t pti, uint32_t pdu_session_type, uint32_t gnb_gtp_teid,
+      uint8_t* gnb_gtp_teid_ip_addr, uint8_t gnb_gtp_teid_ip_addr_len) = 0;
 
   virtual int release_ipv4_address(
       const char* subscriber_id, const char* apn,
@@ -36,9 +35,8 @@ class AsyncM5GMobilityServiceClient : public M5GMobilityServiceClient {
  public:
   int allocate_ipv4_address(
       const char* subscriber_id, const char* apn, uint32_t pdu_session_id,
-      uint8_t pti, uint32_t pdu_session_type, uint8_t* gnb_gtp_teid,
-      uint8_t gnb_gtp_teid_len, uint8_t* gnb_gtp_teid_ip_addr,
-      uint8_t gnb_gtp_teid_ip_addr_len);
+      uint8_t pti, uint32_t pdu_session_type, uint32_t gnb_gtp_teid,
+      uint8_t* gnb_gtp_teid_ip_addr, uint8_t gnb_gtp_teid_ip_addr_len);
 
   int release_ipv4_address(
       const char* subscriber_id, const char* apn, const struct in_addr* addr);

--- a/lte/gateway/c/core/oai/lib/n11/SmfServiceClient.cpp
+++ b/lte/gateway/c/core/oai/lib/n11/SmfServiceClient.cpp
@@ -44,7 +44,7 @@ namespace magma5g {
 
 SetSMSessionContext create_sm_pdu_session_v4(
     char* imsi, uint8_t* apn, uint32_t pdu_session_id,
-    uint32_t pdu_session_type, uint8_t* gnb_gtp_teid, uint8_t pti,
+    uint32_t pdu_session_type, uint32_t gnb_gtp_teid, uint8_t pti,
     uint8_t* gnb_gtp_teid_ip_addr, char* ipv4_addr, uint32_t version) {
   magma::lte::SetSMSessionContext req;
 
@@ -86,9 +86,7 @@ SetSMSessionContext create_sm_pdu_session_v4(
   req_rat_specific->set_pdu_session_type(magma::lte::PduSessionType::IPV4);
 
   // TEID of GNB
-  uint32_t nTeid = (gnb_gtp_teid[0] << 24) | (gnb_gtp_teid[1] << 16) |
-                   (gnb_gtp_teid[2] << 8) | (gnb_gtp_teid[3]);
-  req_rat_specific->mutable_gnode_endpoint()->set_teid(nTeid);
+  req_rat_specific->mutable_gnode_endpoint()->set_teid(gnb_gtp_teid);
 
   // IP Address of GNB
 
@@ -108,7 +106,7 @@ SetSMSessionContext create_sm_pdu_session_v4(
 
 int AsyncSmfServiceClient::amf_smf_create_pdu_session_ipv4(
     char* imsi, uint8_t* apn, uint32_t pdu_session_id,
-    uint32_t pdu_session_type, uint8_t* gnb_gtp_teid, uint8_t pti,
+    uint32_t pdu_session_type, uint32_t gnb_gtp_teid, uint8_t pti,
     uint8_t* gnb_gtp_teid_ip_addr, char* ipv4_addr, uint32_t version) {
   magma::lte::SetSMSessionContext req = create_sm_pdu_session_v4(
       imsi, apn, pdu_session_id, pdu_session_type, gnb_gtp_teid, pti,

--- a/lte/gateway/c/core/oai/lib/n11/SmfServiceClient.h
+++ b/lte/gateway/c/core/oai/lib/n11/SmfServiceClient.h
@@ -30,7 +30,7 @@ namespace magma5g {
 
 SetSMSessionContext create_sm_pdu_session_v4(
     char* imsi, uint8_t* apn, uint32_t pdu_session_id,
-    uint32_t pdu_session_type, uint8_t* gnb_gtp_teid, uint8_t pti,
+    uint32_t pdu_session_type, uint32_t gnb_gtp_teid, uint8_t pti,
     uint8_t* gnb_gtp_teid_ip_addr, char* ipv4_addr, uint32_t version);
 
 class SmfServiceClient {
@@ -67,7 +67,7 @@ class AsyncSmfServiceClient : public magma::GRPCReceiver,
 
   int amf_smf_create_pdu_session_ipv4(
       char* imsi, uint8_t* apn, uint32_t pdu_session_id,
-      uint32_t pdu_session_type, uint8_t* gnb_gtp_teid, uint8_t pti,
+      uint32_t pdu_session_type, uint32_t gnb_gtp_teid, uint8_t pti,
       uint8_t* gnb_gtp_teid_ip_addr, char* ipv4_addr, uint32_t version);
 
   bool set_smf_session(SetSMSessionContext& request);

--- a/lte/gateway/c/core/oai/tasks/amf/amf_app_handler.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_app_handler.cpp
@@ -934,11 +934,11 @@ void amf_app_handle_resource_setup_response(
     memset(
         &smf_ctx->gtp_tunnel_id.gnb_gtp_teid_ip_addr, '\0',
         sizeof(smf_ctx->gtp_tunnel_id.gnb_gtp_teid_ip_addr));
-    memcpy(
-        &smf_ctx->gtp_tunnel_id.gnb_gtp_teid,
-        &session_seup_resp.pduSessionResource_setup_list.item[0]
-             .PDU_Session_Resource_Setup_Response_Transfer.tunnel.gTP_TEID,
-        4);
+
+    smf_ctx->gtp_tunnel_id.gnb_gtp_teid =
+        *session_seup_resp.pduSessionResource_setup_list.item[0]
+             .PDU_Session_Resource_Setup_Response_Transfer.tunnel.gTP_TEID;
+
     memcpy(
         &smf_ctx->gtp_tunnel_id.gnb_gtp_teid_ip_addr,
         &session_seup_resp.pduSessionResource_setup_list.item[0]
@@ -947,16 +947,13 @@ void amf_app_handle_resource_setup_response(
         4);  // time being 4 byte is copying.
     OAILOG_DEBUG(
         LOG_AMF_APP,
-        "gnb_gtp_teid_ipaddr: [%02x %02x %02x %02x]  and gnb_gtp_teid [%02x "
-        "%02x %02x %02x ]\n",
+        "gnb_gtp_teid_ipaddr: [%02x %02x %02x %02x]  and gnb_gtp_teid "
+        "[" GNB_GTP_TEID_FMT "]\n",
         smf_ctx->gtp_tunnel_id.gnb_gtp_teid_ip_addr[0],
         smf_ctx->gtp_tunnel_id.gnb_gtp_teid_ip_addr[1],
         smf_ctx->gtp_tunnel_id.gnb_gtp_teid_ip_addr[2],
         smf_ctx->gtp_tunnel_id.gnb_gtp_teid_ip_addr[3],
-        smf_ctx->gtp_tunnel_id.gnb_gtp_teid[0],
-        smf_ctx->gtp_tunnel_id.gnb_gtp_teid[1],
-        smf_ctx->gtp_tunnel_id.gnb_gtp_teid[0],
-        smf_ctx->gtp_tunnel_id.gnb_gtp_teid[3]);
+        smf_ctx->gtp_tunnel_id.gnb_gtp_teid);
     // Incrementing the  pdu session version
     smf_ctx->pdu_session_version++;
     /*Copy respective gNB fields to amf_smf_establish_t compartible to gRPC
@@ -1337,11 +1334,10 @@ void amf_app_handle_initial_context_setup_rsp(
         amf_smf_establish_t amf_smf_grpc_ies;
 
         // gnb tunnel info
-        memcpy(
-            smf_context->gtp_tunnel_id.gnb_gtp_teid,
-            pdu_list->item[index]
-                .PDU_Session_Resource_Setup_Response_Transfer.tunnel.gTP_TEID,
-            4);
+
+        smf_context->gtp_tunnel_id.gnb_gtp_teid =
+            *pdu_list->item[index]
+                 .PDU_Session_Resource_Setup_Response_Transfer.tunnel.gTP_TEID;
 
         memcpy(
             smf_context->gtp_tunnel_id.gnb_gtp_teid_ip_addr,
@@ -1352,16 +1348,12 @@ void amf_app_handle_initial_context_setup_rsp(
 
         OAILOG_DEBUG(
             LOG_AMF_APP,
-            "IP address %02x %02x %02x %02x  and TEID %02x "
-            "%02x %02x %02x \n",
+            "IP address %02x %02x %02x %02x  and TEID" GNB_GTP_TEID_FMT "\n",
             smf_context->gtp_tunnel_id.gnb_gtp_teid_ip_addr[0],
             smf_context->gtp_tunnel_id.gnb_gtp_teid_ip_addr[1],
             smf_context->gtp_tunnel_id.gnb_gtp_teid_ip_addr[2],
             smf_context->gtp_tunnel_id.gnb_gtp_teid_ip_addr[3],
-            smf_context->gtp_tunnel_id.gnb_gtp_teid[0],
-            smf_context->gtp_tunnel_id.gnb_gtp_teid[1],
-            smf_context->gtp_tunnel_id.gnb_gtp_teid[0],
-            smf_context->gtp_tunnel_id.gnb_gtp_teid[3]);
+            smf_context->gtp_tunnel_id.gnb_gtp_teid);
 
         smf_context->pdu_session_version++;
         /*Copy respective gNB fields to amf_smf_establish_t compartible to gRPC

--- a/lte/gateway/c/core/oai/tasks/amf/amf_app_ue_context_and_proc.h
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_app_ue_context_and_proc.h
@@ -233,7 +233,7 @@ typedef struct teid_upf_gnb_s {
   uint8_t upf_gtp_teid_ip_addr[16];
   uint8_t upf_gtp_teid[4];
   uint8_t gnb_gtp_teid_ip_addr[16];
-  uint8_t gnb_gtp_teid[4];
+  uint32_t gnb_gtp_teid;
 } teid_upf_gnb_t;
 
 // Data get communicated with SMF and stored for reference

--- a/lte/gateway/c/core/oai/tasks/amf/amf_smfDefs.h
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_smfDefs.h
@@ -63,7 +63,7 @@ typedef struct amf_smf_establish_s {
   uint32_t pdu_session_id;    // Session Identity
   uint8_t pti;                // Procedure Tranction Identity
   uint32_t pdu_session_type;  // Session type
-  uint8_t gnb_gtp_teid[5];
+  uint32_t gnb_gtp_teid;
   uint8_t gnb_gtp_teid_ip_addr[16];
   uint8_t cause_value;  // M5GSMCause
 } amf_smf_establish_t;
@@ -97,7 +97,7 @@ int amf_smf_create_pdu_session(
 
 int amf_smf_create_ipv4_session_grpc_req(
     char* imsi, uint8_t* apn, uint32_t pdu_session_id,
-    uint32_t pdu_session_type, uint8_t* gnb_gtp_teid, uint8_t pti,
+    uint32_t pdu_session_type, uint32_t gnb_gtp_teid, uint8_t pti,
     uint8_t* gnb_gtp_teid_ip_addr, char* ipv4_addr);
 
 int create_session_grpc_req_on_gnb_setup_rsp(

--- a/lte/gateway/c/core/oai/tasks/amf/amf_smf_send.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_smf_send.cpp
@@ -167,9 +167,7 @@ void set_amf_smf_context(
   memset(
       smf_ctx->gtp_tunnel_id.gnb_gtp_teid_ip_addr, '\0',
       sizeof(smf_ctx->gtp_tunnel_id.gnb_gtp_teid_ip_addr));
-  memset(
-      smf_ctx->gtp_tunnel_id.gnb_gtp_teid, '\0',
-      sizeof(smf_ctx->gtp_tunnel_id.gnb_gtp_teid));
+  smf_ctx->gtp_tunnel_id.gnb_gtp_teid = 0x0;
 }
 
 /***************************************************************************
@@ -418,15 +416,14 @@ int amf_smf_send(
       memset(
           amf_smf_msg.u.establish.gnb_gtp_teid_ip_addr, '\0',
           sizeof(amf_smf_msg.u.establish.gnb_gtp_teid_ip_addr));
-      memset(
-          amf_smf_msg.u.establish.gnb_gtp_teid, '\0',
-          sizeof(amf_smf_msg.u.establish.gnb_gtp_teid));
+
+      amf_smf_msg.u.establish.gnb_gtp_teid = 0x0;
       memcpy(
           amf_smf_msg.u.establish.gnb_gtp_teid_ip_addr,
           smf_ctx->gtp_tunnel_id.gnb_gtp_teid_ip_addr, GNB_IPV4_ADDR_LEN);
-      memcpy(
-          amf_smf_msg.u.establish.gnb_gtp_teid,
-          smf_ctx->gtp_tunnel_id.gnb_gtp_teid, GNB_TEID_LEN);
+
+      amf_smf_msg.u.establish.gnb_gtp_teid =
+          smf_ctx->gtp_tunnel_id.gnb_gtp_teid;
 
       // Initialize default APN
       memcpy(smf_ctx->apn, "internet", strlen("internet") + 1);

--- a/lte/gateway/c/core/oai/tasks/amf/prepare_request_for_smf.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/prepare_request_for_smf.cpp
@@ -80,10 +80,8 @@ int create_session_grpc_req_on_gnb_setup_rsp(
   req_rat_specific->set_request_type(magma::lte::RequestType::INITIAL_REQUEST);
 
   TeidSet* gnode_endpoint = req_rat_specific->mutable_gnode_endpoint();
-  uint32_t nTeid          = (message->gnb_gtp_teid[0] << 24) |
-                   (message->gnb_gtp_teid[1] << 16) |
-                   (message->gnb_gtp_teid[2] << 8) | (message->gnb_gtp_teid[3]);
-  gnode_endpoint->set_teid(nTeid);
+
+  gnode_endpoint->set_teid(message->gnb_gtp_teid);
 
   char ipv4_str[INET_ADDRSTRLEN] = {0};
   inet_ntop(AF_INET, message->gnb_gtp_teid_ip_addr, ipv4_str, INET_ADDRSTRLEN);
@@ -107,7 +105,7 @@ int create_session_grpc_req_on_gnb_setup_rsp(
 ***************************************************************************/
 int amf_smf_create_ipv4_session_grpc_req(
     char* imsi, uint8_t* apn, uint32_t pdu_session_id,
-    uint32_t pdu_session_type, uint8_t* gnb_gtp_teid, uint8_t pti,
+    uint32_t pdu_session_type, uint32_t gnb_gtp_teid, uint8_t pti,
     uint8_t* gnb_gtp_teid_ip_addr, char* ipv4_addr) {
   OAILOG_INFO(
       LOG_AMF_APP, "Sending msg(grpc) to :[sessiond] for ue: [%s] session\n",
@@ -132,7 +130,7 @@ int amf_smf_create_pdu_session(
       imsi);
   AsyncM5GMobilityServiceClient::getInstance().allocate_ipv4_address(
       imsi, "internet", message->pdu_session_id, message->pti, AF_INET,
-      message->gnb_gtp_teid, 4, message->gnb_gtp_teid_ip_addr, 4);
+      message->gnb_gtp_teid, message->gnb_gtp_teid_ip_addr, 4);
 
   return (RETURNok);
 }

--- a/lte/gateway/c/core/oai/test/n11/test_smf_service_client.cpp
+++ b/lte/gateway/c/core/oai/test/n11/test_smf_service_client.cpp
@@ -28,7 +28,7 @@ TEST(test_create_sm_pdu_session_v4, create_sm_pdu_session_v4) {
   std::string apn("magmacore.com");
   uint32_t pdu_session_id         = 0x5;
   uint32_t pdu_session_type       = 3;
-  uint8_t gnb_gtp_teid[4]         = {0x0, 0x0, 0x0, 0x1};
+  uint32_t gnb_gtp_teid           = 1;
   uint8_t pti                     = 10;
   uint8_t gnb_gtp_teid_ip_addr[4] = {0};  //("10.20.30.40")
   gnb_gtp_teid_ip_addr[0]         = 0xA;


### PR DESCRIPTION
Signed-off-by: LKishor123 <laawanya.kishor@wavelabs.ai>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary
gnb_gtp_teid changed from octet string to uint32 in AMF and NGAP:
 1. All the functions which calls gnb_gtp_teid have been modified.
 2. memcpy() invloving gnb_gtp_teid have been removed.
<!-- Enumerate changes you made and why you made them -->

## Test Plan 
 1. Tested using existing unit test framework.
 2. Testing using UERANSIM.
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
