### PR TITLE
fix(agw): Update dev_utils.py to handle paginated gateways endpoint.

### DIFF
--- a/orc8r/tools/fab/dev_utils.py
+++ b/orc8r/tools/fab/dev_utils.py
@@ -213,10 +213,11 @@ def is_hw_id_registered(
         (True, gw_id) if the HWID is already registered, (False, '') otherwise
     """
     # gateways is a dict mapping gw ID to full resource
-    gateways = cloud_get(
+    paginated_gateways = cloud_get(
         f'networks/{network_id}/gateways',
         admin_cert=admin_cert,
     )
+    gateways = paginated_gateways['gateways']
     for gw in gateways.values():
         if gw['device']['hardware_id'] == hw_id:
             return True, gw['id']


### PR DESCRIPTION
Signed-off-by: mstre123 <mstre123@gmail.com>

## Summary
Update dev_utils.py to handle paginated gateways endpoint
#9278 
## Test Plan
tested locally

pretty print of paginated_gateways
```
{'gateways': {'gw4': {'description': 'Test Gateway',
                      'device': {'hardware_id': '61a357fd-35ae-4435-9b67-d78888de1455',
                                 'key': {'key_type': 'ECHO'}},
                      'id': 'gw4',
                      'magmad': {'autoupgrade_enabled': True,
                                 'autoupgrade_poll_interval': 60,
                                 'checkin_interval': 60,
                                 'checkin_timeout': 30,
                                 'dynamic_services': None},
                      'name': 'TestGateway',
                      'status': {'checkin_time': 1632509230936,
                                 'hardware_id': '61a357fd-35ae-4435-9b67-d78888de1455',
                                 'machine_info': {'cpu_info': {'architecture': 'x86_64',
                                                               'core_count': 4,
                                                               'model_name': 'Intel(R) '
                                                                             'Core(TM) '
                                                                             'i9-9980HK '
                                                                             'CPU '
                                                                             '@ '
                                                                             '2.40GHz',
                                                               'threads_per_core': 1},
                                                  'network_info': {'network_interfaces': [{'ip_addresses': ['127.0.0.1/8'],
                                                                                           'mac_address': '00:00:00:00:00:00',
                                                                                           'network_interface_id': 'lo',
                                                                                           'status': 'UP'},
                                                                                          {'ip_addresses': ['10.0.2.15/24'],
                                                                                           'mac_address': '02:a6:4d:77:e1:00',
                                                                                           'network_interface_id': 'eth0',
                                                                                           'status': 'UP'},
                                                                                          {'ip_addresses': ['192.168.60.142/24'],
                                                                                           'mac_address': '08:00:27:98:13:68',
                                                                                           'network_interface_id': 'eth1',
                                                                                           'status': 'UP'},
                                                                                          {'ip_addresses': ['192.168.129.1/24'],
                                                                                           'mac_address': '08:00:27:18:60:1e',
                                                                                           'network_interface_id': 'eth2',
                                                                                           'status': 'UP'},
                                                                                          {'mac_address': '22:72:20:3b:12:72',
                                                                                           'network_interface_id': 'proxy_port',
                                                                                           'status': 'DOWN'},
                                                                                          {'mac_address': '9a:54:11:03:52:f7',
                                                                                           'network_interface_id': 'ovs-system',
                                                                                           'status': 'DOWN'},
                                                                                          {'ip_addresses': ['192.168.128.1/24'],
                                                                                           'mac_address': 'd6:6d:77:df:e9:43',
                                                                                           'network_interface_id': 'gtp_br0',
                                                                                           'status': 'UP'},
                                                                                          {'ip_addresses': ['10.1.0.1/24'],
                                                                                           'mac_address': '8a:68:20:91:fe:75',
                                                                                           'network_interface_id': 'mtr0',
                                                                                           'status': 'UP'},
                                                                                          {'ip_addresses': ['127.0.0.10/24'],
                                                                                           'mac_address': 'ca:c0:43:0e:d1:1f',
                                                                                           'network_interface_id': 'ipfix0',
                                                                                           'status': 'UP'},
                                                                                          {'ip_addresses': ['127.1.0.0/24'],
                                                                                           'mac_address': '72:c1:db:39:fb:74',
                                                                                           'network_interface_id': 'li_port',
                                                                                           'status': 'UP'},
                                                                                          {'mac_address': '2a:dc:bf:4e:62:43',
                                                                                           'network_interface_id': 'uplink_br0',
                                                                                           'status': 'DOWN'},
                                                                                          {'mac_address': '42:bf:8f:33:a0:ad',
                                                                                           'network_interface_id': 'dhcp0',
                                                                                           'status': 'DOWN'},
                                                                                          {'ip_addresses': ['10.5.0.2/24'],
                                                                                           'mac_address': 'ce:11:2e:c3:70:65',
                                                                                           'network_interface_id': 'envoy_cntr',
                                                                                           'status': 'UP'}],
                                                                   'routing_table': [{'destination_ip': '0.0.0.0',
                                                                                      'gateway_ip': '10.0.2.2',
                                                                                      'genmask': '0.0.0.0',
                                                                                      'network_interface_id': 'eth0'},
                                                                                     {'destination_ip': '10.0.2.0',
                                                                                      'gateway_ip': '0.0.0.0',
                                                                                      'genmask': '255.255.255.0',
                                                                                      'network_interface_id': 'eth0'},
                                                                                     {'destination_ip': '10.1.0.0',
                                                                                      'gateway_ip': '0.0.0.0',
                                                                                      'genmask': '255.255.255.0',
                                                                                      'network_interface_id': 'mtr0'},
                                                                                     {'destination_ip': '10.5.0.0',
                                                                                      'gateway_ip': '0.0.0.0',
                                                                                      'genmask': '255.255.255.0',
                                                                                      'network_interface_id': 'envoy_cntr'},
                                                                                     {'destination_ip': '127.0.0.0',
                                                                                      'gateway_ip': '0.0.0.0',
                                                                                      'genmask': '255.255.255.0',
                                                                                      'network_interface_id': 'ipfix0'},
                                                                                     {'destination_ip': '127.1.0.0',
                                                                                      'gateway_ip': '0.0.0.0',
                                                                                      'genmask': '255.255.255.0',
                                                                                      'network_interface_id': 'li_port'},
                                                                                     {'destination_ip': '192.168.60.0',
                                                                                      'gateway_ip': '0.0.0.0',
                                                                                      'genmask': '255.255.255.0',
                                                                                      'network_interface_id': 'eth1'},
                                                                                     {'destination_ip': '192.168.128.0',
                                                                                      'gateway_ip': '0.0.0.0',
                                                                                      'genmask': '255.255.255.0',
                                                                                      'network_interface_id': 'gtp_br0'},
                                                                                     {'destination_ip': '192.168.129.0',
                                                                                      'gateway_ip': '0.0.0.0',
                                                                                      'genmask': '255.255.255.0',
                                                                                      'network_interface_id': 'eth2'}]}},
                                 'meta': {'enodeb_configured': '0',
                                          'enodeb_connected': '0',
                                          'enodeb_serial': 'N/A',
                                          'enodeb_state': 'N/A',
                                          'gps_connected': '0',
                                          'gps_latitude': '0.0',
                                          'gps_longitude': '0.0',
                                          'mme_connected': '0',
                                          'opstate_enabled': '0',
                                          'ptp_connected': '0',
                                          'rf_tx_desired': 'N/A',
                                          'rf_tx_on': '0'},
                                 'platform_info': {'config_info': {'mconfig_created_at': 1632509181},
                                                   'kernel_version': '5.4.0-74-generic',
                                                   'kernel_versions_installed': ['linux-image-5.4.0-73-generic',
                                                                                 'linux-image-5.4.0-74-generic',
                                                                                 'linux-image-5.4.0-86-generic',
                                                                                 'linux-image-virtual'],
                                                   'packages': [{'name': 'magma',
                                                                 'version': '0.0.0'}],
                                                   'vpn_ip': 'N/A'},
                                 'system_status': {'cpu_idle': 40098660,
                                                   'cpu_system': 814470,
                                                   'cpu_user': 1334040,
                                                   'disk_partitions': [{'device': '/dev/sda1',
                                                                        'free': 25686953984,
                                                                        'mount_point': '/',
                                                                        'total': 41567858688,
                                                                        'used': 15864127488},
                                                                       {'device': '/dev/loop0',
                                                                        'mount_point': '/snap/core18/2066',
                                                                        'total': 58195968,
                                                                        'used': 58195968},
                                                                       {'device': '/dev/loop1',
                                                                        'mount_point': '/snap/lxd/20326',
                                                                        'total': 70909952,
                                                                        'used': 70909952},
                                                                       {'device': '/dev/loop3',
                                                                        'mount_point': '/snap/snapd/12159',
                                                                        'total': 33947648,
                                                                        'used': 33947648},
                                                                       {'device': '/dev/loop4',
                                                                        'mount_point': '/snap/snapd/13170',
                                                                        'total': 33947648,
                                                                        'used': 33947648},
                                                                       {'device': '/dev/loop5',
                                                                        'mount_point': '/snap/core18/2128',
                                                                        'total': 58195968,
                                                                        'used': 58195968},
                                                                       {'device': '/dev/loop2',
                                                                        'mount_point': '/snap/core20/1081',
                                                                        'total': 64880640,
                                                                        'used': 64880640},
                                                                       {'device': '/dev/loop6',
                                                                        'mount_point': '/snap/lxd/21545',
                                                                        'total': 70516736,
                                                                        'used': 70516736}],
                                                   'mem_available': 6742646784,
                                                   'mem_free': 1486671872,
                                                   'mem_total': 8348471296,
                                                   'mem_used': 1280372736,
                                                   'swap_free': 4294426624,
                                                   'swap_total': 4294963200,
                                                   'swap_used': 536576,
                                                   'time': 1632509231,
                                                   'uptime_secs': 73808}},
                      'tier': 'default'}},
 'page_token': '',
 'total_count': 1}
```
