### PR TITLE
fix(ci): path filter

### DIFF
--- a/.github/workflows/agw-workflow.yml
+++ b/.github/workflows/agw-workflow.yml
@@ -14,18 +14,18 @@ on:  # yamllint disable-line rule:truthy
 jobs:
   path_filter:
     runs-on: ubuntu-latest
-    # Map a step output to a job output
     outputs:
-      should_skip: ${{ steps.skip_check.outputs.should_skip }}
+      should_not_skip: ${{ steps.changes.outputs.filesChanged }}
     steps:
-      - id: skip_check
-        uses: fkirc/skip-duplicate-actions@master
+      - uses: dorny/paths-filter@v2
+        id: changes
         with:
-          # Only run the main job for changes including the following paths
-          paths: '["orc8r/**", "lte/**"]'
+          filters: |
+            filesChanged:
+              - [".github/workflows/agw-workflow.yml", "orc8r/**", "lte/**"]
   lte-test:
     needs: path_filter
-    if: ${{ needs.path_filter.outputs.should_skip == 'false' }}
+    if: ${{ needs.path_filter.outputs.should_not_skip == 'true' }}
     name: lte test job
     runs-on: ubuntu-latest
     env:
@@ -106,7 +106,7 @@ jobs:
 
   session_manager_test:
     needs: path_filter
-    if: ${{ needs.path_filter.outputs.should_skip == 'false' }}
+    if: ${{ needs.path_filter.outputs.should_not_skip == 'true' }}
     name: session manager test job
     runs-on: ubuntu-latest
     env:
@@ -146,7 +146,7 @@ jobs:
 
   li_agent_test:
     needs: path_filter
-    if: ${{ needs.path_filter.outputs.should_skip == 'false' }}
+    if: ${{ needs.path_filter.outputs.should_not_skip == 'true' }}
     name: li agent test job
     runs-on: ubuntu-latest
     env:
@@ -187,7 +187,7 @@ jobs:
 
   connection-tracker-test:
     needs: path_filter
-    if: ${{ needs.path_filter.outputs.should_skip == 'false' }}
+    if: ${{ needs.path_filter.outputs.should_not_skip == 'true' }}
     name: connection tracker test job
     runs-on: ubuntu-latest
     env:
@@ -231,7 +231,7 @@ jobs:
 
   mme_test:
     needs: path_filter
-    if: ${{ needs.path_filter.outputs.should_skip == 'false' }}
+    if: ${{ needs.path_filter.outputs.should_not_skip == 'true' }}
     name: mme test job
     runs-on: ubuntu-latest
     env:
@@ -280,7 +280,7 @@ jobs:
 
   mme-clang-tidy:
     needs: path_filter
-    if: ${{ needs.path_filter.outputs.should_skip == 'false' }}
+    if: ${{ needs.path_filter.outputs.should_not_skip == 'true' }}
     name: mme clang tidy job
     runs-on: ubuntu-latest
     env:
@@ -317,7 +317,7 @@ jobs:
 
   mme-clang-warnings:
     needs: path_filter
-    if: ${{ needs.path_filter.outputs.should_skip == 'false' }}
+    if: ${{ needs.path_filter.outputs.should_not_skip == 'true' }}
     name: mme clang warnings job
     runs-on: ubuntu-latest
     env:
@@ -354,7 +354,7 @@ jobs:
 
   c-cpp-codecov:
     needs: path_filter
-    if: ${{ needs.path_filter.outputs.should_skip == 'false' }}
+    if: ${{ needs.path_filter.outputs.should_not_skip == 'true' }}
     name: c-cpp code coverage job
     runs-on: ubuntu-latest
     env:

--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -14,20 +14,20 @@ env:
 jobs:
   path_filter:
     runs-on: ubuntu-latest
-    # Map a step output to a job output
     outputs:
-      should_skip: ${{ steps.skip_check.outputs.should_skip }}
+      should_not_skip: ${{ steps.changes.outputs.filesChanged }}
     steps:
-      - id: skip_check
-        uses: fkirc/skip-duplicate-actions@master
+      - uses: dorny/paths-filter@v2
+        id: changes
         with:
