### PR TITLE
chore(feg): add lte_auth_next_seq to HSS and add some logs to feg and…

### DIFF
--- a/feg/gateway/configs/hss.yml
+++ b/feg/gateway/configs/hss.yml
@@ -18,4 +18,5 @@
 #  <imsi>:
 #    <auth_key>: - required (hex string)
 #    <non_3gpp_enabled>: - optional (bool)
+#    <lte_auth_next_seq>: - optional (int)
 subscribers:

--- a/feg/gateway/go.mod
+++ b/feg/gateway/go.mod
@@ -44,6 +44,7 @@ require (
 	golang.org/x/crypto v0.0.0-20210421170649-83a5a9bb288b // indirect
 	google.golang.org/grpc v1.33.2
 	google.golang.org/protobuf v1.26.0
+	gotest.tools/gotestsum v1.7.0 // indirect
 	layeh.com/radius v0.0.0-20201203135236-838e26d0c9be
 	magma/feg/cloud/go v0.0.0
 	magma/feg/cloud/go/protos v0.0.0

--- a/feg/gateway/services/s6a_proxy/servicers/ai.go
+++ b/feg/gateway/services/s6a_proxy/servicers/ai.go
@@ -124,6 +124,7 @@ func (s *s6aProxy) AuthenticationInformationImpl(
 
 	// check if PLMN list exists, and if IMSI belongs to any of that PLMN
 	if !plmn_filter.CheckImsiOnPlmnIdListIfAny(req.UserName, s.config.PlmnIds) {
+		glog.V(2).Infof("Subscriber %s does not belong to any defined PLMN", req.UserName)
 		return &protos.AuthenticationInformationAnswer{
 			ErrorCode:     protos.ErrorCode_AUTHENTICATION_REJECTED,
 			EutranVectors: nil,

--- a/feg/gateway/services/s6a_proxy/servicers/s6a_proxy.go
+++ b/feg/gateway/services/s6a_proxy/servicers/s6a_proxy.go
@@ -20,17 +20,18 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/fiorix/go-diameter/v4/diam"
-	"github.com/fiorix/go-diameter/v4/diam/avp"
-	"github.com/fiorix/go-diameter/v4/diam/datatype"
-	"github.com/fiorix/go-diameter/v4/diam/dict"
-	"github.com/fiorix/go-diameter/v4/diam/sm"
-
 	"magma/feg/cloud/go/protos"
 	"magma/feg/gateway/diameter"
 	"magma/feg/gateway/plmn_filter"
 	"magma/feg/gateway/services/s6a_proxy/metrics"
 	orcprotos "magma/orc8r/lib/go/protos"
+
+	"github.com/fiorix/go-diameter/v4/diam"
+	"github.com/fiorix/go-diameter/v4/diam/avp"
+	"github.com/fiorix/go-diameter/v4/diam/datatype"
+	"github.com/fiorix/go-diameter/v4/diam/dict"
+	"github.com/fiorix/go-diameter/v4/diam/sm"
+	"github.com/golang/glog"
 )
 
 // Flag definitions
@@ -163,7 +164,9 @@ func (s *s6aProxy) AuthenticationInformation(
 ) {
 	airStartTime := time.Now()
 	res, err := s.AuthenticationInformationImpl(req)
-	if err == nil {
+	if err != nil {
+		glog.V(2).Infof("Error on AuthenticationInformationImpl: %s", err)
+	} else {
 		metrics.AIRLatency.Observe(float64(time.Since(airStartTime)) / float64(time.Millisecond))
 	}
 	metrics.UpdateS6aRecentRequestMetrics(err)
@@ -177,7 +180,9 @@ func (s *s6aProxy) UpdateLocation(
 ) {
 	ulrStartTime := time.Now()
 	res, err := s.UpdateLocationImpl(req)
-	if err == nil {
+	if err != nil {
+		glog.V(2).Infof("Error on UpdateLocationImpl: %s", err)
+	} else {
 		metrics.ULRLatency.Observe(float64(time.Since(ulrStartTime)) / float64(time.Millisecond))
 	}
 	metrics.UpdateS6aRecentRequestMetrics(err)
@@ -188,6 +193,9 @@ func (s *s6aProxy) UpdateLocation(
 // waits (blocks) for PUA & returns its RPC representation
 func (s *s6aProxy) PurgeUE(ctx context.Context, req *protos.PurgeUERequest) (*protos.PurgeUEAnswer, error) {
 	res, err := s.PurgeUEImpl(req)
+	if err != nil {
+		glog.V(2).Infof("Error on PurgeUEImpl: %s", err)
+	}
 	metrics.UpdateS6aRecentRequestMetrics(err)
 	return res, err
 }

--- a/feg/gateway/services/testcore/hss/servicers/message.go
+++ b/feg/gateway/services/testcore/hss/servicers/message.go
@@ -107,7 +107,7 @@ func (srv *HomeSubscriberServer) handleMessage(reply replyFunc) diam.HandlerFunc
 			glog.Error("Received nil message")
 			return
 		}
-		glog.V(2).Infof("Message received in hss service: %s", msg.String())
+		glog.V(2).Infof("Message received in hss service: %s}", msg.String())
 
 		answer, err := reply(srv, msg)
 		if err != nil {
@@ -118,6 +118,7 @@ func (srv *HomeSubscriberServer) handleMessage(reply replyFunc) diam.HandlerFunc
 		if err != nil {
 			glog.Errorf("Failed to send response: %s", err.Error())
 		}
+		glog.V(2).Infof("Message sent from hss service: %s}", answer.String())
 	}
 }
 

--- a/lte/cloud/go/services/lte/servicers/builder_servicer.go
+++ b/lte/cloud/go/services/lte/servicers/builder_servicer.go
@@ -60,28 +60,34 @@ func (s *builderServicer) Build(ctx context.Context, request *builder_protos.Bui
 
 	network, err := (configurator.Network{}).FromProto(request.Network, serdes.Network)
 	if err != nil {
-		return nil, err
-	}
-	graph, err := (configurator.EntityGraph{}).FromProto(request.Graph, serdes.Entity)
-	if err != nil {
+		glog.V(4).Infof("LTE mconfig not build for %s: Network cast failed", request.GatewayId)
 		return nil, err
 	}
 
+	graph, err := (configurator.EntityGraph{}).FromProto(request.Graph, serdes.Entity)
+	if err != nil {
+		glog.V(4).Infof("LTE mconfig not build for %s: EntityGraph cast failed", request.GatewayId)
+		return nil, err
+	}
 	// Only build mconfig if cellular network and gateway configs exist
 	inwConfig, found := network.Configs[lte.CellularNetworkConfigType]
 	if !found || inwConfig == nil {
+		glog.V(4).Infof("LTE mconfig not build for %s: CellularNetworkConfigType not found", request.GatewayId)
 		return ret, nil
 	}
 	cellularNwConfig := inwConfig.(*lte_models.NetworkCellularConfigs)
 
 	cellGW, err := graph.GetEntity(lte.CellularGatewayEntityType, request.GatewayId)
 	if err == merrors.ErrNotFound {
+		glog.V(4).Infof("LTE mconfig not build for %s: CellularGatewayEntityType not found in graph", request.GatewayId)
 		return ret, nil
 	}
 	if err != nil {
 		return nil, err
 	}
+
 	if cellGW.Config == nil {
+		glog.V(4).Infof("LTE mconfig not build for %s: CellularGatewayEntityType.Config is nill", request.GatewayId)
 		return ret, nil
 	}
 	cellularGwConfig := cellGW.Config.(*lte_models.GatewayCellularConfigs)
@@ -92,7 +98,7 @@ func (s *builderServicer) Build(ctx context.Context, request *builder_protos.Bui
 
 	federatedNetworkConfigs, err := getFederatedNetworkConfigs(network.Type, cellularNwConfig.FegNetworkID, request)
 	if err != nil {
-		glog.Errorf("Failed to retrieve LTE_federated network config while building lte mconfig")
+		glog.Errorf("Failed to retrieve LTE_federated network config while building lte mconfig for gateway %s", request.GatewayId)
 		return nil, err
 	}
 

--- a/src/go/go.mod
+++ b/src/go/go.mod
@@ -22,19 +22,3 @@ require (
 	google.golang.org/grpc/cmd/protoc-gen-go-grpc v1.1.0
 	google.golang.org/protobuf v1.27.1
 )
-
-require (
-	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/golang/protobuf v1.5.0 // indirect
-	github.com/pmezard/go-difflib v1.0.0 // indirect
-	go.uber.org/atomic v1.7.0 // indirect
-	go.uber.org/multierr v1.6.0 // indirect
-	golang.org/x/mod v0.4.2 // indirect
-	golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4 // indirect
-	golang.org/x/sys v0.0.0-20210510120138-977fb7262007 // indirect
-	golang.org/x/text v0.3.3 // indirect
-	golang.org/x/tools v0.1.1 // indirect
-	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
-	google.golang.org/genproto v0.0.0-20200526211855-cb27e3aa2013 // indirect
-	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
-)


### PR DESCRIPTION
… mconfig builder

Signed-off-by: Oriol Batalla <obatalla@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

This PR adds lte_auth_next_seq to HSS. This way we can set the initial SQN number stored in HSS
(useful for integ test that starts with sqn = 1)

## Test Plan

```
./build.py -c
```

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
