### PR TITLE
ci: update hash on devcontainer ghcr use

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -16,7 +16,7 @@
 		"coolchyni.beyond-debug",
 		"stackbuild.bazel-stack-vscode-cc",
 	],
-	"image": "ghcr.io/magma/devcontainer:sha-b435783",
+	"image": "ghcr.io/magma/devcontainer:sha-9fe32d6",
 	"settings": {
 		"terminal.integrated.shell.linux": "/bin/bash",
 		"clang-tidy.compilerArgs": [


### PR DESCRIPTION
## Test Plan

Generated a new GH Code space from this branch and confirmed `bazel test ... --config=devcontainer` worked.

Signed-off-by: Scott Harrison Moeller <smoeller@fb.com>