### PR TITLE
refactor(ci): move to uniform GH workflow naming for linters

### DIFF
--- a/.github/workflows/lint-cpplint.yml
+++ b/.github/workflows/lint-cpplint.yml
@@ -1,5 +1,5 @@
 ---
-name: Reviewdog
+name: lint-cpplint
 on:  # yamllint disable-line rule:truthy
   pull_request:
     types:
@@ -25,7 +25,7 @@ on:  # yamllint disable-line rule:truthy
 ##
 
 jobs:
-  cpplint:
+  lint-cpplint:
     runs-on: ubuntu-latest
     steps:
       -

--- a/.github/workflows/lint-hadolint.yml
+++ b/.github/workflows/lint-hadolint.yml
@@ -1,8 +1,8 @@
 ---
-name: Dockerfile Linting
+name: lint-hadolint
 on: [pull_request]  # yamllint disable-line rule:truthy
 jobs:
-  hadolint:
+  lint-hadolint:
     name: Dockerfile Lint
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/lint-misspell.yml
+++ b/.github/workflows/lint-misspell.yml
@@ -1,8 +1,8 @@
 ---
-name: reviewdog
+name: lint-misspell
 on: [pull_request]  # yamllint disable-line rule:truthy
 jobs:
-  misspell:
+  lint-misspell:
     name: runner / misspell
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/lint-shellcheck.yml
+++ b/.github/workflows/lint-shellcheck.yml
@@ -1,7 +1,7 @@
-name: reviewdog
+name: lint-shellcheck
 on: [pull_request]
 jobs:
-  shellcheck:
+  lint-shellcheck:
     name: runner / shellcheck
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/lint-wemake-python-styleguide.yml
+++ b/.github/workflows/lint-wemake-python-styleguide.yml
@@ -1,7 +1,7 @@
-name: Python linting by Reviewdog
+name: lint-wemake-python-styleguide
 on: [pull_request]
 jobs:
-  wemake-python-styleguide:
+  lint-wemake-python-styleguide:
     name: runner / wemake-python-styleguide
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/lint-yamllint.yml
+++ b/.github/workflows/lint-yamllint.yml
@@ -1,5 +1,5 @@
 ---
-name: YAML linting by Reviewdog
+name: lint-yamllint
 on:  # yamllint disable-line rule:truthy
   pull_request:
     types:
@@ -8,7 +8,7 @@ on:  # yamllint disable-line rule:truthy
       - synchronize
 
 jobs:
-  yamllint:
+  lint-yamllint:
     name: runner / yamllint
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
As requested by @quentinDERORY.

Changed workflow NAME for linters to drop the ReviewDog references and just name the tool being run.

While here, re-named all the workflow files to match the workflow NAME.

Signed-off-by: GitHub <noreply@github.com>