### PR TITLE
feat(nms): SubscriberDB Extensions - Addition of CoreNetworkType on nms UI

### DIFF
--- a/nms/packages/magmalte/app/components/Subscribers.js
+++ b/nms/packages/magmalte/app/components/Subscribers.js
@@ -39,6 +39,7 @@ import Text from '@fbcnms/ui/components/design-system/Text';
 import nullthrows from '@fbcnms/util/nullthrows';
 import useMagmaAPI from '../../api/useMagmaAPI';
 import withAlert from '@fbcnms/ui/components/Alert/withAlert';
+import {CoreNetworkTypes} from '../views/subscriber/SubscriberUtils';
 import {Route} from 'react-router-dom';
 import {makeStyles} from '@material-ui/styles';
 import {map} from 'lodash';
@@ -63,6 +64,10 @@ const useStyles = makeStyles(theme => ({
     marginRight: '8px',
   },
 }));
+
+const forbiddenNetworkTypes = Object.keys(CoreNetworkTypes).map(
+  key => CoreNetworkTypes[key],
+);
 
 function Subscribers() {
   const classes = useStyles();
@@ -185,6 +190,7 @@ function Subscribers() {
             onClose={() => history.push(relativeUrl(''))}
             onSave={onSave}
             onSaveError={onError}
+            forbiddenNetworkTypes={forbiddenNetworkTypes}
             subProfiles={Array.from(subProfiles)}
             apns={Array.from(apns)}
           />
@@ -254,6 +260,7 @@ function SubscriberTableRowComponent(props: Props) {
             onSaveError={reason => {
               enqueueSnackbar(reason, {variant: 'error'});
             }}
+            forbiddenNetworkTypes={forbiddenNetworkTypes}
             subProfiles={Array.from(props.subProfiles)}
             apns={Array.from(props.apns)}
           />

--- a/nms/packages/magmalte/app/components/context/SubscriberContext.js
+++ b/nms/packages/magmalte/app/components/context/SubscriberContext.js
@@ -14,6 +14,7 @@
  * @format
  */
 import type {
+  core_network_types,
   gateway_id,
   mutable_subscriber,
   mutable_subscribers,
@@ -39,6 +40,7 @@ setState: POST, PUT, DELETE subscriber
 export type SubscriberContextType = {
   state: {[string]: subscriber},
   sessionState: {[string]: subscriber_state},
+  forbiddenNetworkTypes: {[string]: core_network_types},
   metrics?: {[string]: Metrics},
   gwSubscriberMap: {[gateway_id]: Array<subscriber_id>},
   setState?: (

--- a/nms/packages/magmalte/app/components/lte/AddEditSubscriberDialog.js
+++ b/nms/packages/magmalte/app/components/lte/AddEditSubscriberDialog.js
@@ -14,7 +14,11 @@
  * @format
  */
 
-import type {apn_list, subscriber} from '../../../generated/MagmaAPIBindings';
+import type {
+  apn_list,
+  core_network_types,
+  subscriber,
+} from '../../../generated/MagmaAPIBindings';
 
 import Button from '@fbcnms/ui/components/design-system/Button';
 import Dialog from '@material-ui/core/Dialog';
@@ -50,6 +54,7 @@ type EditingSubscriber = {
   lteState: 'ACTIVE' | 'INACTIVE',
   authKey: string,
   authOpc: string,
+  forbiddenNetworkTypes: core_network_types,
   subProfile: string,
   apnList: apn_list,
 };
@@ -60,6 +65,7 @@ type Props = {
   onSaveError: (reason: string) => void,
   editingSubscriber?: subscriber,
   subProfiles: Array<string>,
+  forbiddenNetworkTypes: core_network_types,
   apns: apn_list,
 };
 
@@ -72,6 +78,7 @@ function buildEditingSubscriber(
       lteState: 'ACTIVE',
       authKey: '',
       authOpc: '',
+      forbiddenNetworkTypes: [],
       subProfile: 'default',
       apnList: [],
     };
@@ -91,6 +98,7 @@ function buildEditingSubscriber(
     lteState: editingSubscriber.lte.state,
     authKey,
     authOpc,
+    forbiddenNetworkTypes: editingSubscriber.forbidden_network_types || [],
     subProfile: editingSubscriber.lte.sub_profile,
     apnList: editingSubscriber.active_apns || [],
   };
@@ -124,6 +132,7 @@ export default function AddEditSubscriberDialog(props: Props) {
         auth_opc: editingSubscriber.authOpc || undefined,
         sub_profile: editingSubscriber.subProfile,
       },
+      forbidden_network_types: editingSubscriber.forbiddenNetworkTypes,
       active_apns: editingSubscriber.apnList,
     };
     if (data.lte.auth_key && isValidHex(data.lte.auth_key)) {
@@ -218,6 +227,27 @@ export default function AddEditSubscriberDialog(props: Props) {
             {props.subProfiles.map(p => (
               <MenuItem value={p} key={p}>
                 {p}
+              </MenuItem>
+            ))}
+          </Select>
+        </FormControl>
+        <FormControl className={classes.input}>
+          <InputLabel htmlFor="forbiddenNetworkTypes">
+            Forbidden Network Types
+          </InputLabel>
+          <Select
+            inputProps={{id: 'forbiddenNetworkTypes'}}
+            value={editingSubscriber.forbiddenNetworkTypes}
+            multiple={false}
+            onChange={({target}) =>
+              setEditingSubscriber({
+                ...editingSubscriber,
+                forbiddenNetworkTypes: ((target.value: any): core_network_types),
+              })
+            }>
+            {props.forbiddenNetworkTypes.map(nw => (
+              <MenuItem value={nw} key={nw}>
+                {nw}
               </MenuItem>
             ))}
           </Select>

--- a/nms/packages/magmalte/app/components/lte/LteContext.js
+++ b/nms/packages/magmalte/app/components/lte/LteContext.js
@@ -238,6 +238,7 @@ export function TraceContextProvider(props: Props) {
 export function SubscriberContextProvider(props: Props) {
   const {networkId} = props;
   const [subscriberMap, setSubscriberMap] = useState({});
+  const [forbiddenNetworkTypes, setForbiddenNetworkTypes] = useState({});
   const [sessionState, setSessionState] = useState({});
   const [subscriberMetrics, setSubscriberMetrics] = useState({});
   const [isLoading, setIsLoading] = useState(true);
@@ -250,6 +251,7 @@ export function SubscriberContextProvider(props: Props) {
       await InitSubscriberState({
         networkId,
         setSubscriberMap,
+        setForbiddenNetworkTypes,
         setSubscriberMetrics,
         setSessionState,
         enqueueSnackbar,
@@ -266,6 +268,7 @@ export function SubscriberContextProvider(props: Props) {
   return (
     <SubscriberContext.Provider
       value={{
+        forbiddenNetworkTypes: forbiddenNetworkTypes,
         state: subscriberMap,
         metrics: subscriberMetrics,
         sessionState: sessionState,
@@ -281,6 +284,7 @@ export function SubscriberContextProvider(props: Props) {
             subscriberMap,
             setSubscriberMap,
             setSessionState,
+            setForbiddenNetworkTypes,
             key,
             value,
             newState,

--- a/nms/packages/magmalte/app/views/network/__tests__/NetworkTest.js
+++ b/nms/packages/magmalte/app/views/network/__tests__/NetworkTest.js
@@ -30,6 +30,7 @@ import SubscriberContext from '../../../components/context/SubscriberContext';
 import axiosMock from 'axios';
 import defaultTheme from '../../../theme/default.js';
 
+import {CoreNetworkTypes} from '../../subscriber/SubscriberUtils';
 import {MemoryRouter, Route} from 'react-router-dom';
 import {MuiThemeProvider} from '@material-ui/core/styles';
 import {UpdateNetworkState} from '../../../state/lte/NetworkState';
@@ -42,6 +43,9 @@ jest.mock('../../../../generated/MagmaAPIBindings.js');
 jest.mock('@fbcnms/ui/hooks/useSnackbar');
 afterEach(cleanup);
 const enqueueSnackbarMock = jest.fn();
+const forbiddenNetworkTypes = Object.keys(CoreNetworkTypes).map(
+  key => CoreNetworkTypes[key],
+);
 jest
   .spyOn(require('@fbcnms/ui/hooks/useSnackbar'), 'useEnqueueSnackbar')
   .mockReturnValue(enqueueSnackbarMock);
@@ -198,6 +202,7 @@ describe('<NetworkDashboard />', () => {
   const subscribers = {
     IMSI00000000001002: {
       active_apns: ['oai.ipv4'],
+      forbidden_network_types: forbiddenNetworkTypes,
       id: 'IMSI722070171001002',
       lte: {
         auth_algo: 'MILENAGE',
@@ -207,6 +212,7 @@ describe('<NetworkDashboard />', () => {
         sub_profile: 'default',
       },
       config: {
+        forbidden_network_types: forbiddenNetworkTypes,
         lte: {
           auth_algo: 'MILENAGE',
           auth_key: 'i69HPy+P0JSHzMvXCXxoYg==',
@@ -305,6 +311,8 @@ describe('<NetworkDashboard />', () => {
 
     const subscriberCtx = {
       state: subscribers,
+      forbidden_network_types: subscribers,
+      forbiddenNetworkTypes: {},
       gwSubscriberMap: {},
       sessionState: {},
     };

--- a/nms/packages/magmalte/app/views/subscriber/SubscriberDetailConfig.js
+++ b/nms/packages/magmalte/app/views/subscriber/SubscriberDetailConfig.js
@@ -215,11 +215,32 @@ function SubscriberInfoConfig({subscriberInfo}: {subscriberInfo: subscriber}) {
   const [authOPC, _setAuthOPC] = useState(subscriberInfo.lte.auth_opc ?? false);
   const [dataPlan, _setDataPlan] = useState(subscriberInfo.lte.sub_profile);
 
+  function CollapseItems(props) {
+    const data: DataRows[] = [
+      [
+        {
+          value: props.data || '-',
+        },
+      ],
+    ];
+
+    return <DataGrid data={data} />;
+  }
+
   const kpiData: DataRows[] = [
     [
       {
         category: 'LTE Network Access',
         value: subscriberInfo.lte.state,
+      },
+    ],
+    [
+      {
+        category: 'Forbidden Network Types',
+        value: subscriberInfo.forbidden_network_types?.length || 0,
+        collapse: subscriberInfo.forbidden_network_types?.map(data => (
+          <CollapseItems key={data} data={data} />
+        )) || <></>,
       },
     ],
     [

--- a/nms/packages/magmalte/app/views/subscriber/SubscriberTable.js
+++ b/nms/packages/magmalte/app/views/subscriber/SubscriberTable.js
@@ -151,6 +151,11 @@ async function exportSubscribers(props: ExportProps) {
               case 'state':
               case 'sub_profile':
                 return subscriberConfig[columnDef.field];
+              case 'forbidden_network_types':
+              case 'name':
+                return typeof subscriberInfo[columnDef.field] === 'object'
+                  ? subscriberInfo[columnDef.field].join(', ')
+                  : subscriberInfo[columnDef.field];
               case 'id':
               case 'active_apns':
               case 'name':
@@ -237,6 +242,7 @@ function SubscriberActionsMenu(props: {onClose: () => void}) {
         const newSubscriber: mutable_subscriber = {
           active_apns: subscriber.apns,
           active_policies: subscriber.policies,
+          forbidden_network_types: subscriber.forbiddenNetworkTypes,
           id: subscriber.imsi,
           name: subscriber.name,
           lte: {

--- a/nms/packages/magmalte/app/views/subscriber/SubscriberUtils.js
+++ b/nms/packages/magmalte/app/views/subscriber/SubscriberUtils.js
@@ -36,6 +36,11 @@ export function convertBitToMbit(val: number) {
   return (val / mBIT).toFixed(2);
 }
 
+export const CoreNetworkTypes = Object.freeze({
+  NT_EPC: 'EPC',
+  NT_5GC: '5GC',
+});
+
 export function getPromValue(resp: promql_return_object) {
   const respArr = resp?.data?.result
     ?.map(item => {
@@ -59,6 +64,7 @@ export const SUBSCRIBER_EXPORT_COLUMNS = [
   {title: 'Auth Key', field: 'auth_key'},
   {title: 'Auth OPC', field: 'auth_opc'},
   {title: 'Service', field: 'state'},
+  {title: 'Forbidden Network Types', field: 'forbidden_network_types'},
   {title: 'Data Plan', field: 'sub_profile'},
   {title: 'Active APNs', field: 'active_apns'},
 ];

--- a/nms/packages/magmalte/app/views/subscriber/__tests__/SubscriberAddEditTest.js
+++ b/nms/packages/magmalte/app/views/subscriber/__tests__/SubscriberAddEditTest.js
@@ -27,6 +27,7 @@ import SubscriberDashboard from '../SubscriberOverview';
 import SubscriberDetailConfig from '../SubscriberDetailConfig';
 import defaultTheme from '../../../theme/default.js';
 
+import {CoreNetworkTypes} from '../SubscriberUtils';
 import {MemoryRouter, Route} from 'react-router-dom';
 import {MuiThemeProvider} from '@material-ui/core/styles';
 import {cleanup, fireEvent, render, wait} from '@testing-library/react';
@@ -38,6 +39,9 @@ jest.mock('../../../../generated/MagmaAPIBindings.js');
 jest.mock('@fbcnms/ui/hooks/useSnackbar');
 afterEach(cleanup);
 const enqueueSnackbarMock = jest.fn();
+const forbiddenNetworkTypes = Object.keys(CoreNetworkTypes).map(
+  key => CoreNetworkTypes[key],
+);
 jest
   .spyOn(require('@fbcnms/ui/hooks/useSnackbar'), 'useEnqueueSnackbar')
   .mockReturnValue(enqueueSnackbarMock);
@@ -47,6 +51,7 @@ const subscribersMock = {
     name: 'subscriber0',
     active_apns: ['apn_0'],
     id: 'IMSI00000000001002',
+    forbidden_network_types: forbiddenNetworkTypes,
     lte: {
       auth_algo: 'MILENAGE',
       auth_key: 'i69HPy+P0JSHzMvXCXxoYg==',
@@ -55,6 +60,7 @@ const subscribersMock = {
       sub_profile: 'default',
     },
     config: {
+      forbidden_network_types: forbiddenNetworkTypes,
       lte: {
         auth_algo: 'MILENAGE',
         auth_key: 'i69HPy+P0JSHzMvXCXxoYg==',
@@ -69,6 +75,7 @@ const subscribersMock = {
     name: 'subscriber1',
     active_apns: [],
     id: 'IMSI00000000001003',
+    forbidden_network_types: forbiddenNetworkTypes,
     lte: {
       auth_algo: 'MILENAGE',
       auth_key: 'i69HPy+P0JSHzMvXCXxoYg==',
@@ -77,6 +84,7 @@ const subscribersMock = {
       sub_profile: 'default',
     },
     config: {
+      forbidden_network_types: forbiddenNetworkTypes,
       lte: {
         auth_algo: 'MILENAGE',
         auth_key: 'i69HPy+P0JSHzMvXCXxoYg==',
@@ -219,9 +227,11 @@ describe('<AddSubscriberButton />', () => {
   const AddWrapper = () => {
     const [subscribers, setSubscribers] = useState(subscribersMock);
     const [sessionState, setSessionState] = useState({});
+    const [forbiddenNetworkTypes, setForbiddenNetworkTypes] = useState({});
 
     const subscriberCtx = {
       state: subscribers,
+      forbiddenNetworkTypes: forbiddenNetworkTypes,
       gwSubscriberMap: {},
       sessionState: sessionState,
       setState: async (key, value?) =>
@@ -232,6 +242,7 @@ describe('<AddSubscriberButton />', () => {
           key: key,
           value: value,
           setSessionState: setSessionState,
+          setForbiddenNetworkTypes: setForbiddenNetworkTypes,
         }),
     };
     const policyCtx = {
@@ -288,6 +299,7 @@ describe('<AddSubscriberButton />', () => {
   const DetailWrapper = () => {
     const [subscribers, setSubscribers] = useState(subscribersMock);
     const [sessionState, setSessionState] = useState({});
+    const [forbiddenNetworkTypes, setForbiddenNetworkTypes] = useState({});
     const policyCtx = {
       state: policies,
       qosProfiles: {},
@@ -329,6 +341,7 @@ describe('<AddSubscriberButton />', () => {
                         IMSI00000000001002: subscribers['IMSI00000000001002'],
                       },
                       gwSubscriberMap: {},
+                      forbiddenNetworkTypes: forbiddenNetworkTypes,
                       sessionState: sessionState,
                       setState: (key, value?) =>
                         setSubscriberState({
@@ -336,6 +349,7 @@ describe('<AddSubscriberButton />', () => {
                           subscriberMap: subscribers,
                           setSubscriberMap: setSubscribers,
                           setSessionState,
+                          setForbiddenNetworkTypes,
                           key: key,
                           value: value,
                         }),
@@ -409,7 +423,6 @@ describe('<AddSubscriberButton />', () => {
       fireEvent.change(authOpc, {
         target: {value: '8e27b6af0e692e750f32667a3b14605d'},
       });
-      // }
     } else {
       throw 'invalid type';
     }
@@ -479,6 +492,7 @@ describe('<AddSubscriberButton />', () => {
       subscriber: {
         active_apns: ['apn_0'],
         active_base_names: undefined,
+        forbidden_network_types: forbiddenNetworkTypes,
         id: 'IMSI00000000001002',
         lte: {
           auth_algo: 'MILENAGE',

--- a/nms/packages/magmalte/app/views/subscriber/__tests__/SubscriberTest.js
+++ b/nms/packages/magmalte/app/views/subscriber/__tests__/SubscriberTest.js
@@ -22,6 +22,7 @@ import SubscriberContext from '../../../components/context/SubscriberContext';
 import SubscriberDashboard from '../SubscriberOverview';
 import defaultTheme from '../../../theme/default.js';
 
+import {CoreNetworkTypes} from '../SubscriberUtils';
 import {MemoryRouter, Route} from 'react-router-dom';
 import {MuiThemeProvider} from '@material-ui/core/styles';
 import {cleanup, fireEvent, render, wait} from '@testing-library/react';
@@ -31,6 +32,9 @@ jest.mock('../../../../generated/MagmaAPIBindings.js');
 jest.mock('@fbcnms/ui/hooks/useSnackbar');
 afterEach(cleanup);
 const enqueueSnackbarMock = jest.fn();
+const forbiddenNetworkTypes = Object.keys(CoreNetworkTypes).map(
+  key => CoreNetworkTypes[key],
+);
 jest
   .spyOn(require('@fbcnms/ui/hooks/useSnackbar'), 'useEnqueueSnackbar')
   .mockReturnValue(enqueueSnackbarMock);
@@ -38,6 +42,7 @@ const subscribers = {
   IMSI0000000000: {
     name: 'subscriber0',
     active_apns: ['oai.ipv4'],
+    forbidden_network_types: forbiddenNetworkTypes,
     id: 'IMSI0000000000',
     lte: {
       auth_algo: 'MILENAGE',
@@ -47,6 +52,7 @@ const subscribers = {
       sub_profile: 'default',
     },
     config: {
+      forbidden_network_types: forbiddenNetworkTypes,
       lte: {
         auth_algo: 'MILENAGE',
         auth_key: 'i69HPy+P0JSHzMvXCXxoYg==',
@@ -59,6 +65,7 @@ const subscribers = {
   IMSI0000000001: {
     name: 'subscriber1',
     active_apns: ['oai.ipv4'],
+    forbidden_network_types: forbiddenNetworkTypes,
     id: 'IMSI0000000001',
     lte: {
       auth_algo: 'MILENAGE',
@@ -68,6 +75,7 @@ const subscribers = {
       sub_profile: 'default',
     },
     config: {
+      forbidden_network_types: forbiddenNetworkTypes,
       lte: {
         auth_algo: 'MILENAGE',
         auth_key: 'i69HPy+P0JSHzMvXCXxoYg==',
@@ -90,6 +98,7 @@ describe('<SubscriberDashboard />', () => {
   const Wrapper = () => {
     const subscriberCtx = {
       state: subscribers,
+      forbiddenNetworkTypes: {},
       gwSubscriberMap: {},
       sessionState: {},
     };

--- a/nms/packages/magmalte/generated/MagmaAPIBindings.js
+++ b/nms/packages/magmalte/generated/MagmaAPIBindings.js
@@ -191,6 +191,8 @@ export type ci_node = {
 export type config_info = {
     mconfig_created_at ? : number,
 };
+export type core_network_types = Array < "EPC" | "5GC" >
+;
 export type csfb = {
     client ? : sctp_client_configs,
 };
@@ -895,6 +897,7 @@ export type mutable_subscriber = {
     active_base_names ? : base_names,
     active_policies ? : policy_ids,
     active_policies_by_apn ? : policy_ids_by_apn,
+    forbidden_network_types ? : core_network_types,
     id: subscriber_id,
     lte: lte_subscription,
     name ? : string,
@@ -1407,6 +1410,7 @@ export type subscriber = {
     active_policies ? : policy_ids,
     active_policies_by_apn ? : policy_ids_by_apn,
     config: subscriber_config,
+    forbidden_network_types ? : core_network_types,
     id: subscriber_id,
     lte: lte_subscription,
     monitoring ? : subscriber_status,
@@ -1415,6 +1419,7 @@ export type subscriber = {
     state ? : subscriber_state,
 };
 export type subscriber_config = {
+    forbidden_network_types ? : core_network_types,
     lte: lte_subscription,
     static_ips ? : subscriber_static_ips,
 };


### PR DESCRIPTION
### **Summary**

This PR deals with the changes as mentioned in the proposal https://github.com/magma/magma/issues/8904

Updated NMS UI to configure allowed network types for Subscriber.
Added support for POST/PUT/GET operations of Subscriber.
By default ["EPC", "5GC"] is configured as allowed network types for Subscriber from NMS.
This PR depends on https://github.com/magma/magma/pull/9161 (For Orc8r changes)

### **Order of Merge**
Please merge the current PR as per the below specified order
PR #9161 - PR #9165 - PR #9775 

### **Test Plan**

Added Unit test cases for all the modified functions.
Verified end-to-end by configuring network type from NMS UI and listed the same using subscriber_cli.py script in AGW.
Please find the screenshots for the same in the comment below.

