### PR TITLE
feat(mme): Add Libfluid TunnelIPv6Dst support

### DIFF
--- a/third_party/build/bin/libfluid_build.sh
+++ b/third_party/build/bin/libfluid_build.sh
@@ -71,9 +71,10 @@ git clone https://github.com/OpenNetworkingFoundation/libfluid_msg.git
 git -C libfluid_msg checkout $LIBFLUID_MSG_COMMIT
 
 pushd libfluid_msg
-git apply "${PATCH_DIR}"/libfluid_msg_patches/TunnelDstPatch.patch
-git apply "${PATCH_DIR}"/libfluid_msg_patches/Add-support-for-setting-OVS-reg8.patch
-git apply "${PATCH_DIR}"/libfluid_msg_patches/Add-Reg-field-match-support.patch
+git apply "${PATCH_DIR}"/libfluid_msg_patches/0001-Add-TunnelIPv4Dst-support.patch
+git apply "${PATCH_DIR}"/libfluid_msg_patches/0002-Add-support-for-setting-OVS-reg8.patch
+git apply "${PATCH_DIR}"/libfluid_msg_patches/0003-Add-Reg-field-match-support.patch
+git apply "${PATCH_DIR}"/libfluid_msg_patches/0004-Add-TunnelIPv6Dst-support.patch
 popd
 
 for repo in libfluid_base libfluid_msg

--- a/third_party/build/patches/libfluid/libfluid_msg_patches/0001-Add-TunnelIPv4Dst-support.patch
+++ b/third_party/build/patches/libfluid/libfluid_msg_patches/0001-Add-TunnelIPv4Dst-support.patch
@@ -1,3 +1,15 @@
+From 470391a119c0fc708319c0d135b3e1f0c7508824 Mon Sep 17 00:00:00 2001
+From: Nick Yurchenko <urchennko@gmail.com>
+Date: Mon, 4 Oct 2021 19:15:09 +0000
+Subject: [PATCH 1/4] Add TunnelIPv4Dst support
+
+Signed-off-by: Nick Yurchenko <urchennko@gmail.com>
+---
+ fluid/of13/of13match.cc  | 70 ++++++++++++++++++++++++++++++++++++++++
+ fluid/of13/of13match.hh  | 32 +++++++++++++++++-
+ fluid/of13/openflow-13.h |  4 +++
+ 3 files changed, 105 insertions(+), 1 deletion(-)
+
 diff --git a/fluid/of13/of13match.cc b/fluid/of13/of13match.cc
 index 1370195..01b75e8 100644
 --- a/fluid/of13/of13match.cc
@@ -141,3 +153,6 @@ index e810fde..d891f35 100644
  /* The VLAN id is 12-bits, so we can use the entire 16 bits to indicate
   * special conditions.
   */
+-- 
+2.25.1
+

--- a/third_party/build/patches/libfluid/libfluid_msg_patches/0002-Add-support-for-setting-OVS-reg8.patch
+++ b/third_party/build/patches/libfluid/libfluid_msg_patches/0002-Add-support-for-setting-OVS-reg8.patch
@@ -1,59 +1,50 @@
-From 605c7bf97554d9ca630414456b87ce9123e46bc1 Mon Sep 17 00:00:00 2001
-From: vagrant <vagrant@magma-dev>
-Date: Sat, 6 Mar 2021 01:09:31 +0000
-Subject: [PATCH 4/4] Add Reg field match support
+From d563f9caf7782f7d7d810de476d371f9a44c2806 Mon Sep 17 00:00:00 2001
+From: Pravin B Shelar <pbshelar@fb.com>
+Date: Tue, 15 Sep 2020 05:31:07 +0000
+Subject: [PATCH 2/4] Add support for setting OVS reg8
 
+Signed-off-by: Pravin B Shelar <pbshelar@fb.com>
 ---
- fluid/of13/of13match.cc  | 79 ++++++++++++++++++++++++++++++++++++++++++++++++
- fluid/of13/of13match.hh  | 32 ++++++++++++++++++++
- fluid/of13/openflow-13.h |  1 +
- 3 files changed, 112 insertions(+)
+ fluid/of13/of13match.cc  | 69 ++++++++++++++++++++++++++++++++++++++++
+ fluid/of13/of13match.hh  | 31 ++++++++++++++++++
+ fluid/of13/openflow-13.h |  2 ++
+ 3 files changed, 102 insertions(+)
 
 diff --git a/fluid/of13/of13match.cc b/fluid/of13/of13match.cc
