### PR TITLE
fix(agw): [Non_Sanity] Fixed standalone pdn conn req with apn correction failing

### DIFF
--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_esm_info_with_apn_correction.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_esm_info_with_apn_correction.py
@@ -20,23 +20,27 @@ from integ_tests.s1aptests import s1ap_wrapper
 from s1ap_utils import MagmadUtil
 
 
-class TestEsmInformationWithApnCorrection(unittest.TestCase):
+class TestAttachEsmInfoWithApnCorrection(unittest.TestCase):
+    """Unittest: TestAttachEsmInfoWithApnCorrection"""
+
     def setUp(self):
+        """Initialize before test case execution"""
         self._s1ap_wrapper = s1ap_wrapper.TestWrapper(
-                apn_correction=MagmadUtil.apn_correction_cmds.ENABLE,
+            apn_correction=MagmadUtil.apn_correction_cmds.ENABLE,
         )
 
     def tearDown(self):
+        """Cleanup after test case execution"""
         self._s1ap_wrapper.cleanup()
 
-    def test_attach_esm_information_with_apn_correction(self):
-        """ Testing of sending wrong APN in Esm Information procedure and
-        using APN correction feature to override it """
+    def test_attach_esm_info_with_apn_correction(self):
+        """Testing of sending wrong APN in Esm Information procedure and
+        using APN correction feature to override it"""
         num_ues = 1
 
-        print('************************* restarting mme')
-        self._s1ap_wrapper.magmad_util.restart_services(['mme'])
-        for j in range(15):
+        print("************************* restarting mme")
+        self._s1ap_wrapper.magmad_util.restart_services(["mme"])
+        for j in range(30):
             print("Waiting mme restart for", j, "seconds")
             time.sleep(1)
 
@@ -57,12 +61,14 @@ class TestEsmInformationWithApnCorrection(unittest.TestCase):
 
         print("Sending Attach Request ue-id", attach_req.ue_Id)
         self._s1ap_wrapper._s1_util.issue_cmd(
-            s1ap_types.tfwCmd.UE_ATTACH_REQUEST, attach_req,
+            s1ap_types.tfwCmd.UE_ATTACH_REQUEST,
+            attach_req,
         )
 
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_AUTH_REQ_IND.value,
+            response.msg_type,
+            s1ap_types.tfwCmd.UE_AUTH_REQ_IND.value,
         )
         print("Received auth req ind ")
 
@@ -73,12 +79,14 @@ class TestEsmInformationWithApnCorrection(unittest.TestCase):
         auth_res.sqnRcvd = sqn_recvd
         print("Sending Auth Response ue-id", auth_res.ue_Id)
         self._s1ap_wrapper._s1_util.issue_cmd(
-            s1ap_types.tfwCmd.UE_AUTH_RESP, auth_res,
+            s1ap_types.tfwCmd.UE_AUTH_RESP,
+            auth_res,
         )
 
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_SEC_MOD_CMD_IND.value,
+            response.msg_type,
+            s1ap_types.tfwCmd.UE_SEC_MOD_CMD_IND.value,
         )
         print("Received Security Mode Command ue-id", auth_res.ue_Id)
 
@@ -87,21 +95,25 @@ class TestEsmInformationWithApnCorrection(unittest.TestCase):
         sec_mode_complete = s1ap_types.ueSecModeComplete_t()
         sec_mode_complete.ue_Id = 1
         self._s1ap_wrapper._s1_util.issue_cmd(
-            s1ap_types.tfwCmd.UE_SEC_MOD_COMPLETE, sec_mode_complete,
+            s1ap_types.tfwCmd.UE_SEC_MOD_COMPLETE,
+            sec_mode_complete,
         )
 
         # Esm Information Request indication
         print(
-            "Received Esm Information Request ue-id", sec_mode_complete.ue_Id,
+            "Received Esm Information Request ue-id",
+            sec_mode_complete.ue_Id,
         )
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_ESM_INFORMATION_REQ.value,
+            response.msg_type,
+            s1ap_types.tfwCmd.UE_ESM_INFORMATION_REQ.value,
         )
         esm_info_req = response.cast(s1ap_types.ueEsmInformationReq_t)
         # Sending Esm Information Response
         print(
-            "Sending Esm Information Response ue-id", sec_mode_complete.ue_Id,
+            "Sending Esm Information Response ue-id",
+            sec_mode_complete.ue_Id,
         )
         esm_info_response = s1ap_types.ueEsmInformationRsp_t()
         esm_info_response.ue_Id = 1
