### PR TITLE
fix(ci): Fix root ca expired in deployment of agw packages

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -449,6 +449,11 @@ commands:
             cp *_version versions || true
           no_output_timeout: 20m
       - run:
+          name: Do not trust expired cert distributed by default
+          command: |
+            sudo sed -i  's,mozilla/DST_Root_CA_X3.crt,!mozilla/DST_Root_CA_X3.crt,' /etc/ca-certificates.conf
+            sudo update-ca-certificates
+      - run:
           name: Copy debian packages to new JFROG repo
           command: |
             cd ${MAGMA_ROOT}/circleci


### PR DESCRIPTION
Signed-off-by: quentinDERORY <15911421+quentinDERORY@users.noreply.github.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

One default distributed root CA is expired and need to be manually deleted from trusted certs

## Test Plan

Directly on host

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
