### PR TITLE
fix(mme): add integ test for failed nw initiated detach and fix stats

### DIFF
--- a/lte/gateway/c/core/oai/tasks/nas/emm/Detach.c
+++ b/lte/gateway/c/core/oai/tasks/nas/emm/Detach.c
@@ -44,6 +44,7 @@
 #include "nas_procedures.h"
 #include "mme_app_defs.h"
 #include "mme_app_timer.h"
+#include "mme_app_statistics.h"
 
 /****************************************************************************/
 /****************  E X T E R N A L    D E F I N I T I O N S  ****************/

--- a/lte/gateway/python/integ_tests/defs.mk
+++ b/lte/gateway/python/integ_tests/defs.mk
@@ -152,8 +152,8 @@ s1aptests/test_idle_mode_with_mme_restart.py \
 s1aptests/test_3485_timer_for_dedicated_bearer_with_mme_restart.py \
 s1aptests/test_3485_timer_for_default_bearer_with_mme_restart.py \
 s1aptests/test_paging_after_mme_restart.py \
-s1aptests/test_restore_mme_config_after_sanity.py \
 s1aptests/test_attach_nw_initiated_detach_fail.py \
+s1aptests/test_restore_mme_config_after_sanity.py
 
 NON_SANITY_TESTS = s1aptests/test_modify_config_for_non_sanity.py \
 s1aptests/test_attach_detach_with_pco_ipcp.py \

--- a/lte/gateway/python/integ_tests/defs.mk
+++ b/lte/gateway/python/integ_tests/defs.mk
@@ -152,7 +152,8 @@ s1aptests/test_idle_mode_with_mme_restart.py \
 s1aptests/test_3485_timer_for_dedicated_bearer_with_mme_restart.py \
 s1aptests/test_3485_timer_for_default_bearer_with_mme_restart.py \
 s1aptests/test_paging_after_mme_restart.py \
-s1aptests/test_restore_mme_config_after_sanity.py
+s1aptests/test_restore_mme_config_after_sanity.py \
+s1aptests/test_attach_nw_initiated_detach_fail.py \
 
 NON_SANITY_TESTS = s1aptests/test_modify_config_for_non_sanity.py \
 s1aptests/test_attach_detach_with_pco_ipcp.py \

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_nw_initiated_detach_fail.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_nw_initiated_detach_fail.py
@@ -1,0 +1,85 @@
+"""
+Copyright 2020 The Magma Authors.
+
+This source code is licensed under the BSD-style license found in the
+LICENSE file in the root directory of this source tree.
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import time
+import unittest
+
+import s1ap_types
+from integ_tests.s1aptests import s1ap_wrapper
+from integ_tests.s1aptests.s1ap_utils import MagmadUtil, SpgwUtil
+
+
+class TestAttachNwInitiatedDetachFail(unittest.TestCase):
+    def setUp(self):
+        self._s1ap_wrapper = s1ap_wrapper.TestWrapper(
+            stateless_mode=MagmadUtil.stateless_cmds.ENABLE,
+        )
+        self._spgw_util = SpgwUtil()
+
+    def tearDown(self):
+        self._s1ap_wrapper.cleanup()
+
+    def test_attach_nw_initiated_detach_fail(self):
+        """
+        The test case validates retransmission of Detach Request after MME
+        restarts
+        Step 1: UE attaches to network
+        Step 2: Send request to delete default bearer, since deletion is
+                invoked for default bearer, MME initiates detach procedure
+        Step 3: MME starts 3422 timer to receive Detach Accept message
+        Step 4: S1AP tester ignores and does not send Detach Accept
+        """
+        self._s1ap_wrapper.configUEDevice(1)
+
+        req = self._s1ap_wrapper.ue_req
+        print(
+            "********************** Running End to End attach for ",
+            "UE id ",
+            req.ue_id,
+        )
+        # Now actually complete the attach
+        attach = self._s1ap_wrapper._s1_util.attach(
+            req.ue_id,
+            s1ap_types.tfwCmd.UE_END_TO_END_ATTACH_REQUEST,
+            s1ap_types.tfwCmd.UE_ATTACH_ACCEPT_IND,
+            s1ap_types.ueAttachAccept_t,
+        )
+
+        # Wait on EMM Information from MME
+        self._s1ap_wrapper._s1_util.receive_emm_info()
+
+        print("Sleeping for 5 seconds")
+        time.sleep(5)
+        print(
+            "********************** Deleting default bearer for IMSI",
+            "".join([str(i) for i in req.imsi]),
+        )
+        # Delete default bearer
+        self._spgw_util.delete_bearer(
+            "IMSI" + "".join([str(i) for i in req.imsi]),
+            attach.esmInfo.epsBearerId,
+            attach.esmInfo.epsBearerId,
+        )
+        # Receive NW initiated detach request
+        for _ in range(5):
+            response = self._s1ap_wrapper.s1_util.get_response()
+            self.assertEqual(
+                response.msg_type,
+                s1ap_types.tfwCmd.UE_NW_INIT_DETACH_REQUEST.value,
+            )
+            print("**************** Received NW initiated Detach Req")
+
+        time.sleep(6)
+
+if __name__ == "__main__":
+    unittest.main()

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_nw_initiated_detach_fail.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_nw_initiated_detach_fail.py
@@ -20,13 +20,20 @@ from integ_tests.s1aptests.s1ap_utils import MagmadUtil, SpgwUtil
 
 
 class TestAttachNwInitiatedDetachFail(unittest.TestCase):
+    """
+    S1AP Integration test for Failed Network Initiated Detach
+    """
     def setUp(self):
+        """Initialize s1ap wrapper and spgw utility
+        """
         self._s1ap_wrapper = s1ap_wrapper.TestWrapper(
             stateless_mode=MagmadUtil.stateless_cmds.ENABLE,
         )
         self._spgw_util = SpgwUtil()
 
     def tearDown(self):
+        """Clean up utilities and sctp connection
+        """
         self._s1ap_wrapper.cleanup()
 
     def test_attach_nw_initiated_detach_fail(self):
@@ -80,6 +87,7 @@ class TestAttachNwInitiatedDetachFail(unittest.TestCase):
             print("**************** Received NW initiated Detach Req")
 
         time.sleep(6)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Signed-off-by: Ulas Kozat <kozat@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->
The PR is based upon PR #9006. It provides:
- an s1ap integ test that can reproduce crash scenario as outlined in #8983. 
- a fix to the counters when network initiated detach ends up in switch off condition.

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->
The test added can reproduce crash before PR #9006 and test passes post PR. Also monitored the mme.log to see that counters were updated properly for UE's in ECM-Connected state.

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
