### PR TITLE
chore: federated integ test part 1

### DIFF
--- a/lte/gateway/configs/subscriberdb.yml
+++ b/lte/gateway/configs/subscriberdb.yml
@@ -12,9 +12,9 @@
 # limitations under the License.
 
 # log_level is set in mconfig. it can be overridden here
-
+log_level: DEBUG
 # Append GRPC content to the log
-print_grpc_payload: False
+print_grpc_payload: True
 
 # Size of subscriber pages returned from cloud
 subscriber_page_size: 5000

--- a/lte/gateway/configs/subscriberdb.yml
+++ b/lte/gateway/configs/subscriberdb.yml
@@ -12,9 +12,9 @@
 # limitations under the License.
 
 # log_level is set in mconfig. it can be overridden here
-log_level: DEBUG
+
 # Append GRPC content to the log
-print_grpc_payload: True
+print_grpc_payload: false
 
 # Size of subscriber pages returned from cloud
 subscriber_page_size: 5000

--- a/lte/gateway/deploy/magma_dev_focal.yml
+++ b/lte/gateway/deploy/magma_dev_focal.yml
@@ -18,6 +18,7 @@
 
   vars:
     magma_root: /home/{{ ansible_user }}/magma
+    user: "{{ ansible_user }}"
     preburn: false
     full_provision: true
 
@@ -49,3 +50,9 @@
         magma_deps: /home/{{ ansible_user }}/magma-deps
     - role: fluent_bit
     - role: pyvenv
+
+  tasks:
+    # Only run installation for docker
+    - include_role:
+        name: docker
+        tasks_from: install

--- a/lte/gateway/dev_tools.py
+++ b/lte/gateway/dev_tools.py
@@ -11,6 +11,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
+import os
 import sys
 from typing import Any, List
 
@@ -40,7 +41,14 @@ def register_vm():
                 lte_auth_amf='gAA=',
                 lte_auth_op='EREREREREREREREREREREQ==',
                 mcc='001', mnc='01', tac=1,
-                relay_enabled=False,
+                gx_gy_relay_enabled=False,
+                hss_relay_enabled=False,
+                network_services=[],
+                mobility=MobilityConfig(
+                    ip_allocation_mode='NAT',
+                    nat=NatConfig(['192.168.128.0/24']),
+                    reserved_addresses=[],
+                ),
             ),
             ran=NetworkRANConfig(
                 bandwidth_mhz=20,
@@ -49,6 +57,7 @@ def register_vm():
                     subframe_assignment=2, special_subframe_pattern=7,
                 ),
             ),
+            feg_network_id="",
         ),
         dns=types.NetworkDNSConfig(enable_caching=False, local_ttl=60),
     )
@@ -66,7 +75,14 @@ def register_federated_vm():
                 lte_auth_amf='gAA=',
                 lte_auth_op='EREREREREREREREREREREQ==',
                 mcc='001', mnc='01', tac=1,
-                relay_enabled=False,
+                gx_gy_relay_enabled=False,
+                hss_relay_enabled=True,
+                network_services=['dpi', 'policy_enforcement'],
+                mobility=MobilityConfig(
+                    ip_allocation_mode='NAT',
+                    nat=NatConfig(['192.168.128.0/24']),
+                    reserved_addresses=[],
+                ),
             ),
             ran=NetworkRANConfig(
                 bandwidth_mhz=20,
@@ -75,12 +91,32 @@ def register_federated_vm():
                     subframe_assignment=2, special_subframe_pattern=7,
                 ),
             ),
+            feg_network_id='feg_test',
         ),
         dns=types.NetworkDNSConfig(enable_caching=False, local_ttl=60),
         federation=FederationNetworkConfig(feg_network_id='feg_test'),
     )
     _register_network(FEG_LTE_NETWORK_TYPE, network_payload)
