### PR TITLE
fix(mme): remove memory leaks on sctp socket creation

### DIFF
--- a/lte/gateway/c/core/oai/tasks/sctp/sctpd_downlink_client.cpp
+++ b/lte/gateway/c/core/oai/tasks/sctp/sctpd_downlink_client.cpp
@@ -110,7 +110,7 @@ std::unique_ptr<SctpdDownlinkClient> client = nullptr;
 
 int init_sctpd_downlink_client(bool force_restart) {
   std::string downstream_sctp_sock(
-      bstr2cstr(mme_config.sctp_config.downstream_sctp_sock, '\0'));
+      bdata(mme_config.sctp_config.downstream_sctp_sock));
   auto channel = grpc::CreateChannel(
       downstream_sctp_sock, grpc::InsecureChannelCredentials());
   client = std::make_unique<SctpdDownlinkClient>(channel, force_restart);

--- a/lte/gateway/c/core/oai/tasks/sctp/sctpd_uplink_server.cpp
+++ b/lte/gateway/c/core/oai/tasks/sctp/sctpd_uplink_server.cpp
@@ -141,7 +141,7 @@ int start_sctpd_uplink_server(void) {
 
   ServerBuilder builder;
   std::string upstream_sctp_sock(
-      bstr2cstr(mme_config.sctp_config.upstream_sctp_sock, '\0'));
+      bdata(mme_config.sctp_config.upstream_sctp_sock);
   builder.AddListeningPort(
       upstream_sctp_sock, grpc::InsecureServerCredentials());
   builder.RegisterService(service.get());

--- a/lte/gateway/c/core/oai/tasks/sctp/sctpd_uplink_server.cpp
+++ b/lte/gateway/c/core/oai/tasks/sctp/sctpd_uplink_server.cpp
@@ -141,7 +141,7 @@ int start_sctpd_uplink_server(void) {
 
   ServerBuilder builder;
   std::string upstream_sctp_sock(
-      bdata(mme_config.sctp_config.upstream_sctp_sock);
+      bdata(mme_config.sctp_config.upstream_sctp_sock));
   builder.AddListeningPort(
       upstream_sctp_sock, grpc::InsecureServerCredentials());
   builder.RegisterService(service.get());


### PR DESCRIPTION
Signed-off-by: Ulas Kozat <kozat@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->
Resolves the memory leaks created during the construction of socket strings.

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->
Run integ tests, restart services and check memory leaks on syslog.

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
