### PR TITLE
fix: apply Magma's clang-format spec to two outliers

### DIFF
--- a/lte/gateway/c/core/oai/tasks/nas/emm/Identification.c
+++ b/lte/gateway/c/core/oai/tasks/nas/emm/Identification.c
@@ -284,7 +284,8 @@ status_code_e emm_proc_identification_complete(
               &old_imsi_ue_mm_ctx->emm_context, ue_mm_context->mme_ue_s1ap_id,
               attach_proc->ies, true);
           emm_ctx->emm_context_state = NEW_EMM_CONTEXT_CREATED;
-          rc = nas_proc_implicit_detach_ue_ind(old_imsi_ue_mm_ctx->mme_ue_s1ap_id);
+          rc                         = nas_proc_implicit_detach_ue_ind(
+              old_imsi_ue_mm_ctx->mme_ue_s1ap_id);
           OAILOG_FUNC_RETURN(LOG_NAS_EMM, rc);
         }
         int emm_cause = check_plmn_restriction(*imsi);


### PR DESCRIPTION
In preparation for #6187 and #8203.

```shell
root@00c8cda064a0:/magma# clang-format --style=file -i lte/gateway/c/session_manager/RedisMap.hpp
root@00c8cda064a0:/magma# clang-format --style=file -i lte/gateway/c/core/oai/tasks/nas/emm/Identification.c
```

This has enabled the new lint-clang-format github Action to pass (see Checks above).

Signed-off-by: Scott Harrison Moeller <smoeller@fb.com>