### PR TITLE
chore: remove manual configuration of sentry release version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -302,8 +302,8 @@ commands:
       - run:
           name: Upload debug artifacts for an executable to Sentry.io
           command: |
-            # The assumption here is that packages.tar.gz was tarred in
-            # $MAGMA_ROOT/circleci in the magma_integ_test step
+            # The assumption here is that packages.tar.gz was copied out and untarred
+            # in $MAGMA_ROOT/circleci in the magma_integ_test step
             cd circleci/executables
 
             SENTRY_ORG="lf-9c"
@@ -337,7 +337,10 @@ commands:
       - run:
           name: Create a release in Sentry.io with the commit hash
           command: |
-            COMMIT_HASH_WITH_VERSION="1.7.0-${CIRCLE_SHA1:0:8}"
+            # The assumption here is that the magma version is copied out
+            # into /home/circleci/project/circleci in the magma_integ_test step
+            COMMIT_HASH_WITH_VERSION=$(cat circleci/magma_version)
+            echo ${COMMIT_HASH_WITH_VERSION}
             sentry-cli --log-level=info releases new -p lab-agws-python -p lab-agws-native ${COMMIT_HASH_WITH_VERSION}
             sentry-cli --log-level=info releases set-commits --auto --ignore-missing ${COMMIT_HASH_WITH_VERSION}
             sentry-cli --log-level=info releases finalize ${COMMIT_HASH_WITH_VERSION}


### PR DESCRIPTION
Signed-off-by: Marie Bremner <marwhal@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary
Currently, everytime a new branch is cut two values need to be updated. The magma version in build-magma.sh and this sentry version in .circleci/config.yml. This PR makes it so that we read from the version set in build-magma.sh. (The value is written into a magma_version file in the packaging process).


<!-- Enumerate changes you made and why you made them -->

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