+    # registering gateway with LTE type. FEG_LTE doesn't have gateway endpoint
     _register_agw(FEG_LTE_NETWORK_TYPE)
+
+
+def deregister_agw():
+    dev_utils.delete_agw_certs('magma')
+    _deregister_agw(LTE_NETWORK_TYPE)
+
+
+def deregister_federated_agw():
+    dev_utils.delete_agw_certs('magma')
+    _deregister_agw(FEG_LTE_NETWORK_TYPE)
+
+
+def register_feg_on_magma_vm():
+    os.system('fab -f ../../feg/gateway/fabfile.py register_feg')
+
+
+def deregister_feg_gw_on_magma_vm():
+    os.system('fab -f ../../feg/gateway/fabfile.py deregister_feg_gw:magma')
 
 
 def _register_network(network_type: str, payload: Any):
@@ -119,10 +155,31 @@ def _register_agw(network_type: str):
         ),
         connected_enodeb_serials=[],
     )
-    dev_utils.cloud_post(f'{network_type}/{network_id}/gateways', gw_payload)
+    dev_utils.cloud_post(f'lte/{network_id}/gateways', gw_payload)
     print()
     print(f'=========================================')
     print(f'Gateway {gw_id} successfully provisioned!')
+    print(f'=========================================')
+
+
+def _deregister_agw(network_type: str):
+    network_id = NIDS_BY_TYPE[network_type]
+    hw_id = dev_utils.get_hardware_id_from_vagrant(vm_name='magma')
+    already_registered, registered_as = dev_utils.is_hw_id_registered(
+        network_id, hw_id,
+    )
+    if not already_registered:
+        print()
+        print(f'===========================================')
+        print(f'VM is not registered (hwid: {hw_id} )')
+        print(f'===========================================')
+        return
+
+    dev_utils.cloud_delete(f'lte/{network_id}/gateways/{registered_as}')
+    print()
+    print(f'=========================================')
+    print(f'AGW Gateway {registered_as} successfully removed!')
+    print(f'(restart AGW services on magma vm)')
     print(f'=========================================')
 
 
@@ -142,25 +199,49 @@ class NetworkRANConfig:
         self.tdd_config = tdd_config
 
 
+class NatConfig:
+    def __init__(self, ip_blocks: List[str]):
+        self.ip_blocks = ip_blocks
+
+
+class MobilityConfig:
+    def __init__(
+        self, ip_allocation_mode: str, nat: NatConfig,
+        reserved_addresses: List[str],
+    ):
+        self.ip_allocation_mode = ip_allocation_mode
+        self.nat = nat
+        self.reserved_addresses = reserved_addresses
+
+
 class NetworkEPCConfig:
     def __init__(
         self, lte_auth_amf: str, lte_auth_op: str,
         mcc: str, mnc: str, tac: int,
-        relay_enabled: bool,
+        gx_gy_relay_enabled: bool, hss_relay_enabled: bool,
+        network_services: List[str],
+        mobility: MobilityConfig,
     ):
         self.lte_auth_amf = lte_auth_amf
         self.lte_auth_op = lte_auth_op
         self.mcc = mcc
         self.mnc = mnc
         self.tac = tac
-        self.gx_gy_relay_enabled = relay_enabled
-        self.hss_relay_enabled = relay_enabled
+        self.gx_gy_relay_enabled = gx_gy_relay_enabled
+        self.hss_relay_enabled = hss_relay_enabled
+        self.default_rule_id = "default_rule_1"
+        self.network_services = network_services
+        self.mobility = mobility
 
 
 class NetworkCellularConfig:
-    def __init__(self, epc: NetworkEPCConfig, ran: NetworkRANConfig):
+    def __init__(
+        self, epc: NetworkEPCConfig, ran: NetworkRANConfig,
+        feg_network_id: str,
+    ):
         self.epc = epc
         self.ran = ran
+        self.feg_network_id = feg_network_id
 
 
 class LTENetwork:
