### PR TITLE
feat(amf): Selection of algorithms based on preference

### DIFF
--- a/lte/gateway/c/core/oai/tasks/amf/amf_app_ue_context_and_proc.h
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_app_ue_context_and_proc.h
@@ -858,6 +858,9 @@ tmsi_t amf_lookup_guti_by_ueid(amf_ue_ngap_id_t ue_id);
 
 int amf_idle_mode_procedure(amf_context_t* amf_ctx);
 void amf_free_ue_context(ue_m5gmm_context_s* ue_context_p);
+int m5g_security_select_algorithms(
+    const int ue_iaP, const int ue_eaP, int* const amf_iaP, int* const amf_eaP);
+
 /************************************************************************
  ** Name:    delete_wrapper()                                         **
  **                                                                   **

--- a/lte/gateway/c/core/oai/tasks/amf/amf_as.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_as.cpp
@@ -987,10 +987,6 @@ static int amf_as_security_req(
         if (ue_context) {
           amf_security_context_t* amf_security_context =
               &ue_context->amf_context._security;
-          amf_security_context->selected_algorithms.integrity =
-              M5G_NAS_SECURITY_ALGORITHMS_128_5G_IA2;  // TODO get this computed
-          amf_security_context->selected_algorithms.encryption =
-              M5G_NAS_SECURITY_ALGORITHMS_5G_EA0;  // TODO get this computed
           nas_msg.security_protected.plain.amf.msg.securitymodecommandmsg
               .nas_sec_algorithms.tca =
               amf_security_context->selected_algorithms.encryption;

--- a/lte/gateway/c/core/oai/tasks/amf/amf_config.c
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_config.c
@@ -428,6 +428,7 @@ void amf_config_exit(void) {
   pthread_rwlock_destroy(&amf_config.rw_lock);
   amf_config_free(&amf_config);
 }
+
 void clear_amf_config(amf_config_t* amf_config) {
   if (!amf_config) return;
 
@@ -466,6 +467,14 @@ void copy_amf_config_from_mme_config(
   dest->relative_capacity              = src->relative_capacity;
   dest->use_stateless                  = src->use_stateless;
   dest->unauthenticated_imsi_supported = src->unauthenticated_imsi_supported;
+
+  // NAS-5G setting
+  for (int i = 0; i < 8; i++) {
+    dest->nas_config.preferred_integrity_algorithm[i] =
+        src->nas_config.prefered_integrity_algorithm[i];
+    dest->nas_config.preferred_ciphering_algorithm[i] =
+        src->nas_config.prefered_ciphering_algorithm[i];
+  }
 
   // TAI list setting
   copy_served_tai_config_list(dest, src);

--- a/lte/gateway/c/core/oai/tasks/amf/nas5g_message.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/nas5g_message.cpp
@@ -913,6 +913,54 @@ static uint32_t _nas5g_message_get_mac(
   }
 
   switch (amf_security_context->selected_algorithms.integrity) {
+    case M5G_NAS_SECURITY_ALGORITHMS_128_5G_IA1: {
+      uint8_t mac[4];
+      nas_stream_cipher_t stream_cipher;
+      uint32_t count;
+      uint32_t* mac32;
+
+      if (direction == SECU_DIRECTION_UPLINK) {
+        count = 0x00000000 |
+                ((amf_security_context->ul_count.overflow & 0x0000FFFF) << 8) |
+                (amf_security_context->ul_count.seq_num & 0x000000FF);
+      } else {
+        count = 0x00000000 |
+                ((amf_security_context->dl_count.overflow & 0x0000FFFF) << 8) |
+                (amf_security_context->dl_count.seq_num & 0x000000FF);
+      }
+
+      OAILOG_INFO(
+          LOG_AMF_APP,
+          "M5G_NAS_SECURITY_ALGORITHMS_128_5G_IA1 %s count.seq_num %u count "
+          "%u\n",
+          (direction == SECU_DIRECTION_UPLINK) ? "UPLINK" : "DOWNLINK",
+          (direction == SECU_DIRECTION_UPLINK) ?
+              amf_security_context->ul_count.seq_num :
+              amf_security_context->dl_count.seq_num,
+          count);
+      stream_cipher.key        = amf_security_context->knas_int;
+      stream_cipher.key_length = AUTH_KNAS_INT_SIZE;
+      stream_cipher.count      = count;
+      stream_cipher.bearer     = 0x01;  // 33.401 section 8.1.1
+      stream_cipher.direction  = direction;
+      stream_cipher.message    = const_cast<uint8_t*>(buffer);
+      /*
+       *        * length in bits
+       *               */
+      stream_cipher.blength = length << 3;
+      nas_stream_encrypt_eia1(&stream_cipher, mac);
+      OAILOG_INFO(
+          LOG_AMF_APP,
+          "M5G_NAS_SECURITY_ALGORITHMS_128_5G_IA1 returned MAC %x.%x.%x.%x(%u) "
+          "for "
+          "length "
+          "%" PRIu32 ", direction %d, count %d\n",
+          mac[0], mac[1], mac[2], mac[3], *(reinterpret_cast<uint32_t*>(&mac)),
+          length, direction, count);
+      mac32 = reinterpret_cast<uint32_t*>(&mac);
+      OAILOG_FUNC_RETURN(LOG_NAS, ntohl(*mac32));
+    } break;
+
     case M5G_NAS_SECURITY_ALGORITHMS_128_5G_IA2: {
       uint8_t mac[4];
       nas_stream_cipher_t stream_cipher;

--- a/lte/gateway/c/core/oai/test/amf/CMakeLists.txt
+++ b/lte/gateway/c/core/oai/test/amf/CMakeLists.txt
@@ -42,6 +42,7 @@ set(AMF_APP_TEST_SRC
     test_amf_encode_decode.cpp
     amf_app_test_util.cpp
     test_amf_procedures.cpp
+    test_amf_algorithm_selection.cpp
     )
 
 add_executable(amf_app_test ${AMF_APP_TEST_SRC})

--- a/lte/gateway/c/core/oai/test/amf/test_amf_algorithm_selection.cpp
+++ b/lte/gateway/c/core/oai/test/amf/test_amf_algorithm_selection.cpp
@@ -1,0 +1,67 @@
+/**
+ * Copyright 2021 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+#include "../../tasks/amf/amf_app_ue_context_and_proc.h"
+
+extern "C" {
+#include "log.h"
+#include "include/amf_config.h"
+}
+
+using ::testing::Test;
+
+namespace magma5g {
+
+/* Test for algorithm selection */
+TEST(test_algorithm_selection, ue_security_capabilities) {
+  // Priority order for integrity algorithm : { IA2 IA1 IA0 }
+  amf_config.nas_config.preferred_integrity_algorithm[0] = 2;
+  amf_config.nas_config.preferred_integrity_algorithm[1] = 1;
+  amf_config.nas_config.preferred_integrity_algorithm[2] = 0;
+  // Priority order for ciphering algorithm : { EA0 EA1 EA2}
+  amf_config.nas_config.preferred_ciphering_algorithm[0] = 0;
+  amf_config.nas_config.preferred_ciphering_algorithm[1] = 1;
+  amf_config.nas_config.preferred_ciphering_algorithm[2] = 2;
+
+  int in_IA, in_EA;
+  int out_IA = 0, out_EA = 0;
+
+  // If UE supports all the above mentioned algortithms, then AMF should select
+  // IA2 and EA0.
+  in_IA = 0xE0;  // 1110 0000
+  in_EA = 0xE0;  // 1110 0000
+  EXPECT_EQ(
+      m5g_security_select_algorithms(in_IA, in_EA, &out_IA, &out_EA), RETURNok);
+  EXPECT_EQ(out_IA, 2);
+  EXPECT_EQ(out_EA, 0);
+
+  // If UE supports IA0, IA1 and EA0, EA1 , then AMF should select IA1 and EA0.
+  in_IA = 0xC0;  // 1100 0000
+  in_EA = 0xC0;  // 1100 0000
+  EXPECT_EQ(
+      m5g_security_select_algorithms(in_IA, in_EA, &out_IA, &out_EA), RETURNok);
+  EXPECT_EQ(out_IA, 1);
+  EXPECT_EQ(out_EA, 0);
+
+  // If UE supports IA0, IA1, IA2 and EA1 EA2, then AMF should select IA2 and
+  // EA1.
+  in_IA = 0x60;  // 0110 0000
+  in_EA = 0x60;  // 0110 0000
+  EXPECT_EQ(
+      m5g_security_select_algorithms(in_IA, in_EA, &out_IA, &out_EA), RETURNok);
+  EXPECT_EQ(out_IA, 2);
+  EXPECT_EQ(out_EA, 1);
+}
+
+}  // namespace magma5g


