### PR TITLE
fix(AGW): Resolve null deference during t3422 detach expiry

### DIFF
--- a/lte/gateway/c/core/oai/tasks/amf/Registration.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/Registration.cpp
@@ -716,6 +716,7 @@ static int registration_accept_t3550_handler(
       amf_proc_registration_abort(amf_ctx, ue_amf_context);
       // Clean up all the sessions.
       amf_smf_context_cleanup_pdu_session(ue_amf_context);
+      amf_free_ue_context(ue_amf_context);
     }
   }
   OAILOG_FUNC_RETURN(LOG_NAS_AMF, RETURNok);
@@ -1140,7 +1141,6 @@ int amf_proc_registration_abort(
     message_p->ittiMsgHeader.imsi = ue_amf_context->amf_context.imsi64;
     send_msg_to_task(&amf_app_task_zmq_ctx, TASK_NGAP, message_p);
     amf_delete_registration_proc(amf_ctx);
-    amf_remove_ue_context(ue_amf_context);
     rc = RETURNok;
   }
   OAILOG_FUNC_RETURN(LOG_AMF_APP, rc);

--- a/lte/gateway/c/core/oai/tasks/amf/amf_app_ue_context.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_app_ue_context.cpp
@@ -407,4 +407,54 @@ int amf_idle_mode_procedure(amf_context_t* amf_ctx) {
   OAILOG_FUNC_RETURN(LOG_AMF_APP, RETURNok);
 }
 
+/****************************************************************************
+ **                                                                        **
+ ** Name:    amf_free_ue_context()                                         **
+ **                                                                        **
+ ** Description: Deletes the ue context                                    **
+ **                                                                        **
+ **                                                                        **
+ ***************************************************************************/
+void amf_free_ue_context(ue_m5gmm_context_s* ue_context_p) {
+  hashtable_rc_t h_rc                = HASH_TABLE_OK;
+  amf_app_desc_t* amf_app_desc_p     = get_amf_nas_state(false);
+  amf_ue_context_t* amf_ue_context_p = &amf_app_desc_p->amf_ue_contexts;
+
+  hash_table_ts_t* amf_state_ue_id_ht = get_amf_ue_state();
+  if (!ue_context_p || !amf_ue_context_p) {
+    return;
+  }
+
+  amf_remove_ue_context(ue_context_p);
+
+  if (ue_context_p->gnb_ngap_id_key != INVALID_GNB_UE_NGAP_ID_KEY) {
+    h_rc = hashtable_uint64_ts_remove(
+        amf_ue_context_p->gnb_ue_ngap_id_ue_context_htbl,
+        (const hash_key_t) ue_context_p->gnb_ngap_id_key);
+    ue_context_p->gnb_ngap_id_key = INVALID_GNB_UE_NGAP_ID_KEY;
+  }
+
+  if (ue_context_p->amf_ue_ngap_id != INVALID_AMF_UE_NGAP_ID) {
+    h_rc = hashtable_ts_remove(
+        amf_state_ue_id_ht, (const hash_key_t) ue_context_p->amf_ue_ngap_id,
+        reinterpret_cast<void**>(&ue_context_p));
+    ue_context_p->amf_ue_ngap_id = INVALID_AMF_UE_NGAP_ID;
+  }
+
+  hashtable_uint64_ts_remove(
+      amf_ue_context_p->imsi_amf_ue_id_htbl,
+      (const hash_key_t) ue_context_p->amf_context.imsi64);
+
+  hashtable_uint64_ts_remove(
+      amf_ue_context_p->tun11_ue_context_htbl,
+      (const hash_key_t) ue_context_p->amf_teid_n11);
+
+  obj_hashtable_uint64_ts_remove(
+      amf_ue_context_p->guti_ue_context_htbl,
+      &ue_context_p->amf_context.m5_guti,
+      sizeof(ue_context_p->amf_context.m5_guti));
+
+  delete ue_context_p;
+  ue_context_p = NULL;
+}
 }  // namespace magma5g

--- a/lte/gateway/c/core/oai/tasks/amf/amf_app_ue_context_and_proc.h
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_app_ue_context_and_proc.h
@@ -846,5 +846,5 @@ ue_m5gmm_context_s* ue_context_lookup_by_gnb_ue_id(
     gnb_ue_ngap_id_t gnb_ue_ngap_id);
 
 int amf_idle_mode_procedure(amf_context_t* amf_ctx);
-
+void amf_free_ue_context(ue_m5gmm_context_s* ue_context_p);
 }  // namespace magma5g

--- a/lte/gateway/c/core/oai/tasks/amf/deregistration_request.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/deregistration_request.cpp
@@ -210,8 +210,7 @@ int amf_app_handle_deregistration_req(amf_ue_ngap_id_t ue_id) {
   // Clean up all the sessions.
   amf_smf_context_cleanup_pdu_session(ue_context);
 
-  // Remove stored UE context from AMF core.
-  amf_remove_ue_context(ue_context);
+  amf_free_ue_context(ue_context);
 
   OAILOG_FUNC_RETURN(LOG_NAS_AMF, rc);
 }

--- a/lte/gateway/c/core/oai/tasks/nas/emm/Detach.c
+++ b/lte/gateway/c/core/oai/tasks/nas/emm/Detach.c
@@ -142,12 +142,7 @@ status_code_e mme_app_handle_detach_t3422_expiry(
     // Resend detach request message to the UE
     emm_proc_nw_initiated_detach_request(mme_ue_s1ap_id, data->detach_type);
   } else {
-    // Abort the detach procedure and perform implicit detach
-    if (data) {
-      // Free timer argument
-      free_wrapper((void**) &data);
-      emm_ctx->t3422_arg = NULL;
-    }
+    // Abort the detach procedure and perform implicit detach    
     if (data->detach_type != NW_DETACH_TYPE_IMSI_DETACH) {
       emm_detach_request_ies_t emm_detach_request_params;
       /*
@@ -157,6 +152,11 @@ status_code_e mme_app_handle_detach_t3422_expiry(
       emm_detach_request_params.switch_off = 1;
       emm_detach_request_params.type       = 0;
       emm_proc_detach_request(mme_ue_s1ap_id, &emm_detach_request_params);
+    }
+    if (data) {
+      // Free timer argument
+      free_wrapper((void**) &data);
+      emm_ctx->t3422_arg = NULL;
     }
   }
   OAILOG_FUNC_RETURN(LOG_NAS_EMM, RETURNok);


### PR DESCRIPTION
## Summary

Moved the freeing of data till after implicit detach

## Test Plan

NA- Will monitor sentry

## Additional Information

This change should result in lower clang warnings
https://gist.github.com/electronjoe/987d20e3e730d0a22ce184644c70b449
