### PR TITLE
feat(ci): focal vms with libvirt

### DIFF
--- a/lte/gateway/deploy/magma_test.yml
+++ b/lte/gateway/deploy/magma_test.yml
@@ -13,9 +13,9 @@
     # - role: stretch_snapshot
     - role: apt_cache
       vars:
-        distribution: "stretch"
+        distribution: "focal"
         oai_build: "{{ c_build }}/core/oai"
-        repo: "dev"
+        repo: "dev-focal"
     - role: pkgrepo
     - role: python_dev
     - role: dev_common

--- a/lte/gateway/deploy/magma_trfserver.yml
+++ b/lte/gateway/deploy/magma_trfserver.yml
@@ -24,5 +24,4 @@
     full_provision: true
 
   roles:
-    - role: stretch_snapshot
     - role: trfserver

--- a/lte/gateway/deploy/roles/dev_common/tasks/main.yml
+++ b/lte/gateway/deploy/roles/dev_common/tasks/main.yml
@@ -419,6 +419,8 @@
   patch:
     src: patches/multipath-conf.patch
     dest: /etc/multipath.conf
+  become: yes
+  ignore_errors: true
 
 - name: Copy Interface file.
   copy:

--- a/lte/gateway/deploy/roles/trfserver/tasks/main.yml
+++ b/lte/gateway/deploy/roles/trfserver/tasks/main.yml
@@ -17,11 +17,6 @@
     msg: "Ansible upgrade needed. Current version is {{ ansible_version.full }}"
   when: preburn or full_provision
 
-# requires Debian 9.2 (Stretch)
-- name: Check Linux distribution version
-  fail: msg="Unsupported host OS {{ ansible_distribution }} {{ ansible_distribution_release }}. Must be Debian 9 (Stretch)"
-  when: ansible_distribution != 'Debian' or ansible_distribution_release != 'stretch'
-
 - name: Create symlink for trfserver scripts
   file:
     src: '{{ magma_root }}/lte/gateway/deploy/roles/trfserver/files/{{ item }}'
@@ -72,9 +67,9 @@
 - name: Install the latest iperf3
   apt:
     deb: "https://iperf.fr/download/ubuntu/{{ item }}"
+    state: present
   with_items:
     - iperf3_3.1.3-1_amd64.deb
-    - libiperf0_3.1.3-1_amd64.deb
   when: preburn
 
 - name: Add convenience function for starting the trfgen test servers

--- a/orc8r/tools/ansible/roles/pkgrepo/tasks/debian.yml
+++ b/orc8r/tools/ansible/roles/pkgrepo/tasks/debian.yml
@@ -12,6 +12,9 @@
 # limitations under the License.
 ################################################################################
 
+- name: Add gpg
+  apt: pkg=gpg state=present update_cache=yes
+
 - name: Add GPG key for magma repository
   apt_key:
     url: https://artifactory.magmacore.org:443/artifactory/api/gpg/key/public

