### PR TITLE
fix(mme): migrate to unique_ptr to release allocation on exception

### DIFF
--- a/lte/gateway/c/core/oai/tasks/mme_app/mme_app_state_converter.cpp
+++ b/lte/gateway/c/core/oai/tasks/mme_app/mme_app_state_converter.cpp
@@ -24,6 +24,7 @@ extern "C" {
 }
 
 #include "mme_app_state_converter.h"
+#include <memory>
 #include "nas_state_converter.h"
 
 namespace magma {
@@ -177,19 +178,19 @@ void MmeNasStateConverter::proto_to_guti_table(
     const google::protobuf::Map<std::string, unsigned long>& proto_map,
     obj_hash_table_uint64_t* guti_htbl) {
   for (auto const& kv : proto_map) {
-    mme_ue_s1ap_id_t mme_ue_id = kv.second;
-    guti_t* guti_p             = (guti_t*) calloc(1, sizeof(guti_t));
+    mme_ue_s1ap_id_t mme_ue_id   = kv.second;
+    std::unique_ptr<guti_t> guti = std::make_unique<guti_t>();
+    memset(guti.get(), 0, sizeof(guti_t));
 
-    mme_app_convert_string_to_guti(guti_p, kv.first);
+    mme_app_convert_string_to_guti(guti.get(), kv.first);
     hashtable_rc_t ht_rc = obj_hashtable_uint64_ts_insert(
-        guti_htbl, guti_p, sizeof(*guti_p), mme_ue_id);
+        guti_htbl, guti.get(), sizeof(guti.get()), mme_ue_id);
     if (ht_rc != HASH_TABLE_OK) {
       OAILOG_ERROR(
           LOG_MME_APP,
           "Failed to insert mme_ue_s1ap_id %u in GUTI table, error: %s\n",
           mme_ue_id, hashtable_rc_code2string(ht_rc));
     }
-    free_wrapper((void**) &guti_p);
   }
 }
 


### PR DESCRIPTION
## Summary

I realize that state converter logic may be deprecated at some point with the C++ / proto encoding work. Regardless, might as well land this PR.

This fixup is required for #6903 and is enumerated in #7136.  The new randomized state converter property test sometimes throws an exception when converting some string fields to integers.  This results in ASAN failures by the unit test, as memory is leaked by some allocations when exceptions are thrown.

This PR wraps the allocation that is leaking - with a unique ptr. Ensuring cleanup even when exceptions are thrown.

## Test Plan

Unit tests, property tests, and `lte integ_test`.

Signed-off-by: Scott Moeller <electronjoe@gmail.com>