### PR TITLE
chore(feg): add new docker-compose for federated lte integ test

### DIFF
--- a/feg/gateway/Vagrantfile
+++ b/feg/gateway/Vagrantfile
@@ -34,7 +34,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     feg.vm.provider "virtualbox" do |vb|
       vb.name = "feg-dev"
       vb.linked_clone = true
-      vb.customize ["modifyvm", :id, "--memory", "4096"]
+      vb.customize ["modifyvm", :id, "--memory", "2048"]
       vb.customize ["modifyvm", :id, "--cpus", "2"]
       vb.customize ["modifyvm", :id, "--nicpromisc2", "allow-all"]
     end
@@ -45,12 +45,10 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       ansible.verbose = 'v'
     end
   end
-end
 
-# Baremetal Version: this will install feg into services (no docker). This is lightweight version
-Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
-  config.vm.synced_folder ".", "/vagrant", disabled: true
-  config.vm.synced_folder "../..", "/home/vagrant/magma"
+  # Baremetal Version: this will install feg into services (no docker). This is lightweight version
+  #config.vm.synced_folder ".", "/vagrant", disabled: true
+  #econfig.vm.synced_folder "../..", "/home/vagrant/magma"
 
   config.vm.define :feg_bare, primary: true do |feg_bare|
     feg_bare.vm.box = "fbcmagma/magma_feg"
@@ -65,7 +63,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     feg_bare.ssh.password = "vagrant"
     feg_bare.ssh.insert_key = true
 
-    config.vm.provider "virtualbox" do |v|
+    feg_bare.vm.provider "virtualbox" do |v|
       v.linked_clone = true
       v.memory = 1536
       v.cpus = 2
@@ -84,7 +82,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     feg_prod_bare.vbguest.auto_update = false
     feg_prod_bare.vm.network "private_network", ip: "192.168.91.10"
     feg_prod_bare.vm.network "private_network", ip: "192.168.81.100"
-    config.vm.provider "virtualbox" do |v|
+    feg_prod_bare.vm.provider "virtualbox" do |v|
       v.customize ['modifyvm', :id, '--natnet1', '10.0.3.0/24']
       v.linked_clone = true
       v.memory = 512

--- a/lte/gateway/python/integ_tests/federated_tests/configs/control_proxy.yml
+++ b/lte/gateway/python/integ_tests/federated_tests/configs/control_proxy.yml
@@ -1,0 +1,41 @@
+---
+#
+# Copyright 2020 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# nghttpx config will be generated here and used
+nghttpx_config_location: /var/tmp/nghttpx.conf
+
+# Location for certs
+rootca_cert: /var/opt/magma/certs/rootCA.pem
+gateway_cert: /var/opt/magma/certs/gateway.crt
+gateway_key: /var/opt/magma/certs/gateway.key
+
+# Listening port of the proxy for local services. The port would be closed
+# for the rest of the world.
+local_port: 8442
+
+# Cloud address for reaching out to the cloud.
+cloud_address: controller.magma.test
+cloud_port: 7443
+
+bootstrap_address: bootstrapper-controller.magma.test
+bootstrap_port: 7444
+
+fluentd_address: fluentd.magma.test
+fluentd_port: 24224
+
+# Option to use nghttpx for proxying. If disabled, the individual
+# services would establish the TLS connections themselves.
+proxy_cloud_connections: True
+
+# Allows http_proxy usage if the environment variable is present
+allow_http_proxy: True

--- a/lte/gateway/python/integ_tests/federated_tests/configs/ctraced.yml
+++ b/lte/gateway/python/integ_tests/federated_tests/configs/ctraced.yml
@@ -1,0 +1,25 @@
+---
+#
+# Copyright 2020 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+log_level: INFO
+
+# Directory for temporary storage of packet captures
+trace_directory: /var/opt/magma/tmp/trace
+
+# Interface to capture on
+trace_interfaces:
+  - any
+
+# Options available:
+#   - tshark
+# tshark has more capabilities - see command_builder.py
+trace_tool: tshark

