### PR TITLE
fix(mme): pgw api for dedicated bearer

### DIFF
--- a/lte/gateway/c/core/oai/lib/openflow/controller/ControllerEvents.cpp
+++ b/lte/gateway/c/core/oai/lib/openflow/controller/ControllerEvents.cpp
@@ -178,28 +178,6 @@ AddGTPTunnelEvent::AddGTPTunnelEvent(
     const struct in_addr ue_ip, struct in6_addr* ue_ipv6, int vlan,
     const struct in_addr enb_ip, const struct in_addr pgw_ip,
     const uint32_t in_tei, const uint32_t out_tei, const uint32_t pgw_in_tei,
-    const uint32_t pgw_out_tei, const char* imsi,
-    const struct ip_flow_dl* dl_flow, const uint32_t dl_flow_precedence,
-    uint32_t enb_gtp_port, uint32_t pgw_gtp_port)
-    : ue_info_(ue_ip, ue_ipv6, vlan),
-      enb_ip_(enb_ip),
-      pgw_ip_(pgw_ip),
-      in_tei_(in_tei),
-      out_tei_(out_tei),
-      pgw_in_tei_(pgw_in_tei),
-      pgw_out_tei_(pgw_out_tei),
-      imsi_(imsi),
-      dl_flow_valid_(true),
-      dl_flow_(*dl_flow),
-      dl_flow_precedence_(DEFAULT_PRECEDENCE),
-      ExternalEvent(EVENT_ADD_GTP_S8_TUNNEL),
-      enb_gtp_port_(enb_gtp_port),
-      pgw_gtp_port_(pgw_gtp_port) {}
-
-AddGTPTunnelEvent::AddGTPTunnelEvent(
-    const struct in_addr ue_ip, struct in6_addr* ue_ipv6, int vlan,
-    const struct in_addr enb_ip, const struct in_addr pgw_ip,
-    const uint32_t in_tei, const uint32_t out_tei, const uint32_t pgw_in_tei,
     const uint32_t pgw_out_tei, const char* imsi, uint32_t enb_gtp_port,
     uint32_t pgw_gtp_port)
     : ue_info_(ue_ip, vlan),
@@ -278,6 +256,7 @@ DeleteGTPTunnelEvent::DeleteGTPTunnelEvent(
     const struct ip_flow_dl* dl_flow, uint32_t enb_gtp_port)
     : ue_info_(ue_ip, ue_ipv6),
       in_tei_(in_tei),
+      pgw_in_tei_(0),
       dl_flow_valid_(true),
       dl_flow_(*dl_flow),
       ExternalEvent(EVENT_DELETE_GTP_TUNNEL),
@@ -289,6 +268,7 @@ DeleteGTPTunnelEvent::DeleteGTPTunnelEvent(
     uint32_t enb_gtp_port)
     : ue_info_(ue_ip, ue_ipv6),
       in_tei_(in_tei),
+      pgw_in_tei_(0),
       dl_flow_valid_(false),
       dl_flow_(),
       ExternalEvent(EVENT_DELETE_GTP_TUNNEL),
@@ -297,21 +277,10 @@ DeleteGTPTunnelEvent::DeleteGTPTunnelEvent(
 
 DeleteGTPTunnelEvent::DeleteGTPTunnelEvent(
     const struct in_addr ue_ip, struct in6_addr* ue_ipv6, const uint32_t in_tei,
-    const struct ip_flow_dl* dl_flow, uint32_t enb_gtp_port,
-    uint32_t pgw_gtp_port)
+    const uint32_t pgw_in_tei, uint32_t enb_gtp_port, uint32_t pgw_gtp_port)
     : ue_info_(ue_ip, ue_ipv6),
       in_tei_(in_tei),
-      dl_flow_valid_(true),
-      dl_flow_(*dl_flow),
-      ExternalEvent(EVENT_DELETE_GTP_S8_TUNNEL),
-      enb_gtp_port_(enb_gtp_port),
-      pgw_gtp_port_(pgw_gtp_port) {}
-
-DeleteGTPTunnelEvent::DeleteGTPTunnelEvent(
-    const struct in_addr ue_ip, struct in6_addr* ue_ipv6, const uint32_t in_tei,
-    uint32_t enb_gtp_port, uint32_t pgw_gtp_port)
-    : ue_info_(ue_ip, ue_ipv6),
-      in_tei_(in_tei),
+      pgw_in_tei_(pgw_in_tei),
       dl_flow_valid_(false),
       dl_flow_(),
       ExternalEvent(EVENT_DELETE_GTP_S8_TUNNEL),
