### PR TITLE
chore: remove custom devcontainer bazel flags from devcontainer config

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -26,10 +26,8 @@
 			"**/.bazel-cache-repo/**": true,
 		},		
 		"bsv.bazel.buildFlags": [
-			"--config=devcontainer",
 		],
 		"bsv.bazel.testFlags": [
-			"--compilation_mode=dbg",
 		],
 		"bsv.bes.enabled": false,
 		"bsv.bzl.codesearch.enabled": false,
@@ -59,9 +57,6 @@
 	"runArgs": [
 		"--init"
 	],
-	"containerEnv": {
-		"VSCODE_BAZEL_BUILD_CONFIG": "devcontainer",
-	},
 	"remoteEnv": {
 		"LOCAL_WORKSPACE_FOLDER": "${localWorkspaceFolder}",
 	},


### PR DESCRIPTION
Signed-off-by: GitHub <noreply@github.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

I recently added a system wide bazelrc to add the --config=devcontainer flag needed for devcontainer development. (https://github.com/magma/magma/blob/master/experimental/bazel-base/bazelrcs/devcontainer.bazelrc)

This is a clean up PR on the devcontainer.json file to remove unnecessary flags


<!-- Enumerate changes you made and why you made them -->

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
