### PR TITLE
fix(mme): Removing stop_timer extra call on service303 thread exit

### DIFF
--- a/lte/gateway/c/core/oai/tasks/service303/service303_task.c
+++ b/lte/gateway/c/core/oai/tasks/service303/service303_task.c
@@ -147,7 +147,6 @@ int service303_init(service303_data_t* service303_data) {
 }
 
 static void service303_server_exit(void) {
-  stop_timer(&service303_message_task_zmq_ctx, display_stats_timer_id);
   destroy_task_context(&service303_server_task_zmq_ctx);
   OAI_FPRINTF_INFO("TASK_SERVICE303_SERVER terminated\n");
   pthread_exit(NULL);


### PR DESCRIPTION
Signed-off-by: Alex Rodriguez <ardzoht@gmail.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->
- v1.6 and master branches are diverged on service303 thread exit handling while backporting #7952, which ended up having two calls for stop_timer on v1.6 (master is in expected state)
- Removing extra call of stop_timer on `service303_server_exit`

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->
- restarting mme continuously to ensure `zloop_timer_end` assert fail does not happen

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