@@ -328,6 +297,10 @@ const struct in_addr& DeleteGTPTunnelEvent::get_ue_ip() const {
 
 const uint32_t DeleteGTPTunnelEvent::get_in_tei() const {
   return in_tei_;
+}
+
+const uint32_t DeleteGTPTunnelEvent::get_pgw_in_tei() const {
+  return pgw_in_tei_;
 }
 
 const bool DeleteGTPTunnelEvent::is_dl_flow_valid() const {

--- a/lte/gateway/c/core/oai/lib/openflow/controller/ControllerEvents.h
+++ b/lte/gateway/c/core/oai/lib/openflow/controller/ControllerEvents.h
@@ -188,14 +188,6 @@ class AddGTPTunnelEvent : public ExternalEvent {
       const struct in_addr ue_ip, struct in6_addr* ue_ipv6, int vlan,
       const struct in_addr enb_ip, const struct in_addr pgw_ip,
       const uint32_t in_tei, const uint32_t out_tei, const uint32_t pgw_in_tei,
-      const uint32_t pgw_out_tei, const char* imsi,
-      const struct ip_flow_dl* dl_flow, const uint32_t dl_flow_precedence,
-      uint32_t enb_gtp_port, uint32_t pgw_gtp_port);
-
-  AddGTPTunnelEvent(
-      const struct in_addr ue_ip, struct in6_addr* ue_ipv6, int vlan,
-      const struct in_addr enb_ip, const struct in_addr pgw_ip,
-      const uint32_t in_tei, const uint32_t out_tei, const uint32_t pgw_in_tei,
       const uint32_t pgw_out_tei, const char* imsi, uint32_t enb_gtp_port,
       uint32_t pgw_gtp_port);
 
@@ -249,15 +241,13 @@ class DeleteGTPTunnelEvent : public ExternalEvent {
 
   DeleteGTPTunnelEvent(
       const struct in_addr ue_ip, struct in6_addr* ue_ipv6,
-      const uint32_t in_tei, const struct ip_flow_dl* dl_flow,
-      uint32_t enb_gtp_port, uint32_t pgw_gtp_port);
-  DeleteGTPTunnelEvent(
-      const struct in_addr ue_ip, struct in6_addr* ue_ipv6,
-      const uint32_t in_tei, uint32_t enb_gtp_port, uint32_t pgw_gtp_port);
+      const uint32_t in_tei, const uint32_t pgw_in_tei, uint32_t enb_gtp_port,
+      uint32_t pgw_gtp_port);
 
   const struct UeNetworkInfo& get_ue_info() const;
   const struct in_addr& get_ue_ip() const;
   const uint32_t get_in_tei() const;
+  const uint32_t get_pgw_in_tei() const;
   const bool is_dl_flow_valid() const;
   const struct ip_flow_dl& get_dl_flow() const;
   const uint32_t get_enb_gtp_portno() const;
@@ -266,6 +256,7 @@ class DeleteGTPTunnelEvent : public ExternalEvent {
  private:
   const UeNetworkInfo ue_info_;
   const uint32_t in_tei_;
+  const uint32_t pgw_in_tei_;
   const struct ip_flow_dl dl_flow_;
   const bool dl_flow_valid_;
   const uint32_t enb_gtp_port_;

--- a/lte/gateway/c/core/oai/lib/openflow/controller/ControllerMain.cpp
+++ b/lte/gateway/c/core/oai/lib/openflow/controller/ControllerMain.cpp
@@ -126,35 +126,23 @@ int openflow_controller_del_gtp_tunnel(
 
 int openflow_controller_add_gtp_s8_tunnel(
     struct in_addr ue, struct in6_addr* ue_ipv6, int vlan, struct in_addr enb,
-    struct in_addr pgw, uint32_t i_tei, uint32_t o_tei, uint32_t pgw_i_tei,
-    uint32_t pgw_o_tei, const char* imsi, struct ip_flow_dl* flow_dl,
-    uint32_t flow_precedence_dl, uint32_t enb_gtp_port, uint32_t pgw_gtp_port) {
-  if (flow_dl) {
-    auto add_tunnel = std::make_shared<openflow::AddGTPTunnelEvent>(
-        ue, ue_ipv6, vlan, enb, pgw, i_tei, o_tei, pgw_i_tei, pgw_o_tei, imsi,
-        flow_dl, flow_precedence_dl, enb_gtp_port, pgw_gtp_port);
-    ctrl.inject_external_event(add_tunnel, external_event_callback);
-  } else {
-    auto add_tunnel = std::make_shared<openflow::AddGTPTunnelEvent>(
-        ue, ue_ipv6, vlan, enb, pgw, i_tei, o_tei, pgw_i_tei, pgw_o_tei, imsi,
-        enb_gtp_port, pgw_gtp_port);
-    ctrl.inject_external_event(add_tunnel, external_event_callback);
-  }
+    struct in_addr pgw, uint32_t i_tei, uint32_t o_tei, uint32_t pgw_in_tei,
+    uint32_t pgw_o_tei, const char* imsi, uint32_t enb_gtp_port,
+    uint32_t pgw_gtp_port) {
+  auto add_tunnel = std::make_shared<openflow::AddGTPTunnelEvent>(
+      ue, ue_ipv6, vlan, enb, pgw, i_tei, o_tei, pgw_in_tei, pgw_o_tei, imsi,
+      enb_gtp_port, pgw_gtp_port);
+  ctrl.inject_external_event(add_tunnel, external_event_callback);
+
   OAILOG_FUNC_RETURN(LOG_GTPV1U, RETURNok);
 }
 
 int openflow_controller_del_gtp_s8_tunnel(
     struct in_addr ue, struct in6_addr* ue_ipv6, uint32_t i_tei,
-    struct ip_flow_dl* flow_dl, uint32_t enb_gtp_port, uint32_t pgw_gtp_port) {
-  if (flow_dl) {
-    auto del_tunnel = std::make_shared<openflow::DeleteGTPTunnelEvent>(
-        ue, ue_ipv6, i_tei, flow_dl, enb_gtp_port, pgw_gtp_port);
-    ctrl.inject_external_event(del_tunnel, external_event_callback);
-  } else {
-    auto del_tunnel = std::make_shared<openflow::DeleteGTPTunnelEvent>(
-        ue, ue_ipv6, i_tei, enb_gtp_port, pgw_gtp_port);
-    ctrl.inject_external_event(del_tunnel, external_event_callback);
-  }
+    uint32_t pgw_in_tei, uint32_t enb_gtp_port, uint32_t pgw_gtp_port) {
+  auto del_tunnel = std::make_shared<openflow::DeleteGTPTunnelEvent>(
+      ue, ue_ipv6, i_tei, pgw_in_tei, enb_gtp_port, pgw_gtp_port);
+  ctrl.inject_external_event(del_tunnel, external_event_callback);
   OAILOG_FUNC_RETURN(LOG_GTPV1U, RETURNok);
 }
 

--- a/lte/gateway/c/core/oai/lib/openflow/controller/ControllerMain.h
+++ b/lte/gateway/c/core/oai/lib/openflow/controller/ControllerMain.h
@@ -56,13 +56,13 @@ int openflow_controller_delete_paging_rule(struct in_addr ue_ip);
 
 int openflow_controller_add_gtp_s8_tunnel(
     struct in_addr ue, struct in6_addr* ue_ipv6, int vlan, struct in_addr enb,
-    struct in_addr pgw, uint32_t i_tei, uint32_t o_tei, uint32_t pgw_i_tei,
-    uint32_t pgw_o_tei, const char* imsi, struct ip_flow_dl* flow_dl,
-    uint32_t flow_precedence_dl, uint32_t enb_gtp_port, uint32_t pgw_gtp_port);
+    struct in_addr pgw, uint32_t i_tei, uint32_t o_tei, uint32_t pgw_in_tei,
+    uint32_t pgw_o_tei, const char* imsi, uint32_t enb_gtp_port,
+    uint32_t pgw_gtp_port);
 
 int openflow_controller_del_gtp_s8_tunnel(
     struct in_addr ue, struct in6_addr* ue_ipv6, uint32_t i_tei,
-    struct ip_flow_dl* flow_dl, uint32_t enb_gtp_port, uint32_t pgw_gtp_port);
+    uint32_t pgw_o_tei, uint32_t enb_gtp_port, uint32_t pgw_gtp_port);
 
 #ifdef __cplusplus
 }

--- a/lte/gateway/c/core/oai/lib/openflow/controller/GTPApplication.h
+++ b/lte/gateway/c/core/oai/lib/openflow/controller/GTPApplication.h
@@ -72,10 +72,22 @@ class GTPApplication : public Application {
       const AddGTPTunnelEvent& ev, const OpenflowMessenger& messenger);
 
   /*
+   * Add uplink flow for s* tunnel.
+   */
+  void add_down_link_s8_tunnel_flow(
+      const AddGTPTunnelEvent& ev, const OpenflowMessenger& messenger);
+
+  /*
    * Remove uplink tunnel flow on disconnect
    * @param ev - DeleteGTPTunnelEvent containing ue ip, and inbound tei
    */
   void delete_uplink_tunnel_flow(
+      const DeleteGTPTunnelEvent& ev, const OpenflowMessenger& messenger);
+
+  /*
+   * Delete s8 flow from pgw.
+   */
+  void delete_down_link_s8_tunnel_flow(
       const DeleteGTPTunnelEvent& ev, const OpenflowMessenger& messenger);
 
   /*

--- a/lte/gateway/c/core/oai/tasks/gtpv1-u/gtp_tunnel_openflow.c
+++ b/lte/gateway/c/core/oai/tasks/gtpv1-u/gtp_tunnel_openflow.c
@@ -291,27 +291,24 @@ int openflow_del_tunnel(
 /* S8 tunnel related APIs */
 int openflow_add_s8_tunnel(
     struct in_addr ue, struct in6_addr* ue_ipv6, int vlan, struct in_addr enb,
-    struct in_addr pgw, uint32_t i_tei, uint32_t o_tei, uint32_t pgw_i_tei,
-    uint32_t pgw_o_tei, Imsi_t imsi, struct ip_flow_dl* flow_dl,
-    uint32_t flow_precedence_dl) {
+    struct in_addr pgw, uint32_t i_tei, uint32_t o_tei, uint32_t pgw_in_tei,
+    uint32_t pgw_o_tei, Imsi_t imsi) {
   uint32_t enb_portno = find_gtp_port_no(enb, false);
   uint32_t pgw_portno = find_gtp_port_no(pgw, true);
 
   return openflow_controller_add_gtp_s8_tunnel(
-      ue, ue_ipv6, vlan, enb, pgw, i_tei, o_tei, pgw_i_tei, pgw_o_tei,
-      (const char*) imsi.digit, flow_dl, flow_precedence_dl, enb_portno,
-      pgw_portno);
+      ue, ue_ipv6, vlan, enb, pgw, i_tei, o_tei, pgw_in_tei, pgw_o_tei,
+      (const char*) imsi.digit, enb_portno, pgw_portno);
 }
 
 int openflow_del_s8_tunnel(
     struct in_addr enb, struct in_addr pgw, struct in_addr ue,
-    struct in6_addr* ue_ipv6, uint32_t i_tei, uint32_t o_tei,
-    struct ip_flow_dl* flow_dl) {
+    struct in6_addr* ue_ipv6, uint32_t i_tei, uint32_t pgw_in_tei) {
   uint32_t enb_portno = find_gtp_port_no(enb, false);
   uint32_t pgw_portno = find_gtp_port_no(pgw, true);
 
   return openflow_controller_del_gtp_s8_tunnel(
-      ue, ue_ipv6, i_tei, flow_dl, enb_portno, pgw_portno);
+      ue, ue_ipv6, i_tei, pgw_in_tei, enb_portno, pgw_portno);
 }
 
 int openflow_discard_data_on_tunnel(

--- a/lte/gateway/c/core/oai/tasks/gtpv1-u/gtpv1u.h
+++ b/lte/gateway/c/core/oai/tasks/gtpv1-u/gtpv1u.h
@@ -145,13 +145,11 @@ struct gtp_tunnel_ops {
       uint32_t i_tei, uint32_t o_tei, struct ip_flow_dl* flow_dl);
   int (*add_s8_tunnel)(
       struct in_addr ue, struct in6_addr* ue_ipv6, int vlan, struct in_addr enb,
-      struct in_addr pgw, uint32_t i_tei, uint32_t o_tei, uint32_t pgw_i_tei,
-      uint32_t pgw_o_tei, Imsi_t imsi, struct ip_flow_dl* flow_dl,
-      uint32_t flow_precedence_dl);
+      struct in_addr pgw, uint32_t i_tei, uint32_t o_tei, uint32_t pgw_in_tei,
+      uint32_t pgw_o_tei, Imsi_t imsi);
   int (*del_s8_tunnel)(
       struct in_addr enb, struct in_addr pgw, struct in_addr ue,
-      struct in6_addr* ue_ipv6, uint32_t i_tei, uint32_t o_tei,
-      struct ip_flow_dl* flow_dl);
+      struct in6_addr* ue_ipv6, uint32_t i_tei, uint32_t pgw_in_tei);
   int (*discard_data_on_tunnel)(
       struct in_addr ue, struct in6_addr* ue_ipv6, uint32_t i_tei,
       struct ip_flow_dl* flow_dl);
