### PR TITLE
ci: points agw-workflow to existing devcontainer image

### DIFF
--- a/.github/workflows/agw-workflow.yml
+++ b/.github/workflows/agw-workflow.yml
@@ -11,6 +11,9 @@ on:  # yamllint disable-line rule:truthy
       - 'v1.*'
     types: [opened, reopened, synchronize]
 
+env:
+  DEVCONTAINER_IMAGE: "ghcr.io/magma/devcontainer:sha-375f28a"
+
 jobs:
   path_filter:
     runs-on: ubuntu-latest
@@ -123,6 +126,7 @@ jobs:
         run: |
             docker run --volume ${{ env.MAGMA_ROOT }}:/magma --volume ${{ env.MAGMA_ROOT }}/lte/gateway/configs:/etc/magma --interactive magma/c_cpp_build:latest /bin/bash -c "cd /magma/lte/gateway;make test_common;"
       - name: Run session_manager tests
+        timeout-minutes: 10
         run: |
             docker run --volume ${{ env.MAGMA_ROOT }}:/magma --volume ${{ env.MAGMA_ROOT }}/lte/gateway/configs:/etc/magma --interactive magma/c_cpp_build:latest /bin/bash -c "cd /magma/lte/gateway;make test_session_manager;"
       - name: Extract commit title
@@ -153,19 +157,25 @@ jobs:
       MAGMA_ROOT: "${{ github.workspace }}"
     steps:
       - uses: actions/checkout@v2
-      - uses: satackey/action-docker-layer-caching@v0.0.11
-        continue-on-error: true
-      - name: Build the base c/c++ container
-        run: |
-            docker build --tag magma/c_cpp_build --file ${{ env.MAGMA_ROOT }}/lte/gateway/docker/mme/Dockerfile.ubuntu20.04 .
       - name: Run common tests
-        # yamllint disable rule:line-length
-        run: |
-            docker run --volume ${{ env.MAGMA_ROOT }}:/magma --volume ${{ env.MAGMA_ROOT }}/lte/gateway/configs:/etc/magma --interactive magma/c_cpp_build:latest /bin/bash -c "cd /magma/lte/gateway;make test_common;"
+        uses: addnab/docker-run-action@v2
+        with:
+          image: ${{ env.DEVCONTAINER_IMAGE }}
+          # TODO: Remove work-around mount of Github workspace to /magma (https://github.com/addnab/docker-run-action/issues/11)
+          options: --volume ${{ env.MAGMA_ROOT }}:/workspaces/magma --volume ${{ env.MAGMA_ROOT }}/lte/gateway/configs:/etc/magma -e ABC=123
+          run: |
+            cd /workspaces/magma/lte/gateway
+            make test_common
       - name: Run li agent tests
         timeout-minutes: 5
-        run: |
-            docker run --volume ${{ env.MAGMA_ROOT }}:/magma --volume ${{ env.MAGMA_ROOT }}/lte/gateway/configs:/etc/magma --interactive magma/c_cpp_build:latest /bin/bash -c "cd /magma/lte/gateway;make test_li_agent;"
+        uses: addnab/docker-run-action@v2
+        with:
+          image: ${{ env.DEVCONTAINER_IMAGE }}
+          # TODO: Remove work-around mount of Github workspace to /magma (https://github.com/addnab/docker-run-action/issues/11)
+          options: --volume ${{ env.MAGMA_ROOT }}:/workspaces/magma --volume ${{ env.MAGMA_ROOT }}/lte/gateway/configs:/etc/magma -e ABC=123
+          run: |
+            cd /workspaces/magma/lte/gateway
+            make test_li_agent
       - name: Extract commit title
         # yamllint enable
         if: failure() && github.ref == 'refs/heads/master'
@@ -194,22 +204,26 @@ jobs:
       MAGMA_ROOT: "${{ github.workspace }}"
     steps:
       - uses: actions/checkout@v2
-      - uses: satackey/action-docker-layer-caching@v0.0.11
-        continue-on-error: true
-      - name: Build the base c/c++ container
-        run: |
-            docker build --tag magma/c_cpp_build --file ${{ env.MAGMA_ROOT }}/lte/gateway/docker/mme/Dockerfile.ubuntu20.04 .
       - name: Build connection tracker with BUILD_TYPE=Debug
         timeout-minutes: 5
-        # yamllint disable rule:line-length
-        run: |
-            # TODO run unit tests once we write some tests
-            docker run --volume ${{ env.MAGMA_ROOT }}:/magma --volume ${{ env.MAGMA_ROOT }}/lte/gateway/configs:/etc/magma --interactive magma/c_cpp_build:latest /bin/bash -c "cd /magma/lte/gateway;make build_connection_tracker BUILD_TYPE=Debug;"
+        uses: addnab/docker-run-action@v2
+        with:
+          image: ${{ env.DEVCONTAINER_IMAGE }}
+          # TODO: Remove work-around mount of Github workspace to /magma (https://github.com/addnab/docker-run-action/issues/11)
+          options: --volume ${{ env.MAGMA_ROOT }}:/workspaces/magma --volume ${{ env.MAGMA_ROOT }}/lte/gateway/configs:/etc/magma -e ABC=123
+          run: |
+            cd /workspaces/magma/lte/gateway
+            make build_connection_tracker BUILD_TYPE=Debug
       - name: Build connection tracker with BUILD_TYPE=RelWithDebInfo
         timeout-minutes: 5
