### PR TITLE
chore: clean up bazelrc and use output base instead of output user

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,6 +1,7 @@
-startup --output_user_root=/tmp/bazel
+startup --output_base=/tmp/bazel
 
 build --announce_rc
+build --color=yes
 build --cxxopt=-std=c++14
 build --cxxopt=-g2
 
@@ -8,12 +9,14 @@ build --cxxopt=-g2
 build:docker --disk_cache=/magma/.bazel-cache
 build:docker --repository_cache=/magma/.bazel-cache-repo
 
+build:specify_vm_cc --action_env=CC=/usr/bin/gcc
+build:specify_vm_cc --action_env=CXX=/usr/bin/g++
+
 # For building with Bazel inside the Magma VM
 build:vm --disk_cache=/home/vagrant/magma/.bazel-cache
 build:vm --repository_cache=/home/vagrant/magma/.bazel-cache-repo
 build:vm --define=folly_so=1
-build:vm --action_env=CC=/usr/bin/gcc
-build:vm --action_env=CXX=/usr/bin/g++
+build:vm --config=specify_vm_cc
 
 build:asan --strip=never
 build:asan --copt=-fsanitize=address


### PR DESCRIPTION
Signed-off-by: Marie Bremner <marwhal@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
