### PR TITLE
chore(mme): Adding unit test for ULA failure

### DIFF
--- a/lte/gateway/c/core/oai/tasks/nas/emm/Attach.c
+++ b/lte/gateway/c/core/oai/tasks/nas/emm/Attach.c
@@ -660,9 +660,8 @@ status_code_e emm_proc_attach_reject(
           (nas_emm_attach_proc_t*) (emm_ctx->emm_procedures->emm_specific_proc);
       attach_proc->emm_cause = emm_cause;
 
-      // TODO could be in callback of attach procedure triggered by
+      // Handling in callback of attach procedure triggered by
       // EMMREG_ATTACH_REJ
-      rc = _emm_attach_reject(emm_ctx, (struct nas_base_proc_s*) attach_proc);
       emm_sap_t emm_sap               = {0};
       emm_sap.primitive               = EMMREG_ATTACH_REJ;
       emm_sap.u.emm_reg.ue_id         = ue_id;

--- a/lte/gateway/c/core/oai/tasks/nas/emm/Attach.c
+++ b/lte/gateway/c/core/oai/tasks/nas/emm/Attach.c
@@ -660,8 +660,9 @@ status_code_e emm_proc_attach_reject(
           (nas_emm_attach_proc_t*) (emm_ctx->emm_procedures->emm_specific_proc);
       attach_proc->emm_cause = emm_cause;
 
-      // Handling in callback of attach procedure triggered by
+      // TODO could be in callback of attach procedure triggered by
       // EMMREG_ATTACH_REJ
+      rc = _emm_attach_reject(emm_ctx, (struct nas_base_proc_s*) attach_proc);
       emm_sap_t emm_sap               = {0};
       emm_sap.primitive               = EMMREG_ATTACH_REJ;
       emm_sap.u.emm_reg.ue_id         = ue_id;

--- a/lte/gateway/c/core/oai/test/mme_app_task/mme_app_test_util.h
+++ b/lte/gateway/c/core/oai/test/mme_app_task/mme_app_test_util.h
@@ -27,7 +27,7 @@ void send_mme_app_uplink_data_ind(
 
 void send_authentication_info_resp(const std::string& imsi, bool success);
 
-void send_s6a_ula(const std::string& imsi);
+void send_s6a_ula(const std::string& imsi, bool success);
 
 void send_create_session_resp();
 

--- a/lte/gateway/c/core/oai/test/mme_app_task/test_mme_procedures.cpp
+++ b/lte/gateway/c/core/oai/test/mme_app_task/test_mme_procedures.cpp
@@ -423,9 +423,9 @@ TEST_F(MmeAppProcedureTest, TestImsiAttachEpsOnlyUlaFailure) {
       magma::lte::MmeNasStateManager::getInstance().get_state(false);
   std::condition_variable cv;
 
-  EXPECT_CALL(*s1ap_handler, s1ap_generate_downlink_nas_transport()).Times(3);
+  EXPECT_CALL(*s1ap_handler, s1ap_generate_downlink_nas_transport()).Times(4);
   EXPECT_CALL(*s1ap_handler, s1ap_handle_conn_est_cnf()).Times(0);
-  EXPECT_CALL(*s1ap_handler, s1ap_handle_ue_context_release_command()).Times(1);
+  EXPECT_CALL(*s1ap_handler, s1ap_handle_ue_context_release_command()).Times(2);
   EXPECT_CALL(*s6a_handler, s6a_viface_authentication_info_req()).Times(1);
   EXPECT_CALL(*s6a_handler, s6a_viface_update_location_req()).Times(1);
   EXPECT_CALL(*s6a_handler, s6a_viface_purge_ue()).Times(0);


### PR DESCRIPTION
<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->
PR adds unit test (`TestImsiAttachEpsOnlyUlaFailure`) for failed Update Location Request towards S6a task. 

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->
Run the unit test suit multiple times and observe that no flakes exist.

## Additional Information

- [ ] This change is backwards-breaking

While running this test, it is discovered that Attach Reject and Context Release Requests are being sent twice rather than once. After this issue is fixed, the unit test need to be updated to the correct values. I.e., instead of:
```
  EXPECT_CALL(*s1ap_handler, s1ap_generate_downlink_nas_transport()).Times(4);
  ...
  EXPECT_CALL(*s1ap_handler, s1ap_handle_ue_context_release_command()).Times(2);
  ...
```

we expect after the fix:

```
  EXPECT_CALL(*s1ap_handler, s1ap_generate_downlink_nas_transport()).Times(3);
  ...
  EXPECT_CALL(*s1ap_handler, s1ap_handle_ue_context_release_command()).Times(1);
  ...

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
