### PR TITLE
fix(nms): Fix nms_prereqs_ubuntu dependency with nodejs for v16

### DIFF
--- a/orc8r/cloud/Makefile
+++ b/orc8r/cloud/Makefile
@@ -181,7 +181,13 @@ nms_prereqs_ubuntu: nms_node_ubuntu
 nms_node_ubuntu:
 	# install pre-reqs
 	apt update
-	apt install -y nodejs npm
+	# Handle certificate verification
+	apt-get install -y libgnutls30
+	# Get a newer version of nodejs
+	curl -fSL https://deb.nodesource.com/setup_14.x | bash -
+	apt-get install -y nodejs
+	# And now install npm
+	apt install -y npm
 	# symlink nodejs executable
 	mkdir -p /usr/local/bin
 


### PR DESCRIPTION
Signed-off-by: Andrei Lee <andreilee@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

Recently `Makefile` command `nms_prereqs` has been failing with the following error:
```
yarn add swagger-js-codegen
/usr/local/lib/node_modules/yarn/lib/cli.js:46280
  let {
      ^

SyntaxError: Unexpected token {
    at exports.runInThisContext (vm.js:53:16)
    at Module._compile (module.js:374:25)
    at Object.Module._extensions..js (module.js:417:10)
    at Module.load (module.js:344:32)
    at Function.Module._load (module.js:301:12)
    at Module.require (module.js:354:17)
    at require (internal/module.js:12:17)
    at Object.<anonymous> (/usr/local/lib/node_modules/yarn/bin/yarn.js:24:13)
    at Module._compile (module.js:410:26)
    at Object.Module._extensions..js (module.js:417:10)
Makefile:173: recipe for target 'nms_prereqs_ubuntu' failed
```

This has been root caused as an issue that occurs when an old `nodejs` version is installed. This fix upgrades the version of `nodejs` to v16

## Test Plan

