### PR TITLE
backport: backport changes to add hostname to sentry events

### DIFF
--- a/lte/gateway/c/core/oai/common/sentry_wrapper.cpp
+++ b/lte/gateway/c/core/oai/common/sentry_wrapper.cpp
@@ -21,6 +21,8 @@
 #include <fstream>
 #include <sstream>
 #include <string>
+#include <limits.h>
+#include <unistd.h>
 
 #include "sentry.h"
 #include "includes/ServiceConfigLoader.h"
@@ -32,6 +34,7 @@
 #define MME_LOG_PATH "/var/log/mme.log"
 #define SNOWFLAKE_PATH "/etc/snowflake"
 #define HWID "hwid"
+#define HOSTNAME "hostname"
 #define SERVICE_NAME "service_name"
 
 using std::experimental::optional;
@@ -79,6 +82,10 @@ void initialize_sentry() {
     sentry_init(options);
 
     sentry_set_tag(SERVICE_NAME, "MME");
+    char node_name[HOST_NAME_MAX];
+    if (gethostname(node_name, HOST_NAME_MAX) == 0) {
+      sentry_set_tag(HOSTNAME, node_name);
+    }
     sentry_set_tag(HWID, get_snowflake().c_str());
   }
 }

--- a/lte/gateway/c/session_manager/SentryWrappers.cpp
+++ b/lte/gateway/c/session_manager/SentryWrappers.cpp
@@ -21,6 +21,8 @@
 #include <fstream>
 #include <sstream>
 #include <string>
+#include <limits.h>
+#include <unistd.h>
 
 #include "magma_logging_init.h"
 #include "sentry.h"
@@ -31,6 +33,7 @@
 #define SENTRY_NATIVE_URL "sentry_url_native"
 #define SNOWFLAKE_PATH "/etc/snowflake"
 #define HWID "hwid"
+#define HOSTNAME "hostname"
 #define SERVICE_NAME "service_name"
 
 using std::experimental::optional;
@@ -71,6 +74,10 @@ void initialize_sentry() {
     sentry_init(options);
     sentry_set_tag(SERVICE_NAME, "SessionD");
     sentry_set_tag(HWID, get_snowflake().c_str());
+    char node_name[HOST_NAME_MAX];
+    if (gethostname(node_name, HOST_NAME_MAX) == 0) {
+      sentry_set_tag(HOSTNAME, node_name);
+    }
   }
 }
 


### PR DESCRIPTION
<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary
original PR: https://github.com/magma/magma/pull/9329
<!-- Enumerate changes you made and why you made them -->

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
