### PR TITLE
fix(ci): packaging agw for ubuntu

### DIFF
--- a/lte/gateway/fabfile.py
+++ b/lte/gateway/fabfile.py
@@ -135,6 +135,8 @@ def package(
 
         with cd('release'):
             mirrored_packages_file = 'mirrored_packages'
+            if os == "ubuntu":
+                mirrored_packages_file += '_focal'
             if vm and vm.startswith('magma_'):
                 mirrored_packages_file += vm[5:]
 


### PR DESCRIPTION
Signed-off-by: quentinDERORY <15911421+quentinDERORY@users.noreply.github.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

Ubuntu need a different package file than debian.
This will fix the lte-agw-deploy job building and publishing agw packages.

## Test Plan

Tested in v1.5-ubuntu

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