Tested inside docker container:
```
➜  docker git:(master) ✗ ./build.py -m
Creating build context in '/tmp/magma_orc8r_build'...
/tmp/magma_orc8r_build/gomod/src/magma/orc8r/cloud/go/go.mod
/tmp/magma_orc8r_build/gomod/src/magma/orc8r/cloud/test/go.mod
/tmp/magma_orc8r_build/gomod/src/magma/orc8r/cloud/api/v1/go/go.mod
/tmp/magma_orc8r_build/gomod/src/magma/orc8r/lib/go/go.mod
/tmp/magma_orc8r_build/gomod/src/magma/orc8r/lib/go/protos/go.mod
/tmp/magma_orc8r_build/gomod/src/magma/orc8r/gateway/go/go.mod
/tmp/magma_orc8r_build/gomod/src/magma/lte/cloud/go/go.mod
/tmp/magma_orc8r_build/gomod/src/magma/feg/cloud/go/go.mod
/tmp/magma_orc8r_build/gomod/src/magma/feg/cloud/go/protos/go.mod
/tmp/magma_orc8r_build/gomod/src/magma/cwf/cloud/go/go.mod
/tmp/magma_orc8r_build/gomod/src/magma/wifi/cloud/go/go.mod
/tmp/magma_orc8r_build/gomod/src/magma/fbinternal/cloud/go/go.mod
Running 'docker-compose build test'...
[+] Building 17.3s (19/19) FINISHED
 => [internal] load build definition from Dockerfile                                                                                                                                                                                                                                                                                                         0.0s
 => => transferring dockerfile: 32B                                                                                                                                                                                                                                                                                                                          0.0s
 => [internal] load .dockerignore                                                                                                                                                                                                                                                                                                                            0.0s
 => => transferring context: 2B                                                                                                                                                                                                                                                                                                                              0.0s
 => [internal] load metadata for docker.io/library/ubuntu:xenial                                                                                                                                                                                                                                                                                             0.0s
 => [base 1/5] FROM docker.io/library/ubuntu:xenial                                                                                                                                                                                                                                                                                                          0.0s
 => [internal] load build context                                                                                                                                                                                                                                                                                                                            0.7s
 => => transferring context: 563.72kB                                                                                                                                                                                                                                                                                                                        0.7s
 => CACHED [base 2/5] RUN apt-get update && apt-get install -y   bzr   curl   gcc   git   make   unzip   vim                                                                                                                                                                                                                                                 0.0s
 => CACHED [base 3/5] WORKDIR /usr/local                                                                                                                                                                                                                                                                                                                     0.0s
 => CACHED [base 4/5] RUN curl https://facebookconnectivity.jfrog.io/artifactory/generic/go1.13.4.linux-amd64.tar.gz -O &&     tar xf go1.13.4.linux-amd64.tar.gz &&     cp -r go/bin/* /usr/local/bin/                                                                                                                                                      0.0s
 => CACHED [base 5/5] RUN curl -Lfs https://github.com/protocolbuffers/protobuf/releases/download/v3.10.0/protoc-3.10.0-linux-x86_64.zip -o protoc3.zip &&     unzip protoc3.zip -d protoc3 &&     mv protoc3/bin/protoc /bin/protoc &&     chmod a+rx /bin/protoc &&     mv protoc3/include/google /usr/include/ &&     chmod -R a+Xr /usr/include/google   0.0s
 => CACHED [gocache 1/4] RUN echo "export GOCACHE_MODULES="$(for m in orc8r lte feg cwf wifi fbinternal ; do echo -n /gomod/src/magma/$m ; echo -n ' ' ; done)"" >> /etc/profile.d/env.sh                                                                                                                                                                    0.0s
 => CACHED [gocache 2/4] COPY gomod /gomod                                                                                                                                                                                                                                                                                                                   0.0s
 => CACHED [gocache 3/4] RUN cat /etc/profile.d/env.sh                                                                                                                                                                                                                                                                                                       0.0s
 => CACHED [gocache 4/4] RUN . /etc/profile.d/env.sh && for m in $GOCACHE_MODULES ; do cd ${m}/cloud/go && echo ${m}/cloud/go && go mod download ; done                                                                                                                                                                                                      0.0s
 => CACHED [src 1/5] RUN echo "export MAGMA_MODULES="$(for m in orc8r lte feg cwf wifi fbinternal ; do echo -n /src/magma/$m ; echo -n ' ' ; done)"" >> /etc/profile.d/env.sh                                                                                                                                                                                0.0s
 => [src 2/5] COPY src /src                                                                                                                                                                                                                                                                                                                                  0.6s
 => [src 3/5] WORKDIR /src/magma/orc8r/cloud                                                                                                                                                                                                                                                                                                                 0.0s
 => [src 4/5] RUN . /etc/profile.d/env.sh && make tools                                                                                                                                                                                                                                                                                                     14.9s
 => [src 5/5] COPY configs /etc/magma/configs                                                                                                                                                                                                                                                                                                                0.0s
 => exporting to image                                                                                                                                                                                                                                                                                                                                       0.8s
 => => exporting layers                                                                                                                                                                                                                                                                                                                                      0.8s
 => => writing image sha256:4010ac73acb1d4a54450e0b50bc0e484a14f95614f01531f786033fc84f34cce                                                                                                                                                                                                                                                                 0.0s
 => => naming to docker.io/library/orc8r_test                                                                                                                                                                                                                                                                                                                0.0s

Use 'docker scan' to run Snyk tests against images to find vulnerabilities and learn how to fix them
Running 'docker-compose run --rm -v /Users/andreilee/magma/.golangci.yml:/src/magma/.golangci.yml -v /Users/andreilee/magma/orc8r:/src/magma/orc8r -v /Users/andreilee/magma/lte:/src/magma/lte -v /Users/andreilee/magma/feg:/src/magma/feg -v /Users/andreilee/magma/cwf:/src/magma/cwf -v /Users/andreilee/magma/wifi:/src/magma/wifi -v /Users/andreilee/magma/fbinternal:/src/magma/fbinternal test bash'...
[+] Running 0/0
[+] Running 2/1r_default  Creating                                                                                                                                                                                                                                                                                                                           0.1s
 ⠿ Network orc8r_default            Created                                                                                                                                                                                                                                                                                                                  0.1s
 ⠿ Container orc8r_postgres_test_1  Created                                                                                                                                                                                                                                                                                                                  0.1s
[+] Running 1/1
 ⠿ Container orc8r_postgres_test_1  Started                                                                                                                                                                                                                                                                                                                  0.4s
root@2c97764dc4cd:/src/magma/orc8r/cloud# make nms_prereqs
make nms_prereqs_ubuntu || make nms_prereqs_osx
make[1]: Entering directory '/src/magma/orc8r/cloud'
# install pre-reqs
apt update
Get:1 http://security.ubuntu.com/ubuntu xenial-security InRelease [109 kB]
Hit:2 http://archive.ubuntu.com/ubuntu xenial InRelease
Get:3 http://archive.ubuntu.com/ubuntu xenial-updates InRelease [109 kB]
Get:4 http://security.ubuntu.com/ubuntu xenial-security/main amd64 Packages [2051 kB]
Get:5 http://security.ubuntu.com/ubuntu xenial-security/universe amd64 Packages [984 kB]
Get:6 http://archive.ubuntu.com/ubuntu xenial-backports InRelease [107 kB]
Get:7 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 Packages [2560 kB]
Get:8 http://archive.ubuntu.com/ubuntu xenial-updates/universe amd64 Packages [1544 kB]
Get:9 http://archive.ubuntu.com/ubuntu xenial-backports/universe amd64 Packages [12.7 kB]
Fetched 7476 kB in 2s (2867 kB/s)
Reading package lists... Done
Building dependency tree
Reading state information... Done
46 packages can be upgraded. Run 'apt list --upgradable' to see them.
# Handle certificate verification
apt-get install -y libgnutls30
Reading package lists... Done
Building dependency tree
Reading state information... Done
Suggested packages:
  gnutls-bin
The following packages will be upgraded:
  libgnutls30
1 upgraded, 0 newly installed, 0 to remove and 45 not upgraded.
Need to get 548 kB of archives.
After this operation, 4096 B of additional disk space will be used.
Get:1 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 libgnutls30 amd64 3.4.10-4ubuntu1.9 [548 kB]
Fetched 548 kB in 1s (462 kB/s)
debconf: delaying package configuration, since apt-utils is not installed
(Reading database ... 17826 files and directories currently installed.)
Preparing to unpack .../libgnutls30_3.4.10-4ubuntu1.9_amd64.deb ...
Unpacking libgnutls30:amd64 (3.4.10-4ubuntu1.9) over (3.4.10-4ubuntu1.8) ...
Processing triggers for libc-bin (2.23-0ubuntu11) ...
Setting up libgnutls30:amd64 (3.4.10-4ubuntu1.9) ...
Processing triggers for libc-bin (2.23-0ubuntu11) ...
# Get a newer version of nodejs
curl -fSL https://deb.nodesource.com/setup_14.x | bash -
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 13764  100 13764    0     0  80306      0 --:--:-- --:--:-- --:--:-- 80491

## Installing the NodeSource Node.js 14.x repo...


## Populating apt-get cache...

+ apt-get update
Hit:1 http://security.ubuntu.com/ubuntu xenial-security InRelease
Hit:2 http://archive.ubuntu.com/ubuntu xenial InRelease
Hit:3 http://archive.ubuntu.com/ubuntu xenial-updates InRelease
Hit:4 http://archive.ubuntu.com/ubuntu xenial-backports InRelease
Reading package lists... Done

## Installing packages required for setup: apt-transport-https lsb-release...

+ apt-get install -y apt-transport-https lsb-release > /dev/null 2>&1

## Confirming "xenial" is supported...

+ curl -sLf -o /dev/null 'https://deb.nodesource.com/node_14.x/dists/xenial/Release'

## Adding the NodeSource signing key to your keyring...

+ curl -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key | gpg --dearmor | tee /usr/share/keyrings/nodesource.gpg >/dev/null

## Creating apt sources list file for the NodeSource Node.js 14.x repo...

+ echo 'deb [signed-by=/usr/share/keyrings/nodesource.gpg] https://deb.nodesource.com/node_14.x xenial main' > /etc/apt/sources.list.d/nodesource.list
+ echo 'deb-src [signed-by=/usr/share/keyrings/nodesource.gpg] https://deb.nodesource.com/node_14.x xenial main' >> /etc/apt/sources.list.d/nodesource.list

## Running `apt-get update` for you...

+ apt-get update
Hit:1 http://security.ubuntu.com/ubuntu xenial-security InRelease
Hit:2 http://archive.ubuntu.com/ubuntu xenial InRelease
Get:3 https://deb.nodesource.com/node_14.x xenial InRelease [4584 B]
Hit:4 http://archive.ubuntu.com/ubuntu xenial-updates InRelease
Hit:5 http://archive.ubuntu.com/ubuntu xenial-backports InRelease
Get:6 https://deb.nodesource.com/node_14.x xenial/main amd64 Packages [768 B]
Fetched 5352 B in 0s (7340 B/s)
Reading package lists... Done

## Run `sudo apt-get install -y nodejs` to install Node.js 14.x and npm
## You may also need development tools to build native addons:
     sudo apt-get install gcc g++ make
## To install the Yarn package manager, run:
     curl -sL https://dl.yarnpkg.com/debian/pubkey.gpg | gpg --dearmor | sudo tee /usr/share/keyrings/yarnkey.gpg >/dev/null
     echo "deb [signed-by=/usr/share/keyrings/yarnkey.gpg] https://dl.yarnpkg.com/debian stable main" | sudo tee /etc/apt/sources.list.d/yarn.list
     sudo apt-get update && sudo apt-get install yarn


apt-get install -y nodejs
Reading package lists... Done
Building dependency tree
Reading state information... Done
The following NEW packages will be installed:
  nodejs
0 upgraded, 1 newly installed, 0 to remove and 45 not upgraded.
Need to get 25.2 MB of archives.
After this operation, 122 MB of additional disk space will be used.
Get:1 https://deb.nodesource.com/node_14.x xenial/main amd64 nodejs amd64 14.18.0-1nodesource1 [25.2 MB]
Fetched 25.2 MB in 0s (29.7 MB/s)
debconf: delaying package configuration, since apt-utils is not installed
Selecting previously unselected package nodejs.
(Reading database ... 17969 files and directories currently installed.)
Preparing to unpack .../nodejs_14.18.0-1nodesource1_amd64.deb ...
Unpacking nodejs (14.18.0-1nodesource1) ...
Setting up nodejs (14.18.0-1nodesource1) ...
# And now install npm
apt install -y npm
Reading package lists... Done
Building dependency tree
Reading state information... Done
Some packages could not be installed. This may mean that you have
requested an impossible situation or if you are using the unstable
distribution that some required packages have not yet been created
or been moved out of Incoming.
The following information may help to resolve the situation:

The following packages have unmet dependencies:
 npm : Depends: nodejs but it is not going to be installed
       Depends: node-abbrev (>= 1.0.4) but it is not going to be installed
       Depends: node-ansi (>= 0.3.0-2) but it is not going to be installed
       Depends: node-ansi-color-table but it is not going to be installed
       Depends: node-archy but it is not going to be installed
       Depends: node-block-stream but it is not going to be installed
       Depends: node-fstream (>= 0.1.22) but it is not going to be installed
       Depends: node-fstream-ignore but it is not going to be installed
       Depends: node-github-url-from-git but it is not going to be installed
       Depends: node-glob (>= 3.1.21) but it is not going to be installed
       Depends: node-graceful-fs (>= 2.0.0) but it is not going to be installed
       Depends: node-inherits but it is not going to be installed
       Depends: node-ini (>= 1.1.0) but it is not going to be installed
       Depends: node-lockfile but it is not going to be installed
       Depends: node-lru-cache (>= 2.3.0) but it is not going to be installed
       Depends: node-minimatch (>= 0.2.11) but it is not going to be installed
       Depends: node-mkdirp (>= 0.3.3) but it is not going to be installed
       Depends: node-gyp (>= 0.10.9) but it is not going to be installed
       Depends: node-nopt (>= 3.0.1) but it is not going to be installed
       Depends: node-npmlog but it is not going to be installed
       Depends: node-once but it is not going to be installed
       Depends: node-osenv but it is not going to be installed
       Depends: node-read but it is not going to be installed
       Depends: node-read-package-json (>= 1.1.0) but it is not going to be installed
       Depends: node-request (>= 2.25.0) but it is not going to be installed
       Depends: node-retry but it is not going to be installed
       Depends: node-rimraf (>= 2.2.2) but it is not going to be installed
       Depends: node-semver (>= 2.1.0) but it is not going to be installed
       Depends: node-sha but it is not going to be installed
       Depends: node-slide but it is not going to be installed
       Depends: node-tar (>= 0.1.18) but it is not going to be installed
       Depends: node-underscore but it is not going to be installed
       Depends: node-which but it is not going to be installed
E: Unable to correct problems, you have held broken packages.
Makefile:182: recipe for target 'nms_node_ubuntu' failed
make[1]: *** [nms_node_ubuntu] Error 100
make[1]: Leaving directory '/src/magma/orc8r/cloud'
make[1]: Entering directory '/src/magma/orc8r/cloud'
node --version || brew install node
v14.18.0
npm --version || brew install npm
6.14.15
yarn --version || npm install --global yarn
/bin/bash: yarn: command not found

> yarn@1.22.15 preinstall /usr/lib/node_modules/yarn
> :; (node ./preinstall.js > /dev/null 2>&1 || true)

/usr/bin/yarn -> /usr/lib/node_modules/yarn/bin/yarn.js
/usr/bin/yarnpkg -> /usr/lib/node_modules/yarn/bin/yarn.js
+ yarn@1.22.15
added 1 package in 0.763s
yarn add swagger-js-codegen
yarn add v1.22.15
warning package.json: No license field
warning No license field
[1/4] Resolving packages...
[2/4] Fetching packages...
[3/4] Linking dependencies...
[4/4] Building fresh packages...
warning No license field
success Saved 1 new dependency.
info Direct dependencies
└─ swagger-js-codegen@1.13.0
info All dependencies
└─ swagger-js-codegen@1.13.0
Done in 12.15s.
make[1]: Leaving directory '/src/magma/orc8r/cloud'
root@2c97764dc4cd:/src/magma/orc8r/cloud# make nms_gen
# generate Swagger API bindings for NMS
/src/magma/nms/packages/magmalte/scripts/generateAPIFromSwagger.sh /src/magma/orc8r/cloud/go/obsidian/swagger/v1/swagger.yml /src/magma/nms/packages/magmalte/generated/MagmaAPIBindings.js
Input Swagger file: /src/magma/orc8r/cloud/go/obsidian/swagger/v1/swagger.yml
Output file: /src/magma/nms/packages/magmalte/generated/MagmaAPIBindings.js
warning package.json: No license field
root@2c97764dc4cd:/src/magma/orc8r/cloud#
```

Also tested on Macbook Pro:
```
➜  cloud git:(master) ✗ export MAGMA_ROOT=/Users/andreilee/magma
➜  cloud git:(master) ✗ make nms_fullgen
...
# install pre-reqs
apt update
...
node --version || brew install node
v12.22.6
npm --version || brew install npm
6.14.15
yarn --version || npm install --global yarn
1.22.11
yarn add swagger-js-codegen
...
# generate Swagger API bindings for NMS
/Users/andreilee/magma/nms/packages/magmalte/scripts/generateAPIFromSwagger.sh /Users/andreilee/magma/orc8r/cloud/go/obsidian/swagger/v1/swagger.yml /Users/andreilee/magma/nms/packages/magmalte/generated/MagmaAPIBindings.js
Input Swagger file: /Users/andreilee/magma/orc8r/cloud/go/obsidian/swagger/v1/swagger.yml
Output file: /Users/andreilee/magma/nms/packages/magmalte/generated/MagmaAPIBindings.js
warning package.json: No license field
```

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
