### PR TITLE
chore: Add a docker build job for the python precommit job

### DIFF
--- a/.github/workflows/docker-push.yml
+++ b/.github/workflows/docker-push.yml
@@ -8,11 +8,48 @@ on:  # yamllint disable-line rule:truthy
       - .devcontainer/Dockerfile
       - .github/workflows/docker-push.yml
       - lte/gateway/docker/mme/Dockerfile.ubuntu20.04
+      - lte/gateway/docker/python-precommit/Dockerfile
   schedule:
     # Run four times a day (hours zero, six, twelve and eighteen)
     - cron:  '0 0,6,12,18 * * *'
 
 jobs:
+  build_python_precommit_dockerfile:
+    env:
+      DOCKERFILE: lte/gateway/docker/python-precommit/Dockerfile
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check Out Repo
+        uses: actions/checkout@v2
+      - name: Docker meta
+        id: meta
+        uses: crazy-max/ghaction-docker-meta@v2
+        with:
+          # list of Docker images to use as base name for tags
+          images: |
+            ghcr.io/magma/python-precommit
+          # generate Docker tags based on the following events/attributes
+          tags: |
+            type=sha
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v1
+      - name: "Login to GHCR"
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Docker Build
+        id: docker_build
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: ${{ env.DOCKERFILE }}
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
   build_devcontainer_dockerfile:
     env:
       DOCKERFILE: .devcontainer/Dockerfile


### PR DESCRIPTION
Signed-off-by: Marie Bremner <marwhal@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary
To prevent python formatting CI job from getting out of sync with the local python precommit job, I propose we store the Docker image for python-precommit in GitHub. Then we can use the same image both locally and in the GitHub action (if the PR is relatively up-to-date)

Question for GitHub action pros... is there a way to not copy and paste the steps? 

<!-- Enumerate changes you made and why you made them -->

## Test Plan
Not exactly sure how to test this
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
