### PR TITLE
fix(agw): force upgrade ca-certs on upgrade agw

### DIFF
--- a/lte/gateway/release/upgrade_magma.sh
+++ b/lte/gateway/release/upgrade_magma.sh
@@ -29,7 +29,7 @@ if grep -q 'Debian' /etc/issue; then
 fi
 
 apt update
-apt install -y apt-transport-https gnupg2
+apt install -y apt-transport-https gnupg2 wget ca-certificates
 
 # We have changed the name too many time we have to wipe all versions
 rm -rf /etc/apt/sources.list.d/*


### PR DESCRIPTION
Signed-off-by: Timothée Dzik <timdzik@fb.com>

fix(agw): force upgrade ca-certs on upgrade agw

## Summary

fix(agw): force upgrade ca-certs on upgrade agw

## Test Plan

upgrade your agw

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