### PR DESCRIPTION
Signed-off-by: chandhu-wavelabs <chandhu.naga@wavelabs.ai>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

Support added for algorithm selection based on preference.
Order of preference : Integrity algorithms = [IA2 IA1 IA0], Ciphering algorithms = [EA0 EA1 EA2].
 
Added IA1 mac calculation support.

## Test Plan

Tested with UERANSIM and TVm. Following are the results captured while testing.

IA0 and EA0 are the default selected algorithms.

Scenario 1 : If UE supports { IA0, IA1, IA2} and {EA0, EA1, EA2}, then AMF should select IA2 and EA0.
![image](https://user-images.githubusercontent.com/84959602/138294200-5f19bae1-a9ee-4750-bc71-66dae36db37a.png)


Scenario 2 :  If UE supports { IA0, IA1} and {EA0, EA1, EA2}, then AMF should select IA1 and EA0.
![image](https://user-images.githubusercontent.com/84959602/138293924-fb18c0e1-bfd9-4303-bf81-f748638e0b02.png)


Scenario 3 :  If UE supports { IA0} and {EA0, EA1, EA2}, then AMF should select IA0 and EA0.
![image](https://user-images.githubusercontent.com/84959602/138293719-e5138991-b618-43c2-a31b-042aa01dcc74.png)


Unit test cases added.
## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
