### PR TITLE
chore(mme): Unit test clean up for mme_app, new checks and new test case

### DIFF
--- a/lte/gateway/c/core/oai/test/mme_app_task/mme_app_test_util.cpp
+++ b/lte/gateway/c/core/oai/test/mme_app_task/mme_app_test_util.cpp
@@ -41,7 +41,7 @@ void send_activate_message_to_mme_app() {
 }
 
 void send_mme_app_initial_ue_msg(
-    uint8_t* nas_msg, uint8_t nas_msg_length, const plmn_t& plmn) {
+    const uint8_t* nas_msg, uint8_t nas_msg_length, const plmn_t& plmn) {
   MessageDef* message_p =
       itti_alloc_new_message(TASK_S1AP, S1AP_INITIAL_UE_MESSAGE);
   ITTI_MSG_LASTHOP_LATENCY(message_p)               = 0;
@@ -58,7 +58,7 @@ void send_mme_app_initial_ue_msg(
 }
 
 void send_mme_app_uplink_data_ind(
-    uint8_t* nas_msg, uint8_t nas_msg_length, const plmn_t& plmn) {
+    const uint8_t* nas_msg, uint8_t nas_msg_length, const plmn_t& plmn) {
   MessageDef* message_p =
       itti_alloc_new_message(TASK_S1AP, MME_APP_UPLINK_DATA_IND);
   ITTI_MSG_LASTHOP_LATENCY(message_p)     = 0;

--- a/lte/gateway/c/core/oai/test/mme_app_task/mme_app_test_util.cpp
+++ b/lte/gateway/c/core/oai/test/mme_app_task/mme_app_test_util.cpp
@@ -72,36 +72,40 @@ void send_mme_app_uplink_data_ind(
   return;
 }
 
-void send_authentication_info_resp(const std::string& imsi) {
+void send_authentication_info_resp(const std::string& imsi, bool success) {
   MessageDef* message_p = itti_alloc_new_message(TASK_S6A, S6A_AUTH_INFO_ANS);
   s6a_auth_info_ans_t* itti_msg = &message_p->ittiMsg.s6a_auth_info_ans;
   strncpy(itti_msg->imsi, imsi.c_str(), imsi.size());
-  itti_msg->imsi_length        = imsi.size();
-  itti_msg->result.present     = S6A_RESULT_BASE;
-  itti_msg->result.choice.base = DIAMETER_SUCCESS;
-  magma::feg::AuthenticationInformationAnswer aia;
-  magma::feg::AuthenticationInformationAnswer::EUTRANVector eutran_vector;
-  uint8_t xres_buf[XRES_LENGTH_MAX]      = {0x66, 0xff, 0x47, 0x2d, 0xd4, 0x93,
-                                       0xf1, 0x5a, 0x00, 0x00, 0x00, 0x00,
-                                       0x00, 0x00, 0x00, 0x00};
-  uint8_t rand_buf[RAND_LENGTH_OCTETS]   = {0x68, 0x16, 0xa1, 0x0c, 0x0f, 0xeb,
-                                          0x44, 0xa5, 0x00, 0x5c, 0x9c, 0x9c,
-                                          0x3c, 0x6f, 0xd6, 0x15};
-  uint8_t autn_buf[AUTN_LENGTH_OCTETS]   = {0x4a, 0xe4, 0xe0, 0xd9, 0xaa, 0x4b,
-                                          0x80, 0x00, 0xc4, 0x80, 0xa1, 0x97,
-                                          0x70, 0x4b, 0x7b, 0x8f};
-  uint8_t kasme_buf[KASME_LENGTH_OCTETS] = {
-      0xc3, 0x5f, 0x03, 0x8f, 0x5f, 0xbe, 0xcc, 0x23, 0xc4, 0xd1, 0xa7,
-      0xd6, 0x8a, 0xf7, 0x05, 0x32, 0xf2, 0x37, 0xf6, 0x40, 0x47, 0xdd,
-      0x29, 0x6e, 0x7d, 0x0e, 0xf6, 0xe9, 0x26, 0x5f, 0x24, 0x39};
-  eutran_vector.set_rand((const void*) rand_buf, RAND_LENGTH_OCTETS);
-  eutran_vector.set_xres((const void*) xres_buf, XRES_LENGTH_MAX);
-  eutran_vector.set_autn((const void*) autn_buf, AUTN_LENGTH_OCTETS);
-  eutran_vector.set_kasme((const void*) kasme_buf, KASME_LENGTH_OCTETS);
-  aia.set_error_code(magma::feg::ErrorCode::SUCCESS);
-  auto eutran_vectors = aia.mutable_eutran_vectors();
-  eutran_vectors->Add()->CopyFrom(eutran_vector);
-  magma::convert_proto_msg_to_itti_s6a_auth_info_ans(aia, itti_msg);
+  itti_msg->imsi_length    = imsi.size();
+  itti_msg->result.present = S6A_RESULT_BASE;
+  if (success) {
+    itti_msg->result.choice.base = DIAMETER_SUCCESS;
+    magma::feg::AuthenticationInformationAnswer aia;
+    magma::feg::AuthenticationInformationAnswer::EUTRANVector eutran_vector;
+    uint8_t xres_buf[XRES_LENGTH_MAX]    = {0x66, 0xff, 0x47, 0x2d, 0xd4, 0x93,
+                                         0xf1, 0x5a, 0x00, 0x00, 0x00, 0x00,
+                                         0x00, 0x00, 0x00, 0x00};
+    uint8_t rand_buf[RAND_LENGTH_OCTETS] = {0x68, 0x16, 0xa1, 0x0c, 0x0f, 0xeb,
+                                            0x44, 0xa5, 0x00, 0x5c, 0x9c, 0x9c,
+                                            0x3c, 0x6f, 0xd6, 0x15};
+    uint8_t autn_buf[AUTN_LENGTH_OCTETS] = {0x4a, 0xe4, 0xe0, 0xd9, 0xaa, 0x4b,
+                                            0x80, 0x00, 0xc4, 0x80, 0xa1, 0x97,
+                                            0x70, 0x4b, 0x7b, 0x8f};
+    uint8_t kasme_buf[KASME_LENGTH_OCTETS] = {
+        0xc3, 0x5f, 0x03, 0x8f, 0x5f, 0xbe, 0xcc, 0x23, 0xc4, 0xd1, 0xa7,
+        0xd6, 0x8a, 0xf7, 0x05, 0x32, 0xf2, 0x37, 0xf6, 0x40, 0x47, 0xdd,
+        0x29, 0x6e, 0x7d, 0x0e, 0xf6, 0xe9, 0x26, 0x5f, 0x24, 0x39};
+    eutran_vector.set_rand((const void*) rand_buf, RAND_LENGTH_OCTETS);
+    eutran_vector.set_xres((const void*) xres_buf, XRES_LENGTH_MAX);
+    eutran_vector.set_autn((const void*) autn_buf, AUTN_LENGTH_OCTETS);
+    eutran_vector.set_kasme((const void*) kasme_buf, KASME_LENGTH_OCTETS);
+    aia.set_error_code(magma::feg::ErrorCode::SUCCESS);
+    auto eutran_vectors = aia.mutable_eutran_vectors();
+    eutran_vectors->Add()->CopyFrom(eutran_vector);
+    magma::convert_proto_msg_to_itti_s6a_auth_info_ans(aia, itti_msg);
+  } else {
+    itti_msg->result.choice.base = DIAMETER_UNABLE_TO_COMPLY;
+  }
   send_msg_to_task(&task_zmq_ctx_main, TASK_MME_APP, message_p);
   return;
 }

--- a/lte/gateway/c/core/oai/test/mme_app_task/mme_app_test_util.h
+++ b/lte/gateway/c/core/oai/test/mme_app_task/mme_app_test_util.h
@@ -20,10 +20,10 @@ void send_sctp_mme_server_initialized();
 void send_activate_message_to_mme_app();
 
 void send_mme_app_initial_ue_msg(
-    uint8_t* nas_msg, uint8_t nas_msg_length, const plmn_t& plmn);
+    const uint8_t* nas_msg, uint8_t nas_msg_length, const plmn_t& plmn);
 
 void send_mme_app_uplink_data_ind(
-    uint8_t* nas_msg, uint8_t nas_msg_length, const plmn_t& plmn);
+    const uint8_t* nas_msg, uint8_t nas_msg_length, const plmn_t& plmn);
 
 void send_authentication_info_resp(const std::string& imsi);
 

--- a/lte/gateway/c/core/oai/test/mme_app_task/mme_app_test_util.h
+++ b/lte/gateway/c/core/oai/test/mme_app_task/mme_app_test_util.h
@@ -25,7 +25,7 @@ void send_mme_app_initial_ue_msg(
 void send_mme_app_uplink_data_ind(
     const uint8_t* nas_msg, uint8_t nas_msg_length, const plmn_t& plmn);
 
-void send_authentication_info_resp(const std::string& imsi);
+void send_authentication_info_resp(const std::string& imsi, bool success);
 
 void send_s6a_ula(const std::string& imsi);
 


### PR DESCRIPTION
<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->
- Moved common definitions and declarations to test object class. 
- Assigned more meaningful names for nas messages.
- Added extra check for the faulty message case.
- Added test case for failed authentication information request.

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->
Run the mme unit tests via `make test_oai` in dev vm. Pasted the results and current run times for test_mme_app.

```
 5/18 Test  #5: test_mme_app ......................   Passed    6.74 sec
 5/18 Test  #5: test_mme_app ......................   Passed    6.88 sec
 5/18 Test  #5: test_mme_app ......................   Passed    7.05 sec
 5/18 Test  #5: test_mme_app ......................   Passed    6.92 sec
 5/18 Test  #5: test_mme_app ......................   Passed    6.94 sec
 5/18 Test  #5: test_mme_app ......................   Passed    6.97 sec
 5/18 Test  #5: test_mme_app ......................   Passed    6.97 sec
 5/18 Test  #5: test_mme_app ......................   Passed    6.85 sec
 5/18 Test  #5: test_mme_app ......................   Passed    6.83 sec
 5/18 Test  #5: test_mme_app ......................   Passed    6.82 sec
```
## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
