### PR TITLE
chore(mme): s1ap: Add support for SCTP connection over IPv6

### DIFF
--- a/lte/gateway/c/core/oai/include/mme_config.h
+++ b/lte/gateway/c/core/oai/include/mme_config.h
@@ -149,6 +149,9 @@
 #define MME_CONFIG_STRING_INTERFACE_NAME_FOR_S1_MME                            \
   "MME_INTERFACE_NAME_FOR_S1_MME"
 #define MME_CONFIG_STRING_IPV4_ADDRESS_FOR_S1_MME "MME_IPV4_ADDRESS_FOR_S1_MME"
+#define MME_CONFIG_STRING_IPV6_ADDRESS_FOR_S1_MME "MME_IPV6_ADDRESS_FOR_S1_MME"
+
+#define MME_CONFIG_STRING_S1_IPV6_ENABLED "MME_S1_IPV6_ENABLED"
 #define MME_CONFIG_STRING_INTERFACE_NAME_FOR_S11_MME                           \
   "MME_INTERFACE_NAME_FOR_S11_MME"
 #define MME_CONFIG_STRING_IPV4_ADDRESS_FOR_S11_MME                             \
@@ -283,6 +286,7 @@ typedef struct ip_s {
   bstring if_name_s1_mme;
   struct in_addr s1_mme_v4;
   struct in6_addr s1_mme_v6;
+  bool s1_ipv6_enabled;
   int netmask_s1_mme;
 
   bstring if_name_s11;

--- a/lte/gateway/c/core/oai/tasks/mme_app/mme_config.c
+++ b/lte/gateway/c/core/oai/tasks/mme_app/mme_config.c
@@ -518,16 +518,18 @@ int mme_config_parse_string(
   int aint                      = 0;
   double adouble                = 0.0;
   int i = 0, n = 0, stop_index = 0, num = 0;
-  const char* astring  = NULL;
-  const char* tac      = NULL;
-  const char* mcc      = NULL;
-  const char* mnc      = NULL;
-  char* if_name_s1_mme = NULL;
-  char* s1_mme         = NULL;
-  char* if_name_s11    = NULL;
-  char* s11            = NULL;
-  char* imsi_low_tmp   = NULL;
-  char* imsi_high_tmp  = NULL;
+  const char* astring    = NULL;
+  const char* tac        = NULL;
+  const char* mcc        = NULL;
+  const char* mnc        = NULL;
+  char* if_name_s1_mme   = NULL;
+  char* s1_mme           = NULL;
+  char* s1_mme_ipv6_addr = NULL;
+  char* s1_ipv6_enabled  = NULL;
+  char* if_name_s11      = NULL;
+  char* s11              = NULL;
+  char* imsi_low_tmp     = NULL;
+  char* imsi_high_tmp    = NULL;
 #if !EMBEDDED_SGW
   char* sgw_ip_address_for_s11 = NULL;
 #endif
@@ -1418,6 +1420,7 @@ int mme_config_parse_string(
                (const char**) &s11) &&
            config_setting_lookup_int(
                setting, MME_CONFIG_STRING_MME_PORT_FOR_S11, &aint))) {
+        // S1AP IPv4 address
         config_pP->ip.port_s11 = (uint16_t) aint;
 
         config_pP->ip.if_name_s1_mme = bfromcstr(if_name_s1_mme);
@@ -1440,8 +1443,9 @@ int mme_config_parse_string(
             inet_ntoa(in_addr_var), config_pP->ip.netmask_s1_mme,
             bdata(config_pP->ip.if_name_s1_mme));
         bdestroy_wrapper(&cidr);
-
         bdestroy(cidr);
+
+        // S11 IPv4 address
         config_pP->ip.if_name_s11 = bfromcstr(if_name_s11);
         cidr                      = bfromcstr(s11);
         list                      = bsplit(cidr, '/');
@@ -1462,6 +1466,28 @@ int mme_config_parse_string(
             inet_ntoa(in_addr_var), config_pP->ip.netmask_s11,
             bdata(config_pP->ip.if_name_s11));
         bdestroy(cidr);
+      }
+      if (config_setting_lookup_string(
+              setting, MME_CONFIG_STRING_IPV6_ADDRESS_FOR_S1_MME,
+              (const char**) &s1_mme_ipv6_addr) &&
+          config_setting_lookup_string(
+              setting, MME_CONFIG_STRING_S1_IPV6_ENABLED,
+              (const char**) &s1_ipv6_enabled)) {
+        // S1AP IPv6 address
+        config_pP->ip.s1_ipv6_enabled = parse_bool(s1_ipv6_enabled);
+        if (config_pP->ip.s1_ipv6_enabled) {
+          char parsed_ipv6[INET6_ADDRSTRLEN];
+
+          IPV6_STR_ADDR_TO_INADDR(
+              s1_mme_ipv6_addr, config_pP->ip.s1_mme_v6,
+              "BAD IPv6 ADDRESS FORMAT FOR S1AP IPv6 address !\n");
+          inet_ntop(
+              AF_INET6, (const void*) &config_pP->ip.s1_mme_v6, parsed_ipv6,
+              INET6_ADDRSTRLEN);
+          OAILOG_INFO(
+              LOG_MME_APP, "Parsing configuration file found S1-MME-IPv6: %s\n",
+              parsed_ipv6);
+        }
       }
     }
 
