### PR TITLE
feat(cloud): support dynamic instance types for teravm and s1ap testing

### DIFF
--- a/experimental/cloudstrapper/playbooks/roles/agw-infra/tasks/provision-instances.yaml
+++ b/experimental/cloudstrapper/playbooks/roles/agw-infra/tasks/provision-instances.yaml
@@ -61,7 +61,7 @@
       paramSshKey: "{{ awsHostKey }}"
       paramAgwTagName: "{{ idGw }}"
       paramAgwTagSite: "{{ siteName }}"
-      paramAgwInstanceType: "t2.medium"
+      paramAgwInstanceType: "{{ awsInstanceType }}"
   when: agwDevops is undefined
 
 - name: Get EBS encryption default
@@ -87,7 +87,7 @@
       paramSshKey: "{{ awsHostKey }}"
       paramAgwTagName: "{{ idGw }}"
       paramAgwTagSite: "{{ siteName }}"
-      paramAgwInstanceType: "t2.medium"
+      paramAgwInstanceType: "{{ awsInstanceType }}"
   when: agwDevops is defined
 
 - name: Enable EBS encryption to permit export of ami

--- a/experimental/cloudstrapper/playbooks/roles/vars/cluster.yaml
+++ b/experimental/cloudstrapper/playbooks/roles/vars/cluster.yaml
@@ -18,6 +18,7 @@ awsAgwRegion: us-west-2
 awsOrc8rRegion: us-west-2
 awsAgwAz: "{{ awsAgwRegion }}a"
 awsAgwVersion: v1.5
+awsInstanceType: "t2.medium"
 
 awsAgwAmi: ami-06447b6fef489a898
 #awsCloudstrapperAmi: ami-03865ac2b925f8056


### PR DESCRIPTION
Signed-off-by: Arun Thulasi <arunuke@gmail.com>


## Summary

Cloudstrapper originally launched AGW instances as t2.medium. However, the same infrastructure is reused for the testing framework with potential teravm and s1aptester components running in the same cluster. The other images require different instance types. Added a tunable to allow instances of multiple supported types to be launched on the AGW VPC.

## Test Plan

Placeholder instances for teravm-vran, teravm-core and s1aptester (all c5.2xlarge) were deployed by setting the new variable agwInstanceType to the desired value.

## Additional Information

- [ ] This change is backwards-breaking


