### PR TITLE
feat: add exclusive flags to SessionD unit tests that cannot be run i…

### DIFF
--- a/lte/gateway/c/session_manager/test/BUILD.bazel
+++ b/lte/gateway/c/session_manager/test/BUILD.bazel
@@ -150,6 +150,7 @@ cc_test(
     size = "small",
     srcs = ["test_cloud_reporter.cpp"],
     flaky = True,
+    tags = ["exclusive"],
     deps = [
         ":sessiond_mocks",
         "//lte/gateway/c/session_manager:session_reporter",
@@ -176,6 +177,10 @@ cc_test(
     size = "small",
     srcs = ["test_sessiond_integ.cpp"],
     flaky = True,
+    # This test unfortunately brings up a test server that collides with another test (cloud_reporter)
+    # Marking it as exclusive so that the test is not run in parallel with other tests
+    # See https://docs.bazel.build/versions/4.2.1/test-encyclopedia.html#tag-conventions
+    tags = ["exclusive"],
     deps = [
         ":consts",
         ":matchers",


### PR DESCRIPTION
…n parallel

Signed-off-by: Marie Bremner <marwhal@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary
Some SessionD unit tests are sad when they are run together. I believe this is because the two unit tests both try to open up a test service at the same port. Will have to refactor the two tests eventually, but disabling parallel test execution for those two.
<!-- Enumerate changes you made and why you made them -->

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
