### PR TITLE
feat(orc8r): [Terraform][helm] improve HA and reliability of EKS based orc8r deployment

### DIFF
--- a/orc8r/cloud/deploy/terraform/orc8r-helm-aws/main.tf
+++ b/orc8r/cloud/deploy/terraform/orc8r-helm-aws/main.tf
@@ -182,7 +182,10 @@ data "template_file" "orc8r_values" {
     orc8r_db_user    = var.orc8r_db_user
     orc8r_db_pass    = var.orc8r_db_pass
 
-    deploy_nms  = var.deploy_nms
+    deploy_nms          = var.deploy_nms
+    magmalte_replicas   = var.nms_replicas
+    ui_nginx_replicas   = var.nginx_replicas
+    
 
     metrics_pvc_promcfg  = kubernetes_persistent_volume_claim.storage["promcfg"].metadata.0.name
     metrics_pvc_promdata = kubernetes_persistent_volume_claim.storage["promdata"].metadata.0.name

--- a/orc8r/cloud/deploy/terraform/orc8r-helm-aws/main.tf
+++ b/orc8r/cloud/deploy/terraform/orc8r-helm-aws/main.tf
@@ -182,9 +182,9 @@ data "template_file" "orc8r_values" {
     orc8r_db_user    = var.orc8r_db_user
     orc8r_db_pass    = var.orc8r_db_pass
 
-    deploy_nms          = var.deploy_nms
-    magmalte_replicas   = var.nms_replicas
-    ui_nginx_replicas   = var.nginx_replicas
+    deploy_nms                = var.deploy_nms
+    magmalte_replicas         = var.nms_replicas
+    magmalte_nginx_replicas   = var.nms_nginx_replicas
     
 
     metrics_pvc_promcfg  = kubernetes_persistent_volume_claim.storage["promcfg"].metadata.0.name

--- a/orc8r/cloud/deploy/terraform/orc8r-helm-aws/main.tf
+++ b/orc8r/cloud/deploy/terraform/orc8r-helm-aws/main.tf
@@ -168,8 +168,8 @@ data "template_file" "orc8r_values" {
     # orc8r certs secret
     nms_certs_secret = var.deploy_nms ? kubernetes_secret.nms_certs.0.metadata.0.name : kubernetes_secret.orc8r_certs.metadata.0.name
 
-    controller_replicas = var.orc8r_controller_replicas
-    nginx_replicas      = var.orc8r_proxy_replicas
+    controller_replicas   = var.orc8r_controller_replicas
+    nginx_replicas        = var.orc8r_proxy_replicas
 
     controller_hostname = format("controller.%s", var.orc8r_domain_name)
     api_hostname        = format("api.%s", var.orc8r_domain_name)
@@ -186,6 +186,8 @@ data "template_file" "orc8r_values" {
     magmalte_replicas         = var.nms_replicas
     magmalte_nginx_replicas   = var.nms_nginx_replicas
     
+    controller_affinity   = var.orc8r_controller_affinity
+    magmalte_affinity     = var.nms_affinity
 
     metrics_pvc_promcfg  = kubernetes_persistent_volume_claim.storage["promcfg"].metadata.0.name
     metrics_pvc_promdata = kubernetes_persistent_volume_claim.storage["promdata"].metadata.0.name

--- a/orc8r/cloud/deploy/terraform/orc8r-helm-aws/templates/orc8r-values.tpl
+++ b/orc8r/cloud/deploy/terraform/orc8r-helm-aws/templates/orc8r-values.tpl
@@ -66,6 +66,7 @@ controller:
       user: ${orc8r_db_user}
     service_registry:
       mode: "k8s"
+  affinity: ${controller_affinity}
 
 metrics:
   imagePullSecrets:
@@ -187,6 +188,11 @@ nms:
       tag: "${docker_tag}"
     
     replicas: ${magmalte_replicas}
+    
+    podDisruptionBudget:
+      enabled: true
+
+    affinity: ${magmalte_affinity}
 
     env:
       api_host: ${api_hostname}

--- a/orc8r/cloud/deploy/terraform/orc8r-helm-aws/templates/orc8r-values.tpl
+++ b/orc8r/cloud/deploy/terraform/orc8r-helm-aws/templates/orc8r-values.tpl
@@ -213,7 +213,7 @@ nms:
         ssl_cert_name: controller.crt
         ssl_cert_key_name: controller.key
     
-    replicas: ${ui_nginx_replicas}
+    replicas: ${magmalte_nginx_replicas}
 
 logging:
   enabled: false

--- a/orc8r/cloud/deploy/terraform/orc8r-helm-aws/templates/orc8r-values.tpl
+++ b/orc8r/cloud/deploy/terraform/orc8r-helm-aws/templates/orc8r-values.tpl
@@ -185,6 +185,8 @@ nms:
     image:
       repository: ${docker_registry}/magmalte
       tag: "${docker_tag}"
+    
+    replicas: ${magmalte_replicas}
 
     env:
       api_host: ${api_hostname}
@@ -210,6 +212,8 @@ nms:
       spec:
         ssl_cert_name: controller.crt
         ssl_cert_key_name: controller.key
+    
+    replicas: ${ui_nginx_replicas}
 
 logging:
   enabled: false

--- a/orc8r/cloud/deploy/terraform/orc8r-helm-aws/variables.tf
+++ b/orc8r/cloud/deploy/terraform/orc8r-helm-aws/variables.tf
@@ -85,6 +85,18 @@ variable "deploy_nms" {
   default     = true
 }
 
+variable "nms_replicas" {
+  description = "Replica count for magmalte pods."
+  type        = number
+  default     = 1
+}
+
+variable "nginx_replicas" {
+  description = "Replica count for nginx pods for magmalte."
+  type        = number
+  default     = 1
+}
+
 variable "orc8r_controller_replicas" {
   description = "Replica count for Orchestrator controller pods."
   type        = number

--- a/orc8r/cloud/deploy/terraform/orc8r-helm-aws/variables.tf
+++ b/orc8r/cloud/deploy/terraform/orc8r-helm-aws/variables.tf
@@ -97,11 +97,25 @@ variable "nms_nginx_replicas" {
   default     = 1
 }
 
+variable "nms_affinity" {
+  description = "NMS deployment affinity spec"
+  type        = object()
+  default     = {}
+}
+
+
 variable "orc8r_controller_replicas" {
   description = "Replica count for Orchestrator controller pods."
   type        = number
   default     = 2
 }
+
+variable "orc8r_controller_affinity" {
+  description = "Controller deployment affinity spec"
+  type        = object()
+  default     = {}
+}
+
 
 variable "orc8r_proxy_replicas" {
   description = "Replica count for Orchestrator proxy pods."

--- a/orc8r/cloud/deploy/terraform/orc8r-helm-aws/variables.tf
+++ b/orc8r/cloud/deploy/terraform/orc8r-helm-aws/variables.tf
@@ -91,7 +91,7 @@ variable "nms_replicas" {
   default     = 1
 }
 
-variable "nginx_replicas" {
+variable "nms_nginx_replicas" {
   description = "Replica count for nginx pods for magmalte."
   type        = number
   default     = 1

--- a/orc8r/cloud/helm/orc8r/charts/nms/templates/magmalte-pdb.yaml
+++ b/orc8r/cloud/helm/orc8r/charts/nms/templates/magmalte-pdb.yaml
@@ -1,0 +1,32 @@
+
+{{/*
+Copyright 2020 The Magma Authors.
+
+This source code is licensed under the BSD-style license found in the
+LICENSE file in the root directory of this source tree.
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/}}
+
+{{- if .Values.magmalte.create and .Values.magmalte.podDisruptionBudget.enabled (gt .Values.magmalte.replicas 1.0 )}}
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: orc8r
+  labels:
+    {{ tuple $envAll "nms" "magmalte" | include "nms.labels" | indent 4 }}
+spec:
+  {{- with .Values.magmalte.podDisruptionBudget.minAvailable }}
+  minAvailable: {{ . }}
+  {{- end }}
+  {{- with .Values.magmalte.podDisruptionBudget.maxUnavailable }}
+  maxUnavailable: {{ . }}
+  {{- end }}
+  selector:
+    matchLabels:
+  {{ tuple $envAll "nms" "magmalte" | include "nms.selector-labels" | indent 6 }}
+{{- end }}

--- a/orc8r/cloud/helm/orc8r/charts/nms/values.yaml
+++ b/orc8r/cloud/helm/orc8r/charts/nms/values.yaml
@@ -79,6 +79,10 @@ magmalte:
   # ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
   affinity: {}
 
+  # Define pod disruption budget for NMS
+  # ref: https://kubernetes.io/docs/tasks/run-application/configure-pdb/
+  podDisruptionBudget: {}
+
 ## Nginx-Proxy
 #
 nginx:

--- a/orc8r/cloud/helm/orc8r/values.yaml
+++ b/orc8r/cloud/helm/orc8r/values.yaml
@@ -17,6 +17,12 @@ nms:
     image:
       repository: <registry>/magmalte
       tag: latest
+    # Configure pod disruption budgets for magmalte
+    # ref: https://kubernetes.io/docs/tasks/run-application/configure-pdb/#specifying-a-poddisruptionbudget
+    podDisruptionBudget:
+      enabled: false
+      minAvailable: 1
+      maxUnavailable: ""
   nginx:
     create: true
 


### PR DESCRIPTION
## Summary
At the moment default EKS deployment have following issues, which make it not truly production ready:
 - magmalte deployment is not HA
 - magmalte deployment does not have PDB  (which kinda makes sense cause it's not HA)
 - non of the deployment has affinity / anti-affinity specified

Following was done to make default EKS based deployment a bit more production ready:
 - orc8r-app terraform module was extended with magmalte replicas count configuration
 - orc8r-app terraform module was extended with affinity configuration for magmalte and controller
 - orc8r helm chart was extended with PDB for magmalte
 