--- a/orc8r/tools/packer/http/preseed_focal_libvirt.cfg
+++ b/orc8r/tools/packer/http/preseed_focal_libvirt.cfg
@@ -1,0 +1,505 @@
+#### Contents of the preconfiguration file (for stretch)
+### Localization
+# Preseeding only locale sets language, country and locale.
+d-i debian-installer/locale string en_US
+
+# The values can also be preseeded individually for greater flexibility.
+#d-i debian-installer/language string en
+#d-i debian-installer/country string NL
+#d-i debian-installer/locale string en_GB.UTF-8
+# Optionally specify additional locales to be generated.
+#d-i localechooser/supported-locales multiselect en_US.UTF-8, nl_NL.UTF-8
+
+# Keyboard selection.
+# Disable automatic (interactive) keymap detection.
+d-i console-setup/ask_detect boolean false
+d-i keyboard-configuration/xkb-keymap select us
+# To select a variant of the selected layout:
+#d-i keyboard-configuration/xkb-keymap select us(dvorak)
+# d-i keyboard-configuration/toggle select No toggling
+
+### Network configuration
+# Disable network configuration entirely. This is useful for cdrom
+# installations on non-networked devices where the network questions,
+# warning and long timeouts are a nuisance.
+#d-i netcfg/enable boolean false
+
+# netcfg will choose an interface that has link if possible. This makes it
+# skip displaying a list if there is more than one interface.
+d-i netcfg/choose_interface select auto
+
+
+
+# To set a different link detection timeout (default is 3 seconds).
+# Values are interpreted as seconds.
+#d-i netcfg/link_wait_timeout string 10
+
+# If you have a slow dhcp server and the installer times out waiting for
+# it, this might be useful.
+#d-i netcfg/dhcp_timeout string 60
+#d-i netcfg/dhcpv6_timeout string 60
+
+# If you prefer to configure the network manually, uncomment this line and
+# the static network configuration below.
+#d-i netcfg/disable_autoconfig boolean true
+
+# If you want the preconfiguration file to work on systems both with and
+# without a dhcp server, uncomment these lines and the static network
+# configuration below.
+#d-i netcfg/dhcp_failed note
+#d-i netcfg/dhcp_options select Configure network manually
+
+# Static network configuration.
+#
+# IPv4 example
+#d-i netcfg/get_ipaddress string 192.168.1.42
+#d-i netcfg/get_netmask string 255.255.255.0
+#d-i netcfg/get_gateway string 192.168.1.1
+#d-i netcfg/get_nameservers string 192.168.1.1
+#d-i netcfg/confirm_static boolean true
+#
+# IPv6 example
+#d-i netcfg/get_ipaddress string fc00::2
+#d-i netcfg/get_netmask string ffff:ffff:ffff:ffff::
+#d-i netcfg/get_gateway string fc00::1
+#d-i netcfg/get_nameservers string fc00::1
+#d-i netcfg/confirm_static boolean true
+
+# Any hostname and domain names assigned from dhcp take precedence over
+# values set here. However, setting the values still prevents the questions
+# from being shown, even if values come from dhcp.
+d-i netcfg/get_hostname string unassigned-hostname
+d-i netcfg/get_domain string unassigned-domain
+
+# If you want to force a hostname, regardless of what either the DHCP
+# server returns or what the reverse DNS entry for the IP is, uncomment
+# and adjust the following line.
+#d-i netcfg/hostname string somehost
+
+# Disable that annoying WEP key dialog.
+d-i netcfg/wireless_wep string
+# The wacky dhcp hostname that some ISPs use as a password of sorts.
+#d-i netcfg/dhcp_hostname string radish
+
+# If non-free firmware is needed for the network or other hardware, you can
+# configure the installer to always try to load it, without prompting. Or
+# change to false to disable asking.
+#d-i hw-detect/load_firmware boolean true
+
+### Network console
+# Use the following settings if you wish to make use of the network-console
+# component for remote installation over SSH. This only makes sense if you
+# intend to perform the remainder of the installation manually.
+#d-i anna/choose_modules string network-console
+#d-i network-console/authorized_keys_url string http://10.0.0.1/openssh-key
+#d-i network-console/password password r00tme
+#d-i network-console/password-again password r00tme
+# Use this instead if you prefer to use key-based authentication
+#d-i network-console/authorized_keys_url http://host/authorized_keys
+
+### Mirror settings
+# If you select ftp, the mirror/country string does not need to be set.
+#d-i mirror/protocol string ftp
+d-i mirror/country string manual
+d-i mirror/http/hostname string archive.ubuntu.com
+d-i mirror/http/directory string /ubuntu
+d-i mirror/http/proxy string
+
+# Alternatively: by default, the installer uses CC.archive.ubuntu.com where
+# CC is the ISO-3166-2 code for the selected country. You can preseed this
+# so that it does so without asking.
+#d-i mirror/http/mirror select CC.archive.ubuntu.com
+
+# Suite to install.
+#d-i mirror/suite string stretch
+# Suite to use for loading installer components (optional).
+#d-i mirror/udeb/suite string stretch
+# Components to use for loading installer components (optional).
+#d-i mirror/udeb/components multiselect main, restricted
+
+### Account setup
+# Skip creation of a root account (normal user account will be able to
+# use sudo). The default is false; preseed this to true if you want to set
+# a root password.
+#d-i passwd/root-login boolean false
+# Alternatively, to skip creation of a normal user account.
+#d-i passwd/make-user boolean false
+
+# Root password, either in clear text
+#d-i passwd/root-password password r00tme
+#d-i passwd/root-password-again password r00tme
+# or encrypted using a crypt(3)  hash.
+#d-i passwd/root-password-crypted password [crypt(3) hash]
+
+# To create a normal user account.
+#d-i passwd/user-fullname string Ubuntu User
+#d-i passwd/username string ubuntu
+# Normal user's password, either in clear text
+#d-i passwd/user-password password insecure
+#d-i passwd/user-password-again password insecure
+# or encrypted using a crypt(3) hash.
+#d-i passwd/user-password-crypted password [crypt(3) hash]
+# Create the first user with the specified UID instead of the default.
+#d-i passwd/user-uid string 1010
+# The installer will warn about weak passwords. If you are sure you know
+# what you're doing and want to override it, uncomment this.
+#d-i user-setup/allow-password-weak boolean true
+
+# The user account will be added to some standard initial groups. To
+# override that, use this.
+#d-i passwd/user-default-groups string audio cdrom video
+
+# Set to true if you want to encrypt the first user's home directory.
+d-i user-setup/encrypt-home boolean false
+
+### Clock and time zone setup
+# Controls whether or not the hardware clock is set to UTC.
+d-i clock-setup/utc boolean true
+
+# You may set this to any valid setting for $TZ; see the contents of
+# /usr/share/zoneinfo/ for valid values.
+d-i time/zone string US/Eastern
+
+# Controls whether to use NTP to set the clock during the install
+d-i clock-setup/ntp boolean true
+# NTP server to use. The default is almost always fine here.
+#d-i clock-setup/ntp-server string ntp.example.com
+
+### i386 specific disk storage
+# Activate DASD disks
+#d-i s390-dasd/dasd string 0.0.0200,0.0.0300,0.0.0400
+
+# DASD configuration; by default dasdfmt (low-level format) if needed
+#d-i s390-dasd/auto-format boolean true
+#d-i s390-dasd/force-format boolean true
+
+# zFCP activation and configuration
+# d-i s390-zfcp/zfcp string 0.0.1b34:0x400870075678a1b2:0x201480c800000000, \
+#                           0.0.1b34:0x400870075679a1b2:0x201480c800000000
+
+### Partitioning
+## Partitioning example
+# If the system has free space you can choose to only partition that space.
+# This is only honoured if partman-auto/method (below) is not set.
+# Alternatives: custom, some_device, some_device_crypto, some_device_lvm.
+#d-i partman-auto/init_automatically_partition select biggest_free
+
+# Alternatively, you may specify a disk to partition. If the system has only
+# one disk the installer will default to using that, but otherwise the device
+# name must be given in traditional, non-devfs format (so e.g. /dev/sda
+# and not e.g. /dev/discs/disc0/disc).
+# For example, to use the first SCSI/SATA hard disk:
+#d-i partman-auto/disk string /dev/sda
+# In addition, you'll need to specify the method to use.
+# The presently available methods are:
+# - regular: use the usual partition types for your architecture
+# - lvm:     use LVM to partition the disk
+# - crypto:  use LVM within an encrypted partition
+d-i partman-auto/method string lvm
+
+# If one of the disks that are going to be automatically partitioned
+# contains an old LVM configuration, the user will normally receive a
+# warning. This can be preseeded away...
+d-i partman-lvm/device_remove_lvm boolean true
+# The same applies to pre-existing software RAID array:
+d-i partman-md/device_remove_md boolean true
+# And the same goes for the confirmation to write the lvm partitions.
+d-i partman-lvm/confirm boolean true
+d-i partman-lvm/confirm_nooverwrite boolean true
+
+# For LVM partitioning, you can select how much of the volume group to use
+# for logical volumes.
+d-i partman-auto-lvm/guided_size string max
+#d-i partman-auto-lvm/guided_size string 10GB
+#d-i partman-auto-lvm/guided_size string 50%
+
+# You can choose one of the three predefined partitioning recipes:
+# - atomic: all files in one partition
+# - home:   separate /home partition
+# - multi:  separate /home, /var, and /tmp partitions
+d-i partman-auto/choose_recipe select atomic
+
+# Or provide a recipe of your own...
+# If you have a way to get a recipe file into the d-i environment, you can
+# just point at it.
+#d-i partman-auto/expert_recipe_file string /hd-media/recipe
+
+# If not, you can put an entire recipe into the preconfiguration file in one
+# (logical) line. This example creates a small /boot partition, suitable
+# swap, and uses the rest of the space for the root partition:
+#d-i partman-auto/expert_recipe string                         \
+#      boot-root ::                                            \
+#              40 50 100 ext3                                  \
+#                      $primary{ } $bootable{ }                \
+#                      method{ format } format{ }              \
+#                      use_filesystem{ } filesystem{ ext3 }    \
+#                      mountpoint{ /boot }                     \
+#              .                                               \
+#              500 10000 1000000000 ext3                       \
+#                      method{ format } format{ }              \
+#                      use_filesystem{ } filesystem{ ext3 }    \
+#                      mountpoint{ / }                         \
+#              .                                               \
+#              64 512 300% linux-swap                          \
+#                      method{ swap } format{ }                \
+#              .
+
+# If you just want to change the default filesystem from ext3 to something
+# else, you can do that without providing a full recipe.
+#d-i partman/default_filesystem string ext4
+
+# The full recipe format is documented in the file partman-auto-recipe.txt
+# included in the 'debian-installer' package or available from D-I source
+# repository. This also documents how to specify settings such as file
+# system labels, volume group names and which physical devices to include
+# in a volume group.
+
+# This makes partman automatically partition without confirmation, provided
+# that you told it what to do using one of the methods above.
+d-i partman-partitioning/confirm_write_new_label boolean true
+d-i partman/choose_partition select finish
+d-i partman/confirm boolean true
+d-i partman/confirm_nooverwrite boolean true
+
+## Partitioning using RAID
+# The method should be set to "raid".
+#d-i partman-auto/method string raid
+# Specify the disks to be partitioned. They will all get the same layout,
+# so this will only work if the disks are the same size.
+#d-i partman-auto/disk string /dev/sda /dev/sdb
+
+# Next you need to specify the physical partitions that will be used.
+#d-i partman-auto/expert_recipe string \
+#      multiraid ::                                         \
+#              1000 5000 4000 raid                          \
+#                      $primary{ } method{ raid }           \
+#              .                                            \
+#              64 512 300% raid                             \
+#                      method{ raid }                       \
+#              .                                            \
+#              500 10000 1000000000 raid                    \
+#                      method{ raid }                       \
+#              .
+
+# Last you need to specify how the previously defined partitions will be
+# used in the RAID setup. Remember to use the correct partition numbers
+# for logical partitions. RAID levels 0, 1, 5, 6 and 10 are supported;
+# devices are separated using "#".
+# Parameters are:
+# <raidtype> <devcount> <sparecount> <fstype> <mountpoint> \
+#          <devices> <sparedevices>
+
+#d-i partman-auto-raid/recipe string \
+#    1 2 0 ext3 /                    \
+#          /dev/sda1#/dev/sdb1       \
+#    .                               \
+#    1 2 0 swap -                    \
+#          /dev/sda5#/dev/sdb5       \
+#    .                               \
+#    0 2 0 ext3 /home                \
+#          /dev/sda6#/dev/sdb6       \
+#    .
+
+# For additional information see the file partman-auto-raid-recipe.txt
+# included in the 'debian-installer' package or available from D-I source
+# repository.
+
+# This makes partman automatically partition without confirmation.
+d-i partman-md/confirm boolean true
+d-i partman-partitioning/confirm_write_new_label boolean true
+d-i partman/choose_partition select finish
+d-i partman/confirm boolean true
+d-i partman/confirm_nooverwrite boolean true
+
+## Controlling how partitions are mounted
+# The default is to mount by UUID, but you can also choose "traditional" to
+# use traditional device names, or "label" to try filesystem labels before
+# falling back to UUIDs.
+#d-i partman/mount_style select uuid
+
+### Base system installation
+# Configure a path to the preconfigured base filesystem. This can be used to
+# specify a path for the installer to retrieve the filesystem image that will
+# be deployed to disk and used as a base system for the installation.
+#d-i live-installer/net-image string /install/filesystem.squashfs
+
+# Configure APT to not install recommended packages by default. Use of this
+# option can result in an incomplete system and should only be used by very
+# experienced users.
+#d-i base-installer/install-recommends boolean false
+
+# The kernel image (meta) package to be installed; "none" can be used if no
+# kernel is to be installed.
+#d-i base-installer/kernel/image string linux-generic
+
+### Apt setup
+# You can choose to install restricted and universe software, or to install
+# software from the backports repository.
+#d-i apt-setup/restricted boolean true
+#d-i apt-setup/universe boolean true
+#d-i apt-setup/backports boolean true
+# Uncomment this if you don't want to use a network mirror.
+#d-i apt-setup/use_mirror boolean false
+# Select which update services to use; define the mirrors to be used.
+# Values shown below are the normal defaults.
+#d-i apt-setup/services-select multiselect security
+#d-i apt-setup/security_host string security.ubuntu.com
+#d-i apt-setup/security_path string /ubuntu
+
+# Additional repositories, local[0-9] available
+#d-i apt-setup/local0/repository string \
+#       http://local.server/ubuntu stretch main
+#d-i apt-setup/local0/comment string local server
+# Enable deb-src lines
+#d-i apt-setup/local0/source boolean true
+# URL to the public key of the local repository; you must provide a key or
+# apt will complain about the unauthenticated repository and so the
+# sources.list line will be left commented out
+#d-i apt-setup/local0/key string http://local.server/key
+
+# By default the installer requires that repositories be authenticated
+# using a known gpg key. This setting can be used to disable that
+# authentication. Warning: Insecure, not recommended.
+#d-i debian-installer/allow_unauthenticated boolean true
+
+# Uncomment this to add multiarch configuration for i386
+#d-i apt-setup/multiarch string i386
+
+
+### Package selection
+tasksel tasksel/first multiselect ubuntu-desktop
+#tasksel tasksel/first multiselect lamp-server, print-server
+#tasksel tasksel/first multiselect kubuntu-desktop
+
+# Individual additional packages to install
+#d-i pkgsel/include string openssh-server build-essential
+# Whether to upgrade packages after debootstrap.
+# Allowed values: none, safe-upgrade, full-upgrade
+#d-i pkgsel/upgrade select none
+
+# Language pack selection
+#d-i pkgsel/language-packs multiselect de, en, zh
+
+# Policy for applying updates. May be "none" (no automatic updates),
+# "unattended-upgrades" (install security updates automatically), or
+# "landscape" (manage system with Landscape).
+d-i pkgsel/update-policy select none
+
+# Some versions of the installer can report back on what software you have
+# installed, and what software you use. The default is not to report back,
+# but sending reports helps the project determine what software is most
+# popular and include it on CDs.
+#popularity-contest popularity-contest/participate boolean false
+
+# By default, the system's locate database will be updated after the
+# installer has finished installing most packages. This may take a while, so
+# if you don't want it, you can set this to "false" to turn it off.
+#d-i pkgsel/updatedb boolean true
+
+### Boot loader installation
+# Grub is the default boot loader (for x86). If you want lilo installed
+# instead, uncomment this:
+#d-i grub-installer/skip boolean true
+# To also skip installing lilo, and install no bootloader, uncomment this
+# too:
+#d-i lilo-installer/skip boolean true
+
+
+# This is fairly safe to set, it makes grub install automatically to the MBR
+# if no other operating system is detected on the machine.
+d-i grub-installer/only_debian boolean true
+
+# This one makes grub-installer install to the MBR if it also finds some other
+# OS, which is less safe as it might not be able to boot that other OS.
+d-i grub-installer/with_other_os boolean true
+
+# Due notably to potential USB sticks, the location of the MBR can not be
+# determined safely in general, so this needs to be specified:
+d-i partman-auto/disk string /dev/vda
+d-i grub-installer/bootdev  string /dev/vda
+# To install to the first device (assuming it is not a USB stick):
+#d-i grub-installer/bootdev  string default
+
+# Alternatively, if you want to install to a location other than the mbr,
+# uncomment and edit these lines:
+#d-i grub-installer/only_debian boolean false
+#d-i grub-installer/with_other_os boolean false
+#d-i grub-installer/bootdev  string (hd0,1)
+# To install grub to multiple disks:
+#d-i grub-installer/bootdev  string (hd0,1) (hd1,1) (hd2,1)
+
+# Optional password for grub, either in clear text
+#d-i grub-installer/password password r00tme
+#d-i grub-installer/password-again password r00tme
+# or encrypted using an MD5 hash, see grub-md5-crypt(8).
+#d-i grub-installer/password-crypted password [MD5 hash]
+
+# Use the following option to add additional boot parameters for the
+# installed system (if supported by the bootloader installer).
+# Note: options passed to the installer will be added automatically.
+#d-i debian-installer/add-kernel-opts string nousb
+
+### Finishing up the installation
+# During installations from serial console, the regular virtual consoles
+# (VT1-VT6) are normally disabled in /etc/inittab. Uncomment the next
+# line to prevent this.
+#d-i finish-install/keep-consoles boolean true
+
+# Avoid that last message about the install being complete.
+d-i finish-install/reboot_in_progress note
+
+# This will prevent the installer from ejecting the CD during the reboot,
+# which is useful in some situations.
+#d-i cdrom-detect/eject boolean false
+
+# This is how to make the installer shutdown when finished, but not
+# reboot into the installed system.
+#d-i debian-installer/exit/halt boolean true
+# This will power off the machine instead of just halting it.
+#d-i debian-installer/exit/poweroff boolean true
+
+### Preseeding other packages
+# Depending on what software you choose to install, or if things go wrong
+# during the installation process, it's possible that other questions may
+# be asked. You can preseed those too, of course. To get a list of every
+# possible question that could be asked during an install, do an
+# installation, and then run these commands:
+#   debconf-get-selections --installer > file
+#   debconf-get-selections >> file
+
+
+#### Advanced options
+### Running custom commands during the installation
+## i386 Preseed Example
+# d-i preseeding is inherently not secure. Nothing in the installer checks
+# for attempts at buffer overflows or other exploits of the values of a
+# preconfiguration file like this one. Only use preconfiguration files from
+# trusted locations! To drive that home, and because it's generally useful,
+# here's a way to run any shell command you'd like inside the installer,
+# automatically.
+
+# This first command is run as early as possible, just after
+# preseeding is read.
+#d-i preseed/early_command string anna-install some-udeb
+# This command is run immediately before the partitioner starts. It may be
+# useful to apply dynamic partitioner preseeding that depends on the state
+# of the disks (which may not be visible when preseed/early_command runs).
+#d-i partman/early_command \
+#       string debconf-set partman-auto/disk "$(list-devices disk | head -n1)"
+# This command is run just before the install finishes, but when there is
+# still a usable /target directory. You can chroot to /target and use it
+# directly, or use the apt-install and in-target commands to easily install
+# packages and run commands in the target system.
+#d-i preseed/late_command string apt-install zsh; in-target chsh -s /bin/zsh
+
+d-i pkgsel/include string openssh-server
+
+# Create vagrant user account.
+d-i passwd/user-fullname string vagrant
+d-i passwd/username string vagrant
+d-i passwd/user-password password vagrant
+d-i passwd/user-password-again password vagrant
+d-i user-setup/allow-password-weak boolean true
+d-i user-setup/encrypt-home boolean false
+d-i passwd/user-default-groups vagrant sudo
+d-i passwd/user-uid string 900

