### PR TITLE
fix(mme): AMF module warning cleanup#8985

### DIFF
--- a/.github/workflows/docker-push.yml
+++ b/.github/workflows/docker-push.yml
@@ -1,0 +1,64 @@
+---
+name: "Dockerfile Push"
+on:  # yamllint disable-line rule:truthy
+  push:
+    branches:
+      -master
+    paths:
+      - .devcontainer/Dockerfile
+      - .github/workflows/docker-push.yml
+      - lte/gateway/docker/mme/Dockerfile.ubuntu20.04
+  schedule:
+    # Run four times a day (hours zero, six, twelve and eighteen)
+    - cron:  '0 0,6,12,18 * * *'
+
+jobs:
+  build_devcontainer_dockerfile:
+    env:
+      DOCKERFILE: .devcontainer/Dockerfile
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check Out Repo
+        uses: actions/checkout@v2
+      - name: Docker meta
+        id: meta
+        uses: crazy-max/ghaction-docker-meta@v2
+        with:
+          # list of Docker images to use as base name for tags
+          images: |
+            ghcr.io/magma/devcontainer
+          # generate Docker tags based on the following events/attributes
+          tags: |
+            type=sha
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Cache Docker layers
+        uses: actions/cache@v2
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ hashFiles( '**/Dockerfile*' ) }}
+      - name: "Login to GHCR"
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password:  ${{ secrets.GITHUB_TOKEN }}
+      - name: Docker Build
+        id: docker_build
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: ${{ env.DOCKERFILE }}
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache-new
+      - name: Move cache - Fixup for buildx cache issue
+        # Temp fix
+        # https://github.com/docker/build-push-action/issues/252
+        # https://github.com/moby/buildkit/issues/1896
+        run: |
+          rm -rf /tmp/.buildx-cache
+          mv /tmp/.buildx-cache-new /tmp/.buildx-cache

