### PR TITLE
fix(mme): NGAP module warning cleanup

### DIFF
--- a/lte/gateway/c/core/oai/tasks/ngap/ngap_amf_nas_procedures.c
+++ b/lte/gateway/c/core/oai/tasks/ngap/ngap_amf_nas_procedures.c
@@ -59,6 +59,9 @@
 #include "ngap_amf_handlers.h"
 #include "ngap_common.h"
 
+int ngap_fill_pdu_session_resource_setup_request_transfer(
+    const pdu_session_resource_setup_request_transfer_t* session_transfer,
+    Ngap_PDUSessionResourceSetupRequestTransfer_t* transfer_request);
 //------------------------------------------------------------------------------
 status_code_e ngap_amf_handle_initial_ue_message(
     ngap_state_t* state, const sctp_assoc_id_t assoc_id,
@@ -795,8 +798,6 @@ void ngap_handle_conn_est_cnf(
 
       ASN_SEQUENCE_ADD(&out->protocolIEs.list, ie);
 
-      const pdu_session_resource_setup_request_transfer_t*
-          amf_pdu_ses_setup_transfer_req;
       const pdusession_setup_item_t* pdu_session_item =
           &conn_est_cnf_pP->PDU_Session_Resource_Setup_Transfer_List.item[i];
 
@@ -817,8 +818,9 @@ void ngap_handle_conn_est_cnf(
                   1, sizeof(Ngap_PDUSessionResourceSetupRequestTransfer_t));
 
       // filling PDU TX Structure
-      amf_pdu_ses_setup_transfer_req =
-          &(pdu_session_item->PDU_Session_Resource_Setup_Request_Transfer);
+      const pdu_session_resource_setup_request_transfer_t*
+          amf_pdu_ses_setup_transfer_req =
+              &(pdu_session_item->PDU_Session_Resource_Setup_Request_Transfer);
 
       ngap_fill_pdu_session_resource_setup_request_transfer(
           amf_pdu_ses_setup_transfer_req,

--- a/lte/gateway/c/core/oai/tasks/ngap/ngap_amf_nas_procedures.c
+++ b/lte/gateway/c/core/oai/tasks/ngap/ngap_amf_nas_procedures.c
@@ -59,9 +59,6 @@
 #include "ngap_amf_handlers.h"
 #include "ngap_common.h"
 
-int ngap_fill_pdu_session_resource_setup_request_transfer(
-    const pdu_session_resource_setup_request_transfer_t* session_transfer,
-    Ngap_PDUSessionResourceSetupRequestTransfer_t* transfer_request);
 //------------------------------------------------------------------------------
 status_code_e ngap_amf_handle_initial_ue_message(
     ngap_state_t* state, const sctp_assoc_id_t assoc_id,


### PR DESCRIPTION
Signed-off-by: Shashidhar Patil <shashidhar.patil@wavelabs.ai>

fix(mme): NGAP module warning cleanup (Issue : 8984)


<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->
Added fixes for NGAP warnings.

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->
Verified basic sanity with UERANSIM.

 Please find attached logs and pcap snap for basic registration and PDU Session setup.

Logs:
[mme_warning_cleanup.log](https://github.com/magma/magma/files/7204381/mme_warning_cleanup.log)

pcap snap:
<img width="956" alt="pcap_snap" src="https://user-images.githubusercontent.com/89975652/134201077-6675dbfe-7377-40d4-9bb4-fe874e5516fc.PNG">



## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
