### PR TITLE
chore: address clang tidy warnings on sessiond

### DIFF
--- a/lte/gateway/c/session_manager/AAAClient.cpp
+++ b/lte/gateway/c/session_manager/AAAClient.cpp
@@ -96,7 +96,7 @@ bool AsyncAAAClient::add_sessions(const magma::lte::SessionMap& session_map) {
                 << "sessions found";
     return true;
   }
-  add_sessions_rpc(req, [this](Status status, acct_resp resp) {
+  add_sessions_rpc(req, [](Status status, acct_resp resp) {
     if (status.ok()) {
       MLOG(MINFO) << "Successfully added all existing sessions to AAA server";
     } else {
@@ -112,8 +112,8 @@ void AsyncAAAClient::add_sessions_rpc(
     std::function<void(Status, acct_resp)> callback) {
   auto local_resp = new magma::AsyncLocalResponse<acct_resp>(
       std::move(callback), RESPONSE_TIMEOUT);
-  local_resp->set_response_reader(std::move(
-      stub_->Asyncadd_sessions(local_resp->get_context(), request, &queue_)));
+  local_resp->set_response_reader(
+      stub_->Asyncadd_sessions(local_resp->get_context(), request, &queue_));
 }
 
 void AsyncAAAClient::terminate_session_rpc(
@@ -121,8 +121,8 @@ void AsyncAAAClient::terminate_session_rpc(
     std::function<void(Status, acct_resp)> callback) {
   auto local_resp = new magma::AsyncLocalResponse<acct_resp>(
       std::move(callback), RESPONSE_TIMEOUT);
-  local_resp->set_response_reader(std::move(stub_->Asyncterminate_session(
-      local_resp->get_context(), request, &queue_)));
+  local_resp->set_response_reader(stub_->Asyncterminate_session(
+      local_resp->get_context(), request, &queue_));
 }
 
 }  // namespace aaa

--- a/lte/gateway/c/session_manager/AmfServiceClient.cpp
+++ b/lte/gateway/c/session_manager/AmfServiceClient.cpp
@@ -30,8 +30,8 @@ bool AsyncAmfServiceClient::handle_response_to_access(
   MLOG(MDEBUG) << "Sending Set SM Session Response from SMF ";
   auto local_resp = new AsyncLocalResponse<SmContextVoid>(
       std::move(callback), RESPONSE_TIMEOUT);
-  local_resp->set_response_reader(std::move(stub_->AsyncSetSmfSessionContext(
-      local_resp->get_context(), response, &queue_)));
+  local_resp->set_response_reader(stub_->AsyncSetSmfSessionContext(
+      local_resp->get_context(), response, &queue_));
   return true;
 }
 
@@ -40,8 +40,8 @@ bool AsyncAmfServiceClient::handle_notification_to_access(
   MLOG(MDEBUG) << "Sending Set SM Session Notification from SMF ";
   auto local_resp = new AsyncLocalResponse<SmContextVoid>(
       std::move(callback), RESPONSE_TIMEOUT);
-  local_resp->set_response_reader(std::move(stub_->AsyncSetAmfNotification(
-      local_resp->get_context(), notif, &queue_)));
+  local_resp->set_response_reader(stub_->AsyncSetAmfNotification(
+      local_resp->get_context(), notif, &queue_));
   return true;
 }
 

--- a/lte/gateway/c/session_manager/DirectorydClient.cpp
+++ b/lte/gateway/c/session_manager/DirectorydClient.cpp
@@ -36,8 +36,8 @@ void AsyncDirectorydClient::update_directoryd_record(
     std::function<void(Status status, Void)> callback) {
   auto local_response =
       new AsyncLocalResponse<Void>(std::move(callback), RESPONSE_TIMEOUT);
-  local_response->set_response_reader(std::move(stub_->AsyncUpdateRecord(
-      local_response->get_context(), request, &queue_)));
+  local_response->set_response_reader(stub_->AsyncUpdateRecord(
+      local_response->get_context(), request, &queue_));
 }
 
 void AsyncDirectorydClient::delete_directoryd_record(
@@ -45,8 +45,8 @@ void AsyncDirectorydClient::delete_directoryd_record(
     std::function<void(Status status, Void)> callback) {
   auto local_response =
       new AsyncLocalResponse<Void>(std::move(callback), RESPONSE_TIMEOUT);
-  local_response->set_response_reader(std::move(stub_->AsyncDeleteRecord(
-      local_response->get_context(), request, &queue_)));
+  local_response->set_response_reader(stub_->AsyncDeleteRecord(
+      local_response->get_context(), request, &queue_));
 }
 
 void AsyncDirectorydClient::get_all_directoryd_records(
@@ -54,7 +54,7 @@ void AsyncDirectorydClient::get_all_directoryd_records(
   magma::Void request;
   auto local_resp = new AsyncLocalResponse<AllDirectoryRecords>(
       std::move(callback), RESPONSE_TIMEOUT);
-  local_resp->set_response_reader(std::move(stub_->AsyncGetAllDirectoryRecords(
-      local_resp->get_context(), request, &queue_)));
+  local_resp->set_response_reader(stub_->AsyncGetAllDirectoryRecords(
+      local_resp->get_context(), request, &queue_));
 }
 }  // namespace magma

--- a/lte/gateway/c/session_manager/DirectorydClient.h
+++ b/lte/gateway/c/session_manager/DirectorydClient.h
@@ -25,6 +25,7 @@
 
 namespace magma {
 using namespace orc8r;
+using grpc::Status;
 
 /**
  * DirectorydClient is the base class for managing interactions with DirectoryD.

--- a/lte/gateway/c/session_manager/LocalEnforcer.cpp
+++ b/lte/gateway/c/session_manager/LocalEnforcer.cpp
@@ -281,10 +281,10 @@ void LocalEnforcer::increment_all_policy_versions(SessionMap& session_map) {
       auto session_info = session->get_session_info_for_setup();
       SessionStateUpdateCriteria& uc =
           session_update[session_info.imsi][session->get_session_id()];
-      for (const magma::RuleToProcess val : session_info.gx_rules) {
+      for (const magma::RuleToProcess& val : session_info.gx_rules) {
         session->increment_rule_stats(val.rule.id(), &uc);
       }
-      for (const magma::RuleToProcess val : session_info.gy_dynamic_rules) {
+      for (const magma::RuleToProcess& val : session_info.gy_dynamic_rules) {
         session->increment_rule_stats(val.rule.id(), &uc);
       }
     }

--- a/lte/gateway/c/session_manager/LocalEnforcer.h
+++ b/lte/gateway/c/session_manager/LocalEnforcer.h
@@ -38,7 +38,6 @@
 #include "ShardTracker.h"
 
 namespace magma {
-using std::experimental::optional;
 
 using ImsiAndSessionID = std::pair<std::string, std::string>;
 

--- a/lte/gateway/c/session_manager/LocalSessionManagerHandler.h
+++ b/lte/gateway/c/session_manager/LocalSessionManagerHandler.h
@@ -24,7 +24,6 @@
 #include "SessionReporter.h"
 #include "SessionStore.h"
 
-using grpc::Server;
 using grpc::ServerContext;
 using grpc::Status;
 

--- a/lte/gateway/c/session_manager/MobilitydClient.cpp
+++ b/lte/gateway/c/session_manager/MobilitydClient.cpp
@@ -34,7 +34,7 @@ void AsyncMobilitydClient::get_subscriberid_from_ipv4(
     std::function<void(Status status, SubscriberID)> callback) {
   auto local_resp = new AsyncLocalResponse<SubscriberID>(
       std::move(callback), RESPONSE_TIMEOUT);
-  local_resp->set_response_reader(std::move(stub_->AsyncGetSubscriberIDFromIP(
-      local_resp->get_context(), ue_ip_addr, &queue_)));
+  local_resp->set_response_reader(stub_->AsyncGetSubscriberIDFromIP(
+      local_resp->get_context(), ue_ip_addr, &queue_));
 }
 }  // namespace magma

--- a/lte/gateway/c/session_manager/MobilitydClient.h
+++ b/lte/gateway/c/session_manager/MobilitydClient.h
@@ -24,7 +24,6 @@ using grpc::Status;
 
 namespace magma {
 using namespace lte;
-using std::experimental::optional;
 
 /**
  * MobilitydClient is the base class for managing interactions with MobilityD.

--- a/lte/gateway/c/session_manager/ObjectMap.h
+++ b/lte/gateway/c/session_manager/ObjectMap.h
@@ -12,6 +12,9 @@
  */
 #pragma once
 
+#include <string>
+#include <vector>
+
 namespace magma {
 
 enum ObjectMapResult {

--- a/lte/gateway/c/session_manager/PipelinedClient.cpp
+++ b/lte/gateway/c/session_manager/PipelinedClient.cpp
@@ -469,8 +469,8 @@ void AsyncPipelinedClient::set_upf_session_rpc(
   auto local_resp = new AsyncLocalResponse<UPFSessionContextState>(
       std::move(callback), RESPONSE_TIMEOUT);
   PrintGrpcMessage(static_cast<const google::protobuf::Message&>(request));
-  local_resp->set_response_reader(std::move(
-      stub_->AsyncSetSMFSessions(local_resp->get_context(), request, &queue_)));
+  local_resp->set_response_reader(
+      stub_->AsyncSetSMFSessions(local_resp->get_context(), request, &queue_));
 }
 
 void AsyncPipelinedClient::setup_default_controllers_rpc(
@@ -479,8 +479,8 @@ void AsyncPipelinedClient::setup_default_controllers_rpc(
   auto local_resp = new AsyncLocalResponse<SetupFlowsResult>(
       std::move(callback), RESPONSE_TIMEOUT);
   PrintGrpcMessage(static_cast<const google::protobuf::Message&>(request));
-  local_resp->set_response_reader(std::move(stub_->AsyncSetupDefaultControllers(
-      local_resp->get_context(), request, &queue_)));
+  local_resp->set_response_reader(stub_->AsyncSetupDefaultControllers(
+      local_resp->get_context(), request, &queue_));
 }
 
 void AsyncPipelinedClient::setup_policy_rpc(
@@ -489,8 +489,8 @@ void AsyncPipelinedClient::setup_policy_rpc(
   auto local_resp = new AsyncLocalResponse<SetupFlowsResult>(
       std::move(callback), RESPONSE_TIMEOUT);
   PrintGrpcMessage(static_cast<const google::protobuf::Message&>(request));
-  local_resp->set_response_reader(std::move(stub_->AsyncSetupPolicyFlows(
-      local_resp->get_context(), request, &queue_)));
+  local_resp->set_response_reader(stub_->AsyncSetupPolicyFlows(
+      local_resp->get_context(), request, &queue_));
 }
 
 void AsyncPipelinedClient::setup_ue_mac_rpc(
@@ -499,8 +499,8 @@ void AsyncPipelinedClient::setup_ue_mac_rpc(
   auto local_resp = new AsyncLocalResponse<SetupFlowsResult>(
       std::move(callback), RESPONSE_TIMEOUT);
   PrintGrpcMessage(static_cast<const google::protobuf::Message&>(request));
-  local_resp->set_response_reader(std::move(stub_->AsyncSetupUEMacFlows(
-      local_resp->get_context(), request, &queue_)));
+  local_resp->set_response_reader(
+      stub_->AsyncSetupUEMacFlows(local_resp->get_context(), request, &queue_));
 }
 
 void AsyncPipelinedClient::deactivate_flows_rpc(
@@ -509,8 +509,8 @@ void AsyncPipelinedClient::deactivate_flows_rpc(
   auto local_resp = new AsyncLocalResponse<DeactivateFlowsResult>(
       std::move(callback), RESPONSE_TIMEOUT);
   PrintGrpcMessage(static_cast<const google::protobuf::Message&>(request));
-  local_resp->set_response_reader(std::move(stub_->AsyncDeactivateFlows(
-      local_resp->get_context(), request, &queue_)));
+  local_resp->set_response_reader(
+      stub_->AsyncDeactivateFlows(local_resp->get_context(), request, &queue_));
 }
 
 void AsyncPipelinedClient::activate_flows_rpc(
@@ -519,8 +519,8 @@ void AsyncPipelinedClient::activate_flows_rpc(
   auto local_resp = new AsyncLocalResponse<ActivateFlowsResult>(
       std::move(callback), RESPONSE_TIMEOUT);
   PrintGrpcMessage(static_cast<const google::protobuf::Message&>(request));
-  local_resp->set_response_reader(std::move(
-      stub_->AsyncActivateFlows(local_resp->get_context(), request, &queue_)));
+  local_resp->set_response_reader(
+      stub_->AsyncActivateFlows(local_resp->get_context(), request, &queue_));
 }
 
 void AsyncPipelinedClient::add_ue_mac_flow_rpc(
@@ -529,8 +529,8 @@ void AsyncPipelinedClient::add_ue_mac_flow_rpc(
   auto local_resp = new AsyncLocalResponse<FlowResponse>(
       std::move(callback), RESPONSE_TIMEOUT);
   PrintGrpcMessage(static_cast<const google::protobuf::Message&>(request));
-  local_resp->set_response_reader(std::move(
-      stub_->AsyncAddUEMacFlow(local_resp->get_context(), request, &queue_)));
+  local_resp->set_response_reader(
+      stub_->AsyncAddUEMacFlow(local_resp->get_context(), request, &queue_));
 }
 
 void AsyncPipelinedClient::update_ipfix_flow_rpc(
@@ -539,8 +539,8 @@ void AsyncPipelinedClient::update_ipfix_flow_rpc(
   auto local_resp = new AsyncLocalResponse<FlowResponse>(
       std::move(callback), RESPONSE_TIMEOUT);
   PrintGrpcMessage(static_cast<const google::protobuf::Message&>(request));
-  local_resp->set_response_reader(std::move(stub_->AsyncUpdateIPFIXFlow(
-      local_resp->get_context(), request, &queue_)));
+  local_resp->set_response_reader(
+      stub_->AsyncUpdateIPFIXFlow(local_resp->get_context(), request, &queue_));
 }
 
 void AsyncPipelinedClient::delete_ue_mac_flow_rpc(
@@ -549,8 +549,8 @@ void AsyncPipelinedClient::delete_ue_mac_flow_rpc(
   auto local_resp = new AsyncLocalResponse<FlowResponse>(
       std::move(callback), RESPONSE_TIMEOUT);
   PrintGrpcMessage(static_cast<const google::protobuf::Message&>(request));
-  local_resp->set_response_reader(std::move(stub_->AsyncDeleteUEMacFlow(
-      local_resp->get_context(), request, &queue_)));
+  local_resp->set_response_reader(
+      stub_->AsyncDeleteUEMacFlow(local_resp->get_context(), request, &queue_));
 }
 
 void AsyncPipelinedClient::update_subscriber_quota_state_rpc(
@@ -559,9 +559,8 @@ void AsyncPipelinedClient::update_subscriber_quota_state_rpc(
   auto local_resp = new AsyncLocalResponse<FlowResponse>(
       std::move(callback), RESPONSE_TIMEOUT);
   PrintGrpcMessage(static_cast<const google::protobuf::Message&>(request));
-  local_resp->set_response_reader(
-      std::move(stub_->AsyncUpdateSubscriberQuotaState(
-          local_resp->get_context(), request, &queue_)));
+  local_resp->set_response_reader(stub_->AsyncUpdateSubscriberQuotaState(
+      local_resp->get_context(), request, &queue_));
 }
 
 void AsyncPipelinedClient::poll_stats_rpc(
@@ -570,8 +569,8 @@ void AsyncPipelinedClient::poll_stats_rpc(
   auto local_resp = new AsyncLocalResponse<RuleRecordTable>(
       std::move(callback), RESPONSE_TIMEOUT);
   PrintGrpcMessage(static_cast<const google::protobuf::Message&>(request));
-  local_resp->set_response_reader(std::move(
-      stub_->AsyncGetStats(local_resp->get_context(), request, &queue_)));
+  local_resp->set_response_reader(
+      stub_->AsyncGetStats(local_resp->get_context(), request, &queue_));
 }
 
 uint32_t AsyncPipelinedClient::get_next_teid() {

--- a/lte/gateway/c/session_manager/RedisMap.hpp
+++ b/lte/gateway/c/session_manager/RedisMap.hpp
@@ -15,6 +15,7 @@
 #include "ObjectMap.h"
 #include "magma_logging.h"
 #include <orc8r/protos/redis.pb.h>
+#include <cpp_redis/cpp_redis>
 
 using magma::orc8r::RedisState;
 

--- a/lte/gateway/c/session_manager/RedisStoreClient.cpp
+++ b/lte/gateway/c/session_manager/RedisStoreClient.cpp
@@ -97,7 +97,7 @@ SessionMap RedisStoreClient::read_sessions(
       // value just doesn't exist
       session_map[key] = SessionVector{};
     } else {
-      session_map[key] = std::move(deserialize_session_vec(reply.as_string()));
+      session_map[key] = deserialize_session_vec(reply.as_string());
     }
   }
   return session_map;
@@ -132,8 +132,7 @@ SessionMap RedisStoreClient::read_all_sessions() {
       MLOG(MERROR) << "RedisStoreClient: Unable to get value for key " << key;
       session_map[key] = SessionVector{};
     } else {
-      session_map[key] =
-          std::move(deserialize_session_vec(value_reply.as_string()));
+      session_map[key] = deserialize_session_vec(value_reply.as_string());
     }
   }
   return session_map;

--- a/lte/gateway/c/session_manager/RestartHandler.cpp
+++ b/lte/gateway/c/session_manager/RestartHandler.cpp
@@ -165,8 +165,8 @@ void RestartHandler::terminate_previous_session(
             DeleteRecordRequest del_request;
             del_request.set_id(response.sid());
             directoryd_client_->delete_directoryd_record(
-                del_request, [this, &del_request, &termination_res, sid](
-                                 Status status, const Void&) {
+                del_request,
+                [&termination_res, sid](Status status, const Void&) {
                   if (!status.ok()) {
                     MLOG(MERROR) << "DirectoryD DeleteRecord failed to remove "
                                  << "subscriber " << sid << " from DirectoryD";

--- a/lte/gateway/c/session_manager/RuleStore.cpp
+++ b/lte/gateway/c/session_manager/RuleStore.cpp
@@ -145,7 +145,7 @@ bool PolicyRuleBiMap::get_rules_by_ids(
     const std::vector<std::string>& rule_ids,
     std::vector<PolicyRule>& rules_out) {
   std::lock_guard<std::mutex> lock(map_mutex_);
-  for (const std::string rule_id : rule_ids) {
+  for (const std::string& rule_id : rule_ids) {
     auto it = rules_by_rule_id_.find(rule_id);
     if (it == rules_by_rule_id_.end()) {
       return false;

--- a/lte/gateway/c/session_manager/RuleStore.h
+++ b/lte/gateway/c/session_manager/RuleStore.h
@@ -25,8 +25,6 @@
 #include "CreditKey.h"
 #include "includes/GRPCReceiver.h"
 
-using grpc::Status;
-
 namespace magma {
 using namespace lte;
 /**

--- a/lte/gateway/c/session_manager/SessionProxyResponderHandler.h
+++ b/lte/gateway/c/session_manager/SessionProxyResponderHandler.h
@@ -22,7 +22,6 @@
 #include "LocalEnforcer.h"
 #include "SessionStore.h"
 
-using grpc::Server;
 using grpc::ServerContext;
 using grpc::Status;
 

--- a/lte/gateway/c/session_manager/SessionReporter.cpp
+++ b/lte/gateway/c/session_manager/SessionReporter.cpp
@@ -62,8 +62,8 @@ void SessionReporterImpl::report_updates(
 
   auto controller_response = new AsyncEvbResponse<UpdateSessionResponse>(
       base_, callback, RESPONSE_TIMEOUT);
-  controller_response->set_response_reader(std::move(stub_->AsyncUpdateSession(
-      controller_response->get_context(), request, &queue_)));
+  controller_response->set_response_reader(stub_->AsyncUpdateSession(
+      controller_response->get_context(), request, &queue_));
 }
 
 void SessionReporterImpl::report_create_session(
@@ -72,8 +72,8 @@ void SessionReporterImpl::report_create_session(
   PrintGrpcMessage(static_cast<const google::protobuf::Message&>(request));
   auto controller_response = new AsyncEvbResponse<CreateSessionResponse>(
       base_, callback, RESPONSE_TIMEOUT);
-  controller_response->set_response_reader(std::move(stub_->AsyncCreateSession(
-      controller_response->get_context(), request, &queue_)));
+  controller_response->set_response_reader(stub_->AsyncCreateSession(
+      controller_response->get_context(), request, &queue_));
 }
 
 void SessionReporterImpl::report_terminate_session(

--- a/lte/gateway/c/session_manager/SessionState.cpp
+++ b/lte/gateway/c/session_manager/SessionState.cpp
@@ -695,7 +695,7 @@ void SessionState::apply_session_static_rule_set(
   std::vector<PolicyRule> static_pending_deactivation;
 
   // Go through the existing rules and uninstall any rule not in the rule set
-  for (const auto static_rule_id : active_static_rules_) {
+  for (const auto& static_rule_id : active_static_rules_) {
     if (static_rules.find(static_rule_id) == static_rules.end()) {
       PolicyRule rule;
       if (static_rules_.get_rule(static_rule_id, &rule)) {
@@ -705,7 +705,7 @@ void SessionState::apply_session_static_rule_set(
   }
   // Do the actual removal separately so we're not modifying the vector while
   // looping
-  for (const PolicyRule static_rule : static_pending_deactivation) {
+  for (const PolicyRule& static_rule : static_pending_deactivation) {
     MLOG(MINFO) << "Removing static rule " << static_rule.id() << " for "
                 << session_id_;
     optional<RuleToProcess> op_rule_info =
@@ -1032,10 +1032,10 @@ SessionState::SessionInfo SessionState::get_session_info_for_setup() {
   gy_dynamic_rules_.get_rules(gy_dynamic_rules);
 
   // Set versions
-  for (const PolicyRule rule : gx_dynamic_rules) {
+  for (const PolicyRule& rule : gx_dynamic_rules) {
     info.gx_rules.push_back(make_rule_to_process(rule));
   }
-  for (const PolicyRule rule : gy_dynamic_rules) {
+  for (const PolicyRule& rule : gy_dynamic_rules) {
     info.gy_dynamic_rules.push_back(make_rule_to_process(rule));
   }
 
@@ -1647,7 +1647,7 @@ std::vector<PolicyRule> SessionState::get_all_final_unit_rules() {
     if (grant->service_state != SERVICE_RESTRICTED) {
       continue;
     }
-    for (const std::string rule_id : grant->final_action_info.restrict_rules) {
+    for (const std::string& rule_id : grant->final_action_info.restrict_rules) {
       PolicyRule rule;
       if (static_rules_.get_rule(rule_id, &rule)) {
         rules.push_back(rule);

--- a/lte/gateway/c/session_manager/SetMessageManagerHandler.h
+++ b/lte/gateway/c/session_manager/SetMessageManagerHandler.h
@@ -28,7 +28,6 @@
 #include "SessionStateEnforcer.h"
 #include "SessionID.h"
 
-using grpc::Server;
 using grpc::ServerContext;
 using grpc::Status;
 namespace magma {

--- a/lte/gateway/c/session_manager/SpgwServiceClient.cpp
+++ b/lte/gateway/c/session_manager/SpgwServiceClient.cpp
@@ -140,8 +140,8 @@ void AsyncSpgwServiceClient::delete_bearer_rpc(
     std::function<void(Status, DeleteBearerResult)> callback) {
   auto local_resp = new AsyncLocalResponse<DeleteBearerResult>(
       std::move(callback), RESPONSE_TIMEOUT);
-  local_resp->set_response_reader(std::move(
-      stub_->AsyncDeleteBearer(local_resp->get_context(), request, &queue_)));
+  local_resp->set_response_reader(
+      stub_->AsyncDeleteBearer(local_resp->get_context(), request, &queue_));
 }
 
 void AsyncSpgwServiceClient::create_dedicated_bearer_rpc(
@@ -149,8 +149,8 @@ void AsyncSpgwServiceClient::create_dedicated_bearer_rpc(
     std::function<void(Status, CreateBearerResult)> callback) {
   auto local_resp = new AsyncLocalResponse<CreateBearerResult>(
       std::move(callback), RESPONSE_TIMEOUT);
-  local_resp->set_response_reader(std::move(
-      stub_->AsyncCreateBearer(local_resp->get_context(), request, &queue_)));
+  local_resp->set_response_reader(
+      stub_->AsyncCreateBearer(local_resp->get_context(), request, &queue_));
 }
 
 }  // namespace magma

--- a/lte/gateway/c/session_manager/sessiond_main.cpp
+++ b/lte/gateway/c/session_manager/sessiond_main.cpp
@@ -387,7 +387,7 @@ int main(int argc, char* argv[]) {
   server.SetOperationalStatesCallback([evb, session_store]() {
     std::promise<magma::OpState> result;
     std::future<magma::OpState> future = result.get_future();
-    evb->runInEventBaseThread([session_store, &result, &future]() {
+    evb->runInEventBaseThread([session_store, &result]() {
       set_sentry_transaction("GetOperationalStates");
       result.set_value(magma::get_operational_states(session_store));
     });


### PR DESCRIPTION
<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary
While setting up the dev container I noticed a bunch of clang tidy warnings. Addressed those that had fixes suggested.



https://user-images.githubusercontent.com/37634144/133857440-b81f5c88-5f90-4fa5-b62b-98e4ddc96a61.mov


https://user-images.githubusercontent.com/37634144/133857453-4b9e748f-eee3-4dcf-ad7c-3c82df4d6afa.mov

<!-- Enumerate changes you made and why you made them -->

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
