### PR TITLE
fix(agw): Better logging for NAS/EMM, tracing IMSI when possible

### DIFF
--- a/lte/gateway/c/core/oai/tasks/nas/emm/Authentication.c
+++ b/lte/gateway/c/core/oai/tasks/nas/emm/Authentication.c
@@ -163,10 +163,10 @@ status_code_e emm_proc_authentication_ksi(
     mme_ue_s1ap_id_t ue_id =
         PARENT_STRUCT(emm_context, struct ue_mm_context_s, emm_context)
             ->mme_ue_s1ap_id;
-    OAILOG_INFO(LOG_NAS_EMM,
-                "ue_id=" MME_UE_S1AP_ID_FMT
-                " EMM-PROC  - Initiate Authentication KSI = %d\n",
-                ue_id, ksi);
+    OAILOG_INFO_UE(LOG_NAS_EMM, emm_context->_imsi64,
+                   "ue_id=" MME_UE_S1AP_ID_FMT
+                   " EMM-PROC  - Initiate Authentication KSI = %d\n",
+                   ue_id, ksi);
 
     nas_emm_auth_proc_t* auth_proc =
         get_nas_common_procedure_authentication(emm_context);
@@ -178,16 +178,17 @@ status_code_e emm_proc_authentication_ksi(
       if (emm_specific_proc) {
         if (EMM_SPEC_PROC_TYPE_ATTACH == emm_specific_proc->type) {
           auth_proc->is_cause_is_attach = true;
-          OAILOG_DEBUG(LOG_NAS_EMM,
-                       "Auth proc cause is EMM_SPEC_PROC_TYPE_ATTACH (%d) for "
-                       "ue_id " MME_UE_S1AP_ID_FMT "\n",
-                       emm_specific_proc->type, ue_id);
+          OAILOG_DEBUG_UE(
+              LOG_NAS_EMM, emm_context->_imsi64,
+              "Auth proc cause is EMM_SPEC_PROC_TYPE_ATTACH (%d) for "
+              "ue_id " MME_UE_S1AP_ID_FMT "\n",
+              emm_specific_proc->type, ue_id);
         } else if (EMM_SPEC_PROC_TYPE_TAU == emm_specific_proc->type) {
           auth_proc->is_cause_is_attach = false;
-          OAILOG_DEBUG(LOG_NAS_EMM,
-                       "Auth proc cause is EMM_SPEC_PROC_TYPE_TAU (%d) for "
-                       "ue_id " MME_UE_S1AP_ID_FMT "\n",
-                       emm_specific_proc->type, ue_id);
+          OAILOG_DEBUG_UE(LOG_NAS_EMM, emm_context->_imsi64,
+                          "Auth proc cause is EMM_SPEC_PROC_TYPE_TAU (%d) for "
+                          "ue_id " MME_UE_S1AP_ID_FMT "\n",
+                          emm_specific_proc->type, ue_id);
         }
       }
       // Set the RAND value
@@ -433,21 +434,22 @@ static int auth_info_proc_success_cb(struct emm_context_s* emm_ctx) {
              auth_info_proc->vector[i]->xres.size);
       emm_ctx->_vector[destination_index].xres_size =
           auth_info_proc->vector[i]->xres.size;
-      OAILOG_DEBUG(LOG_NAS_EMM, "EMM-PROC  - Received Vector %u:\n", i);
-      OAILOG_DEBUG(LOG_NAS_EMM,
-                   "EMM-PROC  - Received XRES ..: " XRES_FORMAT "\n",
-                   XRES_DISPLAY(emm_ctx->_vector[destination_index].xres));
-      OAILOG_DEBUG(LOG_NAS_EMM,
-                   "EMM-PROC  - Received RAND ..: " RAND_FORMAT "\n",
-                   RAND_DISPLAY(emm_ctx->_vector[destination_index].rand));
-      OAILOG_DEBUG(LOG_NAS_EMM,
-                   "EMM-PROC  - Received AUTN ..: " AUTN_FORMAT "\n",
-                   AUTN_DISPLAY(emm_ctx->_vector[destination_index].autn));
-      OAILOG_DEBUG(LOG_NAS_EMM,
-                   "EMM-PROC  - Received KASME .: " KASME_FORMAT
-                   " " KASME_FORMAT "\n",
-                   KASME_DISPLAY_1(emm_ctx->_vector[destination_index].kasme),
-                   KASME_DISPLAY_2(emm_ctx->_vector[destination_index].kasme));
+      OAILOG_DEBUG_UE(LOG_NAS_EMM, emm_ctx->_imsi64,
+                      "EMM-PROC  - Received Vector %u:\n", i);
+      OAILOG_DEBUG_UE(LOG_NAS_EMM, emm_ctx->_imsi64,
+                      "EMM-PROC  - Received XRES ..: " XRES_FORMAT "\n",
+                      XRES_DISPLAY(emm_ctx->_vector[destination_index].xres));
+      OAILOG_DEBUG_UE(LOG_NAS_EMM, emm_ctx->_imsi64,
+                      "EMM-PROC  - Received RAND ..: " RAND_FORMAT "\n",
+                      RAND_DISPLAY(emm_ctx->_vector[destination_index].rand));
+      OAILOG_DEBUG_UE(LOG_NAS_EMM, emm_ctx->_imsi64,
+                      "EMM-PROC  - Received AUTN ..: " AUTN_FORMAT "\n",
+                      AUTN_DISPLAY(emm_ctx->_vector[destination_index].autn));
+      OAILOG_DEBUG_UE(
+          LOG_NAS_EMM, emm_ctx->_imsi64,
+          "EMM-PROC  - Received KASME .: " KASME_FORMAT " " KASME_FORMAT "\n",
+          KASME_DISPLAY_1(emm_ctx->_vector[destination_index].kasme),
+          KASME_DISPLAY_2(emm_ctx->_vector[destination_index].kasme));
       emm_ctx_set_attribute_valid(
           emm_ctx, EMM_CTXT_MEMBER_AUTH_VECTOR0 + destination_index);
     }
@@ -496,16 +498,17 @@ static int auth_info_proc_success_cb(struct emm_context_s* emm_ctx) {
           /*
            * Failed to initiate the authentication procedure
            */
-          OAILOG_WARNING(LOG_NAS_EMM,
-                         "EMM-PROC  - "
-                         "Failed to initiate authentication procedure for ue "
-                         "id " MME_UE_S1AP_ID_FMT "\n",
-                         ue_id);
+          OAILOG_WARNING_UE(
+              LOG_NAS_EMM, emm_ctx->_imsi64,
+              "EMM-PROC  - "
+              "Failed to initiate authentication procedure for ue "
+              "id " MME_UE_S1AP_ID_FMT "\n",
+              ue_id);
           auth_proc->emm_cause = EMM_CAUSE_ILLEGAL_UE;
         }
       } else {
-        OAILOG_WARNING(
-            LOG_NAS_EMM,
+        OAILOG_WARNING_UE(
+            LOG_NAS_EMM, emm_ctx->_imsi64,
             "EMM-PROC  - "
             "Failed to initiate authentication procedure" MME_UE_S1AP_ID_FMT
             "\n",
@@ -596,19 +599,19 @@ status_code_e emm_proc_authentication_failure(mme_ue_s1ap_id_t ue_id,
   int rc = RETURNerror;
 
   if (!ue_mm_context) {
-    OAILOG_WARNING(
-        LOG_NAS_EMM,
+    OAILOG_WARNING_UE(
+        LOG_NAS_EMM, emm_ctx->_imsi64,
         "EMM-PROC  - Failed to authenticate the UE " MME_UE_S1AP_ID_FMT "\n",
         ue_id);
     emm_cause = EMM_CAUSE_ILLEGAL_UE;
     OAILOG_FUNC_RETURN(LOG_NAS_EMM, rc);
   }
 
-  OAILOG_INFO(LOG_NAS_EMM,
-              "EMM-PROC  - Authentication failure (ue_id=" MME_UE_S1AP_ID_FMT
-              ", cause=%d)\n",
-              ue_id, emm_cause);
   emm_ctx = &ue_mm_context->emm_context;
+  OAILOG_INFO_UE(LOG_NAS_EMM, emm_ctx->_imsi64,
+                 "EMM-PROC  - Authentication failure (ue_id=" MME_UE_S1AP_ID_FMT
+                 ", cause=%d)\n",
+                 ue_id, emm_cause);
   nas_emm_auth_proc_t* auth_proc =
       get_nas_common_procedure_authentication(emm_ctx);
 
@@ -627,8 +630,8 @@ status_code_e emm_proc_authentication_failure(mme_ue_s1ap_id_t ue_id,
 
         auth_proc->sync_fail_count += 1;
         if (EMM_AUTHENTICATION_SYNC_FAILURE_MAX > auth_proc->sync_fail_count) {
-          OAILOG_DEBUG(
-              LOG_NAS_EMM,
+          OAILOG_DEBUG_UE(
+              LOG_NAS_EMM, emm_ctx->_imsi64,
               "EMM-PROC  - USIM has detected a mismatch in SQN Ask for new "
               "vector(s)\n");
 
@@ -785,8 +788,8 @@ status_code_e emm_proc_authentication_failure(mme_ue_s1ap_id_t ue_id,
           REQUIREMENT_3GPP_24_301(
               R10_5_4_2_7_d__NOTE2);  // more or less this case...
           // Failed to initiate the identification procedure
-          OAILOG_WARNING(
-              LOG_NAS_EMM,
+          OAILOG_WARNING_UE(
+              LOG_NAS_EMM, emm_ctx->_imsi64,
               "ue_id=" MME_UE_S1AP_ID_FMT
               "EMM-PROC  - Failed to initiate identification procedure\n",
               ue_mm_context->mme_ue_s1ap_id);
@@ -807,9 +810,10 @@ status_code_e emm_proc_authentication_failure(mme_ue_s1ap_id_t ue_id,
 
       default:
         auth_proc->sync_fail_count = 0;
-        OAILOG_DEBUG(LOG_NAS_EMM,
-                     "EMM-PROC  - The MME received an unknown EMM CAUSE %d\n",
-                     emm_cause);
+        OAILOG_DEBUG_UE(
+            LOG_NAS_EMM, emm_ctx->_imsi64,
+            "EMM-PROC  - The MME received an unknown EMM CAUSE %d\n",
+            emm_cause);
         OAILOG_FUNC_RETURN(LOG_NAS_EMM, rc);
     }
   }
@@ -912,12 +916,12 @@ status_code_e emm_proc_authentication_complete(mme_ue_s1ap_id_t ue_id,
     }
 
     if (is_val_fail == true) {
-      OAILOG_WARNING(LOG_NAS_EMM,
-                     "XRES/RES Validation Failed for (ue_id=" MME_UE_S1AP_ID_FMT
-                     ")\n",
-                     ue_id);
       if (!IS_EMM_CTXT_PRESENT_IMSI(
               emm_ctx)) {  // VALID means received in IDENTITY RESPONSE
+        OAILOG_WARNING(
+            LOG_NAS_EMM,
+            "XRES/RES Validation Failed for (ue_id=" MME_UE_S1AP_ID_FMT ")\n",
+            ue_id);
         REQUIREMENT_3GPP_24_301(R10_5_4_2_7_c__2);
         rc = emm_proc_identification(emm_ctx, &auth_proc->emm_com_proc.emm_proc,
                                      IDENTITY_TYPE_2_IMSI,
@@ -935,10 +939,10 @@ status_code_e emm_proc_authentication_complete(mme_ue_s1ap_id_t ue_id,
       } else {
         REQUIREMENT_3GPP_24_301(R10_5_4_2_5__2);
         emm_ctx->emm_cause = EMM_CAUSE_ILLEGAL_UE;
-        OAILOG_ERROR(LOG_NAS_EMM,
-                     "ue_id=" MME_UE_S1AP_ID_FMT
-                     "Auth Failed. XRES is not equal to RES\n",
-                     auth_proc->ue_id);
+        OAILOG_ERROR_UE(LOG_NAS_EMM, emm_ctx->_imsi64,
+                        "ue_id=" MME_UE_S1AP_ID_FMT
+                        "Auth Failed. XRES is not equal to RES\n",
+                        auth_proc->ue_id);
         increment_counter("authentication_failure", 1, 1, "cause",
                           "xres_validation_failed");
         increment_counter("ue_attach", 1, 2, "result", "failure", "cause",
@@ -949,16 +953,16 @@ status_code_e emm_proc_authentication_complete(mme_ue_s1ap_id_t ue_id,
       OAILOG_FUNC_RETURN(LOG_NAS_EMM, rc);
     }
 
-    OAILOG_DEBUG(
-        LOG_NAS_EMM,
+    OAILOG_DEBUG_UE(
+        LOG_NAS_EMM, emm_ctx->_imsi64,
         "EMM-PROC  - Successful authentication of the UE RESP XRES == XRES UE "
         "CONTEXT\n");
 
     /*
      * Notify EMM that the authentication procedure successfully completed
      */
-    OAILOG_DEBUG(
-        LOG_NAS_EMM,
+    OAILOG_DEBUG_UE(
+        LOG_NAS_EMM, emm_ctx->_imsi64,
         "EMM-PROC  - Notify EMM that the authentication procedure successfully "
         "completed\n");
     emm_sap_t emm_sap = {0};
@@ -973,8 +977,9 @@ status_code_e emm_proc_authentication_complete(mme_ue_s1ap_id_t ue_id,
         auth_proc->emm_com_proc.emm_proc.previous_emm_fsm_state;
     rc = emm_sap_send(&emm_sap);
   } else {
-    OAILOG_ERROR(LOG_NAS_EMM,
-                 "Auth proc is null for ue id " MME_UE_S1AP_ID_FMT "\n", ue_id);
+    OAILOG_ERROR_UE(LOG_NAS_EMM, emm_ctx->_imsi64,
+                    "Auth proc is null for ue id " MME_UE_S1AP_ID_FMT "\n",
+                    ue_id);
   }
   OAILOG_FUNC_RETURN(LOG_NAS_EMM, rc);
 }
@@ -1379,8 +1384,8 @@ static int authentication_non_delivered_ho(struct emm_context_s* emm_ctx,
      * Stop timer T3460
      */
     if (auth_proc->T3460.id != NAS_TIMER_INACTIVE_ID) {
-      OAILOG_INFO(
-          LOG_NAS_EMM,
+      OAILOG_INFO_UE(
+          LOG_NAS_EMM, emm_ctx->_imsi64,
           "EMM-PROC  - Stop timer T3460 (%ld) for (ue_id=" MME_UE_S1AP_ID_FMT
           ")\n",
           auth_proc->T3460.id, ue_mm_context->mme_ue_s1ap_id);
@@ -1425,10 +1430,10 @@ static int authentication_abort(emm_context_t* emm_ctx,
     nas_emm_auth_proc_t* auth_proc = (nas_emm_auth_proc_t*)base_proc;
     ue_mm_context_t* ue_mm_context =
         PARENT_STRUCT(emm_ctx, struct ue_mm_context_s, emm_context);
-    OAILOG_INFO(LOG_NAS_EMM,
-                "EMM-PROC  - Abort authentication procedure "
-                "(ue_id=" MME_UE_S1AP_ID_FMT ")\n",
-                ue_mm_context->mme_ue_s1ap_id);
+    OAILOG_INFO_UE(LOG_NAS_EMM, emm_ctx->_imsi64,
+                   "EMM-PROC  - Abort authentication procedure "
+                   "(ue_id=" MME_UE_S1AP_ID_FMT ")\n",
+                   ue_mm_context->mme_ue_s1ap_id);
 
     /*
      * Stop timer T3460

--- a/lte/gateway/c/core/oai/tasks/nas/emm/Detach.c
+++ b/lte/gateway/c/core/oai/tasks/nas/emm/Detach.c
@@ -124,18 +124,18 @@ status_code_e mme_app_handle_detach_t3422_expiry(zloop_t* loop, int timer_id,
   }
 
   if (!data) {
-    OAILOG_ERROR(LOG_NAS_EMM,
-                 "The argument for network initiated"
-                 "detach timer is NULL \n");
+    OAILOG_ERROR_UE(LOG_NAS_EMM, emm_ctx->_imsi64,
+                    "The argument for network initiated"
+                    "detach timer is NULL \n");
     OAILOG_FUNC_RETURN(LOG_NAS_EMM, RETURNok);
   }
 
   // Increment the retransmission counter
   data->retransmission_count += 1;
-  OAILOG_WARNING(LOG_NAS_EMM,
-                 "EMM-PROC: T3422 timer expired,retransmission "
-                 "counter = %d for ue id " MME_UE_S1AP_ID_FMT "\n",
-                 data->retransmission_count, mme_ue_s1ap_id);
+  OAILOG_WARNING_UE(LOG_NAS_EMM, emm_ctx->_imsi64,
+                    "EMM-PROC: T3422 timer expired,retransmission "
+                    "counter = %d for ue id " MME_UE_S1AP_ID_FMT "\n",
+                    data->retransmission_count, mme_ue_s1ap_id);
 
   if (data->retransmission_count < DETACH_REQ_COUNTER_MAX) {
     // Resend detach request message to the UE
@@ -382,8 +382,8 @@ status_code_e emm_proc_detach_request(mme_ue_s1ap_id_t ue_id,
      * release and don't clear emm context return from here
      */
     if (params->type == EMM_DETACH_TYPE_IMSI) {
-      OAILOG_INFO(
-          LOG_NAS_EMM,
+      OAILOG_INFO_UE(
+          LOG_NAS_EMM, emm_ctx->_imsi64,
           "Do not clear emm context for UE Initiated IMSI Detach Request "
           " for the UE (ue_id=" MME_UE_S1AP_ID_FMT ")\n",
           ue_id);
@@ -543,8 +543,8 @@ status_code_e emm_proc_nw_initiated_detach_request(mme_ue_s1ap_id_t ue_id,
         nw_detach_data_t* data =
             (nw_detach_data_t*)calloc(1, sizeof(nw_detach_data_t));
         if (!data) {
-          OAILOG_ERROR(
-              LOG_NAS_EMM,
+          OAILOG_ERROR_UE(
+              LOG_NAS_EMM, emm_ctx->_imsi64,
               "Failed to allocate memory for 3422 timer argument. Didn't start "
               "the 3422 timer for ue id " MME_UE_S1AP_ID_FMT "\n",
               ue_id);

--- a/lte/gateway/c/core/oai/tasks/nas/emm/EmmStatusHdl.c
+++ b/lte/gateway/c/core/oai/tasks/nas/emm/EmmStatusHdl.c
@@ -101,7 +101,6 @@ int emm_proc_status(mme_ue_s1ap_id_t ue_id, emm_cause_t emm_cause) {
   emm_security_context_t* sctx = NULL;
   struct emm_context_s* ctx = NULL;
 
-  OAILOG_INFO(LOG_NAS_EMM, "EMM-PROC  - EMM status procedure requested\n");
   /*
    * Notity EMM that EMM status indication has to be sent to lower layers
    */
@@ -115,6 +114,10 @@ int emm_proc_status(mme_ue_s1ap_id_t ue_id, emm_cause_t emm_cause) {
     if (ctx) {
       sctx = &ctx->_security;
     }
+    OAILOG_INFO_UE(LOG_NAS_EMM, ctx->_imsi64,
+                   "EMM-PROC  - EMM status procedure requested\n");
+  } else {
+    OAILOG_INFO(LOG_NAS_EMM, "EMM-PROC  - EMM status procedure requested\n");
   }
 
   /*

--- a/lte/gateway/c/core/oai/tasks/nas/emm/SecurityModeControl.c
+++ b/lte/gateway/c/core/oai/tasks/nas/emm/SecurityModeControl.c
@@ -175,16 +175,15 @@ status_code_e emm_proc_security_mode_control(
   /*
    * Get the UE context
    */
-
-  OAILOG_INFO(LOG_NAS_EMM,
-              "EMM-PROC  - Initiate security mode control procedure, "
-              "KSI = %d\n",
-              ksi);
-
   if (!(emm_ctx)) {
     OAILOG_ERROR(LOG_NAS_EMM, "Emm Context NULL!\n");
     OAILOG_FUNC_RETURN(LOG_NAS_EMM, RETURNerror);
   }
+
+  OAILOG_INFO_UE(LOG_NAS_EMM, emm_ctx->_imsi64,
+                 "EMM-PROC  - Initiate security mode control procedure, "
+                 "KSI = %d\n",
+                 ksi);
 
   // TODO better than that (quick fixes)
   if (KSI_NO_KEY_AVAILABLE == ksi) {
@@ -237,10 +236,10 @@ status_code_e emm_proc_security_mode_control(
       emm_ctx->_security.selected_algorithms.integrity = mme_eia;
 
       if (rc == RETURNerror) {
-        OAILOG_WARNING(LOG_NAS_EMM,
-                       "EMM-PROC  - Failed to select security "
-                       "algorithms " MME_UE_S1AP_ID_FMT "\n",
-                       ue_id);
+        OAILOG_WARNING_UE(LOG_NAS_EMM, emm_ctx->_imsi64,
+                          "EMM-PROC  - Failed to select security "
+                          "algorithms " MME_UE_S1AP_ID_FMT "\n",
+                          ue_id);
         OAILOG_FUNC_RETURN(LOG_NAS_EMM, RETURNerror);
       }
 
@@ -264,10 +263,10 @@ status_code_e emm_proc_security_mode_control(
       emm_ctx_set_attribute_present(emm_ctx, EMM_CTXT_MEMBER_SECURITY);
     }
   } else {
-    OAILOG_ERROR(LOG_NAS_EMM,
-                 "EMM-PROC  - No EPS security context exists for ue "
-                 "id " MME_UE_S1AP_ID_FMT "\n",
-                 ue_id);
+    OAILOG_ERROR_UE(LOG_NAS_EMM, emm_ctx->_imsi64,
+                    "EMM-PROC  - No EPS security context exists for ue "
+                    "id " MME_UE_S1AP_ID_FMT "\n",
+                    ue_id);
     OAILOG_FUNC_RETURN(LOG_NAS_EMM, RETURNerror);
   }
 
@@ -330,25 +329,26 @@ status_code_e emm_proc_security_mode_control(
     smc_proc->umts_present = emm_ctx->_ue_network_capability.umts_present;
     smc_proc->gprs_present = (gea > 0);
 
-    OAILOG_DEBUG(LOG_NAS_EMM, "EMM-PROC  - SMC gprs_present %d gea bits %02x\n",
-                 smc_proc->gprs_present, smc_proc->gea);
+    OAILOG_DEBUG_UE(LOG_NAS_EMM, emm_ctx->_imsi64,
+                    "EMM-PROC  - SMC gprs_present %d gea bits %02x\n",
+                    smc_proc->gprs_present, smc_proc->gea);
 
     /*
      * Set the EPS encryption algorithms selected to the UE
      */
     smc_proc->selected_eea = emm_ctx->_security.selected_algorithms.encryption;
-    OAILOG_DEBUG(LOG_NAS_EMM,
-                 "EPS encryption algorithm selected is (%d) for UE "
-                 "ID: " MME_UE_S1AP_ID_FMT,
-                 smc_proc->selected_eea, ue_id);
+    OAILOG_DEBUG_UE(LOG_NAS_EMM, emm_ctx->_imsi64,
+                    "EPS encryption algorithm selected is (%d) for UE "
+                    "ID: " MME_UE_S1AP_ID_FMT,
+                    smc_proc->selected_eea, ue_id);
     /*
      * Set the EPS integrity algorithms selected to the UE
      */
     smc_proc->selected_eia = emm_ctx->_security.selected_algorithms.integrity;
-    OAILOG_DEBUG(LOG_NAS_EMM,
-                 "EPS integrity algorithm selected is (%d) for UE "
-                 "ID: " MME_UE_S1AP_ID_FMT,
-                 smc_proc->selected_eia, ue_id);
+    OAILOG_DEBUG_UE(LOG_NAS_EMM, emm_ctx->_imsi64,
+                    "EPS integrity algorithm selected is (%d) for UE "
+                    "ID: " MME_UE_S1AP_ID_FMT,
+                    smc_proc->selected_eia, ue_id);
 
     smc_proc->is_new = security_context_is_new;
 
@@ -463,10 +463,6 @@ status_code_e emm_proc_security_mode_complete(
   emm_context_t* emm_ctx = NULL;
   int rc = RETURNerror;
 
-  OAILOG_INFO(LOG_NAS_EMM,
-              "EMM-PROC  - Security mode complete (ue_id=" MME_UE_S1AP_ID_FMT
-              ")\n",
-              ue_id);
   /*
    * Get the UE context
    */
@@ -476,11 +472,15 @@ status_code_e emm_proc_security_mode_complete(
     if (!emm_ctx) {
       OAILOG_ERROR(
           LOG_NAS_EMM,
-          "EMM-PROC  - emm context is NULL for (ue_id=" MME_UE_S1AP_ID_FMT
-          ")\n",
+          "EMM-PROC  - Security mode complete received but emm context is "
+          "NULL for (ue_id=" MME_UE_S1AP_ID_FMT ")\n",
           ue_id);
       OAILOG_FUNC_RETURN(LOG_NAS_EMM, RETURNerror);
     }
+    OAILOG_INFO_UE(
+        LOG_NAS_EMM, emm_ctx->_imsi64,
+        "EMM-PROC  - Security mode complete (ue_id=" MME_UE_S1AP_ID_FMT ")\n",
+        ue_id);
   } else {
     OAILOG_FUNC_RETURN(LOG_NAS_EMM, RETURNerror);
   }
@@ -551,8 +551,8 @@ status_code_e emm_proc_security_mode_complete(
 
       int emm_cause = validate_imei(&imeisv);
       if (emm_cause != EMM_CAUSE_SUCCESS) {
-        OAILOG_ERROR(
-            LOG_NAS_EMM,
+        OAILOG_ERROR_UE(
+            LOG_NAS_EMM, emm_ctx->_imsi64,
             "EMMAS-SAP - Sending Attach Reject for ue_id =" MME_UE_S1AP_ID_FMT
             " , emm_cause =(%d)\n",
             ue_id, emm_cause);
@@ -587,8 +587,8 @@ status_code_e emm_proc_security_mode_complete(
     }
     OAILOG_FUNC_RETURN(LOG_NAS_EMM, rc);
   } else {
-    OAILOG_ERROR(
-        LOG_NAS_EMM,
+    OAILOG_ERROR_UE(
+        LOG_NAS_EMM, emm_ctx->_imsi64,
         "EMM-PROC  - No EPS security context exists. Ignoring the Security "
         "Mode "
         "Complete message for ue id " MME_UE_S1AP_ID_FMT "\n",
@@ -629,10 +629,6 @@ status_code_e emm_proc_security_mode_reject(mme_ue_s1ap_id_t ue_id) {
   emm_context_t* emm_ctx = NULL;
   int rc = RETURNerror;
 
-  OAILOG_WARNING(LOG_NAS_EMM,
-                 "EMM-PROC  - Security mode command not accepted by the UE"
-                 "(ue_id=" MME_UE_S1AP_ID_FMT ")\n",
-                 ue_id);
   /*
    * Get the UE context
    */
@@ -640,7 +636,15 @@ status_code_e emm_proc_security_mode_reject(mme_ue_s1ap_id_t ue_id) {
   ue_mm_context = mme_ue_context_exists_mme_ue_s1ap_id(ue_id);
   if (ue_mm_context) {
     emm_ctx = &ue_mm_context->emm_context;
+    OAILOG_WARNING_UE(LOG_NAS_EMM, emm_ctx->_imsi64,
+                      "EMM-PROC  - Security mode command not accepted by the UE"
+                      "(ue_id=" MME_UE_S1AP_ID_FMT ")\n",
+                      ue_id);
   } else {
+    OAILOG_WARNING(LOG_NAS_EMM,
+                   "EMM-PROC  - Security mode command not accepted by the UE"
+                   "(ue_id=" MME_UE_S1AP_ID_FMT ") UE Context NULL!\n",
+                   ue_id);
     OAILOG_FUNC_RETURN(LOG_NAS_EMM, RETURNerror);
   }
 
@@ -756,7 +760,10 @@ status_code_e mme_app_handle_security_t3460_expiry(zloop_t* loop, int timer_id,
   emm_context_t* emm_ctx = &ue_context_p->emm_context;
 
   if (!(emm_ctx)) {
-    OAILOG_ERROR(LOG_NAS_EMM, "T3460 timer expired No EMM context\n");
+    OAILOG_ERROR(LOG_NAS_EMM,
+                 "T3460 timer expired No EMM context, MME UE S1AP "
+                 "Id: " MME_UE_S1AP_ID_FMT "\n",
+                 mme_ue_s1ap_id);
     OAILOG_FUNC_RETURN(LOG_NAS_EMM, RETURNok);
   }
   nas_emm_smc_proc_t* smc_proc = get_nas_common_procedure_smc(emm_ctx);
@@ -973,17 +980,17 @@ static int security_abort(emm_context_t* emm_ctx,
   if (emm_ctx && base_proc) {
     nas_emm_smc_proc_t* smc_proc = (nas_emm_smc_proc_t*)base_proc;
     ue_id = smc_proc->ue_id;
-    OAILOG_WARNING(LOG_NAS_EMM,
-                   "EMM-PROC - Abort security mode control\
+    OAILOG_WARNING_UE(LOG_NAS_EMM, emm_ctx->_imsi64,
+                      "EMM-PROC - Abort security mode control\
                     procedure "
-                   "(ue_id=" MME_UE_S1AP_ID_FMT ")\n",
-                   ue_id);
+                      "(ue_id=" MME_UE_S1AP_ID_FMT ")\n",
+                      ue_id);
     /*
      * Stop timer T3460
      */
     if (smc_proc->T3460.id != NAS_TIMER_INACTIVE_ID) {
-      OAILOG_INFO(
-          LOG_NAS_EMM,
+      OAILOG_INFO_UE(
+          LOG_NAS_EMM, emm_ctx->_imsi64,
           "EMM-PROC  - Stop timer T3460 (%ld) for ue id " MME_UE_S1AP_ID_FMT
           "\n",
           smc_proc->T3460.id, ue_id);

--- a/lte/gateway/c/core/oai/tasks/nas/emm/ServiceRequestHdl.c
+++ b/lte/gateway/c/core/oai/tasks/nas/emm/ServiceRequestHdl.c
@@ -92,10 +92,6 @@ static int emm_service_reject(mme_ue_s1ap_id_t ue_id, uint8_t emm_cause)
   emm_context_t* emm_ctx = emm_context_get(&_emm_data, ue_id);
   emm_sap_t emm_sap = {0};
 
-  OAILOG_WARNING(LOG_NAS_EMM,
-                 "EMM-PROC- Sending Service Reject. ue_id=" MME_UE_S1AP_ID_FMT
-                 ", cause=%d)\n",
-                 ue_id, emm_cause);
   /*
    * Notify EMM-AS SAP that Service Reject message has to be sent
    * onto the network
@@ -111,9 +107,19 @@ static int emm_service_reject(mme_ue_s1ap_id_t ue_id, uint8_t emm_cause)
    * Setup EPS NAS security data
    */
   if (emm_ctx) {
+    OAILOG_WARNING_UE(
+        LOG_NAS_EMM, emm_ctx->_imsi64,
+        "EMM-PROC- Sending Service Reject. ue_id=" MME_UE_S1AP_ID_FMT
+        ", cause=%d)\n",
+        ue_id, emm_cause);
     emm_as_set_security_data(&emm_sap.u.emm_as.u.establish.sctx,
                              &emm_ctx->_security, false, false);
   } else {
+    OAILOG_WARNING(
+        LOG_NAS_EMM,
+        "EMM-PROC- Sending Service Reject. No EMM context for the UE. "
+        "ue_id=" MME_UE_S1AP_ID_FMT ", cause=%d)\n",
+        ue_id, emm_cause);
     emm_as_set_security_data(&emm_sap.u.emm_as.u.establish.sctx, NULL, false,
                              false);
   }
@@ -138,23 +144,25 @@ status_code_e emm_proc_extended_service_request(
   int rc = RETURNok;
   emm_context_t* emm_ctx = NULL;
 
-  OAILOG_INFO(
-      LOG_NAS_EMM,
-      "EMM-PROC- Extended Service Request for the UE (ue_id=" MME_UE_S1AP_ID_FMT
-      ") \n",
-      ue_id);
   /*
    * Get the UE context
    */
   emm_ctx = emm_context_get(&_emm_data, ue_id);
 
   if (!emm_ctx) {
-    OAILOG_WARNING(LOG_NAS_EMM,
-                   "No EMM context exists for the UE (ue_id=" MME_UE_S1AP_ID_FMT
-                   ") \n",
-                   ue_id);
+    OAILOG_WARNING(
+        LOG_NAS_EMM,
+        "EMM-PROC- Extended Service Request, No EMM context exists for the UE "
+        "(ue_id=" MME_UE_S1AP_ID_FMT ") \n",
+        ue_id);
     OAILOG_FUNC_RETURN(LOG_NAS_EMM, RETURNerror);
   }
+
+  OAILOG_INFO_UE(
+      LOG_NAS_EMM, emm_ctx->_imsi64,
+      "EMM-PROC- Extended Service Request for the UE (ue_id=" MME_UE_S1AP_ID_FMT
+      ") \n",
+      ue_id);
 
   /*
    * if CSFB Response is recieved for MT CSFB as accepted by ue,
@@ -207,21 +215,6 @@ status_code_e emm_recv_initial_ext_service_request(
   emm_context_t* emm_ctx = NULL;
   emm_sap_t emm_sap = {0};
 
-  OAILOG_INFO(
-      LOG_NAS_EMM,
-      "EMM-PROC- Extended Service Request for the UE (ue_id=" MME_UE_S1AP_ID_FMT
-      ") \n",
-      ue_id);
-  OAILOG_INFO(
-      LOG_NAS_EMM,
-      "EMMAS-SAP - Received Extended Service Request message, Security context "
-      "%s"
-      "Integrity protected %s MAC matched %s Ciphered %s\n",
-      (decode_status->security_context_available) ? "yes" : "no",
-      (decode_status->integrity_protected_message) ? "yes" : "no",
-      (decode_status->mac_matched) ? "yes" : "no",
-      (decode_status->ciphered_message) ? "yes" : "no");
-
   /*
    * Get the UE context
    */
@@ -229,11 +222,27 @@ status_code_e emm_recv_initial_ext_service_request(
 
   if (!emm_ctx) {
     OAILOG_WARNING(LOG_NAS_EMM,
-                   "No EMM context exists for the UE (ue_id=" MME_UE_S1AP_ID_FMT
+                   "EMM-PROC- Extended Service Request received but no EMM "
+                   "context exists for the UE (ue_id=" MME_UE_S1AP_ID_FMT
                    ") \n",
                    ue_id);
     OAILOG_FUNC_RETURN(LOG_NAS_EMM, RETURNerror);
   }
+
+  OAILOG_INFO_UE(
+      LOG_NAS_EMM, emm_ctx->_imsi64,
+      "EMM-PROC- Extended Service Request for the UE (ue_id=" MME_UE_S1AP_ID_FMT
+      ") \n",
+      ue_id);
+  OAILOG_INFO_UE(
+      LOG_NAS_EMM, emm_ctx->_imsi64,
+      "EMMAS-SAP - Received Extended Service Request message, Security context "
+      "%s"
+      "Integrity protected %s MAC matched %s Ciphered %s\n",
+      (decode_status->security_context_available) ? "yes" : "no",
+      (decode_status->integrity_protected_message) ? "yes" : "no",
+      (decode_status->mac_matched) ? "yes" : "no",
+      (decode_status->ciphered_message) ? "yes" : "no");
 
   if (msg->servicetype == MO_CS_FB) {
     /* neaf flag is true*/

--- a/lte/gateway/c/core/oai/tasks/nas/emm/emm_data_ctx.c
+++ b/lte/gateway/c/core/oai/tasks/nas/emm/emm_data_ctx.c
@@ -167,11 +167,11 @@ inline void emm_ctx_set_imsi(emm_context_t* const ctxt, imsi_t* imsi,
   emm_ctx_set_attribute_present(ctxt, EMM_CTXT_MEMBER_IMSI);
   char imsi_str[IMSI_BCD_DIGITS_MAX + 1] = {0};
   IMSI64_TO_STRING(ctxt->_imsi64, imsi_str, ctxt->_imsi.length);
-  OAILOG_DEBUG(LOG_NAS_EMM,
-               "ue_id=" MME_UE_S1AP_ID_FMT " set IMSI %s (valid)\n",
-               (PARENT_STRUCT(ctxt, struct ue_mm_context_s, emm_context))
-                   ->mme_ue_s1ap_id,
-               imsi_str);
+  OAILOG_DEBUG_UE(LOG_NAS_EMM, ctxt->_imsi64,
+                  "ue_id=" MME_UE_S1AP_ID_FMT " set IMSI %s (valid)\n",
+                  (PARENT_STRUCT(ctxt, struct ue_mm_context_s, emm_context))
+                      ->mme_ue_s1ap_id,
+                  imsi_str);
 }
 
 /* Set IMSI, mark it as valid */
@@ -182,11 +182,11 @@ inline void emm_ctx_set_valid_imsi(emm_context_t* const ctxt, imsi_t* imsi,
   emm_ctx_set_attribute_valid(ctxt, EMM_CTXT_MEMBER_IMSI);
   char imsi_str[IMSI_BCD_DIGITS_MAX + 1] = {0};
   IMSI64_TO_STRING(ctxt->_imsi64, imsi_str, ctxt->_imsi.length);
-  OAILOG_DEBUG(LOG_NAS_EMM,
-               "ue_id=" MME_UE_S1AP_ID_FMT " set IMSI %s (valid)\n",
-               (PARENT_STRUCT(ctxt, struct ue_mm_context_s, emm_context))
-                   ->mme_ue_s1ap_id,
-               imsi_str);
+  OAILOG_DEBUG_UE(LOG_NAS_EMM, ctxt->_imsi64,
+                  "ue_id=" MME_UE_S1AP_ID_FMT " set IMSI %s (valid)\n",
+                  (PARENT_STRUCT(ctxt, struct ue_mm_context_s, emm_context))
+                      ->mme_ue_s1ap_id,
+                  imsi_str);
   mme_api_notify_imsi((PARENT_STRUCT(ctxt, struct ue_mm_context_s, emm_context))
                           ->mme_ue_s1ap_id,
                       imsi64);


### PR DESCRIPTION
## Summary

For better readability of NAS EMM logs, use when possible OAI_LOG_loglevel_UE macro instead of  OAI_LOG_loglevel.
This macro displays the UE IMSI.

## Test Plan
Check that when IMSI in known that the EMM log lines display the IMSI.

## Additional Information

- [ ] This change is backwards-breaking