--- a/lte/gateway/python/integ_tests/federated_tests/configs/directoryd.yml
+++ b/lte/gateway/python/integ_tests/federated_tests/configs/directoryd.yml
@@ -1,0 +1,15 @@
+---
+#
+# Copyright 2020 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# log_level is set in mconfig. It can be overridden here
+print_grpc_payload: false

--- a/lte/gateway/python/integ_tests/federated_tests/configs/eventd.yml
+++ b/lte/gateway/python/integ_tests/federated_tests/configs/eventd.yml
@@ -1,0 +1,50 @@
+---
+#
+# Copyright 2020 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+log_level: INFO
+fluent_bit_port: 5170
+tcp_timeout: 5
+event_registry:
+  mock_subscriber_event:
+    module: orc8r
+    filename: mock_event_definitions.v1.yml
+  deleted_stored_mconfig:
+    module: orc8r
+    filename: magmad_events.v1.yml
+  updated_stored_mconfig:
+    module: orc8r
+    filename: magmad_events.v1.yml
+  processed_updates:
+    module: orc8r
+    filename: magmad_events.v1.yml
+  restarted_services:
+    module: orc8r
+    filename: magmad_events.v1.yml
+  disconnected_sync_rpc_stream:
+    module: orc8r
+    filename: magmad_events.v1.yml
+  established_sync_rpc_stream:
+    module: orc8r
+    filename: magmad_events.v1.yml
+  gateway_promotion_succeeded:
+    module: feg
+    filename: health_events.v1.yml
+  gateway_promotion_failed:
+    module: feg
+    filename: health_events.v1.yml
+  gateway_demotion_succeded:
+    module: feg
+    filename: health_events.v1.yml
+  gateway_demotion_failed:
+    module: feg
+    filename: health_events.v1.yml

--- a/lte/gateway/python/integ_tests/federated_tests/configs/gateway.mconfig
+++ b/lte/gateway/python/integ_tests/federated_tests/configs/gateway.mconfig
@@ -1,0 +1,32 @@
+{
+  "configs_by_key": {
+    "control_proxy": {
+      "@type": "type.googleapis.com/magma.mconfig.ControlProxy",
+      "logLevel": "INFO"
+    },
+    "magmad": {
+      "@type": "type.googleapis.com/magma.mconfig.MagmaD",
+      "logLevel": "INFO",
+      "checkinInterval": 60,
+      "checkinTimeout": 10,
+      "autoupgradeEnabled": false,
+      "autoupgradePollInterval": 300,
+      "package_version": "0.0.0-0"
+    },
+    "radiusd": {
+      "@type": "type.googleapis.com/magma.mconfig.RadiusdConfig",
+      "logLevel": "INFO",
+      "radiusMetricsHost": "radius",
+      "radiusMetricsPort": 9100,
+      "radiusMetricsPath": "metrics",
+      "updateIntervalSecs": 60
+    },
+    "td-agent-bit": {
+      "@type": "type.googleapis.com/magma.mconfig.FluentBit",
+      "extraTags": {},
+      "throttleRate": 1000,
+      "throttleWindow": 5,
+      "throttleInterval": "1m"
+    }
+  }
+}

--- a/lte/gateway/python/integ_tests/federated_tests/configs/hss.yml
+++ b/lte/gateway/python/integ_tests/federated_tests/configs/hss.yml
@@ -1,0 +1,27 @@
+---
+#
+# Copyright 2020 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# HSS Config
+#
+# ---
+#subscribers:
+#  <imsi>:
+#    <auth_key>: - required (hex string)
+#    <non_3gpp_enabled>: - optional (bool)
+subscribers:
+  "001010000000001":
+    auth_key: "000102030405060708090A0B0C0D0E0F"
+    lte_auth_next_seq: 1
+  "001010000000002":
+    auth_key: "000102030405060708090A0B0C0D0E0F"
+    lte_auth_next_seq: 1

