### PR TITLE
feat(ci): migrate lte integ test to github actions

### DIFF
--- a/.github/workflows/lte-integ-test.yml
+++ b/.github/workflows/lte-integ-test.yml
@@ -1,0 +1,33 @@
+---
+
+name: LTE integ test
+
+on:  # yamllint disable-line rule:truthy
+  push:
+    branches:
+      - master
+
+jobs:
+  lte-integ-test:
+    runs-on: macos-latest
+    steps:
+      - run: echo "::set-output name=date::$(date +'%m-%d-%Y--%H-%M-%S')"
+        id: date
+      - uses: actions/checkout@v2
+      - name: setup pyenv
+        uses: "gabrielfalcao/pyenv-action@v8"
+        with:
+          default: 3.8.5
+      - uses: actions/setup-python@v2
+        with:
+          python-version: '3.8.5'
+      - name: Install pre requisites
+        run: |
+          pip3 install --upgrade pip
+          pip3 install ansible fabric3 jsonpickle requests PyYAML
+          vagrant plugin install vagrant-vbguest vagrant-disksize
+      - name: Run the integ test
+        run: |
+          cd lte/gateway
+          sed -i '' 's/1.1.20210928/1.1.20210618/' Vagrantfile
+          fab integ_test


### PR DESCRIPTION
First version, will later upload test results and optimize it by not building in the job

Signed-off-by: quentinDERORY <15911421+quentinDERORY@users.noreply.github.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

As CircleCI lte integ tests are down.
We are pushing the first version of the migrated lte integ test in github actions

## Test Plan

Tested in my fork

## Additional Information

Will later improve performance and upload of test results
<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
