### PR TITLE
fix(mme): Adding write of MME UE state for NAS uplink data ind handlers

### DIFF
--- a/lte/gateway/c/core/oai/include/mme_app_state.h
+++ b/lte/gateway/c/core/oai/include/mme_app_state.h
@@ -54,7 +54,8 @@ void clear_mme_nas_state(void);
 // Returns UE MME state hashtable, indexed by IMSI
 hash_table_ts_t* get_mme_ue_state(void);
 // Persists UE MME state for subscriber into db
-void put_mme_ue_state(mme_app_desc_t* mme_app_desc_p, imsi64_t imsi64);
+void put_mme_ue_state(
+    mme_app_desc_t* mme_app_desc_p, imsi64_t imsi64, bool force_ue_write);
 // Deletes entry for UE MME state on db
 void delete_mme_ue_state(imsi64_t imsi64);
 

--- a/lte/gateway/c/core/oai/tasks/mme_app/mme_app_context.c
+++ b/lte/gateway/c/core/oai/tasks/mme_app/mme_app_context.c
@@ -790,7 +790,13 @@ void mme_remove_ue_context(
           ue_context_p->enb_ue_s1ap_id, ue_context_p->mme_ue_s1ap_id);
   }
 
-  _clear_emm_ctxt(&ue_context_p->emm_context);
+  /*
+   * Release ESM PDN and bearer context
+   */
+  release_esm_pdn_context(
+      &ue_context_p->emm_context, ue_context_p->mme_ue_s1ap_id);
+  clear_emm_ctxt(&ue_context_p->emm_context);
+
   // eNB UE S1P UE ID
   hash_rc = hashtable_uint64_ts_remove(
       mme_ue_context_p->enb_ue_s1ap_id_ue_context_htbl,

--- a/lte/gateway/c/core/oai/tasks/mme_app/mme_app_main.c
+++ b/lte/gateway/c/core/oai/tasks/mme_app/mme_app_main.c
@@ -74,6 +74,7 @@ static int handle_message(zloop_t* loop, zsock_t* reader, void* arg) {
   mme_app_desc_t* mme_app_desc_p = get_mme_nas_state(false);
 
   bool is_task_state_same = false;
+  bool force_ue_write     = false;
 
   mme_app_last_msg_latency =
       ITTI_MSG_LATENCY(received_message_p);  // microseconds
@@ -109,6 +110,7 @@ static int handle_message(zloop_t* loop, zsock_t* reader, void* arg) {
           MME_APP_UL_DATA_IND(received_message_p).tai,
           MME_APP_UL_DATA_IND(received_message_p).cgi,
           &MME_APP_UL_DATA_IND(received_message_p).nas_msg);
+      force_ue_write     = true;
       is_task_state_same = true;
     } break;
 
@@ -180,6 +182,7 @@ static int handle_message(zloop_t* loop, zsock_t* reader, void* arg) {
           ue_context_p->ue_context_rel_cause = S1AP_INVALID_CAUSE;
           mme_app_handle_ue_offload(ue_context_p);
         }
+        force_ue_write = true;
       }
     } break;
 
@@ -501,7 +504,7 @@ static int handle_message(zloop_t* loop, zsock_t* reader, void* arg) {
     } break;
   }
 
