### PR TITLE
fix(connectiond): fixes namespace import pollution

### DIFF
--- a/lte/gateway/c/connection_tracker/src/PacketGenerator.cpp
+++ b/lte/gateway/c/connection_tracker/src/PacketGenerator.cpp
@@ -25,7 +25,13 @@
 namespace magma {
 namespace lte {
 
-using namespace Tins;
+using Tins::EthernetII;
+using Tins::IP;
+using Tins::IPv4Address;
+using Tins::NetworkInterface;
+using Tins::PacketSender;
+using Tins::TCP;
+using Tins::UDP;
 
 PacketGenerator::PacketGenerator(
     const std::string& iface_name, const std::string& pkt_dst_mac,


### PR DESCRIPTION
Google Style advocates against wildcard namespace imports. They make trace-ability harder (one cannot tell what symbols come from where) and they can cause collisions.

Signed-off-by: Scott Moeller <electronjoe@gmail.com>