### PR TITLE
chore(pipelined): Add configuration for default GBR.

### DIFF
--- a/lte/gateway/configs/pipelined.yml
+++ b/lte/gateway/configs/pipelined.yml
@@ -123,6 +123,7 @@ qos:
  impl: linux_tc
  enable_pyroute2: true
  max_rate: 1000000000
+ gbr_rate: 80Kbit
  linux_tc:
   min_idx: 2
   max_idx: 65534

--- a/lte/gateway/configs/pipelined.yml_prod
+++ b/lte/gateway/configs/pipelined.yml_prod
@@ -116,6 +116,7 @@ qos:
  impl: linux_tc
  enable_pyroute2: True
  max_rate: 1000000000
+ gbr_rate: 80Kbit
  linux_tc:
   min_idx: 2
   max_idx: 65534

--- a/lte/gateway/python/magma/pipelined/tests/test_qos.py
+++ b/lte/gateway/python/magma/pipelined/tests/test_qos.py
@@ -118,8 +118,8 @@ class TestQosManager(unittest.TestCase):
     ):
         intf = self.ul_intf if d == FlowMatch.UPLINK else self.dl_intf
         mock_get_action_inst.assert_any_call(qid)
-        mock_traffic_cls.init_qdisc.assert_any_call(self.ul_intf, enable_pyroute2=False)
-        mock_traffic_cls.init_qdisc.assert_any_call(self.dl_intf, enable_pyroute2=False)
+        mock_traffic_cls.init_qdisc.assert_any_call(self.ul_intf, enable_pyroute2=False, default_gbr='80Kbit')
+        mock_traffic_cls.init_qdisc.assert_any_call(self.dl_intf, enable_pyroute2=False, default_gbr='80Kbit')
 
     def verifyTcCleanRestart(self, prior_qids, mock_traffic_cls):
         for qid_tuple in prior_qids[self.ul_intf]:


### PR DESCRIPTION
Following patch add pipelined configurtion parameter for default
GBR for UE session. This would

default value is increased to 80 kbps to avoid issue with HTB quantum
calculation.
this avoids warning:
HTB: quantum of class 10029 is small. Consider r2q change.

Signed-off-by: Pravin B Shelar <pbshelar@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->

## Test Plan
validated on bare metal and vagrant integ test.
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
