### PR TITLE
chore(agw): add more details to ovs update script.

### DIFF
--- a/lte/gateway/deploy/roles/magma/files/ovs-kmod-upgrade.sh
+++ b/lte/gateway/deploy/roles/magma/files/ovs-kmod-upgrade.sh
@@ -11,6 +11,7 @@
 # limitations under the License.
 
 SKIP_CHECK=${1:-""}
+SKIP_CHECK_FLUSH=${2:-""}
 
 echo "This upgrade would result in datapath level downtime for few minutes!"
 
@@ -40,9 +41,25 @@ kernel_ver=$(cat /sys/module/openvswitch/srcversion)
 mod_ver=$(modinfo /lib/modules/"$(uname -r)"/updates/dkms/openvswitch.ko |grep srcversion|awk '{print $2}')
 
 if [[ "$kernel_ver" == "$mod_ver" ]]; then
-        echo "update successful"
+        OVS_VER=$(dpkg -l openvswitch-datapath-dkms |grep 'ii' |awk '{print $3}')
+        echo "update successful, installed: $OVS_VER"
 else
         echo "update failed"
 fi
 
-echo "To cleanup control plane state run: config_stateless_agw.py flushall_redis"
+
+echo "Do you want to restart control plane services?"
+
+if [[ "$SKIP_CHECK_FLUSH" != '-y' ]];
+then
+    while true; do
+        read -p "Do you want to proceed with upgrade ?(y/n)" yn
+        case $yn in
+            [Yy]* ) break;;
+            [Nn]* ) exit;;
+            * ) echo "Please answer yes or no.";;
+        esac
+    done
+fi
+
+config_stateless_agw.py flushall_redis


### PR DESCRIPTION
Print installed OVS version.

Signed-off-by: Pravin B Shelar <pbshelar@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->

## Test Plan
validated on bare metal agw:
```
root@phy-u3:~# bash  /home/magma/ovs-kmod-upgrade.sh
This upgrade would result in datapath level downtime for few minutes!
Do you want to proceed with upgrade ?(y/n)y
Hit:1 http://us.archive.ubuntu.com/ubuntu focal InRelease
Hit:2 http://us.archive.ubuntu.com/ubuntu focal-updates InRelease
Hit:3 http://us.archive.ubuntu.com/ubuntu focal-backports InRelease
Hit:4 http://us.archive.ubuntu.com/ubuntu focal-security InRelease
Hit:5 https://artifactory.magmacore.org/artifactory/debian focal-1.5.3 InRelease
Reading package lists... Done
Building dependency tree
Reading state information... Done
102 packages can be upgraded. Run 'apt list --upgradable' to see them.
Reading package lists... Done
Building dependency tree
Reading state information... Done
libopenvswitch is already the newest version (2.15.2-5).
openvswitch-common is already the newest version (2.15.2-5).
openvswitch-datapath-dkms is already the newest version (2.15.2-5).
openvswitch-switch is already the newest version (2.15.2-5).
python3-openvswitch is already the newest version (2.15.2-5).
The following packages were automatically installed and are no longer required:
  docutils-common eatmydata libeatmydata1 libimagequant0 libjs-sphinxdoc libjs-underscore liblcms2-2 libnetplan0 libpaper-utils libpaper1 libwebpdemux2 libwebpmux3 python-babel-localedata python3-babel python3-bcrypt python3-colorama
  python3-debtcollector python3-docutils python3-iso8601 python3-jsonpatch python3-monotonic python3-olefile python3-oslo.config python3-oslo.context python3-oslo.i18n python3-oslo.log python3-oslo.serialization python3-oslo.utils
  python3-paramiko python3-pbr python3-pil python3-pygments python3-pyparsing python3-repoze.lru python3-rfc3986 python3-roman python3-routes python3-stevedore python3-tinyrpc python3-tz python3-webob sgml-base xml-core
Use 'apt autoremove' to remove them.
0 upgraded, 0 newly installed, 0 to remove and 102 not upgraded.
ifdown: interface patch-up not configured
 * Detected internal interfaces:
 * Exiting ovsdb-server (1690416)
 * Starting ovsdb-server
 * Configuring Open vSwitch system IDs
 * Exiting ovs-vswitchd (1690436)
 * Saving interface configuration
 * Removing openvswitch module
 * Inserting openvswitch module
 * Starting ovs-vswitchd
 * Enabling remote OVSDB managers
 * Restoring interface configuration
 * Finding processes on dead interfaces
RTNETLINK answers: File exists
ovs-vsctl: type=: argument does not end in "=" followed by a value.
net.ipv4.ip_forward = 1
ifup: interface patch-up already configured
update successful, installed: 2.15.2-5
Do you want to restart control plane services?
Do you want to proceed with upgrade ?(y/n)y
Flushing all content in Redis
OK
Restarting sctpd
Job for sctpd.service failed because the control process exited with error code.
See "systemctl status sctpd.service" and "journalctl -xe" for details.
```
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
