### PR TITLE
fix(mme): Fix for handling unknown GUTI attach

### DIFF
--- a/lte/gateway/c/core/oai/include/mme_app_ue_context.h
+++ b/lte/gateway/c/core/oai/include/mme_app_ue_context.h
@@ -464,7 +464,6 @@ typedef struct ue_mm_context_s {
   /* Storing activate_dedicated_bearer_req messages received
    * when UE is in ECM_IDLE state*/
   emm_cn_activate_dedicated_bearer_req_t* pending_ded_ber_req[BEARERS_PER_UE];
-  bool is_unknown_guti;
   LIST_HEAD(s11_procedures_s, mme_app_s11_proc_s) * s11_procedures;
 } ue_mm_context_t;
 

--- a/lte/gateway/c/core/oai/include/mme_app_ue_context.h
+++ b/lte/gateway/c/core/oai/include/mme_app_ue_context.h
@@ -464,6 +464,7 @@ typedef struct ue_mm_context_s {
   /* Storing activate_dedicated_bearer_req messages received
    * when UE is in ECM_IDLE state*/
   emm_cn_activate_dedicated_bearer_req_t* pending_ded_ber_req[BEARERS_PER_UE];
+  bool is_unknown_guti;
   LIST_HEAD(s11_procedures_s, mme_app_s11_proc_s) * s11_procedures;
 } ue_mm_context_t;
 

--- a/lte/gateway/c/core/oai/tasks/nas/emm/Attach.c
+++ b/lte/gateway/c/core/oai/tasks/nas/emm/Attach.c
@@ -162,7 +162,7 @@ static int emm_attach_update(
 
 static int emm_attach_accept_retx(emm_context_t* emm_context);
 
-static void create_new_attach_info(
+void create_new_attach_info(
     emm_context_t* emm_context_p, mme_ue_s1ap_id_t mme_ue_s1ap_id,
     struct emm_attach_request_ies_s* ies, bool is_mm_ctx_new);
 
@@ -335,7 +335,13 @@ int emm_proc_attach_request(
       OAILOG_FUNC_RETURN(LOG_NAS_EMM, RETURNok);
     }
     // Allocate new context and process the new request as fresh attach request
-    clear_emm_ctxt = true;
+    clear_emm_ctxt                 = true;
+    ue_mm_context->is_unknown_guti = true;
+    OAILOG_INFO(
+        LOG_NAS_EMM,
+        "EMM-PROC - Received Attach Request with unknown GUTI for ue_id "
+        "= " MME_UE_S1AP_ID_FMT "\n",
+        ue_id);
   }
   if (ies->imsi) {
     imsi_ue_mm_ctx =
@@ -615,6 +621,10 @@ int emm_proc_attach_request(
       new_emm_ctx->volte_params.presencemask |=
           VOICE_DOMAIN_PREF_UE_USAGE_SETTING;
     }
+  }
+  if (ue_mm_context->is_unknown_guti) {
+    ue_mm_context->is_unknown_guti = false;
+    new_emm_ctx->is_unknown_guti   = true;
   }
   if (!is_nas_specific_procedure_attach_running(&ue_mm_context->emm_context)) {
     emm_proc_create_procedure_attach_request(ue_mm_context, ies);
@@ -1237,7 +1247,6 @@ static int emm_attach_failure_identification_cb(emm_context_t* emm_context) {
       LOG_NAS_EMM, emm_context->_imsi64,
       "ATTACH - Identification procedure failed!\n");
 
-  Fatal("Cannot happen...\n");
   OAILOG_FUNC_RETURN(LOG_NAS_EMM, rc);
 }
 
@@ -2677,11 +2686,46 @@ void proc_new_attach_req(
       }
     }
   }
-
-  /* Proceed with new attach request */
+  // Proceed with new attach request
   ue_mm_context_t* ue_mm_context =
       mme_ue_context_exists_mme_ue_s1ap_id(attach_info.mme_ue_s1ap_id);
   emm_context_t* new_emm_ctx = &ue_mm_context->emm_context;
