### PR TITLE
fix(sessiond): Handling UE requested reject/release while PDU session…

### DIFF
--- a/lte/gateway/c/session_manager/SessionStateEnforcer.cpp
+++ b/lte/gateway/c/session_manager/SessionStateEnforcer.cpp
@@ -281,8 +281,8 @@ bool SessionStateEnforcer::m5g_release_session(
 void SessionStateEnforcer::m5g_start_session_termination(
     SessionMap& session_map, const std::unique_ptr<SessionState>& session,
     const uint32_t& pdu_id, SessionStateUpdateCriteria* session_uc) {
-  const auto session_id   = session->get_session_id();
-  const std::string& imsi = session->get_imsi();
+  const auto session_id     = session->get_session_id();
+  const std::string& imsi   = session->get_imsi();
   const auto previous_state = session->get_state();
 
   /* update respective session's state and return from here before timeout
@@ -302,7 +302,7 @@ void SessionStateEnforcer::m5g_start_session_termination(
      * and inform to UPF
      */
     MLOG(MDEBUG) << "Will be removing all associated rules of session id "
-               << session->get_session_id();
+                 << session->get_session_id();
     m5g_pdr_rules_change_and_update_upf(session, PdrState::REMOVE);
     if (session_map[imsi].size() == 0) {
       // delete the rules

--- a/lte/gateway/c/session_manager/SessionStateEnforcer.cpp
+++ b/lte/gateway/c/session_manager/SessionStateEnforcer.cpp
@@ -283,6 +283,7 @@ void SessionStateEnforcer::m5g_start_session_termination(
     const uint32_t& pdu_id, SessionStateUpdateCriteria* session_uc) {
   const auto session_id   = session->get_session_id();
   const std::string& imsi = session->get_imsi();
+  const auto previous_state = session->get_state();
 
   /* update respective session's state and return from here before timeout
    * to update session store with state and version
@@ -296,15 +297,17 @@ void SessionStateEnforcer::m5g_start_session_termination(
       *session, magma::lte::M5GSMCause::OPERATION_SUCCESS,
       PDU_SESSION_STATE_NOTIFY);
 
-  /* Call for all rules to be de-associated from session
-   * and inform to UPF
-   */
-  MLOG(MDEBUG) << "Will be removing all associated rules of session id "
+  if (previous_state != CREATING) {
+    /* Call for all rules to be de-associated from session
+     * and inform to UPF
+     */
+    MLOG(MDEBUG) << "Will be removing all associated rules of session id "
                << session->get_session_id();
-  m5g_pdr_rules_change_and_update_upf(session, PdrState::REMOVE);
-  if (session_map[imsi].size() == 0) {
-    // delete the rules
-    pdr_map_.erase(imsi);
+    m5g_pdr_rules_change_and_update_upf(session, PdrState::REMOVE);
+    if (session_map[imsi].size() == 0) {
+      // delete the rules
+      pdr_map_.erase(imsi);
+    }
   }
   /* Forcefully terminate session context on time out
    * time out = 5000ms from sessiond.yml config file


### PR DESCRIPTION
fix(sessiond): Handling UE requested reject/release while PDU session is in CREATING state.

## Summary
1) This is one kind of Negative scenario handling in Sesssiond
2) If UE sends a reject/release while PDU session is in CREATING state, Sessiond do not call removing rules and update UPF as rules would be created only if session moved to CREATED state.
3) Corresponding git hub issue task : #8714 


## Test Plan
Tested with stub CLI "smf_upf_integration_cli.py". If we run tc1 1st time PDU session will be in CREATING state. If we run tc1 2nd time PDU session will be moved to CREATED state.
To reproduce this issue we have to run tc1 only one time and need to run tc2 as listed below.
1) ./smf_upf_integration_cli.py amf_context set_amf_session_tc1
2) ./smf_upf_integration_cli.py amf_context set_amf_session_tc2

Current bug is listed below:
![image](https://user-images.githubusercontent.com/70899516/134552001-398c6187-bef9-4c7f-9de5-6a188c46e2bc.png)
![image](https://user-images.githubusercontent.com/70899516/134552130-9cac6d1a-a123-42cb-ad9e-c2aba80c26f5.png)

With Fix below is the log:
![image](https://user-images.githubusercontent.com/70899516/134552477-81cc3075-4a88-4178-99dc-7dff749b5e50.png)

For detailed test case steps will add comment in this PR.

## Additional Information

Signed-off-by: GANESH IRRINKI <ganesh.irrinki@wavelabs.ai>