### PR TITLE
chore: commit leftover formatting changes from PR8936

### DIFF
--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_active_tau_with_combined_tala_update_reattach.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_active_tau_with_combined_tala_update_reattach.py
@@ -21,6 +21,7 @@ import s1ap_wrapper
 
 class TestAttachActiveTauWithCombinedTalaUpdateReattach(unittest.TestCase):
     """Test combined TAU with TA/LA updating and active flag set to true"""
+
     def setUp(self):
         """Initialize"""
         self._s1ap_wrapper = s1ap_wrapper.TestWrapper()

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_ipv6.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_ipv6.py
@@ -57,8 +57,8 @@ class TestAttachDetachIpv6(unittest.TestCase):
                 "UE id ", req.ue_id,
             )
             self._s1ap_wrapper.configAPN(
-                "IMSI" + "".join([str(j) for j in req.imsi]), 
-                apn_list, default=False
+                "IMSI" + "".join([str(j) for j in req.imsi]),
+                apn_list, default=False,
             )
             # Now actually complete the attach
             self._s1ap_wrapper._s1_util.attach(

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_inactive_tau_with_combined_tala_update_reattach.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_inactive_tau_with_combined_tala_update_reattach.py
@@ -21,6 +21,7 @@ import s1ap_wrapper
 
 class TestAttachInactiveTauWithCombinedTalaUpdateReattach(unittest.TestCase):
     """Test combined TAU with TA/LA updating and active flag set to false"""
+
     def setUp(self):
         """Initialize"""
         self._s1ap_wrapper = s1ap_wrapper.TestWrapper()


### PR DESCRIPTION
Signed-off-by: Marie Bremner <marwhal@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary
Ran 
```
./lte/gateway/python/precommit.py -f -p lte/gateway/python/integ_tests/s1aptests/s1ap_utils.py lte/gateway/python/integ_tests/s1aptests/test_attach_active_tau_with_combined_tala_update_reattach.py lte/gateway/python/integ_tests/s1aptests/test_attach_detach_ipv6.py lte/gateway/python/integ_tests/s1aptests/test_attach_inactive_tau_with_combined_tala_update_reattach.py lte/gateway/python/magma/subscriberdb/protocols/m5g_auth_servicer.py lte/gateway/python/magma/subscriberdb/protocols/s6a_proxy_servicer.py lte/gateway/python/magma/subscriberdb/rpc_servicer.py lte/gateway/python/scripts/generate_oai_config.py
```
<!-- Enumerate changes you made and why you made them -->

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
