### PR TITLE
feat(amf): Fix for T3592 Retransmission of PDU session release command

### DIFF
--- a/lte/gateway/c/core/oai/tasks/amf/amf_app_ue_context_and_proc.h
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_app_ue_context_and_proc.h
@@ -786,7 +786,7 @@ void amf_app_handle_resource_setup_response(
     itti_ngap_pdusessionresource_setup_rsp_t session_seup_resp);
 int pdu_session_resource_release_request(
     ue_m5gmm_context_s* ue_context, amf_ue_ngap_id_t amf_ue_ngap_id,
-    smf_context_t* smf_ctx);
+    smf_context_t* smf_ctx, bool retransmit);
 void amf_app_handle_resource_release_response(
     itti_ngap_pdusessionresource_rel_rsp_t session_rel_resp);
 void amf_app_handle_cm_idle_on_ue_context_release(


### PR DESCRIPTION
Signed-off-by: Kaleemullah Mohammed <kaleemullah.mohammed@wavelabs.ai>

 

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->
Session release retransmissions were sent as part of PDUSessionResourceReleaseCommand leading to TC17 failures. The fix differentiates between the first transmission and retransmissions such that retransmissions are sent as part of DownlinkNASTransport message.   
## Test Plan
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->
Run TeraVM TC17.

Before the changes:

![3592-orig](https://user-images.githubusercontent.com/83354949/134967112-7ebeaa2c-3887-46ba-8ee2-3d59fafe2457.jpg)

After the changes:

![3592_fix](https://user-images.githubusercontent.com/83354949/134960394-d546f3b8-3031-4546-95f3-2feb1681c6cf.jpg)
excluding PDUSessionReleaseCommand on DL
## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
