### PR TITLE
chore(orc8r): Add magma local prefix to golangci-lint configuration, reformat & fix lint errors

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -11,6 +11,8 @@ linters-settings:
     simplify: true
   misspell:
     locale: US
+  goimports:
+    local-prefixes: magma
 
 issues:
   exclude-rules:

--- a/feg/cloud/go/services/basic_acct/servicers/accounting_service_test.go
+++ b/feg/cloud/go/services/basic_acct/servicers/accounting_service_test.go
@@ -37,7 +37,7 @@ func TestAugmentedNetworkAccounting(t *testing.T) {
 	tests.SetupNetworks(t)
 
 	// Test mapping of provider & consume from CTX
-	ctx, _, _, err := unary.SetIdentityFromContext(getIncomingContextWithCertificate(t, tests.AgwHwId), nil, nil)
+	ctx, _, _, _ := unary.SetIdentityFromContext(getIncomingContextWithCertificate(t, tests.AgwHwId), nil, nil)
 	session := &protos.AcctSession{
 		User:      &protos.AcctSession_IMSI{IMSI: tests.NhImsi},
 		SessionId: testSessionId,

--- a/feg/gateway/multiplex/multiplex_test.go
+++ b/feg/gateway/multiplex/multiplex_test.go
@@ -14,8 +14,9 @@
 package multiplex_test
 
 import (
-	"magma/feg/gateway/multiplex"
 	"testing"
+
+	"magma/feg/gateway/multiplex"
 
 	"github.com/stretchr/testify/assert"
 )

--- a/feg/gateway/services/aaa/aaa_server/without_builtin_radius.go
+++ b/feg/gateway/services/aaa/aaa_server/without_builtin_radius.go
@@ -1,3 +1,4 @@
+//go:build !with_builtin_radius
 // +build !with_builtin_radius
 
 /*

--- a/feg/gateway/services/aaa/events/events.go
+++ b/feg/gateway/services/aaa/events/events.go
@@ -15,7 +15,6 @@ package events
 
 import (
 	"encoding/json"
-	"fmt"
 
 	"magma/feg/gateway/services/aaa/protos"
 	"magma/gateway/eventd"
@@ -165,7 +164,7 @@ func logEvent(streamName string, eventType string, serializedEvent []byte) {
 		StreamName: streamName,
 		EventType:  eventType,
 		Tag:        hwid,
-		Value:      fmt.Sprintf("%s", serializedEvent),
+		Value:      string(serializedEvent),
 	}
 	err := eventd.V(eventd.DefaultVerbosity).Log(event)
 	if err != nil {

--- a/feg/gateway/services/aaa/radius/dae/dae_external.go
+++ b/feg/gateway/services/aaa/radius/dae/dae_external.go
@@ -9,6 +9,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build !with_builtin_radius
 // +build !with_builtin_radius
 
 // package dae implements Radius Dynamic Authorization Extensions API (https://tools.ietf.org/html/rfc5176)

--- a/feg/gateway/services/eap/providers/aka/provider/client_api.go
+++ b/feg/gateway/services/eap/providers/aka/provider/client_api.go
@@ -1,3 +1,4 @@
+//go:build !link_local_service
 // +build !link_local_service
 
 /*

--- a/feg/gateway/services/eap/providers/protos/eap_provider.pb.go
+++ b/feg/gateway/services/eap/providers/protos/eap_provider.pb.go
@@ -19,10 +19,11 @@
 package protos
 
 import (
-	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
-	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	reflect "reflect"
 	sync "sync"
+
+	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
+	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 )
 
 const (

--- a/feg/gateway/services/eap/providers/sim/provider/client_api.go
+++ b/feg/gateway/services/eap/providers/sim/provider/client_api.go
@@ -1,3 +1,4 @@
+//go:build !link_local_service
 // +build !link_local_service
 
 /*

--- a/feg/gateway/services/gateway_health/events/events.go
+++ b/feg/gateway/services/gateway_health/events/events.go
@@ -15,7 +15,6 @@ package events
 
 import (
 	"encoding/json"
-	"fmt"
 
 	"magma/feg/cloud/go/protos"
 	"magma/gateway/eventd"
@@ -60,7 +59,7 @@ func LogGatewayHealthFailedEvent(eventType string, failureReason string, prevAct
 		glog.Errorf("Could not serialize %s event: %s", eventType, err)
 		return
 	}
-	go logEvent(eventType, fmt.Sprintf("%s", serializedHealthEvent))
+	go logEvent(eventType, string(serializedHealthEvent))
 }
 
 func logEvent(eventType string, eventValue string) {

--- a/feg/gateway/services/s6a_proxy/client.go
+++ b/feg/gateway/services/s6a_proxy/client.go
@@ -22,12 +22,12 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/golang/glog"
+	"google.golang.org/grpc"
+
 	"magma/feg/cloud/go/protos"
 	"magma/feg/gateway/registry"
 	"magma/orc8r/lib/go/util"
-
-	"github.com/golang/glog"
-	"google.golang.org/grpc"
 )
 
 type s6aProxyClient struct {

--- a/feg/gateway/services/s6a_proxy/servicers/cl.go
+++ b/feg/gateway/services/s6a_proxy/servicers/cl.go
@@ -17,13 +17,13 @@ limitations under the License.
 package servicers
 
 import (
-	"magma/feg/cloud/go/protos"
-	"magma/feg/gateway/services/s6a_proxy"
-
 	"github.com/fiorix/go-diameter/v4/diam"
 	"github.com/fiorix/go-diameter/v4/diam/avp"
 	"github.com/fiorix/go-diameter/v4/diam/datatype"
 	"github.com/golang/glog"
+
+	"magma/feg/cloud/go/protos"
+	"magma/feg/gateway/services/s6a_proxy"
 )
 
 const (

--- a/feg/gateway/services/s6a_proxy/servicers/s6a_proxy.go
+++ b/feg/gateway/services/s6a_proxy/servicers/s6a_proxy.go
@@ -20,18 +20,18 @@ import (
 	"fmt"
 	"time"
 
-	"magma/feg/cloud/go/protos"
-	"magma/feg/gateway/diameter"
-	"magma/feg/gateway/plmn_filter"
-	"magma/feg/gateway/services/s6a_proxy/metrics"
-	orcprotos "magma/orc8r/lib/go/protos"
-
 	"github.com/fiorix/go-diameter/v4/diam"
 	"github.com/fiorix/go-diameter/v4/diam/avp"
 	"github.com/fiorix/go-diameter/v4/diam/datatype"
 	"github.com/fiorix/go-diameter/v4/diam/dict"
 	"github.com/fiorix/go-diameter/v4/diam/sm"
 	"github.com/golang/glog"
+
+	"magma/feg/cloud/go/protos"
+	"magma/feg/gateway/diameter"
+	"magma/feg/gateway/plmn_filter"
+	"magma/feg/gateway/services/s6a_proxy/metrics"
+	orcprotos "magma/orc8r/lib/go/protos"
 )
 
 // Flag definitions

--- a/feg/gateway/services/s8_proxy/s8_proxy/main.go
+++ b/feg/gateway/services/s8_proxy/s8_proxy/main.go
@@ -16,12 +16,12 @@ package main
 import (
 	"flag"
 
+	"github.com/golang/glog"
+
 	"magma/feg/cloud/go/protos"
 	"magma/feg/gateway/registry"
 	"magma/feg/gateway/services/s8_proxy/servicers"
 	"magma/orc8r/lib/go/service"
-
-	"github.com/golang/glog"
 )
 
 func init() {

--- a/feg/gateway/services/s8_proxy/servicers/config_test.go
+++ b/feg/gateway/services/s8_proxy/servicers/config_test.go
@@ -4,10 +4,10 @@ import (
 	"os"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"magma/feg/gateway/services/s8_proxy/servicers"
 	"magma/gateway/mconfig"
-
-	"github.com/stretchr/testify/assert"
 )
 
 func TestGetS8ProxyConfig(t *testing.T) {

--- a/feg/gateway/services/session_proxy/credit_control/gx/model_conversion_test.go
+++ b/feg/gateway/services/session_proxy/credit_control/gx/model_conversion_test.go
@@ -223,7 +223,7 @@ func TestRuleDefinition_ToProto(t *testing.T) {
 	// Check nil, 1-element, multiple elements, and empty arrays
 	monitoringKey := []byte("monitor")
 	var ratingGroup uint32 = 10
-	var ruleOut *protos.PolicyRule = nil
+	var ruleOut *protos.PolicyRule
 
 	ruleOut = (&gx.RuleDefinition{
 		RuleName:      "rgonly",

--- a/feg/gateway/services/session_proxy/credit_control/gy/model_conversion_test.go
+++ b/feg/gateway/services/session_proxy/credit_control/gy/model_conversion_test.go
@@ -23,7 +23,7 @@ import (
 )
 
 func TestRedirectServer_ToProto(t *testing.T) {
-	var convertedRedirectServer *protos.RedirectServer = nil
+	var convertedRedirectServer *protos.RedirectServer
 	convertedRedirectServer = (&gy.RedirectServer{
 		RedirectAddressType:   gy.IPV4Address,
 		RedirectServerAddress: "www.magma.com",

--- a/feg/gateway/services/session_proxy/relay/mocks/SessionProxyResponderServer.go
+++ b/feg/gateway/services/session_proxy/relay/mocks/SessionProxyResponderServer.go
@@ -6,6 +6,7 @@ package mocks
 
 import (
 	context "context"
+
 	protos "magma/lte/cloud/go/protos"
 
 	mock "github.com/stretchr/testify/mock"

--- a/feg/gateway/tools/s8_cli/s8_client.go
+++ b/feg/gateway/tools/s8_cli/s8_client.go
@@ -15,6 +15,7 @@ package main
 
 import (
 	"context"
+
 	"magma/feg/cloud/go/protos"
 	"magma/feg/gateway/services/s8_proxy"
 )

--- a/lte/cloud/go/services/lte/analytics/calculations/user_throughput.go
+++ b/lte/cloud/go/services/lte/analytics/calculations/user_throughput.go
@@ -15,6 +15,7 @@ package calculations
 
 import (
 	"fmt"
+
 	"magma/orc8r/cloud/go/services/analytics/calculations"
 	"magma/orc8r/cloud/go/services/analytics/protos"
 	"magma/orc8r/cloud/go/services/analytics/query_api"

--- a/lte/cloud/go/services/lte/analytics/calculations/user_throughput_test.go
+++ b/lte/cloud/go/services/lte/analytics/calculations/user_throughput_test.go
@@ -1,11 +1,12 @@
 package calculations_test
 
 import (
+	"testing"
+
 	lte_calculations "magma/lte/cloud/go/services/lte/analytics/calculations"
 	"magma/orc8r/cloud/go/services/analytics/calculations"
 	"magma/orc8r/cloud/go/services/analytics/query_api/mocks"
 	"magma/orc8r/lib/go/metrics"
-	"testing"
 
 	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/assert"

--- a/orc8r/cloud/go/services/analytics/analytics_helper_test.go
+++ b/orc8r/cloud/go/services/analytics/analytics_helper_test.go
@@ -14,12 +14,13 @@
 package analytics
 
 import (
-	"magma/orc8r/cloud/go/services/analytics/calculations"
 	"reflect"
 	"sort"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
+	"magma/orc8r/cloud/go/services/analytics/calculations"
 )
 
 func TestRawMetricsCalculation(t *testing.T) {

--- a/orc8r/cloud/go/services/analytics/calculations/calculations.go
+++ b/orc8r/cloud/go/services/analytics/calculations/calculations.go
@@ -15,10 +15,11 @@ package calculations
 
 import (
 	"fmt"
-	"magma/orc8r/cloud/go/services/analytics/protos"
-	"magma/orc8r/cloud/go/services/analytics/query_api"
 	"sort"
 	"strings"
+
+	"magma/orc8r/cloud/go/services/analytics/protos"
+	"magma/orc8r/cloud/go/services/analytics/query_api"
 
 	"github.com/golang/glog"
 	"github.com/google/go-cmp/cmp"

--- a/orc8r/cloud/go/services/analytics/calculations/log_calculations.go
+++ b/orc8r/cloud/go/services/analytics/calculations/log_calculations.go
@@ -2,9 +2,10 @@ package calculations
 
 import (
 	"context"
+	"time"
+
 	"magma/orc8r/cloud/go/services/analytics/protos"
 	"magma/orc8r/cloud/go/services/analytics/query_api"
-	"time"
 
 	"github.com/golang/glog"
 	"github.com/olivere/elastic/v7"

--- a/orc8r/cloud/go/services/analytics/calculations/raw_metrics_calculations.go
+++ b/orc8r/cloud/go/services/analytics/calculations/raw_metrics_calculations.go
@@ -16,9 +16,10 @@ package calculations
 import (
 	"bytes"
 	"fmt"
+	"text/template"
+
 	"magma/orc8r/cloud/go/services/analytics/protos"
 	"magma/orc8r/cloud/go/services/analytics/query_api"
-	"text/template"
 
 	"github.com/golang/glog"
 )

--- a/orc8r/cloud/go/services/analytics/collector_servicer.go
+++ b/orc8r/cloud/go/services/analytics/collector_servicer.go
@@ -15,12 +15,13 @@ package analytics
 
 import (
 	"context"
+
+	"github.com/golang/glog"
+
 	"magma/orc8r/cloud/go/services/analytics/calculations"
 	"magma/orc8r/cloud/go/services/analytics/protos"
 	"magma/orc8r/cloud/go/services/analytics/query_api"
 	"magma/orc8r/lib/go/metrics"
-
-	"github.com/golang/glog"
 )
 
 // collectorServicer implements the operations of collecting the metrics from CWF service

--- a/orc8r/cloud/go/services/analytics/collector_servicer_test.go
+++ b/orc8r/cloud/go/services/analytics/collector_servicer_test.go
@@ -15,11 +15,6 @@ package analytics_test
 
 import (
 	"context"
-	"magma/orc8r/cloud/go/services/analytics"
-	"magma/orc8r/cloud/go/services/analytics/calculations"
-	"magma/orc8r/cloud/go/services/analytics/protos"
-	"magma/orc8r/cloud/go/services/analytics/query_api"
-	"magma/orc8r/lib/go/metrics"
 	"reflect"
 	"sort"
 	"testing"
@@ -27,6 +22,12 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/assert"
+
+	"magma/orc8r/cloud/go/services/analytics"
+	"magma/orc8r/cloud/go/services/analytics/calculations"
+	"magma/orc8r/cloud/go/services/analytics/protos"
+	"magma/orc8r/cloud/go/services/analytics/query_api"
+	"magma/orc8r/lib/go/metrics"
 )
 
 func TestUserThresholdEnforcement(t *testing.T) {

--- a/orc8r/cloud/go/services/analytics/exporter.go
+++ b/orc8r/cloud/go/services/analytics/exporter.go
@@ -18,11 +18,10 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
-	"magma/orc8r/cloud/go/services/analytics/protos"
-
 	"net/http"
 	"net/url"
 
+	"magma/orc8r/cloud/go/services/analytics/protos"
 	"magma/orc8r/lib/go/metrics"
 )
 

--- a/orc8r/cloud/go/services/analytics/exporter_test.go
+++ b/orc8r/cloud/go/services/analytics/exporter_test.go
@@ -17,17 +17,17 @@ import (
 	"bytes"
 	"fmt"
 	"io/ioutil"
-	"magma/orc8r/cloud/go/services/analytics/calculations"
-	"magma/orc8r/cloud/go/services/analytics/protos"
 	"net/http"
 	"net/url"
 	"testing"
 
-	"magma/orc8r/cloud/go/services/analytics/mocks"
-
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+
+	"magma/orc8r/cloud/go/services/analytics/calculations"
+	"magma/orc8r/cloud/go/services/analytics/mocks"
+	"magma/orc8r/cloud/go/services/analytics/protos"
 )
 
 const (

--- a/orc8r/cloud/go/services/ctraced/obsidian/handlers/handlers_test.go
+++ b/orc8r/cloud/go/services/ctraced/obsidian/handlers/handlers_test.go
@@ -15,6 +15,8 @@ package handlers_test
 
 import (
 	context2 "context"
+	"testing"
+
 	"magma/orc8r/cloud/go/obsidian"
 	"magma/orc8r/cloud/go/obsidian/tests"
 	"magma/orc8r/cloud/go/serdes"
@@ -24,7 +26,6 @@ import (
 	"magma/orc8r/cloud/go/services/ctraced/storage"
 	"magma/orc8r/cloud/go/test_utils"
 	"magma/orc8r/lib/go/protos"
-	"testing"
 
 	configurator_test_init "magma/orc8r/cloud/go/services/configurator/test_init"
 

--- a/orc8r/gateway/go/mconfig/test/mconfig_refresh_test.go
+++ b/orc8r/gateway/go/mconfig/test/mconfig_refresh_test.go
@@ -139,7 +139,7 @@ func TestGatewayMconfigRefresh(t *testing.T) {
 	}
 
 	// Test marshaling of new configs
-	mc.ConfigsByKey["service2"], err = ptypes.MarshalAny(
+	mc.ConfigsByKey["service2"], _ = ptypes.MarshalAny(
 		&testcfg.Service2Config{
 			Str21: "str21",
 			Str22: "str22",

--- a/orc8r/gateway/go/mconfig/test/testcfg/test_configs.pb.go
+++ b/orc8r/gateway/go/mconfig/test/testcfg/test_configs.pb.go
@@ -5,8 +5,9 @@ package testcfg
 
 import (
 	fmt "fmt"
-	proto "github.com/golang/protobuf/proto"
 	math "math"
+
+	proto "github.com/golang/protobuf/proto"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.

--- a/orc8r/gateway/go/redis/client_test.go
+++ b/orc8r/gateway/go/redis/client_test.go
@@ -70,7 +70,7 @@ func TestRedisStateClientTest(t *testing.T) {
 	err = client.MarkAsGarbage("mock1")
 	assert.NoError(t, err)
 
-	actualObjI, err = client.Get("mock1")
+	_, err = client.Get("mock1")
 	assert.EqualError(t, err, "object found for key mock1 is garbage")
 
 	deleted, err := client.Delete("mock1")
@@ -81,7 +81,7 @@ func TestRedisStateClientTest(t *testing.T) {
 	_, err = client.Get("nonexistent")
 	assert.Error(t, err)
 
-	version, err = client.GetVersion("nonexistent")
+	version, _ = client.GetVersion("nonexistent")
 	assert.Equal(t, uint64(0), version)
 
 	err = client.MarkAsGarbage("nonexistent")

--- a/orc8r/gateway/go/services/bootstrapper/main.go
+++ b/orc8r/gateway/go/services/bootstrapper/main.go
@@ -34,7 +34,7 @@ Examples:
     $> %s
 
     The command will run Bootstrapper service which will periodically 
-    check the gateway certificats and update them when needed
+    check the gateway certificates and update them when needed
 
   2. Show the gateway information needed for the gateway registration and exit:
 

--- a/orc8r/gateway/go/services/bootstrapper/service/bootstrapper.go
+++ b/orc8r/gateway/go/services/bootstrapper/service/bootstrapper.go
@@ -140,8 +140,9 @@ func (b *Bootstrapper) Start() error {
 		return err
 	}
 	// Start certificate update loop
-	c := time.Tick(PERIODIC_BOOTSTRAP_CHECK_INTERVAL)
-	for now := range c {
+	certUpdateTicker := time.NewTicker(PERIODIC_BOOTSTRAP_CHECK_INTERVAL)
+	defer certUpdateTicker.Stop()
+	for now := range certUpdateTicker.C {
 		if err := b.PeriodicCheck(now); err != nil {
 			return err
 		}
@@ -256,7 +257,7 @@ func (b *Bootstrapper) RefreshConfigs() {
 }
 
 // bootstrap generates new gateway key & CSR, reaches to the cloud to sign the CSR and returns new cert & key
-// NOTE: it's a responsibility of a caller to synchronise access to Bootstrapper when calling Bootstrap
+// NOTE: it's a responsibility of a caller to synchronize access to Bootstrapper when calling Bootstrap
 func (b *Bootstrapper) bootstrap() (*protos.Certificate, interface{}, error) {
 	var (
 		err  error

--- a/orc8r/gateway/go/services/bootstrapper/service/key.go
+++ b/orc8r/gateway/go/services/bootstrapper/service/key.go
@@ -71,7 +71,7 @@ func GetChallengeKey() (privKey interface{}, err error) {
 				"Bootstrapper Failed to read recently created key from (%s) error: %v", challengeKeyFile, err)
 			return
 		}
-		glog.Infof("successfuly created new challenge key file: %s", challengeKeyFile)
+		glog.Infof("successfully created new challenge key file: %s", challengeKeyFile)
 	}
 	return
 }

--- a/orc8r/gateway/go/services/configurator/service/configurator.go
+++ b/orc8r/gateway/go/services/configurator/service/configurator.go
@@ -122,7 +122,7 @@ func (c *Configurator) Update(ub *protos.DataUpdateBatch) bool {
 		}
 	}
 	// find all removed configs
-	for sn, _ := range oldMap {
+	for sn := range oldMap {
 		if _, found := newMap[sn]; !found {
 			updatedServices = append(updatedServices, sn)
 		}

--- a/orc8r/gateway/go/services/magmad/main.go
+++ b/orc8r/gateway/go/services/magmad/main.go
@@ -46,7 +46,7 @@ Examples:
     $> %s
 
     The command will run magmad service which will periodically
-    check and update the gateway certificats and cloud managed GW configs
+    check and update the gateway certificates and cloud managed GW configs
 
   2. Show the gateway information needed for the gateway registration and exit:
 

--- a/orc8r/gateway/go/services/magmad/service/generic_command/command.go
+++ b/orc8r/gateway/go/services/magmad/service/generic_command/command.go
@@ -56,7 +56,7 @@ func Execute(ctx context.Context, req *protos.GenericCommandParams) (*protos.Gen
 	if formatters > 0 {
 		if len(cmdParams) < formatters {
 			fillIn := make([]interface{}, formatters-len(cmdParams))
-			for i, _ := range fillIn {
+			for i := range fillIn {
 				fillIn[i] = ""
 			}
 			cmdParams = append(cmdParams, fillIn...)

--- a/orc8r/gateway/go/services/sync_rpc/service/sync_rpc_broker_test.go
+++ b/orc8r/gateway/go/services/sync_rpc/service/sync_rpc_broker_test.go
@@ -112,18 +112,18 @@ func (m *magmadTestServer) TailLogs(req *protos.TailLogsRequest, s protos.Magmad
 	r := strings.NewReader(m.tc.logLines)
 	b := make([]byte, 1000)
 	for {
-		len, err := r.Read(b)
+		l, err := r.Read(b)
 		if err != nil {
 			break
 		}
-		s.SendMsg(&protos.LogLine{Line: string(b[:len])})
+		s.SendMsg(&protos.LogLine{Line: string(b[:l])})
 	}
 	return nil
 }
 
 // run instance of the test grpc service
 func runTestMagmadServer(server *magmadTestServer, grpcPortCh chan string, stopCh chan struct{}) {
-	lis, err := net.Listen("tcp", fmt.Sprintf(":0"))
+	lis, err := net.Listen("tcp", ":0")
 	if err != nil {
 		glog.Fatalf("failed to listen: %v", err)
 	}
@@ -219,11 +219,10 @@ func (t *testBroker) handler(w http.ResponseWriter, req *http.Request) {
 		}
 	}
 	t.reqID++
-	return
 }
 
 func runTestBroker(Broker *testBroker, BrokerPortCh chan string) {
-	lis, err := net.Listen("tcp", fmt.Sprintf(":0"))
+	lis, err := net.Listen("tcp", ":0")
 	if err != nil {
 		glog.Fatalf("failed to listen: %v", err)
 	}
@@ -317,7 +316,7 @@ func TestBrokerSanity(t *testing.T) {
 	// TC5 - stop magmad service and check if the client recvs error
 	serverStopCh <- struct{}{}
 
-	v, err = client.GetGatewayId(context.Background(), &protos.Void{})
+	_, err = client.GetGatewayId(context.Background(), &protos.Void{})
 	sts, _ = status.FromError(err)
 	assert.Contains(t, sts.Message(), "connection refused")
 }

--- a/orc8r/gateway/go/services/sync_rpc/service/sync_rpc_client_test.go
+++ b/orc8r/gateway/go/services/sync_rpc/service/sync_rpc_client_test.go
@@ -55,7 +55,7 @@ func (svc *testSyncRpcService) SyncRPC(stream protos.SyncRPCService_SyncRPCServe
 
 // run instance of the test grpc service
 func runTestSyncRpcService(server *testSyncRpcService, grpcPortCh chan string) {
-	lis, err := net.Listen("tcp", fmt.Sprintf(":0"))
+	lis, err := net.Listen("tcp", ":0")
 	if err != nil {
 		glog.Fatalf("failed to listen: %v", err)
 	}
@@ -103,7 +103,8 @@ func TestSyncRpcClient(t *testing.T) {
 		conn, err := grpc.Dial(fmt.Sprintf("localhost:%s", grpcPort),
 			grpc.WithInsecure())
 		if err != nil {
-			t.Fatal("Failed creating a test client")
+			t.Log("Failed creating a test client")
+			svcSyncRpcRespCh <- &protos.SyncRPCResponse{}
 			return
 		}
 		defer conn.Close()
@@ -157,7 +158,8 @@ func TestSyncRpcClient(t *testing.T) {
 		conn, err := grpc.Dial(fmt.Sprintf("localhost:%s", grpcPort),
 			grpc.WithInsecure())
 		if err != nil {
-			t.Fatal("Failed creating a test client")
+			t.Log("Failed creating a test client")
+			svcSyncRpcRespCh <- &protos.SyncRPCResponse{}
 			return
 		}
 		defer conn.Close()

--- a/orc8r/gateway/go/status/gateway_status.go
+++ b/orc8r/gateway/go/status/gateway_status.go
@@ -106,7 +106,7 @@ func GetPlatformInfo() *PlatformInfo {
 	return &PlatformInfo{
 		ConfigInfo:    GetConfigInfo(),
 		KernelVersion: hostInfo.KernelVersion,
-		Packages:      []*Package{&Package{Name: "magma"}},
+		Packages:      []*Package{{Name: "magma"}},
 		VpnIp:         vpnIp,
 	}
 }

--- a/orc8r/lib/go/initflag/parse_flag_release.go
+++ b/orc8r/lib/go/initflag/parse_flag_release.go
@@ -1,3 +1,4 @@
+//go:build !debug_build
 // +build !debug_build
 
 /*

--- a/orc8r/lib/go/profile/profiler_disabled.go
+++ b/orc8r/lib/go/profile/profiler_disabled.go
@@ -1,3 +1,4 @@
+//go:build !with_profiler
 // +build !with_profiler
 
 /*

--- a/orc8r/lib/go/util/util.go
+++ b/orc8r/lib/go/util/util.go
@@ -16,6 +16,7 @@ package util
 import (
 	"crypto/x509/pkix"
 	"encoding/json"
+	"fmt"
 	"io"
 	"io/ioutil"
 	"net"
@@ -27,7 +28,7 @@ import (
 )
 
 func GetFreeTcpPort(preferredPort int) int {
-	l, err := net.Listen("tcp", ":"+string(preferredPort))
+	l, err := net.Listen("tcp", fmt.Sprintf(":%d", preferredPort))
 	if err != nil {
 		l, _ = net.Listen("tcp", "")
 	}


### PR DESCRIPTION


Signed-off-by: Evgeniy Makeev <evgeniym@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

Add magma local prefix to golangci-lint configuration, reformat & fix lint errors

## Test Plan

unit tests,
generate, build, 
goimports -w -local magma/ ..., 
golangci-lint run --fix -c .../.golangci.yml  ./...

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
