### PR TITLE
fix(mme): Fixing guti unknown attach and adding s1ap test case

### DIFF
--- a/lte/gateway/python/integ_tests/defs.mk
+++ b/lte/gateway/python/integ_tests/defs.mk
@@ -156,6 +156,7 @@ s1aptests/test_attach_nw_initiated_detach_fail.py \
 s1aptests/test_tau_ta_updating.py \
 s1aptests/test_tau_ta_updating_reject.py \
 s1aptests/test_tau_mixed_partial_lists.py \
+s1aptests/test_guti_attach_with_zero_mtmsi.py \
 s1aptests/test_restore_mme_config_after_sanity.py
 
 NON_SANITY_TESTS = s1aptests/test_modify_config_for_non_sanity.py \


### PR DESCRIPTION
Signed-off-by: Alex Rodriguez <ardzoht@gmail.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->
- Fixes regression on #9002 (which fixed a sefgault that breaks `test_guti_attach_with_zero_mtmsi` TC on s1ap testing
- Adds `test_guti_attach_with_zero_mtmsi` to EXTENDED_TESTS tests list 

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->
- make integ_test
- verified `test_guti_attach_with_zero_mtmsi` passes successfully

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
