### PR TITLE
feat(pipelined): unified name for enable5gFeatures flag across AGW co…

### DIFF
--- a/cwf/gateway/configs/pipelined.yml
+++ b/cwf/gateway/configs/pipelined.yml
@@ -157,8 +157,7 @@ has_quota_port: 51115
 no_quota_port: 51125
 
 # For 5G Functionality Support flag
-5G_feature_set:
- enable: false
+enable5g_features: false
 
 ###############
 ## IMPORTANT ##

--- a/lte/gateway/configs/pipelined.yml
+++ b/lte/gateway/configs/pipelined.yml
@@ -189,9 +189,9 @@ ovs_internal_conntrack_port_number: 15579
 ovs_internal_conntrack_fwd_tbl_number: 202
 
 # For 5G Functionality Support flag
-5G_feature_set:
- enable: False
- node_identifier: 192.168.200.1
+enable5g_features: false
+
+upf_node_identifier: 192.168.200.1
 
 dp_irq:
  enable: True

--- a/lte/gateway/python/magma/pipelined/app/enforcement_stats.py
+++ b/lte/gateway/python/magma/pipelined/app/enforcement_stats.py
@@ -134,10 +134,7 @@ class EnforcementStatsController(PolicyMixin, RestartMixin, MagmaController):
         self.ng_config = self._get_ng_config(kwargs['config'], kwargs['rpc_stubs'])
 
     def _get_ng_config(self, config_dict, rpc_stub_dict):
-        ng_service_enabled = False
-        ng_flag = config_dict.get('5G_feature_set', None)
-        if ng_flag:
-            ng_service_enabled = ng_flag['enable']
+        ng_service_enabled = config_dict.get('enable5g_features', None)
 
         sessiond_setinterface = rpc_stub_dict.get('sessiond_setinterface')
 

--- a/lte/gateway/python/magma/pipelined/main.py
+++ b/lte/gateway/python/magma/pipelined/main.py
@@ -76,6 +76,12 @@ def main():
     enable_nat = service.config.get('enable_nat', service.mconfig.nat_enabled)
     service.config['enable_nat'] = enable_nat
     logging.info("Nat: %s", enable_nat)