--- a/lte/gateway/c/core/oai/tasks/amf/amf_app_defs.h
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_app_defs.h
@@ -42,7 +42,7 @@ void amf_app_handle_pdu_session_response(
 int amf_app_handle_notification_received(
     itti_n11_received_notification_t* notification);
 int amf_app_handle_pdu_session_accept(
-    itti_n11_create_pdu_session_response_t* pdu_session_resp, uint32_t ue_id);
+    itti_n11_create_pdu_session_response_t* pdu_session_resp, uint64_t ue_id);
 int amf_smf_handle_ip_address_response(
     itti_amf_ip_allocation_response_t* response_p);
 void amf_app_handle_initial_context_setup_rsp(

--- a/lte/gateway/c/core/oai/tasks/amf/amf_app_handler.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_app_handler.cpp
@@ -721,7 +721,7 @@ int amf_app_handle_pdu_session_accept(
   ue_context = amf_ue_context_exists_amf_ue_ngap_id(ue_id);
   if (!ue_context) {
     OAILOG_ERROR(
-        LOG_AMF_APP, "ue context not found for the ue_id : " AMF_UE_NGAP_ID_FMT,
+        LOG_AMF_APP, "ue context not found for the ue_id:" AMF_UE_NGAP_ID_FMT,
         ue_id);
     return M5G_AS_FAILURE;
   }
@@ -729,7 +729,9 @@ int amf_app_handle_pdu_session_accept(
   smf_ctx = amf_smf_context_exists_pdu_session_id(
       ue_context, pdu_session_resp->pdu_session_id);
   if (!smf_ctx) {
-    OAILOG_ERROR(LOG_AMF_APP, "Smf context is not exist UE ID: %lu", ue_id);
+    OAILOG_ERROR(
+        LOG_AMF_APP, "Smf context is not exist UE ID:" AMF_UE_NGAP_ID_FMT,
+        ue_id);
     return M5G_AS_FAILURE;
   }
   // updating session state

--- a/lte/gateway/c/core/oai/tasks/amf/amf_app_handler.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_app_handler.cpp
@@ -596,7 +596,7 @@ void amf_app_handle_pdu_session_response(
   smf_context_t* smf_ctx;
   amf_smf_t amf_smf_msg;
   // TODO: hardcoded for now, addressed in the upcoming multi-UE PR
-  uint32_t ue_id = 0;
+  uint64_t ue_id = 0;
   int rc         = RETURNerror;
 
   imsi64_t imsi64;
@@ -703,7 +703,7 @@ void amf_app_handle_pdu_session_response(
  **                                                                        **
  ***************************************************************************/
 int amf_app_handle_pdu_session_accept(
-    itti_n11_create_pdu_session_response_t* pdu_session_resp, uint32_t ue_id) {
+    itti_n11_create_pdu_session_response_t* pdu_session_resp, uint64_t ue_id) {
   nas5g_error_code_t rc = M5G_AS_SUCCESS;
 
   DLNASTransportMsg* encode_msg;
@@ -720,14 +720,16 @@ int amf_app_handle_pdu_session_accept(
   // Handle smf_context
   ue_context = amf_ue_context_exists_amf_ue_ngap_id(ue_id);
   if (!ue_context) {
-    OAILOG_ERROR(LOG_AMF_APP, "UE context not found for UE ID: %u", ue_id);
+    OAILOG_ERROR(
+        LOG_AMF_APP, "ue context not found for the ue_id : " AMF_UE_NGAP_ID_FMT,
+        ue_id);
     return M5G_AS_FAILURE;
   }
 
   smf_ctx = amf_smf_context_exists_pdu_session_id(
       ue_context, pdu_session_resp->pdu_session_id);
   if (!smf_ctx) {
-    OAILOG_ERROR(LOG_AMF_APP, "Smf context is not exist UE ID: %u", ue_id);
+    OAILOG_ERROR(LOG_AMF_APP, "Smf context is not exist UE ID: %lu", ue_id);
     return M5G_AS_FAILURE;
   }
   // updating session state

--- a/lte/gateway/c/core/oai/tasks/nas5g/include/AmfMessage.h
+++ b/lte/gateway/c/core/oai/tasks/nas5g/include/AmfMessage.h
@@ -32,7 +32,6 @@
 #include "M5GServiceAccept.h"
 #include "M5GServiceReject.h"
 
-using namespace std;
 namespace magma5g {
 // Amf NAS Msg Header
 struct AmfMsgHeader_s {

--- a/lte/gateway/c/core/oai/tasks/nas5g/include/M5GAuthenticationFailure.h
+++ b/lte/gateway/c/core/oai/tasks/nas5g/include/M5GAuthenticationFailure.h
@@ -18,7 +18,6 @@ limitations under the License.
 #include "M5GMMCause.h"
 #include "M5GAuthenticationFailureIE.h"
 
-using namespace std;
 namespace magma5g {
 class AuthenticationFailureMsg {
  public:

--- a/lte/gateway/c/core/oai/tasks/nas5g/include/M5GAuthenticationReject.h
+++ b/lte/gateway/c/core/oai/tasks/nas5g/include/M5GAuthenticationReject.h
@@ -16,7 +16,6 @@
 #include "M5GMessageType.h"
 #include "M5GSpareHalfOctet.h"
 
-using namespace std;
 namespace magma5g {
 class AuthenticationRejectMsg {
  public:

--- a/lte/gateway/c/core/oai/tasks/nas5g/include/M5GAuthenticationRequest.h
+++ b/lte/gateway/c/core/oai/tasks/nas5g/include/M5GAuthenticationRequest.h
@@ -22,7 +22,6 @@
 #include "M5GAuthenticationParameterAUTN.h"
 #include "M5GEAPMessage.h"
 
-using namespace std;
 
 namespace magma5g {
 // AuthenticationRequest Message Class

--- a/lte/gateway/c/core/oai/tasks/nas5g/include/M5GAuthenticationRequest.h
+++ b/lte/gateway/c/core/oai/tasks/nas5g/include/M5GAuthenticationRequest.h
@@ -22,7 +22,6 @@
 #include "M5GAuthenticationParameterAUTN.h"
 #include "M5GEAPMessage.h"
 
-
 namespace magma5g {
 // AuthenticationRequest Message Class
 class AuthenticationRequestMsg {

--- a/lte/gateway/c/core/oai/tasks/nas5g/include/M5GAuthenticationResponse.h
+++ b/lte/gateway/c/core/oai/tasks/nas5g/include/M5GAuthenticationResponse.h
@@ -18,7 +18,6 @@
 #include "M5GMessageType.h"
 #include "M5GAuthenticationResponseParameter.h"
 
-
 namespace magma5g {
 // AuthenticationResponse Message Class
 class AuthenticationResponseMsg {

--- a/lte/gateway/c/core/oai/tasks/nas5g/include/M5GAuthenticationResponse.h
+++ b/lte/gateway/c/core/oai/tasks/nas5g/include/M5GAuthenticationResponse.h
@@ -18,7 +18,6 @@
 #include "M5GMessageType.h"
 #include "M5GAuthenticationResponseParameter.h"
 
-using namespace std;
 
 namespace magma5g {
 // AuthenticationResponse Message Class

--- a/lte/gateway/c/core/oai/tasks/nas5g/include/M5GAuthenticationResult.h
+++ b/lte/gateway/c/core/oai/tasks/nas5g/include/M5GAuthenticationResult.h
@@ -18,7 +18,6 @@
 #include "M5GNASKeySetIdentifier.h"
 #include "M5GEAPMessage.h"
 
-using namespace std;
 namespace magma5g {
 class AuthenticationResultMsg {
  public:

--- a/lte/gateway/c/core/oai/tasks/nas5g/include/M5GDLNASTransport.h
+++ b/lte/gateway/c/core/oai/tasks/nas5g/include/M5GDLNASTransport.h
@@ -20,7 +20,6 @@
 #include "M5GPDUSessionIdentity.h"
 #include "M5GMMCause.h"
 
-using namespace std;
 namespace magma5g {
 // DLNASTransport Message Class
 class DLNASTransportMsg {

--- a/lte/gateway/c/core/oai/tasks/nas5g/include/M5GDeRegistrationAcceptUEInit.h
+++ b/lte/gateway/c/core/oai/tasks/nas5g/include/M5GDeRegistrationAcceptUEInit.h
@@ -16,7 +16,6 @@
 #include "M5GMessageType.h"
 #include "M5GSpareHalfOctet.h"
 
-using namespace std;
 namespace magma5g {
 class DeRegistrationAcceptUEInitMsg {
  public:

--- a/lte/gateway/c/core/oai/tasks/nas5g/include/M5GDeRegistrationRequestUEInit.h
+++ b/lte/gateway/c/core/oai/tasks/nas5g/include/M5GDeRegistrationRequestUEInit.h
@@ -19,7 +19,6 @@
 #include "M5GSMobileIdentity.h"
 #include "M5GSpareHalfOctet.h"
 
-using namespace std;
 namespace magma5g {
 class DeRegistrationRequestUEInitMsg {
  public:

--- a/lte/gateway/c/core/oai/tasks/nas5g/include/M5GIdentityRequest.h
+++ b/lte/gateway/c/core/oai/tasks/nas5g/include/M5GIdentityRequest.h
@@ -17,7 +17,6 @@
 #include "M5GMessageType.h"
 #include "M5GSIdentityType.h"
 
-using namespace std;
 namespace magma5g {
 // 5GSIdentityRequest Message Class
 class IdentityRequestMsg {

--- a/lte/gateway/c/core/oai/tasks/nas5g/include/M5GIdentityResponse.h
+++ b/lte/gateway/c/core/oai/tasks/nas5g/include/M5GIdentityResponse.h
@@ -17,7 +17,6 @@
 #include "M5GMessageType.h"
 #include "M5GSMobileIdentity.h"
 
-using namespace std;
 namespace magma5g {
 // 5GSIdentityResponse Message Class
 class IdentityResponseMsg {

--- a/lte/gateway/c/core/oai/tasks/nas5g/include/M5GPDUSessionEstablishmentReject.h
+++ b/lte/gateway/c/core/oai/tasks/nas5g/include/M5GPDUSessionEstablishmentReject.h
@@ -17,7 +17,6 @@
 #include "M5GMessageType.h"
 #include "M5GSMCause.h"
 
-using namespace std;
 namespace magma5g {
 // PDUSessionEstablishmentReject Message Class
 class PDUSessionEstablishmentRejectMsg {

--- a/lte/gateway/c/core/oai/tasks/nas5g/include/M5GPDUSessionEstablishmentRequest.h
+++ b/lte/gateway/c/core/oai/tasks/nas5g/include/M5GPDUSessionEstablishmentRequest.h
@@ -21,7 +21,6 @@
 #include "M5GSSCMode.h"
 #include "M5GProtocolConfigurationOptions.h"
 
-using namespace std;
 namespace magma5g {
 // PDUSessionEstablishmentRequest Message Class
 class PDUSessionEstablishmentRequestMsg {

--- a/lte/gateway/c/core/oai/tasks/nas5g/include/M5GPDUSessionModificationReject.h
+++ b/lte/gateway/c/core/oai/tasks/nas5g/include/M5GPDUSessionModificationReject.h
@@ -17,7 +17,6 @@
 #include "M5GMessageType.h"
 #include "M5GSMCause.h"
 
-using namespace std;
 namespace magma5g {
 // PDUSessionModificationReject Message Class
 class PDUSessionModificationRejectMsg {

--- a/lte/gateway/c/core/oai/tasks/nas5g/include/M5GPDUSessionModificationRequest.h
+++ b/lte/gateway/c/core/oai/tasks/nas5g/include/M5GPDUSessionModificationRequest.h
@@ -16,7 +16,6 @@
 #include "M5GPTI.h"
 #include "M5GMessageType.h"
 
-using namespace std;
 namespace magma5g {
 // PDUSessionModificationRequest Message Class
 class PDUSessionModificationRequestMsg {

--- a/lte/gateway/c/core/oai/tasks/nas5g/include/M5GPDUSessionReleaseCommand.h
+++ b/lte/gateway/c/core/oai/tasks/nas5g/include/M5GPDUSessionReleaseCommand.h
@@ -17,7 +17,6 @@
 #include "M5GMessageType.h"
 #include "M5GSMCause.h"
 
-using namespace std;
 namespace magma5g {
 // PDUSessionReleaseCommand Message Class
 class PDUSessionReleaseCommandMsg {

--- a/lte/gateway/c/core/oai/tasks/nas5g/include/M5GPDUSessionReleaseReject.h
+++ b/lte/gateway/c/core/oai/tasks/nas5g/include/M5GPDUSessionReleaseReject.h
@@ -17,7 +17,6 @@
 #include "M5GMessageType.h"
 #include "M5GSMCause.h"
 
-using namespace std;
 namespace magma5g {
 // PDUSessionReleaseReject Message Class
 class PDUSessionReleaseRejectMsg {

--- a/lte/gateway/c/core/oai/tasks/nas5g/include/M5GPDUSessionReleaseRequest.h
+++ b/lte/gateway/c/core/oai/tasks/nas5g/include/M5GPDUSessionReleaseRequest.h
@@ -16,7 +16,6 @@
 #include "M5GPTI.h"
 #include "M5GMessageType.h"
 
-using namespace std;
 namespace magma5g {
 // PDUSessionReleaseRequest Message Class
 class PDUSessionReleaseRequestMsg {

--- a/lte/gateway/c/core/oai/tasks/nas5g/include/M5GRegistrationAccept.h
+++ b/lte/gateway/c/core/oai/tasks/nas5g/include/M5GRegistrationAccept.h
@@ -22,7 +22,6 @@
 #include "M5GGprsTimer3.h"
 #include "M5GTAIList.h"
 
-using namespace std;
 namespace magma5g {
 class RegistrationAcceptMsg {
  public:

--- a/lte/gateway/c/core/oai/tasks/nas5g/include/M5GRegistrationComplete.h
+++ b/lte/gateway/c/core/oai/tasks/nas5g/include/M5GRegistrationComplete.h
@@ -17,7 +17,6 @@ limitations under the License.
 #include "M5GSpareHalfOctet.h"
 #include "bstrlib.h"
 
-using namespace std;
 namespace magma5g {
 class RegistrationCompleteMsg {
  public:

--- a/lte/gateway/c/core/oai/tasks/nas5g/include/M5GRegistrationReject.h
+++ b/lte/gateway/c/core/oai/tasks/nas5g/include/M5GRegistrationReject.h
@@ -17,7 +17,6 @@
 #include "M5GSpareHalfOctet.h"
 #include "M5GMMCause.h"
 
-using namespace std;
 namespace magma5g {
 class RegistrationRejectMsg {
  public:

--- a/lte/gateway/c/core/oai/tasks/nas5g/include/M5GRegistrationRequest.h
+++ b/lte/gateway/c/core/oai/tasks/nas5g/include/M5GRegistrationRequest.h
@@ -20,7 +20,6 @@
 #include "M5GSMobileIdentity.h"
 #include "M5GUESecurityCapability.h"
 
-using namespace std;
 namespace magma5g {
 // RegistrationRequest Message Class
 class RegistrationRequestMsg {

--- a/lte/gateway/c/core/oai/tasks/nas5g/include/M5GSecurityModeCommand.h
+++ b/lte/gateway/c/core/oai/tasks/nas5g/include/M5GSecurityModeCommand.h
@@ -20,7 +20,6 @@
 #include "M5GUESecurityCapability.h"
 #include "M5GIMEISVRequest.h"
 
-using namespace std;
 namespace magma5g {
 // SecurityModeCommand Message Class
 class SecurityModeCommandMsg {

--- a/lte/gateway/c/core/oai/tasks/nas5g/include/M5GSecurityModeComplete.h
+++ b/lte/gateway/c/core/oai/tasks/nas5g/include/M5GSecurityModeComplete.h
@@ -16,7 +16,6 @@
 #include "M5GSecurityHeaderType.h"
 #include "M5GMessageType.h"
 
-using namespace std;
 namespace magma5g {
 // SecurityModeComplete Message Class
 class SecurityModeCompleteMsg {

--- a/lte/gateway/c/core/oai/tasks/nas5g/include/M5GSecurityModeReject.h
+++ b/lte/gateway/c/core/oai/tasks/nas5g/include/M5GSecurityModeReject.h
@@ -17,7 +17,6 @@
 #include "M5GSpareHalfOctet.h"
 #include "M5GMMCause.h"
 
-using namespace std;
 namespace magma5g {
 class SecurityModeRejectMsg {
  public:

--- a/lte/gateway/c/core/oai/tasks/nas5g/include/M5GServiceAccept.h
+++ b/lte/gateway/c/core/oai/tasks/nas5g/include/M5GServiceAccept.h
@@ -18,7 +18,6 @@
 #include "M5GPDUSessionStatus.h"
 #include "M5GPDUSessionReActivationResult.h"
 
-using namespace std;
 namespace magma5g {
 // ServiceAccept Message Class
 class ServiceAcceptMsg {

--- a/lte/gateway/c/core/oai/tasks/nas5g/include/M5GServiceReject.h
+++ b/lte/gateway/c/core/oai/tasks/nas5g/include/M5GServiceReject.h
@@ -19,7 +19,6 @@
 #include "M5GPDUSessionStatus.h"
 #include "M5GGprsTimer2.h"
 
-using namespace std;
 namespace magma5g {
 // ServiceAccept Message Class
 class ServiceRejectMsg {

--- a/lte/gateway/c/core/oai/tasks/nas5g/include/M5GServiceRequest.h
+++ b/lte/gateway/c/core/oai/tasks/nas5g/include/M5GServiceRequest.h
@@ -21,7 +21,6 @@
 #include "M5GUplinkDataStatus.h"
 #include "M5GPDUSessionStatus.h"
 
-using namespace std;
 namespace magma5g {
 // ServiceRequest Message Class
 class ServiceRequestMsg {

--- a/lte/gateway/c/core/oai/tasks/nas5g/include/M5GULNASTransport.h
+++ b/lte/gateway/c/core/oai/tasks/nas5g/include/M5GULNASTransport.h
@@ -19,7 +19,6 @@
 #include "M5GPayloadContainer.h"
 #include "M5GRequestType.h"
 
-using namespace std;
 namespace magma5g {
 // ULNASTransport Message Class
 class ULNASTransportMsg {

--- a/lte/gateway/c/core/oai/tasks/nas5g/include/SmfMessage.h
+++ b/lte/gateway/c/core/oai/tasks/nas5g/include/SmfMessage.h
@@ -20,7 +20,6 @@
 #include "M5GPDUSessionModificationRequest.h"
 #include "M5GPDUSessionModificationReject.h"
 
-using namespace std;
 namespace magma5g {
 // Smf NAS Header Class
 class SmfMsgHeader {

--- a/lte/gateway/c/core/oai/tasks/nas5g/include/ies/M5GABBA.h
+++ b/lte/gateway/c/core/oai/tasks/nas5g/include/ies/M5GABBA.h
@@ -12,7 +12,6 @@
 #include <sstream>
 #include <cstdint>
 
-
 namespace magma5g {
 // ABBA IE Class
 class ABBAMsg {

--- a/lte/gateway/c/core/oai/tasks/nas5g/include/ies/M5GABBA.h
+++ b/lte/gateway/c/core/oai/tasks/nas5g/include/ies/M5GABBA.h
@@ -12,7 +12,6 @@
 #include <sstream>
 #include <cstdint>
 
-using namespace std;
 
 namespace magma5g {
 // ABBA IE Class

--- a/lte/gateway/c/core/oai/tasks/nas5g/include/ies/M5GAuthenticationFailureIE.h
+++ b/lte/gateway/c/core/oai/tasks/nas5g/include/ies/M5GAuthenticationFailureIE.h
@@ -14,7 +14,6 @@ limitations under the License.
 #include <cstdint>
 #include "bstrlib.h"
 
-using namespace std;
 namespace magma5g {
 // M5GMMCause IE Class
 class M5GAuthenticationFailureIE {

--- a/lte/gateway/c/core/oai/tasks/nas5g/include/ies/M5GAuthenticationParameterAUTN.h
+++ b/lte/gateway/c/core/oai/tasks/nas5g/include/ies/M5GAuthenticationParameterAUTN.h
@@ -13,7 +13,6 @@
 #include <sstream>
 #include <cstdint>
 
-using namespace std;
 namespace magma5g {
 // AuthenticationParameterAUTN IE Class
 class AuthenticationParameterAUTNMsg {

--- a/lte/gateway/c/core/oai/tasks/nas5g/include/ies/M5GAuthenticationParameterRAND.h
+++ b/lte/gateway/c/core/oai/tasks/nas5g/include/ies/M5GAuthenticationParameterRAND.h
@@ -13,7 +13,6 @@
 #include <sstream>
 #include <cstdint>
 
-
 namespace magma5g {
 // AuthenticationParameterRANDM IE Class
 class AuthenticationParameterRANDMsg {

--- a/lte/gateway/c/core/oai/tasks/nas5g/include/ies/M5GAuthenticationParameterRAND.h
+++ b/lte/gateway/c/core/oai/tasks/nas5g/include/ies/M5GAuthenticationParameterRAND.h
@@ -13,7 +13,6 @@
 #include <sstream>
 #include <cstdint>
 
-using namespace std;
 
 namespace magma5g {
 // AuthenticationParameterRANDM IE Class

--- a/lte/gateway/c/core/oai/tasks/nas5g/include/ies/M5GAuthenticationResponseParameter.h
+++ b/lte/gateway/c/core/oai/tasks/nas5g/include/ies/M5GAuthenticationResponseParameter.h
@@ -13,7 +13,6 @@
 #include <sstream>
 #include <cstdint>
 #include "bstrlib.h"
-using namespace std;
 
 namespace magma5g {
 // AuthenticationResponseParameter IE Class

--- a/lte/gateway/c/core/oai/tasks/nas5g/include/ies/M5GEAPMessage.h
+++ b/lte/gateway/c/core/oai/tasks/nas5g/include/ies/M5GEAPMessage.h
@@ -13,7 +13,6 @@
 #include <sstream>
 #include <cstdint>
 
-using namespace std;
 namespace magma5g {
 class EAPMessageMsg {
  public:

--- a/lte/gateway/c/core/oai/tasks/nas5g/include/ies/M5GExtendedProtocolDiscriminator.h
+++ b/lte/gateway/c/core/oai/tasks/nas5g/include/ies/M5GExtendedProtocolDiscriminator.h
@@ -13,7 +13,6 @@ limitations under the License.
 #include <sstream>
 #include <cstdint>
 
-using namespace std;
 namespace magma5g {
 // ExtendedProtocolDiscriminator IE Class
 class ExtendedProtocolDiscriminatorMsg {

--- a/lte/gateway/c/core/oai/tasks/nas5g/include/ies/M5GGprsTimer2.h
+++ b/lte/gateway/c/core/oai/tasks/nas5g/include/ies/M5GGprsTimer2.h
@@ -11,7 +11,6 @@
 #pragma once
 #include <sstream>
 #include <cstdint>
-using namespace std;
 namespace magma5g {
 class GPRSTimer2Msg {
  public:

--- a/lte/gateway/c/core/oai/tasks/nas5g/include/ies/M5GGprsTimer3.h
+++ b/lte/gateway/c/core/oai/tasks/nas5g/include/ies/M5GGprsTimer3.h
@@ -11,7 +11,6 @@
 #pragma once
 #include <sstream>
 #include <cstdint>
-using namespace std;
 namespace magma5g {
 class GPRSTimer3Msg {
  public:

--- a/lte/gateway/c/core/oai/tasks/nas5g/include/ies/M5GIMEISVRequest.h
+++ b/lte/gateway/c/core/oai/tasks/nas5g/include/ies/M5GIMEISVRequest.h
@@ -13,7 +13,6 @@
 #include <sstream>
 #include <cstdint>
 
-using namespace std;
 namespace magma5g {
 class ImeisvRequestMsg {
  public:

--- a/lte/gateway/c/core/oai/tasks/nas5g/include/ies/M5GIntegrityProtMaxDataRate.h
+++ b/lte/gateway/c/core/oai/tasks/nas5g/include/ies/M5GIntegrityProtMaxDataRate.h
@@ -13,7 +13,6 @@
 #include <sstream>
 #include <cstdint>
 
-using namespace std;
 namespace magma5g {
 // IntegrityProtMaxDataRate IE Class
 class IntegrityProtMaxDataRateMsg {

--- a/lte/gateway/c/core/oai/tasks/nas5g/include/ies/M5GMMCause.h
+++ b/lte/gateway/c/core/oai/tasks/nas5g/include/ies/M5GMMCause.h
@@ -13,7 +13,6 @@ limitations under the License.
 #include <sstream>
 #include <cstdint>
 
-using namespace std;
 namespace magma5g {
 #define AMF_CAUSE_LENGTH 1
 // M5GMMCause IE Class

--- a/lte/gateway/c/core/oai/tasks/nas5g/include/ies/M5GMessageType.h
+++ b/lte/gateway/c/core/oai/tasks/nas5g/include/ies/M5GMessageType.h
@@ -13,7 +13,6 @@
 #include <sstream>
 #include <cstdint>
 
-using namespace std;
 namespace magma5g {
 // MessageType IE Class
 class MessageTypeMsg {

--- a/lte/gateway/c/core/oai/tasks/nas5g/include/ies/M5GNASKeySetIdentifier.h
+++ b/lte/gateway/c/core/oai/tasks/nas5g/include/ies/M5GNASKeySetIdentifier.h
@@ -13,7 +13,6 @@
 #include <sstream>
 #include <cstdint>
 
-using namespace std;
 namespace magma5g {
 class NASKeySetIdentifierMsg {
  public:

--- a/lte/gateway/c/core/oai/tasks/nas5g/include/ies/M5GNASSecurityAlgorithms.h
+++ b/lte/gateway/c/core/oai/tasks/nas5g/include/ies/M5GNASSecurityAlgorithms.h
@@ -13,7 +13,6 @@
 #include <sstream>
 #include <cstdint>
 
-using namespace std;
 namespace magma5g {
 class NASSecurityAlgorithmsMsg {
  public:

--- a/lte/gateway/c/core/oai/tasks/nas5g/include/ies/M5GNSSAI.h
+++ b/lte/gateway/c/core/oai/tasks/nas5g/include/ies/M5GNSSAI.h
@@ -11,7 +11,6 @@ limitations under the License.
 #pragma once
 #include <sstream>
 #include <cstdint>
-using namespace std;
 namespace magma5g {
 class NSSAIMsg {
  public:

--- a/lte/gateway/c/core/oai/tasks/nas5g/include/ies/M5GPDUAddress.h
+++ b/lte/gateway/c/core/oai/tasks/nas5g/include/ies/M5GPDUAddress.h
@@ -13,7 +13,6 @@
 #include <sstream>
 #include <cstdint>
 
-using namespace std;
 namespace magma5g {
 #define TYPE_VAL_IPV4 1
 #define IPV4_ADDRESS_LENGTH 4

--- a/lte/gateway/c/core/oai/tasks/nas5g/include/ies/M5GPDUSessionIdentity.h
+++ b/lte/gateway/c/core/oai/tasks/nas5g/include/ies/M5GPDUSessionIdentity.h
@@ -13,7 +13,6 @@
 #include <sstream>
 #include <cstdint>
 
-using namespace std;
 namespace magma5g {
 // PDUSessionIdentity IE Class
 class PDUSessionIdentityMsg {

--- a/lte/gateway/c/core/oai/tasks/nas5g/include/ies/M5GPDUSessionReActivationResult.h
+++ b/lte/gateway/c/core/oai/tasks/nas5g/include/ies/M5GPDUSessionReActivationResult.h
@@ -12,7 +12,6 @@
 #pragma once
 #include <sstream>
 #include <cstdint>
-using namespace std;
 namespace magma5g {
 class M5GPDUSessionReActivationResult {
  public:

--- a/lte/gateway/c/core/oai/tasks/nas5g/include/ies/M5GPDUSessionStatus.h
+++ b/lte/gateway/c/core/oai/tasks/nas5g/include/ies/M5GPDUSessionStatus.h
@@ -12,7 +12,6 @@
 #pragma once
 #include <sstream>
 #include <cstdint>
-using namespace std;
 namespace magma5g {
 class M5GPDUSessionStatus {
  public:

--- a/lte/gateway/c/core/oai/tasks/nas5g/include/ies/M5GPDUSessionType.h
+++ b/lte/gateway/c/core/oai/tasks/nas5g/include/ies/M5GPDUSessionType.h
@@ -13,7 +13,6 @@
 #include <sstream>
 #include <cstdint>
 
-using namespace std;
 namespace magma5g {
 // PDUSessionType Class
 class PDUSessionTypeMsg {

--- a/lte/gateway/c/core/oai/tasks/nas5g/include/ies/M5GPTI.h
+++ b/lte/gateway/c/core/oai/tasks/nas5g/include/ies/M5GPTI.h
@@ -13,7 +13,6 @@
 #include <sstream>
 #include <cstdint>
 
-using namespace std;
 namespace magma5g {
 // PTI IE Class
 class PTIMsg {

--- a/lte/gateway/c/core/oai/tasks/nas5g/include/ies/M5GPayloadContainerType.h
+++ b/lte/gateway/c/core/oai/tasks/nas5g/include/ies/M5GPayloadContainerType.h
@@ -13,7 +13,6 @@
 #include <sstream>
 #include <cstdint>
 
-using namespace std;
 namespace magma5g {
 class PayloadContainerTypeMsg {
  public:

--- a/lte/gateway/c/core/oai/tasks/nas5g/include/ies/M5GProtocolConfigurationOptions.h
+++ b/lte/gateway/c/core/oai/tasks/nas5g/include/ies/M5GProtocolConfigurationOptions.h
@@ -21,7 +21,6 @@ extern "C" {
 };
 #endif
 
-using namespace std;
 namespace magma5g {
 
 // Protocol Configuration Options IE Class

--- a/lte/gateway/c/core/oai/tasks/nas5g/include/ies/M5GQOSRules.h
+++ b/lte/gateway/c/core/oai/tasks/nas5g/include/ies/M5GQOSRules.h
@@ -14,7 +14,6 @@
 #include <sstream>
 #include <cstdint>
 
-using namespace std;
 namespace magma5g {
 // New QOSRule Class
 class NewQOSRulePktFilter {

--- a/lte/gateway/c/core/oai/tasks/nas5g/include/ies/M5GSDeRegistrationType.h
+++ b/lte/gateway/c/core/oai/tasks/nas5g/include/ies/M5GSDeRegistrationType.h
@@ -12,7 +12,6 @@ limitations under the License.
 #pragma once
 #include <sstream>
 
-using namespace std;
 namespace magma5g {
 class M5GSDeRegistrationTypeMsg {
  public:

--- a/lte/gateway/c/core/oai/tasks/nas5g/include/ies/M5GSIdentityType.h
+++ b/lte/gateway/c/core/oai/tasks/nas5g/include/ies/M5GSIdentityType.h
@@ -13,7 +13,6 @@
 #include <sstream>
 #include <cstdint>
 
-using namespace std;
 namespace magma5g {
 // M5GSIdentitytype IE Class
 class M5GSIdentityTypeMsg {

--- a/lte/gateway/c/core/oai/tasks/nas5g/include/ies/M5GSMCause.h
+++ b/lte/gateway/c/core/oai/tasks/nas5g/include/ies/M5GSMCause.h
@@ -13,7 +13,6 @@
 #include <sstream>
 #include <cstdint>
 
-using namespace std;
 namespace magma5g {
 // M5GSMCause IE Class
 class M5GSMCauseMsg {

--- a/lte/gateway/c/core/oai/tasks/nas5g/include/ies/M5GSMobileIdentity.h
+++ b/lte/gateway/c/core/oai/tasks/nas5g/include/ies/M5GSMobileIdentity.h
@@ -12,7 +12,6 @@ limitations under the License.
 #pragma once
 #include <sstream>
 #include <cstdint>
-using namespace std;
 
 namespace magma5g {
 // 5GS mobile identity information element for type of identity "5G-GUTI" SPEC :

--- a/lte/gateway/c/core/oai/tasks/nas5g/include/ies/M5GSRegistrationResult.h
+++ b/lte/gateway/c/core/oai/tasks/nas5g/include/ies/M5GSRegistrationResult.h
@@ -13,7 +13,6 @@ limitations under the License.
 #include <sstream>
 #include <cstdint>
 
-using namespace std;
 namespace magma5g {
 class M5GSRegistrationResultMsg {
  public:

--- a/lte/gateway/c/core/oai/tasks/nas5g/include/ies/M5GSRegistrationType.h
+++ b/lte/gateway/c/core/oai/tasks/nas5g/include/ies/M5GSRegistrationType.h
@@ -13,7 +13,6 @@
 #include <sstream>
 #include <cstdint>
 
-using namespace std;
 namespace magma5g {
 // M5GSRegistrationType IE Class
 class M5GSRegistrationTypeMsg {

--- a/lte/gateway/c/core/oai/tasks/nas5g/include/ies/M5GSSCMode.h
+++ b/lte/gateway/c/core/oai/tasks/nas5g/include/ies/M5GSSCMode.h
@@ -13,7 +13,6 @@
 #include <sstream>
 #include <cstdint>
 
-using namespace std;
 namespace magma5g {
 // SSCMode IE Class
 class SSCModeMsg {

--- a/lte/gateway/c/core/oai/tasks/nas5g/include/ies/M5GSecurityHeaderType.h
+++ b/lte/gateway/c/core/oai/tasks/nas5g/include/ies/M5GSecurityHeaderType.h
@@ -13,7 +13,6 @@
 #include <sstream>
 #include <cstdint>
 
-using namespace std;
 namespace magma5g {
 // SecurityHeaderType IE Class
 class SecurityHeaderTypeMsg {

--- a/lte/gateway/c/core/oai/tasks/nas5g/include/ies/M5GServiceType.h
+++ b/lte/gateway/c/core/oai/tasks/nas5g/include/ies/M5GServiceType.h
@@ -13,7 +13,6 @@
 #include <sstream>
 #include <cstdint>
 
-using namespace std;
 namespace magma5g {
 class ServiceTypeMsg {
  public:

--- a/lte/gateway/c/core/oai/tasks/nas5g/include/ies/M5GSessionAMBR.h
+++ b/lte/gateway/c/core/oai/tasks/nas5g/include/ies/M5GSessionAMBR.h
@@ -13,7 +13,6 @@
 #include <sstream>
 #include <cstdint>
 
-using namespace std;
 namespace magma5g {
 // SessionAMBR Class
 class SessionAMBRMsg {

--- a/lte/gateway/c/core/oai/tasks/nas5g/include/ies/M5GSpareHalfOctet.h
+++ b/lte/gateway/c/core/oai/tasks/nas5g/include/ies/M5GSpareHalfOctet.h
@@ -13,7 +13,6 @@
 #include <sstream>
 #include <cstdint>
 
-using namespace std;
 namespace magma5g {
 // Spare Half Octet IE Class
 class SpareHalfOctetMsg {

--- a/lte/gateway/c/core/oai/tasks/nas5g/include/ies/M5GTAIList.h
+++ b/lte/gateway/c/core/oai/tasks/nas5g/include/ies/M5GTAIList.h
@@ -11,7 +11,6 @@ limitations under the License.
 #pragma once
 #include <sstream>
 #include <cstdint>
-using namespace std;
 namespace magma5g {
 class TAIListMsg {
  public:

--- a/lte/gateway/c/core/oai/tasks/nas5g/include/ies/M5GUESecurityCapability.h
+++ b/lte/gateway/c/core/oai/tasks/nas5g/include/ies/M5GUESecurityCapability.h
@@ -13,7 +13,6 @@
 #include <sstream>
 #include <cstdint>
 
-using namespace std;
 namespace magma5g {
 class UESecurityCapabilityMsg {
  public:

--- a/lte/gateway/c/core/oai/tasks/nas5g/include/ies/M5GUplinkDataStatus.h
+++ b/lte/gateway/c/core/oai/tasks/nas5g/include/ies/M5GUplinkDataStatus.h
@@ -12,7 +12,6 @@
 #pragma once
 #include <sstream>
 #include <cstdint>
-using namespace std;
 namespace magma5g {
 class M5GUplinkDataStatus {
  public:

--- a/lte/gateway/c/core/oai/tasks/nas5g/src/AmfMessage.cpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/src/AmfMessage.cpp
@@ -15,7 +15,6 @@
 #include "M5gNasMessage.h"
 #include "M5GCommonDefs.h"
 
-using namespace std;
 namespace magma5g {
 AmfMsg::AmfMsg() {
   memset(&msg, 0, sizeof(MMsg_u));
@@ -41,11 +40,11 @@ int AmfMsg::M5gNasMessageDecodeMsg(AmfMsg* msg, uint8_t* buffer, uint32_t len) {
     MLOG(MERROR) << "Error : Buffer is Empty";
     return (RETURNerror);
   }
-  MLOG(MDEBUG) << "   epd = 0x" << hex
+  MLOG(MDEBUG) << "   epd = 0x" << std::hex
                << int(msg->header.extended_protocol_discriminator) << "\n"
-               << "   security hdr =  0x" << hex
+               << "   security hdr =  0x" << std::hex
                << int(msg->header.sec_header_type) << "\n"
-               << "   hdr type = 0x" << hex << int(msg->header.message_type)
+               << "   hdr type = 0x" << std::hex << int(msg->header.message_type)
                << "\n";
   decode_result = msg->AmfMsgDecodeMsg(msg, buffer, len);
   if (decode_result <= 0) {
@@ -70,12 +69,12 @@ int AmfMsg::M5gNasMessageEncodeMsg(AmfMsg* msg, uint8_t* buffer, uint32_t len) {
       return (RETURNerror);
     }
   } else {
-    MLOG(MERROR) << "Error : Buffer is empty " << endl;
+    MLOG(MERROR) << "Error : Buffer is empty " << std::endl;
     return (RETURNerror);
   }
   encode_result = msg->AmfMsgEncodeMsg(msg, buffer, len);
   if (encode_result <= 0) {
-    MLOG(MERROR) << "Error : Encoding AMF Message Failed" << endl;
+    MLOG(MERROR) << "Error : Encoding AMF Message Failed" << std::endl;
     return (RETURNerror);
   }
 
@@ -88,23 +87,23 @@ int AmfMsg::AmfMsgDecodeHeaderMsg(
     AmfMsgHeader_s* hdr, uint8_t* buffer, uint32_t len) {
   int size = 0;
 
-  MLOG(MDEBUG) << "AmfMsgDecodeHeaderMsg:" << endl;
+  MLOG(MDEBUG) << "AmfMsgDecodeHeaderMsg:" << std::endl;
   if (len > 0 || buffer != NULL) {
     DECODE_U8(buffer + size, hdr->extended_protocol_discriminator, size);
     DECODE_U8(buffer + size, hdr->sec_header_type, size);
     DECODE_U8(buffer + size, hdr->message_type, size);
-    MLOG(MDEBUG) << "epd = 0x" << hex
+    MLOG(MDEBUG) << "epd = 0x" << std::hex
                  << int(hdr->extended_protocol_discriminator)
-                 << "security hdr = 0x" << hex << int(hdr->sec_header_type)
-                 << " hdr type = 0x" << hex << int(hdr->message_type);
+                 << "security hdr = 0x" << std::hex << int(hdr->sec_header_type)
+                 << " hdr type = 0x" << std::hex << int(hdr->message_type);
   } else {
-    MLOG(MERROR) << "Error : Buffer is Empty" << endl;
+    MLOG(MERROR) << "Error : Buffer is Empty" << std::endl;
     return (RETURNerror);
   }
 
   if (hdr->extended_protocol_discriminator !=
       M5G_MOBILITY_MANAGEMENT_MESSAGES) {
-    MLOG(MERROR) << "Error : TLV not supported" << endl;
+    MLOG(MERROR) << "Error : TLV not supported" << std::endl;
     return (TLV_PROTOCOL_NOT_SUPPORTED);
   }
   return (size);
@@ -121,10 +120,10 @@ int AmfMsg::AmfMsgEncodeHeaderMsg(
     ENCODE_U8(buffer + size, hdr->extended_protocol_discriminator, size);
     ENCODE_U8(buffer + size, hdr->sec_header_type, size);
     ENCODE_U8(buffer + size, hdr->message_type, size);
-    MLOG(MDEBUG) << "epd = 0x" << hex
+    MLOG(MDEBUG) << "epd = 0x" << std::hex
                  << int(hdr->extended_protocol_discriminator)
-                 << " security hdr = 0x" << hex << int(hdr->sec_header_type)
-                 << " hdr type = 0x" << hex << int(hdr->message_type);
+                 << " security hdr = 0x" << std::hex << int(hdr->sec_header_type)
+                 << " hdr type = 0x" << std::hex << int(hdr->message_type);
   } else {
     MLOG(MERROR) << "Error : Buffer is Empty ";
     return (RETURNerror);
@@ -142,12 +141,12 @@ int AmfMsg::AmfMsgEncodeHeaderMsg(
 int AmfMsg::AmfMsgDecodeMsg(AmfMsg* msg, uint8_t* buffer, uint32_t len) {
   int decode_result = 0;
 
-  MLOG(MDEBUG) << "AmfMsgDecodeMsg:" << endl;
+  MLOG(MDEBUG) << "AmfMsgDecodeMsg:" << std::endl;
   if (len <= 0 || buffer == NULL) {
-    MLOG(MERROR) << "Error : Buffer is Empty" << endl;
+    MLOG(MERROR) << "Error : Buffer is Empty" << std::endl;
     return (RETURNerror);
   }
-  MLOG(MDEBUG) << "msg type = 0x" << hex << int(msg->header.message_type);
+  MLOG(MDEBUG) << "msg type = 0x" << std::hex << int(msg->header.message_type);
 
   switch ((unsigned char) msg->header.message_type) {
     case REG_REQUEST:
@@ -234,7 +233,7 @@ int AmfMsg::AmfMsgDecodeMsg(AmfMsg* msg, uint8_t* buffer, uint32_t len) {
 int AmfMsg::AmfMsgEncodeMsg(AmfMsg* msg, uint8_t* buffer, uint32_t len) {
   int encode_result = 0;
 
-  MLOG(MDEBUG) << " AmfMsgEncodeMsg : " << endl;
+  MLOG(MDEBUG) << " AmfMsgEncodeMsg : " << std::endl;
   if (len <= 0 || buffer == NULL) {
     MLOG(MERROR) << "Error : Buffer is Empty";
     return (RETURNerror);

--- a/lte/gateway/c/core/oai/tasks/nas5g/src/AmfMessage.cpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/src/AmfMessage.cpp
@@ -44,8 +44,8 @@ int AmfMsg::M5gNasMessageDecodeMsg(AmfMsg* msg, uint8_t* buffer, uint32_t len) {
                << int(msg->header.extended_protocol_discriminator) << "\n"
                << "   security hdr =  0x" << std::hex
                << int(msg->header.sec_header_type) << "\n"
-               << "   hdr type = 0x" << std::hex << int(msg->header.message_type)
-               << "\n";
+               << "   hdr type = 0x" << std::hex
+               << int(msg->header.message_type) << "\n";
   decode_result = msg->AmfMsgDecodeMsg(msg, buffer, len);
   if (decode_result <= 0) {
     MLOG(MERROR) << "decode result error ";
@@ -122,8 +122,9 @@ int AmfMsg::AmfMsgEncodeHeaderMsg(
     ENCODE_U8(buffer + size, hdr->message_type, size);
     MLOG(MDEBUG) << "epd = 0x" << std::hex
                  << int(hdr->extended_protocol_discriminator)
-                 << " security hdr = 0x" << std::hex << int(hdr->sec_header_type)
-                 << " hdr type = 0x" << std::hex << int(hdr->message_type);
+                 << " security hdr = 0x" << std::hex
+                 << int(hdr->sec_header_type) << " hdr type = 0x" << std::hex
+                 << int(hdr->message_type);
   } else {
     MLOG(MERROR) << "Error : Buffer is Empty ";
     return (RETURNerror);

--- a/lte/gateway/c/core/oai/tasks/nas5g/src/M5GAuthenticationRequest.cpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/src/M5GAuthenticationRequest.cpp
@@ -14,7 +14,6 @@
 #include "M5GAuthenticationRequest.h"
 #include "M5GCommonDefs.h"
 
-using namespace std;
 namespace magma5g {
 AuthenticationRequestMsg::AuthenticationRequestMsg(){};
 AuthenticationRequestMsg::~AuthenticationRequestMsg(){};

--- a/lte/gateway/c/core/oai/tasks/nas5g/src/M5GAuthenticationResponse.cpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/src/M5GAuthenticationResponse.cpp
@@ -14,7 +14,6 @@
 #include "M5GAuthenticationResponse.h"
 #include "M5GCommonDefs.h"
 
-using namespace std;
 namespace magma5g {
 AuthenticationResponseMsg::AuthenticationResponseMsg(){};
 AuthenticationResponseMsg::~AuthenticationResponseMsg(){};
@@ -29,7 +28,7 @@ int AuthenticationResponseMsg::DecodeAuthenticationResponseMsg(
       buffer, AUTHENTICATION_RESPONSE_MINIMUM_LENGTH, len);
 
   MLOG(MDEBUG) << "\n\n---Decoding Authentication Response Message---\n"
-               << endl;
+               << std::endl;
   if ((decoded_result = auth_response->extended_protocol_discriminator
                             .DecodeExtendedProtocolDiscriminatorMsg(
                                 &auth_response->extended_protocol_discriminator,

--- a/lte/gateway/c/core/oai/tasks/nas5g/src/M5GAuthenticationResult.cpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/src/M5GAuthenticationResult.cpp
@@ -27,7 +27,8 @@ int AuthenticationResultMsg::DecodeAuthenticationResultMsg(
   CHECK_PDU_POINTER_AND_LENGTH_DECODER(
       buffer, AUTHENTICATION_RESULT_MINIMUM_LENGTH, len);
 
-  MLOG(MDEBUG) << "\n\n---Decoding Authentication Result Message---\n" << std::endl;
+  MLOG(MDEBUG) << "\n\n---Decoding Authentication Result Message---\n"
+               << std::endl;
   if ((decoded_result = auth_result->extended_protocol_discriminator
                             .DecodeExtendedProtocolDiscriminatorMsg(
                                 &auth_result->extended_protocol_discriminator,

--- a/lte/gateway/c/core/oai/tasks/nas5g/src/M5GAuthenticationResult.cpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/src/M5GAuthenticationResult.cpp
@@ -14,7 +14,6 @@
 #include "M5GAuthenticationResult.h"
 #include "M5GCommonDefs.h"
 
-using namespace std;
 namespace magma5g {
 AuthenticationResultMsg::AuthenticationResultMsg(){};
 AuthenticationResultMsg::~AuthenticationResultMsg(){};
@@ -28,7 +27,7 @@ int AuthenticationResultMsg::DecodeAuthenticationResultMsg(
   CHECK_PDU_POINTER_AND_LENGTH_DECODER(
       buffer, AUTHENTICATION_RESULT_MINIMUM_LENGTH, len);
 
-  MLOG(MDEBUG) << "\n\n---Decoding Authentication Result Message---\n" << endl;
+  MLOG(MDEBUG) << "\n\n---Decoding Authentication Result Message---\n" << std::endl;
   if ((decoded_result = auth_result->extended_protocol_discriminator
                             .DecodeExtendedProtocolDiscriminatorMsg(
                                 &auth_result->extended_protocol_discriminator,

--- a/lte/gateway/c/core/oai/tasks/nas5g/src/M5GDeRegistrationAcceptUEInit.cpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/src/M5GDeRegistrationAcceptUEInit.cpp
@@ -14,7 +14,6 @@
 #include "M5GDeRegistrationAcceptUEInit.h"
 #include "M5GCommonDefs.h"
 
-using namespace std;
 namespace magma5g {
 DeRegistrationAcceptUEInitMsg::DeRegistrationAcceptUEInitMsg(){};
 DeRegistrationAcceptUEInitMsg::~DeRegistrationAcceptUEInitMsg(){};

--- a/lte/gateway/c/core/oai/tasks/nas5g/src/M5GDeRegistrationRequestUEInit.cpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/src/M5GDeRegistrationRequestUEInit.cpp
@@ -14,7 +14,6 @@
 #include "M5GDeRegistrationRequestUEInit.h"
 #include "M5GCommonDefs.h"
 
-using namespace std;
 namespace magma5g {
 DeRegistrationRequestUEInitMsg::DeRegistrationRequestUEInitMsg(){};
 DeRegistrationRequestUEInitMsg::~DeRegistrationRequestUEInitMsg(){};
@@ -30,7 +29,7 @@ int DeRegistrationRequestUEInitMsg::DecodeDeRegistrationRequestUEInitMsg(
       buffer, DEREGISTRATION_REQUEST_UEINIT_MINIMUM_LENGTH, len);
 
   MLOG(MDEBUG) << "\n\n---Decoding De-Registration Request Message---\n"
-               << endl;
+               << std::endl;
   if ((decoded_result =
            de_reg_request->extended_protocol_discriminator
                .DecodeExtendedProtocolDiscriminatorMsg(

--- a/lte/gateway/c/core/oai/tasks/nas5g/src/M5GServiceRequest.cpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/src/M5GServiceRequest.cpp
@@ -15,7 +15,6 @@
 #include "M5GCommonDefs.h"
 #include "M5gNasMessage.h"
 
-using namespace std;
 namespace magma5g {
 ServiceRequestMsg::ServiceRequestMsg(){};
 ServiceRequestMsg::~ServiceRequestMsg(){};

--- a/lte/gateway/c/core/oai/tasks/nas5g/src/SmfMessage.cpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/src/SmfMessage.cpp
@@ -34,10 +34,10 @@ int SmfMsg::SmfMsgDecodeHeaderMsg(
     DECODE_U8(buffer + size, hdr->message_type, size);
     MLOG(MDEBUG) << "epd = 0x" << std::hex
                  << int(hdr->extended_protocol_discriminator)
-                 << "pdu session id = 0x" << std::hex << int(hdr->pdu_session_id)
-                 << " procedure_transaction_id = 0x" << std::hex
-                 << int(hdr->procedure_transaction_id) << " message_type = 0x"
-                 << std::hex << int(hdr->message_type);
+                 << "pdu session id = 0x" << std::hex
+                 << int(hdr->pdu_session_id) << " procedure_transaction_id = 0x"
+                 << std::hex << int(hdr->procedure_transaction_id)
+                 << " message_type = 0x" << std::hex << int(hdr->message_type);
   } else {
     MLOG(MERROR) << "Error : Buffer is Empty" << std::endl;
     return (RETURNerror);
@@ -63,10 +63,10 @@ int SmfMsg::SmfMsgEncodeHeaderMsg(
     ENCODE_U8(buffer + size, hdr->message_type, size);
     MLOG(MDEBUG) << " epd = 0x" << std::hex
                  << int(hdr->extended_protocol_discriminator)
-                 << " pdu session id = 0x" << std::hex << int(hdr->pdu_session_id)
-                 << " procedure_transaction_id = 0x" << std::hex
-                 << int(hdr->procedure_transaction_id) << " message_type = 0x"
-                 << std::hex << int(hdr->message_type);
+                 << " pdu session id = 0x" << std::hex
+                 << int(hdr->pdu_session_id) << " procedure_transaction_id = 0x"
+                 << std::hex << int(hdr->procedure_transaction_id)
+                 << " message_type = 0x" << std::hex << int(hdr->message_type);
   } else {
     MLOG(MERROR) << "Error : Buffer is Empty ";
     return (RETURNerror);

--- a/lte/gateway/c/core/oai/tasks/nas5g/src/SmfMessage.cpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/src/SmfMessage.cpp
@@ -15,7 +15,6 @@
 #include "M5gNasMessage.h"
 #include "M5GCommonDefs.h"
 
-using namespace std;
 namespace magma5g {
 SMsg_u::SMsg_u(){};
 SMsg_u::~SMsg_u(){};
@@ -27,25 +26,25 @@ int SmfMsg::SmfMsgDecodeHeaderMsg(
     SmfMsgHeader* hdr, uint8_t* buffer, uint32_t len) {
   int size = 0;
 
-  MLOG(MDEBUG) << "SmfMsgDecodeHeaderMsg:" << endl;
+  MLOG(MDEBUG) << "SmfMsgDecodeHeaderMsg:" << std::endl;
   if (len > 0 || buffer != NULL) {
     DECODE_U8(buffer + size, hdr->extended_protocol_discriminator, size);
     DECODE_U8(buffer + size, hdr->pdu_session_id, size);
     DECODE_U8(buffer + size, hdr->procedure_transaction_id, size);
     DECODE_U8(buffer + size, hdr->message_type, size);
-    MLOG(MDEBUG) << "epd = 0x" << hex
+    MLOG(MDEBUG) << "epd = 0x" << std::hex
                  << int(hdr->extended_protocol_discriminator)
-                 << "pdu session id = 0x" << hex << int(hdr->pdu_session_id)
-                 << " procedure_transaction_id = 0x" << hex
+                 << "pdu session id = 0x" << std::hex << int(hdr->pdu_session_id)
+                 << " procedure_transaction_id = 0x" << std::hex
                  << int(hdr->procedure_transaction_id) << " message_type = 0x"
-                 << hex << int(hdr->message_type);
+                 << std::hex << int(hdr->message_type);
   } else {
-    MLOG(MERROR) << "Error : Buffer is Empty" << endl;
+    MLOG(MERROR) << "Error : Buffer is Empty" << std::endl;
     return (RETURNerror);
   }
 
   if (hdr->extended_protocol_discriminator != M5G_SESSION_MANAGEMENT_MESSAGES) {
-    MLOG(MERROR) << "Error : TLV not supported" << endl;
+    MLOG(MERROR) << "Error : TLV not supported" << std::endl;
     return (TLV_PROTOCOL_NOT_SUPPORTED);
   }
   return (size);
@@ -62,12 +61,12 @@ int SmfMsg::SmfMsgEncodeHeaderMsg(
     ENCODE_U8(buffer + size, hdr->pdu_session_id, size);
     ENCODE_U8(buffer + size, hdr->procedure_transaction_id, size);
     ENCODE_U8(buffer + size, hdr->message_type, size);
-    MLOG(MDEBUG) << " epd = 0x" << hex
+    MLOG(MDEBUG) << " epd = 0x" << std::hex
                  << int(hdr->extended_protocol_discriminator)
-                 << " pdu session id = 0x" << hex << int(hdr->pdu_session_id)
-                 << " procedure_transaction_id = 0x" << hex
+                 << " pdu session id = 0x" << std::hex << int(hdr->pdu_session_id)
+                 << " procedure_transaction_id = 0x" << std::hex
                  << int(hdr->procedure_transaction_id) << " message_type = 0x"
-                 << hex << int(hdr->message_type);
+                 << std::hex << int(hdr->message_type);
   } else {
     MLOG(MERROR) << "Error : Buffer is Empty ";
     return (RETURNerror);
@@ -85,9 +84,9 @@ int SmfMsg::SmfMsgDecodeMsg(SmfMsg* msg, uint8_t* buffer, uint32_t len) {
   int decode_result = 0;
   int header_result = 0;
 
-  MLOG(MDEBUG) << "SmfMsgDecodeMsg:" << endl;
+  MLOG(MDEBUG) << "SmfMsgDecodeMsg:" << std::endl;
   if (len <= 0 || buffer == NULL) {
-    MLOG(MERROR) << "Error : Buffer is Empty" << endl;
+    MLOG(MERROR) << "Error : Buffer is Empty" << std::endl;
     return (RETURNerror);
   }
 
@@ -127,7 +126,11 @@ int SmfMsg::SmfMsgEncodeMsg(SmfMsg* msg, uint8_t* buffer, uint32_t len) {
   int encode_result = 0;
   int header_result = 0;
 
-  MLOG(MDEBUG) << " SmfMsgEncodeMsg : " << endl;
+  MLOG(MDEBUG) << " SmfMsgEncodeMsg : " << std::endl;
+  if (len <= 0 || buffer == NULL) {
+    MLOG(MERROR) << "Error : Buffer is Empty";
+    return (RETURNerror);
+  }
 
   header_result = msg->SmfMsgEncodeHeaderMsg(&msg->header, buffer, len);
   if (header_result <= 0) {

--- a/lte/gateway/c/core/oai/tasks/nas5g/src/ies/M5GABBA.cpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/src/ies/M5GABBA.cpp
@@ -15,7 +15,6 @@
 #include "M5GABBA.h"
 #include "M5GCommonDefs.h"
 
-using namespace std;
 namespace magma5g {
 ABBAMsg::ABBAMsg(){};
 ABBAMsg::~ABBAMsg(){};
@@ -40,7 +39,7 @@ int ABBAMsg::EncodeABBAMsg(
   if (iei > 0) {
     CHECK_IEI_ENCODER((unsigned char) iei, abba->iei);
     *buffer = iei;
-    MLOG(MDEBUG) << "In EncodeABBAMsg: iei" << hex << int(*buffer);
+    MLOG(MDEBUG) << "In EncodeABBAMsg: iei" << std::hex << int(*buffer);
     encoded++;
   }
 

--- a/lte/gateway/c/core/oai/tasks/nas5g/src/ies/M5GAuthenticationFailureIE.cpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/src/ies/M5GAuthenticationFailureIE.cpp
@@ -14,7 +14,6 @@
 #include "M5GAuthenticationFailureIE.h"
 #include "M5GCommonDefs.h"
 
-using namespace std;
 namespace magma5g {
 M5GAuthenticationFailureIE::M5GAuthenticationFailureIE(){};
 M5GAuthenticationFailureIE::~M5GAuthenticationFailureIE(){};
@@ -29,8 +28,8 @@ int M5GAuthenticationFailureIE::DecodeM5GAuthenticationFailureIE(
   if (iei > 0) {
     m5g_auth_failure_ie->iei = *(buffer + decoded);
     CHECK_IEI_DECODER((unsigned char) iei, m5g_auth_failure_ie->iei);
-    MLOG(MDEBUG) << "In DecodeM5GAuthenticationFailureIE: iei = " << dec
-                 << int(m5g_auth_failure_ie->iei) << endl;
+    MLOG(MDEBUG) << "In DecodeM5GAuthenticationFailureIE: iei = " << std::dec 
+                 << int(m5g_auth_failure_ie->iei) << std::endl;
     decoded++;
   }
 

--- a/lte/gateway/c/core/oai/tasks/nas5g/src/ies/M5GAuthenticationFailureIE.cpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/src/ies/M5GAuthenticationFailureIE.cpp
@@ -28,7 +28,7 @@ int M5GAuthenticationFailureIE::DecodeM5GAuthenticationFailureIE(
   if (iei > 0) {
     m5g_auth_failure_ie->iei = *(buffer + decoded);
     CHECK_IEI_DECODER((unsigned char) iei, m5g_auth_failure_ie->iei);
-    MLOG(MDEBUG) << "In DecodeM5GAuthenticationFailureIE: iei = " << std::dec 
+    MLOG(MDEBUG) << "In DecodeM5GAuthenticationFailureIE: iei = " << std::hex
                  << int(m5g_auth_failure_ie->iei) << std::endl;
     decoded++;
   }

--- a/lte/gateway/c/core/oai/tasks/nas5g/src/ies/M5GAuthenticationParameterAUTN.cpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/src/ies/M5GAuthenticationParameterAUTN.cpp
@@ -15,7 +15,6 @@
 #include "M5GAuthenticationParameterAUTN.h"
 #include "M5GCommonDefs.h"
 
-using namespace std;
 namespace magma5g {
 AuthenticationParameterAUTNMsg::AuthenticationParameterAUTNMsg(){};
 AuthenticationParameterAUTNMsg::~AuthenticationParameterAUTNMsg(){};
@@ -42,7 +41,7 @@ int AuthenticationParameterAUTNMsg::EncodeAuthenticationParameterAUTNMsg(
   if (iei > 0) {
     CHECK_IEI_ENCODER((unsigned char) iei, autn->iei);
     *buffer = iei;
-    MLOG(MDEBUG) << "In EncodeAuthenticationParameterAUTNMsg: iei" << hex
+    MLOG(MDEBUG) << "In EncodeAuthenticationParameterAUTNMsg: iei" << std::hex
                  << int(*buffer);
     encoded++;
   }

--- a/lte/gateway/c/core/oai/tasks/nas5g/src/ies/M5GAuthenticationParameterRAND.cpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/src/ies/M5GAuthenticationParameterRAND.cpp
@@ -15,7 +15,6 @@
 #include "M5GAuthenticationParameterRAND.h"
 #include "M5GCommonDefs.h"
 
-using namespace std;
 namespace magma5g {
 AuthenticationParameterRANDMsg::AuthenticationParameterRANDMsg(){};
 AuthenticationParameterRANDMsg::~AuthenticationParameterRANDMsg(){};
@@ -41,8 +40,8 @@ int AuthenticationParameterRANDMsg::EncodeAuthenticationParameterRANDMsg(
   if (iei > 0) {
     CHECK_IEI_ENCODER((unsigned char) iei, rand->iei);
     *buffer = iei;
-    MLOG(MDEBUG) << "In EncodeAuthenticationParameterRANDMsg: iei" << hex
-                 << int(*buffer) << endl;
+    MLOG(MDEBUG) << "In EncodeAuthenticationParameterRANDMsg: iei" << std::hex
+                 << int(*buffer) << std::endl;
     encoded++;
   }
 

--- a/lte/gateway/c/core/oai/tasks/nas5g/src/ies/M5GAuthenticationResponseParameter.cpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/src/ies/M5GAuthenticationResponseParameter.cpp
@@ -64,8 +64,8 @@ int AuthenticationResponseParameterMsg::
   if (iei > 0) {
     CHECK_IEI_ENCODER((unsigned char) iei, response_parameter->iei);
     *buffer = iei;
-    MLOG(MDEBUG) << "In EncodeAuthenticationResponseParameterMsg: iei" << std::hex
-                 << int(*buffer) << std::endl;
+    MLOG(MDEBUG) << "In EncodeAuthenticationResponseParameterMsg: iei"
+                 << std::hex << int(*buffer) << std::endl;
     encoded++;
   } else {
     return 0;

--- a/lte/gateway/c/core/oai/tasks/nas5g/src/ies/M5GAuthenticationResponseParameter.cpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/src/ies/M5GAuthenticationResponseParameter.cpp
@@ -16,7 +16,6 @@
 #include "M5GAuthenticationResponseParameter.h"
 #include "M5GCommonDefs.h"
 
-using namespace std;
 namespace magma5g {
 AuthenticationResponseParameterMsg::AuthenticationResponseParameterMsg(){};
 AuthenticationResponseParameterMsg::~AuthenticationResponseParameterMsg(){};
@@ -33,11 +32,11 @@ int AuthenticationResponseParameterMsg::
   if (iei > 0) {
     CHECK_IEI_DECODER(iei, *buffer);
     response_parameter->iei = *(buffer + decoded);
-    MLOG(MDEBUG) << " ElementID : " << hex << int(response_parameter->iei);
+    MLOG(MDEBUG) << " ElementID : " << std::hex << int(response_parameter->iei);
     decoded++;
   }
   response_parameter->length = *(buffer + decoded);
-  MLOG(MDEBUG) << " Length : " << dec << int(response_parameter->length);
+  MLOG(MDEBUG) << " Length : " << std::dec << int(response_parameter->length);
   decoded++;
   response_parameter->response_parameter[0] = 0;
   for (int i = 0; i < (int) (response_parameter->length); i++) {
@@ -45,7 +44,7 @@ int AuthenticationResponseParameterMsg::
     decoded++;
   }
   for (int i = 0; i < (int) (response_parameter->length); i++) {
-    MLOG(MDEBUG) << " RES : " << hex
+    MLOG(MDEBUG) << " RES : " << std::hex
                  << int(response_parameter->response_parameter[i]);
   }
   return (decoded);
@@ -65,8 +64,8 @@ int AuthenticationResponseParameterMsg::
   if (iei > 0) {
     CHECK_IEI_ENCODER((unsigned char) iei, response_parameter->iei);
     *buffer = iei;
-    MLOG(MDEBUG) << "In EncodeAuthenticationResponseParameterMsg: iei" << hex
-                 << int(*buffer) << endl;
+    MLOG(MDEBUG) << "In EncodeAuthenticationResponseParameterMsg: iei" << std::hex
+                 << int(*buffer) << std::endl;
     encoded++;
   } else {
     return 0;

--- a/lte/gateway/c/core/oai/tasks/nas5g/src/ies/M5GEAPMessage.cpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/src/ies/M5GEAPMessage.cpp
@@ -15,7 +15,6 @@
 #include "M5GEAPMessage.h"
 #include "M5GCommonDefs.h"
 
-using namespace std;
 namespace magma5g {
 EAPMessageMsg::EAPMessageMsg(){};
 EAPMessageMsg::~EAPMessageMsg(){};
@@ -51,7 +50,7 @@ int EAPMessageMsg::EncodeEAPMessageMsg(
 
   MLOG(MDEBUG) << "EncodeEAPMessage : ";
   IES_ENCODE_U16(buffer, encoded, eap_message->len);
-  MLOG(MDEBUG) << "Length = " << hex << int(eap_message->len);
+  MLOG(MDEBUG) << "Length = " << std::hex << int(eap_message->len);
   std::copy(eap_message->eap.begin(), eap_message->eap.end(), buffer + encoded);
   BUFFER_PRINT_LOG(buffer + encoded, eap_message->eap.length());
   encoded = encoded + eap_message->eap.length();

--- a/lte/gateway/c/core/oai/tasks/nas5g/src/ies/M5GExtendedProtocolDiscriminator.cpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/src/ies/M5GExtendedProtocolDiscriminator.cpp
@@ -14,7 +14,6 @@
 #include "M5GExtendedProtocolDiscriminator.h"
 #include "M5GCommonDefs.h"
 
-using namespace std;
 namespace magma5g {
 ExtendedProtocolDiscriminatorMsg::ExtendedProtocolDiscriminatorMsg(){};
 ExtendedProtocolDiscriminatorMsg::~ExtendedProtocolDiscriminatorMsg(){};
@@ -30,7 +29,7 @@ int ExtendedProtocolDiscriminatorMsg::DecodeExtendedProtocolDiscriminatorMsg(
       *(buffer + decoded);
   decoded++;
   MLOG(MDEBUG)
-      << " epd = " << hex
+      << " epd = " << std::hex
       << int(extended_protocol_discriminator->extended_proto_discriminator);
   return (decoded);
 };
@@ -44,7 +43,7 @@ int ExtendedProtocolDiscriminatorMsg::EncodeExtendedProtocolDiscriminatorMsg(
   MLOG(MDEBUG) << " EncodeExtendedProtocolDiscriminatorMsg : ";
   *(buffer + encoded) =
       extended_protocol_discriminator->extended_proto_discriminator;
-  MLOG(MDEBUG) << "epd = 0x" << hex << int(*(buffer + encoded));
+  MLOG(MDEBUG) << "epd = 0x" << std::hex << int(*(buffer + encoded));
   encoded++;
   return (encoded);
 };

--- a/lte/gateway/c/core/oai/tasks/nas5g/src/ies/M5GGprsTimer2.cpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/src/ies/M5GGprsTimer2.cpp
@@ -26,11 +26,13 @@ int GPRSTimer2Msg::DecodeGPRSTimer2Msg(
 
   if (iei > 0) {
     gprstimer->iei = *buffer;
-    MLOG(MDEBUG) << "DecodeGPRSTimer2Msg: iei = " << std::hex << int(gprstimer->iei);
+    MLOG(MDEBUG) << "DecodeGPRSTimer2Msg: iei = " << std::hex
+                 << int(gprstimer->iei);
     decoded++;
 
     gprstimer->len = *(buffer + decoded);
-    MLOG(MDEBUG) << "DecodeGPRSTimer2Msg: len = " << std::hex << int(gprstimer->len);
+    MLOG(MDEBUG) << "DecodeGPRSTimer2Msg: len = " << std::hex
+                 << int(gprstimer->len);
     decoded++;
 
     gprstimer->timervalue = *(buffer + decoded);

--- a/lte/gateway/c/core/oai/tasks/nas5g/src/ies/M5GGprsTimer2.cpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/src/ies/M5GGprsTimer2.cpp
@@ -26,15 +26,15 @@ int GPRSTimer2Msg::DecodeGPRSTimer2Msg(
 
   if (iei > 0) {
     gprstimer->iei = *buffer;
-    MLOG(MDEBUG) << "DecodeGPRSTimer2Msg: iei = " << hex << int(gprstimer->iei);
+    MLOG(MDEBUG) << "DecodeGPRSTimer2Msg: iei = " << std::hex << int(gprstimer->iei);
     decoded++;
 
     gprstimer->len = *(buffer + decoded);
-    MLOG(MDEBUG) << "DecodeGPRSTimer2Msg: len = " << hex << int(gprstimer->len);
+    MLOG(MDEBUG) << "DecodeGPRSTimer2Msg: len = " << std::hex << int(gprstimer->len);
     decoded++;
 
     gprstimer->timervalue = *(buffer + decoded);
-    MLOG(MDEBUG) << "DecodeGPRSTimer2Msg: timervalue = " << hex
+    MLOG(MDEBUG) << "DecodeGPRSTimer2Msg: timervalue = " << std::hex
                  << int(gprstimer->timervalue);
     decoded++;
   }

--- a/lte/gateway/c/core/oai/tasks/nas5g/src/ies/M5GIMEISVRequest.cpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/src/ies/M5GIMEISVRequest.cpp
@@ -15,7 +15,6 @@
 #include "M5GIMEISVRequest.h"
 #include "M5GCommonDefs.h"
 
-using namespace std;
 namespace magma5g {
 ImeisvRequestMsg::ImeisvRequestMsg(){};
 ImeisvRequestMsg::~ImeisvRequestMsg(){};
@@ -37,8 +36,8 @@ int ImeisvRequestMsg::DecodeImeisvRequestMsg(
   imeisv_request->spare          = (*(buffer + decoded) >> 7) & 0x1;
   imeisv_request->imeisv_request = (*(buffer + decoded) >> 4) & 0x7;
   decoded++;
-  MLOG(MDEBUG) << "   spare = " << dec << int(imeisv_request->spare);
-  MLOG(MDEBUG) << "   imeisv request = " << dec
+  MLOG(MDEBUG) << "   spare = " << std::dec << int(imeisv_request->spare);
+  MLOG(MDEBUG) << "   imeisv request = " << std::dec 
                << int(imeisv_request->imeisv_request);
   return decoded;
 };
@@ -48,7 +47,7 @@ int ImeisvRequestMsg::EncodeImeisvRequestMsg(
     uint32_t len) {
   uint32_t encoded = 0;
 
-  MLOG(MDEBUG) << " EncodeImeisvRequestMsg : " << endl;
+  MLOG(MDEBUG) << " EncodeImeisvRequestMsg : " << std::endl;
   *(buffer + encoded) = 0xe0 | (imeisv_request->spare & 0x1) << 3 |
                         (imeisv_request->imeisv_request & 0x7);
   encoded++;

--- a/lte/gateway/c/core/oai/tasks/nas5g/src/ies/M5GIMEISVRequest.cpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/src/ies/M5GIMEISVRequest.cpp
@@ -37,7 +37,7 @@ int ImeisvRequestMsg::DecodeImeisvRequestMsg(
   imeisv_request->imeisv_request = (*(buffer + decoded) >> 4) & 0x7;
   decoded++;
   MLOG(MDEBUG) << "   spare = " << std::dec << int(imeisv_request->spare);
-  MLOG(MDEBUG) << "   imeisv request = " << std::dec 
+  MLOG(MDEBUG) << "   imeisv request = " << std::dec
                << int(imeisv_request->imeisv_request);
   return decoded;
 };

--- a/lte/gateway/c/core/oai/tasks/nas5g/src/ies/M5GIntegrityProtMaxDataRate.cpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/src/ies/M5GIntegrityProtMaxDataRate.cpp
@@ -14,7 +14,6 @@
 #include "M5GIntegrityProtMaxDataRate.h"
 #include "M5GCommonDefs.h"
 
-using namespace std;
 namespace magma5g {
 IntegrityProtMaxDataRateMsg::IntegrityProtMaxDataRateMsg(){};
 IntegrityProtMaxDataRateMsg::~IntegrityProtMaxDataRateMsg(){};
@@ -30,9 +29,9 @@ int IntegrityProtMaxDataRateMsg::DecodeIntegrityProtMaxDataRateMsg(
   decoded++;
   integrity_prot_max_data_rate->max_downlink = *(buffer + decoded);
   decoded++;
-  MLOG(MDEBUG) << " max_uplink = " << dec
+  MLOG(MDEBUG) << " max_uplink = " << std::dec 
                << int(integrity_prot_max_data_rate->max_uplink);
-  MLOG(MDEBUG) << " max_downlink = " << dec
+  MLOG(MDEBUG) << " max_downlink = " << std::dec 
                << int(integrity_prot_max_data_rate->max_downlink);
   return (decoded);
 };
@@ -45,11 +44,11 @@ int IntegrityProtMaxDataRateMsg::EncodeIntegrityProtMaxDataRateMsg(
 
   MLOG(MDEBUG) << " EncodeIntegrityProtMaxDataRateMsg : ";
   *(buffer + encoded) = integrity_prot_max_data_rate->max_uplink;
-  MLOG(MDEBUG) << " max_uplink =0x" << hex
+  MLOG(MDEBUG) << " max_uplink =0x" << std::hex
                << int(integrity_prot_max_data_rate->max_uplink);
   encoded++;
   *(buffer + encoded) = integrity_prot_max_data_rate->max_downlink;
-  MLOG(MDEBUG) << " max_downlink =0x" << hex
+  MLOG(MDEBUG) << " max_downlink =0x" << std::hex
                << int(integrity_prot_max_data_rate->max_downlink);
   encoded++;
   return (encoded);

--- a/lte/gateway/c/core/oai/tasks/nas5g/src/ies/M5GIntegrityProtMaxDataRate.cpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/src/ies/M5GIntegrityProtMaxDataRate.cpp
@@ -29,9 +29,9 @@ int IntegrityProtMaxDataRateMsg::DecodeIntegrityProtMaxDataRateMsg(
   decoded++;
   integrity_prot_max_data_rate->max_downlink = *(buffer + decoded);
   decoded++;
-  MLOG(MDEBUG) << " max_uplink = " << std::dec 
+  MLOG(MDEBUG) << " max_uplink = " << std::dec
                << int(integrity_prot_max_data_rate->max_uplink);
-  MLOG(MDEBUG) << " max_downlink = " << std::dec 
+  MLOG(MDEBUG) << " max_downlink = " << std::dec
                << int(integrity_prot_max_data_rate->max_downlink);
   return (decoded);
 };

--- a/lte/gateway/c/core/oai/tasks/nas5g/src/ies/M5GMMCause.cpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/src/ies/M5GMMCause.cpp
@@ -14,7 +14,6 @@
 #include "M5GMMCause.h"
 #include "M5GCommonDefs.h"
 
-using namespace std;
 namespace magma5g {
 M5GMMCauseMsg::M5GMMCauseMsg(){};
 M5GMMCauseMsg::~M5GMMCauseMsg(){};
@@ -27,15 +26,15 @@ int M5GMMCauseMsg::DecodeM5GMMCauseMsg(
   if (iei > 0) {
     m5gmm_cause->iei = *(buffer + decoded);
     CHECK_IEI_DECODER((unsigned char) iei, m5gmm_cause->iei);
-    MLOG(MDEBUG) << "In DecodeM5GMMCauseMsg: iei = " << dec
-                 << int(m5gmm_cause->iei) << endl;
+    MLOG(MDEBUG) << "In DecodeM5GMMCauseMsg: iei = " << std::dec 
+                 << int(m5gmm_cause->iei) << std::endl;
     decoded++;
   }
 
   MLOG(MDEBUG) << "   DecodeM5GMMCauseMsg : ";
   m5gmm_cause->m5gmm_cause = *(buffer + decoded);
   decoded++;
-  MLOG(MDEBUG) << " CauseValue = " << hex << int(m5gmm_cause->m5gmm_cause);
+  MLOG(MDEBUG) << " CauseValue = " << std::hex << int(m5gmm_cause->m5gmm_cause);
   return (decoded);
 };
 
@@ -47,14 +46,14 @@ int M5GMMCauseMsg::EncodeM5GMMCauseMsg(
   if (iei > 0) {
     *(buffer + encoded) = m5gmm_cause->iei;
     CHECK_IEI_ENCODER((unsigned char) iei, m5gmm_cause->iei);
-    MLOG(MDEBUG) << "In EncodeM5GMMCauseMsg: iei = " << hex
-                 << int(*(buffer + encoded)) << endl;
+    MLOG(MDEBUG) << "In EncodeM5GMMCauseMsg: iei = " << std::hex
+                 << int(*(buffer + encoded)) << std::endl;
     encoded++;
   }
 
   MLOG(MDEBUG) << " EncodeM5GMMCauseMsg : ";
   *(buffer + encoded) = m5gmm_cause->m5gmm_cause;
-  MLOG(MDEBUG) << "CauseValue = 0x" << hex << int(*(buffer + encoded));
+  MLOG(MDEBUG) << "CauseValue = 0x" << std::hex << int(*(buffer + encoded));
   encoded++;
   return (encoded);
 };

--- a/lte/gateway/c/core/oai/tasks/nas5g/src/ies/M5GMMCause.cpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/src/ies/M5GMMCause.cpp
@@ -26,7 +26,7 @@ int M5GMMCauseMsg::DecodeM5GMMCauseMsg(
   if (iei > 0) {
     m5gmm_cause->iei = *(buffer + decoded);
     CHECK_IEI_DECODER((unsigned char) iei, m5gmm_cause->iei);
-    MLOG(MDEBUG) << "In DecodeM5GMMCauseMsg: iei = " << std::dec 
+    MLOG(MDEBUG) << "In DecodeM5GMMCauseMsg: iei = " << std::dec
                  << int(m5gmm_cause->iei) << std::endl;
     decoded++;
   }

--- a/lte/gateway/c/core/oai/tasks/nas5g/src/ies/M5GMessageType.cpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/src/ies/M5GMessageType.cpp
@@ -15,7 +15,6 @@
 #include "M5GMessageType.h"
 #include "M5GCommonDefs.h"
 
-using namespace std;
 namespace magma5g {
 MessageTypeMsg::MessageTypeMsg(){};
 MessageTypeMsg::~MessageTypeMsg(){};
@@ -28,7 +27,7 @@ int MessageTypeMsg::DecodeMessageTypeMsg(
   MLOG(MDEBUG) << "   DecodeMessageTypeMsg : ";
   message_type->msg_type = *(buffer + decoded);
   decoded++;
-  MLOG(MDEBUG) << " msg_type = 0x" << hex << int(message_type->msg_type);
+  MLOG(MDEBUG) << " msg_type = 0x" << std::hex << int(message_type->msg_type);
   return (decoded);
 };
 
@@ -39,7 +38,7 @@ int MessageTypeMsg::EncodeMessageTypeMsg(
 
   MLOG(MDEBUG) << " EncodeMessageTypeMsg : ";
   *(buffer + encoded) = message_type->msg_type;
-  MLOG(MDEBUG) << "Message type = 0x" << hex << int(*(buffer + encoded));
+  MLOG(MDEBUG) << "Message type = 0x" << std::hex << int(*(buffer + encoded));
   encoded++;
   return (encoded);
 };

--- a/lte/gateway/c/core/oai/tasks/nas5g/src/ies/M5GNASSecurityAlgorithms.cpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/src/ies/M5GNASSecurityAlgorithms.cpp
@@ -14,7 +14,6 @@
 #include "M5GNASSecurityAlgorithms.h"
 #include "M5GCommonDefs.h"
 
-using namespace std;
 namespace magma5g {
 NASSecurityAlgorithmsMsg::NASSecurityAlgorithmsMsg(){};
 NASSecurityAlgorithmsMsg::~NASSecurityAlgorithmsMsg(){};
@@ -35,9 +34,9 @@ int NASSecurityAlgorithmsMsg::DecodeNASSecurityAlgorithmsMsg(
   nas_sec_algorithms->tca = (*(buffer + decoded) >> 4) & 0x7;
   nas_sec_algorithms->tia = *(buffer + decoded) & 0x7;
   decoded++;
-  MLOG(MDEBUG) << " Type of ciphering algorithm  = " << hex
+  MLOG(MDEBUG) << " Type of ciphering algorithm  = " << std::hex
                << int(nas_sec_algorithms->tca);
-  MLOG(MDEBUG) << " Type of integrity protection algorithm  = " << hex
+  MLOG(MDEBUG) << " Type of integrity protection algorithm  = " << std::hex
                << int(nas_sec_algorithms->tia);
   return (decoded);
 };
@@ -61,9 +60,9 @@ int NASSecurityAlgorithmsMsg::EncodeNASSecurityAlgorithmsMsg(
   *(buffer + encoded) = 0x00 | ((nas_sec_algorithms->tca & 0x7) << 4) |
                         (nas_sec_algorithms->tia & 0x7);
 
-  MLOG(MDEBUG) << " Type of ciphering algorithm  = " << hex
+  MLOG(MDEBUG) << " Type of ciphering algorithm  = " << std::hex
                << int(nas_sec_algorithms->tca);
-  MLOG(MDEBUG) << " Type of integrity protection algorithm  = " << hex
+  MLOG(MDEBUG) << " Type of integrity protection algorithm  = " << std::hex
                << int(nas_sec_algorithms->tia);
   encoded++;
   return (encoded);

--- a/lte/gateway/c/core/oai/tasks/nas5g/src/ies/M5GNSSAI.cpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/src/ies/M5GNSSAI.cpp
@@ -13,7 +13,6 @@ limitations under the License.
 #include <string.h>
 #include "M5GNSSAI.h"
 #include "M5GCommonDefs.h"
-using namespace std;
 namespace magma5g {
 NSSAIMsg::NSSAIMsg(){};
 

--- a/lte/gateway/c/core/oai/tasks/nas5g/src/ies/M5GNasKeySetIdentifier.cpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/src/ies/M5GNasKeySetIdentifier.cpp
@@ -15,7 +15,6 @@
 #include "M5GNASKeySetIdentifier.h"
 #include "M5GCommonDefs.h"
 
-using namespace std;
 namespace magma5g {
 NASKeySetIdentifierMsg::NASKeySetIdentifierMsg(){};
 NASKeySetIdentifierMsg::~NASKeySetIdentifierMsg(){};
@@ -40,8 +39,8 @@ int NASKeySetIdentifierMsg::DecodeNASKeySetIdentifierMsg(
   nas_key_set_identifier->nas_key_set_identifier =
       (*(buffer + decoded) >> 4) & 0x7;
   decoded++;
-  MLOG(MDEBUG) << "   tsc = " << dec << int(nas_key_set_identifier->tsc);
-  MLOG(MDEBUG) << "   NASkeysetidentifier = " << dec
+  MLOG(MDEBUG) << "   tsc = " << std::dec << int(nas_key_set_identifier->tsc);
+  MLOG(MDEBUG) << "   NASkeysetidentifier = " << std::dec 
                << int(nas_key_set_identifier->nas_key_set_identifier);
   return decoded;
 };
@@ -59,17 +58,17 @@ int NASKeySetIdentifierMsg::EncodeNASKeySetIdentifierMsg(
   if (iei > 0) {
     CHECK_IEI_ENCODER((unsigned char) iei, nas_key_set_identifier->iei);
     *buffer = iei;
-    MLOG(MDEBUG) << "In EncodeNASKeySetIdentifierMsg: iei" << hex
-                 << int(*buffer) << endl;
+    MLOG(MDEBUG) << "In EncodeNASKeySetIdentifierMsg: iei" << std::hex
+                 << int(*buffer) << std::endl;
     encoded++;
   }
 
-  MLOG(MDEBUG) << " EncodeNASKeySetIdentifierMsg : " << endl;
+  MLOG(MDEBUG) << " EncodeNASKeySetIdentifierMsg : " << std::endl;
   *(buffer + encoded) = 0x00 | (nas_key_set_identifier->tsc & 0x1) << 3 |
                         (nas_key_set_identifier->nas_key_set_identifier & 0x7);
-  MLOG(MDEBUG) << "   Type of Security Context  = 0x" << hex
+  MLOG(MDEBUG) << "   Type of Security Context  = 0x" << std::hex
                << int(nas_key_set_identifier->tsc) << "\n";
-  MLOG(MDEBUG) << "   NAS key set identifier = 0x" << hex
+  MLOG(MDEBUG) << "   NAS key set identifier = 0x" << std::hex
                << int(*(buffer + encoded)) << "\n";
   encoded++;
 

--- a/lte/gateway/c/core/oai/tasks/nas5g/src/ies/M5GNasKeySetIdentifier.cpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/src/ies/M5GNasKeySetIdentifier.cpp
@@ -40,7 +40,7 @@ int NASKeySetIdentifierMsg::DecodeNASKeySetIdentifierMsg(
       (*(buffer + decoded) >> 4) & 0x7;
   decoded++;
   MLOG(MDEBUG) << "   tsc = " << std::dec << int(nas_key_set_identifier->tsc);
-  MLOG(MDEBUG) << "   NASkeysetidentifier = " << std::dec 
+  MLOG(MDEBUG) << "   NASkeysetidentifier = " << std::dec
                << int(nas_key_set_identifier->nas_key_set_identifier);
   return decoded;
 };

--- a/lte/gateway/c/core/oai/tasks/nas5g/src/ies/M5GPDUAddress.cpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/src/ies/M5GPDUAddress.cpp
@@ -16,7 +16,6 @@
 #include "M5GPDUAddress.h"
 #include "M5GCommonDefs.h"
 
-using namespace std;
 namespace magma5g {
 PDUAddressMsg::PDUAddressMsg(){};
 PDUAddressMsg::~PDUAddressMsg(){};

--- a/lte/gateway/c/core/oai/tasks/nas5g/src/ies/M5GPDUSessionIdentity.cpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/src/ies/M5GPDUSessionIdentity.cpp
@@ -15,7 +15,6 @@
 #include "M5GCommonDefs.h"
 #include "M5gNasMessage.h"
 
-using namespace std;
 namespace magma5g {
 PDUSessionIdentityMsg::PDUSessionIdentityMsg(){};
 PDUSessionIdentityMsg::~PDUSessionIdentityMsg(){};
@@ -37,7 +36,7 @@ int PDUSessionIdentityMsg::DecodePDUSessionIdentityMsg(
   MLOG(MDEBUG) << "   DecodePDUSessionIdentityMsg : ";
   pdu_session_identity->pdu_session_id = *(buffer + decoded);
   decoded++;
-  MLOG(MDEBUG) << " PDUSessionIdentity = " << hex
+  MLOG(MDEBUG) << " PDUSessionIdentity = " << std::hex
                << int(pdu_session_identity->pdu_session_id);
 
   return (decoded);
@@ -61,7 +60,7 @@ int PDUSessionIdentityMsg::EncodePDUSessionIdentityMsg(
   }
 
   *(buffer + encoded) = pdu_session_identity->pdu_session_id;
-  MLOG(MDEBUG) << "PDUSessionIdentity = 0x" << hex << int(*(buffer + encoded));
+  MLOG(MDEBUG) << "PDUSessionIdentity = 0x" << std::hex << int(*(buffer + encoded));
   encoded++;
 
   return (encoded);

--- a/lte/gateway/c/core/oai/tasks/nas5g/src/ies/M5GPDUSessionIdentity.cpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/src/ies/M5GPDUSessionIdentity.cpp
@@ -60,7 +60,8 @@ int PDUSessionIdentityMsg::EncodePDUSessionIdentityMsg(
   }
 
   *(buffer + encoded) = pdu_session_identity->pdu_session_id;
-  MLOG(MDEBUG) << "PDUSessionIdentity = 0x" << std::hex << int(*(buffer + encoded));
+  MLOG(MDEBUG) << "PDUSessionIdentity = 0x" << std::hex
+               << int(*(buffer + encoded));
   encoded++;
 
   return (encoded);

--- a/lte/gateway/c/core/oai/tasks/nas5g/src/ies/M5GPDUSessionReActivationResult.cpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/src/ies/M5GPDUSessionReActivationResult.cpp
@@ -48,13 +48,13 @@ int M5GPDUSessionReActivationResult::DecodePDUSessionReActivationResult(
 
   if (iei > 0) {
     pduSessionReActivationStatus->iei = *buffer;
-    MLOG(MDEBUG) << "In DecodeM5GPDUSessionReActivationResult: iei = " << std::hex
-                 << int(pduSessionReActivationStatus->iei);
+    MLOG(MDEBUG) << "In DecodeM5GPDUSessionReActivationResult: iei = "
+                 << std::hex << int(pduSessionReActivationStatus->iei);
     decoded++;
 
     pduSessionReActivationStatus->len = *(buffer + decoded);
-    MLOG(MDEBUG) << "In DecodeM5GPDUSessionReActivationResult: len = " << std::hex
-                 << int(pduSessionReActivationStatus->len);
+    MLOG(MDEBUG) << "In DecodeM5GPDUSessionReActivationResult: len = "
+                 << std::hex << int(pduSessionReActivationStatus->len);
     decoded++;
 
     pduSessionReActivationStatus->pduSessionReActivationResult =

--- a/lte/gateway/c/core/oai/tasks/nas5g/src/ies/M5GPDUSessionReActivationResult.cpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/src/ies/M5GPDUSessionReActivationResult.cpp
@@ -16,7 +16,6 @@ limitations under the License.
 #include "M5GCommonDefs.h"
 #include "M5GPDUSessionReActivationResult.h"
 
-using namespace std;
 namespace magma5g {
 M5GPDUSessionReActivationResult::M5GPDUSessionReActivationResult(){};
 M5GPDUSessionReActivationResult::~M5GPDUSessionReActivationResult(){};
@@ -49,12 +48,12 @@ int M5GPDUSessionReActivationResult::DecodePDUSessionReActivationResult(
 
   if (iei > 0) {
     pduSessionReActivationStatus->iei = *buffer;
-    MLOG(MDEBUG) << "In DecodeM5GPDUSessionReActivationResult: iei = " << hex
+    MLOG(MDEBUG) << "In DecodeM5GPDUSessionReActivationResult: iei = " << std::hex
                  << int(pduSessionReActivationStatus->iei);
     decoded++;
 
     pduSessionReActivationStatus->len = *(buffer + decoded);
-    MLOG(MDEBUG) << "In DecodeM5GPDUSessionReActivationResult: len = " << hex
+    MLOG(MDEBUG) << "In DecodeM5GPDUSessionReActivationResult: len = " << std::hex
                  << int(pduSessionReActivationStatus->len);
     decoded++;
 
@@ -66,7 +65,7 @@ int M5GPDUSessionReActivationResult::DecodePDUSessionReActivationResult(
     MLOG(MDEBUG)
         << "In DecodeM5GPDUSessionReActivationResult: "
            "pduSessionReActivationResult = "
-        << hex
+        << std::hex
         << int(pduSessionReActivationStatus->pduSessionReActivationResult);
     decoded++;
   }

--- a/lte/gateway/c/core/oai/tasks/nas5g/src/ies/M5GPDUSessionStatus.cpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/src/ies/M5GPDUSessionStatus.cpp
@@ -16,7 +16,6 @@ limitations under the License.
 #include "M5GCommonDefs.h"
 #include "M5GPDUSessionStatus.h"
 
-using namespace std;
 namespace magma5g {
 M5GPDUSessionStatus::M5GPDUSessionStatus(){};
 M5GPDUSessionStatus::~M5GPDUSessionStatus(){};
@@ -47,19 +46,19 @@ int M5GPDUSessionStatus::DecodePDUSessionStatus(
 
   if (iei > 0) {
     pduSessionStatus->iei = *buffer;
-    MLOG(MDEBUG) << "DecodePDUSessionStatus: iei = " << hex
+    MLOG(MDEBUG) << "DecodePDUSessionStatus: iei = " << std::hex
                  << int(pduSessionStatus->iei);
     decoded++;
 
     pduSessionStatus->len = *(buffer + decoded);
-    MLOG(MDEBUG) << "In DecodePDUSessionStatus: len = " << hex
+    MLOG(MDEBUG) << "In DecodePDUSessionStatus: len = " << std::hex
                  << int(pduSessionStatus->len);
     decoded++;
 
     pduSessionStatus->pduSessionStatus = *(buffer + decoded);
     decoded++;
     pduSessionStatus->pduSessionStatus |= (*(buffer + decoded) << 8);
-    MLOG(MDEBUG) << "In DecodePDUSessionStatus: pduSessionStatus = " << hex
+    MLOG(MDEBUG) << "In DecodePDUSessionStatus: pduSessionStatus = " << std::hex
                  << int(pduSessionStatus->pduSessionStatus);
     decoded++;
   }

--- a/lte/gateway/c/core/oai/tasks/nas5g/src/ies/M5GPDUSessionType.cpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/src/ies/M5GPDUSessionType.cpp
@@ -53,8 +53,8 @@ int PDUSessionTypeMsg::EncodePDUSessionTypeMsg(
   if (iei > 0) {
     *buffer = (pdu_session_type->iei & 0x0f) << 4;
     CHECK_IEI_ENCODER((unsigned char) iei, pdu_session_type->iei);
-    MLOG(MDEBUG) << "In EncodePDUSessionTypeMsg: iei" << std::hex << int(*buffer)
-                 << std::endl;
+    MLOG(MDEBUG) << "In EncodePDUSessionTypeMsg: iei" << std::hex
+                 << int(*buffer) << std::endl;
   }
 
   *buffer = 0x00 | (*buffer & 0xf0) | (pdu_session_type->type_val & 0x07);

--- a/lte/gateway/c/core/oai/tasks/nas5g/src/ies/M5GPDUSessionType.cpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/src/ies/M5GPDUSessionType.cpp
@@ -16,7 +16,6 @@
 #include "M5GPDUSessionType.h"
 #include "M5GCommonDefs.h"
 
-using namespace std;
 namespace magma5g {
 PDUSessionTypeMsg::PDUSessionTypeMsg(){};
 PDUSessionTypeMsg::~PDUSessionTypeMsg(){};
@@ -30,14 +29,14 @@ int PDUSessionTypeMsg::DecodePDUSessionTypeMsg(
   // Store the IEI Information
   if (iei > 0) {
     pdu_session_type->iei = (*buffer & 0xf0) >> 4;
-    MLOG(MDEBUG) << "In DecodePDUSessionTypeMsg: iei" << hex
-                 << int(pdu_session_type->iei) << endl;
+    MLOG(MDEBUG) << "In DecodePDUSessionTypeMsg: iei" << std::hex
+                 << int(pdu_session_type->iei) << std::endl;
     decoded++;
   }
 
   pdu_session_type->type_val = (*buffer & 0x07);
-  MLOG(MDEBUG) << "DecodePDUSessionTypeMsg: type_val = " << hex
-               << int(pdu_session_type->type_val) << endl;
+  MLOG(MDEBUG) << "DecodePDUSessionTypeMsg: type_val = " << std::hex
+               << int(pdu_session_type->type_val) << std::endl;
 
   return (decoded);
 };
@@ -50,19 +49,17 @@ int PDUSessionTypeMsg::EncodePDUSessionTypeMsg(
 
   // CHECKING IEI
   MLOG(MDEBUG) << "In EncodePDUSessionTypeMsg: pdu_session_type"
-               << pdu_session_type->type_val << endl;
-
+               << pdu_session_type->type_val << std::endl;
   if (iei > 0) {
     *buffer = (pdu_session_type->iei & 0x0f) << 4;
-    CHECK_IEI_ENCODER(
-        (uint8_t) iei, (uint8_t)((pdu_session_type->iei & 0x0f) << 4));
-    MLOG(MDEBUG) << "In EncodePDUSessionTypeMsg: iei" << hex << int(*buffer)
-                 << endl;
+    CHECK_IEI_ENCODER((unsigned char) iei, pdu_session_type->iei);
+    MLOG(MDEBUG) << "In EncodePDUSessionTypeMsg: iei" << std::hex << int(*buffer)
+                 << std::endl;
   }
 
   *buffer = 0x00 | (*buffer & 0xf0) | (pdu_session_type->type_val & 0x07);
-  MLOG(MDEBUG) << "EncodePDUSessionTypeMsg: type_val = " << hex
-               << int(*(buffer)) << endl;
+  MLOG(MDEBUG) << "EncodePDUSessionTypeMsg: type_val = " << std::hex
+               << int(*(buffer)) << std::endl;
   encoded++;
 
   return (encoded);

--- a/lte/gateway/c/core/oai/tasks/nas5g/src/ies/M5GPTI.cpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/src/ies/M5GPTI.cpp
@@ -14,7 +14,6 @@
 #include "M5GPTI.h"
 #include "M5GCommonDefs.h"
 
-using namespace std;
 namespace magma5g {
 PTIMsg::PTIMsg(){};
 PTIMsg::~PTIMsg(){};
@@ -27,7 +26,7 @@ int PTIMsg::DecodePTIMsg(
   MLOG(MDEBUG) << " DecodePTIMsg : ";
   pti->pti = *(buffer + decoded);
   decoded++;
-  MLOG(MDEBUG) << " PTI = 0x" << hex << int(pti->pti);
+  MLOG(MDEBUG) << " PTI = 0x" << std::hex << int(pti->pti);
 
   return (decoded);
 };
@@ -39,7 +38,7 @@ int PTIMsg::EncodePTIMsg(
 
   MLOG(MDEBUG) << " EncodePTIMsg : ";
   *(buffer + encoded) = pti->pti;
-  MLOG(MDEBUG) << "PTI = 0x" << hex << int(*(buffer + encoded));
+  MLOG(MDEBUG) << "PTI = 0x" << std::hex << int(*(buffer + encoded));
   encoded++;
 
   return (encoded);

--- a/lte/gateway/c/core/oai/tasks/nas5g/src/ies/M5GPayloadContainer.cpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/src/ies/M5GPayloadContainer.cpp
@@ -27,7 +27,7 @@ int PayloadContainerMsg::DecodePayloadContainerMsg(
   uint32_t ielen = 0;
   IES_DECODE_U16(buffer, decoded, ielen);
   payload_container->len = ielen;
-  MLOG(MDEBUG) << "DecodePayloadContainerMsg__: len = " << std::dec 
+  MLOG(MDEBUG) << "DecodePayloadContainerMsg__: len = " << std::dec
                << int(payload_container->len) << std::endl;
   memcpy(&payload_container->contents, buffer + decoded, int(ielen));
   BUFFER_PRINT_LOG(payload_container->contents, int(ielen));
@@ -48,8 +48,8 @@ int PayloadContainerMsg::EncodePayloadContainerMsg(
   ielen          = payload_container->len;
 
   IES_ENCODE_U16(buffer, encoded, ielen);
-  MLOG(MDEBUG) << "DecodePayloadContainerMsg__: len = " << std::hex << int(ielen)
-               << std::endl;
+  MLOG(MDEBUG) << "DecodePayloadContainerMsg__: len = " << std::hex
+               << int(ielen) << std::endl;
   tmp = encoded;
 
   // SMF NAS Message Decode

--- a/lte/gateway/c/core/oai/tasks/nas5g/src/ies/M5GPayloadContainer.cpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/src/ies/M5GPayloadContainer.cpp
@@ -16,7 +16,6 @@
 #include "M5GPayloadContainer.h"
 #include "M5GCommonDefs.h"
 
-using namespace std;
 namespace magma5g {
 PayloadContainerMsg::PayloadContainerMsg(){};
 PayloadContainerMsg::~PayloadContainerMsg(){};
@@ -28,8 +27,8 @@ int PayloadContainerMsg::DecodePayloadContainerMsg(
   uint32_t ielen = 0;
   IES_DECODE_U16(buffer, decoded, ielen);
   payload_container->len = ielen;
-  MLOG(MDEBUG) << "DecodePayloadContainerMsg__: len = " << dec
-               << int(payload_container->len) << endl;
+  MLOG(MDEBUG) << "DecodePayloadContainerMsg__: len = " << std::dec 
+               << int(payload_container->len) << std::endl;
   memcpy(&payload_container->contents, buffer + decoded, int(ielen));
   BUFFER_PRINT_LOG(payload_container->contents, int(ielen));
 
@@ -48,8 +47,10 @@ int PayloadContainerMsg::EncodePayloadContainerMsg(
   int tmp        = 0;
   ielen          = payload_container->len;
 
-  MLOG(MDEBUG) << "EncodePayloadContainerMsg__: len = " << hex << int(ielen)
-               << endl;
+  IES_ENCODE_U16(buffer, encoded, ielen);
+  MLOG(MDEBUG) << "DecodePayloadContainerMsg__: len = " << std::hex << int(ielen)
+               << std::endl;
+  tmp = encoded;
 
   // SMF NAS Message Decode
   encoded += payload_container->smf_msg.SmfMsgEncodeMsg(

--- a/lte/gateway/c/core/oai/tasks/nas5g/src/ies/M5GPayloadContainerType.cpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/src/ies/M5GPayloadContainerType.cpp
@@ -16,7 +16,6 @@
 #include "M5GPayloadContainerType.h"
 #include "M5GCommonDefs.h"
 
-using namespace std;
 namespace magma5g {
 PayloadContainerTypeMsg::PayloadContainerTypeMsg(){};
 PayloadContainerTypeMsg::~PayloadContainerTypeMsg(){};
@@ -29,8 +28,8 @@ int PayloadContainerTypeMsg::DecodePayloadContainerTypeMsg(
 
   payload_container_type->type_val = (*buffer & 0x0f);
   decoded++;
-  MLOG(MDEBUG) << "DecodePayloadContainerTypeMsg__: type_val = " << hex
-               << int(payload_container_type->type_val) << endl;
+  MLOG(MDEBUG) << "DecodePayloadContainerTypeMsg__: type_val = " << std::hex
+               << int(payload_container_type->type_val) << std::endl;
 
   return (decoded);
 };
@@ -42,8 +41,8 @@ int PayloadContainerTypeMsg::EncodePayloadContainerTypeMsg(
   int encoded = 0;
 
   *buffer = payload_container_type->type_val & 0x0f;
-  MLOG(MDEBUG) << "DecodePayloadContainerTypeMsg__: type_val = " << hex
-               << int(*buffer) << endl;
+  MLOG(MDEBUG) << "DecodePayloadContainerTypeMsg__: type_val = " << std::hex
+               << int(*buffer) << std::endl;
   encoded++;
 
   return (encoded);

--- a/lte/gateway/c/core/oai/tasks/nas5g/src/ies/M5GProtocolConfigurationOptions.cpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/src/ies/M5GProtocolConfigurationOptions.cpp
@@ -17,7 +17,6 @@
 #include "M5GCommonDefs.h"
 #include "M5gNasMessage.h"
 
-using namespace std;
 namespace magma5g {
 ProtocolConfigurationOptions::ProtocolConfigurationOptions() {}
 ProtocolConfigurationOptions::~ProtocolConfigurationOptions() {}

--- a/lte/gateway/c/core/oai/tasks/nas5g/src/ies/M5GQOSRules.cpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/src/ies/M5GQOSRules.cpp
@@ -15,7 +15,6 @@
 #include "M5GQOSRules.h"
 #include "M5GCommonDefs.h"
 
-using namespace std;
 namespace magma5g {
 NewQOSRulePktFilter::NewQOSRulePktFilter(){};
 NewQOSRulePktFilter::~NewQOSRulePktFilter(){};
@@ -44,22 +43,22 @@ int QOSRulesMsg::EncodeQOSRulesMsg(
   if (iei > 0) {
     CHECK_IEI_ENCODER((unsigned char) iei, qos_rules->iei);
     *buffer = iei;
-    MLOG(MDEBUG) << "In EncodeQOSRulesMsg: iei" << hex << int(*buffer);
+    MLOG(MDEBUG) << "In EncodeQOSRulesMsg: iei" << std::hex << int(*buffer);
     encoded++;
   }
 
   IES_ENCODE_U16(buffer, encoded, qos_rules->length);
-  MLOG(MDEBUG) << "Length : " << hex << int(qos_rules->length);
+  MLOG(MDEBUG) << "Length : " << std::hex << int(qos_rules->length);
   while (encoded < (qos_rules->length) && i <= 255) {
     *(buffer + encoded) = qos_rules->qos_rule[i].qos_rule_id;
-    MLOG(MDEBUG) << "qos_rule_id: " << hex << int(*(buffer + encoded));
+    MLOG(MDEBUG) << "qos_rule_id: " << std::hex << int(*(buffer + encoded));
     encoded++;
     IES_ENCODE_U16(buffer, encoded, qos_rules->qos_rule[i].len);
     *(buffer + encoded) =
         0x00 | ((qos_rules->qos_rule[i].rule_oper_code & 0x07) << 5) |
         ((qos_rules->qos_rule[i].dqr_bit & 0x01) << 4) |
         (qos_rules->qos_rule[i].no_of_pkt_filters & 0x0f);
-    MLOG(MDEBUG) << "rule_oper_code, dqr_bit, no_of_pkt_filters: " << hex
+    MLOG(MDEBUG) << "rule_oper_code, dqr_bit, no_of_pkt_filters: " << std::hex
                  << int(*(buffer + encoded));
     encoded++;
     for (j = 0; j < qos_rules->qos_rule[i].no_of_pkt_filters; j++) {
@@ -72,12 +71,12 @@ int QOSRulesMsg::EncodeQOSRulesMsg(
            << 4) |
           (qos_rules->qos_rule[i].new_qos_rule_pkt_filter[j].pkt_filter_id &
            0x0f);
-      MLOG(MDEBUG) << "pkt_filter_dir, pkt_filter_id: " << hex
+      MLOG(MDEBUG) << "pkt_filter_dir, pkt_filter_id: " << std::hex
                    << int(*(buffer + encoded));
       encoded++;
       *(buffer + encoded) =
           qos_rules->qos_rule[i].new_qos_rule_pkt_filter[j].len;
-      MLOG(MDEBUG) << "len: " << hex << int(*(buffer + encoded));
+      MLOG(MDEBUG) << "len: " << std::hex << int(*(buffer + encoded));
       encoded++;
       memcpy(
           buffer + encoded,
@@ -90,12 +89,12 @@ int QOSRulesMsg::EncodeQOSRulesMsg(
     }
 
     *(buffer + encoded) = qos_rules->qos_rule[i].qos_rule_precedence;
-    MLOG(MDEBUG) << "qos_rule_precedence: " << hex << int(*(buffer + encoded));
+    MLOG(MDEBUG) << "qos_rule_precedence: " << std::hex << int(*(buffer + encoded));
     encoded++;
     *(buffer + encoded) = 0x00 | ((qos_rules->qos_rule[i].spare & 0x01) << 7) |
                           ((qos_rules->qos_rule[i].segregation & 0x01) << 6) |
                           (qos_rules->qos_rule[i].qfi & 0x3f);
-    MLOG(MDEBUG) << "segregation, qfi: " << hex << int(*(buffer + encoded));
+    MLOG(MDEBUG) << "segregation, qfi: " << std::hex << int(*(buffer + encoded));
     encoded++;
     i++;
   }

--- a/lte/gateway/c/core/oai/tasks/nas5g/src/ies/M5GQOSRules.cpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/src/ies/M5GQOSRules.cpp
@@ -89,12 +89,14 @@ int QOSRulesMsg::EncodeQOSRulesMsg(
     }
 
     *(buffer + encoded) = qos_rules->qos_rule[i].qos_rule_precedence;
-    MLOG(MDEBUG) << "qos_rule_precedence: " << std::hex << int(*(buffer + encoded));
+    MLOG(MDEBUG) << "qos_rule_precedence: " << std::hex
+                 << int(*(buffer + encoded));
     encoded++;
     *(buffer + encoded) = 0x00 | ((qos_rules->qos_rule[i].spare & 0x01) << 7) |
                           ((qos_rules->qos_rule[i].segregation & 0x01) << 6) |
                           (qos_rules->qos_rule[i].qfi & 0x3f);
-    MLOG(MDEBUG) << "segregation, qfi: " << std::hex << int(*(buffer + encoded));
+    MLOG(MDEBUG) << "segregation, qfi: " << std::hex
+                 << int(*(buffer + encoded));
     encoded++;
     i++;
   }

--- a/lte/gateway/c/core/oai/tasks/nas5g/src/ies/M5GSDeRegistrationType.cpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/src/ies/M5GSDeRegistrationType.cpp
@@ -27,11 +27,12 @@ int M5GSDeRegistrationTypeMsg::DecodeM5GSDeRegistrationTypeMsg(
   de_reg_type->switchoff       = (*(buffer + decoded) >> 3) & 0x01;
   de_reg_type->re_reg_required = (*(buffer + decoded) >> 2) & 0x01;
   de_reg_type->access_type     = *(buffer + decoded) & 0x03;
-  MLOG(MDEBUG) << "DecodeM5GSDe-RegistrationType : \n   switchoff = " << std::hex
-               << int(de_reg_type->switchoff);
+  MLOG(MDEBUG) << "DecodeM5GSDe-RegistrationType : \n   switchoff = "
+               << std::hex << int(de_reg_type->switchoff);
   MLOG(MDEBUG) << "   re_reg_required = " << std::hex
                << int(de_reg_type->re_reg_required);
-  MLOG(MDEBUG) << "   access_type = " << std::hex << int(de_reg_type->access_type);
+  MLOG(MDEBUG) << "   access_type = " << std::hex
+               << int(de_reg_type->access_type);
   return (decoded);
 };
 

--- a/lte/gateway/c/core/oai/tasks/nas5g/src/ies/M5GSDeRegistrationType.cpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/src/ies/M5GSDeRegistrationType.cpp
@@ -15,7 +15,6 @@ limitations under the License.
 #include "M5GSDeRegistrationType.h"
 #include "M5GCommonDefs.h"
 
-using namespace std;
 namespace magma5g {
 M5GSDeRegistrationTypeMsg::M5GSDeRegistrationTypeMsg(){};
 M5GSDeRegistrationTypeMsg::~M5GSDeRegistrationTypeMsg(){};
@@ -28,11 +27,11 @@ int M5GSDeRegistrationTypeMsg::DecodeM5GSDeRegistrationTypeMsg(
   de_reg_type->switchoff       = (*(buffer + decoded) >> 3) & 0x01;
   de_reg_type->re_reg_required = (*(buffer + decoded) >> 2) & 0x01;
   de_reg_type->access_type     = *(buffer + decoded) & 0x03;
-  MLOG(MDEBUG) << "DecodeM5GSDe-RegistrationType : \n   switchoff = " << hex
+  MLOG(MDEBUG) << "DecodeM5GSDe-RegistrationType : \n   switchoff = " << std::hex
                << int(de_reg_type->switchoff);
-  MLOG(MDEBUG) << "   re_reg_required = " << hex
+  MLOG(MDEBUG) << "   re_reg_required = " << std::hex
                << int(de_reg_type->re_reg_required);
-  MLOG(MDEBUG) << "   access_type = " << hex << int(de_reg_type->access_type);
+  MLOG(MDEBUG) << "   access_type = " << std::hex << int(de_reg_type->access_type);
   return (decoded);
 };
 
@@ -46,7 +45,7 @@ int M5GSDeRegistrationTypeMsg::EncodeM5GSDeRegistrationTypeMsg(
                         (de_reg_type->access_type & 0x03);
   encoded++;
   MLOG(MDEBUG) << "In EncodeM5GSDeRegistrationTypeMsg___: DeRegistrationType= "
-               << hex << int(*(buffer + encoded));
+               << std::hex << int(*(buffer + encoded));
   return (encoded);
 };
 }  // namespace magma5g

--- a/lte/gateway/c/core/oai/tasks/nas5g/src/ies/M5GSIdentityType.cpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/src/ies/M5GSIdentityType.cpp
@@ -14,7 +14,6 @@
 #include "M5GSIdentityType.h"
 #include "M5GCommonDefs.h"
 
-using namespace std;
 namespace magma5g {
 M5GSIdentityTypeMsg::M5GSIdentityTypeMsg(){};
 M5GSIdentityTypeMsg::~M5GSIdentityTypeMsg(){};
@@ -28,7 +27,7 @@ int M5GSIdentityTypeMsg::DecodeM5GSIdentityTypeMsg(
   MLOG(MDEBUG) << "   DecodeM5GSIdentityTypeMsg : ";
   m5gs_identity_type->toi = *(buffer + decoded) & 0x7;
   decoded++;
-  MLOG(MDEBUG) << " Type of Identity = " << dec << int(m5gs_identity_type->toi);
+  MLOG(MDEBUG) << " Type of Identity = " << std::dec << int(m5gs_identity_type->toi);
   return (decoded);
 };
 
@@ -40,7 +39,7 @@ int M5GSIdentityTypeMsg::EncodeM5GSIdentityTypeMsg(
 
   MLOG(MDEBUG) << " EncodeM5GSIdentityTypeMsg : ";
   *(buffer + encoded) = (m5gs_identity_type->toi) & 0x7;
-  MLOG(MDEBUG) << " Type of identity = 0x" << hex << int(*(buffer + encoded));
+  MLOG(MDEBUG) << " Type of identity = 0x" << std::hex << int(*(buffer + encoded));
   encoded++;
   return (encoded);
 };

--- a/lte/gateway/c/core/oai/tasks/nas5g/src/ies/M5GSIdentityType.cpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/src/ies/M5GSIdentityType.cpp
@@ -27,7 +27,8 @@ int M5GSIdentityTypeMsg::DecodeM5GSIdentityTypeMsg(
   MLOG(MDEBUG) << "   DecodeM5GSIdentityTypeMsg : ";
   m5gs_identity_type->toi = *(buffer + decoded) & 0x7;
   decoded++;
-  MLOG(MDEBUG) << " Type of Identity = " << std::dec << int(m5gs_identity_type->toi);
+  MLOG(MDEBUG) << " Type of Identity = " << std::dec
+               << int(m5gs_identity_type->toi);
   return (decoded);
 };
 
@@ -39,7 +40,8 @@ int M5GSIdentityTypeMsg::EncodeM5GSIdentityTypeMsg(
 
   MLOG(MDEBUG) << " EncodeM5GSIdentityTypeMsg : ";
   *(buffer + encoded) = (m5gs_identity_type->toi) & 0x7;
-  MLOG(MDEBUG) << " Type of identity = 0x" << std::hex << int(*(buffer + encoded));
+  MLOG(MDEBUG) << " Type of identity = 0x" << std::hex
+               << int(*(buffer + encoded));
   encoded++;
   return (encoded);
 };

--- a/lte/gateway/c/core/oai/tasks/nas5g/src/ies/M5GSMCause.cpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/src/ies/M5GSMCause.cpp
@@ -16,7 +16,6 @@ limitations under the License.
 #include "M5GSMCause.h"
 #include "M5GCommonDefs.h"
 
-using namespace std;
 namespace magma5g {
 M5GSMCauseMsg::M5GSMCauseMsg(){};
 M5GSMCauseMsg::~M5GSMCauseMsg(){};
@@ -34,10 +33,10 @@ int M5GSMCauseMsg::DecodeM5GSMCauseMsg(
 
   m5gsm_cause->cause_value = *buffer;
   decoded++;
-  MLOG(MDEBUG) << "DecodeM5GSMCauseMsg__: iei = " << hex
-               << int(m5gsm_cause->iei) << endl;
-  MLOG(MDEBUG) << "DecodeM5GSMCauseMsg__: cause_value = " << hex
-               << int(m5gsm_cause->cause_value) << endl;
+  MLOG(MDEBUG) << "DecodeM5GSMCauseMsg__: iei = " << std::hex
+               << int(m5gsm_cause->iei) << std::endl;
+  MLOG(MDEBUG) << "DecodeM5GSMCauseMsg__: cause_value = " << std::hex
+               << int(m5gsm_cause->cause_value) << std::endl;
 
   return (decoded);
 };
@@ -56,8 +55,8 @@ int M5GSMCauseMsg::EncodeM5GSMCauseMsg(
 
   *(buffer + encoded) = m5gsm_cause->cause_value;
   encoded++;
-  MLOG(MDEBUG) << "EncodeM5GSMCauseMsg__: cause_value = " << hex
-               << int(m5gsm_cause->cause_value) << endl;
+  MLOG(MDEBUG) << "EncodeM5GSMCauseMsg__: cause_value = " << std::hex
+               << int(m5gsm_cause->cause_value) << std::endl;
 
   return (encoded);
 };

--- a/lte/gateway/c/core/oai/tasks/nas5g/src/ies/M5GSMobileIdentity.cpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/src/ies/M5GSMobileIdentity.cpp
@@ -17,7 +17,6 @@
 #include "M5GSMobileIdentity.h"
 #include "M5GCommonDefs.h"
 
-using namespace std;
 namespace magma5g {
 M5GSMobileIdentityMsg::M5GSMobileIdentityMsg(){};
 M5GSMobileIdentityMsg::~M5GSMobileIdentityMsg(){};
@@ -83,22 +82,22 @@ int M5GSMobileIdentityMsg::DecodeGutiMobileIdentityMsg(
   decoded++;
   guti->tmsi4 = *(buffer + decoded);
   decoded++;
-  MLOG(MDEBUG) << "   Odd/Even Indecation = " << dec << int(guti->odd_even)
+  MLOG(MDEBUG) << "   Odd/Even Indecation = " << std::dec << int(guti->odd_even)
                << "\n";
-  MLOG(MDEBUG) << "   Mobile Country Code (MCC) = " << dec
-               << int(guti->mcc_digit1) << dec << int(guti->mcc_digit2) << dec
+  MLOG(MDEBUG) << "   Mobile Country Code (MCC) = " << std::dec 
+               << int(guti->mcc_digit1) << std::dec << int(guti->mcc_digit2) << std::dec 
                << int(guti->mcc_digit3) << "\n";
-  MLOG(MDEBUG) << "   Mobile Network Code (MNC) = " << dec
-               << int(guti->mnc_digit1) << dec << int(guti->mnc_digit2) << dec
+  MLOG(MDEBUG) << "   Mobile Network Code (MNC) = " << std::dec 
+               << int(guti->mnc_digit1) << std::dec << int(guti->mnc_digit2) << std::dec 
                << int(guti->mnc_digit3) << "\n";
-  MLOG(MDEBUG) << "   Amf Region ID = " << dec << int(guti->amf_regionid)
+  MLOG(MDEBUG) << "   Amf Region ID = " << std::dec << int(guti->amf_regionid)
                << "\n";
-  MLOG(MDEBUG) << "   Amf Set ID = " << dec << int(guti->amf_setid) << "\n";
-  MLOG(MDEBUG) << "   Amf Pointer = " << dec << int(guti->amf_pointer) << "\n";
+  MLOG(MDEBUG) << "   Amf Set ID = " << std::dec << int(guti->amf_setid) << "\n";
+  MLOG(MDEBUG) << "   Amf Pointer = " << std::dec << int(guti->amf_pointer) << "\n";
   MLOG(MDEUBG) << "   M5G-TMSI = "
-               << "0x0" << hex << int(guti->tmsi1) << "0" << hex
-               << int(guti->tmsi2) << "0" << hex << int(guti->tmsi3) << "0"
-               << hex << int(guti->tmsi4) << "\n\n";
+               << "0x0" << std::hex << int(guti->tmsi1) << "0" << std::hex
+               << int(guti->tmsi2) << "0" << std::hex << int(guti->tmsi3) << "0"
+               << std::hex << int(guti->tmsi4) << "\n\n";
   return (decoded);
 }
 
@@ -128,10 +127,10 @@ int M5GSMobileIdentityMsg::DecodeImeiMobileIdentityMsg(
   imei->identity_digit3 = (*(buffer + decoded) >> 4) & 0xf;
   imei->identity_digit2 = *(buffer + decoded) & 0xf;
   decoded++;
-  MLOG(MDEBUG) << "  odd_even = " << hex << int(imei->odd_even) << "\n";
-  MLOG(MDEBUG) << "  digit1 = " << hex << int(imei->identity_digit1) << "\n";
-  MLOG(MDEBUG) << "  digit2 = " << hex << int(imei->identity_digit2) << "\n";
-  MLOG(MDEBUG) << "  digit3 = " << hex << int(imei->identity_digit3) << "\n";
+  MLOG(MDEBUG) << "  odd_even = " << std::hex << int(imei->odd_even) << "\n";
+  MLOG(MDEBUG) << "  digit1 = " << std::hex << int(imei->identity_digit1) << "\n";
+  MLOG(MDEBUG) << "  digit2 = " << std::hex << int(imei->identity_digit2) << "\n";
+  MLOG(MDEBUG) << "  digit3 = " << std::hex << int(imei->identity_digit3) << "\n";
 
   return (decoded);
 };
@@ -196,34 +195,34 @@ int M5GSMobileIdentityMsg::DecodeImsiMobileIdentityMsg(
   // TODO
   /* Scheme output (octets 12 to x)
      The Scheme output field consists of a string of characters with a variable
-     length or hexadecimal digits as specified in 3GPP TS 23.003 [4]. If
+     length or std::hexadecimal digits as specified in 3GPP TS 23.003 [4]. If
      Protection scheme identifier is set to "0000" (i.e. Null scheme), then the
      Scheme output consists of the MSIN and is coded using BCD coding with each
      digit of the MSIN coded over 4 bits. If the MSIN includes an odd number of
      digits, bits 5 to 8 of octet x shall be coded as "1111". If Protection
      scheme identifier is not "0000" (i.e. ECIES scheme profile A, ECIES scheme
      profile B or Operator-specific protection scheme), then Scheme output is
-     coded as hexadecimal digits
+     coded as std::hexadecimal digits
   */
 
   int tmp = ielen - decoded;
   decoded = ielen;
 
-  MLOG(MDEBUG) << "  Spare = " << hex << int(imsi->spare2);
-  MLOG(MDEBUG) << "  Supi Format = " << hex << int(imsi->supi_format);
-  MLOG(MDEBUG) << "  Spare = " << hex << int(imsi->spare1);
-  MLOG(MDEBUG) << "  Type of Identity = " << hex << int(imsi->type_of_identity);
-  MLOG(MDEBUG) << "  Mobile Country Code (MCC) = " << dec
-               << int(imsi->mcc_digit1) << dec << int(imsi->mcc_digit2) << dec
+  MLOG(MDEBUG) << "  Spare = " << std::hex << int(imsi->spare2);
+  MLOG(MDEBUG) << "  Supi Format = " << std::hex << int(imsi->supi_format);
+  MLOG(MDEBUG) << "  Spare = " << std::hex << int(imsi->spare1);
+  MLOG(MDEBUG) << "  Type of Identity = " << std::hex << int(imsi->type_of_identity);
+  MLOG(MDEBUG) << "  Mobile Country Code (MCC) = " << std::dec 
+               << int(imsi->mcc_digit1) << std::dec << int(imsi->mcc_digit2) << std::dec 
                << int(imsi->mcc_digit3);
-  MLOG(MDEBUG) << "  Mobile Network Code (MNC) = " << dec
-               << int(imsi->mnc_digit1) << dec << int(imsi->mnc_digit2) << dec
+  MLOG(MDEBUG) << "  Mobile Network Code (MNC) = " << std::dec 
+               << int(imsi->mnc_digit1) << std::dec << int(imsi->mnc_digit2) << std::dec 
                << int(imsi->mnc_digit3);
-  MLOG(MDEBUG) << "  Routing Indicator = " << hex
+  MLOG(MDEBUG) << "  Routing Indicator = " << std::hex
                << int(imsi->rout_ind_digit_1);
-  MLOG(MDEBUG) << "  Protection Scheme ID = " << hex
+  MLOG(MDEBUG) << "  Protection Scheme ID = " << std::hex
                << int(imsi->protect_schm_id);
-  MLOG(MDEBUG) << "  Home Network Public Key Identifier = " << hex
+  MLOG(MDEBUG) << "  Home Network Public Key Identifier = " << std::hex
                << int(imsi->home_nw_id);
   MLOG(MDEBUG) << "  Scheme Output = ";
   BUFFER_PRINT_LOG(imsi->scheme_output, tmp)
@@ -300,18 +299,18 @@ int M5GSMobileIdentityMsg::DecodeTmsiMobileIdentityMsg(
 #endif
   int tmp = ielen - decoded;
   decoded = ielen;
-  MLOG(MDEBUG) << "  spare2 = " << dec << int(tmsi->spare);
-  MLOG(MDEBUG) << "  odd_even = " << dec << int(tmsi->odd_even);
-  MLOG(MDEBUG) << "  type_of_identity = " << dec << int(tmsi->type_of_identity);
-  MLOG(MDEBUG) << "  amf_setid = " << dec << int(tmsi->amf_setid);
-  MLOG(MDEBUG) << "  amf_pointer = " << dec << int(tmsi->amf_pointer);
+  MLOG(MDEBUG) << "  spare2 = " << std::dec << int(tmsi->spare);
+  MLOG(MDEBUG) << "  odd_even = " << std::dec << int(tmsi->odd_even);
+  MLOG(MDEBUG) << "  type_of_identity = " << std::dec << int(tmsi->type_of_identity);
+  MLOG(MDEBUG) << "  amf_setid = " << std::dec << int(tmsi->amf_setid);
+  MLOG(MDEBUG) << "  amf_pointer = " << std::dec << int(tmsi->amf_pointer);
   MLOG(MDEBUG) << "  M5G TMSI = ";
   BUFFER_PRINT_LOG(tmsi->m5g_tmsi, tmp)
 #if 0
-  MLOG(MDEBUG) << "  m5g_tmsi_1 = " << dec << int(tmsi->m5g_tmsi_1);
-  MLOG(MDEBUG) << "  m5g_tmsi_2 = " << dec << int(tmsi->m5g_tmsi_2);
-  MLOG(MDEBUG) << "  m5g_tmsi_3 = " << dec << int(tmsi->m5g_tmsi_3);
-  MLOG(MDEBUG) << "  m5g_tmsi_4 = " << dec << int(tmsi->m5g_tmsi_4);
+  MLOG(MDEBUG) << "  m5g_tmsi_1 = " << std::dec << int(tmsi->m5g_tmsi_1);
+  MLOG(MDEBUG) << "  m5g_tmsi_2 = " << std::dec << int(tmsi->m5g_tmsi_2);
+  MLOG(MDEBUG) << "  m5g_tmsi_3 = " << std::dec << int(tmsi->m5g_tmsi_3);
+  MLOG(MDEBUG) << "  m5g_tmsi_4 = " << std::dec << int(tmsi->m5g_tmsi_4);
 #endif
   return (decoded);
 };
@@ -333,8 +332,8 @@ int M5GSMobileIdentityMsg::DecodeM5GSMobileIdentityMsg(
   IES_DECODE_U16(buffer, decoded, ielen);
   CHECK_LENGTH_DECODER(len - decoded, ielen);
   unsigned char type_of_identity = *(buffer + decoded) & 0x7;
-  MLOG(MDEBUG) << " Length = " << dec << int(ielen)
-               << " Type of Identity = " << dec << int(type_of_identity);
+  MLOG(MDEBUG) << " Length = " << std::dec << int(ielen)
+               << " Type of Identity = " << std::dec << int(type_of_identity);
 
   if (type_of_identity == M5GSMobileIdentityMsg_IMEISV) {
     MLOG(MDEBUG) << " Type suci";
@@ -373,45 +372,45 @@ int M5GSMobileIdentityMsg::EncodeGutiMobileIdentityMsg(
   MLOG(MDEBUG) << "EncodeGutiMobileIdentityMsg:";
   *(buffer + encoded) =
       0xf0 | ((guti->odd_even & 0x01) << 3) | (guti->type_of_identity & 0x7);
-  MLOG(MDEBUG) << "odd_even type_of_identity = " << hex
+  MLOG(MDEBUG) << "odd_even type_of_identity = " << std::hex
                << int(*(buffer + encoded));
   encoded++;
   *(buffer + encoded) =
       0x00 | ((guti->mcc_digit2 & 0x0f) << 4) | (guti->mcc_digit1 & 0x0f);
-  MLOG(MDEBUG) << "mcc_digit2 >mcc_digit1 type_of_identity = " << hex
+  MLOG(MDEBUG) << "mcc_digit2 >mcc_digit1 type_of_identity = " << std::hex
                << int(*(buffer + encoded));
   encoded++;
   *(buffer + encoded) =
       0x00 | ((guti->mnc_digit3 & 0x0f) << 4) | (guti->mcc_digit3 & 0x0f);
-  MLOG(MDEBUG) << "mnc_digit3 >mcc_digit3 type_of_identity = " << hex
+  MLOG(MDEBUG) << "mnc_digit3 >mcc_digit3 type_of_identity = " << std::hex
                << int(*(buffer + encoded));
   encoded++;
   *(buffer + encoded) =
       0x00 | ((guti->mnc_digit2 & 0x0f) << 4) | (guti->mnc_digit1 & 0x0f);
-  MLOG(MDEBUG) << "mnc_digit2 >mcc_digit1 type_of_identity = " << hex
+  MLOG(MDEBUG) << "mnc_digit2 >mcc_digit1 type_of_identity = " << std::hex
                << int(*(buffer + encoded));
   encoded++;
   *(buffer + encoded) = 0x00 | guti->amf_regionid;
-  MLOG(MDEBUG) << "amf_regionid = " << hex << int(*(buffer + encoded));
+  MLOG(MDEBUG) << "amf_regionid = " << std::hex << int(*(buffer + encoded));
   encoded++;
   *(buffer + encoded) = 0x00 | ((guti->amf_setid >> 2) & 0xFF);
-  MLOG(MDEBUG) << "amf_setid = " << hex << int(*(buffer + encoded));
+  MLOG(MDEBUG) << "amf_setid = " << std::hex << int(*(buffer + encoded));
   encoded++;
   *(buffer + encoded) =
       0x00 | ((guti->amf_setid & 0xF3) << 6) | (guti->amf_pointer & 0x3f);
-  MLOG(MDEBUG) << "amf_setid amf_pointer = " << hex << int(*(buffer + encoded));
+  MLOG(MDEBUG) << "amf_setid amf_pointer = " << std::hex << int(*(buffer + encoded));
   encoded++;
   *(buffer + encoded) = 0x00 | guti->tmsi1;
-  MLOG(MDEBUG) << "tmsi1 = " << hex << int(*(buffer + encoded));
+  MLOG(MDEBUG) << "tmsi1 = " << std::hex << int(*(buffer + encoded));
   encoded++;
   *(buffer + encoded) = 0x00 | guti->tmsi2;
-  MLOG(MDEBUG) << "tmsi2 = " << hex << int(*(buffer + encoded));
+  MLOG(MDEBUG) << "tmsi2 = " << std::hex << int(*(buffer + encoded));
   encoded++;
   *(buffer + encoded) = 0x00 | guti->tmsi3;
-  MLOG(MDEBUG) << "tmsi3 = " << hex << int(*(buffer + encoded));
+  MLOG(MDEBUG) << "tmsi3 = " << std::hex << int(*(buffer + encoded));
   encoded++;
   *(buffer + encoded) = 0x00 | guti->tmsi4;
-  MLOG(MDEBUG) << "tmsi4 = " << hex << int(*(buffer + encoded));
+  MLOG(MDEBUG) << "tmsi4 = " << std::hex << int(*(buffer + encoded));
   encoded++;
 
   return encoded;
@@ -427,12 +426,12 @@ int M5GSMobileIdentityMsg::EncodeImeiMobileIdentityMsg(
   *(buffer + encoded) = 0x00 | ((imei->identity_digit1 & 0xf0) << 4) |
                         ((imei->odd_even & 0x1) << 3) |
                         (imei->type_of_identity & 0x7);
-  MLOG(MDEBUG) << "identity_digit1, odd_even, type_of_identity = " << hex
+  MLOG(MDEBUG) << "identity_digit1, odd_even, type_of_identity = " << std::hex
                << int(*(buffer + encoded));
   encoded++;
   *(buffer + encoded) = 0x00 | ((imei->identity_digit2 & 0xf0) << 4) |
                         (imei->identity_digit3 & 0x0f);
-  MLOG(MDEBUG) << "identity_digit2,identity_digit3 = " << hex
+  MLOG(MDEBUG) << "identity_digit2,identity_digit3 = " << std::hex
                << int(*(buffer + encoded));
   encoded++;
 
@@ -448,32 +447,32 @@ int M5GSMobileIdentityMsg::EncodeImsiMobileIdentityMsg(
   *(buffer + encoded) =
       0x00 | ((imsi->spare2 & 0x80) << 7) | ((imsi->supi_format & 0x07) << 4) |
       ((imsi->spare1 & 0x01) << 3) | (imsi->type_of_identity & 0x7);
-  MLOG(MDEBUG) << "  Spare,supi_format,spare1,type_of_identity = " << hex
+  MLOG(MDEBUG) << "  Spare,supi_format,spare1,type_of_identity = " << std::hex
                << int(*(buffer + encoded));
   encoded++;
   *(buffer + encoded) =
       0x00 | ((imsi->mcc_digit2 & 0x0f) << 4) | (imsi->mcc_digit1 & 0x0f);
-  MLOG(MDEBUG) << "  mcc_digit2,mcc_digit1 = " << hex
+  MLOG(MDEBUG) << "  mcc_digit2,mcc_digit1 = " << std::hex
                << int(*(buffer + encoded));
   encoded++;
   *(buffer + encoded) =
       0x00 | ((imsi->mnc_digit3 & 0x0f) << 4) | (imsi->mcc_digit3 & 0x0f);
-  MLOG(MDEBUG) << "  mnc_digit3,mcc_digit3 = " << hex
+  MLOG(MDEBUG) << "  mnc_digit3,mcc_digit3 = " << std::hex
                << int(*(buffer + encoded));
   encoded++;
   *(buffer + encoded) =
       0x00 | ((imsi->mnc_digit2 & 0x0f) << 4) | (imsi->mnc_digit1 & 0x0f);
-  MLOG(MDEBUG) << "  mnc_digit2, mnc_digit1 = " << hex
+  MLOG(MDEBUG) << "  mnc_digit2, mnc_digit1 = " << std::hex
                << int(*(buffer + encoded));
   encoded++;
   *(buffer + encoded) =
       0x00 | ((imsi->rout_ind_digit_2) << 4) | (imsi->rout_ind_digit_1);
-  MLOG(MDEBUG) << "  rout_ind_digit_2,rout_ind_digit_1 = " << hex
+  MLOG(MDEBUG) << "  rout_ind_digit_2,rout_ind_digit_1 = " << std::hex
                << int(*(buffer + encoded));
   encoded++;
   *(buffer + encoded) =
       0x00 | ((imsi->rout_ind_digit_3) << 4) | (imsi->rout_ind_digit_4);
-  MLOG(MDEBUG) << "  rout_ind_digit_3,rout_ind_digit_4 = " << hex
+  MLOG(MDEBUG) << "  rout_ind_digit_3,rout_ind_digit_4 = " << std::hex
                << int(*(buffer + encoded));
   encoded++;
   *(buffer + encoded) =
@@ -481,7 +480,7 @@ int M5GSMobileIdentityMsg::EncodeImsiMobileIdentityMsg(
       ((imsi->spare4 & 0x01) << 5) | ((imsi->spare3 & 0x01) << 4) |
       (imsi->protect_schm_id & 0x0f);
   *(buffer + encoded) = imsi->home_nw_id;
-  MLOG(MDEBUG) << "  spare,protect_schm_id = " << hex
+  MLOG(MDEBUG) << "  spare,protect_schm_id = " << std::hex
                << int(*(buffer + encoded));
   encoded++;
   // Will be supported POST MVC
@@ -490,7 +489,7 @@ int M5GSMobileIdentityMsg::EncodeImsiMobileIdentityMsg(
   MLOG(MDEBUG) << "  Scheme Output = ";
   BUFFER_PRINT_LOG(imsi->scheme_output, imsi->scheme_len);
   encoded = encoded + imsi->scheme_len;
-  MLOG(MDEBUG) << endl;
+  MLOG(MDEBUG) << std::endl;
 
   return encoded;
 };
@@ -535,12 +534,12 @@ int M5GSMobileIdentityMsg::EncodeSuciMobileIdentityMsg(
   encoded++;
   suci->suci_nai.assign(
       (const char*) (buffer + encoded), suci->suci_nai.size());
-  MLOG(MDEBUG) << "ielen = " << hex << (unsigned char) suci->suci_nai.size();
+  MLOG(MDEBUG) << "ielen = " << std::hex << (unsigned char) suci->suci_nai.size();
   MLOG(MDEBUG) << "contents";
   for (uint32_t i = 0; i < suci->suci_nai.size(); i++) {
-    MLOG(MDEBUG) << hex << int(suci->suci_nai[i]);
+    MLOG(MDEBUG) << std::hex << int(suci->suci_nai[i]);
   }
-  MLOG(MDEBUG) << endl;
+  MLOG(MDEBUG) << std::endl;
 
   return encoded;
 };
@@ -560,7 +559,7 @@ int M5GSMobileIdentityMsg::EncodeM5GSMobileIdentityMsg(
     MLOG(MDEBUG) << "EncodeM5GSMobileIdentityMsg:";
     CHECK_IEI_ENCODER((unsigned char) iei, m5gs_mobile_identity->iei);
     *buffer = iei;
-    MLOG(MDEBUG) << "iei" << hex << int(*buffer);
+    MLOG(MDEBUG) << "iei" << std::hex << int(*buffer);
     encoded++;
   } else
     return 0;

--- a/lte/gateway/c/core/oai/tasks/nas5g/src/ies/M5GSMobileIdentity.cpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/src/ies/M5GSMobileIdentity.cpp
@@ -82,18 +82,20 @@ int M5GSMobileIdentityMsg::DecodeGutiMobileIdentityMsg(
   decoded++;
   guti->tmsi4 = *(buffer + decoded);
   decoded++;
-  MLOG(MDEBUG) << "   Odd/Even Indecation = " << std::dec << int(guti->odd_even)
+  MLOG(MDEBUG) << "   Odd/Even Indication = " << std::dec << int(guti->odd_even)
                << "\n";
-  MLOG(MDEBUG) << "   Mobile Country Code (MCC) = " << std::dec 
-               << int(guti->mcc_digit1) << std::dec << int(guti->mcc_digit2) << std::dec 
-               << int(guti->mcc_digit3) << "\n";
-  MLOG(MDEBUG) << "   Mobile Network Code (MNC) = " << std::dec 
-               << int(guti->mnc_digit1) << std::dec << int(guti->mnc_digit2) << std::dec 
-               << int(guti->mnc_digit3) << "\n";
+  MLOG(MDEBUG) << "   Mobile Country Code (MCC) = " << std::dec
+               << int(guti->mcc_digit1) << std::dec << int(guti->mcc_digit2)
+               << std::dec << int(guti->mcc_digit3) << "\n";
+  MLOG(MDEBUG) << "   Mobile Network Code (MNC) = " << std::dec
+               << int(guti->mnc_digit1) << std::dec << int(guti->mnc_digit2)
+               << std::dec << int(guti->mnc_digit3) << "\n";
   MLOG(MDEBUG) << "   Amf Region ID = " << std::dec << int(guti->amf_regionid)
                << "\n";
-  MLOG(MDEBUG) << "   Amf Set ID = " << std::dec << int(guti->amf_setid) << "\n";
-  MLOG(MDEBUG) << "   Amf Pointer = " << std::dec << int(guti->amf_pointer) << "\n";
+  MLOG(MDEBUG) << "   Amf Set ID = " << std::dec << int(guti->amf_setid)
+               << "\n";
+  MLOG(MDEBUG) << "   Amf Pointer = " << std::dec << int(guti->amf_pointer)
+               << "\n";
   MLOG(MDEUBG) << "   M5G-TMSI = "
                << "0x0" << std::hex << int(guti->tmsi1) << "0" << std::hex
                << int(guti->tmsi2) << "0" << std::hex << int(guti->tmsi3) << "0"
@@ -128,9 +130,12 @@ int M5GSMobileIdentityMsg::DecodeImeiMobileIdentityMsg(
   imei->identity_digit2 = *(buffer + decoded) & 0xf;
   decoded++;
   MLOG(MDEBUG) << "  odd_even = " << std::hex << int(imei->odd_even) << "\n";
-  MLOG(MDEBUG) << "  digit1 = " << std::hex << int(imei->identity_digit1) << "\n";
-  MLOG(MDEBUG) << "  digit2 = " << std::hex << int(imei->identity_digit2) << "\n";
-  MLOG(MDEBUG) << "  digit3 = " << std::hex << int(imei->identity_digit3) << "\n";
+  MLOG(MDEBUG) << "  digit1 = " << std::hex << int(imei->identity_digit1)
+               << "\n";
+  MLOG(MDEBUG) << "  digit2 = " << std::hex << int(imei->identity_digit2)
+               << "\n";
+  MLOG(MDEBUG) << "  digit3 = " << std::hex << int(imei->identity_digit3)
+               << "\n";
 
   return (decoded);
 };
@@ -211,13 +216,14 @@ int M5GSMobileIdentityMsg::DecodeImsiMobileIdentityMsg(
   MLOG(MDEBUG) << "  Spare = " << std::hex << int(imsi->spare2);
   MLOG(MDEBUG) << "  Supi Format = " << std::hex << int(imsi->supi_format);
   MLOG(MDEBUG) << "  Spare = " << std::hex << int(imsi->spare1);
-  MLOG(MDEBUG) << "  Type of Identity = " << std::hex << int(imsi->type_of_identity);
-  MLOG(MDEBUG) << "  Mobile Country Code (MCC) = " << std::dec 
-               << int(imsi->mcc_digit1) << std::dec << int(imsi->mcc_digit2) << std::dec 
-               << int(imsi->mcc_digit3);
-  MLOG(MDEBUG) << "  Mobile Network Code (MNC) = " << std::dec 
-               << int(imsi->mnc_digit1) << std::dec << int(imsi->mnc_digit2) << std::dec 
-               << int(imsi->mnc_digit3);
+  MLOG(MDEBUG) << "  Type of Identity = " << std::hex
+               << int(imsi->type_of_identity);
+  MLOG(MDEBUG) << "  Mobile Country Code (MCC) = " << std::dec
+               << int(imsi->mcc_digit1) << std::dec << int(imsi->mcc_digit2)
+               << std::dec << int(imsi->mcc_digit3);
+  MLOG(MDEBUG) << "  Mobile Network Code (MNC) = " << std::dec
+               << int(imsi->mnc_digit1) << std::dec << int(imsi->mnc_digit2)
+               << std::dec << int(imsi->mnc_digit3);
   MLOG(MDEBUG) << "  Routing Indicator = " << std::hex
                << int(imsi->rout_ind_digit_1);
   MLOG(MDEBUG) << "  Protection Scheme ID = " << std::hex
@@ -301,7 +307,8 @@ int M5GSMobileIdentityMsg::DecodeTmsiMobileIdentityMsg(
   decoded = ielen;
   MLOG(MDEBUG) << "  spare2 = " << std::dec << int(tmsi->spare);
   MLOG(MDEBUG) << "  odd_even = " << std::dec << int(tmsi->odd_even);
-  MLOG(MDEBUG) << "  type_of_identity = " << std::dec << int(tmsi->type_of_identity);
+  MLOG(MDEBUG) << "  type_of_identity = " << std::dec
+               << int(tmsi->type_of_identity);
   MLOG(MDEBUG) << "  amf_setid = " << std::dec << int(tmsi->amf_setid);
   MLOG(MDEBUG) << "  amf_pointer = " << std::dec << int(tmsi->amf_pointer);
   MLOG(MDEBUG) << "  M5G TMSI = ";
@@ -398,7 +405,8 @@ int M5GSMobileIdentityMsg::EncodeGutiMobileIdentityMsg(
   encoded++;
   *(buffer + encoded) =
       0x00 | ((guti->amf_setid & 0xF3) << 6) | (guti->amf_pointer & 0x3f);
-  MLOG(MDEBUG) << "amf_setid amf_pointer = " << std::hex << int(*(buffer + encoded));
+  MLOG(MDEBUG) << "amf_setid amf_pointer = " << std::hex
+               << int(*(buffer + encoded));
   encoded++;
   *(buffer + encoded) = 0x00 | guti->tmsi1;
   MLOG(MDEBUG) << "tmsi1 = " << std::hex << int(*(buffer + encoded));
@@ -534,7 +542,8 @@ int M5GSMobileIdentityMsg::EncodeSuciMobileIdentityMsg(
   encoded++;
   suci->suci_nai.assign(
       (const char*) (buffer + encoded), suci->suci_nai.size());
-  MLOG(MDEBUG) << "ielen = " << std::hex << (unsigned char) suci->suci_nai.size();
+  MLOG(MDEBUG) << "ielen = " << std::hex
+               << (unsigned char) suci->suci_nai.size();
   MLOG(MDEBUG) << "contents";
   for (uint32_t i = 0; i < suci->suci_nai.size(); i++) {
     MLOG(MDEBUG) << std::hex << int(suci->suci_nai[i]);

--- a/lte/gateway/c/core/oai/tasks/nas5g/src/ies/M5GSRegistrationResult.cpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/src/ies/M5GSRegistrationResult.cpp
@@ -16,7 +16,6 @@
 #include "M5GSRegistrationResult.h"
 #include "M5GCommonDefs.h"
 
-using namespace std;
 namespace magma5g {
 M5GSRegistrationResultMsg::M5GSRegistrationResultMsg(){};
 M5GSRegistrationResultMsg::~M5GSRegistrationResultMsg(){};
@@ -50,7 +49,7 @@ int M5GSRegistrationResultMsg::EncodeM5GSRegistrationResultMsg(
   if (iei > 0) {
     CHECK_IEI_ENCODER(iei, (unsigned char) m5gs_reg_result->iei);
     *buffer = iei;
-    MLOG(MDEBUG) << "In EncodeM5GSRegistrationResultMsg___: iei  = " << hex
+    MLOG(MDEBUG) << "In EncodeM5GSRegistrationResultMsg___: iei  = " << std::hex
                  << int(*buffer);
     encoded++;
   }
@@ -65,11 +64,11 @@ int M5GSRegistrationResultMsg::EncodeM5GSRegistrationResultMsg(
                << "spare = " << ((m5gs_reg_result->spare & 0xf) << 0x4)
                << ", sms allowed = "
                << ((m5gs_reg_result->sms_allowed & 0x1) << 3)
-               << ", result val = " << hex
+               << ", result val = " << std::hex
                << int(m5gs_reg_result->reg_result_val & 0x7) << ")";
   encoded++;
   *lenPtr = encoded - 1 - ((iei > 0) ? 1 : 0);
-  MLOG(MDEBUG) << " EncodeM5GSRegistrationResultMsg : length  = 0x0" << hex
+  MLOG(MDEBUG) << " EncodeM5GSRegistrationResultMsg : length  = 0x0" << std::hex
                << int(*lenPtr);
   return encoded;
 };

--- a/lte/gateway/c/core/oai/tasks/nas5g/src/ies/M5GSRegistrationType.cpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/src/ies/M5GSRegistrationType.cpp
@@ -16,7 +16,6 @@
 #include "M5GCommonDefs.h"
 #include <bitset>
 
-using namespace std;
 namespace magma5g {
 M5GSRegistrationTypeMsg::M5GSRegistrationTypeMsg(){};
 M5GSRegistrationTypeMsg::~M5GSRegistrationTypeMsg(){};
@@ -34,8 +33,8 @@ int M5GSRegistrationTypeMsg::DecodeM5GSRegistrationTypeMsg(
 
   m5gs_reg_type->FOR      = (*(buffer + decoded) >> 3) & 0x1;
   m5gs_reg_type->type_val = *(buffer + decoded) & 0x7;
-  MLOG(MDEBUG) << " FOR = 0x" << hex << int(m5gs_reg_type->FOR);
-  MLOG(MDEBUG) << " type_val = 0x" << hex << int(m5gs_reg_type->type_val);
+  MLOG(MDEBUG) << " FOR = 0x" << std::hex << int(m5gs_reg_type->FOR);
+  MLOG(MDEBUG) << " type_val = 0x" << std::hex << int(m5gs_reg_type->type_val);
   return decoded;
 };
 

--- a/lte/gateway/c/core/oai/tasks/nas5g/src/ies/M5GSSCMode.cpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/src/ies/M5GSSCMode.cpp
@@ -16,7 +16,6 @@
 #include "M5GSSCMode.h"
 #include "M5GCommonDefs.h"
 
-using namespace std;
 namespace magma5g {
 SSCModeMsg::SSCModeMsg(){};
 SSCModeMsg::~SSCModeMsg(){};
@@ -28,13 +27,13 @@ int SSCModeMsg::DecodeSSCModeMsg(
 
   // Storing the IEI Information
   if (iei > 0) {
-    ssc_mode->iei = (*buffer & 0xf0) >> 4;
-    MLOG(MDEBUG) << "In DecodeSSCModeMsg: iei = " << hex << int(ssc_mode->iei);
+    ssc_mode->iei = *buffer;
+    MLOG(MDEBUG) << "In DecodeSSCModeMsg: iei = " << std::hex << int(ssc_mode->iei);
     decoded++;
   }
 
   ssc_mode->mode_val = (*buffer & 0x07);
-  MLOG(MDEBUG) << "DecodeSSCModeMsg__: mode_val = " << hex
+  MLOG(MDEBUG) << "DecodeSSCModeMsg__: mode_val = " << std::hex
                << int(ssc_mode->mode_val);
 
   return decoded;
@@ -47,15 +46,14 @@ int SSCModeMsg::EncodeSSCModeMsg(
 
   // CHECKING IEI
   if (iei > 0) {
-    CHECK_IEI_ENCODER(
-        (uint8_t) iei, (uint8_t)(0x00 | (ssc_mode->iei & 0x0f) << 4));
-    *buffer = (ssc_mode->iei & 0x0f) << 4;
-    MLOG(MDEBUG) << "In EncodeSSCModeMsg: iei" << hex << int(*buffer);
+    CHECK_IEI_ENCODER((unsigned char) iei, ssc_mode->iei);
+    *buffer = 0x00 | (ssc_mode->iei & 0x0f) << 4;
+    MLOG(MDEBUG) << "In EncodeSSCModeMsg: iei" << std::hex << int(*buffer);
     encoded++;
   }
 
-  *buffer = 0x00 | (*buffer & 0xf0) | (ssc_mode->mode_val & 0x07);
-  MLOG(MDEBUG) << "EncodeSSCModeMsg__: mode_val = " << hex << int(*buffer);
+  *buffer = (ssc_mode->mode_val << 4) & 0xf0;
+  MLOG(MDEBUG) << "EncodeSSCModeMsg__: mode_val = " << std::hex << int(*buffer);
 
   return (encoded);
 };

--- a/lte/gateway/c/core/oai/tasks/nas5g/src/ies/M5GSSCMode.cpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/src/ies/M5GSSCMode.cpp
@@ -28,7 +28,8 @@ int SSCModeMsg::DecodeSSCModeMsg(
   // Storing the IEI Information
   if (iei > 0) {
     ssc_mode->iei = *buffer;
-    MLOG(MDEBUG) << "In DecodeSSCModeMsg: iei = " << std::hex << int(ssc_mode->iei);
+    MLOG(MDEBUG) << "In DecodeSSCModeMsg: iei = " << std::hex
+                 << int(ssc_mode->iei);
     decoded++;
   }
 

--- a/lte/gateway/c/core/oai/tasks/nas5g/src/ies/M5GSecurityHeaderType.cpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/src/ies/M5GSecurityHeaderType.cpp
@@ -28,7 +28,7 @@ int SecurityHeaderTypeMsg::DecodeSecurityHeaderTypeMsg(
   MLOG(MDEBUG) << "   DecodeSecurityHeaderTypeMsg : ";
   sec_header_type->sec_hdr = *(buffer) &0xf;
   decoded++;
-  MLOG(MDEBUG) << " Security header type = " << std::dec 
+  MLOG(MDEBUG) << " Security header type = " << std::dec
                << int(sec_header_type->sec_hdr);
   return (decoded);
 };

--- a/lte/gateway/c/core/oai/tasks/nas5g/src/ies/M5GSecurityHeaderType.cpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/src/ies/M5GSecurityHeaderType.cpp
@@ -15,7 +15,6 @@
 #include "M5GSecurityHeaderType.h"
 #include "M5GCommonDefs.h"
 
-using namespace std;
 namespace magma5g {
 SecurityHeaderTypeMsg::SecurityHeaderTypeMsg(){};
 SecurityHeaderTypeMsg::~SecurityHeaderTypeMsg(){};
@@ -29,7 +28,7 @@ int SecurityHeaderTypeMsg::DecodeSecurityHeaderTypeMsg(
   MLOG(MDEBUG) << "   DecodeSecurityHeaderTypeMsg : ";
   sec_header_type->sec_hdr = *(buffer) &0xf;
   decoded++;
-  MLOG(MDEBUG) << " Security header type = " << dec
+  MLOG(MDEBUG) << " Security header type = " << std::dec 
                << int(sec_header_type->sec_hdr);
   return (decoded);
 };
@@ -43,7 +42,7 @@ int SecurityHeaderTypeMsg::EncodeSecurityHeaderTypeMsg(
   MLOG(MDEBUG) << " EncodeSecurityHeaderTypeMsg : ";
   *(buffer) = sec_header_type->sec_hdr & 0xf;
   encoded++;
-  MLOG(MDEBUG) << "Security header type = 0x" << hex << int(*(buffer));
+  MLOG(MDEBUG) << "Security header type = 0x" << std::hex << int(*(buffer));
   return (encoded);
 };
 }  // namespace magma5g

--- a/lte/gateway/c/core/oai/tasks/nas5g/src/ies/M5GServiceType.cpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/src/ies/M5GServiceType.cpp
@@ -16,7 +16,6 @@
 #include "M5GServiceType.h"
 #include "M5GCommonDefs.h"
 
-using namespace std;
 namespace magma5g {
 ServiceTypeMsg::ServiceTypeMsg(){};
 ServiceTypeMsg::~ServiceTypeMsg(){};
@@ -27,8 +26,8 @@ int ServiceTypeMsg::DecodeServiceTypeMsg(
   int decoded = 0;
 
   svc_type->service_type_value = ((*buffer & 0xf0) >> 4);
-  MLOG(MDEBUG) << "DecodeServiceTypeMsg__: service_type_value = " << hex
-               << int(svc_type->service_type_value) << endl;
+  MLOG(MDEBUG) << "DecodeServiceTypeMsg__: service_type_value = " << std::hex
+               << int(svc_type->service_type_value) << std::endl;
 
   return (decoded);
 };
@@ -39,8 +38,8 @@ int ServiceTypeMsg::EncodeServiceTypeMsg(
   int encoded = 0;
 
   *buffer = svc_type->service_type_value & 0x0f;
-  MLOG(MDEBUG) << "DecodeServiceTypeMsg__: service_type_value = " << hex
-               << int(*buffer) << endl;
+  MLOG(MDEBUG) << "DecodeServiceTypeMsg__: service_type_value = " << std::hex
+               << int(*buffer) << std::endl;
   encoded++;
 
   return (encoded);

--- a/lte/gateway/c/core/oai/tasks/nas5g/src/ies/M5GSessionAMBR.cpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/src/ies/M5GSessionAMBR.cpp
@@ -14,7 +14,6 @@
 #include "M5GSessionAMBR.h"
 #include "M5GCommonDefs.h"
 
-using namespace std;
 namespace magma5g {
 SessionAMBRMsg::SessionAMBRMsg(){};
 SessionAMBRMsg::~SessionAMBRMsg(){};
@@ -39,7 +38,7 @@ int SessionAMBRMsg::EncodeSessionAMBRMsg(
   if (iei > 0) {
     CHECK_IEI_ENCODER((unsigned char) iei, session_ambr->iei);
     *buffer = iei;
-    MLOG(MDEBUG) << "In EncodeSessionAMBRMsg: iei" << hex << int(*buffer);
+    MLOG(MDEBUG) << "In EncodeSessionAMBRMsg: iei" << std::hex << int(*buffer);
     encoded++;
   }
 

--- a/lte/gateway/c/core/oai/tasks/nas5g/src/ies/M5GSpareHalfOctet.cpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/src/ies/M5GSpareHalfOctet.cpp
@@ -15,7 +15,6 @@
 #include "M5GSpareHalfOctet.h"
 #include "M5GCommonDefs.h"
 
-using namespace std;
 namespace magma5g {
 SpareHalfOctetMsg::SpareHalfOctetMsg(){};
 SpareHalfOctetMsg::~SpareHalfOctetMsg(){};
@@ -28,7 +27,7 @@ int SpareHalfOctetMsg::DecodeSpareHalfOctetMsg(
 
   MLOG(MDEBUG) << "   DecodeSpareHalfOctetMsg : ";
   spare_half_octet->spare = (*buffer & 0xf0) >> 4;
-  MLOG(MDEBUG) << "Spare = 0x" << hex << int(spare_half_octet->spare);
+  MLOG(MDEBUG) << "Spare = 0x" << std::hex << int(spare_half_octet->spare);
   return (decoded);
 };
 
@@ -40,7 +39,7 @@ int SpareHalfOctetMsg::EncodeSpareHalfOctetMsg(
 
   MLOG(MDEBUG) << " EncodeSpareHalfOctetMsg : ";
   *(buffer) = 0x00 | (spare_half_octet->spare & 0xf) << 4;
-  MLOG(MDEBUG) << "   Spare = 0x" << hex << int(*(buffer));
+  MLOG(MDEBUG) << "   Spare = 0x" << std::hex << int(*(buffer));
   return (encoded);
 };
 }  // namespace magma5g

--- a/lte/gateway/c/core/oai/tasks/nas5g/src/ies/M5GTAIList.cpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/src/ies/M5GTAIList.cpp
@@ -13,7 +13,6 @@ limitations under the License.
 #include <string.h>
 #include "M5GTAIList.h"
 #include "M5GCommonDefs.h"
-using namespace std;
 namespace magma5g {
 TAIListMsg::TAIListMsg(){};
 
@@ -25,7 +24,7 @@ int TAIListMsg::EncodeTAIListMsg(
   if (iei > 0) {
     CHECK_IEI_ENCODER(iei, (unsigned char) TAIList->iei);
     *buffer = iei;
-    MLOG(MDEBUG) << "iei = " << hex << int(*(buffer + encoded));
+    MLOG(MDEBUG) << "iei = " << std::hex << int(*(buffer + encoded));
     encoded++;
   }
   *(buffer + encoded) = TAIList->len;
@@ -36,17 +35,17 @@ int TAIListMsg::EncodeTAIListMsg(
   encoded++;
   *(buffer + encoded) =
       0x00 | ((TAIList->mcc_digit2 & 0x0f) << 4) | (TAIList->mcc_digit1 & 0x0f);
-  MLOG(MDEBUG) << "mcc_digit2 >mcc_digit1 type_of_identity = " << hex
+  MLOG(MDEBUG) << "mcc_digit2 >mcc_digit1 type_of_identity = " << std::hex
                << int(*(buffer + encoded));
   encoded++;
   *(buffer + encoded) =
       0x00 | ((TAIList->mnc_digit3 & 0x0f) << 4) | (TAIList->mcc_digit3 & 0x0f);
-  MLOG(MDEBUG) << "mnc_digit3 >mcc_digit3 type_of_identity = " << hex
+  MLOG(MDEBUG) << "mnc_digit3 >mcc_digit3 type_of_identity = " << std::hex
                << int(*(buffer + encoded));
   encoded++;
   *(buffer + encoded) =
       0x00 | ((TAIList->mnc_digit2 & 0x0f) << 4) | (TAIList->mnc_digit1 & 0x0f);
-  MLOG(MDEBUG) << "mnc_digit2 >mcc_digit1 type_of_identity = " << hex
+  MLOG(MDEBUG) << "mnc_digit2 >mcc_digit1 type_of_identity = " << std::hex
                << int(*(buffer + encoded));
   encoded++;
 

--- a/lte/gateway/c/core/oai/tasks/nas5g/src/ies/M5GUESecurityCapability.cpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/src/ies/M5GUESecurityCapability.cpp
@@ -17,7 +17,6 @@
 #include "M5GUESecurityCapability.h"
 #include "M5GCommonDefs.h"
 
-using namespace std;
 namespace magma5g {
 UESecurityCapabilityMsg::UESecurityCapabilityMsg(){};
 UESecurityCapabilityMsg::~UESecurityCapabilityMsg(){};
@@ -42,7 +41,7 @@ int UESecurityCapabilityMsg::DecodeUESecurityCapabilityMsg(
 
   ue_sec_capability->length = *(buffer + decoded);
   decoded++;
-  MLOG(MDEBUG) << " length = " << hex << int(ue_sec_capability->length) << endl;
+  MLOG(MDEBUG) << " length = " << std::hex << int(ue_sec_capability->length) << std::endl;
 
   // 5GS encryption algorithms
   ea                     = *(buffer + decoded);
@@ -99,23 +98,23 @@ int UESecurityCapabilityMsg::DecodeUESecurityCapabilityMsg(
   }
 
   // Decoded 5GS encryption algorithms
-  MLOG(MDEBUG) << " ea0 = " << hex << int(ue_sec_capability->ea0) << endl;
-  MLOG(MDEBUG) << " ea1 = " << hex << int(ue_sec_capability->ea1) << endl;
-  MLOG(MDEBUG) << " ea2 = " << hex << int(ue_sec_capability->ea2) << endl;
-  MLOG(MDEBUG) << " ea3 = " << hex << int(ue_sec_capability->ea3) << endl;
-  MLOG(MDEBUG) << " ea4 = " << hex << int(ue_sec_capability->ea4) << endl;
-  MLOG(MDEBUG) << " ea5 = " << hex << int(ue_sec_capability->ea5) << endl;
-  MLOG(MDEBUG) << " ea6 = " << hex << int(ue_sec_capability->ea6) << endl;
-  MLOG(MDEBUG) << " ea7 = " << hex << int(ue_sec_capability->ea7) << endl;
+  MLOG(MDEBUG) << " ea0 = " << std::hex << int(ue_sec_capability->ea0) << std::endl;
+  MLOG(MDEBUG) << " ea1 = " << std::hex << int(ue_sec_capability->ea1) << std::endl;
+  MLOG(MDEBUG) << " ea2 = " << std::hex << int(ue_sec_capability->ea2) << std::endl;
+  MLOG(MDEBUG) << " ea3 = " << std::hex << int(ue_sec_capability->ea3) << std::endl;
+  MLOG(MDEBUG) << " ea4 = " << std::hex << int(ue_sec_capability->ea4) << std::endl;
+  MLOG(MDEBUG) << " ea5 = " << std::hex << int(ue_sec_capability->ea5) << std::endl;
+  MLOG(MDEBUG) << " ea6 = " << std::hex << int(ue_sec_capability->ea6) << std::endl;
+  MLOG(MDEBUG) << " ea7 = " << std::hex << int(ue_sec_capability->ea7) << std::endl;
   // Decoded 5GS integrity algorithm
-  MLOG(MDEBUG) << " ia0 = " << hex << int(ue_sec_capability->ia0) << endl;
-  MLOG(MDEBUG) << " ia1 = " << hex << int(ue_sec_capability->ia1) << endl;
-  MLOG(MDEBUG) << " ia2 = " << hex << int(ue_sec_capability->ia2) << endl;
-  MLOG(MDEBUG) << " ia3 = " << hex << int(ue_sec_capability->ia3) << endl;
-  MLOG(MDEBUG) << " ia4 = " << hex << int(ue_sec_capability->ia4) << endl;
-  MLOG(MDEBUG) << " ia5 = " << hex << int(ue_sec_capability->ia5) << endl;
-  MLOG(MDEBUG) << " ia6 = " << hex << int(ue_sec_capability->ia6) << endl;
-  MLOG(MDEBUG) << " ia7 = " << hex << int(ue_sec_capability->ia7) << endl;
+  MLOG(MDEBUG) << " ia0 = " << std::hex << int(ue_sec_capability->ia0) << std::endl;
+  MLOG(MDEBUG) << " ia1 = " << std::hex << int(ue_sec_capability->ia1) << std::endl;
+  MLOG(MDEBUG) << " ia2 = " << std::hex << int(ue_sec_capability->ia2) << std::endl;
+  MLOG(MDEBUG) << " ia3 = " << std::hex << int(ue_sec_capability->ia3) << std::endl;
+  MLOG(MDEBUG) << " ia4 = " << std::hex << int(ue_sec_capability->ia4) << std::endl;
+  MLOG(MDEBUG) << " ia5 = " << std::hex << int(ue_sec_capability->ia5) << std::endl;
+  MLOG(MDEBUG) << " ia6 = " << std::hex << int(ue_sec_capability->ia6) << std::endl;
+  MLOG(MDEBUG) << " ia7 = " << std::hex << int(ue_sec_capability->ia7) << std::endl;
 
   return (decoded);
 };
@@ -138,7 +137,7 @@ int UESecurityCapabilityMsg::EncodeUESecurityCapabilityMsg(
       buffer, UE_SECURITY_CAPABILITY_MIN_LENGTH, len);
 
   *(buffer + encoded) = ue_sec_capability->length;
-  MLOG(MDEBUG) << "Length : " << setfill('0') << hex << setw(2)
+  MLOG(MDEBUG) << "Length : " << std::setfill('0') << std::hex << std::setw(2)
                << int(*(buffer + encoded));
   encoded++;
 
@@ -151,7 +150,7 @@ int UESecurityCapabilityMsg::EncodeUESecurityCapabilityMsg(
                         ((ue_sec_capability->ea5 & 0x1) << 2) |
                         ((ue_sec_capability->ea6 & 0x1) << 1) |
                         ((ue_sec_capability->ea7) & 0x1);
-  MLOG(MDEBUG) << " 5GS Encryption Algorithms Supported : " << hex
+  MLOG(MDEBUG) << " 5GS Encryption Algorithms Supported : " << std::hex
                << int(*(buffer + encoded));
   encoded++;
 
@@ -164,7 +163,7 @@ int UESecurityCapabilityMsg::EncodeUESecurityCapabilityMsg(
                         ((ue_sec_capability->ia5 & 0x1) << 2) |
                         ((ue_sec_capability->ia6 & 0x1) << 1) |
                         ((ue_sec_capability->ia7) & 0x1);
-  MLOG(MDEBUG) << " 5GS Integrity Algorithms Supported : " << hex
+  MLOG(MDEBUG) << " 5GS Integrity Algorithms Supported : " << std::hex
                << int(*(buffer + encoded));
   encoded++;
 
@@ -195,7 +194,7 @@ int UESecurityCapabilityMsg::EncodeUESecurityCapabilityMsg(
   }
 
   MLOG(DEBUG) << " Encoding UE Security Capability : encoded  " << encoded
-              << endl;
+              << std::endl;
   return encoded;
 };
 }  // namespace magma5g

--- a/lte/gateway/c/core/oai/tasks/nas5g/src/ies/M5GUESecurityCapability.cpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/src/ies/M5GUESecurityCapability.cpp
@@ -41,7 +41,8 @@ int UESecurityCapabilityMsg::DecodeUESecurityCapabilityMsg(
 
   ue_sec_capability->length = *(buffer + decoded);
   decoded++;
-  MLOG(MDEBUG) << " length = " << std::hex << int(ue_sec_capability->length) << std::endl;
+  MLOG(MDEBUG) << " length = " << std::hex << int(ue_sec_capability->length)
+               << std::endl;
 
   // 5GS encryption algorithms
   ea                     = *(buffer + decoded);
@@ -98,23 +99,39 @@ int UESecurityCapabilityMsg::DecodeUESecurityCapabilityMsg(
   }
 
   // Decoded 5GS encryption algorithms
-  MLOG(MDEBUG) << " ea0 = " << std::hex << int(ue_sec_capability->ea0) << std::endl;
-  MLOG(MDEBUG) << " ea1 = " << std::hex << int(ue_sec_capability->ea1) << std::endl;
-  MLOG(MDEBUG) << " ea2 = " << std::hex << int(ue_sec_capability->ea2) << std::endl;
-  MLOG(MDEBUG) << " ea3 = " << std::hex << int(ue_sec_capability->ea3) << std::endl;
-  MLOG(MDEBUG) << " ea4 = " << std::hex << int(ue_sec_capability->ea4) << std::endl;
-  MLOG(MDEBUG) << " ea5 = " << std::hex << int(ue_sec_capability->ea5) << std::endl;
-  MLOG(MDEBUG) << " ea6 = " << std::hex << int(ue_sec_capability->ea6) << std::endl;
-  MLOG(MDEBUG) << " ea7 = " << std::hex << int(ue_sec_capability->ea7) << std::endl;
+  MLOG(MDEBUG) << " ea0 = " << std::hex << int(ue_sec_capability->ea0)
+               << std::endl;
+  MLOG(MDEBUG) << " ea1 = " << std::hex << int(ue_sec_capability->ea1)
+               << std::endl;
+  MLOG(MDEBUG) << " ea2 = " << std::hex << int(ue_sec_capability->ea2)
+               << std::endl;
+  MLOG(MDEBUG) << " ea3 = " << std::hex << int(ue_sec_capability->ea3)
+               << std::endl;
+  MLOG(MDEBUG) << " ea4 = " << std::hex << int(ue_sec_capability->ea4)
+               << std::endl;
+  MLOG(MDEBUG) << " ea5 = " << std::hex << int(ue_sec_capability->ea5)
+               << std::endl;
+  MLOG(MDEBUG) << " ea6 = " << std::hex << int(ue_sec_capability->ea6)
+               << std::endl;
+  MLOG(MDEBUG) << " ea7 = " << std::hex << int(ue_sec_capability->ea7)
+               << std::endl;
   // Decoded 5GS integrity algorithm
-  MLOG(MDEBUG) << " ia0 = " << std::hex << int(ue_sec_capability->ia0) << std::endl;
-  MLOG(MDEBUG) << " ia1 = " << std::hex << int(ue_sec_capability->ia1) << std::endl;
-  MLOG(MDEBUG) << " ia2 = " << std::hex << int(ue_sec_capability->ia2) << std::endl;
-  MLOG(MDEBUG) << " ia3 = " << std::hex << int(ue_sec_capability->ia3) << std::endl;
-  MLOG(MDEBUG) << " ia4 = " << std::hex << int(ue_sec_capability->ia4) << std::endl;
-  MLOG(MDEBUG) << " ia5 = " << std::hex << int(ue_sec_capability->ia5) << std::endl;
-  MLOG(MDEBUG) << " ia6 = " << std::hex << int(ue_sec_capability->ia6) << std::endl;
-  MLOG(MDEBUG) << " ia7 = " << std::hex << int(ue_sec_capability->ia7) << std::endl;
+  MLOG(MDEBUG) << " ia0 = " << std::hex << int(ue_sec_capability->ia0)
+               << std::endl;
+  MLOG(MDEBUG) << " ia1 = " << std::hex << int(ue_sec_capability->ia1)
+               << std::endl;
+  MLOG(MDEBUG) << " ia2 = " << std::hex << int(ue_sec_capability->ia2)
+               << std::endl;
+  MLOG(MDEBUG) << " ia3 = " << std::hex << int(ue_sec_capability->ia3)
+               << std::endl;
+  MLOG(MDEBUG) << " ia4 = " << std::hex << int(ue_sec_capability->ia4)
+               << std::endl;
+  MLOG(MDEBUG) << " ia5 = " << std::hex << int(ue_sec_capability->ia5)
+               << std::endl;
+  MLOG(MDEBUG) << " ia6 = " << std::hex << int(ue_sec_capability->ia6)
+               << std::endl;
+  MLOG(MDEBUG) << " ia7 = " << std::hex << int(ue_sec_capability->ia7)
+               << std::endl;
 
   return (decoded);
 };

--- a/lte/gateway/c/core/oai/tasks/nas5g/src/ies/M5GUplinkDataStatus.cpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/src/ies/M5GUplinkDataStatus.cpp
@@ -16,7 +16,6 @@ limitations under the License.
 #include "M5GCommonDefs.h"
 #include "M5GUplinkDataStatus.h"
 
-using namespace std;
 namespace magma5g {
 M5GUplinkDataStatus::M5GUplinkDataStatus(){};
 M5GUplinkDataStatus::~M5GUplinkDataStatus(){};
@@ -47,19 +46,19 @@ int M5GUplinkDataStatus::DecodeUplinkDataStatus(
 
   if (iei > 0) {
     uplinkDataStatus->iei = *buffer;
-    MLOG(MDEBUG) << "DecodeUplinkDataStatus: iei = " << hex
+    MLOG(MDEBUG) << "DecodeUplinkDataStatus: iei = " << std::hex
                  << int(uplinkDataStatus->iei);
     decoded++;
 
     uplinkDataStatus->len = *(buffer + decoded);
-    MLOG(MDEBUG) << "In DecodeUplinkDataStatus: len = " << hex
+    MLOG(MDEBUG) << "In DecodeUplinkDataStatus: len = " << std::hex
                  << int(uplinkDataStatus->len);
     decoded++;
 
     uplinkDataStatus->uplinkDataStatus = *(buffer + decoded);
     decoded++;
     uplinkDataStatus->uplinkDataStatus |= (*(buffer + decoded) << 8);
-    MLOG(MDEBUG) << "In DecodeUplinkDataStatus: uplinkDataStatus = " << hex
+    MLOG(MDEBUG) << "In DecodeUplinkDataStatus: uplinkDataStatus = " << std::hex
                  << int(uplinkDataStatus->uplinkDataStatus);
     decoded++;
   }


### PR DESCRIPTION
Signed-off-by: sreedharkumartn <sreedhar.kumar@wavelabs.ai>


<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary
Added fixes for AMF warnings.
<!-- Enumerate changes you made and why you made them -->

## Test Plan
 - Verified basic sanity with UERANSIM.
 - Please find attached logs and pcap snap for basic registration and PDU Session setup
 
Logs:
[mme_warning_cleanup.log](https://github.com/magma/magma/files/7204550/mme_warning_cleanup.log)

Pcap snap:
![image](https://user-images.githubusercontent.com/89978170/134204651-8b6e17c4-db50-4d3a-87e2-6301de82f817.png)

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