-          # Only run the main job for changes including the following paths
-         paths: '[".github/workflows/bazel.yml", "lte/gateway/c/**", "orc8r/gateway/c/**", "orc8r/protos/**", "lte/protos/**"]'
+          filters: |
+            filesChanged:
+              - [".github/workflows/bazel.yml", "lte/gateway/c/**", "orc8r/gateway/c/**", "orc8r/protos/**", "lte/protos/**"]
 
   bazel_build_and_test:
     needs:
       - path_filter
-    if: ${{ needs.path_filter.outputs.should_skip == 'false' }}
+    if: ${{ needs.path_filter.outputs.should_not_skip == 'true' }}
     name: Bazel Build and Test Job
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/cloud-workflow.yml
+++ b/.github/workflows/cloud-workflow.yml
@@ -13,21 +13,21 @@ on:  # yamllint disable-line rule:truthy
 jobs:
   path_filter:
     runs-on: ubuntu-latest
-    # Map a step output to a job output
     outputs:
-      should_skip: ${{ steps.skip_check.outputs.should_skip }}
+      should_not_skip: ${{ steps.changes.outputs.filesChanged }}
     steps:
-      - id: skip_check
-        uses: fkirc/skip-duplicate-actions@master
+      - uses: dorny/paths-filter@v2
+        id: changes
         with:
-          # Only run the main job for changes including the following paths
-          paths: '["cwf/cloud/**", "fbinternal/cloud/**", "feg/cloud/**", "lte/cloud/**", "orc8r/cloud/**", "orc8r/lib/**", "wifi/cloud/**"]'
+          filters: |
+            filesChanged:
+              - [".github/workflows/cloud-workflow.yml", "cwf/cloud/**", "fbinternal/cloud/**", "feg/cloud/**", "lte/cloud/**", "orc8r/cloud/**", "orc8r/lib/**", "wifi/cloud/**"]
 
   # Fail if checked-in generated code doesn't match output from
   # generation command.
   insync-checkin:
     needs: path_filter
-    if: ${{ needs.path_filter.outputs.should_skip != 'true' }}
+    if: ${{ needs.path_filter.outputs.should_not_skip == 'true' }}
     name: insync checkin job
     runs-on: ubuntu-latest
     env:
@@ -67,7 +67,7 @@ jobs:
   # Ensure all Helm chart values are in-sync across Orc8r deployment mechanisms
   deploy-sync-checkin:
     needs: path_filter
-    if: ${{ needs.path_filter.outputs.should_skip != 'true' }}
+    if: ${{ needs.path_filter.outputs.should_not_skip == 'true' }}
     name: deploy sync job
     runs-on: ubuntu-latest
     env:
@@ -101,7 +101,7 @@ jobs:
   # Upload test coverage statistics.
   cloud-lint:
     needs: path_filter
-    if: ${{ needs.path_filter.outputs.should_skip != 'true' }}
+    if: ${{ needs.path_filter.outputs.should_not_skip == 'true' }}
     name: cloud lint job
     runs-on: ubuntu-latest
     env:
@@ -142,7 +142,7 @@ jobs:
           SLACK_FOOTER: ' '
   cloud-test:
     needs: path_filter
-    if: ${{ needs.path_filter.outputs.should_skip != 'true' }}
+    if: ${{ needs.path_filter.outputs.should_not_skip == 'true' }}
     name: cloud test job
     runs-on: ubuntu-latest
     env:
@@ -183,7 +183,7 @@ jobs:
           SLACK_FOOTER: ' '
   cloud-upload:
     needs: path_filter
-    if: ${{ needs.path_filter.outputs.should_skip == 'false' && github.ref == 'refs/heads/master' }}
+    if: ${{ needs.path_filter.outputs.should_not_skip == 'true' && github.ref == 'refs/heads/master' }}
     name: cloud upload job
     runs-on: ubuntu-latest
     steps:
@@ -221,7 +221,7 @@ jobs:
       - deploy-sync-checkin
       - cloud-lint
       - cloud-test
