### PR TITLE
chore(agw): Enable incrementing NAS ksi

### DIFF
--- a/lte/gateway/c/core/oai/tasks/nas/emm/Attach.c
+++ b/lte/gateway/c/core/oai/tasks/nas/emm/Attach.c
@@ -847,7 +847,7 @@ status_code_e emm_proc_attach_complete(
           LOG_NAS_EMM,
           " Sending EMM INFORMATION for ue_id = " MME_UE_S1AP_ID_FMT "\n",
           ue_id);
-      emm_proc_emm_information(ue_mm_context);
+      emm_proc_emm_informtion(ue_mm_context);
       increment_counter("ue_attach", 1, 1, "result", "attach_proc_successful");
       attach_success_event(ue_mm_context->emm_context._imsi64);
     }

--- a/lte/gateway/c/core/oai/tasks/nas/emm/Attach.c
+++ b/lte/gateway/c/core/oai/tasks/nas/emm/Attach.c
@@ -847,7 +847,7 @@ status_code_e emm_proc_attach_complete(
           LOG_NAS_EMM,
           " Sending EMM INFORMATION for ue_id = " MME_UE_S1AP_ID_FMT "\n",
           ue_id);
-      emm_proc_emm_informtion(ue_mm_context);
+      emm_proc_emm_information(ue_mm_context);
       increment_counter("ue_attach", 1, 1, "result", "attach_proc_successful");
       attach_success_event(ue_mm_context->emm_context._imsi64);
     }

