### PR TITLE
refactor(nms): NMS Gen refactor for Linux/Darwin

### DIFF
--- a/orc8r/cloud/Makefile
+++ b/orc8r/cloud/Makefile
@@ -39,6 +39,8 @@ SWAGGER_V1_COMMON_DIR := $(SWAGGER_V1_SPECS_DIR)/common
 SWAGGER_V1_STANDALONE_DIR := $(SWAGGER_V1_SPECS_DIR)/standalone
 SWAGGER_NMS_OUT := $(MAGMA_ROOT)/nms/packages/magmalte/generated/MagmaAPIBindings.js
 
+OS_NAME := $(shell uname)
+
 export SWAGGER_ROOT
 export SWAGGER_COMMON
 export SWAGGER_V1_ROOT
@@ -167,7 +169,11 @@ $(SWAGGER_LIST): %_swagger:
 nms_fullgen: nms_prereqs nms_gen
 
 nms_prereqs:
-	$(MAKE) nms_prereqs_ubuntu || $(MAKE) nms_prereqs_osx
+ifeq ($(OS_NAME),Linux)
+	$(MAKE) nms_prereqs_ubuntu
+else ifeq ($(OS_NAME),Darwin)
+	$(MAKE) nms_prereqs_osx
+endif
 
 nms_prereqs_ubuntu: nms_node_ubuntu
 	NODE="$(shell which nodejs)"; ln -s $$NODE /usr/local/bin/node
@@ -187,7 +193,8 @@ nms_node_ubuntu:
 	curl -fSL https://deb.nodesource.com/setup_14.x | bash -
 	apt-get install -y nodejs
 	# And now install npm
-	apt install -y npm
+	apt install -y aptitude
+	aptitude install -y npm
 	# symlink nodejs executable
 	mkdir -p /usr/local/bin
 


### PR DESCRIPTION
Signed-off-by: Andrei Lee <andreilee@fb.com>

## Summary

Small refactor for Makefile directive for nms gen

## Test Plan

Tested on MacOS:
```
➜  cloud git:(1-10-nms-gen-fix-2) ✗ make nms_fullgen
Makefile:21: MAGMA_MODULES is undefined, using default: /Users/andreilee/magma/orc8r /Users/andreilee/magma/lte /Users/andreilee/magma/feg /Users/andreilee/magma/cwf /Users/andreilee/magma/wifi /Users/andreilee/magma/fbinternal
/Library/Developer/CommandLineTools/usr/bin/make nms_prereqs_osx
Makefile:21: MAGMA_MODULES is undefined, using default: /Users/andreilee/magma/orc8r /Users/andreilee/magma/lte /Users/andreilee/magma/feg /Users/andreilee/magma/cwf /Users/andreilee/magma/wifi /Users/andreilee/magma/fbinternal
node --version || brew install node
v12.22.6
npm --version || brew install npm
6.14.15
yarn --version || npm install --global yarn
1.22.11
yarn add swagger-js-codegen
yarn add v1.22.11
warning package.json: No license field
warning No license field
[1/4] 🔍  Resolving packages...
[2/4] 🚚  Fetching packages...
[3/4] 🔗  Linking dependencies...
[4/4] 🔨  Building fresh packages...
warning No license field
success Saved 1 new dependency.
info Direct dependencies
└─ swagger-js-codegen@1.13.0
info All dependencies
└─ swagger-js-codegen@1.13.0
✨  Done in 0.68s.
# generate Swagger API bindings for NMS
/Users/andreilee/magma/nms/packages/magmalte/scripts/generateAPIFromSwagger.sh /Users/andreilee/magma/orc8r/cloud/go/obsidian/swagger/v1/swagger.yml /Users/andreilee/magma/nms/packages/magmalte/generated/MagmaAPIBindings.js
Input Swagger file: /Users/andreilee/magma/orc8r/cloud/go/obsidian/swagger/v1/swagger.yml
Output file: /Users/andreilee/magma/nms/packages/magmalte/generated/MagmaAPIBindings.js
warning package.json: No license field
```

