### PR TITLE
fix(agw): Bad encoding of naskeysetidentifierasme in NAS/AUTHENTICATION_REQUEST

### DIFF
--- a/lte/gateway/c/core/oai/tasks/nas/emm/msg/AuthenticationRequest.c
+++ b/lte/gateway/c/core/oai/tasks/nas/emm/msg/AuthenticationRequest.c
@@ -72,11 +72,8 @@ int encode_authentication_request(
   CHECK_PDU_POINTER_AND_LENGTH_ENCODER(
       buffer, AUTHENTICATION_REQUEST_MINIMUM_LENGTH, len);
   *(buffer + encoded) =
-      ((encode_u8_nas_key_set_identifier(
-            &authentication_request->naskeysetidentifierasme) &
-        0x0f)
-       << 4) |
-      0x00;
+      encode_u8_nas_key_set_identifier(
+            &authentication_request->naskeysetidentifierasme);
   encoded++;
 
   if ((encode_result = encode_authentication_parameter_rand_ie(


### PR DESCRIPTION
## Summary

While trying to stick to 3GPP spec 3GPP TS 24.301 :
5.4.2.2 Authentication initiation by the network
If an eKSI is contained in an initial NAS message during an EMM procedure, the network SHALL include a different eKSI
value in the AUTHENTICATION REQUEST message when it initiates an authentication procedure.

"SHALL" meanning according to 3GPP, meaning according to 43_ETSI_directives_20_may_2021_part2 (EDR).pdf :
is to, is required to, it is required that, has to, only ... is permitted, it is necessary.

The following situation happens with phones when UE re-attach after detach: the 2nd NAS Attach message is security protected with previous security context, ksi = 0. The authentication procedure goes well even if MME set a new security context with ksi=0, and the attach procedure succeed after few remaining exchanges, we never saw Authentication Reject with real UEs in this context.

When testing with dsTester, seems it sticks strictly to the specification, and after the 2nd Attach message, the Authentication procedure fails due to ksi=0, it finally succeed if we set ksi=1.

We are in the process of incrementing eksi in MME code, but the encoding of nas key set identifier asme in the header was wrong, it should fit in the lowest quartet of a byte, the higher quartet is spare and should be zero. The encoding occurred in the spare quartet. We just encoded the  nas key set identifier asme in the lower quartet.

The aim of this first PR is only to fix the encoding of nas key set identifier asme.

## Test Plan

We checked the encoding of NAS authentication request in wireshark between dsTester and magma MME.

## Additional Information

- [ ] This change is backwards-breaking