-index f198f19..522f415 100644
+index 01b75e8..f198f19 100644
 --- a/fluid/of13/of13match.cc
 +++ b/fluid/of13/of13match.cc
-@@ -2868,5 +2868,84 @@ of_error NXMReg8::unpack(uint8_t *buffer) {
-     return 0;
+@@ -2799,5 +2799,74 @@ uint16_t Match::oxm_fields_len() {
+     return len;
  }
  
-+// ----- Reg 6
-+//
-+NXMRegX::NXMRegX()
-+    : OXMTLV(of13::OFPXMC_NXM_1, 0, false,
-+          of13::OFP_NXM_REGx_LEN),
++NXMReg8::NXMReg8()
++    : OXMTLV(of13::OFPXMC_NXM_1, of13::NXM_REG8, false,
++          of13::OFP_NXM_REG8_LEN),
 +      value_((uint32_t) 0),
 +      mask_((uint32_t) 0) {
 +    create_oxm_req(0x0800, 0, 0, 0);
 +}
 +
-+NXMRegX::NXMRegX(uint32_t type)
-+    : OXMTLV(of13::OFPXMC_NXM_1, type, false,
-+          of13::OFP_NXM_REGx_LEN),
-+      value_((uint32_t) 0),
-+      mask_((uint32_t) 0) {
-+    create_oxm_req(0x0800, 0, 0, 0);
-+}
-+
-+NXMRegX::NXMRegX(uint32_t type, uint32_t value)
-+    : OXMTLV(of13::OFPXMC_NXM_1, type, false,
-+          of13::OFP_NXM_REGx_LEN),
++NXMReg8::NXMReg8(uint32_t value)
++    : OXMTLV(of13::OFPXMC_NXM_1, of13::NXM_REG8, false,
++          of13::OFP_NXM_REG8_LEN),
 +      value_(value),
 +      mask_((uint32_t) 0) {
 +    create_oxm_req(0x0800, 0, 0, 0);
 +}
 +
-+NXMRegX::NXMRegX(uint32_t type, uint32_t value, uint32_t mask)
-+    : OXMTLV(of13::OFPXMC_NXM_1, type, true,
-+          of13::OFP_NXM_REGx_LEN),
++NXMReg8::NXMReg8(uint32_t value, uint32_t mask)
++    : OXMTLV(of13::OFPXMC_NXM_1, of13::NXM_REG8, true,
++          of13::OFP_NXM_REG8_LEN),
 +      value_(value),
 +      mask_(mask) {
 +    create_oxm_req(0x0800, 0, 0, 0);
 +}
 +
-+bool NXMRegX::equals(const OXMTLV &other) {
++bool NXMReg8::equals(const OXMTLV &other) {
 +
-+    if (const NXMRegX * field = dynamic_cast<const NXMRegX *>(&other)) {
++    if (const NXMReg8 * field = dynamic_cast<const NXMReg8 *>(&other)) {
 +        return ((OXMTLV::equals(other)) && (this->value_ == field->value_)
 +            && (this->has_mask_ ? this->mask_ == field->mask_ : true));
 +    }
@@ -62,15 +53,15 @@ index f198f19..522f415 100644
 +    }
 +}
 +
-+OXMTLV& NXMRegX::operator=(const OXMTLV& field) {
-+    const NXMRegX& dst = dynamic_cast<const NXMRegX&>(field);
++OXMTLV& NXMReg8::operator=(const OXMTLV& field) {
++    const NXMReg8& dst = dynamic_cast<const NXMReg8&>(field);
 +    OXMTLV::operator=(field);
 +    this->value_ = dst.value_;
 +    this->mask_ = dst.mask_;
 +    return *this;
 +}
 +
-+size_t NXMRegX::pack(uint8_t *buffer) {
++size_t NXMReg8::pack(uint8_t *buffer) {
 +    OXMTLV::pack(buffer);
 +    size_t len = this->length_;
 +    if (this->has_mask_) {
@@ -83,7 +74,7 @@ index f198f19..522f415 100644
 +    return 0;
 +}
 +
-+of_error NXMRegX::unpack(uint8_t *buffer) {
++of_error NXMReg8::unpack(uint8_t *buffer) {
 +    uint32_t val = *((uint32_t*) (buffer + of13::OFP_OXM_HEADER_LEN));
 +    OXMTLV::unpack(buffer);
 +    this->value_ = ntoh32(val);
@@ -99,28 +90,27 @@ index f198f19..522f415 100644
  } //End of namespace of13
  } //End of namespace fluid_msg
 diff --git a/fluid/of13/of13match.hh b/fluid/of13/of13match.hh
-index 5fb9699..9fd35cd 100644
+index cf659a2..5fb9699 100644
 --- a/fluid/of13/of13match.hh
 +++ b/fluid/of13/of13match.hh
-@@ -1208,6 +1208,38 @@ public:
+@@ -1177,6 +1177,37 @@ public:
      }
  };
  
-+class NXMRegX: public OXMTLV {
++class NXMReg8: public OXMTLV {
 +protected:
 +    uint32_t value_;
 +    uint32_t mask_;
 +public:
-+    NXMRegX();
-+    NXMRegX(uint32_t type);
-+    NXMRegX(uint32_t type, uint32_t value);
-+    NXMRegX(uint32_t type, uint32_t value, uint32_t mask);
-+    ~NXMRegX() {
++    NXMReg8();
++    NXMReg8(uint32_t value);
++    NXMReg8(uint32_t value, uint32_t mask);
++    ~NXMReg8() {
 +    }
 +    virtual bool equals(const OXMTLV & other);
 +    OXMTLV& operator=(const OXMTLV& field);
-+    virtual NXMRegX* clone() const {
-+        return new NXMRegX(*this);
++    virtual NXMReg8* clone() const {
++        return new NXMReg8(*this);
 +    }
 +    size_t pack(uint8_t *buffer);
 +    of_error unpack(uint8_t *buffer);
@@ -142,17 +132,25 @@ index 5fb9699..9fd35cd 100644
  private:
      /*Current tlvs present by field*/
 diff --git a/fluid/of13/openflow-13.h b/fluid/of13/openflow-13.h
-index 62a8500..e96bd1c 100644
+index d891f35..62a8500 100644
 --- a/fluid/of13/openflow-13.h
 +++ b/fluid/of13/openflow-13.h
-@@ -257,6 +257,7 @@ const uint8_t OFP_OXM_IPV6_PBB_ISID_LEN = 4;
+@@ -256,6 +256,7 @@ const uint8_t OFP_OXM_MPLS_BOS_LEN = 1;
+ const uint8_t OFP_OXM_IPV6_PBB_ISID_LEN = 4;
  const uint8_t OFP_OXM_TUNNEL_ID_LEN = 8;
  const uint8_t OFP_OXM_IPV6_EXTHDR_LEN = 2;
- const uint8_t OFP_NXM_REG8_LEN = 4;
-+const uint8_t OFP_NXM_REGx_LEN = 4;
++const uint8_t OFP_NXM_REG8_LEN = 4;
  
  /* Fields to match against flows */
  struct ofp_match {
+@@ -343,6 +344,7 @@ enum oxm_ofb_match_fields {
+ };
+ 
+ enum nxm_match_fields {
++  NXM_REG8 	      = 8,
+   NXM_TUNNEL_IPV4_DST = 32
+ };
+ 
 -- 
-2.11.0
+2.25.1
 

--- a/third_party/build/patches/libfluid/libfluid_msg_patches/0003-Add-Reg-field-match-support.patch
+++ b/third_party/build/patches/libfluid/libfluid_msg_patches/0003-Add-Reg-field-match-support.patch
@@ -1,50 +1,59 @@
-From f7bc581728e457a808da1f49313c57268141e1e1 Mon Sep 17 00:00:00 2001
-From: Pravin B Shelar <pbshelar@fb.com>
-Date: Tue, 15 Sep 2020 05:31:07 +0000
-Subject: [PATCH] Add support for setting OVS reg8
+From 1dacf98f50f51c6aca5168c11caca3931ce76984 Mon Sep 17 00:00:00 2001
+From: vagrant <vagrant@magma-dev>
+Date: Sat, 6 Mar 2021 01:09:31 +0000
+Subject: [PATCH 3/4] Add Reg field match support
 
-Signed-off-by: Pravin B Shelar <pbshelar@fb.com>
 ---
- fluid/of13/of13match.cc  | 69 ++++++++++++++++++++++++++++++++++++++++++++++++
- fluid/of13/of13match.hh  | 31 ++++++++++++++++++++++
- fluid/of13/openflow-13.h |  2 ++
- 3 files changed, 102 insertions(+)
+ fluid/of13/of13match.cc  | 79 ++++++++++++++++++++++++++++++++++++++++
+ fluid/of13/of13match.hh  | 32 ++++++++++++++++
+ fluid/of13/openflow-13.h |  1 +
+ 3 files changed, 112 insertions(+)
 
 diff --git a/fluid/of13/of13match.cc b/fluid/of13/of13match.cc
-index 01b75e8..f198f19 100644
+index f198f19..522f415 100644
 --- a/fluid/of13/of13match.cc
 +++ b/fluid/of13/of13match.cc
-@@ -2799,5 +2799,74 @@ uint16_t Match::oxm_fields_len() {
-     return len;
+@@ -2868,5 +2868,84 @@ of_error NXMReg8::unpack(uint8_t *buffer) {
+     return 0;
  }
  
-+NXMReg8::NXMReg8()
-+    : OXMTLV(of13::OFPXMC_NXM_1, of13::NXM_REG8, false,
-+          of13::OFP_NXM_REG8_LEN),
++// ----- Reg 6
++//
++NXMRegX::NXMRegX()
++    : OXMTLV(of13::OFPXMC_NXM_1, 0, false,
++          of13::OFP_NXM_REGx_LEN),
 +      value_((uint32_t) 0),
 +      mask_((uint32_t) 0) {
 +    create_oxm_req(0x0800, 0, 0, 0);
 +}
 +
-+NXMReg8::NXMReg8(uint32_t value)
-+    : OXMTLV(of13::OFPXMC_NXM_1, of13::NXM_REG8, false,
-+          of13::OFP_NXM_REG8_LEN),
++NXMRegX::NXMRegX(uint32_t type)
++    : OXMTLV(of13::OFPXMC_NXM_1, type, false,
++          of13::OFP_NXM_REGx_LEN),
++      value_((uint32_t) 0),
++      mask_((uint32_t) 0) {
++    create_oxm_req(0x0800, 0, 0, 0);
++}
++
++NXMRegX::NXMRegX(uint32_t type, uint32_t value)
++    : OXMTLV(of13::OFPXMC_NXM_1, type, false,
++          of13::OFP_NXM_REGx_LEN),
 +      value_(value),
 +      mask_((uint32_t) 0) {
 +    create_oxm_req(0x0800, 0, 0, 0);
 +}
 +
-+NXMReg8::NXMReg8(uint32_t value, uint32_t mask)
-+    : OXMTLV(of13::OFPXMC_NXM_1, of13::NXM_REG8, true,
-+          of13::OFP_NXM_REG8_LEN),
++NXMRegX::NXMRegX(uint32_t type, uint32_t value, uint32_t mask)
++    : OXMTLV(of13::OFPXMC_NXM_1, type, true,
++          of13::OFP_NXM_REGx_LEN),
 +      value_(value),
 +      mask_(mask) {
 +    create_oxm_req(0x0800, 0, 0, 0);
 +}
 +
-+bool NXMReg8::equals(const OXMTLV &other) {
++bool NXMRegX::equals(const OXMTLV &other) {
 +
-+    if (const NXMReg8 * field = dynamic_cast<const NXMReg8 *>(&other)) {
++    if (const NXMRegX * field = dynamic_cast<const NXMRegX *>(&other)) {
 +        return ((OXMTLV::equals(other)) && (this->value_ == field->value_)
 +            && (this->has_mask_ ? this->mask_ == field->mask_ : true));
 +    }
@@ -53,15 +62,15 @@ index 01b75e8..f198f19 100644
 +    }
 +}
 +
-+OXMTLV& NXMReg8::operator=(const OXMTLV& field) {
-+    const NXMReg8& dst = dynamic_cast<const NXMReg8&>(field);
++OXMTLV& NXMRegX::operator=(const OXMTLV& field) {
++    const NXMRegX& dst = dynamic_cast<const NXMRegX&>(field);
 +    OXMTLV::operator=(field);
 +    this->value_ = dst.value_;
 +    this->mask_ = dst.mask_;
 +    return *this;
 +}
 +
-+size_t NXMReg8::pack(uint8_t *buffer) {
++size_t NXMRegX::pack(uint8_t *buffer) {
 +    OXMTLV::pack(buffer);
 +    size_t len = this->length_;
 +    if (this->has_mask_) {
@@ -74,7 +83,7 @@ index 01b75e8..f198f19 100644
 +    return 0;
 +}
 +
-+of_error NXMReg8::unpack(uint8_t *buffer) {
++of_error NXMRegX::unpack(uint8_t *buffer) {
 +    uint32_t val = *((uint32_t*) (buffer + of13::OFP_OXM_HEADER_LEN));
 +    OXMTLV::unpack(buffer);
 +    this->value_ = ntoh32(val);
@@ -90,27 +99,28 @@ index 01b75e8..f198f19 100644
  } //End of namespace of13
  } //End of namespace fluid_msg
 diff --git a/fluid/of13/of13match.hh b/fluid/of13/of13match.hh
-index cf659a2..5fb9699 100644
+index 5fb9699..9fd35cd 100644
 --- a/fluid/of13/of13match.hh
 +++ b/fluid/of13/of13match.hh
-@@ -1177,6 +1177,37 @@ public:
+@@ -1208,6 +1208,38 @@ public:
      }
  };
  
-+class NXMReg8: public OXMTLV {
++class NXMRegX: public OXMTLV {
 +protected:
 +    uint32_t value_;
 +    uint32_t mask_;
 +public:
-+    NXMReg8();
-+    NXMReg8(uint32_t value);
-+    NXMReg8(uint32_t value, uint32_t mask);
-+    ~NXMReg8() {
++    NXMRegX();
++    NXMRegX(uint32_t type);
++    NXMRegX(uint32_t type, uint32_t value);
++    NXMRegX(uint32_t type, uint32_t value, uint32_t mask);
++    ~NXMRegX() {
 +    }
 +    virtual bool equals(const OXMTLV & other);
 +    OXMTLV& operator=(const OXMTLV& field);
-+    virtual NXMReg8* clone() const {
-+        return new NXMReg8(*this);
++    virtual NXMRegX* clone() const {
++        return new NXMRegX(*this);
 +    }
 +    size_t pack(uint8_t *buffer);
 +    of_error unpack(uint8_t *buffer);
@@ -132,25 +142,17 @@ index cf659a2..5fb9699 100644
  private:
      /*Current tlvs present by field*/
 diff --git a/fluid/of13/openflow-13.h b/fluid/of13/openflow-13.h
-index d891f35..62a8500 100644
+index 62a8500..e96bd1c 100644
 --- a/fluid/of13/openflow-13.h
 +++ b/fluid/of13/openflow-13.h
-@@ -256,6 +256,7 @@ const uint8_t OFP_OXM_MPLS_BOS_LEN = 1;
- const uint8_t OFP_OXM_IPV6_PBB_ISID_LEN = 4;
+@@ -257,6 +257,7 @@ const uint8_t OFP_OXM_IPV6_PBB_ISID_LEN = 4;
  const uint8_t OFP_OXM_TUNNEL_ID_LEN = 8;
  const uint8_t OFP_OXM_IPV6_EXTHDR_LEN = 2;
-+const uint8_t OFP_NXM_REG8_LEN = 4;
+ const uint8_t OFP_NXM_REG8_LEN = 4;
++const uint8_t OFP_NXM_REGx_LEN = 4;
  
  /* Fields to match against flows */
  struct ofp_match {
-@@ -343,6 +344,7 @@ enum oxm_ofb_match_fields {
- };
- 
- enum nxm_match_fields {
-+  NXM_REG8 	      = 8,
-   NXM_TUNNEL_IPV4_DST = 32
- };
- 
 -- 
-2.11.0
+2.25.1
 

--- a/third_party/build/patches/libfluid/libfluid_msg_patches/0004-Add-TunnelIPv6Dst-support.patch
+++ b/third_party/build/patches/libfluid/libfluid_msg_patches/0004-Add-TunnelIPv6Dst-support.patch
@@ -1,0 +1,149 @@
+From e4cf47a607d670007437bae43c0698880ac501fc Mon Sep 17 00:00:00 2001
+From: Nick Yurchenko <urchennko@gmail.com>
+Date: Mon, 4 Oct 2021 19:22:18 +0000
+Subject: [PATCH 4/4] Add TunnelIPv6Dst support
+
+Signed-off-by: Nick Yurchenko <urchennko@gmail.com>
+---
+ fluid/of13/of13match.cc  | 67 ++++++++++++++++++++++++++++++++++++++++
+ fluid/of13/of13match.hh  | 31 +++++++++++++++++++
+ fluid/of13/openflow-13.h |  3 +-
+ 3 files changed, 100 insertions(+), 1 deletion(-)
+
+diff --git a/fluid/of13/of13match.cc b/fluid/of13/of13match.cc
+index 522f415..2ab36ed 100644
+--- a/fluid/of13/of13match.cc
++++ b/fluid/of13/of13match.cc
+@@ -2262,6 +2262,73 @@ of_error TunnelIPv4Dst::unpack(uint8_t *buffer) {
+     return 0;
+ }
+ 
++TunnelIPv6Dst::TunnelIPv6Dst()
++    : OXMTLV(of13::OFPXMC_NXM_1, of13::NXM_TUNNEL_IPV6_DST, false,
++          of13::OFP_OXM_IPV6_LEN),
++      value_((uint32_t) 0),
++      mask_((uint32_t) 0) {
++    create_oxm_req(0x86dd, 0, 0, 0);
++}
++
++TunnelIPv6Dst::TunnelIPv6Dst(IPAddress value)
++    : OXMTLV(of13::OFPXMC_NXM_1, of13::NXM_TUNNEL_IPV6_DST, false,
++          of13::OFP_OXM_IPV6_LEN),
++      value_(value),
++      mask_((uint32_t) 0) {
++    create_oxm_req(0x86dd, 0, 0, 0);
++}
++
++TunnelIPv6Dst::TunnelIPv6Dst(IPAddress value, IPAddress mask)
++    : OXMTLV(of13::OFPXMC_NXM_1, of13::NXM_TUNNEL_IPV6_DST, true,
++          of13::OFP_OXM_IPV6_LEN),
++      value_(value),
++      mask_(mask) {
++    create_oxm_req(0x86dd, 0, 0, 0);
++}
++
++bool TunnelIPv6Dst::equals(const OXMTLV &other) {
++
++    if (const TunnelIPv6Dst * field = dynamic_cast<const TunnelIPv6Dst *>(&other)) {
++        return ((OXMTLV::equals(other)) && (this->value_ == field->value_)
++            && (this->has_mask_ ? this->mask_ == field->mask_ : true));
++    }
++    else {
++        return false;
++    }
++}
++
++OXMTLV& TunnelIPv6Dst::operator=(const OXMTLV& field) {
++    const TunnelIPv6Dst& dst = dynamic_cast<const TunnelIPv6Dst&>(field);
++    OXMTLV::operator=(field);
++    this->value_ = dst.value_;
++    this->mask_ = dst.mask_;
++    return *this;
++}
++
++size_t TunnelIPv6Dst::pack(uint8_t *buffer) {
++    OXMTLV::pack(buffer);
++    size_t len = this->length_;
++    if (this->has_mask_) {
++        len = this->length_ / 2;
++        memcpy(buffer + (of13::OFP_OXM_HEADER_LEN + len), this->mask_.getIPv6(),
++                    len);
++    }
++    memcpy(buffer + of13::OFP_OXM_HEADER_LEN, this->value_.getIPv6(), len);
++    return 0;
++}
++
++of_error TunnelIPv6Dst::unpack(uint8_t *buffer) {
++    struct in6_addr *ip =
++            (struct in6_addr *) (buffer + of13::OFP_OXM_HEADER_LEN);
++    OXMTLV::unpack(buffer);
++    this->value_ = IPAddress(*ip);
++    if (this->has_mask_) {
++        size_t len = this->length_ / 2;
++        ip += 1;
++        this->mask_ = IPAddress(*ip);
++    }
++    return 0;
++}
+ 
+ IPv6Exthdr::IPv6Exthdr()
+     : mask_(0),
+diff --git a/fluid/of13/of13match.hh b/fluid/of13/of13match.hh
+index 9fd35cd..5780370 100644
+--- a/fluid/of13/of13match.hh
++++ b/fluid/of13/of13match.hh
+@@ -1146,6 +1146,37 @@ public:
+     }
+ };
+ 
++class TunnelIPv6Dst: public OXMTLV {
++protected:
++    IPAddress value_;
++    IPAddress mask_;
++public:
++    TunnelIPv6Dst();
++    TunnelIPv6Dst(IPAddress value);
++    TunnelIPv6Dst(IPAddress value, IPAddress mask);
++    ~TunnelIPv6Dst() {
++    }
++    virtual bool equals(const OXMTLV & other);
++    OXMTLV& operator=(const OXMTLV& field);
++    virtual TunnelIPv6Dst* clone() const {
++        return new TunnelIPv6Dst(*this);
++    }
++    size_t pack(uint8_t *buffer);
++    of_error unpack(uint8_t *buffer);
++    IPAddress value() const {
++        return this->value_;
++    }
++    IPAddress mask() const {
++        return this->mask_;
++    }
++    void value(IPAddress value) {
++        this->value_ = value;
++    }
++    void mask(IPAddress mask) {
++        this->mask_ = mask;
++    }
++};
++
+ class IPv6Exthdr: public OXMTLV {
+ private:
+     uint16_t value_;
+diff --git a/fluid/of13/openflow-13.h b/fluid/of13/openflow-13.h
+index e96bd1c..7fa030a 100644
+--- a/fluid/of13/openflow-13.h
++++ b/fluid/of13/openflow-13.h
+@@ -346,7 +346,8 @@ enum oxm_ofb_match_fields {
+ 
+ enum nxm_match_fields {
+   NXM_REG8 	      = 8,
+-  NXM_TUNNEL_IPV4_DST = 32
++  NXM_TUNNEL_IPV4_DST = 32,
++  NXM_TUNNEL_IPV6_DST = 110
+ };
+ 
+ /* The VLAN id is 12-bits, so we can use the entire 16 bits to indicate
+-- 
+2.25.1
+


### PR DESCRIPTION
Signed-off-by: Nick Yurchenko <koolzz@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary
To support ipv6 underlay libfluid needs to support ipv6tundst

## Test Plan

did some hand testing by forcing mme to use a fake ipv6 addr
```
 cookie=0x0, duration=3.185s, table=0, n_packets=0, n_bytes=0, priority=10,ip,in_port=LOCAL,nw_dst=192.168.128.12 actions=load:0xa000128->NXM_NX_TUN_ID[],load:0x1->NXM_NX_TUN_IPV6_DST[0..63],load:0x20010db800000000->NXM_NX_TUN_IPV6_DST[64..127],load:0x3->NXM_NX_REG8[],load:0x10->NXM_NX_REG9[],mod_dl_dst:ff:ff:ff:ff:ff:ff,load:0x7594587a00d->OXM_OF_METADATA[],resubmit(,1)
 cookie=0x0, duration=3.185s, table=0, n_packets=0, n_bytes=0, priority=10,ip,in_port=mtr0,nw_dst=192.168.128.12 actions=load:0xa000128->NXM_NX_TUN_ID[],load:0x1->NXM_NX_TUN_IPV6_DST[0..63],load:0x20010db800000000->NXM_NX_TUN_IPV6_DST[64..127],load:0x3->NXM_NX_REG8[],load:0x10->NXM_NX_REG9[],mod_dl_dst:ff:ff:ff:ff:ff:ff,load:0x7594587a00d->OXM_OF_METADATA[],resubmit(,1)
 ```

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
