### PR TITLE
fix(agw) Check for unset params while extracting status (#9288)

### DIFF
--- a/lte/gateway/python/magma/enodebd/devices/freedomfi_one.py
+++ b/lte/gateway/python/magma/enodebd/devices/freedomfi_one.py
@@ -233,7 +233,8 @@ class StatusParameters(object):
         success_str = "SUCCESS"  # String constant returned by radio
         insync_str = "INSYNC"
 
-        if name_to_val[cls.DEFAULT_GW].upper() != success_str:
+        if name_to_val.get(cls.DEFAULT_GW) \
+                and name_to_val[cls.DEFAULT_GW].upper() != success_str:
             # Nothing will proceed if the eNB doesn't have an IP on the WAN
             serial_num = "unknown"
             if device_cfg.has_parameter(ParameterName.SERIAL_NUMBER):
@@ -266,7 +267,8 @@ class StatusParameters(object):
             )
             return
 
-        if name_to_val[cls.SAS_STATUS].upper() == success_str:
+        if name_to_val.get(cls.SAS_STATUS) \
+                and name_to_val[cls.SAS_STATUS].upper() == success_str:
             device_cfg.set_parameter(
                 param_name=ParameterName.RF_TX_STATUS,
                 value=True,
@@ -279,17 +281,23 @@ class StatusParameters(object):
                 value=False,
             )
 
-        if name_to_val[cls.GPS_SCAN_STATUS].upper() == success_str:
+        if name_to_val.get(cls.GPS_SCAN_STATUS) \
+                and name_to_val[cls.GPS_SCAN_STATUS].upper() == success_str:
             device_cfg.set_parameter(
                 param_name=ParameterName.GPS_STATUS,
                 value=True,
             )
             # Time comes through GPS so can only be insync with GPS is
             # in sync, we use PTP_STATUS field to overload timer is in Sync.
-            if name_to_val[cls.SYNC_STATUS].upper() == insync_str:
+            if name_to_val.get(cls.SYNC_STATUS) \
+                    and name_to_val[cls.SYNC_STATUS].upper() == insync_str:
                 device_cfg.set_parameter(
                     param_name=ParameterName.PTP_STATUS,
                     value=True,
+                )
+            else:
+                device_cfg.set_parameter(
+                    param_name=ParameterName.PTP_STATUS, value=False,
                 )
         else:
             device_cfg.set_parameter(
@@ -301,7 +309,8 @@ class StatusParameters(object):
                 value=False,
             )
 
-        if name_to_val[cls.DEFAULT_GW].upper() == success_str:
+        if name_to_val.get(cls.DEFAULT_GW) \
+                and name_to_val[cls.DEFAULT_GW].upper() == success_str:
             device_cfg.set_parameter(
                 param_name=ParameterName.MME_STATUS,
                 value=True,
@@ -312,7 +321,8 @@ class StatusParameters(object):
                 value=False,
             )
 
-        if name_to_val[cls.ENB_STATUS].upper() == success_str:
+        if name_to_val.get(cls.ENB_STATUS) \
+                and name_to_val[cls.ENB_STATUS].upper() == success_str:
             device_cfg.set_parameter(
                 param_name=ParameterName.OP_STATE,
                 value=True,

--- a/lte/gateway/python/magma/enodebd/tests/freedomfi_one_tests.py
+++ b/lte/gateway/python/magma/enodebd/tests/freedomfi_one_tests.py
@@ -651,6 +651,8 @@ class FreedomFiOneTests(EnodebHandlerTestCase):
             EnodebConfigBuilder.get_mconfig(),
             service_cfg, cfg_desired,
         )
+        print(cfg_desired.mock_calls)
+        print(type(cfg_desired.mock_calls))
         self.assertEqual(cfg_desired.mock_calls.sort(), expected.sort())
 
     @patch('magma.configuration.service_configs.CONFIG_DIR', SRC_CONFIG_DIR)
@@ -667,3 +669,137 @@ class FreedomFiOneTests(EnodebHandlerTestCase):
             SASParameters.SAS_CERT_SUBJECT
         ] = "INVALID_CERT_SUBJECT"
         self.assertEqual(service_cfg, service_cfg_1)
