### PR TITLE
fix: move clangd-12 installation from dev common to magma role

### DIFF
--- a/lte/gateway/deploy/roles/dev_common/tasks/main.yml
+++ b/lte/gateway/deploy/roles/dev_common/tasks/main.yml
@@ -185,14 +185,6 @@
       - python3-aioeventlet
   retries: 5
 
-- name: Install requirements for VSCode <-> Bazel integration
-  when: full_provision
-  apt:
-    state: present
-    pkg:
-      - clangd-12
-  retries: 5
-
 # /etc/environment doesn't expand variables, so if we want to modify the path,
 # we need to do it in profile.d
 - name: Create the env script

--- a/lte/gateway/deploy/roles/magma/tasks/main.yml
+++ b/lte/gateway/deploy/roles/magma/tasks/main.yml
@@ -419,3 +419,11 @@
   patch:
     src: patches/aioeventlet_fd_exception.patch
     dest: /usr/local/lib/python3.8/dist-packages/aioeventlet.py
+
+- name: Install requirements for VSCode <-> Bazel integration
+  when: full_provision
+  apt:
+    state: present
+    pkg:
+      - clangd-12
+  retries: 5


### PR DESCRIPTION
Signed-off-by: Marie Bremner <marwhal@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary
magma_test cannot be brought up on master currently due to the clangd-12 installation step I added into dev-common. This specific tool is not available in the underlying machine used for magma_test. 
<!-- Enumerate changes you made and why you made them -->

## Test Plan

- [x] bringing up magma to test clangd-12 is installed
<img width="680" alt="Screen Shot 2021-09-17 at 1 07 16 PM" src="https://user-images.githubusercontent.com/37634144/133827210-8bb1ad99-bc05-443a-b956-c2e613d7aca7.png">


- [x] bringing up magma_test to make sure that is working
<img width="839" alt="Screen Shot 2021-09-17 at 1 06 42 PM" src="https://user-images.githubusercontent.com/37634144/133827153-d9929193-aa4a-4d6e-a9ad-acb1aa21d207.png">

<!--


    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
