### PR TITLE
ci: accelerates gcc-problems by use of devcontainer from ghcr

### DIFF
--- a/.github/workflows/gcc-problems.yml
+++ b/.github/workflows/gcc-problems.yml
@@ -14,6 +14,8 @@ on:
       - opened
       - reopened
       - synchronize
+env:
+  DEVCONTAINER_IMAGE: "ghcr.io/magma/devcontainer:sha-b435783"
 
 # See [Example Sharing Container Between Jobs](https://github.com/docker/build-push-action/issues/225)
 jobs:
@@ -27,86 +29,27 @@ jobs:
         uses: fkirc/skip-duplicate-actions@master
         with:
           # Only run the main job for changes including the following paths
-          paths: '["orc8r/gateway/c/**", "lte/gateway/c/**"]'
-  gen_build_container:
-    needs: path_filter
-    if: ${{ needs.path_filter.outputs.should_skip == 'false' }}
-    name: gen build container job
-    runs-on: ubuntu-latest
-    steps:
-      -
-        name: Check Out Repo
-        uses: actions/checkout@v2
-      -
-        name: Set up Docker Buildx
-        id: buildx
-        uses: docker/setup-buildx-action@v1
-      -
-        name: Cache Docker layers
-        uses: actions/cache@v2
-        with:
-          path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-buildx
-      -
-        name: Docker Build
-        id: docker_build
-        uses: docker/build-push-action@v2
-        with:
-          context: .
-          file: ./lte/gateway/docker/mme/Dockerfile.ubuntu20.04
-          push: false
-          tags: magma/mme_builder:latest
-          outputs: type=docker,dest=/tmp/mme_builder.tar
-          cache-from: type=local,src=/tmp/.buildx-cache
-          cache-to: type=local,dest=/tmp/.buildx-cache-new
-      -
-        # Temp fix
-        # https://github.com/docker/build-push-action/issues/252
-        # https://github.com/moby/buildkit/issues/1896
-        name: Move cache - Fixup for buildx cache issue
-        run: |
-          rm -rf /tmp/.buildx-cache
-          mv /tmp/.buildx-cache-new /tmp/.buildx-cache
-      -
-        name: Upload docker image for other jobs
-        uses: actions/upload-artifact@v2
-        with:
-          name: build_container
-          path: /tmp/mme_builder.tar
+          paths: '[".github/workflows/gcc-problems.yml", "orc8r/gateway/c/**", "lte/gateway/c/**", "orc8r/protos/**", "lte/protos/**"]'
 
   build_oai:
     needs:
       - path_filter
-      - gen_build_container
     if: ${{ needs.path_filter.outputs.should_skip == 'false' }}
     name: build oai job
     runs-on: ubuntu-latest
     steps:
-      -
+      - name: Check Out Repo
         # This is necessary for overlays into the Docker container below.
-        name: Check Out Repo
         uses: actions/checkout@v2
-      -
+      - name: Fetch list of changed files
         # I am using mmagician fork of get-changed-files (forked from jitterbit/get-changed-files)
         #   Rationale: our workflow (merge branch into upstream master) is incompatible
         #   See long list of GH Issues on https://github.com/jitterbit/get-changed-files w.r.t. head ahead of base
-        name: Fetch list of changed files
         id: changed_files
         uses: mmagician/get-changed-files@v2
         with:
           format: 'space-delimited'
-      -
-        name: Download docker image from generate_container_for_build
-        uses: actions/download-artifact@v2
-        with:
-          name: build_container
-          path: /tmp
-      -
-        name: Load Docker image
-        run: |
-          docker load --input /tmp/mme_builder.tar
-          docker image ls -a
-      -
+      - name: Load problem matcher
         # If needed https://github.com/microsoft/vscode-cpptools/issues/2266 for path fixups
         #
         # Additional GH Issues regarding paths for monorepos without root build.
@@ -116,23 +59,19 @@ jobs:
         # Paths emitted on warnings must be relative to the repository (e.g. lte/gateway/...),
         # Therefore below I use `xo` to fixup our path emissions on gcc warnings.
         uses: electronjoe/gcc-problem-matcher@v1
-      -
-        name: Build and Apply GCC Problem Matcher
+      - name: Build and Apply GCC Problem Matcher
         uses: addnab/docker-run-action@v2
         with:
-          image: magma/mme_builder:latest
+          image: ${{ env.DEVCONTAINER_IMAGE }}
           # TODO: Remove work-around mount of Github workspace to /magma (https://github.com/addnab/docker-run-action/issues/11)
-          options: -v ${{ github.workspace }}:/magma -e ABC=123
+          options: -v ${{ github.workspace }}:/workspaces/magma -e ABC=123
           run: |
-            cd /magma/lte/gateway/
-            CPPFLAGS="-Wextra -Wshadow -Wimplicit-fallthrough -Wduplicated-cond -Wduplicated-branches -Wlogical-op -Wnull-dereference -Wjump-misses-init -Wformat=2 -Wstrict-overflow=4 -Wuninitialized -Wshift-overflow=2" make build_oai 2>&1 > /magma/compile.log
-            BUILD_EXIT_CODE=$?
+            cd /workspaces/magma/lte/gateway/
+            CPPFLAGS="-Wextra -Wshadow -Wimplicit-fallthrough -Wduplicated-cond -Wduplicated-branches -Wlogical-op -Wnull-dereference -Wjump-misses-init -Wformat=2 -Wstrict-overflow=4 -Wuninitialized -Wshift-overflow=2" make build_oai 2>&1 > /workspaces/magma/compile.log
             for file in ${{ steps.changed_files.outputs.all }};
