### PR TITLE
fix(agw): backport-1.6: enable checksum for GTPU

### DIFF
--- a/lte/gateway/c/core/oai/tasks/gtpv1-u/gtp_tunnel_openflow.c
+++ b/lte/gateway/c/core/oai/tasks/gtpv1-u/gtp_tunnel_openflow.c
@@ -166,7 +166,7 @@ static uint32_t create_gtp_port(struct in_addr enb_addr, char port_name[]) {
       gtp_port_create, sizeof(gtp_port_create),
       "sudo ovs-vsctl --may-exist add-port gtp_br0 %s -- set Interface %s "
       "type=%s "
-      "options:remote_ip=%s options:key=flow "
+      "options:remote_ip=%s options:key=flow options:csum=true "
       "bfd:enable=%s "
       "bfd:min_tx=5000 bfd:min_rx=5000",
       port_name, port_name, ovs_gtp_type, inet_ntoa(enb_addr), gtp_echo);


### PR DESCRIPTION
some eNBs expects GTPU checksum.

Signed-off-by: Pravin B Shelar <pbshelar@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