-    if: ${{ needs.path_filter.outputs.should_skip == 'false' }}
+    if: ${{ needs.path_filter.outputs.should_not_skip == 'true' }}
     name: orc8r build job
     runs-on: ubuntu-latest
     env:

--- a/.github/workflows/cwag-workflow.yml
+++ b/.github/workflows/cwag-workflow.yml
@@ -15,16 +15,17 @@ jobs:
     runs-on: ubuntu-latest
     # Map a step output to a job output
     outputs:
-      should_skip: ${{ steps.skip_check.outputs.should_skip }}
+      should_not_skip: ${{ steps.changes.outputs.filesChanged }}
     steps:
-      - id: skip_check
-        uses: fkirc/skip-duplicate-actions@master
+      - uses: dorny/paths-filter@v2
+        id: changes
         with:
-            # Only run the main job for changes including the following paths
-            paths: '["orc8r/**", "lte/**", "feg/**", "cwf/**"]'
+          filters: |
+            filesChanged:
+              - [".github/workflows/cwag-workflow.yml", "orc8r/**", "lte/**", "feg/**", "cwf/**"]
   cwag-precommit:
     needs: path_filter
-    if: ${{ needs.path_filter.outputs.should_skip == 'false' }}
+    if: ${{ needs.path_filter.outputs.should_not_skip == 'true' }}
     name: cwag pre-commit job
     runs-on: ubuntu-latest
     env:
@@ -69,7 +70,7 @@ jobs:
           SLACK_FOOTER: ' '
   cwag-build:
     needs: path_filter
-    if: ${{ needs.path_filter.outputs.should_skip == 'false' }}
+    if: ${{ needs.path_filter.outputs.should_not_skip == 'true' }}
     name: cwag build job
     runs-on: ubuntu-latest
     env:
@@ -108,7 +109,7 @@ jobs:
     needs:
       - path_filter
       - cwag-precommit
-    if: ${{ needs.path_filter.outputs.should_skip == 'false' }}
+    if: ${{ needs.path_filter.outputs.should_not_skip == 'true' }}
     name: cwag deploy job
       # TODO Should also need cwf-integ-test
       # TODO Requires release hold
@@ -197,7 +198,7 @@ jobs:
     needs:
       - path_filter
       - cwag-deploy
-    if: ${{ needs.path_filter.outputs.should_skip == 'false' }}
+    if: ${{ needs.path_filter.outputs.should_not_skip == 'true' }}
     name: xwfm deploy job
     runs-on: ubuntu-latest
     env:

--- a/.github/workflows/cwf-operator.yml
+++ b/.github/workflows/cwf-operator.yml
@@ -15,16 +15,17 @@ jobs:
     runs-on: ubuntu-latest
     # Map a step output to a job output
     outputs:
-      should_skip: ${{ steps.skip_check.outputs.should_skip }}
+      should_not_skip: ${{ steps.changes.outputs.filesChanged }}
     steps:
-      - id: skip_check
-        uses: fkirc/skip-duplicate-actions@master
+      - uses: dorny/paths-filter@v2
+        id: changes
         with:
-          # Only run the main job for changes including the following paths
-          paths: '["cwf/**", "k8s/**"]'
+          filters: |
+            filesChanged:
+              - [".github/workflows/cwf-operator.yml", "cwf/**", "k8s/**"]
   cwf-operator-precommit:
     needs: path_filter
-    if: ${{ needs.path_filter.outputs.should_skip == 'false' }}
+    if: ${{ needs.path_filter.outputs.should_not_skip == 'true' }}
     name: cwf operator pre-commit job
     runs-on: ubuntu-latest
     env:
@@ -68,7 +69,7 @@ jobs:
     needs:
       - path_filter
       - cwf-operator-precommit
-    if: ${{ needs.path_filter.outputs.should_skip == 'false' }}
+    if: ${{ needs.path_filter.outputs.should_not_skip == 'true' }}
     name: cwf operator build job
     runs-on: ubuntu-latest
     env:

