### PR TITLE
ci: adds scheduled gh action to populate Bazel cache

### DIFF
--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -6,6 +6,9 @@ on:  # yamllint disable-line rule:truthy
       - opened
       - reopened
       - synchronize
+  schedule:
+    # Run once a day to build bazel cache at 0200 hours
+    - cron: '0 2 * * *'
 env:
   DEVCONTAINER_IMAGE: "ghcr.io/magma/devcontainer:sha-9fe32d6"
   BAZEL_CACHE: bazel-cache
@@ -27,7 +30,11 @@ jobs:
   bazel_build_and_test:
     needs:
       - path_filter
-    if: ${{ needs.path_filter.outputs.should_skip == 'false' }}
+    # Only run workflow if this is a scheduled run on master branch,
+    # or a push_request that skip-duplicate-action wants to run again.
+    if: |
+      (github.event_name == `schedule` && github.ref == 'refs/heads/master')
+        || ${{ needs.path_filter.outputs.should_skip == 'false' }}
     name: Bazel Build and Test Job
     runs-on: ubuntu-latest
     steps:
@@ -58,6 +65,7 @@ jobs:
               cd /workspaces/magma
               bazel build ... --config=devcontainer
         - name: Bazel Test
+          if: github.event_name == 'pull_request'
           uses: addnab/docker-run-action@v2
           with:
             image: ${{ env.DEVCONTAINER_IMAGE }}


### PR DESCRIPTION
## Summary

The GitHub `Bazel Build & Test` action was updated to support caching across workflow runs in #9229, but after merging it was discovered that the cache use in GitHub Actions is tied to the **key AND branch** in lookup - meaning that in our workflow at Magma (forked PR branch merge requests to upstream master) - these keys are not discoverable between PRs.

Documentation from Github on [Cache Key Lookup](https://docs.github.com/en/actions/advanced-guides/caching-dependencies-to-speed-up-workflows#matching-a-cache-key) indicates that:

> The cache action first searches for cache hits for key and restore-keys in the branch containing the workflow run. If there are no hits in the current branch, the cache action searches for key and restore-keys in the parent branch and *upstream branches.*

The hope with this PR is that the upstream branches clause will kick in for our PR workflows.

This PR therefore adds scheduled GH Bazel Builds on magma/magma:master with the hope that the cache key will be discoverable by PRs when they Bazel Build.

## Test Plan

Untestable, unless I generate a full and ~equivalent repo of my own and mock this out.

Signed-off-by: Scott Moeller <electronjoe@gmail.com>