### PR TITLE
fix(agw): gtp-br0 interface definition.

### DIFF
--- a/lte/gateway/deploy/roles/magma/files/magma_ifaces_gtp
+++ b/lte/gateway/deploy/roles/magma/files/magma_ifaces_gtp
@@ -16,8 +16,9 @@ allow-gtp_br0 gtp0
 iface gtp0 inet manual
     ovs_bridge gtp_br0
     ovs_type OVSTunnel
-    ovs_tunnel_type gtpu
-    ovs_tunnel_options ofport_request=32768 options:remote_ip=flow options:key=flow
+    ovs_tunnel_type gtp
+    ovs_extra set interface ${IFACE} ofport_request=32768
+    ovs_tunnel_options options:remote_ip=flow options:key=flow
 
 allow-gtp_br0 mtr0
 iface mtr0 inet static


### PR DESCRIPTION
following patch fixes error seen on latest OVS:
```
root@phy-u3:~# ifup gtp_br0
RTNETLINK answers: File exists
ovs-vsctl: type=: argument does not end in "=" followed by a value.
net.ipv4.ip_forward = 1
```
Signed-off-by: Pravin B Shelar <pbshelar@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
