### PR TITLE
feat(agw): Add support for IPv6 Non-NAT router mode.

### DIFF
--- a/lte/gateway/python/magma/mobilityd/scripts/setup-uplink-vlan-srv.sh
+++ b/lte/gateway/python/magma/mobilityd/scripts/setup-uplink-vlan-srv.sh
@@ -24,6 +24,7 @@ fi
 prefix="vt$tag"
 ip_addr="10.$network_id.$tag.111/24"
 router_ip="10.$network_id.$tag.211"
+router_ipv6="fc00::$network_id:$tag:211/96"
 
 ip link del "$prefix"_port
 ip link add "$prefix"_port type veth peer name  "$prefix"_port1
@@ -38,6 +39,7 @@ ip link set dev  "$prefix"_port1 netns "$prefix"_dhcp_srv
 ip netns exec    "$prefix"_dhcp_srv   ifconfig  "$prefix"_port1 "$ip_addr"
 ip netns exec    "$prefix"_dhcp_srv   ifconfig  "$prefix"_port1 hw ether b2:a0:cc:85:80:$tag
 ip netns exec    "$prefix"_dhcp_srv   ip addr add $router_ip  dev "$prefix"_port1
+ip netns exec    "$prefix"_dhcp_srv   ip -6 addr add $router_ipv6  dev "$prefix"_port1
 
 ip netns exec    "$prefix"_dhcp_srv   ifconfig  "$prefix"_port1 up
 

--- a/lte/gateway/python/magma/pipelined/tests/pipelined_test_util.py
+++ b/lte/gateway/python/magma/pipelined/tests/pipelined_test_util.py
@@ -713,10 +713,34 @@ def get_iface_ipv4(iface: str) -> List[str]:
     return ip_addr_list
 
 
+def get_iface_ipv6(iface: str) -> List[str]:
+    virt_ifaddresses = netifaces.ifaddresses(iface)
+    ip_addr_list = []
+    for ip_rec in virt_ifaddresses[netifaces.AF_INET6]:
+        ip_rec_tok = ip_rec['addr'].split('%')[0]
+        ip_addr_list.append(ip_rec_tok)
+
+    print("ipv6-list: %s " % ip_addr_list)
+    return ip_addr_list
+
+
 def get_iface_gw_ipv4(iface: str) -> List[str]:
     gateways = netifaces.gateways()
     gateway_ip_addr_list = []
     for gw_ip, gw_iface, _ in gateways[netifaces.AF_INET]:
+        print("pbs: gw_ip %s gw_iface %s " % (gw_ip, gw_iface))
+        if gw_iface != iface:
+            continue
+        gateway_ip_addr_list.append(gw_ip)
+
+    return gateway_ip_addr_list
+
+
+def get_iface_gw_ipv6(iface: str) -> List[str]:
+    gateways = netifaces.gateways()
+    gateway_ip_addr_list = []
+    for gw_ip, gw_iface, _ in gateways[netifaces.AF_INET6]:
+        print("pbs: gw_ipv6 %s gw_iface %s " % (gw_ip, gw_iface))
         if gw_iface != iface:
             continue
         gateway_ip_addr_list.append(gw_ip)

--- a/lte/gateway/python/magma/pipelined/tests/snapshots/test_uplink_bridge.UplinkBridgeWithNonNATTest.testFlowSnapshotMatch.snapshot
+++ b/lte/gateway/python/magma/pipelined/tests/snapshots/test_uplink_bridge.UplinkBridgeWithNonNATTest.testFlowSnapshotMatch.snapshot
@@ -3,6 +3,7 @@
  priority=65534,in_port=1 actions=output:3
  priority=100,in_port=2 actions=mod_dl_src:02:bb:5e:36:06:4b,output:3
  priority=101,ip,in_port=3,nw_dst=1.1.11.1 actions=LOCAL
+ priority=101,ipv6,in_port=3,ipv6_dst=fe80::48a3:2cff:fe1a:abcd actions=LOCAL
  priority=100,ip,in_port=3,dl_dst=02:bb:5e:36:06:4b actions=output:2
  priority=100,ipv6,in_port=3,dl_dst=02:bb:5e:36:06:4b actions=output:2
  priority=0,arp,in_port=3 actions=output:1,output:2,LOCAL

