### PR TITLE
ci: turns up GH Action validating all Bazel {build|test} targets

### DIFF
--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -1,0 +1,151 @@
+---
+name: "Bazel"
+on:  # yamllint disable-line rule:truthy
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+
+jobs:
+  path_filter:
+    runs-on: ubuntu-latest
+    # Map a step output to a job output
+    outputs:
+      should_skip: ${{ steps.skip_check.outputs.should_skip }}
+    steps:
+      - id: skip_check
+        uses: fkirc/skip-duplicate-actions@master
+        with:
+          # Only run the main job for changes including the following paths
+         paths: '[".github/workflows/bazel.yml", "lte/gateway/c/**", "orc8r/gateway/c/**", "orc8r/protos/**", "lte/protos/**"]'
+
+  gen_build_container:
+    needs: path_filter
+    if: ${{ needs.path_filter.outputs.should_skip == 'false' }}
+    name: gen build container job
+    runs-on: ubuntu-latest
+    env:
+      MAGMA_ROOT: "${{ github.workspace }}"
+    steps:
+      -
+        name: Check Out Repo
+        uses: actions/checkout@v2
+      -
+        name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v1
+      -
+        name: Cache Docker layers
+        uses: actions/cache@v2
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx
+      -
+        name: Docker Build
+        id: docker_build
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: ./experimental/bazel-base/Dockerfile
+          push: false
+          tags: magma/bazel:latest
+          outputs: type=docker,dest=/tmp/bazel.tar
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache-new
+      -
+        # Temp fix
+        # https://github.com/docker/build-push-action/issues/252
+        # https://github.com/moby/buildkit/issues/1896
+        name: Move cache - Fixup for buildx cache issue
+        run: |
+          rm -rf /tmp/.buildx-cache
+          mv /tmp/.buildx-cache-new /tmp/.buildx-cache
+      -
+        name: Upload docker image for other jobs
+        uses: actions/upload-artifact@v2
+        with:
+          name: build_container
+          path: /tmp/bazel.tar
+
+  bazel_test:
+    needs:
+      - path_filter
+      - gen_build_container
+    if: ${{ needs.path_filter.outputs.should_skip == 'false' }}
+    name: Bazel Test Job
+    runs-on: ubuntu-latest
+    steps:
+        -
+          # This is necessary for overlays into the Docker container below.
+          name: Check Out Repo
+          uses: actions/checkout@v2
+        -
+          name: Download docker image from generate_container_for_build
+          uses: actions/download-artifact@v2
+          with:
+            name: build_container
+            path: /tmp
+        -
+          name: Load Docker image
+          run: |
+            docker load --input /tmp/bazel.tar
+            docker image ls -a
+        -
+          name: Bazel Test
+          uses: addnab/docker-run-action@v2
+          with:
+            image: magma/bazel:latest
+            # TODO: Remove work-around mount of Github workspace to /magma (https://github.com/addnab/docker-run-action/issues/11)
+            options: -v ${{ github.workspace }}:/magma -e ABC=123
+            run: |
+              bazel test ... | tee /magma/test.log
+              BUILD_EXIT_CODE=$?
+              exit $BUILD_EXIT_CODE
+        -
+          name: Store build_logs_oai Artifact
+          uses: actions/upload-artifact@v2
+          with:
+            name: bazel_test_logs
+            path: ${{ github.workspace }}/test.log
+
+  bazel_build:
+    needs:
+      - path_filter
+      - gen_build_container
+    if: ${{ needs.path_filter.outputs.should_skip == 'false' }}
+    name: Bazel Build Job
+    runs-on: ubuntu-latest
+    steps:
+        -
+          # This is necessary for overlays into the Docker container below.
+          name: Check Out Repo
+          uses: actions/checkout@v2
+        -
+          name: Download docker image from generate_container_for_build
+          uses: actions/download-artifact@v2
+          with:
+            name: build_container
+            path: /tmp
+        -
+          name: Load Docker image
+          run: |
+            docker load --input /tmp/bazel.tar
+            docker image ls -a
+        -
+          name: Bazel Build
+          uses: addnab/docker-run-action@v2
+          with:
+            image: magma/bazel:latest
+            # TODO: Remove work-around mount of Github workspace to /magma (https://github.com/addnab/docker-run-action/issues/11)
+            options: -v ${{ github.workspace }}:/magma -e ABC=123
+            run: |
+              bazel build ... | tee /magma/build.log
+              BUILD_EXIT_CODE=$?
+              exit $BUILD_EXIT_CODE
+        -
+          name: Store build_logs_oai Artifact
+          uses: actions/upload-artifact@v2
+          with:
+            name: bazel_build_logs
+            path: ${{ github.workspace }}/build.log


### PR DESCRIPTION
While we experiment with Bazel Build, it would be nice to have CI support validating our tests and builds.

This PR is an initial pass at that.  The build times are not yet accelerated by caching - though the docker builds are cached (we may want to migrate them to a container repository).

For accelerating Bazel Build using remote caching - see examples from [TensorFlow on Github](https://github.com/tensorflow/io/issues/1236).

Signed-off-by: Scott Moeller <electronjoe@gmail.com>