### PR TITLE
fix: Fix space in feedback request form

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -22,7 +22,7 @@ A clear and concise description of what the problem is, under which scenarios or
 **Additional context**
 Add any other context or screenshots about the problem here. You can also provide links to relevant resources.
 
-### Describe your idea(optional)
+### Describe your idea (optional)
 
 **Description**
 A clear and concise description of any alternative solutions or features you've considered.


### PR DESCRIPTION
Signed-off-by: Wally Rodriguez B <wallyrb@fb.com>

## Summary

- Add missing space in Feedback form.

## Test Plan

![image](https://user-images.githubusercontent.com/37117037/132345325-396265d3-d9cb-481c-ac20-9ecc00d0e3ec.png)