@@ -114,23 +126,27 @@ class TestEsmInformationWithApnCorrection(unittest.TestCase):
         )
         print("Sending Esm Information with wrong APN ", s)
         self._s1ap_wrapper._s1_util.issue_cmd(
-            s1ap_types.tfwCmd.UE_ESM_INFORMATION_RSP, esm_info_response,
+            s1ap_types.tfwCmd.UE_ESM_INFORMATION_RSP,
+            esm_info_response,
         )
 
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.INT_CTX_SETUP_IND.value,
+            response.msg_type,
+            s1ap_types.tfwCmd.INT_CTX_SETUP_IND.value,
         )
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_ATTACH_ACCEPT_IND.value,
+            response.msg_type,
+            s1ap_types.tfwCmd.UE_ATTACH_ACCEPT_IND.value,
         )
 
         # Trigger Attach Complete
         attach_complete = s1ap_types.ueAttachComplete_t()
         attach_complete.ue_Id = 1
         self._s1ap_wrapper._s1_util.issue_cmd(
-            s1ap_types.tfwCmd.UE_ATTACH_COMPLETE, attach_complete,
+            s1ap_types.tfwCmd.UE_ATTACH_COMPLETE,
+            attach_complete,
         )
         # Wait on EMM Information from MME
         self._s1ap_wrapper._s1_util.receive_emm_info()
@@ -143,20 +159,22 @@ class TestEsmInformationWithApnCorrection(unittest.TestCase):
             s1ap_types.ueDetachType_t.UE_SWITCHOFF_DETACH.value
         )
         self._s1ap_wrapper._s1_util.issue_cmd(
-            s1ap_types.tfwCmd.UE_DETACH_REQUEST, detach_req,
+            s1ap_types.tfwCmd.UE_DETACH_REQUEST,
+            detach_req,
         )
         # Wait for UE context release command
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_CTX_REL_IND.value,
+            response.msg_type,
+            s1ap_types.tfwCmd.UE_CTX_REL_IND.value,
         )
 
         # Disable APN Correction
         self._s1ap_wrapper.magmad_util.config_apn_correction(
-                MagmadUtil.apn_correction_cmds.DISABLE,
+            MagmadUtil.apn_correction_cmds.DISABLE,
         )
-        self._s1ap_wrapper.magmad_util.restart_services(['mme'])
-        for j in range(10):
+        self._s1ap_wrapper.magmad_util.restart_services(["mme"])
+        for j in range(30):
             print("Waiting mme restart for", j, "seconds")
             time.sleep(1)
 

--- a/lte/gateway/python/integ_tests/s1aptests/test_standalone_pdn_conn_req_with_apn_correction.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_standalone_pdn_conn_req_with_apn_correction.py
@@ -20,25 +20,28 @@ import s1ap_wrapper
 from s1ap_utils import MagmadUtil
 
 
-class TestStandAlonePdnConnReqWithApnCorrection(unittest.TestCase):
+class TestStandalonePdnConnReqWithApnCorrection(unittest.TestCase):
+    """Unittest: TestStandalonePdnConnReqWithApnCorrection"""
 
     def setUp(self):
+        """Initialize before test case execution"""
         self._s1ap_wrapper = s1ap_wrapper.TestWrapper(
-                apn_correction=MagmadUtil.apn_correction_cmds.ENABLE,
+            apn_correction=MagmadUtil.apn_correction_cmds.ENABLE,
         )
 
     def tearDown(self):
+        """Cleanup after test case execution"""
         self._s1ap_wrapper.cleanup()
 
     def test_standalone_pdn_conn_req_with_apn_correction(self):
