### PR TITLE
ci: remove docker buildx caches

### DIFF
--- a/.github/workflows/docker-push.yml
+++ b/.github/workflows/docker-push.yml
@@ -33,11 +33,6 @@ jobs:
       - name: Set up Docker Buildx
         id: buildx
         uses: docker/setup-buildx-action@v1
-      - name: Cache Docker layers
-        uses: actions/cache@v2
-        with:
-          path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-buildx-${{ hashFiles( '**/Dockerfile*' ) }}
       - name: "Login to GHCR"
         uses: docker/login-action@v1
         with:
@@ -53,12 +48,3 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=local,src=/tmp/.buildx-cache
-          cache-to: type=local,dest=/tmp/.buildx-cache-new
-      - name: Move cache - Fixup for buildx cache issue
-        # Temp fix
-        # https://github.com/docker/build-push-action/issues/252
-        # https://github.com/moby/buildkit/issues/1896
-        run: |
-          rm -rf /tmp/.buildx-cache
-          mv /tmp/.buildx-cache-new /tmp/.buildx-cache

--- a/.github/workflows/dockerfile-health.yml
+++ b/.github/workflows/dockerfile-health.yml
@@ -36,12 +36,6 @@ jobs:
         id: buildx
         uses: docker/setup-buildx-action@v1
       -
-        name: Cache Docker layers
-        uses: actions/cache@v2
-        with:
-          path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-buildx-${{ hashFiles( '**/Dockerfile*' ) }}
-      -
         name: Docker Build
         id: docker_build
         uses: docker/build-push-action@v2
@@ -79,12 +73,6 @@ jobs:
         id: buildx
         uses: docker/setup-buildx-action@v1
       -
-        name: Cache Docker layers
-        uses: actions/cache@v2
-        with:
-          path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-buildx-${{ hashFiles( '**/Dockerfile*' ) }}
-      -
         name: Docker Build
         id: docker_build
         uses: docker/build-push-action@v2
@@ -95,5 +83,3 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           outputs: type=docker,dest=/tmp/mme_builder.tar
-          cache-from: type=local,src=/tmp/.buildx-cache
-          cache-to: type=local,dest=/tmp/.buildx-cache-new


### PR DESCRIPTION
## Summary

Github cache use is limited to 5 GB and docker layer caching easily consumes that allocation, yet is not a build priority w.r.t. speed.  This PR drops the docker build caching so that limited cache space can be reserved for e.g. build tooling that runs regularly on commits (such as Bazel build cache).

Bazel limits cache use to 2.5 GB by default.

Signed-off-by: Scott Moeller <electronjoe@gmail.com>