### PR TITLE
fix(mme): Fixing SEGV on implicit detach of unknown GUTI attach

### DIFF
--- a/lte/gateway/c/core/oai/tasks/nas/emm/Identification.c
+++ b/lte/gateway/c/core/oai/tasks/nas/emm/Identification.c
@@ -259,7 +259,7 @@ status_code_e emm_proc_identification_complete(
 
       if (imsi) {
         imsi64_t imsi64 = imsi_to_imsi64(imsi);
-        // If context already exists for this IMSI ,perform implicit detach
+        // If context already exists for this IMSI, perform implicit detach
         mme_app_desc_t* mme_app_desc_p      = get_mme_nas_state(false);
         ue_mm_context_t* old_imsi_ue_mm_ctx = mme_ue_context_exists_imsi(
             &mme_app_desc_p->mme_ue_contexts, imsi64);
@@ -284,8 +284,8 @@ status_code_e emm_proc_identification_complete(
               &old_imsi_ue_mm_ctx->emm_context, ue_mm_context->mme_ue_s1ap_id,
               attach_proc->ies, true);
           emm_ctx->emm_context_state = NEW_EMM_CONTEXT_CREATED;
-          nas_proc_implicit_detach_ue_ind(old_imsi_ue_mm_ctx->mme_ue_s1ap_id);
-          notify = false;
+          rc = nas_proc_implicit_detach_ue_ind(old_imsi_ue_mm_ctx->mme_ue_s1ap_id);
+          OAILOG_FUNC_RETURN(LOG_NAS_EMM, rc);
         }
         int emm_cause = check_plmn_restriction(*imsi);
         if (emm_cause != EMM_CAUSE_SUCCESS) {


### PR DESCRIPTION
Signed-off-by: Alex Rodriguez <ardzoht@gmail.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

- Closes #8987 
- As part of #7916, part of implicit detach on unknown GUTI attach a double free segfault can be raised, which can be caused due to performing implicit detach (which will later free the MME ue context), and continue with the procedure, which later will try to access the Identification common procedure:
```
      emm_sap.primitive                      = EMMREG_COMMON_PROC_CNF;
      emm_sap.u.emm_reg.ue_id                = ue_id;
      emm_sap.u.emm_reg.ctx                  = emm_ctx;
      emm_sap.u.emm_reg.notify               = notify;
      emm_sap.u.emm_reg.free_proc            = true;
      emm_sap.u.emm_reg.u.common.common_proc = &ident_proc->emm_com_proc;
```

## Test Plan

- Running `make integ_test` and `make precommit` as sanity testing

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
