### PR TITLE
fix(sessiond): Sending Paging notification to AMF only when session i…

### DIFF
--- a/lte/gateway/c/session_manager/UpfMsgManageHandler.cpp
+++ b/lte/gateway/c/session_manager/UpfMsgManageHandler.cpp
@@ -193,12 +193,21 @@ void UpfMsgManageHandler::get_session_from_imsi(
     MLOG(MINFO) << "IDLE_MODE::: Session found in SendingPaging "
                    "Request of imsi: "
                 << imsi << "  session_id: " << session->get_session_id();
-    // Generate Paging trigget to AMF.
-    conv_enforcer_->handle_state_update_to_amf(
-        *session, magma::lte::M5GSMCause::OPERATION_SUCCESS, UE_PAGING_NOTIFY);
-    MLOG(MINFO) << "UPF Paging notification forwarded to AMF of imsi:" << imsi;
-    response_callback(Status::OK, SmContextVoid());
+    /* Generate Paging notification to AMF, only if session is in INACTIVE
+     * state.
+     */
+    if (session->get_state() == INACTIVE) {
+      conv_enforcer_->handle_state_update_to_amf(
+          *session, magma::lte::M5GSMCause::OPERATION_SUCCESS,
+          UE_PAGING_NOTIFY);
+      MLOG(MDEBUG) << "UPF Paging notification forwarded to AMF of imsi:"
+                   << imsi;
+      response_callback(Status::OK, SmContextVoid());
+    } else {
+      MLOG(MDEBUG) << "Can not Trigger Paging notification to AMF, as session "
+                      "is not an INACTIVE state.";
+      return;
+    }
   });
-  return;
 }
 }  // end namespace magma


### PR DESCRIPTION
fix(sessiond): Sending Paging notification to AMF only when session is in INACTIVE state.


## Summary
1) This is one kind of Negative scenario handling in Sesssiond
2) Sessiond has to send Paging Notification to AMF only when session is in INACTVIE state.
3) Corresponding git hub issue task : #8716 


## Test Plan
Tested with stub CLI "smf_upf_integration_cli.py"
Below is the log when session moved to INACTIVE sate and received Paging Notification from UPF and Forwarding to AMF.
![image](https://user-images.githubusercontent.com/70899516/134478719-d8408a6f-5ae6-4886-ace6-acdf2ac0eaec.png)


Below is the log when session moved to ACTIVE sate and received Paging Notification from UPF and Not Forwarding to AMF.
![image](https://user-images.githubusercontent.com/70899516/134478560-96310ac6-f677-4a42-9b4e-d17862aff7b8.png)

For detailed test case steps will be add comment in this PR.

## Additional Information
Signed-off-by: GANESH IRRINKI <ganesh.irrinki@wavelabs.ai>

