### PR TITLE
feat(mme): Add enb name info to s1_setup metrics and events

### DIFF
--- a/lte/gateway/c/core/oai/include/mme_events.h
+++ b/lte/gateway/c/core/oai/include/mme_events.h
@@ -58,6 +58,16 @@ int s1_setup_success_event(const char* enb_name, uint32_t enb_id);
  */
 int attach_reject_event(imsi64_t imsi64);
 
+/**
+ * Logs s1 setup failure event
+ * @param enb_name name assigned to eNodeb
+ * @param enb_id unique identifier of eNodeb
+ * @param cause explanation of failure
+ * @return response code
+ */
+int s1_setup_failure_event(
+    const char* enb_name, uint32_t enb_id, const char* cause);
+
 #ifdef __cplusplus
 }
 #endif

--- a/lte/gateway/c/core/oai/tasks/mme_app/mme_events.cpp
+++ b/lte/gateway/c/core/oai/tasks/mme_app/mme_events.cpp
@@ -39,9 +39,10 @@ using magma::orc8r::Void;
 namespace {
 constexpr char MME_STREAM_NAME[] = "mme";
 constexpr char ATTACH_SUCCESS[] = "attach_success";
+constexpr char ATTACH_REJECT[] = "attach_reject";
 constexpr char DETACH_SUCCESS[] = "detach_success";
 constexpr char S1_SETUP_SUCCESS[] = "s1_setup_success";
-constexpr char ATTACH_REJECT[] = "attach_reject";
+constexpr char S1_SETUP_FAILURE[] = "s1_setup_failure";
 }  // namespace
 
 void event_client_init(void) { init_eventd_client(); }
@@ -112,4 +113,21 @@ int attach_reject_event(imsi64_t imsi64) {
   event_value["imsi"] = imsi_str;
 
   return report_event(event_value, ATTACH_REJECT, MME_STREAM_NAME, imsi_str);
+}
+
+int s1_setup_failure_event(const char* enb_name, uint32_t enb_id,
+                           const char* cause) {
+  nlohmann::json event_value;
+
+  if (enb_name) {
+    event_value["enb_name"] = enb_name;
+  } else {
+    event_value["enb_name"] = "";
+  }
+
+  event_value["enb_id"] = enb_id;
+  event_value["cause"] = cause;
+
+  return report_event(event_value, S1_SETUP_FAILURE, MME_STREAM_NAME,
+                      std::to_string(enb_id));
 }

--- a/lte/gateway/configs/eventd.yml
+++ b/lte/gateway/configs/eventd.yml
@@ -63,3 +63,10 @@ event_registry:
   attach_reject:
     module: lte
     filename: mme_events.v1.yml
+  s1_setup_failure:
+    module: lte
+    filename: mme_events.v1.yml
+
+# [Experimental] Enable Sentry for this service
+# Allowed values: send_all_errors, send_selected_errors, disabled
+sentry: disabled

--- a/lte/swagger/mme_events.v1.yml
+++ b/lte/swagger/mme_events.v1.yml
@@ -36,3 +36,14 @@ definitions:
     properties:
       imsi:
         type: string
+  s1_setup_failure:
+    type: object
+    description: Used to track failed establishment of S1 connection
+    properties:
+      enb_name:
+        type: string
+      enb_id:
+        type: integer
+      cause:
+        description: failure cause
+        type: string


### PR DESCRIPTION
Signed-off-by: Andrei Lee <andreilee@fb.com>

## Summary

Adds the `enb_name` field to `s1_setup` gauge metric, and adds the `s1_setup_failure` event

## Test Plan

Forcing a branch to run which logs an s1_setup failure, and sends an event for the failure, found the following:

AGW `magma@mme` Log:
```
Dec 08 00:48:42 magma-dev-focal mme[208031]: [DEBUG] Success logging event: s1_setup_failure
```

AGW `magma_eventd` Log:
```
Dec 08 00:48:42 magma-dev-focal eventd[202815]: DEBUG:root:Sending log to FluentBit
Dec 08 00:48:42 magma-dev-focal eventd[202815]: DEBUG:root:Successfully logged event: stream_name: "mme"
Dec 08 00:48:42 magma-dev-focal eventd[202815]: event_type: "s1_setup_failure"
Dec 08 00:48:42 magma-dev-focal eventd[202815]: tag: "10"
Dec 08 00:48:42 magma-dev-focal eventd[202815]: value: "{\"cause\":\"plmnid_or_tac_mismatch\",\"enb_id\":10,\"enb_name\":\"\\\"RADISYS\\\"\"}"
```

Metrics captured in Grafana on local development setup:
![Screen Shot 2021-12-07 at 4 51 22 PM](https://user-images.githubusercontent.com/804385/145128894-fdcc38f4-f7ac-485a-8793-fdcaf9bceef8.png)

## Additional Information

- [ ] This change is backwards-breaking
