### PR TITLE
feat(agw): Add support for new managed eNB: FreedomFiOne

### DIFF
--- a/lte/gateway/configs/enodebd.yml
+++ b/lte/gateway/configs/enodebd.yml
@@ -21,10 +21,28 @@ tr069:
   #       if this is ever changed in dnsd.yml, this needs to be updated too
   public_ip: 192.88.99.142
 
+# TODO: @amar: This is a temp workaround to allow for testing until we
+# connect enodebd with the domain proxy which is responsible for talking to
+# SAS.
+sas:
+  sas_enabled: True
+  sas_server_url: "https://spectrum-connect.federatedwireless.com/v1.2/"
+  sas_uid: "INVALID_ID"
+  sas_category: "A"
+  sas_channel_type: "GAA"
+  sas_cert_subject: "INVALID_CERT_SUBJECT"
+  sas_icg_group_id: ""
+  sas_location: "indoor"
+  sas_height_type: "AMSL"
+
 # Reboot eNodeB if eNodeB should be connected to MME but isn't
 # This is a workaround for a bug with BaiCells eNodeB where the S1 connection
 # gets into a bad state
 reboot_enodeb_on_mme_disconnected: True
+
+# Enable webui for debugging for a list of eNB serial numbers.
+# Not supported on all enodeb models
+web_ui_enable: []
 
 # Network interface to terminate S1
 s1_interface: eth1

--- a/lte/gateway/configs/enodebd.yml
+++ b/lte/gateway/configs/enodebd.yml
@@ -42,7 +42,7 @@ reboot_enodeb_on_mme_disconnected: True
 
 # Enable webui for debugging for a list of eNB serial numbers.
 # Not supported on all enodeb models
-web_ui_enable: []
+web_ui_enable_list: []
 
 # Network interface to terminate S1
 s1_interface: eth1

--- a/lte/gateway/python/magma/enodebd/data_models/data_model.py
+++ b/lte/gateway/python/magma/enodebd/data_models/data_model.py
@@ -19,6 +19,14 @@ from magma.enodebd.data_models.data_model_parameters import ParameterName
 
 TrParam = namedtuple('TrParam', ['path', 'is_invasive', 'type', 'is_optional'])
 
+# We may want to model nodes in the datamodel that are derived from other fields
+# in the datamodel and thus maynot have a representation in tr69.
+# e.g PTP_STATUS in FreedomFiOne is True iff GPS is in sync and SyncStatus is
+# True.
+# Explicitly map these params to invalid paths so setters and getters know they
+# should not try to read or write these nodes on the eNB side.
+InvalidTrParamPath = "INVALID_TR_PATH"
+
 
 class DataModel(ABC):
     """

--- a/lte/gateway/python/magma/enodebd/device_config/configuration_init.py
+++ b/lte/gateway/python/magma/enodebd/device_config/configuration_init.py
@@ -39,7 +39,6 @@ DEFAULT_S1_PORT = 36412
 # Cell Identity is a 28 bit number, but not all values are supported.
 DEFAULT_CELL_IDENTITY = 138777000
 
-
 SingleEnodebConfig = namedtuple(
     'SingleEnodebConfig',
     [
@@ -61,11 +60,11 @@ def config_assert(condition: bool, message: str = None) -> None:
 
 
 def build_desired_config(
-    mconfig: Any,
-    service_config: Any,
-    device_config: EnodebConfiguration,
-    data_model: DataModel,
-    post_processor: EnodebConfigurationPostProcessor,
+        mconfig: Any,
+        service_config: Any,
+        device_config: EnodebConfiguration,
+        data_model: DataModel,
+        post_processor: EnodebConfigurationPostProcessor,
 ) -> EnodebConfiguration:
     """
     Factory for initializing DESIRED data model configuration.
