### PR TITLE
ci: updates bazel build cache keys

### DIFF
--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -38,16 +38,12 @@ jobs:
           uses: actions/cache@v2
           with:
             path: ${{ github.workspace }}/.${{ env.BAZEL_CACHE }}
-            key: ${{ runner.os }}-${{ env.BAZEL_CACHE }}-${{ github.sha }}
-            restore-keys: |
-              ${{ runner.os }}-${{ env.BAZEL_CACHE }}-
+            key: ${{ runner.os }}-${{ env.BAZEL_CACHE }}
         - name: Bazel Cache Repo
           uses: actions/cache@v2
           with:
             path: ${{ github.workspace }}/.${{ env.BAZEL_CACHE_REPO }}
-            key: ${{ runner.os }}-${{ env.BAZEL_CACHE_REPO }}-${{ github.sha }}
-            restore-keys: |
-              ${{ runner.os }}-${{ env.BAZEL_CACHE_REPO }}-
+            key: ${{ runner.os }}-${{ env.BAZEL_CACHE_REPO }}
         - name: Bazel Build
           uses: addnab/docker-run-action@v2
           with:


### PR DESCRIPTION
## Summary

The cache key strategy used in the origin Bazel Build cache PR generates a new cache per github.sha on the PR.  This is wasteful. I had believed the key had to be unique (judging from other repo examples, and error messages). But it seems I was wrong.

## Test Strategy

Ran build in CI and noted build-from-scratch ~28 minute execution (no cacheing behavior).

Re-ran the CI stage and observed healthy cache usage by Bazel (~5 minute exectuion).

Signed-off-by: Scott Moeller <electronjoe@gmail.com>