### PR TITLE
fix: corrects turn-up of gopls in devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -308,7 +308,10 @@ RUN git clone https://github.com/OPENAIRINTERFACE/opencord.org.freeDiameter.git 
     rm -rf freediameter
 
 ##### Go language server support for vscode
-RUN go get -v golang.org/x/tools/gopls
+USER vscode
+ENV GO111MODULE=on
+RUN go get -v golang.org/x/tools/gopls && \
+    go clean --modcache
 
 #### Update shared library configuration
 RUN ldconfig -v


### PR DESCRIPTION
This PR corrects a previous attempt (#9399) to add `gopls` to our devcontainer for vscode use.

The prior PR mistakenly installed `gopls` to the root home directory and was inaccessible to our vscode enviornment which is configured to run as user `vscode`.

To avoid making a mistake again, this time I tested more thoroughly.

## Test Plan

- Modified `.devcontainer/dev.container.json
  - removed `"image":` line
  - replaced with
 ```json
	"dockerFile": "Dockerfile",
	"context": "..",
```
- Updated `.devcontainer/Dockerfile` per this PR
- Pressed `F1` and selected `Remote-Containers: Rebuild Container` on a local vs code instance of our repo
- Verified healthy `gopls` behavior

Note that `gopls` was not happy about lack of a `go.mod` in our root repository - but various functions like code discovery and autocomplete were functional.

Signed-off-by: Scott Moeller <electronjoe@gmail.com>