--- a/orc8r/tools/packer/magma-dev-libvirt.json
+++ b/orc8r/tools/packer/magma-dev-libvirt.json
@@ -1,85 +1,80 @@
 {
-  "variables": {
-    "cloud_token": "{{ env `ATLAS_TOKEN` }}",
-    "version": "1.0.{{timestamp}}",
-    "cpus": "2",
-    "memory": "2048",
-    "disk_size": "40G",
-    "boot_wait": "10s"
-  },
-  "builders": [{
-    "type": "qemu",
-    "vm_name": "magma-dev",
-    "iso_checksum": "md5:5c583fd40360fd039b3ac98387b77dbb",
-    "iso_url": "https://cdimage.debian.org/mirror/cdimage/archive/9.2.1/amd64/iso-cd/debian-9.2.1-amd64-netinst.iso",
-    "disk_size": "{{ user `disk_size` }}",
-    "headless": true,
-    "http_directory": ".",
-    "ssh_username": "vagrant",
-    "ssh_password": "vagrant",
-    "shutdown_command": "echo 'vagrant' | sudo -S shutdown -P now",
-    "ssh_wait_timeout": "64206s",
-    "format": "qcow2",
-    "skip_compaction": false,
-    "disk_compression": true,
-    "accelerator": "kvm",
-    "qemuargs": [
-      [ "-smp", "{{ user `cpus` }}" ],
-      [ "-m", "{{ user `memory` }}M" ]
-    ],
-
-    "boot_wait": "{{ user `boot_wait` }}",
-    "boot_command":
-    [
-      "<esc><wait>",
-      "install ",
-      "preseed/url=http://{{ .HTTPIP }}:{{ .HTTPPort }}/magma-libvirt.seed <wait>",
-      "debian-installer=en_US ",
-      "auto=true ",
-      "locale=en_US ",
-      "kbd-chooser/method=us ",
-      "keyboard-configuration/xkb-keymap=us ",
-      "netcfg/get_hostname={{ .Name }} <wait>",
-      "netcfg/get_domain=magma.com <wait>",
-      "fb=false ",
-      "debconf/frontend=noninteractive ",
-      "console-setup/ask_detect=false ",
-      "console-keymaps-at/keymap=us ",
-      "<enter><wait>"
-    ]
-  }],
+  "builders": [
+    {
+      "boot_command": [
+        "<esc><wait>",
+        "<esc><wait>",
+        "<enter><wait>",
+        "/install/vmlinuz<wait>",
+        " auto<wait>",
+        " console-setup/ask_detect=false<wait>",
+        " console-setup/layoutcode=us<wait>",
+        " console-setup/modelcode=pc105<wait>",
+        " debconf/frontend=noninteractive<wait>",
+        " debian-installer=en_US.UTF-8<wait>",
+        " fb=false<wait>",
+        " initrd=/install/initrd.gz<wait>",
+        " kbd-chooser/method=us<wait>",
+        " keyboard-configuration/layout=USA<wait>",
+        " keyboard-configuration/variant=USA<wait>",
+        " locale=en_US.UTF-8<wait>",
+        " netcfg/get_domain=magma.com<wait>",
+        " netcfg/get_hostname={{ .Name }}<wait>",
+        " grub-installer/bootdev=/dev/vda<wait>",
+        " noapic<wait>",
+        " preseed/url=http://{{ .HTTPIP }}:{{ .HTTPPort }}/preseed_focal_libvirt.cfg<wait>",
+        " -- <wait>",
+        "<enter><wait>"
+      ],
+      "boot_wait": "5s",
+      "headless": true,
+      "http_directory": "http",
+      "iso_checksum": "sha256:f11bda2f2caed8f420802b59f382c25160b114ccc665dbac9c5046e7fceaced2",
+      "iso_url": "https://cdimage.ubuntu.com/ubuntu-legacy-server/releases/20.04/release/ubuntu-20.04.1-legacy-server-amd64.iso",
+      "memory": 2048,
+      "name": "magma-dev",
+      "shutdown_command": "echo 'vagrant'|sudo -S shutdown -P now",
+      "ssh_handshake_attempts": "20",
+      "ssh_password": "vagrant",
+      "ssh_timeout": "64206s",
+      "ssh_username": "vagrant",
+      "skip_compaction": false,
+      "disk_compression": true,
+      "type": "qemu",
+      "accelerator": "kvm",
+      "qemuargs": [
+        [ "-smp", "2" ],
+        [ "-m", "2048M" ]
+      ],
+      "vm_name": "magma-dev"
+    }
+  ],
   "provisioners": [
-{
-      "type": "shell",
-      "script": "scripts/provision-stretch.sh",
-      "execute_command": "echo 'vagrant' | sudo -S env {{.Vars}} {{.Path}}"
-    },{
-      "type": "shell",
-      "inline": ["sudo reboot"],
-      "expect_disconnect": true
-    },{
-      "type": "shell",
-      "script": "scripts/guest_additions.sh",
+    {
       "execute_command": "echo 'vagrant' | sudo -S env {{.Vars}} {{.Path}}",
-      "pause_before": "10s"
-    }, {
-      "type": "shell",
+      "script": "scripts/ubuntu_setup_libvirt.sh",
+      "type": "shell"
+    },
+    {
+      "expect_disconnect": true,
+      "inline": [
+        "sudo reboot"
+      ],
+      "type": "shell"
+    },
+    {
+      "execute_command": "echo 'vagrant' | sudo -S env {{.Vars}} {{.Path}}",
       "script": "scripts/vagrant_key.sh",
-      "execute_command": "echo 'vagrant' | sudo -S env {{.Vars}} {{.Path}}"
+      "type": "shell"
     },
     {
-      "type": "shell",
       "execute_command": "echo 'vagrant' | {{.Vars}} sudo -S -E bash '{{.Path}}'",
-      "script": "scripts/setup.sh"
-    },
-    {
-      "type": "shell",
-      "execute_command": "echo 'vagrant' | {{.Vars}} sudo -S -E bash '{{.Path}}'",
-      "script": "scripts/ansible_debian.sh"
+      "script": "scripts/setup.sh",
+      "type": "shell"
     },
     {
       "type": "ansible-local",
-      "playbook_file": "../../../lte/gateway/deploy/magma_dev.yml",
+      "playbook_file": "../../../lte/gateway/deploy/magma_dev_focal.yml",
       "inventory_groups": "dev",
       "role_paths": [
         "../../../orc8r/tools/ansible/roles/apt_cache",
@@ -108,19 +103,19 @@
         "../../../lte/gateway/deploy/roles/uselocalpkgrepo"
       ],
       "extra_arguments": [
-        "--extra-vars '{\"ansible_user\": \"vagrant\", \"preburn\": true, \"full_provision\": false}'"
+        "-vvvv --extra-vars '{\"ansible_user\": \"vagrant\", \"preburn\": true, \"full_provision\": false, \"ansible_distribution\": \"Ubuntu\"}'"
       ]
     }
   ],
   "post-processors": [
     [
       {
-        "output": "builds/magma_dev_{{.Provider}}.box",
+        "output": "builds/magma-dev-{{.Provider}}.box",
         "type": "vagrant"
       },
       {
         "type": "vagrant-cloud",
-        "box_tag": "magmacore/magma_dev",
+        "box_tag": "magmacore/magma_focal_libvirt_dev",
         "access_token": "{{user `cloud_token`}}",
         "version": "{{user `version`}}"
       }

--- a/orc8r/tools/packer/magma-libvirt.seed
+++ b/orc8r/tools/packer/magma-libvirt.seed
@@ -48,8 +48,8 @@ d-i passwd/root-login boolean false
 # create a user
 d-i passwd/user-fullname string vagrant
 d-i passwd/username string vagrant
-d-i passwd/user-password password vagrant
-d-i passwd/user-password-again password vagrant
+d-i passwd/user-password password vagrantvagrant
+d-i passwd/user-password-again password vagrantvagrant
 
 # utc all day
 d-i clock-setup/utc boolean true
@@ -85,4 +85,4 @@ d-i finish-install/reboot_in_progress note
 # Prevent packaged version of VirtualBox Guest Additions being installed:
 d-i preseed/early_command string sed -i \
   '/in-target/idiscover(){/sbin/discover|grep -v VirtualBox;}' \
-  /usr/lib/pre-pkgsel.d/20install-hwpackages
+  /usr/lib/pre-pkgsel.d/20install-hwpackages || true

--- a/orc8r/tools/packer/magma-test-libvirt.json
+++ b/orc8r/tools/packer/magma-test-libvirt.json
@@ -1,81 +1,76 @@
 {
-  "variables": {
-    "cloud_token": "{{ env `ATLAS_TOKEN` }}",
-    "version": "1.0.{{timestamp}}",
-    "cpus": "2",
-    "memory": "2048",
-    "disk_size": "40G",
-    "boot_wait": "10s"
-  },
-  "builders": [{
-    "type": "qemu",
-    "vm_name": "magma-test",
-    "iso_checksum": "md5:5c583fd40360fd039b3ac98387b77dbb",
-    "iso_url": "https://cdimage.debian.org/mirror/cdimage/archive/9.2.1/amd64/iso-cd/debian-9.2.1-amd64-netinst.iso",
-    "disk_size": "{{ user `disk_size` }}",
-    "headless": true,
-    "http_directory": ".",
-    "ssh_username": "vagrant",
-    "ssh_password": "vagrant",
-    "shutdown_command": "echo 'vagrant' | sudo -S shutdown -P now",
-    "ssh_wait_timeout": "64206s",
-    "format": "qcow2",
-    "skip_compaction": false,
-    "disk_compression": true,
-    "accelerator": "kvm",
-    "qemuargs": [
-      [ "-smp", "{{ user `cpus` }}" ],
-      [ "-m", "{{ user `memory` }}M" ]
-    ],
-
-    "boot_wait": "{{ user `boot_wait` }}",
-    "boot_command":
-    [
-      "<esc><wait>",
-      "install ",
-      "preseed/url=http://{{ .HTTPIP }}:{{ .HTTPPort }}/magma-libvirt.seed <wait>",
-      "debian-installer=en_US ",
-      "auto=true ",
-      "locale=en_US ",
-      "kbd-chooser/method=us ",
-      "keyboard-configuration/xkb-keymap=us ",
-      "netcfg/get_hostname={{ .Name }} <wait>",
-      "netcfg/get_domain=magma.com <wait>",
-      "fb=false ",
-      "debconf/frontend=noninteractive ",
-      "console-setup/ask_detect=false ",
-      "console-keymaps-at/keymap=us ",
-      "<enter><wait>"
-    ]
-  }],
+  "builders": [
+    {
+      "boot_command": [
+        "<esc><wait>",
+        "<esc><wait>",
+        "<enter><wait>",
+        "/install/vmlinuz<wait>",
+        " auto<wait>",
+        " console-setup/ask_detect=false<wait>",
+        " console-setup/layoutcode=us<wait>",
+        " console-setup/modelcode=pc105<wait>",
+        " debconf/frontend=noninteractive<wait>",
+        " debian-installer=en_US.UTF-8<wait>",
+        " fb=false<wait>",
+        " initrd=/install/initrd.gz<wait>",
+        " kbd-chooser/method=us<wait>",
+        " keyboard-configuration/layout=USA<wait>",
+        " keyboard-configuration/variant=USA<wait>",
+        " locale=en_US.UTF-8<wait>",
+        " netcfg/get_domain=magma.com<wait>",
+        " netcfg/get_hostname={{ .Name }}<wait>",
+        " grub-installer/bootdev=/dev/vda<wait>",
+        " noapic<wait>",
+        " preseed/url=http://{{ .HTTPIP }}:{{ .HTTPPort }}/preseed_focal_libvirt.cfg<wait>",
+        " -- <wait>",
+        "<enter><wait>"
+      ],
+      "boot_wait": "5s",
+      "headless": true,
+      "http_directory": "http",
+      "iso_checksum": "sha256:f11bda2f2caed8f420802b59f382c25160b114ccc665dbac9c5046e7fceaced2",
+      "iso_url": "https://cdimage.ubuntu.com/ubuntu-legacy-server/releases/20.04/release/ubuntu-20.04.1-legacy-server-amd64.iso",
+      "memory": 2048,
+      "name": "magma-test",
+      "shutdown_command": "echo 'vagrant'|sudo -S shutdown -P now",
+      "ssh_handshake_attempts": "20",
+      "ssh_password": "vagrant",
+      "ssh_timeout": "64206s",
+      "ssh_username": "vagrant",
+      "skip_compaction": false,
+      "disk_compression": true,
+      "type": "qemu",
+      "accelerator": "kvm",
+      "qemuargs": [
+        [ "-smp", "2" ],
+        [ "-m", "2048M" ]
+      ],
+      "vm_name": "magma-test"
+    }
+  ],
   "provisioners": [
-{
-      "type": "shell",
-      "script": "scripts/provision-stretch.sh",
-      "execute_command": "echo 'vagrant' | sudo -S env {{.Vars}} {{.Path}}"
-    },{
-      "type": "shell",
-      "inline": ["sudo reboot"],
-      "expect_disconnect": true
-    },{
-      "type": "shell",
-      "script": "scripts/guest_additions.sh",
+    {
       "execute_command": "echo 'vagrant' | sudo -S env {{.Vars}} {{.Path}}",
-      "pause_before": "10s"
-    }, {
-      "type": "shell",
+      "script": "scripts/ubuntu_setup_libvirt.sh",
+      "type": "shell"
+    },
+    {
+      "expect_disconnect": true,
+      "inline": [
+        "sudo reboot"
+      ],
+      "type": "shell"
+    },
+    {
+      "execute_command": "echo 'vagrant' | sudo -S env {{.Vars}} {{.Path}}",
       "script": "scripts/vagrant_key.sh",
-      "execute_command": "echo 'vagrant' | sudo -S env {{.Vars}} {{.Path}}"
+      "type": "shell"
     },
     {
-      "type": "shell",
       "execute_command": "echo 'vagrant' | {{.Vars}} sudo -S -E bash '{{.Path}}'",
-      "script": "scripts/setup.sh"
-    },
-    {
-      "type": "shell",
-      "execute_command": "echo 'vagrant' | {{.Vars}} sudo -S -E bash '{{.Path}}'",
-      "script": "scripts/ansible_debian.sh"
+      "script": "scripts/setup.sh",
+      "type": "shell"
     },
     {
       "type": "ansible-local",
@@ -108,19 +103,19 @@
         "../../../lte/gateway/deploy/roles/uselocalpkgrepo"
       ],
       "extra_arguments": [
-        "--extra-vars '{\"ansible_user\": \"vagrant\", \"preburn\": true, \"full_provision\": false}'"
+        "-vvvv --extra-vars '{\"ansible_user\": \"vagrant\", \"preburn\": true, \"full_provision\": false, \"ansible_distribution\": \"Ubuntu\"}'"
       ]
     }
   ],
   "post-processors": [
     [
       {
-        "output": "builds/magma_test_{{.Provider}}.box",
+        "output": "builds/magma-test-{{.Provider}}.box",
         "type": "vagrant"
       },
       {
         "type": "vagrant-cloud",
-        "box_tag": "magmacore/magma_test",
+        "box_tag": "magmacore/magma_focal_libvirt_test",
         "access_token": "{{user `cloud_token`}}",
         "version": "{{user `version`}}"
       }
@@ -128,3 +123,4 @@
     ]
   ]
 }
+

--- a/orc8r/tools/packer/magma-trfserver-libvirt.json
+++ b/orc8r/tools/packer/magma-trfserver-libvirt.json
@@ -1,104 +1,98 @@
 {
-  "variables": {
-    "cloud_token": "{{ env `ATLAS_TOKEN` }}",
-    "version": "1.0.{{timestamp}}",
-    "cpus": "2",
-    "memory": "2048",
-    "disk_size": "40G",
-    "boot_wait": "10s"
-  },
-  "builders": [{
-    "type": "qemu",
-    "vm_name": "magma-trfserver",
-    "iso_checksum": "md5:5c583fd40360fd039b3ac98387b77dbb",
-    "iso_url": "https://cdimage.debian.org/mirror/cdimage/archive/9.2.1/amd64/iso-cd/debian-9.2.1-amd64-netinst.iso",
-    "disk_size": "{{ user `disk_size` }}",
-    "headless": true,
-    "http_directory": ".",
-    "ssh_username": "vagrant",
-    "ssh_password": "vagrant",
-    "shutdown_command": "echo 'vagrant' | sudo -S shutdown -P now",
-    "ssh_wait_timeout": "64206s",
-    "format": "qcow2",
-    "skip_compaction": false,
-    "disk_compression": true,
-    "accelerator": "kvm",
-    "qemuargs": [
-      [ "-smp", "{{ user `cpus` }}" ],
-      [ "-m", "{{ user `memory` }}M" ]
-    ],
-
-    "boot_wait": "{{ user `boot_wait` }}",
-    "boot_command":
-    [
-      "<esc><wait>",
-      "install ",
-      "preseed/url=http://{{ .HTTPIP }}:{{ .HTTPPort }}/magma-libvirt.seed <wait>",
-      "debian-installer=en_US ",
-      "auto=true ",
-      "locale=en_US ",
-      "kbd-chooser/method=us ",
-      "keyboard-configuration/xkb-keymap=us ",
-      "netcfg/get_hostname={{ .Name }} <wait>",
-      "netcfg/get_domain=magma.com <wait>",
-      "fb=false ",
-      "debconf/frontend=noninteractive ",
-      "console-setup/ask_detect=false ",
-      "console-keymaps-at/keymap=us ",
-      "<enter><wait>"
-    ]
-  }],
+  "builders": [
+    {
+      "boot_command": [
+        "<esc><wait>",
+        "<esc><wait>",
+        "<enter><wait>",
+        "/install/vmlinuz<wait>",
+        " auto<wait>",
+        " console-setup/ask_detect=false<wait>",
+        " console-setup/layoutcode=us<wait>",
+        " console-setup/modelcode=pc105<wait>",
+        " debconf/frontend=noninteractive<wait>",
+        " debian-installer=en_US.UTF-8<wait>",
+        " fb=false<wait>",
+        " initrd=/install/initrd.gz<wait>",
+        " kbd-chooser/method=us<wait>",
+        " keyboard-configuration/layout=USA<wait>",
+        " keyboard-configuration/variant=USA<wait>",
+        " locale=en_US.UTF-8<wait>",
+        " netcfg/get_domain=magma.com<wait>",
+        " netcfg/get_hostname={{ .Name }}<wait>",
+        " grub-installer/bootdev=/dev/vda<wait>",
+        " noapic<wait>",
+        " preseed/url=http://{{ .HTTPIP }}:{{ .HTTPPort }}/preseed_focal_libvirt.cfg<wait>",
+        " -- <wait>",
+        "<enter><wait>"
+      ],
+      "boot_wait": "5s",
+      "headless": true,
+      "http_directory": "http",
+      "iso_checksum": "sha256:f11bda2f2caed8f420802b59f382c25160b114ccc665dbac9c5046e7fceaced2",
+      "iso_url": "https://cdimage.ubuntu.com/ubuntu-legacy-server/releases/20.04/release/ubuntu-20.04.1-legacy-server-amd64.iso",
+      "memory": 2048,
+      "name": "magma-trfserver",
+      "shutdown_command": "echo 'vagrant'|sudo -S shutdown -P now",
+      "ssh_handshake_attempts": "20",
+      "ssh_password": "vagrant",
+      "ssh_timeout": "64206s",
+      "ssh_username": "vagrant",
+      "skip_compaction": false,
+      "disk_compression": true,
+      "type": "qemu",
+      "accelerator": "kvm",
+      "qemuargs": [
+        [ "-smp", "2" ],
+        [ "-m", "2048M" ]
+      ],
+      "vm_name": "magma-trfserver"
+    }
+  ],
   "provisioners": [
-{
-      "type": "shell",
-      "script": "scripts/provision-stretch.sh",
-      "execute_command": "echo 'vagrant' | sudo -S env {{.Vars}} {{.Path}}"
-    },{
-      "type": "shell",
-      "inline": ["sudo reboot"],
-      "expect_disconnect": true
-    },{
-      "type": "shell",
-      "script": "scripts/guest_additions.sh",
+    {
       "execute_command": "echo 'vagrant' | sudo -S env {{.Vars}} {{.Path}}",
-      "pause_before": "10s"
-    }, {
-      "type": "shell",
+      "script": "scripts/ubuntu_setup_libvirt.sh",
+      "type": "shell"
+    },
+    {
+      "expect_disconnect": true,
+      "inline": [
+        "sudo reboot"
+      ],
+      "type": "shell"
+    },
+    {
+      "execute_command": "echo 'vagrant' | sudo -S env {{.Vars}} {{.Path}}",
       "script": "scripts/vagrant_key.sh",
-      "execute_command": "echo 'vagrant' | sudo -S env {{.Vars}} {{.Path}}"
+      "type": "shell"
     },
     {
-      "type": "shell",
       "execute_command": "echo 'vagrant' | {{.Vars}} sudo -S -E bash '{{.Path}}'",
-      "script": "scripts/setup.sh"
-    },
-    {
-      "type": "shell",
-      "execute_command": "echo 'vagrant' | {{.Vars}} sudo -S -E bash '{{.Path}}'",
-      "script": "scripts/ansible_debian.sh"
+      "script": "scripts/setup.sh",
+      "type": "shell"
     },
     {
       "type": "ansible-local",
       "playbook_file": "../../../lte/gateway/deploy/magma_trfserver.yml",
       "inventory_groups": "trfserver",
       "role_paths": [
-        "../../../lte/gateway/deploy/roles/trfserver",
-        "../../../lte/gateway/deploy/roles/stretch_snapshot"
+        "../../../lte/gateway/deploy/roles/trfserver"
       ],
       "extra_arguments": [
-        "--extra-vars '{\"ansible_user\": \"vagrant\", \"preburn\": true, \"full_provision\": false}'"
+        "-v --extra-vars '{\"ansible_user\": \"vagrant\", \"preburn\": true, \"full_provision\": false, \"ansible_distribution\": \"Ubuntu\"}'"
       ]
     }
   ],
   "post-processors": [
     [
       {
-        "output": "builds/magma_trfserver_{{.Provider}}.box",
+        "output": "builds/magma-trfserver-{{.Provider}}.box",
         "type": "vagrant"
       },
       {
         "type": "vagrant-cloud",
-        "box_tag": "magmacore/magma_trfserver",
+        "box_tag": "magmacore/magma_focal_libvirt_trfserver",
         "access_token": "{{user `cloud_token`}}",
         "version": "{{user `version`}}"
       }

--- a/orc8r/tools/packer/magma-trfserver-virtualbox.json
+++ b/orc8r/tools/packer/magma-trfserver-virtualbox.json
@@ -70,14 +70,14 @@
         "../../../lte/gateway/deploy/roles/stretch_snapshot"
       ],
       "extra_arguments": [
-        "--extra-vars '{\"ansible_user\": \"vagrant\", \"preburn\": true, \"full_provision\": false}'"
+        "-v --extra-vars '{\"ansible_user\": \"vagrant\", \"preburn\": true, \"full_provision\": false}'"
       ]
     }
   ],
   "post-processors": [
     [
       {
-        "output": "builds/magma_trfserver_{{.Provider}}.box",
+        "output": "builds/magma-trfserver-{{.Provider}}.box",
         "type": "vagrant"
       },
       {

--- a/orc8r/tools/packer/scripts/ubuntu_setup_libvirt.sh
+++ b/orc8r/tools/packer/scripts/ubuntu_setup_libvirt.sh
@@ -1,0 +1,45 @@
+#!/bin/bash -eux
+################################################################################
+# Copyright 2020 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+# Add ubuntu user to sudoers.
+echo "ubuntu        ALL=(ALL)       NOPASSWD: ALL" >> /etc/sudoers
+echo "vagrant        ALL=(ALL)       NOPASSWD: ALL" >> /etc/sudoers
+sed -i "s/^.*requiretty/#Defaults requiretty/" /etc/sudoers
+
+# Disable daily apt unattended updates.
+echo 'APT::Periodic::Enable "0";' >> /etc/apt/apt.conf.d/10periodic
+
+apt update
+apt install -y ansible
+
+# Install some packages
+apt-get update
+apt-get install -y openssh-server gcc rsync dirmngr
+apt-get install -y apt-transport-https ca-certificates
+
+# Add the artifactory magma repo
+bash -c 'echo -e "deb https://artifactory.magmacore.org/artifactory/debian focal-1.6.0 main" > /etc/apt/sources.list.d/packages_magma_etagecom_io.list'
+
+
+# Create the preferences file for backports
+bash -c 'cat <<EOF > /etc/apt/preferences.d/magma-preferences
+Package: *
+Pin: origin artifactory.magmacore.org
+Pin-Priority: 900
+EOF'
+
+# Add the Etagecom key
+wget https://artifactory.magmacore.org:443/artifactory/api/gpg/key/public -O /tmp/public
+apt-key add /tmp/public
+apt-get update


### PR DESCRIPTION
Signed-off-by: Quentin, Derory <15911421+quentinDERORY@users.noreply.github.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

Update libvirt images to use focal instead of stretch

## Test Plan

Built the vms correctly.
Will test the integration test with these new vms

## Additional Information

This is part of the effort to migrate the lte integration test to the new jenkins.
As virtualbox focal vms have issues booting up on focal instances, I am migrating the libvirt vms to use focal.
