### PR TITLE
fix(agw): Set minimum Sctpd package version to last stable 1.6.0

### DIFF
--- a/lte/gateway/release/build-magma.sh
+++ b/lte/gateway/release/build-magma.sh
@@ -21,7 +21,7 @@ SCRIPT_DIR="$(dirname "$(realpath "$0")")"
 # Please update the version number accordingly for beta/stable builds
 # Test builds are versioned automatically by fabfile.py
 VERSION=1.7.0 # magma version number
-SCTPD_MIN_VERSION=1.7.0 # earliest version of sctpd with which this version is compatible
+SCTPD_MIN_VERSION=1.6.0 # earliest version of sctpd with which this version is compatible
 
 # RelWithDebInfo or Debug
 BUILD_TYPE=RelWithDebInfo


### PR DESCRIPTION
## Summary

The minimum Sctpd package version should only be updated when there is a code change in Sctpd. It may not match the version of Magma package. Keeping the package versions separate allows us to upgrade the Magma services without upgrading (and without restarting) Sctpd.

## Test Plan


1. Build magma package with `fab dev package` on local host
2. On dev VM, check package dependencies:
`vagrant@magma:~$ dpkg -I magma-packages/magma_1.7.0-1633715730-706d1a8a_amd64.deb  | grep sctpd`

,and verify that **magma-sctpd (>= 1.6.0)** shows up in the list

