### PR TITLE
chore: Address Python Formatting check from PR9007

### DIFF
--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_nw_initiated_detach_fail.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_nw_initiated_detach_fail.py
@@ -23,6 +23,7 @@ class TestAttachNwInitiatedDetachFail(unittest.TestCase):
     """
     S1AP Integration test for Failed Network Initiated Detach
     """
+
     def setUp(self):
         """Initialize s1ap wrapper and spgw utility
         """


### PR DESCRIPTION
Signed-off-by: Marie Bremner <marwhal@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary
Ran `./lte/gateway/python/precommit.py -f -p lte/gateway/python/integ_tests/s1aptests/test_attach_nw_initiated_detach_fail.py` to address Python Format Check failure from https://github.com/magma/magma/pull/9007
<!-- Enumerate changes you made and why you made them -->

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
