### PR TITLE
fix(ci): Changes to fix issue 8165 to Aggregate PR comment on check failure

### DIFF
--- a/.github/workflows/comment-pr-on-check-failure.yml
+++ b/.github/workflows/comment-pr-on-check-failure.yml
@@ -10,34 +10,16 @@ on:  # yamllint disable-line rule:truthy
       - completed
 
 jobs:
-  on-failure:
+  comment_pr:
     runs-on: ubuntu-latest
-    if: ${{ github.event.workflow_run.conclusion == 'failure' }}
     env:
       CHECK_GUIDELINE: "[Guide to the different CI checks and resolution guidelines](https://docs.magmacore.org/docs/next/contributing/contribute_ci_checks)"
+      WORKFLOW_NAME: "${{ github.event.workflow.name }}"
+      WORKFLOW_STATUS: "${{ github.event.workflow_run.conclusion }}"
+      COMMIT_ID: "${{ github.event.workflow_run.pull_requests[0].head.sha }}"
+      COMMIT_ID_URL: "${{ github.event.repository.html_url }}/commit/${{ github.event.workflow_run.pull_requests[0].head.sha }}"
     steps:
       # Retrieve PR number from triggering workflow artifacts
-      - name: 'Download artifact'
-        uses: actions/github-script@v3.1.0
-        with:
-          script: |
-            var artifacts = await github.actions.listWorkflowRunArtifacts({
-               owner: context.repo.owner,
-               repo: context.repo.repo,
-               run_id: ${{github.event.workflow_run.id }},
-            });
-            var matchArtifact = artifacts.data.artifacts.filter((artifact) => {
-              return artifact.name == "pr"
-            })[0];
-            var download = await github.actions.downloadArtifact({
-               owner: context.repo.owner,
-               repo: context.repo.repo,
-               artifact_id: matchArtifact.id,
-               archive_format: 'zip',
-            });
-            var fs = require('fs');
-            fs.writeFileSync('${{github.workspace}}/pr.zip', Buffer.from(download.data));
-      - run: unzip pr.zip
       - name: DCO comment message
         if: ${{ github.event.workflow.name == 'DCO check' }}
         run: |
@@ -68,12 +50,48 @@ jobs:
         with:
           script: |
             var fs = require('fs');
-            var issue_number = Number(fs.readFileSync('./NR'));
-            const msg = fs.readFileSync('./msg',{encoding: 'utf8'})
+            const msg = fs.readFileSync('./msg',{encoding: 'utf8'});
+            var issue_number = ${{ github.event.workflow_run.pull_requests[0].number }};
+            var commentId = 0;
+            var oldMsg = '';
+            var updMsg = '';
+            var newMsg = '';
+            var shortCommitId = process.env.COMMIT_ID.substr(0,8);
 
-            github.issues.createComment({
-              issue_number: issue_number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body: msg,
-            })
+            const commentsList = await github.issues.listComments({
+                                        owner: context.repo.owner,
+                                        repo: context.repo.repo,
+                                        issue_number: issue_number,
+                                      });
+
+            for (const c of commentsList['data']) {
+              oldMsg = c.body;
+              if( oldMsg.includes('Oops! Looks like you failed the ') && oldMsg.includes(process.env.WORKFLOW_NAME) ) {
+                  commentId = c.id;
+                  if( process.env.WORKFLOW_STATUS == 'failure' )  {
+                      updMsg = ":recycle: Updated: :x: The check is still failing the " + process.env.WORKFLOW_NAME + " on last commit id: [" + shortCommitId + "](" + process.env.COMMIT_ID_URL + ")";
+                  }
+                  else  {
+                      updMsg = ":recycle: Updated: :white_check_mark: The check is passing the " + process.env.WORKFLOW_NAME + " on last commit id: [" + shortCommitId + "](" + process.env.COMMIT_ID_URL + ")";
+                  }
+                  newMsg = oldMsg + "\n\n" + updMsg;
+                  console.log("UPDATING comment=" + newMsg);
+                  github.issues.updateComment({
+                                owner: context.repo.owner,
+                                repo: context.repo.repo,
+                                comment_id: commentId,
+                                body: newMsg,
+                              });
+                  break;
+              } // end of if block
+            } // end of for loop on commentsList
+
+            if( (commentId == 0) && (process.env.WORKFLOW_STATUS == 'failure') ) {
+              console.log("CREATING comment=" + msg);
+              github.issues.createComment({
+                            issue_number: issue_number,
+                            owner: context.repo.owner,
+                            repo: context.repo.repo,
+                            body: msg,
+                          });
+            }