--- a/.github/workflows/docs-workflow.yml
+++ b/.github/workflows/docs-workflow.yml
@@ -13,19 +13,19 @@ on:  # yamllint disable-line rule:truthy
 jobs:
   path_filter:
     runs-on: ubuntu-latest
-    # Map a step output to a job output
     outputs:
-      should_skip: ${{ steps.skip_check.outputs.should_skip }}
+      should_not_skip: ${{ steps.changes.outputs.filesChanged }}
     steps:
-      - id: skip_check
-        uses: fkirc/skip-duplicate-actions@master
+      - uses: dorny/paths-filter@v2
+        id: changes
         with:
-          # Only run the main job for changes including the following paths
-          paths: '["docs/**"]'
+          filters: |
+            filesChanged:
+              - [".github/workflows/docs-workflow.yml", "docs/**"]
   # Fail if Markdown doesn't pass linter
   markdown-lint:
     needs: path_filter
-    if: ${{ needs.path_filter.outputs.should_skip == 'false' }}
+    if: ${{ needs.path_filter.outputs.should_not_skip == 'true' }}
     name: markdown lint job
     runs-on: ubuntu-latest
     env:

--- a/.github/workflows/feg-workflow.yml
+++ b/.github/workflows/feg-workflow.yml
@@ -14,18 +14,18 @@ on:
 jobs:
   path_filter:
     runs-on: ubuntu-latest
-    # Map a step output to a job output
     outputs:
-      should_skip: ${{ steps.skip_check.outputs.should_skip }}
+      should_not_skip: ${{ steps.changes.outputs.filesChanged }}
     steps:
-      - id: skip_check
-        uses: fkirc/skip-duplicate-actions@master
+      - uses: dorny/paths-filter@v2
+        id: changes
         with:
-          # Only run the main job for changes including the following paths
-          paths: '["orc8r/**", "lte/**", "feg/**"]'
+          filters: |
+            filesChanged:
+              - [".github/workflows/feg-workflow.yml", "orc8r/**", "lte/**", "feg/**"]
   feg-lint:
     needs: path_filter
-    if: ${{ needs.path_filter.outputs.should_skip == 'false' }}
+    if: ${{ needs.path_filter.outputs.should_not_skip == 'true' }}
     name: feg lint job
     runs-on: ubuntu-latest
     env:
@@ -78,7 +78,7 @@ jobs:
           SLACK_FOOTER: ' '
   feg-precommit:
     needs: path_filter
-    if: ${{ needs.path_filter.outputs.should_skip == 'false' }}
+    if: ${{ needs.path_filter.outputs.should_not_skip == 'true' }}
     name: feg pre-commit job
     runs-on: ubuntu-latest
     env:
@@ -131,7 +131,7 @@ jobs:
     needs:
       - path_filter
       - feg-precommit
-    if: ${{ needs.path_filter.outputs.should_skip == 'false' }}
+    if: ${{ needs.path_filter.outputs.should_not_skip == 'true' }}
     name: feg-build
     runs-on: ubuntu-latest
     env:

--- a/.github/workflows/gcc-problems.yml
+++ b/.github/workflows/gcc-problems.yml
@@ -21,20 +21,19 @@ env:
 jobs:
   path_filter:
     runs-on: ubuntu-latest
-    # Map a step output to a job output
     outputs:
-      should_skip: ${{ steps.skip_check.outputs.should_skip }}
+      should_not_skip: ${{ steps.changes.outputs.filesChanged }}
     steps:
-      - id: skip_check
-        uses: fkirc/skip-duplicate-actions@master
+      - uses: dorny/paths-filter@v2
+        id: changes
         with:
-          # Only run the main job for changes including the following paths
-          paths: '[".github/workflows/gcc-problems.yml", "orc8r/gateway/c/**", "lte/gateway/c/**", "orc8r/protos/**", "lte/protos/**"]'
-
+          filters: |
+            filesChanged:
+              - [".github/workflows/gcc-problems.yml", "orc8r/gateway/c/**", "lte/gateway/c/**", "orc8r/protos/**", "lte/protos/**"]
   build_oai:
     needs:
       - path_filter
