### PR TITLE
fix(mme): fix compilation warnings related to UE ID and constness

### DIFF
--- a/lte/gateway/c/core/oai/tasks/amf/Registration.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/Registration.cpp
@@ -657,7 +657,7 @@ int amf_send_registration_accept(amf_context_t* amf_context) {
       OAILOG_DEBUG(
           LOG_AMF_APP,
           "Timer: Registration_accept timer T3550 with id  %lu "
-          "Started for ue id: " AMF_UE_NGAP_ID_FMT "\n",
+          "Started for ue id: " AMF_UE_NGAP_ID_FMT,
           registration_proc->T3550.id, registration_proc->ue_id);
     }
   }

--- a/lte/gateway/c/core/oai/tasks/amf/amf_Security_Mode.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_Security_Mode.cpp
@@ -59,7 +59,9 @@ int amf_handle_security_complete_response(
   if (ue_mm_context) {
     amf_ctx = &ue_mm_context->amf_context;
   } else {
-    OAILOG_ERROR(LOG_AMF_APP, "ue context not found for the ue_id=%u\n", ue_id);
+    OAILOG_ERROR(
+        LOG_AMF_APP, "ue context not found for the UE ID " AMF_UE_NGAP_ID_FMT,
+        ue_id);
     OAILOG_FUNC_RETURN(LOG_NAS_AMF, RETURNerror);
   }
   nas_amf_smc_proc_t* smc_proc = get_nas5g_common_procedure_smc(amf_ctx);
@@ -68,7 +70,7 @@ int amf_handle_security_complete_response(
     OAILOG_DEBUG(
         LOG_AMF_APP,
         "Timer: After stopping timer T3560 for securiy mode command"
-        " with id: %lu and ue_id: %d\n",
+        " with id: %lu and UE ID: " AMF_UE_NGAP_ID_FMT,
         smc_proc->T3560.id, ue_id);
     smc_proc->T3560.id = NAS5G_TIMER_INACTIVE_ID;
 

--- a/lte/gateway/c/core/oai/tasks/amf/amf_app_handler.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_app_handler.cpp
@@ -489,7 +489,7 @@ imsi64_t amf_app_handle_initial_ue_message(
     OAILOG_DEBUG(
         LOG_AMF_APP,
         "Creating new ue_m5gmm_context: [%p]"
-        "for amf_ue_ngap_id: [%u]\n",
+        "for amf_ue_ngap_id: [" AMF_UE_NGAP_ID_FMT "]",
         ue_context_p, ue_context_p->amf_ue_ngap_id);
 
     AMF_APP_GNB_NGAP_ID_KEY(
@@ -517,7 +517,7 @@ imsi64_t amf_app_handle_initial_ue_message(
     OAILOG_DEBUG(
         LOG_AMF_APP,
         " Sending nas establishment indication to nas for ue_id = "
-        "(%d)\n",
+        "(" AMF_UE_NGAP_ID_FMT ")",
         ue_context_p->amf_ue_ngap_id);
   }
   is_mm_ctx_new = true;
@@ -525,7 +525,7 @@ imsi64_t amf_app_handle_initial_ue_message(
   OAILOG_DEBUG(
       LOG_AMF_APP,
       " Sending NAS Establishment Indication to NAS for ue_id = "
-      "(%d)\n",
+      "(" AMF_UE_NGAP_ID_FMT ")",
       ue_context_p->amf_ue_ngap_id);
   nas_proc_establish_ind(
       ue_context_p->amf_ue_ngap_id, is_mm_ctx_new, initial_pP->tai,
@@ -566,7 +566,9 @@ int amf_app_handle_uplink_nas_message(
     rc                                   = amf_sap_send(&amf_sap);
   } else {
     OAILOG_WARNING(
-        LOG_NAS, "Received NAS message in uplink is NULL for ue_id = (%u)\n",
+        LOG_NAS,
+        "Received NAS message in uplink is NULL for for UE "
+        "ID: " AMF_UE_NGAP_ID_FMT,
         amf_app_desc_p->amf_app_ue_ngap_id_generator);
   }
   OAILOG_FUNC_RETURN(LOG_NAS_AMF, rc);
@@ -721,14 +723,14 @@ int amf_app_handle_pdu_session_accept(
   // Handle smf_context
   ue_context = amf_ue_context_exists_amf_ue_ngap_id(ue_id);
   if (!ue_context) {
-    OAILOG_ERROR(LOG_AMF_APP, "UE context not found for UE ID: %d", ue_id);
+    OAILOG_ERROR(LOG_AMF_APP, "UE context not found for UE ID: %u", ue_id);
     return M5G_AS_FAILURE;
   }
 
   smf_ctx = amf_smf_context_exists_pdu_session_id(
       ue_context, pdu_session_resp->pdu_session_id);
   if (!smf_ctx) {
-    OAILOG_ERROR(LOG_AMF_APP, "Smf context is not exist UE ID: %d", ue_id);
+    OAILOG_ERROR(LOG_AMF_APP, "Smf context is not exist UE ID: %u", ue_id);
     return M5G_AS_FAILURE;
   }
   // updating session state
@@ -899,7 +901,8 @@ void amf_app_handle_resource_setup_response(
     ue_context = amf_ue_context_exists_amf_ue_ngap_id(ue_id);
     if (ue_context == NULL) {
       OAILOG_ERROR(
-          LOG_AMF_APP, "UE context not found for the ue_id=%u\n", ue_id);
+          LOG_AMF_APP,
+          "UE context not found for the ue_id = " AMF_UE_NGAP_ID_FMT, ue_id);
       return;
     }
 
@@ -927,7 +930,9 @@ void amf_app_handle_resource_setup_response(
     ue_context = amf_ue_context_exists_amf_ue_ngap_id(ue_id);
     // Handling of ue context
     if (!ue_context) {
-      OAILOG_ERROR(LOG_AMF_APP, "UE context not found for UE ID: %d", ue_id);
+      OAILOG_ERROR(
+          LOG_AMF_APP, "UE context not found for UE ID: " AMF_UE_NGAP_ID_FMT,
+          ue_id);
     }
 
     // Store gNB ip and TEID in respective smf_context
@@ -1032,7 +1037,9 @@ void amf_app_handle_cm_idle_on_ue_context_release(
     itti_ngap_ue_context_release_req_t cm_idle_req) {
   int rc = RETURNerror;
   OAILOG_DEBUG(
-      LOG_AMF_APP, " Handling UL UE context release for CM-idle for ue id %d\n",
+      LOG_AMF_APP,
+      " Handling UL UE context release for CM-idle for UE "
+      "ID: " AMF_UE_NGAP_ID_FMT,
       cm_idle_req.amf_ue_ngap_id);
   /* Currently only one PDU session is considered.
    * for multiple PDU session context (smf_context_t) will be part of vector
@@ -1072,7 +1079,7 @@ void amf_app_handle_cm_idle_on_ue_context_release(
       OAILOG_WARNING(
           LOG_AMF_APP,
           " UE in registered_connected state, but cause from NGAP"
-          " is wrong for UE ID %d and return\n",
+          " is wrong for UE ID: " AMF_UE_NGAP_ID_FMT " and return",
           cm_idle_req.amf_ue_ngap_id);
       return;
     }
@@ -1085,7 +1092,7 @@ void amf_app_handle_cm_idle_on_ue_context_release(
     OAILOG_DEBUG(
         LOG_AMF_APP,
         " UE in REGISTERED_IDLE or CM-idle state, nothing to do"
-        " for UE ID %d\n",
+        " for UE ID: " AMF_UE_NGAP_ID_FMT,
         cm_idle_req.amf_ue_ngap_id);
     return;
   }
@@ -1105,7 +1112,7 @@ void ue_context_release_command(
   OAILOG_DEBUG(
       LOG_AMF_APP,
       "preparing for context release command to NGAP "
-      "for ue_id %d\n",
+      "for ue_id " AMF_UE_NGAP_ID_FMT,
       amf_ue_ngap_id);
 
   message_p =
@@ -1156,8 +1163,8 @@ static int paging_t3513_handler(zloop_t* loop, int timer_id, void* arg) {
 
     OAILOG_DEBUG(
         LOG_AMF_APP,
-        "T3513: timer has expired for ue id: %d with timer id: %d,"
-        "Sending Paging request again\n",
+        "T3513: timer has expired for UE ID: " AMF_UE_NGAP_ID_FMT
+        " with timer id: %d, Sending Paging request again",
         ue_id, timer_id);
     /*
      * Increment the retransmission counter
@@ -1253,7 +1260,8 @@ int amf_app_handle_notification_received(
       paging_ctx = &ue_context->paging_context;
 
       OAILOG_INFO(
-          LOG_AMF_APP, "T3513: Starting PAGING Timer for ue id: %d\n",
+          LOG_AMF_APP,
+          "T3513: Starting PAGING Timer for UE ID: " AMF_UE_NGAP_ID_FMT,
           ue_context->amf_ue_ngap_id);
       paging_ctx->paging_retx_count = 0;
       /* Start Paging Timer T3513 */
@@ -1263,7 +1271,8 @@ int amf_app_handle_notification_received(
       // Fill the itti msg based on context info produced in amf core
       OAILOG_INFO(
           LOG_AMF_APP,
-          "T3513: Starting PAGING Timer for ue id: %u and timer id: %ld\n",
+          "T3513: Starting PAGING Timer for UE ID: " AMF_UE_NGAP_ID_FMT
+          " and timer id: %ld",
           ue_context->amf_ue_ngap_id, paging_ctx->m5_paging_response_timer.id);
 
       message_p = itti_alloc_new_message(TASK_AMF_APP, NGAP_PAGING_REQUEST);
@@ -1317,7 +1326,7 @@ void amf_app_handle_initial_context_setup_rsp(
 
   if (!ue_context) {
     OAILOG_ERROR(
-        LOG_AMF_APP, " Ue context not found for the id %u\n",
+        LOG_AMF_APP, " Ue context not found for the id " AMF_UE_NGAP_ID_FMT,
         initial_context_rsp->ue_id);
     return;
   }

--- a/lte/gateway/c/core/oai/tasks/amf/amf_app_timer_management.h
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_app_timer_management.h
@@ -15,6 +15,7 @@ limitations under the License.
 //--C includes -----------------------------------------------------------------
 extern "C" {
 #include "intertask_interface.h"
+#include "3gpp_38.401.h"
 }
 ////--C++ includes
 ///---------------------------------------------------------------
@@ -30,7 +31,7 @@ namespace magma5g {
 typedef uint64_t timer_arg_t;
 
 typedef struct ue_pdu_id {
-  uint32_t ue_id;
+  amf_ue_ngap_id_t ue_id;
   uint8_t pdu_id;
 } ue_pdu_id_t;
 

--- a/lte/gateway/c/core/oai/tasks/amf/amf_app_transport.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_app_transport.cpp
@@ -51,7 +51,9 @@ int amf_app_handle_nas_dl_req(
   if (ue_context) {
     gnb_ue_ngap_id = ue_context->gnb_ue_ngap_id;
   } else {
-    OAILOG_ERROR(LOG_AMF_APP, "ue context not found for the ue_id=%u\n", ue_id);
+    OAILOG_ERROR(
+        LOG_AMF_APP, "ue context not found for the UE ID = " AMF_UE_NGAP_ID_FMT,
+        ue_id);
     OAILOG_FUNC_RETURN(LOG_AMF_APP, rc);
   }
 

--- a/lte/gateway/c/core/oai/tasks/amf/amf_app_ue_context.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_app_ue_context.cpp
@@ -112,7 +112,8 @@ int amf_insert_ue_context(
       // Overwrite the existing element.
       found_ue_id->second = ue_context_p;
       OAILOG_DEBUG(
-          LOG_AMF_APP, "Overwriting the Existing entry UE_ID=%u\n", ue_id);
+          LOG_AMF_APP,
+          "Overwriting the Existing entry UE_ID = " AMF_UE_NGAP_ID_FMT, ue_id);
     }
   }
 

--- a/lte/gateway/c/core/oai/tasks/amf/amf_as.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_as.cpp
@@ -1457,8 +1457,7 @@ static int amf_as_establish_rej(
   OAILOG_FUNC_IN(LOG_NAS_AMF);
   OAILOG_DEBUG(
       LOG_NAS_AMF,
-      "Send AS connection establish Reject for (ue_id = "
-      "%d)\n",
+      "Send AS connection establish Reject for UE ID: " AMF_UE_NGAP_ID_FMT,
       msg->ue_id);
   amf_nas_message_t nas_msg = {0};
   // Setting-up the AS message

--- a/lte/gateway/c/core/oai/tasks/amf/amf_cn.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_cn.cpp
@@ -65,7 +65,8 @@ static int amf_cn_authentication_res(amf_cn_auth_res_t* const msg) {
       OAILOG_ERROR(
           LOG_NAS_AMF,
           "EMM-PROC  - "
-          "Failed to find Auth_info procedure associated to UE %d\n",
+          "Failed to find Auth_info procedure associated to UE "
+          "ID: " AMF_UE_NGAP_ID_FMT,
           msg->ue_id);
     }
   }

--- a/lte/gateway/c/core/oai/tasks/amf/amf_recv.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_recv.cpp
@@ -77,7 +77,7 @@ int amf_handle_service_request(
   if (ue_context && (tmsi_rcv == tmsi_stored)) {
     OAILOG_DEBUG(
         LOG_NAS_AMF,
-        "TMSI matched for the UE id %d "
+        "TMSI matched for UE ID " AMF_UE_NGAP_ID_FMT
         " receved TMSI %08X stored TMSI %08X \n",
         ue_id, tmsi_rcv, tmsi_stored);
 
@@ -251,7 +251,9 @@ int amf_handle_registration_request(
 
   ue_m5gmm_context_s* ue_context = amf_ue_context_exists_amf_ue_ngap_id(ue_id);
   if (ue_context == NULL) {
-    OAILOG_ERROR(LOG_AMF_APP, "UE context is null for ue id:%d \n", ue_id);
+    OAILOG_ERROR(
+        LOG_AMF_APP, "UE context is null for UE ID: " AMF_UE_NGAP_ID_FMT,
+        ue_id);
     return RETURNerror;
   }
   // Save the UE Security Capability into AMF's UE Context
@@ -275,7 +277,7 @@ int amf_handle_registration_request(
       OAILOG_ERROR(
           LOG_NAS_AMF,
           "UE is not supporting any algorithms, AMF rejecting the initial "
-          "registration with cause : %d for UE ID : %d",
+          "registration with cause : %d for UE ID: " AMF_UE_NGAP_ID_FMT,
           amf_cause, ue_id);
       rc = amf_proc_registration_reject(ue_id, amf_cause);
       OAILOG_FUNC_RETURN(LOG_NAS_AMF, rc);
@@ -295,8 +297,8 @@ int amf_handle_registration_request(
         OAILOG_ERROR(
             LOG_NAS_AMF,
             "UE is not supporting the algorithms IA0,IA1,IA2 and EA0,EA1,EA2, "
-            "AMF rejecting the initial registration with cause : %d for UE ID "
-            ": %d",
+            "AMF rejecting the initial registration with cause : %d for UE "
+            "ID: " AMF_UE_NGAP_ID_FMT,
             amf_cause, ue_id);
         rc = amf_proc_registration_reject(ue_id, amf_cause);
         OAILOG_FUNC_RETURN(LOG_NAS_AMF, rc);

--- a/lte/gateway/c/core/oai/tasks/amf/amf_security_mode_control.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_security_mode_control.cpp
@@ -150,7 +150,8 @@ static int amf_security_request(nas_amf_smc_proc_t* const smc_proc) {
       amf_ctx = &ue_mm_context->amf_context;
     } else {
       OAILOG_ERROR(
-          LOG_NAS_AMF, "UE 5G-MM context NULL! for ue_id = (%u)\n",
+          LOG_NAS_AMF,
+          "UE 5G-MM context NULL! for for UE ID: " AMF_UE_NGAP_ID_FMT,
           smc_proc->ue_id);
       OAILOG_FUNC_RETURN(LOG_NAS_AMF, RETURNerror);
     }
@@ -187,7 +188,8 @@ static int security_mode_t3560_handler(zloop_t* loop, int timer_id, void* arg) {
   if (!amf_app_get_timer_arg(timer_id, &ue_id)) {
     OAILOG_WARNING(
         LOG_AMF_APP,
-        "T3560: Invalid Timer Id expiration, Timer Id: %u and ue Id: %d \n",
+        "T3560: Invalid Timer Id expiration, Timer Id: %d and for UE "
+        "ID " AMF_UE_NGAP_ID_FMT,
         timer_id, ue_id);
     OAILOG_FUNC_RETURN(LOG_NAS_AMF, RETURNok);
   }
@@ -197,7 +199,8 @@ static int security_mode_t3560_handler(zloop_t* loop, int timer_id, void* arg) {
 
   if (ue_amf_context == NULL) {
     OAILOG_DEBUG(
-        LOG_AMF_APP, "T3560: ue_amf_context is NULL for ue id: %d\n", ue_id);
+        LOG_AMF_APP,
+        "T3560: ue_amf_context is NULL for UE ID: " AMF_UE_NGAP_ID_FMT, ue_id);
     OAILOG_FUNC_RETURN(LOG_NAS_AMF, RETURNok);
   }
 
@@ -205,7 +208,8 @@ static int security_mode_t3560_handler(zloop_t* loop, int timer_id, void* arg) {
 
   if (!(amf_ctx)) {
     OAILOG_ERROR(
-        LOG_AMF_APP, "T3560: Timer expired no amf context for ue id: %d\n",
+        LOG_AMF_APP,
+        "T3560: Timer expired no amf context for UE ID: " AMF_UE_NGAP_ID_FMT,
         ue_id);
     OAILOG_FUNC_RETURN(LOG_NAS_AMF, RETURNok);
   }
@@ -214,7 +218,8 @@ static int security_mode_t3560_handler(zloop_t* loop, int timer_id, void* arg) {
 
   if (smc_proc) {
     OAILOG_WARNING(
-        LOG_AMF_APP, "T3560: Timer expired  for timer id %lu ue id %d\n",
+        LOG_AMF_APP,
+        "T3560: Timer expired  for timer id %lu for UE ID " AMF_UE_NGAP_ID_FMT,
         smc_proc->T3560.id, smc_proc->ue_id);
     smc_proc->T3560.id = -1;
     /*
@@ -231,7 +236,8 @@ static int security_mode_t3560_handler(zloop_t* loop, int timer_id, void* arg) {
        */
       OAILOG_ERROR(
           LOG_AMF_APP,
-          "T3560: timer T3560 has expired for ud id:%d, so retransmitting "
+          "T3560: timer T3560 has expired for ud id: " AMF_UE_NGAP_ID_FMT
+          ", so retransmitting "
           "Security Command Mode request\n",
           ue_id);
       amf_security_request(smc_proc);
@@ -395,13 +401,14 @@ int amf_proc_security_mode_control(
     smc_proc->selected_eea = amf_ctx->_security.selected_algorithms.encryption;
     OAILOG_DEBUG(
         LOG_NAS_AMF,
-        "5G CN encryption algorithm selected is (%d) for ue_id (%u) "
-        "smc_proc->ksi=%d\n",
+        "5G CN encryption algorithm selected is (%d) for UE "
+        "ID " AMF_UE_NGAP_ID_FMT "smc_proc->ksi=%d",
         smc_proc->selected_eea, ue_id, smc_proc->ksi);
     smc_proc->selected_eia = amf_ctx->_security.selected_algorithms.integrity;
     OAILOG_DEBUG(
         LOG_NAS_AMF,
-        "5G CN integrity algorithm selected is (%d) for ue_id (%u)\n",
+        "5G CN integrity algorithm selected is (%d) for UE "
+        "ID " AMF_UE_NGAP_ID_FMT,
         smc_proc->selected_eia, ue_id);
     smc_proc->is_new = security_context_is_new;
 

--- a/lte/gateway/c/core/oai/tasks/amf/amf_smf_send.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_smf_send.cpp
@@ -306,7 +306,8 @@ static int pdu_session_resource_release_t3592_handler(
     }
   } else {
     OAILOG_ERROR(
-        LOG_AMF_APP, "T3592: ue context not found for the ue_id=%u\n",
+        LOG_AMF_APP,
+        "T3592: ue context not found for UE ID = " AMF_UE_NGAP_ID_FMT,
         amf_ue_ngap_id);
     OAILOG_FUNC_RETURN(LOG_AMF_APP, rc);
   }
@@ -381,7 +382,9 @@ int amf_smf_send(
       OAILOG_FUNC_RETURN(LOG_AMF_APP, rc);
     }
   } else {
-    OAILOG_ERROR(LOG_AMF_APP, "ue context not found for the ue_id=%u\n", ue_id);
+    OAILOG_ERROR(
+        LOG_AMF_APP, "ue context not found for the ue_id = " AMF_UE_NGAP_ID_FMT,
+        ue_id);
     OAILOG_FUNC_RETURN(LOG_AMF_APP, rc);
   }
 

--- a/lte/gateway/c/core/oai/tasks/amf/deregistration_request.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/deregistration_request.cpp
@@ -110,7 +110,7 @@ int amf_proc_deregistration_request(
   OAILOG_FUNC_IN(LOG_NAS_AMF);
   OAILOG_DEBUG(
       LOG_NAS_AMF,
-      "Processing deregistration UE-id = " AMF_UE_NGAP_ID_FMT " type = %d\n",
+      "Processing deregistration UE-id = " AMF_UE_NGAP_ID_FMT " type = %d",
       ue_id, params->de_reg_type);
   int rc = RETURNerror;
 

--- a/lte/gateway/c/core/oai/tasks/amf/nas_proc.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/nas_proc.cpp
@@ -284,14 +284,16 @@ static int identification_t3570_handler(
 
   if (ue_amf_context == NULL) {
     OAILOG_DEBUG(
-        LOG_AMF_APP, "T3570: ue_amf_context is NULL for ue id: %d\n", ue_id);
+        LOG_AMF_APP,
+        "T3570: ue_amf_context is NULL for UE ID: " AMF_UE_NGAP_ID_FMT, ue_id);
     OAILOG_FUNC_RETURN(LOG_NAS_AMF, RETURNok);
   }
 
   amf_ctx = &ue_amf_context->amf_context;
   if (!(amf_ctx)) {
     OAILOG_ERROR(
-        LOG_AMF_APP, "T3570: timer expired No AMF context for ue id: %d\n",
+        LOG_AMF_APP,
+        "T3570: timer expired No AMF context for UE ID: " AMF_UE_NGAP_ID_FMT,
         ue_id);
     OAILOG_FUNC_RETURN(LOG_NAS_AMF, RETURNok);
   }
@@ -301,7 +303,8 @@ static int identification_t3570_handler(
 
   if (ident_proc) {
     OAILOG_WARNING(
-        LOG_AMF_APP, "T3570: Timer expired for timer id %lu ue id %d\n",
+        LOG_AMF_APP,
+        "T3570: Timer expired for timer id %lu for UE ID " AMF_UE_NGAP_ID_FMT,
         ident_proc->T3570.id, ident_proc->ue_id);
     ident_proc->T3570.id = NAS5G_TIMER_INACTIVE_ID;
     /*
@@ -434,7 +437,7 @@ int amf_nas_proc_authentication_info_answer(
   OAILOG_DEBUG(
       LOG_NAS_AMF,
       "Received Authentication Information Answer from Subscriberdb for"
-      " ue_id = %d\n",
+      " UE ID = " AMF_UE_NGAP_ID_FMT,
       amf_ue_ngap_id);
 
   if (aia->auth_info.nb_of_vectors) {

--- a/lte/gateway/c/core/oai/tasks/ha/ha_service_handler.cpp
+++ b/lte/gateway/c/core/oai/tasks/ha/ha_service_handler.cpp
@@ -127,10 +127,10 @@ bool trigger_agw_offload_for_ue(
     OAILOG_INFO(
         LOG_UTIL,
         "Processing IMSI64: " IMSI_64_FMT
-        " Requested IMSI: %s, MME UE ID: %d, ENB UE ID: %d, UE "
-        "Context ENB ID: "
-        "%d, UE "
-        "Context cell id: %d, S1AP State ENB ID: %d",
+        " Requested IMSI: %s, MME UE ID: " MME_UE_S1AP_ID_FMT
+        ", ENB UE ID: " ENB_UE_S1AP_ID_FMT
+        " , UE Context ENB ID: %d, UE Context cell id: %d, S1AP State ENB ID: "
+        "%d",
         ue_context_p->emm_context._imsi64, offload_request->imsi,
         ue_context_p->mme_ue_s1ap_id, ue_context_p->enb_ue_s1ap_id,
         ue_context_p->e_utran_cgi.cell_identity.enb_id,

--- a/lte/gateway/c/core/oai/tasks/mme_app/mme_app_bearer.c
+++ b/lte/gateway/c/core/oai/tasks/mme_app/mme_app_bearer.c
@@ -1316,8 +1316,8 @@ error_handling_csr_failure:
   create_session_response_fail.ue_id = ue_context_p->mme_ue_s1ap_id;
   OAILOG_ERROR_UE(
       LOG_MME_APP, ue_context_p->emm_context._imsi64,
-      "Handling Create Session Response failure for ue_id = (%u), "
-      "bearer id = (%d), pti = (%d)\n",
+      "Handling Create Session Response failure for ue_id = " MME_UE_S1AP_ID_FMT
+      ", bearer id = (%d), pti = (%d)",
       ue_context_p->mme_ue_s1ap_id, bearer_id, transaction_identifier);
   rc = nas_proc_ula_or_csrsp_fail(&create_session_response_fail);
   OAILOG_FUNC_RETURN(LOG_MME_APP, rc);
@@ -2979,7 +2979,7 @@ void mme_app_handle_modify_ue_ambr_request(
     OAILOG_DEBUG_UE(
         LOG_MME_APP, ue_context_p->emm_context._imsi64,
         "MME APP :Sent UE context modification request \
-        for UE id %d\n",
+        for UE id " MME_UE_S1AP_ID_FMT,
         ue_context_p->mme_ue_s1ap_id);
   }
   OAILOG_FUNC_OUT(LOG_MME_APP);

--- a/lte/gateway/c/core/oai/tasks/mme_app/mme_app_bearer_context.c
+++ b/lte/gateway/c/core/oai/tasks/mme_app/mme_app_bearer_context.c
@@ -122,14 +122,13 @@ void mme_app_add_bearer_context(
       return;
     }
     OAILOG_WARNING(
-        LOG_MME_APP, "No PDN id %u exist for ue id " MME_UE_S1AP_ID_FMT "\n",
+        LOG_MME_APP, "No PDN id %u exist for ue id " MME_UE_S1AP_ID_FMT,
         pdn_cid, ue_context->mme_ue_s1ap_id);
     return;
   }
   OAILOG_WARNING(
       LOG_MME_APP,
-      "Bearer ebi %u PDN id %u already exist for ue id " MME_UE_S1AP_ID_FMT
-      "\n",
+      "Bearer ebi %u PDN id %u already exist for ue id " MME_UE_S1AP_ID_FMT,
       bc->ebi, pdn_cid, ue_context->mme_ue_s1ap_id);
 }
 

--- a/lte/gateway/c/core/oai/tasks/mme_app/mme_app_itti_messaging.h
+++ b/lte/gateway/c/core/oai/tasks/mme_app/mme_app_itti_messaging.h
@@ -110,7 +110,7 @@ static inline void mme_app_itti_ue_context_mod_for_csfb(
     OAILOG_DEBUG(
         LOG_MME_APP,
         "MME APP :Sent UE context modification request and Started guard timer "
-        "for UE id %d\n",
+        "for UE id " MME_UE_S1AP_ID_FMT,
         ue_context_p->mme_ue_s1ap_id);
   }
   OAILOG_FUNC_OUT(LOG_MME_APP);

--- a/lte/gateway/c/core/oai/tasks/mme_app/mme_app_location.c
+++ b/lte/gateway/c/core/oai/tasks/mme_app/mme_app_location.c
@@ -254,14 +254,15 @@ status_code_e mme_app_handle_s6a_update_location_ans(
         ula_pP->result.present);
     if (handle_ula_failure(ue_mm_context) == RETURNok) {
       OAILOG_DEBUG(
-          LOG_MME_APP, "Sent PDN Connectivity failure to NAS for ue_id (%u)\n",
+          LOG_MME_APP,
+          "Sent PDN Connectivity failure to NAS for UE ID: " MME_UE_S1AP_ID_FMT,
           ue_mm_context->mme_ue_s1ap_id);
       OAILOG_FUNC_RETURN(LOG_MME_APP, rc);
     } else {
       OAILOG_ERROR(
           LOG_MME_APP,
           "Failed to send PDN Connectivity failure to NAS for "
-          "ue_id " MME_UE_S1AP_ID_FMT "\n",
+          "UE ID: " MME_UE_S1AP_ID_FMT "\n",
           ue_mm_context->mme_ue_s1ap_id);
       OAILOG_FUNC_RETURN(LOG_MME_APP, RETURNerror);
     }

--- a/lte/gateway/c/core/oai/tasks/mme_app/mme_app_sgs_detach.c
+++ b/lte/gateway/c/core/oai/tasks/mme_app/mme_app_sgs_detach.c
@@ -167,7 +167,7 @@ status_code_e mme_app_handle_sgs_eps_detach_timer_expiry(
   if (ue_context_p->sgs_context == NULL) {
     OAILOG_ERROR(
         LOG_MME_APP,
-        "SGS EPS Detach Timer expired but no assoicated SGS context for UE "
+        "SGS EPS Detach Timer expired but no associated SGS context for UE "
         "id " MME_UE_S1AP_ID_FMT "\n",
         mme_ue_s1ap_id);
     OAILOG_FUNC_RETURN(LOG_MME_APP, RETURNerror);
@@ -228,7 +228,7 @@ status_code_e mme_app_handle_sgs_implicit_eps_detach_timer_expiry(
   if (ue_context_p->sgs_context == NULL) {
     OAILOG_ERROR(
         LOG_MME_APP,
-        "SGS EPS Detach Timer expired but no assoicated SGS context for UE "
+        "SGS EPS Detach Timer expired but no associated SGS context for UE "
         "id " MME_UE_S1AP_ID_FMT "\n",
         mme_ue_s1ap_id);
     OAILOG_FUNC_RETURN(LOG_MME_APP, RETURNerror);
@@ -451,7 +451,7 @@ status_code_e mme_app_handle_sgs_implicit_imsi_detach_timer_expiry(
   if (ue_context_p->sgs_context == NULL) {
     OAILOG_ERROR(
         LOG_MME_APP,
-        "SGS IMPLICIT IMSI Detach Timer expired but no assoicated SGS context "
+        "SGS IMPLICIT IMSI Detach Timer expired but no associated SGS context "
         "for"
         " ue_id " MME_UE_S1AP_ID_FMT "\n",
         mme_ue_s1ap_id);

--- a/lte/gateway/c/core/oai/tasks/mme_app/mme_app_sgsap_location_update.c
+++ b/lte/gateway/c/core/oai/tasks/mme_app/mme_app_sgsap_location_update.c
@@ -527,7 +527,7 @@ status_code_e send_itti_sgsap_location_update_req(
 
   if (ue_context_p->sgs_context == NULL) {
     OAILOG_ERROR(
-        LOG_MME_APP, "SGS Context is NULL for UE ID %d ",
+        LOG_MME_APP, "SGS Context is NULL for UE ID " MME_UE_S1AP_ID_FMT,
         ue_context_p->mme_ue_s1ap_id);
     OAILOG_FUNC_RETURN(LOG_MME_APP, RETURNerror);
   }
@@ -679,7 +679,8 @@ status_code_e sgs_fsm_null_loc_updt_acc(const sgs_fsm_t* fsm_evt) {
 
   if (sgs_context == NULL) {
     OAILOG_ERROR(
-        LOG_MME_APP, "SGS Context is NULL for UE ID %d ", fsm_evt->ue_id);
+        LOG_MME_APP, "SGS Context is NULL for UE ID " MME_UE_S1AP_ID_FMT,
+        fsm_evt->ue_id);
     OAILOG_FUNC_RETURN(LOG_MME_APP, RETURNerror);
   }
 
@@ -741,7 +742,8 @@ status_code_e sgs_fsm_associated_loc_updt_acc(const sgs_fsm_t* fsm_evt) {
 
   sgs_context_t* sgs_context = (sgs_context_t*) fsm_evt->ctx;
   if (sgs_context == NULL) {
-    OAILOG_ERROR(LOG_MME_APP, "Unknown UE ID %d ", fsm_evt->ue_id);
+    OAILOG_ERROR(
+        LOG_MME_APP, "Unknown UE ID " MME_UE_S1AP_ID_FMT, fsm_evt->ue_id);
     OAILOG_FUNC_RETURN(LOG_MME_APP, RETURNerror);
   }
   // If we received Location Updt Accept from MSC/VLR and ts6_1_timer is not
@@ -781,13 +783,15 @@ status_code_e sgs_fsm_la_updt_req_loc_updt_acc(const sgs_fsm_t* fsm_evt) {
   OAILOG_FUNC_IN(LOG_MME_APP);
   ue_context_p = mme_ue_context_exists_mme_ue_s1ap_id(fsm_evt->ue_id);
   if (ue_context_p == NULL) {
-    OAILOG_ERROR(LOG_MME_APP, "Unknown UE ID %d ", fsm_evt->ue_id);
+    OAILOG_ERROR(
+        LOG_MME_APP, "Unknown UE ID " MME_UE_S1AP_ID_FMT, fsm_evt->ue_id);
     OAILOG_FUNC_RETURN(LOG_MME_APP, RETURNerror);
   }
   sgs_context_t* sgs_context = (sgs_context_t*) fsm_evt->ctx;
   if (sgs_context == NULL) {
     OAILOG_ERROR(
-        LOG_MME_APP, "SGS context not found for UE ID %d ", fsm_evt->ue_id);
+        LOG_MME_APP, "SGS context not found for UE ID " MME_UE_S1AP_ID_FMT,
+        fsm_evt->ue_id);
     OAILOG_FUNC_RETURN(LOG_MME_APP, RETURNerror);
   }
   itti_sgsap_location_update_acc_p =
@@ -894,14 +898,16 @@ status_code_e sgs_fsm_la_updt_req_loc_updt_rej(const sgs_fsm_t* fsm_evt) {
   ue_context_p = mme_ue_context_exists_mme_ue_s1ap_id(fsm_evt->ue_id);
   if (ue_context_p == NULL) {
     mme_app_desc_t* mme_app_desc_p = get_mme_nas_state(false);
-    OAILOG_ERROR(LOG_MME_APP, "Unknown UE ID %d ", fsm_evt->ue_id);
+    OAILOG_ERROR(
+        LOG_MME_APP, "Unknown UE ID " MME_UE_S1AP_ID_FMT, fsm_evt->ue_id);
     mme_ue_context_dump_coll_keys(&mme_app_desc_p->mme_ue_contexts);
     OAILOG_FUNC_RETURN(LOG_MME_APP, RETURNerror);
   }
 
   if (sgs_context == NULL) {
     OAILOG_ERROR(
-        LOG_MME_APP, "SGS Context is NULL for UE ID %d ", fsm_evt->ue_id);
+        LOG_MME_APP, "SGS Context is NULL for UE ID " MME_UE_S1AP_ID_FMT,
+        fsm_evt->ue_id);
     OAILOG_FUNC_RETURN(LOG_MME_APP, RETURNerror);
   }
   // Change SGS state to NULL
@@ -990,12 +996,14 @@ status_code_e sgs_fsm_associated_loc_updt_rej(const sgs_fsm_t* fsm_evt) {
   IMSI_STRING_TO_IMSI64(itti_sgsap_location_update_rej_p->imsi, &imsi64);
   ue_context_p = mme_ue_context_exists_mme_ue_s1ap_id(fsm_evt->ue_id);
   if (ue_context_p == NULL) {
-    OAILOG_ERROR(LOG_MME_APP, "Unknown UE ID %d ", fsm_evt->ue_id);
+    OAILOG_ERROR(
+        LOG_MME_APP, "Unknown UE ID " MME_UE_S1AP_ID_FMT, fsm_evt->ue_id);
     OAILOG_FUNC_RETURN(LOG_MME_APP, RETURNerror);
   }
   if (sgs_context == NULL) {
     OAILOG_ERROR(
-        LOG_MME_APP, "SGS context not found for UE ID %d ", fsm_evt->ue_id);
+        LOG_MME_APP, "SGS context not found for UE ID " MME_UE_S1AP_ID_FMT,
+        fsm_evt->ue_id);
     OAILOG_FUNC_RETURN(LOG_MME_APP, RETURNerror);
   }
   OAILOG_DEBUG(

--- a/lte/gateway/c/core/oai/tasks/mme_app/mme_app_sgsap_service_abort.c
+++ b/lte/gateway/c/core/oai/tasks/mme_app/mme_app_sgsap_service_abort.c
@@ -112,7 +112,8 @@ status_code_e sgs_fsm_associated_service_abort_request(
 
   if (sgs_context == NULL) {
     OAILOG_ERROR(
-        LOG_MME_APP, "SGS context not found for UE ID %d \n", fsm_evt->ue_id);
+        LOG_MME_APP, "SGS context not found for UE ID " MME_UE_S1AP_ID_FMT,
+        fsm_evt->ue_id);
     OAILOG_FUNC_RETURN(LOG_MME_APP, RETURNerror);
   }
   /* As per 29.118 ,if we receive EXT Service Request with csfb_response set to
@@ -125,7 +126,7 @@ status_code_e sgs_fsm_associated_service_abort_request(
     OAILOG_INFO(
         LOG_MME_APP,
         "Dropping SGS SERVICE ABORT REQUEST message as MT call is already "
-        "accepted by the user for UE ID %d\n",
+        "accepted by the user for UE ID " MME_UE_S1AP_ID_FMT,
         fsm_evt->ue_id);
   }
 
@@ -146,7 +147,7 @@ status_code_e sgs_fsm_null_service_abort_request(const sgs_fsm_t* fsm_evt) {
   OAILOG_ERROR(
       LOG_MME_APP,
       "Dropping SGS SERVICE ABORT REQUEST message as it is received in NULL "
-      "state for UE ID %d\n",
+      "state for UE ID " MME_UE_S1AP_ID_FMT,
       fsm_evt->ue_id);
 
   OAILOG_FUNC_RETURN(LOG_MME_APP, RETURNok);
@@ -166,7 +167,7 @@ status_code_e sgs_fsm_la_update_req_service_abort_request(
   OAILOG_ERROR(
       LOG_MME_APP,
       "Dropping SGS SERVICE ABORT REQUEST message as it is received in "
-      "LA-UPDATE-REQUESTED stae for UE ID %d\n",
+      "LA-UPDATE-REQUESTED stae for UE ID " MME_UE_S1AP_ID_FMT,
       fsm_evt->ue_id);
 
   OAILOG_FUNC_RETURN(LOG_MME_APP, RETURNok);

--- a/lte/gateway/c/core/oai/tasks/nas/emm/SecurityModeControl.c
+++ b/lte/gateway/c/core/oai/tasks/nas/emm/SecurityModeControl.c
@@ -345,7 +345,8 @@ status_code_e emm_proc_security_mode_control(
     smc_proc->selected_eea = emm_ctx->_security.selected_algorithms.encryption;
     OAILOG_DEBUG(
         LOG_NAS_EMM,
-        "EPS encryption algorithm selected is (%d) for ue_id (%u)\n",
+        "EPS encryption algorithm selected is (%d) for UE "
+        "ID: " MME_UE_S1AP_ID_FMT,
         smc_proc->selected_eea, ue_id);
     /*
      * Set the EPS integrity algorithms selected to the UE
@@ -353,7 +354,8 @@ status_code_e emm_proc_security_mode_control(
     smc_proc->selected_eia = emm_ctx->_security.selected_algorithms.integrity;
     OAILOG_DEBUG(
         LOG_NAS_EMM,
-        "EPS integrity algorithm selected is (%d) for ue_id (%u)\n",
+        "EPS integrity algorithm selected is (%d) for UE "
+        "ID: " MME_UE_S1AP_ID_FMT,
         smc_proc->selected_eia, ue_id);
 
     smc_proc->is_new = security_context_is_new;

--- a/lte/gateway/c/core/oai/tasks/nas/emm/sap/emm_as.c
+++ b/lte/gateway/c/core/oai/tasks/nas/emm/sap/emm_as.c
@@ -782,7 +782,8 @@ static int emm_as_establish_req(emm_as_establish_t* msg, int* emm_cause) {
    */
   OAILOG_DEBUG(
       LOG_NAS_EMM,
-      "EMMAS-SAP - Decoding Initial NAS message for ue_id = (%u)\n",
+      "EMMAS-SAP - Decoding Initial NAS message for ue_id "
+      "= " MME_UE_S1AP_ID_FMT,
       msg->ue_id);
   decoder_rc = nas_message_decode(
       msg->nas_msg->data, &nas_msg, blength(msg->nas_msg), emm_security_context,

--- a/lte/gateway/c/core/oai/tasks/nas/emm/sap/emm_send.c
+++ b/lte/gateway/c/core/oai/tasks/nas/emm/sap/emm_send.c
@@ -1293,7 +1293,8 @@ status_code_e emm_send_identity_request(
 
   OAILOG_INFO(
       LOG_NAS_EMM,
-      "EMMAS-SAP - Send Identity Request message for ue_id = (%u)\n",
+      "EMMAS-SAP - Send Identity Request message for ue_id "
+      "= " MME_UE_S1AP_ID_FMT,
       msg->ue_id);
   /*
    * Mandatory - Message type

--- a/lte/gateway/c/core/oai/tasks/nas/nas_proc.c
+++ b/lte/gateway/c/core/oai/tasks/nas/nas_proc.c
@@ -328,7 +328,9 @@ status_code_e nas_proc_ul_transfer_ind(
     rc                           = emm_sap_send(&emm_sap);
   } else {
     OAILOG_WARNING(
-        LOG_NAS, "Received NAS message in uplink is NULL for ue_id = (%u)\n",
+        LOG_NAS,
+        "Received NAS message in uplink is NULL for ue_id "
+        "= " MME_UE_S1AP_ID_FMT,
         ue_id);
   }
 

--- a/lte/gateway/c/core/oai/tasks/ngap/ngap_amf_itti_messaging.c
+++ b/lte/gateway/c/core/oai/tasks/ngap/ngap_amf_itti_messaging.c
@@ -60,7 +60,8 @@ status_code_e ngap_amf_itti_nas_uplink_ind(
   imsi64_t imsi64       = INVALID_IMSI64;
   OAILOG_DEBUG_UE(
       LOG_NGAP, imsi64,
-      "Sending NAS Uplink indication to NAS_AMF_APP, amf_ue_ngap_id = (%u) \n",
+      "Sending NAS Uplink indication to NAS_AMF_APP, amf_ue_ngap_id "
+      "= " AMF_UE_NGAP_ID_FMT,
       ue_id);
   message_p = itti_alloc_new_message(TASK_NGAP, AMF_APP_UPLINK_DATA_IND);
   if (message_p == NULL) {

--- a/lte/gateway/c/core/oai/tasks/ngap/ngap_amf_nas_procedures.c
+++ b/lte/gateway/c/core/oai/tasks/ngap/ngap_amf_nas_procedures.c
@@ -796,9 +796,9 @@ void ngap_handle_conn_est_cnf(
 
       ASN_SEQUENCE_ADD(&out->protocolIEs.list, ie);
 
-      pdu_session_resource_setup_request_transfer_t*
+      const pdu_session_resource_setup_request_transfer_t*
           amf_pdu_ses_setup_transfer_req;
-      pdusession_setup_item_t* pdu_session_item =
+      const pdusession_setup_item_t* pdu_session_item =
           &conn_est_cnf_pP->PDU_Session_Resource_Setup_Transfer_List.item[i];
 
       Ngap_PDUSessionResourceSetupItemCxtReq_t* session_context =
@@ -986,7 +986,7 @@ static int get_ue_ref(
 
 /* ngap_build_pdu_session_resource_setup_request_transfer */
 int ngap_fill_pdu_session_resource_setup_request_transfer(
-    pdu_session_resource_setup_request_transfer_t* session_transfer,
+    const pdu_session_resource_setup_request_transfer_t* session_transfer,
     Ngap_PDUSessionResourceSetupRequestTransfer_t* transfer_request) {
   OAILOG_FUNC_IN(LOG_NGAP);
 
@@ -1135,7 +1135,8 @@ int ngap_amf_nas_pdusession_resource_setup_stream(
 
   uint8_t* buffer_p = NULL;
   uint32_t length   = 0;
-  pdu_session_resource_setup_request_transfer_t* amf_pdu_ses_setup_transfer_req;
+  const pdu_session_resource_setup_request_transfer_t*
+      amf_pdu_ses_setup_transfer_req;
 
   /*
    * We have found the UE in the list.

--- a/lte/gateway/c/core/oai/tasks/ngap/ngap_common.h
+++ b/lte/gateway/c/core/oai/tasks/ngap/ngap_common.h
@@ -794,5 +794,5 @@ status_code_e ngap_send_msg_to_task(
  @returns 0 on success
  **/
 int ngap_fill_pdu_session_resource_setup_request_transfer(
-    pdu_session_resource_setup_request_transfer_t* session_transfer,
+    const pdu_session_resource_setup_request_transfer_t* session_transfer,
     Ngap_PDUSessionResourceSetupRequestTransfer_t* transfer_request);

--- a/lte/gateway/c/core/oai/tasks/s1ap/s1ap_mme.c
+++ b/lte/gateway/c/core/oai/tasks/s1ap/s1ap_mme.c
@@ -305,7 +305,7 @@ static int handle_message(zloop_t* loop, zsock_t* reader, void* arg) {
           if ((ue_ref_p = s1ap_state_get_ue_mmeid(mme_ue_s1ap_id)) == NULL) {
             OAILOG_WARNING_UE(
                 LOG_S1AP, imsi64,
-                "Timer expired but no assoicated UE context for UE "
+                "Timer expired but no associated UE context for UE "
                 "id " MME_UE_S1AP_ID_FMT,
                 mme_ue_s1ap_id);
             timer_handle_expired(

--- a/lte/gateway/c/core/oai/tasks/s1ap/s1ap_mme.c
+++ b/lte/gateway/c/core/oai/tasks/s1ap/s1ap_mme.c
@@ -305,7 +305,8 @@ static int handle_message(zloop_t* loop, zsock_t* reader, void* arg) {
           if ((ue_ref_p = s1ap_state_get_ue_mmeid(mme_ue_s1ap_id)) == NULL) {
             OAILOG_WARNING_UE(
                 LOG_S1AP, imsi64,
-                "Timer expired but no assoicated UE context for UE id %d\n",
+                "Timer expired but no assoicated UE context for UE "
+                "id " MME_UE_S1AP_ID_FMT,
                 mme_ue_s1ap_id);
             timer_handle_expired(
                 received_message_p->ittiMsg.timer_has_expired.timer_id);
@@ -317,7 +318,8 @@ static int handle_message(zloop_t* loop, zsock_t* reader, void* arg) {
             // UE context release complete timer expiry handler
             OAILOG_WARNING_UE(
                 LOG_S1AP, imsi64,
-                "ue_context_release_command_timer_expired for UE id %d\n",
+                "ue_context_release_command_timer_expired for UE "
+                "id " MME_UE_S1AP_ID_FMT,
                 mme_ue_s1ap_id);
             increment_counter(
                 "ue_context_release_command_timer_expired", 1, NO_LABELS);
@@ -570,7 +572,8 @@ void s1ap_remove_ue(s1ap_state_t* state, ue_description_t* ue_ref) {
     if (timer_remove(ue_ref->s1ap_ue_context_rel_timer.id, NULL)) {
       OAILOG_ERROR(
           LOG_MME_APP,
-          "Failed to stop s1ap ue context release complete timer, UE id: %d\n",
+          "Failed to stop s1ap ue context release complete timer, UE "
+          "id: " MME_UE_S1AP_ID_FMT,
           ue_ref->mme_ue_s1ap_id);
     }
     ue_ref->s1ap_ue_context_rel_timer.id = S1AP_TIMER_INACTIVE_ID;


### PR DESCRIPTION
Signed-off-by: Ulas Kozat <kozat@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->
- Fixed compilation warnings mostly due to UE ID and constness.
- Fixed few typos in log messages.

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->
unit and integ tests.

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