-        """ Attach a single UE and send standalone PDN Connectivity
+        """Attach a single UE and send standalone PDN Connectivity
         Request with wrong APN and use APN correction feature to
         override it"""
         num_ues = 1
 
-        print('************************* restarting mme')
-        self._s1ap_wrapper.magmad_util.restart_services(['mme'])
-        for j in range(15):
+        print("************************* restarting mme")
+        self._s1ap_wrapper.magmad_util.restart_services(["mme"])
+        for j in range(30):
             print("Waiting mme restart for", j, "seconds")
             time.sleep(1)
 
@@ -51,7 +54,8 @@ class TestStandAlonePdnConnReqWithApnCorrection(unittest.TestCase):
         )
         # Now actually complete the attach
         self._s1ap_wrapper.s1_util.attach(
-            ue_id, s1ap_types.tfwCmd.UE_END_TO_END_ATTACH_REQUEST,
+            ue_id,
+            s1ap_types.tfwCmd.UE_END_TO_END_ATTACH_REQUEST,
             s1ap_types.tfwCmd.UE_ATTACH_ACCEPT_IND,
             s1ap_types.ueAttachAccept_t,
         )
@@ -61,7 +65,8 @@ class TestStandAlonePdnConnReqWithApnCorrection(unittest.TestCase):
 
         print(
             "************************* Sending PDN Connectivity Request ",
-            "for UE id ", ue_id,
+            "for UE id ",
+            ue_id,
         )
         req = s1ap_types.uepdnConReq_t()
         req.ue_Id = ue_id
@@ -71,36 +76,41 @@ class TestStandAlonePdnConnReqWithApnCorrection(unittest.TestCase):
         # PDN Type = IPv4
         req.pdnType_pr.pdn_type = 1
         req.pdnAPN_pr.pres = 1
-        s = 'internet.mnc012.mcc345.gprs'
+        s = "internet.mnc012.mcc345.gprs"
         req.pdnAPN_pr.len = len(s)
-        req.pdnAPN_pr.pdn_apn = (ctypes.c_ubyte * 100)(*[ctypes.c_ubyte(ord(c)) for c in s[:100]])
+        req.pdnAPN_pr.pdn_apn = (ctypes.c_ubyte * 100)(
+            *[ctypes.c_ubyte(ord(c)) for c in s[:100]],
+        )
         self._s1ap_wrapper.s1_util.issue_cmd(
-            s1ap_types.tfwCmd.UE_PDN_CONN_REQ, req,
+            s1ap_types.tfwCmd.UE_PDN_CONN_REQ,
+            req,
         )
         # Receive PDN Connectivity Reject
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_PDN_CONN_RSP_IND.value,
+            response.msg_type,
+            s1ap_types.tfwCmd.UE_PDN_CONN_RSP_IND.value,
         )
-        # self.assertEqual(
-        #    response.msg_type, s1ap_types.tfwCmd.UE_ATTACH_FAIL_IND.value)
 
         print("Received PDN CONNECTIVITY REJECT")
         print(
             "************************* Running UE detach (switch-off) for ",
-            "UE id ", ue_id,
+            "UE id ",
+            ue_id,
         )
         # Now detach the UE
         self._s1ap_wrapper.s1_util.detach(
-            ue_id, s1ap_types.ueDetachType_t.UE_SWITCHOFF_DETACH.value, False,
+            ue_id,
+            s1ap_types.ueDetachType_t.UE_SWITCHOFF_DETACH.value,
+            wait_for_s1_ctxt_release=False,
         )
 
         # Disable APN correction
         self._s1ap_wrapper.magmad_util.config_apn_correction(
-                MagmadUtil.apn_correction_cmds.DISABLE,
+            MagmadUtil.apn_correction_cmds.DISABLE,
         )
-        self._s1ap_wrapper.magmad_util.restart_services(['mme'])
-        for j in range(10):
+        self._s1ap_wrapper.magmad_util.restart_services(["mme"])
+        for j in range(30):
             print("Waiting mme restart for", j, "seconds")
             time.sleep(1)
 


### PR DESCRIPTION
## Title
[Non_Sanity] Fixed standalone pdn conn req with apn correction and ESM information with APN correction

## Summary
The non sanity test case s1aptests/test_standalone_pdn_conn_req_with_apn_correction.py and s1aptests/test_attach_esm_info_with_apn_correction.py were failing because MME was not reachable after the small sleep time set in the test script. This PR fixes the issue by increasing the sleep time to 30 seconds for MME to come up properly

## Test Plan
Tested individually and as part of sanity

Signed-off-by: VinashakAnkitAman <ankit.aman@radisys.com>