### PR TITLE
ci: adds golang support to our devcontainer (e.g. codespaces)

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -307,6 +307,9 @@ RUN git clone https://github.com/OPENAIRINTERFACE/opencord.org.freeDiameter.git 
     cd / && \
     rm -rf freediameter
 
+##### Go language server support for vscode
+RUN go get -v golang.org/x/tools/gopls
+
 #### Update shared library configuration
 RUN ldconfig -v
 

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,6 +2,7 @@
 	"extensions": [
 		"CoenraadS.bracket-pair-colorizer-2",
 		"xaver.clang-format",
+		"golang.go",
 		"notskm.clang-tidy",
 		"eamodio.gitlens",
 		"yzhang.markdown-all-in-one",


### PR DESCRIPTION
## Test Strategy

Manually applied edits to my `Github Codespace` and confirmed that after reload, the `/src/go/log/*.go` files had correct mouse-over annotations for functions, and right click offered a suite of golang tooling.

Signed-off-by: Scott Moeller <electronjoe@gmail.com>