--- a/lte/gateway/python/integ_tests/federated_tests/configs/logfiles.txt
+++ b/lte/gateway/python/integ_tests/federated_tests/configs/logfiles.txt
@@ -1,0 +1,1 @@
+/var/log/syslog

--- a/lte/gateway/python/integ_tests/federated_tests/configs/magmad.yml
+++ b/lte/gateway/python/integ_tests/federated_tests/configs/magmad.yml
@@ -1,0 +1,97 @@
+---
+# Copyright 2020 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+log_level: INFO
+
+print_grpc_payload: false
+
+# List of services for magmad to control
+magma_services:
+  - control_proxy
+  - redis
+  - session_proxy
+  - s8_proxy
+  - s6a_proxy
+  - csfb
+  - feg_hello
+  - health
+  - swx_proxy
+  - eap_aka
+  - eap_sim
+  - aaa_server
+
+# List of services that don't provide service303 interface
+non_service303_services:
+  - control_proxy
+  - redis
+  - td-agent-bit
+
+# List of all possible dynamic services (enabled from gateway.mconfig)
+registered_dynamic_services:
+  - td-agent-bit
+
+# Init system to use to control services
+# Supported systems include: [systemd, runit, docker]
+init_system: docker
+
+# bootstrap_manager config
+bootstrap_config:
+  # location of the challenge key
+  challenge_key: /var/opt/magma/certs/gw_challenge.key
+
+# Flags indicating the magmad features to be enabled
+enable_config_streamer: True
+enable_upgrade_manager: True
+enable_network_monitor: False
+enable_sync_rpc: True
+
+upgrader_factory:
+  module: magma.magmad.upgrade.docker_upgrader
+  class: DockerUpgraderFactory
+  gateway_module: feg
+  use_proxy: False
+
+mconfig_modules:
+  - orc8r.protos.mconfig.mconfigs_pb2
+  - lte.protos.mconfig.mconfigs_pb2
+  - feg.protos.mconfig.mconfigs_pb2
+
+metricsd:
+  log_level: INFO
+  collect_interval: 60 # How frequently to collect metrics samples in seconds
+  sync_interval: 60 # How frequently to sync to cloud in seconds
+  grpc_timeout: 10 # Timeout in seconds
+  max_grpc_msg_size_mb: 4 # Max message size for gRPC channel in MBs
+  # List of services for metricsd to poll
+  services:
+    - magmad
+    - session_proxy
+    - s6a_proxy
+    - swx_proxy
+    - eap_aka
+    - eap_sim
+    - aaa_server
+    - csfb
+
+generic_command_config:
+  module: magma.magmad.generic_command.shell_command_executor
+  class: ShellCommandExecutor
+  shell_commands:
+    - name: bash
+      command: "bash {}"
+      allow_params: True
+    - name: fab
+      command: "fab {}"
+      allow_params: True
+    - name: echo
+      command: "echo {}"
+      allow_params: True

--- a/lte/gateway/python/integ_tests/federated_tests/configs/redis.yml
+++ b/lte/gateway/python/integ_tests/federated_tests/configs/redis.yml
@@ -1,0 +1,27 @@
+---
+#
+# Copyright 2020 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+port: 6380
+bind: 127.0.0.1
+redis_loglevel: notice
+dir: /var/opt/magma
+# How frequently to save/dump to disk.
+# E.g. the first element indicates we save every 900 seconds
+# if at least 1 key has changed.
+save:
+  - seconds: 900
+    num_keys: 1
+  - seconds: 300
+    num_keys: 10
+  - seconds: 60
+    num_keys: 1000

