### PR TITLE
fix(mme): Fix default bearer timer expiry handler

### DIFF
--- a/lte/gateway/c/core/oai/tasks/nas/esm/DedicatedEpsBearerContextActivation.c
+++ b/lte/gateway/c/core/oai/tasks/nas/esm/DedicatedEpsBearerContextActivation.c
@@ -445,7 +445,7 @@ void dedicated_eps_bearer_activate_t3485_handler(void* args, imsi64_t* imsi64) {
       OAILOG_FUNC_OUT(LOG_NAS_ESM);
     }
     bearer_context =
-        ue_mm_context->bearer_contexts[EBI_TO_INDEX(esm_ebr_timer_data->ebi)];
+        mme_app_get_bearer_context(ue_mm_context, esm_ebr_timer_data->ebi);
     if (bearer_context == NULL) {
       OAILOG_ERROR_UE(
           LOG_NAS_ESM, *imsi64,

--- a/lte/gateway/c/core/oai/tasks/nas/esm/DefaultEpsBearerContextActivation.c
+++ b/lte/gateway/c/core/oai/tasks/nas/esm/DefaultEpsBearerContextActivation.c
@@ -481,26 +481,24 @@ void default_eps_bearer_activate_t3485_handler(void* args, imsi64_t* imsi64) {
    */
   esm_ebr_timer_data_t* esm_ebr_timer_data = (esm_ebr_timer_data_t*) (args);
 
-  ue_mm_context_t* ue_context_p =
-      mme_ue_context_exists_mme_ue_s1ap_id(esm_ebr_timer_data->ue_id);
-  bearer_context_t* bc =
-      mme_app_get_bearer_context(ue_context_p, esm_ebr_timer_data->ebi);
-  if (bc) {
-    bc->esm_ebr_context.timer.id = NAS_TIMER_INACTIVE_ID;
-  } else {
-    OAILOG_WARNING(
-        LOG_NAS_ESM,
-        "ESM-PROC  - T3485 timer expired (ue_id=" MME_UE_S1AP_ID_FMT
-        ", ebi=%d), "
-        "but bearer context is already deleted.\n",
-        esm_ebr_timer_data->ue_id, esm_ebr_timer_data->ebi);
-    OAILOG_FUNC_OUT(LOG_NAS_ESM);
-  }
-
   if (esm_ebr_timer_data) {
-    /*
-     * Increment the retransmission counter
-     */
+    ue_mm_context_t* ue_context_p =
+        mme_ue_context_exists_mme_ue_s1ap_id(esm_ebr_timer_data->ue_id);
+    bearer_context_t* bc =
+        mme_app_get_bearer_context(ue_context_p, esm_ebr_timer_data->ebi);
+    // Set timer ID to inactive as it is expired
+    if (bc) {
+      bc->esm_ebr_context.timer.id = NAS_TIMER_INACTIVE_ID;
+    } else {
+      OAILOG_WARNING(
+          LOG_NAS_ESM,
+          "ESM-PROC  - T3485 timer expired (ue_id=" MME_UE_S1AP_ID_FMT
+          ", ebi=%d), "
+          "but bearer context is already deleted.\n",
+          esm_ebr_timer_data->ue_id, esm_ebr_timer_data->ebi);
+      OAILOG_FUNC_OUT(LOG_NAS_ESM);
+    }
+    // Increment the retransmission counter
     esm_ebr_timer_data->count += 1;
     OAILOG_WARNING(
         LOG_NAS_ESM,

--- a/lte/gateway/c/core/oai/tasks/nas/esm/DefaultEpsBearerContextActivation.c
+++ b/lte/gateway/c/core/oai/tasks/nas/esm/DefaultEpsBearerContextActivation.c
@@ -481,6 +481,22 @@ void default_eps_bearer_activate_t3485_handler(void* args, imsi64_t* imsi64) {
    */
   esm_ebr_timer_data_t* esm_ebr_timer_data = (esm_ebr_timer_data_t*) (args);
 
+  ue_mm_context_t* ue_context_p =
+      mme_ue_context_exists_mme_ue_s1ap_id(esm_ebr_timer_data->ue_id);
+  bearer_context_t* bc =
+      mme_app_get_bearer_context(ue_context_p, esm_ebr_timer_data->ebi);
+  if (bc) {
+    bc->esm_ebr_context.timer.id = NAS_TIMER_INACTIVE_ID;
+  } else {
+    OAILOG_WARNING(
+        LOG_NAS_ESM,
+        "ESM-PROC  - T3485 timer expired (ue_id=" MME_UE_S1AP_ID_FMT
+        ", ebi=%d), "
+        "but bearer context is already deleted.\n",
+        esm_ebr_timer_data->ue_id, esm_ebr_timer_data->ebi);
+    OAILOG_FUNC_OUT(LOG_NAS_ESM);
+  }
+
   if (esm_ebr_timer_data) {
     /*
      * Increment the retransmission counter
@@ -507,11 +523,6 @@ void default_eps_bearer_activate_t3485_handler(void* args, imsi64_t* imsi64) {
        * If PDN connectivity is received along with attach req send
        * activate default eps bearer req message in ICS req
        */
-      ue_mm_context_t* ue_context_p = PARENT_STRUCT(
-          ((emm_context_t*) esm_ebr_timer_data->ctx), struct ue_mm_context_s,
-          emm_context);
-      bearer_context_t* bc =
-          mme_app_get_bearer_context(ue_context_p, esm_ebr_timer_data->ebi);
       if (((emm_context_t*) esm_ebr_timer_data->ctx)
               ->esm_ctx.pending_standalone &&
           (!(bc->enb_fteid_s1u.teid))) {


### PR DESCRIPTION
<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->
- Upon expiry of T3485, the timer id was not reinitialized to invalid id leading to mishandling later in `esm_ebr_start_timer` where timer arguments are populated as if the timer was not expired.
- Although not functionally creating an issue, for readability and more uniformity, `dedicated_eps_bearer_activate_t3485_handler` is modified in how the bearer context is fetched.

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->
Run the flaky test `test_3485_timer_for_default_bearer_with_mme_restart.py` multiple times consecutively. Run another integration test that checks multiple expirations.

Run s1ap integ tests.

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
