### PR TITLE
chore(orc8r): Update usages of deprecated x/net/context package

### DIFF
--- a/cwf/cloud/go/go.mod
+++ b/cwf/cloud/go/go.mod
@@ -33,7 +33,6 @@ require (
 	github.com/prometheus/client_golang v1.5.1
 	github.com/prometheus/common v0.9.1
 	github.com/stretchr/testify v1.6.1
-	golang.org/x/net v0.0.0-20201031054903-ff519b6c9102
 	google.golang.org/grpc v1.31.0
 	magma/feg/cloud/go v0.0.0
 	magma/feg/cloud/go/protos v0.0.0

--- a/cwf/cloud/go/services/cwf/obsidian/handlers/handlers_test.go
+++ b/cwf/cloud/go/services/cwf/obsidian/handlers/handlers_test.go
@@ -14,7 +14,7 @@
 package handlers_test
 
 import (
-	context2 "context"
+	"context"
 	"testing"
 	"time"
 
@@ -22,7 +22,6 @@ import (
 	"github.com/go-openapi/swag"
 	"github.com/labstack/echo"
 	"github.com/stretchr/testify/assert"
-	"golang.org/x/net/context"
 
 	"magma/cwf/cloud/go/cwf"
 	"magma/cwf/cloud/go/serdes"
@@ -182,7 +181,7 @@ func TestCwfNetworks(t *testing.T) {
 	}
 	tests.RunUnitTest(t, e, tc)
 
-	actualN1, err := configurator.LoadNetwork(context2.Background(), "n1", true, true, serdes.Network)
+	actualN1, err := configurator.LoadNetwork(context.Background(), "n1", true, true, serdes.Network)
 	assert.NoError(t, err)
 	expected := configurator.Network{
 		ID:          "n1",
@@ -829,7 +828,7 @@ func TestCwfHaPairs(t *testing.T) {
 // n1, n3 are cwf networks, n2, n5 are not
 func seedCwfNetworks(t *testing.T) {
 	fegNetworkID := "n5"
-	_, err := configurator.CreateNetworks(context2.Background(), []configurator.Network{
+	_, err := configurator.CreateNetworks(context.Background(), []configurator.Network{
 		{
 			ID:          fegNetworkID,
 			Type:        feg.FederationNetworkType,
@@ -843,7 +842,7 @@ func seedCwfNetworks(t *testing.T) {
 		},
 	}, serdes.Network)
 	assert.NoError(t, err)
-	_, err = configurator.CreateNetworks(context2.Background(), []configurator.Network{
+	_, err = configurator.CreateNetworks(context.Background(), []configurator.Network{
 		{
 			ID:          "n1",
 			Type:        cwf.CwfNetworkType,
@@ -985,7 +984,7 @@ func seedCwfGateway(t *testing.T, id string, hwId string) {
 
 func seedCwfTier(t *testing.T, networkID string) {
 	// setup fixtures in backend
-	_, err := configurator.CreateEntities(context2.Background(), networkID, []configurator.NetworkEntity{
+	_, err := configurator.CreateEntities(context.Background(), networkID, []configurator.NetworkEntity{
 		{Type: orc8r.UpgradeTierEntityType, Key: "t1"},
 	}, serdes.Entity)
 	assert.NoError(t, err)

--- a/cwf/gateway/go.sum
+++ b/cwf/gateway/go.sum
@@ -934,6 +934,7 @@ github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77 h1:ESFSdwY
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=
 github.com/yuin/goldmark v1.2.1 h1:ruQGxdhGHe7FWOJPT0mKs5+pD2Xs1Bm/kdGlHO04FmM=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
+github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
 github.com/yuin/gopher-lua v0.0.0-20190514113301-1cd887cd7036/go.mod h1:gqRgreBUhTSL0GeU64rtZ3Uq3wtjOa/TB2YfrtkCbVQ=
 github.com/yuin/gopher-lua v0.0.0-20200816102855-ee81675732da h1:NimzV1aGyq29m5ukMK0AMWEhFaL/lrEOaephfuoiARg=
 github.com/yuin/gopher-lua v0.0.0-20200816102855-ee81675732da/go.mod h1:E1AXubJBdNmFERAOucpDIxNzeGfLzg0mYh+UfMWdChA=
@@ -1002,6 +1003,7 @@ golang.org/x/mod v0.1.1-0.20191105210325-c90efee705ee/go.mod h1:QqPTAvyqsEbceGzB
 golang.org/x/mod v0.3.0 h1:RM4zey1++hCTbCVQfnWeKs9/IEsaBLA8vTkd0WVtmH4=
 golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.4.2 h1:Gz96sIWK3OalVv/I/qNygP42zyoKp3xptRVCWRFEBvo=
+golang.org/x/mod v0.4.2/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/net v0.0.0-20170114055629-f2499483f923/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180826012351-8a410e7b638d/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
@@ -1034,6 +1036,7 @@ golang.org/x/net v0.0.0-20200625001655-4c5254603344/go.mod h1:/O7V0waA8r7cgGh81R
 golang.org/x/net v0.0.0-20201021035429-f5854403a974/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/net v0.0.0-20201031054903-ff519b6c9102/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
+golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4/go.mod h1:p54w0d4576C0XHj96bSt6lcn1PtDYWL6XObtHCRCNQM=
 golang.org/x/net v0.0.0-20210501142056-aec3718b3fa0 h1:6QqBc2UURz4Sbr4IE15uXM8CTQlHnRdtKuogDhwnu2Y=
 golang.org/x/net v0.0.0-20210501142056-aec3718b3fa0/go.mod h1:OJAsFXCWl8Ukc7SiCT/9KSuxbyM7479/AVlXFRxuMCk=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
@@ -1050,6 +1053,7 @@ golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201207232520-09787c993a3a h1:DcqTD9SDLc+1P/r1EmRBwnVsrOwW+kk2vWf9n+1sGhs=
 golang.org/x/sync v0.0.0-20201207232520-09787c993a3a/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20210220032951-036812b2e83c/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20170830134202-bb24a47a89ea/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180823144017-11551d06cbcc/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
@@ -1097,9 +1101,11 @@ golang.org/x/sys v0.0.0-20210119212857-b64e53b001e4/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210124154548-22da62e12c0c/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210217105451-b926d437f341/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210309074719-68d13333faf2/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210330210617-4fbd30eecc44/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210426080607-c94f62235c83 h1:kHSDPqCtsHZOg0nVylfTo20DDhE9gG4Y0jn7hKQ0QAM=
 golang.org/x/sys v0.0.0-20210426080607-c94f62235c83/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210510120138-977fb7262007/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210603081109-ebe580a85c40/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1 h1:SrN+KX8Art/Sf4HNj6Zcz06G7VEz+7w9tdXTPOZ7+l4=
 golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
@@ -1147,6 +1153,7 @@ golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtn
 golang.org/x/tools v0.0.0-20200103221440-774c71fcf114/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
 golang.org/x/tools v0.1.0 h1:po9/4sTYwZU9lPhi1tOrb4hCv3qrhiQ77LZfGa2OjwY=
 golang.org/x/tools v0.1.0/go.mod h1:xkSsbof2nBLbhDlRMhhhyNLN/zl3eTqcnHD5viDpcZ0=
+golang.org/x/tools v0.1.5/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/cwf/gateway/integ_tests/hssless_test.go
+++ b/cwf/gateway/integ_tests/hssless_test.go
@@ -28,8 +28,8 @@ import (
 
 	"magma/cwf/gateway/services/uesim/servicers"
 
+	"context"
 	"github.com/stretchr/testify/assert"
-	"golang.org/x/net/context"
 )
 
 const (

--- a/cwf/gateway/services/uesim/servicers/uesim.go
+++ b/cwf/gateway/services/uesim/servicers/uesim.go
@@ -28,9 +28,9 @@ import (
 	"magma/orc8r/cloud/go/storage"
 	"magma/orc8r/lib/go/protos"
 
+	"context"
 	"github.com/golang/glog"
 	"github.com/pkg/errors"
-	"golang.org/x/net/context"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )

--- a/cwf/gateway/services/uesim/servicers/uesim_hssless.go
+++ b/cwf/gateway/services/uesim/servicers/uesim_hssless.go
@@ -21,8 +21,8 @@ import (
 	"magma/orc8r/lib/go/protos"
 	"strings"
 
+	"context"
 	"github.com/golang/glog"
-	"golang.org/x/net/context"
 )
 
 const (

--- a/fbinternal/cloud/go/services/testcontroller/obsidian/handlers/node_handlers_test.go
+++ b/fbinternal/cloud/go/services/testcontroller/obsidian/handlers/node_handlers_test.go
@@ -14,7 +14,7 @@
 package handlers_test
 
 import (
-	context2 "context"
+	"context"
 	"testing"
 	"time"
 
@@ -55,9 +55,9 @@ func Test_ListCINodes(t *testing.T) {
 	tests.RunUnitTest(t, e, tc)
 
 	// Happy path
-	err := testcontroller.CreateOrUpdateNode(context2.Background(), &storage.MutableCINode{Id: "node1", Tag: "foo", VpnIP: "192.168.100.1"})
+	err := testcontroller.CreateOrUpdateNode(context.Background(), &storage.MutableCINode{Id: "node1", Tag: "foo", VpnIP: "192.168.100.1"})
 	assert.NoError(t, err)
-	err = testcontroller.CreateOrUpdateNode(context2.Background(), &storage.MutableCINode{Id: "node2", VpnIP: "10.0.2.1"})
+	err = testcontroller.CreateOrUpdateNode(context.Background(), &storage.MutableCINode{Id: "node2", VpnIP: "10.0.2.1"})
 	assert.NoError(t, err)
 	tc.ExpectedResult = tests.JSONMarshaler([]*models.CiNode{
 		{
@@ -124,7 +124,7 @@ func Test_GetCINode(t *testing.T) {
 	tests.RunUnitTest(t, e, tc)
 
 	// Happy path
-	err := testcontroller.CreateOrUpdateNode(context2.Background(), &storage.MutableCINode{Id: "node1", VpnIP: "192.168.100.1"})
+	err := testcontroller.CreateOrUpdateNode(context.Background(), &storage.MutableCINode{Id: "node1", VpnIP: "192.168.100.1"})
 	assert.NoError(t, err)
 	tc = tests.Test{
 		Method:         "GET",
@@ -179,7 +179,7 @@ func Test_CreateCINode(t *testing.T) {
 	}
 	tests.RunUnitTest(t, e, tc)
 
-	actual, err := testcontroller.GetNodes(context2.Background(), nil, nil)
+	actual, err := testcontroller.GetNodes(context.Background(), nil, nil)
 	assert.NoError(t, err)
 	expected := map[string]*storage.CINode{
 		"node1": {
@@ -223,7 +223,7 @@ func Test_UpdateCINode(t *testing.T) {
 	}
 	tests.RunUnitTest(t, e, tc)
 
-	actual, err := testcontroller.GetNodes(context2.Background(), nil, nil)
+	actual, err := testcontroller.GetNodes(context.Background(), nil, nil)
 	assert.NoError(t, err)
 	expected := map[string]*storage.CINode{
 		"node1": {
@@ -241,7 +241,7 @@ func Test_UpdateCINode(t *testing.T) {
 		VpnIP: ipv4("192.168.100.1"),
 	}
 	tests.RunUnitTest(t, e, tc)
-	actual, err = testcontroller.GetNodes(context2.Background(), nil, nil)
+	actual, err = testcontroller.GetNodes(context.Background(), nil, nil)
 	assert.NoError(t, err)
 	expected["node1"].VpnIp = "192.168.100.1"
 	assert.Equal(t, expected, actual)
@@ -254,7 +254,7 @@ func Test_UpdateCINode(t *testing.T) {
 	tc.ExpectedStatus = 400
 	tc.ExpectedError = "payload ID does not match path param"
 	tests.RunUnitTest(t, e, tc)
-	actual, err = testcontroller.GetNodes(context2.Background(), nil, nil)
+	actual, err = testcontroller.GetNodes(context.Background(), nil, nil)
 	assert.NoError(t, err)
 	assert.Equal(t, expected, actual)
 }
@@ -280,10 +280,10 @@ func Test_DeleteCINode(t *testing.T) {
 	tests.RunUnitTest(t, e, tc)
 
 	// Happy path
-	err := testcontroller.CreateOrUpdateNode(context2.Background(), &storage.MutableCINode{Id: "node1", VpnIP: "10.0.2.1"})
+	err := testcontroller.CreateOrUpdateNode(context.Background(), &storage.MutableCINode{Id: "node1", VpnIP: "10.0.2.1"})
 	assert.NoError(t, err)
 	tests.RunUnitTest(t, e, tc)
-	actual, err := testcontroller.GetNodes(context2.Background(), nil, nil)
+	actual, err := testcontroller.GetNodes(context.Background(), nil, nil)
 	assert.NoError(t, err)
 	assert.Empty(t, actual)
 }
@@ -312,9 +312,9 @@ func Test_ReserveCINode(t *testing.T) {
 	tests.RunUnitTest(t, e, tc)
 
 	// Happy path
-	err := testcontroller.CreateOrUpdateNode(context2.Background(), &storage.MutableCINode{Id: "node1", VpnIP: "192.168.100.1"})
+	err := testcontroller.CreateOrUpdateNode(context.Background(), &storage.MutableCINode{Id: "node1", VpnIP: "192.168.100.1"})
 	assert.NoError(t, err)
-	err = testcontroller.CreateOrUpdateNode(context2.Background(), &storage.MutableCINode{Id: "node2", Tag: "foo", VpnIP: "10.0.0.2"})
+	err = testcontroller.CreateOrUpdateNode(context.Background(), &storage.MutableCINode{Id: "node2", Tag: "foo", VpnIP: "10.0.0.2"})
 	assert.NoError(t, err)
 	tc = tests.Test{
 		Method:         "POST",
@@ -328,7 +328,7 @@ func Test_ReserveCINode(t *testing.T) {
 		},
 	}
 	tests.RunUnitTest(t, e, tc)
-	actual, err := testcontroller.GetNodes(context2.Background(), nil, strPtr(""))
+	actual, err := testcontroller.GetNodes(context.Background(), nil, strPtr(""))
 	assert.NoError(t, err)
 	expected := map[string]*storage.CINode{
 		"node1": {
@@ -365,7 +365,7 @@ func Test_ReserveCINode(t *testing.T) {
 		},
 	}
 	tests.RunUnitTest(t, e, tc)
-	actual, err = testcontroller.GetNodes(context2.Background(), nil, strPtr(""))
+	actual, err = testcontroller.GetNodes(context.Background(), nil, strPtr(""))
 	assert.NoError(t, err)
 	expected = map[string]*storage.CINode{
 		"node1": {
@@ -390,7 +390,7 @@ func Test_ReserveCINode(t *testing.T) {
 		},
 	}
 	tests.RunUnitTest(t, e, tc)
-	actual, err = testcontroller.GetNodes(context2.Background(), nil, nil)
+	actual, err = testcontroller.GetNodes(context.Background(), nil, nil)
 	assert.NoError(t, err)
 	expected = map[string]*storage.CINode{
 		"node1": {
@@ -436,7 +436,7 @@ func Test_ReserveSpecificCINode(t *testing.T) {
 	tests.RunUnitTest(t, e, tc)
 
 	// Happy path
-	err := testcontroller.CreateOrUpdateNode(context2.Background(), &storage.MutableCINode{Id: "node1", VpnIP: "192.168.100.1"})
+	err := testcontroller.CreateOrUpdateNode(context.Background(), &storage.MutableCINode{Id: "node1", VpnIP: "192.168.100.1"})
 	assert.NoError(t, err)
 	tc = tests.Test{
 		Method:         "POST",
@@ -452,7 +452,7 @@ func Test_ReserveSpecificCINode(t *testing.T) {
 		},
 	}
 	tests.RunUnitTest(t, e, tc)
-	actual, err := testcontroller.GetNodes(context2.Background(), nil, nil)
+	actual, err := testcontroller.GetNodes(context.Background(), nil, nil)
 	assert.NoError(t, err)
 	expected := map[string]*storage.CINode{
 		"node1": {
@@ -507,9 +507,9 @@ func Test_ReleaseCINode(t *testing.T) {
 	tests.RunUnitTest(t, e, tc)
 
 	// Happy path
-	err := testcontroller.CreateOrUpdateNode(context2.Background(), &storage.MutableCINode{Id: "node1", VpnIP: "192.168.100.1"})
+	err := testcontroller.CreateOrUpdateNode(context.Background(), &storage.MutableCINode{Id: "node1", VpnIP: "192.168.100.1"})
 	assert.NoError(t, err)
-	actualLease, err := testcontroller.LeaseNode(context2.Background(), "")
+	actualLease, err := testcontroller.LeaseNode(context.Background(), "")
 	assert.NoError(t, err)
 	expectedLease := &storage.NodeLease{Id: "node1", VpnIP: "192.168.100.1", LeaseID: "1"}
 	assert.Equal(t, expectedLease, actualLease)
@@ -523,7 +523,7 @@ func Test_ReleaseCINode(t *testing.T) {
 	}
 	tests.RunUnitTest(t, e, tc)
 
-	actual, err := testcontroller.GetNodes(context2.Background(), nil, nil)
+	actual, err := testcontroller.GetNodes(context.Background(), nil, nil)
 	assert.NoError(t, err)
 	expected := map[string]*storage.CINode{
 		"node1": {

--- a/fbinternal/cloud/go/services/testcontroller/obsidian/handlers/testcontroller_handlers_test.go
+++ b/fbinternal/cloud/go/services/testcontroller/obsidian/handlers/testcontroller_handlers_test.go
@@ -14,7 +14,7 @@
 package handlers_test
 
 import (
-	context2 "context"
+	"context"
 	"testing"
 
 	"github.com/go-openapi/swag"
@@ -53,11 +53,11 @@ func Test_ListTestCases(t *testing.T) {
 	tests.RunUnitTest(t, e, tc)
 
 	// Happy path
-	err := testcontroller.CreateOrUpdateTestCase(context2.Background(), 1, testcontroller.EnodedTestCaseType, defaultEnodebdTestConfig(), serdes.TestController)
+	err := testcontroller.CreateOrUpdateTestCase(context.Background(), 1, testcontroller.EnodedTestCaseType, defaultEnodebdTestConfig(), serdes.TestController)
 	assert.NoError(t, err)
-	err = testcontroller.CreateOrUpdateTestCase(context2.Background(), 2, testcontroller.EnodedTestCaseType, defaultEnodebdTestConfig(), serdes.TestController)
+	err = testcontroller.CreateOrUpdateTestCase(context.Background(), 2, testcontroller.EnodedTestCaseType, defaultEnodebdTestConfig(), serdes.TestController)
 	assert.NoError(t, err)
-	err = testcontroller.CreateOrUpdateTestCase(context2.Background(), 3, testcontroller.EnodedTestExcludeTraffic, enodebdNoTrafficTestConfig(), serdes.TestController)
+	err = testcontroller.CreateOrUpdateTestCase(context.Background(), 3, testcontroller.EnodedTestExcludeTraffic, enodebdNoTrafficTestConfig(), serdes.TestController)
 	assert.NoError(t, err)
 
 	tc.ExpectedResult = tests.JSONMarshaler([]*models.E2eTestCase{
@@ -118,9 +118,9 @@ func Test_ListEnodebdTestCases(t *testing.T) {
 	tests.RunUnitTest(t, e, tc)
 
 	// Happy path
-	err := testcontroller.CreateOrUpdateTestCase(context2.Background(), 1, testcontroller.EnodedTestCaseType, defaultEnodebdTestConfig(), serdes.TestController)
+	err := testcontroller.CreateOrUpdateTestCase(context.Background(), 1, testcontroller.EnodedTestCaseType, defaultEnodebdTestConfig(), serdes.TestController)
 	assert.NoError(t, err)
-	err = testcontroller.CreateOrUpdateTestCase(context2.Background(), 2, testcontroller.EnodedTestCaseType, defaultEnodebdTestConfig(), serdes.TestController)
+	err = testcontroller.CreateOrUpdateTestCase(context.Background(), 2, testcontroller.EnodedTestCaseType, defaultEnodebdTestConfig(), serdes.TestController)
 	assert.NoError(t, err)
 	tc.ExpectedResult = tests.JSONMarshaler([]*models.EnodebdE2eTest{
 		{
@@ -168,7 +168,7 @@ func Test_CreateEnodebdTestCase(t *testing.T) {
 	}
 	tests.RunUnitTest(t, e, tc)
 
-	actual, err := testcontroller.GetTestCases(context2.Background(), nil, serdes.TestController)
+	actual, err := testcontroller.GetTestCases(context.Background(), nil, serdes.TestController)
 	assert.NoError(t, err)
 	expected := map[int64]*testcontroller.UnmarshalledTestCase{
 		1: {
@@ -221,7 +221,7 @@ func Test_GetEnodebdTestCase(t *testing.T) {
 	tests.RunUnitTest(t, e, tc)
 
 	// Happy path
-	err := testcontroller.CreateOrUpdateTestCase(context2.Background(), 1, testcontroller.EnodedTestCaseType, defaultEnodebdTestConfig(), serdes.TestController)
+	err := testcontroller.CreateOrUpdateTestCase(context.Background(), 1, testcontroller.EnodedTestCaseType, defaultEnodebdTestConfig(), serdes.TestController)
 	assert.NoError(t, err)
 	tc = tests.Test{
 		Method:         "GET",
@@ -253,7 +253,7 @@ func Test_UpdateEnodebdTestCase(t *testing.T) {
 	oHands := handlers.GetObsidianHandlers()
 	updateTest := tests.GetHandlerByPathAndMethod(t, oHands, testURLRoot+"/:test_pk", obsidian.PUT).HandlerFunc
 
-	err := testcontroller.CreateOrUpdateTestCase(context2.Background(), 1, testcontroller.EnodedTestCaseType, defaultEnodebdTestConfig(), serdes.TestController)
+	err := testcontroller.CreateOrUpdateTestCase(context.Background(), 1, testcontroller.EnodedTestCaseType, defaultEnodebdTestConfig(), serdes.TestController)
 	assert.NoError(t, err)
 
 	newCfg := defaultEnodebdTestConfig()
@@ -270,7 +270,7 @@ func Test_UpdateEnodebdTestCase(t *testing.T) {
 	}
 	tests.RunUnitTest(t, e, tc)
 
-	actual, err := testcontroller.GetTestCases(context2.Background(), nil, serdes.TestController)
+	actual, err := testcontroller.GetTestCases(context.Background(), nil, serdes.TestController)
 	assert.NoError(t, err)
 	expected := map[int64]*testcontroller.UnmarshalledTestCase{
 		1: {
@@ -298,7 +298,7 @@ func Test_DeleteEnodebdTestCase(t *testing.T) {
 	oHands := handlers.GetObsidianHandlers()
 	deleteTest := tests.GetHandlerByPathAndMethod(t, oHands, testURLRoot+"/:test_pk", obsidian.DELETE).HandlerFunc
 
-	err := testcontroller.CreateOrUpdateTestCase(context2.Background(), 1, testcontroller.EnodedTestCaseType, defaultEnodebdTestConfig(), serdes.TestController)
+	err := testcontroller.CreateOrUpdateTestCase(context.Background(), 1, testcontroller.EnodedTestCaseType, defaultEnodebdTestConfig(), serdes.TestController)
 	assert.NoError(t, err)
 
 	tc := tests.Test{
@@ -310,7 +310,7 @@ func Test_DeleteEnodebdTestCase(t *testing.T) {
 		ExpectedStatus: 204,
 	}
 	tests.RunUnitTest(t, e, tc)
-	actual, err := testcontroller.GetTestCases(context2.Background(), nil, serdes.TestController)
+	actual, err := testcontroller.GetTestCases(context.Background(), nil, serdes.TestController)
 	assert.NoError(t, err)
 	assert.Empty(t, actual)
 }

--- a/fbinternal/cloud/go/services/vpnservice/client_api.go
+++ b/fbinternal/cloud/go/services/vpnservice/client_api.go
@@ -1,8 +1,9 @@
 package vpnservice
 
 import (
+	"context"
+
 	"github.com/golang/glog"
-	"golang.org/x/net/context"
 
 	fbprotos "magma/fbinternal/cloud/go/protos"
 	"magma/orc8r/lib/go/errors"

--- a/fbinternal/cloud/go/services/vpnservice/servicers/vpn_servicer.go
+++ b/fbinternal/cloud/go/services/vpnservice/servicers/vpn_servicer.go
@@ -1,12 +1,12 @@
 package servicers
 
 import (
+	"context"
 	"fmt"
 	"io/ioutil"
 	"time"
 
 	"github.com/golang/protobuf/ptypes/duration"
-	"golang.org/x/net/context"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 

--- a/fbinternal/cloud/go/services/vpnservice/servicers/vpn_servicer_test.go
+++ b/fbinternal/cloud/go/services/vpnservice/servicers/vpn_servicer_test.go
@@ -1,6 +1,7 @@
 package servicers_test
 
 import (
+	"context"
 	"crypto/rand"
 	"crypto/x509"
 	"crypto/x509/pkix"
@@ -12,7 +13,6 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
-	"golang.org/x/net/context"
 
 	fbprotos "magma/fbinternal/cloud/go/protos"
 	"magma/fbinternal/cloud/go/services/vpnservice/servicers"

--- a/feg/cloud/go/go.mod
+++ b/feg/cloud/go/go.mod
@@ -33,7 +33,6 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.5.1
 	github.com/stretchr/testify v1.6.1
-	golang.org/x/net v0.0.0-20201031054903-ff519b6c9102
 	google.golang.org/grpc v1.31.0
 	magma/feg/cloud/go/protos v0.0.0
 	magma/lte/cloud/go v0.0.0

--- a/feg/cloud/go/services/health/servicers/health.go
+++ b/feg/cloud/go/services/health/servicers/health.go
@@ -14,11 +14,11 @@ limitations under the License.
 package servicers
 
 import (
+	"context"
 	"fmt"
 	"time"
 
 	"github.com/golang/glog"
-	"golang.org/x/net/context"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 

--- a/feg/cloud/go/services/health/servicers/health_test_service.go
+++ b/feg/cloud/go/services/health/servicers/health_test_service.go
@@ -14,7 +14,7 @@ limitations under the License.
 package servicers
 
 import (
-	"golang.org/x/net/context"
+	"context"
 
 	fegprotos "magma/feg/cloud/go/protos"
 	"magma/feg/cloud/go/services/health/storage"

--- a/feg/cloud/go/services/health/test_utils/test_utils.go
+++ b/feg/cloud/go/services/health/test_utils/test_utils.go
@@ -16,7 +16,7 @@ limitations under the License.
 package test_utils
 
 import (
-	context2 "context"
+	"context"
 	"testing"
 	"time"
 
@@ -102,7 +102,7 @@ func GetUnhealthyRequest() *protos.HealthRequest {
 }
 
 func RegisterNetwork(t *testing.T, networkID string) {
-	err := configurator.CreateNetwork(context2.Background(), configurator.Network{
+	err := configurator.CreateNetwork(context.Background(), configurator.Network{
 		ID:   TestFegNetwork,
 		Type: feg.FegNetworkType,
 	}, serdes.Network)

--- a/feg/cloud/go/tools/health_cli/main.go
+++ b/feg/cloud/go/tools/health_cli/main.go
@@ -14,7 +14,7 @@ limitations under the License.
 package main
 
 import (
-	context2 "context"
+	"context"
 	"flag"
 	"fmt"
 	"os"
@@ -78,7 +78,7 @@ func handleCommands(cmd string) error {
 }
 
 func getHealth(networkID string, gatewayID string) error {
-	healthStats, err := health.GetHealth(context2.Background(), networkID, gatewayID)
+	healthStats, err := health.GetHealth(context.Background(), networkID, gatewayID)
 	if err != nil {
 		return err
 	}
@@ -104,7 +104,7 @@ func getHealth(networkID string, gatewayID string) error {
 }
 
 func getActiveGateway(networkID string) error {
-	activeID, err := health.GetActiveGateway(context2.Background(), networkID)
+	activeID, err := health.GetActiveGateway(context.Background(), networkID)
 	if err != nil {
 		return err
 	}

--- a/feg/gateway/go.mod
+++ b/feg/gateway/go.mod
@@ -42,10 +42,8 @@ require (
 	github.com/thoas/go-funk v0.7.0
 	github.com/wmnsk/go-gtp v0.7.26
 	golang.org/x/crypto v0.0.0-20210421170649-83a5a9bb288b // indirect
-	golang.org/x/tools v0.1.5 // indirect
 	google.golang.org/grpc v1.33.2
 	google.golang.org/protobuf v1.26.0
-	gotest.tools/gotestsum v1.7.0 // indirect
 	layeh.com/radius v0.0.0-20201203135236-838e26d0c9be
 	magma/feg/cloud/go v0.0.0
 	magma/feg/cloud/go/protos v0.0.0

--- a/feg/gateway/go.sum
+++ b/feg/gateway/go.sum
@@ -97,8 +97,6 @@ github.com/dgrijalva/jwt-go v3.2.0+incompatible h1:7qlOGliEKZXTDg6OTjfoBKDXWrumC
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgryski/go-farm v0.0.0-20190423205320-6a90982ecee2/go.mod h1:SqUrOPUnsFjfmXRMNPybcSiG0BgUW2AuFH8PAnS2iTw=
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
-github.com/dnephin/pflag v1.0.7 h1:oxONGlWxhmUct0YzKTgrpQv9AUA1wtPBn7zuSjJqptk=
-github.com/dnephin/pflag v1.0.7/go.mod h1:uxE91IoWURlOiTUIA8Mq5ZZkAv3dPUfZNaT80Zm7OQE=
 github.com/docker/distribution v2.7.1+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
 github.com/docker/docker v1.13.1/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
 github.com/docker/go-connections v0.4.0/go.mod h1:Gbd7IOopHjR8Iph03tsViu4nIes5XhDvyHbTtUxmeec=
@@ -132,8 +130,6 @@ github.com/facebookincubator/prometheus-configmanager v0.0.0-20200717220759-a828
 github.com/facebookincubator/prometheus-edge-hub v1.1.0 h1:3DqpYjRuYx1Ay02NiShGpEuzNtUu32iV/fq7jWetkaM=
 github.com/facebookincubator/prometheus-edge-hub v1.1.0/go.mod h1:MXZSK377xnwne4of8TGkZ2FEXYX2IKQZcIxjD8aNqrU=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
-github.com/fatih/color v1.10.0 h1:s36xzo75JdqLaaWoiEHk767eHiwo0598uUxyfiPkDsg=
-github.com/fatih/color v1.10.0/go.mod h1:ELkj/draVOlAH/xkhN6mQ50Qd0MPOk5AAr3maGEBuJM=
 github.com/fiorix/go-diameter/v4 v4.0.4 h1:/nw5zEmEW7pmP9YUYjOfU1GomR0LupKdYy52yd1j3NM=
 github.com/fiorix/go-diameter/v4 v4.0.4/go.mod h1:Qx/+pf+c9sBUHWq1d7EH3bkdwN8U0mUpdy9BieDw6UQ=
 github.com/fortytw2/leaktest v1.3.0 h1:u8491cBMTQ8ft8aeV+adlcytMZylmA5nnwwkRZjI8vw=
@@ -364,8 +360,6 @@ github.com/jmespath/go-jmespath v0.0.0-20160202185014-0b12d6b521d8/go.mod h1:Nht
 github.com/jmespath/go-jmespath v0.0.0-20160803190731-bd40a432e4c7/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
 github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
 github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22gdxWY5EU2bo=
-github.com/jonboulle/clockwork v0.2.2 h1:UOGuzwb1PwsrDAObMuhUnj0p5ULPj8V/xJ7Kx9qUBdQ=
-github.com/jonboulle/clockwork v0.2.2/go.mod h1:Pkfl5aHPm1nk2H9h0bjmnJD/BcgbGXUBGnn1kMkgxc8=
 github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8HmY=
 github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
 github.com/jpillora/backoff v1.0.0 h1:uvFg412JmmHBHw7iwprIxkPMI+sGQ4kzOWsMeHnm2EA=
@@ -689,7 +683,6 @@ github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q
 github.com/xlab/treeprint v0.0.0-20180616005107-d6fb6747feb6/go.mod h1:ce1O1j6UtZfjr22oyGxGLbauSBp2YVXpARAosm7dHBg=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
-github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
 github.com/yuin/gopher-lua v0.0.0-20200816102855-ee81675732da/go.mod h1:E1AXubJBdNmFERAOucpDIxNzeGfLzg0mYh+UfMWdChA=
 go.etcd.io/bbolt v1.3.2/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
 go.mongodb.org/mongo-driver v1.0.3 h1:GKoji1ld3tw2aC+GX1wbr/J2fX13yNacEYoJ8Nhr0yU=
@@ -732,8 +725,6 @@ golang.org/x/lint v0.0.0-20190313153728-d0100b6bd8b3/go.mod h1:6SW0HCj/g11FgYtHl
 golang.org/x/lint v0.0.0-20190409202823-959b441ac422/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=
 golang.org/x/mod v0.3.0 h1:RM4zey1++hCTbCVQfnWeKs9/IEsaBLA8vTkd0WVtmH4=
 golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
-golang.org/x/mod v0.4.2 h1:Gz96sIWK3OalVv/I/qNygP42zyoKp3xptRVCWRFEBvo=
-golang.org/x/mod v0.4.2/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/net v0.0.0-20170114055629-f2499483f923/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180826012351-8a410e7b638d/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
@@ -767,7 +758,6 @@ golang.org/x/net v0.0.0-20201021035429-f5854403a974/go.mod h1:sp8m0HH+o8qH0wwXwY
 golang.org/x/net v0.0.0-20201031054903-ff519b6c9102/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/net v0.0.0-20210226172049-e18ecbb05110 h1:qWPm9rbaAMKs8Bq/9LRpbMqxWRVUAQwMI9fVrssnTfw=
 golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
-golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4/go.mod h1:p54w0d4576C0XHj96bSt6lcn1PtDYWL6XObtHCRCNQM=
 golang.org/x/net v0.0.0-20210501142056-aec3718b3fa0 h1:6QqBc2UURz4Sbr4IE15uXM8CTQlHnRdtKuogDhwnu2Y=
 golang.org/x/net v0.0.0-20210501142056-aec3718b3fa0/go.mod h1:OJAsFXCWl8Ukc7SiCT/9KSuxbyM7479/AVlXFRxuMCk=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
@@ -785,8 +775,6 @@ golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9 h1:SQFwaSi55rU7vdNs9Yr0Z324
 golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201207232520-09787c993a3a h1:DcqTD9SDLc+1P/r1EmRBwnVsrOwW+kk2vWf9n+1sGhs=
 golang.org/x/sync v0.0.0-20201207232520-09787c993a3a/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
-golang.org/x/sync v0.0.0-20210220032951-036812b2e83c h1:5KslGYwFpkhGh+Q16bwMP3cOontH8FOep7tGV86Y7SQ=
-golang.org/x/sync v0.0.0-20210220032951-036812b2e83c/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20170830134202-bb24a47a89ea/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180823144017-11551d06cbcc/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
@@ -830,9 +818,7 @@ golang.org/x/sys v0.0.0-20210119212857-b64e53b001e4 h1:myAQVi0cGEoqQVR5POX+8RR2m
 golang.org/x/sys v0.0.0-20210119212857-b64e53b001e4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210124154548-22da62e12c0c/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210217105451-b926d437f341/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20210330210617-4fbd30eecc44/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20210510120138-977fb7262007/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210603081109-ebe580a85c40 h1:JWgyZ1qgdTaF3N3oxC+MdTV7qvEEgHo3otj+HB5CM7Q=
 golang.org/x/sys v0.0.0-20210603081109-ebe580a85c40/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1 h1:SrN+KX8Art/Sf4HNj6Zcz06G7VEz+7w9tdXTPOZ7+l4=
@@ -869,15 +855,12 @@ golang.org/x/tools v0.0.0-20190524140312-2c0ae7006135/go.mod h1:RgjU9mgBXZiqYHBn
 golang.org/x/tools v0.0.0-20190606124116-d0a3d012864b/go.mod h1:/rFqwRUd4F7ZHNgwSSTFct+R/Kf4OFW1sUzUTQQTgfc=
 golang.org/x/tools v0.0.0-20190614205625-5aca471b1d59/go.mod h1:/rFqwRUd4F7ZHNgwSSTFct+R/Kf4OFW1sUzUTQQTgfc=
 golang.org/x/tools v0.0.0-20190617190820-da514acc4774/go.mod h1:/rFqwRUd4F7ZHNgwSSTFct+R/Kf4OFW1sUzUTQQTgfc=
-golang.org/x/tools v0.0.0-20190624222133-a101b041ded4/go.mod h1:/rFqwRUd4F7ZHNgwSSTFct+R/Kf4OFW1sUzUTQQTgfc=
 golang.org/x/tools v0.0.0-20190907020128-2ca718005c18/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20191012152004-8de300cfc20a h1:TwMENskLwU2NnWBzrJGEWHqSiGUkO/B4rfyhwqDxDYQ=
 golang.org/x/tools v0.0.0-20191012152004-8de300cfc20a/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.1.0 h1:po9/4sTYwZU9lPhi1tOrb4hCv3qrhiQ77LZfGa2OjwY=
 golang.org/x/tools v0.1.0/go.mod h1:xkSsbof2nBLbhDlRMhhhyNLN/zl3eTqcnHD5viDpcZ0=
-golang.org/x/tools v0.1.5 h1:ouewzE6p+/VEB31YYnTbEJdi8pFqKp4P4n85vwo3DHA=
-golang.org/x/tools v0.1.5/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
@@ -964,11 +947,6 @@ gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776 h1:tQIYjPdBoyREyB9XMu+nnTclpTYkz2zFM+lzLJFO4gQ=
 gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
-gotest.tools v2.2.0+incompatible h1:VsBPFP1AI068pPrMxtb/S8Zkgf9xEmTLJjfM+P5UIEo=
-gotest.tools/gotestsum v1.6.4/go.mod h1:fTR9ZhxC/TLAAx2/WMk/m3TkMB9eEI89gdEzhiRVJT8=
-gotest.tools/gotestsum v1.7.0 h1:RwpqwwFKBAa2h+F6pMEGpE707Edld0etUD3GhqqhDNc=
-gotest.tools/gotestsum v1.7.0/go.mod h1:V1m4Jw3eBerhI/A6qCxUE07RnCg7ACkKj9BYcAm09V8=
-gotest.tools/v3 v3.0.3/go.mod h1:Z7Lb0S5l+klDB31fvDQX8ss/FlKDxtlFlw3Oa8Ymbl8=
 honnef.co/go/tools v0.0.0-20180728063816-88497007e858/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
@@ -984,8 +962,6 @@ k8s.io/klog v0.4.0/go.mod h1:4Bi6QPql/J/LkTDqv7R/cd3hPo4k2DG6Ptcz060Ez5I=
 k8s.io/kube-openapi v0.0.0-20180629012420-d83b052f768a/go.mod h1:BXM9ceUBTj2QnfH2MK1odQs778ajze1RxcmP6S8RVVc=
 k8s.io/kube-openapi v0.0.0-20190816220812-743ec37842bf/go.mod h1:1TqjTSzOxsLGIKfj0lK8EeCP7K1iUG65v09OM0/WG5E=
 k8s.io/utils v0.0.0-20190308190857-21c4ce38f2a7/go.mod h1:8k8uAuAQ0rXslZKaEWd0c3oVhZz7sSzSiPnVZayjIX0=
-layeh.com/radius v0.0.0-20200615152116-663b41c3bf86 h1:fusTUj5p5gvde/S45jZxsRO7Kuehu3JlYX6fTOvAedw=
-layeh.com/radius v0.0.0-20200615152116-663b41c3bf86/go.mod h1:lGEjzZ49j7EhtyvqZboqTYD6tnw/NR0S8ix1PXHfRgE=
 layeh.com/radius v0.0.0-20201203135236-838e26d0c9be h1:4YeDNYYOf9Pnn3pWEktFE+ZCZ5qX5ZVMaw3VAtfoXPk=
 layeh.com/radius v0.0.0-20201203135236-838e26d0c9be/go.mod h1:pFWM9De99EY9TPVyHIyA56QmoRViVck/x41WFkUlc9A=
 sigs.k8s.io/structured-merge-diff v0.0.0-20190525122527-15d366b2352e/go.mod h1:wWxsB5ozmmv/SG7nM11ayaAW51xMvak/t1r0CSlcokI=

--- a/lte/cloud/go/go.mod
+++ b/lte/cloud/go/go.mod
@@ -45,7 +45,6 @@ require (
 	github.com/stretchr/testify v1.6.1
 	github.com/thoas/go-funk v0.7.0
 	github.com/warthog618/sms v0.3.0
-	golang.org/x/net v0.0.0-20201031054903-ff519b6c9102
 	google.golang.org/genproto v0.0.0-20190819201941-24fa4b261c55
 	google.golang.org/grpc v1.31.0
 	gopkg.in/DATA-DOG/go-sqlmock.v1 v1.3.0

--- a/lte/cloud/go/services/lte/analytics/calculations/state_test.go
+++ b/lte/cloud/go/services/lte/analytics/calculations/state_test.go
@@ -1,7 +1,7 @@
 package calculations_test
 
 import (
-	context2 "context"
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -23,9 +23,9 @@ import (
 func TestUserCalculations(t *testing.T) {
 	configurator_test_init.StartTestService(t)
 	state_test_init.StartTestService(t)
-	err := configurator.CreateNetwork(context2.Background(), configurator.Network{ID: "n0"}, serdes.Network)
+	err := configurator.CreateNetwork(context.Background(), configurator.Network{ID: "n0"}, serdes.Network)
 	assert.NoError(t, err)
-	_, err = configurator.CreateEntity(context2.Background(), "n0", configurator.NetworkEntity{Type: orc8r.MagmadGatewayType, Key: "g0", Config: &models.MagmadGatewayConfigs{}, PhysicalID: "hw0"}, serdes.Entity)
+	_, err = configurator.CreateEntity(context.Background(), "n0", configurator.NetworkEntity{Type: orc8r.MagmadGatewayType, Key: "g0", Config: &models.MagmadGatewayConfigs{}, PhysicalID: "hw0"}, serdes.Entity)
 	assert.NoError(t, err)
 
 	ctx := test_utils.GetContextWithCertificate(t, "hw0")
@@ -87,10 +87,10 @@ func TestUserCalculations(t *testing.T) {
 func TestSiteCalculations(t *testing.T) {
 	configurator_test_init.StartTestService(t)
 	state_test_init.StartTestService(t)
-	err := configurator.CreateNetwork(context2.Background(), configurator.Network{ID: "n0"}, serdes.Network)
+	err := configurator.CreateNetwork(context.Background(), configurator.Network{ID: "n0"}, serdes.Network)
 	assert.NoError(t, err)
 
-	_, err = configurator.CreateEntity(context2.Background(), "n0", configurator.NetworkEntity{
+	_, err = configurator.CreateEntity(context.Background(), "n0", configurator.NetworkEntity{
 		Type:       lte.CellularGatewayEntityType,
 		Key:        "g0",
 		Config:     &models.MagmadGatewayConfigs{},

--- a/lte/cloud/go/services/lte/servicers/indexer_servicer_test.go
+++ b/lte/cloud/go/services/lte/servicers/indexer_servicer_test.go
@@ -14,7 +14,7 @@ limitations under the License.
 package servicers_test
 
 import (
-	context2 "context"
+	"context"
 	"testing"
 	"time"
 
@@ -85,10 +85,10 @@ func TestIndexerEnodebState(t *testing.T) {
 	errs, err = idx.Index(networkID, stateGw2)
 	assert.NoError(t, err)
 	assert.Empty(t, errs)
-	gotA, err := lte_service.GetEnodebState(context2.Background(), networkID, gatewayID1, enbSN)
+	gotA, err := lte_service.GetEnodebState(context.Background(), networkID, gatewayID1, enbSN)
 	assert.NoError(t, err)
 	assert.Equal(t, enbState1, gotA)
-	gotB, err := lte_service.GetEnodebState(context2.Background(), networkID, gatewayID2, enbSN)
+	gotB, err := lte_service.GetEnodebState(context.Background(), networkID, gatewayID2, enbSN)
 	assert.NoError(t, err)
 	assert.Equal(t, enbState2, gotB)
 
@@ -100,18 +100,18 @@ func TestIndexerEnodebState(t *testing.T) {
 	errs, err = idx.Index(networkID, states)
 	assert.NoError(t, err)
 	assert.Error(t, errs[id3])
-	gotC, err := lte_service.GetEnodebState(context2.Background(), networkID, gatewayID1, enbSN)
+	gotC, err := lte_service.GetEnodebState(context.Background(), networkID, gatewayID1, enbSN)
 	assert.NoError(t, err)
 	assert.Equal(t, enbState2, gotC)
 }
 
 func seedNetwork(t *testing.T, networkID string) {
-	err := configurator.CreateNetwork(context2.Background(), configurator.Network{ID: networkID}, serdes.Network)
+	err := configurator.CreateNetwork(context.Background(), configurator.Network{ID: networkID}, serdes.Network)
 	assert.NoError(t, err)
 }
 
 func seedGateway(t *testing.T, networkID string, gatewayID string, hwID string) {
-	_, err := configurator.CreateEntity(context2.Background(), networkID, configurator.NetworkEntity{
+	_, err := configurator.CreateEntity(context.Background(), networkID, configurator.NetworkEntity{
 		Type:         orc8r.MagmadGatewayType,
 		Key:          gatewayID,
 		Config:       &models2.MagmadGatewayConfigs{},
@@ -123,7 +123,7 @@ func seedGateway(t *testing.T, networkID string, gatewayID string, hwID string) 
 
 func seedTier(t *testing.T, networkID string) {
 	// setup fixtures in backend
-	_, err := configurator.CreateEntities(context2.Background(), networkID, []configurator.NetworkEntity{
+	_, err := configurator.CreateEntities(context.Background(), networkID, []configurator.NetworkEntity{
 		{Type: orc8r.UpgradeTierEntityType, Key: "t0"},
 	}, serdes.Entity)
 	assert.NoError(t, err)

--- a/lte/cloud/go/services/nprobe/obsidian/handlers/handlers_test.go
+++ b/lte/cloud/go/services/nprobe/obsidian/handlers/handlers_test.go
@@ -14,7 +14,7 @@
 package handlers_test
 
 import (
-	context2 "context"
+	"context"
 	"testing"
 	"time"
 
@@ -49,7 +49,7 @@ func getNProbeBlobstore(t *testing.T) storage.NProbeStorage {
 
 func TestCreateNetworkProbeTask(t *testing.T) {
 	configuratorTestInit.StartTestService(t)
-	err := configurator.CreateNetwork(context2.Background(), configurator.Network{ID: "n1"}, serdes.Network)
+	err := configurator.CreateNetwork(context.Background(), configurator.Network{ID: "n1"}, serdes.Network)
 	assert.NoError(t, err)
 
 	e := echo.New()
@@ -79,7 +79,7 @@ func TestCreateNetworkProbeTask(t *testing.T) {
 	}
 	tests.RunUnitTest(t, e, tc)
 
-	actual, err := configurator.LoadEntity(context2.Background(), "n1", lte.NetworkProbeTaskEntityType, "test", configurator.FullEntityLoadCriteria(), serdes.Entity)
+	actual, err := configurator.LoadEntity(context.Background(), "n1", lte.NetworkProbeTaskEntityType, "test", configurator.FullEntityLoadCriteria(), serdes.Entity)
 	assert.NoError(t, err)
 	expected := configurator.NetworkEntity{
 		NetworkID: "n1",
@@ -100,7 +100,7 @@ func TestCreateNetworkProbeTask(t *testing.T) {
 
 func TestListNetworkProbeTasks(t *testing.T) {
 	configuratorTestInit.StartTestService(t)
-	err := configurator.CreateNetwork(context2.Background(), configurator.Network{ID: "n1"}, serdes.Network)
+	err := configurator.CreateNetwork(context.Background(), configurator.Network{ID: "n1"}, serdes.Network)
 	assert.NoError(t, err)
 
 	e := echo.New()
@@ -119,7 +119,7 @@ func TestListNetworkProbeTasks(t *testing.T) {
 	}
 	tests.RunUnitTest(t, e, tc)
 
-	_, err = configurator.CreateEntities(context2.Background(), "n1", []configurator.NetworkEntity{
+	_, err = configurator.CreateEntities(context.Background(), "n1", []configurator.NetworkEntity{
 		{
 			Key:  "IMSI1234",
 			Type: lte.NetworkProbeTaskEntityType,
@@ -176,7 +176,7 @@ func TestListNetworkProbeTasks(t *testing.T) {
 
 func TestGetNetworkProbeTask(t *testing.T) {
 	configuratorTestInit.StartTestService(t)
-	err := configurator.CreateNetwork(context2.Background(), configurator.Network{ID: "n1"}, serdes.Network)
+	err := configurator.CreateNetwork(context.Background(), configurator.Network{ID: "n1"}, serdes.Network)
 	assert.NoError(t, err)
 
 	e := echo.New()
@@ -195,7 +195,7 @@ func TestGetNetworkProbeTask(t *testing.T) {
 	}
 	tests.RunUnitTest(t, e, tc)
 
-	_, err = configurator.CreateEntity(context2.Background(), "n1", configurator.NetworkEntity{
+	_, err = configurator.CreateEntity(context.Background(), "n1", configurator.NetworkEntity{
 		Key:  "IMSI1234",
 		Type: lte.NetworkProbeTaskEntityType,
 		Config: &models.NetworkProbeTaskDetails{
@@ -229,7 +229,7 @@ func TestGetNetworkProbeTask(t *testing.T) {
 
 func TestUpdateNetworkProbeTask(t *testing.T) {
 	configuratorTestInit.StartTestService(t)
-	err := configurator.CreateNetwork(context2.Background(), configurator.Network{ID: "n1"}, serdes.Network)
+	err := configurator.CreateNetwork(context.Background(), configurator.Network{ID: "n1"}, serdes.Network)
 	assert.NoError(t, err)
 
 	e := echo.New()
@@ -261,7 +261,7 @@ func TestUpdateNetworkProbeTask(t *testing.T) {
 	tests.RunUnitTest(t, e, tc)
 
 	// Add the NetworkProbeTask
-	_, err = configurator.CreateEntity(context2.Background(), "n1", configurator.NetworkEntity{
+	_, err = configurator.CreateEntity(context.Background(), "n1", configurator.NetworkEntity{
 		Key:  "IMSI1234",
 		Type: lte.NetworkProbeTaskEntityType,
 		Config: &models.NetworkProbeTaskDetails{
@@ -284,7 +284,7 @@ func TestUpdateNetworkProbeTask(t *testing.T) {
 	}
 	tests.RunUnitTest(t, e, tc)
 
-	actual, err := configurator.LoadEntity(context2.Background(), "n1", lte.NetworkProbeTaskEntityType, "IMSI1234", configurator.FullEntityLoadCriteria(), serdes.Entity)
+	actual, err := configurator.LoadEntity(context.Background(), "n1", lte.NetworkProbeTaskEntityType, "IMSI1234", configurator.FullEntityLoadCriteria(), serdes.Entity)
 	assert.NoError(t, err)
 	expected := configurator.NetworkEntity{
 		NetworkID: "n1",
@@ -299,7 +299,7 @@ func TestUpdateNetworkProbeTask(t *testing.T) {
 
 func TestDeleteNetworkProbeTask(t *testing.T) {
 	configuratorTestInit.StartTestService(t)
-	err := configurator.CreateNetwork(context2.Background(), configurator.Network{ID: "n1"}, serdes.Network)
+	err := configurator.CreateNetwork(context.Background(), configurator.Network{ID: "n1"}, serdes.Network)
 	assert.NoError(t, err)
 
 	e := echo.New()
@@ -307,7 +307,7 @@ func TestDeleteNetworkProbeTask(t *testing.T) {
 	handlers := handlers.GetHandlers(getNProbeBlobstore(t))
 	deleteNetworkProbeTask := tests.GetHandlerByPathAndMethod(t, handlers, testURLRoot, obsidian.DELETE).HandlerFunc
 
-	_, err = configurator.CreateEntities(context2.Background(), "n1", []configurator.NetworkEntity{
+	_, err = configurator.CreateEntities(context.Background(), "n1", []configurator.NetworkEntity{
 		{
 			Key:  "IMSI1234",
 			Type: lte.NetworkProbeTaskEntityType,
@@ -341,7 +341,7 @@ func TestDeleteNetworkProbeTask(t *testing.T) {
 	}
 	tests.RunUnitTest(t, e, tc)
 
-	actual, _, err := configurator.LoadAllEntitiesOfType(context2.Background(), "n1", lte.NetworkProbeTaskEntityType, configurator.FullEntityLoadCriteria(), serdes.Entity)
+	actual, _, err := configurator.LoadAllEntitiesOfType(context.Background(), "n1", lte.NetworkProbeTaskEntityType, configurator.FullEntityLoadCriteria(), serdes.Entity)
 	assert.NoError(t, err)
 	assert.Equal(t, 1, len(actual))
 	expected := configurator.NetworkEntity{
@@ -362,7 +362,7 @@ func TestDeleteNetworkProbeTask(t *testing.T) {
 
 func TestCreateNetworkProbeDestination(t *testing.T) {
 	configuratorTestInit.StartTestService(t)
-	err := configurator.CreateNetwork(context2.Background(), configurator.Network{ID: "n1"}, serdes.Network)
+	err := configurator.CreateNetwork(context.Background(), configurator.Network{ID: "n1"}, serdes.Network)
 	assert.NoError(t, err)
 
 	e := echo.New()
@@ -392,7 +392,7 @@ func TestCreateNetworkProbeDestination(t *testing.T) {
 	}
 	tests.RunUnitTest(t, e, tc)
 
-	actual, err := configurator.LoadEntity(context2.Background(), "n1", lte.NetworkProbeDestinationEntityType, "test", configurator.FullEntityLoadCriteria(), serdes.Entity)
+	actual, err := configurator.LoadEntity(context.Background(), "n1", lte.NetworkProbeDestinationEntityType, "test", configurator.FullEntityLoadCriteria(), serdes.Entity)
 	assert.NoError(t, err)
 	expected := configurator.NetworkEntity{
 		NetworkID: "n1",
@@ -406,7 +406,7 @@ func TestCreateNetworkProbeDestination(t *testing.T) {
 
 func TestListNetworkProbeDestinations(t *testing.T) {
 	configuratorTestInit.StartTestService(t)
-	err := configurator.CreateNetwork(context2.Background(), configurator.Network{ID: "n1"}, serdes.Network)
+	err := configurator.CreateNetwork(context.Background(), configurator.Network{ID: "n1"}, serdes.Network)
 	assert.NoError(t, err)
 
 	e := echo.New()
@@ -425,7 +425,7 @@ func TestListNetworkProbeDestinations(t *testing.T) {
 	}
 	tests.RunUnitTest(t, e, tc)
 
-	_, err = configurator.CreateEntities(context2.Background(), "n1", []configurator.NetworkEntity{
+	_, err = configurator.CreateEntities(context.Background(), "n1", []configurator.NetworkEntity{
 		{
 			Key:  "1111-2222-3333",
 			Type: lte.NetworkProbeDestinationEntityType,
@@ -474,7 +474,7 @@ func TestListNetworkProbeDestinations(t *testing.T) {
 
 func TestGetNetworkProbeDestination(t *testing.T) {
 	configuratorTestInit.StartTestService(t)
-	err := configurator.CreateNetwork(context2.Background(), configurator.Network{ID: "n1"}, serdes.Network)
+	err := configurator.CreateNetwork(context.Background(), configurator.Network{ID: "n1"}, serdes.Network)
 	assert.NoError(t, err)
 
 	e := echo.New()
@@ -493,7 +493,7 @@ func TestGetNetworkProbeDestination(t *testing.T) {
 	}
 	tests.RunUnitTest(t, e, tc)
 
-	_, err = configurator.CreateEntity(context2.Background(), "n1", configurator.NetworkEntity{
+	_, err = configurator.CreateEntity(context.Background(), "n1", configurator.NetworkEntity{
 		Key:  "1111-2222-3333",
 		Type: lte.NetworkProbeDestinationEntityType,
 		Config: &models.NetworkProbeDestinationDetails{
@@ -523,7 +523,7 @@ func TestGetNetworkProbeDestination(t *testing.T) {
 
 func TestUpdateNetworkProbeDestination(t *testing.T) {
 	configuratorTestInit.StartTestService(t)
-	err := configurator.CreateNetwork(context2.Background(), configurator.Network{ID: "n1"}, serdes.Network)
+	err := configurator.CreateNetwork(context.Background(), configurator.Network{ID: "n1"}, serdes.Network)
 	assert.NoError(t, err)
 
 	e := echo.New()
@@ -556,7 +556,7 @@ func TestUpdateNetworkProbeDestination(t *testing.T) {
 	tests.RunUnitTest(t, e, tc)
 
 	// Add the NetworkProbeDestination
-	_, err = configurator.CreateEntity(context2.Background(), "n1", configurator.NetworkEntity{
+	_, err = configurator.CreateEntity(context.Background(), "n1", configurator.NetworkEntity{
 		Key:  "1111-2222-3333",
 		Type: lte.NetworkProbeDestinationEntityType,
 		Config: &models.NetworkProbeDestinationDetails{
@@ -577,7 +577,7 @@ func TestUpdateNetworkProbeDestination(t *testing.T) {
 	}
 	tests.RunUnitTest(t, e, tc)
 
-	actual, err := configurator.LoadEntity(context2.Background(), "n1", lte.NetworkProbeDestinationEntityType, "1111-2222-3333", configurator.FullEntityLoadCriteria(), serdes.Entity)
+	actual, err := configurator.LoadEntity(context.Background(), "n1", lte.NetworkProbeDestinationEntityType, "1111-2222-3333", configurator.FullEntityLoadCriteria(), serdes.Entity)
 	assert.NoError(t, err)
 	expected := configurator.NetworkEntity{
 		NetworkID: "n1",
@@ -592,7 +592,7 @@ func TestUpdateNetworkProbeDestination(t *testing.T) {
 
 func TestDeleteNetworkProbeDestination(t *testing.T) {
 	configuratorTestInit.StartTestService(t)
-	err := configurator.CreateNetwork(context2.Background(), configurator.Network{ID: "n1"}, serdes.Network)
+	err := configurator.CreateNetwork(context.Background(), configurator.Network{ID: "n1"}, serdes.Network)
 	assert.NoError(t, err)
 
 	e := echo.New()
@@ -600,7 +600,7 @@ func TestDeleteNetworkProbeDestination(t *testing.T) {
 	handlers := handlers.GetHandlers(getNProbeBlobstore(t))
 	deleteNetworkProbeDestination := tests.GetHandlerByPathAndMethod(t, handlers, testURLRoot, obsidian.DELETE).HandlerFunc
 
-	_, err = configurator.CreateEntities(context2.Background(), "n1", []configurator.NetworkEntity{
+	_, err = configurator.CreateEntities(context.Background(), "n1", []configurator.NetworkEntity{
 		{
 			Key:  "1111-2222-3333",
 			Type: lte.NetworkProbeDestinationEntityType,
@@ -636,7 +636,7 @@ func TestDeleteNetworkProbeDestination(t *testing.T) {
 	}
 	tests.RunUnitTest(t, e, tc)
 
-	actual, _, err := configurator.LoadAllEntitiesOfType(context2.Background(), "n1", lte.NetworkProbeDestinationEntityType, configurator.FullEntityLoadCriteria(), serdes.Entity)
+	actual, _, err := configurator.LoadAllEntitiesOfType(context.Background(), "n1", lte.NetworkProbeDestinationEntityType, configurator.FullEntityLoadCriteria(), serdes.Entity)
 	assert.NoError(t, err)
 	assert.Equal(t, 1, len(actual))
 	expected := configurator.NetworkEntity{

--- a/lte/cloud/go/services/policydb/obsidian/handlers/policy_handlers_test.go
+++ b/lte/cloud/go/services/policydb/obsidian/handlers/policy_handlers_test.go
@@ -14,7 +14,7 @@
 package handlers_test
 
 import (
-	context2 "context"
+	"context"
 	"fmt"
 	"testing"
 
@@ -39,7 +39,7 @@ func TestPolicyDBHandlersBasic(t *testing.T) {
 	e := echo.New()
 
 	obsidianHandlers := handlers.GetHandlers()
-	err := configurator.CreateNetwork(context2.Background(), configurator.Network{ID: "n1", Type: lte.NetworkType}, serdes.Network)
+	err := configurator.CreateNetwork(context.Background(), configurator.Network{ID: "n1", Type: lte.NetworkType}, serdes.Network)
 	assert.NoError(t, err)
 
 	listPolicies := tests.GetHandlerByPathAndMethod(t, obsidianHandlers, "/magma/v1/networks/:network_id/policies/rules", obsidian.GET).HandlerFunc
@@ -651,7 +651,7 @@ func TestPolicyHandlersAssociations(t *testing.T) {
 	e := echo.New()
 
 	obsidianHandlers := handlers.GetHandlers()
-	err := configurator.CreateNetwork(context2.Background(), configurator.Network{ID: "n1", Type: lte.NetworkType}, serdes.Network)
+	err := configurator.CreateNetwork(context.Background(), configurator.Network{ID: "n1", Type: lte.NetworkType}, serdes.Network)
 	assert.NoError(t, err)
 
 	createPolicy := tests.GetHandlerByPathAndMethod(t, obsidianHandlers, "/magma/v1/networks/:network_id/policies/rules", obsidian.POST).HandlerFunc
@@ -664,7 +664,7 @@ func TestPolicyHandlersAssociations(t *testing.T) {
 
 	// preseed 3 subscribers
 	imsi1, imsi2, imsi3 := "IMSI1234567890", "IMSI0987654321", "IMSI1111111111"
-	_, err = configurator.CreateEntities(context2.Background(), "n1", []configurator.NetworkEntity{
+	_, err = configurator.CreateEntities(context.Background(), "n1", []configurator.NetworkEntity{
 		{Type: lte.SubscriberEntityType, Key: imsi1},
 		{Type: lte.SubscriberEntityType, Key: imsi2},
 		{Type: lte.SubscriberEntityType, Key: imsi3},
@@ -870,7 +870,7 @@ func TestQoSProfile(t *testing.T) {
 	e := echo.New()
 
 	policydbHandlers := handlers.GetHandlers()
-	err := configurator.CreateNetwork(context2.Background(), configurator.Network{ID: "n1", Type: lte.NetworkType}, serdes.Network)
+	err := configurator.CreateNetwork(context.Background(), configurator.Network{ID: "n1", Type: lte.NetworkType}, serdes.Network)
 	assert.NoError(t, err)
 
 	getAllProfiles := tests.GetHandlerByPathAndMethod(t, policydbHandlers, "/magma/v1/lte/:network_id/policy_qos_profiles", obsidian.GET).HandlerFunc
@@ -1090,7 +1090,7 @@ func TestPolicyWithQoSProfile(t *testing.T) {
 	e := echo.New()
 
 	policydbHandlers := handlers.GetHandlers()
-	err := configurator.CreateNetwork(context2.Background(), configurator.Network{ID: "n1", Type: lte.NetworkType}, serdes.Network)
+	err := configurator.CreateNetwork(context.Background(), configurator.Network{ID: "n1", Type: lte.NetworkType}, serdes.Network)
 	assert.NoError(t, err)
 
 	postProfile := tests.GetHandlerByPathAndMethod(t, policydbHandlers, "/magma/v1/lte/:network_id/policy_qos_profiles", obsidian.POST).HandlerFunc
@@ -1221,7 +1221,7 @@ func TestPolicyWithQoSProfile(t *testing.T) {
 func validatePolicy(t *testing.T, e *echo.Echo, getRule echo.HandlerFunc, expectedModel *policyModels.PolicyRule, expectedEnt configurator.NetworkEntity) {
 	expectedEnt.Config = getExpectedRuleConfig(expectedModel)
 
-	actual, err := configurator.LoadEntity(context2.Background(), "n1", lte.PolicyRuleEntityType, string(expectedModel.ID), configurator.FullEntityLoadCriteria(), serdes.Entity)
+	actual, err := configurator.LoadEntity(context.Background(), "n1", lte.PolicyRuleEntityType, string(expectedModel.ID), configurator.FullEntityLoadCriteria(), serdes.Entity)
 	assert.NoError(t, err)
 	assert.Equal(t, expectedEnt, actual)
 	tc := tests.Test{
@@ -1248,7 +1248,7 @@ func getExpectedRuleConfig(m *policyModels.PolicyRule) *policyModels.PolicyRuleC
 }
 
 func validateBaseName(t *testing.T, e *echo.Echo, getName echo.HandlerFunc, expectedModel *policyModels.BaseNameRecord, expectedEnt configurator.NetworkEntity) {
-	actual, err := configurator.LoadEntity(context2.Background(), "n1", lte.BaseNameEntityType, string(expectedModel.Name), configurator.FullEntityLoadCriteria(), serdes.Entity)
+	actual, err := configurator.LoadEntity(context.Background(), "n1", lte.BaseNameEntityType, string(expectedModel.Name), configurator.FullEntityLoadCriteria(), serdes.Entity)
 	assert.NoError(t, err)
 	assert.Equal(t, expectedEnt, actual)
 	tc := tests.Test{

--- a/lte/cloud/go/services/policydb/obsidian/handlers/rating_groups_handlers_test.go
+++ b/lte/cloud/go/services/policydb/obsidian/handlers/rating_groups_handlers_test.go
@@ -14,7 +14,7 @@
 package handlers_test
 
 import (
-	context2 "context"
+	"context"
 	"testing"
 
 	"github.com/go-openapi/swag"
@@ -37,7 +37,7 @@ func TestRatingGroupHandlersBasic(t *testing.T) {
 	e := echo.New()
 
 	obsidianHandlers := handlers.GetHandlers()
-	err := configurator.CreateNetwork(context2.Background(), configurator.Network{ID: "n1", Type: lte.NetworkType}, serdes.Network)
+	err := configurator.CreateNetwork(context.Background(), configurator.Network{ID: "n1", Type: lte.NetworkType}, serdes.Network)
 	assert.NoError(t, err)
 
 	listRatingGroups := tests.GetHandlerByPathAndMethod(t, obsidianHandlers, "/magma/v1/networks/:network_id/rating_groups", obsidian.GET).HandlerFunc

--- a/lte/cloud/go/services/policydb/servicers/assignments.go
+++ b/lte/cloud/go/services/policydb/servicers/assignments.go
@@ -18,7 +18,8 @@ services to interact with assignments from policy rules and subscribers.
 package servicers
 
 import (
-	"golang.org/x/net/context"
+	"context"
+
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 

--- a/lte/cloud/go/services/policydb/servicers/assignments_test.go
+++ b/lte/cloud/go/services/policydb/servicers/assignments_test.go
@@ -14,12 +14,11 @@ limitations under the License.
 package servicers_test
 
 import (
-	context2 "context"
+	"context"
 	"testing"
 
 	"github.com/go-openapi/swag"
 	"github.com/stretchr/testify/assert"
-	"golang.org/x/net/context"
 
 	"magma/lte/cloud/go/lte"
 	"magma/lte/cloud/go/protos"
@@ -47,11 +46,11 @@ func TestAssignmentsServicer(t *testing.T) {
 	testBaseName := "b1"
 
 	// Initialize network
-	err := configurator.CreateNetwork(context2.Background(), configurator.Network{ID: testNetworkId}, serdes.Network)
+	err := configurator.CreateNetwork(context.Background(), configurator.Network{ID: testNetworkId}, serdes.Network)
 	assert.NoError(t, err)
 
 	// Initialize gateway -> subscriber, and create a policy rule
-	_, err = configurator.CreateEntities(context2.Background(), testNetworkId, []configurator.NetworkEntity{
+	_, err = configurator.CreateEntities(context.Background(), testNetworkId, []configurator.NetworkEntity{
 		{Type: lte.SubscriberEntityType, Key: testSubscriberId},
 		{
 			Type: lte.PolicyRuleEntityType,
@@ -120,13 +119,13 @@ func TestAssignmentsServicer(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Verify that the rule is associated to the subscriber
-	ent, err := configurator.LoadEntity(context2.Background(), testNetworkId, lte.PolicyRuleEntityType, testPolicyId, configurator.FullEntityLoadCriteria(), serdes.Entity)
+	ent, err := configurator.LoadEntity(context.Background(), testNetworkId, lte.PolicyRuleEntityType, testPolicyId, configurator.FullEntityLoadCriteria(), serdes.Entity)
 	testPolicy := (&models.PolicyRule{}).FromEntity(ent)
 	assert.NoError(t, err)
 	assert.Equal(t, 1, len(testPolicy.AssignedSubscribers))
 
 	// Verify that the base name is associated to the subscriber
-	ent, err = configurator.LoadEntity(context2.Background(), testNetworkId, lte.BaseNameEntityType, testBaseName, configurator.FullEntityLoadCriteria(), serdes.Entity)
+	ent, err = configurator.LoadEntity(context.Background(), testNetworkId, lte.BaseNameEntityType, testBaseName, configurator.FullEntityLoadCriteria(), serdes.Entity)
 	baseName := (&models.BaseNameRecord{}).FromEntity(ent)
 	assert.NoError(t, err)
 	assert.Equal(t, 1, len(baseName.AssignedSubscribers))
@@ -137,13 +136,13 @@ func TestAssignmentsServicer(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Verify that the rule is disassociated from the subscriber
-	ent, err = configurator.LoadEntity(context2.Background(), testNetworkId, lte.PolicyRuleEntityType, testPolicyId, configurator.EntityLoadCriteria{LoadConfig: true}, serdes.Entity)
+	ent, err = configurator.LoadEntity(context.Background(), testNetworkId, lte.PolicyRuleEntityType, testPolicyId, configurator.EntityLoadCriteria{LoadConfig: true}, serdes.Entity)
 	testPolicy = (&models.PolicyRule{}).FromEntity(ent)
 	assert.NoError(t, err)
 	assert.Equal(t, 0, len(testPolicy.AssignedSubscribers))
 
 	// Verify that the base name is disassociated from the subscriber
-	ent, err = configurator.LoadEntity(context2.Background(), testNetworkId, lte.BaseNameEntityType, testBaseName, configurator.FullEntityLoadCriteria(), serdes.Entity)
+	ent, err = configurator.LoadEntity(context.Background(), testNetworkId, lte.BaseNameEntityType, testBaseName, configurator.FullEntityLoadCriteria(), serdes.Entity)
 	baseName = (&models.BaseNameRecord{}).FromEntity(ent)
 	assert.NoError(t, err)
 	assert.Equal(t, 0, len(baseName.AssignedSubscribers))

--- a/lte/cloud/go/services/subscriberdb/digest_test.go
+++ b/lte/cloud/go/services/subscriberdb/digest_test.go
@@ -14,7 +14,7 @@ limitations under the License.
 package subscriberdb_test
 
 import (
-	context2 "context"
+	"context"
 	"fmt"
 	"testing"
 
@@ -37,11 +37,11 @@ func TestGetDigestDeterministic(t *testing.T) {
 	lte_test_init.StartTestService(t)
 	configurator_test_init.StartTestService(t)
 
-	err := configurator.CreateNetwork(context2.Background(), configurator.Network{ID: "n1"}, serdes.Network)
+	err := configurator.CreateNetwork(context.Background(), configurator.Network{ID: "n1"}, serdes.Network)
 	assert.NoError(t, err)
-	_, err = configurator.CreateEntity(context2.Background(), "n1", configurator.NetworkEntity{Type: orc8r.MagmadGatewayType, Key: "g1", PhysicalID: "hw1"}, serdes.Entity)
+	_, err = configurator.CreateEntity(context.Background(), "n1", configurator.NetworkEntity{Type: orc8r.MagmadGatewayType, Key: "g1", PhysicalID: "hw1"}, serdes.Entity)
 	assert.NoError(t, err)
-	gw, err := configurator.CreateEntity(context2.Background(), "n1", configurator.NetworkEntity{Type: lte.CellularGatewayEntityType, Key: "g1"}, serdes.Entity)
+	gw, err := configurator.CreateEntity(context.Background(), "n1", configurator.NetworkEntity{Type: lte.CellularGatewayEntityType, Key: "g1"}, serdes.Entity)
 	assert.NoError(t, err)
 
 	// Create 1 APN and 5 pages of subscribers to test deterministic digest over multiple pages
@@ -61,7 +61,7 @@ func TestGetDigestDeterministic(t *testing.T) {
 		Config: &lte_models.ApnConfiguration{},
 	})
 
-	_, err = configurator.CreateEntities(context2.Background(), "n1", networkEntities, serdes.Entity)
+	_, err = configurator.CreateEntities(context.Background(), "n1", networkEntities, serdes.Entity)
 	assert.NoError(t, err)
 
 	expected, err := subscriberdb.GetDigest("n1")
@@ -73,7 +73,7 @@ func TestGetDigestDeterministic(t *testing.T) {
 	}
 
 	// Update the subscriber list, the digest should update too
-	_, err = configurator.CreateEntity(context2.Background(), "n1", configurator.NetworkEntity{
+	_, err = configurator.CreateEntity(context.Background(), "n1", configurator.NetworkEntity{
 		Type: lte.SubscriberEntityType, Key: "IMSI11111",
 		Config: &models.SubscriberConfig{
 			Lte: &models.LteSubscription{State: "ACTIVE"},
@@ -107,7 +107,7 @@ func TestGetDigestDeterministic(t *testing.T) {
 		AssociationsToAdd: storage.TKs{{Type: lte.APNResourceEntityType, Key: "resource"}},
 	}
 	writes = append(writes, write)
-	err = configurator.WriteEntities(context2.Background(), "n1", writes, serdes.Entity)
+	err = configurator.WriteEntities(context.Background(), "n1", writes, serdes.Entity)
 	assert.NoError(t, err)
 
 	digest, err = subscriberdb.GetDigest("n1")
@@ -121,16 +121,16 @@ func TestGetDigestApnResourceAssocs(t *testing.T) {
 	lte_test_init.StartTestService(t)
 	configurator_test_init.StartTestService(t)
 
-	err := configurator.CreateNetwork(context2.Background(), configurator.Network{ID: "n1"}, serdes.Network)
+	err := configurator.CreateNetwork(context.Background(), configurator.Network{ID: "n1"}, serdes.Network)
 	assert.NoError(t, err)
-	gw1, err := configurator.CreateEntity(context2.Background(), "n1", configurator.NetworkEntity{Type: lte.CellularGatewayEntityType, Key: "g1"}, serdes.Entity)
+	gw1, err := configurator.CreateEntity(context.Background(), "n1", configurator.NetworkEntity{Type: lte.CellularGatewayEntityType, Key: "g1"}, serdes.Entity)
 	assert.NoError(t, err)
-	gw2, err := configurator.CreateEntity(context2.Background(), "n1", configurator.NetworkEntity{Type: lte.CellularGatewayEntityType, Key: "g2"}, serdes.Entity)
+	gw2, err := configurator.CreateEntity(context.Background(), "n1", configurator.NetworkEntity{Type: lte.CellularGatewayEntityType, Key: "g2"}, serdes.Entity)
 	assert.NoError(t, err)
-	gw3, err := configurator.CreateEntity(context2.Background(), "n1", configurator.NetworkEntity{Type: lte.CellularGatewayEntityType, Key: "g3"}, serdes.Entity)
+	gw3, err := configurator.CreateEntity(context.Background(), "n1", configurator.NetworkEntity{Type: lte.CellularGatewayEntityType, Key: "g3"}, serdes.Entity)
 	assert.NoError(t, err)
 
-	_, err = configurator.CreateEntities(context2.Background(), "n1", []configurator.NetworkEntity{
+	_, err = configurator.CreateEntities(context.Background(), "n1", []configurator.NetworkEntity{
 		{
 			Type: lte.APNEntityType, Key: "apn1",
 			Config: &lte_models.ApnConfiguration{},
@@ -189,7 +189,7 @@ func TestGetDigestApnResourceAssocs(t *testing.T) {
 			},
 		},
 	}
-	err = configurator.WriteEntities(context2.Background(), "n1", writes, serdes.Entity)
+	err = configurator.WriteEntities(context.Background(), "n1", writes, serdes.Entity)
 	assert.NoError(t, err)
 	expected, err := subscriberdb.GetDigest("n1")
 	assert.NoError(t, err)
@@ -212,7 +212,7 @@ func TestGetDigestApnResourceAssocs(t *testing.T) {
 			},
 		},
 	}
-	err = configurator.WriteEntities(context2.Background(), "n1", writes, serdes.Entity)
+	err = configurator.WriteEntities(context.Background(), "n1", writes, serdes.Entity)
 	assert.NoError(t, err)
 
 	digest, err := subscriberdb.GetDigest("n1")
@@ -221,7 +221,7 @@ func TestGetDigestApnResourceAssocs(t *testing.T) {
 	expected = digest
 
 	// Digest reflects changes in apn resource->apn associations
-	err = configurator.DeleteEntity(context2.Background(), "n1", lte.APNResourceEntityType, "resource1")
+	err = configurator.DeleteEntity(context.Background(), "n1", lte.APNResourceEntityType, "resource1")
 	assert.NoError(t, err)
 	writes = []configurator.EntityWriteOperation{
 		configurator.NetworkEntity{
@@ -240,7 +240,7 @@ func TestGetDigestApnResourceAssocs(t *testing.T) {
 			},
 		},
 	}
-	err = configurator.WriteEntities(context2.Background(), "n1", writes, serdes.Entity)
+	err = configurator.WriteEntities(context.Background(), "n1", writes, serdes.Entity)
 	assert.NoError(t, err)
 
 	digest, err = subscriberdb.GetDigest("n1")
@@ -252,9 +252,9 @@ func TestGetPerSubscriberDigests(t *testing.T) {
 	lte_test_init.StartTestService(t)
 	configurator_test_init.StartTestService(t)
 
-	err := configurator.CreateNetwork(context2.Background(), configurator.Network{ID: "n1"}, serdes.Network)
+	err := configurator.CreateNetwork(context.Background(), configurator.Network{ID: "n1"}, serdes.Network)
 	assert.NoError(t, err)
-	gw, err := configurator.CreateEntity(context2.Background(), "n1", configurator.NetworkEntity{Type: lte.CellularGatewayEntityType, Key: "g1"}, serdes.Entity)
+	gw, err := configurator.CreateEntity(context.Background(), "n1", configurator.NetworkEntity{Type: lte.CellularGatewayEntityType, Key: "g1"}, serdes.Entity)
 	assert.NoError(t, err)
 
 	perSubDigests, err := subscriberdb.GetPerSubscriberDigests("n1")
@@ -264,7 +264,7 @@ func TestGetPerSubscriberDigests(t *testing.T) {
 	assert.Equal(t, []*protos.LeafDigest{}, perSubDigests)
 
 	// Generate individual digests for each newly detected subscriber in the network
-	_, err = configurator.CreateEntities(context2.Background(), "n1", configurator.NetworkEntities{
+	_, err = configurator.CreateEntities(context.Background(), "n1", configurator.NetworkEntities{
 		configurator.NetworkEntity{
 			Type: lte.SubscriberEntityType, Key: "IMSI00001",
 			Config: &models.SubscriberConfig{
@@ -293,18 +293,18 @@ func TestGetPerSubscriberDigests(t *testing.T) {
 	assert.NotEmpty(t, perSubDigests[1].Digest.Md5Base64Digest)
 	digestSub1 := perSubDigests[0].Digest.Md5Base64Digest
 
-	_, err = configurator.CreateEntity(context2.Background(), "n1", configurator.NetworkEntity{
+	_, err = configurator.CreateEntity(context.Background(), "n1", configurator.NetworkEntity{
 		Type: lte.SubscriberEntityType, Key: "IMSI00003",
 		Config: &models.SubscriberConfig{
 			Lte: &models.LteSubscription{State: "ACTIVE"},
 		},
 	}, serdes.Entity)
 	assert.NoError(t, err)
-	err = configurator.DeleteEntity(context2.Background(), "n1", lte.SubscriberEntityType, "IMSI00001")
+	err = configurator.DeleteEntity(context.Background(), "n1", lte.SubscriberEntityType, "IMSI00001")
 	assert.NoError(t, err)
-	err = configurator.DeleteEntity(context2.Background(), "n1", lte.SubscriberEntityType, "IMSI00002")
+	err = configurator.DeleteEntity(context.Background(), "n1", lte.SubscriberEntityType, "IMSI00002")
 	assert.NoError(t, err)
-	_, err = configurator.CreateEntity(context2.Background(), "n1", configurator.NetworkEntity{
+	_, err = configurator.CreateEntity(context.Background(), "n1", configurator.NetworkEntity{
 		Type: lte.SubscriberEntityType, Key: "IMSI00001",
 		Config: &models.SubscriberConfig{
 			Lte: &models.LteSubscription{State: "INACTIVE"},
@@ -343,7 +343,7 @@ func TestGetPerSubscriberDigests(t *testing.T) {
 		AssociationsToAdd: storage.TKs{{Type: lte.APNResourceEntityType, Key: "resource"}},
 	}
 	writes = append(writes, write)
-	err = configurator.WriteEntities(context2.Background(), "n1", writes, serdes.Entity)
+	err = configurator.WriteEntities(context.Background(), "n1", writes, serdes.Entity)
 	assert.NoError(t, err)
 
 	// Detect changes in apn resources data and reflect them in the ENTIRE set of generated digests

--- a/lte/cloud/go/services/subscriberdb/servicers/indexer_servicer_test.go
+++ b/lte/cloud/go/services/subscriberdb/servicers/indexer_servicer_test.go
@@ -14,7 +14,7 @@ limitations under the License.
 package servicers_test
 
 import (
-	context2 "context"
+	"context"
 	"encoding/base64"
 	"net"
 	"testing"
@@ -66,10 +66,10 @@ func TestIndexerIP(t *testing.T) {
 	errs, err := idx.Index("nid0", states)
 	assert.NoError(t, err)
 	assert.Empty(t, errs)
-	gotA, err := subscriberdb.GetIMSIsForIP(context2.Background(), "nid0", "127.0.0.1")
+	gotA, err := subscriberdb.GetIMSIsForIP(context.Background(), "nid0", "127.0.0.1")
 	assert.NoError(t, err)
 	assert.Equal(t, []string{"IMSI0", "IMSI1"}, gotA)
-	gotB, err := subscriberdb.GetIMSIsForIP(context2.Background(), "nid0", "127.0.0.2")
+	gotB, err := subscriberdb.GetIMSIsForIP(context.Background(), "nid0", "127.0.0.2")
 	assert.NoError(t, err)
 	assert.Equal(t, []string{"IMSI1"}, gotB)
 
@@ -81,7 +81,7 @@ func TestIndexerIP(t *testing.T) {
 	errs, err = idx.Index("nid0", states)
 	assert.NoError(t, err)
 	assert.Error(t, errs[id2])
-	gotC, err := subscriberdb.GetIMSIsForIP(context2.Background(), "nid0", "127.0.0.3")
+	gotC, err := subscriberdb.GetIMSIsForIP(context.Background(), "nid0", "127.0.0.3")
 	assert.NoError(t, err)
 	assert.Equal(t, []string{"IMSI0"}, gotC)
 }

--- a/lte/cloud/go/services/subscriberdb_cache/worker_test.go
+++ b/lte/cloud/go/services/subscriberdb_cache/worker_test.go
@@ -14,14 +14,13 @@ limitations under the License.
 package subscriberdb_cache_test
 
 import (
-	context2 "context"
+	"context"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/golang/protobuf/proto"
 	"github.com/stretchr/testify/assert"
-	"golang.org/x/net/context"
 
 	"magma/lte/cloud/go/lte"
 	lte_protos "magma/lte/cloud/go/protos"
@@ -65,7 +64,7 @@ func TestSubscriberdbCacheWorker(t *testing.T) {
 	assert.Empty(t, subProtos)
 	assert.Empty(t, nextToken)
 
-	err = configurator.CreateNetwork(context2.Background(), configurator.Network{ID: "n1"}, serdes.Network)
+	err = configurator.CreateNetwork(context.Background(), configurator.Network{ID: "n1"}, serdes.Network)
 	assert.NoError(t, err)
 
 	_, _, err = subscriberdb_cache.RenewDigests(serviceConfig, store)
@@ -81,7 +80,7 @@ func TestSubscriberdbCacheWorker(t *testing.T) {
 	rootDigestExpected := digestTree.RootDigest.GetMd5Base64Digest()
 
 	// Detect outdated digests and update
-	_, err = configurator.CreateEntities(context2.Background(), "n1", []configurator.NetworkEntity{
+	_, err = configurator.CreateEntities(context.Background(), "n1", []configurator.NetworkEntity{
 		{
 			Type: lte.APNEntityType, Key: "apn1",
 			Config: &lte_models.ApnConfiguration{},
@@ -195,7 +194,7 @@ func TestUpdateSubProtosByNetworkNoChange(t *testing.T) {
 
 	err := configurator.CreateNetwork(context.Background(), configurator.Network{ID: "n1"}, serdes.Network)
 	assert.NoError(t, err)
-	_, err = configurator.CreateEntities(context2.Background(), "n1", []configurator.NetworkEntity{
+	_, err = configurator.CreateEntities(context.Background(), "n1", []configurator.NetworkEntity{
 		{Type: lte.APNEntityType, Key: "apn1", Config: &lte_models.ApnConfiguration{}},
 		{Type: lte.SubscriberEntityType, Key: "IMSI00001", Config: &models.SubscriberConfig{Lte: &models.LteSubscription{State: "ACTIVE"}}},
 		{Type: lte.SubscriberEntityType, Key: "IMSI00002", Config: &models.SubscriberConfig{Lte: &models.LteSubscription{State: "ACTIVE"}}},
@@ -218,7 +217,7 @@ func TestUpdateSubProtosByNetworkNoChange(t *testing.T) {
 
 	// If the generated root digest matches the one in store, the update for cached subscribers wouldn't be triggered
 	err = configurator.DeleteEntities(
-		context2.Background(),
+		context.Background(),
 		"n1",
 		storage2.MakeTKs(lte.SubscriberEntityType, []string{"IMSI00001", "IMSI00002", "IMSI00003"}),
 	)

--- a/orc8r/cloud/go/obsidian/access/tests/utils.go
+++ b/orc8r/cloud/go/obsidian/access/tests/utils.go
@@ -25,7 +25,6 @@ import (
 
 	"github.com/labstack/echo"
 	"github.com/stretchr/testify/assert"
-	context2 "golang.org/x/net/context"
 
 	"magma/orc8r/cloud/go/identity"
 	"magma/orc8r/cloud/go/obsidian/access"
@@ -104,7 +103,7 @@ func StartMockAccessControl(t *testing.T, adminId string) string {
 	csrMsg, err := certifier_test_utils.CreateCSR(
 		time.Hour*4, adminId, adminId)
 	assert.NoError(t, err)
-	certMsg, err := certifier.SignCSR(context2.Background(), csrMsg)
+	certMsg, err := certifier.SignCSR(context.Background(), csrMsg)
 	assert.NoError(t, err, "Failed to sign Admin's CSR")
 	// get sn from cert
 	superCert, err := x509.ParseCertificates(certMsg.CertDer)
@@ -160,7 +159,7 @@ func MockAccessControl(t *testing.T) (certSn string, superCertSn string) {
 	csrMsg, err := certifier_test_utils.CreateCSR(
 		time.Hour*12, TEST_OPERATOR_ID, TEST_OPERATOR_ID)
 	assert.NoError(t, err)
-	certMsg, err := certifier.SignCSR(context2.Background(), csrMsg)
+	certMsg, err := certifier.SignCSR(context.Background(), csrMsg)
 	assert.NoError(t, err, "Failed to sign CSR")
 	// get sn from cert
 	cert, err := x509.ParseCertificates(certMsg.CertDer)

--- a/orc8r/cloud/go/service/middleware/unary/identity_decorator.go
+++ b/orc8r/cloud/go/service/middleware/unary/identity_decorator.go
@@ -15,13 +15,13 @@
 package unary
 
 import (
+	"context"
 	"net"
 	"time"
 
 	"github.com/golang/glog"
 	"github.com/golang/protobuf/ptypes"
 	"github.com/prometheus/client_golang/prometheus"
-	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"

--- a/orc8r/cloud/go/service/middleware/unary/identity_decorator_test.go
+++ b/orc8r/cloud/go/service/middleware/unary/identity_decorator_test.go
@@ -14,14 +14,13 @@
 package unary_test
 
 import (
-	context2 "context"
+	"context"
 	"net"
 	"testing"
 	"time"
 
 	"github.com/golang/protobuf/proto"
 	"github.com/stretchr/testify/assert"
-	"golang.org/x/net/context"
 	"google.golang.org/grpc/metadata"
 
 	"magma/orc8r/cloud/go/orc8r"
@@ -175,7 +174,7 @@ func TestIdentityInjector(t *testing.T) {
 	// Unregister GW
 	assert.NoError(
 		t,
-		configurator.DeleteEntity(context2.Background(), networkID, orc8r.MagmadGatewayType, gwid.LogicalId))
+		configurator.DeleteEntity(context.Background(), networkID, orc8r.MagmadGatewayType, gwid.LogicalId))
 
 	ctx = metadata.NewOutgoingContext(
 		context.Background(),

--- a/orc8r/cloud/go/service/middleware/unary/interceptors.go
+++ b/orc8r/cloud/go/service/middleware/unary/interceptors.go
@@ -17,12 +17,12 @@ limitations under the License.
 package unary
 
 import (
+	"context"
 	"runtime/debug"
 
 	"github.com/golang/glog"
 	grpc_prometheus "github.com/grpc-ecosystem/go-grpc-prometheus"
 	"github.com/prometheus/client_golang/prometheus"
-	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"

--- a/orc8r/cloud/go/service/middleware/unary/registered_gw_enforcer.go
+++ b/orc8r/cloud/go/service/middleware/unary/registered_gw_enforcer.go
@@ -15,9 +15,9 @@
 package unary
 
 import (
+	"context"
 	"log"
 
-	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"

--- a/orc8r/cloud/go/service/middleware/unary/test/access.go
+++ b/orc8r/cloud/go/service/middleware/unary/test/access.go
@@ -14,13 +14,13 @@
 package test
 
 import (
+	"context"
 	"crypto/x509"
 	"sync"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
-	context2 "golang.org/x/net/context"
 
 	"magma/orc8r/cloud/go/identity"
 	"magma/orc8r/cloud/go/services/certifier"
@@ -49,7 +49,7 @@ func StartMockGwAccessControl(t *testing.T, hwGwIds []string) []string {
 			time.Hour*4, identity.NewGateway(hwId, "", ""))
 		assert.NoError(t, err)
 
-		certMsg, err := certifier.SignCSR(context2.Background(), csrMsg)
+		certMsg, err := certifier.SignCSR(context.Background(), csrMsg)
 		assert.NoError(t, err, "Failed to sign Gateway's CSR")
 		// get cert sn from cert
 		gwCert, err := x509.ParseCertificates(certMsg.CertDer)

--- a/orc8r/cloud/go/service/service_test.go
+++ b/orc8r/cloud/go/service/service_test.go
@@ -14,12 +14,12 @@ limitations under the License.
 package service_test
 
 import (
+	"context"
 	"flag"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
-	"golang.org/x/net/context"
 
 	"magma/orc8r/cloud/go/orc8r"
 	"magma/orc8r/cloud/go/services/state"

--- a/orc8r/cloud/go/services/accessd/servicers/accessd.go
+++ b/orc8r/cloud/go/services/accessd/servicers/accessd.go
@@ -18,7 +18,8 @@ check & manage Identity access permissions.
 package servicers
 
 import (
-	"golang.org/x/net/context"
+	"context"
+
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 

--- a/orc8r/cloud/go/services/bootstrapper/servicers/bootstrapper.go
+++ b/orc8r/cloud/go/services/bootstrapper/servicers/bootstrapper.go
@@ -15,6 +15,7 @@ package servicers
 
 import (
 	"bytes"
+	"context"
 	"crypto"
 	"crypto/ecdsa"
 	"crypto/rand"
@@ -29,7 +30,6 @@ import (
 
 	"github.com/golang/protobuf/ptypes"
 	"github.com/pkg/errors"
-	"golang.org/x/net/context"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"

--- a/orc8r/cloud/go/services/bootstrapper/servicers/bootstrapper_test.go
+++ b/orc8r/cloud/go/services/bootstrapper/servicers/bootstrapper_test.go
@@ -14,6 +14,7 @@ limitations under the License.
 package servicers_test
 
 import (
+	"context"
 	"crypto"
 	"crypto/ecdsa"
 	"crypto/rand"
@@ -31,7 +32,6 @@ import (
 	"github.com/emakeev/snowflake"
 	"github.com/go-openapi/strfmt"
 	"github.com/stretchr/testify/assert"
-	"golang.org/x/net/context"
 	"google.golang.org/grpc/metadata"
 
 	"magma/gateway/config"

--- a/orc8r/cloud/go/services/certifier/certifier/main.go
+++ b/orc8r/cloud/go/services/certifier/certifier/main.go
@@ -14,12 +14,12 @@ limitations under the License.
 package main
 
 import (
+	"context"
 	"flag"
 	"math/rand"
 	"time"
 
 	"github.com/golang/glog"
-	"golang.org/x/net/context"
 
 	"magma/orc8r/cloud/go/blobstore"
 	"magma/orc8r/cloud/go/orc8r"

--- a/orc8r/cloud/go/services/certifier/client_api.go
+++ b/orc8r/cloud/go/services/certifier/client_api.go
@@ -14,13 +14,13 @@ limitations under the License.
 package certifier
 
 import (
+	"context"
 	"errors"
 	"fmt"
 
 	"github.com/golang/glog"
 	"github.com/golang/protobuf/ptypes"
 	"github.com/golang/protobuf/ptypes/timestamp"
-	"golang.org/x/net/context"
 
 	"magma/orc8r/cloud/go/clock"
 	certifierprotos "magma/orc8r/cloud/go/services/certifier/protos"

--- a/orc8r/cloud/go/services/certifier/client_api_test.go
+++ b/orc8r/cloud/go/services/certifier/client_api_test.go
@@ -22,7 +22,6 @@ import (
 
 	"github.com/golang/protobuf/proto"
 	"github.com/stretchr/testify/assert"
-	context2 "golang.org/x/net/context"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 
@@ -40,7 +39,7 @@ func TestCertifier(t *testing.T) {
 	// create and sign csr
 	csrMsg, err := certifier_test_utils.CreateCSR(time.Hour*24*365, "cn", "cn")
 	assert.NoError(t, err)
-	certMsg, err := certifier.SignCSR(context2.Background(), csrMsg)
+	certMsg, err := certifier.SignCSR(context.Background(), csrMsg)
 	assert.NoError(t, err, "Failed to sign CSR")
 
 	firstCertDer := certMsg.CertDer
@@ -54,15 +53,15 @@ func TestCertifier(t *testing.T) {
 	}
 
 	// test get identity
-	certInfoMsg, err := certifier.GetIdentity(context2.Background(), snMsg)
+	certInfoMsg, err := certifier.GetIdentity(context.Background(), snMsg)
 	assert.NoError(t, err, "Error getting identity")
 	fmt.Printf("%+v\n", certInfoMsg)
 	assert.True(t, proto.Equal(certInfoMsg.Id, csrMsg.Id))
 
 	// test revoke cert
-	err = certifier.RevokeCertificate(context2.Background(), snMsg)
+	err = certifier.RevokeCertificate(context.Background(), snMsg)
 	assert.NoError(t, err, "Failed to revoke cert")
-	_, err = certifier.GetIdentity(context2.Background(), snMsg)
+	_, err = certifier.GetIdentity(context.Background(), snMsg)
 	assert.Error(t, err, "Error: no error getting revoked identity")
 
 	// test collect garbage
@@ -70,7 +69,7 @@ func TestCertifier(t *testing.T) {
 
 	csrMsg, err = certifier_test_utils.CreateCSR(time.Duration(0), "cn", "cn")
 	assert.NoError(t, err)
-	certMsg, err = certifier.SignCSR(context2.Background(), csrMsg)
+	certMsg, err = certifier.SignCSR(context.Background(), csrMsg)
 	assert.NoError(t, err, "Failed to sign CSR")
 	cert, err = x509.ParseCertificates(certMsg.CertDer)
 	assert.NoError(t, err, "Failed to parse cert")
@@ -78,9 +77,9 @@ func TestCertifier(t *testing.T) {
 		Sn: security_cert.SerialToString(cert[0].SerialNumber),
 	}
 
-	err = certifier.CollectGarbage(context2.Background())
+	err = certifier.CollectGarbage(context.Background())
 	assert.NoError(t, err, "Failed to collect garbage")
-	_, err = certifier.GetIdentity(context2.Background(), snMsg)
+	_, err = certifier.GetIdentity(context.Background(), snMsg)
 	assert.Equal(t, grpc.Code(err), codes.NotFound)
 
 	oper := protos.NewOperatorIdentity("testOperator")
@@ -88,26 +87,26 @@ func TestCertifier(t *testing.T) {
 		certifier.AddCertificate(context.Background(), oper, firstCertDer),
 		"Failed to Add Existing Cert")
 
-	certInfoMsg, err = certifier.GetCertificateIdentity(context2.Background(), security_cert.SerialToString(firstCertSN))
+	certInfoMsg, err = certifier.GetCertificateIdentity(context.Background(), security_cert.SerialToString(firstCertSN))
 	assert.NoError(t, err, "Error getting added cert identity")
 	if err == nil {
 		assert.Equal(t, oper.HashString(), certInfoMsg.Id.HashString())
 	}
 
-	sns, err := certifier.ListCertificates(context2.Background())
+	sns, err := certifier.ListCertificates(context.Background())
 	assert.NoError(t, err, "Error Listing Certificates")
 	assert.Equal(t, 1, len(sns))
 
 	csrMsg, err = certifier_test_utils.CreateCSR(time.Hour*2, "cn1", "cn1")
 	assert.NoError(t, err)
-	_, err = certifier.SignCSR(context2.Background(), csrMsg)
+	_, err = certifier.SignCSR(context.Background(), csrMsg)
 	assert.NoError(t, err, "Failed to sign CSR")
 
-	sns, err = certifier.ListCertificates(context2.Background())
+	sns, err = certifier.ListCertificates(context.Background())
 	assert.NoError(t, err, "Error Listing Certificates")
 	assert.Equal(t, 2, len(sns))
 
-	operSNs, err := certifier.FindCertificates(context2.Background(), oper)
+	operSNs, err := certifier.FindCertificates(context.Background(), oper)
 	assert.NoError(t, err, "Error Finding Operator Certificates")
 	assert.Equal(t, 1, len(operSNs))
 	if len(operSNs) > 0 {

--- a/orc8r/cloud/go/services/certifier/servicers/certifier.go
+++ b/orc8r/cloud/go/services/certifier/servicers/certifier.go
@@ -14,6 +14,7 @@ limitations under the License.
 package servicers
 
 import (
+	"context"
 	"crypto/rand"
 	"crypto/x509"
 	"fmt"
@@ -23,7 +24,6 @@ import (
 
 	"github.com/golang/glog"
 	"github.com/golang/protobuf/ptypes"
-	"golang.org/x/net/context"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 

--- a/orc8r/cloud/go/services/certifier/servicers/certifier_test.go
+++ b/orc8r/cloud/go/services/certifier/servicers/certifier_test.go
@@ -14,6 +14,7 @@ limitations under the License.
 package servicers_test
 
 import (
+	"context"
 	"crypto/x509"
 	"testing"
 	"time"
@@ -22,7 +23,6 @@ import (
 	"github.com/golang/protobuf/ptypes"
 	_ "github.com/mattn/go-sqlite3"
 	"github.com/stretchr/testify/assert"
-	"golang.org/x/net/context"
 
 	"magma/orc8r/cloud/go/blobstore"
 	"magma/orc8r/cloud/go/services/certifier/servicers"

--- a/orc8r/cloud/go/services/ctraced/obsidian/handlers/gateway_api.go
+++ b/orc8r/cloud/go/services/ctraced/obsidian/handlers/gateway_api.go
@@ -14,11 +14,11 @@ limitations under the License.
 package handlers
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/golang/glog"
 	"github.com/pkg/errors"
-	"golang.org/x/net/context"
 
 	"magma/orc8r/cloud/go/orc8r"
 	"magma/orc8r/cloud/go/services/configurator"

--- a/orc8r/cloud/go/services/ctraced/servicers/trace_servicer_test.go
+++ b/orc8r/cloud/go/services/ctraced/servicers/trace_servicer_test.go
@@ -14,11 +14,10 @@ limitations under the License.
 package servicers_test
 
 import (
-	context2 "context"
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"golang.org/x/net/context"
 
 	"magma/orc8r/cloud/go/orc8r"
 	"magma/orc8r/cloud/go/serdes"
@@ -41,7 +40,7 @@ func TestCallTraceServicer(t *testing.T) {
 	testGwLogicalId := "g1"
 
 	// Initialize network
-	err := configurator.CreateNetwork(context2.Background(), configurator.Network{ID: testNetworkId}, serdes.Network)
+	err := configurator.CreateNetwork(context.Background(), configurator.Network{ID: testNetworkId}, serdes.Network)
 	assert.NoError(t, err)
 
 	// Create a call trace
@@ -58,7 +57,7 @@ func TestCallTraceServicer(t *testing.T) {
 			CallTraceEnding:    false,
 		},
 	}
-	_, err = configurator.CreateEntity(context2.Background(), testNetworkId, configurator.NetworkEntity{
+	_, err = configurator.CreateEntity(context.Background(), testNetworkId, configurator.NetworkEntity{
 		Type:   orc8r.CallTraceEntityType,
 		Key:    "CallTrace1",
 		Config: testTrace,
@@ -86,7 +85,7 @@ func TestCallTraceServicer(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Verify that the call trace has ended
-	ent, err := configurator.LoadEntity(context2.Background(), testNetworkId, orc8r.CallTraceEntityType, "CallTrace1", configurator.FullEntityLoadCriteria(), serdes.Entity)
+	ent, err := configurator.LoadEntity(context.Background(), testNetworkId, orc8r.CallTraceEntityType, "CallTrace1", configurator.FullEntityLoadCriteria(), serdes.Entity)
 	testCallTrace := (&models.CallTrace{}).FromEntity(ent)
 	assert.NoError(t, err)
 	assert.Equal(t, true, testCallTrace.State.CallTraceAvailable)

--- a/orc8r/cloud/go/services/directoryd/servicers/servicer_test.go
+++ b/orc8r/cloud/go/services/directoryd/servicers/servicer_test.go
@@ -14,10 +14,10 @@ limitations under the License.
 package servicers_test
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"golang.org/x/net/context"
 
 	"magma/orc8r/cloud/go/blobstore"
 	"magma/orc8r/cloud/go/services/directoryd/servicers"

--- a/orc8r/cloud/go/services/dispatcher/gw_client_apis/service303/gw_service303_client_api.go
+++ b/orc8r/cloud/go/services/dispatcher/gw_client_apis/service303/gw_service303_client_api.go
@@ -14,11 +14,11 @@ limitations under the License.
 package service303
 
 import (
+	"context"
 	"errors"
 	"fmt"
 
 	"github.com/golang/glog"
-	"golang.org/x/net/context"
 
 	"magma/orc8r/cloud/go/services/dispatcher/gateway_registry"
 	"magma/orc8r/lib/go/protos"

--- a/orc8r/cloud/go/services/dispatcher/servicers/sync_rpc_service.go
+++ b/orc8r/cloud/go/services/dispatcher/servicers/sync_rpc_service.go
@@ -14,13 +14,13 @@ limitations under the License.
 package servicers
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"sync"
 	"time"
 
 	"github.com/golang/glog"
-	"golang.org/x/net/context"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 

--- a/orc8r/cloud/go/services/magmad/gateway_api.go
+++ b/orc8r/cloud/go/services/magmad/gateway_api.go
@@ -15,11 +15,11 @@ limitations under the License.
 package magmad
 
 import (
+	"context"
 	"errors"
 	"fmt"
 
 	"github.com/golang/glog"
-	"golang.org/x/net/context"
 
 	"magma/orc8r/cloud/go/orc8r"
 	"magma/orc8r/cloud/go/services/configurator"

--- a/orc8r/cloud/go/services/metricsd/prometheus/handlers/promo_handlers_test.go
+++ b/orc8r/cloud/go/services/metricsd/prometheus/handlers/promo_handlers_test.go
@@ -14,7 +14,7 @@ limitations under the License.
 package handlers
 
 import (
-	context2 "context"
+	"context"
 	"errors"
 	"net/http"
 	"net/http/httptest"
@@ -132,7 +132,7 @@ func TestGetPrometheusQueryHandler(t *testing.T) {
 
 func TestGetTenantQueryHandler(t *testing.T) {
 	tenants_test_init.StartTestService(t)
-	tenants.CreateTenant(context2.Background(), 0, &protos.Tenant{
+	tenants.CreateTenant(context.Background(), 0, &protos.Tenant{
 		Name:     "0",
 		Networks: []string{"test"},
 	})
@@ -227,7 +227,7 @@ func TestGetPrometheusQueryRangeHandler(t *testing.T) {
 
 func TestGetTenantQueryRangeHandler(t *testing.T) {
 	tenants_test_init.StartTestService(t)
-	tenants.CreateTenant(context2.Background(), 0, &protos.Tenant{
+	tenants.CreateTenant(context.Background(), 0, &protos.Tenant{
 		Name:     "0",
 		Networks: []string{"test"},
 	})
@@ -317,7 +317,7 @@ func TestGetPrometheusSeriesHandler(t *testing.T) {
 
 func TestGetTenantPromSeriesHandler(t *testing.T) {
 	tenants_test_init.StartTestService(t)
-	tenants.CreateTenant(context2.Background(), 0, &protos.Tenant{
+	tenants.CreateTenant(context.Background(), 0, &protos.Tenant{
 		Name:     "0",
 		Networks: []string{"test"},
 	})
@@ -396,7 +396,7 @@ func TestGetTenantPromSeriesHandler(t *testing.T) {
 
 func TestGetTenantPromValuesHandler(t *testing.T) {
 	tenants_test_init.StartTestService(t)
-	tenants.CreateTenant(context2.Background(), 0, &protos.Tenant{
+	tenants.CreateTenant(context.Background(), 0, &protos.Tenant{
 		Name:     "0",
 		Networks: []string{"test"},
 	})
@@ -535,7 +535,7 @@ func TestGetSeriesMatches(t *testing.T) {
 
 func TestTenantSeriesHandlerProvider(t *testing.T) {
 	tenants_test_init.StartTestService(t)
-	tenants.CreateTenant(context2.Background(), 0, &protos.Tenant{
+	tenants.CreateTenant(context.Background(), 0, &protos.Tenant{
 		Name:     "0",
 		Networks: []string{"test"},
 	})

--- a/orc8r/cloud/go/services/metricsd/servicers/servicer.go
+++ b/orc8r/cloud/go/services/metricsd/servicers/servicer.go
@@ -14,12 +14,12 @@ limitations under the License.
 package servicers
 
 import (
+	"context"
 	"time"
 
 	"github.com/golang/glog"
 	"github.com/pkg/errors"
 	prom_proto "github.com/prometheus/client_model/go"
-	"golang.org/x/net/context"
 
 	"magma/orc8r/cloud/go/serdes"
 	"magma/orc8r/cloud/go/services/configurator"

--- a/orc8r/cloud/go/services/metricsd/servicers/servicer_test.go
+++ b/orc8r/cloud/go/services/metricsd/servicers/servicer_test.go
@@ -14,6 +14,7 @@ limitations under the License.
 package servicers_test
 
 import (
+	"context"
 	"errors"
 	"flag"
 	"strconv"
@@ -23,7 +24,6 @@ import (
 	"github.com/golang/glog"
 	dto "github.com/prometheus/client_model/go"
 	"github.com/stretchr/testify/assert"
-	"golang.org/x/net/context"
 
 	configurator_test_init "magma/orc8r/cloud/go/services/configurator/test_init"
 	"magma/orc8r/cloud/go/services/configurator/test_utils"

--- a/orc8r/cloud/go/services/orchestrator/analytics/calculations/state_test.go
+++ b/orc8r/cloud/go/services/orchestrator/analytics/calculations/state_test.go
@@ -1,7 +1,7 @@
 package calculations_test
 
 import (
-	context2 "context"
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -21,10 +21,10 @@ import (
 func TestSiteCalculations(t *testing.T) {
 	configurator_test_init.StartTestService(t)
 	state_test_init.StartTestService(t)
-	err := configurator.CreateNetwork(context2.Background(), configurator.Network{ID: "n0"}, serdes.Network)
+	err := configurator.CreateNetwork(context.Background(), configurator.Network{ID: "n0"}, serdes.Network)
 	assert.NoError(t, err)
 
-	_, err = configurator.CreateEntity(context2.Background(), "n0", configurator.NetworkEntity{
+	_, err = configurator.CreateEntity(context.Background(), "n0", configurator.NetworkEntity{
 		Type:       orc8r.MagmadGatewayType,
 		Key:        "g0",
 		Config:     &models.MagmadGatewayConfigs{},
@@ -61,10 +61,10 @@ func TestSiteCalculations(t *testing.T) {
 func TestNetworkCalculations(t *testing.T) {
 	configurator_test_init.StartTestService(t)
 	state_test_init.StartTestService(t)
-	configurator.CreateNetwork(context2.Background(), configurator.Network{ID: "n0_1", Type: "LTE"}, serdes.Network)
-	configurator.CreateNetwork(context2.Background(), configurator.Network{ID: "n1", Type: "FEG_LTE"}, serdes.Network)
-	configurator.CreateNetwork(context2.Background(), configurator.Network{ID: "n2_0", Type: "FEG"}, serdes.Network)
-	configurator.CreateNetwork(context2.Background(), configurator.Network{ID: "n2_2", Type: "FEG"}, serdes.Network)
+	configurator.CreateNetwork(context.Background(), configurator.Network{ID: "n0_1", Type: "LTE"}, serdes.Network)
+	configurator.CreateNetwork(context.Background(), configurator.Network{ID: "n1", Type: "FEG_LTE"}, serdes.Network)
+	configurator.CreateNetwork(context.Background(), configurator.Network{ID: "n2_0", Type: "FEG"}, serdes.Network)
+	configurator.CreateNetwork(context.Background(), configurator.Network{ID: "n2_2", Type: "FEG"}, serdes.Network)
 	analyticsConfig := &calculations.AnalyticsConfig{
 		Metrics: map[string]calculations.MetricConfig{
 			metrics.NetworkTypeMetric: {

--- a/orc8r/cloud/go/services/orchestrator/obsidian/handlers/gateway_handler_factory_test.go
+++ b/orc8r/cloud/go/services/orchestrator/obsidian/handlers/gateway_handler_factory_test.go
@@ -14,7 +14,7 @@
 package handlers_test
 
 import (
-	context2 "context"
+	"context"
 	"fmt"
 	"testing"
 
@@ -62,13 +62,13 @@ func Test_GetPartialReadGatewayHandler(t *testing.T) {
 	}
 	tests.RunUnitTest(t, e, tc)
 
-	assert.NoError(t, configurator.CreateNetwork(context2.Background(), network, serdes.Network))
+	assert.NoError(t, configurator.CreateNetwork(context.Background(), network, serdes.Network))
 	gateway := configurator.NetworkEntity{
 		Key:  "gw1",
 		Type: orc8r.MagmadGatewayType,
 		Name: "gateway 1",
 	}
-	_, err := configurator.CreateEntity(context2.Background(), networkID, gateway, serdes.Entity)
+	_, err := configurator.CreateEntity(context.Background(), networkID, gateway, serdes.Entity)
 	assert.NoError(t, err)
 
 	tc = tests.Test{
@@ -113,13 +113,13 @@ func Test_GetPartialUpdateGatewayHandler(t *testing.T) {
 	}
 	tests.RunUnitTest(t, e, tc)
 
-	assert.NoError(t, configurator.CreateNetwork(context2.Background(), network, serdes.Network))
+	assert.NoError(t, configurator.CreateNetwork(context.Background(), network, serdes.Network))
 	Gateway := configurator.NetworkEntity{
 		Key:  "test_gateway_1",
 		Type: orc8r.MagmadGatewayType,
 		Name: "Gateway 1",
 	}
-	_, err := configurator.CreateEntity(context2.Background(), networkID, Gateway, serdes.Entity)
+	_, err := configurator.CreateEntity(context.Background(), networkID, Gateway, serdes.Entity)
 	assert.NoError(t, err)
 
 	// validation failure
@@ -146,7 +146,7 @@ func Test_GetPartialUpdateGatewayHandler(t *testing.T) {
 	}
 	tests.RunUnitTest(t, e, tc)
 
-	Gateway, err = configurator.LoadEntity(context2.Background(), networkID, orc8r.MagmadGatewayType, "test_gateway_1", configurator.EntityLoadCriteria{LoadMetadata: true}, serdes.Entity)
+	Gateway, err = configurator.LoadEntity(context.Background(), networkID, orc8r.MagmadGatewayType, "test_gateway_1", configurator.EntityLoadCriteria{LoadMetadata: true}, serdes.Entity)
 	assert.NoError(t, err)
 	assert.Equal(t, "updated Name!", Gateway.Name)
 }
@@ -194,7 +194,7 @@ type testName struct {
 	Name string
 }
 
-func (m *testName) ValidateModel(context2.Context) error {
+func (m *testName) ValidateModel(context.Context) error {
 	if m == nil {
 		return fmt.Errorf("Cannot be nil")
 	}
@@ -204,7 +204,7 @@ func (m *testName) ValidateModel(context2.Context) error {
 	return nil
 }
 
-func (m *testName) FromBackendModels(ctx context2.Context, networkID string, gatewayID string) error {
+func (m *testName) FromBackendModels(ctx context.Context, networkID string, gatewayID string) error {
 	entity, err := configurator.LoadEntity(
 		ctx,
 		networkID, orc8r.MagmadGatewayType, gatewayID,
@@ -218,7 +218,7 @@ func (m *testName) FromBackendModels(ctx context2.Context, networkID string, gat
 	return nil
 }
 
-func (m *testName) ToUpdateCriteria(ctx context2.Context, networkID string, gatewayID string) ([]configurator.EntityUpdateCriteria, error) {
+func (m *testName) ToUpdateCriteria(ctx context.Context, networkID string, gatewayID string) ([]configurator.EntityUpdateCriteria, error) {
 	exists, err := configurator.DoesEntityExist(ctx, networkID, orc8r.MagmadGatewayType, gatewayID)
 	if err != nil {
 		return nil, err

--- a/orc8r/cloud/go/services/orchestrator/obsidian/handlers/network_handler_factory_test.go
+++ b/orc8r/cloud/go/services/orchestrator/obsidian/handlers/network_handler_factory_test.go
@@ -14,7 +14,7 @@
 package handlers_test
 
 import (
-	context2 "context"
+	"context"
 	"encoding/json"
 	"fmt"
 	"testing"
@@ -54,7 +54,7 @@ func Test_GetPartialReadNetworkHandler(t *testing.T) {
 		Name:        "Test Network 1",
 		Description: "Test Network 1",
 	}
-	assert.NoError(t, configurator.CreateNetwork(context2.Background(), network, networkSerdes))
+	assert.NoError(t, configurator.CreateNetwork(context.Background(), network, networkSerdes))
 
 	networkURL := fmt.Sprintf("%s/%s", testURLRoot, networkID)
 
@@ -92,7 +92,7 @@ func Test_GetPartialReadNetworkHandler(t *testing.T) {
 			"test": &TestFeature1{ID: &ID{Name: "hello!"}, Desc: "goodbye!"},
 		},
 	}
-	assert.NoError(t, configurator.UpdateNetworks(context2.Background(), []configurator.NetworkUpdateCriteria{update}, networkSerdes))
+	assert.NoError(t, configurator.UpdateNetworks(context.Background(), []configurator.NetworkUpdateCriteria{update}, networkSerdes))
 
 	// happy full case
 	getFullConfig = handlers.GetPartialReadNetworkHandler(networkURL, &TestFeature1{}, networkSerdes)
@@ -138,7 +138,7 @@ func TestGetUpdateNetworkConfigHandler(t *testing.T) {
 		Description: "Test Network 1",
 		Configs:     map[string]interface{}{"test": &TestFeature1{ID: &ID{Name: "hello!"}, Desc: "goodbye!"}},
 	}
-	assert.NoError(t, configurator.CreateNetwork(context2.Background(), network, networkSerdes))
+	assert.NoError(t, configurator.CreateNetwork(context.Background(), network, networkSerdes))
 
 	networkURL := fmt.Sprintf("%s/%s", testURLRoot, networkID)
 
@@ -185,7 +185,7 @@ func TestGetUpdateNetworkConfigHandler(t *testing.T) {
 	}
 	tests.RunUnitTest(t, e, updateFullConfig)
 
-	config, err := configurator.LoadNetworkConfig(context2.Background(), networkID, "test", networkSerdes)
+	config, err := configurator.LoadNetworkConfig(context.Background(), networkID, "test", networkSerdes)
 	assert.NoError(t, err)
 	assert.Equal(t, expectedConfig, config)
 
@@ -202,7 +202,7 @@ func TestGetUpdateNetworkConfigHandler(t *testing.T) {
 	}
 	tests.RunUnitTest(t, e, updateFullConfig)
 
-	config, err = configurator.LoadNetworkConfig(context2.Background(), networkID, "test", networkSerdes)
+	config, err = configurator.LoadNetworkConfig(context.Background(), networkID, "test", networkSerdes)
 	assert.NoError(t, err)
 	assert.Equal(t, expectedConfig, config)
 }
@@ -222,7 +222,7 @@ func TestGetDeleteNetworkConfigHandler(t *testing.T) {
 		Description: "Test Network 1",
 		Configs:     map[string]interface{}{"test": &TestFeature1{ID: &ID{Name: "hello!"}, Desc: "goodbye!"}},
 	}
-	assert.NoError(t, configurator.CreateNetwork(context2.Background(), network, networkSerdes))
+	assert.NoError(t, configurator.CreateNetwork(context.Background(), network, networkSerdes))
 
 	networkURL := fmt.Sprintf("%s/%s", testURLRoot, networkID)
 
@@ -237,7 +237,7 @@ func TestGetDeleteNetworkConfigHandler(t *testing.T) {
 	}
 	tests.RunUnitTest(t, e, deleteTestConfig)
 
-	_, err := configurator.LoadNetworkConfig(context2.Background(), networkID, "test", networkSerdes)
+	_, err := configurator.LoadNetworkConfig(context.Background(), networkID, "test", networkSerdes)
 	assert.EqualError(t, err, errors.ErrNotFound.Error())
 }
 
@@ -251,7 +251,7 @@ func (m *ID) Validate(_ strfmt.Registry) error {
 	return fmt.Errorf("Name cannot be nil")
 }
 
-func (m *ID) ValidateModel(context2.Context) error {
+func (m *ID) ValidateModel(context.Context) error {
 	return m.Validate(strfmt.Default)
 }
 
@@ -279,7 +279,7 @@ func (m *TestFeature1) Validate(str strfmt.Registry) error {
 	return nil
 }
 
-func (m *TestFeature1) ValidateModel(context2.Context) error {
+func (m *TestFeature1) ValidateModel(context.Context) error {
 	return m.Validate(strfmt.Default)
 }
 

--- a/orc8r/cloud/go/services/orchestrator/obsidian/handlers/network_handlers_test.go
+++ b/orc8r/cloud/go/services/orchestrator/obsidian/handlers/network_handlers_test.go
@@ -14,7 +14,7 @@
 package handlers_test
 
 import (
-	context2 "context"
+	"context"
 	"fmt"
 	"testing"
 
@@ -74,7 +74,7 @@ func Test_GetNetworkHandlers(t *testing.T) {
 		ID:   "n1",
 		Name: networkName1,
 	}
-	err := configurator.CreateNetwork(context2.Background(), network1, serdes.Network)
+	err := configurator.CreateNetwork(context.Background(), network1, serdes.Network)
 	assert.NoError(t, err)
 
 	tc = tests.Test{
@@ -112,7 +112,7 @@ func Test_GetNetworkHandlers(t *testing.T) {
 		ID:                   "n1",
 		ConfigsToAddOrUpdate: map[string]interface{}{orc8r.NetworkFeaturesConfig: networkFeatures1},
 	}
-	err = configurator.UpdateNetworks(context2.Background(), []configurator.NetworkUpdateCriteria{update1}, serdes.Network)
+	err = configurator.UpdateNetworks(context.Background(), []configurator.NetworkUpdateCriteria{update1}, serdes.Network)
 	assert.NoError(t, err)
 
 	expectedNetwork1 = models.Network{
@@ -140,7 +140,7 @@ func Test_GetNetworkHandlers(t *testing.T) {
 		ID:                   "n1",
 		ConfigsToAddOrUpdate: map[string]interface{}{orc8r.NetworkSentryConfig: sentryConfig},
 	}
-	err = configurator.UpdateNetworks(context2.Background(), []configurator.NetworkUpdateCriteria{update1}, serdes.Network)
+	err = configurator.UpdateNetworks(context.Background(), []configurator.NetworkUpdateCriteria{update1}, serdes.Network)
 	assert.NoError(t, err)
 
 	expectedNetwork1 = models.Network{
@@ -171,7 +171,7 @@ func Test_GetNetworkHandlers(t *testing.T) {
 		NewDescription:       &description1,
 		ConfigsToAddOrUpdate: map[string]interface{}{orc8r.DnsdNetworkType: dnsdConfig},
 	}
-	err = configurator.UpdateNetworks(context2.Background(), []configurator.NetworkUpdateCriteria{update1}, serdes.Network)
+	err = configurator.UpdateNetworks(context.Background(), []configurator.NetworkUpdateCriteria{update1}, serdes.Network)
 	assert.NoError(t, err)
 
 	expectedNetwork1 = models.Network{
@@ -203,7 +203,7 @@ func Test_GetNetworkHandlers(t *testing.T) {
 		ID:   networkID2,
 		Name: networkName2,
 	}
-	err = configurator.CreateNetwork(context2.Background(), network2, serdes.Network)
+	err = configurator.CreateNetwork(context.Background(), network2, serdes.Network)
 	assert.NoError(t, err)
 
 	tc = tests.Test{
@@ -328,7 +328,7 @@ func Test_PostNetworkHandlers(t *testing.T) {
 	}
 	tests.RunUnitTest(t, e, tc)
 
-	actualNetwork1, err := configurator.LoadNetwork(context2.Background(), "n1", true, true, serdes.Network)
+	actualNetwork1, err := configurator.LoadNetwork(context.Background(), "n1", true, true, serdes.Network)
 	assert.NoError(t, err)
 	expectedNetwork1 := configurator.Network{
 		ID:          string(network1.ID),
@@ -646,7 +646,7 @@ func Test_PutNetworkMetadataHandlers(t *testing.T) {
 	}
 	tests.RunUnitTest(t, e, tc)
 
-	actualNetwork, err := configurator.LoadNetwork(context2.Background(), "n1", true, false, serdes.Network)
+	actualNetwork, err := configurator.LoadNetwork(context.Background(), "n1", true, false, serdes.Network)
 	assert.NoError(t, err)
 	expectedNetwork1.Version = 1
 	expectedNetwork1.Name = "new_name"
@@ -663,7 +663,7 @@ func Test_PutNetworkMetadataHandlers(t *testing.T) {
 		ExpectedStatus: 204,
 	}
 	tests.RunUnitTest(t, e, tc)
-	actualNetwork, err = configurator.LoadNetwork(context2.Background(), "n1", true, false, serdes.Network)
+	actualNetwork, err = configurator.LoadNetwork(context.Background(), "n1", true, false, serdes.Network)
 	assert.NoError(t, err)
 	expectedNetwork1.Type = "new_type"
 	expectedNetwork1.Version = 2
@@ -681,7 +681,7 @@ func Test_PutNetworkMetadataHandlers(t *testing.T) {
 	}
 	tests.RunUnitTest(t, e, putNetworkDesc)
 
-	actualNetwork, err = configurator.LoadNetwork(context2.Background(), "n1", true, false, serdes.Network)
+	actualNetwork, err = configurator.LoadNetwork(context.Background(), "n1", true, false, serdes.Network)
 	assert.NoError(t, err)
 	expectedNetwork1.Description = "new_name"
 	expectedNetwork1.Version = 3
@@ -740,7 +740,7 @@ func Test_PutNetworkFeaturesHandlers(t *testing.T) {
 		ExpectedStatus: 204,
 	}
 	tests.RunUnitTest(t, e, tc)
-	config, err := configurator.LoadNetworkConfig(context2.Background(), "n1", orc8r.NetworkFeaturesConfig, serdes.Network)
+	config, err := configurator.LoadNetworkConfig(context.Background(), "n1", orc8r.NetworkFeaturesConfig, serdes.Network)
 	assert.NoError(t, err)
 	assert.Equal(t, newFeatures, config)
 }
@@ -870,7 +870,7 @@ func Test_PutNetworkDNSHandlers(t *testing.T) {
 	}
 	tests.RunUnitTest(t, e, tc)
 
-	config, err := configurator.LoadNetworkConfig(context2.Background(), "n1", orc8r.DnsdNetworkType, serdes.Network)
+	config, err := configurator.LoadNetworkConfig(context.Background(), "n1", orc8r.DnsdNetworkType, serdes.Network)
 	assert.NoError(t, err)
 	assert.Equal(t, newDNS, config)
 
@@ -893,7 +893,7 @@ func Test_PutNetworkDNSHandlers(t *testing.T) {
 		ExpectedStatus: 204,
 	}
 	tests.RunUnitTest(t, e, tc)
-	config, err = configurator.LoadNetworkConfig(context2.Background(), "n1", orc8r.DnsdNetworkType, serdes.Network)
+	config, err = configurator.LoadNetworkConfig(context.Background(), "n1", orc8r.DnsdNetworkType, serdes.Network)
 	assert.NoError(t, err)
 	assert.Equal(t, models.NetworkDNSRecords(records), config.(*models.NetworkDNSConfig).Records)
 
@@ -933,7 +933,7 @@ func Test_PutNetworkDNSHandlers(t *testing.T) {
 		ExpectedStatus: 204,
 	}
 	tests.RunUnitTest(t, e, tc)
-	config, err = configurator.LoadNetworkConfig(context2.Background(), "n1", orc8r.DnsdNetworkType, serdes.Network)
+	config, err = configurator.LoadNetworkConfig(context.Background(), "n1", orc8r.DnsdNetworkType, serdes.Network)
 	assert.NoError(t, err)
 	assert.Equal(t, record, config.(*models.NetworkDNSConfig).Records[0])
 
@@ -949,7 +949,7 @@ func Test_PutNetworkDNSHandlers(t *testing.T) {
 		ExpectedStatus: 204,
 	}
 	tests.RunUnitTest(t, e, tc)
-	config, err = configurator.LoadNetworkConfig(context2.Background(), "n1", orc8r.DnsdNetworkType, serdes.Network)
+	config, err = configurator.LoadNetworkConfig(context.Background(), "n1", orc8r.DnsdNetworkType, serdes.Network)
 	assert.NoError(t, err)
 	assert.Empty(t, config.(*models.NetworkDNSConfig).Records)
 }
@@ -1039,7 +1039,7 @@ func Test_DeleteNetworkDNSHandlers(t *testing.T) {
 	}
 	tests.RunUnitTest(t, e, tc)
 
-	config, err := configurator.LoadNetworkConfig(context2.Background(), "n1", orc8r.DnsdNetworkType, serdes.Network)
+	config, err := configurator.LoadNetworkConfig(context.Background(), "n1", orc8r.DnsdNetworkType, serdes.Network)
 	assert.NoError(t, err)
 	dnsConfig := config.(*models.NetworkDNSConfig)
 	assert.Empty(t, dnsConfig.Records)
@@ -1054,13 +1054,13 @@ func Test_DeleteNetworkDNSHandlers(t *testing.T) {
 	}
 	tests.RunUnitTest(t, e, tc)
 
-	_, err = configurator.LoadNetworkConfig(context2.Background(), "n1", orc8r.DnsdNetworkType, serdes.Network)
+	_, err = configurator.LoadNetworkConfig(context.Background(), "n1", orc8r.DnsdNetworkType, serdes.Network)
 	assert.EqualError(t, err, "Not found")
 
 }
 
 func seedNetworks(t *testing.T) {
-	_, err := configurator.CreateNetworks(context2.Background(), []configurator.Network{
+	_, err := configurator.CreateNetworks(context.Background(), []configurator.Network{
 		{
 			ID:          "n1",
 			Type:        "type1",

--- a/orc8r/cloud/go/services/orchestrator/obsidian/handlers/upgrade_handlers_test.go
+++ b/orc8r/cloud/go/services/orchestrator/obsidian/handlers/upgrade_handlers_test.go
@@ -14,13 +14,12 @@
 package handlers_test
 
 import (
-	context2 "context"
+	"context"
 	"testing"
 
 	"github.com/go-openapi/swag"
 	"github.com/labstack/echo"
 	"github.com/stretchr/testify/assert"
-	"golang.org/x/net/context"
 
 	models1 "magma/orc8r/cloud/go/models"
 	"magma/orc8r/cloud/go/obsidian"
@@ -54,7 +53,7 @@ func Test_ListReleaseChannels(t *testing.T) {
 	tests.RunUnitTest(t, e, tc)
 
 	// add a channel
-	_, err := configurator.CreateInternalEntity(context2.Background(), configurator.NetworkEntity{
+	_, err := configurator.CreateInternalEntity(context.Background(), configurator.NetworkEntity{
 		Type: orc8r.UpgradeReleaseChannelEntityType, Key: "channel1",
 		Config: &models.ReleaseChannel{
 			ID:                "channel1",
@@ -145,7 +144,7 @@ func Test_ReleaseChannel(t *testing.T) {
 	tests.RunUnitTest(t, e, tc)
 
 	// add a channel
-	_, err := configurator.CreateInternalEntity(context2.Background(), configurator.NetworkEntity{
+	_, err := configurator.CreateInternalEntity(context.Background(), configurator.NetworkEntity{
 		Type: orc8r.UpgradeReleaseChannelEntityType, Key: "channel1",
 		Config: &models.ReleaseChannel{
 			ID:                "channel1",
@@ -228,7 +227,7 @@ func Test_Tiers(t *testing.T) {
 	readTier := tests.GetHandlerByPathAndMethod(t, obsidianHandlers, manageTiers, obsidian.GET).HandlerFunc
 	deleteTier := tests.GetHandlerByPathAndMethod(t, obsidianHandlers, manageTiers, obsidian.DELETE).HandlerFunc
 
-	assert.NoError(t, configurator.CreateNetwork(context2.Background(), configurator.Network{ID: "n1"}, serdes.Network))
+	assert.NoError(t, configurator.CreateNetwork(context.Background(), configurator.Network{ID: "n1"}, serdes.Network))
 
 	// happy case list
 	tc := tests.Test{
@@ -286,7 +285,7 @@ func Test_Tiers(t *testing.T) {
 	}
 	tests.RunUnitTest(t, e, tc)
 
-	entities, _, err := configurator.LoadEntities(context2.Background(), "n1", swag.String(orc8r.UpgradeTierEntityType), nil, nil, nil, configurator.FullEntityLoadCriteria(), serdes.Entity)
+	entities, _, err := configurator.LoadEntities(context.Background(), "n1", swag.String(orc8r.UpgradeTierEntityType), nil, nil, nil, configurator.FullEntityLoadCriteria(), serdes.Entity)
 	assert.NoError(t, err)
 	expected := configurator.NetworkEntitiesByTK{
 		storage.TypeAndKey{Type: orc8r.UpgradeTierEntityType, Key: "tier1"}: {
@@ -322,7 +321,7 @@ func Test_Tiers(t *testing.T) {
 		{Type: orc8r.MagmadGatewayType, Key: "g2"},
 		{Type: orc8r.UpgradeTierEntityType, Key: "tier1"},
 	}
-	entities, _, err = configurator.LoadEntities(context2.Background(), "n1", nil, nil, nil, entitiesToQuery, configurator.FullEntityLoadCriteria(), serdes.Entity)
+	entities, _, err = configurator.LoadEntities(context.Background(), "n1", nil, nil, nil, entitiesToQuery, configurator.FullEntityLoadCriteria(), serdes.Entity)
 	assert.NoError(t, err)
 	expected = configurator.NetworkEntitiesByTK{
 		storage.TypeAndKey{Type: orc8r.UpgradeTierEntityType, Key: "tier1"}: {
@@ -400,7 +399,7 @@ func Test_Tiers(t *testing.T) {
 	}
 	tests.RunUnitTest(t, e, tc)
 
-	entities, _, err = configurator.LoadEntities(context2.Background(), "n1", nil, nil, nil, entitiesToQuery, configurator.FullEntityLoadCriteria(), serdes.Entity)
+	entities, _, err = configurator.LoadEntities(context.Background(), "n1", nil, nil, nil, entitiesToQuery, configurator.FullEntityLoadCriteria(), serdes.Entity)
 	assert.NoError(t, err)
 	expected = configurator.NetworkEntitiesByTK{
 		storage.TypeAndKey{Type: orc8r.MagmadGatewayType, Key: "g1"}: {
@@ -437,7 +436,7 @@ func TestPartialTierReads(t *testing.T) {
 		Version:  "1-1-1-1",
 	}
 
-	_, err := configurator.CreateEntity(context2.Background(), "n1", configurator.NetworkEntity{
+	_, err := configurator.CreateEntity(context.Background(), "n1", configurator.NetworkEntity{
 		Type: orc8r.UpgradeTierEntityType, Key: "tier1",
 		Name:         string(tier.Name),
 		Config:       tier,
@@ -532,7 +531,7 @@ func TestPartialTierUpdates(t *testing.T) {
 		Version:  "1-1-1-1",
 	}
 
-	_, err := configurator.CreateEntity(context2.Background(), "n1", configurator.NetworkEntity{
+	_, err := configurator.CreateEntity(context.Background(), "n1", configurator.NetworkEntity{
 		Type: orc8r.UpgradeTierEntityType, Key: "tier1",
 		Name:         string(tier.Name),
 		Config:       tier,
@@ -571,7 +570,7 @@ func TestPartialTierUpdates(t *testing.T) {
 		GraphID:      "2",
 		Version:      1,
 	}
-	actualTier, err := configurator.LoadEntity(context2.Background(), "n1", orc8r.UpgradeTierEntityType, "tier1", configurator.EntityLoadCriteria{LoadAssocsFromThis: true, LoadConfig: true, LoadMetadata: true}, serdes.Entity)
+	actualTier, err := configurator.LoadEntity(context.Background(), "n1", orc8r.UpgradeTierEntityType, "tier1", configurator.EntityLoadCriteria{LoadAssocsFromThis: true, LoadConfig: true, LoadMetadata: true}, serdes.Entity)
 	assert.NoError(t, err)
 	assert.Equal(t, expectedTier, actualTier)
 
@@ -597,7 +596,7 @@ func TestPartialTierUpdates(t *testing.T) {
 		GraphID:      "2",
 		Version:      2,
 	}
-	actualTier, err = configurator.LoadEntity(context2.Background(), "n1", orc8r.UpgradeTierEntityType, "tier1", configurator.EntityLoadCriteria{LoadAssocsFromThis: true, LoadConfig: true, LoadMetadata: true}, serdes.Entity)
+	actualTier, err = configurator.LoadEntity(context.Background(), "n1", orc8r.UpgradeTierEntityType, "tier1", configurator.EntityLoadCriteria{LoadAssocsFromThis: true, LoadConfig: true, LoadMetadata: true}, serdes.Entity)
 	assert.NoError(t, err)
 	assert.Equal(t, expectedTier, actualTier)
 
@@ -623,7 +622,7 @@ func TestPartialTierUpdates(t *testing.T) {
 		GraphID:      "2",
 		Version:      3,
 	}
-	actualTier, err = configurator.LoadEntity(context2.Background(), "n1", orc8r.UpgradeTierEntityType, "tier1", configurator.EntityLoadCriteria{LoadAssocsFromThis: true, LoadConfig: true, LoadMetadata: true}, serdes.Entity)
+	actualTier, err = configurator.LoadEntity(context.Background(), "n1", orc8r.UpgradeTierEntityType, "tier1", configurator.EntityLoadCriteria{LoadAssocsFromThis: true, LoadConfig: true, LoadMetadata: true}, serdes.Entity)
 	assert.NoError(t, err)
 	assert.Equal(t, expectedTier, actualTier)
 
@@ -651,7 +650,7 @@ func TestPartialTierUpdates(t *testing.T) {
 		GraphID: "2",
 		Version: 4,
 	}
-	actualTier, err = configurator.LoadEntity(context2.Background(), "n1", orc8r.UpgradeTierEntityType, "tier1", configurator.EntityLoadCriteria{LoadAssocsFromThis: true, LoadConfig: true, LoadMetadata: true}, serdes.Entity)
+	actualTier, err = configurator.LoadEntity(context.Background(), "n1", orc8r.UpgradeTierEntityType, "tier1", configurator.EntityLoadCriteria{LoadAssocsFromThis: true, LoadConfig: true, LoadMetadata: true}, serdes.Entity)
 	assert.NoError(t, err)
 	assert.Equal(t, expectedTier, actualTier)
 
@@ -680,7 +679,7 @@ func TestPartialTierUpdates(t *testing.T) {
 		GraphID: "2",
 		Version: 5,
 	}
-	actualTier, err = configurator.LoadEntity(context2.Background(), "n1", orc8r.UpgradeTierEntityType, "tier1", configurator.EntityLoadCriteria{LoadAssocsFromThis: true, LoadConfig: true, LoadMetadata: true}, serdes.Entity)
+	actualTier, err = configurator.LoadEntity(context.Background(), "n1", orc8r.UpgradeTierEntityType, "tier1", configurator.EntityLoadCriteria{LoadAssocsFromThis: true, LoadConfig: true, LoadMetadata: true}, serdes.Entity)
 	assert.NoError(t, err)
 	assert.Equal(t, expectedTier, actualTier)
 
@@ -720,7 +719,7 @@ func TestPartialTierUpdates(t *testing.T) {
 		GraphID: "2",
 		Version: 6,
 	}
-	actualTier, err = configurator.LoadEntity(context2.Background(), "n1", orc8r.UpgradeTierEntityType, "tier1", configurator.EntityLoadCriteria{LoadAssocsFromThis: true, LoadConfig: true, LoadMetadata: true}, serdes.Entity)
+	actualTier, err = configurator.LoadEntity(context.Background(), "n1", orc8r.UpgradeTierEntityType, "tier1", configurator.EntityLoadCriteria{LoadAssocsFromThis: true, LoadConfig: true, LoadMetadata: true}, serdes.Entity)
 	assert.NoError(t, err)
 	assert.Equal(t, expectedTier, actualTier)
 
@@ -762,7 +761,7 @@ func TestPartialTierUpdates(t *testing.T) {
 		GraphID: "2",
 		Version: 7,
 	}
-	actualTier, err = configurator.LoadEntity(context2.Background(), "n1", orc8r.UpgradeTierEntityType, "tier1", configurator.EntityLoadCriteria{LoadAssocsFromThis: true, LoadConfig: true, LoadMetadata: true}, serdes.Entity)
+	actualTier, err = configurator.LoadEntity(context.Background(), "n1", orc8r.UpgradeTierEntityType, "tier1", configurator.EntityLoadCriteria{LoadAssocsFromThis: true, LoadConfig: true, LoadMetadata: true}, serdes.Entity)
 	assert.NoError(t, err)
 	assert.Equal(t, expectedTier, actualTier)
 
@@ -789,7 +788,7 @@ func TestPartialTierUpdates(t *testing.T) {
 		GraphID: "2",
 		Version: 8,
 	}
-	actualTier, err = configurator.LoadEntity(context2.Background(), "n1", orc8r.UpgradeTierEntityType, "tier1", configurator.EntityLoadCriteria{LoadAssocsFromThis: true, LoadConfig: true, LoadMetadata: true}, serdes.Entity)
+	actualTier, err = configurator.LoadEntity(context.Background(), "n1", orc8r.UpgradeTierEntityType, "tier1", configurator.EntityLoadCriteria{LoadAssocsFromThis: true, LoadConfig: true, LoadMetadata: true}, serdes.Entity)
 	assert.NoError(t, err)
 	assert.Equal(t, expectedTier, actualTier)
 }

--- a/orc8r/cloud/go/services/service_registry/servicers/docker_servicer.go
+++ b/orc8r/cloud/go/services/service_registry/servicers/docker_servicer.go
@@ -14,12 +14,12 @@
 package servicers
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/filters"
-	"golang.org/x/net/context"
 
 	"magma/orc8r/lib/go/protos"
 	"magma/orc8r/lib/go/registry"

--- a/orc8r/cloud/go/services/service_registry/servicers/kubernetes_servicer.go
+++ b/orc8r/cloud/go/services/service_registry/servicers/kubernetes_servicer.go
@@ -14,6 +14,7 @@
 package servicers
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"strings"
@@ -22,7 +23,6 @@ import (
 	"github.com/golang/glog"
 	"github.com/pkg/errors"
 	"github.com/robfig/cron/v3"
-	"golang.org/x/net/context"
 	corev1types "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"

--- a/orc8r/cloud/go/services/service_registry/servicers/kubernetes_servicer_test.go
+++ b/orc8r/cloud/go/services/service_registry/servicers/kubernetes_servicer_test.go
@@ -14,13 +14,13 @@
 package servicers_test
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
-	"golang.org/x/net/context"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"

--- a/orc8r/cloud/go/services/state/servicers/servicer.go
+++ b/orc8r/cloud/go/services/state/servicers/servicer.go
@@ -14,12 +14,12 @@ limitations under the License.
 package servicers
 
 import (
+	"context"
 	"encoding/json"
 	"time"
 
 	"github.com/pkg/errors"
 	"github.com/thoas/go-funk"
-	"golang.org/x/net/context"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 

--- a/orc8r/cloud/go/services/state/test_utils/utils.go
+++ b/orc8r/cloud/go/services/state/test_utils/utils.go
@@ -14,10 +14,10 @@ limitations under the License.
 package test_utils
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"golang.org/x/net/context"
 	"google.golang.org/grpc/metadata"
 
 	"magma/orc8r/cloud/go/identity"

--- a/orc8r/cloud/go/services/streamer/providers/providers_test.go
+++ b/orc8r/cloud/go/services/streamer/providers/providers_test.go
@@ -14,7 +14,7 @@ limitations under the License.
 package providers_test
 
 import (
-	context2 "context"
+	"context"
 	"testing"
 
 	"github.com/golang/protobuf/proto"
@@ -22,7 +22,6 @@ import (
 	"github.com/golang/protobuf/ptypes/any"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
-	"golang.org/x/net/context"
 
 	"magma/orc8r/cloud/go/orc8r"
 	"magma/orc8r/cloud/go/serdes"
@@ -54,9 +53,9 @@ func TestMconfigStreamer_Configurator(t *testing.T) {
 	mockBuilder.On("Build", mock.Anything, mock.Anything, "gw1").Return(marshaledConfigs, nil)
 	configurator_test_init.StartNewTestBuilder(t, mockBuilder)
 
-	err = configurator.CreateNetwork(context2.Background(), configurator.Network{ID: "n1"}, serdes.Network)
+	err = configurator.CreateNetwork(context.Background(), configurator.Network{ID: "n1"}, serdes.Network)
 	assert.NoError(t, err)
-	_, err = configurator.CreateEntity(context2.Background(), "n1", configurator.NetworkEntity{Type: orc8r.MagmadGatewayType, Key: "gw1", PhysicalID: "hw1"}, serdes.Entity)
+	_, err = configurator.CreateEntity(context.Background(), "n1", configurator.NetworkEntity{Type: orc8r.MagmadGatewayType, Key: "gw1", PhysicalID: "hw1"}, serdes.Entity)
 	assert.NoError(t, err)
 
 	conn, err := registry.GetConnection(streamer.ServiceName)

--- a/orc8r/cloud/go/services/streamer/servicers/servicer_test.go
+++ b/orc8r/cloud/go/services/streamer/servicers/servicer_test.go
@@ -14,13 +14,12 @@ limitations under the License.
 package servicers_test
 
 import (
-	context2 "context"
+	"context"
 	"errors"
 	"testing"
 
 	"github.com/golang/protobuf/ptypes/any"
 	"github.com/stretchr/testify/assert"
-	"golang.org/x/net/context"
 	"google.golang.org/grpc/codes"
 
 	"magma/orc8r/cloud/go/services/streamer"
@@ -34,7 +33,7 @@ type mockStreamProvider struct {
 	retErr error
 }
 
-func (m *mockStreamProvider) GetUpdates(ctx context2.Context, gatewayId string, extraArgs *any.Any) ([]*protos.DataUpdate, error) {
+func (m *mockStreamProvider) GetUpdates(ctx context.Context, gatewayId string, extraArgs *any.Any) ([]*protos.DataUpdate, error) {
 	return m.retVal, m.retErr
 }
 

--- a/orc8r/gateway/go/directoryd/client_api.go
+++ b/orc8r/gateway/go/directoryd/client_api.go
@@ -19,8 +19,8 @@ import (
 	"fmt"
 	"strings"
 
+	"context"
 	"github.com/golang/glog"
-	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 
 	"magma/orc8r/lib/go/errors"

--- a/orc8r/gateway/go/service_registry/registry.go
+++ b/orc8r/gateway/go/service_registry/registry.go
@@ -14,7 +14,7 @@ limitations under the License.
 package service_registry
 
 import (
-	"golang.org/x/net/context"
+	"context"
 	"google.golang.org/grpc"
 
 	platform_registry "magma/orc8r/lib/go/registry"

--- a/orc8r/gateway/go/services/bootstrapper/service/rpc.go
+++ b/orc8r/gateway/go/services/bootstrapper/service/rpc.go
@@ -22,8 +22,8 @@ import (
 	"strings"
 	"time"
 
+	"context"
 	"github.com/golang/glog"
-	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/backoff"
 	"google.golang.org/grpc/credentials"

--- a/orc8r/lib/go/go.mod
+++ b/orc8r/lib/go/go.mod
@@ -11,7 +11,6 @@ require (
 	github.com/prometheus/client_golang v0.9.3-0.20190127221311-3c4408c8b829
 	github.com/prometheus/client_model v0.2.0
 	github.com/stretchr/testify v1.4.0
-	golang.org/x/net v0.0.0-20200202094626-16171245cfb2
 	google.golang.org/grpc v1.27.1
 	gopkg.in/yaml.v2 v2.2.8
 	magma/orc8r/lib/go/protos v0.0.0-00010101000000-000000000000

--- a/orc8r/lib/go/protos/go.mod
+++ b/orc8r/lib/go/protos/go.mod
@@ -7,6 +7,6 @@ require (
 	github.com/golang/protobuf v1.3.3
 	github.com/prometheus/client_model v0.2.0
 	github.com/stretchr/testify v1.4.0
-	golang.org/x/net v0.0.0-20200202094626-16171245cfb2
+	golang.org/x/net v0.0.0-20200202094626-16171245cfb2 // indirect
 	google.golang.org/grpc v1.27.1
 )

--- a/orc8r/lib/go/protos/identity_helper.go
+++ b/orc8r/lib/go/protos/identity_helper.go
@@ -19,8 +19,8 @@ import (
 	"fmt"
 	"reflect"
 
+	"context"
 	"github.com/golang/glog"
-	"golang.org/x/net/context"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )

--- a/orc8r/lib/go/registry/cloud_connection.go
+++ b/orc8r/lib/go/registry/cloud_connection.go
@@ -24,8 +24,8 @@ import (
 	"sync/atomic"
 	"time"
 
+	"context"
 	"github.com/golang/glog"
-	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/backoff"
 	"google.golang.org/grpc/credentials"

--- a/orc8r/lib/go/registry/global_registry.go
+++ b/orc8r/lib/go/registry/global_registry.go
@@ -17,8 +17,8 @@ package registry
 import (
 	"time"
 
+	"context"
 	"github.com/golang/glog"
-	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 )
 

--- a/orc8r/lib/go/registry/registry.go
+++ b/orc8r/lib/go/registry/registry.go
@@ -21,8 +21,8 @@ import (
 	"sync"
 	"time"
 
+	"context"
 	"github.com/golang/glog"
-	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/keepalive"
 

--- a/orc8r/lib/go/service/client/client_api.go
+++ b/orc8r/lib/go/service/client/client_api.go
@@ -14,8 +14,8 @@ limitations under the License.
 package client
 
 import (
+	"context"
 	"github.com/golang/glog"
-	"golang.org/x/net/context"
 
 	"magma/orc8r/lib/go/errors"
 	"magma/orc8r/lib/go/protos"

--- a/orc8r/lib/go/service/service303.go
+++ b/orc8r/lib/go/service/service303.go
@@ -18,7 +18,7 @@ import (
 	"fmt"
 	"strconv"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"magma/orc8r/lib/go/metrics"
 	"magma/orc8r/lib/go/protos"

--- a/src/go/go.mod
+++ b/src/go/go.mod
@@ -22,19 +22,3 @@ require (
 	google.golang.org/grpc/cmd/protoc-gen-go-grpc v1.1.0
 	google.golang.org/protobuf v1.27.1
 )
-
-require (
-	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/golang/protobuf v1.5.0 // indirect
-	github.com/pmezard/go-difflib v1.0.0 // indirect
-	go.uber.org/atomic v1.7.0 // indirect
-	go.uber.org/multierr v1.6.0 // indirect
-	golang.org/x/mod v0.4.2 // indirect
-	golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4 // indirect
-	golang.org/x/sys v0.0.0-20210510120138-977fb7262007 // indirect
-	golang.org/x/text v0.3.3 // indirect
-	golang.org/x/tools v0.1.1 // indirect
-	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
-	google.golang.org/genproto v0.0.0-20200526211855-cb27e3aa2013 // indirect
-	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
-)


### PR DESCRIPTION
## Summary

- Replacing a deprecated package - see https://pkg.go.dev/golang.org/x/net/context?utm_source=godoc

## Test Plan

- make test

## Additional Information

- [ ] This change is backwards-breaking

Signed-off-by: Jacky Tian <jacky@xjtian.com>