### PR TITLE
fix(feg): Fix for PLMN ID filter issue when IDs with identical prefixes can overwrite each other

### DIFF
--- a/feg/gateway/services/aaa/aaa_server/aaa_aka_auth_test.go
+++ b/feg/gateway/services/aaa/aaa_server/aaa_aka_auth_test.go
@@ -236,7 +236,7 @@ func TestEAPAkaPlmnId6(t *testing.T) {
 	go srv.RunTest(lis)
 
 	eapSrv, eapLis := test_utils.NewTestService(t, registry.ModuleName, registry.EAP_AKA)
-	servicer, err := servicers.NewEapAkaService(&mconfig.EapAkaConfig{PlmnIds: []string{wrongPlmnID6, plmnID6}})
+	servicer, err := servicers.NewEapAkaService(&mconfig.EapAkaConfig{PlmnIds: []string{plmnID6, wrongPlmnID6}})
 	if err != nil {
 		t.Fatalf("failed to create EAP AKA Service: %v", err)
 		return
@@ -252,6 +252,19 @@ func TestEAPAkaPlmnId6(t *testing.T) {
 	tst := eap_test.Units[eap_test.IMSI1]
 	eapCtx := &protos.Context{SessionId: eap.CreateSessionId()}
 	peap, err := aaa_client.Handle(&protos.Eap{Payload: tst.EapIdentityResp, Ctx: eapCtx})
+	if err != nil {
+		t.Fatalf("Error Handling Test EAP: %v", err)
+	}
+	if !reflect.DeepEqual(peap.GetPayload(), tst.ExpectedChallengeReq) {
+		t.Fatalf(
+			"Unexpected identityResponse EAP\n\tReceived: %.3v\n\tExpected: %.3v",
+			peap.GetPayload(), tst.ExpectedChallengeReq)
+	}
+
+	servicer.SetPlmnIdFilter([]string{wrongPlmnID6, plmnID6})
+	tst = eap_test.Units[eap_test.IMSI1]
+	eapCtx = &protos.Context{SessionId: eap.CreateSessionId()}
+	peap, err = aaa_client.Handle(&protos.Eap{Payload: tst.EapIdentityResp, Ctx: eapCtx})
 	if err != nil {
 		t.Fatalf("Error Handling Test EAP: %v", err)
 	}

--- a/feg/gateway/services/eap/providers/aka/servicers/service.go
+++ b/feg/gateway/services/eap/providers/aka/servicers/service.go
@@ -158,6 +158,11 @@ func NewEapAkaService(config *mconfig.EapAkaConfig) (*EapAkaSrv, error) {
 	return service, nil
 }
 
+// SetPlmnIdFilter resets the service's PLMN ID filter from given PLMN ID list
+func (s *EapAkaSrv) SetPlmnIdFilter(plmnIds []string) {
+	s.plmnFilter = plmn_filter.GetPlmnVals(plmnIds, "EAP-AKA")
+}
+
 // CheckPlmnId returns true either if there is no PLMN ID filters (allowlist) configured or
 // one the configured PLMN IDs matches passed IMSI
 func (s *EapAkaSrv) CheckPlmnId(imsi aka.IMSI) bool {


### PR DESCRIPTION


Signed-off-by: Evgeniy Makeev <evgeniym@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

Fix for PLMN ID filter issue when IDs with identical prefixes can overwrite each other

When PLMN ID filters get initialized different PLMN ID can overwrite each other in the filter map if they have an identical 5 digit prefixes.

## Test Plan
Add & run unit test

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
