### PR TITLE
feat: modify devcontainer to support bazel builds

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -9,6 +9,10 @@ build --cxxopt=-g2
 build:docker --disk_cache=/magma/.bazel-cache
 build:docker --repository_cache=/magma/.bazel-cache-repo
 
+build:devcontainer --disk_cache=/workspaces/magma/.bazel-cache
+build:devcontainer --repository_cache=/workspaces/magma/.bazel-cache-repo
+build:devcontainer --define=folly_so=1
+
 build:specify_vm_cc --action_env=CC=/usr/bin/gcc
 build:specify_vm_cc --action_env=CXX=/usr/bin/g++
 

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -85,6 +85,14 @@ RUN echo "Install general purpose packages" && \
         update-alternatives --install /usr/bin/clang-tidy clang-tidy /usr/lib/llvm-11/bin/clang-tidy 10 && \
         update-alternatives --install /usr/bin/clang-apply-replacements clang-apply-replacements /usr/lib/llvm-11/bin/clang-apply-replacements 10
 
+RUN DEBIAN_FRONTEND=noninteractive apt-get install -y clangd-12
+
+# Install bazel
+WORKDIR /usr/sbin
+RUN wget --progress=dot:giga https://github.com/bazelbuild/bazelisk/releases/download/v1.10.0/bazelisk-linux-amd64 && \
+    chmod +x bazelisk-linux-amd64 && \
+    ln -s /usr/sbin/bazelisk-linux-amd64 /usr/sbin/bazel
+
 RUN echo "Install 3rd party dependencies" && \
     apt-get update && \
     echo "Install CMake" && \

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,14 +3,18 @@
 		"CoenraadS.bracket-pair-colorizer-2",
 		"xaver.clang-format",
 		"notskm.clang-tidy",
-		"ms-vscode.cpptools",
 		"eamodio.gitlens",
 		"yzhang.markdown-all-in-one",
 		"christian-kohler.path-intellisense",
 		"vscodevim.vim",
 		"vscode-icons-team.vscode-icons",
 		"ms-vsliveshare.vsliveshare",
-		"ms-azuretools.vscode-docker"
+		"ms-azuretools.vscode-docker",
+		"llvm-vs-code-extensions.vscode-clangd",
+		"mitaki28.vscode-clang",
+		"stackbuild.bazel-stack-vscode",
+		"coolchyni.beyond-debug",
+		"stackbuild.bazel-stack-vscode-cc",
 	],
 	"image": "ghcr.io/magma/devcontainer:sha-b435783",
 	"settings": {
@@ -47,6 +51,36 @@
 			"-I/workspaces/magma/lte/gateway/c/oai/tasks/nas/esm/msg/",
 			"-I/workspaces/magma/lte/gateway/c/oai/tasks/nas/ies/",
 			"-I/workspaces/magma/lte/gateway/c/oai/tasks/nas/util/"
+		],
+		"files.watcherExclude": {
+			"**/.bazel-cache/**": true,
+			"**/.bazel-cache-repo/**": true,
+		},		
+		"bsv.bazel.buildFlags": [
+			"--config=devcontainer",
+		],
+		"bsv.bazel.testFlags": [
+			"--compilation_mode=dbg",
+		],
+		"bsv.bes.enabled": false,
+		"bsv.bzl.codesearch.enabled": false,
+		"bsv.bzl.invocation.buildEventPublishAllActions": false,
+		"bsv.bzl.invocation.enabled": false,
+		"bsv.bzl.invocation.invokeWithBuildEventStreaming": false,
+		"bsv.bzl.lsp.enableCodelensStarlarkDebug": false,
+		"bsv.bzl.lsp.enableCodelensRun": false,
+		"bsv.bzl.remoteCache.enabled": false,
+		"bsv.bzl.starlarkDebugger.enabled": false,
+		"clangd.path": "clangd-12",
+		"clangd.arguments": [
+			"-log=verbose",
+			"-pretty",
+			"--background-index",
+		],
+		"clangd.onConfigChanged": "restart",
+		// Update this field with any new targets that need compilation database generation
+		"bsv.cc.compdb.targets": [
+			"//lte/gateway/c/session_manager:sessiond"
 		]
 	},
 	"mounts": [

--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -10,7 +10,6 @@
 # limitations under the License.
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
-load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 load("//:third_party_repositories.bzl", "boost", "cpp_redis", "cpp_testing_deps", "gflags", "glog", "grpc", "nlohmann_json", "prometheus_cpp_deps", "protobuf", "yaml_cpp")
 
 ### BUILDIFIER DEPENDENCIES


### PR DESCRIPTION
Signed-off-by: Marie Bremner <marwhal@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary
See https://github.com/magma/magma/pull/9172 for some fixes done via the Clang Tidy linting enabled by this PR. :) 

Still trying to figure out a way to add all the debug / build configurations to the devcontainer setup. Will work on those next. 

1. Added a devcontainer bazel configuration to get bazel builds to work in this env
2. Added a similar extension configuration to `vscode-workspaces/workspace.magma-vm-workspace.code-workspace` (most non-core bazel functionalities are turned off by default, as they require subscription or they are still experimental)
3. turning off cpptools extension as it collides with clangd

<!-- Enumerate changes you made and why you made them -->

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
