### PR TITLE
fix(agw): Fix default logging level

### DIFF
--- a/lte/gateway/configs/directoryd.yml
+++ b/lte/gateway/configs/directoryd.yml
@@ -13,3 +13,5 @@
 
 # log_level is set in mconfig. It can be overridden here
 print_grpc_payload: false
+
+log_level: INFO

--- a/lte/gateway/configs/state.yml
+++ b/lte/gateway/configs/state.yml
@@ -15,6 +15,7 @@
 # sync_interval is set in mconfig. it can be overridden here
 
 print_grpc_payload: false
+log_level: INFO
 
 #state_protos:
 #  - proto_file:  - file to load proto from


### PR DESCRIPTION
In scale test, services like state or directoryD can log huge
amount of data on certain events. That results in CPU spikes.
Following PR sets the default value to INFO to avoid unnecessary
logging.

Signed-off-by: Pravin B Shelar <pbshelar@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
