### PR TITLE
fix(mme): eliminate memory leaked during config parsing

### DIFF
--- a/lte/gateway/c/core/oai/tasks/mme_app/mme_config.c
+++ b/lte/gateway/c/core/oai/tasks/mme_app/mme_config.c
@@ -1821,7 +1821,9 @@ int mme_config_parse_file(mme_config_t* config_pP) {
         "Failed to read MME configuration file at path: %s:\n",
         bdata(config_pP->config_file));
   }
-  return mme_config_parse_string(bdata(buff), config_pP);
+  int rc = mme_config_parse_string(bdata(buff), config_pP);
+  bdestroy_wrapper(&buff);
+  return rc;
 }
 
 //------------------------------------------------------------------------------


### PR DESCRIPTION
Signed-off-by: Ulas Kozat <kozat@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->
Fix memory leak introduced at https://github.com/magma/magma/pull/9181.

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->
Restart mme service and observe no memory leaks.
Pass s1ap integ test suit.

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