-    if: ${{ needs.path_filter.outputs.should_skip == 'false' }}
+    if: ${{ needs.path_filter.outputs.should_not_skip == 'true' }}
     name: build oai job
     runs-on: ubuntu-latest
     steps:
@@ -80,7 +79,7 @@ jobs:
   build_session_manager:
     needs:
       - path_filter
-    if: ${{ needs.path_filter.outputs.should_skip == 'false' }}
+    if: ${{ needs.path_filter.outputs.should_not_skip == 'true' }}
     name: build session manager job
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/golang-build-test.yml
+++ b/.github/workflows/golang-build-test.yml
@@ -10,19 +10,19 @@ on:  # yamllint disable-line rule:truthy
 jobs:
   pre_job_src_go_determinator:
     runs-on: ubuntu-latest
-    # Map a step output to a job output
     outputs:
-      should_skip: ${{ steps.skip_check.outputs.should_skip }}
+      should_not_skip: ${{ steps.changes.outputs.filesChanged }}
     steps:
-      - id: skip_check
-        uses: fkirc/skip-duplicate-actions@master
+      - uses: dorny/paths-filter@v2
+        id: changes
         with:
-          # Only run the main job for changes including the following paths
-          paths: '[".github/workflows/golang-build-test.yml", "src/go/**"]'
+          filters: |
+            filesChanged:
+              - [".github/workflows/golang-build-test.yml", "src/go/**"]
 
   build_src_go:
     needs: pre_job_src_go_determinator
-    if: ${{ needs.pre_job_src_go_determinator.outputs.should_skip == 'false' }}
+    if: ${{ needs.pre_job_src_go_determinator.outputs.should_not_skip == 'true' }}
     strategy:
       matrix:
         go-version: [1.17.x]
@@ -42,7 +42,7 @@ jobs:
 
   test_src_go:
     needs: pre_job_src_go_determinator
-    if: ${{ needs.pre_job_src_go_determinator.outputs.should_skip == 'false' }}
+    if: ${{ needs.pre_job_src_go_determinator.outputs.should_not_skip == 'true' }}
     strategy:
       matrix:
         go-version: [1.17.x]
@@ -71,7 +71,7 @@ jobs:
 
   test_src_go_qemu:
     needs: pre_job_src_go_determinator
-    if: ${{ needs.pre_job_src_go_determinator.outputs.should_skip == 'false' }}
+    if: ${{ needs.pre_job_src_go_determinator.outputs.should_not_skip == 'true' }}
     strategy:
       matrix:
         go-version: [1.17.x]
@@ -105,7 +105,7 @@ jobs:
 
   codecov_src_go:
     needs: pre_job_src_go_determinator
-    if: ${{ needs.pre_job_src_go_determinator.outputs.should_skip == 'false' }}
+    if: ${{ needs.pre_job_src_go_determinator.outputs.should_not_skip == 'true' }}
     runs-on: ubuntu-latest
     steps:
       - name: Install Go

--- a/.github/workflows/lint-clang-format.yml
+++ b/.github/workflows/lint-clang-format.yml
@@ -10,19 +10,19 @@ on:  # yamllint disable-line rule:truthy
 jobs:
   pre_job_c_cpp_determinator:
     runs-on: ubuntu-latest
-    # Map a step output to a job output
     outputs:
-      should_skip: ${{ steps.skip_check.outputs.should_skip }}
+      should_not_skip: ${{ steps.changes.outputs.filesChanged }}
     steps:
-      - id: skip_check
-        uses: fkirc/skip-duplicate-actions@master
+      - uses: dorny/paths-filter@v2
+        id: changes
         with:
-          # Only run the main job for changes including the following paths
-          paths: '[".github/workflows/lint-clang-format.yml", "lte/gateway/c/**", "orc8r/gateway/c/**"]'
+          filters: |
+            filesChanged:
+              - [".github/workflows/lint-clang-format.yml", "lte/gateway/c/**", "orc8r/gateway/c/**"]
 
   lint-clang-format:
     needs: pre_job_c_cpp_determinator
