### PR TITLE
chore: add back sentry doc into docusaurus

### DIFF
--- a/docs/docusaurus/sidebars.json
+++ b/docs/docusaurus/sidebars.json
@@ -124,7 +124,7 @@
         "label": "Access Gateway",
         "ids": [
           "lte/configure_agw_ha",
-          "lte/integrate_sentry"
+          "lte/configure_sentry"
         ]
       },
       {


### PR DESCRIPTION
Signed-off-by: Marie Bremner <marwhal@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary
Noticed that the sentry configuration documentation was missing from master's docusaurus. It probably got renamed at some point but the change didn't make it to sidebars.json.
<!-- Enumerate changes you made and why you made them -->

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
