### PR TITLE
chore: update docker container version for bazel job and devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -17,7 +17,7 @@
 		"stackbuild.bazel-stack-vscode-cc",
 		"augustocdias.tasks-shell-input",
 	],
-	"image": "ghcr.io/magma/devcontainer:sha-9fe32d6",
+	"image": "ghcr.io/magma/devcontainer:sha-72b1f20",
 	"settings": {
 		"terminal.integrated.shell.linux": "/bin/bash",
 		"files.watcherExclude": {

--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -7,7 +7,7 @@ on:  # yamllint disable-line rule:truthy
       - reopened
       - synchronize
 env:
-  DEVCONTAINER_IMAGE: "ghcr.io/magma/devcontainer:sha-9fe32d6"
+  DEVCONTAINER_IMAGE: "ghcr.io/magma/devcontainer:sha-72b1f20"
   BAZEL_CACHE: bazel-cache
   BAZEL_CACHE_REPO: bazel-cache-repo
 

--- a/.github/workflows/gcc-problems.yml
+++ b/.github/workflows/gcc-problems.yml
@@ -15,7 +15,7 @@ on:
       - reopened
       - synchronize
 env:
-  DEVCONTAINER_IMAGE: "ghcr.io/magma/devcontainer:sha-b435783"
+  DEVCONTAINER_IMAGE: "ghcr.io/magma/devcontainer:sha-72b1f20"
 
 # See [Example Sharing Container Between Jobs](https://github.com/docker/build-push-action/issues/225)
 jobs:


### PR DESCRIPTION
Signed-off-by: Marie Bremner <marwhal@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary
I recently updated the devcontainer Dockerfile. Now that the new image has been pushed to GitHub, point the bazel workflow and devcontainer to this build: `sha-72b1f20`
<!-- Enumerate changes you made and why you made them -->

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
