### PR TITLE
fix(agw): backport-v1.6: restore SGi bridge flows to keep connectivit…

### DIFF
--- a/lte/gateway/deploy/roles/magma/files/magma-bridge-reset.sh
+++ b/lte/gateway/deploy/roles/magma/files/magma-bridge-reset.sh
@@ -1,0 +1,131 @@
+#!/bin/bash
+# Copyright 2021 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+GTP_BR="gtp_br0"
+
+# ARG 1
+# -f: force reload kmod and OVS restart
+# -y: reload kmod and restart OVS in case uplink-br is not configured
+# any other value: restart OVS in case uplink-br is not configured
+
+KMOD_RELOAD=${1:-""}
+
+# ARG 2
+# uplink bridge name
+SGI_BR=${2:-"uplink_br0"}
+
+# ARG 3: used to detect Non-NAT
+# sgi port name.
+SGI_PORT=$(ovs-ofctl show "$SGI_BR"|grep eth|cut -d'(' -f2|cut -d')' -f1)
+if [[ -z $SGI_PORT ]];
+then
+  # This is Non-NAT case, SGi-port is egress interface
+  SGI_PORT=$3
+fi
+
+# ARG 4
+# static SGi IP
+SGI_IP=$(ip a sh "$SGI_BR"|grep 'inet ' |awk '{print $2}')
+if [[ -z $SGI_IP ]];
+then
+  SGI_IP=$4
+else
+  SGI_IP_SET="true"
+fi
+
+# ARG 5
+# SGi network GW IP.
+SGI_DEF_GW=$(ip r sh|grep default|grep "$SGI_BR"| awk '{print $3}')
+if [[ -z $SGI_DEF_GW ]];
+then
+  SGI_DEF_GW=$5
+fi
+
+
+if [[ "$KMOD_RELOAD" != '-f' ]];
+then
+  if [[ $SGI_IP_SET == "true" ]];
+  then
+    echo "Uplink-br has IP address. dont reset the bridge"
+    ifdown "$GTP_BR"
+    ifdown patch-up
+    sleep 1
+    ifup "$GTP_BR"
+    ifup patch-up
+    exit 0
+  fi
+fi
+# local variables
+FLOW_DUMP="$(mktemp)"
+
+#check DHCP client
+DHCP_PID=$(pgrep -a 'dhclient' | grep "$SGI_BR" | awk '{print $1}')
+if [[ -n $DHCP_PID ]];
+then
+  for pid in $DHCP_PID
+  do
+    kill "$pid"
+  done
+fi
+
+# start reset procedure:
+# save flows
+ovs-ofctl dump-flows --no-names --no-stats "$SGI_BR" | \
+            sed -e '/NXST_FLOW/d' \
+                -e '/OFPST_FLOW/d' \
+                -e 's/\(idle\|hard\)_age=[^,]*,//g' > "$FLOW_DUMP"
+
+# remove OVS objects
+ovs-vsctl --all destroy Flow_Sample_Collector_Set
+
+ifdown "$SGI_BR"
+ifdown "$GTP_BR"
+ifdown patch-up
+if [ "$KMOD_RELOAD" != '-y' ] && [ "$KMOD_RELOAD" != '-f' ];
+then
+  service openvswitch-switch restart
+else
+  /etc/init.d/openvswitch-switch  force-reload-kmod
+fi
+
+# create OVS objects
+sleep 1
+ifup "$SGI_BR"
+ifup "$GTP_BR"
+ifup patch-up
+sleep 1
+
+if [[ -n $SGI_PORT ]];
+then
+  ovs-vsctl --may-exist add-port "$SGI_BR" "$SGI_PORT"
+  ip link set dev "$SGI_PORT"  up
+fi
+
+# restore OVS flows
+ovs-ofctl del-flows "$SGI_BR"
+ovs-ofctl add-flows "$SGI_BR" "$FLOW_DUMP"
+rm "$FLOW_DUMP"
+
+# start DHCP client if needed
+if [[ -n $DHCP_PID ]];
+then
+  dhclient "$SGI_BR" &
+else
+  #restore IP config
+  if [[ -n $SGI_IP ]];
+  then
+    ip a add "$SGI_IP" dev "$SGI_BR"
+  fi
+  if [[ -n $SGI_DEF_GW ]];
+  then
+    ip r add default via "$SGI_DEF_GW"
+  fi
+fi

--- a/lte/gateway/deploy/roles/magma/files/ovs-kmod-upgrade.sh
+++ b/lte/gateway/deploy/roles/magma/files/ovs-kmod-upgrade.sh
@@ -31,15 +31,9 @@ apt install -y  openvswitch-datapath-dkms libopenvswitch openvswitch-common open
 
 dkms autoinstall
 service magma@* stop
-sleep 5
-ifdown gtp_br0
-ifdown uplink_br0
-sleep 5
-/etc/init.d/openvswitch-switch  force-reload-kmod
-sleep 5
-ifup uplink_br0
-ifup gtp_br0
-sleep 5
+
+magma-bridge-reset.sh -f uplink_br0
+
 service magma@magmad start
 
 kernel_ver=$(cat /sys/module/openvswitch/srcversion)

