### PR TITLE
chore(mme): Remove flakiness in mme_app unit tests

### DIFF
--- a/lte/gateway/Makefile
+++ b/lte/gateway/Makefile
@@ -146,7 +146,7 @@ build_oai: ## Build OAI
 	$(call run_cmake, $(C_BUILD)/core, $(GATEWAY_C_DIR)/core, $(OAI_FLAGS) $(COMMON_FLAGS) $(OAI_NOTEST_FLAGS))
 
 build_oai_clang: ## Build OAI with Clang, store compiler outputs to log
-	$(call run_cmake, $(C_BUILD)/core, $(GATEWAY_C_DIR)/core, $(OAI_FLAGS) $(COMMON_FLAGS), CC="clang" CXX="clang++") 2>&1 | tee /tmp/clang-build.oai.log
+	$(call run_cmake, $(C_BUILD)/core, $(GATEWAY_C_DIR)/core, $(OAI_FLAGS) $(COMMON_FLAGS) $(OAI_NOTEST_FLAGS), CC="clang" CXX="clang++") 2>&1 | tee /tmp/clang-build.oai.log
 
 format_all:
 	find $(MAGMA_ROOT)/orc8r/gateway/c/ \( -iname "*.c" -o -iname "*.cpp" -o -iname "*.h" \) -exec \