--- a/lte/gateway/python/magma/pipelined/tests/snapshots/test_uplink_bridge.UplinkBridgeWithNonNATTestVlan.testFlowSnapshotMatch.snapshot
+++ b/lte/gateway/python/magma/pipelined/tests/snapshots/test_uplink_bridge.UplinkBridgeWithNonNATTestVlan.testFlowSnapshotMatch.snapshot
@@ -4,6 +4,7 @@
  priority=100,in_port=2 actions=mod_dl_src:02:bb:5e:36:06:4b,output:3
  priority=65534,udp,in_port=3,tp_dst=68 actions=output:1,LOCAL
  priority=101,ip,in_port=3,nw_dst=1.1.11.1 actions=LOCAL
+ priority=101,ipv6,in_port=3,ipv6_dst=fe80::48a3:2cff:fe1a:dd47 actions=LOCAL
  priority=100,ip,in_port=3,vlan_tci=0x0000/0x1000,dl_dst=02:bb:5e:36:06:4b actions=output:2
  priority=100,ipv6,in_port=3,vlan_tci=0x0000/0x1000,dl_dst=02:bb:5e:36:06:4b actions=output:2
  priority=100,ip,in_port=3,vlan_tci=0x1000/0x1000,dl_dst=02:bb:5e:36:06:4b actions=strip_vlan,output:70

--- a/lte/gateway/python/magma/pipelined/tests/snapshots/test_uplink_bridge.UplinkBridgeWithNonNATTest_IP_VLAN.testFlowSnapshotMatch.snapshot
+++ b/lte/gateway/python/magma/pipelined/tests/snapshots/test_uplink_bridge.UplinkBridgeWithNonNATTest_IP_VLAN.testFlowSnapshotMatch.snapshot
@@ -4,6 +4,7 @@
  priority=100,in_port=2 actions=mod_dl_src:02:bb:5e:36:06:4b,output:3
  priority=65534,udp,in_port=3,tp_dst=68 actions=output:1,LOCAL
  priority=101,ip,in_port=3,nw_dst=1.6.5.7 actions=LOCAL
+ priority=101,ipv6,in_port=3,ipv6_dst=fe80::48a3:2cff:fe1a:cccc actions=LOCAL
  priority=100,ip,in_port=3,vlan_tci=0x0000/0x1000,dl_dst=02:bb:5e:36:06:4b actions=output:2
  priority=100,ipv6,in_port=3,vlan_tci=0x0000/0x1000,dl_dst=02:bb:5e:36:06:4b actions=output:2
  priority=100,ip,in_port=3,vlan_tci=0x1000/0x1000,dl_dst=02:bb:5e:36:06:4b actions=strip_vlan,output:70

--- a/lte/gateway/python/magma/pipelined/tests/snapshots/test_uplink_bridge.UplinkBridgeWithNonNATTest_IP_VLAN_GW.testFlowSnapshotMatch.snapshot
+++ b/lte/gateway/python/magma/pipelined/tests/snapshots/test_uplink_bridge.UplinkBridgeWithNonNATTest_IP_VLAN_GW.testFlowSnapshotMatch.snapshot
@@ -4,6 +4,7 @@
  priority=100,in_port=2 actions=mod_dl_src:02:bb:5e:36:06:4b,output:3
  priority=65534,udp,in_port=3,tp_dst=68 actions=output:1,LOCAL
  priority=101,ip,in_port=3,nw_dst=1.6.5.7 actions=LOCAL
+ priority=101,ipv6,in_port=3,ipv6_dst=fe80::48a3:2cff:aaaa:dd47 actions=LOCAL
  priority=100,ip,in_port=3,vlan_tci=0x0000/0x1000,dl_dst=02:bb:5e:36:06:4b actions=output:2
  priority=100,ipv6,in_port=3,vlan_tci=0x0000/0x1000,dl_dst=02:bb:5e:36:06:4b actions=output:2
  priority=100,ip,in_port=3,vlan_tci=0x1000/0x1000,dl_dst=02:bb:5e:36:06:4b actions=strip_vlan,output:70

