### PR TITLE
fix(agw): force upgrade ca-certs

### DIFF
--- a/lte/gateway/deploy/roles/magma_deploy/tasks/main.yml
+++ b/lte/gateway/deploy/roles/magma_deploy/tasks/main.yml
@@ -58,6 +58,7 @@
   become: yes
   apt:
     name: "{{ packages }}"
+    only_upgrade: yes
   vars:
     packages:
       - graphviz
@@ -66,6 +67,7 @@
       - openssl
       - dkms
       - uuid-runtime
+      - ca-certificates
 
 - name: Preconfigure wireshark (tshark) SUID property
   become: yes

--- a/orc8r/tools/ansible/roles/pkgrepo/tasks/debian.yml
+++ b/orc8r/tools/ansible/roles/pkgrepo/tasks/debian.yml
@@ -11,6 +11,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 ################################################################################
+- name: Ensure ca-certificates is up to date
+  become: yes
+  apt:
+    name: "{{ packages }}"
+    only_upgrade: yes
+  vars:
+    packages:
+      - ca-certificates
 
 - name: Add GPG key for magma repository
   apt_key:


### PR DESCRIPTION
Signed-off-by: Timothée Dzik <timdzik@fb.com>

fix(agw): force upgrade ca-certs
## Summary

fix(agw): force upgrade ca-certs

## Test Plan

let lte-integ-test run and make sure it's fixed 

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
