### PR TITLE
ci: ensures ci dockerfiles finalize with ldconfig

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -304,3 +304,8 @@ RUN git clone https://github.com/OPENAIRINTERFACE/opencord.org.freeDiameter.git 
     make install && \
     cd / && \
     rm -rf freediameter
+
+#### Update shared library configuration
+RUN ldconfig -v
+
+WORKDIR /workspaces/magma

--- a/experimental/bazel-base/Dockerfile
+++ b/experimental/bazel-base/Dockerfile
@@ -82,4 +82,7 @@ RUN git clone --branch v4.3 https://github.com/mfontanini/libtins.git && \
     # symlink to /usr/lib to match Magma VM
     ln -s /usr/local/lib/libtins.so /usr/lib/libtins.so
 
+#### Update shared library configuration
+RUN ldconfig -v
+
 WORKDIR /magma


### PR DESCRIPTION
## Summary

Some recent Bazel PRs have failed in various environments because the shared libraries are not fully integrated into their expected paths and representations.

To ensure a canonical set of shared library availability in expected paths, we refresh the final shared library configuration by use of ldconfig in these dockerfiles, as a finalization action.

## Test Plan

Built devcontainer and demonstrated `bazel test ... --config=devcontainer` functions propery for #9224.

Signed-off-by: Scott Moeller <electronjoe@gmail.com>