+  /* In case of GUTI attach with unknown GUTI, attach procedure is already
+     created and identification procedure is also completed.
+     So invoke authentication procedure
+  */
+  if (new_emm_ctx && new_emm_ctx->is_unknown_guti) {
+    nas_emm_attach_proc_t* attach_proc =
+        get_nas_specific_procedure_attach(new_emm_ctx);
+    if (attach_proc) {
+      /* Upsert IMSI stored in emm context into the hashtable
+       * as it will be deleted during implicit detach
+       */
+      emm_context_upsert_imsi(&_emm_data, new_emm_ctx);
+      OAILOG_INFO(
+          LOG_NAS_EMM,
+          "EMM-PROC  - Triggering authentication for ue_id "
+          "= " MME_UE_S1AP_ID_FMT "\n",
+          ue_mm_context->mme_ue_s1ap_id);
+      if (emm_start_attach_proc_authentication(new_emm_ctx, attach_proc) !=
+          RETURNok) {
+        OAILOG_ERROR(
+            LOG_NAS_EMM,
+            "EMM-PROC  - Failed to start authentication procedure for ue_id "
+            "= " MME_UE_S1AP_ID_FMT "\n",
+            ue_mm_context->mme_ue_s1ap_id);
+      }
+    } else {
+      OAILOG_ERROR(
+          LOG_NAS_EMM,
+          "EMM-PROC  - Attach procedure does not exist for ue_id "
+          "= " MME_UE_S1AP_ID_FMT "\n",
+          ue_mm_context->mme_ue_s1ap_id);
+    }
+    new_emm_ctx->is_unknown_guti = false;
+    OAILOG_FUNC_OUT(LOG_NAS_EMM);
+  }
+
   bdestroy(new_emm_ctx->esm_msg);
   emm_init_context(new_emm_ctx, true);
 
@@ -2710,7 +2754,7 @@ void proc_new_attach_req(
   OAILOG_FUNC_OUT(LOG_NAS_EMM);
 }
 
