### PR TITLE
fix(agw): handle gtp length update in gso

### DIFF
--- a/lte/gateway/release/build-magma.sh
+++ b/lte/gateway/release/build-magma.sh
@@ -159,10 +159,10 @@ OAI_DEPS=(
 # OVS runtime dependencies
 OVS_DEPS=(
       "magma-libfluid >= 0.1.0.6"
-      "libopenvswitch >= 2.15.2-1"
-      "openvswitch-switch >= 2.15.2-1"
-      "openvswitch-common >= 2.15.2-1"
-      "openvswitch-datapath-dkms >= 2.15.2-1"
+      "libopenvswitch >= 2.15.2-5"
+      "openvswitch-switch >= 2.15.2-5"
+      "openvswitch-common >= 2.15.2-5"
+      "openvswitch-datapath-dkms >= 2.15.2-5"
       )
 
 # generate string for FPM

--- a/third_party/gtp_ovs/ovs-gtp-patches/2.15/0019-AGW-OVS-handle-gtp-tunnel-type.patch
+++ b/third_party/gtp_ovs/ovs-gtp-patches/2.15/0019-AGW-OVS-handle-gtp-tunnel-type.patch
@@ -1,0 +1,53 @@
+From 5a5fce3160004dc4dd6589c17bb60bb65b09c2aa Mon Sep 17 00:00:00 2001
+From: Pravin B Shelar <pbshelar@fb.com>
+Date: Wed, 23 Sep 2020 04:01:59 +0000
+Subject: [PATCH 19/21] AGW: OVS: handle gtp tunnel type
+
+magma GTP implementation defines gtp as tunnel type for OVS tunnel.
+But upstream ovs it is defined as gtpu. This patch maps older name to
+new type.
+This patch can be removed once the transition to new OVS binaries is done.
+
+Signed-off-by: Pravin B Shelar <pbshelar@fb.com>
+---
+ debian/ifupdown.sh                          | 6 +++++-
+ rhel/etc_sysconfig_network-scripts_ifup-ovs | 4 ++++
+ 2 files changed, 9 insertions(+), 1 deletion(-)
+
+diff --git a/debian/ifupdown.sh b/debian/ifupdown.sh
+index 01982acbf..26ae08b1b 100755
+--- a/debian/ifupdown.sh
++++ b/debian/ifupdown.sh
+@@ -77,9 +77,13 @@ if [ "${MODE}" = "start" ]; then
+                     ${OVS_EXTRA+-- $OVS_EXTRA}
+                 ;;
+         OVSTunnel)
++                if [ "$IF_OVS_TUNNEL_TYPE" = "gtp" ]; then
++                    OVS_TUNNEL_TYPE="gtpu"
++                fi
++
+                 ovs_vsctl -- --may-exist add-port "${IF_OVS_BRIDGE}"\
+                     "${IFACE}" ${IF_OVS_OPTIONS} -- set Interface "${IFACE}" \
+-                    type=${IF_OVS_TUNNEL_TYPE} ${IF_OVS_TUNNEL_OPTIONS} \
++                    type=${OVS_TUNNEL_TYPE} ${IF_OVS_TUNNEL_OPTIONS} \
+                     ${OVS_EXTRA+-- $OVS_EXTRA}
+                 ;;
+         *)
+diff --git a/rhel/etc_sysconfig_network-scripts_ifup-ovs b/rhel/etc_sysconfig_network-scripts_ifup-ovs
+index 0955c0e1f..14f133888 100755
+--- a/rhel/etc_sysconfig_network-scripts_ifup-ovs
++++ b/rhel/etc_sysconfig_network-scripts_ifup-ovs
+@@ -153,6 +153,10 @@ case "$TYPE" in
+                 ;;
+         OVSTunnel)
+                 ifup_ovs_bridge
++
++                if [ "$OVS_TUNNEL_TYPE" = "gtp" ]; then
++                    OVS_TUNNEL_TYPE="gtpu"
++                fi
+                 ovs-vsctl -t ${TIMEOUT} \
+                         -- --if-exists del-port "$OVS_BRIDGE" "$DEVICE" \
+                         -- add-port "$OVS_BRIDGE" "$DEVICE" $OVS_OPTIONS \
+-- 
+2.25.1
+

