### PR TITLE
feat(amf): Handling SCTP close association

### DIFF
--- a/lte/gateway/c/core/oai/tasks/ngap/ngap_amf.c
+++ b/lte/gateway/c/core/oai/tasks/ngap/ngap_amf.c
@@ -118,6 +118,13 @@ static int handle_message(zloop_t* loop, zsock_t* reader, void* arg) {
 
     } break;
 
+    // SCTP layer notifies NGAP of disconnection of a peer.
+    case SCTP_CLOSE_ASSOCIATION: {
+      ngap_handle_sctp_disconnection(
+          state, SCTP_CLOSE_ASSOCIATION(received_message_p).assoc_id,
+          SCTP_CLOSE_ASSOCIATION(received_message_p).reset);
+    } break;
+
     case SCTP_NEW_ASSOCIATION: {
       increment_counter("amf_new_association", 1, NO_LABELS);
       if (ngap_handle_new_association(

--- a/lte/gateway/c/core/oai/tasks/ngap/ngap_amf_handlers.c
+++ b/lte/gateway/c/core/oai/tasks/ngap/ngap_amf_handlers.c
@@ -1527,7 +1527,6 @@ typedef struct arg_ngap_construct_gnb_reset_req_s {
 status_code_e ngap_handle_sctp_disconnection(
     ngap_state_t* state, const sctp_assoc_id_t assoc_id, bool reset) {
   arg_ngap_send_gnb_dereg_ind_t arg  = {0};
-  int i                              = 0;
   MessageDef* message_p              = NULL;
   gnb_description_t* gnb_association = NULL;
 
@@ -1558,6 +1557,7 @@ status_code_e ngap_handle_sctp_disconnection(
       OAILOG_INFO(
           LOG_NGAP, "Moving gNB with assoc_id %u to INIT state\n", assoc_id);
       gnb_association->ng_state = NGAP_INIT;
+      state->num_gnbs--;
       // update_amf_app_stats_connected_gnb_sub(); TODO : part of stats
     } else {
       OAILOG_INFO(
@@ -1582,15 +1582,6 @@ status_code_e ngap_handle_sctp_disconnection(
   hashtable_uint64_ts_apply_callback_on_elements(
       &gnb_association->ue_id_coll, ngap_send_gnb_deregistered_ind,
       (void*) &arg, (void**) &message_p);
-
-  for (i = arg.current_ue_index; i < NGAP_ITTI_UE_PER_DEREGISTER_MESSAGE; i++) {
-    NGAP_GNB_DEREGISTERED_IND(message_p).amf_ue_ngap_id[arg.current_ue_index] =
-        0;
-    NGAP_GNB_DEREGISTERED_IND(message_p).gnb_ue_ngap_id[arg.current_ue_index] =
-        0;
-  }
-  NGAP_GNB_DEREGISTERED_IND(message_p).gnb_id = gnb_association->gnb_id;
-  message_p                                   = NULL;
 
   OAILOG_FUNC_RETURN(LOG_NGAP, RETURNok);
 }

--- a/lte/gateway/c/core/oai/test/ngap/CMakeLists.txt
+++ b/lte/gateway/c/core/oai/test/ngap/CMakeLists.txt
@@ -14,6 +14,7 @@ add_executable(ngap_test
         util_ngap_amf_nas_procedures.cpp
         test_ngap_encode_decode.cpp
         test_ngap_handle_new_association.cpp
+        test_ngap_handle_close_association.cpp
         test_ngap_flows.cpp)
 
 target_link_libraries(ngap_test

--- a/lte/gateway/c/core/oai/test/ngap/test_ngap_handle_close_association.cpp
+++ b/lte/gateway/c/core/oai/test/ngap/test_ngap_handle_close_association.cpp
@@ -1,0 +1,69 @@
+/**
+ * Copyright 2021 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <gtest/gtest.h>
+
+extern "C" {
+#include "Ngap_NGAP-PDU.h"
+#include "ngap_amf_handlers.h"
+}
+
+#include "ngap_state_manager.h"
+
+using ::testing::Test;
+
+namespace magma5g {
+
+TEST(test_ngap_handle_close_association, shutdown) {
+  ngap_state_t* state   = create_ngap_state(2, 2);
+  bstring ran_cp_ipaddr = bfromcstr("\xc0\xa8\x3c\x8d");
+  sctp_new_peer_t p     = {
+      .instreams     = 1,
+      .outstreams    = 2,
+      .assoc_id      = 3,
+      .ran_cp_ipaddr = ran_cp_ipaddr,
+  };
+
+  EXPECT_EQ(ngap_handle_new_association(state, &p), RETURNok);
+  EXPECT_EQ(state->gnbs.num_elements, 1);
+
+  gnb_description_t* gnbd = nullptr;
+  EXPECT_EQ(
+      hashtable_ts_get(
+          &state->gnbs, (const hash_key_t) p.assoc_id,
+          reinterpret_cast<void**>(&gnbd)),
+      HASH_TABLE_OK);
+  EXPECT_EQ(gnbd->sctp_assoc_id, 3);
+  EXPECT_EQ(gnbd->instreams, 1);
+  EXPECT_EQ(gnbd->outstreams, 2);
+  EXPECT_EQ(gnbd->gnb_id, 0);
+  EXPECT_EQ(gnbd->ng_state, NGAP_INIT);
+  EXPECT_EQ(gnbd->next_sctp_stream, 1);
+
+  EXPECT_EQ(state->num_gnbs, 1);
+
+  // Handling sctp close association
+  EXPECT_EQ(ngap_handle_sctp_disconnection(state, p.assoc_id, 0), RETURNok);
+  EXPECT_EQ(
+      hashtable_ts_get(
+          &state->gnbs, (const hash_key_t) p.assoc_id,
+          reinterpret_cast<void**>(&gnbd)),
+      HASH_TABLE_KEY_NOT_EXISTS);
+
+  // Expecting number of gnbs as ZERO after closing sctp association
+  EXPECT_EQ(state->num_gnbs, 0);
+
+  bdestroy(ran_cp_ipaddr);
+  free_ngap_state(state);
+}
+
+}  // namespace magma5g


### PR DESCRIPTION
Signed-off-by: chandhu-wavelabs <chandhu.naga@wavelabs.ai>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

Support added for handling sctp close association.

## Test Plan

The Following scenario is tested in TVM setup with TC59 test script. test TC59 is passing.
Scenario : 
Have 5 UEs to be registered and established session (they are in connected state)
Have 5 UEs to be registered, established session and moved to idle mode.
Action: Trigger sctp shutdown
Observe that all UEs transition into idle mode in the logs, NGAP receives the context releases
Action: Bring up gNB and have UEs send service request
Observe that all UEs are switched from idle to connected state in the logs

[sctp_close_association_logs_and_pcap.zip](https://github.com/magma/magma/files/7428212/sctp_close_association_logs_and_pcap.zip)
Triggering STCP-SHUTDWON:
![image](https://user-images.githubusercontent.com/84959602/139117987-0aaa067f-8f9f-4960-99fe-eb9a3659d968.png)
After bringing back the gNB, service request procedure is handling fine.
![image](https://user-images.githubusercontent.com/84959602/139118479-1fb9747b-0dbe-4761-ac3d-c8ff9fb4894e.png)





## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