-        run: |
-            # TODO run unit tests once we write some tests
-            docker run --volume ${{ env.MAGMA_ROOT }}:/magma --volume ${{ env.MAGMA_ROOT }}/lte/gateway/configs:/etc/magma --interactive magma/c_cpp_build:latest /bin/bash -c "cd /magma/lte/gateway;make build_connection_tracker BUILD_TYPE=RelWithDebInfo;"
+        uses: addnab/docker-run-action@v2
+        with:
+          image: ${{ env.DEVCONTAINER_IMAGE }}
+          # TODO: Remove work-around mount of Github workspace to /magma (https://github.com/addnab/docker-run-action/issues/11)
+          options: --volume ${{ env.MAGMA_ROOT }}:/workspaces/magma --volume ${{ env.MAGMA_ROOT }}/lte/gateway/configs:/etc/magma -e ABC=123
+          run: |
+            cd /workspaces/magma/lte/gateway
+            make build_connection_tracker BUILD_TYPE=RelWithDebInfo
       - name: Extract commit title
         # yamllint enable
         if: failure() && github.ref == 'refs/heads/master'
@@ -238,27 +252,51 @@ jobs:
       MAGMA_ROOT: "${{ github.workspace }}"
     steps:
       - uses: actions/checkout@v2
-      - uses: satackey/action-docker-layer-caching@v0.0.11
-        continue-on-error: true
-      - name: Build the base c/c++ container
-        run: |
-            docker build --tag magma/c_cpp_build --file ${{ env.MAGMA_ROOT }}/lte/gateway/docker/mme/Dockerfile.ubuntu20.04 .
       - name: Run common tests
-        # yamllint disable rule:line-length
-        run: |
-            docker run --volume ${{ env.MAGMA_ROOT }}:/magma --volume ${{ env.MAGMA_ROOT }}/lte/gateway/configs:/etc/magma --interactive magma/c_cpp_build:latest /bin/bash -c "cd /magma/lte/gateway;make test_common;"
+        uses: addnab/docker-run-action@v2
+        with:
+          image: ${{ env.DEVCONTAINER_IMAGE }}
+          # TODO: Remove work-around mount of Github workspace to /magma (https://github.com/addnab/docker-run-action/issues/11)
+          options: --volume ${{ env.MAGMA_ROOT }}:/workspaces/magma --volume ${{ env.MAGMA_ROOT }}/lte/gateway/configs:/etc/magma -e ABC=123
+          run: |
+            cd /workspaces/magma/lte/gateway
+            make test_common
       - name: Run sctpd tests with Debug build type
-        run: |
-            docker run --volume ${{ env.MAGMA_ROOT }}:/magma --volume ${{ env.MAGMA_ROOT }}/lte/gateway/configs:/etc/magma --interactive magma/c_cpp_build:latest /bin/bash -c "cd /magma/lte/gateway;make test_sctpd BUILD_TYPE=Debug;"
+        uses: addnab/docker-run-action@v2
+        with:
+          image: ${{ env.DEVCONTAINER_IMAGE }}
+          # TODO: Remove work-around mount of Github workspace to /magma (https://github.com/addnab/docker-run-action/issues/11)
+          options: --volume ${{ env.MAGMA_ROOT }}:/workspaces/magma --volume ${{ env.MAGMA_ROOT }}/lte/gateway/configs:/etc/magma -e ABC=123
+          run: |
+            cd /workspaces/magma/lte/gateway
+            make test_sctpd BUILD_TYPE=Debug
       - name: Run sctpd tests with RelWithDebInfo build type
-        run: |
-            docker run --volume ${{ env.MAGMA_ROOT }}:/magma --volume ${{ env.MAGMA_ROOT }}/lte/gateway/configs:/etc/magma --interactive magma/c_cpp_build:latest /bin/bash -c "cd /magma/lte/gateway;make test_sctpd BUILD_TYPE=RelWithDebInfo;"
+        uses: addnab/docker-run-action@v2
+        with:
+          image: ${{ env.DEVCONTAINER_IMAGE }}
+          # TODO: Remove work-around mount of Github workspace to /magma (https://github.com/addnab/docker-run-action/issues/11)
+          options: --volume ${{ env.MAGMA_ROOT }}:/workspaces/magma --volume ${{ env.MAGMA_ROOT }}/lte/gateway/configs:/etc/magma -e ABC=123
+          run: |
+            cd /workspaces/magma/lte/gateway
+            make test_sctpd BUILD_TYPE=RelWithDebInfo
       - name: Run mme tests with Debug build type