-static void create_new_attach_info(
+void create_new_attach_info(
     emm_context_t* emm_context_p, mme_ue_s1ap_id_t mme_ue_s1ap_id,
     struct emm_attach_request_ies_s* ies, bool is_mm_ctx_new) {
   OAILOG_FUNC_IN(LOG_NAS_EMM);

--- a/lte/gateway/c/core/oai/tasks/nas/emm/Attach.c
+++ b/lte/gateway/c/core/oai/tasks/nas/emm/Attach.c
@@ -620,8 +620,8 @@ int emm_proc_attach_request(
     }
   }
   if (is_unknown_guti) {
-    is_unknown_guti              = false;
-    new_emm_ctx->is_unknown_guti = true;
+    is_unknown_guti                = false;
+    new_emm_ctx->emm_context_state = UNKOWN_GUTI;
   }
   if (!is_nas_specific_procedure_attach_running(&ue_mm_context->emm_context)) {
     emm_proc_create_procedure_attach_request(ue_mm_context, ies);
@@ -2692,7 +2692,8 @@ void proc_new_attach_req(
      created and identification procedure is also completed.
      So invoke authentication procedure
   */
-  if (new_emm_ctx && new_emm_ctx->is_unknown_guti) {
+  if (new_emm_ctx &&
+      (new_emm_ctx->emm_context_state == NEW_EMM_CONTEXT_CREATED)) {
     nas_emm_attach_proc_t* attach_proc =
         get_nas_specific_procedure_attach(new_emm_ctx);
     if (attach_proc) {
@@ -2720,7 +2721,7 @@ void proc_new_attach_req(
           "= " MME_UE_S1AP_ID_FMT "\n",
           ue_mm_context->mme_ue_s1ap_id);
     }
-    new_emm_ctx->is_unknown_guti = false;
+    new_emm_ctx->emm_context_state = NEW_EMM_CONTEXT_NOT_CREATED;
     OAILOG_FUNC_OUT(LOG_NAS_EMM);
   }
 

--- a/lte/gateway/c/core/oai/tasks/nas/emm/Attach.c
+++ b/lte/gateway/c/core/oai/tasks/nas/emm/Attach.c
@@ -162,10 +162,6 @@ static int emm_attach_update(
 
 static int emm_attach_accept_retx(emm_context_t* emm_context);
 
-void create_new_attach_info(
-    emm_context_t* emm_context_p, mme_ue_s1ap_id_t mme_ue_s1ap_id,
-    struct emm_attach_request_ies_s* ies, bool is_mm_ctx_new);
-
 /****************************************************************************/
 /******************  E X P O R T E D    F U N C T I O N S  ******************/
 /****************************************************************************/
@@ -208,6 +204,7 @@ int emm_proc_attach_request(
   ue_mm_context_t ue_ctx;
   emm_fsm_state_t fsm_state       = EMM_DEREGISTERED;
   bool clear_emm_ctxt             = false;
+  bool is_unknown_guti            = false;
   ue_mm_context_t* ue_mm_context  = NULL;
   ue_mm_context_t* guti_ue_mm_ctx = NULL;
   ue_mm_context_t* imsi_ue_mm_ctx = NULL;
@@ -335,8 +332,8 @@ int emm_proc_attach_request(
       OAILOG_FUNC_RETURN(LOG_NAS_EMM, RETURNok);
     }
     // Allocate new context and process the new request as fresh attach request
-    clear_emm_ctxt                 = true;
-    ue_mm_context->is_unknown_guti = true;
+    clear_emm_ctxt  = true;
+    is_unknown_guti = true;
     OAILOG_INFO(
         LOG_NAS_EMM,
         "EMM-PROC - Received Attach Request with unknown GUTI for ue_id "
@@ -622,9 +619,9 @@ int emm_proc_attach_request(
           VOICE_DOMAIN_PREF_UE_USAGE_SETTING;
     }
   }
-  if (ue_mm_context->is_unknown_guti) {
-    ue_mm_context->is_unknown_guti = false;
-    new_emm_ctx->is_unknown_guti   = true;
+  if (is_unknown_guti) {
+    is_unknown_guti              = false;
+    new_emm_ctx->is_unknown_guti = true;
   }
   if (!is_nas_specific_procedure_attach_running(&ue_mm_context->emm_context)) {
     emm_proc_create_procedure_attach_request(ue_mm_context, ies);
@@ -2752,16 +2749,5 @@ void proc_new_attach_req(
     emm_proc_create_procedure_attach_request(ue_mm_context, attach_info.ies);
   }
   emm_attach_run_procedure(&ue_mm_context->emm_context);
-  OAILOG_FUNC_OUT(LOG_NAS_EMM);
-}
-
-void create_new_attach_info(
-    emm_context_t* emm_context_p, mme_ue_s1ap_id_t mme_ue_s1ap_id,
-    struct emm_attach_request_ies_s* ies, bool is_mm_ctx_new) {
-  OAILOG_FUNC_IN(LOG_NAS_EMM);
-  emm_context_p->new_attach_info = calloc(1, sizeof(new_attach_info_t));
-  emm_context_p->new_attach_info->mme_ue_s1ap_id = mme_ue_s1ap_id;
-  emm_context_p->new_attach_info->ies            = ies;
-  emm_context_p->new_attach_info->is_mm_ctx_new  = is_mm_ctx_new;
   OAILOG_FUNC_OUT(LOG_NAS_EMM);
 }

--- a/lte/gateway/c/core/oai/tasks/nas/emm/Attach.c
+++ b/lte/gateway/c/core/oai/tasks/nas/emm/Attach.c
@@ -2686,6 +2686,7 @@ void proc_new_attach_req(
       }
     }
   }
+
   // Proceed with new attach request
   ue_mm_context_t* ue_mm_context =
       mme_ue_context_exists_mme_ue_s1ap_id(attach_info.mme_ue_s1ap_id);

--- a/lte/gateway/c/core/oai/tasks/nas/emm/Attach.c
+++ b/lte/gateway/c/core/oai/tasks/nas/emm/Attach.c
@@ -621,7 +621,7 @@ int emm_proc_attach_request(
   }
   if (is_unknown_guti) {
     is_unknown_guti                = false;
-    new_emm_ctx->emm_context_state = UNKOWN_GUTI;
+    new_emm_ctx->emm_context_state = UNKNOWN_GUTI;
   }
   if (!is_nas_specific_procedure_attach_running(&ue_mm_context->emm_context)) {
     emm_proc_create_procedure_attach_request(ue_mm_context, ies);

--- a/lte/gateway/c/core/oai/tasks/nas/emm/EmmCommon.c
+++ b/lte/gateway/c/core/oai/tasks/nas/emm/EmmCommon.c
@@ -487,3 +487,14 @@ void emm_proc_common_clear_args(mme_ue_s1ap_id_t ue_id) {
   }
   OAILOG_FUNC_OUT(LOG_NAS_EMM);
 }
+
+void create_new_attach_info(
+    emm_context_t* emm_context_p, mme_ue_s1ap_id_t mme_ue_s1ap_id,
+    struct emm_attach_request_ies_s* ies, bool is_mm_ctx_new) {
+  OAILOG_FUNC_IN(LOG_NAS_EMM);
+  emm_context_p->new_attach_info = calloc(1, sizeof(new_attach_info_t));
+  emm_context_p->new_attach_info->mme_ue_s1ap_id = mme_ue_s1ap_id;
+  emm_context_p->new_attach_info->ies            = ies;
+  emm_context_p->new_attach_info->is_mm_ctx_new  = is_mm_ctx_new;
+  OAILOG_FUNC_OUT(LOG_NAS_EMM);
+}

--- a/lte/gateway/c/core/oai/tasks/nas/emm/EmmCommon.h
+++ b/lte/gateway/c/core/oai/tasks/nas/emm/EmmCommon.h
@@ -129,4 +129,7 @@ void emm_common_cleanup_by_ueid(mme_ue_s1ap_id_t ue_id);
 struct emm_common_data_s* emm_common_data_context_get(
     struct emm_common_data_head_s* root, mme_ue_s1ap_id_t _ueid);
 
+void create_new_attach_info(
+    emm_context_t* emm_context_p, mme_ue_s1ap_id_t mme_ue_s1ap_id,
+    struct emm_attach_request_ies_s* ies, bool is_mm_ctx_new);
 #endif /* FILE_EMM_COMMON_SEEN*/

--- a/lte/gateway/c/core/oai/tasks/nas/emm/Identification.c
+++ b/lte/gateway/c/core/oai/tasks/nas/emm/Identification.c
@@ -54,9 +54,6 @@ extern mme_congestion_params_t mme_congestion_params;
 
 extern int check_plmn_restriction(imsi_t imsi);
 extern int validate_imei(imeisv_t* imeisv);
-extern void create_new_attach_info(
-    emm_context_t* emm_context_p, mme_ue_s1ap_id_t mme_ue_s1ap_id,
-    struct emm_attach_request_ies_s* ies, bool is_mm_ctx_new);
 /****************************************************************************/
 /*******************  L O C A L    D E F I N I T I O N S  *******************/
 /****************************************************************************/
@@ -269,7 +266,7 @@ int emm_proc_identification_complete(
         if (emm_ctx->is_unknown_guti && old_imsi_ue_mm_ctx) {
           OAILOG_INFO_UE(
               LOG_NAS_EMM, imsi64,
-              "EMMAS-SAP - Old ue context already exists for for ue_id "
+              "EMMAS-SAP - UE context already exists for for ue_id "
               "=." MME_UE_S1AP_ID_FMT " Triggering implicit detach\n",
               ue_id);
           nas_emm_attach_proc_t* attach_proc =

--- a/lte/gateway/c/core/oai/tasks/nas/emm/Identification.c
+++ b/lte/gateway/c/core/oai/tasks/nas/emm/Identification.c
@@ -42,6 +42,7 @@
 #include "mme_app_defs.h"
 #include "mme_app_state.h"
 #include "nas_procedures.h"
+#include "nas_proc.h"
 
 /****************************************************************************/
 /****************  E X T E R N A L    D E F I N I T I O N S  ****************/
@@ -53,6 +54,9 @@ extern mme_congestion_params_t mme_congestion_params;
 
 extern int check_plmn_restriction(imsi_t imsi);
 extern int validate_imei(imeisv_t* imeisv);
+extern void create_new_attach_info(
+    emm_context_t* emm_context_p, mme_ue_s1ap_id_t mme_ue_s1ap_id,
+    struct emm_attach_request_ies_s* ies, bool is_mm_ctx_new);
 /****************************************************************************/
 /*******************  L O C A L    D E F I N I T I O N S  *******************/
 /****************************************************************************/
@@ -206,6 +210,7 @@ int emm_proc_identification_complete(
   int rc                 = RETURNerror;
   emm_sap_t emm_sap      = {0};
   emm_context_t* emm_ctx = NULL;
+  bool notify            = true;
 
   OAILOG_INFO(
       LOG_NAS_EMM,
@@ -257,7 +262,33 @@ int emm_proc_identification_complete(
 
       if (imsi) {
         imsi64_t imsi64 = imsi_to_imsi64(imsi);
-        int emm_cause   = check_plmn_restriction(*imsi);
+        // If context already exists for this IMSI ,perform implicit detach
+        mme_app_desc_t* mme_app_desc_p      = get_mme_nas_state(false);
+        ue_mm_context_t* old_imsi_ue_mm_ctx = mme_ue_context_exists_imsi(
+            &mme_app_desc_p->mme_ue_contexts, imsi64);
+        if (emm_ctx->is_unknown_guti && old_imsi_ue_mm_ctx) {
+          OAILOG_INFO_UE(
+              LOG_NAS_EMM, imsi64,
+              "EMMAS-SAP - Old ue context already exists for for ue_id "
+              "=." MME_UE_S1AP_ID_FMT " Triggering implicit detach\n",
+              ue_id);
+          nas_emm_attach_proc_t* attach_proc =
+              get_nas_specific_procedure_attach(emm_ctx);
+          if (!attach_proc) {
+            OAILOG_ERROR_UE(
+                LOG_NAS_EMM, imsi64,
+                "EMMAS-SAP - Attach procedure does not exist for ue_id "
+                "=" MME_UE_S1AP_ID_FMT "\n",
+                ue_id);
+            OAILOG_FUNC_RETURN(LOG_NAS_EMM, RETURNerror);
+          }
+          create_new_attach_info(
+              &old_imsi_ue_mm_ctx->emm_context, ue_mm_context->mme_ue_s1ap_id,
+              attach_proc->ies, true);
+          nas_proc_implicit_detach_ue_ind(old_imsi_ue_mm_ctx->mme_ue_s1ap_id);
+          notify = false;
+        }
+        int emm_cause = check_plmn_restriction(*imsi);
         if (emm_cause != EMM_CAUSE_SUCCESS) {
           OAILOG_ERROR_UE(
               LOG_NAS_EMM, imsi64,
@@ -267,7 +298,6 @@ int emm_proc_identification_complete(
           rc = emm_proc_attach_reject(ue_id, emm_cause);
           OAILOG_FUNC_RETURN(LOG_NAS_EMM, rc);
         }
-
         /*
          * Update the IMSI
          */
@@ -296,9 +326,11 @@ int emm_proc_identification_complete(
         /*
          * Update the GUTI
          */
-        Fatal(
-            "TODO, should not happen because this type of identity is not "
-            "requested by MME");
+        OAILOG_ERROR(
+            LOG_NAS_EMM,
+            "EMMAS-SAP - Received TMSI in Identication rsp for ue_id "
+            "=" MME_UE_S1AP_ID_FMT ", This case is not handled!\n",
+            ue_id);
       }
 
       /*
@@ -307,7 +339,7 @@ int emm_proc_identification_complete(
       emm_sap.primitive                      = EMMREG_COMMON_PROC_CNF;
       emm_sap.u.emm_reg.ue_id                = ue_id;
       emm_sap.u.emm_reg.ctx                  = emm_ctx;
-      emm_sap.u.emm_reg.notify               = true;
+      emm_sap.u.emm_reg.notify               = notify;
       emm_sap.u.emm_reg.free_proc            = true;
       emm_sap.u.emm_reg.u.common.common_proc = &ident_proc->emm_com_proc;
       emm_sap.u.emm_reg.u.common.previous_emm_fsm_state =

--- a/lte/gateway/c/core/oai/tasks/nas/emm/Identification.c
+++ b/lte/gateway/c/core/oai/tasks/nas/emm/Identification.c
@@ -263,7 +263,7 @@ int emm_proc_identification_complete(
         mme_app_desc_t* mme_app_desc_p      = get_mme_nas_state(false);
         ue_mm_context_t* old_imsi_ue_mm_ctx = mme_ue_context_exists_imsi(
             &mme_app_desc_p->mme_ue_contexts, imsi64);
-        if (emm_ctx->is_unknown_guti && old_imsi_ue_mm_ctx) {
+        if ((emm_ctx->emm_context_state == UNKOWN_GUTI) && old_imsi_ue_mm_ctx) {
           OAILOG_INFO_UE(
               LOG_NAS_EMM, imsi64,
               "EMMAS-SAP - UE context already exists for for ue_id "
@@ -282,6 +282,7 @@ int emm_proc_identification_complete(
           create_new_attach_info(
               &old_imsi_ue_mm_ctx->emm_context, ue_mm_context->mme_ue_s1ap_id,
               attach_proc->ies, true);
+          emm_ctx->emm_context_state = NEW_EMM_CONTEXT_CREATED;
           nas_proc_implicit_detach_ue_ind(old_imsi_ue_mm_ctx->mme_ue_s1ap_id);
           notify = false;
         }

--- a/lte/gateway/c/core/oai/tasks/nas/emm/Identification.c
+++ b/lte/gateway/c/core/oai/tasks/nas/emm/Identification.c
@@ -263,7 +263,8 @@ int emm_proc_identification_complete(
         mme_app_desc_t* mme_app_desc_p      = get_mme_nas_state(false);
         ue_mm_context_t* old_imsi_ue_mm_ctx = mme_ue_context_exists_imsi(
             &mme_app_desc_p->mme_ue_contexts, imsi64);
-        if ((emm_ctx->emm_context_state == UNKOWN_GUTI) && old_imsi_ue_mm_ctx) {
+        if ((emm_ctx->emm_context_state == UNKNOWN_GUTI) &&
+            old_imsi_ue_mm_ctx) {
           OAILOG_INFO_UE(
               LOG_NAS_EMM, imsi64,
               "EMMAS-SAP - UE context already exists for for ue_id "

--- a/lte/gateway/c/core/oai/tasks/nas/emm/Identification.c
+++ b/lte/gateway/c/core/oai/tasks/nas/emm/Identification.c
@@ -298,6 +298,7 @@ int emm_proc_identification_complete(
           rc = emm_proc_attach_reject(ue_id, emm_cause);
           OAILOG_FUNC_RETURN(LOG_NAS_EMM, rc);
         }
+
         /*
          * Update the IMSI
          */

--- a/lte/gateway/c/core/oai/tasks/nas/emm/emm_data.h
+++ b/lte/gateway/c/core/oai/tasks/nas/emm/emm_data.h
@@ -118,6 +118,11 @@ typedef struct emm_security_context_s {
 struct emm_common_data_s;
 
 typedef enum { SUCCESS, FAILURE } sgs_loc_updt_status_t;
+typedef enum {
+  NEW_EMM_CONTEXT_NOT_CREATED,
+  NEW_EMM_CONTEXT_CREATED,
+  UNKOWN_GUTI
+} emm_context_state_t;
 
 typedef struct csfb_params_s {
 #define MOBILE_IDENTITY (1 << 0)
@@ -376,7 +381,7 @@ typedef struct emm_context_s {
   bool nw_init_bearer_deactv;
   new_attach_info_t* new_attach_info;
   bool initiate_identity_after_smc;
-  bool is_unknown_guti;
+  emm_context_state_t emm_context_state;
 } emm_context_t;
 
 /*

--- a/lte/gateway/c/core/oai/tasks/nas/emm/emm_data.h
+++ b/lte/gateway/c/core/oai/tasks/nas/emm/emm_data.h
@@ -376,6 +376,7 @@ typedef struct emm_context_s {
   bool nw_init_bearer_deactv;
   new_attach_info_t* new_attach_info;
   bool initiate_identity_after_smc;
+  bool is_unknown_guti;
 } emm_context_t;
 
 /*

--- a/lte/gateway/c/core/oai/tasks/nas/emm/emm_data.h
+++ b/lte/gateway/c/core/oai/tasks/nas/emm/emm_data.h
@@ -121,7 +121,7 @@ typedef enum { SUCCESS, FAILURE } sgs_loc_updt_status_t;
 typedef enum {
   NEW_EMM_CONTEXT_NOT_CREATED,
   NEW_EMM_CONTEXT_CREATED,
-  UNKOWN_GUTI
+  UNKNOWN_GUTI
 } emm_context_state_t;
 
 typedef struct csfb_params_s {

--- a/lte/gateway/c/core/oai/tasks/nas/emm/emm_data_ctx.c
+++ b/lte/gateway/c/core/oai/tasks/nas/emm/emm_data_ctx.c
@@ -951,9 +951,10 @@ void emm_init_context(
   emm_ctx_clear_drx_parameter(emm_ctx);
   emm_ctx_clear_mobile_station_clsMark2(emm_ctx);
   emm_ctx_clear_ue_additional_security_capability(emm_ctx);
-  emm_ctx->T3422.id        = NAS_TIMER_INACTIVE_ID;
-  emm_ctx->T3422.sec       = T3422_DEFAULT_VALUE;
-  emm_ctx->new_attach_info = NULL;
+  emm_ctx->T3422.id          = NAS_TIMER_INACTIVE_ID;
+  emm_ctx->T3422.sec         = T3422_DEFAULT_VALUE;
+  emm_ctx->new_attach_info   = NULL;
+  emm_ctx->emm_context_state = NEW_EMM_CONTEXT_NOT_CREATED;
 
   if (init_esm_ctxt) {
     esm_init_context(&emm_ctx->esm_ctx);


### PR DESCRIPTION
<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

- Backporting changes to v1.6 from #7916 
- SEGV issue will be merged and fixed as part of backporting #9002 to v1.6

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->
- Verified with s1ap tester as sanity
- Ran `test_guti_attach_with_zero_mtmsi.py` to validate fix 

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