+
+    def test_status_nodes(self):
+        """ Test that the status of the node is valid"""
+        status = StatusParameters()
+
+        # Happy path
+        n1 = {
+            StatusParameters.DEFAULT_GW: "SUCCESS",
+            StatusParameters.SYNC_STATUS: "InSync",
+            StatusParameters.ENB_STATUS: "Success",
+            StatusParameters.SAS_STATUS: "Success",
+            StatusParameters.GPS_SCAN_STATUS: "SUCCESS",
+            ParameterName.GPS_LONG: "1",
+            ParameterName.GPS_LAT: "1",
+        }
+        deviceConfig = Mock()
+        status.set_magma_device_cfg(n1, deviceConfig)
+        expected = [
+            call.set_parameter(param_name='RF TX status', value=True),
+            call.set_parameter(param_name='GPS status', value=True),
+            call.set_parameter(param_name='PTP status', value=True),
+            call.set_parameter(param_name='MME status', value=True),
+            call.set_parameter(param_name='Opstate', value=True),
+            call.set_parameter('GPS lat', '1'),
+            call.set_parameter('GPS long', '1'),
+        ]
+        self.assertEqual(expected, deviceConfig.mock_calls)
+
+        n2 = n1.copy()
+        # Verify we can handle specific none params
+        n2[StatusParameters.DEFAULT_GW] = None
+        n3 = n1.copy()
+        n3[StatusParameters.SYNC_STATUS] = None
+        n4 = n1.copy()
+        n4[StatusParameters.ENB_STATUS] = None
+        n5 = n1.copy()
+        n5[StatusParameters.SAS_STATUS] = None
+        n6 = n1.copy()
+        n6[StatusParameters.GPS_SCAN_STATUS] = None
+        n7 = n1.copy()
+        n7[ParameterName.GPS_LONG] = None
+        n8 = n1.copy()
+        n8[ParameterName.GPS_LAT] = None
+
+        deviceConfig = Mock()
+        expected = [
+            call.set_parameter(param_name='RF TX status', value=True),
+            call.set_parameter(param_name='GPS status', value=True),
+            call.set_parameter(param_name='PTP status', value=True),
+            call.set_parameter(param_name='MME status', value=False),
+            call.set_parameter(param_name='Opstate', value=True),
+            call.set_parameter('GPS lat', '1'),
+            call.set_parameter('GPS long', '1'),
+        ]
+        status.set_magma_device_cfg(n2, deviceConfig)
+        self.assertEqual(expected, deviceConfig.mock_calls)
+
+        deviceConfig = Mock()
+        expected = [
+            call.set_parameter(param_name='RF TX status', value=True),
+            call.set_parameter(param_name='GPS status', value=True),
+            call.set_parameter(param_name='PTP status', value=False),
+            call.set_parameter(param_name='MME status', value=True),
+            call.set_parameter(param_name='Opstate', value=True),
+            call.set_parameter('GPS lat', '1'),
+            call.set_parameter('GPS long', '1'),
+        ]
+        status.set_magma_device_cfg(n3, deviceConfig)
+        self.assertEqual(expected, deviceConfig.mock_calls)
+
+        deviceConfig = Mock()
+        expected = [
+            call.set_parameter(param_name='RF TX status', value=True),
+            call.set_parameter(param_name='GPS status', value=True),
+            call.set_parameter(param_name='PTP status', value=True),
+            call.set_parameter(param_name='MME status', value=True),
+            call.set_parameter(param_name='Opstate', value=False),
+            call.set_parameter('GPS lat', '1'),
+            call.set_parameter('GPS long', '1'),
+        ]
+        status.set_magma_device_cfg(n4, deviceConfig)
+        self.assertEqual(expected, deviceConfig.mock_calls)
+
+        deviceConfig = Mock()
+        expected = [
+            call.set_parameter(param_name='RF TX status', value=False),
+            call.set_parameter(param_name='GPS status', value=True),
+            call.set_parameter(param_name='PTP status', value=True),
+            call.set_parameter(param_name='MME status', value=True),
+            call.set_parameter(param_name='Opstate', value=True),
+            call.set_parameter('GPS lat', '1'),
+            call.set_parameter('GPS long', '1'),
+        ]
+        status.set_magma_device_cfg(n5, deviceConfig)
+        self.assertEqual(expected, deviceConfig.mock_calls)
+
+        deviceConfig = Mock()
+        expected = [
+            call.set_parameter(param_name='RF TX status', value=True),
+            call.set_parameter(param_name='GPS status', value=False),
+            call.set_parameter(param_name='PTP status', value=False),
+            call.set_parameter(param_name='MME status', value=True),
+            call.set_parameter(param_name='Opstate', value=True),
+            call.set_parameter('GPS lat', '1'),
+            call.set_parameter('GPS long', '1'),
+        ]
+        status.set_magma_device_cfg(n6, deviceConfig)
+        self.assertEqual(expected, deviceConfig.mock_calls)
+
+        deviceConfig = Mock()
+        expected = [
+            call.set_parameter(param_name='RF TX status', value=True),
+            call.set_parameter(param_name='GPS status', value=True),
+            call.set_parameter(param_name='PTP status', value=True),
+            call.set_parameter(param_name='MME status', value=True),
+            call.set_parameter(param_name='Opstate', value=True),
+            call.set_parameter('GPS lat', '1'),
+            call.set_parameter('GPS long', None),
+        ]
+        status.set_magma_device_cfg(n7, deviceConfig)
+        self.assertEqual(expected, deviceConfig.mock_calls)
+
+        deviceConfig = Mock()
+        expected = [
+            call.set_parameter(param_name='RF TX status', value=True),
+            call.set_parameter(param_name='GPS status', value=True),
+            call.set_parameter(param_name='PTP status', value=True),
+            call.set_parameter(param_name='MME status', value=True),
+            call.set_parameter(param_name='Opstate', value=True),
+            call.set_parameter('GPS lat', None),
+            call.set_parameter('GPS long', '1'),
+        ]
+        status.set_magma_device_cfg(n8, deviceConfig)
+        self.assertEqual(expected, deviceConfig.mock_calls)


### PR DESCRIPTION
<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

fix(agw): Check for unset params while extracting status
When the eNB just comes up some of the eNB status nodes might not
be populated, check before dereferencing attribute.

Signed-off-by: Amar Padmanabhan <amar@freedomfi.com>

fix(agw): Use get insteard of operator []

Address review comments, get is safer than [] and
the code is cleaner as explicitly set to None values are
handled identifical to the key itself being missing.

Signed-off-by: Amar Padmanabhan <amar@freedomfi.com>

## Test Plan
unit tests
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
