### PR TITLE
fix(mme): remove memory leak on migrated esm ebr timer

### DIFF
--- a/lte/gateway/c/core/oai/tasks/nas/esm/esm_ebr.c
+++ b/lte/gateway/c/core/oai/tasks/nas/esm/esm_ebr.c
@@ -288,6 +288,7 @@ status_code_e esm_ebr_start_timer(
     // Re-start the retransmission timer
     nas_timer_stop(&(ebr_ctx->timer));
     nas_timer_start(&(ebr_ctx->timer), cb, &timer_args);
+    esm_ebr_timer_data = ebr_ctx->args;
   } else {
     /*
      * If timer-id is set to NAS_TIMER_INACTIVE_ID and has non-null

--- a/lte/gateway/c/core/oai/tasks/nas/esm/esm_ebr.c
+++ b/lte/gateway/c/core/oai/tasks/nas/esm/esm_ebr.c
@@ -192,13 +192,11 @@ status_code_e esm_ebr_release(emm_context_t* emm_context, ebi_t ebi) {
         "ESM-FSM   - Stop retransmission timer %ld for ue "
         "id " MME_UE_S1AP_ID_FMT "\n",
         ebr_ctx->timer.id, ue_mm_context->mme_ue_s1ap_id);
-    esm_ebr_timer_data_t* esm_ebr_timer_data = NULL;
+    esm_ebr_timer_data_t* esm_ebr_timer_data = ebr_ctx->args;
     // stop the timer if it's running
     if (ebr_ctx->timer.id != NAS_TIMER_INACTIVE_ID) {
       nas_timer_stop(&(ebr_ctx->timer));
-    } else {  // Timer has expired, release the args
-      esm_ebr_timer_data = ebr_ctx->args;
-    }
+    } 
     /*
      * Release the retransmisison timer parameters
      */
@@ -383,12 +381,12 @@ status_code_e esm_ebr_stop_timer(emm_context_t* emm_context, ebi_t ebi) {
   /*
    * Stop the retransmission timer if still running
    */
-  if (ebr_ctx->timer.id != NAS_TIMER_INACTIVE_ID) {
+  if ( ebr_ctx->timer.id != NAS_TIMER_INACTIVE_ID || ebr_ctx->args ) {
     OAILOG_INFO(
         LOG_NAS_ESM,
         "ESM-FSM   - Stop retransmission timer %ld " MME_UE_S1AP_ID_FMT "\n",
         ebr_ctx->timer.id, ue_mm_context->mme_ue_s1ap_id);
-    esm_ebr_timer_data_t* esm_ebr_timer_data = NULL;
+    esm_ebr_timer_data_t* esm_ebr_timer_data = ebr_ctx->args;
     nas_timer_stop(&(ebr_ctx->timer));
     /*
      * Release the retransmisison timer parameters


### PR DESCRIPTION
Signed-off-by: Ulas Kozat <kozat@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->
This PR fixes the following:
- During the migration of network initiated bearer activation/deactivation timers, the stored msg context was not properly released.
- When the timer is restarted as part of retransmission, the stored context was not properly accessed and erroneous log message was shown.
## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->
Run s1ap integ tests such as `test_attach_detach_dedicated.py` and then restart the services, observe syslog for any reported leaks. Observe mme log for the correct behavior.

Additional unit tests to be added in follow up PRs.

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
