### PR TITLE
fix(amf): Reimplement PDU Session data structure as maps in amf_context

### DIFF
--- a/lte/gateway/c/core/oai/tasks/amf/amf_app_handler.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_app_handler.cpp
@@ -582,7 +582,7 @@ void amf_app_handle_pdu_session_response(
   DLNASTransportMsg encode_msg;
   int amf_rc = RETURNerror;
   ue_m5gmm_context_s* ue_context;
-  smf_context_t* smf_ctx;
+  std::shared_ptr<smf_context_t> smf_ctx;
   amf_smf_t amf_smf_msg;
   // TODO: hardcoded for now, addressed in the upcoming multi-UE PR
   uint64_t ue_id = 0;
@@ -702,7 +702,7 @@ int amf_app_handle_pdu_session_accept(
   SmfMsg* smf_msg       = nullptr;
   bstring buffer;
   // smf_ctx declared and set but not used, commented to cleanup warnings
-  smf_context_t* smf_ctx                           = nullptr;
+  std::shared_ptr<smf_context_t> smf_ctx;
   ue_m5gmm_context_s* ue_context                   = nullptr;
   protocol_configuration_options_t* msg_accept_pco = nullptr;
 
@@ -873,7 +873,7 @@ void amf_app_handle_resource_setup_response(
   amf_ue_ngap_id_t ue_id;
 
   ue_m5gmm_context_s* ue_context = nullptr;
-  smf_context_t* smf_ctx         = nullptr;
+  std::shared_ptr<smf_context_t> smf_ctx;
 
   /* Check if failure message is not NULL and if NULL,
    * it is successful message from gNB.
@@ -1307,7 +1307,7 @@ void amf_app_handle_initial_context_setup_rsp(
     amf_app_desc_t* amf_app_desc_p,
     itti_amf_app_initial_context_setup_rsp_t* initial_context_rsp) {
   ue_m5gmm_context_s* ue_context = NULL;
-  smf_context_t* smf_context     = NULL;
+  std::shared_ptr<smf_context_t> smf_context;
   char imsi[IMSI_BCD_DIGITS_MAX + 1];
   Ngap_PDUSession_Resource_Setup_Response_List_t* pdu_list =
       &initial_context_rsp->PDU_Session_Resource_Setup_Response_Transfer;

--- a/lte/gateway/c/core/oai/tasks/amf/amf_app_handler.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_app_handler.cpp
@@ -593,7 +593,7 @@ void amf_app_handle_pdu_session_response(
   // Handle smf_context
   ue_context = lookup_ue_ctxt_by_imsi(imsi64);
   if (ue_context) {
-    smf_ctx = amf_smf_context_exists_pdu_session_id(
+    smf_ctx = amf_get_smf_context_by_pdu_session_id(
         ue_context, pdu_session_resp->pdu_session_id);
     if (smf_ctx == NULL) {
       OAILOG_ERROR(
@@ -715,7 +715,7 @@ int amf_app_handle_pdu_session_accept(
     return M5G_AS_FAILURE;
   }
 
-  smf_ctx = amf_smf_context_exists_pdu_session_id(
+  smf_ctx = amf_get_smf_context_by_pdu_session_id(
       ue_context, pdu_session_resp->pdu_session_id);
   if (!smf_ctx) {
     OAILOG_ERROR(
@@ -897,7 +897,7 @@ void amf_app_handle_resource_setup_response(
       return;
     }
 
-    smf_ctx = amf_smf_context_exists_pdu_session_id(
+    smf_ctx = amf_get_smf_context_by_pdu_session_id(
         ue_context,
         session_seup_resp.pduSessionResource_setup_list.item[0].Pdu_Session_ID);
     if (smf_ctx == NULL) {
@@ -1325,7 +1325,7 @@ void amf_app_handle_initial_context_setup_rsp(
   /* activating pdu sessions when UE is in IDLE state  */
   if (pdu_list->no_of_items) {
     for (uint32_t index = 0; index < pdu_list->no_of_items; index++) {
-      smf_context = amf_smf_context_exists_pdu_session_id(
+      smf_context = amf_get_smf_context_by_pdu_session_id(
           ue_context, pdu_list->item[index].Pdu_Session_ID);
       if (smf_context == NULL) {
         OAILOG_ERROR(

--- a/lte/gateway/c/core/oai/tasks/amf/amf_app_pdu_resource_setup_req_rel.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_app_pdu_resource_setup_req_rel.cpp
@@ -50,7 +50,8 @@ uint64_t get_bit_rate(uint8_t ambr_unit) {
  * AMBR calculation based on 9.11.4.14 of 24-501
  */
 void ambr_calculation_pdu_session(
-    smf_context_t* smf_context, uint64_t* dl_pdu_ambr, uint64_t* ul_pdu_ambr) {
+    std::shared_ptr<smf_context_t> smf_context, uint64_t* dl_pdu_ambr,
+    uint64_t* ul_pdu_ambr) {
   if ((smf_context->dl_ambr_unit == 0) || (smf_context->ul_ambr_unit == 0) ||
       (smf_context->dl_session_ambr == 0) ||
       (smf_context->dl_session_ambr == 0)) {
@@ -84,7 +85,7 @@ void ambr_calculation_pdu_session(
  */
 int pdu_session_resource_setup_request(
     ue_m5gmm_context_s* ue_context, amf_ue_ngap_id_t amf_ue_ngap_id,
-    smf_context_t* smf_context) {
+    std::shared_ptr<smf_context_t> smf_context) {
   pdu_session_resource_setup_request_transfer_t amf_pdu_ses_setup_transfer_req;
   itti_ngap_pdusession_resource_setup_req_t* ngap_pdu_ses_setup_req = nullptr;
   MessageDef* message_p                                             = nullptr;
@@ -156,7 +157,7 @@ int pdu_session_resource_setup_request(
 /* Resource release request to gNB through NGAP */
 int pdu_session_resource_release_request(
     ue_m5gmm_context_s* ue_context, amf_ue_ngap_id_t amf_ue_ngap_id,
-    smf_context_t* smf_ctx, bool retransmit) {
+    std::shared_ptr<smf_context_t> smf_ctx, bool retransmit) {
   bstring buffer;
   uint32_t bytes                = 0;
   DLNASTransportMsg* encode_msg = NULL;

--- a/lte/gateway/c/core/oai/tasks/amf/amf_app_ue_context.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_app_ue_context.cpp
@@ -221,7 +221,7 @@ std::shared_ptr<smf_context_t> amf_insert_smf_context(
     ue_m5gmm_context_s* ue_context, uint8_t pdu_session_id) {
   std::shared_ptr<smf_context_t> smf_context;
   smf_context =
-      amf_smf_context_exists_pdu_session_id(ue_context, pdu_session_id);
+      amf_get_smf_context_by_pdu_session_id(ue_context, pdu_session_id);
   if (smf_context) {
     return smf_context;
   } else {
@@ -233,13 +233,13 @@ std::shared_ptr<smf_context_t> amf_insert_smf_context(
 
 /****************************************************************************
  **                                                                        **
- ** Name:    amf_smf_context_exists_pdu_session_id()                       **
+ ** Name:   amf_get_smf_context_by_pdu_session_id()                        **
  **                                                                        **
  ** Description: Get the smf context from the map                          **
  **                                                                        **
  **                                                                        **
  ***************************************************************************/
-std::shared_ptr<smf_context_t> amf_smf_context_exists_pdu_session_id(
+std::shared_ptr<smf_context_t> amf_get_smf_context_by_pdu_session_id(
     ue_m5gmm_context_s* ue_context, uint8_t id) {
   std::shared_ptr<smf_context_t> smf_context;
   for (const auto& it : ue_context->amf_context.smf_ctxt_map) {

--- a/lte/gateway/c/core/oai/tasks/amf/amf_app_ue_context.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_app_ue_context.cpp
@@ -32,6 +32,11 @@ namespace magma5g {
 extern task_zmq_ctx_t amf_app_task_zmq_ctx;
 // Creating ue_context_map based on key:ue_id and value:ue_context
 std::unordered_map<amf_ue_ngap_id_t, ue_m5gmm_context_s*> ue_context_map;
+// Creating smf_ctxt_map based on key:pdu_session_id and value:smf_context
+std::unordered_map<uint8_t, std::shared_ptr<smf_context_t>> smf_ctxt_map;
+
+std::shared_ptr<smf_context_t> amf_insert_smf_context(
+    ue_m5gmm_context_s*, uint8_t);
 
 amf_ue_ngap_id_t amf_app_ctx_get_new_ue_id(
     amf_ue_ngap_id_t* amf_app_ue_ngap_id_generator_p) {
@@ -208,49 +213,42 @@ ue_m5gmm_context_s* amf_ue_context_exists_amf_ue_ngap_id(
  **                                                                        **
  ** Name:    amf_insert_smf_context()                                      **
  **                                                                        **
- ** Description: Insert smf context in the vector                          **
+ ** Description: Insert smf context in the map                             **
  **                                                                        **
  **                                                                        **
  ***************************************************************************/
-smf_context_t* amf_insert_smf_context(
+std::shared_ptr<smf_context_t> amf_insert_smf_context(
     ue_m5gmm_context_s* ue_context, uint8_t pdu_session_id) {
-  smf_context_t smf_context = {};
-  std::vector<smf_context_t>::iterator i;
-  int j = 0;
-
-  for (i = ue_context->amf_context.smf_ctxt_vector.begin();
-       i != ue_context->amf_context.smf_ctxt_vector.end(); i++, j++) {
-    if (i->smf_proc_data.pdu_session_identity.pdu_session_id ==
-        pdu_session_id) {
-      ue_context->amf_context.smf_ctxt_vector.at(j) = smf_context;
-      return ue_context->amf_context.smf_ctxt_vector.data() + j;
-    }
+  std::shared_ptr<smf_context_t> smf_context;
+  smf_context =
+      amf_smf_context_exists_pdu_session_id(ue_context, pdu_session_id);
+  if (smf_context) {
+    return smf_context;
+  } else {
+    smf_context = std::make_shared<smf_context_t>();
+    ue_context->amf_context.smf_ctxt_map[pdu_session_id] = smf_context;
   }
-
-  // add new element to the vector
-  ue_context->amf_context.smf_ctxt_vector.push_back(smf_context);
-  return ue_context->amf_context.smf_ctxt_vector.data() + j;
+  return smf_context;
 }
 
 /****************************************************************************
  **                                                                        **
  ** Name:    amf_smf_context_exists_pdu_session_id()                       **
  **                                                                        **
- ** Description: Get the smf context from the vector                       **
+ ** Description: Get the smf context from the map                          **
  **                                                                        **
  **                                                                        **
  ***************************************************************************/
-smf_context_t* amf_smf_context_exists_pdu_session_id(
+std::shared_ptr<smf_context_t> amf_smf_context_exists_pdu_session_id(
     ue_m5gmm_context_s* ue_context, uint8_t id) {
-  std::vector<smf_context_t>::iterator i;
-  int j = 0;
-  for (i = ue_context->amf_context.smf_ctxt_vector.begin();
-       i != ue_context->amf_context.smf_ctxt_vector.end(); i++, j++) {
-    if (i->smf_proc_data.pdu_session_identity.pdu_session_id == id) {
-      return ue_context->amf_context.smf_ctxt_vector.data() + j;
+  std::shared_ptr<smf_context_t> smf_context;
+  for (const auto& it : ue_context->amf_context.smf_ctxt_map) {
+    if (it.first == id) {
+      smf_context = it.second;
+      break;
     }
   }
-  return NULL;
+  return smf_context;
 }
 
 /****************************************************************************
@@ -395,9 +393,10 @@ int amf_idle_mode_procedure(amf_context_t* amf_ctx) {
       PARENT_STRUCT(amf_ctx, ue_m5gmm_context_s, amf_context);
   amf_ue_ngap_id_t ue_id = ue_context_p->amf_ue_ngap_id;
 
-  for (auto it = ue_context_p->amf_context.smf_ctxt_vector.begin();
-       it != ue_context_p->amf_context.smf_ctxt_vector.end(); it++) {
-    it->pdu_session_state = INACTIVE;
+  std::shared_ptr<smf_context_t> smf_ctx;
+  for (auto& it : ue_context_p->amf_context.smf_ctxt_map) {
+    smf_ctx                    = it.second;
+    smf_ctx->pdu_session_state = INACTIVE;
   }
 
   amf_smf_notification_send(ue_id, ue_context_p, UE_IDLE_MODE_NOTIFY);

--- a/lte/gateway/c/core/oai/tasks/amf/amf_app_ue_context_and_proc.h
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_app_ue_context_and_proc.h
@@ -400,7 +400,7 @@ ue_m5gmm_context_s* amf_create_new_ue_context(void);
 /*Multi PDU Session*/
 std::shared_ptr<smf_context_t> amf_insert_smf_context(
     ue_m5gmm_context_s* ue_context, uint8_t pdu_session_id);
-std::shared_ptr<smf_context_t> amf_smf_context_exists_pdu_session_id(
+std::shared_ptr<smf_context_t> amf_get_smf_context_by_pdu_session_id(
     ue_m5gmm_context_s* ue_context, uint8_t id);
 
 // Retrieve required UE context from the respective hash table

--- a/lte/gateway/c/core/oai/tasks/amf/amf_app_ue_context_and_proc.h
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_app_ue_context_and_proc.h
@@ -32,6 +32,7 @@ extern "C" {
 #ifdef __cplusplus
 };
 #endif
+#include <unordered_map>
 #include <vector>
 #include "amf_fsm.h"
 #include "amf_data.h"
@@ -292,8 +293,8 @@ typedef struct amf_context_s {
   uint32_t member_present_mask;   /* bitmask, see significance of bits below */
   uint32_t member_valid_mask;     /* bitmask, see significance of bits below */
   uint8_t m5gsregistrationtype;
-  std::vector<smf_context_t> smf_ctxt_vector;  // smf contents
-  // smf_context_t smf_ctxt_vector;  // smf contents
+  // Creating smf_ctxt_map based on key:pdu_session_id and value:smf_context
+  std::unordered_map<uint8_t, std::shared_ptr<smf_context_t>> smf_ctxt_map;
   amf_procedures_t* amf_procedures;
   imsi_t imsi;     /* The IMSI provided by the UE or the AMF, set valid when
                        identification returns IMSI */
@@ -397,9 +398,9 @@ void notify_ngap_new_ue_amf_ngap_id_association(
 
 ue_m5gmm_context_s* amf_create_new_ue_context(void);
 /*Multi PDU Session*/
-smf_context_t* amf_insert_smf_context(
+std::shared_ptr<smf_context_t> amf_insert_smf_context(
     ue_m5gmm_context_s* ue_context, uint8_t pdu_session_id);
-smf_context_t* amf_smf_context_exists_pdu_session_id(
+std::shared_ptr<smf_context_t> amf_smf_context_exists_pdu_session_id(
     ue_m5gmm_context_s* ue_context, uint8_t id);
 
 // Retrieve required UE context from the respective hash table
@@ -783,12 +784,12 @@ void amf_smf_context_cleanup_pdu_session(ue_m5gmm_context_s* ue_context);
 // PDU session related communication to gNB
 int pdu_session_resource_setup_request(
     ue_m5gmm_context_s* ue_context, amf_ue_ngap_id_t amf_ue_ngap_id,
-    smf_context_t*);
+    std::shared_ptr<smf_context_t>);
 void amf_app_handle_resource_setup_response(
     itti_ngap_pdusessionresource_setup_rsp_t session_seup_resp);
 int pdu_session_resource_release_request(
     ue_m5gmm_context_s* ue_context, amf_ue_ngap_id_t amf_ue_ngap_id,
-    smf_context_t* smf_ctx, bool retransmit);
+    std::shared_ptr<smf_context_t> smf_ctx, bool retransmit);
 void amf_app_handle_resource_release_response(
     itti_ngap_pdusessionresource_rel_rsp_t session_rel_resp);
 void amf_app_handle_cm_idle_on_ue_context_release(
@@ -839,7 +840,8 @@ void amf_ue_context_on_new_guti(
 ue_m5gmm_context_s* amf_ue_context_exists_guti(
     amf_ue_context_t* const amf_ue_context_p, const guti_m5_t* const guti_p);
 void ambr_calculation_pdu_session(
-    smf_context_t* smf_context, uint64_t* dl_pdu_ambr, uint64_t* ul_pdu_ambr);
+    std::shared_ptr<smf_context_t> smf_context, uint64_t* dl_pdu_ambr,
+    uint64_t* ul_pdu_ambr);
 int amf_proc_registration_abort(
     amf_context_t* amf_ctx, struct ue_m5gmm_context_s* ue_amf_context);
 ue_m5gmm_context_s* ue_context_loopkup_by_guti(tmsi_t tmsi_rcv);

--- a/lte/gateway/c/core/oai/tasks/amf/amf_as.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_as.cpp
@@ -1213,21 +1213,20 @@ int initial_context_setup_request(
     pdusession_setup_item_t* item = nullptr;
     pdu_resource_transfer_ie = &req->PDU_Session_Resource_Setup_Transfer_List;
 
-    for (auto it = ue_context->amf_context.smf_ctxt_vector.begin();
-         it != ue_context->amf_context.smf_ctxt_vector.end(); it++) {
-      smf_context_t smf_context = *it;
-      if (smf_context.pdu_session_state == ACTIVE) {
+    for (const auto& it : ue_context->amf_context.smf_ctxt_map) {
+      std::shared_ptr<smf_context_t> smf_context = it.second;
+      if (smf_context->pdu_session_state == ACTIVE) {
         uint8_t item_num     = 0;
         uint64_t ul_pdu_ambr = 0;
         uint64_t dl_pdu_ambr = 0;
         pdu_resource_transfer_ie->no_of_items += 1;
         item_num = pdu_resource_transfer_ie->no_of_items - 1;
         item     = &pdu_resource_transfer_ie->item[item_num];
-        ambr_calculation_pdu_session(&smf_context, &dl_pdu_ambr, &ul_pdu_ambr);
+        ambr_calculation_pdu_session(smf_context, &dl_pdu_ambr, &ul_pdu_ambr);
 
         // pdu session id
         item->Pdu_Session_ID =
-            smf_context.smf_proc_data.pdu_session_identity.pdu_session_id;
+            smf_context->smf_proc_data.pdu_session_identity.pdu_session_id;
 
         // pdu ambr
         item->PDU_Session_Resource_Setup_Request_Transfer
@@ -1237,22 +1236,23 @@ int initial_context_setup_request(
 
         // pdu session type
         item->PDU_Session_Resource_Setup_Request_Transfer.pdu_ip_type.pdn_type =
-            smf_context.pdu_address.pdn_type;
+            smf_context->pdu_address.pdn_type;
 
         // up transport info
         memcpy(
             &item->PDU_Session_Resource_Setup_Request_Transfer
                  .up_transport_layer_info.gtp_tnl.gtp_tied,
-            smf_context.gtp_tunnel_id.upf_gtp_teid, GNB_TEID_LEN);
+            smf_context->gtp_tunnel_id.upf_gtp_teid, GNB_TEID_LEN);
         item->PDU_Session_Resource_Setup_Request_Transfer
             .up_transport_layer_info.gtp_tnl.endpoint_ip_address = blk2bstr(
-            &smf_context.gtp_tunnel_id.upf_gtp_teid_ip_addr, GNB_IPV4_ADDR_LEN);
+            &smf_context->gtp_tunnel_id.upf_gtp_teid_ip_addr,
+            GNB_IPV4_ADDR_LEN);
 
         // qos flow list
         memcpy(
             &item->PDU_Session_Resource_Setup_Request_Transfer
                  .qos_flow_setup_request_list.qos_flow_req_item,
-            &smf_context.pdu_resource_setup_req
+            &smf_context->pdu_resource_setup_req
                  .pdu_session_resource_setup_request_transfer
                  .qos_flow_setup_request_list.qos_flow_req_item,
             sizeof(qos_flow_setup_request_item));

--- a/lte/gateway/c/core/oai/tasks/amf/amf_fsm.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_fsm.cpp
@@ -254,7 +254,7 @@ int pdu_state_handle_message(
     ue_m5gmm_context_s* ue_m5gmm_context, amf_smf_t amf_smf_msg, char* imsi,
     itti_n11_create_pdu_session_response_t* pdu_session_resp, uint32_t ue_id) {
   std::shared_ptr<smf_context_t> smf_ctx =
-      amf_smf_context_exists_pdu_session_id(
+      amf_get_smf_context_by_pdu_session_id(
           ue_m5gmm_context, amf_smf_msg.pdu_session_id);
 
   if (ue_state_matrix[cur_state][event][session_state].handler.func) {

--- a/lte/gateway/c/core/oai/tasks/amf/amf_fsm.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_fsm.cpp
@@ -253,8 +253,9 @@ int pdu_state_handle_message(
     m5gmm_state_t cur_state, int event, SMSessionFSMState session_state,
     ue_m5gmm_context_s* ue_m5gmm_context, amf_smf_t amf_smf_msg, char* imsi,
     itti_n11_create_pdu_session_response_t* pdu_session_resp, uint32_t ue_id) {
-  smf_context_t* smf_ctx = amf_smf_context_exists_pdu_session_id(
-      ue_m5gmm_context, amf_smf_msg.pdu_session_id);
+  std::shared_ptr<smf_context_t> smf_ctx =
+      amf_smf_context_exists_pdu_session_id(
+          ue_m5gmm_context, amf_smf_msg.pdu_session_id);
 
   if (ue_state_matrix[cur_state][event][session_state].handler.func) {
     OAILOG_INFO(

--- a/lte/gateway/c/core/oai/tasks/amf/amf_recv.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_recv.cpp
@@ -154,7 +154,7 @@ int amf_handle_service_request(
              session_id++) {
           if (msg->uplink_data_status.uplinkDataStatus & (1 << session_id)) {
             std::shared_ptr<smf_context_t> smf_context =
-                amf_smf_context_exists_pdu_session_id(ue_context, session_id);
+                amf_get_smf_context_by_pdu_session_id(ue_context, session_id);
             if (smf_context) {
               pdu_session_status |= (1 << session_id);
               IMSI64_TO_STRING(ue_context->amf_context.imsi64, imsi, 15);

--- a/lte/gateway/c/core/oai/tasks/amf/amf_recv.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_recv.cpp
@@ -153,7 +153,7 @@ int amf_handle_service_request(
         for (uint16_t session_id = 1; session_id < (sizeof(session_id) * 8);
              session_id++) {
           if (msg->uplink_data_status.uplinkDataStatus & (1 << session_id)) {
-            smf_context_t* smf_context =
+            std::shared_ptr<smf_context_t> smf_context =
                 amf_smf_context_exists_pdu_session_id(ue_context, session_id);
             if (smf_context) {
               pdu_session_status |= (1 << session_id);

--- a/lte/gateway/c/core/oai/tasks/amf/amf_smf_send.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_smf_send.cpp
@@ -306,7 +306,7 @@ static int pdu_session_resource_release_t3592_handler(
 
   if (ue_context) {
     IMSI64_TO_STRING(ue_context->amf_context.imsi64, imsi, 15);
-    smf_ctx = amf_smf_context_exists_pdu_session_id(ue_context, pdu_session_id);
+    smf_ctx = amf_get_smf_context_by_pdu_session_id(ue_context, pdu_session_id);
 
     if (smf_ctx == NULL) {
       OAILOG_ERROR(
@@ -423,7 +423,7 @@ int amf_smf_send(
     smf_ctx = amf_insert_smf_context(
         ue_context, msg->payload_container.smf_msg.header.pdu_session_id);
   } else {
-    smf_ctx = amf_smf_context_exists_pdu_session_id(
+    smf_ctx = amf_get_smf_context_by_pdu_session_id(
         ue_context, msg->payload_container.smf_msg.header.pdu_session_id);
   }
 
@@ -607,7 +607,7 @@ int amf_update_smf_context_pdu_ip(
     return rc;
   }
 
-  smf_ctx = amf_smf_context_exists_pdu_session_id(ue_context, pdu_session_id);
+  smf_ctx = amf_get_smf_context_by_pdu_session_id(ue_context, pdu_session_id);
   if (NULL == smf_ctx) {
     return rc;
   }

--- a/lte/gateway/c/core/oai/tasks/amf/deregistration_request.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/deregistration_request.cpp
@@ -231,17 +231,15 @@ int amf_app_handle_deregistration_req(amf_ue_ngap_id_t ue_id) {
 **                                                                        **
 ***************************************************************************/
 void amf_smf_context_cleanup_pdu_session(ue_m5gmm_context_s* ue_context) {
-  std::vector<smf_context_t>::iterator i;
-
   amf_smf_release_t smf_message;
   char imsi[IMSI_BCD_DIGITS_MAX + 1];
 
   memset(&smf_message, 0, sizeof(amf_smf_release_t));
 
-  for (i = ue_context->amf_context.smf_ctxt_vector.begin();
-       i != ue_context->amf_context.smf_ctxt_vector.end(); i++) {
+  for (auto& it : ue_context->amf_context.smf_ctxt_map) {
     IMSI64_TO_STRING(ue_context->amf_context.imsi64, imsi, 15);
 
+    std::shared_ptr<smf_context_t> i = it.second;
     smf_message.pdu_session_id =
         i->smf_proc_data.pdu_session_identity.pdu_session_id;
 

--- a/lte/gateway/c/core/oai/test/amf/test_amf.cpp
+++ b/lte/gateway/c/core/oai/test/amf/test_amf.cpp
@@ -461,9 +461,9 @@ TEST_F(AmfUeContextTest, test_ue_context_creation) {
 }
 
 TEST_F(AmfUeContextTest, test_smf_context_creation) {
-  smf_context_t* smf_context = nullptr;
-  uint8_t pdu_session_id     = 10;
-  smf_context = amf_insert_smf_context(ue_context, pdu_session_id);
+  std::shared_ptr<smf_context_t> smf_context;
+  uint8_t pdu_session_id = 10;
+  smf_context            = amf_insert_smf_context(ue_context, pdu_session_id);
   EXPECT_TRUE(0 == smf_context->n_active_pdus);
   EXPECT_TRUE(0 == smf_context->pdu_session_version);
 }


### PR DESCRIPTION
Signed-off-by: sreedharkumartn <sreedhar.kumar@wavelabs.ai>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary
Right now the PDU Session is stored as Vectors in UE context under amf. Vectors implementation needs additional clean up. But while doing clean ups it was realized that its better to implement PDU Session Data structure as maps as the storage, lookup and traversal is much more optimized.

Following are the main changes to be taken up for PDU Sessions :
1. Replace the vector implementation by maps.
2. All lookups to be tuned.
<!-- Enumerate changes you made and why you made them -->

## Test Plan
- Verified basic sanity with UERANSIM.
- Please find attached logs and pcap snap for basic registration, PDU Session setup and PDU Session release.
- Verified UT cases.

Logs:
[maps in amf context.log](https://github.com/magma/magma/files/7310345/maps.in.amf.context.log)

Pcap snap:
![maps in amf context](https://user-images.githubusercontent.com/89978170/136537333-1027dd05-3d4b-40b9-bcba-a2c28dd56200.JPG)

Test cases compiled:
![UT test](https://user-images.githubusercontent.com/89978170/136556076-f4adf2bc-661d-4dd7-a014-4bb995acc25b.JPG)


<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