--- a/lte/gateway/python/integ_tests/federated_tests/configs/service_registry.yml
+++ b/lte/gateway/python/integ_tests/federated_tests/configs/service_registry.yml
@@ -1,0 +1,73 @@
+---
+services:
+  # NOTE: do NOT include dash(-) in your service name. Use underscore instead.
+  # Example service name that contains dash: hello-world-blah
+  # As we use "-" in nghttpx config to connect service name and hostname,
+  # "-" is used as a delimiter in dispatcher to parse out service names.
+
+  # Format:
+  # service:
+  #   host:       Host name to register in registry
+  #   ip_address: IP address used by control_proxy
+  #   port:       Port number used by control_proxy
+
+  # Production Services
+  magmad:
+    ip_address: 127.0.0.1
+    port: 50042
+  control_proxy:
+    ip_address: 127.0.0.1
+    port: 50043
+  session_proxy:
+    ip_address: 127.0.0.1
+    port: 9097
+  s6a_proxy:
+    ip_address: 127.0.0.1
+    port: 9098
+  s8_proxy:
+    ip_address: 127.0.0.1
+    port: 9099
+  swx_proxy:
+    ip_address: 127.0.0.1
+    port: 9110
+  eap_sim:
+    ip_address: 127.0.0.1
+    port: 9118
+  eap_aka:
+    ip_address: 127.0.0.1
+    port: 9123
+  aaa_server:
+    ip_address: 127.0.0.1
+    port: 9109
+  csfb:
+    ip_address: 127.0.0.1
+    port: 9101
+  feg_hello:
+    ip_address: 127.0.0.1
+    port: 9093
+  health:
+    ip_address: 127.0.0.1
+    port: 9107
+  radiusd:
+    ip_address: 127.0.0.1
+    port: 9115
+  eventd:
+    ip_address: 127.0.0.1
+    port: 50045
+  ctraced:
+    ip_address: 127.0.0.1
+    port: 50049
+
+  # Development/Test Services
+  mock_ocs:
+    ip_address: 127.0.0.1
+    port: 9201
+  mock_pcrf:
+    ip_address: 127.0.0.1
+    port: 9202
+  mock_vlr:
+    ip_address: 127.0.0.1
+    port: 9203
+  hss:
+    ip_address: 127.0.0.1
+    port: 9204

--- a/lte/gateway/python/integ_tests/federated_tests/configs/streamer.yml
+++ b/lte/gateway/python/integ_tests/federated_tests/configs/streamer.yml
@@ -1,0 +1,16 @@
+---
+#
+# Copyright 2020 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+reconnect_sec: 60
+
+stream_timeout: 150

--- a/lte/gateway/python/integ_tests/federated_tests/docker/.env
+++ b/lte/gateway/python/integ_tests/federated_tests/docker/.env
@@ -1,0 +1,29 @@
+# Copyright 2020 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+COMPOSE_PROJECT_NAME=feg
+DOCKER_USERNAME=
+DOCKER_PASSWORD=
+DOCKER_REGISTRY=feg_
+IMAGE_VERSION=latest
+GIT_HASH=master
+BUILD_CONTEXT=../../../../../../
+
+ROOTCA_PATH=../../../../../../.cache/test_certs/rootCA.pem
+CONTROL_PROXY_PATH=../configs/control_proxy.yml
+SNOWFLAKE_PATH=../../../../../../.cache/feg/snowflake
+CONFIGS_DEFAULT_VOLUME=../configs
+CONFIGS_TEMPLATES_PATH=../../../../../../orc8r/gateway/configs/templates
+
+CERTS_VOLUME=gwcerts
+CONFIGS_VOLUME=gwconfigs
+
+#LOG_DRIVER=journald

--- a/lte/gateway/python/integ_tests/federated_tests/docker/docker-compose.cache.yml
+++ b/lte/gateway/python/integ_tests/federated_tests/docker/docker-compose.cache.yml
@@ -1,0 +1,8 @@
+version: "3.7"
+
+services:
+  cache:
+    build:
+      target: gocache
+      context: ${BUILD_CONTEXT}
+      dockerfile: feg/gateway/docker/go/Dockerfile