@@ -206,6 +287,8 @@ class GatewayEPCConfig:
     def __init__(self, ip_block: str, nat_enabled: bool):
         self.ip_block = ip_block
         self.nat_enabled = nat_enabled
+        self.dns_primary = "8.8.8.8"
+        self.dns_secondary = "8.8.4.4"
 
 
 class GatewayCellularConfig:

--- a/lte/gateway/fabfile.py
+++ b/lte/gateway/fabfile.py
@@ -464,6 +464,16 @@ def load_test(gateway_host=None, destroy_vm=True):
 
 
 def build_and_start_magma(gateway_host=None, destroy_vm='False', provision_vm='False'):
+    """
+    Build Magma AGW and starts magma
+    Args:
+        gateway_host: name of host in case is not Vagrant
+        destroy_vm: if set to True it will destroy Magma Vagrant VM
+        provision_vm: if set to true it will reprovision Magma VM
+
+    Returns:
+
+    """
     provision_vm = bool(strtobool(provision_vm))
     destroy_vm = bool(strtobool(destroy_vm))
     if gateway_host:
@@ -499,7 +509,7 @@ def start_magma(test_host=None, destroy_vm='False', provision_vm='False'):
     destroy_vm = bool(strtobool(destroy_vm))
     provision_vm = bool(strtobool(provision_vm))
     if not test_host:
-        vagrant_setup('magma_trfserver', destroy_vm, force_provision=provision_vm)
+        vagrant_setup('magma', destroy_vm, force_provision=provision_vm)
     else:
         ansible_setup(test_host, "test", "magma_test.yml")
     sudo('service magma@magmad start')
@@ -527,7 +537,9 @@ def _dist_upgrade():
 
 
 def _build_magma():
-    """ Builds ma_build_magmagma """
+    """
+    Build magma on AGW
+    """
     with cd(AGW_ROOT):
         run('make')
 
@@ -576,22 +588,22 @@ def _start_trfserver():
         ' sh -c "sudo ethtool --offload eth1 rx off tx off; '
         '";'
         % (key, host, port),
-        )
+    )
     local(
         'ssh -f -i %s -o UserKnownHostsFile=/dev/null'
         ' -o StrictHostKeyChecking=no -tt %s -p %s'
         ' sh -c "sudo ethtool --offload eth2 rx off tx off; '
         'nohup sudo /usr/local/bin/traffic_server.py 192.168.60.144 62462 > /dev/null 2>&1";'
         % (key, host, port),
-        )
+    )
     local(
         'ssh -f -i %s -o UserKnownHostsFile=/dev/null'
         ' -o StrictHostKeyChecking=no -tt %s -p %s'
         ' sh -c "'
         'nohup sudo /usr/local/bin/traffic_server.py 192.168.60.144 62462 > /dev/null 2>&1";'
         % (key, host, port),
-        )
-    #local(
+    )
+    # local(
     #    'stty cbreak'
     #    )
 

