### PR TITLE
feat(agw): adds li_agent Bazel build and test support

### DIFF
--- a/experimental/bazel-base/Dockerfile
+++ b/experimental/bazel-base/Dockerfile
@@ -21,6 +21,7 @@ RUN apt-get update && \
         python-dev \
         zip \
         unzip \
+        uuid-dev \
         vim \
         wget \
         libssl-dev

--- a/lte/gateway/c/li_agent/src/BUILD.bazel
+++ b/lte/gateway/c/li_agent/src/BUILD.bazel
@@ -1,0 +1,86 @@
+# Copyright 2021 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+package(default_visibility = ["//lte/gateway/c/li_agent/src:__subpackages__"])
+
+cc_binary(
+    name = "main",
+    srcs = ["main.cpp"],
+    deps = [
+        ":interface_monitor",
+        "//orc8r/gateway/c/common/config:mconfig_loader",
+        "//orc8r/gateway/c/common/service303",
+    ],
+)
+
+cc_library(
+    name = "interface_monitor",
+    srcs = ["InterfaceMonitor.cpp"],
+    hdrs = ["InterfaceMonitor.h"],
+    deps = [
+        ":pdu_generator",
+        "@system_libraries//:libpcap",
+    ],
+)
+
+cc_library(
+    name = "pdu_generator",
+    srcs = ["PDUGenerator.cpp"],
+    hdrs = ["PDUGenerator.h"],
+    # TODO(@smoeller): Migrate to using full path for includes - GH8494
+    strip_include_prefix = "/lte/gateway/c/li_agent/src",
+    deps = [
+        ":mobilityd_client",
+        ":proxy_connector",
+        ":utilities",
+        "//lte/protos:mconfigs_cpp_proto",
+        "//orc8r/gateway/c/common/config:mconfig_loader",
+        "@system_libraries//:libtins",
+        "@system_libraries//:libuuid",
+    ],
+)
+
+cc_library(
+    name = "proxy_connector",
+    srcs = ["ProxyConnector.cpp"],
+    hdrs = ["ProxyConnector.h"],
+    # TODO(@smoeller): Migrate to using full path for includes - GH8494
+    strip_include_prefix = "/lte/gateway/c/li_agent/src",
+    deps = [
+        "//orc8r/gateway/c/common/logging",
+    ],
+)
+
+cc_library(
+    name = "mobilityd_client",
+    srcs = ["MobilitydClient.cpp"],
+    hdrs = ["MobilitydClient.h"],
+    # TODO(@smoeller): Migrate to using full path for includes - GH8494
+    strip_include_prefix = "/lte/gateway/c/li_agent/src",
+    deps = [
+        "//lte/protos:mobilityd_cpp_grpc",
+        "//orc8r/gateway/c/common/async_grpc:async_grpc_receiver",
+        "//orc8r/gateway/c/common/service_registry",
+    ],
+)
+
+cc_library(
+    name = "utilities",
+    srcs = ["Utilities.cpp"],
+    hdrs = ["Utilities.h"],
+    # TODO(@smoeller): Migrate to using full path for includes - GH8494
+    strip_include_prefix = "/lte/gateway/c/li_agent/src",
+    deps = [
+        "//lte/protos:mconfigs_cpp_proto",
+        "//orc8r/gateway/c/common/config:mconfig_loader",
+        "//orc8r/gateway/c/common/service303",
+    ],
+)

--- a/lte/gateway/c/li_agent/src/InterfaceMonitor.cpp
+++ b/lte/gateway/c/li_agent/src/InterfaceMonitor.cpp
@@ -12,6 +12,7 @@
  */
 
 #include <stdio.h>
+#include <unistd.h>
 #include <utility>
 
 #include "InterfaceMonitor.h"

--- a/lte/gateway/c/li_agent/src/ProxyConnector.cpp
+++ b/lte/gateway/c/li_agent/src/ProxyConnector.cpp
@@ -15,6 +15,7 @@
 #include <arpa/inet.h>
 #include <openssl/ssl.h>
 #include <openssl/err.h>
+#include <unistd.h>
 
 #include "ProxyConnector.h"
 #include "magma_logging.h"

--- a/lte/gateway/c/li_agent/src/test/BUILD.bazel
+++ b/lte/gateway/c/li_agent/src/test/BUILD.bazel
@@ -1,0 +1,35 @@
+# Copyright 2021 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("@rules_cc//cc:defs.bzl", "cc_test")
+
+cc_test(
+    name = "pdu_generator_test",
+    size = "small",
+    srcs = [
+        "Consts.h",
+        "test_pdu_generator.cpp",
+    ],
+    deps = [
+        ":li_agentd_mocks",
+        "//lte/gateway/c/li_agent/src:mobilityd_client",
+        "//lte/gateway/c/li_agent/src:pdu_generator",
+        "//lte/gateway/c/li_agent/src:utilities",
+        "@com_github_gflags_gflags//:gflags",
+        "@com_github_google_glog//:glog",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+cc_library(
+    name = "li_agentd_mocks",
+    hdrs = ["LIAgentdMocks.h"],
+)

--- a/lte/gateway/c/li_agent/src/test/test_pdu_generator.cpp
+++ b/lte/gateway/c/li_agent/src/test/test_pdu_generator.cpp
@@ -13,6 +13,7 @@
 
 #include <netinet/ip.h>
 #include <net/ethernet.h>
+#include <gflags/gflags.h>
 #include <gtest/gtest.h>
 
 #include <limits>
@@ -129,8 +130,6 @@ TEST_F(PDUGeneratorTest, test_generator_non_ip_packet) {
 
 int main(int argc, char** argv) {
   ::testing::InitGoogleTest(&argc, argv);
-  FLAGS_logtostderr = 1;
-  FLAGS_v           = 10;
   return RUN_ALL_TESTS();
 }
 

--- a/third_party/system_libraries.BUILD
+++ b/third_party/system_libraries.BUILD
@@ -46,12 +46,20 @@ cc_library(
 
 cc_library(
     name = "libtins",
-    srcs = ["usr/lib/libtins.so"],
     linkopts = ["-ltins"],
 )
 
 cc_library(
     name = "libmnl",
-    srcs = ["usr/lib/x86_64-linux-gnu/libmnl.so"],
     linkopts = ["-lmnl"],
+)
+
+cc_library(
+    name = "libpcap",
+    linkopts = ["-lpcap"],
+)
+
+cc_library(
+    name = "libuuid",
+    linkopts = ["-luuid"],
 )


### PR DESCRIPTION
## Summary

Adds support for building and testing li_agent code via Bazel.

Note the auxiliary change to 

## Test Plan

### Validated health in devcontainer

From a Magma GH Code Space (which uses our devcontainer).

```
bazel test ... --config=devcontainer
```

### Validated health in experimental/bazel-baze/Dockerfile

From a Magma GH Code Space (which uses our devcontainer).

```
sudo docker build -t bazel-base -f experimental/bazel-base/Dockerfile .
sudo docker run -v /var/lib/docker/codespacemount/workspace/magma:/workspaces/magma -v /var/lib/docker/codespacemount/workspace/magma/lte/gateway/configs:/etc/magma -it bazel-base /bin/bash
bazel test ... --config=docker
```

Signed-off-by: Scott Moeller <electronjoe@gmail.com>