--- a/lte/gateway/deploy/roles/magma/tasks/main.yml
+++ b/lte/gateway/deploy/roles/magma/tasks/main.yml
@@ -80,6 +80,10 @@
   copy: src=set_irq_affinity dest=/usr/local/bin/set_irq_affinity mode=751
   when: full_provision
 
+- name: Copy magma-bridge-reset.sh
+  copy: src=magma-bridge-reset.sh dest=/usr/local/bin/magma-bridge-reset.sh mode=751
+  when: full_provision
+
 - name: Add the sysctl config from the step before
   become: yes
   command: 'sysctl -p /etc/sysctl.d/99-magma.conf'

--- a/lte/gateway/python/scripts/config_stateless_agw.py
+++ b/lte/gateway/python/scripts/config_stateless_agw.py
@@ -23,11 +23,14 @@ import time
 from enum import Enum
 
 from magma.common.redis.client import get_default_client
+from magma.configuration.mconfig_managers import get_mconfig_manager
+
 from magma.configuration.service_configs import (
     load_override_config,
     load_service_config,
     save_override_config,
 )
+from lte.protos.mconfig import mconfigs_pb2
 
 return_codes = Enum(
     "return_codes", "STATELESS STATEFUL CORRUPT INVALID", start=0
@@ -160,21 +163,34 @@ def disable_stateless_agw():
 
 
 def ovs_reset_bridges():
+    mconfig = get_mconfig_manager().load_service_mconfig(
+        'pipelined', mconfigs_pb2.PipelineD(),
+    )
     service_config = load_service_config('pipelined')
-    sgi_interface = service_config['nat_iface']
-    if_up_cmd = "ip link set dev %s up" % sgi_interface
-    subprocess.call(if_up_cmd.split())
-    print("ip up cmd %s", if_up_cmd)
+    if service_config.get('enable_nat', mconfig.nat_enabled):
+        non_nat_sgi_interface = ""
+        sgi_management_iface_ip_addr = ""
+        sgi_management_iface_gw = ""
+    else:
+        non_nat_sgi_interface = service_config['nat_iface']
+        sgi_management_iface_ip_addr = service_config.get(
+           'sgi_management_iface_ip_addr', mconfig.sgi_management_iface_ip_addr,
+        )
+        sgi_management_iface_gw = service_config.get(
+           'sgi_management_iface_gw', mconfig.sgi_management_iface_gw,
+        )
 
-    subprocess.call(
-        "ovs-vsctl --all destroy Flow_Sample_Collector_Set".split())
-    subprocess.call("ifdown uplink_br0".split())
-    subprocess.call("ifdown gtp_br0".split())
-    subprocess.call("ifdown patch-up".split())
-    subprocess.call("service openvswitch-switch restart".split())
-    subprocess.call("ifup uplink_br0".split())
-    subprocess.call("ifup gtp_br0".split())
-    subprocess.call("ifup patch-up".split())
+    sgi_bridge_name = service_config.get('uplink_bridge', "uplink_br0")
+
+    reset_br = "magma-bridge-reset.sh -n %s %s %s %s" % \
+               (
+                   sgi_bridge_name,
+                   non_nat_sgi_interface,
+                   sgi_management_iface_ip_addr,
+                   sgi_management_iface_gw,
+               )
+    print("ovs-restart: ", reset_br)
+    subprocess.call(reset_br.split())
 
 
 def sctpd_pre_start():

--- a/lte/gateway/release/build-magma.sh
+++ b/lte/gateway/release/build-magma.sh
@@ -422,6 +422,7 @@ ${MAGMA_ROOT}/lte/gateway/release/stretch_snapshot=/usr/local/share/magma/ \
 ${MAGMA_ROOT}/orc8r/tools/ansible/roles/fluent_bit/files/60-fluent-bit.conf=/etc/rsyslog.d/60-fluent-bit.conf \
 ${ANSIBLE_FILES}/set_irq_affinity=/usr/local/bin/ \
 ${ANSIBLE_FILES}/ovs-kmod-upgrade.sh=/usr/local/bin/ \
+${ANSIBLE_FILES}/magma-bridge-reset.sh=/usr/local/bin/ \
 ${PY_PROTOS}=${PY_DEST} \
 $(glob_files "${PY_TMP_BUILD}/${PY_TMP_BUILD_SUFFIX}/${PKGNAME}*" ${PY_DEST}) \
 $(glob_files "${PY_TMP_BUILD}/${PY_TMP_BUILD_SUFFIX}/*.egg-info" ${PY_DEST}) \


### PR DESCRIPTION
…y. (#8146)

In case AGW service crash loop, the bridged mode AGW can
completely loose connectivity due to OVS reset done by
service monitoring the crash loop.
Following PR restores flows to keep the connectivity
to AGW via SGi interface.

Signed-off-by: Pravin B Shelar <pbshelar@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