--- a/lte/gateway/python/integ_tests/federated_tests/README.md
+++ b/lte/gateway/python/integ_tests/federated_tests/README.md
@@ -1,0 +1,95 @@
+---
+id: federated_integ_test
+title: Federated Integration Tests
+hide_title: true
+---
+# Federated Integration Tests (EXPERIMENTAL)
+
+The objective of Federated Integration Tests is to provide a test platform
+where to run Magma with all its components.
+
+As the diagram indicates, this test spins up AGW, FEG and Orc8r
+and uses S1aP and trf server to run tests.
+
+```mermaid
+graph LR;
+    S1AP --> AGW --> orc8r --> FEG --> 3ggp_CORE;
+    3ggp_CORE --> FEG --> orc8r --> AGW --> S1AP;
+    AGW --> trf_server;
+    trf_server --> AGW;
+```
+
+The processes will run on the following machines:
+- AGW will run on **magma** vm.
+- FEG and Orc8r will run on our **local docker**.
+- Traffic server will run on **magma_trf** vm
+- Test will be started from **magma_test** vm
+
+## Build environment
+### Automatic build
+On your host machine go to
+`cd  magma/lte/gateway/python/integ_tests/federated_tests` and run
+```
+fab build_all
+```
+Once it is built, start the traffic and test vm
+```
+cd magma/lte/gateway
+vagrant up magma_test
+vagrant up magma_trf
+```
+
+### Manual build
+If you want to build the environment manually:
+- AGW:
+```
+cd magma/lte/gateway
+vagrant up magma
+vagrant ssh magma
+# inside vagrant vm
+cd magma/lte/gateway
+make run
+```
+- FEG:
+```
+cd magma/lte/gateway/python/integ_tests/federated_tests/docker
+docker-compose build
+docker-compose up -d
+```
+Orc8r
+```
+cd magma/orc8r/cloud/docker
+./build -a
+./run
+# return to agw folder
+cd magma/lte/gateway
+# register gateways
+fab --fabfile=dev_tools.py register_federated_vm
+fab --fabfile=dev_tools.py register_feg_on_magma_vm
+```
+Test vm
+```
+cd magma/lte/gateway
+vagrant up magma_test
+vagrannt ssh magma_test
+# inside vagrant vm
+cd magma/lte/gateway/python
+make
+```
+Traffic vm
+```
+cd magma/lte/gateway
+vagrant up magma_trf
+```
+
+## Run test
+
+Once you have built all the vms, you can try to run a test from
+`magma_test` vm
+```
+cd magma/lte/gateway
+vagrannt ssh magma_test
+# inside vagrant vm
+cd magma/lte/gateway/python/integ_test
+make integ_test TESTS=s1aptests/test_attach_detach.py
+```

--- a/lte/gateway/python/integ_tests/federated_tests/README.md
+++ b/lte/gateway/python/integ_tests/federated_tests/README.md
@@ -25,39 +25,78 @@ The processes will run on the following machines:
 - Traffic server will run on **magma_trf** vm
 - Test will be started from **magma_test** vm
 
+Note commands for AGW will have to be run inside the vagrant VM. That is
+why all the actions include the `vagrant ssh magma` command first. To leave
+from vagrant just type `exit`. FEG and Orc8r will need to be run in the
+host itself (no vagrant involved)
+
 ## Build environment
 ### Automatic build
-On your host machine go to
-`cd  magma/lte/gateway/python/integ_tests/federated_tests` and run
-```
+On your host machine do
+```bash
+cd magma/lte/gateway/python/integ_tests/federated_tests
 fab build_all
 ```
-Once it is built, start the traffic and test vm
+That will build AGW, FEG and Orc8r and start them all. It will also try to
+register a federated AGW and a FEG gateway. After this is run you can check
+if your gateways have been bootstrapped using magmad logs at AGW and FEG
+```bash
+#on AGW
+cd magma/lte/gateway
+vagrant ssh magma
+sudo service magma@magmad logs
+# exit from vagrant vm
+exit
+
+#on FEG
+cd magma/lte/gateway/python/integ_tests/federated_tests
+docker-compose logs -f magmad
 ```
+
+You can also confirm communication between AGW-ORC8R-FEG using `feg_hello_cli`
+```bash
+cd magma/lte/gateway
+vagrant ssh magma
+magtivate
+#this will let you access to a specific pyton environment
+feg_hello_cli.py m 0
+# which will return something like:
+# resp:  greeting: "m"
+
+# exit from vagrant vm
+exit
+```
+
+
+Once it is built, start the traffic and test vm
+```bash
 cd magma/lte/gateway
 vagrant up magma_test
-vagrant up magma_trf
+vagrant up magma_trfserver
 ```
 
 ### Manual build
 If you want to build the environment manually:
 - AGW:
-```
+```bash
 cd magma/lte/gateway
 vagrant up magma
 vagrant ssh magma
 # inside vagrant vm
 cd magma/lte/gateway
 make run
+
+# exit from vagrant vm
+exit
 ```
 - FEG:
