### PR TITLE
fix(agw): remove fluentbit registry using ansible(hotfix)

### DIFF
--- a/orc8r/tools/ansible/roles/fluent_bit/tasks/main.yml
+++ b/orc8r/tools/ansible/roles/fluent_bit/tasks/main.yml
@@ -10,18 +10,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-- name: Add fluent bit apt signing key
-  apt_key:
-    url: https://packages.fluentbit.io/fluentbit.key
-    state: present
-  when: preburn
-
-- name: Add fluent bit repo to /etc/apt/sources.list
-  apt_repository:
-    repo: deb https://packages.fluentbit.io/{{ ansible_distribution|lower}}/{{ ansible_distribution_release }} {{ ansible_distribution_release }} main
-    state: present
-  when: preburn
-
 - name: Create directories for the fluent-bit DB
   file:
     path: /var/opt/magma/fluent-bit

--- a/orc8r/tools/ansible/roles/pkgrepo/tasks/main.yml
+++ b/orc8r/tools/ansible/roles/pkgrepo/tasks/main.yml
@@ -14,6 +14,10 @@
   fail: msg="distribution is undefined for the pkgrepo role"
   when: distribution is undefined
 
+- name: remove fluentbit repo as its broken
+  shell: rm -rf /etc/apt/sources.list.d/packages_fluentbit_io_ubuntu_focal.list
+  become: yes
+
 - name: Set up debian style repository
   when: ansible_distribution == 'Debian' or ansible_distribution == 'Ubuntu'
   include_tasks: debian.yml

--- a/orc8r/tools/ansible/roles/pkgrepo/tasks/main.yml
+++ b/orc8r/tools/ansible/roles/pkgrepo/tasks/main.yml
@@ -17,6 +17,7 @@
 - name: remove fluentbit repo as its broken
   shell: rm -rf /etc/apt/sources.list.d/packages_fluentbit_io_ubuntu_focal.list
   become: yes
+  ignore_errors: yes
 
 - name: Set up debian style repository
   when: ansible_distribution == 'Debian' or ansible_distribution == 'Ubuntu'


### PR DESCRIPTION
Signed-off-by: Timothée Dzik <timdzik@fb.com>

fix(agw): remove fluentbit registry using ansible(hotfix)

## Summary

fix(agw): remove fluentbit registry using ansible(hotfix)

## Test Plan

lte-integ-test should be happy (tested locally)

## Additional Information
