### PR TITLE
test(mme): Adding unit tests for S1AP MME handler functions

### DIFF
--- a/lte/gateway/c/core/oai/common/itti_free_defined_msg.c
+++ b/lte/gateway/c/core/oai/common/itti_free_defined_msg.c
@@ -162,8 +162,9 @@ void itti_free_msg_content(MessageDef* const message_p) {
                        .ue_to_reset_list);
       break;
     case S1AP_UE_CAPABILITIES_IND: {
-        free_wrapper((void**) &message_p->ittiMsg.s1ap_ue_cap_ind.radio_capabilities);
-        break;
+      free_wrapper(
+          (void**) &message_p->ittiMsg.s1ap_ue_cap_ind.radio_capabilities);
+      break;
     }
     case S1AP_ENB_DEREGISTERED_IND:
     case S1AP_UE_CONTEXT_RELEASE_REQ:

--- a/lte/gateway/c/core/oai/common/itti_free_defined_msg.c
+++ b/lte/gateway/c/core/oai/common/itti_free_defined_msg.c
@@ -161,7 +161,10 @@ void itti_free_msg_content(MessageDef* const message_p) {
       free_wrapper((void**) &message_p->ittiMsg.s1ap_enb_initiated_reset_ack
                        .ue_to_reset_list);
       break;
-    case S1AP_UE_CAPABILITIES_IND:
+    case S1AP_UE_CAPABILITIES_IND: {
+        free_wrapper((void**) &message_p->ittiMsg.s1ap_ue_cap_ind.radio_capabilities);
+        break;
+    }
     case S1AP_ENB_DEREGISTERED_IND:
     case S1AP_UE_CONTEXT_RELEASE_REQ:
     case S1AP_UE_CONTEXT_RELEASE_COMMAND:

--- a/lte/gateway/c/core/oai/include/mme_config.h
+++ b/lte/gateway/c/core/oai/include/mme_config.h
@@ -465,6 +465,8 @@ int mme_config_parse_string(const char* config_string, mme_config_t* config_pP);
 void mme_config_display(mme_config_t*);
 void create_partial_lists(mme_config_t* config_pP);
 void mme_config_exit(void);
+
+void free_partial_lists(mme_config_t* config_pP);
 void free_mme_config(mme_config_t* mme_config);
 
 #define mme_config_read_lock(mMEcONFIG)                                        \

--- a/lte/gateway/c/core/oai/include/s1ap_state.h
+++ b/lte/gateway/c/core/oai/include/s1ap_state.h
@@ -84,6 +84,9 @@ bool get_mme_ue_ids_no_imsi(
 
 void remove_ues_without_imsi_from_ue_id_coll(void);
 
+void clean_stale_enb_state(
+    s1ap_state_t* state, enb_description_t* new_enb_association);
+
 #ifdef __cplusplus
 }
 #endif

--- a/lte/gateway/c/core/oai/lib/itti/intertask_interface.c
+++ b/lte/gateway/c/core/oai/lib/itti/intertask_interface.c
@@ -35,15 +35,11 @@
 #include <stdbool.h>
 #include <unistd.h>
 #include <string.h>
-#include <errno.h>
-#include <signal.h>
 #include <malloc.h>
 #include <stdint.h>
-#include <sys/time.h>
 
 #include "assertions.h"
 #include "intertask_interface.h"
-#include "intertask_interface_conf.h"
 #include "common_defs.h"
 
 /* Includes "intertask_interface_init.h" to check prototype coherence, but

--- a/lte/gateway/c/core/oai/tasks/mme_app/mme_app_capabilities.c
+++ b/lte/gateway/c/core/oai/tasks/mme_app/mme_app_capabilities.c
@@ -61,7 +61,6 @@ status_code_e mme_app_handle_s1ap_ue_capabilities_ind(
   ue_context_p->ue_radio_capability = blk2bstr(
       s1ap_ue_cap_ind_pP->radio_capabilities,
       s1ap_ue_cap_ind_pP->radio_capabilities_length);
-  free_wrapper((void**) &s1ap_ue_cap_ind_pP->radio_capabilities);
 
   OAILOG_DEBUG(
       LOG_MME_APP, "UE radio capabilities of length %d found and cached\n",

--- a/lte/gateway/c/core/oai/tasks/mme_app/mme_app_transport.c
+++ b/lte/gateway/c/core/oai/tasks/mme_app/mme_app_transport.c
@@ -36,7 +36,6 @@
 #include "nas/as_message.h"
 #include "common_types.h"
 #include "intertask_interface_types.h"
-#include "itti_types.h"
 #include "mme_app_desc.h"
 #include "s1ap_messages_types.h"
 #include "sgs_messages_types.h"

--- a/lte/gateway/c/core/oai/tasks/s1ap/s1ap_mme.c
+++ b/lte/gateway/c/core/oai/tasks/s1ap/s1ap_mme.c
@@ -28,13 +28,6 @@
 #include "config.h"
 #endif
 
-#include <stdlib.h>
-#include <stdio.h>
-#include <stdbool.h>
-#include <stdint.h>
-#include <pthread.h>
-#include <netinet/in.h>
-
 #include "bstrlib.h"
 #include "hashtable.h"
 #include "log.h"
@@ -53,7 +46,6 @@
 #include "common_defs.h"
 #include "intertask_interface.h"
 #include "intertask_interface_types.h"
-#include "itti_types.h"
 #include "mme_app_messages_types.h"
 #include "mme_default_values.h"
 #include "s1ap_messages_types.h"

--- a/lte/gateway/c/core/oai/tasks/s1ap/s1ap_mme_decoder.c
+++ b/lte/gateway/c/core/oai/tasks/s1ap/s1ap_mme_decoder.c
@@ -22,21 +22,18 @@
    \version 0.1
 */
 
-#include <stdbool.h>
-#include <string.h>
+#include "s1ap_mme_decoder.h"
 
 #include "bstrlib.h"
 #include "log.h"
 #include "assertions.h"
 #include "common_defs.h"
-#include "s1ap_mme_decoder.h"
 #include "S1ap_S1AP-PDU.h"
 #include "S1ap_InitiatingMessage.h"
 #include "S1ap_ProcedureCode.h"
 #include "S1ap_SuccessfulOutcome.h"
 #include "S1ap_UnsuccessfulOutcome.h"
 #include "asn_codecs.h"
-#include "constr_TYPE.h"
 #include "per_decoder.h"
 
 //-----------------------------------------------------------------------------

--- a/lte/gateway/c/core/oai/tasks/s1ap/s1ap_mme_handlers.c
+++ b/lte/gateway/c/core/oai/tasks/s1ap/s1ap_mme_handlers.c
@@ -28,7 +28,6 @@
 #include <stdint.h>
 #include <netinet/in.h>
 #include <string.h>
-#include <sys/types.h>
 
 #include "bstrlib.h"
 #include "hashtable.h"
@@ -47,7 +46,6 @@
 #include "s1ap_mme_handlers.h"
 #include "mme_events.h"
 #include "3gpp_23.003.h"
-#include "3gpp_24.008.h"
 #include "3gpp_36.401.h"
 #include "3gpp_36.413.h"
 #include "BIT_STRING.h"
@@ -93,7 +91,6 @@
 #include "asn_SEQUENCE_OF.h"
 #include "common_defs.h"
 #include "intertask_interface_types.h"
-#include "itti_types.h"
 #include "mme_app_messages_types.h"
 #include "includes/MetricsHelpers.h"
 #include "s1ap_state.h"
@@ -349,7 +346,7 @@ status_code_e s1ap_mme_generate_s1_setup_failure(
     OAILOG_FUNC_RETURN(LOG_S1AP, RETURNerror);
   }
 
-  bstring b = blk2bstr(buffer_p, length);
+  bstring b = blk2bstr(buffer_p, (int) length);
   free(buffer_p);
   rc = s1ap_mme_itti_send_sctp_request(&b, assoc_id, 0, INVALID_MME_UE_S1AP_ID);
   OAILOG_FUNC_RETURN(LOG_S1AP, rc);

--- a/lte/gateway/c/core/oai/tasks/s1ap/s1ap_mme_handlers.c
+++ b/lte/gateway/c/core/oai/tasks/s1ap/s1ap_mme_handlers.c
@@ -1338,6 +1338,9 @@ status_code_e s1ap_mme_generate_ue_context_release_command(
       cause_value = S1ap_CauseRadioNetwork_load_balancing_tau_required;
       break;
     default:
+      // Freeing ie and pdu data since it will not be encoded
+      free_wrapper((void**) &ie);
+      ASN_STRUCT_FREE_CONTENTS_ONLY(asn_DEF_S1ap_S1AP_PDU, &pdu);
       OAILOG_ERROR_UE(LOG_S1AP, imsi64, "Unknown cause for context release");
       OAILOG_FUNC_RETURN(LOG_S1AP, RETURNerror);
   }

--- a/lte/gateway/c/core/oai/tasks/s1ap/s1ap_mme_itti_messaging.c
+++ b/lte/gateway/c/core/oai/tasks/s1ap/s1ap_mme_itti_messaging.c
@@ -50,7 +50,7 @@ status_code_e s1ap_mme_itti_send_sctp_request(
     OAILOG_FUNC_RETURN(LOG_S1AP, RETURNerror);
   }
   SCTP_DATA_REQ(message_p).payload       = *payload;
-  *payload = NULL;
+  *payload                               = NULL;
   SCTP_DATA_REQ(message_p).assoc_id      = assoc_id;
   SCTP_DATA_REQ(message_p).stream        = stream;
   SCTP_DATA_REQ(message_p).agw_ue_xap_id = ue_id;

--- a/lte/gateway/c/core/oai/tasks/s1ap/s1ap_mme_itti_messaging.c
+++ b/lte/gateway/c/core/oai/tasks/s1ap/s1ap_mme_itti_messaging.c
@@ -21,21 +21,17 @@
   \company Eurecom
   \email: lionel.gauthier@eurecom.fr
 */
+#include "s1ap_mme_itti_messaging.h"
 
-#include <stdio.h>
-#include <stdbool.h>
-#include <stdint.h>
 #include <mme_app_ue_context.h>
 
 #include "bstrlib.h"
 #include "log.h"
 #include "assertions.h"
 #include "intertask_interface.h"
-#include "s1ap_mme_itti_messaging.h"
 #include "S1ap_CauseRadioNetwork.h"
 #include "nas/as_message.h"
 #include "intertask_interface_types.h"
-#include "itti_types.h"
 #include "s1ap_messages_types.h"
 #include "sctp_messages_types.h"
 
@@ -54,7 +50,7 @@ status_code_e s1ap_mme_itti_send_sctp_request(
     OAILOG_FUNC_RETURN(LOG_S1AP, RETURNerror);
   }
   SCTP_DATA_REQ(message_p).payload       = *payload;
-  *payload                               = NULL;
+  *payload = NULL;
   SCTP_DATA_REQ(message_p).assoc_id      = assoc_id;
   SCTP_DATA_REQ(message_p).stream        = stream;
   SCTP_DATA_REQ(message_p).agw_ue_xap_id = ue_id;
@@ -265,9 +261,6 @@ void s1ap_mme_itti_nas_non_delivery_ind(
   MME_APP_DL_DATA_REJ(message_p).err_code =
       s1ap_mme_non_delivery_cause_2_nas_data_rej_cause(cause);
   MME_APP_DL_DATA_REJ(message_p).nas_msg = blk2bstr(nas_msg, nas_msg_length);
-
-  // should be sent to MME_APP, but this one would forward it to NAS_MME, so
-  // send it directly to NAS_MME but let's see
 
   message_p->ittiMsgHeader.imsi = imsi64;
   send_msg_to_task(&s1ap_task_zmq_ctx, TASK_MME_APP, message_p);

--- a/lte/gateway/c/core/oai/tasks/s1ap/s1ap_mme_nas_procedures.c
+++ b/lte/gateway/c/core/oai/tasks/s1ap/s1ap_mme_nas_procedures.c
@@ -28,7 +28,6 @@
 #include <string.h>
 
 #include "bstrlib.h"
-#include "dynamic_memory_check.h"
 #include "assertions.h"
 #include "hashtable.h"
 #include "log.h"
@@ -40,7 +39,6 @@
 #include "s1ap_mme_itti_messaging.h"
 #include "service303.h"
 #include "3gpp_23.003.h"
-#include "3gpp_24.007.h"
 #include "3gpp_36.413.h"
 #include "INTEGER.h"
 #include "OCTET_STRING.h"

--- a/lte/gateway/c/core/oai/tasks/sctp/sctpd_downlink_client.cpp
+++ b/lte/gateway/c/core/oai/tasks/sctp/sctpd_downlink_client.cpp
@@ -21,6 +21,7 @@ extern "C" {
 #include <arpa/inet.h>
 
 #include "assertions.h"
+#include "dynamic_memory_check.h"
 #include "log.h"
 #include "mme_config.h"
 }

--- a/lte/gateway/c/core/oai/test/mock_tasks/CMakeLists.txt
+++ b/lte/gateway/c/core/oai/test/mock_tasks/CMakeLists.txt
@@ -26,6 +26,8 @@ add_library(MOCK_TASKS
     sgw_s8_mock.cpp
     spgw_mock.cpp
     sms_orc8r_mock.cpp
+    mme_app_mock.cpp
+    sctp_mock.cpp
 )
 
 target_link_libraries(MOCK_TASKS

--- a/lte/gateway/c/core/oai/test/mock_tasks/mme_app_mock.cpp
+++ b/lte/gateway/c/core/oai/test/mock_tasks/mme_app_mock.cpp
@@ -81,6 +81,7 @@ static int handle_message(zloop_t* loop, zsock_t* reader, void* arg) {
     } break;
 
     case S1AP_UE_CONTEXT_RELEASE_REQ: {
+        mme_app_handler_->mme_app_handle_s1ap_ue_context_release_req();
     } break;
 
     case S1AP_UE_CONTEXT_MODIFICATION_RESPONSE: {

--- a/lte/gateway/c/core/oai/test/mock_tasks/mme_app_mock.cpp
+++ b/lte/gateway/c/core/oai/test/mock_tasks/mme_app_mock.cpp
@@ -81,7 +81,7 @@ static int handle_message(zloop_t* loop, zsock_t* reader, void* arg) {
     } break;
 
     case S1AP_UE_CONTEXT_RELEASE_REQ: {
-        mme_app_handler_->mme_app_handle_s1ap_ue_context_release_req();
+      mme_app_handler_->mme_app_handle_s1ap_ue_context_release_req();
     } break;
 
     case S1AP_UE_CONTEXT_MODIFICATION_RESPONSE: {

--- a/lte/gateway/c/core/oai/test/mock_tasks/mme_app_mock.cpp
+++ b/lte/gateway/c/core/oai/test/mock_tasks/mme_app_mock.cpp
@@ -1,0 +1,205 @@
+/**
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "mock_tasks.h"
+
+task_zmq_ctx_t task_zmq_ctx_mme;
+static std::shared_ptr<MockMmeAppHandler> mme_app_handler_;
+
+void stop_mock_mme_app_task();
+
+static int handle_message(zloop_t* loop, zsock_t* reader, void* arg) {
+  MessageDef* received_message_p = receive_msg(reader);
+
+  switch (ITTI_MSG_ID(received_message_p)) {
+    case MME_APP_INITIAL_CONTEXT_SETUP_RSP: {
+    } break;
+
+    case S6A_CANCEL_LOCATION_REQ: {
+    } break;
+
+    case MME_APP_UPLINK_DATA_IND: {
+    } break;
+
+    case S11_CREATE_BEARER_REQUEST: {
+    } break;
+
+    case S6A_RESET_REQ: {
+    } break;
+
+    case S11_CREATE_SESSION_RESPONSE: {
+    } break;
+
+    case S11_MODIFY_BEARER_RESPONSE: {
+    } break;
+
+    case S11_RELEASE_ACCESS_BEARERS_RESPONSE: {
+    } break;
+
+    case S11_DELETE_SESSION_RESPONSE: {
+    } break;
+
+    case S11_SUSPEND_ACKNOWLEDGE: {
+    } break;
+
+    case S1AP_E_RAB_SETUP_RSP: {
+    } break;
+
+    case S1AP_E_RAB_REL_RSP: {
+    } break;
+
+    case S1AP_E_RAB_MODIFICATION_IND: {
+    } break;
+
+    case S1AP_INITIAL_UE_MESSAGE: {
+      mme_app_handler_->mme_app_handle_initial_ue_message();
+      bdestroy_wrapper(&S1AP_INITIAL_UE_MESSAGE(received_message_p).nas);
+    } break;
+
+    case S6A_UPDATE_LOCATION_ANS: {
+    } break;
+
+    case S1AP_ENB_INITIATED_RESET_REQ: {
+    } break;
+
+    case S11_PAGING_REQUEST: {
+    } break;
+
+    case MME_APP_INITIAL_CONTEXT_SETUP_FAILURE: {
+    } break;
+
+    case S1AP_UE_CAPABILITIES_IND: {
+    } break;
+
+    case S1AP_UE_CONTEXT_RELEASE_REQ: {
+    } break;
+
+    case S1AP_UE_CONTEXT_MODIFICATION_RESPONSE: {
+    } break;
+
+    case S1AP_UE_CONTEXT_MODIFICATION_FAILURE: {
+    } break;
+
+    case S1AP_UE_CONTEXT_RELEASE_COMPLETE: {
+    } break;
+
+    case S1AP_ENB_DEREGISTERED_IND: {
+    } break;
+
+    case ACTIVATE_MESSAGE: {
+    } break;
+
+    case SCTP_MME_SERVER_INITIALIZED: {
+    } break;
+
+    case S6A_PURGE_UE_ANS: {
+    } break;
+
+    case SGSAP_LOCATION_UPDATE_ACC: {
+    } break;
+
+    case SGSAP_LOCATION_UPDATE_REJ: {
+    } break;
+
+    case SGSAP_ALERT_REQUEST: {
+    } break;
+
+    case SGSAP_VLR_RESET_INDICATION: {
+    } break;
+
+    case SGSAP_PAGING_REQUEST: {
+    } break;
+
+    case SGSAP_SERVICE_ABORT_REQ: {
+    } break;
+
+    case SGSAP_EPS_DETACH_ACK: {
+    } break;
+
+    case SGSAP_IMSI_DETACH_ACK: {
+    } break;
+
+    case S11_MODIFY_UE_AMBR_REQUEST: {
+    } break;
+
+    case S11_NW_INITIATED_ACTIVATE_BEARER_REQUEST: {
+    } break;
+
+    case SGSAP_STATUS: {
+    } break;
+
+    case S11_NW_INITIATED_DEACTIVATE_BEARER_REQUEST: {
+    } break;
+
+    case S1AP_PATH_SWITCH_REQUEST: {
+    } break;
+
+    case S1AP_HANDOVER_REQUIRED: {
+    } break;
+
+    case S1AP_HANDOVER_REQUEST_ACK: {
+    } break;
+
+    case S1AP_HANDOVER_NOTIFY: {
+    } break;
+
+    case S6A_AUTH_INFO_ANS: {
+    } break;
+
+    case MME_APP_DOWNLINK_DATA_CNF: {
+    } break;
+
+    case MME_APP_DOWNLINK_DATA_REJ: {
+    } break;
+
+    case SGSAP_DOWNLINK_UNITDATA: {
+    } break;
+
+    case SGSAP_RELEASE_REQ: {
+    } break;
+
+    case SGSAP_MM_INFORMATION_REQ: {
+    } break;
+
+    case S1AP_REMOVE_STALE_UE_CONTEXT: {
+    } break;
+
+    case RECOVERY_MESSAGE: {
+    } break;
+
+    case TERMINATE_MESSAGE: {
+      mme_app_handler_.reset();
+      itti_free_msg_content(received_message_p);
+      free(received_message_p);
+      stop_mock_mme_app_task();
+    } break;
+
+    default: { } break; }
+
+  itti_free_msg_content(received_message_p);
+  free(received_message_p);
+
+  return 0;
+}
+
+void stop_mock_mme_app_task() {
+  destroy_task_context(&task_zmq_ctx_mme);
+  pthread_exit(NULL);
+}
+
+void start_mock_mme_app_task(
+    std::shared_ptr<MockMmeAppHandler> mme_app_handler) {
+  mme_app_handler_ = mme_app_handler;
+  init_task_context(
+      TASK_MME_APP, nullptr, 0, handle_message, &task_zmq_ctx_mme);
+  zloop_start(task_zmq_ctx_mme.event_loop);
+}

--- a/lte/gateway/c/core/oai/test/mock_tasks/mock_tasks.h
+++ b/lte/gateway/c/core/oai/test/mock_tasks/mock_tasks.h
@@ -48,6 +48,7 @@ class MockS1apHandler {
 class MockMmeAppHandler {
  public:
   MOCK_METHOD0(mme_app_handle_initial_ue_message, void());
+  MOCK_METHOD0(mme_app_handle_s1ap_ue_context_release_req, void());
 };
 
 class MockSctpdHandler {

--- a/lte/gateway/c/core/oai/test/mock_tasks/mock_tasks.h
+++ b/lte/gateway/c/core/oai/test/mock_tasks/mock_tasks.h
@@ -45,6 +45,16 @@ class MockS1apHandler {
   MOCK_METHOD0(s1ap_handle_ue_context_release_command, void());
 };
 
+class MockMmeAppHandler {
+ public:
+  MOCK_METHOD0(mme_app_handle_initial_ue_message, void());
+};
+
+class MockSctpdHandler {
+public:
+    MOCK_METHOD0(sctpd_send_dl, void());
+};
+
 class MockS6aHandler {
  public:
   MOCK_METHOD0(s6a_viface_authentication_info_req, void());
@@ -65,6 +75,8 @@ class MockService303Handler {
 
 void start_mock_ha_task();
 void start_mock_s1ap_task(std::shared_ptr<MockS1apHandler>);
+void start_mock_sctp_task(std::shared_ptr<MockSctpdHandler>);
+void start_mock_mme_app_task(std::shared_ptr<MockMmeAppHandler>);
 void start_mock_s6a_task(std::shared_ptr<MockS6aHandler>);
 void start_mock_s11_task();
 void start_mock_service303_task(std::shared_ptr<MockService303Handler>);

--- a/lte/gateway/c/core/oai/test/mock_tasks/mock_tasks.h
+++ b/lte/gateway/c/core/oai/test/mock_tasks/mock_tasks.h
@@ -51,9 +51,9 @@ class MockMmeAppHandler {
   MOCK_METHOD0(mme_app_handle_s1ap_ue_context_release_req, void());
 };
 
-class MockSctpdHandler {
-public:
-    MOCK_METHOD0(sctpd_send_dl, void());
+class MockSctpHandler {
+ public:
+  MOCK_METHOD0(sctpd_send_dl, void());
 };
 
 class MockS6aHandler {
@@ -76,7 +76,7 @@ class MockService303Handler {
 
 void start_mock_ha_task();
 void start_mock_s1ap_task(std::shared_ptr<MockS1apHandler>);
-void start_mock_sctp_task(std::shared_ptr<MockSctpdHandler>);
+void start_mock_sctp_task(std::shared_ptr<MockSctpHandler>);
 void start_mock_mme_app_task(std::shared_ptr<MockMmeAppHandler>);
 void start_mock_s6a_task(std::shared_ptr<MockS6aHandler>);
 void start_mock_s11_task();

--- a/lte/gateway/c/core/oai/test/mock_tasks/sctp_mock.cpp
+++ b/lte/gateway/c/core/oai/test/mock_tasks/sctp_mock.cpp
@@ -13,7 +13,7 @@
 #include "mock_tasks.h"
 
 task_zmq_ctx_t task_zmq_ctx_sctp;
-static std::shared_ptr<MockSctpdHandler> sctpd_handler_;
+static std::shared_ptr<MockSctpHandler> sctp_handler_;
 
 void stop_mock_sctp_task();
 
@@ -28,7 +28,7 @@ static int handle_message(zloop_t* loop, zsock_t* reader, void* arg) {
     } break;
 
     case SCTP_DATA_REQ: {
-        sctpd_handler_->sctpd_send_dl();
+      sctp_handler_->sctpd_send_dl();
     } break;
 
     case MESSAGE_TEST: {
@@ -53,8 +53,8 @@ void stop_mock_sctp_task() {
   pthread_exit(NULL);
 }
 
-void start_mock_sctp_task(std::shared_ptr<MockSctpdHandler> sctpd_handler) {
-  sctpd_handler_ = sctpd_handler;
+void start_mock_sctp_task(std::shared_ptr<MockSctpHandler> sctp_handler) {
+  sctp_handler_ = sctp_handler;
   init_task_context(TASK_SCTP, nullptr, 0, handle_message, &task_zmq_ctx_sctp);
   zloop_start(task_zmq_ctx_sctp.event_loop);
 }

--- a/lte/gateway/c/core/oai/test/mock_tasks/sctp_mock.cpp
+++ b/lte/gateway/c/core/oai/test/mock_tasks/sctp_mock.cpp
@@ -1,0 +1,60 @@
+/**
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "mock_tasks.h"
+
+task_zmq_ctx_t task_zmq_ctx_sctp;
+static std::shared_ptr<MockSctpdHandler> sctpd_handler_;
+
+void stop_mock_sctp_task();
+
+static int handle_message(zloop_t* loop, zsock_t* reader, void* arg) {
+  MessageDef* received_message_p = receive_msg(reader);
+
+  switch (ITTI_MSG_ID(received_message_p)) {
+    case SCTP_INIT_MSG: {
+    } break;
+
+    case SCTP_CLOSE_ASSOCIATION: {
+    } break;
+
+    case SCTP_DATA_REQ: {
+        sctpd_handler_->sctpd_send_dl();
+    } break;
+
+    case MESSAGE_TEST: {
+    } break;
+
+    case TERMINATE_MESSAGE: {
+      itti_free_msg_content(received_message_p);
+      free(received_message_p);
+      stop_mock_sctp_task();
+    } break;
+
+    default: { } break; }
+
+  itti_free_msg_content(received_message_p);
+  free(received_message_p);
+
+  return 0;
+}
+
+void stop_mock_sctp_task() {
+  destroy_task_context(&task_zmq_ctx_sctp);
+  pthread_exit(NULL);
+}
+
+void start_mock_sctp_task(std::shared_ptr<MockSctpdHandler> sctpd_handler) {
+  sctpd_handler_ = sctpd_handler;
+  init_task_context(TASK_SCTP, nullptr, 0, handle_message, &task_zmq_ctx_sctp);
+  zloop_start(task_zmq_ctx_sctp.event_loop);
+}

--- a/lte/gateway/c/core/oai/test/s1ap_task/CMakeLists.txt
+++ b/lte/gateway/c/core/oai/test/s1ap_task/CMakeLists.txt
@@ -6,15 +6,32 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+cmake_minimum_required(VERSION 3.7.2)
+
+set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
+include_directories("/usr/src/googletest/googlemock/include/")
+link_directories(/usr/src/googletest/googlemock/lib/)
+
+include_directories(${PROJECT_SOURCE_DIR})
 
 add_executable(s1ap_test
+        s1ap_mme_test_utils.cpp
         s1ap_test.cpp
+        test_s1ap_mme_handlers.cpp
         test_s1ap_handle_new_association.cpp
         test_s1ap_state_manager.cpp)
 
 target_link_libraries(s1ap_test
-        TASK_S1AP
+        TASK_S1AP MOCK_TASKS
         gtest gtest_main
+        )
+
+target_include_directories(s1ap_test PUBLIC
+        ${CMAKE_CURRENT_SOURCE_DIR}
+        ${CHECK_INCLUDE_DIRS}
         )
 
 add_test(test_s1ap s1ap_test)

--- a/lte/gateway/c/core/oai/test/s1ap_task/s1ap_mme_test_utils.cpp
+++ b/lte/gateway/c/core/oai/test/s1ap_task/s1ap_mme_test_utils.cpp
@@ -1,0 +1,67 @@
+/**
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "s1ap_mme_test_utils.h"
+
+extern "C" {
+#include "intertask_interface.h"
+}
+
+namespace magma {
+namespace lte {
+
+extern task_zmq_ctx_t task_zmq_ctx_main_s1ap;
+
+status_code_e setup_new_association(
+    s1ap_state_t* state, sctp_assoc_id_t assoc_id) {
+  bstring ran_cp_ipaddr = bfromcstr("\xc0\xa8\x3c\x8d");
+  sctp_new_peer_t p     = {
+      .instreams     = 1,
+      .outstreams    = 2,
+      .assoc_id      = assoc_id,
+      .ran_cp_ipaddr = ran_cp_ipaddr,
+  };
+  status_code_e rc = s1ap_handle_new_association(state, &p);
+  bdestroy(ran_cp_ipaddr);
+  return rc;
+}
+status_code_e generate_s1_setup_request_pdu(S1ap_S1AP_PDU_t* pdu_s1) {
+  uint8_t packet_bytes[] = {
+      0x00, 0x11, 0x00, 0x2f, 0x00, 0x00, 0x04, 0x00, 0x3b, 0x00, 0x09,
+      0x00, 0x00, 0xf1, 0x10, 0x40, 0x00, 0x00, 0x00, 0xa0, 0x00, 0x3c,
+      0x40, 0x0b, 0x80, 0x09, 0x22, 0x52, 0x41, 0x44, 0x49, 0x53, 0x59,
+      0x53, 0x22, 0x00, 0x40, 0x00, 0x07, 0x00, 0x00, 0x00, 0x40, 0x00,
+      0xf1, 0x10, 0x00, 0x89, 0x40, 0x01, 0x00};
+
+  bstring payload_s1_setup;
+  payload_s1_setup = blk2bstr(&packet_bytes, sizeof(packet_bytes));
+
+  status_code_e pdu_rc = s1ap_mme_decode_pdu(pdu_s1, payload_s1_setup);
+  bdestroy_wrapper(&payload_s1_setup);
+  return pdu_rc;
+}
+
+
+void handle_mme_ue_id_notification(s1ap_state_t* s, sctp_assoc_id_t assoc_id) {
+    MessageDef* message_p  = itti_alloc_new_message(
+            TASK_MME_APP, MME_APP_S1AP_MME_UE_ID_NOTIFICATION);
+    itti_mme_app_s1ap_mme_ue_id_notification_t* notification_p = &message_p->ittiMsg.mme_app_s1ap_mme_ue_id_notification;
+    memset(notification_p, 0, sizeof(itti_mme_app_s1ap_mme_ue_id_notification_t));
+    notification_p->enb_ue_s1ap_id = 1;
+    notification_p->mme_ue_s1ap_id = 7;
+    notification_p->sctp_assoc_id  = assoc_id;
+    s1ap_handle_mme_ue_id_notification(s, notification_p);
+    free(message_p);
+}
+
+}  // namespace lte
+}  // namespace magma

--- a/lte/gateway/c/core/oai/test/s1ap_task/s1ap_mme_test_utils.cpp
+++ b/lte/gateway/c/core/oai/test/s1ap_task/s1ap_mme_test_utils.cpp
@@ -50,17 +50,17 @@ status_code_e generate_s1_setup_request_pdu(S1ap_S1AP_PDU_t* pdu_s1) {
   return pdu_rc;
 }
 
-
 void handle_mme_ue_id_notification(s1ap_state_t* s, sctp_assoc_id_t assoc_id) {
-    MessageDef* message_p  = itti_alloc_new_message(
-            TASK_MME_APP, MME_APP_S1AP_MME_UE_ID_NOTIFICATION);
-    itti_mme_app_s1ap_mme_ue_id_notification_t* notification_p = &message_p->ittiMsg.mme_app_s1ap_mme_ue_id_notification;
-    memset(notification_p, 0, sizeof(itti_mme_app_s1ap_mme_ue_id_notification_t));
-    notification_p->enb_ue_s1ap_id = 1;
-    notification_p->mme_ue_s1ap_id = 7;
-    notification_p->sctp_assoc_id  = assoc_id;
-    s1ap_handle_mme_ue_id_notification(s, notification_p);
-    free(message_p);
+  MessageDef* message_p =
+      itti_alloc_new_message(TASK_MME_APP, MME_APP_S1AP_MME_UE_ID_NOTIFICATION);
+  itti_mme_app_s1ap_mme_ue_id_notification_t* notification_p =
+      &message_p->ittiMsg.mme_app_s1ap_mme_ue_id_notification;
+  memset(notification_p, 0, sizeof(itti_mme_app_s1ap_mme_ue_id_notification_t));
+  notification_p->enb_ue_s1ap_id = 1;
+  notification_p->mme_ue_s1ap_id = 7;
+  notification_p->sctp_assoc_id  = assoc_id;
+  s1ap_handle_mme_ue_id_notification(s, notification_p);
+  free(message_p);
 }
 
 }  // namespace lte

--- a/lte/gateway/c/core/oai/test/s1ap_task/s1ap_mme_test_utils.h
+++ b/lte/gateway/c/core/oai/test/s1ap_task/s1ap_mme_test_utils.h
@@ -1,0 +1,32 @@
+/**
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+extern "C" {
+#include "bstrlib.h"
+#include "dynamic_memory_check.h"
+#include "s1ap_mme.h"
+#include "s1ap_mme_decoder.h"
+#include "s1ap_mme_handlers.h"
+#include "s1ap_mme_nas_procedures.h"
+}
+
+namespace magma {
+namespace lte {
+
+status_code_e setup_new_association(
+    s1ap_state_t* state, sctp_assoc_id_t assoc_id);
+status_code_e generate_s1_setup_request_pdu(S1ap_S1AP_PDU_t* pdu_s1);
+
+void handle_mme_ue_id_notification(s1ap_state_t* s, sctp_assoc_id_t assoc_id);
+
+}  // namespace lte
+}  // namespace magma

--- a/lte/gateway/c/core/oai/test/s1ap_task/test_s1ap_mme_handlers.cpp
+++ b/lte/gateway/c/core/oai/test/s1ap_task/test_s1ap_mme_handlers.cpp
@@ -108,7 +108,7 @@ TEST_F(S1apMmeHandlersTest, HandleS1SetupRequestFailureHss) {
 
     sctp_stream_id_t stream_id = 0;
     status_code_e rc =
-            s1ap_mme_handle_s1_setup_request(s, assoc_id, stream_id, &pdu_s1);
+            s1ap_mme_handle_message(s, assoc_id, stream_id, &pdu_s1);
     ASSERT_EQ(rc, RETURNok);
 
     // State validation
@@ -142,7 +142,7 @@ TEST_F(S1apMmeHandlersTest, HandleS1SetupRequestFailureReseting) {
 
     sctp_stream_id_t stream_id = 0;
     status_code_e rc =
-            s1ap_mme_handle_s1_setup_request(s, assoc_id, stream_id, &pdu_s1);
+            s1ap_mme_handle_message(s, assoc_id, stream_id, &pdu_s1);
     ASSERT_EQ(rc, RETURNok);
 
     // State validation
@@ -170,7 +170,7 @@ TEST_F(S1apMmeHandlersTest, HandleICSResponse) {
     S1ap_S1AP_PDU_t pdu_s1;
     memset(&pdu_s1, 0, sizeof(pdu_s1));
     ASSERT_EQ(RETURNok, generate_s1_setup_request_pdu(&pdu_s1));
-    ASSERT_EQ(RETURNok, s1ap_mme_handle_s1_setup_request(s, assoc_id, stream_id, &pdu_s1));
+    ASSERT_EQ(RETURNok, s1ap_mme_handle_message(s, assoc_id, stream_id, &pdu_s1));
 
     uint8_t initial_ue_bytes[] = {
             0x00, 0x0c, 0x40, 0x48, 0x00, 0x00, 0x05, 0x00,
@@ -190,7 +190,7 @@ TEST_F(S1apMmeHandlersTest, HandleICSResponse) {
     memset(&pdu, 0, sizeof(pdu));
 
     ASSERT_EQ(RETURNok, s1ap_mme_decode_pdu(&pdu, payload));
-    ASSERT_EQ(RETURNok, s1ap_mme_handle_initial_ue_message(s, assoc_id, stream_id, &pdu));
+    ASSERT_EQ(RETURNok, s1ap_mme_handle_message(s, assoc_id, stream_id, &pdu));
 
     handle_mme_ue_id_notification(s, assoc_id);
 
@@ -219,7 +219,7 @@ TEST_F(S1apMmeHandlersTest, HandleICSResponse) {
     memset(&pdu_nas, 0, sizeof(pdu_nas));
 
     ASSERT_EQ(s1ap_mme_decode_pdu(&pdu_nas, payload_nas), RETURNok);
-    ASSERT_EQ( s1ap_mme_handle_uplink_nas_transport(s, assoc_id, stream_id, &pdu_nas), RETURNok);
+    ASSERT_EQ( s1ap_mme_handle_message(s, assoc_id, stream_id, &pdu_nas), RETURNok);
 
     uint8_t ics_bytes[] = {
             0x20, 0x09, 0x00, 0x22, 0x00, 0x00, 0x03, 0x00,
@@ -234,7 +234,7 @@ TEST_F(S1apMmeHandlersTest, HandleICSResponse) {
     memset(&pdu_ics, 0, sizeof(pdu_ics));
 
     ASSERT_EQ(s1ap_mme_decode_pdu(&pdu_ics, payload_ics), RETURNok);
-    ASSERT_EQ( s1ap_mme_handle_initial_context_setup_response(s, assoc_id, stream_id, &pdu_ics), RETURNok);
+    ASSERT_EQ( s1ap_mme_handle_message(s, assoc_id, stream_id, &pdu_ics), RETURNok);
 
     // Freeing pdu and payload data
     bdestroy_wrapper(&payload);
@@ -263,7 +263,7 @@ TEST_F(S1apMmeHandlersTest, HandleUECapIndication) {
     S1ap_S1AP_PDU_t pdu_s1;
     memset(&pdu_s1, 0, sizeof(pdu_s1));
     ASSERT_EQ(RETURNok, generate_s1_setup_request_pdu(&pdu_s1));
-    ASSERT_EQ(RETURNok, s1ap_mme_handle_s1_setup_request(s, assoc_id, stream_id, &pdu_s1));
+    ASSERT_EQ(RETURNok, s1ap_mme_handle_message(s, assoc_id, stream_id, &pdu_s1));
 
     uint8_t initial_ue_bytes[] = {
             0x00, 0x0c, 0x40, 0x48, 0x00, 0x00, 0x05, 0x00,
@@ -283,7 +283,7 @@ TEST_F(S1apMmeHandlersTest, HandleUECapIndication) {
     memset(&pdu, 0, sizeof(pdu));
 
     ASSERT_EQ(RETURNok, s1ap_mme_decode_pdu(&pdu, payload));
-    ASSERT_EQ(RETURNok, s1ap_mme_handle_initial_ue_message(s, assoc_id, stream_id, &pdu));
+    ASSERT_EQ(RETURNok, s1ap_mme_handle_message(s, assoc_id, stream_id, &pdu));
 
     handle_mme_ue_id_notification(s, assoc_id);
 
@@ -307,7 +307,7 @@ TEST_F(S1apMmeHandlersTest, HandleUECapIndication) {
     memset(&pdu_cap, 0, sizeof(pdu_cap));
 
     ASSERT_EQ(s1ap_mme_decode_pdu(&pdu_cap, payload_ue_cap), RETURNok);
-    ASSERT_EQ( s1ap_mme_handle_ue_cap_indication(s, assoc_id, stream_id, &pdu_cap), RETURNok);
+    ASSERT_EQ( s1ap_mme_handle_message(s, assoc_id, stream_id, &pdu_cap), RETURNok);
 
     // Freeing pdu and payload data
     bdestroy_wrapper(&payload);

--- a/lte/gateway/c/core/oai/test/s1ap_task/test_s1ap_mme_handlers.cpp
+++ b/lte/gateway/c/core/oai/test/s1ap_task/test_s1ap_mme_handlers.cpp
@@ -1,0 +1,324 @@
+/**
+ * Copyright 2021 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <gtest/gtest.h>
+#include <thread>
+
+#include "../mock_tasks/mock_tasks.h"
+
+extern "C" {
+#include "bstrlib.h"
+#include "log.h"
+#include "mme_config.h"
+#include "s1ap_mme.h"
+#include "s1ap_mme_decoder.h"
+#include "s1ap_mme_handlers.h"
+#include "s1ap_mme_nas_procedures.h"
+}
+
+#include "s1ap_mme_test_utils.h"
+#include "s1ap_state_manager.h"
+
+extern bool hss_associated;
+
+namespace magma {
+namespace lte {
+
+task_zmq_ctx_t task_zmq_ctx_main_s1ap;
+
+static int handle_message(zloop_t* loop, zsock_t* reader, void* arg) {
+  MessageDef* received_message_p = receive_msg(reader);
+
+  switch (ITTI_MSG_ID(received_message_p)) {
+    default: { } break; }
+
+  itti_free_msg_content(received_message_p);
+  free(received_message_p);
+  return 0;
+}
+
+class S1apMmeHandlersTest : public ::testing::Test {
+  virtual void SetUp() {
+    mme_app_handler = std::make_shared<MockMmeAppHandler>();
+    sctpd_handler = std::make_shared<MockSctpdHandler>();
+
+    itti_init(
+        TASK_MAX, THREAD_MAX, MESSAGES_ID_MAX, tasks_info, messages_info, NULL,
+        NULL);
+
+    // initialize mme config
+    mme_config_init(&mme_config);
+    create_partial_lists(&mme_config);
+    mme_config.use_stateless = false;
+    hss_associated           = true;
+
+    task_id_t task_id_list[4] = {TASK_MME_APP, TASK_S1AP, TASK_SCTP,
+                                 TASK_SERVICE303};
+    init_task_context(
+        TASK_MAIN, task_id_list, 4, handle_message, &task_zmq_ctx_main_s1ap);
+
+    std::thread task_mme_app(start_mock_mme_app_task, mme_app_handler);
+    std::thread task_sctpd(start_mock_sctp_task, sctpd_handler);
+    task_mme_app.detach();
+    task_sctpd.detach();
+
+    s1ap_mme_init(&mme_config);
+    std::this_thread::sleep_for(std::chrono::milliseconds(500));
+  }
+
+  virtual void TearDown() {
+    send_terminate_message_fatal(&task_zmq_ctx_main_s1ap);
+    destroy_task_context(&task_zmq_ctx_main_s1ap);
+    itti_free_desc_threads();
+
+    free_mme_config(&mme_config);
+
+    // Sleep to ensure that messages are received and contexts are released
+    std::this_thread::sleep_for(std::chrono::milliseconds(1000));
+  }
+
+ protected:
+  std::shared_ptr<MockMmeAppHandler> mme_app_handler;
+  std::shared_ptr<MockSctpdHandler> sctpd_handler;
+};
+
+TEST_F(S1apMmeHandlersTest, HandleS1SetupRequestFailureHss) {
+    // Setup new association for testing
+    s1ap_state_t* s          = S1apStateManager::getInstance().get_state(false);
+    sctp_assoc_id_t assoc_id = 1;
+    setup_new_association(s, assoc_id);
+
+    EXPECT_CALL(*sctpd_handler, sctpd_send_dl()).Times(1);
+
+    hss_associated = false;
+
+    S1ap_S1AP_PDU_t pdu_s1;
+    memset(&pdu_s1, 0, sizeof(pdu_s1));
+    status_code_e pdu_rc = generate_s1_setup_request_pdu(&pdu_s1);
+    ASSERT_EQ(pdu_rc, RETURNok);
+
+    sctp_stream_id_t stream_id = 0;
+    status_code_e rc =
+            s1ap_mme_handle_s1_setup_request(s, assoc_id, stream_id, &pdu_s1);
+    ASSERT_EQ(rc, RETURNok);
+
+    // State validation
+    ASSERT_EQ(s->num_enbs, 0);
+
+    // Freeing pdu and payload data
+    ASN_STRUCT_FREE_CONTENTS_ONLY(asn_DEF_S1ap_S1AP_PDU, &pdu_s1);
+
+    // Sleep to ensure that messages are received and contexts are released
+    std::this_thread::sleep_for(std::chrono::milliseconds(1000));
+}
+
+TEST_F(S1apMmeHandlersTest, HandleS1SetupRequestFailureReseting) {
+    // Setup new association for testing
+    s1ap_state_t* s          = S1apStateManager::getInstance().get_state(false);
+    sctp_assoc_id_t assoc_id = 1;
+    setup_new_association(s, assoc_id);
+
+    EXPECT_CALL(*sctpd_handler, sctpd_send_dl()).Times(1);
+
+    enb_description_t* enb_associated = NULL;
+    hashtable_ts_get(
+            &s->enbs, (const hash_key_t) assoc_id,
+            reinterpret_cast<void**>(&enb_associated));
+    enb_associated->s1_state = S1AP_RESETING;
+
+    S1ap_S1AP_PDU_t pdu_s1;
+    memset(&pdu_s1, 0, sizeof(pdu_s1));
+    status_code_e pdu_rc = generate_s1_setup_request_pdu(&pdu_s1);
+    ASSERT_EQ(pdu_rc, RETURNok);
+
+    sctp_stream_id_t stream_id = 0;
+    status_code_e rc =
+            s1ap_mme_handle_s1_setup_request(s, assoc_id, stream_id, &pdu_s1);
+    ASSERT_EQ(rc, RETURNok);
+
+    // State validation
+    ASSERT_EQ(s->num_enbs, 0);
+
+    // Freeing pdu and payload data
+    ASN_STRUCT_FREE_CONTENTS_ONLY(asn_DEF_S1ap_S1AP_PDU, &pdu_s1);
+
+    // Sleep to ensure that messages are received and contexts are released
+    std::this_thread::sleep_for(std::chrono::milliseconds(1500));
+}
+
+TEST_F(S1apMmeHandlersTest, HandleICSResponse) {
+    ASSERT_EQ(task_zmq_ctx_main_s1ap.ready, true);
+
+    // Setup new association for testing
+    s1ap_state_t* s          = S1apStateManager::getInstance().get_state(false);
+    sctp_assoc_id_t assoc_id = 1;
+    sctp_stream_id_t stream_id = 0;
+    bool is_state_same = false;
+    setup_new_association(s, assoc_id);
+
+    EXPECT_CALL(*mme_app_handler, mme_app_handle_initial_ue_message()).Times(1);
+
+    S1ap_S1AP_PDU_t pdu_s1;
+    memset(&pdu_s1, 0, sizeof(pdu_s1));
+    ASSERT_EQ(RETURNok, generate_s1_setup_request_pdu(&pdu_s1));
+    ASSERT_EQ(RETURNok, s1ap_mme_handle_s1_setup_request(s, assoc_id, stream_id, &pdu_s1));
+
+    uint8_t initial_ue_bytes[] = {
+            0x00, 0x0c, 0x40, 0x48, 0x00, 0x00, 0x05, 0x00,
+            0x08, 0x00, 0x02, 0x00, 0x01, 0x00, 0x1a, 0x00,
+            0x20, 0x1f, 0x07, 0x41, 0x71, 0x08, 0x09, 0x10,
+            0x10, 0x00, 0x00, 0x00, 0x00, 0x10, 0x02, 0xe0,
+            0xe0, 0x00, 0x04, 0x02, 0x01, 0xd0, 0x11, 0x40,
+            0x08, 0x04, 0x02, 0x60, 0x04, 0x00, 0x02, 0x1c,
+            0x00, 0x00, 0x43, 0x00, 0x06, 0x00, 0x00, 0xf1,
+            0x10, 0x00, 0x01, 0x00, 0x64, 0x40, 0x08, 0x00,
+            0x00, 0xf1, 0x10, 0x00, 0x00, 0x00, 0xa0, 0x00,
+            0x86, 0x40, 0x01, 0x30};
+
+    bstring payload;
+    payload = blk2bstr(&initial_ue_bytes, sizeof(initial_ue_bytes));
+    S1ap_S1AP_PDU_t pdu;
+    memset(&pdu, 0, sizeof(pdu));
+
+    ASSERT_EQ(RETURNok, s1ap_mme_decode_pdu(&pdu, payload));
+    ASSERT_EQ(RETURNok, s1ap_mme_handle_initial_ue_message(s, assoc_id, stream_id, &pdu));
+
+    handle_mme_ue_id_notification(s, assoc_id);
+
+    // Generate downlink nas transport with dummy payload
+    bstring p;
+    std::string test_str = "test";
+    STRING_TO_BSTRING(test_str, p);
+    s1ap_generate_downlink_nas_transport(s, 1, 7, &p, 1, &is_state_same);
+    bdestroy_wrapper(&p);
+
+    // Authentication response proc packet bytes
+    uint8_t auth_bytes[] = {
+            0x00, 0x0d, 0x40, 0x3d, 0x00, 0x00, 0x05, 0x00,
+            0x00, 0x00, 0x02, 0x00, 0x07, 0x00, 0x08, 0x00,
+            0x02, 0x00, 0x01, 0x00, 0x1a, 0x00, 0x14, 0x13,
+            0x07, 0x53, 0x10, 0x1e, 0x63, 0x7e, 0x5c, 0x58,
+            0xec, 0x5a, 0xa8, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x00, 0x64, 0x40, 0x08, 0x00,
+            0x00, 0xf1, 0x10, 0x00, 0x00, 0x00, 0xa0, 0x00,
+            0x43, 0x40, 0x06, 0x00, 0x00, 0xf1, 0x10, 0x00,
+            0x01};
+
+    bstring payload_nas;
+    payload_nas = blk2bstr(&auth_bytes, sizeof(auth_bytes));
+    S1ap_S1AP_PDU_t pdu_nas;
+    memset(&pdu_nas, 0, sizeof(pdu_nas));
+
+    ASSERT_EQ(s1ap_mme_decode_pdu(&pdu_nas, payload_nas), RETURNok);
+    ASSERT_EQ( s1ap_mme_handle_uplink_nas_transport(s, assoc_id, stream_id, &pdu_nas), RETURNok);
+
+    uint8_t ics_bytes[] = {
+            0x20, 0x09, 0x00, 0x22, 0x00, 0x00, 0x03, 0x00,
+            0x00, 0x40, 0x02, 0x00, 0x07, 0x00, 0x08, 0x40,
+            0x02, 0x00, 0x01, 0x00, 0x33, 0x40, 0x0f, 0x00,
+            0x00, 0x32, 0x40, 0x0a, 0x0a, 0x1f, 0xc0, 0xa8,
+            0x3c, 0x8d, 0x0a, 0x00, 0x01, 0x28};
+
+    bstring payload_ics;
+    payload_ics = blk2bstr(&ics_bytes, sizeof(ics_bytes));
+    S1ap_S1AP_PDU_t pdu_ics;
+    memset(&pdu_ics, 0, sizeof(pdu_ics));
+
+    ASSERT_EQ(s1ap_mme_decode_pdu(&pdu_ics, payload_ics), RETURNok);
+    ASSERT_EQ( s1ap_mme_handle_initial_context_setup_response(s, assoc_id, stream_id, &pdu_ics), RETURNok);
+
+    // Freeing pdu and payload data
+    bdestroy_wrapper(&payload);
+    bdestroy_wrapper(&payload_nas);
+    bdestroy_wrapper(&payload_ics);
+    ASN_STRUCT_FREE_CONTENTS_ONLY(asn_DEF_S1ap_S1AP_PDU, &pdu);
+    ASN_STRUCT_FREE_CONTENTS_ONLY(asn_DEF_S1ap_S1AP_PDU, &pdu_s1);
+    ASN_STRUCT_FREE_CONTENTS_ONLY(asn_DEF_S1ap_S1AP_PDU, &pdu_nas);
+    ASN_STRUCT_FREE_CONTENTS_ONLY(asn_DEF_S1ap_S1AP_PDU, &pdu_ics);
+
+    // Sleep to ensure that messages are received and contexts are released
+    std::this_thread::sleep_for(std::chrono::milliseconds(2000));
+}
+
+TEST_F(S1apMmeHandlersTest, HandleUECapIndication) {
+    ASSERT_EQ(task_zmq_ctx_main_s1ap.ready, true);
+
+    // Setup new association for testing
+    s1ap_state_t* s          = S1apStateManager::getInstance().get_state(false);
+    sctp_assoc_id_t assoc_id = 1;
+    sctp_stream_id_t stream_id = 0;
+    setup_new_association(s, assoc_id);
+
+    EXPECT_CALL(*mme_app_handler, mme_app_handle_initial_ue_message()).Times(1);
+
+    S1ap_S1AP_PDU_t pdu_s1;
+    memset(&pdu_s1, 0, sizeof(pdu_s1));
+    ASSERT_EQ(RETURNok, generate_s1_setup_request_pdu(&pdu_s1));
+    ASSERT_EQ(RETURNok, s1ap_mme_handle_s1_setup_request(s, assoc_id, stream_id, &pdu_s1));
+
+    uint8_t initial_ue_bytes[] = {
+            0x00, 0x0c, 0x40, 0x48, 0x00, 0x00, 0x05, 0x00,
+            0x08, 0x00, 0x02, 0x00, 0x01, 0x00, 0x1a, 0x00,
+            0x20, 0x1f, 0x07, 0x41, 0x71, 0x08, 0x09, 0x10,
+            0x10, 0x00, 0x00, 0x00, 0x00, 0x10, 0x02, 0xe0,
+            0xe0, 0x00, 0x04, 0x02, 0x01, 0xd0, 0x11, 0x40,
+            0x08, 0x04, 0x02, 0x60, 0x04, 0x00, 0x02, 0x1c,
+            0x00, 0x00, 0x43, 0x00, 0x06, 0x00, 0x00, 0xf1,
+            0x10, 0x00, 0x01, 0x00, 0x64, 0x40, 0x08, 0x00,
+            0x00, 0xf1, 0x10, 0x00, 0x00, 0x00, 0xa0, 0x00,
+            0x86, 0x40, 0x01, 0x30};
+
+    bstring payload;
+    payload = blk2bstr(&initial_ue_bytes, sizeof(initial_ue_bytes));
+    S1ap_S1AP_PDU_t pdu;
+    memset(&pdu, 0, sizeof(pdu));
+
+    ASSERT_EQ(RETURNok, s1ap_mme_decode_pdu(&pdu, payload));
+    ASSERT_EQ(RETURNok, s1ap_mme_handle_initial_ue_message(s, assoc_id, stream_id, &pdu));
+
+    handle_mme_ue_id_notification(s, assoc_id);
+
+    uint8_t ue_cap_bytes[] = {
+            0x00, 0x16, 0x40, 0x53, 0x00, 0x00, 0x03, 0x00,
+            0x00, 0x00, 0x02, 0x00, 0x07, 0x00, 0x08, 0x00,
+            0x02, 0x00, 0x01, 0x00, 0x4a, 0x40, 0x40, 0x3f,
+            0x01, 0xe8, 0x01, 0x03, 0xac, 0x59, 0x80, 0x07,
+            0x00, 0x08, 0x20, 0x81, 0x83, 0x9b, 0x4e, 0x1c,
+            0x3f, 0xf8, 0x7f, 0xf0, 0xff, 0xe1, 0xff, 0xc3,
+            0xff, 0x87, 0xff, 0x0f, 0xfe, 0x1f, 0xfd, 0xf8,
+            0x37, 0x62, 0x78, 0x00, 0xa0, 0x18, 0x5f, 0x80,
+            0x00, 0x00, 0x00, 0x1c, 0x07, 0xe0, 0xdd, 0x89,
+            0xe0, 0x00, 0x00, 0x00, 0x07, 0x09, 0xf8, 0x37,
+            0x62, 0x78, 0x00, 0x00, 0x00, 0x00, 0x00
+    };
+
+    bstring payload_ue_cap;
+    payload_ue_cap = blk2bstr(&ue_cap_bytes, sizeof(ue_cap_bytes));
+    S1ap_S1AP_PDU_t pdu_cap;
+    memset(&pdu_cap, 0, sizeof(pdu_cap));
+
+    ASSERT_EQ(s1ap_mme_decode_pdu(&pdu_cap, payload_ue_cap), RETURNok);
+    ASSERT_EQ( s1ap_mme_handle_ue_cap_indication(s, assoc_id, stream_id, &pdu_cap), RETURNok);
+
+    // Freeing pdu and payload data
+    bdestroy_wrapper(&payload);
+    bdestroy_wrapper(&payload_ue_cap);
+    ASN_STRUCT_FREE_CONTENTS_ONLY(asn_DEF_S1ap_S1AP_PDU, &pdu_cap);
+    ASN_STRUCT_FREE_CONTENTS_ONLY(asn_DEF_S1ap_S1AP_PDU, &pdu);
+    ASN_STRUCT_FREE_CONTENTS_ONLY(asn_DEF_S1ap_S1AP_PDU, &pdu_s1);
+
+    // Sleep to ensure that messages are received and contexts are released
+    std::this_thread::sleep_for(std::chrono::milliseconds(500));
+}
+
+}  // namespace lte
+}  // namespace magma

--- a/lte/gateway/c/core/oai/test/s1ap_task/test_s1ap_mme_handlers.cpp
+++ b/lte/gateway/c/core/oai/test/s1ap_task/test_s1ap_mme_handlers.cpp
@@ -49,7 +49,7 @@ static int handle_message(zloop_t* loop, zsock_t* reader, void* arg) {
 class S1apMmeHandlersTest : public ::testing::Test {
   virtual void SetUp() {
     mme_app_handler = std::make_shared<MockMmeAppHandler>();
-    sctpd_handler = std::make_shared<MockSctpdHandler>();
+    sctp_handler    = std::make_shared<MockSctpHandler>();
 
     itti_init(
         TASK_MAX, THREAD_MAX, MESSAGES_ID_MAX, tasks_info, messages_info, NULL,
@@ -67,9 +67,9 @@ class S1apMmeHandlersTest : public ::testing::Test {
         TASK_MAIN, task_id_list, 4, handle_message, &task_zmq_ctx_main_s1ap);
 
     std::thread task_mme_app(start_mock_mme_app_task, mme_app_handler);
-    std::thread task_sctpd(start_mock_sctp_task, sctpd_handler);
+    std::thread task_sctp(start_mock_sctp_task, sctp_handler);
     task_mme_app.detach();
-    task_sctpd.detach();
+    task_sctp.detach();
 
     s1ap_mme_init(&mme_config);
     std::this_thread::sleep_for(std::chrono::milliseconds(500));
@@ -88,302 +88,297 @@ class S1apMmeHandlersTest : public ::testing::Test {
 
  protected:
   std::shared_ptr<MockMmeAppHandler> mme_app_handler;
-  std::shared_ptr<MockSctpdHandler> sctpd_handler;
+  std::shared_ptr<MockSctpHandler> sctp_handler;
 };
 
 TEST_F(S1apMmeHandlersTest, HandleS1SetupRequestFailureHss) {
-    // Setup new association for testing
-    s1ap_state_t* s          = S1apStateManager::getInstance().get_state(false);
-    sctp_assoc_id_t assoc_id = 1;
-    setup_new_association(s, assoc_id);
+  // Setup new association for testing
+  s1ap_state_t* s          = S1apStateManager::getInstance().get_state(false);
+  sctp_assoc_id_t assoc_id = 1;
+  setup_new_association(s, assoc_id);
 
-    EXPECT_CALL(*sctpd_handler, sctpd_send_dl()).Times(1);
+  EXPECT_CALL(*sctp_handler, sctpd_send_dl()).Times(1);
 
-    hss_associated = false;
+  hss_associated = false;
 
-    S1ap_S1AP_PDU_t pdu_s1;
-    memset(&pdu_s1, 0, sizeof(pdu_s1));
-    status_code_e pdu_rc = generate_s1_setup_request_pdu(&pdu_s1);
-    ASSERT_EQ(pdu_rc, RETURNok);
+  S1ap_S1AP_PDU_t pdu_s1;
+  memset(&pdu_s1, 0, sizeof(pdu_s1));
+  status_code_e pdu_rc = generate_s1_setup_request_pdu(&pdu_s1);
+  ASSERT_EQ(pdu_rc, RETURNok);
 
-    sctp_stream_id_t stream_id = 0;
-    status_code_e rc =
-            s1ap_mme_handle_message(s, assoc_id, stream_id, &pdu_s1);
-    ASSERT_EQ(rc, RETURNok);
+  sctp_stream_id_t stream_id = 0;
+  status_code_e rc = s1ap_mme_handle_message(s, assoc_id, stream_id, &pdu_s1);
+  ASSERT_EQ(rc, RETURNok);
 
-    // State validation
-    ASSERT_EQ(s->num_enbs, 0);
+  // State validation
+  ASSERT_EQ(s->num_enbs, 0);
 
-    // Freeing pdu and payload data
-    ASN_STRUCT_FREE_CONTENTS_ONLY(asn_DEF_S1ap_S1AP_PDU, &pdu_s1);
+  // Freeing pdu and payload data
+  ASN_STRUCT_FREE_CONTENTS_ONLY(asn_DEF_S1ap_S1AP_PDU, &pdu_s1);
 
-    // Sleep to ensure that messages are received and contexts are released
-    std::this_thread::sleep_for(std::chrono::milliseconds(1000));
+  // Sleep to ensure that messages are received and contexts are released
+  std::this_thread::sleep_for(std::chrono::milliseconds(1000));
 }
 
 TEST_F(S1apMmeHandlersTest, HandleS1SetupRequestFailureReseting) {
-    // Setup new association for testing
-    s1ap_state_t* s          = S1apStateManager::getInstance().get_state(false);
-    sctp_assoc_id_t assoc_id = 1;
-    setup_new_association(s, assoc_id);
+  // Setup new association for testing
+  s1ap_state_t* s          = S1apStateManager::getInstance().get_state(false);
+  sctp_assoc_id_t assoc_id = 1;
+  setup_new_association(s, assoc_id);
 
-    EXPECT_CALL(*sctpd_handler, sctpd_send_dl()).Times(1);
+  EXPECT_CALL(*sctp_handler, sctpd_send_dl()).Times(1);
 
-    enb_description_t* enb_associated = NULL;
-    hashtable_ts_get(
-            &s->enbs, (const hash_key_t) assoc_id,
-            reinterpret_cast<void**>(&enb_associated));
-    enb_associated->s1_state = S1AP_RESETING;
+  enb_description_t* enb_associated = NULL;
+  hashtable_ts_get(
+      &s->enbs, (const hash_key_t) assoc_id,
+      reinterpret_cast<void**>(&enb_associated));
+  enb_associated->s1_state = S1AP_RESETING;
 
-    S1ap_S1AP_PDU_t pdu_s1;
-    memset(&pdu_s1, 0, sizeof(pdu_s1));
-    status_code_e pdu_rc = generate_s1_setup_request_pdu(&pdu_s1);
-    ASSERT_EQ(pdu_rc, RETURNok);
+  S1ap_S1AP_PDU_t pdu_s1;
+  memset(&pdu_s1, 0, sizeof(pdu_s1));
+  status_code_e pdu_rc = generate_s1_setup_request_pdu(&pdu_s1);
+  ASSERT_EQ(pdu_rc, RETURNok);
 
-    sctp_stream_id_t stream_id = 0;
-    status_code_e rc =
-            s1ap_mme_handle_message(s, assoc_id, stream_id, &pdu_s1);
-    ASSERT_EQ(rc, RETURNok);
+  sctp_stream_id_t stream_id = 0;
+  status_code_e rc = s1ap_mme_handle_message(s, assoc_id, stream_id, &pdu_s1);
+  ASSERT_EQ(rc, RETURNok);
 
-    // State validation
-    ASSERT_EQ(s->num_enbs, 0);
+  // State validation
+  ASSERT_EQ(s->num_enbs, 0);
 
-    // Freeing pdu and payload data
-    ASN_STRUCT_FREE_CONTENTS_ONLY(asn_DEF_S1ap_S1AP_PDU, &pdu_s1);
+  // Freeing pdu and payload data
+  ASN_STRUCT_FREE_CONTENTS_ONLY(asn_DEF_S1ap_S1AP_PDU, &pdu_s1);
 
-    // Sleep to ensure that messages are received and contexts are released
-    std::this_thread::sleep_for(std::chrono::milliseconds(1500));
+  // Sleep to ensure that messages are received and contexts are released
+  std::this_thread::sleep_for(std::chrono::milliseconds(1500));
 }
 
 TEST_F(S1apMmeHandlersTest, HandleICSResponseICSRelease) {
-    ASSERT_EQ(task_zmq_ctx_main_s1ap.ready, true);
+  ASSERT_EQ(task_zmq_ctx_main_s1ap.ready, true);
 
-    // Setup new association for testing
-    s1ap_state_t* s          = S1apStateManager::getInstance().get_state(false);
-    sctp_assoc_id_t assoc_id = 1;
-    sctp_stream_id_t stream_id = 0;
-    bool is_state_same = false;
-    setup_new_association(s, assoc_id);
+  // Setup new association for testing
+  s1ap_state_t* s            = S1apStateManager::getInstance().get_state(false);
+  sctp_assoc_id_t assoc_id   = 1;
+  sctp_stream_id_t stream_id = 0;
+  bool is_state_same         = false;
+  setup_new_association(s, assoc_id);
 
-    EXPECT_CALL(*mme_app_handler, mme_app_handle_initial_ue_message()).Times(1);
-    EXPECT_CALL(*mme_app_handler, mme_app_handle_s1ap_ue_context_release_req()).Times(1);
+  EXPECT_CALL(*sctp_handler, sctpd_send_dl()).Times(2);
+  EXPECT_CALL(*mme_app_handler, mme_app_handle_initial_ue_message()).Times(1);
+  EXPECT_CALL(*mme_app_handler, mme_app_handle_s1ap_ue_context_release_req())
+      .Times(1);
 
-    S1ap_S1AP_PDU_t pdu_s1;
-    memset(&pdu_s1, 0, sizeof(pdu_s1));
-    ASSERT_EQ(RETURNok, generate_s1_setup_request_pdu(&pdu_s1));
-    ASSERT_EQ(RETURNok, s1ap_mme_handle_message(s, assoc_id, stream_id, &pdu_s1));
+  S1ap_S1AP_PDU_t pdu_s1;
+  memset(&pdu_s1, 0, sizeof(pdu_s1));
+  ASSERT_EQ(RETURNok, generate_s1_setup_request_pdu(&pdu_s1));
+  ASSERT_EQ(RETURNok, s1ap_mme_handle_message(s, assoc_id, stream_id, &pdu_s1));
 
-    uint8_t initial_ue_bytes[] = {
-            0x00, 0x0c, 0x40, 0x48, 0x00, 0x00, 0x05, 0x00,
-            0x08, 0x00, 0x02, 0x00, 0x01, 0x00, 0x1a, 0x00,
-            0x20, 0x1f, 0x07, 0x41, 0x71, 0x08, 0x09, 0x10,
-            0x10, 0x00, 0x00, 0x00, 0x00, 0x10, 0x02, 0xe0,
-            0xe0, 0x00, 0x04, 0x02, 0x01, 0xd0, 0x11, 0x40,
-            0x08, 0x04, 0x02, 0x60, 0x04, 0x00, 0x02, 0x1c,
-            0x00, 0x00, 0x43, 0x00, 0x06, 0x00, 0x00, 0xf1,
-            0x10, 0x00, 0x01, 0x00, 0x64, 0x40, 0x08, 0x00,
-            0x00, 0xf1, 0x10, 0x00, 0x00, 0x00, 0xa0, 0x00,
-            0x86, 0x40, 0x01, 0x30};
+  uint8_t initial_ue_bytes[] = {
+      0x00, 0x0c, 0x40, 0x48, 0x00, 0x00, 0x05, 0x00, 0x08, 0x00, 0x02,
+      0x00, 0x01, 0x00, 0x1a, 0x00, 0x20, 0x1f, 0x07, 0x41, 0x71, 0x08,
+      0x09, 0x10, 0x10, 0x00, 0x00, 0x00, 0x00, 0x10, 0x02, 0xe0, 0xe0,
+      0x00, 0x04, 0x02, 0x01, 0xd0, 0x11, 0x40, 0x08, 0x04, 0x02, 0x60,
+      0x04, 0x00, 0x02, 0x1c, 0x00, 0x00, 0x43, 0x00, 0x06, 0x00, 0x00,
+      0xf1, 0x10, 0x00, 0x01, 0x00, 0x64, 0x40, 0x08, 0x00, 0x00, 0xf1,
+      0x10, 0x00, 0x00, 0x00, 0xa0, 0x00, 0x86, 0x40, 0x01, 0x30};
 
-    bstring payload;
-    payload = blk2bstr(&initial_ue_bytes, sizeof(initial_ue_bytes));
-    S1ap_S1AP_PDU_t pdu;
-    memset(&pdu, 0, sizeof(pdu));
+  bstring payload;
+  payload = blk2bstr(&initial_ue_bytes, sizeof(initial_ue_bytes));
+  S1ap_S1AP_PDU_t pdu;
+  memset(&pdu, 0, sizeof(pdu));
 
-    ASSERT_EQ(RETURNok, s1ap_mme_decode_pdu(&pdu, payload));
-    ASSERT_EQ(RETURNok, s1ap_mme_handle_message(s, assoc_id, stream_id, &pdu));
+  ASSERT_EQ(RETURNok, s1ap_mme_decode_pdu(&pdu, payload));
+  ASSERT_EQ(RETURNok, s1ap_mme_handle_message(s, assoc_id, stream_id, &pdu));
 
-    handle_mme_ue_id_notification(s, assoc_id);
+  handle_mme_ue_id_notification(s, assoc_id);
 
-    // Generate downlink nas transport with dummy payload
-    bstring p;
-    std::string test_str = "test";
-    STRING_TO_BSTRING(test_str, p);
-    s1ap_generate_downlink_nas_transport(s, 1, 7, &p, 1, &is_state_same);
-    bdestroy_wrapper(&p);
+  // Generate downlink nas transport with dummy payload
+  bstring p;
+  std::string test_str = "test";
+  STRING_TO_BSTRING(test_str, p);
+  s1ap_generate_downlink_nas_transport(s, 1, 7, &p, 1, &is_state_same);
+  bdestroy_wrapper(&p);
 
-    // Authentication response proc packet bytes
-    uint8_t auth_bytes[] = {
-            0x00, 0x0d, 0x40, 0x3d, 0x00, 0x00, 0x05, 0x00,
-            0x00, 0x00, 0x02, 0x00, 0x07, 0x00, 0x08, 0x00,
-            0x02, 0x00, 0x01, 0x00, 0x1a, 0x00, 0x14, 0x13,
-            0x07, 0x53, 0x10, 0x1e, 0x63, 0x7e, 0x5c, 0x58,
-            0xec, 0x5a, 0xa8, 0x00, 0x00, 0x00, 0x00, 0x00,
-            0x00, 0x00, 0x00, 0x00, 0x64, 0x40, 0x08, 0x00,
-            0x00, 0xf1, 0x10, 0x00, 0x00, 0x00, 0xa0, 0x00,
-            0x43, 0x40, 0x06, 0x00, 0x00, 0xf1, 0x10, 0x00,
-            0x01};
+  // Authentication response proc packet bytes
+  uint8_t auth_bytes[] = {
+      0x00, 0x0d, 0x40, 0x3d, 0x00, 0x00, 0x05, 0x00, 0x00, 0x00, 0x02,
+      0x00, 0x07, 0x00, 0x08, 0x00, 0x02, 0x00, 0x01, 0x00, 0x1a, 0x00,
+      0x14, 0x13, 0x07, 0x53, 0x10, 0x1e, 0x63, 0x7e, 0x5c, 0x58, 0xec,
+      0x5a, 0xa8, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+      0x64, 0x40, 0x08, 0x00, 0x00, 0xf1, 0x10, 0x00, 0x00, 0x00, 0xa0,
+      0x00, 0x43, 0x40, 0x06, 0x00, 0x00, 0xf1, 0x10, 0x00, 0x01};
 
-    bstring payload_nas;
-    payload_nas = blk2bstr(&auth_bytes, sizeof(auth_bytes));
-    S1ap_S1AP_PDU_t pdu_nas;
-    memset(&pdu_nas, 0, sizeof(pdu_nas));
+  bstring payload_nas;
+  payload_nas = blk2bstr(&auth_bytes, sizeof(auth_bytes));
+  S1ap_S1AP_PDU_t pdu_nas;
+  memset(&pdu_nas, 0, sizeof(pdu_nas));
 
-    ASSERT_EQ(s1ap_mme_decode_pdu(&pdu_nas, payload_nas), RETURNok);
-    ASSERT_EQ( s1ap_mme_handle_message(s, assoc_id, stream_id, &pdu_nas), RETURNok);
+  ASSERT_EQ(s1ap_mme_decode_pdu(&pdu_nas, payload_nas), RETURNok);
+  ASSERT_EQ(
+      s1ap_mme_handle_message(s, assoc_id, stream_id, &pdu_nas), RETURNok);
 
-    uint8_t ics_bytes[] = {
-            0x20, 0x09, 0x00, 0x22, 0x00, 0x00, 0x03, 0x00,
-            0x00, 0x40, 0x02, 0x00, 0x07, 0x00, 0x08, 0x40,
-            0x02, 0x00, 0x01, 0x00, 0x33, 0x40, 0x0f, 0x00,
-            0x00, 0x32, 0x40, 0x0a, 0x0a, 0x1f, 0xc0, 0xa8,
-            0x3c, 0x8d, 0x0a, 0x00, 0x01, 0x28};
+  uint8_t ics_bytes[] = {0x20, 0x09, 0x00, 0x22, 0x00, 0x00, 0x03, 0x00,
+                         0x00, 0x40, 0x02, 0x00, 0x07, 0x00, 0x08, 0x40,
+                         0x02, 0x00, 0x01, 0x00, 0x33, 0x40, 0x0f, 0x00,
+                         0x00, 0x32, 0x40, 0x0a, 0x0a, 0x1f, 0xc0, 0xa8,
+                         0x3c, 0x8d, 0x0a, 0x00, 0x01, 0x28};
 
-    bstring payload_ics;
-    payload_ics = blk2bstr(&ics_bytes, sizeof(ics_bytes));
-    S1ap_S1AP_PDU_t pdu_ics;
-    memset(&pdu_ics, 0, sizeof(pdu_ics));
+  bstring payload_ics;
+  payload_ics = blk2bstr(&ics_bytes, sizeof(ics_bytes));
+  S1ap_S1AP_PDU_t pdu_ics;
+  memset(&pdu_ics, 0, sizeof(pdu_ics));
 
-    ASSERT_EQ(s1ap_mme_decode_pdu(&pdu_ics, payload_ics), RETURNok);
-    ASSERT_EQ( s1ap_mme_handle_message(s, assoc_id, stream_id, &pdu_ics), RETURNok);
+  ASSERT_EQ(s1ap_mme_decode_pdu(&pdu_ics, payload_ics), RETURNok);
+  ASSERT_EQ(
+      s1ap_mme_handle_message(s, assoc_id, stream_id, &pdu_ics), RETURNok);
 
-    // Freeing pdu and payload data
-    bdestroy_wrapper(&payload);
-    bdestroy_wrapper(&payload_nas);
-    bdestroy_wrapper(&payload_ics);
-    ASN_STRUCT_FREE_CONTENTS_ONLY(asn_DEF_S1ap_S1AP_PDU, &pdu);
-    ASN_STRUCT_FREE_CONTENTS_ONLY(asn_DEF_S1ap_S1AP_PDU, &pdu_s1);
-    ASN_STRUCT_FREE_CONTENTS_ONLY(asn_DEF_S1ap_S1AP_PDU, &pdu_nas);
-    ASN_STRUCT_FREE_CONTENTS_ONLY(asn_DEF_S1ap_S1AP_PDU, &pdu_ics);
+  // Freeing pdu and payload data
+  bdestroy_wrapper(&payload);
+  bdestroy_wrapper(&payload_nas);
+  bdestroy_wrapper(&payload_ics);
+  ASN_STRUCT_FREE_CONTENTS_ONLY(asn_DEF_S1ap_S1AP_PDU, &pdu);
+  ASN_STRUCT_FREE_CONTENTS_ONLY(asn_DEF_S1ap_S1AP_PDU, &pdu_s1);
+  ASN_STRUCT_FREE_CONTENTS_ONLY(asn_DEF_S1ap_S1AP_PDU, &pdu_nas);
+  ASN_STRUCT_FREE_CONTENTS_ONLY(asn_DEF_S1ap_S1AP_PDU, &pdu_ics);
 
-    uint8_t ics_release_bytes[] = {
-            0x00, 0x12, 0x40, 0x15, 0x00, 0x00, 0x03, 0x00,
-            0x00, 0x00, 0x02, 0x00, 0x07, 0x00, 0x08, 0x00,
-            0x02, 0x00, 0x01, 0x00, 0x02, 0x40, 0x02, 0x02,
-            0x80
-    };
+  uint8_t ics_release_bytes[] = {0x00, 0x12, 0x40, 0x15, 0x00, 0x00, 0x03,
+                                 0x00, 0x00, 0x00, 0x02, 0x00, 0x07, 0x00,
+                                 0x08, 0x00, 0x02, 0x00, 0x01, 0x00, 0x02,
+                                 0x40, 0x02, 0x02, 0x80};
 
-    bstring payload_ics_r;
-    payload_ics_r = blk2bstr(&ics_release_bytes, sizeof(ics_release_bytes));
-    S1ap_S1AP_PDU_t pdu_ics_r;
-    memset(&pdu_ics_r, 0, sizeof(pdu_ics_r));
+  bstring payload_ics_r;
+  payload_ics_r = blk2bstr(&ics_release_bytes, sizeof(ics_release_bytes));
+  S1ap_S1AP_PDU_t pdu_ics_r;
+  memset(&pdu_ics_r, 0, sizeof(pdu_ics_r));
 
-    ASSERT_EQ(s1ap_mme_decode_pdu(&pdu_ics_r, payload_ics_r), RETURNok);
-    ASSERT_EQ( s1ap_mme_handle_message(s, assoc_id, stream_id, &pdu_ics_r), RETURNok);
+  ASSERT_EQ(s1ap_mme_decode_pdu(&pdu_ics_r, payload_ics_r), RETURNok);
+  ASSERT_EQ(
+      s1ap_mme_handle_message(s, assoc_id, stream_id, &pdu_ics_r), RETURNok);
 
-    bdestroy_wrapper(&payload_ics_r);
-    ASN_STRUCT_FREE_CONTENTS_ONLY(asn_DEF_S1ap_S1AP_PDU, &pdu_ics_r);
+  bdestroy_wrapper(&payload_ics_r);
+  ASN_STRUCT_FREE_CONTENTS_ONLY(asn_DEF_S1ap_S1AP_PDU, &pdu_ics_r);
 
-    // Sleep to ensure that messages are received and contexts are released
-    std::this_thread::sleep_for(std::chrono::milliseconds(2000));
+  // Sleep to ensure that messages are received and contexts are released
+  std::this_thread::sleep_for(std::chrono::milliseconds(1000));
 }
 
 TEST_F(S1apMmeHandlersTest, HandleUECapIndication) {
-    ASSERT_EQ(task_zmq_ctx_main_s1ap.ready, true);
+  ASSERT_EQ(task_zmq_ctx_main_s1ap.ready, true);
 
-    // Setup new association for testing
-    s1ap_state_t* s          = S1apStateManager::getInstance().get_state(false);
-    sctp_assoc_id_t assoc_id = 1;
-    sctp_stream_id_t stream_id = 0;
-    setup_new_association(s, assoc_id);
+  // Setup new association for testing
+  s1ap_state_t* s            = S1apStateManager::getInstance().get_state(false);
+  sctp_assoc_id_t assoc_id   = 1;
+  sctp_stream_id_t stream_id = 0;
+  setup_new_association(s, assoc_id);
 
-    EXPECT_CALL(*mme_app_handler, mme_app_handle_initial_ue_message()).Times(1);
+  EXPECT_CALL(*sctp_handler, sctpd_send_dl()).Times(1);
+  EXPECT_CALL(*mme_app_handler, mme_app_handle_initial_ue_message()).Times(1);
 
-    S1ap_S1AP_PDU_t pdu_s1;
-    memset(&pdu_s1, 0, sizeof(pdu_s1));
-    ASSERT_EQ(RETURNok, generate_s1_setup_request_pdu(&pdu_s1));
-    ASSERT_EQ(RETURNok, s1ap_mme_handle_message(s, assoc_id, stream_id, &pdu_s1));
+  S1ap_S1AP_PDU_t pdu_s1;
+  memset(&pdu_s1, 0, sizeof(pdu_s1));
+  ASSERT_EQ(RETURNok, generate_s1_setup_request_pdu(&pdu_s1));
+  ASSERT_EQ(RETURNok, s1ap_mme_handle_message(s, assoc_id, stream_id, &pdu_s1));
 
-    uint8_t initial_ue_bytes[] = {
-            0x00, 0x0c, 0x40, 0x48, 0x00, 0x00, 0x05, 0x00,
-            0x08, 0x00, 0x02, 0x00, 0x01, 0x00, 0x1a, 0x00,
-            0x20, 0x1f, 0x07, 0x41, 0x71, 0x08, 0x09, 0x10,
-            0x10, 0x00, 0x00, 0x00, 0x00, 0x10, 0x02, 0xe0,
-            0xe0, 0x00, 0x04, 0x02, 0x01, 0xd0, 0x11, 0x40,
-            0x08, 0x04, 0x02, 0x60, 0x04, 0x00, 0x02, 0x1c,
-            0x00, 0x00, 0x43, 0x00, 0x06, 0x00, 0x00, 0xf1,
-            0x10, 0x00, 0x01, 0x00, 0x64, 0x40, 0x08, 0x00,
-            0x00, 0xf1, 0x10, 0x00, 0x00, 0x00, 0xa0, 0x00,
-            0x86, 0x40, 0x01, 0x30};
+  uint8_t initial_ue_bytes[] = {
+      0x00, 0x0c, 0x40, 0x48, 0x00, 0x00, 0x05, 0x00, 0x08, 0x00, 0x02,
+      0x00, 0x01, 0x00, 0x1a, 0x00, 0x20, 0x1f, 0x07, 0x41, 0x71, 0x08,
+      0x09, 0x10, 0x10, 0x00, 0x00, 0x00, 0x00, 0x10, 0x02, 0xe0, 0xe0,
+      0x00, 0x04, 0x02, 0x01, 0xd0, 0x11, 0x40, 0x08, 0x04, 0x02, 0x60,
+      0x04, 0x00, 0x02, 0x1c, 0x00, 0x00, 0x43, 0x00, 0x06, 0x00, 0x00,
+      0xf1, 0x10, 0x00, 0x01, 0x00, 0x64, 0x40, 0x08, 0x00, 0x00, 0xf1,
+      0x10, 0x00, 0x00, 0x00, 0xa0, 0x00, 0x86, 0x40, 0x01, 0x30};
 
-    bstring payload;
-    payload = blk2bstr(&initial_ue_bytes, sizeof(initial_ue_bytes));
-    S1ap_S1AP_PDU_t pdu;
-    memset(&pdu, 0, sizeof(pdu));
+  bstring payload;
+  payload = blk2bstr(&initial_ue_bytes, sizeof(initial_ue_bytes));
+  S1ap_S1AP_PDU_t pdu;
+  memset(&pdu, 0, sizeof(pdu));
 
-    ASSERT_EQ(RETURNok, s1ap_mme_decode_pdu(&pdu, payload));
-    ASSERT_EQ(RETURNok, s1ap_mme_handle_message(s, assoc_id, stream_id, &pdu));
+  ASSERT_EQ(RETURNok, s1ap_mme_decode_pdu(&pdu, payload));
+  ASSERT_EQ(RETURNok, s1ap_mme_handle_message(s, assoc_id, stream_id, &pdu));
 
-    handle_mme_ue_id_notification(s, assoc_id);
+  handle_mme_ue_id_notification(s, assoc_id);
 
-    uint8_t ue_cap_bytes[] = {
-            0x00, 0x16, 0x40, 0x53, 0x00, 0x00, 0x03, 0x00,
-            0x00, 0x00, 0x02, 0x00, 0x07, 0x00, 0x08, 0x00,
-            0x02, 0x00, 0x01, 0x00, 0x4a, 0x40, 0x40, 0x3f,
-            0x01, 0xe8, 0x01, 0x03, 0xac, 0x59, 0x80, 0x07,
-            0x00, 0x08, 0x20, 0x81, 0x83, 0x9b, 0x4e, 0x1c,
-            0x3f, 0xf8, 0x7f, 0xf0, 0xff, 0xe1, 0xff, 0xc3,
-            0xff, 0x87, 0xff, 0x0f, 0xfe, 0x1f, 0xfd, 0xf8,
-            0x37, 0x62, 0x78, 0x00, 0xa0, 0x18, 0x5f, 0x80,
-            0x00, 0x00, 0x00, 0x1c, 0x07, 0xe0, 0xdd, 0x89,
-            0xe0, 0x00, 0x00, 0x00, 0x07, 0x09, 0xf8, 0x37,
-            0x62, 0x78, 0x00, 0x00, 0x00, 0x00, 0x00
-    };
+  uint8_t ue_cap_bytes[] = {
+      0x00, 0x16, 0x40, 0x53, 0x00, 0x00, 0x03, 0x00, 0x00, 0x00, 0x02,
+      0x00, 0x07, 0x00, 0x08, 0x00, 0x02, 0x00, 0x01, 0x00, 0x4a, 0x40,
+      0x40, 0x3f, 0x01, 0xe8, 0x01, 0x03, 0xac, 0x59, 0x80, 0x07, 0x00,
+      0x08, 0x20, 0x81, 0x83, 0x9b, 0x4e, 0x1c, 0x3f, 0xf8, 0x7f, 0xf0,
+      0xff, 0xe1, 0xff, 0xc3, 0xff, 0x87, 0xff, 0x0f, 0xfe, 0x1f, 0xfd,
+      0xf8, 0x37, 0x62, 0x78, 0x00, 0xa0, 0x18, 0x5f, 0x80, 0x00, 0x00,
+      0x00, 0x1c, 0x07, 0xe0, 0xdd, 0x89, 0xe0, 0x00, 0x00, 0x00, 0x07,
+      0x09, 0xf8, 0x37, 0x62, 0x78, 0x00, 0x00, 0x00, 0x00, 0x00};
 
-    bstring payload_ue_cap;
-    payload_ue_cap = blk2bstr(&ue_cap_bytes, sizeof(ue_cap_bytes));
-    S1ap_S1AP_PDU_t pdu_cap;
-    memset(&pdu_cap, 0, sizeof(pdu_cap));
+  bstring payload_ue_cap;
+  payload_ue_cap = blk2bstr(&ue_cap_bytes, sizeof(ue_cap_bytes));
+  S1ap_S1AP_PDU_t pdu_cap;
+  memset(&pdu_cap, 0, sizeof(pdu_cap));
 
-    ASSERT_EQ(s1ap_mme_decode_pdu(&pdu_cap, payload_ue_cap), RETURNok);
-    ASSERT_EQ( s1ap_mme_handle_message(s, assoc_id, stream_id, &pdu_cap), RETURNok);
+  ASSERT_EQ(s1ap_mme_decode_pdu(&pdu_cap, payload_ue_cap), RETURNok);
+  ASSERT_EQ(
+      s1ap_mme_handle_message(s, assoc_id, stream_id, &pdu_cap), RETURNok);
 
-    // Freeing pdu and payload data
-    bdestroy_wrapper(&payload);
-    bdestroy_wrapper(&payload_ue_cap);
-    ASN_STRUCT_FREE_CONTENTS_ONLY(asn_DEF_S1ap_S1AP_PDU, &pdu_cap);
-    ASN_STRUCT_FREE_CONTENTS_ONLY(asn_DEF_S1ap_S1AP_PDU, &pdu);
-    ASN_STRUCT_FREE_CONTENTS_ONLY(asn_DEF_S1ap_S1AP_PDU, &pdu_s1);
+  // Freeing pdu and payload data
+  bdestroy_wrapper(&payload);
+  bdestroy_wrapper(&payload_ue_cap);
+  ASN_STRUCT_FREE_CONTENTS_ONLY(asn_DEF_S1ap_S1AP_PDU, &pdu_cap);
+  ASN_STRUCT_FREE_CONTENTS_ONLY(asn_DEF_S1ap_S1AP_PDU, &pdu);
+  ASN_STRUCT_FREE_CONTENTS_ONLY(asn_DEF_S1ap_S1AP_PDU, &pdu_s1);
 
-    // Sleep to ensure that messages are received and contexts are released
-    std::this_thread::sleep_for(std::chrono::milliseconds(500));
+  // Sleep to ensure that messages are received and contexts are released
+  std::this_thread::sleep_for(std::chrono::milliseconds(500));
 }
 
 TEST_F(S1apMmeHandlersTest, GenerateUEContextReleaseCommand) {
-    // Setup new association for testing
-    s1ap_state_t* s          = S1apStateManager::getInstance().get_state(false);
-    sctp_assoc_id_t assoc_id = 1;
-    sctp_stream_id_t stream_id = 0;
-    setup_new_association(s, assoc_id);
-    ue_description_t ue_ref_p = {.enb_ue_s1ap_id = 1, .mme_ue_s1ap_id = 1, .sctp_assoc_id = assoc_id, .comp_s1ap_id = S1AP_GENERATE_COMP_S1AP_ID(assoc_id, 1)};
+  // Setup new association for testing
+  s1ap_state_t* s            = S1apStateManager::getInstance().get_state(false);
+  sctp_assoc_id_t assoc_id   = 1;
+  sctp_stream_id_t stream_id = 0;
+  setup_new_association(s, assoc_id);
+  ue_description_t ue_ref_p = {
+      .enb_ue_s1ap_id = 1,
+      .mme_ue_s1ap_id = 1,
+      .sctp_assoc_id  = assoc_id,
+      .comp_s1ap_id   = S1AP_GENERATE_COMP_S1AP_ID(assoc_id, 1)};
 
-    EXPECT_CALL(*sctpd_handler, sctpd_send_dl()).Times(2);
-    EXPECT_CALL(*mme_app_handler, mme_app_handle_initial_ue_message()).Times(1);
+  EXPECT_CALL(*mme_app_handler, mme_app_handle_initial_ue_message()).Times(1);
 
-    S1ap_S1AP_PDU_t pdu_s1;
-    memset(&pdu_s1, 0, sizeof(pdu_s1));
-    ASSERT_EQ(RETURNok, generate_s1_setup_request_pdu(&pdu_s1));
-    ASSERT_EQ(RETURNok, s1ap_mme_handle_message(s, assoc_id, stream_id, &pdu_s1));
+  S1ap_S1AP_PDU_t pdu_s1;
+  memset(&pdu_s1, 0, sizeof(pdu_s1));
+  ASSERT_EQ(RETURNok, generate_s1_setup_request_pdu(&pdu_s1));
+  ASSERT_EQ(RETURNok, s1ap_mme_handle_message(s, assoc_id, stream_id, &pdu_s1));
 
-    uint8_t initial_ue_bytes[] = {
-            0x00, 0x0c, 0x40, 0x48, 0x00, 0x00, 0x05, 0x00,
-            0x08, 0x00, 0x02, 0x00, 0x01, 0x00, 0x1a, 0x00,
-            0x20, 0x1f, 0x07, 0x41, 0x71, 0x08, 0x09, 0x10,
-            0x10, 0x00, 0x00, 0x00, 0x00, 0x10, 0x02, 0xe0,
-            0xe0, 0x00, 0x04, 0x02, 0x01, 0xd0, 0x11, 0x40,
-            0x08, 0x04, 0x02, 0x60, 0x04, 0x00, 0x02, 0x1c,
-            0x00, 0x00, 0x43, 0x00, 0x06, 0x00, 0x00, 0xf1,
-            0x10, 0x00, 0x01, 0x00, 0x64, 0x40, 0x08, 0x00,
-            0x00, 0xf1, 0x10, 0x00, 0x00, 0x00, 0xa0, 0x00,
-            0x86, 0x40, 0x01, 0x30};
+  uint8_t initial_ue_bytes[] = {
+      0x00, 0x0c, 0x40, 0x48, 0x00, 0x00, 0x05, 0x00, 0x08, 0x00, 0x02,
+      0x00, 0x01, 0x00, 0x1a, 0x00, 0x20, 0x1f, 0x07, 0x41, 0x71, 0x08,
+      0x09, 0x10, 0x10, 0x00, 0x00, 0x00, 0x00, 0x10, 0x02, 0xe0, 0xe0,
+      0x00, 0x04, 0x02, 0x01, 0xd0, 0x11, 0x40, 0x08, 0x04, 0x02, 0x60,
+      0x04, 0x00, 0x02, 0x1c, 0x00, 0x00, 0x43, 0x00, 0x06, 0x00, 0x00,
+      0xf1, 0x10, 0x00, 0x01, 0x00, 0x64, 0x40, 0x08, 0x00, 0x00, 0xf1,
+      0x10, 0x00, 0x00, 0x00, 0xa0, 0x00, 0x86, 0x40, 0x01, 0x30};
 
-    bstring payload;
-    payload = blk2bstr(&initial_ue_bytes, sizeof(initial_ue_bytes));
-    S1ap_S1AP_PDU_t pdu;
-    memset(&pdu, 0, sizeof(pdu));
+  bstring payload;
+  payload = blk2bstr(&initial_ue_bytes, sizeof(initial_ue_bytes));
+  S1ap_S1AP_PDU_t pdu;
+  memset(&pdu, 0, sizeof(pdu));
 
-    ASSERT_EQ(RETURNok, s1ap_mme_decode_pdu(&pdu, payload));
-    ASSERT_EQ(RETURNok, s1ap_mme_handle_message(s, assoc_id, stream_id, &pdu));
+  ASSERT_EQ(RETURNok, s1ap_mme_decode_pdu(&pdu, payload));
+  ASSERT_EQ(RETURNok, s1ap_mme_handle_message(s, assoc_id, stream_id, &pdu));
 
-    // Invalid S1 Cause returns error
-    ASSERT_EQ(RETURNerror, s1ap_mme_generate_ue_context_release_command(s, &ue_ref_p, S1AP_IMPLICIT_CONTEXT_RELEASE, INVALID_IMSI64, assoc_id, stream_id, 1, 1));
-    // Valid S1 Causes passess successfully
-    ASSERT_EQ(RETURNok, s1ap_mme_generate_ue_context_release_command(s, &ue_ref_p, S1AP_INITIAL_CONTEXT_SETUP_FAILED, INVALID_IMSI64, assoc_id, stream_id, 1, 1));
+  // Invalid S1 Cause returns error
+  ASSERT_EQ(
+      RETURNerror, s1ap_mme_generate_ue_context_release_command(
+                       s, &ue_ref_p, S1AP_IMPLICIT_CONTEXT_RELEASE,
+                       INVALID_IMSI64, assoc_id, stream_id, 1, 1));
+  // Valid S1 Causes passess successfully
+  ASSERT_EQ(
+      RETURNok, s1ap_mme_generate_ue_context_release_command(
+                    s, &ue_ref_p, S1AP_INITIAL_CONTEXT_SETUP_FAILED,
+                    INVALID_IMSI64, assoc_id, stream_id, 1, 1));
 
-    // Freeing pdu and payload data
-    bdestroy_wrapper(&payload);
-    ASN_STRUCT_FREE_CONTENTS_ONLY(asn_DEF_S1ap_S1AP_PDU, &pdu);
-    ASN_STRUCT_FREE_CONTENTS_ONLY(asn_DEF_S1ap_S1AP_PDU, &pdu_s1);
+  // Freeing pdu and payload data
+  bdestroy_wrapper(&payload);
+  ASN_STRUCT_FREE_CONTENTS_ONLY(asn_DEF_S1ap_S1AP_PDU, &pdu);
+  ASN_STRUCT_FREE_CONTENTS_ONLY(asn_DEF_S1ap_S1AP_PDU, &pdu_s1);
 }
 
 }  // namespace lte


### PR DESCRIPTION
Signed-off-by: Alex Rodriguez <ardzoht@gmail.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->
- Adds first set of unit tests for S1AP tasks, using test mock ITTI framework introduced on #8487 
    - s1ap_handle_initial_ue_message
    - s1ap_handle_s1_setup_request
    - s1ap_handle_initial_context_setup_response
    - s1ap_handle_ue_context_release_request
    - s1ap_handle_ue_cap_indication
    - added unit tests for s1ap enb stale association
- Adds MME app mock class handler
- Refactoring some S1AP related code 
- Removing unused code and imports

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->
- make test_oai

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
