### PR TITLE
fix(orc8r): Fix broken modules proto make to terminate on erroneous protos (issue #9231)

### DIFF
--- a/orc8r/cloud/go/module.mk
+++ b/orc8r/cloud/go/module.mk
@@ -54,7 +54,7 @@ gen_protos::
 			--proto_path $(MAGMA_ROOT)/orc8r/protos/prometheus \
 			--proto_path $(PROTO_INCLUDES) \
 			--go_out=plugins=grpc,Mgoogle/protobuf/field_mask.proto=google.golang.org/genproto/protobuf/field_mask:$(MAGMA_ROOT)/.. \
-			$${x} ; \
+			$${x} || exit 1 ; \
 	done ; \
 	for x in $$(find $(MODULE_NAME)/cloud/go -name '*.proto') ; do \
 		protoc \
@@ -63,7 +63,7 @@ gen_protos::
 			--proto_path $(PROTO_INCLUDES) \
 			--go_opt=paths=source_relative \
 			--go_out=plugins=grpc,Mgoogle/protobuf/field_mask.proto=google.golang.org/genproto/protobuf/field_mask:. \
-			$${x} ; \
+			$${x} || exit 1 ; \
 	done
 
 
@@ -84,7 +84,7 @@ copy_swagger_files:
 
 # reorder imports with goimports
 order_imports:
-	for f in $$(find . -type f -name '*.go' ! -name '*.pb.go' ! -name '*_swaggergen.go') ; do $(MAGMA_ROOT)/orc8r/cloud/order_go_imports.sh $${f} ; done
+	for f in $$(find . -type f -name '*.go' ! -name '*.pb.go' ! -name '*_swaggergen.go') ; do $(MAGMA_ROOT)/orc8r/cloud/order_go_imports.sh $${f} || exit 1 ; done
 
 lint:
 	golangci-lint run


### PR DESCRIPTION


Signed-off-by: Evgeniy Makeev <evgeniym@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

Fix broken modules proto make to terminate on erroneous protos (issue #9231)

The issue #9231 introduced by PR #8437 prevents build erroring out inside make for loop when invalid proto is introduced.
This fix should address it.

## Test Plan
build.py -g,
'break' one of the proto definitions,
build.py -g to verify error termination

$ build.py -g 
...
lte/protos/oai/sgw_state.proto:17:1: warning: Import lte/protos/oai/std_3gpp_types.proto but not used.
lte/cloud/go/services/subscriberdb/protos/subscriberdb.proto:17:1: warning: Import lte/protos/subscriberdb.proto but not used.
make[1]: Leaving directory '/src/magma/lte/cloud/go'
make -C /src/magma/feg/cloud/go gen_protos
make[1]: Entering directory '/src/magma/feg/cloud/go'
cd /src/magma ; \
for x in $(find feg/protos -name '*.proto') ; do \
	protoc \
		--proto_path /src/magma \
		--proto_path /src/magma/orc8r/protos/prometheus \
		--proto_path /usr/include \
		--go_out=plugins=grpc,Mgoogle/protobuf/field_mask.proto=google.golang.org/genproto/protobuf/field_mask:/src/magma/.. \
		${x} || exit 1 ; \
done ; \
for x in $(find feg/cloud/go -name '*.proto') ; do \
	protoc \
		--proto_path /src/magma \
		--proto_path /src/magma/orc8r/protos/prometheus \
		--proto_path /usr/include \
		--go_opt=paths=source_relative \
		--go_out=plugins=grpc,Mgoogle/protobuf/field_mask.proto=google.golang.org/genproto/protobuf/field_mask:. \
		${x} || exit 1 ; \
done
feg/protos/s6a_proxy.proto:264:29: Field number 1 has already been used in "magma.feg.PurgeUEAnswer" by field "error_code".
/src/magma/orc8r/cloud/go/module.mk:50: recipe for target 'gen_protos' failed
make[1]: *** [gen_protos] Error 1
make[1]: Leaving directory '/src/magma/feg/cloud/go'
Makefile:124: recipe for target '/src/magma/feg_gen_proto' failed
make: *** [/src/magma/feg_gen_proto] Error 2
ERROR: 2


<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
