### PR TITLE
fix(mme): removed a few compilation warnings

### DIFF
--- a/lte/gateway/c/core/oai/tasks/amf/amf_app_handler.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_app_handler.cpp
@@ -662,7 +662,7 @@ void amf_app_handle_pdu_session_response(
     amf_sap.u.amf_as.u.establish.guti = ue_context->amf_context.m5_guti;
     rc                                = amf_sap_send(&amf_sap);
     if (RETURNok == rc) {
-      ue_context->mm_state == REGISTERED_CONNECTED;
+      ue_context->mm_state = REGISTERED_CONNECTED;
     }
   } else {
     OAILOG_DEBUG(
@@ -1215,9 +1215,8 @@ static int paging_t3513_handler(zloop_t* loop, int timer_id, void* arg) {
         LOG_AMF_APP,
         "T3513: Maximum retires done hence Abort the Paging Request "
         "procedure\n");
-    OAILOG_FUNC_RETURN(LOG_NAS_AMF, RETURNok);
   }
-  OAILOG_FUNC_RETURN(LOG_NAS_AMF, RETURNok);
+  OAILOG_FUNC_RETURN(LOG_NAS_AMF, rc);
 }
 
 // Doing Paging Request handling received from SMF in AMF CORE

--- a/lte/gateway/c/core/oai/tasks/amf/amf_app_handler.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_app_handler.cpp
@@ -1206,6 +1206,8 @@ static int paging_t3513_handler(zloop_t* loop, int timer_id, void* arg) {
 
     OAILOG_INFO(LOG_AMF_APP, "T3513: sending downlink message to NGAP");
     rc = send_msg_to_task(&amf_app_task_zmq_ctx, TASK_NGAP, message_p);
+    if (rc != RETURNok)
+      OAILOG_ERROR(LOG_AMF_APP, "Could not send msg to task\n");
     //    amf_paging_request(paging_ctx);
   } else {
     /*
@@ -1216,7 +1218,7 @@ static int paging_t3513_handler(zloop_t* loop, int timer_id, void* arg) {
         "T3513: Maximum retires done hence Abort the Paging Request "
         "procedure\n");
   }
-  OAILOG_FUNC_RETURN(LOG_NAS_AMF, rc);
+  OAILOG_FUNC_RETURN(LOG_NAS_AMF, RETURNok);
 }
 
 // Doing Paging Request handling received from SMF in AMF CORE

--- a/lte/gateway/c/core/oai/tasks/amf/amf_app_main.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_app_main.cpp
@@ -56,7 +56,8 @@ void amf_app_exit(void);
 static int handle_message(zloop_t* loop, zsock_t* reader, void* arg) {
   MessageDef* received_message_p = receive_msg(reader);
   amf_app_desc_t* amf_app_desc_p = get_amf_nas_state(false);
-  imsi64_t imsi64                = itti_get_associated_imsi(received_message_p);
+  // imsi64_t imsi64                =
+  // itti_get_associated_imsi(received_message_p);
 
   OAILOG_INFO(
       LOG_AMF_APP, "Received msg from :[%s] id:[%d] name:[%s]\n",
@@ -117,7 +118,6 @@ static int handle_message(zloop_t* loop, zsock_t* reader, void* arg) {
       /* This case handles Notification Received for Paging or other events
        * or success messages are coming from NGAP
        */
-      imsi64 = itti_get_associated_imsi(received_message_p);
       amf_app_handle_notification_received(
           &N11_NOTIFICATION_RECEIVED(received_message_p));
       break;

--- a/lte/gateway/c/core/oai/tasks/amf/amf_app_ue_context.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_app_ue_context.cpp
@@ -431,6 +431,8 @@ void amf_free_ue_context(ue_m5gmm_context_s* ue_context_p) {
     h_rc = hashtable_uint64_ts_remove(
         amf_ue_context_p->gnb_ue_ngap_id_ue_context_htbl,
         (const hash_key_t) ue_context_p->gnb_ngap_id_key);
+    if (h_rc != HASH_TABLE_OK)
+      OAILOG_TRACE(LOG_AMF_APP, "Error Could not remove this ue context \n");
     ue_context_p->gnb_ngap_id_key = INVALID_GNB_UE_NGAP_ID_KEY;
   }
 
@@ -438,6 +440,8 @@ void amf_free_ue_context(ue_m5gmm_context_s* ue_context_p) {
     h_rc = hashtable_ts_remove(
         amf_state_ue_id_ht, (const hash_key_t) ue_context_p->amf_ue_ngap_id,
         reinterpret_cast<void**>(&ue_context_p));
+    if (h_rc != HASH_TABLE_OK)
+      OAILOG_TRACE(LOG_AMF_APP, "Error Could not remove this ue context \n");
     ue_context_p->amf_ue_ngap_id = INVALID_AMF_UE_NGAP_ID;
   }
 

--- a/lte/gateway/c/core/oai/tasks/amf/amf_recv.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_recv.cpp
@@ -40,14 +40,12 @@ int amf_handle_service_request(
     const amf_nas_message_decode_status_t decode_status) {
   int rc                         = RETURNok;
   ue_m5gmm_context_s* ue_context = nullptr;
-  bool tmsi_based_context_found  = false;
   notify_ue_event notify_ue_event_type;
   amf_sap_t amf_sap;
   tmsi_t tmsi_rcv;
   char imsi[IMSI_BCD_DIGITS_MAX + 1];
   char ip_str[INET_ADDRSTRLEN];
-  uint16_t pdu_session_status      = 0;
-  uint16_t pdu_reactivation_result = 0;
+  uint16_t pdu_session_status = 0;
   uint32_t tmsi_stored;
   paging_context_t* paging_ctx = nullptr;
   guti_and_amf_id_t guti_and_amf_id;

--- a/lte/gateway/c/core/oai/tasks/amf/amf_security_mode_control.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_security_mode_control.cpp
@@ -294,9 +294,7 @@ int amf_proc_security_mode_control(
   // TODO: Hardcoded values Will be taken care in upcoming PR
   int amf_eea       = 0;
   int amf_eia       = 0;  // Integrity Algorithm 2
-  uint8_t snni[32]  = {0};
   uint8_t ak_sqn[6] = {0};
-  amf_plmn_t plmn   = {0};
 
   OAILOG_DEBUG(
       LOG_NAS_AMF,

--- a/lte/gateway/c/core/oai/tasks/amf/amf_session_manager_pco.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_session_manager_pco.cpp
@@ -111,8 +111,6 @@ uint16_t sm_process_pco_request_ipcp(
   int16_t ipcp_req_remaining_length          = poc_id->length;
   size_t pco_in_index                        = 4;
 
-  struct sockaddr_in primary_dns_sa;
-  struct sockaddr_in secondry_dns_sa;
   uint8_t idp[6]          = {0};
   uint8_t ids[6]          = {0};
   int16_t ipcp_out_length = 0;

--- a/lte/gateway/c/core/oai/tasks/amf/nas5g_message.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/nas5g_message.cpp
@@ -1038,7 +1038,7 @@ std::string uint8_to_hex_string(const uint8_t* v, const size_t s) {
   std::stringstream ss;
 
   ss << std::hex << std::setfill('0');
-  for (int i = 0; i < s; i++) {
+  for (unsigned int i = 0; i < s; i++) {
     ss << std::hex << std::setw(2) << static_cast<int>(v[i]) << " ";
     if ((i + 1) % 8 == 0) ss << " ";
     if ((i + 1) % 16 == 0) ss << "\n";

--- a/lte/gateway/c/core/oai/tasks/ngap/ngap_amf_itti_messaging.c
+++ b/lte/gateway/c/core/oai/tasks/ngap/ngap_amf_itti_messaging.c
@@ -20,6 +20,7 @@
 #include "assertions.h"
 #include "intertask_interface.h"
 #include "Ngap_CauseRadioNetwork.h"
+#include "ngap_common.h"
 #include "nas/as_message.h"
 #include "intertask_interface_types.h"
 #include "itti_types.h"
@@ -57,7 +58,7 @@ status_code_e ngap_amf_itti_nas_uplink_ind(
     const ecgi_t* cgi) {
   MessageDef* message_p = NULL;
   imsi64_t imsi64       = INVALID_IMSI64;
-  OAILOG_DEBUG(
+  OAILOG_DEBUG_UE(
       LOG_NGAP, imsi64,
       "Sending NAS Uplink indication to NAS_AMF_APP, amf_ue_ngap_id = (%u) \n",
       ue_id);

--- a/lte/gateway/c/core/oai/tasks/ngap/ngap_amf_nas_procedures.c
+++ b/lte/gateway/c/core/oai/tasks/ngap/ngap_amf_nas_procedures.c
@@ -810,7 +810,7 @@ void ngap_handle_conn_est_cnf(
   ASN_SEQUENCE_ADD(&out->protocolIEs.list, ie);
 
   if (conn_est_cnf_pP->PDU_Session_Resource_Setup_Transfer_List.no_of_items) {
-    for (auto i = 0;
+    for (int i = 0;
          i <
          conn_est_cnf_pP->PDU_Session_Resource_Setup_Transfer_List.no_of_items;
          i++) {
@@ -862,7 +862,7 @@ void ngap_handle_conn_est_cnf(
       if (er.encoded <= 0) {
         OAILOG_ERROR(
             LOG_NGAP, "PDU Session Resource Request IE encode error \n");
-        OAILOG_FUNC_RETURN(LOG_NGAP, RETURNerror);
+        OAILOG_FUNC_OUT(LOG_NGAP);
       }
 
       asn_fprint(

--- a/lte/gateway/c/core/oai/tasks/ngap/ngap_common.h
+++ b/lte/gateway/c/core/oai/tasks/ngap/ngap_common.h
@@ -787,3 +787,12 @@ void ngap_handle_criticality(Ngap_Criticality_t criticality);
 status_code_e ngap_send_msg_to_task(
     task_zmq_ctx_t* task_zmq_ctx_p, task_id_t destination_task_id,
     MessageDef* message);
+
+/** \brief Setup a request transfer
+ \param session transfer pointer
+ \param pointer to transfer request
+ @returns 0 on success
+ **/
+int ngap_fill_pdu_session_resource_setup_request_transfer(
+    pdu_session_resource_setup_request_transfer_t* session_transfer,
+    Ngap_PDUSessionResourceSetupRequestTransfer_t* transfer_request);


### PR DESCRIPTION
Signed-off-by: Raphael Defosseux <raphael.defosseux@openairinterface.org>

## Summary

5G Pull Requests are incorporating a lot of compilation warnings.

I trimmed:

- `Ubuntu18` image --> 22 warnings downto 6
- `RHEL8` image --> 8 warnings downto 3

## Test Plan

None.

## Additional Information

- [ ] This change is backwards-breaking
