### PR TITLE
chore: clean up folly lib def for bazel builds

### DIFF
--- a/third_party/system_libraries.BUILD
+++ b/third_party/system_libraries.BUILD
@@ -21,7 +21,7 @@ config_setting(
 cc_library(
     name = "folly",
     srcs = select({
-        ":use_folly_so": ["usr/local/lib/libfolly.so"],
+        ":use_folly_so": [],
         "//conditions:default": [
             "usr/local/lib/libfolly.a",
             "usr/local/lib/libfmt.a",
@@ -29,6 +29,8 @@ cc_library(
     }),
     linkopts = select({
         ":use_folly_so": [
+            "-L/usr/local/lib",
+            "-lfolly",
             "-ldl",
             "-levent",
             "-ldouble-conversion",


### PR DESCRIPTION
Signed-off-by: Marie Bremner <marwhal@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary
Got inspired by  https://github.com/magma/magma/pull/9224 and tried cleaning up the folly def
<!-- Enumerate changes you made and why you made them -->

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