--- a/third_party/gtp_ovs/ovs-gtp-patches/2.15/0020-datapath-fix-gso-length.patch
+++ b/third_party/gtp_ovs/ovs-gtp-patches/2.15/0020-datapath-fix-gso-length.patch
@@ -1,0 +1,176 @@
+From 18aec0382d3b2e47d482d3f5fc6e8bc0b993f8ff Mon Sep 17 00:00:00 2001
+From: Pravin B Shelar <pbshelar@fb.com>
+Date: Tue, 21 Sep 2021 22:26:20 +0000
+Subject: [PATCH 20/21] datapath: fix gso length
+
+In some cases GSO lngth is not calculated in case
+of TSO.
+
+Signed-off-by: Pravin B Shelar <pbshelar@fb.com>
+---
+ datapath/linux/compat/gtp.c | 84 +++++++++++++++++++++++++++++++------
+ 1 file changed, 71 insertions(+), 13 deletions(-)
+
+diff --git a/datapath/linux/compat/gtp.c b/datapath/linux/compat/gtp.c
+index 16c06f91e..529d6080e 100644
+--- a/datapath/linux/compat/gtp.c
++++ b/datapath/linux/compat/gtp.c
+@@ -20,6 +20,7 @@
+ #include <linux/net.h>
+ #include <linux/file.h>
+ #include <linux/gtp.h>
++#include <linux/sctp.h>
+ 
+ #include <net/dst_metadata.h>
+ #include <net/net_namespace.h>
+@@ -328,14 +329,55 @@ const struct gtpu_ext_hdr_pdu_sc pdu_sc_hdr = {
+         .next_type = 0,
+ };
+ 
+-static inline void gtp1_push_header(struct sk_buff *skb, __be32 tid, __u8 qfi)
++static unsigned int skb_gso_transport_seglen(const struct sk_buff *skb)
++{
++        const struct skb_shared_info *shinfo = skb_shinfo(skb);
++        unsigned int thlen = 0;
++
++        if (skb->encapsulation) {
++                thlen = skb_inner_transport_header(skb) -
++                        skb_transport_header(skb);
++
++                if (likely(shinfo->gso_type & (SKB_GSO_TCPV4 | SKB_GSO_TCPV6)))
++                        thlen += inner_tcp_hdrlen(skb);
++        } else if (likely(shinfo->gso_type & (SKB_GSO_TCPV4 | SKB_GSO_TCPV6))) {
++                thlen = tcp_hdrlen(skb);
++        } else if (unlikely(skb_is_gso_sctp(skb))) {
++                thlen = sizeof(struct sctphdr);
++        } else if (shinfo->gso_type & SKB_GSO_UDP_L4) {
++                thlen = sizeof(struct udphdr);
++        }
++        /* UFO sets gso_size to the size of the fragmentation
++         * payload, i.e. the size of the L4 (UDP) header is already
++         * accounted for.
++         */
++        return thlen + shinfo->gso_size;
++}
++
++static unsigned int skb_gso_network_seglen(const struct sk_buff *skb)
++{
++        unsigned int hdr_len = skb_transport_header(skb) -
++                               skb_network_header(skb);
++
++        return hdr_len + skb_gso_transport_seglen(skb);
++}
++
++static inline void gtp1_push_header(struct net_device *dev, struct sk_buff *skb, __be32 tid, __u8 qfi)
+ {
+ 	struct gtpu_ext_hdr *next_hdr;
+ 	struct gtpu_ext_hdr_pdu_sc *pdu_sc;
+ 	struct gtp1_header *gtp1;
+-	int payload_len = skb->len;
++	int payload_len;
+ 	__u8 flags = 0x30;
+ 
++	if (skb_is_gso(skb)) {
++		payload_len = skb_gso_network_seglen(skb);
++		netdev_dbg(dev, "gso_size %d skb_gso_network_seglen(skb) %d skb->len %d\n",
++				skb_shinfo(skb)->gso_size, skb_gso_network_seglen(skb), skb->len);
++	} else {
++		netdev_dbg(dev,"No gso len %d\n", skb->len);
++		payload_len = skb->len;
++	}
+ 	if (qfi) {
+ 		gtp1 = (struct gtp1_header *) skb_push(skb, sizeof(*gtp1) + sizeof (*next_hdr) + sizeof (*pdu_sc));
+ 		payload_len += (sizeof(*next_hdr) + sizeof(*pdu_sc));
+@@ -436,18 +478,20 @@ static netdev_tx_t gtp_dev_xmit_fb(struct sk_buff *skb, struct net_device *dev)
+ 	struct gtp_dev *gtp = netdev_priv(dev);
+ 	struct rtable *rt;
+ 	struct flowi4 fl4;
++	int min_headroom;
+ 	__be16 df;
+         __u8 ttl;
+         __u8 set_qfi = 0;
+         __u8 csum;
+         int err;
++	int mtu;
+ 
+ 	/* Read the IP destination address and resolve the PDP context.
+ 	 * Prepend PDP header with TEI/TID from PDP ctx.
+ 	 */
+ 
+ 	if (!info) {
+-		netdev_dbg(dev, "no info for FB tunnel xmit\n");
++		netdev_dbg(dev, "no info for tunnel xmit\n");
+ 		goto err;
+ 	}
+ 	rt = gtp_get_v4_rt(skb, dev, gtp->sk1u, &fl4, info);
+@@ -456,23 +500,38 @@ static netdev_tx_t gtp_dev_xmit_fb(struct sk_buff *skb, struct net_device *dev)
+ 		dev->stats.tx_carrier_errors++;
+ 		goto err;
+ 	}
+-
+ 	skb_dst_drop(skb);
+         csum = !!(info->key.tun_flags & TUNNEL_CSUM);
+-        err = udp_tunnel_handle_offloads(skb, csum);
+-        if (err)
+-                goto err_rt;
+-        netdev_dbg(dev, "skb->protocol %d\n", skb->protocol);
+-        ovs_skb_set_inner_protocol(skb, cpu_to_be16(ETH_P_IP));
++	err = udp_tunnel_handle_offloads(skb, csum);
++	if (err)
++		goto err_rt;
++	ovs_skb_set_inner_protocol(skb, cpu_to_be16(ETH_P_IP));
+ 
+         ttl = info->key.ttl;
+         df = info->key.tun_flags & TUNNEL_DONT_FRAGMENT ? htons(IP_DF) : 0;
++
++	/* hack to handle MTU */
++	if (df) {
++		mtu = dst_mtu(&rt->dst) - dev->hard_header_len -
++			sizeof(struct iphdr) - sizeof(struct udphdr);
++		mtu -= sizeof(struct gtp1_header);
++	} else {
++		mtu = dst_mtu(&rt->dst);
++	}
++	min_headroom = LL_RESERVED_SPACE(rt->dst.dev) + rt->dst.header_len
++			+ sizeof(struct gtp1_header) + sizeof(struct iphdr)
++			+ info->options_len;
++
++	err = skb_cow_head(skb, min_headroom);
++	if (unlikely(err))
++		goto err_rt;
++
+         netdev_dbg(dev, "packet with opt len %d", info->options_len);
+         if (info->options_len == 0) {
+             if (info->key.tun_flags & TUNNEL_OAM) {
+                set_qfi = 5;
+             }
+-            gtp1_push_header(skb, tunnel_id_to_key32(info->key.tun_id), set_qfi);
++            gtp1_push_header(dev, skb, tunnel_id_to_key32(info->key.tun_id), set_qfi);
+         } else if (info->key.tun_flags & TUNNEL_GTPU_OPT) {
+                 struct gtpu_metadata *opts = ip_tunnel_info_opts(info);
+                 __be32 tid = tunnel_id_to_key32(info->key.tun_id);
+@@ -644,11 +703,11 @@ static void gtp_link_setup(struct net_device *dev)
+ 
+ 	netif_keep_dst(dev);
+ 
+-	/* Assume largest header, ie. GTPv0. */
+ 	dev->needed_headroom	= LL_MAX_HEADER +
+ 				  sizeof(struct iphdr) +
+ 				  sizeof(struct udphdr) +
+-				  sizeof(struct gtp0_header);
++				  sizeof(struct gtp1_header);
++
+ }
+ 
+ #ifdef HAVE_EXT_ACK_IN_RTNL_LINKOPS
+@@ -756,7 +815,6 @@ static int gtp_configure(struct net *net, struct net_device *dev)
+ 	dev->features   |= NETIF_F_LLTX;
+ 	netif_keep_dst(dev);
+ 
+-	/* Assume largest header, ie. GTPv0. */
+ 	dev->needed_headroom    = LL_MAX_HEADER +
+ 		sizeof(struct iphdr) +
+ 		sizeof(struct udphdr) +
+-- 
+2.25.1
+

--- a/third_party/gtp_ovs/ovs-gtp-patches/2.15/0021-datapath-update-version.patch
+++ b/third_party/gtp_ovs/ovs-gtp-patches/2.15/0021-datapath-update-version.patch
@@ -1,0 +1,22 @@
+From 3201e906d96e8b0dcb2e7f5912d96990b294ef2e Mon Sep 17 00:00:00 2001
+From: Pravin B Shelar <pbshelar@fb.com>
+Date: Tue, 21 Sep 2021 22:39:41 +0000
+Subject: [PATCH 21/21] datapath: update version
+
+---
+ debian/changelog | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/debian/changelog b/debian/changelog
+index ed5b127e5..d48ede187 100644
+--- a/debian/changelog
++++ b/debian/changelog
+@@ -1,4 +1,4 @@
+-openvswitch (2.15.2-1) unstable; urgency=low
++openvswitch (2.15.2-5) unstable; urgency=low
+    [ Open vSwitch team ]
+    * New upstream version
+ 
+-- 
+2.25.1
+


### PR DESCRIPTION
In some cases the GTP packet length is not calculated
correctly. following patch add calculation in gtp-driver.

Signed-off-by: Pravin B Shelar <pbshelar@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->

## Test Plan
validated performance on bare metal setup with UE and spirent.
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