--- a/.github/workflows/comment-pr-on-check-failure.yml
+++ b/.github/workflows/comment-pr-on-check-failure.yml
@@ -66,15 +66,15 @@ jobs:
 
             for (const c of commentsList['data']) {
               oldMsg = c.body;
-              if( oldMsg.includes('Oops! Looks like you failed the ') && oldMsg.includes(process.env.WORKFLOW_NAME) ) {
+              if( oldMsg.includes('Oops! Looks like you failed the `' + process.env.WORKFLOW_NAME) ) {
                   commentId = c.id;
                   if( process.env.WORKFLOW_STATUS == 'failure' )  {
                       updMsg = ":recycle: Updated: :x: The check is still failing the " + process.env.WORKFLOW_NAME + " on last commit id: [" + shortCommitId + "](" + process.env.COMMIT_ID_URL + ")";
                   }
-                  else  {
+                  else if( process.env.WORKFLOW_STATUS == 'success' ) {
                       updMsg = ":recycle: Updated: :white_check_mark: The check is passing the " + process.env.WORKFLOW_NAME + " on last commit id: [" + shortCommitId + "](" + process.env.COMMIT_ID_URL + ")";
                   }
-                  newMsg = oldMsg + "\n\n" + updMsg;
+                  newMsg = msg + "\n\n" + updMsg;
                   console.log("UPDATING comment=" + newMsg);
                   github.issues.updateComment({
                                 owner: context.repo.owner,

--- a/.github/workflows/dco-check.yml
+++ b/.github/workflows/dco-check.yml
@@ -18,14 +18,4 @@ jobs:
       uses: tim-actions/dco@master
       with:
         commits: ${{ steps.get-pr-commits.outputs.commits }}
-    # Need to save PR number as Github action does not propagate it with workflow_run event
-    - name: Save PR number
-      if: failure()
-      run: |
-        mkdir -p ./pr
-        echo ${{ github.event.number }} > ./pr/NR
-    - uses: actions/upload-artifact@v2
-      if: failure()
-      with:
-        name: pr
-        path: pr/
+

--- a/.github/workflows/python-workflow.yml
+++ b/.github/workflows/python-workflow.yml
@@ -57,14 +57,4 @@ jobs:
               autopep8 --exit-code --select W191,W291,W292,W293,W391,E131,E2,E3 -r --in-place  $file;
               add-trailing-comma --py35-plus $file;
             done;
-      # Need to save PR number as Github action does not propagate it with workflow_run event
-      - name: Save PR number
-        if: failure()
-        run: |
-          mkdir -p ./pr
-          echo ${{ github.event.number }} > ./pr/NR
-      - uses: actions/upload-artifact@v2
-        if: failure()
-        with:
-          name: pr
-          path: pr/
+

--- a/.github/workflows/semantic-pr.yml
+++ b/.github/workflows/semantic-pr.yml
@@ -93,14 +93,4 @@ jobs:
           # merge commit, and it's easy to commit this by mistake. Enable this option
           # to also validate the commit message for one commit PRs.
           validateSingleCommit: true
-      # Need to save PR number as Github action does not propagate it with workflow_run event
-      - name: Save PR number
-        if: failure()
-        run: |
-          mkdir -p ./pr
-          echo ${{ github.event.number }} > ./pr/NR
-      - uses: actions/upload-artifact@v2
-        if: failure()
-        with:
-          name: pr
-          path: pr/
+


### PR DESCRIPTION
Signed-off-by: Ranjini Iyer <ranj8work@gmail.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary
Fix for issue 8165 - Aggregate PR comment on check failure.

<!-- Enumerate changes you made and why you made them -->
The changes are made to address the issue 8165 - Aggregate PR comment on check failure. Code changes where first made in master branch of forked repo and tested using a [test-PR](https://github.com/ranj8work/magma/pull/4)

## Test Plan
The changes are made in the master branch of my forked repo and tested. The test PR is [here](https://github.com/ranj8work/magma/pull/4). The github workflow action logs during testing dated 28-SEP-2021 are [here](https://github.com/ranj8work/magma/actions/runs/1283147352).

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [NO] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