--- a/lte/gateway/python/integ_tests/federated_tests/docker/docker-compose.override.yml
+++ b/lte/gateway/python/integ_tests/federated_tests/docker/docker-compose.override.yml
@@ -1,0 +1,73 @@
+version: "3.7"
+
+services:
+  test:
+    container_name: test
+    image: feg_gateway_go_base
+    build:
+      target: base
+      context: ${BUILD_CONTEXT}
+      dockerfile: feg/gateway/docker/go/Dockerfile
+    network_mode: host
+    volumes:
+      - ../../../:/magma
+      - ../configs:/etc/magma
+      - gwcerts:/var/opt/magma/certs
+      - gwconfigs:/var/opt/magma/configs
+    command:
+      - /bin/bash
+      - -c
+      - |
+         mkdir -p ../../.cache/feg/
+         touch ../../.cache/feg/snowflake
+         tail -f /dev/null
+
+  hss:
+    container_name: hss
+    image: feg_gateway_go
+    network_mode: host
+    volumes:
+      - ../configs:/etc/magma
+      - gwcerts:/var/opt/magma/certs
+      - gwconfigs:/var/opt/magma/configs
+    restart: always
+    environment:
+      USE_REMOTE_SWX_PROXY: 0
+    command: envdir /var/opt/magma/envdir /var/opt/magma/bin/hss -logtostderr=true -v=0
+
+  control_proxy:
+    depends_on:
+      - test
+    extra_hosts:
+      - controller.magma.test:127.0.0.1
+      - bootstrapper-controller.magma.test:127.0.0.1
+      #- controller.magma.test:10.0.2.2
+      #- bootstrapper-controller.magma.test:10.0.0.2
+    command:
+      - /bin/bash
+      - -c
+      - |
+         /usr/local/bin/generate_nghttpx_config.py
+         /usr/bin/env nghttpx --conf /var/opt/magma/tmp/nghttpx.conf /var/opt/magma/certs/controller.key /var/opt/magma/certs/controller.crt
+
+  csfb:
+    build:
+      context: ${BUILD_CONTEXT}
+      dockerfile: feg/gateway/docker/go/Dockerfile
+
+  magmad:
+    depends_on:
+      - test
+    build:
+      context: ${BUILD_CONTEXT}
+      dockerfile: feg/gateway/docker/python/Dockerfile
+    extra_hosts:
+      - controller.magma.test:127.0.0.1
+      - bootstrapper-controller.magma.test:127.0.0.1
+      #- controller.magma.test:10.0.2.2
+      #- bootstrapper-controller.magma.test:10.0.2.2
+    command: python3.8 -m magma.magmad.main
+
+volumes:
+  gwcerts:
+  gwconfigs:

--- a/lte/gateway/python/integ_tests/federated_tests/docker/docker-compose.yml
+++ b/lte/gateway/python/integ_tests/federated_tests/docker/docker-compose.yml
@@ -1,0 +1,181 @@
+version: "3.7"
+
+# Standard logging for each service
+x-logging: &logging_anchor
+  driver: ${LOG_DRIVER}
+
+# Standard volumes mounted
+x-volumes: &volumes_anchor
+  - ${ROOTCA_PATH}:/var/opt/magma/certs/rootCA.pem
+  - ${CONTROL_PROXY_PATH}:/etc/magma/control_proxy.yml
+  - ${CERTS_VOLUME}:/var/opt/magma/certs
+  - ${CONFIGS_VOLUME}:/var/opt/magma/configs
+  - ${CONFIGS_DEFAULT_VOLUME}:/etc/magma
+  - ${CONFIGS_TEMPLATES_PATH}:/etc/magma/templates
+
+# Standard volumes plus the snowflake
+x-snowflake-volumes: &snowflake_volumes
+  - ${ROOTCA_PATH}:/var/opt/magma/certs/rootCA.pem
+  - ${CONTROL_PROXY_PATH}:/etc/magma/control_proxy.yml
+  - ${CERTS_VOLUME}:/var/opt/magma/certs
+  - ${CONFIGS_VOLUME}:/var/opt/magma/configs
+  - ${CONFIGS_DEFAULT_VOLUME}:/etc/magma
+  - ${CONFIGS_TEMPLATES_PATH}:/etc/magma/templates
+  - ${SNOWFLAKE_PATH}:/etc/snowflake
+
+# Use generic go anchor to avoid repetition for go services
+x-generic-service: &service
+  volumes: *volumes_anchor
+  logging: *logging_anchor
+  restart: always
+  network_mode: host
+
+# Use generic anchor to defined dependence on td-agent-bit container
+x-log-forward: &depends_on_logs
+  depends_on:
+    td-agent-bit:
+      condition: service_healthy
+
+# Use generic python anchor to avoid repetition for python services
+x-pyservice_base: &pyservice_base
+  <<: *service
+  image: ${DOCKER_REGISTRY}gateway_python:${IMAGE_VERSION}
+
+# Use generic python anchor with logging capabilities to avoid repetition for python services
+x-pyservice: &pyservice
+  <<: *pyservice_base
+  <<: *depends_on_logs
+
+# Use generic go anchor to avoid repetition for go services
+x-goservice: &goservice
+  <<: *service
+  <<: *depends_on_logs
+  image: ${DOCKER_REGISTRY}gateway_go:${IMAGE_VERSION}
+
+
+services:
+  csfb:
+    <<: *goservice
+    container_name: csfb
+    command: envdir /var/opt/magma/envdir /var/opt/magma/bin/csfb -logtostderr=true -v=0
+
+  eap_aka:
+    <<: *goservice
+    container_name: eap_aka
+    environment:
+      USE_REMOTE_SWX_PROXY: 0
+    command: envdir /var/opt/magma/envdir /var/opt/magma/bin/eap_aka -logtostderr=true -v=0
+
+  eap_sim:
+    <<: *goservice
+    container_name: eap_sim
+    environment:
+      USE_REMOTE_SWX_PROXY: 0
+    command: envdir /var/opt/magma/envdir /var/opt/magma/bin/eap_sim -logtostderr=true -v=0
+
+  eventd:
+    <<: *pyservice
+    container_name: eventd
+    command: python3.8 -m magma.eventd.main
+
+  aaa_server:
+    <<: *goservice
+    container_name: aaa_server
+    environment:
+      USE_REMOTE_SWX_PROXY: 0
+    command: envdir /var/opt/magma/envdir /var/opt/magma/bin/aaa_server -logtostderr=true -v=0
+
+  feg_hello:
+    <<: *goservice
+    container_name: feg_hello
+    command: envdir /var/opt/magma/envdir /var/opt/magma/bin/feg_hello -logtostderr=true -v=0
+
+  health:
+    <<: *goservice
+    volumes: *snowflake_volumes
+    container_name: health
+    command: envdir /var/opt/magma/envdir /var/opt/magma/bin/gateway_health -logtostderr=true -v=0
+
+  session_proxy:
+    <<: *goservice
+    environment:
+      USE_GY_FOR_AUTH_ONLY: ${USE_GY_FOR_AUTH_ONLY}
+      GY_SUPPORTED_VENDOR_IDS: ${GY_SUPPORTED_VENDOR_IDS}
+      GY_SERVICE_CONTEXT_ID: ${GY_SERVICE_CONTEXT_ID}
+      DISABLE_REQUESTED_SERVICE_UNIT_AVP: ${DISABLE_REQUESTED_SERVICE_UNIT_AVP}
+      MAGMA_PRINT_GRPC_PAYLOAD: 0
+    container_name: session_proxy
+    command: envdir /var/opt/magma/envdir /var/opt/magma/bin/session_proxy -logtostderr=true -v=0
+
+  swx_proxy:
+    <<: *goservice
+    container_name: swx_proxy
+    command: envdir /var/opt/magma/envdir /var/opt/magma/bin/swx_proxy -logtostderr=true -v=0
+
+  s6a_proxy:
+    <<: *goservice
+    container_name: s6a_proxy
+    environment:
+      MAGMA_PRINT_GRPC_PAYLOAD: 0
+    command: envdir /var/opt/magma/envdir /var/opt/magma/bin/s6a_proxy -logtostderr=true -v=0
+
+
+  s8_proxy:
+    <<: *goservice
+    container_name: s8_proxy
+    command: envdir /var/opt/magma/envdir /var/opt/magma/bin/s8_proxy -logtostderr=true -v=0
+
+  radiusd:
+    <<: *goservice
+    container_name: radiusd
+    command: envdir /var/opt/magma/envdir /var/opt/magma/bin/radiusd -logtostderr=true -v=0
+
+  control_proxy:
+    <<: *pyservice
+    container_name: control_proxy
+    volumes: *snowflake_volumes
+    command: >
+      /bin/bash -c "/usr/local/bin/generate_nghttpx_config.py &&
+             /usr/bin/env nghttpx --conf /var/opt/magma/tmp/nghttpx.conf /var/opt/magma/certs/controller.key /var/opt/magma/certs/controller.crt"
+
+  magmad:
+    <<: *pyservice
+    container_name: magmad
+    volumes:
+      - ${ROOTCA_PATH}:/var/opt/magma/certs/rootCA.pem
+      - ${CONTROL_PROXY_PATH}:/etc/magma/control_proxy.yml
+      - ${CERTS_VOLUME}:/var/opt/magma/certs
+      - ${CONFIGS_VOLUME}:/var/opt/magma/configs
+      - ${SNOWFLAKE_PATH}:/etc/snowflake
+      - ${CONFIGS_DEFAULT_VOLUME}:/etc/magma
+      - ${CONFIGS_TEMPLATES_PATH}:/etc/magma/templates
+      - /var/run/docker.sock:/var/run/docker.sock
+      - ./:/var/opt/magma/docker
+    environment:
+      DOCKER_REGISTRY: ${DOCKER_REGISTRY}
+      DOCKER_USERNAME: ${DOCKER_USERNAME}
+      DOCKER_PASSWORD: ${DOCKER_PASSWORD}
+    command: python3.8 -m magma.magmad.main
+
+  redis:
+    <<: *pyservice
+    container_name: redis
+    command: >
+      /bin/bash -c "/usr/local/bin/generate_service_config.py --service=redis --template=redis &&
+             /usr/bin/redis-server /var/opt/magma/tmp/redis.conf --daemonize no &&
+             /usr/bin/redis-cli shutdown"
+
+  td-agent-bit:
+    <<: *pyservice_base
+    container_name: td-agent-bit
+    logging:
+      driver: json-file
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://127.0.0.1:2020"]
+      interval: 5s
+      timeout: 5s
+      retries: 3
+      start_period: 10s
+    command: >
+        /bin/bash -c "/usr/local/bin/generate_fluent_bit_config.py &&
+        /opt/td-agent-bit/bin/td-agent-bit -c /var/opt/magma/tmp/td-agent-bit.conf"


### PR DESCRIPTION
Signed-off-by: Oriol Batalla <obatalla@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

This PR is part of the federated integ test setup to build a local environment to test AGW+Orc8r+FEG

Those files are the same as in `magma/feg/gateway/docker` with some modifications on the `.env` file and `hss.yml`

The idea for now is to separate those files from their originals to modify them freely.Once we have better understanding on how to create this setup we may remove those and use the ones at `magma/feg/gateway/docker`

## Test Plan

```
docker-compose build
docker-compose up -d
```
## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