-            do grep "$file" /magma/compile.log | xo '/\/magma\/((.*):(\d+):(\d+):\s+(?:fatal\s)?(warning|error):\s+(.*))/$1/' || true;
+            do grep "$file" /workspaces/magma/compile.log | xo '/\/magma\/((.*):(\d+):(\d+):\s+(?:fatal\s)?(warning|error):\s+(.*))/$1/' || true;
             done;
-            exit $BUILD_EXIT_CODE
-      -
-        name: Store build_logs_oai Artifact
+      - name: Store build_logs_oai Artifact
         uses: actions/upload-artifact@v2
         with:
           name: build_logs_oai
@@ -141,36 +80,22 @@ jobs:
   build_session_manager:
     needs:
       - path_filter
-      - gen_build_container
     if: ${{ needs.path_filter.outputs.should_skip == 'false' }}
     name: build session manager job
     runs-on: ubuntu-latest
     steps:
-      -
+      - name: Check Out Repo
         # This is necessary for overlays into the Docker container below.
-        name: Check Out Repo
         uses: actions/checkout@v2
-      -
+      - name: Fetch list of changed files
         # I am using mmagician fork of get-changed-files (forked from jitterbit/get-changed-files)
         #   Rationale: our workflow (merge branch into upstream master) is incompatible
         #   See long list of GH Issues on https://github.com/jitterbit/get-changed-files w.r.t. head ahead of base
-        name: Fetch list of changed files
         id: changed_files
         uses: mmagician/get-changed-files@v2
         with:
           format: 'space-delimited'
-      -
-        name: Download docker image from generate_container_for_build
-        uses: actions/download-artifact@v2
-        with:
-          name: build_container
-          path: /tmp
-      -
-        name: Load Docker image
-        run: |
-          docker load --input /tmp/mme_builder.tar
-          docker image ls -a
-      -
+      - name: Load problem matcher
         # If needed https://github.com/microsoft/vscode-cpptools/issues/2266 for path fixups
         #
         # Additional GH Issues regarding paths for monorepos without root build.
@@ -180,23 +105,19 @@ jobs:
         # Paths emitted on warnings must be relative to the repository (e.g. lte/gateway/...),
         # Therefore below I use `xo` to fixup our path emissions on gcc warnings.
         uses: electronjoe/gcc-problem-matcher@v1
-      -
-        name: Build and Apply GCC Problem Matcher
+      - name: Build and Apply GCC Problem Matcher
         uses: addnab/docker-run-action@v2
         with:
-          image: magma/mme_builder:latest
+          image: ${{ env.DEVCONTAINER_IMAGE }}
           # TODO: Remove work-around mount of Github workspace to /magma (https://github.com/addnab/docker-run-action/issues/11)
-          options: -v ${{ github.workspace }}:/magma -e ABC=123
+          options: -v ${{ github.workspace }}:/workspaces/magma -e ABC=123
           run: |
-            cd /magma/lte/gateway/
-            CPPFLAGS="-Wextra -Wshadow -Wimplicit-fallthrough -Wduplicated-cond -Wduplicated-branches -Wlogical-op -Wnull-dereference -Wjump-misses-init -Wformat=2 -Wstrict-overflow=4 -Wuninitialized -Wshift-overflow=2" make build_session_manager 2>&1 > /magma/compile.log
-            BUILD_EXIT_CODE=$?
+            cd /workspaces/magma/lte/gateway/
+            CPPFLAGS="-Wextra -Wshadow -Wimplicit-fallthrough -Wduplicated-cond -Wduplicated-branches -Wlogical-op -Wnull-dereference -Wjump-misses-init -Wformat=2 -Wstrict-overflow=4 -Wuninitialized -Wshift-overflow=2" make build_session_manager 2>&1 > /workspaces/magma/compile.log
             for file in ${{ steps.changed_files.outputs.all }};
-            do grep "$file" /magma/compile.log | xo '/\/magma\/((.*):(\d+):(\d+):\s+(?:fatal\s)?(warning|error):\s+(.*))/$1/' || true;
+            do grep "$file" /workspaces/magma/compile.log | xo '/\/magma\/((.*):(\d+):(\d+):\s+(?:fatal\s)?(warning|error):\s+(.*))/$1/' || true;
             done;
-            exit $BUILD_EXIT_CODE
-      -
-        name: Store build_logs_session_manager Artifact
+      - name: Store build_logs_session_manager Artifact
         uses: actions/upload-artifact@v2
         with:
           name: build_logs_session_manager


### PR DESCRIPTION
**GItHub Action Build and annotation of GCC warnings dropped from 44 minutes to ~12 minutes with this PR.**

This PR does the following

- Adds `orc8r/protos/***` and `lte/protos/**` proto paths to trigger events (they were missing)
- Adds `gcc-problems.yml` to trigger events (it was missing)
- Removes docker build of `lte/gateway/docker/mme/Dockerfile.ubuntu20.04`
- Migrates to GitHub Container Registry fetch of `.devcontainer/Dockerfile`

Signed-off-by: Scott Moeller <electronjoe@gmail.com>