Tested with `build.py --generate`
```
➜  docker git:(1-10-nms-gen-fix-2) ✗ ./build.py --generate
Creating build context in '/tmp/magma_orc8r_build'...
...make nms_prereqs_ubuntu
make[1]: Entering directory '/src/magma/orc8r/cloud'
# install pre-reqs
apt update
Get:1 http://security.ubuntu.com/ubuntu xenial-security InRelease [109 kB]
Hit:2 http://archive.ubuntu.com/ubuntu xenial InRelease
Get:3 http://archive.ubuntu.com/ubuntu xenial-updates InRelease [109 kB]
Get:4 http://security.ubuntu.com/ubuntu xenial-security/main amd64 Packages [2051 kB]
Get:5 http://archive.ubuntu.com/ubuntu xenial-backports InRelease [107 kB]
Get:6 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 Packages [2560 kB]
Get:7 http://security.ubuntu.com/ubuntu xenial-security/universe amd64 Packages [984 kB]
Get:8 http://archive.ubuntu.com/ubuntu xenial-updates/universe amd64 Packages [1544 kB]
Get:9 http://archive.ubuntu.com/ubuntu xenial-backports/universe amd64 Packages [12.7 kB]
Fetched 7476 kB in 3s (2077 kB/s)
Reading package lists... Done
Building dependency tree
Reading state information... Done
46 packages can be upgraded. Run 'apt list --upgradable' to see them.
# Handle certificate verification
apt-get install -y libgnutls30
Reading package lists... Done
Building dependency tree
Reading state information... Done
Suggested packages:
  gnutls-bin
The following packages will be upgraded:
  libgnutls30
1 upgraded, 0 newly installed, 0 to remove and 45 not upgraded.
Need to get 548 kB of archives.
After this operation, 4096 B of additional disk space will be used.
Get:1 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 libgnutls30 amd64 3.4.10-4ubuntu1.9 [548 kB]
Fetched 548 kB in 2s (226 kB/s)
debconf: delaying package configuration, since apt-utils is not installed
(Reading database ... 17826 files and directories currently installed.)
Preparing to unpack .../libgnutls30_3.4.10-4ubuntu1.9_amd64.deb ...
Unpacking libgnutls30:amd64 (3.4.10-4ubuntu1.9) over (3.4.10-4ubuntu1.8) ...
Processing triggers for libc-bin (2.23-0ubuntu11) ...
Setting up libgnutls30:amd64 (3.4.10-4ubuntu1.9) ...
Processing triggers for libc-bin (2.23-0ubuntu11) ...
# Get a newer version of nodejs
curl -fSL https://deb.nodesource.com/setup_14.x | bash -
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 13764  100 13764    0     0  26674      0 --:--:-- --:--:-- --:--:-- 26726

## Installing the NodeSource Node.js 14.x repo...


## Populating apt-get cache...

+ apt-get update
Hit:1 http://security.ubuntu.com/ubuntu xenial-security InRelease
Hit:2 http://archive.ubuntu.com/ubuntu xenial InRelease
Hit:3 http://archive.ubuntu.com/ubuntu xenial-updates InRelease
Hit:4 http://archive.ubuntu.com/ubuntu xenial-backports InRelease
Reading package lists... Done

## Installing packages required for setup: apt-transport-https lsb-release...

+ apt-get install -y apt-transport-https lsb-release > /dev/null 2>&1

## Confirming "xenial" is supported...

+ curl -sLf -o /dev/null 'https://deb.nodesource.com/node_14.x/dists/xenial/Release'

## Adding the NodeSource signing key to your keyring...

+ curl -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key | gpg --dearmor | tee /usr/share/keyrings/nodesource.gpg >/dev/null

## Creating apt sources list file for the NodeSource Node.js 14.x repo...

+ echo 'deb [signed-by=/usr/share/keyrings/nodesource.gpg] https://deb.nodesource.com/node_14.x xenial main' > /etc/apt/sources.list.d/nodesource.list
+ echo 'deb-src [signed-by=/usr/share/keyrings/nodesource.gpg] https://deb.nodesource.com/node_14.x xenial main' >> /etc/apt/sources.list.d/nodesource.list

## Running `apt-get update` for you...

+ apt-get update
Hit:1 http://archive.ubuntu.com/ubuntu xenial InRelease
Hit:2 http://security.ubuntu.com/ubuntu xenial-security InRelease
Get:3 https://deb.nodesource.com/node_14.x xenial InRelease [4584 B]
Hit:4 http://archive.ubuntu.com/ubuntu xenial-updates InRelease
Get:5 https://deb.nodesource.com/node_14.x xenial/main amd64 Packages [768 B]
Hit:6 http://archive.ubuntu.com/ubuntu xenial-backports InRelease
Fetched 5352 B in 1s (5307 B/s)
Reading package lists... Done

## Run `sudo apt-get install -y nodejs` to install Node.js 14.x and npm
## You may also need development tools to build native addons:
     sudo apt-get install gcc g++ make
## To install the Yarn package manager, run:
     curl -sL https://dl.yarnpkg.com/debian/pubkey.gpg | gpg --dearmor | sudo tee /usr/share/keyrings/yarnkey.gpg >/dev/null
     echo "deb [signed-by=/usr/share/keyrings/yarnkey.gpg] https://dl.yarnpkg.com/debian stable main" | sudo tee /etc/apt/sources.list.d/yarn.list
     sudo apt-get update && sudo apt-get install yarn


apt-get install -y nodejs
Reading package lists... Done
Building dependency tree
Reading state information... Done
The following NEW packages will be installed:
  nodejs
0 upgraded, 1 newly installed, 0 to remove and 45 not upgraded.
Need to get 25.2 MB of archives.
After this operation, 122 MB of additional disk space will be used.
Get:1 https://deb.nodesource.com/node_14.x xenial/main amd64 nodejs amd64 14.18.0-1nodesource1 [25.2 MB]
Fetched 25.2 MB in 34s (722 kB/s)
debconf: delaying package configuration, since apt-utils is not installed
Selecting previously unselected package nodejs.
(Reading database ... 17969 files and directories currently installed.)
Preparing to unpack .../nodejs_14.18.0-1nodesource1_amd64.deb ...
Unpacking nodejs (14.18.0-1nodesource1) ...
Setting up nodejs (14.18.0-1nodesource1) ...
# And now install npm
apt install -y aptitude
Reading package lists... Done
Building dependency tree
Reading state information... Done
The following additional packages will be installed:
  aptitude-common libboost-iostreams1.58.0 libcgi-fast-perl libcgi-pm-perl libclass-accessor-perl libcwidget3v5 libencode-locale-perl libfcgi-perl libhtml-parser-perl libhtml-tagset-perl libhttp-date-perl libhttp-message-perl libio-html-perl libio-string-perl
  liblocale-gettext-perl liblwp-mediatypes-perl libparse-debianchangelog-perl libsigc++-2.0-0v5 libsub-name-perl libtimedate-perl liburi-perl libxapian22v5
Suggested packages:
  apt-xapian-index aptitude-doc-en | aptitude-doc debtags tasksel libcwidget-dev libdata-dump-perl libhtml-template-perl libxml-simple-perl libwww-perl xapian-tools
The following NEW packages will be installed:
  aptitude aptitude-common libboost-iostreams1.58.0 libcgi-fast-perl libcgi-pm-perl libclass-accessor-perl libcwidget3v5 libencode-locale-perl libfcgi-perl libhtml-parser-perl libhtml-tagset-perl libhttp-date-perl libhttp-message-perl libio-html-perl
  libio-string-perl liblocale-gettext-perl liblwp-mediatypes-perl libparse-debianchangelog-perl libsigc++-2.0-0v5 libsub-name-perl libtimedate-perl liburi-perl libxapian22v5
0 upgraded, 23 newly installed, 0 to remove and 45 not upgraded.
Need to get 3664 kB of archives.
After this operation, 14.8 MB of additional disk space will be used.
Get:1 http://archive.ubuntu.com/ubuntu xenial/main amd64 liblocale-gettext-perl amd64 1.07-1build1 [17.1 kB]
Get:2 http://archive.ubuntu.com/ubuntu xenial/main amd64 aptitude-common all 0.7.4-2ubuntu2 [747 kB]
Get:3 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 libboost-iostreams1.58.0 amd64 1.58.0+dfsg-5ubuntu3.1 [29.0 kB]
Get:4 http://archive.ubuntu.com/ubuntu xenial/main amd64 libsigc++-2.0-0v5 amd64 2.6.2-1 [11.1 kB]
Get:5 http://archive.ubuntu.com/ubuntu xenial/main amd64 libcwidget3v5 amd64 0.5.17-4ubuntu2 [292 kB]
Get:6 http://archive.ubuntu.com/ubuntu xenial/main amd64 libxapian22v5 amd64 1.2.22-2 [589 kB]
Get:7 http://archive.ubuntu.com/ubuntu xenial/main amd64 aptitude amd64 0.7.4-2ubuntu2 [1306 kB]
Get:8 http://archive.ubuntu.com/ubuntu xenial/main amd64 libhtml-tagset-perl all 3.20-2 [13.5 kB]
Get:9 http://archive.ubuntu.com/ubuntu xenial/main amd64 liburi-perl all 1.71-1 [76.9 kB]
Get:10 http://archive.ubuntu.com/ubuntu xenial/main amd64 libhtml-parser-perl amd64 3.72-1 [86.1 kB]
Get:11 http://archive.ubuntu.com/ubuntu xenial/main amd64 libcgi-pm-perl all 4.26-1 [185 kB]
Get:12 http://archive.ubuntu.com/ubuntu xenial/main amd64 libfcgi-perl amd64 0.77-1build1 [32.3 kB]
Get:13 http://archive.ubuntu.com/ubuntu xenial/main amd64 libcgi-fast-perl all 1:2.10-1 [10.2 kB]
Get:14 http://archive.ubuntu.com/ubuntu xenial/main amd64 libsub-name-perl amd64 0.14-1build1 [10.8 kB]
Get:15 http://archive.ubuntu.com/ubuntu xenial/main amd64 libclass-accessor-perl all 0.34-1 [26.0 kB]
Get:16 http://archive.ubuntu.com/ubuntu xenial/main amd64 libencode-locale-perl all 1.05-1 [12.3 kB]
Get:17 http://archive.ubuntu.com/ubuntu xenial/main amd64 libtimedate-perl all 2.3000-2 [37.5 kB]
Get:18 http://archive.ubuntu.com/ubuntu xenial/main amd64 libhttp-date-perl all 6.02-1 [10.4 kB]
Get:19 http://archive.ubuntu.com/ubuntu xenial/main amd64 libio-html-perl all 1.001-1 [14.9 kB]
Get:20 http://archive.ubuntu.com/ubuntu xenial/main amd64 liblwp-mediatypes-perl all 6.02-1 [21.7 kB]
Get:21 http://archive.ubuntu.com/ubuntu xenial/main amd64 libhttp-message-perl all 6.11-1 [74.3 kB]
Get:22 http://archive.ubuntu.com/ubuntu xenial/main amd64 libio-string-perl all 1.08-3 [11.1 kB]
Get:23 http://archive.ubuntu.com/ubuntu xenial/main amd64 libparse-debianchangelog-perl all 1.2.0-8 [50.4 kB]
Fetched 3664 kB in 2s (1226 kB/s)
debconf: delaying package configuration, since apt-utils is not installed
Selecting previously unselected package liblocale-gettext-perl.
(Reading database ... 22900 files and directories currently installed.)
Preparing to unpack .../liblocale-gettext-perl_1.07-1build1_amd64.deb ...
Unpacking liblocale-gettext-perl (1.07-1build1) ...
Selecting previously unselected package aptitude-common.
Preparing to unpack .../aptitude-common_0.7.4-2ubuntu2_all.deb ...
Unpacking aptitude-common (0.7.4-2ubuntu2) ...
Selecting previously unselected package libboost-iostreams1.58.0:amd64.
Preparing to unpack .../libboost-iostreams1.58.0_1.58.0+dfsg-5ubuntu3.1_amd64.deb ...
Unpacking libboost-iostreams1.58.0:amd64 (1.58.0+dfsg-5ubuntu3.1) ...
Selecting previously unselected package libsigc++-2.0-0v5:amd64.
Preparing to unpack .../libsigc++-2.0-0v5_2.6.2-1_amd64.deb ...
Unpacking libsigc++-2.0-0v5:amd64 (2.6.2-1) ...
Selecting previously unselected package libcwidget3v5:amd64.
Preparing to unpack .../libcwidget3v5_0.5.17-4ubuntu2_amd64.deb ...
Unpacking libcwidget3v5:amd64 (0.5.17-4ubuntu2) ...
Selecting previously unselected package libxapian22v5:amd64.
Preparing to unpack .../libxapian22v5_1.2.22-2_amd64.deb ...
Unpacking libxapian22v5:amd64 (1.2.22-2) ...
Selecting previously unselected package aptitude.
Preparing to unpack .../aptitude_0.7.4-2ubuntu2_amd64.deb ...
Unpacking aptitude (0.7.4-2ubuntu2) ...
Selecting previously unselected package libhtml-tagset-perl.
Preparing to unpack .../libhtml-tagset-perl_3.20-2_all.deb ...
Unpacking libhtml-tagset-perl (3.20-2) ...
Selecting previously unselected package liburi-perl.
Preparing to unpack .../liburi-perl_1.71-1_all.deb ...
Unpacking liburi-perl (1.71-1) ...
Selecting previously unselected package libhtml-parser-perl.
Preparing to unpack .../libhtml-parser-perl_3.72-1_amd64.deb ...
Unpacking libhtml-parser-perl (3.72-1) ...
Selecting previously unselected package libcgi-pm-perl.
Preparing to unpack .../libcgi-pm-perl_4.26-1_all.deb ...
Unpacking libcgi-pm-perl (4.26-1) ...
Selecting previously unselected package libfcgi-perl.
Preparing to unpack .../libfcgi-perl_0.77-1build1_amd64.deb ...
Unpacking libfcgi-perl (0.77-1build1) ...
Selecting previously unselected package libcgi-fast-perl.
Preparing to unpack .../libcgi-fast-perl_1%3a2.10-1_all.deb ...
Unpacking libcgi-fast-perl (1:2.10-1) ...
Selecting previously unselected package libsub-name-perl.
Preparing to unpack .../libsub-name-perl_0.14-1build1_amd64.deb ...
Unpacking libsub-name-perl (0.14-1build1) ...
Selecting previously unselected package libclass-accessor-perl.
Preparing to unpack .../libclass-accessor-perl_0.34-1_all.deb ...
Unpacking libclass-accessor-perl (0.34-1) ...
Selecting previously unselected package libencode-locale-perl.
Preparing to unpack .../libencode-locale-perl_1.05-1_all.deb ...
Unpacking libencode-locale-perl (1.05-1) ...
Selecting previously unselected package libtimedate-perl.
Preparing to unpack .../libtimedate-perl_2.3000-2_all.deb ...
Unpacking libtimedate-perl (2.3000-2) ...
Selecting previously unselected package libhttp-date-perl.
Preparing to unpack .../libhttp-date-perl_6.02-1_all.deb ...
Unpacking libhttp-date-perl (6.02-1) ...
Selecting previously unselected package libio-html-perl.
Preparing to unpack .../libio-html-perl_1.001-1_all.deb ...
Unpacking libio-html-perl (1.001-1) ...
Selecting previously unselected package liblwp-mediatypes-perl.
Preparing to unpack .../liblwp-mediatypes-perl_6.02-1_all.deb ...
Unpacking liblwp-mediatypes-perl (6.02-1) ...
Selecting previously unselected package libhttp-message-perl.
Preparing to unpack .../libhttp-message-perl_6.11-1_all.deb ...
Unpacking libhttp-message-perl (6.11-1) ...
Selecting previously unselected package libio-string-perl.
Preparing to unpack .../libio-string-perl_1.08-3_all.deb ...
Unpacking libio-string-perl (1.08-3) ...
Selecting previously unselected package libparse-debianchangelog-perl.
Preparing to unpack .../libparse-debianchangelog-perl_1.2.0-8_all.deb ...
Unpacking libparse-debianchangelog-perl (1.2.0-8) ...
Processing triggers for libc-bin (2.23-0ubuntu11) ...
Setting up liblocale-gettext-perl (1.07-1build1) ...
Setting up aptitude-common (0.7.4-2ubuntu2) ...
Setting up libboost-iostreams1.58.0:amd64 (1.58.0+dfsg-5ubuntu3.1) ...
Setting up libsigc++-2.0-0v5:amd64 (2.6.2-1) ...
Setting up libcwidget3v5:amd64 (0.5.17-4ubuntu2) ...
Setting up libxapian22v5:amd64 (1.2.22-2) ...
Setting up aptitude (0.7.4-2ubuntu2) ...
update-alternatives: using /usr/bin/aptitude-curses to provide /usr/bin/aptitude (aptitude) in auto mode
Setting up libhtml-tagset-perl (3.20-2) ...
Setting up liburi-perl (1.71-1) ...
Setting up libhtml-parser-perl (3.72-1) ...
Setting up libcgi-pm-perl (4.26-1) ...
Setting up libfcgi-perl (0.77-1build1) ...
Setting up libcgi-fast-perl (1:2.10-1) ...
Setting up libsub-name-perl (0.14-1build1) ...
Setting up libclass-accessor-perl (0.34-1) ...
Setting up libencode-locale-perl (1.05-1) ...
Setting up libtimedate-perl (2.3000-2) ...
Setting up libhttp-date-perl (6.02-1) ...
Setting up libio-html-perl (1.001-1) ...
Setting up liblwp-mediatypes-perl (6.02-1) ...
Setting up libhttp-message-perl (6.11-1) ...
Setting up libio-string-perl (1.08-3) ...
Setting up libparse-debianchangelog-perl (1.2.0-8) ...
Processing triggers for libc-bin (2.23-0ubuntu11) ...
aptitude install -y npm
The following NEW packages will be installed:
  build-essential{a} bzip2{a} dpkg-dev{a} fakeroot{a} g++{a} g++-5{a} gyp{a} libalgorithm-diff-perl{a} libalgorithm-diff-xs-perl{a} libalgorithm-merge-perl{a} libdpkg-perl{a} libfakeroot{a} libfile-fcntllock-perl{a} libjs-inherits{a} libjs-node-uuid{a}
  libjs-underscore{a} libstdc++-5-dev{a} node-abbrev{a} node-ansi{a} node-ansi-color-table{a} node-archy{a} node-async{a} node-block-stream{a} node-combined-stream{a} node-cookie-jar{a} node-delayed-stream{a} node-forever-agent{a} node-form-data{a}
  node-fstream{a} node-fstream-ignore{a} node-github-url-from-git{a} node-glob{a} node-graceful-fs{a} node-gyp{a} node-inherits{a} node-ini{a} node-json-stringify-safe{a} node-lockfile{a} node-lru-cache{a} node-mime{a} node-minimatch{a} node-mkdirp{a}
  node-mute-stream{a} node-node-uuid{a} node-nopt{a} node-normalize-package-data{a} node-npmlog{a} node-once{a} node-osenv{a} node-qs{a} node-read{a} node-read-package-json{a} node-request{a} node-retry{a} node-rimraf{a} node-semver{a} node-sha{a}
  node-sigmund{a} node-slide{a} node-tar{a} node-tunnel-agent{a} node-underscore{a} node-which{a} npm xz-utils{a}
0 packages upgraded, 65 newly installed, 0 to remove and 45 not upgraded.
Need to get 13.2 MB of archives. After unpacking 58.8 MB will be used.
The following packages have unmet dependencies:
 nodejs : Conflicts: npm but 3.5.2-0ubuntu4 is to be installed.
The following actions will resolve these dependencies:

     Keep the following packages at their current version:
1)     npm [Not Installed]



No packages will be installed, upgraded, or removed.
0 packages upgraded, 0 newly installed, 0 to remove and 45 not upgraded.
Need to get 0 B of archives. After unpacking 0 B will be used.

# symlink nodejs executable
mkdir -p /usr/local/bin
NODE="/usr/bin/nodejs"; ln -s $NODE /usr/local/bin/node
# update nodejs to latest
curl -sL https://deb.nodesource.com/setup_lts.x | bash -

## Installing the NodeSource Node.js 14.x repo...


## Populating apt-get cache...

+ apt-get update
Hit:1 http://security.ubuntu.com/ubuntu xenial-security InRelease
Hit:2 https://deb.nodesource.com/node_14.x xenial InRelease
Hit:3 http://archive.ubuntu.com/ubuntu xenial InRelease
Hit:4 http://archive.ubuntu.com/ubuntu xenial-updates InRelease
Hit:5 http://archive.ubuntu.com/ubuntu xenial-backports InRelease
Reading package lists... Done

## Confirming "xenial" is supported...

+ curl -sLf -o /dev/null 'https://deb.nodesource.com/node_14.x/dists/xenial/Release'

## Adding the NodeSource signing key to your keyring...

+ curl -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key | gpg --dearmor | tee /usr/share/keyrings/nodesource.gpg >/dev/null

## Creating apt sources list file for the NodeSource Node.js 14.x repo...

+ echo 'deb [signed-by=/usr/share/keyrings/nodesource.gpg] https://deb.nodesource.com/node_14.x xenial main' > /etc/apt/sources.list.d/nodesource.list
+ echo 'deb-src [signed-by=/usr/share/keyrings/nodesource.gpg] https://deb.nodesource.com/node_14.x xenial main' >> /etc/apt/sources.list.d/nodesource.list

## Running `apt-get update` for you...

+ apt-get update
Hit:1 http://security.ubuntu.com/ubuntu xenial-security InRelease
Hit:2 https://deb.nodesource.com/node_14.x xenial InRelease
Hit:3 http://archive.ubuntu.com/ubuntu xenial InRelease
Hit:4 http://archive.ubuntu.com/ubuntu xenial-updates InRelease
Hit:5 http://archive.ubuntu.com/ubuntu xenial-backports InRelease
Reading package lists... Done

## Run `sudo apt-get install -y nodejs` to install Node.js 14.x and npm
## You may also need development tools to build native addons:
     sudo apt-get install gcc g++ make
## To install the Yarn package manager, run:
     curl -sL https://dl.yarnpkg.com/debian/pubkey.gpg | gpg --dearmor | sudo tee /usr/share/keyrings/yarnkey.gpg >/dev/null
     echo "deb [signed-by=/usr/share/keyrings/yarnkey.gpg] https://dl.yarnpkg.com/debian stable main" | sudo tee /etc/apt/sources.list.d/yarn.list
     sudo apt-get update && sudo apt-get install yarn


apt-get install -y nodejs
Reading package lists... Done
Building dependency tree
Reading state information... Done
nodejs is already the newest version (14.18.0-1nodesource1).
0 upgraded, 0 newly installed, 0 to remove and 45 not upgraded.
# get codegen dependency
npm install --global yarn

> yarn@1.22.15 preinstall /usr/lib/node_modules/yarn
> :; (node ./preinstall.js > /dev/null 2>&1 || true)

/usr/bin/yarnpkg -> /usr/lib/node_modules/yarn/bin/yarn.js
/usr/bin/yarn -> /usr/lib/node_modules/yarn/bin/yarn.js
+ yarn@1.22.15
added 1 package in 1.687s
yarn add swagger-js-codegen
yarn add v1.22.15
warning package.json: No license field
warning No license field
[1/4] Resolving packages...
[2/4] Fetching packages...
[3/4] Linking dependencies...
[4/4] Building fresh packages...
warning No license field
success Saved 1 new dependency.
info Direct dependencies
└─ swagger-js-codegen@1.13.0
info All dependencies
└─ swagger-js-codegen@1.13.0
Done in 10.37s.
make[1]: Leaving directory '/src/magma/orc8r/cloud'
# generate Swagger API bindings for NMS
/src/magma/nms/packages/magmalte/scripts/generateAPIFromSwagger.sh /src/magma/orc8r/cloud/go/obsidian/swagger/v1/swagger.yml /src/magma/nms/packages/magmalte/generated/MagmaAPIBindings.js
Input Swagger file: /src/magma/orc8r/cloud/go/obsidian/swagger/v1/swagger.yml
Output file: /src/magma/nms/packages/magmalte/generated/MagmaAPIBindings.js
warning package.json: No license field
make -C /src/magma/orc8r/cloud/go tidy
make[1]: Entering directory '/src/magma/orc8r/cloud/go'
go mod tidy
make -C /src/magma/orc8r/lib/go tidy
make[2]: Entering directory '/src/magma/orc8r/lib/go'
go mod tidy
go: downloading github.com/google/go-cmp v0.2.0
go: downloading github.com/stretchr/testify v1.4.0
go: downloading gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405
go: extracting gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405
go: extracting github.com/stretchr/testify v1.4.0
go: extracting github.com/google/go-cmp v0.2.0
make[2]: Leaving directory '/src/magma/orc8r/lib/go'
make -C /src/magma/orc8r/lib/go/protos tidy
make[2]: Entering directory '/src/magma/orc8r/lib/go/protos'
go mod tidy
go: downloading github.com/davecgh/go-spew v1.1.0
go: downloading gopkg.in/yaml.v2 v2.2.2
go: extracting gopkg.in/yaml.v2 v2.2.2
go: extracting github.com/davecgh/go-spew v1.1.0
make[2]: Leaving directory '/src/magma/orc8r/lib/go/protos'
make[1]: Leaving directory '/src/magma/orc8r/cloud/go'
make -C /src/magma/lte/cloud/go tidy
make[1]: Entering directory '/src/magma/lte/cloud/go'
go mod tidy
make[1]: Leaving directory '/src/magma/lte/cloud/go'
make -C /src/magma/feg/cloud/go tidy
make[1]: Entering directory '/src/magma/feg/cloud/go'
go mod tidy
make[1]: Leaving directory '/src/magma/feg/cloud/go'
make -C /src/magma/cwf/cloud/go tidy
make[1]: Entering directory '/src/magma/cwf/cloud/go'
go mod tidy
make[1]: Leaving directory '/src/magma/cwf/cloud/go'
make -C /src/magma/wifi/cloud/go tidy
make[1]: Entering directory '/src/magma/wifi/cloud/go'
go mod tidy
make[1]: Leaving directory '/src/magma/wifi/cloud/go'
make -C /src/magma/fbinternal/cloud/go tidy
make[1]: Entering directory '/src/magma/fbinternal/cloud/go'
go mod tidy
make[1]: Leaving directory '/src/magma/fbinternal/cloud/go'
Running 'docker-compose down'...
[+] Running 2/1
 ⠿ Container orc8r_postgres_test_1  Removed                                                                                                                                                                                                                      0.2s
 ⠿ Network orc8r_default            Removed
```

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
