### PR TITLE
fix(pipelined): backport-1.5 (#8974): fix vlan match

### DIFF
--- a/lte/gateway/python/magma/pipelined/app/inout.py
+++ b/lte/gateway/python/magma/pipelined/app/inout.py
@@ -256,7 +256,7 @@ class InOutController(RestartMixin, MagmaController):
         if vlan.isdigit():
             vid = 0x1000 | int(vlan)
             uplink_match = MagmaMatch(direction=Direction.OUT,
-                                      vlan_vid=(vid))
+                                      vlan_vid=(vid, 0x1fff))
         else:
             uplink_match = MagmaMatch(direction=Direction.OUT)
 


### PR DESCRIPTION
RYU expects mask even when vlan match is not wildcarded match.

Signed-off-by: Pravin B Shelar <pbshelar@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
