### PR TITLE
feat(session_proxy): Merge updates into one singe CCRU for same sessi…

### DIFF
--- a/feg/gateway/services/session_proxy/servicers/credits.go
+++ b/feg/gateway/services/session_proxy/servicers/credits.go
@@ -189,8 +189,8 @@ loop:
 				metrics.GyResultCodes.WithLabelValues(strconv.FormatUint(uint64(ans.ResultCode), 10)).Inc()
 				metrics.UpdateGyRecentRequestMetrics(nil)
 				key := credit_control.GetRequestKey(credit_control.Gy, ans.SessionID, ans.RequestNumber)
-				newResponse := getSingleCreditResponseFromCCA(ans, requestMap[key])
-				responses = append(responses, newResponse)
+				newResponses := getGroupedCreditResponseFromCCA(ans, requestMap[key])
+				responses = append(responses, newResponses...)
 				// satisfied request, remove
 				delete(requestMap, key)
 			default:
@@ -253,45 +253,48 @@ func addMissingResponses(
 	return responses
 }
 
-// getSingleCreditResponseFromCCA creates a CreditUpdateResponse proto from a CCA
-func getSingleCreditResponseFromCCA(
+// getGroupedCreditResponseFromCCA creates a CreditUpdateResponse proto from a CCA
+func getGroupedCreditResponseFromCCA(
 	answer *gy.CreditControlAnswer,
 	request *gy.CreditControlRequest,
-) *protos.CreditUpdateResponse {
+) []*protos.CreditUpdateResponse {
 	success := answer.ResultCode == diameter.SuccessCode
 	imsi := credit_control.AddIMSIPrefix(request.IMSI)
 
 	if len(answer.Credits) == 0 {
-		return &protos.CreditUpdateResponse{
+		return []*protos.CreditUpdateResponse{{
 			Success:    false,
 			Sid:        imsi,
 			SessionId:  request.SessionID,
 			ResultCode: answer.ResultCode,
+		}}
+	}
+	responses := []*protos.CreditUpdateResponse{}
+	for _, receivedCredit := range answer.Credits {
+		msccSuccess := receivedCredit.ResultCode == diameter.SuccessCode || receivedCredit.ResultCode == 0 // 0: not set
+		tgppCtx := request.TgppCtx
+		if len(answer.OriginHost) > 0 {
+			if tgppCtx == nil {
+				tgppCtx = new(protos.TgppContext)
+			}
+			tgppCtx.GyDestHost = answer.OriginHost
 		}
-	}
-	receivedCredit := answer.Credits[0]
-	msccSuccess := receivedCredit.ResultCode == diameter.SuccessCode || receivedCredit.ResultCode == 0 // 0: not set
-	tgppCtx := request.TgppCtx
-	if len(answer.OriginHost) > 0 {
-		if tgppCtx == nil {
-			tgppCtx = new(protos.TgppContext)
+		res := &protos.CreditUpdateResponse{
+			Success:     success && msccSuccess,
+			SessionId:   request.SessionID,
+			Sid:         imsi,
+			ChargingKey: receivedCredit.RatingGroup,
+			Credit:      getSingleChargingCreditFromCCA(receivedCredit),
+			TgppCtx:     tgppCtx,
+			ResultCode:  receivedCredit.ResultCode, // answer.ResultCode is returned in case of general failure
 		}
-		tgppCtx.GyDestHost = answer.OriginHost
-	}
-	res := &protos.CreditUpdateResponse{
-		Success:     success && msccSuccess,
-		SessionId:   request.SessionID,
-		Sid:         imsi,
-		ChargingKey: receivedCredit.RatingGroup,
-		Credit:      getSingleChargingCreditFromCCA(receivedCredit),
-		TgppCtx:     tgppCtx,
-		ResultCode:  receivedCredit.ResultCode, //answer.ResultCode is returned in case of general failure
-	}
 
-	if receivedCredit.ServiceIdentifier != nil {
-		res.ServiceIdentifier = &protos.ServiceIdentifier{Value: *receivedCredit.ServiceIdentifier}
+		if receivedCredit.ServiceIdentifier != nil {
+			res.ServiceIdentifier = &protos.ServiceIdentifier{Value: *receivedCredit.ServiceIdentifier}
+		}
+		responses = append(responses, res)
 	}
-	return res
+	return responses
 }
 
 func getInitialCreditResponsesFromCCA(request *gy.CreditControlRequest, answer *gy.CreditControlAnswer) []*protos.CreditUpdateResponse {
@@ -338,15 +341,6 @@ func getSingleChargingCreditFromCCA(
 		chargingCredit.RestrictRules = credits.FinalUnitIndication.RestrictRules
 	}
 	return chargingCredit
-}
-
-// getUpdateRequestsFromUsage returns a slice of CCRs from usage update protos
-func getGyUpdateRequestsFromUsage(updates []*protos.CreditUsageUpdate) []*gy.CreditControlRequest {
-	requests := []*gy.CreditControlRequest{}
-	for _, update := range updates {
-		requests = append(requests, (&gy.CreditControlRequest{}).FromCreditUsageUpdate(update))
-	}
-	return requests
 }
 
 // getTerminateRequestFromUsage returns a slice of CCRs from usage update protos

--- a/feg/gateway/services/session_proxy/servicers/policy.go
+++ b/feg/gateway/services/session_proxy/servicers/policy.go
@@ -165,15 +165,6 @@ func getUsageMonitorsFromCCA_I(
 	return monitors
 }
 
-// getGxUpdateRequestsFromUsage returns a slice of CCRs from usage update protos
-func getGxUpdateRequestsFromUsage(updates []*protos.UsageMonitoringUpdateRequest) []*gx.CreditControlRequest {
-	requests := []*gx.CreditControlRequest{}
-	for _, update := range updates {
-		requests = append(requests, (&gx.CreditControlRequest{}).FromUsageMonitorUpdate(update))
-	}
-	return requests
-}
-
 // sendMultipleGxRequestsWithTimeout sends a batch of update requests to the PCRF
 // and returns a response for every request, even during timeouts.
 func (srv *CentralSessionController) sendMultipleGxRequestsWithTimeout(
@@ -233,8 +224,8 @@ loop:
 				metrics.GxResultCodes.WithLabelValues(strconv.FormatUint(uint64(ans.ResultCode), 10)).Inc()
 				metrics.UpdateGxRecentRequestMetrics(nil)
 				key := credit_control.GetRequestKey(credit_control.Gx, ans.SessionID, ans.RequestNumber)
-				newResponse := srv.getSingleUsageMonitorResponseFromCCA(ans, requestMap[key])
-				responses = append(responses, newResponse)
+				newResponses := srv.getGroupedUsageMonitorResponseFromCCA(ans, requestMap[key])
+				responses = append(responses, newResponses...)
 				// satisfied request, remove
 				delete(requestMap, key)
 			default:
@@ -298,8 +289,60 @@ func addMissingGxResponses(
 }
 
 // getSingleUsageMonitorResponseFromCCA creates a UsageMonitoringUpdateResponse proto from a CCA
-func (srv *CentralSessionController) getSingleUsageMonitorResponseFromCCA(
-	answer *gx.CreditControlAnswer, request *gx.CreditControlRequest) *protos.UsageMonitoringUpdateResponse {
+func (srv *CentralSessionController) getGroupedUsageMonitorResponseFromCCA(
+	answer *gx.CreditControlAnswer, request *gx.CreditControlRequest) []*protos.UsageMonitoringUpdateResponse {
+
+	// fix tgppCtx
+	tgppCtx := request.TgppCtx
+	if len(answer.OriginHost) > 0 {
+		if tgppCtx == nil {
+			tgppCtx = new(protos.TgppContext)
+		}
+		tgppCtx.GxDestHost = answer.OriginHost
+	}
+
+	usageInfoByCreditRes := make(map[string]*gx.UsageMonitoringInfo)
+	for _, usageInfo := range answer.UsageMonitors {
+		usageInfoByCreditRes[string(usageInfo.MonitoringKey)] = usageInfo
+	}
+
+	responses := []*protos.UsageMonitoringUpdateResponse{}
+	// check if the responses include all the monitors, otherwise cancel the specific missing monitor
+	for _, usage := range request.UsageReports {
+		// create basic response
+		newResponse := &protos.UsageMonitoringUpdateResponse{
+			Success:    answer.ResultCode == diameter.SuccessCode || answer.ResultCode == 0,
+			SessionId:  request.SessionID,
+			Sid:        credit_control.AddIMSIPrefix(request.IMSI),
+			ResultCode: answer.ResultCode,
+			TgppCtx:    request.TgppCtx,
+		}
+		// add credit Info or cancel the monitor
+		usageInfo, ok := usageInfoByCreditRes[string(usage.MonitoringKey)]
+		if !ok {
+			glog.Infof(
+				"No usage monitor response in CCA for subscriber %s in monitor %s", request.IMSI, string(usage.MonitoringKey))
+			newResponse.Credit = &protos.UsageMonitoringCredit{
+				Action:        protos.UsageMonitoringCredit_DISABLE,
+				MonitoringKey: request.UsageReports[0].MonitoringKey,
+				Level:         protos.MonitoringLevel(request.UsageReports[0].Level)}
+		} else {
+			newResponse.Credit = usageInfo.ToUsageMonitoringCredit()
+		}
+		responses = append(responses, newResponse)
+	}
+
+	// add all StaticRulesToInstall, DynamicRulesToInstall, Events on the first request
+	if len(responses) == 0 {
+		newResponse := &protos.UsageMonitoringUpdateResponse{
+			Success:    answer.ResultCode == diameter.SuccessCode || answer.ResultCode == 0,
+			SessionId:  request.SessionID,
+			Sid:        credit_control.AddIMSIPrefix(request.IMSI),
+			ResultCode: answer.ResultCode,
+			TgppCtx:    request.TgppCtx,
+		}
+		responses = append(responses, newResponse)
+	}
 
 	staticRules, dynamicRules := gx.ParseRuleInstallAVPs(
 		srv.dbClient,
@@ -309,37 +352,17 @@ func (srv *CentralSessionController) getSingleUsageMonitorResponseFromCCA(
 		srv.dbClient,
 		answer.RuleRemoveAVP,
 	)
-	tgppCtx := request.TgppCtx
-	if len(answer.OriginHost) > 0 {
-		if tgppCtx == nil {
-			tgppCtx = new(protos.TgppContext)
-		}
-		tgppCtx.GxDestHost = answer.OriginHost
-	}
-	res := &protos.UsageMonitoringUpdateResponse{
-		Success:               answer.ResultCode == diameter.SuccessCode || answer.ResultCode == 0,
-		SessionId:             request.SessionID,
-		Sid:                   credit_control.AddIMSIPrefix(request.IMSI),
-		ResultCode:            answer.ResultCode,
-		RulesToRemove:         rulesToRemove,
-		StaticRulesToInstall:  staticRules,
-		DynamicRulesToInstall: dynamicRules,
-		TgppCtx:               tgppCtx,
-	}
-	if len(answer.UsageMonitors) != 0 {
-		res.Credit = answer.UsageMonitors[0].ToUsageMonitoringCredit()
-	} else if len(request.UsageReports) != 0 {
-		glog.Infof("No usage monitor response in CCA for subscriber %s", request.IMSI)
-		res.Credit = &protos.UsageMonitoringCredit{
-			Action:        protos.UsageMonitoringCredit_DISABLE,
-			MonitoringKey: request.UsageReports[0].MonitoringKey,
-			Level:         protos.MonitoringLevel(request.UsageReports[0].Level)}
-
-	}
-
-	res.EventTriggers, res.RevalidationTime = gx.GetEventTriggersRelatedInfo(
+	eventTriggers, revalidationTime := gx.GetEventTriggersRelatedInfo(
 		answer.EventTriggers,
 		answer.RevalidationTime,
 	)
-	return res
+	firstResponse := responses[0]
+
+	firstResponse.StaticRulesToInstall = staticRules
+	firstResponse.DynamicRulesToInstall = dynamicRules
+	firstResponse.RulesToRemove = rulesToRemove
+	firstResponse.EventTriggers = eventTriggers
+	firstResponse.RevalidationTime = revalidationTime
+
+	return responses
 }

--- a/feg/gateway/services/session_proxy/servicers/session_controller.go
+++ b/feg/gateway/services/session_proxy/servicers/session_controller.go
@@ -222,7 +222,7 @@ func (srv *CentralSessionController) UpdateSession(
 		if srv.cfg.DisableGx {
 			return
 		}
-		requests := getGxUpdateRequestsFromUsage(request.UsageMonitors)
+		requests := gx.FromUsageMonitorUpdates(request.UsageMonitors)
 		gxUpdateResponses = srv.sendMultipleGxRequestsWithTimeout(requests, srv.cfg.RequestTimeout)
 		for _, mur := range gxUpdateResponses {
 			if mur != nil {
@@ -240,7 +240,7 @@ func (srv *CentralSessionController) UpdateSession(
 		if srv.cfg.DisableGy {
 			return
 		}
-		requests := getGyUpdateRequestsFromUsage(request.Updates)
+		requests := gy.FromCreditUsageUpdates(request.Updates)
 		gyUpdateResponses = srv.sendMultipleGyRequestsWithTimeout(requests, srv.cfg.RequestTimeout)
 		for _, cur := range gyUpdateResponses {
 			if cur != nil {

--- a/feg/gateway/services/session_proxy/servicers/session_controller_test.go
+++ b/feg/gateway/services/session_proxy/servicers/session_controller_test.go
@@ -202,7 +202,7 @@ func standardUsageTest(
 	ctx := context.Background()
 	mockPolicyDBClient := policyDb.(*mockPolicyDB.PolicyDBClient)
 
-	// Create a structure to store the pointers to the type assertions. his is needed later to
+	// Create a structure to store the pointers to the type assertions. This is needed later to
 	// be used on Enable/Disable. If it were not saved here the reference of the type to be
 	// asserted will be different than the reference of the type inside the srv
 	mocksGxs := make([]*mockGx.PolicyClient, 0, len(controllerParams))
@@ -378,7 +378,7 @@ func standardUsageTest(
 	// updates
 	mocksGy.On("SendCreditControlRequest", mock.Anything, mock.Anything,
 		mock.MatchedBy(getGyCCRMatcher(IMSI1_NOPREFIX, credit_control.CRTUpdate)),
-	).Return(nil).Run(returnDefaultGyResponse).Times(2)
+	).Return(nil).Run(returnDefaultGyResponse).Times(1)
 
 	updateResponse, _ := srv.UpdateSession(ctx,
 		&protos.UpdateSessionRequest{
@@ -596,7 +596,7 @@ func TestSessionControllerTimeouts(t *testing.T) {
 	).Return(nil).Run(func(args mock.Arguments) {
 		done := args.Get(1).(chan interface{})
 		request := args.Get(2).(*gy.CreditControlRequest)
-		if request.RequestNumber%2 == 0 {
+		if request.RequestNumber%1 == 0 {
 			return
 		} else {
 			done <- &gy.CreditControlAnswer{
@@ -612,11 +612,14 @@ func TestSessionControllerTimeouts(t *testing.T) {
 		}
 	}).Return(nil).Times(1)
 
+	// create a different session id update to force 2 different requests
+	modUsageUpdate := createUsageUpdate(IMSI1, 1, 2, protos.CreditUsage_TERMINATED)
+	modUsageUpdate.SessionId = fmt.Sprintf("%s-9999", IMSI1)
 	updateResponse, _ := srv.UpdateSession(ctx, &protos.UpdateSessionRequest{
 		Updates: []*protos.CreditUsageUpdate{
 			createUsageUpdate(IMSI1, 1, 1, protos.CreditUsage_QUOTA_EXHAUSTED),
-			createUsageUpdate(IMSI2, 2, 2, protos.CreditUsage_TERMINATED),
-			createUsageUpdate(IMSI1, 1, 2, protos.CreditUsage_TERMINATED),
+			createUsageUpdate(IMSI2, 2, 1, protos.CreditUsage_TERMINATED),
+			modUsageUpdate,
 		},
 	})
 	mocksGy_1.AssertExpectations(t)
@@ -764,20 +767,20 @@ func TestGxUsageMonitoring(t *testing.T) {
 	mocksGy_1.On("SendCreditControlRequest",
 		mock.Anything, mock.Anything,
 		mock.MatchedBy(getGyCCRMatcher(IMSI1_NOPREFIX, credit_control.CRTUpdate)),
-	).Return(nil).Run(returnDefaultGyResponse).Times(2)
+	).Return(nil).Run(returnDefaultGyResponse).Times(1)
 	mocksGx_1.On("SendCreditControlRequest",
 		mock.Anything, mock.Anything,
 		mock.MatchedBy(getGxCCRMatcher(IMSI1_NOPREFIX, credit_control.CRTUpdate)),
-	).Return(nil).Run(returnDefaultGxUpdateResponse).Times(2)
+	).Return(nil).Run(returnDefaultGxUpdateResponse).Times(1)
 
 	mocksGy_2.On("SendCreditControlRequest",
 		mock.Anything, mock.Anything,
 		mock.MatchedBy(getGyCCRMatcher(IMSI2_NOPREFIX, credit_control.CRTUpdate)),
-	).Return(nil).Run(returnDefaultGyResponse).Times(2)
+	).Return(nil).Run(returnDefaultGyResponse).Times(1)
 	mocksGx_2.On("SendCreditControlRequest",
 		mock.Anything, mock.Anything,
 		mock.MatchedBy(getGxCCRMatcher(IMSI2_NOPREFIX, credit_control.CRTUpdate)),
-	).Return(nil).Run(returnDefaultGxUpdateResponse).Times(2)
+	).Return(nil).Run(returnDefaultGxUpdateResponse).Times(1)
 
 	updateSessionRequest := &protos.UpdateSessionRequest{
 		Updates: []*protos.CreditUsageUpdate{
@@ -1045,20 +1048,20 @@ func TestGetHealthStatus(t *testing.T) {
 	mocksGy_1.On("SendCreditControlRequest",
 		mock.Anything, mock.Anything,
 		mock.MatchedBy(getGyCCRMatcher(IMSI1_NOPREFIX, credit_control.CRTUpdate)),
-	).Return(nil).Run(returnDefaultGyResponse).Times(2)
+	).Return(nil).Run(returnDefaultGyResponse).Times(1)
 	mocksGx_1.On("SendCreditControlRequest",
 		mock.Anything, mock.Anything,
 		mock.MatchedBy(getGxCCRMatcher(IMSI1_NOPREFIX, credit_control.CRTUpdate)),
-	).Return(nil).Run(returnDefaultGxUpdateResponse).Times(2)
+	).Return(nil).Run(returnDefaultGxUpdateResponse).Times(1)
 
 	mocksGy_2.On("SendCreditControlRequest",
 		mock.Anything, mock.Anything,
 		mock.MatchedBy(getGyCCRMatcher(IMSI2_NOPREFIX, credit_control.CRTUpdate)),
-	).Return(nil).Run(returnDefaultGyResponse).Times(2)
+	).Return(nil).Run(returnDefaultGyResponse).Times(1)
 	mocksGx_2.On("SendCreditControlRequest",
 		mock.Anything, mock.Anything,
 		mock.MatchedBy(getGxCCRMatcher(IMSI2_NOPREFIX, credit_control.CRTUpdate)),
-	).Return(nil).Run(returnDefaultGxUpdateResponse).Times(2)
+	).Return(nil).Run(returnDefaultGxUpdateResponse).Times(1)
 
 	updateResponse, err := srv.UpdateSession(ctx, &protos.UpdateSessionRequest{
 		Updates: []*protos.CreditUsageUpdate{
@@ -1090,20 +1093,20 @@ func TestGetHealthStatus(t *testing.T) {
 	mocksGy_1.On("SendCreditControlRequest",
 		mock.Anything, mock.Anything,
 		mock.MatchedBy(getGyCCRMatcher(IMSI1_NOPREFIX, credit_control.CRTUpdate)),
-	).Return(fmt.Errorf("Failed to establish new diameter connection; will retry upon first request.")).Run(returnDefaultGyResponse).Times(2)
+	).Return(fmt.Errorf("Failed to establish new diameter connection; will retry upon first request.")).Run(returnDefaultGyResponse).Times(1)
 	mocksGx_1.On("SendCreditControlRequest",
 		mock.Anything, mock.Anything,
 		mock.MatchedBy(getGxCCRMatcher(IMSI1_NOPREFIX, credit_control.CRTUpdate)),
-	).Return(fmt.Errorf("Failed to establish new diameter connection; will retry upon first request.")).Run(returnDefaultGxUpdateResponse).Times(2)
+	).Return(fmt.Errorf("Failed to establish new diameter connection; will retry upon first request.")).Run(returnDefaultGxUpdateResponse).Times(1)
 
 	mocksGy_2.On("SendCreditControlRequest",
 		mock.Anything, mock.Anything,
 		mock.MatchedBy(getGyCCRMatcher(IMSI2_NOPREFIX, credit_control.CRTUpdate)),
-	).Return(fmt.Errorf("Failed to establish new diameter connection; will retry upon first request.")).Run(returnDefaultGyResponse).Times(2)
+	).Return(fmt.Errorf("Failed to establish new diameter connection; will retry upon first request.")).Run(returnDefaultGyResponse).Times(1)
 	mocksGx_2.On("SendCreditControlRequest",
 		mock.Anything, mock.Anything,
 		mock.MatchedBy(getGxCCRMatcher(IMSI2_NOPREFIX, credit_control.CRTUpdate)),
-	).Return(fmt.Errorf("Failed to establish new diameter connection; will retry upon first request.")).Run(returnDefaultGxUpdateResponse).Times(2)
+	).Return(fmt.Errorf("Failed to establish new diameter connection; will retry upon first request.")).Run(returnDefaultGxUpdateResponse).Times(1)
 
 	updateResponse, err = srv.UpdateSession(ctx, &protos.UpdateSessionRequest{
 		Updates: []*protos.CreditUsageUpdate{


### PR DESCRIPTION
…on updates

Signed-off-by: Oriol Batalla <obatalla@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

When two updates for the same session come to FEG in the same update report they are sent in parallel. This seems to be causing some issues at some OCS that can't handle simultaneous updates on the same subscriber

This PR merges all CCR U belonging to the same session into one single update


## Test Plan

Tested on Terravm and CWAG integ test and all passed
Adding a couple of terravm test to check this out before landing
- `gxgy06b` (see below for the results)

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
