### PR TITLE
fix(mme): Updating S1AP UE state IMSI write on connection_establishment_cnf

### DIFF
--- a/lte/gateway/c/core/oai/tasks/s1ap/s1ap_mme.c
+++ b/lte/gateway/c/core/oai/tasks/s1ap/s1ap_mme.c
@@ -219,10 +219,11 @@ static int handle_message(zloop_t* loop, zsock_t* reader, void* arg) {
     } break;
 
     case MME_APP_CONNECTION_ESTABLISHMENT_CNF: {
-      is_task_state_same = true;  // the following handler does not modify state
-      is_ue_state_same   = true;
+      is_task_state_same = false;
+      is_ue_state_same = false;
       s1ap_handle_conn_est_cnf(
-          state, &MME_APP_CONNECTION_ESTABLISHMENT_CNF(received_message_p));
+          state, &MME_APP_CONNECTION_ESTABLISHMENT_CNF(received_message_p),
+          imsi64);
     } break;
 
     case MME_APP_S1AP_MME_UE_ID_NOTIFICATION: {

--- a/lte/gateway/c/core/oai/tasks/s1ap/s1ap_mme_nas_procedures.c
+++ b/lte/gateway/c/core/oai/tasks/s1ap/s1ap_mme_nas_procedures.c
@@ -864,7 +864,8 @@ int s1ap_generate_s1ap_e_rab_setup_req(
 //------------------------------------------------------------------------------
 void s1ap_handle_conn_est_cnf(
     s1ap_state_t* state,
-    const itti_mme_app_connection_establishment_cnf_t* const conn_est_cnf_pP) {
+    const itti_mme_app_connection_establishment_cnf_t* const conn_est_cnf_pP,
+    imsi64_t imsi64) {
   /*
    * We received create session response from S-GW on S11 interface abstraction.
    * At least one bearer has been established. We can now send s1ap initial
@@ -901,11 +902,10 @@ void s1ap_handle_conn_est_cnf(
     OAILOG_FUNC_OUT(LOG_S1AP);
   }
 
-  imsi64_t imsi64;
   s1ap_imsi_map_t* imsi_map = get_s1ap_imsi_map();
-  hashtable_uint64_ts_get(
+  hashtable_uint64_ts_insert(
       imsi_map->mme_ue_id_imsi_htbl, (const hash_key_t) conn_est_cnf_pP->ue_id,
-      &imsi64);
+      imsi64);
 
   pdu.present = S1ap_S1AP_PDU_PR_initiatingMessage;
   pdu.choice.initiatingMessage.procedureCode =

--- a/lte/gateway/c/core/oai/tasks/s1ap/s1ap_mme_nas_procedures.h
+++ b/lte/gateway/c/core/oai/tasks/s1ap/s1ap_mme_nas_procedures.h
@@ -66,7 +66,8 @@ int s1ap_mme_handle_nas_non_delivery(
 
 void s1ap_handle_conn_est_cnf(
     s1ap_state_t* state,
-    const itti_mme_app_connection_establishment_cnf_t* const conn_est_cnf_p);
+    const itti_mme_app_connection_establishment_cnf_t* const conn_est_cnf_p,
+    imsi64_t imsi64);
 
 int s1ap_generate_downlink_nas_transport(
     s1ap_state_t* state, const enb_ue_s1ap_id_t enb_ue_s1ap_id,


### PR DESCRIPTION
Signed-off-by: Alex Rodriguez <ardzoht@gmail.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

- Backport changes to v1.6 branch from #9145

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->
- validated with s1ap non sanity tests

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
