### PR TITLE
feat: add hostname tag to sentry events

### DIFF
--- a/orc8r/gateway/c/common/sentry/SentryWrapper.cpp
+++ b/orc8r/gateway/c/common/sentry/SentryWrapper.cpp
@@ -20,6 +20,7 @@
 #include <cstdlib>
 #include <fstream>
 #include <cstring>
+#include <unistd.h>
 
 #include "sentry.h"
 #include "includes/ServiceConfigLoader.h"
@@ -84,6 +85,7 @@ std::string get_snowflake() {
 }
 
 void initialize_sentry(
+    char node_name[50]
     const char* service_tag, const sentry_config_t* sentry_config) {
   auto control_proxy_config = magma::ServiceConfigLoader{}.load_service_config(
       CONTROL_PROXY_SERVICE_NAME);
@@ -105,7 +107,9 @@ void initialize_sentry(
     }
 
     sentry_init(options);
-
+    if (gethostname(node_name, sizeof(node_name)) == 0) {
+      sentry_set_tag(HOSTNAME, node_name);
+    }
     sentry_set_tag(SERVICE_NAME, service_tag);
     sentry_set_tag(HWID, get_snowflake().c_str());
   }

--- a/orc8r/gateway/c/common/sentry/SentryWrapper.cpp
+++ b/orc8r/gateway/c/common/sentry/SentryWrapper.cpp
@@ -107,7 +107,7 @@ void initialize_sentry(
     }
 
     sentry_init(options);
-    char node_name[HOST_NAME_MAX]
+    char node_name[HOST_NAME_MAX];
     if (gethostname(node_name, HOST_NAME_MAX) == 0) {
       sentry_set_tag(HOSTNAME, node_name);
     }

--- a/orc8r/gateway/c/common/sentry/SentryWrapper.cpp
+++ b/orc8r/gateway/c/common/sentry/SentryWrapper.cpp
@@ -34,6 +34,7 @@
 #define MME_LOG_PATH "/var/log/mme.log"
 #define SNOWFLAKE_PATH "/etc/snowflake"
 #define HWID "hwid"
+#define HOSTNAME "hostname"
 #define SERVICE_NAME "service_name"
 #define DEFAULT_SAMPLE_RATE 0.5f
 

--- a/orc8r/gateway/c/common/sentry/SentryWrapper.cpp
+++ b/orc8r/gateway/c/common/sentry/SentryWrapper.cpp
@@ -20,6 +20,7 @@
 #include <cstdlib>
 #include <fstream>
 #include <cstring>
+#include <limits.h>
 #include <unistd.h>
 
 #include "sentry.h"
@@ -85,7 +86,6 @@ std::string get_snowflake() {
 }
 
 void initialize_sentry(
-    char node_name[50]
     const char* service_tag, const sentry_config_t* sentry_config) {
   auto control_proxy_config = magma::ServiceConfigLoader{}.load_service_config(
       CONTROL_PROXY_SERVICE_NAME);
@@ -107,7 +107,8 @@ void initialize_sentry(
     }
 
     sentry_init(options);
-    if (gethostname(node_name, sizeof(node_name)) == 0) {
+    char node_name[HOST_NAME_MAX]
+    if (gethostname(node_name, HOST_NAME_MAX) == 0) {
       sentry_set_tag(HOSTNAME, node_name);
     }
     sentry_set_tag(SERVICE_NAME, service_tag);


### PR DESCRIPTION
Signed-off-by: Milap Joshi <milapjoshi@gmail.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary
This PR adds hostname tag to be sent to sentry events. This will help identify from where sentry issue came from.

<!-- Enumerate changes you made and why you made them -->

## Test Plan

tested on current HIL GW,

`magma@hil-1:~$ ./hello
ENV VAR : hil-1
magma@hil-1:~$ cat hello.cpp
#include <unistd.h>
#include <iostream>
int main() {
  char node_name[50];
  if (gethostname(node_name, sizeof(node_name)) == 0) {
    std::cout << "ENV VAR : " << node_name << std::endl;`


Tested by Marie with local sentry instance:
<img width="1513" alt="Screen Shot 2021-09-28 at 6 05 01 PM" src="https://user-images.githubusercontent.com/37634144/135172090-f7bd4e07-37a4-4d7f-b02b-132996389eb1.png">

<img width="1145" alt="Screen Shot 2021-09-28 at 6 04 51 PM" src="https://user-images.githubusercontent.com/37634144/135172070-a13760ee-0c2d-4043-8766-bd2f02596a27.png">

## Additional Information

- [ ] This change is backwards-breaking - NO

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
