### PR TITLE
chore(mme): fix compilation warnings for gtp ops

### DIFF
--- a/lte/gateway/c/core/oai/tasks/gtpv1-u/gtp_tunnel_upf.c
+++ b/lte/gateway/c/core/oai/tasks/gtpv1-u/gtp_tunnel_upf.c
@@ -48,38 +48,38 @@ const struct gtp_tunnel_ops* upf_gtp_tunnel_ops_init_openflow(void) {
   return (&upf_openflow_ops);
 }
 
-void upf_add_tunnel(
+int upf_add_tunnel(
     struct in_addr ue, struct in6_addr* ue_ipv6, int vlan, struct in_addr enb,
     uint32_t i_tei, uint32_t o_tei, Imsi_t imsi, struct ip_flow_dl* flow_dl,
     uint32_t flow_precedence_dl, char* apn) {
-  upf_classifier_add_tunnel(
+  return upf_classifier_add_tunnel(
       ue, ue_ipv6, vlan, enb, i_tei, o_tei, (const char*) imsi.digit, flow_dl,
       flow_precedence_dl, apn);
 }
 
-void upf_del_tunnel(
+int upf_del_tunnel(
     struct in_addr enb, struct in_addr ue, struct in6_addr* ue_ipv6,
     uint32_t i_tei, uint32_t o_tei, struct ip_flow_dl* flow_dl) {
-  upf_classifier_del_tunnel(enb, ue, ue_ipv6, i_tei, o_tei, flow_dl);
+  return upf_classifier_del_tunnel(enb, ue, ue_ipv6, i_tei, o_tei, flow_dl);
 }
 
-void upf_discard_data_on_tunnel(
+int upf_discard_data_on_tunnel(
     struct in_addr ue, struct in6_addr* ue_ipv6, uint32_t i_tei,
     struct ip_flow_dl* flow_dl) {
-  upf_classifier_discard_data_on_tunnel(ue, ue_ipv6, i_tei, flow_dl);
+  return upf_classifier_discard_data_on_tunnel(ue, ue_ipv6, i_tei, flow_dl);
 }
 
-void upf_forward_data_on_tunnel(
+int upf_forward_data_on_tunnel(
     struct in_addr ue, struct in6_addr* ue_ipv6, uint32_t i_tei,
     struct ip_flow_dl* flow_dl, uint32_t flow_precedence_dl) {
-  upf_classifier_forward_data_on_tunnel(
+  return upf_classifier_forward_data_on_tunnel(
       ue, ue_ipv6, i_tei, flow_dl, flow_precedence_dl);
 }
 
-void upf_add_paging_rule(struct in_addr ue) {
-  upf_classifier_add_paging_rule(ue);
+int upf_add_paging_rule(struct in_addr ue) {
+  return upf_classifier_add_paging_rule(ue);
 }
 
-void upf_delete_paging_rule(struct in_addr ue) {
-  upf_classifier_delete_paging_rule(ue);
+int upf_delete_paging_rule(struct in_addr ue) {
+  return upf_classifier_delete_paging_rule(ue);
 }

--- a/lte/gateway/c/core/oai/tasks/gtpv1-u/gtp_tunnel_upf.h
+++ b/lte/gateway/c/core/oai/tasks/gtpv1-u/gtp_tunnel_upf.h
@@ -21,23 +21,23 @@
 
 const struct gtp_tunnel_ops* upf_gtp_tunnel_ops_init_openflow(void);
 
-void upf_add_tunnel(
+int upf_add_tunnel(
     struct in_addr ue, struct in6_addr* ue_ipv6, int vlan, struct in_addr enb,
     uint32_t i_tei, uint32_t o_tei, Imsi_t imsi, struct ip_flow_dl* flow_dl,
     uint32_t flow_precedence_dl, char* apn);
 
-void upf_del_tunnel(
+int upf_del_tunnel(
     struct in_addr enb, struct in_addr ue, struct in6_addr* ue_ipv6,
     uint32_t i_tei, uint32_t o_tei, struct ip_flow_dl* flow_dl);
 
-void upf_discard_data_on_tunnel(
+int upf_discard_data_on_tunnel(
     struct in_addr ue, struct in6_addr* ue_ipv6, uint32_t i_tei,
     struct ip_flow_dl* flow_dl);
 
-void upf_forward_data_on_tunnel(
+int upf_forward_data_on_tunnel(
     struct in_addr ue, struct in6_addr* ue_ipv6, uint32_t i_tei,
     struct ip_flow_dl* flow_dl, uint32_t flow_precedence_dl);
 
-void upf_add_paging_rule(struct in_addr ue);
+int upf_add_paging_rule(struct in_addr ue);
 
-void upf_delete_paging_rule(struct in_addr ue);
+int upf_delete_paging_rule(struct in_addr ue);


### PR DESCRIPTION
Signed-off-by: Ulas Kozat <kozat@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->
Fixed the following compilation warnings:
```
[magma@10.240.0.5] out: [vagrant@127.0.0.1:2222] out: /home/vagrant/magma/lte/gateway/c/core/oai/tasks/gtpv1-u/gtp_tunnel_upf.c:36:31: warning: initialization of ‘int (*)(struct in_addr,  struct in6_addr *, int,  struct in_addr,  uint32_t,  uint32_t,  Imsi_t,  struct ip_flow_dl *, uint32_t,  char *)’ {aka ‘int (*)(struct in_addr,  struct in6_addr *, int,  struct in_addr,  unsigned int,  unsigned int,  struct <anonymous>,  struct ip_flow_dl *, unsigned int,  char *)’} from incompatible pointer type ‘void (*)(struct in_addr,  struct in6_addr *, int,  struct in_addr,  uint32_t,  uint32_t,  Imsi_t,  struct ip_flow_dl *, uint32_t,  char *)’ {aka ‘void (*)(struct in_addr,  struct in6_addr *, int,  struct in_addr,  unsigned int,  unsigned int,  struct <anonymous>,  struct ip_flow_dl *, unsigned int,  char *)’} [-Wincompatible-pointer-types]
[magma@10.240.0.5] out: [vagrant@127.0.0.1:2222] out:    36 |     .add_tunnel             = upf_add_tunnel,
[magma@10.240.0.5] out: [vagrant@127.0.0.1:2222] out:       |                               ^~~~~~~~~~~~~~
[magma@10.240.0.5] out: [vagrant@127.0.0.1:2222] out: /home/vagrant/magma/lte/gateway/c/core/oai/tasks/gtpv1-u/gtp_tunnel_upf.c:36:31: note: (near initialization for ‘upf_openflow_ops.add_tunnel’)
[magma@10.240.0.5] out: [vagrant@127.0.0.1:2222] out: /home/vagrant/magma/lte/gateway/c/core/oai/tasks/gtpv1-u/gtp_tunnel_upf.c:37:31: warning: initialization of ‘int (*)(struct in_addr,  struct in_addr,  struct in6_addr *, uint32_t,  uint32_t,  struct ip_flow_dl *)’ {aka ‘int (*)(struct in_addr,  struct in_addr,  struct in6_addr *, unsigned int,  unsigned int,  struct ip_flow_dl *)’} from incompatible pointer type ‘void (*)(struct in_addr,  struct in_addr,  struct in6_addr *, uint32_t,  uint32_t,  struct ip_flow_dl *)’ {aka ‘void (*)(struct in_addr,  struct in_addr,  struct in6_addr *, unsigned int,  unsigned int,  struct ip_flow_dl *)’} [-Wincompatible-pointer-types]
[magma@10.240.0.5] out: [vagrant@127.0.0.1:2222] out:    37 |     .del_tunnel             = upf_del_tunnel,
[magma@10.240.0.5] out: [vagrant@127.0.0.1:2222] out:       |                               ^~~~~~~~~~~~~~
[magma@10.240.0.5] out: [vagrant@127.0.0.1:2222] out: /home/vagrant/magma/lte/gateway/c/core/oai/tasks/gtpv1-u/gtp_tunnel_upf.c:37:31: note: (near initialization for ‘upf_openflow_ops.del_tunnel’)
[magma@10.240.0.5] out: [vagrant@127.0.0.1:2222] out: /home/vagrant/magma/lte/gateway/c/core/oai/tasks/gtpv1-u/gtp_tunnel_upf.c:38:31: warning: initialization of ‘int (*)(struct in_addr,  struct in6_addr *, uint32_t,  struct ip_flow_dl *)’ {aka ‘int (*)(struct in_addr,  struct in6_addr *, unsigned int,  struct ip_flow_dl *)’} from incompatible pointer type ‘void (*)(struct in_addr,  struct in6_addr *, uint32_t,  struct ip_flow_dl *)’ {aka ‘void (*)(struct in_addr,  struct in6_addr *, unsigned int,  struct ip_flow_dl *)’} [-Wincompatible-pointer-types]
[magma@10.240.0.5] out: [vagrant@127.0.0.1:2222] out:    38 |     .discard_data_on_tunnel = upf_discard_data_on_tunnel,
[magma@10.240.0.5] out: [vagrant@127.0.0.1:2222] out:       |                               ^~~~~~~~~~~~~~~~~~~~~~~~~~
[magma@10.240.0.5] out: [vagrant@127.0.0.1:2222] out: /home/vagrant/magma/lte/gateway/c/core/oai/tasks/gtpv1-u/gtp_tunnel_upf.c:38:31: note: (near initialization for ‘upf_openflow_ops.discard_data_on_tunnel’)
[magma@10.240.0.5] out: [vagrant@127.0.0.1:2222] out: /home/vagrant/magma/lte/gateway/c/core/oai/tasks/gtpv1-u/gtp_tunnel_upf.c:39:31: warning: initialization of ‘int (*)(struct in_addr,  struct in6_addr *, uint32_t,  struct ip_flow_dl *, uint32_t)’ {aka ‘int (*)(struct in_addr,  struct in6_addr *, unsigned int,  struct ip_flow_dl *, unsigned int)’} from incompatible pointer type ‘void (*)(struct in_addr,  struct in6_addr *, uint32_t,  struct ip_flow_dl *, uint32_t)’ {aka ‘void (*)(struct in_addr,  struct in6_addr *, unsigned int,  struct ip_flow_dl *, unsigned int)’} [-Wincompatible-pointer-types]
[magma@10.240.0.5] out: [vagrant@127.0.0.1:2222] out:    39 |     .forward_data_on_tunnel = upf_forward_data_on_tunnel,
[magma@10.240.0.5] out: [vagrant@127.0.0.1:2222] out:       |                               ^~~~~~~~~~~~~~~~~~~~~~~~~~
[magma@10.240.0.5] out: [vagrant@127.0.0.1:2222] out: /home/vagrant/magma/lte/gateway/c/core/oai/tasks/gtpv1-u/gtp_tunnel_upf.c:39:31: note: (near initialization for ‘upf_openflow_ops.forward_data_on_tunnel’)
[magma@10.240.0.5] out: [vagrant@127.0.0.1:2222] out: /home/vagrant/magma/lte/gateway/c/core/oai/tasks/gtpv1-u/gtp_tunnel_upf.c:40:31: warning: initialization of ‘int (*)(struct in_addr)’ from incompatible pointer type ‘void (*)(struct in_addr)’ [-Wincompatible-pointer-types]
[magma@10.240.0.5] out: [vagrant@127.0.0.1:2222] out:    40 |     .add_paging_rule        = upf_add_paging_rule,
[magma@10.240.0.5] out: [vagrant@127.0.0.1:2222] out:       |                               ^~~~~~~~~~~~~~~~~~~
[magma@10.240.0.5] out: [vagrant@127.0.0.1:2222] out: /home/vagrant/magma/lte/gateway/c/core/oai/tasks/gtpv1-u/gtp_tunnel_upf.c:40:31: note: (near initialization for ‘upf_openflow_ops.add_paging_rule’)
[magma@10.240.0.5] out: [vagrant@127.0.0.1:2222] out: /home/vagrant/magma/lte/gateway/c/core/oai/tasks/gtpv1-u/gtp_tunnel_upf.c:41:31: warning: initialization of ‘int (*)(struct in_addr)’ from incompatible pointer type ‘void (*)(struct in_addr)’ [-Wincompatible-pointer-types]
[magma@10.240.0.5] out: [vagrant@127.0.0.1:2222] out:    41 |     .delete_paging_rule     = upf_delete_paging_rule,
[magma@10.240.0.5] out: [vagrant@127.0.0.1:2222] out:       |                               ^~~~~~~~~~~~~~~~~~~~~~
[magma@10.240.0.5] out: [vagrant@127.0.0.1:2222] out: /home/vagrant/magma/lte/gateway/c/core/oai/tasks/gtpv1-u/gtp_tunnel_upf.c:41:31: note: (near initialization for ‘upf_openflow_ops.delete_paging_rule’)
```

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->
Integ tests.

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
