### PR TITLE
fix(mme): [AMF: Unit Test] Creating ue_context infrastructure#8347

### DIFF
--- a/lte/gateway/c/core/oai/test/amf/test_amf.cpp
+++ b/lte/gateway/c/core/oai/test/amf/test_amf.cpp
@@ -99,17 +99,24 @@ uint8_t NAS5GPktSnapShot::registration_reject[4] = {0x00, 0x00, 0x00, 0x00};
 
 uint8_t NAS5GPktSnapShot::security_mode_reject[4] = {0x7e, 0x00, 0x5f, 0x24};
 
-TEST(test_amf_nas5g_pkt_process, test_amf_ue_register_req_msg) {
-  NAS5GPktSnapShot nas5g_pkt_snap;
+class AmfNas5GTest : public ::testing::Test {
+ protected:
+  NAS5GPktSnapShot* nas5g_pkt_snap;
   RegistrationRequestMsg reg_request;
-  bool decode_res = false;
+  bool decode_res;
+  virtual void SetUp() {
+    nas5g_pkt_snap = new NAS5GPktSnapShot();
+    decode_res     = false;
+    memset(&reg_request, 0, sizeof(RegistrationRequestMsg));
+  }
+  virtual void TearDown() { delete nas5g_pkt_snap; }
+};
 
-  uint32_t len = nas5g_pkt_snap.get_reg_req_buffer_len();
-
-  memset(&reg_request, 0, sizeof(RegistrationRequestMsg));
+TEST_F(AmfNas5GTest, test_amf_ue_register_req_msg) {
+  uint32_t len = nas5g_pkt_snap->get_reg_req_buffer_len();
 
   decode_res = decode_registration_request_msg(
-      &reg_request, nas5g_pkt_snap.reg_req_buffer, len);
+      &reg_request, nas5g_pkt_snap->reg_req_buffer, len);
 
   EXPECT_EQ(decode_res, true);
 
@@ -145,17 +152,11 @@ TEST(test_amf_nas5g_pkt_process, test_amf_ue_register_req_msg) {
       reg_request.m5gs_mobile_identity.mobile_identity.imsi.mcc_digit2, 0x0);
 }
 
-TEST(test_amf_nas5g_pkt_process, test_amf_ue_guti_register_req_msg) {
-  NAS5GPktSnapShot nas5g_pkt_snap;
-  RegistrationRequestMsg reg_request;
-  bool decode_res = false;
-
-  uint32_t len = nas5g_pkt_snap.get_guti_based_registration_len();
-
-  memset(&reg_request, 0, sizeof(RegistrationRequestMsg));
+TEST_F(AmfNas5GTest, test_amf_ue_guti_register_req_msg) {
+  uint32_t len = nas5g_pkt_snap->get_guti_based_registration_len();
 
   decode_res = decode_registration_request_msg(
-      &reg_request, nas5g_pkt_snap.guti_based_registration, len);
+      &reg_request, nas5g_pkt_snap->guti_based_registration, len);
 
   EXPECT_EQ(decode_res, true);
 }
@@ -425,26 +426,27 @@ TEST(test_amf_nas5g_pkt_process, test_amf_service_accept) {
           .pdu_re_activation_status.pduSessionReActivationResult,
       PDU_SESSION_ID);
 }
-TEST(test_amf_data_struct, test_ue_context_creation) {
-  ue_m5gmm_context_s* ue_context = nullptr;
 
-  ue_context = amf_create_new_ue_context();
+class AmfUeContextTest : public ::testing::Test {
+ protected:
+  ue_m5gmm_context_s* ue_context;
+
+  virtual void SetUp() { ue_context = amf_create_new_ue_context(); }
+  virtual void TearDown() { delete ue_context; }
+};
+
+TEST_F(AmfUeContextTest, test_ue_context_creation) {
   EXPECT_TRUE(nullptr != ue_context);
   EXPECT_TRUE(0 == ue_context->amf_teid_n11);
   EXPECT_TRUE(0 == ue_context->paging_context.paging_retx_count);
-  delete ue_context;
 }
 
-TEST(test_smf_context_struct, test_smf_context_creation) {
-  ue_m5gmm_context_s* ue_context = nullptr;
-  smf_context_t* smf_context     = nullptr;
-
-  ue_context             = amf_create_new_ue_context();
-  uint8_t pdu_session_id = 10;
-  smf_context            = amf_insert_smf_context(ue_context, pdu_session_id);
+TEST_F(AmfUeContextTest, test_smf_context_creation) {
+  smf_context_t* smf_context = nullptr;
+  uint8_t pdu_session_id     = 10;
+  smf_context = amf_insert_smf_context(ue_context, pdu_session_id);
   EXPECT_TRUE(0 == smf_context->n_active_pdus);
   EXPECT_TRUE(0 == smf_context->pdu_session_version);
-  delete ue_context;
 }
 
 /* Test for registration reject */

--- a/lte/gateway/c/core/oai/test/amf/test_amf.cpp
+++ b/lte/gateway/c/core/oai/test/amf/test_amf.cpp
@@ -101,22 +101,18 @@ uint8_t NAS5GPktSnapShot::security_mode_reject[4] = {0x7e, 0x00, 0x5f, 0x24};
 
 class AmfNas5GTest : public ::testing::Test {
  protected:
-  NAS5GPktSnapShot* nas5g_pkt_snap;
-  RegistrationRequestMsg reg_request;
+  NAS5GPktSnapShot nas5g_pkt_snap;
+  RegistrationRequestMsg reg_request = {};
   bool decode_res;
-  virtual void SetUp() {
-    nas5g_pkt_snap = new NAS5GPktSnapShot();
-    decode_res     = false;
-    memset(&reg_request, 0, sizeof(RegistrationRequestMsg));
-  }
-  virtual void TearDown() { delete nas5g_pkt_snap; }
+  virtual void SetUp() { decode_res = false; }
+  virtual void TearDown() {}
 };
 
 TEST_F(AmfNas5GTest, test_amf_ue_register_req_msg) {
-  uint32_t len = nas5g_pkt_snap->get_reg_req_buffer_len();
+  uint32_t len = nas5g_pkt_snap.get_reg_req_buffer_len();
 
   decode_res = decode_registration_request_msg(
-      &reg_request, nas5g_pkt_snap->reg_req_buffer, len);
+      &reg_request, nas5g_pkt_snap.reg_req_buffer, len);
 
   EXPECT_EQ(decode_res, true);
 
@@ -153,10 +149,10 @@ TEST_F(AmfNas5GTest, test_amf_ue_register_req_msg) {
 }
 
 TEST_F(AmfNas5GTest, test_amf_ue_guti_register_req_msg) {
-  uint32_t len = nas5g_pkt_snap->get_guti_based_registration_len();
+  uint32_t len = nas5g_pkt_snap.get_guti_based_registration_len();
 
   decode_res = decode_registration_request_msg(
-      &reg_request, nas5g_pkt_snap->guti_based_registration, len);
+      &reg_request, nas5g_pkt_snap.guti_based_registration, len);
 
   EXPECT_EQ(decode_res, true);
 }


### PR DESCRIPTION
Signed-off-by: krishnavamsi-wavelabs <krishna.vamsi@wavelabs.ai>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary
Added test_fixtures for common code
For instance in setup :
a. Created amf_create_new_ue_context()
In tear Down
b. Cleaned up the variables.


## Test Plan

Verified basic sanity with UERANSIM.
Please find attached logs and pcap snap for basic registration and PDU Session setup

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
