### PR TITLE
chore: remove all unit tests that are covered outside of the lte-inte…

### DIFF
--- a/lte/gateway/Makefile
+++ b/lte/gateway/Makefile
@@ -204,6 +204,9 @@ scan_oai: ## Scan OAI
 test_python: stop ## Run all Python-specific tests
 	make -C $(MAGMA_ROOT)/lte/gateway/python test_all
 
+test_sudo_python: stop ## Run Python tests that require sudo (datapath, etc.)
+	make -C $(MAGMA_ROOT)/lte/gateway/python test_all SKIP_NON_SUDO_TESTS=1
+
 test_oai: ## Run all OAI-specific tests
 	$(call run_ctest, $(C_BUILD)/core, $(C_BUILD)/core/oai, $(GATEWAY_C_DIR)/core, $(OAI_FLAGS) $(OAI_TEST_FLAGS))
 

--- a/lte/gateway/fabfile.py
+++ b/lte/gateway/fabfile.py
@@ -253,8 +253,7 @@ def integ_test(
 
     execute(_dist_upgrade)
     execute(_build_magma)
-    execute(_run_unit_tests)
-    execute(_python_coverage)
+    execute(_run_sudo_python_unit_tests)
     execute(_start_gateway)
 
     # Run suite of integ tests that are required to be run on the access gateway
@@ -288,7 +287,6 @@ def integ_test(
         setup_env_vagrant()
     else:
         env.hosts = [gateway_host]
-    execute(_oai_coverage)
 
 
 def run_integ_tests(tests=None):
@@ -497,16 +495,11 @@ def _oai_coverage():
         run('make coverage_oai')
 
 
-def _run_unit_tests():
+def _run_sudo_python_unit_tests():
     """ Run the magma unit tests """
     with cd(AGW_ROOT):
-        # Run the unit tests
-        run('make test')
-
-
-def _python_coverage():
-    with cd(AGW_PYTHON_ROOT):
-        run('make coverage')
+        # Run all unit tests that are not run as pre-commit checks in CI
+        run('make test_sudo_python')
 
 
 def _start_gateway():
@@ -514,12 +507,6 @@ def _start_gateway():
 
     with cd(AGW_ROOT):
         run('make run')
-
-
-def _run_local_integ_tests():
-    """ Execute integ tests that run on magma access gateway """
-    with cd(AGW_INTEG_ROOT):
-        run('make local_integ_test')
 
 
 def _set_service_config_var(service, var_name, value):

--- a/orc8r/gateway/python/python.mk
+++ b/orc8r/gateway/python/python.mk
@@ -121,8 +121,10 @@ CODECOV_DIR := /var/tmp/codecovs
 
 .tests:
 ifdef TESTS
+ifndef SKIP_NON_SUDO_TESTS
 	$(eval NAME ?= $(shell $(BIN)/python setup.py --name))
 	. $(PYTHON_BUILD)/bin/activate; $(BIN)/nosetests --with-xunit --xunit-file=$(RESULTS_DIR)/tests_$(NAME).xml --with-coverage --cover-erase --cover-branches --cover-package=magma --cover-xml --cover-xml-file=$(CODECOV_DIR)/cover_$(NAME).xml -s $(TESTS)
+endif
 endif
 
 .sudo_tests:


### PR DESCRIPTION
…g-test job

Signed-off-by: Marie Bremner <marwhal@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary
Can be up for discussion.

This PR adds a new make command to run ONLY the python unit tests marked as SUDO. These are the only unit tests that are currently not run on PRs as a pre-commit check.

I've modified the fabfile used to run lte-integ-test to run only the SUDO python unit tests instead of running all existing unit tests. (C/C++ included.) 
This will remove the following unit tests from being executed as part of lte-integ-test:

This might only cut down run time by only ~10 minutes, but these set of tests contain a few flaky tests that can fail the job.

1. sessiond unit tests (has flaky tests) (Couldn't find a job but sessiond_integ_test is flaky and occasionally fails on this job)
2. mme unit tests (has flaky tests) [CI job that failed at TestGutiAttachEpsOnlyDetach](https://circleci.com/api/v1.1/project/github/magma/magma/391178/output/111/0?file=true&allocation-id=614dd76ca4fb1456f3103a55-0-build%2F83B6D08)
3. orc8r/gateway/c/common unit tests (not flaky)
4. sctpd unit tests (not flaky)
5. li agent unit tests (not flaky)
6. non SUDO python unit tests [CI job that failed at test_ipv6_flows](https://app.circleci.com/pipelines/github/magma/magma/33527/workflows/b00d3bb8-e8e3-4ce4-8d35-add8e7992ab7/jobs/390989)


I also removed the job that generates coverage information from this job. (Could add it back if there are objections.) We don't seem to use this information anyways, and the job is currently at 3hrs so it doesn't seem like we'll be losing out too much.

## Test Plan

Ended up being about 30 min shorter.
<img width="1544" alt="Screen Shot 2021-09-24 at 8 44 12 PM" src="https://user-images.githubusercontent.com/37634144/134752130-6187cb46-4e0e-4107-97c1-d512232bbcab.png">



Will run this in CircleCI to test it out. (https://app.circleci.com/pipelines/github/magma/magma/33579/workflows/77067657-0ae9-48c4-960c-f57f47d53a93/jobs/391478)
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