@@ -183,8 +182,8 @@ def _get_enb_yang_config(
 
 
 def _get_enb_config(
-    mconfig: mconfigs_pb2.EnodebD,
-    device_config: EnodebConfiguration,
+        mconfig: mconfigs_pb2.EnodebD,
+        device_config: EnodebConfiguration,
 ) -> SingleEnodebConfig:
     # For fields that are specified per eNB
     if mconfig.enb_configs_by_serial is not None and \
@@ -251,8 +250,8 @@ def _get_enb_config(
 
 
 def _set_pci(
-    cfg: EnodebConfiguration,
-    pci: Any,
+        cfg: EnodebConfiguration,
+        pci: Any,
 ) -> None:
     """
     Set the following parameters:
@@ -264,16 +263,19 @@ def _set_pci(
 
 
 def _set_bandwidth(
-    cfg: EnodebConfiguration,
-    data_model: DataModel,
-    bandwidth_mhz: Any,
+        cfg: EnodebConfiguration,
+        data_model: DataModel,
+        bandwidth_mhz: Any,
 ) -> None:
     """
     Set the following parameters:
      - DL bandwidth
      - UL bandwidth
     """
-    cfg.set_parameter(ParameterName.DL_BANDWIDTH, bandwidth_mhz)
+    _set_param_if_present(
+        cfg, data_model, ParameterName.DL_BANDWIDTH,
+        bandwidth_mhz,
+    )
     _set_param_if_present(
         cfg, data_model, ParameterName.UL_BANDWIDTH,
         bandwidth_mhz,
@@ -281,8 +283,8 @@ def _set_bandwidth(
 
 
 def _set_cell_id(
-    cfg: EnodebConfiguration,
-    cell_id: int,
+        cfg: EnodebConfiguration,
+        cell_id: int,
 ) -> None:
     config_assert(
         cell_id in range(0, 268435456),
@@ -292,10 +294,10 @@ def _set_cell_id(
 
 
 def _set_tdd_subframe_config(
-    device_cfg: EnodebConfiguration,
-    cfg: EnodebConfiguration,
-    subframe_assignment: Any,
-    special_subframe_pattern: Any,
+        device_cfg: EnodebConfiguration,
+        cfg: EnodebConfiguration,
+        subframe_assignment: Any,
+        special_subframe_pattern: Any,
 ) -> None:
     """
     Set the following parameters:
@@ -303,8 +305,11 @@ def _set_tdd_subframe_config(
      - Special subframe pattern
     """
     # Don't try to set if this is not TDD mode
-    if device_cfg.get_parameter(ParameterName.DUPLEX_MODE_CAPABILITY) != \
-            'TDDMode':
+    if (
+        device_cfg.has_parameter(ParameterName.DUPLEX_MODE_CAPABILITY)
+            and device_cfg.get_parameter(ParameterName.DUPLEX_MODE_CAPABILITY)
+            != 'TDDMode'
+    ):
         return
 
     config_assert(
@@ -339,9 +344,9 @@ def _set_management_server(cfg: EnodebConfiguration) -> None:
 
 
 def _set_s1_connection(
-    cfg: EnodebConfiguration,
-    mme_ip: Any,
-    mme_port: Any = DEFAULT_S1_PORT,
+        cfg: EnodebConfiguration,
+        mme_ip: Any,
+        mme_port: Any = DEFAULT_S1_PORT,
 ) -> None:
     """
     Set the following parameters:
@@ -355,9 +360,9 @@ def _set_s1_connection(
 
 
 def _set_perf_mgmt(
-    cfg: EnodebConfiguration,
-    perf_mgmt_ip: str,
-    perf_mgmt_port: int,
+        cfg: EnodebConfiguration,
+        perf_mgmt_ip: str,
+        perf_mgmt_port: int,
 ) -> None:
     """
     Set the following parameters:
@@ -381,9 +386,9 @@ def _set_perf_mgmt(
 
 
 def _set_misc_static_params(
-    device_cfg: EnodebConfiguration,
-    cfg: EnodebConfiguration,
-    data_model: DataModel,
+        device_cfg: EnodebConfiguration,
+        cfg: EnodebConfiguration,
+        data_model: DataModel,
 ) -> None:
     """
     Set the following parameters:
@@ -397,11 +402,12 @@ def _set_misc_static_params(
     _set_param_if_present(cfg, data_model, ParameterName.GPS_ENABLE, True)
     # For BaiCells eNodeBs, IPSec enable may be either integer or bool.
     # Set to false/0 depending on the current type
-    try:
-        int(device_cfg.get_parameter(ParameterName.IP_SEC_ENABLE))
-        cfg.set_parameter(ParameterName.IP_SEC_ENABLE, 0)
-    except ValueError:
-        cfg.set_parameter(ParameterName.IP_SEC_ENABLE, False)
+    if data_model.is_parameter_present(ParameterName.IP_SEC_ENABLE):
+        try:
+            int(device_cfg.get_parameter(ParameterName.IP_SEC_ENABLE))
+            cfg.set_parameter(ParameterName.IP_SEC_ENABLE, value=0)
+        except ValueError:
+            cfg.set_parameter(ParameterName.IP_SEC_ENABLE, value=False)
 
     _set_param_if_present(cfg, data_model, ParameterName.CELL_RESERVED, False)
     _set_param_if_present(
@@ -411,9 +417,9 @@ def _set_misc_static_params(
 
 
 def _set_plmnids_tac(
-    cfg: EnodebConfiguration,
-    plmnids: Union[int, str],
-    tac: Any,
+        cfg: EnodebConfiguration,
+        plmnids: Union[int, str],
+        tac: Any,
 ) -> None:
     """
     Set the following parameters:
@@ -479,10 +485,10 @@ def _set_plmnids_tac(
 
 
 def _set_earfcn_freq_band_mode(
-    device_cfg: EnodebConfiguration,
-    cfg: EnodebConfiguration,
-    data_model: DataModel,
-    earfcndl: int,
+        device_cfg: EnodebConfiguration,
+        cfg: EnodebConfiguration,
+        data_model: DataModel,
+        earfcndl: int,
 ) -> None:
     """
     Set the following parameters:
@@ -500,42 +506,43 @@ def _set_earfcn_freq_band_mode(
         raise ConfigurationError(err)
 
     # Verify capabilities
-    duplex_capability =\
-        device_cfg.get_parameter(ParameterName.DUPLEX_MODE_CAPABILITY)
-    if duplex_mode == DuplexMode.TDD and duplex_capability != 'TDDMode':
-        raise ConfigurationError((
-            'eNodeB duplex mode capability is <{0}>, '
-            'but earfcndl is <{1}>, giving duplex '
-            'mode <{2}> instead'
-        ).format(
-            duplex_capability, str(earfcndl), str(duplex_mode),
-        ))
-    elif duplex_mode == DuplexMode.FDD and duplex_capability != 'FDDMode':
-        raise ConfigurationError((
-            'eNodeB duplex mode capability is <{0}>, '
-            'but earfcndl is <{1}>, giving duplex '
-            'mode <{2}> instead'
-        ).format(
-            duplex_capability, str(earfcndl), str(duplex_mode),
-        ))
-    elif duplex_mode not in [DuplexMode.TDD, DuplexMode.FDD]:
-        raise ConfigurationError(
-            'Invalid duplex mode (%s)' % str(duplex_mode),
-        )
+    if device_cfg.has_parameter(ParameterName.DUPLEX_MODE_CAPABILITY):
+        duplex_capability = \
+            device_cfg.get_parameter(ParameterName.DUPLEX_MODE_CAPABILITY)
+        if duplex_mode == DuplexMode.TDD and duplex_capability != 'TDDMode':
+            raise ConfigurationError((
+                'eNodeB duplex mode capability is <{0}>, '
+                'but earfcndl is <{1}>, giving duplex '
+                'mode <{2}> instead'
+            ).format(
+                duplex_capability, str(earfcndl), str(duplex_mode),
+            ))
+        elif duplex_mode == DuplexMode.FDD and duplex_capability != 'FDDMode':
+            raise ConfigurationError((
+                'eNodeB duplex mode capability is <{0}>, '
+                'but earfcndl is <{1}>, giving duplex '
+                'mode <{2}> instead'
+            ).format(
+                duplex_capability, str(earfcndl), str(duplex_mode),
+            ))
+        elif duplex_mode not in {DuplexMode.TDD, DuplexMode.FDD}:
+            raise ConfigurationError(
+                'Invalid duplex mode (%s)' % str(duplex_mode),
+            )
 
-    # Baicells indicated that they no longer use the band capability list,
-    # so it may not be populated correctly
-    band_capability_list = device_cfg.get_parameter(
-        ParameterName.BAND_CAPABILITY,
-    )
-    band_capabilities = band_capability_list.split(',')
-    if str(band) not in band_capabilities:
-        logger.warning(
-            'Band %d not in capabilities list (%s). Continuing'
-            ' with config because capabilities list may not be'
-            ' correct', band, band_capabilities,
+    if device_cfg.has_parameter(ParameterName.BAND_CAPABILITY):
+        # Baicells indicated that they no longer use the band capability list,
+        # so it may not be populated correctly
+        band_capability_list = device_cfg.get_parameter(
+            ParameterName.BAND_CAPABILITY,
         )
-
+        band_capabilities = band_capability_list.split(',')
+        if str(band) not in band_capabilities:
+            logger.warning(
+                'Band %d not in capabilities list (%s). Continuing'
+                ' with config because capabilities list may not be'
+                ' correct', band, band_capabilities,
+            )
     cfg.set_parameter(ParameterName.EARFCNDL, earfcndl)
     if duplex_mode == DuplexMode.FDD:
         _set_param_if_present(
@@ -549,7 +556,7 @@ def _set_earfcn_freq_band_mode(
 
     if duplex_mode == DuplexMode.TDD:
         logger.debug('Set EARFCNDL=%d, Band=%d', earfcndl, band)
-    else:
+    elif duplex_mode == DuplexMode.FDD:
         logger.debug(
             'Set EARFCNDL=%d, EARFCNUL=%d, Band=%d',
             earfcndl, earfcnul, band,
@@ -557,10 +564,10 @@ def _set_earfcn_freq_band_mode(
 
 
 def _set_param_if_present(
-    cfg: EnodebConfiguration,
-    data_model: DataModel,
-    param: ParameterName,
-    value: Any,
+        cfg: EnodebConfiguration,
+        data_model: DataModel,
+        param: ParameterName,
+        value: Any,
 ) -> None:
     if data_model.is_parameter_present(param):
         cfg.set_parameter(param, value)

--- a/lte/gateway/python/magma/enodebd/devices/baicells.py
+++ b/lte/gateway/python/magma/enodebd/devices/baicells.py
@@ -56,7 +56,7 @@ class BaicellsHandler(BasicEnodebAcsStateMachine):
         service: MagmaService,
     ) -> None:
         self._state_map = {}
-        super().__init__(service)
+        super().__init__(service=service, use_param_key=False)
 
     def reboot_asap(self) -> None:
         self.transition('reboot')

--- a/lte/gateway/python/magma/enodebd/devices/baicells_old.py
+++ b/lte/gateway/python/magma/enodebd/devices/baicells_old.py
@@ -56,7 +56,7 @@ class BaicellsOldHandler(BasicEnodebAcsStateMachine):
             service: MagmaService,
     ) -> None:
         self._state_map = {}
-        super().__init__(service)
+        super().__init__(service=service, use_param_key=False)
 
     def reboot_asap(self) -> None:
         self.transition('reboot')

--- a/lte/gateway/python/magma/enodebd/devices/baicells_qafa.py
+++ b/lte/gateway/python/magma/enodebd/devices/baicells_qafa.py
@@ -56,7 +56,7 @@ class BaicellsQAFAHandler(BasicEnodebAcsStateMachine):
         service: MagmaService,
     ) -> None:
         self._state_map = {}
-        super().__init__(service)
+        super().__init__(service=service, use_param_key=False)
 
     def reboot_asap(self) -> None:
         self.transition('reboot')

--- a/lte/gateway/python/magma/enodebd/devices/baicells_qafb.py
+++ b/lte/gateway/python/magma/enodebd/devices/baicells_qafb.py
@@ -65,7 +65,7 @@ class BaicellsQAFBHandler(BasicEnodebAcsStateMachine):
             service: MagmaService,
     ) -> None:
         self._state_map = {}
-        super().__init__(service)
+        super().__init__(service=service, use_param_key=False)
 
     def reboot_asap(self) -> None:
         self.transition('reboot')

--- a/lte/gateway/python/magma/enodebd/devices/baicells_rts.py
+++ b/lte/gateway/python/magma/enodebd/devices/baicells_rts.py
@@ -55,7 +55,7 @@ class BaicellsRTSHandler(BasicEnodebAcsStateMachine):
             service: MagmaService,
     ) -> None:
         self._state_map = {}
-        super().__init__(service)
+        super().__init__(service=service, use_param_key=False)
 
     def reboot_asap(self) -> None:
         self.transition('reboot')

--- a/lte/gateway/python/magma/enodebd/devices/device_map.py
+++ b/lte/gateway/python/magma/enodebd/devices/device_map.py
@@ -20,6 +20,7 @@ from magma.enodebd.devices.baicells_qafb import BaicellsQAFBHandler
 from magma.enodebd.devices.baicells_rts import BaicellsRTSHandler
 from magma.enodebd.devices.device_utils import EnodebDeviceName
 from magma.enodebd.devices.experimental.cavium import CaviumHandler
+from magma.enodebd.devices.freedomfi_one import FreedomFiOneHandler
 from magma.enodebd.state_machines.enb_acs import EnodebAcsStateMachine
 
 # This exists only to break a circular dependency. Otherwise there's no
@@ -33,6 +34,7 @@ DEVICE_HANDLER_BY_NAME = {
     EnodebDeviceName.BAICELLS_QAFB: BaicellsQAFBHandler,
     EnodebDeviceName.BAICELLS_RTS: BaicellsRTSHandler,
     EnodebDeviceName.CAVIUM: CaviumHandler,
+    EnodebDeviceName.FREEDOMFI_ONE: FreedomFiOneHandler,
 }
 
 

--- a/lte/gateway/python/magma/enodebd/devices/device_utils.py
+++ b/lte/gateway/python/magma/enodebd/devices/device_utils.py
@@ -28,6 +28,7 @@ class EnodebDeviceName():
     BAICELLS_QAFB = 'Baicells QAFB'
     BAICELLS_RTS = 'Baicells RTS'
     CAVIUM = 'Cavium'
+    FREEDOMFI_ONE = 'FREEDOMFI ONE'
 
 
 def get_device_name(
@@ -75,6 +76,8 @@ def get_device_name(
             )
     elif device_oui in {'000FB7', '744D28'}:
         return EnodebDeviceName.CAVIUM
+    elif device_oui == '000E8F':
+        return EnodebDeviceName.FREEDOMFI_ONE
     else:
         raise UnrecognizedEnodebError("Device %s unsupported" % device_oui)
 

--- a/lte/gateway/python/magma/enodebd/devices/experimental/cavium.py
+++ b/lte/gateway/python/magma/enodebd/devices/experimental/cavium.py
@@ -64,7 +64,7 @@ class CaviumHandler(BasicEnodebAcsStateMachine):
             service: MagmaService,
     ) -> None:
         self._state_map = {}
-        super().__init__(service)
+        super().__init__(service=service, use_param_key=False)
 
     def reboot_asap(self) -> None:
         self.transition('reboot')

--- a/lte/gateway/python/magma/enodebd/devices/freedomfi_one.py
+++ b/lte/gateway/python/magma/enodebd/devices/freedomfi_one.py
@@ -1,0 +1,1020 @@
+"""
+Copyright 2020 The Magma Authors.
+
+This source code is licensed under the BSD-style license found in the
+LICENSE file in the root directory of this source tree.
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+import logging
+from typing import Any, Callable, Dict, List, Optional, Type
+
+from magma.common.service import MagmaService
+from magma.enodebd.data_models import transform_for_magma
+from magma.enodebd.data_models.data_model import (
+    DataModel,
+    InvalidTrParamPath,
+    TrParam,
+)
+from magma.enodebd.data_models.data_model_parameters import (
+    ParameterName,
+    TrParameterType,
+)
+from magma.enodebd.device_config.configuration_init import build_desired_config
+from magma.enodebd.device_config.enodeb_config_postprocessor import (
+    EnodebConfigurationPostProcessor,
+)
+from magma.enodebd.device_config.enodeb_configuration import EnodebConfiguration
+from magma.enodebd.devices.device_utils import EnodebDeviceName
+from magma.enodebd.logger import EnodebdLogger
+from magma.enodebd.state_machines.acs_state_utils import (
+    get_all_objects_to_add,
+    get_all_objects_to_delete,
+    get_all_param_values_to_set,
+    get_params_to_get,
+    parse_get_parameter_values_response,
+)
+from magma.enodebd.state_machines.enb_acs import EnodebAcsStateMachine
+from magma.enodebd.state_machines.enb_acs_impl import BasicEnodebAcsStateMachine
+from magma.enodebd.state_machines.enb_acs_states import (
+    AcsMsgAndTransition,
+    AcsReadMsgResult,
+    AddObjectsState,
+    DeleteObjectsState,
+    EnbSendRebootState,
+    EndSessionState,
+    EnodebAcsState,
+    ErrorState,
+    GetParametersState,
+    SetParameterValuesState,
+    WaitGetParametersState,
+    WaitInformMRebootState,
+    WaitInformState,
+    WaitRebootResponseState,
+    WaitSetParameterValuesState,
+)
+from magma.enodebd.tr069 import models
+
+
+class SASParameters(object):
+    """ Class modeling the SAS parameters and their TR path"""
+    # SAS parameters for FreedomFiOne
+    FAP_CONTROL = 'Device.Services.FAPService.1.FAPControl.'
+    FAPSERVICE_PATH = 'Device.Services.FAPService.1.'
+
+    # Sas management parameters
+    SAS_ENABLE = "sas_enabled"
+    SAS_SERVER_URL = "sas_server_url"
+    SAS_UID = "sas_uid"
+    SAS_CATEGORY = "sas_category"
+    SAS_CHANNEL_TYPE = "sas_channel_type"
+    SAS_CERT_SUBJECT = "sas_cert_subject"
+    SAS_IC_GROUP_ID = "sas_icg_group_id"
+    SAS_LOCATION = "sas_location"
+    SAS_HEIGHT_TYPE = "sas_height_type"
+    SAS_CPI_ENABLE = "sas_cpi_enable"
+    SAS_CPI_IPE = "sas_cpi_ipe"  # Install param supplied enable
+    FREQ_BAND_1 = "freq_band_1"
+    FREQ_BAND_2 = "freq_band_2"
+    # For CBRS radios we set this to the limit and the SAS can reduce the
+    # power if needed.
+    TX_POWER_CONFIG = "tx_power_config"
+
+    SAS_PARAMETERS = {
+        SAS_ENABLE: TrParam(
+            FAP_CONTROL + 'LTE.X_000E8F_SAS.Enable',
+            is_invasive=False,
+            type=TrParameterType.BOOLEAN,
+            is_optional=False,
+        ),
+        SAS_SERVER_URL: TrParam(
+            FAP_CONTROL + 'LTE.X_000E8F_SAS.Server', is_invasive=False,
+            type=TrParameterType.STRING,
+            is_optional=False,
+        ),
+        SAS_UID: TrParam(
+            FAP_CONTROL + 'LTE.X_000E8F_SAS.UserContactInformation', is_invasive=False,
+            type=TrParameterType.STRING, is_optional=False,
+        ),
+        SAS_CATEGORY: TrParam(
+            FAP_CONTROL + 'LTE.X_000E8F_SAS.Category', is_invasive=False,
+            type=TrParameterType.STRING,
+            is_optional=False,
+        ),
+        SAS_CHANNEL_TYPE: TrParam(
+            FAP_CONTROL + 'LTE.X_000E8F_SAS.ProtectionLevel', is_invasive=False,
+            type=TrParameterType.STRING, is_optional=False,
+        ),
+        SAS_CERT_SUBJECT: TrParam(
+            FAP_CONTROL + 'LTE.X_000E8F_SAS.CertSubject', is_invasive=False,
+            type=TrParameterType.STRING, is_optional=False,
+        ),
+        # SAS_IC_GROUP_ID: TrParam(
+        #     FAP_CONTROL + 'LTE.X_000E8F_SAS.ICGGroupId', is_invasive=False,
+        #     type=TrParameterType.STRING, False),
+        SAS_LOCATION: TrParam(
+            FAP_CONTROL + 'LTE.X_000E8F_SAS.Location', is_invasive=False,
+            type=TrParameterType.STRING,
+            is_optional=False,
+        ),
+        SAS_HEIGHT_TYPE: TrParam(
+            FAP_CONTROL + 'LTE.X_000E8F_SAS.HeightType', is_invasive=False,
+            type=TrParameterType.STRING, is_optional=False,
+        ),
+        SAS_CPI_ENABLE: TrParam(
+            FAP_CONTROL + 'LTE.X_000E8F_SAS.CPIEnable', is_invasive=False,
+            type=TrParameterType.BOOLEAN, is_optional=False,
+        ),
+        SAS_CPI_IPE: TrParam(
+            FAP_CONTROL + 'LTE.X_000E8F_SAS.CPIInstallParamSuppliedEnable',
+            is_invasive=False, type=TrParameterType.BOOLEAN, is_optional=False,
+        ),
+        FREQ_BAND_1: TrParam(
+            FAPSERVICE_PATH + 'CellConfig.LTE.RAN.RF.FreqBandIndicator',
+            is_invasive=False, type=TrParameterType.UNSIGNED_INT, is_optional=False,
+        ),
+        FREQ_BAND_2: TrParam(
+            FAPSERVICE_PATH + 'CellConfig.LTE.RAN.RF.X_000E8F_FreqBandIndicator2',
+            is_invasive=False, type=TrParameterType.UNSIGNED_INT, is_optional=False,
+        ),
+        TX_POWER_CONFIG: TrParam(
+            FAPSERVICE_PATH + 'CellConfig.LTE.RAN.RF.X_000E8F_TxPowerConfig',
+            is_invasive=True, type=TrParameterType.INT, is_optional=False,
+        ),
+    }
+
+
+class StatusParameters(object):
+    """
+    Stateful class that converts eNB status to Magma understood status.
+    FreedomFiOne has many status params that interact with each other.
+    This class maintains the business logic of parsing these status params
+    and converting it to Magma understood fields.
+    """
+    STATUS_PATH = "Device.X_000E8F_DeviceFeature.X_000E8F_NEStatus."
+
+    # Status parameters
+    DEFAULT_GW = 'defaultGW'
+    SYNC_STATUS = 'syncStatus'
+    SAS_STATUS = 'sasStatus'
+    ENB_STATUS = 'enbStatus'
+    GPS_SCAN_STATUS = 'gpsScanStatus'
+
+    STATUS_PARAMETERS = {
+        # Status nodes
+        DEFAULT_GW: TrParam(
+            STATUS_PATH + 'X_000E8F_DEFGW_Status', is_invasive=False,
+            type=TrParameterType.STRING, is_optional=False,
+        ),
+        SYNC_STATUS: TrParam(
+            STATUS_PATH + 'X_000E8F_Sync_Status', is_invasive=False,
+            type=TrParameterType.STRING, is_optional=False,
+        ),
+        SAS_STATUS: TrParam(
+            STATUS_PATH + 'X_000E8F_SAS_Status', is_invasive=False,
+            type=TrParameterType.STRING, is_optional=False,
+        ),
+        ENB_STATUS: TrParam(
+            STATUS_PATH + 'X_000E8F_eNB_Status', is_invasive=False,
+            type=TrParameterType.STRING, is_optional=False,
+        ),
+
+        # GPS status, lat, long
+        GPS_SCAN_STATUS: TrParam(
+            'Device.FAP.GPS.ScanStatus',
+            is_invasive=False, type=TrParameterType.STRING, is_optional=False,
+        ),
+        ParameterName.GPS_LAT: TrParam(
+            'Device.FAP.GPS.LockedLatitude',
+            is_invasive=False, type=TrParameterType.STRING, is_optional=False,
+        ),
+        ParameterName.GPS_LONG: TrParam(
+            'Device.FAP.GPS.LockedLongitude',
+            is_invasive=False, type=TrParameterType.STRING, is_optional=False,
+        ),
+    }
+
+    # Derived status params that don't have tr69 representation.
+    DERIVED_STATUS_PARAMETERS = {
+        ParameterName.RF_TX_STATUS: TrParam(
+            InvalidTrParamPath, is_invasive=False,
+            type=TrParameterType.BOOLEAN, is_optional=False,
+        ),
+        ParameterName.GPS_STATUS: TrParam(
+            InvalidTrParamPath, is_invasive=False,
+            type=TrParameterType.BOOLEAN, is_optional=False,
+        ),
+        ParameterName.PTP_STATUS: TrParam(
+            InvalidTrParamPath, is_invasive=False,
+            type=TrParameterType.BOOLEAN, is_optional=False,
+        ),
+        ParameterName.MME_STATUS: TrParam(
+            InvalidTrParamPath, is_invasive=False,
+            type=TrParameterType.BOOLEAN, is_optional=False,
+        ),
+        ParameterName.OP_STATE: TrParam(
+            InvalidTrParamPath, is_invasive=False,
+            type=TrParameterType.BOOLEAN, is_optional=False,
+        ),
+    }
+
+    @classmethod
+    def set_magma_device_cfg(
+        cls, name_to_val: Dict,
+        device_cfg: EnodebConfiguration,
+    ):
+        """
+        Convert FreedomFiOne name_to_val representation to magma device_cfg
+        """
+        success_str = "SUCCESS"  # String constant returned by radio
+        insync_str = "INSYNC"
+
+        if name_to_val[cls.DEFAULT_GW].upper() != success_str:
+            # Nothing will proceed if the eNB doesn't have an IP on the WAN
+            serial_num = "unknown"
+            if device_cfg.has_parameter(ParameterName.SERIAL_NUMBER):
+                serial_num = device_cfg.get_parameter(
+                    ParameterName.SERIAL_NUMBER,
+                )
+            EnodebdLogger.error(
+                "Radio with serial number %s doesn't have IP address "
+                "on WAN", serial_num,
+            )
+            device_cfg.set_parameter(param_name=ParameterName.RF_TX_STATUS,
+                                     value=False)
+            device_cfg.set_parameter(param_name=ParameterName.GPS_STATUS,
+                                     value=False)
+            device_cfg.set_parameter(param_name=ParameterName.PTP_STATUS,
+                                     value=False)
+            device_cfg.set_parameter(param_name=ParameterName.MME_STATUS,
+                                     value=False)
+            device_cfg.set_parameter(param_name=ParameterName.OP_STATE,
+                                     value=False)
+            return
+
+        if name_to_val[cls.SAS_STATUS].upper() == success_str:
+            device_cfg.set_parameter(param_name=ParameterName.RF_TX_STATUS,
+                                     value=True)
+        else:
+            # No sas grant so not transmitting. There is no explicit node for Tx
+            # in FreedomFiOne
+            device_cfg.set_parameter(param_name=ParameterName.RF_TX_STATUS,
+                                     value=False)
+
+        if name_to_val[cls.GPS_SCAN_STATUS].upper() == success_str:
+            device_cfg.set_parameter(param_name=ParameterName.GPS_STATUS,
+                                     value=True)
+            # Time comes through GPS so can only be insync with GPS is
+            # in sync, we use PTP_STATUS field to overload timer is in Sync.
+            if name_to_val[cls.SYNC_STATUS].upper() == insync_str:
+                device_cfg.set_parameter(param_name=ParameterName.PTP_STATUS,
+                                         value=True)
+        else:
+            device_cfg.set_parameter(param_name=ParameterName.GPS_STATUS,
+                                     value=False)
+            device_cfg.set_parameter(param_name=ParameterName.PTP_STATUS,
+                                     value=False)
+
+        if name_to_val[cls.DEFAULT_GW].upper() == success_str:
+            device_cfg.set_parameter(param_name=ParameterName.MME_STATUS,
+                                     value=True)
+        else:
+            device_cfg.set_parameter(param_name=ParameterName.MME_STATUS,
+                                     value=False)
+
+        if name_to_val[cls.ENB_STATUS].upper() == success_str:
+            device_cfg.set_parameter(param_name=ParameterName.OP_STATE,
+                                     value=True)
+        else:
+            device_cfg.set_parameter(param_name=ParameterName.OP_STATE,
+                                     value=False)
+
+        pass_through_params = [ParameterName.GPS_LAT, ParameterName.GPS_LONG]
+        for name in pass_through_params:
+            device_cfg.set_parameter(name, name_to_val[name])
+
+
+class FreedomFiOneMiscParameters(object):
+    """
+    Default set of parameters that enable carrier aggregation and other
+    miscellaneous properties
+    """
+    FAP_CONTROL = 'Device.Services.FAPService.1.FAPControl.'
+    FAPSERVICE_PATH = 'Device.Services.FAPService.1.'
+
+    # Tunnel ref format clobber it to non IPSEC as we don't support
+    # IPSEC
+    TUNNEL_REF = "tunnel_ref"
+    PRIM_SOURCE = "prim_src"
+
+    # Carrier aggregation
+    CARRIER_AGG_ENABLE = "carrier_agg_enable"
+    CARRIER_NUMBER = "carrier_number"  # Carrier aggregation params
+    CONTIGUOUS_CC = "contiguous_cc"
+    WEB_UI_ENABLE = "web_ui_enable"  # Enable or disable local enb UI
+
+    MISC_PARAMETERS = {
+        WEB_UI_ENABLE: TrParam(
+            'Device.X_000E8F_DeviceFeature.X_000E8F_WebServerEnable', is_invasive=False,
+            type=TrParameterType.BOOLEAN, is_optional=False,
+        ),
+        CARRIER_AGG_ENABLE: TrParam(
+            FAP_CONTROL + 'LTE.X_000E8F_RRMConfig.X_000E8F_CA_Enable', is_invasive=False,
+            type=TrParameterType.BOOLEAN, is_optional=False,
+        ),
+        CARRIER_NUMBER: TrParam(
+            FAP_CONTROL + 'LTE.X_000E8F_RRMConfig.X_000E8F_Cell_Number', is_invasive=False,
+            type=TrParameterType.INT, is_optional=False,
+        ),
+        CONTIGUOUS_CC: TrParam(
+            FAP_CONTROL
+            + 'LTE.X_000E8F_RRMConfig.X_000E8F_CELL_Freq_Contiguous',
+            is_invasive=False,
+            type=TrParameterType.INT, is_optional=False,
+        ),
+        TUNNEL_REF: TrParam(
+            FAPSERVICE_PATH + 'CellConfig.LTE.Tunnel.1.TunnelRef', is_invasive=False,
+            type=TrParameterType.STRING, is_optional=False,
+        ),
+        PRIM_SOURCE: TrParam(
+            FAPSERVICE_PATH + 'REM.X_000E8F_tfcsManagerConfig.primSrc',
+            is_invasive=False,
+            type=TrParameterType.STRING, is_optional=False,
+        ),
+    }
+
+    # Hardcoded defaults
+    defaults = {
+        # Use IPV4 only
+        TUNNEL_REF: "Device.IP.Interface.1.IPv4Address.1.",
+        # Only synchronize with GPS
+        PRIM_SOURCE: "GNSS",
+        # Always enable carrier aggregation for the CBRS bands
+        CARRIER_AGG_ENABLE: True,
+        CARRIER_NUMBER: 2,  # CBRS has two carriers
+        CONTIGUOUS_CC: 0,  # Its not contiguous carrier
+        WEB_UI_ENABLE: False,  # Disable WebUI by default
+    }
+
+
+class FreedomFiOneHandler(BasicEnodebAcsStateMachine):
+    def __init__(
+            self,
+            service: MagmaService,
+    ) -> None:
+        self._state_map = {}
+        super().__init__(service=service, use_param_key=True)
+
+    def reboot_asap(self) -> None:
+        self.transition('reboot')
+
+    def is_enodeb_connected(self) -> bool:
+        return not isinstance(self.state, WaitInformState)
+
+    def _init_state_map(self) -> None:
+        self._state_map = {
+            # Inform comes in -> Respond with InformResponse
+            'wait_inform': WaitInformState(self, when_done='get_rpc_methods'),
+            # If first inform after boot -> GetRpc request comes in, if not
+            # empty request comes in => Transition to get_transient_params
+            'get_rpc_methods': FreedomFiOneGetInitState(
+                self,
+                when_done='get_transient_params',
+            ),
+
+            # Read transient readonly params.
+            'get_transient_params': FreedomFiOneSendGetTransientParametersState(
+                self,
+                when_done='get_params',
+            ),
+
+            'get_params':
+                FreedomFiOneGetObjectParametersState(
+                    self,
+                    when_delete='delete_objs',
+                    when_add='add_objs',
+                    when_set='set_params',
+                    when_skip='end_session',
+            ),
+
+            'delete_objs': DeleteObjectsState(
+                self, when_add='add_objs',
+                when_skip='set_params',
+            ),
+            'add_objs': AddObjectsState(self, when_done='set_params'),
+            'set_params': SetParameterValuesState(
+                self,
+                when_done='wait_set_params',
+            ),
+            'wait_set_params': WaitSetParameterValuesState(
+                self,
+                when_done='check_get_params',
+                when_apply_invasive='check_get_params',
+                status_non_zero_allowed=True,
+            ),
+            'check_get_params': GetParametersState(
+                self,
+                when_done='check_wait_get_params',
+                request_all_params=True,
+            ),
+            'check_wait_get_params': WaitGetParametersState(
+                self,
+                when_done='end_session',
+            ),
+            'end_session': EndSessionState(self),
+
+            # These states are only entered through manual user intervention
+            'reboot': EnbSendRebootState(self, when_done='wait_reboot'),
+            'wait_reboot': WaitRebootResponseState(
+                self,
+                when_done='wait_post_reboot_inform',
+            ),
+            'wait_post_reboot_inform': WaitInformMRebootState(
+                self,
+                when_done='wait_empty',
+                when_timeout='wait_inform',
+            ),
+            # The states below are entered when an unexpected message type is
+            # received
+            'unexpected_fault': ErrorState(
+                self,
+                inform_transition_target='wait_inform',
+            ),
+        }
+
+    @property
+    def device_name(self) -> str:
+        return EnodebDeviceName.FREEDOMFI_ONE
+
+    @property
+    def data_model_class(self) -> Type[DataModel]:
+        return FreedomFiOneTrDataModel
+
+    @property
+    def config_postprocessor(self) -> EnodebConfigurationPostProcessor:
+        return FreedomFiOneConfigurationInitializer(self)
+
+    @property
+    def state_map(self) -> Dict[str, EnodebAcsState]:
+        return self._state_map
+
+    @property
+    def disconnected_state_name(self) -> str:
+        return 'wait_inform'
+
+    @property
+    def unexpected_fault_state_name(self) -> str:
+        return 'unexpected_fault'
+
+
+class FreedomFiOneTrDataModel(DataModel):
+    """
+    Class to represent relevant data model parameters from TR-196/TR-098.
+    This class is effectively read-only.
+
+    These models have these idiosyncrasies (on account of running TR098):
+
+    - Parameter content root is different (InternetGatewayDevice)
+    - GetParameter queries with a wildcard e.g. InternetGatewayDevice. do
+      not respond with the full tree (we have to query all parameters)
+    - MME status is not exposed - we assume the MME is connected if
+      the eNodeB is transmitting (OpState=true)
+    - Parameters such as band capability/duplex config
+      are rooted under `boardconf.` and not the device config root
+    - Num PLMNs is not reported by these units
+    """
+    # Mapping of TR parameter paths to aliases
+    DEVICE_PATH = 'Device.'
+    FAPSERVICE_PATH = DEVICE_PATH + 'Services.FAPService.1.'
+    FAP_CONTROL = FAPSERVICE_PATH + 'FAPControl.'
+    BCCH = FAPSERVICE_PATH + 'REM.LTE.Cell.1.BCCH.'
+
+    PARAMETERS = {
+        # Top-level objects
+        ParameterName.DEVICE: TrParam(
+            DEVICE_PATH, is_invasive=False, type=TrParameterType.OBJECT,
+            is_optional=False,
+        ),
+        ParameterName.FAP_SERVICE: TrParam(
+            FAP_CONTROL, is_invasive=False,
+            type=TrParameterType.OBJECT, is_optional=False,
+        ),
+
+        # Device info
+        ParameterName.SW_VERSION: TrParam(
+            DEVICE_PATH + 'DeviceInfo.SoftwareVersion', is_invasive=False,
+            type=TrParameterType.STRING,
+            is_optional=False,
+        ),
+        ParameterName.SERIAL_NUMBER: TrParam(
+            DEVICE_PATH + 'DeviceInfo.SerialNumber', is_invasive=False,
+            type=TrParameterType.STRING,
+            is_optional=False,
+        ),
+
+        # RF-related parameters
+        ParameterName.EARFCNDL: TrParam(
+            FAPSERVICE_PATH + 'CellConfig.LTE.RAN.RF.EARFCNDL', is_invasive=False,
+            type=TrParameterType.INT,
+            is_optional=False,
+        ),
+        ParameterName.DL_BANDWIDTH: TrParam(
+            FAPSERVICE_PATH + 'CellConfig.LTE.RAN.RF.DLBandwidth', is_invasive=False,
+            type=TrParameterType.STRING, is_optional=False,
+        ),
+        ParameterName.UL_BANDWIDTH: TrParam(
+            FAPSERVICE_PATH + 'CellConfig.LTE.RAN.RF.ULBandwidth', is_invasive=False,
+            type=TrParameterType.STRING, is_optional=False,
+        ),
+        ParameterName.PCI: TrParam(
+            FAPSERVICE_PATH + 'CellConfig.LTE.RAN.RF.PhyCellID', is_invasive=False,
+            type=TrParameterType.STRING,
+            is_optional=False,
+        ),
+        ParameterName.SUBFRAME_ASSIGNMENT: TrParam(
+            FAPSERVICE_PATH + 'CellConfig.LTE.RAN.PHY.TDDFrame.SubFrameAssignment',
+            is_invasive=False, type=TrParameterType.BOOLEAN, is_optional=False,
+        ),
+        ParameterName.SPECIAL_SUBFRAME_PATTERN: TrParam(
+            FAPSERVICE_PATH + 'CellConfig.LTE.RAN.PHY.TDDFrame.SpecialSubframePatterns',
+            is_invasive=False, type=TrParameterType.INT,
+            is_optional=False,
+        ),
+        ParameterName.CELL_ID: TrParam(
+            FAPSERVICE_PATH + 'CellConfig.LTE.RAN.Common.CellIdentity', is_invasive=False,
+            type=TrParameterType.UNSIGNED_INT, is_optional=False,
+        ),
+
+        # Readonly LTE state
+        ParameterName.ADMIN_STATE: TrParam(
+            FAP_CONTROL + 'LTE.AdminState',
+            is_invasive=False, type=TrParameterType.BOOLEAN,
+            is_optional=False,
+        ),
+        ParameterName.GPS_ENABLE: TrParam(
+            DEVICE_PATH + 'FAP.GPS.ScanOnBoot',
+            is_invasive=False, type=TrParameterType.BOOLEAN, is_optional=False,
+        ),
+
+        # Core network parameters
+        ParameterName.MME_IP: TrParam(
+            FAP_CONTROL + 'LTE.Gateway.S1SigLinkServerList', is_invasive=False,
+            type=TrParameterType.STRING,
+            is_optional=False,
+        ),
+        ParameterName.MME_PORT: TrParam(
+            FAP_CONTROL + 'LTE.Gateway.S1SigLinkPort', is_invasive=False,
+            type=TrParameterType.INT, is_optional=False,
+        ),
+
+        ParameterName.NUM_PLMNS: TrParam(
+            FAPSERVICE_PATH + 'CellConfig.LTE.EPC.PLMNListNumberOfEntries',
+            is_invasive=False,
+            type=TrParameterType.INT, is_optional=False,
+        ),
+
+        ParameterName.TAC: TrParam(
+            FAPSERVICE_PATH + 'CellConfig.LTE.EPC.TAC', is_invasive=False,
+            type=TrParameterType.INT, is_optional=False,
+        ),
+        # Management server parameters
+        ParameterName.PERIODIC_INFORM_ENABLE: TrParam(
+            DEVICE_PATH + 'ManagementServer.PeriodicInformEnable', is_invasive=False,
+            type=TrParameterType.BOOLEAN, is_optional=False,
+        ),
+        ParameterName.PERIODIC_INFORM_INTERVAL: TrParam(
+            DEVICE_PATH + 'ManagementServer.PeriodicInformInterval', is_invasive=False,
+            type=TrParameterType.INT, is_optional=False,
+        ),
+
+        # Performance management parameters
+        ParameterName.PERF_MGMT_ENABLE: TrParam(
+            DEVICE_PATH + 'FAP.PerfMgmt.Config.1.Enable',
+            is_invasive=False,
+            type=TrParameterType.BOOLEAN, is_optional=False,
+        ),
+        ParameterName.PERF_MGMT_UPLOAD_INTERVAL: TrParam(
+            DEVICE_PATH + 'FAP.PerfMgmt.Config.1.PeriodicUploadInterval',
+            is_invasive=False,
+            type=TrParameterType.INT,
+            is_optional=False,
+        ),
+        ParameterName.PERF_MGMT_UPLOAD_URL: TrParam(
+            DEVICE_PATH + 'FAP.PerfMgmt.Config.1.URL',
+            is_invasive=False,
+            type=TrParameterType.STRING,
+            is_optional=False,
+        ),
+    }
+    TRANSFORMS_FOR_ENB = {}
+    NUM_PLMNS_IN_CONFIG = 1
+    for i in range(1, NUM_PLMNS_IN_CONFIG + 1):
+        PARAMETERS[ParameterName.PLMN_N % i] = TrParam(
+            FAPSERVICE_PATH + 'CellConfig.LTE.EPC.PLMNList.%d.' % i, is_invasive=False,
+            type=TrParameterType.STRING, is_optional=False,
+        )
+        PARAMETERS[ParameterName.PLMN_N_CELL_RESERVED % i] = TrParam(
+            FAPSERVICE_PATH + 'CellConfig.LTE.EPC.PLMNList.%d.CellReservedForOperatorUse' % i,
+            is_invasive=False,
+            type=TrParameterType.BOOLEAN, is_optional=False,
+        )
+        PARAMETERS[ParameterName.PLMN_N_ENABLE % i] = TrParam(
+            FAPSERVICE_PATH + 'CellConfig.LTE.EPC.PLMNList.%d.Enable' % i, is_invasive=False,
+            type=TrParameterType.BOOLEAN, is_optional=False,
+        )
+        PARAMETERS[ParameterName.PLMN_N_PRIMARY % i] = TrParam(
+            FAPSERVICE_PATH + 'CellConfig.LTE.EPC.PLMNList.%d.IsPrimary' % i,
+            is_invasive=False, type=TrParameterType.BOOLEAN, is_optional=False,
+        )
+        PARAMETERS[ParameterName.PLMN_N_PLMNID % i] = TrParam(
+            FAPSERVICE_PATH + 'CellConfig.LTE.EPC.PLMNList.%d.PLMNID' % i, is_invasive=False,
+            type=TrParameterType.STRING, is_optional=False,
+        )
+
+    PARAMETERS.update(SASParameters.SAS_PARAMETERS)
+    PARAMETERS.update(FreedomFiOneMiscParameters.MISC_PARAMETERS)
+    PARAMETERS.update(StatusParameters.STATUS_PARAMETERS)
+    # These are stateful parameters that have no tr-69 representation
+    PARAMETERS.update(StatusParameters.DERIVED_STATUS_PARAMETERS)
+
+    TRANSFORMS_FOR_MAGMA = {
+        # We don't set these parameters
+        ParameterName.BAND_CAPABILITY: transform_for_magma.band_capability,
+        ParameterName.DUPLEX_MODE_CAPABILITY: transform_for_magma.duplex_mode,
+    }
+
+    @classmethod
+    def get_parameter(cls, param_name: ParameterName) -> Optional[TrParam]:
+        return cls.PARAMETERS.get(param_name)
+
+    @classmethod
+    def _get_magma_transforms(
+            cls,
+    ) -> Dict[ParameterName, Callable[[Any], Any]]:
+        return cls.TRANSFORMS_FOR_MAGMA
+
+    @classmethod
+    def _get_enb_transforms(cls) -> Dict[ParameterName, Callable[[Any], Any]]:
+        return cls.TRANSFORMS_FOR_ENB
+
+    @classmethod
+    def get_load_parameters(cls) -> List[ParameterName]:
+        """
+        Load all the parameters instead of a subset.
+        """
+        return list(cls.PARAMETERS.keys())
+
+    @classmethod
+    def get_num_plmns(cls) -> int:
+        return cls.NUM_PLMNS_IN_CONFIG
+
+    @classmethod
+    def get_parameter_names(cls) -> List[ParameterName]:
+        excluded_params = [
+            str(ParameterName.DEVICE),
+            str(ParameterName.FAP_SERVICE),
+        ]
+        names = list(
+            filter(
+                lambda x: (not str(x).startswith('PLMN'))
+                and (str(x) not in excluded_params),
+                cls.PARAMETERS.keys(),
+            ),
+        )
+        return names
+
+    @classmethod
+    def get_numbered_param_names(
+            cls,
+    ) -> Dict[ParameterName, List[ParameterName]]:
+        names = {}
+        for i in range(1, cls.NUM_PLMNS_IN_CONFIG + 1):
+            params = [
+                ParameterName.PLMN_N_CELL_RESERVED % i,
+                ParameterName.PLMN_N_ENABLE % i,
+                ParameterName.PLMN_N_PRIMARY % i,
+                ParameterName.PLMN_N_PLMNID % i,
+            ]
+            names[ParameterName.PLMN_N % i] = params
+
+        return names
+
+    @classmethod
+    def get_sas_param_names(cls) -> List[ParameterName]:
+        return SASParameters.SAS_PARAMETERS.keys()
+
+
+class FreedomFiOneConfigurationInitializer(EnodebConfigurationPostProcessor):
+    """
+    Class to add the sas related parameters to the desired config.
+    """
+    SAS_KEY = 'sas'
+
+    def __init__(self, acs: EnodebAcsStateMachine):
+        super().__init__()
+        self.acs = acs
+
+    def postprocess(
+        self, mconfig: Any, service_cfg: Any,
+        desired_cfg: EnodebConfiguration,
+    ) -> None:
+        # TODO: Get this config from the domain proxy
+        # TODO @amarpad, set these when DProxy integration is done.
+        # For now the radio will directly talk to the SAS and get these
+        # attributes.
+        desired_cfg.delete_parameter(ParameterName.EARFCNDL)
+        desired_cfg.delete_parameter(ParameterName.DL_BANDWIDTH)
+        desired_cfg.delete_parameter(ParameterName.UL_BANDWIDTH)
+
+        # go through misc parameters and set them to default.
+        for name, val in FreedomFiOneMiscParameters.defaults.items():
+            desired_cfg.set_parameter(name, val)
+
+        # Bump up the parameter key version
+        self.acs.parameter_version_inc()
+
+        if FreedomFiOneMiscParameters.WEB_UI_ENABLE in service_cfg:
+            serial_nos = service_cfg[FreedomFiOneMiscParameters.WEB_UI_ENABLE]
+            if self.acs.device_cfg.has_parameter(
+                    ParameterName.SERIAL_NUMBER,
+            ):
+                if self.acs.get_parameter(ParameterName.SERIAL_NUMBER) in \
+                        serial_nos:
+                    desired_cfg.set_parameter(
+                        FreedomFiOneMiscParameters.WEB_UI_ENABLE,
+                        True,
+                    )
+            else:
+                # This should not happen
+                EnodebdLogger.error("Serial number unknown for device")
+
+        if self.SAS_KEY not in service_cfg:
+            return
+
+        sas_cfg = service_cfg[self.SAS_KEY]
+        sas_param_names = self.acs.data_model.get_sas_param_names()
+        for name, val in sas_cfg.items():
+            if name not in sas_param_names:
+                EnodebdLogger.warning("Ignoring attribute %s", name)
+                continue
+            desired_cfg.set_parameter(name, val)
+
+
+class FreedomFiOneSendGetTransientParametersState(EnodebAcsState):
+    """
+    Periodically read eNodeB status. Note: keep frequency low to avoid
+    backing up large numbers of read operations if enodebd is busy.
+    Some eNB parameters are read only and updated by the eNB itself.
+    """
+
+    def __init__(self, acs: EnodebAcsStateMachine, when_done: str):
+        super().__init__()
+        self.acs = acs
+        self.done_transition = when_done
+
+    def get_msg(self, message: Any) -> AcsMsgAndTransition:
+        request = models.GetParameterValues()
+        request.ParameterNames = models.ParameterNames()
+        request.ParameterNames.string = []
+        for _, tr_param in StatusParameters.STATUS_PARAMETERS.items():
+            path = tr_param.path
+            request.ParameterNames.string.append(path)
+        request.ParameterNames.arrayType = \
+            'xsd:string[%d]' % len(request.ParameterNames.string)
+
+        return AcsMsgAndTransition(msg=request, next_state=None)
+
+    def read_msg(self, message: Any) -> AcsReadMsgResult:
+
+        if not isinstance(message, models.GetParameterValuesResponse):
+            return AcsReadMsgResult(msg_handled=False, next_state=None)
+        # Current values of the fetched parameters
+        name_to_val = parse_get_parameter_values_response(
+            self.acs.data_model,
+            message,
+        )
+        EnodebdLogger.debug('Received Parameters: %s', str(name_to_val))
+
+        # Update device configuration
+        StatusParameters.set_magma_device_cfg(
+            name_to_val,
+            self.acs.device_cfg,
+        )
+
+        return AcsReadMsgResult(msg_handled=True, next_state=self.done_transition)
+
+    def state_description(self) -> str:
+        return 'Getting transient read-only parameters'
+
+
+class FreedomFiOneGetInitState(EnodebAcsState):
+    """
+    After the first Inform message the following can happen:
+    1 - eNB can try to learn the RPC method of the ACS, reply back with the
+    RPC response (happens right after boot)
+    2 - eNB can send an empty message -> This means that the eNB is already
+    provisioned so transition to next state. Only transition to next state
+    after this message.
+    3 - Some other method call that we don't care about so ignore.
+    expected that the eNB -> This is an unhandled state so unlikely
+    """
+
+    def __init__(self, acs: EnodebAcsStateMachine, when_done):
+        super().__init__()
+        self.acs = acs
+        self.done_transition = when_done
+        self._is_rpc_request = False
+
+    def get_msg(self, message: Any) -> AcsMsgAndTransition:
+        """
+        Return empty message response if care about this
+        message type otherwise return empty RPC methods response.
+        """
+        if not self._is_rpc_request:
+            resp = models.DummyInput()
+            return AcsMsgAndTransition(msg=resp, next_state=None)
+
+        resp = models.GetRPCMethodsResponse()
+        resp.MethodList = models.MethodList()
+        RPC_METHODS = ['Inform', 'GetRPCMethods', 'TransferComplete']
+        resp.MethodList.arrayType = 'xsd:string[%d]' \
+                                    % len(RPC_METHODS)
+        resp.MethodList.string = RPC_METHODS
+        # Don't transition to next state wait for the empty HTTP post
+        return AcsMsgAndTransition(msg=resp, next_state=None)
+
+    def read_msg(self, message: Any) -> AcsReadMsgResult:
+        # If this is a regular Inform, not after a reboot we'll get an empty
+        # message, in this case transition to the next state. We consider
+        # this phase as "initialized"
+        if isinstance(message, models.DummyInput):
+            return AcsReadMsgResult(msg_handled=True, next_state=self.done_transition)
+        if not isinstance(message, models.GetRPCMethods):
+            # Unexpected, just don't die, ignore message.
+            logging.error("Ignoring message %s", str(type(message)))
+            # Set this so get_msg will return an empty message
+            self._is_rpc_request = False
+        else:
+            # Return a valid RPC response
+            self._is_rpc_request = True
+        return AcsReadMsgResult(msg_handled=True, next_state=None)
+
+    def state_description(self) -> str:
+        return 'Initializing the post boot sequence for eNB'
+
+
+class FreedomFiOneGetObjectParametersState(EnodebAcsState):
+    """
+    Get information on parameters belonging to objects that can be added or
+    removed from the configuration.
+
+    Englewood will report a parameter value as None if it does not exist
+    in the data model, rather than replying with a Fault message like most
+    eNB devices.
+    """
+
+    def __init__(
+            self,
+            acs: EnodebAcsStateMachine,
+            when_delete: str,
+            when_add: str,
+            when_set: str,
+            when_skip: str,
+    ):
+        super().__init__()
+        self.acs = acs
+        self.rm_obj_transition = when_delete
+        self.add_obj_transition = when_add
+        self.set_params_transition = when_set
+        self.skip_transition = when_skip
+
+    def get_params_to_get(
+        self,
+        data_model: DataModel,
+    ) -> List[ParameterName]:
+        names = []
+
+        # First get base params
+        names = get_params_to_get(
+            self.acs.device_cfg, self.acs.data_model, request_all_params=True,
+        )
+        # Add object params.
+        num_plmns = data_model.get_num_plmns()
+        obj_to_params = data_model.get_numbered_param_names()
+        for i in range(1, num_plmns + 1):
+            obj_name = ParameterName.PLMN_N % i
+            desired = obj_to_params[obj_name]
+            names += desired
+        return names
+
+    def get_msg(self, message: Any) -> AcsMsgAndTransition:
+        """ Respond with GetParameterValuesRequest """
+        names = self.get_params_to_get(
+            self.acs.data_model,
+        )
+
+        # Generate the request
+        request = models.GetParameterValues()
+        request.ParameterNames = models.ParameterNames()
+        request.ParameterNames.arrayType = 'xsd:string[%d]' \
+                                           % len(names)
+        request.ParameterNames.string = []
+        for name in names:
+            path = self.acs.data_model.get_parameter(name).path
+            if path is not InvalidTrParamPath:
+                # Only get data elements backed by tr69 path
+                request.ParameterNames.string.append(path)
+
+        return AcsMsgAndTransition(msg=request, next_state=None)
+
+    def read_msg(self, message: Any) -> AcsReadMsgResult:
+        """
+        Process GetParameterValuesResponse
+        """
+        if not isinstance(message, models.GetParameterValuesResponse):
+            return AcsReadMsgResult(msg_handled=False, next_state=None)
+
+        path_to_val = {}
+        for param_value_struct in message.ParameterList.ParameterValueStruct:
+            path_to_val[param_value_struct.Name] = \
+                param_value_struct.Value.Data
+
+        EnodebdLogger.debug('Received object parameters: %s', str(path_to_val))
+
+        # Parse simple params
+        param_name_list = self.acs.data_model.get_parameter_names()
+        for name in param_name_list:
+            path = self.acs.data_model.get_parameter(name).path
+            if path in path_to_val:
+                value = path_to_val.get(path)
+                magma_val = \
+                    self.acs.data_model.transform_for_magma(
+                        name,
+                        value,
+                    )
+                self.acs.device_cfg.set_parameter(name, magma_val)
+
+        # Parse object params
+        num_plmns = self.acs.data_model.get_num_plmns()
+        for i in range(1, num_plmns + 1):
+            obj_name = ParameterName.PLMN_N % i
+            obj_to_params = self.acs.data_model.get_numbered_param_names()
+            param_name_list = obj_to_params[obj_name]
+            for name in param_name_list:
+                path = self.acs.data_model.get_parameter(name).path
+                if path in path_to_val:
+                    value = path_to_val.get(path)
+                    if value is None:
+                        continue
+                    if obj_name not in self.acs.device_cfg.get_object_names():
+                        self.acs.device_cfg.add_object(obj_name)
+                    magma_value = \
+                        self.acs.data_model.transform_for_magma(name, value)
+                    self.acs.device_cfg.set_parameter_for_object(
+                        name,
+                        magma_value,
+                        obj_name,
+                    )
+        # Now we have enough information to build the desired configuration
+        if self.acs.desired_cfg is None:
+            self.acs.desired_cfg = build_desired_config(
+                self.acs.mconfig,
+                self.acs.service_config,
+                self.acs.device_cfg,
+                self.acs.data_model,
+                self.acs.config_postprocessor,
+            )
+
+        if len(
+                get_all_objects_to_delete(
+                    self.acs.desired_cfg,
+                    self.acs.device_cfg,
+                ),
+        ) > 0:
+            return AcsReadMsgResult(msg_handled=True,
+                                    next_state=self.rm_obj_transition)
+        elif len(
+                get_all_objects_to_add(
+                    self.acs.desired_cfg,
+                    self.acs.device_cfg,
+                ),
+        ) > 0:
+            return AcsReadMsgResult(msg_handled=True,
+                                    next_state=self.add_obj_transition)
+        elif len(
+                get_all_param_values_to_set(
+                    self.acs.desired_cfg,
+                    self.acs.device_cfg,
+                    self.acs.data_model,
+                ),
+        ) > 0:
+            return AcsReadMsgResult(msg_handled=True,
+                                    next_state=self.set_params_transition)
+        return AcsReadMsgResult(msg_handled=True, next_state=self.skip_transition)
+
+    def state_description(self) -> str:
+        return 'Getting well known parameters'

--- a/lte/gateway/python/magma/enodebd/devices/freedomfi_one.py
+++ b/lte/gateway/python/magma/enodebd/devices/freedomfi_one.py
@@ -713,6 +713,7 @@ class FreedomFiOneConfigurationInitializer(EnodebConfigurationPostProcessor):
     Class to add the sas related parameters to the desired config.
     """
     SAS_KEY = 'sas'
+    WEB_UI_ENABLE_LIST_KEY = 'web_ui_enable_list'
 
     def __init__(self, acs: EnodebAcsStateMachine):
         super().__init__()
@@ -737,8 +738,8 @@ class FreedomFiOneConfigurationInitializer(EnodebConfigurationPostProcessor):
         # Bump up the parameter key version
         self.acs.parameter_version_inc()
 
-        if FreedomFiOneMiscParameters.WEB_UI_ENABLE in service_cfg:
-            serial_nos = service_cfg[FreedomFiOneMiscParameters.WEB_UI_ENABLE]
+        if self.WEB_UI_ENABLE_LIST_KEY in service_cfg:
+            serial_nos = service_cfg.get(self.WEB_UI_ENABLE_LIST_KEY)
             if self.acs.device_cfg.has_parameter(
                     ParameterName.SERIAL_NUMBER,
             ):

--- a/lte/gateway/python/magma/enodebd/devices/freedomfi_one.py
+++ b/lte/gateway/python/magma/enodebd/devices/freedomfi_one.py
@@ -244,54 +244,84 @@ class StatusParameters(object):
                 "Radio with serial number %s doesn't have IP address "
                 "on WAN", serial_num,
             )
-            device_cfg.set_parameter(param_name=ParameterName.RF_TX_STATUS,
-                                     value=False)
-            device_cfg.set_parameter(param_name=ParameterName.GPS_STATUS,
-                                     value=False)
-            device_cfg.set_parameter(param_name=ParameterName.PTP_STATUS,
-                                     value=False)
-            device_cfg.set_parameter(param_name=ParameterName.MME_STATUS,
-                                     value=False)
-            device_cfg.set_parameter(param_name=ParameterName.OP_STATE,
-                                     value=False)
+            device_cfg.set_parameter(
+                param_name=ParameterName.RF_TX_STATUS,
+                value=False,
+            )
+            device_cfg.set_parameter(
+                param_name=ParameterName.GPS_STATUS,
+                value=False,
+            )
+            device_cfg.set_parameter(
+                param_name=ParameterName.PTP_STATUS,
+                value=False,
+            )
+            device_cfg.set_parameter(
+                param_name=ParameterName.MME_STATUS,
+                value=False,
+            )
+            device_cfg.set_parameter(
+                param_name=ParameterName.OP_STATE,
+                value=False,
+            )
             return
 
         if name_to_val[cls.SAS_STATUS].upper() == success_str:
-            device_cfg.set_parameter(param_name=ParameterName.RF_TX_STATUS,
-                                     value=True)
+            device_cfg.set_parameter(
+                param_name=ParameterName.RF_TX_STATUS,
+                value=True,
+            )
         else:
             # No sas grant so not transmitting. There is no explicit node for Tx
             # in FreedomFiOne
-            device_cfg.set_parameter(param_name=ParameterName.RF_TX_STATUS,
-                                     value=False)
+            device_cfg.set_parameter(
+                param_name=ParameterName.RF_TX_STATUS,
+                value=False,
+            )
 
         if name_to_val[cls.GPS_SCAN_STATUS].upper() == success_str:
-            device_cfg.set_parameter(param_name=ParameterName.GPS_STATUS,
-                                     value=True)
+            device_cfg.set_parameter(
+                param_name=ParameterName.GPS_STATUS,
+                value=True,
+            )
             # Time comes through GPS so can only be insync with GPS is
             # in sync, we use PTP_STATUS field to overload timer is in Sync.
             if name_to_val[cls.SYNC_STATUS].upper() == insync_str:
-                device_cfg.set_parameter(param_name=ParameterName.PTP_STATUS,
-                                         value=True)
+                device_cfg.set_parameter(
+                    param_name=ParameterName.PTP_STATUS,
+                    value=True,
+                )
         else:
-            device_cfg.set_parameter(param_name=ParameterName.GPS_STATUS,
-                                     value=False)
-            device_cfg.set_parameter(param_name=ParameterName.PTP_STATUS,
-                                     value=False)
+            device_cfg.set_parameter(
+                param_name=ParameterName.GPS_STATUS,
+                value=False,
+            )
+            device_cfg.set_parameter(
+                param_name=ParameterName.PTP_STATUS,
+                value=False,
+            )
 
         if name_to_val[cls.DEFAULT_GW].upper() == success_str:
-            device_cfg.set_parameter(param_name=ParameterName.MME_STATUS,
-                                     value=True)
+            device_cfg.set_parameter(
+                param_name=ParameterName.MME_STATUS,
+                value=True,
+            )
         else:
-            device_cfg.set_parameter(param_name=ParameterName.MME_STATUS,
-                                     value=False)
+            device_cfg.set_parameter(
+                param_name=ParameterName.MME_STATUS,
+                value=False,
+            )
 
         if name_to_val[cls.ENB_STATUS].upper() == success_str:
-            device_cfg.set_parameter(param_name=ParameterName.OP_STATE,
-                                     value=True)
+            device_cfg.set_parameter(
+                param_name=ParameterName.OP_STATE,
+                value=True,
+            )
         else:
-            device_cfg.set_parameter(param_name=ParameterName.OP_STATE,
-                                     value=False)
+            device_cfg.set_parameter(
+                param_name=ParameterName.OP_STATE,
+                value=False,
+            )
 
         pass_through_params = [ParameterName.GPS_LAT, ParameterName.GPS_LONG]
         for name in pass_through_params:
@@ -399,7 +429,7 @@ class FreedomFiOneHandler(BasicEnodebAcsStateMachine):
                     when_add='add_objs',
                     when_set='set_params',
                     when_skip='end_session',
-            ),
+                ),
 
             'delete_objs': DeleteObjectsState(
                 self, when_add='add_objs',
@@ -996,16 +1026,20 @@ class FreedomFiOneGetObjectParametersState(EnodebAcsState):
                     self.acs.device_cfg,
                 ),
         ) > 0:
-            return AcsReadMsgResult(msg_handled=True,
-                                    next_state=self.rm_obj_transition)
+            return AcsReadMsgResult(
+                msg_handled=True,
+                next_state=self.rm_obj_transition,
+            )
         elif len(
                 get_all_objects_to_add(
                     self.acs.desired_cfg,
                     self.acs.device_cfg,
                 ),
         ) > 0:
-            return AcsReadMsgResult(msg_handled=True,
-                                    next_state=self.add_obj_transition)
+            return AcsReadMsgResult(
+                msg_handled=True,
+                next_state=self.add_obj_transition,
+            )
         elif len(
                 get_all_param_values_to_set(
                     self.acs.desired_cfg,
@@ -1013,8 +1047,10 @@ class FreedomFiOneGetObjectParametersState(EnodebAcsState):
                     self.acs.data_model,
                 ),
         ) > 0:
-            return AcsReadMsgResult(msg_handled=True,
-                                    next_state=self.set_params_transition)
+            return AcsReadMsgResult(
+                msg_handled=True,
+                next_state=self.set_params_transition,
+            )
         return AcsReadMsgResult(msg_handled=True, next_state=self.skip_transition)
 
     def state_description(self) -> str:

--- a/lte/gateway/python/magma/enodebd/state_machines/enb_acs_impl.py
+++ b/lte/gateway/python/magma/enodebd/state_machines/enb_acs_impl.py
@@ -57,8 +57,9 @@ class BasicEnodebAcsStateMachine(EnodebAcsStateMachine):
     def __init__(
             self,
             service: MagmaService,
+            use_param_key: bool,
     ) -> None:
-        super().__init__()
+        super().__init__(use_param_key=use_param_key)
         self.state = None
         self.timeout_handler = None
         self.mme_timeout_handler = None

--- a/lte/gateway/python/magma/enodebd/state_machines/enb_acs_states.py
+++ b/lte/gateway/python/magma/enodebd/state_machines/enb_acs_states.py
@@ -14,6 +14,7 @@ from abc import ABC, abstractmethod
 from collections import namedtuple
 from typing import Any, Optional
 
+from magma.enodebd.data_models.data_model import InvalidTrParamPath
 from magma.enodebd.data_models.data_model_parameters import ParameterName
 from magma.enodebd.device_config.configuration_init import build_desired_config
 from magma.enodebd.exceptions import ConfigurationError, Tr069Error
@@ -530,7 +531,9 @@ class GetParametersState(EnodebAcsState):
         request.ParameterNames.string = []
         for name in names:
             path = self.acs.data_model.get_parameter(name).path
-            request.ParameterNames.string.append(path)
+            if path is not InvalidTrParamPath:
+                # Only get data elements backed by tr69 path
+                request.ParameterNames.string.append(path)
 
         return AcsMsgAndTransition(request, self.done_transition)
 

--- a/lte/gateway/python/magma/enodebd/tests/enodeb_acs_states_tests.py
+++ b/lte/gateway/python/magma/enodebd/tests/enodeb_acs_states_tests.py
@@ -71,7 +71,7 @@ class DummyHandler(BasicEnodebAcsStateMachine):
             service: MagmaService,
     ) -> None:
         self._state_map = {}
-        super().__init__(service)
+        super().__init__(service=service, use_param_key=False)
 
     def are_invasive_changes_applied(self) -> bool:
         return False

--- a/lte/gateway/python/magma/enodebd/tests/freedomfi_one_tests.py
+++ b/lte/gateway/python/magma/enodebd/tests/freedomfi_one_tests.py
@@ -1,0 +1,669 @@
+"""
+Copyright 2020 The Magma Authors.
+
+This source code is licensed under the BSD-style license found in the
+LICENSE file in the root directory of this source tree.
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+import logging
+import os
+from unittest.mock import Mock, call, patch
+
+from lte.protos.mconfig import mconfigs_pb2
+from magma.common.service import MagmaService
+from magma.enodebd.data_models.data_model_parameters import ParameterName
+from magma.enodebd.devices.device_map import get_device_handler_from_name
+from magma.enodebd.devices.device_utils import EnodebDeviceName
+from magma.enodebd.devices.freedomfi_one import (
+    FreedomFiOneConfigurationInitializer,
+    SASParameters,
+    StatusParameters,
+)
+from magma.enodebd.tests.test_utils.config_builder import EnodebConfigBuilder
+from magma.enodebd.tests.test_utils.enb_acs_builder import (
+    EnodebAcsStateMachineBuilder,
+)
+from magma.enodebd.tests.test_utils.enodeb_handler import EnodebHandlerTestCase
+from magma.enodebd.tests.test_utils.tr069_msg_builder import Tr069MessageBuilder
+from magma.enodebd.tr069 import models
+
+SRC_CONFIG_DIR = os.path.join(
+    os.environ.get('MAGMA_ROOT'),
+    'lte/gateway/configs',
+)
+
+
+class FreedomFiOneTests(EnodebHandlerTestCase):
+
+    def _get_freedomfi_one_read_only_param_values_response(
+            self,
+    ) -> models.GetParameterValuesResponse:
+        msg = models.GetParameterValuesResponse()
+        param_val_list = []
+        param_val_list.append(
+            Tr069MessageBuilder.get_parameter_value_struct(
+                name='Device.X_000E8F_DeviceFeature.X_000E8F_NEStatus'
+                     '.X_000E8F_Sync_Status',
+                val_type='string',
+                data='InSync',
+            ),
+        )
+        param_val_list.append(
+            Tr069MessageBuilder.get_parameter_value_struct(
+                name='Device.X_000E8F_DeviceFeature.X_000E8F_NEStatus'
+                     '.X_000E8F_SAS_Status',
+                val_type='string',
+                data='SUCCESS',
+            ),
+        )
+        param_val_list.append(
+            Tr069MessageBuilder.get_parameter_value_struct(
+                name='Device.X_000E8F_DeviceFeature.X_000E8F_NEStatus'
+                     '.X_000E8F_eNB_Status',
+                val_type='string',
+                data='SUCCESS',
+            ),
+        )
+        param_val_list.append(
+            Tr069MessageBuilder.get_parameter_value_struct(
+                name='Device.X_000E8F_DeviceFeature.X_000E8F_NEStatus'
+                     '.X_000E8F_DEFGW_Status',
+                val_type='string',
+                data='SUCCESS',
+            ),
+        )
+        param_val_list.append(
+            Tr069MessageBuilder.get_parameter_value_struct(
+                name='Device.FAP.GPS.ScanStatus',
+                val_type='string',
+                data='SUCCESS',
+            ),
+        )
+        param_val_list.append(
+            Tr069MessageBuilder.get_parameter_value_struct(
+                name='Device.FAP.GPS.LockedLongitude',
+                val_type='int',
+                data='-105272892',
+            ),
+        )
+        param_val_list.append(
+            Tr069MessageBuilder.get_parameter_value_struct(
+                name='Device.FAP.GPS.LockedLatitude',
+                val_type='int',
+                data='40019606',
+            ),
+        )
+        msg.ParameterList = models.ParameterValueList()
+        msg.ParameterList.ParameterValueStruct = param_val_list
+        return msg
+
+    def _get_freedomfi_one_param_values_response(self):
+        msg = models.GetParameterValuesResponse()
+        param_val_list = []
+        msg.ParameterList = models.ParameterValueList()
+        msg.ParameterList.ParameterValueStruct = param_val_list
+
+        param_val_list.append(
+            Tr069MessageBuilder.get_parameter_value_struct(
+                name='Device.Services.FAPService.1.CellConfig.LTE.RAN.RF.EARFCNDL',
+                val_type='int',
+                data='56240',
+            ),
+        )
+        param_val_list.append(
+            Tr069MessageBuilder.get_parameter_value_struct(
+                name='Device.FAP.GPS.ScanOnBoot',
+                val_type='boolean',
+                data='1',
+            ),
+        )
+        param_val_list.append(
+            Tr069MessageBuilder.get_parameter_value_struct(
+                name='Device.Services.FAPService.1.FAPControl.LTE.AdminState',
+                val_type='boolean',
+                data='1',
+            ),
+        )
+        param_val_list.append(
+            Tr069MessageBuilder.get_parameter_value_struct(
+                name='Device.FAP.PerfMgmt.Config.1.Enable',
+                val_type='boolean',
+                data='1',
+            ),
+        )
+        param_val_list.append(
+            Tr069MessageBuilder.get_parameter_value_struct(
+                name='Device.Services.FAPService.1.FAPControl.LTE.Gateway.S1SigLinkServerList',
+                val_type='string',
+                data='10.0.2.1',
+            ),
+        )
+        param_val_list.append(
+            Tr069MessageBuilder.get_parameter_value_struct(
+                name='Device.Services.FAPService.1.FAPControl.LTE.X_000E8F_RRMConfig.X_000E8F_Cell_Number',
+                val_type='int',
+                data='2',
+            ),
+        )
+        param_val_list.append(
+            Tr069MessageBuilder.get_parameter_value_struct(
+                name='Device.Services.FAPService.1.CellConfig.LTE.EPC.TAC',
+                val_type='int',
+                data='1',
+            ),
+        )
+        param_val_list.append(
+            Tr069MessageBuilder.get_parameter_value_struct(
+                name='Device.FAP.PerfMgmt.Config.1.PeriodicUploadInterval',
+                val_type='int',
+                data='60',
+            ),
+        )
+        param_val_list.append(
+            Tr069MessageBuilder.get_parameter_value_struct(
+                name='Device.DeviceInfo.SoftwareVersion',
+                val_type='string',
+                data='TEST3920@210901',
+            ),
+        )
+        param_val_list.append(
+            Tr069MessageBuilder.get_parameter_value_struct(
+                name='Device.Services.FAPService.1.FAPControl.LTE.X_000E8F_SAS.UserContactInformation',
+                val_type='string',
+                data='M0LK4T',
+            ),
+        )
+        param_val_list.append(
+            Tr069MessageBuilder.get_parameter_value_struct(
+                name='Device.Services.FAPService.1.FAPControl.LTE.X_000E8F_SAS.ProtectionLevel',
+                val_type='string',
+                data='GAA',
+            ),
+        )
+        param_val_list.append(
+            Tr069MessageBuilder.get_parameter_value_struct(
+                name='Device.Services.FAPService.1.FAPControl.LTE.X_000E8F_SAS.CertSubject',
+                val_type='string',
+                data='/C=TW/O=Sercomm/OU=WInnForum CBSD Certificate/CN=P27-SCE4255W:%s',
+            ),
+        )
+        param_val_list.append(
+            Tr069MessageBuilder.get_parameter_value_struct(
+                name='Device.Services.FAPService.1.FAPControl.LTE.X_000E8F_SAS.HeightType',
+                val_type='string',
+                data='AMSL',
+            ),
+        )
+        param_val_list.append(
+            Tr069MessageBuilder.get_parameter_value_struct(
+                name='Device.Services.FAPService.1.FAPControl.LTE.X_000E8F_SAS.Category',
+                val_type='string',
+                data='A',
+            ),
+        )
+        param_val_list.append(
+            Tr069MessageBuilder.get_parameter_value_struct(
+                name='Device.FAP.GPS.ScanStatus',
+                val_type='string',
+                data='Success',
+            ),
+        )
+        param_val_list.append(
+            Tr069MessageBuilder.get_parameter_value_struct(
+                name='Device.ManagementServer.PeriodicInformInterval',
+                val_type='int',
+                data='60',
+            ),
+        )
+        param_val_list.append(
+            Tr069MessageBuilder.get_parameter_value_struct(
+                name='Device.Services.FAPService.1.CellConfig.LTE.RAN.RF.FreqBandIndicator',
+                val_type='unsignedInt',
+                data='48',
+            ),
+        )
+        param_val_list.append(
+            Tr069MessageBuilder.get_parameter_value_struct(
+                name='Device.Services.FAPService.1.CellConfig.LTE.RAN.Common.CellIdentity',
+                val_type='unsignedInt',
+                data='101',
+            ),
+        )
+        param_val_list.append(
+            Tr069MessageBuilder.get_parameter_value_struct(
+                name='Device.FAP.GPS.LockedLongitude',
+                val_type='string',
+                data='-105272892',
+            ),
+        )
+        param_val_list.append(
+            Tr069MessageBuilder.get_parameter_value_struct(
+                name='Device.FAP.GPS.LockedLatitude',
+                val_type='string',
+                data='40019606',
+            ),
+        )
+        param_val_list.append(
+            Tr069MessageBuilder.get_parameter_value_struct(
+                name='Device.Services.FAPService.1.FAPControl.LTE.X_000E8F_SAS.CPIEnable',
+                val_type='boolean',
+                data='0',
+            ),
+        )
+        param_val_list.append(
+            Tr069MessageBuilder.get_parameter_value_struct(
+                name='Device.Services.FAPService.1.FAPControl.LTE.X_000E8F_RRMConfig.X_000E8F_CA_Enable',
+                val_type='boolean',
+                data='1',
+            ),
+        )
+        param_val_list.append(
+            Tr069MessageBuilder.get_parameter_value_struct(
+                name='Device.FAP.GPS.ScanOnBoot',
+                val_type='boolean',
+                data='1',
+            ),
+        )
+        param_val_list.append(
+            Tr069MessageBuilder.get_parameter_value_struct(
+                name='Device.X_000E8F_DeviceFeature.X_000E8F_NEStatus.X_000E8F_Sync_Status',
+                val_type='string',
+                data='InSync',
+            ),
+        )
+        param_val_list.append(
+            Tr069MessageBuilder.get_parameter_value_struct(
+                name='Device.Services.FAPService.1.CellConfig.LTE.RAN.RF.PhyCellID',
+                val_type='string',
+                data='101,102',
+            ),
+        )
+        param_val_list.append(
+            Tr069MessageBuilder.get_parameter_value_struct(
+                name='Device.FAP.PerfMgmt.Config.1.URL',
+                val_type='string',
+                data=None,
+            ),
+        )
+        param_val_list.append(
+            Tr069MessageBuilder.get_parameter_value_struct(
+                name='Device.Services.FAPService.1.FAPControl.LTE.X_000E8F_SAS.Location',
+                val_type='string',
+                data='indoor',
+            ),
+        )
+        param_val_list.append(
+            Tr069MessageBuilder.get_parameter_value_struct(
+                name='Device.Services.FAPService.1.CellConfig.LTE.RAN.PHY.TDDFrame.SubFrameAssignment',
+                val_type='boolean',
+                data='2',
+            ),
+        )
+        param_val_list.append(
+            Tr069MessageBuilder.get_parameter_value_struct(
+                name='Device.Services.FAPService.1.CellConfig.LTE.EPC.PLMNList.1.IsPrimary',
+                val_type='boolean',
+                data='1',
+            ),
+        )
+        param_val_list.append(
+            Tr069MessageBuilder.get_parameter_value_struct(
+                name='Device.Services.FAPService.1.CellConfig.LTE.EPC.PLMNList.1.Enable',
+                val_type='boolean',
+                data='1',
+            ),
+        )
+        param_val_list.append(
+            Tr069MessageBuilder.get_parameter_value_struct(
+                name='Device.Services.FAPService.1.FAPControl.LTE.X_000E8F_SAS.Server',
+                val_type='string',
+                data='https://spectrum-connect.federatedwireless.com/v1.2/',
+            ),
+        )
+        param_val_list.append(
+            Tr069MessageBuilder.get_parameter_value_struct(
+                name='Device.X_000E8F_DeviceFeature.X_000E8F_WebServerEnable',
+                val_type='boolean',
+                data='1',
+            ),
+        )
+        param_val_list.append(
+            Tr069MessageBuilder.get_parameter_value_struct(
+                name='Device.Services.FAPService.1.CellConfig.LTE.EPC.PLMNList.1.CellReservedForOperatorUse',
+                val_type='boolean',
+                data='0',
+            ),
+        )
+        param_val_list.append(
+            Tr069MessageBuilder.get_parameter_value_struct(
+                name='Device.Services.FAPService.1.CellConfig.LTE.Tunnel.1.TunnelRef',
+                val_type='string',
+                data='Device.IP.Interface.1.IPv4Address.1.',
+            ),
+        )
+        param_val_list.append(
+            Tr069MessageBuilder.get_parameter_value_struct(
+                name='Device.Services.FAPService.1.REM.X_000E8F_tfcsManagerConfig.primSrc',
+                val_type='string',
+                data='GNSS',
+            ),
+        )
+        param_val_list.append(
+            Tr069MessageBuilder.get_parameter_value_struct(
+                name='Device.Services.FAPService.1.FAPControl.LTE.X_000E8F_SAS.Enable',
+                val_type='boolean',
+                data='1',
+            ),
+        )
+        param_val_list.append(
+            Tr069MessageBuilder.get_parameter_value_struct(
+                name='Device.ManagementServer.PeriodicInformEnable',
+                val_type='boolean',
+                data='1',
+            ),
+        )
+        param_val_list.append(
+            Tr069MessageBuilder.get_parameter_value_struct(
+                name='Device.Services.FAPService.1.CellConfig.LTE.EPC.PLMNListNumberOfEntries',
+                val_type='int',
+                data='1',
+            ),
+        )
+        param_val_list.append(
+            Tr069MessageBuilder.get_parameter_value_struct(
+                name='Device.Services.FAPService.1.CellConfig.LTE.RAN.PHY.TDDFrame.SpecialSubframePatterns',
+                val_type='int',
+                data='7',
+            ),
+        )
+        param_val_list.append(
+            Tr069MessageBuilder.get_parameter_value_struct(
+                name='Device.Services.FAPService.1.FAPControl.LTE.X_000E8F_RRMConfig.X_000E8F_CELL_Freq_Contiguous',
+                val_type='int',
+                data='0',
+            ),
+        )
+        param_val_list.append(
+            Tr069MessageBuilder.get_parameter_value_struct(
+                name='Device.Services.FAPService.1.FAPControl.LTE.Gateway.S1SigLinkPort',
+                val_type='int',
+                data='36412',
+            ),
+        )
+        return msg
+
+    def _get_service_config(self):
+        return {
+            "tr069": {
+                "interface": "eth1",
+                "port": 48080,
+                "perf_mgmt_port": 8081,
+                "public_ip": "192.88.99.142",
+            },
+            "reboot_enodeb_on_mme_disconnected": True,
+            "s1_interface": "eth1",
+            "sas": {
+                "sas_enabled": True,
+                "sas_server_url":
+                    "https://spectrum-connect.federatedwireless.com/v1.2/",
+                "sas_uid": "M0LK4T",
+                "sas_category": "A",
+                "sas_channel_type": "GAA",
+                "sas_cert_subject": "/C=TW/O=Sercomm/OU=WInnForum CBSD "
+                                    "Certificate/CN=P27-SCE4255W:%s",
+                "sas_icg_group_id": "",
+                "sas_location": "indoor",
+                "sas_height_type": "AMSL",
+            },
+        }
+
+    def build_freedomfi_one_acs_state_machine(self):
+        service = EnodebAcsStateMachineBuilder.build_magma_service(
+            mconfig=EnodebConfigBuilder.get_mconfig(),
+            service_config=self._get_service_config(),
+        )
+        handler_class = get_device_handler_from_name(
+            EnodebDeviceName.FREEDOMFI_ONE,
+        )
+        acs_state_machine = handler_class(service)
+        return acs_state_machine
+
+    def test_provision(self) -> None:
+        """
+        Test the basic provisioning workflow
+        1 - enodeb sends Inform, enodebd sends InformResponse
+        2 - enodeb sends empty HTTP message,
+        3 - enodebd sends get transient params, updates the device state.
+        4 - enodebd sends get param values, updates the device state
+        5 - enodebd, sets fields including SAS fields.
+        """
+        logging.root.level = logging.DEBUG
+        acs_state_machine = self.build_freedomfi_one_acs_state_machine()
+
+        inform = Tr069MessageBuilder.get_inform(
+            oui="000E8F",
+            sw_version="TEST3920@210901",
+            enb_serial="2006CW5000023",
+        )
+        resp = acs_state_machine.handle_tr069_message(inform)
+        self.assertTrue(
+            isinstance(resp, models.InformResponse),
+            'Should respond with an InformResponse',
+        )
+
+        # Send an empty http request
+        req = models.DummyInput()
+        resp = acs_state_machine.handle_tr069_message(req)
+
+        # Expect a request for read-only params
+        self.assertTrue(
+            isinstance(resp, models.GetParameterValues),
+            'State machine should be requesting param values',
+        )
+        for tr_69_nodes in StatusParameters.STATUS_PARAMETERS.values():
+            self.assertIn(tr_69_nodes.path, resp.ParameterNames.string)
+
+        req = self._get_freedomfi_one_read_only_param_values_response()
+        get_resp = acs_state_machine.handle_tr069_message(req)
+
+        self.assertTrue(
+            isinstance(get_resp, models.GetParameterValues),
+            'State machine should be requesting param values',
+        )
+        req = self._get_freedomfi_one_param_values_response()
+        resp = acs_state_machine.handle_tr069_message(req)
+        self.assertTrue(
+            isinstance(resp, models.SetParameterValues),
+            'State machine should be setting parameters',
+        )
+        self.assertIsNotNone(
+            resp.ParameterKey.Data,
+            'ParameterKey should be set for FreedomFiOne eNB',
+        )
+
+        msg = models.SetParameterValuesResponse()
+        msg.Status = 1
+        get_resp = acs_state_machine.handle_tr069_message(msg)
+        self.assertTrue(
+            isinstance(get_resp, models.GetParameterValues),
+            'We should read back all parameters',
+        )
+
+        req = self._get_freedomfi_one_param_values_response()
+        resp = acs_state_machine.handle_tr069_message(req)
+        self.assertTrue(
+            isinstance(resp, models.DummyInput),
+            'Provisioning completed with Dummy response',
+        )
+
+    def test_manual_reboot_during_provisioning(self) -> None:
+        """
+        Test a scenario where a Magma user goes through the enodebd CLI to
+        reboot the Baicells eNodeB.
+
+        This checks the scenario where the command is sent in the middle
+        of a TR-069 provisioning session.
+        """
+        logging.root.level = logging.DEBUG
+        acs_state_machine = self.build_freedomfi_one_acs_state_machine()
+
+        # Send an Inform message, wait for an InformResponse
+        inform = Tr069MessageBuilder.get_inform(
+            oui="000E8F",
+            sw_version="TEST3920@210901",
+            enb_serial="2006CW5000023",
+        )
+        resp = acs_state_machine.handle_tr069_message(inform)
+        self.assertTrue(
+            isinstance(resp, models.InformResponse),
+            'Should respond with an InformResponse',
+        )
+
+        # Send an empty http request to kick off the rest of provisioning
+        req = models.DummyInput()
+        resp = acs_state_machine.handle_tr069_message(req)
+
+        # Expect a request for an optional parameter, three times
+        self.assertTrue(
+            isinstance(resp, models.GetParameterValues),
+            'State machine should be requesting param values',
+        )
+        req = Tr069MessageBuilder.get_fault()
+
+        # User uses the CLI tool to get eNodeB to reboot
+        acs_state_machine.reboot_asap()
+
+        resp = acs_state_machine.handle_tr069_message(req)
+        self.assertTrue(
+            isinstance(resp, models.Reboot),
+            'In reboot sequence, state machine should send a '
+            'Reboot message.',
+        )
+        req = Tr069MessageBuilder.get_reboot_response()
+        resp = acs_state_machine.handle_tr069_message(req)
+        self.assertTrue(
+            isinstance(resp, models.DummyInput),
+            'State machine should end TR-069 session after '
+            'receiving a RebootResponse',
+        )
+
+    def test_post_processing(self) -> None:
+        """ Test FreedomFi One specific post processing functionality"""
+
+        acs_state_machine = self.build_freedomfi_one_acs_state_machine()
+        cfg_desired = Mock()
+        acs_state_machine.device_cfg.set_parameter(
+            ParameterName.SERIAL_NUMBER,
+            "2006CW5000023",
+        )
+
+        cfg_init = FreedomFiOneConfigurationInitializer(acs_state_machine)
+        cfg_init.postprocess(
+            EnodebConfigBuilder.get_mconfig(),
+            self._get_service_config(), cfg_desired,
+        )
+        expected = [
+            call.delete_parameter('EARFCNDL'),
+            call.delete_parameter('DL bandwidth'),
+            call.delete_parameter('UL bandwidth'),
+            call.set_parameter(
+                'tunnel_ref',
+                'Device.IP.Interface.1.IPv4Address.1.',
+            ),
+            call.set_parameter('prim_src', 'GNSS'),
+            call.set_parameter('carrier_agg_enable', True),
+            call.set_parameter('carrier_number', 2),
+            call.set_parameter('contiguous_cc', 0),
+            call.set_parameter('web_ui_enable', False),
+            call.set_parameter('sas_enabled', True),
+            call.set_parameter(
+                'sas_server_url',
+                'https://spectrum-connect.federatedwireless.com/v1.2/',
+            ),
+            call.set_parameter('sas_uid', 'M0LK4T'),
+            call.set_parameter('sas_category', 'A'),
+            call.set_parameter('sas_channel_type', 'GAA'),
+            call.set_parameter(
+                'sas_cert_subject',
+                '/C=TW/O=Sercomm/OU=WInnForum CBSD Certificate/CN=P27-SCE4255W:%s',
+            ),
+            call.set_parameter('sas_location', 'indoor'),
+            call.set_parameter('sas_height_type', 'AMSL'),
+        ]
+        self.assertEqual(cfg_desired.mock_calls, expected)
+
+        # Check without sas config
+        service_cfg = {
+            "tr069": {
+                "interface": "eth1",
+                "port": 48080,
+                "perf_mgmt_port": 8081,
+                "public_ip": "192.88.99.142",
+            },
+            "reboot_enodeb_on_mme_disconnected": True,
+            "s1_interface": "eth1",
+        }
+        cfg_desired = Mock()
+        cfg_init.postprocess(
+            EnodebConfigBuilder.get_mconfig(),
+            service_cfg, cfg_desired,
+        )
+        expected = [
+            call.delete_parameter('EARFCNDL'),
+            call.delete_parameter('DL bandwidth'),
+            call.delete_parameter('UL bandwidth'),
+            call.set_parameter(
+                'tunnel_ref',
+                'Device.IP.Interface.1.IPv4Address.1.',
+            ),
+            call.set_parameter('prim_src', 'GNSS'),
+            call.set_parameter('carrier_agg_enable', True),
+            call.set_parameter('carrier_number', 2),
+            call.set_parameter('contiguous_cc', 0),
+            call.set_parameter('web_ui_enable', False),
+        ]
+        self.assertEqual(cfg_desired.mock_calls, expected)
+
+        service_cfg['web_ui_enable'] = ["2006CW5000023"]
+
+        expected = [
+            call.delete_parameter('EARFCNDL'),
+            call.delete_parameter('DL bandwidth'),
+            call.delete_parameter('UL bandwidth'),
+            call.set_parameter(
+                'tunnel_ref',
+                'Device.IP.Interface.1.IPv4Address.1.',
+            ),
+            call.set_parameter('prim_src', 'GNSS'),
+            call.set_parameter('carrier_agg_enable', True),
+            call.set_parameter('carrier_number', 2),
+            call.set_parameter('contiguous_cc', 0),
+            call.set_parameter('web_ui_enable', False),
+            call.set_parameter('web_ui_enable', True),
+        ]
+        cfg_desired = Mock()
+        cfg_init.postprocess(
+            EnodebConfigBuilder.get_mconfig(),
+            service_cfg, cfg_desired,
+        )
+        self.assertEqual(cfg_desired.mock_calls, expected)
+
+    @patch('magma.configuration.service_configs.CONFIG_DIR', SRC_CONFIG_DIR)
+    def test_service_cfg_parsing(self):
+        """ Test the parsing of the service config file for enodebd.yml"""
+        service = MagmaService('enodebd', mconfigs_pb2.EnodebD())
+        service_cfg = service.config
+        service_cfg_1 = self._get_service_config()
+        service_cfg_1['web_ui_enable'] = []
+        service_cfg_1[FreedomFiOneConfigurationInitializer.SAS_KEY][
+            SASParameters.SAS_UID
+        ] = "INVALID_ID"
+        service_cfg_1[FreedomFiOneConfigurationInitializer.SAS_KEY][
+            SASParameters.SAS_CERT_SUBJECT
+        ] = "INVALID_CERT_SUBJECT"
+        self.assertEqual(service_cfg, service_cfg_1)

--- a/lte/gateway/python/magma/enodebd/tests/freedomfi_one_tests.py
+++ b/lte/gateway/python/magma/enodebd/tests/freedomfi_one_tests.py
@@ -629,7 +629,7 @@ class FreedomFiOneTests(EnodebHandlerTestCase):
         ]
         self.assertEqual(cfg_desired.mock_calls, expected)
 
-        service_cfg['web_ui_enable'] = ["2006CW5000023"]
+        service_cfg['web_ui_enable_list'] = ["2006CW5000023"]
 
         expected = [
             call.delete_parameter('EARFCNDL'),
@@ -659,7 +659,7 @@ class FreedomFiOneTests(EnodebHandlerTestCase):
         service = MagmaService('enodebd', mconfigs_pb2.EnodebD())
         service_cfg = service.config
         service_cfg_1 = self._get_service_config()
-        service_cfg_1['web_ui_enable'] = []
+        service_cfg_1['web_ui_enable_list'] = []
         service_cfg_1[FreedomFiOneConfigurationInitializer.SAS_KEY][
             SASParameters.SAS_UID
         ] = "INVALID_ID"

--- a/lte/gateway/python/magma/enodebd/tests/test_utils/enb_acs_builder.py
+++ b/lte/gateway/python/magma/enodebd/tests/test_utils/enb_acs_builder.py
@@ -12,8 +12,10 @@ limitations under the License.
 """
 
 import asyncio
+from typing import Dict
 from unittest import mock
 
+from lte.protos.mconfig import mconfigs_pb2
 from magma.common.service import MagmaService
 from magma.enodebd.devices.device_map import get_device_handler_from_name
 from magma.enodebd.devices.device_utils import EnodebDeviceName
@@ -64,10 +66,14 @@ class EnodebAcsStateMachineBuilder:
     def build_magma_service(
         cls,
         device: EnodebDeviceName = EnodebDeviceName.BAICELLS,
+            mconfig: mconfigs_pb2.EnodebD = None,
+            service_config: Dict = None,
     ) -> MagmaService:
         event_loop = asyncio.get_event_loop()
-        mconfig = EnodebConfigBuilder.get_mconfig(device)
-        service_config = EnodebConfigBuilder.get_service_config()
+        if not mconfig:
+            mconfig = EnodebConfigBuilder.get_mconfig(device)
+        if not service_config:
+            service_config = EnodebConfigBuilder.get_service_config()
         with mock.patch('magma.common.service.MagmaService') as MockService:
             MockService.config = service_config
             MockService.mconfig = mconfig


### PR DESCRIPTION
<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

Add support for a new CBRS capable eNB (FreedomFiOne)
The change also adds some parameters to enodebd.yml which
will be replaced by settings from the domain proxy in a later patch
Note: Introducing domain proxy in the SAS path also requires FCC
certification

## Test Plan

unit tests
running setup for a month.

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
