### PR TITLE
chore: update devcontainer hash to sha-007ddb9

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -18,7 +18,7 @@
 		"stackbuild.bazel-stack-vscode-cc",
 		"augustocdias.tasks-shell-input",
 	],
-	"image": "ghcr.io/magma/devcontainer:sha-6c9b920",
+	"image": "ghcr.io/magma/devcontainer:sha-007ddb9",
 	"settings": {
 		"terminal.integrated.shell.linux": "/bin/bash",
 		"files.watcherExclude": {

--- a/.github/workflows/agw-workflow.yml
+++ b/.github/workflows/agw-workflow.yml
@@ -12,7 +12,7 @@ on:  # yamllint disable-line rule:truthy
     types: [opened, reopened, synchronize]
 
 env:
-  DEVCONTAINER_IMAGE: "ghcr.io/magma/devcontainer:sha-6c9b920"
+  DEVCONTAINER_IMAGE: "ghcr.io/magma/devcontainer:sha-007ddb9"
 
 jobs:
   path_filter:

--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -10,7 +10,7 @@ on:  # yamllint disable-line rule:truthy
     # Run once a day to build bazel cache at 0200 hours
     - cron: '0 2 * * *'
 env:
-  DEVCONTAINER_IMAGE: "ghcr.io/magma/devcontainer:sha-6c9b920"
+  DEVCONTAINER_IMAGE: "ghcr.io/magma/devcontainer:sha-007ddb9"
   BAZEL_CACHE: bazel-cache
   BAZEL_CACHE_REPO: bazel-cache-repo
 

--- a/.github/workflows/gcc-problems.yml
+++ b/.github/workflows/gcc-problems.yml
@@ -15,7 +15,7 @@ on:
       - reopened
       - synchronize
 env:
-  DEVCONTAINER_IMAGE: "ghcr.io/magma/devcontainer:sha-6c9b920"
+  DEVCONTAINER_IMAGE: "ghcr.io/magma/devcontainer:sha-007ddb9"
 
 # See [Example Sharing Container Between Jobs](https://github.com/docker/build-push-action/issues/225)
 jobs:


### PR DESCRIPTION
Signed-off-by: Marie Bremner <marwhal@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary
I had to re-build the devcontainer again, so now that it's built updating the hash.
<!-- Enumerate changes you made and why you made them -->

## Test Plan
The file is there locally in the devcontainer if I use the hash
<img width="607" alt="Screen Shot 2021-10-07 at 10 07 31 AM" src="https://user-images.githubusercontent.com/37634144/136401483-754638a3-b680-46ba-b038-5fe020ed6c15.png">
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
