### PR TITLE
chore(mme): Migrate S11 timers to zmq

### DIFF
--- a/lte/gateway/c/core/oai/lib/gtpv2-c/nwgtpv2c-0.11/include/NwGtpv2c.h
+++ b/lte/gateway/c/core/oai/lib/gtpv2-c/nwgtpv2c-0.11/include/NwGtpv2c.h
@@ -42,6 +42,8 @@
 #include "sgw_ie_defs.h"
 #include "udp_messages_types.h"
 
+#include <czmq.h>
+
 /** @mainpage
 
   @section intro Introduction
@@ -468,9 +470,8 @@ typedef struct nw_gtpv2c_timer_mgr_entity_s {
   nw_gtpv2c_timer_mgr_handle_t tmrMgrHandle;
   nw_rc_t (*tmrStartCallback)(
       NW_IN nw_gtpv2c_timer_mgr_handle_t tmrMgrHandle,
-      NW_IN uint32_t timeoutSec, NW_IN uint32_t timeoutUsec,
-      NW_IN uint32_t tmrType, NW_IN void* tmrArg,
-      NW_OUT nw_gtpv2c_timer_handle_t* tmrHandle);
+      NW_IN uint32_t timeoutMilliSec, NW_IN uint32_t tmrType,
+      NW_IN void* tmrArg, NW_OUT nw_gtpv2c_timer_handle_t* tmrHandle);
 
   nw_rc_t (*tmrStopCallback)(
       NW_IN nw_gtpv2c_timer_mgr_handle_t tmrMgrHandle,
@@ -638,11 +639,21 @@ nw_rc_t nwGtpv2cProcessUlpReq(
 /**
  Process Timer timeout Request from Timer Manager
 
- @param[in] pLogMgr : Pointer timeout arguments.
+ @param[in] loop : ZMQ zloop_t pointer, unused .
+ @param[in] timer_id : unused.
+ @param[in] arg : Pointer timeout arguments.
  @return NW_OK on success.
  */
+nw_rc_t nwGtpv2cProcessTimeoutExt(
+    NW_IN zloop_t* loop, NW_IN int timer_id, NW_IN void* arg);
 
-nw_rc_t nwGtpv2cProcessTimeout(NW_IN void* timeoutArg);
+/**
+ Process Timer timeout Request from Timer Manager
+
+ @param[in] arg : Pointer timeout arguments.
+ @return NW_OK on success.
+ */
+nw_rc_t nwGtpv2cProcessTimeout(void* arg);
 
 #ifdef __cplusplus
 }