--- a/lte/gateway/c/core/oai/tasks/nas/emm/Authentication.c
+++ b/lte/gateway/c/core/oai/tasks/nas/emm/Authentication.c
@@ -224,8 +224,8 @@ status_code_e emm_proc_authentication_ksi(
     }
     OAILOG_INFO_UE(
         LOG_NAS_EMM, emm_context->_imsi64,
-        "ATTACH - Authentication proc ksi %d parent proc %p\n",
-        auth_proc->ksi, ((nas_base_proc_t*) auth_proc)->parent);
+        "ATTACH - Authentication proc ksi %d parent proc %p\n", auth_proc->ksi,
+        ((nas_base_proc_t*) auth_proc)->parent);
 
     /*
      * Send authentication request message to the UE
@@ -267,25 +267,26 @@ status_code_e emm_proc_authentication(
     if (emm_specific_proc) {
       if (EMM_SPEC_PROC_TYPE_ATTACH == emm_specific_proc->type) {
         auth_proc->is_cause_is_attach = true;
-       // if UE re-attach with a previous security context, then we have
-       // to provide a new one
-       // with ksi incremented by one from the UE ksi.
-       // 3GPP spec 3GPP TS 24.301 :
-       // 5.4.2.2 Authentication initiation by the network
-       // If an eKSI is contained in an initial NAS message during an EMM 
-       // procedure, the network SHALL include a different eKSI value in 
-       // the AUTHENTICATION REQUEST message when it initiates an 
-       // authentication procedure.
-       nas_emm_attach_proc_t * attach_proc = (nas_emm_attach_proc_t*)emm_specific_proc;
-       if ((attach_proc->ies->ksi < KSI_NO_KEY_AVAILABLE) &&
-           (!IS_EMM_CTXT_VALID_AUTH_VECTOR(
-             emm_context, (attach_proc->ies->ksi % MAX_EPS_AUTH_VECTORS)))) {
-         auth_proc->ksi = attach_proc->ksi;
-         emm_context->_security.eksi = attach_proc->ies->ksi;
-         OAILOG_INFO_UE(
-               LOG_NAS_EMM, emm_context->_imsi64,
-               "ATTACH - Authentication set proc ksi to %d \n", auth_proc->ksi);
-       }
+        // if UE re-attach with a previous security context, then we have
+        // to provide a new one
+        // with ksi incremented by one from the UE ksi.
+        // 3GPP spec 3GPP TS 24.301 :
+        // 5.4.2.2 Authentication initiation by the network
+        // If an eKSI is contained in an initial NAS message during an EMM
+        // procedure, the network SHALL include a different eKSI value in
+        // the AUTHENTICATION REQUEST message when it initiates an
+        // authentication procedure.
+        nas_emm_attach_proc_t* attach_proc =
+            (nas_emm_attach_proc_t*) emm_specific_proc;
+        if ((attach_proc->ies->ksi < KSI_NO_KEY_AVAILABLE) &&
+            (!IS_EMM_CTXT_VALID_AUTH_VECTOR(
+                emm_context, (attach_proc->ies->ksi % MAX_EPS_AUTH_VECTORS)))) {
+          auth_proc->ksi              = attach_proc->ksi;
+          emm_context->_security.eksi = attach_proc->ies->ksi;
+          OAILOG_INFO_UE(
+              LOG_NAS_EMM, emm_context->_imsi64,
+              "ATTACH - Authentication set proc ksi to %d \n", auth_proc->ksi);
+        }
       } else if (EMM_SPEC_PROC_TYPE_TAU == emm_specific_proc->type) {
         auth_proc->is_cause_is_attach = false;
       }
@@ -335,9 +336,8 @@ status_code_e emm_proc_authentication(
       auth_proc->ksi = eksi;
       OAILOG_INFO_UE(
           LOG_NAS_EMM, emm_context->_imsi64,
-          "ATTACH - Authentication update proc ksi to %d\n",
-          auth_proc->ksi);
-      // eksi should not always be 0, seems reals UEs accept this, but 
+          "ATTACH - Authentication update proc ksi to %d\n", auth_proc->ksi);
+      // eksi should not always be 0, seems reals UEs accept this, but
       // not all RAN emulators.
       if (!IS_EMM_CTXT_VALID_AUTH_VECTOR(
               emm_context, (eksi % MAX_EPS_AUTH_VECTORS))) {
@@ -1006,8 +1006,10 @@ status_code_e emm_proc_authentication_complete(
 
     if (auth_proc->is_cause_is_attach) {
       nas_emm_attach_proc_t* attach_proc =
-            get_nas_specific_procedure_attach(emm_ctx);
-      OAILOG_DEBUG(LOG_NAS_EMM, "EMM-PROC  - Force base proc Attach ksi %u:\n", auth_proc->ksi);
+          get_nas_specific_procedure_attach(emm_ctx);
+      OAILOG_DEBUG(
+          LOG_NAS_EMM, "EMM-PROC  - Force base proc Attach ksi %u:\n",
+          auth_proc->ksi);
       // attach proc IE ksi remains unchanged.
       attach_proc->ksi = auth_proc->ksi;
     }

--- a/lte/gateway/c/core/oai/tasks/nas/emm/sap/emm_send.c
+++ b/lte/gateway/c/core/oai/tasks/nas/emm/sap/emm_send.c
@@ -1393,8 +1393,8 @@ status_code_e emm_send_authentication_request(
   OAILOG_INFO(
       LOG_NAS_EMM,
       "EMMAS-SAP - Send Authentication Request message for ue_id "
-      "= " MME_UE_S1AP_ID_FMT "\n",
-      msg->ue_id);
+      "= " MME_UE_S1AP_ID_FMT " ksi %d\n",
+      msg->ue_id, msg->ksi);
   /*
    * Mandatory - Message type
    */


### PR DESCRIPTION
## Summary

While trying to stick to 3GPP spec 3GPP TS 24.301 :
5.4.2.2 Authentication initiation by the network
If an eKSI is contained in an initial NAS message during an EMM procedure, the network SHALL include a different eKSI
value in the AUTHENTICATION REQUEST message when it initiates an authentication procedure.

The following situation happens with phones when UE re-attach after detach: the 2nd NAS Attach message is security protected with previous security context, ksi = 0. The authentication procedure goes well even if MME set a new security context with ksi=0, and the attach procedure succeed after few remaining exchanges, we never saw Authentication Reject with real UEs in this context.

When testing with dsTester, seems it sticks strictly to the specification, and after the 2nd NAS Attach message, the NAS Authentication procedure fails due to ksi=0.

## Test Plan

Tested with RAN emulator dsTester.
Testing with integ test.
Testing with UEs.

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
