### PR TITLE
chore: Add golangci.yml to make precommit at feg

### DIFF
--- a/feg/gateway/Makefile
+++ b/feg/gateway/Makefile
@@ -7,8 +7,9 @@ export MAGMA_ROOT
 
 COVER_DIR:=$(MAGMA_ROOT)/feg/gateway/coverage
 export COVER_DIR
-COVER_FILE:=$(COVER_DIR)/feg.gocov
+COVER_FILE := $(COVER_DIR)/feg.gocov
 DOCKER_DIR := ${MAGMA_ROOT}/feg/gateway/docker
+GOLINT_FILE := ${MAGMA_ROOT}/.golangci.yml
 
 all: fmt lint test vet install
 
@@ -56,7 +57,7 @@ vet:
 	go vet ./...
 
 lint: lint_tools
-	golangci-lint run
+	golangci-lint run --config ${GOLINT_FILE}
 
 lint_tools:
 	@if which golangci-lint 2>/dev/null; then \


### PR DESCRIPTION
Signed-off-by: Oriol Batalla <obatalla@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

Add `golangci.yml` config file to make lint at feg to make sure both local lint an CI lint uses the same rule

## Test Plan

`./build -l` at feg

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
