### PR TITLE
fix(ci): https://liblfds.org website certificate expired on Sep 5th 2021

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -186,9 +186,8 @@ RUN git clone https://github.com/cpp-redis/cpp_redis.git && \
 
 ##### liblfds
 # https://www.liblfds.org/mediawiki/index.php?title=r7.1.0:Building_Guide_(liblfds)
-RUN wget --progress=dot:giga https://liblfds.org/downloads/liblfds%20release%207.1.0%20source.tar.bz2  && \
-    tar -xf liblfds\ release\ 7.1.0\ source.tar.bz2  && \
-    cd liblfds/liblfds7.1.0/liblfds710/build/gcc_gnumake/ && \
+RUN git clone https://github.com/liblfds/liblfds.git && \
+    cd liblfds/liblfds/liblfds7.1.0/liblfds710/build/gcc_gnumake/ && \
     make -j"$(nproc)" && \
     make ar_install && \
     cd / && \

--- a/lte/gateway/docker/mme/Dockerfile.rhel8
+++ b/lte/gateway/docker/mme/Dockerfile.rhel8
@@ -147,7 +147,7 @@ RUN  git clone --recurse-submodules -b v1.15.0 https://github.com/grpc/grpc && \
      git clone https://github.com/cpp-redis/cpp_redis.git && \
      wget https://ftp.gnu.org/gnu/nettle/nettle-2.5.tar.gz && \
      wget https://www.gnupg.org/ftp/gcrypt/gnutls/v3.1/gnutls-3.1.23.tar.xz && \
-     wget https://liblfds.org/downloads/liblfds%20release%207.1.0%20source.tar.bz2  && \
+     git clone https://github.com/liblfds/liblfds.git && \
      git clone https://git.osmocom.org/libgtpnl && \
      git clone https://github.com/OPENAIRINTERFACE/asn1c.git && \
      git clone https://github.com/fmtlib/fmt.git && \
@@ -254,8 +254,7 @@ RUN tar -xf nettle-2.5.tar.gz && \
 ##### liblfds
 # https://www.liblfds.org/mediawiki/index.php?title=r7.1.0:Building_Guide_(liblfds)
 RUN tar -xf liblfds\ release\ 7.1.0\ source.tar.bz2  && \
-    # Moved wget https://liblfds.org/downloads/liblfds%20release%207.1.0%20source.tar.bz2  && \
-    cd liblfds/liblfds7.1.0/liblfds710/build/gcc_gnumake/ && \
+    cd liblfds/liblfds/liblfds7.1.0/liblfds710/build/gcc_gnumake/ && \
     make -j`nproc` && \
     make ar_install
 

--- a/lte/gateway/docker/mme/Dockerfile.ubuntu18.04
+++ b/lte/gateway/docker/mme/Dockerfile.ubuntu18.04
@@ -150,9 +150,8 @@ RUN git clone https://github.com/cpp-redis/cpp_redis.git && \
 
 ##### liblfds
 # https://www.liblfds.org/mediawiki/index.php?title=r7.1.0:Building_Guide_(liblfds)
-RUN wget --quiet https://liblfds.org/downloads/liblfds%20release%207.1.0%20source.tar.bz2  && \
-    tar -xf liblfds\ release\ 7.1.0\ source.tar.bz2  && \
-    cd liblfds/liblfds7.1.0/liblfds710/build/gcc_gnumake/ && \
+RUN git clone https://github.com/liblfds/liblfds.git && \
+    cd liblfds/liblfds/liblfds7.1.0/liblfds710/build/gcc_gnumake/ && \
     make -j`nproc` && \
     make ar_install
 

--- a/lte/gateway/docker/mme/Dockerfile.ubuntu20.04
+++ b/lte/gateway/docker/mme/Dockerfile.ubuntu20.04
@@ -167,9 +167,8 @@ RUN git clone https://github.com/cpp-redis/cpp_redis.git && \
 
 ##### liblfds
 # https://www.liblfds.org/mediawiki/index.php?title=r7.1.0:Building_Guide_(liblfds)
-RUN wget --progress=dot:giga https://liblfds.org/downloads/liblfds%20release%207.1.0%20source.tar.bz2  && \
-    tar -xf liblfds\ release\ 7.1.0\ source.tar.bz2  && \
-    cd liblfds/liblfds7.1.0/liblfds710/build/gcc_gnumake/ && \
+RUN git clone https://github.com/liblfds/liblfds.git && \
+    cd liblfds/liblfds/liblfds7.1.0/liblfds710/build/gcc_gnumake/ && \
     make -j"$(nproc)" && \
     make ar_install && \
     cd / && \


### PR DESCRIPTION
**URGENT TO MERGE**

Replacing with a git clone of repo.

Signed-off-by: Raphael Defosseux <raphael.defosseux@openairinterface.org>

## Summary

As in title, website certificate expired on `Sep 5th, 2021`.
Other scripts are using GitHub source repo cloning instead of tar ball downloads.

## Test Plan

Tested manually.

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
