### PR TITLE
fix(agw): Fix subscriber sync after manual deletion

### DIFF
--- a/lte/gateway/python/magma/subscriberdb/client.py
+++ b/lte/gateway/python/magma/subscriberdb/client.py
@@ -171,9 +171,6 @@ class SubscriberDBCloudClient(SDWatchdogTask):
             return True
 
         if not res.resync:
-            self._update_root_digest(res.digests.root_digest)
-            self._update_leaf_digests(res.digests.leaf_digests)
-
             # TODO(hcgatewood): switch to bulk editing subscriber data rows
             changeset = self._process_changeset(res.changeset)
             for subscriber_data in changeset.to_renew:
@@ -181,6 +178,9 @@ class SubscriberDBCloudClient(SDWatchdogTask):
             for sid in changeset.deleted:
                 self._store.delete_subscriber(sid)
             self._detach_subscribers_by_ids(changeset.deleted)
+
+            self._update_root_digest(res.digests.root_digest)
+            self._update_leaf_digests(res.digests.leaf_digests)
 
         return res.resync
 


### PR DESCRIPTION
<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

Fixes https://github.com/magma/magma/issues/9029

## Test Plan

New unit tests

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->