### PR TITLE
chore: refactor circleci config for sentry upload so we can add more …

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -293,25 +293,46 @@ commands:
               fi
             done
 
-  sentry-upload:
+  sentry-create-artifacts:
     parameters:
       executable_name:
         description: Name of executable that should be pushed to sentry
         type: string
     steps:
       - run:
-          name: Upload debug artifacts for an executable to Sentry.io
+          name: Create debug artifacts to be uploaded to Sentry.io
           command: |
             # The assumption here is that packages.tar.gz was copied out and untarred
             # in $MAGMA_ROOT/circleci in the magma_integ_test step
             cd circleci/executables
 
-            SENTRY_ORG="lf-9c"
-            NATIVE_PROJECT="lab-agws-native"
             EXEC="<< parameters.executable_name >>"
             objcopy --only-keep-debug "$EXEC" "$EXEC".debug
             objcopy --strip-debug --strip-unneeded "$EXEC"
             objcopy --add-gnu-debuglink="$EXEC".debug "$EXEC"
+
+  sentry-upload:
+    parameters:
+      executable_name:
+        description: Name of executable that should be pushed to sentry
+        type: string
+      project:
+        description: Name of Sentry project that the symbols should be uploaded to
+        type: string
+      org:
+        description: Name of Sentry organization that the symbols should be uploaded to
+        type: string
+    steps:
+      - run:
+          name: Upload debug artifacts for an executable to Sentry.io
+          command: |
+            # The assumption here is that debug artifacts already exist for this executable
+            # This should be true if sentry-create-artifacts was run before this
+            cd circleci/executables
+
+            SENTRY_ORG="<< parameters.org >>"
+            NATIVE_PROJECT="<< parameters.project >>"
+            EXEC="<< parameters.executable_name >>"
 
             # [Optional] Log included debug information
             sentry-cli difutil check "$EXEC"
@@ -330,10 +351,18 @@ commands:
           command: |
             echo export SENTRY_ENVIRONMENT="staging" >> $BASH_ENV
             echo export SENTRY_ORG="lf-9c" >> $BASH_ENV
+      - sentry-create-artifacts:
+          executable_name: sessiond
+      - sentry-create-artifacts:
+          executable_name: mme
       - sentry-upload:
           executable_name: sessiond
+          project: lab-agws-native
+          org: lf-9c
       - sentry-upload:
           executable_name: mme
+          project: lab-agws-native
+          org: lf-9c
       - run:
           name: Create a release in Sentry.io with the commit hash
           command: |


### PR DESCRIPTION
…projects

Signed-off-by: Marie Bremner <marwhal@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary
Issue: https://github.com/magma/magma/issues/9375

Sentry only allows artifact upload for one project at a time, unfortunately. This PR refactors the sentry related logic in CircleCI into 2 steps. (one for generating the debug artifact, and one for uploading to a project). This will make it easy to upload artifacts for any new project we create in the future. 
<!-- Enumerate changes you made and why you made them -->

## Test Plan
Tested on a branch with CircleCI
<img width="1010" alt="Screen Shot 2021-09-30 at 10 15 50 AM" src="https://user-images.githubusercontent.com/37634144/135472306-6eba5fff-c12f-4c49-af8d-a9fddf1be49a.png">

https://app.circleci.com/pipelines/github/magma/magma/33989/workflows/beafdb8b-af17-4793-bc8f-ffa2ef4fa492/jobs/395461
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