-```
+```bash
 cd magma/lte/gateway/python/integ_tests/federated_tests/docker
 docker-compose build
 docker-compose up -d
 ```
 Orc8r
-```
+```bash
 cd magma/orc8r/cloud/docker
 ./build -a
 ./run
@@ -65,31 +104,40 @@ cd magma/orc8r/cloud/docker
 cd magma/lte/gateway
 # register gateways
 fab --fabfile=dev_tools.py register_federated_vm
-fab --fabfile=dev_tools.py register_feg_on_magma_vm
+fab --fabfile=dev_tools.py register_feg_gw
 ```
 Test vm
-```
+```bash
 cd magma/lte/gateway
 vagrant up magma_test
 vagrannt ssh magma_test
 # inside vagrant vm
 cd magma/lte/gateway/python
 make
+
+# exit from vagrant vm
+exit
 ```
 Traffic vm
-```
+```bash
 cd magma/lte/gateway
-vagrant up magma_trf
+vagrant up magma_trfserver
+
+# exit from vagrant vm
+exit
 ```
 
 ## Run test
 
 Once you have built all the vms, you can try to run a test from
 `magma_test` vm
-```
+```bash
 cd magma/lte/gateway
 vagrannt ssh magma_test
 # inside vagrant vm
 cd magma/lte/gateway/python/integ_test
 make integ_test TESTS=s1aptests/test_attach_detach.py
