### PR TITLE
chore(orc8r): Reorder gateway & lib modules imports to comply with std Go format/lint tools & conventions

### DIFF
--- a/orc8r/gateway/go/eventd/client_api.go
+++ b/orc8r/gateway/go/eventd/client_api.go
@@ -17,13 +17,13 @@ import (
 	"context"
 	"strings"
 
+	"github.com/golang/glog"
+
 	"magma/gateway/mconfig"
 	"magma/orc8r/lib/go/errors"
 	"magma/orc8r/lib/go/protos"
 	mcfgprotos "magma/orc8r/lib/go/protos/mconfig"
 	platformregistry "magma/orc8r/lib/go/registry"
-
-	"github.com/golang/glog"
 )
 
 const (

--- a/orc8r/gateway/go/mconfig/mconfig.go
+++ b/orc8r/gateway/go/mconfig/mconfig.go
@@ -19,10 +19,10 @@ import (
 	"sync/atomic"
 	"unsafe"
 
-	"magma/orc8r/lib/go/protos"
-
 	"github.com/golang/protobuf/proto"
 	"github.com/golang/protobuf/ptypes"
+
+	"magma/orc8r/lib/go/protos"
 )
 
 func GetServiceConfigs(service string, result proto.Message) error {

--- a/orc8r/gateway/go/redis/client.go
+++ b/orc8r/gateway/go/redis/client.go
@@ -18,10 +18,10 @@ import (
 	"fmt"
 	"reflect"
 
-	"magma/orc8r/lib/go/protos"
-
 	"github.com/go-redis/redis"
 	"github.com/golang/protobuf/proto"
+
+	"magma/orc8r/lib/go/protos"
 )
 
 type RedisStateClient struct {

--- a/orc8r/gateway/go/services/bootstrapper/gateway_info/get_info.go
+++ b/orc8r/gateway/go/services/bootstrapper/gateway_info/get_info.go
@@ -6,11 +6,11 @@ import (
 	"encoding/base64"
 	"fmt"
 
+	"github.com/emakeev/snowflake"
+
 	"magma/gateway/config"
 	"magma/gateway/services/bootstrapper/service"
 	"magma/orc8r/lib/go/security/key"
-
-	"github.com/emakeev/snowflake"
 )
 
 // Get returns Gateway Hardware Id and bootstrapping public key

--- a/orc8r/gateway/go/services/magmad/service/ping/ping_test.go
+++ b/orc8r/gateway/go/services/magmad/service/ping/ping_test.go
@@ -16,9 +16,9 @@ package ping
 import (
 	"testing"
 
-	"magma/orc8r/lib/go/protos"
-
 	"github.com/stretchr/testify/assert"
+
+	"magma/orc8r/lib/go/protos"
 )
 
 var (

--- a/orc8r/gateway/go/status/status_test.go
+++ b/orc8r/gateway/go/status/status_test.go
@@ -17,9 +17,9 @@ import (
 	"encoding/json"
 	"testing"
 
-	"magma/gateway/status"
-
 	"github.com/stretchr/testify/assert"
+
+	"magma/gateway/status"
 )
 
 func TestGatewayStatus(t *testing.T) {

--- a/orc8r/gateway/go/streamer/listener.go
+++ b/orc8r/gateway/go/streamer/listener.go
@@ -15,9 +15,9 @@ limitations under the License.
 package streamer
 
 import (
-	"magma/orc8r/lib/go/protos"
-
 	"github.com/golang/protobuf/ptypes/any"
+
+	"magma/orc8r/lib/go/protos"
 )
 
 // Listener interface defines Stream Listener which will become

--- a/orc8r/lib/go/profile/profiler_disabled.go
+++ b/orc8r/lib/go/profile/profiler_disabled.go
@@ -20,7 +20,6 @@ package profile
 import "os"
 
 // empty stubs for disabled profiler builds
-
 // MemWrite stub
 func MemWrite() error {
 	return nil

--- a/orc8r/lib/go/protos/fill_in_test.go
+++ b/orc8r/lib/go/protos/fill_in_test.go
@@ -16,9 +16,9 @@ package protos_test
 import (
 	"testing"
 
-	"magma/orc8r/lib/go/protos"
-
 	"github.com/stretchr/testify/assert"
+
+	"magma/orc8r/lib/go/protos"
 )
 
 func TestOverlapFillIn(t *testing.T) {

--- a/orc8r/lib/go/protos/tests/identity_test.go
+++ b/orc8r/lib/go/protos/tests/identity_test.go
@@ -18,9 +18,9 @@ import (
 	"regexp"
 	"testing"
 
-	"magma/orc8r/lib/go/protos"
-
 	"github.com/stretchr/testify/assert"
+
+	"magma/orc8r/lib/go/protos"
 )
 
 func TestIdentities(t *testing.T) {

--- a/orc8r/lib/go/registry/registry.go
+++ b/orc8r/lib/go/registry/registry.go
@@ -21,13 +21,13 @@ import (
 	"sync"
 	"time"
 
-	"magma/orc8r/lib/go/protos"
-	registry_client "magma/orc8r/lib/go/registry/client"
-
 	"github.com/golang/glog"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/keepalive"
+
+	"magma/orc8r/lib/go/protos"
+	registry_client "magma/orc8r/lib/go/registry/client"
 )
 
 const (

--- a/orc8r/lib/go/registry/service_registry.go
+++ b/orc8r/lib/go/registry/service_registry.go
@@ -17,10 +17,10 @@ import (
 	"fmt"
 	"strings"
 
-	"magma/orc8r/lib/go/service/config"
-
 	"github.com/golang/glog"
 	"github.com/pkg/errors"
+
+	"magma/orc8r/lib/go/service/config"
 )
 
 const (

--- a/orc8r/lib/go/security/csr/csr_test.go
+++ b/orc8r/lib/go/security/csr/csr_test.go
@@ -21,10 +21,10 @@ import (
 	"os"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"magma/orc8r/lib/go/security/csr"
 	"magma/orc8r/lib/go/security/key"
-
-	"github.com/stretchr/testify/assert"
 )
 
 func getDefaultCertificateRequestTemplate() (template *x509.CertificateRequest) {

--- a/orc8r/lib/go/service/service.go
+++ b/orc8r/lib/go/service/service.go
@@ -23,16 +23,16 @@ import (
 	"sync"
 	"time"
 
-	"magma/orc8r/lib/go/protos"
-	"magma/orc8r/lib/go/registry"
-	"magma/orc8r/lib/go/service/config"
-	"magma/orc8r/lib/go/util"
-
 	"github.com/golang/glog"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/encoding"
 	grpc_proto "google.golang.org/grpc/encoding/proto"
 	"google.golang.org/grpc/keepalive"
+
+	"magma/orc8r/lib/go/protos"
+	"magma/orc8r/lib/go/registry"
+	"magma/orc8r/lib/go/service/config"
+	"magma/orc8r/lib/go/util"
 )
 
 const (


### PR DESCRIPTION
Signed-off-by: Evgeniy Makeev <evgeniym@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

Reorder orc8r/gateway/go & lib modules imports to comply with std Go format/lint tools & conventions.

goimports, golangci-lint, ... order imports as follows: std packages, third party packages, local module packages.
This PR standartizes gateway & lib module import order according to the conventions.

## Test Plan

unit tests,
generate, build,
goimports -w -local magma/ ...

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
