### PR TITLE
docs: fixed semantic-pr.yml link on magma documentation

### DIFF
--- a/docs/docusaurus/versioned_docs/version-1.6.0/contributing/contribute_workflow.md
+++ b/docs/docusaurus/versioned_docs/version-1.6.0/contributing/contribute_workflow.md
@@ -24,7 +24,7 @@ Once your PR has been approved and passed all CI checks, use the [`ready2merge`]
 
 **Required: commits must be signed off.** You must sign-off all commits on the originating branch for a PR, using [the `--signoff` flag in Git](https://stackoverflow.com/questions/1962094). There is a CI check that will fail if any commit in your branch has an unsigned commit.
 
-**Required: PR title must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format.** For example, `fix(agw): Fix pyroute2 dependency`. See [semantic.yml](https://github.com/magma/magma/blob/master/.github/semantic.yml) for the set of supported scopes.
+**Required: PR title must follow [conventional commits](https://github.com/magma/magma/blob/master/.github/workflows/semantic-pr.yml) for the set of supported scopes.
 
 **Required: label backward-breaking pull requests.** Use the [`breaking change` label](https://github.com/magma/magma/issues?q=label%3A%22breaking+change%22+). All breaking changes and their mitigation steps will be aggregated in the subsequent release notes. A breaking change fits one or more of the following criteria
 


### PR DESCRIPTION
Signed-off-by: Oriol Batalla <obatalla@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

Fixed missing link for new location of `semantic.yml`  (now `semantic-pr.yml` under `.githug/workflow`)

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
