### PR TITLE
fix: fix system wide bazelrc path in devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -313,6 +313,6 @@ RUN go get -v golang.org/x/tools/gopls
 #### Update shared library configuration
 RUN ldconfig -v
 
-RUN ln -s /magma/experimental/bazel-base/bazelrcs/devcontainer.bazelrc /etc/bazelrc
+RUN ln -s "$MAGMA_ROOT"/experimental/bazel-base/bazelrcs/devcontainer.bazelrc /etc/bazelrc
 
-WORKDIR /workspaces/magma
+WORKDIR $MAGMA_ROOT


### PR DESCRIPTION
Signed-off-by: Marie Bremner <marwhal@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary
Bad copy paste in this Dockerfile. The magma directory lives under /workspaces, not /
<!-- Enumerate changes you made and why you made them -->

## Test Plan
Tested inside devcontainer
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
