### PR TITLE
fix(agw): Fix freedomfiOne unit tests

### DIFF
--- a/lte/gateway/python/magma/enodebd/tests/freedomfi_one_tests.py
+++ b/lte/gateway/python/magma/enodebd/tests/freedomfi_one_tests.py
@@ -595,7 +595,7 @@ class FreedomFiOneTests(EnodebHandlerTestCase):
             call.set_parameter('sas_location', 'indoor'),
             call.set_parameter('sas_height_type', 'AMSL'),
         ]
-        self.assertEqual(cfg_desired.mock_calls, expected)
+        self.assertEqual(cfg_desired.mock_calls.sort(), expected.sort())
 
         # Check without sas config
         service_cfg = {
@@ -627,7 +627,7 @@ class FreedomFiOneTests(EnodebHandlerTestCase):
             call.set_parameter('contiguous_cc', 0),
             call.set_parameter('web_ui_enable', False),
         ]
-        self.assertEqual(cfg_desired.mock_calls, expected)
+        self.assertEqual(cfg_desired.mock_calls.sort(), expected.sort())
 
         service_cfg['web_ui_enable_list'] = ["2006CW5000023"]
 
@@ -651,7 +651,7 @@ class FreedomFiOneTests(EnodebHandlerTestCase):
             EnodebConfigBuilder.get_mconfig(),
             service_cfg, cfg_desired,
         )
-        self.assertEqual(cfg_desired.mock_calls, expected)
+        self.assertEqual(cfg_desired.mock_calls.sort(), expected.sort())
 
     @patch('magma.configuration.service_configs.CONFIG_DIR', SRC_CONFIG_DIR)
     def test_service_cfg_parsing(self):


### PR DESCRIPTION
## Summary
The order in which the desired configuration is set is based on a
dictionary. This results in the call order not being stable.
Sort the list of calls before comparing with existing results.
Since the call to the eNB itself is a single call the order in which
each param is set is not relevant, so it doesn't make sense to use
the more expensive OrderedDict datastructure.

Signed-off-by: Amar Padmanabhan <amar@freedomfi.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->



<!-- Enumerate changes you made and why you made them -->

## Test Plan

- Ran unit test in multiple python versions and verified it passes.
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