-    if: ${{ needs.pre_job_c_cpp_determinator.outputs.should_skip == 'false' }}
+    if: ${{ needs.pre_job_c_cpp_determinator.outputs.should_not_skip == 'true' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/python-workflow.yml
+++ b/.github/workflows/python-workflow.yml
@@ -10,19 +10,19 @@ on:  # yamllint disable-line rule:truthy
 jobs:
   pre_job:
     runs-on: ubuntu-latest
-    # Map a step output to a job output
     outputs:
-      should_skip: ${{ steps.skip_check.outputs.should_skip }}
+      should_not_skip: ${{ steps.changes.outputs.filesChanged }}
     steps:
-      - id: skip_check
-        uses: fkirc/skip-duplicate-actions@master
+      - uses: dorny/paths-filter@v2
+        id: changes
         with:
-          # Only run the main job for changes including the following paths
-          paths: '["**/*.py"]'
+          filters: |
+            filesChanged:
+              - [".github/workflows/python-workflow.yml", "**/*.py"]
 
   run-formatters-and-check-for-errors:
     needs: pre_job
-    if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
+    if: ${{ needs.pre_job.outputs.should_not_skip == 'true' }}
     name: Python Format Check
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/reviewdog-workflow.yml
+++ b/.github/workflows/reviewdog-workflow.yml
@@ -15,31 +15,31 @@ on:  # yamllint disable-line rule:truthy
 jobs:
   pre_job_go_determinator:
     runs-on: ubuntu-latest
-    # Map a step output to a job output
     outputs:
-      should_skip: ${{ steps.skip_check.outputs.should_skip }}
+      should_not_skip: ${{ steps.changes.outputs.filesChanged }}
     steps:
-      - id: skip_check
-        uses: fkirc/skip-duplicate-actions@master
+      - uses: dorny/paths-filter@v2
+        id: changes
         with:
-          # Only run the main job for changes including the following paths
-          paths: '[".github/workflows/reviewdog-workflow.yml", "src/go/**"]'
+          filters: |
+            filesChanged:
+              - [".github/workflows/reviewdog-workflow.yml", "src/go/**"]
 
   pre_job_c_cpp_determinator:
     runs-on: ubuntu-latest
-    # Map a step output to a job output
     outputs:
-      should_skip: ${{ steps.skip_check.outputs.should_skip }}
+      should_not_skip: ${{ steps.changes.outputs.filesChanged }}
     steps:
-      - id: skip_check
-        uses: fkirc/skip-duplicate-actions@master
+      - uses: dorny/paths-filter@v2
+        id: changes
         with:
-          # Only run the main job for changes including the following paths
-          paths: '[".github/workflows/reviewdog-workflow.yml", "lte/gateway/c/**", "orc8r/gateway/c/**"]'
+          filters: |
+            filesChanged:
+              - [".github/workflows/reviewdog-workflow.yml", "lte/gateway/c/**", "orc8r/gateway/c/**"]
 
   cpplint:
     needs: pre_job_c_cpp_determinator
-    if: ${{ needs.pre_job_c_cpp_determinator.outputs.should_skip == 'false' }}
+    if: ${{ needs.pre_job_c_cpp_determinator.outputs.should_not_skip == 'true' }}
     ##
     #  Cpplint aims to lint to the Google Style guide. For detailed
     #  rationale on each linting rule, see
@@ -75,7 +75,7 @@ jobs:
 
   golangci-lint:
     needs: pre_job_go_determinator
-    if: ${{ needs.pre_job_go_determinator.outputs.should_skip == 'false' }}
+    if: ${{ needs.pre_job_go_determinator.outputs.should_not_skip == 'true' }}
     runs-on: ubuntu-latest
     steps:
       - name: Check out code into the Go module directory


### PR DESCRIPTION
Signed-off-by: Quentin, Derory <15911421+quentinDERORY@users.noreply.github.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

fkirc/skip-duplicate-actions@master module does not work well on pull_request event type.
The backtracking algorithm is tuned for workflow events.
They advise using dorny/paths-filter@v2 for pull_request events.

## Test Plan

On this PR

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
