### PR TITLE
fix(nms): Fix org creation and editing

### DIFF
--- a/nms/packages/magmalte/server/main/routes.js
+++ b/nms/packages/magmalte/server/main/routes.js
@@ -18,6 +18,7 @@ import type {AppContextAppData} from '@fbcnms/ui/context/AppContext';
 import type {ExpressResponse} from 'express';
 import type {FBCNMSRequest} from '@fbcnms/auth/access';
 
+import MagmaV1API from '../magma/index';
 import adminRoutes from '../admin/routes';
 import apiControllerRoutes from '../apicontroller/routes';
 import asyncHandler from '@fbcnms/util/asyncHandler';
@@ -91,6 +92,23 @@ router.use(
   }),
 );
 router.get('/nms*', access(AccessRoles.USER), handleReact('nms'));
+
+// router.get(
+//   '/master/network*',
+//   masterOrgMiddleware,
+//   asyncHandler(async (req: FBCNMSRequest, res) => {
+//     res.send
+//     console.warn('request made to req: ', req);
+//   }),
+// );
+
+router.get(
+  '/master/networks/async',
+  asyncHandler(async (_: FBCNMSRequest, res) => {
+    const networks = await MagmaV1API.getNetworks();
+    res.status(200).send(networks);
+  }),
+);
 
 const masterRouter = require('@fbcnms/platform-server/master/routes');
 router.use('/master', masterOrgMiddleware, masterRouter.default);


### PR DESCRIPTION
Signed-off-by: Andrei Lee <andreilee@fb.com>

## Summary

Fixes NMS organization creation and editing capability.

A bug was introduced in dependency `@fbcnms/platform-server` with [this](https://github.com/facebookincubator/fbc-js-core/pull/117/files) pull request, in file `master/routes.js` with the removal removal of handling `/networks/async`.

In file [`OrganizationDialog.js`](https://github.com/facebookincubator/fbc-js-core/blob/main/fbcnms-packages/fbcnms-ui/master/OrganizationDialog.js#L55) a request is made to the unhandled path.

This pull request adds the handling of the networks request back into Magma code

## Test Plan

Sanity checked by bringing up a local development NMS, and created and edited an organization.

## Additional Information

- [ ] This change is backwards-breaking