+
+# exit from vagrant vm
+exit
 ```

--- a/lte/gateway/python/integ_tests/federated_tests/configs/magmad_legacy.yml
+++ b/lte/gateway/python/integ_tests/federated_tests/configs/magmad_legacy.yml
@@ -1,0 +1,74 @@
+---
+# Copyright 2020 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+log_level: INFO
+# List of services for magmad to control
+magma_services:
+  - control_proxy
+  - redis
+  - session_proxy
+  - s6a_proxy
+  - csfb
+  - feg_hello
+  - health
+  - swx_proxy
+  - eap_aka
+  - aaa_server
+
+# List of services that don't provide service303 interface
+non_service303_services:
+  - control_proxy
+  - redis
+
+# Init system to use to control services
+# Supported systems include: [systemd, runit, docker]
+init_system: systemd
+
+# bootstrap_manager config
+bootstrap_config:
+  # location of the challenge key
+  challenge_key: /var/opt/magma/certs/gw_challenge.key
+
+# Flags indicating the magmad features to be enabled
+enable_config_streamer: True
+enable_upgrade_manager: False
+enable_network_monitor: False
+enable_systemd_tailer: True
+enable_sync_rpc: True
+
+systemd_tailer_poll_interval: 30 # seconds
+
+upgrader_factory:
+  module: magma.magmad.upgrade.feg_upgrader
+  class: FegUpgraderFactory
+  http_base_url: https://api.magma.test/s3/feg
+
+mconfig_modules:
+  - orc8r.protos.mconfig.mconfigs_pb2
+  - lte.protos.mconfig.mconfigs_pb2
+  - feg.protos.mconfig.mconfigs_pb2
+
+metricsd:
+  log_level: INFO
+  collect_interval: 60 # How frequently to collect metrics samples in seconds
+  sync_interval: 60 # How frequently to sync to cloud in seconds
+  grpc_timeout: 10 # Timeout in seconds
+  # List of services for metricsd to poll
+  services:
+    - magmad
+    - session_proxy
+    - s6a_proxy
+    - swx_proxy
+    - eap_aka
+    - aaa_server
+    - csfb
+

--- a/lte/gateway/python/integ_tests/federated_tests/docker/docker-compose.override.yml
+++ b/lte/gateway/python/integ_tests/federated_tests/docker/docker-compose.override.yml
@@ -1,8 +1,8 @@
 version: "3.7"
 
 services:
-  test:
-    container_name: test
+  test2:
+    container_name: test2
     image: feg_gateway_go_base
     build:
       target: base
@@ -37,7 +37,7 @@ services:
 
   control_proxy:
     depends_on:
-      - test
+      - test2
     extra_hosts:
       - controller.magma.test:127.0.0.1
       - bootstrapper-controller.magma.test:127.0.0.1
@@ -57,7 +57,7 @@ services:
 
   magmad:
     depends_on:
-      - test
+      - test2
     build:
       context: ${BUILD_CONTEXT}
       dockerfile: feg/gateway/docker/python/Dockerfile

--- a/lte/gateway/python/integ_tests/federated_tests/docker/docker-compose.yml
+++ b/lte/gateway/python/integ_tests/federated_tests/docker/docker-compose.yml
@@ -116,8 +116,8 @@ services:
     <<: *goservice
     container_name: s6a_proxy
     environment:
-      MAGMA_PRINT_GRPC_PAYLOAD: 0
-    command: envdir /var/opt/magma/envdir /var/opt/magma/bin/s6a_proxy -logtostderr=true -v=0
+      MAGMA_PRINT_GRPC_PAYLOAD: 1
+    command: envdir /var/opt/magma/envdir /var/opt/magma/bin/s6a_proxy -logtostderr=true -v=9
 
 
   s8_proxy:

--- a/lte/gateway/python/integ_tests/federated_tests/fabfile.py
+++ b/lte/gateway/python/integ_tests/federated_tests/fabfile.py
@@ -1,0 +1,161 @@
+"""
+Copyright 2020 The Magma Authors.
+
+This source code is licensed under the BSD-style license found in the
+LICENSE file in the root directory of this source tree.
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import subprocess
+import sys
+from distutils.util import strtobool
+
+from fabric.api import cd, env, execute, hide, run
+
+sys.path.append('../../../../../orc8r')
+
+
+magma_path = "../../../../../"
+orc8_docker_path = magma_path + "orc8r/cloud/docker/"
+feg_path = magma_path + "feg/gateway/"
+feg_docker_path = feg_path + "docker/"
+agw_path = magma_path + "lte/gateway/"
+
+vagrant_agw_path = "~/lte/gateway"
+
+
+def build_all(clear_orc8r='False', provision_vm='False'):
+    """ Builds AGW, FEG and Orc8r and starts them
+
+        clear_orc8r: removes all contents from orc8r database like gw configs
+
+        force_provision: forces the reprovision of the magma VM
+    """
+
+    clear_orc8r = bool(strtobool(clear_orc8r))
+    execute(build_agw, provision_vm=provision_vm)
+    execute(build_feg)
+    execute(build_orc8r)
+    execute(start_orc8r)
+    if clear_orc8r:
+        execute(clear_orc8r)
+        execute(start_orc8r)
+
+    execute(build_test_vm, provision_vm=provision_vm)
+    execute(build_magma_trf, provision_vm=provision_vm)
+
+    # do this at the end to make sure or8cr is running
+    execute(configure_orc8r)
+
+
+def build_orc8r():
+    """build_orc8r builds orc8r locally on the host VM"""
+    subprocess.check_call('./build.py -a', shell=True, cwd=orc8_docker_path)
+
+
+def start_orc8r():
+    subprocess.check_call(['./run.py'], shell=True, cwd=orc8_docker_path)
+
+
+def configure_orc8r():
+    print(f'#### Configuring orc8r ####')
+    subprocess.check_call(
+        'fab --fabfile=dev_tools.py register_federated_vm',
+        shell=True, cwd=agw_path,
+    )
+    subprocess.check_call(
+        'fab --fabfile=dev_tools.py register_feg_on_magma_vm', shell=True, cwd=agw_path,
+    )
+
+
+def reconfigure_orc8r():
+    print(f'#### Removing VMs from orc8r ####')
+    subprocess.check_call(
+        'fab --fabfile=dev_tools.py deregister_federated_agw', shell=True, cwd=agw_path,
+    )
+    subprocess.check_call(
+        'fab --fabfile=dev_tools.py deregister_feg_gw_on_magma_vm',
+        shell=True, cwd=agw_path,
+    )
+    execute(configure_orc8r)
+
+
+def clear_orc8r():
+    print(f'#### Clearing swagger database from Orc8r ####')
+    subprocess.check_call(['./run.py --clear_db'], shell=True, cwd=orc8_docker_path)
+    print(
+        f'#### Remember you may need to delete '
+        f'gateway certs from the AGW and FEG ####',
+    )
+
+
+def build_agw(provision_vm='False'):
+    print(f'#### Building AGW ####')
+    subprocess.check_call('vagrant up magma', shell=True, cwd=agw_path)
+    subprocess.check_call(
+        'fab build_and_start_magma:provision_vm=%s'
+        % provision_vm, shell=True, cwd=agw_path,
+    )
+
+
+def build_feg(provision_vm='False'):
+    print(f'#### Building FEG ####')
+    subprocess.check_call(
+        'docker-compose down', shell=True,
+        cwd=feg_docker_path,
+    )
+    subprocess.check_call(
+        'docker-compose build', shell=True,
+        cwd=feg_docker_path,
+    )
+    subprocess.check_call(
+        'docker-compose up -d', shell=True,
+        cwd=feg_docker_path,
+    )
+
+
+def build_test_vm(provision_vm='False'):
+    print(f'#### Building test vm ####')
+    subprocess.check_call('vagrant up magma_test', shell=True, cwd=agw_path)
+    subprocess.check_call(
+        'fab make_integ_tests:provision_vm=%s'
+        % provision_vm, shell=True, cwd=agw_path,
+    )
+
+
+def build_magma_trf(provision_vm='False'):
+    print(f'#### Building Traffic vm ####')
+    subprocess.check_call('vagrant up magma_trf', shell=True, cwd=agw_path)
+    subprocess.check_call(
+        'fab build_and_start_magma_trf:provision_vm=%s'
+        % provision_vm, shell=True, cwd=agw_path,
+    )
+
+
+def start_all(provision_vm='False'):
+    subprocess.check_call(['./run.py'], shell=True, cwd=orc8_docker_path)
+    subprocess.check_call('docker-compose up', shell=True, cwd=feg_docker_path)
+    subprocess.check_call(
+        'fab start_magma:provision_vm=%s' % provision_vm,
+        shell=True, cwd=agw_path,
+    )
+
+
+def stop_all():
+    subprocess.check_call(
+        ['./run.py --down'], shell=True,
+        cwd=orc8_docker_path,
+    )
+    subprocess.check_call(
+        'docker-compose down', shell=True,
+        cwd=feg_docker_path,
+    )
+    subprocess.check_call(
+        'vagrant halt magma', shell=True,
+        cwd=agw_path,
+    )

--- a/orc8r/cloud/docker/docker-compose.yml
+++ b/orc8r/cloud/docker/docker-compose.yml
@@ -7,6 +7,7 @@ services:
   controller:
     volumes:
       - $PWD/../../../.cache/test_certs:/var/opt/magma/certs
+      # log level can be modified at supervisord.conf without the need of building a new image
       - $PWD/controller/supervisord.conf:/etc/supervisor/conf.d/supervisord.conf
     environment:
       TEST_MODE: "1"  # Run dev scripts on startup

--- a/orc8r/cloud/docker/docker-compose.yml
+++ b/orc8r/cloud/docker/docker-compose.yml
@@ -7,6 +7,7 @@ services:
   controller:
     volumes:
       - $PWD/../../../.cache/test_certs:/var/opt/magma/certs
+      - $PWD/controller/supervisord.conf:/etc/supervisor/conf.d/supervisord.conf
     environment:
       TEST_MODE: "1"  # Run dev scripts on startup
       SERVICE_HOSTNAME: localhost  # All services are reachable through localhost
@@ -17,6 +18,7 @@ services:
       SERVICE_REGISTRY_MODE: yaml
       VERSION_TAG: LOCAL-DEV
       HELM_VERSION_TAG: LOCAL-DEV
+      MAGMA_PRINT_GRPC_PAYLOAD: 0
     links:
       - fluentd
     depends_on:

--- a/orc8r/cloud/docker/run.py
+++ b/orc8r/cloud/docker/run.py
@@ -54,7 +54,7 @@ def main() -> None:
         try:
             cmd = ['docker-compose', 'down']
             subprocess.run(cmd, check=True)
-            cmd = ['docker', 'volume', 'rm', '-f', 'orc8r_pgdata']
+            cmd = ['docker', 'volume', 'rm', '--force', 'orc8r_pgdata']
             subprocess.run(cmd, check=True)
         except subprocess.CalledProcessError as err:
             exit(err.returncode)
@@ -138,9 +138,9 @@ def _parse_args() -> argparse.Namespace:
     )
 
     parser.add_argument(
-        '--clear_db', '-b',
+        '--clear-db',
         action='store_true',
-        help='Clear contents of pgdata database (swagger api)',
+        help='Clear all content on the database',
     )
 
     args = parser.parse_args()

--- a/orc8r/cloud/docker/run.py
+++ b/orc8r/cloud/docker/run.py
@@ -50,6 +50,16 @@ def main() -> None:
     if args.print:
         return
 
+    if args.clear_db:
+        try:
+            cmd = ['docker-compose', 'down']
+            subprocess.run(cmd, check=True)
+            cmd = ['docker', 'volume', 'rm', '-f', 'orc8r_pgdata']
+            subprocess.run(cmd, check=True)
+        except subprocess.CalledProcessError as err:
+            exit(err.returncode)
+        return
+
     # Ensure build context exists, otherwise docker-compose throws an error
     pathlib.Path(HOST_BUILD_CTX).mkdir(parents=True, exist_ok=True)
 
@@ -125,6 +135,12 @@ def _parse_args() -> argparse.Namespace:
         '--down', '-d',
         action='store_true',
         help='Stop running containers',
+    )
+
+    parser.add_argument(
+        '--clear_db', '-b',
+        action='store_true',
+        help='Clear contents of pgdata database (swagger api)',
     )
 
     args = parser.parse_args()

--- a/orc8r/tools/fab/types.py
+++ b/orc8r/tools/fab/types.py
@@ -43,11 +43,13 @@ class MagmadGatewayConfigs:
         autoupgrade_poll_interval: int,
         checkin_interval: int,
         checkin_timeout: int,
+        dynamic_services: List[str],
     ):
         self.autoupgrade_enabled = autoupgrade_enabled
         self.autoupgrade_poll_interval = autoupgrade_poll_interval
         self.checkin_interval = checkin_interval
         self.checkin_timeout = checkin_timeout
+        self.dynamic_services = dynamic_services
 
 
 class ChallengeKey:


### PR DESCRIPTION
Signed-off-by: Oriol Batalla <obatalla@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

This is the first PR which tries to add some code to configure a full local federated environment running AGW, Orc8r and FEG all at the same time.

Note this PR is not final and more testing will be needed to make sure the setup works properly. More PR will come to try to set up a full working environment.


This PR includes new fab file to control this environment
You can try it either running
```
cd ~/magma/l/g/python/integ_tests/federated_tests

fab build_all
# if it fails you may need to build MAGMA , feg and Orc8r manually using
fab_build_or8r
fab build_feg
fab build_agw
fab start_all
fab configure_orc8r

```

## Test Plan

created new fab file 

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