-  put_mme_ue_state(mme_app_desc_p, imsi64);
+  put_mme_ue_state(mme_app_desc_p, imsi64, force_ue_write);
 
   if (!is_task_state_same) {
     put_mme_nas_state();

--- a/lte/gateway/c/core/oai/tasks/mme_app/mme_app_state.cpp
+++ b/lte/gateway/c/core/oai/tasks/mme_app/mme_app_state.cpp
@@ -61,13 +61,17 @@ hash_table_ts_t* get_mme_ue_state() {
   return MmeNasStateManager::getInstance().get_ue_state_ht();
 }
 
-void put_mme_ue_state(mme_app_desc_t* mme_app_desc_p, imsi64_t imsi64) {
+void put_mme_ue_state(
+    mme_app_desc_t* mme_app_desc_p, imsi64_t imsi64, bool force_ue_write) {
   if (MmeNasStateManager::getInstance().is_persist_state_enabled()) {
     if (imsi64 != INVALID_IMSI64) {
       ue_mm_context_t* ue_context = nullptr;
       ue_context =
           mme_ue_context_exists_imsi(&mme_app_desc_p->mme_ue_contexts, imsi64);
-      if (ue_context && ue_context->mm_state == UE_REGISTERED) {
+      // Only write MME UE state to redis if force flag is set or UE is in EMM
+      // Registered state
+      if ((ue_context && force_ue_write) ||
+          (ue_context && ue_context->mm_state == UE_REGISTERED)) {
         auto imsi_str = MmeNasStateManager::getInstance().get_imsi_str(imsi64);
         MmeNasStateManager::getInstance().write_ue_state_to_db(
             ue_context, imsi_str);

--- a/lte/gateway/c/core/oai/tasks/nas/emm/Attach.c
+++ b/lte/gateway/c/core/oai/tasks/nas/emm/Attach.c
@@ -847,7 +847,7 @@ int emm_proc_attach_complete(
           LOG_NAS_EMM,
           " Sending EMM INFORMATION for ue_id = " MME_UE_S1AP_ID_FMT "\n",
           ue_id);
-      emm_proc_emm_informtion(ue_mm_context);
+      emm_proc_emm_information(ue_mm_context);
       increment_counter("ue_attach", 1, 1, "result", "attach_proc_successful");
       attach_success_event(ue_mm_context->emm_context._imsi64);
     }

--- a/lte/gateway/c/core/oai/tasks/nas/emm/EmmInformation.c
+++ b/lte/gateway/c/core/oai/tasks/nas/emm/EmmInformation.c
@@ -68,7 +68,7 @@
 
 static void emm_information_pack_gsm_7Bit(bstring str, unsigned char* result);
 
-int emm_proc_emm_informtion(ue_mm_context_t* ue_emm_ctx) {
+int emm_proc_emm_information(ue_mm_context_t* ue_emm_ctx) {
   int rc                    = RETURNerror;
   unsigned char result[256] = {0};
   emm_sap_t emm_sap         = {0};

--- a/lte/gateway/c/core/oai/tasks/nas/emm/emm_proc.h
+++ b/lte/gateway/c/core/oai/tasks/nas/emm/emm_proc.h
@@ -294,9 +294,11 @@ int emm_proc_security_mode_control(
 int emm_proc_security_mode_complete(
     mme_ue_s1ap_id_t ue_id, const imeisv_mobile_identity_t* const imeisv);
 int emm_proc_security_mode_reject(mme_ue_s1ap_id_t ue_id);
-int emm_proc_emm_informtion(ue_mm_context_t* emm_ctx);
+int emm_proc_emm_information(ue_mm_context_t* emm_ctx);
 
-void _clear_emm_ctxt(emm_context_t* emm_ctx);
+status_code_e release_esm_pdn_context(
+    emm_context_t* emm_ctx, mme_ue_s1ap_id_t ue_id);
+void clear_emm_ctxt(emm_context_t* emm_ctx);
 
 int emm_proc_tau_complete(mme_ue_s1ap_id_t ue_id);
 int emm_send_service_reject_in_dl_nas(

--- a/lte/gateway/c/core/oai/tasks/nas/emm/sap/emm_cn.c
+++ b/lte/gateway/c/core/oai/tasks/nas/emm/sap/emm_cn.c
@@ -1031,7 +1031,7 @@ static int emm_cn_cs_domain_mm_information_req(
     }
 
     if (ue_context_p->sgs_context->sgs_state == SGS_ASSOCIATED) {
-      if ((rc = emm_proc_emm_informtion(ue_context_p)) != RETURNok) {
+      if ((rc = emm_proc_emm_information(ue_context_p)) != RETURNok) {
         OAILOG_WARNING(
             LOG_NAS_EMM,
             "Failed to send Emm Information Reqest for " IMSI_64_FMT "\n",

--- a/lte/gateway/c/core/oai/tasks/nas/nas_state_converter.cpp
+++ b/lte/gateway/c/core/oai/tasks/nas/nas_state_converter.cpp
@@ -20,7 +20,6 @@ extern "C" {
 }
 
 #include "nas_state_converter.h"
-//#include "spgw_state_converter.h"
 
 namespace magma {
 namespace lte {
@@ -475,6 +474,7 @@ void NasStateConverter::proto_to_esm_ebr_context(
         esm_ebr_context_proto.esm_ebr_timer_data(),
         &state_esm_ebr_context->args);
   }
+  state_esm_ebr_context->timer.id = NAS_TIMER_INACTIVE_ID;
 }
 
 /*************************************************/
@@ -857,6 +857,7 @@ void NasStateConverter::proto_to_nas_emm_attach_proc(
   state_nas_emm_attach_proc->ksi       = attach_proc_proto.ksi();
   state_nas_emm_attach_proc->emm_cause = attach_proc_proto.emm_cause();
   state_nas_emm_attach_proc->T3450.sec = T3450_DEFAULT_VALUE;
+  state_nas_emm_attach_proc->T3450.id  = NAS_TIMER_INACTIVE_ID;
   set_callbacks_for_attach_proc(state_nas_emm_attach_proc);
 }
 
@@ -994,6 +995,7 @@ void NasStateConverter::proto_to_nas_emm_auth_proc(
 
   state_nas_emm_auth_proc->emm_cause = auth_proc_proto.emm_cause();
   state_nas_emm_auth_proc->T3460.sec = T3460_DEFAULT_VALUE;
+  state_nas_emm_auth_proc->T3460.id  = NAS_TIMER_INACTIVE_ID;
   // update callback functions for auth proc
   set_callbacks_for_auth_proc(state_nas_emm_auth_proc);
   set_notif_callbacks_for_auth_proc(state_nas_emm_auth_proc);
@@ -1064,6 +1066,10 @@ void NasStateConverter::proto_to_nas_emm_smc_proc(
   state_nas_emm_smc_proc->notify_failure = smc_proc_proto.notify_failure();
   state_nas_emm_smc_proc->is_new         = smc_proc_proto.is_new();
   state_nas_emm_smc_proc->imeisv_request = smc_proc_proto.imeisv_request();
+
+  state_nas_emm_smc_proc->T3460.sec = T3460_DEFAULT_VALUE;
+  state_nas_emm_smc_proc->T3460.id  = NAS_TIMER_INACTIVE_ID;
+
   set_notif_callbacks_for_smc_proc(state_nas_emm_smc_proc);
   set_callbacks_for_smc_proc(state_nas_emm_smc_proc);
 }

--- a/lte/gateway/c/core/oai/tasks/nas/nas_state_converter.h
+++ b/lte/gateway/c/core/oai/tasks/nas/nas_state_converter.h
@@ -127,6 +127,22 @@ class NasStateConverter : StateConverter {
       const oai::EsmEbrTimerData& proto_esm_ebr_timer_data,
       esm_ebr_timer_data_t** state_esm_ebr_timer_data);
 
+  static void proto_to_esm_context(
+      const oai::EsmContext& esm_context_proto,
+      esm_context_t* state_esm_context);
+
+  static void proto_to_nas_emm_attach_proc(
+      const oai::AttachProc& attach_proc_proto,
+      nas_emm_attach_proc_t* state_nas_emm_attach_proc);
+
+  static void proto_to_nas_emm_smc_proc(
+      const oai::SmcProc& smc_proc_proto,
+      nas_emm_smc_proc_t* state_nas_emm_smc_proc);
+
+  static void proto_to_nas_emm_auth_proc(
+      const oai::AuthProc& auth_proc_proto,
+      nas_emm_auth_proc_t* state_nas_emm_auth_proc);
+
  private:
   static void partial_tai_list_to_proto(
       const partial_tai_list_t* state_partial_tai_list,
@@ -206,10 +222,6 @@ class NasStateConverter : StateConverter {
       const esm_context_t* state_esm_context,
       oai::EsmContext* esm_context_proto);
 
-  static void proto_to_esm_context(
-      const oai::EsmContext& esm_context_proto,
-      esm_context_t* state_esm_context);
-
   static void nas_message_decode_status_to_proto(
       const nas_message_decode_status_t* state_nas_message_decode_status,
       oai::NasMsgDecodeStatus* nas_msg_decode_status_proto);
@@ -229,10 +241,6 @@ class NasStateConverter : StateConverter {
   static void nas_attach_proc_to_proto(
       const nas_emm_attach_proc_t* state_nas_attach_proc,
       oai::AttachProc* attach_proc_proto);
-
-  static void proto_to_nas_emm_attach_proc(
-      const oai::AttachProc& attach_proc_proto,
-      nas_emm_attach_proc_t* state_nas_emm_attach_proc);
 
   static void emm_detach_request_ies_to_proto(
       const emm_detach_request_ies_t* state_emm_detach_request_ies,
@@ -262,17 +270,9 @@ class NasStateConverter : StateConverter {
       const nas_emm_auth_proc_t* state_nas_emm_auth_proc,
       oai::AuthProc* auth_proc_proto);
 
-  static void proto_to_nas_emm_auth_proc(
-      const oai::AuthProc& auth_proc_proto,
-      nas_emm_auth_proc_t* state_nas_emm_auth_proc);
-
   static void nas_emm_smc_proc_to_proto(
       const nas_emm_smc_proc_t* state_nas_emm_smc_proc,
       oai::SmcProc* smc_proc_proto);
-
-  static void proto_to_nas_emm_smc_proc(
-      const oai::SmcProc& smc_proc_proto,
-      nas_emm_smc_proc_t* state_nas_emm_smc_proc);
 
   static void nas_proc_mess_sign_to_proto(
       const nas_proc_mess_sign_t* state_nas_proc_mess_sign,


### PR DESCRIPTION
Signed-off-by: Alex Rodriguez <ardzoht@gmail.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->
- Backporting changes from #8986 to `v1.6` branch to fix MME UE state write for attach procedure cases

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->
- Ran non sanity restart tests on v1.6 

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
