### PR TITLE
feat(ci): Turn up clang-format linter Github Action

### DIFF
--- a/.github/workflows/lint-clang-format.yml
+++ b/.github/workflows/lint-clang-format.yml
@@ -1,0 +1,24 @@
+---
+name: lint-clang-format
+on:  # yamllint disable-line rule:truthy
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+    paths:
+      - .github/workflows/lint-clang-format.yml
+      - lte/gateway/c/**
+      - orc8r/gateway/c/**
+
+jobs:
+  lint-clang-format:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: DoozyX/clang-format-lint-action@v0.12
+        with:
+          source: 'orc8r/gateway/c lte/gateway/c'
+          extensions: 'h,hpp,c,cpp'
+          clangFormatVersion: 7
+          style: file


### PR DESCRIPTION
In preparation for #6187 and #8203, turn up a [clang-format Github action](https://github.com/marketplace/actions/clang-format-lint).

This GH Action does not support linting of lines touched by the to-be-analyzed PR, so it will fail any PR for which any source in our repo does match our style.  This is probably OK once this check becomes `required` - but until it is required we may have people submitting unformatted code and blocking others from submission.

Signed-off-by: Scott Harrison Moeller <smoeller@fb.com>