+    enable5g_features = service.config.get(
+        'enable5g_features',
+        service.mconfig.enable5g_features,
+    )
+    service.config['enable5g_features'] = enable5g_features
+    logging.info("enable5g_features: %s", enable5g_features)
     vlan_tag = service.config.get(
         'sgi_management_iface_vlan',
         service.mconfig.sgi_management_iface_vlan,

--- a/lte/gateway/python/magma/pipelined/ng_manager/node_state_manager.py
+++ b/lte/gateway/python/magma/pipelined/ng_manager/node_state_manager.py
@@ -76,13 +76,13 @@ class NodeStateManager:
             return enode_if_ip[netifaces.AF_INET][0]['addr']
 
         def get_node_identifier(ng_params):
-            if ng_params and ng_params.get('node_identifier', None):
-                return ng_params['node_identifier']
+            if ng_params:
+                return ng_params
             return get_enodeb_if_ip(ng_params)
 
         return self.LocalNodeConfig(
-            downlink_ip=get_enodeb_if_ip(config_dict['5G_feature_set']),
-            node_identifier=get_node_identifier(config_dict['5G_feature_set']),
+            downlink_ip=get_enodeb_if_ip(config_dict),
+            node_identifier=get_node_identifier(config_dict['upf_node_identifier']),
         )
 
     def _send_messsage_wrapper(self, node_message):

--- a/lte/gateway/python/magma/pipelined/service_manager.py
+++ b/lte/gateway/python/magma/pipelined/service_manager.py
@@ -508,11 +508,10 @@ class ServiceManager:
 
     def __init__(self, magma_service: MagmaService):
         self._magma_service = magma_service
-        if '5G_feature_set' not in magma_service.config:
+        if 'enable5g_features' not in magma_service.config:
             self._5G_flag_enable = False
         else:
-          ng_flag = magma_service.config.get('5G_feature_set')
-          self._5G_flag_enable = ng_flag['enable']
+            self._5G_flag_enable = magma_service.config.get('enable5g_features')
 
         # inout is a mandatory app and it occupies:
         #   table 1(for ingress)

--- a/lte/gateway/python/magma/pipelined/tests/ng_node_rpc_servicer.py
+++ b/lte/gateway/python/magma/pipelined/tests/ng_node_rpc_servicer.py
@@ -77,8 +77,8 @@ class RpcTests(unittest.TestCase):
         config_mock = {
                    'enodeb_iface': 'eth1',
                    'clean_restart': True,
-                   '5G_feature_set': {'enable': True},
-                   '5G_feature_set': {'node_identifier': '192.168.220.1'},
+                   'enable5g_features': True,
+                   'upf_node_identifier': '192.168.220.1',
                    'bridge_name': self.BRIDGE,
         }
 

--- a/lte/gateway/python/magma/pipelined/tests/pipelined_test_util.py
+++ b/lte/gateway/python/magma/pipelined/tests/pipelined_test_util.py
@@ -414,7 +414,7 @@ def create_service_manager(
         static_services = []
     magma_service.config = {
         'static_services': static_services,
-        '5G_feature_set': {'enable': False},
+        'enable5g_features': False,
     }
     # mock the get_default_client function used to return a fakeredis object
     func_mock = MagicMock(return_value=fakeredis.FakeStrictRedis())

--- a/lte/gateway/python/magma/pipelined/tests/test_ng_servicer_node.py
+++ b/lte/gateway/python/magma/pipelined/tests/test_ng_servicer_node.py
@@ -74,8 +74,8 @@ class NGServiceControllerTest(unittest.TestCase):
             config={
                 'enodeb_iface': 'eth1',
                 'clean_restart': True,
-                '5G_feature_set': {'enable': True},
-                '5G_feature_set': {'node_identifier': '192.168.220.1'},
+                'enable5g_features': True,
+                'upf_node_identifier': '192.168.220.1',
                 'bridge_name': self.BRIDGE,
             },
             mconfig=None,

--- a/lte/gateway/python/magma/pipelined/tests/test_ng_servicer_session.py
+++ b/lte/gateway/python/magma/pipelined/tests/test_ng_servicer_session.py
@@ -72,10 +72,8 @@ class NGServiceControllerTest(unittest.TestCase):
             config={
                 'enodeb_iface': 'eth1',
                 'clean_restart': True,
-                '5G_feature_set': {
-                    'enable': True,
-                    'node_identifier': '192.168.220.1',
-                },
+                'enable5g_features': True,
+                'upf_node_identifier': '192.168.220.1',
                 'bridge_name': self.BRIDGE,
             },
             mconfig=None,

--- a/lte/gateway/python/magma/pipelined/tests/test_service_manager.py
+++ b/lte/gateway/python/magma/pipelined/tests/test_service_manager.py
@@ -44,7 +44,7 @@ class ServiceManagerTest(unittest.TestCase):
         )
         magma_service_mock.config = {
             'static_services': ['arpd', 'access_control', 'ipfix', 'proxy'],
-            '5G_feature_set': {'enable': False},
+            'enable5g_features': False,
         }
         # mock the get_default_client function used to return a fakeredis object
         func_mock = MagicMock(return_value=fakeredis.FakeStrictRedis())


### PR DESCRIPTION
## Summary
feat(pipelined): unified name for enable5gFeatures flag across AGW components to enable/disable 5G SA feature
1) This PR depends on #8999 
2) This PR is for pipelined related changes for "enable5gFeatures" flag to unified across AGW components to enable/disable 5G SA feature

## Test Plan
1) End-to-End testing done with all AGW components PRs with UERANSIM

## Additional Information
Signed-off-by: GANESH IRRINKI <ganesh.irrinki@wavelabs.ai>
