### PR TITLE
feat: add system level bazelrcs to make building easier in various sy…

### DIFF
--- a/.bazelignore
+++ b/.bazelignore
@@ -1,3 +1,5 @@
+.bazel-cache/
+.bazel-cache-repo/
 .cache
 orc8r/cloud/docker/metrics-configs/alert_rules
 nms/app/node_modules

--- a/.bazelrc
+++ b/.bazelrc
@@ -29,3 +29,6 @@ build:asan --copt=-O0
 build:asan --copt=-fno-omit-frame-pointer
 build:asan --linkopt=-fsanitize=address
 build:asan --action_env=ASAN_OPTIONS=detect_leaks=1:color=always
+
+# system bazelrc should include config specific to different build envs (--config=vm, --config=devcontainer, etc.)
+try-import /etc/bazelrc

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -313,4 +313,6 @@ RUN go get -v golang.org/x/tools/gopls
 #### Update shared library configuration
 RUN ldconfig -v
 
+RUN ln -s /magma/experimental/bazel-base/bazelrcs/devcontainer.bazelrc /etc/bazelrc
+
 WORKDIR /workspaces/magma

--- a/experimental/bazel-base/Dockerfile
+++ b/experimental/bazel-base/Dockerfile
@@ -87,4 +87,6 @@ RUN git clone --branch v4.3 https://github.com/mfontanini/libtins.git && \
 #### Update shared library configuration
 RUN ldconfig -v
 
+RUN ln -s /magma/experimental/bazel-base/bazelrcs/docker.bazelrc /etc/bazelrc
+
 WORKDIR /magma

--- a/experimental/bazel-base/bazelrcs/devcontainer.bazelrc
+++ b/experimental/bazel-base/bazelrcs/devcontainer.bazelrc
@@ -1,0 +1,1 @@
+common --config=devcontainer

--- a/experimental/bazel-base/bazelrcs/docker.bazelrc
+++ b/experimental/bazel-base/bazelrcs/docker.bazelrc
@@ -1,0 +1,1 @@
+common --config=docker

--- a/experimental/bazel-base/bazelrcs/vm.bazelrc
+++ b/experimental/bazel-base/bazelrcs/vm.bazelrc
@@ -1,0 +1,1 @@
+common --config=vm

--- a/experimental/bazel-base/docker-compose.yml
+++ b/experimental/bazel-base/docker-compose.yml
@@ -7,4 +7,5 @@ services:
         volumes:
             - ${MAGMA_ROOT}:/magma
             - ${MAGMA_ROOT}/lte/gateway/configs:/etc/magma
+            - /tmp/bazel:/tmp/bazel
         working_dir: /magma

--- a/lte/gateway/deploy/roles/magma/tasks/main.yml
+++ b/lte/gateway/deploy/roles/magma/tasks/main.yml
@@ -428,3 +428,10 @@
     pkg:
       - clangd-12
   retries: 5
+
+- name: Symlink system wide bazelrc into the VM
+  file:
+    src: '/home/vagrant/magma/experimental/bazel-base/bazelrcs/vm.bazelrc'
+    path: '/etc/bazelrc'
+    state: link
+    force: yes

--- a/vscode-workspaces/workspace.magma-vm-workspace.code-workspace
+++ b/vscode-workspaces/workspace.magma-vm-workspace.code-workspace
@@ -20,10 +20,8 @@
 			"**/.bazel-cache-repo/**": true,
 		},		
 		"bsv.bazel.buildFlags": [
-			"--config=vm",
 		],
 		"bsv.bazel.testFlags": [
-			"--compilation_mode=dbg",
 		],
 		"bsv.bes.enabled": false,
 		"bsv.bzl.codesearch.enabled": false,
@@ -42,7 +40,7 @@
 		],
 		"clangd.onConfigChanged": "restart",
 		"bsv.cc.compdb.targets": [
-			"//lte/gateway/c/session_manager:sessiond"
+			"//lte/gateway/c/session_manager:sessiond",
 		]
 	},
 }


### PR DESCRIPTION
…stems

Signed-off-by: Marie Bremner <marwhal@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary
It gets annoying to always add the --config=docker/devcontainer/vm depending on different underlying build environments. Add a system level bazelrc at /etc/bazelrc so that this can be done implicitly.

When running bazel build ... in the magma VM , bazel will import the --config=vm flag from the system bazelrc. 

<!-- Enumerate changes you made and why you made them -->

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
