### PR TITLE
fix(ci): Force destroy locked magma-dev vm

### DIFF
--- a/circleci/fabfile.py
+++ b/circleci/fabfile.py
@@ -95,6 +95,14 @@ def integ_test(
     try:
         _set_host_for_lease(lease, node_ssh_key)
         _checkout_code(repo, branch, sha1, tag, pr_num, magma_root)
+        # Try to destroy all vm with vagrant destroy and workarround locked virtualbox vm
+        run(
+            "vagrant global-status 2>/dev/null | "
+            "awk '/virtualbox/{print $1}' | "
+            "xargs -I {} vagrant destroy -f {}"
+            "&> >(grep -oP '(?<=\"unregistervm\", \").*(?=\",)') | "
+            "xargs -I {} vboxmanage startvm {} --type emergencystop",
+        )
         # Destroy all running vagrant VMs. If we use the same node to run integ
         # tests on more than one repo, Vagrant will complain about colliding
         # VM names.


### PR DESCRIPTION
Signed-off-by: quentinDERORY <15911421+quentinDERORY@users.noreply.github.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary
Magma-dev box is sometimes in process of deletion and unable to be deleted by vagrant
This address this issue


## Test Plan

Tested on PR

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
