### PR TITLE
ci: migrates vscode devcontainer to registry

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -12,8 +12,7 @@
 		"ms-vsliveshare.vsliveshare",
 		"ms-azuretools.vscode-docker"
 	],
-	"dockerFile": "Dockerfile",
-	"context": "..",
+	"image": "ghcr.io/magma/devcontainer:sha-b435783",
 	"settings": {
 		"terminal.integrated.shell.linux": "/bin/bash",
 		"clang-tidy.compilerArgs": [


### PR DESCRIPTION
Tested by starting up a Devcontainer from `electronjoe:pr-devcontainer-registry`.

Works towards #9178

This may not be the final location for the container - that is in progress (Jfrog?) but we are committing this now just to get the GH Code Space experience improved by 40x ASAP.

Signed-off-by: GitHub <noreply@github.com>