--- a/lte/gateway/python/magma/pipelined/tests/snapshots/test_uplink_bridge.UplinkBridgeWithNonNatUplinkConnect_Static_IP_Test.testFlowSnapshotMatch.snapshot
+++ b/lte/gateway/python/magma/pipelined/tests/snapshots/test_uplink_bridge.UplinkBridgeWithNonNatUplinkConnect_Static_IP_Test.testFlowSnapshotMatch.snapshot
@@ -1,0 +1,13 @@
+ priority=65534,udp,in_port=200,tp_dst=68 actions=output:1,LOCAL
+ priority=0,in_port=LOCAL actions=output:200
+ priority=65534,in_port=1 actions=output:200
+ priority=100,in_port=2 actions=mod_dl_src:02:bb:5e:36:06:4b,output:200
+ priority=101,ip,in_port=200,nw_dst=10.55.0.41 actions=LOCAL
+ priority=101,ipv6,in_port=200,ipv6_dst=fc00::55:0:111 actions=LOCAL
+ priority=100,ip,in_port=200,vlan_tci=0x0000/0x1000,dl_dst=02:bb:5e:36:06:4b actions=output:2
+ priority=100,ipv6,in_port=200,vlan_tci=0x0000/0x1000,dl_dst=02:bb:5e:36:06:4b actions=output:2
+ priority=100,ip,in_port=200,vlan_tci=0x1000/0x1000,dl_dst=02:bb:5e:36:06:4b actions=strip_vlan,output:70
+ priority=100,ipv6,in_port=200,vlan_tci=0x1000/0x1000,dl_dst=02:bb:5e:36:06:4b actions=strip_vlan,output:70
+ priority=100,ip,in_port=71,dl_dst=02:bb:5e:36:06:4b actions=output:2
+ priority=100,ipv6,in_port=71,dl_dst=02:bb:5e:36:06:4b actions=output:2
+ priority=0,arp,in_port=200 actions=output:1,output:2,LOCAL

