### PR TITLE
ci: accelerates the bazel workflows by pulling from GHCR

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -7,10 +7,10 @@ build --cxxopt=-g2
 
 # For building with Bazel inside the Magma-Builder Docker container
 build:docker --disk_cache=/magma/.bazel-cache
-build:docker --repository_cache=/magma/.bazel-cache-repo
+common:docker --repository_cache=/magma/.bazel-cache-repo
 
 build:devcontainer --disk_cache=/workspaces/magma/.bazel-cache
-build:devcontainer --repository_cache=/workspaces/magma/.bazel-cache-repo
+common:devcontainer --repository_cache=/workspaces/magma/.bazel-cache-repo
 build:devcontainer --define=folly_so=1
 
 build:specify_vm_cc --action_env=CC=/usr/bin/gcc
@@ -18,7 +18,7 @@ build:specify_vm_cc --action_env=CXX=/usr/bin/g++
 
 # For building with Bazel inside the Magma VM
 build:vm --disk_cache=/home/vagrant/magma/.bazel-cache
-build:vm --repository_cache=/home/vagrant/magma/.bazel-cache-repo
+common:vm --repository_cache=/home/vagrant/magma/.bazel-cache-repo
 build:vm --define=folly_so=1
 build:vm --config=specify_vm_cc
 

--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -1,11 +1,15 @@
 ---
-name: "Bazel"
+name: "Bazel Build & Test"
 on:  # yamllint disable-line rule:truthy
   pull_request:
     types:
       - opened
       - reopened
       - synchronize
+env:
+  DEVCONTAINER_IMAGE: "ghcr.io/magma/devcontainer:sha-9fe32d6"
+  BAZEL_CACHE: bazel-cache
+  BAZEL_CACHE_REPO: bazel-cache-repo
 
 jobs:
   path_filter:
@@ -20,132 +24,45 @@ jobs:
           # Only run the main job for changes including the following paths
          paths: '[".github/workflows/bazel.yml", "lte/gateway/c/**", "orc8r/gateway/c/**", "orc8r/protos/**", "lte/protos/**"]'
 
-  gen_build_container:
-    needs: path_filter
-    if: ${{ needs.path_filter.outputs.should_skip == 'false' }}
-    name: gen build container job
-    runs-on: ubuntu-latest
-    env:
-      MAGMA_ROOT: "${{ github.workspace }}"
-    steps:
-      -
-        name: Check Out Repo
-        uses: actions/checkout@v2
-      -
-        name: Set up Docker Buildx
-        id: buildx
-        uses: docker/setup-buildx-action@v1
-      -
-        name: Cache Docker layers
-        uses: actions/cache@v2
-        with:
-          path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-buildx
-      -
-        name: Docker Build
-        id: docker_build
-        uses: docker/build-push-action@v2
-        with:
-          context: .
-          file: ./experimental/bazel-base/Dockerfile
-          push: false
-          tags: magma/bazel:latest
-          outputs: type=docker,dest=/tmp/bazel.tar
-          cache-from: type=local,src=/tmp/.buildx-cache
-          cache-to: type=local,dest=/tmp/.buildx-cache-new
-      -
-        # Temp fix
-        # https://github.com/docker/build-push-action/issues/252
-        # https://github.com/moby/buildkit/issues/1896
-        name: Move cache - Fixup for buildx cache issue
-        run: |
-          rm -rf /tmp/.buildx-cache
-          mv /tmp/.buildx-cache-new /tmp/.buildx-cache
-      -
-        name: Upload docker image for other jobs
-        uses: actions/upload-artifact@v2
-        with:
-          name: build_container
-          path: /tmp/bazel.tar
-
-  bazel_test:
+  bazel_build_and_test:
     needs:
       - path_filter
-      - gen_build_container
     if: ${{ needs.path_filter.outputs.should_skip == 'false' }}
-    name: Bazel Test Job
+    name: Bazel Build and Test Job
     runs-on: ubuntu-latest
     steps:
-        -
+        - name: Check Out Repo
           # This is necessary for overlays into the Docker container below.
-          name: Check Out Repo
           uses: actions/checkout@v2
-        -
-          name: Download docker image from generate_container_for_build
-          uses: actions/download-artifact@v2
+        - name: Bazel Cache
+          uses: actions/cache@v2
           with:
-            name: build_container
-            path: /tmp
-        -
-          name: Load Docker image
-          run: |
-            docker load --input /tmp/bazel.tar
-            docker image ls -a
-        -
-          name: Bazel Test
+            path: ${{ github.workspace }}/.${{ env.BAZEL_CACHE }}
+            key: ${{ runner.os }}-${{ env.BAZEL_CACHE }}-${{ github.sha }}
+            restore-keys: |
+              ${{ runner.os }}-${{ env.BAZEL_CACHE }}-
+        - name: Bazel Cache Repo
+          uses: actions/cache@v2
+          with:
+            path: ${{ github.workspace }}/.${{ env.BAZEL_CACHE_REPO }}
+            key: ${{ runner.os }}-${{ env.BAZEL_CACHE_REPO }}-${{ github.sha }}
+            restore-keys: |
+              ${{ runner.os }}-${{ env.BAZEL_CACHE_REPO }}-
+        - name: Bazel Build
           uses: addnab/docker-run-action@v2
           with:
