### PR TITLE
chore(td-agent-bit): change local port for td-agent-bit client

### DIFF
--- a/orc8r/gateway/configs/templates/td-agent-bit.conf.template
+++ b/orc8r/gateway/configs/templates/td-agent-bit.conf.template
@@ -49,7 +49,7 @@
     Name     forward
     Tag      docker.log
     Listen   0.0.0.0
-    port     24224
+    port     24221
 
 # Input from the EventD service
 [INPUT]


### PR DESCRIPTION
Signed-off-by: Oriol Batalla <obatalla@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

td-agent-bit client and server use the same local port to run 24224. That prevents running td-agent-bit client and server on the same host (for example feg and orc8r can run at the same time)

This PR changes td-agent-bit client template to use 24221 as a local port at `orc8r/gateway/configs/templates/td-agent-bit.conf.template`

This PR **does not** change the server local port at `orc8r/cloud/docker/fluentd/conf/fluent.conf`

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->
ran both orc8r and feg on the same host


## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
