### PR TITLE
feat(connectiond): add support for Bazel build

### DIFF
--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -141,6 +141,6 @@ cpp_testing_deps()
 new_local_repository(
     name = "system_libraries",
     build_file = "//third_party:system_libraries.BUILD",
-    path = "/usr/local/lib",
+    path = "/",
 )
 ### Folly dependencies ###

--- a/lte/gateway/c/connection_tracker/src/BUILD.bazel
+++ b/lte/gateway/c/connection_tracker/src/BUILD.bazel
@@ -1,0 +1,41 @@
+# Copyright 2021 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+cc_binary(
+    name = "main",
+    srcs = ["main.cpp"],
+    deps = [
+        ":event_tracker",
+        "//lte/protos:mconfigs_cpp_proto",
+        "//orc8r/gateway/c/common/config:mconfig_loader",
+        "//orc8r/gateway/c/common/service303",
+    ],
+)
+
+cc_library(
+    name = "event_tracker",
+    srcs = ["EventTracker.cpp"],
+    hdrs = ["EventTracker.h"],
+    deps = [
+        ":packet_generator",
+        "@system_libraries//:libmnl",
+    ],
+)
+
+cc_library(
+    name = "packet_generator",
+    srcs = ["PacketGenerator.cpp"],
+    hdrs = ["PacketGenerator.h"],
+    deps = [
+        "//orc8r/gateway/c/common/logging",
+        "@system_libraries//:libtins",
+    ],
+)

--- a/third_party/system_libraries.BUILD
+++ b/third_party/system_libraries.BUILD
@@ -21,10 +21,10 @@ config_setting(
 cc_library(
     name = "folly",
     srcs = select({
-        ":use_folly_so": ["libfolly.so"],
+        ":use_folly_so": ["usr/local/lib/libfolly.so"],
         "//conditions:default": [
-            "libfolly.a",
-            "libfmt.a",
+            "usr/local/lib/libfolly.a",
+            "usr/local/lib/libfmt.a",
         ],
     }),
     linkopts = select({
@@ -42,4 +42,16 @@ cc_library(
             "-liberty",
         ],
     }),
+)
+
+cc_library(
+    name = "libtins",
+    srcs = ["usr/local/lib/libtins.so"],
+    linkopts = ["-ltins"],
+)
+
+cc_library(
+    name = "libmnl",
+    srcs = ["usr/lib/x86_64-linux-gnu/libmnl.so"],
+    linkopts = ["-lmnl"],
 )


### PR DESCRIPTION
Formatted Bazel files with `bazel run //:buildifier`.

## Test Strategy

Validated build and test from within GH Code Space with:

```shell
bazel build //lte/gateway/c/connection_tracker/src/... --config=devcontainer
bazel build ... --config=devcontainer
bazel test ... --config=devcontainer
```

Signed-off-by: Scott Moeller <electronjoe@gmail.com>