-            image: magma/bazel:latest
+            image: ${{ env.DEVCONTAINER_IMAGE }}
             # TODO: Remove work-around mount of Github workspace to /magma (https://github.com/addnab/docker-run-action/issues/11)
-            options: -v ${{ github.workspace }}:/magma -e ABC=123
+            options: -v ${{ github.workspace }}:/workspaces/magma/ -v ${{ github.workspace }}/lte/gateway/configs:/etc/magma -e ABC=123
             run: |
-              bazel test ... | tee /magma/test.log
-              BUILD_EXIT_CODE=$?
-              exit $BUILD_EXIT_CODE
-        -
-          name: Store build_logs_oai Artifact
-          uses: actions/upload-artifact@v2
-          with:
-            name: bazel_test_logs
-            path: ${{ github.workspace }}/test.log
-
-  bazel_build:
-    needs:
-      - path_filter
-      - gen_build_container
-    if: ${{ needs.path_filter.outputs.should_skip == 'false' }}
-    name: Bazel Build Job
-    runs-on: ubuntu-latest
-    steps:
-        -
-          # This is necessary for overlays into the Docker container below.
-          name: Check Out Repo
-          uses: actions/checkout@v2
-        -
-          name: Download docker image from generate_container_for_build
-          uses: actions/download-artifact@v2
-          with:
-            name: build_container
-            path: /tmp
-        -
-          name: Load Docker image
-          run: |
-            docker load --input /tmp/bazel.tar
-            docker image ls -a
-        -
-          name: Bazel Build
+              cd /workspaces/magma
+              bazel build ... --config=devcontainer
+        - name: Bazel Test
           uses: addnab/docker-run-action@v2
           with:
-            image: magma/bazel:latest
+            image: ${{ env.DEVCONTAINER_IMAGE }}
             # TODO: Remove work-around mount of Github workspace to /magma (https://github.com/addnab/docker-run-action/issues/11)
-            options: -v ${{ github.workspace }}:/magma -e ABC=123
+            options: -v ${{ github.workspace }}:/workspaces/magma/ -v ${{ github.workspace }}/lte/gateway/configs:/etc/magma -e ABC=123
             run: |
-              bazel build ... | tee /magma/build.log
-              BUILD_EXIT_CODE=$?
-              exit $BUILD_EXIT_CODE
-        -
-          name: Store build_logs_oai Artifact
-          uses: actions/upload-artifact@v2
-          with:
-            name: bazel_build_logs
-            path: ${{ github.workspace }}/build.log
+              cd /workspaces/magma
+              bazel test ... --test_output=errors --config=devcontainer


### PR DESCRIPTION
## Summary

### Impact

Bazel build times

- 27 minutes baseline
- 24 minutes With GHCR Pull
- 3 minutes with GHCR Pull + Bazel Cache (includes ~1 minute of dockerfile fetch)

Bazel build + test

<img width="650" alt="Screen Shot 2021-09-22 at 10 33 09 AM" src="https://user-images.githubusercontent.com/3752618/134365478-1e114c8c-c8d0-4238-b65c-63cbd8570cdc.png">

### Approach

PR overlays two GH Caches (actions/cache@v2) onto the docker run (addnab/docker-run-action@v2) - one for the Bazel Repo cache (storing external deps), one for the Bazel cache (storing build artifacts).

I found I had to provide a unique cache key (so it will be missing) - I don't know why and maybe this needs to be re-verified. Advice for compensation on this is to define `restore-key` options so that they wildcard-fallback to the prior cache that exact matches the `restore-key` or is a longest match on `restore-key`. Here we rely on longest match.

GH Cache is limited to 5 GB per repo - and is evicted LRU manner. I think we should drop our use of this cache for docker buildx behavior as they are likely consuming all of this cache - and instead use it for high gain / smaller storage e.g. Bazel and others.

The present PR caches ~500 MB of external repo contents in the bazel-cache-repo and ~210 MB of build artifacts (this will grow with time - as Bazel attempts to cache all of history).

### Open Questions

1. Do we want to limit cache size? Can that be done with e.g. `bazelrc` config?
2. Is the key behavior used in this PR going to be effective for maximally effective caching? Do we need a differing format to give good behavior on restore-key fallback?
3. Is the key behavior used in this PR going to thrash our cache 5GB allocation? If indeed I need to use a unique key then I'm in a pickle?

## Test Plan

Measured build times with and without cache - observed above speedups.

Signed-off-by: Scott Moeller <electronjoe@gmail.com>