@@ -177,12 +175,10 @@ int gtpv1u_add_tunnel(
 
 int gtpv1u_add_s8_tunnel(
     struct in_addr ue, struct in6_addr* ue_ipv6, int vlan, struct in_addr enb,
-    struct in_addr pgw, uint32_t i_tei, uint32_t o_tei, uint32_t pgw_i_tei,
-    uint32_t pgw_o_tei, Imsi_t imsi, struct ip_flow_dl* flow_dl,
-    uint32_t flow_precedence_dl);
+    struct in_addr pgw, uint32_t i_tei, uint32_t o_tei, uint32_t pgw_in_tei,
+    uint32_t pgw_o_tei, Imsi_t imsi);
 
 int gtpv1u_del_s8_tunnel(
     struct in_addr enb, struct in_addr pgw, struct in_addr ue,
-    struct in6_addr* ue_ipv6, uint32_t i_tei, uint32_t o_tei,
-    struct ip_flow_dl* flow_dl);
+    struct in6_addr* ue_ipv6, uint32_t i_tei, uint32_t pgw_in_tei);
 #endif /* FILE_GTPV1_U_SEEN */

--- a/lte/gateway/c/core/oai/tasks/gtpv1-u/gtpv1u_task.c
+++ b/lte/gateway/c/core/oai/tasks/gtpv1-u/gtpv1u_task.c
@@ -210,14 +210,12 @@ int gtpv1u_add_tunnel(
 
 int gtpv1u_add_s8_tunnel(
     struct in_addr ue, struct in6_addr* ue_ipv6, int vlan, struct in_addr enb,
-    struct in_addr pgw, uint32_t i_tei, uint32_t o_tei, uint32_t pgw_i_tei,
-    uint32_t pgw_o_tei, Imsi_t imsi, struct ip_flow_dl* flow_dl,
-    uint32_t flow_precedence_dl) {
+    struct in_addr pgw, uint32_t i_tei, uint32_t o_tei, uint32_t pgw_in_tei,
+    uint32_t pgw_o_tei, Imsi_t imsi) {
   OAILOG_DEBUG(LOG_GTPV1U, "Add S8 tunnel ue %s", inet_ntoa(ue));
   if (gtp_tunnel_ops->add_s8_tunnel) {
     return gtp_tunnel_ops->add_s8_tunnel(
-        ue, ue_ipv6, vlan, enb, pgw, i_tei, o_tei, pgw_i_tei, pgw_o_tei, imsi,
-        flow_dl, flow_precedence_dl);
+        ue, ue_ipv6, vlan, enb, pgw, i_tei, o_tei, pgw_in_tei, pgw_o_tei, imsi);
   } else {
     return -EINVAL;
   }
@@ -225,12 +223,11 @@ int gtpv1u_add_s8_tunnel(
 
 int gtpv1u_del_s8_tunnel(
     struct in_addr enb, struct in_addr pgw, struct in_addr ue,
-    struct in6_addr* ue_ipv6, uint32_t i_tei, uint32_t o_tei,
-    struct ip_flow_dl* flow_dl) {
+    struct in6_addr* ue_ipv6, uint32_t i_tei, uint32_t pgw_in_tei) {
   OAILOG_DEBUG(LOG_GTPV1U, "Del S8 tunnel ue %s", inet_ntoa(ue));
   if (gtp_tunnel_ops->del_s8_tunnel) {
     return gtp_tunnel_ops->del_s8_tunnel(
-        enb, pgw, ue, ue_ipv6, i_tei, o_tei, flow_dl);
+        enb, pgw, ue, ue_ipv6, i_tei, pgw_in_tei);
   } else {
     return -EINVAL;
   }

--- a/lte/gateway/c/core/oai/tasks/sgw/sgw_handlers.c
+++ b/lte/gateway/c/core/oai/tasks/sgw/sgw_handlers.c
@@ -2255,7 +2255,7 @@ void sgw_process_release_access_bearer_request(
         rv = gtpv1u_del_s8_tunnel(
             enb, pgw, eps_bearer_ctxt->paa.ipv4_address, ue_ipv6,
             eps_bearer_ctxt->s_gw_teid_S1u_S12_S4_up,
-            eps_bearer_ctxt->enb_teid_S1u, NULL);
+            eps_bearer_ctxt->s_gw_teid_S5_S8_up);
       }
 
       // TODO Need to add handling on failing to delete s1-u tunnel rules from

--- a/lte/gateway/c/core/oai/tasks/sgw_s8/sgw_s8_handlers.c
+++ b/lte/gateway/c/core/oai/tasks/sgw_s8/sgw_s8_handlers.c
@@ -634,7 +634,7 @@ void sgw_s8_handle_modify_bearer_request(
         // delete GTPv1-U tunnel
         gtpv1u_del_s8_tunnel(
             enb, pgw, ue_ipv4, ue_ipv6, bearer_ctx_p->s_gw_teid_S1u_S12_S4_up,
-            bearer_ctx_p->enb_teid_S1u, NULL);
+            bearer_ctx_p->s_gw_teid_S5_S8_up);
       }
       populate_sgi_end_point_update(
           sgi_rsp_idx, idx, modify_bearer_pP, bearer_ctx_p,
@@ -812,7 +812,7 @@ static int sgw_s8_add_gtp_up_tunnel(
         ue_ipv4, ue_ipv6, vlan, enb, pgw,
         eps_bearer_ctxt_p->s_gw_teid_S1u_S12_S4_up,
         eps_bearer_ctxt_p->enb_teid_S1u, eps_bearer_ctxt_p->s_gw_teid_S5_S8_up,
-        eps_bearer_ctxt_p->p_gw_teid_S5_S8_up, imsi, NULL, DEFAULT_PRECEDENCE);
+        eps_bearer_ctxt_p->p_gw_teid_S5_S8_up, imsi);
     if (rv < 0) {
       OAILOG_ERROR_UE(
           LOG_SGW_S8, sgw_context_p->imsi64,
@@ -923,7 +923,7 @@ static void delete_userplane_tunnels(
       // Delete S1-U tunnel and S8-U tunnel
       rv = gtpv1u_del_s8_tunnel(
           enb, pgw, ue_ipv4, ue_ipv6, bearer_ctxt_p->s_gw_teid_S1u_S12_S4_up,
-          bearer_ctxt_p->enb_teid_S1u, NULL);
+          bearer_ctxt_p->s_gw_teid_S5_S8_up);
       if (rv < 0) {
         OAILOG_ERROR_UE(
             LOG_SPGW_APP, sgw_context_p->imsi64,

--- a/lte/gateway/c/core/oai/test/openflow/test_gtp_app.cpp
+++ b/lte/gateway/c/core/oai/test/openflow/test_gtp_app.cpp
@@ -939,10 +939,11 @@ TEST_F(GTPApplicationTest, TestAddTunnelS8) {
       *messenger,
       send_of_msg(
           AllOf(
-              CheckTableId(0), CheckInPort(pgw_port), CheckEthType(0x0800),
-              CheckIPv4Dst(ue_ip), CheckCommandType(of13::OFPFC_ADD)),
+              CheckTableId(0), CheckInPort(pgw_port), CheckTunnelId(pgw_in_tei),
+              CheckCommandType(of13::OFPFC_ADD)),
           _))
       .Times(1);
+
   EXPECT_CALL(
       *messenger,
       send_of_msg(
@@ -969,12 +970,14 @@ TEST_F(GTPApplicationTest, TestAddTunnelS8) {
  */
 TEST_F(GTPApplicationTest, TestDeleteTunnelS8) {
   struct in_addr ue_ip;
-  ue_ip.s_addr    = inet_addr("0.0.0.1");
-  uint32_t in_tei = 1;
-  int enb_port    = 100;
-  int pgw_port    = 200;
+  ue_ip.s_addr        = inet_addr("0.0.0.1");
+  uint32_t in_tei     = 1;
+  uint32_t pgw_in_tei = 3;
+  int enb_port        = 100;
+  int pgw_port        = 200;
 
-  DeleteGTPTunnelEvent del_tunnel(ue_ip, NULL, in_tei, enb_port, pgw_port);
+  DeleteGTPTunnelEvent del_tunnel(
+      ue_ip, NULL, in_tei, pgw_in_tei, enb_port, pgw_port);
   // Uplink
   EXPECT_CALL(
       *messenger,
@@ -989,10 +992,11 @@ TEST_F(GTPApplicationTest, TestDeleteTunnelS8) {
       *messenger,
       send_of_msg(
           AllOf(
-              CheckTableId(0), CheckInPort(pgw_port), CheckEthType(0x0800),
-              CheckIPv4Dst(ue_ip), CheckCommandType(of13::OFPFC_DELETE)),
+              CheckTableId(0), CheckInPort(pgw_port), CheckTunnelId(pgw_in_tei),
+              CheckCommandType(of13::OFPFC_DELETE)),
           _))
       .Times(1);
+
   EXPECT_CALL(
       *messenger,
       send_of_msg(
@@ -1033,17 +1037,9 @@ TEST_F(GTPApplicationTest, TestAddTunnelS8DlFlowGtpPort) {
   int enb_port                = 100;
   int pgw_port                = 200;
 
-  dl_flow.dst_ip.s_addr = inet_addr("0.0.0.3");
-  dl_flow.src_ip.s_addr = inet_addr("0.0.0.4");
-  dl_flow.tcp_dst_port  = 33;
-  dl_flow.tcp_src_port  = 44;
-  dl_flow.ip_proto      = 6;  // TCP
-  dl_flow.set_params =
-      SRC_IPV4 | DST_IPV4 | TCP_SRC_PORT | TCP_DST_PORT | IP_PROTO;
-
   AddGTPTunnelEvent add_tunnel(
       ue_ip, NULL, vlan, enb_ip, pgw_ip, in_tei, out_tei, pgw_in_tei,
-      pgw_out_tei, imsi, &dl_flow, dl_flow_precedence, enb_port, pgw_port);
+      pgw_out_tei, imsi, enb_port, pgw_port);
 
   // Uplink
   EXPECT_CALL(
@@ -1059,24 +1055,17 @@ TEST_F(GTPApplicationTest, TestAddTunnelS8DlFlowGtpPort) {
       *messenger,
       send_of_msg(
           AllOf(
-              CheckTableId(0), CheckInPort(pgw_port), CheckEthType(0x0800),
-              CheckIPv4Dst(dl_flow.dst_ip), CheckIPv4Src(dl_flow.src_ip),
-              CheckIPv4Proto(dl_flow.ip_proto),
-              CheckTcpDstPort(dl_flow.tcp_dst_port),
-              CheckTcpSrcPort(dl_flow.tcp_src_port),
+              CheckTableId(0), CheckInPort(pgw_port), CheckTunnelId(pgw_in_tei),
               CheckCommandType(of13::OFPFC_ADD)),
           _))
       .Times(1);
+
   EXPECT_CALL(
       *messenger,
       send_of_msg(
           AllOf(
               CheckTableId(0), CheckInPort(TEST_MTR_PORT), CheckEthType(0x0800),
-              CheckIPv4Dst(dl_flow.dst_ip), CheckIPv4Src(dl_flow.src_ip),
-              CheckIPv4Proto(dl_flow.ip_proto),
-              CheckTcpDstPort(dl_flow.tcp_dst_port),
-              CheckTcpSrcPort(dl_flow.tcp_src_port),
-              CheckCommandType(of13::OFPFC_ADD)),
+              CheckIPv4Dst(ue_ip), CheckCommandType(of13::OFPFC_ADD)),
           _))
       .Times(1);
 
@@ -1094,22 +1083,16 @@ TEST_F(GTPApplicationTest, TestAddTunnelS8DlFlowGtpPort) {
 
 TEST_F(GTPApplicationTest, TestDeleteTunnelS8DlFlowGtpPort) {
   struct in_addr ue_ip;
-  ue_ip.s_addr    = inet_addr("0.0.0.1");
-  uint32_t in_tei = 1;
+  ue_ip.s_addr        = inet_addr("0.0.0.1");
+  uint32_t in_tei     = 1;
+  uint32_t pgw_in_tei = 3;
+
   struct ip_flow_dl dl_flow;
   int enb_port = 100;
   int pgw_port = 200;
 
-  dl_flow.dst_ip.s_addr = inet_addr("0.0.0.3");
-  dl_flow.src_ip.s_addr = inet_addr("0.0.0.4");
-  dl_flow.tcp_dst_port  = 33;
-  dl_flow.tcp_src_port  = 44;
-  dl_flow.ip_proto      = 6;  // TCP
-  dl_flow.set_params =
-      SRC_IPV4 | DST_IPV4 | TCP_SRC_PORT | TCP_DST_PORT | IP_PROTO;
-
   DeleteGTPTunnelEvent del_tunnel(
-      ue_ip, NULL, in_tei, &dl_flow, enb_port, pgw_port);
+      ue_ip, NULL, in_tei, pgw_in_tei, enb_port, pgw_port);
 
   // Uplink
   EXPECT_CALL(
@@ -1125,24 +1108,17 @@ TEST_F(GTPApplicationTest, TestDeleteTunnelS8DlFlowGtpPort) {
       *messenger,
       send_of_msg(
           AllOf(
-              CheckTableId(0), CheckInPort(pgw_port), CheckEthType(0x0800),
-              CheckIPv4Dst(dl_flow.dst_ip), CheckIPv4Src(dl_flow.src_ip),
-              CheckIPv4Proto(dl_flow.ip_proto),
-              CheckTcpDstPort(dl_flow.tcp_dst_port),
-              CheckTcpSrcPort(dl_flow.tcp_src_port),
+              CheckTableId(0), CheckInPort(pgw_port), CheckTunnelId(pgw_in_tei),
               CheckCommandType(of13::OFPFC_DELETE)),
           _))
       .Times(1);
+
   EXPECT_CALL(
       *messenger,
       send_of_msg(
           AllOf(
               CheckTableId(0), CheckInPort(TEST_MTR_PORT), CheckEthType(0x0800),
-              CheckIPv4Dst(dl_flow.dst_ip), CheckIPv4Src(dl_flow.src_ip),
-              CheckIPv4Proto(dl_flow.ip_proto),
-              CheckTcpDstPort(dl_flow.tcp_dst_port),
-              CheckTcpSrcPort(dl_flow.tcp_src_port),
-              CheckCommandType(of13::OFPFC_DELETE)),
+              CheckIPv4Dst(ue_ip), CheckCommandType(of13::OFPFC_DELETE)),
           _))
       .Times(1);
 


### PR DESCRIPTION
This patch removes dependency of flow-dl for
dedicated bearer of inbound roaming UEs. This results
in simplified inbound roaming flows by matching on
PGW TEIDs.

Signed-off-by: Pravin B Shelar <pbshelar@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->

## Test Plan
`make test_oai`
Ran `make integ_test` on branch and master. I got same result for both test result.
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