-        run: |
-            docker run --volume ${{ env.MAGMA_ROOT }}:/magma --volume ${{ env.MAGMA_ROOT }}/lte/gateway/configs:/etc/magma --interactive magma/c_cpp_build:latest /bin/bash -c "cd /magma/lte/gateway;make test_oai BUILD_TYPE=Debug;"
+        uses: addnab/docker-run-action@v2
+        with:
+          image: ${{ env.DEVCONTAINER_IMAGE }}
+          # TODO: Remove work-around mount of Github workspace to /magma (https://github.com/addnab/docker-run-action/issues/11)
+          options: --volume ${{ env.MAGMA_ROOT }}:/workspaces/magma --volume ${{ env.MAGMA_ROOT }}/lte/gateway/configs:/etc/magma -e ABC=123
+          run: |
+            cd /workspaces/magma/lte/gateway
+            make test_oai BUILD_TYPE=Debug;
       - name: Run mme tests with RelWithDebInfo build type
-        run: |
-            docker run --volume ${{ env.MAGMA_ROOT }}:/magma --volume ${{ env.MAGMA_ROOT }}/lte/gateway/configs:/etc/magma --interactive magma/c_cpp_build:latest /bin/bash -c "cd /magma/lte/gateway;make test_oai BUILD_TYPE=RelWithDebInfo;"
+        uses: addnab/docker-run-action@v2
+        with:
+          image: ${{ env.DEVCONTAINER_IMAGE }}
+          # TODO: Remove work-around mount of Github workspace to /magma (https://github.com/addnab/docker-run-action/issues/11)
+          options: --volume ${{ env.MAGMA_ROOT }}:/workspaces/magma --volume ${{ env.MAGMA_ROOT }}/lte/gateway/configs:/etc/magma -e ABC=123
+          run: |
+            cd /workspaces/magma/lte/gateway
+            make test_oai BUILD_TYPE=RelWithDebInfo;
       - name: Extract commit title
         # yamllint enable
         if: failure() && github.ref == 'refs/heads/master'


### PR DESCRIPTION
## Summary

Build of our dockerfile is causing flakes (actually at this very moment, `li agent test` is broken by upstream fetch of grpc as part of container build) and slowing the test down
(e.g. see [failure](https://github.com/magma/magma/pull/9088/checks?check_run_id=3766565267)).

This PR re-uses the devcontainer which supports all c/c++ tests in AGW.

Note that this change does not impact the compiler used - we still use `gcc` for these builds:

```shell
-- The C compiler identification is GNU 9.3.0
-- The CXX compiler identification is GNU 9.3.0
-- Check for working C compiler: /usr/bin/cc
-- Check for working C compiler: /usr/bin/cc -- works
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Detecting C compile features
-- Detecting C compile features - done
-- Check for working CXX compiler: /usr/bin/c++
-- Check for working CXX compiler: /usr/bin/c++ -- works
```

```shell
@electronjoe ➜ /workspaces/magma (pr-ci-agw-to-devcontainer) $ ls -lh /usr/bin/cc
lrwxrwxrwx 1 root root 20 Sep 21 09:11 /usr/bin/cc -> /etc/alternatives/cc
@electronjoe ➜ /workspaces/magma (pr-ci-agw-to-devcontainer) $ ls -lh /etc/alternatives/cc
lrwxrwxrwx 1 root root 12 Sep 21 09:11 /etc/alternatives/cc -> /usr/bin/gcc
@electronjoe ➜ /workspaces/magma (pr-ci-agw-to-devcontainer) $ ls -lh /usr/bin/c++
lrwxrwxrwx 1 root root 21 Sep 21 09:11 /usr/bin/c++ -> /etc/alternatives/c++
@electronjoe ➜ /workspaces/magma (pr-ci-agw-to-devcontainer) $ ls -lh /etc/alternatives/c++
lrwxrwxrwx 1 root root 12 Sep 21 09:11 /etc/alternatives/c++ -> /usr/bin/g++
```

## Pitfalls

This PR does couple our devcontainer environment with our CI test environment, which eventually we may want to break. But changing what container is executed from the registry is a simple change relative to the delta of this PR.  Tying these means that moving the container forward (see ##Maintenance below) will require additional testing in the container (e.g. running these workflows).

## Maintenance

Periodically we will move the container image forward after testing it's health, by updating the container tag / hash:

```yaml
env:
  DEVCONTAINER_IMAGE: "ghcr.io/magma/devcontainer:sha-375f28a"
```

## Misc

While we are here, add a 10 minute timeout to `session manager tests` which in one of my pushes ran for 44 minutes without failure.

Signed-off-by: Scott Moeller <electronjoe@gmail.com>