@@ -1965,6 +1991,13 @@ void mme_config_display(mme_config_t* config_pP) {
   OAILOG_INFO(
       LOG_CONFIG, "    s1-MME ip ........: %s\n",
       inet_ntoa(*((struct in_addr*) &config_pP->ip.s1_mme_v4)));
+  if (config_pP->ip.s1_ipv6_enabled) {
+    char strv6[INET6_ADDRSTRLEN];
+    OAILOG_INFO(
+        LOG_CONFIG, "    s1-MME ipv6 ......: %s\n",
+        inet_ntop(AF_INET6, &config_pP->ip.s1_mme_v6, strv6, INET6_ADDRSTRLEN));
+  }
+
   OAILOG_INFO(
       LOG_CONFIG, "    s11 MME iface ....: %s\n",
       bdata(config_pP->ip.if_name_s11));

--- a/lte/gateway/configs/mme.yml
+++ b/lte/gateway/configs/mme.yml
@@ -33,3 +33,6 @@ mme_app_zmq_auth_th_us: 200000  # delay threshold used for dropping Authenticati
 mme_app_zmq_ident_th_us: 400000  # delay threshold used for dropping Identification Complete
 mme_app_zmq_smc_th_us: 1000000  # delay threshold used for dropping SMC Complete
 accept_combined_attach_tau_wo_csfb: true
+
+# Enable IPv6 support for S1AP SCTP endpoint
+s1ap_ipv6_enabled: false

--- a/lte/gateway/configs/templates/mme.conf.template
+++ b/lte/gateway/configs/templates/mme.conf.template
@@ -258,11 +258,13 @@ MME :
         # we don't advise wireless interfaces
         MME_INTERFACE_NAME_FOR_S1_MME         = "{{ s1ap_iface_name }}";
         MME_IPV4_ADDRESS_FOR_S1_MME           = "{{ s1ap_ip }}";
+        MME_IPV6_ADDRESS_FOR_S1_MME           = "{{ s1ap_ipv6 }}";
 
         # MME binded interface for S11 communication (GTPV2-C)
         MME_INTERFACE_NAME_FOR_S11_MME        = "{{ s11_iface_name }}";
         MME_IPV4_ADDRESS_FOR_S11_MME          = "{{ mme_s11_ip }}";
         MME_PORT_FOR_S11_MME                  = 2123;
+        MME_S1_IPV6_ENABLED                   = "{{ s1ap_ipv6_enabled }}";
     };
 
     LOGGING :

--- a/lte/gateway/python/scripts/generate_oai_config.py
+++ b/lte/gateway/python/scripts/generate_oai_config.py
@@ -23,6 +23,7 @@ from magma.common.misc_utils import (
     IpPreference,
     get_ip_from_if,
     get_ip_from_if_cidr,
+    get_ipv6_from_if,
 )
 from magma.configuration.mconfig_managers import load_service_mconfig
 from magma.configuration.service_configs import get_service_config_value
@@ -52,6 +53,14 @@ def _get_iface_ip(service, iface_config):
     """
     iface_name = get_service_config_value(service, iface_config, "")
     return get_ip_from_if_cidr(iface_name)
+
+
+def _get_iface_ipv6(service, iface_config):
+    """
+    Get the interface IPv6 given its name.
+    """
+    iface_name = get_service_config_value(service, iface_config, "")
+    return get_ipv6_from_if(iface_name)
 
 
 def _get_primary_dns_ip(service_mconfig, iface_config):
@@ -395,6 +404,7 @@ def _get_context():
         'sgw_s5s8_up_iface_name': iface_name,
         "remote_sgw_ip": get_service_config_value("mme", "remote_sgw_ip", ""),
         "s1ap_ip": _get_iface_ip("mme", "s1ap_iface_name"),
+        "s1ap_ipv6": _get_iface_ipv6("mme", "s1ap_iface_name"),
         "oai_log_level": _get_oai_log_level(),
         "ipv4_dns": _get_primary_dns_ip(mme_service_config, "dns_iface_name"),
         "ipv4_sec_dns": _get_secondary_dns_ip(mme_service_config),

--- a/orc8r/gateway/python/magma/common/misc_utils.py
+++ b/orc8r/gateway/python/magma/common/misc_utils.py
@@ -156,6 +156,25 @@ def get_ip_from_if(iface_name, preference=IpPreference.IPV4_PREFERRED):
     return get_if_ip_with_netmask(iface_name, preference)[0]
 
 
+def get_ipv6_from_if(iface_name):
+    """
+    Get ipv6 address from interface name and return as string.
+    Extract only ipv6 address from (ipv6, netmask)
+    """
+    ip6_addresses = netifaces.ifaddresses(iface_name)[netifaces.AF_INET6]
+    ret = None
+    for ip_rec in ip6_addresses:
+        if "addr" in ip_rec:
+            ip = ip_rec["addr"].split("%")[0]
+            # lower priority of link local address.
+            if ip.startswith('fe80') is False:
+                return ip
+            ret = ip_rec
+    if ret:
+        return ret["addr"].split("%")[0]
+    return "::"
+
+
 def get_all_ips_from_if(iface_name, preference=IpPreference.IPV4_PREFERRED):
     """
     Get all ip addresses from interface name and return as a list of string.


### PR DESCRIPTION
Following patch add a config point to enable SCTP listener
over IPv6. It automatically uses S1 interface IPv6 address
to create the listening socket.

Signed-off-by: Pravin B Shelar <pbshelar@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->

## Test Plan
`make test` and integ test.
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
