### PR TITLE
fix(amf): fix to free the memory allocated for the ue context

### DIFF
--- a/lte/gateway/c/core/oai/tasks/amf/Registration.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/Registration.cpp
@@ -716,6 +716,7 @@ static int registration_accept_t3550_handler(
       amf_proc_registration_abort(amf_ctx, ue_amf_context);
       // Clean up all the sessions.
       amf_smf_context_cleanup_pdu_session(ue_amf_context);
+      amf_free_ue_context(ue_amf_context);
     }
   }
   OAILOG_FUNC_RETURN(LOG_NAS_AMF, RETURNok);
@@ -1140,7 +1141,6 @@ int amf_proc_registration_abort(
     message_p->ittiMsgHeader.imsi = ue_amf_context->amf_context.imsi64;
     send_msg_to_task(&amf_app_task_zmq_ctx, TASK_NGAP, message_p);
     amf_delete_registration_proc(amf_ctx);
-    amf_remove_ue_context(ue_amf_context);
     rc = RETURNok;
   }
   OAILOG_FUNC_RETURN(LOG_AMF_APP, rc);

--- a/lte/gateway/c/core/oai/tasks/amf/amf_app_ue_context.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_app_ue_context.cpp
@@ -437,7 +437,7 @@ void amf_free_ue_context(ue_m5gmm_context_s* ue_context_p) {
   if (ue_context_p->amf_ue_ngap_id != INVALID_AMF_UE_NGAP_ID) {
     h_rc = hashtable_ts_remove(
         amf_state_ue_id_ht, (const hash_key_t) ue_context_p->amf_ue_ngap_id,
-        (void**) &ue_context_p);
+        reinterpret_cast<void**>(&ue_context_p));
     ue_context_p->amf_ue_ngap_id = INVALID_AMF_UE_NGAP_ID;
   }
 

--- a/lte/gateway/c/core/oai/tasks/amf/amf_app_ue_context.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_app_ue_context.cpp
@@ -409,13 +409,13 @@ int amf_idle_mode_procedure(amf_context_t* amf_ctx) {
 
 /****************************************************************************
  **                                                                        **
- ** Name:    amf_delete_ue_context()                                       **
+ ** Name:    amf_free_ue_context()                                         **
  **                                                                        **
  ** Description: Deletes the ue context                                    **
  **                                                                        **
  **                                                                        **
  ***************************************************************************/
-void amf_delete_ue_context(ue_m5gmm_context_s* ue_context_p) {
+void amf_free_ue_context(ue_m5gmm_context_s* ue_context_p) {
   hashtable_rc_t h_rc                = HASH_TABLE_OK;
   amf_app_desc_t* amf_app_desc_p     = get_amf_nas_state(false);
   amf_ue_context_t* amf_ue_context_p = &amf_app_desc_p->amf_ue_contexts;
@@ -456,6 +456,5 @@ void amf_delete_ue_context(ue_m5gmm_context_s* ue_context_p) {
 
   delete ue_context_p;
   ue_context_p = NULL;
-  return;
 }
 }  // namespace magma5g

--- a/lte/gateway/c/core/oai/tasks/amf/amf_app_ue_context.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_app_ue_context.cpp
@@ -27,7 +27,6 @@ extern "C" {
 #include "amf_app_state_manager.h"
 #include "amf_recv.h"
 #include "amf_common.h"
-//#include "amf_app_defs.h"
 
 namespace magma5g {
 extern task_zmq_ctx_t amf_app_task_zmq_ctx;

--- a/lte/gateway/c/core/oai/tasks/amf/amf_app_ue_context_and_proc.h
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_app_ue_context_and_proc.h
@@ -844,5 +844,5 @@ ue_m5gmm_context_s* ue_context_lookup_by_gnb_ue_id(
     gnb_ue_ngap_id_t gnb_ue_ngap_id);
 
 int amf_idle_mode_procedure(amf_context_t* amf_ctx);
-
+void amf_delete_ue_context(ue_m5gmm_context_s* ue_context_p);
 }  // namespace magma5g

--- a/lte/gateway/c/core/oai/tasks/amf/amf_app_ue_context_and_proc.h
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_app_ue_context_and_proc.h
@@ -844,5 +844,5 @@ ue_m5gmm_context_s* ue_context_lookup_by_gnb_ue_id(
     gnb_ue_ngap_id_t gnb_ue_ngap_id);
 
 int amf_idle_mode_procedure(amf_context_t* amf_ctx);
-void amf_delete_ue_context(ue_m5gmm_context_s* ue_context_p);
+void amf_free_ue_context(ue_m5gmm_context_s* ue_context_p);
 }  // namespace magma5g

--- a/lte/gateway/c/core/oai/tasks/amf/deregistration_request.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/deregistration_request.cpp
@@ -210,10 +210,7 @@ int amf_app_handle_deregistration_req(amf_ue_ngap_id_t ue_id) {
   // Clean up all the sessions.
   amf_smf_context_cleanup_pdu_session(ue_context);
 
-  // Remove stored UE context from AMF core.
-  amf_remove_ue_context(ue_context);
-
-  amf_delete_ue_context(ue_context);
+  amf_free_ue_context(ue_context);
 
   OAILOG_FUNC_RETURN(LOG_NAS_AMF, rc);
 }

--- a/lte/gateway/c/core/oai/tasks/amf/deregistration_request.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/deregistration_request.cpp
@@ -213,6 +213,8 @@ int amf_app_handle_deregistration_req(amf_ue_ngap_id_t ue_id) {
   // Remove stored UE context from AMF core.
   amf_remove_ue_context(ue_context);
 
+  amf_delete_ue_context(ue_context);
+
   OAILOG_FUNC_RETURN(LOG_NAS_AMF, rc);
 }
 


### PR DESCRIPTION

fix to free the memory allocated for the ue context

## Summary

ue context deleted once moved to De-Registered

## Test Plan

Tested on NGAP Tester

## Additional Information