--- a/lte/gateway/python/magma/pipelined/tests/test_uplink_bridge.py
+++ b/lte/gateway/python/magma/pipelined/tests/test_uplink_bridge.py
@@ -12,6 +12,7 @@ limitations under the License.
 """
 import logging
 import subprocess
+import threading
 import unittest
 import warnings
 from concurrent.futures import Future
@@ -25,7 +26,9 @@ from magma.pipelined.tests.pipelined_test_util import (
     assert_bridge_snapshot_match,
     create_service_manager,
     get_iface_gw_ipv4,
+    get_iface_gw_ipv6,
     get_iface_ipv4,
+    get_iface_ipv6,
     get_ovsdb_port_tag,
     start_ryu_app_thread,
     stop_ryu_app_thread,
@@ -156,6 +159,7 @@ class UplinkBridgeWithNonNATTest(unittest.TestCase):
                 'dev_vlan_out': cls.VLAN_DEV_OUT,
                 'ovs_vlan_workaround': False,
                 'sgi_management_iface_ip_addr': '1.1.11.1',
+                'sgi_management_iface_ipv6_addr': 'fe80::48a3:2cff:fe1a:abcd/10',
             },
             mconfig=None,
             loop=None,
@@ -272,6 +276,7 @@ class UplinkBridgeWithNonNATTestVlan(unittest.TestCase):
                 'dev_vlan_in': cls.VLAN_DEV_IN,
                 'dev_vlan_out': cls.VLAN_DEV_OUT,
                 'sgi_management_iface_ip_addr': '1.1.11.1',
+                'sgi_management_iface_ipv6_addr': 'fe80::48a3:2cff:fe1a:dd47/10',
             },
             mconfig=None,
             loop=None,
@@ -332,8 +337,6 @@ class UplinkBridgeWithNonNATTestVlan(unittest.TestCase):
         )
 
 
-@unittest.skip
-# this reset default GW
 class UplinkBridgeWithNonNATTest_IP_VLAN(unittest.TestCase):
     BRIDGE = 'testing_br'
     MAC_DEST = "5e:cc:cc:b1:49:4b"
@@ -345,6 +348,7 @@ class UplinkBridgeWithNonNATTest_IP_VLAN(unittest.TestCase):
     UPLINK_ETH_PORT = 'test_eth3'
     VLAN_TAG = '500'
     SGi_IP = "1.6.5.7"
+    SGi_IPv6 = 'fe80::48a3:2cff:fe1a:cccc'
 
     @classmethod
     def setUpClass(cls):
@@ -390,6 +394,8 @@ class UplinkBridgeWithNonNATTest_IP_VLAN(unittest.TestCase):
                 'sgi_management_iface_ip_addr': cls.SGi_IP,
                 'dev_vlan_in': "test_v_in",
                 'dev_vlan_out': "test_v_out",
+                'sgi_management_iface_ipv6_addr': cls.SGi_IPv6 + '/10',
+
             },
             mconfig=None,
             loop=None,
@@ -398,8 +404,7 @@ class UplinkBridgeWithNonNATTest_IP_VLAN(unittest.TestCase):
         )
 
         BridgeTools.create_bridge(cls.BRIDGE, cls.BRIDGE)
-        # validate vlan id set
-        vlan = "10"
+
         BridgeTools.create_bridge(cls.UPLINK_BRIDGE, cls.UPLINK_BRIDGE)
 
         set_ip_cmd = [
@@ -443,10 +448,9 @@ class UplinkBridgeWithNonNATTest_IP_VLAN(unittest.TestCase):
         )
 
         self.assertIn(cls.SGi_IP, get_iface_ipv4(cls.UPLINK_BRIDGE), "ip not found")
+        self.assertIn(cls.SGi_IPv6, get_iface_ipv6(cls.UPLINK_BRIDGE), "ipv6 not found")
 
 
-@unittest.skip
-# this reset default GW
 class UplinkBridgeWithNonNATTest_IP_VLAN_GW(unittest.TestCase):
     BRIDGE = 'testing_br'
     MAC_DEST = "5e:cc:cc:b1:49:4b"
@@ -459,6 +463,7 @@ class UplinkBridgeWithNonNATTest_IP_VLAN_GW(unittest.TestCase):
     VLAN_TAG = '100'
     SGi_IP = "1.6.5.7/24"
     SGi_GW = "1.6.5.1"
+    SGi_IPv6_GW = 'fe80::48a3:2cff:dddd:dd47'
 
     @classmethod
     def setUpClass(cls):
@@ -503,8 +508,10 @@ class UplinkBridgeWithNonNATTest_IP_VLAN_GW(unittest.TestCase):
                 'sgi_management_iface_vlan': cls.VLAN_TAG,
                 'sgi_management_iface_ip_addr': cls.SGi_IP,
                 'sgi_management_iface_gw': cls.SGi_GW,
+                'sgi_management_iface_gw_ipv6': cls.SGi_IPv6_GW,
                 'dev_vlan_in': "test_v_in",
                 'dev_vlan_out': "test_v_out",
+                'sgi_management_iface_ipv6_addr': 'fe80::48a3:2cff:aaaa:dd47/10',
             },
             mconfig=None,
             loop=None,
@@ -562,11 +569,254 @@ class UplinkBridgeWithNonNATTest_IP_VLAN_GW(unittest.TestCase):
             self.service_manager,
             include_stats=False,
         )
-
         self.assertIn(
             cls.SGi_GW, get_iface_gw_ipv4(cls.UPLINK_BRIDGE),
             "gw not found",
         )
+        self.assertIn(
+            cls.SGi_IPv6_GW, get_iface_gw_ipv6(cls.UPLINK_BRIDGE),
+            "gw not found",
+        )
+
+
+class UplinkBridgeWithNonNatUplinkConnect_Static_IP_Test(unittest.TestCase):
+    BRIDGE = 'testing_br'
+    IFACE = 'testing_br'
+    MAC_DEST = "5e:cc:cc:b1:49:4b"
+    BRIDGE_IP = '192.168.128.1'
+    SCRIPT_PATH = "/home/vagrant/magma/lte/gateway/python/magma/mobilityd/"
+    NET_SW_BR = "net_sw_up1"
+    UPLINK_DHCP = "tino_dhcp"
+    SCRIPT_PATH = "/home/vagrant/magma/lte/gateway/python/magma/mobilityd/"
+    UPLINK_ETH_PORT = "upb_ul_0"
+    UPLINK_BRIDGE = 'upt_br0'
+    UPLINK_PATCH = 'test_patch_p2'
+    ROUTER_IP = "10.55.0.211"
+    ROUTER_IPV6 = 'fc00::55:0:211'
+
+    @classmethod
+    def _setup_vlan_network(cls, vlan: str):
+        setup_vlan_switch = cls.SCRIPT_PATH + "scripts/setup-uplink-vlan-sw.sh"
+        subprocess.check_call([setup_vlan_switch, cls.NET_SW_BR, "upb"])
+        cls._setup_vlan(vlan)
+
+    @classmethod
+    def _setup_vlan(cls, vlan):
+        setup_vlan_switch = cls.SCRIPT_PATH + "scripts/setup-uplink-vlan-srv.sh"
+        subprocess.check_call([setup_vlan_switch, cls.NET_SW_BR, vlan, "55"])
+
+    @classmethod
+    def setUpClass(cls):
+        """
+        Starts the thread which launches ryu apps
+
+        Create a testing bridge, add a port, setup the port interfaces. Then
+        launch the ryu apps for testing pipelined. Gets the references
+        to apps launched by using futures.
+        """
+        super(UplinkBridgeWithNonNatUplinkConnect_Static_IP_Test, cls).setUpClass()
+        warnings.simplefilter('ignore')
+        cls.service_manager = create_service_manager([])
+
+        cls._setup_vlan_network("0")
+
+        BridgeTools.create_bridge(cls.UPLINK_BRIDGE, cls.UPLINK_BRIDGE)
+        BridgeTools.create_internal_iface(
+            cls.UPLINK_BRIDGE,
+            cls.UPLINK_DHCP, None,
+        )
+        BridgeTools.create_internal_iface(
+            cls.UPLINK_BRIDGE,
+            cls.UPLINK_PATCH, None,
+        )
+
+        check_connectivity(cls.ROUTER_IP, cls.UPLINK_ETH_PORT)
+        BridgeTools.add_ovs_port(cls.UPLINK_BRIDGE, cls.UPLINK_ETH_PORT, "200")
+        print("create uplink br: done")
+
+        # this is setup after AGW boot up in NATed mode.
+        uplink_bridge_controller_reference = Future()
+        testing_controller_reference = Future()
+        test_setup = TestSetup(
+            apps=[
+                PipelinedController.UplinkBridge,
+                PipelinedController.Testing,
+                PipelinedController.StartupFlows,
+            ],
+            references={
+                PipelinedController.UplinkBridge:
+                    uplink_bridge_controller_reference,
+                PipelinedController.Testing:
+                    testing_controller_reference,
+                PipelinedController.StartupFlows:
+                    Future(),
+            },
+            config={
+                'bridge_name': cls.BRIDGE,
+                'bridge_ip_address': cls.BRIDGE_IP,
+                'ovs_gtp_port_number': 32768,
+                'clean_restart': True,
+                'enable_nat': False,
+                'uplink_bridge': cls.UPLINK_BRIDGE,
+                'uplink_eth_port_name': cls.UPLINK_ETH_PORT,
+                'virtual_mac': '02:bb:5e:36:06:4b',
+                'uplink_patch': cls.UPLINK_PATCH,
+                'uplink_dhcp_port': cls.UPLINK_DHCP,
+                'sgi_management_iface_vlan': "",
+                'ovs_vlan_workaround': True,
+                'dev_vlan_in': "testv1_in",
+                'dev_vlan_out': "testv1_out",
+                'sgi_management_iface_ip_addr': '10.55.0.41/24',
+                'sgi_management_iface_ipv6_addr': 'fc00::55:0:111/96',
+            },
+            mconfig=None,
+            loop=None,
+            service_manager=cls.service_manager,
+            integ_test=False,
+        )
+
+        BridgeTools.create_bridge(cls.BRIDGE, cls.BRIDGE)
+
+        cls.thread = start_ryu_app_thread(test_setup)
+        cls.uplink_br_controller = uplink_bridge_controller_reference.result()
+
+        cls.testing_controller = testing_controller_reference.result()
+
+    @classmethod
+    def tearDownClass(cls):
+        stop_ryu_app_thread(cls.thread)
+        BridgeTools.destroy_bridge(cls.BRIDGE)
+        BridgeTools.destroy_bridge(cls.UPLINK_BRIDGE)
+        BridgeTools.destroy_bridge(cls.NET_SW_BR)
+
+    def testFlowSnapshotMatch(self):
+        cls = self.__class__
+        # after Non NAT init, router shld be accessible.
+        # manually start DHCP client on up-br
+
+        check_connectivity(cls.ROUTER_IP, cls.UPLINK_BRIDGE, False)
+        check_connectivity_v6(cls.ROUTER_IPV6)
+
+        assert_bridge_snapshot_match(
+            self, self.UPLINK_BRIDGE, self.service_manager,
+            include_stats=False,
+        )
+        self.assertEqual(get_ovsdb_port_tag(cls.UPLINK_BRIDGE), '[]')
+
+
+class UplinkBridgeTestNatIPAddr(unittest.TestCase):
+    BRIDGE = 'testing_br'
+    MAC_DEST = "5e:cc:cc:b1:49:4b"
+    BRIDGE_IP = '192.168.128.1'
+    BRIDGE_ETH_PORT = "eth_t1"
+    UPLINK_BRIDGE = 'upt_br0'
+    SGi_IP = "1.6.5.77"
+
+    @classmethod
+    def setUpClass(cls):
+        """
+        Starts the thread which launches ryu apps
+
+        Create a testing bridge, add a port, setup the port interfaces. Then
+        launch the ryu apps for testing pipelined. Gets the references
+        to apps launched by using futures.
+        """
+        super(UplinkBridgeTestNatIPAddr, cls).setUpClass()
+        warnings.simplefilter('ignore')
+        cls.service_manager = create_service_manager([])
+
+        uplink_bridge_controller_reference = Future()
+        testing_controller_reference = Future()
+        test_setup = TestSetup(
+            apps=[
+                PipelinedController.UplinkBridge,
+                PipelinedController.Testing,
+                PipelinedController.StartupFlows,
+            ],
+            references={
+                PipelinedController.UplinkBridge:
+                    uplink_bridge_controller_reference,
+                PipelinedController.Testing:
+                    testing_controller_reference,
+                PipelinedController.StartupFlows:
+                    Future(),
+            },
+            config={
+                'bridge_name': cls.BRIDGE,
+                'bridge_ip_address': cls.BRIDGE_IP,
+                'ovs_gtp_port_number': 32768,
+                'clean_restart': True,
+                'enable_nat': True,
+                'uplink_bridge': cls.UPLINK_BRIDGE,
+                'sgi_management_iface_ip_addr': cls.SGi_IP,
+                'uplink_eth_port_name': cls.BRIDGE_ETH_PORT,
+            },
+            mconfig=None,
+            loop=None,
+            service_manager=cls.service_manager,
+            integ_test=False,
+        )
+
+        BridgeTools.create_bridge(cls.BRIDGE, cls.BRIDGE)
+        BridgeTools.create_bridge(cls.UPLINK_BRIDGE, cls.UPLINK_BRIDGE)
+        BridgeTools.create_internal_iface(
+            cls.BRIDGE,
+            cls.BRIDGE_ETH_PORT, '2.2.2.2',
+        )
+        cls.thread = start_ryu_app_thread(test_setup)
+        cls.uplink_br_controller = uplink_bridge_controller_reference.result()
+        cls.testing_controller = testing_controller_reference.result()
+
+    @classmethod
+    def tearDownClass(cls):
+        stop_ryu_app_thread(cls.thread)
+        BridgeTools.destroy_bridge(cls.BRIDGE)
+        BridgeTools.destroy_bridge(cls.UPLINK_BRIDGE)
+
+    def testFlowSnapshotMatch(self):
+        cls = self.__class__
+
+        assert_bridge_snapshot_match(self, self.UPLINK_BRIDGE, self.service_manager)
+        self.assertIn(cls.SGi_IP, get_iface_ipv4(cls.BRIDGE_ETH_PORT), "ip not found")
+
+
+class UplinkBridgeTestFlowRestore(unittest.TestCase):
+    BRIDGE = 'uplink_br0'
+    FLOWS_FILE = '/home/vagrant/magma/lte/gateway/python/magma/pipelined/tests/snapshots/ovs-restart-test1.txt'
+    OVS_RESET_CMD = '/home/vagrant/magma/lte/gateway/deploy/roles/magma/files/magma-bridge-reset.sh'
+
+    @classmethod
+    def setUpClass(cls):
+        """
+        Starts the thread which launches ryu apps
+
+        Create a testing bridge, add a port, setup the port interfaces. Then
+        launch the ryu apps for testing pipelined. Gets the references
+        to apps launched by using futures.
+        """
+        super(UplinkBridgeTestFlowRestore, cls).setUpClass()
+        cls.service_manager = create_service_manager([])
+
+        BridgeTools.create_bridge(cls.BRIDGE, cls.BRIDGE)
+        cmd1 = ['ovs-ofctl', 'del-flows', cls.BRIDGE]
+        subprocess.check_call(cmd1)
+        cmd1 = ['ovs-ofctl', 'add-flows', cls.BRIDGE, cls.FLOWS_FILE]
+        subprocess.check_call(cmd1)
+
+    @classmethod
+    def tearDownClass(cls):
+        cmd1 = ['ovs-ofctl', 'del-flows', cls.BRIDGE]
+        subprocess.check_call(cmd1)
+
+    def test_flow_snapshot_match(self):
+        cls = self.__class__
+
+        assert_bridge_snapshot_match(self, self.BRIDGE, self.service_manager)
+        cmd1 = [cls.OVS_RESET_CMD, '-f', cls.BRIDGE]
+        subprocess.check_call(cmd1)
+        assert_bridge_snapshot_match(self, self.BRIDGE, self.service_manager)
+
+# DHCP based test
 
 
 @unittest.skip
@@ -686,137 +936,26 @@ class UplinkBridgeWithNonNatUplinkConnect_Test(unittest.TestCase):
         self.assertEqual(get_ovsdb_port_tag(cls.UPLINK_BRIDGE), '[]')
         # after Non NAT init, router shld be accessible.
         # manually start DHCP client on up-br
+        threading.Event().wait(.5)
         check_connectivity(cls.ROUTER_IP, cls.UPLINK_BRIDGE)
-
-
-class UplinkBridgeTestNatIPAddr(unittest.TestCase):
-    BRIDGE = 'testing_br'
-    MAC_DEST = "5e:cc:cc:b1:49:4b"
-    BRIDGE_IP = '192.168.128.1'
-    BRIDGE_ETH_PORT = "eth_t1"
-    UPLINK_BRIDGE = 'upt_br0'
-    SGi_IP = "1.6.5.77"
-
-    @classmethod
-    def setUpClass(cls):
-        """
-        Starts the thread which launches ryu apps
-
-        Create a testing bridge, add a port, setup the port interfaces. Then
-        launch the ryu apps for testing pipelined. Gets the references
-        to apps launched by using futures.
-        """
-        super(UplinkBridgeTestNatIPAddr, cls).setUpClass()
-        warnings.simplefilter('ignore')
-        cls.service_manager = create_service_manager([])
-
-        uplink_bridge_controller_reference = Future()
-        testing_controller_reference = Future()
-        test_setup = TestSetup(
-            apps=[
-                PipelinedController.UplinkBridge,
-                PipelinedController.Testing,
-                PipelinedController.StartupFlows,
-            ],
-            references={
-                PipelinedController.UplinkBridge:
-                    uplink_bridge_controller_reference,
-                PipelinedController.Testing:
-                    testing_controller_reference,
-                PipelinedController.StartupFlows:
-                    Future(),
-            },
-            config={
-                'bridge_name': cls.BRIDGE,
-                'bridge_ip_address': cls.BRIDGE_IP,
-                'ovs_gtp_port_number': 32768,
-                'clean_restart': True,
-                'enable_nat': True,
-                'uplink_bridge': cls.UPLINK_BRIDGE,
-                'sgi_management_iface_ip_addr': cls.SGi_IP,
-                'uplink_eth_port_name': cls.BRIDGE_ETH_PORT,
-            },
-            mconfig=None,
-            loop=None,
-            service_manager=cls.service_manager,
-            integ_test=False,
-        )
-
-        BridgeTools.create_bridge(cls.BRIDGE, cls.BRIDGE)
-        BridgeTools.create_bridge(cls.UPLINK_BRIDGE, cls.UPLINK_BRIDGE)
-        BridgeTools.create_internal_iface(
-            cls.BRIDGE,
-            cls.BRIDGE_ETH_PORT, '2.2.2.2',
-        )
-        cls.thread = start_ryu_app_thread(test_setup)
-        cls.uplink_br_controller = uplink_bridge_controller_reference.result()
-        cls.testing_controller = testing_controller_reference.result()
-
-    @classmethod
-    def tearDownClass(cls):
-        stop_ryu_app_thread(cls.thread)
-        BridgeTools.destroy_bridge(cls.BRIDGE)
-        BridgeTools.destroy_bridge(cls.UPLINK_BRIDGE)
-
-    def testFlowSnapshotMatch(self):
-        cls = self.__class__
-
-        assert_bridge_snapshot_match(self, self.UPLINK_BRIDGE, self.service_manager)
-        self.assertIn(cls.SGi_IP, get_iface_ipv4(cls.BRIDGE_ETH_PORT), "ip not found")
-
-
-class UplinkBridgeTestFlowRestore(unittest.TestCase):
-    BRIDGE = 'uplink_br0'
-    FLOWS_FILE = '/home/vagrant/magma/lte/gateway/python/magma/pipelined/tests/snapshots/ovs-restart-test1.txt'
-    OVS_RESET_CMD = '/home/vagrant/magma/lte/gateway/deploy/roles/magma/files/magma-bridge-reset.sh'
-
-    @classmethod
-    def setUpClass(cls):
-        """
-        Starts the thread which launches ryu apps
-
-        Create a testing bridge, add a port, setup the port interfaces. Then
-        launch the ryu apps for testing pipelined. Gets the references
-        to apps launched by using futures.
-        """
-        super(UplinkBridgeTestFlowRestore, cls).setUpClass()
-        cls.service_manager = create_service_manager([])
-
-        BridgeTools.create_bridge(cls.BRIDGE, cls.BRIDGE)
-        cmd1 = ['ovs-ofctl', 'del-flows', cls.BRIDGE]
-        subprocess.check_call(cmd1)
-        cmd1 = ['ovs-ofctl', 'add-flows', cls.BRIDGE, cls.FLOWS_FILE]
-        subprocess.check_call(cmd1)
-
-    @classmethod
-    def tearDownClass(cls):
-        cmd1 = ['ovs-ofctl', 'del-flows', cls.BRIDGE]
-        subprocess.check_call(cmd1)
-
-    def test_flow_snapshot_match(self):
-        cls = self.__class__
-
-        assert_bridge_snapshot_match(self, self.BRIDGE, self.service_manager)
-        cmd1 = [cls.OVS_RESET_CMD, '-f', cls.BRIDGE]
-        subprocess.check_call(cmd1)
-        assert_bridge_snapshot_match(self, self.BRIDGE, self.service_manager)
 
 
 if __name__ == "__main__":
     unittest.main()
 
 
-def check_connectivity(dst: str, dev_name: str):
-    try:
-        ifdown_if = ["dhclient", dev_name]
-        subprocess.check_call(ifdown_if)
-    except subprocess.SubprocessError as e:
-        logging.warning(
-            "Error while setting dhcl IP: %s: %s",
-            dev_name, e,
-        )
-        return
-    hub.sleep(1)
+def check_connectivity(dst: str, dev_name: str, setup_dhcp: bool = True):
+    if setup_dhcp:
+        try:
+            ifdown_if = ["dhclient", dev_name]
+            subprocess.check_call(ifdown_if)
+        except subprocess.SubprocessError as e:
+            logging.warning(
+                "Error while setting dhcl IP: %s: %s",
+                dev_name, e,
+            )
+            return
+        hub.sleep(1)
 
     try:
         ping_cmd = ["ping", "-c", "3", dst]
@@ -826,6 +965,15 @@ def check_connectivity(dst: str, dev_name: str):
         # for now dont assert here.
 
     validate_routing_table(dst, dev_name)
+
+
+def check_connectivity_v6(dst: str):
+
+    try:
+        ping_cmd = ["ping6", "-c", "3", dst]
+        subprocess.check_call(ping_cmd)
+    except subprocess.SubprocessError as e:
+        logging.warning("Error while ping: %s", e)
 
 
 def validate_routing_table(dst: str, dev_name: str) -> str:
@@ -843,7 +991,7 @@ def validate_routing_table(dst: str, dev_name: str) -> str:
             pass
     logging.error("could not find route to %s via %s", dst, dev_name)
     dump1 = subprocess.Popen(
-        ["ovs-ofctl", "dump-flows", cls.UPLINK_BRIDGE],
+        ["ovs-ofctl", "dump-flows", dev_name],
         stdout=subprocess.PIPE,
     )
     for line in dump1.stdout.readlines():


### PR DESCRIPTION
This add support to set IPv6 add and IPv6 GW IP for SGi
device on AGW.
It also cleans up test cases for uplink-br app. As a result
two skipped test can be enabled.

Signed-off-by: Pravin B Shelar <pbshelar@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->

## Test Plan
validated using new and existing test cases on magma dev vm.
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
