### PR TITLE
chore(agw): add configuration for controlling GTP-U checksum

### DIFF
--- a/lte/gateway/c/core/oai/include/sgw_config.h
+++ b/lte/gateway/c/core/oai/include/sgw_config.h
@@ -60,6 +60,7 @@
 #define SGW_CONFIG_STRING_OVS_UPLINK_MAC "UPLINK_MAC"
 #define SGW_CONFIG_STRING_OVS_MULTI_TUNNEL "MULTI_TUNNEL"
 #define SGW_CONFIG_STRING_OVS_GTP_ECHO "GTP_ECHO"
+#define SGW_CONFIG_STRING_OVS_GTP_CHECKSUM "GTP_CHECKSUM"
 #define SGW_CONFIG_STRING_AGW_L3_TUNNEL "AGW_L3_TUNNEL"
 #define SGW_CONFIG_STRING_OVS_PIPELINED_CONFIG_ENABLED                         \
   "PIPELINED_CONFIG_ENABLED"
@@ -78,6 +79,7 @@ typedef struct ovs_config_s {
   bool multi_tunnel;
   bool gtp_echo;
   bool pipelined_managed_tbl0;
+  bool gtp_csum;
 } ovs_config_t;
 
 typedef struct sgw_config_s {

--- a/lte/gateway/c/core/oai/tasks/gtpv1-u/gtp_tunnel_openflow.c
+++ b/lte/gateway/c/core/oai/tasks/gtpv1-u/gtp_tunnel_openflow.c
@@ -156,6 +156,7 @@ static uint32_t create_gtp_port(
     struct in_addr enb_addr, char port_name[], bool is_pgw) {
   char gtp_port_create[512];
   char* gtp_echo;
+  char* gtp_csum;
   char* l3_tunnel;
   int rc;
 
@@ -165,6 +166,12 @@ static uint32_t create_gtp_port(
     gtp_echo = "false";
   }
 
+  if (spgw_config.sgw_config.ovs_config.gtp_csum) {
+    gtp_csum = "true";
+  } else {
+    gtp_csum = "false";
+  }
+
   if (is_pgw && spgw_config.sgw_config.agw_l3_tunnel) {
     l3_tunnel = "true";
   } else {
@@ -172,8 +179,8 @@ static uint32_t create_gtp_port(
   }
   rc = snprintf(
       gtp_port_create, sizeof(gtp_port_create),
-      "sudo /usr/local/bin/magma-create-gtp-port.sh %s %s %s %s", port_name,
-      inet_ntoa(enb_addr), gtp_echo, l3_tunnel);
+      "sudo /usr/local/bin/magma-create-gtp-port.sh %s %s %s %s %s", port_name,
+      inet_ntoa(enb_addr), gtp_echo, gtp_csum, l3_tunnel);
   if (rc < 0) {
     OAILOG_ERROR(LOG_GTPV1U, "gtp-port create: format error %d", rc);
     return rc;

--- a/lte/gateway/c/core/oai/tasks/sgw/sgw_config.c
+++ b/lte/gateway/c/core/oai/tasks/sgw/sgw_config.c
@@ -313,6 +313,7 @@ status_code_e sgw_config_parse_file(sgw_config_t* config_pP)
     char* multi_tunnel                          = NULL;
     char* agw_l3_tunnel                         = NULL;
     char* gtp_echo                              = NULL;
+    char* gtp_csum                              = NULL;
 
     char* uplink_mac             = NULL;
     char* pipelined_managed_tbl0 = NULL;
@@ -341,6 +342,9 @@ status_code_e sgw_config_parse_file(sgw_config_t* config_pP)
         config_setting_lookup_string(
             ovs_settings, SGW_CONFIG_STRING_OVS_GTP_ECHO,
             (const char**) &gtp_echo) &&
+        config_setting_lookup_string(
+            ovs_settings, SGW_CONFIG_STRING_OVS_GTP_CHECKSUM,
+            (const char**) &gtp_csum) &&
         config_setting_lookup_string(
             ovs_settings, SGW_CONFIG_STRING_AGW_L3_TUNNEL,
             (const char**) &agw_l3_tunnel) &&
@@ -378,6 +382,12 @@ status_code_e sgw_config_parse_file(sgw_config_t* config_pP)
         config_pP->ovs_config.gtp_echo = false;
       }
       OAILOG_INFO(LOG_SPGW_APP, "GTP-U echo response enable: %s\n", gtp_echo);
+      if (strcasecmp(gtp_csum, "true") == 0) {
+        config_pP->ovs_config.gtp_csum = true;
+      } else {
+        config_pP->ovs_config.gtp_csum = false;
+      }
+      OAILOG_INFO(LOG_SPGW_APP, "GTP-U checksum enable: %s\n", gtp_csum);
 
       if (strcasecmp(agw_l3_tunnel, "true") == 0) {
         config_pP->agw_l3_tunnel = true;

--- a/lte/gateway/configs/spgw.yml
+++ b/lte/gateway/configs/spgw.yml
@@ -51,3 +51,7 @@ ovs_gtpu_echo_resp: true
 
 # To enable PGW tunnel over wireguard tunneling
 agw_l3_tunnel: false
+
+# To enable UDP checksum for GTP-U tunnel
+# This might have performance overhead depending of NIC capability.
+ovs_gtpu_checksum: false

--- a/lte/gateway/configs/templates/spgw.conf.template
+++ b/lte/gateway/configs/templates/spgw.conf.template
@@ -47,6 +47,7 @@ S-GW :
       UPLINK_MAC                           = "{{ ovs_uplink_mac }}";
       MULTI_TUNNEL                         = "{{ ovs_multi_tunnel }}";
       GTP_ECHO                             = "{{ ovs_gtpu_echo_resp }}";
+      GTP_CHECKSUM                         = "{{ ovs_gtpu_checksum }}";
       AGW_L3_TUNNEL                        = "{{ agw_l3_tunnel }}";
       PIPELINED_CONFIG_ENABLED             = "{{ pipelined_managed_tbl0 }}";
     };

--- a/lte/gateway/deploy/roles/magma/files/magma-create-gtp-port.sh
+++ b/lte/gateway/deploy/roles/magma/files/magma-create-gtp-port.sh
@@ -13,13 +13,14 @@
 port_name=$1
 enb_addr=$2
 gtp_echo=$3
-enable_wg_tuneling=$4
+gtp_csum=$4
+enable_wg_tuneling=$5
 
 wg_setup_utility="/usr/local/bin/magma-setup-wg.sh"
 wg_key_dir="/var/opt/magma/sgi-tunnel"
 bfd_time=5000
 
-sudo ovs-vsctl --may-exist add-port gtp_br0 $port_name -- set Interface $port_name type=gtpu options:remote_ip=$enb_addr options:key=flow bfd:enable=$gtp_echo bfd:min_tx=$bfd_time bfd:min_rx=$bfd_time
+sudo ovs-vsctl --may-exist add-port gtp_br0 $port_name -- set Interface $port_name type=gtpu options:remote_ip=$enb_addr options:key=flow bfd:enable=$gtp_echo options:csum=$gtp_csum bfd:min_tx=$bfd_time bfd:min_rx=$bfd_time
 
 if [[ $enable_wg_tuneling == "true" ]]; then
   $wg_setup_utility $wg_key_dir $enb_addr


### PR DESCRIPTION
Few eNBs expects UDP checksum for GTP-U tunnel. But calculating 
checksum has cost on AGW. so following patch adds support to enable it
selective basis.


Signed-off-by: Pravin B Shelar <pbshelar@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->

## Test Plan
validated  on magma-dev using integ tests.
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
