### PR TITLE
fix: Fix show-tech tool checksum errors

### DIFF
--- a/show-tech/constants.yml
+++ b/show-tech/constants.yml
@@ -11,7 +11,7 @@ general_commands:
   - "uname -a"
   - "top -b -n 1"
   - "df -kh"
-debian_commands:
+ubuntu_commands:
   - "dpkg -l magma*"
   - "dpkg -l *openvswitch*"
   - "ovs-vsctl show"
@@ -35,7 +35,8 @@ debian_commands:
 # files to collect from src to relative destination in tar.gz package
 paths_to_collect:
   - "/var/opt/magma/configs/*"
-  - "/etc/magma/configs/*"
+  - "/etc/magma/*"
+  - "/etc/magma/templates/*"
   - "/etc/systemd/system/*"
   - "/usr/local/bin/mme"
   - "/var/core/*"

--- a/show-tech/roles/commands/tasks/main.yml
+++ b/show-tech/roles/commands/tasks/main.yml
@@ -18,6 +18,6 @@
   ignore_errors: yes
   loop: "{{general_commands}}"
 
-- name: Run debian commands
+- name: Run ubuntu commands
   when: ansible_facts['distribution'] == 'Debian' or ansible_facts['distribution'] == 'Ubuntu'
-  include_tasks: debian.yml
+  include_tasks: ubuntu.yml

--- a/show-tech/roles/commands/tasks/ubuntu.yml
+++ b/show-tech/roles/commands/tasks/ubuntu.yml
@@ -11,9 +11,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License
 
-- name: Get output of debian commands
+- name: Get output of ubuntu commands
   shell: |
     ( echo Command: {{item}} && {{item}} ) | tee -a {{ report_dir_output.stdout }}/commands_output.log
   register: output
   ignore_errors: yes
-  loop: "{{debian_commands}}"
+  loop: "{{ubuntu_commands}}"

--- a/show-tech/roles/files/tasks/main.yml
+++ b/show-tech/roles/files/tasks/main.yml
@@ -12,17 +12,11 @@
 # limitations under the License
 
 # Magma files collection based on map paths_to_collect
-- name: Create a dest directory for magma files under report directory
-  file:
-    path: "{{report_dir_output.stdout}}/{{item | dirname}}"
-    state: directory
-    mode: "0700"
-  with_fileglob: "{{paths_to_collect}}"
 
-
-
-- name: Copy magma files to destination
-  copy:
+- name: Fetch magma files to destination
+  fetch:
     src: "{{item}}"
-    dest: "{{report_dir_output.stdout }}/{{item | dirname}}"
+    dest: "{{report_dir_output.stdout }}/{{item | dirname}}/"
+    flat: yes
+    validate_checksum: no
   with_fileglob: "{{paths_to_collect}}"


### PR DESCRIPTION
<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

- Change copy module with fetch module. Copy module always do checksum validation, for logs that changes very fast(syslogs) the task kept failing due to checksum errors. Fetch module has the option to set `validate_checksum: no`
- There was an error in getting the /etc/magma/ configuration. Fixing the path
- Renaming "debian" with "ubuntu" in some commands.

## Test Plan

- Updated playbook has been tested in my local environment and one production AGW.

