### PR TITLE
fix(ci): website certificate expired on Sep 5th 2021

### DIFF
--- a/lte/gateway/docker/mme/Dockerfile.rhel8
+++ b/lte/gateway/docker/mme/Dockerfile.rhel8
@@ -253,8 +253,7 @@ RUN tar -xf nettle-2.5.tar.gz && \
 
 ##### liblfds
 # https://www.liblfds.org/mediawiki/index.php?title=r7.1.0:Building_Guide_(liblfds)
-RUN tar -xf liblfds\ release\ 7.1.0\ source.tar.bz2  && \
-    cd liblfds/liblfds/liblfds7.1.0/liblfds710/build/gcc_gnumake/ && \
+RUN cd /liblfds/liblfds/liblfds7.1.0/liblfds710/build/gcc_gnumake/ && \
     make -j`nproc` && \
     make ar_install
 


### PR DESCRIPTION
Take 2

## Summary

As in title, website certificate expired on Sep 5th, 2021.
Other scripts are using GitHub source repo cloning instead of tar ball downloads.

I tested on the 1st PR only the `Ubuntu18` images. I did not tested the fixes on the `RHEL8` dockerfile.
As usual, not tested means no feature.


## Test Plan

Tested manually the `RHEL8` dockerfile.

## Additional Information

- [ ] This change is backwards-breaking

