### PR TITLE
fix(amf): UE context needs to be cleaned up for the Authentication negative scenarios

### DIFF
--- a/lte/gateway/c/core/oai/tasks/amf/Registration.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/Registration.cpp
@@ -1149,6 +1149,7 @@ int amf_proc_registration_abort(
     message_p->ittiMsgHeader.imsi = ue_amf_context->amf_context.imsi64;
     send_msg_to_task(&amf_app_task_zmq_ctx, TASK_NGAP, message_p);
     amf_delete_registration_proc(amf_ctx);
+    amf_free_ue_context(ue_amf_context);
     rc = RETURNok;
   }
   OAILOG_FUNC_RETURN(LOG_AMF_APP, rc);

--- a/lte/gateway/c/core/oai/tasks/amf/amf_app_ue_context.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_app_ue_context.cpp
@@ -417,7 +417,7 @@ void amf_free_ue_context(ue_m5gmm_context_s* ue_context_p) {
   hashtable_rc_t h_rc                = HASH_TABLE_OK;
   amf_app_desc_t* amf_app_desc_p     = get_amf_nas_state(false);
   amf_ue_context_t* amf_ue_context_p = &amf_app_desc_p->amf_ue_contexts;
-
+  OAILOG_DEBUG(LOG_NAS_AMF, "amf_free_ue_context \n");
   hash_table_ts_t* amf_state_ue_id_ht = get_amf_ue_state();
   if (!ue_context_p || !amf_ue_context_p) {
     return;

--- a/lte/gateway/c/core/oai/tasks/amf/amf_authentication.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_authentication.cpp
@@ -621,11 +621,14 @@ void amf_ctx_clear_auth_vectors(amf_context_t* const ctxt) {
 
 int amf_auth_auth_rej(amf_ue_ngap_id_t ue_id) {
   int rc                               = RETURNerror;
+  ue_m5gmm_context_s* ue_mm_context    = nullptr;
   amf_sap_t amf_sap                    = {};
   amf_sap.primitive                    = AMFAS_SECURITY_REJ;
   amf_sap.u.amf_as.u.security.ue_id    = ue_id;
   amf_sap.u.amf_as.u.security.msg_type = AMF_AS_MSG_TYPE_AUTH;
   rc                                   = amf_sap_send(&amf_sap);
+  ue_mm_context = amf_ue_context_exists_amf_ue_ngap_id(ue_id);
+  amf_free_ue_context(ue_mm_context);
   return rc;
 }
 


### PR DESCRIPTION
Signed-off-by: krishnavamsi-wavelabs <krishna.vamsi@wavelabs.ai>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

cleared ue_context for Authentication Negative scenario and Timeout scenario.

## Test Plan

Tested both Authentication failure scenario and Timeout scenario with UERANSIM
Please find attached logs and pcap snap.

1. Authentication failure scenario
    a. pcap
![athentication_failure](https://user-images.githubusercontent.com/88074557/136768061-b668ea59-0333-4770-bbc6-ee40c82de0e8.PNG)

    b. log file
[authentication_failure.txt](https://github.com/magma/magma/files/7321369/authentication_failure.txt)

2. Timeout scenario
    a. pcap
![timeout](https://user-images.githubusercontent.com/88074557/136768570-83d2ca74-228f-4940-a27b-d8b86829a82e.PNG)
  
    b. log file
[timeout.txt](https://github.com/magma/magma/files/7321382/timeout.txt)
 
3. Test Cases compiled
![Capture](https://user-images.githubusercontent.com/88074557/136896246-30475a26-8232-4b15-a4d8-bcc75cfb7649.PNG)



## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
