### PR TITLE
ci: adds scheduled GH Action docker builds for dev / CI

### DIFF
--- a/.github/workflows/docker-push.yml
+++ b/.github/workflows/docker-push.yml
@@ -1,0 +1,64 @@
+---
+name: "Dockerfile Push"
+on:  # yamllint disable-line rule:truthy
+  push:
+    branches:
+      -master
+    paths:
+      - .devcontainer/Dockerfile
+      - .github/workflows/docker-push.yml
+      - lte/gateway/docker/mme/Dockerfile.ubuntu20.04
+  schedule:
+    # Run four times a day (hours zero, six, twelve and eighteen)
+    - cron:  '0 0,6,12,18 * * *'
+
+jobs:
+  build_devcontainer_dockerfile:
+    env:
+      DOCKERFILE: .devcontainer/Dockerfile
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check Out Repo
+        uses: actions/checkout@v2
+      - name: Docker meta
+        id: meta
+        uses: crazy-max/ghaction-docker-meta@v2
+        with:
+          # list of Docker images to use as base name for tags
+          images: |
+            ghcr.io/magma/devcontainer
+          # generate Docker tags based on the following events/attributes
+          tags: |
+            type=sha
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Cache Docker layers
+        uses: actions/cache@v2
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ hashFiles( '**/Dockerfile*' ) }}
+      - name: "Login to GHCR"
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password:  ${{ secrets.GITHUB_TOKEN }}
+      - name: Docker Build
+        id: docker_build
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: ${{ env.DOCKERFILE }}
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache-new
+      - name: Move cache - Fixup for buildx cache issue
+        # Temp fix
+        # https://github.com/docker/build-push-action/issues/252
+        # https://github.com/moby/buildkit/issues/1896
+        run: |
+          rm -rf /tmp/.buildx-cache
+          mv /tmp/.buildx-cache-new /tmp/.buildx-cache


### PR DESCRIPTION
## Summary

Working toward #9178.

The Action builds the vscode devcontainer Dockerfile and pushes it to the GH Container Registry. This allows GH Code Spaces to rapidly spin up by local registry access of the devcontainer.  This PR may be extended in follow-up to include other CI related docker images (e.g. the MME build container).

The GitHub Action is triggered on `Push` that modifies the associated Dockerfile, and also executes on a fixed schedule four times a day.

## Testing

Pushed to a novel branch of `magma/magma` and confirmed build and push to Github Container Registry, then used the container in GitHub Code Spaces with #9177. Validated successful codespace loading / operation.

Signed-off-by: Scott Moeller <electronjoe@gmail.com>