### PR TITLE
fix(session_proxy): fix linter issue using make precommit

### DIFF
--- a/feg/gateway/services/session_proxy/credit_control/gy/config.go
+++ b/feg/gateway/services/session_proxy/credit_control/gy/config.go
@@ -24,7 +24,6 @@ import (
 	"magma/feg/gateway/services/session_proxy/credit_control"
 	managed_configs "magma/gateway/mconfig"
 	"magma/orc8r/lib/go/util"
-
 )
 
 // OCS Environment Variables
@@ -54,11 +53,11 @@ const (
 )
 
 var (
-	_ = flag.String(GyInitMethodFlag, "", "Gy init method (per_key|per_session)")
-	_ = flag.String(OCSApnOverwriteFlag, "", "OCS APN to use instead of request's APN")
-	_ = flag.String(OCSServiceIdentifierFlag, "", "OCS ServiceIdentifier to use in Gy requests")
+	_          = flag.String(GyInitMethodFlag, "", "Gy init method (per_key|per_session)")
+	_          = flag.String(OCSApnOverwriteFlag, "", "OCS APN to use instead of request's APN")
+	_          = flag.String(OCSServiceIdentifierFlag, "", "OCS ServiceIdentifier to use in Gy requests")
 	avp437Flag = flag.Bool(DisableRequestedGrantedUnitsAVPFlag, false, "Disable Requested-Service-Unit AVP (437)")
-	)
+)
 
 // InitMethod describes the type of ways sessions can be initialized through the
 // Gy interface


### PR DESCRIPTION
Signed-off-by: Oriol Batalla <obatalla@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

fix this 

https://app.circleci.com/pipelines/github/magma/magma/33846/workflows/c6da8aa9-1f38-4d14-bab0-5e4f4a60a157/jobs/393813

```
make: Entering directory '/home/circleci/project/feg/gateway'
-> installing golangci 
golangci/golangci-lint info checking GitHub for tag 'v1.35.2'
golangci/golangci-lint info found version: 1.35.2 for v1.35.2/linux/amd64
golangci/golangci-lint info installed /usr/sbin//golangci-lint
golangci-lint run
services/session_proxy/credit_control/gy/config.go:27: File is not `gofmt`-ed with `-s` (gofmt)

Makefile:59: recipe for target 'lint' failed
make: *** [lint] Error 1
make: Leaving directory '/home/circleci/project/feg/gateway'

Exited with code exit status 2
CircleCI received exit code 2
```

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
