### PR TITLE
chore: add dependencies to bazel-base Docker so that connection track…

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -259,6 +259,7 @@ RUN cd /usr/src/googletest && \
     ldconfig -v
 
 #### libtins is required to build the connection_tracker
+# TODO(@themarwhal): this might not be hard to bazelify if we can generate the config
 RUN git clone --branch v4.3 https://github.com/mfontanini/libtins.git && \
     cd libtins && \
     mkdir build && \
@@ -267,7 +268,9 @@ RUN git clone --branch v4.3 https://github.com/mfontanini/libtins.git && \
     make -j"$(nproc)" && \
     make install && \
     cd / && \
-    rm -rf libtins
+    rm -rf libtins && \
+    # symlink to /usr/lib to match Magma VM
+    ln -s /usr/local/lib/libtins.so /usr/lib/libtins.so
 
 ###### Install Include What You Use for c/cpp header include fixup tooling
 # Tag 0.15 tracks Clang 11.0 per https://github.com/include-what-you-use/include-what-you-use/tags

--- a/experimental/bazel-base/Dockerfile
+++ b/experimental/bazel-base/Dockerfile
@@ -64,5 +64,22 @@ RUN git clone https://github.com/facebook/folly && cd folly && \
     cd / && \
     rm -rf folly
 
+#### libtins is required to build the connection_tracker
+RUN apt-get install -y --no-install-recommends \
+    libpcap-dev \
+    libmnl-dev
+
+# TODO(@themarwhal): this might not be hard to bazelify if we can generate the config
+RUN git clone --branch v4.3 https://github.com/mfontanini/libtins.git && \
+    cd libtins && \
+    mkdir build && \
+    cd build && \
+    cmake ../ -DLIBTINS_ENABLE_CXX11=1 && \
+    make -j"$(nproc)" && \
+    make install && \
+    cd / && \
+    rm -rf libtins && \
+    # symlink to /usr/lib to match Magma VM
+    ln -s /usr/local/lib/libtins.so /usr/lib/libtins.so
 
 WORKDIR /magma

--- a/third_party/system_libraries.BUILD
+++ b/third_party/system_libraries.BUILD
@@ -46,7 +46,7 @@ cc_library(
 
 cc_library(
     name = "libtins",
-    srcs = ["usr/local/lib/libtins.so"],
+    srcs = ["usr/lib/libtins.so"],
     linkopts = ["-ltins"],
 )
 


### PR DESCRIPTION
…er can be built

Signed-off-by: Marie Bremner <marwhal@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary
Change up the docker containers so that the libtins.so file is available at the same place as the magma VM.
<!-- Enumerate changes you made and why you made them -->

## Test Plan

- [x] bazel test in VM
- [x] bazel test in devcontainer
- [x] bazel test in bazel-base docker

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