--- a/lte/gateway/c/core/oai/common/redis_utils/redis_client.cpp
+++ b/lte/gateway/c/core/oai/common/redis_utils/redis_client.cpp
@@ -57,6 +57,7 @@ void RedisClient::init_db_connection() {
 
 status_code_e RedisClient::write(
     const std::string& key, const std::string& value) {
+#if !MME_UNIT_TEST
   if (!is_connected()) {
     return RETURNerror;
   }
@@ -68,7 +69,7 @@ status_code_e RedisClient::write(
   if (db_write_reply.is_error()) {
     return RETURNerror;
   }
-
+#endif
   return RETURNok;
 }
 
@@ -130,6 +131,7 @@ int RedisClient::read_version(const std::string& key) {
 
 status_code_e RedisClient::clear_keys(
     const std::vector<std::string>& keys_to_clear) {
+#if !MME_UNIT_TEST
   auto db_write = db_client_->del(keys_to_clear);
   db_client_->sync_commit();
   auto reply = db_write.get();
@@ -137,7 +139,7 @@ status_code_e RedisClient::clear_keys(
   if (reply.is_error()) {
     return RETURNerror;
   }
-
+#endif
   return RETURNok;
 }
 

--- a/lte/gateway/c/core/oai/include/state_manager.h
+++ b/lte/gateway/c/core/oai/include/state_manager.h
@@ -84,6 +84,7 @@ class StateManager {
    * @return response code of operation
    */
   virtual status_code_e read_state_from_db() {
+#if !MME_UNIT_TEST
     if (persist_state_enabled) {
       ProtoType state_proto = ProtoType();
       if (redis_client->read_proto(table_key, state_proto) != RETURNok) {
@@ -96,6 +97,7 @@ class StateManager {
 
       StateConverter::proto_to_state(state_proto, state_cache_p);
     }
+#endif
     return RETURNok;
   }
 

--- a/lte/gateway/c/core/oai/tasks/mme_app/mme_app_state_manager.cpp
+++ b/lte/gateway/c/core/oai/tasks/mme_app/mme_app_state_manager.cpp
@@ -69,8 +69,12 @@ int MmeNasStateManager::initialize_state(const mme_config_t* mme_config_p) {
 
   // Allocate the local mme state
   create_state();
-
+#if !MME_UNIT_TEST
+  OAILOG_DEBUG(LOG_MME_APP, "MME_UNIT_TEST Flag is Disabled");
   redis_client = std::make_unique<RedisClient>(persist_state_enabled);
+#else
+  redis_client = std::make_unique<RedisClient>(false);
+#endif
   int rc       = read_state_from_db();
   read_ue_state_from_db();
   create_mme_ueip_imsi_map();
@@ -212,6 +216,7 @@ void MmeNasStateManager::free_state() {
 }
 
 status_code_e MmeNasStateManager::read_ue_state_from_db() {
+#if !MME_UNIT_TEST
   if (persist_state_enabled) {
     auto keys = redis_client->get_keys("IMSI*" + task_name + "*");
     for (const auto& key : keys) {
@@ -240,10 +245,12 @@ status_code_e MmeNasStateManager::read_ue_state_from_db() {
       }
     }
   }
+#endif
   return RETURNok;
 }
 
 void MmeNasStateManager::create_mme_ueip_imsi_map() {
+#if !MME_UNIT_TEST
   if (!persist_state_enabled) {
     OAILOG_ERROR(log_task, "persist_state_enabled is not enabled \n");
     return;
@@ -253,6 +260,7 @@ void MmeNasStateManager::create_mme_ueip_imsi_map() {
 
   MmeNasStateConverter::mme_app_proto_to_ueip_imsi_map(
       ueip_proto, ueip_imsi_map);
+#endif
   return;
 }
 

--- a/lte/gateway/c/core/oai/tasks/mme_app/mme_app_state_manager.cpp
+++ b/lte/gateway/c/core/oai/tasks/mme_app/mme_app_state_manager.cpp
@@ -75,7 +75,7 @@ int MmeNasStateManager::initialize_state(const mme_config_t* mme_config_p) {
 #else
   redis_client = std::make_unique<RedisClient>(false);
 #endif
-  int rc       = read_state_from_db();
+  int rc = read_state_from_db();
   read_ue_state_from_db();
   create_mme_ueip_imsi_map();
   is_initialized = true;

--- a/lte/gateway/c/core/oai/test/mme_app_task/mme_app_test_util.cpp
+++ b/lte/gateway/c/core/oai/test/mme_app_task/mme_app_test_util.cpp
@@ -26,6 +26,20 @@ namespace lte {
 
 extern task_zmq_ctx_t task_zmq_ctx_main;
 
+void send_sctp_mme_server_initialized() {
+  MessageDef* message_p =
+      itti_alloc_new_message(TASK_S1AP, SCTP_MME_SERVER_INITIALIZED);
+  SCTP_MME_SERVER_INITIALIZED(message_p).successful = true;
+  send_msg_to_task(&task_zmq_ctx_main, TASK_MME_APP, message_p);
+  return;
+}
+
+void send_activate_message_to_mme_app() {
+  MessageDef* message_p = itti_alloc_new_message(TASK_MAIN, ACTIVATE_MESSAGE);
+  send_msg_to_task(&task_zmq_ctx_main, TASK_MME_APP, message_p);
+  return;
+}
+
 void send_mme_app_initial_ue_msg(
     uint8_t* nas_msg, uint8_t nas_msg_length, const plmn_t& plmn) {
   MessageDef* message_p =

--- a/lte/gateway/c/core/oai/test/mme_app_task/mme_app_test_util.h
+++ b/lte/gateway/c/core/oai/test/mme_app_task/mme_app_test_util.h
@@ -15,6 +15,10 @@ extern "C" {}
 namespace magma {
 namespace lte {
 
+void send_sctp_mme_server_initialized();
+
+void send_activate_message_to_mme_app();
+
 void send_mme_app_initial_ue_msg(
     uint8_t* nas_msg, uint8_t nas_msg_length, const plmn_t& plmn);
 

--- a/lte/gateway/c/core/oai/test/mme_app_task/test_mme_procedures.cpp
+++ b/lte/gateway/c/core/oai/test/mme_app_task/test_mme_procedures.cpp
@@ -63,7 +63,7 @@ static int handle_message(zloop_t* loop, zsock_t* reader, void* arg) {
 class MmeAppProcedureTest : public ::testing::Test {
   virtual void SetUp() {
     mme_hss_associated = false;
-    mme_sctp_bounded = false;
+    mme_sctp_bounded   = false;
     s1ap_handler       = std::make_shared<MockS1apHandler>();
     s6a_handler        = std::make_shared<MockS6aHandler>();
     spgw_handler       = std::make_shared<MockSpgwHandler>();
@@ -126,13 +126,12 @@ class MmeAppProcedureTest : public ::testing::Test {
 };
 
 TEST_F(MmeAppProcedureTest, TestInitialUeMessageFaultyNasMsg) {
-  plmn_t plmn = {
-      .mcc_digit2 = 0,
-      .mcc_digit1 = 0,
-      .mnc_digit3 = 0x0f,
-      .mcc_digit3 = 1,
-      .mnc_digit2 = 1,
-      .mnc_digit1 = 0};
+  plmn_t plmn = {.mcc_digit2 = 0,
+                 .mcc_digit1 = 0,
+                 .mnc_digit3 = 0x0f,
+                 .mcc_digit3 = 1,
+                 .mnc_digit2 = 1,
+                 .mnc_digit1 = 0};
 
   EXPECT_CALL(*s1ap_handler, s1ap_generate_downlink_nas_transport()).Times(1);
 
@@ -150,13 +149,12 @@ TEST_F(MmeAppProcedureTest, TestInitialUeMessageFaultyNasMsg) {
 }
 
 TEST_F(MmeAppProcedureTest, TestImsiAttachEpsOnlyDetach) {
-  plmn_t plmn = {
-      .mcc_digit2 = 0,
-      .mcc_digit1 = 0,
-      .mnc_digit3 = 0x0f,
-      .mcc_digit3 = 1,
-      .mnc_digit2 = 1,
-      .mnc_digit1 = 0};
+  plmn_t plmn      = {.mcc_digit2 = 0,
+                 .mcc_digit1 = 0,
+                 .mnc_digit3 = 0x0f,
+                 .mcc_digit3 = 1,
+                 .mnc_digit2 = 1,
+                 .mnc_digit1 = 0};
   std::string imsi = "001010000000001";
   mme_app_desc_t* mme_state_p =
       magma::lte::MmeNasStateManager::getInstance().get_state(false);
@@ -258,13 +256,12 @@ TEST_F(MmeAppProcedureTest, TestImsiAttachEpsOnlyDetach) {
 }
 
 TEST_F(MmeAppProcedureTest, TestGutiAttachEpsOnlyDetach) {
-  plmn_t plmn = {
-      .mcc_digit2 = 0,
-      .mcc_digit1 = 0,
-      .mnc_digit3 = 0x0f,
-      .mcc_digit3 = 1,
-      .mnc_digit2 = 1,
-      .mnc_digit1 = 0};
+  plmn_t plmn      = {.mcc_digit2 = 0,
+                 .mcc_digit1 = 0,
+                 .mnc_digit3 = 0x0f,
+                 .mcc_digit3 = 1,
+                 .mnc_digit2 = 1,
+                 .mnc_digit1 = 0};
   std::string imsi = "001010000000001";
   mme_app_desc_t* mme_state_p =
       magma::lte::MmeNasStateManager::getInstance().get_state(false);

--- a/lte/gateway/c/core/oai/test/mme_app_task/test_mme_procedures.cpp
+++ b/lte/gateway/c/core/oai/test/mme_app_task/test_mme_procedures.cpp
@@ -60,7 +60,7 @@ class MmeAppProcedureTest : public ::testing::Test {
     // initialize mme config
     mme_config_init(&mme_config);
     create_partial_lists(&mme_config);
-    mme_config.use_stateless                              = false;
+    mme_config.use_stateless                              = true;
     mme_config.nas_config.prefered_integrity_algorithm[0] = EIA2_128_ALG_ID;
 
     task_id_t task_id_list[10] = {

--- a/lte/gateway/c/core/oai/test/mock_tasks/mock_tasks.h
+++ b/lte/gateway/c/core/oai/test/mock_tasks/mock_tasks.h
@@ -58,11 +58,16 @@ class MockSpgwHandler {
   MOCK_METHOD0(sgw_handle_delete_session_request, void());
 };
 
+class MockService303Handler {
+ public:
+  MOCK_METHOD0(service303_set_application_health, void());
+};
+
 void start_mock_ha_task();
 void start_mock_s1ap_task(std::shared_ptr<MockS1apHandler>);
 void start_mock_s6a_task(std::shared_ptr<MockS6aHandler>);
 void start_mock_s11_task();
-void start_mock_service303_task();
+void start_mock_service303_task(std::shared_ptr<MockService303Handler>);
 void start_mock_sgs_task();
 void start_mock_sgw_s8_task();
 void start_mock_sms_orc8r_task();

--- a/lte/gateway/c/core/oai/test/mock_tasks/service303_mock.cpp
+++ b/lte/gateway/c/core/oai/test/mock_tasks/service303_mock.cpp
@@ -44,7 +44,8 @@ void stop_mock_service303_task() {
   pthread_exit(NULL);
 }
 
-void start_mock_service303_task(std::shared_ptr<MockService303Handler> service303_handler) {
+void start_mock_service303_task(
+    std::shared_ptr<MockService303Handler> service303_handler) {
   service303_handler_ = service303_handler;
   init_task_context(
       TASK_SERVICE303, nullptr, 0, handle_message, &task_zmq_ctx_service303);

--- a/lte/gateway/c/core/oai/test/mock_tasks/service303_mock.cpp
+++ b/lte/gateway/c/core/oai/test/mock_tasks/service303_mock.cpp
@@ -13,6 +13,7 @@
 #include "mock_tasks.h"
 
 task_zmq_ctx_t task_zmq_ctx_service303;
+static std::shared_ptr<MockService303Handler> service303_handler_;
 
 void stop_mock_service303_task();
 
@@ -21,9 +22,14 @@ static int handle_message(zloop_t* loop, zsock_t* reader, void* arg) {
 
   switch (ITTI_MSG_ID(received_message_p)) {
     case TERMINATE_MESSAGE: {
+      service303_handler_.reset();
       itti_free_msg_content(received_message_p);
       free(received_message_p);
       stop_mock_service303_task();
+    } break;
+
+    case APPLICATION_HEALTHY_MSG: {
+      service303_handler_->service303_set_application_health();
     } break;
 
     default: { } break; }
@@ -38,7 +44,8 @@ void stop_mock_service303_task() {
   pthread_exit(NULL);
 }
 
-void start_mock_service303_task() {
+void start_mock_service303_task(std::shared_ptr<MockService303Handler> service303_handler) {
+  service303_handler_ = service303_handler;
   init_task_context(
       TASK_SERVICE303, nullptr, 0, handle_message, &task_zmq_ctx_service303);
   zloop_start(task_zmq_ctx_service303.event_loop);


### PR DESCRIPTION
<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->
- In unit testing for mme procedures, there is no explicit observation point in steady states about whether mme_app has completed state updates or not. This PR repurposes the existing health check mechanism to trigger such explicit observation points at mocked service303 task, that in turn is used to verify the expected mme_app_task states.

- Enabled stateless config and sandwiched critical parts with `if` directive to prevent an actual connection and I/O to the redis server.

- Some minor reordering of statements is also done to improve clang formatting output. 

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->
Run `make test_oai` and check execution time of unit tests. Repeat it 500 times and observe no flakes.

Run integ tests.
 
## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
