### PR TITLE
style: Add check for correct Go imports order to build.py -g

### DIFF
--- a/cwf/cloud/go/services/cwf/analytics/analytics.go
+++ b/cwf/cloud/go/services/cwf/analytics/analytics.go
@@ -17,12 +17,12 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus"
+
 	cwf_calculations "magma/cwf/cloud/go/services/cwf/analytics/calculations"
 	"magma/orc8r/cloud/go/services/analytics"
 	"magma/orc8r/cloud/go/services/analytics/calculations"
 	"magma/orc8r/lib/go/metrics"
-
-	"github.com/prometheus/client_golang/prometheus"
 )
 
 const (

--- a/cwf/cloud/go/services/cwf/analytics/analytics_test.go
+++ b/cwf/cloud/go/services/cwf/analytics/analytics_test.go
@@ -17,11 +17,11 @@ import (
 	"fmt"
 	"testing"
 
-	cwf_calculations "magma/cwf/cloud/go/services/cwf/analytics/calculations"
-	"magma/orc8r/cloud/go/services/analytics/calculations"
-
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/assert"
+
+	cwf_calculations "magma/cwf/cloud/go/services/cwf/analytics/calculations"
+	"magma/orc8r/cloud/go/services/analytics/calculations"
 )
 
 func TestGetXAPCalculations(t *testing.T) {

--- a/cwf/cloud/go/services/cwf/analytics/calculations/ap_throughput.go
+++ b/cwf/cloud/go/services/cwf/analytics/calculations/ap_throughput.go
@@ -17,13 +17,13 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/golang/glog"
+	v1 "github.com/prometheus/client_golang/api/prometheus/v1"
+
 	"magma/orc8r/cloud/go/services/analytics/calculations"
 	"magma/orc8r/cloud/go/services/analytics/protos"
 	"magma/orc8r/cloud/go/services/analytics/query_api"
 	"magma/orc8r/lib/go/metrics"
-
-	"github.com/golang/glog"
-	v1 "github.com/prometheus/client_golang/api/prometheus/v1"
 )
 
 // APNThroughputCalculation APN throughput calc params

--- a/cwf/cloud/go/services/cwf/analytics/calculations/authentications.go
+++ b/cwf/cloud/go/services/cwf/analytics/calculations/authentications.go
@@ -3,12 +3,12 @@ package calculations
 import (
 	"fmt"
 
+	"github.com/golang/glog"
+
 	"magma/orc8r/cloud/go/services/analytics/calculations"
 	"magma/orc8r/cloud/go/services/analytics/protos"
 	"magma/orc8r/cloud/go/services/analytics/query_api"
 	"magma/orc8r/lib/go/metrics"
-
-	"github.com/golang/glog"
 )
 
 // AuthenticationsCalculation holds the parameters needed to run an authentication

--- a/cwf/cloud/go/services/cwf/analytics/calculations/cwf_calculations_test.go
+++ b/cwf/cloud/go/services/cwf/analytics/calculations/cwf_calculations_test.go
@@ -18,15 +18,15 @@ import (
 	"testing"
 	"time"
 
-	"magma/orc8r/cloud/go/services/analytics/calculations"
-	"magma/orc8r/cloud/go/services/analytics/protos"
-	"magma/orc8r/cloud/go/services/analytics/query_api"
-	"magma/orc8r/cloud/go/services/analytics/query_api/mocks"
-
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+
+	"magma/orc8r/cloud/go/services/analytics/calculations"
+	"magma/orc8r/cloud/go/services/analytics/protos"
+	"magma/orc8r/cloud/go/services/analytics/query_api"
+	"magma/orc8r/cloud/go/services/analytics/query_api/mocks"
 )
 
 // mocked prometheus clients that are used for multiple calculation types

--- a/cwf/cloud/go/services/cwf/analytics/calculations/user_consumption.go
+++ b/cwf/cloud/go/services/cwf/analytics/calculations/user_consumption.go
@@ -16,12 +16,12 @@ package calculations
 import (
 	"fmt"
 
+	"github.com/golang/glog"
+
 	"magma/orc8r/cloud/go/services/analytics/calculations"
 	"magma/orc8r/cloud/go/services/analytics/protos"
 	"magma/orc8r/cloud/go/services/analytics/query_api"
 	"magma/orc8r/lib/go/metrics"
-
-	"github.com/golang/glog"
 )
 
 // UserConsumptionCalculation input params, direction can be user consumption volume

--- a/cwf/cloud/go/services/cwf/analytics/calculations/user_throughput.go
+++ b/cwf/cloud/go/services/cwf/analytics/calculations/user_throughput.go
@@ -17,13 +17,13 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/golang/glog"
+	v1 "github.com/prometheus/client_golang/api/prometheus/v1"
+
 	"magma/orc8r/cloud/go/services/analytics/calculations"
 	"magma/orc8r/cloud/go/services/analytics/protos"
 	"magma/orc8r/cloud/go/services/analytics/query_api"
 	"magma/orc8r/lib/go/metrics"
-
-	"github.com/golang/glog"
-	v1 "github.com/prometheus/client_golang/api/prometheus/v1"
 )
 
 // UserThroughputCalculation params for computing average user throughput

--- a/cwf/cloud/go/services/cwf/analytics/calculations/xap.go
+++ b/cwf/cloud/go/services/cwf/analytics/calculations/xap.go
@@ -16,12 +16,12 @@ package calculations
 import (
 	"fmt"
 
+	"github.com/golang/glog"
+
 	"magma/orc8r/cloud/go/services/analytics/calculations"
 	"magma/orc8r/cloud/go/services/analytics/protos"
 	"magma/orc8r/cloud/go/services/analytics/query_api"
 	"magma/orc8r/lib/go/metrics"
-
-	"github.com/golang/glog"
 )
 
 // XAPCalculation holds the parameters needed to run a XAP query and the registered

