### PR TITLE
chore(state): add print grpc to state service on gateways

### DIFF
--- a/cwf/gateway/configs/state.yml
+++ b/cwf/gateway/configs/state.yml
@@ -11,7 +11,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# log_level is set in mconfig. it can be overridden here
 log_level: INFO
+
+print_grpc_payload: false
 
 sync_interval: 60
 

--- a/docs/readmes/lte/dev_notes.md
+++ b/docs/readmes/lte/dev_notes.md
@@ -168,7 +168,7 @@ Note GRPC printing is independent of the `log_level`. So you can enabled GRPC
 printing even that your level is set as `INFO`.
 
 To enable GRPC logging for `magmad`, `sessiond`, `pipelined`, `mobilityd`,
-`directoryd` or`subscriberdb` you can modify this line on the
+`directoryd`, `subscriberdb` or `state` you can modify this line on the
 `/etc/magma/<service_name>.yml` config file:
 
 ```yaml

--- a/lte/gateway/configs/state.yml
+++ b/lte/gateway/configs/state.yml
@@ -13,6 +13,8 @@
 
 # log_level is set in mconfig. it can be overridden here
 
+print_grpc_payload: false
+
 sync_interval: 60
 
 #state_protos:

--- a/lte/gateway/python/magma/mobilityd/rpc_servicer.py
+++ b/lte/gateway/python/magma/mobilityd/rpc_servicer.py
@@ -32,7 +32,7 @@ from lte.protos.mobilityd_pb2_grpc import (
     add_MobilityServiceServicer_to_server,
 )
 from lte.protos.subscriberdb_pb2 import SubscriberID
-from magma.common.rpc_utils import return_void
+from magma.common.rpc_utils import print_grpc, return_void
 from magma.subscriberdb.sid import SIDUtils
 
 from .ip_address_man import (

--- a/orc8r/gateway/python/magma/common/rpc_utils.py
+++ b/orc8r/gateway/python/magma/common/rpc_utils.py
@@ -13,9 +13,12 @@ limitations under the License.
 # pylint: disable=broad-except
 
 import asyncio
+import logging
 from enum import Enum
 
 import grpc
+from google.protobuf import message as proto_message
+from google.protobuf.json_format import MessageToJson
 from magma.common.service_registry import ServiceRegistry
 from orc8r.protos import common_pb2
 
@@ -147,3 +150,34 @@ def is_grpc_error_retryable(error: grpc.RpcError) -> bool:
         # server end closed connection.
         return True
     return False
+
+
+def print_grpc(
+    message: proto_message.Message, print_grpc_payload: bool,
+    message_header: str = "",
+):
+    """
+    Prints content of grpc message
+
+    Args:
+        message: grpc message to print
+        print_grpc_payload: flag to enable/disable printing of the message
+        message_header: header to print before printing grpc content
+    """
+
+    if print_grpc_payload:
+        log_msg = "{} {}".format(
+            message.DESCRIPTOR.full_name,
+            MessageToJson(message),
+        )
+        # add indentation
+        padding = 2 * ' '
+        log_msg = ''.join(
+            "{}{}".format(padding, line)
+            for line in log_msg.splitlines(True)
+        )
+        log_msg = "GRPC message:\n{}".format(log_msg)
+
+        if message_header:
+            logging.info(message_header)
+        logging.info(log_msg)

--- a/orc8r/gateway/python/magma/state/main.py
+++ b/orc8r/gateway/python/magma/state/main.py
@@ -36,13 +36,19 @@ def main():
         max_client_reuse=60,
     )
 
+    config = service.config
+    print_grpc_payload = config.get('print_grpc_payload', False)
+
     # Garbage collector propagates state deletions back to Orchestrator
-    garbage_collector = GarbageCollector(service, grpc_client_manager)
+    garbage_collector = GarbageCollector(
+        service, grpc_client_manager, print_grpc_payload,
+    )
 
     # Start state replication loop
     state_manager = StateReplicator(
         service, garbage_collector,
         grpc_client_manager,
+        print_grpc_payload,
     )
     state_manager.start()
 


### PR DESCRIPTION
Signed-off-by: Oriol Batalla <obatalla@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

Added grpc messages print to state service

Note in this PR we are using `utils_rpc.py` to define the function. 
I will be moving the rest of the other services that use the grpc print function to use the new print function defined on that file 

## Test Plan
`make test` at agw

```
Sep 12 19:56:30 ubuntuAGW state[183963]: INFO:root:Printing GRPC messages
Sep 12 19:56:30 ubuntuAGW state[183963]: INFO:root:Starting state...                                                                                                                                                                                                            Sep 12 19:56:30 ubuntuAGW state[183963]: INFO:root:Listening on address 127.0.0.1:50074
Sep 12 19:58:02 ubuntuAGW state[183963]: INFO:root:Sending resync state request
Sep 12 19:58:02 ubuntuAGW state[183963]: INFO:root:GRPC message:                                                                                                                                                                                                                Sep 12 19:58:02 ubuntuAGW state[183963]:   magma.orc8r.SyncStatesRequest {
Sep 12 19:58:02 ubuntuAGW state[183963]:     "states": [                                                                                                                                                                                                                        Sep 12 19:58:02 ubuntuAGW state[183963]:       {
Sep 12 19:58:02 ubuntuAGW state[183963]:         "id": {                                                                                                                                                                                                                        Sep 12 19:58:02 ubuntuAGW state[183963]:           "type": "S1AP",
Sep 12 19:58:02 ubuntuAGW state[183963]:           "deviceID": "IMSI001020000000064"                                                                                                                                                                                            Sep 12 19:58:02 ubuntuAGW state[183963]:         }
Sep 12 19:58:02 ubuntuAGW state[183963]:       },                                                                                                                                                                                                                               Sep 12 19:58:02 ubuntuAGW state[183963]:       {
Sep 12 19:58:02 ubuntuAGW state[183963]:         "id": {
Sep 12 19:58:02 ubuntuAGW state[183963]:           "type": "MME",
Sep 12 19:58:02 ubuntuAGW state[183963]:           "deviceID": "IMSI001020000000064"
Sep 12 19:58:02 ubuntuAGW state[183963]:         }
Sep 12 19:58:02 ubuntuAGW state[183963]:       },
Sep 12 19:58:02 ubuntuAGW state[183963]:       {
Sep 12 19:58:02 ubuntuAGW state[183963]:         "id": {
Sep 12 19:58:02 ubuntuAGW state[183963]:           "type": "directory_record",
Sep 12 19:58:02 ubuntuAGW state[183963]:           "deviceID": "IMSI001020000000064"
Sep 12 19:58:02 ubuntuAGW state[183963]:         },
Sep 12 19:58:02 ubuntuAGW state[183963]:         "version": "2"
Sep 12 19:58:02 ubuntuAGW state[183963]:       }
Sep 12 19:58:02 ubuntuAGW state[183963]:     ]
Sep 12 19:58:02 ubuntuAGW state[183963]:   }
Sep 12 19:58:02 ubuntuAGW state[183963]: INFO:root:Received resync state request
Sep 12 19:58:02 ubuntuAGW state[183963]: INFO:root:GRPC message:
Sep 12 19:58:02 ubuntuAGW state[183963]:   magma.orc8r.SyncStatesResponse {
Sep 12 19:58:02 ubuntuAGW state[183963]:     "unsyncedStates": [
Sep 12 19:58:02 ubuntuAGW state[183963]:       {
Sep 12 19:58:02 ubuntuAGW state[183963]:         "id": {
Sep 12 19:58:02 ubuntuAGW state[183963]:           "type": "S1AP",
Sep 12 19:58:02 ubuntuAGW state[183963]:           "deviceID": "IMSI001020000000064"
Sep 12 19:58:02 ubuntuAGW state[183963]:         },
Sep 12 19:58:02 ubuntuAGW state[183963]:         "version": "8"
Sep 12 19:58:02 ubuntuAGW state[183963]:       },
Sep 12 19:58:02 ubuntuAGW state[183963]:       {
Sep 12 19:58:02 ubuntuAGW state[183963]:         "id": {
Sep 12 19:58:02 ubuntuAGW state[183963]:           "type": "MME",
Sep 12 19:58:02 ubuntuAGW state[183963]:           "deviceID": "IMSI001020000000064"
Sep 12 19:58:02 ubuntuAGW state[183963]:         },
Sep 12 19:58:02 ubuntuAGW state[183963]:         "version": "7"
Sep 12 19:58:02 ubuntuAGW state[183963]:       },
Sep 12 19:58:02 ubuntuAGW state[183963]:       {
Sep 12 19:58:02 ubuntuAGW state[183963]:         "id": {
Sep 12 19:58:02 ubuntuAGW state[183963]:           "type": "directory_record",
Sep 12 19:58:02 ubuntuAGW state[183963]:           "deviceID": "IMSI001020000000064"
Sep 12 19:58:02 ubuntuAGW state[183963]:         }
Sep 12 19:58:02 ubuntuAGW state[183963]:       }
Sep 12 19:58:02 ubuntuAGW state[183963]:     ]
Sep 12 19:58:02 ubuntuAGW state[183963]:   }
Sep 12 19:58:02 ubuntuAGW state[183963]: INFO:root:Successfully resynced state with Orchestrator!
```



<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