--- a/lte/gateway/c/core/oai/tasks/amf/deregistration_request.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/deregistration_request.cpp
@@ -110,14 +110,14 @@ int amf_proc_deregistration_request(
   OAILOG_FUNC_IN(LOG_NAS_AMF);
   OAILOG_DEBUG(
       LOG_NAS_AMF,
-      "Processing deregistration UE-id = " AMF_UE_NGAP_ID_FMT " type = %d\n",
+      "Processing deregistration UE-id = " AMF_UE_NGAP_ID_FMT " type = %d",
       ue_id, params->de_reg_type);
   int rc = RETURNerror;
 
   ue_m5gmm_context_s* ue_context = amf_ue_context_exists_amf_ue_ngap_id(ue_id);
 
   if (ue_context == NULL) {
-    OAILOG_FUNC_RETURN(LOG_NAS_AMF, -1);
+    return -1;
   }
 
   amf_context_t* amf_ctx = amf_context_get(ue_id);

--- a/lte/gateway/c/core/oai/tasks/amf/deregistration_request.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/deregistration_request.cpp
@@ -110,14 +110,14 @@ int amf_proc_deregistration_request(
   OAILOG_FUNC_IN(LOG_NAS_AMF);
   OAILOG_DEBUG(
       LOG_NAS_AMF,
-      "Processing deregistration UE-id = " AMF_UE_NGAP_ID_FMT " type = %d",
+      "Processing deregistration UE-id = " AMF_UE_NGAP_ID_FMT " type = %d\n",
       ue_id, params->de_reg_type);
   int rc = RETURNerror;
 
   ue_m5gmm_context_s* ue_context = amf_ue_context_exists_amf_ue_ngap_id(ue_id);
 
   if (ue_context == NULL) {
-    return -1;
+    OAILOG_FUNC_RETURN(LOG_NAS_AMF, -1);
   }
 
   amf_context_t* amf_ctx = amf_context_get(ue_id);

--- a/lte/gateway/c/core/oai/tasks/s11/s11_tasks.c
+++ b/lte/gateway/c/core/oai/tasks/s11/s11_tasks.c
@@ -163,37 +163,32 @@ static nw_rc_t s11_mme_send_udp_msg(
 
 //------------------------------------------------------------------------------
 static nw_rc_t s11_mme_start_timer_wrapper(
-    nw_gtpv2c_timer_mgr_handle_t tmrMgrHandle, uint32_t timeoutSec,
-    uint32_t timeoutUsec, uint32_t tmrType, void* timeoutArg,
-    nw_gtpv2c_timer_handle_t* hTmr) {
+    nw_gtpv2c_timer_mgr_handle_t tmrMgrHandle, uint32_t timeoutMilliSec,
+    uint32_t tmrType, void* timeoutArg, nw_gtpv2c_timer_handle_t* hTmr) {
   long timer_id;
   int ret = 0;
 
   if (tmrType == NW_GTPV2C_TMR_TYPE_REPETITIVE) {
-    ret = timer_setup(
-        timeoutSec, timeoutUsec, TASK_S11, INSTANCE_DEFAULT, TIMER_PERIODIC,
-        timeoutArg, 0, &timer_id);
+    *hTmr = (nw_gtpv2c_timer_handle_t) start_timer(
+        &s11_task_zmq_ctx, timeoutMilliSec, TIMER_REPEAT_FOREVER,
+        nwGtpv2cProcessTimeoutExt, timeoutArg);
   } else {
-    ret = timer_setup(
-        timeoutSec, timeoutUsec, TASK_S11, INSTANCE_DEFAULT, TIMER_ONE_SHOT,
-        timeoutArg, 0, &timer_id);
+    *hTmr = (nw_gtpv2c_timer_handle_t) start_timer(
+        &s11_task_zmq_ctx, timeoutMilliSec, TIMER_REPEAT_ONCE,
+        nwGtpv2cProcessTimeoutExt, timeoutArg);
   }
-
-  *hTmr = (nw_gtpv2c_timer_handle_t) timer_id;
-  return ((ret == 0) ? NW_OK : NW_FAILURE);
+  return NW_OK;
 }
 
 //------------------------------------------------------------------------------
 static nw_rc_t s11_mme_stop_timer_wrapper(
     nw_gtpv2c_timer_mgr_handle_t tmrMgrHandle,
     nw_gtpv2c_timer_handle_t tmrHandle) {
-  static long timer_id = 0;
-  void* timeoutArg     = NULL;
-
-  timer_id = (long) tmrHandle;
-  return ((timer_remove(timer_id, &timeoutArg) == 0) ? NW_OK : NW_FAILURE);
+  stop_timer(&s11_task_zmq_ctx, (int) tmrHandle);
+  return NW_OK;
 }
 
+//------------------------------------------------------------------------------
 static int handle_message(zloop_t* loop, zsock_t* reader, void* arg) {
   MessageDef* received_message_p = receive_msg(reader);
 
@@ -249,22 +244,6 @@ static int handle_message(zloop_t* loop, zsock_t* reader, void* arg) {
       itti_free_msg_content(received_message_p);
       free(received_message_p);
       s11_mme_exit();
-    } break;
-
-    case TIMER_HAS_EXPIRED: {
-      OAILOG_DEBUG(
-          LOG_S11, "Processing timeout for timer_id 0x%lx and arg %p\n",
-          received_message_p->ittiMsg.timer_has_expired.timer_id,
-          received_message_p->ittiMsg.timer_has_expired.arg);
-      nw_rc_t nw_rc = nwGtpv2cProcessTimeout(
-          received_message_p->ittiMsg.timer_has_expired.arg);
-      if (nw_rc != NW_OK) {
-        OAILOG_DEBUG(
-            LOG_S11,
-            "Processing timeout for timer_id 0x%lx and arg %p failed\n",
-            received_message_p->ittiMsg.timer_has_expired.timer_id,
-            received_message_p->ittiMsg.timer_has_expired.arg);
-      }
     } break;
 
     case UDP_DATA_IND: {


### PR DESCRIPTION
## Summary

S11/GTPV2-C timers now use ZMQ timers instead of itti/timers.c.

## Test Plan

Tested with dsTester scenario on CUPS deployment of magma MME.

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