--- a/cwf/cloud/go/services/cwf/cwf/main.go
+++ b/cwf/cloud/go/services/cwf/cwf/main.go
@@ -14,6 +14,8 @@
 package main
 
 import (
+	"github.com/golang/glog"
+
 	"magma/cwf/cloud/go/cwf"
 	cwf_service "magma/cwf/cloud/go/services/cwf"
 	cwf_analytics "magma/cwf/cloud/go/services/cwf/analytics"
@@ -28,8 +30,6 @@ import (
 	"magma/orc8r/cloud/go/services/analytics/protos"
 	builder_protos "magma/orc8r/cloud/go/services/configurator/mconfig/protos"
 	"magma/orc8r/lib/go/service/config"
-
-	"github.com/golang/glog"
 )
 
 func main() {

--- a/cwf/cloud/go/services/cwf/obsidian/handlers/handlers.go
+++ b/cwf/cloud/go/services/cwf/obsidian/handlers/handlers.go
@@ -19,6 +19,9 @@ import (
 	"fmt"
 	"net/http"
 
+	"github.com/labstack/echo"
+	"github.com/pkg/errors"
+
 	"magma/cwf/cloud/go/cwf"
 	"magma/cwf/cloud/go/serdes"
 	cwfModels "magma/cwf/cloud/go/services/cwf/obsidian/models"
@@ -35,9 +38,6 @@ import (
 	"magma/orc8r/cloud/go/services/state"
 	"magma/orc8r/cloud/go/storage"
 	merrors "magma/orc8r/lib/go/errors"
-
-	"github.com/labstack/echo"
-	"github.com/pkg/errors"
 )
 
 const (

--- a/cwf/cloud/go/services/cwf/obsidian/handlers/handlers_test.go
+++ b/cwf/cloud/go/services/cwf/obsidian/handlers/handlers_test.go
@@ -18,6 +18,12 @@ import (
 	"testing"
 	"time"
 
+	"github.com/go-openapi/strfmt"
+	"github.com/go-openapi/swag"
+	"github.com/labstack/echo"
+	"github.com/stretchr/testify/assert"
+	"golang.org/x/net/context"
+
 	"magma/cwf/cloud/go/cwf"
 	"magma/cwf/cloud/go/serdes"
 	"magma/cwf/cloud/go/services/cwf/obsidian/handlers"
@@ -39,12 +45,6 @@ import (
 	stateTestInit "magma/orc8r/cloud/go/services/state/test_init"
 	"magma/orc8r/cloud/go/services/state/test_utils"
 	"magma/orc8r/lib/go/protos"
-
-	"github.com/go-openapi/strfmt"
-	"github.com/go-openapi/swag"
-	"github.com/labstack/echo"
-	"github.com/stretchr/testify/assert"
-	"golang.org/x/net/context"
 )
 
 func TestCwfNetworks(t *testing.T) {

--- a/cwf/cloud/go/services/cwf/obsidian/models/conversion.go
+++ b/cwf/cloud/go/services/cwf/obsidian/models/conversion.go
@@ -17,6 +17,9 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/go-openapi/strfmt"
+	"github.com/go-openapi/swag"
+
 	"magma/cwf/cloud/go/cwf"
 	"magma/feg/cloud/go/feg"
 	fegModels "magma/feg/cloud/go/services/feg/obsidian/models"
@@ -29,9 +32,6 @@ import (
 	orc8rModels "magma/orc8r/cloud/go/services/orchestrator/obsidian/models"
 	"magma/orc8r/cloud/go/storage"
 	merrors "magma/orc8r/lib/go/errors"
-
-	"github.com/go-openapi/strfmt"
-	"github.com/go-openapi/swag"
 )
 
 func (m *CwfNetwork) GetEmptyNetwork() handlers.NetworkModel {

--- a/cwf/cloud/go/services/cwf/servicers/builder_servicer.go
+++ b/cwf/cloud/go/services/cwf/servicers/builder_servicer.go
@@ -18,6 +18,10 @@ import (
 	"log"
 	"strings"
 
+	"github.com/go-openapi/swag"
+	"github.com/golang/protobuf/proto"
+	"github.com/pkg/errors"
+
 	"magma/cwf/cloud/go/cwf"
 	cwf_mconfig "magma/cwf/cloud/go/protos/mconfig"
 	"magma/cwf/cloud/go/serdes"
@@ -30,10 +34,6 @@ import (
 	merrors "magma/orc8r/lib/go/errors"
 	"magma/orc8r/lib/go/protos"
 	orc8r_mconfig "magma/orc8r/lib/go/protos/mconfig"
-
-	"github.com/go-openapi/swag"
-	"github.com/golang/protobuf/proto"
-	"github.com/pkg/errors"
 )
 
 const (

--- a/cwf/cloud/go/services/cwf/servicers/builder_servicer_test.go
+++ b/cwf/cloud/go/services/cwf/servicers/builder_servicer_test.go
@@ -16,6 +16,10 @@ package servicers_test
 import (
 	"testing"
 
+	"github.com/go-openapi/swag"
+	"github.com/golang/protobuf/proto"
+	"github.com/stretchr/testify/assert"
+
 	"magma/cwf/cloud/go/cwf"
 	cwf_mconfig "magma/cwf/cloud/go/protos/mconfig"
 	"magma/cwf/cloud/go/serdes"
@@ -31,10 +35,6 @@ import (
 	"magma/orc8r/cloud/go/storage"
 	"magma/orc8r/lib/go/protos"
 	orc8r_mconfig "magma/orc8r/lib/go/protos/mconfig"
-
-	"github.com/go-openapi/swag"
-	"github.com/golang/protobuf/proto"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestBuilder_Build(t *testing.T) {

--- a/fbinternal/cloud/go/services/download/client_test.go
+++ b/fbinternal/cloud/go/services/download/client_test.go
@@ -10,11 +10,11 @@ import (
 	"testing"
 	"time"
 
-	"magma/fbinternal/cloud/go/services/download/servicers"
-
 	"github.com/golang/glog"
 	"github.com/stretchr/testify/assert"
 	"golang.org/x/net/http2"
+
+	"magma/fbinternal/cloud/go/services/download/servicers"
 )
 
 func TestDownloadServiceClientMethods(t *testing.T) {

--- a/fbinternal/cloud/go/services/download/servicers/server_lib.go
+++ b/fbinternal/cloud/go/services/download/servicers/server_lib.go
@@ -8,14 +8,14 @@ import (
 	"strconv"
 	"strings"
 
-	"magma/fbinternal/cloud/go/services/download"
-	"magma/orc8r/lib/go/registry"
-
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/golang/glog"
 	"golang.org/x/net/http2"
+
+	"magma/fbinternal/cloud/go/services/download"
+	"magma/orc8r/lib/go/registry"
 )
 
 const (

--- a/fbinternal/cloud/go/services/fbinternal/fbinternal/main.go
+++ b/fbinternal/cloud/go/services/fbinternal/fbinternal/main.go
@@ -16,6 +16,9 @@ package main
 import (
 	"os"
 
+	"github.com/golang/glog"
+	"google.golang.org/grpc"
+
 	"magma/fbinternal/cloud/go/fbinternal"
 	fbinternal_service "magma/fbinternal/cloud/go/services/fbinternal"
 	"magma/fbinternal/cloud/go/services/fbinternal/servicers"
@@ -24,9 +27,6 @@ import (
 	"magma/orc8r/cloud/go/service"
 	"magma/orc8r/cloud/go/services/metricsd/protos"
 	"magma/orc8r/lib/go/definitions"
-
-	"github.com/golang/glog"
-	"google.golang.org/grpc"
 )
 
 const (

--- a/fbinternal/cloud/go/services/fbinternal/servicers/exporter_servicer.go
+++ b/fbinternal/cloud/go/services/fbinternal/servicers/exporter_servicer.go
@@ -27,12 +27,12 @@ import (
 	"sync"
 	"time"
 
+	"github.com/golang/glog"
+
 	"magma/fbinternal/cloud/go/metrics/ods"
 	"magma/orc8r/cloud/go/services/metricsd/exporters"
 	"magma/orc8r/cloud/go/services/metricsd/protos"
 	"magma/orc8r/lib/go/metrics"
-
-	"github.com/golang/glog"
 )
 
 const (

--- a/fbinternal/cloud/go/services/fbinternal/servicers/exporter_servicer_test.go
+++ b/fbinternal/cloud/go/services/fbinternal/servicers/exporter_servicer_test.go
@@ -21,6 +21,10 @@ import (
 	"testing"
 	"time"
 
+	prometheus_models "github.com/prometheus/client_model/go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+
 	"magma/fbinternal/cloud/go/metrics/ods"
 	"magma/fbinternal/cloud/go/services/fbinternal"
 	"magma/fbinternal/cloud/go/services/fbinternal/servicers"
@@ -29,10 +33,6 @@ import (
 	"magma/orc8r/cloud/go/services/metricsd/exporters"
 	"magma/orc8r/cloud/go/services/metricsd/test_common"
 	"magma/orc8r/lib/go/metrics"
-
-	prometheus_models "github.com/prometheus/client_model/go"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/mock"
 )
 
 func TestODSSubmit(t *testing.T) {

--- a/fbinternal/cloud/go/services/testcontroller/e2e_client_api.go
+++ b/fbinternal/cloud/go/services/testcontroller/e2e_client_api.go
@@ -16,15 +16,15 @@ package testcontroller
 import (
 	"context"
 
+	"github.com/golang/glog"
+	"github.com/pkg/errors"
+
 	"magma/fbinternal/cloud/go/services/testcontroller/protos"
 	"magma/fbinternal/cloud/go/services/testcontroller/statemachines"
 	"magma/fbinternal/cloud/go/services/testcontroller/storage"
 	"magma/orc8r/cloud/go/serde"
 	merrors "magma/orc8r/lib/go/errors"
 	"magma/orc8r/lib/go/registry"
-
-	"github.com/golang/glog"
-	"github.com/pkg/errors"
 )
 
 // UnmarshalledTestCase encapsulates a TestCase and the unmarshaled

--- a/fbinternal/cloud/go/services/testcontroller/node_client_api.go
+++ b/fbinternal/cloud/go/services/testcontroller/node_client_api.go
@@ -16,13 +16,13 @@ package testcontroller
 import (
 	"context"
 
+	"github.com/golang/glog"
+	"github.com/golang/protobuf/ptypes/wrappers"
+
 	"magma/fbinternal/cloud/go/services/testcontroller/protos"
 	"magma/fbinternal/cloud/go/services/testcontroller/storage"
 	merrors "magma/orc8r/lib/go/errors"
 	"magma/orc8r/lib/go/registry"
-
-	"github.com/golang/glog"
-	"github.com/golang/protobuf/ptypes/wrappers"
 )
 
 func getNodeClient() (protos.NodeLeasorClient, error) {

--- a/fbinternal/cloud/go/services/testcontroller/obsidian/handlers/node_handlers.go
+++ b/fbinternal/cloud/go/services/testcontroller/obsidian/handlers/node_handlers.go
@@ -18,11 +18,6 @@ import (
 	"net/http"
 	"sort"
 
-	"magma/fbinternal/cloud/go/services/testcontroller"
-	"magma/fbinternal/cloud/go/services/testcontroller/obsidian/models"
-	"magma/fbinternal/cloud/go/services/testcontroller/storage"
-	"magma/orc8r/cloud/go/obsidian"
-
 	"github.com/go-openapi/strfmt"
 	"github.com/go-openapi/swag"
 	"github.com/golang/glog"
@@ -30,6 +25,11 @@ import (
 	"github.com/labstack/echo"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+
+	"magma/fbinternal/cloud/go/services/testcontroller"
+	"magma/fbinternal/cloud/go/services/testcontroller/obsidian/models"
+	"magma/fbinternal/cloud/go/services/testcontroller/storage"
+	"magma/orc8r/cloud/go/obsidian"
 )
 
 const (

--- a/fbinternal/cloud/go/services/testcontroller/obsidian/handlers/node_handlers_test.go
+++ b/fbinternal/cloud/go/services/testcontroller/obsidian/handlers/node_handlers_test.go
@@ -18,6 +18,13 @@ import (
 	"testing"
 	"time"
 
+	"github.com/go-openapi/strfmt"
+	"github.com/go-openapi/swag"
+	"github.com/golang/protobuf/ptypes"
+	"github.com/golang/protobuf/ptypes/timestamp"
+	"github.com/labstack/echo"
+	"github.com/stretchr/testify/assert"
+
 	"magma/fbinternal/cloud/go/services/testcontroller"
 	"magma/fbinternal/cloud/go/services/testcontroller/obsidian/handlers"
 	"magma/fbinternal/cloud/go/services/testcontroller/obsidian/models"
@@ -26,13 +33,6 @@ import (
 	"magma/orc8r/cloud/go/clock"
 	"magma/orc8r/cloud/go/obsidian"
 	"magma/orc8r/cloud/go/obsidian/tests"
-
-	"github.com/go-openapi/strfmt"
-	"github.com/go-openapi/swag"
-	"github.com/golang/protobuf/ptypes"
-	"github.com/golang/protobuf/ptypes/timestamp"
-	"github.com/labstack/echo"
-	"github.com/stretchr/testify/assert"
 )
 
 func Test_ListCINodes(t *testing.T) {

--- a/fbinternal/cloud/go/services/testcontroller/obsidian/handlers/testcontroller_handlers.go
+++ b/fbinternal/cloud/go/services/testcontroller/obsidian/handlers/testcontroller_handlers.go
@@ -18,17 +18,17 @@ import (
 	"sort"
 	"strconv"
 
-	"magma/fbinternal/cloud/go/serdes"
-	"magma/fbinternal/cloud/go/services/testcontroller"
-	"magma/fbinternal/cloud/go/services/testcontroller/obsidian/models"
-	"magma/orc8r/cloud/go/obsidian"
-
 	"github.com/go-openapi/strfmt"
 	"github.com/go-openapi/swag"
 	"github.com/golang/glog"
 	"github.com/golang/protobuf/ptypes"
 	"github.com/golang/protobuf/ptypes/timestamp"
 	"github.com/labstack/echo"
+
+	"magma/fbinternal/cloud/go/serdes"
+	"magma/fbinternal/cloud/go/services/testcontroller"
+	"magma/fbinternal/cloud/go/services/testcontroller/obsidian/models"
+	"magma/orc8r/cloud/go/obsidian"
 )
 
 const (

--- a/fbinternal/cloud/go/services/testcontroller/obsidian/handlers/testcontroller_handlers_test.go
+++ b/fbinternal/cloud/go/services/testcontroller/obsidian/handlers/testcontroller_handlers_test.go
@@ -17,6 +17,10 @@ import (
 	context2 "context"
 	"testing"
 
+	"github.com/go-openapi/swag"
+	"github.com/labstack/echo"
+	"github.com/stretchr/testify/assert"
+
 	"magma/fbinternal/cloud/go/serdes"
 	"magma/fbinternal/cloud/go/services/testcontroller"
 	"magma/fbinternal/cloud/go/services/testcontroller/obsidian/handlers"
@@ -27,10 +31,6 @@ import (
 	"magma/orc8r/cloud/go/obsidian"
 	"magma/orc8r/cloud/go/obsidian/tests"
 	"magma/orc8r/cloud/go/serde"
-
-	"github.com/go-openapi/swag"
-	"github.com/labstack/echo"
-	"github.com/stretchr/testify/assert"
 )
 
 func Test_ListTestCases(t *testing.T) {

--- a/fbinternal/cloud/go/services/testcontroller/servicers/e2e.go
+++ b/fbinternal/cloud/go/services/testcontroller/servicers/e2e.go
@@ -16,12 +16,12 @@ package servicers
 import (
 	"context"
 
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
 	tcprotos "magma/fbinternal/cloud/go/services/testcontroller/protos"
 	"magma/fbinternal/cloud/go/services/testcontroller/storage"
 	"magma/orc8r/lib/go/protos"
-
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 )
 
 type e2eServicer struct {

--- a/fbinternal/cloud/go/services/testcontroller/servicers/nodes.go
+++ b/fbinternal/cloud/go/services/testcontroller/servicers/nodes.go
@@ -16,13 +16,13 @@ package servicers
 import (
 	"context"
 
-	tcprotos "magma/fbinternal/cloud/go/services/testcontroller/protos"
-	"magma/fbinternal/cloud/go/services/testcontroller/storage"
-	"magma/orc8r/lib/go/protos"
-
 	"github.com/golang/protobuf/ptypes/wrappers"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+
+	tcprotos "magma/fbinternal/cloud/go/services/testcontroller/protos"
+	"magma/fbinternal/cloud/go/services/testcontroller/storage"
+	"magma/orc8r/lib/go/protos"
 )
 
 type nodeLeasorServicer struct {

--- a/fbinternal/cloud/go/services/testcontroller/statemachines/enodebd.go
+++ b/fbinternal/cloud/go/services/testcontroller/statemachines/enodebd.go
@@ -25,6 +25,12 @@ import (
 	"strings"
 	"time"
 
+	"github.com/golang/glog"
+	"github.com/golang/protobuf/proto"
+	structpb "github.com/golang/protobuf/ptypes/struct"
+	"github.com/pkg/errors"
+	"github.com/thoas/go-funk"
+
 	"magma/fbinternal/cloud/go/services/testcontroller/obsidian/models"
 	"magma/fbinternal/cloud/go/services/testcontroller/storage"
 	"magma/fbinternal/cloud/go/services/testcontroller/utils"
@@ -39,12 +45,6 @@ import (
 	"magma/orc8r/cloud/go/services/state"
 	"magma/orc8r/cloud/go/services/state/wrappers"
 	"magma/orc8r/lib/go/protos"
-
-	"github.com/golang/glog"
-	"github.com/golang/protobuf/proto"
-	structpb "github.com/golang/protobuf/ptypes/struct"
-	"github.com/pkg/errors"
-	"github.com/thoas/go-funk"
 )
 
 const (

--- a/fbinternal/cloud/go/services/testcontroller/statemachines/enodebd_test.go
+++ b/fbinternal/cloud/go/services/testcontroller/statemachines/enodebd_test.go
@@ -28,6 +28,11 @@ import (
 	"testing"
 	"time"
 
+	"github.com/go-openapi/swag"
+	structpb "github.com/golang/protobuf/ptypes/struct"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+
 	"magma/fbinternal/cloud/go/services/testcontroller/obsidian/models"
 	"magma/fbinternal/cloud/go/services/testcontroller/statemachines"
 	storage2 "magma/fbinternal/cloud/go/services/testcontroller/storage"
@@ -49,11 +54,6 @@ import (
 	"magma/orc8r/cloud/go/services/state/test_utils"
 	"magma/orc8r/cloud/go/storage"
 	"magma/orc8r/lib/go/protos"
-
-	"github.com/go-openapi/swag"
-	structpb "github.com/golang/protobuf/ptypes/struct"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/mock"
 )
 
 // don't test intermediate failure conditions (e.g. unexpected config types,

--- a/fbinternal/cloud/go/services/testcontroller/storage/sql.go
+++ b/fbinternal/cloud/go/services/testcontroller/storage/sql.go
@@ -19,13 +19,13 @@ import (
 	"fmt"
 	"time"
 
-	"magma/orc8r/cloud/go/clock"
-	"magma/orc8r/cloud/go/sqorc"
-
 	"github.com/Masterminds/squirrel"
 	"github.com/golang/protobuf/ptypes"
 	"github.com/pkg/errors"
 	"github.com/thoas/go-funk"
+
+	"magma/orc8r/cloud/go/clock"
+	"magma/orc8r/cloud/go/sqorc"
 )
 
 const (

--- a/fbinternal/cloud/go/services/testcontroller/storage/sql_integ_test.go
+++ b/fbinternal/cloud/go/services/testcontroller/storage/sql_integ_test.go
@@ -17,14 +17,14 @@ import (
 	"testing"
 	"time"
 
-	"magma/orc8r/cloud/go/clock"
-	"magma/orc8r/cloud/go/sqorc"
-
 	"github.com/golang/protobuf/ptypes"
 	"github.com/golang/protobuf/ptypes/timestamp"
 	_ "github.com/lib/pq"
 	"github.com/stretchr/testify/assert"
 	"github.com/thoas/go-funk"
+
+	"magma/orc8r/cloud/go/clock"
+	"magma/orc8r/cloud/go/sqorc"
 )
 
 func TestNewSQLTestcontrollerStorage_Integration(t *testing.T) {

--- a/fbinternal/cloud/go/services/testcontroller/storage/sql_nodes.go
+++ b/fbinternal/cloud/go/services/testcontroller/storage/sql_nodes.go
@@ -20,14 +20,14 @@ import (
 	"os"
 	"time"
 
-	"magma/orc8r/cloud/go/clock"
-	"magma/orc8r/cloud/go/sqorc"
-	"magma/orc8r/cloud/go/storage"
-
 	"github.com/Masterminds/squirrel"
 	"github.com/golang/protobuf/ptypes"
 	"github.com/pkg/errors"
 	"github.com/thoas/go-funk"
+
+	"magma/orc8r/cloud/go/clock"
+	"magma/orc8r/cloud/go/sqorc"
+	"magma/orc8r/cloud/go/storage"
 )
 
 const (

--- a/fbinternal/cloud/go/services/testcontroller/storage/sql_nodes_integ_test.go
+++ b/fbinternal/cloud/go/services/testcontroller/storage/sql_nodes_integ_test.go
@@ -18,11 +18,11 @@ import (
 	"testing"
 	"time"
 
-	"magma/orc8r/cloud/go/clock"
-	"magma/orc8r/cloud/go/sqorc"
-
 	_ "github.com/lib/pq"
 	"github.com/stretchr/testify/assert"
+
+	"magma/orc8r/cloud/go/clock"
+	"magma/orc8r/cloud/go/sqorc"
 )
 
 func TestNewSQLNodeLeasorStorage_Integration(t *testing.T) {

--- a/fbinternal/cloud/go/services/testcontroller/storage/sql_nodes_test.go
+++ b/fbinternal/cloud/go/services/testcontroller/storage/sql_nodes_test.go
@@ -19,13 +19,13 @@ import (
 	"testing"
 	"time"
 
-	"magma/fbinternal/cloud/go/services/testcontroller/storage"
-	"magma/orc8r/cloud/go/clock"
-	"magma/orc8r/cloud/go/sqorc"
-
 	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
+
+	"magma/fbinternal/cloud/go/services/testcontroller/storage"
+	"magma/orc8r/cloud/go/clock"
+	"magma/orc8r/cloud/go/sqorc"
 )
 
 var expectedNodeCols = []string{

--- a/fbinternal/cloud/go/services/testcontroller/storage/sql_test.go
+++ b/fbinternal/cloud/go/services/testcontroller/storage/sql_test.go
@@ -21,14 +21,14 @@ import (
 	"testing"
 	"time"
 
-	"magma/fbinternal/cloud/go/services/testcontroller/storage"
-	"magma/orc8r/cloud/go/clock"
-	"magma/orc8r/cloud/go/sqorc"
-
 	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/golang/protobuf/ptypes"
 	"github.com/golang/protobuf/ptypes/timestamp"
 	"github.com/stretchr/testify/assert"
+
+	"magma/fbinternal/cloud/go/services/testcontroller/storage"
+	"magma/orc8r/cloud/go/clock"
+	"magma/orc8r/cloud/go/sqorc"
 )
 
 var allExpectedCols = []string{

--- a/fbinternal/cloud/go/services/testcontroller/store/store_test.go
+++ b/fbinternal/cloud/go/services/testcontroller/store/store_test.go
@@ -17,12 +17,12 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+	"gopkg.in/DATA-DOG/go-sqlmock.v1"
+
 	"magma/fbinternal/cloud/go/services/testcontroller/obsidian/models"
 	"magma/orc8r/cloud/go/blobstore"
 	"magma/orc8r/cloud/go/sqorc"
-
-	"github.com/stretchr/testify/assert"
-	"gopkg.in/DATA-DOG/go-sqlmock.v1"
 )
 
 type mockClock struct {

--- a/fbinternal/cloud/go/services/testcontroller/store/testcontroller_store.go
+++ b/fbinternal/cloud/go/services/testcontroller/store/testcontroller_store.go
@@ -18,13 +18,13 @@ import (
 	"testing"
 	"time"
 
+	"github.com/golang/glog"
+	"github.com/pkg/errors"
+
 	"magma/fbinternal/cloud/go/services/testcontroller/obsidian/models"
 	"magma/fbinternal/cloud/go/services/testcontroller/utils"
 	"magma/orc8r/cloud/go/blobstore"
 	"magma/orc8r/cloud/go/storage"
-
-	"github.com/golang/glog"
-	"github.com/pkg/errors"
 )
 
 const (

--- a/fbinternal/cloud/go/services/testcontroller/test_init/test_controller_test_service_init.go
+++ b/fbinternal/cloud/go/services/testcontroller/test_init/test_controller_test_service_init.go
@@ -17,6 +17,9 @@ import (
 	"fmt"
 	"testing"
 
+	_ "github.com/lib/pq"
+	"github.com/stretchr/testify/assert"
+
 	"magma/fbinternal/cloud/go/services/testcontroller"
 	"magma/fbinternal/cloud/go/services/testcontroller/protos"
 	"magma/fbinternal/cloud/go/services/testcontroller/servicers"
@@ -25,9 +28,6 @@ import (
 	"magma/orc8r/cloud/go/sqorc"
 	"magma/orc8r/cloud/go/test_utils"
 	"magma/orc8r/lib/go/definitions"
-
-	_ "github.com/lib/pq"
-	"github.com/stretchr/testify/assert"
 )
 
 func StartTestService(t *testing.T) {

--- a/fbinternal/cloud/go/services/testcontroller/testcontroller/main.go
+++ b/fbinternal/cloud/go/services/testcontroller/testcontroller/main.go
@@ -17,6 +17,8 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/golang/glog"
+
 	"magma/fbinternal/cloud/go/fbinternal"
 	"magma/fbinternal/cloud/go/serdes"
 	"magma/fbinternal/cloud/go/services/testcontroller"
@@ -31,8 +33,6 @@ import (
 	"magma/orc8r/cloud/go/service"
 	"magma/orc8r/cloud/go/sqorc"
 	storage2 "magma/orc8r/cloud/go/storage"
-
-	"github.com/golang/glog"
 )
 
 func main() {

--- a/fbinternal/cloud/go/services/vpnservice/client_api.go
+++ b/fbinternal/cloud/go/services/vpnservice/client_api.go
@@ -1,13 +1,13 @@
 package vpnservice
 
 import (
+	"github.com/golang/glog"
+	"golang.org/x/net/context"
+
 	fbprotos "magma/fbinternal/cloud/go/protos"
 	"magma/orc8r/lib/go/errors"
 	"magma/orc8r/lib/go/protos"
 	"magma/orc8r/lib/go/registry"
-
-	"github.com/golang/glog"
-	"golang.org/x/net/context"
 )
 
 const ServiceName = "VPNSERVICE"

--- a/fbinternal/cloud/go/services/vpnservice/servicers/vpn_servicer.go
+++ b/fbinternal/cloud/go/services/vpnservice/servicers/vpn_servicer.go
@@ -5,16 +5,16 @@ import (
 	"io/ioutil"
 	"time"
 
+	"github.com/golang/protobuf/ptypes/duration"
+	"golang.org/x/net/context"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
 	fbprotos "magma/fbinternal/cloud/go/protos"
 	"magma/orc8r/cloud/go/identity"
 	"magma/orc8r/cloud/go/services/certifier"
 	certprotos "magma/orc8r/cloud/go/services/certifier/protos"
 	"magma/orc8r/lib/go/protos"
-
-	"github.com/golang/protobuf/ptypes/duration"
-	"golang.org/x/net/context"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 )
 
 type VPNServicer struct {

--- a/fbinternal/cloud/go/services/vpnservice/servicers/vpn_servicer_test.go
+++ b/fbinternal/cloud/go/services/vpnservice/servicers/vpn_servicer_test.go
@@ -11,6 +11,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+	"golang.org/x/net/context"
+
 	fbprotos "magma/fbinternal/cloud/go/protos"
 	"magma/fbinternal/cloud/go/services/vpnservice/servicers"
 	"magma/orc8r/cloud/go/services/certifier"
@@ -18,9 +21,6 @@ import (
 	certifier_test_init "magma/orc8r/cloud/go/services/certifier/test_init"
 	"magma/orc8r/lib/go/protos"
 	"magma/orc8r/lib/go/security/key"
-
-	"github.com/stretchr/testify/assert"
-	"golang.org/x/net/context"
 )
 
 const (

--- a/orc8r/cloud/Makefile
+++ b/orc8r/cloud/Makefile
@@ -63,6 +63,7 @@ define add_module
 	COVER_LIST += $(MODULE)_cover
 	DOWNLOAD_LIST += $(MODULE)_download
 	FMT_LIST += $(MODULE)_fmt
+	GOIMPORTS_LIST += $(MODULE)_goimports
 	GEN_LIST += $(MODULE)_gen
 	GEN_PROTO_LIST += $(MODULE)_gen_proto
 	LINT_LIST += $(MODULE)_lint
@@ -110,9 +111,13 @@ $(FMT_LIST): %_fmt:
 
 fullgen: clean_gen gen swagger tidy
 
-gen: tools gen_protos $(GEN_LIST)
+gen: tools order_imports gen_protos $(GEN_LIST)
 $(GEN_LIST): %_gen:
 	make -C $*/cloud/go gen
+
+order_imports: $(GOIMPORTS_LIST)
+$(GOIMPORTS_LIST): %_goimports:
+	make -C $*/cloud/go order_imports
 
 gen_protos: $(GEN_PROTO_LIST)
 $(GEN_PROTO_LIST): %_gen_proto:

--- a/orc8r/cloud/docker/controller/Dockerfile
+++ b/orc8r/cloud/docker/controller/Dockerfile
@@ -27,6 +27,9 @@ RUN curl https://facebookconnectivity.jfrog.io/artifactory/generic/go1.13.4.linu
     tar xf go1.13.4.linux-amd64.tar.gz && \
     cp -r go/bin/* /usr/local/bin/
 
+# Install goimports
+# RUN go get golang.org/x/tools/cmd/goimports
+
 # Protobuf compiler
 # Apt has 2.x but we need 3.x
 # See: https://grpc.io/docs/protoc-installation/

--- a/orc8r/cloud/go/Makefile
+++ b/orc8r/cloud/go/Makefile
@@ -7,7 +7,9 @@ TOOL_DEPS:= \
 	github.com/ory/go-acc \
 	github.com/vektra/mockery/cmd/mockery \
 	github.com/wadey/gocovmerge \
-	gotest.tools/gotestsum
+	gotest.tools/gotestsum \
+	golang.org/x/tools/cmd/goimports
+
 include $(MAGMA_ROOT)/orc8r/cloud/go/module.mk
 
 LIB_ROOT=$(MAGMA_ROOT)/orc8r/lib/go

--- a/orc8r/cloud/go/module.mk
+++ b/orc8r/cloud/go/module.mk
@@ -11,7 +11,7 @@
 
 SHELL:=/bin/bash
 
-.PHONY: build clean clean_gen download fmt fullgen gen gen_prots lint test tidy vet
+.PHONY: build clean clean_gen download fmt fullgen gen gen_prots lint test tidy vet order_imports
 
 build::
 	go install ./...
@@ -81,6 +81,10 @@ gen_protos::
 #	- After: orc8r/cloud/swagger/specs/partial/policydb.swagger.v1.yml
 copy_swagger_files:
 	for f in $$(find . -name swagger.v1.yml) ; do cp $$f $${SWAGGER_V1_PARTIAL_SPECS_DIR}/$$(echo $$f | sed -r 's/.*\/services\/([^\/]*)\/obsidian\/models\/(swagger\.v1\.yml)/\1.\2/g') ; done
+
+# reorder imports with goimports
+order_imports:
+	for f in $$(find . -type f -name '*.go' ! -name '*.pb.go' ! -name '*_swaggergen.go') ; do $(MAGMA_ROOT)/orc8r/cloud/order_go_imports.sh $${f} ; done
 
 lint:
 	golangci-lint run

--- a/orc8r/cloud/go/services/configurator/mconfig/mocks/Builder.go
+++ b/orc8r/cloud/go/services/configurator/mconfig/mocks/Builder.go
@@ -6,7 +6,6 @@ import (
 	mock "github.com/stretchr/testify/mock"
 
 	mconfig "magma/orc8r/cloud/go/services/configurator/mconfig"
-
 	storage "magma/orc8r/cloud/go/services/configurator/storage"
 )
 

--- a/orc8r/cloud/go/services/dispatcher/broker/mocks/GatewayRPCBroker.go
+++ b/orc8r/cloud/go/services/dispatcher/broker/mocks/GatewayRPCBroker.go
@@ -20,7 +20,6 @@ import (
 	mock "github.com/stretchr/testify/mock"
 
 	broker "magma/orc8r/cloud/go/services/dispatcher/broker"
-
 	protos "magma/orc8r/lib/go/protos"
 )
 

--- a/orc8r/cloud/order_go_imports.sh
+++ b/orc8r/cloud/order_go_imports.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+# remove all blank lines in go 'imports' statements,
+# then sort with goimports
+
+if [ $# != 1 ] ; then
+  echo "usage: $0 <filename>"
+  exit 1
+fi
+
+sed -i '
+  /^import/,/)/ {
+    /^$/ d
+  }
+' "$1"
+
+goimports -w -local magma/ "$1"

--- a/wifi/cloud/go/services/wifi/obsidian/handlers/handlers.go
+++ b/wifi/cloud/go/services/wifi/obsidian/handlers/handlers.go
@@ -18,6 +18,9 @@ import (
 	"reflect"
 	"sort"
 
+	"github.com/labstack/echo"
+	"github.com/pkg/errors"
+
 	"magma/orc8r/cloud/go/models"
 	"magma/orc8r/cloud/go/obsidian"
 	"magma/orc8r/cloud/go/orc8r"
@@ -30,9 +33,6 @@ import (
 	"magma/wifi/cloud/go/serdes"
 	wifimodels "magma/wifi/cloud/go/services/wifi/obsidian/models"
 	"magma/wifi/cloud/go/wifi"
-
-	"github.com/labstack/echo"
-	"github.com/pkg/errors"
 )
 
 const (

--- a/wifi/cloud/go/services/wifi/obsidian/handlers/handlers_test.go
+++ b/wifi/cloud/go/services/wifi/obsidian/handlers/handlers_test.go
@@ -18,6 +18,10 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/go-openapi/swag"
+	"github.com/labstack/echo"
+	"github.com/stretchr/testify/assert"
+
 	models3 "magma/orc8r/cloud/go/models"
 	"magma/orc8r/cloud/go/obsidian"
 	"magma/orc8r/cloud/go/obsidian/tests"
@@ -33,10 +37,6 @@ import (
 	"magma/wifi/cloud/go/services/wifi/obsidian/handlers"
 	models2 "magma/wifi/cloud/go/services/wifi/obsidian/models"
 	"magma/wifi/cloud/go/wifi"
-
-	"github.com/go-openapi/swag"
-	"github.com/labstack/echo"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestListNetworks(t *testing.T) {

--- a/wifi/cloud/go/services/wifi/obsidian/models/conversion.go
+++ b/wifi/cloud/go/services/wifi/obsidian/models/conversion.go
@@ -14,6 +14,8 @@
 package models
 
 import (
+	"github.com/go-openapi/swag"
+
 	"magma/orc8r/cloud/go/models"
 	"magma/orc8r/cloud/go/orc8r"
 	"magma/orc8r/cloud/go/services/configurator"
@@ -22,8 +24,6 @@ import (
 	"magma/orc8r/cloud/go/storage"
 	merrors "magma/orc8r/lib/go/errors"
 	"magma/wifi/cloud/go/wifi"
-
-	"github.com/go-openapi/swag"
 )
 
 func (m *WifiNetwork) GetEmptyNetwork() handlers.NetworkModel {

--- a/wifi/cloud/go/services/wifi/obsidian/models/defaults.go
+++ b/wifi/cloud/go/services/wifi/obsidian/models/defaults.go
@@ -14,10 +14,10 @@
 package models
 
 import (
+	"github.com/go-openapi/swag"
+
 	models2 "magma/orc8r/cloud/go/models"
 	"magma/orc8r/cloud/go/services/orchestrator/obsidian/models"
-
-	"github.com/go-openapi/swag"
 )
 
 func NewDefaultWifiNetwork() *WifiNetwork {

--- a/wifi/cloud/go/services/wifi/servicers/builder_servicer.go
+++ b/wifi/cloud/go/services/wifi/servicers/builder_servicer.go
@@ -16,6 +16,8 @@ package servicers
 import (
 	"context"
 
+	"github.com/golang/protobuf/proto"
+
 	"magma/orc8r/cloud/go/services/configurator"
 	"magma/orc8r/cloud/go/services/configurator/mconfig"
 	builder_protos "magma/orc8r/cloud/go/services/configurator/mconfig/protos"
@@ -24,8 +26,6 @@ import (
 	"magma/wifi/cloud/go/serdes"
 	"magma/wifi/cloud/go/services/wifi/obsidian/models"
 	"magma/wifi/cloud/go/wifi"
-
-	"github.com/golang/protobuf/proto"
 )
 
 type builderServicer struct{}

--- a/wifi/cloud/go/services/wifi/servicers/builder_servicer_test.go
+++ b/wifi/cloud/go/services/wifi/servicers/builder_servicer_test.go
@@ -16,6 +16,9 @@ package servicers_test
 import (
 	"testing"
 
+	"github.com/golang/protobuf/proto"
+	"github.com/stretchr/testify/assert"
+
 	"magma/orc8r/cloud/go/orc8r"
 	"magma/orc8r/cloud/go/services/configurator"
 	"magma/orc8r/cloud/go/services/configurator/mconfig"
@@ -26,9 +29,6 @@ import (
 	"magma/wifi/cloud/go/services/wifi/obsidian/models"
 	wifi_test_init "magma/wifi/cloud/go/services/wifi/test_init"
 	"magma/wifi/cloud/go/wifi"
-
-	"github.com/golang/protobuf/proto"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestBuilder_Build_BaseCases(t *testing.T) {

--- a/wifi/cloud/go/services/wifi/wifi/main.go
+++ b/wifi/cloud/go/services/wifi/wifi/main.go
@@ -14,6 +14,8 @@
 package main
 
 import (
+	"github.com/golang/glog"
+
 	"magma/orc8r/cloud/go/obsidian"
 	"magma/orc8r/cloud/go/obsidian/swagger"
 	swagger_protos "magma/orc8r/cloud/go/obsidian/swagger/protos"
@@ -23,8 +25,6 @@ import (
 	"magma/wifi/cloud/go/services/wifi/obsidian/handlers"
 	"magma/wifi/cloud/go/services/wifi/servicers"
 	"magma/wifi/cloud/go/wifi"
-
-	"github.com/golang/glog"
 )
 
 func main() {


### PR DESCRIPTION
Signed-off-by: Evgeniy Makeev <evgeniym@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

Add check for correct Go imports order to build.py -g

There is currently no enforcement of corect goimports order outside of a single import block (set of imports surrounded by empty lines). This PR adds such check to build -g to be run during insync check.

## Test Plan
build.py -g
CI tests

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
