### PR TITLE
fix(agw): allows agwd to run with default config

### DIFF
--- a/src/go/agwd/main.go
+++ b/src/go/agwd/main.go
@@ -22,18 +22,20 @@ import (
 
 func main() {
 	configFlag := flag.String(
-		"c", "/etc/magma/accessd.json", "Path to config file")
+		"c", "/etc/magma/agwd.json", "Path to config file")
 	flag.Parse()
 
 	cfgr := config.NewConfigManager()
-	if err := config.LoadConfigFile(cfgr, *configFlag); err != nil {
-		panic(err)
-	}
+	cfgr_err := config.LoadConfigFile(cfgr, *configFlag)
 
 	lm := log.NewManager(zap.NewLogger())
 	lm.
 		LoggerFor("").
 		SetLevel(config.LogLevel(cfgr.Config().GetLogLevel()))
+
+	if cfgr_err != nil {
+		lm.LoggerFor("").Warning().Printf("using default configuration as LoadConfigFile failed with %q", cfgr_err)
+	}
 
 	server.Start(cfgr, lm.LoggerFor("server"))
 


### PR DESCRIPTION
## Summary

Addresses the following.

- We want `agwd` to operate without a config file by use of defaults (not panic)
- We want `agwd` to look for a config file of `/etc/magma/agwd.json` not `/etc/magma/accessd.json`

## Test Plan

Built and ran `agwd` in devcontainer (i.e. GH Codespace) and confirmed log warning / healthy execution without a config file at expected path.

```
vscode ➜ /workspaces/magma (pr-agwd-config-fixup) $ bazel build //src/go/agwd:agwd --config=devcontainer
vscode ➜ /workspaces/magma (pr-agwd-config-fixup) $ ./bazel-bin/src/go/agwd/agwd_/agwd
2021-10-12T09:45:09.773Z        WARN    agwd/main.go:37 using default configuration as LoadConfigFile failed with "path=/etc/magma/agwd.json: stat /etc/magma/agwd.json: no such file or directory"
```

Signed-off-by: Scott Harrison Moeller <smoeller@fb.com>