### PR TITLE
chore(mme): Add s1ap test for simple attach detach with IPv6 primary PDN

### DIFF
--- a/lte/gateway/python/integ_tests/defs.mk
+++ b/lte/gateway/python/integ_tests/defs.mk
@@ -163,6 +163,7 @@ s1aptests/test_send_error_ind_for_erab_setup_req.py \
 s1aptests/test_attach_detach_with_ipv6_pcscf_and_dns_addr.py \
 s1aptests/test_concurrent_secondary_pdns.py \
 s1aptests/test_concurrent_secondary_pdn_reject.py \
+s1aptests/test_attach_detach_ipv6.py \
 s1aptests/test_ipv4v6_secondary_pdn_rs_retransmit.py \
 s1aptests/test_ipv4v6_secondary_pdn_spgw_initiated_ded_bearer.py \
 s1aptests/test_ipv6_secondary_pdn_rs_retransmit.py \

--- a/lte/gateway/python/integ_tests/s1aptests/s1ap_utils.py
+++ b/lte/gateway/python/integ_tests/s1aptests/s1ap_utils.py
@@ -396,7 +396,7 @@ class S1ApUtil(object):
             assert s1ap_types.tfwCmd.UE_CTX_REL_IND.value == response.msg_type
 
         with self._lock:
-            del self._ue_ip_map[ue_id]
+            self._ue_ip_map.pop(ue_id, 0)
 
     def _verify_dl_flow(self, dl_flow_rules=None):
         # try at least 5 times before failing as gateway

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_ipv6.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_ipv6.py
@@ -1,0 +1,84 @@
+"""
+Copyright 2020 The Magma Authors.
+
+This source code is licensed under the BSD-style license found in the
+LICENSE file in the root directory of this source tree.
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import time
+import unittest
+
+import s1ap_types
+from integ_tests.s1aptests import s1ap_wrapper
+
+
+class TestAttachDetachIpv6(unittest.TestCase):
+
+    def setUp(self):
+        self._s1ap_wrapper = s1ap_wrapper.TestWrapper()
+
+    def tearDown(self):
+        self._s1ap_wrapper.cleanup()
+
+    def test_attach_detach_ipv6(self):
+        """ Basic attach/detach IPv6 test with single UE """
+        num_ues = 2
+        detach_type = [
+            s1ap_types.ueDetachType_t.UE_NORMAL_DETACH.value,
+            s1ap_types.ueDetachType_t.UE_SWITCHOFF_DETACH.value,
+        ]
+        wait_for_s1 = [True, False]
+        self._s1ap_wrapper.configUEDevice(num_ues)
+
+        # Default apn over-write
+        magma_default_apn = {
+            "apn_name": "magma.ipv4",  # APN-name
+            "qci": 9,  # qci
+            "priority": 15,  # priority
+            "pre_cap": 1,  # preemption-capability
+            "pre_vul": 0,  # preemption-vulnerability
+            "mbr_ul": 200000000,  # MBR UL
+            "mbr_dl": 100000000,  # MBR DL
+            "pdn_type": 2,  # PDN Type 0-IPv4,1-IPv6,2-IPv4v6
+        }
+
+        apn_list = [magma_default_apn]
+
+        for i in range(num_ues):
+            req = self._s1ap_wrapper.ue_req
+            print(
+                "************************* Running End to End attach for ",
+                "UE id ", req.ue_id,
+            )
+            self._s1ap_wrapper.configAPN(
+                "IMSI" + "".join([str(j) for j in req.imsi]), 
+                apn_list, default=False
+            )
+            # Now actually complete the attach
+            self._s1ap_wrapper._s1_util.attach(
+                req.ue_id, s1ap_types.tfwCmd.UE_END_TO_END_ATTACH_REQUEST,
+                s1ap_types.tfwCmd.UE_ATTACH_ACCEPT_IND,
+                s1ap_types.ueAttachAccept_t,
+                pdn_type=2,
+            )
+
+            # Wait on EMM Information from MME
+            self._s1ap_wrapper._s1_util.receive_emm_info()
+            print(
+                "************************* Running UE detach for UE id ",
+                req.ue_id,
+            )
+            # Now detach the UE
+            self._s1ap_wrapper.s1_util.detach(
+                req.ue_id, detach_type[i], wait_for_s1[i],
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->
Current test cases were adding IPv6 and IPv4v6 PDNs as secondary PDNs. This test case adds the first PDN session (established as part of the attach procedure) an IPv6 session.
 
## Test Plan
Executed the test:

```
sleep 1; 	echo "Running test: s1aptests/test_attach_detach_ipv6.py"
Running test: s1aptests/test_attach_detach_ipv6.py
timeout --foreground -k 930s 900s sudo -E PATH=/usr/lib/ccache:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/go/bin PYTHONPATH=:/home/vagrant/s1ap-tester/bin /home/vagrant/build/python/bin/nosetests --with-xunit --xunit-file=/var/tmp/test_results/test_attach_detach_ipv6.xml -x -s s1aptests/test_attach_detach_ipv6.py || exit 1
Start time 18:19:34
tag: AUTH_TYPE tagVal: MILENAGE
************************* Enb tester config

**********************TPT open server******** 0

 Server Socket FD =[13]
************* Testing *Time elapsed(in usec): for timer expiry               :4320 usec
AGW is stateless
APN Correction configured
Health service is disabled
Using subscriber IMSI IMSI001010000000001
Using IMEI 3805468432113171
Using subscriber IMSI IMSI001010000000002
Using IMEI 3805468432113172
************************* UE device config for ue_id  1
************************* UE device config for ue_id  2
************************* Configuring IP block
************************* Waiting for IP changes to propagate
************************* S1 setup
************************* UE App config
************************* Running End to End attach for  UE id  1
ue id 1 found
PDN_TYPE: 2
IPv6 interface id: b4 cf 28 65 7a 98 b5 64

*************NbUiNbuHdlUeRadioCapMsg: Send UE cap msg SUCCESS*********
******** Successfully sent Router Solicit message for ip fe80::b4cf:2865:7a98:b564
IPv6 PDN type received
************************* Running UE detach for UE id  1
************************* Running End to End attach for  UE id  2
ue id 2 found

*************NbUiNbuHdlUeRadioCapMsg: Send UE cap msg SUCCESS*********
PDN_TYPE: 2
IPv6 interface id: cd 68 a0 77 46 ec 33 cd
******** Successfully sent Router Solicit message for ip fe80::cd68:a077:46ec:33cd
IPv6 PDN type received
************************* Running UE detach for UE id  2
************************* send SCTP SHUTDOWN
Keys left in Redis (list should be empty)[
  
]
Entries in s1ap_imsi_map (should be zero): 0
Entries left in hashtables (should be zero): 0
Entries in mme_ueip_imsi_map (should be zero): 0
```

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
